### PR TITLE
remove obsolete flag from ApplicationFeature

### DIFF
--- a/arangod/Cluster/MaintenanceFeature.cpp
+++ b/arangod/Cluster/MaintenanceFeature.cpp
@@ -177,7 +177,6 @@ MaintenanceFeature::MaintenanceFeature(Server& server)
   startsAfter<metrics::MetricsFeature>();
 
   setOptional(true);
-  requiresElevatedPrivileges(false);
 }
 
 MaintenanceFeature::~MaintenanceFeature() { stop(); }

--- a/arangod/RestServer/EndpointFeature.cpp
+++ b/arangod/RestServer/EndpointFeature.cpp
@@ -43,7 +43,6 @@ EndpointFeature::EndpointFeature(ArangodServer& server)
       _reuseAddress(true),
       _backlogSize(64) {
   setOptional(true);
-  requiresElevatedPrivileges(true);
   startsAfter<application_features::AqlFeaturePhase, ArangodServer>();
 
   startsAfter<ServerFeature, ArangodServer>();

--- a/arangod/RestServer/WindowsServiceFeature.cpp
+++ b/arangod/RestServer/WindowsServiceFeature.cpp
@@ -83,7 +83,6 @@ WindowsServiceFeature::WindowsServiceFeature(Server& server)
       _progress(2),
       _shutdownNoted(false) {
   setOptional(true);
-  requiresElevatedPrivileges(true);
   startsAfter<application_features::GreetingsFeaturePhase>();
 
   ArangoInstance = this;

--- a/client-tools/Backup/BackupFeature.cpp
+++ b/client-tools/Backup/BackupFeature.cpp
@@ -690,7 +690,6 @@ BackupFeature::BackupFeature(Server& server, int& exitCode)
       _exitCode{exitCode} {
   static_assert(Server::isCreatedAfter<BackupFeature, HttpEndpointProvider>());
 
-  requiresElevatedPrivileges(false);
   setOptional(false);
   startsAfter<HttpEndpointProvider>();
 }

--- a/client-tools/Benchmark/BenchFeature.cpp
+++ b/client-tools/Benchmark/BenchFeature.cpp
@@ -100,7 +100,6 @@ BenchFeature::BenchFeature(Server& server, int* result)
       _histogramNumIntervals(1000),
       _histogramIntervalSize(0.0),
       _percentiles({50.0, 80.0, 85.0, 90.0, 95.0, 99.0, 99.99}) {
-  requiresElevatedPrivileges(false);
   setOptional(false);
   startsAfter<application_features::BasicFeaturePhaseClient>();
 

--- a/client-tools/Dump/DumpFeature.cpp
+++ b/client-tools/Dump/DumpFeature.cpp
@@ -633,7 +633,6 @@ DumpFeature::DumpFeature(Server& server, int& exitCode)
                      Logger::DUMP},
       _clientTaskQueue{server, ::processJob},
       _exitCode{exitCode} {
-  requiresElevatedPrivileges(false);
   setOptional(false);
   startsAfter<application_features::BasicFeaturePhaseClient>();
 

--- a/client-tools/Export/ExportFeature.cpp
+++ b/client-tools/Export/ExportFeature.cpp
@@ -83,7 +83,6 @@ ExportFeature::ExportFeature(Server& server, int* result)
       _currentCollection(),
       _currentGraph(),
       _result(result) {
-  requiresElevatedPrivileges(false);
   setOptional(false);
   startsAfter<application_features::BasicFeaturePhaseClient>();
 

--- a/client-tools/Import/ImportFeature.cpp
+++ b/client-tools/Import/ImportFeature.cpp
@@ -74,7 +74,6 @@ ImportFeature::ImportFeature(Server& server, int* result)
       _result(result),
       _skipValidation(false),
       _latencyStats(false) {
-  requiresElevatedPrivileges(false);
   setOptional(false);
   startsAfter<application_features::BasicFeaturePhaseClient>();
   _threadCount = std::max(uint32_t(_threadCount),

--- a/client-tools/Restore/RestoreFeature.cpp
+++ b/client-tools/Restore/RestoreFeature.cpp
@@ -1631,7 +1631,6 @@ RestoreFeature::RestoreFeature(Server& server, int& exitCode)
       _exitCode{exitCode} {
   static_assert(Server::isCreatedAfter<RestoreFeature, HttpEndpointProvider>());
 
-  requiresElevatedPrivileges(false);
   setOptional(false);
   startsAfter<application_features::BasicFeaturePhaseClient>();
 

--- a/client-tools/Shell/ClientFeature.cpp
+++ b/client-tools/Shell/ClientFeature.cpp
@@ -84,7 +84,6 @@ ClientFeature::ClientFeature(ApplicationServer& server,
       _haveServerPassword(false),
       _forceJson(false) {
   setOptional(true);
-  requiresElevatedPrivileges(false);
 }
 
 void ClientFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {

--- a/client-tools/Shell/ShellConsoleFeature.cpp
+++ b/client-tools/Shell/ShellConsoleFeature.cpp
@@ -92,7 +92,6 @@ ShellConsoleFeature::ShellConsoleFeature(Server& server)
       _lastDuration(0.0),
       _startTime(TRI_microtime()) {
   setOptional(false);
-  requiresElevatedPrivileges(false);
   startsAfter<application_features::BasicFeaturePhaseClient>();
   if (!_supportsColors) {
     _colors = false;

--- a/client-tools/Shell/ShellFeature.cpp
+++ b/client-tools/Shell/ShellFeature.cpp
@@ -43,7 +43,6 @@ ShellFeature::ShellFeature(Server& server, int* result)
       _jslint(),
       _result(result),
       _runMode(RunMode::INTERACTIVE) {
-  requiresElevatedPrivileges(false);
   setOptional(false);
   startsAfter<application_features::V8ShellFeaturePhase>();
 }

--- a/client-tools/Shell/V8ShellFeature.cpp
+++ b/client-tools/Shell/V8ShellFeature.cpp
@@ -87,7 +87,6 @@ V8ShellFeature::V8ShellFeature(Server& server, std::string const& name)
       _gcInterval(50),
       _name(name),
       _isolate(nullptr) {
-  requiresElevatedPrivileges(false);
   setOptional(false);
   startsAfter<application_features::BasicFeaturePhaseClient>();
 

--- a/client-tools/VPack/VPackFeature.cpp
+++ b/client-tools/VPack/VPackFeature.cpp
@@ -121,7 +121,6 @@ VPackFeature::VPackFeature(Server& server, int* result)
       _inputType("vpack"),
       _outputType("json-pretty"),
       _failOnNonJson(true) {
-  requiresElevatedPrivileges(false);
   setOptional(false);
 }
 

--- a/lib/ApplicationFeatures/ApplicationFeature.cpp
+++ b/lib/ApplicationFeatures/ApplicationFeature.cpp
@@ -47,7 +47,6 @@ ApplicationFeature::ApplicationFeature(ApplicationServer& server,
       _state(State::UNINITIALIZED),
       _enabled(true),
       _optional(false),
-      _requiresElevatedPrivileges(false),
       _ancestorsDetermined(false) {}
 
 // add the feature's options to the global list of options. this method will be

--- a/lib/ApplicationFeatures/ApplicationFeature.h
+++ b/lib/ApplicationFeatures/ApplicationFeature.h
@@ -100,16 +100,6 @@ class ApplicationFeature {
   // names of features required to be enabled for this feature to be enabled
   std::vector<size_t> const& dependsOn() const { return _requires; }
 
-  // register whether the feature requires elevated privileges
-  void requiresElevatedPrivileges(bool value) {
-    _requiresElevatedPrivileges = value;
-  }
-
-  // test whether the feature requires elevated privileges
-  bool requiresElevatedPrivileges() const {
-    return _requiresElevatedPrivileges;
-  }
-
   // whether the feature starts before another
   template<typename T, typename Server>
   bool doesStartBefore() const {
@@ -268,9 +258,6 @@ class ApplicationFeature {
 
   // whether or not the feature is optional
   bool _optional;
-
-  // whether or not the feature requires elevated privileges
-  bool _requiresElevatedPrivileges;
 
   bool _ancestorsDetermined;
 };


### PR DESCRIPTION
### Scope & Purpose

Enterprise companion PR: https://github.com/arangodb/enterprise/pull/916

Removes the _requiresElevatedPrivileges flag from ApplicationFeature.
That flag was set by different features, but it had no effect, because the flag's value was nowhere read later.
This change does not need to be backported.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -
  - [ ] Backport for 3.7: -

#### Related Information

- [ ] Docs PR: 
- [x] Enterprise PR: https://github.com/arangodb/enterprise/pull/916
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

