### PR TITLE
AQL: Add `KEEP_RECURSIVE()` function

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,8 +1,8 @@
 devel
 -----
 
-* added new AQL function `KEEP_RECURSIVE` to recursively keep attritutes from
-  objects/documents, as a conterpart to `UNSET_RECURSIVE`
+* Added new AQL function `KEEP_RECURSIVE` to recursively keep attritutes from
+  objects/documents, as a conterpart to `UNSET_RECURSIVE`.
 
 * Added an HTTP fuzzer that will fuzz requests (the header for the actual
   moment) and send to the server. The amount of requests sent is provided 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 devel
 -----
 
+* added new AQL function `KEEP_RECURSIVE` to recursively keep attritutes from
+  objects/documents, as a conterpart to `UNSET_RECURSIVE`
+
 * Added an HTTP fuzzer that will fuzz requests (the header for the actual
   moment) and send to the server. The amount of requests sent is provided 
   by one of the parameters of the function `fuzzRequests()` in arangosh.

--- a/arangod/Aql/AqlFunctionFeature.cpp
+++ b/arangod/Aql/AqlFunctionFeature.cpp
@@ -372,6 +372,7 @@ void AqlFunctionFeature::addDocumentFunctions() {
   add({"UNSET", ".,.|+", flags, &Functions::Unset});
   add({"UNSET_RECURSIVE", ".,.|+", flags, &Functions::UnsetRecursive});
   add({"KEEP", ".,.|+", flags, &Functions::Keep});
+  add({"KEEP_RECURSIVE", ".,.|+", flags, &Functions::KeepRecursive});
   add({"TRANSLATE", ".,.|.", flags, &Functions::Translate});
   add({"ZIP", ".,.", flags, &Functions::Zip});
   add({"JSON_STRINGIFY", ".", flags, &Functions::JsonStringify});

--- a/arangod/Aql/Functions.cpp
+++ b/arangod/Aql/Functions.cpp
@@ -4532,6 +4532,32 @@ AqlValue Functions::Keep(ExpressionContext* expressionContext, AstNode const&,
   return AqlValue(builder->slice(), builder->size());
 }
 
+/// @brief function KEEP_RECURSIVE
+AqlValue Functions::KeepRecursive(ExpressionContext* expressionContext,
+                                  AstNode const&,
+                                  VPackFunctionParameters const& parameters) {
+  static char const* AFN = "KEEP_RECURSIVE";
+
+  AqlValue const& value = extractFunctionParameterValue(parameters, 0);
+
+  if (!value.isObject()) {
+    registerInvalidArgumentWarning(expressionContext, AFN);
+    return AqlValue(AqlValueHintNull());
+  }
+
+  transaction::Methods* trx = &expressionContext->trx();
+  auto* vopts = &trx->vpackOptions();
+
+  containers::FlatHashSet<std::string> names;
+  ::extractKeys(names, expressionContext, vopts, parameters, 1, AFN);
+
+  AqlValueMaterializer materializer(vopts);
+  VPackSlice slice = materializer.slice(value, false);
+  transaction::BuilderLeaser builder(trx);
+  ::unsetOrKeep(trx, slice, names, false, true, *builder.get());
+  return AqlValue(builder->slice(), builder->size());
+}
+
 /// @brief function TRANSLATE
 AqlValue Functions::Translate(ExpressionContext* expressionContext,
                               AstNode const&,

--- a/arangod/Aql/Functions.h
+++ b/arangod/Aql/Functions.h
@@ -273,6 +273,9 @@ struct Functions {
                                  VPackFunctionParameters const&);
   static AqlValue Keep(arangodb::aql::ExpressionContext*, AstNode const&,
                        VPackFunctionParameters const&);
+  static AqlValue KeepRecursive(arangodb::aql::ExpressionContext*,
+                                AstNode const&,
+                                VPackFunctionParameters const&);
   static AqlValue Translate(arangodb::aql::ExpressionContext*, AstNode const&,
                             VPackFunctionParameters const&);
   static AqlValue Merge(arangodb::aql::ExpressionContext*, AstNode const&,

--- a/arangod/Aql/Functions.h
+++ b/arangod/Aql/Functions.h
@@ -274,8 +274,7 @@ struct Functions {
   static AqlValue Keep(arangodb::aql::ExpressionContext*, AstNode const&,
                        VPackFunctionParameters const&);
   static AqlValue KeepRecursive(arangodb::aql::ExpressionContext*,
-                                AstNode const&,
-                                VPackFunctionParameters const&);
+                                AstNode const&, VPackFunctionParameters const&);
   static AqlValue Translate(arangodb::aql::ExpressionContext*, AstNode const&,
                             VPackFunctionParameters const&);
   static AqlValue Merge(arangodb::aql::ExpressionContext*, AstNode const&,

--- a/js/apps/system/_admin/aardvark/APP/react/public/assets/src/mode-aql.js
+++ b/js/apps/system/_admin/aardvark/APP/react/public/assets/src/mode-aql.js
@@ -97,7 +97,7 @@ var AqlHighlightRules = function() {
         "log|log2|log10|exp|exp2|sin|cos|tan|asin|acos|atan|atan2|radians|degrees|pi|regex_test|regex_replace|" +
         "like|floor|ceil|round|abs|rand|sqrt|pow|length|count|min|max|average|avg|sum|product|median|variance_population|variance_sample|variance|" +
         "bit_and|bit_or|bit_xor|bit_negate|bit_test|bit_popcount|bit_shift_left|bit_shift_right|bit_construct|bit_deconstruct|bit_to_string|bit_from_string|" +
-        "first|last|unique|outersection|interleave|in_range|jaccard|matches|merge|merge_recursive|has|attributes|values|unset|unset_recursive|keep|" +
+        "first|last|unique|outersection|interleave|in_range|jaccard|matches|merge|merge_recursive|has|attributes|values|unset|unset_recursive|keep|keep_recursive|" +
         "near|within|within_rectangle|is_in_polygon|distance|fulltext|stddev_sample|stddev_population|stddev|" +
         "slice|nth|position|contains_array|translate|zip|call|apply|push|append|pop|shift|unshift|remove_value|remove_values|" +
         "remove_nth|replace_nth|date_now|date_timestamp|date_iso8601|date_dayofweek|date_year|date_month|date_day|date_hour|" +

--- a/tests/js/server/aql/aql-functions-brute.js
+++ b/tests/js/server/aql/aql-functions-brute.js
@@ -128,6 +128,7 @@ function ahuacatlFunctionsBruteTestSuite () {
     "UNSET",
     "UNSET_RECURSIVE",
     "KEEP",
+    "KEEP_RECURSIVE",
     "TRANSLATE",
     "ZIP",
     "NEAR",

--- a/tests/js/server/aql/aql-functions.js
+++ b/tests/js/server/aql/aql-functions.js
@@ -1273,6 +1273,63 @@ function ahuacatlFunctionsTestSuite () {
     },
 
 ////////////////////////////////////////////////////////////////////////////////
+/// @brief test keep_recursive function
+////////////////////////////////////////////////////////////////////////////////
+    
+    testKeepRecursiveInvalid : function () {
+      assertQueryError(errors.ERROR_QUERY_FUNCTION_ARGUMENT_NUMBER_MISMATCH.code, "RETURN KEEP_RECURSIVE()"); 
+      assertQueryError(errors.ERROR_QUERY_FUNCTION_ARGUMENT_NUMBER_MISMATCH.code, "RETURN KEEP_RECURSIVE({ })"); 
+      assertQueryWarningAndNull(errors.ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH.code, "RETURN KEEP_RECURSIVE(null, 1)"); 
+      assertQueryWarningAndNull(errors.ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH.code, "RETURN KEEP_RECURSIVE(false, 1)"); 
+      assertQueryWarningAndNull(errors.ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH.code, "RETURN KEEP_RECURSIVE(1, 1)"); 
+      assertQueryWarningAndNull(errors.ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH.code, "RETURN KEEP_RECURSIVE(1, 'foo')"); 
+      assertQueryWarningAndNull(errors.ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH.code, "RETURN KEEP_RECURSIVE('bar', 1)"); 
+      assertQueryWarningAndNull(errors.ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH.code, "RETURN KEEP_RECURSIVE('foo', 'bar')"); 
+      assertQueryWarningAndNull(errors.ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH.code, "RETURN KEEP_RECURSIVE([ ], 1)"); 
+      assertQueryWarningAndNull(errors.ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH.code, "RETURN KEEP_RECURSIVE('foo', 'foo')"); 
+    },
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief test keep_recursive function
+////////////////////////////////////////////////////////////////////////////////
+    
+    testKeepRecursive : function () {
+      var actual, expected;
+
+      expected = { };
+      actual = getQueryResults("RETURN KEEP_RECURSIVE({ foo: { bar: { baz: 1 }, baz: 2 }, baz: 3 }, 'moo')");
+      assertEqualObj(expected, actual[0]);
+
+      expected = { foo: { bar: { baz: 1 }, baz: 2 }, baz: 3 };
+      actual = getQueryResults("RETURN KEEP_RECURSIVE({ foo: { bar: { baz: 1 }, baz: 2 }, baz: 3 }, 'foo', 'bar', 'baz')");
+      assertEqualObj(expected, actual[0]);
+
+      expected = { foo: { } };
+      actual = getQueryResults("RETURN KEEP_RECURSIVE({ foo: { bar: { baz: 1 }, baz: 2 }, baz: 3 }, 'foo')");
+      assertEqualObj(expected, actual[0]);
+
+      expected = { };
+      actual = getQueryResults("RETURN KEEP_RECURSIVE({ foo: { bar: { baz: 1 }, baz: 2 }, baz: 3 }, 'bar')");
+      assertEqualObj(expected, actual[0]);
+
+      expected = { baz: 3 };
+      actual = getQueryResults("RETURN KEEP_RECURSIVE({ foo: { bar: { baz: 1 }, baz: 2 }, baz: 3 }, 'baz')");
+      assertEqualObj(expected, actual[0]);
+
+      expected = { foo: { foo: 2 } };
+      actual = getQueryResults("RETURN KEEP_RECURSIVE({ foo: { bar: { foo: 1 }, foo: 2 } }, 'foo')");
+      assertEqualObj(expected, actual[0]);
+
+      expected = { foo: { baz: 2 }, baz: 3 };
+      actual = getQueryResults("RETURN KEEP_RECURSIVE({ foo: { bar: { baz: 1 }, baz: 2 }, baz: 3 }, 'baz', 'foo')");
+      assertEqualObj(expected, actual[0]);
+
+      expected = { foo: { bar: { } } };
+      actual = getQueryResults("RETURN KEEP_RECURSIVE({ foo: { bar: { baz: 1 }, baz: 2 }, baz: 3 }, 'bar', 'foo')");
+      assertEqualObj(expected, actual[0]);
+    },
+
+////////////////////////////////////////////////////////////////////////////////
 /// @brief test merge function
 ////////////////////////////////////////////////////////////////////////////////
     

--- a/tests/js/server/aql/aql-functions.js
+++ b/tests/js/server/aql/aql-functions.js
@@ -1275,24 +1275,24 @@ function ahuacatlFunctionsTestSuite () {
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief test keep_recursive function
 ////////////////////////////////////////////////////////////////////////////////
-    
+
     testKeepRecursiveInvalid : function () {
-      assertQueryError(errors.ERROR_QUERY_FUNCTION_ARGUMENT_NUMBER_MISMATCH.code, "RETURN KEEP_RECURSIVE()"); 
-      assertQueryError(errors.ERROR_QUERY_FUNCTION_ARGUMENT_NUMBER_MISMATCH.code, "RETURN KEEP_RECURSIVE({ })"); 
-      assertQueryWarningAndNull(errors.ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH.code, "RETURN KEEP_RECURSIVE(null, 1)"); 
-      assertQueryWarningAndNull(errors.ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH.code, "RETURN KEEP_RECURSIVE(false, 1)"); 
-      assertQueryWarningAndNull(errors.ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH.code, "RETURN KEEP_RECURSIVE(1, 1)"); 
-      assertQueryWarningAndNull(errors.ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH.code, "RETURN KEEP_RECURSIVE(1, 'foo')"); 
-      assertQueryWarningAndNull(errors.ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH.code, "RETURN KEEP_RECURSIVE('bar', 1)"); 
-      assertQueryWarningAndNull(errors.ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH.code, "RETURN KEEP_RECURSIVE('foo', 'bar')"); 
-      assertQueryWarningAndNull(errors.ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH.code, "RETURN KEEP_RECURSIVE([ ], 1)"); 
-      assertQueryWarningAndNull(errors.ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH.code, "RETURN KEEP_RECURSIVE('foo', 'foo')"); 
+      assertQueryError(errors.ERROR_QUERY_FUNCTION_ARGUMENT_NUMBER_MISMATCH.code, "RETURN KEEP_RECURSIVE()");
+      assertQueryError(errors.ERROR_QUERY_FUNCTION_ARGUMENT_NUMBER_MISMATCH.code, "RETURN KEEP_RECURSIVE({ })");
+      assertQueryWarningAndNull(errors.ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH.code, "RETURN KEEP_RECURSIVE(null, 1)");
+      assertQueryWarningAndNull(errors.ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH.code, "RETURN KEEP_RECURSIVE(false, 1)");
+      assertQueryWarningAndNull(errors.ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH.code, "RETURN KEEP_RECURSIVE(1, 1)");
+      assertQueryWarningAndNull(errors.ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH.code, "RETURN KEEP_RECURSIVE(1, 'foo')");
+      assertQueryWarningAndNull(errors.ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH.code, "RETURN KEEP_RECURSIVE('bar', 1)");
+      assertQueryWarningAndNull(errors.ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH.code, "RETURN KEEP_RECURSIVE('foo', 'bar')");
+      assertQueryWarningAndNull(errors.ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH.code, "RETURN KEEP_RECURSIVE([ ], 1)");
+      assertQueryWarningAndNull(errors.ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH.code, "RETURN KEEP_RECURSIVE('foo', 'foo')");
     },
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief test keep_recursive function
 ////////////////////////////////////////////////////////////////////////////////
-    
+
     testKeepRecursive : function () {
       var actual, expected;
 
@@ -1316,6 +1316,10 @@ function ahuacatlFunctionsTestSuite () {
       actual = getQueryResults("RETURN KEEP_RECURSIVE({ foo: { bar: { baz: 1 }, baz: 2 }, baz: 3 }, 'baz')");
       assertEqualObj(expected, actual[0]);
 
+      expected = { baz: 3 };
+      actual = getQueryResults("RETURN KEEP_RECURSIVE({ foo: { bar: { baz: 1 }, baz: 2 }, baz: 3 }, ['baz'])");
+      assertEqualObj(expected, actual[0]);
+
       expected = { foo: { foo: 2 } };
       actual = getQueryResults("RETURN KEEP_RECURSIVE({ foo: { bar: { foo: 1 }, foo: 2 } }, 'foo')");
       assertEqualObj(expected, actual[0]);
@@ -1326,6 +1330,26 @@ function ahuacatlFunctionsTestSuite () {
 
       expected = { foo: { bar: { } } };
       actual = getQueryResults("RETURN KEEP_RECURSIVE({ foo: { bar: { baz: 1 }, baz: 2 }, baz: 3 }, 'bar', 'foo')");
+      assertEqualObj(expected, actual[0]);
+
+      expected = { foo: { bar: { } } };
+      actual = getQueryResults("RETURN KEEP_RECURSIVE({ foo: { bar: { baz: 1 }, baz: 2 }, baz: 3 }, ['bar', 'foo'])");
+      assertEqualObj(expected, actual[0]);
+
+      expected = { foo: { bar: { foo: 1 }, foo: 2 }, bar: 3 };
+      actual = getQueryResults("RETURN KEEP_RECURSIVE({ foo: { bar: { foo: 1, bark: 5 }, foo: 2 }, bar: 3, baz: 4 }, 'bar', 'foo')");
+      assertEqualObj(expected, actual[0]);
+
+      expected = { foo: { bar: { foo: 1 }, foo: 2 }, bar: 3 };
+      actual = getQueryResults("RETURN KEEP_RECURSIVE({ foo: { bar: { foo: 1, bark: 5 }, foo: 2 }, bar: 3, baz: 4 }, ['bar', 'foo'])");
+      assertEqualObj(expected, actual[0]);
+
+      expected = { };
+      actual = getQueryResults("RETURN KEEP_RECURSIVE({ foo: { bar: { foo: 1, bark: 5 }, foo: 2 }, bar: 3, baz: 4 }, [])");
+      assertEqualObj(expected, actual[0]);
+
+      expected = { };
+      actual = getQueryResults("RETURN KEEP_RECURSIVE({ foo: { bar: { foo: 1, bark: 5 }, foo: 2 }, bar: 3, baz: 4 }, ['moo', 'fasa'])");
       assertEqualObj(expected, actual[0]);
     },
 

--- a/tests/js/server/aql/aql-stresstest-nightly.js
+++ b/tests/js/server/aql/aql-stresstest-nightly.js
@@ -94,6 +94,7 @@ var aqlFuncs = {
   "UNSET":"a,sl|+",
   "UNSET_RECURSIVE":"a,sl|+",
   "KEEP":"a,sl|+",
+  "KEEP_RECURSIVE":"a,sl|+",
   "TRANSLATE":".,a|.",
   "ZIP":"l,l",
   "NEAR":"hs,n,n|nz,s",


### PR DESCRIPTION
### Scope & Purpose

We have the function pair `UNSET()` and `KEEP()` but no counterpart to `UNSET_RECURSIVE()`. A user asked for `KEEP_RECURSIVE()` in the community slack and it turns out that the functionality is already there, just needing to be exposed and unit-tested.

- [x] :pizza: New feature

### Checklist

- [x] Tests
  - [x] **Regression tests** (or are `tests/js/server/aql/...` tests integration tests?)
  - [ ] C++ **Unit tests**
  - [ ] **integration tests** 
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports - any?
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*
  - [ ] Backport for 3.7: *(Please link PR)*

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
- [x] Slack: https://arangodb-community.slack.com/archives/C5L3P6SUF/p1647349095761259