### PR TITLE
[CINFRA-271] WaitForSync Persistor Test

### DIFF
--- a/tests/Replication2/Mocks/PersistedLog.cpp
+++ b/tests/Replication2/Mocks/PersistedLog.cpp
@@ -9,7 +9,7 @@ using namespace arangodb::replication2;
 using namespace arangodb::replication2::replicated_log;
 using namespace arangodb::replication2::test;
 
-auto MockLog::insert(PersistedLogIterator& iter, WriteOptions const&)
+auto MockLog::insert(PersistedLogIterator& iter, WriteOptions const& opts)
     -> arangodb::Result {
   auto lastIndex = LogIndex{0};
 
@@ -19,6 +19,9 @@ auto MockLog::insert(PersistedLogIterator& iter, WriteOptions const&)
 
     TRI_ASSERT(entry->logIndex() > lastIndex);
     lastIndex = entry->logIndex();
+    if (opts.waitForSync) {
+      _writtenWithWaitForSync.insert(entry->logIndex());
+    }
   }
 
   return {};

--- a/tests/Replication2/Mocks/PersistedLog.h
+++ b/tests/Replication2/Mocks/PersistedLog.h
@@ -60,9 +60,14 @@ struct MockLog : replication2::replicated_log::PersistedLog {
 
   [[nodiscard]] storeType getStorage() const { return _storage; }
 
+  auto checkEntryWaitedForSync(LogIndex idx) const noexcept -> bool {
+    return _writtenWithWaitForSync.find(idx) != _writtenWithWaitForSync.end();
+  }
+
  private:
   using iteratorType = storeType::iterator;
   storeType _storage;
+  std::unordered_set<LogIndex> _writtenWithWaitForSync;
 };
 
 struct AsyncMockLog : MockLog {

--- a/tests/Replication2/ReplicatedLog/WaitForSyncTest.cpp
+++ b/tests/Replication2/ReplicatedLog/WaitForSyncTest.cpp
@@ -132,3 +132,59 @@ TEST_F(WaitForSyncTest, per_entry_wait_for_sync) {
     follower->resolveRequest(std::move(result));
   }
 }
+
+struct WaitForSyncPersistorTest : ReplicatedLogTest {};
+
+TEST_F(WaitForSyncPersistorTest, wait_for_sync_entry) {
+  auto leaderId = LogId{1};
+  auto followerId = LogId{2};
+  bool const waitForSyncGlobal = false;
+
+  auto followerLog = makeReplicatedLog(followerId);
+  auto follower = followerLog->becomeFollower("follower", LogTerm{1}, "leader");
+
+  auto leaderLog = makeReplicatedLog(leaderId);
+  auto leader = leaderLog->becomeLeader("leader", LogTerm{1}, {follower}, 2,
+                                        waitForSyncGlobal);
+  leader->triggerAsyncReplication();
+
+  auto leaderPersisted = _persistedLogs.at(leaderId);
+  auto followerPersisted = _persistedLogs.at(followerId);
+
+  auto idx = leader->insert(LogPayload::createFromString("first entry"));
+  follower->runAllAsyncAppendEntries();
+  EXPECT_FALSE(leaderPersisted->checkEntryWaitedForSync(idx));
+  EXPECT_FALSE(followerPersisted->checkEntryWaitedForSync(idx));
+  auto idx2 =
+      leader->insert(LogPayload::createFromString("second entry"), true);
+  follower->runAllAsyncAppendEntries();
+  EXPECT_TRUE(leaderPersisted->checkEntryWaitedForSync(idx2));
+  EXPECT_TRUE(followerPersisted->checkEntryWaitedForSync(idx2));
+}
+
+TEST_F(WaitForSyncPersistorTest, wait_for_sync_global) {
+  auto leaderId = LogId{1};
+  auto followerId = LogId{2};
+  bool const waitForSyncGlobal = true;
+
+  auto followerLog = makeReplicatedLog(followerId);
+  auto follower = followerLog->becomeFollower("follower", LogTerm{1}, "leader");
+
+  auto leaderLog = makeReplicatedLog(leaderId);
+  auto leader = leaderLog->becomeLeader("leader", LogTerm{1}, {follower}, 2,
+                                        waitForSyncGlobal);
+  leader->triggerAsyncReplication();
+
+  auto leaderPersisted = _persistedLogs.at(leaderId);
+  auto followerPersisted = _persistedLogs.at(followerId);
+
+  auto idx = leader->insert(LogPayload::createFromString("first entry"));
+  follower->runAllAsyncAppendEntries();
+  EXPECT_TRUE(leaderPersisted->checkEntryWaitedForSync(idx));
+  EXPECT_TRUE(followerPersisted->checkEntryWaitedForSync(idx));
+  auto idx2 =
+      leader->insert(LogPayload::createFromString("second entry"), true);
+  follower->runAllAsyncAppendEntries();
+  EXPECT_TRUE(leaderPersisted->checkEntryWaitedForSync(idx2));
+  EXPECT_TRUE(followerPersisted->checkEntryWaitedForSync(idx2));
+}


### PR DESCRIPTION
### Scope & Purpose

This PR adds unit tests for the LogLeader and LogFollower. These tests check if both units forward the waitForSynch flag to the persistor as expected.