### PR TITLE
Feature 3.9/add fuzzer to tests blocklist

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,8 +1,6 @@
 v3.9.1 (XXXX-XX-XX)
 -------------------
 
-* Added fuzzer tests to oskar blocklist.
-
 * Speed up initial sync (in case there is already data present) by prefetching
   data from leader.
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 v3.9.1 (XXXX-XX-XX)
 -------------------
 
+* Added fuzzer tests to oskar blocklist.
+
 * Speed up initial sync (in case there is already data present) by prefetching
   data from leader.
 

--- a/UnitTests/OskarTestSuitesBlockList
+++ b/UnitTests/OskarTestSuitesBlockList
@@ -6,3 +6,4 @@ upgrade_data_3.5.*
 audit
 dfdb
 replication2_client
+shell_fuzzer


### PR DESCRIPTION
### Scope & Purpose

This PR adds fuzzer tests to oskar blocklist in version 3.9, as they only should be triggered in devel. 
The tests were introduced in https://github.com/arangodb/arangodb/pull/15828 and registered in oskar in https://github.com/arangodb/oskar/pull/379.

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [x] Backports
 There's no PR for adding this restriction on devel, but I'll consider as backport as there is gonna be the same PR in 3.8 and 3.7 as well, so this is the 3.9 backport.



