### PR TITLE
Slightly simplify explain output

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,11 @@
 devel
 -----
 
+* Only show slowest optimizer rules in explain output for optimizer rules
+  that took a considerable amount of time (>= 0.0002 seconds). Previously
+  the slowest 5 optimizer rules were shown, regardless of how long they
+  took to execute and even if they executed sufficiently fast.
+
 * Updated arangosync to v2.9.0-preview-4.
 
 * Make the StatisticsFeature start after the NetworkFeature, so that any 

--- a/js/common/modules/@arangodb/aql/explainer.js
+++ b/js/common/modules/@arangodb/aql/explainer.js
@@ -257,6 +257,9 @@ function printRules(rules, stats) {
     }
     return { name: key, time: stats.rules[key] };
   });
+  // filter out everything that was reasonably fast
+  times = times.filter((item) => item.time >= 0.0002);
+
   times.sort(function(l, r) {
     // highest cost first
     return r.time - l.time;
@@ -264,13 +267,16 @@ function printRules(rules, stats) {
   // top few only
   times = times.slice(0, 5);
 
-  stringBuilder.appendLine(section('Optimization rules with highest execution times:'));
-  stringBuilder.appendLine(' ' + header('RuleName') + '   ' + pad(maxNameLength - 'RuleName'.length) + header('Duration [s]'));
-  times.forEach(function(rule) {
-    stringBuilder.appendLine(' ' + keyword(rule.name) + '   ' + pad(12 + maxNameLength - rule.name.length - rule.time.toFixed(5).length) + value(rule.time.toFixed(5)));
-  });
+  if (times.length > 0) {
+    stringBuilder.appendLine(section('Optimization rules with highest execution times:'));
+    stringBuilder.appendLine(' ' + header('RuleName') + '   ' + pad(maxNameLength - 'RuleName'.length) + header('Duration [s]'));
+    times.forEach(function(rule) {
+      stringBuilder.appendLine(' ' + keyword(rule.name) + '   ' + pad(12 + maxNameLength - rule.name.length - rule.time.toFixed(5).length) + value(rule.time.toFixed(5)));
+    });
   
-  stringBuilder.appendLine();
+    stringBuilder.appendLine();
+  }
+
   stringBuilder.appendLine(value(stats.rulesExecuted) + annotation(' rule(s) executed, ') + value(stats.plansCreated) + annotation(' plan(s) created'));
   stringBuilder.appendLine();
 }


### PR DESCRIPTION
### Scope & Purpose

* Only show slowest optimizer rules in explain output for optimizer rules
  that took a considerable amount of time (>= 0.0002 seconds). Previously
  the slowest 5 optimizer rules were shown, regardless of how long they
  took to execute and even if they executed sufficiently fast.

This is only a simplification for the explain output and does not need to be backported.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -
  - [ ] Backport for 3.7: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 