### PR TITLE
Fixed use-after-scope in SimpleAttributeMatcher

### DIFF
--- a/arangod/ClusterEngine/ClusterIndex.cpp
+++ b/arangod/ClusterEngine/ClusterIndex.cpp
@@ -230,9 +230,10 @@ Index::FilterCosts ClusterIndex::supportsFilterCondition(
             allIndexes, this, node, reference, itemsInIndex);
       }
       // other...
-      SimpleAttributeEqualityMatcher matcher(
-          {{arangodb::basics::AttributeName(StaticStrings::IdString, false)},
-           {arangodb::basics::AttributeName(StaticStrings::KeyString, false)}});
+      std::vector<std::vector<arangodb::basics::AttributeName>> fields{
+          {arangodb::basics::AttributeName(StaticStrings::IdString, false)},
+          {arangodb::basics::AttributeName(StaticStrings::KeyString, false)}};
+      SimpleAttributeEqualityMatcher matcher(fields);
       return matcher.matchOne(this, node, reference, itemsInIndex);
     }
     case TRI_IDX_TYPE_EDGE_INDEX: {


### PR DESCRIPTION
### Scope & Purpose

Detected by ASAN
[https://jenkins.arangodb.biz/job/arangodb-ANY-linux-san.x86-64/1072/EDITION=enterprise,[…]&&test&&x86-64/artifact/aulsan.log.arangodbtests.62224.log](https://jenkins.arangodb.biz/job/arangodb-ANY-linux-san.x86-64/1072/EDITION=enterprise,SAN_MODE=AULSan,STORAGE_ENGINE=rocksdb,TEST_SUITE=single,limit=linux&&test&&x86-64/artifact/aulsan.log.arangodbtests.62224.log)

This code is only applied during our tests.
It is not triggered in Production
=> No Test
=> No Changelog

- [X] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*
  - [ ] Backport for 3.7: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

