### PR TITLE
add getByPrimaryKey workload

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1417,6 +1417,7 @@ if (BUILD_SEPP)
     tests/sepp/RocksDBOptions.cpp
     tests/sepp/Server.cpp
     tests/sepp/ValueGenerators/RandomStringGenerator.cpp
+    tests/sepp/Workloads/GetByPrimaryKey.cpp
     tests/sepp/Workloads/InsertDocuments.cpp
     tests/sepp/Workloads/IterateDocuments.cpp
   )

--- a/tests/sepp/Execution.cpp
+++ b/tests/sepp/Execution.cpp
@@ -41,6 +41,14 @@ Execution::Execution(Options const& options, std::shared_ptr<Workload> workload)
 
 Execution::~Execution() {
   _state.store(ExecutionState::kStopped);
+  joinThreads();
+}
+
+void Execution::createThreads(Server& server) {
+  _threads = _workload->createThreads(*this, server);
+}
+
+void Execution::joinThreads() {
   for (auto& thread : _threads) {
     if (thread->_thread.joinable()) {
       thread->_thread.join();
@@ -48,27 +56,44 @@ Execution::~Execution() {
   }
 }
 
-void Execution::createThreads(Server& server) {
-  _threads = _workload->createThreads(*this, server);
-}
-
 ExecutionState Execution::state(std::memory_order order) const noexcept {
   return _state.load(order);
 }
 
+void Execution::signalStartingThread() noexcept { _activeThreads.fetch_add(1); }
 void Execution::signalFinishedThread() noexcept { _activeThreads.fetch_sub(1); }
 
+void Execution::advanceStatusIfNotStopped(ExecutionState state) noexcept {
+  ExecutionState value = _state.load();
+  if (state == ExecutionState::kStopped && value == state) {
+    // already stopped
+    return;
+  }
+  // never move the status backwards
+  while (value != ExecutionState::kStopped &&
+         !_state.compare_exchange_strong(value, state)) {
+    std::this_thread::yield();
+  }
+}
+
+void Execution::stop() noexcept {
+  ExecutionState value = ExecutionState::kRunning;
+  // try to advance from Running to Stopped
+  while (!_state.compare_exchange_strong(value, ExecutionState::kStopped)) {
+    std::this_thread::yield();
+  }
+}
+
 Report Execution::run() {
-  _activeThreads.store(_threads.size());
-  _state.store(ExecutionState::kPreparing);
+  advanceStatusIfNotStopped(ExecutionState::kPreparing);
 
   waitUntilAllThreadsAre(ThreadState::kRunning);
 
-  _state.store(ExecutionState::kInitializing);
+  advanceStatusIfNotStopped(ExecutionState::kInitializing);
 
   waitUntilAllThreadsAre(ThreadState::kReady);
 
-  _state.store(ExecutionState::kRunning);
+  advanceStatusIfNotStopped(ExecutionState::kRunning);
 
   auto start = std::chrono::high_resolution_clock::now();
 
@@ -91,22 +116,26 @@ Report Execution::run() {
     // TODO - record samples (memory usage, rocksdb stats, ...)
   }
 
-  _state.store(ExecutionState::kStopped);
+  // set our execution state to stopped
+  stop();
 
   waitUntilAllThreadsAre(ThreadState::kFinished);
 
   std::chrono::duration<double, std::milli> runtime =
       std::chrono::high_resolution_clock::now() - start;
+
+  joinThreads();
+
+  for (auto const& thread : _threads) {
+    if (thread->failed()) {
+      throw std::runtime_error("aborted due to runtime failure");
+    }
+  }
+
   return buildReport(runtime.count());
 }
 
 Report Execution::buildReport(double runtime) {
-  for (auto& thread : _threads) {
-    if (thread->_thread.joinable()) {
-      thread->_thread.join();
-    }
-  }
-
   std::vector<ThreadReport> threadReports;
   threadReports.reserve(_threads.size());
   for (auto& thread : _threads) {

--- a/tests/sepp/Execution.cpp
+++ b/tests/sepp/Execution.cpp
@@ -84,6 +84,10 @@ void Execution::stop() noexcept {
   }
 }
 
+bool Execution::stopped() const noexcept {
+  return _state.load(std::memory_order_relaxed) == ExecutionState::kStopped;
+}
+
 Report Execution::run() {
   advanceStatusIfNotStopped(ExecutionState::kPreparing);
 

--- a/tests/sepp/Execution.h
+++ b/tests/sepp/Execution.h
@@ -58,6 +58,8 @@ struct Execution {
   void signalFinishedThread() noexcept;
   // stop execution (for example, because an error occurred somewhere)
   void stop() noexcept;
+  // whether or not the execution was stopped
+  bool stopped() const noexcept;
 
  private:
   void advanceStatusIfNotStopped(ExecutionState state) noexcept;

--- a/tests/sepp/Execution.h
+++ b/tests/sepp/Execution.h
@@ -46,6 +46,7 @@ struct Execution {
   Execution(Options const& options, std::shared_ptr<Workload> workload);
   ~Execution();
   void createThreads(Server& server);
+  void joinThreads();
   Report run();
   [[nodiscard]] ExecutionState state(
       std::memory_order order = std::memory_order_relaxed) const noexcept;
@@ -53,9 +54,13 @@ struct Execution {
     return static_cast<std::uint32_t>(_threads.size());
   }
 
+  void signalStartingThread() noexcept;
   void signalFinishedThread() noexcept;
+  // stop execution (for example, because an error occurred somewhere)
+  void stop() noexcept;
 
  private:
+  void advanceStatusIfNotStopped(ExecutionState state) noexcept;
   void waitUntilAllThreadsAre(ThreadState state) const;
 
   void waitUntilRunning(ExecutionThread const& thread) const;

--- a/tests/sepp/ExecutionThread.h
+++ b/tests/sepp/ExecutionThread.h
@@ -50,6 +50,7 @@ struct ExecutionThread {
   // not supposed to be accessed while the test is running, but only
   // at the end
   virtual bool failed() const noexcept { return _failed; }
+  Execution const& execution() const { return _execution; }
 
  protected:
   Server& _server;

--- a/tests/sepp/ExecutionThread.h
+++ b/tests/sepp/ExecutionThread.h
@@ -47,6 +47,10 @@ struct ExecutionThread {
   virtual bool shouldStop() const noexcept = 0;
   [[nodiscard]] virtual ThreadReport report() const { return {{}, 0}; }
 
+  // not supposed to be accessed while the test is running, but only
+  // at the end
+  virtual bool failed() const noexcept { return _failed; }
+
  protected:
   Server& _server;
 
@@ -56,6 +60,7 @@ struct ExecutionThread {
   std::mt19937_64 _randomizer{};
   std::thread _thread{};
   std::chrono::duration<double, std::milli> _runtime{};
+  bool _failed{false};
 
   friend struct Execution;
   void threadFunc();

--- a/tests/sepp/Options.h
+++ b/tests/sepp/Options.h
@@ -33,6 +33,7 @@
 
 #include "Inspection/Types.h"
 #include "Inspection/VPackLoadInspector.h"
+#include "Workloads/GetByPrimaryKey.h"
 #include "Workloads/InsertDocuments.h"
 #include "Workloads/IterateDocuments.h"
 
@@ -75,7 +76,8 @@ auto inspect(Inspector& f, Setup& o) {
                             f.field("prefill", o.prefill).fallback(f.keep()));
 }
 
-using WorkloadVariants = std::variant<workloads::InsertDocuments::Options,
+using WorkloadVariants = std::variant<workloads::GetByPrimaryKey::Options,
+                                      workloads::InsertDocuments::Options,
                                       workloads::IterateDocuments::Options>;
 namespace workloads {
 // this inspect function must be in namespace workloads for ADL to pick it up
@@ -83,6 +85,7 @@ template<class Inspector>
 inline auto inspect(Inspector& f, WorkloadVariants& o) {
   namespace insp = arangodb::inspection;
   return f.variant(o).unqualified().alternatives(
+      insp::type<workloads::GetByPrimaryKey::Options>("getByPrimaryKey"),
       insp::type<workloads::InsertDocuments::Options>("insert"),
       insp::type<workloads::IterateDocuments::Options>("iterate"));
 }

--- a/tests/sepp/Runner.cpp
+++ b/tests/sepp/Runner.cpp
@@ -35,6 +35,7 @@
 #include "Basics/overload.h"
 #include "Execution.h"
 #include "Server.h"
+#include "Workloads/GetByPrimaryKey.h"
 #include "Workloads/InsertDocuments.h"
 #include "Workloads/IterateDocuments.h"
 #include "velocypack/Collection.h"
@@ -83,7 +84,11 @@ auto Runner::runBenchmark() -> Report {
 
   std::cout << "Running benchmark...\n";
   auto workload = std::visit(
-      overload{[](workloads::InsertDocuments::Options& opts)
+      overload{[](workloads::GetByPrimaryKey::Options& opts)
+                   -> std::shared_ptr<Workload> {
+                 return std::make_shared<workloads::GetByPrimaryKey>(opts);
+               },
+               [](workloads::InsertDocuments::Options& opts)
                    -> std::shared_ptr<Workload> {
                  return std::make_shared<workloads::InsertDocuments>(opts);
                },

--- a/tests/sepp/Workloads/GetByPrimaryKey.cpp
+++ b/tests/sepp/Workloads/GetByPrimaryKey.cpp
@@ -164,13 +164,17 @@ void GetByPrimaryKey::Thread::run() {
     }
     ++_operations;
 
-    if (_operations % 512 == 0 && execution().stopped()) {
+    if (_operations % 512 == 0 && shouldStop()) {
       break;
     }
   }
 }
 
 auto GetByPrimaryKey::Thread::shouldStop() const noexcept -> bool {
+  if (execution().stopped()) {
+    return true;
+  }
+
   using StopAfterOps = StoppingCriterion::NumberOfOperations;
   if (std::holds_alternative<StopAfterOps>(_options.stop)) {
     return _operations >= std::get<StopAfterOps>(_options.stop).count;

--- a/tests/sepp/Workloads/GetByPrimaryKey.cpp
+++ b/tests/sepp/Workloads/GetByPrimaryKey.cpp
@@ -39,6 +39,7 @@
 #include "RocksDBEngine/RocksDBValue.h"
 #include "VocBase/Methods/Collections.h"
 
+#include "Execution.h"
 #include "Server.h"
 
 #include <rocksdb/db.h>
@@ -162,6 +163,10 @@ void GetByPrimaryKey::Thread::run() {
       }
     }
     ++_operations;
+
+    if (_operations % 512 == 0 && execution().stopped()) {
+      break;
+    }
   }
 }
 

--- a/tests/sepp/Workloads/InsertDocuments.cpp
+++ b/tests/sepp/Workloads/InsertDocuments.cpp
@@ -36,6 +36,7 @@
 #include "velocypack/Builder.h"
 #include "VocBase/Methods/Collections.h"
 
+#include "Execution.h"
 #include "Server.h"
 #include "ValueGenerators/RandomStringGenerator.h"
 
@@ -132,6 +133,10 @@ void InsertDocuments::Thread::buildDocument(velocypack::Builder& builder) {
 }
 
 auto InsertDocuments::Thread::shouldStop() const noexcept -> bool {
+  if (execution().stopped()) {
+    return true;
+  }
+
   using StopAfterOps = StoppingCriterion::NumberOfOperations;
   if (std::holds_alternative<StopAfterOps>(_options.stop)) {
     return _operations >= std::get<StopAfterOps>(_options.stop).count;

--- a/tests/sepp/Workloads/IterateDocuments.cpp
+++ b/tests/sepp/Workloads/IterateDocuments.cpp
@@ -113,13 +113,17 @@ void IterateDocuments::Thread::run() {
   OperationOptions options;
   for (it->Seek(bounds.start()); it->Valid(); it->Next()) {
     ++_operations;
-    if (_operations % 512 == 0 && execution().stopped()) {
+    if (_operations % 512 == 0 && shouldStop()) {
       break;
     }
   }
 }
 
 auto IterateDocuments::Thread::shouldStop() const noexcept -> bool {
+  if (execution().stopped()) {
+    return true;
+  }
+
   using StopAfterOps = StoppingCriterion::NumberOfOperations;
   if (std::holds_alternative<StopAfterOps>(_options.stop)) {
     return _operations >= std::get<StopAfterOps>(_options.stop).count;

--- a/tests/sepp/Workloads/IterateDocuments.cpp
+++ b/tests/sepp/Workloads/IterateDocuments.cpp
@@ -40,6 +40,7 @@
 #include "Utils/SingleCollectionTransaction.h"
 #include "VocBase/Methods/Collections.h"
 
+#include "Execution.h"
 #include "Server.h"
 
 #include <rocksdb/db.h>
@@ -110,11 +111,12 @@ void IterateDocuments::Thread::run() {
   std::unique_ptr<rocksdb::Iterator> it(rootDB->NewIterator(ro, docCF));
 
   OperationOptions options;
-  std::uint64_t numIts = 0;
-  for (it->Seek(bounds.start()); it->Valid(); it->Next(), ++numIts) {
-    // TODO
+  for (it->Seek(bounds.start()); it->Valid(); it->Next()) {
+    ++_operations;
+    if (_operations % 512 == 0 && execution().stopped()) {
+      break;
+    }
   }
-  _operations += numIts;
 }
 
 auto IterateDocuments::Thread::shouldStop() const noexcept -> bool {


### PR DESCRIPTION
### Scope & Purpose

Performance-test only...

Adds a new workload to fetch data by primary key, either document keys only, or the full documents in addition.
Key values are supposed to be contiguous numeric values, optionally starting with a prefix.

Example config:
```
{
  "rocksdb": {},
  "workload": {
    "getByPrimaryKey": {
      "default": {
        "collection": "peter",
        "fillBlockCache": true,
        "fetchFullDocument": false,
        "keyPrefix": "testmann",
        "minNumericKeyValue" : 0,
        "maxNumericKeyValue" : 100000
      },
      "stopAfter": {
        "runtime": 10000
      },
      "threads": 1
    }
  }
}
```

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -
  - [ ] Backport for 3.7: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 