### PR TITLE
Disable index estimates for TTL indexes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 v3.8.7 (XXXX-XX-XX)
 -------------------
 
+* Make sure that newly created TTL indexes do not use index estimates, which
+  wouldn't be used for TTL indexes anyway.
+
 * Bump the number of RocksDB transaction lock stripes to at least 16, if the
   number of cores is lower than that value.
 

--- a/arangod/ClusterEngine/ClusterIndex.cpp
+++ b/arangod/ClusterEngine/ClusterIndex.cpp
@@ -89,6 +89,8 @@ ClusterIndex::ClusterIndex(IndexId id, LogicalCollection& collection,
       if (VPackSlice s = info.get(StaticStrings::IndexEstimates); s.isBoolean()) {
         _estimates = s.getBoolean();
       }
+    } else if (_indexType == TRI_IDX_TYPE_TTL_INDEX) {
+      _estimates = false;
     }
   }
 }
@@ -114,6 +116,9 @@ void ClusterIndex::toVelocyPack(VPackBuilder& builder,
       _indexType == Index::TRI_IDX_TYPE_SKIPLIST_INDEX ||
       _indexType == Index::TRI_IDX_TYPE_PERSISTENT_INDEX) {
     builder.add(StaticStrings::IndexEstimates, VPackValue(_estimates));
+  } else if (_indexType == Index::TRI_IDX_TYPE_TTL_INDEX) {
+    // no estimates for the ttl index
+    builder.add(StaticStrings::IndexEstimates, VPackValue(false));
   }
 
   for (auto pair : VPackObjectIterator(_info.slice())) {

--- a/arangod/RocksDBEngine/RocksDBTtlIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBTtlIndex.cpp
@@ -61,6 +61,7 @@ void RocksDBTtlIndex::toVelocyPack(arangodb::velocypack::Builder& builder,
   builder.openObject();
   RocksDBIndex::toVelocyPack(builder, flags);
   builder.add(StaticStrings::IndexExpireAfter, VPackValue(_expireAfter));
+  builder.add(StaticStrings::IndexEstimates, VPackValue(hasEstimates()));
   builder.close();
 }
 

--- a/arangod/RocksDBEngine/RocksDBVPackIndex.h
+++ b/arangod/RocksDBEngine/RocksDBVPackIndex.h
@@ -88,12 +88,13 @@ class RocksDBVPackIndex : public RocksDBIndex {
 
   /// @brief return the attribute paths
   std::vector<std::vector<std::string>> const& paths() const { return _paths; }
-
+  
   /// @brief return the attribute paths, a -1 entry means none is expanding,
   /// otherwise the non-negative number is the index of the expanding one.
   std::vector<int> const& expanding() const { return _expanding; }
-
-  static constexpr size_t minimalPrefixSize() { return sizeof(TRI_voc_tick_t); }
+  
+  /// @brief whether or not the index has estimates
+  bool hasEstimates() const noexcept { return _estimates; }
 
   /// @brief attempts to locate an entry in the index
   std::unique_ptr<IndexIterator> lookup(transaction::Methods*,

--- a/tests/js/common/shell/shell-index-estimates.js
+++ b/tests/js/common/shell/shell-index-estimates.js
@@ -159,7 +159,8 @@ function indexEstimatesSuite() {
       assertEqual("ttl", indexes[1].type);
       assertFalse(indexes[0].hasOwnProperty("estimates"));
       assertTrue(indexes[0].hasOwnProperty("selectivityEstimate"));
-      assertFalse(indexes[1].hasOwnProperty("estimates"));
+      assertTrue(indexes[1].hasOwnProperty("estimates"));
+      assertFalse(indexes[1].estimates);
       assertFalse(indexes[1].hasOwnProperty("selectivityEstimate"));
     },
   };

--- a/tests/js/common/shell/shell-ttl.js
+++ b/tests/js/common/shell/shell-ttl.js
@@ -279,6 +279,30 @@ function TtlSuite () {
       }
     },
     
+    testCreateIndexAttributes : function () {
+      let c = db._create(cn, { numberOfShards: 2 });
+      let idx = c.ensureIndex({ type: "ttl", fields: ["dateCreated"], expireAfter: 10 });
+      assertTrue(idx.isNewlyCreated);
+      assertEqual("ttl", idx.type);
+      assertEqual(["dateCreated"], idx.fields);
+      assertEqual(10, idx.expireAfter);
+      assertFalse(idx.estimates);
+
+      // fetch index data yet again via API
+      idx = c.indexes()[1];
+      assertEqual("ttl", idx.type);
+      assertEqual(["dateCreated"], idx.fields);
+      assertEqual(10, idx.expireAfter);
+      assertFalse(idx.estimates);
+    },
+    
+    testCreateIndexWithEstimates : function () {
+      let c = db._create(cn, { numberOfShards: 2 });
+      let idx = c.ensureIndex({ type: "ttl", fields: ["dateCreated"], expireAfter: 10, estimates: true });
+      assertTrue(idx.isNewlyCreated);
+      assertFalse(idx.estimates);
+    },
+    
     testCreateIndexWithInvalidExpireAfter : function () {
       const values = [ 
         null,

--- a/tests/js/server/recovery/indexes-ttl.js
+++ b/tests/js/server/recovery/indexes-ttl.js
@@ -1,0 +1,88 @@
+/* jshint globalstrict:false, strict:false, unused : false */
+/* global assertEqual, assertFalse, assertTrue, assertNotNull */
+// //////////////////////////////////////////////////////////////////////////////
+// / DISCLAIMER
+// /
+// / Copyright 2010-2012 triagens GmbH, Cologne, Germany
+// /
+// / Licensed under the Apache License, Version 2.0 (the "License")
+// / you may not use this file except in compliance with the License.
+// / You may obtain a copy of the License at
+// /
+// /     http://www.apache.org/licenses/LICENSE-2.0
+// /
+// / Unless required by applicable law or agreed to in writing, software
+// / distributed under the License is distributed on an "AS IS" BASIS,
+// / WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// / See the License for the specific language governing permissions and
+// / limitations under the License.
+// /
+// / Copyright holder is triAGENS GmbH, Cologne, Germany
+// /
+// / @author Jan Steemann
+// / @author Copyright 2013, triAGENS GmbH, Cologne, Germany
+// //////////////////////////////////////////////////////////////////////////////
+
+const db = require('@arangodb').db;
+const internal = require('internal');
+const jsunity = require('jsunity');
+
+function runSetup () {
+  'use strict';
+  internal.debugClearFailAt();
+
+  let c = db._create('UnitTestsRecovery1');
+  c.ensureIndex({ type: "ttl", fields: ["value"], expireAfter: 60 });
+  
+  c = db._create('UnitTestsRecovery2');
+  c.ensureIndex({ type: "ttl", fields: ["value"], expireAfter: 600, estimates: true });
+
+  c.save({ _key: 'crashme' }, true);
+
+  internal.debugTerminate('crashing server');
+}
+
+// //////////////////////////////////////////////////////////////////////////////
+// / @brief test suite
+// //////////////////////////////////////////////////////////////////////////////
+
+function recoverySuite () {
+  'use strict';
+  jsunity.jsUnity.attachAssertions();
+
+  return {
+    testIndexesTtl: function () {
+      let c = db._collection('UnitTestsRecovery1');
+      let idx = c.getIndexes()[1];
+
+      assertEqual("ttl", idx.type);
+      assertEqual(["value"], idx.fields);
+      assertEqual(60, idx.expireAfter);
+      assertFalse(idx.estimates);
+      
+      c = db._collection('UnitTestsRecovery2');
+      idx = c.getIndexes()[1];
+
+      assertEqual("ttl", idx.type);
+      assertEqual(["value"], idx.fields);
+      assertEqual(600, idx.expireAfter);
+      assertFalse(idx.estimates);
+    }
+
+  };
+}
+
+// //////////////////////////////////////////////////////////////////////////////
+// / @brief executes the test suite
+// //////////////////////////////////////////////////////////////////////////////
+
+function main (argv) {
+  'use strict';
+  if (argv[1] === 'setup') {
+    runSetup();
+    return 0;
+  } else {
+    jsunity.run(recoverySuite);
+    return jsunity.writeDone().status ? 0 : 1;
+  }
+}


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/16165

* Make sure that newly created TTL indexes do not use index estimates, which
  wouldn't be used for TTL indexes anyway.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [x] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [x] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [x] Backports
  - [x] Backport for 3.9: 
  - [x] Backport for 3.8: this PR
  - [ ] Backport for 3.7: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 