### PR TITLE
[CINFRA-386] Check Resigned before release

### DIFF
--- a/arangod/Replication2/ReplicatedLog/LogFollower.cpp
+++ b/arangod/Replication2/ReplicatedLog/LogFollower.cpp
@@ -604,7 +604,9 @@ replicated_log::LogFollower::~LogFollower() {
 
 auto LogFollower::release(LogIndex doneWithIdx) -> Result {
   auto guard = _guardedFollowerData.getLockedGuard();
-
+  if (guard->didResign()) {
+    return {TRI_ERROR_REPLICATION_REPLICATED_LOG_FOLLOWER_RESIGNED};
+  }
   guard.wait(_appendEntriesInFlightCondVar,
              [&] { return !_appendEntriesInFlight; });
 

--- a/arangod/Replication2/ReplicatedLog/LogLeader.cpp
+++ b/arangod/Replication2/ReplicatedLog/LogLeader.cpp
@@ -972,6 +972,9 @@ replicated_log::LogLeader::GuardedLeaderData::GuardedLeaderData(
 
 auto replicated_log::LogLeader::release(LogIndex doneWithIdx) -> Result {
   return _guardedLeaderData.doUnderLock([&](GuardedLeaderData& self) -> Result {
+    if (self._didResign) {
+      return {TRI_ERROR_REPLICATION_REPLICATED_LOG_FOLLOWER_RESIGNED};
+    }
     TRI_ASSERT(doneWithIdx <= self._inMemoryLog.getLastIndex());
     if (doneWithIdx <= self._releaseIndex) {
       return {};

--- a/arangod/Replication2/ReplicatedLog/LogLeader.cpp
+++ b/arangod/Replication2/ReplicatedLog/LogLeader.cpp
@@ -973,7 +973,7 @@ replicated_log::LogLeader::GuardedLeaderData::GuardedLeaderData(
 auto replicated_log::LogLeader::release(LogIndex doneWithIdx) -> Result {
   return _guardedLeaderData.doUnderLock([&](GuardedLeaderData& self) -> Result {
     if (self._didResign) {
-      return {TRI_ERROR_REPLICATION_REPLICATED_LOG_FOLLOWER_RESIGNED};
+      return {TRI_ERROR_REPLICATION_REPLICATED_LOG_LEADER_RESIGNED};
     }
     TRI_ASSERT(doneWithIdx <= self._inMemoryLog.getLastIndex());
     if (doneWithIdx <= self._releaseIndex) {


### PR DESCRIPTION
### Scope & Purpose

LogLeader and LogFollower classes did not check if they already resigned before they called release on a (then nullptr) LogCore.