### PR TITLE
Fix committed tick adjustments

### DIFF
--- a/arangod/IResearch/IResearchDataStore.cpp
+++ b/arangod/IResearch/IResearchDataStore.cpp
@@ -732,7 +732,6 @@ Result IResearchDataStore::commitUnsafeImpl(bool wait, CommitResult* code) {
   auto& impl = basics::downCast<IResearchFlushSubscription>(*subscription);
 
   try {
-    auto const lastTickBeforeCommit = _engine->currentTick();
 
     std::unique_lock commitLock{_commitMutex, std::try_to_lock};
     if (!commitLock.owns_lock()) {
@@ -751,7 +750,7 @@ Result IResearchDataStore::commitUnsafeImpl(bool wait, CommitResult* code) {
 
       commitLock.lock();
     }
-
+    auto const lastTickBeforeCommit = _engine->currentTick();
     auto const lastCommittedTick = _lastCommittedTick;
 
     try {

--- a/arangod/IResearch/IResearchDataStore.cpp
+++ b/arangod/IResearch/IResearchDataStore.cpp
@@ -732,7 +732,6 @@ Result IResearchDataStore::commitUnsafeImpl(bool wait, CommitResult* code) {
   auto& impl = basics::downCast<IResearchFlushSubscription>(*subscription);
 
   try {
-
     std::unique_lock commitLock{_commitMutex, std::try_to_lock};
     if (!commitLock.owns_lock()) {
       if (!wait) {


### PR DESCRIPTION
### Scope & Purpose

There was a small glitch between actual taking commitLock and reading the tick from engine.
If other commit could sneak by that will lead to assertion failure in the FlushSubscription.
The behaviour is covered by existing tests. No new tests introduced.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [] :hammer: Refactoring/simplification

### Checklist

- [x] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*
  - [ ] Backport for 3.7: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

