### PR TITLE
fix spuriously failing test

### DIFF
--- a/tests/js/client/shell/api/async.js
+++ b/tests/js/client/shell/api/async.js
@@ -66,6 +66,22 @@ function wait_for_put(cmd, code, maxWait) {
 function dealing_with_async_requestsSuite () {
   return {
     tearDownAll: function() {
+      // cancel all pending jobs this test may have created
+      // (and probably also others, but other tests should
+      // have cleaned up their own data)
+      let tries = 0;
+      while (++tries < 60) {
+        let jobs = arango.GET('/_api/job/pending');
+        if (jobs.length === 0) {
+          break;
+        }
+        jobs.forEach((id) => {
+          let cmd = "/_api/job/" + id + "/cancel";
+          // don't fail if cancelation of jobs fails
+          arango.PUT_RAW(cmd, "");
+        });
+        sleep(0.5);
+      }
       arango.DELETE('/_api/query/slow');
     },
 


### PR DESCRIPTION
### Scope & Purpose

Fix spuriously failing query-analysis test. The test failures are due to another test not cleaning up properly.
This is an issue only in testing, and it only affects devel. No backports are needed.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -
  - [ ] Backport for 3.7: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
