### PR TITLE
SEPP: fix db size calculation

### DIFF
--- a/tests/sepp/Execution.cpp
+++ b/tests/sepp/Execution.cpp
@@ -32,18 +32,6 @@
 
 #include "Workload.h"
 
-namespace {
-std::size_t getFolderSize(std::string_view path) {
-  return std::accumulate(std::filesystem::recursive_directory_iterator(path),
-                         std::filesystem::recursive_directory_iterator(), 0ull,
-                         [](auto size, auto const& path) {
-                           return std::filesystem::is_directory(path)
-                                      ? size
-                                      : size + std::filesystem::file_size(path);
-                         });
-}
-}  // namespace
-
 namespace arangodb::sepp {
 
 Execution::Execution(Options const& options, std::shared_ptr<Workload> workload)
@@ -130,7 +118,7 @@ Report Execution::buildReport(double runtime) {
                 .configBuilder = {},
                 .threads = std::move(threadReports),
                 .runtime = runtime,
-                .databaseSize = getFolderSize(_options.databaseDirectory)};
+                .databaseSize = {}};
   velocypack::serialize(report.configBuilder, _options);
   report.config = report.configBuilder.slice();
   return report;

--- a/tests/sepp/Options.h
+++ b/tests/sepp/Options.h
@@ -90,6 +90,7 @@ inline auto inspect(Inspector& f, WorkloadVariants& o) {
 
 struct Options {
   std::string databaseDirectory;
+  bool clearDatabaseDirectory{true};
 
   Setup setup;
 
@@ -105,9 +106,11 @@ auto inspect(Inspector& f, Options& o) {
           .fallback(basics::FileUtils::buildFilename(
               TRI_GetTempPath(),
               "sepp-" + std::to_string(Thread::currentProcessId()))),
-      f.field("setup", o.setup),                           //
+      f.field("clearDatabaseDirectory", o.clearDatabaseDirectory)
+          .fallback(true),
+      f.field("setup", o.setup).fallback(f.keep()),        //
       f.field("workload", o.workload).fallback(f.keep()),  //
-      f.field("rocksdb", o.rocksdb));
+      f.field("rocksdb", o.rocksdb).fallback(f.keep()));
 }
 
 }  // namespace arangodb::sepp

--- a/tests/sepp/Runner.cpp
+++ b/tests/sepp/Runner.cpp
@@ -130,6 +130,9 @@ void Runner::writeReport(Report const& report) {
 }
 
 void Runner::startServer() {
+  if (_options.clearDatabaseDirectory) {
+    std::filesystem::remove_all(_options.databaseDirectory);
+  }
   _server =
       std::make_unique<Server>(_options.rocksdb, _options.databaseDirectory);
   _server->start(_executable.data());

--- a/tests/sepp/Server.cpp
+++ b/tests/sepp/Server.cpp
@@ -25,7 +25,6 @@
 
 #include <chrono>
 #include <cstdlib>
-#include <filesystem>
 #include <memory>
 #include <iostream>
 #include <stdexcept>
@@ -188,9 +187,6 @@ void Server::Impl::setupServer(std::string const& name, int& result) {
 }
 
 void Server::Impl::runServer(char const* exectuable) {
-  // TODO - make cleanup optional
-  std::filesystem::remove_all(_databaseDirectory);
-
   std::vector<std::string> args{exectuable, "--database.directory",
                                 _databaseDirectory, "--server.endpoint",
                                 "tcp://127.0.0.1:8530"};


### PR DESCRIPTION
### Scope & Purpose

Fix race when calculating the size of the db directory.
Also make clearing the db folder before startup optional.

- [x] :hankey: Bugfix
