### PR TITLE
fixed BTS-875

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,12 +1,14 @@
 devel
 -----
 
+* Fixed issue BTS-875.
+
 * Updated arangosync to v2.10.0-preview-1.
 
-* Enterprise only: Restricted behaviour of Hybrid Disjoint Smart Graphs. Within a single
-  traversal or path query we now restrict that you can only switch between
-  Smart and Satellite sharding once, all queries where  more than one switch
-  is (in theory) possible will be rejected. e.g:
+* Enterprise only: Restricted behaviour of Hybrid Disjoint Smart Graphs. Within 
+  a single traversal or path query we now restrict that you can only switch 
+  between Smart and Satellite sharding once, all queries where more than one 
+  switch is (in theory) possible will be rejected. e.g:
   ```
     FOR v IN 2 OUTBOUND @start smartToSatEdges, satToSmartEdges
   ```


### PR DESCRIPTION
### Scope & Purpose

Fixed BTS-875: https://arangodb.atlassian.net/browse/BTS-875
When multiple followers are trying to get in sync with the leader at the same time, and more than one follower tries to update the collection count value on the leader, this could result in a race, so that more than one follower applies the collection count update on the leader. This will again lead to the count on the leader being wrong.
This PR fixes the issue by using a ticket id for all callers that want to update the counts, and having only one caller succeed for the same ticket id.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -
  - [ ] Backport for 3.7: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [x] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/BTS-875
- [ ] Design document: 