### PR TITLE
Add metrics and failure point for read-from-followers, APM-296

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -59,6 +59,10 @@ devel
   change.
   The responses which can contain dirty reads will have set the HTTP header
   "x-arango-potential-dirty-read" set to "true".
+  There are the following new metrics showing the use of this feature:
+    - `arangodb_dirty_read_transactions_total`
+    - `arangodb_potentially_dirty_document_reads_total`
+    - `arangodb_dirty_read_queries_total`
 
 * Changed HTTP response code for error number 1521 from 500 to 400.
 

--- a/Documentation/Metrics/arangodb_dirty_read_queries_total.yaml
+++ b/Documentation/Metrics/arangodb_dirty_read_queries_total.yaml
@@ -1,0 +1,15 @@
+name: arangodb_dirty_read_queries_total
+introducedIn: "3.10.0"
+help: |
+  Number of AQL queries which have been executed with dirty reads.
+unit: number
+type: counter
+category: AQL
+complexity: simple
+exposedBy:
+  - coordinator
+description: |
+  This counter exposes the number of AQL queries which have been executed
+  with "dirty reads". A dirty read is one which may also use follower shards
+  and not only leader shards. Note that it is the transaction in the context
+  of which the AQL runs which determines, if dirty reads are allowed.

--- a/Documentation/Metrics/arangodb_dirty_read_transactions_total.yaml
+++ b/Documentation/Metrics/arangodb_dirty_read_transactions_total.yaml
@@ -1,0 +1,19 @@
+name: arangodb_dirty_read_transactions_total
+introducedIn: "3.10.0"
+help: |
+  Number of read transactions, which are allowed to do dirty reads.
+unit: number
+type: counter
+category: Transactions
+complexity: simple
+exposedBy:
+  - coordinator
+  - dbserver
+  - agent
+  - single
+description: |
+  Total number of read-only transactions, which allow for dirty reads
+  (read from followers). In the cluster, this metric will
+  be only be collected for transactions on Coordinators, it might report
+  0 on other instance types.
+

--- a/Documentation/Metrics/arangodb_dirty_read_transactions_total.yaml
+++ b/Documentation/Metrics/arangodb_dirty_read_transactions_total.yaml
@@ -13,7 +13,7 @@ exposedBy:
   - single
 description: |
   Total number of read-only transactions, which allow for dirty reads
-  (read from followers). In the cluster, this metric will
-  be only be collected for transactions on Coordinators, it might report
-  0 on other instance types.
+  (read from followers). This metric will only be collected for
+  transactions on Coordinators in a cluster. Other instances may expose
+  the value as 0.
 

--- a/Documentation/Metrics/arangodb_potential_dirty_document_reads_total.yaml
+++ b/Documentation/Metrics/arangodb_potential_dirty_document_reads_total.yaml
@@ -1,0 +1,16 @@
+name: arangodb_potential_dirty_document_reads_total
+introducedIn: "3.10.0"
+help: |
+  Number of document reads which have been executed with dirty reads.
+unit: number
+type: counter
+category: Statistics
+complexity: simple
+exposedBy:
+  - coordinator
+description: |
+  This counter exposes the number of document reads (single or batch to
+  shards in the cluster) which have been executed with "dirty reads".
+  A dirty read is one which may also use follower shards and not only
+  leader shards. Note that it is the transaction in the context of which
+  the read runs which determines, if dirty reads are allowed.

--- a/Documentation/Metrics/arangodb_potentially_dirty_document_reads_total.yaml
+++ b/Documentation/Metrics/arangodb_potentially_dirty_document_reads_total.yaml
@@ -1,4 +1,4 @@
-name: arangodb_potential_dirty_document_reads_total
+name: arangodb_potentially_dirty_document_reads_total
 introducedIn: "3.10.0"
 help: |
   Number of document reads which have been executed with dirty reads.

--- a/arangod/Aql/ShardLocking.cpp
+++ b/arangod/Aql/ShardLocking.cpp
@@ -35,6 +35,7 @@
 #include "Aql/Query.h"
 #include "Cluster/ClusterFeature.h"
 #include "Logger/LogMacros.h"
+#include "Metrics/Counter.h"
 #include "StorageEngine/TransactionState.h"
 #include "Utilities/NameValidator.h"
 

--- a/arangod/Aql/ShardLocking.cpp
+++ b/arangod/Aql/ShardLocking.cpp
@@ -384,10 +384,13 @@ ShardLocking::getShardMapping() {
     if (!server.hasFeature<ClusterFeature>()) {
       THROW_ARANGO_EXCEPTION(TRI_ERROR_SHUTTING_DOWN);
     }
-    auto& ci = server.getFeature<ClusterFeature>().clusterInfo();
+    auto& cf = server.getFeature<ClusterFeature>();
+    auto& ci = cf.clusterInfo();
 #ifdef USE_ENTERPRISE
+    TRI_ASSERT(ServerState::instance()->isCoordinator());
     auto& trx = _query.trxForOptimization();
     if (trx.state()->options().allowDirtyReads) {
+      ++cf.dirtyReadQueriesCounter();
       _shardMapping = trx.state()->whichReplicas(shardIds);
     } else
 #endif

--- a/arangod/Cluster/ClusterFeature.cpp
+++ b/arangod/Cluster/ClusterFeature.cpp
@@ -571,9 +571,9 @@ DECLARE_COUNTER(arangodb_sync_rebuilds_total,
                 "Number of times a follower shard needed to be completely "
                 "rebuilt because of too many synchronization failures");
 DECLARE_COUNTER(arangodb_potentially_dirty_document_reads_total,
-                "Number of document reads which could be dirty.");
+                "Number of document reads which could be dirty");
 DECLARE_COUNTER(arangodb_dirty_read_queries_total,
-                "Number of queries which could be doing dirty reads.");
+                "Number of queries which could be doing dirty reads");
 
 // IMPORTANT: Please read the first comment block a couple of lines down, before
 // Adding code to this section.

--- a/arangod/Cluster/ClusterFeature.cpp
+++ b/arangod/Cluster/ClusterFeature.cpp
@@ -570,6 +570,10 @@ DECLARE_COUNTER(arangodb_sync_wrong_checksum_total,
 DECLARE_COUNTER(arangodb_sync_rebuilds_total,
                 "Number of times a follower shard needed to be completely "
                 "rebuilt because of too many synchronization failures");
+DECLARE_COUNTER(arangodb_potentially_dirty_document_reads_total,
+                "Number of document reads which could be dirty.");
+DECLARE_COUNTER(arangodb_dirty_read_queries_total,
+                "Number of queries which could be doing dirty reads.");
 
 // IMPORTANT: Please read the first comment block a couple of lines down, before
 // Adding code to this section.
@@ -646,6 +650,11 @@ void ClusterFeature::start() {
         &_metrics.add(arangodb_sync_wrong_checksum_total{});
     _followersTotalRebuildCounter =
         &_metrics.add(arangodb_sync_rebuilds_total{});
+  } else if (role == ServerState::RoleEnum::ROLE_COORDINATOR) {
+    _potentiallyDirtyDocumentReadsCounter =
+        &_metrics.add(arangodb_potentially_dirty_document_reads_total{});
+    _dirtyReadQueriesCounter =
+        &_metrics.add(arangodb_dirty_read_queries_total{});
   }
 
   LOG_TOPIC("b6826", INFO, arangodb::Logger::CLUSTER)

--- a/arangod/Cluster/ClusterFeature.h
+++ b/arangod/Cluster/ClusterFeature.h
@@ -131,6 +131,14 @@ class ClusterFeature : public ArangodFeature {
     TRI_ASSERT(_followersTotalRebuildCounter != nullptr);
     return *_followersTotalRebuildCounter;
   }
+  metrics::Counter& potentiallyDirtyDocumentReadsCounter() {
+    TRI_ASSERT(_potentiallyDirtyDocumentReadsCounter != nullptr);
+    return *_potentiallyDirtyDocumentReadsCounter;
+  }
+  metrics::Counter& dirtyReadQueriesCounter() {
+    TRI_ASSERT(_dirtyReadQueriesCounter != nullptr);
+    return *_dirtyReadQueriesCounter;
+  }
 
   /**
    * @brief Add databases to dirty list
@@ -230,7 +238,9 @@ class ClusterFeature : public ArangodFeature {
   metrics::Counter* _followersRefusedCounter = nullptr;
   metrics::Counter* _followersWrongChecksumCounter = nullptr;
   metrics::Counter* _followersTotalRebuildCounter = nullptr;
-  std::shared_ptr<AgencyCallback> _hotbackupRestoreCallback;
+  metrics::Counter* _potentiallyDirtyDocumentReadsCounter = nullptr;
+  metrics::Counter* _dirtyReadQueriesCounter = nullptr;
+  std::shared_ptr<AgencyCallback> _hotbackupRestoreCallback = nullptr;
 
   /// @brief lock for dirty database list
   mutable arangodb::Mutex _dirtyLock;

--- a/arangod/Cluster/ClusterMethods.cpp
+++ b/arangod/Cluster/ClusterMethods.cpp
@@ -42,6 +42,7 @@
 #include "Futures/Utilities.h"
 #include "Graph/ClusterGraphDatalake.h"
 #include "Graph/ClusterTraverserCache.h"
+#include "Metrics/Counter.h"
 #include "Network/ClusterUtils.h"
 #include "Network/Methods.h"
 #include "Network/NetworkFeature.h"

--- a/arangod/ClusterEngine/ClusterTransactionState.cpp
+++ b/arangod/ClusterEngine/ClusterTransactionState.cpp
@@ -90,6 +90,9 @@ Result ClusterTransactionState::beginTransaction(transaction::Hints hints) {
   updateStatus(transaction::Status::RUNNING);
   if (isReadOnlyTransaction()) {
     ++stats._readTransactions;
+    if (_options.allowDirtyReads) {
+      ++stats._dirtyReadTransactions;
+    }
   } else {
     ++stats._transactionsStarted;
   }

--- a/arangod/ClusterEngine/ClusterTransactionState.cpp
+++ b/arangod/ClusterEngine/ClusterTransactionState.cpp
@@ -91,6 +91,7 @@ Result ClusterTransactionState::beginTransaction(transaction::Hints hints) {
   if (isReadOnlyTransaction()) {
     ++stats._readTransactions;
     if (_options.allowDirtyReads) {
+      TRI_ASSERT(ServerState::instance()->isCoordinator());
       ++stats._dirtyReadTransactions;
     }
   } else {

--- a/arangod/Statistics/Descriptions.cpp
+++ b/arangod/Statistics/Descriptions.cpp
@@ -452,6 +452,8 @@ void stats::Descriptions::serverStatistics(velocypack::Builder& b) const {
         VPackValue(info._transactionsStatistics._intermediateCommits.load()));
   b.add("readOnly",
         VPackValue(info._transactionsStatistics._readTransactions.load()));
+  b.add("dirtyReadOnly",
+        VPackValue(info._transactionsStatistics._dirtyReadTransactions.load()));
   b.close();
 
   if (dealer.isEnabled()) {

--- a/arangod/Statistics/ServerStatistics.cpp
+++ b/arangod/Statistics/ServerStatistics.cpp
@@ -59,6 +59,8 @@ DECLARE_COUNTER(arangodb_intermediate_commits_total,
                 "Number of intermediate commits performed in transactions");
 DECLARE_COUNTER(arangodb_read_transactions_total,
                 "Number of read transactions");
+DECLARE_COUNTER(arangodb_dirty_read_transactions_total,
+                "Number of read transactions which can do dirty reads");
 
 DECLARE_COUNTER(arangodb_collection_truncates_total,
                 "Total number of collection truncate operations (excl. "
@@ -93,6 +95,8 @@ TransactionStatistics::TransactionStatistics(metrics::MetricsFeature& metrics)
           _metrics.add(arangodb_transactions_committed_total{})),
       _intermediateCommits(_metrics.add(arangodb_intermediate_commits_total{})),
       _readTransactions(_metrics.add(arangodb_read_transactions_total{})),
+      _dirtyReadTransactions(
+          _metrics.add(arangodb_dirty_read_transactions_total{})),
       _exclusiveLockTimeouts(
           _metrics.add(arangodb_collection_lock_timeouts_exclusive_total{})),
       _writeLockTimeouts(

--- a/arangod/Statistics/ServerStatistics.h
+++ b/arangod/Statistics/ServerStatistics.h
@@ -47,6 +47,7 @@ struct TransactionStatistics {
   metrics::Counter& _transactionsCommitted;
   metrics::Counter& _intermediateCommits;
   metrics::Counter& _readTransactions;
+  metrics::Counter& _dirtyReadTransactions;
 
   // total number of lock timeouts for exclusive locks
   metrics::Counter& _exclusiveLockTimeouts;

--- a/arangod/Statistics/StatisticsWorker.cpp
+++ b/arangod/Statistics/StatisticsWorker.cpp
@@ -1000,6 +1000,10 @@ void StatisticsWorker::generateRawStatistics(VPackBuilder& builder,
   builder.add(
       "readOnly",
       VPackValue(serverInfo._transactionsStatistics._readTransactions.load()));
+  builder.add(
+      "dirtyReadOnly",
+      VPackValue(
+          serverInfo._transactionsStatistics._dirtyReadTransactions.load()));
   builder.close();
 
   // export v8 statistics

--- a/arangod/Transaction/Options.cpp
+++ b/arangod/Transaction/Options.cpp
@@ -124,6 +124,10 @@ void Options::fromVelocyPack(arangodb::velocypack::Slice const& slice) {
   value = slice.get("allowDirtyReads");
   if (value.isBool()) {
     allowDirtyReads = value.getBool();
+  } else {
+    TRI_IF_FAILURE("TransactionState::dirtyReadsAreDefault") {
+      allowDirtyReads = true;
+    }
   }
 
   if (!ServerState::instance()->isSingleServer()) {

--- a/arangod/V8Server/v8-statistics.cpp
+++ b/arangod/V8Server/v8-statistics.cpp
@@ -152,6 +152,10 @@ static void JS_ServerStatistics(
       ->Set(context, TRI_V8_ASCII_STRING(isolate, "readOnly"),
             v8::Number::New(isolate, (double)ts._readTransactions.load()))
       .FromMaybe(false);
+  v8TransactionInfoObj
+      ->Set(context, TRI_V8_ASCII_STRING(isolate, "dirtyReadOnly"),
+            v8::Number::New(isolate, (double)ts._dirtyReadTransactions.load()))
+      .FromMaybe(false);
   result
       ->Set(context, TRI_V8_ASCII_STRING(isolate, "transactions"),
             v8TransactionInfoObj)

--- a/tests/js/server/aql/aql-graph-traversal-generic-cluster.js
+++ b/tests/js/server/aql/aql-graph-traversal-generic-cluster.js
@@ -1,4 +1,5 @@
 /*jshint globalstrict:true, strict:true, esnext: true */
+/*global: assertTrue, instanceManager */
 
 "use strict";
 
@@ -30,6 +31,9 @@ const {testsByGraph, metaTests} = require('@arangodb/testutils/aql-graph-travers
 const jsunity = require('jsunity');
 const console = require('console');
 const _ = require("lodash");
+const internal = require("internal");
+
+let getMetric = require('@arangodb/test-helper').getMetric;
 
 function graphTraversalGenericGeneralGraphClusterSuite() {
   let testGraphs = _.fromPairs(_.keys(protoGraphs).map(x => [x, {}]));
@@ -89,6 +93,32 @@ function graphTraversalGenericGeneralGraphClusterSuite() {
   return suite;
 }
 
+let beforeQueries;
+let beforeTrxs;
+
+function checkMetricsSuite() {
+  return {
+    testCheckMetrics : function() {
+      internal.wait(0.5);  // Wait until metrics updated
+      let afterQueries = getMetric(instanceManager.url, "arangodb_dirty_read_queries_total");
+      let afterTrxs = getMetric(instanceManager.url, "arangodb_dirty_read_transactions_total");
+      // The following checks that indeed dirty reads have been happening. The
+      // tests execute well over a thousand queries, so we should be on the safe
+      // side with the threshold 10, even if some tests might be removed in
+      // the future.
+      assertTrue(afterQueries - beforeQueries < 10);
+      assertTrue(afterTrxs - beforeTrxs < 10);
+    }
+  }
+}
+
+// We want to verify that this testsuite runs without dirty reads, therefore
+// we check some metrics before and after:
+beforeQueries = getMetric(instanceManager.url, "arangodb_dirty_read_queries_total");
+beforeTrxs = getMetric(instanceManager.url, "arangodb_dirty_read_transactions_total");
+
 jsunity.run(graphTraversalGenericGeneralGraphClusterSuite);
+
+jsunity.run(checkMetricsSuite);
 
 return jsunity.done();

--- a/tests/js/server/aql/aql-graph-traversal-generic-cluster.js
+++ b/tests/js/server/aql/aql-graph-traversal-generic-cluster.js
@@ -1,5 +1,5 @@
 /*jshint globalstrict:true, strict:true, esnext: true */
-/*global: assertTrue, instanceManager */
+/*global assertTrue, instanceManager */
 
 "use strict";
 
@@ -109,7 +109,7 @@ function checkMetricsSuite() {
       assertTrue(afterQueries - beforeQueries < 10);
       assertTrue(afterTrxs - beforeTrxs < 10);
     }
-  }
+  };
 }
 
 // We want to verify that this testsuite runs without dirty reads, therefore


### PR DESCRIPTION
This PRs adds some metrics for the read-from-followers feature:

```
  arangodb_dirty_read_transactions_total
  arangodb_potentially_dirty_document_reads_total
  arangodb_dirty_read_queries_total
```

These are only exposed on coordinators, because that is where they only
make sense. Furthermore, a failure point to make dirty reads the default
is added to allow for more testing in the enterprise repo.

### Scope & Purpose

*(Please describe the changes in this PR for reviewers, motivation, rationale - **mandatory**)*

- [*] :pizza: New feature

### Checklist

- [*] Tests
  - [*] **integration tests**
- [*] :book: CHANGELOG entry made
- [*] Backports: no backports

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [*] Docs PR: https://github.com/arangodb/docs/pull/1048
- [*] Enterprise PR: ???
- [*] GitHub issue / Jira ticket: APM-296
- [*] Design document: https://github.com/arangodb/documents/blob/master/DesignDocuments/02_PLANNING/ReadFromFollowers.md

