### PR TITLE
[CINFRA-213] Move some logic in a more fitting place

### DIFF
--- a/arangod/Replication2/ReplicatedLog/Algorithms.cpp
+++ b/arangod/Replication2/ReplicatedLog/Algorithms.cpp
@@ -105,26 +105,6 @@ auto algorithms::detectConflict(replicated_log::InMemoryLog const& log,
   }
 }
 
-namespace {
-// For (unordered) maps left and right, return keys(left) \ keys(right)
-auto keySetDifference = [](auto const& left, auto const& right) {
-  using left_t = std::decay_t<decltype(left)>;
-  using right_t = std::decay_t<decltype(right)>;
-  static_assert(
-      std::is_same_v<typename left_t::key_type, typename right_t::key_type>);
-  using key_t = typename left_t::key_type;
-
-  auto result = std::vector<key_t>{};
-  for (auto const& [key, val] : left) {
-    if (!right.contains(key)) {
-      result.emplace_back(key);
-    }
-  }
-
-  return result;
-};
-}  // namespace
-
 auto algorithms::updateReplicatedLog(
     LogActionContext& ctx, ServerID const& myServerId, RebootId myRebootId,
     LogId logId, agency::LogPlanSpecification const* spec,
@@ -147,32 +127,25 @@ auto algorithms::updateReplicatedLog(
       TRI_ASSERT(leader != nullptr);
       auto const status = log->getParticipant()->getStatus();
       auto* const leaderStatus = status.asLeaderStatus();
-      // Note that newParticipants contains the leader, while oldFollowers does
-      // not.
-      auto const& oldFollowers = leaderStatus->follower;
-      auto const& newParticipants = spec->participantsConfig.participants;
-      // TODO move this calculation into updateParticipantsConfig()
-      auto const additionalParticipantIds =
-          keySetDifference(newParticipants, oldFollowers);
-      auto const obsoleteParticipantIds =
-          keySetDifference(oldFollowers, newParticipants);
-
-      auto additionalParticipants =
-          std::unordered_map<ParticipantId,
-                             std::shared_ptr<AbstractFollower>>{};
-      for (auto const& participantId : additionalParticipantIds) {
-        if (participantId != myServerId) {
-          additionalParticipants.try_emplace(
-              participantId,
-              ctx.buildAbstractFollowerImpl(logId, participantId));
-        }
-      }
+      // get the keys of leaderStatus->follower
+      auto const oldFollowerIds = std::invoke([&] {
+        auto result = std::set<ParticipantId>();
+        std::transform(std::begin(leaderStatus->follower),
+                       std::end(leaderStatus->follower),
+                       std::inserter(result, result.end()),
+                       [&](auto const& it) { return it.first; });
+        return result;
+      });
+      // Provide the leader with a way to build a follower
+      auto const buildFollower = [&ctx,
+                                  &logId](ParticipantId const& participantId) {
+        return ctx.buildAbstractFollowerImpl(logId, participantId);
+      };
 
       auto const& previousConfig = leaderStatus->activeParticipantsConfig;
       auto index = leader->updateParticipantsConfig(
           std::make_shared<ParticipantsConfig const>(spec->participantsConfig),
-          previousConfig.generation, std::move(additionalParticipants),
-          obsoleteParticipantIds);
+          previousConfig.generation, oldFollowerIds, buildFollower);
       return leader->waitFor(index).thenValue(
           [](auto&& quorum) -> Result { return Result{TRI_ERROR_NO_ERROR}; });
     } else if (plannedLeader.has_value() &&

--- a/arangod/Replication2/ReplicatedLog/LogLeader.h
+++ b/arangod/Replication2/ReplicatedLog/LogLeader.h
@@ -159,11 +159,11 @@ class LogLeader : public std::enable_shared_from_this<LogLeader>,
 
   // Updates the flags of the participants.
   auto updateParticipantsConfig(
-      std::shared_ptr<ParticipantsConfig const> config,
+      std::shared_ptr<ParticipantsConfig const> const& config,
       std::size_t previousGeneration,
-      std::unordered_map<ParticipantId, std::shared_ptr<AbstractFollower>>
-          additionalFollowers,
-      std::vector<ParticipantId> const& followersToRemove) -> LogIndex;
+      std::set<ParticipantId> const& oldFollowerIds,
+      std::function<std::shared_ptr<replicated_log::AbstractFollower>(
+          ParticipantId const&)> const& buildFollower) -> LogIndex;
 
   // Returns [acceptedConfig.generation, committedConfig.?generation]
   auto getParticipantConfigGenerations() const noexcept

--- a/arangod/Replication2/ReplicatedLog/LogLeader.h
+++ b/arangod/Replication2/ReplicatedLog/LogLeader.h
@@ -160,8 +160,6 @@ class LogLeader : public std::enable_shared_from_this<LogLeader>,
   // Updates the flags of the participants.
   auto updateParticipantsConfig(
       std::shared_ptr<ParticipantsConfig const> const& config,
-      std::size_t previousGeneration,
-      std::set<ParticipantId> const& oldFollowerIds,
       std::function<std::shared_ptr<replicated_log::AbstractFollower>(
           ParticipantId const&)> const& buildFollower) -> LogIndex;
 

--- a/tests/Replication2/ReplicatedLog/EstablishLeadershipTest.cpp
+++ b/tests/Replication2/ReplicatedLog/EstablishLeadershipTest.cpp
@@ -162,7 +162,7 @@ TEST_F(EstablishLeadershipTest, excluded_follower) {
     auto newConfig = std::make_shared<ParticipantsConfig>(oldConfig);
     newConfig->generation = 2;
     newConfig->participants["follower"] = replication2::ParticipantFlags{};
-    leader->updateParticipantsConfig(newConfig, oldConfig.generation, {}, {});
+    leader->updateParticipantsConfig(newConfig, nullptr);
   }
 
   {

--- a/tests/Replication2/ReplicatedLog/UpdateParticipantsFlags.cpp
+++ b/tests/Replication2/ReplicatedLog/UpdateParticipantsFlags.cpp
@@ -93,7 +93,7 @@ TEST_F(UpdateParticipantsFlagsTest, wc2_but_server_forced) {
     // make follower2 forced
     newConfig->participants["follower2"] =
         replication2::ParticipantFlags{true, false};
-    leader->updateParticipantsConfig(newConfig, oldConfig.generation, {}, {});
+    leader->updateParticipantsConfig(newConfig, nullptr);
   }
 
   {
@@ -151,7 +151,7 @@ TEST_F(UpdateParticipantsFlagsTest, wc2_but_server_excluded) {
     // make follower1 excluded
     newConfig->participants["follower1"] = replication2::ParticipantFlags{
         .forced = false, .allowedInQuorum = false};
-    leader->updateParticipantsConfig(newConfig, oldConfig.generation, {}, {});
+    leader->updateParticipantsConfig(newConfig, nullptr);
   }
 
   {
@@ -195,7 +195,7 @@ TEST_F(UpdateParticipantsFlagsTest,
     // make follower1 excluded
     newConfig->participants["follower1"] =
         replication2::ParticipantFlags{.allowedInQuorum = false};
-    leader->updateParticipantsConfig(newConfig, oldConfig.generation, {}, {});
+    leader->updateParticipantsConfig(newConfig, nullptr);
   }
 
   {
@@ -247,7 +247,7 @@ TEST_F(UpdateParticipantsFlagsTest, multiple_updates_check) {
     // make follower2 forced
     newConfig->participants["follower2"] =
         replication2::ParticipantFlags{true, false};
-    leader->updateParticipantsConfig(newConfig, oldConfig.generation, {}, {});
+    leader->updateParticipantsConfig(newConfig, nullptr);
   }
 
   auto idx = leader->insert(LogPayload::createFromString("entry #1"));
@@ -270,7 +270,7 @@ TEST_F(UpdateParticipantsFlagsTest, multiple_updates_check) {
     auto newConfig = std::make_shared<ParticipantsConfig>(oldConfig);
     newConfig->participants["follower2"] = {};
     newConfig->generation = 3;
-    leader->updateParticipantsConfig(newConfig, oldConfig.generation, {}, {});
+    leader->updateParticipantsConfig(newConfig, nullptr);
   }
 
   {
@@ -308,7 +308,7 @@ TEST_F(UpdateParticipantsFlagsTest, update_without_additional_entry) {
     // make follower2 excluded
     newConfig->participants["follower2"] =
         replication2::ParticipantFlags{true, false};
-    leader->updateParticipantsConfig(newConfig, oldConfig.generation, {}, {});
+    leader->updateParticipantsConfig(newConfig, nullptr);
   }
 
   EXPECT_EQ(leader->getCommitIndex(), LogIndex{1});
@@ -338,6 +338,10 @@ TEST_F(UpdateParticipantsFlagsTest, wc2_add_new_follower) {
   auto follower3 = std::shared_ptr<DelayedFollowerLog>{};
   follower3 = followerLog3->becomeFollower("follower3", startTerm, "leader");
   followers.emplace_back(follower3);
+  auto const buildFollower = [&](ParticipantId const& participantId) {
+    EXPECT_EQ("follower3", participantId);
+    return follower3;
+  };
 
   {  // First add the new follower3
     auto oldConfig =
@@ -347,8 +351,7 @@ TEST_F(UpdateParticipantsFlagsTest, wc2_add_new_follower) {
     newConfig->generation = 2;
 
     // note that this adds a new log entry
-    leader->updateParticipantsConfig(newConfig, oldConfig.generation,
-                                     {{"follower3", follower3}}, {});
+    leader->updateParticipantsConfig(newConfig, buildFollower);
   }
 
   {  // checks
@@ -384,6 +387,10 @@ TEST_F(UpdateParticipantsFlagsTest,
   auto follower3 = std::shared_ptr<DelayedFollowerLog>{};
   follower3 = followerLog3->becomeFollower("follower3", startTerm, "leader");
   followers.emplace_back(follower3);
+  auto const buildFollower = [&](ParticipantId const& participantId) {
+    EXPECT_EQ("follower3", participantId);
+    return follower3;
+  };
 
   {  // First add the new follower3
     auto oldConfig =
@@ -393,8 +400,7 @@ TEST_F(UpdateParticipantsFlagsTest,
     newConfig->participants["follower3"] = replication2::ParticipantFlags{};
 
     // note that this adds a new log entry
-    leader->updateParticipantsConfig(newConfig, oldConfig.generation,
-                                     {{"follower3", follower3}}, {});
+    leader->updateParticipantsConfig(newConfig, buildFollower);
   }
 
   {  // checks
@@ -434,6 +440,10 @@ TEST_F(UpdateParticipantsFlagsTest, wc2_remove_exclude_flag) {
   auto follower3 = std::shared_ptr<DelayedFollowerLog>{};
   follower3 = followerLog3->becomeFollower("follower3", startTerm, "leader");
   followers.emplace_back(follower3);
+  auto const buildFollower = [&](ParticipantId const& participantId) {
+    EXPECT_EQ("follower3", participantId);
+    return follower3;
+  };
 
   {  // First add the new follower3, but excluded
     auto oldConfig =
@@ -445,8 +455,7 @@ TEST_F(UpdateParticipantsFlagsTest, wc2_remove_exclude_flag) {
         replication2::ParticipantFlags{.allowedInQuorum = false};
 
     // note that this adds a new log entry
-    leader->updateParticipantsConfig(newConfig, oldConfig.generation,
-                                     {{"follower3", follower3}}, {});
+    leader->updateParticipantsConfig(newConfig, buildFollower);
   }
 
   {  // checks
@@ -488,7 +497,7 @@ TEST_F(UpdateParticipantsFlagsTest, wc2_remove_exclude_flag) {
                        oldConfig.participants.at("follower3"));
     flags.allowedInQuorum = true;
 
-    leader->updateParticipantsConfig(newConfig, oldConfig.generation, {}, {});
+    leader->updateParticipantsConfig(newConfig, nullptr);
   }
 
   {  // checks
@@ -530,8 +539,7 @@ TEST_F(UpdateParticipantsFlagsTest, wc2_remove_follower) {
     newConfig->generation = 2;
 
     // remove follower1
-    leader->updateParticipantsConfig(newConfig, oldConfig.generation, {},
-                                     {"follower1"});
+    leader->updateParticipantsConfig(newConfig, nullptr);
   }
 
   {  // checks
@@ -585,8 +593,7 @@ TEST_F(UpdateParticipantsFlagsTest,
     newConfig->generation = 2;
 
     // remove follower1
-    leader->updateParticipantsConfig(newConfig, oldConfig.generation, {},
-                                     {"follower1"});
+    leader->updateParticipantsConfig(newConfig, nullptr);
   }
 
   {  // checks
@@ -641,17 +648,6 @@ TEST_F(UpdateParticipantsFlagsTest, wc2_add_mismatching_config_should_fail) {
   EXPECT_EQ(leader->getParticipantConfigGenerations(),
             (std::pair<std::size_t, std::optional<std::size_t>>(1, 1)));
 
-  {  // (unsuccessfully) try to set a new config with the wrong generation
-    auto oldConfig =
-        leader->getStatus().asLeaderStatus()->activeParticipantsConfig;
-    EXPECT_EQ(oldConfig.generation, 1);
-    auto newConfig = std::make_shared<ParticipantsConfig>(oldConfig);
-    newConfig->generation = 4;
-
-    EXPECT_ANY_THROW(leader->updateParticipantsConfig(newConfig, 2, {}, {}));
-    EXPECT_ANY_THROW(leader->updateParticipantsConfig(newConfig, 3, {}, {}));
-  }
-
   runAllAsyncAppendEntries();
 
   // should be unchanged
@@ -666,8 +662,7 @@ TEST_F(UpdateParticipantsFlagsTest, wc2_add_mismatching_config_should_fail) {
     auto newConfig = std::make_shared<ParticipantsConfig>(oldConfig);
     newConfig->generation = 2;
 
-    auto logIndex = leader->updateParticipantsConfig(
-        newConfig, oldConfig.generation, {}, {});
+    auto logIndex = leader->updateParticipantsConfig(newConfig, nullptr);
     EXPECT_EQ(logIndex, LogIndex{2});
   }
 
@@ -678,16 +673,6 @@ TEST_F(UpdateParticipantsFlagsTest, wc2_add_mismatching_config_should_fail) {
   EXPECT_EQ(leader->getCommitIndex(), LogIndex{2});
   EXPECT_EQ(leader->getParticipantConfigGenerations(),
             (std::pair<std::size_t, std::optional<std::size_t>>(2, 2)));
-
-  {  // (unsuccessfully) try to set a new config with the wrong generation
-    auto oldConfig =
-        leader->getStatus().asLeaderStatus()->activeParticipantsConfig;
-    EXPECT_EQ(oldConfig.generation, 2);
-    auto newConfig = std::make_shared<ParticipantsConfig>(oldConfig);
-    newConfig->generation = 3;
-
-    EXPECT_ANY_THROW(leader->updateParticipantsConfig(newConfig, 0, {}, {}));
-  }
 
   // should be unchanged
   runAllAsyncAppendEntries();
@@ -725,7 +710,7 @@ TEST_F(UpdateParticipantsFlagsTest, check_update_participants_meta_entry) {
     // make follower2 forced
     newConfig->participants["follower2"] =
         replication2::ParticipantFlags{true, false};
-    leader->updateParticipantsConfig(newConfig, oldConfig.generation, {}, {});
+    leader->updateParticipantsConfig(newConfig, nullptr);
   }
 
   // commit this configuration


### PR DESCRIPTION
### Scope & Purpose

Minor changes: shuffle some logic around. In essence, change the signature of `updateParticipantsConfig` from

```cpp
  auto updateParticipantsConfig(
      std::shared_ptr<ParticipantsConfig const> config,
      std::size_t previousGeneration,
      std::unordered_map<ParticipantId, std::shared_ptr<AbstractFollower>> additionalFollowers,
      std::vector<ParticipantId> const& followersToRemove
  ) -> LogIndex;
```
to
```cpp
  auto updateParticipantsConfig(
      std::shared_ptr<ParticipantsConfig const> const& config,
      std::function<std::shared_ptr<AbstractFollower>(ParticipantId const&)> const& buildFollower
  ) -> LogIndex;
```
.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*
  - [ ] Backport for 3.7: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

