### PR TITLE
[CINFRA-342] Bug fix/update leader property when replacing leader

### DIFF
--- a/arangod/Cluster/AgencyCache.cpp
+++ b/arangod/Cluster/AgencyCache.cpp
@@ -830,12 +830,14 @@ AgencyCache::change_set_t AgencyCache::changedSince(
                       std::move(rest_res));
 }
 
-std::ostream& arangodb::operator<<(std::ostream& o, AgencyCache::change_set_t const& c) {
+std::ostream& arangodb::operator<<(std::ostream& o,
+                                   AgencyCache::change_set_t const& c) {
   o << c.ind;
   return o;
 }
 
-std::ostream& arangodb::operator<<(std::ostream& o, AgencyCache::databases_t const& dbs) {
+std::ostream& arangodb::operator<<(std::ostream& o,
+                                   AgencyCache::databases_t const& dbs) {
   o << "{";
   bool first = true;
   for (auto const& db : dbs) {

--- a/arangod/Cluster/AgencyCache.cpp
+++ b/arangod/Cluster/AgencyCache.cpp
@@ -830,13 +830,12 @@ AgencyCache::change_set_t AgencyCache::changedSince(
                       std::move(rest_res));
 }
 
-namespace std {
-ostream& operator<<(ostream& o, AgencyCache::change_set_t const& c) {
+std::ostream& arangodb::operator<<(std::ostream& o, AgencyCache::change_set_t const& c) {
   o << c.ind;
   return o;
 }
 
-ostream& operator<<(ostream& o, AgencyCache::databases_t const& dbs) {
+std::ostream& arangodb::operator<<(std::ostream& o, AgencyCache::databases_t const& dbs) {
   o << "{";
   bool first = true;
   for (auto const& db : dbs) {
@@ -850,4 +849,3 @@ ostream& operator<<(ostream& o, AgencyCache::databases_t const& dbs) {
   o << "}";
   return o;
 }
-}  // namespace std

--- a/arangod/Cluster/AgencyCache.h
+++ b/arangod/Cluster/AgencyCache.h
@@ -212,7 +212,9 @@ class AgencyCache final : public ServerThread<ArangodServer> {
   metrics::Gauge<uint64_t>& _callbacksCount;
 };
 
-std::ostream& operator<<(std::ostream& o, arangodb::AgencyCache::change_set_t const& c);
-std::ostream& operator<<(std::ostream& o, arangodb::AgencyCache::databases_t const& d);
+std::ostream& operator<<(std::ostream& o,
+                         arangodb::AgencyCache::change_set_t const& c);
+std::ostream& operator<<(std::ostream& o,
+                         arangodb::AgencyCache::databases_t const& d);
 
 }  // namespace arangodb

--- a/arangod/Cluster/AgencyCache.h
+++ b/arangod/Cluster/AgencyCache.h
@@ -212,9 +212,7 @@ class AgencyCache final : public ServerThread<ArangodServer> {
   metrics::Gauge<uint64_t>& _callbacksCount;
 };
 
-}  // namespace arangodb
+std::ostream& operator<<(std::ostream& o, arangodb::AgencyCache::change_set_t const& c);
+std::ostream& operator<<(std::ostream& o, arangodb::AgencyCache::databases_t const& d);
 
-namespace std {
-ostream& operator<<(ostream& o, arangodb::AgencyCache::change_set_t const& c);
-ostream& operator<<(ostream& o, arangodb::AgencyCache::databases_t const& d);
-}  // namespace std
+}  // namespace arangodb

--- a/arangod/Replication2/AgencyMethods.cpp
+++ b/arangod/Replication2/AgencyMethods.cpp
@@ -273,22 +273,40 @@ auto methods::createReplicatedState(
 
 auto methods::replaceReplicatedStateParticipant(
     TRI_vocbase_t& vocbase, LogId id, ParticipantId const& participantToRemove,
-    ParticipantId const& participantToAdd) -> futures::Future<Result> {
+    ParticipantId const& participantToAdd,
+    std::optional<ParticipantId> const& currentLeader)
+    -> futures::Future<Result> {
   auto path =
       paths::target()->replicatedStates()->database(vocbase.name())->state(id);
+
+  bool replaceLeader = currentLeader == participantToRemove;
+  // note that replaceLeader => currentLeader.has_value()
+  TRI_ASSERT(!replaceLeader || currentLeader.has_value());
 
   VPackBufferUInt8 trx;
   {
     VPackBuilder builder(trx);
     arangodb::agency::envelope::into_builder(builder)
         .write()
+        // remove the old participant
         .remove(*path->participants()->server(participantToRemove))
+        // add the new participant
         .set(*path->participants()->server(participantToAdd),
              VPackSlice::emptyObjectSlice())
+        // if the old participant was the leader, set the leader to the new one
+        .cond(replaceLeader, [&](auto&& write) {
+          return std::move(write).set(*path->leader(), participantToAdd);
+        })
         .inc(*paths::target()->version())
         .precs()
+        // assert that the old participant actually was a participant
         .isNotEmpty(*path->participants()->server(participantToRemove))
+        // assert that the new participant didn't exist
         .isEmpty(*path->participants()->server(participantToAdd))
+        // if the old participant was the leader, assert that it
+        .cond(replaceLeader, [&](auto&& precs){
+          return std::move(precs).isEqual(*path->leader(), *currentLeader);
+        })
         .end()
         .done();
   }

--- a/arangod/Replication2/AgencyMethods.cpp
+++ b/arangod/Replication2/AgencyMethods.cpp
@@ -294,9 +294,10 @@ auto methods::replaceReplicatedStateParticipant(
         .set(*path->participants()->server(participantToAdd),
              VPackSlice::emptyObjectSlice())
         // if the old participant was the leader, set the leader to the new one
-        .cond(replaceLeader, [&](auto&& write) {
-          return std::move(write).set(*path->leader(), participantToAdd);
-        })
+        .cond(replaceLeader,
+              [&](auto&& write) {
+                return std::move(write).set(*path->leader(), participantToAdd);
+              })
         .inc(*paths::target()->version())
         .precs()
         // assert that the old participant actually was a participant
@@ -304,9 +305,11 @@ auto methods::replaceReplicatedStateParticipant(
         // assert that the new participant didn't exist
         .isEmpty(*path->participants()->server(participantToAdd))
         // if the old participant was the leader, assert that it
-        .cond(replaceLeader, [&](auto&& precs){
-          return std::move(precs).isEqual(*path->leader(), *currentLeader);
-        })
+        .cond(replaceLeader,
+              [&](auto&& precs) {
+                return std::move(precs).isEqual(*path->leader(),
+                                                *currentLeader);
+              })
         .end()
         .done();
   }

--- a/arangod/Replication2/AgencyMethods.h
+++ b/arangod/Replication2/AgencyMethods.h
@@ -91,9 +91,10 @@ auto createReplicatedState(DatabaseID const& database,
 auto getCurrentSupervision(TRI_vocbase_t& vocbase, LogId id)
     -> LogCurrentSupervision;
 
-auto replaceReplicatedStateParticipant(TRI_vocbase_t& vocbase, LogId id,
-                                       ParticipantId const& participantToRemove,
-                                       ParticipantId const& participantToAdd)
+auto replaceReplicatedStateParticipant(
+    TRI_vocbase_t& vocbase, LogId id, ParticipantId const& participantToRemove,
+    ParticipantId const& participantToAdd,
+    std::optional<ParticipantId> const& currentLeader)
     -> futures::Future<Result>;
 
 auto replaceReplicatedSetLeader(TRI_vocbase_t& vocbase, LogId id,

--- a/arangod/Replication2/Methods.cpp
+++ b/arangod/Replication2/Methods.cpp
@@ -716,8 +716,9 @@ struct ReplicatedStateDBServerMethods
   }
 
   auto replaceParticipant(LogId logId, ParticipantId const& participantToRemove,
-                          ParticipantId const& participantToAdd) const
-      -> futures::Future<Result> override {
+                          ParticipantId const& participantToAdd,
+                          std::optional<ParticipantId> const& currentLeader)
+      const -> futures::Future<Result> override {
     // Only available on the coordinator
     THROW_ARANGO_EXCEPTION(TRI_ERROR_HTTP_NOT_IMPLEMENTED);
   }
@@ -837,10 +838,11 @@ struct ReplicatedStateCoordinatorMethods
   }
 
   auto replaceParticipant(LogId id, ParticipantId const& participantToRemove,
-                          ParticipantId const& participantToAdd) const
-      -> futures::Future<Result> override {
+                          ParticipantId const& participantToAdd,
+                          std::optional<ParticipantId> const& currentLeader)
+      const -> futures::Future<Result> override {
     return replication2::agency::methods::replaceReplicatedStateParticipant(
-        vocbase, id, participantToRemove, participantToAdd);
+        vocbase, id, participantToRemove, participantToAdd, currentLeader);
   }
 
   auto setLeader(LogId id, std::optional<ParticipantId> const& leaderId) const

--- a/arangod/Replication2/Methods.h
+++ b/arangod/Replication2/Methods.h
@@ -134,7 +134,8 @@ struct ReplicatedStateMethods {
 
   [[nodiscard]] virtual auto replaceParticipant(
       LogId, ParticipantId const& participantToRemove,
-      ParticipantId const& participantToAdd) const
+      ParticipantId const& participantToAdd,
+      std::optional<ParticipantId> const& currentLeader) const
       -> futures::Future<Result> = 0;
 
   [[nodiscard]] virtual auto setLeader(

--- a/js/server/modules/@arangodb/testutils/replicated-logs-helper.js
+++ b/js/server/modules/@arangodb/testutils/replicated-logs-helper.js
@@ -30,7 +30,7 @@ const arangodb = require('@arangodb');
 const ArangoError = arangodb.ArangoError;
 const ERRORS = arangodb.errors;
 const db = arangodb.db;
-const lpreds = require("@arangodb/testutils/replicated-log-predicates");
+const lpreds = require("@arangodb/testutils/replicated-logs-predicates");
 
 const waitFor = function (checkFn, maxTries = 240) {
   let count = 0;

--- a/js/server/modules/@arangodb/testutils/replicated-logs-helper.js
+++ b/js/server/modules/@arangodb/testutils/replicated-logs-helper.js
@@ -25,13 +25,12 @@
 const internal = require("internal");
 const {wait} = internal;
 const _ = require("lodash");
-const jsunity = require("jsunity");
-const {assertTrue} = jsunity.jsUnity.assertions;
 const request = require('@arangodb/request');
 const arangodb = require('@arangodb');
 const ArangoError = arangodb.ArangoError;
 const ERRORS = arangodb.errors;
 const db = arangodb.db;
+const lpreds = require("@arangodb/testutils/replicated-log-predicates");
 
 const waitFor = function (checkFn, maxTries = 240) {
   let count = 0;
@@ -210,69 +209,6 @@ const replicatedLogDeleteTarget = function (database, logId) {
   global.ArangoAgency.increaseVersion(`Target/Version`);
 };
 
-const replicatedLogIsReady = function (database, logId, term, participants, leader) {
-  return function () {
-    let {current} = readReplicatedLogAgency(database, logId);
-    if (current === undefined) {
-      return Error("current not yet defined");
-    }
-
-    for (const srv of participants) {
-      if (!current.localStatus || !current.localStatus[srv]) {
-        return Error(`Participant ${srv} has not yet reported to current.`);
-      }
-      if (current.localStatus[srv].term < term) {
-        return Error(`Participant ${srv} has not yet acknowledged the current term; ` +
-            `found = ${current.localStatus[srv].term}, expected = ${term}.`);
-      }
-    }
-
-    if (leader !== undefined) {
-      if (!current.leader) {
-        return Error("Leader has not yet established its term");
-      }
-      if (current.leader.serverId !== leader) {
-        return Error(`Wrong leader in current; found = ${current.leader.serverId}, expected = ${leader}`);
-      }
-      if (current.leader.term < term) {
-        return Error(`Leader has not yet confirmed the term; found = ${current.leader.term}, expected = ${term}`);
-      }
-      if (!current.leader.leadershipEstablished) {
-        return Error("Leader has not yet established its leadership");
-      }
-    }
-    return true;
-  };
-};
-
-const replicatedLogLeaderEstablished = function (database, logId, term, participants) {
-  return function () {
-    let {current} = readReplicatedLogAgency(database, logId);
-    if (current === undefined) {
-      return Error("current not yet defined");
-    }
-
-    for (const srv of participants) {
-      if (!current.localStatus || !current.localStatus[srv]) {
-        return Error(`Participant ${srv} has not yet reported to current.`);
-      }
-      if (term !== undefined && current.localStatus[srv].term < term) {
-        return Error(`Participant ${srv} has not yet acknowledged the current term; ` +
-            `found = ${current.localStatus[srv].term}, expected = ${term}.`);
-      }
-    }
-
-    if (!current.leader) {
-      return Error("Leader has not yet established its term");
-    }
-    if (!current.leader.leadershipEstablished) {
-      return Error("Leader has not yet established its leadership");
-    }
-
-    return true;
-  };
-};
-
 const waitForReplicatedLogAvailable = function (id) {
   while (true) {
     try {
@@ -322,39 +258,14 @@ const continueServer = function (serverId) {
   }
 };
 
-const allServersHealthy = function () {
-  return function () {
-    for (const server of dbservers) {
-      const health = getServerHealth(server);
-      if (health !== "GOOD") {
-        return Error(`${server} is ${health}`);
-      }
-    }
-
-    return true;
-  };
-};
-
-const checkServerHealth = function (serverId, value) {
-  return function () {
-    if (value === getServerHealth(serverId)) {
-      return true;
-    }
-    return Error(`${serverId} is not ${value}`);
-  };
-};
-
-const serverHealthy = (serverId) => checkServerHealth(serverId, "GOOD");
-const serverFailed = (serverId) => checkServerHealth(serverId, "FAILED");
-
 const continueServerWaitOk = function (serverId) {
   continueServer(serverId);
-  waitFor(serverHealthy(serverId));
+  waitFor(lpreds.serverHealthy(serverId));
 };
 
 const stopServerWaitFailed = function (serverId) {
   stopServer(serverId);
-  waitFor(serverFailed(serverId));
+  waitFor(lpreds.serverFailed(serverId));
 };
 
 const nextUniqueLogId = function () {
@@ -419,42 +330,6 @@ const getLocalStatus = function (database, logId, serverId) {
 };
 
 
-const replicatedLogParticipantsFlag = function (database, logId, flags, generation = undefined) {
-  return function () {
-    let {current} = readReplicatedLogAgency(database, logId);
-    if (current === undefined) {
-      return Error("current not yet defined");
-    }
-    if (!current.leader) {
-      return Error("Leader has not yet established its term");
-    }
-    if (!current.leader.committedParticipantsConfig) {
-      return Error("Leader has not yet committed any participants config");
-    }
-    if (generation !== undefined) {
-      if (current.leader.committedParticipantsConfig.generation < generation) {
-        return Error("Leader has not yet acked new generation; "
-            + `found ${current.leader.committedParticipantsConfig.generation}, expected = ${generation}`);
-      }
-    }
-
-    const participants = current.leader.committedParticipantsConfig.participants;
-    for (const [p, v] of Object.entries(flags)) {
-      if (v === null) {
-        if (participants[p] !== undefined) {
-          return Error(`Entry for server ${p} still present in participants flags`);
-        }
-      } else {
-        if (!_.isEqual(v, participants[p])) {
-          return Error(`Flags for participant ${p} are not as expected: ${JSON.stringify(v)} vs. ${JSON.stringify(participants[p])}`);
-        }
-      }
-    }
-
-    return true;
-  };
-};
-
 const getReplicatedLogLeaderPlan = function (database, logId) {
   let {plan} = readReplicatedLogAgency(database, logId);
   if (!plan.currentTerm) {
@@ -483,53 +358,11 @@ const createReplicatedLog = function (database, targetConfig) {
     supervision: {maxActionsTraceLength: 20},
   });
 
-  waitFor(replicatedLogLeaderEstablished(database, logId, undefined, servers));
+  waitFor(lpreds.replicatedLogLeaderEstablished(database, logId, undefined, servers));
 
   const {leader, term} = getReplicatedLogLeaderPlan(database, logId);
   const followers = _.difference(servers, [leader]);
   return {logId, servers, leader, term, followers};
-};
-
-const replicatedLogTargetVersion = function(database, logId, version) {
-  return function() {
-    let {current} = readReplicatedLogAgency(database, logId);
-
-    if (current === undefined) {
-      return Error(`current not yet defined`);
-    }
-    if (!current.supervision) {
-      return Error(`supervision not yet reported to current`);
-    }
-    if (!current.supervision.targetVersion) {
-      return Error(`no version reported in current by supervision`);
-    }
-    if (current.supervision.targetVersion !== version) {
-      return Error(`found version ${current.supervison.targetVersion}, expected ${version}`);
-    }
-    return true;
-  };
-};
-
-const replicatedLogLeaderTargetIs = function(database, stateId, expectedLeader) {
-  return function () {
-    const currentLeader = getReplicatedLogLeaderTarget(database, stateId);
-    if (currentLeader === expectedLeader) {
-      return true;
-    } else {
-      return new Error(`Expected log leader to switch to ${expectedLeader}, but is still ${currentLeader}`);
-    }
-  };
-};
-
-const replicatedLogLeaderPlanIs = function(database, stateId, expectedLeader) {
-  return function () {
-    const {leader: currentLeader} = getReplicatedLogLeaderPlan(database, stateId);
-    if (currentLeader === expectedLeader) {
-      return true;
-    } else {
-      return new Error(`Expected log leader to switch to ${expectedLeader}, but is still ${currentLeader}`);
-    }
-  };
 };
 
 exports.waitFor = waitFor;
@@ -544,7 +377,6 @@ exports.replicatedLogUpdatePlanParticipantsConfigParticipants = replicatedLogUpd
 exports.replicatedLogSetPlanTerm = replicatedLogSetPlanTerm;
 exports.replicatedLogSetPlan = replicatedLogSetPlan;
 exports.replicatedLogDeletePlan = replicatedLogDeletePlan;
-exports.replicatedLogIsReady = replicatedLogIsReady;
 exports.stopServer = stopServer;
 exports.continueServer = continueServer;
 exports.nextUniqueLogId = nextUniqueLogId;
@@ -552,22 +384,16 @@ exports.registerAgencyTestBegin = registerAgencyTestBegin;
 exports.registerAgencyTestEnd = registerAgencyTestEnd;
 exports.replicatedLogSetTarget = replicatedLogSetTarget;
 exports.getParticipantsObjectForServers = getParticipantsObjectForServers;
-exports.allServersHealthy = allServersHealthy;
 exports.continueServerWaitOk = continueServerWaitOk;
 exports.stopServerWaitFailed = stopServerWaitFailed;
 exports.replicatedLogDeleteTarget = replicatedLogDeleteTarget;
 exports.getLocalStatus = getLocalStatus;
 exports.getServerRebootId = getServerRebootId;
 exports.replicatedLogUpdateTargetParticipants = replicatedLogUpdateTargetParticipants;
-exports.replicatedLogLeaderEstablished = replicatedLogLeaderEstablished;
 exports.waitForReplicatedLogAvailable = waitForReplicatedLogAvailable;
-exports.replicatedLogParticipantsFlag = replicatedLogParticipantsFlag;
 exports.getReplicatedLogLeaderPlan = getReplicatedLogLeaderPlan;
 exports.getReplicatedLogLeaderTarget = getReplicatedLogLeaderTarget;
 exports.createReplicatedLog = createReplicatedLog;
 exports.checkRequestResult = checkRequestResult;
 exports.getServerUrl = getServerUrl;
 exports.getServerHealth = getServerHealth;
-exports.replicatedLogTargetVersion = replicatedLogTargetVersion;
-exports.replicatedLogLeaderTargetIs = replicatedLogLeaderTargetIs;
-exports.replicatedLogLeaderPlanIs = replicatedLogLeaderPlanIs;

--- a/js/server/modules/@arangodb/testutils/replicated-logs-helper.js
+++ b/js/server/modules/@arangodb/testutils/replicated-logs-helper.js
@@ -510,6 +510,28 @@ const replicatedLogTargetVersion = function(database, logId, version) {
   };
 };
 
+const replicatedLogLeaderTargetIs = function(database, stateId, expectedLeader) {
+  return function () {
+    const currentLeader = getReplicatedLogLeaderTarget(database, stateId);
+    if (currentLeader === expectedLeader) {
+      return true;
+    } else {
+      return new Error(`Expected log leader to switch to ${expectedLeader}, but is still ${currentLeader}`);
+    }
+  };
+};
+
+const replicatedLogLeaderPlanIs = function(database, stateId, expectedLeader) {
+  return function () {
+    const {leader: currentLeader} = getReplicatedLogLeaderPlan(database, stateId);
+    if (currentLeader === expectedLeader) {
+      return true;
+    } else {
+      return new Error(`Expected log leader to switch to ${expectedLeader}, but is still ${currentLeader}`);
+    }
+  };
+};
+
 exports.waitFor = waitFor;
 exports.readAgencyValueAt = readAgencyValueAt;
 exports.createParticipantsConfig = createParticipantsConfig;
@@ -547,3 +569,5 @@ exports.checkRequestResult = checkRequestResult;
 exports.getServerUrl = getServerUrl;
 exports.getServerHealth = getServerHealth;
 exports.replicatedLogTargetVersion = replicatedLogTargetVersion;
+exports.replicatedLogLeaderTargetIs = replicatedLogLeaderTargetIs;
+exports.replicatedLogLeaderPlanIs = replicatedLogLeaderPlanIs;

--- a/js/server/modules/@arangodb/testutils/replicated-logs-predicates.js
+++ b/js/server/modules/@arangodb/testutils/replicated-logs-predicates.js
@@ -1,0 +1,203 @@
+/*jshint strict: true */
+'use strict';
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2022 ArangoDB GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License")
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Tobias Gödderz
+////////////////////////////////////////////////////////////////////////////////
+
+const LH = require("@arangodb/testutils/replicated-logs-helper");
+const _ = require("lodash");
+
+
+const replicatedLogIsReady = function (database, logId, term, participants, leader) {
+  return function () {
+    let {current} = LH.readReplicatedLogAgency(database, logId);
+    if (current === undefined) {
+      return Error("current not yet defined");
+    }
+
+    for (const srv of participants) {
+      if (!current.localStatus || !current.localStatus[srv]) {
+        return Error(`Participant ${srv} has not yet reported to current.`);
+      }
+      if (current.localStatus[srv].term < term) {
+        return Error(`Participant ${srv} has not yet acknowledged the current term; ` +
+          `found = ${current.localStatus[srv].term}, expected = ${term}.`);
+      }
+    }
+
+    if (leader !== undefined) {
+      if (!current.leader) {
+        return Error("Leader has not yet established its term");
+      }
+      if (current.leader.serverId !== leader) {
+        return Error(`Wrong leader in current; found = ${current.leader.serverId}, expected = ${leader}`);
+      }
+      if (current.leader.term < term) {
+        return Error(`Leader has not yet confirmed the term; found = ${current.leader.term}, expected = ${term}`);
+      }
+      if (!current.leader.leadershipEstablished) {
+        return Error("Leader has not yet established its leadership");
+      }
+    }
+    return true;
+  };
+};
+
+const replicatedLogLeaderEstablished = function (database, logId, term, participants) {
+  return function () {
+    let {current} = LH.readReplicatedLogAgency(database, logId);
+    if (current === undefined) {
+      return Error("current not yet defined");
+    }
+
+    for (const srv of participants) {
+      if (!current.localStatus || !current.localStatus[srv]) {
+        return Error(`Participant ${srv} has not yet reported to current.`);
+      }
+      if (term !== undefined && current.localStatus[srv].term < term) {
+        return Error(`Participant ${srv} has not yet acknowledged the current term; ` +
+          `found = ${current.localStatus[srv].term}, expected = ${term}.`);
+      }
+    }
+
+    if (!current.leader) {
+      return Error("Leader has not yet established its term");
+    }
+    if (!current.leader.leadershipEstablished) {
+      return Error("Leader has not yet established its leadership");
+    }
+
+    return true;
+  };
+};
+
+const allServersHealthy = function () {
+  return function () {
+    for (const server of LH.dbservers) {
+      const health = LH.getServerHealth(server);
+      if (health !== "GOOD") {
+        return Error(`${server} is ${health}`);
+      }
+    }
+
+    return true;
+  };
+};
+
+const checkServerHealth = function (serverId, value) {
+  return function () {
+    if (value === LH.getServerHealth(serverId)) {
+      return true;
+    }
+    return Error(`${serverId} is not ${value}`);
+  };
+};
+
+const serverHealthy = (serverId) => checkServerHealth(serverId, "GOOD");
+const serverFailed = (serverId) => checkServerHealth(serverId, "FAILED");
+
+const replicatedLogParticipantsFlag = function (database, logId, flags, generation = undefined) {
+  return function () {
+    let {current} = LH.readReplicatedLogAgency(database, logId);
+    if (current === undefined) {
+      return Error("current not yet defined");
+    }
+    if (!current.leader) {
+      return Error("Leader has not yet established its term");
+    }
+    if (!current.leader.committedParticipantsConfig) {
+      return Error("Leader has not yet committed any participants config");
+    }
+    if (generation !== undefined) {
+      if (current.leader.committedParticipantsConfig.generation < generation) {
+        return Error("Leader has not yet acked new generation; "
+          + `found ${current.leader.committedParticipantsConfig.generation}, expected = ${generation}`);
+      }
+    }
+
+    const participants = current.leader.committedParticipantsConfig.participants;
+    for (const [p, v] of Object.entries(flags)) {
+      if (v === null) {
+        if (participants[p] !== undefined) {
+          return Error(`Entry for server ${p} still present in participants flags`);
+        }
+      } else {
+        if (!_.isEqual(v, participants[p])) {
+          return Error(`Flags for participant ${p} are not as expected: ${JSON.stringify(v)} vs. ${JSON.stringify(participants[p])}`);
+        }
+      }
+    }
+
+    return true;
+  };
+};
+
+const replicatedLogTargetVersion = function(database, logId, version) {
+  return function() {
+    let {current} = LH.readReplicatedLogAgency(database, logId);
+
+    if (current === undefined) {
+      return Error(`current not yet defined`);
+    }
+    if (!current.supervision) {
+      return Error(`supervision not yet reported to current`);
+    }
+    if (!current.supervision.targetVersion) {
+      return Error(`no version reported in current by supervision`);
+    }
+    if (current.supervision.targetVersion !== version) {
+      return Error(`found version ${current.supervison.targetVersion}, expected ${version}`);
+    }
+    return true;
+  };
+};
+
+const replicatedLogLeaderTargetIs = function(database, stateId, expectedLeader) {
+  return function () {
+    const currentLeader = LH.getReplicatedLogLeaderTarget(database, stateId);
+    if (currentLeader === expectedLeader) {
+      return true;
+    } else {
+      return new Error(`Expected log leader to switch to ${expectedLeader}, but is still ${currentLeader}`);
+    }
+  };
+};
+
+const replicatedLogLeaderPlanIs = function(database, stateId, expectedLeader) {
+  return function () {
+    const {leader: currentLeader} = LH.getReplicatedLogLeaderPlan(database, stateId);
+    if (currentLeader === expectedLeader) {
+      return true;
+    } else {
+      return new Error(`Expected log leader to switch to ${expectedLeader}, but is still ${currentLeader}`);
+    }
+  };
+};
+
+exports.replicatedLogIsReady = replicatedLogIsReady;
+exports.allServersHealthy = allServersHealthy;
+exports.serverHealthy = serverHealthy;
+exports.serverFailed = serverFailed;
+exports.replicatedLogLeaderEstablished = replicatedLogLeaderEstablished;
+exports.replicatedLogParticipantsFlag = replicatedLogParticipantsFlag;
+exports.replicatedLogTargetVersion = replicatedLogTargetVersion;
+exports.replicatedLogLeaderTargetIs = replicatedLogLeaderTargetIs;
+exports.replicatedLogLeaderPlanIs = replicatedLogLeaderPlanIs;

--- a/js/server/modules/@arangodb/testutils/replicated-state-helper.js
+++ b/js/server/modules/@arangodb/testutils/replicated-state-helper.js
@@ -21,6 +21,7 @@
 ///
 /// @author Lars Maier
 ////////////////////////////////////////////////////////////////////////////////
+
 const _ = require("lodash");
 const LH = require("@arangodb/testutils/replicated-logs-helper");
 const request = require('@arangodb/request');

--- a/js/server/modules/@arangodb/testutils/replicated-state-helper.js
+++ b/js/server/modules/@arangodb/testutils/replicated-state-helper.js
@@ -125,8 +125,14 @@ const createReplicatedStateTarget = function (database, targetConfig, type) {
   return {stateId, servers, leader, followers};
 };
 
+const getReplicatedStateLeaderTarget = function (database, logId) {
+  let {target} = readReplicatedStateAgency(database, logId);
+  return target.leader;
+};
+
 exports.readReplicatedStateAgency = readReplicatedStateAgency;
 exports.updateReplicatedStatePlan = updateReplicatedStatePlan;
 exports.getLocalStatus = getLocalStatus;
 exports.createReplicatedStateTarget = createReplicatedStateTarget;
 exports.updateReplicatedStateTarget = updateReplicatedStateTarget;
+exports.getReplicatedStateLeaderTarget = getReplicatedStateLeaderTarget;

--- a/js/server/modules/@arangodb/testutils/replicated-state-predicates.js
+++ b/js/server/modules/@arangodb/testutils/replicated-state-predicates.js
@@ -119,3 +119,4 @@ const replicatedStateTargetLeaderIs = function (database, stateId, expectedLeade
 exports.replicatedStateIsReady = replicatedStateIsReady;
 exports.serverReceivedSnapshotGeneration = serverReceivedSnapshotGeneration;
 exports.replicatedStateVersionConverged = replicatedStateVersionConverged;
+exports.replicatedStateTargetLeaderIs = replicatedStateTargetLeaderIs;

--- a/js/server/modules/@arangodb/testutils/replicated-state-predicates.js
+++ b/js/server/modules/@arangodb/testutils/replicated-state-predicates.js
@@ -105,6 +105,17 @@ const replicatedStateVersionConverged = function (database, logId, expectedVersi
   };
 };
 
+const replicatedStateTargetLeaderIs = function (database, stateId, expectedLeader) {
+  return function () {
+    const currentLeader = SH.getReplicatedStateLeaderTarget(database, stateId);
+    if (currentLeader === expectedLeader) {
+      return true;
+    } else {
+      return new Error(`Expected state leader to switch to ${newLeader}, but is still ${currentLeader}`);
+    }
+  };
+}
+
 exports.replicatedStateIsReady = replicatedStateIsReady;
 exports.serverReceivedSnapshotGeneration = serverReceivedSnapshotGeneration;
 exports.replicatedStateVersionConverged = replicatedStateVersionConverged;

--- a/js/server/modules/@arangodb/testutils/replicated-state-predicates.js
+++ b/js/server/modules/@arangodb/testutils/replicated-state-predicates.js
@@ -21,9 +21,8 @@
 ///
 /// @author Lars Maier
 ////////////////////////////////////////////////////////////////////////////////
-const LH = require("@arangodb/testutils/replicated-logs-helper");
+
 const SH = require("@arangodb/testutils/replicated-state-helper");
-const _ = require("lodash");
 
 const isError = function (value) {
   return value instanceof Error;
@@ -114,7 +113,7 @@ const replicatedStateTargetLeaderIs = function (database, stateId, expectedLeade
       return new Error(`Expected state leader to switch to ${expectedLeader}, but is still ${currentLeader}`);
     }
   };
-}
+};
 
 exports.replicatedStateIsReady = replicatedStateIsReady;
 exports.serverReceivedSnapshotGeneration = serverReceivedSnapshotGeneration;

--- a/js/server/modules/@arangodb/testutils/replicated-state-predicates.js
+++ b/js/server/modules/@arangodb/testutils/replicated-state-predicates.js
@@ -111,7 +111,7 @@ const replicatedStateTargetLeaderIs = function (database, stateId, expectedLeade
     if (currentLeader === expectedLeader) {
       return true;
     } else {
-      return new Error(`Expected state leader to switch to ${newLeader}, but is still ${currentLeader}`);
+      return new Error(`Expected state leader to switch to ${expectedLeader}, but is still ${currentLeader}`);
     }
   };
 }

--- a/tests/js/server/replication2/replication2-maintenance-replicated-log-cluster.js
+++ b/tests/js/server/replication2/replication2-maintenance-replicated-log-cluster.js
@@ -36,12 +36,15 @@ const {
   replicatedLogSetPlanTerm,
   createParticipantsConfig,
   createTermSpecification,
-  replicatedLogIsReady,
   dbservers,
   nextUniqueLogId,
   registerAgencyTestBegin, registerAgencyTestEnd,
-  replicatedLogParticipantsFlag,
 } = require("@arangodb/testutils/replicated-logs-helper");
+
+const {
+  replicatedLogIsReady,
+  replicatedLogParticipantsFlag,
+} = require("@arangodb/testutils/replicated-logs-predicates");
 
 const database = 'ReplLogsMaintenanceTest';
 

--- a/tests/js/server/replication2/replication2-maintenance-replicated-state-cluster.js
+++ b/tests/js/server/replication2/replication2-maintenance-replicated-state-cluster.js
@@ -30,6 +30,7 @@ const _ = require('lodash');
 const LH = require("@arangodb/testutils/replicated-logs-helper");
 const SH = require("@arangodb/testutils/replicated-state-helper");
 const spreds = require("@arangodb/testutils/replicated-state-predicates");
+const lpreds = require("@arangodb/testutils/replicated-logs-predicates");
 const {dbservers} = require("@arangodb/testutils/replicated-logs-helper");
 
 const database = "Replicated_StateMaintenanceTestDB";
@@ -158,7 +159,7 @@ const replicatedStateSuite = function () {
         return {state, log};
       });
 
-      LH.waitFor(LH.replicatedLogIsReady(database, logId, 2, servers, leader));
+      LH.waitFor(lpreds.replicatedLogIsReady(database, logId, 2, servers, leader));
       LH.waitFor(spreds.replicatedStateIsReady(database, logId, servers));
     },
 
@@ -184,7 +185,7 @@ const replicatedStateSuite = function () {
       });
 
       const newParticipants = [newFollower, ..._.difference(servers, [oldFollower])];
-      LH.waitFor(LH.replicatedLogIsReady(database, logId, 1, newParticipants, leader));
+      LH.waitFor(lpreds.replicatedLogIsReady(database, logId, 1, newParticipants, leader));
       LH.waitFor(spreds.replicatedStateIsReady(database, logId, newParticipants));
     },
   };

--- a/tests/js/server/replication2/replication2-regression.js
+++ b/tests/js/server/replication2/replication2-regression.js
@@ -36,13 +36,13 @@ const {
   waitForReplicatedLogAvailable,
   registerAgencyTestBegin, registerAgencyTestEnd,
   waitFor,
-  allServersHealthy,
   getServerUrl,
   checkRequestResult,
-  readReplicatedLogAgency,
   replicatedLogDeleteTarget,
-  replicatedLogIsReady,
 } = helper;
+const {
+  allServersHealthy,
+} = require("@arangodb/testutils/replicated-logs-predicates");
 
 const database = "replication2_supervision_test_db";
 const IS_FAILED = true;

--- a/tests/js/server/replication2/replication2-regression.js
+++ b/tests/js/server/replication2/replication2-regression.js
@@ -185,7 +185,7 @@ const replicatedLogRegressionSuite = function () {
       waitFor(() => {
         const followerSpearhead = log.status().participants[leader].response.follower[followers[0]].spearhead.index;
         return logIdx === followerSpearhead
-          || newError(`Expected spearhead of ${followers[0]} to be ${logIdx}, but is ${followerSpearhead}.`);
+          || new Error(`Expected spearhead of ${followers[0]} to be ${logIdx}, but is ${followerSpearhead}.`);
       });
 
       { // followers[1] got the log entry before it was stopped, and followers[0] just got it now, so it should be committed.

--- a/tests/js/server/replication2/replication2-regression.js
+++ b/tests/js/server/replication2/replication2-regression.js
@@ -153,15 +153,24 @@ const replicatedLogRegressionSuite = function () {
       // is the only server that has received log index 2.
       const {index: logIdx} = log.insert({foo: "baz"}, {dontWaitForCommit: true});
 
-      { // As followers[0] is stopped and writeConcern=3, the log cannot currently commit.
-        const {participants: {[leader]: {response: status}}} = log.status();
-        assertIdentical(status.lastCommitStatus.reason, "QuorumSizeNotReached", JSON.stringify({status}));
-        assertTrue(status.local.commitIndex < logIdx, `Commit index is ${status.local.commitIndex}, but should be lower than ${JSON.stringify(logIdx)}`);
-      }
+      waitFor(() => {
+          // As followers[0] is stopped and writeConcern=3, the log cannot currently commit.
+          const {participants: {[leader]: {response: status}}} = log.status();
+          if (status.lastCommitStatus.reason !== "QuorumSizeNotReached") {
+            return new Error(`Expected status to be QuorumSizeNotReached, but is ${status.lastCommitStatus.reason}. Full status is: ${JSON.stringify(status)}`);
+          }
+          if (!(status.local.commitIndex < logIdx)) {
+            return new Error(`Commit index is ${status.local.commitIndex}, but should be lower than ${JSON.stringify(logIdx)}.`);
+          }
+          return true;
+        }
+      );
 
       // wait for followers[1] to have received the log entries, and the leader to take note of that
       waitFor(() => {
-        return logIdx === log.status().participants[leader].response.follower[followers[1]].spearhead.index;
+        const followerSpearhead = log.status().participants[leader].response.follower[followers[1]].spearhead.index;
+        return logIdx === followerSpearhead
+          || new Error(`Expected spearhead of ${followers[1]} to be ${logIdx}, but is ${followerSpearhead}.`);
       });
 
       // stop the other follower as well
@@ -174,7 +183,9 @@ const replicatedLogRegressionSuite = function () {
 
       // wait for followers[0] to have received the log entries, and the leader to take note of that
       waitFor(() => {
-        return logIdx === log.status().participants[leader].response.follower[followers[0]].spearhead.index;
+        const followerSpearhead = log.status().participants[leader].response.follower[followers[0]].spearhead.index;
+        return logIdx === followerSpearhead
+          || newError(`Expected spearhead of ${followers[0]} to be ${logIdx}, but is ${followerSpearhead}.`);
       });
 
       { // followers[1] got the log entry before it was stopped, and followers[0] just got it now, so it should be committed.

--- a/tests/js/server/replication2/replication2-replicated-log-entry-cluster.js
+++ b/tests/js/server/replication2/replication2-replicated-log-entry-cluster.js
@@ -26,9 +26,9 @@
 const jsunity = require('jsunity');
 const arangodb = require("@arangodb");
 const _ = require('lodash');
-const {sleep} = require('internal');
-const {db, errors: ERRORS} = arangodb;
+const {db} = arangodb;
 const lh = require("@arangodb/testutils/replicated-logs-helper");
+const lpreds = require("@arangodb/testutils/replicated-logs-predicates");
 const helper = require("@arangodb/testutils/replicated-logs-helper");
 
 const {waitForReplicatedLogAvailable} = helper;
@@ -95,7 +95,7 @@ const replicatedLogEntrySuite = function () {
       lh.replicatedLogUpdateTargetParticipants(database, logId, {
         [follower]: {forced: true},
       });
-      lh.waitFor(lh.replicatedLogParticipantsFlag(database, logId, {
+      lh.waitFor(lpreds.replicatedLogParticipantsFlag(database, logId, {
         [follower]: {
           allowedInQuorum: true,
           allowedAsLeader: true,

--- a/tests/js/server/replication2/replication2-replicated-state-http-api-cluster.js
+++ b/tests/js/server/replication2/replication2-replicated-state-http-api-cluster.js
@@ -225,13 +225,13 @@ const replicatedStateSuite = function () {
         assertEqual(newParticipants, Object.keys(stateAgencyContent.target.participants).sort());
       }
 
-      waitFor(replicatedStateTargetLeaderIs(newLeader));
+      waitFor(replicatedStateTargetLeaderIs(database, stateId, newLeader));
       waitFor(() => {
         const stateAgencyContent = sh.readReplicatedStateAgency(database, stateId);
         return sortedArrayEqualOrError(newParticipants, Object.keys(stateAgencyContent.plan.participants).sort());
       });
-      waitFor(replicatedLogTargetLeaderIs(newLeader));
-      waitFor(replicatedLogLeaderPlanIs(newLeader));
+      waitFor(replicatedLogTargetLeaderIs(database, stateId, newLeader));
+      waitFor(replicatedLogLeaderPlanIs(database, stateId, newLeader));
       // Current won't be cleaned up yet.
       // waitFor(() => {
       //   const stateAgencyContent = sh.readReplicatedStateAgency(database, stateId);

--- a/tests/js/server/replication2/replication2-replicated-state-http-api-cluster.js
+++ b/tests/js/server/replication2/replication2-replicated-state-http-api-cluster.js
@@ -224,11 +224,11 @@ const replicatedStateSuite = function () {
         assertEqual(newParticipants, Object.keys(stateAgencyContent.target.participants).sort());
       }
 
+      waitFor(replicatedStateTargetLeaderIs(newLeader));
       waitFor(() => {
         const stateAgencyContent = sh.readReplicatedStateAgency(database, stateId);
         return sortedArrayEqualOrError(newParticipants, Object.keys(stateAgencyContent.plan.participants).sort());
       });
-      waitFor(replicatedStateTargetLeaderIs(newLeader));
       waitFor(replicatedLogTargetLeaderIs(newLeader));
       waitFor(replicatedLogLeaderPlanIs(newLeader));
       // Current won't be cleaned up yet.

--- a/tests/js/server/replication2/replication2-replicated-state-http-api-cluster.js
+++ b/tests/js/server/replication2/replication2-replicated-state-http-api-cluster.js
@@ -29,6 +29,7 @@ const _ = require('lodash');
 const db = arangodb.db;
 const lh = require("@arangodb/testutils/replicated-logs-helper");
 const sh = require("@arangodb/testutils/replicated-state-helper");
+const {replicatedStateTargetLeaderIs} = require("@arangodb/testutils/replicated-state-predicates.js");
 const request = require('@arangodb/request');
 const {waitFor} = require("@arangodb/testutils/replicated-logs-helper");
 

--- a/tests/js/server/replication2/replication2-soft-write-concern-replicated-log-cluster.js
+++ b/tests/js/server/replication2/replication2-soft-write-concern-replicated-log-cluster.js
@@ -1,5 +1,4 @@
 /*jshint strict: true */
-/*global assertTrue, assertEqual*/
 'use strict';
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -23,22 +22,17 @@
 ///
 /// @author Lars Maier
 ////////////////////////////////////////////////////////////////////////////////
+
 const jsunity = require('jsunity');
+const {assertEqual} = jsunity.jsUnity.assertions;
 const arangodb = require("@arangodb");
 const _ = require('lodash');
-const {sleep} = require('internal');
 const db = arangodb.db;
-const ERRORS = arangodb.errors;
 const helper = require("@arangodb/testutils/replicated-logs-helper");
-
+const lpreds = require("@arangodb/testutils/replicated-logs-predicates");
 const {
   waitFor,
-  readReplicatedLogAgency,
-  replicatedLogSetTarget,
-  dbservers, getParticipantsObjectForServers,
-  nextUniqueLogId, allServersHealthy,
   registerAgencyTestBegin, registerAgencyTestEnd,
-  replicatedLogLeaderEstablished,
   waitForReplicatedLogAvailable,
 } = helper;
 
@@ -103,7 +97,7 @@ const replicatedLogSuite = function () {
     setUp: registerAgencyTestBegin,
     tearDown: function (test) {
       resumeAll();
-      waitFor(allServersHealthy());
+      waitFor(lpreds.allServersHealthy());
       registerAgencyTestEnd(test);
     },
 

--- a/tests/js/server/replication2/replication2-supervision-replicated-log-target-cluster.js
+++ b/tests/js/server/replication2/replication2-supervision-replicated-log-target-cluster.js
@@ -23,28 +23,30 @@
 ///
 /// @author Lars Maier
 ////////////////////////////////////////////////////////////////////////////////
+
 const jsunity = require('jsunity');
 const arangodb = require("@arangodb");
 const _ = require('lodash');
-const {sleep} = require('internal');
 const db = arangodb.db;
 const helper = require("@arangodb/testutils/replicated-logs-helper");
+const lpreds = require("@arangodb/testutils/replicated-logs-predicates");
 
 const {
   waitFor,
   readReplicatedLogAgency,
   replicatedLogSetTarget,
   replicatedLogDeleteTarget,
-  replicatedLogIsReady,
-  dbservers, getParticipantsObjectForServers,
-  nextUniqueLogId, allServersHealthy,
+  dbservers, allServersHealthy,
   registerAgencyTestBegin, registerAgencyTestEnd,
-  replicatedLogLeaderEstablished,
   replicatedLogUpdateTargetParticipants,
-  replicatedLogParticipantsFlag,
-  replicatedLogTargetVersion,
   waitForReplicatedLogAvailable,
 } = helper;
+const {
+  replicatedLogIsReady,
+  replicatedLogLeaderEstablished,
+  replicatedLogParticipantsFlag,
+  replicatedLogTargetVersion,
+} = lpreds;
 
 const database = "replication2_supervision_test_db";
 
@@ -62,7 +64,7 @@ const replicatedLogLeaderElectionFailed = function (database, logId, term, serve
     let election = current.supervision.election;
     if (election.term !== term) {
       return Error("supervision report not yet available for current term; "
-          + `found = ${election.term}; expected = ${term}`);
+        + `found = ${election.term}; expected = ${term}`);
     }
 
     if (servers !== undefined) {
@@ -591,7 +593,7 @@ const replicatedLogSuite = function () {
 
         if (!_.isEqual(leaderData.response, localStatus)) {
           return Error("Copy of local status does not yet match actual local status, " +
-              `found = ${JSON.stringify(globalStatus.participants[leader])}; expected = ${JSON.stringify(localStatus)}`);
+            `found = ${JSON.stringify(globalStatus.participants[leader])}; expected = ${JSON.stringify(localStatus)}`);
         }
         localStatus = helper.getLocalStatus(database, logId, followers[1]);
         if (localStatus.role !== "follower") {
@@ -621,7 +623,7 @@ const replicatedLogSuite = function () {
 
         if (!_.isEqual(election, supervisionData.response.election)) {
           return Error('Coordinator not reporting latest state from supervision' +
-              `found = ${globalStatus.supervision.election}; expected = ${election}`);
+            `found = ${globalStatus.supervision.election}; expected = ${election}`);
         }
 
         if (globalStatus.specification.source !== "RemoteAgency") {

--- a/tests/js/server/replication2/replication2-supervision-replicated-log-target-cluster.js
+++ b/tests/js/server/replication2/replication2-supervision-replicated-log-target-cluster.js
@@ -36,7 +36,7 @@ const {
   readReplicatedLogAgency,
   replicatedLogSetTarget,
   replicatedLogDeleteTarget,
-  dbservers, allServersHealthy,
+  dbservers,
   registerAgencyTestBegin, registerAgencyTestEnd,
   replicatedLogUpdateTargetParticipants,
   waitForReplicatedLogAvailable,
@@ -179,7 +179,7 @@ const replicatedLogSuite = function () {
     setUp: registerAgencyTestBegin,
     tearDown: function (test) {
       resumeAll();
-      waitFor(allServersHealthy());
+      waitFor(lpreds.allServersHealthy());
       registerAgencyTestEnd(test);
     },
 

--- a/tests/js/server/replication2/replication2-supervision-replicated-state-target-cluster.js
+++ b/tests/js/server/replication2/replication2-supervision-replicated-state-target-cluster.js
@@ -29,6 +29,7 @@ const db = arangodb.db;
 const lh = require("@arangodb/testutils/replicated-logs-helper");
 const sh = require("@arangodb/testutils/replicated-state-helper");
 const spreds = require("@arangodb/testutils/replicated-state-predicates");
+const lpreds = require("@arangodb/testutils/replicated-log-predicates");
 
 const database = "replication2_supervision_test_db";
 
@@ -178,7 +179,7 @@ const replicatedStateSuite = function () {
 
       lh.waitFor(spreds.replicatedStateIsReady(database, stateId, newServers));
 
-      lh.waitFor(lh.replicatedLogParticipantsFlag(database, stateId, {
+      lh.waitFor(lpreds.replicatedLogParticipantsFlag(database, stateId, {
         [newParticipant]: {allowedInQuorum: true, allowedAsLeader: true, forced: false},
       }));
     },
@@ -213,8 +214,8 @@ const replicatedStateSuite = function () {
           target.leader = newLeader;
           return target;
         });
-      lh.waitFor(lh.replicatedLogLeaderTargetIs(database, stateId, newLeader));
-      lh.waitFor(lh.replicatedLogLeaderPlanIs(database, stateId, newLeader));
+      lh.waitFor(lpreds.replicatedLogLeaderTargetIs(database, stateId, newLeader));
+      lh.waitFor(lpreds.replicatedLogLeaderPlanIs(database, stateId, newLeader));
     },
 
     testUnsetLeader: function () {
@@ -247,7 +248,7 @@ const replicatedStateSuite = function () {
         });
       lh.waitFor(spreds.replicatedStateVersionConverged(database, stateId, 2));
       const newServers = _.without(servers, serverToBeRemoved);
-      lh.waitFor(lh.replicatedLogParticipantsFlag(database, stateId, {
+      lh.waitFor(lpreds.replicatedLogParticipantsFlag(database, stateId, {
         [serverToBeRemoved]: null,
       }));
       lh.waitFor(spreds.replicatedStateIsReady(database, stateId, newServers));

--- a/tests/js/server/replication2/replication2-supervision-replicated-state-target-cluster.js
+++ b/tests/js/server/replication2/replication2-supervision-replicated-state-target-cluster.js
@@ -29,7 +29,7 @@ const db = arangodb.db;
 const lh = require("@arangodb/testutils/replicated-logs-helper");
 const sh = require("@arangodb/testutils/replicated-state-helper");
 const spreds = require("@arangodb/testutils/replicated-state-predicates");
-const lpreds = require("@arangodb/testutils/replicated-log-predicates");
+const lpreds = require("@arangodb/testutils/replicated-logs-predicates");
 
 const database = "replication2_supervision_test_db";
 

--- a/tests/js/server/replication2/replication2-supervision-replicated-state-target-cluster.js
+++ b/tests/js/server/replication2/replication2-supervision-replicated-state-target-cluster.js
@@ -213,22 +213,8 @@ const replicatedStateSuite = function () {
           target.leader = newLeader;
           return target;
         });
-      lh.waitFor(() => {
-        const currentLeader = lh.getReplicatedLogLeaderTarget(database, stateId);
-        if (currentLeader === newLeader) {
-          return true;
-        } else {
-          return new Error(`Expected log leader to switch to ${newLeader}, but is still ${currentLeader}`);
-        }
-      });
-      lh.waitFor(() => {
-        const {leader: currentLeader} = lh.getReplicatedLogLeaderPlan(database, stateId);
-        if (currentLeader === newLeader) {
-          return true;
-        } else {
-          return new Error(`Expected log leader to switch to ${newLeader}, but is still ${currentLeader}`);
-        }
-      });
+      lh.waitFor(lh.replicatedLogLeaderTargetIs(database, stateId, newLeader));
+      lh.waitFor(lh.replicatedLogLeaderPlanIs(database, stateId, newLeader));
     },
 
     testUnsetLeader: function () {

--- a/tests/js/server/resilience/failover/resilience-failure-oracle.js
+++ b/tests/js/server/resilience/failover/resilience-failure-oracle.js
@@ -28,11 +28,11 @@ const jsunity = require('jsunity');
 const request = require('@arangodb/request');
 const {sleep} = require('internal');
 const helper = require("@arangodb/testutils/replicated-logs-helper");
+const lpreds = require("@arangodb/testutils/replicated-logs-predicates");
 
 const {
   waitFor,
   dbservers,
-  allServersHealthy,
   registerAgencyTestBegin,
   registerAgencyTestEnd,
   checkRequestResult,
@@ -41,6 +41,9 @@ const {
   continueServerWaitOk,
   stopServerWaitFailed,
 } = helper;
+const {
+  allServersHealthy,
+} = lpreds;
 
 function getFailureOracleStatus(url) {
   const status = request.get(`${url}/_admin/cluster/failureOracle/status`);


### PR DESCRIPTION
### Scope & Purpose

The HTTP API to replace the participant of a replicated state did not touch the state's `leader` property. This PR changes this: If the to-be-replaced participant currently is the leader, the API call will also set the leader to be the new participant.

Additional minor changes:

* Fixed a race in `tests/js/server/replication2/replication2-regression.js` / `testFailedServerDoesNotPreventProgress`
* Moved log predicates into their own file `replicated-logs-predicates.js`

- [X] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [X] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [X] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*
  - [ ] Backport for 3.7: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

