### PR TITLE
Feature 3.7/add fuzzer to tests blocklist

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 v3.7.18 (XXXX-XX-XX)
 --------------------
 
+* Added fuzzer tests to oskar blocklist.
+
 * Fixed ES-1078: The REST API endpoint for handling `/_api/user/${user}/config`
   did not work properly. The supplied data by sending a PUT request has not been
   stored to the correct location. The Web UI uses this endpoint to store its

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,8 +1,6 @@
 v3.7.18 (XXXX-XX-XX)
 --------------------
 
-* Added fuzzer tests to oskar blocklist.
-
 * Fixed ES-1078: The REST API endpoint for handling `/_api/user/${user}/config`
   did not work properly. The supplied data by sending a PUT request has not been
   stored to the correct location. The Web UI uses this endpoint to store its

--- a/UnitTests/OskarTestSuitesBlockList
+++ b/UnitTests/OskarTestSuitesBlockList
@@ -11,3 +11,4 @@ dump_no_envelope
 dump_with_crashes
 replication2_client
 replication2_server
+shell_fuzzer


### PR DESCRIPTION
### Scope & Purpose

This PR adds fuzzer tests to oskar blocklist in version 3.7, as they only should be triggered in devel. 
The tests were introduced in https://github.com/arangodb/arangodb/pull/15828 and registered in oskar in https://github.com/arangodb/oskar/pull/379.

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [x] Backports
 There's no PR for adding this restriction on devel, but I'll consider as backport as there is gonna be the same PR in 3.9 and 3.8 as well, so this is the 3.7 backport.



