### PR TITLE
clang-format: Improve PowerShell wrapper to not open a new window

### DIFF
--- a/scripts/clang-format.ps1
+++ b/scripts/clang-format.ps1
@@ -14,7 +14,8 @@ if (![bool]$git_for_windows.InstallPath) {
     throw 'Could not find Git InstallPath in registry'
 }
 
-$git_bash = Join-Path ($git_for_windows).InstallPath 'git-bash.exe'
+# Using bash.exe because git-bash.exe would open a new window
+$git_bash = Join-Path ($git_for_windows).InstallPath 'bin' 'bash.exe'
 $files = ''
 if ($args.length -gt 0) {
     $files = $args.Replace('\', '/')


### PR DESCRIPTION
Yet another minor follow-up to https://github.com/arangodb/arangodb/pull/15786 that ports b69c2470e682a79de121e61405d641b5842ca20a to 3.9:

Use bash.exe instead of git-bash.exe to stay in the same terminal

