### PR TITLE
fix response handling for cluster-internal messages

### DIFF
--- a/arangod/Cluster/ClusterMethods.cpp
+++ b/arangod/Cluster/ClusterMethods.cpp
@@ -223,14 +223,12 @@ OperationResult handleResponsesFromAllShards(
   if (!result.fail()) {
     for (Try<arangodb::network::Response> const& tryRes : responses) {
       network::Response const& res = tryRes.get();  // throws exceptions upwards
-      ShardID sId = res.destinationShard();
-      auto commError = network::fuerteToArangoErrorCode(res);
-      if (commError != TRI_ERROR_NO_ERROR) {
-        result.reset(commError);
-      } else {
+
+      TRI_ASSERT(result.ok());
+      result = res.combinedResult();
+      if (result.ok()) {
         TRI_ASSERT(res.error == fuerte::Error::NoError);
-        VPackSlice answer = res.slice();
-        handler(result, builder, sId, answer);
+        handler(result, builder, res.destinationShard(), res.slice());
       }
 
       if (result.fail()) {
@@ -1030,11 +1028,11 @@ futures::Future<OperationResult> revisionOnCoordinator(
                 builder.clear();
                 builder.add(VPackValue(cmp.id()));
               }
+              return;
             }
-          } else {
-            // didn't get the expected response
-            result.reset(TRI_ERROR_INTERNAL);
           }
+          // didn't get the expected response
+          result.reset(TRI_ERROR_INTERNAL);
         });
   };
   return futures::collectAll(std::move(futures)).thenValue(std::move(cb));
@@ -1228,21 +1226,16 @@ futures::Future<OperationResult> figuresOnCoordinator(
     auto handler = [details](Result& result, VPackBuilder& builder,
                              ShardID const&,
                              VPackSlice answer) mutable -> void {
-      if (!answer.isObject()) {
-        // didn't get the expected response
-        result.reset(TRI_ERROR_INTERNAL);
-      } else if (!result.fail()) {
-        Result r = network::resultFromBody(answer, TRI_ERROR_NO_ERROR);
-        if (r.fail()) {
-          result.reset(r);
-        } else {
-          VPackSlice figures = answer.get("figures");
-          // add to the total
-          if (figures.isObject()) {
-            aggregateClusterFigures(details, false, figures, builder);
-          }
+      if (answer.isObject()) {
+        VPackSlice figures = answer.get("figures");
+        // add to the total
+        if (figures.isObject()) {
+          aggregateClusterFigures(details, false, figures, builder);
+          return;
         }
       }
+      // didn't get the expected response
+      result.reset(TRI_ERROR_INTERNAL);
     };
     auto pre = [](Result&, VPackBuilder& builder) -> void {
       // initialize to empty object
@@ -1324,15 +1317,16 @@ futures::Future<OperationResult> countOnCoordinator(
                       ShardID const& shardId,
                       VPackSlice answer) mutable -> void {
       if (answer.isObject()) {
-        // add to the total
-        VPackArrayBuilder array(&builder);
-        array->add(VPackValue(shardId));
-        array->add(
-            VPackValue(Helper::getNumericValue<uint64_t>(answer, "count", 0)));
-      } else {
-        // didn't get the expected response
-        result.reset(TRI_ERROR_INTERNAL);
+        if (VPackSlice count = answer.get("count"); count.isNumber()) {
+          // add to the total
+          VPackArrayBuilder array(&builder);
+          array->add(VPackValue(shardId));
+          array->add(count);
+          return;
+        }
       }
+      // didn't get the expected response
+      result.reset(TRI_ERROR_INTERNAL);
     };
     auto pre = [](Result&, VPackBuilder& builder) -> void {
       builder.openArray();
@@ -1909,12 +1903,7 @@ futures::Future<OperationResult> truncateCollectionOnCoordinator(
           std::vector<Try<network::Response>>&& results) -> OperationResult {
     return handleResponsesFromAllShards(
         options, results,
-        [](Result& result, VPackBuilder&, ShardID const&,
-           VPackSlice answer) -> void {
-          if (Helper::getBooleanValue(answer, StaticStrings::Error, false)) {
-            result = network::resultFromBody(answer, TRI_ERROR_NO_ERROR);
-          }
-        });
+        [](Result&, VPackBuilder&, ShardID const&, VPackSlice) -> void {});
   };
   return futures::collectAll(std::move(futures)).thenValue(std::move(cb));
 }


### PR DESCRIPTION
### Scope & Purpose

Potential fix for BTS-885: https://arangodb.atlassian.net/browse/BTS-885

Fix response handling for cluster-internal messages in case a non-HTTP 200 error was returned for a count/revision/figures/truncate request. Some of these operations handled errors properly, and some didn't. the error processing for the ops is now unified so that errors are properly reported.
This could be a solution to https://arangodb.atlassian.net/browse/BTS-885

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -
  - [ ] Backport for 3.7: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [x] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/BTS-885
- [ ] Design document: 