### PR TITLE
Fixing compiler warnings.

### DIFF
--- a/tests/Replication2/ReplicatedState/ReplicatedStateTest.cpp
+++ b/tests/Replication2/ReplicatedState/ReplicatedStateTest.cpp
@@ -90,6 +90,7 @@ TEST_F(ReplicatedStateTest, simple_unconfigured_log_test) {
       std::get<replicated_state::UnconfiguredStatus>(status->variant);
   ASSERT_EQ(unconfiguredStatus, (replicated_state::UnconfiguredStatus{
                                     .generation = stateGeneration,
+                                    .snapshot = {},
                                 }));
 }
 
@@ -113,6 +114,7 @@ TEST_F(ReplicatedStateTest, unconfigured_log_becomes_leader_test) {
         std::get<replicated_state::UnconfiguredStatus>(status->variant);
     ASSERT_EQ(unconfiguredStatus, (replicated_state::UnconfiguredStatus{
                                       .generation = stateGeneration,
+                                      .snapshot = {},
                                   }));
   }
 
@@ -168,6 +170,7 @@ TEST_F(ReplicatedStateTest, unconfigured_log_becomes_follower_test) {
         std::get<replicated_state::UnconfiguredStatus>(status->variant);
     ASSERT_EQ(unconfiguredStatus, (replicated_state::UnconfiguredStatus{
                                       .generation = stateGeneration,
+                                      .snapshot = {},
                                   }));
   }
 


### PR DESCRIPTION
### Scope & Purpose
This PR fixes compiler warnings in the arangodb tests.