### PR TITLE
[CINFRA-302] Select Participants in RestHandler

### DIFF
--- a/arangod/Replication2/Methods.cpp
+++ b/arangod/Replication2/Methods.cpp
@@ -212,7 +212,7 @@ struct ReplicatedLogMethodsCoordinator final
                                    });
 
       std::shuffle(dbservers.begin(), newEnd,
-                   RandomGenerator::UniformRandomGenerator<std::size_t>{});
+                   RandomGenerator::UniformRandomGenerator<std::uint32_t>{});
       auto iter = dbservers.begin();
       while (spec.participants.size() < spec.config.replicationFactor) {
         TRI_ASSERT(iter != newEnd);
@@ -709,7 +709,7 @@ struct ReplicatedStateCoordinatorMethods
                                    });
 
       std::shuffle(dbservers.begin(), newEnd,
-                   RandomGenerator::UniformRandomGenerator<std::size_t>{});
+                   RandomGenerator::UniformRandomGenerator<std::uint32_t>{});
       auto iter = dbservers.begin();
       while (spec.participants.size() < spec.config.replicationFactor) {
         TRI_ASSERT(iter != newEnd);

--- a/arangod/Replication2/Methods.cpp
+++ b/arangod/Replication2/Methods.cpp
@@ -41,6 +41,7 @@
 
 #include "Methods.h"
 #include "Agency/AsyncAgencyComm.h"
+#include "Random/RandomGenerator.h"
 
 using namespace arangodb;
 using namespace arangodb::replication2;
@@ -52,7 +53,7 @@ struct ReplicatedLogMethodsDBServer final
       std::enable_shared_from_this<ReplicatedLogMethodsDBServer> {
   explicit ReplicatedLogMethodsDBServer(TRI_vocbase_t& vocbase)
       : vocbase(vocbase) {}
-  auto createReplicatedLog(replication2::agency::LogTarget const& spec) const
+  auto createReplicatedLog(replication2::agency::LogTarget spec) const
       -> futures::Future<Result> override {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_NOT_IMPLEMENTED);
   }
@@ -193,8 +194,33 @@ struct VPackLogIterator final : PersistedLogIterator {
 struct ReplicatedLogMethodsCoordinator final
     : ReplicatedLogMethods,
       std::enable_shared_from_this<ReplicatedLogMethodsCoordinator> {
-  auto createReplicatedLog(replication2::agency::LogTarget const& spec) const
+  auto createReplicatedLog(replication2::agency::LogTarget spec) const
       -> futures::Future<Result> override {
+    if (spec.participants.size() > spec.config.replicationFactor) {
+      return Result{
+          TRI_ERROR_BAD_PARAMETER,
+          "More participants specified than indicated by replication factor"};
+    } else if (spec.participants.size() < spec.config.replicationFactor) {
+      // add more servers to the list
+      auto dbservers = clusterInfo.getCurrentDBServers();
+      if (dbservers.size() < spec.config.replicationFactor) {
+        return Result{TRI_ERROR_CLUSTER_INSUFFICIENT_DBSERVERS};
+      }
+      auto newEnd = std::remove_if(dbservers.begin(), dbservers.end(),
+                                   [&](std::string const& server) {
+                                     return spec.participants.contains(server);
+                                   });
+
+      std::shuffle(dbservers.begin(), newEnd,
+                   RandomGenerator::UniformRandomGenerator<std::size_t>{});
+      auto iter = dbservers.begin();
+      while (spec.participants.size() < spec.config.replicationFactor) {
+        TRI_ASSERT(iter != newEnd);
+        spec.participants.emplace(*iter, ParticipantFlags{});
+        iter += 1;
+      }
+    }
+
     return replication2::agency::methods::createReplicatedLog(vocbase.name(),
                                                               spec)
         .thenValue([self = shared_from_this()](
@@ -636,7 +662,7 @@ struct ReplicatedStateDBServerMethods
   explicit ReplicatedStateDBServerMethods(TRI_vocbase_t& vocbase)
       : vocbase(vocbase) {}
 
-  auto createReplicatedState(replicated_state::agency::Target const& spec) const
+  auto createReplicatedState(replicated_state::agency::Target spec) const
       -> futures::Future<Result> override {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_NOT_IMPLEMENTED);
   }
@@ -665,8 +691,34 @@ struct ReplicatedStateCoordinatorMethods
         clusterInfo(
             vocbase.server().getFeature<ClusterFeature>().clusterInfo()) {}
 
-  auto createReplicatedState(replicated_state::agency::Target const& spec) const
+  auto createReplicatedState(replicated_state::agency::Target spec) const
       -> futures::Future<Result> override {
+    if (spec.participants.size() > spec.config.replicationFactor) {
+      return Result{
+          TRI_ERROR_BAD_PARAMETER,
+          "More participants specified than indicated by replication factor"};
+    } else if (spec.participants.size() < spec.config.replicationFactor) {
+      // add more servers to the list
+      auto dbservers = clusterInfo.getCurrentDBServers();
+      if (dbservers.size() < spec.config.replicationFactor) {
+        return Result{TRI_ERROR_CLUSTER_INSUFFICIENT_DBSERVERS};
+      }
+      auto newEnd = std::remove_if(dbservers.begin(), dbservers.end(),
+                                   [&](std::string const& server) {
+                                     return spec.participants.contains(server);
+                                   });
+
+      std::shuffle(dbservers.begin(), newEnd,
+                   RandomGenerator::UniformRandomGenerator<std::size_t>{});
+      auto iter = dbservers.begin();
+      while (spec.participants.size() < spec.config.replicationFactor) {
+        TRI_ASSERT(iter != newEnd);
+        spec.participants.emplace(
+            *iter, replicated_state::agency::Target::Participant{});
+        iter += 1;
+      }
+    }
+
     return replication2::agency::methods::createReplicatedState(vocbase.name(),
                                                                 spec)
         .thenValue([self = shared_from_this()](

--- a/arangod/Replication2/Methods.h
+++ b/arangod/Replication2/Methods.h
@@ -64,7 +64,7 @@ struct ReplicatedLogMethods {
                    replication2::replicated_log::GlobalStatus>;
 
   virtual ~ReplicatedLogMethods() = default;
-  virtual auto createReplicatedLog(agency::LogTarget const& spec) const
+  virtual auto createReplicatedLog(agency::LogTarget spec) const
       -> futures::Future<Result> = 0;
   virtual auto deleteReplicatedLog(LogId id) const
       -> futures::Future<Result> = 0;
@@ -117,9 +117,8 @@ struct ReplicatedLogMethods {
 struct ReplicatedStateMethods {
   virtual ~ReplicatedStateMethods() = default;
 
-  virtual auto createReplicatedState(
-      replicated_state::agency::Target const& spec) const
-      -> futures::Future<Result> = 0;
+  virtual auto createReplicatedState(replicated_state::agency::Target spec)
+      const -> futures::Future<Result> = 0;
   virtual auto deleteReplicatedLog(LogId id) const
       -> futures::Future<Result> = 0;
 

--- a/arangod/Replication2/ReplicatedLog/Supervision.cpp
+++ b/arangod/Replication2/ReplicatedLog/Supervision.cpp
@@ -360,23 +360,6 @@ auto checkReplicatedLog(Log const& log, ParticipantsHealth const& health)
     -> Action {
   auto const& target = log.target;
 
-  // TODO: this is a temporary hack/
-  // TODO: see whether we still need it
-  if (target.participants.empty()) {
-    auto newTarget = log.target;
-
-    for (auto const& [pid, health] : health._health) {
-      if (health.notIsFailed) {
-        newTarget.participants.emplace(pid, ParticipantFlags{});
-      }
-      if (newTarget.participants.size() ==
-          log.target.config.replicationFactor) {
-        break;
-      }
-    }
-    return AddParticipantsToTargetAction(newTarget);
-  }
-
   if (!log.plan) {
     // The log is not planned right now, so we create it
     return AddLogToPlanAction(log.target.participants);

--- a/arangod/Replication2/ReplicatedLog/SupervisionAction.cpp
+++ b/arangod/Replication2/ReplicatedLog/SupervisionAction.cpp
@@ -64,17 +64,6 @@ void Executor::operator()(AddLogToPlanAction const& action) {
                  .end();
 }
 
-void Executor::operator()(AddParticipantsToTargetAction const& action) {
-  envelope = envelope.write()
-                 .emplace_object(targetPath->str(),
-                                 [&](VPackBuilder& builder) {
-                                   action._spec.toVelocyPack(builder);
-                                 })
-                 .inc(paths::plan()->version()->str())
-                 .precs()
-                 .end();
-}
-
 void Executor::operator()(CreateInitialTermAction const& action) {
   auto term =
       LogPlanTermSpecification(LogTerm{1}, action._config, std::nullopt);
@@ -293,11 +282,6 @@ void VelocyPacker::operator()(ErrorAction const& action) {
 }
 
 void VelocyPacker::operator()(AddLogToPlanAction const& action) {
-  builder.add(VPackValue("type"));
-  builder.add(VPackValue(action.name));
-}
-
-void VelocyPacker::operator()(AddParticipantsToTargetAction const& action) {
   builder.add(VPackValue("type"));
   builder.add(VPackValue(action.name));
 }

--- a/arangod/Replication2/ReplicatedLog/SupervisionAction.h
+++ b/arangod/Replication2/ReplicatedLog/SupervisionAction.h
@@ -58,13 +58,6 @@ struct AddLogToPlanAction {
   LogTarget::Participants const _participants;
 };
 
-struct AddParticipantsToTargetAction {
-  static constexpr std::string_view name = "AddParticipantsToTargetAction";
-
-  AddParticipantsToTargetAction(LogTarget const& spec) : _spec(spec){};
-  LogTarget const _spec;
-};
-
 struct CreateInitialTermAction {
   static constexpr std::string_view name = "CreateIntialTermAction";
 
@@ -186,13 +179,14 @@ struct ConvergedToTargetAction {
   static constexpr std::string_view name = "ConvergedToTargetAction";
 };
 
-using Action = std::variant<
-    EmptyAction, ErrorAction, AddLogToPlanAction, AddParticipantsToTargetAction,
-    CreateInitialTermAction, CurrentNotAvailableAction, DictateLeaderAction,
-    DictateLeaderFailedAction, EvictLeaderAction, UpdateTermAction,
-    WriteEmptyTermAction, LeaderElectionAction, UpdateParticipantFlagsAction,
-    AddParticipantToPlanAction, RemoveParticipantFromPlanAction,
-    UpdateLogConfigAction, ConvergedToTargetAction>;
+using Action =
+    std::variant<EmptyAction, ErrorAction, AddLogToPlanAction,
+                 CreateInitialTermAction, CurrentNotAvailableAction,
+                 DictateLeaderAction, DictateLeaderFailedAction,
+                 EvictLeaderAction, UpdateTermAction, WriteEmptyTermAction,
+                 LeaderElectionAction, UpdateParticipantFlagsAction,
+                 AddParticipantToPlanAction, RemoveParticipantFromPlanAction,
+                 UpdateLogConfigAction, ConvergedToTargetAction>;
 
 using namespace arangodb::cluster::paths;
 
@@ -236,7 +230,6 @@ struct Executor {
   void operator()(EmptyAction const& action);
   void operator()(ErrorAction const& action);
   void operator()(AddLogToPlanAction const& action);
-  void operator()(AddParticipantsToTargetAction const& action);
   void operator()(CreateInitialTermAction const& action);
   void operator()(DictateLeaderAction const& action);
   void operator()(DictateLeaderFailedAction const& action);
@@ -261,7 +254,6 @@ struct VelocyPacker {
   void operator()(EmptyAction const& action);
   void operator()(ErrorAction const& action);
   void operator()(AddLogToPlanAction const& action);
-  void operator()(AddParticipantsToTargetAction const& action);
   void operator()(CreateInitialTermAction const& action);
   void operator()(CurrentNotAvailableAction const& action);
   void operator()(DictateLeaderAction const& action);

--- a/arangod/RestHandler/RestLogHandler.cpp
+++ b/arangod/RestHandler/RestLogHandler.cpp
@@ -198,14 +198,15 @@ RestStatus RestLogHandler::handlePost(ReplicatedLogMethods const& methods,
   // create a new log
   replication2::agency::LogTarget spec(replication2::agency::from_velocypack,
                                        specSlice);
-  return waitForFuture(
-      methods.createReplicatedLog(spec).thenValue([this](Result&& result) {
-        if (result.ok()) {
-          generateOk(rest::ResponseCode::OK, VPackSlice::emptyObjectSlice());
-        } else {
-          generateError(result);
-        }
-      }));
+  return waitForFuture(methods.createReplicatedLog(std::move(spec))
+                           .thenValue([this](Result&& result) {
+                             if (result.ok()) {
+                               generateOk(rest::ResponseCode::OK,
+                                          VPackSlice::emptyObjectSlice());
+                             } else {
+                               generateError(result);
+                             }
+                           }));
 }
 
 RestStatus RestLogHandler::handleGetRequest(

--- a/arangod/RestHandler/RestReplicatedStateHandler.cpp
+++ b/arangod/RestHandler/RestReplicatedStateHandler.cpp
@@ -95,12 +95,13 @@ auto arangodb::RestReplicatedStateHandler::handlePostRequest(
   // create a new state
   auto spec =
       replication2::replicated_state::agency::Target::fromVelocyPack(body);
-  return waitForFuture(
-      methods.createReplicatedState(spec).thenValue([this](auto&& result) {
-        if (result.ok()) {
-          generateOk(rest::ResponseCode::OK, VPackSlice::emptyObjectSlice());
-        } else {
-          generateError(result);
-        }
-      }));
+  return waitForFuture(methods.createReplicatedState(std::move(spec))
+                           .thenValue([this](auto&& result) {
+                             if (result.ok()) {
+                               generateOk(rest::ResponseCode::OK,
+                                          VPackSlice::emptyObjectSlice());
+                             } else {
+                               generateError(result);
+                             }
+                           }));
 }


### PR DESCRIPTION
### Scope & Purpose

When a replicated log or replicated state is created, the Methods now fill up missing participants according to the replication factor. The servers are selected randomly.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [x] Tests
  - [x] Covered by existing tests.

