### PR TITLE
simplify internal API for sslMD5 overload

### DIFF
--- a/lib/Ssl/SslInterface.cpp
+++ b/lib/Ssl/SslInterface.cpp
@@ -58,20 +58,18 @@ static UniformCharacter SaltGenerator(
     "[]:;<>,.?/|");
 }
 
-namespace arangodb {
-namespace rest {
-namespace SslInterface {
+namespace arangodb::rest::SslInterface {
 
 // -----------------------------------------------------------------------------
 // public methods
 // -----------------------------------------------------------------------------
 
-std::string sslMD5(std::string const& inputStr) {
+std::string sslMD5(std::string_view input) {
   char hash[17];
   char* p = &hash[0];
   size_t length;
 
-  sslMD5(inputStr.c_str(), inputStr.size(), p, length);
+  sslMD5(input.data(), input.size(), p, length);
 
   char hex[33];
   p = &hex[0];
@@ -389,6 +387,4 @@ int rsaPrivSign(std::string const& pem, std::string const& msg,
   return rsaPrivSign(ctx, pKey, msg, sign, error);
 }
 
-}  // namespace SslInterface
-}  // namespace rest
-}  // namespace arangodb
+}  // namespace arangodb::rest::SslInterface

--- a/lib/Ssl/SslInterface.h
+++ b/lib/Ssl/SslInterface.h
@@ -25,12 +25,11 @@
 
 #include <cstdlib>
 #include <string>
+#include <string_view>
 
 #include "Basics/Common.h"
 
-namespace arangodb {
-namespace rest {
-namespace SslInterface {
+namespace arangodb::rest::SslInterface {
 
 enum Algorithm {
   ALGORITHM_SHA256 = 0,
@@ -45,7 +44,7 @@ enum Algorithm {
 /// @brief md5 hash
 //////////////////////////////////////////////////////////////////////////
 
-std::string sslMD5(std::string const&);
+std::string sslMD5(std::string_view);
 
 //////////////////////////////////////////////////////////////////////////
 /// @brief md5 hash
@@ -208,6 +207,4 @@ int sslRand(int32_t*);
 int rsaPrivSign(std::string const& pem, std::string const& msg,
                 std::string& sign, std::string& error);
 
-}  // namespace SslInterface
-}  // namespace rest
-}  // namespace arangodb
+}  // namespace arangodb::rest::SslInterface


### PR DESCRIPTION
### Scope & Purpose

Make an overload of `SslInterface::sslMD5()` easier to use.
This is an internal-only change.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -
  - [ ] Backport for 3.7: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 