### PR TITLE
Improve UnshackledMutex via absl::Mutex

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1254,6 +1254,7 @@ link_libraries(
   absl::node_hash_set
   absl::node_hash_map
   absl::inlined_vector
+  absl::synchronization
 )
 
 

--- a/lib/Basics/UnshackledMutex.h
+++ b/lib/Basics/UnshackledMutex.h
@@ -23,8 +23,7 @@
 
 #pragma once
 
-#include <condition_variable>
-#include <mutex>
+#include <absl/synchronization/mutex.h>
 
 namespace arangodb::basics {
 
@@ -34,19 +33,12 @@ namespace arangodb::basics {
 // This mutex lifts this requirement and can be unlocked from another thread.
 class UnshackledMutex {
  public:
-  UnshackledMutex() = default;
-  ~UnshackledMutex() = default;
-
-  UnshackledMutex(UnshackledMutex const&) = delete;
-  auto operator=(UnshackledMutex const&) -> UnshackledMutex& = delete;
-
-  void lock();
-  void unlock();
-  bool try_lock();
+  void lock() noexcept;
+  void unlock() noexcept;
+  bool try_lock() noexcept;
 
  private:
-  std::mutex _mutex;
-  std::condition_variable _cv;
+  absl::Mutex _mutex;
   bool _locked{false};
 };
 


### PR DESCRIPTION
### Scope & Purpose

One futex instead of two

Props:
* Simpler
* Have a kind of fast path (fast lock with cond, unlock without waiters). 
  So it better when there is no contention on mutex
* `noexcept`

Cons:
* Every unlock is possible notify. So we make unnecessary condition check in `absl::Mutex::unlock` in `UnshackledMutex::lock`

About notification counts.
I think it is smaller with absl, because:
* with std we have always have `notify_one`, and two `std::mutex::unlock`
* with absl only two `absl::Mutex::unlock`

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*
  - [ ] Backport for 3.7: *(Please link PR)*

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

