### PR TITLE
[PREG-68] Add javascript tests

### DIFF
--- a/arangod/Aql/AqlFunctionFeature.cpp
+++ b/arangod/Aql/AqlFunctionFeature.cpp
@@ -498,7 +498,7 @@ void AqlFunctionFeature::addMiscFunctions() {
                            FF::CanRunOnDBServerOneShard),
        &Functions::CallGreenspun});
 
-  add({"CALL_WASM", ".,.,.,.", Function::makeFlags(FF::CanReadDocuments),
+  add({"CALL_WASM", ".,.,.,.", Function::makeFlags(FF::None),
        &Functions::CallWasm});
 
   // special flags:

--- a/arangod/Aql/Functions.cpp
+++ b/arangod/Aql/Functions.cpp
@@ -9061,7 +9061,7 @@ AqlValue Functions::CallWasm(ExpressionContext* expressionContext,
     return AqlValue(builder.slice());
   } else {
     auto msg = "Cannot find function";
-    expressionContext->registerError(TRI_ERROR_AIR_EXECUTION_ERROR, msg);
+    expressionContext->registerError(TRI_ERROR_WASM_EXECUTION_ERROR, msg);
     return AqlValue(AqlValueHintNull());
   }
 }

--- a/arangod/Aql/Functions.cpp
+++ b/arangod/Aql/Functions.cpp
@@ -9053,12 +9053,10 @@ AqlValue Functions::CallWasm(ExpressionContext* expressionContext,
           static_cast<uint64_t>(functionParameter2.toInt64())});
 
   if (result.has_value()) {
-    VPackBuilder builder;
-    {
-      VPackObjectBuilder ob(&builder);
-      builder.add("result", VPackValue(result.value()));
-    }
-    return AqlValue(builder.slice());
+    transaction::Methods* trx = &expressionContext->trx();
+    transaction::BuilderLeaser builder(trx);
+    builder->add(VPackValue(result.value()));
+    return AqlValue(builder->slice(), builder->size());
   } else {
     auto msg = "Cannot find function";
     expressionContext->registerError(TRI_ERROR_WASM_EXECUTION_ERROR, msg);

--- a/arangod/WasmServer/Methods.cpp
+++ b/arangod/WasmServer/Methods.cpp
@@ -54,6 +54,11 @@ struct WasmVmMethodsSingleServer final
     return vocbase.server().getFeature<WasmServerFeature>().allModules();
   }
 
+  auto module(ModuleName const& name) const
+      -> futures::Future<std::optional<Module>> override {
+    return vocbase.server().getFeature<WasmServerFeature>().module(name);
+  }
+
   auto executeFunction(ModuleName const& moduleName,
                        FunctionName const& functionName,
                        FunctionParameters const& parameters) const

--- a/arangod/WasmServer/Methods.h
+++ b/arangod/WasmServer/Methods.h
@@ -45,6 +45,8 @@ struct WasmVmMethods {
       -> futures::Future<Result> = 0;
   virtual auto allModules() const
       -> futures::Future<std::unordered_map<std::string, Module>> = 0;
+  virtual auto module(ModuleName const& name) const
+      -> futures::Future<std::optional<Module>> = 0;
   virtual auto executeFunction(ModuleName const& moduleName,
                                FunctionName const& functionName,
                                FunctionParameters const& parameters) const

--- a/arangod/WasmServer/WasmCommon.cpp
+++ b/arangod/WasmServer/WasmCommon.cpp
@@ -18,10 +18,9 @@ using namespace arangodb::wasm;
 using namespace arangodb::velocypack;
 
 void codeToVelocypack(Code const& code, VPackBuilder& builder) {
-  auto ab = VPackArrayBuilder(&builder);
-  for (auto const& entry : code.bytes) {
-    builder.add(VPackValue(entry));
-  }
+  std::string string(code.bytes.begin(), code.bytes.end());
+  auto encodedString = arangodb::basics::StringUtils::encodeBase64(string);
+  builder.add(VPackValue(encodedString));
 }
 
 void arangodb::wasm::moduleToVelocypack(Module const& module,

--- a/arangod/WasmServer/WasmServerFeature.cpp
+++ b/arangod/WasmServer/WasmServerFeature.cpp
@@ -83,7 +83,20 @@ void WasmServerFeature::deleteModule(ModuleName const& name) {
 
 auto WasmServerFeature::allModules() const
     -> std::unordered_map<std::string, Module> {
-  return _guardedModules.doUnderLock([&](GuardedModules const& guardedModules) {
+  return _guardedModules.doUnderLock([](GuardedModules const& guardedModules) {
     return guardedModules._modules;
   });
+}
+
+auto WasmServerFeature::module(ModuleName const& name) const
+    -> std::optional<Module> {
+  return _guardedModules.doUnderLock(
+      [&name](GuardedModules const& guardedModules) -> std::optional<Module> {
+        auto module = guardedModules._modules.find(name.string);
+        if (module == std::end(guardedModules._modules)) {
+          return std::nullopt;
+        } else {
+          return module->second;
+        }
+      });
 }

--- a/arangod/WasmServer/WasmServerFeature.h
+++ b/arangod/WasmServer/WasmServerFeature.h
@@ -50,6 +50,8 @@ class WasmServerFeature final : public ArangodFeature {
       -> std::optional<uint64_t>;
   void deleteModule(wasm::ModuleName const& name);
   auto allModules() const -> std::unordered_map<std::string, wasm::Module>;
+  auto module(wasm::ModuleName const& name) const
+      -> std::optional<wasm::Module>;
 
  private:
   struct GuardedModules {

--- a/js/client/modules/@arangodb/aql/wasmFunctions.js
+++ b/js/client/modules/@arangodb/aql/wasmFunctions.js
@@ -50,7 +50,7 @@ var base64 = function (file) {
 var unregisterFunction = function (name) {
   'use strict';
 
-  var requestResult = db._connection.DELETE('/_api/wasm/', { name });
+  var requestResult = db._connection.DELETE('/_api/wasm/' + name);
 
   arangosh.checkRequestResult(requestResult);
   return requestResult.result;

--- a/js/client/modules/@arangodb/aql/wasmModules.js
+++ b/js/client/modules/@arangodb/aql/wasmModules.js
@@ -44,10 +44,10 @@ var base64 = function (file) {
 };
 
 // //////////////////////////////////////////////////////////////////////////////
-// / @brief was docuBlock delete a user-defined webassembly function by name
+// / @brief was docuBlock delete a user-defined webassembly module by name
 // //////////////////////////////////////////////////////////////////////////////
 
-var unregisterFunction = function (name) {
+var unregisterModule = function (name) {
   'use strict';
 
   var requestResult = db._connection.DELETE('/_api/wasm/' + name);
@@ -57,11 +57,11 @@ var unregisterFunction = function (name) {
 };
 
 // //////////////////////////////////////////////////////////////////////////////
-// / @brief was docuBlock add a user-defined webassembly function.
+// / @brief was docuBlock add a user-defined webassembly module.
 //                        codefile is the path to the webassembly code file
 // //////////////////////////////////////////////////////////////////////////////
 
-var registerFunction = function (name, codefile, isDeterministic = false) {
+var registerModuleByFile = function (name, codefile, isDeterministic = false) {
   var db = internal.db;
 
   var requestResult = db._connection.POST('/_api/wasm/',
@@ -76,10 +76,29 @@ var registerFunction = function (name, codefile, isDeterministic = false) {
 };
 
 // //////////////////////////////////////////////////////////////////////////////
-// / @brief was docuBlock get all user-defined webassembly functions
+// / @brief was docuBlock add a user-defined webassembly module.
+//                        codefile is the path to the webassembly code file
 // //////////////////////////////////////////////////////////////////////////////
 
-var toArrayFunctions = function () {
+var registerModuleByBase64 = function (name, base64code, isDeterministic = false) {
+  var db = internal.db;
+
+  var requestResult = db._connection.POST('/_api/wasm/',
+                                          {
+                                            name: name,
+                                            code: base64code,
+                                            isDeterministic: isDeterministic
+                                          });
+  
+  arangosh.checkRequestResult(requestResult);
+  return requestResult.result;
+};
+
+// //////////////////////////////////////////////////////////////////////////////
+// / @brief was docuBlock get all user-defined webassembly modules
+// //////////////////////////////////////////////////////////////////////////////
+
+var toArrayModules = function () {
   'use strict';
 
     var requestResult = db._connection.GET('/_api/wasm/');
@@ -88,6 +107,7 @@ var toArrayFunctions = function () {
   return requestResult.result;
 };
 
-exports.unregister = unregisterFunction;
-exports.register = registerFunction;
-exports.toArray = toArrayFunctions;
+exports.unregister = unregisterModule;
+exports.registerByFile = registerModuleByFile;
+exports.register = registerModuleByBase64;
+exports.toArray = toArrayModules;

--- a/js/client/modules/@arangodb/aql/wasmModules.js
+++ b/js/client/modules/@arangodb/aql/wasmModules.js
@@ -26,19 +26,16 @@
 // / @author Copyright 2022, ArangoDB GmbH, Cologne, Germany
 // //////////////////////////////////////////////////////////////////////////////
 
+'use strict';
 var internal = require('internal');
 var arangosh = require('@arangodb/arangosh');
 var fs = require('fs');
-
-var ArangoError = require('@arangodb').ArangoError;
 
 // //////////////////////////////////////////////////////////////////////////////
 // / @brief encode data in file with base64 
 // //////////////////////////////////////////////////////////////////////////////
 
 var base64 = function (file) {
-  'use strict';
-
     var buffer = fs.readFileSync(file);
     return buffer.toString('base64');
 };
@@ -48,10 +45,7 @@ var base64 = function (file) {
 // //////////////////////////////////////////////////////////////////////////////
 
 var unregisterModule = function (name) {
-  'use strict';
-
   var requestResult = db._connection.DELETE('/_api/wasm/' + name);
-
   arangosh.checkRequestResult(requestResult);
   return requestResult.result;
 };
@@ -62,15 +56,12 @@ var unregisterModule = function (name) {
 // //////////////////////////////////////////////////////////////////////////////
 
 var registerModuleByFile = function (name, codefile, isDeterministic = false) {
-  var db = internal.db;
-
   var requestResult = db._connection.POST('/_api/wasm/',
                                           {
                                             name: name,
                                             code: base64(codefile),
                                             isDeterministic: isDeterministic
                                           });
-  
   arangosh.checkRequestResult(requestResult);
   return requestResult.result;
 };
@@ -81,15 +72,12 @@ var registerModuleByFile = function (name, codefile, isDeterministic = false) {
 // //////////////////////////////////////////////////////////////////////////////
 
 var registerModuleByBase64 = function (name, base64code, isDeterministic = false) {
-  var db = internal.db;
-
   var requestResult = db._connection.POST('/_api/wasm/',
                                           {
                                             name: name,
                                             code: base64code,
                                             isDeterministic: isDeterministic
                                           });
-  
   arangosh.checkRequestResult(requestResult);
   return requestResult.result;
 };
@@ -99,15 +87,23 @@ var registerModuleByBase64 = function (name, base64code, isDeterministic = false
 // //////////////////////////////////////////////////////////////////////////////
 
 var toArrayModules = function () {
-  'use strict';
-
-    var requestResult = db._connection.GET('/_api/wasm/');
-
+  var requestResult = db._connection.GET('/_api/wasm/');
   arangosh.checkRequestResult(requestResult);
   return requestResult.result;
 };
+
+// //////////////////////////////////////////////////////////////////////////////
+// / @brief was docuBlock show detail information of user-defined webassembly module
+// //////////////////////////////////////////////////////////////////////////////
+
+var showModule = function (name) {
+  var requestResult = db._connection.GET('/_api/wasm/' + name);
+  arangosh.checkRequestResult(requestResult);
+  return requestResult.result;
+}
 
 exports.unregister = unregisterModule;
 exports.registerByFile = registerModuleByFile;
 exports.register = registerModuleByBase64;
 exports.toArray = toArrayModules;
+exports.show = showModule;

--- a/js/common/bootstrap/errors.js
+++ b/js/common/bootstrap/errors.js
@@ -363,6 +363,7 @@
     "ERROR_HOT_BACKUP_DBSERVERS_AWOL" : { "code" : 7012, "message" : "hot backup not all db servers reachable" },
     "ERROR_CLUSTER_COULD_NOT_MODIFY_ANALYZERS_IN_PLAN" : { "code" : 7021, "message" : "analyzers in plan could not be modified" },
     "ERROR_AIR_EXECUTION_ERROR"    : { "code" : 8001, "message" : "error during AIR execution" },
+    "ERROR_WASM_EXECUTION_ERROR"    : { "code" : 8002, "message" : "error during WASM execution" },
     "ERROR_LICENSE_EXPIRED_OR_INVALID" : { "code" : 9001, "message" : "license has expired or is invalid" },
     "ERROR_LICENSE_SIGNATURE_VERIFICATION" : { "code" : 9002, "message" : "license verification failed" },
     "ERROR_LICENSE_NON_MATCHING_ID" : { "code" : 9003, "message" : "non-matching license id" },

--- a/lib/Basics/voc-errors.h
+++ b/lib/Basics/voc-errors.h
@@ -1931,6 +1931,11 @@
 /// During the execution of an AIR program an error occurred
 #define TRI_ERROR_AIR_EXECUTION_ERROR (::ErrorCode{8001})
 
+/// 8002: ERROR_WASM_EXECUTION_ERROR
+/// "error during WASM execution"
+/// An error occured during the execution of function in the WASM vm
+#define TRI_ERROR_WASM_EXECUTION_ERROR (::ErrorCode{8002})
+
 /// 9001: ERROR_LICENSE_EXPIRED_OR_INVALID
 /// "license has expired or is invalid"
 /// The license has expired or is invalid.

--- a/tests/WasmServer/WasmFunctionSliceTest.cpp
+++ b/tests/WasmServer/WasmFunctionSliceTest.cpp
@@ -110,7 +110,7 @@ TEST(WasmModuleConversion, converts_module_to_velocypack) {
   EXPECT_EQ(
       velocypackBuilder.toJson(),
       VPackParser::fromJson(
-          R"({"name": "module_name", "code": [3, 233], "isDeterministic": false})")
+          R"({"name": "module_name", "code": "A+k=", "isDeterministic": false})")
           ->slice()
           .toJson());
 }

--- a/tests/js/client/shell/shell-wasm.js
+++ b/tests/js/client/shell/shell-wasm.js
@@ -1,0 +1,167 @@
+/*jshint globalstrict:false, strict:false, maxlen: 200, unused: false*/
+/*global assertEqual, assertTrue, assertFalse, fail, AQL_WARNING */
+
+/* unused for functions with 'what' parameter.*/
+////////////////////////////////////////////////////////////////////////////////
+/// @brief test the AQL user functions management
+///
+/// @file
+///
+/// DISCLAIMER
+///
+/// Copyright 2022 ArangoDB GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Julia Volmer
+/// @author Copyright 2022, ArangoDB GmbH, Cologne, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+var jsunity = require("jsunity");
+var arangodb = require("@arangodb");
+var db = arangodb.db;
+var ERRORS = arangodb.errors;
+
+var wasmmodules = require("@arangodb/aql/wasmModules");
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief test suite
+////////////////////////////////////////////////////////////////////////////////
+
+function WasmModulesSuite () {
+  'use strict';
+
+    const modulename = "my_module";
+    const code = "AGFzbQEAAAABKwhgAAF/YAF/AX9gAn9/AX9gAABgAX8AYAN/f38Bf2ADf35/AX5gAn5+AX4CeQQWd2FzaV9zbmFwc2hvdF9wcmV2aWV3MQ5hcmdzX3NpemVzX2dldAACFndhc2lfc25hcHNob3RfcHJldmlldzEIYXJnc19nZXQAAhZ3YXNpX3NuYXBzaG90X3ByZXZpZXcxCXByb2NfZXhpdAAEA2VudgRtYWluAAIDCwoDBwMAAAAEAQEBBAUBcAECAgUGAQGAAoACBgkBfwFBoIjAAgsHeQkGbWVtb3J5AgADYWRkAAUZX19pbmRpcmVjdF9mdW5jdGlvbl90YWJsZQEABl9zdGFydAAGEF9fZXJybm9fbG9jYXRpb24ACAZmZmx1c2gADAlzdGFja1NhdmUACQxzdGFja1Jlc3RvcmUACgpzdGFja0FsbG9jAAsJBwEAQQELAQQKmQMKAwABCwcAIAAgAXwLBwAQBxACAAuNAQEEfyMAQRBrIgAkAAJAIAAiAkEMaiAAQQhqEABFBEACf0EAIAIoAgwiAUUNABogACABQQJ0IgNBE2pBcHFrIgAiASQAIAEgAigCCEEPakFwcWsiASQAIAAgA2pBADYCACAAIAEQAQ0CIAIoAgwLIAAQAyEAIAJBEGokACAADwtBxwAQAgALQccAEAIACwUAQYAICwQAIwALBgAgACQACxAAIwAgAGtBcHEiACQAIAALZwEBfyAABEAgACgCTEF/TARAIAAQDQ8LIAAQDQ8LQZAIKAIABEBBkAgoAgAQDCEBC0GMCCgCACIABEADQCAAKAJMGiAAKAIUIAAoAhxLBEAgABANIAFyIQELIAAoAjgiAA0ACwsgAQtpAQJ/AkAgACgCFCAAKAIcTQ0AIABBAEEAIAAoAiQRBQAaIAAoAhQNAEF/DwsgACgCBCIBIAAoAggiAkkEQCAAIAEgAmusQQEgACgCKBEGABoLIABBADYCHCAAQgA3AxAgAEIANwIEQQAL";
+    
+return {
+
+    tearDown : function () {
+	wasmmodules.unregister(modulename);
+    },
+
+    test_modules_are_initially_empty : function () {
+	assertEqual(wasmmodules.toArray(), []);
+    },
+
+    test_module_can_be_registered : function () {
+	assertEqual(wasmmodules.register(modulename, code), {"installed": modulename});
+    },
+
+    test_names_of_all_registered_modules_are_shown : function () {
+	wasmmodules.register(modulename, code);
+
+	assertEqual(wasmmodules.toArray(), [modulename]);
+    },
+
+    test_module_with_invalid_base64_encoded_code_cannot_be_registered : function () {
+	try {
+	    wasmmodules.register(modulename, "AB$(");
+	} catch (err) {
+	    assertEqual(err.errorNum, ERRORS.ERROR_BAD_PARAMETER.code);
+	}
+    },
+
+    test_existing_module_is_overwritten_with_module_of_same_name : function () {
+	wasmmodules.register(modulename, code, true);
+
+	wasmmodules.register(modulename, "AQL/", false);
+
+	assertEqual(wasmmodules.toArray(), [modulename]);
+	assertEqual(wasmmodules.show(modulename), {
+	    "result": {
+		"name": modulename,
+		"code": "AQL/",
+		"isDeterministic": false
+	    }});
+    },
+
+    test_a_registered_module_shows_its_detail_information : function () {
+	wasmmodules.register(modulename, code);
+
+	assertEqual(wasmmodules.show(modulename), {
+	    "result": {
+		"name": modulename,
+		"code": code,
+		"isDeterministic": false
+	    }});
+    },
+
+    test_querying_a_unknown_module_gives_an_error : function () {
+	try {
+	    wasmmodules.show("unknown_module");
+	} catch (err) {
+	    assertEqual(err.errorNum, ERRORS.ERROR_BAD_PARAMETER.code);
+	}
+    },
+
+    test_modules_can_be_unregistered : function () {
+	wasmmodules.register(modulename, code);
+
+	assertEqual(wasmmodules.unregister(modulename), {"removed": modulename});
+    },
+
+    test_modules_are_deleted_when_unregistered : function () {
+	wasmmodules.register(modulename, code);
+
+	wasmmodules.unregister(modulename);
+
+	assertEqual(wasmmodules.toArray(), []);
+    },
+
+    test_function_in_registered_module_is_exectable_via_AQL_query : function () {
+	wasmmodules.register(modulename, code);
+
+	const queryresult = db._query("RETURN CALL_WASM('" + modulename + "', 'add', 1, 4)").toArray();
+
+	assertEqual(queryresult, [ 5 ]);
+    },
+
+    test_unknown_module_execution_throws_error : function () {
+	try {
+	    const queryresult = db._query("RETURN CALL_WASM('unknown_module', 'add', 1, 4)").toArray();
+	} catch (err) {
+	    assertEqual(err.errorNum, ERRORS.ERROR_WASM_EXECUTION_ERROR.code);
+	}
+    },
+
+    test_unknown_function_execution_throws_error : function () {
+	wasmmodules.register(modulename, code);
+	
+	try {
+	    const queryresult = db._query("RETURN CALL_WASM('" + modulename + "', 'function_not_inside_module', 1, 4)").toArray();
+	} catch (err) {
+	    assertEqual(err.errorNum, ERRORS.ERROR_WASM_EXECUTION_ERROR.code);
+	}
+    },
+
+    test_wrong_code_cannot_be_executed : function () {
+	// TODO PREG-87 Return result from wasm3 and raise a different error in handler
+
+	wasmmodules.register(modulename, "AQL/");
+
+	try {
+	    const queryresult = db._query("RETURN CALL_WASM('" + modulename + "', 'function_not_inside_module', 1, 4)").toArray();
+	} catch (err) {
+	    assertEqual(err.errorNum, ERRORS.ERROR_INTERNAL.code);
+	}
+    },
+
+  };
+}
+
+jsunity.run(WasmModulesSuite);
+
+return jsunity.done();


### PR DESCRIPTION
PR adds javascript tests for wasm functions.
I also improved the wasm interface (arangosh and REST):
- fixed the deletion of a module
- PREG-81: in arangosh you can now upload code with a base64 string or a file that includes the compiled was code.
- improved the responses when creating or deleting a module
- added a GET request to show details of one module (including the code in base64)

