### PR TITLE
fix duplicate acquisition of thread name

### DIFF
--- a/lib/Basics/CrashHandler.cpp
+++ b/lib/Basics/CrashHandler.cpp
@@ -335,10 +335,8 @@ void logBacktrace() try {
 
     p += arangodb::basics::StringUtils::itoa(
         uint64_t(arangodb::Thread::currentThreadNumber()), p);
-    arangodb::ThreadNameFetcher nameFetcher;
-    std::string_view name = nameFetcher.get();
     appendNullTerminatedString(" [", p);
-    appendNullTerminatedString(name, p);
+    appendNullTerminatedString(currentThreadName, p);
     appendNullTerminatedString("]", p);
 
     LOG_TOPIC("c962b", INFO, arangodb::Logger::CRASH)


### PR DESCRIPTION
### Scope & Purpose

Micro optimization: fix duplication acquisition of thread name in case we are going to crash.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -
  - [ ] Backport for 3.7: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 