### PR TITLE
[PREG-103] Make wasm functions run in cluster - DBServer and coordinator

### DIFF
--- a/arangod/Aql/AqlFunctionFeature.cpp
+++ b/arangod/Aql/AqlFunctionFeature.cpp
@@ -499,7 +499,9 @@ void AqlFunctionFeature::addMiscFunctions() {
                            FF::CanRunOnDBServerOneShard),
        &Functions::CallGreenspun});
 
-  add({"CALL_WASM", ".,.,.,.", Function::makeFlags(FF::None),
+  add({"CALL_WASM", ".,.,.,.",
+       Function::makeFlags(FF::CanRunOnDBServerCluster,
+                           FF::CanRunOnDBServerOneShard),
        &Functions::CallWasm});
 
   // special flags:

--- a/arangod/WasmServer/CMakeLists.txt
+++ b/arangod/WasmServer/CMakeLists.txt
@@ -3,7 +3,9 @@ add_library(arango_wasm STATIC
   Methods.cpp
   WasmCommon.cpp
   RestWasmHandler.cpp
-  WasmServerFeature.cpp)
+  WasmServerFeature.cpp
+  WasmModuleCollection.cpp)
 
 target_link_libraries(arango_wasm arango)
 target_link_libraries(arango_wasm m3)
+target_link_libraries(arango_wasm arango_vocbase)

--- a/arangod/WasmServer/Methods.cpp
+++ b/arangod/WasmServer/Methods.cpp
@@ -24,17 +24,16 @@
 #include "Methods.h"
 
 #include <cstdint>
+#include <memory>
+#include <vector>
 
 #include "ApplicationFeatures/ApplicationServer.h"
-#include "Basics/Exceptions.h"
 #include "Basics/Result.h"
 #include "Basics/ResultT.h"
-#include "Basics/voc-errors.h"
-#include "Cluster/ServerState.h"
 #include "Futures/Future.h"
 #include "VocBase/vocbase.h"
-#include "WasmServerFeature.h"
-#include "WasmCommon.h"
+#include "WasmServer/WasmServerFeature.h"
+#include "WasmServer/WasmCommon.h"
 
 using namespace arangodb;
 using namespace arangodb::wasm;
@@ -47,23 +46,21 @@ struct WasmVmMethodsSingleServer final
 
   auto addModule(Module const& module) const
       -> futures::Future<Result> override {
-    vocbase.server().getFeature<WasmServerFeature>().addModule(module);
-    return Result{TRI_ERROR_NO_ERROR};
+    return vocbase.server().getFeature<WasmServerFeature>().addModule(module);
   }
 
-  auto deleteModule(ModuleName const& name) const
+  auto removeModule(ModuleName const& name) const
       -> futures::Future<Result> override {
-    vocbase.server().getFeature<WasmServerFeature>().deleteModule(name);
-    return Result{TRI_ERROR_NO_ERROR};
+    return vocbase.server().getFeature<WasmServerFeature>().removeModule(name);
   }
 
   auto allModules() const
-      -> futures::Future<std::unordered_map<std::string, Module>> override {
+      -> futures::Future<ResultT<std::vector<ModuleName>>> override {
     return vocbase.server().getFeature<WasmServerFeature>().allModules();
   }
 
   auto module(ModuleName const& name) const
-      -> futures::Future<std::optional<Module>> override {
+      -> futures::Future<ResultT<Module>> override {
     return vocbase.server().getFeature<WasmServerFeature>().module(name);
   }
 
@@ -80,16 +77,5 @@ struct WasmVmMethodsSingleServer final
 
 auto WasmVmMethods::createInstance(TRI_vocbase_t& vocbase)
     -> std::shared_ptr<WasmVmMethods> {
-  switch (ServerState::instance()->getRole()) {
-    case ServerState::ROLE_SINGLE:
-      return std::make_shared<WasmVmMethodsSingleServer>(vocbase);
-    case ServerState::ROLE_COORDINATOR:
-      // TODO PREG-102 Create a separate class for Coordinator
-      return std::make_shared<WasmVmMethodsSingleServer>(vocbase);
-    // TODO PREG-103 Create a separate class for DBServer
-    default:
-      THROW_ARANGO_EXCEPTION_MESSAGE(
-          TRI_ERROR_NOT_IMPLEMENTED,
-          "This API is only available on single server.");
-  }
+  return std::make_shared<WasmVmMethodsSingleServer>(vocbase);
 }

--- a/arangod/WasmServer/WasmCommon.cpp
+++ b/arangod/WasmServer/WasmCommon.cpp
@@ -26,12 +26,16 @@ void codeToVelocypack(Code const& code, VPackBuilder& builder) {
 }
 
 void arangodb::wasm::moduleToVelocypack(Module const& module,
-                                        VPackBuilder& builder) {
+                                        VPackBuilder& builder,
+                                        bool forCollection) {
   auto ob = VPackObjectBuilder(&builder);
   builder.add("name", VPackValue(module.name.string));
   builder.add(VPackValue("code"));
   codeToVelocypack(module.code, builder);
   builder.add("isDeterministic", VPackValue(module.isDeterministic));
+  if (forCollection) {
+    builder.add("_key", VPackValue(module.name.string));
+  }
 }
 
 auto checkVelocypackToModuleIsPossible(Slice slice) -> Result {
@@ -49,7 +53,7 @@ auto checkVelocypackToModuleIsPossible(Slice slice) -> Result {
   std::set<std::string> validFields = {"name", "code", "isDeterministic"};
   for (const auto& field : ObjectIterator(slice)) {
     if (auto fieldname = field.key.copyString();
-        !(validFields.contains(fieldname))) {
+        !fieldname.starts_with("_") && !validFields.contains(fieldname)) {
       return Result{TRI_ERROR_BAD_PARAMETER,
                     "Found unknown field '" + fieldname + "'"};
     }

--- a/arangod/WasmServer/WasmCommon.h
+++ b/arangod/WasmServer/WasmCommon.h
@@ -69,7 +69,8 @@ struct FunctionParameters {
 };
 
 auto velocypackToModule(arangodb::velocypack::Slice slice) -> ResultT<Module>;
-void moduleToVelocypack(Module const& module, VPackBuilder& builder);
+void moduleToVelocypack(Module const& module, VPackBuilder& builder,
+                        bool forCollection = false);
 auto velocypackToFunctionParameters(arangodb::velocypack::Slice slice)
     -> ResultT<FunctionParameters>;
 

--- a/arangod/WasmServer/WasmModuleCollection.cpp
+++ b/arangod/WasmServer/WasmModuleCollection.cpp
@@ -1,0 +1,257 @@
+#include "WasmModuleCollection.h"
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "ApplicationFeatures/ApplicationServer.h"
+#include "Aql/Query.h"
+#include "Aql/QueryResult.h"
+#include "Aql/QueryString.h"
+#include "Basics/StaticStrings.h"
+#include "Basics/voc-errors.h"
+#include "Cluster/ClusterFeature.h"
+#include "Cluster/ClusterInfo.h"
+#include "Cluster/ServerState.h"
+#include "RestServer/UpgradeFeature.h"
+#include "Transaction/Hints.h"
+#include "Transaction/Methods.h"
+#include "Transaction/StandaloneContext.h"
+#include "Utils/OperationOptions.h"
+#include "Utils/OperationResult.h"
+#include "Utils/SingleCollectionTransaction.h"
+#include "VocBase/Identifiers/LocalDocumentId.h"
+#include "velocypack/Builder.h"
+#include "velocypack/Iterator.h"
+#include "velocypack/Slice.h"
+#include "velocypack/Value.h"
+#include "VocBase/AccessMode.h"
+#include "VocBase/Identifiers/DataSourceId.h"
+#include "VocBase/LogicalCollection.h"
+#include "VocBase/Methods/Collections.h"
+#include "VocBase/Methods/Upgrade.h"
+#include "VocBase/vocbase.h"
+#include "VocBase/voc-types.h"
+#include "velocypack/Buffer.h"
+#include "WasmServer/WasmCommon.h"
+
+namespace arangodb {
+class LocalDocumentId;
+}
+
+using namespace arangodb;
+using namespace arangodb::wasm;
+using namespace velocypack;
+
+std::string const errorContext = "WasmModuleCollection";
+
+WasmModuleCollection::WasmModuleCollection(TRI_vocbase_t& vocbase)
+    : _vocbase{vocbase} {}
+
+auto WasmModuleCollection::allNames() const
+    -> ResultT<std::vector<ModuleName>> {
+  std::string const aql("FOR l IN " + _collection + " RETURN l._key");
+  auto query = arangodb::aql::Query::create(
+      transaction::StandaloneContext::Create(_vocbase),
+      arangodb::aql::QueryString(aql), nullptr);
+
+  aql::QueryResult queryResult = query->executeSync();
+
+  if (queryResult.result.fail()) {
+    return Result{TRI_ERROR_INTERNAL,
+                  errorContext + " Could not get all keys: " +
+                      queryResult.result.errorMessage().data()};
+  }
+
+  std::vector<ModuleName> names;
+  for (auto const& item :
+       velocypack::ArrayIterator(queryResult.data->slice())) {
+    names.emplace_back(ModuleName{item.copyString()});
+  }
+
+  return ResultT<std::vector<ModuleName>>(names);
+}
+
+auto WasmModuleCollection::getFromDBServer(ModuleName const& name) const
+    -> ResultT<Module> {
+  auto& clusterInfo =
+      _vocbase.server().getFeature<ClusterFeature>().clusterInfo();
+  auto logicalCollectionPtr =
+      clusterInfo.getCollection(_vocbase.name(), _collection);
+  auto shardList =
+      clusterInfo.getShardList(std::to_string(logicalCollectionPtr->id().id()));
+  if (shardList->size() != 1) {
+    return Result{
+        TRI_ERROR_INTERNAL,
+        errorContext +
+            " Could not find shard for satellite collection on this server."};
+  }
+  auto collectionName = shardList->at(0);
+
+  SingleCollectionTransaction trx(
+      transaction::StandaloneContext::Create(_vocbase), _collection,
+      AccessMode::Type::READ);
+  if (auto res = trx.begin(); res.fail()) {
+    return Result{TRI_ERROR_INTERNAL, errorContext +
+                                          " Could not start transaction: " +
+                                          res.errorMessage().data()};
+  }
+  VPackBuilder builder;
+  auto result = trx.documentFastPathLocal(
+      collectionName, name.string,
+      [&builder](LocalDocumentId const& id, velocypack::Slice slice) {
+        builder.add(slice);
+        return true;
+      });
+  if (auto res = trx.finish(result); res.fail()) {
+    return Result{
+        TRI_ERROR_BAD_PARAMETER,
+        errorContext + " Could not get document: " + res.errorMessage().data()};
+  }
+  return velocypackToModule(builder.slice());
+}
+
+auto WasmModuleCollection::get(ModuleName const& name) const
+    -> ResultT<Module> {
+  if (ServerState::instance()->isDBServer()) {
+    return getFromDBServer(name);
+  }
+
+  VPackBuilder search;
+  {
+    VPackObjectBuilder ob(&search);
+    search.add(StaticStrings::KeyString, VPackValue(name.string));
+  }
+  SingleCollectionTransaction trx(
+      transaction::StandaloneContext::Create(_vocbase), _collection,
+      AccessMode::Type::READ);
+  if (auto res = trx.begin(); res.fail()) {
+    return Result{TRI_ERROR_INTERNAL, errorContext +
+                                          " Could not start transaction: " +
+                                          res.errorMessage().data()};
+  }
+  return trx.documentAsync(_collection, search.slice(), OperationOptions())
+      .thenValue([&trx](OperationResult opRes) {
+        return trx.finishAsync(opRes.result)
+            .thenValue(
+                [opRes(std::move(opRes))](Result result) -> ResultT<Module> {
+                  if (result.fail()) {
+                    return Result{TRI_ERROR_BAD_PARAMETER,
+                                  errorContext + " Could not get document: " +
+                                      result.errorMessage().data()};
+                  }
+                  return velocypackToModule(Slice(opRes.buffer->data()));
+                });
+      })
+      .get();
+}
+
+auto WasmModuleCollection::add(wasm::Module const& module) -> Result {
+  SingleCollectionTransaction trx(
+      transaction::StandaloneContext::Create(_vocbase), _collection,
+      AccessMode::Type::WRITE);
+  trx.addHint(transaction::Hints::Hint::SINGLE_OPERATION);
+  if (auto res = trx.begin(); res.fail()) {
+    return Result{TRI_ERROR_INTERNAL, errorContext +
+                                          " Could not start transaction: " +
+                                          res.errorMessage().data()};
+  }
+
+  VPackBuilder moduleAsVelocypack;
+  moduleToVelocypack(module, moduleAsVelocypack, true);
+
+  arangodb::OperationOptions opOptions;
+  opOptions.waitForSync = false;
+  opOptions.silent = true;
+  opOptions.overwriteMode = OperationOptions::OverwriteMode::Replace;
+  return trx.insertAsync(_collection, moduleAsVelocypack.slice(), opOptions)
+      .thenValue([&trx](OperationResult opRes) {
+        return trx.finishAsync(opRes.result)
+            .thenValue([opRes(std::move(opRes))](Result result) -> Result {
+              if (result.fail()) {
+                return Result{TRI_ERROR_BAD_PARAMETER,
+                              errorContext + " Could not write module: " +
+                                  result.errorMessage().data()};
+              }
+              return {};
+            });
+      })
+      .get();
+}
+
+auto WasmModuleCollection::remove(wasm::ModuleName const& name) -> Result {
+  SingleCollectionTransaction trx(
+      transaction::StandaloneContext::Create(_vocbase), _collection,
+      AccessMode::Type::WRITE);
+  trx.addHint(transaction::Hints::Hint::SINGLE_OPERATION);
+  if (auto res = trx.begin(); res.fail()) {
+    return Result{TRI_ERROR_INTERNAL, errorContext +
+                                          " Could not start transaction: " +
+                                          res.errorMessage().data()};
+  }
+
+  VPackBuilder search;
+  {
+    VPackObjectBuilder ob(&search);
+    search.add(StaticStrings::KeyString, VPackValue(name.string));
+  }
+  return trx.removeAsync(_collection, search.slice(), OperationOptions())
+      .thenValue([&trx](OperationResult opRes) {
+        return trx.finishAsync(opRes.result)
+            .thenValue([opRes(std::move(opRes))](Result result) -> Result {
+              if (result.fail()) {
+                return Result{TRI_ERROR_BAD_PARAMETER,
+                              errorContext + " Could not remove module: " +
+                                  result.errorMessage().data()};
+              }
+              return {};
+            });
+      })
+      .get();
+}
+
+bool upgradeWasmModuleSystemCollection(
+    TRI_vocbase_t& vocbase, velocypack::Slice const& /*upgradeParams*/) {
+  VPackBuilder collectionProperties;
+  {
+    VPackObjectBuilder builder(&collectionProperties);
+    collectionProperties.add(StaticStrings::ReplicationFactor,
+                             VPackValue(StaticStrings::Satellite));
+  }
+  auto collections = std::shared_ptr<LogicalCollection>();
+  auto result = methods::Collections::create(
+      vocbase, OperationOptions(), "wasmModules", TRI_COL_TYPE_DOCUMENT,
+      collectionProperties.slice(),
+      true,  // createWaitsForSyncReplication
+      true,  // enforceReplicationFactor
+      true,  // isNewDatabase
+      collections,
+      false  // allow system collection creation
+  );
+  return true;
+}
+
+void arangodb::registerWasmModuleCollectionUpgradeTask(ArangodServer& server) {
+  if (!server.hasFeature<UpgradeFeature>()) {
+    return;
+  }
+  auto& upgrade = server.getFeature<UpgradeFeature>();
+
+  {
+    methods::Upgrade::Task task;
+    task.name = "upgradeWasm";
+    task.description =
+        "ensure creation of satellite collection for wasm modules";
+    task.systemFlag = methods::Upgrade::Flags::DATABASE_ALL;
+    task.clusterFlags = methods::Upgrade::Flags::CLUSTER_COORDINATOR_GLOBAL |
+                        methods::Upgrade::Flags::CLUSTER_NONE;
+    task.databaseFlags = methods::Upgrade::Flags::DATABASE_UPGRADE |
+                         methods::Upgrade::Flags::DATABASE_EXISTING |
+                         methods::Upgrade::Flags::DATABASE_INIT |
+                         methods::Upgrade::Flags::DATABASE_ONLY_ONCE;
+    task.action = &upgradeWasmModuleSystemCollection;
+    upgrade.addTask(std::move(task));
+  }
+}

--- a/arangod/WasmServer/WasmModuleCollection.h
+++ b/arangod/WasmServer/WasmModuleCollection.h
@@ -22,44 +22,33 @@
 ////////////////////////////////////////////////////////////////////////////////
 #pragma once
 
-#include <cstdint>
-#include <memory>
 #include <string>
 #include <vector>
 
+#include "Basics/Result.h"
+#include "Basics/ResultT.h"
+#include "RestServer/arangod.h"
 #include "WasmServer/WasmCommon.h"
 
 struct TRI_vocbase_t;
 
 namespace arangodb {
-class Result;
-template<typename T>
-class ResultT;
 
-namespace futures {
-template<typename T>
-class Future;
-}
-}  // namespace arangodb
+class WasmModuleCollection {
+ public:
+  WasmModuleCollection(TRI_vocbase_t& vocbase);
+  auto allNames() const -> ResultT<std::vector<wasm::ModuleName>>;
+  auto get(wasm::ModuleName const& name) const -> ResultT<wasm::Module>;
+  auto add(wasm::Module const& module) -> Result;
+  auto remove(wasm::ModuleName const& name) -> Result;
 
-namespace arangodb::wasm {
-
-struct WasmVmMethods {
-  virtual ~WasmVmMethods() = default;
-  virtual auto addModule(Module const& module) const
-      -> futures::Future<Result> = 0;
-  virtual auto removeModule(ModuleName const& name) const
-      -> futures::Future<Result> = 0;
-  virtual auto allModules() const
-      -> futures::Future<ResultT<std::vector<ModuleName>>> = 0;
-  virtual auto module(ModuleName const& name) const
-      -> futures::Future<ResultT<Module>> = 0;
-  virtual auto executeFunction(ModuleName const& moduleName,
-                               FunctionName const& functionName,
-                               FunctionParameters const& parameters) const
-      -> futures::Future<ResultT<uint64_t>> = 0;
-  static auto createInstance(TRI_vocbase_t& vocbase)
-      -> std::shared_ptr<WasmVmMethods>;
+ private:
+  TRI_vocbase_t& _vocbase;
+  inline static std::string const _collection = "wasmModules";
+  auto getFromDBServer(wasm::ModuleName const& name) const
+      -> ResultT<wasm::Module>;
 };
 
-}  // namespace arangodb::wasm
+void registerWasmModuleCollectionUpgradeTask(ArangodServer& server);
+
+}  // namespace arangodb

--- a/arangod/WasmServer/WasmServerFeature.cpp
+++ b/arangod/WasmServer/WasmServerFeature.cpp
@@ -1,19 +1,20 @@
 #include "WasmServerFeature.h"
 
 #include <cstdint>
-#include <iterator>
-#include <optional>
-#include <unordered_map>
+#include <memory>
 #include <utility>
 #include <vector>
 
 #include "ApplicationFeatures/ApplicationServer.h"
 #include "Basics/error-registry.h"
 #include "Basics/Result.h"
+#include "Basics/application-exit.h"
 #include "Basics/voc-errors.h"
-#include "Cluster/ServerState.h"
+#include "Logger/LogMacros.h"
+#include "RestServer/SystemDatabaseFeature.h"
 #include "WasmServer/Wasm3cpp.h"
 #include "WasmServer/WasmCommon.h"
+#include "WasmServer/WasmModuleCollection.h"
 
 namespace arangodb {
 namespace application_features {
@@ -30,16 +31,20 @@ WasmServerFeature::WasmServerFeature(Server& server)
   setOptional(true);
   // TODO: check when to start WasmServerFeature
   startsAfter<CommunicationFeaturePhase>();
-  startsAfter<DatabaseFeaturePhase>();
+  startsBefore<DatabaseFeaturePhase>();
 }
 
-void WasmServerFeature::prepare() {
-  if (ServerState::instance()->isCoordinator() or
-      ServerState::instance()->isDBServer()) {
-    setEnabled(true);
-  } else {
-    setEnabled(false);
+void WasmServerFeature::prepare() { setEnabled(true); }
+
+void WasmServerFeature::start() {
+  auto vocbase = server().getFeature<SystemDatabaseFeature>().use();
+  if (!vocbase) {
+    LOG_TOPIC("4bcfc", FATAL, Logger::WASM) << "could not get vocbase";
+    FATAL_ERROR_EXIT();
+    return;
   }
+  _wasmModuleCollection = std::make_unique<WasmModuleCollection>(*vocbase);
+  arangodb::registerWasmModuleCollectionUpgradeTask(server());
 }
 
 void WasmServerFeature::collectOptions(
@@ -47,45 +52,36 @@ void WasmServerFeature::collectOptions(
 void WasmServerFeature::validateOptions(
     std::shared_ptr<options::ProgramOptions>) {}
 
-void WasmServerFeature::addModule(Module const& module) {
-  _guardedModules.doUnderLock([&module](GuardedModules& guardedModules) {
-    guardedModules._modules.insert_or_assign(module.name.string, module);
-  });
-}
-
 auto WasmServerFeature::loadModuleIntoRuntime(ModuleName const& name)
     -> Result {
-  auto module = _guardedModules.doUnderLock(
-      [&name](GuardedModules& guardedModules) -> std::optional<Module> {
-        auto maybef = guardedModules._modules.find(name.string);
-        if (maybef == std::end(guardedModules._modules)) {
-          return std::nullopt;
-        } else {
-          return maybef->second;
-        }
-      });
-
-  if (!module.has_value()) {
-    return Result{TRI_ERROR_WASM_EXECUTION_ERROR,
-                  "WasmServerFeature: Module '" + name.string + "' not found"};
+  auto module = _wasmModuleCollection->get(name);
+  if (module.fail()) {
+    return Result{TRI_ERROR_WASM_EXECUTION_ERROR, module.errorMessage()};
   }
 
-  auto wasm3Module = _environment.parse_module(
-      module.value().code.bytes.data(), module.value().code.bytes.size());
+  auto wasm3Module = _environment.parse_module(module.get().code.bytes.data(),
+                                               module.get().code.bytes.size());
   _runtime.load(wasm3Module);
-  _loadedModules.emplace(name.string);
+  _guardedModules.doUnderLock([&name](GuardedModules& guardedModules) {
+    guardedModules._loadedModules.emplace(name.string);
+  });
   return Result{};
 }
 
 auto WasmServerFeature::executeFunction(
     ModuleName const& moduleName, FunctionName const& functionName,
     wasm::FunctionParameters const& parameters) -> ResultT<uint64_t> {
-  if (!_loadedModules.contains(moduleName.string)) {
+  auto moduleAlreadyLoaded = _guardedModules.doUnderLock(
+      [&moduleName](GuardedModules const& guardedModules) -> bool {
+        return guardedModules._loadedModules.contains(moduleName.string);
+      });
+  if (!moduleAlreadyLoaded) {
     if (auto result = loadModuleIntoRuntime(moduleName); result.fail()) {
       return ResultT<uint64_t>::error(result.errorNumber(),
                                       result.errorMessage());
     }
   }
+
   auto function = _runtime.find_function(functionName.string.c_str());
   if (!function.has_value()) {
     return ResultT<uint64_t>::error(TRI_ERROR_WASM_EXECUTION_ERROR,
@@ -93,32 +89,22 @@ auto WasmServerFeature::executeFunction(
                                         functionName.string + "' in module '" +
                                         moduleName.string + "' not found");
   }
-
   return function.value().call<uint64_t>(parameters.a, parameters.b);
 }
 
-void WasmServerFeature::deleteModule(ModuleName const& name) {
-  _guardedModules.doUnderLock([&name](GuardedModules& guardedModules) {
-    guardedModules._modules.erase(name.string);
-  });
+auto WasmServerFeature::addModule(Module const& module) -> Result {
+  return _wasmModuleCollection->add(module);
 }
 
-auto WasmServerFeature::allModules() const
-    -> std::unordered_map<std::string, Module> {
-  return _guardedModules.doUnderLock([](GuardedModules const& guardedModules) {
-    return guardedModules._modules;
-  });
+auto WasmServerFeature::removeModule(ModuleName const& name) -> Result {
+  return _wasmModuleCollection->remove(name);
+}
+
+auto WasmServerFeature::allModules() const -> ResultT<std::vector<ModuleName>> {
+  return _wasmModuleCollection->allNames();
 }
 
 auto WasmServerFeature::module(ModuleName const& name) const
-    -> std::optional<Module> {
-  return _guardedModules.doUnderLock(
-      [&name](GuardedModules const& guardedModules) -> std::optional<Module> {
-        auto module = guardedModules._modules.find(name.string);
-        if (module == std::end(guardedModules._modules)) {
-          return std::nullopt;
-        } else {
-          return module->second;
-        }
-      });
+    -> ResultT<Module> {
+  return _wasmModuleCollection->get(name);
 }

--- a/arangod/WasmServer/WasmServerFeature.h
+++ b/arangod/WasmServer/WasmServerFeature.h
@@ -23,12 +23,11 @@
 #pragma once
 
 #include <cstdint>
-#include <unordered_map>
 #include <memory>
-#include <optional>
 #include <set>
 #include <string>
 #include <string_view>
+#include <vector>
 
 #include "ApplicationFeatures/ApplicationFeature.h"
 #include "Basics/Guarded.h"
@@ -37,6 +36,7 @@
 #include "RestServer/arangod.h"
 #include "WasmServer/Wasm3cpp.h"
 #include "WasmServer/WasmCommon.h"
+#include "WasmServer/WasmModuleCollection.h"
 
 namespace arangodb {
 namespace options {
@@ -56,26 +56,27 @@ class WasmServerFeature final : public ArangodFeature {
 
   void validateOptions(std::shared_ptr<options::ProgramOptions>) override final;
   void prepare() override;
-  void addModule(wasm::Module const& module);
+  void start() override;
+
   auto loadModuleIntoRuntime(wasm::ModuleName const& name) -> Result;
   auto executeFunction(wasm::ModuleName const& moduleName,
                        wasm::FunctionName const& functionName,
                        wasm::FunctionParameters const& parameters)
       -> ResultT<uint64_t>;
-  void deleteModule(wasm::ModuleName const& name);
-  auto allModules() const -> std::unordered_map<std::string, wasm::Module>;
-  auto module(wasm::ModuleName const& name) const
-      -> std::optional<wasm::Module>;
+  auto addModule(wasm::Module const& module) -> Result;
+  auto removeModule(wasm::ModuleName const& name) -> Result;
+  auto allModules() const -> ResultT<std::vector<wasm::ModuleName>>;
+  auto module(wasm::ModuleName const& name) const -> ResultT<wasm::Module>;
 
  private:
   struct GuardedModules {
-    std::unordered_map<std::string, wasm::Module> _modules;
+    std::set<std::string> _loadedModules;
   };
   Guarded<GuardedModules> _guardedModules;
 
   wasm3::environment _environment;
   wasm3::runtime _runtime = _environment.new_runtime(1024);
 
-  std::set<std::string> _loadedModules;
+  std::unique_ptr<WasmModuleCollection> _wasmModuleCollection;
 };
 }  // namespace arangodb

--- a/lib/Logger/LogTopic.cpp
+++ b/lib/Logger/LogTopic.cpp
@@ -160,6 +160,7 @@ LogTopic Logger::TTL("ttl", LogLevel::WARN);
 LogTopic Logger::VALIDATION("validation", LogLevel::INFO);
 LogTopic Logger::V8("v8", LogLevel::WARN);
 LogTopic Logger::VIEWS("views", LogLevel::FATAL);
+LogTopic Logger::WASM("wasm", LogLevel::WARN);
 
 #ifdef USE_ENTERPRISE
 LogTopic LdapAuthProvider::LDAP_TOPIC("ldap", LogLevel::INFO);

--- a/lib/Logger/Logger.h
+++ b/lib/Logger/Logger.h
@@ -205,6 +205,7 @@ class Logger {
   static LogTopic VALIDATION;
   static LogTopic V8;
   static LogTopic VIEWS;
+  static LogTopic WASM;
 
  public:
   struct FIXED {

--- a/tests/WasmServer/WasmFunctionSliceTest.cpp
+++ b/tests/WasmServer/WasmFunctionSliceTest.cpp
@@ -79,6 +79,11 @@ TEST_F(WasmModuleCreation, gives_error_for_unknown_key) {
   expectError(R"({"name": "test", "code": [8, 9, 0], "banane": 5})");
 }
 
+TEST_F(WasmModuleCreation, creates_module_with_additional_underscore_key) {
+  expectModule(R"({"name": "test", "code": [8, 9, 0], "_banane": 5})",
+               Module{{"test"}, {{8, 9, 0}}, false});
+}
+
 TEST_F(WasmModuleCreation, gives_error_when_name_is_not_a_string) {
   expectError(R"({"name": 1, "code": [0]})");
 }
@@ -111,6 +116,18 @@ TEST(WasmModuleConversion, converts_module_to_velocypack) {
       velocypackBuilder.toJson(),
       VPackParser::fromJson(
           R"({"name": "module_name", "code": "A+k=", "isDeterministic": false})")
+          ->slice()
+          .toJson());
+}
+
+TEST(WasmModuleConversion, converts_module_to_velocypack_with_name_as_key) {
+  VPackBuilder velocypackBuilder;
+  arangodb::wasm::moduleToVelocypack(Module{{"module_name"}, {{3, 233}}, false},
+                                     velocypackBuilder, true);
+  EXPECT_EQ(
+      velocypackBuilder.toJson(),
+      VPackParser::fromJson(
+          R"({"name": "module_name", "code": "A+k=", "isDeterministic": false, "_key": "module_name"})")
           ->slice()
           .toJson());
 }

--- a/tests/js/client/shell/shell-wasm.js
+++ b/tests/js/client/shell/shell-wasm.js
@@ -40,131 +40,133 @@ var wasmmodules = require("@arangodb/aql/wasmModules");
 /// @brief test suite
 ////////////////////////////////////////////////////////////////////////////////
 
-function WasmModulesSuite () {
-  'use strict';
+function WasmModulesSuite() {
+	'use strict';
 
-    const modulename = "my_module";
-    const code = "AGFzbQEAAAABKwhgAAF/YAF/AX9gAn9/AX9gAABgAX8AYAN/f38Bf2ADf35/AX5gAn5+AX4CeQQWd2FzaV9zbmFwc2hvdF9wcmV2aWV3MQ5hcmdzX3NpemVzX2dldAACFndhc2lfc25hcHNob3RfcHJldmlldzEIYXJnc19nZXQAAhZ3YXNpX3NuYXBzaG90X3ByZXZpZXcxCXByb2NfZXhpdAAEA2VudgRtYWluAAIDCwoDBwMAAAAEAQEBBAUBcAECAgUGAQGAAoACBgkBfwFBoIjAAgsHeQkGbWVtb3J5AgADYWRkAAUZX19pbmRpcmVjdF9mdW5jdGlvbl90YWJsZQEABl9zdGFydAAGEF9fZXJybm9fbG9jYXRpb24ACAZmZmx1c2gADAlzdGFja1NhdmUACQxzdGFja1Jlc3RvcmUACgpzdGFja0FsbG9jAAsJBwEAQQELAQQKmQMKAwABCwcAIAAgAXwLBwAQBxACAAuNAQEEfyMAQRBrIgAkAAJAIAAiAkEMaiAAQQhqEABFBEACf0EAIAIoAgwiAUUNABogACABQQJ0IgNBE2pBcHFrIgAiASQAIAEgAigCCEEPakFwcWsiASQAIAAgA2pBADYCACAAIAEQAQ0CIAIoAgwLIAAQAyEAIAJBEGokACAADwtBxwAQAgALQccAEAIACwUAQYAICwQAIwALBgAgACQACxAAIwAgAGtBcHEiACQAIAALZwEBfyAABEAgACgCTEF/TARAIAAQDQ8LIAAQDQ8LQZAIKAIABEBBkAgoAgAQDCEBC0GMCCgCACIABEADQCAAKAJMGiAAKAIUIAAoAhxLBEAgABANIAFyIQELIAAoAjgiAA0ACwsgAQtpAQJ/AkAgACgCFCAAKAIcTQ0AIABBAEEAIAAoAiQRBQAaIAAoAhQNAEF/DwsgACgCBCIBIAAoAggiAkkEQCAAIAEgAmusQQEgACgCKBEGABoLIABBADYCHCAAQgA3AxAgAEIANwIEQQAL";
-    
-return {
+	const modulename = "my_module";
+	const code = "AGFzbQEAAAABKwhgAAF/YAF/AX9gAn9/AX9gAABgAX8AYAN/f38Bf2ADf35/AX5gAn5+AX4CeQQWd2FzaV9zbmFwc2hvdF9wcmV2aWV3MQ5hcmdzX3NpemVzX2dldAACFndhc2lfc25hcHNob3RfcHJldmlldzEIYXJnc19nZXQAAhZ3YXNpX3NuYXBzaG90X3ByZXZpZXcxCXByb2NfZXhpdAAEA2VudgRtYWluAAIDCwoDBwMAAAAEAQEBBAUBcAECAgUGAQGAAoACBgkBfwFBoIjAAgsHeQkGbWVtb3J5AgADYWRkAAUZX19pbmRpcmVjdF9mdW5jdGlvbl90YWJsZQEABl9zdGFydAAGEF9fZXJybm9fbG9jYXRpb24ACAZmZmx1c2gADAlzdGFja1NhdmUACQxzdGFja1Jlc3RvcmUACgpzdGFja0FsbG9jAAsJBwEAQQELAQQKmQMKAwABCwcAIAAgAXwLBwAQBxACAAuNAQEEfyMAQRBrIgAkAAJAIAAiAkEMaiAAQQhqEABFBEACf0EAIAIoAgwiAUUNABogACABQQJ0IgNBE2pBcHFrIgAiASQAIAEgAigCCEEPakFwcWsiASQAIAAgA2pBADYCACAAIAEQAQ0CIAIoAgwLIAAQAyEAIAJBEGokACAADwtBxwAQAgALQccAEAIACwUAQYAICwQAIwALBgAgACQACxAAIwAgAGtBcHEiACQAIAALZwEBfyAABEAgACgCTEF/TARAIAAQDQ8LIAAQDQ8LQZAIKAIABEBBkAgoAgAQDCEBC0GMCCgCACIABEADQCAAKAJMGiAAKAIUIAAoAhxLBEAgABANIAFyIQELIAAoAjgiAA0ACwsgAQtpAQJ/AkAgACgCFCAAKAIcTQ0AIABBAEEAIAAoAiQRBQAaIAAoAhQNAEF/DwsgACgCBCIBIAAoAggiAkkEQCAAIAEgAmusQQEgACgCKBEGABoLIABBADYCHCAAQgA3AxAgAEIANwIEQQAL";
 
-    tearDown : function () {
-	wasmmodules.unregister(modulename);
-	// Keep in mind that modules that are once loaded into the runtime (by trying to execute a function from it)
-	// will be in the runtime forever, they cannot be deleted from there. This will change with PREG-108.
-    },
+	return {
 
-    test_modules_are_initially_empty : function () {
-	assertEqual(wasmmodules.toArray(), []);
-    },
+		test_modules_are_initially_empty: function() {
+			assertEqual(wasmmodules.toArray(), []);
+		},
 
-    test_module_can_be_registered : function () {
-	assertEqual(wasmmodules.register(modulename, code), {"installed": modulename});
-    },
+		test_module_can_be_registered: function() {
+			assertEqual(wasmmodules.register(modulename, code), { "installed": modulename });
+		},
 
-    test_names_of_all_registered_modules_are_shown : function () {
-	wasmmodules.register(modulename, code);
+		test_names_of_all_registered_modules_are_shown: function() {
+			wasmmodules.register(modulename, code);
 
-	assertEqual(wasmmodules.toArray(), [modulename]);
-    },
+			assertEqual(wasmmodules.toArray(), [modulename]);
+		},
 
-    test_module_with_invalid_base64_encoded_code_cannot_be_registered : function () {
-	try {
-	    wasmmodules.register(modulename, "AB$(");
-	} catch (err) {
-	    assertEqual(err.errorNum, ERRORS.ERROR_BAD_PARAMETER.code);
-	}
-    },
+		test_module_with_invalid_base64_encoded_code_cannot_be_registered: function() {
+			try {
+				wasmmodules.register(modulename, "AB$(");
+			} catch (err) {
+				assertEqual(err.errorNum, ERRORS.ERROR_BAD_PARAMETER.code);
+			}
+		},
 
-    test_existing_module_is_overwritten_with_module_of_same_name : function () {
-	wasmmodules.register(modulename, code, true);
+		test_existing_module_is_overwritten_with_module_of_same_name: function() {
+			wasmmodules.register(modulename, code, true);
 
-	wasmmodules.register(modulename, "AQL/", false);
+			wasmmodules.register(modulename, "AQL/", false);
 
-	assertEqual(wasmmodules.toArray(), [modulename]);
-	assertEqual(wasmmodules.show(modulename), {
-	    "result": {
-		"name": modulename,
-		"code": "AQL/",
-		"isDeterministic": false
-	    }});
-    },
+			assertEqual(wasmmodules.toArray(), [modulename]);
+			assertEqual(wasmmodules.show(modulename), {
+				"result": {
+					"name": modulename,
+					"code": "AQL/",
+					"isDeterministic": false
+				}
+			});
+		},
 
-    test_a_registered_module_shows_its_detail_information : function () {
-	wasmmodules.register(modulename, code);
+		test_a_registered_module_shows_its_detail_information: function() {
+			wasmmodules.register(modulename, code);
 
-	assertEqual(wasmmodules.show(modulename), {
-	    "result": {
-		"name": modulename,
-		"code": code,
-		"isDeterministic": false
-	    }});
-    },
+			assertEqual(wasmmodules.show(modulename), {
+				"result": {
+					"name": modulename,
+					"code": code,
+					"isDeterministic": false
+				}
+			});
+		},
 
-    test_querying_a_unknown_module_gives_an_error : function () {
-	try {
-	    wasmmodules.show("unknown_module");
-	} catch (err) {
-	    assertEqual(err.errorNum, ERRORS.ERROR_BAD_PARAMETER.code);
-	}
-    },
+		test_querying_an_unknown_module_gives_an_error: function() {
+			try {
+				wasmmodules.show("unknown_module");
+			} catch (err) {
+				assertEqual(err.errorNum, ERRORS.ERROR_BAD_PARAMETER.code);
+			}
+		},
 
-    test_modules_can_be_unregistered : function () {
-	wasmmodules.register(modulename, code);
+		test_modules_can_be_unregistered: function() {
+			wasmmodules.register(modulename, code);
 
-	assertEqual(wasmmodules.unregister(modulename), {"removed": modulename});
-    },
+			assertEqual(wasmmodules.unregister(modulename), { "removed": modulename });
+		},
 
-    test_modules_are_deleted_when_unregistered : function () {
-	wasmmodules.register(modulename, code);
+		test_modules_are_deleted_when_unregistered: function() {
+			wasmmodules.register(modulename, code);
 
-	wasmmodules.unregister(modulename);
+			wasmmodules.unregister(modulename);
 
-	assertEqual(wasmmodules.toArray(), []);
-    },
+			assertEqual(wasmmodules.toArray(), []);
+		},
 
-    test_function_in_registered_module_is_exectable_via_AQL_query : function () {
-	wasmmodules.register(modulename, code);
+		test_unregistering_an_unknown_modules_throws_error: function() {
+			try {
+				wasmmodules.unregister("unknown_module");
+			} catch (err) {
+				assertEqual(err.errorNum, ERRORS.ERROR_BAD_PARAMETER.code);
+			}
+		},
 
-	const queryresult = db._query("RETURN CALL_WASM('" + modulename + "', 'add', 1, 4)").toArray();
+		test_function_in_registered_module_is_exectable_via_AQL_query: function() {
+			wasmmodules.register(modulename, code);
 
-	assertEqual(queryresult, [ 5 ]);
-    },
+			const queryresult = db._query("RETURN CALL_WASM('" + modulename + "', 'add', 1, 4)").toArray();
 
-    test_unknown_module_execution_throws_error : function () {
-	try {
-	    const queryresult = db._query("RETURN CALL_WASM('unknown_module', 'add', 1, 4)").toArray();
-	} catch (err) {
-	    assertEqual(err.errorNum, ERRORS.ERROR_WASM_EXECUTION_ERROR.code);
-	}
-    },
+			assertEqual(queryresult, [5]);
+		},
 
-    test_unknown_function_execution_throws_error : function () {
-	wasmmodules.register(modulename, code);
-	
-	try {
-	    const queryresult = db._query("RETURN CALL_WASM('" + modulename + "', 'function_not_inside_module', 1, 4)").toArray();
-	} catch (err) {
-	    assertEqual(err.errorNum, ERRORS.ERROR_WASM_EXECUTION_ERROR.code);
-	}
-    },
+		test_unknown_module_execution_throws_error: function() {
+			try {
+				const queryresult = db._query("RETURN CALL_WASM('unknown_module', 'add', 1, 4)").toArray();
+			} catch (err) {
+				assertEqual(err.errorNum, ERRORS.ERROR_WASM_EXECUTION_ERROR.code);
+			}
+		},
 
-    test_wrong_code_cannot_be_executed : function () {
-	wasmmodules.register("new_module", "AQL/");
-	// TODO PREG-108 Use modulename to make sure that it is unregistered after the test
-	// (cannot be done right, see reason in tearDown function)
+		test_unknown_function_execution_throws_error: function() {
+			wasmmodules.register(modulename, code);
 
-	// TODO PREG-87 Return result from wasm3 parse_module function
-	// and return ERROR_WASM_EXECUTION_ERROR in handler
+			try {
+				const queryresult = db._query("RETURN CALL_WASM('" + modulename + "', 'function_not_inside_module', 1, 4)").toArray();
+			} catch (err) {
+				assertEqual(err.errorNum, ERRORS.ERROR_WASM_EXECUTION_ERROR.code);
+			}
+		},
 
-	try {
-	    const queryresult = db._query("RETURN CALL_WASM('new_module', 'function_not_inside_module', 1, 4)").toArray();
-	} catch (err) {
-	    assertEqual(err.errorNum, ERRORS.ERROR_INTERNAL.code);
-	}
-    },
+		test_wrong_code_cannot_be_executed: function() {
+			wasmmodules.register("new_module", "AQL/");
 
-  };
+			// TODO PREG-87 Return result from wasm3 parse_module function
+			// and return ERROR_WASM_EXECUTION_ERROR in handler
+
+			try {
+				const queryresult = db._query("RETURN CALL_WASM('new_module', 'function_not_inside_module', 1, 4)").toArray();
+			} catch (err) {
+				assertEqual(err.errorNum, ERRORS.ERROR_INTERNAL.code);
+			}
+		},
+
+	};
 }
 
 jsunity.run(WasmModulesSuite);


### PR DESCRIPTION
This PR includes
- PREG-101 Save wasm modules in satellite collection instead of in memory
- PREG-102 Enable wasm functions to run on coordinator
- PREG-103 Enable wasm function to run on DB Server

This PR does still use the old velocypack functions, I'll do a separate PR to fix all of the velocypack usages in the Wasm directory.

