### PR TITLE
Search-184: Distributed volatile cache for accumulated metrics

### DIFF
--- a/arangod/Cluster/ClusterInfo.cpp
+++ b/arangod/Cluster/ClusterInfo.cpp
@@ -116,6 +116,11 @@ struct ShardStatistics {
 };
 
 namespace {
+
+std::string const kMetricsServerId = "Plan/Metrics/ServerId";
+std::string const kMetricsRebootId = "Plan/Metrics/RebootId";
+std::string const kMetricsVersion = "Plan/Metrics/Version";
+
 void addToShardStatistics(arangodb::ShardStatistics& stats,
                           containers::FlatHashSet<std::string>& servers,
                           arangodb::velocypack::Slice databaseSlice,
@@ -4505,6 +4510,139 @@ Result ClusterInfo::finishModifyingAnalyzerCoordinator(
   } while (true);
 
   return Result(TRI_ERROR_NO_ERROR);
+}
+
+void ClusterInfo::initMetricsState() {
+  auto rebootId = ServerState::instance()->getRebootId().value();
+  auto serverId = ServerState::instance()->getId();
+
+  VPackBuilder builderRebootId;
+  builderRebootId.add(VPackValue{rebootId});
+  VPackBuilder builderServerId;
+  builderServerId.add(VPackValue{serverId});
+  VPackBuilder builderVersion;
+  builderVersion.add(VPackValue{0});
+
+  AgencyWriteTransaction const write{
+      {{kMetricsRebootId, AgencyValueOperationType::SET,
+        builderRebootId.slice()},
+       {kMetricsServerId, AgencyValueOperationType::SET,
+        builderServerId.slice()},
+       {kMetricsVersion, AgencyValueOperationType::SET,
+        builderVersion.slice()}},
+      {{kMetricsRebootId, AgencyPrecondition::Type::EMPTY, true},
+       {kMetricsServerId, AgencyPrecondition::Type::EMPTY, true},
+       {kMetricsVersion, AgencyPrecondition::Type::EMPTY, true}}};
+  AgencyComm ac{_server};
+  while (!server().isStopping()) {
+    auto const r = ac.sendTransactionWithFailover(write);
+    if (r.successful() ||
+        r.httpCode() == rest::ResponseCode::PRECONDITION_FAILED) {
+      return;
+    }
+    LOG_TOPIC("bfdc3", WARN, Logger::CLUSTER)
+        << "Failed to self-propose leader with httpCode: " << r.httpCode();
+  }
+}
+
+ClusterInfo::MetricsState ClusterInfo::getMetricsState(bool wantLeader) {
+  auto& ac = _server.getFeature<ClusterFeature>().agencyCache();
+  auto [result, index] = ac.read({AgencyCommHelper::path(kMetricsServerId),
+                                  AgencyCommHelper::path(kMetricsRebootId),
+                                  AgencyCommHelper::path(kMetricsVersion)});
+  auto data = result->slice().at(0).get(std::initializer_list<std::string_view>{
+      AgencyCommHelper::path(), "Plan", "Metrics"});
+  auto leaderRebootId = data.get("RebootId").getNumber<uint64_t>();
+  auto leaderServerId = data.get("ServerId").stringView();
+  auto leaderVersion = data.get("Version").getNumber<uint64_t>();
+  auto ourRebootId = ServerState::instance()->getRebootId().value();
+  auto ourServerId = ServerState::instance()->getId();
+  if (ourRebootId == leaderRebootId && ourServerId == leaderServerId) {
+    // TRI_ASSERT(_metricsGuard.empty());
+    return {std::nullopt, leaderVersion};
+  }
+  if (wantLeader) {
+    // remove old callback (with _metricsGuard call, then store new callback)
+    _metricsGuard = _rebootTracker.callMeOnChange(
+        {std::string{leaderServerId}, RebootId{leaderRebootId}},
+        [this, leaderRebootId, serverId = std::string{leaderServerId}] {
+          proposeMetricsLeader(leaderRebootId, serverId);
+        },
+        "Try to propose current server as a new leader for cluster metrics");
+  }
+  return {std::string{leaderServerId}, leaderVersion};
+}
+
+bool ClusterInfo::tryIncMetricsVersion(uint64_t version) {
+  AgencyComm ac{_server};
+  auto rebootId = ServerState::instance()->getRebootId().value();
+  auto serverId = ServerState::instance()->getId();
+
+  VPackBuilder builderRebootId;
+  builderRebootId.add(VPackValue{rebootId});
+  VPackBuilder builderServerId;
+  builderServerId.add(VPackValue{serverId});
+  VPackBuilder builderVersion;
+  builderVersion.add(VPackValue{version});
+
+  AgencyWriteTransaction const write{
+      {kMetricsVersion, AgencySimpleOperationType::INCREMENT_OP},
+      {{kMetricsRebootId, AgencyPrecondition::Type::VALUE,
+        builderRebootId.slice()},
+       {kMetricsServerId, AgencyPrecondition::Type::VALUE,
+        builderServerId.slice()},
+       {kMetricsVersion, AgencyPrecondition::Type::VALUE,
+        builderVersion.slice()}}};
+  auto const r = ac.sendTransactionWithFailover(write);
+  if (r.successful()) {
+    return true;
+  }
+  if (r.httpCode() == rest::ResponseCode::PRECONDITION_FAILED) {
+    LOG_TOPIC("bfdc0", INFO, Logger::CLUSTER)
+        << "Failed increment Metrics/Version with precondition failed";
+  } else {
+    LOG_TOPIC("bfdc1", WARN, Logger::CLUSTER)
+        << "Failed increment Metrics/Version with httpCode: " << r.httpCode();
+  }
+  return false;
+}
+
+void ClusterInfo::proposeMetricsLeader(uint64_t oldRebootId,
+                                       std::string_view oldServerId) {
+  AgencyComm ac{_server};
+  auto rebootId = ServerState::instance()->getRebootId().value();
+  auto serverId = ServerState::instance()->getId();
+
+  VPackBuilder builderOldRebootId;
+  builderOldRebootId.add(VPackValue{oldRebootId});
+  VPackBuilder builderOldServerId;
+  builderOldServerId.add(VPackValue{oldServerId});
+  VPackBuilder builderRebootId;
+  builderRebootId.add(VPackValue{rebootId});
+  VPackBuilder builderServerId;
+  builderServerId.add(VPackValue{serverId});
+
+  AgencyWriteTransaction const write{
+      {{kMetricsRebootId, AgencyValueOperationType::SET,
+        builderRebootId.slice()},
+       {kMetricsServerId, AgencyValueOperationType::SET,
+        builderServerId.slice()}},
+      {{kMetricsRebootId, AgencyPrecondition::Type::VALUE,
+        builderOldRebootId.slice()},
+       {kMetricsServerId, AgencyPrecondition::Type::VALUE,
+        builderOldServerId.slice()}}};
+  auto const r = ac.sendTransactionWithFailover(write);
+  if (r.successful()) {
+    return;
+  }
+  if (r.httpCode() == rest::ResponseCode::PRECONDITION_FAILED) {
+    LOG_TOPIC("bfdc5", TRACE, Logger::CLUSTER)
+        << "Failed to self-propose leader";
+  } else {
+    // We don't need retry here, because we have retry in ClusterMetricsFeature
+    LOG_TOPIC("bfdc6", WARN, Logger::CLUSTER)
+        << "Failed to self-propose leader with httpCode: " << r.httpCode();
+  }
 }
 
 AnalyzerModificationTransaction::Ptr

--- a/arangod/Cluster/ClusterInfo.cpp
+++ b/arangod/Cluster/ClusterInfo.cpp
@@ -4550,7 +4550,7 @@ ClusterInfo::MetricsState ClusterInfo::getMetricsState(bool wantLeader) {
   auto ourRebootId = ServerState::instance()->getRebootId().value();
   auto ourServerId = ServerState::instance()->getId();
   if (ourRebootId == leaderRebootId && ourServerId == leaderServerId) {
-    // TRI_ASSERT(_metricsGuard.empty());
+    TRI_ASSERT(_metricsGuard.empty());
     return {std::nullopt};
   }
   if (wantLeader) {

--- a/arangod/Cluster/ClusterInfo.h
+++ b/arangod/Cluster/ClusterInfo.h
@@ -801,7 +801,6 @@ class ClusterInfo final {
 
   struct [[nodiscard]] MetricsState {
     std::optional<ServerID> leader;
-    uint64_t version;
   };
 
   //////////////////////////////////////////////////////////////////////////////
@@ -820,15 +819,6 @@ class ClusterInfo final {
   /// @return Who is the leader, and what cache version is current.
   //////////////////////////////////////////////////////////////////////////////
   MetricsState getMetricsState(bool wantLeader);
-
-  //////////////////////////////////////////////////////////////////////////////
-  /// @brief try to increment current version in cache
-  /// @param version old version
-  /// Success only current server is a leader and
-  /// old version is equal current version in agency
-  /// @return success or not
-  //////////////////////////////////////////////////////////////////////////////
-  bool tryIncMetricsVersion(uint64_t version);
 
   //////////////////////////////////////////////////////////////////////////////
   /// @brief try to propose self as new leader

--- a/arangod/Cluster/ClusterInfo.h
+++ b/arangod/Cluster/ClusterInfo.h
@@ -793,12 +793,17 @@ class ClusterInfo final {
                                             bool restore);
 
   //////////////////////////////////////////////////////////////////////////////
-  /// @brief init metrics state
-  /// try to propose self as leader or understand who is current leader
-  /// no return while no stopping and we don't know who is leader
+  /// @brief Init metrics state
+  /// @note Current server should be Coordinator
+  /// Try to propose current server as leader or know that someone
+  /// was a leader. No return while we don't know that or server should stop.
   //////////////////////////////////////////////////////////////////////////////
   void initMetricsState();
 
+  //////////////////////////////////////////////////////////////////////////////
+  /// @brief The MetricsState that stored in agency.
+  /// @note If `leader` is `nullopt` that means we ourselves are the leader.
+  //////////////////////////////////////////////////////////////////////////////
   struct [[nodiscard]] MetricsState {
     std::optional<ServerID> leader;
   };
@@ -813,15 +818,14 @@ class ClusterInfo final {
   /// something is not founded or some other error occurs, so the called
   /// must guard against this. In particular, this can happen in the
   /// bootstrap phase if the `AgencyCache` has not yet heard about this.
-  /// @note If `leader` in the resulting `MetricsState` is `nullopt`
-  /// that means we ourselves are the leader.
   /// @note If `wantLeader` is true, then thread-safe, otherwise not
   /// @return Who is the leader, and what cache version is current.
   //////////////////////////////////////////////////////////////////////////////
   MetricsState getMetricsState(bool wantLeader);
 
   //////////////////////////////////////////////////////////////////////////////
-  /// @brief try to propose self as new leader
+  /// @brief Try to propose current server as new leader
+  /// @note Current server should be Coordinator
   /// @param oldRebootId last leader RebootId
   /// @param oldServerId last leader ServerID
   //////////////////////////////////////////////////////////////////////////////

--- a/arangod/Cluster/ClusterInfo.h
+++ b/arangod/Cluster/ClusterInfo.h
@@ -805,11 +805,19 @@ class ClusterInfo final {
   };
 
   //////////////////////////////////////////////////////////////////////////////
-  /// @brief get current MetricsState from agencyCache
-  /// @param wantLeader if true we need to propose self to leader if current die
-  /// @note can throw exception if something not founded, or another error
-  /// @note if leader is nullopt that means our server is a leader
-  /// @return who is leader, and what it cache version
+  /// @brief Gets the current MetricsState from the agencyCache.
+  /// @param wantLeader If it is `true`, a RebootTracker event is set,
+  /// in which we will try to become the new leader ourselves, if the current
+  /// leader dies. If the flag is `false`, no new event is set,
+  /// but the old one is also not deleted.
+  /// @note This method can throw exceptions of various types, if
+  /// something is not founded or some other error occurs, so the called
+  /// must guard against this. In particular, this can happen in the
+  /// bootstrap phase if the `AgencyCache` has not yet heard about this.
+  /// @note If `leader` in the resulting `MetricsState` is `nullopt`
+  /// that means we ourselves are the leader.
+  /// @note If `wantLeader` is true, then thread-safe, otherwise not
+  /// @return Who is the leader, and what cache version is current.
   //////////////////////////////////////////////////////////////////////////////
   MetricsState getMetricsState(bool wantLeader);
 

--- a/arangod/Cluster/ClusterMethods.cpp
+++ b/arangod/Cluster/ClusterMethods.cpp
@@ -1441,15 +1441,14 @@ futures::Future<metrics::LeaderResponse> metricsFromLeader(
   auto* pool = network.pool();
   network::Headers headers;
   headers.emplace(StaticStrings::Accept, StaticStrings::MimeTypeJsonNoEncoding);
+  auto options = network::RequestOptions{}
+                     .param("type", metrics::kCDJson)
+                     .param("MetricsServerId", std::move(serverId))
+                     .param("MetricsRebootId", std::to_string(rebootId))
+                     .param("MetricsVersion", std::to_string(version));
   auto future = network::sendRequest(
       pool, absl::StrCat("server:", leader), fuerte::RestVerb::Get,
-      "/_admin/metrics", {},
-      network::RequestOptions{}
-          .param("type", metrics::kCDJson)
-          .param("MetricsServerId", std::move(serverId))
-          .param("MetricsRebootId", std::to_string(rebootId))
-          .param("MetricsVersion", std::to_string(version)),
-      std::move(headers));
+      "/_admin/metrics", {}, std::move(options), std::move(headers));
   return std::move(future).then([](Try<network::Response>&& response) {
     if (response.hasValue()) {
       return response->response().stealPayload();

--- a/arangod/Cluster/ClusterMethods.h
+++ b/arangod/Cluster/ClusterMethods.h
@@ -127,8 +127,15 @@ futures::Future<OperationResult> countOnCoordinator(
 /// @brief gets the metrics from DBServers
 ////////////////////////////////////////////////////////////////////////////////
 
-futures::Future<metrics::RawDBServers> metricsOnCoordinator(
-    NetworkFeature& network, ClusterFeature& cluster);
+futures::Future<metrics::RawDBServers> metricsOnLeader(NetworkFeature& network,
+                                                       ClusterFeature& cluster);
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief gets the metrics from leader Coordinator
+////////////////////////////////////////////////////////////////////////////////
+
+futures::Future<metrics::LeaderResponse> metricsFromLeader(
+    NetworkFeature& network, ClusterFeature& cluster, std::string_view leader);
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief gets the selectivity estimates from DBservers

--- a/arangod/Cluster/ClusterMethods.h
+++ b/arangod/Cluster/ClusterMethods.h
@@ -135,7 +135,8 @@ futures::Future<metrics::RawDBServers> metricsOnLeader(NetworkFeature& network,
 ////////////////////////////////////////////////////////////////////////////////
 
 futures::Future<metrics::LeaderResponse> metricsFromLeader(
-    NetworkFeature& network, ClusterFeature& cluster, std::string_view leader);
+    NetworkFeature& network, ClusterFeature& cluster, std::string_view leader,
+    std::string serverId, uint64_t rebootId, uint64_t version);
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief gets the selectivity estimates from DBservers

--- a/arangod/IResearch/IResearchLinkCoordinator.cpp
+++ b/arangod/IResearch/IResearchLinkCoordinator.cpp
@@ -101,8 +101,8 @@ Result IResearchLinkCoordinator::init(velocypack::Slice definition) {
   auto batchToCoordinator = [](ClusterMetricsFeature::Metrics& metrics,
                                std::string_view name, velocypack::Slice labels,
                                velocypack::Slice value) {
-    std::get<uint64_t>(metrics[{std::string{name}, labels.copyString()}]) +=
-        value.getNumber<uint64_t>();
+    auto& v = metrics.values[{std::string{name}, labels.copyString()}];
+    std::get<uint64_t>(v) += value.getNumber<uint64_t>();
   };
   auto batchToPrometheus = [](std::string& result, std::string_view globals,
                               std::string_view name, std::string_view labels,
@@ -129,8 +129,8 @@ Result IResearchLinkCoordinator::init(velocypack::Slice definition) {
       return;
     }
     labelsStr = labelsStr.substr(0, end);
-    std::get<uint64_t>(metrics[{std::string{name}, std::string{labelsStr}}]) +=
-        value.getNumber<uint64_t>();
+    auto& v = metrics.values[{std::string{name}, std::string{labelsStr}}];
+    std::get<uint64_t>(v) += value.getNumber<uint64_t>();
   };
   metric.add("arangodb_search_num_failed_commits", gaugeToCoordinator);
   metric.add("arangodb_search_num_failed_cleanups", gaugeToCoordinator);
@@ -166,8 +166,8 @@ IResearchDataStore::Stats IResearchLinkCoordinator::stats() const {
   addLabel("view", getViewId());
   addLabel("collection", getCollectionName());
   auto getValue = [&, labels = std::string_view{labels}](std::string_view key) {
-    if (auto it = metrics.find(metrics::MetricKeyView{key, labels});
-        it != metrics.end()) {
+    if (auto it = metrics.values.find(metrics::MetricKeyView{key, labels});
+        it != metrics.values.end()) {
       return std::get<uint64_t>(it->second);
     }
     return uint64_t{0};

--- a/arangod/Metrics/ClusterMetricsFeature.cpp
+++ b/arangod/Metrics/ClusterMetricsFeature.cpp
@@ -192,7 +192,8 @@ void ClusterMetricsFeature::update() {
     return rescheduleUpdate(std::max(_timeout, 1U));
   }
   auto rebootId = isData ? oldData.get("RebootId").getNumber<uint64_t>() : 0;
-  auto serverId = isData ? oldData.get("ServerId").copyString() : "";
+  // We use `"0"` instead of `""` because we cannot parse empty string parameter
+  auto serverId = isData ? oldData.get("ServerId").copyString() : "0";
   data.reset();
   metricsFromLeader(nf, cf, *leader, std::move(serverId), rebootId, version)
       .thenFinal([this](futures::Try<LeaderResponse>&& raw) mutable noexcept {

--- a/arangod/Metrics/ClusterMetricsFeature.cpp
+++ b/arangod/Metrics/ClusterMetricsFeature.cpp
@@ -36,10 +36,10 @@
 #include "ProgramOptions/ProgramOptions.h"
 #include "ProgramOptions/Section.h"
 #include "Scheduler/SchedulerFeature.h"
-#include "StorageEngine/EngineSelectorFeature.h"
+#include "RestServer/SystemDatabaseFeature.h"
+#include "Transaction/StandaloneContext.h"
 
 namespace arangodb::metrics {
-using namespace std::chrono_literals;
 
 ClusterMetricsFeature::ClusterMetricsFeature(Server& server)
     : ArangodFeature{server, *this} {
@@ -57,7 +57,7 @@ void ClusterMetricsFeature::collectOptions(
                   new options::UInt32Parameter(&_timeout),
                   arangodb::options::makeDefaultFlags(
                       arangodb::options::Flags::Uncommon))
-      .setIntroducedIn(310000);
+      .setIntroducedIn(3'10'00);
 }
 
 void ClusterMetricsFeature::validateOptions(
@@ -67,73 +67,201 @@ void ClusterMetricsFeature::validateOptions(
   }
 }
 
-void ClusterMetricsFeature::start() { asyncUpdate(); }
-
-void ClusterMetricsFeature::beginShutdown() {
-  _count.store(kStop, std::memory_order_release);
-  _handle = nullptr;
-}
-
-void ClusterMetricsFeature::asyncUpdate() {
-  if (_count.load(std::memory_order_acquire) % 2 != kStop &&
-      _count.fetch_add(kUpdate, std::memory_order_acq_rel) == 0) {
-    scheduleUpdate();
+void ClusterMetricsFeature::start() {
+  if (wasStop()) {
+    return;
+  }
+  auto& ci = server().getFeature<ClusterFeature>().clusterInfo();
+  ci.initMetricsState();
+  if (_timeout != 0) {
+    rescheduleTimer();
   }
 }
 
-void ClusterMetricsFeature::scheduleUpdate() noexcept {
-  auto now = std::chrono::steady_clock::now();
-  auto next = _lastUpdate + std::chrono::seconds{_timeout};
-  _handle = SchedulerFeature::SCHEDULER->queueDelayed(
-      RequestLane::CLUSTER_INTERNAL, (now < next ? next - now : 0ns),
-      [this](bool canceled) {
-        if (canceled) {
+void ClusterMetricsFeature::beginShutdown() {
+  _count.store(kStop, std::memory_order_release);
+  std::atomic_store_explicit(&_timer, {}, std::memory_order_relaxed);
+  std::atomic_store_explicit(&_update, {}, std::memory_order_relaxed);
+}
+
+void ClusterMetricsFeature::stop() { beginShutdown(); }
+
+std::optional<std::string> ClusterMetricsFeature::update(
+    CollectMode mode) noexcept {
+  if (mode == CollectMode::TriggerGlobal) {
+    auto const count = _count.fetch_add(kUpdate, std::memory_order_acq_rel);
+    if (count == 0) {
+      rescheduleUpdate(0);
+    }
+    return std::nullopt;
+  }
+  TRI_ASSERT(mode != CollectMode::Local);
+  auto& nf = server().getFeature<NetworkFeature>();
+  auto& cf = server().getFeature<ClusterFeature>();
+  auto& ci = cf.clusterInfo();
+  try {
+    // TODO(MBkkt) Need to return Future<std::optional<std::string>>:
+    // 1) other CollectModes: invalidFuture()
+    // 2) follower:           makeFuture(leader)
+    // 3) leader:             metricsOnLeader(...).thenValue(...)
+    auto [leader, version] = ci.getMetricsState(false);
+    if (leader) {
+      return leader;
+    }
+    if (!leader && mode == CollectMode::WriteGlobal) {
+      writeData(version, metricsOnLeader(nf, cf).getTry());
+    }
+  } catch (...) {
+  }
+  return std::nullopt;
+}
+
+void ClusterMetricsFeature::rescheduleTimer() noexcept {
+  auto h = SchedulerFeature::SCHEDULER->queueDelayed(
+      RequestLane::DELAYED_FUTURE, std::chrono::seconds{_timeout},
+      [this](bool canceled) noexcept {
+        if (canceled || wasStop()) {
+          return;
+        }
+        update(CollectMode::TriggerGlobal);
+        rescheduleTimer();
+      });
+  std::atomic_store_explicit(&_timer, std::move(h), std::memory_order_relaxed);
+}
+
+void ClusterMetricsFeature::rescheduleUpdate(uint32_t timeout) noexcept {
+  auto h = SchedulerFeature::SCHEDULER->queueDelayed(
+      RequestLane::CLUSTER_INTERNAL, std::chrono::seconds{timeout},
+      [this](bool canceled) noexcept {
+        if (canceled || wasStop()) {
           return;
         }
         if (_count.exchange(kUpdate, std::memory_order_acq_rel) % 2 == kStop) {
-          // If someone call more than 1 billion asyncUpdate() before we execute
-          // store we defer Stop to next try. But it's impossible,
-          // so it's valid optimization: exchange + store instead of cas loop
+          // If someone call more than billion update(TriggerGlobal)
+          // before we execute execute store we defer Stop to next try.
+          // But it's impossible, so it's valid optimization:
+          // exchange + store instead of cas loop
           _count.store(kStop, std::memory_order_release);
           return;
         }
         try {
           update();
         } catch (...) {
-          repeatUpdate();
+          repeatUpdate(true);
         }
       });
+  std::atomic_store_explicit(&_update, std::move(h), std::memory_order_relaxed);
 }
 
 void ClusterMetricsFeature::update() {
   auto& nf = server().getFeature<NetworkFeature>();
   auto& cf = server().getFeature<ClusterFeature>();
-  // TODO try get from agency
-  metricsOnCoordinator(nf, cf).thenFinal(
-      [this](futures::Try<RawDBServers>&& metrics) mutable {
-        // We want more time than kTimeout should expire
-        // after last try cross cluster communication
-        _lastUpdate = std::chrono::steady_clock::now();
-        if (!metrics.hasValue()) {
-          scheduleUpdate();
+  auto& ci = cf.clusterInfo();
+  auto [leader, version] = ci.getMetricsState(true);
+  if (wasStop()) {
+    return;
+  }
+  if (!leader) {  // cannot read leader from agency, so assume it's leader
+    return metricsOnLeader(nf, cf).thenFinal(
+        [this, v = version](futures::Try<RawDBServers>&& raw) mutable noexcept {
+          if (wasStop()) {
+            return;
+          }
+          bool force = false;
+          try {
+            force = !writeData(v, std::move(raw));
+          } catch (...) {
+            force = true;
+          }
+          repeatUpdate(force);
+        });
+  }
+  auto const oldVersion = [&] {
+    auto data = getData();
+    return data ? data->version : 0;
+  }();
+  if (leader->empty() || version <= oldVersion) {
+    return rescheduleUpdate(std::max(_timeout, 1U));
+  }
+  metricsFromLeader(nf, cf, *leader)
+      .thenFinal([this](futures::Try<LeaderResponse>&& raw) mutable noexcept {
+        if (wasStop()) {
           return;
         }
+        bool force = false;
         try {
-          set(std::move(*metrics));
+          force = !readData(std::move(raw));
         } catch (...) {
+          force = true;
         }
-        repeatUpdate();
+        repeatUpdate(force);
       });
 }
 
-void ClusterMetricsFeature::repeatUpdate() noexcept {
-  auto count = _count.fetch_sub(kUpdate, std::memory_order_acq_rel);
-  if (count % 2 != kStop && count > kUpdate) {
-    scheduleUpdate();
+void ClusterMetricsFeature::repeatUpdate(bool force) noexcept {
+  if (force) {
+    if (!wasStop()) {
+      rescheduleUpdate(std::max(_timeout, 1U));
+    }
+  } else {
+    auto const count = _count.fetch_sub(kUpdate, std::memory_order_acq_rel);
+    if (count % 2 != kStop && count > kUpdate) {
+      rescheduleUpdate(0);
+    }
   }
 }
 
-void ClusterMetricsFeature::set(RawDBServers&& raw) const {
+bool ClusterMetricsFeature::writeData(uint64_t version,
+                                      futures::Try<RawDBServers>&& raw) {
+  if (!raw.hasValue()) {
+    return false;
+  }
+  auto metrics = parse(std::move(raw).get());
+  if (metrics.values.empty()) {
+    return true;
+  }
+  velocypack::Builder builder;
+  builder.openObject();
+  builder.add("version", VPackValue{version + 1});
+  builder.add(VPackValue{"data"});
+  metrics.toVelocyPack(builder);
+  builder.close();
+  auto data = std::make_shared<Data>(version + 1, std::move(metrics));
+  data->packed = builder.buffer();
+  auto& cf = server().getFeature<ClusterFeature>();
+  auto& ci = cf.clusterInfo();
+  if (ci.tryIncMetricsVersion(version)) {
+    std::atomic_store_explicit(&_data, std::move(data),
+                               std::memory_order_release);
+  }
+  return true;
+}
+
+bool ClusterMetricsFeature::readData(futures::Try<LeaderResponse>&& raw) {
+  if (!raw.hasValue() || !raw.get()) {
+    return false;
+  }
+  velocypack::Slice metrics{raw.get()->data()};
+  if (!metrics.isObject()) {
+    return false;
+  }
+  auto const newVersion = metrics.get("version").getNumber<uint64_t>();
+  auto const oldVersion = [&] {
+    auto data = getData();
+    return data ? data->version : 0;
+  }();
+  if (newVersion <= oldVersion) {
+    return true;
+  }
+  auto data = Data::fromVPack(metrics);
+  data->packed = std::move(raw).get();
+  std::atomic_store_explicit(&_data, std::move(data),
+                             std::memory_order_release);
+  return true;
+}
+
+ClusterMetricsFeature::Metrics ClusterMetricsFeature::parse(
+    RawDBServers&& raw) const {
   Metrics metrics;
   for (std::shared_lock lock{_m}; auto const& payload : raw) {
     TRI_ASSERT(payload);
@@ -141,56 +269,46 @@ void ClusterMetricsFeature::set(RawDBServers&& raw) const {
     TRI_ASSERT(slice.isArray());
     auto const size = slice.length();
     TRI_ASSERT(size % 3 == 0);
-    for (size_t i = 0; i != size; i += 3) {
+    for (size_t i = 0; i < size; i += 3) {
       auto name = slice.at(i).stringView();
       auto labels = slice.at(i + 1);
       auto value = slice.at(i + 2);
-      auto f = _toCoordinator.find(name);
-      if (f != _toCoordinator.end()) {
+      auto f = _mapReduce.find(name);
+      if (f != _mapReduce.end()) {
         f->second(metrics, name, labels, value);
       }
     }
   }
-
-  auto data = std::make_shared<Data>(std::move(metrics));
-  std::atomic_store_explicit(&_data, data, std::memory_order_release);
-  // TODO(MBkkt) serialize to velocypack array
-  // TODO(MBkkt) set to agency
+  return metrics;
 }
 
-void ClusterMetricsFeature::add(std::string_view metric,
-                                ToCoordinator toCoordinator) {
-  if (_count.load(std::memory_order_acquire) % 2 == kStop) {
-    return;
-  }
+bool ClusterMetricsFeature::wasStop() const noexcept {
+  return _count.load(std::memory_order_acquire) % 2 == kStop ||
+         server().isStopping();
+}
+
+void ClusterMetricsFeature::add(std::string_view metric, MapReduce mapReduce) {
   std::lock_guard lock{_m};
-  _toCoordinator[metric] = toCoordinator;
+  _mapReduce[metric] = mapReduce;
 }
 
-void ClusterMetricsFeature::add(std::string_view metric,
-                                ToCoordinator toCoordinator,
+void ClusterMetricsFeature::add(std::string_view metric, MapReduce mapReduce,
                                 ToPrometheus toPrometheus) {
-  if (_count.load(std::memory_order_acquire) % 2 == kStop) {
-    return;
-  }
   std::lock_guard lock{_m};
-  _toCoordinator[metric] = toCoordinator;
+  _mapReduce[metric] = mapReduce;
   _toPrometheus[metric] = toPrometheus;
 }
 
 void ClusterMetricsFeature::toPrometheus(std::string& result,
                                          std::string_view globals) const {
-  if (_count.load(std::memory_order_acquire) % 2 == kStop) {
-    return;
-  }
-  auto data = std::atomic_load_explicit(&_data, std::memory_order_acquire);
+  auto data = getData();
   if (!data) {
     return;
   }
-  std::shared_lock lock{_m};
   std::string_view metricName;
+  std::shared_lock lock{_m};
   auto it = _toPrometheus.end();
-  for (auto const& [key, value] : data->metrics) {
+  for (auto const& [key, value] : data->metrics.values) {
     if (metricName != key.name) {
       metricName = key.name;
       it = _toPrometheus.find(metricName);
@@ -208,6 +326,33 @@ void ClusterMetricsFeature::toPrometheus(std::string& result,
 std::shared_ptr<ClusterMetricsFeature::Data> ClusterMetricsFeature::getData()
     const {
   return std::atomic_load_explicit(&_data, std::memory_order_acquire);
+}
+
+std::shared_ptr<ClusterMetricsFeature::Data>
+ClusterMetricsFeature::Data::fromVPack(VPackSlice slice) {
+  auto version = slice.get("version").getNumber<uint64_t>();
+  auto metrics = slice.get("data");
+  auto const size = metrics.length();
+  auto data = std::make_shared<Data>(version);
+  for (size_t i = 0; i < size; i += 3) {
+    auto name = metrics.at(i).stringView();
+    auto labels = metrics.at(i + 1).stringView();
+    auto value = metrics.at(i + 2).getNumber<uint64_t>();
+    data->metrics.values.emplace(
+        MetricKey<std::string>{std::string{name}, std::string{labels}},
+        MetricValue{value});
+  }
+  return data;
+}
+
+void ClusterMetricsFeature::Metrics::toVelocyPack(VPackBuilder& builder) const {
+  builder.openArray();
+  for (auto const& [key, value] : values) {
+    builder.add(VPackValue{key.name});
+    builder.add(VPackValue{key.labels});
+    std::visit([&](auto&& v) { builder.add(VPackValue{v}); }, value);
+  }
+  builder.close();
 }
 
 }  // namespace arangodb::metrics

--- a/arangod/Metrics/ClusterMetricsFeature.h
+++ b/arangod/Metrics/ClusterMetricsFeature.h
@@ -70,15 +70,12 @@ class ClusterMetricsFeature final : public ArangodFeature {
   };
 
   struct Data final {
-    explicit Data(uint64_t v) : version{v} {}
-
-    explicit Data(uint64_t v, Metrics&& m)
-        : version{v}, metrics{std::move(m)} {}
+    Data() = default;
+    explicit Data(Metrics&& m) : metrics{std::move(m)} {}
 
     static std::shared_ptr<Data> fromVPack(VPackSlice slice);
 
     LeaderResponse packed;
-    uint64_t version;
     Metrics metrics;
   };
   explicit ClusterMetricsFeature(Server& server);

--- a/arangod/Metrics/ClusterMetricsFeature.h
+++ b/arangod/Metrics/ClusterMetricsFeature.h
@@ -35,6 +35,7 @@
 #include "Containers/FlatHashMap.h"
 #include "Metrics/Batch.h"
 #include "Metrics/Builder.h"
+#include "Metrics/CollectMode.h"
 #include "Metrics/IBatch.h"
 #include "Metrics/Metric.h"
 #include "Metrics/MetricKey.h"
@@ -57,40 +58,47 @@ class ClusterMetricsFeature final : public ArangodFeature {
   // If you need to store a metric of another type,
   // such as double, or char, just add it to this variant
   using MetricValue = std::variant<uint64_t>;
-  // We want map because of promtool format
-  // Another option is hashmap<string, hashmap<string, value>
-  using Metrics = std::map<MetricKey<std::string>, MetricValue, std::less<>>;
 
-  struct Data {
-    Data() = default;
-    explicit Data(Metrics&& m) : metrics{std::move(m)} {}
+  struct Metrics final {
+    // We want map because of promtool format
+    // Another option is hashmap<string, hashmap<string, value>Ю
+    using Values = std::map<MetricKey<std::string>, MetricValue, std::less<>>;
 
-    Metrics metrics;
+    Values values;
+
+    void toVelocyPack(VPackBuilder& builder) const;
   };
 
+  struct Data final {
+    explicit Data(uint64_t v) : version{v} {}
+
+    explicit Data(uint64_t v, Metrics&& m)
+        : version{v}, metrics{std::move(m)} {}
+
+    static std::shared_ptr<Data> fromVPack(VPackSlice slice);
+
+    LeaderResponse packed;
+    uint64_t version;
+    Metrics metrics;
+  };
   explicit ClusterMetricsFeature(Server& server);
 
   void collectOptions(std::shared_ptr<options::ProgramOptions> options) final;
   void validateOptions(std::shared_ptr<options::ProgramOptions> options) final;
   void start() final;
   void beginShutdown() final;
+  void stop() final;
 
-  //////////////////////////////////////////////////////////////////////////////
-  /// Attempt to start updating metrics. If it's happening right now, or the
-  /// timeout hasn't passed since the last update, then we will postpone this
-  /// update for the future. There will be no more than one scheduled update at
-  /// a time, they will collapse.
-  //////////////////////////////////////////////////////////////////////////////
-  void asyncUpdate();
+  std::optional<std::string> update(CollectMode mode) noexcept;
 
   //////////////////////////////////////////////////////////////////////////////
   /// ToCoordinator custom function that accumulate many metrics from DBServers
   /// to some metrics on Coordinators
   //////////////////////////////////////////////////////////////////////////////
-  using ToCoordinator = void (*)(Metrics& /*reduced metrics*/,
-                                 std::string_view /*metric name*/,
-                                 velocypack::Slice /*metric labels*/,
-                                 velocypack::Slice /*metric value*/);
+  using MapReduce = void (*)(Metrics& /*reduced metrics*/,
+                             std::string_view /*metric name*/,
+                             velocypack::Slice /*metric labels*/,
+                             velocypack::Slice /*metric value*/);
   //////////////////////////////////////////////////////////////////////////////
   /// ToCoordinator custom function that accumulate many metrics from DBServers
   /// to some metrics on Coordinators
@@ -104,17 +112,17 @@ class ClusterMetricsFeature final : public ArangodFeature {
   //////////////////////////////////////////////////////////////////////////////
   /// Registration of some metric. We need to pass it name, and callbacks.
   ///
-  /// @param toCoordinator used to accumulate metrics
+  /// @param mapReduce used to accumulate metrics
   /// @param toPrometheus used to print accumulated metrics in Prometheus format
   //////////////////////////////////////////////////////////////////////////////
-  void add(std::string_view metric, ToCoordinator toCoordinator,
+  void add(std::string_view metric, MapReduce mapReduce,
            ToPrometheus toPrometheus);
 
   //////////////////////////////////////////////////////////////////////////////
   /// @see add but sometimes we want to accumulate some metrics from DBServers,
   /// but we don't want to make them public, so we don't need toPrometheus
   //////////////////////////////////////////////////////////////////////////////
-  void add(std::string_view metric, ToCoordinator toCoordinator);
+  void add(std::string_view metric, MapReduce mapReduce);
 
   void toPrometheus(std::string& result, std::string_view globals) const;
 
@@ -122,23 +130,28 @@ class ClusterMetricsFeature final : public ArangodFeature {
 
  private:
   mutable std::shared_mutex _m;
-  containers::FlatHashMap<std::string_view, ToCoordinator> _toCoordinator;
+  containers::FlatHashMap<std::string_view, MapReduce> _mapReduce;
   containers::FlatHashMap<std::string_view, ToPrometheus> _toPrometheus;
 
-  void scheduleUpdate() noexcept;
+  void rescheduleTimer() noexcept;
+  void rescheduleUpdate(uint32_t timeout) noexcept;
+
   void update();
-  void repeatUpdate() noexcept;
+  void repeatUpdate(bool force) noexcept;
+  bool writeData(uint64_t version, futures::Try<RawDBServers>&& raw);
+  bool readData(futures::Try<LeaderResponse>&& raw);
+  Metrics parse(RawDBServers&& metrics) const;
 
-  void set(RawDBServers&& metrics) const;
+  bool wasStop() const noexcept;
 
-  mutable std::shared_ptr<Data> _data;
-  Scheduler::WorkHandle _handle;
-  std::chrono::time_point<std::chrono::steady_clock> _lastUpdate{};
-  uint32_t _timeout{0};
+  std::shared_ptr<Data> _data;
+  Scheduler::WorkHandle _update;
+  Scheduler::WorkHandle _timer;
+  uint32_t _timeout = 0;
 
   static constexpr uint32_t kStop = 1;
   static constexpr uint32_t kUpdate = 2;
-  std::atomic_uint32_t _count{0};
+  std::atomic_uint32_t _count = 0;
 };
 
 }  // namespace arangodb::metrics

--- a/arangod/Metrics/ClusterMetricsFeature.h
+++ b/arangod/Metrics/ClusterMetricsFeature.h
@@ -89,6 +89,17 @@ class ClusterMetricsFeature final : public ArangodFeature {
   void beginShutdown() final;
   void stop() final;
 
+  //////////////////////////////////////////////////////////////////////////////
+  /// @brief Update current local cache of cluster metrics
+  /// @param mode customize update behavior
+  /// if mode is TriggerGlobal then async update and return nullopt
+  /// other modes if we aren't leader return who is leader
+  /// (RestHandler will make redirect to it)
+  /// if we are leader then if mode is ReadGlobal just do nothing
+  /// if mode is WriteGlobal then make blocking update from DB Servers
+  /// @return leader server id, nullopt means no need return (TriggerGlobal)
+  /// or current server is leader (other modes)
+  //////////////////////////////////////////////////////////////////////////////
   std::optional<std::string> update(CollectMode mode) noexcept;
 
   //////////////////////////////////////////////////////////////////////////////

--- a/arangod/Metrics/ClusterMetricsFeature.h
+++ b/arangod/Metrics/ClusterMetricsFeature.h
@@ -48,8 +48,11 @@
 namespace arangodb::metrics {
 
 ////////////////////////////////////////////////////////////////////////////////
-/// This feature is able to asynchronously collect metrics
-/// from cluster DBServers and accumulate them on the Coordinators
+/// This feature is able to asynchronously collect
+/// metrics from cluster DBServers (MetricsFeature)
+/// and accumulate them on the Coordinators (ClusterMetricsFeature)
+///
+/// See IResearchLinkCoordinator as an example
 ////////////////////////////////////////////////////////////////////////////////
 class ClusterMetricsFeature final : public ArangodFeature {
  public:

--- a/arangod/Metrics/ClusterMetricsFeature.h
+++ b/arangod/Metrics/ClusterMetricsFeature.h
@@ -158,7 +158,11 @@ class ClusterMetricsFeature final : public ArangodFeature {
   std::shared_ptr<Data> _data;
   Scheduler::WorkHandle _update;
   Scheduler::WorkHandle _timer;
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+  uint32_t _timeout = 1;
+#else
   uint32_t _timeout = 0;
+#endif
 
   static constexpr uint32_t kStop = 1;
   static constexpr uint32_t kUpdate = 2;

--- a/arangod/Metrics/CollectMode.h
+++ b/arangod/Metrics/CollectMode.h
@@ -22,15 +22,20 @@
 ////////////////////////////////////////////////////////////////////////////////
 #pragma once
 
-#include <velocypack/Buffer.h>
-
-#include <memory>
-#include <vector>
-
 namespace arangodb::metrics {
 
-using Raw = std::shared_ptr<velocypack::Buffer<uint8_t>>;
-using RawDBServers = std::vector<Raw>;
-using LeaderResponse = std::shared_ptr<velocypack::Buffer<uint8_t>>;
+/**
+ *         Local -- collect only local metrics
+ * .......Global -- collect cached cluster-wide metrics
+ * TriggerGlobal -- and trigger async update cache
+ *    ReadGlobal -- and try to sync read metrics from cache
+ *   WriteGlobal -- and try to sync collect metrics for cache
+ */
+enum class CollectMode {
+  Local,
+  TriggerGlobal,
+  ReadGlobal,
+  WriteGlobal,
+};
 
 }  // namespace arangodb::metrics

--- a/arangod/Metrics/MetricsFeature.cpp
+++ b/arangod/Metrics/MetricsFeature.cpp
@@ -153,6 +153,9 @@ void MetricsFeature::toPrometheus(std::string& result, CollectMode mode) const {
   }
 }
 
+////////////////////////////////////////////////////////////////////////////////
+/// Sets metrics that can be collected by ClusterMetricsFeature
+////////////////////////////////////////////////////////////////////////////////
 constexpr auto kCoordinatorBatch = frozen::make_unordered_set<frozen::string>({
     "arangodb_search_link_stats",
 });

--- a/arangod/Metrics/MetricsFeature.cpp
+++ b/arangod/Metrics/MetricsFeature.cpp
@@ -111,12 +111,7 @@ void MetricsFeature::validateOptions(std::shared_ptr<options::ProgramOptions>) {
   }
 }
 
-void MetricsFeature::toPrometheus(std::string& result) const {
-  auto& cm = server().getFeature<ClusterMetricsFeature>();
-  if (cm.isEnabled()) {
-    cm.asyncUpdate();
-  }
-
+void MetricsFeature::toPrometheus(std::string& result, CollectMode mode) const {
   // minimize reallocs
   result.reserve(32768);
 
@@ -152,10 +147,12 @@ void MetricsFeature::toPrometheus(std::string& result) const {
   if (es.typeName() == RocksDBEngine::kEngineName) {
     es.getStatistics(result);
   }
-  if (hasGlobals && cm.isEnabled()) {
+  auto& cm = server().getFeature<ClusterMetricsFeature>();
+  if (hasGlobals && cm.isEnabled() && mode != CollectMode::Local) {
     cm.toPrometheus(result, _globals);
   }
 }
+
 constexpr auto kCoordinatorBatch = frozen::make_unordered_set<frozen::string>({
     "arangodb_search_link_stats",
 });

--- a/arangod/Metrics/MetricsFeature.h
+++ b/arangod/Metrics/MetricsFeature.h
@@ -28,6 +28,7 @@
 #include "Metrics/Metric.h"
 #include "Metrics/IBatch.h"
 #include "Metrics/MetricKey.h"
+#include "Metrics/CollectMode.h"
 #include "ProgramOptions/ProgramOptions.h"
 #include "RestServer/arangod.h"
 #include "Statistics/ServerStatistics.h"
@@ -62,7 +63,7 @@ class MetricsFeature final : public ArangodFeature {
   Metric* get(MetricKeyView const& key);
   bool remove(Builder const& builder);
 
-  void toPrometheus(std::string& result) const;
+  void toPrometheus(std::string& result, CollectMode mode) const;
   void toVPack(velocypack::Builder& builder) const;
 
   ServerStatistics& serverStatistics() noexcept;

--- a/arangod/Metrics/MetricsFeature.h
+++ b/arangod/Metrics/MetricsFeature.h
@@ -64,6 +64,11 @@ class MetricsFeature final : public ArangodFeature {
   bool remove(Builder const& builder);
 
   void toPrometheus(std::string& result, CollectMode mode) const;
+
+  //////////////////////////////////////////////////////////////////////////////
+  /// @brief That used for collect some metrics
+  /// to array for ClusterMetricsFeature
+  //////////////////////////////////////////////////////////////////////////////
   void toVPack(velocypack::Builder& builder) const;
 
   ServerStatistics& serverStatistics() noexcept;

--- a/arangod/Metrics/Types.h
+++ b/arangod/Metrics/Types.h
@@ -22,15 +22,12 @@
 ////////////////////////////////////////////////////////////////////////////////
 #pragma once
 
-#include <velocypack/Buffer.h>
-
-#include <memory>
-#include <vector>
+#include <string_view>
 
 namespace arangodb::metrics {
 
-using Raw = std::shared_ptr<velocypack::Buffer<uint8_t>>;
-using RawDBServers = std::vector<Raw>;
-using LeaderResponse = std::shared_ptr<velocypack::Buffer<uint8_t>>;
+inline constexpr std::string_view kDBJson = "db_json";
+inline constexpr std::string_view kCDJson = "cd_json";
+inline constexpr std::string_view kLast = "last";
 
 }  // namespace arangodb::metrics

--- a/arangod/Metrics/Types.h
+++ b/arangod/Metrics/Types.h
@@ -26,6 +26,17 @@
 
 namespace arangodb::metrics {
 
+////////////////////////////////////////////////////////////////////////////////
+/// These are constants can be used for `type` in /admin/_metrics?type=...
+///
+/// `type` needed only for internal requests:
+/// `db_json` -- for async collect some metrics from DBServer to Coordinator
+/// `cd_json` -- for async collect cluster metrics from one Coordinator
+///   to another, commonly from follower to leader, needed to update local cache
+/// `last` -- We have some user request on Coordinator, then it make this
+///   request, and it consider requested Coordinator is a leader,
+///   if it's not true, we don't want redirect another time
+////////////////////////////////////////////////////////////////////////////////
 inline constexpr std::string_view kDBJson = "db_json";
 inline constexpr std::string_view kCDJson = "cd_json";
 inline constexpr std::string_view kLast = "last";

--- a/arangod/Network/Methods.h
+++ b/arangod/Network/Methods.h
@@ -139,6 +139,7 @@ struct RequestOptions {
 
   template<typename K, typename V>
   RequestOptions& param(K&& key, V&& val) {
+    TRI_ASSERT(!std::string_view{val}.empty());  // cannot parse it on receiver
     this->parameters.insert_or_assign(std::forward<K>(key),
                                       std::forward<V>(val));
     return *this;

--- a/arangod/RestHandler/RestMetricsHandler.cpp
+++ b/arangod/RestHandler/RestMetricsHandler.cpp
@@ -23,9 +23,6 @@
 
 #include "RestMetricsHandler.h"
 
-#include "Agency/AgencyComm.h"
-#include "Agency/AgencyFeature.h"
-#include "Agency/Agent.h"
 #include "ApplicationFeatures/ApplicationServer.h"
 #include "Cluster/ClusterFeature.h"
 #include "Cluster/ServerState.h"
@@ -37,11 +34,21 @@
 #include "Rest/Version.h"
 #include "RestServer/ServerFeature.h"
 #include "Metrics/MetricsFeature.h"
+#include "Metrics/Types.h"
 
+#include <frozen/string.h>
+#include <frozen/unordered_map.h>
 #include <velocypack/Builder.h>
 
 namespace arangodb {
 namespace {
+
+constexpr frozen::unordered_map<frozen::string, metrics::CollectMode, 4> kModes{
+    {"local", metrics::CollectMode::Local},
+    {"trigger_global", metrics::CollectMode::TriggerGlobal},
+    {"read_global", metrics::CollectMode::ReadGlobal},
+    {"write_global", metrics::CollectMode::WriteGlobal},
+};
 
 network::Headers buildHeaders(
     std::unordered_map<std::string, std::string> const& originalHeaders) {
@@ -79,55 +86,96 @@ RestStatus RestMetricsHandler::execute() {
   }
 
   if (_request->requestType() != RequestType::GET) {
+    // TODO(MBkkt) Now our API return 405 errorCode for 400 HTTP response code
+    //             I think we should fix it, but its breaking change
     generateError(ResponseCode::BAD, TRI_ERROR_HTTP_METHOD_NOT_ALLOWED);
     return RestStatus::DONE;
   }
 
-  bool foundServerIdParameter;
-  auto const& serverId = _request->value("serverId", foundServerIdParameter);
-
-  if (ServerState::instance()->isCoordinator() && foundServerIdParameter) {
-    if (serverId != ServerState::instance()->getId()) {
-      // not ourselves! - need to pass through the request
-      auto& ci = server().getFeature<ClusterFeature>().clusterInfo();
-      if (!ci.serverExists(serverId)) {
-        generateError(rest::ResponseCode::NOT_FOUND,
-                      TRI_ERROR_HTTP_BAD_PARAMETER,
-                      std::string("unknown serverId supplied."));
-        return RestStatus::DONE;
-      }
-      auto* pool = server().getFeature<NetworkFeature>().pool();
-      if (pool == nullptr) {
-        THROW_ARANGO_EXCEPTION(TRI_ERROR_SHUTTING_DOWN);
-      }
-
-      network::RequestOptions options;
-      options.timeout = network::Timeout(30.0);
-      options.database = _request->databaseName();
-      options.parameters = _request->parameters();
-
-      auto f = network::sendRequest(
-          pool, "server:" + serverId, fuerte::RestVerb::Get,
-          _request->requestPath(), VPackBuffer<uint8_t>{}, options,
-          buildHeaders(_request->headers()));
-      return waitForFuture(std::move(f).thenValue(
-          [self = std::dynamic_pointer_cast<RestMetricsHandler>(
-               shared_from_this())](network::Response const& r) {
-            if (r.fail() || !r.hasResponse()) {
-              TRI_ASSERT(r.fail());
-              self->generateError(r.combinedResult());
-            } else {
-              // the response will not contain any velocypack.
-              // we need to forward the request with content-type text/plain.
-              self->_response->setResponseCode(rest::ResponseCode::OK);
-              self->_response->setContentType(rest::ContentType::TEXT);
-              auto payload = r.response().stealPayload();
-              self->_response->addRawPayload(std::string_view(
-                  reinterpret_cast<char const*>(payload->data()),
-                  payload->size()));
-            }
-          }));
+  bool foundServerId;
+  bool foundType;
+  bool foundMode;
+  auto const& serverId = _request->value("serverId", foundServerId);
+  std::string_view type = _request->value("type", foundType);
+  std::string_view modeStr = _request->value("mode", foundMode);
+  auto itMode = kModes.find(modeStr);
+  auto mode = [&] {
+    if (itMode != kModes.end()) {
+      return itMode->second;
     }
+    return metrics::CollectMode::Local;
+  }();
+
+  foundServerId = foundServerId && ServerState::instance()->isCoordinator() &&
+                  serverId != ServerState::instance()->getId();
+  // TODO(MBkkt) I think in the future we should return an error
+  //             if the ServerId is not a Coordinator or it's our ServerId.
+  //             But now it will be breaking changes.
+
+  std::string error;
+
+  if (foundMode) {
+    if (foundType && type != metrics::kLast) {
+      error += "Can't use mode parameter with type parameter.\n";
+    }
+    if (!ServerState::instance()->isCoordinator()) {
+      error += "Can't supply mode parameter to non-Coordinator.\n";
+    }
+    if (itMode == kModes.end()) {
+      error += "Unknown value of mode parameter.\n";
+    }
+  }
+
+  if (foundType) {
+    if (foundServerId) {
+      error += "Can't use type parameter with serverId parameter.\n";
+    }
+    if (type == metrics::kCDJson || type == metrics::kLast) {
+      if (!ServerState::instance()->isCoordinator()) {
+        error +=
+            "Can't supply type=cd_json/last parameter to non-Coordinator.\n";
+      }
+    } else if (type == metrics::kDBJson) {
+      if (!ServerState::instance()->isDBServer()) {
+        error += "Can't supply type=db_json parameter to non-DBServer.\n";
+      }
+    } else {
+      error += "Unknown value of type parameter.\n";
+    }
+  }
+
+  bool const notFound = error.empty();
+  if (foundServerId) {
+    auto& ci = server().getFeature<ClusterFeature>().clusterInfo();
+    if (!ci.serverExists(serverId)) {
+      error += "Unknown value of serverId parameter.\n";
+    }
+  }
+
+  if (!error.empty()) {
+    // TODO(MBkkt) Now our API return 400 errorCode for 404 HTTP response code
+    //             I think we should fix it, but its breaking change
+    generateError(
+        notFound ? rest::ResponseCode::NOT_FOUND : rest::ResponseCode::BAD,
+        TRI_ERROR_HTTP_BAD_PARAMETER, error);
+    return RestStatus::DONE;
+  }
+
+  if (foundServerId) {
+    return makeRedirection(serverId, false);
+  }
+
+  if (type == metrics::kCDJson) {
+    auto& metrics = server().getFeature<metrics::ClusterMetricsFeature>();
+    auto data = metrics.getData();
+    _response->setResponseCode(rest::ResponseCode::OK);
+    _response->setContentType(rest::ContentType::VPACK);
+    if (data->packed) {
+      _response->addPayload(velocypack::Slice{data->packed->data()});
+    } else {
+      _response->addPayload(velocypack::Slice::emptyArraySlice());
+    }
+    return RestStatus::DONE;
   }
 
   auto& metrics = server().getFeature<metrics::MetricsFeature>();
@@ -137,26 +185,85 @@ RestStatus RestMetricsHandler::execute() {
     return RestStatus::DONE;
   }
 
-  auto const& values = _request->values();
-  auto it = values.find("type");
-  if (it != values.end() && it->second == "json") {
+  if (type == metrics::kDBJson) {
     VPackBuilder builder;
     metrics.toVPack(builder);
     _response->setResponseCode(rest::ResponseCode::OK);
     _response->setContentType(rest::ContentType::VPACK);
     _response->addPayload(builder.slice());
-  } else if (it != values.end()) {
-    generateError(rest::ResponseCode::NOT_FOUND, TRI_ERROR_HTTP_BAD_PARAMETER,
-                  std::string("unknown 'type' parameter supplied."));
     return RestStatus::DONE;
-  } else {
+  }
+
+  auto const leader = [&]() -> std::optional<std::string> {
+    auto& cm = server().getFeature<metrics::ClusterMetricsFeature>();
+    if (cm.isEnabled() && mode != metrics::CollectMode::Local) {
+      return cm.update(mode);
+    }
+    return std::nullopt;
+  }();
+
+  if (leader && (leader->empty() || type == metrics::kLast)) {
+    // TODO(MBkkt) Maybe response with some error?
+    mode = metrics::CollectMode::Local;
+  }
+
+  if (!leader) {
     std::string result;
-    metrics.toPrometheus(result);
+    metrics.toPrometheus(result, mode);
     _response->setResponseCode(rest::ResponseCode::OK);
     _response->setContentType(rest::ContentType::TEXT);
     _response->addRawPayload(result);
+    return RestStatus::DONE;
   }
-  return RestStatus::DONE;
+  TRI_ASSERT(mode == metrics::CollectMode::ReadGlobal ||
+             mode == metrics::CollectMode::WriteGlobal)
+      << modeStr;
+  return makeRedirection(*leader, true);
+}
+
+RestStatus RestMetricsHandler::makeRedirection(std::string const& serverId,
+                                               bool last) {
+  auto* pool = server().getFeature<NetworkFeature>().pool();
+  if (pool == nullptr) {
+    THROW_ARANGO_EXCEPTION(TRI_ERROR_SHUTTING_DOWN);
+  }
+
+  network::RequestOptions options;
+  options.timeout = network::Timeout(30.0);
+  options.database = _request->databaseName();
+  options.parameters = _request->parameters();
+  if (last) {
+    options.parameters.try_emplace("type", metrics::kLast);
+  }
+
+  auto f =
+      network::sendRequest(pool, "server:" + serverId, fuerte::RestVerb::Get,
+                           _request->requestPath(), VPackBuffer<uint8_t>{},
+                           options, buildHeaders(_request->headers()));
+
+  return waitForFuture(std::move(f).thenValue(
+      [self = shared_from_this(), last](network::Response&& r) {
+        auto& me = basics::downCast<RestMetricsHandler>(*self);
+        if (r.fail() || !r.hasResponse()) {
+          TRI_ASSERT(r.fail());
+          me.generateError(r.combinedResult());
+          return;
+        }
+        if (last) {
+          auto& cm = me.server().getFeature<metrics::ClusterMetricsFeature>();
+          if (cm.isEnabled()) {
+            cm.update(metrics::CollectMode::TriggerGlobal);
+          }
+        }
+        // TODO(MBkkt) move response
+        // the response will not contain any velocypack.
+        // we need to forward the request with content-type text/plain.
+        me._response->setResponseCode(rest::ResponseCode::OK);
+        me._response->setContentType(rest::ContentType::TEXT);
+        auto payload = r.response().stealPayload();
+        me._response->addRawPayload(
+            {reinterpret_cast<char const*>(payload->data()), payload->size()});
+      }));
 }
 
 }  // namespace arangodb

--- a/arangod/RestHandler/RestMetricsHandler.cpp
+++ b/arangod/RestHandler/RestMetricsHandler.cpp
@@ -74,13 +74,15 @@ bool isOutdated(
   }
   velocypack::Slice newData{data->packed->data()};
   auto const oldVersion = oldData.value("MetricsVersion");
+  TRI_ASSERT(!oldVersion.empty());
   auto const newVersion = newData.get("Version").getNumber<uint64_t>();
-  if (oldVersion.empty() || std::stoull(oldVersion) < newVersion) {
+  if (std::stoull(oldVersion) < newVersion) {
     return true;
   }
   auto const oldRebootId = oldData.value("MetricsRebootId");
+  TRI_ASSERT(!oldRebootId.empty());
   auto const newRebootId = newData.get("RebootId").getNumber<uint64_t>();
-  if (oldRebootId.empty() || std::stoull(oldRebootId) != newRebootId) {
+  if (std::stoull(oldRebootId) != newRebootId) {
     return true;
   }
   auto const oldServerId = oldData.value("MetricsServerId");
@@ -194,9 +196,9 @@ RestStatus RestMetricsHandler::execute() {
     auto& metrics = server().getFeature<metrics::ClusterMetricsFeature>();
     auto data = metrics.getData();
     if (isOutdated(*_request, data)) {
-      _response->addPayload(velocypack::Slice{data->packed->data()});
+      _response->addPayload(VPackSlice{data->packed->data()});
     } else {
-      _response->addPayload(velocypack::Slice::emptyArraySlice());
+      _response->addPayload(VPackSlice::noneSlice());
     }
     return RestStatus::DONE;
   }

--- a/arangod/RestHandler/RestMetricsHandler.h
+++ b/arangod/RestHandler/RestMetricsHandler.h
@@ -25,6 +25,8 @@
 
 #include "RestHandler/RestBaseHandler.h"
 
+#include <string>
+
 namespace arangodb {
 
 class RestMetricsHandler : public arangodb::RestBaseHandler {
@@ -36,6 +38,9 @@ class RestMetricsHandler : public arangodb::RestBaseHandler {
   /// even from otherwise totally busy servers
   RequestLane lane() const final { return RequestLane::CLIENT_FAST; }
   RestStatus execute() final;
+
+ private:
+  RestStatus makeRedirection(std::string const& serverId, bool last);
 };
 
 }  // namespace arangodb

--- a/js/client/modules/@arangodb/test-helper.js
+++ b/js/client/modules/@arangodb/test-helper.js
@@ -161,18 +161,23 @@ exports.getChecksum = function (endpoint, name) {
     reconnectRetry(primaryEndpoint, "_system", "root", "");
   }
 };
-exports.getMetricRaw = function (endpoint, tags) {
+
+exports.getRawMetric = function (endpoint, tags) {
   const primaryEndpoint = arango.getEndpoint();
   try {
     reconnectRetry(endpoint, db._name(), "root", "");
-    let res = arango.GET_RAW('/_admin/metrics' + tags);
-    if (res.code !== 200) {
-      throw "error fetching metric";
-    }
-    return res.body;
+    return arango.GET_RAW('/_admin/metrics' + tags);
   } finally {
-    reconnectRetry(primaryEndpoint, "_system", "root", "");
+    reconnectRetry(primaryEndpoint, db._name(), "root", "");
   }
+};
+
+exports.getAllMetric = function (endpoint, tags) {
+  let res = exports.getRawMetric(endpoint, tags);
+  if (res.code !== 200) {
+    throw "error fetching metric";
+  }
+  return res.body;
 };
 
 function getMetricName(text, name) {
@@ -185,17 +190,8 @@ function getMetricName(text, name) {
 }
 
 exports.getMetric = function (endpoint, name) {
-  const primaryEndpoint = arango.getEndpoint();
-  try {
-    reconnectRetry(endpoint, db._name(), "root", "");
-    let res = arango.GET_RAW("/_admin/metrics");
-    if (res.code !== 200) {
-      throw "error fetching metric";
-    }
-    return getMetricName(res.body, name);
-  } finally {
-    reconnectRetry(primaryEndpoint, db._name(), "root", "");
-  }
+  let text = exports.getAllMetric(endpoint, '');
+  return getMetricName(text, name);
 };
 
 exports.getMetricSingle = function (name) {

--- a/tests/js/client/shell/api/coordinator-metrics-noncluster.js
+++ b/tests/js/client/shell/api/coordinator-metrics-noncluster.js
@@ -77,6 +77,18 @@ function CoordinatorMetricsTestSuite() {
         let res = getRawMetric(primary, '?mode=local');
         assertEqual(res.code, 400);
       }
+      let type = ['?e0=e0', '?type=invalid', '?type=db_json', '?type=cd_json', '?type=last'];
+      let mode = ['&e1=e1', '&mode=invalid', '&mode=local', '&mode=trigger_global', '&mode=read_global', '&mode=write_global'];
+      let serverId = ['&e2=e2', '&serverId=invalid'];
+      let f = (a, b) => [].concat(...a.map(a => b.map(b => [].concat(a, b))));
+      let cartesian = (a, b, ...c) => b ? cartesian(f(a, b), ...c) : a;
+      let params = cartesian(type, mode, serverId);
+      for (let k = 0; k < params.length; k++) {
+        let param = params[k][0] + params[k][1] + params[k][2];
+        // require('internal').print(param);
+        let res = getRawMetric(primary, param);
+        // require('internal').print(res.errorCode);
+      }
     },
   };
 }

--- a/tests/js/client/shell/api/coordinator-metrics-noncluster.js
+++ b/tests/js/client/shell/api/coordinator-metrics-noncluster.js
@@ -1,0 +1,90 @@
+/*jshint globalstrict:false, strict:false, maxlen: 500 */
+/*global fail, assertUndefined, assertEqual, assertNotEqual, assertTrue, assertFalse, assertNull*/
+
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2022 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Valery Mironov
+////////////////////////////////////////////////////////////////////////////////
+
+const jsunity = require("jsunity");
+const arangodb = require("@arangodb");
+const {getRawMetric} = require("@arangodb/test-helper");
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief test suite
+////////////////////////////////////////////////////////////////////////////////
+function CoordinatorMetricsTestSuite() {
+  return {
+    setUpAll: function () {
+    },
+
+    tearDownAll: function () {
+    },
+
+    ////////////////////////////////////////////////////////////////////////////////
+    /// @brief CoordinatorMetricsTestSuite tests
+    ////////////////////////////////////////////////////////////////////////////////
+    testMetricsParameterValidation: function () {
+      let primary = arangodb.arango.getEndpoint();
+      {
+        let res = getRawMetric(primary, '?mode=invalid');
+        assertEqual(res.code, 400);
+      }
+      {
+        let res = getRawMetric(primary, '?type=invalid');
+        assertEqual(res.code, 400);
+      }
+      {
+        let res = getRawMetric(primary, '?type=invalid&mode=invalid');
+        assertEqual(res.code, 400);
+      }
+      {
+        let res = getRawMetric(primary, '?serverId=invalid');
+        // Should be 404, see TODO in arangod/RestHandler/RestMetricsHandler.cpp
+        assertEqual(res.code, 200);
+      }
+      {
+        let res = getRawMetric(primary, '?serverId=invalid&mode=invalid');
+        assertEqual(res.code, 400);
+      }
+      {
+        let res = getRawMetric(primary, '?serverId=invalid&type=invalid');
+        assertEqual(res.code, 400);
+      }
+      {
+        let res = getRawMetric(primary, '?serverId=invalid&type=invalid&mode=invalid');
+        assertEqual(res.code, 400);
+      }
+      {
+        let res = getRawMetric(primary, '?mode=local');
+        assertEqual(res.code, 400);
+      }
+    },
+  };
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief executes the test suite
+////////////////////////////////////////////////////////////////////////////////
+
+jsunity.run(CoordinatorMetricsTestSuite);
+
+return jsunity.done();

--- a/tests/js/common/aql/aql-view-arangosearch-ddl-cluster.js
+++ b/tests/js/common/aql/aql-view-arangosearch-ddl-cluster.js
@@ -29,18 +29,28 @@ var db = require("@arangodb").db;
 var analyzers = require("@arangodb/analyzers");
 var ERRORS = require("@arangodb").errors;
 const isServer = require("@arangodb").isServer;
-const {getMetricRaw} = require("@arangodb/test-helper");
+const {getRawMetric, getEndpointsByType} = require("@arangodb/test-helper");
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief test suite
 ////////////////////////////////////////////////////////////////////////////////
 
-function IResearchFeatureDDLTestSuite () {
+let triggerMetrics = function () {
+  let coordinators = getEndpointsByType("coordinator");
+  getRawMetric(coordinators[0], '?mode=write_global');
+  for (let i = 1; i < coordinators.length; i++) {
+    let c = coordinators[i];
+    getRawMetric(c, '?mode=trigger_global');
+  }
+  require('internal').sleep(1);
+};
+
+function IResearchFeatureDDLTestSuite() {
   return {
-    setUpAll : function () {
+    setUpAll: function () {
     },
 
-    tearDownAll : function () {
+    tearDownAll: function () {
       db._useDatabase("_system");
 
       db._dropView("TestView");
@@ -161,30 +171,39 @@ function IResearchFeatureDDLTestSuite () {
 
     testAddDuplicateAnalyzers : function() {
       db._useDatabase("_system");
-      try { db._dropDatabase("TestDuplicateDB"); } catch (e) {}
-      try { analyzers.remove("myIdentity", true); } catch (e) {}
-        
+      try {
+        db._dropDatabase("TestDuplicateDB");
+      } catch (e) {
+      }
+      try {
+        analyzers.remove("myIdentity", true);
+      } catch (e) {
+      }
+
       analyzers.save("myIdentity", "identity");
       db._createDatabase("TestDuplicateDB");
       db._useDatabase("TestDuplicateDB");
       analyzers.save("myIdentity", "identity");
       db._create("TestCollection0");
 
-      var view = db._createView("TestView", "arangosearch", 
-        { links : 
-          { "TestCollection0" : 
-            { includeAllFields: true, analyzers: 
-                [ "identity", "identity", 
-                "TestDuplicateDB::myIdentity" , "myIdentity", 
-                "::myIdentity", "_system::myIdentity" 
-                ]
-            } 
-          }
+      var view = db._createView("TestView", "arangosearch",
+        {
+          links:
+            {
+              "TestCollection0":
+                {
+                  includeAllFields: true, analyzers:
+                    ["identity", "identity",
+                      "TestDuplicateDB::myIdentity", "myIdentity",
+                      "::myIdentity", "_system::myIdentity"
+                    ]
+                }
+            }
         }
-        );
+      );
       var properties = view.properties();
       assertEqual(3, Object.keys(properties.links.TestCollection0.analyzers).length);
-      
+
       let expectedAnalyzers = new Set();
       expectedAnalyzers.add("identity");
       expectedAnalyzers.add("myIdentity");
@@ -600,7 +619,7 @@ function IResearchFeatureDDLTestSuite () {
       assertEqual((0.5).toFixed(6), properties.consolidationPolicy.threshold.toFixed(6));
 
       col0.save({ name: "quarter", text: "quick over" });
-      
+
       result = db._query("FOR doc IN TestView OPTIONS { waitForSync: true } SORT doc.name RETURN doc").toArray();
       assertEqual(1, result.length);
       assertEqual("quarter", result[0].name);
@@ -750,19 +769,19 @@ function IResearchFeatureDDLTestSuite () {
     testViewModifyImmutableProperties: function() {
       db._dropView("TestView");
 
-      var view = db._createView("TestView", "arangosearch", { 
+      var view = db._createView("TestView", "arangosearch", {
         writebufferActive: 25,
         writebufferIdle: 12,
         writebufferSizeMax: 44040192,
         locale: "C",
         version: 1,
-        primarySortCompression:"none",
+        primarySortCompression: "none",
         primarySort: [
-          { field: "my.Nested.field", direction: "asc" },
-          { field: "another.field", asc: false }
+          {field: "my.Nested.field", direction: "asc"},
+          {field: "another.field", asc: false}
         ],
         "cleanupIntervalStep": 42,
-        "commitIntervalMsec": 12345 
+        "commitIntervalMsec": 12345
       });
 
       var properties = view.properties();
@@ -791,14 +810,14 @@ function IResearchFeatureDDLTestSuite () {
       assertEqual(2*(1 << 20), properties.consolidationPolicy.segmentsBytesFloor);
       assertEqual((0.0).toFixed(6), properties.consolidationPolicy.minScore.toFixed(6));
 
-      view.properties({ 
+      view.properties({
         writebufferActive: 225,
         writebufferIdle: 112,
         writebufferSizeMax: 414040192,
         locale: "en_EN.UTF-8",
         version: 2,
-        primarySort: [ { field: "field", asc: false } ],
-        primarySortCompression:"lz4",
+        primarySort: [{field: "field", asc: false}],
+        primarySortCompression: "lz4",
         "cleanupIntervalStep": 442
       }, false); // full update
 
@@ -930,8 +949,7 @@ function IResearchFeatureDDLTestSuite () {
       });
       view.properties({ links: { [colName]: { includeAllFields: true } } });
 
-      getMetricRaw(arango.getEndpoint(), '');
-      require('internal').sleep(5);
+      triggerMetrics();
 
       // check link stats
       {
@@ -952,8 +970,7 @@ function IResearchFeatureDDLTestSuite () {
       col.save({ foo: 'bar' });
       col.save({ foo: 'baz' });
 
-      getMetricRaw(arango.getEndpoint(), '');
-      require('internal').sleep(5);
+      triggerMetrics();
 
       // check link stats
       {
@@ -976,8 +993,7 @@ function IResearchFeatureDDLTestSuite () {
       assertEqual('bar', res[0].foo);
       assertEqual('baz', res[1].foo);
 
-      getMetricRaw(arango.getEndpoint(), '');
-      require('internal').sleep(5);
+      triggerMetrics();
 
       // check link stats
       {
@@ -1002,8 +1018,7 @@ function IResearchFeatureDDLTestSuite () {
       assertEqual(1, res.length);
       assertEqual('baz', res[0].foo);
 
-      getMetricRaw(arango.getEndpoint(), '');
-      require('internal').sleep(5);
+      triggerMetrics();
 
       // check link stats
       {
@@ -1027,8 +1042,7 @@ function IResearchFeatureDDLTestSuite () {
       res = db._query("FOR d IN TestView OPTIONS {waitForSync:true} SORT d.foo RETURN d").toArray();
       assertEqual(0, res.length);
 
-      getMetricRaw(arango.getEndpoint(), '');
-      require('internal').sleep(5);
+      triggerMetrics();
 
       // check link stats
       {
@@ -1163,29 +1177,32 @@ function IResearchFeatureDDLTestSuite () {
     testAnalyzerWithStopwordsNameConflict : function() {
       const dbName = "TestNameConflictDB";
       db._useDatabase("_system");
-      try { db._dropDatabase(dbName); } catch (e) {}
+      try {
+        db._dropDatabase(dbName);
+      } catch (e) {
+      }
 
       db._createDatabase(dbName);
       db._useDatabase(dbName);
 
       db._create("col1");
       db._create("col2");
-      analyzers.save("custom_analyzer", 
-        "text", 
-        { 
-          locale: "en.UTF-8", 
-          case: "lower", 
-          stopwords: ["the", "of", "inc", "co", "plc", "ltd", "ag"], 
-          accent: false, 
+      analyzers.save("custom_analyzer",
+        "text",
+        {
+          locale: "en.UTF-8",
+          case: "lower",
+          stopwords: ["the", "of", "inc", "co", "plc", "ltd", "ag"],
+          accent: false,
           stemming: false
         },
-        ["position", "norm","frequency"]);
+        ["position", "norm", "frequency"]);
 
       let v = db._createView("view1", "arangosearch", {
         "links": {
           "col1": {
             "analyzers": ["identity"],
-            "fields": { "name": { "analyzers": ["custom_analyzer"]}},
+            "fields": {"name": {"analyzers": ["custom_analyzer"]}},
             "includeAllFields": false,
             "storeValues": "none",
             "trackListPositions": false
@@ -1240,7 +1257,7 @@ function IResearchFeatureDDLTestSuite () {
       assertEqual(1, properties.links.col2.analyzers.length);
       assertTrue(String === properties.links.col2.analyzers[0].constructor);
       assertEqual("identity", properties.links.col2.analyzers[0]);
-      
+
       db._useDatabase("_system");
       db._dropDatabase(dbName);
     },


### PR DESCRIPTION
### Scope & Purpose

This PR adds volatile distributed cache between coordinators for DBservers metrics that are accumulated on Coordinators.
This cache is implemented using `ClusterMetricsFeature` and `Agency`.
1) Agency stores the current leader (master) among all coordinators (its `ServerID` (`std::string`) and `RebootId` (`uint64_t`)), and the current cache version (`uint64_t`))
2) At the start of each coordinator (ClusterMetricsFeature::start) we try to offer ourselves as a leader (master) for this cache.
We try (make a record in the Agency) until we succeed, or we realize that someone else had become the leader.
3) `ClusterMetricsFeature` has an `update(CollectMode::TriggerGlobal)` method that triggers a async local cache update.
3.1) At the beginning we read from `agencyCache()` who is the current cache leader and the cache version on this leader
3.2) If we are the leader, then we collect data from db servers, aggregate them (having previously aggregated them on db servers), then try to write a new version to the `Agency` (we check that we are still the leader and that the version we collected is an increment of what is in leader), if it works, then we make this new cache available to any readers (`ClusterMetricsFeature::getData`)
3.3) If we are a follower, then we save a callback for the current leader in `RebootTracker`. That callback will be called if the current leader dies. In this callback, we will try to become a leader ourselves (only if current leader is old died leader).
3.4) We also know our local version and the version on the leader, if ours is smaller, then we make retry.
3.5) Otherwise, we go to the leader and read its local cache, making it available already on our coordinator.

Important notes:
1) No matter how many times (parallel also allowed) `update(CollectMode::TriggerGlobal)` is called, only one real update will work at a time
It can also be noted that the "queue" of updates is virtual and its size is never more than 1, that is, in fact, we have a state machine with the following states:
V1: no update and doesn't need an update
V2: update in progress and doesn't need an update
V3: update in progress and needs an update
transitions are as follows:
E1: V1 -> V2, there were any (> 1) number of `update(TriggerGlobal)` during V1
E2: V2 -> V1
E3: V2 -> V2, there were any (> 1) number of `update(TriggerGlobal)` during V2
E4: V3 -> V2

2) Each (successful) update of the distributed cache is done by a (successful) write transaction to Agency (ServerID (string), RebootID (uint64_t), version(uint64_t))

3) Each re-election of the leader, there are attempts to write to the Agency (ServerID (string), RebootID (uint64_t)), of which exactly one is successful.


- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*
  - [ ] Backport for 3.7: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

