### PR TITLE
[CINFRA-305] Refactor Leader Selection

### DIFF
--- a/arangod/Replication2/ReplicatedLog/Supervision.cpp
+++ b/arangod/Replication2/ReplicatedLog/Supervision.cpp
@@ -498,26 +498,22 @@ auto checkReplicatedLog(LogTarget const& target,
 
     if (participantId == leader.serverId) {
       // do not remove the leader (yet)
-    } else
-
-      // If the participant is not allowed in Quorum it is safe to remove it
-      if (not planFlags.allowedInQuorum and
-          current.leader->committedParticipantsConfig->generation ==
-              plan.participantsConfig.generation) {
-        return RemoveParticipantFromPlanAction(participantId);
-      } else
-        // if the participant is allowed in a quorum, first prevent it
-        // from being in a quorum
-        if (planFlags.allowedInQuorum) {
-          // make this server not allowed in quorum. If the generation is
-          // committed
-          auto newFlags = planFlags;
-          newFlags.allowedInQuorum = false;
-          return UpdateParticipantFlagsAction(participantId, newFlags);
-        } else {
-          // still waiting
-          return EmptyAction("Waiting for participants config to be committed");
-        }
+    } else if (not planFlags.allowedInQuorum and
+               current.leader->committedParticipantsConfig->generation ==
+                   plan.participantsConfig.generation) {
+      // If the participant is not allowed in any quorum it is safe to
+      // remove it
+      return RemoveParticipantFromPlanAction(participantId);
+    } else if (planFlags.allowedInQuorum) {
+      // if the participant is allowed in a quorum, first prevent it
+      // from being in a quorum
+      auto newFlags = planFlags;
+      newFlags.allowedInQuorum = false;
+      return UpdateParticipantFlagsAction(participantId, newFlags);
+    } else {
+      // still waiting
+      return EmptyAction("Waiting for participants config to be committed");
+    }
   }
 
   // If the participant who is leader has been removed from target,
@@ -529,19 +525,6 @@ auto checkReplicatedLog(LogTarget const& target,
   // it will be disallowd from any quorum above.
   if (!target.participants.contains(leader.serverId)) {
     return switchLeader(target, plan, current, health);
-  }
-
-  // If the user has updated flags for a participant, which is detected by
-  // comparing Target to Plan, write that change to Plan.
-  // TODO: This function currently forces a participant if it is set
-  //       as desired leader in Target, and this isn't obvious at all.
-  //       This should be moved to a separate action that overrides that
-  //       particular field for the desired leader.
-  if (auto participantFlags = getParticipantWithUpdatedFlags(
-          target.participants, plan.participantsConfig.participants,
-          target.leader, leader.serverId)) {
-    return UpdateParticipantFlagsAction(participantFlags->first,
-                                        participantFlags->second);
   }
 
   // Check whether a specific participant is configured in Target to become
@@ -557,6 +540,19 @@ auto checkReplicatedLog(LogTarget const& target,
     } else {
       // TODO!
     }
+  }
+
+  // If the user has updated flags for a participant, which is detected by
+  // comparing Target to Plan, write that change to Plan.
+  // TODO: This function currently forces a participant if it is set
+  //       as desired leader in Target, and this isn't obvious at all.
+  //       This should be moved to a separate action that overrides that
+  //       particular field for the desired leader.
+  if (auto participantFlags = getParticipantWithUpdatedFlags(
+          target.participants, plan.participantsConfig.participants,
+          target.leader, leader.serverId)) {
+    return UpdateParticipantFlagsAction(participantFlags->first,
+                                        participantFlags->second);
   }
 
   // If the configuration differs between Target and Plan,

--- a/arangod/Replication2/ReplicatedLog/Supervision.cpp
+++ b/arangod/Replication2/ReplicatedLog/Supervision.cpp
@@ -480,12 +480,10 @@ auto checkReplicatedLog(LogTarget const& target,
   if (auto maybeParticipant = getRemovedParticipant(
           target.participants, plan.participantsConfig.participants)) {
     auto const& [participantId, planFlags] = *maybeParticipant;
-    // The removed participant is currently the leader
-    if (participantId == leader.serverId) {
-      return EvictLeaderAction{};
-    } else if (not planFlags.allowedInQuorum and
-               current.leader->committedParticipantsConfig->generation ==
-                   plan.participantsConfig.generation) {
+
+    if (not planFlags.allowedInQuorum and
+        current.leader->committedParticipantsConfig->generation ==
+            plan.participantsConfig.generation) {
       return RemoveParticipantFromPlanAction(participantId);
     } else if (planFlags.allowedInQuorum) {
       // make this server not allowed in quorum. If the generation is committed

--- a/arangod/Replication2/ReplicatedLog/Supervision.cpp
+++ b/arangod/Replication2/ReplicatedLog/Supervision.cpp
@@ -561,31 +561,6 @@ auto checkReplicatedLog(LogTarget const& target,
     }
   }
 
-<<<<<<< HEAD
-=======
-  // If a participant is in Plan but not in Target, gracefully
-  // remove them
-  if (auto maybeParticipant = getRemovedParticipant(
-          target.participants, plan.participantsConfig.participants)) {
-    auto const& [participantId, planFlags] = *maybeParticipant;
-
-    if (not planFlags.allowedInQuorum and
-        current.leader->committedParticipantsConfig->generation ==
-            plan.participantsConfig.generation) {
-      return RemoveParticipantFromPlanAction(participantId);
-    } else if (planFlags.allowedInQuorum) {
-      // make this server not allowed in quorum. If the generation is
-      // committed
-      auto newFlags = planFlags;
-      newFlags.allowedInQuorum = false;
-      return UpdateParticipantFlagsAction(participantId, newFlags);
-    } else {
-      // still waiting
-      return EmptyAction("Waiting for participants config to be committed");
-    }
-  }
-
->>>>>>> devel
   // If the configuration differs between Target and Plan,
   // apply the new configuration.
   //

--- a/arangod/Replication2/ReplicatedLog/Supervision.h
+++ b/arangod/Replication2/ReplicatedLog/Supervision.h
@@ -41,50 +41,50 @@ namespace arangodb::replication2::replicated_log {
 using LogCurrentLocalStates =
     std::unordered_map<ParticipantId, LogCurrentLocalState>;
 
-auto isLeaderFailed(LogPlanTermSpecification::Leader const& leader,
-                    ParticipantsHealth const& health) -> bool;
+auto isLeaderFailed(LogPlanTermSpecification::Leader const &leader,
+                    ParticipantsHealth const &health) -> bool;
 
-auto getAddedParticipant(ParticipantsFlagsMap const& target,
-                         ParticipantsFlagsMap const& plan)
+auto getAddedParticipant(ParticipantsFlagsMap const &target,
+                         ParticipantsFlagsMap const &plan)
     -> std::optional<std::pair<ParticipantId, ParticipantFlags>>;
 
-auto getRemovedParticipant(ParticipantsFlagsMap const& target,
-                           ParticipantsFlagsMap const& plan)
+auto getRemovedParticipant(ParticipantsFlagsMap const &target,
+                           ParticipantsFlagsMap const &plan)
     -> std::optional<std::pair<ParticipantId, ParticipantFlags>>;
 
 auto getParticipantWithUpdatedFlags(
-    ParticipantsFlagsMap const& targetParticipants,
-    ParticipantsFlagsMap const& planParticipants,
-    std::optional<ParticipantId> const& targetLeader,
-    ParticipantId const& currentTermLeader)
+    ParticipantsFlagsMap const &targetParticipants,
+    ParticipantsFlagsMap const &planParticipants,
+    std::optional<ParticipantId> const &targetLeader,
+    ParticipantId const &currentTermLeader)
     -> std::optional<std::pair<ParticipantId, ParticipantFlags>>;
 
-auto computeReason(LogCurrentLocalState const& status, bool healthy,
+auto computeReason(LogCurrentLocalState const &status, bool healthy,
                    bool excluded, LogTerm term)
     -> LogCurrentSupervisionElection::ErrorCode;
 
-auto runElectionCampaign(LogCurrentLocalStates const& states,
-                         ParticipantsConfig const& participantsConfig,
-                         ParticipantsHealth const& health, LogTerm term)
+auto runElectionCampaign(LogCurrentLocalStates const &states,
+                         ParticipantsConfig const &participantsConfig,
+                         ParticipantsHealth const &health, LogTerm term)
     -> LogCurrentSupervisionElection;
 
-auto doLeadershipElection(LogPlanSpecification const& plan,
-                          LogCurrent const& current,
-                          ParticipantsHealth const& health) -> Action;
+auto doLeadershipElection(LogPlanSpecification const &plan,
+                          LogCurrent const &current,
+                          ParticipantsHealth const &health) -> Action;
 
 auto getParticipantsAcceptableAsLeaders(
-    ParticipantId const& currentLeader,
-    ParticipantsFlagsMap const& participants) -> std::vector<ParticipantId>;
+    ParticipantId const &currentLeader,
+    ParticipantsFlagsMap const &participants) -> std::vector<ParticipantId>;
 
-auto dictateLeader(LogTarget const& target, LogPlanSpecification const& plan,
-                   LogCurrent const& current, ParticipantsHealth const& health)
+auto switchLeader(LogTarget const &target, LogPlanSpecification const &plan,
+                  LogCurrent const &current, ParticipantsHealth const &health)
     -> Action;
 
 // Actions capture entries in log, so they have to stay
 // valid until the returned action has been executed (or discarded)
-auto checkReplicatedLog(LogTarget const& target,
-                        std::optional<LogPlanSpecification> const& plan,
-                        std::optional<LogCurrent> const& current,
-                        ParticipantsHealth const& health) -> Action;
+auto checkReplicatedLog(LogTarget const &target,
+                        std::optional<LogPlanSpecification> const &plan,
+                        std::optional<LogCurrent> const &current,
+                        ParticipantsHealth const &health) -> Action;
 
-}  // namespace arangodb::replication2::replicated_log
+} // namespace arangodb::replication2::replicated_log

--- a/arangod/Replication2/ReplicatedLog/Supervision.h
+++ b/arangod/Replication2/ReplicatedLog/Supervision.h
@@ -41,50 +41,50 @@ namespace arangodb::replication2::replicated_log {
 using LogCurrentLocalStates =
     std::unordered_map<ParticipantId, LogCurrentLocalState>;
 
-auto isLeaderFailed(LogPlanTermSpecification::Leader const &leader,
-                    ParticipantsHealth const &health) -> bool;
+auto isLeaderFailed(LogPlanTermSpecification::Leader const& leader,
+                    ParticipantsHealth const& health) -> bool;
 
-auto getAddedParticipant(ParticipantsFlagsMap const &target,
-                         ParticipantsFlagsMap const &plan)
+auto getAddedParticipant(ParticipantsFlagsMap const& target,
+                         ParticipantsFlagsMap const& plan)
     -> std::optional<std::pair<ParticipantId, ParticipantFlags>>;
 
-auto getRemovedParticipant(ParticipantsFlagsMap const &target,
-                           ParticipantsFlagsMap const &plan)
+auto getRemovedParticipant(ParticipantsFlagsMap const& target,
+                           ParticipantsFlagsMap const& plan)
     -> std::optional<std::pair<ParticipantId, ParticipantFlags>>;
 
 auto getParticipantWithUpdatedFlags(
-    ParticipantsFlagsMap const &targetParticipants,
-    ParticipantsFlagsMap const &planParticipants,
-    std::optional<ParticipantId> const &targetLeader,
-    ParticipantId const &currentTermLeader)
+    ParticipantsFlagsMap const& targetParticipants,
+    ParticipantsFlagsMap const& planParticipants,
+    std::optional<ParticipantId> const& targetLeader,
+    ParticipantId const& currentTermLeader)
     -> std::optional<std::pair<ParticipantId, ParticipantFlags>>;
 
-auto computeReason(LogCurrentLocalState const &status, bool healthy,
+auto computeReason(LogCurrentLocalState const& status, bool healthy,
                    bool excluded, LogTerm term)
     -> LogCurrentSupervisionElection::ErrorCode;
 
-auto runElectionCampaign(LogCurrentLocalStates const &states,
-                         ParticipantsConfig const &participantsConfig,
-                         ParticipantsHealth const &health, LogTerm term)
+auto runElectionCampaign(LogCurrentLocalStates const& states,
+                         ParticipantsConfig const& participantsConfig,
+                         ParticipantsHealth const& health, LogTerm term)
     -> LogCurrentSupervisionElection;
 
-auto doLeadershipElection(LogPlanSpecification const &plan,
-                          LogCurrent const &current,
-                          ParticipantsHealth const &health) -> Action;
+auto doLeadershipElection(LogPlanSpecification const& plan,
+                          LogCurrent const& current,
+                          ParticipantsHealth const& health) -> Action;
 
 auto getParticipantsAcceptableAsLeaders(
-    ParticipantId const &currentLeader,
-    ParticipantsFlagsMap const &participants) -> std::vector<ParticipantId>;
+    ParticipantId const& currentLeader,
+    ParticipantsFlagsMap const& participants) -> std::vector<ParticipantId>;
 
-auto switchLeader(LogTarget const &target, LogPlanSpecification const &plan,
-                  LogCurrent const &current, ParticipantsHealth const &health)
+auto switchLeader(LogTarget const& target, LogPlanSpecification const& plan,
+                  LogCurrent const& current, ParticipantsHealth const& health)
     -> Action;
 
 // Actions capture entries in log, so they have to stay
 // valid until the returned action has been executed (or discarded)
-auto checkReplicatedLog(LogTarget const &target,
-                        std::optional<LogPlanSpecification> const &plan,
-                        std::optional<LogCurrent> const &current,
-                        ParticipantsHealth const &health) -> Action;
+auto checkReplicatedLog(LogTarget const& target,
+                        std::optional<LogPlanSpecification> const& plan,
+                        std::optional<LogCurrent> const& current,
+                        ParticipantsHealth const& health) -> Action;
 
-} // namespace arangodb::replication2::replicated_log
+}  // namespace arangodb::replication2::replicated_log

--- a/arangod/Replication2/ReplicatedLog/SupervisionAction.h
+++ b/arangod/Replication2/ReplicatedLog/SupervisionAction.h
@@ -229,10 +229,10 @@ auto inspect(Inspector& f, CurrentNotAvailableAction& x) {
   return f.object(x).fields(f.field("type", hack));
 }
 
-struct DictateLeaderAction {
-  static constexpr std::string_view name = "DictateLeaderAction";
+struct SwitchLeaderAction {
+  static constexpr std::string_view name = "SwitchLeaderAction";
 
-  DictateLeaderAction(LogPlanTermSpecification::Leader const& leader)
+  SwitchLeaderAction(LogPlanTermSpecification::Leader const& leader)
       : _leader{leader} {};
 
   LogPlanTermSpecification::Leader _leader;
@@ -245,16 +245,16 @@ struct DictateLeaderAction {
   }
 };
 template<typename Inspector>
-auto inspect(Inspector& f, DictateLeaderAction& x) {
+auto inspect(Inspector& f, SwitchLeaderAction& x) {
   auto hack = std::string{x.name};
   return f.object(x).fields(f.field("type", hack),
                             f.field("leader", x._leader));
 }
 
-struct DictateLeaderFailedAction {
-  static constexpr std::string_view name = "DictateLeaderFailedAction";
+struct SwitchLeaderFailedAction {
+  static constexpr std::string_view name = "SwitchLeaderFailedAction";
 
-  DictateLeaderFailedAction(std::string const& message) : _message{message} {};
+  SwitchLeaderFailedAction(std::string const& message) : _message{message} {};
 
   std::string _message;
 
@@ -269,7 +269,7 @@ struct DictateLeaderFailedAction {
   }
 };
 template<typename Inspector>
-auto inspect(Inspector& f, DictateLeaderFailedAction& x) {
+auto inspect(Inspector& f, SwitchLeaderFailedAction& x) {
   auto hack = std::string{x.name};
   return f.object(x).fields(f.field("type", hack),
                             f.field("message", x._message));
@@ -512,7 +512,7 @@ auto inspect(Inspector& f, ConvergedToTargetAction& x) {
 
 using Action = std::variant<
     EmptyAction, ErrorAction, AddLogToPlanAction, CreateInitialTermAction,
-    CurrentNotAvailableAction, DictateLeaderAction, DictateLeaderFailedAction,
+    CurrentNotAvailableAction, SwitchLeaderAction, SwitchLeaderFailedAction,
     WriteEmptyTermAction, LeaderElectionAction, LeaderElectionImpossibleAction,
     LeaderElectionOutOfBoundsAction, LeaderElectionQuorumNotReachedAction,
     UpdateParticipantFlagsAction, AddParticipantToPlanAction,

--- a/arangod/Replication2/ReplicatedLog/SupervisionAction.h
+++ b/arangod/Replication2/ReplicatedLog/SupervisionAction.h
@@ -265,26 +265,6 @@ auto inspect(Inspector& f, DictateLeaderFailedAction& x) {
                             f.field("message", x._message));
 }
 
-struct EvictLeaderAction {
-  static constexpr std::string_view name = "EvictLeaderAction";
-
-  auto execute(ActionContext& ctx) const -> void {
-    ctx.modifyPlan([&](LogPlanSpecification& plan) {
-      plan.participantsConfig.participants
-          .at(plan.currentTerm->leader->serverId)
-          .allowedAsLeader = false;
-      plan.participantsConfig.generation += 1;
-      plan.currentTerm->term = LogTerm{plan.currentTerm->term.value + 1};
-      plan.currentTerm->leader.reset();
-    });
-  }
-};
-template<typename Inspector>
-auto inspect(Inspector& f, EvictLeaderAction& x) {
-  auto hack = std::string{x.name};
-  return f.object(x).fields(f.field("type", hack));
-}
-
 struct WriteEmptyTermAction {
   static constexpr std::string_view name = "WriteEmptyTermAction";
   LogTerm minTerm;
@@ -523,11 +503,11 @@ auto inspect(Inspector& f, ConvergedToTargetAction& x) {
 using Action = std::variant<
     EmptyAction, ErrorAction, AddLogToPlanAction, CreateInitialTermAction,
     CurrentNotAvailableAction, DictateLeaderAction, DictateLeaderFailedAction,
-    EvictLeaderAction, WriteEmptyTermAction, LeaderElectionAction,
-    LeaderElectionImpossibleAction, LeaderElectionOutOfBoundsAction,
-    LeaderElectionQuorumNotReachedAction, UpdateParticipantFlagsAction,
-    AddParticipantToPlanAction, RemoveParticipantFromPlanAction,
-    UpdateLogConfigAction, ConvergedToTargetAction>;
+    WriteEmptyTermAction, LeaderElectionAction, LeaderElectionImpossibleAction,
+    LeaderElectionOutOfBoundsAction, LeaderElectionQuorumNotReachedAction,
+    UpdateParticipantFlagsAction, AddParticipantToPlanAction,
+    RemoveParticipantFromPlanAction, UpdateLogConfigAction,
+    ConvergedToTargetAction>;
 
 auto execute(Action const& action, DatabaseID const& dbName, LogId const& log,
              std::optional<LogPlanSpecification> plan,

--- a/tests/Replication2/ReplicatedLog/SupervisionTest.cpp
+++ b/tests/Replication2/ReplicatedLog/SupervisionTest.cpp
@@ -499,9 +499,9 @@ TEST_F(LogSupervisionTest, test_dictate_leader_no_current) {
 
   auto const& health = ParticipantsHealth{._health = {}};
 
-  auto r = dictateLeader(target, plan, current, health);
+  auto r = switchLeader(target, plan, current, health);
 
-  ASSERT_TRUE(std::holds_alternative<DictateLeaderFailedAction>(r))
+  ASSERT_TRUE(std::holds_alternative<SwitchLeaderFailedAction>(r))
       << to_string(r);
 }
 
@@ -546,7 +546,7 @@ TEST_F(LogSupervisionTest, test_dictate_leader_force_first) {
           {"D",
            ParticipantHealth{.rebootId = RebootId{14}, .notIsFailed = true}}}};
 
-  auto r = dictateLeader(target, plan, current, health);
+  auto r = switchLeader(target, plan, current, health);
 
   // Should get an UpdateParticipantsFlagAction for one of the
   // acceptable participants that are acceptable as leaders to
@@ -606,14 +606,14 @@ TEST_F(LogSupervisionTest, test_dictate_leader_success) {
           {"D",
            ParticipantHealth{.rebootId = RebootId{14}, .notIsFailed = true}}}};
 
-  auto r = dictateLeader(target, plan, current, health);
+  auto r = switchLeader(target, plan, current, health);
 
   // Should get an UpdateParticipantsFlagAction for one of the
   // acceptable participants that are acceptable as leaders to
   // become forced
-  ASSERT_TRUE(std::holds_alternative<DictateLeaderAction>(r)) << to_string(r);
+  ASSERT_TRUE(std::holds_alternative<SwitchLeaderAction>(r)) << to_string(r);
 
-  auto action = std::get<DictateLeaderAction>(r);
+  auto action = std::get<SwitchLeaderAction>(r);
 
   ASSERT_EQ(action._leader.serverId, "D");
 }


### PR DESCRIPTION
### Scope & Purpose

Rename `DictateLeader` to `SwitchLeader` and consolidate the switching of leaders that happens due to leader participant removal and the user declaring a leader in target.

Work in progress.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*
  - [ ] Backport for 3.7: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

