### PR TITLE
avoid deadlock in agency (#15773)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 v3.9.1 (XXXX-XX-XX)
 -------------------
 
+* Avoid a deadlock in agency, when Inception::gossip() acquired a mutex, then 
+  could call Agent under the mutex, and Agent could finally could call 
+  Inception::signalConditionVar(), which would try to acquire the mutex again.
+
 * Upgraded JavaScript "i" module from 0.3.6 to 0.3.7.
 
 * Removed internal JavaScript dependencies "mocha" and "chalk". We recommend

--- a/arangod/Agency/Inception.h
+++ b/arangod/Agency/Inception.h
@@ -75,8 +75,8 @@ class Inception : public Thread {
   Agent& _agent;                            //< @brief The agent
   arangodb::basics::ConditionVariable _cv;  //< @brief For proper shutdown
   std::unordered_map<std::string, size_t>
-      _acked;                      //< @brief acknowledged config version
-  mutable arangodb::Mutex _vLock;  //< @brieg Guard _acked
+      _acked;                        //< @brief acknowledged config version
+  mutable arangodb::Mutex _ackLock;  //< @brieg Guard _acked
 };
 
 }  // namespace consensus


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/15773

Avoid a deadlock in agency, when Inception::gossip() acquired a mutex, then could call Agent under the mutex, and Agent could finally could call Inception::signalConditionVar(), which would try to acquire the mutex again.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [x] Backports
  - [x] Backport for 3.9: this PR
  - [ ] Backport for 3.8: decided to not backport
  - [ ] Backport for 3.7: decided to not backport

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 