### PR TITLE
fix users checking

### DIFF
--- a/js/client/modules/@arangodb/testutils/testrunner.js
+++ b/js/client/modules/@arangodb/testutils/testrunner.js
@@ -45,19 +45,29 @@ let didSplitBuckets = false;
 // //////////////////////////////////////////////////////////////////////////////
 let usersTests = {
   name: 'users',
-  setUp: function (te) {
-    this.usersCount = userManager.all().length;
+  setUp: function (obj, te) {
+    try {
+      this.usersCount = userManager.all().length;
+    } catch (x) {
+      obj.results[te] = {
+        status: false,
+        message: 'failed to fetch the users on the system before the test: ' + x.message
+      };
+      obj.continueTesting = false;
+      obj.serverDead = true;
+      return false;
+    }
     return true;
   },
-  runCheck: function (te) {
+  runCheck: function (obj, te) {
     if (userManager.all().length !== this.usersCount) {
-      this.continueTesting = false;
-      this.results[te] = {
+      obj.continueTesting = false;
+      obj.results[te] = {
         status: false,
         message: 'Cleanup of users missing - found users left over: [ ' +
           JSON.stringify(userManager.all()) +
           ' ] - Original test status: ' +
-          JSON.stringify(this.results[te])
+          JSON.stringify(obj.results[te])
       };
       return false;
     }


### PR DESCRIPTION
### Scope & Purpose

https://github.com/arangodb/arangodb/pull/15998 introduced a main overhaul of the test framework, and added users testing. However, the function signature and SUT failure resillience of the newly introduced users module wasn't good. 

- [x] :hankey: Bugfix

### Checklist

- [x] This fixes the test framework
#### Related Information

A testrun would abort like this, and not give propper error output to testfailures.txt:
```
caught exception during test execution!
not connected
ArangoError: not connected
    at Object.exports.all (c:\gce-win-22dbmn\oskar\work\ArangoDB\js\client\modules\@arangodb\users.js:148:38)
    at Object.setUp (c:\gce-win-22dbmn\oskar\work\ArangoDB\js\client\modules\@arangodb\testutils\testrunner.js:49:35)
    at runOnArangodRunner.run (c:\gce-win-22dbmn\oskar\work\ArangoDB\js\client\modules\@arangodb\testutils\testrunner.js:463:63)
    at Object.replication2Server [as replication2_server] (c:\gce-win-22dbmn\oskar\work\ArangoDB\js\client\modules\@arangodb\testsuites\replication2.js:69:6)
    at iterateTests (c:\gce-win-22dbmn\oskar\work\ArangoDB\js\client\modules\@arangodb\testutils\testing.js:529:36)
    at unitTest (c:\gce-win-22dbmn\oskar\work\ArangoDB\js\client\modules\@arangodb\testutils\testing.js:625:12)
    at main (C:\gce-win-22dbmn\oskar\work\ArangoDB\UnitTests\unittest.js:67:14)
    at C:\gce-win-22dbmn\oskar\work\ArangoDB\UnitTests\unittest.js:118:14
{}
2022-04-25T13:57:16Z [12240] ERROR [8a210] {general} JavaScript exception in file 'C:\gce-win-22dbmn\oskar\work\ArangoDB\UnitTests\unittest.js' at 85,5: ArangoError 2001: not connected
2022-04-25T13:57:16Z [12240] ERROR [409ee] {general} !    throw x;
2022-04-25T13:57:16Z [12240] ERROR [cb0bd] {general} !    ^
```