### PR TITLE
Fix indexSize in IResearchFeatureDDLTestSuite is not deterministic

### DIFF
--- a/tests/js/common/aql/aql-view-arangosearch-ddl-cluster.js
+++ b/tests/js/common/aql/aql-view-arangosearch-ddl-cluster.js
@@ -987,7 +987,7 @@ function IResearchFeatureDDLTestSuite () {
         assertNotEqual(null, figures);
         assertTrue(Object === figures.constructor);
         assertEqual(5, Object.keys(figures).length);
-        assertEqual(1278, figures.indexSize);
+        assertTrue(1000 < figures.indexSize);
         assertEqual(2, figures.numDocs);
         assertEqual(2, figures.numLiveDocs);
         assertEqual(6, figures.numFiles);
@@ -1013,7 +1013,7 @@ function IResearchFeatureDDLTestSuite () {
         assertNotEqual(null, figures);
         assertTrue(Object === figures.constructor);
         assertEqual(5, Object.keys(figures).length);
-        assertEqual(1326, figures.indexSize);
+        assertTrue(1000 < figures.indexSize);
         assertEqual(2, figures.numDocs);
         assertEqual(1, figures.numLiveDocs);
         assertEqual(7, figures.numFiles);


### PR DESCRIPTION
### Scope & Purpose

Fix indexSize in IResearchFeatureDDLTestSuite is not deterministic

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*
  - [ ] Backport for 3.7: *(Please link PR)*

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

