### PR TITLE
[BTS-226] Sporadic test failures in Foxx recovery test

### DIFF
--- a/tests/js/server/recovery/foxx-directories.js
+++ b/tests/js/server/recovery/foxx-directories.js
@@ -27,11 +27,12 @@
 // / @author Copyright 2013, triAGENS GmbH, Cologne, Germany
 // //////////////////////////////////////////////////////////////////////////////
 
-var db = require('@arangodb').db;
-var internal = require('internal');
-var FoxxService = require('@arangodb/foxx/service');
-var jsunity = require('jsunity');
-var fs = require('fs');
+const db = require('@arangodb').db;
+const internal = require('internal');
+const console = require('console');
+const FoxxService = require('@arangodb/foxx/service');
+const jsunity = require('jsunity');
+const fs = require('fs');
 
 function runSetup () {
   'use strict';
@@ -62,14 +63,10 @@ function runSetup () {
   // we need to wait long enough for the DatabaseManagerThread to 
   // physically carry out the deletion
   let path = fs.join(appPath, 'UnitTestsRecovery2');
-  let tries = 0;
-  while (++tries < 30) {
-    if (!fs.isDirectory(path)) {
-      require("console").log("database directory for UnitTestsRecovery2 is gone");
-      break;
-    }
+  while (fs.isDirectory(path)) {
     internal.wait(1, false);
   }
+  console.log("database directory for UnitTestsRecovery2 is gone");
   internal.debugTerminate('crashing server');
 }
 


### PR DESCRIPTION
### Scope & Purpose

Try to fix sporadic test failure as described in BTS-226. The server process fails to remove the apps directory of a deleted database within about 30 seconds;

It is currently unclear whether this is just the Jenkins environment being slow or a locking/race/exception problem in the code. It is also unclear whether this problem and test are still relevant.

The first attempt at a fix just removes the arbitrary 30 second time limit and relies on Jenkins to kill the process.


- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*
  - [ ] Backport for 3.7: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

