### PR TITLE
[CINFRA-385] Incorrect ongoing state in prototype

### DIFF
--- a/arangod/Replication2/StateMachines/Prototype/PrototypeCore.h
+++ b/arangod/Replication2/StateMachines/Prototype/PrototypeCore.h
@@ -142,12 +142,12 @@ void PrototypeCore::applyEntries(std::unique_ptr<EntryIterator> ptr) {
  */
 template<typename EntryIterator>
 void PrototypeCore::update(std::unique_ptr<EntryIterator> ptr) {
-  auto lastAppliedIndex = ptr->range().to.saturatedDecrement();
-  while (!_ongoingStates.empty() &&
-         _ongoingStates.front().first < lastAppliedIndex) {
+  auto lastIndexToApply = ptr->range().to.saturatedDecrement();
+  while (_ongoingStates.size() > 1 &&
+         _ongoingStates[1].first <= lastIndexToApply) {
     _ongoingStates.pop_front();
   }
-  _lastAppliedIndex = std::move(lastAppliedIndex);
+  _lastAppliedIndex = lastIndexToApply;
 }
 
 }  // namespace arangodb::replication2::replicated_state::prototype

--- a/arangod/Replication2/StateMachines/Prototype/PrototypeCore.h
+++ b/arangod/Replication2/StateMachines/Prototype/PrototypeCore.h
@@ -142,6 +142,12 @@ void PrototypeCore::applyEntries(std::unique_ptr<EntryIterator> ptr) {
  */
 template<typename EntryIterator>
 void PrototypeCore::update(std::unique_ptr<EntryIterator> ptr) {
+  // Meta-entries are never seen by the state machine, but still increase the
+  // log index, creating gaps between ongoing states. Hence,
+  // lastIndexToApply could be greater than the last index of the current
+  // ongoing state, but smaller than that of the next ongoing state, in which
+  // case we prefer to keep the current one. We have to look ahead in the
+  // deque to make sure this stays correct.
   auto lastIndexToApply = ptr->range().to.saturatedDecrement();
   while (_ongoingStates.size() > 1 &&
          _ongoingStates[1].first <= lastIndexToApply) {


### PR DESCRIPTION
### Scope & Purpose

The ongoing state of the prototype leader works like a deque: newer states, containing operations that were only applied locally, are always appended at the back. When state machine operations (log entries) have been replicated and committed, we look at the last log iterator to be applied and pop from the front of the deque until we reach that index.

The problem is that sometimes we could get entries that were not inserted by a user (meta entries), which means the prototype leader doesn’t know about the existence of these entries. These entries still add up to the log index, which could cause our leader to pop from the deque when it’s not supposed to do so.

Consider the following entries: 101 (operation), 102 (meta), 103 (operation). The deque will contain the states at 101, followed by the state at index 103. If log entries 101 and 102 come together, we would pop from the deque and move the state to 103, which is wrong, because we are supposed to stay at 101.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*
  - [ ] Backport for 3.7: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

