### PR TITLE
Fix behavior when accessing document APIs with view names

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 devel
 -----
 
+* Fix behavior when accessing a view instead of a collection by name in a REST
+  document operation. Now return a proper error.
+
 * Upgraded bundled version of RocksDB to 7.2.
 
 * Fix documentation of collection's `cacheEnabled` property default.

--- a/arangod/Utils/SingleCollectionTransaction.cpp
+++ b/arangod/Utils/SingleCollectionTransaction.cpp
@@ -83,7 +83,10 @@ TransactionCollection* SingleCollectionTransaction::resolveTrxCollection() {
     }
   }
 
-  TRI_ASSERT(_trxCollection != nullptr);
+  if (_trxCollection == nullptr) {
+    THROW_ARANGO_EXCEPTION(TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND);
+  }
+
   return _trxCollection;
 }
 
@@ -94,7 +97,11 @@ LogicalCollection* SingleCollectionTransaction::documentCollection() {
   if (_documentCollection == nullptr) {
     resolveTrxCollection();
   }
-  TRI_ASSERT(_documentCollection != nullptr);
+
+  if (_documentCollection == nullptr) {
+    THROW_ARANGO_EXCEPTION(TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND);
+  }
+
   return _documentCollection;
 }
 

--- a/js/client/modules/@arangodb/testutils/testrunner.js
+++ b/js/client/modules/@arangodb/testutils/testrunner.js
@@ -222,6 +222,7 @@ let databasesTest = {
     // TODO: we are currently filtering out the UnitTestDB here because it is 
     // created and not cleaned up by a lot of the `authentication` tests. This
     // should be fixed eventually
+    db._useDatabase('_system');
     let databasesAfter = db._databases().filter((name) => name !== 'UnitTestDB');
     if (databasesAfter.length !== 1 || databasesAfter[0] !== '_system') {
       obj.results[te] = {

--- a/js/common/modules/jsunity.js
+++ b/js/common/modules/jsunity.js
@@ -95,10 +95,8 @@ jsUnity.results.fail = function (index, testName, message) {
 
   ++testCount;
 
-  if (RESULTS[testName] === undefined)
-  {
-    if (testCount === 1)
-    {
+  if (RESULTS[testName] === undefined) {
+    if (testCount === 1) {
       print(newtime.toISOString() + internal.COLORS.COLOR_RED + " [   FAILED   ] " + currentSuiteName +
            internal.COLORS.COLOR_RESET + " (setUpAll: " + (jsUnity.env.getDate() - STARTTEST) + "ms)");
 
@@ -115,19 +113,28 @@ jsUnity.results.fail = function (index, testName, message) {
 
   RESULTS[testName].status = false;
   RESULTS[testName].message = message;
-  RESULTS[testName].duration = (ENDTEST - STARTTEST);
 
-  if (RESULTS[testName].setUpDuration === undefined)
-  {
+  RESULTS[testName].duration = (ENDTEST - STARTTEST);
+  if (RESULTS[testName].duration < 0) {
+    // if ENDTEST not set...
+    RESULTS[testName].duration = 0;
+  }
+
+  if (RESULTS[testName].setUpDuration === undefined) {
     RESULTS[testName].setUpDuration = newtime - SETUPS;
     RESULTS[testName].duration = 0;
+    RESULTS[testName].tearDownDuration = 0;
+  }
+  
+  if (RESULTS[testName].tearDownDuration === undefined) {
+    RESULTS[testName].tearDownDuration = 0;
   }
 
   print(newtime.toISOString() + internal.COLORS.COLOR_RED + " [   FAILED   ] " +
        testName + internal.COLORS.COLOR_RESET +
        ' (setUp: ' + RESULTS[testName].setUpDuration + 'ms,' +
        ' test: ' + RESULTS[testName].duration + 'ms,' +
-       ' tearDown: ' +  (newtime - ENDTEST) + 'ms)\n' +
+       ' tearDown: ' +  RESULTS[testName].tearDownDuration + 'ms)\n' +
        internal.COLORS.COLOR_RED + message + internal.COLORS.COLOR_RESET);
 
   STARTTEST = newtime;

--- a/js/common/modules/jsunity/jsunity.js
+++ b/js/common/modules/jsunity/jsunity.js
@@ -541,8 +541,11 @@ var jsUnity = exports.jsUnity = (function () {
               try {
                 if (!didSetUp && !skipTest) {
                   this.results.beginSetUp(suite.scope, test.name);
-                  setUp(test.name);
-                  this.results.endSetUp(suite.scope, test.name);
+                  try {
+                    setUp(test.name);
+                  } finally {
+                    this.results.endSetUp(suite.scope, test.name);
+                  }
                   didSetUp = true;
                 }
                 if (!didTest && !skipTest) {
@@ -551,8 +554,11 @@ var jsUnity = exports.jsUnity = (function () {
                 }
                 if (!didTearDown && !skipTest) {
                   this.results.beginTeardown(suite.scope, test.name);
-                  tearDown(test.name);
-                  this.results.endTeardown(suite.scope, test.name);
+                  try {
+                    tearDown(test.name);
+                  } finally {
+                    this.results.endTeardown(suite.scope, test.name);
+                  }
                   didTearDown = true;
                 }
 

--- a/tests/js/client/shell/api/view-instead-of-collection.js
+++ b/tests/js/client/shell/api/view-instead-of-collection.js
@@ -1,0 +1,134 @@
+/* jshint globalstrict:false, strict:false, maxlen: 200 */
+/* global assertEqual, arango, fail */
+
+// //////////////////////////////////////////////////////////////////////////////
+// / DISCLAIMER
+// /
+// / Copyright 2018 ArangoDB GmbH, Cologne, Germany
+// /
+// / Licensed under the Apache License, Version 2.0 (the "License")
+// / you may not use this file except in compliance with the License.
+// / You may obtain a copy of the License at
+// /
+// /     http://www.apache.org/licenses/LICENSE-2.0
+// /
+// / Unless required by applicable law or agreed to in writing, software
+// / distributed under the License is distributed on an "AS IS" BASIS,
+// / WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// / See the License for the specific language governing permissions and
+// / limitations under the License.
+// /
+// / Copyright holder is triAGENS GmbH, Cologne, Germany
+// /
+// / @author Jan Steemann
+// //////////////////////////////////////////////////////////////////////////////
+
+const jsunity = require('jsunity');
+const arangodb = require('@arangodb');
+const db = arangodb.db;
+const internal = require("internal");
+
+function testSuite () {
+  'use strict';
+  const cn = "UnitTestsCollection";
+  const vn = "UnitTestsView";
+  
+  return {
+    setUpAll: function () {
+      let c = db._create(cn);
+      c.insert({ _key: "test" });
+      db._createView(vn, "arangosearch", {});
+    },
+
+    tearDownAll: function () {
+      db._drop(cn);
+      db._dropView(vn);
+    },
+    
+    testGetDocument: function () {
+      let result = arango.GET_RAW("/_api/document/" + encodeURIComponent(cn) + "/test");
+      assertEqual(200, result.code);
+      
+      result = arango.GET_RAW("/_api/document/" + encodeURIComponent(vn) + "/test");
+      assertEqual(404, result.code);
+      assertEqual(internal.errors.ERROR_ARANGO_DATA_SOURCE_NOT_FOUND.code, result.parsedBody.errorNum);
+    },
+    
+    testInsertDocument: function () {
+      let result = arango.POST_RAW("/_api/document/" + encodeURIComponent(cn), {});
+      assertEqual(202, result.code);
+      
+      result = arango.POST_RAW("/_api/document/" + encodeURIComponent(vn), {});
+      assertEqual(404, result.code);
+      assertEqual(internal.errors.ERROR_ARANGO_DATA_SOURCE_NOT_FOUND.code, result.parsedBody.errorNum);
+    },
+    
+    testUpdateDocument: function () {
+      let result = arango.PATCH_RAW("/_api/document/" + encodeURIComponent(cn) + "/test", {});
+      assertEqual(202, result.code);
+      
+      result = arango.PATCH_RAW("/_api/document/" + encodeURIComponent(vn) + "/test", {});
+      assertEqual(404, result.code);
+      assertEqual(internal.errors.ERROR_ARANGO_DATA_SOURCE_NOT_FOUND.code, result.parsedBody.errorNum);
+    },
+    
+    testReplaceDocument: function () {
+      let result = arango.PUT_RAW("/_api/document/" + encodeURIComponent(cn) + "/test", {});
+      assertEqual(202, result.code);
+      
+      result = arango.PUT_RAW("/_api/document/" + encodeURIComponent(vn) + "/test", {});
+      assertEqual(404, result.code);
+      assertEqual(internal.errors.ERROR_ARANGO_DATA_SOURCE_NOT_FOUND.code, result.parsedBody.errorNum);
+    },
+    
+    testRemoveDocument: function () {
+      let key = arango.POST_RAW("/_api/document/" + encodeURIComponent(cn), {}).parsedBody._key;
+      let result = arango.DELETE_RAW("/_api/document/" + encodeURIComponent(cn) + "/" + encodeURIComponent(key));
+      assertEqual(202, result.code);
+      
+      key = arango.POST_RAW("/_api/document/" + encodeURIComponent(cn), {}).parsedBody._key;
+      result = arango.DELETE_RAW("/_api/document/" + encodeURIComponent(vn) + "/" + encodeURIComponent(key));
+      assertEqual(404, result.code);
+      assertEqual(internal.errors.ERROR_ARANGO_DATA_SOURCE_NOT_FOUND.code, result.parsedBody.errorNum);
+    },
+    
+    testAQLInsertDocument: function () {
+      try {
+        db._query(`INSERT {} INTO ${vn}`);
+        fail();
+      } catch (err) {
+        assertEqual(internal.errors.ERROR_ARANGO_COLLECTION_TYPE_MISMATCH.code, err.errorNum);
+      }
+    },
+
+    testAQLUpdateDocument: function () {
+      try {
+        db._query(`UPDATE 'test' WITH {} IN ${vn}`);
+        fail();
+      } catch (err) {
+        assertEqual(internal.errors.ERROR_ARANGO_COLLECTION_TYPE_MISMATCH.code, err.errorNum);
+      }
+    },
+    
+    testAQLReplaceDocument: function () {
+      try {
+        db._query(`REPLACE 'test' WITH {} IN ${vn}`);
+        fail();
+      } catch (err) {
+        assertEqual(internal.errors.ERROR_ARANGO_COLLECTION_TYPE_MISMATCH.code, err.errorNum);
+      }
+    },
+    
+    testAQLRemoveDocument: function () {
+      try {
+        db._query(`REMOVE 'test' IN ${vn}`);
+        fail();
+      } catch (err) {
+        assertEqual(internal.errors.ERROR_ARANGO_COLLECTION_TYPE_MISMATCH.code, err.errorNum);
+      }
+    },
+  };
+}
+
+jsunity.run(testSuite);
+return jsunity.done();


### PR DESCRIPTION
### Scope & Purpose

Fix behavior when accessing document APIs with view names.
Now a proper error is returned on such attempts.
This PR also fixes some issues in testing.js when it returned negative numbers for setup/teardown or test durations, and also failed on cleaning up leftover collections/databases from tests if it wasn't already in the `_system` database.
Also fixes line endings (\n instead of \r\n) in some JavaScript file.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [x] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [x] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [x] Backports
  - [x] Backport for 3.9: https://github.com/arangodb/arangodb/pull/16299
  - [x] Backport for 3.8: https://github.com/arangodb/arangodb/pull/16302
  - [ ] Backport for 3.7: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 