### PR TITLE
speed up comparisons in replication iterator

### DIFF
--- a/arangod/RocksDBEngine/RocksDBReplicationIterator.cpp
+++ b/arangod/RocksDBEngine/RocksDBReplicationIterator.cpp
@@ -101,10 +101,13 @@ RocksDBRevisionReplicationIterator::RocksDBRevisionReplicationIterator(
 }
 
 bool RocksDBRevisionReplicationIterator::hasMore() const {
-  // TODO - check if the comparator is still necessary (thus the assertion)
+  // checking the comparator is actually not necessary here,
+  // because we have iterate_upper_bound set. Anyway, it does
+  // no harm in production and adds another line of defense
+  // in maintainer mode.
   TRI_ASSERT(!_iter->Valid() ||
              _cmp->Compare(_iter->key(), _bounds.end()) <= 0);
-  return _iter->Valid() && _cmp->Compare(_iter->key(), _bounds.end()) <= 0;
+  return _iter->Valid();
 }
 
 void RocksDBRevisionReplicationIterator::reset() {


### PR DESCRIPTION
### Scope & Purpose

We can get away with calling Compare() here, because we have set iterate_upper_bound on the rocksdb::Iterator.
This is a small performance optimization, very likely negligible.
There is no intention to backport this change.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [x] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -
  - [ ] Backport for 3.7: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 