### PR TITLE
decrease wait time in agency inception in case of HTTP 503

### DIFF
--- a/arangod/Agency/Inception.cpp
+++ b/arangod/Agency/Inception.cpp
@@ -95,7 +95,7 @@ void handleGossipResponse(arangodb::network::Response const& r,
         // service unavailable
         LOG_TOPIC("f9c3f", INFO, Logger::AGENCY)
             << "Gossip endpoint " << endpoint << " is still unavailable";
-        std::this_thread::sleep_for(std::chrono::seconds(10));
+        std::this_thread::sleep_for(std::chrono::milliseconds(500));
         break;
 
       default:


### PR DESCRIPTION
### Scope & Purpose

Previously, when the inception received an HTTP 503 error, it could fail
with a VelocyPack error when trying to unserialize data in the response
body that was not there. This issue was fixed about a week ago. Now an
agent will handle 503 responses correctly, but it will go to a 10
seconds sleep. This is too long, because it delays the cluster start
unnecessarily. Reduce the sleep duration to 500ms when getting an HTTP
503.
The original bugfix with the 10 seconds sleep time was not released yet.
So no extra CHANGELOG entry is added for reducing the sleep duration.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [x] Backports
  - [x] Backport for 3.9: this PR
  - [ ] Backport for 3.8: -
  - [ ] Backport for 3.7: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 