### PR TITLE
[CINFRA-343] EvictLeaderAction considered harmful

### DIFF
--- a/arangod/Replication2/ReplicatedLog/Supervision.cpp
+++ b/arangod/Replication2/ReplicatedLog/Supervision.cpp
@@ -480,12 +480,10 @@ auto checkReplicatedLog(LogTarget const& target,
   if (auto maybeParticipant = getRemovedParticipant(
           target.participants, plan.participantsConfig.participants)) {
     auto const& [participantId, planFlags] = *maybeParticipant;
-    // The removed participant is currently the leader
-    if (participantId == leader.serverId) {
-      return EvictLeaderAction{};
-    } else if (not planFlags.allowedInQuorum and
-               current.leader->committedParticipantsConfig->generation ==
-                   plan.participantsConfig.generation) {
+
+    if (not planFlags.allowedInQuorum and
+        current.leader->committedParticipantsConfig->generation ==
+            plan.participantsConfig.generation) {
       return RemoveParticipantFromPlanAction(participantId);
     } else if (planFlags.allowedInQuorum) {
       // make this server not allowed in quorum. If the generation is committed

--- a/arangod/Replication2/ReplicatedLog/SupervisionAction.h
+++ b/arangod/Replication2/ReplicatedLog/SupervisionAction.h
@@ -265,26 +265,6 @@ auto inspect(Inspector& f, DictateLeaderFailedAction& x) {
                             f.field("message", x._message));
 }
 
-struct EvictLeaderAction {
-  static constexpr std::string_view name = "EvictLeaderAction";
-
-  auto execute(ActionContext& ctx) const -> void {
-    ctx.modifyPlan([&](LogPlanSpecification& plan) {
-      plan.participantsConfig.participants
-          .at(plan.currentTerm->leader->serverId)
-          .allowedAsLeader = false;
-      plan.participantsConfig.generation += 1;
-      plan.currentTerm->term = LogTerm{plan.currentTerm->term.value + 1};
-      plan.currentTerm->leader.reset();
-    });
-  }
-};
-template<typename Inspector>
-auto inspect(Inspector& f, EvictLeaderAction& x) {
-  auto hack = std::string{x.name};
-  return f.object(x).fields(f.field("type", hack));
-}
-
 struct WriteEmptyTermAction {
   static constexpr std::string_view name = "WriteEmptyTermAction";
   LogTerm minTerm;
@@ -523,11 +503,11 @@ auto inspect(Inspector& f, ConvergedToTargetAction& x) {
 using Action = std::variant<
     EmptyAction, ErrorAction, AddLogToPlanAction, CreateInitialTermAction,
     CurrentNotAvailableAction, DictateLeaderAction, DictateLeaderFailedAction,
-    EvictLeaderAction, WriteEmptyTermAction, LeaderElectionAction,
-    LeaderElectionImpossibleAction, LeaderElectionOutOfBoundsAction,
-    LeaderElectionQuorumNotReachedAction, UpdateParticipantFlagsAction,
-    AddParticipantToPlanAction, RemoveParticipantFromPlanAction,
-    UpdateLogConfigAction, ConvergedToTargetAction>;
+    WriteEmptyTermAction, LeaderElectionAction, LeaderElectionImpossibleAction,
+    LeaderElectionOutOfBoundsAction, LeaderElectionQuorumNotReachedAction,
+    UpdateParticipantFlagsAction, AddParticipantToPlanAction,
+    RemoveParticipantFromPlanAction, UpdateLogConfigAction,
+    ConvergedToTargetAction>;
 
 auto execute(Action const& action, DatabaseID const& dbName, LogId const& log,
              std::optional<LogPlanSpecification> plan,


### PR DESCRIPTION
### Scope & Purpose

Remove `EvictLeaderAction` as it simulated a failed leader by just removing the leader from the Plan.

This is harmful and was due to my earlier lack of understanding of replicated logs.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [x] Tests
  - [ ] **Regression tests**
  - [x] C++ **Unit tests**
  - [x] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*
  - [ ] Backport for 3.7: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

