### PR TITLE
better error message in testfailures.txt if an incomplete rspec install is there

### DIFF
--- a/js/client/modules/@arangodb/testutils/test-utils.js
+++ b/js/client/modules/@arangodb/testutils/test-utils.js
@@ -240,8 +240,7 @@ function performTests (options, testList, testname, runFn, serverOptions, startS
         
         print('\n' + (new Date()).toISOString() + GREEN + " [============] " + runFn.info + ': Trying', te, '...', RESET);
         let reply = runFn(options, instanceInfo, te, env);
-
-        if (reply.hasOwnProperty('forceTerminate')) {
+        if (reply.hasOwnProperty('forceTerminate') && reply.forceTerminate) {
           results[te] = reply;
           continueTesting = false;
           forceTerminate = true;
@@ -1038,7 +1037,7 @@ function runInRSpec (options, instanceInfo, file, addArgs) {
     command = options.ruby;
     if (!fs.exists(rspec) || !fs.exists(command)) {
       return {
-        total: 0,
+        total: 1,
         failed: 1,
         status: false,
         forceTerminate: false,

--- a/js/client/modules/@arangodb/testutils/test-utils.js
+++ b/js/client/modules/@arangodb/testutils/test-utils.js
@@ -1036,6 +1036,15 @@ function runInRSpec (options, instanceInfo, file, addArgs) {
     let rx = new RegExp('ruby.exe$');
     rspec = options.ruby.replace(rx, 'rspec');
     command = options.ruby;
+    if (!fs.exists(rspec) || !fs.exists(command)) {
+      return {
+        total: 0,
+        failed: 1,
+        status: false,
+        forceTerminate: false,
+        message: "rspec missing on your system! either " + rspec + " or " + command + " is unavailable!"
+      };
+    }
   } else {
     if (platform.substr(0, 3) !== 'win') {
       command = 'rspec';


### PR DESCRIPTION
### Scope & Purpose

if the windows testen vironment lacks a rspec installation return a propper error message so no guesswork is needed

- [x] :hankey: Bugfix
https://github.com/arangodb/arangodb/pull/15849

### Checklist

- [x] is Tests improvement
- [x] Backports
  - [x] Backport for 3.9: https://github.com/arangodb/arangodb/pull/15849
  - [x] Backport for 3.8: https://github.com/arangodb/arangodb/pull/15850
  - [x] Backport for 3.7: https://github.com/arangodb/arangodb/pull/15851
