### PR TITLE
[PREGEL] Report Worker Status

### DIFF
--- a/arangod/Pregel/Common.h
+++ b/arangod/Pregel/Common.h
@@ -23,7 +23,32 @@
 #pragma once
 
 #include <chrono>
+#include <string>
+
+#include <Inspection/VPack.h>
+#include <Inspection/Transformers.h>
 
 namespace arangodb::pregel {
+
+namespace static_strings {
+constexpr auto start = std::string_view{"start"};
+constexpr auto end = std::string_view{"end"};
+
+}  // namespace static_strings
+
 using TimeStamp = std::chrono::system_clock::time_point;
+
+struct TimeInterval {
+  std::optional<TimeStamp> start;
+  std::optional<TimeStamp> end;
+};
+
+template<typename Inspector>
+auto inspect(Inspector& f, TimeInterval& x) {
+  return f.object(x).fields(
+      f.field(static_strings::start, x.start)
+          .transformWith(inspection::TimeStampTransformer{}),
+      f.field(static_strings::end, x.end)
+          .transformWith(inspection::TimeStampTransformer{}));
 }
+}  // namespace arangodb::pregel

--- a/arangod/Pregel/Common.h
+++ b/arangod/Pregel/Common.h
@@ -1,0 +1,29 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2022 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Markus Pfeiffer
+////////////////////////////////////////////////////////////////////////////////
+#pragma once
+
+#include <chrono>
+
+namespace arangodb::pregel {
+using TimeStamp = std::chrono::system_clock::time_point;
+}

--- a/arangod/Pregel/Conductor.cpp
+++ b/arangod/Pregel/Conductor.cpp
@@ -35,7 +35,7 @@
 #include "Pregel/PregelFeature.h"
 #include "Pregel/Recovery.h"
 #include "Pregel/Utils.h"
-#include "Pregel/Structs/WorkerStatusUpdate.h"
+#include "Pregel/Structs/WorkerStatus.h"
 #include "Pregel/Structs/ConductorStatus.h"
 
 #include "ApplicationFeatures/ApplicationServer.h"
@@ -338,8 +338,8 @@ void Conductor::workerStatusUpdate(VPackSlice const& data) {
   _status.edgesLoaded = 0;
 
   for (auto&& [_, workerStatus] : _status.workers) {
-    _status.verticesLoaded += workerStatus.verticesLoaded;
-    _status.edgesLoaded += workerStatus.edgesLoaded;
+    _status.verticesLoaded += workerStatus.graphStoreStats.numberVerticesLoaded;
+    _status.edgesLoaded += workerStatus.graphStoreStats.numberEdgesLoaded;
   }
 }
 
@@ -370,6 +370,10 @@ void Conductor::finishedWorkerStartup(VPackSlice const& data) {
   }
 
   _computationStartTimeSecs = TRI_microtime();
+
+  auto const now = std::chrono::system_clock::now();
+  _status.timing.loading.end = now;
+  _status.timing.running.start = now;
   _startGlobalStep();
 }
 
@@ -863,6 +867,7 @@ void Conductor::finishedWorkerFinalize(VPackSlice data) {
   _aggregators->serializeValues(debugOut);
   debugOut.close();
 
+  _status.timing.running.end = std::chrono::system_clock::now();
   if (_finalizationStartTimeSecs < _computationStartTimeSecs) {
     // prevent negative computation times from being reported
     _finalizationStartTimeSecs = _computationStartTimeSecs;

--- a/arangod/Pregel/Conductor.h
+++ b/arangod/Pregel/Conductor.h
@@ -33,6 +33,8 @@
 #include "Scheduler/Scheduler.h"
 #include "Utils/DatabaseGuard.h"
 
+#include "Pregel/Structs/ConductorStatus.h"
+
 #include <chrono>
 
 namespace arangodb {
@@ -115,6 +117,11 @@ class Conductor : public std::enable_shared_from_this<Conductor> {
   double _stepStartTimeSecs = 0.0;  // start time of current gss
   Scheduler::WorkHandle _workHandle;
 
+  // Work in Progress: Move data incrementally into this
+  // struct; sort it into categories and make it (de)serialisable
+  // with the Inspecotr framework
+  ConductorStatus _status;
+
   bool _startGlobalStep();
   ErrorCode _initializeWorkers(std::string const& suffix,
                                VPackSlice additional);
@@ -127,6 +134,7 @@ class Conductor : public std::enable_shared_from_this<Conductor> {
   void _ensureUniqueResponse(VPackSlice body);
 
   // === REST callbacks ===
+  void workerStatusUpdate(VPackSlice const& data);
   void finishedWorkerStartup(VPackSlice const& data);
   VPackBuilder finishedWorkerStep(VPackSlice const& data);
   void finishedWorkerFinalize(VPackSlice data);

--- a/arangod/Pregel/PregelFeature.cpp
+++ b/arangod/Pregel/PregelFeature.cpp
@@ -442,7 +442,9 @@ void PregelFeature::handleConductorRequest(TRI_vocbase_t& vocbase,
             std::to_string(exeNum));
   }
 
-  if (path == Utils::finishedStartupPath) {
+  if (path == Utils::statusUpdatePath) {
+    co->workerStatusUpdate(body);
+  } else if (path == Utils::finishedStartupPath) {
     co->finishedWorkerStartup(body);
   } else if (path == Utils::finishedWorkerStepPath) {
     outBuilder = co->finishedWorkerStep(body);

--- a/arangod/Pregel/Structs/ConductorStatus.h
+++ b/arangod/Pregel/Structs/ConductorStatus.h
@@ -38,11 +38,28 @@
 
 namespace arangodb::pregel {
 
+struct ConductorTiming {
+  TimeInterval loading;
+  TimeInterval running;
+  TimeInterval storing;
+};
+template<typename Inspector>
+auto inspect(Inspector& f, ConductorTiming& x) {
+  return f.object(x).fields(f.field(static_strings::loading, x.loading),
+                            f.field(static_strings::running, x.running),
+                            f.field(static_strings::storing, x.storing));
+}
+
 struct ConductorStatus {
   TimeStamp timeStamp;
   std::size_t verticesLoaded;
   std::size_t edgesLoaded;
   std::unordered_map<ServerID, WorkerStatus> workers;
+
+  TimeStamp created;
+  TimeStamp expires;
+
+  ConductorTiming timing;
 
   ConductorStatus()
       : timeStamp{std::chrono::system_clock::now()},
@@ -56,8 +73,9 @@ auto inspect(Inspector& f, ConductorStatus& x) {
   return f.object(x).fields(
       f.field(static_strings::timeStamp, x.timeStamp)
           .transformWith(inspection::TimeStampTransformer{}),
-      f.field(static_strings::verticesLoaded, x.verticesLoaded),
-      f.field(static_strings::edgesLoaded, x.edgesLoaded),
+      f.field(static_strings::numberVerticesLoaded, x.verticesLoaded),
+      f.field(static_strings::numberEdgesLoaded, x.edgesLoaded),
+      f.field(static_strings::timing, x.timing),
       f.field(static_strings::workerStatus, x.workers));
 }
 

--- a/arangod/Pregel/Structs/ConductorStatus.h
+++ b/arangod/Pregel/Structs/ConductorStatus.h
@@ -1,0 +1,64 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2022 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Markus Pfeiffer
+////////////////////////////////////////////////////////////////////////////////
+#pragma once
+
+#include <chrono>
+#include <cstdint>
+#include <string>
+
+#include <Inspection/VPack.h>
+#include <Inspection/Transformers.h>
+
+#include <Cluster/ClusterTypes.h>
+
+#include <Pregel/Common.h>
+#include <Pregel/Structs/WorkerStatus.h>
+
+#include "StaticStrings.h"
+
+namespace arangodb::pregel {
+
+struct ConductorStatus {
+  TimeStamp timeStamp;
+  std::size_t verticesLoaded;
+  std::size_t edgesLoaded;
+  std::unordered_map<ServerID, WorkerStatus> workers;
+
+  ConductorStatus()
+      : timeStamp{std::chrono::system_clock::now()},
+        verticesLoaded{0},
+        edgesLoaded{0},
+        workers{} {}
+};
+
+template<typename Inspector>
+auto inspect(Inspector& f, ConductorStatus& x) {
+  return f.object(x).fields(
+      f.field(static_strings::timeStamp, x.timeStamp)
+          .transformWith(inspection::TimeStampTransformer{}),
+      f.field(static_strings::verticesLoaded, x.verticesLoaded),
+      f.field(static_strings::edgesLoaded, x.edgesLoaded),
+      f.field(static_strings::workerStatus, x.workers));
+}
+
+}  // namespace arangodb::pregel

--- a/arangod/Pregel/Structs/GraphStoreStats.h
+++ b/arangod/Pregel/Structs/GraphStoreStats.h
@@ -1,0 +1,98 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2022 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Markus Pfeiffer
+////////////////////////////////////////////////////////////////////////////////
+#pragma once
+
+#include <chrono>
+#include <cstdint>
+#include <string>
+#include <atomic>
+
+#include <Inspection/VPack.h>
+#include <Inspection/Transformers.h>
+
+#include <Pregel/Common.h>
+
+#include "StaticStrings.h"
+
+namespace arangodb::pregel {
+
+struct GraphStoreStats {
+  std::size_t numberVerticesLoaded{0};
+  std::size_t vertexStorageBytes{0};
+  std::size_t vertexStorageBytesUsed{0};
+  std::size_t vertexKeyStorageBytes{0};
+  std::size_t vertexKeyStorageBytesUsed{0};
+
+  std::size_t numberEdgesLoaded{0};
+  std::size_t edgeStorageBytes{0};
+  std::size_t edgeStorageBytesUsed{0};
+  std::size_t edgeKeyStorageBytes{0};
+  std::size_t edgeKeyStorageBytesUsed{0};
+};
+
+struct AtomicGraphStoreStats {
+  std::atomic<std::size_t> numberVerticesLoaded{0};
+  std::atomic<std::size_t> vertexStorageBytes{0};
+  std::atomic<std::size_t> vertexStorageBytesUsed{0};
+  std::atomic<std::size_t> vertexKeyStorageBytes{0};
+  std::atomic<std::size_t> vertexKeyStorageBytesUsed{0};
+
+  std::atomic<std::size_t> numberEdgesLoaded{0};
+  std::atomic<std::size_t> edgeStorageBytes{0};
+  std::atomic<std::size_t> edgeStorageBytesUsed{0};
+  std::atomic<std::size_t> edgeKeyStorageBytes{0};
+  std::atomic<std::size_t> edgeKeyStorageBytesUsed{0};
+
+  auto snapshot() -> GraphStoreStats {
+    return GraphStoreStats{
+        .numberVerticesLoaded = numberVerticesLoaded.load(),
+        .vertexStorageBytes = vertexStorageBytes.load(),
+        .vertexStorageBytesUsed = vertexStorageBytesUsed.load(),
+        .vertexKeyStorageBytes = vertexKeyStorageBytes.load(),
+        .vertexKeyStorageBytesUsed = vertexKeyStorageBytesUsed.load(),
+        .numberEdgesLoaded = numberEdgesLoaded.load(),
+        .edgeStorageBytes = edgeStorageBytes.load(),
+        .edgeStorageBytesUsed = edgeStorageBytesUsed.load(),
+        .edgeKeyStorageBytes = edgeKeyStorageBytes.load(),
+        .edgeKeyStorageBytesUsed = edgeKeyStorageBytesUsed.load()};
+  }
+};
+
+template<typename Inspector>
+auto inspect(Inspector& f, GraphStoreStats& x) {
+  return f.object(x).fields(
+      f.field(static_strings::numberVerticesLoaded, x.numberVerticesLoaded),
+      f.field(static_strings::vertexStorageBytes, x.vertexStorageBytes),
+      f.field(static_strings::vertexStorageBytesUsed, x.vertexStorageBytesUsed),
+      f.field(static_strings::vertexKeyStorageBytes, x.vertexKeyStorageBytes),
+      f.field(static_strings::vertexKeyStorageBytesUsed,
+              x.vertexKeyStorageBytesUsed),
+      f.field(static_strings::numberEdgesLoaded, x.numberEdgesLoaded),
+      f.field(static_strings::edgeStorageBytes, x.edgeStorageBytes),
+      f.field(static_strings::edgeStorageBytesUsed, x.edgeStorageBytesUsed),
+      f.field(static_strings::edgeKeyStorageBytes, x.edgeKeyStorageBytes),
+      f.field(static_strings::edgeKeyStorageBytesUsed,
+              x.edgeKeyStorageBytesUsed));
+}
+
+}  // namespace arangodb::pregel

--- a/arangod/Pregel/Structs/StaticStrings.h
+++ b/arangod/Pregel/Structs/StaticStrings.h
@@ -33,8 +33,25 @@
 namespace arangodb::pregel::static_strings {
 
 constexpr auto timeStamp = std::string_view{"timeStamp"};
-constexpr auto verticesLoaded = std::string_view{"verticesLoaded"};
-constexpr auto edgesLoaded = std::string_view{"edgesLoaded"};
+constexpr auto numberVerticesLoaded = std::string_view{"numberVerticesLoaded"};
+constexpr auto vertexStorageBytes = std::string_view{"vertexStorageBytes"};
+constexpr auto vertexStorageBytesUsed =
+    std::string_view{"vertexStorageBytesUsed"};
+constexpr auto vertexKeyStorageBytes =
+    std::string_view{"vertexKeyStorageBytes"};
+constexpr auto vertexKeyStorageBytesUsed =
+    std::string_view{"vertexKeyStorageBytesUsed"};
+constexpr auto numberEdgesLoaded = std::string_view{"numberEdgesLoaded"};
+constexpr auto edgeStorageBytes = std::string_view{"edgeStorageBytes"};
+constexpr auto edgeStorageBytesUsed = std::string_view{"edgeStorageBytesUsed"};
+constexpr auto edgeKeyStorageBytes = std::string_view{"edgeKeyStorageBytes"};
+constexpr auto edgeKeyStorageBytesUsed =
+    std::string_view{"edgeKeyStorageBytesUsed"};
 constexpr auto workerStatus = std::string_view{"workerStatus"};
+constexpr auto timing = std::string_view{"timing"};
+constexpr auto loading = std::string_view{"loading"};
+constexpr auto running = std::string_view{"running"};
+constexpr auto storing = std::string_view{"storing"};
+constexpr auto graphStoreStats = std::string_view{"graphStoreStats"};
 
 }  // namespace arangodb::pregel::static_strings

--- a/arangod/Pregel/Structs/StaticStrings.h
+++ b/arangod/Pregel/Structs/StaticStrings.h
@@ -1,0 +1,40 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2022 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Markus Pfeiffer
+////////////////////////////////////////////////////////////////////////////////
+#pragma once
+
+#include <chrono>
+#include <cstdint>
+#include <string>
+
+#include <Inspection/VPack.h>
+
+#include <Cluster/ClusterTypes.h>
+
+namespace arangodb::pregel::static_strings {
+
+constexpr auto timeStamp = std::string_view{"timeStamp"};
+constexpr auto verticesLoaded = std::string_view{"verticesLoaded"};
+constexpr auto edgesLoaded = std::string_view{"edgesLoaded"};
+constexpr auto workerStatus = std::string_view{"workerStatus"};
+
+}  // namespace arangodb::pregel::static_strings

--- a/arangod/Pregel/Structs/WorkerStatus.h
+++ b/arangod/Pregel/Structs/WorkerStatus.h
@@ -30,6 +30,7 @@
 #include <Inspection/Transformers.h>
 
 #include <Pregel/Common.h>
+#include <Pregel/Structs/GraphStoreStats.h>
 
 #include "StaticStrings.h"
 
@@ -38,13 +39,10 @@ using TimeStamp = std::chrono::system_clock::time_point;
 namespace arangodb::pregel {
 struct WorkerStatus {
   TimeStamp timeStamp;
-  std::size_t verticesLoaded;
-  std::size_t edgesLoaded;
 
-  WorkerStatus()
-      : timeStamp{std::chrono::system_clock::now()},
-        verticesLoaded{0},
-        edgesLoaded{0} {}
+  GraphStoreStats graphStoreStats;
+
+  WorkerStatus() : timeStamp{std::chrono::system_clock::now()} {}
 };
 
 template<typename Inspector>
@@ -52,8 +50,7 @@ auto inspect(Inspector& f, WorkerStatus& x) {
   return f.object(x).fields(
       f.field(static_strings::timeStamp, x.timeStamp)
           .transformWith(inspection::TimeStampTransformer{}),
-      f.field(static_strings::verticesLoaded, x.verticesLoaded),
-      f.field(static_strings::edgesLoaded, x.edgesLoaded));
+      f.field(static_strings::graphStoreStats, x.graphStoreStats));
 }
 
 }  // namespace arangodb::pregel

--- a/arangod/Pregel/Structs/WorkerStatus.h
+++ b/arangod/Pregel/Structs/WorkerStatus.h
@@ -1,0 +1,59 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2022 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Markus Pfeiffer
+////////////////////////////////////////////////////////////////////////////////
+#pragma once
+
+#include <chrono>
+#include <cstdint>
+#include <string>
+
+#include <Inspection/VPack.h>
+#include <Inspection/Transformers.h>
+
+#include <Pregel/Common.h>
+
+#include "StaticStrings.h"
+
+using TimeStamp = std::chrono::system_clock::time_point;
+
+namespace arangodb::pregel {
+struct WorkerStatus {
+  TimeStamp timeStamp;
+  std::size_t verticesLoaded;
+  std::size_t edgesLoaded;
+
+  WorkerStatus()
+      : timeStamp{std::chrono::system_clock::now()},
+        verticesLoaded{0},
+        edgesLoaded{0} {}
+};
+
+template<typename Inspector>
+auto inspect(Inspector& f, WorkerStatus& x) {
+  return f.object(x).fields(
+      f.field(static_strings::timeStamp, x.timeStamp)
+          .transformWith(inspection::TimeStampTransformer{}),
+      f.field(static_strings::verticesLoaded, x.verticesLoaded),
+      f.field(static_strings::edgesLoaded, x.edgesLoaded));
+}
+
+}  // namespace arangodb::pregel

--- a/arangod/Pregel/TypedBuffer.h
+++ b/arangod/Pregel/TypedBuffer.h
@@ -81,6 +81,7 @@ struct TypedBuffer {
     TRI_ASSERT(_end >= _begin);
     return static_cast<size_t>(_end - _begin);
   }
+  size_t memoryUseInBytes() const noexcept { return capacity() * sizeof(T); }
   /// get number of actually mapped bytes
   size_t capacity() const noexcept {
     TRI_ASSERT(_capacity >= _begin);

--- a/arangod/Pregel/Utils.cpp
+++ b/arangod/Pregel/Utils.cpp
@@ -38,6 +38,7 @@ std::string const Utils::workerPrefix = "worker";
 
 std::string const Utils::startExecutionPath = "startExecution";
 std::string const Utils::finishedStartupPath = "finishedStartup";
+std::string const Utils::statusUpdatePath = "statusUpdate";
 std::string const Utils::prepareGSSPath = "prepareGSS";
 std::string const Utils::startGSSPath = "startGSS";
 std::string const Utils::finishedWorkerStepPath = "finishedStep";
@@ -75,6 +76,7 @@ std::string const Utils::edgeCountKey = "edgeCount";
 std::string const Utils::shardIdKey = "shrdId";
 std::string const Utils::messagesKey = "msgs";
 std::string const Utils::senderKey = "sender";
+std::string const Utils::payloadKey = "payload";
 std::string const Utils::recoveryMethodKey = "rmethod";
 std::string const Utils::storeResultsKey = "storeResults";
 std::string const Utils::aggregatorValuesKey = "aggregators";

--- a/arangod/Pregel/Utils.h
+++ b/arangod/Pregel/Utils.h
@@ -46,6 +46,7 @@ class Utils {
 
   static std::string const edgeShardingKey;
   static std::string const startExecutionPath;
+  static std::string const statusUpdatePath;
   static std::string const finishedStartupPath;
   static std::string const prepareGSSPath;
   static std::string const startGSSPath;
@@ -93,6 +94,7 @@ class Utils {
 
   /// sender cluster id
   static std::string const senderKey;
+  static std::string const payloadKey;
 
   /// Recovery method name
   static std::string const recoveryMethodKey;

--- a/arangod/Pregel/Worker.cpp
+++ b/arangod/Pregel/Worker.cpp
@@ -160,8 +160,7 @@ void Worker<V, E, M>::setupWorker() {
   std::function<void()> statusUpdateCallback = [self = shared_from_this(),
                                                 this] {
     auto update = WorkerStatus();
-    update.verticesLoaded = _graphStore->verticesLoadedCount();
-    update.edgesLoaded = _graphStore->edgesLoadedCount();
+    update.graphStoreStats = _graphStore->getStats();
     VPackBuilder statusUpdateMsg;
     {
       auto ob = VPackObjectBuilder(&statusUpdateMsg);

--- a/arangod/Pregel/Worker.cpp
+++ b/arangod/Pregel/Worker.cpp
@@ -31,10 +31,15 @@
 #include "Pregel/PregelFeature.h"
 #include "Pregel/VertexComputation.h"
 
+#include "Pregel/Structs/WorkerStatus.h"
+
 #include "ApplicationFeatures/ApplicationServer.h"
 #include "Basics/WriteLocker.h"
 #include "Network/Methods.h"
 #include "Scheduler/SchedulerFeature.h"
+
+#include "Inspection/VPack.h"
+#include "velocypack/Builder.h"
 
 using namespace arangodb;
 using namespace arangodb::basics;
@@ -139,7 +144,7 @@ void Worker<V, E, M>::_initializeMessageCaches() {
 // @brief load the initial worker data, call conductor eventually
 template<typename V, typename E, typename M>
 void Worker<V, E, M>::setupWorker() {
-  std::function<void()> cb = [self = shared_from_this(), this] {
+  std::function<void()> finishedCallback = [self = shared_from_this(), this] {
     VPackBuilder package;
     package.openObject();
     package.add(Utils::senderKey, VPackValue(ServerState::instance()->getId()));
@@ -152,23 +157,46 @@ void Worker<V, E, M>::setupWorker() {
     _callConductor(Utils::finishedStartupPath, package);
   };
 
+  std::function<void()> statusUpdateCallback = [self = shared_from_this(),
+                                                this] {
+    auto update = WorkerStatus();
+    update.verticesLoaded = _graphStore->verticesLoadedCount();
+    update.edgesLoaded = _graphStore->edgesLoadedCount();
+    VPackBuilder statusUpdateMsg;
+    {
+      auto ob = VPackObjectBuilder(&statusUpdateMsg);
+      statusUpdateMsg.add(Utils::senderKey,
+                          VPackValue(ServerState::instance()->getId()));
+      statusUpdateMsg.add(Utils::executionNumberKey,
+                          VPackValue(_config.executionNumber()));
+      statusUpdateMsg.add(VPackValue(Utils::payloadKey));
+      serialize(statusUpdateMsg, update);
+    }
+
+    _callConductor(Utils::statusUpdatePath, statusUpdateMsg);
+  };
+
   // initialization of the graphstore might take an undefined amount
   // of time. Therefore this is performed asynchronously
   TRI_ASSERT(SchedulerFeature::SCHEDULER != nullptr);
   Scheduler* scheduler = SchedulerFeature::SCHEDULER;
-  scheduler->queue(RequestLane::INTERNAL_LOW, [this, self = shared_from_this(),
-                                               cb = std::move(cb)] {
-    try {
-      _graphStore->loadShards(&_config, cb);
-    } catch (std::exception const& ex) {
-      LOG_PREGEL("a47c4", WARN)
-          << "caught exception in loadShards: " << ex.what();
-      throw;
-    } catch (...) {
-      LOG_PREGEL("e932d", WARN) << "caught unknown exception in loadShards";
-      throw;
-    }
-  });
+  scheduler->queue(RequestLane::INTERNAL_LOW,
+                   [this, self = shared_from_this(),
+                    statusUpdateCallback = std::move(statusUpdateCallback),
+                    finishedCallback = std::move(finishedCallback)] {
+                     try {
+                       _graphStore->loadShards(&_config, statusUpdateCallback,
+                                               finishedCallback);
+                     } catch (std::exception const& ex) {
+                       LOG_PREGEL("a47c4", WARN)
+                           << "caught exception in loadShards: " << ex.what();
+                       throw;
+                     } catch (...) {
+                       LOG_PREGEL("e932d", WARN)
+                           << "caught unknown exception in loadShards";
+                       throw;
+                     }
+                   });
 }
 
 template<typename V, typename E, typename M>
@@ -253,7 +281,7 @@ void Worker<V, E, M>::receivedMessages(VPackSlice const& data) {
   uint64_t gss = gssSlice.getUInt();
   if (gss == _config._globalSuperstep) {
     {  // make sure the pointer is not changed while
-       // parsing messages
+      // parsing messages
       MY_READ_LOCKER(guard, _cacheRWLock);
       // handles locking for us
       _writeCache->parseMessages(data);
@@ -694,10 +722,12 @@ void Worker<V, E, M>::startRecovery(VPackSlice const& data) {
   _preRecoveryTotal = _graphStore->localVertexCount();
   WorkerConfig nextState(_config);
   nextState.updateConfig(data);
-  _graphStore->loadShards(&nextState, [this, nextState, copy] {
-    _config = nextState;
-    compensateStep(copy.slice());
-  });
+  _graphStore->loadShards(
+      &nextState, []() {},
+      [this, nextState, copy] {
+        _config = nextState;
+        compensateStep(copy.slice());
+      });
 }
 
 template<typename V, typename E, typename M>


### PR DESCRIPTION
### Scope & Purpose

This adds some code that enables reporting worker status back to the conductor for Pregel runs; this improves observability. 

Example use and output:
```
localhost:8530@_system> pregel.start("wcc", "cit-Patents", { useMemoryMaps: false, parallelism: 8 });
2199023265898

localhost:8530@_system> pregel.status()
[ 
  { 
    "id" : "2199023265898", 
    "database" : "_system", 
    "algorithm" : "WCC", 
    "created" : "2022-05-26T10:58:44Z", 
    "ttl" : 600, 
    "state" : "running", 
    "gss" : 0, 
    "totalRuntime" : 0, 
    "startupTime" : 0, 
    "computationTime" : 0, 
    "aggregators" : { 
    }, 
    "sendCount" : 0, 
    "receivedCount" : 0, 
    "reports" : [ ], 
    "parallelism" : 8, 
    "status" : { 
      "timeStamp" : "2022-05-26T10:58:46Z", 
      "verticesLoaded" : 90000, 
      "edgesLoaded" : 0, 
      "workerStatus" : { 
        "PRMR-ef92a2d5-fd48-44a1-9dfb-3186b9b0d243" : { 
          "timeStamp" : "2022-05-26T10:58:46Z", 
          "verticesLoaded" : 40000, 
          "edgesLoaded" : 0 
        }, 
        "PRMR-4bdc7e93-122e-4713-9b09-7f1dd66e2fce" : { 
          "timeStamp" : "2022-05-26T10:58:46Z", 
          "verticesLoaded" : 30000, 
          "edgesLoaded" : 0 
        }, 
        "PRMR-2d6f910c-abd3-4b2d-a6f5-9698f7973868" : { 
          "timeStamp" : "2022-05-26T10:58:46Z", 
          "verticesLoaded" : 20000, 
          "edgesLoaded" : 0 
        } 
      } 
    } 
  } 
]
``` 

I will expand these status reports in further pull-requests.

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
