### PR TITLE
[CINFRA-344] Remove Multiple Participants

### DIFF
--- a/arangod/Replication2/ReplicatedLog/Supervision.cpp
+++ b/arangod/Replication2/ReplicatedLog/Supervision.cpp
@@ -480,12 +480,10 @@ auto checkReplicatedLog(LogTarget const& target,
   if (auto maybeParticipant = getRemovedParticipant(
           target.participants, plan.participantsConfig.participants)) {
     auto const& [participantId, planFlags] = *maybeParticipant;
-    // The removed participant is currently the leader
-    if (participantId == leader.serverId) {
-      return EvictLeaderAction{};
-    } else if (not planFlags.allowedInQuorum and
-               current.leader->committedParticipantsConfig->generation ==
-                   plan.participantsConfig.generation) {
+
+    if (not planFlags.allowedInQuorum and
+        current.leader->committedParticipantsConfig->generation ==
+            plan.participantsConfig.generation) {
       return RemoveParticipantFromPlanAction(participantId);
     } else if (planFlags.allowedInQuorum) {
       // make this server not allowed in quorum. If the generation is committed

--- a/arangod/Replication2/ReplicatedLog/Supervision.cpp
+++ b/arangod/Replication2/ReplicatedLog/Supervision.cpp
@@ -493,42 +493,38 @@ auto checkReplicatedLog(LogTarget const& target,
   }
 
   // If a participant is in Plan but not in Target, gracefully
-  // remove them
+  // remove it
   if (auto maybeParticipant = getRemovedParticipant(
           target.participants, plan.participantsConfig.participants)) {
     auto const& [participantId, planFlags] = *maybeParticipant;
 
-    if (participantId == leader.serverId) {
-      // do not remove the leader (yet)
-    } else
-
+    // We do not ever remove a leader
+    if (participantId != leader.serverId) {
       // If the participant is not allowed in Quorum it is safe to remove it
       if (not planFlags.allowedInQuorum and
           current.leader->committedParticipantsConfig->generation ==
               plan.participantsConfig.generation) {
         return RemoveParticipantFromPlanAction(participantId);
-      } else
-        // if the participant is allowed in a quorum, first prevent it
-        // from being in a quorum
-        if (planFlags.allowedInQuorum) {
-          // make this server not allowed in quorum. If the generation is
-          // committed
-          auto newFlags = planFlags;
-          newFlags.allowedInQuorum = false;
-          return UpdateParticipantFlagsAction(participantId, newFlags);
-        } else {
-          // still waiting
-          return EmptyAction("Waiting for participants config to be committed");
-        }
+      } else if (planFlags.allowedInQuorum) {
+        // A participant can only be removed without risk,
+        // if it is not member of any quorum
+        auto newFlags = planFlags;
+        newFlags.allowedInQuorum = false;
+        return UpdateParticipantFlagsAction(participantId, newFlags);
+      } else {
+        // still waiting
+        return EmptyAction("Waiting for participants config to be committed");
+      }
+    }
   }
 
   // If the participant who is leader has been removed from target,
   // gracefully remove it by selecting a different eligible participant
   // as leader
   //
-  // At this point there should only ever be precisely one participant to remove
-  // (the current leader); Once it is not the leader anymore
-  // it will be disallowd from any quorum above.
+  // At this point there should only ever be precisely one participant to
+  // remove (the current leader); Once it is not the leader anymore it will be
+  // disallowed from any quorum above.
   if (!target.participants.contains(leader.serverId)) {
     return dictateLeader(target, plan, current, health);
   }

--- a/arangod/Replication2/ReplicatedLog/Supervision.cpp
+++ b/arangod/Replication2/ReplicatedLog/Supervision.cpp
@@ -561,31 +561,6 @@ auto checkReplicatedLog(LogTarget const& target,
     }
   }
 
-<<<<<<< HEAD
-=======
-  // If a participant is in Plan but not in Target, gracefully
-  // remove them
-  if (auto maybeParticipant = getRemovedParticipant(
-          target.participants, plan.participantsConfig.participants)) {
-    auto const& [participantId, planFlags] = *maybeParticipant;
-
-    if (not planFlags.allowedInQuorum and
-        current.leader->committedParticipantsConfig->generation ==
-            plan.participantsConfig.generation) {
-      return RemoveParticipantFromPlanAction(participantId);
-    } else if (planFlags.allowedInQuorum) {
-      // make this server not allowed in quorum. If the generation is
-      // committed
-      auto newFlags = planFlags;
-      newFlags.allowedInQuorum = false;
-      return UpdateParticipantFlagsAction(participantId, newFlags);
-    } else {
-      // still waiting
-      return EmptyAction("Waiting for participants config to be committed");
-    }
-  }
-
->>>>>>> devel
   // If the configuration differs between Target and Plan,
   // apply the new configuration.
   //

--- a/arangod/Replication2/ReplicatedLog/SupervisionAction.h
+++ b/arangod/Replication2/ReplicatedLog/SupervisionAction.h
@@ -265,26 +265,6 @@ auto inspect(Inspector& f, DictateLeaderFailedAction& x) {
                             f.field("message", x._message));
 }
 
-struct EvictLeaderAction {
-  static constexpr std::string_view name = "EvictLeaderAction";
-
-  auto execute(ActionContext& ctx) const -> void {
-    ctx.modifyPlan([&](LogPlanSpecification& plan) {
-      plan.participantsConfig.participants
-          .at(plan.currentTerm->leader->serverId)
-          .allowedAsLeader = false;
-      plan.participantsConfig.generation += 1;
-      plan.currentTerm->term = LogTerm{plan.currentTerm->term.value + 1};
-      plan.currentTerm->leader.reset();
-    });
-  }
-};
-template<typename Inspector>
-auto inspect(Inspector& f, EvictLeaderAction& x) {
-  auto hack = std::string{x.name};
-  return f.object(x).fields(f.field("type", hack));
-}
-
 struct WriteEmptyTermAction {
   static constexpr std::string_view name = "WriteEmptyTermAction";
   LogTerm minTerm;
@@ -523,11 +503,11 @@ auto inspect(Inspector& f, ConvergedToTargetAction& x) {
 using Action = std::variant<
     EmptyAction, ErrorAction, AddLogToPlanAction, CreateInitialTermAction,
     CurrentNotAvailableAction, DictateLeaderAction, DictateLeaderFailedAction,
-    EvictLeaderAction, WriteEmptyTermAction, LeaderElectionAction,
-    LeaderElectionImpossibleAction, LeaderElectionOutOfBoundsAction,
-    LeaderElectionQuorumNotReachedAction, UpdateParticipantFlagsAction,
-    AddParticipantToPlanAction, RemoveParticipantFromPlanAction,
-    UpdateLogConfigAction, ConvergedToTargetAction>;
+    WriteEmptyTermAction, LeaderElectionAction, LeaderElectionImpossibleAction,
+    LeaderElectionOutOfBoundsAction, LeaderElectionQuorumNotReachedAction,
+    UpdateParticipantFlagsAction, AddParticipantToPlanAction,
+    RemoveParticipantFromPlanAction, UpdateLogConfigAction,
+    ConvergedToTargetAction>;
 
 auto execute(Action const& action, DatabaseID const& dbName, LogId const& log,
              std::optional<LogPlanSpecification> plan,

--- a/js/client/modules/@arangodb/testsuites/replication2.js
+++ b/js/client/modules/@arangodb/testsuites/replication2.js
@@ -58,7 +58,7 @@ function replication2Server(options) {
   const testCases = tu.scanTestPaths(testPaths.replication2_server, options);
 
   const opts = _.clone(options);
-  opts.dbServers = Math.max(opts.dbServers, 5);
+  opts.dbServers = Math.max(opts.dbServers, 6);
 
   return new tu.runOnArangodRunner(opts, 'replication2_server', {
     'javascript.allow-external-process-control': 'true',


### PR DESCRIPTION
### Scope & Purpose

This PR reorganises the ReplicatedLog Supervision to execute the adding/removal of participants as follows:

 * If there are participants to be added, add them
 * If there are participants that are *not currently the leader* to remove, phase them out and remove them
 * If the participant that is currently the leader has been removed from Target, it will remain as the last participant; leadership is transfered to a different eligible participant.   

- [x] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*
  - [ ] Backport for 3.7: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

