### PR TITLE
[CINFRA-356] Failed dictated leader is forced as part of the quorum

### DIFF
--- a/arangod/Replication2/ReplicatedLog/AgencyLogSpecification.cpp
+++ b/arangod/Replication2/ReplicatedLog/AgencyLogSpecification.cpp
@@ -144,6 +144,8 @@ auto agency::to_string(LogCurrentSupervisionError error) noexcept
       return "the leader selected in target is excluded";
     case LogCurrentSupervisionError::TARGET_NOT_ENOUGH_PARTICIPANTS:
       return "not enough participants to create the log safely";
+    case LogCurrentSupervisionError::TARGET_LEADER_FAILED:
+      return "the leader selected in target is failed";
   }
   LOG_TOPIC("7eee2", FATAL, arangodb::Logger::REPLICATION2)
       << "Invalid LogCurrentSupervisionError "

--- a/arangod/Replication2/ReplicatedLog/AgencyLogSpecification.h
+++ b/arangod/Replication2/ReplicatedLog/AgencyLogSpecification.h
@@ -139,7 +139,8 @@ enum class LogCurrentSupervisionError {
   TARGET_LEADER_INVALID,
   TARGET_LEADER_EXCLUDED,
   TARGET_NOT_ENOUGH_PARTICIPANTS,
-  GENERAL_ERROR  // TODO: Using this whilw refactoring
+  TARGET_LEADER_FAILED,
+  GENERAL_ERROR  // TODO: Using this while refactoring
                  // other code; needs to be improved
 };
 

--- a/arangod/Replication2/ReplicatedLog/Supervision.h
+++ b/arangod/Replication2/ReplicatedLog/Supervision.h
@@ -56,7 +56,7 @@ auto getParticipantWithUpdatedFlags(
     ParticipantsFlagsMap const& targetParticipants,
     ParticipantsFlagsMap const& planParticipants,
     std::optional<ParticipantId> const& targetLeader,
-    ParticipantId const& currentTermLeader)
+    ParticipantId const& currentTermLeader, ParticipantsHealth const& health)
     -> std::optional<std::pair<ParticipantId, ParticipantFlags>>;
 
 auto computeReason(std::optional<LogCurrentLocalState> const& maybeStatus,

--- a/js/server/modules/@arangodb/testutils/replicated-logs-helper.js
+++ b/js/server/modules/@arangodb/testutils/replicated-logs-helper.js
@@ -330,13 +330,21 @@ const getLocalStatus = function (database, logId, serverId) {
 };
 
 
-const getReplicatedLogLeaderPlan = function (database, logId) {
+const getReplicatedLogLeaderPlan = function (database, logId, nothrow = false) {
   let {plan} = readReplicatedLogAgency(database, logId);
   if (!plan.currentTerm) {
-    throw Error("no current term in plan");
+    let error = Error("no current term in plan");
+    if (nothrow) {
+      return error;
+    }
+    throw error;
   }
   if (!plan.currentTerm.leader) {
-    throw Error("current term has no leader");
+    let error = Error("current term has no leader");
+    if (nothrow) {
+      return error;
+    }
+    throw error;
   }
   const leader = plan.currentTerm.leader.serverId;
   const term = plan.currentTerm.term;

--- a/js/server/modules/@arangodb/testutils/replicated-logs-predicates.js
+++ b/js/server/modules/@arangodb/testutils/replicated-logs-predicates.js
@@ -192,6 +192,22 @@ const replicatedLogLeaderPlanIs = function (database, stateId, expectedLeader) {
   };
 };
 
+const replicatedLogLeaderPlanChanged = function (database, stateId, oldLeader) {
+  return function () {
+    try {
+      const {leader: currentLeader} = LH.getReplicatedLogLeaderPlan(database, stateId);
+      if (currentLeader !== oldLeader) {
+        return true;
+      } else {
+        return new Error(`Expected log leader to switch from ${oldLeader}, but is still the same`);
+      }
+    } catch (error) {
+      // There might be no current term or no leader in plan
+      return error;
+    }
+  };
+};
+
 const replicatedLogLeaderCommitFail = function (database, logId, expected) {
   return function () {
     let {current} = LH.readReplicatedLogAgency(database, logId);
@@ -228,4 +244,5 @@ exports.replicatedLogParticipantsFlag = replicatedLogParticipantsFlag;
 exports.replicatedLogTargetVersion = replicatedLogTargetVersion;
 exports.replicatedLogLeaderTargetIs = replicatedLogLeaderTargetIs;
 exports.replicatedLogLeaderPlanIs = replicatedLogLeaderPlanIs;
+exports.replicatedLogLeaderPlanChanged = replicatedLogLeaderPlanChanged;
 exports.replicatedLogLeaderCommitFail = replicatedLogLeaderCommitFail;

--- a/js/server/modules/@arangodb/testutils/replicated-logs-predicates.js
+++ b/js/server/modules/@arangodb/testutils/replicated-logs-predicates.js
@@ -194,17 +194,15 @@ const replicatedLogLeaderPlanIs = function (database, stateId, expectedLeader) {
 
 const replicatedLogLeaderPlanChanged = function (database, stateId, oldLeader) {
   return function () {
-    try {
-      const {leader: currentLeader} = LH.getReplicatedLogLeaderPlan(database, stateId);
-      if (currentLeader !== oldLeader) {
+      const leaderPlan = LH.getReplicatedLogLeaderPlan(database, stateId);
+      if (leaderPlan instanceof Error) {
+        return leaderPlan;
+      }
+      if (leaderPlan.leader !== oldLeader) {
         return true;
       } else {
         return new Error(`Expected log leader to switch from ${oldLeader}, but is still the same`);
       }
-    } catch (error) {
-      // There might be no current term or no leader in plan
-      return error;
-    }
   };
 };
 


### PR DESCRIPTION
### Scope & Purpose

When the user dictates a leader by setting it in `Target`, the system finds a way of ensuring that the certain participant eventually becomes leader. In order to do that, it has to set the `forced` flag on the required participant. In case the server fails, this setting will prevent any new entries from being committed into the log.

This PR brings an additional health check to the `getParticipantWithUpdatedFlags` and `leaderInTarget` functions, preventing a failed leader from being forced.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [x] C++ **Unit tests**
  - [x] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*
  - [ ] Backport for 3.7: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

