### PR TITLE
Try to fix some of data races that tsan reported

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1253,6 +1253,7 @@ link_libraries(
   absl::flat_hash_map
   absl::node_hash_set
   absl::node_hash_map
+  absl::inlined_vector
 )
 
 

--- a/arangod/Aql/Query.cpp
+++ b/arangod/Aql/Query.cpp
@@ -266,20 +266,16 @@ void Query::setLockTimeout(double timeout) noexcept {
 }
 
 bool Query::killed() const {
-  if (_queryOptions.maxRuntime > std::numeric_limits<double>::epsilon() &&
-      elapsedSince(_startTime) > _queryOptions.maxRuntime) {
-    return true;
-  }
-  return _queryKilled;
+  return (std::numeric_limits<double>::epsilon() < _queryOptions.maxRuntime &&
+          _queryOptions.maxRuntime < elapsedSince(_startTime)) ||
+         _queryKilled.load(std::memory_order_acquire);
 }
 
 /// @brief set the query to killed
 void Query::kill() {
-  if (ServerState::instance()->isCoordinator() && !_queryKilled) {
-    _queryKilled = true;
-    this->cleanupPlanAndEngine(TRI_ERROR_QUERY_KILLED, /*sync*/ false);
-  } else {
-    _queryKilled = true;
+  auto const wasKilled = _queryKilled.exchange(true, std::memory_order_acq_rel);
+  if (ServerState::instance()->isCoordinator() && !wasKilled) {
+    cleanupPlanAndEngine(TRI_ERROR_QUERY_KILLED, /*sync*/ false);
   }
 }
 
@@ -1269,7 +1265,7 @@ void Query::enterState(QueryExecutionState::ValueType state) {
 
 /// @brief cleanup plan and engine for current query
 ExecutionState Query::cleanupPlanAndEngine(ErrorCode errorCode, bool sync) {
-  if (!_resultCode.has_value()) {
+  if (!_resultCode.has_value()) {  // TODO possible data race here
     // result code not yet set.
     _resultCode = errorCode;
   }

--- a/arangod/Aql/Query.h
+++ b/arangod/Aql/Query.h
@@ -252,8 +252,6 @@ class Query : public QueryContext, public std::enable_shared_from_this<Query> {
  private:
   aql::ExecutionState cleanupTrxAndEngines(ErrorCode errorCode);
 
-  void finishDBServerParts(int errorCode);
-
   // @brief injects vertex collections into all types of graph nodes:
   // ExecutionNode::TRAVERSAL, ExecutionNode::SHORTEST_PATH and
   // ExecutionNode::K_SHORTEST_PATHS - in case the GraphNode does not contain

--- a/arangod/Aql/QueryList.h
+++ b/arangod/Aql/QueryList.h
@@ -242,7 +242,7 @@ class QueryList {
   arangodb::basics::ReadWriteLock _lock;
 
   /// @brief list of current queries, protected by _lock
-  std::unordered_map<TRI_voc_tick_t, Query*> _current;
+  std::unordered_map<TRI_voc_tick_t, std::weak_ptr<Query>> _current;
 
   /// @brief list of slow queries, protected by _lock
   std::list<QueryEntryCopy> _slow;

--- a/arangod/RocksDBEngine/RocksDBMetadata.h
+++ b/arangod/RocksDBEngine/RocksDBMetadata.h
@@ -231,7 +231,7 @@ struct RocksDBMetadata final {
 
 #ifdef ARANGODB_ENABLE_FAILURE_TESTS
   // whether document counts are tainted during testing
-  bool _tainted = false;
+  std::atomic_bool _tainted = false;
 #endif
 };
 

--- a/tests/Network/MethodsTest.cpp
+++ b/tests/Network/MethodsTest.cpp
@@ -63,7 +63,10 @@ struct DummyConnection final : public fuerte::Connection {
 
   fuerte::Error _err = fuerte::Error::NoError;
   std::unique_ptr<fuerte::Response> _response;
-  int _sendRequestNum = 0;
+  // Should be atomic because we don't wait,
+  // we just sleep and expect the request to be completed within that time.
+  // In general, this is synchronization via sleep and you can’t write like that
+  std::atomic_int _sendRequestNum = 0;
 };
 
 struct DummyPool : public network::ConnectionPool {

--- a/tests/Network/MethodsTest.cpp
+++ b/tests/Network/MethodsTest.cpp
@@ -45,12 +45,10 @@ struct DummyConnection final : public fuerte::Connection {
       : fuerte::Connection(conf) {}
   void sendRequest(std::unique_ptr<fuerte::Request> r,
                    fuerte::RequestCallback cb) override {
-    auto err = _err;
-    auto response = std::move(_response);
     _sendRequestNum++;
-    cb(err, std::move(r), std::move(response));
-    if (err == fuerte::Error::WriteError ||
-        err == fuerte::Error::ConnectionClosed) {
+    cb(_err, std::move(r), std::move(_response));
+    if (_err == fuerte::Error::WriteError ||
+        _err == fuerte::Error::ConnectionClosed) {
       _state = fuerte::Connection::State::Closed;
     }
   }
@@ -65,7 +63,7 @@ struct DummyConnection final : public fuerte::Connection {
 
   fuerte::Error _err = fuerte::Error::NoError;
   std::unique_ptr<fuerte::Response> _response;
-  std::atomic_int _sendRequestNum = 0;
+  int _sendRequestNum = 0;
 };
 
 struct DummyPool : public network::ConnectionPool {
@@ -344,35 +342,37 @@ TEST_F(NetworkMethodsTest, request_automatic_retry_write_error_when_from_pool) {
 }
 
 TEST_F(NetworkMethodsTest, request_with_retry_after_error) {
-  // Step 1: Make valid response for Step 5
-  fuerte::ResponseHeader header;
-  header.contentType(fuerte::ContentType::VPack);
-  header.responseCode = fuerte::StatusAccepted;
-  auto response = std::make_unique<fuerte::Response>(std::move(header));
-  auto resBuffer = VPackParser::fromJson("{\"error\":false}")->steal();
-  response->setPayload(std::move(*resBuffer), 0);
-  // Step 2: Provoke a connection error
+  // Step 1: Provoke a connection error
   pool->_conn->_err = fuerte::Error::CouldNotConnect;
-  // Step 3: Send request
+
   network::RequestOptions reqOpts;
   reqOpts.timeout = network::Timeout(5.0);
+
   VPackBuffer<uint8_t> buffer;
   auto f =
       network::sendRequestRetry(pool.get(), "tcp://example.org:80",
                                 fuerte::RestVerb::Get, "/", buffer, reqOpts);
-  // Step 4: Wait for first try failed
-  while (pool->_conn->_sendRequestNum != 1) {
-    std::this_thread::sleep_for(std::chrono::milliseconds(1));
-    ASSERT_FALSE(f.isReady());
-  }
-  // Default behaviour should be to retry after 200 ms, so store without sync
-  // Step 5: Now respond with no error
+
+  // the default behaviour should be to retry after 200 ms
+  std::this_thread::sleep_for(std::chrono::milliseconds(5));
+  ASSERT_FALSE(f.isReady());
+  ASSERT_EQ(pool->_conn->_sendRequestNum, 1);
+
+  // Step 2: Now respond with no error
   pool->_conn->_err = fuerte::Error::NoError;
-  pool->_conn->_response = std::move(response);
-  // Step 6: Wait response
+
+  fuerte::ResponseHeader header;
+  header.contentType(fuerte::ContentType::VPack);
+  header.responseCode = fuerte::StatusAccepted;
+  pool->_conn->_response =
+      std::make_unique<fuerte::Response>(std::move(header));
+  std::shared_ptr<VPackBuilder> b = VPackParser::fromJson("{\"error\":false}");
+  auto resBuffer = b->steal();
+  pool->_conn->_response->setPayload(std::move(*resBuffer), 0);
+
   auto status = f.wait_for(std::chrono::milliseconds(350));
   ASSERT_EQ(futures::FutureStatus::Ready, status);
-  // Step 7: Validate response
+
   network::Response res = std::move(f).get();
   ASSERT_EQ(res.destination, "tcp://example.org:80");
   ASSERT_EQ(res.error, fuerte::Error::NoError);
@@ -381,38 +381,38 @@ TEST_F(NetworkMethodsTest, request_with_retry_after_error) {
 }
 
 TEST_F(NetworkMethodsTest, request_with_retry_after_421) {
-  // Step 1: Make valid response for Step 5
+  // Step 1: Provoke a 421 response
   fuerte::ResponseHeader header;
-  header.contentType(fuerte::ContentType::VPack);
-  header.responseCode = fuerte::StatusAccepted;
-  auto response = std::make_unique<fuerte::Response>(std::move(header));
-  auto resBuffer = VPackParser::fromJson("{\"error\":false}")->steal();
-  response->setPayload(std::move(*resBuffer), 0);
-  // Step 2: Provoke a 421 response
   header.contentType(fuerte::ContentType::VPack);
   header.responseCode = fuerte::StatusMisdirectedRequest;
   pool->_conn->_response =
       std::make_unique<fuerte::Response>(std::move(header));
-  // Step 3: Send request
+
   network::RequestOptions reqOpts;
   reqOpts.timeout = network::Timeout(5.0);
+
   VPackBuffer<uint8_t> buffer;
   auto f =
       network::sendRequestRetry(pool.get(), "tcp://example.org:80",
                                 fuerte::RestVerb::Get, "/", buffer, reqOpts);
-  // Step 4: Wait for first try failed
-  while (pool->_conn->_sendRequestNum != 1) {
-    std::this_thread::sleep_for(std::chrono::milliseconds(1));
-    ASSERT_FALSE(f.isReady());
-  }
-  // Default behaviour should be to retry after 200 ms, so store without sync
-  // Step 5: Now respond with no error
-  pool->_conn->_err = fuerte::Error::NoError;
-  pool->_conn->_response = std::move(response);
-  // Step 6: Wait response
+
+  // the default behaviour should be to retry after 200 ms
+  std::this_thread::sleep_for(std::chrono::milliseconds(5));
+  ASSERT_FALSE(f.isReady());
+  ASSERT_EQ(pool->_conn->_sendRequestNum, 1);
+
+  // Step 2: Now respond with no error
+  header.responseCode = fuerte::StatusAccepted;
+  header.contentType(fuerte::ContentType::VPack);
+  pool->_conn->_response =
+      std::make_unique<fuerte::Response>(std::move(header));
+  auto b = VPackParser::fromJson("{\"error\":false}");
+  auto resBuffer = b->steal();
+  pool->_conn->_response->setPayload(std::move(*resBuffer), 0);
+
   auto status = f.wait_for(std::chrono::milliseconds(350));
   ASSERT_EQ(futures::FutureStatus::Ready, status);
-  // Step 7: Validate response
+
   network::Response res = std::move(f).get();
   ASSERT_EQ(res.destination, "tcp://example.org:80");
   ASSERT_EQ(res.error, fuerte::Error::NoError);
@@ -421,36 +421,37 @@ TEST_F(NetworkMethodsTest, request_with_retry_after_421) {
 }
 
 TEST_F(NetworkMethodsTest, request_with_retry_after_conn_canceled) {
-  // Step 1: Make valid response for Step 5
-  fuerte::ResponseHeader header;
-  header.contentType(fuerte::ContentType::VPack);
-  header.responseCode = fuerte::StatusOK;
-  auto response = std::make_unique<fuerte::Response>(std::move(header));
-  auto b = VPackParser::fromJson("{\"error\":false}");
-  auto resBuffer = b->steal();
-  response->setPayload(std::move(*resBuffer), 0);
-  // Step 2: Provoke a ConnectionCanceled
+  // Step 1: Provoke a ConnectionCanceled
   pool->_conn->_err = fuerte::Error::ConnectionCanceled;
-  // Step 3: Send request
+
   network::RequestOptions reqOpts;
   reqOpts.timeout = network::Timeout(5.0);
+
   VPackBuffer<uint8_t> buffer;
   auto f =
       network::sendRequestRetry(pool.get(), "tcp://example.org:80",
                                 fuerte::RestVerb::Get, "/", buffer, reqOpts);
-  // Step 4: Wait for first try failed
-  while (pool->_conn->_sendRequestNum != 1) {
-    std::this_thread::sleep_for(std::chrono::milliseconds(1));
-    ASSERT_FALSE(f.isReady());
-  }
-  // Default behaviour should be to retry after 200 ms, so store without sync
-  // Step 5: Now respond with no error
+
+  // the default behaviour should be to retry after 200 ms
+  std::this_thread::sleep_for(std::chrono::milliseconds(5));
+  ASSERT_FALSE(f.isReady());
+  ASSERT_EQ(pool->_conn->_sendRequestNum, 1);
+
+  // Step 2: Now respond with no error
+  fuerte::ResponseHeader header;
+  header.contentType(fuerte::ContentType::VPack);
+  header.responseCode = fuerte::StatusOK;
+  header.contentType(fuerte::ContentType::VPack);
+  pool->_conn->_response =
+      std::make_unique<fuerte::Response>(std::move(header));
+  auto b = VPackParser::fromJson("{\"error\":false}");
+  auto resBuffer = b->steal();
+  pool->_conn->_response->setPayload(std::move(*resBuffer), 0);
   pool->_conn->_err = fuerte::Error::NoError;
-  pool->_conn->_response = std::move(response);
-  // Step 6: Wait response
+
   auto status = f.wait_for(std::chrono::milliseconds(350));
   ASSERT_EQ(futures::FutureStatus::Ready, status);
-  // Step 7: Validate response
+
   network::Response res = std::move(f).get();
   ASSERT_EQ(res.destination, "tcp://example.org:80");
   ASSERT_EQ(res.error, fuerte::Error::NoError);
@@ -459,41 +460,45 @@ TEST_F(NetworkMethodsTest, request_with_retry_after_conn_canceled) {
 }
 
 TEST_F(NetworkMethodsTest, request_with_retry_after_not_found_error) {
-  // Step 1: Make valid response for Step 5
+  // Step 1: Provoke a data source not found error
+  pool->_conn->_err = fuerte::Error::NoError;
   fuerte::ResponseHeader header;
-  header.contentType(fuerte::ContentType::VPack);
-  header.responseCode = fuerte::StatusAccepted;
-  auto response = std::make_unique<fuerte::Response>(std::move(header));
-  auto resBuffer = VPackParser::fromJson("{\"error\":false}")->steal();
-  response->setPayload(std::move(*resBuffer), 0);
-  // Step 2: Provoke a data source not found error
   header.contentType(fuerte::ContentType::VPack);
   header.responseCode = fuerte::StatusNotFound;
   pool->_conn->_response =
       std::make_unique<fuerte::Response>(std::move(header));
-  resBuffer = VPackParser::fromJson("{\"errorNum\":1203}")->steal();
+  std::shared_ptr<VPackBuilder> b =
+      VPackParser::fromJson("{\"errorNum\":1203}");
+  auto resBuffer = b->steal();
   pool->_conn->_response->setPayload(std::move(*resBuffer), 0);
-  // Step 3: Send request
+
   network::RequestOptions reqOpts;
   reqOpts.timeout = network::Timeout(60.0);
   reqOpts.retryNotFound = true;
+
   VPackBuffer<uint8_t> buffer;
   auto f =
       network::sendRequestRetry(pool.get(), "tcp://example.org:80",
                                 fuerte::RestVerb::Get, "/", buffer, reqOpts);
-  // Step 4: Wait for first try failed
-  while (pool->_conn->_sendRequestNum != 1) {
-    std::this_thread::sleep_for(std::chrono::milliseconds(1));
-    ASSERT_FALSE(f.isReady());
-  }
-  // Default behaviour should be to retry after 200 ms, so store without sync
-  // Step 5: Now respond with no error
+
+  // the default behaviour should be to retry after 200 ms
+  std::this_thread::sleep_for(std::chrono::milliseconds(5));
+  ASSERT_FALSE(f.isReady());
+
+  // Step 2: Now respond with no error
   pool->_conn->_err = fuerte::Error::NoError;
-  pool->_conn->_response = std::move(response);
-  // Step 6: Wait response
+
+  header.responseCode = fuerte::StatusAccepted;
+  header.contentType(fuerte::ContentType::VPack);
+  pool->_conn->_response =
+      std::make_unique<fuerte::Response>(std::move(header));
+  b = VPackParser::fromJson("{\"error\":false}");
+  resBuffer = b->steal();
+  pool->_conn->_response->setPayload(std::move(*resBuffer), 0);
+
   auto status = f.wait_for(std::chrono::milliseconds(350));
   ASSERT_EQ(futures::FutureStatus::Ready, status);
-  // Step 7: Validate response
+
   network::Response res = std::move(f).get();
   ASSERT_EQ(res.destination, "tcp://example.org:80");
   ASSERT_EQ(res.error, fuerte::Error::NoError);


### PR DESCRIPTION
### Scope & Purpose

Try to fix some of data races that tsan reported

https://jenkins.arangodb.biz:3456/job/arangodb-ANY-linux-san.x86-64/1078/EDITION=enterprise,SAN_MODE=TSan,STORAGE_ENGINE=rocksdb,TEST_SUITE=single,limit=linux&&test&&x86-64/

Everything except unsafe calls, velocypack function initilization, and agency lock-order-inversion 

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*
  - [ ] Backport for 3.7: *(Please link PR)*

#### Related Information

TSAN build: https://jenkins.arangodb.biz:3456/job/arangodb-ANY-linux-san.x86-64/1082/

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

