### PR TITLE
Improve startup error logging

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,7 @@
 v3.8.6 (2022-02-16)
 -------------------
 
-* Log a better startup error in case an ArangoDB 3.7 is started on a too new 
+* Log a better startup error in case an ArangoDB 3.8 is started on a too new 
   database directory (3.9 or higher).
 
 * Harden validator for binary VelocyPack against additional types of malicious

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 v3.8.6 (2022-02-16)
 -------------------
 
+* Log a better startup error in case an ArangoDB 3.7 is started on a too new 
+  database directory (3.9 or higher).
+
 * Harden validator for binary VelocyPack against additional types of malicious
   inputs.
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,7 @@
 v3.8.6 (2022-02-16)
 -------------------
 
-* Log a better startup error in case an ArangoDB 3.8 is started on a too new 
+* Log a better startup error in case an ArangoDB 3.8 is started on a too new
   database directory (3.9 or higher).
 
 * Harden validator for binary VelocyPack against additional types of malicious


### PR DESCRIPTION
### Scope & Purpose

Log a better startup error in case an ArangoDB 3.8 is started on a too new database directory (3.9 or higher).

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*
  - [ ] Backport for 3.7: *(Please link PR)*

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 