### PR TITLE
Refactor/rename-frontend-startup-options

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -47,7 +47,7 @@ devel
   defaults and bounds for Pregel jobs. Each individual Pregel job can set
   its own parallelism value using the job's `parallelism` option, but the
   job's parallelism value will be clamped to the bounds defined by
-  `--pregel,min-parallelism` and `--pregel.max-parallelism`. If a job does
+  `--pregel.min-parallelism` and `--pregel.max-parallelism`. If a job does
   not set its `parallelism` value, it will default to the parallelism value
   configured via `--pregel.parallelism`.
 
@@ -58,7 +58,7 @@ devel
     default store their temporary data in disk-backed memory-mapped files. 
     If set to `false`, the temporary data of Pregel jobs will be buffered in 
     RAM. The default value is `true`, meaning that memory-mapped files will
-    be used. The option can be overriden for each Pregel job by setting the 
+    be used. The option can be overridden for each Pregel job by setting the 
     `useMemoryMaps` option of the job.
 
   - `--pregel.memory-mapped-files-location-type`: location for memory-mapped
@@ -98,7 +98,7 @@ devel
 
 * Updated arangosync to v2.10.0-preview-1.
 
-* Enterprise only: Restricted behaviour of Hybrid Disjoint Smart Graphs. Within 
+* Enterprise only: Restricted behavior of Hybrid Disjoint Smart Graphs. Within 
   a single traversal or path query we now restrict that you can only switch 
   between Smart and Satellite sharding once, all queries where more than one 
   switch is (in theory) possible will be rejected. e.g:
@@ -175,7 +175,7 @@ devel
   - `array[?]`: returns `false` if array is empty, `true` otherwise
   - `array[? FILTER CURRENT ...]`: returns `false` if no array member
      satisfies the filter condition, returns `true` if at least one member
-     satistifies it.
+     satisfies it.
 
 * Fixed Github issue #16279: assertion failure/crash in AQL query optimizer when
   permuting adjacent FOR loops that depended on each other.
@@ -221,7 +221,7 @@ devel
 
 * Fix: Highly unlikely race in cluster maintenance. For every shard only
   one operation (change attribute, change leadership) should be performed
-  at the same time. However if two changes are detected in the same hearbeat
+  at the same time. However if two changes are detected in the same heartbeat
   it could lead to both operations to be executed in parallel. In most cases
   this is also fine, but could lead to races on the same attribute, however
   the race will be sorted out in the next heartbeat interval.
@@ -278,7 +278,7 @@ devel
   * key generator type
   * whether or not the document and primary index cache is enabled
   * if cache is enabled, show cache usage and allocation size in figures
-  The `cacheEnabled` property of collections is now also changable via the
+  The `cacheEnabled` property of collections is now also changeable via the
   UI for existing collections.
 
 * FE-45: Added tooltips with helpful information to the options on the View UI
@@ -390,8 +390,8 @@ devel
   run.
 
 * Remove error handling fetching license information to improve user
-  experience. To display the license informationn in the UI is only
-  informational. It disturbs the user experience to know somthing went wrong
+  experience. To display the license information in the UI is only
+  informational. It disturbs the user experience to know something went wrong
   and doesn't provide any important information for the user.
 
 * Updated bundled version of zlib library to 1.2.12.
@@ -560,7 +560,7 @@ devel
   - Rules for polygons and multigons have been clarified and are now properly
     enforced for the `GEO_POLYGON` and `GEO_MULTIPOLYGON` AQL functions.
   - Introduced `legacyPolygon` flag for geo indexes to continue to support
-    the old behaviour in existing geo indexes.
+    the old behavior in existing geo indexes.
   - Added lots of additional tests, thereby fixing several bugs in geo index
     lookup.
   - Use a faster algorithm for pure `GEO_CONTAINS` and `GEO_INTERSECTS`
@@ -615,19 +615,19 @@ devel
 * The multi-dimensional index type `zkd` now supports an optional index hint for
   tweaking performance by prefetching documents:
 
-	```
-	FOR app IN appointments OPTIONS { lookahead: 32 }
+  ```
+  FOR app IN appointments OPTIONS { lookahead: 32 }
     FILTER @to <= app.to
     FILTER app.from <= @from
     RETURN app
-	```
+  ```
 
-	Specifiying a lookahead value greater than zero makes the index fetch more documents
-	that are no longer in the search box, before seeking to the next lookup position.
-	Because the seek operation is computationally expensive, probing more documents
-	before seeking may reduce the number of seeks, if matching documents are found.
-	Please keep in mind that it might also affect performance negatively if documents
-	are fetched unnecessarily.
+  Specifying a lookahead value greater than zero makes the index fetch more documents
+  that are no longer in the search box, before seeking to the next lookup position.
+  Because the seek operation is computationally expensive, probing more documents
+  before seeking may reduce the number of seeks, if matching documents are found.
+  Please keep in mind that it might also affect performance negatively if documents
+  are fetched unnecessarily.
 
 * Replaced internal JS dependency xmldom with @xmldom/xmldom.
 
@@ -827,7 +827,7 @@ devel
 
   The default value of `disableIndex` is `false`.
   In case a different index hint is provided, `disableIndex: true` takes
-  precendence and produces a warning about the ambiguous settings.
+  precedence and produces a warning about the ambiguous settings.
 
 * Added `maxProjections` hint for AQL FOR loops. This hint can be used to set
   the maximum number of document attributes that are taken into account for
@@ -1949,7 +1949,7 @@ devel
   startup, reporting corruption. However, empty WAL files are possible in case
   of server crashes etc. Now, if a WAL file is completely empty, there will be
   no attempt to read the encryption meta data from it, so the startup succeeds
-	(BTS-392).
+  (BTS-392).
 
 * Remove _msg/please-upgrade handler.
 
@@ -2245,18 +2245,18 @@ devel
 
 * Implemented an optimization for Traversals. If you apply a POST filter on
   the vertex and/or edge result this filter will now be applied during the
-	traversal to avoid generating the full output for AQL. This will have
-	positive effect if you filter on the vertex/edge but return the path,
-	this way the system does only need to produce a path that is allowed to
-	be passed through.
-	e.g.
+  traversal to avoid generating the full output for AQL. This will have
+  positive effect if you filter on the vertex/edge but return the path,
+  this way the system does only need to produce a path that is allowed to
+  be passed through.
+  e.g.
 
     FOR v,e,p IN 10 OUTBOUND @start GRAPH "myGraph"
-		  FILTER v.isRelevant == true
-			RETURN p
+      FILTER v.isRelevant == true
+      RETURN p
 
-	can now be optimized, and the traversal statement will only produce
-	paths where the last vertex has `isRelevant == true`.
+  can now be optimized, and the traversal statement will only produce
+  paths where the last vertex has `isRelevant == true`.
 
 * Fix BTS-450: RandomGenerator caught assertion during a value generation within
   `dump_maskings` testsuite. Ensure correct conversion between 64 and 32bit.
@@ -2282,10 +2282,10 @@ devel
 
 * Removed unused documentation snippets (non-Rest DocuBlocks) as well as the
   documentation about the long deprecated features Simple Queries and
-	JavaScript-based graph traversal. Also removed the descriptions of the
-	JS API methods `collection.range()`, `collection.closedRange()`,
-	`cursor.setBatchSize()` and `cursor.getBatchSize()`. All the functionality
-	is superseded by AQL.
+  JavaScript-based graph traversal. Also removed the descriptions of the
+  JS API methods `collection.range()`, `collection.closedRange()`,
+  `cursor.setBatchSize()` and `cursor.getBatchSize()`. All the functionality
+  is superseded by AQL.
 
 * Implemented APM-86: add query option `fillBlockCache` to control population
   of RocksDB block cache with data read by the query. The default value for
@@ -2789,11 +2789,11 @@ devel
 
 * Bug-fix in the case of very rare network issues there was a chance that
   an AQL query could get stuck during a cleanup and after a commit.
-	This would cause the client to receive a timeout, and the Coordinator
-	blocking a Scheduler thread. This situation is sorted out and the thread
-	will not be blocked anymore. We also added logs in case the query
-	could not successfully be cleaned up, which would leave locks on shards
-	behind.
+  This would cause the client to receive a timeout, and the Coordinator
+  blocking a Scheduler thread. This situation is sorted out and the thread
+  will not be blocked anymore. We also added logs in case the query
+  could not successfully be cleaned up, which would leave locks on shards
+  behind.
 
 * Switched to GCC 10 as the default compiler and use Sandy Bridge as the
   default required architecture (Linux, macOS binaries).
@@ -4890,8 +4890,8 @@ devel
 
 * Fixed issue ES-664: the optimizer rule `inline-subqueries` must not pull out
   subqueries that contains a COLLECT statement if the subquery is itself called
-	from within a loop. Otherwise the COLLECT will be applied to the values in the
-	outer FOR loop, which can produce a different result.
+  from within a loop. Otherwise the COLLECT will be applied to the values in the
+  outer FOR loop, which can produce a different result.
 
 * Fixed a blockage on hotbackup when writes are happening concurrently, since
   followers could no longer replicate leader transactions.
@@ -5777,20 +5777,20 @@ devel
 * Added feature: SatelliteGraphs
 
   SatelliteGraphs are a new type of graph, added in addition to the existing
-	ones, General Graphs and SmartGraphs.
+  ones, General Graphs and SmartGraphs.
 
-	When doing joins involving graph traversals, shortest path or k-shortest paths
-	computation in an ArangoDB cluster, data has to be exchanged between different
-	servers. In particular graph traversals are usually executed on a Coordinator,
-	because they need global information. This results in a lot of network traffic
-	and potentially slow query execution.
+  When doing joins involving graph traversals, shortest path or k-shortest paths
+  computation in an ArangoDB cluster, data has to be exchanged between different
+  servers. In particular graph traversals are usually executed on a Coordinator,
+  because they need global information. This results in a lot of network traffic
+  and potentially slow query execution.
 
   SatelliteGraphs are the natural extension of the concept of
-	SatelliteCollections to graphs. All of the usual benefits and caveats apply.
-	SatelliteGraphs are synchronously replicated to all DB-Servers that are part of
-	a cluster, which enables DB-Servers to execute graph traversals locally. This
-	includes (k-)shortest path(s) computation and possibly joins with traversals
-	and greatly improves performance for such queries.
+  SatelliteCollections to graphs. All of the usual benefits and caveats apply.
+  SatelliteGraphs are synchronously replicated to all DB-Servers that are part of
+  a cluster, which enables DB-Servers to execute graph traversals locally. This
+  includes (k-)shortest path(s) computation and possibly joins with traversals
+  and greatly improves performance for such queries.
 
 * Removed deprecated MMFiles storage engine and also the `arango-dfdb`
   (datafile debugger) executable that could be used to validate MMFiles
@@ -8704,7 +8704,7 @@ v3.4.0-rc.1 (2018-09-06)
   The `padded` key generator generates keys of a fixed length (16 bytes) in
   ascending lexicographical sort order.
 
-* The REST API of `/_admin/status` added: "operationMode" filed with same meaning as
+* The REST API of `/_admin/status` added: "operationMode" field with same meaning as
   the "mode" field and field "readOnly" that has the inverted meaning of the field
   "writeOpsEnabled". The old field names will be deprecated in upcoming versions.
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,14 @@
 devel
 -----
 
+* Renamed the `--frontend.*` startup options to `--web-interface.*`:
+
+  - `--frontend.proxy-request.check` -> `--web-interface.proxy-request.check`
+  - `--frontend.trusted-proxy` -> `--web-interface.trusted-proxy`
+  - `--frontend.version-check` -> `--web-interface.version-check`
+
+  The former startup options are still supported.
+
 * Now supporting projections on traversals. In AQL Traversal statements like
   FOR v,e,p IN 1..3 OUTBOUND @start GRAPH @graph RETURN v.name
   we will now detect attribute accesses on the data, in above example "v.name"

--- a/arangod/Cluster/ClusterFeature.cpp
+++ b/arangod/Cluster/ClusterFeature.cpp
@@ -107,7 +107,7 @@ void ClusterFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
                              true);
   options->addObsoleteOption("--cluster.disable-dispatcher-frontend",
                              "The dispatcher feature isn't available anymore; "
-                             "Use ArangoDBStarter for this now!",
+                             "Use ArangoDB Starter for this now!",
                              true);
   options->addObsoleteOption(
       "--cluster.dbserver-config",
@@ -289,7 +289,7 @@ void ClusterFeature::validateOptions(std::shared_ptr<ProgramOptions> options) {
           "cluster.disable-dispatcher-frontend")) {
     LOG_TOPIC("33707", FATAL, arangodb::Logger::CLUSTER)
         << "The dispatcher feature isn't available anymore. Use "
-        << "ArangoDBStarter for this now! See "
+        << "ArangoDB Starter for this now! See "
         << "https://github.com/arangodb-helper/arangodb/ for more "
         << "details.";
     FATAL_ERROR_EXIT();

--- a/arangod/GeneralServer/GeneralServerFeature.cpp
+++ b/arangod/GeneralServer/GeneralServerFeature.cpp
@@ -261,7 +261,10 @@ void GeneralServerFeature::collectOptions(
                   new BooleanParameter(&_allowEarlyConnections))
       .setIntroducedIn(31000);
 
-  options->addOption("--frontend.proxy-request-check",
+  options->addOldOption("frontend.proxy-request-check",
+                        "web-interface.proxy-request-check");
+
+  options->addOption("--web-interface.proxy-request-check",
                      "enable proxy request checking",
                      new BooleanParameter(&_proxyCheck),
                      arangodb::options::makeFlags(
@@ -269,9 +272,12 @@ void GeneralServerFeature::collectOptions(
                          arangodb::options::Flags::OnCoordinator,
                          arangodb::options::Flags::OnSingle));
 
-  options->addOption("--frontend.trusted-proxy",
+  options->addOldOption("frontend.trusted-proxy",
+                        "web-interface.trusted-proxy");
+
+  options->addOption("--web-interface.trusted-proxy",
                      "list of proxies to trust (may be IP or network). Make "
-                     "sure --frontend.proxy-request-check is enabled",
+                     "sure --web-interface.proxy-request-check is enabled",
                      new VectorParameter<StringParameter>(&_trustedProxies),
                      arangodb::options::makeFlags(
                          arangodb::options::Flags::DefaultNoComponents,

--- a/arangod/RestServer/FrontendFeature.cpp
+++ b/arangod/RestServer/FrontendFeature.cpp
@@ -40,9 +40,12 @@ FrontendFeature::FrontendFeature(Server& server)
 }
 
 void FrontendFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
-  options->addSection("frontend", "web interface");
+  options->addSection("web-interface", "browser-based frontend");
 
-  options->addOption("--frontend.version-check",
+  options->addOldOption("frontend.version-check",
+                        "web-interface.version-check");
+
+  options->addOption("--web-interface.version-check",
                      "alert the user if new versions are available",
                      new BooleanParameter(&_versionCheck),
                      arangodb::options::makeFlags(


### PR DESCRIPTION
### Scope & Purpose

Rename the `--frontend.*` startup options to `--web-interface.*`. All user-visible referenced to Aardvark should use the term "Web Interface".

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [x] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*
  - [ ] Backport for 3.7: *(Please link PR)*

#### Related Information

- [x] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
- [x] Slack conversation: https://arangodb.slack.com/archives/C0NQHDJ59/p1654896421316669
