### PR TITLE
[CINFRA-265] Update race in Failure Oracle

### DIFF
--- a/arangod/Cluster/AgencyCallback.cpp
+++ b/arangod/Cluster/AgencyCallback.cpp
@@ -131,9 +131,9 @@ void AgencyCallback::refetchAndUpdate(bool needToAcquireMutex,
 
   if (needToAcquireMutex) {
     CONDITION_LOCKER(locker, _cv);
-    checkValue(std::move(newData), forceCheck, idx);
+    checkValue(std::move(newData), idx, forceCheck);
   } else {
-    checkValue(std::move(newData), forceCheck, idx);
+    checkValue(std::move(newData), idx, forceCheck);
   }
 }
 

--- a/arangod/Cluster/AgencyCallback.cpp
+++ b/arangod/Cluster/AgencyCallback.cpp
@@ -41,19 +41,25 @@
 using namespace arangodb;
 using namespace arangodb::application_features;
 
-AgencyCallback::AgencyCallback(ArangodServer& server, std::string const& key,
-                               std::function<bool(VPackSlice const&)> const& cb,
-                               bool needsValue, bool needsInitialValue)
-    : key(key),
+AgencyCallback::AgencyCallback(ArangodServer& server, std::string key,
+                               CallbackType cb, bool needsValue,
+                               bool needsInitialValue)
+    : key(std::move(key)),
       _server(server),
-      _cb(cb),
-      _needsValue(needsValue),
-      _wasSignaled(false),
-      _local(true) {
+      _cb(std::move(cb)),
+      _needsValue(needsValue) {
   if (_needsValue && needsInitialValue) {
     refetchAndUpdate(true, false);
   }
 }
+
+AgencyCallback::AgencyCallback(ArangodServer& server, std::string const& key,
+                               std::function<bool(VPackSlice const&)> const& cb,
+                               bool needsValue, bool needsInitialValue)
+    : AgencyCallback(
+          server, key,
+          [cb](VPackSlice slice, consensus::index_t) { return cb(slice); },
+          needsValue, needsInitialValue) {}
 
 void AgencyCallback::local(bool b) {
   _local = b;
@@ -125,14 +131,14 @@ void AgencyCallback::refetchAndUpdate(bool needToAcquireMutex,
 
   if (needToAcquireMutex) {
     CONDITION_LOCKER(locker, _cv);
-    checkValue(std::move(newData), forceCheck);
+    checkValue(std::move(newData), forceCheck, idx);
   } else {
-    checkValue(std::move(newData), forceCheck);
+    checkValue(std::move(newData), forceCheck, idx);
   }
 }
 
 void AgencyCallback::checkValue(std::shared_ptr<VPackBuilder> newData,
-                                bool forceCheck) {
+                                consensus::index_t raftIndex, bool forceCheck) {
   // Only called from refetchAndUpdate, we always have the mutex when
   // we get here!
   if (!_lastData || forceCheck ||
@@ -141,7 +147,7 @@ void AgencyCallback::checkValue(std::shared_ptr<VPackBuilder> newData,
     LOG_TOPIC("2bd14", DEBUG, Logger::CLUSTER)
         << "AgencyCallback: Got new value " << newData->slice().typeName()
         << " " << newData->toJson() << " forceCheck=" << forceCheck;
-    if (execute(newData->slice())) {
+    if (execute(newData->slice(), raftIndex)) {
       _lastData = newData;
     } else {
       LOG_TOPIC("337dc", DEBUG, Logger::CLUSTER)
@@ -152,17 +158,19 @@ void AgencyCallback::checkValue(std::shared_ptr<VPackBuilder> newData,
 
 bool AgencyCallback::executeEmpty() {
   // only called from refetchAndUpdate, we always have the mutex when
-  // we get here!
-  return execute(VPackSlice::noneSlice());
+  // we get here! No value is needed, so this is just a notify.
+  // No index available in that case.
+  return execute(VPackSlice::noneSlice(), 0);
 }
 
-bool AgencyCallback::execute(velocypack::Slice newData) {
+bool AgencyCallback::execute(velocypack::Slice newData,
+                             consensus::index_t raftIndex) {
   // only called from refetchAndUpdate, we always have the mutex when
   // we get here!
   LOG_TOPIC("add4e", DEBUG, Logger::CLUSTER)
       << "Executing" << (newData.isNone() ? " (empty)" : "");
   try {
-    bool result = _cb(newData);
+    bool result = _cb(newData, raftIndex);
     if (result) {
       _wasSignaled = true;
       _cv.signal();

--- a/tests/js/server/replication2/replication2-replicated-log-entry-cluster.js
+++ b/tests/js/server/replication2/replication2-replicated-log-entry-cluster.js
@@ -29,7 +29,7 @@ const _ = require('lodash');
 const {sleep} = require('internal');
 const {db, errors: ERRORS} = arangodb;
 const lh = require("@arangodb/testutils/replicated-logs-helper");
-const helper = require("../../../../js/server/modules/@arangodb/testutils/replicated-logs-helper");
+const helper = require("@arangodb/testutils/replicated-logs-helper");
 
 const {waitForReplicatedLogAvailable} = helper;
 


### PR DESCRIPTION
### Scope & Purpose
This PR adds a second parameter to agency callback functions. It contains the raft index of the entry that triggered the callback. This is then used in the Failure Oracle to skip callbacks for older indexes if a later updates has already been received.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [x] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [x] **integration tests**
  - [ ] **resilience tests**
