### PR TITLE
remove obsolete #ifdef sections from the code

### DIFF
--- a/lib/Basics/ConditionLocker.cpp
+++ b/lib/Basics/ConditionLocker.cpp
@@ -27,54 +27,18 @@
 #include "Basics/ConditionVariable.h"
 #include "Basics/debugging.h"
 
-#ifdef ARANGODB_SHOW_LOCK_TIME
-#include "Basics/system-functions.h"
-#include "Logger/LogMacros.h"
-#endif
-
 using namespace arangodb::basics;
-
-/// @brief locks the condition variable
-///
-/// The constructors locks the condition variable, the destructors unlocks
-/// the condition variable
-#ifdef ARANGODB_SHOW_LOCK_TIME
-
-ConditionLocker::ConditionLocker(ConditionVariable* conditionVariable,
-                                 char const* file, int line, bool showLockTime)
-    : _conditionVariable(conditionVariable),
-      _isLocked(true),
-      _file(file),
-      _line(line),
-      _showLockTime(showLockTime),
-      _time(0.0) {
-  double t = TRI_microtime();
-  _conditionVariable->lock();
-  _time = TRI_microtime() - t;
-}
-
-#else
 
 ConditionLocker::ConditionLocker(ConditionVariable* conditionVariable) noexcept
     : _conditionVariable(conditionVariable), _isLocked(true) {
   _conditionVariable->lock();
 }
 
-#endif
-
 /// @brief unlocks the condition variable
 ConditionLocker::~ConditionLocker() {
   if (_isLocked) {
     unlock();
   }
-
-#ifdef ARANGODB_SHOW_LOCK_TIME
-  if (_showLockTime && _time > TRI_SHOW_LOCK_THRESHOLD) {
-    LOG_TOPIC("89086", INFO, arangodb::Logger::PERFORMANCE)
-        << "ConditionLocker for condition [" << _conditionVariable << "]"
-        << _file << ":" << _line << " took " << _time << " s";
-  }
-#endif
 }
 
 /// @brief waits for an event to occur

--- a/lib/Basics/ConditionLocker.h
+++ b/lib/Basics/ConditionLocker.h
@@ -29,17 +29,8 @@
 
 #include <chrono>
 
-/// @brief construct locker with file and line information
-#ifdef ARANGODB_SHOW_LOCK_TIME
-
-#define CONDITION_LOCKER(a, b) \
-  arangodb::basics::ConditionLocker a(&(b), __FILE__, __LINE__)
-
-#else
-
+/// @brief construct locker
 #define CONDITION_LOCKER(a, b) ::arangodb::basics::ConditionLocker a(&(b))
-
-#endif
 
 namespace arangodb::basics {
 class ConditionVariable;
@@ -54,20 +45,9 @@ class ConditionLocker {
   ConditionLocker(ConditionLocker const&) = delete;
   ConditionLocker& operator=(ConditionLocker const&) = delete;
 
-/// @brief locks the condition variable
-///
-/// The constructor locks the condition variable, the destructor unlocks
-/// the condition variable
-#ifdef ARANGODB_SHOW_LOCK_TIME
-
-  ConditionLocker(ConditionVariable* conditionVariable, char const* file,
-                  int line, bool showLockTime = true);
-
-#else
-
+  /// The constructor locks the condition variable, the destructor unlocks
+  /// the condition variable
   explicit ConditionLocker(ConditionVariable* conditionVariable) noexcept;
-
-#endif
 
   /// @brief unlocks the condition variable
   ~ConditionLocker();
@@ -105,20 +85,5 @@ class ConditionLocker {
 
   /// @brief lock state
   bool _isLocked;
-
-#ifdef ARANGODB_SHOW_LOCK_TIME
-
-  /// @brief file
-  char const* _file;
-
-  /// @brief line number
-  int _line;
-
-  bool _showLockTime;
-
-  /// @brief lock time
-  double _time;
-
-#endif
 };
 }  // namespace arangodb::basics

--- a/lib/Basics/Locking.h
+++ b/lib/Basics/Locking.h
@@ -25,9 +25,6 @@
 
 #include "Basics/Common.h"
 
-#undef ARANGODB_SHOW_LOCK_TIME
-#define TRI_SHOW_LOCK_THRESHOLD 0.000199
-
 namespace arangodb {
 namespace basics {
 

--- a/lib/Basics/MutexUnlocker.h
+++ b/lib/Basics/MutexUnlocker.h
@@ -28,10 +28,6 @@
 #include "Basics/Locking.h"
 #include "Basics/debugging.h"
 
-#ifdef ARANGODB_SHOW_LOCK_TIME
-#include "Logger/Logger.h"
-#endif
-
 #include <thread>
 
 #define MUTEX_UNLOCKER(obj, lock)                                            \

--- a/lib/Basics/ReadLocker.h
+++ b/lib/Basics/ReadLocker.h
@@ -29,11 +29,6 @@
 #include "Basics/Locking.h"
 #include "Basics/debugging.h"
 
-#ifdef ARANGODB_SHOW_LOCK_TIME
-#include "Basics/system-functions.h"
-#include "Logger/LogMacros.h"
-#endif
-
 #include <thread>
 
 /// @brief construct locker with file and line information
@@ -72,18 +67,7 @@ class ReadLocker {
       : _readWriteLock(readWriteLock),
         _file(file),
         _line(line),
-#ifdef ARANGODB_SHOW_LOCK_TIME
-        _isLocked(false),
-        _time(0.0) {
-#else
         _isLocked(false) {
-#endif
-
-#ifdef ARANGODB_SHOW_LOCK_TIME
-    // fetch current time
-    double t = TRI_microtime();
-#endif
-
     if (condition) {
       if (type == LockerType::BLOCKING) {
         lock();
@@ -95,11 +79,6 @@ class ReadLocker {
         _isLocked = tryLock();
       }
     }
-
-#ifdef ARANGODB_SHOW_LOCK_TIME
-    // add elapsed time to time tracker
-    _time = TRI_microtime() - t;
-#endif
   }
 
   /// @brief releases the read-lock
@@ -107,14 +86,6 @@ class ReadLocker {
     if (_isLocked) {
       _readWriteLock->unlockRead();
     }
-
-#ifdef ARANGODB_SHOW_LOCK_TIME
-    if (_time > TRI_SHOW_LOCK_THRESHOLD) {
-      LOG_TOPIC("8e47e", INFO, arangodb::Logger::PERFORMANCE)
-          << "ReadLocker for lock [" << _readWriteLock << "] " << _file << ":"
-          << _line << " took " << _time << " s";
-    }
-#endif
   }
 
   /// @brief whether or not we acquired the lock
@@ -174,11 +145,6 @@ class ReadLocker {
 
   /// @brief whether or not we acquired the lock
   bool _isLocked;
-
-#ifdef ARANGODB_SHOW_LOCK_TIME
-  /// @brief lock time
-  double _time;
-#endif
 };
 
 }  // namespace arangodb::basics

--- a/lib/Logger/LogThread.cpp
+++ b/lib/Logger/LogThread.cpp
@@ -74,13 +74,8 @@ void LogThread::flush() noexcept {
 }
 
 void LogThread::wakeup() noexcept {
-#ifdef ARANGODB_SHOW_LOCK_TIME
-  // cppcheck-suppress redundantPointerOp
-  basics::ConditionLocker guard(_condition, __FILE__, __LINE__, false);
-#else
   // cppcheck-suppress redundantPointerOp
   CONDITION_LOCKER(guard, _condition);
-#endif
   guard.signal();
 }
 


### PR DESCRIPTION
### Scope & Purpose

Remove obsolete `#ifdef`s from code in locking classes:
* `ARANGODB_SHOW_LOCK_TIME`
* `TRI_SHOW_LOCK_THRESHOLD`

These ifdefs were used in the olden days of ArangoDB 2.x to conditionally compile some time measurement functionality for locking-related code.
There is no official way (e.g. via CMake) to activate these ifdefs, so it is effectively code that hasn't been used for years.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -
  - [ ] Backport for 3.7: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
