### PR TITLE
[CINFRA-299] Invalid Log Entries Created from Prototype

### DIFF
--- a/arangod/Replication2/StateMachines/Prototype/PrototypeStateMachine.cpp
+++ b/arangod/Replication2/StateMachines/Prototype/PrototypeStateMachine.cpp
@@ -205,6 +205,20 @@ auto PrototypeFollowerState::resign() && noexcept
   });
 }
 
+auto PrototypeFollowerState::get(std::string key)
+    -> std::optional<std::string> {
+  return guardedData.doUnderLock(
+      [key = std::move(key)](auto& core) -> std::optional<std::string> {
+        if (!core) {
+          return std::nullopt;
+        }
+        if (auto it = core->store.find(key); it != nullptr) {
+          return *it;
+        }
+        return std::nullopt;
+      });
+}
+
 auto PrototypeFactory::constructFollower(std::unique_ptr<PrototypeCore> core)
     -> std::shared_ptr<PrototypeFollowerState> {
   return std::make_shared<PrototypeFollowerState>(std::move(core));
@@ -260,23 +274,22 @@ operator()(
   std::visit(overload{
                  [&b](PrototypeLogEntry::DeleteOperation const& op) {
                    VPackObjectBuilder ob(&b);
-                   b.add("type", VPackValue("delete"));
-                   b.add("key", VPackValue(op.key));
+                   b.add("type", "delete");
+                   b.add("key", op.key);
                  },
                  [&b](PrototypeLogEntry::InsertOperation const& op) {
                    VPackObjectBuilder ob(&b);
-                   b.add("type", VPackValue("insert"));
+                   b.add("type", "insert");
                    {
                      VPackObjectBuilder ob2(&b, "entries");
                      for (auto const& [key, value] : op.entries) {
-                       b.add("key", VPackValue(key));
-                       b.add("value", VPackValue(value));
+                       b.add(key, value);
                      }
                    }
                  },
                  [&b](PrototypeLogEntry::BulkDeleteOperation const& op) {
                    VPackObjectBuilder ob(&b);
-                   b.add("type", VPackValue("bulkDelete"));
+                   b.add("type", "bulkDelete");
                    {
                      VPackArrayBuilder ob2(&b, "keys");
                      for (auto const& it : op.keys) {

--- a/arangod/Replication2/StateMachines/Prototype/PrototypeStateMachine.h
+++ b/arangod/Replication2/StateMachines/Prototype/PrototypeStateMachine.h
@@ -217,6 +217,8 @@ struct PrototypeFollowerState : IReplicatedFollowerState<PrototypeState> {
   auto applyEntries(std::unique_ptr<EntryIterator> ptr) noexcept
       -> futures::Future<Result> override;
 
+  auto get(std::string key) -> std::optional<std::string>;
+
   Guarded<std::unique_ptr<PrototypeCore>, basics::UnshackledMutex> guardedData;
 };
 


### PR DESCRIPTION
### Scope & Purpose

There was a problem with the serialization of newly inserted state machine entries, when sending them to the replicated log. Therefore, only one out of multiple key-value pairs would get inserted into the state machine.
This PR fixes the serialization method and improves the `PrototypeStateMachineTest`. For that, an additional get method was introduced on the `PrototypeFollowerState`.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [x] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*
  - [ ] Backport for 3.7: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

