### PR TITLE
Improve CHANGELOG for IO heartbeat

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -61,7 +61,12 @@ v3.8.7 (XXXX-XX-XX)
 
 * Added an IO heartbeat which checks that the underlying volume is writable with
   reasonable performance. The test is done every 15 seconds and can be
-  explicitly switched off. New metrics to give visibility if the test fails.
+  explicitly switched off. New metrics to give visibility if the test fails:
+    - `arangodb_ioheartbeat_delays_total`: total number of delayed io heartbeats
+    - `arangodb_ioheartbeat_duration`: histogram of execution times [us]
+    - `arangodb_ioheartbeat_failures_total`: total number of failures
+  These metrics are only populated, if `--database.io-heartbeat` is set to
+  `true` (which is currently the default).
 
 * Resync follower shard after a follower restart immediately and not lazily
   (BTS-829).


### PR DESCRIPTION
This PR adds the new metrics for the IO heartbeat to the CHANGELOG

### Checklist

- [*] Backports
  - [*] Backport for 3.9: https://github.com/arangodb/arangodb/pull/16294
  - [*] Backport for 3.8: This is 3.8.


