### PR TITLE
[CINFRA-361] Use 3 DB Servers by Default

### DIFF
--- a/scripts/cluster-run-common.sh
+++ b/scripts/cluster-run-common.sh
@@ -34,7 +34,7 @@ function help() {
 
 # defaults
 NRAGENTS=1
-NRDBSERVERS=2
+NRDBSERVERS=3
 NRCOORDINATORS=1
 POOLSZ=""
 TRANSPORT="tcp"


### PR DESCRIPTION
### Scope & Purpose

For most experiments related to replication, 2 DB servers is not enough. Using 3 servers by default does not really affect the startup speed, while making the `startLocalCluster.sh` more universal, being better suited for observing a cluster that contains a stopped server.
This is just for convenience, as most of the time when you tell someone to start a local cluster, they would use the default parameters. By changing the number of DB servers to 3, we make sure there's not going to be any issue with that.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*
  - [ ] Backport for 3.7: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

