### PR TITLE
[3.7] fix default collection property cache enabled

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 v3.7.18 (XXXX-XX-XX)
 --------------------
 
+* Fix documentation of collection's `cacheEnabled` property default.
+
 * Fixed Github issue #16279: assertion failure/crash in AQL query optimizer when
   permuting adjacent FOR loops that depended on each other.
 

--- a/Documentation/DocuBlocks/Rest/Collections/post_api_collection.md
+++ b/Documentation/DocuBlocks/Rest/Collections/post_api_collection.md
@@ -102,7 +102,7 @@ The following values for `type` are valid:<br>
 
 @RESTBODYPARAM{cacheEnabled,boolean,optional,}
 Whether the in-memory hash cache for documents should be enabled for this
-collection (default: `true`). Can be controlled globally with the `--cache.size`
+collection (default: `false`). Can be controlled globally with the `--cache.size`
 startup option. The cache can speed up repeated reads of the same documents via
 their document keys. If the same documents are not fetched often or are
 modified frequently, then you may disable the cache to avoid the maintenance

--- a/Documentation/DocuBlocks/Rest/Collections/put_api_collection_properties.md
+++ b/Documentation/DocuBlocks/Rest/Collections/put_api_collection_properties.md
@@ -27,7 +27,7 @@ document create, update, replace or removal operation. (default: false)
 
 @RESTBODYPARAM{cacheEnabled,boolean,optional,}
 Whether the in-memory hash cache for documents should be enabled for this
-collection (default: *true*). Can be controlled globally with the `--cache.size`
+collection (default: *false*). Can be controlled globally with the `--cache.size`
 startup option. The cache can speed up repeated reads of the same documents via
 their document keys. If the same documents are not fetched often or are
 modified frequently, then you may disable the cache to avoid the maintenance


### PR DESCRIPTION
[### Scope & Purpose

*fix default collection property cache enabled*

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
- [X] :book: Documentation 

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*
  - [ ] Backport for 3.7: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

](https://github.com/arangodb/arangodb/pull/16289)