### PR TITLE
SEARCH-184 Add agency cache for cluster metrics

### DIFF
--- a/arangod/Cluster/ClusterInfo.h
+++ b/arangod/Cluster/ClusterInfo.h
@@ -48,6 +48,7 @@
 #include "Futures/Future.h"
 #include "Network/types.h"
 #include "Metrics/Fwd.h"
+#include "Metrics/ClusterMetricsFeature.h"
 #include "VocBase/Identifiers/IndexId.h"
 #include "VocBase/LogicalCollection.h"
 #include "VocBase/VocbaseInfo.h"
@@ -777,6 +778,17 @@ class ClusterInfo final {
 
   Result finishModifyingAnalyzerCoordinator(std::string_view databaseId,
                                             bool restore);
+  void initMetrics();
+
+  enum class MetricsResult {
+    Repeat,
+    Reschedule,
+    Update,
+  };
+  [[nodiscard]] MetricsResult startCollectMetrics(
+      std::shared_ptr<metrics::ClusterMetricsFeature::Data>& data);
+
+  uint64_t endCollectMetrics(velocypack::Slice data);
 
   //////////////////////////////////////////////////////////////////////////////
   /// @brief Creates cleanup transaction for first found dangling operation

--- a/arangod/IResearch/IResearchLinkCoordinator.cpp
+++ b/arangod/IResearch/IResearchLinkCoordinator.cpp
@@ -138,7 +138,6 @@ Result IResearchLinkCoordinator::init(velocypack::Slice definition) {
   metric.add("arangodb_search_cleanup_time", gaugeToCoordinator);
   metric.add("arangodb_search_consolidation_time", gaugeToCoordinator);
 
-  metric.asyncUpdate();
   return r;
 }
 

--- a/arangod/Metrics/ClusterMetricsFeature.cpp
+++ b/arangod/Metrics/ClusterMetricsFeature.cpp
@@ -69,66 +69,111 @@ void ClusterMetricsFeature::validateOptions(
     disable();
   }
 }
+void ClusterMetricsFeature::start() {
+  if (!isEnabled()) {
+    return;
+  }
+  auto& ci = server().getFeature<ClusterFeature>().clusterInfo();
+  ci.initMetrics();
+  asyncUpdate();
+}
+
 void ClusterMetricsFeature::beginShutdown() {
+  if (!isEnabled()) {
+    return;
+  }
+  disable();
   _count.store(std::numeric_limits<int32_t>::min() + 1,
                std::memory_order_relaxed);
+  _handle = nullptr;
 }
 
 void ClusterMetricsFeature::asyncUpdate() {
   if (isEnabled() && _count.fetch_add(1, std::memory_order_acq_rel) == 0) {
-    scheduleUpdate();
+    rescheduleUpdate(_timeout);
   }
 }
 
-void ClusterMetricsFeature::scheduleUpdate() noexcept {
+void ClusterMetricsFeature::rescheduleUpdate(uint32_t timeout) noexcept {
   auto now = std::chrono::steady_clock::now();
-  auto next = _lastUpdate + std::chrono::seconds{_timeout};
+  auto next = _lastUpdate + std::chrono::seconds{timeout};
   _handle = SchedulerFeature::SCHEDULER->queueDelayed(
       RequestLane::CLUSTER_INTERNAL, (now < next ? next - now : 0ns),
       [this](bool canceled) {
-        if (canceled) {
+        if (canceled || _count.exchange(1, std::memory_order_relaxed) < 1) {
           return;
         }
-        _count.store(1, std::memory_order_relaxed);
+
         try {
           update();
         } catch (...) {
-          repeatUpdate();
+          rescheduleUpdate(std::max(_timeout, uint32_t{1}));
         }
       });
 }
 
 void ClusterMetricsFeature::update() {
-  auto& nf = server().getFeature<NetworkFeature>();
+  // We want more time than _timeout should expire
+  // after last try cross cluster communication
+  _lastUpdate = std::chrono::steady_clock::now();
   auto& cf = server().getFeature<ClusterFeature>();
-  // TODO try get from agency
+  auto data = std::atomic_load_explicit(&_data, std::memory_order_acquire);
+  auto r = cf.clusterInfo().startCollectMetrics(data);
+  if (data) {
+    std::atomic_store_explicit(&_data, std::move(data),
+                               std::memory_order_release);
+  }
+
+  _lastUpdate = std::chrono::steady_clock::now();
+  if (r == ClusterInfo::MetricsResult::Repeat) {
+    return repeatUpdate();
+  }
+  if (r == ClusterInfo::MetricsResult::Reschedule) {
+    return rescheduleUpdate(std::max(_timeout, uint32_t{1}));
+  }
+
+  auto& nf = server().getFeature<NetworkFeature>();
   metricsOnCoordinator(nf, cf).thenFinal(
-      [this](futures::Try<RawDBServers>&& metrics) mutable {
-        // We want more time than kTimeout should expire
-        // after last try cross cluster communication
+      [this](futures::Try<RawDBServers>&& raw) mutable {
         _lastUpdate = std::chrono::steady_clock::now();
-        if (!metrics.hasValue()) {
-          scheduleUpdate();
-          return;
+        if (!raw.hasValue()) {
+          return rescheduleUpdate(std::max(_timeout, uint32_t{1}));
         }
+
         try {
-          set(std::move(*metrics));
+          auto& ci = server().getFeature<ClusterFeature>().clusterInfo();
+          auto metrics = parse(std::move(*raw));
+          if (metrics.empty()) {
+            ci.endCollectMetrics(VPackSlice::noneSlice());  // unlock
+            return repeatUpdate();
+          }
+          VPackBuilder builder;
+          metrics::ClusterMetricsFeature::Data::toVPack(metrics, builder);
+          auto version = ci.endCollectMetrics(builder.slice());
+          if (version == 0) {
+            return rescheduleUpdate(_timeout);
+          }
+          std::atomic_store_explicit(
+              &_data, std::make_shared<Data>(version, std::move(metrics)),
+              std::memory_order_release);
         } catch (...) {
+          return rescheduleUpdate(std::max(_timeout, uint32_t{1}));
         }
+
         repeatUpdate();
       });
 }
 
 void ClusterMetricsFeature::repeatUpdate() noexcept {
   if (_count.fetch_sub(1, std::memory_order_acq_rel) > 1) {
-    scheduleUpdate();
+    rescheduleUpdate(_timeout);
   }
 }
 
-void ClusterMetricsFeature::set(RawDBServers&& raw) const {
+ClusterMetricsFeature::Metrics ClusterMetricsFeature::parse(
+    RawDBServers&& raw) const {
   Metrics metrics;
-  std::shared_lock lock{_m};
-  for (auto const& payload : raw) {
+  for (std::shared_lock lock{_m}; auto const& payload : raw) {
     TRI_ASSERT(payload);
     velocypack::Slice slice{payload->data()};
     TRI_ASSERT(slice.isArray());
@@ -144,15 +189,12 @@ void ClusterMetricsFeature::set(RawDBServers&& raw) const {
       }
     }
   }
-  lock.unlock();
-  auto data = std::make_shared<Data>(std::move(metrics));
-  std::atomic_store_explicit(&_data, data, std::memory_order_release);
-  // TODO(MBkkt) serialize to velocypack array
-  // TODO(MBkkt) set to agency
+  return metrics;
 }
 
 void ClusterMetricsFeature::add(std::string_view metric,
                                 ToCoordinator toCoordinator) {
+  TRI_ASSERT(isEnabled());
   std::lock_guard lock{_m};
   _toCoordinator[metric] = toCoordinator;
 }
@@ -160,6 +202,7 @@ void ClusterMetricsFeature::add(std::string_view metric,
 void ClusterMetricsFeature::add(std::string_view metric,
                                 ToCoordinator toCoordinator,
                                 ToPrometheus toPrometheus) {
+  TRI_ASSERT(isEnabled());
   std::lock_guard lock{_m};
   _toCoordinator[metric] = toCoordinator;
   _toPrometheus[metric] = toPrometheus;
@@ -167,12 +210,13 @@ void ClusterMetricsFeature::add(std::string_view metric,
 
 void ClusterMetricsFeature::toPrometheus(std::string& result,
                                          std::string_view globals) const {
+  TRI_ASSERT(isEnabled());
   auto data = std::atomic_load_explicit(&_data, std::memory_order_acquire);
   if (!data) {
     return;
   }
-  std::shared_lock lock{_m};
   std::string_view metricName;
+  std::shared_lock lock{_m};
   auto it = _toPrometheus.end();
   for (auto const& [key, value] : data->metrics) {
     if (metricName != key.first) {
@@ -187,6 +231,47 @@ void ClusterMetricsFeature::toPrometheus(std::string& result,
       it->second(result, globals, key, value);
     }
   }
+}
+
+std::shared_ptr<ClusterMetricsFeature::Data>
+ClusterMetricsFeature::Data::fromVPack(VPackSlice slice) {
+  auto metrics = slice.get("Data");
+  auto version = slice.get("Version").getUInt();
+  if (!metrics.isArray()) {
+    TRI_ASSERT(false);
+    return {};
+  }
+  auto const size = metrics.length();
+  if (size % 3 != 0) {
+    TRI_ASSERT(false);
+    return {};
+  }
+  auto data = std::make_shared<Data>(version);
+  for (size_t i = 0; i != size; i += 3) {
+    auto name = metrics.at(i).stringView();
+    auto labels = metrics.at(i + 1).stringView();
+    auto type = metrics.at(i + 2).type();
+    MetricValue value;
+    if (type == VPackValueType::UInt || type == VPackValueType::SmallInt) {
+      value = metrics.at(i + 2).getUInt();
+    } else {
+      TRI_ASSERT(false);
+      return {};
+    }
+    data->metrics.emplace(MetricKey{name, labels}, value);
+  }
+  return data;
+}
+
+void ClusterMetricsFeature::Data::toVPack(Metrics const& metrics,
+                                          VPackBuilder& builder) {
+  builder.openArray();
+  for (auto const& [key, value] : metrics) {
+    builder.add(VPackValue{key.first});
+    builder.add(VPackValue{key.second});
+    std::visit([&](auto&& v) { builder.add(VPackValue{v}); }, value);
+  }
+  builder.close();
 }
 
 }  // namespace arangodb::metrics

--- a/arangod/Metrics/ClusterMetricsFeature.h
+++ b/arangod/Metrics/ClusterMetricsFeature.h
@@ -63,9 +63,14 @@ class ClusterMetricsFeature final : public ArangodFeature {
   using Metrics = std::map<MetricKey, MetricValue>;
 
   struct Data {
-    Data() = default;
-    explicit Data(Metrics&& m) : metrics{std::move(m)} {}
+    explicit Data(uint64_t v) : version{v} {}
+    explicit Data(uint64_t v, Metrics&& m)
+        : version{v}, metrics{std::move(m)} {}
 
+    static std::shared_ptr<Data> fromVPack(VPackSlice slice);
+    static void toVPack(Metrics const& metrics, VPackBuilder& builder);
+
+    uint64_t version{0};
     Metrics metrics;
   };
 
@@ -73,6 +78,7 @@ class ClusterMetricsFeature final : public ArangodFeature {
 
   void collectOptions(std::shared_ptr<options::ProgramOptions> options) final;
   void validateOptions(std::shared_ptr<options::ProgramOptions> options) final;
+  void start() final;
   void beginShutdown() final;
 
   //////////////////////////////////////////////////////////////////////////////
@@ -121,11 +127,11 @@ class ClusterMetricsFeature final : public ArangodFeature {
   containers::FlatHashMap<std::string_view, ToCoordinator> _toCoordinator;
   containers::FlatHashMap<std::string_view, ToPrometheus> _toPrometheus;
 
-  void scheduleUpdate() noexcept;
   void update();
   void repeatUpdate() noexcept;
+  void rescheduleUpdate(uint32_t timeout) noexcept;
 
-  void set(RawDBServers&& metrics) const;
+  Metrics parse(RawDBServers&& metrics) const;
 
   mutable std::shared_ptr<Data> _data;
   Scheduler::WorkHandle _handle;

--- a/tests/js/client/http/coordinator-metrics-cluster.js
+++ b/tests/js/client/http/coordinator-metrics-cluster.js
@@ -98,7 +98,6 @@ function CoordinatorMetricsTestSuite() {
 ////////////////////////////////////////////////////////////////////////////////
     testIResearchJsonMetrics: function () {
       let dbservers = getEndpointsByType("dbserver");
-      require('internal').sleep(2);
       let metrics = {};
       for (let i = 0; i < dbservers.length; i++) {
         let dbserver = dbservers[i];
@@ -148,10 +147,8 @@ function CoordinatorMetricsTestSuite() {
 
     testIResearchMetricStats: function () {
       let coordinators = getEndpointsByType("coordinator");
-      for (let i = 0; i < coordinators.length; i++) { // make metrics actual
-        let c = coordinators[i];
-        getMetricRaw(c, '');
-      }
+      let c = coordinators[coordinators.length - 1];
+      getMetricRaw(c, '');
       require('internal').sleep(5);
       for (let i = 0; i < coordinators.length; i++) {
         let c = coordinators[i];


### PR DESCRIPTION
### Scope & Purpose

Add agency cache for cluster metrics:
* Only one coordinator in the same time going to dbservers
* If coordinator read something new it don't go to dbservers
* TODO(MBkkt) What if coordinator die when get lock (need some timeout with reset callback)
* TODO(MBkkt) Option for metrics endpoint that make blocking update all metrics before make response

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*
  - [ ] Backport for 3.7: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

