### PR TITLE
Fix potential resource leak when reusing PinnableSlice instances

### DIFF
--- a/3rdParty/rocksdb/6.27/db/db_impl/db_impl.cc
+++ b/3rdParty/rocksdb/6.27/db/db_impl/db_impl.cc
@@ -1704,6 +1704,8 @@ Status DBImpl::Get(const ReadOptions& read_options,
 Status DBImpl::Get(const ReadOptions& read_options,
                    ColumnFamilyHandle* column_family, const Slice& key,
                    PinnableSlice* value, std::string* timestamp) {
+  assert(value != nullptr);
+  value->Reset();
   GetImplOptions get_impl_options;
   get_impl_options.column_family = column_family;
   get_impl_options.value = value;
@@ -2290,6 +2292,7 @@ void DBImpl::MultiGet(const ReadOptions& read_options, const size_t num_keys,
   autovector<KeyContext*, MultiGetContext::MAX_BATCH_SIZE> sorted_keys;
   sorted_keys.resize(num_keys);
   for (size_t i = 0; i < num_keys; ++i) {
+    values[i].Reset();
     key_context.emplace_back(column_families[i], keys[i], &values[i],
                              timestamps ? &timestamps[i] : nullptr,
                              &statuses[i]);
@@ -2436,6 +2439,7 @@ void DBImpl::MultiGet(const ReadOptions& read_options,
   autovector<KeyContext*, MultiGetContext::MAX_BATCH_SIZE> sorted_keys;
   sorted_keys.resize(num_keys);
   for (size_t i = 0; i < num_keys; ++i) {
+    values[i].Reset();
     key_context.emplace_back(column_family, keys[i], &values[i],
                              timestamps ? &timestamps[i] : nullptr,
                              &statuses[i]);

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,11 @@
+v3.9.3 (XXXX-XX-XX)
+-------------------
+
+* Fixed potential resource leak when reusing `rocksdb::PinnableSlice` instances
+  without resetting them first. This issue can lead to the block cache filling
+  up with data that will not be evicted from the block cache anymore.
+
+
 v3.9.2 (2022-06-07)
 -------------------
 


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/16422

* Fixed potential resource leak when reusing `rocksdb::PinnableSlice` instances
  without resetting them first. This issue can lead to the block cache filling
  up with data that will not be evicted from the block cache anymore.

Fixed in upstream RocksDB via https://github.com/facebook/rocksdb/pull/10166

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [x] Backports
  - [x] Backport for 3.9: this PR
  - [x] Backport for 3.8: https://github.com/arangodb/arangodb/pull/16424
  - [ ] Backport for 3.7: 

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 