### PR TITLE
Fix thread ids and names in logs for 3rd party code threads

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,11 @@
 devel
 -----
 
+* Fix thread ids and thread names in log output for threads that are not
+  started directly by ArangoDB code, but indirectly via library code.
+  Previously, the ids of these threads were always reported as "1", and
+  the thread name was "main". Now return proper thread ids and names.
+
 * Changed default Linux CI compiler to gcc-11.
 
 * Updated arangosync to v2.11.0-preview-2.

--- a/arangod/Cluster/ClusterInfo.cpp
+++ b/arangod/Cluster/ClusterInfo.cpp
@@ -6921,10 +6921,12 @@ void ClusterInfo::SyncerThread::beginShutdown() {
 }
 
 bool ClusterInfo::SyncerThread::start() {
+  ThreadNameFetcher nameFetcher;
+  std::string_view name = nameFetcher.get();
+
   LOG_TOPIC("38256", DEBUG, Logger::CLUSTER)
       << "Starting "
-      << (currentThreadName() != nullptr ? currentThreadName()
-                                         : "by unknown thread");
+      << (name.empty() ? std::string_view("by unknown thread") : name);
   return Thread::start();
 }
 

--- a/lib/Basics/CrashHandler.cpp
+++ b/lib/Basics/CrashHandler.cpp
@@ -220,15 +220,12 @@ size_t buildLogMessage(char* s, std::string_view context, int signal,
       uint64_t(arangodb::Thread::currentThreadNumber()), p);
 
 #ifdef __linux__
-  char const* name = arangodb::Thread::currentThreadName();
-#else
-  char const* name = nullptr;
+  arangodb::ThreadNameFetcher nameFetcher;
+  std::string_view name = nameFetcher.get();
+  appendNullTerminatedString(" [", p);
+  appendNullTerminatedString(name, p);
+  appendNullTerminatedString("]", p);
 #endif
-  if (name != nullptr && *name != '\0') {
-    appendNullTerminatedString(" [", p);
-    appendNullTerminatedString(name, p);
-    appendNullTerminatedString("]", p);
-  }
 
   appendNullTerminatedString(" caught unexpected signal ", p);
   p += arangodb::basics::StringUtils::itoa(uint64_t(signal), p);
@@ -319,9 +316,9 @@ void logBacktrace() try {
     return;
   }
 
-  char const* currentThreadName = arangodb::Thread::currentThreadName();
-  if (currentThreadName != nullptr &&
-      strcmp("Logging", currentThreadName) == 0) {
+  arangodb::ThreadNameFetcher nameFetcher;
+  std::string_view currentThreadName = nameFetcher.get();
+  if (currentThreadName == arangodb::Logger::logThreadName) {
     // we must not log a backtrace from the logging thread itself. if we would
     // do, we may cause a deadlock
     return;
@@ -338,12 +335,11 @@ void logBacktrace() try {
 
     p += arangodb::basics::StringUtils::itoa(
         uint64_t(arangodb::Thread::currentThreadNumber()), p);
-    char const* name = arangodb::Thread::currentThreadName();
-    if (name != nullptr && *name != '\0') {
-      appendNullTerminatedString(" [", p);
-      appendNullTerminatedString(name, p);
-      appendNullTerminatedString("]", p);
-    }
+    arangodb::ThreadNameFetcher nameFetcher;
+    std::string_view name = nameFetcher.get();
+    appendNullTerminatedString(" [", p);
+    appendNullTerminatedString(name, p);
+    appendNullTerminatedString("]", p);
 
     LOG_TOPIC("c962b", INFO, arangodb::Logger::CRASH)
         << arangodb::Logger::CHARS(&buffer[0], p - &buffer[0]);

--- a/lib/Basics/Thread.h
+++ b/lib/Basics/Thread.h
@@ -25,6 +25,8 @@
 #pragma once
 
 #include <atomic>
+#include <string>
+#include <string_view>
 
 #include "Basics/threads.h"
 
@@ -35,6 +37,21 @@ class ApplicationServer;
 namespace basics {
 class ConditionVariable;
 }
+
+class ThreadNameFetcher {
+ public:
+  ThreadNameFetcher() noexcept;
+  ThreadNameFetcher(ThreadNameFetcher const&) = delete;
+  ThreadNameFetcher& operator=(ThreadNameFetcher const&) = delete;
+
+  // retrieve the current thread's name. the string view will
+  // remain valid as long as the ThreadNameFetcher remains valid.
+  std::string_view get() const noexcept;
+
+ private:
+  // stored retrieved thread name, used by the ctor
+  char _buffer[32];
+};
 
 /// @brief thread
 ///
@@ -72,11 +89,7 @@ class Thread {
   ///
   /// Note that there is a companion function "threadNumber", which returns
   /// the thread number of a running thread.
-  static uint64_t currentThreadNumber();
-
-  /// @brief returns the name of the current thread, if set
-  /// note that this function may return a nullptr
-  static char const* currentThreadName();
+  static uint64_t currentThreadNumber() noexcept;
 
   /// @brief returns the thread id
   static TRI_tid_t currentThreadId();

--- a/lib/Logger/Logger.h
+++ b/lib/Logger/Logger.h
@@ -59,6 +59,7 @@
 #include <functional>
 #include <memory>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
@@ -257,6 +258,8 @@ class Logger {
   };
 
  public:
+  static constexpr std::string_view logThreadName = "Logging";
+
   static LogGroup& defaultLogGroup();
   static LogLevel logLevel();
   static std::unordered_set<std::string> structuredLogParams();


### PR DESCRIPTION
### Scope & Purpose

* Fix thread ids and thread names in log output for threads that are not
  started directly by ArangoDB code, but indirectly via library code.
  Previously, the ids of these threads were always reported as "1", and
  the thread name was "main". Now return proper thread ids and names.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -
  - [ ] Backport for 3.7: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 