### PR TITLE
allow parallel access to the shards of smart edge collections in AQL

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 devel
 -----
 
+* Allow parallel access to the shards of smart edge collections in AQL via 
+  parallel GatherNodes.
+
 * Updated arangosync to v2.10.0.
 
 * Added several startup option to configure parallelism for individual Pregel 

--- a/arangod/Aql/ClusterNodes.cpp
+++ b/arangod/Aql/ClusterNodes.cpp
@@ -574,10 +574,9 @@ GatherNode::Parallelism GatherNode::evaluateParallelism(
   // single-sharded collections don't require any parallelism. collections with
   // more than one shard are eligible for later parallelization (the Undefined
   // allows this)
-  return (((collection.isSmart() && collection.type() == TRI_COL_TYPE_EDGE) ||
-           (collection.numberOfShards() <= 1 && !collection.isSatellite()))
-              ? Parallelism::Serial
-              : Parallelism::Undefined);
+  return (collection.numberOfShards() == 1 || collection.isSatellite())
+             ? Parallelism::Serial
+             : Parallelism::Undefined;
 }
 
 void GatherNode::replaceVariables(


### PR DESCRIPTION
### Scope & Purpose

Allow parallel access to the shards of smart edge collections in AQL via parallel GatherNodes.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [x] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -
  - [ ] Backport for 3.7: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 