### PR TITLE
fix a memleak in the snowball compiler

### DIFF
--- a/3rdParty/snowball/compiler/driver.c
+++ b/3rdParty/snowball/compiler/driver.c
@@ -146,8 +146,17 @@ static int read_options(struct options * o, int argc, char * argv[]) {
                 continue;
             }
             if (eq(s, "-n") || eq(s, "-name")) {
+                char * new_name;
+                size_t len;
+
                 check_lim(i, argc);
-                o->name = argv[i++];
+                /* Take a copy of the argument here, because
+                 * later we will free o->name */
+                len = strlen(argv[i]);
+                new_name = malloc(len + 1);
+                memcpy(new_name, argv[i++], len);
+                new_name[len] = '\0';
+                o->name = new_name;
                 continue;
             }
 #ifndef DISABLE_JS
@@ -599,6 +608,7 @@ extern int main(int argc, char * argv[]) {
             lose_b(p->b); FREE(p); p = q;
         }
     }
+    FREE(o->name);
     FREE(o);
     if (space_count) fprintf(stderr, "%d blocks unfreed\n", space_count);
     return 0;

--- a/3rdParty/snowball/compiler/header.h
+++ b/3rdParty/snowball/compiler/header.h
@@ -338,7 +338,7 @@ struct options {
     /* for the command line: */
 
     const char * output_file;
-    const char * name;
+    char * name;
     FILE * output_src;
     FILE * output_h;
     byte syntax_tree;


### PR DESCRIPTION
### Scope & Purpose

This fixes a memleak in the snowball compiler during generation of the language-specific C files. The memleak currently makes our ASan-/LSan-instrumented builds fail.

The same fix was suggested to upstream snowball via https://github.com/snowballstem/snowball/pull/166 but is still waiting on feedback there.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -
  - [ ] Backport for 3.7: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 