### PR TITLE
Deadlocked SynchronizeShards BTS-662

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 v3.8.7 (XXXX-XX-XX)
 -------------------
 
+* Fix deadlocked shard synchronisations when planned shard leader has
+  not yet taken over leadership.
+
 * Updated ArangoDB Starter to 0.15.4.
 
 * Fixed an assertion failure which could occur when there was an error in the

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,8 +1,8 @@
 v3.8.7 (XXXX-XX-XX)
 -------------------
 
-* Fix deadlocked shard synchronisations when planned shard leader has
-  not yet taken over leadership.
+* Fix deadlocked shard synchronisations when planned shard leader has not yet
+  taken over leadership.
 
 * Added an IO heartbeat which checks that the underlying volume is writable with
   reasonable performance. The test is done every 15 seconds and can be

--- a/arangod/Cluster/MaintenanceFeature.h
+++ b/arangod/Cluster/MaintenanceFeature.h
@@ -111,6 +111,7 @@ class MaintenanceFeature : public application_features::ApplicationFeature {
   // stop the feature
   virtual void stop() override;
 
+  void initializeMetrics();
   //
   // api features
   //
@@ -381,8 +382,6 @@ class MaintenanceFeature : public application_features::ApplicationFeature {
   static constexpr auto maxReplicationErrorsPerShardAge = std::chrono::hours(24);
   
  protected:
-  void initializeMetrics();
-
  private:
   /// @brief Search for first action matching hash and predicate
   /// @return shared pointer to action object if exists, empty shared_ptr if not

--- a/arangod/Cluster/SynchronizeShard.cpp
+++ b/arangod/Cluster/SynchronizeShard.cpp
@@ -799,6 +799,14 @@ bool SynchronizeShard::first() {
       LOG_TOPIC("4abcb", DEBUG, Logger::MAINTENANCE) << "SynchronizeOneShard: " << error.str();
       result(TRI_ERROR_FAILED, error.str());
       return false;
+    } else {
+      // we need to immediately exit, as the planned leader is not yet leading
+      // in current
+      LOG_TOPIC("4acdc", DEBUG, Logger::MAINTENANCE)
+          << "SynchronizeOneShard: Planned leader has not taken over "
+             "leadership";
+      result(TRI_ERROR_FAILED, "Planned leader has not taken over leadership");
+      return false;
     }
 
     LOG_TOPIC("28600", DEBUG, Logger::MAINTENANCE)

--- a/tests/Maintenance/MaintenanceFeatureTest.cpp
+++ b/tests/Maintenance/MaintenanceFeatureTest.cpp
@@ -34,6 +34,7 @@
 #include "Cluster/Action.h"
 #include "Cluster/Maintenance.h"
 #include "Cluster/MaintenanceFeature.h"
+#include "Mocks/Servers.h"
 #include "RestServer/MetricsFeature.h"
 #include "RestServer/UpgradeFeature.h"
 

--- a/tests/Maintenance/MaintenanceFeatureTest.cpp
+++ b/tests/Maintenance/MaintenanceFeatureTest.cpp
@@ -35,6 +35,7 @@
 #include "Cluster/Maintenance.h"
 #include "Cluster/MaintenanceFeature.h"
 #include "RestServer/MetricsFeature.h"
+#include "RestServer/UpgradeFeature.h"
 
 #include "MaintenanceFeatureMock.h"
 
@@ -157,6 +158,25 @@ class TestActionBasic : public ActionBase {
   bool _reschedule;
 
 };  // TestActionBasic
+
+class MaintenanceFeatureTestDBServer
+    : public ::testing::Test,
+      public arangodb::tests::LogSuppressor<arangodb::Logger::AGENCY,
+                                            arangodb::LogLevel::FATAL>,
+      public arangodb::tests::LogSuppressor<arangodb::Logger::AUTHENTICATION,
+                                            arangodb::LogLevel::ERR>,
+      public arangodb::tests::LogSuppressor<arangodb::Logger::CLUSTER,
+                                            arangodb::LogLevel::FATAL> {
+ protected:
+  arangodb::tests::mocks::MockDBServer server;
+
+  MaintenanceFeatureTestDBServer() : server(false) {
+    arangodb::ServerState::instance()->setRebootId(
+        arangodb::RebootId{1});  // Hack.
+    server.untrackFeature<arangodb::UpgradeFeature>();
+    server.startFeatures();
+  }
+};
 
 //
 //
@@ -808,3 +828,23 @@ TEST(MaintenanceFeatureTestThreaded, populate_action_queue_reschedule_and_valida
 #endif
 }
 
+TEST_F(MaintenanceFeatureTestDBServer, test_synchronize_shard_abort) {
+  auto& mf = server.getFeature<arangodb::MaintenanceFeature>();
+  mf.start();
+
+  std::shared_ptr<ActionDescription> description =
+      std::make_shared<ActionDescription>(
+          std::map<std::string, std::string>{{NAME, SYNCHRONIZE_SHARD},
+                                             {DATABASE, "_system"},
+                                             {COLLECTION, "tmp"},
+                                             {SHARD, "s1"},
+                                             {THE_LEADER, "PRMR-1"},
+                                             {SHARD_VERSION, "1"}},
+          SYNCHRONIZE_PRIORITY, true);
+
+  // The following will executed the action right away:
+  auto res = mf.addAction(description, true /* executeNow */);
+  ASSERT_FALSE(res.ok());  // must have been aborted
+  mf.beginShutdown();
+  mf.stop();
+}

--- a/tests/Maintenance/MaintenanceFeatureTest.cpp
+++ b/tests/Maintenance/MaintenanceFeatureTest.cpp
@@ -840,7 +840,8 @@ TEST_F(MaintenanceFeatureTestDBServer, test_synchronize_shard_abort) {
                                              {COLLECTION, "tmp"},
                                              {SHARD, "s1"},
                                              {THE_LEADER, "PRMR-1"},
-                                             {SHARD_VERSION, "1"}},
+                                             {SHARD_VERSION, "1"},
+                                             {FORCED_RESYNC, "false"}},
           SYNCHRONIZE_PRIORITY, true);
 
   // The following will executed the action right away:


### PR DESCRIPTION
### Scope & Purpose

A situation can arise in which a planned shard leader cannot assume
its leadership since one of its `SynchronizeShard` jobs is in the
Maintenance work queue and is locking the shard. If this happens
multiple times in the same cluster, everything can get stuck.

- [*] :hankey: Bugfix

### Checklist

- [*] Tests
  - [*] C++ **Unit tests**
- [*] :book: CHANGELOG entry made
- [*] Backports: This is the backport for 3.8. Original PR: https://github.com/arangodb/arangodb/pull/16019

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [*] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/BTS-662

This supersedes https://github.com/arangodb/arangodb/pull/15241, which is somehow failed for technical reasons.


