### PR TITLE
we have to mimic the instanceInfo structure better in order to work with the crash-utils

### DIFF
--- a/js/client/modules/@arangodb/testutils/process-utils.js
+++ b/js/client/modules/@arangodb/testutils/process-utils.js
@@ -721,7 +721,8 @@ function executeAndWait (cmd, args, options, valgrindTest, rootDir, coreCheck = 
   let instanceInfo = {
     rootDir: rootDir,
     pid: 0,
-    exitStatus: {}
+    exitStatus: {},
+    getStructure: function() { return {}; }
   };
 
   let res = {};


### PR DESCRIPTION
### Scope & Purpose

When creating instance.js the crash-utils should get the structure of this object for better visualisation.
This verry case `pu.executeAndWait` would invoke this with a fake structure without this method. Here we add a dummy. 

- [x] :hankey: Bugfix
