### PR TITLE
try to fix test

### DIFF
--- a/tests/js/server/recovery/view-arangosearch-link-recover-view-not-again-noncluster.js
+++ b/tests/js/server/recovery/view-arangosearch-link-recover-view-not-again-noncluster.js
@@ -56,7 +56,9 @@ function runSetup () {
   
   lastTick = replication.logger.state().state.lastLogTick;
   c.insert({ _key: "lastLogTick2", tick: lastTick });
-  
+ 
+  // make sure view has caught up
+  db._query(`FOR doc IN ${vn} SEARCH doc.value1 == 42 OPTIONS {waitForSync: true} RETURN doc`);
   internal.waitForEstimatorSync();
   
   lastTick = replication.logger.state().state.lastLogTick;


### PR DESCRIPTION
### Scope & Purpose

Attempt to fix a sometimes-unstable test that runs into this assertion:
```
* Test "recovery_2"
    [FAILED]  tests/js/server/recovery/view-arangosearch-link-recover-view-not-again-noncluster.js

      "testIResearchRecoverWithTickInPast" failed: Error: at assertion #3: { "storedTick1" : "2037", "storedTick2" : "2043", "storedTick3" : "2105", "recoverTick" : "2041" }: (false) does not evaluate to true
(Error
    at assertTrue (/work/ArangoDB/js/common/modules/jsunity/jsunity.js:71:19)
    at Object.testIResearchRecoverWithTickInPast (tests/js/server/recovery/view-arangosearch-link-recover-view-not-again-noncluster.js:85:7)
```
This change only affects the test code. The change has been made in devel already. 3.8 and 3.7 do not have the test in question.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [x] Backports
  - [x] Backport for 3.9: this PR
  - [ ] Backport for 3.8: -
  - [ ] Backport for 3.7: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

