### PR TITLE
[PREGEL] Remove custom Edge store

### DIFF
--- a/arangod/Pregel/Algos/AIR/VertexComputation.cpp
+++ b/arangod/Pregel/Algos/AIR/VertexComputation.cpp
@@ -278,24 +278,21 @@ greenspun::EvalResult VertexComputation::air_outboundEdges(
   if (res.fail()) {
     return res.error();
   }
-  RangeIterator<Edge<EdgeData>> edgeIter = getEdges();
   VPackArrayBuilder edgesGuard(&result);
 
-  // FIXME: Uglay
-  // FIXME: For needs iterable support!
-  for (; edgeIter.hasMore(); ++edgeIter) {
+  for (auto const& edge : getEdges()) {
     VPackObjectBuilder objGuard(&result);
     result.add(VPackValue("to-pregel-id"));
     {
       VPackObjectBuilder pidGuard(&result);
       result.add(VPackValue("shard"));
-      result.add(VPackValue((*edgeIter)->targetShard()));
+      result.add(VPackValue(edge.targetShard()));
       result.add(VPackValue("key"));
-      result.add(VPackValue((*edgeIter)->toKey()));
+      result.add(VPackValue(edge.toKey()));
     }
 
     result.add(VPackValue("document"));
-    VPackSlice edgeDoc = (*edgeIter)->data()._document.slice();
+    VPackSlice edgeDoc = edge.data()._document.slice();
     result.add(edgeDoc);
   }
 

--- a/arangod/Pregel/Algos/DMID/DMID.cpp
+++ b/arangod/Pregel/Algos/DMID/DMID.cpp
@@ -162,10 +162,8 @@ struct DMIDComputation
    */
   void superstep0(MessageIterator<DMIDMessage> const& messages) {
     DMIDMessage message(pregelId(), 0);
-    RangeIterator<Edge<float>> edges = getEdges();
-    for (; edges.hasMore(); ++edges) {
-      Edge<float>* edge = *edges;
-      message.weight = edge->data();  // edge weight
+    for (auto const& edge : getEdges()) {
+      message.weight = edge.data();
       sendMessage(edge, message);
     }
   }
@@ -332,11 +330,9 @@ struct DMIDComputation
        */
       bool hasEdgeToSender = false;
 
-      for (auto edges = getEdges(); edges.hasMore(); ++edges) {
-        Edge<float>* edge = *edges;
-
-        if (edge->targetShard() == senderID.shard &&
-            edge->toKey() == senderID.key) {
+      for (auto const& edge : getEdges()) {
+        if (edge.targetShard() == senderID.shard &&
+            edge.toKey() == senderID.key) {
           hasEdgeToSender = true;
           /**
            * Has this vertex more influence on the sender than the
@@ -344,7 +340,7 @@ struct DMIDComputation
            */
           float senderInfluence =
               (float)vecLS->getAggregatedValue(senderID.shard, senderID.key);
-          senderInfluence *= edge->data();
+          senderInfluence *= edge.data();
 
           if (myInfluence > senderInfluence) {
             /** send new message */

--- a/arangod/Pregel/Algos/SSSP.cpp
+++ b/arangod/Pregel/Algos/SSSP.cpp
@@ -44,10 +44,8 @@ struct SSSPComputation : public VertexComputation<int64_t, int64_t, int64_t> {
     if (tmp < *state || (tmp == 0 && localSuperstep() == 0)) {
       *state = tmp;  // update state
 
-      RangeIterator<Edge<int64_t>> edges = getEdges();
-      for (; edges.hasMore(); ++edges) {
-        Edge<int64_t>* edge = *edges;
-        int64_t val = edge->data() + tmp;
+      for (auto const& edge : getEdges()) {
+        int64_t val = edge.data() + tmp;
         sendMessage(edge, val);
       }
     }

--- a/arangod/Pregel/Algos/ShortestPath.cpp
+++ b/arangod/Pregel/Algos/ShortestPath.cpp
@@ -63,10 +63,8 @@ struct SPComputation : public VertexComputation<int64_t, int64_t, int64_t> {
         return;
       }
 
-      RangeIterator<Edge<int64_t>> edges = getEdges();
-      for (; edges.hasMore(); ++edges) {
-        Edge<int64_t>* edge = *edges;
-        int64_t val = edge->data() + current;
+      for (auto const& edge : getEdges()) {
+        int64_t val = edge.data() + current;
         if (val < max) {
           sendMessage(edge, val);
         }

--- a/arangod/Pregel/Algos/WCC.cpp
+++ b/arangod/Pregel/Algos/WCC.cpp
@@ -109,18 +109,10 @@ struct WCCComputation
     auto const& myData = vertexData();
     SenderMessage<uint64_t> message(pregelId(), myData.component);
     // Send to OUTBOUND neighbors
-    RangeIterator<Edge<uint64_t>> edges = this->getEdges();
-    for (; edges.hasMore(); ++edges) {
-      Edge<uint64_t>* edge = *edges;
-      if (edge->toKey() == this->key()) {
+    for (auto const& edge : this->getEdges()) {
+      if (edge.toKey() == this->key()) {
         continue;  // no need to send message to self
       }
-
-      // remember the value we send
-      // NOTE: I have done refactroing of the algorithm
-      // the original variant saved this, i do not know
-      // if it is actually relevant for anything.
-      edge->data() = myData.component;
 
       sendMessage(edge, message);
     }

--- a/arangod/Pregel/Graph.h
+++ b/arangod/Pregel/Graph.h
@@ -120,7 +120,7 @@ class Vertex {
   // adds an edge for the vertex. returns the number of edges
   // after the addition. note that the caller must make sure that
   // we don't end up with more than 4GB edges per verte.
-  size_t emplaceEdge(Edge<E>&& edge) noexcept {
+  size_t addEdge(Edge<E>&& edge) noexcept {
     // must only be called during initial vertex creation
     TRI_ASSERT(active());
     _edges.emplace_back(std::move(edge));

--- a/arangod/Pregel/GraphStore.cpp
+++ b/arangod/Pregel/GraphStore.cpp
@@ -511,7 +511,7 @@ void GraphStore<V, E>::loadEdges(transaction::Methods& trx,
 
           auto newEdge = buildEdge(toValue);
           if (newEdge.has_value()) {
-            vertex.emplaceEdge(std::move(*newEdge));
+            vertex.addEdge(std::move(*newEdge));
             return true;
           } else {
             return false;
@@ -530,7 +530,7 @@ void GraphStore<V, E>::loadEdges(transaction::Methods& trx,
 
           auto newEdge = buildEdge(toValue);
           if (newEdge.has_value()) {
-            vertex.emplaceEdge(std::move(*newEdge));
+            vertex.addEdge(std::move(*newEdge));
             _graphFormat->copyEdgeData(
                 *trx.transactionContext()->getVPackOptions(), slice,
                 newEdge->data_mut());

--- a/arangod/Pregel/GraphStore.h
+++ b/arangod/Pregel/GraphStore.h
@@ -151,6 +151,7 @@ class GraphStore final {
   ReportManager* _reports;
 
  private:
+  auto buildEdge(std::string_view toValue) -> std::optional<Edge<E>>;
   void loadVertices(ShardID const& vertexShard,
                     std::vector<ShardID> const& edgeShards,
                     std::function<void()> const& statusUpdateCallback);

--- a/arangod/Pregel/GraphStore.h
+++ b/arangod/Pregel/GraphStore.h
@@ -156,7 +156,6 @@ class GraphStore final {
                     std::function<void()> const& statusUpdateCallback);
   void loadEdges(transaction::Methods& trx, Vertex<V, E>& vertex,
                  ShardID const& edgeShard, std::string const& documentID,
-                 std::vector<std::unique_ptr<TypedBuffer<Edge<E>>>>& edges,
                  uint64_t numVertices, traverser::EdgeCollectionInfo& info);
 
   void storeVertices(std::vector<ShardID> const& globalShards,

--- a/arangod/Pregel/VertexComputation.h
+++ b/arangod/Pregel/VertexComputation.h
@@ -88,8 +88,8 @@ class VertexContext {
 
   size_t getEdgeCount() const { return _vertexEntry->getEdgeCount(); }
 
-  RangeIterator<Edge<E>> getEdges() const {
-    return _graphStore->edgeIterator(_vertexEntry);
+  std::vector<Edge<E>> const& getEdges() const {
+    return _vertexEntry->getEdges();
   }
 
   void setVertexData(V const& val) {
@@ -131,17 +131,17 @@ class VertexComputation : public VertexContext<V, E, M> {
     _cache->appendMessage(edge->targetShard(), edge->toKey(), data);
   }
 
+  void sendMessage(Edge<E> const& edge, M const& data) {
+    _cache->appendMessage(edge.targetShard(), edge.toKey(), data);
+  }
+
   void sendMessage(PregelID const& pid, M const& data) {
     _cache->appendMessage(pid.shard, std::string_view(pid.key), data);
   }
 
-  /// Send message along outgoing edges to all reachable neighbours
-  /// TODO Multi-receiver messages
   void sendMessageToAllNeighbours(M const& data) {
-    RangeIterator<Edge<E>> edges = this->getEdges();
-    for (; edges.hasMore(); ++edges) {
-      Edge<E> const* edge = *edges;
-      _cache->appendMessage(edge->targetShard(), edge->toKey(), data);
+    for (auto const& edge : this->getEdges()) {
+      _cache->appendMessage(edge.targetShard(), edge.toKey(), data);
     }
   }
 


### PR DESCRIPTION
Removes the custom data structure for storing edges, instead placing them in the vertex structure.