### PR TITLE
Fix blocking test

### DIFF
--- a/tests/Maintenance/MaintenanceFeatureTest.cpp
+++ b/tests/Maintenance/MaintenanceFeatureTest.cpp
@@ -870,7 +870,6 @@ TEST(MaintenanceFeatureTestThreaded,
 #endif
 }
 
-#if 0
 // temporarily disabled since it may hang
 TEST_F(MaintenanceFeatureTestDBServer, test_synchronize_shard_abort) {
   auto& mf = server.getFeature<arangodb::MaintenanceFeature>();
@@ -883,7 +882,8 @@ TEST_F(MaintenanceFeatureTestDBServer, test_synchronize_shard_abort) {
                                              {COLLECTION, "tmp"},
                                              {SHARD, "s1"},
                                              {THE_LEADER, "PRMR-1"},
-                                             {SHARD_VERSION, "1"}},
+                                             {SHARD_VERSION, "1"},
+                                             {FORCED_RESYNC, "false"}},
           SYNCHRONIZE_PRIORITY, true);
 
   // The following will executed the action right away:
@@ -892,4 +892,3 @@ TEST_F(MaintenanceFeatureTestDBServer, test_synchronize_shard_abort) {
   mf.beginShutdown();
   mf.stop();
 }
-#endif


### PR DESCRIPTION
### Scope & Purpose

This fixes a test which could block by setting a description attribute
which was left out. Reactivates test.

- [*] :hankey: Bugfix

### Checklist

- [*] Tests
  - [*] C++ **Unit tests**

