### PR TITLE
[CINFRA-390] Added number of servers parameter

### DIFF
--- a/arangod/Replication2/Methods.cpp
+++ b/arangod/Replication2/Methods.cpp
@@ -286,7 +286,9 @@ struct ReplicatedLogMethodsCoordinator final
     auto dbservers = clusterInfo.getCurrentDBServers();
 
     auto expectedNumberOfServers = std::min(dbservers.size(), std::size_t{3});
-    if (!options.servers.empty()) {
+    if (options.numberOfServers.has_value()) {
+      expectedNumberOfServers = *options.numberOfServers;
+    } else if (!options.servers.empty()) {
       expectedNumberOfServers = options.servers.size();
     }
 

--- a/arangod/Replication2/Methods.h
+++ b/arangod/Replication2/Methods.h
@@ -74,6 +74,7 @@ struct ReplicatedLogMethods {
     std::optional<LogId> id;
     std::optional<agency::LogTargetConfig> config;
     std::optional<ParticipantId> leader;
+    std::optional<std::size_t> numberOfServers;
     std::vector<ParticipantId> servers;
   };
 
@@ -151,6 +152,7 @@ auto inspect(Inspector& f, ReplicatedLogMethods::CreateOptions& x) {
       f.field("waitForReady", x.waitForReady).fallback(true),
       f.field("id", x.id), f.field("config", x.config),
       f.field("leader", x.leader),
+      f.field("numberOfServers", x.numberOfServers),
       f.field("servers", x.servers).fallback(std::vector<ParticipantId>{}));
 }
 

--- a/arangod/Replication2/StateMachines/Prototype/PrototypeStateMethods.cpp
+++ b/arangod/Replication2/StateMachines/Prototype/PrototypeStateMethods.cpp
@@ -437,7 +437,9 @@ struct PrototypeStateMethodsCoordinator final
     auto dbservers = _clusterInfo.getCurrentDBServers();
     std::size_t expectedNumberOfServers =
         std::min(dbservers.size(), std::size_t{3});
-    if (!options.servers.empty()) {
+    if (options.numberOfServers.has_value()) {
+      expectedNumberOfServers = *options.numberOfServers;
+    } else if (!options.servers.empty()) {
       expectedNumberOfServers = options.servers.size();
     }
 

--- a/arangod/Replication2/StateMachines/Prototype/PrototypeStateMethods.h
+++ b/arangod/Replication2/StateMachines/Prototype/PrototypeStateMethods.h
@@ -58,6 +58,7 @@ struct PrototypeStateMethods {
     bool waitForReady{false};
     std::optional<LogId> id;
     std::optional<agency::LogTargetConfig> config;
+    std::optional<std::size_t> numberOfServers;
     std::vector<ParticipantId> servers;
   };
 
@@ -138,6 +139,7 @@ auto inspect(Inspector& f, PrototypeStateMethods::CreateOptions& x) {
   return f.object(x).fields(
       f.field("waitForReady", x.waitForReady).fallback(true),
       f.field("id", x.id), f.field("config", x.config),
+      f.field("numberOfServers", x.numberOfServers),
       f.field("servers", x.servers).fallback(std::vector<ParticipantId>{}));
 }
 template<class Inspector>

--- a/tests/js/server/replication2/replication2-replicated-log-create-api-cluster.js
+++ b/tests/js/server/replication2/replication2-replicated-log-create-api-cluster.js
@@ -83,6 +83,13 @@ const replicatedLogCreateSuite = function () {
       const status = log.status();
       assertEqual(Object.keys(status.participants).sort(), servers.sort());
     },
+
+    testCreateWithNumberOfServers: function () {
+      const servers = _.sampleSize(lh.dbservers, 3);
+      const log = db._createReplicatedLog({servers, config: targetConfig, numberOfServers: 4});
+      const status = log.status();
+      assertEqual(Object.keys(status.participants).length, 4);
+    },
   };
 };
 


### PR DESCRIPTION
### Scope & Purpose
(Re-)add the `numberOfServers` parameter when creating a replicated log or a prototype replicated state. These have been removed in the past due to some refactoring of the LogConfig.