### PR TITLE
Change default `format_version` for RocksDB .sst files from 3 to 5.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 devel
 -----
 
+* Change default `format_version` for RocksDB .sst files from 3 to 5.
+
 * Added support for creating autoincrement keys on cluster mode, but only for 
   single sharded collections.
 

--- a/arangod/RocksDBEngine/RocksDBOptionFeature.cpp
+++ b/arangod/RocksDBEngine/RocksDBOptionFeature.cpp
@@ -172,7 +172,7 @@ RocksDBOptionFeature::RocksDBOptionFeature(Server& server)
       _pendingCompactionBytesSlowdownTrigger(128 * 1024ull),
       _pendingCompactionBytesStopTrigger(16 * 1073741824ull),
       _checksumType("xxHash64"),
-      _formatVersion(3),
+      _formatVersion(5),
       _enableIndexCompression(
           rocksDBTableOptionsDefaults.enable_index_compression),
       _prepopulateBlockCache(false),

--- a/tests/sepp/RocksDBOptions.cpp
+++ b/tests/sepp/RocksDBOptions.cpp
@@ -140,7 +140,7 @@ RocksDBOptions::RocksDBOptions()
           .filterPolicy =
               TableOptions::BloomFilterPolicy{.bitsPerKey = 10,
                                               .useBlockBasedBuilder = true},
-          .formatVersion = 3,
+          .formatVersion = 5,
           .blockAlignDataBlocks = rocksDBTableOptionsDefaults.block_align,
           .checksum = "crc32c",         // TODO - use enum
           .compressionType = "snappy",  // TODO - use enum


### PR DESCRIPTION
### Scope & Purpose

Change default `format_version` for RocksDB .sst files from 3 to 5.
We haven't measured consistent performance improvements with version 5 (over versions 3 or 4), but we also haven't seen no negative effects in testing.
The RocksDB comments about format version 5 are:
> Can be read by RocksDB's versions since 6.6.0. Full and partitioned
> filters use a generally faster and more accurate Bloom filter
> implementation, with a different schema.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -
  - [ ] Backport for 3.7: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

