### PR TITLE
[CINFRA-260] waitForApplied for FollowerStateManager

### DIFF
--- a/arangod/Replication2/ReplicatedState/FollowerStateManager.h
+++ b/arangod/Replication2/ReplicatedState/FollowerStateManager.h
@@ -62,7 +62,7 @@ struct FollowerStateManager
   [[nodiscard]] auto resign() && noexcept
       -> std::tuple<std::unique_ptr<CoreType>,
                     std::unique_ptr<ReplicatedStateToken>,
-                    std::unique_ptr<WaitForAppliedQueue>> override;
+                    DeferredAction> override;
 
   [[nodiscard]] auto getStream() const noexcept -> std::shared_ptr<Stream>;
 

--- a/arangod/Replication2/ReplicatedState/FollowerStateManager.h
+++ b/arangod/Replication2/ReplicatedState/FollowerStateManager.h
@@ -37,6 +37,10 @@ struct FollowerStateManager
   using FollowerType = typename ReplicatedStateTraits<S>::FollowerType;
   using LeaderType = typename ReplicatedStateTraits<S>::LeaderType;
   using CoreType = typename ReplicatedStateTraits<S>::CoreType;
+  using WaitForAppliedQueue =
+      typename ReplicatedState<S>::StateManagerBase::WaitForAppliedQueue;
+  using WaitForAppliedPromise =
+      typename ReplicatedState<S>::StateManagerBase::WaitForAppliedPromise;
 
   using Stream = streams::Stream<EntryType>;
   using Iterator = typename Stream::Iterator;
@@ -48,7 +52,7 @@ struct FollowerStateManager
       std::unique_ptr<ReplicatedStateToken> token,
       std::shared_ptr<Factory> factory) noexcept;
 
-  void run();
+  void run() override;
 
   [[nodiscard]] auto getStatus() const -> StateStatus final;
 
@@ -56,15 +60,13 @@ struct FollowerStateManager
       -> std::shared_ptr<IReplicatedFollowerState<S>>;
 
   [[nodiscard]] auto resign() && noexcept
-      -> std::pair<std::unique_ptr<CoreType>,
-                   std::unique_ptr<ReplicatedStateToken>> override;
+      -> std::tuple<std::unique_ptr<CoreType>,
+                    std::unique_ptr<ReplicatedStateToken>,
+                    std::unique_ptr<WaitForAppliedQueue>> override;
 
   [[nodiscard]] auto getStream() const noexcept -> std::shared_ptr<Stream>;
 
   auto waitForApplied(LogIndex) -> futures::Future<futures::Unit>;
-
-  using WaitForAppliedPromise = futures::Promise<futures::Unit>;
-  using WaitForAppliedQueue = std::multimap<LogIndex, WaitForAppliedPromise>;
 
  private:
   void awaitLeaderShip();

--- a/arangod/Replication2/ReplicatedState/FollowerStateManager.tpp
+++ b/arangod/Replication2/ReplicatedState/FollowerStateManager.tpp
@@ -198,7 +198,7 @@ void FollowerStateManager<S>::checkSnapshot(
 template<typename S>
 void FollowerStateManager<S>::startService(
     std::shared_ptr<IReplicatedFollowerState<S>> hiddenState) {
-  _guardedData.template doUnderLock([&](GuardedData& data) {
+  _guardedData.doUnderLock([&](GuardedData& data) {
     LOG_TOPIC("26c55", TRACE, Logger::REPLICATED_STATE)
         << "starting service as follower";
     data.state = hiddenState;
@@ -209,7 +209,7 @@ void FollowerStateManager<S>::startService(
 
 template<typename S>
 void FollowerStateManager<S>::ingestLogData() {
-  auto core = _guardedData.template doUnderLock([&](GuardedData& data) {
+  auto core = _guardedData.doUnderLock([&](GuardedData& data) {
     data.updateInternalState(FollowerInternalState::kTransferSnapshot);
     auto demux = Demultiplexer::construct(logFollower);
     demux->listen();
@@ -359,7 +359,8 @@ auto FollowerStateManager<S>::resign() && noexcept
       DeferredAction([resolveQueue = std::move(resolveQueue)]() noexcept {
         for (auto& p : *resolveQueue) {
           p.second.setException(replicated_log::ParticipantResignedException(
-              TRI_ERROR_REPLICATION_REPLICATED_LOG_LEADER_RESIGNED, ADB_HERE));
+              TRI_ERROR_REPLICATION_REPLICATED_LOG_FOLLOWER_RESIGNED,
+              ADB_HERE));
         }
       })};
 }

--- a/arangod/Replication2/ReplicatedState/LeaderStateManager.h
+++ b/arangod/Replication2/ReplicatedState/LeaderStateManager.h
@@ -40,6 +40,11 @@ struct LeaderStateManager
   using LeaderType = typename ReplicatedStateTraits<S>::LeaderType;
   using CoreType = typename ReplicatedStateTraits<S>::CoreType;
 
+  using WaitForAppliedQueue =
+      typename ReplicatedState<S>::StateManagerBase::WaitForAppliedQueue;
+  using WaitForAppliedPromise =
+      typename ReplicatedState<S>::StateManagerBase::WaitForAppliedQueue;
+
   explicit LeaderStateManager(
       std::shared_ptr<ReplicatedState<S>> const& parent,
       std::shared_ptr<replicated_log::ILogLeader> leader,
@@ -52,11 +57,12 @@ struct LeaderStateManager
 
   [[nodiscard]] auto getStatus() const -> StateStatus final;
 
-  void run();
+  void run() override;
 
   [[nodiscard]] auto resign() && noexcept
-      -> std::pair<std::unique_ptr<CoreType>,
-                   std::unique_ptr<ReplicatedStateToken>> override;
+      -> std::tuple<std::unique_ptr<CoreType>,
+                    std::unique_ptr<ReplicatedStateToken>,
+                    std::unique_ptr<WaitForAppliedQueue>> override;
 
   using Multiplexer = streams::LogMultiplexer<ReplicatedStateStreamSpec<S>>;
   std::shared_ptr<IReplicatedLeaderState<S>> state;

--- a/arangod/Replication2/ReplicatedState/LeaderStateManager.h
+++ b/arangod/Replication2/ReplicatedState/LeaderStateManager.h
@@ -62,7 +62,7 @@ struct LeaderStateManager
   [[nodiscard]] auto resign() && noexcept
       -> std::tuple<std::unique_ptr<CoreType>,
                     std::unique_ptr<ReplicatedStateToken>,
-                    std::unique_ptr<WaitForAppliedQueue>> override;
+                    DeferredAction> override;
 
   using Multiplexer = streams::LogMultiplexer<ReplicatedStateStreamSpec<S>>;
   std::shared_ptr<IReplicatedLeaderState<S>> state;

--- a/arangod/Replication2/ReplicatedState/LeaderStateManager.tpp
+++ b/arangod/Replication2/ReplicatedState/LeaderStateManager.tpp
@@ -177,8 +177,7 @@ auto LeaderStateManager<S>::getStatus() const -> StateStatus {
 template<typename S>
 auto LeaderStateManager<S>::resign() && noexcept
     -> std::tuple<std::unique_ptr<CoreType>,
-                  std::unique_ptr<ReplicatedStateToken>,
-                  std::unique_ptr<WaitForAppliedQueue>> {
+                  std::unique_ptr<ReplicatedStateToken>, DeferredAction> {
   LOG_TOPIC("edcf3", TRACE, Logger::REPLICATED_STATE)
       << "Leader manager resign";
   auto core = std::invoke([&] {
@@ -193,7 +192,7 @@ auto LeaderStateManager<S>::resign() && noexcept
   TRI_ASSERT(token != nullptr);
   TRI_ASSERT(!_didResign);
   _didResign = true;
-  return {std::move(core), std::move(token), nullptr};
+  return std::make_tuple(std::move(core), std::move(token), DeferredAction{});
 }
 
 template<typename S>

--- a/arangod/Replication2/ReplicatedState/LeaderStateManager.tpp
+++ b/arangod/Replication2/ReplicatedState/LeaderStateManager.tpp
@@ -176,8 +176,9 @@ auto LeaderStateManager<S>::getStatus() const -> StateStatus {
 
 template<typename S>
 auto LeaderStateManager<S>::resign() && noexcept
-    -> std::pair<std::unique_ptr<CoreType>,
-                 std::unique_ptr<ReplicatedStateToken>> {
+    -> std::tuple<std::unique_ptr<CoreType>,
+                  std::unique_ptr<ReplicatedStateToken>,
+                  std::unique_ptr<WaitForAppliedQueue>> {
   LOG_TOPIC("edcf3", TRACE, Logger::REPLICATED_STATE)
       << "Leader manager resign";
   auto core = std::invoke([&] {
@@ -192,7 +193,7 @@ auto LeaderStateManager<S>::resign() && noexcept
   TRI_ASSERT(token != nullptr);
   TRI_ASSERT(!_didResign);
   _didResign = true;
-  return {std::move(core), std::move(token)};
+  return {std::move(core), std::move(token), nullptr};
 }
 
 template<typename S>

--- a/arangod/Replication2/ReplicatedState/ReplicatedState.h
+++ b/arangod/Replication2/ReplicatedState/ReplicatedState.h
@@ -131,7 +131,7 @@ struct ReplicatedState final
     [[nodiscard]] virtual auto resign() && noexcept
         -> std::tuple<std::unique_ptr<CoreType>,
                       std::unique_ptr<ReplicatedStateToken>,
-                      std::unique_ptr<WaitForAppliedQueue>> = 0;
+                      DeferredAction> = 0;
   };
 
  private:
@@ -152,21 +152,19 @@ struct ReplicatedState final
     auto runLeader(std::shared_ptr<replicated_log::ILogLeader> logLeader,
                    std::unique_ptr<CoreType>,
                    std::unique_ptr<ReplicatedStateToken> token)
-        -> std::shared_ptr<StateManagerBase>;
+        -> DeferredAction;
     auto runFollower(std::shared_ptr<replicated_log::ILogFollower> logFollower,
                      std::unique_ptr<CoreType>,
                      std::unique_ptr<ReplicatedStateToken> token)
-        -> std::shared_ptr<StateManagerBase>;
+        -> DeferredAction;
     auto runUnconfigured(
         std::shared_ptr<replicated_log::LogUnconfiguredParticipant>
             unconfiguredParticipant,
         std::unique_ptr<CoreType> core,
-        std::unique_ptr<ReplicatedStateToken> token)
-        -> std::shared_ptr<StateManagerBase>;
+        std::unique_ptr<ReplicatedStateToken> token) -> DeferredAction;
 
     auto rebuild(std::unique_ptr<CoreType> core,
-                 std::unique_ptr<ReplicatedStateToken> token)
-        -> std::shared_ptr<StateManagerBase>;
+                 std::unique_ptr<ReplicatedStateToken> token) -> DeferredAction;
 
     auto flush(StateGeneration planGeneration) -> DeferredAction;
 

--- a/arangod/Replication2/ReplicatedState/ReplicatedState.h
+++ b/arangod/Replication2/ReplicatedState/ReplicatedState.h
@@ -23,6 +23,8 @@
 
 #pragma once
 
+#include <map>
+
 #include "Replication2/ReplicatedState/ReplicatedStateToken.h"
 #include "Replication2/ReplicatedState/ReplicatedStateTraits.h"
 #include "Replication2/ReplicatedState/StateStatus.h"
@@ -34,7 +36,10 @@
 namespace arangodb::futures {
 template<typename T>
 class Future;
-}
+template<typename T>
+class Promise;
+struct Unit;
+}  // namespace arangodb::futures
 namespace arangodb {
 class Result;
 }
@@ -117,10 +122,16 @@ struct ReplicatedState final
 
   struct StateManagerBase {
     virtual ~StateManagerBase() = default;
+    virtual void run() = 0;
+
+    using WaitForAppliedPromise = futures::Promise<futures::Unit>;
+    using WaitForAppliedQueue = std::multimap<LogIndex, WaitForAppliedPromise>;
+
     [[nodiscard]] virtual auto getStatus() const -> StateStatus = 0;
     [[nodiscard]] virtual auto resign() && noexcept
-        -> std::pair<std::unique_ptr<CoreType>,
-                     std::unique_ptr<ReplicatedStateToken>> = 0;
+        -> std::tuple<std::unique_ptr<CoreType>,
+                      std::unique_ptr<ReplicatedStateToken>,
+                      std::unique_ptr<WaitForAppliedQueue>> = 0;
   };
 
  private:
@@ -141,19 +152,21 @@ struct ReplicatedState final
     auto runLeader(std::shared_ptr<replicated_log::ILogLeader> logLeader,
                    std::unique_ptr<CoreType>,
                    std::unique_ptr<ReplicatedStateToken> token)
-        -> DeferredAction;
+        -> std::shared_ptr<StateManagerBase>;
     auto runFollower(std::shared_ptr<replicated_log::ILogFollower> logFollower,
                      std::unique_ptr<CoreType>,
                      std::unique_ptr<ReplicatedStateToken> token)
-        -> DeferredAction;
+        -> std::shared_ptr<StateManagerBase>;
     auto runUnconfigured(
         std::shared_ptr<replicated_log::LogUnconfiguredParticipant>
             unconfiguredParticipant,
         std::unique_ptr<CoreType> core,
-        std::unique_ptr<ReplicatedStateToken> token) -> DeferredAction;
+        std::unique_ptr<ReplicatedStateToken> token)
+        -> std::shared_ptr<StateManagerBase>;
 
     auto rebuild(std::unique_ptr<CoreType> core,
-                 std::unique_ptr<ReplicatedStateToken> token) -> DeferredAction;
+                 std::unique_ptr<ReplicatedStateToken> token)
+        -> std::shared_ptr<StateManagerBase>;
 
     auto flush(StateGeneration planGeneration) -> DeferredAction;
 

--- a/arangod/Replication2/ReplicatedState/ReplicatedState.tpp
+++ b/arangod/Replication2/ReplicatedState/ReplicatedState.tpp
@@ -84,7 +84,7 @@ auto IReplicatedFollowerState<S>::waitForApplied(LogIndex index)
   } else {
     WaitForAppliedFuture future(
         std::make_exception_ptr(replicated_log::ParticipantResignedException(
-            TRI_ERROR_REPLICATION_REPLICATED_LOG_LEADER_RESIGNED, ADB_HERE)));
+            TRI_ERROR_REPLICATION_REPLICATED_LOG_FOLLOWER_RESIGNED, ADB_HERE)));
     return future;
   }
 }

--- a/arangod/Replication2/ReplicatedState/UnconfiguredStateManager.h
+++ b/arangod/Replication2/ReplicatedState/UnconfiguredStateManager.h
@@ -64,7 +64,7 @@ struct UnconfiguredStateManager
   [[nodiscard]] auto resign() && noexcept
       -> std::tuple<std::unique_ptr<CoreType>,
                     std::unique_ptr<ReplicatedStateToken>,
-                    std::unique_ptr<WaitForAppliedQueue>> override;
+                    DeferredAction> override;
 
  private:
   std::weak_ptr<ReplicatedState<S>> _parent;

--- a/arangod/Replication2/ReplicatedState/UnconfiguredStateManager.h
+++ b/arangod/Replication2/ReplicatedState/UnconfiguredStateManager.h
@@ -45,6 +45,11 @@ struct UnconfiguredStateManager
   using LeaderType = typename ReplicatedStateTraits<S>::LeaderType;
   using CoreType = typename ReplicatedStateTraits<S>::CoreType;
 
+  using WaitForAppliedQueue =
+      typename ReplicatedState<S>::StateManagerBase::WaitForAppliedQueue;
+  using WaitForAppliedPromise =
+      typename ReplicatedState<S>::StateManagerBase::WaitForAppliedQueue;
+
   UnconfiguredStateManager(
       std::shared_ptr<ReplicatedState<S>> const& parent,
       std::shared_ptr<replicated_log::LogUnconfiguredParticipant>
@@ -52,13 +57,14 @@ struct UnconfiguredStateManager
       std::unique_ptr<CoreType> core,
       std::unique_ptr<ReplicatedStateToken> token);
 
-  void run();
+  void run() override;
 
   [[nodiscard]] auto getStatus() const -> StateStatus override;
 
   [[nodiscard]] auto resign() && noexcept
-      -> std::pair<std::unique_ptr<CoreType>,
-                   std::unique_ptr<ReplicatedStateToken>> override;
+      -> std::tuple<std::unique_ptr<CoreType>,
+                    std::unique_ptr<ReplicatedStateToken>,
+                    std::unique_ptr<WaitForAppliedQueue>> override;
 
  private:
   std::weak_ptr<ReplicatedState<S>> _parent;

--- a/arangod/Replication2/ReplicatedState/UnconfiguredStateManager.tpp
+++ b/arangod/Replication2/ReplicatedState/UnconfiguredStateManager.tpp
@@ -77,9 +77,10 @@ auto UnconfiguredStateManager<S>::getStatus() const -> StateStatus {
 
 template<typename S>
 auto UnconfiguredStateManager<S>::resign() && noexcept
-    -> std::pair<std::unique_ptr<CoreType>,
-                 std::unique_ptr<ReplicatedStateToken>> {
-  return {std::move(_core), std::move(_token)};
+    -> std::tuple<std::unique_ptr<CoreType>,
+                  std::unique_ptr<ReplicatedStateToken>,
+                  std::unique_ptr<WaitForAppliedQueue>> {
+  return {std::move(_core), std::move(_token), nullptr};
 }
 
 }  // namespace arangodb::replication2::replicated_state

--- a/arangod/Replication2/ReplicatedState/UnconfiguredStateManager.tpp
+++ b/arangod/Replication2/ReplicatedState/UnconfiguredStateManager.tpp
@@ -78,9 +78,8 @@ auto UnconfiguredStateManager<S>::getStatus() const -> StateStatus {
 template<typename S>
 auto UnconfiguredStateManager<S>::resign() && noexcept
     -> std::tuple<std::unique_ptr<CoreType>,
-                  std::unique_ptr<ReplicatedStateToken>,
-                  std::unique_ptr<WaitForAppliedQueue>> {
-  return {std::move(_core), std::move(_token), nullptr};
+                  std::unique_ptr<ReplicatedStateToken>, DeferredAction> {
+  return std::make_tuple(std::move(_core), std::move(_token), DeferredAction{});
 }
 
 }  // namespace arangodb::replication2::replicated_state

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -348,6 +348,7 @@ set(ARANGODB_REPLICATION2_TEST_SOURCES
   Replication2/ReplicatedLog/InMemoryLogTest.cpp
   Replication2/ReplicatedState/AbstractStateMachinePollTest.cpp
   Replication2/ReplicatedState/FollowerSnapshotTest.cpp
+  Replication2/ReplicatedState/FollowerWaitForTest.cpp
   Replication2/ReplicatedState/LeaderRecoveryTest.cpp
   Replication2/ReplicatedState/ReplicatedStateFeatureTest.cpp
   Replication2/ReplicatedState/ReplicatedStateTest.cpp

--- a/tests/Replication2/Mocks/FakeReplicatedState.h
+++ b/tests/Replication2/Mocks/FakeReplicatedState.h
@@ -122,6 +122,7 @@ struct AsyncOperationMarker {
     TRI_ASSERT(triggered);
     TRI_ASSERT(promise->isFulfilled());
     triggered = false;
+    in.reset();
     promise.reset();
   }
 

--- a/tests/Replication2/ReplicatedState/FollowerWaitForTest.cpp
+++ b/tests/Replication2/ReplicatedState/FollowerWaitForTest.cpp
@@ -1,0 +1,95 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2021-2021 ArangoDB GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Lars Maier
+////////////////////////////////////////////////////////////////////////////////
+
+#include <gtest/gtest.h>
+
+#include <utility>
+
+#include "Logger/LogMacros.h"
+#include "LogLevels.h"
+
+#include "Replication2/Mocks/FakeFollower.h"
+#include "Replication2/Mocks/FakeReplicatedState.h"
+#include "Replication2/Mocks/PersistedLog.h"
+#include "Replication2/ReplicatedLog/TestHelper.h"
+#include "Replication2/ReplicatedState/ReplicatedState.tpp"
+#include "Replication2/ReplicatedState/ReplicatedStateFeature.h"
+#include "Replication2/Streams/LogMultiplexer.h"
+
+using namespace arangodb;
+using namespace arangodb::replication2;
+using namespace arangodb::replication2::replicated_state;
+
+struct FollowerWaitForAppliedTest
+    : testing::Test,
+      tests::LogSuppressor<Logger::REPLICATED_STATE, LogLevel::TRACE> {
+  struct State {
+    using LeaderType = test::EmptyLeaderType<State>;
+    using FollowerType = test::FakeFollowerType<State>;
+    using EntryType = test::DefaultEntryType;
+    using FactoryType = test::RecordingFactory<LeaderType, FollowerType>;
+    using CoreType = test::TestCoreType;
+  };
+
+  std::shared_ptr<State::FactoryType> factory =
+      std::make_shared<State::FactoryType>();
+  std::unique_ptr<State::CoreType> core = std::make_unique<State::CoreType>();
+};
+
+TEST_F(FollowerWaitForAppliedTest, wait_for_applied_future_test) {
+  auto follower =
+      std::make_shared<test::FakeFollower>("follower", "leader", LogTerm{1});
+  follower->insertMultiplexedValue<State>(
+      test::DefaultEntryType{.key = "A", .value = "a"});
+  follower->updateCommitIndex(LogIndex{1});  // insert and commit index 1
+
+  auto manager = std::make_shared<FollowerStateManager<State>>(
+      nullptr, follower, std::move(core),
+      std::make_unique<ReplicatedStateToken>(StateGeneration{1}), factory);
+  manager->run();
+  follower->triggerLeaderAcked();
+
+  // complete snapshot transfer
+  auto state = factory->getLatestFollower();
+  state->acquire.resolveWith(Result{});
+
+  // apply index 1
+  state->apply.resolveWith(Result{});
+  state->apply.reset();
+
+  auto f1 = state->waitForApplied(LogIndex{1});
+  ASSERT_TRUE(f1.isReady());
+
+  auto f2 = state->waitForApplied(LogIndex{4});
+  ASSERT_FALSE(f2.isReady());
+
+  // insert more entries
+  for (int i = 0; i < 5; i++) {
+    follower->insertMultiplexedValue<State>(
+        test::DefaultEntryType{.key = "A", .value = "a"});
+  }
+  follower->updateCommitIndex(LogIndex{5});  // commit index 5
+
+  EXPECT_TRUE(state->apply.wasTriggered());
+  state->apply.resolveWith({});
+  EXPECT_TRUE(f2.isReady());
+}

--- a/tests/Replication2/ReplicatedState/FollowerWaitForTest.cpp
+++ b/tests/Replication2/ReplicatedState/FollowerWaitForTest.cpp
@@ -120,8 +120,11 @@ TEST_F(FollowerWaitForAppliedTest, wait_for_applied_resign_resolve) {
 
   auto f2 = state->waitForApplied(LogIndex{4});
   ASSERT_FALSE(f2.isReady());
-  std::move(*manager).resign();
+  auto [core, token, action] = std::move(*manager).resign();
+  action.fire();
 
   // This is now fulfilled because we dropped the return value of resign
   ASSERT_TRUE(f2.isReady());
+  ASSERT_TRUE(f2.hasException());
+  ASSERT_THROW({ f2.get(); }, replicated_log::ParticipantResignedException);
 }


### PR DESCRIPTION
### Scope & Purpose

Adds a `waitForApplied` function to follower states and the follower state manager. It returns a future that is resolved if either the given index was applied or the participant has resigned. This is used for reading on follower to synchronize with writes on leader.