### PR TITLE
less copying of repeatedly used bind parameter values

### DIFF
--- a/arangod/Aql/Ast.cpp
+++ b/arangod/Aql/Ast.cpp
@@ -46,6 +46,7 @@
 #include "Basics/tryEmplaceHelper.h"
 #include "Cluster/ClusterFeature.h"
 #include "Cluster/ClusterInfo.h"
+#include "Containers/FlatHashSet.h"
 #include "Containers/SmallVector.h"
 #include "Graph/Graph.h"
 #include "RestServer/DatabaseFeature.h"
@@ -1795,7 +1796,7 @@ void Ast::injectBindParameters(
                                 param);
         }
 
-        VPackSlice value = parameters.markUsed(param);
+        auto [value, cachedNode] = parameters.get(param);
         if (value.isNone()) {
           // query uses a bind parameter that was not defined by the user
           ::throwFormattedError(_query, TRI_ERROR_QUERY_BIND_PARAMETER_MISSING,
@@ -1804,23 +1805,45 @@ void Ast::injectBindParameters(
 
         if (node->type == NODE_TYPE_PARAMETER) {
           auto const constantParameter = node->isConstant();
-          // bind parameter containing a value literal
-          node = nodeFromVPack(value, true);
 
-          if (node != nullptr) {
+          if (cachedNode != nullptr) {
+            // we have already processed this bind parameter and turned it into
+            // an AstNode before.
+            // now only create a shallow copy of the bind parameter.
+            node = shallowCopyForModify(cachedNode);
+
             if (constantParameter) {
-              // already mark node as constant here if parameters are constant
-              node->setFlag(DETERMINED_CONSTANT, VALUE_CONSTANT);
+              TRI_ASSERT(node->hasFlag(DETERMINED_CONSTANT));
+              TRI_ASSERT(node->hasFlag(VALUE_CONSTANT));
             }
-            // mark node as simple
-            node->setFlag(DETERMINED_SIMPLE, VALUE_SIMPLE);
-            // mark node as executable on db-server
-            node->setFlag(DETERMINED_RUNONDBSERVER, VALUE_RUNONDBSERVER);
-            // mark node as deterministic
-            node->setFlag(DETERMINED_NONDETERMINISTIC);
+            TRI_ASSERT(node->hasFlag(DETERMINED_SIMPLE));
+            TRI_ASSERT(node->hasFlag(VALUE_SIMPLE));
+            TRI_ASSERT(node->hasFlag(DETERMINED_RUNONDBSERVER));
+            TRI_ASSERT(node->hasFlag(VALUE_RUNONDBSERVER));
+            TRI_ASSERT(node->hasFlag(DETERMINED_NONDETERMINISTIC));
+            TRI_ASSERT(!node->hasFlag(VALUE_NONDETERMINISTIC));
+            TRI_ASSERT(node->hasFlag(FLAG_BIND_PARAMETER));
+          } else {
+            // bind parameter containing a value literal. not processed before.
+            node = nodeFromVPack(value, true);
 
-            // finally note that the node was created from a bind parameter
-            node->setFlag(FLAG_BIND_PARAMETER);
+            if (node != nullptr) {
+              if (constantParameter) {
+                // already mark node as constant here if parameters are constant
+                node->setFlag(DETERMINED_CONSTANT, VALUE_CONSTANT);
+              }
+              // mark node as simple
+              node->setFlag(DETERMINED_SIMPLE, VALUE_SIMPLE);
+              // mark node as executable on db-server
+              node->setFlag(DETERMINED_RUNONDBSERVER, VALUE_RUNONDBSERVER);
+              // mark node as deterministic
+              node->setFlag(DETERMINED_NONDETERMINISTIC);
+
+              // finally note that the node was created from a bind parameter
+              node->setFlag(FLAG_BIND_PARAMETER);
+
+              parameters.registerNode(param, node);
+            }
           }
         } else {
           TRI_ASSERT(node->type == NODE_TYPE_PARAMETER_DATASOURCE);
@@ -1888,6 +1911,10 @@ void Ast::injectBindParameters(
             }
           }
           node = newNode;
+
+          if (cachedNode == nullptr) {
+            parameters.registerNode(param, node);
+          }
         }
       } else if (node->type == NODE_TYPE_BOUND_ATTRIBUTE_ACCESS) {
         // look at second sub-node. this is the (replaced) bind parameter
@@ -1980,13 +2007,15 @@ void Ast::injectBindParameters(
     }
   }
 
-  // visit all bind parameters to ensure that they are all marked as used
-  parameters.visit([](std::string const& key, VPackSlice /*value*/, bool used) {
-    if (!used) {
-      THROW_ARANGO_EXCEPTION_PARAMS(TRI_ERROR_QUERY_BIND_PARAMETER_UNDECLARED,
-                                    key.c_str());
-    }
-  });
+  // visit all bind parameters to ensure that they have all been accessed via
+  // registerNode
+  parameters.visit(
+      [](std::string const& key, VPackSlice /*value*/, AstNode* node) {
+        if (node == nullptr) {
+          THROW_ARANGO_EXCEPTION_PARAMS(
+              TRI_ERROR_QUERY_BIND_PARAMETER_UNDECLARED, key.c_str());
+        }
+      });
 }
 
 /// @brief replace an attribute access with just the variable
@@ -2191,6 +2220,8 @@ void Ast::validateAndOptimize(transaction::Methods& trx) {
     } else if (node->type == NODE_TYPE_SUBQUERY) {
       ++ctx->nestingLevel;
     } else if (node->hasFlag(FLAG_BIND_PARAMETER)) {
+      // don't traverse deeper into values that were created
+      // from a bind parameter
       return false;
     } else if (node->type == NODE_TYPE_REMOVE ||
                node->type == NODE_TYPE_INSERT ||
@@ -2206,6 +2237,11 @@ void Ast::validateAndOptimize(transaction::Methods& trx) {
       return false;
     } else if (node->type == NODE_TYPE_ARRAY && node->isConstant()) {
       // nothing to be done in constant arrays
+      return false;
+    } else if (node->type == NODE_TYPE_OBJECT && node->isConstant() &&
+               node->hasFlag(DETERMINED_CHECKUNIQUENESS) &&
+               !node->hasFlag(VALUE_CHECKUNIQUENESS)) {
+      // nothing to be done in constant objects with known-to-be-unique keys
       return false;
     }
 
@@ -2758,6 +2794,12 @@ AstNode* Ast::clone(AstNode const* node) {
   if (type == NODE_TYPE_NOP) {
     // nop node is a singleton
     return const_cast<AstNode*>(node);
+  }
+
+  if (node->hasFlag(FLAG_BIND_PARAMETER)) {
+    // use a simplified (i.e. fast) shallow cloning for values
+    // originally created from bind parameters
+    return shallowCopyForModify(node);
   }
 
   AstNode* copy = createNode(type);
@@ -3727,29 +3769,25 @@ AstNode* Ast::optimizeObject(AstNode* node) {
   size_t const n = node->numMembers();
 
   // only useful to check when there are 2 or more keys
-  if (n < 2) {
-    // no need to check for uniqueless later
-    node->setFlag(DETERMINED_CHECKUNIQUENESS);
-    return node;
-  }
+  if (n >= 2) {
+    containers::FlatHashSet<std::string> keys;
 
-  std::unordered_set<std::string> keys;
+    for (size_t i = 0; i < n; ++i) {
+      auto member = node->getMemberUnchecked(i);
 
-  for (size_t i = 0; i < n; ++i) {
-    auto member = node->getMemberUnchecked(i);
-
-    if (member->type == NODE_TYPE_OBJECT_ELEMENT) {
-      // constant key
-      if (!keys.emplace(member->getString()).second) {
-        // duplicate key
+      if (member->type == NODE_TYPE_OBJECT_ELEMENT) {
+        // constant key
+        if (!keys.emplace(member->getString()).second) {
+          // duplicate key
+          node->setFlag(DETERMINED_CHECKUNIQUENESS, VALUE_CHECKUNIQUENESS);
+          return node;
+        }
+      } else if (member->type == NODE_TYPE_CALCULATED_OBJECT_ELEMENT) {
+        // dynamic key... we don't know the key yet, so there's no
+        // way around check it at runtime later
         node->setFlag(DETERMINED_CHECKUNIQUENESS, VALUE_CHECKUNIQUENESS);
         return node;
       }
-    } else if (member->type == NODE_TYPE_CALCULATED_OBJECT_ELEMENT) {
-      // dynamic key... we don't know the key yet, so there's no
-      // way around check it at runtime later
-      node->setFlag(DETERMINED_CHECKUNIQUENESS, VALUE_CHECKUNIQUENESS);
-      return node;
     }
   }
 

--- a/arangod/Aql/Ast.cpp
+++ b/arangod/Aql/Ast.cpp
@@ -1930,6 +1930,12 @@ void Ast::injectBindParameters(
             // "unused bind parameter
             // '@...' later.
             parameters.registerNode(param, node);
+          } else {
+            // double check that the already registered node has the correct
+            // type
+            TRI_ASSERT(cachedNode->type == NODE_TYPE_VIEW ||
+                       cachedNode->type == NODE_TYPE_COLLECTION);
+            TRI_ASSERT(cachedNode->getStringView() == name);
           }
         }
       } else if (node->type == NODE_TYPE_BOUND_ATTRIBUTE_ACCESS) {

--- a/arangod/Aql/AstNode.h
+++ b/arangod/Aql/AstNode.h
@@ -583,8 +583,8 @@ struct AstNode {
   void computeValue(arangodb::velocypack::Builder& builder) const;
   void freeComputedValue() noexcept;
 
-  /// @brief stringify the value of a node into a string buffer
-  /// this method is used when generated JavaScript code for the node!
+  /// @brief stringify the value of a node into a string buffer.
+  /// this method is used when generating JavaScript code for the node!
   /// this creates an equivalent to what JSON.stringify() would do
   void appendValue(std::string& buffer) const;
 

--- a/arangod/Aql/BindParameters.cpp
+++ b/arangod/Aql/BindParameters.cpp
@@ -66,8 +66,10 @@ uint64_t BindParameters::hash() const {
   return _builder->slice().hash();
 }
 
-/// @brief return a bind parameter value by name
-/// will return VPackSlice::noneSlice() if the bind parameter does not exist!
+/// @brief return a bind parameter value and its corresponding AstNode by
+/// parameter name. will return VPackSlice::noneSlice() if the bind parameter
+/// does not exist. the returned AstNode is a nullptr in case no AstNode was yet
+/// registered for this bind parameter. This is not an error.
 std::pair<VPackSlice, AstNode*> BindParameters::get(
     std::string const& name) const noexcept {
   TRI_ASSERT(_processed);
@@ -79,7 +81,7 @@ std::pair<VPackSlice, AstNode*> BindParameters::get(
 
   // return parameter value and AstNode
   TRI_ASSERT(!(*it).second.first.isNone());
-  return std::make_pair((*it).second.first, (*it).second.second);
+  return (*it).second;
 }
 
 /// @brief register an AstNode for the bind parameter

--- a/arangod/Aql/BindParameters.cpp
+++ b/arangod/Aql/BindParameters.cpp
@@ -22,6 +22,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #include "Aql/BindParameters.h"
+#include "Aql/AstNode.h"
 #include "Basics/Exceptions.h"
 #include "Basics/ResourceUsage.h"
 #include "Basics/debugging.h"
@@ -65,28 +66,42 @@ uint64_t BindParameters::hash() const {
   return _builder->slice().hash();
 }
 
-/// @brief mark a bind parameter as "used", and return its value.
+/// @brief return a bind parameter value by name
 /// will return VPackSlice::noneSlice() if the bind parameter does not exist!
-VPackSlice BindParameters::markUsed(std::string const& name) noexcept {
+std::pair<VPackSlice, AstNode*> BindParameters::get(
+    std::string const& name) const noexcept {
   TRI_ASSERT(_processed);
 
   auto it = _parameters.find(name);
   if (it == _parameters.end()) {
-    return VPackSlice::noneSlice();
+    return std::make_pair(VPackSlice::noneSlice(), nullptr);
   }
 
-  // mark the bind parameter as being used
-  (*it).second.second = true;
-
-  // return parameter value
+  // return parameter value and AstNode
   TRI_ASSERT(!(*it).second.first.isNone());
-  return (*it).second.first;
+  return std::make_pair((*it).second.first, (*it).second.second);
+}
+
+/// @brief register an AstNode for the bind parameter
+void BindParameters::registerNode(std::string const& name, AstNode* node) {
+  TRI_ASSERT(_processed);
+
+  auto it = _parameters.find(name);
+  if (it == _parameters.end()) {
+    THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_INTERNAL,
+                                   "invalid bind parameter access");
+  }
+
+  TRI_ASSERT(!(*it).second.first.isNone());
+  // no node must have been registered before
+  TRI_ASSERT((*it).second.second == nullptr);
+  (*it).second.second = node;
 }
 
 /// @brief run a visitor function on all bind parameters
 void BindParameters::visit(
     std::function<void(std::string const& key,
-                       arangodb::velocypack::Slice value, bool used)> const&
+                       arangodb::velocypack::Slice value, AstNode* node)> const&
         visitor) const {
   for (auto const& it : _parameters) {
     visitor(it.first, it.second.first, it.second.second);
@@ -154,7 +169,7 @@ void BindParameters::process() {
                                     key.c_str());
     }
 
-    if (key[0] == '@' && !value.isString()) {
+    if (!key.empty() && key[0] == '@' && !value.isString()) {
       // collection bind parameter
       THROW_ARANGO_EXCEPTION_PARAMS(TRI_ERROR_QUERY_BIND_PARAMETER_TYPE,
                                     key.c_str());
@@ -162,7 +177,7 @@ void BindParameters::process() {
 
     ResourceUsageScope guard(_resourceMonitor, memoryUsage(key, value));
 
-    _parameters.try_emplace(std::move(key), value, false);
+    _parameters.try_emplace(std::move(key), value, nullptr);
 
     // now we are responsible for tracking the memory usage
     guard.steal();

--- a/arangod/Aql/BindParameters.h
+++ b/arangod/Aql/BindParameters.h
@@ -39,9 +39,10 @@ namespace velocypack {
 class Builder;
 }
 namespace aql {
+struct AstNode;
 
 typedef std::unordered_map<std::string,
-                           std::pair<arangodb::velocypack::Slice, bool>>
+                           std::pair<arangodb::velocypack::Slice, AstNode*>>
     BindParametersType;
 
 class BindParameters {
@@ -59,14 +60,18 @@ class BindParameters {
   /// @brief destroy the parameters
   ~BindParameters();
 
-  /// @brief mark a bind parameter as "used", and return its value.
+  /// @brief return a bind parameter value by name
   /// will return VPackSlice::noneSlice() if the bind parameter does not exist!
-  arangodb::velocypack::Slice markUsed(std::string const& name) noexcept;
+  std::pair<arangodb::velocypack::Slice, AstNode*> get(
+      std::string const& name) const noexcept;
+
+  /// @brief register an AstNode for the bind parameter
+  void registerNode(std::string const& name, AstNode* node);
 
   /// @brief run a visitor function on all bind parameters
   void visit(std::function<void(std::string const& key,
                                 arangodb::velocypack::Slice value,
-                                bool used)> const& visitor) const;
+                                AstNode* node)> const& visitor) const;
 
   /// @brief return the bind parameters as passed by the user
   std::shared_ptr<arangodb::velocypack::Builder> builder() const;
@@ -74,7 +79,7 @@ class BindParameters {
   /// @brief create a hash value for the bind parameters
   uint64_t hash() const;
 
-  /// @brief strip collection name prefixes from the parameters
+  /// @brief strip collection name prefixes from the parameters.
   /// the values must be a VelocyPack array
   static void stripCollectionNames(arangodb::velocypack::Slice keys,
                                    std::string const& collectionName,
@@ -88,13 +93,12 @@ class BindParameters {
   std::size_t memoryUsage(std::string const& key,
                           arangodb::velocypack::Slice value) const noexcept;
 
- private:
   arangodb::ResourceMonitor& _resourceMonitor;
 
-  /// @brief the parameter values
+  /// @brief the parameter values memory
   std::shared_ptr<arangodb::velocypack::Builder> _builder;
 
-  /// @brief pointer to collection parameters
+  /// @brief bind parameters map, indexed by name
   BindParametersType _parameters;
 
   /// @brief internal state

--- a/arangod/Aql/BindParameters.h
+++ b/arangod/Aql/BindParameters.h
@@ -60,8 +60,10 @@ class BindParameters {
   /// @brief destroy the parameters
   ~BindParameters();
 
-  /// @brief return a bind parameter value by name
-  /// will return VPackSlice::noneSlice() if the bind parameter does not exist!
+  /// @brief return a bind parameter value and its corresponding AstNode by
+  /// parameter name. will return VPackSlice::noneSlice() if the bind parameter
+  /// does not exist. the returned AstNode is a nullptr in case no AstNode was
+  /// yet registered for this bind parameter. This is not an error.
   std::pair<arangodb::velocypack::Slice, AstNode*> get(
       std::string const& name) const noexcept;
 


### PR DESCRIPTION
### Scope & Purpose

Less copying of repeatedly used bind parameter values in AQL queries.
This reduces memory overhead for queries that access large bind parameter values (large arrays or objects) via repeatedly refering to them by name (e.g. `FOR doc IN collection FILTER doc.value == CONCAT(@largeBind['foo'], @largeBind['bar'], @largeBind[...], ...`).
The bind parameter values are only once converted into an AstNode per query, and from the on only shallow-cloned when accessed.
In some example query this decreased memory usage by 99%.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [x] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*
  - [ ] Backport for 3.7: *(Please link PR)*

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 