### PR TITLE
try to stabilize test even more

### DIFF
--- a/arangod/Scheduler/SupervisedScheduler.cpp
+++ b/arangod/Scheduler/SupervisedScheduler.cpp
@@ -39,7 +39,6 @@
 #include "Logger/LogMacros.h"
 #include "Logger/Logger.h"
 #include "Network/NetworkFeature.h"
-#include "Random/RandomGenerator.h"
 #include "Metrics/CounterBuilder.h"
 #include "Metrics/GaugeBuilder.h"
 #include "Metrics/MetricsFeature.h"


### PR DESCRIPTION
### Scope & Purpose

Attempt to stabilize a test that sporadically failed depending on the current server load.
The test checks for queuing times on the server, so it is obviously load-dependent.
The changes in this PR try to give the test more room for the desired situation to kick in.
This is a test-only fix. The server behavior is not affected.

This PR is a follow-up to https://github.com/arangodb/arangodb/pull/16033, which did not fully solve the instability.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -
  - [ ] Backport for 3.7: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

