### PR TITLE
[PREGEL] Spill dynamic WCC vertex data into MMAP buffer

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,7 @@
 devel
 -----
+* Pregel Weakly Connected Components (WCC) now allocates incoming neighbors
+  in TypedBuffers as a measure to be able to spill into memory mapped files.
 
 * Updated arangosync to v2.10.0.
 

--- a/arangod/Pregel/CommonFormats.h
+++ b/arangod/Pregel/CommonFormats.h
@@ -170,20 +170,20 @@ struct WCCValue {
     MemRange storage = MemRange{.from = nullptr, .to = nullptr};
     // FIXME: output iterator?
     uint8_t* current = nullptr;
-    uint32_t count = 0;
 
-    auto init(MemRange inStorage, uint32_t inCount) -> void {
+    auto init(MemRange inStorage) -> void {
       storage = inStorage;
-      current = const_cast<uint8_t*>(storage.from);
-      count = inCount;
+      current = storage.from;
     }
 
-    auto emplace(PregelID pid) -> void {
+    auto emplace(PregelID const& pid) -> void {
+      ADB_PROD_ASSERT(current + sizeof(InNeighbor) + pid.key.length() <=
+                      storage.to);
       auto storedInNeighbor = reinterpret_cast<InNeighbor*>(current);
       storedInNeighbor->fromShard = pid.shard;
       storedInNeighbor->keylen = pid.key.length();
-      memmove(storedInNeighbor->fromKey, pid.key.c_str(),
-              storedInNeighbor->keylen);
+      memcpy(storedInNeighbor->fromKey, pid.key.c_str(),
+             storedInNeighbor->keylen);
 
       current += storedInNeighbor->size();
     }

--- a/arangod/Pregel/GraphStore.h
+++ b/arangod/Pregel/GraphStore.h
@@ -122,7 +122,7 @@ class GraphStore final {
 
   auto allocateAuxiliaryStorage(size_t bytes) -> MemRange {
     return _auxiliaryStorage.allocate(bytes);
-  };
+  }
 
  private:
   void loadVertices(ShardID const& vertexShard,
@@ -171,7 +171,7 @@ class GraphStore final {
   // state being spilled to memory mapped files.
   //
   // This buffer is currently here to address this problem; the solution
-  // is not ideal, and will hopefulle be improved in future iterations
+  // is not ideal, and will hopefully be improved in future iterations
   // on the code.
   //
   // note that ExpandingBuffer does locking, because it might be used

--- a/arangod/Pregel/VertexComputation.h
+++ b/arangod/Pregel/VertexComputation.h
@@ -96,17 +96,6 @@ class VertexContext {
     return _graphStore->allocateAuxiliaryStorage(bytes);
   }
 
-  /*
-void setVertexData(V const& val) {
-  _graphStore->replaceVertexData(_vertexEntry, (void*)(&val), sizeof(V));
-}
-
-/// store data, will potentially move the data around
-void setVertexData(void const* ptr, size_t size) {
-  _graphStore->replaceVertexData(_vertexEntry, (void*)ptr, size);
-}
-*/
-
   void voteHalt() { _vertexEntry->setActive(false); }
   void voteActive() { _vertexEntry->setActive(true); }
   bool isActive() { return _vertexEntry->active(); }

--- a/arangod/Pregel/VertexComputation.h
+++ b/arangod/Pregel/VertexComputation.h
@@ -23,8 +23,6 @@
 
 #pragma once
 
-#include <algorithm>
-#include <cstddef>
 #include "Basics/Common.h"
 #include "Pregel/Graph.h"
 #include "Pregel/GraphStore.h"
@@ -32,6 +30,8 @@
 #include "Pregel/WorkerConfig.h"
 #include "Pregel/WorkerContext.h"
 #include "Reports.h"
+#include <algorithm>
+#include <cstddef>
 
 namespace arangodb {
 namespace pregel {
@@ -92,14 +92,20 @@ class VertexContext {
     return _graphStore->edgeIterator(_vertexEntry);
   }
 
-  void setVertexData(V const& val) {
-    _graphStore->replaceVertexData(_vertexEntry, (void*)(&val), sizeof(V));
+  auto allocateAuxiliaryStorage(size_t bytes) -> MemRange {
+    return _graphStore->allocateAuxiliaryStorage(bytes);
   }
 
-  /// store data, will potentially move the data around
-  void setVertexData(void const* ptr, size_t size) {
-    _graphStore->replaceVertexData(_vertexEntry, (void*)ptr, size);
-  }
+  /*
+void setVertexData(V const& val) {
+  _graphStore->replaceVertexData(_vertexEntry, (void*)(&val), sizeof(V));
+}
+
+/// store data, will potentially move the data around
+void setVertexData(void const* ptr, size_t size) {
+  _graphStore->replaceVertexData(_vertexEntry, (void*)ptr, size);
+}
+*/
 
   void voteHalt() { _vertexEntry->setActive(false); }
   void voteActive() { _vertexEntry->setActive(true); }


### PR DESCRIPTION
### Scope & Purpose

This PR changes the Weakly Connected Component Pregel algorithm to use memory mapped storage for the (dynamically allocated) incoming edges;

It is inherent in the current Pregel implementation that on a given DB Server, loading a shard of vertices, we can only also load outgoing edges.

Since for WCC we need incoming edges as well, we cache sender ids on the first global superstep; the memory use of this step is somewhere in the order of the number of edges times the size of vertex-ids; a fairly significant number.

Hopefully this is only a temporary measure while we implement more robust memory management for pregel.

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*
  - [ ] Backport for 3.7: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

