### PR TITLE
catch probable test exception so we have good results

### DIFF
--- a/js/client/modules/@arangodb/testsuites/recovery_cluster.js
+++ b/js/client/modules/@arangodb/testsuites/recovery_cluster.js
@@ -293,7 +293,20 @@ function recovery (options) {
           duration: -1
         });
       } catch (er) {}
-      runArangodRecovery(params);
+      try {
+        runArangodRecovery(params);
+      } catch (err) {
+        results[test] = {
+          failed: 1,
+          status: false,
+          message: "Crashed! \n" + err + "\nAborting execution of more tests",
+          duration: -1
+        };
+        results.status = false;
+        results.crashed = true;
+        print("skipping more tests!");
+        return results;
+      }
 
       results[test] = tu.readTestResult(
         params.args['temp.path'],


### PR DESCRIPTION
### Scope & Purpose
This improves test result handling, so the test flow will not be abortet by exceptions in mid air, and fail to deliver results as seen here: 

```
caught exception during test execution!
cluster startup: pid 18275 no longer alive! bailing out!
Error: cluster startup: pid 18275 no longer alive! bailing out!
    at /work/ArangoDB/js/client/modules/@arangodb/testutils/process-utils.js:1924:15
    at Array.forEach (<anonymous>)
    at checkClusterAlive (/work/ArangoDB/js/client/modules/@arangodb/testutils/process-utils.js:1895:27)
    at Object.reStartInstance (/work/ArangoDB/js/client/modules/@arangodb/testutils/process-utils.js:2566:5)
    at runArangodRecovery (/work/ArangoDB/js/client/modules/@arangodb/testsuites/recovery_cluster.js:187:8)
    at Object.recovery [as recovery_cluster] (/work/ArangoDB/js/client/modules/@arangodb/testsuites/recovery_cluster.js:296:7)
    at iterateTests (/work/ArangoDB/js/client/modules/@arangodb/testutils/testing.js:525:36)
    at unitTest (/work/ArangoDB/js/client/modules/@arangodb/testutils/testing.js:615:12)
    at main (UnitTests/unittest.js:67:14)
    at UnitTests/unittest.js:118:14
{}
2022-02-24T12:39:51Z [5653] ERROR [8a210] {general} JavaScript exception in file 'UnitTests/unittest.js' at 85,5: Error: cluster startup: pid 18275 no longer alive! bailing out!
2022-02-24T12:39:51Z [5653] ERROR [409ee] {general} !    throw x;
2022-02-24T12:39:51Z [5653] ERROR [cb0bd] {general} !    ^
```