### PR TITLE
[CINFRA-407] Prevent write to current if State/Plan is deleted

### DIFF
--- a/arangod/Cluster/Maintenance.cpp
+++ b/arangod/Cluster/Maintenance.cpp
@@ -1727,12 +1727,24 @@ static void reportCurrentReplicatedState(
   update.generation = status.getGeneration();
   update.snapshot = status.getSnapshotInfo();
 
+  auto preconditionPath =
+      cluster::paths::aliases::plan()
+          ->replicatedStates()
+          ->database(dbName)
+          ->state(id)
+          ->id()
+          ->str(cluster::paths::SkipComponents(
+              1) /* skip first path component, i.e. 'arango' */);
   report.add(VPackValue(updatePath->str(cluster::paths::SkipComponents(1))));
   {
     VPackObjectBuilder o(&report);
     report.add(OP, VP_SET);
     report.add(VPackValue("payload"));
     velocypack::serialize(report, update);
+    {
+      VPackObjectBuilder preconditionBuilder(&report, "precondition");
+      report.add(preconditionPath, VPackValue(id));
+    }
   }
 }
 

--- a/arangod/Cluster/Maintenance.cpp
+++ b/arangod/Cluster/Maintenance.cpp
@@ -1742,6 +1742,8 @@ static void reportCurrentReplicatedState(
     report.add(VPackValue("payload"));
     velocypack::serialize(report, update);
     {
+      // Assert that State/Plan/<db>/<id>/id is still there and equal to <id>.
+      // This is true if and only if the state was not yet dropped from Plan.
       VPackObjectBuilder preconditionBuilder(&report, "precondition");
       report.add(preconditionPath, VPackValue(id));
     }


### PR DESCRIPTION
### Scope & Purpose
The maintenance writes to State/Current even if the replicated state is already deleted from State/Plan. This PR adds a precondition on `State/Plan/<database>/<state-id>/id` to be equal to `<state-id>`. This precondition fails if and only if the entry in Plan is gone. Sadly the maintenance code enforces a certain format on the preconditions and it is not possible to formulate a less cryptic precondition.