### PR TITLE
Fix SEARCH-294: remove DataStore when not valid initialization

### DIFF
--- a/arangod/IResearch/IResearchDataStore.h
+++ b/arangod/IResearch/IResearchDataStore.h
@@ -358,7 +358,8 @@ class IResearchDataStore {
   /// @brief initialize the data store with a new or from an existing directory
   //////////////////////////////////////////////////////////////////////////////
   Result initDataStore(
-      InitCallback const& initCallback, uint32_t version, bool sorted,
+      bool& pathExist, InitCallback const& initCallback, uint32_t version,
+      bool sorted,
       std::vector<IResearchViewStoredValues::StoredColumn> const& storedColumns,
       irs::type_info::type_id primarySortCompression);
 
@@ -376,13 +377,13 @@ class IResearchDataStore {
   /// @brief wait for all outstanding commit/consolidate operations and closes
   /// data store
   //////////////////////////////////////////////////////////////////////////////
-  Result shutdownDataStore();
+  void shutdownDataStore() noexcept;
 
   //////////////////////////////////////////////////////////////////////////////
   /// @brief wait for all outstanding commit/consolidate operations and remove
   /// data store
   //////////////////////////////////////////////////////////////////////////////
-  Result deleteDataStore();
+  Result deleteDataStore() noexcept;
 
  public:  // TODO(MBkkt) public only for tests, make protected
   // These methods only for tests

--- a/arangod/IResearch/IResearchInvertedIndex.cpp
+++ b/arangod/IResearch/IResearchInvertedIndex.cpp
@@ -862,19 +862,15 @@ IResearchInvertedIndex::sortedFields(IResearchInvertedIndexMeta const& meta) {
 }
 
 Result IResearchInvertedIndex::init(
+    bool& pathExists,
     IResearchDataStore::InitCallback const& initCallback /*= {}*/) {
-  auto const& storedValuesColumns = _meta._storedValues.columns();
   TRI_ASSERT(_meta._sortCompression);
-  auto const primarySortCompression =
-      _meta._sortCompression ? _meta._sortCompression : getDefaultCompression();
-  auto const res = initDataStore(initCallback, _meta._version, isSorted(),
-                                 storedValuesColumns, primarySortCompression);
-
-  if (!res.ok()) {
-    return res;
+  auto r = initDataStore(pathExists, initCallback, _meta._version, isSorted(),
+                         _meta._storedValues.columns(), _meta._sortCompression);
+  if (r.ok()) {
+    _comparer.reset(_meta._sort);
   }
-  _comparer.reset(_meta._sort);
-  return {};
+  return r;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/arangod/IResearch/IResearchInvertedIndex.h
+++ b/arangod/IResearch/IResearchInvertedIndex.h
@@ -176,7 +176,7 @@ class IResearchInvertedIndex : public IResearchDataStore {
 
   bool isSorted() const { return !_meta._sort.empty(); }
 
-  Result init(InitCallback const& initCallback = {});
+  Result init(bool& pathExist, InitCallback const& initCallback = {});
 
   static std::vector<std::vector<arangodb::basics::AttributeName>> fields(
       IResearchInvertedIndexMeta const& meta);

--- a/arangod/IResearch/IResearchLink.h
+++ b/arangod/IResearch/IResearchLink.h
@@ -122,7 +122,7 @@ class IResearchLink : public IResearchDataStore {
   /// @brief called when the iResearch Link is unloaded from memory
   /// @note arangodb::Index override
   ////////////////////////////////////////////////////////////////////////////////
-  Result unload();
+  Result unload() noexcept;
 
   ////////////////////////////////////////////////////////////////////////////////
   /// @brief lookup referenced analyzer
@@ -133,8 +133,8 @@ class IResearchLink : public IResearchDataStore {
   /// @brief initialize from the specified definition used in make(...)
   /// @return success
   ////////////////////////////////////////////////////////////////////////////////
-  virtual Result init(velocypack::Slice definition,
-                      InitCallback const& init = {});
+  Result init(velocypack::Slice definition, bool& pathExists,
+              InitCallback const& init = {});
 
   ////////////////////////////////////////////////////////////////////////////////
   /// @return arangosearch internal format identifier
@@ -183,11 +183,12 @@ class IResearchLink : public IResearchDataStore {
   template<typename T>
   Result toView(std::shared_ptr<LogicalView> const& logical,
                 std::shared_ptr<T>& view);
-  Result initAndLink(InitCallback const& init, IResearchView* view);
+  Result initAndLink(bool& pathExists, InitCallback const& init,
+                     IResearchView* view);
 
-  Result initSingleServer(InitCallback const& init);
+  Result initSingleServer(bool& pathExists, InitCallback const& init);
   Result initCoordinator(InitCallback const& init);
-  Result initDBServer(InitCallback const& init);
+  Result initDBServer(bool& pathExists, InitCallback const& init);
 
   IResearchLinkMeta _meta;
   // the identifier of the desired view (read-only, set via init())

--- a/arangod/IResearch/IResearchLinkCoordinator.cpp
+++ b/arangod/IResearch/IResearchLinkCoordinator.cpp
@@ -84,10 +84,10 @@ IResearchLinkCoordinator::IResearchLinkCoordinator(
   _sparse = true;   // always sparse
 }
 
-Result IResearchLinkCoordinator::init(
-    velocypack::Slice definition,
-    IResearchLink::InitCallback const& initCallback) {
-  auto r = IResearchLink::init(definition, initCallback);
+Result IResearchLinkCoordinator::init(velocypack::Slice definition) {
+  bool pathExists = false;
+  auto r = IResearchLink::init(definition, pathExists);
+  TRI_ASSERT(!pathExists);
   if (!r.ok()) {
     return r;
   }

--- a/arangod/IResearch/IResearchLinkCoordinator.h
+++ b/arangod/IResearch/IResearchLinkCoordinator.h
@@ -55,8 +55,7 @@ class IResearchLinkCoordinator final : public arangodb::ClusterIndex,
   /// @brief initialize from the specified definition used in make(...)
   /// @return success
   ////////////////////////////////////////////////////////////////////////////////
-  Result init(velocypack::Slice definition,
-              InitCallback const& initCallback = {}) final;
+  Result init(velocypack::Slice definition);
 
   bool canBeDropped() const final { return IResearchLink::canBeDropped(); }
 

--- a/arangod/IResearch/IResearchRocksDBLink.h
+++ b/arangod/IResearch/IResearchRocksDBLink.h
@@ -49,7 +49,7 @@ class IResearchRocksDBLink final : public RocksDBIndex, public IResearchLink {
 
   bool canBeDropped() const override { return IResearchLink::canBeDropped(); }
 
-  Result drop() override { return IResearchLink::drop(); }
+  Result drop() override /*noexcept*/ { return IResearchLink::drop(); }
 
   bool hasSelectivityEstimate() const override {
     return IResearchLink::hasSelectivityEstimate();

--- a/tests/IResearch/IResearchInvertedIndexIteratorTest.cpp
+++ b/tests/IResearch/IResearchInvertedIndexIteratorTest.cpp
@@ -135,7 +135,8 @@ class IResearchInvertedIndexIteratorTestBase
     _index = std::make_shared<arangodb::iresearch::IResearchInvertedIndex>(
         id, *_collection, std::move(meta));
     EXPECT_TRUE(_index);
-    EXPECT_TRUE(_index->init().ok());
+    bool pathExists = false;
+    EXPECT_TRUE(_index->init(pathExists).ok());
 
     // now populate the docs
     static std::vector<std::string> const EMPTY;

--- a/tests/IResearch/IResearchViewDBServerTest.cpp
+++ b/tests/IResearch/IResearchViewDBServerTest.cpp
@@ -64,7 +64,8 @@ struct Link : public arangodb::iresearch::IResearchLink {
   Link(arangodb::IndexId id, arangodb::LogicalCollection& col)
       : IResearchLink(id, col) {
     auto json = VPackParser::fromJson(R"({ "view": "42" })");
-    EXPECT_TRUE(init(json->slice()).ok());
+    bool pathExists = false;
+    EXPECT_TRUE(init(json->slice(), pathExists).ok());
   }
 };
 

--- a/tests/IResearch/IResearchViewTest.cpp
+++ b/tests/IResearch/IResearchViewTest.cpp
@@ -2763,7 +2763,8 @@ TEST_F(IResearchViewTest, test_emplace_cid) {
     Link(arangodb::IndexId id, arangodb::LogicalCollection& col)
         : IResearchLink(id, col) {
       auto json = VPackParser::fromJson(R"({ "view": "42" })");
-      EXPECT_TRUE(init(json->slice()).ok());
+      bool pathExists = false;
+      EXPECT_TRUE(init(json->slice(), pathExists).ok());
     }
   };
 


### PR DESCRIPTION
### Scope & Purpose

Fix SEARCH-294: remove DataStore when not valid initialization
Also, fix possible leak physical DataStore directory

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*
  - [ ] Backport for 3.7: *(Please link PR)*

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

