### PR TITLE
make ownership transparent in internal log API

### DIFF
--- a/lib/Logger/LogAppenderSyslog.h
+++ b/lib/Logger/LogAppenderSyslog.h
@@ -30,14 +30,13 @@ namespace arangodb {
 
 class LogAppenderSyslog final : public LogAppender {
  public:
-  static void close();
-
- public:
   LogAppenderSyslog(std::string const& facility, std::string const& name);
 
   void logMessage(LogMessage const& message) override final;
 
   std::string details() const override final;
+
+  static void close();
 
  private:
   std::string const _sysname;

--- a/lib/Logger/Logger.h
+++ b/lib/Logger/Logger.h
@@ -312,9 +312,9 @@ class Logger {
                   std::string const& message);
 
   static void append(
-      LogGroup&, std::unique_ptr<LogMessage>& msg, bool forceDirect,
-      std::function<void(std::unique_ptr<LogMessage>&)> const& inactive =
-          [](std::unique_ptr<LogMessage>&) -> void {});
+      LogGroup&, std::unique_ptr<LogMessage> msg, bool forceDirect,
+      std::function<void(LogMessage const&)> const& inactive =
+          [](LogMessage const&) -> void {});
 
   static bool isEnabled(LogLevel level) {
     return (int)level <= (int)_level.load(std::memory_order_relaxed);


### PR DESCRIPTION
### Scope & Purpose

Make ownership more clear in some internal log API. Previously a unique_ptr was passed into a method via mutable reference. Because the call site does not need any ownership, we can as well move the unique_ptr into the API and give up the ownership.

The PR also changes a few occurrences of StringUtils::isPrefix() to the standard std::string::starts_with, which became available with c++20.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -
  - [ ] Backport for 3.7: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 