### PR TITLE
[BTS-800] Cluster not enabled exception

### DIFF
--- a/arangod/Cluster/FailureOracleFeature.cpp
+++ b/arangod/Cluster/FailureOracleFeature.cpp
@@ -215,7 +215,7 @@ void FailureOracleFeature::prepare() {
 void FailureOracleFeature::start() {
   TRI_ASSERT(_cache == nullptr);
   _cache = std::make_shared<FailureOracleImpl>(
-      server().getFeature<ClusterFeature>());
+      server().getEnabledFeature<ClusterFeature>());
   _cache->createAgencyCallback(server());
   _cache->start();
 

--- a/arangod/Cluster/FailureOracleFeature.cpp
+++ b/arangod/Cluster/FailureOracleFeature.cpp
@@ -202,6 +202,8 @@ FailureOracleFeature::FailureOracleFeature(Server& server)
   setOptional(true);
   startsAfter<SchedulerFeature>();
   startsAfter<ClusterFeature>();
+  onlyEnabledWith<SchedulerFeature>();
+  onlyEnabledWith<ClusterFeature>();
 }
 
 void FailureOracleFeature::prepare() {
@@ -213,7 +215,7 @@ void FailureOracleFeature::prepare() {
 void FailureOracleFeature::start() {
   TRI_ASSERT(_cache == nullptr);
   _cache = std::make_shared<FailureOracleImpl>(
-      server().getEnabledFeature<ClusterFeature>());
+      server().getFeature<ClusterFeature>());
   _cache->createAgencyCallback(server());
   _cache->start();
 

--- a/arangod/RestServer/UpgradeFeature.cpp
+++ b/arangod/RestServer/UpgradeFeature.cpp
@@ -27,7 +27,6 @@
 #include "Basics/ScopeGuard.h"
 #include "Basics/StaticStrings.h"
 #include "Basics/application-exit.h"
-#include "Cluster/FailureOracleFeature.h"
 #include "Cluster/ServerState.h"
 #ifdef USE_ENTERPRISE
 #include "Enterprise/StorageEngine/HotBackupFeature.h"
@@ -148,10 +147,6 @@ void UpgradeFeature::validateOptions(std::shared_ptr<ProgramOptions> options) {
   ReplicationFeature& replicationFeature =
       server().getFeature<ReplicationFeature>();
   replicationFeature.disableReplicationApplier();
-
-  cluster::FailureOracleFeature& failureOracleFeature =
-      server().getFeature<cluster::FailureOracleFeature>();
-  failureOracleFeature.forceDisable();
 
   DatabaseFeature& database = server().getFeature<DatabaseFeature>();
   database.enableUpgrade();

--- a/arangod/RestServer/UpgradeFeature.cpp
+++ b/arangod/RestServer/UpgradeFeature.cpp
@@ -27,6 +27,7 @@
 #include "Basics/ScopeGuard.h"
 #include "Basics/StaticStrings.h"
 #include "Basics/application-exit.h"
+#include "Cluster/FailureOracleFeature.h"
 #include "Cluster/ServerState.h"
 #ifdef USE_ENTERPRISE
 #include "Enterprise/StorageEngine/HotBackupFeature.h"
@@ -147,6 +148,10 @@ void UpgradeFeature::validateOptions(std::shared_ptr<ProgramOptions> options) {
   ReplicationFeature& replicationFeature =
       server().getFeature<ReplicationFeature>();
   replicationFeature.disableReplicationApplier();
+
+  cluster::FailureOracleFeature& failureOracleFeature =
+      server().getFeature<cluster::FailureOracleFeature>();
+  failureOracleFeature.forceDisable();
 
   DatabaseFeature& database = server().getFeature<DatabaseFeature>();
   database.enableUpgrade();


### PR DESCRIPTION
### Scope & Purpose

This aims to fix the following error: `caught exception during start of feature 'FailureOracle': feature 'Cluster' is not enabled (exception location: /work/ArangoDB/lib/ApplicationFeatures/ApplicationServer.h:466)`.

It is suspected that during `UpgradeFeature` the `ClusterFeature` gets disabled, and thus other features which depend on it should too.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*
  - [ ] Backport for 3.7: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

