### PR TITLE
fix broken tests

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,14 @@
 devel
 -----
 
+* Changed HTTP response code for error number 1521 from 500 to 400.
+
+  Error 1521 (query collection lock failed) is nowadays only emitted by
+  traversals, when a collection is accessed during the traversal that has
+  not been specified in the WITH statement of the query. 
+  Thus returning HTTP 500 is not a good idea, as it is clearly a user error
+  that triggered the problem.
+
 * Renamed the `--frontend.*` startup options to `--web-interface.*`:
 
   - `--frontend.proxy-request.check` -> `--web-interface.proxy-request.check`

--- a/lib/Rest/GeneralResponse.cpp
+++ b/lib/Rest/GeneralResponse.cpp
@@ -300,6 +300,7 @@ rest::ResponseCode GeneralResponse::responseCode(ErrorCode code) {
     case static_cast<int>(TRI_ERROR_QUERY_VARIABLE_NAME_INVALID):
     case static_cast<int>(TRI_ERROR_QUERY_VARIABLE_REDECLARED):
     case static_cast<int>(TRI_ERROR_QUERY_VARIABLE_NAME_UNKNOWN):
+    case static_cast<int>(TRI_ERROR_QUERY_COLLECTION_LOCK_FAILED):
     case static_cast<int>(TRI_ERROR_QUERY_TOO_MANY_COLLECTIONS):
     case static_cast<int>(TRI_ERROR_QUERY_FUNCTION_NAME_UNKNOWN):
     case static_cast<int>(TRI_ERROR_QUERY_FUNCTION_ARGUMENT_NUMBER_MISMATCH):

--- a/tests/js/server/recovery/crash-handler-abort-noasan.js
+++ b/tests/js/server/recovery/crash-handler-abort-noasan.js
@@ -38,6 +38,9 @@ function runSetup () {
     // crash handler only available on Linux
     return;
   }
+  // make log level more verbose, as by default we hide most messages from
+  // the test output
+  require("internal").logLevel("crash=info");
   // calls std::abort() in the server
   internal.debugTerminate('CRASH-HANDLER-TEST-ABORT');
 }

--- a/tests/js/server/recovery/crash-handler-assert-noasan.js
+++ b/tests/js/server/recovery/crash-handler-assert-noasan.js
@@ -38,6 +38,9 @@ function runSetup () {
     // crash handler only available on Linux
     return;
   }
+  // make log level more verbose, as by default we hide most messages from
+  // the test output
+  require("internal").logLevel("crash=info");
   // produces an assertion failure in the server
   internal.debugTerminate('CRASH-HANDLER-TEST-ASSERT');
 }

--- a/tests/js/server/recovery/crash-handler-segfault-noasan.js
+++ b/tests/js/server/recovery/crash-handler-segfault-noasan.js
@@ -38,6 +38,9 @@ function runSetup () {
     // crash handler only available on Linux
     return;
   }
+  // make log level more verbose, as by default we hide most messages from
+  // the test output
+  require("internal").logLevel("crash=info");
   // produces a segfault in the server
   internal.debugTerminate('CRASH-HANDLER-TEST-SEGFAULT');
 }

--- a/tests/js/server/recovery/crash-handler-terminate-active-noasan.js
+++ b/tests/js/server/recovery/crash-handler-terminate-active-noasan.js
@@ -38,6 +38,9 @@ function runSetup () {
     // crash handler only available on Linux
     return;
   }
+  // make log level more verbose, as by default we hide most messages from
+  // the test output
+  require("internal").logLevel("crash=info");
   // calls std::terminate() in the server
   internal.debugTerminate('CRASH-HANDLER-TEST-TERMINATE-ACTIVE');
 }

--- a/tests/js/server/recovery/crash-handler-terminate-noasan.js
+++ b/tests/js/server/recovery/crash-handler-terminate-noasan.js
@@ -38,6 +38,9 @@ function runSetup () {
     // crash handler only available on Linux
     return;
   }
+  // make log level more verbose, as by default we hide most messages from
+  // the test output
+  require("internal").logLevel("crash=info");
   // calls std::terminate() in the server
   internal.debugTerminate('CRASH-HANDLER-TEST-TERMINATE');
 }


### PR DESCRIPTION
### Scope & Purpose

Fixes two issues:

1. Broken crash handler tests
   These tests were broken since the general test verbosity was reduced in devel a few months ago. these tests check for specific log messages, which were not emitted after the log verbosity was reduced. Now the tests specifically enable the log topic in question, so that all required log messages for the tests are emitted again.

2. Adjust HTTP response code for error number 1521 from 500 to 400
   Error 1521 (query collection lock failed) is nowadays only emitted in traversals, when a collection is accessed during the traversal that has not been specified in the WITH statement of the query. Thus returning HTTP 500 is not a good idea, as it is clear a user error that triggered the problem.

No backports are planned for this.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -
  - [ ] Backport for 3.7: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 