### PR TITLE
[CNFRA-414] Add CoreParameterType to Replicated States

### DIFF
--- a/arangod/Cluster/ClusterInfo.h
+++ b/arangod/Cluster/ClusterInfo.h
@@ -1097,9 +1097,9 @@ class ClusterInfo final {
   /// @brief a replicated state is created for each shard, only when using
   /// Replication2
   //////////////////////////////////////////////////////////////////////////////
-  static auto createReplicatedStateSpec(
-      std::string const& shardId, std::vector<std::string> const& serverIds,
-      std::size_t writeConcern, std::size_t softWriteConcern)
+  static auto createDocumentStateSpec(std::string const& shardId,
+                                      std::vector<std::string> const& serverIds,
+                                      ClusterCollectionCreationInfo const& info)
       -> replication2::replicated_state::agency::Target;
 
   //////////////////////////////////////////////////////////////////////////////

--- a/arangod/Replication2/ReplicatedState/AgencySpecification.cpp
+++ b/arangod/Replication2/ReplicatedState/AgencySpecification.cpp
@@ -24,6 +24,7 @@
 #include "AgencySpecification.h"
 #include "Basics/Exceptions.h"
 #include "Basics/StaticStrings.h"
+#include "Basics/VelocyPackHelper.h"
 #include "Basics/debugging.h"
 #include "Basics/voc-errors.h"
 #include "velocypack/Builder.h"
@@ -80,4 +81,16 @@ auto replicated_state::agency::to_string(StatusCode code) noexcept
     default:
       return "(unknown status code)";
   }
+}
+
+auto replicated_state::agency::operator==(ImplementationSpec const& s,
+                                          ImplementationSpec const& s2) noexcept
+    -> bool {
+  if (s.type != s2.type ||
+      s.parameters.has_value() != s2.parameters.has_value()) {
+    return false;
+  }
+  return !s.parameters.has_value() ||
+         basics::VelocyPackHelper::equal(s.parameters->slice(),
+                                         s2.parameters->slice(), true);
 }

--- a/arangod/Replication2/ReplicatedState/AgencySpecification.h
+++ b/arangod/Replication2/ReplicatedState/AgencySpecification.h
@@ -50,15 +50,20 @@ auto const String_Generation = velocypack::StringRef{"generation"};
 
 struct ImplementationSpec {
   std::string type;
+  std::optional<velocypack::SharedSlice> parameters;
 
   friend auto operator==(ImplementationSpec const& s,
-                         ImplementationSpec const& s2) noexcept
-      -> bool = default;
+                         ImplementationSpec const& s2) noexcept -> bool;
 };
+
+auto operator==(ImplementationSpec const& s,
+                ImplementationSpec const& s2) noexcept -> bool;
 
 template<class Inspector>
 auto inspect(Inspector& f, ImplementationSpec& x) {
-  return f.object(x).fields(f.field(StaticStrings::IndexType, x.type));
+  return f.object(x).fields(
+      f.field(StaticStrings::IndexType, x.type),
+      f.field(StaticStrings::DataSourceParameters, x.parameters));
 }
 
 struct Properties {

--- a/arangod/Replication2/ReplicatedState/ReplicatedState.h
+++ b/arangod/Replication2/ReplicatedState/ReplicatedState.h
@@ -65,7 +65,9 @@ struct ReplicatedStateBase {
   virtual ~ReplicatedStateBase() = default;
 
   virtual void flush(StateGeneration plannedGeneration) = 0;
-  virtual void start(std::unique_ptr<ReplicatedStateToken> token) = 0;
+  virtual void start(
+      std::unique_ptr<ReplicatedStateToken> token,
+      std::optional<velocypack::SharedSlice> const& coreParameter) = 0;
   virtual void forceRebuild() = 0;
   [[nodiscard]] virtual auto getStatus() -> std::optional<StateStatus> = 0;
   [[nodiscard]] auto getLeader()
@@ -102,7 +104,9 @@ struct ReplicatedState final
    * Forces to rebuild the state machine depending on the replicated log state.
    */
   void flush(StateGeneration planGeneration) override;
-  void start(std::unique_ptr<ReplicatedStateToken> token) override;
+  void start(
+      std::unique_ptr<ReplicatedStateToken> token,
+      std::optional<velocypack::SharedSlice> const& coreParameter) override;
 
   /**
    * Returns the follower state machine. Returns nullptr if no follower state

--- a/arangod/Replication2/ReplicatedState/ReplicatedState.tpp
+++ b/arangod/Replication2/ReplicatedState/ReplicatedState.tpp
@@ -153,8 +153,27 @@ void ReplicatedState<S>::forceRebuild() {
 }
 
 template<typename S>
-void ReplicatedState<S>::start(std::unique_ptr<ReplicatedStateToken> token) {
-  auto core = factory->constructCore(log->getGlobalLogId());
+void ReplicatedState<S>::start(
+    std::unique_ptr<ReplicatedStateToken> token,
+    std::optional<velocypack::SharedSlice> const& coreParameter) {
+  auto core = std::invoke([&]() {
+    if constexpr (std::is_void_v<typename S::CoreParameterType>) {
+      return factory->constructCore(log->getGlobalLogId());
+    } else {
+      if (!coreParameter.has_value()) {
+        auto const& gid = log->getGlobalLogId();
+        THROW_ARANGO_EXCEPTION_MESSAGE(
+            TRI_ERROR_BAD_PARAMETER,
+            fmt::format("Cannot find core parameter for replicated state with "
+                        "ID {}, created in database {}",
+                        gid.id, gid.database));
+      }
+      auto params = velocypack::deserialize<typename S::CoreParameterType>(
+          coreParameter->slice());
+      return factory->constructCore(log->getGlobalLogId(), std::move(params));
+    }
+  });
+
   auto deferred =
       guardedData.getLockedGuard()->rebuild(std::move(core), std::move(token));
   // execute *after* the lock has been released

--- a/arangod/Replication2/ReplicatedState/UpdateReplicatedState.cpp
+++ b/arangod/Replication2/ReplicatedState/UpdateReplicatedState.cpp
@@ -90,7 +90,7 @@ auto algorithms::updateReplicatedState(
       return std::make_unique<ReplicatedStateToken>(expectedGeneration);
     });
     // now start the replicated state
-    state->start(std::move(token));
+    state->start(std::move(token), spec->properties.implementation.parameters);
     return {TRI_ERROR_NO_ERROR};
   } else {
     auto status = state->getStatus();

--- a/arangod/Replication2/StateMachines/BlackHole/BlackHoleStateMachine.h
+++ b/arangod/Replication2/StateMachines/BlackHole/BlackHoleStateMachine.h
@@ -45,6 +45,7 @@ struct BlackHoleState {
   using EntryType = BlackHoleLogEntry;
   using FactoryType = BlackHoleFactory;
   using CoreType = BlackHoleCore;
+  using CoreParameterType = void;
 };
 
 struct BlackHoleLogEntry {

--- a/arangod/Replication2/StateMachines/Document/DocumentStateMachine.cpp
+++ b/arangod/Replication2/StateMachines/Document/DocumentStateMachine.cpp
@@ -28,6 +28,12 @@
 
 using namespace arangodb::replication2::replicated_state::document;
 
+auto DocumentCoreParameters::toSharedSlice() -> velocypack::SharedSlice {
+  VPackBuilder builder;
+  velocypack::serialize(builder, *this);
+  return builder.sharedSlice();
+}
+
 DocumentLeaderState::DocumentLeaderState(std::unique_ptr<DocumentCore> core)
     : _core(std::move(core)){};
 
@@ -70,7 +76,8 @@ auto DocumentFactory::constructLeader(std::unique_ptr<DocumentCore> core)
   return std::make_shared<DocumentLeaderState>(std::move(core));
 }
 
-auto DocumentFactory::constructCore(GlobalLogIdentifier const& gid)
+auto DocumentFactory::constructCore(GlobalLogIdentifier const& gid,
+                                    DocumentCoreParameters)
     -> std::unique_ptr<DocumentCore> {
   return std::make_unique<DocumentCore>();
 }

--- a/arangod/Replication2/StateMachines/Document/DocumentStateMachine.h
+++ b/arangod/Replication2/StateMachines/Document/DocumentStateMachine.h
@@ -39,18 +39,33 @@ struct DocumentLogEntry;
 struct DocumentLeaderState;
 struct DocumentFollowerState;
 struct DocumentCore;
+struct DocumentCoreParameters;
 
 struct DocumentState {
+  static constexpr std::string_view NAME = "document";
+
   using LeaderType = DocumentLeaderState;
   using FollowerType = DocumentFollowerState;
   using EntryType = DocumentLogEntry;
   using FactoryType = DocumentFactory;
   using CoreType = DocumentCore;
+  using CoreParameterType = DocumentCoreParameters;
 };
 
 /* Empty for now */
 struct DocumentLogEntry {};
 struct DocumentCore {};
+
+struct DocumentCoreParameters {
+  std::string collectionId;
+
+  template<class Inspector>
+  inline friend auto inspect(Inspector& f, DocumentCoreParameters& p) {
+    return f.object(p).fields(f.field("collectionId", p.collectionId));
+  }
+
+  auto toSharedSlice() -> velocypack::SharedSlice;
+};
 
 struct DocumentLeaderState
     : replicated_state::IReplicatedLeaderState<DocumentState> {
@@ -85,7 +100,7 @@ struct DocumentFactory {
       -> std::shared_ptr<DocumentFollowerState>;
   auto constructLeader(std::unique_ptr<DocumentCore> core)
       -> std::shared_ptr<DocumentLeaderState>;
-  auto constructCore(GlobalLogIdentifier const&)
+  auto constructCore(GlobalLogIdentifier const&, DocumentCoreParameters)
       -> std::unique_ptr<DocumentCore>;
 };
 }  // namespace document

--- a/arangod/Replication2/StateMachines/Document/DocumentStateMachineFeature.cpp
+++ b/arangod/Replication2/StateMachines/Document/DocumentStateMachineFeature.cpp
@@ -30,7 +30,7 @@ using namespace arangodb::replication2::replicated_state::document;
 
 void DocumentStateMachineFeature::start() {
   auto& feature = server().getFeature<ReplicatedStateAppFeature>();
-  feature.registerStateType<DocumentState>("document");
+  feature.registerStateType<DocumentState>(std::string{DocumentState::NAME});
 }
 
 DocumentStateMachineFeature::DocumentStateMachineFeature(Server& server)

--- a/arangod/Replication2/StateMachines/Prototype/PrototypeStateMachine.h
+++ b/arangod/Replication2/StateMachines/Prototype/PrototypeStateMachine.h
@@ -58,6 +58,7 @@ struct PrototypeState {
   using EntryType = PrototypeLogEntry;
   using FactoryType = PrototypeFactory;
   using CoreType = PrototypeCore;
+  using CoreParameterType = void;
 };
 
 struct IPrototypeLeaderInterface {

--- a/lib/Inspection/VPackLoadInspector.h
+++ b/lib/Inspection/VPackLoadInspector.h
@@ -112,6 +112,14 @@ struct VPackLoadInspectorImpl
     return {};
   }
 
+  [[nodiscard]] Status::Success value(velocypack::SharedSlice& v) {
+    // TODO - fix SharedSlice to use uint8_t[]
+    auto p = new uint8_t[_slice.byteSize()];
+    std::memcpy(p, _slice.start(), _slice.byteSize());
+    v = velocypack::SharedSlice{std::shared_ptr<uint8_t const>(p)};
+    return {};
+  }
+
   [[nodiscard]] Status value(bool& v) {
     if (!_slice.isBool()) {
       return {"Expecting type Bool"};

--- a/lib/Inspection/VPackSaveInspector.h
+++ b/lib/Inspection/VPackSaveInspector.h
@@ -65,6 +65,11 @@ struct VPackSaveInspector : InspectorBase<VPackSaveInspector> {
     return {};
   }
 
+  [[nodiscard]] Status::Success value(velocypack::SharedSlice s) {
+    _builder.add(s.slice());
+    return {};
+  }
+
   [[nodiscard]] Status::Success value(velocypack::HashedStringRef const& s) {
     _builder.add(VPackValue(s.stringView()));
     return {};

--- a/lib/Inspection/detail/traits.h
+++ b/lib/Inspection/detail/traits.h
@@ -27,6 +27,7 @@
 #include <type_traits>
 
 #include <velocypack/HashedStringRef.h>
+#include <velocypack/SharedSlice.h>
 #include <velocypack/Slice.h>
 
 #include "Inspection/Status.h"
@@ -58,7 +59,8 @@ template<class T>
 constexpr inline bool IsSafeBuiltinType() {
   return std::is_same_v<T, bool> || std::is_integral_v<T> ||
          std::is_floating_point_v<T> ||
-         std::is_same_v<T, std::string>;  // TODO - use is-string-like?
+         std::is_same_v<T, std::string> ||  // TODO - use is-string-like?
+         std::is_same_v<T, arangodb::velocypack::SharedSlice>;
 }
 
 template<class T>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -348,6 +348,7 @@ set(ARANGODB_REPLICATION2_TEST_SOURCES
   Replication2/ReplicatedState/FollowerWaitForTest.cpp
   Replication2/ReplicatedState/LeaderRecoveryTest.cpp
   Replication2/ReplicatedState/MaintenanceTest.cpp
+  Replication2/ReplicatedState/DocumentStateMachineTest.cpp
   Replication2/ReplicatedState/PrototypeConcurrencyTest.cpp
   Replication2/ReplicatedState/PrototypeStateMachineTest.cpp
   Replication2/ReplicatedState/ReplicatedStateFeatureTest.cpp

--- a/tests/Replication2/ReplicatedState/DocumentStateMachineTest.cpp
+++ b/tests/Replication2/ReplicatedState/DocumentStateMachineTest.cpp
@@ -1,0 +1,81 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2021-2021 ArangoDB GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Alexandru Petenchea
+////////////////////////////////////////////////////////////////////////////////
+
+#include <gtest/gtest.h>
+
+#include "Replication2/ReplicatedLog/TestHelper.h"
+
+#include "Replication2/ReplicatedState/ReplicatedState.h"
+#include "Replication2/ReplicatedState/ReplicatedStateFeature.h"
+
+#include "Replication2/StateMachines/Document/DocumentStateMachine.h"
+
+using namespace arangodb;
+using namespace arangodb::replication2;
+using namespace arangodb::replication2::replicated_state;
+using namespace arangodb::replication2::replicated_state::document;
+using namespace arangodb::replication2::test;
+
+#include "Replication2/ReplicatedState/ReplicatedState.tpp"
+
+struct DocumentStateMachineTest : test::ReplicatedLogTest {
+  DocumentStateMachineTest() {
+    feature->registerStateType<DocumentState>(std::string{DocumentState::NAME});
+  }
+
+  std::shared_ptr<ReplicatedStateFeature> feature =
+      std::make_shared<ReplicatedStateFeature>();
+};
+
+TEST_F(DocumentStateMachineTest, simple_operations) {
+  auto followerLog = makeReplicatedLog(LogId{1});
+  auto follower = followerLog->becomeFollower("follower", LogTerm{1}, "leader");
+
+  auto leaderLog = makeReplicatedLog(LogId{1});
+  auto leader = leaderLog->becomeLeader("leader", LogTerm{1}, {follower}, 2);
+
+  leader->triggerAsyncReplication();
+
+  auto parameters =
+      document::DocumentCoreParameters{"testCollectionID"}.toSharedSlice();
+
+  auto leaderReplicatedState =
+      std::dynamic_pointer_cast<ReplicatedState<DocumentState>>(
+          feature->createReplicatedState(DocumentState::NAME, leaderLog));
+  ASSERT_NE(leaderReplicatedState, nullptr);
+  leaderReplicatedState->start(
+      std::make_unique<ReplicatedStateToken>(StateGeneration{1}), parameters);
+  follower->runAllAsyncAppendEntries();
+
+  auto leaderState = leaderReplicatedState->getLeader();
+  ASSERT_NE(leaderState, nullptr);
+
+  auto followerReplicatedState =
+      std::dynamic_pointer_cast<ReplicatedState<DocumentState>>(
+          feature->createReplicatedState(DocumentState::NAME, followerLog));
+  ASSERT_NE(followerReplicatedState, nullptr);
+  followerReplicatedState->start(
+      std::make_unique<ReplicatedStateToken>(StateGeneration{1}), parameters);
+
+  auto followerState = followerReplicatedState->getFollower();
+  ASSERT_NE(followerState, nullptr);
+}

--- a/tests/Replication2/ReplicatedState/FollowerSnapshotTest.cpp
+++ b/tests/Replication2/ReplicatedState/FollowerSnapshotTest.cpp
@@ -48,6 +48,7 @@ struct FollowerSnapshotTest
     using EntryType = test::DefaultEntryType;
     using FactoryType = test::RecordingFactory<LeaderType, FollowerType>;
     using CoreType = test::TestCoreType;
+    using CoreParameterType = void;
   };
 
   std::shared_ptr<State::FactoryType> factory =

--- a/tests/Replication2/ReplicatedState/LeaderRecoveryTest.cpp
+++ b/tests/Replication2/ReplicatedState/LeaderRecoveryTest.cpp
@@ -50,6 +50,7 @@ struct MyHelperState {
   using EntryType = MyEntryType;
   using FollowerType = EmptyFollowerType<MyHelperState>;
   using CoreType = MyCoreType;
+  using CoreParameterType = void;
 };
 
 struct MyHelperLeaderState : IReplicatedLeaderState<MyHelperState> {
@@ -137,7 +138,7 @@ TEST_F(ReplicatedStateRecoveryTest, trigger_recovery) {
   ASSERT_EQ(leaderState, nullptr);
 
   replicatedState->start(
-      std::make_unique<ReplicatedStateToken>(StateGeneration{1}));
+      std::make_unique<ReplicatedStateToken>(StateGeneration{1}), std::nullopt);
 
   {
     auto status = replicatedState->getStatus().value();
@@ -215,7 +216,7 @@ TEST_F(ReplicatedStateRecoveryTest, trigger_recovery_error_DeathTest) {
   ASSERT_EQ(leaderState, nullptr);
 
   replicatedState->start(
-      std::make_unique<ReplicatedStateToken>(StateGeneration{1}));
+      std::make_unique<ReplicatedStateToken>(StateGeneration{1}), std::nullopt);
 
   {
     auto status = replicatedState->getStatus().value();

--- a/tests/Replication2/ReplicatedState/PrototypeConcurrencyTest.cpp
+++ b/tests/Replication2/ReplicatedState/PrototypeConcurrencyTest.cpp
@@ -105,7 +105,8 @@ struct PrototypeConcurrencyTest : test::ReplicatedLogTest {
     auto replicatedState =
         feature->createReplicatedState("prototype-state", leaderLog);
     replicatedState->start(
-        std::make_unique<ReplicatedStateToken>(StateGeneration{1}));
+        std::make_unique<ReplicatedStateToken>(StateGeneration{1}),
+        std::nullopt);
     leaderState = std::dynamic_pointer_cast<PrototypeLeaderState>(
         replicatedState->getLeader());
     TRI_ASSERT(leaderState != nullptr);
@@ -114,7 +115,8 @@ struct PrototypeConcurrencyTest : test::ReplicatedLogTest {
     replicatedState =
         feature->createReplicatedState("prototype-state", followerLog);
     replicatedState->start(
-        std::make_unique<ReplicatedStateToken>(StateGeneration{1}));
+        std::make_unique<ReplicatedStateToken>(StateGeneration{1}),
+        std::nullopt);
     followerState = std::dynamic_pointer_cast<PrototypeFollowerState>(
         replicatedState->getFollower());
   }

--- a/tests/Replication2/ReplicatedState/PrototypeStateMachineTest.cpp
+++ b/tests/Replication2/ReplicatedState/PrototypeStateMachineTest.cpp
@@ -140,7 +140,7 @@ TEST_F(PrototypeStateMachineTest, prototype_core_flush) {
           feature->createReplicatedState("prototype-state", leaderLog));
   ASSERT_NE(leaderReplicatedState, nullptr);
   leaderReplicatedState->start(
-      std::make_unique<ReplicatedStateToken>(StateGeneration{1}));
+      std::make_unique<ReplicatedStateToken>(StateGeneration{1}), std::nullopt);
   follower->runAllAsyncAppendEntries();
 
   auto leaderState = leaderReplicatedState->getLeader();
@@ -152,7 +152,7 @@ TEST_F(PrototypeStateMachineTest, prototype_core_flush) {
           feature->createReplicatedState("prototype-state", followerLog));
   ASSERT_NE(followerReplicatedState, nullptr);
   followerReplicatedState->start(
-      std::make_unique<ReplicatedStateToken>(StateGeneration{1}));
+      std::make_unique<ReplicatedStateToken>(StateGeneration{1}), std::nullopt);
 
   auto followerState = followerReplicatedState->getFollower();
   ASSERT_NE(followerState, nullptr);
@@ -198,7 +198,7 @@ TEST_F(PrototypeStateMachineTest, simple_operations) {
           feature->createReplicatedState("prototype-state", leaderLog));
   ASSERT_NE(leaderReplicatedState, nullptr);
   leaderReplicatedState->start(
-      std::make_unique<ReplicatedStateToken>(StateGeneration{1}));
+      std::make_unique<ReplicatedStateToken>(StateGeneration{1}), std::nullopt);
   follower->runAllAsyncAppendEntries();
 
   auto leaderState = leaderReplicatedState->getLeader();
@@ -210,7 +210,7 @@ TEST_F(PrototypeStateMachineTest, simple_operations) {
           feature->createReplicatedState("prototype-state", followerLog));
   ASSERT_NE(followerReplicatedState, nullptr);
   followerReplicatedState->start(
-      std::make_unique<ReplicatedStateToken>(StateGeneration{1}));
+      std::make_unique<ReplicatedStateToken>(StateGeneration{1}), std::nullopt);
 
   auto followerState = followerReplicatedState->getFollower();
   ASSERT_NE(followerState, nullptr);
@@ -353,7 +353,7 @@ TEST_F(PrototypeStateMachineTest, snapshot_transfer) {
           feature->createReplicatedState("prototype-state", leaderLog));
   ASSERT_NE(leaderReplicatedState, nullptr);
   leaderReplicatedState->start(
-      std::make_unique<ReplicatedStateToken>(StateGeneration{1}));
+      std::make_unique<ReplicatedStateToken>(StateGeneration{1}), std::nullopt);
   follower->runAllAsyncAppendEntries();
 
   auto leaderState = leaderReplicatedState->getLeader();
@@ -365,7 +365,7 @@ TEST_F(PrototypeStateMachineTest, snapshot_transfer) {
           feature->createReplicatedState("prototype-state", followerLog));
   ASSERT_NE(followerReplicatedState, nullptr);
   followerReplicatedState->start(
-      std::make_unique<ReplicatedStateToken>(StateGeneration{1}));
+      std::make_unique<ReplicatedStateToken>(StateGeneration{1}), std::nullopt);
 
   auto followerState = followerReplicatedState->getFollower();
   ASSERT_NE(followerState, nullptr);

--- a/tests/Replication2/ReplicatedState/ReplicatedStateTest.cpp
+++ b/tests/Replication2/ReplicatedState/ReplicatedStateTest.cpp
@@ -50,7 +50,8 @@ TEST_F(ReplicatedStateTest, simple_become_follower_test) {
       feature->createReplicatedState("my-state", log));
   ASSERT_NE(state, nullptr);
 
-  state->start(std::make_unique<ReplicatedStateToken>(StateGeneration{1}));
+  state->start(std::make_unique<ReplicatedStateToken>(StateGeneration{1}),
+               std::nullopt);
 
   auto leaderLog = makeReplicatedLog(LogId{1});
   auto leader = leaderLog->becomeLeader("leader", LogTerm{1}, {follower}, 2);
@@ -79,7 +80,8 @@ TEST_F(ReplicatedStateTest, simple_unconfigured_log_test) {
   ASSERT_NE(state, nullptr);
 
   auto const stateGeneration = StateGeneration{1};
-  state->start(std::make_unique<ReplicatedStateToken>(stateGeneration));
+  state->start(std::make_unique<ReplicatedStateToken>(stateGeneration),
+               std::nullopt);
 
   auto status = state->getStatus();
 
@@ -102,7 +104,8 @@ TEST_F(ReplicatedStateTest, unconfigured_log_becomes_leader_test) {
   ASSERT_NE(state, nullptr);
 
   auto const stateGeneration = StateGeneration{1};
-  state->start(std::make_unique<ReplicatedStateToken>(stateGeneration));
+  state->start(std::make_unique<ReplicatedStateToken>(stateGeneration),
+               std::nullopt);
 
   {  // check the unconfigured state
     auto status = state->getStatus();
@@ -158,7 +161,8 @@ TEST_F(ReplicatedStateTest, unconfigured_log_becomes_follower_test) {
   ASSERT_NE(state, nullptr);
 
   auto const stateGeneration = StateGeneration{1};
-  state->start(std::make_unique<ReplicatedStateToken>(stateGeneration));
+  state->start(std::make_unique<ReplicatedStateToken>(stateGeneration),
+               std::nullopt);
 
   {  // check the unconfigured state
     auto status = state->getStatus();
@@ -220,7 +224,8 @@ TEST_F(ReplicatedStateTest, recreate_follower_on_new_term) {
   auto inputStream = mux->getStreamById<1>();
   inputStream->insert({.key = "hello", .value = "world"});
 
-  state->start(std::make_unique<ReplicatedStateToken>(StateGeneration{1}));
+  state->start(std::make_unique<ReplicatedStateToken>(StateGeneration{1}),
+               std::nullopt);
 
   // recreate follower
   follower = log->becomeFollower("follower", LogTerm{2}, "leader");
@@ -252,7 +257,8 @@ TEST_F(ReplicatedStateTest, simple_become_leader_test) {
   auto state = std::dynamic_pointer_cast<ReplicatedState<MyState>>(
       feature->createReplicatedState("my-state", log));
   ASSERT_NE(state, nullptr);
-  state->start(std::make_unique<ReplicatedStateToken>(StateGeneration{1}));
+  state->start(std::make_unique<ReplicatedStateToken>(StateGeneration{1}),
+               std::nullopt);
   {
     auto status = state->getStatus().value();
     ASSERT_TRUE(
@@ -290,7 +296,8 @@ TEST_F(ReplicatedStateTest, simple_become_leader_recovery_test) {
         feature->createReplicatedState("my-state", log));
     ASSERT_NE(state, nullptr);
 
-    state->start(std::make_unique<ReplicatedStateToken>(StateGeneration{1}));
+    state->start(std::make_unique<ReplicatedStateToken>(StateGeneration{1}),
+                 std::nullopt);
     {
       auto status = state->getStatus().value();
       ASSERT_TRUE(std::holds_alternative<replicated_state::FollowerStatus>(
@@ -331,7 +338,8 @@ TEST_F(ReplicatedStateTest, simple_become_leader_recovery_test) {
         feature->createReplicatedState("my-state", log));
     ASSERT_NE(state, nullptr);
 
-    state->start(std::make_unique<ReplicatedStateToken>(StateGeneration{1}));
+    state->start(std::make_unique<ReplicatedStateToken>(StateGeneration{1}),
+                 std::nullopt);
     while (follower->hasPendingAppendEntries()) {
       follower->runAsyncAppendEntries();
     }
@@ -365,13 +373,13 @@ TEST_F(ReplicatedStateTest, stream_test) {
 
   auto leaderState = std::dynamic_pointer_cast<ReplicatedState<MyState>>(
       feature->createReplicatedState("my-state", leaderLog));
-  leaderState->start(
-      std::make_unique<ReplicatedStateToken>(StateGeneration{1}));
+  leaderState->start(std::make_unique<ReplicatedStateToken>(StateGeneration{1}),
+                     std::nullopt);
 
   auto followerState = std::dynamic_pointer_cast<ReplicatedState<MyState>>(
       feature->createReplicatedState("my-state", followerLog));
   followerState->start(
-      std::make_unique<ReplicatedStateToken>(StateGeneration{1}));
+      std::make_unique<ReplicatedStateToken>(StateGeneration{1}), std::nullopt);
 
   // make sure we do recovery
   while (follower->hasPendingAppendEntries()) {

--- a/tests/Replication2/ReplicatedState/StateMachines/MyStateMachine.h
+++ b/tests/Replication2/ReplicatedState/StateMachines/MyStateMachine.h
@@ -41,6 +41,7 @@ struct MyState {
   using EntryType = MyEntryType;
   using FactoryType = MyFactory;
   using CoreType = MyCoreType;
+  using CoreParameterType = void;
 };
 
 struct MyEntryType {


### PR DESCRIPTION
### Scope & Purpose

This PR adds a new `parameters` field to the `properties/implementation` object, used by replicated states in `Target` and `Plan`. This field is supposed to hold generic velocypack data, which is then serialized and de-serialized accordingly by the replicated state. The presence of this field is optional, hence only the `DocumentState` is using it so far to store the ID of a collection. If not `nullopt`, it is passed to the core during its creation.
The corresponding `CoreParameterType` of the `DocumentState` is `DocumentCoreParameters`. All other replicated states have `CoreParemeterType=void`.
A basic unit tests has been added for `DocumentState`, just to make sure there are no errors. The document-store JS tests also cover these changes.

On the side, we have added serialization and de-serialization support for `SharedSlice`.

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [x] **Regression tests**
  - [x] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*
  - [ ] Backport for 3.7: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

