### PR TITLE
[CINFRA-381] Move Log config from Term to ParticipantsConfig

### DIFF
--- a/arangod/Cluster/Maintenance.cpp
+++ b/arangod/Cluster/Maintenance.cpp
@@ -1503,7 +1503,7 @@ static auto reportCurrentReplicatedLogLeader(
   });
 
   if (requiresUpdate) {
-    std::optional<arangodb::replication2::ParticipantsConfig>
+    std::optional<arangodb::replication2::agency::ParticipantsConfig>
         committedParticipantsConfig;
     if (status.committedParticipantsConfig != nullptr) {
       committedParticipantsConfig = *status.committedParticipantsConfig;

--- a/arangod/Replication2/ReplicatedLog/AgencyLogSpecification.cpp
+++ b/arangod/Replication2/ReplicatedLog/AgencyLogSpecification.cpp
@@ -50,9 +50,8 @@ LogPlanConfig::LogPlanConfig(std::size_t writeConcern,
     : effectiveWriteConcern(writeConcern), waitForSync(waitForSync) {}
 
 LogPlanTermSpecification::LogPlanTermSpecification(LogTerm term,
-                                                   LogPlanConfig config,
                                                    std::optional<Leader> leader)
-    : term(term), config(config), leader(std::move(leader)) {}
+    : term(term), leader(std::move(leader)) {}
 
 LogPlanSpecification::LogPlanSpecification(
     LogId id, std::optional<LogPlanTermSpecification> term)

--- a/arangod/Replication2/ReplicatedLog/AgencyLogSpecification.h
+++ b/arangod/Replication2/ReplicatedLog/AgencyLogSpecification.h
@@ -60,9 +60,25 @@ auto inspect(Inspector& f, LogPlanConfig& x) {
       f.field("waitForSync", x.waitForSync));
 }
 
+struct ParticipantsConfig {
+  std::size_t generation = 0;
+  ParticipantsFlagsMap participants;
+  LogPlanConfig config;
+
+  // to be defaulted soon
+  friend auto operator==(ParticipantsConfig const& left,
+                         ParticipantsConfig const& right) noexcept
+      -> bool = default;
+};
+
+template<class Inspector>
+auto inspect(Inspector& f, ParticipantsConfig& x) {
+  return f.object(x).fields(f.field("generation", x.generation),
+                            f.field("participants", x.participants));
+}
+
 struct LogPlanTermSpecification {
   LogTerm term;
-  LogPlanConfig config;
   struct Leader {
     ParticipantId serverId;
     RebootId rebootId;
@@ -77,8 +93,7 @@ struct LogPlanTermSpecification {
 
   LogPlanTermSpecification() = default;
 
-  LogPlanTermSpecification(LogTerm term, LogPlanConfig config,
-                           std::optional<Leader>);
+  LogPlanTermSpecification(LogTerm term, std::optional<Leader>);
 
   friend auto operator==(LogPlanTermSpecification const&,
                          LogPlanTermSpecification const&) noexcept

--- a/arangod/Replication2/ReplicatedLog/AgencyLogSpecification.h
+++ b/arangod/Replication2/ReplicatedLog/AgencyLogSpecification.h
@@ -74,6 +74,7 @@ struct ParticipantsConfig {
 template<class Inspector>
 auto inspect(Inspector& f, ParticipantsConfig& x) {
   return f.object(x).fields(f.field("generation", x.generation),
+                            f.field("config", x.config),
                             f.field("participants", x.participants));
 }
 

--- a/arangod/Replication2/ReplicatedLog/AgencySpecificationInspectors.h
+++ b/arangod/Replication2/ReplicatedLog/AgencySpecificationInspectors.h
@@ -69,7 +69,6 @@ auto inspect(Inspector& f, LogPlanTermSpecification::Leader& x) {
 template<class Inspector>
 auto inspect(Inspector& f, LogPlanTermSpecification& x) {
   return f.object(x).fields(f.field(StaticStrings::Term, x.term),
-                            f.field(StaticStrings::Config, x.config),
                             f.field(StaticStrings::Leader, x.leader));
 }
 

--- a/arangod/Replication2/ReplicatedLog/Algorithms.cpp
+++ b/arangod/Replication2/ReplicatedLog/Algorithms.cpp
@@ -150,7 +150,7 @@ auto algorithms::updateReplicatedLog(
 
       TRI_ASSERT(spec->participantsConfig.generation > 0);
       auto newLeader = log->becomeLeader(
-          spec->currentTerm->config, myServerId, spec->currentTerm->term,
+          spec->participantsConfig.config, myServerId, spec->currentTerm->term,
           followers,
           std::make_shared<ParticipantsConfig>(spec->participantsConfig),
           std::move(failureOracle));

--- a/arangod/Replication2/ReplicatedLog/LogCommon.h
+++ b/arangod/Replication2/ReplicatedLog/LogCommon.h
@@ -254,25 +254,6 @@ auto inspect(Inspector& f, ParticipantFlags& x) {
 
 auto operator<<(std::ostream&, ParticipantFlags const&) -> std::ostream&;
 
-using ParticipantsFlagsMap =
-    std::unordered_map<ParticipantId, ParticipantFlags>;
-
-struct ParticipantsConfig {
-  std::size_t generation = 0;
-  ParticipantsFlagsMap participants;
-
-  // to be defaulted soon
-  friend auto operator==(ParticipantsConfig const& left,
-                         ParticipantsConfig const& right) noexcept
-      -> bool = default;
-};
-
-template<class Inspector>
-auto inspect(Inspector& f, ParticipantsConfig& x) {
-  return f.object(x).fields(f.field("generation", x.generation),
-                            f.field("participants", x.participants));
-}
-
 // These settings are initialised by the ReplicatedLogFeature based on command
 // line arguments
 struct ReplicatedLogGlobalSettings {

--- a/arangod/Replication2/ReplicatedLog/LogEntries.cpp
+++ b/arangod/Replication2/ReplicatedLog/LogEntries.cpp
@@ -247,7 +247,7 @@ auto LogMetaPayload::UpdateParticipantsConfig::fromVelocyPack(
     velocypack::Slice s) -> UpdateParticipantsConfig {
   TRI_ASSERT(s.get(StaticStrings::IndexType)
                  .isEqualString(StringUpdateParticipantsConfig));
-  auto participants = velocypack::deserialize<ParticipantsConfig>(
+  auto participants = velocypack::deserialize<agency::ParticipantsConfig>(
       s.get(StaticStrings::Participants));
   return UpdateParticipantsConfig{std::move(participants)};
 }
@@ -257,20 +257,20 @@ auto LogMetaPayload::FirstEntryOfTerm::fromVelocyPack(velocypack::Slice s)
   TRI_ASSERT(
       s.get(StaticStrings::IndexType).isEqualString(StringFirstIndexOfTerm));
   auto leader = s.get(StaticStrings::Leader).copyString();
-  auto participants = velocypack::deserialize<ParticipantsConfig>(
+  auto participants = velocypack::deserialize<agency::ParticipantsConfig>(
       s.get(StaticStrings::Participants));
   return FirstEntryOfTerm{std::move(leader), std::move(participants)};
 }
 
 auto LogMetaPayload::withFirstEntryOfTerm(ParticipantId leader,
-                                          ParticipantsConfig config)
+                                          agency::ParticipantsConfig config)
     -> LogMetaPayload {
   return LogMetaPayload{FirstEntryOfTerm{.leader = std::move(leader),
                                          .participants = std::move(config)}};
 }
 
-auto LogMetaPayload::withUpdateParticipantsConfig(ParticipantsConfig config)
-    -> LogMetaPayload {
+auto LogMetaPayload::withUpdateParticipantsConfig(
+    agency::ParticipantsConfig config) -> LogMetaPayload {
   return LogMetaPayload{
       UpdateParticipantsConfig{.participants = std::move(config)}};
 }

--- a/arangod/Replication2/ReplicatedLog/LogEntries.h
+++ b/arangod/Replication2/ReplicatedLog/LogEntries.h
@@ -27,7 +27,10 @@
 #include <velocypack/Buffer.h>
 #include <velocypack/Slice.h>
 
+#include "Replication2/ReplicatedLog/AgencyLogSpecification.h"
 #include "Replication2/ReplicatedLog/LogCommon.h"
+
+using namespace arangodb::replication2::agency;
 
 namespace arangodb::replication2 {
 

--- a/arangod/Replication2/ReplicatedLog/LogEntries.h
+++ b/arangod/Replication2/ReplicatedLog/LogEntries.h
@@ -30,8 +30,6 @@
 #include "Replication2/ReplicatedLog/AgencyLogSpecification.h"
 #include "Replication2/ReplicatedLog/LogCommon.h"
 
-using namespace arangodb::replication2::agency;
-
 namespace arangodb::replication2 {
 
 struct LogPayload {
@@ -60,7 +58,7 @@ auto operator==(LogPayload const&, LogPayload const&) -> bool;
 struct LogMetaPayload {
   struct FirstEntryOfTerm {
     ParticipantId leader;
-    ParticipantsConfig participants;
+    agency::ParticipantsConfig participants;
 
     static auto fromVelocyPack(velocypack::Slice) -> FirstEntryOfTerm;
     void toVelocyPack(velocypack::Builder&) const;
@@ -70,10 +68,11 @@ struct LogMetaPayload {
   };
 
   static auto withFirstEntryOfTerm(ParticipantId leader,
-                                   ParticipantsConfig config) -> LogMetaPayload;
+                                   agency::ParticipantsConfig config)
+      -> LogMetaPayload;
 
   struct UpdateParticipantsConfig {
-    ParticipantsConfig participants;
+    agency::ParticipantsConfig participants;
 
     static auto fromVelocyPack(velocypack::Slice) -> UpdateParticipantsConfig;
     void toVelocyPack(velocypack::Builder&) const;
@@ -83,7 +82,7 @@ struct LogMetaPayload {
         -> bool = default;
   };
 
-  static auto withUpdateParticipantsConfig(ParticipantsConfig config)
+  static auto withUpdateParticipantsConfig(agency::ParticipantsConfig config)
       -> LogMetaPayload;
 
   static auto fromVelocyPack(velocypack::Slice) -> LogMetaPayload;

--- a/arangod/Replication2/ReplicatedLog/LogLeader.cpp
+++ b/arangod/Replication2/ReplicatedLog/LogLeader.cpp
@@ -293,7 +293,7 @@ void replicated_log::LogLeader::executeAppendEntriesRequests(
 auto replicated_log::LogLeader::construct(
     agency::LogPlanConfig config, std::unique_ptr<LogCore> logCore,
     std::vector<std::shared_ptr<AbstractFollower>> const& followers,
-    std::shared_ptr<ParticipantsConfig const> participantsConfig,
+    std::shared_ptr<agency::ParticipantsConfig const> participantsConfig,
     ParticipantId id, LogTerm term, LoggerContext const& logContext,
     std::shared_ptr<ReplicatedLogMetrics> logMetrics,
     std::shared_ptr<ReplicatedLogGlobalSettings const> options,
@@ -1209,7 +1209,7 @@ auto replicated_log::LogLeader::isLeadershipEstablished() const noexcept
 }
 
 void replicated_log::LogLeader::establishLeadership(
-    std::shared_ptr<ParticipantsConfig const> config) {
+    std::shared_ptr<agency::ParticipantsConfig const> config) {
   LOG_CTX("f3aa8", TRACE, _logContext) << "trying to establish leadership";
   auto waitForIndex =
       _guardedLeaderData.doUnderLock([&](GuardedLeaderData& data) {
@@ -1286,7 +1286,7 @@ auto const keySetDifference = [](auto const& left, auto const& right) {
 }  // namespace
 
 auto replicated_log::LogLeader::updateParticipantsConfig(
-    std::shared_ptr<ParticipantsConfig const> const& config,
+    std::shared_ptr<agency::ParticipantsConfig const> const& config,
     std::function<std::shared_ptr<replicated_log::AbstractFollower>(
         ParticipantId const&)> const& buildFollower) -> LogIndex {
   LOG_CTX("ac277", TRACE, _logContext)

--- a/arangod/Replication2/ReplicatedLog/LogLeader.h
+++ b/arangod/Replication2/ReplicatedLog/LogLeader.h
@@ -95,7 +95,7 @@ class LogLeader : public std::enable_shared_from_this<LogLeader>,
   [[nodiscard]] static auto construct(
       agency::LogPlanConfig config, std::unique_ptr<LogCore> logCore,
       std::vector<std::shared_ptr<AbstractFollower>> const& followers,
-      std::shared_ptr<ParticipantsConfig const> participantsConfig,
+      std::shared_ptr<agency::ParticipantsConfig const> participantsConfig,
       ParticipantId id, LogTerm term, LoggerContext const& logContext,
       std::shared_ptr<ReplicatedLogMetrics> logMetrics,
       std::shared_ptr<ReplicatedLogGlobalSettings const> options,
@@ -160,7 +160,7 @@ class LogLeader : public std::enable_shared_from_this<LogLeader>,
 
   // Updates the flags of the participants.
   auto updateParticipantsConfig(
-      std::shared_ptr<ParticipantsConfig const> const& config,
+      std::shared_ptr<agency::ParticipantsConfig const> const& config,
       std::function<std::shared_ptr<replicated_log::AbstractFollower>(
           ParticipantId const&)> const& buildFollower) -> LogIndex;
 
@@ -327,10 +327,11 @@ class LogLeader : public std::enable_shared_from_this<LogLeader>,
     CommitFailReason _lastCommitFailReason;
 
     // active - that is currently used to check for committed entries
-    std::shared_ptr<ParticipantsConfig const> activeParticipantsConfig;
+    std::shared_ptr<agency::ParticipantsConfig const> activeParticipantsConfig;
     // committed - latest active config that has committed at least one entry
     // Note that this will be nullptr until leadership is established!
-    std::shared_ptr<ParticipantsConfig const> committedParticipantsConfig;
+    std::shared_ptr<agency::ParticipantsConfig const>
+        committedParticipantsConfig;
   };
 
   LoggerContext const _logContext;
@@ -347,7 +348,8 @@ class LogLeader : public std::enable_shared_from_this<LogLeader>,
   // a single mutex.
   Guarded<GuardedLeaderData> _guardedLeaderData;
 
-  void establishLeadership(std::shared_ptr<ParticipantsConfig const> config);
+  void establishLeadership(
+      std::shared_ptr<agency::ParticipantsConfig const> config);
 
   [[nodiscard]] static auto instantiateFollowers(
       LoggerContext const&,

--- a/arangod/Replication2/ReplicatedLog/LogStatus.h
+++ b/arangod/Replication2/ReplicatedLog/LogStatus.h
@@ -35,6 +35,8 @@
 #include "Replication2/ReplicatedLog/types.h"
 #include "Replication2/ReplicatedLog/AgencyLogSpecification.h"
 
+using namespace arangodb::replication2::agency;
+
 namespace arangodb::replication2::replicated_log {
 
 enum class ParticipantRole { kUnconfigured, kLeader, kFollower };

--- a/arangod/Replication2/ReplicatedLog/LogStatus.h
+++ b/arangod/Replication2/ReplicatedLog/LogStatus.h
@@ -35,8 +35,6 @@
 #include "Replication2/ReplicatedLog/types.h"
 #include "Replication2/ReplicatedLog/AgencyLogSpecification.h"
 
-using namespace arangodb::replication2::agency;
-
 namespace arangodb::replication2::replicated_log {
 
 enum class ParticipantRole { kUnconfigured, kLeader, kFollower };
@@ -53,10 +51,11 @@ struct QuickLogStatus {
   std::optional<CommitFailReason> commitFailReason{};
 
   // The following make sense only for a leader.
-  std::shared_ptr<ParticipantsConfig const> activeParticipantsConfig{};
+  std::shared_ptr<agency::ParticipantsConfig const> activeParticipantsConfig{};
   // Note that committedParticipantsConfig will be nullptr until leadership has
   // been established!
-  std::shared_ptr<ParticipantsConfig const> committedParticipantsConfig{};
+  std::shared_ptr<agency::ParticipantsConfig const>
+      committedParticipantsConfig{};
 
   [[nodiscard]] auto getCurrentTerm() const noexcept -> std::optional<LogTerm>;
   [[nodiscard]] auto getLocalStatistics() const noexcept
@@ -75,11 +74,13 @@ struct ParticipantRoleStringTransformer {
 
 template<typename Inspector>
 auto inspect(Inspector& f, QuickLogStatus& x) {
-  auto activeParticipantsConfig = std::shared_ptr<ParticipantsConfig>();
-  auto committedParticipantsConfig = std::shared_ptr<ParticipantsConfig>();
+  auto activeParticipantsConfig = std::shared_ptr<agency::ParticipantsConfig>();
+  auto committedParticipantsConfig =
+      std::shared_ptr<agency::ParticipantsConfig>();
   if constexpr (!Inspector::isLoading) {
-    activeParticipantsConfig = std::make_shared<ParticipantsConfig>();
-    committedParticipantsConfig = std::make_shared<ParticipantsConfig>();
+    activeParticipantsConfig = std::make_shared<agency::ParticipantsConfig>();
+    committedParticipantsConfig =
+        std::make_shared<agency::ParticipantsConfig>();
   }
   auto res = f.object(x).fields(
       f.field("role", x.role).transformWith(ParticipantRoleStringTransformer{}),
@@ -135,8 +136,8 @@ struct LeaderStatus {
   // now() - insertTP of last uncommitted entry
   std::chrono::duration<double, std::milli> commitLagMS;
   CommitFailReason lastCommitStatus;
-  ParticipantsConfig activeParticipantsConfig;
-  std::optional<ParticipantsConfig> committedParticipantsConfig;
+  agency::ParticipantsConfig activeParticipantsConfig;
+  std::optional<agency::ParticipantsConfig> committedParticipantsConfig;
 
   friend auto operator==(LeaderStatus const& left,
                          LeaderStatus const& right) noexcept -> bool = default;

--- a/arangod/Replication2/ReplicatedLog/ReplicatedLog.cpp
+++ b/arangod/Replication2/ReplicatedLog/ReplicatedLog.cpp
@@ -73,7 +73,7 @@ replicated_log::ReplicatedLog::~ReplicatedLog() {
 auto replicated_log::ReplicatedLog::becomeLeader(
     agency::LogPlanConfig config, ParticipantId id, LogTerm newTerm,
     std::vector<std::shared_ptr<AbstractFollower>> const& follower,
-    std::shared_ptr<ParticipantsConfig const> participantsConfig,
+    std::shared_ptr<agency::ParticipantsConfig const> participantsConfig,
     std::shared_ptr<cluster::IFailureOracle const> failureOracle)
     -> std::shared_ptr<LogLeader> {
   auto [leader, deferred] = std::invoke([&] {

--- a/arangod/Replication2/ReplicatedLog/ReplicatedLog.h
+++ b/arangod/Replication2/ReplicatedLog/ReplicatedLog.h
@@ -90,7 +90,7 @@ struct alignas(64) ReplicatedLog {
   auto becomeLeader(
       agency::LogPlanConfig config, ParticipantId id, LogTerm term,
       std::vector<std::shared_ptr<AbstractFollower>> const& follower,
-      std::shared_ptr<ParticipantsConfig const> participantsConfig,
+      std::shared_ptr<agency::ParticipantsConfig const> participantsConfig,
       std::shared_ptr<cluster::IFailureOracle const> failureOracle)
       -> std::shared_ptr<LogLeader>;
   auto becomeFollower(ParticipantId id, LogTerm term,

--- a/arangod/Replication2/ReplicatedLog/Supervision.cpp
+++ b/arangod/Replication2/ReplicatedLog/Supervision.cpp
@@ -213,18 +213,18 @@ auto checkLeaderPresent(SupervisionContext& ctx, Log const& log,
 
   // Check whether there are enough participants to reach a quorum
   if (plan.participantsConfig.participants.size() + 1 <=
-      plan.currentTerm->config.effectiveWriteConcern) {
+      plan.participantsConfig.config.effectiveWriteConcern) {
     ctx.reportStatus<LogCurrentSupervision::LeaderElectionImpossible>();
     ctx.createAction<NoActionPossibleAction>();
     return;
   }
 
   TRI_ASSERT(plan.participantsConfig.participants.size() + 1 >
-             plan.currentTerm->config.effectiveWriteConcern);
+             plan.participantsConfig.config.effectiveWriteConcern);
 
   auto const requiredNumberOfOKParticipants =
       plan.participantsConfig.participants.size() + 1 -
-      plan.currentTerm->config.effectiveWriteConcern;
+      plan.participantsConfig.config.effectiveWriteConcern;
 
   // Find the participants that are healthy and that have the best LogTerm
   auto election = runElectionCampaign(

--- a/arangod/Replication2/ReplicatedLog/SupervisionAction.h
+++ b/arangod/Replication2/ReplicatedLog/SupervisionAction.h
@@ -101,8 +101,9 @@ struct AddLogToPlanAction {
 
   auto execute(ActionContext& ctx) const -> void {
     auto newPlan = LogPlanSpecification(
-        _id, LogPlanTermSpecification(LogTerm{1}, _config, _leader),
-        ParticipantsConfig{.generation = 1, .participants = _participants});
+        _id, LogPlanTermSpecification(LogTerm{1}, _leader),
+        ParticipantsConfig{
+            .generation = 1, .participants = _participants, .config = _config});
     newPlan.owner = "target";
     ctx.setValue<LogPlanSpecification>(std::move(newPlan));
   }
@@ -325,8 +326,8 @@ using Action =
 auto executeAction(Log log, Action& action) -> ActionContext;
 }  // namespace arangodb::replication2::replicated_log
 
-#include "Replication2/ReplicatedLog/AgencySpecificationInspectors.h"
 #include "Inspection/VPack.h"
+#include "Replication2/ReplicatedLog/AgencySpecificationInspectors.h"
 
 template<>
 struct fmt::formatter<arangodb::replication2::replicated_log::Action>

--- a/arangod/Replication2/ReplicatedState/Supervision.cpp
+++ b/arangod/Replication2/ReplicatedState/Supervision.cpp
@@ -32,6 +32,7 @@
 #include "Logger/LogMacros.h"
 
 using namespace arangodb;
+using namespace arangodb::replication2::agency;
 
 /*
  * This is the flow graph of the replicated state supervision. Operations that

--- a/js/server/modules/@arangodb/testutils/replicated-logs-helper.js
+++ b/js/server/modules/@arangodb/testutils/replicated-logs-helper.js
@@ -77,15 +77,16 @@ const getParticipantsObjectForServers = function (servers) {
   }, {});
 };
 
-const createParticipantsConfig = function (generation, servers) {
+const createParticipantsConfig = function (generation, config, servers) {
   return {
     generation,
+    config,
     participants: getParticipantsObjectForServers(servers),
   };
 };
 
-const createTermSpecification = function (term, servers, config, leader) {
-  let spec = {term, config};
+const createTermSpecification = function (term, servers, leader) {
+  let spec = {term};
   if (leader !== undefined) {
     if (!_.includes(servers, leader)) {
       throw Error("leader is not part of the participants");
@@ -364,8 +365,8 @@ const createReplicatedLogPlanOnly = function (database, targetConfig, replicatio
   const generation = 1;
   replicatedLogSetPlan(database, logId, {
     id: logId,
-    currentTerm: createTermSpecification(term, servers, targetConfig, leader),
-    participantsConfig: createParticipantsConfig(generation, servers),
+    currentTerm: createTermSpecification(term, servers, leader),
+    participantsConfig: createParticipantsConfig(generation, targetConfig, servers),
   });
 
   // wait for all servers to have reported in current

--- a/tests/Replication2/Helper/AgencyLogBuilder.h
+++ b/tests/Replication2/Helper/AgencyLogBuilder.h
@@ -73,7 +73,7 @@ struct AgencyLogBuilder {
     if (!plan.currentTerm.has_value()) {
       plan.currentTerm.emplace();
       plan.currentTerm->term = LogTerm{1};
-      plan.currentTerm->config = RLA::LogPlanConfig(
+      plan.participantsConfig.config = RLA::LogPlanConfig(
           _log.target.config.writeConcern, _log.target.config.softWriteConcern,
           _log.target.config.waitForSync);
     }

--- a/tests/Replication2/Helper/ModelChecker/HashValues.h
+++ b/tests/Replication2/Helper/ModelChecker/HashValues.h
@@ -94,11 +94,17 @@ static inline std::size_t hash_value(ParticipantFlags const& s) {
 }
 }  // namespace arangodb::replication2
 namespace arangodb::replication2::agency {
+static inline std::size_t hash_value(LogPlanConfig const& s) {
+  std::size_t seed = 0;
+  boost::hash_combine(seed, s.effectiveWriteConcern);
+  boost::hash_combine(seed, s.waitForSync);
+  return seed;
+}
 static inline std::size_t hash_value(ParticipantsConfig const& s) {
   std::size_t seed = 0;
   boost::hash_combine(seed, s.generation);
   boost::hash_combine(seed, s.participants);
-  //  boost::hash_combine(seed, s.config);
+  boost::hash_combine(seed, s.config);
   return seed;
 }
 static inline std::size_t hash_value(LogTarget const& s) {

--- a/tests/Replication2/Helper/ModelChecker/HashValues.h
+++ b/tests/Replication2/Helper/ModelChecker/HashValues.h
@@ -21,6 +21,8 @@
 ////////////////////////////////////////////////////////////////////////////////
 #pragma once
 #include <boost/container_hash/hash.hpp>
+
+#include "Replication2/ReplicatedLog/AgencyLogSpecification.h"
 #include "Replication2/ReplicatedLog/LogCommon.h"
 #include "Replication2/ReplicatedState/AgencySpecification.h"
 #include "Replication2/ReplicatedLog/SupervisionAction.h"
@@ -90,15 +92,15 @@ static inline std::size_t hash_value(ParticipantFlags const& s) {
   boost::hash_combine(seed, s.forced);
   return seed;
 }
+}  // namespace arangodb::replication2
+namespace arangodb::replication2::agency {
 static inline std::size_t hash_value(ParticipantsConfig const& s) {
   std::size_t seed = 0;
   boost::hash_combine(seed, s.generation);
   boost::hash_combine(seed, s.participants);
+  //  boost::hash_combine(seed, s.config);
   return seed;
 }
-}  // namespace arangodb::replication2
-namespace arangodb::replication2::agency {
-
 static inline std::size_t hash_value(LogTarget const& s) {
   std::size_t seed = 0;
   boost::hash_combine(seed, s.id.id());

--- a/tests/Replication2/Mocks/FakeReplicatedLog.cpp
+++ b/tests/Replication2/Mocks/FakeReplicatedLog.cpp
@@ -51,11 +51,10 @@ auto TestReplicatedLog::becomeLeader(
   for (auto const& participant : follower) {
     participants.emplace(participant->getParticipantId(), ParticipantFlags{});
   }
-  auto participantsConfig =
-      std::make_shared<ParticipantsConfig>(ParticipantsConfig{
-          .generation = 1,
-          .participants = std::move(participants),
-      });
+  auto participantsConfig = std::make_shared<agency::ParticipantsConfig>(
+      agency::ParticipantsConfig{.generation = 1,
+                                 .participants = std::move(participants),
+                                 .config = config});
 
   if (!failureOracle) {
     failureOracle = std::make_shared<FakeFailureOracle>();

--- a/tests/Replication2/ReplicatedLog/CheckLogsTest.cpp
+++ b/tests/Replication2/ReplicatedLog/CheckLogsTest.cpp
@@ -54,7 +54,6 @@ struct CheckLogsAlgorithmTest : ::testing::Test {
       -> agency::LogPlanTermSpecification {
     auto termSpec = agency::LogPlanTermSpecification{};
     termSpec.term = term;
-    termSpec.config = config;
     return termSpec;
   }
 

--- a/tests/Replication2/ReplicatedLog/EstablishLeadershipTest.cpp
+++ b/tests/Replication2/ReplicatedLog/EstablishLeadershipTest.cpp
@@ -103,8 +103,10 @@ TEST_F(EstablishLeadershipTest, check_meta_create_leader_entry) {
     auto const& info = std::get<LogMetaPayload::FirstEntryOfTerm>(meta.info);
     EXPECT_EQ(info.leader, "leader");
 
-    auto const expectedConfiguration = ParticipantsConfig{
-        .generation = 1, .participants = {{"leader", {}}, {"follower", {}}}};
+    auto const expectedConfiguration = agency::ParticipantsConfig{
+        .generation = 1,
+        .participants = {{"leader", {}}, {"follower", {}}},
+        .config = agency::LogPlanConfig(2, false)};
 
     EXPECT_EQ(info.participants, expectedConfiguration);
   }
@@ -120,7 +122,7 @@ TEST_F(EstablishLeadershipTest, excluded_follower) {
   auto participants = std::unordered_map<ParticipantId, ParticipantFlags>{
       {"leader", {}}, {"follower", {.allowedInQuorum = false}}};
   auto participantsConfig =
-      std::make_shared<ParticipantsConfig>(ParticipantsConfig{
+      std::make_shared<agency::ParticipantsConfig>(agency::ParticipantsConfig{
           .generation = 1,
           .participants = std::move(participants),
       });
@@ -160,7 +162,7 @@ TEST_F(EstablishLeadershipTest, excluded_follower) {
   {
     auto oldConfig =
         leader->getStatus().asLeaderStatus()->activeParticipantsConfig;
-    auto newConfig = std::make_shared<ParticipantsConfig>(oldConfig);
+    auto newConfig = std::make_shared<agency::ParticipantsConfig>(oldConfig);
     newConfig->generation = 2;
     newConfig->participants["follower"] = replication2::ParticipantFlags{};
     leader->updateParticipantsConfig(newConfig, nullptr);

--- a/tests/Replication2/ReplicatedLog/MaintenanceTests.cpp
+++ b/tests/Replication2/ReplicatedLog/MaintenanceTests.cpp
@@ -51,17 +51,15 @@ TEST_F(ReplicationMaintenanceTest, create_replicated_log_we_are_participant) {
       {logId,
        agency::LogPlanTermSpecification{
            LogTerm{3},
-           defaultConfig,
            std::nullopt,
        },
-       ParticipantsConfig{
-           .generation = 0,
-           .participants =
-               {
-                   {ParticipantId{"A"}, {}},
-                   {ParticipantId{"leader"}, {}},
-               },
-       }},
+       ParticipantsConfig{.generation = 0,
+                          .participants =
+                              {
+                                  {ParticipantId{"A"}, {}},
+                                  {ParticipantId{"leader"}, {}},
+                              },
+                          .config = defaultConfig}},
   }};
 
   diffReplicatedLogs(database, localLogs, planLogs, "A", errors, dirtyset,
@@ -89,7 +87,6 @@ TEST_F(ReplicationMaintenanceTest,
           logId,
           agency::LogPlanTermSpecification{
               LogTerm{3},
-              defaultConfig,
               std::nullopt,
           },
           ParticipantsConfig{
@@ -99,6 +96,7 @@ TEST_F(ReplicationMaintenanceTest,
                       {ParticipantId{"B"}, {}},
                       {ParticipantId{"leader"}, {}},
                   },
+              .config = defaultConfig,
           },
       },
   }};
@@ -128,7 +126,6 @@ TEST_F(ReplicationMaintenanceTest,
           logId,
           agency::LogPlanTermSpecification{
               LogTerm{3},
-              defaultConfig,
               std::nullopt,
           },
           ParticipantsConfig{
@@ -138,6 +135,7 @@ TEST_F(ReplicationMaintenanceTest,
                       {ParticipantId{"B"}, {}},
                       {ParticipantId{"leader"}, {}},
                   },
+              .config = defaultConfig,
           },
       },
   }};
@@ -170,7 +168,6 @@ TEST_F(ReplicationMaintenanceTest, create_replicated_log_detect_unconfigured) {
           logId,
           agency::LogPlanTermSpecification{
               LogTerm{3},
-              defaultConfig,
               std::nullopt,
           },
           ParticipantsConfig{
@@ -180,6 +177,7 @@ TEST_F(ReplicationMaintenanceTest, create_replicated_log_detect_unconfigured) {
                       {ParticipantId{"A"}, {}},
                       {ParticipantId{"leader"}, {}},
                   },
+              .config = defaultConfig,
           },
       },
   }};
@@ -214,7 +212,6 @@ TEST_F(ReplicationMaintenanceTest, create_replicated_log_detect_wrong_term) {
           logId,
           agency::LogPlanTermSpecification{
               LogTerm{3},
-              defaultConfig,
               std::nullopt,
           },
           ParticipantsConfig{
@@ -224,6 +221,7 @@ TEST_F(ReplicationMaintenanceTest, create_replicated_log_detect_wrong_term) {
                       {ParticipantId{"A"}, {}},
                       {ParticipantId{"leader"}, {}},
                   },
+              .config = defaultConfig,
           },
       },
   }};
@@ -244,14 +242,17 @@ TEST_F(ReplicationMaintenanceTest,
        create_replicated_log_detect_wrong_generation) {
   auto const logId = LogId{12};
   auto const database = DatabaseID{"mydb"};
+  auto const defaultConfig = agency::LogPlanConfig{};
 
   // Expect updates in case we are leader
   auto participantsConfig =
-      ParticipantsConfig{1,
-                         {
-                             {ParticipantId{"A"}, {}},
-                             {ParticipantId{"leader"}, {}},
-                         }};
+      ParticipantsConfig{.generation = 1,
+                         .participants =
+                             {
+                                 {ParticipantId{"A"}, {}},
+                                 {ParticipantId{"leader"}, {}},
+                             },
+                         .config = defaultConfig};
   auto leaderStatus = replicated_log::QuickLogStatus{
       .role = replicated_log::ParticipantRole::kLeader,
       .term = LogTerm{3},
@@ -265,7 +266,6 @@ TEST_F(ReplicationMaintenanceTest,
   auto localLogs = ReplicatedLogStatusMap{
       {logId, replicated_log::QuickLogStatus{std::move(leaderStatus)}},
   };
-  auto const defaultConfig = agency::LogPlanConfig{};
 
   // Modify generation to trigger an update
   participantsConfig.generation = 2;
@@ -274,7 +274,6 @@ TEST_F(ReplicationMaintenanceTest,
       {logId,
        agency::LogPlanTermSpecification{
            LogTerm{3},
-           defaultConfig,
            std::nullopt,
        },
        participantsConfig},

--- a/tests/Replication2/ReplicatedLog/MaintenanceTests.cpp
+++ b/tests/Replication2/ReplicatedLog/MaintenanceTests.cpp
@@ -53,13 +53,13 @@ TEST_F(ReplicationMaintenanceTest, create_replicated_log_we_are_participant) {
            LogTerm{3},
            std::nullopt,
        },
-       ParticipantsConfig{.generation = 0,
-                          .participants =
-                              {
-                                  {ParticipantId{"A"}, {}},
-                                  {ParticipantId{"leader"}, {}},
-                              },
-                          .config = defaultConfig}},
+       agency::ParticipantsConfig{.generation = 0,
+                                  .participants =
+                                      {
+                                          {ParticipantId{"A"}, {}},
+                                          {ParticipantId{"leader"}, {}},
+                                      },
+                                  .config = defaultConfig}},
   }};
 
   diffReplicatedLogs(database, localLogs, planLogs, "A", errors, dirtyset,
@@ -89,7 +89,7 @@ TEST_F(ReplicationMaintenanceTest,
               LogTerm{3},
               std::nullopt,
           },
-          ParticipantsConfig{
+          agency::ParticipantsConfig{
               .generation = 0,
               .participants =
                   {
@@ -128,7 +128,7 @@ TEST_F(ReplicationMaintenanceTest,
               LogTerm{3},
               std::nullopt,
           },
-          ParticipantsConfig{
+          agency::ParticipantsConfig{
               .generation = 0,
               .participants =
                   {
@@ -170,7 +170,7 @@ TEST_F(ReplicationMaintenanceTest, create_replicated_log_detect_unconfigured) {
               LogTerm{3},
               std::nullopt,
           },
-          ParticipantsConfig{
+          agency::ParticipantsConfig{
               .generation = 0,
               .participants =
                   {
@@ -214,7 +214,7 @@ TEST_F(ReplicationMaintenanceTest, create_replicated_log_detect_wrong_term) {
               LogTerm{3},
               std::nullopt,
           },
-          ParticipantsConfig{
+          agency::ParticipantsConfig{
               .generation = 0,
               .participants =
                   {
@@ -246,22 +246,24 @@ TEST_F(ReplicationMaintenanceTest,
 
   // Expect updates in case we are leader
   auto participantsConfig =
-      ParticipantsConfig{.generation = 1,
-                         .participants =
-                             {
-                                 {ParticipantId{"A"}, {}},
-                                 {ParticipantId{"leader"}, {}},
-                             },
-                         .config = defaultConfig};
+      agency::ParticipantsConfig{.generation = 1,
+                                 .participants =
+                                     {
+                                         {ParticipantId{"A"}, {}},
+                                         {ParticipantId{"leader"}, {}},
+                                     },
+                                 .config = defaultConfig};
   auto leaderStatus = replicated_log::QuickLogStatus{
       .role = replicated_log::ParticipantRole::kLeader,
       .term = LogTerm{3},
       .local = {},
       .leadershipEstablished = true,
       .activeParticipantsConfig =
-          std::make_shared<ParticipantsConfig const>(participantsConfig),
+          std::make_shared<agency::ParticipantsConfig const>(
+              participantsConfig),
       .committedParticipantsConfig =
-          std::make_shared<ParticipantsConfig const>(participantsConfig)};
+          std::make_shared<agency::ParticipantsConfig const>(
+              participantsConfig)};
 
   auto localLogs = ReplicatedLogStatusMap{
       {logId, replicated_log::QuickLogStatus{std::move(leaderStatus)}},

--- a/tests/Replication2/ReplicatedLog/RocksDBLogTest.cpp
+++ b/tests/Replication2/ReplicatedLog/RocksDBLogTest.cpp
@@ -292,9 +292,10 @@ TEST_F(RocksDBLogTest, insert_iterate_with_meta) {
                            LogMetaPayload::withFirstEntryOfTerm("Foobar", {})},
         PersistingLogEntry{
             TermIndexPair{LogTerm{1}, LogIndex{2}},
-            LogMetaPayload::withUpdateParticipantsConfig(ParticipantsConfig{
-                .generation = 1,
-                .participants = {{"FooBar", {.allowedInQuorum = false}}}})},
+            LogMetaPayload::withUpdateParticipantsConfig(
+                agency::ParticipantsConfig{
+                    .generation = 1,
+                    .participants = {{"FooBar", {.allowedInQuorum = false}}}})},
         PersistingLogEntry{LogTerm{2}, LogIndex{3},
                            LogPayload::createFromString("third")},
     };
@@ -326,7 +327,7 @@ TEST_F(RocksDBLogTest, insert_iterate_with_meta) {
     EXPECT_FALSE(entry->hasPayload());
     EXPECT_TRUE(entry->hasMeta());
     auto const expected =
-        LogMetaPayload::withUpdateParticipantsConfig(ParticipantsConfig{
+        LogMetaPayload::withUpdateParticipantsConfig(agency::ParticipantsConfig{
             .generation = 1,
             .participants = {{"FooBar", {.allowedInQuorum = false}}}});
     ASSERT_EQ(*entry->meta(), expected)

--- a/tests/Replication2/ReplicatedLog/SupervisionTest.cpp
+++ b/tests/Replication2/ReplicatedLog/SupervisionTest.cpp
@@ -288,13 +288,14 @@ TEST_F(LogSupervisionTest, test_remove_participant_action) {
                                          {"C", ParticipantFlags{}},
                                          {"D", ParticipantFlags{}}};
   auto const& participantsConfig =
-      ParticipantsConfig{.generation = 1, .participants = participantsFlags};
+      ParticipantsConfig{.generation = 1,
+                         .participants = participantsFlags,
+                         .config = LogPlanConfig(3, 3, true)};
 
   auto const& plan = LogPlanSpecification(
       logId,
       LogPlanTermSpecification(
-          LogTerm{1}, LogPlanConfig(3, 3, true),
-          LogPlanTermSpecification::Leader{"A", RebootId{42}}),
+          LogTerm{1}, LogPlanTermSpecification::Leader{"A", RebootId{42}}),
       participantsConfig);
 
   auto current = LogCurrent();
@@ -357,13 +358,14 @@ TEST_F(LogSupervisionTest, test_remove_participant_action_wait_for_committed) {
       {"C", ParticipantFlags{}},
       {"D", ParticipantFlags{.allowedInQuorum = false}}};
   auto const& participantsConfig =
-      ParticipantsConfig{.generation = 2, .participants = participantsFlags};
+      ParticipantsConfig{.generation = 2,
+                         .participants = participantsFlags,
+                         .config = LogPlanConfig(3, 3, true)};
 
   auto const& plan = LogPlanSpecification(
       logId,
       LogPlanTermSpecification(
-          LogTerm{1}, LogPlanConfig(3, 3, true),
-          LogPlanTermSpecification::Leader{"A", RebootId{42}}),
+          LogTerm{1}, LogPlanTermSpecification::Leader{"A", RebootId{42}}),
       participantsConfig);
 
   ParticipantsFlagsMap participantsFlagsOld{{"A", ParticipantFlags{}},
@@ -437,13 +439,14 @@ TEST_F(LogSupervisionTest, test_remove_participant_action_committed) {
       {"C", ParticipantFlags{}},
       {"D", ParticipantFlags{.allowedInQuorum = false}}};
   auto const& participantsConfig =
-      ParticipantsConfig{.generation = 2, .participants = participantsFlags};
+      ParticipantsConfig{.generation = 2,
+                         .participants = participantsFlags,
+                         .config = LogPlanConfig(3, 3, true)};
 
   auto const& plan = LogPlanSpecification(
       logId,
       LogPlanTermSpecification(
-          LogTerm{1}, LogPlanConfig(3, 3, true),
-          LogPlanTermSpecification::Leader{"A", RebootId{42}}),
+          LogTerm{1}, LogPlanTermSpecification::Leader{"A", RebootId{42}}),
       participantsConfig);
 
   auto current = LogCurrent();
@@ -500,13 +503,14 @@ TEST_F(LogSupervisionTest, test_write_empty_term) {
       {"C", ParticipantFlags{}},
       {"D", ParticipantFlags{.allowedInQuorum = false}}};
   auto const& participantsConfig =
-      ParticipantsConfig{.generation = 2, .participants = participantsFlags};
+      ParticipantsConfig{.generation = 2,
+                         .participants = participantsFlags,
+                         .config = LogPlanConfig(3, 3, true)};
 
   auto const& plan = LogPlanSpecification(
       logId,
       LogPlanTermSpecification(
-          LogTerm{2}, LogPlanConfig(3, 3, true),
-          LogPlanTermSpecification::Leader{"A", RebootId{42}}),
+          LogTerm{2}, LogPlanTermSpecification::Leader{"A", RebootId{42}}),
       participantsConfig);
 
   ParticipantsFlagsMap participantsFlagsOld{{"A", ParticipantFlags{}},

--- a/tests/Replication2/ReplicatedLog/TestHelper.h
+++ b/tests/Replication2/ReplicatedLog/TestHelper.h
@@ -107,11 +107,10 @@ struct ReplicatedLogTest : ::testing::Test {
     for (auto const& participant : follower) {
       participants.emplace(participant->getParticipantId(), ParticipantFlags{});
     }
-    auto participantsConfig =
-        std::make_shared<ParticipantsConfig>(ParticipantsConfig{
-            .generation = 1,
-            .participants = std::move(participants),
-        });
+    auto participantsConfig = std::make_shared<agency::ParticipantsConfig>(
+        agency::ParticipantsConfig{.generation = 1,
+                                   .participants = std::move(participants),
+                                   .config = config});
 
     if (!failureOracle) {
       failureOracle = std::make_shared<FakeFailureOracle>();

--- a/tests/Replication2/ReplicatedLog/UpdateParticipantsFlags.cpp
+++ b/tests/Replication2/ReplicatedLog/UpdateParticipantsFlags.cpp
@@ -88,7 +88,7 @@ TEST_F(UpdateParticipantsFlagsTest, wc2_but_server_forced) {
   {
     auto oldConfig =
         leader->getStatus().asLeaderStatus()->activeParticipantsConfig;
-    auto newConfig = std::make_shared<ParticipantsConfig>(oldConfig);
+    auto newConfig = std::make_shared<agency::ParticipantsConfig>(oldConfig);
     newConfig->generation = 2;
     // make follower2 forced
     newConfig->participants["follower2"] =
@@ -146,7 +146,7 @@ TEST_F(UpdateParticipantsFlagsTest, wc2_but_server_excluded) {
   {
     auto oldConfig =
         leader->getStatus().asLeaderStatus()->activeParticipantsConfig;
-    auto newConfig = std::make_shared<ParticipantsConfig>(oldConfig);
+    auto newConfig = std::make_shared<agency::ParticipantsConfig>(oldConfig);
     newConfig->generation = 2;
     // make follower1 excluded
     newConfig->participants["follower1"] = replication2::ParticipantFlags{
@@ -190,7 +190,7 @@ TEST_F(UpdateParticipantsFlagsTest,
   {
     auto oldConfig =
         leader->getStatus().asLeaderStatus()->activeParticipantsConfig;
-    auto newConfig = std::make_shared<ParticipantsConfig>(oldConfig);
+    auto newConfig = std::make_shared<agency::ParticipantsConfig>(oldConfig);
     newConfig->generation = 2;
     // make follower1 excluded
     newConfig->participants["follower1"] =
@@ -242,7 +242,7 @@ TEST_F(UpdateParticipantsFlagsTest, multiple_updates_check) {
   {
     auto oldConfig =
         leader->getStatus().asLeaderStatus()->activeParticipantsConfig;
-    auto newConfig = std::make_shared<ParticipantsConfig>(oldConfig);
+    auto newConfig = std::make_shared<agency::ParticipantsConfig>(oldConfig);
     newConfig->generation = 2;
     // make follower2 forced
     newConfig->participants["follower2"] =
@@ -267,7 +267,7 @@ TEST_F(UpdateParticipantsFlagsTest, multiple_updates_check) {
   {
     auto oldConfig =
         leader->getStatus().asLeaderStatus()->activeParticipantsConfig;
-    auto newConfig = std::make_shared<ParticipantsConfig>(oldConfig);
+    auto newConfig = std::make_shared<agency::ParticipantsConfig>(oldConfig);
     newConfig->participants["follower2"] = {};
     newConfig->generation = 3;
     leader->updateParticipantsConfig(newConfig, nullptr);
@@ -303,7 +303,7 @@ TEST_F(UpdateParticipantsFlagsTest, update_without_additional_entry) {
   {
     auto oldConfig =
         leader->getStatus().asLeaderStatus()->activeParticipantsConfig;
-    auto newConfig = std::make_shared<ParticipantsConfig>(oldConfig);
+    auto newConfig = std::make_shared<agency::ParticipantsConfig>(oldConfig);
     newConfig->generation = 2;
     // make follower2 excluded
     newConfig->participants["follower2"] =
@@ -346,7 +346,7 @@ TEST_F(UpdateParticipantsFlagsTest, wc2_add_new_follower) {
   {  // First add the new follower3
     auto oldConfig =
         leader->getStatus().asLeaderStatus()->activeParticipantsConfig;
-    auto newConfig = std::make_shared<ParticipantsConfig>(oldConfig);
+    auto newConfig = std::make_shared<agency::ParticipantsConfig>(oldConfig);
     newConfig->participants["follower3"] = {};
     newConfig->generation = 2;
 
@@ -395,7 +395,7 @@ TEST_F(UpdateParticipantsFlagsTest,
   {  // First add the new follower3
     auto oldConfig =
         leader->getStatus().asLeaderStatus()->activeParticipantsConfig;
-    auto newConfig = std::make_shared<ParticipantsConfig>(oldConfig);
+    auto newConfig = std::make_shared<agency::ParticipantsConfig>(oldConfig);
     newConfig->generation = 2;
     newConfig->participants["follower3"] = replication2::ParticipantFlags{};
 
@@ -448,7 +448,7 @@ TEST_F(UpdateParticipantsFlagsTest, wc2_remove_exclude_flag) {
   {  // First add the new follower3, but excluded
     auto oldConfig =
         leader->getStatus().asLeaderStatus()->activeParticipantsConfig;
-    auto newConfig = std::make_shared<ParticipantsConfig>(oldConfig);
+    auto newConfig = std::make_shared<agency::ParticipantsConfig>(oldConfig);
     newConfig->generation = 2;
     // exclude follower3
     newConfig->participants["follower3"] =
@@ -490,7 +490,7 @@ TEST_F(UpdateParticipantsFlagsTest, wc2_remove_exclude_flag) {
   {  // set follower3.excluded = false; this is the central point of this test!
     auto oldConfig =
         leader->getStatus().asLeaderStatus()->activeParticipantsConfig;
-    auto newConfig = std::make_shared<ParticipantsConfig>(oldConfig);
+    auto newConfig = std::make_shared<agency::ParticipantsConfig>(oldConfig);
     newConfig->generation = 3;
     // exclude follower3
     auto& flags = (newConfig->participants["follower3"] =
@@ -534,7 +534,7 @@ TEST_F(UpdateParticipantsFlagsTest, wc2_remove_follower) {
   {  // remove follower1
     auto oldConfig =
         leader->getStatus().asLeaderStatus()->activeParticipantsConfig;
-    auto newConfig = std::make_shared<ParticipantsConfig>(oldConfig);
+    auto newConfig = std::make_shared<agency::ParticipantsConfig>(oldConfig);
     newConfig->participants.erase("follower1");
     newConfig->generation = 2;
 
@@ -588,7 +588,7 @@ TEST_F(UpdateParticipantsFlagsTest,
   {  // remove follower1
     auto oldConfig =
         leader->getStatus().asLeaderStatus()->activeParticipantsConfig;
-    auto newConfig = std::make_shared<ParticipantsConfig>(oldConfig);
+    auto newConfig = std::make_shared<agency::ParticipantsConfig>(oldConfig);
     newConfig->participants.erase("follower1");
     newConfig->generation = 2;
 
@@ -659,7 +659,7 @@ TEST_F(UpdateParticipantsFlagsTest, wc2_add_mismatching_config_should_fail) {
     auto oldConfig =
         leader->getStatus().asLeaderStatus()->activeParticipantsConfig;
     EXPECT_EQ(oldConfig.generation, 1);
-    auto newConfig = std::make_shared<ParticipantsConfig>(oldConfig);
+    auto newConfig = std::make_shared<agency::ParticipantsConfig>(oldConfig);
     newConfig->generation = 2;
 
     auto logIndex = leader->updateParticipantsConfig(newConfig, nullptr);
@@ -704,7 +704,7 @@ TEST_F(UpdateParticipantsFlagsTest, check_update_participants_meta_entry) {
 
   auto oldConfig =
       leader->getStatus().asLeaderStatus()->activeParticipantsConfig;
-  auto newConfig = std::make_shared<ParticipantsConfig>(oldConfig);
+  auto newConfig = std::make_shared<agency::ParticipantsConfig>(oldConfig);
   {
     newConfig->generation = 2;
     // make follower2 forced
@@ -755,7 +755,7 @@ TEST_F(UpdateParticipantsFlagsTest, refuse_old_generation) {
   {
     auto oldConfig =
         leader->getStatus().asLeaderStatus()->activeParticipantsConfig;
-    auto newConfig = std::make_shared<ParticipantsConfig>(oldConfig);
+    auto newConfig = std::make_shared<agency::ParticipantsConfig>(oldConfig);
     // just update the generation
     newConfig->generation = 3;
     leader->updateParticipantsConfig(newConfig, nullptr);
@@ -770,7 +770,7 @@ TEST_F(UpdateParticipantsFlagsTest, refuse_old_generation) {
   {
     auto oldConfig =
         leader->getStatus().asLeaderStatus()->activeParticipantsConfig;
-    auto newConfig = std::make_shared<ParticipantsConfig>(oldConfig);
+    auto newConfig = std::make_shared<agency::ParticipantsConfig>(oldConfig);
     // purposefully try to update to an old generation
     newConfig->generation = 2;
     EXPECT_ANY_THROW(leader->updateParticipantsConfig(newConfig, nullptr));
@@ -793,7 +793,7 @@ TEST_F(UpdateParticipantsFlagsTest, refuse_old_generation) {
   {
     auto oldConfig =
         leader->getStatus().asLeaderStatus()->activeParticipantsConfig;
-    auto newConfig = std::make_shared<ParticipantsConfig>(oldConfig);
+    auto newConfig = std::make_shared<agency::ParticipantsConfig>(oldConfig);
     // purposefully try to update to an old generation
     newConfig->generation = 2;
     EXPECT_ANY_THROW(leader->updateParticipantsConfig(newConfig, nullptr));

--- a/tests/Replication2/ReplicatedState/MaintenanceTest.cpp
+++ b/tests/Replication2/ReplicatedState/MaintenanceTest.cpp
@@ -58,11 +58,12 @@ TEST_F(ReplicatedStateMaintenanceTest, create_state_test_without_local_log) {
    * Test that the maintenance waits for the replicated log to be present first
    * before creating a replicated state.
    */
-  auto const participantsConfig = ParticipantsConfig{.generation = 1,
-                                                     .participants = {
-                                                         {serverId, {}},
-                                                         {"otherServer", {}},
-                                                     }};
+  auto const participantsConfig =
+      agency::ParticipantsConfig{.generation = 1,
+                                 .participants = {
+                                     {serverId, {}},
+                                     {"otherServer", {}},
+                                 }};
   auto const localLogs = ReplicatedLogStatusMap{};
   auto const localStates = ReplicatedStateStatusMap{};
   auto const planLogs = ReplicatedLogSpecMap{
@@ -90,11 +91,12 @@ TEST_F(ReplicatedStateMaintenanceTest, create_state_test_with_local_log) {
   /*
    * Test that the maintenance create an action to create the replicated state.
    */
-  auto const participantsConfig = ParticipantsConfig{.generation = 1,
-                                                     .participants = {
-                                                         {serverId, {}},
-                                                         {"otherServer", {}},
-                                                     }};
+  auto const participantsConfig =
+      agency::ParticipantsConfig{.generation = 1,
+                                 .participants = {
+                                     {serverId, {}},
+                                     {"otherServer", {}},
+                                 }};
   auto const localLogs = ReplicatedLogStatusMap{
       {logId,
        replicated_log::QuickLogStatus{
@@ -140,11 +142,12 @@ TEST_F(ReplicatedStateMaintenanceTest,
    * Test that the maintenance creates a replicated state and forwards the
    * current entry into the action.
    */
-  auto const participantsConfig = ParticipantsConfig{.generation = 1,
-                                                     .participants = {
-                                                         {serverId, {}},
-                                                         {"otherServer", {}},
-                                                     }};
+  auto const participantsConfig =
+      agency::ParticipantsConfig{.generation = 1,
+                                 .participants = {
+                                     {serverId, {}},
+                                     {"otherServer", {}},
+                                 }};
   auto const localLogs = ReplicatedLogStatusMap{
       {logId,
        replicated_log::QuickLogStatus{
@@ -198,11 +201,12 @@ TEST_F(ReplicatedStateMaintenanceTest, do_nothing_if_stable) {
   /*
    * Check that if the configuration is stable, nothing happens.
    */
-  auto const participantsConfig = ParticipantsConfig{.generation = 1,
-                                                     .participants = {
-                                                         {serverId, {}},
-                                                         {"otherServer", {}},
-                                                     }};
+  auto const participantsConfig =
+      agency::ParticipantsConfig{.generation = 1,
+                                 .participants = {
+                                     {serverId, {}},
+                                     {"otherServer", {}},
+                                 }};
   auto const localLogs = ReplicatedLogStatusMap{
       {logId,
        replicated_log::QuickLogStatus{
@@ -251,11 +255,12 @@ TEST_F(ReplicatedStateMaintenanceTest, check_resync_if_generation_changes) {
   /*
    * Check that the maintenance triggers a resync if the generation changes.
    */
-  auto const participantsConfig = ParticipantsConfig{.generation = 1,
-                                                     .participants = {
-                                                         {serverId, {}},
-                                                         {"otherServer", {}},
-                                                     }};
+  auto const participantsConfig =
+      agency::ParticipantsConfig{.generation = 1,
+                                 .participants = {
+                                     {serverId, {}},
+                                     {"otherServer", {}},
+                                 }};
   auto const localLogs = ReplicatedLogStatusMap{
       {logId,
        replicated_log::QuickLogStatus{

--- a/tests/Replication2/ReplicatedState/PrototypeConcurrencyTest.cpp
+++ b/tests/Replication2/ReplicatedState/PrototypeConcurrencyTest.cpp
@@ -148,7 +148,7 @@ struct PrototypeConcurrencyTest : test::ReplicatedLogTest {
       participants.emplace(participant->getParticipantId(), ParticipantFlags{});
     }
     auto participantsConfig =
-        std::make_shared<ParticipantsConfig>(ParticipantsConfig{
+        std::make_shared<agency::ParticipantsConfig>(agency::ParticipantsConfig{
             .generation = 1,
             .participants = std::move(participants),
         });

--- a/tests/Replication2/Serialization/AgencyLogSpecificationTest.cpp
+++ b/tests/Replication2/Serialization/AgencyLogSpecificationTest.cpp
@@ -31,6 +31,8 @@
 #include "Replication2/ReplicatedLog/AgencyLogSpecification.h"
 #include "Replication2/ReplicatedLog/AgencySpecificationInspectors.h"
 
+#include "Logger/LogMacros.h"
+
 using namespace arangodb;
 using namespace arangodb::replication2;
 using namespace arangodb::replication2::agency;
@@ -57,10 +59,6 @@ TEST(AgencyLogSpecificationTest, log_plan_term_specification) {
     "id": 1234,
     "currentTerm": {
       "term": 1,
-      "config": {
-        "effectiveWriteConcern": 1,
-        "waitForSync": false
-      },
       "leader": {
         "serverId": "leaderId",
         "rebootId": 100
@@ -68,6 +66,10 @@ TEST(AgencyLogSpecificationTest, log_plan_term_specification) {
     },
     "participantsConfig": {
       "generation": 15,
+      "config": {
+        "effectiveWriteConcern": 1,
+        "waitForSync": false
+      },
       "participants": {
         "p1": {
           "forced": true,
@@ -90,14 +92,14 @@ TEST(AgencyLogSpecificationTest, log_plan_term_specification) {
   jsonBuffer = R"({
     "id": 1234,
     "currentTerm": {
-      "term": 1,
-      "config": {
-        "effectiveWriteConcern": 1,
-        "waitForSync": false
-      }
+      "term": 1
     },
     "participantsConfig": {
       "generation": 15,
+      "config": {
+        "effectiveWriteConcern": 1,
+        "waitForSync": false
+      },
       "participants": {}
     }
   })"_vpack;
@@ -110,7 +112,12 @@ TEST(AgencyLogSpecificationTest, log_plan_term_specification) {
     "id": 1234,
     "participantsConfig": {
       "generation": 15,
-      "participants": {}
+      "participants": {
+      },
+      "config": {
+        "effectiveWriteConcern": 1,
+        "waitForSync": false
+      }
     }
   })"_vpack;
 

--- a/tests/Replication2/Serialization/AgencyLogSpecificationTest.cpp
+++ b/tests/Replication2/Serialization/AgencyLogSpecificationTest.cpp
@@ -42,9 +42,10 @@ TEST(AgencyLogSpecificationTest, log_plan_term_specification) {
   auto spec = LogPlanSpecification{
       id,
       LogPlanTermSpecification{
-          LogTerm{1}, LogPlanConfig{1, 1, false},
+          LogTerm{1},
           LogPlanTermSpecification::Leader{"leaderId", RebootId{100}}},
-      ParticipantsConfig{15, {{"p1", {true, false}}, {"p2", {}}}}};
+      ParticipantsConfig{
+          15, {{"p1", {true, false}}, {"p2", {}}}, LogPlanConfig{1, 1, false}}};
 
   VPackBuilder builder;
   velocypack::serialize(builder, spec);

--- a/tests/Replication2/Serialization/LogCommonTest.cpp
+++ b/tests/Replication2/Serialization/LogCommonTest.cpp
@@ -27,8 +27,8 @@
 
 #include "Aql/VelocyPackHelper.h"
 #include "Inspection/VPack.h"
-#include "Replication2/ReplicatedLog/LogCommon.h"
 #include "Replication2/ReplicatedLog/AgencyLogSpecification.h"
+#include "Replication2/ReplicatedLog/LogCommon.h"
 
 using namespace arangodb;
 using namespace arangodb::replication2;
@@ -192,6 +192,10 @@ TEST(LogCommonTest, participants_config_inspector) {
 
   auto jsonBuffer = R"({
       "generation": 15,
+      "config": {
+        "effectiveWriteConcern":1,
+        "waitForSync":false
+      },
       "participants": {
         "A": {
           "forced": false,

--- a/tests/Replication2/Serialization/LogCommonTest.cpp
+++ b/tests/Replication2/Serialization/LogCommonTest.cpp
@@ -28,9 +28,11 @@
 #include "Aql/VelocyPackHelper.h"
 #include "Inspection/VPack.h"
 #include "Replication2/ReplicatedLog/LogCommon.h"
+#include "Replication2/ReplicatedLog/AgencyLogSpecification.h"
 
 using namespace arangodb;
 using namespace arangodb::replication2;
+using namespace arangodb::replication2::agency;
 using namespace arangodb::replication2::replicated_log;
 using namespace arangodb::basics;
 using namespace arangodb::tests;

--- a/tests/Replication2/Serialization/LogStatusTest.cpp
+++ b/tests/Replication2/Serialization/LogStatusTest.cpp
@@ -178,7 +178,7 @@ TEST(LogStatusTest, leader_status) {
   leaderStatus.term = LogTerm{2};
   leaderStatus.lowestIndexToKeep = LogIndex{1};
   leaderStatus.activeParticipantsConfig.generation = 14;
-  leaderStatus.committedParticipantsConfig = ParticipantsConfig{};
+  leaderStatus.committedParticipantsConfig = agency::ParticipantsConfig{};
   leaderStatus.committedParticipantsConfig->generation = 18;
   std::unordered_map<ParticipantId, FollowerStatistics> follower(
       {{"PRMR-45c56239-6a83-4ab0-961e-9adea5078286",

--- a/tests/Replication2/Streams/TestLogSpecification.h
+++ b/tests/Replication2/Streams/TestLogSpecification.h
@@ -73,11 +73,10 @@ struct LogMultiplexerTestBase
     for (auto const& participant : follower) {
       participants.emplace(participant->getParticipantId(), ParticipantFlags{});
     }
-    auto participantsConfig =
-        std::make_shared<ParticipantsConfig>(ParticipantsConfig{
-            .generation = 1,
-            .participants = std::move(participants),
-        });
+    auto participantsConfig = std::make_shared<agency::ParticipantsConfig>(
+        agency::ParticipantsConfig{.generation = 1,
+                                   .participants = std::move(participants),
+                                   .config = config});
     return log->becomeLeader(config, std::move(id), term, follower,
                              std::move(participantsConfig),
                              std::make_shared<FakeFailureOracle>());

--- a/tests/js/server/replication2/replication2-maintenance-replicated-log-cluster.js
+++ b/tests/js/server/replication2/replication2-maintenance-replicated-log-cluster.js
@@ -88,8 +88,8 @@ const replicatedLogSuite = function () {
       const term = 1;
       lh.replicatedLogSetPlan(database, logId, {
         id: logId,
-        currentTerm: lh.createTermSpecification(term, servers, planConfig, leader),
-        participantsConfig: lh.createParticipantsConfig(1, servers),
+        currentTerm: lh.createTermSpecification(term, servers, leader),
+        participantsConfig: lh.createParticipantsConfig(1, planConfig, servers),
       });
 
       // wait for all servers to have reported in current
@@ -104,8 +104,8 @@ const replicatedLogSuite = function () {
       const term = 1;
       lh.replicatedLogSetPlan(database, logId, {
         id: logId,
-        currentTerm: lh.createTermSpecification(term, servers, planConfig),
-        participantsConfig: lh.createParticipantsConfig(1, servers),
+        currentTerm: lh.createTermSpecification(term, servers),
+        participantsConfig: lh.createParticipantsConfig(1, planConfig, servers),
       });
 
       // wait for all servers to have reported in current
@@ -153,7 +153,7 @@ const replicatedLogSuite = function () {
 
     testUpdateTermInPlanLog: function () {
       const {logId, term, servers, leader} = lh.createReplicatedLogPlanOnly(database, planConfig, replicationFactor);
-      const newTerm = lh.createTermSpecification(term + 1, servers, planConfig, leader);
+      const newTerm = lh.createTermSpecification(term + 1, servers, leader);
       lh.replicatedLogSetPlanTerm(database, logId, newTerm);
 
       // wait again for all servers to have acked term
@@ -165,7 +165,7 @@ const replicatedLogSuite = function () {
       const {logId, term, servers} = lh.createReplicatedLogPlanOnly(database, planConfig, replicationFactor);
       // wait again for all servers to have acked term
       const otherLeader = servers[1];
-      const newTerm = lh.createTermSpecification(term + 1, servers, planConfig, otherLeader);
+      const newTerm = lh.createTermSpecification(term + 1, servers, otherLeader);
       lh.replicatedLogSetPlanTerm(database, logId, newTerm);
       lh.waitFor(lp.replicatedLogIsReady(database, logId, term + 1, servers, otherLeader));
       lh.replicatedLogDeletePlan(database, logId);
@@ -193,8 +193,8 @@ const replicatedLogSuite = function () {
       const newServers = [...servers, toBeRemoved];
       lh.replicatedLogSetPlan(database, logId, {
         id: logId,
-        currentTerm: lh.createTermSpecification(term, newServers, planConfig, leader),
-        participantsConfig: lh.createParticipantsConfig(1, newServers),
+        currentTerm: lh.createTermSpecification(term, newServers, leader),
+        participantsConfig: lh.createParticipantsConfig(1, planConfig, newServers),
       });
 
       // wait for all servers to have reported in current

--- a/tests/js/server/replication2/replication2-maintenance-replicated-state-cluster.js
+++ b/tests/js/server/replication2/replication2-maintenance-replicated-state-cluster.js
@@ -44,10 +44,6 @@ const createReplicatedState = function (database, logId, servers, leader, stateT
       id: logId,
       currentTerm: {
         term: 1,
-        config: {
-          effectiveWriteConcern: 2,
-          waitForSync: false,
-        },
         leader: {
           serverId: leader,
           rebootId: LH.getServerRebootId(leader),
@@ -55,6 +51,10 @@ const createReplicatedState = function (database, logId, servers, leader, stateT
       },
       participantsConfig: {
         generation: 1,
+        config: {
+          effectiveWriteConcern: 2,
+          waitForSync: false,
+        },
         participants: {},
       }
     };


### PR DESCRIPTION
### Scope & Purpose

Move Log config from Term to ParticipantsConfig; this means the log config is under the `generation` revision mechanism.