### PR TITLE
[3.8] Fix for ES-1147

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 v3.8.7 (XXXX-XX-XX)
 -------------------
 
+* Fix ES-1147. Fixed boost propagation in STARTS_WITH function.
+
 * Fix documentation of collection's `cacheEnabled` property default.
 
 * Make all requests which are needed for shard resync at least medium priority

--- a/arangod/IResearch/IResearchFilterFactory.cpp
+++ b/arangod/IResearch/IResearchFilterFactory.cpp
@@ -3581,7 +3581,6 @@ Result fromFuncStartsWith(
 
     TRI_ASSERT(filterCtx.analyzer);
     kludge::mangleField(name, filterCtx.analyzer);
-    filter->boost(filterCtx.boost);
 
     if (isMultiPrefix) {
       auto& minMatchFilter = filter->add<irs::Or>();

--- a/arangod/IResearch/IResearchFilterFactory.cpp
+++ b/arangod/IResearch/IResearchFilterFactory.cpp
@@ -3586,12 +3586,17 @@ Result fromFuncStartsWith(
     if (isMultiPrefix) {
       auto& minMatchFilter = filter->add<irs::Or>();
       minMatchFilter.min_match_count(static_cast<size_t>(minMatchCount));
+      minMatchFilter.boost(filterCtx.boost);
       // become a new root
       filter = &minMatchFilter;
     }
 
     for (size_t i = 0, size = prefixes.size(); i < size; ++i) {
       auto& prefixFilter = filter->add<irs::by_prefix>();
+      if (!isMultiPrefix) {
+        TRI_ASSERT(prefixes.size() == 1);
+        prefixFilter.boost(filterCtx.boost);
+      }
       if (i + 1 < size) {
         *prefixFilter.mutable_field() = name;
       } else {

--- a/tests/IResearch/IResearchFilterFunction-test.cpp
+++ b/tests/IResearch/IResearchFilterFunction-test.cpp
@@ -5481,8 +5481,8 @@ TEST_F(IResearchFilterFunctionTest, StartsWith) {
   // with scoring limit (double), boost
   {
     irs::Or expected;
-    expected.boost(3.1f);
     auto& prefix = expected.add<irs::by_prefix>();
+    prefix.boost(3.1f);
     *prefix.mutable_field() = mangleStringIdentity("name");
     auto* opt = prefix.mutable_options();
     opt->term = irs::ref_cast<irs::byte_type>(irs::string_ref("abc"));
@@ -5503,10 +5503,10 @@ TEST_F(IResearchFilterFunctionTest, StartsWith) {
   // with scoring limit with min match count (double), boost
   {
     irs::Or expected;
-    expected.boost(3.1f);
     auto& orFilter = expected.add<irs::Or>();
     orFilter.min_match_count(2);
     auto& prefix = orFilter.add<irs::by_prefix>();
+    orFilter.boost(3.1f);
     *prefix.mutable_field() = mangleStringIdentity("name");
     auto* opt = prefix.mutable_options();
     opt->term = irs::ref_cast<irs::byte_type>(irs::string_ref("abc"));


### PR DESCRIPTION
### Scope & Purpose

Fix boost propagation in STARTS_WITH function. 
Fix in newer version was merged as part of #14744

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [x] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*
  - [ ] Backport for 3.7: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

