### PR TITLE
[PREGEL] APM-538 Add reporting for loading state observables

### DIFF
--- a/arangod/Pregel/Conductor.cpp
+++ b/arangod/Pregel/Conductor.cpp
@@ -333,7 +333,7 @@ void Conductor::workerStatusUpdate(VPackSlice const& data) {
 
   LOG_PREGEL("76632", INFO) << fmt::format("Update received {}", data.toJson());
 
-  _status.updateWorkerStatus(sender, update);
+  _status.updateWorkerStatus(sender, std::move(update));
 }
 
 void Conductor::finishedWorkerStartup(VPackSlice const& data) {

--- a/arangod/Pregel/Conductor.cpp
+++ b/arangod/Pregel/Conductor.cpp
@@ -35,7 +35,7 @@
 #include "Pregel/PregelFeature.h"
 #include "Pregel/Recovery.h"
 #include "Pregel/Utils.h"
-#include "Pregel/Status/WorkerStatus.h"
+#include "Pregel/Status/Status.h"
 #include "Pregel/Status/ConductorStatus.h"
 
 #include "ApplicationFeatures/ApplicationServer.h"
@@ -328,7 +328,7 @@ void Conductor::workerStatusUpdate(VPackSlice const& data) {
   // TODO: for these updates we do not care about uniqueness of responses
   // _ensureUniqueResponse(data);
 
-  auto update = deserialize<WorkerStatus>(data.get(Utils::payloadKey));
+  auto update = deserialize<Status>(data.get(Utils::payloadKey));
   auto sender = data.get(Utils::senderKey).copyString();
 
   LOG_PREGEL("76632", INFO) << fmt::format("Update received {}", data.toJson());
@@ -978,7 +978,8 @@ void Conductor::toVelocyPack(VPackBuilder& result) const {
   result.add("useMemoryMaps", VPackValue(_useMemoryMaps));
 
   result.add(VPackValue("detail"));
-  serialize(result, _status);
+  auto conductorStatus = _status.accumulate();
+  serialize(result, conductorStatus);
 
   result.close();
 }

--- a/arangod/Pregel/GraphStore.h
+++ b/arangod/Pregel/GraphStore.h
@@ -28,6 +28,7 @@
 #include "Pregel/GraphFormat.h"
 #include "Pregel/Iterators.h"
 #include "Pregel/Reports.h"
+#include "Pregel/Status/Status.h"
 #include "Pregel/TypedBuffer.h"
 #include "Utils/DatabaseGuard.h"
 
@@ -72,6 +73,8 @@ class GraphStore final {
   uint64_t numberVertexSegments() const { return _vertices.size(); }
   uint64_t localVertexCount() const { return _localVertexCount; }
   uint64_t localEdgeCount() const { return _localEdgeCount; }
+
+  Status status() const { return _observables.observe(); }
 
   GraphFormat<V, E> const* graphFormat() { return _graphFormat.get(); }
 
@@ -134,6 +137,8 @@ class GraphStore final {
   std::vector<std::unique_ptr<TypedBuffer<Edge<E>>>> _edges;
   std::vector<TypedBuffer<Edge<E>>*> _nextEdgeBuffer;
   std::vector<std::unique_ptr<TypedBuffer<char>>> _edgeKeys;
+
+  Observables _observables;
 
   // cache the amount of vertices
   std::set<ShardID> _loadedShards;

--- a/arangod/Pregel/Status/ConductorStatus.h
+++ b/arangod/Pregel/Status/ConductorStatus.h
@@ -61,11 +61,11 @@ struct ConductorStatus {
     }
     return status;
   }
-  auto updateWorkerStatus(ServerID const& id, Status const& status) -> void {
+  auto updateWorkerStatus(ServerID const& id, Status&& status) -> void {
     workers.at(id) = status;
   }
   auto accumulate() const -> AccumulatedConductorStatus {
-    Status aggregate = std::accumulate(
+    auto aggregate = std::accumulate(
         workers.begin(), workers.end(), Status{.timeStamp = TimeStamp::min()},
         [](Status const& accumulation,
            std::unordered_map<ServerID, Status>::value_type const& workers) {

--- a/arangod/Pregel/Status/ConductorStatus.h
+++ b/arangod/Pregel/Status/ConductorStatus.h
@@ -25,6 +25,7 @@
 #include <chrono>
 #include <cstddef>
 #include <cstdint>
+#include <numeric>
 #include <string>
 
 #include <Inspection/VPack.h>
@@ -33,34 +34,45 @@
 #include <Cluster/ClusterTypes.h>
 
 #include <Pregel/Common.h>
-#include <Pregel/Status/WorkerStatus.h>
+#include <Pregel/Status/Status.h>
 
 namespace arangodb::pregel {
 
-struct ConductorStatus {
-  TimeStamp timeStamp = std::chrono::system_clock::now();
-  std::unordered_map<ServerID, WorkerStatus> workers;
-
-  static auto forWorkers(std::vector<ServerID> const& ids) -> ConductorStatus {
-    auto status = ConductorStatus{};
-    for (auto const& id : ids) {
-      status.workers.emplace(id, WorkerStatus{});
-    }
-    return status;
-  }
-  auto updateWorkerStatus(ServerID const& id, WorkerStatus const& status)
-      -> void {
-    workers.at(id) = status;
-    timeStamp = status.timeStamp;
-  }
+struct AccumulatedConductorStatus {
+  Status status;
+  std::unordered_map<ServerID, Status> workers;
+  bool operator==(AccumulatedConductorStatus const&) const = default;
 };
 
 template<typename Inspector>
-auto inspect(Inspector& f, ConductorStatus& x) {
+auto inspect(Inspector& f, AccumulatedConductorStatus& x) {
   return f.object(x).fields(
-      f.field(timeStampString, x.timeStamp)
-          .transformWith(inspection::TimeStampTransformer{}),
+      f.field("aggregatedStatus",
+              x.status),  // TODO status entries should be on top level
       f.field("workerStatus", x.workers));
 }
+
+struct ConductorStatus {
+  std::unordered_map<ServerID, Status> workers;
+  static auto forWorkers(std::vector<ServerID> const& ids) -> ConductorStatus {
+    auto status = ConductorStatus{};
+    for (auto const& id : ids) {
+      status.workers.emplace(id, Status{});
+    }
+    return status;
+  }
+  auto updateWorkerStatus(ServerID const& id, Status const& status) -> void {
+    workers.at(id) = status;
+  }
+  auto accumulate() const -> AccumulatedConductorStatus {
+    Status aggregate = std::accumulate(
+        workers.begin(), workers.end(), Status{.timeStamp = TimeStamp::min()},
+        [](Status const& accumulation,
+           std::unordered_map<ServerID, Status>::value_type const& workers) {
+          return accumulation + workers.second;
+        });
+    return AccumulatedConductorStatus{.status = aggregate, .workers = workers};
+  }
+};
 
 }  // namespace arangodb::pregel

--- a/arangod/Pregel/Status/Status.h
+++ b/arangod/Pregel/Status/Status.h
@@ -22,6 +22,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 #pragma once
 
+#include <atomic>
 #include <chrono>
 #include <cstddef>
 #include <cstdint>
@@ -34,10 +35,16 @@
 
 namespace arangodb::pregel {
 struct Status {
-  TimeStamp timeStamp = std::chrono::system_clock::now();
+  TimeStamp timeStamp{std::chrono::system_clock::now()};
+  std::size_t verticesLoaded{0};
+  std::size_t edgesLoaded{0};
+  std::size_t memoryBytesUsed{0};
   bool operator==(Status const&) const = default;
-  auto operator+(Status const& otherStatus) const -> Status {
-    return Status{.timeStamp = std::max(timeStamp, otherStatus.timeStamp)};
+  auto operator+(Status const& other) const -> Status {
+    return Status{.timeStamp = std::max(timeStamp, other.timeStamp),
+                  .verticesLoaded = verticesLoaded + other.verticesLoaded,
+                  .edgesLoaded = edgesLoaded + other.edgesLoaded,
+                  .memoryBytesUsed = memoryBytesUsed + other.memoryBytesUsed};
   };
 };
 
@@ -45,7 +52,20 @@ template<typename Inspector>
 auto inspect(Inspector& f, Status& x) {
   return f.object(x).fields(
       f.field(timeStampString, x.timeStamp)
-          .transformWith(inspection::TimeStampTransformer{}));
+          .transformWith(inspection::TimeStampTransformer{}),
+      f.field("verticesLoaded", x.verticesLoaded),
+      f.field("edgesLoaded", x.edgesLoaded),
+      f.field("memoryUsed", x.memoryBytesUsed));
 }
 
+struct Observables {
+  std::atomic<std::size_t> verticesLoaded{0};
+  std::atomic<std::size_t> edgesLoaded{0};
+  std::atomic<std::size_t> memoryBytesUsed{0};
+  auto observe() const -> Status {
+    return Status{.verticesLoaded = verticesLoaded.load(),
+                  .edgesLoaded = edgesLoaded.load(),
+                  .memoryBytesUsed = memoryBytesUsed.load()};
+  }
+};
 }  // namespace arangodb::pregel

--- a/arangod/Pregel/Status/Status.h
+++ b/arangod/Pregel/Status/Status.h
@@ -33,12 +33,16 @@
 #include <Pregel/Common.h>
 
 namespace arangodb::pregel {
-struct WorkerStatus {
+struct Status {
   TimeStamp timeStamp = std::chrono::system_clock::now();
+  bool operator==(Status const&) const = default;
+  auto operator+(Status const& otherStatus) const -> Status {
+    return Status{.timeStamp = std::max(timeStamp, otherStatus.timeStamp)};
+  };
 };
 
 template<typename Inspector>
-auto inspect(Inspector& f, WorkerStatus& x) {
+auto inspect(Inspector& f, Status& x) {
   return f.object(x).fields(
       f.field(timeStampString, x.timeStamp)
           .transformWith(inspection::TimeStampTransformer{}));

--- a/arangod/Pregel/Worker.cpp
+++ b/arangod/Pregel/Worker.cpp
@@ -31,7 +31,7 @@
 #include "Pregel/PregelFeature.h"
 #include "Pregel/VertexComputation.h"
 
-#include "Pregel/Status/WorkerStatus.h"
+#include "Pregel/Status/Status.h"
 
 #include "ApplicationFeatures/ApplicationServer.h"
 #include "Basics/WriteLocker.h"
@@ -169,7 +169,7 @@ void Worker<V, E, M>::setupWorker() {
       statusUpdateMsg.add(Utils::executionNumberKey,
                           VPackValue(_config.executionNumber()));
       statusUpdateMsg.add(VPackValue(Utils::payloadKey));
-      auto update = WorkerStatus{};
+      auto update = Status{};
       serialize(statusUpdateMsg, update);
     }
 

--- a/arangod/Pregel/Worker.cpp
+++ b/arangod/Pregel/Worker.cpp
@@ -169,7 +169,7 @@ void Worker<V, E, M>::setupWorker() {
       statusUpdateMsg.add(Utils::executionNumberKey,
                           VPackValue(_config.executionNumber()));
       statusUpdateMsg.add(VPackValue(Utils::payloadKey));
-      auto update = Status{};
+      auto update = _graphStore->status();
       serialize(statusUpdateMsg, update);
     }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -251,6 +251,7 @@ set(ARANGODB_TESTS_SOURCES
   Network/MethodsTest.cpp
   Network/UtilsTest.cpp
   Pregel/typedbuffer.cpp
+  Pregel/StatusTest.cpp
   ProgramOptions/InifileParserTest.cpp
   ProgramOptions/ParametersTest.cpp
   Replication/ReplicationClientsProgressTrackerTest.cpp

--- a/tests/Pregel/StatusTest.cpp
+++ b/tests/Pregel/StatusTest.cpp
@@ -1,0 +1,58 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2022 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Julia Volmer
+////////////////////////////////////////////////////////////////////////////////
+
+#include <date/date.h>
+#include <chrono>
+#include "Pregel/Common.h"
+#include "Pregel/Status/ConductorStatus.h"
+#include "Pregel/Status/Status.h"
+
+#include "Pregel/Status/ConductorStatus.h"
+#include "gtest/gtest.h"
+
+using namespace arangodb::pregel;
+
+TEST(PregelStatus,
+     adding_two_status_gives_a_status_with_the_most_recent_timestamp) {
+  auto earlierStatus =
+      Status{.timeStamp = date::sys_days{date::March / 4 / 2020}};
+  auto laterStatus =
+      Status{.timeStamp = date::sys_days{date::March / 7 / 2020}};
+
+  ASSERT_EQ(earlierStatus + laterStatus,
+            Status{.timeStamp = laterStatus.timeStamp});
+}
+
+TEST(PregelConductorStatus, accumulates_worker_status) {
+  auto workers = std::unordered_map<arangodb::ServerID, Status>{
+      {"worker_with_later_status",
+       Status{.timeStamp = date::sys_days{date::March / 7 / 2020}}},
+      {"worker_with_earlier_status",
+       Status{.timeStamp = date::sys_days{date::March / 4 / 2020}}}};
+  auto conductorStatus = ConductorStatus{.workers = workers};
+
+  ASSERT_EQ(conductorStatus.accumulate(),
+            (AccumulatedConductorStatus{
+                .status = workers.at("worker_with_later_status"),
+                .workers = workers}));
+}


### PR DESCRIPTION
Measure number of vertices, number of edges and memory used when loading the graph into pregel.
Measurements of workers are aggregated only when required.