### PR TITLE
[CINFRA-337] Let RocksDB Log Persistor resolve promises with its executor

### DIFF
--- a/arangod/RocksDBEngine/RocksDBPersistedLog.cpp
+++ b/arangod/RocksDBEngine/RocksDBPersistedLog.cpp
@@ -239,10 +239,10 @@ void RocksDBLogPersistor::runPersistorWorker(Lane& lane) noexcept {
 
         // resolve all promises in [nextReqToResolve, nextReqToWrite)
         for (; nextReqToResolve != nextReqToWrite; ++nextReqToResolve) {
-          _executor->operator()(fu2::unique_function<void() noexcept>{
+          _executor->operator()(
               [reqToResolve = std::move(*nextReqToResolve)]() mutable noexcept {
                 reqToResolve.promise.setValue(TRI_ERROR_NO_ERROR);
-              }});
+              });
         }
       }
 
@@ -257,12 +257,11 @@ void RocksDBLogPersistor::runPersistorWorker(Lane& lane) noexcept {
         // should always be increased as well; meaning we only exactly iterate
         // over the unfulfilled promises here.
         TRI_ASSERT(!nextReqToResolve->promise.isFulfilled());
-        _executor->operator()(fu2::unique_function<void() noexcept>{
-            [reqToResolve = std::move(*nextReqToResolve),
-             result = result]() mutable noexcept {
-              TRI_ASSERT(!reqToResolve.promise.isFulfilled());
-              reqToResolve.promise.setValue(std::move(result));
-            }});
+        _executor->operator()([reqToResolve = std::move(*nextReqToResolve),
+                               result = result]() mutable noexcept {
+          TRI_ASSERT(!reqToResolve.promise.isFulfilled());
+          reqToResolve.promise.setValue(std::move(result));
+        });
       }
     }
   }

--- a/arangod/RocksDBEngine/RocksDBPersistedLog.cpp
+++ b/arangod/RocksDBEngine/RocksDBPersistedLog.cpp
@@ -33,8 +33,6 @@
 #include "RocksDBKey.h"
 #include "RocksDBPersistedLog.h"
 #include "RocksDBValue.h"
-#include "Scheduler/Scheduler.h"
-#include "Scheduler/SchedulerFeature.h"
 
 using namespace arangodb;
 using namespace arangodb::replication2;


### PR DESCRIPTION
### Scope & Purpose

This is to avoid the persistor thread executing arbitrary code, which can lead to erratic slowdown of the persistor thread and deadlocks.

- [X] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*
  - [ ] Backport for 3.7: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

