### PR TITLE
[CINFRA-322] wait for resign race

### DIFF
--- a/arangod/Replication2/Methods.h
+++ b/arangod/Replication2/Methods.h
@@ -86,9 +86,9 @@ struct ReplicatedLogMethods {
 
   virtual auto deleteReplicatedLog(LogId id) const
       -> futures::Future<Result> = 0;
-  virtual auto getReplicatedLogs() const
-      -> futures::Future<std::unordered_map<arangodb::replication2::LogId,
-                                            std::variant<replicated_log::LogStatus, ParticipantsList>>> = 0;
+  virtual auto getReplicatedLogs() const -> futures::Future<std::unordered_map<
+      arangodb::replication2::LogId,
+      std::variant<replicated_log::LogStatus, ParticipantsList>>> = 0;
   virtual auto getLocalStatus(LogId) const
       -> futures::Future<replication2::replicated_log::LogStatus> = 0;
   virtual auto getGlobalStatus(

--- a/arangod/Replication2/ReplicatedLog/LogFollower.h
+++ b/arangod/Replication2/ReplicatedLog/LogFollower.h
@@ -106,6 +106,9 @@ class LogFollower : public ILogFollower,
         -> DeferredAction;
     [[nodiscard]] auto didResign() const noexcept -> bool;
 
+    [[nodiscard]] auto waitForResign()
+        -> std::pair<futures::Future<futures::Unit>, DeferredAction>;
+
     LogFollower const& _follower;
     InMemoryLog _inMemoryLog;
     std::unique_ptr<LogCore> _logCore;

--- a/arangod/Replication2/ReplicatedLog/LogLeader.cpp
+++ b/arangod/Replication2/ReplicatedLog/LogLeader.cpp
@@ -1022,6 +1022,26 @@ auto replicated_log::LogLeader::GuardedLeaderData::calculateCommitLag()
   }
 }
 
+auto replicated_log::LogLeader::GuardedLeaderData::waitForResign()
+    -> std::pair<futures::Future<futures::Unit>, DeferredAction> {
+  if (!_didResign) {
+    auto future = _waitForResignQueue.addWaitFor();
+    return {std::move(future), DeferredAction{}};
+  } else {
+    TRI_ASSERT(_waitForResignQueue.empty());
+    auto promise = futures::Promise<futures::Unit>{};
+    auto future = promise.getFuture();
+
+    auto action =
+        DeferredAction([promise = std::move(promise)]() mutable noexcept {
+          TRI_ASSERT(promise.valid());
+          promise.setValue();
+        });
+
+    return {std::move(future), std::move(action)};
+  }
+}
+
 auto replicated_log::LogLeader::getReplicatedLogSnapshot() const
     -> InMemoryLog::log_type {
   auto [log, commitIndex] =
@@ -1428,7 +1448,13 @@ auto replicated_log::LogLeader::getParticipantConfigGenerations() const noexcept
 
 auto replicated_log::LogLeader::waitForResign()
     -> futures::Future<futures::Unit> {
-  return _guardedLeaderData.getLockedGuard()->_waitForResignQueue.addWaitFor();
+  using namespace arangodb::futures;
+  auto&& [future, action] =
+      _guardedLeaderData.getLockedGuard()->waitForResign();
+
+  action.fire();
+
+  return std::move(future);
 }
 
 auto replicated_log::LogLeader::LocalFollower::release(LogIndex stop) const

--- a/arangod/Replication2/ReplicatedLog/LogLeader.h
+++ b/arangod/Replication2/ReplicatedLog/LogLeader.h
@@ -308,6 +308,9 @@ class LogLeader : public std::enable_shared_from_this<LogLeader>,
         std::optional<InMemoryLogEntry::clock::time_point> insertTp)
         -> LogIndex;
 
+    [[nodiscard]] auto waitForResign()
+        -> std::pair<futures::Future<futures::Unit>, DeferredAction>;
+
     LogLeader& _self;
     InMemoryLog _inMemoryLog;
     std::unordered_map<ParticipantId, std::shared_ptr<FollowerInfo>>

--- a/arangod/Replication2/ReplicatedLog/LogUnconfiguredParticipant.h
+++ b/arangod/Replication2/ReplicatedLog/LogUnconfiguredParticipant.h
@@ -77,7 +77,10 @@ struct LogUnconfiguredParticipant final
         std::unique_ptr<arangodb::replication2::replicated_log::LogCore>,
         arangodb::DeferredAction>;
 
-    [[nodiscard]] auto waitForResign() -> futures::Future<futures::Unit>;
+    [[nodiscard]] auto didResign() const noexcept -> bool;
+
+    [[nodiscard]] auto waitForResign()
+        -> std::pair<futures::Future<futures::Unit>, DeferredAction>;
 
     std::unique_ptr<arangodb::replication2::replicated_log::LogCore> _logCore;
     WaitForBag _waitForResignQueue;

--- a/arangod/Replication2/ReplicatedLog/WaitForBag.cpp
+++ b/arangod/Replication2/ReplicatedLog/WaitForBag.cpp
@@ -48,3 +48,5 @@ void WaitForBag::resolveAll(std::exception_ptr const& ex) {
   }
   _waitForBag.clear();
 }
+
+auto WaitForBag::empty() const noexcept -> bool { return _waitForBag.empty(); }

--- a/arangod/Replication2/ReplicatedLog/WaitForBag.h
+++ b/arangod/Replication2/ReplicatedLog/WaitForBag.h
@@ -44,6 +44,8 @@ struct WaitForBag {
 
   void resolveAll(std::exception_ptr const&);
 
+  [[nodiscard]] auto empty() const noexcept -> bool;
+
  private:
   std::vector<futures::Promise<futures::Unit>> _waitForBag;
 };

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -349,6 +349,7 @@ set(ARANGODB_REPLICATION2_TEST_SOURCES
   Replication2/ReplicatedLog/LogStatusTest.cpp
   Replication2/ReplicatedLog/MaintenanceTests.cpp
   Replication2/ReplicatedLog/MultiTermTest.cpp
+  Replication2/ReplicatedLog/ParticipantResignTest.cpp
   Replication2/ReplicatedLog/ReplicatedLogTest.cpp
   Replication2/ReplicatedLog/RewriteLogTest.cpp
   Replication2/ReplicatedLog/RocksDBLogTest.cpp

--- a/tests/Replication2/ReplicatedLog/ParticipantResignTest.cpp
+++ b/tests/Replication2/ReplicatedLog/ParticipantResignTest.cpp
@@ -1,0 +1,96 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2022-2022 ArangoDB GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Tobias Gödderz
+////////////////////////////////////////////////////////////////////////////////
+
+#include "TestHelper.h"
+
+using namespace arangodb;
+using namespace arangodb::replication2;
+using namespace arangodb::replication2::test;
+
+enum class ParticipantTesteeRole { Leader, Follower, UnconfiguredParticipant };
+
+auto allRoles = {ParticipantTesteeRole::UnconfiguredParticipant,
+                 ParticipantTesteeRole::Follower,
+                 ParticipantTesteeRole::Leader};
+
+auto to_string(ParticipantTesteeRole role) -> std::string {
+  switch (role) {
+    case ParticipantTesteeRole::Leader:
+      return "ParticipantTesteeRole::Leader";
+    case ParticipantTesteeRole::Follower:
+      return "ParticipantTesteeRole::Follower";
+    case ParticipantTesteeRole::UnconfiguredParticipant:
+      return "ParticipantTesteeRole::UnconfiguredParticipant";
+  }
+  std::abort();
+}
+
+auto operator<<(std::ostream& ostream, ParticipantTesteeRole role)
+    -> std::ostream& {
+  return ostream << to_string(role);
+}
+
+struct ParticipantResignTest
+    : ReplicatedLogTest,
+      ::testing::WithParamInterface<ParticipantTesteeRole> {};
+
+TEST_P(ParticipantResignTest, participant_resign) {
+  auto log = makeReplicatedLog(LogId{1});
+
+  switch (GetParam()) {
+    case ParticipantTesteeRole::Leader:
+      log->becomeLeader({}, LogTerm{1}, {}, 1);
+      break;
+    case ParticipantTesteeRole::Follower:
+      log->becomeFollower({}, {}, {});
+      break;
+    case ParticipantTesteeRole::UnconfiguredParticipant:
+      break;
+  }
+
+  auto participant = log->getParticipant();
+
+  bool alpha = false;
+  bool beta = false;
+
+  {  // install first callback
+    auto future = participant->waitForResign();
+
+    std::move(future).thenFinal([&](auto) noexcept { alpha = true; });
+
+    EXPECT_FALSE(alpha);
+    // resign
+    log.reset();
+    EXPECT_TRUE(alpha);
+  }
+
+  {  // install second callback
+    auto future = participant->waitForResign();
+
+    EXPECT_FALSE(beta);
+    std::move(future).thenFinal([&](auto) noexcept { beta = true; });
+    EXPECT_TRUE(beta);
+  }
+}
+
+INSTANTIATE_TEST_CASE_P(ParticipantResign, ParticipantResignTest,
+                        testing::ValuesIn(allRoles));


### PR DESCRIPTION
### Scope & Purpose

Calling `waitForResign()` when a participant was resigned already did not properly resolve the promise.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [x] **Regression tests**
  - [x] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*
  - [ ] Backport for 3.7: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

