### PR TITLE
[CINFRA-296] Remove LogTargetSpecification::Properties

### DIFF
--- a/arangod/Replication2/ReplicatedLog/AgencyLogSpecification.cpp
+++ b/arangod/Replication2/ReplicatedLog/AgencyLogSpecification.cpp
@@ -372,21 +372,11 @@ void LogTarget::toVelocyPack(velocypack::Builder& builder) const {
   }
 
   builder.add(VPackValue("properties"));
-  properties.toVelocyPack(builder);
 
   if (supervision.has_value()) {
     builder.add(VPackValue("supervision"));
     supervision->toVelocyPack(builder);
   }
-}
-
-void LogTarget::Properties::toVelocyPack(velocypack::Builder& builder) const {
-  VPackObjectBuilder ob(&builder);
-}
-
-auto LogTarget::Properties::fromVelocyPack(velocypack::Slice s)
-    -> LogTarget::Properties {
-  return {};
 }
 
 auto LogTarget::Supervision::fromVelocyPack(velocypack::Slice s)
@@ -421,10 +411,6 @@ LogTarget::LogTarget(from_velocypack_t, VPackSlice slice) {
       participants.emplace(pid.copyString(),
                            ParticipantFlags::fromVelocyPack(flags));
     }
-  }
-
-  if (auto propSlice = slice.get("properties"); !propSlice.isNone()) {
-    properties = Properties::fromVelocyPack(propSlice);
   }
 
   if (auto supSlice = slice.get("supervision"); !supSlice.isNone()) {

--- a/arangod/Replication2/ReplicatedLog/AgencyLogSpecification.cpp
+++ b/arangod/Replication2/ReplicatedLog/AgencyLogSpecification.cpp
@@ -371,8 +371,6 @@ void LogTarget::toVelocyPack(velocypack::Builder& builder) const {
     }
   }
 
-  builder.add(VPackValue("properties"));
-
   if (supervision.has_value()) {
     builder.add(VPackValue("supervision"));
     supervision->toVelocyPack(builder);

--- a/arangod/Replication2/ReplicatedLog/AgencyLogSpecification.h
+++ b/arangod/Replication2/ReplicatedLog/AgencyLogSpecification.h
@@ -202,12 +202,6 @@ struct LogTarget {
 
   std::optional<ParticipantId> leader;
 
-  struct Properties {
-    void toVelocyPack(velocypack::Builder&) const;
-    static auto fromVelocyPack(velocypack::Slice) -> Properties;
-  };
-  Properties properties;
-
   struct Supervision {
     std::size_t maxActionsTraceLength{0};
     auto toVelocyPack(velocypack::Builder&) const -> void;


### PR DESCRIPTION
### Scope & Purpose

It looks like this is not used (anymore?) and hence lets remove it until or unless we need it again.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification



