### PR TITLE
reset nesting level on each invocation of parse

### DIFF
--- a/3rdParty/velocypack/include/velocypack/Parser.h
+++ b/3rdParty/velocypack/include/velocypack/Parser.h
@@ -184,6 +184,7 @@ class Parser {
     _start = start;
     _size = size;
     _pos = 0;
+    _nesting = 0;
     if (options->clearBuilderBeforeParse) {
       _builder->clear();
     }


### PR DESCRIPTION
### Scope & Purpose

This is a follow-up to bugfix PR https://github.com/arangodb/arangodb/pull/15661. This PR fixes a theoretical issue in VelocyPack when exceeding the maximum nesting level when parsing a JSON value. When invoking the `parse` method multiple times on the same Parser object, the `_nesting` attribute of the Parser was not reset back to 0 when starting the parsing.
This is only a theoretical issue because no maximum nesting level is set for JSON/VPack objects before 3.10/devel. Anyway, it should be fixed in 3.9 too in case a maximum nesting level is introduced at some later point.
Test cases are added via the arangodb/velocypack repository: https://github.com/arangodb/velocypack/pull/122

Other, still open velocypack-related backports for 3.8 and 3.7 have been adjusted so they now include the same fix. For devel, `_nesting` is already resetted correctly.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [x] Tests
  - [ ] **Regression tests**
  - [x] C++ **Unit tests**: https://github.com/arangodb/velocypack/pull/122
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [x] Backports
  - [x] Backport for 3.9: this PR
  - [x] Backport for 3.8: included in https://github.com/arangodb/arangodb/pull/15662
  - [x] Backport for 3.7: included in https://github.com/arangodb/arangodb/pull/15663

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 