### PR TITLE
[CINFRA-273] Refactor ReplicatedLog SupervisionAction

### DIFF
--- a/arangod/Agency/Supervision.cpp
+++ b/arangod/Agency/Supervision.cpp
@@ -2620,11 +2620,8 @@ void Supervision::checkReplicatedLogs() {
             }
           });
 
-      auto maybeLogId = replication2::LogId::fromString(idString);
-
-      if (maybeAction && maybeLogId) {
+      if (maybeAction) {
         auto const& action = *maybeAction;
-        auto const& logId = *maybeLogId;
 
         if (target.supervision.has_value() &&
             target.supervision->maxActionsTraceLength > 0) {
@@ -2650,7 +2647,7 @@ void Supervision::checkReplicatedLogs() {
                   .end();
         }
         envelope = arangodb::replication2::replicated_log::execute(
-            action, dbName, logId, std::move(envelope));
+            action, dbName, target.id, std::move(envelope));
       }
     }
   }

--- a/arangod/Replication2/ReplicatedLog/Supervision.cpp
+++ b/arangod/Replication2/ReplicatedLog/Supervision.cpp
@@ -25,10 +25,10 @@
 
 #include <memory>
 
-#include "Basics/StringUtils.h"
 #include "Basics/Exceptions.h"
-#include "Replication2/ReplicatedLog/AgencyLogSpecification.h"
+#include "Basics/StringUtils.h"
 #include "Random/RandomGenerator.h"
+#include "Replication2/ReplicatedLog/AgencyLogSpecification.h"
 #include "Replication2/ReplicatedLog/LogCommon.h"
 #include "Replication2/ReplicatedLog/SupervisionAction.h"
 
@@ -38,8 +38,7 @@ using namespace arangodb::replication2::agency;
 
 namespace arangodb::replication2::replicated_log {
 
-auto checkLogAdded(const Log& log, ParticipantsHealth const& health)
-    -> std::unique_ptr<Action> {
+auto checkLogAdded(const Log& log, ParticipantsHealth const& health) -> Action {
   if (!log.plan) {
     // TODO: this is a temporary hack
     if (log.target.participants.empty()) {
@@ -55,30 +54,29 @@ auto checkLogAdded(const Log& log, ParticipantsHealth const& health)
         }
       }
 
-      return std::make_unique<AddParticipantsToTargetAction>(newTarget);
+      return AddParticipantsToTargetAction(newTarget);
     }
     auto const spec = LogPlanSpecification(
         log.target.id, std::nullopt,
         ParticipantsConfig{.generation = 1,
                            .participants = log.target.participants});
 
-    return std::make_unique<AddLogToPlanAction>(spec);
+    return AddLogToPlanAction(spec);
   }
-  return std::make_unique<EmptyAction>();
+  return EmptyAction();
 }
 
 auto checkTermPresent(LogPlanSpecification const& plan, LogConfig const& config)
-    -> std::unique_ptr<Action> {
+    -> Action {
   if (!plan.currentTerm) {
-    return std::make_unique<CreateInitialTermAction>(
+    return CreateInitialTermAction(
         plan.id, LogPlanTermSpecification(LogTerm(1), config, std::nullopt));
   }
-  return std::make_unique<EmptyAction>();
+  return EmptyAction();
 }
 
 auto checkLeaderFailed(LogPlanSpecification const& plan,
-                       ParticipantsHealth const& health)
-    -> std::unique_ptr<Action> {
+                       ParticipantsHealth const& health) -> Action {
   // TODO: if we assert this here, we assume we're always called
   //       with non std::nullopt currentTerm and leader
   TRI_ASSERT(plan.currentTerm != std::nullopt);
@@ -88,7 +86,7 @@ auto checkLeaderFailed(LogPlanSpecification const& plan,
       health.validRebootId(plan.currentTerm->leader->serverId,
                            plan.currentTerm->leader->rebootId)) {
     // Current leader is all healthy so nothing to do.
-    return std::make_unique<EmptyAction>();
+    return EmptyAction();
   } else {
     // Leader has failed; start a new term
     auto newTerm = *plan.currentTerm;
@@ -96,7 +94,7 @@ auto checkLeaderFailed(LogPlanSpecification const& plan,
     newTerm.leader.reset();
     newTerm.term = LogTerm{plan.currentTerm->term.value + 1};
 
-    return std::make_unique<UpdateTermAction>(plan.id, newTerm);
+    return UpdateTermAction(plan.id, newTerm);
   }
 }
 
@@ -116,13 +114,12 @@ auto checkLeaderFailed(LogPlanSpecification const& plan,
 auto checkLeaderRemovedFromTarget(LogTarget const& target,
                                   LogPlanSpecification const& plan,
                                   LogCurrent const& current,
-                                  ParticipantsHealth const& health)
-    -> std::unique_ptr<Action> {
+                                  ParticipantsHealth const& health) -> Action {
   // TODO: integrate
   if (!current.leader || !current.leader->committedParticipantsConfig ||
       current.leader->committedParticipantsConfig->generation !=
           plan.participantsConfig.generation) {
-    return std::make_unique<EmptyAction>();
+    return EmptyAction();
   }
 
   if (plan.currentTerm && plan.currentTerm->leader &&
@@ -153,7 +150,7 @@ auto checkLeaderRemovedFromTarget(LogTarget const& target,
             term, plan.currentTerm->config,
             LogPlanTermSpecification::Leader{participant, rebootId});
 
-        return std::make_unique<DictateLeaderAction>(target.id, termSpec);
+        return DictateLeaderAction(target.id, termSpec);
       }
     }
 
@@ -170,15 +167,15 @@ auto checkLeaderRemovedFromTarget(LogTarget const& target,
 
       flags.forced = true;
 
-      return std::make_unique<UpdateParticipantFlagsAction>(
-          target.id, chosenOne, flags, plan.participantsConfig.generation);
+      return UpdateParticipantFlagsAction(target.id, chosenOne, flags,
+                                          plan.participantsConfig.generation);
     } else {
       // We should be signaling that we could not determine a leader
       // because noone suitable was available
     }
   }
 
-  return std::make_unique<EmptyAction>();
+  return EmptyAction();
 }
 
 /*
@@ -189,8 +186,7 @@ auto checkLeaderRemovedFromTarget(LogTarget const& target,
 auto checkLeaderInTarget(LogTarget const& target,
                          LogPlanSpecification const& plan,
                          LogCurrent const& current,
-                         ParticipantsHealth const& health)
-    -> std::unique_ptr<Action> {
+                         ParticipantsHealth const& health) -> Action {
   // Someone wishes there to be a particular leader
 
   if (target.leader && plan.currentTerm && plan.currentTerm->leader &&
@@ -204,7 +200,7 @@ auto checkLeaderInTarget(LogTarget const& target,
     if (!current.leader || !current.leader->committedParticipantsConfig ||
         current.leader->committedParticipantsConfig->generation !=
             plan.participantsConfig.generation) {
-      return std::make_unique<EmptyAction>();
+      return EmptyAction();
     }
 
     if (!plan.participantsConfig.participants.contains(*target.leader)) {
@@ -212,22 +208,22 @@ auto checkLeaderInTarget(LogTarget const& target,
           current.supervision->error ==
               LogCurrentSupervisionError::TARGET_LEADER_INVALID) {
         // Error has already been reported; don't re-report
-        return std::make_unique<EmptyAction>();
+        return EmptyAction();
       } else {
-        return std::make_unique<ErrorAction>(
-            plan.id, LogCurrentSupervisionError::TARGET_LEADER_INVALID);
+        return ErrorAction(plan.id,
+                           LogCurrentSupervisionError::TARGET_LEADER_INVALID);
       }
     }
     auto const& planLeaderConfig =
         plan.participantsConfig.participants.at(*target.leader);
 
     if (planLeaderConfig.forced != true || planLeaderConfig.excluded == true) {
-      return std::make_unique<ErrorAction>(
-          plan.id, LogCurrentSupervisionError::TARGET_LEADER_EXCLUDED);
+      return ErrorAction(plan.id,
+                         LogCurrentSupervisionError::TARGET_LEADER_EXCLUDED);
     }
 
     if (!health.notIsFailed(*target.leader)) {
-      return std::make_unique<EmptyAction>();
+      return EmptyAction();
       // TODO: we need to be able to trace why actions were not taken
       //       distinguishing between errors and conditions not being met (?)
     };
@@ -238,9 +234,9 @@ auto checkLeaderInTarget(LogTarget const& target,
         term, plan.currentTerm->config,
         LogPlanTermSpecification::Leader{*target.leader, rebootId});
 
-    return std::make_unique<DictateLeaderAction>(target.id, termSpec);
+    return DictateLeaderAction(target.id, termSpec);
   }
-  return std::make_unique<EmptyAction>();
+  return EmptyAction();
 }
 
 auto computeReason(LogCurrentLocalState const& status, bool healthy,
@@ -289,8 +285,7 @@ auto runElectionCampaign(LogCurrentLocalStates const& states,
 
 auto tryLeadershipElection(LogPlanSpecification const& plan,
                            LogCurrent const& current,
-                           ParticipantsHealth const& health)
-    -> std::unique_ptr<Action> {
+                           ParticipantsHealth const& health) -> Action {
   // Check whether there are enough participants to reach a quorum
 
   if (plan.participantsConfig.participants.size() + 1 <=
@@ -298,7 +293,7 @@ auto tryLeadershipElection(LogPlanSpecification const& plan,
     auto election = LogCurrentSupervisionElection();
     election.term = plan.currentTerm->term;
     election.outcome = LogCurrentSupervisionElection::Outcome::IMPOSSIBLE;
-    return std::make_unique<LeaderElectionAction>(plan.id, election);
+    return LeaderElectionAction(plan.id, election);
   }
 
   TRI_ASSERT(plan.participantsConfig.participants.size() + 1 >
@@ -319,7 +314,7 @@ auto tryLeadershipElection(LogPlanSpecification const& plan,
   if (numElectible == 0 ||
       numElectible > std::numeric_limits<uint16_t>::max()) {
     election.outcome = LogCurrentSupervisionElection::Outcome::IMPOSSIBLE;
-    return std::make_unique<LeaderElectionAction>(plan.id, election);
+    return LeaderElectionAction(plan.id, election);
   }
 
   if (election.participantsAvailable >= requiredNumberOfOKParticipants) {
@@ -330,7 +325,7 @@ auto tryLeadershipElection(LogPlanSpecification const& plan,
     auto const& newLeaderRebootId = health._health.at(newLeader).rebootId;
 
     election.outcome = LogCurrentSupervisionElection::Outcome::SUCCESS;
-    return std::make_unique<LeaderElectionAction>(
+    return LeaderElectionAction(
         plan.id, election,
         LogPlanTermSpecification(
             LogTerm{plan.currentTerm->term.value + 1}, plan.currentTerm->config,
@@ -340,19 +335,18 @@ auto tryLeadershipElection(LogPlanSpecification const& plan,
     // Not enough participants were available to form a quorum, so
     // we can't elect a leader
     election.outcome = LogCurrentSupervisionElection::Outcome::FAILED;
-    return std::make_unique<LeaderElectionAction>(plan.id, election);
+    return LeaderElectionAction(plan.id, election);
   }
 }
 
 auto checkLeaderPresent(LogPlanSpecification const& plan,
                         LogCurrent const& current,
-                        ParticipantsHealth const& health)
-    -> std::unique_ptr<Action> {
+                        ParticipantsHealth const& health) -> Action {
   // currentTerm has no leader
   if (!plan.currentTerm->leader.has_value()) {
     return tryLeadershipElection(plan, current, health);
   } else {
-    return std::make_unique<EmptyAction>();
+    return EmptyAction();
   }
 }
 
@@ -373,7 +367,7 @@ auto desiredParticipantFlags(LogTarget const& target,
 
 auto checkLogTargetParticipantFlags(LogTarget const& target,
                                     LogPlanSpecification const& plan)
-    -> std::unique_ptr<Action> {
+    -> Action {
   auto const& tps = target.participants;
   auto const& pps = plan.participantsConfig.participants;
 
@@ -384,20 +378,19 @@ auto checkLogTargetParticipantFlags(LogTarget const& target,
       auto const df = desiredParticipantFlags(target, plan, targetParticipant);
       if (df != planParticipant->second) {
         // Flags changed, so we need to commit new flags for this participant
-        return std::make_unique<UpdateParticipantFlagsAction>(
-            target.id, targetParticipant, df,
-            plan.participantsConfig.generation);
+        return UpdateParticipantFlagsAction(target.id, targetParticipant, df,
+                                            plan.participantsConfig.generation);
       }
     }
   }
 
   // nothing changed, nothing to do
-  return std::make_unique<EmptyAction>();
+  return EmptyAction();
 }
 
 auto checkLogTargetParticipantAdded(LogTarget const& target,
                                     LogPlanSpecification const& plan)
-    -> std::unique_ptr<Action> {
+    -> Action {
   auto tps = target.participants;
   auto pps = plan.participantsConfig.participants;
 
@@ -406,17 +399,16 @@ auto checkLogTargetParticipantAdded(LogTarget const& target,
     if (auto const& planParticipant = pps.find(targetParticipant);
         planParticipant == pps.end()) {
       // Here's a participant that is not in plan yet; we add it
-      return std::make_unique<AddParticipantToPlanAction>(
-          plan.id, targetParticipant, targetFlags,
-          plan.participantsConfig.generation);
+      return AddParticipantToPlanAction(plan.id, targetParticipant, targetFlags,
+                                        plan.participantsConfig.generation);
     }
   }
-  return std::make_unique<EmptyAction>();
+  return EmptyAction();
 }
 
 auto checkLogTargetParticipantRemoved(LogTarget const& target,
                                       LogPlanSpecification const& plan)
-    -> std::unique_ptr<Action> {
+    -> Action {
   auto tps = target.participants;
   auto pps = plan.participantsConfig.participants;
 
@@ -430,38 +422,35 @@ auto checkLogTargetParticipantRemoved(LogTarget const& target,
         auto newTerm = *plan.currentTerm;
         newTerm.term = LogTerm{newTerm.term.value + 1};
         newTerm.leader.reset();
-        return std::make_unique<EvictLeaderAction>(
-            plan.id, planParticipant, desiredFlags, newTerm,
-            plan.participantsConfig.generation);
+        return EvictLeaderAction(plan.id, planParticipant, desiredFlags,
+                                 newTerm, plan.participantsConfig.generation);
       } else {
-        return std::make_unique<RemoveParticipantFromPlanAction>(
+        return RemoveParticipantFromPlanAction(
             plan.id, planParticipant, plan.participantsConfig.generation);
       }
     }
   }
-  return std::make_unique<EmptyAction>();
+  return EmptyAction();
 }
 
 // Check whether the Target configuration differs from Plan
 // and do a validity check on the new config
 auto checkLogTargetConfig(LogTarget const& target,
-                          LogPlanSpecification const& plan)
-    -> std::unique_ptr<Action> {
+                          LogPlanSpecification const& plan) -> Action {
   if (plan.currentTerm && target.config != plan.currentTerm->config) {
     // TODO: validity Check on target config
-    return std::make_unique<UpdateLogConfigAction>(plan.id, target.config);
+    return UpdateLogConfigAction(plan.id, target.config);
   }
-  return std::make_unique<EmptyAction>();
+  return EmptyAction();
 }
 
-auto isEmptyAction(std::unique_ptr<Action>& action) {
-  return (action == nullptr) or
-         (action->type() == Action::ActionType::EmptyAction);
+auto isEmptyAction(Action& action) {
+  return std::holds_alternative<EmptyAction>(action);
 }
 
 // The main function
 auto checkReplicatedLog(Log const& log, ParticipantsHealth const& health)
-    -> std::unique_ptr<Action> {
+    -> Action {
   // Check whether this log exists in plan;
   //
   // If it doesn't the action is to create the log;
@@ -485,7 +474,7 @@ auto checkReplicatedLog(Log const& log, ParticipantsHealth const& health)
   // leadership
   // TODO: Action that reports we're waiting for Current
   if (!log.current) {
-    return std::make_unique<EmptyAction>();
+    return EmptyAction();
   }
 
   // Check that the log has a leader in plan; if not try electing one
@@ -551,7 +540,7 @@ auto checkReplicatedLog(Log const& log, ParticipantsHealth const& health)
   }
 
   // Nothing todo
-  return std::make_unique<EmptyAction>();
+  return EmptyAction();
 }
 
 }  // namespace arangodb::replication2::replicated_log

--- a/arangod/Replication2/ReplicatedLog/Supervision.h
+++ b/arangod/Replication2/ReplicatedLog/Supervision.h
@@ -42,52 +42,45 @@ using LogCurrentLocalStates =
     std::unordered_map<ParticipantId, LogCurrentLocalState>;
 
 // Check whether a log has been added to target
-auto checkLogAdded(Log const& log, ParticipantsHealth const& health)
-    -> std::unique_ptr<Action>;
+auto checkLogAdded(Log const &log, ParticipantsHealth const &health) -> Action;
 
 //
-auto checkLeaderPresent(LogPlanSpecification const& plan,
-                        LogCurrent const& current,
-                        ParticipantsHealth const& health)
-    -> std::unique_ptr<Action>;
+auto checkLeaderPresent(LogPlanSpecification const &plan,
+                        LogCurrent const &current,
+                        ParticipantsHealth const &health) -> Action;
 
-auto checkLeaderFailed(LogPlanSpecification const& plan,
-                       ParticipantsHealth const& health)
-    -> std::unique_ptr<Action>;
+auto checkLeaderFailed(LogPlanSpecification const &plan,
+                       ParticipantsHealth const &health) -> Action;
 
-auto computeReason(LogCurrentLocalState const& status, bool healthy,
+auto computeReason(LogCurrentLocalState const &status, bool healthy,
                    bool excluded, LogTerm term)
     -> LogCurrentSupervisionElection::ErrorCode;
 
-auto runElectionCampaign(LogCurrentLocalStates const& states,
-                         ParticipantsConfig const& participantsConfig,
-                         ParticipantsHealth const& health, LogTerm term)
+auto runElectionCampaign(LogCurrentLocalStates const &states,
+                         ParticipantsConfig const &participantsConfig,
+                         ParticipantsHealth const &health, LogTerm term)
     -> LogCurrentSupervisionElection;
 
-auto tryLeadershipElection(LogPlanSpecification const& plan,
-                           LogCurrent const& current,
-                           ParticipantsHealth const& health)
-    -> std::unique_ptr<Action>;
+auto tryLeadershipElection(LogPlanSpecification const &plan,
+                           LogCurrent const &current,
+                           ParticipantsHealth const &health) -> Action;
 
-auto checkLogTargetParticipantFlags(LogTarget const& target,
-                                    LogPlanSpecification const& plan)
-    -> std::unique_ptr<Action>;
+auto checkLogTargetParticipantFlags(LogTarget const &target,
+                                    LogPlanSpecification const &plan) -> Action;
 
-auto checkLogTargetParticipantAdded(LogTarget const& target,
-                                    LogPlanSpecification const& plan)
-    -> std::unique_ptr<Action>;
+auto checkLogTargetParticipantAdded(LogTarget const &target,
+                                    LogPlanSpecification const &plan) -> Action;
 
-auto checkLogTargetParticipantRemoved(LogTarget const& target,
-                                      LogPlanSpecification const& plan)
-    -> std::unique_ptr<Action>;
+auto checkLogTargetParticipantRemoved(LogTarget const &target,
+                                      LogPlanSpecification const &plan)
+    -> Action;
 
-auto checkLogTargetConfig(LogTarget const& target,
-                          LogPlanSpecification const& plan)
-    -> std::unique_ptr<Action>;
+auto checkLogTargetConfig(LogTarget const &target,
+                          LogPlanSpecification const &plan) -> Action;
 
 // Actions capture entries in log, so they have to stay
 // valid until the returned action has been executed (or discarded)
-auto checkReplicatedLog(Log const& log, ParticipantsHealth const& health)
-    -> std::unique_ptr<Action>;
+auto checkReplicatedLog(Log const &log, ParticipantsHealth const &health)
+    -> Action;
 
-}  // namespace arangodb::replication2::replicated_log
+} // namespace arangodb::replication2::replicated_log

--- a/arangod/Replication2/ReplicatedLog/Supervision.h
+++ b/arangod/Replication2/ReplicatedLog/Supervision.h
@@ -42,45 +42,45 @@ using LogCurrentLocalStates =
     std::unordered_map<ParticipantId, LogCurrentLocalState>;
 
 // Check whether a log has been added to target
-auto checkLogAdded(Log const &log, ParticipantsHealth const &health) -> Action;
+auto checkLogAdded(Log const& log, ParticipantsHealth const& health) -> Action;
 
 //
-auto checkLeaderPresent(LogPlanSpecification const &plan,
-                        LogCurrent const &current,
-                        ParticipantsHealth const &health) -> Action;
+auto checkLeaderPresent(LogPlanSpecification const& plan,
+                        LogCurrent const& current,
+                        ParticipantsHealth const& health) -> Action;
 
-auto checkLeaderFailed(LogPlanSpecification const &plan,
-                       ParticipantsHealth const &health) -> Action;
+auto checkLeaderFailed(LogPlanSpecification const& plan,
+                       ParticipantsHealth const& health) -> Action;
 
-auto computeReason(LogCurrentLocalState const &status, bool healthy,
+auto computeReason(LogCurrentLocalState const& status, bool healthy,
                    bool excluded, LogTerm term)
     -> LogCurrentSupervisionElection::ErrorCode;
 
-auto runElectionCampaign(LogCurrentLocalStates const &states,
-                         ParticipantsConfig const &participantsConfig,
-                         ParticipantsHealth const &health, LogTerm term)
+auto runElectionCampaign(LogCurrentLocalStates const& states,
+                         ParticipantsConfig const& participantsConfig,
+                         ParticipantsHealth const& health, LogTerm term)
     -> LogCurrentSupervisionElection;
 
-auto tryLeadershipElection(LogPlanSpecification const &plan,
-                           LogCurrent const &current,
-                           ParticipantsHealth const &health) -> Action;
+auto tryLeadershipElection(LogPlanSpecification const& plan,
+                           LogCurrent const& current,
+                           ParticipantsHealth const& health) -> Action;
 
-auto checkLogTargetParticipantFlags(LogTarget const &target,
-                                    LogPlanSpecification const &plan) -> Action;
+auto checkLogTargetParticipantFlags(LogTarget const& target,
+                                    LogPlanSpecification const& plan) -> Action;
 
-auto checkLogTargetParticipantAdded(LogTarget const &target,
-                                    LogPlanSpecification const &plan) -> Action;
+auto checkLogTargetParticipantAdded(LogTarget const& target,
+                                    LogPlanSpecification const& plan) -> Action;
 
-auto checkLogTargetParticipantRemoved(LogTarget const &target,
-                                      LogPlanSpecification const &plan)
+auto checkLogTargetParticipantRemoved(LogTarget const& target,
+                                      LogPlanSpecification const& plan)
     -> Action;
 
-auto checkLogTargetConfig(LogTarget const &target,
-                          LogPlanSpecification const &plan) -> Action;
+auto checkLogTargetConfig(LogTarget const& target,
+                          LogPlanSpecification const& plan) -> Action;
 
 // Actions capture entries in log, so they have to stay
 // valid until the returned action has been executed (or discarded)
-auto checkReplicatedLog(Log const &log, ParticipantsHealth const &health)
+auto checkReplicatedLog(Log const& log, ParticipantsHealth const& health)
     -> Action;
 
-} // namespace arangodb::replication2::replicated_log
+}  // namespace arangodb::replication2::replicated_log

--- a/arangod/Replication2/ReplicatedLog/SupervisionAction.cpp
+++ b/arangod/Replication2/ReplicatedLog/SupervisionAction.cpp
@@ -217,6 +217,7 @@ auto to_string(Action const& action) -> std::string_view {
 
 void toVelocyPack(Action const& action, VPackBuilder& builder) {
   auto ob = VPackObjectBuilder(&builder);
+  builder.add(VPackValue("type"));
   builder.add(VPackValue(to_string(action)));
 }
 

--- a/arangod/Replication2/ReplicatedLog/SupervisionAction.cpp
+++ b/arangod/Replication2/ReplicatedLog/SupervisionAction.cpp
@@ -34,203 +34,57 @@ using namespace arangodb::replication2::agency;
 namespace paths = arangodb::cluster::paths::aliases;
 
 namespace arangodb::replication2::replicated_log {
-auto to_string(Action::ActionType action) -> std::string_view {
-  switch (action) {
-    case Action::ActionType::EmptyAction: {
-      return "Empty";
-    } break;
-    case Action::ActionType::ErrorAction: {
-      return "Error";
-    } break;
-    case Action::ActionType::AddLogToPlanAction: {
-      return "AddLogToPlan";
-    } break;
-    case Action::ActionType::AddParticipantsToTargetAction: {
-      return "AddLogToPlan";
-    } break;
-    case Action::ActionType::LeaderElectionAction: {
-      return "LeaderElection";
-    } break;
-    case Action::ActionType::CreateInitialTermAction: {
-      return "CreateInitialTermAction";
-    } break;
-    case Action::ActionType::DictateLeaderAction: {
-      return "DictateLeaderAction";
-    } break;
-    case Action::ActionType::UpdateTermAction: {
-      return "UpdateTermAction";
-    } break;
-    case Action::ActionType::UpdateParticipantFlagsAction: {
-      return "UpdateParticipantFlags";
-    } break;
-    case Action::ActionType::AddParticipantToPlanAction: {
-      return "AddParticipantToPlanAction";
-    } break;
-    case Action::ActionType::RemoveParticipantFromPlanAction: {
-      return "RemoveParticipantFromPlan";
-    } break;
-    case Action::ActionType::UpdateLogConfigAction: {
-      return "UpdateLogConfig";
-    } break;
-    case Action::ActionType::EvictLeaderAction: {
-      return "EvictLeaderAction";
-    } break;
-  }
-  return "this-value-is-here-to-shut-up-the-compiler-if-this-is-reached-that-"
-         "is-a-bug";
-}
 
-auto operator<<(std::ostream& os, Action::ActionType const& action)
-    -> std::ostream& {
-  return os << to_string(action);
-}
-auto to_string(Action const& action) -> std::string {
-  VPackBuilder bb;
-  action.toVelocyPack(bb);
-  return bb.toString();
-}
+void Executor::operator()(EmptyAction const& action) {}
 
-auto operator<<(std::ostream& os, Action const& action) -> std::ostream& {
-  return os << to_string(action);
-}
-
-/*
- * EmptyAction
- */
-void EmptyAction::toVelocyPack(VPackBuilder& builder) const {
-  auto ob = VPackObjectBuilder(&builder);
-  builder.add(VPackValue("type"));
-  builder.add(VPackValue(to_string(type())));
-
-  builder.add(VPackValue("message"));
-  builder.add(VPackValue(_message));
-}
-
-void ErrorAction::toVelocyPack(VPackBuilder& builder) const {
-  auto ob = VPackObjectBuilder(&builder);
-  builder.add(VPackValue("type"));
-  builder.add(VPackValue(to_string(type())));
-
-  builder.add(VPackValue("error"));
-  ::toVelocyPack(_error, builder);
-}
-
-auto ErrorAction::execute(std::string dbName,
-                          arangodb::agency::envelope envelope)
-    -> arangodb::agency::envelope {
-  auto current_path = paths::current()
-                          ->replicatedLogs()
-                          ->database(dbName)
-                          ->log(_id)
-                          ->supervision()
-                          ->error()
-                          ->str();
-  return envelope.write()
-      .emplace_object(
-          current_path,
-          [&](VPackBuilder& builder) { ::toVelocyPack(_error, builder); })
+void Executor::operator()(ErrorAction const& action) {
+  envelope.write()
+      .emplace_object(currentPath->supervision()->error()->str(),
+                      [&](VPackBuilder& builder) {
+                        ::toVelocyPack(action._error, builder);
+                      })
       .inc(paths::current()->version()->str())
       .precs()
       .end();
 }
 
-/*
- * AddLogToPlanAction
- */
-void AddLogToPlanAction::toVelocyPack(VPackBuilder& builder) const {
-  auto ob = VPackObjectBuilder(&builder);
-  builder.add(VPackValue("type"));
-  builder.add(VPackValue(to_string(type())));
-}
-
-auto AddLogToPlanAction::execute(std::string dbName,
-                                 arangodb::agency::envelope envelope)
-    -> arangodb::agency::envelope {
-  auto path =
-      paths::plan()->replicatedLogs()->database(dbName)->log(_spec.id)->str();
-
-  return envelope.write()
+void Executor::operator()(AddLogToPlanAction const& action) {
+  envelope.write()
       .emplace_object(
-          path, [&](VPackBuilder& builder) { _spec.toVelocyPack(builder); })
+          planPath->str(),
+          [&](VPackBuilder& builder) { action._spec.toVelocyPack(builder); })
       .inc(paths::plan()->version()->str())
       .precs()
-      .isEmpty(path)
-      .end();
-};
-
-/*
- * AddLogToPlanAction
- */
-void AddParticipantsToTargetAction::toVelocyPack(VPackBuilder& builder) const {
-  auto ob = VPackObjectBuilder(&builder);
-  builder.add(VPackValue("type"));
-  builder.add(VPackValue(to_string(type())));
-}
-
-auto AddParticipantsToTargetAction::execute(std::string dbName,
-                                            arangodb::agency::envelope envelope)
-    -> arangodb::agency::envelope {
-  auto path =
-      paths::target()->replicatedLogs()->database(dbName)->log(_spec.id)->str();
-
-  return envelope.write()
-      .emplace_object(
-          path, [&](VPackBuilder& builder) { _spec.toVelocyPack(builder); })
-      .inc(paths::plan()->version()->str())
-      .precs()
-      //      .isEmpty(path)
-      .end();
-};
-
-/*
- * CreateInitialTermAction
- */
-void CreateInitialTermAction::toVelocyPack(VPackBuilder& builder) const {
-  auto ob = VPackObjectBuilder(&builder);
-  builder.add(VPackValue("type"));
-  builder.add(VPackValue(to_string(type())));
-}
-
-auto CreateInitialTermAction::execute(std::string dbName,
-                                      arangodb::agency::envelope envelope)
-    -> arangodb::agency::envelope {
-  auto path = paths::plan()
-                  ->replicatedLogs()
-                  ->database(dbName)
-                  ->log(_id)
-                  ->currentTerm()
-                  ->str();
-
-  return envelope.write()
-      .emplace_object(
-          path, [&](VPackBuilder& builder) { _term.toVelocyPack(builder); })
-      .inc(paths::plan()->version()->str())
-      .precs()
-      .isEmpty(path)
+      .isEmpty(planPath->str())
       .end();
 }
 
-void DictateLeaderAction::toVelocyPack(VPackBuilder& builder) const {
-  auto ob = VPackObjectBuilder(&builder);
-  builder.add(VPackValue("type"));
-  builder.add(VPackValue(to_string(type())));
-  builder.add(VPackValue("newTerm"));
-  _term.toVelocyPack(builder);
+void Executor::operator()(AddParticipantsToTargetAction const& action) {
+  envelope.write()
+      .emplace_object(
+          targetPath->str(),
+          [&](VPackBuilder& builder) { action._spec.toVelocyPack(builder); })
+      .inc(paths::plan()->version()->str())
+      .precs()
+      .end();
 }
 
-auto DictateLeaderAction::execute(std::string dbName,
-                                  arangodb::agency::envelope envelope)
-    -> arangodb::agency::envelope {
-  auto path = paths::plan()
-                  ->replicatedLogs()
-                  ->database(dbName)
-                  ->log(_id)
-                  ->currentTerm()
-                  ->str();
-
-  return envelope.write()
+void Executor::operator()(CreateInitialTermAction const& action) {
+  envelope.write()
       .emplace_object(
-          path, [&](VPackBuilder& builder) { _term.toVelocyPack(builder); })
+          planPath->currentTerm()->str(),
+          [&](VPackBuilder& builder) { action._term.toVelocyPack(builder); })
+      .inc(paths::plan()->version()->str())
+      .precs()
+      .isEmpty(planPath->currentTerm()->str())
+      .end();
+}
+
+void Executor::operator()(DictateLeaderAction const& action) {
+  envelope.write()
+      .emplace_object(
+          planPath->currentTerm()->str(),
+          [&](VPackBuilder& builder) { action._term.toVelocyPack(builder); })
       .inc(paths::plan()->version()->str())
 
       /* TODO: previous term should still be there
@@ -238,227 +92,142 @@ auto DictateLeaderAction::execute(std::string dbName,
             .isEmpty(path)
        */
       .end();
-
-  return envelope;
 }
 
-void EvictLeaderAction::toVelocyPack(VPackBuilder& builder) const {
-  auto ob = VPackObjectBuilder(&builder);
-  builder.add(VPackValue("type"));
-  builder.add(VPackValue(to_string(type())));
-}
-
-auto EvictLeaderAction::execute(std::string dbName,
-                                arangodb::agency::envelope envelope)
-    -> arangodb::agency::envelope {
-  auto path = paths::plan()->replicatedLogs()->database(dbName)->log(_id);
-
-  return envelope.write()
+void Executor::operator()(EvictLeaderAction const& action) {
+  envelope.write()
       .emplace_object(
-          path->participantsConfig()->participants()->server(_leader)->str(),
-          [&](VPackBuilder& builder) { _flags.toVelocyPack(builder); })
+          planPath->participantsConfig()
+              ->participants()
+              ->server(action._leader)
+              ->str(),
+          [&](VPackBuilder& builder) { action._flags.toVelocyPack(builder); })
       .emplace_object(
-          path->currentTerm()->str(),
-          [&](VPackBuilder& builder) { _newTerm.toVelocyPack(builder); })
-      .inc(path->participantsConfig()->generation()->str())
+          planPath->currentTerm()->str(),
+          [&](VPackBuilder& builder) { action._newTerm.toVelocyPack(builder); })
+      .inc(planPath->participantsConfig()->generation()->str())
       .inc(paths::plan()->version()->str())
       .precs()
-      .isEqual(path->participantsConfig()->generation()->str(), _generation)
+      .isEqual(planPath->participantsConfig()->generation()->str(),
+               action._generation)
       .end();
 }
 
-/*
- * UpdateTermAction
- */
-void UpdateTermAction::toVelocyPack(VPackBuilder& builder) const {
-  auto ob = VPackObjectBuilder(&builder);
-  builder.add(VPackValue("type"));
-  builder.add(VPackValue(to_string(type())));
-
-  builder.add(VPackValue("newTerm"));
-  _newTerm.toVelocyPack(builder);
-}
-
-auto UpdateTermAction::execute(std::string dbName,
-                               arangodb::agency::envelope envelope)
-    -> arangodb::agency::envelope {
-  auto path = paths::plan()
-                  ->replicatedLogs()
-                  ->database(dbName)
-                  ->log(_id)
-                  ->currentTerm()
-                  ->str();
-
-  return envelope.write()
+void Executor::operator()(UpdateTermAction const& action) {
+  envelope.write()
       .emplace_object(
-          path, [&](VPackBuilder& builder) { _newTerm.toVelocyPack(builder); })
+          planPath->currentTerm()->str(),
+          [&](VPackBuilder& builder) { action._newTerm.toVelocyPack(builder); })
       .inc(paths::plan()->version()->str())
       .end();
 }
 
-/*
- * LeaderElectionAction
- */
-void LeaderElectionAction::toVelocyPack(VPackBuilder& builder) const {
-  auto ob = VPackObjectBuilder(&builder);
-  builder.add(VPackValue("type"));
-  builder.add(VPackValue(to_string(type())));
-
-  builder.add(VPackValue("campaign"));
-  _election.toVelocyPack(builder);
-
-  if (_newTerm) {
-    builder.add(VPackValue("newTerm"));
-    _newTerm->toVelocyPack(builder);
-  }
-}
-
-auto LeaderElectionAction::execute(std::string dbName,
-                                   arangodb::agency::envelope envelope)
-    -> arangodb::agency::envelope {
-  auto plan_path = paths::plan()
-                       ->replicatedLogs()
-                       ->database(dbName)
-                       ->log(_id)
-                       ->currentTerm()
-                       ->str();
-  auto current_path = paths::current()
-                          ->replicatedLogs()
-                          ->database(dbName)
-                          ->log(_id)
-                          ->supervision()
-                          ->election()
-                          ->str();
-
-  if (_election.outcome == LogCurrentSupervisionElection::Outcome::SUCCESS) {
-    TRI_ASSERT(_newTerm);
-    return envelope.write()
-        .emplace_object(
-            plan_path,
-            [&](VPackBuilder& builder) { _newTerm->toVelocyPack(builder); })
+void Executor::operator()(LeaderElectionAction const& action) {
+  if (action._election.outcome ==
+      LogCurrentSupervisionElection::Outcome::SUCCESS) {
+    TRI_ASSERT(action._newTerm);
+    envelope.write()
+        .emplace_object(planPath->currentTerm()->str(),
+                        [&](VPackBuilder& builder) {
+                          action._newTerm->toVelocyPack(builder);
+                        })
         .inc(paths::plan()->version()->str())
-        .emplace_object(
-            current_path,
-            [&](VPackBuilder& builder) { _election.toVelocyPack(builder); })
+        .emplace_object(currentPath->supervision()->election()->str(),
+                        [&](VPackBuilder& builder) {
+                          action._election.toVelocyPack(builder);
+                        })
         .inc(paths::current()->version()->str())
         .precs()
         .end();
   } else {
-    return envelope.write()
-        .emplace_object(
-            current_path,
-            [&](VPackBuilder& builder) { _election.toVelocyPack(builder); })
+    envelope.write()
+        .emplace_object(currentPath->supervision()->election()->str(),
+                        [&](VPackBuilder& builder) {
+                          action._election.toVelocyPack(builder);
+                        })
         .inc(paths::current()->version()->str())
         .precs()
         .end();
   }
 }
 
-/*
- * UpdateParticipantFlagsAction
- */
-void UpdateParticipantFlagsAction::toVelocyPack(VPackBuilder& builder) const {
-  auto ob = VPackObjectBuilder(&builder);
-  builder.add(VPackValue("type"));
-  builder.add(VPackValue(to_string(type())));
-
-  builder.add("participant", VPackValue(_participant));
-  builder.add(VPackValue("flags"));
-  _flags.toVelocyPack(builder);
-}
-auto UpdateParticipantFlagsAction::execute(std::string dbName,
-                                           arangodb::agency::envelope envelope)
-    -> arangodb::agency::envelope {
-  auto path = paths::plan()
-                  ->replicatedLogs()
-                  ->database(dbName)
-                  ->log(_id)
-                  ->participantsConfig();
-
-  return envelope.write()
+void Executor::operator()(UpdateParticipantFlagsAction const& action) {
+  envelope.write()
       .emplace_object(
-          path->participants()->server(_participant)->str(),
-          [&](VPackBuilder& builder) { _flags.toVelocyPack(builder); })
-      .inc(path->generation()->str())
+          planPath->participantsConfig()
+              ->participants()
+              ->server(action._participant)
+              ->str(),
+          [&](VPackBuilder& builder) { action._flags.toVelocyPack(builder); })
+      .inc(planPath->participantsConfig()->generation()->str())
       .inc(paths::plan()->version()->str())
       .precs()
-      .isEqual(path->generation()->str(), _generation)
+      .isEqual(planPath->participantsConfig()->generation()->str(),
+               action._generation)
       .end();
 }
 
-/*
- * AddParticipantToPlanAction
- */
-void AddParticipantToPlanAction::toVelocyPack(VPackBuilder& builder) const {
-  auto ob = VPackObjectBuilder(&builder);
-  builder.add(VPackValue("type"));
-  builder.add(VPackValue(to_string(type())));
-}
-auto AddParticipantToPlanAction::execute(std::string dbName,
-                                         arangodb::agency::envelope envelope)
-    -> arangodb::agency::envelope {
-  auto path = paths::plan()
-                  ->replicatedLogs()
-                  ->database(dbName)
-                  ->log(_id)
-                  ->participantsConfig();
-
-  return envelope.write()
+void Executor::operator()(AddParticipantToPlanAction const& action) {
+  envelope.write()
       .emplace_object(
-          path->participants()->server(_participant)->str(),
-          [&](VPackBuilder& builder) { _flags.toVelocyPack(builder); })
-      .inc(path->generation()->str())
+          planPath->participantsConfig()
+              ->participants()
+              ->server(action._participant)
+              ->str(),
+          [&](VPackBuilder& builder) { action._flags.toVelocyPack(builder); })
+      .inc(planPath->participantsConfig()->generation()->str())
       .inc(paths::plan()->version()->str())
       .precs()
-      .isEmpty(path->participants()->server(_participant)->str())
-      .isEqual(path->generation()->str(), _generation)
+      .isEmpty(planPath->participantsConfig()
+                   ->participants()
+                   ->server(action._participant)
+                   ->str())
+      .isEqual(planPath->participantsConfig()->generation()->str(),
+               action._generation)
       .end();
 }
 
-/*
- * RemoveParticipantFromPlanAction
- */
-void RemoveParticipantFromPlanAction::toVelocyPack(
-    VPackBuilder& builder) const {
-  auto ob = VPackObjectBuilder(&builder);
-  builder.add(VPackValue("type"));
-  builder.add(VPackValue(to_string(type())));
-}
-
-auto RemoveParticipantFromPlanAction::execute(
-    std::string dbName, arangodb::agency::envelope envelope)
-    -> arangodb::agency::envelope {
-  auto path = paths::plan()
-                  ->replicatedLogs()
-                  ->database(dbName)
-                  ->log(_id)
-                  ->participantsConfig();
-
-  return envelope.write()
-      .remove(path->participants()->server(_participant)->str())
-      .inc(path->generation()->str())
+void Executor::operator()(RemoveParticipantFromPlanAction const& action) {
+  envelope.write()
+      .remove(planPath->participantsConfig()
+                  ->participants()
+                  ->server(action._participant)
+                  ->str())
+      .inc(planPath->participantsConfig()->generation()->str())
       .inc(paths::plan()->version()->str())
       .precs()
-      .isNotEmpty(path->participants()->server(_participant)->str())
-      .isEqual(path->generation()->str(), _generation)
+      .isNotEmpty(planPath->participantsConfig()
+                      ->participants()
+                      ->server(action._participant)
+                      ->str())
+      .isEqual(planPath->participantsConfig()->generation()->str(),
+               action._generation)
       .end();
 }
 
-/*
- * UpdateLogConfigAction
- */
-void UpdateLogConfigAction::toVelocyPack(VPackBuilder& builder) const {
-  auto ob = VPackObjectBuilder(&builder);
-  builder.add(VPackValue("type"));
-  builder.add(VPackValue(to_string(type())));
-}
-auto UpdateLogConfigAction::execute(std::string dbName,
-                                    arangodb::agency::envelope envelope)
-    -> arangodb::agency::envelope {
+void Executor::operator()(UpdateLogConfigAction const& action) {
   // It is currently undefined what should happen if someone changes
   // the configuration
   TRI_ASSERT(false);
-  return envelope;
+}
+
+auto to_string(Action const& action) -> std::string_view {
+  return std::visit([](auto&& arg) { return arg.name; }, action);
+}
+
+void toVelocyPack(Action const& action, VPackBuilder& builder) {
+  auto ob = VPackObjectBuilder(&builder);
+  builder.add(VPackValue(to_string(action)));
+}
+
+auto execute(Action const& action, DatabaseID const& dbName, LogId const& log,
+             arangodb::agency::envelope envelope)
+    -> arangodb::agency::envelope {
+  auto exec = Executor(dbName, log, std::move(envelope));
+
+  std::visit(exec, action);
+
+  return std::move(exec.envelope);
 }
 
 }  // namespace arangodb::replication2::replicated_log

--- a/arangod/Replication2/ReplicatedLog/SupervisionAction.h
+++ b/arangod/Replication2/ReplicatedLog/SupervisionAction.h
@@ -251,6 +251,7 @@ struct Executor {
 auto execute(Action const& action, DatabaseID const& dbName, LogId const& log,
              arangodb::agency::envelope envelope) -> arangodb::agency::envelope;
 
+auto to_string(Action const& action) -> std::string_view;
 void toVelocyPack(Action const& action, VPackBuilder& builder);
 
 }  // namespace arangodb::replication2::replicated_log

--- a/arangod/Replication2/ReplicatedLog/SupervisionAction.h
+++ b/arangod/Replication2/ReplicatedLog/SupervisionAction.h
@@ -26,135 +26,68 @@
 #include "velocypack/velocypack-common.h"
 
 #include "Agency/TransactionBuilder.h"
-#include "Replication2/ReplicatedLog/LogCommon.h"
 #include "Replication2/ReplicatedLog/AgencyLogSpecification.h"
+#include "Replication2/ReplicatedLog/LogCommon.h"
 
 using namespace arangodb::replication2::agency;
 
 namespace arangodb::replication2::replicated_log {
 
-struct Action {
-  enum class ActionType {
-    EmptyAction,
-    ErrorAction,
-    AddLogToPlanAction,
-    AddParticipantsToTargetAction,
-    CreateInitialTermAction,
-    UpdateTermAction,
-    DictateLeaderAction,
-    EvictLeaderAction,
-    LeaderElectionAction,
-    UpdateParticipantFlagsAction,
-    AddParticipantToPlanAction,
-    RemoveParticipantFromPlanAction,
-    UpdateLogConfigAction,
-  };
-  virtual auto execute(std::string dbName, arangodb::agency::envelope envelope)
-      -> arangodb::agency::envelope = 0;
+struct EmptyAction {
+  static constexpr std::string_view name = "EmptyAction";
 
-  virtual ActionType type() const = 0;
-  virtual void toVelocyPack(VPackBuilder& builder) const = 0;
-  virtual ~Action() = default;
-};
-
-auto to_string(Action::ActionType action) -> std::string_view;
-auto operator<<(std::ostream& os, Action::ActionType const& action)
-    -> std::ostream&;
-auto operator<<(std::ostream& os, Action const& action) -> std::ostream&;
-
-// Empty Action
-// TODO: we currently use a mix of nullptr and EmptyAction; should only use one
-// of them.
-struct EmptyAction : Action {
   EmptyAction() : _message(""){};
   EmptyAction(std::string_view message) : _message(message){};
-  auto execute(std::string dbName, arangodb::agency::envelope envelope)
-      -> arangodb::agency::envelope override {
-    return envelope;
-  };
-  ActionType type() const override { return Action::ActionType::EmptyAction; };
-  void toVelocyPack(VPackBuilder& builder) const override;
-
   std::string _message;
 };
-auto to_string(EmptyAction action) -> std::string;
-auto operator<<(std::ostream& os, EmptyAction const& action) -> std::ostream&;
 
-struct ErrorAction : Action {
+struct ErrorAction {
+  static constexpr std::string_view name = "ErrorAction";
+
   ErrorAction(LogId const& id, LogCurrentSupervisionError const& error)
       : _id{id}, _error{error} {};
-  auto execute(std::string dbName, arangodb::agency::envelope envelope)
-      -> arangodb::agency::envelope override;
-  ActionType type() const override { return Action::ActionType::ErrorAction; };
-  void toVelocyPack(VPackBuilder& builder) const override;
 
   LogId _id;
   LogCurrentSupervisionError _error;
 };
-auto to_string(ErrorAction action) -> std::string;
-auto operator<<(std::ostream& os, ErrorAction const& action) -> std::ostream&;
 
-// AddLogToPlanAction
-struct AddLogToPlanAction : Action {
+struct AddLogToPlanAction {
+  static constexpr std::string_view name = "AddLogToPlanAction";
+
   AddLogToPlanAction(LogPlanSpecification const& spec) : _spec(spec){};
-  auto execute(std::string dbName, arangodb::agency::envelope envelope)
-      -> arangodb::agency::envelope override;
-  ActionType type() const override {
-    return Action::ActionType::AddLogToPlanAction;
-  };
-  void toVelocyPack(VPackBuilder& builder) const override;
-
   LogPlanSpecification const _spec;
 };
-auto to_string(AddLogToPlanAction const& action) -> std::string;
-auto operator<<(std::ostream& os, AddLogToPlanAction const& action)
-    -> std::ostream&;
 
-// AddParticipantsToTarget
-struct AddParticipantsToTargetAction : Action {
+struct AddParticipantsToTargetAction {
+  static constexpr std::string_view name = "AddParticipantsToTargetAction";
+
   AddParticipantsToTargetAction(LogTarget const& spec) : _spec(spec){};
-  auto execute(std::string dbName, arangodb::agency::envelope envelope)
-      -> arangodb::agency::envelope override;
-  ActionType type() const override {
-    return Action::ActionType::AddParticipantsToTargetAction;
-  };
-  void toVelocyPack(VPackBuilder& builder) const override;
-
   LogTarget const _spec;
 };
-auto to_string(AddParticipantsToTargetAction const& action) -> std::string;
-auto operator<<(std::ostream& os, AddParticipantsToTargetAction const& action)
-    -> std::ostream&;
 
-struct CreateInitialTermAction : Action {
+struct CreateInitialTermAction {
+  static constexpr std::string_view name = "CreateIntialTermAction";
+
   CreateInitialTermAction(LogId id, LogPlanTermSpecification const& term)
       : _id(id), _term(term){};
-  auto execute(std::string dbName, arangodb::agency::envelope envelope)
-      -> arangodb::agency::envelope override;
-  ActionType type() const override {
-    return Action::ActionType::CreateInitialTermAction;
-  };
-  void toVelocyPack(VPackBuilder& builder) const override;
 
   LogId const _id;
   LogPlanTermSpecification const _term;
 };
 
-struct DictateLeaderAction : Action {
+struct DictateLeaderAction {
+  static constexpr std::string_view name = "DictateLeaderAction";
+
   DictateLeaderAction(LogId const& id, LogPlanTermSpecification const& newTerm)
       : _id(id), _term{newTerm} {};
-  auto execute(std::string dbName, arangodb::agency::envelope envelope)
-      -> arangodb::agency::envelope override;
-  ActionType type() const override {
-    return Action::ActionType::DictateLeaderAction;
-  };
-  void toVelocyPack(VPackBuilder& builder) const override;
 
   LogId const _id;
   LogPlanTermSpecification _term;
 };
 
-struct EvictLeaderAction : Action {
+struct EvictLeaderAction {
+  static constexpr std::string_view name = "EvictLeaderAction";
+
   EvictLeaderAction(LogId const& id, ParticipantId const& leader,
                     ParticipantFlags const& flags,
                     LogPlanTermSpecification const& newTerm,
@@ -164,12 +97,6 @@ struct EvictLeaderAction : Action {
         _flags{flags},
         _newTerm{newTerm},
         _generation{generation} {};
-  auto execute(std::string dbName, arangodb::agency::envelope envelope)
-      -> arangodb::agency::envelope override;
-  ActionType type() const override {
-    return Action::ActionType::EvictLeaderAction;
-  };
-  void toVelocyPack(VPackBuilder& builder) const override;
 
   LogId const _id;
   ParticipantId _leader;
@@ -178,46 +105,33 @@ struct EvictLeaderAction : Action {
   std::size_t _generation;
 };
 
-struct UpdateTermAction : Action {
+struct UpdateTermAction {
+  static constexpr std::string_view name = "UpdateTermAction";
+
   UpdateTermAction(LogId const& id, LogPlanTermSpecification const& newTerm)
       : _id{id}, _newTerm(newTerm){};
-  auto execute(std::string dbName, arangodb::agency::envelope envelope)
-      -> arangodb::agency::envelope override;
-  ActionType type() const override {
-    return Action::ActionType::UpdateTermAction;
-  };
-  void toVelocyPack(VPackBuilder& builder) const override;
 
   LogId const _id;
   LogPlanTermSpecification _newTerm;
 };
 
-auto to_string(UpdateTermAction action) -> std::string;
-auto operator<<(std::ostream& os, UpdateTermAction const& action)
-    -> std::ostream&;
+struct LeaderElectionAction {
+  static constexpr std::string_view name = "LeaderElectionAction";
 
-struct LeaderElectionAction : Action {
   LeaderElectionAction(LogId id, LogCurrentSupervisionElection const& election)
       : _id(id), _election{election}, _newTerm{std::nullopt} {};
   LeaderElectionAction(LogId id, LogCurrentSupervisionElection const& election,
                        LogPlanTermSpecification newTerm)
       : _id(id), _election{election}, _newTerm{newTerm} {};
-  auto execute(std::string dbName, arangodb::agency::envelope envelope)
-      -> arangodb::agency::envelope override;
-  ActionType type() const override {
-    return Action::ActionType::LeaderElectionAction;
-  };
-  void toVelocyPack(VPackBuilder& builder) const override;
 
   LogId const _id;
   LogCurrentSupervisionElection _election;
   std::optional<LogPlanTermSpecification> _newTerm;
 };
-auto to_string(LeaderElectionAction action) -> std::string;
-auto operator<<(std::ostream& os, LeaderElectionAction const& action)
-    -> std::ostream&;
 
-struct UpdateParticipantFlagsAction : Action {
+struct UpdateParticipantFlagsAction {
+  static constexpr std::string_view name = "UpdateParticipantFlagsAction";
+
   UpdateParticipantFlagsAction(LogId id, ParticipantId const& participant,
                                ParticipantFlags const& flags,
                                std::size_t generation)
@@ -225,13 +139,6 @@ struct UpdateParticipantFlagsAction : Action {
         _participant(participant),
         _flags(flags),
         _generation{generation} {};
-  ActionType type() const override {
-    return Action::ActionType::UpdateParticipantFlagsAction;
-  };
-
-  auto execute(std::string dbName, arangodb::agency::envelope envelope)
-      -> arangodb::agency::envelope override;
-  void toVelocyPack(VPackBuilder& builder) const override;
 
   LogId const _id;
   ParticipantId _participant;
@@ -239,7 +146,9 @@ struct UpdateParticipantFlagsAction : Action {
   std::size_t _generation;
 };
 
-struct AddParticipantToPlanAction : Action {
+struct AddParticipantToPlanAction {
+  static constexpr std::string_view name = "AddParticipantToPlanAction";
+
   AddParticipantToPlanAction(LogId id, ParticipantId const& participant,
                              ParticipantFlags const& flags,
                              std::size_t generation)
@@ -247,13 +156,6 @@ struct AddParticipantToPlanAction : Action {
         _participant(participant),
         _flags(flags),
         _generation{generation} {};
-  ActionType type() const override {
-    return Action::ActionType::AddParticipantToPlanAction;
-  };
-
-  auto execute(std::string dbName, arangodb::agency::envelope envelope)
-      -> arangodb::agency::envelope override;
-  void toVelocyPack(VPackBuilder& builder) const override;
 
   LogId const _id;
   ParticipantId _participant;
@@ -261,37 +163,94 @@ struct AddParticipantToPlanAction : Action {
   std::size_t _generation;
 };
 
-struct RemoveParticipantFromPlanAction : Action {
+struct RemoveParticipantFromPlanAction {
+  static constexpr std::string_view name = "RemoveParticipantFromPlanAction";
+
   RemoveParticipantFromPlanAction(LogId const& id,
                                   ParticipantId const& participant,
                                   std::size_t generation)
       : _id{id}, _participant(participant), _generation{generation} {};
-  ActionType type() const override {
-    return Action::ActionType::RemoveParticipantFromPlanAction;
-  };
-
-  auto execute(std::string dbName, arangodb::agency::envelope envelope)
-      -> arangodb::agency::envelope override;
-  void toVelocyPack(VPackBuilder& builder) const override;
 
   LogId const _id;
   ParticipantId _participant;
   std::size_t _generation;
 };
 
-struct UpdateLogConfigAction : Action {
+struct UpdateLogConfigAction {
+  static constexpr std::string_view name = "UpdateLogConfigAction";
+
   UpdateLogConfigAction(LogId const& id, LogConfig const& config)
       : _id(id), _config(config){};
-  ActionType type() const override {
-    return Action::ActionType::UpdateLogConfigAction;
-  };
-
-  auto execute(std::string dbName, arangodb::agency::envelope envelope)
-      -> arangodb::agency::envelope override;
-  void toVelocyPack(VPackBuilder& builder) const override;
 
   LogId const _id;
   LogConfig _config;
 };
+
+using Action =
+    std::variant<EmptyAction, ErrorAction, AddLogToPlanAction,
+                 AddParticipantsToTargetAction, CreateInitialTermAction,
+                 DictateLeaderAction, EvictLeaderAction, UpdateTermAction,
+                 LeaderElectionAction, UpdateParticipantFlagsAction,
+                 AddParticipantToPlanAction, RemoveParticipantFromPlanAction,
+                 UpdateLogConfigAction>;
+
+using namespace arangodb::cluster::paths;
+
+/*
+ * Execute a SupervisionAction
+ */
+struct Executor {
+  explicit Executor(DatabaseID const& dbName, LogId const& log,
+                    arangodb::agency::envelope envelope)
+      : dbName{dbName},
+        log{log},
+        envelope{std::move(envelope)},
+        targetPath{
+            root()->arango()->target()->replicatedLogs()->database(dbName)->log(
+                log)},
+        planPath{
+            root()->arango()->plan()->replicatedLogs()->database(dbName)->log(
+                log)},
+        currentPath{root()
+                        ->arango()
+                        ->current()
+                        ->replicatedLogs()
+                        ->database(dbName)
+                        ->log(log)}
+
+        {};
+
+  DatabaseID dbName;
+  LogId log;
+  arangodb::agency::envelope envelope;
+
+  std::shared_ptr<Root::Arango::Target::ReplicatedLogs::Database::Log const>
+      targetPath;
+  std::shared_ptr<Root::Arango::Plan::ReplicatedLogs::Database::Log const>
+      planPath;
+  std::shared_ptr<Root::Arango::Current::ReplicatedLogs::Database::Log const>
+      currentPath;
+
+  std::shared_ptr<Root::Arango::Plan::Version const> planVersionPath;
+
+  void operator()(EmptyAction const& action);
+  void operator()(ErrorAction const& action);
+  void operator()(AddLogToPlanAction const& action);
+  void operator()(AddParticipantsToTargetAction const& action);
+  void operator()(CreateInitialTermAction const& action);
+  void operator()(DictateLeaderAction const& action);
+  void operator()(EvictLeaderAction const& action);
+  void operator()(UpdateTermAction const& action);
+  void operator()(LeaderElectionAction const& action);
+  void operator()(UpdateParticipantFlagsAction const& action);
+  void operator()(AddParticipantToPlanAction const& action);
+  void operator()(RemoveParticipantFromPlanAction const& action);
+  void operator()(UpdateLogConfigAction const& action);
+};
+
+auto execute(Action const& action, DatabaseID const& dbName, LogId const& log,
+             arangodb::agency::envelope envelope) -> arangodb::agency::envelope;
+
+void toVelocyPack(Action const& action, VPackBuilder& builder);
 
 }  // namespace arangodb::replication2::replicated_log

--- a/tests/js/server/replication2/replication2-supervision-replicated-log-target-cluster.js
+++ b/tests/js/server/replication2/replication2-supervision-replicated-log-target-cluster.js
@@ -273,7 +273,7 @@ const replicatedLogSuite = function () {
         //  3. update participant flags with leader.forced = false
         {
           const action = _.nth(actions, -3).desc;
-          assertEqual(action.type, 'UpdateParticipantFlags');
+          assertEqual(action.type, 'UpdateParticipantFlagsAction');
           assertEqual(action.participant, newLeader);
           assertEqual(action.flags, {excluded: false, forced: true});
         }
@@ -284,7 +284,7 @@ const replicatedLogSuite = function () {
         }
         {
           const action = _.nth(actions, -1).desc;
-          assertEqual(action.type, 'UpdateParticipantFlags');
+          assertEqual(action.type, 'UpdateParticipantFlagsAction');
           assertEqual(action.participant, newLeader);
           assertEqual(action.flags, {excluded: false, forced: false});
         }


### PR DESCRIPTION
### Scope & Purpose

This is the first half of #15830 

The rationale behind doing the refactor in two steps is to make sure we break less code on the way, hence making debugging easier (ideally not necessary).

This half refactors SupervisionActions into a variant of simple structs which can be `std::visit`ed using an (also fairly simple) `Exectutor` struct, which itlsef encapsulates some information that was previously assembled manually, such as the path-prefix that is used for writing into the agency.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [x] Tests
  - [ ] **Regression tests**
  - [x] C++ **Unit tests**
  - [x] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*
  - [ ] Backport for 3.7: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

