### PR TITLE
[CINFRA-329] Run supervision and maintenance tests using prototype

### DIFF
--- a/tests/js/server/replication2/replication2-maintenance-replicated-state-cluster.js
+++ b/tests/js/server/replication2/replication2-maintenance-replicated-state-cluster.js
@@ -105,7 +105,7 @@ const replicatedStateSuite = function (stateType) {
     setUp: LH.registerAgencyTestBegin,
     tearDown: LH.registerAgencyTestEnd,
 
-    testCreateReplicatedState: function () {
+    ["testCreateReplicatedState_" + stateType]: function () {
       const logId = LH.nextUniqueLogId();
       const servers = _.sampleSize(LH.dbservers, 3);
       const leader = servers[0];
@@ -113,7 +113,7 @@ const replicatedStateSuite = function (stateType) {
       LH.waitFor(spreds.replicatedStateIsReady(database, logId, servers));
     },
 
-    testCheckTimestampSnapshotStatus: function () {
+    ["testCheckTimestampSnapshotStatus_" + stateType]: function () {
       const logId = LH.nextUniqueLogId();
       const servers = _.sampleSize(LH.dbservers, 3);
       const leader = servers[0];
@@ -127,7 +127,7 @@ const replicatedStateSuite = function (stateType) {
       }
     },
 
-    testReplicatedStateUpdateParticipantGeneration: function () {
+    ["testReplicatedStateUpdateParticipantGeneration_" + stateType]: function () {
       const logId = LH.nextUniqueLogId();
       const servers = _.sampleSize(LH.dbservers, 3);
       const leader = servers[0];
@@ -146,7 +146,7 @@ const replicatedStateSuite = function (stateType) {
       LH.waitFor(spreds.replicatedStateIsReady(database, logId, servers));
     },
 
-    testReplicatedStateChangeLeader: function () {
+    ["testReplicatedStateChangeLeader_" + stateType]: function () {
       const logId = LH.nextUniqueLogId();
       const servers = _.sampleSize(LH.dbservers, 3);
       const leader = servers[0];
@@ -163,7 +163,7 @@ const replicatedStateSuite = function (stateType) {
       LH.waitFor(spreds.replicatedStateIsReady(database, logId, servers));
     },
 
-    testReplicatedStateIncreaseSnapshotGen: function () {
+    ["testReplicatedStateIncreaseSnapshotGen_" + stateType]: function () {
       const logId = LH.nextUniqueLogId();
       const servers = _.sampleSize(LH.dbservers, 3);
       const leader = servers[0];
@@ -182,7 +182,7 @@ const replicatedStateSuite = function (stateType) {
       LH.waitFor(spreds.replicatedStateIsReady(database, logId, servers));
     },
 
-    testReplicatedStateDropFollower: function () {
+    ["testReplicatedStateDropFollower_" + stateType]: function () {
       const logId = LH.nextUniqueLogId();
       const servers = _.sampleSize(LH.dbservers, 3);
       const leader = servers[0];

--- a/tests/js/server/replication2/replication2-maintenance-replicated-state-cluster.js
+++ b/tests/js/server/replication2/replication2-maintenance-replicated-state-cluster.js
@@ -56,7 +56,7 @@ const {setUpAll, tearDownAll} = (function () {
   };
 }());
 
-const replicatedStateSuite = function () {
+const replicatedStateSuite = function (stateType) {
 
   const createReplicatedState = function (database, logId, servers, leader) {
     SH.updateReplicatedStatePlan(database, logId, function () {
@@ -86,7 +86,7 @@ const replicatedStateSuite = function () {
         participants: {},
         properties: {
           implementation: {
-            type: "black-hole",
+            type: stateType,
           }
         }
       };
@@ -210,5 +210,12 @@ const replicatedStateSuite = function () {
   };
 };
 
-jsunity.run(replicatedStateSuite);
+const suiteWithState = function (stateType) {
+  return function () {
+    return replicatedStateSuite(stateType);
+  };
+};
+
+jsunity.run(suiteWithState("black-hole"));
+jsunity.run(suiteWithState("prototype"));
 return jsunity.done();

--- a/tests/js/server/replication2/replication2-replicated-state-http-api-cluster.js
+++ b/tests/js/server/replication2/replication2-replicated-state-http-api-cluster.js
@@ -70,7 +70,7 @@ const unsetLeader = (database, logId) => {
   return result;
 };
 
-const replicatedStateSuite = function () {
+const replicatedStateSuite = function (stateType) {
   const targetConfig = {
     writeConcern: 2,
     softWriteConcern: 2,
@@ -105,7 +105,7 @@ const replicatedStateSuite = function () {
     tearDown: lh.registerAgencyTestEnd,
 
     testGetLocalStatus: function () {
-      const {stateId, followers, leader} = sh.createReplicatedStateTarget(database, targetConfig, "black-hole");
+      const {stateId, followers, leader} = sh.createReplicatedStateTarget(database, targetConfig, stateType);
 
       {
         const status = sh.getLocalStatus(leader, database, stateId);
@@ -133,7 +133,7 @@ const replicatedStateSuite = function () {
         stateId,
         servers: participants,
         followers
-      } = sh.createReplicatedStateTarget(database, targetConfig, "black-hole");
+      } = sh.createReplicatedStateTarget(database, targetConfig, stateType);
       const nonParticipants = _.without(lh.dbservers, ...participants);
       const oldParticipant = _.sample(followers);
       const newParticipant = _.sample(nonParticipants);
@@ -168,7 +168,7 @@ const replicatedStateSuite = function () {
         stateId,
         servers: participants,
         leader
-      } = sh.createReplicatedStateTarget(database, targetConfig, "black-hole");
+      } = sh.createReplicatedStateTarget(database, targetConfig, stateType);
       const nonParticipants = _.without(lh.dbservers, ...participants);
       const oldParticipant = leader;
       const newParticipant = _.sample(nonParticipants);
@@ -203,7 +203,7 @@ const replicatedStateSuite = function () {
         stateId,
         servers: participants,
         leader
-      } = sh.createReplicatedStateTarget(database, targetConfig, "black-hole");
+      } = sh.createReplicatedStateTarget(database, targetConfig, stateType);
 
       {
         // Explicitly set the leader, just use the existing one
@@ -251,7 +251,7 @@ const replicatedStateSuite = function () {
       const {
         stateId,
         servers: participants,
-      } = sh.createReplicatedStateTarget(database, targetConfig, "black-hole");
+      } = sh.createReplicatedStateTarget(database, targetConfig, stateType);
       const nonParticipants = _.without(lh.dbservers, ...participants);
       const [oldParticipant, newParticipant] = _.sampleSize(nonParticipants, 2);
 
@@ -273,7 +273,7 @@ const replicatedStateSuite = function () {
       const {
         stateId,
         servers: participants,
-      } = sh.createReplicatedStateTarget(database, targetConfig, "black-hole");
+      } = sh.createReplicatedStateTarget(database, targetConfig, stateType);
       const [oldParticipant, newParticipant] = _.sampleSize(participants, 2);
 
       try {
@@ -294,7 +294,7 @@ const replicatedStateSuite = function () {
       const {
         stateId,
         followers,
-      } = sh.createReplicatedStateTarget(database, targetConfig, "black-hole");
+      } = sh.createReplicatedStateTarget(database, targetConfig, stateType);
       const newLeader = _.sample(followers);
 
       const result = setLeader(database, stateId, newLeader);
@@ -311,7 +311,7 @@ const replicatedStateSuite = function () {
       const {
         stateId,
         followers,
-      } = sh.createReplicatedStateTarget(database, targetConfig, "black-hole");
+      } = sh.createReplicatedStateTarget(database, targetConfig, stateType);
       { // set the leader first
         const newLeader = _.sample(followers);
 
@@ -346,7 +346,7 @@ const replicatedStateSuite = function () {
       const {
         stateId,
         servers: participants,
-      } = sh.createReplicatedStateTarget(database, targetConfig, "black-hole");
+      } = sh.createReplicatedStateTarget(database, targetConfig, stateType);
       const nonParticipants = _.without(lh.dbservers, ...participants);
       const newLeader = _.sample(nonParticipants);
 
@@ -365,5 +365,11 @@ const replicatedStateSuite = function () {
   };
 };
 
-jsunity.run(replicatedStateSuite);
+const suiteWithState = function (stateType) {
+  return function () {
+    return replicatedStateSuite(stateType);
+  };
+};
+
+jsunity.run(suiteWithState("black-hole"));
 return jsunity.done();

--- a/tests/js/server/replication2/replication2-supervision-replicated-state-target-cluster.js
+++ b/tests/js/server/replication2/replication2-supervision-replicated-state-target-cluster.js
@@ -32,7 +32,7 @@ const lpreds = require("@arangodb/testutils/replicated-logs-predicates");
 
 const database = "replication2_supervision_test_db";
 
-const replicatedStateSuite = function () {
+const replicatedStateSuite = function (stateType) {
   const targetConfig = {
     writeConcern: 2,
     softWriteConcern: 2,
@@ -43,10 +43,10 @@ const replicatedStateSuite = function () {
   const {setUpAll, tearDownAll, stopServer, continueServer, setUp, tearDown} = lh.testHelperFunctions(database);
 
   const createReplicatedStateWithServers = function (servers) {
-    return sh.createReplicatedStateTargetWithServers(database, targetConfig, "black-hole", servers);
+    return sh.createReplicatedStateTargetWithServers(database, targetConfig, stateType, servers);
   };
   const createReplicatedState = function () {
-    return sh.createReplicatedStateTarget(database, targetConfig, "black-hole");
+    return sh.createReplicatedStateTarget(database, targetConfig, stateType);
   };
 
   return {
@@ -78,7 +78,7 @@ const replicatedStateSuite = function () {
               },
               properties: {
                 implementation: {
-                  type: "black-hole"
+                  type: stateType
                 }
               }
             };
@@ -227,5 +227,12 @@ const replicatedStateSuite = function () {
   };
 };
 
-jsunity.run(replicatedStateSuite);
+const suiteWithState = function (stateType) {
+  return function () {
+    return replicatedStateSuite(stateType);
+  };
+};
+
+jsunity.run(suiteWithState("black-hole"));
+jsunity.run(suiteWithState("prototype"));
 return jsunity.done();

--- a/tests/js/server/replication2/replication2-supervision-replicated-state-target-cluster.js
+++ b/tests/js/server/replication2/replication2-supervision-replicated-state-target-cluster.js
@@ -56,7 +56,7 @@ const replicatedStateSuite = function (stateType) {
     // writing a configuration to Target
     //
     // Await availability of the requested state
-    testCreateReplicatedState: function () {
+    ["testCreateReplicatedState" + stateType]: function () {
       const stateId = lh.nextUniqueLogId();
 
       const servers = _.sampleSize(lh.dbservers, 3);
@@ -87,7 +87,7 @@ const replicatedStateSuite = function (stateType) {
       lh.waitFor(spreds.replicatedStateIsReady(database, stateId, servers));
     },
 
-    testAddParticipant: function () {
+    ["testAddParticipant_" + stateType]: function () {
       const {stateId, servers, others} = createReplicatedState();
       const newParticipant = _.sample(others);
 
@@ -105,7 +105,7 @@ const replicatedStateSuite = function (stateType) {
       }));
     },
 
-    testUpdateVersionTest: function () {
+    ["testUpdateVersionTest_" + stateType]: function () {
       const {stateId} = createReplicatedState();
 
       const version = 4;
@@ -127,7 +127,7 @@ const replicatedStateSuite = function (stateType) {
       lh.waitFor(spreds.replicatedStateVersionConverged(database, stateId, newVersion));
     },
 
-    testSetLeader: function () {
+    ["testSetLeader_" + stateType]: function () {
       const {stateId, followers} = createReplicatedState();
       const newLeader = _.sample(followers);
       sh.updateReplicatedStateTarget(database, stateId,
@@ -139,7 +139,7 @@ const replicatedStateSuite = function (stateType) {
       lh.waitFor(lpreds.replicatedLogLeaderPlanIs(database, stateId, newLeader));
     },
 
-    testUnsetLeader: function () {
+    ["testUnsetLeader_" + stateType]: function () {
       const {stateId} = createReplicatedState();
       sh.updateReplicatedStateTarget(database, stateId,
           (target) => {
@@ -156,7 +156,7 @@ const replicatedStateSuite = function (stateType) {
       });
     },
 
-    testRemoveLeader: function () {
+    ["testRemoveLeader_" + stateType]: function () {
       const servers = _.sampleSize(lh.dbservers, 4);
       const {stateId, leader} = createReplicatedStateWithServers(servers);
 
@@ -175,7 +175,7 @@ const replicatedStateSuite = function (stateType) {
       lh.waitFor(spreds.replicatedStateIsReady(database, stateId, newServers));
     },
 
-    testReplaceAllServers: function () {
+    ["testReplaceAllServers_" + stateType]: function () {
       const {stateId, others} = createReplicatedState();
       const otherServers = _.sampleSize(others, targetConfig.replicationFactor);
 
@@ -188,7 +188,7 @@ const replicatedStateSuite = function (stateType) {
       lh.waitFor(spreds.replicatedStateIsReady(database, stateId, otherServers));
     },
 
-    testReplaceWithBadParticipant: function () {
+    ["testReplaceWithBadParticipant_" + stateType]: function () {
       const {stateId, servers, others, followers} = createReplicatedState();
       const toBeReplaced = _.sample(followers);
       const newParticipant = _.sample(others);


### PR DESCRIPTION
### Scope & Purpose

Supervision and maintenance tests are executed with the prototype state machine, apart from the black-hole. The following tests are affected by the change:
- replication2-supervision-replicated-state-target-cluster.js
- replication2-maintenance-replicated-state-cluster.js
The `replication2-replicated-state-http-api-cluster.js` file has just been refactored for convenient switching between the two.
`replication2-supervision-replicated-state-cluster.js` was already written this way, thus it remains untouched.


- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [x] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*
  - [ ] Backport for 3.7: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

