### PR TITLE
[CINFRA-383] Forward Config to Log

### DIFF
--- a/arangod/Replication2/ReplicatedState/Supervision.cpp
+++ b/arangod/Replication2/ReplicatedState/Supervision.cpp
@@ -195,6 +195,16 @@ auto checkLeaderSet(SupervisionContext& ctx, RLA::Log const& log,
   }
 }
 
+auto checkConfigSet(SupervisionContext& ctx, RLA::Log const& log,
+                    RSA::State const& state) {
+  auto const& stateConfig = state.target.config;
+  auto const& logConfig = log.target.config;
+
+  if (stateConfig != logConfig) {
+    ctx.createAction<SetLogConfigAction>(stateConfig);
+  }
+}
+
 auto checkParticipantAdded(SupervisionContext& ctx, RLA::Log const& log,
                            RSA::State const& state) {
   ADB_PROD_ASSERT(state.plan.has_value());
@@ -386,6 +396,7 @@ auto checkReplicatedStateParticipants(SupervisionContext& ctx,
 auto checkForwardSettings(SupervisionContext& ctx, RLA::Log const& log,
                           RSA::State const& state) {
   checkLeaderSet(ctx, log, state);
+  checkConfigSet(ctx, log, state);
 }
 
 void checkReplicatedState(SupervisionContext& ctx,

--- a/arangod/Replication2/ReplicatedState/SupervisionAction.h
+++ b/arangod/Replication2/ReplicatedState/SupervisionAction.h
@@ -115,10 +115,21 @@ struct SetLeaderAction {
   }
 };
 
-using Action = std::variant<
-    EmptyAction, AddParticipantAction, RemoveParticipantFromLogTargetAction,
-    RemoveParticipantFromStatePlanAction, AddStateToPlanAction,
-    UpdateParticipantFlagsAction, CurrentConvergedAction, SetLeaderAction>;
+struct SetLogConfigAction {
+  replication2::agency::LogTargetConfig config;
+
+  void execute(ActionContext& ctx) {
+    ctx.modify<replication2::agency::LogTarget>(
+        [&](auto& target) { target.config = config; });
+  }
+};
+
+using Action =
+    std::variant<EmptyAction, AddParticipantAction,
+                 RemoveParticipantFromLogTargetAction,
+                 RemoveParticipantFromStatePlanAction, AddStateToPlanAction,
+                 UpdateParticipantFlagsAction, CurrentConvergedAction,
+                 SetLeaderAction, SetLogConfigAction>;
 
 auto executeAction(
     arangodb::replication2::replicated_state::agency::State state,

--- a/tests/Replication2/Helper/AgencyLogBuilder.h
+++ b/tests/Replication2/Helper/AgencyLogBuilder.h
@@ -56,6 +56,11 @@ struct AgencyLogBuilder {
     return *this;
   }
 
+  auto setPlanConfig(RLA::LogPlanConfig config) -> AgencyLogBuilder& {
+    makePlan().participantsConfig.config = config;
+    return *this;
+  }
+
   auto setTargetLeader(std::optional<ParticipantId> leader)
       -> AgencyLogBuilder& {
     _log.target.leader = std::move(leader);

--- a/tests/Replication2/ReplicatedState/SupervisionTest.cpp
+++ b/tests/Replication2/ReplicatedState/SupervisionTest.cpp
@@ -71,6 +71,7 @@ TEST_F(ReplicatedStateSupervisionTest, check_wait_current) {
   state.makePlan();
 
   log.setId(logId)
+      .setTargetConfig(defaultConfig)
       .setTargetParticipant("A", flagsSnapshotIncomplete)
       .setTargetParticipant("B", flagsSnapshotIncomplete)
       .setTargetParticipant("C", flagsSnapshotIncomplete);
@@ -98,6 +99,7 @@ TEST_F(ReplicatedStateSupervisionTest, check_wait_log_plan) {
   state.makeCurrent();
 
   log.setId(logId)
+      .setTargetConfig(defaultConfig)
       .setTargetParticipant("A", flagsSnapshotIncomplete)
       .setTargetParticipant("B", flagsSnapshotIncomplete)
       .setTargetParticipant("C", flagsSnapshotIncomplete);
@@ -125,6 +127,7 @@ TEST_F(ReplicatedStateSupervisionTest, check_wait_snapshot) {
   state.makeCurrent();
 
   log.setId(logId)
+      .setTargetConfig(defaultConfig)
       .setTargetParticipant("A", flagsSnapshotIncomplete)
       .setTargetParticipant("B", flagsSnapshotIncomplete)
       .setTargetParticipant("C", flagsSnapshotIncomplete);
@@ -166,6 +169,7 @@ TEST_F(ReplicatedStateSupervisionTest, check_snapshot_complete) {
   state.makeCurrent();
 
   log.setId(logId)
+      .setTargetConfig(defaultConfig)
       .setTargetParticipant("A", flagsSnapshotIncomplete)
       .setTargetParticipant("B", flagsSnapshotIncomplete)
       .setTargetParticipant("C", flagsSnapshotIncomplete);
@@ -213,6 +217,7 @@ TEST_F(ReplicatedStateSupervisionTest, check_all_snapshot_complete) {
   state.setCurrentVersion(12);
 
   log.setId(logId)
+      .setTargetConfig(defaultConfig)
       .setTargetParticipant("A", flagsSnapshotComplete)
       .setTargetParticipant("B", flagsSnapshotComplete)
       .setTargetParticipant("C", flagsSnapshotComplete);
@@ -241,6 +246,7 @@ TEST_F(ReplicatedStateSupervisionTest, check_add_participant_1) {
   state.setCurrentVersion(5);
 
   log.setId(logId)
+      .setTargetConfig(defaultConfig)
       .setTargetParticipant("A", flagsSnapshotComplete)
       .setTargetParticipant("B", flagsSnapshotComplete)
       .setTargetParticipant("C", flagsSnapshotComplete);
@@ -274,6 +280,7 @@ TEST_F(ReplicatedStateSupervisionTest, check_add_participant_2) {
   state.setCurrentVersion(5);
 
   log.setId(logId)
+      .setTargetConfig(defaultConfig)
       .setTargetParticipant("A", flagsSnapshotComplete)
       .setTargetParticipant("B", flagsSnapshotComplete)
       .setTargetParticipant("C", flagsSnapshotComplete)
@@ -309,6 +316,7 @@ TEST_F(ReplicatedStateSupervisionTest, check_add_participant_3_1) {
   state.setCurrentVersion(5);
 
   log.setId(logId)
+      .setTargetConfig(defaultConfig)
       .setTargetParticipant("A", flagsSnapshotComplete)
       .setTargetParticipant("B", flagsSnapshotComplete)
       .setTargetParticipant("C", flagsSnapshotComplete)
@@ -343,6 +351,7 @@ TEST_F(ReplicatedStateSupervisionTest, check_add_participant_3_2) {
   state.setCurrentVersion(5);
 
   log.setId(logId)
+      .setTargetConfig(defaultConfig)
       .setTargetParticipant("A", flagsSnapshotComplete)
       .setTargetParticipant("B", flagsSnapshotComplete)
       .setTargetParticipant("C", flagsSnapshotComplete)
@@ -377,6 +386,7 @@ TEST_F(ReplicatedStateSupervisionTest, check_add_participant_4) {
   state.setCurrentVersion(5);
 
   log.setId(logId)
+      .setTargetConfig(defaultConfig)
       .setTargetParticipant("A", flagsSnapshotComplete)
       .setTargetParticipant("B", flagsSnapshotComplete)
       .setTargetParticipant("C", flagsSnapshotComplete)
@@ -411,6 +421,7 @@ TEST_F(ReplicatedStateSupervisionTest, check_remove_two_servers_0) {
   state.setCurrentVersion(12);
 
   log.setId(logId)
+      .setTargetConfig(defaultConfig)
       .setTargetParticipant("A", flagsSnapshotComplete)
       .setTargetParticipant("B", flagsSnapshotComplete)
       .setTargetParticipant("C", flagsSnapshotComplete);
@@ -445,6 +456,7 @@ TEST_F(ReplicatedStateSupervisionTest, check_remove_two_servers_1) {
   state.setCurrentVersion(12);
 
   log.setId(logId)
+      .setTargetConfig(defaultConfig)
       .setTargetParticipant("A", flagsSnapshotComplete)
       .setTargetParticipant("B", flagsSnapshotComplete)
       .setTargetParticipant("C", flagsSnapshotComplete)
@@ -484,6 +496,7 @@ TEST_F(ReplicatedStateSupervisionTest, check_remove_two_servers_2) {
   state.setCurrentVersion(12);
 
   log.setId(logId)
+      .setTargetConfig(defaultConfig)
       .setTargetParticipant("A", flagsSnapshotComplete)
       .setTargetParticipant("C", flagsSnapshotComplete)
       .setTargetParticipant("D", flagsSnapshotIncomplete);
@@ -531,6 +544,7 @@ TEST_F(ReplicatedStateSupervisionTest, check_remove_two_servers_3_1) {
   state.setCurrentVersion(12);
 
   log.setId(logId)
+      .setTargetConfig(defaultConfig)
       .setTargetParticipant("A", flagsSnapshotComplete)
       .setTargetParticipant("C", flagsSnapshotComplete)
       .setTargetParticipant("D", flagsSnapshotIncomplete);
@@ -576,6 +590,7 @@ TEST_F(ReplicatedStateSupervisionTest, check_remove_two_servers_3_2) {
   state.setCurrentVersion(12);
 
   log.setId(logId)
+      .setTargetConfig(defaultConfig)
       .setTargetParticipant("A", flagsSnapshotComplete)
       .setTargetParticipant("C", flagsSnapshotComplete)
       .setTargetParticipant("D", flagsSnapshotIncomplete);
@@ -609,4 +624,38 @@ TEST_F(ReplicatedStateSupervisionTest, check_remove_two_servers_3_2) {
   EXPECT_EQ(report[0].participant, "B");
   EXPECT_EQ(report[1].code, RSA::StatusCode::kInsufficientSnapshotCoverage);
   EXPECT_EQ(report[1].participant, "C");
+}
+
+TEST_F(ReplicatedStateSupervisionTest, check_change_config) {
+  AgencyStateBuilder state;
+  AgencyLogBuilder log;
+  RLA::LogTargetConfig newConfig = defaultConfig;
+  newConfig.writeConcern = 3; // change write concern from 2 -> 3
+
+  state.setId(logId)
+      .setTargetParticipants("A", "B", "C")
+      .setTargetVersion(12)
+      .setTargetConfig(newConfig);
+
+  state.setPlanParticipants("A", "B", "C").setAllSnapshotsComplete();
+  state.setCurrentVersion(12);
+
+  log.setId(logId)
+      .setTargetConfig(defaultConfig)
+      .setTargetParticipant("A", flagsSnapshotComplete)
+      .setTargetParticipant("B", flagsSnapshotComplete)
+      .setTargetParticipant("C", flagsSnapshotComplete);
+
+  log.setPlanParticipant("A", flagsSnapshotComplete)
+      .setPlanParticipant("B", flagsSnapshotComplete)
+      .setPlanParticipant("C", flagsSnapshotComplete);
+
+  replicated_state::SupervisionContext ctx;
+  ctx.enableErrorReporting();
+  replicated_state::checkReplicatedState(ctx, log.get(), state.get());
+
+  EXPECT_TRUE(ctx.hasUpdates());
+  auto& action = ctx.getAction();
+  ASSERT_TRUE(std::holds_alternative<SetLogConfigAction>(action));
+  EXPECT_EQ(std::get<SetLogConfigAction>(action).config, newConfig);
 }


### PR DESCRIPTION
### Scope & Purpose
This PR forwards a configuration change from a replicated state to the replicated log.