### PR TITLE
Do not audit log replication writes by default [BTS-826]

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,7 +2,9 @@ devel
 -----
 
 * No longer put document writes from replication into the audit log by
-  default. Same with low priority authentication.
+  default. Same with low priority authentication like internal UI requests
+  to .html files for the UI. This solves a performance problem for
+  shards getting in sync with audit log switched on.
 
 * Added an HTTP fuzzer that will fuzz requests (the header for the actual
   moment) and send to the server. The amount of requests sent is provided 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 devel
 -----
 
+* No longer put document writes from replication into the audit log by
+  default. Same with low priority authentication.
+
 * Added an HTTP fuzzer that will fuzz requests (the header for the actual
   moment) and send to the server. The amount of requests sent is provided 
   by one of the parameters of the function `fuzzRequests()` in arangosh.

--- a/lib/Logger/LogTopic.cpp
+++ b/lib/Logger/LogTopic.cpp
@@ -165,13 +165,13 @@ LogTopic Logger::VIEWS("views", LogLevel::FATAL);
 LogTopic LdapAuthProvider::LDAP_TOPIC("ldap", LogLevel::INFO);
 
 LogTopic AuditFeature::AUDIT_AUTHENTICATION("audit-authentication",
-                                            LogLevel::DEBUG);
+                                            LogLevel::INFO);
 LogTopic AuditFeature::AUDIT_AUTHORIZATION("audit-authorization",
                                            LogLevel::INFO);
 LogTopic AuditFeature::AUDIT_DATABASE("audit-database", LogLevel::INFO);
 LogTopic AuditFeature::AUDIT_COLLECTION("audit-collection", LogLevel::INFO);
 LogTopic AuditFeature::AUDIT_VIEW("audit-view", LogLevel::INFO);
-LogTopic AuditFeature::AUDIT_DOCUMENT("audit-document", LogLevel::DEBUG);
+LogTopic AuditFeature::AUDIT_DOCUMENT("audit-document", LogLevel::INFO);
 LogTopic AuditFeature::AUDIT_SERVICE("audit-service", LogLevel::INFO);
 LogTopic AuditFeature::AUDIT_HOTBACKUP("audit-hotbackup", LogLevel::INFO);
 #endif


### PR DESCRIPTION
We found that replication document writes are audit logged on the DEBUG
log level of the topic "audit-document". Seemingly accidentally the
default log level for this topic is currently DEBUG. This leads to
extreme delays for shards trying to get in sync, since there there is
an audit log call for every single document being replicated. Since
a synchronously written audit log can delay writing a document by up
to a factor of 1000 and since the document write has already been audit
logged on the leader, we propose to set the default log level for
"audit-document" to INFO, which was probably intended in the first
place.

Similarly, the default log level for "audit-authentication" is also
DEBUG. This leads that non-authentication events for low priority things
like credentials missing for internal UI requests and /_open/auth are
currently audit logged by default. Again, we propose to change the 
default log level for "audit-authentication" to INFO, which was probably
intended in the first place.

### Scope & Purpose

*(Please describe the changes in this PR for reviewers, motivation, rationale - **mandatory**)*

- [*] :hankey: Bugfix
- [*] :fire: Performance improvement

### Checklist

- [*] :book: CHANGELOG entry made
- [*] Backports
  - [*] Backport for 3.9: https://github.com/arangodb/arangodb/pull/15929
  - [*] Backport for 3.8: https://github.com/arangodb/arangodb/pull/15930
  - [*] Backport for 3.7: https://github.com/arangodb/arangodb/pull/15931

