### PR TITLE
Fix clang-format check

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -16,10 +16,6 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: extract base
-        run: echo "PR_BASE=${{ github.event.pull_request.base.sha }}" >> $GITHUB_ENV
-      - name: extract head
-        run: echo "PR_HEAD=${{ github.event.pull_request.head.sha }}" >> $GITHUB_ENV
       - name: calculate diff
         run: |
           mkdir -p build 

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -20,5 +20,9 @@ jobs:
         run: echo "PR_BASE=${{ github.event.pull_request.base.sha }}" >> $GITHUB_ENV
       - name: extract head
         run: echo "PR_HEAD=${{ github.event.pull_request.head.sha }}" >> $GITHUB_ENV
+      - name: calculate diff
+        run: |
+          mkdir -p build 
+          git diff --diff-filter=ACMRT --name-only ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} -- arangosh/ arangod/ lib/ client-tools/ tests/ Enterprise/ > build/DIFF
       - name: arangodb-clang-format
         uses: arangodb/clang-format-action@1.0.3

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -21,4 +21,4 @@ jobs:
       - name: extract head
         run: echo "PR_HEAD=${{ github.event.pull_request.head.sha }}" >> $GITHUB_ENV
       - name: arangodb-clang-format
-        uses: arangodb/clang-format-action@1.0.2
+        uses: jsteemann/clang-format-action@1.0.3

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: extract base

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -21,4 +21,4 @@ jobs:
       - name: extract head
         run: echo "PR_HEAD=${{ github.event.pull_request.head.sha }}" >> $GITHUB_ENV
       - name: arangodb-clang-format
-        uses: jsteemann/clang-format-action@1.0.3
+        uses: arangodb/clang-format-action@1.0.3

--- a/arangod/Aql/SortExecutor.cpp
+++ b/arangod/Aql/SortExecutor.cpp
@@ -39,6 +39,7 @@ using namespace arangodb;
 using namespace arangodb::aql;
 
 namespace {
+  // dum di dum di dum
    // wuit
   // testi
   // grrr

--- a/arangod/Aql/SortExecutor.cpp
+++ b/arangod/Aql/SortExecutor.cpp
@@ -23,7 +23,6 @@
 
 #include "SortExecutor.h"
 
-
 #include "Aql/AllRowsFetcher.h"
 #include "Aql/ExecutionBlockImpl.h"
 #include "Aql/InputAqlItemRow.h"
@@ -39,12 +38,7 @@ using namespace arangodb;
 using namespace arangodb::aql;
 
 namespace {
-  // dum di dum di dum
-   // wuit
-  // testi
-  // grrr
-// more wut
-/// @brief OurLessThan
+// custom AqlValue-aware comparator for sorting
 class OurLessThan {
  public:
   OurLessThan(velocypack::Options const* options, AqlItemMatrix const& input,

--- a/arangod/Aql/SortExecutor.cpp
+++ b/arangod/Aql/SortExecutor.cpp
@@ -39,7 +39,7 @@ using namespace arangodb;
 using namespace arangodb::aql;
 
 namespace {
-  // wuit
+   // wuit
   // testi
   // grrr
 // more wut

--- a/arangod/Aql/SortExecutor.cpp
+++ b/arangod/Aql/SortExecutor.cpp
@@ -40,6 +40,7 @@ using namespace arangodb::aql;
 
 namespace {
   // testi
+  // grrr
 // more wut
 /// @brief OurLessThan
 class OurLessThan {

--- a/arangod/Aql/SortExecutor.cpp
+++ b/arangod/Aql/SortExecutor.cpp
@@ -39,6 +39,7 @@ using namespace arangodb;
 using namespace arangodb::aql;
 
 namespace {
+  // wuit
   // testi
   // grrr
 // more wut

--- a/arangod/Aql/SortExecutor.cpp
+++ b/arangod/Aql/SortExecutor.cpp
@@ -40,7 +40,7 @@ using namespace arangodb::aql;
 
 namespace {
   // testi
-
+// more wut
 /// @brief OurLessThan
 class OurLessThan {
  public:

--- a/arangod/Aql/SortExecutor.cpp
+++ b/arangod/Aql/SortExecutor.cpp
@@ -23,6 +23,7 @@
 
 #include "SortExecutor.h"
 
+
 #include "Aql/AllRowsFetcher.h"
 #include "Aql/ExecutionBlockImpl.h"
 #include "Aql/InputAqlItemRow.h"
@@ -38,6 +39,7 @@ using namespace arangodb;
 using namespace arangodb::aql;
 
 namespace {
+  // testi
 
 /// @brief OurLessThan
 class OurLessThan {


### PR DESCRIPTION
### Scope & Purpose

The clang-format check executed via Github actions suddenly started failing last week, without having made any changes to the Github action or the invoked Docker container. So Github seems to have changed something in their Github actions environment.
This PR repairs the Github action so that it doesn't fail with git errors anymore.
Relies on code in another repository: https://github.com/arangodb/clang-format-action/releases/tag/1.0.3

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [x] Backports
  - [x] Backport for 3.9: https://github.com/arangodb/arangodb/pull/16141
  - [ ] Backport for 3.8: -
  - [ ] Backport for 3.7: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 