### PR TITLE
add UBSan suppressions for RocksDB

### DIFF
--- a/ubsan_arangodb_suppressions.txt
+++ b/ubsan_arangodb_suppressions.txt
@@ -1,8 +1,12 @@
 null:arangodb::ExecContext
 
 # fix issues with RocksDB library
-# (actually no issues in RocksDB, but issues with UBSan
+# (potentially no issues in RocksDB, but issues with UBSan
 # failing to understand thread-local variables properly)
+# there is also a pending issue in upstream RocksDB:
+# https://github.com/facebook/rocksdb/issues/10205
+# we may get rid of our own suppressions once the upstream
+# issue is fixed.
 null:3rdParty/rocksdb/db/memtable.cc
 null:3rdParty/rocksdb/db/db_iter.cc
 null:3rdParty/rocksdb/db/db_impl/db_impl.cc


### PR DESCRIPTION
### Scope & Purpose

Add UBSan suppressions for RocksDB

These suppressions are necessary because UBSan otherwise chokes on uses of thread-local variables inside RocksDB. The usage of thread-locals in RocksDB is actually ok, but it seems UBSan has a problem understanding
that.
This is actually not a bugfix, but it is suppressing false positive warnings when running tests with UBSan.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -
  - [ ] Backport for 3.7: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
