### PR TITLE
attempt to fix compile warning on MSVC

### DIFF
--- a/lib/Inspection/VPackLoadInspector.h
+++ b/lib/Inspection/VPackLoadInspector.h
@@ -23,6 +23,7 @@
 
 #pragma once
 
+#include <limits>
 #include <optional>
 #include <string_view>
 #include <tuple>
@@ -95,7 +96,10 @@ struct VPackLoadInspectorImpl
       return {"Expecting type String"};
     }
     auto s = _slice.stringView();
-    v = velocypack::HashedStringRef(s.data(), s.size());
+    if (s.size() > std::numeric_limits<uint32_t>::max()) {
+      return {"String value too long to store In HashedStringRef"};
+    }
+    v = velocypack::HashedStringRef(s.data(), static_cast<uint32_t>(s.size()));
     return {};
   }
 


### PR DESCRIPTION
### Scope & Purpose

Attempt to fix the following compile warning on MSVC:
```
lib/Inspection/VPackLoadInspector.h(98,1): error C2220: the following warning is treated as an error
lib/Inspection/VPackLoadInspector.h(92): message : while compiling class template member function 'arangodb::inspection::Status arangodb::inspection::VPackLoadInspectorImpl<true>::value(arangodb::velocypack::HashedStringRef &)'
lib/Inspection/Access.h(55): message : see reference to function template instantiation 'arangodb::inspection::Status arangodb::inspection::VPackLoadInspectorImpl<true>::value(arangodb::velocypack::HashedStringRef &)' being compiled
tests/Basics/InspectionTest.cpp(1547): message : see reference to class template instantiation 'arangodb::inspection::VPackLoadInspectorImpl<true>' being compiled
lib/Inspection/VPackLoadInspector.h(98,1): warning C4267: 'argument': conversion from 'size_t' to 'uint32_t', possible loss of data
```
No backports are needed.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [-] Backports
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -
  - [ ] Backport for 3.7: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 