### PR TITLE
Velocypack Inspection for Empty Objects

### DIFF
--- a/lib/Inspection/VPackLoadInspector.h
+++ b/lib/Inspection/VPackLoadInspector.h
@@ -329,6 +329,10 @@ struct VPackLoadInspectorImpl
   }
 
  protected:
+  Status::Success parseFields(velocypack::Slice* slices) {
+    return Status::Success{};
+  }
+
   template<class Arg>
   Status parseFields(velocypack::Slice* slices, Arg&& arg) {
     return parseField(*slices, std::forward<Arg>(arg));

--- a/lib/Inspection/VPackSaveInspector.h
+++ b/lib/Inspection/VPackSaveInspector.h
@@ -115,6 +115,8 @@ struct VPackSaveInspector : InspectorBase<VPackSaveInspector> {
            | [&]() { return endObject(); };     //
   }
 
+  auto applyFields() { return Status::Success{}; }
+
   template<class Arg, class... Args>
   auto applyFields(Arg&& arg, Args&&... args) {
     auto res = self().applyField(std::forward<Arg>(arg));

--- a/tests/Basics/InspectionTest.cpp
+++ b/tests/Basics/InspectionTest.cpp
@@ -480,6 +480,7 @@ TEST_F(VPackSaveInspectorTest, store_empty_object) {
   auto result = inspector.apply(empty);
   EXPECT_TRUE(result.ok());
   EXPECT_TRUE(builder.slice().isObject());
+  EXPECT_EQ(0, builder.slice().length());
 }
 
 TEST_F(VPackSaveInspectorTest, store_int) {

--- a/tests/Basics/InspectionTest.cpp
+++ b/tests/Basics/InspectionTest.cpp
@@ -343,6 +343,13 @@ auto inspect(Inspector& f, EnumStorage<Enum>& e) {
                               f.field("message", e.message));
   }
 }
+
+struct AnEmptyObject {};
+template<class Inspector>
+auto inspect(Inspector& f, AnEmptyObject& x) {
+  return f.object(x).fields();
+}
+
 }  // namespace
 
 namespace arangodb::inspection {
@@ -467,6 +474,13 @@ struct VPackSaveInspectorTest : public ::testing::Test {
   velocypack::Builder builder;
   VPackSaveInspector inspector{builder};
 };
+
+TEST_F(VPackSaveInspectorTest, store_empty_object) {
+  auto empty = AnEmptyObject{};
+  auto result = inspector.apply(empty);
+  EXPECT_TRUE(result.ok());
+  EXPECT_TRUE(builder.slice().isObject());
+}
 
 TEST_F(VPackSaveInspectorTest, store_int) {
   int x = 42;
@@ -852,6 +866,16 @@ TEST_F(VPackSaveInspectorTest, store_unqualified_variant) {
 struct VPackLoadInspectorTest : public ::testing::Test {
   velocypack::Builder builder;
 };
+
+TEST_F(VPackLoadInspectorTest, load_empty_object) {
+  builder.openObject();
+  builder.close();
+  VPackLoadInspector inspector{builder};
+
+  auto d = AnEmptyObject{};
+  auto result = inspector.apply(d);
+  ASSERT_TRUE(result.ok());
+}
 
 TEST_F(VPackLoadInspectorTest, load_int) {
   builder.add(VPackValue(42));


### PR DESCRIPTION
### Scope & Purpose

Support empty objects in VelocyPack inspection.

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [x] Tests
  - [ ] **Regression tests**
  - [x] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

