### PR TITLE
remove compile dependency on RocksDB from unrelated code

### DIFF
--- a/arangod/Metrics/ClusterMetricsFeature.cpp
+++ b/arangod/Metrics/ClusterMetricsFeature.cpp
@@ -35,8 +35,6 @@
 #include "Network/NetworkFeature.h"
 #include "ProgramOptions/ProgramOptions.h"
 #include "ProgramOptions/Section.h"
-#include "RestServer/QueryRegistryFeature.h"
-#include "RocksDBEngine/RocksDBEngine.h"
 #include "Scheduler/SchedulerFeature.h"
 #include "Statistics/StatisticsFeature.h"
 #include "StorageEngine/EngineSelectorFeature.h"

--- a/arangod/RestHandler/RestCompactHandler.cpp
+++ b/arangod/RestHandler/RestCompactHandler.cpp
@@ -26,7 +26,6 @@
 #include "Basics/StringUtils.h"
 #include "Basics/debugging.h"
 #include "Cluster/ClusterMethods.h"
-#include "RocksDBEngine/RocksDBCommon.h"
 #include "StorageEngine/EngineSelectorFeature.h"
 #include "StorageEngine/StorageEngine.h"
 #include "Utils/ExecContext.h"

--- a/arangod/RocksDBEngine/RocksDBLogValue.cpp
+++ b/arangod/RocksDBEngine/RocksDBLogValue.cpp
@@ -319,11 +319,13 @@ RevisionId RocksDBLogValue::revisionId(rocksdb::Slice const& slice) {
   TRI_ASSERT(slice.size() >= sizeof(RocksDBLogType) + (sizeof(uint64_t)));
   RocksDBLogType type = static_cast<RocksDBLogType>(slice.data()[0]);
   if (type == RocksDBLogType::DocumentRemoveV2) {
-    return RevisionId::fromPersistent(slice.data() + sizeof(RocksDBLogType));
+    char const* data = slice.data() + sizeof(RocksDBLogType);
+    return RevisionId{rocksutils::uint64FromPersistent(data)};
   } else if (type == RocksDBLogType::SingleRemoveV2) {
     TRI_ASSERT(slice.size() >= sizeof(RocksDBLogType) + (3 * sizeof(uint64_t)));
-    return RevisionId::fromPersistent(slice.data() + sizeof(RocksDBLogType) +
-                                      2 * sizeof(uint64_t));
+    char const* data =
+        slice.data() + sizeof(RocksDBLogType) + 2 * sizeof(uint64_t);
+    return RevisionId{rocksutils::uint64FromPersistent(data)};
   }
   TRI_ASSERT(false);  // invalid type
   return RevisionId::none();

--- a/arangod/RocksDBEngine/RocksDBValue.cpp
+++ b/arangod/RocksDBEngine/RocksDBValue.cpp
@@ -121,8 +121,8 @@ LocalDocumentId RocksDBValue::documentId(std::string_view s) {
 
 bool RocksDBValue::revisionId(rocksdb::Slice const& slice, RevisionId& id) {
   if (slice.size() == sizeof(LocalDocumentId::BaseType) + sizeof(RevisionId)) {
-    id = RevisionId::fromPersistent(slice.data() +
-                                    sizeof(LocalDocumentId::BaseType));
+    char const* data = slice.data() + sizeof(LocalDocumentId::BaseType);
+    id = RevisionId{rocksutils::uint64FromPersistent(data)};
     return true;
   }
   return false;
@@ -211,7 +211,7 @@ RocksDBValue::RocksDBValue(RocksDBEntryType type, LocalDocumentId const& docId,
       } else {
         _buffer.reserve(sizeof(uint64_t) * 2);
         uint64ToPersistent(_buffer, docId.id());  // LocalDocumentId
-        revision.toPersistent(_buffer);           // revision
+        rocksutils::uint64ToPersistent(_buffer, revision.id());  // revision
       }
       break;
     }

--- a/arangod/VocBase/Identifiers/RevisionId.cpp
+++ b/arangod/VocBase/Identifiers/RevisionId.cpp
@@ -33,7 +33,6 @@
 #include "Basics/debugging.h"
 #include "Cluster/ClusterInfo.h"
 #include "Logger/LogMacros.h"
-#include "RocksDBEngine/RocksDBFormat.h"
 #include "VocBase/Identifiers/LocalDocumentId.h"
 
 namespace {
@@ -87,11 +86,6 @@ arangodb::velocypack::ValuePair RevisionId::toValuePair(char* buffer) const {
   return arangodb::velocypack::ValuePair(&buffer[0] + positions.first,
                                          positions.second,
                                          velocypack::ValueType::String);
-}
-
-/// @brief Write revision ID to string for storage with correct endianness
-void RevisionId::toPersistent(std::string& buffer) const {
-  rocksutils::uint64ToPersistent(buffer, id());
 }
 
 /// @brief create a revision id with a lower-bound HLC value
@@ -169,10 +163,6 @@ RevisionId RevisionId::fromSlice(velocypack::Slice slice) {
   }
 
   return RevisionId::none();
-}
-
-RevisionId RevisionId::fromPersistent(char const* data) {
-  return RevisionId{rocksutils::uint64FromPersistent(data)};
 }
 
 }  // namespace arangodb

--- a/arangod/VocBase/Identifiers/RevisionId.h
+++ b/arangod/VocBase/Identifiers/RevisionId.h
@@ -68,10 +68,6 @@ class RevisionId final : public arangodb::basics::Identifier {
   /// bytes long
   arangodb::velocypack::ValuePair toValuePair(char* buffer) const;
 
-  /// @brief Write revision ID to string for storage with correct endianness
-  void toPersistent(std::string& buffer) const;
-
- public:
   /// @brief create a not-set revision id
   static constexpr RevisionId none() { return RevisionId{0}; }
 
@@ -106,9 +102,6 @@ class RevisionId final : public arangodb::basics::Identifier {
   /// @brief extract revision from slice; expects either an integer or string,
   /// or an object with a string or integer _rev attribute
   static RevisionId fromSlice(velocypack::Slice slice);
-
-  /// @brief extract revision from persistent storage (proper endianness)
-  static RevisionId fromPersistent(char const* data);
 };
 
 static_assert(sizeof(RevisionId) == sizeof(RevisionId::BaseType),


### PR DESCRIPTION
### Scope & Purpose

Remove compile-time dependency on RocksDB headers for code that doesn't need them.
Simple refactoring. No backports are needed for this change.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -
  - [ ] Backport for 3.7: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 