### PR TITLE
fix global buffer overflow in minizip after zlib upgrade

### DIFF
--- a/lib/Zip/crypt.h
+++ b/lib/Zip/crypt.h
@@ -32,8 +32,7 @@
 /***********************************************************************
  * Return the next byte in the pseudo-random sequence
  */
-static int decrypt_byte(unsigned long* pkeys,
-                        const unsigned long* pcrc_32_tab) {
+static int decrypt_byte(unsigned long* pkeys, const z_crc_t* pcrc_32_tab) {
   unsigned temp; /* POTENTIAL BUG:  temp*(temp^1) may overflow in an
                   * unpredictable manner on 16-bit systems; not a problem
                   * with any known compiler so far, though */
@@ -45,7 +44,7 @@ static int decrypt_byte(unsigned long* pkeys,
 /***********************************************************************
  * Update the encryption keys with the next byte of plain text
  */
-static int update_keys(unsigned long* pkeys, const unsigned long* pcrc_32_tab,
+static int update_keys(unsigned long* pkeys, const z_crc_t* pcrc_32_tab,
                        int c) {
   (*(pkeys + 0)) = CRC32((*(pkeys + 0)), c);
   (*(pkeys + 1)) += (*(pkeys + 0)) & 0xff;
@@ -62,7 +61,7 @@ static int update_keys(unsigned long* pkeys, const unsigned long* pcrc_32_tab,
  * the given password.
  */
 static void init_keys(char const* passwd, unsigned long* pkeys,
-                      const unsigned long* pcrc_32_tab) {
+                      const z_crc_t* pcrc_32_tab) {
   *(pkeys + 0) = 305419896L;
   *(pkeys + 1) = 591751049L;
   *(pkeys + 2) = 878082192L;
@@ -90,8 +89,7 @@ static void init_keys(char const* passwd, unsigned long* pkeys,
 static int crypthead(char const* passwd, /* password string */
                      unsigned char* buf, /* where to write header */
                      int bufSize, unsigned long* pkeys,
-                     const unsigned long* pcrc_32_tab,
-                     unsigned long crcForCrypting) {
+                     const z_crc_t* pcrc_32_tab, unsigned long crcForCrypting) {
   int n;                                   /* index in random header */
   int t;                                   /* temporary */
   int c;                                   /* random byte */

--- a/lib/Zip/unzip.cpp
+++ b/lib/Zip/unzip.cpp
@@ -188,7 +188,7 @@ typedef struct {
 
 #ifndef NOUNCRYPT
   unsigned long keys[3]; /* keys defining the pseudo-random sequence */
-  const unsigned long* pcrc_32_tab;
+  const z_crc_t* pcrc_32_tab;
 #endif
 } unz64_s;
 
@@ -1514,7 +1514,7 @@ extern int ZEXPORT unzOpenCurrentFile3(unzFile file, int* method, int* level,
 #ifndef NOUNCRYPT
   if (password != NULL) {
     int i;
-    s->pcrc_32_tab = (unsigned long*)get_crc_table();
+    s->pcrc_32_tab = get_crc_table();
     init_keys(password, s->keys, s->pcrc_32_tab);
     if (ZSEEK64(s->z_filefunc, s->filestream,
                 s->pfile_in_zip_read->pos_in_zipfile +

--- a/lib/Zip/zip.cpp
+++ b/lib/Zip/zip.cpp
@@ -164,7 +164,7 @@ typedef struct {
   ZPOS64_T totalUncompressedData;
 #ifndef NOCRYPT
   unsigned long keys[3]; /* keys defining the pseudo-random sequence */
-  const unsigned long* pcrc_32_tab;
+  const z_crc_t* pcrc_32_tab;
   int crypt_header_size;
 #endif
 } curfile64_info;
@@ -1263,7 +1263,7 @@ extern int ZEXPORT zipOpenNewFileInZip4_64(
     unsigned char bufHead[RAND_HEAD_LEN];
     unsigned int sizeHead;
     zi->ci.encrypt = 1;
-    zi->ci.pcrc_32_tab = (unsigned long*)get_crc_table();
+    zi->ci.pcrc_32_tab = get_crc_table();
     /*init_keys(password,zi->ci.keys,zi->ci.pcrc_32_tab);*/
 
     sizeHead = crypthead(password, bufHead, RAND_HEAD_LEN, zi->ci.keys,


### PR DESCRIPTION
### Scope & Purpose

fix global buffer overflow in minizip after zlib upgrade

minizip is a contribution to zlib, and needs to be updated in sync with a zlib library update. 
This PR updates our version of minizip so that the overflow is fixed.
We only upgraded zlib in devel recently (for good reasons), so this bugfix does not need to be backported.

The overflow was detected by ASan builds and according to a local ASan run, is now fixed.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -
  - [ ] Backport for 3.7: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 