### PR TITLE
[BTS-862] unstable js test grants spec (#16243)

### DIFF
--- a/arangod/Auth/UserManager.cpp
+++ b/arangod/Auth/UserManager.cpp
@@ -179,7 +179,7 @@ static std::shared_ptr<VPackBuilder> QueryAllUsers(
   } else if (!usersSlice.isArray()) {
     LOG_TOPIC("4b11d", ERR, arangodb::Logger::AUTHENTICATION)
         << "cannot read users from _users collection";
-    return std::shared_ptr<VPackBuilder>();
+    return {};
   }
 
   return queryResult.data;
@@ -448,7 +448,7 @@ void auth::UserManager::triggerGlobalReload() {
         agency.sendTransactionWithFailover(incrementVersion);
     if (result.successful()) {
       _globalVersion.fetch_add(1, std::memory_order_release);
-      _internalVersion.fetch_add(1, std::memory_order_release);
+      _internalVersion.store(0, std::memory_order_release);
       return;
     }
   }

--- a/tests/js/client/shell/api/grants-spec.js
+++ b/tests/js/client/shell/api/grants-spec.js
@@ -1,5 +1,5 @@
 /* jshint globalstrict:false, strict:false, maxlen: 5000 */
-/* global describe, after, afterEach, before, beforeEach, it, db, arango */
+/* global describe, after, afterEach, before, beforeEach, it, db, arango, print */
 'use strict';
 
 // //////////////////////////////////////////////////////////////////////////////
@@ -132,6 +132,9 @@ describe('UserProperties', function () {
   };
 
   const verifyEmptyConfig = (result) => {
+    if (result.error !== false) {
+      print(result);
+    }
     expect(result.error).to.be.false;
     expect(result).to.have.property('code', 200);
     expect(result).to.have.property('result', null);
@@ -211,7 +214,7 @@ describe('UserProperties', function () {
   });
 
   after(function () {
-        db._useDatabase('_system');
+    db._useDatabase('_system');
     db._dropDatabase(nonRootDB);
   });
 


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/16243

Attempt to fix BTS-862. It can happen that by incrementing the local and global version due to a local modification, we always miss an update from the heartbeat thread. This PR always does a full flush, even on the coordinator that modifies the user data.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [x] Backports
  - [x] Backport for 3.9: this PR
  - [ ] Backport for 3.8: -
  - [ ] Backport for 3.7: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 