### PR TITLE
set useRevisionsAsDocumentIds=true upon arangorestore

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,13 +1,16 @@
 devel
 -----
 
+* Set "useRevisionsAsDocumentIds" to true when restoring collection data
+  via arangorestore in case it is not set in the collection structure input
+  data. This allows using revision trees for restored collections.
+
 * FE-46: UI improvement on the view UI pages as well as adding tooltips to
   options where necessary. The affected pages are mostly the Info and
   Consolidation Policy pages.
 
 * FE-44: Moved the Info page to before JSON, making the settings page the
   default page in the view web UI.
-
 
 * Refactor internal code paths responsible for `_key` generation. For
   collections with only a single shard, we can now always let the leader

--- a/arangod/RestHandler/RestReplicationHandler.cpp
+++ b/arangod/RestHandler/RestReplicationHandler.cpp
@@ -1335,6 +1335,15 @@ Result RestReplicationHandler::processRestoreCollection(
     }
 #endif
 
+    if (parameters.get(StaticStrings::UsesRevisionsAsDocumentIds).isNone() &&
+        (parameters.get(StaticStrings::SyncByRevision).isNone() ||
+         parameters.get(StaticStrings::SyncByRevision).isTrue())) {
+      // for restored collections that do not have "syncByRevision" nor
+      // "usesRevisionsAsDocumentIds" set, set "usesRevisionsAsDocumentIds"
+      // to true. This allows the usage of revision trees for the collection.
+      toMerge.add(StaticStrings::UsesRevisionsAsDocumentIds, VPackValue(true));
+    }
+
     // Always ignore `shadowCollections` they were accidentially dumped in
     // arangodb versions earlier than 3.3.6
     toMerge.add(StaticStrings::ShadowCollections,
@@ -3414,6 +3423,14 @@ ErrorCode RestReplicationHandler::createCollection(VPackSlice slice) {
     // needed in case we restore cluster related data into single server
     // instance
     patch.add(StaticStrings::DataSourcePlanId, VPackSlice::nullSlice());
+    if (slice.get(StaticStrings::UsesRevisionsAsDocumentIds).isNone() &&
+        (slice.get(StaticStrings::SyncByRevision).isNone() ||
+         slice.get(StaticStrings::SyncByRevision).isTrue())) {
+      // for restored collections that do not have the attribute
+      // "usesRevisionsAsDocumentIds" set, set "usesRevisionsAsDocumentIds"
+      // to true. This allows the usage of revision trees for the collection.
+      patch.add(StaticStrings::UsesRevisionsAsDocumentIds, VPackValue(true));
+    }
   }
   patch.close();
 

--- a/arangod/VocBase/LogicalCollection.cpp
+++ b/arangod/VocBase/LogicalCollection.cpp
@@ -21,6 +21,7 @@
 /// @author Michael Hackstein
 /// @author Daniel H. Larkin
 ////////////////////////////////////////////////////////////////////////////////
+
 #include "LogicalCollection.h"
 
 #include "ApplicationFeatures/ApplicationServer.h"

--- a/arangod/VocBase/Methods/Collections.cpp
+++ b/arangod/VocBase/Methods/Collections.cpp
@@ -240,6 +240,9 @@ VPackBuilder createCollectionProperties(
         vocbase.server()
             .getFeature<arangodb::EngineSelectorFeature>()
             .isRocksDB() &&
+        !info.properties
+             .get(arangodb::StaticStrings::UsesRevisionsAsDocumentIds)
+             .isFalse() &&
         LogicalCollection::currentVersion() >= LogicalCollection::Version::v37;
 
     if (addUseRevs) {

--- a/tests/js/client/shell/shell-restore-integration.js
+++ b/tests/js/client/shell/shell-restore-integration.js
@@ -635,6 +635,92 @@ function restoreIntegrationSuite () {
       }
     },
     
+    testRestoreWithoutUsesRevisions: function () {
+      let path = fs.getTempFile();
+      try {
+        fs.makeDirectory(path);
+        let fn = fs.join(path, cn + ".structure.json");
+
+        fs.write(fn, JSON.stringify({
+          indexes: [],
+          parameters: {
+            name: cn,
+            type: 2
+          }
+        }));
+
+        let args = ['--collection', cn, '--import-data', 'false'];
+        runRestore(path, args, 0); 
+
+        let c = db._collection(cn);
+        let props = c.properties();
+        assertTrue(props.hasOwnProperty("syncByRevision"));
+        assertTrue(props.syncByRevision);
+      } finally {
+        try {
+          fs.removeDirectory(path);
+        } catch (err) {}
+      }
+    },
+    
+    testRestoreWithUsesRevisionsFalse: function () {
+      let path = fs.getTempFile();
+      try {
+        fs.makeDirectory(path);
+        let fn = fs.join(path, cn + ".structure.json");
+
+        fs.write(fn, JSON.stringify({
+          indexes: [],
+          parameters: {
+            usesRevisionsAsDocumentIds: false,
+            name: cn,
+            type: 2
+          }
+        }));
+
+        let args = ['--collection', cn, '--import-data', 'false'];
+        runRestore(path, args, 0); 
+
+        let c = db._collection(cn);
+        let props = c.properties();
+        assertTrue(props.hasOwnProperty("syncByRevision"));
+        assertFalse(props.syncByRevision);
+      } finally {
+        try {
+          fs.removeDirectory(path);
+        } catch (err) {}
+      }
+    },
+    
+    testRestoreWithUsesRevisionsTrue: function () {
+      let path = fs.getTempFile();
+      try {
+        fs.makeDirectory(path);
+        let fn = fs.join(path, cn + ".structure.json");
+
+        fs.write(fn, JSON.stringify({
+          indexes: [],
+          parameters: {
+            usesRevisionsAsDocumentIds: true,
+            name: cn,
+            type: 2
+          }
+        }));
+
+        let args = ['--collection', cn, '--import-data', 'false'];
+        runRestore(path, args, 0); 
+
+        let c = db._collection(cn);
+        let props = c.properties();
+        assertTrue(props.hasOwnProperty("syncByRevision"));
+        assertTrue(props.syncByRevision);
+      } finally {
+        try {
+          fs.removeDirectory(path);
+        } catch (err) {}
+      }
+    },
+    
     testRestoreNumericGloballyUniqueId: function () {
       let path = fs.getTempFile();
       try {


### PR DESCRIPTION
### Scope & Purpose

* Set "useRevisionsAsDocumentIds" to true when restoring collection data
  via arangorestore in case it is not set in the collection structure input
  data. This allows using revision trees for restored collections.

No backport decision yet.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.9: may be backported
  - [ ] Backport for 3.8: may be backported
  - [ ] Backport for 3.7: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
