### PR TITLE
Bug fix 3.9/remove deletion after bts 750

### DIFF
--- a/js/server/modules/@arangodb/testutils/collection-modification-aql-generic-tests.js
+++ b/js/server/modules/@arangodb/testutils/collection-modification-aql-generic-tests.js
@@ -98,8 +98,6 @@ const generateTestSuite = (collectionWrapper, testNamePostfix = "") => {
       // Locally apply the patch from before
       let updatedDoc = {...doc, ...patch};
 
-      // TODO: Remove me after BTS-750 is resolved
-      delete updatedDoc._key;
       const replace = {test2: "testmann2"};
       for (const [key, value] of Object.entries(replace)) {
         // Just make sure we are actually updating something here.


### PR DESCRIPTION
### Scope & Purpose

This is a backport to https://github.com/arangodb/arangodb/pull/16383, which removes a deletion that was requested to be removed after BTS-750 was merged.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification


#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [x] GitHub issue / Jira ticket: not it, but related to https://arangodb.atlassian.net/browse/BTS-750
- [ ] Design document: 

