### PR TITLE
move some CHANGELOG entries to 3.8.7, where they belong

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-v3.8.6 (2022-02-16)
+v3.8.7 (XXXX-XX-XX)
 -------------------
 
 * Log a better startup error in case an ArangoDB 3.8 is started on a too new
@@ -6,6 +6,10 @@ v3.8.6 (2022-02-16)
 
 * Harden validator for binary VelocyPack against additional types of malicious
   inputs.
+
+
+v3.8.6 (2022-02-16)
+-------------------
 
 * Replaced internal JS dependency xmldom with @xmldom/xmldom.
 


### PR DESCRIPTION
### Scope & Purpose

Fix 3.8 changelog:
A few PRs were merged after the release of v3.8.6, and the newer changes should be attributed to the v3.8.7 CHANGELOG.

This PR only modifies the CHANGELOG.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*
  - [ ] Backport for 3.7: *(Please link PR)*

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

