### PR TITLE
Emergency unblock test

### DIFF
--- a/tests/Maintenance/MaintenanceFeatureTest.cpp
+++ b/tests/Maintenance/MaintenanceFeatureTest.cpp
@@ -870,6 +870,8 @@ TEST(MaintenanceFeatureTestThreaded,
 #endif
 }
 
+#if 0
+// temporarily disabled since it may hang
 TEST_F(MaintenanceFeatureTestDBServer, test_synchronize_shard_abort) {
   auto& mf = server.getFeature<arangodb::MaintenanceFeature>();
   mf.start();
@@ -890,3 +892,4 @@ TEST_F(MaintenanceFeatureTestDBServer, test_synchronize_shard_abort) {
   mf.beginShutdown();
   mf.stop();
 }
+#endif


### PR DESCRIPTION
### Scope & Purpose

Emergency PR to disable a test which was found to sometimes block.
