### PR TITLE
Improve CHANGELOG for IO heartbeat

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -158,6 +158,8 @@ devel
     - `arangodb_ioheartbeat_delays_total`: total number of delayed io heartbeats
     - `arangodb_ioheartbeat_duration`: histogram of execution times [us]
     - `arangodb_ioheartbeat_failures_total`: total number of failures
+  These metrics are only populated, if `--database.io-heartbeat` is set to
+  `true` (which is currently the default).
 
 * Fix lock order in Agent::advanceCommitIndex for State's _logLock and
   Agent's _waitForCV.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -154,8 +154,10 @@ devel
 
 * Added an IO heartbeat which checks that the underlying volume is writable
   with reasonable performance. The test is done every 15 seconds and can
-  be explicitly switched off. New metrics to give visibility if the test
-  fails.
+  explicitly switched off. New metrics to give visibility if the test fails:
+    - `arangodb_ioheartbeat_delays_total`: total number of delayed io heartbeats
+    - `arangodb_ioheartbeat_duration`: histogram of execution times [us]
+    - `arangodb_ioheartbeat_failures_total`: total number of failures
 
 * Fix lock order in Agent::advanceCommitIndex for State's _logLock and
   Agent's _waitForCV.


### PR DESCRIPTION
This PR adds the new metrics for the IO heartbeat to the CHANGELOG

### Checklist

- [*] Backports
  - [*] Backport for 3.9: https://github.com/arangodb/arangodb/pull/16294
  - [*] Backport for 3.8: https://github.com/arangodb/arangodb/pull/16296

