### PR TITLE
[3.9] Give superpowers to arangsync for SmartGraphs

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 v3.9.1 (XXXX-XX-XX)
 -------------------
 
+* Bugfix: DC-2-DC Disjoint-SmartGraphs and Hybrid-SmartGraphs are now
+  replicated to the follower data-center keeping their sharding intact.
+
 * As we are now in constant stall regime, stall onset and warnings are demoted
   to DEBUG.
 

--- a/arangod/RestHandler/RestCollectionHandler.cpp
+++ b/arangod/RestHandler/RestCollectionHandler.cpp
@@ -372,9 +372,12 @@ void RestCollectionHandler::handleCommandPost() {
     }
   }
 
+  bool isDC2DCContext = ExecContext::current().isSuperuser();
+
   // for some "security" a list of allowed parameters (i.e. all
   // others are disallowed!)
-  VPackBuilder filtered = methods::Collections::filterInput(body);
+  VPackBuilder filtered =
+      methods::Collections::filterInput(body, isDC2DCContext);
   VPackSlice const parameters = filtered.slice();
 
   // now we can create the collection

--- a/arangod/V8Server/v8-vocindex.cpp
+++ b/arangod/V8Server/v8-vocindex.cpp
@@ -269,7 +269,7 @@ static void CreateVocBase(v8::FunctionCallbackInfo<v8::Value> const& args,
         isolate, obj, "enforceReplicationFactor", enforceReplicationFactor);
   }
 
-  VPackBuilder filtered = methods::Collections::filterInput(propSlice);
+  VPackBuilder filtered = methods::Collections::filterInput(propSlice, false);
   propSlice = filtered.slice();
 
   v8::Handle<v8::Value> result;

--- a/arangod/VocBase/Methods/Collections.h
+++ b/arangod/VocBase/Methods/Collections.h
@@ -145,7 +145,7 @@ struct Collections {
 
   /// @brief filters properties for collection creation
   static arangodb::velocypack::Builder filterInput(
-      arangodb::velocypack::Slice slice);
+      arangodb::velocypack::Slice slice, bool allowDC2DCAttributes);
 };
 
 #ifdef USE_ENTERPRISE


### PR DESCRIPTION
Backport of (https://github.com/arangodb/arangodb/pull/15795)
No Conflicts.

### Scope & Purpose

In order to get DC-2-DC to work, we need to allow the ArangoSync process to set more (and dangerous) options when creating the Collections, it cannot use the GraphsAPI (like the user can), as it needs a bit more fine-grained control about the sharing being identical on source and target datacenter.

Tests for this are in ArangoSync repository.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [x] Backports
  - [x] Backport for 3.9: *TO BE DONE*
  - [x] Backport for 3.8: *For disjoint smart graphs*
  - [ ] Backport for 3.7: *save, no back port required.*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
