### PR TITLE
[CINFRA-374] Delete from Target -> Drop from Plan

### DIFF
--- a/arangod/Agency/Supervision.h
+++ b/arangod/Agency/Supervision.h
@@ -195,6 +195,9 @@ class Supervision : public arangodb::Thread {
   /// @brief Check replicated logs
   void checkReplicatedStates();
 
+  /// @brief Check replicated logs
+  void cleanupReplicatedLogs();
+
   struct ResourceCreatorLostEvent {
     std::shared_ptr<Node> const& resource;
     std::string const& coordinatorId;

--- a/arangod/Replication2/AgencyMethods.cpp
+++ b/arangod/Replication2/AgencyMethods.cpp
@@ -137,14 +137,20 @@ auto methods::updateTermSpecification(DatabaseID const& database, LogId id,
 auto methods::deleteReplicatedLogTrx(arangodb::agency::envelope envelope,
                                      DatabaseID const& database, LogId id)
     -> arangodb::agency::envelope {
-  auto path =
+  auto planPath =
       paths::plan()->replicatedLogs()->database(database)->log(id)->str();
+  auto targetPath =
+      paths::target()->replicatedLogs()->database(database)->log(id)->str();
+  auto currentPath =
+      paths::current()->replicatedLogs()->database(database)->log(id)->str();
 
   return envelope.write()
-      .remove(path)
+      .remove(planPath)
       .inc(paths::plan()->version()->str())
-      .precs()
-      .isNotEmpty(path)
+      .remove(targetPath)
+      .inc(paths::target()->version()->str())
+      .remove(currentPath)
+      .inc(paths::current()->version()->str())
       .end();
 }
 

--- a/arangod/Replication2/ReplicatedLog/AgencyLogSpecification.h
+++ b/arangod/Replication2/ReplicatedLog/AgencyLogSpecification.h
@@ -33,6 +33,7 @@
 
 #include <optional>
 #include <type_traits>
+#include <utility>
 
 namespace arangodb::replication2::agency {
 
@@ -43,8 +44,8 @@ struct LogPlanTermSpecification {
     ParticipantId serverId;
     RebootId rebootId;
 
-    Leader(ParticipantId const& participant, RebootId const& rebootId)
-        : serverId{participant}, rebootId{rebootId} {}
+    Leader(ParticipantId participant, RebootId rebootId)
+        : serverId{std::move(participant)}, rebootId{rebootId} {}
     Leader() : rebootId{RebootId{0}} {};
     auto toVelocyPack(VPackBuilder&) const -> void;
     friend auto operator==(Leader const&, Leader const&) noexcept
@@ -68,6 +69,8 @@ struct LogPlanSpecification {
   std::optional<LogPlanTermSpecification> currentTerm;
 
   ParticipantsConfig participantsConfig;
+
+  std::optional<std::string> owner;
 
   auto toVelocyPack(velocypack::Builder&) const -> void;
   [[nodiscard]] static auto fromVelocyPack(velocypack::Slice)

--- a/arangod/Replication2/ReplicatedLog/AgencySpecificationInspectors.h
+++ b/arangod/Replication2/ReplicatedLog/AgencySpecificationInspectors.h
@@ -53,6 +53,7 @@ auto constexpr MaxActionsTraceLength =
     std::string_view{"maxActionsTraceLength"};
 auto constexpr Code = std::string_view{"code"};
 auto constexpr Message = std::string_view{"message"};
+auto constexpr Owner = std::string_view{"owner"};
 }  // namespace static_strings
 
 template<class Inspector>
@@ -73,6 +74,7 @@ auto inspect(Inspector& f, LogPlanSpecification& x) {
   return f.object(x).fields(
       f.field(StaticStrings::Id, x.id),
       f.field(StaticStrings::CurrentTerm, x.currentTerm),
+      f.field(static_strings::Owner, x.owner),
       f.field(static_strings::ParticipantsConfig, x.participantsConfig));
 };
 

--- a/arangod/Replication2/ReplicatedLog/SupervisionAction.cpp
+++ b/arangod/Replication2/ReplicatedLog/SupervisionAction.cpp
@@ -93,6 +93,9 @@ auto execute(Action const& action, DatabaseID const& dbName, LogId const& log,
                       })
                   .inc(paths::current()->version()->str());
             })
+      .precs()
+      .isNotEmpty(
+          paths::target()->replicatedLogs()->database(dbName)->log(log)->str())
       .end();
 }
 

--- a/arangod/Replication2/ReplicatedLog/SupervisionAction.h
+++ b/arangod/Replication2/ReplicatedLog/SupervisionAction.h
@@ -177,9 +177,11 @@ struct AddLogToPlanAction {
   std::optional<LogPlanTermSpecification::Leader> _leader;
 
   auto execute(ActionContext& ctx) const -> void {
-    ctx.setPlan(LogPlanSpecification(
+    auto newPlan = LogPlanSpecification(
         _id, LogPlanTermSpecification(LogTerm{1}, _config, _leader),
-        ParticipantsConfig{.generation = 1, .participants = _participants}));
+        ParticipantsConfig{.generation = 1, .participants = _participants});
+    newPlan.owner = "target";
+    ctx.setPlan(newPlan);
   }
 };
 template<typename Inspector>

--- a/tests/js/server/replication2/replication2-supervision-replicated-log-target-drop-cluster.js
+++ b/tests/js/server/replication2/replication2-supervision-replicated-log-target-drop-cluster.js
@@ -1,0 +1,61 @@
+/*jshint strict: true */
+/*global assertTrue, assertEqual*/
+'use strict';
+
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2021 ArangoDB GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License")
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Lars Maier
+////////////////////////////////////////////////////////////////////////////////
+
+const jsunity = require('jsunity');
+const lh = require("@arangodb/testutils/replicated-logs-helper");
+const lpreds = require("@arangodb/testutils/replicated-logs-predicates");
+
+const database = "replication2_supervision_test_drop_db";
+
+const {setUpAll, tearDownAll, setUp, tearDown} = lh.testHelperFunctions(database);
+
+const replicatedLogSuite = function () {
+
+  const targetConfig = {
+    writeConcern: 2,
+    softWriteConcern: 2,
+    replicationFactor: 3,
+    waitForSync: false,
+  };
+
+  return {
+    setUpAll, tearDownAll,
+    setUp, tearDown,
+
+    // This test create a replicated log in target and then drops it again
+    // we expect Plan and Current to be deleted
+    testDropFromTarget: function () {
+      const {logId} = lh.createReplicatedLog(database, targetConfig);
+      lh.waitForReplicatedLogAvailable(logId);
+      lh.replicatedLogDeleteTarget(database, logId);
+
+      lh.waitFor(lpreds.replicatedLogIsGone(database, logId));
+    },
+  };
+};
+
+jsunity.run(replicatedLogSuite);
+return jsunity.done();


### PR DESCRIPTION
### Scope & Purpose
When deleting a replicated log, the coordinator deletes the log from Target, Plan and Current. The supervision checks if a replicated log in Plan has the `owner` attribute set to `target`. If it finds such a log, it checks if a log with the same id is found in Target. If that is not the case, it deletes that replicated log.

Furthermore the supervision now adds a precondition to all modifications of plan, ensuring that target is still in place.