### PR TITLE
[3.8] no fatal error missing local timestamp agency state

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 v3.8.7 (XXXX-XX-XX)
 -------------------
 
+* No good reason to fatal error in agency state, when local database entries
+  lack local timestamp (legacy). In that situation, we will record epoch
+  begin as local time.
+
 * Updated OpenSSL to 1.1.1o and OpenLDAP to 2.6.2.
 
 * Added option `--enable-revision-trees` to arangorestore, which will add the

--- a/arangod/Agency/State.cpp
+++ b/arangod/Agency/State.cpp
@@ -1155,7 +1155,7 @@ bool State::loadRemaining(index_t cind) {
       if (auto milliSlice = ii.get("epoch_millis"); milliSlice.isNumber()) {
         try {
           millis = milliSlice.getNumber<uint64_t>();
-        }
+        } catch (...) {}
       }
 
       // Empty patches :

--- a/arangod/Agency/State.cpp
+++ b/arangod/Agency/State.cpp
@@ -1155,14 +1155,7 @@ bool State::loadRemaining(index_t cind) {
       if (auto milliSlice = ii.get("epoch_millis"); milliSlice.isNumber()) {
         try {
           millis = milliSlice.getNumber<uint64_t>();
-        } catch (std::exception const& e) {
-          LOG_TOPIC("2ee75", FATAL, Logger::AGENCY)
-            << "Failed to parse integer value for epoch_millis: " << e.what();
-          FATAL_ERROR_EXIT();
         }
-      } else {
-        LOG_TOPIC("52ee7", FATAL, Logger::AGENCY) << "epoch_millis is not an integer type";
-        FATAL_ERROR_EXIT();
       }
 
       // Empty patches :


### PR DESCRIPTION
### Scope & Purpose

*Do not fatal error on missing local timestamp in persisted log entries in agent*

- [X] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*
  - [ ] Backport for 3.7: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

