### PR TITLE
[PREG-60 and PREG-78]

### DIFF
--- a/arangod/WasmServer/Methods.cpp
+++ b/arangod/WasmServer/Methods.cpp
@@ -47,7 +47,12 @@ struct WasmVmMethodsSingleServer final
       -> futures::Future<Result> override {
     vocbase.server().getFeature<WasmServerFeature>().deleteFunction(
         functionName);
-    return Result{};
+    return Result{TRI_ERROR_NO_ERROR};
+  }
+
+  auto getAllWasmUdfs() const -> futures::Future<
+      std::unordered_map<std::string, WasmFunction>> override {
+    return vocbase.server().getFeature<WasmServerFeature>().getAllFunctions();
   }
 
   TRI_vocbase_t& vocbase;

--- a/arangod/WasmServer/Methods.h
+++ b/arangod/WasmServer/Methods.h
@@ -43,6 +43,8 @@ struct WasmVmMethods {
       -> futures::Future<Result> = 0;
   virtual auto deleteWasmUdf(std::string const& functionName) const
       -> futures::Future<Result> = 0;
+  virtual auto getAllWasmUdfs() const
+      -> futures::Future<std::unordered_map<std::string, WasmFunction>> = 0;
   static auto createInstance(TRI_vocbase_t& vocbase)
       -> std::shared_ptr<WasmVmMethods>;
 };

--- a/arangod/WasmServer/WasmCommon.cpp
+++ b/arangod/WasmServer/WasmCommon.cpp
@@ -17,7 +17,7 @@ WasmFunction::WasmFunction(std::string name, std::string code,
       _code{std::move(code)},
       _isDeterministic{isDeterministic} {}
 
-void WasmFunction::toVelocyPack(VPackBuilder& builder) {
+void WasmFunction::toVelocyPack(VPackBuilder& builder) const {
   auto ob = VPackObjectBuilder(&builder);
   builder.add("name", VPackValue(_name));
   builder.add("code", VPackValue(_code));

--- a/arangod/WasmServer/WasmCommon.h
+++ b/arangod/WasmServer/WasmCommon.h
@@ -57,7 +57,7 @@ class WasmFunction {
   auto name() const -> std::string { return _name; };
   static auto fromVelocyPack(arangodb::velocypack::Slice slice)
       -> ResultT<WasmFunction>;
-  void toVelocyPack(VPackBuilder& builder);
+  void toVelocyPack(VPackBuilder& builder) const;
   auto operator==(const WasmFunction& function) const -> bool = default;
 };
 

--- a/arangod/WasmServer/WasmServerFeature.cpp
+++ b/arangod/WasmServer/WasmServerFeature.cpp
@@ -1,3 +1,4 @@
+#include <unordered_map>
 #include "WasmServerFeature.h"
 #include <s2/base/integral_types.h>
 #include <optional>
@@ -33,7 +34,7 @@ void WasmServerFeature::validateOptions(
 void WasmServerFeature::addFunction(wasm::WasmFunction const& function) {
   _guardedFunctions.doUnderLock(
       [&function](GuardedFunctions& guardedFunctions) {
-        guardedFunctions._functions.emplace(function.name(), function);
+        guardedFunctions._functions.insert_or_assign(function.name(), function);
       });
 }
 
@@ -74,5 +75,13 @@ void WasmServerFeature::deleteFunction(std::string const& functionName) {
   _guardedFunctions.doUnderLock(
       [&functionName](GuardedFunctions& guardedFunctions) {
         guardedFunctions._functions.erase(functionName);
+      });
+}
+
+auto WasmServerFeature::getAllFunctions() const
+    -> std::unordered_map<std::string, wasm::WasmFunction> {
+  return _guardedFunctions.doUnderLock(
+      [&](GuardedFunctions const& guardedFunctions) {
+        return guardedFunctions._functions;
       });
 }

--- a/arangod/WasmServer/WasmServerFeature.h
+++ b/arangod/WasmServer/WasmServerFeature.h
@@ -23,6 +23,7 @@
 #pragma once
 
 #include <s2/base/integral_types.h>
+#include <unordered_map>
 #include "RestServer/arangod.h"
 #include "WasmCommon.h"
 #include "Basics/Guarded.h"
@@ -45,6 +46,8 @@ class WasmServerFeature final : public ArangodFeature {
   auto loadFunction(std::string const& name) -> std::optional<wasm3::module>;
   auto executeFunction(std::string const& name) -> std::optional<uint64_t>;
   void deleteFunction(std::string const& functionName);
+  auto getAllFunctions() const
+      -> std::unordered_map<std::string, wasm::WasmFunction>;
 
  private:
   struct GuardedFunctions {

--- a/js/client/modules/@arangodb/aql/wasmFunctions.js
+++ b/js/client/modules/@arangodb/aql/wasmFunctions.js
@@ -2,13 +2,11 @@
 /* global db */
 
 // //////////////////////////////////////////////////////////////////////////////
-// / @brief AQL user functions management
+// / @brief AQL WebAssembly user functions management
 // /
 // / @file
 // /
 // / DISCLAIMER
-// /
-// / Copyright 2012 triagens GmbH, Cologne, Germany
 // /
 // / Licensed under the Apache License, Version 2.0 (the "License")
 // / you may not use this file except in compliance with the License.
@@ -22,32 +20,31 @@
 // / See the License for the specific language governing permissions and
 // / limitations under the License.
 // /
-// / Copyright holder is triAGENS GmbH, Cologne, Germany
+// / Copyright holder is ArangoDB GmbH, Cologne, Germany
 // /
 // / @author Julia Volmer
-// / @author Copyright 2012, triAGENS GmbH, Cologne, Germany
+// / @author Copyright 2022, ArangoDB GmbH, Cologne, Germany
 // //////////////////////////////////////////////////////////////////////////////
 
 var internal = require('internal');
 var arangosh = require('@arangodb/arangosh');
+var fs = require('fs');
 
 var ArangoError = require('@arangodb').ArangoError;
 
 // //////////////////////////////////////////////////////////////////////////////
-// / @brief eventually convert function to string
+// / @brief encode data in file with base64 
 // //////////////////////////////////////////////////////////////////////////////
 
-var stringifyFunction = function (code, name) {
+var base64 = function (file) {
   'use strict';
 
-  if (typeof code === 'function') {
-    code = String(code) + '\n';
-  }
-  return code;
+    var buffer = fs.readFileSync(file);
+    return buffer.toString('base64');
 };
 
 // //////////////////////////////////////////////////////////////////////////////
-// / @brief was docuBlock wasmFunctionsUnregister
+// / @brief was docuBlock delete a user-defined webassembly function by name
 // //////////////////////////////////////////////////////////////////////////////
 
 var unregisterFunction = function (name) {
@@ -60,16 +57,17 @@ var unregisterFunction = function (name) {
 };
 
 // //////////////////////////////////////////////////////////////////////////////
-// / @brief was docuBlock wasmFunctionsRegister
+// / @brief was docuBlock add a user-defined webassembly function.
+//                        codefile is the path to the webassembly code file
 // //////////////////////////////////////////////////////////////////////////////
 
-var registerFunction = function (name, code, isDeterministic = false) {
+var registerFunction = function (name, codefile, isDeterministic = false) {
   var db = internal.db;
 
   var requestResult = db._connection.POST('/_api/wasm/',
                                           {
                                             name: name,
-                                            code: stringifyFunction(code),
+                                            code: base64(codefile),
                                             isDeterministic: isDeterministic
                                           });
   
@@ -78,7 +76,7 @@ var registerFunction = function (name, code, isDeterministic = false) {
 };
 
 // //////////////////////////////////////////////////////////////////////////////
-// / @brief was docuBlock wasmFunctionsToArray
+// / @brief was docuBlock get all user-defined webassembly functions
 // //////////////////////////////////////////////////////////////////////////////
 
 var toArrayFunctions = function () {

--- a/js/client/modules/@arangodb/aql/wasmFunctions.js
+++ b/js/client/modules/@arangodb/aql/wasmFunctions.js
@@ -1,0 +1,95 @@
+/* jshint strict: false */
+/* global db */
+
+// //////////////////////////////////////////////////////////////////////////////
+// / @brief AQL user functions management
+// /
+// / @file
+// /
+// / DISCLAIMER
+// /
+// / Copyright 2012 triagens GmbH, Cologne, Germany
+// /
+// / Licensed under the Apache License, Version 2.0 (the "License")
+// / you may not use this file except in compliance with the License.
+// / You may obtain a copy of the License at
+// /
+// /     http://www.apache.org/licenses/LICENSE-2.0
+// /
+// / Unless required by applicable law or agreed to in writing, software
+// / distributed under the License is distributed on an "AS IS" BASIS,
+// / WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// / See the License for the specific language governing permissions and
+// / limitations under the License.
+// /
+// / Copyright holder is triAGENS GmbH, Cologne, Germany
+// /
+// / @author Julia Volmer
+// / @author Copyright 2012, triAGENS GmbH, Cologne, Germany
+// //////////////////////////////////////////////////////////////////////////////
+
+var internal = require('internal');
+var arangosh = require('@arangodb/arangosh');
+
+var ArangoError = require('@arangodb').ArangoError;
+
+// //////////////////////////////////////////////////////////////////////////////
+// / @brief eventually convert function to string
+// //////////////////////////////////////////////////////////////////////////////
+
+var stringifyFunction = function (code, name) {
+  'use strict';
+
+  if (typeof code === 'function') {
+    code = String(code) + '\n';
+  }
+  return code;
+};
+
+// //////////////////////////////////////////////////////////////////////////////
+// / @brief was docuBlock wasmFunctionsUnregister
+// //////////////////////////////////////////////////////////////////////////////
+
+var unregisterFunction = function (name) {
+  'use strict';
+
+  var requestResult = db._connection.DELETE('/_api/wasm/', { name });
+
+  arangosh.checkRequestResult(requestResult);
+  return requestResult.result;
+};
+
+// //////////////////////////////////////////////////////////////////////////////
+// / @brief was docuBlock wasmFunctionsRegister
+// //////////////////////////////////////////////////////////////////////////////
+
+var registerFunction = function (name, code, isDeterministic = false) {
+  var db = internal.db;
+
+  var requestResult = db._connection.POST('/_api/wasm/',
+                                          {
+                                            name: name,
+                                            code: stringifyFunction(code),
+                                            isDeterministic: isDeterministic
+                                          });
+  
+  arangosh.checkRequestResult(requestResult);
+  return requestResult.result;
+};
+
+// //////////////////////////////////////////////////////////////////////////////
+// / @brief was docuBlock wasmFunctionsToArray
+// //////////////////////////////////////////////////////////////////////////////
+
+var toArrayFunctions = function () {
+  'use strict';
+
+    var requestResult = db._connection.GET('/_api/wasm/');
+
+  arangosh.checkRequestResult(requestResult);
+  return requestResult.result;
+};
+
+exports.unregister = unregisterFunction;
+exports.register = registerFunction;
+exports.toArray = toArrayFunctions;


### PR DESCRIPTION
### Scope & Purpose

This PR includes changes for two tickets:
- PREG-78 Write RestHandler to GET all registered wasm functions
I also improved the responses of all handler functions and corrected the add-function functionality (now functions are overwritten when you post a function with an already existing name)
- PREG-60 Write JavaScript module to install/remove/query wasm functions