### PR TITLE
Fix initialization of _maxSubcompactions.

### DIFF
--- a/arangod/RocksDBEngine/RocksDBOptionFeature.cpp
+++ b/arangod/RocksDBEngine/RocksDBOptionFeature.cpp
@@ -618,9 +618,6 @@ void RocksDBOptionFeature::validateOptions(
     FATAL_ERROR_EXIT();
   }
 
-  if (_maxSubcompactions > _numThreadsLow) {
-    _maxSubcompactions = _numThreadsLow;
-  }
   _minWriteBufferNumberToMergeTouched = options->processingResult().touched(
       "--rocksdb.min-write-buffer-number-to-merge");
 
@@ -694,6 +691,18 @@ void RocksDBOptionFeature::start() {
   }
   if (_numThreadsLow == 0) {
     _numThreadsLow = clamped;
+  }
+
+  if (_maxSubcompactions > _numThreadsLow) {
+    if (server().options()->processingResult().touched(
+            "--rocksdb.max-subcompactions")) {
+      LOG_TOPIC("e7c85", WARN, Logger::ENGINES)
+          << "overriding value for option `--rocksdb.max-subcompactions` to "
+          << _numThreadsLow
+          << " because the specified value is greater than the number of "
+             "threads for low priority operations";
+    }
+    _maxSubcompactions = _numThreadsLow;
   }
 
   LOG_TOPIC("f66e4", TRACE, Logger::ROCKSDB)


### PR DESCRIPTION
### Scope & Purpose

We deliberately limit `_maxSubcompactions` by the number of threads for low priority operations ( `--rocksdb.num-threads-priority-low`). This number of threads is initialized to zero and if it is not specified, it is dynamically calculated.

However, the code to limit `_maxSubcompactions` to `_numThreadsLow` was executed _before_ that calculation was done, so unless the user explicitly set  `--rocksdb.num-threads-priority-low`, `_maxSubcompactions` was always set to zero.

- [x] :hankey: Bugfix

### Checklist

- [x] Tests
  - [x] manually tested