### PR TITLE
do not make dump/restore/import depend on fuerte

### DIFF
--- a/client-tools/CMakeLists.txt
+++ b/client-tools/CMakeLists.txt
@@ -168,7 +168,6 @@ target_link_libraries(${BIN_ARANGODUMP}
   boost_system
   boost_boost
   arango_shell
-  fuerte
 )
 
 install(
@@ -278,8 +277,6 @@ install(
 
 install_config(arangoimport)
 
-add_dependencies(arangoimport fuerte)
-
 if (NOT USE_PRECOMPILED_V8)
   add_dependencies(arangoimport zlibstatic v8_build) # v8_build includes ICU
                                                      # build
@@ -335,7 +332,6 @@ target_link_libraries(${BIN_ARANGORESTORE}
   boost_system
   boost_boost
   arango_shell
-  fuerte
 )
 
 install(


### PR DESCRIPTION
### Scope & Purpose

Do not make arango{dump,restore,import} depend on fuerte.
None of these client tools uses fuerte, so there should be no compile-time dependency on it.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -
  - [ ] Backport for 3.7: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
