### PR TITLE
Make transaction lock stripes configurable

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,11 @@
 v3.9.2 (XXXX-XX-XX)
 -------------------
 
+* Added startup option `--rocksdb.transaction-lock-stripes` to configure the
+  number of lock stripes to be used by RocksDB transactions. The option
+  defaults to the number of available cores, but is bumped to a value of
+  16 if the number of cores is lower.
+
 * Added an IO heartbeat which checks that the underlying volume is writable with
   reasonable performance. The test is done every 15 seconds and can be
   explicitly switched off. New metrics to give visibility if the test fails.

--- a/arangod/RocksDBEngine/RocksDBEngine.cpp
+++ b/arangod/RocksDBEngine/RocksDBEngine.cpp
@@ -686,8 +686,9 @@ void RocksDBEngine::start() {
   auto const& opts = server().getFeature<arangodb::RocksDBOptionFeature>();
 
   rocksdb::TransactionDBOptions transactionOptions;
-  // number of locks per column_family
-  transactionOptions.num_stripes = NumberOfCores::getValue();
+  // num_stripes must be at least 1
+  transactionOptions.num_stripes =
+      std::max(size_t(1), static_cast<size_t>(opts._transactionLockStripes));
   transactionOptions.transaction_lock_timeout = opts._transactionLockTimeout;
 
   _options.allow_fallocate = opts._allowFAllocate;

--- a/arangod/RocksDBEngine/RocksDBOptionFeature.cpp
+++ b/arangod/RocksDBEngine/RocksDBOptionFeature.cpp
@@ -122,6 +122,10 @@ uint64_t defaultMinWriteBufferNumberToMerge(uint64_t totalSize,
 RocksDBOptionFeature::RocksDBOptionFeature(
     application_features::ApplicationServer& server)
     : application_features::ApplicationFeature(server, "RocksDBOption"),
+      // number of lock stripes for the transaction lock manager. we bump this
+      // to at least 16 to reduce contention for small scale systems.
+      _transactionLockStripes(
+          std::max(NumberOfCores::getValue(), std::size_t(16))),
       _transactionLockTimeout(rocksDBTrxDefaults.transaction_lock_timeout),
       _totalWriteBufferSize(rocksDBDefaults.db_write_buffer_size),
       _writeBufferSize(rocksDBDefaults.write_buffer_size),

--- a/arangod/RocksDBEngine/RocksDBOptionFeature.h
+++ b/arangod/RocksDBEngine/RocksDBOptionFeature.h
@@ -63,6 +63,7 @@ class RocksDBOptionFeature final
       RocksDBColumnFamilyManager::Family family, rocksdb::Options const& base,
       rocksdb::BlockBasedTableOptions const& tableBase) const;
 
+  uint64_t _transactionLockStripes;
   int64_t _transactionLockTimeout;
   std::string _walDirectory;
   uint64_t _totalWriteBufferSize;


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/16118

* Added startup option `--rocksdb.transaction-lock-stripes` to configure the number of lock stripes to be used by RocksDB transactions. The option defaults to the number of available cores, but is bumped to a value of 16 if the number of cores is lower.

Docs PR: https://github.com/arangodb/docs/pull/978

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [x] :books: documentation written (release notes, API changes, ...)
- [x] Backports
  - [x] Backport for 3.9: this PR
  - [ ] Backport for 3.8: -
  - [ ] Backport for 3.7: -

#### Related Information

- [x] Docs PR: https://github.com/arangodb/docs/pull/978
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 