### PR TITLE
Add type inspection for VPack de/serialization.

### DIFF
--- a/lib/Inspection/Access.h
+++ b/lib/Inspection/Access.h
@@ -1,0 +1,364 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2022 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Manuel Pöter
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <type_traits>
+#include <utility>
+
+#include <velocypack/Value.h>
+
+#include "Inspection/detail/traits.h"
+
+namespace arangodb::inspection {
+
+template<class T>
+struct Access;
+
+template<class T>
+struct AccessBase;
+
+template<class Inspector, class T>
+[[nodiscard]] auto process(Inspector& f, T& x) {
+  using TT = std::remove_cvref_t<T>;
+  static_assert(detail::IsInspectable<TT, Inspector>());
+  if constexpr (detail::HasInspectOverload<TT, Inspector>::value) {
+    return static_cast<Result>(inspect(f, x));
+  } else if constexpr (detail::HasAccessSpecialization<TT>()) {
+    return Access<T>::apply(f, x);
+  } else if constexpr (detail::IsBuiltinType<TT>()) {
+    return f.value(x);
+  } else if constexpr (detail::IsTuple<TT>::value) {
+    return f.tuple(x);
+  } else if constexpr (detail::IsMapLike<TT>::value) {
+    return f.map(x);
+  } else if constexpr (detail::IsListLike<TT>::value) {
+    return f.list(x);
+  }
+}
+
+template<class Inspector, class T>
+[[nodiscard]] Result process(Inspector& f, T const& x) {
+  static_assert(!Inspector::isLoading);
+  return process(f, const_cast<T&>(x));
+}
+
+template<class Inspector, class Value>
+[[nodiscard]] auto saveField(Inspector& f, std::string_view name, Value& val) {
+  return detail::AccessType<Value>::saveField(f, name, val);
+}
+
+template<class Inspector, class Value, class Transformer>
+[[nodiscard]] auto saveTransformedField(Inspector& f, std::string_view name,
+                                        Value& val, Transformer& transformer) {
+  return detail::AccessType<Value>::saveTransformedField(f, name, val,
+                                                         transformer);
+}
+
+template<class Inspector, class Value>
+[[nodiscard]] Result loadField(Inspector& f, std::string_view name,
+                               Value& val) {
+  return detail::AccessType<Value>::loadField(f, name, val);
+}
+
+template<class Inspector, class Value, class Fallback>
+[[nodiscard]] Result loadField(Inspector& f,
+                               [[maybe_unused]] std::string_view name,
+                               Value& val, Fallback&& fallback) {
+  return detail::AccessType<Value>::loadField(f, name, val, fallback);
+}
+
+template<class Inspector, class Value, class Transformer>
+[[nodiscard]] Result loadTransformedField(Inspector& f, std::string_view name,
+                                          Value& val,
+                                          Transformer& transformer) {
+  return detail::AccessType<Value>::loadTransformedField(f, name, val,
+                                                         transformer);
+}
+
+template<class Inspector, class Value, class Fallback, class Transformer>
+[[nodiscard]] Result loadTransformedField(
+    Inspector& f, [[maybe_unused]] std::string_view name, Value& val,
+    Fallback&& fallback, Transformer& transformer) {
+  return detail::AccessType<Value>::loadTransformedField(f, name, val, fallback,
+                                                         transformer);
+}
+
+template<class Value>
+struct AccessBase {
+  template<class Inspector>
+  [[nodiscard]] static auto saveField(Inspector& f, std::string_view name,
+                                      Value& val) {
+    f.builder().add(VPackValue(name));
+    return f.apply(val);
+  }
+
+  template<class Inspector, class Transformer>
+  [[nodiscard]] static Result saveTransformedField(Inspector& f,
+                                                   std::string_view name,
+                                                   Value& val,
+                                                   Transformer& transformer) {
+    typename Transformer::SerializedType v;
+    return transformer.toSerialized(val, v)                        //
+           | [&]() { return inspection::saveField(f, name, v); };  //
+  }
+
+  template<class Inspector>
+  [[nodiscard]] static Result loadField(Inspector& f, std::string_view name,
+                                        Value& val) {
+    auto s = f.slice();
+    if (s.isNone()) {
+      return {"Missing required attribute '" + std::string(name) + "'"};
+    }
+    return f.apply(val);
+  }
+
+  template<class Inspector, class Fallback>
+  [[nodiscard]] static Result loadField(Inspector& f, std::string_view name,
+                                        Value& val, Fallback& fallback) {
+    auto s = f.slice();
+    if (s.isNone()) {
+      if constexpr (std::is_assignable_v<Value, Fallback>) {
+        val = std::forward<Fallback>(fallback);
+      } else {
+        val = Value{std::forward<Fallback>(fallback)};
+      }
+      return {};
+    }
+    return f.apply(val);
+  }
+
+  template<class Inspector, class Transformer>
+  [[nodiscard]] static Result loadTransformedField(Inspector& f,
+                                                   std::string_view name,
+                                                   Value& val,
+                                                   Transformer& transformer) {
+    typename Transformer::SerializedType v;
+    return inspection::loadField(f, name, v)                        //
+           | [&]() { return transformer.fromSerialized(v, val); };  //
+  }
+
+  template<class Inspector, class Fallback, class Transformer>
+  [[nodiscard]] static Result loadTransformedField(Inspector& f,
+                                                   std::string_view name,
+                                                   Value& val,
+                                                   Fallback&& fallback,
+                                                   Transformer& transformer) {
+    auto s = f.slice();
+    if (s.isNone()) {
+      if constexpr (std::is_assignable_v<Value, Fallback>) {
+        val = std::forward<Fallback>(fallback);
+      } else {
+        val = Value{std::forward<Fallback>(fallback)};
+      }
+      return {};
+    }
+    typename Transformer::SerializedType v;
+    return f.apply(v)                                               //
+           | [&]() { return transformer.fromSerialized(v, val); };  //
+  }
+};
+
+template<class T>
+struct Access<std::optional<T>> {
+  template<class Inspector>
+  [[nodiscard]] static Result apply(Inspector& f, std::optional<T>& val) {
+    if constexpr (Inspector::isLoading) {
+      if (f.slice().isNone() || f.slice().isNull()) {
+        val.reset();
+        return {};
+      } else {
+        T v;
+        auto assign = [&]() -> Result::Success {
+          val = std::move(v);
+          return {};
+        };
+        return f.apply(v)  //
+               | assign;   //
+      }
+    } else {
+      if (val.has_value()) {
+        return f.apply(val.value());
+      }
+      f.builder().add(VPackValue(velocypack::ValueType::Null));
+      return {};
+    }
+  }
+
+  template<class Inspector>
+  [[nodiscard]] static auto saveField(Inspector& f, std::string_view name,
+                                      std::optional<T>& val)
+      -> decltype(inspection::saveField(f, name, val.value())) {
+    if (!val.has_value()) {
+      return {};
+    }
+    return inspection::saveField(f, name, val.value());
+  }
+
+  template<class Inspector, class Transformer>
+  [[nodiscard]] static Result saveTransformedField(Inspector& f,
+                                                   std::string_view name,
+                                                   std::optional<T>& val,
+                                                   Transformer& transformer) {
+    if (!val.has_value()) {
+      return {};
+    }
+    typename Transformer::SerializedType v;
+    return transformer.toSerialized(*val, v) |
+           [&]() { return inspection::saveField(f, name, v); };
+  }
+
+  template<class Inspector>
+  [[nodiscard]] static Result loadField(Inspector& f,
+                                        [[maybe_unused]] std::string_view name,
+                                        std::optional<T>& val) {
+    return f.apply(val);
+  }
+
+  template<class Inspector, class U>
+  [[nodiscard]] static Result loadField(Inspector& f,
+                                        [[maybe_unused]] std::string_view name,
+                                        std::optional<T>& val, U& fallback) {
+    auto s = f.slice();
+    if (s.isNone()) {
+      val = fallback;
+      return {};
+    }
+    return f.apply(val);
+  }
+
+  template<class Inspector, class Transformer>
+  [[nodiscard]] static Result loadTransformedField(
+      Inspector& f, [[maybe_unused]] std::string_view name,
+      std::optional<T>& val, Transformer& transformer) {
+    std::optional<typename Transformer::SerializedType> v;
+    auto load = [&]() -> Result {
+      if (!v.has_value()) {
+        val.reset();
+        return {};
+      }
+      T vv;
+      auto res = transformer.fromSerialized(*v, vv);
+      val = vv;
+      return res;
+    };
+    return f.apply(v)  //
+           | load;     //
+  }
+
+  template<class Inspector, class Fallback, class Transformer>
+  [[nodiscard]] static Result loadTransformedField(
+      Inspector& f, [[maybe_unused]] std::string_view name,
+      std::optional<T>& val, Fallback&& fallback, Transformer& transformer) {
+    auto s = f.slice();
+    if (s.isNone()) {
+      if constexpr (std::is_assignable_v<std::optional<T>, Fallback>) {
+        val = std::forward<Fallback>(fallback);
+      } else {
+        val = std::optional<T>{std::forward<Fallback>(fallback)};
+      }
+      return {};
+    }
+    return loadTransformedField(f, name, val, transformer);
+  }
+};
+
+template<class Derived, class T>
+struct PointerAccess {
+  template<class Inspector>
+  [[nodiscard]] static Result apply(Inspector& f, T& val) {
+    if constexpr (Inspector::isLoading) {
+      if (f.slice().isNone() || f.slice().isNull()) {
+        val.reset();
+        return {};
+      }
+      val = Derived::make();  // TODO - reuse existing object?
+      return f.apply(*val);
+    } else {
+      if (val != nullptr) {
+        return f.apply(*val);
+      }
+      f.builder().add(VPackValue(velocypack::ValueType::Null));
+      return {};
+    }
+  }
+
+  template<class Inspector>
+  [[nodiscard]] static auto saveField(Inspector& f, std::string_view name,
+                                      T& val)
+      -> decltype(inspection::saveField(f, name, *val)) {
+    if (val == nullptr) {
+      return {};
+    }
+    return inspection::saveField(f, name, *val);
+  }
+
+  template<class Inspector>
+  [[nodiscard]] static Result loadField(Inspector& f,
+                                        [[maybe_unused]] std::string_view name,
+                                        T& val) {
+    auto s = f.slice();
+    if (s.isNone() || s.isNull()) {
+      val.reset();
+      return {};
+    }
+    val = Derived::make();  // TODO - reuse existing object?
+    return f.apply(val);
+  }
+
+  template<class Inspector, class U>
+  [[nodiscard]] static Result loadField(Inspector& f,
+                                        [[maybe_unused]] std::string_view name,
+                                        T& val, U& fallback) {
+    auto s = f.slice();
+    if (s.isNone()) {
+      val = fallback;
+      return {};
+    } else if (s.isNull()) {
+      val.reset();
+      return {};
+    }
+    val = Derived::make();  // TODO - reuse existing object?
+    return f.apply(val);
+  }
+};
+
+template<class T, class Deleter>
+struct Access<std::unique_ptr<T, Deleter>>
+    : PointerAccess<Access<std::unique_ptr<T, Deleter>>,
+                    std::unique_ptr<T, Deleter>> {
+  static auto make() { return std::make_unique<T>(); }
+};
+
+template<class T>
+struct Access<std::shared_ptr<T>>
+    : PointerAccess<Access<std::shared_ptr<T>>, std::shared_ptr<T>> {
+  static auto make() { return std::make_shared<T>(); }
+};
+
+}  // namespace arangodb::inspection

--- a/lib/Inspection/InspectorBase.h
+++ b/lib/Inspection/InspectorBase.h
@@ -35,6 +35,12 @@
 
 namespace arangodb::inspection {
 
+#ifdef _MSC_VER
+#define EMPTY_BASE __declspec(empty_bases)
+#else
+#define EMPTY_BASE
+#endif
+
 template<class Derived>
 struct InspectorBase {
   Derived& self() { return static_cast<Derived&>(*this); }
@@ -204,7 +210,7 @@ struct InspectorBase {
 
  private:
   template<class Field>
-  struct InvariantMixin {
+  struct EMPTY_BASE InvariantMixin {
     template<class Predicate>
     [[nodiscard]] auto invariant(Predicate predicate) && {
       return InvariantField<Field, Predicate>(
@@ -233,7 +239,7 @@ struct InspectorBase {
                          InvariantMixin<Inner>>;
 
   template<class Field>
-  struct FallbackMixin {
+  struct EMPTY_BASE FallbackMixin {
     template<class U>
     [[nodiscard]] auto fallback(U&& val) && {
       static_assert(std::is_constructible_v<typename Field::value_type, U>);
@@ -257,7 +263,7 @@ struct InspectorBase {
                                           std::monostate, FallbackMixin<Inner>>;
 
   template<class Field>
-  struct TransformMixin {
+  struct EMPTY_BASE TransformMixin {
     template<class T>
     [[nodiscard]] auto transformWith(T transformer) && {
       return TransformField<Field, T>(std::move(static_cast<Field&>(*this)),
@@ -280,7 +286,8 @@ struct InspectorBase {
 
  public:
   template<class InnerField, class U>
-  struct FallbackField : Derived::template FallbackContainer<U>,
+  struct EMPTY_BASE FallbackField
+      : Derived::template FallbackContainer<U>,
                          WithInvariant<FallbackField<InnerField, U>>,
                          WithTransform<FallbackField<InnerField, U>> {
     FallbackField(InnerField inner, U&& val)
@@ -291,7 +298,8 @@ struct InspectorBase {
   };
 
   template<class InnerField, class Invariant>
-  struct InvariantField : Derived::template InvariantContainer<Invariant>,
+  struct EMPTY_BASE InvariantField
+      : Derived::template InvariantContainer<Invariant>,
                           WithFallback<InvariantField<InnerField, Invariant>>,
                           WithTransform<InvariantField<InnerField, Invariant>> {
     InvariantField(InnerField inner, Invariant&& invariant)
@@ -302,7 +310,8 @@ struct InspectorBase {
   };
 
   template<class InnerField, class T>
-  struct TransformField : WithInvariant<TransformField<InnerField, T>>,
+  struct EMPTY_BASE TransformField
+      : WithInvariant<TransformField<InnerField, T>>,
                           WithFallback<TransformField<InnerField, T>> {
     TransformField(InnerField inner, T&& transformer)
         : inner(std::move(inner)), transformer(std::move(transformer)) {}
@@ -312,7 +321,7 @@ struct InspectorBase {
   };
 
   template<typename DerivedField>
-  struct BasicField : InvariantMixin<DerivedField>,
+  struct EMPTY_BASE BasicField : InvariantMixin<DerivedField>,
                       FallbackMixin<DerivedField>,
                       TransformMixin<DerivedField> {
     explicit BasicField(std::string_view name) : name(name) {}
@@ -320,7 +329,7 @@ struct InspectorBase {
   };
 
   template<typename T>
-  struct RawField : BasicField<RawField<T>> {
+  struct EMPTY_BASE RawField : BasicField<RawField<T>> {
     RawField(std::string_view name, T& value)
         : BasicField<RawField>(name), value(value) {}
     using value_type = T;

--- a/lib/Inspection/InspectorBase.h
+++ b/lib/Inspection/InspectorBase.h
@@ -288,8 +288,8 @@ struct InspectorBase {
   template<class InnerField, class U>
   struct EMPTY_BASE FallbackField
       : Derived::template FallbackContainer<U>,
-                         WithInvariant<FallbackField<InnerField, U>>,
-                         WithTransform<FallbackField<InnerField, U>> {
+        WithInvariant<FallbackField<InnerField, U>>,
+        WithTransform<FallbackField<InnerField, U>> {
     FallbackField(InnerField inner, U&& val)
         : Derived::template FallbackContainer<U>(std::move(val)),
           inner(std::move(inner)) {}
@@ -300,8 +300,8 @@ struct InspectorBase {
   template<class InnerField, class Invariant>
   struct EMPTY_BASE InvariantField
       : Derived::template InvariantContainer<Invariant>,
-                          WithFallback<InvariantField<InnerField, Invariant>>,
-                          WithTransform<InvariantField<InnerField, Invariant>> {
+        WithFallback<InvariantField<InnerField, Invariant>>,
+        WithTransform<InvariantField<InnerField, Invariant>> {
     InvariantField(InnerField inner, Invariant&& invariant)
         : Derived::template InvariantContainer<Invariant>(std::move(invariant)),
           inner(std::move(inner)) {}
@@ -312,7 +312,7 @@ struct InspectorBase {
   template<class InnerField, class T>
   struct EMPTY_BASE TransformField
       : WithInvariant<TransformField<InnerField, T>>,
-                          WithFallback<TransformField<InnerField, T>> {
+        WithFallback<TransformField<InnerField, T>> {
     TransformField(InnerField inner, T&& transformer)
         : inner(std::move(inner)), transformer(std::move(transformer)) {}
     using value_type = typename InnerField::value_type;
@@ -322,8 +322,8 @@ struct InspectorBase {
 
   template<typename DerivedField>
   struct EMPTY_BASE BasicField : InvariantMixin<DerivedField>,
-                      FallbackMixin<DerivedField>,
-                      TransformMixin<DerivedField> {
+                                 FallbackMixin<DerivedField>,
+                                 TransformMixin<DerivedField> {
     explicit BasicField(std::string_view name) : name(name) {}
     std::string_view name;
   };

--- a/lib/Inspection/InspectorBase.h
+++ b/lib/Inspection/InspectorBase.h
@@ -337,4 +337,6 @@ struct InspectorBase {
   };
 };
 
+#undef EMPTY_BASE
+
 }  // namespace arangodb::inspection

--- a/lib/Inspection/InspectorBase.h
+++ b/lib/Inspection/InspectorBase.h
@@ -1,0 +1,331 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2022 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Manuel Pöter
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include <array>
+#include <functional>
+#include <string_view>
+#include <type_traits>
+#include <variant>
+
+#include <velocypack/Iterator.h>
+
+#include "Inspection/Access.h"
+
+namespace arangodb::inspection {
+
+template<class Derived>
+struct InspectorBase {
+  Derived& self() { return static_cast<Derived&>(*this); }
+
+  template<class T>
+  [[nodiscard]] Result apply(T& x) {
+    return process(self(), x);
+  }
+
+  template<class T>
+  struct Object;
+
+  template<class T, const char ErrorMsg[], class Func, class... Args>
+  static Result checkInvariant(Func&& func, Args&&... args) {
+    using result_t = std::invoke_result_t<Func, Args...>;
+    if constexpr (std::is_same_v<result_t, bool>) {
+      if (!std::invoke(std::forward<Func>(func), std::forward<Args>(args)...)) {
+        return {ErrorMsg};
+      }
+      return {};
+    } else {
+      static_assert(std::is_same_v<result_t, Result>,
+                    "Invariants must either return bool or "
+                    "velocypack::inspection::Result");
+      return std::invoke(std::forward<Func>(func), std::forward<Args>(args)...);
+    }
+  }
+
+  template<class T>
+  struct FieldsResult {
+    template<class Invariant>
+    Result invariant(Invariant&& func) {
+      if constexpr (Derived::isLoading) {
+        if (!result.ok()) {
+          return std::move(result);
+        }
+        return checkInvariant<FieldsResult, FieldsResult::InvariantFailedError>(
+            std::forward<Invariant>(func), object);
+      } else {
+        return std::move(result);
+      }
+    }
+    operator Result() && { return std::move(result); }
+
+    static constexpr const char InvariantFailedError[] =
+        "Object invariant failed";
+
+   private:
+    template<class TT>
+    friend struct Object;
+    FieldsResult(Result&& res, T& object)
+        : result(std::move(res)), object(object) {}
+    Result result;
+    T& object;
+  };
+
+  template<class T>
+  struct Object {
+    template<class... Args>
+    [[nodiscard]] FieldsResult<T> fields(Args&&... args) {
+      auto& i = inspector;
+      auto res =
+          i.beginObject()                                                 //
+          | [&]() { return i.applyFields(std::forward<Args>(args)...); }  //
+          | [&]() { return i.endObject(); };                              //
+
+      return {std::move(res), object};
+    }
+
+   private:
+    friend struct InspectorBase;
+    explicit Object(Derived& inspector, T& o)
+        : inspector(inspector), object(o) {}
+
+    Derived& inspector;
+    T& object;
+  };
+
+  template<class InnerField, class Fallback>
+  struct FallbackField;
+
+  template<class InnerField, class Invariant>
+  struct InvariantField;
+
+  template<class InnerField, class Transformer>
+  struct TransformField;
+
+  template<typename DerivedField>
+  struct BasicField;
+
+  template<typename T>
+  struct RawField;
+
+  // TODO - support virtual fields with getter/setter
+  // template<typename T>
+  // struct VirtualField : BasicField<VirtualField<T>> {
+  //   using value_type = T;
+  // };
+
+  template<class T>
+  [[nodiscard]] Object<T> object(T& o) noexcept {
+    return Object<T>{self(), o};
+  }
+
+  template<typename T>
+  [[nodiscard]] RawField<T> field(std::string_view name,
+                                  T& value) const noexcept {
+    static_assert(!std::is_const<T>::value);
+    return RawField<T>{{name}, value};
+  }
+
+ protected:
+  template<class T>
+  struct IsRawField : std::false_type {};
+  template<class T>
+  struct IsRawField<RawField<T>> : std::true_type {};
+
+  template<class T>
+  struct IsTransformField : std::false_type {};
+  template<class T, class U>
+  struct IsTransformField<TransformField<T, U>> : std::true_type {};
+
+  template<class T>
+  struct IsFallbackField : std::false_type {};
+  template<class T, class U>
+  struct IsFallbackField<FallbackField<T, U>> : std::true_type {};
+
+  template<class T>
+  static std::string_view getFieldName(T& field) noexcept {
+    if constexpr (IsRawField<std::remove_cvref_t<T>>::value) {
+      return field.name;
+    } else {
+      return getFieldName(field.inner);
+    }
+  }
+
+  template<class T>
+  static auto& getFieldValue(T& field) noexcept {
+    if constexpr (IsRawField<std::remove_cvref_t<T>>::value) {
+      return field.value;
+    } else {
+      return getFieldValue(field.inner);
+    }
+  }
+
+  template<class T>
+  static decltype(auto) getFallbackValue(T& field) noexcept {
+    using TT = std::remove_cvref_t<T>;
+    if constexpr (IsFallbackField<TT>::value) {
+      auto& result = field.fallbackValue;  // We want to return a reference!
+      return result;
+    } else if constexpr (!IsRawField<TT>::value) {
+      return getFallbackValue(field.inner);
+    }
+  }
+
+  template<class T>
+  static decltype(auto) getTransformer(T& field) noexcept {
+    using TT = std::remove_cvref_t<T>;
+    if constexpr (IsTransformField<TT>::value) {
+      auto& result = field.transformer;  // We want to return a reference!
+      return result;
+    } else if constexpr (!IsRawField<TT>::value) {
+      return getTransformer(field.inner);
+    }
+  }
+
+ private:
+  template<class Field>
+  struct InvariantMixin {
+    template<class Predicate>
+    [[nodiscard]] auto invariant(Predicate predicate) && {
+      return InvariantField<Field, Predicate>(
+          std::move(static_cast<Field&>(*this)), std::move(predicate));
+    }
+  };
+
+  template<class Field, class = void>
+  struct HasInvariantMethod : std::false_type {};
+
+  struct True {
+    template<class T>
+    bool operator()(T&&) {
+      return true;
+    }
+  };
+
+  template<class Field>
+  struct HasInvariantMethod<
+      Field, std::void_t<decltype(std::declval<Field>().invariant(True{}))>>
+      : std::true_type {};
+
+  template<class Inner>
+  using WithInvariant =
+      std::conditional_t<HasInvariantMethod<Inner>::value, std::monostate,
+                         InvariantMixin<Inner>>;
+
+  template<class Field>
+  struct FallbackMixin {
+    template<class U>
+    [[nodiscard]] auto fallback(U&& val) && {
+      static_assert(std::is_constructible_v<typename Field::value_type, U>);
+
+      return FallbackField<Field, U>(std::move(static_cast<Field&>(*this)),
+                                     std::forward<U>(val));
+    }
+  };
+
+  template<class Field, class = void>
+  struct HasFallbackMethod : std::false_type {};
+
+  template<class Field>
+  struct HasFallbackMethod<Field,
+                           std::void_t<decltype(std::declval<Field>().fallback(
+                               std::declval<typename Field::value_type>()))>>
+      : std::true_type {};
+
+  template<class Inner>
+  using WithFallback = std::conditional_t<HasFallbackMethod<Inner>::value,
+                                          std::monostate, FallbackMixin<Inner>>;
+
+  template<class Field>
+  struct TransformMixin {
+    template<class T>
+    [[nodiscard]] auto transformWith(T transformer) && {
+      return TransformField<Field, T>(std::move(static_cast<Field&>(*this)),
+                                      std::move(transformer));
+    }
+  };
+
+  template<class Field, class = void>
+  struct HasTransformMethod : std::false_type {};
+
+  template<class Field>
+  struct HasTransformMethod<
+      Field, std::void_t<decltype(std::declval<Field>().transformWith)>>
+      : std::true_type {};
+
+  template<class Inner>
+  using WithTransform =
+      std::conditional_t<HasTransformMethod<Inner>::value, std::monostate,
+                         TransformMixin<Inner>>;
+
+ public:
+  template<class InnerField, class U>
+  struct FallbackField : Derived::template FallbackContainer<U>,
+                         WithInvariant<FallbackField<InnerField, U>>,
+                         WithTransform<FallbackField<InnerField, U>> {
+    FallbackField(InnerField inner, U&& val)
+        : Derived::template FallbackContainer<U>(std::move(val)),
+          inner(std::move(inner)) {}
+    using value_type = typename InnerField::value_type;
+    InnerField inner;
+  };
+
+  template<class InnerField, class Invariant>
+  struct InvariantField : Derived::template InvariantContainer<Invariant>,
+                          WithFallback<InvariantField<InnerField, Invariant>>,
+                          WithTransform<InvariantField<InnerField, Invariant>> {
+    InvariantField(InnerField inner, Invariant&& invariant)
+        : Derived::template InvariantContainer<Invariant>(std::move(invariant)),
+          inner(std::move(inner)) {}
+    using value_type = typename InnerField::value_type;
+    InnerField inner;
+  };
+
+  template<class InnerField, class T>
+  struct TransformField : WithInvariant<TransformField<InnerField, T>>,
+                          WithFallback<TransformField<InnerField, T>> {
+    TransformField(InnerField inner, T&& transformer)
+        : inner(std::move(inner)), transformer(std::move(transformer)) {}
+    using value_type = typename InnerField::value_type;
+    InnerField inner;
+    T transformer;
+  };
+
+  template<typename DerivedField>
+  struct BasicField : InvariantMixin<DerivedField>,
+                      FallbackMixin<DerivedField>,
+                      TransformMixin<DerivedField> {
+    explicit BasicField(std::string_view name) : name(name) {}
+    std::string_view name;
+  };
+
+  template<typename T>
+  struct RawField : BasicField<RawField<T>> {
+    RawField(std::string_view name, T& value)
+        : BasicField<RawField>(name), value(value) {}
+    using value_type = T;
+    T& value;
+  };
+};
+
+}  // namespace arangodb::inspection

--- a/lib/Inspection/Result.h
+++ b/lib/Inspection/Result.h
@@ -1,0 +1,116 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2022 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Manuel Pöter
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include <memory>
+#include <string>
+
+#include "Basics/debugging.h"
+
+namespace arangodb::inspection {
+struct Result {
+  // Type that can be returned by a function instead of a Results
+  // to indicate that this function cannot fail.
+  struct Success {
+    constexpr bool ok() const noexcept { return true; }
+    constexpr bool canFail() const noexcept { return false; }
+  };
+
+  Result() = default;
+
+  Result(Success) : Result() {}
+
+  Result(std::string error)
+      : _error(std::make_unique<Error>(std::move(error))) {}
+
+  bool ok() const noexcept { return _error == nullptr; }
+  constexpr bool canFail() const noexcept { return true; }
+
+  std::string const& error() const noexcept {
+    TRI_ASSERT(!ok());
+    return _error->message;
+  }
+
+  std::string const& path() const noexcept {
+    TRI_ASSERT(!ok());
+    return _error->path;
+  }
+
+ private:
+  template<class T>
+  friend struct InspectorBase;
+  friend struct VPackLoadInspector;
+  friend struct VPackSaveInspector;
+
+  struct AttributeTag {};
+  struct ArrayTag {};
+
+  Result(Result&& res, std::string const& index, ArrayTag)
+      : Result(std::move(res)) {
+    prependPath("[" + index + "]");
+  }
+
+  Result(Result&& res, std::string_view attribute, AttributeTag)
+      : Result(std::move(res)) {
+    if (attribute.find('.') != std::string::npos) {
+      prependPath("['" + std::string(attribute) + "']");
+    } else {
+      prependPath(std::string(attribute));
+    }
+  }
+
+  void prependPath(std::string const& s) {
+    assert(!ok());
+    if (_error->path.empty()) {
+      _error->path = s;
+    } else {
+      if (_error->path[0] != '[') {
+        _error->path = "." + _error->path;
+      }
+      _error->path = s + _error->path;
+    }
+  }
+
+  struct Error {
+    explicit Error(std::string&& msg) : message(std::move(msg)) {}
+    std::string message;
+    std::string path;
+  };
+  std::unique_ptr<Error> _error;
+};
+
+template<class Func>
+Result operator|(Result&& res, Func&& func) {
+  if (!res.ok()) {
+    return std::move(res);
+  }
+  return func();
+}
+
+template<class Func>
+auto operator|(Result::Success&&, Func&& func) {
+  return func();
+}
+
+}  // namespace arangodb::inspection

--- a/lib/Inspection/VPack.h
+++ b/lib/Inspection/VPack.h
@@ -1,0 +1,64 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2020 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Manuel Pöter
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "Basics/Exceptions.h"
+#include "Basics/voc-errors.h"
+
+#include "Inspection/VPackLoadInspector.h"
+#include "Inspection/VPackSaveInspector.h"
+
+namespace arangodb::velocypack {
+
+template<class T>
+void serialize(Builder& builder, T& value) {
+  inspection::VPackSaveInspector inspector(builder);
+  if (auto res = inspector.apply(value); !res.ok()) {
+    THROW_ARANGO_EXCEPTION_MESSAGE(
+        TRI_ERROR_INTERNAL,
+        std::string{"Error while serializing to VelocyPack: "} + res.error() +
+            "\nPath: " + res.path());
+  }
+}
+
+template<class T>
+void deserialize(Slice slice, T& result,
+                 inspection::ParseOptions options = {}) {
+  inspection::VPackLoadInspector inspector(slice, options);
+  if (auto res = inspector.apply(result); !res.ok()) {
+    THROW_ARANGO_EXCEPTION_MESSAGE(
+        TRI_ERROR_INTERNAL, std::string{"Error while parsing VelocyPack: "} +
+                                res.error() + "\nPath: " + res.path());
+  }
+}
+
+template<class T>
+T deserialize(Slice slice, inspection::ParseOptions options = {}) {
+  inspection::VPackLoadInspector inspector(slice, options);
+  T result;
+  deserialize(slice, result);
+  return result;
+}
+
+}  // namespace arangodb::velocypack

--- a/lib/Inspection/VPackLoadInspector.h
+++ b/lib/Inspection/VPackLoadInspector.h
@@ -1,0 +1,307 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2022 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Manuel Pöter
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include <optional>
+#include <string_view>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+
+#include <velocypack/Builder.h>
+#include <velocypack/Iterator.h>
+#include <velocypack/Slice.h>
+#include <velocypack/Value.h>
+
+#include "Inspection/InspectorBase.h"
+
+namespace arangodb::inspection {
+
+struct ParseOptions {
+  bool ignoreUnknownFields = false;
+};
+
+struct VPackLoadInspector : InspectorBase<VPackLoadInspector> {
+  static constexpr bool isLoading = true;
+
+  explicit VPackLoadInspector(velocypack::Builder& builder,
+                              ParseOptions options = {})
+      : VPackLoadInspector(builder.slice(), options) {}
+  explicit VPackLoadInspector(velocypack::Slice slice, ParseOptions options)
+      : _slice(slice), _options(options) {}
+
+  template<class T, class = std::enable_if_t<std::is_integral_v<T>>>
+  [[nodiscard]] Result value(T& v) {
+    try {
+      v = _slice.getNumber<T>();
+      return {};
+    } catch (velocypack::Exception& e) {
+      return {e.what()};
+    }
+  }
+
+  [[nodiscard]] Result value(double& v) {
+    try {
+      v = _slice.getNumber<double>();
+      return {};
+    } catch (velocypack::Exception& e) {
+      return {e.what()};
+    }
+  }
+
+  [[nodiscard]] Result value(std::string& v) {
+    if (!_slice.isString()) {
+      return {"Expecting type String"};
+    }
+    v = _slice.copyString();
+    return {};
+  }
+
+  [[nodiscard]] Result value(bool& v) {
+    if (!_slice.isBool()) {
+      return {"Expecting type Bool"};
+    }
+    v = _slice.isTrue();
+    return {};
+  }
+
+  [[nodiscard]] Result beginObject() {
+    if (!_slice.isObject()) {
+      return {"Expecting type Object"};
+    }
+    return {};
+  }
+
+  [[nodiscard]] Result::Success endObject() { return {}; }
+
+  [[nodiscard]] Result beginArray() {
+    if (!_slice.isArray()) {
+      return {"Expecting type Array"};
+    }
+    return {};
+  }
+
+  [[nodiscard]] Result::Success endArray() { return {}; }
+
+  template<class T>
+  [[nodiscard]] Result list(T& list) {
+    return beginArray()                           //
+           | [&]() { return processList(list); }  //
+           | [&]() { return endArray(); };        //
+  }
+
+  template<class T>
+  [[nodiscard]] Result map(T& map) {
+    return beginObject()                        //
+           | [&]() { return processMap(map); }  //
+           | [&]() { return endObject(); };     //
+  }
+
+  template<class T>
+  [[nodiscard]] Result tuple(T& data) {
+    constexpr auto arrayLength = std::tuple_size_v<T>;
+
+    return beginArray()                                            //
+           | [&]() { return checkArrayLength(arrayLength); }       //
+           | [&]() { return processTuple<0, arrayLength>(data); }  //
+           | [&]() { return endArray(); };                         //
+  }
+
+  template<class T, size_t N>
+  [[nodiscard]] Result tuple(T (&data)[N]) {
+    return beginArray()                             //
+           | [&]() { return checkArrayLength(N); }  //
+           | [&]() { return processArray(data); }   //
+           | [&]() { return endArray(); };          //
+  }
+
+  template<class T>
+  [[nodiscard]] Result parseField(velocypack::Slice slice, T&& field) {
+    VPackLoadInspector ff(slice, _options);
+    auto name = getFieldName(field);
+    auto& value = getFieldValue(field);
+    auto load = [&]() {
+      if constexpr (!std::is_void_v<decltype(getFallbackValue(field))>) {
+        if constexpr (!std::is_void_v<decltype(getTransformer(field))>) {
+          return loadTransformedField(ff, name, value, getFallbackValue(field),
+                                      getTransformer(field));
+        } else {
+          return loadField(ff, name, value, getFallbackValue(field));
+        }
+      } else {
+        if constexpr (!std::is_void_v<decltype(getTransformer(field))>) {
+          return loadTransformedField(ff, name, value, getTransformer(field));
+        } else {
+          return loadField(ff, name, value);
+        }
+      }
+    };
+
+    auto res = load()                                      //
+               | [&]() { return checkInvariant(field); };  //
+
+    if (!res.ok()) {
+      return {std::move(res), name, Result::AttributeTag{}};
+    }
+    return res;
+  }
+
+  velocypack::Slice slice() noexcept { return _slice; }
+
+  ParseOptions options() const noexcept { return _options; }
+
+  template<class U>
+  struct FallbackContainer {
+    explicit FallbackContainer(U&& val) : fallbackValue(std::move(val)) {}
+    U fallbackValue;
+  };
+
+  template<class Invariant>
+  struct InvariantContainer {
+    explicit InvariantContainer(Invariant&& invariant)
+        : invariantFunc(std::move(invariant)) {}
+    Invariant invariantFunc;
+
+    static constexpr const char InvariantFailedError[] =
+        "Field invariant failed";
+  };
+
+  template<class... Args>
+  Result applyFields(Args&&... args) {
+    std::array<std::string_view, sizeof...(args)> names{getFieldName(args)...};
+    std::array<velocypack::Slice, sizeof...(args)> slices;
+    for (auto [k, v] : VPackObjectIterator(slice())) {
+      auto it = std::find(names.begin(), names.end(), k.stringView());
+      if (it != names.end()) {
+        slices[std::distance(names.begin(), it)] = v;
+      } else if (_options.ignoreUnknownFields) {
+        continue;
+      } else {
+        return {"Found unexpected attribute '" + k.copyString() + "'"};
+      }
+    }
+    return parseFields(slices.data(), std::forward<Args>(args)...);
+  }
+
+ private:
+  template<class T>
+  struct HasFallback : std::false_type {};
+
+  template<class T, class U>
+  struct HasFallback<FallbackField<T, U>> : std::true_type {};
+
+  template<class Arg>
+  Result parseFields(velocypack::Slice* slices, Arg&& arg) {
+    return parseField(*slices, std::forward<Arg>(arg));
+  }
+
+  template<class Arg, class... Args>
+  Result parseFields(velocypack::Slice* slices, Arg&& arg, Args&&... args) {
+    return parseField(*slices, std::forward<Arg>(arg)) |
+           [&]() { return parseFields(++slices, std::forward<Args>(args)...); };
+  }
+
+  template<class T>
+  Result processList(T& list) {
+    std::size_t idx = 0;
+    for (auto&& s : VPackArrayIterator(_slice)) {
+      VPackLoadInspector ff(s, _options);
+      typename T::value_type val;
+      if (auto res = process(ff, val); !res.ok()) {
+        return {std::move(res), std::to_string(idx), Result::ArrayTag{}};
+      }
+      list.push_back(std::move(val));
+      ++idx;
+    }
+    return {};
+  }
+
+  template<class T>
+  Result processMap(T& map) {
+    for (auto&& pair : VPackObjectIterator(_slice)) {
+      VPackLoadInspector ff(pair.value, _options);
+      typename T::mapped_type val;
+      if (auto res = process(ff, val); !res.ok()) {
+        return {std::move(res), "'" + pair.key.copyString() + "'",
+                Result::ArrayTag{}};
+      }
+      map.emplace(pair.key.copyString(), std::move(val));
+    }
+    return {};
+  }
+
+  template<class T, class U>
+  Result checkInvariant(InvariantField<T, U>& field) {
+    return InspectorBase::checkInvariant<
+        InvariantField<T, U>, InvariantField<T, U>::InvariantFailedError>(
+        field.invariantFunc, getFieldValue(field));
+  }
+
+  template<class T>
+  auto checkInvariant(T& field) {
+    if constexpr (!IsRawField<std::remove_cvref_t<T>>::value) {
+      return checkInvariant(field.inner);
+    } else {
+      return Result::Success{};
+    }
+  }
+
+  template<std::size_t Idx, std::size_t End, class T>
+  [[nodiscard]] Result processTuple(T& data) {
+    if constexpr (Idx < End) {
+      VPackLoadInspector ff{_slice[Idx], _options};
+      if (auto res = process(ff, std::get<Idx>(data)); !res.ok()) {
+        return {std::move(res), std::to_string(Idx), Result::ArrayTag{}};
+      }
+      return {processTuple<Idx + 1, End>(data)};
+    } else {
+      return {};
+    }
+  }
+
+  template<class T, size_t N>
+  [[nodiscard]] Result processArray(T (&data)[N]) {
+    std::size_t index = 0;
+    for (auto&& v : VPackArrayIterator(_slice)) {
+      VPackLoadInspector ff(v, _options);
+      if (auto res = process(ff, data[index]); !res.ok()) {
+        return {std::move(res), std::to_string(index), Result::ArrayTag{}};
+      }
+      ++index;
+    }
+    return {};
+  }
+
+  Result checkArrayLength(std::size_t arrayLength) {
+    if (_slice.length() != arrayLength) {
+      return {"Expected array of length " + std::to_string(arrayLength)};
+    }
+    return {};
+  }
+
+  velocypack::Slice _slice;
+  ParseOptions _options;
+};
+
+}  // namespace arangodb::inspection

--- a/lib/Inspection/VPackSaveInspector.h
+++ b/lib/Inspection/VPackSaveInspector.h
@@ -1,0 +1,179 @@
+
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2022 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Manuel Pöter
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include <optional>
+#include <string_view>
+#include <type_traits>
+#include <variant>
+
+#include <velocypack/Builder.h>
+#include <velocypack/Slice.h>
+#include <velocypack/Value.h>
+
+#include "Inspection/InspectorBase.h"
+
+namespace arangodb::inspection {
+
+struct VPackSaveInspector : InspectorBase<VPackSaveInspector> {
+  static constexpr bool isLoading = false;
+
+  explicit VPackSaveInspector(velocypack::Builder& builder)
+      : _builder(builder) {}
+
+  [[nodiscard]] Result::Success beginObject() {
+    _builder.openObject();
+    return {};
+  }
+
+  [[nodiscard]] Result::Success endObject() {
+    _builder.close();
+    return {};
+  }
+
+  template<class T, class = std::enable_if_t<detail::IsBuiltinType<T>()>>
+  [[nodiscard]] Result::Success value(T const& v) {
+    static_assert(detail::IsBuiltinType<T>());
+    _builder.add(VPackValue(v));
+    return {};
+  }
+
+  [[nodiscard]] Result::Success beginArray() {
+    _builder.openArray();
+    return {};
+  }
+
+  [[nodiscard]] Result::Success endArray() {
+    _builder.close();
+    return {};
+  }
+
+  template<class T>
+  [[nodiscard]] auto tuple(T const& data) {
+    return beginArray()                                                     //
+           | [&]() { return processTuple<0, std::tuple_size_v<T>>(data); }  //
+           | [&]() { return endArray(); };                                  //
+  }
+
+  template<class T, size_t N>
+  [[nodiscard]] auto tuple(T (&data)[N]) {
+    return beginArray()                                                       //
+           | [&]() { return processList(std::begin(data), std::end(data)); }  //
+           | [&]() { return endArray(); };                                    //
+  }
+
+  template<class T>
+  [[nodiscard]] auto list(T const& list) {
+    return beginArray()                                                       //
+           | [&]() { return processList(std::begin(list), std::end(list)); }  //
+           | [&]() { return endArray(); };                                    //
+  }
+
+  template<class T>
+  [[nodiscard]] auto map(T const& map) {
+    return beginObject()                        //
+           | [&]() { return processMap(map); }  //
+           | [&]() { return endObject(); };     //
+  }
+
+  template<class Arg, class... Args>
+  auto applyFields(Arg&& arg, Args&&... args) {
+    auto res = self().applyField(std::forward<Arg>(arg));
+    if constexpr (sizeof...(args) == 0) {
+      return res;
+    } else {
+      return std::move(res)                                                 //
+             | [&]() { return applyFields(std::forward<Args>(args)...); };  //
+    }
+  }
+
+  velocypack::Builder& builder() noexcept { return _builder; }
+
+  template<class U>
+  struct FallbackContainer {
+    explicit FallbackContainer(U&&) {}
+  };
+  template<class T>
+  struct InvariantContainer {
+    explicit InvariantContainer(T&&) {}
+  };
+
+ private:
+  template<class T>
+  [[nodiscard]] auto applyField(T const& field) {
+    auto name = getFieldName(field);
+    auto& value = getFieldValue(field);
+    auto res = [&]() {
+      if constexpr (!std::is_void_v<decltype(getTransformer(field))>) {
+        return saveTransformedField(*this, name, value, getTransformer(field));
+      } else {
+        return saveField(*this, name, value);
+      }
+    }();
+    if constexpr (res.canFail()) {
+      if (!res.ok()) {
+        return Result{std::move(res), name, Result::AttributeTag{}};
+      }
+    }
+    return res;
+  }
+
+  template<std::size_t Idx, std::size_t End, class T>
+  [[nodiscard]] auto processTuple(T const& data) {
+    if constexpr (Idx < End) {
+      return process(*this, std::get<Idx>(data))                    //
+             | [&]() { return processTuple<Idx + 1, End>(data); };  //
+    } else {
+      return Result::Success{};
+    }
+  }
+
+  template<class Iterator>
+  [[nodiscard]] auto processList(Iterator begin, Iterator end)
+      -> decltype(process(std::declval<VPackSaveInspector&>(), *begin)) {
+    for (auto it = begin; it != end; ++it) {
+      if (auto res = process(*this, *it); !res.ok()) {
+        return res;
+      }
+    }
+    return {};
+  }
+  template<class T>
+  [[nodiscard]] auto processMap(T const& map)
+      -> decltype(process(std::declval<VPackSaveInspector&>(),
+                          map.begin()->second)) {
+    for (auto&& [k, v] : map) {
+      _builder.add(VPackValue(k));
+      if (auto res = process(*this, v); !res.ok()) {
+        return res;
+      }
+    }
+    return {};
+  }
+
+  velocypack::Builder& _builder;
+};
+
+}  // namespace arangodb::inspection

--- a/lib/Inspection/detail/traits.h
+++ b/lib/Inspection/detail/traits.h
@@ -1,0 +1,121 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2022 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Manuel Pöter
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include <type_traits>
+
+#include "Inspection/Result.h"
+
+namespace arangodb::inspection {
+template<class T>
+struct Access;
+
+template<class T>
+struct AccessBase;
+}  // namespace arangodb::inspection
+
+namespace arangodb::inspection::detail {
+
+template<class T, class Inspector, class = void>
+struct HasInspectOverload : std::false_type {};
+
+template<class T, class Inspector>
+struct HasInspectOverload<T, Inspector,
+                          std::void_t<decltype(inspect(
+                              std::declval<Inspector&>(), std::declval<T&>()))>>
+    : std::conditional_t<
+          std::is_convertible_v<decltype(inspect(std::declval<Inspector&>(),
+                                                 std::declval<T&>())),
+                                Result>,
+          std::true_type, typename std::false_type> {};
+
+template<class T>
+constexpr inline bool IsBuiltinType() {
+  return std::is_same_v<T, bool> || std::is_integral_v<T> ||
+         std::is_floating_point_v<T> ||
+         std::is_same_v<T, std::string>;  // TODO - use is-string-like?
+}
+
+template<class T, class = void>
+struct IsListLike : std::false_type {};
+
+template<class T>
+struct IsListLike<T, std::void_t<decltype(std::declval<T>().begin() !=
+                                          std::declval<T>().end()),
+                                 decltype(++std::declval<T>().begin()),
+                                 decltype(*std::declval<T>().begin()),
+                                 decltype(std::declval<T>().push_back(
+                                     std::declval<typename T::value_type>()))>>
+    : std::true_type {};
+
+template<class T, class = void>
+struct IsMapLike : std::false_type {};
+
+template<class T>
+struct IsMapLike<T, std::void_t<decltype(std::declval<T>().begin() !=
+                                         std::declval<T>().end()),
+                                decltype(++std::declval<T>().begin()),
+                                decltype(*std::declval<T>().begin()),
+                                typename T::key_type, typename T::mapped_type,
+                                decltype(std::declval<T>().emplace(
+                                    std::declval<std::string>(),
+                                    std::declval<typename T::mapped_type>()))>>
+    : std::true_type {};
+
+template<class T, class = void>
+struct IsTuple
+    : std::conditional_t<std::is_array_v<T>, std::true_type, std::false_type> {
+};
+
+template<class T>
+struct IsTuple<T, std::void_t<typename std::tuple_size<T>::type>>
+    : std::true_type {};
+
+template<class T, std::size_t = sizeof(T)>
+std::true_type IsCompleteTypeImpl(T*);
+
+std::false_type IsCompleteTypeImpl(...);
+
+template<class T>
+constexpr inline bool IsCompleteType() {
+  return decltype(IsCompleteTypeImpl(std::declval<T*>()))::value;
+}
+
+template<class T>
+constexpr inline bool HasAccessSpecialization() {
+  return IsCompleteType<Access<T>>();
+}
+
+template<class T, class Inspector>
+constexpr inline bool IsInspectable() {
+  return IsBuiltinType<T>() || HasInspectOverload<T, Inspector>::value ||
+         IsListLike<T>::value || IsMapLike<T>::value || IsTuple<T>::value ||
+         HasAccessSpecialization<T>();
+}
+
+template<class T>
+using AccessType = std::conditional_t<detail::HasAccessSpecialization<T>(),
+                                      Access<T>, AccessBase<T>>;
+
+}  // namespace arangodb::inspection::detail

--- a/tests/Basics/InspectionTest.cpp
+++ b/tests/Basics/InspectionTest.cpp
@@ -1,0 +1,1470 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2022 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Manuel Pöter
+////////////////////////////////////////////////////////////////////////////////
+
+#include <gtest/gtest.h>
+
+#include <iostream>
+#include <list>
+#include <memory>
+#include <optional>
+#include <ostream>
+#include <string>
+#include <vector>
+
+#include <velocypack/Value.h>
+#include <velocypack/ValueType.h>
+#include <velocypack/velocypack-memory.h>
+
+#include "Inspection/VPackLoadInspector.h"
+#include "Inspection/VPackSaveInspector.h"
+#include "Inspection/VPack.h"
+
+namespace {
+
+struct Dummy {
+  int i;
+  double d;
+  bool b;
+  std::string s;
+};
+
+template<class Inspector>
+auto inspect(Inspector& f, Dummy& x) {
+  return f.object(x).fields(f.field("i", x.i), f.field("d", x.d),
+                            f.field("b", x.b), f.field("s", x.s));
+}
+
+struct Nested {
+  Dummy dummy;
+};
+
+template<class Inspector>
+auto inspect(Inspector& f, Nested& x) {
+  return f.object(x).fields(f.field("dummy", x.dummy));
+}
+
+struct TypedInt {
+  int value;
+  int getValue() { return value; }
+  bool operator==(TypedInt const& r) const { return value == r.value; };
+};
+
+struct Container {
+  TypedInt i{.value = 0};
+  bool operator==(Container const& r) const { return i == r.i; };
+};
+
+template<class Inspector>
+auto inspect(Inspector& f, TypedInt& x) {
+  if constexpr (Inspector::isLoading) {
+    int v;
+    auto res = f.apply(v);
+    if (res.ok()) {
+      x = TypedInt{.value = v};
+    }
+    return res;
+  } else {
+    return f.apply(x.value);
+  }
+}
+
+template<class Inspector>
+auto inspect(Inspector& f, Container& x) {
+  return f.object(x).fields(f.field("i", x.i));
+}
+struct List {
+  std::vector<Container> vec;
+  std::list<int> list;
+};
+
+template<class Inspector>
+auto inspect(Inspector& f, List& x) {
+  return f.object(x).fields(f.field("vec", x.vec), f.field("list", x.list));
+}
+
+struct Map {
+  std::map<std::string, Container> map;
+  std::unordered_map<std::string, int> unordered;
+};
+
+template<class Inspector>
+auto inspect(Inspector& f, Map& x) {
+  return f.object(x).fields(f.field("map", x.map),
+                            f.field("unordered", x.unordered));
+}
+
+struct Tuple {
+  std::tuple<std::string, int, double> tuple;
+  std::pair<int, std::string> pair;
+  std::string array1[2];
+  std::array<int, 3> array2;
+};
+
+template<class Inspector>
+auto inspect(Inspector& f, Tuple& x) {
+  return f.object(x).fields(f.field("tuple", x.tuple), f.field("pair", x.pair),
+                            f.field("array1", x.array1),
+                            f.field("array2", x.array2));
+}
+
+struct Optional {
+  std::optional<int> a;
+  std::optional<int> b;
+  std::optional<int> x;
+  std::optional<std::string> y;
+  std::vector<std::optional<int>> vec;
+  std::map<std::string, std::optional<int>> map;
+};
+
+template<class Inspector>
+auto inspect(Inspector& f, Optional& x) {
+  return f.object(x).fields(f.field("a", x.a).fallback(123),
+                            f.field("b", x.b).fallback(456), f.field("x", x.x),
+                            f.field("y", x.y), f.field("vec", x.vec),
+                            f.field("map", x.map));
+}
+
+struct Pointer {
+  std::shared_ptr<int> a;
+  std::shared_ptr<int> b;
+  std::unique_ptr<int> c;
+  std::unique_ptr<Container> d;
+  std::vector<std::unique_ptr<int>> vec;
+  std::shared_ptr<int> x;
+  std::shared_ptr<int> y;
+};
+
+template<class Inspector>
+auto inspect(Inspector& f, Pointer& x) {
+  return f.object(x).fields(
+      f.field("a", x.a), f.field("b", x.b), f.field("c", x.c),
+      f.field("d", x.d), f.field("vec", x.vec),
+      f.field("x", x.x).fallback(std::make_shared<int>(123)),
+      f.field("y", x.y).fallback(std::make_shared<int>(456)));
+}
+
+struct Fallback {
+  int i;
+  std::string s;
+};
+
+template<class Inspector>
+auto inspect(Inspector& f, Fallback& x) {
+  return f.object(x).fields(f.field("i", x.i).fallback(42),
+                            f.field("s", x.s).fallback("foobar"));
+}
+
+struct Invariant {
+  int i;
+  std::string s;
+};
+
+template<class Inspector>
+auto inspect(Inspector& f, Invariant& x) {
+  return f.object(x).fields(
+      f.field("i", x.i).invariant([](int v) { return v != 0; }),
+      f.field("s", x.s).invariant(
+          [](std::string const& v) { return !v.empty(); }));
+}
+
+struct InvariantWithResult {
+  int i;
+  std::string s;
+};
+
+template<class Inspector>
+auto inspect(Inspector& f, InvariantWithResult& x) {
+  return f.object(x).fields(
+      f.field("i", x.i).invariant([](int v) -> arangodb::inspection::Result {
+        if (v == 0) {
+          return {"Must not be zero"};
+        }
+        return {};
+      }));
+}
+
+struct InvariantAndFallback {
+  int i;
+  std::string s;
+};
+
+template<class Inspector>
+auto inspect(Inspector& f, InvariantAndFallback& x) {
+  return f.object(x).fields(
+      f.field("i", x.i).fallback(42).invariant([](int v) { return v != 0; }),
+      f.field("s", x.s)
+          .invariant([](std::string const& v) { return !v.empty(); })
+          .fallback("foobar"));
+}
+
+struct ObjectInvariant {
+  int i;
+  std::string s;
+};
+
+template<class Inspector>
+auto inspect(Inspector& f, ObjectInvariant& x) {
+  return f.object(x)
+      .fields(f.field("i", x.i), f.field("s", x.s))
+      .invariant([](ObjectInvariant& o) { return o.i != 0 && !o.s.empty(); });
+}
+
+struct FallbackReference {
+  int x;
+  int y;
+};
+
+template<class Inspector>
+auto inspect(Inspector& f, FallbackReference& x) {
+  return f.object(x).fields(f.field("x", x.x),
+                            f.field("y", x.y).fallback(std::ref(x.x)));
+}
+
+struct MyTransformer {
+  using MemoryType = int;
+  using SerializedType = std::string;
+
+  arangodb::inspection::Result toSerialized(MemoryType v,
+                                            SerializedType& result) const {
+    result = std::to_string(v);
+    return {};
+  }
+  arangodb::inspection::Result fromSerialized(SerializedType const& v,
+                                              MemoryType& result) const {
+    result = std::stoi(v);
+    return {};
+  }
+};
+
+struct FieldTransform {
+  int x;
+};
+
+template<class Inspector>
+auto inspect(Inspector& f, FieldTransform& x) {
+  return f.object(x).fields(f.field("x", x.x).transformWith(MyTransformer{}));
+}
+
+struct FieldTransformWithFallback {
+  int x;
+  int y;
+};
+
+template<class Inspector>
+auto inspect(Inspector& f, FieldTransformWithFallback& x) {
+  return f.object(x).fields(
+      f.field("x", x.x).fallback(1).transformWith(MyTransformer{}),
+      f.field("y", x.y).transformWith(MyTransformer{}).fallback(2));
+}
+
+struct OptionalFieldTransform {
+  std::optional<int> x;
+  std::optional<int> y;
+  std::optional<int> z;
+};
+
+template<class Inspector>
+auto inspect(Inspector& f, OptionalFieldTransform& x) {
+  return f.object(x).fields(
+      f.field("x", x.x).transformWith(MyTransformer{}),
+      f.field("y", x.y).transformWith(MyTransformer{}),
+      f.field("z", x.z).transformWith(MyTransformer{}).fallback(123));
+}
+
+struct Specialization {
+  int i;
+  std::string s;
+};
+}  // namespace
+
+namespace arangodb::inspection {
+template<>
+struct Access<Specialization> : AccessBase<Specialization> {
+  template<class Inspector>
+  [[nodiscard]] static Result apply(Inspector& f, Specialization& x) {
+    return f.object(x).fields(f.field("i", x.i), f.field("s", x.s));
+  }
+};
+}  // namespace arangodb::inspection
+
+namespace {
+using namespace arangodb;
+using VPackLoadInspector = inspection::VPackLoadInspector;
+using VPackSaveInspector = inspection::VPackSaveInspector;
+
+struct VPackSaveInspectorTest : public ::testing::Test {
+  velocypack::Builder builder;
+  VPackSaveInspector inspector{builder};
+};
+
+TEST_F(VPackSaveInspectorTest, store_int) {
+  int x = 42;
+  auto result = inspector.apply(x);
+  EXPECT_TRUE(result.ok());
+  EXPECT_EQ(x, builder.slice().getInt());
+}
+
+TEST_F(VPackSaveInspectorTest, store_double) {
+  double x = 123.456;
+  auto result = inspector.apply(x);
+  EXPECT_TRUE(result.ok());
+  EXPECT_EQ(x, builder.slice().getDouble());
+}
+
+TEST_F(VPackSaveInspectorTest, store_bool) {
+  bool x = true;
+  auto result = inspector.apply(x);
+  EXPECT_TRUE(result.ok());
+  EXPECT_EQ(x, builder.slice().getBool());
+}
+
+TEST_F(VPackSaveInspectorTest, store_string) {
+  std::string x = "foobar";
+  auto result = inspector.apply(x);
+  EXPECT_TRUE(result.ok());
+  EXPECT_EQ(x, builder.slice().copyString());
+}
+
+TEST_F(VPackSaveInspectorTest, store_object) {
+  static_assert(
+      inspection::detail::HasInspectOverload<Dummy, VPackSaveInspector>::value);
+
+  Dummy const f{.i = 42, .d = 123.456, .b = true, .s = "foobar"};
+  auto result = inspector.apply(f);
+  ASSERT_TRUE(result.ok());
+
+  velocypack::Slice slice = builder.slice();
+  ASSERT_TRUE(slice.isObject());
+  EXPECT_EQ(f.i, slice["i"].getInt());
+  EXPECT_EQ(f.d, slice["d"].getDouble());
+  EXPECT_EQ(f.b, slice["b"].getBool());
+  EXPECT_EQ(f.s, slice["s"].copyString());
+}
+
+TEST_F(VPackSaveInspectorTest, store_nested_object) {
+  static_assert(
+      inspection::detail::HasInspectOverload<Nested,
+                                             VPackSaveInspector>::value);
+
+  Nested b{.dummy = {.i = 42, .d = 123.456, .b = true, .s = "foobar"}};
+  auto result = inspector.apply(b);
+  ASSERT_TRUE(result.ok());
+
+  velocypack::Slice slice = builder.slice();
+  ASSERT_TRUE(slice.isObject());
+  auto d = slice["dummy"];
+  ASSERT_TRUE(d.isObject());
+  EXPECT_EQ(b.dummy.i, d["i"].getInt());
+  EXPECT_EQ(b.dummy.d, d["d"].getDouble());
+  EXPECT_EQ(b.dummy.b, d["b"].getBool());
+  EXPECT_EQ(b.dummy.s, d["s"].copyString());
+}
+
+TEST_F(VPackSaveInspectorTest, store_nested_object_without_nesting) {
+  static_assert(
+      inspection::detail::HasInspectOverload<Container,
+                                             VPackSaveInspector>::value);
+
+  Container c{.i = {.value = 42}};
+  auto result = inspector.apply(c);
+  ASSERT_TRUE(result.ok());
+
+  velocypack::Slice slice = builder.slice();
+  ASSERT_TRUE(slice.isObject());
+  EXPECT_EQ(c.i.value, slice["i"].getInt());
+}
+
+TEST_F(VPackSaveInspectorTest, store_list) {
+  static_assert(
+      inspection::detail::HasInspectOverload<List, VPackSaveInspector>::value);
+
+  List l{.vec = {{1}, {2}, {3}}, .list = {4, 5}};
+  auto result = inspector.apply(l);
+  ASSERT_TRUE(result.ok());
+
+  velocypack::Slice slice = builder.slice();
+  ASSERT_TRUE(slice.isObject());
+  auto list = slice["vec"];
+  ASSERT_TRUE(list.isArray());
+  ASSERT_EQ(3, list.length());
+  EXPECT_EQ(l.vec[0].i.value, list[0]["i"].getInt());
+  EXPECT_EQ(l.vec[1].i.value, list[1]["i"].getInt());
+  EXPECT_EQ(l.vec[2].i.value, list[2]["i"].getInt());
+
+  list = slice["list"];
+  ASSERT_TRUE(list.isArray());
+  ASSERT_EQ(2, list.length());
+  auto it = l.list.begin();
+  EXPECT_EQ(*it++, list[0].getInt());
+  EXPECT_EQ(*it++, list[1].getInt());
+}
+
+TEST_F(VPackSaveInspectorTest, store_map) {
+  static_assert(
+      inspection::detail::HasInspectOverload<Map, VPackSaveInspector>::value);
+
+  Map m{.map = {{"1", {1}}, {"2", {2}}, {"3", {3}}},
+        .unordered = {{"4", 4}, {"5", 5}}};
+  auto result = inspector.apply(m);
+  ASSERT_TRUE(result.ok());
+
+  velocypack::Slice slice = builder.slice();
+  ASSERT_TRUE(slice.isObject());
+  auto obj = slice["map"];
+  ASSERT_TRUE(obj.isObject());
+  ASSERT_EQ(3, obj.length());
+  EXPECT_EQ(m.map["1"].i.value, obj["1"]["i"].getInt());
+  EXPECT_EQ(m.map["2"].i.value, obj["2"]["i"].getInt());
+  EXPECT_EQ(m.map["3"].i.value, obj["3"]["i"].getInt());
+
+  obj = slice["unordered"];
+  ASSERT_TRUE(obj.isObject());
+  ASSERT_EQ(2, obj.length());
+  EXPECT_EQ(m.unordered["4"], obj["4"].getInt());
+  EXPECT_EQ(m.unordered["5"], obj["5"].getInt());
+}
+
+TEST_F(VPackSaveInspectorTest, store_tuples) {
+  static_assert(
+      inspection::detail::HasInspectOverload<Tuple, VPackSaveInspector>::value);
+
+  Tuple t{.tuple = {"foo", 42, 12.34},
+          .pair = {987, "bar"},
+          .array1 = {"a", "b"},
+          .array2 = {1, 2, 3}};
+  auto result = inspector.apply(t);
+  ASSERT_TRUE(result.ok());
+
+  velocypack::Slice slice = builder.slice();
+  ASSERT_TRUE(slice.isObject());
+  auto list = slice["tuple"];
+  ASSERT_EQ(3, list.length());
+  EXPECT_EQ(std::get<0>(t.tuple), list[0].copyString());
+  EXPECT_EQ(std::get<1>(t.tuple), list[1].getInt());
+  EXPECT_EQ(std::get<2>(t.tuple), list[2].getDouble());
+
+  list = slice["pair"];
+  ASSERT_EQ(2, list.length());
+  EXPECT_EQ(std::get<0>(t.pair), list[0].getInt());
+  EXPECT_EQ(std::get<1>(t.pair), list[1].copyString());
+
+  list = slice["array1"];
+  ASSERT_EQ(2, list.length());
+  EXPECT_EQ(t.array1[0], list[0].copyString());
+  EXPECT_EQ(t.array1[1], list[1].copyString());
+
+  list = slice["array2"];
+  ASSERT_EQ(3, list.length());
+  EXPECT_EQ(t.array2[0], list[0].getInt());
+  EXPECT_EQ(t.array2[1], list[1].getInt());
+  EXPECT_EQ(t.array2[2], list[2].getInt());
+}
+
+TEST_F(VPackSaveInspectorTest, store_optional) {
+  static_assert(
+      inspection::detail::HasInspectOverload<Optional,
+                                             VPackSaveInspector>::value);
+
+  Optional o{.a = std::nullopt,
+             .b = std::nullopt,
+             .x = std::nullopt,
+             .y = "blubb",
+             .vec = {1, std::nullopt, 3},
+             .map = {{"1", 1}, {"2", std::nullopt}, {"3", 3}}};
+  auto result = inspector.apply(o);
+  ASSERT_TRUE(result.ok());
+
+  velocypack::Slice slice = builder.slice();
+  ASSERT_TRUE(slice.isObject());
+  EXPECT_EQ(3, slice.length());
+  EXPECT_EQ("blubb", slice["y"].copyString());
+
+  auto vec = slice["vec"];
+  ASSERT_TRUE(vec.isArray());
+  ASSERT_EQ(3, vec.length());
+  EXPECT_EQ(1, vec[0].getInt());
+  EXPECT_TRUE(vec[1].isNull());
+  EXPECT_EQ(3, vec[2].getInt());
+
+  auto map = slice["map"];
+  ASSERT_TRUE(map.isObject());
+  ASSERT_EQ(3, map.length());
+  EXPECT_EQ(1, map["1"].getInt());
+  EXPECT_TRUE(map["2"].isNull());
+  EXPECT_EQ(3, map["3"].getInt());
+}
+
+TEST_F(VPackSaveInspectorTest, store_optional_pointer) {
+  static_assert(
+      inspection::detail::HasInspectOverload<Pointer,
+                                             VPackSaveInspector>::value);
+
+  Pointer p{.a = nullptr,
+            .b = std::make_shared<int>(42),
+            .c = nullptr,
+            .d = std::make_unique<Container>(Container{.i = {.value = 43}}),
+            .vec = {},
+            .x = {},
+            .y = {}};
+  p.vec.push_back(std::make_unique<int>(1));
+  p.vec.push_back(nullptr);
+  p.vec.push_back(std::make_unique<int>(2));
+  auto result = inspector.apply(p);
+  ASSERT_TRUE(result.ok());
+
+  velocypack::Slice slice = builder.slice();
+  ASSERT_TRUE(slice.isObject());
+  EXPECT_EQ(3, slice.length());
+  EXPECT_EQ(42, slice["b"].getInt());
+  EXPECT_EQ(43, slice["d"]["i"].getInt());
+  auto vec = slice["vec"];
+  EXPECT_TRUE(vec.isArray());
+  EXPECT_EQ(3, vec.length());
+  EXPECT_EQ(1, vec[0].getInt());
+  EXPECT_TRUE(vec[1].isNull());
+  EXPECT_EQ(2, vec[2].getInt());
+}
+
+TEST_F(VPackSaveInspectorTest, store_object_with_fallbacks) {
+  Fallback f;
+  auto result = inspector.apply(f);
+  ASSERT_TRUE(result.ok());
+
+  static_assert(sizeof(inspector.field("i", f.i)) ==
+                sizeof(inspector.field("i", f.i).fallback(42)));
+}
+
+TEST_F(VPackSaveInspectorTest, store_object_with_invariant) {
+  Invariant i;
+  auto result = inspector.apply(i);
+  ASSERT_TRUE(result.ok());
+
+  auto invariant = [](auto) { return true; };
+  static_assert(sizeof(inspector.field("i", i.i)) ==
+                sizeof(inspector.field("i", i.i).invariant(invariant)));
+}
+
+TEST_F(VPackSaveInspectorTest, store_object_with_invariant_and_fallback) {
+  InvariantAndFallback i;
+  auto result = inspector.apply(i);
+  ASSERT_TRUE(result.ok());
+
+  auto invariant = [](auto) { return true; };
+  static_assert(
+      sizeof(inspector.field("i", i.i)) ==
+      sizeof(inspector.field("i", i.i).invariant(invariant).fallback(42)));
+  static_assert(
+      sizeof(inspector.field("i", i.i)) ==
+      sizeof(inspector.field("i", i.i).fallback(42).invariant(invariant)));
+}
+
+TEST_F(VPackSaveInspectorTest, store_object_with_field_transform) {
+  FieldTransform f{.x = 42};
+  auto result = inspector.apply(f);
+  ASSERT_TRUE(result.ok());
+
+  velocypack::Slice slice = builder.slice();
+  ASSERT_TRUE(slice.isObject());
+  EXPECT_EQ("42", slice["x"].copyString());
+}
+
+TEST_F(VPackSaveInspectorTest, store_object_with_optional_field_transform) {
+  OptionalFieldTransform f{.x = 1, .y = std::nullopt, .z = 3};
+  auto result = inspector.apply(f);
+
+  velocypack::Slice slice = builder.slice();
+  ASSERT_TRUE(slice.isObject());
+  EXPECT_EQ(2, slice.length());
+  EXPECT_EQ("1", slice["x"].copyString());
+  EXPECT_EQ("3", slice["z"].copyString());
+}
+
+TEST_F(VPackSaveInspectorTest, store_type_with_custom_specialization) {
+  Specialization s{.i = 42, .s = "foobar"};
+  auto result = inspector.apply(s);
+  ASSERT_TRUE(result.ok());
+
+  velocypack::Slice slice = builder.slice();
+  ASSERT_TRUE(slice.isObject());
+  EXPECT_EQ(s.i, slice["i"].getInt());
+  EXPECT_EQ(s.s, slice["s"].copyString());
+}
+
+struct VPackLoadInspectorTest : public ::testing::Test {
+  velocypack::Builder builder;
+};
+
+TEST_F(VPackLoadInspectorTest, load_int) {
+  builder.add(VPackValue(42));
+  VPackLoadInspector inspector{builder};
+
+  int x = 0;
+  auto result = inspector.apply(x);
+  EXPECT_TRUE(result.ok());
+  EXPECT_EQ(42, x);
+}
+
+TEST_F(VPackLoadInspectorTest, load_double) {
+  builder.add(VPackValue(123.456));
+  VPackLoadInspector inspector{builder};
+
+  double x = 0;
+  auto result = inspector.apply(x);
+  EXPECT_TRUE(result.ok());
+  EXPECT_EQ(123.456, x);
+}
+
+TEST_F(VPackLoadInspectorTest, load_bool) {
+  builder.add(VPackValue(true));
+  VPackLoadInspector inspector{builder};
+
+  bool x = false;
+  auto result = inspector.apply(x);
+  EXPECT_TRUE(result.ok());
+  EXPECT_EQ(true, x);
+}
+
+TEST_F(VPackLoadInspectorTest, store_string) {
+  builder.add(VPackValue("foobar"));
+  VPackLoadInspector inspector{builder};
+
+  std::string x;
+  auto result = inspector.apply(x);
+  EXPECT_TRUE(result.ok());
+  EXPECT_EQ("foobar", x);
+}
+
+TEST_F(VPackLoadInspectorTest, load_object) {
+  builder.openObject();
+  builder.add("i", VPackValue(42));
+  builder.add("d", VPackValue(123.456));
+  builder.add("b", VPackValue(true));
+  builder.add("s", VPackValue("foobar"));
+  builder.close();
+  VPackLoadInspector inspector{builder};
+
+  Dummy d;
+  auto result = inspector.apply(d);
+  ASSERT_TRUE(result.ok());
+  EXPECT_EQ(42, d.i);
+  EXPECT_EQ(123.456, d.d);
+  EXPECT_EQ(true, d.b);
+  EXPECT_EQ("foobar", d.s);
+}
+
+TEST_F(VPackLoadInspectorTest, load_nested_object) {
+  builder.openObject();
+  builder.add(VPackValue("dummy"));
+  builder.openObject();
+  builder.add("i", VPackValue(42));
+  builder.add("d", VPackValue(123));
+  builder.add("b", VPackValue(true));
+  builder.add("s", VPackValue("foobar"));
+  builder.close();
+  builder.close();
+  VPackLoadInspector inspector{builder};
+
+  Nested n;
+  auto result = inspector.apply(n);
+  ASSERT_TRUE(result.ok());
+  EXPECT_EQ(42, n.dummy.i);
+  EXPECT_EQ(123, n.dummy.d);
+  EXPECT_EQ(true, n.dummy.b);
+  EXPECT_EQ("foobar", n.dummy.s);
+}
+
+TEST_F(VPackLoadInspectorTest, load_nested_object_without_nesting) {
+  builder.openObject();
+  builder.add("i", VPackValue(42));
+  builder.close();
+  VPackLoadInspector inspector{builder};
+
+  Container c;
+  auto result = inspector.apply(c);
+  ASSERT_TRUE(result.ok());
+  EXPECT_EQ(42, c.i.value);
+}
+
+TEST_F(VPackLoadInspectorTest, load_list) {
+  builder.openObject();
+  builder.add(VPackValue("vec"));
+  builder.openArray();
+  builder.openObject();
+  builder.add("i", VPackValue(1));
+  builder.close();
+  builder.openObject();
+  builder.add("i", VPackValue(2));
+  builder.close();
+  builder.openObject();
+  builder.add("i", VPackValue(3));
+  builder.close();
+  builder.close();
+  builder.add(VPackValue("list"));
+  builder.openArray();
+  builder.add(VPackValue(4));
+  builder.add(VPackValue(5));
+  builder.close();
+  builder.close();
+  VPackLoadInspector inspector{builder};
+
+  List l;
+  auto result = inspector.apply(l);
+  ASSERT_TRUE(result.ok());
+
+  EXPECT_EQ(3, l.vec.size());
+  EXPECT_EQ(1, l.vec[0].i.value);
+  EXPECT_EQ(2, l.vec[1].i.value);
+  EXPECT_EQ(3, l.vec[2].i.value);
+  EXPECT_EQ((std::list<int>{4, 5}), l.list);
+}
+
+TEST_F(VPackLoadInspectorTest, load_map) {
+  builder.openObject();
+  builder.add(VPackValue("map"));
+  builder.openObject();
+  builder.add(VPackValue("1"));
+  builder.openObject();
+  builder.add("i", VPackValue(1));
+  builder.close();
+  builder.add(VPackValue("2"));
+  builder.openObject();
+  builder.add("i", VPackValue(2));
+  builder.close();
+  builder.add(VPackValue("3"));
+  builder.openObject();
+  builder.add("i", VPackValue(3));
+  builder.close();
+  builder.close();
+  builder.add(VPackValue("unordered"));
+  builder.openObject();
+  builder.add("4", VPackValue(4));
+  builder.add("5", VPackValue(5));
+  builder.close();
+  builder.close();
+  VPackLoadInspector inspector{builder};
+
+  Map m;
+  auto result = inspector.apply(m);
+  ASSERT_TRUE(result.ok());
+
+  EXPECT_EQ(
+      (std::map<std::string, Container>{{"1", {1}}, {"2", {2}}, {"3", {3}}}),
+      m.map);
+  EXPECT_EQ((std::unordered_map<std::string, int>{{"4", 4}, {"5", 5}}),
+            m.unordered);
+}
+
+TEST_F(VPackLoadInspectorTest, load_tuples) {
+  builder.openObject();
+
+  builder.add(VPackValue("tuple"));
+  builder.openArray();
+  builder.add(VPackValue("foo"));
+  builder.add(VPackValue(42));
+  builder.add(VPackValue(12.34));
+  builder.close();
+
+  builder.add(VPackValue("pair"));
+  builder.openArray();
+  builder.add(VPackValue(987));
+  builder.add(VPackValue("bar"));
+  builder.close();
+
+  builder.add(VPackValue("array1"));
+  builder.openArray();
+  builder.add(VPackValue("a"));
+  builder.add(VPackValue("b"));
+  builder.close();
+
+  builder.add(VPackValue("array2"));
+  builder.openArray();
+  builder.add(VPackValue(1));
+  builder.add(VPackValue(2));
+  builder.add(VPackValue(3));
+  builder.close();
+
+  builder.close();
+  VPackLoadInspector inspector{builder};
+
+  Tuple t;
+  auto result = inspector.apply(t);
+  ASSERT_TRUE(result.ok());
+
+  Tuple expected{.tuple = {"foo", 42, 12.34},
+                 .pair = {987, "bar"},
+                 .array1 = {"a", "b"},
+                 .array2 = {1, 2, 3}};
+  EXPECT_EQ(expected.tuple, t.tuple);
+  EXPECT_EQ(expected.pair, t.pair);
+  EXPECT_EQ(expected.array1[0], t.array1[0]);
+  EXPECT_EQ(expected.array1[1], t.array1[1]);
+  EXPECT_EQ(expected.array2, t.array2);
+}
+
+TEST_F(VPackLoadInspectorTest, load_optional) {
+  builder.openObject();
+  builder.add("y", VPackValue("blubb"));
+
+  builder.add(VPackValue("vec"));
+  builder.openArray();
+  builder.add(VPackValue(1));
+  builder.add(VPackValue(velocypack::ValueType::Null));
+  builder.add(VPackValue(3));
+  builder.close();
+
+  builder.add(VPackValue("map"));
+  builder.openObject();
+  builder.add("1", VPackValue(1));
+  builder.add("2", VPackValue(velocypack::ValueType::Null));
+  builder.add("3", VPackValue(3));
+  builder.close();
+
+  builder.add("a", VPackValue(velocypack::ValueType::Null));
+  builder.close();
+  VPackLoadInspector inspector{builder};
+
+  Optional o{.a = 1, .b = 2, .x = 42, .y = {}, .vec = {}, .map = {}};
+  auto result = inspector.apply(o);
+  ASSERT_TRUE(result.ok());
+
+  Optional expected{.a = std::nullopt,
+                    .b = 456,
+                    .x = std::nullopt,
+                    .y = "blubb",
+                    .vec = {1, std::nullopt, 3},
+                    .map = {{"1", 1}, {"2", std::nullopt}, {"3", 3}}};
+  EXPECT_EQ(expected.a, o.a);
+  EXPECT_EQ(expected.b, o.b);
+  EXPECT_EQ(expected.x, o.x);
+  EXPECT_EQ(expected.y, o.y);
+  ASSERT_EQ(expected.vec, o.vec);
+  EXPECT_EQ(expected.map, o.map);
+}
+
+TEST_F(VPackLoadInspectorTest, load_optional_pointer) {
+  builder.openObject();
+  builder.add(VPackValue("vec"));
+  builder.openArray();
+  builder.add(VPackValue(1));
+  builder.add(VPackValue(VPackValueType::Null));
+  builder.add(VPackValue(2));
+  builder.close();
+
+  builder.add("a", VPackValue(VPackValueType::Null));
+
+  builder.add("b", VPackValue(42));
+
+  builder.add(VPackValue("d"));
+  builder.openObject();
+  builder.add("i", VPackValue(43));
+  builder.close();
+
+  builder.add("x", VPackValue(VPackValueType::Null));
+
+  builder.close();
+  VPackLoadInspector inspector{builder};
+
+  Pointer p{.a = std::make_shared<int>(0),
+            .b = std::make_shared<int>(0),
+            .c = std::make_unique<int>(0),
+            .d = std::make_unique<Container>(Container{.i = {.value = 0}}),
+            .vec = {},
+            .x = std::make_shared<int>(0),
+            .y = std::make_shared<int>(0)};
+  auto result = inspector.apply(p);
+  ASSERT_TRUE(result.ok()) << result.error() << "; " << result.path();
+
+  EXPECT_EQ(nullptr, p.a);
+  ASSERT_NE(nullptr, p.b);
+  EXPECT_EQ(42, *p.b);
+  EXPECT_EQ(nullptr, p.c);
+  ASSERT_NE(nullptr, p.d);
+  EXPECT_EQ(43, p.d->i.value);
+
+  ASSERT_EQ(3, p.vec.size());
+  ASSERT_NE(nullptr, p.vec[0]);
+  EXPECT_EQ(1, *p.vec[0]);
+  EXPECT_EQ(nullptr, p.vec[1]);
+  ASSERT_NE(nullptr, p.vec[2]);
+  EXPECT_EQ(2, *p.vec[2]);
+
+  EXPECT_EQ(nullptr, p.x);
+  ASSERT_NE(nullptr, p.y);
+  EXPECT_EQ(456, *p.y);
+}
+
+TEST_F(VPackLoadInspectorTest, error_expecting_int) {
+  builder.add(VPackValue("foo"));
+  VPackLoadInspector inspector{builder};
+
+  int i;
+  auto result = inspector.apply(i);
+  ASSERT_FALSE(result.ok());
+  EXPECT_EQ("Expecting type Int", result.error());
+}
+
+TEST_F(VPackLoadInspectorTest, error_expecting_int16) {
+  builder.add(VPackValue(123456789));
+  VPackLoadInspector inspector{builder};
+
+  std::int16_t i;
+  auto result = inspector.apply(i);
+  ASSERT_FALSE(result.ok());
+  EXPECT_EQ("Number out of range", result.error());
+}
+
+TEST_F(VPackLoadInspectorTest, error_expecting_double) {
+  builder.add(VPackValue("foo"));
+  VPackLoadInspector inspector{builder};
+
+  double d;
+  auto result = inspector.apply(d);
+  ASSERT_FALSE(result.ok());
+  EXPECT_EQ("Expecting numeric type", result.error());
+}
+
+TEST_F(VPackLoadInspectorTest, error_expecting_bool) {
+  builder.add(VPackValue(42));
+  VPackLoadInspector inspector{builder};
+
+  bool b;
+  auto result = inspector.apply(b);
+  ASSERT_FALSE(result.ok());
+  EXPECT_EQ("Expecting type Bool", result.error());
+}
+
+TEST_F(VPackLoadInspectorTest, error_expecting_string) {
+  builder.add(VPackValue(42));
+  VPackLoadInspector inspector{builder};
+
+  std::string s;
+  auto result = inspector.apply(s);
+  ASSERT_FALSE(result.ok());
+  EXPECT_EQ("Expecting type String", result.error());
+}
+
+TEST_F(VPackLoadInspectorTest, error_expecting_array) {
+  builder.add(VPackValue(42));
+  VPackLoadInspector inspector{builder};
+
+  std::vector<int> v;
+  auto result = inspector.apply(v);
+  ASSERT_FALSE(result.ok());
+  EXPECT_EQ("Expecting type Array", result.error());
+}
+
+TEST_F(VPackLoadInspectorTest, error_expecting_object) {
+  builder.add(VPackValue(42));
+  VPackLoadInspector inspector{builder};
+
+  Dummy d;
+  auto result = inspector.apply(d);
+  ASSERT_FALSE(result.ok());
+  EXPECT_EQ("Expecting type Object", result.error());
+}
+
+TEST_F(VPackLoadInspectorTest, error_tuple_array_too_short) {
+  builder.openArray();
+  builder.add(VPackValue("foo"));
+  builder.add(VPackValue(42));
+  builder.close();
+  VPackLoadInspector inspector{builder};
+
+  std::tuple<std::string, int, double> t;
+  auto result = inspector.apply(t);
+  ASSERT_FALSE(result.ok());
+  EXPECT_EQ("Expected array of length 3", result.error());
+}
+
+TEST_F(VPackLoadInspectorTest, error_tuple_array_too_large) {
+  builder.openArray();
+  builder.add(VPackValue("foo"));
+  builder.add(VPackValue(42));
+  builder.add(VPackValue(123.456));
+  builder.close();
+  VPackLoadInspector inspector{builder};
+
+  std::tuple<std::string, int> t;
+  auto result = inspector.apply(t);
+  ASSERT_FALSE(result.ok());
+  EXPECT_EQ("Expected array of length 2", result.error());
+}
+
+TEST_F(VPackLoadInspectorTest, error_c_style_array_too_short) {
+  builder.openArray();
+  builder.add(VPackValue(1));
+  builder.add(VPackValue(2));
+  builder.close();
+  VPackLoadInspector inspector{builder};
+
+  int a[4];
+  auto result = inspector.apply(a);
+  ASSERT_FALSE(result.ok());
+  EXPECT_EQ("Expected array of length 4", result.error());
+}
+
+TEST_F(VPackLoadInspectorTest, error_c_style_array_too_long) {
+  builder.openArray();
+  builder.add(VPackValue(1));
+  builder.add(VPackValue(2));
+  builder.add(VPackValue(3));
+  builder.add(VPackValue(4));
+  builder.close();
+  VPackLoadInspector inspector{builder};
+
+  int a[3];
+  auto result = inspector.apply(a);
+  ASSERT_FALSE(result.ok());
+  EXPECT_EQ("Expected array of length 3", result.error());
+}
+
+TEST_F(VPackLoadInspectorTest, error_expecting_type_on_path) {
+  builder.openObject();
+  builder.add(VPackValue("dummy"));
+  builder.openObject();
+  builder.add("i", VPackValue("foo"));
+  builder.close();
+  builder.close();
+  VPackLoadInspector inspector{builder};
+
+  Nested n;
+  auto result = inspector.apply(n);
+  ASSERT_FALSE(result.ok());
+  EXPECT_EQ("dummy.i", result.path());
+}
+
+TEST_F(VPackLoadInspectorTest, error_expecting_type_on_path_with_array) {
+  builder.openObject();
+  builder.add(VPackValue("vec"));
+  builder.openArray();
+  builder.openObject();
+  builder.add("i", VPackValue(1));
+  builder.close();
+  builder.openObject();
+  builder.add("i", VPackValue(2));
+  builder.close();
+  builder.openObject();
+  builder.add("i", VPackValue("foobar"));
+  builder.close();
+  builder.close();
+  builder.close();
+  VPackLoadInspector inspector{builder};
+
+  List l;
+  auto result = inspector.apply(l);
+
+  ASSERT_FALSE(result.ok());
+  EXPECT_EQ("vec[2].i", result.path());
+}
+
+TEST_F(VPackLoadInspectorTest, error_expecting_type_on_path_with_map) {
+  builder.openObject();
+  builder.add(VPackValue("map"));
+  builder.openObject();
+  builder.add(VPackValue("1"));
+  builder.openObject();
+  builder.add("i", VPackValue(1));
+  builder.close();
+  builder.add(VPackValue("2"));
+  builder.openObject();
+  builder.add("i", VPackValue(2));
+  builder.close();
+  builder.add(VPackValue("3"));
+  builder.openObject();
+  builder.add("i", VPackValue("foobar"));
+  builder.close();
+  builder.close();
+  builder.close();
+  VPackLoadInspector inspector{builder};
+
+  Map m;
+  auto result = inspector.apply(m);
+
+  ASSERT_FALSE(result.ok());
+  EXPECT_EQ("map['3'].i", result.path());
+}
+
+TEST_F(VPackLoadInspectorTest, error_expecting_type_on_path_with_tuple) {
+  builder.openObject();
+
+  builder.add(VPackValue("tuple"));
+  builder.openArray();
+  builder.add(VPackValue("foo"));
+  builder.add(VPackValue(42));
+  builder.add(VPackValue("bar"));
+  builder.close();
+
+  builder.close();
+  VPackLoadInspector inspector{builder};
+
+  Tuple l;
+  auto result = inspector.apply(l);
+
+  ASSERT_FALSE(result.ok());
+  EXPECT_EQ("tuple[2]", result.path());
+}
+
+TEST_F(VPackLoadInspectorTest,
+       error_expecting_type_on_path_with_c_style_array) {
+  builder.openObject();
+
+  builder.add(VPackValue("tuple"));
+  builder.openArray();
+  builder.add(VPackValue("foo"));
+  builder.add(VPackValue(42));
+  builder.add(VPackValue(0));
+  builder.close();
+
+  builder.add(VPackValue("pair"));
+  builder.openArray();
+  builder.add(VPackValue(987));
+  builder.add(VPackValue("bar"));
+  builder.close();
+
+  builder.add(VPackValue("array1"));
+  builder.openArray();
+  builder.add(VPackValue("a"));
+  builder.add(VPackValue(42));
+  builder.close();
+
+  builder.close();
+  VPackLoadInspector inspector{builder};
+
+  Tuple l;
+  auto result = inspector.apply(l);
+
+  ASSERT_FALSE(result.ok());
+  EXPECT_EQ("array1[1]", result.path());
+}
+
+TEST_F(VPackLoadInspectorTest, error_expecting_type_on_path_with_std_array) {
+  builder.openObject();
+
+  builder.add(VPackValue("tuple"));
+  builder.openArray();
+  builder.add(VPackValue("foo"));
+  builder.add(VPackValue(42));
+  builder.add(VPackValue(0));
+  builder.close();
+
+  builder.add(VPackValue("pair"));
+  builder.openArray();
+  builder.add(VPackValue(987));
+  builder.add(VPackValue("bar"));
+  builder.close();
+
+  builder.add(VPackValue("array1"));
+  builder.openArray();
+  builder.add(VPackValue("a"));
+  builder.add(VPackValue("b"));
+  builder.close();
+
+  builder.add(VPackValue("array2"));
+  builder.openArray();
+  builder.add(VPackValue(1));
+  builder.add(VPackValue(2));
+  builder.add(VPackValue("foo"));
+  builder.close();
+
+  builder.close();
+  VPackLoadInspector inspector{builder};
+
+  Tuple l;
+  auto result = inspector.apply(l);
+
+  ASSERT_FALSE(result.ok());
+  EXPECT_EQ("array2[2]", result.path());
+}
+
+TEST_F(VPackLoadInspectorTest, error_missing_field) {
+  builder.openObject();
+  builder.add(VPackValue("dummy"));
+  builder.openObject();
+  builder.add("s", VPackValue("foo"));
+  builder.close();
+  builder.close();
+  VPackLoadInspector inspector{builder};
+
+  Nested n;
+  auto result = inspector.apply(n);
+  ASSERT_FALSE(result.ok());
+  EXPECT_EQ("Missing required attribute 'i'", result.error());
+  EXPECT_EQ("dummy.i", result.path());
+}
+
+TEST_F(VPackLoadInspectorTest, error_found_unexpected_attribute) {
+  builder.openObject();
+  builder.add("i", VPackValue(42));
+  builder.add("should_not_be_here", VPackValue(123));
+  builder.close();
+  VPackLoadInspector inspector{builder};
+
+  Container c;
+  auto result = inspector.apply(c);
+  ASSERT_FALSE(result.ok());
+  EXPECT_EQ("Found unexpected attribute 'should_not_be_here'", result.error());
+}
+
+TEST_F(VPackLoadInspectorTest, load_object_ignoring_unknown_attributes) {
+  builder.openObject();
+  builder.add("i", VPackValue(42));
+  builder.add("ignore_me", VPackValue(123));
+  builder.close();
+  VPackLoadInspector inspector{builder, {.ignoreUnknownFields = true}};
+
+  Container c;
+  auto result = inspector.apply(c);
+  ASSERT_TRUE(result.ok()) << "Error: " << result.error()
+                           << "\nPath: " << result.path();
+}
+
+TEST_F(VPackLoadInspectorTest, load_object_with_fallbacks) {
+  builder.openObject();
+  builder.close();
+  VPackLoadInspector inspector{builder};
+
+  Fallback f;
+  auto result = inspector.apply(f);
+  ASSERT_TRUE(result.ok());
+  EXPECT_EQ(42, f.i);
+  EXPECT_EQ("foobar", f.s);
+}
+
+TEST_F(VPackLoadInspectorTest, load_object_with_fallback_reference) {
+  builder.openObject();
+  builder.add("x", VPackValue(42));
+  builder.close();
+  VPackLoadInspector inspector{builder};
+
+  FallbackReference f;
+  auto result = inspector.apply(f);
+  ASSERT_TRUE(result.ok());
+  EXPECT_EQ(42, f.x);
+  EXPECT_EQ(42, f.y);
+}
+
+TEST_F(VPackLoadInspectorTest, load_object_with_invariant_fulfilled) {
+  builder.openObject();
+  builder.add("i", VPackValue(42));
+  builder.add("s", VPackValue("foobar"));
+  builder.close();
+  VPackLoadInspector inspector{builder};
+
+  Invariant i;
+  auto result = inspector.apply(i);
+  ASSERT_TRUE(result.ok());
+  EXPECT_EQ(42, i.i);
+  EXPECT_EQ("foobar", i.s);
+}
+
+TEST_F(VPackLoadInspectorTest, load_object_with_invariant_not_fulfilled) {
+  {
+    builder.openObject();
+    builder.add("i", VPackValue(0));
+    builder.add("s", VPackValue("foobar"));
+    builder.close();
+    VPackLoadInspector inspector{builder};
+
+    Invariant i;
+    auto result = inspector.apply(i);
+    ASSERT_FALSE(result.ok());
+    EXPECT_EQ("Field invariant failed", result.error());
+    EXPECT_EQ("i", result.path());
+  }
+
+  {
+    builder.clear();
+    builder.openObject();
+    builder.add("i", VPackValue(42));
+    builder.add("s", VPackValue(""));
+    builder.close();
+    VPackLoadInspector inspector{builder};
+
+    Invariant i;
+    auto result = inspector.apply(i);
+    ASSERT_FALSE(result.ok());
+    EXPECT_EQ("Field invariant failed", result.error());
+    EXPECT_EQ("s", result.path());
+  }
+}
+
+TEST_F(VPackLoadInspectorTest,
+       load_object_with_invariant_Result_not_fulfilled) {
+  {
+    builder.openObject();
+    builder.add("i", VPackValue(0));
+    builder.close();
+    VPackLoadInspector inspector{builder};
+
+    InvariantWithResult i;
+    auto result = inspector.apply(i);
+    ASSERT_FALSE(result.ok());
+    EXPECT_EQ("Must not be zero", result.error());
+    EXPECT_EQ("i", result.path());
+  }
+
+  {
+    builder.clear();
+    builder.openObject();
+    builder.add("i", VPackValue(42));
+    builder.add("s", VPackValue(""));
+    builder.close();
+    VPackLoadInspector inspector{builder};
+
+    Invariant i;
+    auto result = inspector.apply(i);
+    ASSERT_FALSE(result.ok());
+    EXPECT_EQ("Field invariant failed", result.error());
+    EXPECT_EQ("s", result.path());
+  }
+}
+
+TEST_F(VPackLoadInspectorTest, load_object_with_invariant_and_fallback) {
+  builder.openObject();
+  builder.close();
+  VPackLoadInspector inspector{builder};
+
+  InvariantAndFallback i;
+  auto result = inspector.apply(i);
+  ASSERT_TRUE(result.ok());
+  EXPECT_EQ(42, i.i);
+  EXPECT_EQ("foobar", i.s);
+}
+
+TEST_F(VPackLoadInspectorTest, load_object_with_object_invariant) {
+  builder.openObject();
+  builder.add("i", VPackValue(42));
+  builder.add("s", VPackValue(""));
+  builder.close();
+  VPackLoadInspector inspector{builder};
+
+  ObjectInvariant o;
+  auto result = inspector.apply(o);
+  ASSERT_FALSE(result.ok());
+  EXPECT_EQ("Object invariant failed", result.error());
+}
+
+TEST_F(VPackLoadInspectorTest, load_object_with_field_transform) {
+  builder.openObject();
+  builder.add("x", VPackValue("42"));
+  builder.close();
+  VPackLoadInspector inspector{builder};
+
+  FieldTransform f;
+  auto result = inspector.apply(f);
+  ASSERT_TRUE(result.ok());
+  EXPECT_EQ(42, f.x);
+}
+
+TEST_F(VPackLoadInspectorTest, load_object_with_field_transform_and_fallback) {
+  builder.openObject();
+  builder.add("x", VPackValue("42"));
+  builder.close();
+  VPackLoadInspector inspector{builder};
+
+  FieldTransformWithFallback f;
+  auto result = inspector.apply(f);
+  ASSERT_TRUE(result.ok());
+  EXPECT_EQ(42, f.x);
+  EXPECT_EQ(2, f.y);
+}
+
+TEST_F(VPackLoadInspectorTest, load_object_with_optional_field_transform) {
+  builder.openObject();
+  builder.add("x", VPackValue("42"));
+  builder.close();
+  VPackLoadInspector inspector{builder};
+
+  OptionalFieldTransform f{.x = 1, .y = 2, .z = 3};
+  auto result = inspector.apply(f);
+  ASSERT_TRUE(result.ok());
+  EXPECT_EQ(42, *f.x);
+  EXPECT_FALSE(f.y.has_value());
+  EXPECT_EQ(123, *f.z);
+}
+
+TEST_F(VPackLoadInspectorTest, load_type_with_custom_specialization) {
+  builder.openObject();
+  builder.add("i", VPackValue(42));
+  builder.add("s", VPackValue("foobar"));
+  builder.close();
+  VPackLoadInspector inspector{builder};
+
+  Specialization s;
+  auto result = inspector.apply(s);
+  ASSERT_TRUE(result.ok());
+  EXPECT_EQ(42, s.i);
+  EXPECT_EQ("foobar", s.s);
+}
+
+struct VPackInspectionTest : public ::testing::Test {};
+
+TEST_F(VPackInspectionTest, serialize) {
+  velocypack::Builder builder;
+  Dummy const d{.i = 42, .d = 123.456, .b = true, .s = "foobar"};
+  arangodb::velocypack::serialize(builder, d);
+
+  velocypack::Slice slice = builder.slice();
+  ASSERT_TRUE(slice.isObject());
+  EXPECT_EQ(d.i, slice["i"].getInt());
+  EXPECT_EQ(d.d, slice["d"].getDouble());
+  EXPECT_EQ(d.b, slice["b"].getBool());
+  EXPECT_EQ(d.s, slice["s"].copyString());
+}
+
+TEST_F(VPackInspectionTest, deserialize) {
+  velocypack::Builder builder;
+  builder.openObject();
+  builder.add("i", VPackValue(42));
+  builder.add("d", VPackValue(123.456));
+  builder.add("b", VPackValue(true));
+  builder.add("s", VPackValue("foobar"));
+  builder.close();
+
+  Dummy d = arangodb::velocypack::deserialize<Dummy>(builder.slice());
+  EXPECT_EQ(42, d.i);
+  EXPECT_EQ(123.456, d.d);
+  EXPECT_EQ(true, d.b);
+  EXPECT_EQ("foobar", d.s);
+}
+
+TEST_F(VPackInspectionTest, deserialize_throws) {
+  velocypack::Builder builder;
+  builder.openObject();
+  builder.close();
+
+  EXPECT_THROW(
+      {
+        try {
+          arangodb::velocypack::deserialize<Dummy>(builder.slice());
+        } catch (arangodb::basics::Exception& e) {
+          EXPECT_TRUE(std::string(e.what()).starts_with(
+              "Error while parsing VelocyPack: Missing required attribute"))
+              << "Actual error message: " << e.what();
+          throw;
+        }
+      },
+      arangodb::basics::Exception);
+}
+
+}  // namespace

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -192,6 +192,7 @@ set(ARANGODB_TESTS_SOURCES
   Basics/FixedSizeAllocatorTest.cpp
   Basics/GuardedTest.cpp
   Basics/InifileParserTest.cpp
+  Basics/InspectionTest.cpp
   Basics/LoggerTest.cpp
   Basics/MemoryUsageTest.cpp
   Basics/NumberUtilsTest.cpp


### PR DESCRIPTION
### Scope & Purpose

Adds a type inspection framework for simple serialization/deserialization of custom types from/to velocypack.
The underlying concept is very generic, so it should be easy to extend it and implement inspectors for (de)serializion from/to agency nodes.

This PR only adds the framework itself + tests.

Documentation is still missing and will be added in a separate PR.

- [x] :pizza: New feature

### Checklist

- [x] Tests
  - [x] C++ **Unit tests**
