### PR TITLE
fetch schema only once per batch operation

### DIFF
--- a/arangod/RocksDBEngine/RocksDBCollection.cpp
+++ b/arangod/RocksDBEngine/RocksDBCollection.cpp
@@ -1095,19 +1095,12 @@ Result RocksDBCollection::insert(arangodb::transaction::Methods* trx,
       options.isSynchronousReplicationFrom.empty()) {
     // only do schema validation when we are not restoring/replicating
     res = _logicalCollection.validate(
-        newSlice, trx->transactionContextPtr()->getVPackOptions());
+        options.schema, newSlice,
+        trx->transactionContextPtr()->getVPackOptions());
 
     if (res.fail()) {
       return res;
     }
-  }
-
-  auto r = transaction::Methods::validateSmartJoinAttribute(_logicalCollection,
-                                                            newSlice);
-
-  if (r != TRI_ERROR_NO_ERROR) {
-    res.reset(r);
-    return res;
   }
 
   LocalDocumentId const documentId =
@@ -1272,7 +1265,8 @@ Result RocksDBCollection::performUpdateOrReplace(
 
   if (options.validate && options.isSynchronousReplicationFrom.empty()) {
     res = _logicalCollection.validate(
-        newDoc, oldDoc, trx->transactionContextPtr()->getVPackOptions());
+        options.schema, newDoc, oldDoc,
+        trx->transactionContextPtr()->getVPackOptions());
     if (res.fail()) {
       return res;
     }

--- a/arangod/Utils/OperationOptions.h
+++ b/arangod/Utils/OperationOptions.h
@@ -31,6 +31,7 @@
 
 namespace arangodb {
 class ExecContext;
+struct ValidatorBase;
 
 /// @brief Indicates whether we want to observe writes performed within the
 /// current (sub) transaction. This is only relevant for AQL queries.
@@ -103,7 +104,6 @@ struct OperationOptions {
   /// @brief determine the overwrite mode from the string value
   static OverwriteMode determineOverwriteMode(std::string_view value);
 
- public:
   // for synchronous replication operations, we have to mark them such that
   // we can deny them if we are a (new) leader, and that we can deny other
   // operation if we are merely a follower. Finally, we must deny replications
@@ -169,6 +169,10 @@ struct OperationOptions {
   // necessary for UPSERTS where the subquery relies on a non-unique secondary
   // index.
   bool canDisableIndexing = true;
+
+  // schema used for validation during INSERT/UPDATE/REPLACE. this value is only
+  // set temporarily.
+  std::shared_ptr<ValidatorBase> schema = nullptr;
 
   // get associated execution context
   ExecContext const& context() const;

--- a/arangod/VocBase/LogicalCollection.cpp
+++ b/arangod/VocBase/LogicalCollection.cpp
@@ -1155,9 +1155,13 @@ void LogicalCollection::schemaToVelocyPack(VPackBuilder& b) const {
   }
 }
 
-Result LogicalCollection::validate(VPackSlice s,
+std::shared_ptr<ValidatorBase> LogicalCollection::schema() const {
+  return std::atomic_load_explicit(&_schema, std::memory_order_relaxed);
+}
+
+Result LogicalCollection::validate(std::shared_ptr<ValidatorBase> const& schema,
+                                   VPackSlice s,
                                    VPackOptions const* options) const {
-  auto schema = std::atomic_load_explicit(&_schema, std::memory_order_relaxed);
   if (schema != nullptr) {
     auto res = schema->validate(s, VPackSlice::noneSlice(), true, options);
     if (res.fail()) {
@@ -1173,9 +1177,11 @@ Result LogicalCollection::validate(VPackSlice s,
   return {};
 }
 
-Result LogicalCollection::validate(VPackSlice modifiedDoc, VPackSlice oldDoc,
+Result LogicalCollection::validate(std::shared_ptr<ValidatorBase> const& schema,
+                                   VPackSlice modifiedDoc, VPackSlice oldDoc,
                                    VPackOptions const* options) const {
-  auto schema = std::atomic_load_explicit(&_schema, std::memory_order_relaxed);
+  //  auto schema = std::atomic_load_explicit(&_schema,
+  //  std::memory_order_relaxed);
   if (schema != nullptr) {
     auto res = schema->validate(modifiedDoc, oldDoc, false, options);
     if (res.fail()) {

--- a/arangod/VocBase/LogicalCollection.h
+++ b/arangod/VocBase/LogicalCollection.h
@@ -340,13 +340,20 @@ class LogicalCollection : public LogicalDataSource {
       std::function<bool(LogicalCollection&)> const& callback);
 
   void schemaToVelocyPack(VPackBuilder&) const;
-  Result validate(VPackSlice newDoc, VPackOptions const*) const;  // insert
-  Result validate(VPackSlice modifiedDoc, VPackSlice oldDoc,
-                  VPackOptions const*) const;  // update / replace
+
+  // return a pointer to the schema. can be a nullptr if no schema
+  std::shared_ptr<ValidatorBase> schema() const;
+
+  // validate a document on INSERT
+  Result validate(std::shared_ptr<ValidatorBase> const& schema,
+                  VPackSlice newDoc, VPackOptions const*) const;
+  // validate a document on UPDATE/REPLACE
+  Result validate(std::shared_ptr<ValidatorBase> const& schema,
+                  VPackSlice modifiedDoc, VPackSlice oldDoc,
+                  VPackOptions const*) const;
 
   // Get a reference to this KeyGenerator.
-  // Caller is not allowed to free it.
-  KeyGenerator& keyGenerator() const { return *_keyGenerator; }
+  KeyGenerator& keyGenerator() const noexcept { return *_keyGenerator; }
 
   transaction::CountCache& countCache() { return _countCache; }
 


### PR DESCRIPTION
### Scope & Purpose

Fetch collection's schema only once per batch operation, not once per document.
Because the schema is an atomic shared_ptr, fetching it only once per batch can reduce contention when dealing with large concurrent batch operations.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [x] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [x] Backports
  - [x] Backport for 3.9: https://github.com/arangodb/arangodb/pull/16351
  - [ ] Backport for 3.8: -
  - [ ] Backport for 3.7: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
