### PR TITLE
[CINFRA-475] use same leader state during transaction

### DIFF
--- a/arangod/RocksDBEngine/ReplicatedRocksDBTransactionCollection.cpp
+++ b/arangod/RocksDBEngine/ReplicatedRocksDBTransactionCollection.cpp
@@ -21,17 +21,19 @@
 /// @author Manuel Pöter
 ////////////////////////////////////////////////////////////////////////////////
 
-#include <algorithm>
-#include "ApplicationFeatures/ApplicationServer.h"
-#include "RocksDBEngine/RocksDBTransactionCollection.h"
 #include "ReplicatedRocksDBTransactionCollection.h"
 
+#include "ApplicationFeatures/ApplicationServer.h"
+#include "Replication2/StateMachines/Document/DocumentLeaderState.h"
 #include "RocksDBEngine/Methods/RocksDBReadOnlyMethods.h"
 #include "RocksDBEngine/Methods/RocksDBSingleOperationReadOnlyMethods.h"
 #include "RocksDBEngine/Methods/RocksDBSingleOperationTrxMethods.h"
 #include "RocksDBEngine/Methods/RocksDBTrxMethods.h"
 #include "RocksDBEngine/ReplicatedRocksDBTransactionState.h"
+#include "RocksDBEngine/RocksDBTransactionCollection.h"
 #include "RocksDBEngine/RocksDBTransactionMethods.h"
+
+#include <algorithm>
 
 using namespace arangodb;
 
@@ -146,4 +148,24 @@ uint64_t ReplicatedRocksDBTransactionCollection::numOperations()
 
 bool ReplicatedRocksDBTransactionCollection::ensureSnapshot() {
   return _rocksMethods->ensureSnapshot();
+}
+
+auto ReplicatedRocksDBTransactionCollection::leaderState() -> std::shared_ptr<
+    replication2::replicated_state::document::DocumentLeaderState> {
+  return _leaderState;
+}
+
+auto ReplicatedRocksDBTransactionCollection::ensureCollection() -> Result {
+  auto res = RocksDBTransactionCollection::ensureCollection();
+
+  if (res.fail()) {
+    return res;
+  }
+
+  if (_leaderState == nullptr) {
+    _leaderState = _collection->getDocumentStateLeader();
+    ADB_PROD_ASSERT(_leaderState != nullptr);
+  }
+
+  return res;
 }

--- a/arangod/RocksDBEngine/ReplicatedRocksDBTransactionCollection.cpp
+++ b/arangod/RocksDBEngine/ReplicatedRocksDBTransactionCollection.cpp
@@ -163,6 +163,12 @@ auto ReplicatedRocksDBTransactionCollection::ensureCollection() -> Result {
   }
 
   if (_leaderState == nullptr) {
+    // Note that doing this here is only correct as long as we're not supporting
+    // distributeShardsLike.
+    // Later, we must make sure to get the very same state for all collections
+    // (shards) belonging to the same collection group (shard sheaf) (i.e.
+    // belong to the same distributeShardsLike group) See
+    // https://arangodb.atlassian.net/browse/CINFRA-294.
     _leaderState = _collection->getDocumentStateLeader();
     ADB_PROD_ASSERT(_leaderState != nullptr);
   }

--- a/arangod/RocksDBEngine/ReplicatedRocksDBTransactionCollection.h
+++ b/arangod/RocksDBEngine/ReplicatedRocksDBTransactionCollection.h
@@ -26,6 +26,9 @@
 #include "RocksDBEngine/RocksDBTransactionCollection.h"
 
 namespace arangodb {
+namespace replication2::replicated_state::document {
+struct DocumentLeaderState;
+}
 class RocksDBTransactionMethods;
 class ReplicatedRocksDBTransactionState;
 
@@ -60,9 +63,17 @@ class ReplicatedRocksDBTransactionCollection final
 
   bool ensureSnapshot();
 
+  auto leaderState() -> std::shared_ptr<
+      replication2::replicated_state::document::DocumentLeaderState>;
+
+ protected:
+  auto ensureCollection() -> Result override;
+
  private:
   void maybeDisableIndexing();
 
+  std::shared_ptr<replication2::replicated_state::document::DocumentLeaderState>
+      _leaderState;
   /// @brief wrapper to use outside this class to access rocksdb
   std::unique_ptr<RocksDBTransactionMethods> _rocksMethods;
 };

--- a/arangod/RocksDBEngine/RocksDBTransactionCollection.h
+++ b/arangod/RocksDBEngine/RocksDBTransactionCollection.h
@@ -135,6 +135,9 @@ class RocksDBTransactionCollection : public TransactionCollection {
     return empty;
   }
 
+ protected:
+  virtual Result ensureCollection();
+
  private:
   /// @brief request a lock for a collection
   /// returns TRI_ERROR_LOCKED in case the lock was successfully acquired
@@ -144,8 +147,6 @@ class RocksDBTransactionCollection : public TransactionCollection {
 
   /// @brief request an unlock for a collection
   Result doUnlock(AccessMode::Type) override;
-
-  Result ensureCollection();
 
  private:
   uint64_t _initialNumberDocuments;

--- a/arangod/Transaction/Methods.h
+++ b/arangod/Transaction/Methods.h
@@ -570,7 +570,7 @@ class Methods {
   bool _mainTransaction;
 
   Future<Result> replicateOperations(
-      std::shared_ptr<LogicalCollection> collection,
+      TransactionCollection& collection,
       std::shared_ptr<const std::vector<std::string>> const& followers,
       OperationOptions const& options,
       velocypack::Builder const& replicationData,

--- a/arangod/VocBase/LogicalCollection.cpp
+++ b/arangod/VocBase/LogicalCollection.cpp
@@ -58,6 +58,8 @@
 #endif
 
 #include <absl/strings/str_cat.h>
+#include <fmt/core.h>
+#include <fmt/ostream.h>
 
 #include <velocypack/Collection.h>
 #include <velocypack/Utf8Helper.h>
@@ -1298,57 +1300,42 @@ auto LogicalCollection::getDocumentState()
 auto LogicalCollection::getDocumentStateLeader() -> std::shared_ptr<
     replication2::replicated_state::document::DocumentLeaderState> {
   auto stateMachine = getDocumentState();
-  auto leader = stateMachine->getLeader();
-  // TODO improve error handling
-  ADB_PROD_ASSERT(leader != nullptr)
-      << "Cannot get DocumentLeaderState in shard " << name();
-  return leader;
-}
 
-auto LogicalCollection::waitForDocumentStateLeader() -> std::shared_ptr<
-    replication2::replicated_state::document::DocumentLeaderState> {
-  auto replicatedState = getDocumentState();
-  std::optional<replication2::replicated_state::StateStatus> status =
-      std::nullopt;
-  replication2::replicated_state::LeaderStatus const* leaderStatus = nullptr;
+  static constexpr auto throwUnavailable = []<typename... Args>(
+      basics::SourceLocation location, fmt::format_string<Args...> formatString,
+      Args && ... args) {
+    throw basics::Exception(
+        TRI_ERROR_REPLICATION_REPLICATED_STATE_NOT_AVAILABLE,
+        fmt::vformat(formatString, fmt::make_format_args(args...)), location);
+  };
 
-  // TODO find a better way to wait for service availability
-  for (int counter{0}; counter < 30; ++counter) {
-    status = replicatedState->getStatus();
-    if (status) {
-      leaderStatus = status->asLeaderStatus();
-      if (leaderStatus != nullptr &&
-          leaderStatus->managerState.state ==
-              replication2::replicated_state::LeaderInternalState::
-                  kServiceAvailable) {
-        break;
-      }
-    }
-    using namespace std::chrono_literals;
-    std::this_thread::sleep_for(1s);
+  auto const status = stateMachine->getStatus();
+  if (status == std::nullopt) {
+    throwUnavailable(ADB_HERE,
+                     "Replicated state {} is not available as leader, accessed "
+                     "from {}/{}. No status available.",
+                     shardIdToStateId(name()), vocbase().name(), name());
   }
 
+  auto const* const leaderStatus = status->asLeaderStatus();
   if (leaderStatus == nullptr) {
-    if (status.has_value()) {
-      std::stringstream stream;
-      stream << "Could not get leader status, current status is " << *status;
-      THROW_ARANGO_EXCEPTION_MESSAGE(
-          TRI_ERROR_REPLICATION_REPLICATED_LOG_NOT_THE_LEADER, stream.str());
-    } else {
-      THROW_ARANGO_EXCEPTION_MESSAGE(
-          TRI_ERROR_REPLICATION_REPLICATED_LOG_NOT_FOUND,
-          "Could not get any status from replicated state");
-    }
-  }
-  if (leaderStatus->managerState.state !=
-      replication2::replicated_state::LeaderInternalState::kServiceAvailable) {
-    THROW_ARANGO_EXCEPTION_MESSAGE(
-        TRI_ERROR_REPLICATION_REPLICATED_LOG_NOT_THE_LEADER,
-        "Leader state service is not available, the current status being: " +
-            std::string(to_string(leaderStatus->managerState.state)));
+    throwUnavailable(ADB_HERE,
+                     "Replicated state {} is not available as leader, accessed "
+                     "from {}/{}. Status is {}.",
+                     shardIdToStateId(name()), vocbase().name(), name(),
+                     *status);
   }
 
-  return getDocumentStateLeader();
+  auto leader = stateMachine->getLeader();
+  if (leader == nullptr) {
+    throwUnavailable(ADB_HERE,
+                     "Replicated state {} is not available as leader, accessed "
+                     "from {}/{}. Status is {}.",
+                     shardIdToStateId(name()), vocbase().name(), name(),
+                     to_string(leaderStatus->managerState.state));
+  }
+
+  return leader;
 }
 
 auto LogicalCollection::getDocumentStateFollower() -> std::shared_ptr<

--- a/arangod/VocBase/LogicalCollection.h
+++ b/arangod/VocBase/LogicalCollection.h
@@ -248,8 +248,6 @@ class LogicalCollection : public LogicalDataSource {
           replication2::replicated_state::document::DocumentState>>;
   auto getDocumentStateLeader() -> std::shared_ptr<
       replication2::replicated_state::document::DocumentLeaderState>;
-  auto waitForDocumentStateLeader() -> std::shared_ptr<
-      replication2::replicated_state::document::DocumentLeaderState>;
   auto getDocumentStateFollower() -> std::shared_ptr<
       replication2::replicated_state::document::DocumentFollowerState>;
 

--- a/js/common/bootstrap/errors.js
+++ b/js/common/bootstrap/errors.js
@@ -132,6 +132,7 @@
     "ERROR_REPLICATION_REPLICATED_LOG_INVALID_TERM" : { "code" : 1425, "message" : "an invalid term was given" },
     "ERROR_REPLICATION_REPLICATED_LOG_UNCONFIGURED" : { "code" : 1426, "message" : "log participant unconfigured" },
     "ERROR_REPLICATION_REPLICATED_STATE_NOT_FOUND" : { "code" : 1427, "message" : "replicated state {id:} of type {type:} not found" },
+    "ERROR_REPLICATION_REPLICATED_STATE_NOT_AVAILABLE" : { "code" : 1428, "message" : "replicated state {id:} of type {type:} is unavailable" },
     "ERROR_CLUSTER_NOT_FOLLOWER"   : { "code" : 1446, "message" : "not a follower" },
     "ERROR_CLUSTER_FOLLOWER_TRANSACTION_COMMIT_PERFORMED" : { "code" : 1447, "message" : "follower transaction intermediate commit already performed" },
     "ERROR_CLUSTER_CREATE_COLLECTION_PRECONDITION_FAILED" : { "code" : 1448, "message" : "creating collection failed due to precondition" },

--- a/lib/Basics/errors.dat
+++ b/lib/Basics/errors.dat
@@ -165,6 +165,7 @@ ERROR_REPLICATION_REPLICATED_LOG_PARTICIPANT_GONE,1424,"the replicated log of th
 ERROR_REPLICATION_REPLICATED_LOG_INVALID_TERM,1425,"an invalid term was given","Will be raised when a participant tries to change its term but found a invalid new term."
 ERROR_REPLICATION_REPLICATED_LOG_UNCONFIGURED,1426,"log participant unconfigured","Will be raised when a participant is currently unconfigured, i.e. neither a leader nor a follower."
 ERROR_REPLICATION_REPLICATED_STATE_NOT_FOUND,1427,"replicated state {id:} of type {type:} not found","Will be raised when a specific replicated state was not found."
+ERROR_REPLICATION_REPLICATED_STATE_NOT_AVAILABLE,1428,"replicated state {id:} of type {type:} is unavailable","Will be raised when a specific replicated state was accessed but is not (yet) available."
 
 ################################################################################
 ## ArangoDB cluster errors


### PR DESCRIPTION
### Scope & Purpose

At the beginning of each transaction, save the replicated state for each collection / shard only once, and reuse it during the transaction. The same transaction must not use different instances of the same replicated state.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*
  - [ ] Backport for 3.7: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

