### PR TITLE
Add IO heartbeat

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,11 @@
 v3.8.7 (XXXX-XX-XX)
 -------------------
 
+* Added an IO heartbeat which checks that the underlying volume is writable
+  with reasonable performance. The test is done every 15 seconds and can
+  be explicitly switched off. New metrics to give visibility if the test
+  fails.
+
 * Updated ArangoDB Starter to 0.15.4.
 
 * Fixed an assertion failure which could occur when there was an error in the

--- a/Documentation/Metrics/arangodb_ioheartbeat_delays_total.yaml
+++ b/Documentation/Metrics/arangodb_ioheartbeat_delays_total.yaml
@@ -1,0 +1,21 @@
+name: arangodb_ioheartbeat_delays_total
+introducedIn: "3.8.7"
+help: |
+  Number of delays in the io heartbeat test.
+unit: number
+type: counter
+category: Health
+complexity: medium
+exposedBy:
+  - dbserver
+  - agent
+  - single
+description: |
+  This counter is increased whenever the io heartbeat encounters a delay
+  of at least 1s when writing a small file to the database directory,
+  reading it and then removing it again.
+  This test is done periodically to ensure that the underlying volume is
+  usable and performs reasonably well. The test can be switched off
+  explicitly with the flag `--database.io-heartbeat=false`, but the
+  default is `true`. Furthermore, every such failure leads to a line in
+  the log at INFO level for the `ENGINES` topic.

--- a/Documentation/Metrics/arangodb_ioheartbeat_duration.yaml
+++ b/Documentation/Metrics/arangodb_ioheartbeat_duration.yaml
@@ -1,0 +1,19 @@
+name: arangodb_ioheartbeat_duration
+introducedIn: "3.8.7"
+help: |
+  Histogram of execution times of a single IO heartbeat check.
+unit: us
+type: histogram
+category: Health
+complexity: medium
+exposedBy:
+  - dbserver
+  - agent
+  - single
+description: |
+  This histogram is updated whenever the io heartbeat runs its test in
+  the database directory. It writes a small file, syncs it to durable
+  storage, reads it, and then unlinks the file again. This test is done
+  periodically to ensure that the underlying volume is usable and performs
+  reasonably well. The test can be switched off explicitly with the flag
+  `--database.io-heartbeat=false`, but the default is `true`.

--- a/Documentation/Metrics/arangodb_ioheartbeat_failures_total.yaml
+++ b/Documentation/Metrics/arangodb_ioheartbeat_failures_total.yaml
@@ -1,0 +1,20 @@
+name: arangodb_ioheartbeat_failures_total
+introducedIn: "3.8.7"
+help: |
+  Number of failures in the io heartbeat test.
+unit: number
+type: counter
+category: Health
+complexity: medium
+exposedBy:
+  - dbserver
+  - agent
+  - single
+description: |
+  This counter is increased whenever the io heartbeat encounters a problem
+  when writing a small file to the database directory, reading it and then
+  removing it again. This test is done
+  periodically to ensure that the underlying volume is usable. The test can
+  be switched off explicitly with the flag `--database.io-heartbeat=false`,
+  but the default is `true`. Furthermore, every such failure leads to a
+  line in the log at INFO level for the `ENGINES` topic.

--- a/Documentation/Metrics/rocksdb_wal_sequence.yaml
+++ b/Documentation/Metrics/rocksdb_wal_sequence.yaml
@@ -5,7 +5,7 @@ help: |
 unit: number
 type: gauge
 category: RocksDB
-complexity: high
+complexity: advanced
 exposedBy:
   - dbserver
   - agent

--- a/Documentation/Metrics/rocksdb_wal_sequence_lower_bound.yaml
+++ b/Documentation/Metrics/rocksdb_wal_sequence_lower_bound.yaml
@@ -6,7 +6,7 @@ help: |
 unit: number
 type: gauge
 category: RocksDB
-complexity: high
+complexity: advanced
 exposedBy:
   - dbserver
   - agent

--- a/arangod/RestServer/DatabaseFeature.cpp
+++ b/arangod/RestServer/DatabaseFeature.cpp
@@ -270,11 +270,158 @@ void DatabaseManagerThread::run() {
   }
 }
 
+struct HeartbeatTimescale {
+  static log_scale_t<double> scale() { return {10.f, 0.f, 1000000.f, 8}; }
+};
+
+DECLARE_HISTOGRAM(arangodb_ioheartbeat_duration, HeartbeatTimescale,
+                  "Time to execute the io heartbeat once [us]");
+DECLARE_COUNTER(arangodb_ioheartbeat_failures_total,
+                "Total number of failures in IO heartbeat");
+DECLARE_COUNTER(arangodb_ioheartbeat_delays_total,
+                "Total number of delays in IO heartbeat");
+
+/// IO check thread main loop
+/// The purpose of this thread is to try to perform a simple IO write
+/// operation on the database volume regularly. We need visibility in
+/// production if IO is slow or not possible at all.
+IOHeartbeatThread::IOHeartbeatThread(
+    application_features::ApplicationServer& server,
+    MetricsFeature& metricsFeature)
+    : Thread(server, "IOHeartbeat"),
+      _exeTimeHistogram(metricsFeature.add(arangodb_ioheartbeat_duration{})),
+      _failures(metricsFeature.add(arangodb_ioheartbeat_failures_total{})),
+      _delays(metricsFeature.add(arangodb_ioheartbeat_delays_total{})) {}
+
+IOHeartbeatThread::~IOHeartbeatThread() { shutdown(); }
+
+void IOHeartbeatThread::run() {
+  auto& databasePathFeature = server().getFeature<DatabasePathFeature>();
+  std::string testFilePath = FileUtils::buildFilename(
+      databasePathFeature.directory(), "TestFileIOHeartbeat");
+  std::string testFileContent = "This is just an I/O test.\n";
+
+  LOG_TOPIC("66665", DEBUG, Logger::ENGINES) << "IOHeartbeatThread: running...";
+
+  while (true) {
+    try {  // protect thread against any exceptions
+      if (isStopping()) {
+        // done
+        break;
+      }
+
+      LOG_TOPIC("66659", DEBUG, Logger::ENGINES)
+          << "IOHeartbeat: testing to write/read/remove " << testFilePath;
+      // We simply write a file and sync it to disk in the database
+      // directory and then read it and then delete it again:
+      auto start1 = std::chrono::steady_clock::now();
+      bool trouble = false;
+      try {
+        FileUtils::spit(testFilePath, testFileContent, true);
+      } catch (std::exception const& exc) {
+        ++_failures;
+        LOG_TOPIC("66663", INFO, Logger::ENGINES)
+            << "IOHeartbeat: exception when writing test file: " << exc.what();
+        trouble = true;
+      }
+      auto finish = std::chrono::steady_clock::now();
+      std::chrono::duration<double> dur = finish - start1;
+      bool delayed = dur > std::chrono::seconds(1);
+      if (trouble || delayed) {
+        if (delayed) {
+          ++_delays;
+        }
+        LOG_TOPIC("66662", INFO, Logger::ENGINES)
+            << "IOHeartbeat: trying to write test file took "
+            << std::chrono::duration_cast<std::chrono::microseconds>(dur)
+                   .count()
+            << " microseconds.";
+      }
+
+      // Read the file if we can reasonably assume it is there:
+      if (!trouble) {
+        auto start = std::chrono::steady_clock::now();
+        try {
+          std::string content = FileUtils::slurp(testFilePath);
+          if (content != testFileContent) {
+            LOG_TOPIC("66660", INFO, Logger::ENGINES)
+                << "IOHeartbeat: read content of test file was not as "
+                   "expected, found:'"
+                << content << "', expected: '" << testFileContent << "'";
+            trouble = true;
+            ++_failures;
+          }
+        } catch (std::exception const& exc) {
+          ++_failures;
+          LOG_TOPIC("66661", INFO, Logger::ENGINES)
+              << "IOHeartbeat: exception when reading test file: "
+              << exc.what();
+          trouble = true;
+        }
+        auto finish = std::chrono::steady_clock::now();
+        std::chrono::duration<double> dur = finish - start;
+        bool delayed = dur > std::chrono::seconds(1);
+        if (trouble || delayed) {
+          if (delayed) {
+            ++_delays;
+          }
+          LOG_TOPIC("66669", INFO, Logger::ENGINES)
+              << "IOHeartbeat: trying to read test file took "
+              << std::chrono::duration_cast<std::chrono::microseconds>(dur)
+                     .count()
+              << " microseconds.";
+        }
+
+        // And remove it again:
+        start = std::chrono::steady_clock::now();
+        ErrorCode err = FileUtils::remove(testFilePath);
+        if (err != TRI_ERROR_NO_ERROR) {
+          ++_failures;
+          LOG_TOPIC("66670", INFO, Logger::ENGINES)
+              << "IOHeartbeat: error when removing test file: " << err;
+          trouble = true;
+        }
+        finish = std::chrono::steady_clock::now();
+        dur = finish - start;
+        delayed = dur > std::chrono::seconds(1);
+        if (trouble || delayed) {
+          if (delayed) {
+            ++_delays;
+          }
+          LOG_TOPIC("66671", INFO, Logger::ENGINES)
+              << "IOHeartbeat: trying to remove test file took "
+              << std::chrono::duration_cast<std::chrono::microseconds>(dur)
+                     .count()
+              << " microseconds.";
+        }
+      }
+
+      // Total duration and update histogram:
+      dur = finish - start1;
+      _exeTimeHistogram.count(
+          std::chrono::duration_cast<std::chrono::microseconds>(dur).count());
+
+      std::unique_lock<std::mutex> guard(_mutex);
+      if (trouble) {
+        // In case of trouble, we retry more quickly, since we want to
+        // have a record when the trouble has actually stopped!
+        _cv.wait_for(guard, checkIntervalTrouble);
+      } else {
+        _cv.wait_for(guard, checkIntervalNormal);
+      }
+    } catch (...) {
+    }
+    // next iteration
+  }
+  LOG_TOPIC("66664", DEBUG, Logger::ENGINES) << "IOHeartbeatThread: stopped.";
+}
+
 DatabaseFeature::DatabaseFeature(application_features::ApplicationServer& server)
     : ApplicationFeature(server, "Database"),
       _defaultWaitForSync(false),
       _forceSyncProperties(true),
       _ignoreDatafileErrors(false),
+      _performIOHeartbeat(true),
       _databasesLists(new DatabasesLists()),
       _isInitiallyEmpty(false),
       _checkVersion(false),
@@ -317,6 +464,12 @@ void DatabaseFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
                      "load collections even if datafiles may contain errors",
                      new BooleanParameter(&_ignoreDatafileErrors),
                      arangodb::options::makeDefaultFlags(arangodb::options::Flags::Hidden));
+
+  options
+      ->addOption("--database.io-heartbeat",
+                  "perform IO heartbeat to test underlying volume",
+                  new BooleanParameter(&_performIOHeartbeat))
+      .setIntroducedIn(30807);
 
   options->addOption(
       "--database.old-system-collections",
@@ -406,6 +559,20 @@ void DatabaseFeature::start() {
     FATAL_ERROR_EXIT();
   }
 
+  // start IOHeartbeat thread:
+  if ((ServerState::instance()->isDBServer() ||
+       ServerState::instance()->isSingleServer() ||
+       ServerState::instance()->isAgent()) &&
+      _performIOHeartbeat) {
+    _ioHeartbeatThread = std::make_unique<IOHeartbeatThread>(
+        server(), server().getFeature<MetricsFeature>());
+    if (!_ioHeartbeatThread->start()) {
+      LOG_TOPIC("7eb07", FATAL, arangodb::Logger::FIXME)
+          << "could not start IO check thread";
+      FATAL_ERROR_EXIT();
+    }
+  }
+
   // activate deadlock detection in case we're not running in cluster mode
   if (!arangodb::ServerState::instance()->isRunningInCluster()) {
     enableDeadlockDetection();
@@ -418,6 +585,11 @@ void DatabaseFeature::start() {
 // this speeds up the actual shutdown because no waiting is necessary
 // until the cursors happen to free their underlying transactions
 void DatabaseFeature::beginShutdown() {
+  if (_ioHeartbeatThread) {
+    _ioHeartbeatThread->beginShutdown();  // will set thread state to STOPPING
+    _ioHeartbeatThread->wakeup();         // will shorten the wait
+  }
+
   auto unuser(_databasesProtector.use());
   auto theLists = _databasesLists.load();
 
@@ -507,6 +679,15 @@ void DatabaseFeature::stop() {
 }
 
 void DatabaseFeature::unprepare() {
+  // delete the IO checker thread
+  if (_ioHeartbeatThread != nullptr) {
+    _ioHeartbeatThread->beginShutdown();
+
+    while (_ioHeartbeatThread->isRunning()) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+  }
+
   // delete the database manager thread
   if (_databaseManager != nullptr) {
     _databaseManager->beginShutdown();
@@ -522,6 +703,7 @@ void DatabaseFeature::unprepare() {
     // we're in the shutdown... simply ignore any errors produced here
   }
 
+  _ioHeartbeatThread.reset();
   _databaseManager.reset();
 
 #ifdef ARANGODB_USE_GOOGLE_TESTS
@@ -771,8 +953,8 @@ ErrorCode DatabaseFeature::dropDatabase(std::string const& name, bool removeApps
       id = vocbase->id();
       // mark as deleted
 
-      // call LogicalDataSource::drop() to allow instances to clean up internal
-      // state (e.g. for LogicalView implementations)
+      // call LogicalDataSource::drop() to allow instances to clean up
+      // internal state (e.g. for LogicalView implementations)
       TRI_vocbase_t::dataSourceVisitor visitor =
           [&res, &vocbase](arangodb::LogicalDataSource& dataSource) -> bool {
         // skip LogicalCollection since their internal state is always in the
@@ -1148,7 +1330,8 @@ void DatabaseFeature::closeOpenDatabases() {
     delete vocbase;
   }
 
-  delete oldList;  // Note that this does not delete the TRI_vocbase_t pointers!
+  delete oldList;  // Note that this does not delete the TRI_vocbase_t
+                   // pointers!
 }
 
 /// @brief create base app directory
@@ -1354,7 +1537,8 @@ void DatabaseFeature::closeDroppedDatabases() {
     }
   }
 
-  delete oldList;  // Note that this does not delete the TRI_vocbase_t pointers!
+  delete oldList;  // Note that this does not delete the TRI_vocbase_t
+                   // pointers!
 }
 
 void DatabaseFeature::verifyAppPaths() {

--- a/utils/makeDashboards.py
+++ b/utils/makeDashboards.py
@@ -45,7 +45,8 @@ YAMLFILE = "Documentation/Metrics/allMetrics.yaml"
 CATEGORYNAMES = ["Health", "AQL", "Transactions", "Foxx", "Pregel", \
                  "Statistics", "Replication", "Disk", "Errors", \
                  "RocksDB", "Hotbackup", "k8s", "Connectivity", "Network",\
-                 "V8", "Agency", "Scheduler", "Maintenance", "kubearangodb"]
+                 "V8", "Agency", "Scheduler", "Maintenance", "kubearangodb",
+                 "ArangoSearch"]
 
 COMPLEXITIES = ["none", "simple", "medium", "advanced"]
 
@@ -70,6 +71,7 @@ PERSONAINTERESTS["all"] = \
      "Scheduler":    "advanced", \
      "Maintenance":  "advanced", \
      "kubearangodb": "advanced", \
+     "ArangoSearch": "advanced", \
     }
 PERSONAINTERESTS["dbadmin"] = \
     {"Health":       "advanced", \
@@ -91,6 +93,7 @@ PERSONAINTERESTS["dbadmin"] = \
      "Scheduler":    "none", \
      "Maintenance":  "none", \
      "kubearangodb": "medium", \
+     "ArangoSearch": "advanced", \
     }
 PERSONAINTERESTS["sysadmin"] = \
     {"Health":       "advanced", \
@@ -112,6 +115,7 @@ PERSONAINTERESTS["sysadmin"] = \
      "Scheduler":    "none", \
      "Maintenance":  "none", \
      "kubearangodb": "simple", \
+     "ArangoSearch": "simple", \
     }
 PERSONAINTERESTS["user"] = \
     {"Health":       "simple", \
@@ -133,6 +137,7 @@ PERSONAINTERESTS["user"] = \
      "Scheduler":    "none", \
      "Maintenance":  "none", \
      "kubearangodb": "none", \
+     "ArangoSearch": "simple", \
     }
 PERSONAINTERESTS["oasiscustomer"] = \
     {"Health":       "simple", \
@@ -154,6 +159,7 @@ PERSONAINTERESTS["oasiscustomer"] = \
      "Scheduler":    "none", \
      "Maintenance":  "none", \
      "kubearangodb": "none", \
+     "ArangoSearch": "simple", \
     }
 PERSONAINTERESTS["appdeveloper"] = \
     {"Health":       "medium", \
@@ -175,6 +181,7 @@ PERSONAINTERESTS["appdeveloper"] = \
      "Scheduler":    "simple", \
      "Maintenance":  "none", \
      "kubearangodb": "none", \
+     "ArangoSearch": "simple", \
     }
 PERSONAINTERESTS["oasisoncall"] = \
     {"Health":       "advanced", \
@@ -196,6 +203,7 @@ PERSONAINTERESTS["oasisoncall"] = \
      "Scheduler":    "medium", \
      "Maintenance":  "simple", \
      "kubearangodb": "medium", \
+     "ArangoSearch": "simple", \
     }
 PERSONAINTERESTS["arangodbdeveloper"] = \
     {"Health":       "advanced", \
@@ -217,6 +225,7 @@ PERSONAINTERESTS["arangodbdeveloper"] = \
      "Scheduler":    "advanced", \
      "Maintenance":  "advanced", \
      "kubearangodb": "advanced", \
+     "ArangoSearch": "advanced", \
     }
 
 # Parse command line options:


### PR DESCRIPTION
This adds an IO heartbeat.

This is a test which is run every 15s on instances which have a RocksDB
instance (DBServer, Agent, Single server, but not Coordinator). A small
file in the database directory is written, synced, read and removed
again. If any of these operations fails or takes longer than 1s, a log
line is written on the INFO level to the ENGINES log topic. Furthermore,
a metrics count when these operations fail or are delayed. A histogram
for all such executions is updated.

This is to ensure that we can write to the underlying volume at all
times with a reasonable performance.

- Introduce an IO heartbeat check for the local volume.
- Add metrics, add feature switch.
- Add metrics Documentation.
- Fix metrics documentation.

Furthermore, some cleanup in the metrics documentation is done.

The whole feature is switched on by default, but can be deactivated with
a configuration option.

### Scope & Purpose

- [*] :pizza: New feature
- [*] Improved visibility in case of external trouble.

### Checklist

- [*] :book: CHANGELOG entry made
- [*] Backports: This is the backport to 3.8. Original PR: https://github.com/arangodb/arangodb/pull/16053



