### PR TITLE
Bufgix tests just sleep 5 seconds on every coordinator link create/drop

### DIFF
--- a/arangod/Cluster/ClusterInfo.cpp
+++ b/arangod/Cluster/ClusterInfo.cpp
@@ -4744,6 +4744,9 @@ Result ClusterInfo::ensureIndexCoordinatorInner(
 
       {
         CONDITION_LOCKER(locker, agencyCallback->_cv);
+#ifdef ARANGODB_USE_GOOGLE_TESTS
+        agencyCallback->refetchAndUpdate(false, true);  // Force a check
+#endif
         agencyCallback->executeByCallbackOrTimeout(interval);
       }
     }
@@ -4985,6 +4988,9 @@ Result ClusterInfo::dropIndexCoordinatorInner(std::string const& databaseName,
 
       {
         CONDITION_LOCKER(locker, agencyCallback->_cv);
+#ifdef ARANGODB_USE_GOOGLE_TESTS
+        agencyCallback->refetchAndUpdate(false, true);  // Force a check
+#endif
         agencyCallback->executeByCallbackOrTimeout(interval);
       }
 


### PR DESCRIPTION
### Scope & Purpose

Without this changes every link create and drop in unit tests spends 5 seconds!

Any idea how to fix it correctly?

Example of test:
`TEST_F(IResearchViewCoordinatorTest, test_drop_with_link)`
here 5 seconds
```C++
    EXPECT_TRUE(
        view->properties(linksJson->slice(), true, true).ok());  // add link
```
here 5 seconds
```C++
    // drop link
    EXPECT_TRUE(
        (arangodb::methods::Indexes::drop(
             logicalCollection.get(),
             arangodb::velocypack::Parser::fromJson(std::to_string(linkId.id()))
                 ->slice())
             .ok()));
```


- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*
  - [ ] Backport for 3.7: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

