### PR TITLE
[PREG-107] Improve wasm execution time

### DIFF
--- a/arangod/WasmServer/Methods.cpp
+++ b/arangod/WasmServer/Methods.cpp
@@ -62,7 +62,7 @@ struct WasmVmMethodsSingleServer final
   auto executeFunction(ModuleName const& moduleName,
                        FunctionName const& functionName,
                        FunctionParameters const& parameters) const
-      -> futures::Future<std::optional<uint64_t>> override {
+      -> futures::Future<ResultT<uint64_t>> override {
     return vocbase.server().getFeature<WasmServerFeature>().executeFunction(
         moduleName, functionName, parameters);
   }

--- a/arangod/WasmServer/Methods.h
+++ b/arangod/WasmServer/Methods.h
@@ -50,7 +50,7 @@ struct WasmVmMethods {
   virtual auto executeFunction(ModuleName const& moduleName,
                                FunctionName const& functionName,
                                FunctionParameters const& parameters) const
-      -> futures::Future<std::optional<uint64_t>> = 0;
+      -> futures::Future<ResultT<uint64_t>> = 0;
   static auto createInstance(TRI_vocbase_t& vocbase)
       -> std::shared_ptr<WasmVmMethods>;
 };

--- a/arangod/WasmServer/RestWasmHandler.cpp
+++ b/arangod/WasmServer/RestWasmHandler.cpp
@@ -153,10 +153,8 @@ auto addWasmModule(VPackSlice slice, wasm::WasmVmMethods const& methods,
 
   auto create = methods.addModule(module.get());
 
-  {
-    VPackObjectBuilder ob1(&response);
-    response.add("installed", VPackValue(module.get().name.string));
-  }
+  VPackObjectBuilder ob1(&response);
+  response.add("installed", VPackValue(module.get().name.string));
   return Result{};
 }
 
@@ -175,17 +173,12 @@ auto executeWasmFunction(ModuleName const& moduleName,
       methods
           .executeFunction(moduleName, functionName, functionParameters.get())
           .get();
-  if (!result.has_value()) {
-    return Result{TRI_ERROR_BAD_PARAMETER,
-                  "RestWasmHandler: Function '" + functionName.string +
-                      "' in module '" + moduleName.string +
-                      "' cannot be found"};
+  if (result.fail()) {
+    return Result{result.errorNumber(), result.errorMessage()};
   }
 
-  {
-    VPackObjectBuilder ob(&response);
-    response.add("result", VPackValue(result.value()));
-  }
+  VPackObjectBuilder ob(&response);
+  response.add("result", VPackValue(result.get()));
   return Result{};
 }
 

--- a/arangod/WasmServer/Wasm3cpp.h
+++ b/arangod/WasmServer/Wasm3cpp.h
@@ -1,6 +1,7 @@
 // Taken from the wasm3 cpp platform example code
 #pragma once
 
+#include <optional>
 #include <tuple>
 #include <algorithm>
 #include <type_traits>
@@ -10,7 +11,6 @@
 #include <string>
 #include <iterator>
 #include <cassert>
-#include "Basics/ResultT.h"
 
 #include "wasm3.h"
 
@@ -220,7 +220,7 @@ class runtime {
    * @param name  name of a function, c-string
    * @return function object
    */
-  ResultT<function> find_function(const char* name);
+  std::optional<function> find_function(const char* name);
 
  protected:
   friend class environment;
@@ -388,12 +388,11 @@ inline module environment::parse_module(const uint8_t* data, size_t size) {
 
 inline void runtime::load(module& mod) { mod.load_into(m_runtime.get()); }
 
-inline ResultT<function> runtime::find_function(const char* name) {
+inline std::optional<function> runtime::find_function(const char* name) {
   M3Function* m_func = nullptr;
   M3Result err = m3_FindFunction(&m_func, m_runtime.get(), name);
   if (err != m3Err_none or m_func == nullptr) {
-    return ResultT<function>::error(TRI_ERROR_BAD_PARAMETER,
-                                    "Function not found");
+    return std::nullopt;
   }
   return function(m_func);
 }

--- a/tests/js/client/shell/shell-wasm.js
+++ b/tests/js/client/shell/shell-wasm.js
@@ -50,6 +50,8 @@ return {
 
     tearDown : function () {
 	wasmmodules.unregister(modulename);
+	// Keep in mind that modules that are once loaded into the runtime (by trying to execute a function from it)
+	// will be in the runtime forever, they cannot be deleted from there. This will change with PREG-108.
     },
 
     test_modules_are_initially_empty : function () {
@@ -148,12 +150,15 @@ return {
     },
 
     test_wrong_code_cannot_be_executed : function () {
-	// TODO PREG-87 Return result from wasm3 and raise a different error in handler
+	wasmmodules.register("new_module", "AQL/");
+	// TODO PREG-108 Use modulename to make sure that it is unregistered after the test
+	// (cannot be done right, see reason in tearDown function)
 
-	wasmmodules.register(modulename, "AQL/");
+	// TODO PREG-87 Return result from wasm3 parse_module function
+	// and return ERROR_WASM_EXECUTION_ERROR in handler
 
 	try {
-	    const queryresult = db._query("RETURN CALL_WASM('" + modulename + "', 'function_not_inside_module', 1, 4)").toArray();
+	    const queryresult = db._query("RETURN CALL_WASM('new_module', 'function_not_inside_module', 1, 4)").toArray();
 	} catch (err) {
 	    assertEqual(err.errorNum, ERRORS.ERROR_INTERNAL.code);
 	}


### PR DESCRIPTION
Execution time is not down to 0.02 s for wasm addition vs something between 0.01 0.02 s for native addition (10.000 rows).

Runtime is created when the feature is constructed.
A set makes sure that we load modules only once into the runtime.

Unclear:
- Currently there is no possibility to delete a module from the runtime
- Not sure if the loadedModules set has to be guarded, nothing is deleted from it so far, therefore I think it should be ok like it is right now