### PR TITLE
Bug fix/3.9 maintanence lock shard

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,12 +1,12 @@
 v3.9.2 (XXXX-XX-XX)
 -------------------
 
-* Fix: Highly unlikely race in cluster maintenance. For every shard only
-  one operation (change attribute, change leadership) should be performed
-  at the same time. However if two changes are detected in the same hearbeat
-  it could lead to both operations to be executed in parallel. In most cases
-  this is also fine, but could lead to races on the same attribute, however
-  the race will be sorted out in the next heartbeat interval.
+* Fix: Highly unlikely race in cluster maintenance. For every shard only one
+  operation (change attribute, change leadership) should be performed at the
+  same time. However if two changes are detected in the same hearbeat  it could
+  lead to both operations to be executed in parallel. In most cases this is also
+  fine, but could lead to races on the same attribute, however the race will be
+  sorted out in the next heartbeat interval.
 
 * Fix: for the Windows build, the new Snappy version, which was introduced in
   3.9, generated code that contained BMI2 instructions which where introduced

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,10 +3,10 @@ v3.9.2 (XXXX-XX-XX)
 
 * Fix: Highly unlikely race in cluster maintenance. For every shard only
   one operation (change attribute, change leadership) should be performed
-	at the same time. However if two changes are detected in the same hearbeat
-	it could lead to both operations to be executed in parallel. In most cases
-	this is also fine, but could lead to races on the same attribute, however
-	the race will be sorted out in the next heartbeat interval.
+  at the same time. However if two changes are detected in the same hearbeat
+  it could lead to both operations to be executed in parallel. In most cases
+  this is also fine, but could lead to races on the same attribute, however
+  the race will be sorted out in the next heartbeat interval.
 
 * Fix: for the Windows build, the new Snappy version, which was introduced in
   3.9, generated code that contained BMI2 instructions which where introduced

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,13 @@
 v3.9.2 (XXXX-XX-XX)
 -------------------
 
+* Fix: Highly unlikely race in cluster maintenance. For every shard only
+  one operation (change attribute, change leadership) should be performed
+	at the same time. However if two changes are detected in the same hearbeat
+	it could lead to both operations to be executed in parallel. In most cases
+	this is also fine, but could lead to races on the same attribute, however
+	the race will be sorted out in the next heartbeat interval.
+
 * Fix: for the Windows build, the new Snappy version, which was introduced in
   3.9, generated code that contained BMI2 instructions which where introduced
   with the Intel Haswell architecture. However, our target architecture for 3.9


### PR DESCRIPTION
### Scope & Purpose

Partial Backport of: https://github.com/arangodb/arangodb/pull/16166

In the Maintenance there is a lock-shard mechanism that ensures only one Job should run at a time.
However it does not react correctly, if within the same Maintenance loop two different actions for the same shard are found. (e.g. update a property and change shard leader). IN that case two jobs would be queued and the lock was off-by-one.
In production this race is highly unlikely, all operations triggering it are seldom, furthermore if the bug occurs the behavior of maintenance is sub-optimal, but nothing critical is performed.

- [X] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*
  - [ ] Backport for 3.7: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

