### PR TITLE
[CINFRA-442] Configuration change:  waitForSync

### DIFF
--- a/arangod/Replication2/ReplicatedLog/AgencyLogSpecification.h
+++ b/arangod/Replication2/ReplicatedLog/AgencyLogSpecification.h
@@ -259,6 +259,7 @@ struct LogCurrentSupervision {
   // first effectiveWriteConcern that is calculated on creation
   // of the log.
   size_t assumedWriteConcern{1};
+  bool assumedWaitForSync{true};
   std::optional<uint64_t> targetVersion;
   std::optional<StatusReport> statusReport;
   std::optional<clock::time_point> lastTimeModified;

--- a/arangod/Replication2/ReplicatedLog/AgencySpecificationInspectors.h
+++ b/arangod/Replication2/ReplicatedLog/AgencySpecificationInspectors.h
@@ -59,6 +59,7 @@ auto constexpr LastTimeModified = std::string_view{"lastTimeModified"};
 auto constexpr Participant = std::string_view{"participant"};
 auto constexpr Owner = std::string_view{"owner"};
 auto constexpr AssumedWriteConcern = std::string_view{"assumedWriteConcern"};
+auto constexpr AssumedWaitForSync = std::string_view{"assumedWaitForSync"};
 }  // namespace static_strings
 
 template<class Inspector>
@@ -236,6 +237,7 @@ auto inspect(Inspector& f, LogCurrentSupervision& x) {
   return f.object(x).fields(
       f.field(static_strings::AssumedWriteConcern, x.assumedWriteConcern)
           .fallback(static_cast<size_t>(1)),
+      f.field(static_strings::AssumedWaitForSync, x.assumedWaitForSync),
       f.field(static_strings::TargetVersion, x.targetVersion),
       f.field(static_strings::StatusReport, x.statusReport),
       f.field(static_strings::LastTimeModified, x.lastTimeModified)

--- a/arangod/Replication2/ReplicatedLog/Supervision.cpp
+++ b/arangod/Replication2/ReplicatedLog/Supervision.cpp
@@ -665,20 +665,34 @@ auto checkConfigUpdated(SupervisionContext& ctx, Log const& log,
     return;
   }
 
+  // Wait for sync
+  if (target.config.waitForSync != plan.participantsConfig.config.waitForSync) {
+    // FIXME: assumedWaitForSync does not change here.
+    ctx.createAction<UpdateWaitForSyncAction>(
+        target.config.waitForSync, current.supervision->assumedWaitForSync);
+    return;
+  }
+
   if (!current.leader.has_value() ||
       !current.leader->committedParticipantsConfig.has_value()) {
     return;
   }
-  if (plan.participantsConfig.generation ==
-          current.leader->committedParticipantsConfig->generation and
-      plan.participantsConfig.config.effectiveWriteConcern !=
-          current.supervision->assumedWriteConcern) {
-    // update assumedWriteConcern
-    ctx.createAction<SetAssumedWriteConcernAction>(
-        plan.participantsConfig.config.effectiveWriteConcern);
-  }
 
-  // TODO: waitForSync
+  if (plan.participantsConfig.generation ==
+      current.leader->committedParticipantsConfig->generation)
+
+    if (plan.participantsConfig.config.effectiveWriteConcern !=
+        current.supervision->assumedWriteConcern) {
+      // update assumedWriteConcern
+      ctx.createAction<SetAssumedWriteConcernAction>(
+          plan.participantsConfig.config.effectiveWriteConcern);
+    }
+
+  if (plan.participantsConfig.config.waitForSync !=
+      current.supervision->assumedWaitForSync) {
+    ctx.createAction<SetAssumedWaitForSyncAction>(
+        plan.participantsConfig.config.waitForSync);
+  }
 }
 
 auto checkConverged(SupervisionContext& ctx, Log const& log) {

--- a/arangod/Replication2/ReplicatedLog/SupervisionAction.h
+++ b/arangod/Replication2/ReplicatedLog/SupervisionAction.h
@@ -311,6 +311,30 @@ auto inspect(Inspector& f, UpdateEffectiveAndAssumedWriteConcernAction& x) {
       f.field("newAssumedWriteConcern", x.newAssumedWriteConcern));
 }
 
+struct UpdateWaitForSyncAction {
+  static constexpr std::string_view name = "UpdateWaitForSyncAction";
+  bool newWaitForSync;
+  bool newAssumedWaitForSync;
+
+  auto execute(ActionContext& ctx) const -> void {
+    ctx.modify<LogPlanSpecification>([&](LogPlanSpecification& plan) {
+      plan.participantsConfig.config.waitForSync = newWaitForSync;
+      plan.participantsConfig.generation += 1;
+    });
+    ctx.modify<LogCurrentSupervision>(
+        [&](LogCurrentSupervision& currentSupervision) {
+          currentSupervision.assumedWaitForSync = newAssumedWaitForSync;
+        });
+  }
+};
+template<typename Inspector>
+auto inspect(Inspector& f, UpdateWaitForSyncAction& x) {
+  auto hack = std::string{x.name};
+  return f.object(x).fields(
+      f.field("type", hack), f.field("newWaitForSync", x.newWaitForSync),
+      f.field("newAssumedWaitForSync", x.newAssumedWaitForSync));
+}
+
 struct SetAssumedWriteConcernAction {
   static constexpr std::string_view name = "SetAssumedWriteConcernAction";
   size_t newAssumedWriteConcern;
@@ -328,6 +352,25 @@ auto inspect(Inspector& f, SetAssumedWriteConcernAction& x) {
   return f.object(x).fields(
       f.field("type", hack),
       f.field("newAssumedWriteConcern", x.newAssumedWriteConcern));
+}
+
+struct SetAssumedWaitForSyncAction {
+  static constexpr std::string_view name = "SetAssumedWaitForSyncAction";
+  bool newAssumedWaitForSync;
+
+  auto execute(ActionContext& ctx) const -> void {
+    ctx.modifyOrCreate<LogCurrentSupervision>(
+        [&](LogCurrentSupervision& currentSupervision) {
+          currentSupervision.assumedWaitForSync = newAssumedWaitForSync;
+        });
+  }
+};
+template<typename Inspector>
+auto inspect(Inspector& f, SetAssumedWaitForSyncAction& x) {
+  auto hack = std::string{x.name};
+  return f.object(x).fields(
+      f.field("type", hack),
+      f.field("newAssumedWriteConcern", x.newAssumedWaitForSync));
 }
 
 struct ConvergedToTargetAction {
@@ -360,7 +403,8 @@ using Action =
                  UpdateParticipantFlagsAction, AddParticipantToPlanAction,
                  RemoveParticipantFromPlanAction, UpdateLogConfigAction,
                  UpdateEffectiveAndAssumedWriteConcernAction,
-                 SetAssumedWriteConcernAction, ConvergedToTargetAction>;
+                 SetAssumedWriteConcernAction, UpdateWaitForSyncAction,
+                 SetAssumedWaitForSyncAction, ConvergedToTargetAction>;
 
 auto executeAction(Log log, Action& action) -> ActionContext;
 }  // namespace arangodb::replication2::replicated_log

--- a/tests/Replication2/Helper/ModelChecker/Actors.cpp
+++ b/tests/Replication2/Helper/ModelChecker/Actors.cpp
@@ -433,3 +433,11 @@ ModifySoftWCMultipleStepsActor::ModifySoftWCMultipleStepsActor(
     size_t setInvalidWc, size_t resetValidWc)
     : setInvalidWC(setInvalidWc), resetValidWC(resetValidWc) {}
 }  // namespace arangodb::test
+
+SetWaitForSyncActor::SetWaitForSyncActor(bool newWaitForSync)
+    : newWaitForSync(newWaitForSync) {}
+
+auto SetWaitForSyncActor::step(AgencyState const& agency) const
+    -> std::vector<AgencyTransition> {
+  return {SetWaitForSyncAction(newWaitForSync)};
+}

--- a/tests/Replication2/Helper/ModelChecker/Actors.h
+++ b/tests/Replication2/Helper/ModelChecker/Actors.h
@@ -257,4 +257,11 @@ struct ModifySoftWCMultipleStepsActor
       -> std::vector<std::tuple<AgencyTransition, AgencyState, InternalState>>;
 };
 
+struct SetWaitForSyncActor : OnceActorBase<SetWaitForSyncActor> {
+  explicit SetWaitForSyncActor(bool waitForSync);
+  auto step(AgencyState const& agency) const -> std::vector<AgencyTransition>;
+
+  bool newWaitForSync;
+};
+
 }  // namespace arangodb::test

--- a/tests/Replication2/Helper/ModelChecker/AgencyTransition.cpp
+++ b/tests/Replication2/Helper/ModelChecker/AgencyTransition.cpp
@@ -317,4 +317,18 @@ auto SetBothWriteConcernAction::toString() const -> std::string {
                      newWriteConcern, newSoftWriteConcern);
 }
 
+SetWaitForSyncAction::SetWaitForSyncAction(bool newWaitForSync)
+    : newWaitForSync(newWaitForSync) {}
+
+void SetWaitForSyncAction::apply(AgencyState& agency) const {
+  TRI_ASSERT(agency.replicatedLog.has_value());
+  auto& target = agency.replicatedLog->target;
+  target.config.waitForSync = newWaitForSync;
+  target.version.emplace(target.version.value_or(0) + 1);
+}
+
+auto SetWaitForSyncAction::toString() const -> std::string {
+  return fmt::format("setting waitForSync to {}", newWaitForSync);
+}
+
 }  // namespace arangodb::test

--- a/tests/Replication2/Helper/ModelChecker/AgencyTransitions.h
+++ b/tests/Replication2/Helper/ModelChecker/AgencyTransitions.h
@@ -141,6 +141,13 @@ struct SetBothWriteConcernAction {
   size_t newSoftWriteConcern;
 };
 
+struct SetWaitForSyncAction {
+  SetWaitForSyncAction(bool newWaitForSync);
+  void apply(AgencyState& agency) const;
+  auto toString() const -> std::string;
+  bool newWaitForSync;
+};
+
 struct AddLogParticipantAction {
   AddLogParticipantAction(replication2::ParticipantId server);
   void apply(AgencyState& agency) const;
@@ -162,7 +169,8 @@ using AgencyTransition =
                  ReplaceServerTargetState, AddLogParticipantAction,
                  SetLeaderInTargetAction, RemoveLogParticipantAction,
                  SetWriteConcernAction, SetSoftWriteConcernAction,
-                 SetBothWriteConcernAction, ReplaceServerTargetLog>;
+                 SetBothWriteConcernAction, ReplaceServerTargetLog,
+                 SetWaitForSyncAction>;
 
 auto operator<<(std::ostream& os, AgencyTransition const& a) -> std::ostream&;
 }  // namespace arangodb::test

--- a/tests/Replication2/Helper/ModelChecker/Predicates.h
+++ b/tests/Replication2/Helper/ModelChecker/Predicates.h
@@ -192,4 +192,15 @@ static inline auto isAssumedWriteConcernLessThanWriteConcernUsedForCommit() {
   });
 }
 
+static inline auto isPlannedWriteConcern(bool concern) {
+  return MC_BOOL_PRED(global, {
+    AgencyState const& state = global.state;
+    if (state.replicatedLog && state.replicatedLog->plan) {
+      return state.replicatedLog->plan->participantsConfig.config.waitForSync ==
+             concern;
+    }
+    return false;
+  });
+}
+
 }  // namespace arangodb::test::mcpreds

--- a/tests/Replication2/ReplicatedLog/SupervisionSimulationTest.cpp
+++ b/tests/Replication2/ReplicatedLog/SupervisionSimulationTest.cpp
@@ -396,6 +396,70 @@ TEST_F(ReplicatedLogSupervisionSimulationTest, check_log_change_config) {
   //  std::cout << result.stats << std::endl;
 }
 
+TEST_F(ReplicatedLogSupervisionSimulationTest, check_log_change_wait_for_sync) {
+  AgencyLogBuilder log;
+  log.setTargetConfig(LogTargetConfig(2, 2, true))
+      .setId(logId)
+      .setTargetParticipant("A", defaultFlags)
+      .setTargetParticipant("B", defaultFlags)
+      .setTargetParticipant("C", defaultFlags);
+
+  log.setPlanParticipant("A", defaultFlags)
+      .setPlanParticipant("B", defaultFlags)
+      .setPlanParticipant("C", defaultFlags);
+
+  log.setPlanLeader("A");
+  log.establishLeadership();
+
+  log.acknowledgeTerm("A").acknowledgeTerm("B").acknowledgeTerm("C");
+
+  replicated_log::ParticipantsHealth health;
+  health._health.emplace(
+      "A", replicated_log::ParticipantHealth{.rebootId = RebootId(0),
+                                             .notIsFailed = true});
+  health._health.emplace(
+      "B", replicated_log::ParticipantHealth{.rebootId = RebootId(0),
+                                             .notIsFailed = true});
+  health._health.emplace(
+      "C", replicated_log::ParticipantHealth{.rebootId = RebootId(0),
+                                             .notIsFailed = true});
+  health._health.emplace(
+      "D", replicated_log::ParticipantHealth{.rebootId = RebootId(0),
+                                             .notIsFailed = true});
+  health._health.emplace(
+      "E", replicated_log::ParticipantHealth{.rebootId = RebootId(0),
+                                             .notIsFailed = true});
+
+  auto initState = makeAgencyState(log.get(), std::move(health));
+
+  auto driver = model_checker::ActorDriver{
+      SupervisionActor{},          KillLeaderActor{},
+      DBServerActor{"A"},          DBServerActor{"B"},
+      DBServerActor{"C"},          DBServerActor{"D"},
+      AddServerActor{"D"},         SetWriteConcernActor{1},
+      SetSoftWriteConcernActor{3}, SetWaitForSyncActor{false}};
+
+  auto allTests = model_checker::combined{
+      MC_ALWAYS(
+          mcpreds::isAssumedWriteConcernLessThanWriteConcernUsedForCommit()),
+      MC_ALWAYS(
+          mcpreds::
+              isAssumedWriteConcernLessThanOrEqualToEffectiveWriteConcern()),
+      MC_EVENTUALLY_ALWAYS(mcpreds::isPlannedWriteConcern(false)),
+      MC_EVENTUALLY_ALWAYS(mcpreds::isLeaderHealth())};
+  // Unfortunately the deterministic checker takes too long
+  using Engine = model_checker::ActorEngine<model_checker::DFSEnumerator,
+                                            AgencyState, AgencyTransition>;
+  // using Engine = model_checker::ActorEngine<model_checker::RandomEnumerator,
+  //                                           AgencyState, AgencyTransition>;
+  //
+  auto result =
+      Engine::run(driver, allTests, initState,
+                  {.iterations = 20000, .seed = this->seed(ADB_HERE)});
+  EXPECT_FALSE(result.failed) << *result.failed;
+  std::cout << result.stats << std::endl;
+}
+
 TEST_F(ReplicatedLogSupervisionSimulationTest, check_log_replace_leader) {
   AgencyLogBuilder log;
   log.setTargetConfig(LogTargetConfig(2, 2, true))


### PR DESCRIPTION
### Scope & Purpose

User can change the setting of `waitForSync` for a ReplicatedState/ReplicatedLog.
