### PR TITLE
Feature 3.8/add fuzzer to tests blocklist

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,8 +1,6 @@
 v3.8.7 (XXXX-XX-XX)
 -------------------
 
-* Added fuzzer tests to oskar blocklist.
-
 * Updated arangosync to 2.9.0.
 
 * Bug-Fix: Resolve BTS-673/Issue #15107, a spliced subquery could return too few

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 v3.8.7 (XXXX-XX-XX)
 -------------------
 
+* Added fuzzer tests to oskar blocklist.
+
 * Updated arangosync to 2.9.0.
 
 * Bug-Fix: Resolve BTS-673/Issue #15107, a spliced subquery could return too few

--- a/UnitTests/OskarTestSuitesBlockList
+++ b/UnitTests/OskarTestSuitesBlockList
@@ -6,3 +6,4 @@ audit
 dfdb
 replication2_client
 replication2_server
+shell_fuzzer


### PR DESCRIPTION
### Scope & Purpose

This PR adds fuzzer tests to oskar blocklist in version 3.8, as they only should be triggered in devel. 
The tests were introduced in https://github.com/arangodb/arangodb/pull/15828 and registered in oskar in https://github.com/arangodb/oskar/pull/379.

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [x] Backports
 There's no PR for adding this restriction on devel, but I'll consider as backport as there is gonna be the same PR in 3.9 and 3.7 as well, so this is the 3.8 backport.



