### PR TITLE
fix spuriously failing test

### DIFF
--- a/tests/js/client/shell/shell-api-async.js
+++ b/tests/js/client/shell/shell-api-async.js
@@ -65,6 +65,9 @@ function wait_for_put(cmd, code, maxWait) {
 
 function dealing_with_async_requestsSuite () {
   return {
+    tearDownAll: function() {
+      arango.DELETE('/_api/query/slow');
+    },
 
     ////////////////////////////////////////////////////////////////////////////////;
     // checking methods;

--- a/tests/js/client/shell/shell-api-query-analysis.js
+++ b/tests/js/client/shell/shell-api-query-analysis.js
@@ -103,7 +103,6 @@ function queryAnalysisSuite () {
       arango.DELETE(slow);
     },
 
-
     tearDown: function() {
       // Let the queries finish;
       let count = 0;
@@ -112,7 +111,7 @@ function queryAnalysisSuite () {
         if (res.length === 0) {
           break;
         }
-        res.forEach( q => {
+        res.forEach(q => {
           if (q["query"].search('SLEEP') >= 0) {
             arango.DELETE(api + '/' + q["id"]);
           }
@@ -123,12 +122,13 @@ function queryAnalysisSuite () {
         }
         sleep(1);
       }
+      arango.DELETE(slow);
     },
+
     test_should_activate_tracking: function() {
       let doc = arango.PUT_RAW(properties, {enable: true});
       assertEqual(doc.code, 200);
     },
-
 
     test_should_track_running_queries: function() {
       send_queries();


### PR DESCRIPTION
### Scope & Purpose

Fix a spuriously failing test that broke as a side-effect of another test that didn't have a proper cleanup.
This only affects devel after some ruby tests were migrated to JS. No backports are needed.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -
  - [ ] Backport for 3.7: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 