### PR TITLE
[CINFRA-415] Core Parameter Type

### DIFF
--- a/arangod/Replication2/ReplicatedState/ReplicatedState.tpp
+++ b/arangod/Replication2/ReplicatedState/ReplicatedState.tpp
@@ -165,8 +165,8 @@ void ReplicatedState<S>::start(
         THROW_ARANGO_EXCEPTION_MESSAGE(
             TRI_ERROR_BAD_PARAMETER,
             fmt::format("Cannot find core parameter for replicated state with "
-                        "ID {}, created in database {}",
-                        gid.id, gid.database));
+                        "ID {}, created in database {}, for {} state",
+                        gid.id, gid.database, S::NAME));
       }
       auto params = velocypack::deserialize<typename S::CoreParameterType>(
           coreParameter->slice());

--- a/lib/Inspection/VPackLoadInspector.h
+++ b/lib/Inspection/VPackLoadInspector.h
@@ -114,9 +114,7 @@ struct VPackLoadInspectorImpl
 
   [[nodiscard]] Status::Success value(velocypack::SharedSlice& v) {
     // TODO - fix SharedSlice to use uint8_t[]
-    auto p = new uint8_t[_slice.byteSize()];
-    std::memcpy(p, _slice.start(), _slice.byteSize());
-    v = velocypack::SharedSlice{std::shared_ptr<uint8_t const>(p)};
+    v = VPackBuilder{_slice}.sharedSlice();
     return {};
   }
 

--- a/tests/Replication2/ReplicatedState/FollowerWaitForTest.cpp
+++ b/tests/Replication2/ReplicatedState/FollowerWaitForTest.cpp
@@ -48,6 +48,7 @@ struct FollowerWaitForAppliedTest
     using EntryType = test::DefaultEntryType;
     using FactoryType = test::RecordingFactory<LeaderType, FollowerType>;
     using CoreType = test::TestCoreType;
+    using CoreParameterType = void;
   };
 
   std::shared_ptr<State::FactoryType> factory =


### PR DESCRIPTION
### Scope & Purpose

We had various issues caused by the `CoreParameterType`, introduced for replicated states. When compiled with `gcc-10` on Linux, DB servers used to crash with `SIGSEGV`. I can't really explain why, just that it had to do with the velocypack deserialization. This PR fixes that, along with a change requires for `MSVC`.

Jenkins: https://jenkins.arangodb.biz:3456/view/PR/job/arangodb-matrix-pr/21899/

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*
  - [ ] Backport for 3.7: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

