### PR TITLE
change RocksDB internal table checksum type to xxHash64

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 devel
 -----
 
+* Update RocksDB internal table checksum type to xxHash64.
+
 * Updated arangosync to v2.10.0.
 
 * Added several startup option to configure parallelism for individual Pregel 

--- a/arangod/RocksDBEngine/RocksDBOptionFeature.cpp
+++ b/arangod/RocksDBEngine/RocksDBOptionFeature.cpp
@@ -167,7 +167,7 @@ RocksDBOptionFeature::RocksDBOptionFeature(Server& server)
       _level0StopTrigger(256),
       _pendingCompactionBytesSlowdownTrigger(128 * 1024ull),
       _pendingCompactionBytesStopTrigger(16 * 1073741824ull),
-      _checksumType("crc32c"),
+      _checksumType("xxHash64"),
       _formatVersion(3),
       _enableIndexCompression(
           rocksDBTableOptionsDefaults.enable_index_compression),


### PR DESCRIPTION
### Scope & Purpose

Change RocksDB internal table checksum type to xxHash64.
This has shown to slightly improve performance (around 2%) in insert-only tests.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [x] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -
  - [ ] Backport for 3.7: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 