### PR TITLE
make some internal code parts not unnecessarily depend on v8

### DIFF
--- a/arangod/Agency/AgencyFeature.h
+++ b/arangod/Agency/AgencyFeature.h
@@ -27,10 +27,6 @@
 #include "RestServer/arangod.h"
 
 namespace arangodb {
-namespace application_features {
-class FoxxFeaturePhase;
-}
-
 namespace consensus {
 class Agent;
 }

--- a/arangod/Aql/Functions.cpp
+++ b/arangod/Aql/Functions.cpp
@@ -74,7 +74,6 @@
 #include "Utils/CollectionNameResolver.h"
 #include "Utils/ExecContext.h"
 #include "V8/v8-vpack.h"
-#include "V8Server/v8-collection.h"
 #include "VocBase/KeyGenerator.h"
 #include "VocBase/LogicalCollection.h"
 #include "VocBase/Methods/Collections.h"
@@ -4986,14 +4985,7 @@ AqlValue Functions::Collections(ExpressionContext* exprCtx, AstNode const&,
   builder->openArray();
 
   auto& vocbase = exprCtx->vocbase();
-  auto colls = GetCollections(vocbase);
-
-  std::sort(colls.begin(), colls.end(),
-            [](std::shared_ptr<LogicalCollection> const& lhs,
-               std::shared_ptr<LogicalCollection> const& rhs) -> bool {
-              return arangodb::basics::StringUtils::tolower(lhs->name()) <
-                     arangodb::basics::StringUtils::tolower(rhs->name());
-            });
+  auto colls = methods::Collections::sorted(vocbase);
 
   size_t const n = colls.size();
 

--- a/arangod/Aql/Query.h
+++ b/arangod/Aql/Query.h
@@ -30,6 +30,7 @@
 #include "Aql/ExecutionStats.h"
 #include "Aql/QueryContext.h"
 #include "Aql/QueryExecutionState.h"
+#include "Aql/QueryResult.h"
 #include "Aql/QueryResultV8.h"
 #include "Aql/QueryString.h"
 #include "Aql/SharedQueryState.h"

--- a/arangod/RestHandler/RestControlPregelHandler.cpp
+++ b/arangod/RestHandler/RestControlPregelHandler.cpp
@@ -33,8 +33,6 @@
 #include "Pregel/Conductor.h"
 #include "Pregel/PregelFeature.h"
 #include "Transaction/StandaloneContext.h"
-#include "V8/v8-vpack.h"
-#include "VocBase/Methods/Tasks.h"
 
 #include <velocypack/Builder.h>
 #include <velocypack/Iterator.h>

--- a/arangod/RestServer/ServerFeature.cpp
+++ b/arangod/RestServer/ServerFeature.cpp
@@ -38,10 +38,6 @@
 #include "Replication/ReplicationFeature.h"
 #include "RestServer/DatabaseFeature.h"
 #include "Scheduler/SchedulerFeature.h"
-#include "V8/v8-conv.h"
-#include "V8/v8-globals.h"
-#include "V8/v8-utils.h"
-#include "V8Server/V8Context.h"
 #include "V8Server/V8DealerFeature.h"
 
 using namespace arangodb::application_features;

--- a/arangod/V8Server/v8-collection-util.cpp
+++ b/arangod/V8Server/v8-collection-util.cpp
@@ -32,35 +32,6 @@
 
 using namespace arangodb;
 
-/// @brief check if a name belongs to a collection
-bool EqualCollection(CollectionNameResolver const* resolver,
-                     std::string const& collectionName,
-                     LogicalCollection const* collection) {
-  if (collectionName == collection->name()) {
-    return true;
-  }
-
-  if (collectionName == std::to_string(collection->id().id())) {
-    return true;
-  }
-
-  // Shouldn't it just be: If we are on DBServer we also have to check for
-  // global ID name and cid should be the shard.
-  if (ServerState::instance()->isCoordinator()) {
-    if (collectionName ==
-        resolver->getCollectionNameCluster(collection->id())) {
-      return true;
-    }
-    return false;
-  }
-
-  if (collectionName == resolver->getCollectionName(collection->id())) {
-    return true;
-  }
-
-  return false;
-}
-
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief unwrap a LogicalCollection wrapped via WrapCollection(...)
 /// @return collection or nullptr on failure

--- a/arangod/V8Server/v8-collection.h
+++ b/arangod/V8Server/v8-collection.h
@@ -39,20 +39,6 @@ class LogicalCollection;
 void ReleaseCollection(arangodb::LogicalCollection const* collection);
 
 ////////////////////////////////////////////////////////////////////////////////
-/// @brief return all collections in a cluster
-////////////////////////////////////////////////////////////////////////////////
-std::vector<std::shared_ptr<arangodb::LogicalCollection>> GetCollections(
-    TRI_vocbase_t& vocbase);
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief check if a name belongs to a collection
-////////////////////////////////////////////////////////////////////////////////
-
-bool EqualCollection(arangodb::CollectionNameResolver const* resolver,
-                     std::string const& collectionName,
-                     arangodb::LogicalCollection const* collection);
-
-////////////////////////////////////////////////////////////////////////////////
 /// @brief wraps a LogicalCollection
 /// Note that if collection is a local collection, then the object will never
 /// be freed. If it is not a local collection (coordinator case), then delete

--- a/arangod/VocBase/Methods/Collections.h
+++ b/arangod/VocBase/Methods/Collections.h
@@ -39,6 +39,7 @@ namespace arangodb {
 class ClusterFeature;
 class LogicalCollection;
 struct CollectionCreationInfo;
+class CollectionNameResolver;
 
 namespace transaction {
 class Methods;
@@ -67,6 +68,15 @@ struct Collections {
     transaction::Methods* _trx;
     bool const _responsibleForTrx;
   };
+
+  /// @brief check if a name belongs to a collection
+  static bool hasName(CollectionNameResolver const& resolver,
+                      LogicalCollection const& collection,
+                      std::string const& collectionName);
+
+  /// @brief returns all collections, sorted by names
+  static std::vector<std::shared_ptr<LogicalCollection>> sorted(
+      TRI_vocbase_t& vocbase);
 
   static void enumerate(
       TRI_vocbase_t* vocbase,

--- a/arangod/VocBase/Methods/Databases.cpp
+++ b/arangod/VocBase/Methods/Databases.cpp
@@ -46,8 +46,6 @@
 #include "Utilities/NameValidator.h"
 #include "V8/JavaScriptSecurityContext.h"
 #include "V8/v8-utils.h"
-#include "V8/v8-vpack.h"
-#include "V8Server/V8Context.h"
 #include "V8Server/V8DealerFeature.h"
 #include "VocBase/Methods/Tasks.h"
 #include "VocBase/Methods/Upgrade.h"

--- a/arangod/VocBase/Methods/Indexes.cpp
+++ b/arangod/VocBase/Methods/Indexes.cpp
@@ -44,12 +44,14 @@
 #include "Transaction/Hints.h"
 #include "Transaction/StandaloneContext.h"
 #include "Transaction/V8Context.h"
+#include "Utils/CollectionNameResolver.h"
 #include "Utils/Events.h"
 #include "Utils/ExecContext.h"
 #include "Utils/SingleCollectionTransaction.h"
 #include "Utilities/NameValidator.h"
 #include "V8Server/v8-collection.h"
 #include "VocBase/LogicalCollection.h"
+#include "VocBase/Methods/Collections.h"
 #include "VocBase/vocbase.h"
 #include "Logger/Logger.h"
 #include "Logger/LogMacros.h"
@@ -627,7 +629,8 @@ Result Indexes::extractHandle(arangodb::LogicalCollection const* collection,
   }
 
   if (!collectionName.empty()) {
-    if (!EqualCollection(resolver, collectionName, collection)) {
+    if (!methods::Collections::hasName(*resolver, *collection,
+                                       collectionName)) {
       // I wish this error provided me with more information!
       // e.g. 'cannot access index outside the collection it was defined in'
       return Result(TRI_ERROR_ARANGO_CROSS_COLLECTION_REQUEST);


### PR DESCRIPTION
### Scope & Purpose

Remove a few unused includes of headers that rely on v8.
Move some functions that are not v8-related out of v8-related code files.
This PR contains only an internal refactoring and should not change user-visibile behavior.
No backports are planned.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -
  - [ ] Backport for 3.7: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 