### PR TITLE
[CINFRA] Bugfix Log Supervision Loop

### DIFF
--- a/arangod/Replication2/ReplicatedLog/Supervision.cpp
+++ b/arangod/Replication2/ReplicatedLog/Supervision.cpp
@@ -355,15 +355,16 @@ auto checkLeaderRemovedFromTargetParticipants(SupervisionContext& ctx,
   TRI_ASSERT(log.current.has_value());
   auto const& current = *log.current;
 
-  if (!isConfigurationCommitted(log)) {
-    ctx.reportStatus<LogCurrentSupervision::WaitingForConfigCommitted>();
-    ctx.createAction<NoActionPossibleAction>();
-    return;
-  }
   auto const& committedParticipants =
       current.leader->committedParticipantsConfig->participants;
 
   if (!target.participants.contains(leader.serverId)) {
+    if (!isConfigurationCommitted(log)) {
+      ctx.reportStatus<LogCurrentSupervision::WaitingForConfigCommitted>();
+      ctx.createAction<NoActionPossibleAction>();
+      return;
+    }
+
     auto const acceptableLeaderSet = getParticipantsAcceptableAsLeaders(
         current.leader->serverId,
         current.leader->committedParticipantsConfig->participants);

--- a/arangod/Replication2/ReplicatedLog/Supervision.cpp
+++ b/arangod/Replication2/ReplicatedLog/Supervision.cpp
@@ -605,6 +605,7 @@ auto checkParticipantToRemove(SupervisionContext& ctx, Log const& log,
       } else {
         // still waiting
         ctx.reportStatus<LogCurrentSupervision::WaitingForConfigCommitted>();
+        ctx.createAction<NoActionPossibleAction>();
       }
     }
   }

--- a/arangod/Replication2/ReplicatedLog/Supervision.cpp
+++ b/arangod/Replication2/ReplicatedLog/Supervision.cpp
@@ -357,6 +357,7 @@ auto checkLeaderRemovedFromTargetParticipants(SupervisionContext& ctx,
 
   if (!isConfigurationCommitted(log)) {
     ctx.reportStatus<LogCurrentSupervision::WaitingForConfigCommitted>();
+    ctx.createAction<NoActionPossibleAction>();
     return;
   }
   auto const& committedParticipants =

--- a/tests/Replication2/Helper/ModelChecker/Actors.cpp
+++ b/tests/Replication2/Helper/ModelChecker/Actors.cpp
@@ -323,6 +323,23 @@ auto ReplaceSpecificServerActor::step(AgencyState const& agency) const
   return {ReplaceServerTargetState{oldServer, newServer}};
 }
 
+ReplaceSpecificLogServerActor::ReplaceSpecificLogServerActor(ParticipantId oldServer,
+                                                       ParticipantId newServer)
+    : oldServer(std::move(oldServer)), newServer(std::move(newServer)) {}
+
+auto ReplaceSpecificLogServerActor::step(AgencyState const& agency) const
+    -> std::vector<AgencyTransition> {
+  if (!agency.replicatedLog) {
+    return {};
+  }
+
+  auto const& target = agency.replicatedLog->target;
+  TRI_ASSERT(!target.participants.contains(newServer));
+  TRI_ASSERT(target.participants.contains(oldServer));
+
+  return {ReplaceServerTargetLog{oldServer, newServer}};
+}
+
 SetLeaderActor::SetLeaderActor(ParticipantId leader) : newLeader(leader) {}
 
 auto SetLeaderActor::step(AgencyState const& agency) const

--- a/tests/Replication2/Helper/ModelChecker/Actors.h
+++ b/tests/Replication2/Helper/ModelChecker/Actors.h
@@ -180,8 +180,18 @@ struct ReplaceAnyServerActor : OnceActorBase<ReplaceAnyServerActor> {
 
   replication2::ParticipantId newServer;
 };
+
 struct ReplaceSpecificServerActor : OnceActorBase<ReplaceSpecificServerActor> {
   explicit ReplaceSpecificServerActor(replication2::ParticipantId oldServer,
+                                      replication2::ParticipantId newServer);
+  auto step(AgencyState const& agency) const -> std::vector<AgencyTransition>;
+
+  replication2::ParticipantId oldServer;
+  replication2::ParticipantId newServer;
+};
+
+struct ReplaceSpecificLogServerActor : OnceActorBase<ReplaceSpecificLogServerActor> {
+  explicit ReplaceSpecificLogServerActor(replication2::ParticipantId oldServer,
                                       replication2::ParticipantId newServer);
   auto step(AgencyState const& agency) const -> std::vector<AgencyTransition>;
 

--- a/tests/Replication2/Helper/ModelChecker/AgencyTransition.cpp
+++ b/tests/Replication2/Helper/ModelChecker/AgencyTransition.cpp
@@ -213,6 +213,22 @@ void ReplaceServerTargetState::apply(AgencyState& agency) const {
   target.version.emplace(target.version.value_or(0) + 1);
 }
 
+ReplaceServerTargetLog::ReplaceServerTargetLog(ParticipantId oldServer,
+                                                   ParticipantId newServer)
+    : oldServer(std::move(oldServer)), newServer(std::move(newServer)) {}
+
+auto ReplaceServerTargetLog::toString() const -> std::string {
+  return fmt::format("replacing {} with {}", oldServer, newServer);
+}
+
+void ReplaceServerTargetLog::apply(AgencyState& agency) const {
+  TRI_ASSERT(agency.replicatedLog.has_value());
+  auto& target = agency.replicatedLog->target;
+  target.participants.erase(oldServer);
+  target.participants[newServer];
+  target.version.emplace(target.version.value_or(0) + 1);
+}
+
 auto SetLeaderInTargetAction::toString() const -> std::string {
   return fmt::format("setting `{}` as leader in target", newLeader);
 }

--- a/tests/Replication2/Helper/ModelChecker/AgencyTransitions.h
+++ b/tests/Replication2/Helper/ModelChecker/AgencyTransitions.h
@@ -103,6 +103,15 @@ struct ReplaceServerTargetState {
   replication2::ParticipantId newServer;
 };
 
+struct ReplaceServerTargetLog {
+  ReplaceServerTargetLog(replication2::ParticipantId oldServer,
+                         replication2::ParticipantId newServer);
+  void apply(AgencyState& agency) const;
+  auto toString() const -> std::string;
+  replication2::ParticipantId oldServer;
+  replication2::ParticipantId newServer;
+};
+
 struct SetLeaderInTargetAction {
   SetLeaderInTargetAction(replication2::ParticipantId newLeader);
   void apply(AgencyState& agency) const;
@@ -153,7 +162,7 @@ using AgencyTransition =
                  ReplaceServerTargetState, AddLogParticipantAction,
                  SetLeaderInTargetAction, RemoveLogParticipantAction,
                  SetWriteConcernAction, SetSoftWriteConcernAction,
-                 SetBothWriteConcernAction>;
+                 SetBothWriteConcernAction, ReplaceServerTargetLog>;
 
 auto operator<<(std::ostream& os, AgencyTransition const& a) -> std::ostream&;
 }  // namespace arangodb::test

--- a/tests/Replication2/ReplicatedLog/SupervisionSimulationTest.cpp
+++ b/tests/Replication2/ReplicatedLog/SupervisionSimulationTest.cpp
@@ -320,6 +320,7 @@ TEST_F(ReplicatedLogSupervisionSimulationTest, check_log_set_leader) {
   EXPECT_FALSE(result.failed) << *result.failed;
   std::cout << result.stats << std::endl;
 }
+
 TEST_F(ReplicatedLogSupervisionSimulationTest, check_log_change_config) {
   AgencyLogBuilder log;
   log.setTargetConfig(LogTargetConfig(2, 2, true))
@@ -391,4 +392,51 @@ TEST_F(ReplicatedLogSupervisionSimulationTest, check_log_change_config) {
                   {.iterations = 20000, .seed = this->seed(ADB_HERE)});
   EXPECT_FALSE(result.failed) << *result.failed;
   //  std::cout << result.stats << std::endl;
+}
+
+TEST_F(ReplicatedLogSupervisionSimulationTest, check_log_replace_leader) {
+  AgencyLogBuilder log;
+  log.setTargetConfig(LogTargetConfig(2, 2, true))
+      .setId(logId)
+      .setTargetParticipant("A", defaultFlags)
+      .setTargetParticipant("B", defaultFlags)
+      .setTargetParticipant("C", defaultFlags);
+
+  log.setPlanParticipant("A", defaultFlags)
+      .setPlanParticipant("B", defaultFlags)
+      .setPlanParticipant("C", defaultFlags);
+  log.setPlanLeader("A");
+  log.establishLeadership();
+  log.acknowledgeTerm("A").acknowledgeTerm("B").acknowledgeTerm("C");
+
+  replicated_log::ParticipantsHealth health;
+  health._health.emplace(
+      "A", replicated_log::ParticipantHealth{.rebootId = RebootId(0),
+                                             .notIsFailed = true});
+  health._health.emplace(
+      "B", replicated_log::ParticipantHealth{.rebootId = RebootId(0),
+                                             .notIsFailed = true});
+  health._health.emplace(
+      "C", replicated_log::ParticipantHealth{.rebootId = RebootId(0),
+                                             .notIsFailed = true});
+  health._health.emplace(
+      "D", replicated_log::ParticipantHealth{.rebootId = RebootId(0),
+                                             .notIsFailed = true});
+
+  auto initState =
+      AgencyState{.replicatedLog = log.get(), .health = std::move(health)};
+
+  auto driver = model_checker::ActorDriver{
+      SupervisionActor{}, ReplaceSpecificLogServerActor{"A", "D"},
+      DBServerActor{"A"}, DBServerActor{"B"}, DBServerActor{"C"}, DBServerActor{"D"}};
+
+  auto allTests = model_checker::combined{
+      MC_EVENTUALLY_ALWAYS(mcpreds::isLeaderHealth()),
+      MC_EVENTUALLY_ALWAYS(mcpreds::isParticipantNotPlanned("A"))};
+  using Engine = model_checker::ActorEngine<model_checker::DFSEnumerator,
+                                            AgencyState, AgencyTransition>;
+
+  auto result = Engine::run(driver, allTests, initState);
+  EXPECT_FALSE(result.failed) << *result.failed;
+  std::cout << result.stats << std::endl;
 }

--- a/tests/Replication2/ReplicatedLog/SupervisionTest.cpp
+++ b/tests/Replication2/ReplicatedLog/SupervisionTest.cpp
@@ -408,16 +408,11 @@ TEST_F(LogSupervisionTest, test_remove_participant_action_wait_for_committed) {
 
   auto const& r = ctx.getReport();
 
-  // TODO: we get two "Waiting for config committed", and the source
-  //       of this report should be made obvious.
-  EXPECT_EQ(r.size(), 2);
+  EXPECT_EQ(r.size(), 1);
 
   EXPECT_TRUE(
       std::holds_alternative<LogCurrentSupervision::WaitingForConfigCommitted>(
           r[0]));
-  EXPECT_TRUE(
-      std::holds_alternative<LogCurrentSupervision::WaitingForConfigCommitted>(
-          r[1]));
 }
 
 TEST_F(LogSupervisionTest, test_remove_participant_action_committed) {

--- a/tests/Replication2/ReplicatedLog/SupervisionTest.cpp
+++ b/tests/Replication2/ReplicatedLog/SupervisionTest.cpp
@@ -400,8 +400,13 @@ TEST_F(LogSupervisionTest, test_remove_participant_action_wait_for_committed) {
 
   checkReplicatedLog(ctx, log, health);
 
-  EXPECT_FALSE(ctx.hasAction());
-  auto const r = ctx.getReport();
+  EXPECT_TRUE(ctx.hasAction());
+  auto const& a = ctx.getAction();
+
+  EXPECT_TRUE(std::holds_alternative<NoActionPossibleAction>(a))
+      << fmt::format("{}", a);
+
+  auto const& r = ctx.getReport();
 
   // TODO: we get two "Waiting for config committed", and the source
   //       of this report should be made obvious.


### PR DESCRIPTION
### Scope & Purpose

When the log supervision was trying to force a participant to become
leader and then waited for that configuration to be committed, it did
not put a NoActionPossibleAction into the context which lead to the
forced flag on the selected participant to be reset again.


- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [x] Tests
  - [x] **Regression tests**
  - [x] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
