### PR TITLE
dont show errors when trying to delete non-existing files

### DIFF
--- a/arangod/RocksDBEngine/RocksDBChecksumEnv.h
+++ b/arangod/RocksDBEngine/RocksDBChecksumEnv.h
@@ -62,8 +62,9 @@ class ChecksumHelper {
 
  private:
   std::string _rootPath;
-  std::unordered_map<std::string, std::string> _fileNamesToHashes;
+
   Mutex _calculatedHashesMutex;
+  std::unordered_map<std::string, std::string> _fileNamesToHashes;
 };
 
 class ChecksumWritableFile : public rocksdb::WritableFileWrapper {


### PR DESCRIPTION
### Scope & Purpose

We need to suppress warnings when deletion of such fails, because RocksDB can call its DeleteFile method even for files it does not create...
Only affects devel.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -
  - [ ] Backport for 3.7: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
