### PR TITLE
[CINFRA-234] Remote Global Status Specification

### DIFF
--- a/arangod/Replication2/Methods.cpp
+++ b/arangod/Replication2/Methods.cpp
@@ -71,7 +71,8 @@ struct ReplicatedLogMethodsDBServer final
     return vocbase.getReplicatedLogById(id)->getParticipant()->getStatus();
   }
 
-  [[noreturn]] auto getGlobalStatus(LogId id) const
+  [[noreturn]] auto getGlobalStatus(
+      LogId id, replicated_log::GlobalStatus::SpecificationSource) const
       -> futures::Future<replication2::replicated_log::GlobalStatus> override {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_NOT_IMPLEMENTED);
   }
@@ -230,11 +231,11 @@ struct ReplicatedLogMethodsCoordinator final
     THROW_ARANGO_EXCEPTION(TRI_ERROR_NOT_IMPLEMENTED);
   }
 
-  auto getGlobalStatus(LogId id) const
+  auto getGlobalStatus(
+      LogId id, replicated_log::GlobalStatus::SpecificationSource source) const
       -> futures::Future<replication2::replicated_log::GlobalStatus> override {
     // 1. Determine which source to use for gathering information
     // 2. Query information from all sources
-    auto source = GlobalStatus::SpecificationSource::kLocalCache;
     auto futureSpec = loadLogSpecification(vocbase.name(), id, source);
     return std::move(futureSpec)
         .thenValue([self = shared_from_this(), source](
@@ -252,9 +253,10 @@ struct ReplicatedLogMethodsCoordinator final
   }
 
   auto getStatus(LogId id) const -> futures::Future<GenericLogStatus> override {
-    return getGlobalStatus(id).thenValue([](GlobalStatus&& status) {
-      return GenericLogStatus(std::move(status));
-    });
+    return getGlobalStatus(id, GlobalStatus::SpecificationSource::kRemoteAgency)
+        .thenValue([](GlobalStatus&& status) {
+          return GenericLogStatus(std::move(status));
+        });
   }
 
   auto getLogEntryByIndex(LogId id, LogIndex index) const
@@ -502,9 +504,36 @@ struct ReplicatedLogMethodsCoordinator final
     if (source == GlobalStatus::SpecificationSource::kLocalCache) {
       return clusterInfo.getReplicatedLogPlanSpecification(database, id);
     } else {
-      return ResultT<std::shared_ptr<
-          arangodb::replication2::agency::LogPlanSpecification const>>::
-          error(TRI_ERROR_NOT_IMPLEMENTED);
+      AsyncAgencyComm ac;
+      auto f = ac.getValues(arangodb::cluster::paths::aliases::plan()
+                                ->replicatedLogs()
+                                ->database(database)
+                                ->log(id),
+                            std::chrono::seconds{5});
+
+      return std::move(f).then(
+          [self =
+               shared_from_this()](futures::Try<AgencyReadResult>&& tryResult)
+              -> ResultT<std::shared_ptr<
+                  arangodb::replication2::agency::LogPlanSpecification const>> {
+            auto result = basics::catchToResultT(
+                [&] { return std::move(tryResult.get()); });
+
+            if (result.fail()) {
+              return result.result();
+            }
+
+            if (result->value().isNone()) {
+              return {TRI_ERROR_REPLICATION_REPLICATED_LOG_NOT_FOUND};
+            }
+
+            auto spec = arangodb::replication2::agency::LogPlanSpecification::
+                fromVelocyPack(result->value());
+
+            return {std::make_shared<
+                arangodb::replication2::agency::LogPlanSpecification>(
+                std::move(spec))};
+          });
     }
   }
 

--- a/arangod/Replication2/Methods.h
+++ b/arangod/Replication2/Methods.h
@@ -24,6 +24,7 @@
 
 #include "Replication2/ReplicatedLog/LogCommon.h"
 #include "Replication2/ReplicatedLog/LogEntries.h"
+#include "Replication2/ReplicatedLog/LogStatus.h"
 #include "Replication2/ReplicatedState/AgencySpecification.h"
 
 #include <variant>
@@ -43,8 +44,6 @@ struct LogTarget;
 }
 
 namespace replicated_log {
-struct LogStatus;
-struct GlobalStatus;
 struct AppendEntriesRequest;
 struct AppendEntriesResult;
 struct WaitForResult;
@@ -73,7 +72,8 @@ struct ReplicatedLogMethods {
                                             replicated_log::LogStatus>> = 0;
   virtual auto getLocalStatus(LogId) const
       -> futures::Future<replication2::replicated_log::LogStatus> = 0;
-  virtual auto getGlobalStatus(LogId) const
+  virtual auto getGlobalStatus(
+      LogId, replicated_log::GlobalStatus::SpecificationSource) const
       -> futures::Future<replication2::replicated_log::GlobalStatus> = 0;
   virtual auto getStatus(LogId) const -> futures::Future<GenericLogStatus> = 0;
 

--- a/arangod/RestHandler/RestLogHandler.cpp
+++ b/arangod/RestHandler/RestLogHandler.cpp
@@ -440,7 +440,7 @@ RestStatus RestLogHandler::handleGetGlobalStatus(
   }
 
   auto specSource = std::invoke([&] {
-    auto isLocal = _request->parsedValue<bool>("local").value_or(false);
+    auto isLocal = _request->parsedValue<bool>("useLocalCache").value_or(false);
     if (isLocal) {
       return replicated_log::GlobalStatus::SpecificationSource::kLocalCache;
     }

--- a/arangod/RestHandler/RestLogHandler.cpp
+++ b/arangod/RestHandler/RestLogHandler.cpp
@@ -439,12 +439,20 @@ RestStatus RestLogHandler::handleGetGlobalStatus(
     return RestStatus::DONE;
   }
 
-  return waitForFuture(
-      methods.getGlobalStatus(logId).thenValue([this](auto&& status) {
-        VPackBuilder buffer;
-        status.toVelocyPack(buffer);
-        generateOk(rest::ResponseCode::OK, buffer.slice());
-      }));
+  auto specSource = std::invoke([&] {
+    auto isLocal = _request->parsedValue<bool>("local").value_or(false);
+    if (isLocal) {
+      return replicated_log::GlobalStatus::SpecificationSource::kLocalCache;
+    }
+    return replicated_log::GlobalStatus::SpecificationSource::kRemoteAgency;
+  });
+
+  return waitForFuture(methods.getGlobalStatus(logId, specSource)
+                           .thenValue([this](auto&& status) {
+                             VPackBuilder buffer;
+                             status.toVelocyPack(buffer);
+                             generateOk(rest::ResponseCode::OK, buffer.slice());
+                           }));
 }
 
 RestStatus RestLogHandler::handleGetEntry(ReplicatedLogMethods const& methods,

--- a/arangod/V8Server/v8-replicated-logs.cpp
+++ b/arangod/V8Server/v8-replicated-logs.cpp
@@ -356,12 +356,27 @@ static void JS_GlobalStatus(v8::FunctionCallbackInfo<v8::Value> const& args) {
         std::string("No access to replicated log '") + to_string(id) + "'");
   }
 
-  auto result =
-      ReplicatedLogMethods::createInstance(vocbase)
-          ->getGlobalStatus(
-              id,
-              replicated_log::GlobalStatus::SpecificationSource::kRemoteAgency)
-          .get();
+  bool isLocal = std::invoke([&] {
+    if (args.Length() > 0) {
+      auto builder = VPackBuilder();
+      TRI_V8ToVPack(isolate, builder, args[0], false, false);
+      auto const options = builder.slice();
+      if (auto slice = options.get("useLocalCache"); slice.isTrue()) {
+        return true;
+      }
+    }
+
+    return false;
+  });
+
+  auto source =
+      isLocal
+          ? replicated_log::GlobalStatus::SpecificationSource::kLocalCache
+          : replicated_log::GlobalStatus::SpecificationSource::kRemoteAgency;
+
+  auto result = ReplicatedLogMethods::createInstance(vocbase)
+                    ->getGlobalStatus(id, source)
+                    .get();
   VPackBuilder response;
   result.toVelocyPack(response);
   TRI_V8_RETURN(TRI_VPackToV8(isolate, response.slice()));

--- a/arangod/V8Server/v8-replicated-logs.cpp
+++ b/arangod/V8Server/v8-replicated-logs.cpp
@@ -357,7 +357,11 @@ static void JS_GlobalStatus(v8::FunctionCallbackInfo<v8::Value> const& args) {
   }
 
   auto result =
-      ReplicatedLogMethods::createInstance(vocbase)->getGlobalStatus(id).get();
+      ReplicatedLogMethods::createInstance(vocbase)
+          ->getGlobalStatus(
+              id,
+              replicated_log::GlobalStatus::SpecificationSource::kRemoteAgency)
+          .get();
   VPackBuilder response;
   result.toVelocyPack(response);
   TRI_V8_RETURN(TRI_VPackToV8(isolate, response.slice()));

--- a/js/client/modules/@arangodb/replicated-logs.js
+++ b/js/client/modules/@arangodb/replicated-logs.js
@@ -69,8 +69,8 @@ ArangoReplicatedLog.prototype.status = function() {
   return requestResult.result;
 };
 
-ArangoReplicatedLog.prototype.globalStatus = function () {
-  let query = '/global-status';
+ArangoReplicatedLog.prototype.globalStatus = function ({useLocalCache = false} = {}) {
+  let query = `/global-status?useLocalCache=${useLocalCache}`;
   let requestResult = this._database._connection.GET(this._baseurl() + query);
   arangosh.checkRequestResult(requestResult);
   return requestResult.result;

--- a/tests/js/common/shell/shell-replicated-logs-cluster.js
+++ b/tests/js/common/shell/shell-replicated-logs-cluster.js
@@ -150,8 +150,11 @@ function ReplicatedLogsWriteSuite () {
       let leaderStatus = getLeaderStatus(logId);
       assertEqual(leaderStatus.local.commitIndex, 1);
       let globalStatus = log.globalStatus();
+      assertEqual(globalStatus.specification.source, "RemoteAgency");
       let status = log.status();
       assertEqual(status, globalStatus);
+      let localGlobalStatus = log.globalStatus({useLocalCache: true});
+      assertEqual(localGlobalStatus.specification.source, "LocalCache");
     },
 
     testInsert : function() {

--- a/tests/js/server/replication2/replication2-supervision-replicated-log-target-cluster.js
+++ b/tests/js/server/replication2/replication2-supervision-replicated-log-target-cluster.js
@@ -418,7 +418,7 @@ const replicatedLogSuite = function () {
       waitFor(replicatedLogParticipantsFlag(database, logId, {
         [newServer]: {excluded: true, forced: false},
       }));
-	   
+
       // now remove the excluded flag
       replicatedLogUpdateTargetParticipants(database, logId, {
         [newServer]: {excluded: false},
@@ -558,6 +558,10 @@ const replicatedLogSuite = function () {
         if (!_.isEqual(election, supervisionData.response.election)) {
           return Error('Coordinator not reporting latest state from supervision' +
               `found = ${globalStatus.supervision.election}; expected = ${election}`);
+        }
+
+        if (globalStatus.specification.source !== "RemoteAgency") {
+          return Error(`Specification source is ${globalStatus.specification.source}, expected RemoteAgency`);
         }
 
         return true;


### PR DESCRIPTION
### Scope & Purpose
`_api/log/<id>/global-status` now by default uses a direct read from the agency instead of the local cache. This is to make sure, that we do not run into caching issues. If you want to access the local cache, you can specify the `useLocalCache`.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [x] **integration tests**
  - [ ] **resilience tests**
