### PR TITLE
Added autoincrement key generation for cluster with one shard and test

### DIFF
--- a/arangod/VocBase/KeyGenerator.cpp
+++ b/arangod/VocBase/KeyGenerator.cpp
@@ -723,10 +723,12 @@ std::unordered_map<
     {static_cast<GeneratorMapType>(GeneratorType::AUTOINCREMENT),
      [](LogicalCollection const& collection,
         VPackSlice options) -> std::unique_ptr<KeyGenerator> {
-       if (ServerState::instance()->isCoordinator()) {
-         THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_CLUSTER_UNSUPPORTED,
-                                        "the specified key generator is not "
-                                        "supported for sharded collections");
+       if (collection.numberOfShards() > 1) {
+         //   if (ServerState::instance()->isCoordinator()) {
+         THROW_ARANGO_EXCEPTION_MESSAGE(
+             TRI_ERROR_CLUSTER_UNSUPPORTED,
+             "the specified key generator is not "
+             "supported for collections with more than one shard");
        }
 
        uint64_t offset = 0;
@@ -956,11 +958,13 @@ std::unique_ptr<KeyGenerator> KeyGeneratorHelper::createKeyGenerator(
 }
 
 #ifndef USE_ENTERPRISE
+
 std::unique_ptr<KeyGenerator> KeyGeneratorHelper::createEnterpriseKeyGenerator(
     std::unique_ptr<KeyGenerator> generator) {
   // nothing to be done here
   return generator;
 }
+
 #endif
 
 /// @brief create the key generator


### PR DESCRIPTION
### Scope & Purpose

This PR adds key generation of type "autoincrement" for cluster mode, but only if the collection is single shard. 
Obs.: To be edited
- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [x] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [x] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  No backports required.

#### Related Information

- [ ] Docs PR: to be added here
- [ ] Enterprise PR:
- [x] GitHub issue / Jira ticket: related to https://arangodb.atlassian.net/browse/ES-1092?atlOrigin=eyJpIjoiYjEzZTY2ZGExNzhhNDhhMmE3YjJmYTYzZDNhYTQ0YTQiLCJwIjoiaiJ9
- [ ] Design document: 

