### PR TITLE
Improve restore parallelism for new data format

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 devel
 -----
 
+* Improve parallelism in arangorestore in case new data format is used.
+
 * Updated OpenSSL to 1.1.1n and OpenLDAP to 2.6.1.
 
 * Updated arangosync to v2.9.0-preview-2.

--- a/client-tools/Restore/RestoreFeature.cpp
+++ b/client-tools/Restore/RestoreFeature.cpp
@@ -1344,7 +1344,7 @@ Result RestoreFeature::RestoreMainJob::restoreData(
   using arangodb::basics::StringUtils::formatSize;
 
   int type = arangodb::basics::VelocyPackHelper::getNumericValue<int>(
-      parameters, "type", 2);
+      parameters, std::vector<std::string_view>({"parameters", "type"}), 2);
   std::string const collectionType(type == 2 ? "document" : "edge");
 
   auto&& currentStatus = progressTracker.getStatus(collectionName);
@@ -1482,7 +1482,7 @@ Result RestoreFeature::RestoreMainJob::restoreData(
       // data in order. this is because the enveloped data format may contain
       // documents to insert *AND* documents to remove (this is an MMFiles
       // legacy).
-      bool const forceDirect = (numRead == 0) || !useEnvelope;
+      bool const forceDirect = (numRead == 0) || useEnvelope;
 
       result = dispatchRestoreData(client, datafileReadOffset, buffer->begin(),
                                    length, forceDirect);
@@ -1526,7 +1526,7 @@ Result RestoreFeature::RestoreMainJob::restoreData(
         }
 
         LOG_TOPIC("69a73", INFO, Logger::RESTORE)
-            << "# Still loading data into " << collectionType << " collection '"
+            << "# Loading data into " << collectionType << " collection '"
             << collectionName << "', " << formatSize(numReadForThisCollection)
             << ofFilesize << " read" << percentage;
         numReadSinceLastReport = 0;
@@ -2214,7 +2214,7 @@ void RestoreFeature::start() {
       LOG_TOPIC("a66e1", INFO, Logger::RESTORE)
           << "Processed " << _stats.restoredCollections
           << " collection(s) from " << databases.size() << " database(s) in "
-          << Logger::FIXED(totalTime, 6) << " s total time. Read "
+          << Logger::FIXED(totalTime, 2) << " s total time. Read "
           << formatSize(_stats.totalRead) << " from datafiles, "
           << "sent " << _stats.totalBatches << " data batch(es) of "
           << formatSize(_stats.totalSent) << " total size.";
@@ -2222,7 +2222,7 @@ void RestoreFeature::start() {
       LOG_TOPIC("147ca", INFO, Logger::RESTORE)
           << "Processed " << _stats.restoredCollections
           << " collection(s) from " << databases.size() << " database(s) in "
-          << Logger::FIXED(totalTime, 6) << " s total time.";
+          << Logger::FIXED(totalTime, 2) << " s total time.";
     }
   }
 }


### PR DESCRIPTION
### Scope & Purpose

In case the new data format (useEnvelope = false) was used with arangodump, arangorestore can submit multiple batches with documents concurrently. That way a restore can be multi-threaded even for a single collection. Due to some invalid if condition, the logic was reversed and parallelism was turned off when using the new format.
This probably needs a backport to 3.9, will check.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.9: https://github.com/arangodb/arangodb/pull/16030
  - [x] Backport for 3.8: to be determined
  - [ ] Backport for 3.7: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 