### PR TITLE
Fix ambiguity between date::format and std::format with MSVC 16.11.14

### DIFF
--- a/lib/Basics/datetime.cpp
+++ b/lib/Basics/datetime.cpp
@@ -291,8 +291,8 @@ std::
                  }},
                 {"%z",
                  [](std::string& wrk, arangodb::tp_sys_clock_ms const& tp) {
-                   std::string formatted =
-                       format("%FT%TZ", floor<std::chrono::milliseconds>(tp));
+                   std::string formatted = date::format(
+                       "%FT%TZ", floor<std::chrono::milliseconds>(tp));
                    wrk.append(formatted);
                  }},
                 {"%w",


### PR DESCRIPTION
### Scope & Purpose

Fix compile error, see title.

- [X] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*
  - [ ] Backport for 3.7: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

