### PR TITLE
Docs: Add unit to lockTimeout (seconds)

### DIFF
--- a/Documentation/DocuBlocks/Rest/Transactions/post_api_transaction.md
+++ b/Documentation/DocuBlocks/Rest/Transactions/post_api_transaction.md
@@ -33,8 +33,9 @@ Allow reading from undeclared collections.
 
 @RESTBODYPARAM{lockTimeout,integer,optional,int64}
 an optional numeric value that can be used to set a
-timeout in seconds for waiting on collection locks. If not specified, a default
-value will be used. Setting *lockTimeout* to *0* will make ArangoDB
+timeout in seconds for waiting on collection locks. This option is only
+meaningful when using exclusive locks. If not specified, a default value of
+900 seconds will be used. Setting *lockTimeout* to *0* will make ArangoDB
 not time out waiting for a lock.
 
 @RESTBODYPARAM{params,string,optional,string}

--- a/Documentation/DocuBlocks/Rest/Transactions/post_api_transaction.md
+++ b/Documentation/DocuBlocks/Rest/Transactions/post_api_transaction.md
@@ -33,7 +33,7 @@ Allow reading from undeclared collections.
 
 @RESTBODYPARAM{lockTimeout,integer,optional,int64}
 an optional numeric value that can be used to set a
-timeout for waiting on collection locks. If not specified, a default
+timeout in seconds for waiting on collection locks. If not specified, a default
 value will be used. Setting *lockTimeout* to *0* will make ArangoDB
 not time out waiting for a lock.
 

--- a/Documentation/DocuBlocks/Rest/Transactions/post_api_transaction_begin.md
+++ b/Documentation/DocuBlocks/Rest/Transactions/post_api_transaction_begin.md
@@ -21,7 +21,8 @@ Allow reading from undeclared collections.
 
 @RESTBODYPARAM{lockTimeout,integer,optional,int64}
 an optional numeric value that can be used to set a
-timeout in seconds for waiting on collection locks. If not specified, a default
+timeout in seconds for waiting on collection locks. This option is only
+meaningful when using exclusive locks. If not specified, a default
 value will be used. Setting *lockTimeout* to *0* will make ArangoDB
 not time out waiting for a lock.
 

--- a/Documentation/DocuBlocks/Rest/Transactions/post_api_transaction_begin.md
+++ b/Documentation/DocuBlocks/Rest/Transactions/post_api_transaction_begin.md
@@ -21,7 +21,7 @@ Allow reading from undeclared collections.
 
 @RESTBODYPARAM{lockTimeout,integer,optional,int64}
 an optional numeric value that can be used to set a
-timeout for waiting on collection locks. If not specified, a default
+timeout in seconds for waiting on collection locks. If not specified, a default
 value will be used. Setting *lockTimeout* to *0* will make ArangoDB
 not time out waiting for a lock.
 


### PR DESCRIPTION
### Scope & Purpose

The JS Transaction endpoint `_api/transaction` and the Stream Transaction endpoint `_api/transaction/begin` accept a parameter `lockTimeout`. We fail to mention the unit (https://github.com/arangodb/docs/issues/938). It is **seconds** according to @jsteemann.

TODO: What is the default value that is mentioned?

> If not specified, a default value will be used.

Does it refer to the startup option `--transaction.streaming-lock-timeout` in case of Stream Transactions?

What about JS Transactions? There is another startup option `--rocksdb.transaction-lock-timeout` but the unit is milliseconds and it seems unrelated to me (storage engine).

- [x] 📚 Documentation

### Checklist

- [x] Backports
  - [x] Backport for 3.9: *(Please link PR)*
  - [x] Backport for 3.8: *(Please link PR)*
  - [x] Backport for 3.7: *(Please link PR)*
  
### Related information
  
  - [x] Docs PR: https://github.com/arangodb/docs/pull/959