### PR TITLE
[3.9] Reduce maintainer mode stack usage

### DIFF
--- a/lib/Basics/debugging.cpp
+++ b/lib/Basics/debugging.cpp
@@ -205,7 +205,7 @@ char const conpar<false>::open = '[';
 template<>
 char const conpar<false>::close = ']';
 
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
 thread_local std::ostringstream
     arangodb::debug::AssertionLogger::assertionStringStream;
-thread_local arangodb::debug::AssertionConditionalStream
-    arangodb::debug::AssertionConditionalLogger::assertionStringStream;
+#endif


### PR DESCRIPTION
### Scope & Purpose

Partial backport of https://github.com/arangodb/arangodb/pull/16308:

Reduce stack usage of assertions in maintainer mode.