### PR TITLE
Increase lock timeout on followers

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,14 @@
 devel
 -----
 
+* Increase internal transaction lock timeout on followers during cluster
+  write operations. Although writes to the same keys on followers should be
+  serialized by the key locks held on the leader, it is still possible that
+  the global transaction lock striped mutex is a source of contention and 
+  that concurrent write operations time out while waiting to acquire this
+  global mutex. The lock timeout on followers is now significantly increased
+  to make this very unlikely.
+
 * Added command line option to arangobench to disable implicit collection
   creation. This allows one to run tests against a manually created and
   configured collection.


### PR DESCRIPTION
### Scope & Purpose

* Increase internal transaction lock timeout on followers during cluster
  write operations. Although writes to the same keys on followers should be
  serialized by the key locks held on the leader, it is still possible that
  the global transaction lock striped mutex is a source of contention and
  that concurrent write operations time out while waiting to acquire this
  global mutex. The lock timeout on followers is now significantly increased
  to make this very unlikely.

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*
  - [ ] Backport for 3.7: *(Please link PR)*

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
