### PR TITLE
[PREG-86] Separate module and function concepts

### DIFF
--- a/arangod/WasmServer/Methods.cpp
+++ b/arangod/WasmServer/Methods.cpp
@@ -37,28 +37,29 @@ struct WasmVmMethodsSingleServer final
   explicit WasmVmMethodsSingleServer(TRI_vocbase_t& vocbase)
       : vocbase(vocbase){};
 
-  auto createWasmUdf(WasmFunction const& function) const
+  auto addModule(Module const& module) const
       -> futures::Future<Result> override {
-    vocbase.server().getFeature<WasmServerFeature>().addFunction(function);
+    vocbase.server().getFeature<WasmServerFeature>().addModule(module);
     return Result{TRI_ERROR_NO_ERROR};
   }
 
-  auto deleteWasmUdf(std::string const& functionName) const
+  auto deleteModule(std::string const& name) const
       -> futures::Future<Result> override {
-    vocbase.server().getFeature<WasmServerFeature>().deleteFunction(
-        functionName);
+    vocbase.server().getFeature<WasmServerFeature>().deleteModule(name);
     return Result{TRI_ERROR_NO_ERROR};
   }
 
-  auto getAllWasmUdfs() const -> futures::Future<
-      std::unordered_map<std::string, WasmFunction>> override {
-    return vocbase.server().getFeature<WasmServerFeature>().getAllFunctions();
+  auto allModules() const
+      -> futures::Future<std::unordered_map<std::string, Module>> override {
+    return vocbase.server().getFeature<WasmServerFeature>().allModules();
   }
 
-  auto executeWasmUdf(std::string const& name, uint64_t a, uint64_t b) const
+  auto executeFunction(std::string const& moduleName,
+                       std::string const& functionName,
+                       FunctionParameters const& parameters) const
       -> futures::Future<std::optional<uint64_t>> override {
     return vocbase.server().getFeature<WasmServerFeature>().executeFunction(
-        name, a, b);
+        moduleName, functionName, parameters);
   }
 
   TRI_vocbase_t& vocbase;

--- a/arangod/WasmServer/Methods.cpp
+++ b/arangod/WasmServer/Methods.cpp
@@ -43,7 +43,7 @@ struct WasmVmMethodsSingleServer final
     return Result{TRI_ERROR_NO_ERROR};
   }
 
-  auto deleteModule(std::string const& name) const
+  auto deleteModule(ModuleName const& name) const
       -> futures::Future<Result> override {
     vocbase.server().getFeature<WasmServerFeature>().deleteModule(name);
     return Result{TRI_ERROR_NO_ERROR};
@@ -54,8 +54,8 @@ struct WasmVmMethodsSingleServer final
     return vocbase.server().getFeature<WasmServerFeature>().allModules();
   }
 
-  auto executeFunction(std::string const& moduleName,
-                       std::string const& functionName,
+  auto executeFunction(ModuleName const& moduleName,
+                       FunctionName const& functionName,
                        FunctionParameters const& parameters) const
       -> futures::Future<std::optional<uint64_t>> override {
     return vocbase.server().getFeature<WasmServerFeature>().executeFunction(

--- a/arangod/WasmServer/Methods.h
+++ b/arangod/WasmServer/Methods.h
@@ -41,12 +41,12 @@ struct WasmVmMethods {
   virtual ~WasmVmMethods() = default;
   virtual auto addModule(Module const& module) const
       -> futures::Future<Result> = 0;
-  virtual auto deleteModule(std::string const& name) const
+  virtual auto deleteModule(ModuleName const& name) const
       -> futures::Future<Result> = 0;
   virtual auto allModules() const
       -> futures::Future<std::unordered_map<std::string, Module>> = 0;
-  virtual auto executeFunction(std::string const& moduleName,
-                               std::string const& functionName,
+  virtual auto executeFunction(ModuleName const& moduleName,
+                               FunctionName const& functionName,
                                FunctionParameters const& parameters) const
       -> futures::Future<std::optional<uint64_t>> = 0;
   static auto createInstance(TRI_vocbase_t& vocbase)

--- a/arangod/WasmServer/Methods.h
+++ b/arangod/WasmServer/Methods.h
@@ -39,14 +39,15 @@ namespace arangodb::wasm {
 
 struct WasmVmMethods {
   virtual ~WasmVmMethods() = default;
-  virtual auto createWasmUdf(WasmFunction const& function) const
+  virtual auto addModule(Module const& module) const
       -> futures::Future<Result> = 0;
-  virtual auto deleteWasmUdf(std::string const& functionName) const
+  virtual auto deleteModule(std::string const& name) const
       -> futures::Future<Result> = 0;
-  virtual auto getAllWasmUdfs() const
-      -> futures::Future<std::unordered_map<std::string, WasmFunction>> = 0;
-  virtual auto executeWasmUdf(std::string const& name, uint64_t a,
-                              uint64_t b) const
+  virtual auto allModules() const
+      -> futures::Future<std::unordered_map<std::string, Module>> = 0;
+  virtual auto executeFunction(std::string const& moduleName,
+                               std::string const& functionName,
+                               FunctionParameters const& parameters) const
       -> futures::Future<std::optional<uint64_t>> = 0;
   static auto createInstance(TRI_vocbase_t& vocbase)
       -> std::shared_ptr<WasmVmMethods>;

--- a/arangod/WasmServer/WasmCommon.cpp
+++ b/arangod/WasmServer/WasmCommon.cpp
@@ -27,7 +27,7 @@ void codeToVelocypack(Code const& code, VPackBuilder& builder) {
 void arangodb::wasm::moduleToVelocypack(Module const& module,
                                         VPackBuilder& builder) {
   auto ob = VPackObjectBuilder(&builder);
-  builder.add("name", VPackValue(module.name));
+  builder.add("name", VPackValue(module.name.string));
   builder.add(VPackValue("code"));
   codeToVelocypack(module.code, builder);
   builder.add("isDeterministic", VPackValue(module.isDeterministic));
@@ -139,7 +139,7 @@ auto arangodb::wasm::velocypackToModule(Slice slice) -> ResultT<Module> {
   }
 
   return ResultT<Module>(
-      Module{name.get(), {codeField.get()}, isDeterministic.get()});
+      Module{{name.get()}, {codeField.get()}, isDeterministic.get()});
 }
 
 auto uint64FromSlice(Slice slice) -> std::optional<uint64_t> {

--- a/arangod/WasmServer/WasmCommon.h
+++ b/arangod/WasmServer/WasmCommon.h
@@ -38,24 +38,22 @@ struct Code {
   auto operator==(Code const& function) const -> bool = default;
 };
 
-struct WasmFunction {
+struct Module {
   std::string name;
   Code code;
   bool isDeterministic;
-  auto operator==(WasmFunction const& function) const -> bool = default;
+  auto operator==(Module const& function) const -> bool = default;
 };
 
-struct Parameters {
+struct FunctionParameters {
   uint64_t a;
   uint64_t b;
-  auto operator==(Parameters const& parameters) const -> bool = default;
+  auto operator==(FunctionParameters const& parameters) const -> bool = default;
 };
 
-auto velocypackToWasmFunction(arangodb::velocypack::Slice slice)
-    -> ResultT<WasmFunction>;
-void wasmFunctionToVelocypack(WasmFunction const& wasmFunction,
-                              VPackBuilder& builder);
-auto velocypackToParameters(arangodb::velocypack::Slice slice)
-    -> ResultT<Parameters>;
+auto velocypackToModule(arangodb::velocypack::Slice slice) -> ResultT<Module>;
+void moduleToVelocypack(Module const& wasmFunction, VPackBuilder& builder);
+auto velocypackToFunctionParameters(arangodb::velocypack::Slice slice)
+    -> ResultT<FunctionParameters>;
 
 }  // namespace arangodb::wasm

--- a/arangod/WasmServer/WasmCommon.h
+++ b/arangod/WasmServer/WasmCommon.h
@@ -28,8 +28,6 @@
 #include "Basics/ResultT.h"
 #include "Basics/Result.h"
 #include "velocypack/Slice.h"
-#include <set>
-#include <tuple>
 
 namespace arangodb::wasm {
 
@@ -38,11 +36,23 @@ struct Code {
   auto operator==(Code const& function) const -> bool = default;
 };
 
+struct ModuleName {
+  std::string string;
+  auto operator==(ModuleName const& module) const -> bool = default;
+  ModuleName(std::string string) : string{std::move(string)} {}
+};
+
 struct Module {
-  std::string name;
+  ModuleName name;
   Code code;
   bool isDeterministic;
   auto operator==(Module const& function) const -> bool = default;
+};
+
+struct FunctionName {
+  std::string string;
+  auto operator==(FunctionName const& module) const -> bool = default;
+  FunctionName(std::string string) : string{std::move(string)} {}
 };
 
 struct FunctionParameters {
@@ -52,7 +62,7 @@ struct FunctionParameters {
 };
 
 auto velocypackToModule(arangodb::velocypack::Slice slice) -> ResultT<Module>;
-void moduleToVelocypack(Module const& wasmFunction, VPackBuilder& builder);
+void moduleToVelocypack(Module const& module, VPackBuilder& builder);
 auto velocypackToFunctionParameters(arangodb::velocypack::Slice slice)
     -> ResultT<FunctionParameters>;
 

--- a/arangod/WasmServer/WasmServerFeature.h
+++ b/arangod/WasmServer/WasmServerFeature.h
@@ -42,19 +42,20 @@ class WasmServerFeature final : public ArangodFeature {
   void collectOptions(std::shared_ptr<options::ProgramOptions>) override final;
   void validateOptions(std::shared_ptr<options::ProgramOptions>) override final;
   void prepare() override;
-  void addFunction(wasm::WasmFunction const& function);
-  auto loadFunction(std::string const& name) -> std::optional<wasm3::module>;
-  auto executeFunction(std::string const& name, uint64_t a, uint64_t b)
+  void addModule(wasm::Module const& module);
+  auto loadModule(std::string const& name) -> std::optional<wasm3::module>;
+  auto executeFunction(std::string const& moduleName,
+                       std::string const& functionName,
+                       wasm::FunctionParameters const& parameters)
       -> std::optional<uint64_t>;
-  void deleteFunction(std::string const& functionName);
-  auto getAllFunctions() const
-      -> std::unordered_map<std::string, wasm::WasmFunction>;
+  void deleteModule(std::string const& name);
+  auto allModules() const -> std::unordered_map<std::string, wasm::Module>;
 
  private:
-  struct GuardedFunctions {
-    std::unordered_map<std::string, wasm::WasmFunction> _functions;
+  struct GuardedModules {
+    std::unordered_map<std::string, wasm::Module> _modules;
   };
-  Guarded<GuardedFunctions> _guardedFunctions;
+  Guarded<GuardedModules> _guardedModules;
 
   wasm3::environment environment;
 };

--- a/arangod/WasmServer/WasmServerFeature.h
+++ b/arangod/WasmServer/WasmServerFeature.h
@@ -43,12 +43,12 @@ class WasmServerFeature final : public ArangodFeature {
   void validateOptions(std::shared_ptr<options::ProgramOptions>) override final;
   void prepare() override;
   void addModule(wasm::Module const& module);
-  auto loadModule(std::string const& name) -> std::optional<wasm3::module>;
-  auto executeFunction(std::string const& moduleName,
-                       std::string const& functionName,
+  auto loadModule(wasm::ModuleName const& name) -> std::optional<wasm3::module>;
+  auto executeFunction(wasm::ModuleName const& moduleName,
+                       wasm::FunctionName const& functionName,
                        wasm::FunctionParameters const& parameters)
       -> std::optional<uint64_t>;
-  void deleteModule(std::string const& name);
+  void deleteModule(wasm::ModuleName const& name);
   auto allModules() const -> std::unordered_map<std::string, wasm::Module>;
 
  private:

--- a/tests/WasmServer/WasmFunctionSliceTest.cpp
+++ b/tests/WasmServer/WasmFunctionSliceTest.cpp
@@ -49,18 +49,18 @@ struct WasmModuleCreation : public ::testing::Test {
 TEST_F(WasmModuleCreation, module_is_created_from_velocypack_with_byte_array) {
   expectModule(
       R"({"name": "Anne", "code": [1, 2, 255], "isDeterministic": true})",
-      Module{"Anne", {{1, 2, 255}}, true});
+      Module{{"Anne"}, {{1, 2, 255}}, true});
 }
 
 TEST_F(WasmModuleCreation,
        module_is_created_from_velocypack_with_base64_string) {
   expectModule(R"({"name": "Anne", "code": "AQL/", "isDeterministic": true})",
-               Module{"Anne", {{1, 2, 255}}, true});
+               Module{{"Anne"}, {{1, 2, 255}}, true});
 }
 
 TEST_F(WasmModuleCreation, uses_false_as_isDeterministic_default) {
   expectModule(R"({"name": "Anne", "code": [43, 8]})",
-               Module{"Anne", {{43, 8}}, false});
+               Module{{"Anne"}, {{43, 8}}, false});
 }
 
 TEST_F(WasmModuleCreation, returns_error_when_name_is_not_given) {
@@ -105,7 +105,7 @@ TEST_F(WasmModuleCreation, gives_error_when_isDeterministic_is_not_a_boolean) {
 
 TEST(WasmModuleConversion, converts_module_to_velocypack) {
   VPackBuilder velocypackBuilder;
-  arangodb::wasm::moduleToVelocypack(Module{"module_name", {{3, 233}}, false},
+  arangodb::wasm::moduleToVelocypack(Module{{"module_name"}, {{3, 233}}, false},
                                      velocypackBuilder);
   EXPECT_EQ(
       velocypackBuilder.toJson(),

--- a/tests/WasmServer/WasmFunctionSliceTest.cpp
+++ b/tests/WasmServer/WasmFunctionSliceTest.cpp
@@ -30,97 +30,95 @@
 using namespace arangodb;
 using namespace arangodb::wasm;
 
-struct WasmFunctionCreation : public ::testing::Test {
-  void expectWasmFunction(std::string&& string, WasmFunction&& wasmFunction) {
-    auto result = arangodb::wasm::velocypackToWasmFunction(
+struct WasmModuleCreation : public ::testing::Test {
+  void expectModule(std::string&& string, Module&& module) {
+    auto result = arangodb::wasm::velocypackToModule(
         VPackParser::fromJson(string)->slice());
     EXPECT_TRUE(result.ok());
-    EXPECT_EQ(result.get(), wasmFunction);
+    EXPECT_EQ(result.get(), module);
   }
 
   void expectError(std::string&& string) {
-    auto result = arangodb::wasm::velocypackToWasmFunction(
+    auto result = arangodb::wasm::velocypackToModule(
         VPackParser::fromJson(string)->slice());
     EXPECT_TRUE(result.fail());
     EXPECT_EQ(result.errorNumber(), TRI_ERROR_BAD_PARAMETER);
   }
 };
 
-TEST_F(WasmFunctionCreation,
-       wasm_function_is_created_from_velocypack_with_byte_array) {
-  expectWasmFunction(
+TEST_F(WasmModuleCreation, module_is_created_from_velocypack_with_byte_array) {
+  expectModule(
       R"({"name": "Anne", "code": [1, 2, 255], "isDeterministic": true})",
-      WasmFunction{"Anne", {{1, 2, 255}}, true});
+      Module{"Anne", {{1, 2, 255}}, true});
 }
 
-TEST_F(WasmFunctionCreation,
-       WasmFunction_is_created_from_velocypack_with_base64_string) {
-  expectWasmFunction(
-      R"({"name": "Anne", "code": "AQL/", "isDeterministic": true})",
-      WasmFunction{"Anne", {{1, 2, 255}}, true});
+TEST_F(WasmModuleCreation,
+       module_is_created_from_velocypack_with_base64_string) {
+  expectModule(R"({"name": "Anne", "code": "AQL/", "isDeterministic": true})",
+               Module{"Anne", {{1, 2, 255}}, true});
 }
 
-TEST_F(WasmFunctionCreation, uses_false_as_isDeterministic_default) {
-  expectWasmFunction(R"({"name": "Anne", "code": [43, 8]})",
-                     WasmFunction{"Anne", {{43, 8}}, false});
+TEST_F(WasmModuleCreation, uses_false_as_isDeterministic_default) {
+  expectModule(R"({"name": "Anne", "code": [43, 8]})",
+               Module{"Anne", {{43, 8}}, false});
 }
 
-TEST_F(WasmFunctionCreation, returns_error_when_name_is_not_given) {
+TEST_F(WasmModuleCreation, returns_error_when_name_is_not_given) {
   expectError(R"({"code": [43, 8]})");
 }
 
-TEST_F(WasmFunctionCreation, returns_error_when_code_is_not_given) {
+TEST_F(WasmModuleCreation, returns_error_when_code_is_not_given) {
   expectError(R"({"name": "test"})");
 }
 
-TEST_F(WasmFunctionCreation, returns_error_when_velocypack_is_not_an_object) {
+TEST_F(WasmModuleCreation, returns_error_when_velocypack_is_not_an_object) {
   expectError(R"([])");
 }
 
-TEST_F(WasmFunctionCreation, gives_error_for_unknown_key) {
+TEST_F(WasmModuleCreation, gives_error_for_unknown_key) {
   expectError(R"({"name": "test", "code": [8, 9, 0], "banane": 5})");
 }
 
-TEST_F(WasmFunctionCreation, gives_error_when_name_is_not_a_string) {
+TEST_F(WasmModuleCreation, gives_error_when_name_is_not_a_string) {
   expectError(R"({"name": 1, "code": [0]})");
 }
 
-TEST_F(WasmFunctionCreation, gives_error_when_code_is_a_number) {
-  expectError(R"({"name": "some_function", "code": 1})");
+TEST_F(WasmModuleCreation, gives_error_when_code_is_a_number) {
+  expectError(R"({"name": "some_module", "code": 1})");
 }
 
-TEST_F(WasmFunctionCreation,
+TEST_F(WasmModuleCreation,
        gives_error_when_code_byte_array_includes_not_only_bytes) {
-  expectError(R"({"name": "some_function", "code": [1000]})");
+  expectError(R"({"name": "some_module", "code": [1000]})");
 }
 
-TEST_F(WasmFunctionCreation,
+TEST_F(WasmModuleCreation,
        gives_error_when_code_string_is_not_a_base64_string) {
-  expectError(R"({"name": "some_function", "code": "121ü"})");
+  expectError(R"({"name": "some_module", "code": "121ü"})");
 }
 
-TEST_F(WasmFunctionCreation,
-       gives_error_when_isDeterministic_is_not_a_boolean) {
+TEST_F(WasmModuleCreation, gives_error_when_isDeterministic_is_not_a_boolean) {
   expectError(
-      R"({"name": "some_function", "code": [0, 1], "isDeterministic":
+      R"({"name": "some_module", "code": [0, 1], "isDeterministic":
       "ABC"})");
 }
 
-TEST(WasmFunctionConversion, converts_wasm_function_to_velocypack) {
+TEST(WasmModuleConversion, converts_module_to_velocypack) {
   VPackBuilder velocypackBuilder;
-  arangodb::wasm::wasmFunctionToVelocypack(
-      WasmFunction{"function_name", {{3, 233}}, false}, velocypackBuilder);
+  arangodb::wasm::moduleToVelocypack(Module{"module_name", {{3, 233}}, false},
+                                     velocypackBuilder);
   EXPECT_EQ(
       velocypackBuilder.toJson(),
       VPackParser::fromJson(
-          R"({"name": "function_name", "code": [3, 233], "isDeterministic": false})")
+          R"({"name": "module_name", "code": [3, 233], "isDeterministic": false})")
           ->slice()
           .toJson());
 }
 
-TEST(ParameterCreation, extracts_parameters_from_velocypack) {
+TEST(WasmFunctionParameterCreation,
+     extracts_function_parameters_from_velocypack) {
   auto velocypack = VPackParser::fromJson(R"({"a": 3, "b": 982})")->slice();
-  auto result = arangodb::wasm::velocypackToParameters(velocypack);
+  auto result = arangodb::wasm::velocypackToFunctionParameters(velocypack);
   EXPECT_TRUE(result.ok());
-  EXPECT_EQ(result.get(), (Parameters{3, 982}));
+  EXPECT_EQ(result.get(), (FunctionParameters{3, 982}));
 }


### PR DESCRIPTION
- Renames variables and functions to make clear when a function and when a module is relevant
- Includes wrapping types for FunctionName and ModuleName to assure type safety
- When executing a function, now you need to give a module name and a function name
