### PR TITLE
[CINFRA] BugFix Replicated Log Maintenance Race

### DIFF
--- a/arangod/Replication2/ReplicatedLog/ReplicatedLog.cpp
+++ b/arangod/Replication2/ReplicatedLog/ReplicatedLog.cpp
@@ -79,7 +79,7 @@ auto replicated_log::ReplicatedLog::becomeLeader(
   auto [leader, deferred] = std::invoke([&] {
     std::unique_lock guard(_mutex);
     if (auto currentTerm = _participant->getTerm();
-        currentTerm && *currentTerm > newTerm) {
+        currentTerm && *currentTerm >= newTerm) {
       LOG_CTX("b8bf7", INFO, _logContext)
           << "tried to become leader with term " << newTerm
           << ", but current term is " << *currentTerm;
@@ -106,7 +106,7 @@ auto replicated_log::ReplicatedLog::becomeFollower(
   auto [follower, deferred] = std::invoke([&] {
     std::unique_lock guard(_mutex);
     if (auto currentTerm = _participant->getTerm();
-        currentTerm && *currentTerm > term) {
+        currentTerm && *currentTerm >= term) {
       LOG_CTX("c97e9", INFO, _logContext)
           << "tried to become follower with term " << term
           << ", but current term is " << *currentTerm;

--- a/arangod/Replication2/ReplicatedLog/Supervision.cpp
+++ b/arangod/Replication2/ReplicatedLog/Supervision.cpp
@@ -704,6 +704,10 @@ auto checkConverged(SupervisionContext& ctx, Log const& log) {
   TRI_ASSERT(log.current.has_value());
   auto const& current = *log.current;
 
+  if (!current.leader.has_value()) {
+    return;
+  }
+
   if (log.plan->participantsConfig.generation !=
       current.leader->committedParticipantsConfig->generation) {
     return;

--- a/lib/Logger/LogTopic.cpp
+++ b/lib/Logger/LogTopic.cpp
@@ -143,7 +143,7 @@ LogTopic Logger::PERFORMANCE("performance", LogLevel::WARN);
 LogTopic Logger::PREGEL("pregel", LogLevel::INFO);
 LogTopic Logger::QUERIES("queries", LogLevel::INFO);
 LogTopic Logger::REPLICATION("replication", LogLevel::INFO);
-LogTopic Logger::REPLICATION2("replication2", LogLevel::TRACE);
+LogTopic Logger::REPLICATION2("replication2", LogLevel::INFO);
 LogTopic Logger::REPLICATED_STATE("rep-state", LogLevel::DEBUG);
 LogTopic Logger::REQUESTS("requests", LogLevel::FATAL);  // suppress
 LogTopic Logger::RESTORE("restore", LogLevel::INFO);

--- a/lib/Logger/LogTopic.cpp
+++ b/lib/Logger/LogTopic.cpp
@@ -143,7 +143,7 @@ LogTopic Logger::PERFORMANCE("performance", LogLevel::WARN);
 LogTopic Logger::PREGEL("pregel", LogLevel::INFO);
 LogTopic Logger::QUERIES("queries", LogLevel::INFO);
 LogTopic Logger::REPLICATION("replication", LogLevel::INFO);
-LogTopic Logger::REPLICATION2("replication2", LogLevel::INFO);
+LogTopic Logger::REPLICATION2("replication2", LogLevel::TRACE);
 LogTopic Logger::REPLICATED_STATE("rep-state", LogLevel::DEBUG);
 LogTopic Logger::REQUESTS("requests", LogLevel::FATAL);  // suppress
 LogTopic Logger::RESTORE("restore", LogLevel::INFO);

--- a/tests/Replication2/ReplicatedLog/LogParticipantWaitForResignTests.cpp
+++ b/tests/Replication2/ReplicatedLog/LogParticipantWaitForResignTests.cpp
@@ -105,7 +105,7 @@ TEST_F(WaitForResignTest, wait_for_resign_follower_become_follower) {
   participant->waitForResign().thenFinal(getSetResignStatusCallback());
 
   ASSERT_FALSE(resigned);
-  testLog->becomeFollower("follower", LogTerm{1}, "leader");
+  testLog->becomeFollower("follower", LogTerm{2}, "leader");
   ASSERT_TRUE(resigned);
 }
 
@@ -116,7 +116,7 @@ TEST_F(WaitForResignTest, wait_for_resign_follower_become_leader) {
   participant->waitForResign().thenFinal(getSetResignStatusCallback());
 
   ASSERT_FALSE(resigned);
-  testLog->becomeLeader("leader", LogTerm{1}, {}, 1);
+  testLog->becomeLeader("leader", LogTerm{2}, {}, 1);
   ASSERT_TRUE(resigned);
 }
 
@@ -150,7 +150,7 @@ TEST_F(WaitForResignTest, wait_for_resign_leader_become_follower) {
   participant->waitForResign().thenFinal(getSetResignStatusCallback());
 
   ASSERT_FALSE(resigned);
-  testLog->becomeFollower("follower", LogTerm{1}, "leader");
+  testLog->becomeFollower("follower", LogTerm{2}, "leader");
   ASSERT_TRUE(resigned);
 }
 
@@ -161,7 +161,7 @@ TEST_F(WaitForResignTest, wait_for_resign_leader_become_leader) {
   participant->waitForResign().thenFinal(getSetResignStatusCallback());
 
   ASSERT_FALSE(resigned);
-  testLog->becomeLeader("leader", LogTerm{1}, {}, 1);
+  testLog->becomeLeader("leader", LogTerm{2}, {}, 1);
   ASSERT_TRUE(resigned);
 }
 


### PR DESCRIPTION
### Scope & Purpose
Since the maintenance can create multiple actions it can happen that two replicated log actions are scheduled and both try to update a replicated log become the leader. Previously both succeeded, which resulted in the leader to be recreated. The replicated log was modified to only allow new replicated logs to be created with a higher term.