### PR TITLE
Adjust importing test structure to be more similar to dumping

### DIFF
--- a/js/client/modules/@arangodb/testsuites/importing.js
+++ b/js/client/modules/@arangodb/testsuites/importing.js
@@ -442,9 +442,9 @@ class importRunner extends tu.runInArangoshRunner {
     } catch (exception) {
       result['run'] = {
         'failed': 1,
-        'message': 'An exceptions of the following form was caught: ' + exception + "\n" + exception.stack
+        'message': 'An exception of the following form was caught: ' + exception + "\n" + exception.stack
       };
-      print('An exceptions of the following form was caught: ',
+      print('An exception of the following form was caught: ',
             exception);
     }
     print('Shutting down...');

--- a/js/client/modules/@arangodb/testsuites/importing.js
+++ b/js/client/modules/@arangodb/testsuites/importing.js
@@ -413,8 +413,10 @@ class importRunner extends tu.runInArangoshRunner {
 
       for (let i = 0; i < impTodos.length; i++) {
         const impTodo = impTodos[i];
-
-        result[impTodo.id] = pu.run.arangoImport(this.options, this.instanceInfo, impTodo, this.options.coreCheck);
+        let cfg = pu.createBaseConfig('import', this.options, this.instanceInfo);
+        cfg.setWhatToImport(impTodo);
+        cfg.setEndpoint(this.instanceInfo.endpoint);
+        result[impTodo.id] = pu.run.arangoImport(cfg, this.options, this.instanceInfo.rootDir, this.options.coreCheck);
         result[impTodo.id].failed = 0;
 
         if (impTodo.expectFailure) {
@@ -437,15 +439,17 @@ class importRunner extends tu.runInArangoshRunner {
       result.teardown = this.runOneTest(tu.makePathUnix(fs.join(testPaths.importing[0], 'import-teardown.js')));
 
       result.teardown.failed = result.teardown.success ? 0 : 1;
-    } catch (banana) {
-      print('An exceptions of the following form was caught:',
-            yaml.safeDump(banana));
+    } catch (exception) {
+      result['run'] = {
+        'failed': 1,
+        'message': 'An exceptions of the following form was caught: ' + exception + "\n" + exception.stack
+      };
+      print('An exceptions of the following form was caught: ',
+            exception);
     }
-
     print('Shutting down...');
     result['shutdown'] = pu.shutdownInstance(this.instanceInfo, this.options);
     print('done.');
-
     return result;
   }
 }


### PR DESCRIPTION
### Scope & Purpose

- make imporiting binary config and handling similar to dumping.
- move client tool invocation function up
-  fix exception handling in the importing testsuites so it actually produces errors in the result. 

- [x] :hammer: Refactoring/simplification

### Checklist

- [x] Tests
