### PR TITLE
[CINFRA-345] proper replicated log creation

### DIFF
--- a/arangod/Replication2/Methods.cpp
+++ b/arangod/Replication2/Methods.cpp
@@ -228,7 +228,6 @@ struct ReplicatedLogMethodsCoordinator final
     auto cb = std::make_shared<AgencyCallback>(
         vocbase.server(), path->str(SkipComponents(1)),
         [ctx](velocypack::Slice slice, consensus::index_t index) -> bool {
-          LOG_DEVEL << "callback called with " << slice.toJson();
           if (slice.isNone()) {
             return false;
           }

--- a/arangod/Replication2/Methods.h
+++ b/arangod/Replication2/Methods.h
@@ -57,15 +57,30 @@ struct WaitForResult;
  * request to the leader.
  */
 struct ReplicatedLogMethods {
+  virtual ~ReplicatedLogMethods() = default;
+
   static constexpr auto kDefaultLimit = std::size_t{10};
 
   using GenericLogStatus =
       std::variant<replication2::replicated_log::LogStatus,
                    replication2::replicated_log::GlobalStatus>;
 
-  virtual ~ReplicatedLogMethods() = default;
-  virtual auto createReplicatedLog(agency::LogTarget spec) const
-      -> futures::Future<Result> = 0;
+  struct CreateOptions {
+    bool waitForReady{true};
+    std::optional<LogId> id;
+    std::optional<LogConfig> config;
+    std::optional<ParticipantId> leader;
+    std::vector<ParticipantId> servers;
+  };
+
+  struct CreateResult {
+    LogId id;
+    std::vector<ParticipantId> servers;
+  };
+
+  virtual auto createReplicatedLog(CreateOptions spec) const
+      -> futures::Future<ResultT<CreateResult>> = 0;
+
   virtual auto deleteReplicatedLog(LogId id) const
       -> futures::Future<Result> = 0;
   virtual auto getReplicatedLogs() const
@@ -111,9 +126,34 @@ struct ReplicatedLogMethods {
 
   virtual auto release(LogId, LogIndex) const -> futures::Future<Result> = 0;
 
+  /*
+   * Wait until the supervision reports that the replicated log has converged
+   * to the given version.
+   */
+  [[nodiscard]] virtual auto waitForLogReady(LogId, std::uint64_t version) const
+      -> futures::Future<ResultT<consensus::index_t>> = 0;
+
   static auto createInstance(TRI_vocbase_t& vocbase)
       -> std::shared_ptr<ReplicatedLogMethods>;
+
+ private:
+  virtual auto createReplicatedLog(agency::LogTarget spec) const
+      -> futures::Future<Result> = 0;
 };
+
+template<class Inspector>
+auto inspect(Inspector& f, ReplicatedLogMethods::CreateOptions& x) {
+  return f.object(x).fields(
+      f.field("waitForReady", x.waitForReady).fallback(true),
+      f.field("id", x.id), f.field("config", x.config),
+      f.field("leader", x.leader),
+      f.field("servers", x.servers).fallback(std::vector<ParticipantId>{}));
+}
+
+template<class Inspector>
+auto inspect(Inspector& f, ReplicatedLogMethods::CreateResult& x) {
+  return f.object(x).fields(f.field("id", x.id), f.field("servers", x.servers));
+}
 
 struct ReplicatedStateMethods {
   virtual ~ReplicatedStateMethods() = default;

--- a/arangod/Replication2/ReplicatedLog/AgencyLogSpecification.h
+++ b/arangod/Replication2/ReplicatedLog/AgencyLogSpecification.h
@@ -276,6 +276,7 @@ struct LogCurrentSupervision {
   std::optional<uint64_t> targetVersion;
 
   auto toVelocyPack(VPackBuilder&) const -> void;
+  static auto fromVelocyPack(velocypack::Slice) -> LogCurrentSupervision;
 
   LogCurrentSupervision() = default;
   LogCurrentSupervision(from_velocypack_t, VPackSlice slice);

--- a/arangod/Replication2/ReplicatedLog/Supervision.cpp
+++ b/arangod/Replication2/ReplicatedLog/Supervision.cpp
@@ -558,7 +558,9 @@ auto checkReplicatedLog(LogTarget const& target,
     return UpdateLogConfigAction(target.config);
   }
 
-  if (target.version != current.supervision->targetVersion) {
+  if (target.version.has_value() &&
+      (!current.supervision.has_value() ||
+       target.version != current.supervision->targetVersion)) {
     return ConvergedToTargetAction{target.version};
   } else {
     // Note that if we converged and the version is the same this ends up

--- a/arangod/Replication2/ReplicatedLog/SupervisionAction.cpp
+++ b/arangod/Replication2/ReplicatedLog/SupervisionAction.cpp
@@ -70,7 +70,10 @@ auto execute(Action const& action, DatabaseID const& dbName, LogId const& log,
     return envelope;
   }
 
-  return envelope.write()
+  return envelope
+      .write()
+      // this is here to trigger all waitForPlan, even if we only
+      // update current.
       .inc(paths::plan()->version()->str())
       .cond(ctx.hasPlanModification(),
             [&](arangodb::agency::envelope::write_trx&& trx) {

--- a/arangod/Replication2/ReplicatedLog/SupervisionAction.cpp
+++ b/arangod/Replication2/ReplicatedLog/SupervisionAction.cpp
@@ -71,14 +71,13 @@ auto execute(Action const& action, DatabaseID const& dbName, LogId const& log,
   }
 
   return envelope.write()
+      .inc(paths::plan()->version()->str())
       .cond(ctx.hasPlanModification(),
             [&](arangodb::agency::envelope::write_trx&& trx) {
-              return std::move(trx)
-                  .emplace_object(planPath,
-                                  [&](VPackBuilder& builder) {
-                                    ctx.getPlan().toVelocyPack(builder);
-                                  })
-                  .inc(paths::plan()->version()->str());
+              return std::move(trx).emplace_object(
+                  planPath, [&](VPackBuilder& builder) {
+                    ctx.getPlan().toVelocyPack(builder);
+                  });
             })
       .cond(ctx.hasCurrentModification(),
             [&](arangodb::agency::envelope::write_trx&& trx) {

--- a/js/client/modules/@arangodb/arango-database.js
+++ b/js/client/modules/@arangodb/arango-database.js
@@ -511,7 +511,7 @@ ArangoDatabase.prototype._create = function (name, properties, type, options) {
 ArangoDatabase.prototype._createReplicatedLog = function (spec) {
   let requestResult = this._connection.POST(this._replicatedlogurl(), spec);
   arangosh.checkRequestResult(requestResult);
-  return new ArangoReplicatedLog(this, spec.id);
+  return new ArangoReplicatedLog(this, requestResult.result.id);
 };
 
 // //////////////////////////////////////////////////////////////////////////////

--- a/tests/js/common/shell/shell-replicated-logs-cluster.js
+++ b/tests/js/common/shell/shell-replicated-logs-cluster.js
@@ -62,10 +62,6 @@ function ReplicatedLogsCreateSuite() {
 
   return {
     setUpAll, tearDownAll,
-    setUp: function () {
-    },
-    tearDown: function () {
-    },
 
     testCreateAndDropReplicatedLog: function () {
       const logId = 12;
@@ -85,8 +81,6 @@ function ReplicatedLogsCreateSuite() {
     testCreateNoId: function () {
       const log = db._createReplicatedLog({config});
       assertEqual(log.id(), db._replicatedLog(log.id()).id());
-      const status = log.status();
-      console.log(status);
     },
   };
 }
@@ -130,7 +124,6 @@ function ReplicatedLogsWriteSuite() {
     setUpAll, tearDownAll,
     setUp: function () {
       log = db._createReplicatedLog({config});
-      print(log.id());
     },
     tearDown: function () {
       db._replicatedLog(log.id()).drop();
@@ -263,14 +256,11 @@ function ReplicatedLogsWriteSuite() {
         assertTrue(next > index);
         index = next;
       }
-      print("first poll");
       let s = log.poll();
-      print("first poll - after");
       assertEqual(s.length, 9);
       assertEqual(s[0].logIndex, 1);
       assertEqual(s[8].logIndex, 9);
       s = log.poll(50, 10);
-      print("second poll - after");
       assertEqual(s.length, 10);
       for (let i = 0; i < 10; i++) {
         assertEqual(s[i].logIndex, 50 + i);

--- a/tests/js/server/replication2/replication2-replicated-log-create-api-cluster.js
+++ b/tests/js/server/replication2/replication2-replicated-log-create-api-cluster.js
@@ -1,0 +1,91 @@
+/*jshint strict: true */
+/*global assertTrue, assertEqual*/
+'use strict';
+
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2021 ArangoDB GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License")
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Lars Maier
+////////////////////////////////////////////////////////////////////////////////
+const jsunity = require('jsunity');
+const arangodb = require("@arangodb");
+const _ = require('lodash');
+const {db} = arangodb;
+const lh = require("@arangodb/testutils/replicated-logs-helper");
+
+const database = "replication2_entry_test_db_create";
+
+const replicatedLogCreateSuite = function () {
+  const targetConfig = {
+    writeConcern: 2,
+    softWriteConcern: 2,
+    replicationFactor: 3,
+    waitForSync: false,
+  };
+
+  const {setUpAll, tearDownAll} = (function () {
+    let previousDatabase, databaseExisted = true;
+    return {
+      setUpAll: function () {
+        previousDatabase = db._name();
+        if (!_.includes(db._databases(), database)) {
+          db._createDatabase(database);
+          databaseExisted = false;
+        }
+        db._useDatabase(database);
+      },
+
+      tearDownAll: function () {
+        db._useDatabase(previousDatabase);
+        if (!databaseExisted) {
+          db._dropDatabase(database);
+        }
+      }
+    };
+  }());
+
+  return {
+    setUpAll, tearDownAll,
+    setUp: lh.registerAgencyTestBegin,
+    tearDown: lh.registerAgencyTestEnd,
+
+    testCreateWithExplicitId: function () {
+      const logId = lh.nextUniqueLogId();
+      const log = db._createReplicatedLog({id: logId, config: targetConfig});
+      assertEqual(logId, log.id());
+    },
+
+    testCreateWithExplicitLeader: function () {
+      const leader = _.sample(lh.dbservers);
+      const log = db._createReplicatedLog({leader, config: targetConfig});
+      const status = log.status();
+      assertEqual(status.leaderId, leader);
+    },
+
+    testCreateWithExplicitServers: function () {
+      const servers = _.sampleSize(lh.dbservers, 3);
+      const log = db._createReplicatedLog({servers, config: targetConfig});
+      const status = log.status();
+      assertEqual(Object.keys(status.participants).sort(), servers.sort());
+    },
+  };
+};
+
+jsunity.run(replicatedLogCreateSuite);
+return jsunity.done();


### PR DESCRIPTION
### Scope & Purpose

Better log creation api. The old api expected a log id to be specified. The new api selects it randomly but uniquely. You can also specify if you want to wait for the log to be finished. (which is now default)

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [x] **integration tests**
  - [ ] **resilience tests**
