### PR TITLE
allow turning off edge cache and TTL thread

### DIFF
--- a/arangod/Cache/CacheManagerFeature.cpp
+++ b/arangod/Cache/CacheManagerFeature.cpp
@@ -82,7 +82,7 @@ void CacheManagerFeature::collectOptions(
 
 void CacheManagerFeature::validateOptions(
     std::shared_ptr<options::ProgramOptions>) {
-  if (_cacheSize < Manager::minSize) {
+  if (_cacheSize > 0 && _cacheSize < Manager::minSize) {
     LOG_TOPIC("75778", FATAL, arangodb::Logger::FIXME)
         << "invalid value for `--cache.size', need at least "
         << Manager::minSize;
@@ -98,7 +98,7 @@ void CacheManagerFeature::validateOptions(
 }
 
 void CacheManagerFeature::start() {
-  if (ServerState::instance()->isAgent()) {
+  if (ServerState::instance()->isAgent() || _cacheSize == 0) {
     // we intentionally do not activate the cache on an agency node, as it
     // is not needed there
     return;

--- a/arangod/RestServer/TtlFeature.cpp
+++ b/arangod/RestServer/TtlFeature.cpp
@@ -471,7 +471,8 @@ void TtlFeature::validateOptions(std::shared_ptr<ProgramOptions> options) {
     FATAL_ERROR_EXIT();
   }
 
-  if (_properties.frequency < TtlProperties::minFrequency) {
+  if (_properties.frequency > 0 &&
+      _properties.frequency < TtlProperties::minFrequency) {
     LOG_TOPIC("ea696", FATAL, arangodb::Logger::STARTUP)
         << "too low value for '--ttl.frequency'.";
     FATAL_ERROR_EXIT();
@@ -508,7 +509,7 @@ void TtlFeature::start() {
     return;
   }
 
-  _thread.reset(new TtlThread(server(), *this));
+  _thread = std::make_unique<TtlThread>(server(), *this);
 
   if (!_thread->start()) {
     LOG_TOPIC("33c33", FATAL, Logger::TTL)

--- a/arangod/RocksDBEngine/RocksDBEngine.cpp
+++ b/arangod/RocksDBEngine/RocksDBEngine.cpp
@@ -537,7 +537,8 @@ void RocksDBEngine::collectOptions(
                       arangodb::options::Flags::OnDBServer,
                       arangodb::options::Flags::OnSingle,
                       arangodb::options::Flags::Uncommon))
-      .setIntroducedIn(30604);
+      .setIntroducedIn(30604)
+      .setDeprecatedIn(30100);
 
   options->addOption(
       "--rocksdb.wal-archive-size-limit",


### PR DESCRIPTION
### Scope & Purpose

Allow turning off edge cache and background TTL thread ia config options as advertised by their respective startup options help texts.
No backports are planned for this.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -
  - [ ] Backport for 3.7: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 