### PR TITLE
[CINFRA-479] Convergence waits for Leadership

### DIFF
--- a/arangod/Replication2/ReplicatedLog/Supervision.cpp
+++ b/arangod/Replication2/ReplicatedLog/Supervision.cpp
@@ -709,6 +709,10 @@ auto checkConverged(SupervisionContext& ctx, Log const& log) {
     return;
   }
 
+  if (!current.leader->leadershipEstablished) {
+    return;
+  }
+
   if (target.version.has_value() &&
       (!current.supervision.has_value() ||
        target.version != current.supervision->targetVersion)) {

--- a/tests/Replication2/Helper/AgencyLogBuilder.h
+++ b/tests/Replication2/Helper/AgencyLogBuilder.h
@@ -26,9 +26,6 @@
 #include "Replication2/ReplicatedState/AgencySpecification.h"
 #include "Replication2/ReplicatedState/Supervision.h"
 
-using namespace arangodb;
-using namespace arangodb::replication2;
-using namespace arangodb::replication2::replicated_state;
 namespace RLA = arangodb::replication2::agency;
 namespace RSA = arangodb::replication2::replicated_state::agency;
 
@@ -37,7 +34,7 @@ namespace arangodb::test {
 struct AgencyLogBuilder {
   AgencyLogBuilder() = default;
 
-  auto setId(LogId id) -> AgencyLogBuilder& {
+  auto setId(replication2::LogId id) -> AgencyLogBuilder& {
     _log.target.id = id;
     if (_log.plan) {
       _log.plan->id = id;
@@ -45,7 +42,8 @@ struct AgencyLogBuilder {
     return *this;
   }
 
-  auto setTargetParticipant(ParticipantId const& id, ParticipantFlags flags)
+  auto setTargetParticipant(replication2::ParticipantId const& id,
+                            replication2::ParticipantFlags flags)
       -> AgencyLogBuilder& {
     _log.target.participants[id] = flags;
     return *this;
@@ -61,7 +59,7 @@ struct AgencyLogBuilder {
     return *this;
   }
 
-  auto setTargetLeader(std::optional<ParticipantId> leader)
+  auto setTargetLeader(std::optional<replication2::ParticipantId> leader)
       -> AgencyLogBuilder& {
     _log.target.leader = std::move(leader);
     return *this;
@@ -83,20 +81,21 @@ struct AgencyLogBuilder {
     auto& plan = makePlan();
     if (!plan.currentTerm.has_value()) {
       plan.currentTerm.emplace();
-      plan.currentTerm->term = LogTerm{1};
+      plan.currentTerm->term = replication2::LogTerm{1};
       plan.participantsConfig.config = RLA::LogPlanConfig(
           _log.target.config.writeConcern, _log.target.config.waitForSync);
     }
     return plan.currentTerm.value();
   }
 
-  auto setPlanLeader(ParticipantId const& id, RebootId rid = RebootId{0})
-      -> AgencyLogBuilder& {
+  auto setPlanLeader(replication2::ParticipantId const& id,
+                     RebootId rid = RebootId{0}) -> AgencyLogBuilder& {
     makeTerm().leader.emplace(id, rid);
     return *this;
   }
 
-  auto setPlanParticipant(ParticipantId const& id, ParticipantFlags flags)
+  auto setPlanParticipant(replication2::ParticipantId const& id,
+                          replication2::ParticipantFlags flags)
       -> AgencyLogBuilder& {
     makePlan().participantsConfig.participants[id] = flags;
     return *this;
@@ -120,7 +119,8 @@ struct AgencyLogBuilder {
     return *this;
   }
 
-  auto acknowledgeTerm(ParticipantId const& id) -> AgencyLogBuilder& {
+  auto acknowledgeTerm(replication2::ParticipantId const& id)
+      -> AgencyLogBuilder& {
     auto& current = makeCurrent();
     current.localState[id].term = makeTerm().term;
     return *this;

--- a/tests/Replication2/Helper/AgencyStateBuilder.h
+++ b/tests/Replication2/Helper/AgencyStateBuilder.h
@@ -26,18 +26,16 @@
 #include "Replication2/ReplicatedState/AgencySpecification.h"
 #include "Replication2/ReplicatedState/Supervision.h"
 
-using namespace arangodb;
-using namespace arangodb::replication2;
-using namespace arangodb::replication2::replicated_state;
 namespace RLA = arangodb::replication2::agency;
 namespace RSA = arangodb::replication2::replicated_state::agency;
+namespace RS = arangodb::replication2::replicated_state;
 
 namespace arangodb::test {
 
 struct AgencyStateBuilder {
   AgencyStateBuilder() = default;
 
-  auto setId(LogId id) -> AgencyStateBuilder& {
+  auto setId(replication2::LogId id) -> AgencyStateBuilder& {
     _state.target.id = id;
     if (_state.plan) {
       _state.plan->id = id;
@@ -45,7 +43,8 @@ struct AgencyStateBuilder {
     return *this;
   }
 
-  auto setTargetParticipant(ParticipantId const& id) -> AgencyStateBuilder& {
+  auto setTargetParticipant(replication2::ParticipantId const& id)
+      -> AgencyStateBuilder& {
     _state.target.participants[id];
     return *this;
   }
@@ -60,7 +59,7 @@ struct AgencyStateBuilder {
     return *this;
   }
 
-  auto setTargetLeader(std::optional<ParticipantId> leader)
+  auto setTargetLeader(std::optional<replication2::ParticipantId> leader)
       -> AgencyStateBuilder& {
     _state.target.leader = std::move(leader);
     return *this;
@@ -78,17 +77,18 @@ struct AgencyStateBuilder {
     return *this;
   }
 
-  auto setPlanGeneration(StateGeneration gen) -> AgencyStateBuilder& {
+  auto setPlanGeneration(RS::StateGeneration gen) -> AgencyStateBuilder& {
     makePlan().generation = gen;
     return *this;
   }
 
-  auto setPlanParticipant(ParticipantId const& name, StateGeneration gen)
-      -> AgencyStateBuilder& {
+  auto setPlanParticipant(replication2::ParticipantId const& name,
+                          RS::StateGeneration gen) -> AgencyStateBuilder& {
     makePlan().participants[name].generation = gen;
     return *this;
   }
-  auto setPlanParticipant(ParticipantId const& name) -> AgencyStateBuilder& {
+  auto setPlanParticipant(replication2::ParticipantId const& name)
+      -> AgencyStateBuilder& {
     makePlan().participants[name].generation = makePlan().generation;
     return *this;
   }
@@ -97,7 +97,8 @@ struct AgencyStateBuilder {
     (setPlanParticipant(std::forward<Vs>(vs)), ...);
     return *this;
   }
-  auto addPlanParticipant(ParticipantId const& name) -> AgencyStateBuilder& {
+  auto addPlanParticipant(replication2::ParticipantId const& name)
+      -> AgencyStateBuilder& {
     makePlan().participants[name].generation = ++makePlan().generation;
     return *this;
   }
@@ -113,7 +114,7 @@ struct AgencyStateBuilder {
     if (!_state.plan.has_value()) {
       _state.plan.emplace();
       _state.plan->id = _state.target.id;
-      _state.plan->generation = StateGeneration{1};
+      _state.plan->generation = RS::StateGeneration{1};
     }
     return _state.plan.value();
   }
@@ -122,8 +123,8 @@ struct AgencyStateBuilder {
   auto setSnapshotCompleteFor(Vs&&... id) -> AgencyStateBuilder& {
     ((makeCurrent().participants[id] =
           {_state.plan.value().participants.at(id).generation,
-           SnapshotInfo{SnapshotStatus::kCompleted, SnapshotInfo::clock::now(),
-                        std::nullopt}}),
+           RS::SnapshotInfo{RS::SnapshotStatus::kCompleted,
+                            RS::SnapshotInfo::clock::now(), std::nullopt}}),
      ...);
     return *this;
   }

--- a/tests/Replication2/ReplicatedLog/SupervisionTest.cpp
+++ b/tests/Replication2/ReplicatedLog/SupervisionTest.cpp
@@ -32,6 +32,7 @@
 #include "Replication2/ReplicatedLog/ParticipantsHealth.h"
 #include "Replication2/ReplicatedLog/Supervision.h"
 #include "Replication2/ReplicatedLog/SupervisionAction.h"
+#include "Replication2/Helper/AgencyLogBuilder.h"
 
 #include "velocypack/Parser.h"
 #include "Inspection/VPack.h"
@@ -40,6 +41,7 @@ using namespace arangodb;
 using namespace arangodb::replication2;
 using namespace arangodb::replication2::agency;
 using namespace arangodb::replication2::replicated_log;
+using namespace arangodb::test;
 
 struct LeaderElectionCampaignTest : ::testing::Test {};
 TEST_F(LeaderElectionCampaignTest, test_computeReason) {
@@ -210,7 +212,12 @@ TEST_F(SupervisionLogTest, test_log_not_created) {
   EXPECT_TRUE(std::holds_alternative<NoActionPossibleAction>(r));
 }
 
-struct LogSupervisionTest : ::testing::Test {};
+struct LogSupervisionTest : ::testing::Test {
+  LogId const logId = LogId{12};
+  ParticipantFlags const defaultFlags{};
+  LogTargetConfig const defaultConfig{2, 2, true};
+  LogPlanConfig const defaultPlanConfig{2, true};
+};
 
 TEST_F(LogSupervisionTest, test_leader_not_failed) {
   // Leader is not failed and the reboot id is as expected
@@ -644,4 +651,45 @@ TEST_F(
   auto effectiveWriteConcern =
       computeEffectiveWriteConcern(config, participants, health);
   ASSERT_EQ(effectiveWriteConcern, 2);
+}
+
+TEST_F(LogSupervisionTest, test_convergence_no_leader_established) {
+  AgencyLogBuilder log;
+  log.setTargetConfig(defaultConfig)
+      .setId(logId)
+      .setTargetParticipant("A", defaultFlags)
+      .setTargetParticipant("B", defaultFlags)
+      .setTargetParticipant("C", defaultFlags)
+      .setTargetVersion(5);
+
+  log.setPlanParticipant("A", defaultFlags)
+      .setPlanParticipant("B", defaultFlags)
+      .setPlanParticipant("C", defaultFlags);
+  log.setPlanLeader("A").setPlanConfig(defaultPlanConfig);
+  log.acknowledgeTerm("A").acknowledgeTerm("B").acknowledgeTerm("C");
+
+  replicated_log::ParticipantsHealth health;
+  health._health.emplace(
+      "A", replicated_log::ParticipantHealth{.rebootId = RebootId(0),
+                                             .notIsFailed = true});
+  health._health.emplace(
+      "B", replicated_log::ParticipantHealth{.rebootId = RebootId(0),
+                                             .notIsFailed = true});
+  health._health.emplace(
+      "C", replicated_log::ParticipantHealth{.rebootId = RebootId(0),
+                                             .notIsFailed = true});
+
+  {
+    SupervisionContext ctx;
+    checkReplicatedLog(ctx, log.get(), health);
+    EXPECT_FALSE(ctx.hasAction());
+  }
+  log.establishLeadership();
+  {
+    SupervisionContext ctx;
+    checkReplicatedLog(ctx, log.get(), health);
+    EXPECT_TRUE(ctx.hasAction());
+    auto const& r = ctx.getAction();
+    EXPECT_TRUE(std::holds_alternative<ConvergedToTargetAction>(r));
+  }
 }


### PR DESCRIPTION
### Scope & Purpose
The ReplicatedLog Supervision now waits for the leadership of the log to be established. Without this, a log might be declared converged although it is not yet and the first request to the leader might fail.