### PR TITLE
[CINFRA-xxx] Test failed dictated leader

### DIFF
--- a/js/server/modules/@arangodb/testutils/replicated-logs-helper.js
+++ b/js/server/modules/@arangodb/testutils/replicated-logs-helper.js
@@ -329,13 +329,22 @@ const getLocalStatus = function (database, logId, serverId) {
   return res.json.result;
 };
 
-const getReplicatedLogLeaderPlan = function (database, logId) {
+const getReplicatedLogLeaderPlan = function (database, logId, nothrow = false) {
   let {plan} = readReplicatedLogAgency(database, logId);
   if (!plan.currentTerm) {
     throw Error("no current term in plan");
+        let error = Error("no current term in plan");
+    if (nothrow) {
+      return error;
+    }
+    throw error;
   }
   if (!plan.currentTerm.leader) {
-    throw Error("current term has no leader");
+    let error = Error("current term has no leader");
+    if (nothrow) {
+      return error;
+    }
+    throw error;
   }
   const leader = plan.currentTerm.leader.serverId;
   const term = plan.currentTerm.term;

--- a/js/server/modules/@arangodb/testutils/replicated-logs-predicates.js
+++ b/js/server/modules/@arangodb/testutils/replicated-logs-predicates.js
@@ -207,6 +207,20 @@ const replicatedLogLeaderPlanIs = function (database, stateId, expectedLeader) {
   };
 };
 
+const replicatedLogLeaderPlanChanged = function (database, stateId, oldLeader) {
+  return function () {
+      const leaderPlan = LH.getReplicatedLogLeaderPlan(database, stateId);
+      if (leaderPlan instanceof Error) {
+        return leaderPlan;
+      }
+      if (leaderPlan.leader !== oldLeader) {
+        return true;
+      } else {
+        return new Error(`Expected log leader to switch from ${oldLeader}, but is still the same`);
+      }
+  };
+};
+
 const replicatedLogLeaderCommitFail = function (database, logId, expected) {
   return function () {
     let {current} = LH.readReplicatedLogAgency(database, logId);
@@ -262,6 +276,7 @@ exports.replicatedLogLeaderCommitFail = replicatedLogLeaderCommitFail;
 exports.replicatedLogLeaderEstablished = replicatedLogLeaderEstablished;
 exports.replicatedLogLeaderPlanIs = replicatedLogLeaderPlanIs;
 exports.replicatedLogLeaderTargetIs = replicatedLogLeaderTargetIs;
+exports.replicatedLogLeaderPlanChanged = replicatedLogLeaderPlanChanged;
 exports.replicatedLogParticipantGeneration = replicatedLogParticipantGeneration;
 exports.replicatedLogParticipantsFlag = replicatedLogParticipantsFlag;
 exports.replicatedLogTargetVersion = replicatedLogTargetVersion;

--- a/js/server/modules/@arangodb/testutils/replicated-logs-predicates.js
+++ b/js/server/modules/@arangodb/testutils/replicated-logs-predicates.js
@@ -209,7 +209,7 @@ const replicatedLogLeaderPlanIs = function (database, stateId, expectedLeader) {
 
 const replicatedLogLeaderPlanChanged = function (database, stateId, oldLeader) {
   return function () {
-      const leaderPlan = LH.getReplicatedLogLeaderPlan(database, stateId);
+      const leaderPlan = LH.getReplicatedLogLeaderPlan(database, stateId, true);
       if (leaderPlan instanceof Error) {
         return leaderPlan;
       }

--- a/tests/js/server/replication2/replication2-supervision-replicated-log-target-cluster.js
+++ b/tests/js/server/replication2/replication2-supervision-replicated-log-target-cluster.js
@@ -489,7 +489,7 @@ const replicatedLogSuite = function () {
       stopServer(setLeader);
 
       // Supervision should notice that the target leader is failed and should not try to set it.
-      const errorCode = 3; // TARGET_LEADER_FAILED
+      const errorCode = "TargetLeaderFailed";
       waitFor(replicatedLogSupervisionError(database, logId, errorCode));
 
       waitFor(lpreds.replicatedLogLeaderPlanChanged(database, logId, setLeader));

--- a/tests/js/server/replication2/replication2-supervision-replicated-log-target-cluster.js
+++ b/tests/js/server/replication2/replication2-supervision-replicated-log-target-cluster.js
@@ -472,6 +472,37 @@ const replicatedLogSuite = function () {
       replicatedLogDeleteTarget(database, logId);
     },
 
+    // This test first sets a new leader and waits for the leader exchange to take place.
+    // Then the new leader is stopped, thus an election is triggered.
+    // Although the now failed ex-leader remains in target, the election is expected to succeed.
+    testChangeLeaderWithFailed: function () {
+      const {logId, servers, term, followers} = createReplicatedLogAndWaitForLeader(database);
+
+      const setLeader = followers[0];
+      setReplicatedLogLeaderTarget(database, logId, setLeader);
+      waitFor(replicatedLogIsReady(database, logId, term, servers, setLeader));
+      waitFor(replicatedLogParticipantsFlag(database, logId, {
+        [setLeader]: {allowedAsLeader: true, allowedInQuorum: true, forced: false},
+      }));
+
+      // Stop current leader and wait for the leader to be changed
+      stopServer(setLeader);
+
+      // Supervision should notice that the target leader is failed and should not try to set it.
+      const errorCode = 3; // TARGET_LEADER_FAILED
+      waitFor(replicatedLogSupervisionError(database, logId, errorCode));
+
+      waitFor(lpreds.replicatedLogLeaderPlanChanged(database, logId, setLeader));
+      let {newLeader} = helper.getReplicatedLogLeaderPlan(database, logId);
+      waitFor(replicatedLogIsReady(database, logId, term, servers, newLeader));
+
+      replicatedLogUpdateTargetParticipants(database, logId, {
+        [setLeader]: {allowedInQuorum: true, allowedAsLeader: true},
+      });
+
+      replicatedLogDeleteTarget(database, logId);
+    },
+
     // This test first makes a follower excluded and then asks for this follower
     // to become the leader. It then removed the excluded flag and expects the
     // leadership to be transferred.


### PR DESCRIPTION
### Scope & Purpose

This rescues over a test from #16226 which becomes out-of-date by the supervision refactor.
- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [x] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [x] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*
  - [ ] Backport for 3.7: *(Please link PR)*
