### PR TITLE
[CINFRA-408] Document State Implementation

### DIFF
--- a/arangod/CMakeLists.txt
+++ b/arangod/CMakeLists.txt
@@ -625,6 +625,8 @@ set(LIB_ARANGO_REPLICATION2_SOURCES
   Replication2/ReplicatedState/UpdateReplicatedState.h
   Replication2/StateMachines/BlackHole/BlackHoleStateMachine.cpp
   Replication2/StateMachines/BlackHole/BlackHoleStateMachineFeature.cpp
+  Replication2/StateMachines/Document/DocumentStateMachine.cpp
+  Replication2/StateMachines/Document/DocumentStateMachineFeature.cpp
   Replication2/StateMachines/Prototype/PrototypeLogEntry.cpp
   Replication2/StateMachines/Prototype/PrototypeLeaderState.cpp
   Replication2/StateMachines/Prototype/PrototypeCore.cpp

--- a/arangod/Cluster/ClusterInfo.cpp
+++ b/arangod/Cluster/ClusterInfo.cpp
@@ -522,7 +522,7 @@ auto ClusterInfo::createReplicatedStateSpec(
   replication2::replicated_state::agency::Target spec;
 
   spec.id = LogicalCollection::shardIdToStateId(shardId);
-  spec.properties.implementation.type = "black-hole";
+  spec.properties.implementation.type = "document";
   TRI_ASSERT(!serverIds.empty());
   spec.leader = serverIds.front();
 

--- a/arangod/Replication2/Methods.h
+++ b/arangod/Replication2/Methods.h
@@ -187,10 +187,12 @@ struct ReplicatedStateMethods {
   static auto createInstance(TRI_vocbase_t& vocbase)
       -> std::shared_ptr<ReplicatedStateMethods>;
 
-  static auto createInstanceDBServer(TRI_vocbase_t& vocbase) -> std::shared_ptr<ReplicatedStateMethods>;
+  static auto createInstanceDBServer(TRI_vocbase_t& vocbase)
+      -> std::shared_ptr<ReplicatedStateMethods>;
 
-  static auto createInstanceCoordinator(ArangodServer& server, std::string databaseName)
-  -> std::shared_ptr<ReplicatedStateMethods>;
+  static auto createInstanceCoordinator(ArangodServer& server,
+                                        std::string databaseName)
+      -> std::shared_ptr<ReplicatedStateMethods>;
 
   [[nodiscard]] virtual auto replaceParticipant(
       LogId, ParticipantId const& participantToRemove,

--- a/arangod/Replication2/StateMachines/Document/DocumentStateMachine.cpp
+++ b/arangod/Replication2/StateMachines/Document/DocumentStateMachine.cpp
@@ -1,0 +1,93 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2022 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Alexandru Petenchea
+////////////////////////////////////////////////////////////////////////////////
+
+#include <Basics/voc-errors.h>
+#include <Futures/Future.h>
+
+#include "DocumentStateMachine.h"
+
+using namespace arangodb::replication2::replicated_state::document;
+
+DocumentLeaderState::DocumentLeaderState(std::unique_ptr<DocumentCore> core)
+    : _core(std::move(core)){};
+
+auto DocumentLeaderState::resign() && noexcept
+    -> std::unique_ptr<DocumentCore> {
+  return std::move(_core);
+}
+
+auto DocumentLeaderState::recoverEntries(std::unique_ptr<EntryIterator> ptr)
+    -> futures::Future<Result> {
+  return {TRI_ERROR_NO_ERROR};
+}
+
+DocumentFollowerState::DocumentFollowerState(std::unique_ptr<DocumentCore> core)
+    : _core(std::move(core)){};
+
+auto DocumentFollowerState::resign() && noexcept
+    -> std::unique_ptr<DocumentCore> {
+  return std::move(_core);
+}
+
+auto DocumentFollowerState::acquireSnapshot(ParticipantId const& destination,
+                                            LogIndex) noexcept
+    -> futures::Future<Result> {
+  return {TRI_ERROR_NO_ERROR};
+}
+
+auto DocumentFollowerState::applyEntries(
+    std::unique_ptr<EntryIterator> ptr) noexcept -> futures::Future<Result> {
+  return {TRI_ERROR_NO_ERROR};
+};
+
+auto DocumentFactory::constructFollower(std::unique_ptr<DocumentCore> core)
+    -> std::shared_ptr<DocumentFollowerState> {
+  return std::make_shared<DocumentFollowerState>(std::move(core));
+}
+
+auto DocumentFactory::constructLeader(std::unique_ptr<DocumentCore> core)
+    -> std::shared_ptr<DocumentLeaderState> {
+  return std::make_shared<DocumentLeaderState>(std::move(core));
+}
+
+auto DocumentFactory::constructCore(GlobalLogIdentifier const& gid)
+    -> std::unique_ptr<DocumentCore> {
+  return std::make_unique<DocumentCore>();
+}
+
+auto arangodb::replication2::replicated_state::EntryDeserializer<
+    DocumentLogEntry>::operator()(streams::serializer_tag_t<DocumentLogEntry>,
+                                  velocypack::Slice s) const
+    -> DocumentLogEntry {
+  return DocumentLogEntry{};
+}
+
+void arangodb::replication2::replicated_state::EntrySerializer<
+    DocumentLogEntry>::operator()(streams::serializer_tag_t<DocumentLogEntry>,
+                                  DocumentLogEntry const& e,
+                                  velocypack::Builder& b) const {}
+
+#include "Replication2/ReplicatedState/ReplicatedState.tpp"
+
+template struct arangodb::replication2::replicated_state::ReplicatedState<
+    DocumentState>;

--- a/arangod/Replication2/StateMachines/Document/DocumentStateMachine.h
+++ b/arangod/Replication2/StateMachines/Document/DocumentStateMachine.h
@@ -1,0 +1,112 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2022 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Alexandru Petenchea
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "Replication2/ReplicatedState/ReplicatedState.h"
+#include "Replication2/ReplicatedState/StateInterfaces.h"
+
+namespace arangodb::replication2::replicated_state {
+/**
+ * The Document State Machine is used as a middle-man between a shard and a
+ * replicated log, inside collections from databases configured with
+ * Replication2.
+ */
+namespace document {
+
+struct DocumentFactory;
+struct DocumentLogEntry;
+struct DocumentLeaderState;
+struct DocumentFollowerState;
+struct DocumentCore;
+
+struct DocumentState {
+  using LeaderType = DocumentLeaderState;
+  using FollowerType = DocumentFollowerState;
+  using EntryType = DocumentLogEntry;
+  using FactoryType = DocumentFactory;
+  using CoreType = DocumentCore;
+};
+
+/* Empty for now */
+struct DocumentLogEntry {};
+struct DocumentCore {};
+
+struct DocumentLeaderState
+    : replicated_state::IReplicatedLeaderState<DocumentState> {
+  explicit DocumentLeaderState(std::unique_ptr<DocumentCore> core);
+
+  [[nodiscard]] auto resign() && noexcept
+      -> std::unique_ptr<DocumentCore> override;
+
+  auto recoverEntries(std::unique_ptr<EntryIterator> ptr)
+      -> futures::Future<Result> override;
+
+  std::unique_ptr<DocumentCore> _core;
+};
+
+struct DocumentFollowerState
+    : replicated_state::IReplicatedFollowerState<DocumentState> {
+  explicit DocumentFollowerState(std::unique_ptr<DocumentCore> core);
+
+ protected:
+  [[nodiscard]] auto resign() && noexcept
+      -> std::unique_ptr<DocumentCore> override;
+  auto acquireSnapshot(ParticipantId const& destination, LogIndex) noexcept
+      -> futures::Future<Result> override;
+  auto applyEntries(std::unique_ptr<EntryIterator> ptr) noexcept
+      -> futures::Future<Result> override;
+
+  std::unique_ptr<DocumentCore> _core;
+};
+
+struct DocumentFactory {
+  auto constructFollower(std::unique_ptr<DocumentCore> core)
+      -> std::shared_ptr<DocumentFollowerState>;
+  auto constructLeader(std::unique_ptr<DocumentCore> core)
+      -> std::shared_ptr<DocumentLeaderState>;
+  auto constructCore(GlobalLogIdentifier const&)
+      -> std::unique_ptr<DocumentCore>;
+};
+}  // namespace document
+
+template<>
+struct EntryDeserializer<document::DocumentLogEntry> {
+  auto operator()(
+      streams::serializer_tag_t<replicated_state::document::DocumentLogEntry>,
+      velocypack::Slice s) const
+      -> replicated_state::document::DocumentLogEntry;
+};
+
+template<>
+struct EntrySerializer<document::DocumentLogEntry> {
+  void operator()(
+      streams::serializer_tag_t<replicated_state::document::DocumentLogEntry>,
+      replicated_state::document::DocumentLogEntry const& e,
+      velocypack::Builder& b) const;
+};
+
+extern template struct replicated_state::ReplicatedState<
+    document::DocumentState>;
+
+}  // namespace arangodb::replication2::replicated_state

--- a/arangod/Replication2/StateMachines/Document/DocumentStateMachineFeature.cpp
+++ b/arangod/Replication2/StateMachines/Document/DocumentStateMachineFeature.cpp
@@ -1,0 +1,37 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2022 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Alexandru Petenchea
+////////////////////////////////////////////////////////////////////////////////
+
+#include "DocumentStateMachineFeature.h"
+#include "DocumentStateMachine.h"
+#include "ApplicationFeatures/ApplicationServer.h"
+#include "Replication2/ReplicatedState/ReplicatedStateFeature.h"
+
+using namespace arangodb::replication2::replicated_state::document;
+
+void DocumentStateMachineFeature::start() {
+  auto& feature = server().getFeature<ReplicatedStateAppFeature>();
+  feature.registerStateType<DocumentState>("document");
+}
+
+DocumentStateMachineFeature::DocumentStateMachineFeature(Server& server)
+    : ArangodFeature{server, *this} {}

--- a/arangod/Replication2/StateMachines/Document/DocumentStateMachineFeature.h
+++ b/arangod/Replication2/StateMachines/Document/DocumentStateMachineFeature.h
@@ -1,0 +1,38 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2022 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Alexandru Petenchea
+////////////////////////////////////////////////////////////////////////////////
+#pragma once
+
+#include "RestServer/arangod.h"
+
+namespace arangodb::replication2::replicated_state::document {
+
+struct DocumentStateMachineFeature : public ArangodFeature {
+  static constexpr std::string_view name() noexcept {
+    return "DocumentStateMachine";
+  }
+
+  explicit DocumentStateMachineFeature(Server& server);
+  void start() override;
+};
+
+}  // namespace arangodb::replication2::replicated_state::document

--- a/arangod/RestServer/arangod.cpp
+++ b/arangod/RestServer/arangod.cpp
@@ -87,6 +87,7 @@
 #include "Replication2/ReplicatedLog/ReplicatedLogFeature.h"
 #include "Replication2/ReplicatedState/ReplicatedStateFeature.h"
 #include "Replication2/StateMachines/BlackHole/BlackHoleStateMachineFeature.h"
+#include "Replication2/StateMachines/Document/DocumentStateMachineFeature.h"
 #include "Replication2/StateMachines/Prototype/PrototypeStateMachineFeature.h"
 #include "RestServer/AqlFeature.h"
 #include "RestServer/BootstrapFeature.h"

--- a/arangod/RestServer/arangod.h
+++ b/arangod/RestServer/arangod.h
@@ -170,6 +170,10 @@ struct BlackHoleStateMachineFeature;
 namespace prototype {
 struct PrototypeStateMachineFeature;
 }
+
+namespace document {
+struct DocumentStateMachineFeature;
+}
 }  // namespace replication2::replicated_state
 
 using namespace application_features;
@@ -286,7 +290,8 @@ using ArangodFeatures = TypeList<
     cluster::FailureOracleFeature,
     replication2::replicated_state::ReplicatedStateAppFeature,
     replication2::replicated_state::black_hole::BlackHoleStateMachineFeature,
-    replication2::replicated_state::prototype::PrototypeStateMachineFeature
+    replication2::replicated_state::prototype::PrototypeStateMachineFeature,
+    replication2::replicated_state::document::DocumentStateMachineFeature
 >;  // clang-format on
 
 using ArangodServer = application_features::ApplicationServerT<ArangodFeatures>;


### PR DESCRIPTION
### Scope & Purpose

This is just a skeleton for the document state. We replaced the `black-hole` with `document` state machine inside the create collection method.

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

