### PR TITLE
Added `--custom-query-file` option to arangoexport

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 devel
 -----
 
+* Added option `--custom-query-file` to arangoexport, so that a custom query
+  string can also be read from an input file.
+
 * Added startup option `--cluster.shard-synchronization-attempt-timeout` to
   limit the amount of time to spend in shard synchronization attempts. The
   default timeout value is 20 minutes.

--- a/client-tools/Export/ExportFeature.h
+++ b/client-tools/Export/ExportFeature.h
@@ -81,6 +81,7 @@ class ExportFeature final : public ArangoExportFeature,
 
   std::vector<std::string> _collections;
   std::string _customQuery;
+  std::string _customQueryFile;
   std::string _graphName;
   std::string _xgmmlLabelAttribute;
   std::string _typeExport;

--- a/js/client/modules/@arangodb/testsuites/export.js
+++ b/js/client/modules/@arangodb/testsuites/export.js
@@ -373,6 +373,39 @@ class exportRunner extends tu.runInArangoshRunner {
           };
         }
       }
+      
+      print(CYAN + Date() + ': Export query from file (jsonl)' + RESET);
+      {
+        let tempFile = fs.join(tmpPath, 'query-string');
+        let args = Object.assign({}, commonArgValues);
+        fs.writeFileSync(tempFile, 'FOR doc IN UnitTestsExport RETURN doc');
+        args['type'] = 'jsonl';
+        args['custom-query-file'] = tempFile;
+        testName = "exportQueryFile" + idx;
+        results[testName] = pu.executeAndWait(pu.ARANGOEXPORT_BIN, toArgv(args), this.options, 'arangosh', tmpPath, this.options.coreCheck);
+        results[testName].failed = results[testName].status ? 0 : 1;
+      }
+
+      {
+        testName = "parseQueryFile" + idx;
+        try {
+          fs.read(fs.join(tmpPath, 'query.jsonl')).split('\n')
+            .filter(line => line.trim() !== '')
+            .forEach(line => JSON.parse(line));
+          results[testName] = {
+            failed: 0,
+            status: true
+          };
+        } catch (e) {
+          print(e);
+          results.failed += 1;
+          results[testName] = {
+            failed: 1,
+            status: false,
+            message: e
+          };
+        }
+      }
 
       print(CYAN + Date() + ': Export query (jsonl)' + RESET);
       {


### PR DESCRIPTION
### Scope & Purpose

* Added option `--custom-query-file` to arangoexport, so that a custom query
  string can also be read from an input file.

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -
  - [ ] Backport for 3.7: -

#### Related Information

- [ ] Docs PR: TO DO: MISSING!
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 