### PR TITLE
Fix behavior when accessing document APIs with view names

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 v3.8.7 (XXXX-XX-XX)
 -------------------
 
+* Fix behavior when accessing a view instead of a collection by name in a REST
+  document operation. Now return a proper error.
+
 * Fix documentation of collection's `cacheEnabled` property default.
 
 * Make all requests which are needed for shard resync at least medium priority

--- a/arangod/Utils/SingleCollectionTransaction.cpp
+++ b/arangod/Utils/SingleCollectionTransaction.cpp
@@ -82,7 +82,10 @@ TransactionCollection* SingleCollectionTransaction::resolveTrxCollection() {
     }
   }
 
-  TRI_ASSERT(_trxCollection != nullptr);
+  if (_trxCollection == nullptr) {
+    THROW_ARANGO_EXCEPTION(TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND);
+  }
+
   return _trxCollection;
 }
 
@@ -93,7 +96,11 @@ LogicalCollection* SingleCollectionTransaction::documentCollection() {
   if (_documentCollection == nullptr) {
     resolveTrxCollection();
   }
-  TRI_ASSERT(_documentCollection != nullptr);
+
+  if (_documentCollection == nullptr) {
+    THROW_ARANGO_EXCEPTION(TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND);
+  }
+
   return _documentCollection;
 }
 

--- a/tests/js/client/shell/api/view-instead-of-collection.js
+++ b/tests/js/client/shell/api/view-instead-of-collection.js
@@ -1,0 +1,134 @@
+/* jshint globalstrict:false, strict:false, maxlen: 200 */
+/* global assertEqual, arango, fail */
+
+// //////////////////////////////////////////////////////////////////////////////
+// / DISCLAIMER
+// /
+// / Copyright 2018 ArangoDB GmbH, Cologne, Germany
+// /
+// / Licensed under the Apache License, Version 2.0 (the "License")
+// / you may not use this file except in compliance with the License.
+// / You may obtain a copy of the License at
+// /
+// /     http://www.apache.org/licenses/LICENSE-2.0
+// /
+// / Unless required by applicable law or agreed to in writing, software
+// / distributed under the License is distributed on an "AS IS" BASIS,
+// / WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// / See the License for the specific language governing permissions and
+// / limitations under the License.
+// /
+// / Copyright holder is triAGENS GmbH, Cologne, Germany
+// /
+// / @author Jan Steemann
+// //////////////////////////////////////////////////////////////////////////////
+
+const jsunity = require('jsunity');
+const arangodb = require('@arangodb');
+const db = arangodb.db;
+const internal = require("internal");
+
+function testSuite () {
+  'use strict';
+  const cn = "UnitTestsCollection";
+  const vn = "UnitTestsView";
+  
+  return {
+    setUpAll: function () {
+      let c = db._create(cn);
+      c.insert({ _key: "test" });
+      db._createView(vn, "arangosearch", {});
+    },
+
+    tearDownAll: function () {
+      db._drop(cn);
+      db._dropView(vn);
+    },
+    
+    testGetDocument: function () {
+      let result = arango.GET_RAW("/_api/document/" + encodeURIComponent(cn) + "/test");
+      assertEqual(200, result.code);
+      
+      result = arango.GET_RAW("/_api/document/" + encodeURIComponent(vn) + "/test");
+      assertEqual(404, result.code);
+      assertEqual(internal.errors.ERROR_ARANGO_DATA_SOURCE_NOT_FOUND.code, result.parsedBody.errorNum);
+    },
+    
+    testInsertDocument: function () {
+      let result = arango.POST_RAW("/_api/document/" + encodeURIComponent(cn), {});
+      assertEqual(202, result.code);
+      
+      result = arango.POST_RAW("/_api/document/" + encodeURIComponent(vn), {});
+      assertEqual(404, result.code);
+      assertEqual(internal.errors.ERROR_ARANGO_DATA_SOURCE_NOT_FOUND.code, result.parsedBody.errorNum);
+    },
+    
+    testUpdateDocument: function () {
+      let result = arango.PATCH_RAW("/_api/document/" + encodeURIComponent(cn) + "/test", {});
+      assertEqual(202, result.code);
+      
+      result = arango.PATCH_RAW("/_api/document/" + encodeURIComponent(vn) + "/test", {});
+      assertEqual(404, result.code);
+      assertEqual(internal.errors.ERROR_ARANGO_DATA_SOURCE_NOT_FOUND.code, result.parsedBody.errorNum);
+    },
+    
+    testReplaceDocument: function () {
+      let result = arango.PUT_RAW("/_api/document/" + encodeURIComponent(cn) + "/test", {});
+      assertEqual(202, result.code);
+      
+      result = arango.PUT_RAW("/_api/document/" + encodeURIComponent(vn) + "/test", {});
+      assertEqual(404, result.code);
+      assertEqual(internal.errors.ERROR_ARANGO_DATA_SOURCE_NOT_FOUND.code, result.parsedBody.errorNum);
+    },
+    
+    testRemoveDocument: function () {
+      let key = arango.POST_RAW("/_api/document/" + encodeURIComponent(cn), {}).parsedBody._key;
+      let result = arango.DELETE_RAW("/_api/document/" + encodeURIComponent(cn) + "/" + encodeURIComponent(key));
+      assertEqual(202, result.code);
+      
+      key = arango.POST_RAW("/_api/document/" + encodeURIComponent(cn), {}).parsedBody._key;
+      result = arango.DELETE_RAW("/_api/document/" + encodeURIComponent(vn) + "/" + encodeURIComponent(key));
+      assertEqual(404, result.code);
+      assertEqual(internal.errors.ERROR_ARANGO_DATA_SOURCE_NOT_FOUND.code, result.parsedBody.errorNum);
+    },
+    
+    testAQLInsertDocument: function () {
+      try {
+        db._query(`INSERT {} INTO ${vn}`);
+        fail();
+      } catch (err) {
+        assertEqual(internal.errors.ERROR_ARANGO_COLLECTION_TYPE_MISMATCH.code, err.errorNum);
+      }
+    },
+
+    testAQLUpdateDocument: function () {
+      try {
+        db._query(`UPDATE 'test' WITH {} IN ${vn}`);
+        fail();
+      } catch (err) {
+        assertEqual(internal.errors.ERROR_ARANGO_COLLECTION_TYPE_MISMATCH.code, err.errorNum);
+      }
+    },
+    
+    testAQLReplaceDocument: function () {
+      try {
+        db._query(`REPLACE 'test' WITH {} IN ${vn}`);
+        fail();
+      } catch (err) {
+        assertEqual(internal.errors.ERROR_ARANGO_COLLECTION_TYPE_MISMATCH.code, err.errorNum);
+      }
+    },
+    
+    testAQLRemoveDocument: function () {
+      try {
+        db._query(`REMOVE 'test' IN ${vn}`);
+        fail();
+      } catch (err) {
+        assertEqual(internal.errors.ERROR_ARANGO_COLLECTION_TYPE_MISMATCH.code, err.errorNum);
+      }
+    },
+  };
+}
+
+jsunity.run(testSuite);
+return jsunity.done();


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/16301

Fix behavior when accessing document APIs with view names.
Now a proper error is returned on such attempts.
This PR also fixes some issues in testing.js when it returned negative numbers for setup/teardown or test durations, and also failed on cleaning up leftover collections/databases from tests if it wasn't already in the `_system` database.
Also fixes line endings (\n instead of \r\n) in some JavaScript file.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [x] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [x] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [x] Backports
  - [x] Backport for 3.9: https://github.com/arangodb/arangodb/pull/16299
  - [x] Backport for 3.8: this PR
  - [ ] Backport for 3.7: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 