### PR TITLE
as sugested by @adityamukho use Array.includes()

### DIFF
--- a/tests/js/common/replication_api/shell-api-replication-global.js
+++ b/tests/js/common/replication_api/shell-api-replication-global.js
@@ -976,7 +976,7 @@ function dealing_with_the_initial_dumpSuite () {
       let filtered = [ ];
       
       collections.forEach(collection => {
-        if (collection["parameters"]["name"] in [ "UnitTestsReplication", "UnitTestsReplication2" ]) {
+        if ([ "UnitTestsReplication", "UnitTestsReplication2" ].includes(collection["parameters"]["name"])) {
           filtered.push(collection);
         }
         assertTrue(collection["parameters"].hasOwnProperty('globallyUniqueId'));
@@ -1012,9 +1012,7 @@ function dealing_with_the_initial_dumpSuite () {
         let collections = database["collections"];
         filtered = [ ];
         collections.forEach(collection => {
-          if ([ "UnitTestsReplication", "UnitTestsReplication2" ].find( name => {
-            return name === collection["parameters"]["name"];
-          }) !== undefined) {
+          if ([ "UnitTestsReplication", "UnitTestsReplication2" ].includes(collection["parameters"]["name"])) {
             filtered.push(collection);
           }
           assertTrue(collection["parameters"].hasOwnProperty('globallyUniqueId'));
@@ -1101,9 +1099,7 @@ function dealing_with_the_initial_dumpSuite () {
         assertTrue(database.hasOwnProperty('collections'));
         let collections = database['collections'];
         collections.forEach(collection => {
-          if ([ "UnitTestsReplication", "UnitTestsReplication2" ].find( name => {
-            return name === collection["parameters"]["name"];
-          }) !== undefined) {
+          if ([ "UnitTestsReplication", "UnitTestsReplication2" ].includes(collection["parameters"]["name"])) {
             filtered.push(collection);
           }
         });


### PR DESCRIPTION
### Scope & Purpose

this test was converted from ruby to js and in the midst of https://github.com/arangodb/arangodb/pull/16189 we discovered that `Array.includes()` must be used.