### PR TITLE
Add time format utc-datestring-micros

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,9 @@
 devel
 -----
+
+* Add log.time-format utc-datestring-micros to make debugging of concurrency
+  bugs easier.
+
 * Renamed KShortestPathsNode to EnumeratePathsNote; this is visible in 
   explain outputs for AQL queries.
 

--- a/lib/Basics/datetime.h
+++ b/lib/Basics/datetime.h
@@ -36,6 +36,8 @@ namespace arangodb {
 
 using tp_sys_clock_ms = std::chrono::time_point<std::chrono::system_clock,
                                                 std::chrono::milliseconds>;
+using tp_sys_clock_us = std::chrono::time_point<std::chrono::system_clock,
+                                                std::chrono::microseconds>;
 
 using d_sys_clock_ms = std::chrono::duration<std::chrono::milliseconds>;
 

--- a/lib/Logger/LogTimeFormat.h
+++ b/lib/Logger/LogTimeFormat.h
@@ -39,6 +39,7 @@ enum class TimeFormat {
   UnixTimestampMicros,
   UTCDateString,
   UTCDateStringMillis,
+  UTCDateStringMicros,
   LocalDateString,
 };
 

--- a/tests/Basics/LoggerTest.cpp
+++ b/tests/Basics/LoggerTest.cpp
@@ -221,6 +221,11 @@ TEST_F(LoggerTest, testTimeFormats) {
     EXPECT_EQ("2016-12-11T14:02:43.000Z", out);
 
     out.clear();
+    LogTimeFormats::writeTime(
+        out, LogTimeFormats::TimeFormat::UTCDateStringMicros, tp, startTp);
+    EXPECT_EQ("2016-12-11T14:02:43.000000Z", out);
+
+    out.clear();
     LogTimeFormats::writeTime(out, LogTimeFormats::TimeFormat::LocalDateString,
                               tp, startTp);
     ASSERT_TRUE(std::regex_match(
@@ -287,6 +292,11 @@ TEST_F(LoggerTest, testTimeFormats) {
     LogTimeFormats::writeTime(
         out, LogTimeFormats::TimeFormat::UTCDateStringMillis, tp, startTp);
     EXPECT_EQ("2020-12-02T11:57:26.004Z", out);
+
+    out.clear();
+    LogTimeFormats::writeTime(
+        out, LogTimeFormats::TimeFormat::UTCDateStringMicros, tp, startTp);
+    EXPECT_EQ("2020-12-02T11:57:26.004000Z", out);
 
     out.clear();
     LogTimeFormats::writeTime(out, LogTimeFormats::TimeFormat::LocalDateString,


### PR DESCRIPTION
### Scope & Purpose

This adds the timeformat for log messages "utc-datestring-micros", which
is useful when hunting concurrency bugs, in particular for RocksDB.

- [*] :hankey: Bugfix
- [*] :pizza: New feature

### Checklist

- [*] Tests
  - [*] C++ **Unit tests**
- [*] :book: CHANGELOG entry made
- [*] :books: documentation written (release notes, API changes, ...)
- [*] Backports: none
