### PR TITLE
improve clang-format script

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -51,7 +51,7 @@ ConstructorInitializerAllOnOneLineOrOnePerLine: true
 ConstructorInitializerIndentWidth: 4
 ContinuationIndentWidth: 4
 Cpp11BracedListStyle: true
-DerivePointerAlignment: true
+DerivePointerAlignment: false
 DisableFormat:   false
 ExperimentalAutoDetectBinPacking: false
 FixNamespaceComments: true

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -15,7 +15,8 @@ pushd "$adb_path" > /dev/null
 
 changed_files_filename=".clang-format-$$.changed.tmp"
 # clean up after ourselves
-trap "rm -f $changed_files_filename" EXIT SIGINT SIGTERM SIGHUP
+trap "rm -f $changed_files_filename" EXIT
+trap "rm -f $changed_files_filename; exit" SIGINT SIGTERM SIGHUP
 
 # collect a list of file names of all modified files in $changed_files_filename
 git diff --cached --diff-filter=ACMRT --name-only -- arangod/ lib/ arangosh/ tests/ | grep -e '\.ipp$' -e '\.tpp$' -e '\.cpp$' -e '\.hpp$' -e '\.cc$' -e '\.c$' -e '\.h$' > "$changed_files_filename"
@@ -23,7 +24,7 @@ git diff --cached --diff-filter=ACMRT --name-only -- arangod/ lib/ arangosh/ tes
 if [ -s "$changed_files_filename" ]; then
   # hand over a list of changed files from the local filesystem into a Docker container that contains a fixed
   # version of clang-format and some small shell wrapper to iterate over the list of files
-  docker run --rm -u "$(id -u):$(id -g)" --mount type=bind,source="$adb_path",target=/usr/src/arangodb arangodb/clang-format:1.1 "validate" "$changed_files_filename"
+  docker run --rm -u "$(id -u):$(id -g)" --mount type=bind,source="$adb_path",target=/usr/src/arangodb arangodb/clang-format:1.2 "validate" "$changed_files_filename"
 fi
 status=$?
 

--- a/scripts/clang-format.sh
+++ b/scripts/clang-format.sh
@@ -18,7 +18,8 @@ pushd "$adb_path" > /dev/null
 
 changed_files_filename=".clang-format-$$.changed.tmp"
 # clean up after ourselves
-trap "rm -f $changed_files_filename $changed_files_filename.sorted" EXIT SIGINT SIGTERM SIGHUP
+trap "rm -f $changed_files_filename $changed_files_filename.sorted" EXIT 
+trap "rm -f $changed_files_filename $changed_files_filename.sorted; exit" SIGINT SIGTERM SIGHUP
 
 if [[ "$#" -gt 0 ]]
 then
@@ -55,14 +56,14 @@ else
 fi
 
 if [ -s "$changed_files_filename" ]; then
-  sort "$changed_files_filename" | grep -E "\.\(ipp|tpp|cpp|hpp|cc|c|h\)$" | uniq > "$changed_files_filename.sorted"
+  sort "$changed_files_filename" | grep -e '\.ipp$' -e '\.tpp$' -e '\.cpp$' -e '\.hpp$' -e '\.cc$' -e '\.c$' -e '\.h$' | uniq > "$changed_files_filename.sorted"
 
   echo 
   echo "About to run formatting on the following files:"
   cat -n "$changed_files_filename.sorted"
   echo
 
-  docker run --rm -u "$(id -u):$(id -g)" --mount type=bind,source="$adb_path",target=/usr/src/arangodb arangodb/clang-format:1.1 "format" "$changed_files_filename.sorted" 
+  docker run --rm -u "$(id -u):$(id -g)" --mount type=bind,source="$adb_path",target=/usr/src/arangodb arangodb/clang-format:1.2 "format" "$changed_files_filename.sorted" 
 fi
 status=$?
 


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/15800
Enterprise companion PR: https://github.com/arangodb/enterprise/pull/898

Small improvement for clang-formatting script: make script and docker container react on CTRL-C, and don't block the signal.
Also backport changes that others made to `.clang-format` in devel.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [x] Backports
  - [x] Backport for 3.9: this PR

#### Related Information

- [ ] Docs PR: 
- [x] Enterprise PR: https://github.com/arangodb/enterprise/pull/898
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 