### PR TITLE
Follower resync on restart BTS-829

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+v3.9.2 (XXXX-XX-XX)
+-------------------
+
+* Resync follower shard after a follower restart immediately and not lazily.
+
 v3.9.1 (XXXX-XX-XX)
 -------------------
 

--- a/arangod/Cluster/Maintenance.cpp
+++ b/arangod/Cluster/Maintenance.cpp
@@ -1698,12 +1698,30 @@ void arangodb::maintenance::syncReplicatedShardsWithLeaders(
         // Current's servers
         VPackSlice const cservers = cshrd.get(SERVERS);
 
+        // From above, we know that the shard exists locally. For the case
+        // that we have been restarted but the leader did not notice that
+        // we were gone, we must check if the leader is set correctly here
+        // locally for our shard:
+        VPackSlice lshard = localdb.get(shname);
+        TRI_ASSERT(lshard.isObject());
+        bool needsResyncBecauseOfRestart = false;
+        if (lshard.isObject()) {  // just in case
+          VPackSlice theLeader = lshard.get("theLeader");
+          if (theLeader.isString() &&
+              theLeader.compareString(maintenance::ResignShardLeadership::
+                                          LeaderNotYetKnownString) == 0) {
+            needsResyncBecauseOfRestart = true;
+          }
+        }
+
         // if we are considered to be in sync there is nothing to do
-        if (indexOf(cservers, serverId) > 0) {
+        if (!needsResyncBecauseOfRestart && indexOf(cservers, serverId) > 0) {
           continue;
         }
 
         std::string leader = pservers[0].copyString();
+        std::string forcedResync =
+            needsResyncBecauseOfRestart ? "true" : "false";
 
         // If the leader is failed, we need not try to get in sync:
         if (failedServers.find(leader) != failedServers.end()) {
@@ -1721,6 +1739,7 @@ void arangodb::maintenance::syncReplicatedShardsWithLeaders(
                     {COLLECTION, colname.toString()},
                     {SHARD, shname.toString()},
                     {THE_LEADER, std::move(leader)},
+                    {FORCED_RESYNC, std::move(forcedResync)},
                     {SHARD_VERSION,
                      std::to_string(feature.shardVersion(shname.toString()))}},
                 SYNCHRONIZE_PRIORITY, true);

--- a/arangod/Cluster/MaintenanceStrings.h
+++ b/arangod/Cluster/MaintenanceStrings.h
@@ -38,6 +38,7 @@ constexpr char const* DROP_DATABASE = "DropDatabase";
 constexpr char const* DROP_INDEX = "DropIndex";
 constexpr char const* ENSURE_INDEX = "EnsureIndex";
 constexpr char const* FIELDS = "fields";
+constexpr char const* FORCED_RESYNC = "forcedResync";
 constexpr char const* FOLLOWERS_TO_DROP = "followersToDrop";
 constexpr char const* FOLLOWER_ID = "followerId";
 constexpr char const* GLOB_UID = "globallyUniqueId";

--- a/arangod/Cluster/SynchronizeShard.cpp
+++ b/arangod/Cluster/SynchronizeShard.cpp
@@ -333,7 +333,6 @@ static arangodb::Result addShardFollower(
           result.errorNumber(),
           StringUtils::concatT(errorMessage, ", ", result.errorMessage()));
     }
-
     LOG_TOPIC("79935", DEBUG, Logger::MAINTENANCE)
         << "addShardFollower: success";
     return arangodb::Result();
@@ -689,6 +688,7 @@ bool SynchronizeShard::first() {
   std::string planId = _description.get(COLLECTION);
   std::string const& shard = getShard();
   std::string leader = _description.get(THE_LEADER);
+  bool forcedResync = _description.get(FORCED_RESYNC) == "true";
 
   size_t failuresInRow = feature().replicationErrors(database, shard);
 
@@ -822,8 +822,22 @@ bool SynchronizeShard::first() {
           current.end()) {
         break;  // start synchronization work
       }
-      // We are already there, this is rather strange, but never mind:
+      // This was the normal case. However, if we have been away for a short
+      // amount of time and the leader has not yet noticed that we were gone,
+      // we might actually get here and try to resync and are still in
+      // Current. In this case, we write a log message and sync anyway:
       std::stringstream error;
+      if (forcedResync) {
+        error << "found ourselves in Current, but resyncing anyways because of "
+                 "a recent restart, ";
+        AppendShardInformationToMessage(database, shard, planId, startTime,
+                                        error);
+        LOG_TOPIC("4abcd", DEBUG, Logger::MAINTENANCE)
+            << "SynchronizeOneShard: " << error.str();
+        break;
+      }
+      // Otherwise, we give up on the job, since we do not want to repeat
+      // a SynchronizeShard if we are already in Current:
       error << "already done, ";
       AppendShardInformationToMessage(database, shard, planId, startTime,
                                       error);


### PR DESCRIPTION
Currently, when a follower is restarted and comes back so quickly such
that the leader has not noticed that the follower was gone, we only
resync the follower on the first write to the leader (lazy resync) and
not right away.

In this way, we later get a potentially expensive dropped follower and
shard resync when the server restart is already a long time ago.

This PR makes it so that we immediately resync a follower shard if the
server has been restarted.

- Always resync a follower shard on restart.
- CHANGELOG.

### Scope & Purpose

- [*] :hankey: Bugfix

### Checklist

- [*] Tests
  - [*] **integration tests** (covered by existing)
  - [*] **resilience tests** (covered by existing)
- [*] :book: CHANGELOG entry made
- [*] Backports:
  - This is the backport to 3.9, original for devel: https://github.com/arangodb/arangodb/pull/15974

- [*] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/BTS-829



