### PR TITLE
fix compile error in non-maintainer mode on AppleClang

### DIFF
--- a/arangod/Transaction/Methods.cpp
+++ b/arangod/Transaction/Methods.cpp
@@ -1073,7 +1073,7 @@ Future<OperationResult> transaction::Methods::insertLocal(
   ManagedDocumentResult docResult;
   ManagedDocumentResult prevDocResult;  // return OLD (with override option)
 
-  size_t numExclusions = 0;
+  [[maybe_unused]] size_t numExclusions = 0;
 
   auto workForOneDocument = [&](VPackSlice value, bool isBabies,
                                 bool& excludeFromReplication) -> Result {
@@ -1161,7 +1161,10 @@ Future<OperationResult> transaction::Methods::insertLocal(
         // replication!
         excludeFromReplication = true;
 
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
         numExclusions++;
+#endif
+
         return res;
       }
 
@@ -1172,7 +1175,10 @@ Future<OperationResult> transaction::Methods::insertLocal(
             collection->update(this, value, docResult, options, prevDocResult);
         if (res.ok() && prevDocResult.revisionId() == docResult.revisionId()) {
           excludeFromReplication = true;
+
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
           numExclusions++;
+#endif
         }
       } else if (options.overwriteMode ==
                  OperationOptions::OverwriteMode::Replace) {
@@ -1272,7 +1278,9 @@ Future<OperationResult> transaction::Methods::insertLocal(
   TRI_ASSERT(!value.isArray() || options.silent ||
              resultBuilder.slice().length() == value.length());
 
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   TRI_ASSERT(numExclusions == excludePositions.size());
+#endif
 
   std::shared_ptr<VPackBufferUInt8> resDocs = resultBuilder.steal();
   if (res.ok()) {
@@ -1472,10 +1480,8 @@ Future<OperationResult> transaction::Methods::modifyLocal(
   [[maybe_unused]] size_t numExclusions = 0;
 
   // lambda //////////////
-  auto workForOneDocument = [this, &numExclusions, &operation, &options,
-                             &collection, &resultBuilder, &cid, &previous,
-                             &result](VPackSlice const newVal, bool isBabies,
-                                      bool& excludeFromReplication) -> Result {
+  auto workForOneDocument = [&](VPackSlice newVal, bool isBabies,
+                                bool& excludeFromReplication) -> Result {
     Result res;
     if (!newVal.isObject()) {
       res.reset(TRI_ERROR_ARANGO_DOCUMENT_TYPE_INVALID);

--- a/arangod/Transaction/Methods.cpp
+++ b/arangod/Transaction/Methods.cpp
@@ -1073,7 +1073,7 @@ Future<OperationResult> transaction::Methods::insertLocal(
   ManagedDocumentResult docResult;
   ManagedDocumentResult prevDocResult;  // return OLD (with override option)
 
-  [[maybe_unused]] size_t numExclusions = 0;
+  size_t numExclusions = 0;
 
   auto workForOneDocument = [&](VPackSlice value, bool isBabies,
                                 bool& excludeFromReplication) -> Result {
@@ -1161,10 +1161,7 @@ Future<OperationResult> transaction::Methods::insertLocal(
         // replication!
         excludeFromReplication = true;
 
-#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
         numExclusions++;
-#endif
-
         return res;
       }
 
@@ -1175,10 +1172,7 @@ Future<OperationResult> transaction::Methods::insertLocal(
             collection->update(this, value, docResult, options, prevDocResult);
         if (res.ok() && prevDocResult.revisionId() == docResult.revisionId()) {
           excludeFromReplication = true;
-
-#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
           numExclusions++;
-#endif
         }
       } else if (options.overwriteMode ==
                  OperationOptions::OverwriteMode::Replace) {
@@ -1278,9 +1272,7 @@ Future<OperationResult> transaction::Methods::insertLocal(
   TRI_ASSERT(!value.isArray() || options.silent ||
              resultBuilder.slice().length() == value.length());
 
-#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   TRI_ASSERT(numExclusions == excludePositions.size());
-#endif
 
   std::shared_ptr<VPackBufferUInt8> resDocs = resultBuilder.steal();
   if (res.ok()) {


### PR DESCRIPTION
### Scope & Purpose

This PR should fix a devel-only compile error with AppleClang when compiling in non-maintainer mode:
```
/Users/jenkins/hw35-mac/oskar/work/ArangoDB/arangod/Transaction/Methods.cpp:1483:37: error: lambda capture 'numExclusions' is not used [-Werror,-Wunused-lambda-capture]
  auto workForOneDocument = [this, &numExclusions, &operation, &options,
                                 ~~~^~~~~~~~~~~~~
1 error generated.
```
The code in question is not in any other versions than devel, so no backports are needed.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -
  - [ ] Backport for 3.7: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 