### PR TITLE
[CINFRA] Fix Document State Feature Dependencies

### DIFF
--- a/arangod/Replication2/StateMachines/Document/DocumentStateMachineFeature.cpp
+++ b/arangod/Replication2/StateMachines/Document/DocumentStateMachineFeature.cpp
@@ -58,5 +58,6 @@ DocumentStateMachineFeature::DocumentStateMachineFeature(Server& server)
   startsAfter<ClusterFeature>();
   startsAfter<MaintenanceFeature>();
   startsAfter<ReplicatedStateAppFeature>();
+  onlyEnabledWith<ClusterFeature>();
   onlyEnabledWith<ReplicatedStateAppFeature>();
 }


### PR DESCRIPTION
### Scope & Purpose

There is a problem during the upgrade tests, when the `ClusterFeature` is not enabled, but the `DocumentStateMachineFeature` tries to access it, and thus triggers an exception during startup.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*
  - [ ] Backport for 3.7: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

