### PR TITLE
Fix shutdown hang

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 v3.8.7 (XXXX-XX-XX)
 -------------------
 
+* Fixed a potential hang on shutdown, when there were still document operations
+  queued.
+
 * Fixed BTS-860. Changed ArangoSearch index recovery procedure to remove
   necessity to always fully recreate index if IndexCreation marker encountered.
 

--- a/arangod/VocBase/vocbase.cpp
+++ b/arangod/VocBase/vocbase.cpp
@@ -1737,9 +1737,16 @@ std::vector<std::shared_ptr<arangodb::LogicalView>> TRI_vocbase_t::views() {
 }
 
 void TRI_vocbase_t::processCollectionsOnShutdown(std::function<void(LogicalCollection*)> const& cb) {
-  RECURSIVE_WRITE_LOCKER(_dataSourceLock, _dataSourceLockWriteOwner);
+  std::vector<std::shared_ptr<arangodb::LogicalCollection>> collections;
 
-  for (auto const& it : _collections) {
+  // make a copy of _collections, so we can call the callback function without
+  // the lock
+  {
+    RECURSIVE_READ_LOCKER(_dataSourceLock, _dataSourceLockWriteOwner);
+    collections = _collections;
+  }
+
+  for (auto const& it : collections) {
     cb(it.get());
   }
 }


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/16273

* Fixed a potential hang on shutdown, when there were still document operations
  queued.

The same bugfix has been made in devel in December, and does not seem to have caused any issues since then.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [x] Backports
  - [x] Backport for 3.9: https://github.com/arangodb/arangodb/pull/16273
  - [x] Backport for 3.8: this PR
  - [ ] Backport for 3.7: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 