### PR TITLE
add support for LZ4 and LZ4HC compression in RocksDB

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 devel
 -----
 
+* Add support for LZ4 and LZ4HC compression in RocksDB.
+
 * Change default value of `--rocksdb.block-cache-shard-bits` to an automatic
   default value that allows data blocks of at least 128MiB to be stored in each
   cache shard if the block cache's strict capacity limit is used. The strict 

--- a/arangod/RocksDBEngine/RocksDBEngine.cpp
+++ b/arangod/RocksDBEngine/RocksDBEngine.cpp
@@ -752,7 +752,9 @@ void RocksDBEngine::start() {
   _options.use_fsync = opts._useFSync;
 
   rocksdb::CompressionType compressionType = rocksdb::kNoCompression;
-  if (opts._compressionType == "snappy") {
+  if (opts._compressionType == "none") {
+    compressionType = rocksdb::kNoCompression;
+  } else if (opts._compressionType == "snappy") {
     compressionType = rocksdb::kSnappyCompression;
   } else if (opts._compressionType == "lz4") {
     compressionType = rocksdb::kLZ4Compression;

--- a/arangod/RocksDBEngine/RocksDBEngine.cpp
+++ b/arangod/RocksDBEngine/RocksDBEngine.cpp
@@ -751,12 +751,26 @@ void RocksDBEngine::start() {
   _options.max_subcompactions = opts._maxSubcompactions;
   _options.use_fsync = opts._useFSync;
 
+  rocksdb::CompressionType compressionType = rocksdb::kNoCompression;
+  if (opts._compressionType == "snappy") {
+    compressionType = rocksdb::kSnappyCompression;
+  } else if (opts._compressionType == "lz4") {
+    compressionType = rocksdb::kLZ4Compression;
+  } else if (opts._compressionType == "lz4hc") {
+    compressionType = rocksdb::kLZ4HCCompression;
+  } else {
+    TRI_ASSERT(false);
+    LOG_TOPIC("74b7f", FATAL, arangodb::Logger::STARTUP)
+        << "unexpected compression type '" << opts._compressionType << "'";
+    FATAL_ERROR_EXIT();
+  }
+
   // only compress levels >= 2
   _options.compression_per_level.resize(_options.num_levels);
   for (int level = 0; level < _options.num_levels; ++level) {
     _options.compression_per_level[level] =
-        (((uint64_t)level >= opts._numUncompressedLevels)
-             ? rocksdb::kSnappyCompression
+        ((uint64_t(level) >= opts._numUncompressedLevels)
+             ? compressionType
              : rocksdb::kNoCompression);
   }
 

--- a/arangod/RocksDBEngine/RocksDBOptionFeature.cpp
+++ b/arangod/RocksDBEngine/RocksDBOptionFeature.cpp
@@ -225,10 +225,12 @@ void RocksDBOptionFeature::collectOptions(
                      "regular data directory",
                      new StringParameter(&_walDirectory));
 
-  options->addOption("--rocksdb.compression-type",
-                     "compression algorithm to use within RocksDB",
-                     new DiscreteValuesParameter<StringParameter>(
-                         &_compressionType, ::compressionTypes));
+  options
+      ->addOption("--rocksdb.compression-type",
+                  "compression algorithm to use within RocksDB",
+                  new DiscreteValuesParameter<StringParameter>(
+                      &_compressionType, ::compressionTypes))
+      .setIntroducedIn(31000);
 
   options
       ->addOption("--rocksdb.target-file-size-base",

--- a/arangod/RocksDBEngine/RocksDBOptionFeature.h
+++ b/arangod/RocksDBEngine/RocksDBOptionFeature.h
@@ -63,6 +63,7 @@ class RocksDBOptionFeature final : public ArangodFeature {
   uint64_t _transactionLockStripes;
   int64_t _transactionLockTimeout;
   std::string _walDirectory;
+  std::string _compressionType;
   uint64_t _totalWriteBufferSize;
   uint64_t _writeBufferSize;
   // Update max_write_buffer_number above if you change number of families used


### PR DESCRIPTION
### Scope & Purpose

Add support for LZ4 and LZ4HC compression in RocksDB. The default is still to use Snappy compression.
This PR allows us to make tests with LZ4 and LZ4HC, so we can decide if we want to move away from Snappy or not.

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -
  - [ ] Backport for 3.7: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 