### PR TITLE
do not include empty velocypack-aliases.h header

### DIFF
--- a/3rdParty/fuerte/src/VstConnection.cpp
+++ b/3rdParty/fuerte/src/VstConnection.cpp
@@ -28,7 +28,6 @@
 #include <fuerte/loop.h>
 #include <fuerte/message.h>
 #include <fuerte/types.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include "debugging.h"
 

--- a/3rdParty/fuerte/src/helper.cpp
+++ b/3rdParty/fuerte/src/helper.cpp
@@ -25,7 +25,6 @@
 #include <string.h>
 #include <velocypack/Iterator.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include <sstream>
 #include <stdexcept>

--- a/3rdParty/fuerte/src/jwt.cpp
+++ b/3rdParty/fuerte/src/jwt.cpp
@@ -28,7 +28,6 @@
 #include <openssl/rand.h>
 #include <openssl/sha.h>
 #include <velocypack/Builder.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include <chrono>
 

--- a/3rdParty/fuerte/src/message.cpp
+++ b/3rdParty/fuerte/src/message.cpp
@@ -24,7 +24,6 @@
 #include <fuerte/helper.h>
 #include <fuerte/message.h>
 #include <velocypack/Validator.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include <sstream>
 

--- a/3rdParty/fuerte/src/requests.cpp
+++ b/3rdParty/fuerte/src/requests.cpp
@@ -21,7 +21,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #include <fuerte/requests.h>
-#include <velocypack/velocypack-aliases.h>
 
 namespace arangodb { namespace fuerte { inline namespace v1 {
 

--- a/3rdParty/fuerte/src/vst.cpp
+++ b/3rdParty/fuerte/src/vst.cpp
@@ -30,7 +30,6 @@
 #include <velocypack/HexDump.h>
 #include <velocypack/Iterator.h>
 #include <velocypack/Validator.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include <boost/algorithm/string.hpp>
 

--- a/3rdParty/json-schema-validation/src/validation.cpp
+++ b/3rdParty/json-schema-validation/src/validation.cpp
@@ -3,7 +3,6 @@
 #include <tao/json/contrib/schema.hpp>
 
 #include <velocypack/Iterator.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include <validation/events_from_slice.hpp>
 #include <validation/types.hpp>

--- a/arangod/Agency/AgencyComm.cpp
+++ b/arangod/Agency/AgencyComm.cpp
@@ -55,7 +55,6 @@
 #include <thread>
 
 #include <velocypack/Iterator.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include <boost/uuid/uuid.hpp>
 #include <boost/uuid/uuid_generators.hpp>

--- a/arangod/Agency/AgencyComm.h
+++ b/arangod/Agency/AgencyComm.h
@@ -34,7 +34,6 @@
 
 #include <velocypack/Builder.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include "Agency/PathComponent.h"
 #include "AgencyComm.h"

--- a/arangod/Agency/AgencyCommon.h
+++ b/arangod/Agency/AgencyCommon.h
@@ -27,7 +27,6 @@
 
 #include <velocypack/Buffer.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include "Basics/VelocyPackHelper.h"
 #include "Logger/Logger.h"

--- a/arangod/Agency/Agent.cpp
+++ b/arangod/Agency/Agent.cpp
@@ -24,7 +24,6 @@
 #include "Agent.h"
 
 #include <velocypack/Iterator.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include <chrono>
 #include <thread>

--- a/arangod/Agency/AgentConfiguration.h
+++ b/arangod/Agency/AgentConfiguration.h
@@ -27,7 +27,6 @@
 #include "Basics/ReadWriteLock.h"
 
 #include <velocypack/Iterator.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include <map>
 #include <string>

--- a/arangod/Agency/AsyncAgencyComm.cpp
+++ b/arangod/Agency/AsyncAgencyComm.cpp
@@ -38,7 +38,6 @@
 
 #include <velocypack/Buffer.h>
 #include <velocypack/Iterator.h>
-#include <velocypack/velocypack-aliases.h>
 
 namespace {
 using namespace arangodb::fuerte;

--- a/arangod/Agency/AsyncAgencyComm.h
+++ b/arangod/Agency/AsyncAgencyComm.h
@@ -31,7 +31,6 @@
 
 #include <velocypack/Builder.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include "Agency/AgencyComm.h"
 

--- a/arangod/Agency/Constituent.cpp
+++ b/arangod/Agency/Constituent.cpp
@@ -28,7 +28,6 @@
 #include <thread>
 
 #include <velocypack/Iterator.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include "Agency/Agent.h"
 #include "ApplicationFeatures/ApplicationServer.h"

--- a/arangod/Agency/Inception.h
+++ b/arangod/Agency/Inception.h
@@ -32,7 +32,6 @@
 #include "Basics/Thread.h"
 
 #include <velocypack/Builder.h>
-#include <velocypack/velocypack-aliases.h>
 
 namespace arangodb {
 namespace consensus {

--- a/arangod/Agency/Job.h
+++ b/arangod/Agency/Job.h
@@ -33,7 +33,6 @@
 #include <velocypack/Builder.h>
 #include <velocypack/Iterator.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include "Agency/AgencyCommon.h"
 #include "Agency/AgentInterface.h"

--- a/arangod/Agency/JobContext.h
+++ b/arangod/Agency/JobContext.h
@@ -27,7 +27,6 @@
 
 #include <velocypack/Iterator.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include <string>
 

--- a/arangod/Agency/Node.cpp
+++ b/arangod/Agency/Node.cpp
@@ -33,7 +33,6 @@
 #include <velocypack/Compare.h>
 #include <velocypack/Iterator.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include <deque>
 

--- a/arangod/Agency/Node.h
+++ b/arangod/Agency/Node.h
@@ -27,7 +27,6 @@
 #include "Basics/ResultT.h"
 
 #include <velocypack/Buffer.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include <cstdint>
 #include <type_traits>

--- a/arangod/Agency/RestAgencyHandler.cpp
+++ b/arangod/Agency/RestAgencyHandler.cpp
@@ -26,7 +26,6 @@
 #include <thread>
 
 #include <velocypack/Builder.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include "ApplicationFeatures/ApplicationServer.h"
 #include "Agency/Agent.h"

--- a/arangod/Agency/RestAgencyPrivHandler.cpp
+++ b/arangod/Agency/RestAgencyPrivHandler.cpp
@@ -28,7 +28,6 @@
 #include <typeinfo>
 
 #include <velocypack/Builder.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include "Logger/Logger.h"
 #include "Rest/Version.h"

--- a/arangod/Agency/State.cpp
+++ b/arangod/Agency/State.cpp
@@ -25,7 +25,6 @@
 
 #include <velocypack/Buffer.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include <chrono>
 #include <iomanip>

--- a/arangod/Agency/Store.cpp
+++ b/arangod/Agency/Store.cpp
@@ -41,7 +41,6 @@
 #include <velocypack/Compare.h>
 #include <velocypack/Iterator.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include <ctime>
 #include <iomanip>

--- a/arangod/Agency/TransactionBuilder.h
+++ b/arangod/Agency/TransactionBuilder.h
@@ -30,7 +30,6 @@
 #include <vector>
 
 #include <velocypack/Builder.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include "Basics/debugging.h"
 

--- a/arangod/Agency/v8-agency.cpp
+++ b/arangod/Agency/v8-agency.cpp
@@ -35,7 +35,6 @@
 #include "V8/v8-vpack.h"
 
 #include <velocypack/Iterator.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::application_features;

--- a/arangod/Aql/Aggregator.cpp
+++ b/arangod/Aql/Aggregator.cpp
@@ -35,7 +35,6 @@
 #include <velocypack/Builder.h>
 #include <velocypack/Iterator.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include <set>
 

--- a/arangod/Aql/AqlCallList.cpp
+++ b/arangod/Aql/AqlCallList.cpp
@@ -32,7 +32,6 @@
 #include <velocypack/Builder.h>
 #include <velocypack/Collection.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include <iostream>
 #include <map>

--- a/arangod/Aql/AqlCallStack.cpp
+++ b/arangod/Aql/AqlCallStack.cpp
@@ -26,7 +26,6 @@
 #include <velocypack/Builder.h>
 #include <velocypack/Iterator.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 // TODO: This class is not yet memory efficient or optimized in any way.
 // it might be reimplemented soon to have the above features, Focus now is on

--- a/arangod/Aql/AqlFunctionsInternalCache.cpp
+++ b/arangod/Aql/AqlFunctionsInternalCache.cpp
@@ -31,7 +31,6 @@
 #include <velocypack/Collection.h>
 #include <velocypack/Dumper.h>
 #include <velocypack/Iterator.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb::aql;
 

--- a/arangod/Aql/AqlItemBlock.cpp
+++ b/arangod/Aql/AqlItemBlock.cpp
@@ -39,7 +39,6 @@
 
 #include <velocypack/Iterator.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include <algorithm>
 #include <limits>

--- a/arangod/Aql/AqlItemBlockInputMatrix.cpp
+++ b/arangod/Aql/AqlItemBlockInputMatrix.cpp
@@ -26,7 +26,6 @@
 
 #include <Logger/LogMacros.h>
 #include <velocypack/Builder.h>
-#include <velocypack/velocypack-aliases.h>
 #include <numeric>
 
 using namespace arangodb;

--- a/arangod/Aql/AqlItemBlockInputRange.cpp
+++ b/arangod/Aql/AqlItemBlockInputRange.cpp
@@ -25,7 +25,6 @@
 #include "Aql/ShadowAqlItemRow.h"
 
 #include <velocypack/Builder.h>
-#include <velocypack/velocypack-aliases.h>
 #include <algorithm>
 #include <numeric>
 

--- a/arangod/Aql/AqlValue.cpp
+++ b/arangod/Aql/AqlValue.cpp
@@ -37,7 +37,6 @@
 #include <velocypack/Buffer.h>
 #include <velocypack/Iterator.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 #include <type_traits>
 
 #ifndef velocypack_malloc

--- a/arangod/Aql/Ast.cpp
+++ b/arangod/Aql/Ast.cpp
@@ -23,7 +23,6 @@
 
 #include <velocypack/Iterator.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include "Ast.h"
 

--- a/arangod/Aql/AstNode.cpp
+++ b/arangod/Aql/AstNode.cpp
@@ -48,7 +48,6 @@
 #include <velocypack/Sink.h>
 #include <velocypack/Slice.h>
 #include <velocypack/ValueType.h>
-#include <velocypack/velocypack-aliases.h>
 #include <array>
 
 using namespace arangodb;

--- a/arangod/Aql/BindParameters.cpp
+++ b/arangod/Aql/BindParameters.cpp
@@ -30,7 +30,6 @@
 #include <velocypack/Iterator.h>
 #include <velocypack/Slice.h>
 #include <velocypack/Value.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include <utility>
 

--- a/arangod/Aql/BlocksWithClients.cpp
+++ b/arangod/Aql/BlocksWithClients.cpp
@@ -56,7 +56,6 @@
 #include <velocypack/Collection.h>
 #include <velocypack/Parser.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::aql;

--- a/arangod/Aql/ClusterNodes.cpp
+++ b/arangod/Aql/ClusterNodes.cpp
@@ -25,7 +25,6 @@
 #include <type_traits>
 
 #include <velocypack/Iterator.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include "ClusterNodes.h"
 

--- a/arangod/Aql/ClusterQuery.cpp
+++ b/arangod/Aql/ClusterQuery.cpp
@@ -38,7 +38,6 @@
 #include "Cluster/TraverserEngine.h"
 
 #include <velocypack/Iterator.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::aql;

--- a/arangod/Aql/CollectNode.cpp
+++ b/arangod/Aql/CollectNode.cpp
@@ -40,7 +40,6 @@
 
 #include <velocypack/Builder.h>
 #include <velocypack/Value.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::aql;

--- a/arangod/Aql/CollectOptions.cpp
+++ b/arangod/Aql/CollectOptions.cpp
@@ -26,7 +26,6 @@
 
 #include <velocypack/Builder.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb::aql;
 

--- a/arangod/Aql/Collection.cpp
+++ b/arangod/Aql/Collection.cpp
@@ -24,7 +24,6 @@
 #include "Collection.h"
 
 #include <velocypack/Iterator.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include "ApplicationFeatures/ApplicationServer.h"
 #include "Basics/Exceptions.h"

--- a/arangod/Aql/CollectionAccessingNode.cpp
+++ b/arangod/Aql/CollectionAccessingNode.cpp
@@ -36,7 +36,6 @@
 #include "VocBase/vocbase.h"
 
 #include <velocypack/Iterator.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::aql;

--- a/arangod/Aql/Collections.cpp
+++ b/arangod/Aql/Collections.cpp
@@ -27,7 +27,6 @@
 #include "VocBase/AccessMode.h"
 
 #include <velocypack/Builder.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::aql;

--- a/arangod/Aql/Condition.cpp
+++ b/arangod/Aql/Condition.cpp
@@ -43,7 +43,6 @@
 #include "Transaction/Methods.h"
 
 #include <velocypack/Builder.h>
-#include <velocypack/velocypack-aliases.h>
 
 #ifdef _WIN32
 // turn off warnings about too long type name for debug symbols blabla in MSVC

--- a/arangod/Aql/DistributeExecutor.cpp
+++ b/arangod/Aql/DistributeExecutor.cpp
@@ -36,7 +36,6 @@
 #include "VocBase/LogicalCollection.h"
 
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::aql;

--- a/arangod/Aql/DocumentProducingHelper.cpp
+++ b/arangod/Aql/DocumentProducingHelper.cpp
@@ -36,7 +36,6 @@
 
 #include <velocypack/Builder.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::aql;

--- a/arangod/Aql/DocumentProducingNode.cpp
+++ b/arangod/Aql/DocumentProducingNode.cpp
@@ -35,7 +35,6 @@
 #include <velocypack/Iterator.h>
 #include <velocypack/Value.h>
 #include <velocypack/ValueType.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb::aql;
 

--- a/arangod/Aql/ExecutionBlock.cpp
+++ b/arangod/Aql/ExecutionBlock.cpp
@@ -38,7 +38,6 @@
 
 #include <velocypack/Builder.h>
 #include <velocypack/Dumper.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::aql;

--- a/arangod/Aql/ExecutionBlockImpl.cpp
+++ b/arangod/Aql/ExecutionBlockImpl.cpp
@@ -86,7 +86,6 @@
 #include "Graph/algorithm-aliases.h"
 
 #include <velocypack/Dumper.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include <type_traits>
 

--- a/arangod/Aql/ExecutionNode.cpp
+++ b/arangod/Aql/ExecutionNode.cpp
@@ -73,7 +73,6 @@
 #include "Transaction/Methods.h"
 
 #include <velocypack/Iterator.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include <algorithm>
 

--- a/arangod/Aql/ExecutionPlan.cpp
+++ b/arangod/Aql/ExecutionPlan.cpp
@@ -23,7 +23,6 @@
 
 #include <Graph/TraverserOptions.h>
 #include <velocypack/Iterator.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include "ExecutionPlan.h"
 

--- a/arangod/Aql/ExecutionStats.cpp
+++ b/arangod/Aql/ExecutionStats.cpp
@@ -28,7 +28,6 @@
 #include <velocypack/Builder.h>
 #include <velocypack/Iterator.h>
 #include <velocypack/Value.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb::aql;
 

--- a/arangod/Aql/Expression.cpp
+++ b/arangod/Aql/Expression.cpp
@@ -52,7 +52,6 @@
 #include <velocypack/Iterator.h>
 #include <velocypack/Sink.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include <v8.h>
 

--- a/arangod/Aql/Functions.cpp
+++ b/arangod/Aql/Functions.cpp
@@ -106,7 +106,6 @@
 #include <velocypack/Dumper.h>
 #include <velocypack/Iterator.h>
 #include <velocypack/Sink.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include <algorithm>
 

--- a/arangod/Aql/GraphNode.cpp
+++ b/arangod/Aql/GraphNode.cpp
@@ -54,7 +54,6 @@
 #endif
 
 #include <velocypack/Iterator.h>
-#include <velocypack/velocypack-aliases.h>
 #include <utility>
 
 using namespace arangodb;

--- a/arangod/Aql/IndexHint.cpp
+++ b/arangod/Aql/IndexHint.cpp
@@ -32,7 +32,6 @@
 #include <velocypack/Builder.h>
 #include <velocypack/Iterator.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include <ostream>
 

--- a/arangod/Aql/IndexNode.cpp
+++ b/arangod/Aql/IndexNode.cpp
@@ -49,7 +49,6 @@
 #include "Transaction/Methods.h"
 
 #include <velocypack/Iterator.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::aql;

--- a/arangod/Aql/InputAqlItemRow.cpp
+++ b/arangod/Aql/InputAqlItemRow.cpp
@@ -31,7 +31,6 @@
 #include "Aql/Range.h"
 
 #include <velocypack/Builder.h>
-#include <velocypack/velocypack-aliases.h>
 #include <boost/container/flat_set.hpp>
 
 #include <algorithm>

--- a/arangod/Aql/KShortestPathsExecutor.cpp
+++ b/arangod/Aql/KShortestPathsExecutor.cpp
@@ -47,7 +47,6 @@
 
 #include <velocypack/Builder.h>
 #include <velocypack/HashedStringRef.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include <utility>
 

--- a/arangod/Aql/KShortestPathsNode.cpp
+++ b/arangod/Aql/KShortestPathsNode.cpp
@@ -56,7 +56,6 @@
 #include "Graph/algorithm-aliases.h"
 
 #include <velocypack/Iterator.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include <memory>
 

--- a/arangod/Aql/ModificationExecutor.cpp
+++ b/arangod/Aql/ModificationExecutor.cpp
@@ -34,7 +34,6 @@
 #include "Aql/SimpleModifier.h"
 #include "Aql/UpsertModifier.h"
 
-#include <velocypack/velocypack-aliases.h>
 #include <algorithm>
 
 using namespace arangodb;

--- a/arangod/Aql/ModificationExecutor.h
+++ b/arangod/Aql/ModificationExecutor.h
@@ -35,7 +35,6 @@
 #include <velocypack/Builder.h>
 #include <velocypack/Iterator.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include <memory>
 #include <optional>

--- a/arangod/Aql/ModificationExecutorAccumulator.h
+++ b/arangod/Aql/ModificationExecutorAccumulator.h
@@ -28,7 +28,6 @@
 
 #include <velocypack/Builder.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 namespace arangodb::aql {
 

--- a/arangod/Aql/ModificationExecutorHelpers.cpp
+++ b/arangod/Aql/ModificationExecutorHelpers.cpp
@@ -33,7 +33,6 @@
 #include <velocypack/Builder.h>
 #include <velocypack/Iterator.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include <string>
 

--- a/arangod/Aql/ModificationExecutorHelpers.h
+++ b/arangod/Aql/ModificationExecutorHelpers.h
@@ -32,7 +32,6 @@
 
 #include <velocypack/Builder.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include <string>
 

--- a/arangod/Aql/ModificationExecutorInfos.h
+++ b/arangod/Aql/ModificationExecutorInfos.h
@@ -31,7 +31,6 @@
 #include "VocBase/LogicalCollection.h"
 
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 namespace arangodb {
 namespace aql {

--- a/arangod/Aql/ModificationOptions.cpp
+++ b/arangod/Aql/ModificationOptions.cpp
@@ -27,7 +27,6 @@
 
 #include <velocypack/Builder.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb::aql;
 

--- a/arangod/Aql/MultiAqlItemBlockInputRange.cpp
+++ b/arangod/Aql/MultiAqlItemBlockInputRange.cpp
@@ -26,7 +26,6 @@
 
 #include <velocypack/Builder.h>
 #include <velocypack/Options.h>
-#include <velocypack/velocypack-aliases.h>
 #include <numeric>
 
 #include "Logger/LogMacros.h"

--- a/arangod/Aql/MultiDependencySingleRowFetcher.cpp
+++ b/arangod/Aql/MultiDependencySingleRowFetcher.cpp
@@ -31,7 +31,6 @@
 #include "Transaction/Methods.h"
 
 #include <velocypack/Builder.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::aql;

--- a/arangod/Aql/NonConstExpressionContainer.cpp
+++ b/arangod/Aql/NonConstExpressionContainer.cpp
@@ -28,7 +28,6 @@
 #include "Basics/StringUtils.h"
 
 #include <velocypack/Iterator.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb::aql;
 

--- a/arangod/Aql/OutputAqlItemRow.cpp
+++ b/arangod/Aql/OutputAqlItemRow.cpp
@@ -42,7 +42,6 @@ The following conditions need to hold true, we need to add c++ tests for this.
 #include "Basics/Exceptions.h"
 
 #include <velocypack/Builder.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::aql;

--- a/arangod/Aql/QueryCache.cpp
+++ b/arangod/Aql/QueryCache.cpp
@@ -38,7 +38,6 @@
 
 #include <velocypack/Builder.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb::aql;
 

--- a/arangod/Aql/QueryCursor.cpp
+++ b/arangod/Aql/QueryCursor.cpp
@@ -43,7 +43,6 @@
 #include <velocypack/Dumper.h>
 #include <velocypack/Iterator.h>
 #include <velocypack/Options.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::aql;

--- a/arangod/Aql/QueryList.cpp
+++ b/arangod/Aql/QueryList.cpp
@@ -43,7 +43,6 @@
 #include <velocypack/Dumper.h>
 #include <velocypack/Sink.h>
 #include <velocypack/Value.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::aql;

--- a/arangod/Aql/QueryOptions.cpp
+++ b/arangod/Aql/QueryOptions.cpp
@@ -32,7 +32,6 @@
 #include <velocypack/Builder.h>
 #include <velocypack/Iterator.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb::aql;
 

--- a/arangod/Aql/QueryProfile.cpp
+++ b/arangod/Aql/QueryProfile.cpp
@@ -31,7 +31,6 @@
 #include "VocBase/vocbase.h"
 
 #include <velocypack/Builder.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::aql;

--- a/arangod/Aql/QuerySnippet.cpp
+++ b/arangod/Aql/QuerySnippet.cpp
@@ -40,8 +40,6 @@
 #include "Enterprise/Aql/LocalGraphNode.h"
 #endif
 
-#include <velocypack/velocypack-aliases.h>
-
 using namespace arangodb;
 using namespace arangodb::aql;
 using namespace arangodb::basics;

--- a/arangod/Aql/QueryWarnings.cpp
+++ b/arangod/Aql/QueryWarnings.cpp
@@ -28,7 +28,6 @@
 #include "Basics/Exceptions.h"
 
 #include <velocypack/Builder.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::aql;

--- a/arangod/Aql/RegisterPlan.cpp
+++ b/arangod/Aql/RegisterPlan.cpp
@@ -40,7 +40,6 @@
 #include <velocypack/Builder.h>
 #include <velocypack/Iterator.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::aql;

--- a/arangod/Aql/RemoteExecutor.cpp
+++ b/arangod/Aql/RemoteExecutor.cpp
@@ -50,7 +50,6 @@
 #include <fuerte/requests.h>
 #include <velocypack/Builder.h>
 #include <velocypack/Iterator.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::aql;

--- a/arangod/Aql/RestAqlHandler.cpp
+++ b/arangod/Aql/RestAqlHandler.cpp
@@ -52,7 +52,6 @@
 #include "Transaction/Methods.h"
 
 #include <velocypack/Iterator.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::rest;

--- a/arangod/Aql/ShortestPathExecutor.cpp
+++ b/arangod/Aql/ShortestPathExecutor.cpp
@@ -34,7 +34,6 @@
 #include "Graph/ShortestPathResult.h"
 
 #include <velocypack/Builder.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include <utility>
 

--- a/arangod/Aql/ShortestPathNode.cpp
+++ b/arangod/Aql/ShortestPathNode.cpp
@@ -40,7 +40,6 @@
 #include "Indexes/Index.h"
 
 #include <velocypack/Iterator.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include <memory>
 

--- a/arangod/Aql/SimpleModifier.cpp
+++ b/arangod/Aql/SimpleModifier.cpp
@@ -39,7 +39,6 @@
 #include "VocBase/LogicalCollection.h"
 
 #include <velocypack/Collection.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::aql;

--- a/arangod/Aql/SkipResult.cpp
+++ b/arangod/Aql/SkipResult.cpp
@@ -27,7 +27,6 @@
 
 #include <velocypack/Builder.h>
 #include <velocypack/Iterator.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb::aql;
 

--- a/arangod/Aql/SortedCollectExecutor.cpp
+++ b/arangod/Aql/SortedCollectExecutor.cpp
@@ -35,7 +35,6 @@
 #include "Basics/ConditionalDeleter.h"
 
 #include <velocypack/Buffer.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include <Logger/LogMacros.h>
 #include <utility>

--- a/arangod/Aql/SubqueryEndExecutionNode.cpp
+++ b/arangod/Aql/SubqueryEndExecutionNode.cpp
@@ -37,7 +37,6 @@
 #include "Transaction/Methods.h"
 
 #include <velocypack/Iterator.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::aql;

--- a/arangod/Aql/SubqueryEndExecutor.cpp
+++ b/arangod/Aql/SubqueryEndExecutor.cpp
@@ -31,7 +31,6 @@
 #include "Basics/ScopeGuard.h"
 
 #include <velocypack/Builder.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include <memory>
 #include <utility>

--- a/arangod/Aql/SubqueryStartExecutionNode.cpp
+++ b/arangod/Aql/SubqueryStartExecutionNode.cpp
@@ -34,7 +34,6 @@
 #include "Aql/SubqueryStartExecutor.h"
 
 #include <velocypack/Iterator.h>
-#include <velocypack/velocypack-aliases.h>
 
 namespace arangodb {
 namespace aql {

--- a/arangod/Aql/TraversalNode.cpp
+++ b/arangod/Aql/TraversalNode.cpp
@@ -57,7 +57,6 @@
 #include "VocBase/ticks.h"
 
 #include <velocypack/Iterator.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include <Graph/algorithm-aliases.h>
 #include <memory>

--- a/arangod/Aql/UpdateReplaceModifier.cpp
+++ b/arangod/Aql/UpdateReplaceModifier.cpp
@@ -35,7 +35,6 @@
 #include "VocBase/LogicalCollection.h"
 
 #include <velocypack/Collection.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include "Logger/LogMacros.h"
 

--- a/arangod/Aql/UpsertModifier.cpp
+++ b/arangod/Aql/UpsertModifier.cpp
@@ -38,7 +38,6 @@
 #include "VocBase/LogicalCollection.h"
 
 #include <velocypack/Collection.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include "Logger/LogMacros.h"
 

--- a/arangod/Aql/Variable.cpp
+++ b/arangod/Aql/Variable.cpp
@@ -28,7 +28,6 @@
 #include "Basics/debugging.h"
 
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb::aql;
 

--- a/arangod/Aql/VariableGenerator.cpp
+++ b/arangod/Aql/VariableGenerator.cpp
@@ -28,7 +28,6 @@
 #include <velocypack/Builder.h>
 #include <velocypack/Iterator.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb::aql;
 

--- a/arangod/Aql/WindowNode.cpp
+++ b/arangod/Aql/WindowNode.cpp
@@ -38,7 +38,6 @@
 
 #include <velocypack/Builder.h>
 #include <velocypack/Value.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::aql;

--- a/arangod/Auth/TokenCache.cpp
+++ b/arangod/Auth/TokenCache.cpp
@@ -41,7 +41,6 @@
 #include <velocypack/Builder.h>
 #include <velocypack/Collection.h>
 #include <velocypack/Iterator.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::basics;

--- a/arangod/Auth/User.cpp
+++ b/arangod/Auth/User.cpp
@@ -45,7 +45,6 @@
 #include "VocBase/Methods/Databases.h"
 
 #include <velocypack/Iterator.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::basics;

--- a/arangod/Auth/UserManager.cpp
+++ b/arangod/Auth/UserManager.cpp
@@ -53,7 +53,6 @@
 #include <velocypack/Builder.h>
 #include <velocypack/Collection.h>
 #include <velocypack/Iterator.h>
-#include <velocypack/velocypack-aliases.h>
 
 namespace {
 

--- a/arangod/Cluster/ActionDescription.h
+++ b/arangod/Cluster/ActionDescription.h
@@ -32,7 +32,6 @@
 #include <string>
 
 #include <velocypack/Builder.h>
-#include <velocypack/velocypack-aliases.h>
 
 namespace arangodb {
 namespace maintenance {

--- a/arangod/Cluster/AgencyCallback.cpp
+++ b/arangod/Cluster/AgencyCallback.cpp
@@ -28,7 +28,6 @@
 
 #include <velocypack/Builder.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include "ApplicationFeatures/ApplicationServer.h"
 #include "Basics/ConditionLocker.h"

--- a/arangod/Cluster/AgencyCallbackRegistry.cpp
+++ b/arangod/Cluster/AgencyCallbackRegistry.cpp
@@ -24,7 +24,6 @@
 #include "AgencyCallbackRegistry.h"
 
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include "ApplicationFeatures/ApplicationServer.h"
 #include "Basics/Exceptions.h"

--- a/arangod/Cluster/ClusterCollectionCreationInfo.cpp
+++ b/arangod/Cluster/ClusterCollectionCreationInfo.cpp
@@ -28,7 +28,6 @@
 #include "Cluster/ClusterTypes.h"
 
 #include <velocypack/Collection.h>
-#include <velocypack/velocypack-aliases.h>
 #include <utility>
 
 using namespace arangodb;

--- a/arangod/Cluster/ClusterEdgeCursor.cpp
+++ b/arangod/Cluster/ClusterEdgeCursor.cpp
@@ -32,7 +32,6 @@
 #include "Transaction/Methods.h"
 
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::graph;

--- a/arangod/Cluster/ClusterHelpers.cpp
+++ b/arangod/Cluster/ClusterHelpers.cpp
@@ -25,7 +25,6 @@
 
 #include <velocypack/Iterator.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 

--- a/arangod/Cluster/ClusterInfo.cpp
+++ b/arangod/Cluster/ClusterInfo.cpp
@@ -82,7 +82,6 @@
 #include <velocypack/Collection.h>
 #include <velocypack/Iterator.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include <boost/uuid/uuid.hpp>
 #include <boost/uuid/uuid_generators.hpp>

--- a/arangod/Cluster/ClusterInfo.h
+++ b/arangod/Cluster/ClusterInfo.h
@@ -29,7 +29,6 @@
 
 #include <velocypack/Iterator.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 #include <memory>
 
 #include "Agency/AgencyComm.h"

--- a/arangod/Cluster/ClusterMethods.cpp
+++ b/arangod/Cluster/ClusterMethods.cpp
@@ -81,7 +81,6 @@
 #include <velocypack/HashedStringRef.h>
 #include <velocypack/Iterator.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include <boost/uuid/uuid.hpp>
 #include <boost/uuid/uuid_generators.hpp>

--- a/arangod/Cluster/ClusterMethods.h
+++ b/arangod/Cluster/ClusterMethods.h
@@ -39,7 +39,6 @@
 #include "VocBase/voc-types.h"
 
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include <map>
 

--- a/arangod/Cluster/ClusterTraverser.cpp
+++ b/arangod/Cluster/ClusterTraverser.cpp
@@ -24,7 +24,6 @@
 #include "ClusterTraverser.h"
 
 #include <velocypack/Iterator.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include "ApplicationFeatures/ApplicationServer.h"
 #include "Basics/StaticStrings.h"

--- a/arangod/Cluster/ClusterTrxMethods.cpp
+++ b/arangod/Cluster/ClusterTrxMethods.cpp
@@ -42,7 +42,6 @@
 #include "VocBase/LogicalCollection.h"
 
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::basics;

--- a/arangod/Cluster/ClusterTtlMethods.cpp
+++ b/arangod/Cluster/ClusterTtlMethods.cpp
@@ -37,7 +37,6 @@
 #include <velocypack/Buffer.h>
 #include <velocypack/Iterator.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include <vector>
 

--- a/arangod/Cluster/ClusterTypes.h
+++ b/arangod/Cluster/ClusterTypes.h
@@ -28,7 +28,6 @@
 #include <iosfwd>
 #include <memory>
 #include "velocypack/Builder.h"
-#include "velocypack/velocypack-aliases.h"
 
 #include "Basics/Result.h"
 

--- a/arangod/Cluster/CreateCollection.cpp
+++ b/arangod/Cluster/CreateCollection.cpp
@@ -42,7 +42,6 @@
 #include <velocypack/Compare.h>
 #include <velocypack/Iterator.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::application_features;

--- a/arangod/Cluster/HeartbeatThread.cpp
+++ b/arangod/Cluster/HeartbeatThread.cpp
@@ -29,7 +29,6 @@
 #include <Basics/application-exit.h>
 #include <date/date.h>
 #include <velocypack/Iterator.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include "ApplicationFeatures/ApplicationServer.h"
 #include "Basics/ConditionLocker.h"

--- a/arangod/Cluster/Maintenance.cpp
+++ b/arangod/Cluster/Maintenance.cpp
@@ -56,7 +56,6 @@
 #include <velocypack/Compare.h>
 #include <velocypack/Iterator.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include <algorithm>
 

--- a/arangod/Cluster/MaintenanceRestHandler.cpp
+++ b/arangod/Cluster/MaintenanceRestHandler.cpp
@@ -36,7 +36,6 @@
 #include "Logger/LoggerStream.h"
 
 #include "velocypack/Iterator.h"
-#include "velocypack/velocypack-aliases.h"
 
 using namespace arangodb;
 using namespace arangodb::application_features;

--- a/arangod/Cluster/ResignShardLeadership.cpp
+++ b/arangod/Cluster/ResignShardLeadership.cpp
@@ -46,7 +46,6 @@
 #include <velocypack/Compare.h>
 #include <velocypack/Iterator.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::application_features;

--- a/arangod/Cluster/RestClusterHandler.cpp
+++ b/arangod/Cluster/RestClusterHandler.cpp
@@ -37,7 +37,6 @@
 #include "Rest/Version.h"
 
 #include <velocypack/Builder.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::basics;

--- a/arangod/Cluster/ServerState.cpp
+++ b/arangod/Cluster/ServerState.cpp
@@ -58,7 +58,6 @@
 #include "VocBase/ticks.h"
 
 #include <velocypack/Iterator.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::basics;

--- a/arangod/Cluster/SynchronizeShard.cpp
+++ b/arangod/Cluster/SynchronizeShard.cpp
@@ -65,7 +65,6 @@
 #include <velocypack/Compare.h>
 #include <velocypack/Iterator.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb::application_features;
 using namespace arangodb::maintenance;

--- a/arangod/Cluster/TakeoverShardLeadership.cpp
+++ b/arangod/Cluster/TakeoverShardLeadership.cpp
@@ -53,7 +53,6 @@
 #include <velocypack/Compare.h>
 #include <velocypack/Iterator.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::application_features;

--- a/arangod/Cluster/TraverserEngine.cpp
+++ b/arangod/Cluster/TraverserEngine.cpp
@@ -41,7 +41,6 @@
 
 #include <velocypack/Iterator.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 #ifdef USE_ENTERPRISE
 #include "Enterprise/Transaction/IgnoreNoAccessMethods.h"

--- a/arangod/Cluster/v8-cluster.cpp
+++ b/arangod/Cluster/v8-cluster.cpp
@@ -24,7 +24,6 @@
 #include "v8-cluster.h"
 
 #include <velocypack/Iterator.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include "Agency/AgencyComm.h"
 #include "Agency/AsyncAgencyComm.h"

--- a/arangod/ClusterEngine/ClusterCollection.cpp
+++ b/arangod/ClusterEngine/ClusterCollection.cpp
@@ -53,7 +53,6 @@
 
 #include <velocypack/Collection.h>
 #include <velocypack/Iterator.h>
-#include <velocypack/velocypack-aliases.h>
 
 using Helper = arangodb::basics::VelocyPackHelper;
 

--- a/arangod/ClusterEngine/ClusterEngine.cpp
+++ b/arangod/ClusterEngine/ClusterEngine.cpp
@@ -46,7 +46,6 @@
 #include "VocBase/ticks.h"
 
 #include <velocypack/Iterator.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::application_features;

--- a/arangod/ClusterEngine/ClusterIndex.cpp
+++ b/arangod/ClusterEngine/ClusterIndex.cpp
@@ -35,7 +35,6 @@
 
 #include <velocypack/Collection.h>
 #include <velocypack/Iterator.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using Helper = arangodb::basics::VelocyPackHelper;

--- a/arangod/ClusterEngine/ClusterIndexFactory.cpp
+++ b/arangod/ClusterEngine/ClusterIndexFactory.cpp
@@ -43,7 +43,6 @@
 #include <velocypack/Builder.h>
 #include <velocypack/Iterator.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 namespace {
 

--- a/arangod/GeneralServer/H2CommTask.cpp
+++ b/arangod/GeneralServer/H2CommTask.cpp
@@ -40,7 +40,6 @@
 #include "Statistics/ConnectionStatistics.h"
 #include "Statistics/RequestStatistics.h"
 
-#include <velocypack/velocypack-aliases.h>
 #include <cstring>
 
 using namespace arangodb::basics;

--- a/arangod/GeneralServer/HttpCommTask.cpp
+++ b/arangod/GeneralServer/HttpCommTask.cpp
@@ -40,7 +40,6 @@
 #include "Statistics/ConnectionStatistics.h"
 #include "Statistics/RequestStatistics.h"
 
-#include <velocypack/velocypack-aliases.h>
 #include <cstring>
 
 using namespace arangodb;

--- a/arangod/GeneralServer/SslServerFeature.h
+++ b/arangod/GeneralServer/SslServerFeature.h
@@ -29,7 +29,6 @@
 #include <velocypack/Builder.h>
 #include <velocypack/Options.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include "Basics/asio_ns.h"
 #include "RestServer/arangod.h"

--- a/arangod/GeneralServer/VstCommTask.cpp
+++ b/arangod/GeneralServer/VstCommTask.cpp
@@ -49,7 +49,6 @@
 
 #include <velocypack/Options.h>
 #include <velocypack/Validator.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::basics;

--- a/arangod/GeoIndex/Near.cpp
+++ b/arangod/GeoIndex/Near.cpp
@@ -34,7 +34,6 @@
 
 #include <velocypack/Builder.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include "Basics/Common.h"
 #include "Geo/GeoParams.h"

--- a/arangod/Graph/AttributeWeightShortestPathFinder.cpp
+++ b/arangod/Graph/AttributeWeightShortestPathFinder.cpp
@@ -34,7 +34,6 @@
 #include "Transaction/Helpers.h"
 
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::graph;

--- a/arangod/Graph/BaseOptions.cpp
+++ b/arangod/Graph/BaseOptions.cpp
@@ -49,7 +49,6 @@
 #include <velocypack/Builder.h>
 #include <velocypack/Iterator.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::aql;

--- a/arangod/Graph/BreadthFirstEnumerator.cpp
+++ b/arangod/Graph/BreadthFirstEnumerator.cpp
@@ -32,7 +32,6 @@
 #include "Graph/TraverserOptions.h"
 
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::graph;

--- a/arangod/Graph/Cache/RefactoredClusterTraverserCache.cpp
+++ b/arangod/Graph/Cache/RefactoredClusterTraverserCache.cpp
@@ -26,8 +26,6 @@
 
 #include "Basics/StaticStrings.h"
 
-#include <velocypack/velocypack-aliases.h>
-
 using namespace arangodb;
 using namespace arangodb::basics;
 using namespace arangodb::graph;

--- a/arangod/Graph/Cache/RefactoredTraverserCache.cpp
+++ b/arangod/Graph/Cache/RefactoredTraverserCache.cpp
@@ -46,7 +46,6 @@
 #include <velocypack/Builder.h>
 #include <velocypack/HashedStringRef.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::graph;

--- a/arangod/Graph/ClusterTraverserCache.cpp
+++ b/arangod/Graph/ClusterTraverserCache.cpp
@@ -35,7 +35,6 @@
 #include <velocypack/Builder.h>
 #include <velocypack/HashedStringRef.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::basics;

--- a/arangod/Graph/ConstantWeightShortestPathFinder.cpp
+++ b/arangod/Graph/ConstantWeightShortestPathFinder.cpp
@@ -32,7 +32,6 @@
 #include "Transaction/Helpers.h"
 
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::graph;

--- a/arangod/Graph/Enumerators/TwoSidedEnumerator.cpp
+++ b/arangod/Graph/Enumerators/TwoSidedEnumerator.cpp
@@ -47,7 +47,6 @@
 #include <Logger/LogMacros.h>
 #include <velocypack/Builder.h>
 #include <velocypack/HashedStringRef.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::graph;

--- a/arangod/Graph/Graph.cpp
+++ b/arangod/Graph/Graph.cpp
@@ -27,7 +27,6 @@
 #include <velocypack/Buffer.h>
 #include <velocypack/Collection.h>
 #include <velocypack/Iterator.h>
-#include <velocypack/velocypack-aliases.h>
 #include <array>
 #include <utility>
 

--- a/arangod/Graph/GraphManager.cpp
+++ b/arangod/Graph/GraphManager.cpp
@@ -27,7 +27,6 @@
 #include <velocypack/Buffer.h>
 #include <velocypack/Collection.h>
 #include <velocypack/Iterator.h>
-#include <velocypack/velocypack-aliases.h>
 #include <array>
 #include <boost/range/join.hpp>
 #include <utility>

--- a/arangod/Graph/GraphOperations.cpp
+++ b/arangod/Graph/GraphOperations.cpp
@@ -26,7 +26,6 @@
 #include <velocypack/Buffer.h>
 #include <velocypack/Collection.h>
 #include <velocypack/Iterator.h>
-#include <velocypack/velocypack-aliases.h>
 #include <array>
 #include <boost/range/join.hpp>
 #include <utility>

--- a/arangod/Graph/GraphOperations.h
+++ b/arangod/Graph/GraphOperations.h
@@ -24,7 +24,6 @@
 #pragma once
 
 #include <velocypack/Buffer.h>
-#include <velocypack/velocypack-aliases.h>
 #include <chrono>
 #include <utility>
 

--- a/arangod/Graph/KShortestPathsFinder.cpp
+++ b/arangod/Graph/KShortestPathsFinder.cpp
@@ -36,7 +36,6 @@
 
 #include <velocypack/Iterator.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::graph;

--- a/arangod/Graph/PathManagement/PathResult.cpp
+++ b/arangod/Graph/PathManagement/PathResult.cpp
@@ -36,7 +36,6 @@
 #endif
 
 #include <velocypack/Builder.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::graph;

--- a/arangod/Graph/PathManagement/SingleProviderPathResult.cpp
+++ b/arangod/Graph/PathManagement/SingleProviderPathResult.cpp
@@ -37,7 +37,6 @@
 #endif
 
 #include <velocypack/Builder.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::graph;

--- a/arangod/Graph/ShortestPathOptions.cpp
+++ b/arangod/Graph/ShortestPathOptions.cpp
@@ -33,7 +33,6 @@
 #include "Transaction/Helpers.h"
 
 #include <velocypack/Iterator.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::basics;

--- a/arangod/Graph/ShortestPathResult.cpp
+++ b/arangod/Graph/ShortestPathResult.cpp
@@ -31,7 +31,6 @@
 #include "Transaction/Methods.h"
 
 #include <velocypack/Builder.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::aql;

--- a/arangod/Graph/Traverser.cpp
+++ b/arangod/Graph/Traverser.cpp
@@ -31,7 +31,6 @@
 #include "VocBase/KeyGenerator.h"
 
 #include <velocypack/Iterator.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::traverser;

--- a/arangod/Graph/TraverserCache.cpp
+++ b/arangod/Graph/TraverserCache.cpp
@@ -45,7 +45,6 @@
 #include <velocypack/Builder.h>
 #include <velocypack/HashedStringRef.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::graph;

--- a/arangod/Graph/TraverserDocumentCache.cpp
+++ b/arangod/Graph/TraverserDocumentCache.cpp
@@ -40,7 +40,6 @@
 
 #include <velocypack/Builder.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::graph;

--- a/arangod/Graph/TraverserOptions.cpp
+++ b/arangod/Graph/TraverserOptions.cpp
@@ -36,7 +36,6 @@
 #include "Indexes/Index.h"
 
 #include <velocypack/Iterator.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::graph;

--- a/arangod/Graph/WeightedEnumerator.cpp
+++ b/arangod/Graph/WeightedEnumerator.cpp
@@ -31,7 +31,6 @@
 #include "Graph/TraverserOptions.h"
 
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include <utility>
 

--- a/arangod/IResearch/Geo.cpp
+++ b/arangod/IResearch/Geo.cpp
@@ -29,7 +29,6 @@
 #include "IResearch/IResearchCommon.h"
 #include "velocypack/Builder.h"
 #include "velocypack/Slice.h"
-#include "velocypack/velocypack-aliases.h"
 
 namespace arangodb {
 namespace iresearch {

--- a/arangod/IResearch/GeoAnalyzer.cpp
+++ b/arangod/IResearch/GeoAnalyzer.cpp
@@ -30,7 +30,6 @@
 
 #include "analysis/analyzers.hpp"
 #include "velocypack/Builder.h"
-#include "velocypack/velocypack-aliases.h"
 #include "Geo/GeoJson.h"
 #include "Geo/GeoParams.h"
 #include "IResearch/Geo.h"

--- a/arangod/IResearch/GeoAnalyzer.h
+++ b/arangod/IResearch/GeoAnalyzer.h
@@ -33,7 +33,6 @@
 #include "Geo/ShapeContainer.h"
 #include "IResearch/Geo.h"
 #include "velocypack/Slice.h"
-#include "velocypack/velocypack-aliases.h"
 
 namespace arangodb {
 

--- a/arangod/IResearch/IResearchAnalyzerFeature.cpp
+++ b/arangod/IResearch/IResearchAnalyzerFeature.cpp
@@ -28,8 +28,6 @@
 #include "date/date.h"
 #endif
 
-#include "velocypack/velocypack-aliases.h"
-
 #include "analysis/analyzers.hpp"
 #include "analysis/delimited_token_stream.hpp"
 #include "analysis/collation_token_stream.hpp"

--- a/arangod/IResearch/IResearchAnalyzerFeature.h
+++ b/arangod/IResearch/IResearchAnalyzerFeature.h
@@ -50,7 +50,6 @@
 
 #include <velocypack/Builder.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include "Auth/Common.h"
 #include "Basics/ReadWriteLock.h"

--- a/arangod/IResearch/IResearchIdentityAnalyzer.h
+++ b/arangod/IResearch/IResearchIdentityAnalyzer.h
@@ -26,7 +26,6 @@
 #include "analysis/analyzer.hpp"
 #include "analysis/token_attributes.hpp"
 #include "velocypack/Slice.h"
-#include "velocypack/velocypack-aliases.h"
 
 namespace arangodb {
 namespace iresearch {

--- a/arangod/IResearch/VelocyPackHelper.h
+++ b/arangod/IResearch/VelocyPackHelper.h
@@ -28,7 +28,6 @@
 #include "Basics/debugging.h"
 
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include "utils/string.hpp"  // for irs::string_ref
 

--- a/arangod/Indexes/Index.cpp
+++ b/arangod/Indexes/Index.cpp
@@ -27,7 +27,6 @@
 #include <date/date.h>
 #include <velocypack/Iterator.h>
 #include <velocypack/Utf8Helper.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include "Index.h"
 

--- a/arangod/Indexes/IndexFactory.cpp
+++ b/arangod/Indexes/IndexFactory.cpp
@@ -39,7 +39,6 @@
 
 #include <velocypack/Iterator.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 #include <limits.h>
 
 #include <regex>

--- a/arangod/Metrics/Scale.h
+++ b/arangod/Metrics/Scale.h
@@ -27,7 +27,6 @@
 
 #include <velocypack/Builder.h>
 #include <velocypack/Value.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include <cstddef>
 #include <iosfwd>

--- a/arangod/Network/ClusterUtils.cpp
+++ b/arangod/Network/ClusterUtils.cpp
@@ -29,8 +29,6 @@
 
 #include "Logger/LogMacros.h"
 
-#include <velocypack/velocypack-aliases.h>
-
 namespace arangodb {
 namespace network {
 

--- a/arangod/Network/Utils.cpp
+++ b/arangod/Network/Utils.cpp
@@ -37,7 +37,6 @@
 #include "VocBase/ticks.h"
 
 #include <fuerte/types.h>
-#include <velocypack/velocypack-aliases.h>
 
 namespace arangodb {
 namespace network {

--- a/arangod/Pregel/AggregatorHandler.h
+++ b/arangod/Pregel/AggregatorHandler.h
@@ -25,7 +25,6 @@
 
 #include <velocypack/Builder.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 #include <functional>
 #include <map>
 #include "Basics/ReadWriteLock.h"

--- a/arangod/Pregel/Algos/AIR/AbstractAccumulator.h
+++ b/arangod/Pregel/Algos/AIR/AbstractAccumulator.h
@@ -29,7 +29,6 @@
 #include <numeric>
 
 #include "velocypack/Builder.h"
-#include "velocypack/velocypack-aliases.h"
 
 #include "AccumulatorOptions.h"
 #include "MessageData.h"

--- a/arangod/Pregel/Algos/AIR/AccumulatorOptions.h
+++ b/arangod/Pregel/Algos/AIR/AccumulatorOptions.h
@@ -27,7 +27,6 @@
 
 #include <velocypack/Builder.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 #include <map>
 #include <unordered_set>
 #include <string>

--- a/arangod/Pregel/Algos/AIR/EdgeData.cpp
+++ b/arangod/Pregel/Algos/AIR/EdgeData.cpp
@@ -26,8 +26,6 @@
 #include "EdgeData.h"
 #include <Basics/StaticStrings.h>
 
-#include "velocypack/velocypack-aliases.h"
-
 using namespace arangodb::pregel::algos::accumulators;
 
 void EdgeData::reset(VPackSlice const& doc) {

--- a/arangod/Pregel/Algos/AIR/EdgeData.h
+++ b/arangod/Pregel/Algos/AIR/EdgeData.h
@@ -27,7 +27,6 @@
 
 #include <velocypack/Builder.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include <string>
 

--- a/arangod/Pregel/Algos/AIR/GraphFormat.cpp
+++ b/arangod/Pregel/Algos/AIR/GraphFormat.cpp
@@ -32,7 +32,6 @@
 #include "Basics/overload.h"
 
 #include <velocypack/Collection.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include <utility>
 

--- a/arangod/Pregel/Algos/AIR/MessageData.cpp
+++ b/arangod/Pregel/Algos/AIR/MessageData.cpp
@@ -26,8 +26,6 @@
 #include "Basics/debugging.h"
 #include "MessageData.h"
 
-#include "velocypack/velocypack-aliases.h"
-
 using namespace arangodb::pregel::algos::accumulators;
 
 void MessageData::reset(std::string accumulatorName, VPackSlice const& value,

--- a/arangod/Pregel/Algos/AIR/MessageData.h
+++ b/arangod/Pregel/Algos/AIR/MessageData.h
@@ -27,7 +27,6 @@
 
 #include <velocypack/Builder.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 #include <string>
 
 namespace arangodb {

--- a/arangod/Pregel/Algos/AIR/VertexData.cpp
+++ b/arangod/Pregel/Algos/AIR/VertexData.cpp
@@ -27,8 +27,6 @@
 
 #include <Pregel/Algos/AIR/AbstractAccumulator.h>
 
-#include <velocypack/velocypack-aliases.h>
-
 #include <utility>
 
 using namespace arangodb::pregel::algos::accumulators;

--- a/arangod/Pregel/Algos/AIR/VertexData.h
+++ b/arangod/Pregel/Algos/AIR/VertexData.h
@@ -31,7 +31,6 @@
 
 #include <velocypack/Builder.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 namespace arangodb {
 namespace pregel {

--- a/arangod/Pregel/Algos/DMID/VertexSumAggregator.h
+++ b/arangod/Pregel/Algos/DMID/VertexSumAggregator.h
@@ -26,7 +26,6 @@
 #include <velocypack/Builder.h>
 #include <velocypack/Iterator.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include "Pregel/Graph.h"
 

--- a/arangod/Pregel/Conductor.cpp
+++ b/arangod/Pregel/Conductor.cpp
@@ -52,7 +52,6 @@
 #include "VocBase/vocbase.h"
 
 #include <velocypack/Iterator.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::pregel;

--- a/arangod/Pregel/IncomingCache.cpp
+++ b/arangod/Pregel/IncomingCache.cpp
@@ -32,7 +32,6 @@
 #include "Basics/VelocyPackHelper.h"
 
 #include <velocypack/Iterator.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include <algorithm>
 #include <random>

--- a/arangod/Pregel/MessageFormat.h
+++ b/arangod/Pregel/MessageFormat.h
@@ -28,7 +28,6 @@
 
 #include <velocypack/Builder.h>
 #include <velocypack/Iterator.h>
-#include <velocypack/velocypack-aliases.h>
 
 namespace arangodb {
 namespace pregel {

--- a/arangod/Pregel/OutgoingCache.cpp
+++ b/arangod/Pregel/OutgoingCache.cpp
@@ -38,7 +38,6 @@
 #include "VocBase/LogicalCollection.h"
 
 #include <velocypack/Iterator.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::pregel;

--- a/arangod/Pregel/PregelFeature.h
+++ b/arangod/Pregel/PregelFeature.h
@@ -32,7 +32,6 @@
 
 #include <velocypack/Builder.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include "Basics/Common.h"
 #include "Basics/Mutex.h"

--- a/arangod/Pregel/Reports.h
+++ b/arangod/Pregel/Reports.h
@@ -26,7 +26,6 @@
 
 #include <velocypack/Builder.h>
 #include <velocypack/Iterator.h>
-#include <velocypack/velocypack-aliases.h>
 #include "Pregel/Graph.h"
 
 namespace arangodb::pregel {

--- a/arangod/Pregel/Statistics.h
+++ b/arangod/Pregel/Statistics.h
@@ -25,7 +25,6 @@
 
 #include <velocypack/Builder.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include "Pregel/Utils.h"
 #include "Logger/LogMacros.h"

--- a/arangod/Pregel/Worker.cpp
+++ b/arangod/Pregel/Worker.cpp
@@ -36,8 +36,6 @@
 #include "Network/Methods.h"
 #include "Scheduler/SchedulerFeature.h"
 
-#include <velocypack/velocypack-aliases.h>
-
 using namespace arangodb;
 using namespace arangodb::basics;
 using namespace arangodb::pregel;

--- a/arangod/Pregel/WorkerConfig.h
+++ b/arangod/Pregel/WorkerConfig.h
@@ -26,7 +26,6 @@
 #include <set>
 #include <map>
 
-#include <velocypack/velocypack-aliases.h>
 #include <algorithm>
 #include "Basics/Common.h"
 #include "Cluster/ClusterInfo.h"

--- a/arangod/Pregel/WorkerContext.h
+++ b/arangod/Pregel/WorkerContext.h
@@ -24,7 +24,6 @@
 #pragma once
 
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 #include "Basics/Common.h"
 #include "Pregel/AggregatorHandler.h"
 #include "Pregel/Utils.h"

--- a/arangod/Replication/DatabaseInitialSyncer.cpp
+++ b/arangod/Replication/DatabaseInitialSyncer.cpp
@@ -64,7 +64,6 @@
 #include <velocypack/Iterator.h>
 #include <velocypack/Slice.h>
 #include <velocypack/Validator.h>
-#include <velocypack/velocypack-aliases.h>
 #include <array>
 #include <cstring>
 

--- a/arangod/Replication/DatabaseReplicationApplier.cpp
+++ b/arangod/Replication/DatabaseReplicationApplier.cpp
@@ -43,7 +43,6 @@
 #include <velocypack/Builder.h>
 #include <velocypack/Iterator.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 namespace arangodb {
 

--- a/arangod/Replication/DatabaseTailingSyncer.cpp
+++ b/arangod/Replication/DatabaseTailingSyncer.cpp
@@ -47,7 +47,6 @@
 #include <velocypack/Iterator.h>
 #include <velocypack/Parser.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::basics;

--- a/arangod/Replication/GlobalInitialSyncer.cpp
+++ b/arangod/Replication/GlobalInitialSyncer.cpp
@@ -42,7 +42,6 @@
 #include <velocypack/Builder.h>
 #include <velocypack/Iterator.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::basics;

--- a/arangod/Replication/GlobalTailingSyncer.cpp
+++ b/arangod/Replication/GlobalTailingSyncer.cpp
@@ -33,7 +33,6 @@
 #include "Replication/ReplicationFeature.h"
 
 #include <velocypack/Iterator.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::basics;

--- a/arangod/Replication/ReplicationApplierConfiguration.cpp
+++ b/arangod/Replication/ReplicationApplierConfiguration.cpp
@@ -33,7 +33,6 @@
 #include <velocypack/Builder.h>
 #include <velocypack/Iterator.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 

--- a/arangod/Replication/ReplicationApplierState.cpp
+++ b/arangod/Replication/ReplicationApplierState.cpp
@@ -25,7 +25,6 @@
 #include "Replication/common-defines.h"
 
 #include <velocypack/Builder.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 

--- a/arangod/Replication/ReplicationApplierState.h
+++ b/arangod/Replication/ReplicationApplierState.h
@@ -32,7 +32,6 @@
 
 #include <velocypack/Builder.h>
 #include <velocypack/Value.h>
-#include <velocypack/velocypack-aliases.h>
 
 namespace arangodb {
 

--- a/arangod/Replication/ReplicationClients.cpp
+++ b/arangod/Replication/ReplicationClients.cpp
@@ -33,7 +33,6 @@
 #include "Replication/utilities.h"
 
 #include <velocypack/Builder.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 

--- a/arangod/Replication/Syncer.cpp
+++ b/arangod/Replication/Syncer.cpp
@@ -60,7 +60,6 @@
 #include <velocypack/Builder.h>
 #include <velocypack/Collection.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 namespace {
 

--- a/arangod/Replication/TailingSyncer.cpp
+++ b/arangod/Replication/TailingSyncer.cpp
@@ -61,7 +61,6 @@
 #include <velocypack/Iterator.h>
 #include <velocypack/Parser.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::basics;

--- a/arangod/Replication/utilities.cpp
+++ b/arangod/Replication/utilities.cpp
@@ -29,7 +29,6 @@
 
 #include <velocypack/Builder.h>
 #include <velocypack/Parser.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include "ApplicationFeatures/ApplicationServer.h"
 #include "Basics/Mutex.h"

--- a/arangod/Replication2/AgencyCollectionSpecification.cpp
+++ b/arangod/Replication2/AgencyCollectionSpecification.cpp
@@ -22,7 +22,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #include <velocypack/Iterator.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include <Basics/debugging.h>
 #include <Basics/StaticStrings.h>

--- a/arangod/Replication2/AgencyCollectionSpecification.h
+++ b/arangod/Replication2/AgencyCollectionSpecification.h
@@ -26,7 +26,6 @@
 
 #include <velocypack/Builder.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include <Basics/Identifier.h>
 #include "Cluster/ClusterTypes.h"

--- a/arangod/Replication2/AgencyMethods.cpp
+++ b/arangod/Replication2/AgencyMethods.cpp
@@ -30,7 +30,6 @@
 #include <string>
 #include <utility>
 
-#include <velocypack/velocypack-aliases.h>
 #include <velocypack/velocypack-common.h>
 
 #include "ApplicationFeatures/ApplicationServer.h"

--- a/arangod/Replication2/ReplicatedLog/AgencyLogSpecification.cpp
+++ b/arangod/Replication2/ReplicatedLog/AgencyLogSpecification.cpp
@@ -30,7 +30,6 @@
 #include "Logger/Logger.h"
 
 #include <velocypack/Iterator.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include <type_traits>
 

--- a/arangod/Replication2/ReplicatedLog/ILogInterfaces.cpp
+++ b/arangod/Replication2/ReplicatedLog/ILogInterfaces.cpp
@@ -28,7 +28,6 @@
 #include "Replication2/ReplicatedLog/ReplicatedLogMetrics.h"
 
 #include <Basics/StaticStrings.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::replication2;

--- a/arangod/Replication2/ReplicatedLog/LogStatus.cpp
+++ b/arangod/Replication2/ReplicatedLog/LogStatus.cpp
@@ -29,7 +29,6 @@
 #include <Logger/LogMacros.h>
 #include <velocypack/Builder.h>
 #include <velocypack/Iterator.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include "LogStatus.h"
 

--- a/arangod/Replication2/ReplicatedLog/NetworkMessages.cpp
+++ b/arangod/Replication2/ReplicatedLog/NetworkMessages.cpp
@@ -25,7 +25,6 @@
 
 #include <velocypack/Builder.h>
 #include <velocypack/Iterator.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include <Basics/application-exit.h>
 #include <Containers/ImmerMemoryPolicy.h>

--- a/arangod/Replication2/ReplicatedLog/Supervision.h
+++ b/arangod/Replication2/ReplicatedLog/Supervision.h
@@ -28,7 +28,6 @@
 
 #include "velocypack/Builder.h"
 #include "velocypack/velocypack-common.h"
-#include "velocypack/velocypack-aliases.h"
 
 #include "Replication2/ReplicatedLog/LogCommon.h"
 #include "Replication2/ReplicatedLog/ParticipantsHealth.h"

--- a/arangod/Replication2/ReplicatedLog/SupervisionAction.cpp
+++ b/arangod/Replication2/ReplicatedLog/SupervisionAction.cpp
@@ -25,7 +25,6 @@
 #include "Replication2/ReplicatedLog/AgencyLogSpecification.h"
 #include "velocypack/Builder.h"
 #include "velocypack/velocypack-common.h"
-#include "velocypack/velocypack-aliases.h"
 
 #include "Agency/AgencyPaths.h"
 

--- a/arangod/Replication2/ReplicatedLog/SupervisionAction.h
+++ b/arangod/Replication2/ReplicatedLog/SupervisionAction.h
@@ -24,7 +24,6 @@
 
 #include "velocypack/Builder.h"
 #include "velocypack/velocypack-common.h"
-#include "velocypack/velocypack-aliases.h"
 
 #include "Agency/TransactionBuilder.h"
 #include "Replication2/ReplicatedLog/LogCommon.h"

--- a/arangod/Replication2/ReplicatedLog/types.cpp
+++ b/arangod/Replication2/ReplicatedLog/types.cpp
@@ -30,7 +30,6 @@
 #include <Logger/LogMacros.h>
 #include <velocypack/Builder.h>
 #include <velocypack/Iterator.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include <cstddef>
 #include <functional>

--- a/arangod/Replication2/ReplicatedState/AgencySpecification.cpp
+++ b/arangod/Replication2/ReplicatedState/AgencySpecification.cpp
@@ -28,7 +28,6 @@
 #include "Basics/voc-errors.h"
 #include "velocypack/Builder.h"
 #include "velocypack/Iterator.h"
-#include "velocypack/velocypack-aliases.h"
 
 #include "Logger/LogMacros.h"
 

--- a/arangod/RestHandler/RestAdminClusterHandler.cpp
+++ b/arangod/RestHandler/RestAdminClusterHandler.cpp
@@ -29,7 +29,6 @@
 
 #include <velocypack/Buffer.h>
 #include <velocypack/Iterator.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include "Agency/AgencyPaths.h"
 #include "Agency/AsyncAgencyComm.h"

--- a/arangod/RestHandler/RestAdminDatabaseHandler.cpp
+++ b/arangod/RestHandler/RestAdminDatabaseHandler.cpp
@@ -28,7 +28,6 @@
 #include "Rest/Version.h"
 
 #include <velocypack/Builder.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::rest;

--- a/arangod/RestHandler/RestAdminExecuteHandler.cpp
+++ b/arangod/RestHandler/RestAdminExecuteHandler.cpp
@@ -42,7 +42,6 @@
 
 #include <velocypack/Builder.h>
 #include <velocypack/Value.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::rest;

--- a/arangod/RestHandler/RestAdminLogHandler.cpp
+++ b/arangod/RestHandler/RestAdminLogHandler.cpp
@@ -26,7 +26,6 @@
 #include <velocypack/Builder.h>
 #include <velocypack/Iterator.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include "ApplicationFeatures/ApplicationServer.h"
 #include "Basics/StringUtils.h"

--- a/arangod/RestHandler/RestAdminStatisticsHandler.cpp
+++ b/arangod/RestHandler/RestAdminStatisticsHandler.cpp
@@ -23,7 +23,6 @@
 
 #include <velocypack/Buffer.h>
 #include <velocypack/Builder.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include "RestAdminStatisticsHandler.h"
 

--- a/arangod/RestHandler/RestAqlFunctionsHandler.cpp
+++ b/arangod/RestHandler/RestAqlFunctionsHandler.cpp
@@ -26,7 +26,6 @@
 #include "Aql/AqlFunctionFeature.h"
 
 #include <velocypack/Builder.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::rest;

--- a/arangod/RestHandler/RestAqlUserFunctionsHandler.cpp
+++ b/arangod/RestHandler/RestAqlUserFunctionsHandler.cpp
@@ -28,7 +28,6 @@
 #include "VocBase/Methods/AqlUserFunctions.h"
 
 #include <velocypack/Builder.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::basics;

--- a/arangod/RestHandler/RestAuthHandler.cpp
+++ b/arangod/RestHandler/RestAuthHandler.cpp
@@ -25,7 +25,6 @@
 
 #include <fuerte/jwt.h>
 #include <velocypack/Builder.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include "Basics/ScopeGuard.h"
 #include "Basics/StringUtils.h"

--- a/arangod/RestHandler/RestAuthReloadHandler.cpp
+++ b/arangod/RestHandler/RestAuthReloadHandler.cpp
@@ -31,7 +31,6 @@
 
 #include <velocypack/Builder.h>
 #include <velocypack/Value.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::rest;

--- a/arangod/RestHandler/RestBaseHandler.cpp
+++ b/arangod/RestHandler/RestBaseHandler.cpp
@@ -26,7 +26,6 @@
 #include <velocypack/Builder.h>
 #include <velocypack/Collection.h>
 #include <velocypack/Options.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include "Basics/Exceptions.h"
 #include "Basics/StaticStrings.h"

--- a/arangod/RestHandler/RestCollectionHandler.cpp
+++ b/arangod/RestHandler/RestCollectionHandler.cpp
@@ -46,7 +46,6 @@
 
 #include <velocypack/Builder.h>
 #include <velocypack/Collection.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::basics;

--- a/arangod/RestHandler/RestControlPregelHandler.cpp
+++ b/arangod/RestHandler/RestControlPregelHandler.cpp
@@ -38,7 +38,6 @@
 
 #include <velocypack/Builder.h>
 #include <velocypack/Iterator.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb::basics;
 using namespace arangodb::rest;

--- a/arangod/RestHandler/RestCursorHandler.cpp
+++ b/arangod/RestHandler/RestCursorHandler.cpp
@@ -41,7 +41,6 @@
 
 #include <velocypack/Iterator.h>
 #include <velocypack/Value.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::basics;

--- a/arangod/RestHandler/RestCursorHandler.h
+++ b/arangod/RestHandler/RestCursorHandler.h
@@ -30,7 +30,6 @@
 
 #include <velocypack/Builder.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include "Scheduler/Scheduler.h"
 

--- a/arangod/RestHandler/RestDatabaseHandler.cpp
+++ b/arangod/RestHandler/RestDatabaseHandler.cpp
@@ -34,7 +34,6 @@
 
 #include <velocypack/Builder.h>
 #include <velocypack/Iterator.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::basics;

--- a/arangod/RestHandler/RestEdgesHandler.cpp
+++ b/arangod/RestHandler/RestEdgesHandler.cpp
@@ -36,7 +36,6 @@
 #include "VocBase/LogicalCollection.h"
 
 #include <velocypack/Iterator.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::basics;

--- a/arangod/RestHandler/RestEngineHandler.cpp
+++ b/arangod/RestHandler/RestEngineHandler.cpp
@@ -29,7 +29,6 @@
 #include "StorageEngine/StorageEngine.h"
 
 #include <velocypack/Builder.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::basics;

--- a/arangod/RestHandler/RestImportHandler.cpp
+++ b/arangod/RestHandler/RestImportHandler.cpp
@@ -39,7 +39,6 @@
 #include <velocypack/Iterator.h>
 #include <velocypack/Parser.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::basics;

--- a/arangod/RestHandler/RestImportHandler.h
+++ b/arangod/RestHandler/RestImportHandler.h
@@ -29,7 +29,6 @@
 
 #include <velocypack/Builder.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 namespace arangodb {
 struct OperationOptions;

--- a/arangod/RestHandler/RestIndexHandler.cpp
+++ b/arangod/RestHandler/RestIndexHandler.cpp
@@ -41,7 +41,6 @@
 #include <velocypack/Builder.h>
 #include <velocypack/Collection.h>
 #include <velocypack/Iterator.h>
-#include <velocypack/velocypack-aliases.h>
 
 namespace {
 bool startsWith(std::string const& str, std::string const& prefix) {

--- a/arangod/RestHandler/RestJobHandler.cpp
+++ b/arangod/RestHandler/RestJobHandler.cpp
@@ -24,7 +24,6 @@
 #include "RestJobHandler.h"
 
 #include <velocypack/Builder.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include "ApplicationFeatures/ApplicationServer.h"
 #include "Basics/StringUtils.h"

--- a/arangod/RestHandler/RestLicenseHandler.cpp
+++ b/arangod/RestHandler/RestLicenseHandler.cpp
@@ -25,7 +25,6 @@
 
 #include <velocypack/Builder.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include "ApplicationFeatures/ApplicationServer.h"
 #ifdef USE_ENTERPRISE

--- a/arangod/RestHandler/RestLogHandler.cpp
+++ b/arangod/RestHandler/RestLogHandler.cpp
@@ -24,7 +24,6 @@
 #include "RestLogHandler.h"
 
 #include <velocypack/Iterator.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include <Cluster/ServerState.h>
 #include <Network/ConnectionPool.h>

--- a/arangod/RestHandler/RestMetricsHandler.cpp
+++ b/arangod/RestHandler/RestMetricsHandler.cpp
@@ -39,7 +39,6 @@
 #include "Metrics/MetricsFeature.h"
 
 #include <velocypack/Builder.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::basics;

--- a/arangod/RestHandler/RestPregelHandler.cpp
+++ b/arangod/RestHandler/RestPregelHandler.cpp
@@ -26,7 +26,6 @@
 #include "ApplicationFeatures/ApplicationServer.h"
 
 #include <velocypack/Builder.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include "Logger/LogMacros.h"
 #include "Pregel/PregelFeature.h"

--- a/arangod/RestHandler/RestReplicationHandler.cpp
+++ b/arangod/RestHandler/RestReplicationHandler.cpp
@@ -79,7 +79,6 @@
 #include <velocypack/Iterator.h>
 #include <velocypack/Parser.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::basics;

--- a/arangod/RestHandler/RestShutdownHandler.cpp
+++ b/arangod/RestHandler/RestShutdownHandler.cpp
@@ -24,7 +24,6 @@
 #include "RestShutdownHandler.h"
 
 #include <velocypack/Builder.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include "ApplicationFeatures/ApplicationServer.h"
 #include "Agency/AgencyComm.h"

--- a/arangod/RestHandler/RestSimpleHandler.cpp
+++ b/arangod/RestHandler/RestSimpleHandler.cpp
@@ -38,7 +38,6 @@
 #include <velocypack/Dumper.h>
 #include <velocypack/Iterator.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::rest;

--- a/arangod/RestHandler/RestSimpleQueryHandler.cpp
+++ b/arangod/RestHandler/RestSimpleQueryHandler.cpp
@@ -33,7 +33,6 @@
 
 #include <velocypack/Builder.h>
 #include <velocypack/Iterator.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::rest;

--- a/arangod/RestHandler/RestStatusHandler.cpp
+++ b/arangod/RestHandler/RestStatusHandler.cpp
@@ -32,7 +32,6 @@
 #endif
 
 #include <velocypack/Builder.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include "Agency/AgencyComm.h"
 #include "Agency/AgencyFeature.h"

--- a/arangod/RestHandler/RestSupportInfoHandler.cpp
+++ b/arangod/RestHandler/RestSupportInfoHandler.cpp
@@ -51,7 +51,6 @@
 #include "Utils/ExecContext.h"
 
 #include <velocypack/Builder.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include <chrono>
 

--- a/arangod/RestHandler/RestSystemReportHandler.cpp
+++ b/arangod/RestHandler/RestSystemReportHandler.cpp
@@ -34,7 +34,6 @@
 #include "Utils/ExecContext.h"
 
 #include <velocypack/Builder.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include <fstream>
 

--- a/arangod/RestHandler/RestTasksHandler.cpp
+++ b/arangod/RestHandler/RestTasksHandler.cpp
@@ -37,7 +37,6 @@
 #include "VocBase/Methods/Tasks.h"
 
 #include <velocypack/Builder.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb::basics;
 using namespace arangodb::rest;

--- a/arangod/RestHandler/RestTimeHandler.cpp
+++ b/arangod/RestHandler/RestTimeHandler.cpp
@@ -28,7 +28,6 @@
 
 #include <velocypack/Builder.h>
 #include <velocypack/Value.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::rest;

--- a/arangod/RestHandler/RestTransactionHandler.cpp
+++ b/arangod/RestHandler/RestTransactionHandler.cpp
@@ -43,7 +43,6 @@
 #include "VocBase/voc-types.h"
 
 #include <velocypack/Builder.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::basics;

--- a/arangod/RestHandler/RestTtlHandler.cpp
+++ b/arangod/RestHandler/RestTtlHandler.cpp
@@ -30,7 +30,6 @@
 #include "VocBase/Methods/Ttl.h"
 
 #include <velocypack/Builder.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::basics;

--- a/arangod/RestHandler/RestUsersHandler.cpp
+++ b/arangod/RestHandler/RestUsersHandler.cpp
@@ -36,7 +36,6 @@
 
 #include <velocypack/Builder.h>
 #include <velocypack/Collection.h>
-#include <velocypack/velocypack-aliases.h>
 
 namespace {
 

--- a/arangod/RestHandler/RestVersionHandler.cpp
+++ b/arangod/RestHandler/RestVersionHandler.cpp
@@ -29,7 +29,6 @@
 #include "RestVersionHandler.h"
 
 #include <velocypack/Builder.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::basics;

--- a/arangod/RestHandler/RestVersionHandler.h
+++ b/arangod/RestHandler/RestVersionHandler.h
@@ -25,8 +25,6 @@
 
 #include "RestHandler/RestBaseHandler.h"
 
-#include <velocypack/velocypack-aliases.h>
-
 namespace arangodb {
 class RestVersionHandler : public arangodb::RestBaseHandler {
  public:

--- a/arangod/RestHandler/RestViewHandler.cpp
+++ b/arangod/RestHandler/RestViewHandler.cpp
@@ -34,8 +34,6 @@
 #include "Utils/Events.h"
 #include "VocBase/LogicalView.h"
 
-#include <velocypack/velocypack-aliases.h>
-
 namespace {
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/arangod/RestHandler/RestVocbaseBaseHandler.cpp
+++ b/arangod/RestHandler/RestVocbaseBaseHandler.cpp
@@ -52,7 +52,6 @@
 #include <velocypack/Exception.h>
 #include <velocypack/Parser.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::basics;

--- a/arangod/RestHandler/RestWalAccessHandler.cpp
+++ b/arangod/RestHandler/RestWalAccessHandler.cpp
@@ -53,7 +53,6 @@
 #include <velocypack/Builder.h>
 #include <velocypack/Dumper.h>
 #include <velocypack/Iterator.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::basics;

--- a/arangod/RestServer/DatabaseFeature.cpp
+++ b/arangod/RestServer/DatabaseFeature.cpp
@@ -65,8 +65,6 @@
 #include "VocBase/ticks.h"
 #include "VocBase/vocbase.h"
 
-#include <velocypack/velocypack-aliases.h>
-
 using namespace arangodb;
 using namespace arangodb::application_features;
 using namespace arangodb::basics;

--- a/arangod/RestServer/SoftShutdownFeature.h
+++ b/arangod/RestServer/SoftShutdownFeature.h
@@ -29,7 +29,6 @@
 
 #include <velocypack/Builder.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include <atomic>
 

--- a/arangod/RestServer/TtlFeature.cpp
+++ b/arangod/RestServer/TtlFeature.cpp
@@ -48,7 +48,6 @@
 
 #include <velocypack/Builder.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include <chrono>
 #include <thread>

--- a/arangod/RocksDBEngine/RocksDBBuilderIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBBuilderIndex.cpp
@@ -49,7 +49,6 @@
 
 #include <velocypack/Builder.h>
 #include <velocypack/Iterator.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::rocksutils;

--- a/arangod/RocksDBEngine/RocksDBCollection.cpp
+++ b/arangod/RocksDBEngine/RocksDBCollection.cpp
@@ -82,7 +82,6 @@
 #include <rocksdb/utilities/transaction.h>
 #include <rocksdb/utilities/transaction_db.h>
 #include <velocypack/Iterator.h>
-#include <velocypack/velocypack-aliases.h>
 
 namespace {
 // number of write operations in transactions after which we will start

--- a/arangod/RocksDBEngine/RocksDBComparator.cpp
+++ b/arangod/RocksDBEngine/RocksDBComparator.cpp
@@ -32,7 +32,6 @@
 
 #include <velocypack/Iterator.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 

--- a/arangod/RocksDBEngine/RocksDBEdgeIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBEdgeIndex.cpp
@@ -58,7 +58,6 @@
 #include <rocksdb/utilities/write_batch_with_index.h>
 
 #include <velocypack/Iterator.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include <cmath>
 

--- a/arangod/RocksDBEngine/RocksDBEngine.cpp
+++ b/arangod/RocksDBEngine/RocksDBEngine.cpp
@@ -114,7 +114,6 @@
 #include <rocksdb/write_batch.h>
 
 #include <velocypack/Iterator.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include <iomanip>
 #include <limits>

--- a/arangod/RocksDBEngine/RocksDBFulltextIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBFulltextIndex.cpp
@@ -42,7 +42,6 @@
 #include <rocksdb/utilities/write_batch_with_index.h>
 #include <velocypack/Builder.h>
 #include <velocypack/Iterator.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include <algorithm>
 

--- a/arangod/RocksDBEngine/RocksDBGeoIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBGeoIndex.cpp
@@ -41,7 +41,6 @@
 #include <s2/s2cell_id.h>
 
 #include <velocypack/Iterator.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 

--- a/arangod/RocksDBEngine/RocksDBIncrementalSync.cpp
+++ b/arangod/RocksDBEngine/RocksDBIncrementalSync.cpp
@@ -49,7 +49,6 @@
 #include <velocypack/Builder.h>
 #include <velocypack/Iterator.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 namespace arangodb {
 

--- a/arangod/RocksDBEngine/RocksDBIndexFactory.cpp
+++ b/arangod/RocksDBEngine/RocksDBIndexFactory.cpp
@@ -44,7 +44,6 @@
 
 #include <velocypack/Builder.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 

--- a/arangod/RocksDBEngine/RocksDBKey.h
+++ b/arangod/RocksDBEngine/RocksDBKey.h
@@ -34,7 +34,6 @@
 #include <rocksdb/slice.h>
 
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 namespace arangodb {
 

--- a/arangod/RocksDBEngine/RocksDBKeyBounds.h
+++ b/arangod/RocksDBEngine/RocksDBKeyBounds.h
@@ -30,7 +30,6 @@
 
 #include <rocksdb/slice.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include <iosfwd>
 

--- a/arangod/RocksDBEngine/RocksDBLogValue.h
+++ b/arangod/RocksDBEngine/RocksDBLogValue.h
@@ -27,7 +27,6 @@
 #include <rocksdb/slice.h>
 
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include "Basics/Common.h"
 #include "RocksDBEngine/RocksDBTypes.h"

--- a/arangod/RocksDBEngine/RocksDBMetaCollection.cpp
+++ b/arangod/RocksDBEngine/RocksDBMetaCollection.cpp
@@ -51,7 +51,6 @@
 #include "Utils/SingleCollectionTransaction.h"
 
 #include <velocypack/Iterator.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include <chrono>
 

--- a/arangod/RocksDBEngine/RocksDBMetadata.cpp
+++ b/arangod/RocksDBEngine/RocksDBMetadata.cpp
@@ -25,7 +25,6 @@
 #include <rocksdb/utilities/transaction.h>
 
 #include <velocypack/Iterator.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include "RocksDBMetadata.h"
 

--- a/arangod/RocksDBEngine/RocksDBPrimaryIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBPrimaryIndex.cpp
@@ -64,7 +64,6 @@
 #include <velocypack/Builder.h>
 #include <velocypack/Collection.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::basics;

--- a/arangod/RocksDBEngine/RocksDBPrimaryIndex.h
+++ b/arangod/RocksDBEngine/RocksDBPrimaryIndex.h
@@ -31,7 +31,6 @@
 
 #include <velocypack/Iterator.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 namespace arangodb {
 class RocksDBKeyLeaser;

--- a/arangod/RocksDBEngine/RocksDBRecoveryManager.cpp
+++ b/arangod/RocksDBEngine/RocksDBRecoveryManager.cpp
@@ -59,7 +59,6 @@
 #include <velocypack/Iterator.h>
 #include <velocypack/Parser.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb::application_features;
 

--- a/arangod/RocksDBEngine/RocksDBReplicationContext.cpp
+++ b/arangod/RocksDBEngine/RocksDBReplicationContext.cpp
@@ -56,7 +56,6 @@
 #include "VocBase/vocbase.h"
 
 #include <velocypack/Dumper.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::rocksutils;

--- a/arangod/RocksDBEngine/RocksDBReplicationManager.cpp
+++ b/arangod/RocksDBEngine/RocksDBReplicationManager.cpp
@@ -36,7 +36,6 @@
 #include "VocBase/LogicalCollection.h"
 
 #include <velocypack/Builder.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::rocksutils;

--- a/arangod/RocksDBEngine/RocksDBReplicationTailing.cpp
+++ b/arangod/RocksDBEngine/RocksDBReplicationTailing.cpp
@@ -39,7 +39,6 @@
 
 #include <velocypack/Builder.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include <rocksdb/utilities/transaction_db.h>
 #include <rocksdb/utilities/write_batch_with_index.h>

--- a/arangod/RocksDBEngine/RocksDBRestReplicationHandler.cpp
+++ b/arangod/RocksDBEngine/RocksDBRestReplicationHandler.cpp
@@ -53,7 +53,6 @@
 #include <velocypack/Dumper.h>
 #include <velocypack/Iterator.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::basics;

--- a/arangod/RocksDBEngine/RocksDBSettingsManager.cpp
+++ b/arangod/RocksDBEngine/RocksDBSettingsManager.cpp
@@ -54,7 +54,6 @@
 #include <velocypack/Iterator.h>
 #include <velocypack/Parser.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 namespace {
 arangodb::Result writeSettings(arangodb::StorageEngine& engine,

--- a/arangod/RocksDBEngine/RocksDBTtlIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBTtlIndex.cpp
@@ -29,7 +29,6 @@
 
 #include <velocypack/Builder.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 

--- a/arangod/RocksDBEngine/RocksDBUpgrade.cpp
+++ b/arangod/RocksDBEngine/RocksDBUpgrade.cpp
@@ -48,7 +48,6 @@
 #include <rocksdb/write_batch.h>
 
 #include <velocypack/Iterator.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 

--- a/arangod/RocksDBEngine/RocksDBVPackIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBVPackIndex.cpp
@@ -56,7 +56,6 @@
 #include <rocksdb/utilities/write_batch_with_index.h>
 
 #include <velocypack/Iterator.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 

--- a/arangod/RocksDBEngine/RocksDBValue.h
+++ b/arangod/RocksDBEngine/RocksDBValue.h
@@ -29,7 +29,6 @@
 #include <s2/s2point.h>
 
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include "Basics/Common.h"
 #include "Basics/debugging.h"

--- a/arangod/Scheduler/Scheduler.cpp
+++ b/arangod/Scheduler/Scheduler.cpp
@@ -25,7 +25,6 @@
 #include "Scheduler.h"
 
 #include <velocypack/Builder.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include <thread>
 

--- a/arangod/Scheduler/SupervisedScheduler.cpp
+++ b/arangod/Scheduler/SupervisedScheduler.cpp
@@ -27,7 +27,6 @@
 #include <memory>
 
 #include <velocypack/Value.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include "SupervisedScheduler.h"
 

--- a/arangod/Sharding/ShardDistributionReporter.cpp
+++ b/arangod/Sharding/ShardDistributionReporter.cpp
@@ -24,7 +24,6 @@
 #include <queue>
 
 #include <velocypack/Builder.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include "ApplicationFeatures/ApplicationServer.h"
 #include "Basics/StringUtils.h"

--- a/arangod/Sharding/ShardingFeature.cpp
+++ b/arangod/Sharding/ShardingFeature.cpp
@@ -36,8 +36,6 @@
 #include "Enterprise/Sharding/ShardingStrategyEE.h"
 #endif
 
-#include <velocypack/velocypack-aliases.h>
-
 using namespace arangodb::application_features;
 using namespace arangodb::basics;
 

--- a/arangod/Sharding/ShardingInfo.cpp
+++ b/arangod/Sharding/ShardingInfo.cpp
@@ -36,8 +36,6 @@
 #include "VocBase/KeyGenerator.h"
 #include "VocBase/LogicalCollection.h"
 
-#include <velocypack/velocypack-aliases.h>
-
 using namespace arangodb;
 
 ShardingInfo::ShardingInfo(arangodb::velocypack::Slice info,

--- a/arangod/Sharding/ShardingStrategy.cpp
+++ b/arangod/Sharding/ShardingStrategy.cpp
@@ -26,7 +26,6 @@
 #include "Cluster/ServerState.h"
 
 #include <velocypack/Builder.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 

--- a/arangod/Sharding/ShardingStrategyDefault.cpp
+++ b/arangod/Sharding/ShardingStrategyDefault.cpp
@@ -36,7 +36,6 @@
 
 #include <velocypack/Builder.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 

--- a/arangod/Statistics/Descriptions.cpp
+++ b/arangod/Statistics/Descriptions.cpp
@@ -36,7 +36,6 @@
 #include "V8Server/V8DealerFeature.h"
 
 #include <velocypack/Builder.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 

--- a/arangod/Statistics/StatisticsWorker.cpp
+++ b/arangod/Statistics/StatisticsWorker.cpp
@@ -59,7 +59,6 @@
 
 #include <velocypack/Exception.h>
 #include <velocypack/Iterator.h>
-#include <velocypack/velocypack-aliases.h>
 
 namespace {
 std::string const garbageCollectionQuery(

--- a/arangod/StorageEngine/HealthData.cpp
+++ b/arangod/StorageEngine/HealthData.cpp
@@ -26,7 +26,6 @@
 
 #include <velocypack/Builder.h>
 #include <velocypack/Value.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 

--- a/arangod/StorageEngine/HotBackup.h
+++ b/arangod/StorageEngine/HotBackup.h
@@ -29,7 +29,6 @@
 
 #include <velocypack/Builder.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 namespace arangodb {
 namespace application_features {

--- a/arangod/StorageEngine/HotBackupCommon.h
+++ b/arangod/StorageEngine/HotBackupCommon.h
@@ -27,7 +27,6 @@
 
 #include <velocypack/Builder.h>
 #include <velocypack/Iterator.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include "Basics/VelocyPackHelper.h"
 #include "Cluster/ServerState.h"

--- a/arangod/StorageEngine/PhysicalCollection.cpp
+++ b/arangod/StorageEngine/PhysicalCollection.cpp
@@ -49,7 +49,6 @@
 #include <velocypack/Collection.h>
 #include <velocypack/Iterator.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 namespace arangodb {
 

--- a/arangod/Transaction/Context.cpp
+++ b/arangod/Transaction/Context.cpp
@@ -37,7 +37,6 @@
 #include <velocypack/Builder.h>
 #include <velocypack/Dumper.h>
 #include <velocypack/Options.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 

--- a/arangod/Transaction/Helpers.h
+++ b/arangod/Transaction/Helpers.h
@@ -31,7 +31,6 @@
 #include "VocBase/voc-types.h"
 
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 namespace arangodb {
 class CollectionNameResolver;

--- a/arangod/Transaction/Manager.cpp
+++ b/arangod/Transaction/Manager.cpp
@@ -57,7 +57,6 @@
 
 #include <fuerte/jwt.h>
 #include <velocypack/Iterator.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include <thread>
 

--- a/arangod/Transaction/Methods.cpp
+++ b/arangod/Transaction/Methods.cpp
@@ -24,7 +24,6 @@
 #include <velocypack/Builder.h>
 #include <velocypack/Options.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include "Basics/ScopeGuard.h"
 #include "Methods.h"

--- a/arangod/Transaction/Options.cpp
+++ b/arangod/Transaction/Options.cpp
@@ -28,7 +28,6 @@
 
 #include <velocypack/Builder.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb::transaction;
 

--- a/arangod/Utils/CursorRepository.cpp
+++ b/arangod/Utils/CursorRepository.cpp
@@ -38,7 +38,6 @@
 
 #include <Basics/ScopeGuard.h>
 #include <velocypack/Builder.h>
-#include <velocypack/velocypack-aliases.h>
 
 namespace {
 bool authorized(std::pair<arangodb::Cursor*, std::string> const& cursor) {

--- a/arangod/Utils/Events.h
+++ b/arangod/Utils/Events.h
@@ -26,7 +26,6 @@
 #include "Basics/Common.h"
 
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include "Rest/CommonDefines.h"
 #include "Utils/OperationOptions.h"

--- a/arangod/Utils/OperationResult.h
+++ b/arangod/Utils/OperationResult.h
@@ -31,7 +31,6 @@
 #include <velocypack/Buffer.h>
 #include <velocypack/Options.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include <unordered_map>
 

--- a/arangod/V8Server/V8DealerFeature.h
+++ b/arangod/V8Server/V8DealerFeature.h
@@ -33,7 +33,6 @@
 
 #include <velocypack/Builder.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 struct TRI_vocbase_t;
 

--- a/arangod/V8Server/v8-actions.cpp
+++ b/arangod/V8Server/v8-actions.cpp
@@ -64,7 +64,6 @@
 #include <velocypack/Buffer.h>
 #include <velocypack/Builder.h>
 #include <velocypack/Parser.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include <string_view>
 

--- a/arangod/V8Server/v8-collection.cpp
+++ b/arangod/V8Server/v8-collection.cpp
@@ -67,7 +67,6 @@
 
 #include <velocypack/Builder.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 namespace {
 

--- a/arangod/V8Server/v8-dispatcher.cpp
+++ b/arangod/V8Server/v8-dispatcher.cpp
@@ -25,7 +25,6 @@
 #include "v8-dispatcher.h"
 
 #include <velocypack/Builder.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include "ApplicationFeatures/ApplicationServer.h"
 #include "ApplicationFeatures/V8SecurityFeature.h"

--- a/arangod/V8Server/v8-query.cpp
+++ b/arangod/V8Server/v8-query.cpp
@@ -46,7 +46,6 @@
 #include <velocypack/Builder.h>
 #include <velocypack/Iterator.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::basics;

--- a/arangod/V8Server/v8-replication.cpp
+++ b/arangod/V8Server/v8-replication.cpp
@@ -51,7 +51,6 @@
 #include <velocypack/Builder.h>
 #include <velocypack/Parser.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::basics;

--- a/arangod/V8Server/v8-ttl.cpp
+++ b/arangod/V8Server/v8-ttl.cpp
@@ -32,7 +32,6 @@
 #include "VocBase/Methods/Ttl.h"
 
 #include <velocypack/Builder.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 

--- a/arangod/V8Server/v8-user-functions.cpp
+++ b/arangod/V8Server/v8-user-functions.cpp
@@ -24,7 +24,6 @@
 #include <v8.h>
 
 #include <velocypack/Builder.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include "V8/v8-conv.h"
 #include "V8/v8-utils.h"

--- a/arangod/V8Server/v8-user-structures.cpp
+++ b/arangod/V8Server/v8-user-structures.cpp
@@ -35,7 +35,6 @@
 #include <velocypack/Buffer.h>
 #include <velocypack/Builder.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 namespace arangodb {
 

--- a/arangod/V8Server/v8-users.cpp
+++ b/arangod/V8Server/v8-users.cpp
@@ -42,7 +42,6 @@
 #include <velocypack/Builder.h>
 #include <velocypack/Collection.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 namespace {
 

--- a/arangod/V8Server/v8-util.cpp
+++ b/arangod/V8Server/v8-util.cpp
@@ -23,7 +23,6 @@
 
 #include <velocypack/Builder.h>
 #include <velocypack/Value.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include "Basics/StaticStrings.h"
 #include "Basics/conversions.h"

--- a/arangod/V8Server/v8-vocbase.cpp
+++ b/arangod/V8Server/v8-vocbase.cpp
@@ -29,7 +29,6 @@
 
 #include <velocypack/Iterator.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include <v8.h>
 #include <iostream>

--- a/arangod/V8Server/v8-voccursor.cpp
+++ b/arangod/V8Server/v8-voccursor.cpp
@@ -41,7 +41,6 @@
 #include "v8-vocbaseprivate.h"
 
 #include <velocypack/Iterator.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include "Logger/Logger.h"
 

--- a/arangod/V8Server/v8-vocindex.cpp
+++ b/arangod/V8Server/v8-vocindex.cpp
@@ -54,7 +54,6 @@
 
 #include <velocypack/Builder.h>
 #include <velocypack/Iterator.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::basics;

--- a/arangod/VocBase/LogicalCollection.cpp
+++ b/arangod/VocBase/LogicalCollection.cpp
@@ -51,7 +51,6 @@
 
 #include <velocypack/Collection.h>
 #include <velocypack/Utf8Helper.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using Helper = basics::VelocyPackHelper;

--- a/arangod/VocBase/LogicalView.cpp
+++ b/arangod/VocBase/LogicalView.cpp
@@ -38,7 +38,6 @@
 #include "VocBase/vocbase.h"
 
 #include <velocypack/Iterator.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include <utility>
 

--- a/arangod/VocBase/ManagedDocumentResult.cpp
+++ b/arangod/VocBase/ManagedDocumentResult.cpp
@@ -26,7 +26,6 @@
 
 #include <velocypack/Builder.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 

--- a/arangod/VocBase/Methods/AqlUserFunctions.cpp
+++ b/arangod/VocBase/Methods/AqlUserFunctions.cpp
@@ -45,7 +45,6 @@
 #include <v8.h>
 #include <velocypack/Builder.h>
 #include <velocypack/Iterator.h>
-#include <velocypack/velocypack-aliases.h>
 #include <regex>
 
 using namespace arangodb;

--- a/arangod/VocBase/Methods/Collections.cpp
+++ b/arangod/VocBase/Methods/Collections.cpp
@@ -62,7 +62,6 @@
 #include <velocypack/Builder.h>
 #include <velocypack/Collection.h>
 #include <velocypack/Iterator.h>
-#include <velocypack/velocypack-aliases.h>
 
 #ifdef USE_ENTERPRISE
 #include "Enterprise/VocBase/Methods/CollectionValidatorEE.h"

--- a/arangod/VocBase/Methods/Collections.h
+++ b/arangod/VocBase/Methods/Collections.h
@@ -33,7 +33,6 @@
 
 #include <velocypack/Builder.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 #include <functional>
 
 namespace arangodb {

--- a/arangod/VocBase/Methods/Databases.cpp
+++ b/arangod/VocBase/Methods/Databases.cpp
@@ -60,7 +60,6 @@
 #include <velocypack/Builder.h>
 #include <velocypack/Iterator.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::methods;

--- a/arangod/VocBase/Methods/Databases.h
+++ b/arangod/VocBase/Methods/Databases.h
@@ -25,7 +25,6 @@
 
 #include <velocypack/Builder.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 #include "Basics/Result.h"
 #include "Basics/debugging.h"
 #include "VocBase/voc-types.h"

--- a/arangod/VocBase/Methods/Indexes.cpp
+++ b/arangod/VocBase/Methods/Indexes.cpp
@@ -57,7 +57,6 @@
 #include <velocypack/Builder.h>
 #include <velocypack/Collection.h>
 #include <velocypack/Iterator.h>
-#include <velocypack/velocypack-aliases.h>
 #include <regex>
 
 using namespace arangodb;

--- a/arangod/VocBase/Methods/Queries.cpp
+++ b/arangod/VocBase/Methods/Queries.cpp
@@ -44,7 +44,6 @@
 #include <velocypack/Builder.h>
 #include <velocypack/Iterator.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::methods;

--- a/arangod/VocBase/Methods/Tasks.cpp
+++ b/arangod/VocBase/Methods/Tasks.cpp
@@ -27,7 +27,6 @@
 
 #include <v8.h>
 #include <velocypack/Builder.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include "ApplicationFeatures/ApplicationServer.h"
 #include "Basics/FunctionUtils.h"

--- a/arangod/VocBase/Methods/Transactions.h
+++ b/arangod/VocBase/Methods/Transactions.h
@@ -25,7 +25,6 @@
 
 #include <v8.h>
 #include <velocypack/Builder.h>
-#include <velocypack/velocypack-aliases.h>
 #include "Basics/ReadWriteLock.h"
 #include "Basics/Result.h"
 #include "VocBase/vocbase.h"

--- a/arangod/VocBase/Methods/Ttl.cpp
+++ b/arangod/VocBase/Methods/Ttl.cpp
@@ -30,7 +30,6 @@
 #include "RestServer/TtlFeature.h"
 
 #include <velocypack/Builder.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::methods;

--- a/arangod/VocBase/Methods/Upgrade.cpp
+++ b/arangod/VocBase/Methods/Upgrade.cpp
@@ -35,7 +35,6 @@
 #include "VocBase/vocbase.h"
 
 #include <velocypack/Iterator.h>
-#include <velocypack/velocypack-aliases.h>
 
 namespace {
 

--- a/arangod/VocBase/Methods/UpgradeTasks.cpp
+++ b/arangod/VocBase/Methods/UpgradeTasks.cpp
@@ -49,7 +49,6 @@
 #include "VocBase/vocbase.h"
 
 #include <velocypack/Collection.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::methods;

--- a/arangod/VocBase/Methods/Version.cpp
+++ b/arangod/VocBase/Methods/Version.cpp
@@ -41,7 +41,6 @@
 #include <velocypack/Iterator.h>
 #include <velocypack/Parser.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::methods;

--- a/arangod/VocBase/Validators.h
+++ b/arangod/VocBase/Validators.h
@@ -27,7 +27,6 @@
 #include <velocypack/Builder.h>
 #include <velocypack/Options.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 #include <string>
 
 #include <tao/json/forward.hpp>

--- a/arangod/VocBase/VocbaseInfo.h
+++ b/arangod/VocBase/VocbaseInfo.h
@@ -25,7 +25,6 @@
 
 #include <velocypack/Builder.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 #include "Basics/Result.h"
 #include "Basics/debugging.h"
 #include "RestServer/arangod.h"

--- a/arangod/VocBase/vocbase.cpp
+++ b/arangod/VocBase/vocbase.cpp
@@ -37,7 +37,6 @@
 #include <velocypack/Utf8Helper.h>
 #include <velocypack/Value.h>
 #include <velocypack/ValueType.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include "ApplicationFeatures/ApplicationServer.h"
 #include "Aql/PlanCache.h"

--- a/client-tools/Benchmark/BenchFeature.cpp
+++ b/client-tools/Benchmark/BenchFeature.cpp
@@ -25,7 +25,6 @@
 #include <velocypack/Iterator.h>
 #include <velocypack/Parser.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include "BenchFeature.h"
 

--- a/client-tools/Benchmark/BenchFeature.h
+++ b/client-tools/Benchmark/BenchFeature.h
@@ -29,7 +29,6 @@
 #include "Benchmark/arangobench.h"
 #include "Benchmark/BenchmarkThread.h"
 #include "Benchmark/BenchmarkStats.h"
-#include <velocypack/velocypack-aliases.h>
 
 namespace arangodb {
 namespace arangobench {

--- a/client-tools/Benchmark/arangobench.cpp
+++ b/client-tools/Benchmark/arangobench.cpp
@@ -30,7 +30,6 @@
 #include <velocypack/Builder.h>
 #include <velocypack/Iterator.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include "ApplicationFeatures/ApplicationServer.h"
 #include "ApplicationFeatures/CommunicationFeaturePhase.h"

--- a/client-tools/Dump/DumpFeature.cpp
+++ b/client-tools/Dump/DumpFeature.cpp
@@ -28,7 +28,6 @@
 
 #include <velocypack/Collection.h>
 #include <velocypack/Iterator.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include "ApplicationFeatures/ApplicationServer.h"
 #include "Basics/Exceptions.h"

--- a/client-tools/Export/ExportFeature.cpp
+++ b/client-tools/Export/ExportFeature.cpp
@@ -44,7 +44,6 @@
 #include <velocypack/Dumper.h>
 #include <velocypack/Slice.h>
 #include <velocypack/Sink.h>
-#include <velocypack/velocypack-aliases.h>
 #include <iostream>
 #include <regex>
 #include <sys/types.h>

--- a/client-tools/Export/ExportFeature.h
+++ b/client-tools/Export/ExportFeature.h
@@ -25,7 +25,6 @@
 
 #include <velocypack/Builder.h>
 #include <velocypack/Iterator.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include "ApplicationFeatures/ApplicationFeature.h"
 #include "Basics/files.h"

--- a/client-tools/Import/ImportHelper.cpp
+++ b/client-tools/Import/ImportHelper.cpp
@@ -42,7 +42,6 @@
 
 #include <velocypack/Builder.h>
 #include <velocypack/Iterator.h>
-#include <velocypack/velocypack-aliases.h>
 
 #ifdef TRI_HAVE_UNISTD_H
 #include <unistd.h>

--- a/client-tools/Import/SenderThread.cpp
+++ b/client-tools/Import/SenderThread.cpp
@@ -35,7 +35,6 @@
 
 #include <velocypack/Builder.h>
 #include <velocypack/Iterator.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::import;

--- a/client-tools/Restore/RestoreFeature.cpp
+++ b/client-tools/Restore/RestoreFeature.cpp
@@ -27,7 +27,6 @@
 #include <velocypack/Builder.h>
 #include <velocypack/Collection.h>
 #include <velocypack/Iterator.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include <algorithm>
 #include <chrono>

--- a/client-tools/Shell/V8ClientConnection.cpp
+++ b/client-tools/Shell/V8ClientConnection.cpp
@@ -59,7 +59,6 @@
 #include <velocypack/Builder.h>
 #include <velocypack/Parser.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include <iostream>
 

--- a/client-tools/Utils/ClientTaskQueue.h
+++ b/client-tools/Utils/ClientTaskQueue.h
@@ -29,7 +29,6 @@
 #include <vector>
 
 #include <velocypack/Iterator.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include "Basics/ConditionLocker.h"
 #include "Basics/ConditionVariable.h"

--- a/client-tools/Utils/ManagedDirectory.h
+++ b/client-tools/Utils/ManagedDirectory.h
@@ -30,7 +30,6 @@
 
 #include <velocypack/Builder.h>
 #include <velocypack/Parser.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include "zlib.h"
 

--- a/client-tools/V8Client/ArangoClientHelper.cpp
+++ b/client-tools/V8Client/ArangoClientHelper.cpp
@@ -24,7 +24,6 @@
 #include "ArangoClientHelper.h"
 
 #include <velocypack/Iterator.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include "Basics/StringUtils.h"
 #include "Basics/VelocyPackHelper.h"

--- a/client-tools/VPack/VPackFeature.cpp
+++ b/client-tools/VPack/VPackFeature.cpp
@@ -36,7 +36,6 @@
 #include <velocypack/Sink.h>
 #include <velocypack/Slice.h>
 #include <velocypack/Validator.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include <iostream>
 #include <unordered_set>

--- a/lib/ApplicationFeatures/ApplicationServer.cpp
+++ b/lib/ApplicationFeatures/ApplicationServer.cpp
@@ -36,7 +36,6 @@
 
 #include <velocypack/Options.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include "ApplicationServer.h"
 

--- a/lib/Basics/EncodingUtils.cpp
+++ b/lib/Basics/EncodingUtils.cpp
@@ -27,7 +27,6 @@
 #include "Basics/voc-errors.h"
 
 #include <velocypack/Buffer.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include <zconf.h>
 #include <zlib.h>

--- a/lib/Basics/Result.cpp
+++ b/lib/Basics/Result.cpp
@@ -31,7 +31,6 @@
 
 #include <velocypack/Builder.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::result;

--- a/lib/Basics/ResultError.cpp
+++ b/lib/Basics/ResultError.cpp
@@ -29,7 +29,6 @@
 
 #include <velocypack/Builder.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include <ostream>
 

--- a/lib/Basics/RocksDBUtils.h
+++ b/lib/Basics/RocksDBUtils.h
@@ -33,7 +33,6 @@
 #include <velocypack/Buffer.h>
 #include <velocypack/Builder.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include <string>
 

--- a/lib/Basics/VPackStringBufferAdapter.h
+++ b/lib/Basics/VPackStringBufferAdapter.h
@@ -27,7 +27,6 @@
 #include "Basics/StringBuffer.h"
 
 #include <velocypack/Sink.h>
-#include <velocypack/velocypack-aliases.h>
 
 namespace arangodb {
 namespace basics {

--- a/lib/Basics/VelocyPackHelper.cpp
+++ b/lib/Basics/VelocyPackHelper.cpp
@@ -36,7 +36,6 @@
 #include <velocypack/Iterator.h>
 #include <velocypack/Options.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 #include <velocypack/velocypack-common.h>
 
 #include "Basics/operating-system.h"

--- a/lib/Basics/VelocyPackHelper.h
+++ b/lib/Basics/VelocyPackHelper.h
@@ -38,7 +38,6 @@
 #include <velocypack/Parser.h>
 #include <velocypack/Slice.h>
 #include <velocypack/ValueType.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include "Basics/system-compiler.h"
 

--- a/lib/Geo/GeoJson.cpp
+++ b/lib/Geo/GeoJson.cpp
@@ -29,7 +29,6 @@
 #include <vector>
 
 #include <velocypack/Iterator.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include <s2/s2loop.h>
 #include <s2/s2point_region.h>

--- a/lib/Geo/GeoParams.cpp
+++ b/lib/Geo/GeoParams.cpp
@@ -31,7 +31,6 @@
 
 #include <velocypack/Builder.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include "Basics/Common.h"
 #include "Basics/debugging.h"

--- a/lib/Geo/ShapeContainer.cpp
+++ b/lib/Geo/ShapeContainer.cpp
@@ -37,7 +37,6 @@
 #include <s2/util/math/vector.h>
 
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include "ShapeContainer.h"
 

--- a/lib/Greenspun/EvalResult.h
+++ b/lib/Greenspun/EvalResult.h
@@ -31,7 +31,6 @@
 
 #include <velocypack/Iterator.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 namespace arangodb {
 namespace greenspun {

--- a/lib/Greenspun/Interpreter.h
+++ b/lib/Greenspun/Interpreter.h
@@ -34,7 +34,6 @@
 #include <velocypack/Builder.h>
 #include <velocypack/Iterator.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include <Containers/ImmerMemoryPolicy.h>
 

--- a/lib/Greenspun/Primitives.cpp
+++ b/lib/Greenspun/Primitives.cpp
@@ -29,7 +29,6 @@
 #include <velocypack/Collection.h>
 #include <velocypack/Iterator.h>
 #include <velocypack/Parser.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include <iostream>
 #include <list>

--- a/lib/Greenspun/Primitives.h
+++ b/lib/Greenspun/Primitives.h
@@ -29,7 +29,6 @@
 
 #include <velocypack/Builder.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 namespace arangodb {
 namespace greenspun {

--- a/lib/Greenspun/lib/DateTime.cpp
+++ b/lib/Greenspun/lib/DateTime.cpp
@@ -27,7 +27,6 @@
 #include <Basics/datetime.h>
 #include <velocypack/Collection.h>
 #include <velocypack/Iterator.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include <iostream>
 

--- a/lib/Greenspun/lib/DateTime.h
+++ b/lib/Greenspun/lib/DateTime.h
@@ -29,7 +29,6 @@
 
 #include <velocypack/Builder.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 namespace arangodb {
 namespace greenspun {

--- a/lib/Greenspun/lib/Dicts.cpp
+++ b/lib/Greenspun/lib/Dicts.cpp
@@ -25,7 +25,6 @@
 #include <string_view>
 
 #include <velocypack/Collection.h>
-#include <velocypack/velocypack-aliases.h>
 #include "Dicts.h"
 
 #include "Greenspun/Extractor.h"

--- a/lib/Greenspun/lib/Lists.cpp
+++ b/lib/Greenspun/lib/Lists.cpp
@@ -23,7 +23,6 @@
 
 #include "Lists.h"
 #include <velocypack/Collection.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include "Greenspun/Extractor.h"
 #include "Greenspun/Interpreter.h"

--- a/lib/Greenspun/lib/Math.cpp
+++ b/lib/Greenspun/lib/Math.cpp
@@ -24,7 +24,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #include <velocypack/Collection.h>
-#include <velocypack/velocypack-aliases.h>
 #include <cmath>
 
 #include "Greenspun/Extractor.h"

--- a/lib/Greenspun/lib/Strings.cpp
+++ b/lib/Greenspun/lib/Strings.cpp
@@ -23,7 +23,6 @@
 
 #include "Strings.h"
 #include <velocypack/Collection.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include "Greenspun/Extractor.h"
 

--- a/lib/Maskings/AttributeMasking.h
+++ b/lib/Maskings/AttributeMasking.h
@@ -29,7 +29,6 @@
 #include <velocypack/Iterator.h>
 #include <velocypack/Parser.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include "Maskings/MaskingFunction.h"
 #include "Maskings/ParseResult.h"

--- a/lib/Maskings/Collection.h
+++ b/lib/Maskings/Collection.h
@@ -29,7 +29,6 @@
 #include <velocypack/Iterator.h>
 #include <velocypack/Parser.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include "Maskings/AttributeMasking.h"
 #include "Maskings/CollectionFilter.h"

--- a/lib/Maskings/MaskingFunction.h
+++ b/lib/Maskings/MaskingFunction.h
@@ -31,7 +31,6 @@
 #include <velocypack/Iterator.h>
 #include <velocypack/Parser.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 namespace arangodb {
 namespace maskings {

--- a/lib/Maskings/Maskings.cpp
+++ b/lib/Maskings/Maskings.cpp
@@ -32,7 +32,6 @@
 #include <velocypack/Options.h>
 #include <velocypack/Parser.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 #include <velocypack/velocypack-common.h>
 
 #include "Maskings.h"

--- a/lib/Maskings/Maskings.h
+++ b/lib/Maskings/Maskings.h
@@ -32,7 +32,6 @@
 
 #include <velocypack/Builder.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include "Basics/Common.h"
 #include "Maskings/Collection.h"

--- a/lib/ProgramOptions/Option.cpp
+++ b/lib/ProgramOptions/Option.cpp
@@ -28,7 +28,6 @@
 #include "ProgramOptions/Parameters.h"
 
 #include <velocypack/Builder.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include <iostream>
 

--- a/lib/ProgramOptions/Parameters.h
+++ b/lib/ProgramOptions/Parameters.h
@@ -29,7 +29,6 @@
 #include "Basics/fpconv.h"
 
 #include <velocypack/Builder.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include <atomic>
 #include <limits>

--- a/lib/ProgramOptions/ProgramOptions.cpp
+++ b/lib/ProgramOptions/ProgramOptions.cpp
@@ -31,7 +31,6 @@
 #include "ProgramOptions/Translator.h"
 
 #include <velocypack/Builder.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include <algorithm>
 #include <iostream>

--- a/lib/Rest/GeneralRequest.cpp
+++ b/lib/Rest/GeneralRequest.cpp
@@ -22,8 +22,6 @@
 /// @author Achim Brandt
 ////////////////////////////////////////////////////////////////////////////////
 
-#include <velocypack/velocypack-aliases.h>
-
 #include "GeneralRequest.h"
 
 #include "Basics/StaticStrings.h"

--- a/lib/Rest/HttpRequest.cpp
+++ b/lib/Rest/HttpRequest.cpp
@@ -30,7 +30,6 @@
 #include <velocypack/Options.h>
 #include <velocypack/Parser.h>
 #include <velocypack/Validator.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include "Basics/StaticStrings.h"
 #include "Basics/StringUtils.h"

--- a/lib/Rest/HttpResponse.cpp
+++ b/lib/Rest/HttpResponse.cpp
@@ -28,7 +28,6 @@
 #include <velocypack/Dumper.h>
 #include <velocypack/Options.h>
 #include <velocypack/Sink.h>
-#include <velocypack/velocypack-aliases.h>
 #include <time.h>
 
 #include "Basics/Exceptions.h"

--- a/lib/Rest/Version.cpp
+++ b/lib/Rest/Version.cpp
@@ -36,7 +36,6 @@
 
 #include <velocypack/Builder.h>
 #include <velocypack/Version.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include "Basics/FeatureFlags.h"
 #include "Basics/StringUtils.h"

--- a/lib/Rest/VstRequest.cpp
+++ b/lib/Rest/VstRequest.cpp
@@ -34,7 +34,6 @@
 #include <velocypack/Iterator.h>
 #include <velocypack/Parser.h>
 #include <velocypack/Validator.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include "Basics/StaticStrings.h"
 #include "Basics/StringUtils.h"

--- a/lib/Rest/VstResponse.cpp
+++ b/lib/Rest/VstResponse.cpp
@@ -27,7 +27,6 @@
 #include <velocypack/Builder.h>
 #include <velocypack/Dumper.h>
 #include <velocypack/Options.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include "Basics/Exceptions.h"
 #include "Basics/StringBuffer.h"

--- a/lib/SimpleHttpClient/HttpResponseChecker.cpp
+++ b/lib/SimpleHttpClient/HttpResponseChecker.cpp
@@ -29,7 +29,6 @@
 #include <velocypack/Builder.h>
 #include <velocypack/Iterator.h>
 #include <velocypack/Parser.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 

--- a/lib/SimpleHttpClient/SimpleHttpClient.cpp
+++ b/lib/SimpleHttpClient/SimpleHttpClient.cpp
@@ -33,7 +33,6 @@
 #include <velocypack/Builder.h>
 #include <velocypack/Parser.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include "SimpleHttpClient.h"
 

--- a/lib/SimpleHttpClient/SimpleHttpResult.cpp
+++ b/lib/SimpleHttpClient/SimpleHttpResult.cpp
@@ -29,7 +29,6 @@
 #include "Basics/VelocyPackHelper.h"
 
 #include <velocypack/Parser.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include <string_view>
 

--- a/lib/SimpleHttpClient/SimpleHttpResult.h
+++ b/lib/SimpleHttpClient/SimpleHttpResult.h
@@ -29,7 +29,6 @@
 
 #include <velocypack/Builder.h>
 #include <velocypack/Options.h>
-#include <velocypack/velocypack-aliases.h>
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief class for storing a request result

--- a/lib/V8/JSLoader.cpp
+++ b/lib/V8/JSLoader.cpp
@@ -27,7 +27,6 @@
 #include <v8.h>
 
 #include <velocypack/Builder.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include "JSLoader.h"
 

--- a/lib/V8/v8-shell.cpp
+++ b/lib/V8/v8-shell.cpp
@@ -40,7 +40,6 @@
 #include <velocypack/Builder.h>
 #include <velocypack/Parser.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include <fstream>
 #include <sys/types.h>

--- a/lib/V8/v8-utils.cpp
+++ b/lib/V8/v8-utils.cpp
@@ -117,7 +117,6 @@
 #endif
 
 #include <velocypack/Validator.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::application_features;

--- a/lib/V8/v8-vpack.cpp
+++ b/lib/V8/v8-vpack.cpp
@@ -26,7 +26,6 @@
 #include <velocypack/Builder.h>
 #include <velocypack/Iterator.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include "ApplicationFeatures/V8PlatformFeature.h"
 #include "Basics/Exceptions.h"

--- a/tests/Agency/ActiveFailoverTest.cpp
+++ b/tests/Agency/ActiveFailoverTest.cpp
@@ -30,7 +30,6 @@
 #include <velocypack/Collection.h>
 #include <velocypack/Parser.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include "Mocks/LogLevels.h"
 

--- a/tests/Agency/AddFollowerTest.cpp
+++ b/tests/Agency/AddFollowerTest.cpp
@@ -30,7 +30,6 @@
 
 #include <velocypack/Parser.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include "Mocks/LogLevels.h"
 

--- a/tests/Agency/CleanOutServerTest.cpp
+++ b/tests/Agency/CleanOutServerTest.cpp
@@ -26,7 +26,6 @@
 #include "fakeit.hpp"
 
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include "Mocks/LogLevels.h"
 

--- a/tests/Agency/CleanUpLostCollectionTest.cpp
+++ b/tests/Agency/CleanUpLostCollectionTest.cpp
@@ -30,7 +30,6 @@
 #include "Agency/Node.h"
 
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::basics;

--- a/tests/Agency/FailedFollowerTest.cpp
+++ b/tests/Agency/FailedFollowerTest.cpp
@@ -30,7 +30,6 @@
 
 #include <velocypack/Parser.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include "Mocks/LogLevels.h"
 

--- a/tests/Agency/FailedLeaderTest.cpp
+++ b/tests/Agency/FailedLeaderTest.cpp
@@ -32,7 +32,6 @@
 #include <velocypack/Collection.h>
 #include <velocypack/Parser.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include "Mocks/LogLevels.h"
 

--- a/tests/Agency/FailedServerTest.cpp
+++ b/tests/Agency/FailedServerTest.cpp
@@ -28,7 +28,6 @@
 
 #include <velocypack/Parser.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 #include <iostream>
 
 #include "Mocks/LogLevels.h"

--- a/tests/Agency/MoveShardTest.cpp
+++ b/tests/Agency/MoveShardTest.cpp
@@ -26,7 +26,6 @@
 #include "fakeit.hpp"
 
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include "Mocks/LogLevels.h"
 

--- a/tests/Agency/NodeTest.cpp
+++ b/tests/Agency/NodeTest.cpp
@@ -29,7 +29,6 @@
 #include <velocypack/Builder.h>
 #include <velocypack/Parser.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 #include <iostream>
 
 #include "Mocks/LogLevels.h"

--- a/tests/Agency/RemoveFollowerTest.cpp
+++ b/tests/Agency/RemoveFollowerTest.cpp
@@ -36,7 +36,6 @@
 
 #include <velocypack/Parser.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 #include <iostream>
 
 using namespace arangodb;

--- a/tests/Agency/StoreTestAPI.cpp
+++ b/tests/Agency/StoreTestAPI.cpp
@@ -30,7 +30,6 @@
 #include <velocypack/Builder.h>
 #include <velocypack/Compare.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include <random>
 

--- a/tests/Agency/SupervisionTest.cpp
+++ b/tests/Agency/SupervisionTest.cpp
@@ -32,7 +32,6 @@
 #include "fakeit.hpp"
 
 #include <velocypack/Iterator.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include <typeinfo>
 

--- a/tests/Aql/AllRowsFetcherTest.cpp
+++ b/tests/Aql/AllRowsFetcherTest.cpp
@@ -38,7 +38,6 @@
 
 #include <Containers/HashSet.h>
 #include <velocypack/Builder.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::aql;

--- a/tests/Aql/AqlItemBlockInputRangeTest.cpp
+++ b/tests/Aql/AqlItemBlockInputRangeTest.cpp
@@ -34,7 +34,6 @@
 
 #include <velocypack/Builder.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::aql;

--- a/tests/Aql/AqlItemBlockTest.cpp
+++ b/tests/Aql/AqlItemBlockTest.cpp
@@ -31,7 +31,6 @@
 
 #include <velocypack/Builder.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::aql;

--- a/tests/Aql/AqlItemRowTest.cpp
+++ b/tests/Aql/AqlItemRowTest.cpp
@@ -36,7 +36,6 @@
 
 #include <velocypack/Builder.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::aql;

--- a/tests/Aql/AqlShadowRowTest.cpp
+++ b/tests/Aql/AqlShadowRowTest.cpp
@@ -34,7 +34,6 @@
 
 #include <velocypack/Builder.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 #include <boost/container/flat_set.hpp>
 
 using namespace arangodb;

--- a/tests/Aql/AqlValueMemoryLayoutTest.cpp
+++ b/tests/Aql/AqlValueMemoryLayoutTest.cpp
@@ -28,7 +28,6 @@
 
 #include <velocypack/Builder.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::aql;

--- a/tests/Aql/BitFunctionsTest.cpp
+++ b/tests/Aql/BitFunctionsTest.cpp
@@ -37,7 +37,6 @@
 #include <velocypack/Iterator.h>
 #include <velocypack/Parser.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::aql;

--- a/tests/Aql/CalculationExecutorTest.cpp
+++ b/tests/Aql/CalculationExecutorTest.cpp
@@ -43,7 +43,6 @@
 #include "Transaction/Methods.h"
 
 #include <velocypack/Builder.h>
-#include <velocypack/velocypack-aliases.h>
 
 // required for QuerySetup
 #include "Mocks/Servers.h"

--- a/tests/Aql/DateFunctionsTest.cpp
+++ b/tests/Aql/DateFunctionsTest.cpp
@@ -38,7 +38,6 @@
 #include <velocypack/Iterator.h>
 #include <velocypack/Parser.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include <cmath>
 

--- a/tests/Aql/DecaysFunctionTest.cpp
+++ b/tests/Aql/DecaysFunctionTest.cpp
@@ -39,7 +39,6 @@
 #include <velocypack/Iterator.h>
 #include <velocypack/Parser.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::aql;

--- a/tests/Aql/DistanceFunctionTest.cpp
+++ b/tests/Aql/DistanceFunctionTest.cpp
@@ -39,7 +39,6 @@
 #include <velocypack/Iterator.h>
 #include <velocypack/Parser.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::aql;

--- a/tests/Aql/DistinctCollectExecutorTest.cpp
+++ b/tests/Aql/DistinctCollectExecutorTest.cpp
@@ -45,7 +45,6 @@
 
 #include <velocypack/Builder.h>
 #include <velocypack/Options.h>
-#include <velocypack/velocypack-aliases.h>
 #include <functional>
 
 using namespace arangodb;

--- a/tests/Aql/EnumerateCollectionExecutorTest.cpp
+++ b/tests/Aql/EnumerateCollectionExecutorTest.cpp
@@ -54,7 +54,6 @@
 #include "VocBase/AccessMode.h"
 #include "VocBase/LogicalCollection.h"
 
-#include <velocypack/velocypack-aliases.h>
 #include <functional>
 #include <utility>
 

--- a/tests/Aql/EnumerateListExecutorTest.cpp
+++ b/tests/Aql/EnumerateListExecutorTest.cpp
@@ -44,7 +44,6 @@
 #include "Transaction/Methods.h"
 
 #include <velocypack/Builder.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::aql;

--- a/tests/Aql/ExecutionNodeTest.cpp
+++ b/tests/Aql/ExecutionNodeTest.cpp
@@ -32,7 +32,6 @@
 #include "Logger/LogMacros.h"
 
 #include "velocypack/Builder.h"
-#include "velocypack/velocypack-aliases.h"
 
 #include "../Mocks/Servers.h"
 

--- a/tests/Aql/FilterExecutorTest.cpp
+++ b/tests/Aql/FilterExecutorTest.cpp
@@ -41,7 +41,6 @@
 #include "Basics/ResourceUsage.h"
 
 #include <velocypack/Builder.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::aql;

--- a/tests/Aql/HashedCollectExecutorTest.cpp
+++ b/tests/Aql/HashedCollectExecutorTest.cpp
@@ -43,7 +43,6 @@
 #include "Transaction/Methods.h"
 
 #include <velocypack/Builder.h>
-#include <velocypack/velocypack-aliases.h>
 #include <functional>
 
 using namespace arangodb;

--- a/tests/Aql/IdExecutorTest.cpp
+++ b/tests/Aql/IdExecutorTest.cpp
@@ -42,8 +42,6 @@
 #include "Aql/SubqueryStartExecutor.h"
 #include "Basics/ResourceUsage.h"
 
-#include <velocypack/velocypack-aliases.h>
-
 using namespace arangodb;
 using namespace arangodb::aql;
 

--- a/tests/Aql/InRangeFunctionTest.cpp
+++ b/tests/Aql/InRangeFunctionTest.cpp
@@ -39,7 +39,6 @@
 #include <velocypack/Iterator.h>
 #include <velocypack/Parser.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 #include <set>
 
 using namespace arangodb;

--- a/tests/Aql/InsertExecutorTest.cpp
+++ b/tests/Aql/InsertExecutorTest.cpp
@@ -34,7 +34,6 @@
 #include <velocypack/Builder.h>
 #include <velocypack/Iterator.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include "../IResearch/IResearchQueryCommon.h"
 

--- a/tests/Aql/JaccardFunctionTest.cpp
+++ b/tests/Aql/JaccardFunctionTest.cpp
@@ -37,7 +37,6 @@
 #include <velocypack/Iterator.h>
 #include <velocypack/Parser.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::aql;

--- a/tests/Aql/KShortestPathsExecutorTest.cpp
+++ b/tests/Aql/KShortestPathsExecutorTest.cpp
@@ -25,7 +25,6 @@
 
 #include <velocypack/Builder.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include "Aql/RowFetcherHelper.h"
 #include "Mocks/LogLevels.h"

--- a/tests/Aql/LevenshteinMatchFunctionTest.cpp
+++ b/tests/Aql/LevenshteinMatchFunctionTest.cpp
@@ -37,7 +37,6 @@
 #include <velocypack/Iterator.h>
 #include <velocypack/Parser.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::aql;

--- a/tests/Aql/LimitExecutorTest.cpp
+++ b/tests/Aql/LimitExecutorTest.cpp
@@ -37,7 +37,6 @@
 #include "Basics/ResourceUsage.h"
 
 #include <velocypack/Builder.h>
-#include <velocypack/velocypack-aliases.h>
 #include <numeric>
 
 using namespace arangodb;

--- a/tests/Aql/MultiDependencySingleRowFetcherTest.cpp
+++ b/tests/Aql/MultiDependencySingleRowFetcherTest.cpp
@@ -39,7 +39,6 @@
 #include "Basics/ResourceUsage.h"
 
 #include <velocypack/Builder.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::aql;

--- a/tests/Aql/NgramMatchFunctionTest.cpp
+++ b/tests/Aql/NgramMatchFunctionTest.cpp
@@ -42,7 +42,6 @@
 #include <velocypack/Iterator.h>
 #include <velocypack/Parser.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 #include <set>
 
 using namespace arangodb;

--- a/tests/Aql/NgramPosSimilarityFunctionTest.cpp
+++ b/tests/Aql/NgramPosSimilarityFunctionTest.cpp
@@ -39,7 +39,6 @@
 #include <velocypack/Iterator.h>
 #include <velocypack/Parser.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 #include <set>
 
 using namespace arangodb;

--- a/tests/Aql/NgramSimilarityFunctionTest.cpp
+++ b/tests/Aql/NgramSimilarityFunctionTest.cpp
@@ -39,7 +39,6 @@
 #include <velocypack/Iterator.h>
 #include <velocypack/Parser.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 #include <set>
 
 using namespace arangodb;

--- a/tests/Aql/QueryCursorTest.cpp
+++ b/tests/Aql/QueryCursorTest.cpp
@@ -33,7 +33,6 @@
 #include <velocypack/Options.h>
 #include <velocypack/Parser.h>
 #include <velocypack/SharedSlice.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb::tests;
 

--- a/tests/Aql/QueryHelper.cpp
+++ b/tests/Aql/QueryHelper.cpp
@@ -30,7 +30,6 @@
 
 #include <velocypack/Iterator.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::aql;

--- a/tests/Aql/RemoveExecutorTest.cpp
+++ b/tests/Aql/RemoveExecutorTest.cpp
@@ -32,7 +32,6 @@
 #include <velocypack/Builder.h>
 #include <velocypack/Iterator.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include "../IResearch/IResearchQueryCommon.h"
 

--- a/tests/Aql/ReplaceExecutorTest.cpp
+++ b/tests/Aql/ReplaceExecutorTest.cpp
@@ -31,7 +31,6 @@
 
 #include <velocypack/Builder.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include "Logger/LogMacros.h"
 

--- a/tests/Aql/ReturnExecutorTest.cpp
+++ b/tests/Aql/ReturnExecutorTest.cpp
@@ -37,7 +37,6 @@
 #include "Basics/ResourceUsage.h"
 
 #include <velocypack/Builder.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::aql;

--- a/tests/Aql/RowFetcherHelper.cpp
+++ b/tests/Aql/RowFetcherHelper.cpp
@@ -40,7 +40,6 @@
 #include <velocypack/Buffer.h>
 #include <velocypack/Iterator.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::tests;

--- a/tests/Aql/ShortestPathExecutorTest.cpp
+++ b/tests/Aql/ShortestPathExecutorTest.cpp
@@ -25,7 +25,6 @@
 
 #include <velocypack/Builder.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include "Aql/RowFetcherHelper.h"
 #include "Mocks/LogLevels.h"

--- a/tests/Aql/SingleRowFetcherTest.cpp
+++ b/tests/Aql/SingleRowFetcherTest.cpp
@@ -43,7 +43,6 @@
 #include "FetcherTestHelper.h"
 
 #include <velocypack/Builder.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::aql;

--- a/tests/Aql/SkipResultTest.cpp
+++ b/tests/Aql/SkipResultTest.cpp
@@ -27,7 +27,6 @@
 #include "Basics/ResultT.h"
 
 #include <velocypack/Builder.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::aql;

--- a/tests/Aql/SortExecutorTest.cpp
+++ b/tests/Aql/SortExecutorTest.cpp
@@ -49,7 +49,6 @@
 #include "search/sort.hpp"
 
 #include <velocypack/Builder.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::aql;

--- a/tests/Aql/SortLimitTest.cpp
+++ b/tests/Aql/SortLimitTest.cpp
@@ -25,7 +25,6 @@
 
 #include <velocypack/Builder.h>
 #include <velocypack/Iterator.h>
-#include <velocypack/velocypack-aliases.h>
 
 // test setup
 #include "IResearch/common.h"

--- a/tests/Aql/SortedCollectExecutorTest.cpp
+++ b/tests/Aql/SortedCollectExecutorTest.cpp
@@ -45,7 +45,6 @@
 
 #include <velocypack/Builder.h>
 #include <velocypack/Options.h>
-#include <velocypack/velocypack-aliases.h>
 #include <functional>
 
 using namespace arangodb;

--- a/tests/Aql/SpliceSubqueryOptimizerRuleTest.cpp
+++ b/tests/Aql/SpliceSubqueryOptimizerRuleTest.cpp
@@ -44,7 +44,6 @@
 #include "velocypack/Builder.h"
 #include "velocypack/Collection.h"
 #include "velocypack/Slice.h"
-#include "velocypack/velocypack-aliases.h"
 
 #include "../IResearch/IResearchQueryCommon.h"
 #include "../Mocks/Servers.h"

--- a/tests/Aql/SubqueryStartExecutorTest.cpp
+++ b/tests/Aql/SubqueryStartExecutorTest.cpp
@@ -37,7 +37,6 @@
 
 #include <velocypack/Builder.h>
 #include <velocypack/Parser.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include "Logger/LogMacros.h"
 using namespace arangodb;

--- a/tests/Aql/TraversalExecutorTest.cpp
+++ b/tests/Aql/TraversalExecutorTest.cpp
@@ -45,7 +45,6 @@
 #include <velocypack/Buffer.h>
 #include <velocypack/Builder.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::aql;

--- a/tests/Aql/UpdateExecutorTest.cpp
+++ b/tests/Aql/UpdateExecutorTest.cpp
@@ -31,7 +31,6 @@
 
 #include <velocypack/Builder.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include "Logger/LogMacros.h"
 

--- a/tests/Aql/VelocyPackHelper.cpp
+++ b/tests/Aql/VelocyPackHelper.cpp
@@ -23,8 +23,6 @@
 
 #include "VelocyPackHelper.h"
 
-#include <velocypack/velocypack-aliases.h>
-
 using namespace arangodb;
 using namespace arangodb::aql;
 using namespace arangodb::tests;

--- a/tests/Aql/WaitingExecutionBlockMock.cpp
+++ b/tests/Aql/WaitingExecutionBlockMock.cpp
@@ -32,8 +32,6 @@
 
 #include "Logger/LogMacros.h"
 
-#include <velocypack/velocypack-aliases.h>
-
 using namespace arangodb;
 using namespace arangodb::aql;
 using namespace arangodb::tests;

--- a/tests/Aql/WindowExecutorTest.cpp
+++ b/tests/Aql/WindowExecutorTest.cpp
@@ -40,7 +40,6 @@
 #include "FixedOutputExecutionBlockMock.h"
 
 #include <velocypack/Builder.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include <chrono>
 #include <functional>

--- a/tests/AsyncAgencyComm/AsyncAgencyCommTest.cpp
+++ b/tests/AsyncAgencyComm/AsyncAgencyCommTest.cpp
@@ -31,7 +31,6 @@
 #include <velocypack/Iterator.h>
 #include <velocypack/Options.h>
 #include <velocypack/Parser.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include <utility>
 

--- a/tests/Basics/VelocyPackHelperTest.cpp
+++ b/tests/Basics/VelocyPackHelperTest.cpp
@@ -28,7 +28,6 @@
 
 #include <velocypack/Builder.h>
 #include <velocypack/Parser.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include "Basics/VelocyPackHelper.h"
 

--- a/tests/Cluster/ClusterHelpersTest.cpp
+++ b/tests/Cluster/ClusterHelpersTest.cpp
@@ -27,7 +27,6 @@
 #include "Cluster/ClusterHelpers.h"
 
 #include <velocypack/Builder.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 

--- a/tests/Cluster/QueryAnalyzerRevisionsTest.cpp
+++ b/tests/Cluster/QueryAnalyzerRevisionsTest.cpp
@@ -27,7 +27,6 @@
 #include "velocypack/Slice.h"
 #include "velocypack/Parser.h"
 #include <velocypack/Builder.h>
-#include <velocypack/velocypack-aliases.h>
 #include <ostream>
 
 TEST(QueryAnalyzerRevisionsTest, fullData) {

--- a/tests/Fuerte/10000WritesTest.cpp
+++ b/tests/Fuerte/10000WritesTest.cpp
@@ -27,7 +27,6 @@
 
 #include <velocypack/Parser.h>
 #include <velocypack/Iterator.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include <chrono>
 #include <iostream>

--- a/tests/Fuerte/ConnectionBasicTest.cpp
+++ b/tests/Fuerte/ConnectionBasicTest.cpp
@@ -25,7 +25,6 @@
 #include <fuerte/fuerte.h>
 #include <fuerte/helper.h>
 #include <velocypack/Builder.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include "ConnectionTest.h"
 

--- a/tests/Fuerte/ConnectionConcurrentTest.cpp
+++ b/tests/Fuerte/ConnectionConcurrentTest.cpp
@@ -24,7 +24,6 @@
 #include <fuerte/loop.h>
 #include <fuerte/helper.h>
 #include <thread>
-#include <velocypack/velocypack-aliases.h>
 
 #include "gtest/gtest.h"
 #include "ConnectionTest.h"

--- a/tests/Fuerte/ConnectionTimeoutsTest.cpp
+++ b/tests/Fuerte/ConnectionTimeoutsTest.cpp
@@ -22,7 +22,6 @@
 
 #include <fuerte/fuerte.h>
 #include <fuerte/requests.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include "gtest/gtest.h"
 #include "common.h"

--- a/tests/Fuerte/VstTest.cpp
+++ b/tests/Fuerte/VstTest.cpp
@@ -23,7 +23,6 @@
 
 #include "vst.h"
 #include "Basics/Format.h"
-#include <velocypack/velocypack-aliases.h>
 
 namespace fu = ::arangodb::fuerte;
 

--- a/tests/Geo/GeoConstructorTest.cpp
+++ b/tests/Geo/GeoConstructorTest.cpp
@@ -40,7 +40,6 @@
 #include <velocypack/Iterator.h>
 #include <velocypack/Parser.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::aql;

--- a/tests/Geo/GeoFunctionsTest.cpp
+++ b/tests/Geo/GeoFunctionsTest.cpp
@@ -40,7 +40,6 @@
 #include <velocypack/Iterator.h>
 #include <velocypack/Parser.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::aql;

--- a/tests/Geo/GeoJsonTest.cpp
+++ b/tests/Geo/GeoJsonTest.cpp
@@ -28,7 +28,6 @@
 #include <s2/s2point.h>
 #include <s2/s2polyline.h>
 #include <velocypack/Builder.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include "Aql/VelocyPackHelper.h"
 #include "Basics/Common.h"

--- a/tests/Geo/NearUtilsTest.cpp
+++ b/tests/Geo/NearUtilsTest.cpp
@@ -37,7 +37,6 @@
 #include <s2/s2metrics.h>
 #include <velocypack/Builder.h>
 #include <velocypack/Parser.h>
-#include <velocypack/velocypack-aliases.h>
 #include <cmath>
 
 #ifdef _WIN32

--- a/tests/Geo/ShapeContainerTest.cpp
+++ b/tests/Geo/ShapeContainerTest.cpp
@@ -27,7 +27,6 @@
 
 #include <velocypack/Builder.h>
 #include <velocypack/Parser.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include "Aql/VelocyPackHelper.h"
 

--- a/tests/Graph/ClusterTraverserCacheTest.cpp
+++ b/tests/Graph/ClusterTraverserCacheTest.cpp
@@ -38,7 +38,6 @@
 
 #include <velocypack/Builder.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::aql;

--- a/tests/Graph/ConstantWeightShortestPathFinder.cpp
+++ b/tests/Graph/ConstantWeightShortestPathFinder.cpp
@@ -48,7 +48,6 @@
 
 #include <velocypack/Builder.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 // test setup
 #include "../Mocks/Servers.h"

--- a/tests/Graph/DFSFinderTest.cpp
+++ b/tests/Graph/DFSFinderTest.cpp
@@ -46,7 +46,6 @@
 #include "Graph/algorithm-aliases.h"
 
 #include <velocypack/HashedStringRef.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::graph;

--- a/tests/Graph/GenericGraphProviderTest.cpp
+++ b/tests/Graph/GenericGraphProviderTest.cpp
@@ -35,7 +35,6 @@
 #include "Graph/Steps/SingleServerProviderStep.h"
 #include "Graph/TraverserOptions.h"
 
-#include <velocypack/velocypack-aliases.h>
 #include <unordered_set>
 
 using namespace arangodb;

--- a/tests/Graph/KPathFinderTest.cpp
+++ b/tests/Graph/KPathFinderTest.cpp
@@ -46,7 +46,6 @@
 #include "Graph/algorithm-aliases.h"
 
 #include <velocypack/HashedStringRef.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::graph;

--- a/tests/Graph/KShortestPathsFinder.cpp
+++ b/tests/Graph/KShortestPathsFinder.cpp
@@ -48,7 +48,6 @@
 
 #include <velocypack/Builder.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 // test setup
 #include "../Mocks/Servers.h"

--- a/tests/Graph/SingleServerProviderTest.cpp
+++ b/tests/Graph/SingleServerProviderTest.cpp
@@ -31,7 +31,6 @@
 #include "Graph/Providers/SingleServerProvider.h"
 #include "Graph/Steps/SingleServerProviderStep.h"
 
-#include <velocypack/velocypack-aliases.h>
 #include <unordered_set>
 
 using namespace arangodb;

--- a/tests/Graph/TraverserCacheTest.cpp
+++ b/tests/Graph/TraverserCacheTest.cpp
@@ -34,7 +34,6 @@
 
 #include <Aql/TraversalStats.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::aql;

--- a/tests/Greenspun/PrimitivesTest.cpp
+++ b/tests/Greenspun/PrimitivesTest.cpp
@@ -4,7 +4,6 @@
 #include "Greenspun/Primitives.h"
 #include "velocypack/Builder.h"
 #include "velocypack/Parser.h"
-#include "velocypack/velocypack-aliases.h"
 
 #include "gtest/gtest.h"
 

--- a/tests/Greenspun/REPL.cpp
+++ b/tests/Greenspun/REPL.cpp
@@ -6,7 +6,6 @@
 #include "Greenspun/Primitives.h"
 #include "velocypack/Builder.h"
 #include "velocypack/Parser.h"
-#include "velocypack/velocypack-aliases.h"
 
 #include "Utilities/Completer.h"
 #include "Utilities/LineEditor.h"

--- a/tests/HotBackup/HotBackupCoordinatorTest.cpp
+++ b/tests/HotBackup/HotBackupCoordinatorTest.cpp
@@ -30,7 +30,6 @@
 #include <velocypack/Iterator.h>
 #include <velocypack/Options.h>
 #include <velocypack/Parser.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include <boost/uuid/uuid.hpp>
 #include <boost/uuid/uuid_generators.hpp>

--- a/tests/IResearch/AgencyMock.cpp
+++ b/tests/IResearch/AgencyMock.cpp
@@ -35,8 +35,6 @@
 #include "Cluster/ClusterFeature.h"
 #include "Cluster/ClusterInfo.h"
 
-#include <velocypack/velocypack-aliases.h>
-
 #include <utility>
 
 namespace arangodb::consensus {

--- a/tests/IResearch/GeoAnalyzerTest.cpp
+++ b/tests/IResearch/GeoAnalyzerTest.cpp
@@ -29,7 +29,6 @@
 #include "IResearch/VelocyPackHelper.h"
 #include "Geo/GeoJson.h"
 #include "velocypack/Parser.h"
-#include "velocypack/velocypack-aliases.h"
 
 using namespace arangodb;
 using namespace arangodb::iresearch;

--- a/tests/IResearch/GeoDistanceFilterTest.cpp
+++ b/tests/IResearch/GeoDistanceFilterTest.cpp
@@ -39,7 +39,6 @@
 
 #include <velocypack/Iterator.h>
 #include <velocypack/Parser.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::iresearch;

--- a/tests/IResearch/GeoFilterTest.cpp
+++ b/tests/IResearch/GeoFilterTest.cpp
@@ -39,7 +39,6 @@
 
 #include <velocypack/Iterator.h>
 #include <velocypack/Parser.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::iresearch;

--- a/tests/IResearch/IResearchDocumentTest.cpp
+++ b/tests/IResearch/IResearchDocumentTest.cpp
@@ -29,7 +29,6 @@
 #include "velocypack/Builder.h"
 #include "velocypack/Iterator.h"
 #include "velocypack/Parser.h"
-#include "velocypack/velocypack-aliases.h"
 
 #include "analysis/analyzers.hpp"
 #include "analysis/token_streams.hpp"

--- a/tests/IResearch/IResearchFields.h
+++ b/tests/IResearch/IResearchFields.h
@@ -30,7 +30,6 @@
 #include "IResearch/VelocyPackHelper.h"
 
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 namespace arangodb {
 namespace tests {

--- a/tests/IResearch/IResearchQueryScorerTest.cpp
+++ b/tests/IResearch/IResearchQueryScorerTest.cpp
@@ -40,7 +40,6 @@
 
 #include <regex>
 #include <velocypack/Iterator.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include "utils/string_utils.hpp"
 

--- a/tests/IResearch/IResearchTestCommon.cpp
+++ b/tests/IResearch/IResearchTestCommon.cpp
@@ -26,7 +26,6 @@
 
 #include <analysis/analyzers.hpp>
 #include <velocypack/Builder.h>
-#include <velocypack/velocypack-aliases.h>
 
 TestAnalyzer::TestAnalyzer()
     : irs::analysis::analyzer(irs::type<TestAnalyzer>::get()) {}

--- a/tests/IResearch/VelocyPackHelperTest.cpp
+++ b/tests/IResearch/VelocyPackHelperTest.cpp
@@ -30,7 +30,6 @@
 #include "velocypack/Builder.h"
 #include "velocypack/Iterator.h"
 #include "velocypack/Parser.h"
-#include "velocypack/velocypack-aliases.h"
 
 TEST(IResearchVelocyPackHelperTest, test_getstring) {
   // string value

--- a/tests/IResearch/common.h
+++ b/tests/IResearch/common.h
@@ -39,7 +39,6 @@
 
 #include <velocypack/Builder.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief a TRI_vocbase_t that will call shutdown() on deallocation

--- a/tests/Maintenance/MaintenanceFeatureMock.h
+++ b/tests/Maintenance/MaintenanceFeatureMock.h
@@ -34,7 +34,6 @@
 
 #include <velocypack/Builder.h>
 #include <velocypack/Iterator.h>
-#include <velocypack/velocypack-aliases.h>
 
 // structure used to store expected states of action properties
 struct Expected {

--- a/tests/Maintenance/MaintenanceRestHandlerTest.cpp
+++ b/tests/Maintenance/MaintenanceRestHandlerTest.cpp
@@ -34,7 +34,6 @@
 #include <velocypack/Buffer.h>
 #include <velocypack/Builder.h>
 #include <velocypack/Iterator.h>
-#include <velocypack/velocypack-aliases.h>
 
 // give access to some protected routines for more thorough unit tests
 class TestHandler : public arangodb::MaintenanceRestHandler {

--- a/tests/Maintenance/MaintenanceTest.cpp
+++ b/tests/Maintenance/MaintenanceTest.cpp
@@ -39,7 +39,6 @@
 #include "StorageEngine/EngineSelectorFeature.h"
 
 #include <velocypack/Iterator.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include <fstream>
 #include <iostream>

--- a/tests/Mocks/MockGraph.h
+++ b/tests/Mocks/MockGraph.h
@@ -31,7 +31,6 @@
 
 #include <velocypack/Builder.h>
 #include <velocypack/Value.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include <numeric>
 #include <unordered_set>

--- a/tests/Mocks/MockGraphProvider.cpp
+++ b/tests/Mocks/MockGraphProvider.cpp
@@ -34,7 +34,6 @@
 #include <velocypack/Builder.h>
 #include <velocypack/HashedStringRef.h>
 #include <velocypack/Value.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::tests;

--- a/tests/Mocks/PreparedResponseConnectionPool.h
+++ b/tests/Mocks/PreparedResponseConnectionPool.h
@@ -26,8 +26,6 @@
 #include "Rest/CommonDefines.h"
 #include "Rest/GeneralResponse.h"
 
-#include <velocypack/velocypack-aliases.h>
-
 #include <vector>
 
 struct GeneralRequestMock;

--- a/tests/Mocks/Servers.cpp
+++ b/tests/Mocks/Servers.cpp
@@ -105,7 +105,6 @@
 #include <velocypack/Builder.h>
 #include <velocypack/Parser.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include <boost/core/demangle.hpp>
 

--- a/tests/Mocks/StorageEngineMock.cpp
+++ b/tests/Mocks/StorageEngineMock.cpp
@@ -61,7 +61,6 @@
 
 #include <velocypack/Collection.h>
 #include <velocypack/Iterator.h>
-#include <velocypack/velocypack-aliases.h>
 
 namespace {
 

--- a/tests/Network/MethodsTest.cpp
+++ b/tests/Network/MethodsTest.cpp
@@ -26,7 +26,6 @@
 #include <fuerte/connection.h>
 #include <fuerte/requests.h>
 #include <velocypack/Parser.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include "Mocks/LogLevels.h"
 #include "Mocks/Servers.h"

--- a/tests/Network/UtilsTest.cpp
+++ b/tests/Network/UtilsTest.cpp
@@ -30,7 +30,6 @@
 #include <fuerte/requests.h>
 
 #include <velocypack/Parser.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 using namespace arangodb::network;

--- a/tests/Replication/ReplicationClientsProgressTrackerTest.cpp
+++ b/tests/Replication/ReplicationClientsProgressTrackerTest.cpp
@@ -32,7 +32,6 @@
 #include "VocBase/Identifiers/ServerId.h"
 
 #include <velocypack/Builder.h>
-#include <velocypack/velocypack-aliases.h>
 
 using namespace arangodb;
 

--- a/tests/Replication2/ReplicatedLog/ConcurrencyTests.cpp
+++ b/tests/Replication2/ReplicatedLog/ConcurrencyTests.cpp
@@ -21,7 +21,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include "Replication2/ReplicatedLog/ILogInterfaces.h"
 #include "Replication2/ReplicatedLog/types.h"

--- a/tests/RocksDBEngine/EncryptionProviderTest.cpp
+++ b/tests/RocksDBEngine/EncryptionProviderTest.cpp
@@ -33,8 +33,6 @@
 #include <memory>
 #include <string>
 
-#include <velocypack/velocypack-aliases.h>
-
 #ifdef USE_ENTERPRISE
 #include "Enterprise/RocksDBEngine/EncryptionProvider.h"
 #endif

--- a/tests/RocksDBEngine/HotBackupTest.cpp
+++ b/tests/RocksDBEngine/HotBackupTest.cpp
@@ -33,10 +33,6 @@
 
 #include "Mocks/Servers.h"
 
-//#include "Basics/Exceptions.h"
-//#include "Basics/VelocyPackHelper.h"
-#include <velocypack/velocypack-aliases.h>
-
 #ifdef USE_ENTERPRISE
 #include "Enterprise/RocksDBEngine/RocksDBHotBackup.h"
 #include "Enterprise/StorageEngine/HotBackupFeature.h"

--- a/tests/Sharding/ShardDistributionReporterTest.cpp
+++ b/tests/Sharding/ShardDistributionReporterTest.cpp
@@ -31,7 +31,6 @@
 
 #include <velocypack/Builder.h>
 #include <velocypack/Slice.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include "IResearch/common.h"
 #include "Mocks/LogLevels.h"

--- a/tests/Transaction/ContextTest.cpp
+++ b/tests/Transaction/ContextTest.cpp
@@ -35,7 +35,6 @@
 
 #include <velocypack/Builder.h>
 #include <velocypack/Parser.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include "../IResearch/common.h"
 #include "gtest/gtest.h"

--- a/tests/Transaction/ManagerTest.cpp
+++ b/tests/Transaction/ManagerTest.cpp
@@ -35,7 +35,6 @@
 #include "VocBase/LogicalCollection.h"
 
 #include <velocypack/Parser.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include "gtest/gtest.h"
 

--- a/tests/Transaction/RestTransactionHandlerTest.cpp
+++ b/tests/Transaction/RestTransactionHandlerTest.cpp
@@ -36,7 +36,6 @@
 #include "VocBase/LogicalCollection.h"
 
 #include <velocypack/Parser.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include "gtest/gtest.h"
 

--- a/tests/V8Server/V8AnalyzersTest.cpp
+++ b/tests/V8Server/V8AnalyzersTest.cpp
@@ -39,7 +39,6 @@
 
 #include <velocypack/Iterator.h>
 #include <velocypack/Parser.h>
-#include <velocypack/velocypack-aliases.h>
 
 #include "IResearch/common.h"
 #include "Mocks/LogLevels.h"


### PR DESCRIPTION
### Scope & Purpose

Enterprise companion PR: https://github.com/arangodb/enterprise/pull/891

Do not include empty `velocypack/velocypack-aliases.h` header anymore. This header became useless after some velocypack refactorings.
This PR does not change any behavior, and thus does not need documentation or a changelog entry.
No backports are planned.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -
  - [ ] Backport for 3.7: -

#### Related Information

- [ ] Docs PR: 
- [x] Enterprise PR: https://github.com/arangodb/enterprise/pull/891
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
