### PR TITLE
Improvements for the type inspection library

### DIFF
--- a/lib/Inspection/VPackLoadInspector.h
+++ b/lib/Inspection/VPackLoadInspector.h
@@ -191,13 +191,6 @@ struct VPackLoadInspector : InspectorBase<VPackLoadInspector> {
     U fallbackValue;
   };
 
-  template<>
-  struct FallbackContainer<VPackLoadInspector::Keep> {
-    explicit FallbackContainer(VPackLoadInspector::Keep&&) {}
-    template<class T>
-    void apply(T&) const noexcept {}
-  };
-
   template<class Invariant>
   struct InvariantContainer {
     explicit InvariantContainer(Invariant&& invariant)
@@ -323,6 +316,13 @@ struct VPackLoadInspector : InspectorBase<VPackLoadInspector> {
 
   velocypack::Slice _slice;
   ParseOptions _options;
+};
+
+template<>
+struct VPackLoadInspector::FallbackContainer<VPackLoadInspector::Keep> {
+  explicit FallbackContainer(VPackLoadInspector::Keep&&) {}
+  template<class T>
+  void apply(T&) const noexcept {}
 };
 
 }  // namespace arangodb::inspection

--- a/lib/Inspection/VPackSaveInspector.h
+++ b/lib/Inspection/VPackSaveInspector.h
@@ -43,6 +43,11 @@ struct VPackSaveInspector : InspectorBase<VPackSaveInspector> {
   explicit VPackSaveInspector(velocypack::Builder& builder)
       : _builder(builder) {}
 
+  template<class T>
+  [[nodiscard]] Result apply(T const& x) {
+    return process(*this, x);
+  }
+
   [[nodiscard]] Result::Success beginObject() {
     _builder.openObject();
     return {};

--- a/tests/Basics/InspectionTest.cpp
+++ b/tests/Basics/InspectionTest.cpp
@@ -85,7 +85,7 @@ auto inspect(Inspector& f, TypedInt& x) {
     }
     return res;
   } else {
-    return f.apply(x.value);
+    return f.apply(x.getValue());
   }
 }
 

--- a/tests/Basics/InspectionTest.cpp
+++ b/tests/Basics/InspectionTest.cpp
@@ -856,7 +856,7 @@ TEST_F(VPackLoadInspectorTest, load_optional) {
                     .y = "blubb",
                     .vec = {1, std::nullopt, 3},
                     .map = {{"1", 1}, {"2", std::nullopt}, {"3", 3}}};
-  EXPECT_EQ(expected.a, o.a);
+  EXPECT_EQ(expected.a, o.a) << o.a.has_value() << " " << o.a.value();
   EXPECT_EQ(expected.b, o.b);
   EXPECT_EQ(expected.x, o.x);
   EXPECT_EQ(expected.y, o.y);
@@ -920,7 +920,7 @@ TEST_F(VPackLoadInspectorTest, error_expecting_int) {
   builder.add(VPackValue("foo"));
   VPackLoadInspector inspector{builder};
 
-  int i;
+  int i{};
   auto result = inspector.apply(i);
   ASSERT_FALSE(result.ok());
   EXPECT_EQ("Expecting type Int", result.error());
@@ -930,7 +930,7 @@ TEST_F(VPackLoadInspectorTest, error_expecting_int16) {
   builder.add(VPackValue(123456789));
   VPackLoadInspector inspector{builder};
 
-  std::int16_t i;
+  std::int16_t i{};
   auto result = inspector.apply(i);
   ASSERT_FALSE(result.ok());
   EXPECT_EQ("Number out of range", result.error());
@@ -940,7 +940,7 @@ TEST_F(VPackLoadInspectorTest, error_expecting_double) {
   builder.add(VPackValue("foo"));
   VPackLoadInspector inspector{builder};
 
-  double d;
+  double d{};
   auto result = inspector.apply(d);
   ASSERT_FALSE(result.ok());
   EXPECT_EQ("Expecting numeric type", result.error());
@@ -950,7 +950,7 @@ TEST_F(VPackLoadInspectorTest, error_expecting_bool) {
   builder.add(VPackValue(42));
   VPackLoadInspector inspector{builder};
 
-  bool b;
+  bool b{};
   auto result = inspector.apply(b);
   ASSERT_FALSE(result.ok());
   EXPECT_EQ("Expecting type Bool", result.error());


### PR DESCRIPTION
### Scope & Purpose

Some improvements for the type inspection library.
- Allow keeping the current value as fallback.
- Allow passing const& values when saving.

- [x] :pizza: New feature

### Checklist

- [x] Tests
  - [x] C++ **Unit tests**
