### PR TITLE
reduce memory usage at startup

### DIFF
--- a/arangod/RocksDBEngine/RocksDBBuilderIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBBuilderIndex.cpp
@@ -79,11 +79,12 @@ struct BuilderCookie : public arangodb::TransactionState::Cookie {
 }  // namespace
 
 RocksDBBuilderIndex::RocksDBBuilderIndex(
-    std::shared_ptr<arangodb::RocksDBIndex> const& wp)
+    std::shared_ptr<arangodb::RocksDBIndex> wp, uint64_t numDocsHint)
     : RocksDBIndex(wp->id(), wp->collection(), wp->name(), wp->fields(),
                    wp->unique(), wp->sparse(), wp->columnFamily(),
                    wp->objectId(), /*useCache*/ false),
-      _wrapped(wp),
+      _wrapped(std::move(wp)),
+      _numDocsHint(numDocsHint),
       _docsProcessed(0) {
   TRI_ASSERT(_wrapped);
 }
@@ -303,6 +304,15 @@ arangodb::Result RocksDBBuilderIndex::fillIndexForeground() {
     _docsProcessed.fetch_add(docsProcessed, std::memory_order_relaxed);
   };
 
+  // reserve some space in WriteBatch
+  size_t batchSize = 1024 * 1024;
+  if (_numDocsHint >= 1024) {
+    batchSize = 4 * 1024 * 1024;
+  }
+  if (_numDocsHint >= 8192) {
+    batchSize = 32 * 1024 * 1024;
+  }
+
   Result res;
   auto& selector =
       _collection.vocbase().server().getFeature<EngineSelectorFeature>();
@@ -312,14 +322,14 @@ arangodb::Result RocksDBBuilderIndex::fillIndexForeground() {
     const rocksdb::Comparator* cmp = internal->columnFamily()->GetComparator();
     // unique index. we need to keep track of all our changes because we need to
     // avoid duplicate index keys. must therefore use a WriteBatchWithIndex
-    rocksdb::WriteBatchWithIndex batch(cmp, 32 * 1024 * 1024);
+    rocksdb::WriteBatchWithIndex batch(cmp, batchSize);
     RocksDBBatchedWithIndexMethods methods(engine.db(), &batch);
     res =
         ::fillIndex<true>(db, *internal, methods, batch, snap, reportProgress);
   } else {
     // non-unique index. all index keys will be unique anyway because they
     // contain the document id we can therefore get away with a cheap WriteBatch
-    rocksdb::WriteBatch batch(32 * 1024 * 1024);
+    rocksdb::WriteBatch batch(batchSize);
     RocksDBBatchedMethods methods(&batch);
     res =
         ::fillIndex<true>(db, *internal, methods, batch, snap, reportProgress);

--- a/arangod/RocksDBEngine/RocksDBBuilderIndex.h
+++ b/arangod/RocksDBEngine/RocksDBBuilderIndex.h
@@ -37,7 +37,8 @@ class RocksDBCollection;
 /// and adds some required synchronization logic on top
 class RocksDBBuilderIndex final : public arangodb::RocksDBIndex {
  public:
-  explicit RocksDBBuilderIndex(std::shared_ptr<arangodb::RocksDBIndex> const&);
+  explicit RocksDBBuilderIndex(std::shared_ptr<arangodb::RocksDBIndex>,
+                               uint64_t numDocsHint);
 
   /// @brief return a VelocyPack representation of the index
   void toVelocyPack(
@@ -122,6 +123,7 @@ class RocksDBBuilderIndex final : public arangodb::RocksDBIndex {
 
  private:
   std::shared_ptr<arangodb::RocksDBIndex> _wrapped;
+  std::uint64_t _numDocsHint;
   std::atomic<uint64_t> _docsProcessed;
 };
 }  // namespace arangodb

--- a/arangod/RocksDBEngine/RocksDBCollection.cpp
+++ b/arangod/RocksDBEngine/RocksDBCollection.cpp
@@ -490,7 +490,8 @@ std::shared_ptr<Index> RocksDBCollection::createIndex(VPackSlice const& info,
 
     // Step 3. add index to collection entry (for removal after a crash)
     auto buildIdx = std::make_shared<RocksDBBuilderIndex>(
-        std::static_pointer_cast<RocksDBIndex>(newIdx));
+        std::static_pointer_cast<RocksDBIndex>(newIdx),
+        _meta.numberDocuments());
     if (!engine.inRecovery()) {
       // manually modify collection entry, other methods need lock
       RocksDBKey key;  // read collection info from database

--- a/arangod/RocksDBEngine/RocksDBSettingsManager.cpp
+++ b/arangod/RocksDBEngine/RocksDBSettingsManager.cpp
@@ -179,8 +179,10 @@ Result RocksDBSettingsManager::sync(bool force) {
   bool didWork = false;
   auto mappings = _engine.collectionMappings();
 
-  // reserve 1MB of scratch space to work with
-  _scratch.reserve(10485760);
+  // reserve a bit of scratch space to work with.
+  // note: the scratch buffer is recycled, so we can start
+  // small here. it will grow as needed.
+  _scratch.reserve(128 * 1024);
 
   for (auto const& pair : mappings) {
     TRI_voc_tick_t dbid = pair.first;

--- a/client-tools/Benchmark/testcases/CustomQueryTestCase.h
+++ b/client-tools/Benchmark/testcases/CustomQueryTestCase.h
@@ -27,7 +27,7 @@
 
 #include "Basics/ScopeGuard.h"
 #include "Basics/files.h"
-#include "Basics/StringBuffer.h"
+
 #include <velocypack/Builder.h>
 #include <velocypack/Value.h>
 #include <string>

--- a/lib/ApplicationFeatures/LanguageFeature.h
+++ b/lib/ApplicationFeatures/LanguageFeature.h
@@ -48,7 +48,6 @@ class LanguageFeature final : public application_features::ApplicationFeature {
         _locale(),
         _langType(basics::LanguageType::INVALID),
         _binaryPath(server.getBinaryPath()),
-        _icuDataPtr(nullptr),
         _forceLanguageCheck(true) {
     setOptional(false);
     startsAfter<application_features::GreetingsFeaturePhase, Server>();
@@ -59,9 +58,10 @@ class LanguageFeature final : public application_features::ApplicationFeature {
   void collectOptions(std::shared_ptr<options::ProgramOptions>) override final;
   void prepare() override final;
   void start() override final;
-  static void* prepareIcu(std::string const& binaryPath,
-                          std::string const& binaryExecutionPath,
-                          std::string& path, std::string const& binaryName);
+  static std::string prepareIcu(std::string const& binaryPath,
+                                std::string const& binaryExecutionPath,
+                                std::string& path,
+                                std::string const& binaryName);
   icu::Locale& getLocale();
   std::tuple<std::string_view, arangodb::basics::LanguageType> getLanguage()
       const;
@@ -76,7 +76,7 @@ class LanguageFeature final : public application_features::ApplicationFeature {
   std::string _icuLanguage;
   arangodb::basics::LanguageType _langType;
   char const* _binaryPath;
-  void* _icuDataPtr;
+  std::string _icuData;
   bool _forceLanguageCheck;
 };
 

--- a/lib/Basics/FileUtils.h
+++ b/lib/Basics/FileUtils.h
@@ -33,11 +33,7 @@
 #include "Basics/FileResultString.h"
 #include "Basics/Result.h"
 
-namespace arangodb {
-namespace basics {
-class StringBuffer;
-
-namespace FileUtils {
+namespace arangodb::basics::FileUtils {
 
 // removes trailing path separators from path, path will be modified in-place
 std::string removeTrailingSeparator(std::string const& name);
@@ -61,16 +57,13 @@ inline std::string buildFilename(std::string const& path,
 }
 
 // reads file into string or buffer
+void slurp(std::string const& filename, std::string& result);
 std::string slurp(std::string const& filename);
-void slurp(std::string const& filename, StringBuffer& result);
-Result slurp(std::string const& filename, std::string& result);
 
 // creates file and writes string to it
 void spit(std::string const& filename, char const* ptr, size_t len,
           bool sync = false);
 void spit(std::string const& filename, std::string const& content,
-          bool sync = false);
-void spit(std::string const& filename, StringBuffer const& content,
           bool sync = false);
 
 // if a file could be removed returns TRI_ERROR_NO_ERROR.
@@ -148,6 +141,4 @@ std::string dirname(std::string const&);
 // returns the output of a program
 std::string slurpProgram(std::string const& program);
 
-}  // namespace FileUtils
-}  // namespace basics
-}  // namespace arangodb
+}  // namespace arangodb::basics::FileUtils

--- a/tests/Basics/icu-helper.cpp
+++ b/tests/Basics/icu-helper.cpp
@@ -30,34 +30,20 @@
 #include "Basics/Utf8Helper.h"
 #include "Basics/directories.h"
 #include "Basics/files.h"
-#include "Basics/memory.h"
 
-static IcuInitializer theInstance;  // must be here to call the dtor
-
-bool IcuInitializer::initialized = false;
-void* IcuInitializer::icuDataPtr = nullptr;
-
-IcuInitializer::IcuInitializer() {}
-
-IcuInitializer::~IcuInitializer() {
-  if (icuDataPtr != nullptr) {
-    TRI_Free(icuDataPtr);
-  }
-  icuDataPtr = nullptr;
-}
+std::string IcuInitializer::icuData;
 
 void IcuInitializer::setup(char const* path) {
-  if (initialized) {
+  if (!icuData.empty()) {
     return;
   }
-  initialized = true;
   std::string p;
   std::string binaryPath = TRI_LocateBinaryPath(path);
-  icuDataPtr = arangodb::LanguageFeature::prepareIcu(TEST_DIRECTORY, binaryPath,
-                                                     p, "basics_suite");
-  if (icuDataPtr == nullptr ||
+  icuData = arangodb::LanguageFeature::prepareIcu(TEST_DIRECTORY, binaryPath, p,
+                                                  "basics_suite");
+  if (icuData.empty() ||
       !arangodb::basics::Utf8Helper::DefaultUtf8Helper.setCollatorLanguage(
-          "", arangodb::basics::LanguageType::DEFAULT, icuDataPtr)) {
+          "", arangodb::basics::LanguageType::DEFAULT, icuData.data())) {
     std::string msg =
         "failed to initialize ICU library. The environment variable ICU_DATA";
     if (getenv("ICU_DATA") != nullptr) {

--- a/tests/Basics/icu-helper.h
+++ b/tests/Basics/icu-helper.h
@@ -26,12 +26,10 @@
 
 #include "Basics/Common.h"
 
-struct IcuInitializer {
-  IcuInitializer();
-  ~IcuInitializer();
+#include <string>
 
+struct IcuInitializer {
   static void setup(char const* path);
 
-  static void* icuDataPtr;
-  static bool initialized;
+  static std::string icuData;
 };


### PR DESCRIPTION
### Scope & Purpose

- for loading icudtl.dat. previously a string buffer was built up
  incrementally while reading the binary input file, while triggered
  some resize operations and some final overallocation along the way. as
  the size of the input file is precisely known when loading the file,
  we can get away with reserving a buffer of exactly the required size
  instead.
- when creating initial indexes for initial collections: previously, a
  (temporary) memory allocation of 32MB was done per index creation.
  this is now reduced to smaller amounts of memory if the indexes are
  expected to contain few documents

No backports are planned for these changes

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [x] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -
  - [ ] Backport for 3.7: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 