### PR TITLE
[CINFRA-312] Add constructCore method to factory

### DIFF
--- a/arangod/Replication2/ReplicatedLog/LogCommon.cpp
+++ b/arangod/Replication2/ReplicatedLog/LogCommon.cpp
@@ -574,3 +574,6 @@ void replicated_log::CommitFailReason::FewerParticipantsThanWriteConcern::
   builder.add(StaticStrings::SoftWriteConcern, softWriteConcern);
   builder.add(StaticStrings::EffectiveWriteConcern, effectiveWriteConcern);
 }
+
+GlobalLogIdentifier::GlobalLogIdentifier(std::string database, LogId id)
+    : database(std::move(database)), id(id) {}

--- a/arangod/Replication2/ReplicatedLog/LogCommon.h
+++ b/arangod/Replication2/ReplicatedLog/LogCommon.h
@@ -160,6 +160,14 @@ class LogId : public arangodb::basics::Identifier {
 
 auto to_string(LogId logId) -> std::string;
 
+struct GlobalLogIdentifier {
+  GlobalLogIdentifier(std::string database, LogId id);
+  std::string database;
+  LogId id;
+};
+
+auto to_string(GlobalLogIdentifier const&) -> std::string;
+
 struct LogConfig {
   std::size_t writeConcern = 1;
   std::size_t softWriteConcern = 1;

--- a/arangod/Replication2/ReplicatedLog/LogCore.cpp
+++ b/arangod/Replication2/ReplicatedLog/LogCore.cpp
@@ -97,3 +97,7 @@ auto LogCore::removeFront(LogIndex stop) -> futures::Future<Result> {
         return std::move(res);
       });
 }
+
+auto LogCore::gid() const noexcept -> GlobalLogIdentifier const& {
+  return _persistedLog->gid();
+}

--- a/arangod/Replication2/ReplicatedLog/LogCore.h
+++ b/arangod/Replication2/ReplicatedLog/LogCore.h
@@ -68,6 +68,7 @@ struct alignas(64) LogCore {
   auto releasePersistedLog() && -> std::shared_ptr<PersistedLog>;
 
   auto logId() const noexcept -> LogId;
+  auto gid() const noexcept -> GlobalLogIdentifier const&;
 
  private:
   std::shared_ptr<PersistedLog> _persistedLog;

--- a/arangod/Replication2/ReplicatedLog/PersistedLog.h
+++ b/arangod/Replication2/ReplicatedLog/PersistedLog.h
@@ -30,6 +30,7 @@
 #include "Futures/Future.h"
 
 #include <memory>
+#include <utility>
 
 namespace arangodb::replication2::replicated_log {
 
@@ -39,13 +40,16 @@ namespace arangodb::replication2::replicated_log {
  */
 struct PersistedLog {
   virtual ~PersistedLog() = default;
-  explicit PersistedLog(LogId lid) : _lid(lid) {}
+  explicit PersistedLog(GlobalLogIdentifier gid) : _gid(std::move(gid)) {}
 
   struct WriteOptions {
     bool waitForSync = false;
   };
 
-  [[nodiscard]] auto id() const noexcept -> LogId { return _lid; }
+  [[nodiscard]] auto id() const noexcept -> LogId { return _gid.id; }
+  [[nodiscard]] auto gid() const noexcept -> GlobalLogIdentifier const& {
+    return _gid;
+  }
   virtual auto insert(PersistedLogIterator& iter, WriteOptions const&)
       -> Result = 0;
   virtual auto insertAsync(std::unique_ptr<PersistedLogIterator> iter,
@@ -58,7 +62,7 @@ struct PersistedLog {
   virtual auto drop() -> Result = 0;
 
  private:
-  LogId _lid;
+  GlobalLogIdentifier _gid;
 };
 
 }  // namespace arangodb::replication2::replicated_log

--- a/arangod/Replication2/ReplicatedLog/ReplicatedLog.cpp
+++ b/arangod/Replication2/ReplicatedLog/ReplicatedLog.cpp
@@ -51,7 +51,7 @@ replicated_log::ReplicatedLog::ReplicatedLog(
     std::shared_ptr<ReplicatedLogMetrics> const& metrics,
     std::shared_ptr<ReplicatedLogGlobalSettings const> options,
     LoggerContext const& logContext)
-    : _logId(core->logId()),
+    : _logId(core->gid()),
       _logContext(logContext.with<logContextKeyLogId>(core->logId())),
       _participant(std::make_shared<LogUnconfiguredParticipant>(std::move(core),
                                                                 metrics)),
@@ -172,5 +172,10 @@ auto replicated_log::ReplicatedLog::drop() -> std::unique_ptr<LogCore> {
 }
 
 auto replicated_log::ReplicatedLog::getId() const noexcept -> LogId {
+  return _logId.id;
+}
+
+auto replicated_log::ReplicatedLog::getGlobalLogId() const noexcept
+    -> GlobalLogIdentifier const& {
   return _logId;
 }

--- a/arangod/Replication2/ReplicatedLog/ReplicatedLog.h
+++ b/arangod/Replication2/ReplicatedLog/ReplicatedLog.h
@@ -85,6 +85,7 @@ struct alignas(64) ReplicatedLog {
   auto operator=(ReplicatedLog&&) -> ReplicatedLog& = delete;
 
   auto getId() const noexcept -> LogId;
+  auto getGlobalLogId() const noexcept -> GlobalLogIdentifier const&;
   auto becomeLeader(
       LogConfig config, ParticipantId id, LogTerm term,
       std::vector<std::shared_ptr<AbstractFollower>> const& follower,
@@ -121,7 +122,7 @@ struct alignas(64) ReplicatedLog {
   }
 
  private:
-  LogId const _logId;
+  GlobalLogIdentifier const _logId;
   LoggerContext const _logContext = LoggerContext(Logger::REPLICATION2);
   mutable std::mutex _mutex;
   std::shared_ptr<ILogParticipant> _participant;

--- a/arangod/Replication2/ReplicatedState/ReplicatedState.h
+++ b/arangod/Replication2/ReplicatedState/ReplicatedState.h
@@ -177,6 +177,7 @@ struct ReplicatedState final
   };
   Guarded<GuardedData> guardedData;
   LoggerContext const loggerContext;
+  DatabaseID const database;
 };
 
 template<typename S>

--- a/arangod/Replication2/ReplicatedState/ReplicatedState.tpp
+++ b/arangod/Replication2/ReplicatedState/ReplicatedState.tpp
@@ -153,7 +153,7 @@ void ReplicatedState<S>::forceRebuild() {
 
 template<typename S>
 void ReplicatedState<S>::start(std::unique_ptr<ReplicatedStateToken> token) {
-  auto core = factory->constructCore(log->getId());
+  auto core = factory->constructCore(log->getGlobalLogId());
   auto deferred =
       guardedData.getLockedGuard()->rebuild(std::move(core), std::move(token));
   // execute *after* the lock has been released

--- a/arangod/Replication2/ReplicatedState/ReplicatedState.tpp
+++ b/arangod/Replication2/ReplicatedState/ReplicatedState.tpp
@@ -153,7 +153,7 @@ void ReplicatedState<S>::forceRebuild() {
 
 template<typename S>
 void ReplicatedState<S>::start(std::unique_ptr<ReplicatedStateToken> token) {
-  auto core = std::make_unique<CoreType>();
+  auto core = factory->constructCore(log->getId());
   auto deferred =
       guardedData.getLockedGuard()->rebuild(std::move(core), std::move(token));
   // execute *after* the lock has been released

--- a/arangod/Replication2/StateMachines/BlackHole/BlackHoleStateMachine.cpp
+++ b/arangod/Replication2/StateMachines/BlackHole/BlackHoleStateMachine.cpp
@@ -77,7 +77,8 @@ auto BlackHoleFactory::constructLeader(std::unique_ptr<BlackHoleCore> core)
   return std::make_shared<BlackHoleLeaderState>(std::move(core));
 }
 
-auto BlackHoleFactory::constructCore(LogId) -> std::unique_ptr<BlackHoleCore> {
+auto BlackHoleFactory::constructCore(GlobalLogIdentifier const&)
+    -> std::unique_ptr<BlackHoleCore> {
   return std::make_unique<BlackHoleCore>();
 }
 

--- a/arangod/Replication2/StateMachines/BlackHole/BlackHoleStateMachine.cpp
+++ b/arangod/Replication2/StateMachines/BlackHole/BlackHoleStateMachine.cpp
@@ -77,6 +77,10 @@ auto BlackHoleFactory::constructLeader(std::unique_ptr<BlackHoleCore> core)
   return std::make_shared<BlackHoleLeaderState>(std::move(core));
 }
 
+auto BlackHoleFactory::constructCore(LogId) -> std::unique_ptr<BlackHoleCore> {
+  return std::make_unique<BlackHoleCore>();
+}
+
 auto replicated_state::EntryDeserializer<
     replicated_state::black_hole::BlackHoleLogEntry>::
 operator()(

--- a/arangod/Replication2/StateMachines/BlackHole/BlackHoleStateMachine.h
+++ b/arangod/Replication2/StateMachines/BlackHole/BlackHoleStateMachine.h
@@ -89,6 +89,7 @@ struct BlackHoleFactory {
       -> std::shared_ptr<BlackHoleFollowerState>;
   auto constructLeader(std::unique_ptr<BlackHoleCore> core)
       -> std::shared_ptr<BlackHoleLeaderState>;
+  auto constructCore(LogId) -> std::unique_ptr<BlackHoleCore>;
 };
 
 }  // namespace black_hole

--- a/arangod/Replication2/StateMachines/BlackHole/BlackHoleStateMachine.h
+++ b/arangod/Replication2/StateMachines/BlackHole/BlackHoleStateMachine.h
@@ -89,7 +89,8 @@ struct BlackHoleFactory {
       -> std::shared_ptr<BlackHoleFollowerState>;
   auto constructLeader(std::unique_ptr<BlackHoleCore> core)
       -> std::shared_ptr<BlackHoleLeaderState>;
-  auto constructCore(LogId) -> std::unique_ptr<BlackHoleCore>;
+  auto constructCore(GlobalLogIdentifier const&)
+      -> std::unique_ptr<BlackHoleCore>;
 };
 
 }  // namespace black_hole

--- a/arangod/Replication2/StateMachines/Prototype/PrototypeStateMachine.cpp
+++ b/arangod/Replication2/StateMachines/Prototype/PrototypeStateMachine.cpp
@@ -229,7 +229,8 @@ auto PrototypeFactory::constructLeader(std::unique_ptr<PrototypeCore> core)
   return std::make_shared<PrototypeLeaderState>(std::move(core));
 }
 
-auto PrototypeFactory::constructCore(LogId) -> std::unique_ptr<PrototypeCore> {
+auto PrototypeFactory::constructCore(GlobalLogIdentifier const&)
+    -> std::unique_ptr<PrototypeCore> {
   return std::make_unique<PrototypeCore>();
 }
 

--- a/arangod/Replication2/StateMachines/Prototype/PrototypeStateMachine.cpp
+++ b/arangod/Replication2/StateMachines/Prototype/PrototypeStateMachine.cpp
@@ -229,6 +229,10 @@ auto PrototypeFactory::constructLeader(std::unique_ptr<PrototypeCore> core)
   return std::make_shared<PrototypeLeaderState>(std::move(core));
 }
 
+auto PrototypeFactory::constructCore(LogId) -> std::unique_ptr<PrototypeCore> {
+  return std::make_unique<PrototypeCore>();
+}
+
 auto replicated_state::EntryDeserializer<
     replicated_state::prototype::PrototypeLogEntry>::
 operator()(

--- a/arangod/Replication2/StateMachines/Prototype/PrototypeStateMachine.h
+++ b/arangod/Replication2/StateMachines/Prototype/PrototypeStateMachine.h
@@ -227,7 +227,8 @@ struct PrototypeFactory {
       -> std::shared_ptr<PrototypeFollowerState>;
   auto constructLeader(std::unique_ptr<PrototypeCore> core)
       -> std::shared_ptr<PrototypeLeaderState>;
-  auto constructCore(LogId) -> std::unique_ptr<PrototypeCore>;
+  auto constructCore(GlobalLogIdentifier const&)
+      -> std::unique_ptr<PrototypeCore>;
 };
 
 }  // namespace prototype

--- a/arangod/Replication2/StateMachines/Prototype/PrototypeStateMachine.h
+++ b/arangod/Replication2/StateMachines/Prototype/PrototypeStateMachine.h
@@ -227,6 +227,7 @@ struct PrototypeFactory {
       -> std::shared_ptr<PrototypeFollowerState>;
   auto constructLeader(std::unique_ptr<PrototypeCore> core)
       -> std::shared_ptr<PrototypeLeaderState>;
+  auto constructCore(LogId) -> std::unique_ptr<PrototypeCore>;
 };
 
 }  // namespace prototype

--- a/arangod/RocksDBEngine/RocksDBEngine.cpp
+++ b/arangod/RocksDBEngine/RocksDBEngine.cpp
@@ -2870,8 +2870,10 @@ std::unique_ptr<TRI_vocbase_t> RocksDBEngine::openExistingDatabase(
           it.get(StaticStrings::DataSourcePlanId).getNumericValue<uint64_t>()};
       auto objectId =
           it.get(StaticStrings::ObjectId).getNumericValue<uint64_t>();
-      auto log =
-          std::make_shared<RocksDBPersistedLog>(logId, objectId, _logPersistor);
+      auto log = std::make_shared<RocksDBPersistedLog>(
+          replication2::GlobalLogIdentifier(vocbase->name(),
+                                            replication2::LogId()),
+          objectId, _logPersistor);
       StorageEngine::registerReplicatedLog(*vocbase, logId, log);
     }
   } catch (std::exception const& ex) {
@@ -3583,8 +3585,9 @@ auto RocksDBEngine::createReplicatedLog(TRI_vocbase_t& vocbase,
           RocksDBColumnFamilyManager::Family::Definitions),
       key.string(), value.string());
   if (s.ok()) {
-    return {
-        std::make_shared<RocksDBPersistedLog>(logId, objectId, _logPersistor)};
+    return {std::make_shared<RocksDBPersistedLog>(
+        replication2::GlobalLogIdentifier(vocbase.name(), logId), objectId,
+        _logPersistor)};
   }
 
   return rocksutils::convertStatus(s);

--- a/arangod/RocksDBEngine/RocksDBPersistedLog.cpp
+++ b/arangod/RocksDBEngine/RocksDBPersistedLog.cpp
@@ -39,9 +39,11 @@ using namespace arangodb::replication2;
 using namespace arangodb::replication2::replicated_log;
 
 RocksDBPersistedLog::RocksDBPersistedLog(
-    replication2::LogId id, uint64_t objectId,
+    replication2::GlobalLogIdentifier id, uint64_t objectId,
     std::shared_ptr<RocksDBLogPersistor> persistor)
-    : PersistedLog(id), _objectId(objectId), _persistor(std::move(persistor)) {}
+    : PersistedLog(std::move(id)),
+      _objectId(objectId),
+      _persistor(std::move(persistor)) {}
 
 auto RocksDBPersistedLog::insert(PersistedLogIterator& iter,
                                  WriteOptions const& options) -> Result {

--- a/arangod/RocksDBEngine/RocksDBPersistedLog.h
+++ b/arangod/RocksDBEngine/RocksDBPersistedLog.h
@@ -110,7 +110,7 @@ class RocksDBPersistedLog
       public std::enable_shared_from_this<RocksDBPersistedLog> {
  public:
   ~RocksDBPersistedLog() override = default;
-  RocksDBPersistedLog(replication2::LogId id, uint64_t objectId,
+  RocksDBPersistedLog(replication2::GlobalLogIdentifier id, uint64_t objectId,
                       std::shared_ptr<RocksDBLogPersistor> persistor);
 
   auto insert(replication2::PersistedLogIterator& iter, WriteOptions const&)

--- a/tests/Replication2/Mocks/FakeReplicatedState.h
+++ b/tests/Replication2/Mocks/FakeReplicatedState.h
@@ -234,7 +234,7 @@ struct RecordingFactory {
     return ptr;
   }
 
-  auto constructCore(LogId) -> std::unique_ptr<CoreType> {
+  auto constructCore(GlobalLogIdentifier const&) -> std::unique_ptr<CoreType> {
     return std::make_unique<CoreType>();
   }
 

--- a/tests/Replication2/Mocks/FakeReplicatedState.h
+++ b/tests/Replication2/Mocks/FakeReplicatedState.h
@@ -234,6 +234,10 @@ struct RecordingFactory {
     return ptr;
   }
 
+  auto constructCore(LogId) -> std::unique_ptr<CoreType> {
+    return std::make_unique<CoreType>();
+  }
+
   auto getLatestLeader() -> std::shared_ptr<LeaderType> {
     TRI_ASSERT(!leaders.empty());
     return leaders.back().lock();

--- a/tests/Replication2/Mocks/PersistedLog.cpp
+++ b/tests/Replication2/Mocks/PersistedLog.cpp
@@ -79,7 +79,7 @@ void MockLog::setEntry(replication2::LogIndex idx, replication2::LogTerm term,
 MockLog::MockLog(replication2::LogId id) : MockLog(id, {}) {}
 
 MockLog::MockLog(replication2::LogId id, MockLog::storeType storage)
-    : PersistedLog(id), _storage(std::move(storage)) {}
+    : PersistedLog(GlobalLogIdentifier("", id)), _storage(std::move(storage)) {}
 
 AsyncMockLog::AsyncMockLog(replication2::LogId id)
     : MockLog(id), _asyncWorker([this] { this->runWorker(); }) {}

--- a/tests/Replication2/ReplicatedLog/RocksDBLogTest.cpp
+++ b/tests/Replication2/ReplicatedLog/RocksDBLogTest.cpp
@@ -70,7 +70,8 @@ struct RocksDBLogTest : testing::Test {
       _maxLogId = id;
     }
 
-    return std::make_shared<RocksDBPersistedLog>(id, id.id(), _persistor);
+    return std::make_shared<RocksDBPersistedLog>(GlobalLogIdentifier("", id),
+                                                 id.id(), _persistor);
   }
 
   auto createUniqueLog() -> std::shared_ptr<RocksDBPersistedLog> {

--- a/tests/Replication2/ReplicatedState/LeaderRecoveryTest.cpp
+++ b/tests/Replication2/ReplicatedState/LeaderRecoveryTest.cpp
@@ -87,7 +87,8 @@ struct MyHelperFactory {
       -> std::shared_ptr<EmptyFollowerType<MyHelperState>> {
     return std::make_shared<EmptyFollowerType<MyHelperState>>(std::move(core));
   }
-  auto constructCore(LogId) -> std::unique_ptr<MyCoreType> {
+  auto constructCore(GlobalLogIdentifier const&)
+      -> std::unique_ptr<MyCoreType> {
     return std::make_unique<MyCoreType>();
   }
   ReplicatedStateRecoveryTest& test;

--- a/tests/Replication2/ReplicatedState/LeaderRecoveryTest.cpp
+++ b/tests/Replication2/ReplicatedState/LeaderRecoveryTest.cpp
@@ -87,6 +87,9 @@ struct MyHelperFactory {
       -> std::shared_ptr<EmptyFollowerType<MyHelperState>> {
     return std::make_shared<EmptyFollowerType<MyHelperState>>(std::move(core));
   }
+  auto constructCore(LogId) -> std::unique_ptr<MyCoreType> {
+    return std::make_unique<MyCoreType>();
+  }
   ReplicatedStateRecoveryTest& test;
 };
 

--- a/tests/Replication2/ReplicatedState/StateMachines/MyStateMachine.cpp
+++ b/tests/Replication2/ReplicatedState/StateMachines/MyStateMachine.cpp
@@ -77,7 +77,8 @@ auto MyFactory::constructFollower(std::unique_ptr<MyCoreType> core)
   return std::make_shared<MyFollowerState>(std::move(core));
 }
 
-auto MyFactory::constructCore(LogId) -> std::unique_ptr<MyCoreType> {
+auto MyFactory::constructCore(GlobalLogIdentifier const&)
+    -> std::unique_ptr<MyCoreType> {
   return std::make_unique<MyCoreType>();
 }
 

--- a/tests/Replication2/ReplicatedState/StateMachines/MyStateMachine.cpp
+++ b/tests/Replication2/ReplicatedState/StateMachines/MyStateMachine.cpp
@@ -77,6 +77,10 @@ auto MyFactory::constructFollower(std::unique_ptr<MyCoreType> core)
   return std::make_shared<MyFollowerState>(std::move(core));
 }
 
+auto MyFactory::constructCore(LogId) -> std::unique_ptr<MyCoreType> {
+  return std::make_unique<MyCoreType>();
+}
+
 auto MyFollowerState::applyEntries(std::unique_ptr<EntryIterator> ptr) noexcept
     -> futures::Future<Result> {
   applyIterator(*ptr);

--- a/tests/Replication2/ReplicatedState/StateMachines/MyStateMachine.h
+++ b/tests/Replication2/ReplicatedState/StateMachines/MyStateMachine.h
@@ -97,6 +97,8 @@ struct MyFactory {
       -> std::shared_ptr<MyFollowerState>;
   auto constructLeader(std::unique_ptr<MyCoreType>)
       -> std::shared_ptr<MyLeaderState>;
+  auto constructCore(LogId)
+  -> std::unique_ptr<MyCoreType>;
 };
 
 struct MyCoreType {};

--- a/tests/Replication2/ReplicatedState/StateMachines/MyStateMachine.h
+++ b/tests/Replication2/ReplicatedState/StateMachines/MyStateMachine.h
@@ -97,7 +97,7 @@ struct MyFactory {
       -> std::shared_ptr<MyFollowerState>;
   auto constructLeader(std::unique_ptr<MyCoreType>)
       -> std::shared_ptr<MyLeaderState>;
-  auto constructCore(LogId) -> std::unique_ptr<MyCoreType>;
+  auto constructCore(GlobalLogIdentifier const&) -> std::unique_ptr<MyCoreType>;
 };
 
 struct MyCoreType {};

--- a/tests/Replication2/ReplicatedState/StateMachines/MyStateMachine.h
+++ b/tests/Replication2/ReplicatedState/StateMachines/MyStateMachine.h
@@ -97,8 +97,7 @@ struct MyFactory {
       -> std::shared_ptr<MyFollowerState>;
   auto constructLeader(std::unique_ptr<MyCoreType>)
       -> std::shared_ptr<MyLeaderState>;
-  auto constructCore(LogId)
-  -> std::unique_ptr<MyCoreType>;
+  auto constructCore(LogId) -> std::unique_ptr<MyCoreType>;
 };
 
 struct MyCoreType {};


### PR DESCRIPTION
### Scope & Purpose

This PR adds the `constructCore(LogId)` method to the replicated states factory. This allows for more flexibility, as currently there is no way of passing additional arguments to the constructor of `core`.
Our use-case is to pass a `TransactionDB`, that's going to be used for RocksDB serialization.

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*
  - [ ] Backport for 3.7: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

