### PR TITLE
Fix unstable test

### DIFF
--- a/tests/js/client/shell/shell-collection-counts-cluster.js
+++ b/tests/js/client/shell/shell-collection-counts-cluster.js
@@ -33,7 +33,7 @@ const jsunity = require('jsunity');
 const db = require("@arangodb").db;
 const request = require("@arangodb/request");
 const _ = require("lodash");
-const { deriveTestSuite, getEndpointById, getMetric } = require('@arangodb/test-helper');
+const { deriveTestSuite, getEndpointById, getMetric, waitForShardsInSync } = require('@arangodb/test-helper');
   
 const cn = "UnitTestsCollection";
 
@@ -103,6 +103,8 @@ function BaseTestConfig () {
       // which will eventually call the holdReadLockCollection API, which then
       // will call leaseManagedTrx and get the nullptr back
       c.properties({ replicationFactor: 2 });
+      
+      waitForShardsInSync(cn, 60); 
 
       // wait until we have an in-sync follower
       let tries = 0;
@@ -170,6 +172,8 @@ function BaseTestConfig () {
       clearFailurePoints([]);
 
       c.properties({ replicationFactor: 2 });
+      
+      waitForShardsInSync(cn, 60); 
 
       // wait until we have an in-sync follower
       let tries = 0;
@@ -226,6 +230,8 @@ function BaseTestConfig () {
       assertNotEqual(100, c.count());
 
       c.properties({ replicationFactor: 2 });
+      
+      waitForShardsInSync(cn, 60); 
 
       // wait until we have an in-sync follower
       let tries = 0;
@@ -289,6 +295,8 @@ function BaseTestConfig () {
       clearFailurePoints([]);
 
       c.properties({ replicationFactor: 2 });
+      
+      waitForShardsInSync(cn, 60); 
 
       // wait until we have an in-sync follower
       let tries = 0;
@@ -355,6 +363,8 @@ function BaseTestConfig () {
       clearFailurePoints([]);
 
       c.properties({ replicationFactor: 2 });
+      
+      waitForShardsInSync(cn, 60); 
 
       // wait until we have an in-sync follower
       let tries = 0;
@@ -421,6 +431,8 @@ function BaseTestConfig () {
       clearFailurePoints([]);
 
       c.properties({ replicationFactor: 3 });
+      
+      waitForShardsInSync(cn, 60); 
 
       // wait until we have an in-sync follower
       let tries = 0;
@@ -482,6 +494,8 @@ function BaseTestConfig () {
 
       c.properties({ replicationFactor: 3 });
 
+      waitForShardsInSync(cn, 60); 
+      
       // wait until we have an in-sync follower
       let tries = 0;
       while (tries++ < 120) {
@@ -552,6 +566,8 @@ function BaseTestConfig () {
       clearFailurePoints([]);
 
       c.properties({ replicationFactor: 3 });
+      
+      waitForShardsInSync(cn, 60); 
 
       // wait until we have an in-sync follower
       let tries = 0;
@@ -606,6 +622,8 @@ function BaseTestConfig () {
       });
 
       c.properties({ replicationFactor: 2 });
+      
+      waitForShardsInSync(cn, 60); 
 
       // wait until we have an in-sync follower
       let tries = 0;
@@ -660,6 +678,8 @@ function BaseTestConfig () {
       });
 
       c.properties({ replicationFactor: 2 });
+      
+      waitForShardsInSync(cn, 60); 
 
       // wait until we have an in-sync follower
       let tries = 0;
@@ -709,6 +729,8 @@ function BaseTestConfig () {
         c.insert({ _key: "test" + i }); 
       }
       
+      waitForShardsInSync(cn, 60); 
+      
       // wait until we have an in-sync follower
       let tries = 0;
       while (tries++ < 120) {
@@ -733,6 +755,8 @@ function BaseTestConfig () {
       assertEqual(101, c.toArray().length);
       
       clearFailurePoints([]);
+      
+      waitForShardsInSync(cn, 60); 
         
       // wait until we have an in-sync follower again
       tries = 0;
@@ -788,6 +812,8 @@ function BaseTestConfig () {
         c.insert({ _key: "test" + i }); 
       }
       
+      waitForShardsInSync(cn, 60); 
+      
       // wait until we have an in-sync follower
       let tries = 0;
       while (tries++ < 120) {
@@ -808,6 +834,8 @@ function BaseTestConfig () {
       assertEqual(101, c.toArray().length);
       
       clearFailurePoints([]);
+      
+      waitForShardsInSync(cn, 60); 
         
       // wait until we have an in-sync follower again
       tries = 0;
@@ -865,6 +893,8 @@ function BaseTestConfig () {
         c.insert({ _key: "test" + i }); 
       }
       
+      waitForShardsInSync(cn, 60); 
+      
       // wait until we have an in-sync follower
       let tries = 0;
       while (tries++ < 120) {
@@ -886,6 +916,8 @@ function BaseTestConfig () {
       assertEqual(101, c.count());
       
       clearFailurePoints([]);
+      
+      waitForShardsInSync(cn, 60); 
         
       // wait until we have an in-sync follower again
       tries = 0;
@@ -945,6 +977,8 @@ function BaseTestConfig () {
       for (let i = 0; i < 100; ++i) {
         c.insert({ _key: "test" + i }); 
       }
+      
+      waitForShardsInSync(cn, 60); 
       
       // wait until we have an in-sync follower
       let tries = 0;


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/16365
Some tests relied on shard data in the agency plan, but it was not guaranteed that shards were already present on followers after changing the replicationFactor. This led to spuriously failing test runs.
This is a test-only bugfix.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [x] Backports
  - [x] Backport for 3.9: this PR
  - [ ] Backport for 3.8: -
  - [ ] Backport for 3.7: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

