### PR TITLE
Feature/arangoimport override collection prefix

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,15 @@
 devel
 -----
+
+* arangoimport now supports an additional option "--overwrite-collection-prefix".
+  This option will only help while importing edge collections, and if it is used
+  together with "--to-collection-prefix" or "--from-collection-prefix". If there
+  are vertex collection prefixes in the file you want to import (e.g. you just
+  exported an edge collection from ArangoDB) you allow arangoimport to overwrite
+  those with the commandline prefixes. If the option is false (default value)
+  only _from and _to values without a prefix will be prefixed by the handed in
+  values.
+
 * Fixed parsing of K_SHORTEST_PATHS queries to not allow ranges anymore.
 
 * Updated arangosync to v2.11.0.

--- a/arangod/RestHandler/RestImportHandler.h
+++ b/arangod/RestHandler/RestImportHandler.h
@@ -185,6 +185,8 @@ class RestImportHandler : public RestVocbaseBaseHandler {
   std::string _fromPrefix;
   std::string _toPrefix;
 
+  bool _overwritePrefix{false};
+
   /// @brief whether or not we will tolerate missing values for the CSV import
   bool _ignoreMissing;
 };

--- a/client-tools/Import/ImportFeature.cpp
+++ b/client-tools/Import/ImportFeature.cpp
@@ -60,6 +60,7 @@ ImportFeature::ImportFeature(Server& server, int* result)
       _collectionName(""),
       _fromCollectionPrefix(""),
       _toCollectionPrefix(""),
+      _overwriteCollectionPrefix(false),
       _createCollection(false),
       _createDatabase(false),
       _createCollectionType("document"),
@@ -118,6 +119,11 @@ void ImportFeature::collectOptions(
       "--to-collection-prefix",
       "_to collection name prefix (will be prepended to all values in '_to')",
       new StringParameter(&_toCollectionPrefix));
+
+  options->addOption("--overwrite-collection-prefix",
+                     "only useful with '--from/--to-collection-prefix', if the "
+                     "value is already prefixed, overwrite the prefix.",
+                     new BooleanParameter(&_overwriteCollectionPrefix));
 
   options->addOption("--create-collection",
                      "create collection if it does not yet exist",
@@ -407,6 +413,8 @@ void ImportFeature::start() {
       std::cout << "to collection prefix:   " << _toCollectionPrefix
                 << std::endl;
     }
+    std::cout << "overwrite coll. prefix: "
+              << (_overwriteCollectionPrefix ? "yes" : "no") << std::endl;
     std::cout << "create:                 "
               << (_createCollection ? "yes" : "no") << std::endl;
     std::cout << "create database:        " << (_createDatabase ? "yes" : "no")
@@ -591,6 +599,7 @@ void ImportFeature::start() {
     // set prefixes
     ih.setFrom(_fromCollectionPrefix);
     ih.setTo(_toCollectionPrefix);
+    ih.setOverwritePrefix(_overwriteCollectionPrefix);
 
     TRI_NormalizePath(_filename);
     // import type

--- a/client-tools/Import/ImportFeature.h
+++ b/client-tools/Import/ImportFeature.h
@@ -62,6 +62,7 @@ class ImportFeature final : public ArangoImportFeature,
   std::string _collectionName;
   std::string _fromCollectionPrefix;
   std::string _toCollectionPrefix;
+  bool _overwriteCollectionPrefix;
   bool _createCollection;
   bool _createDatabase;
   std::string _createCollectionType;

--- a/client-tools/Import/ImportHelper.cpp
+++ b/client-tools/Import/ImportHelper.cpp
@@ -189,6 +189,7 @@ ImportHelper::ImportHelper(EncryptionFeature* encryption,
       _keyColumn(-1),
       _onDuplicateAction("error"),
       _collectionName(),
+      _overwriteCollectionPrefix(false),
       _lineBuffer(false),
       _outputBuffer(false),
       _firstLine(""),
@@ -1174,7 +1175,9 @@ void ImportHelper::handleCsvBuffer(uint64_t bufferSizeThreshold) {
   std::string url("/_api/import?" + getCollectionUrlPart() + "&line=" +
                   StringUtils::itoa(_rowOffset) + "&details=true&onDuplicate=" +
                   StringUtils::urlEncode(_onDuplicateAction) +
-                  "&ignoreMissing=" + (_ignoreMissing ? "true" : "false"));
+                  "&ignoreMissing=" + (_ignoreMissing ? "true" : "false") +
+                  "&" + StaticStrings::OverwriteCollectionPrefix + "=" +
+                  (_overwriteCollectionPrefix ? "true" : "false"));
 
   if (!_fromCollectionPrefix.empty()) {
     url += "&fromPrefix=" + StringUtils::urlEncode(_fromCollectionPrefix);
@@ -1210,7 +1213,9 @@ void ImportHelper::sendJsonBuffer(char const* str, size_t len, bool isObject) {
   // build target url
   std::string url("/_api/import?" + getCollectionUrlPart() +
                   "&details=true&onDuplicate=" +
-                  StringUtils::urlEncode(_onDuplicateAction));
+                  StringUtils::urlEncode(_onDuplicateAction) + "&" +
+                  StaticStrings::OverwriteCollectionPrefix + "=" +
+                  (_overwriteCollectionPrefix ? "true" : "false"));
   if (isObject) {
     url += "&type=array";
   } else {

--- a/client-tools/Import/ImportHelper.h
+++ b/client-tools/Import/ImportHelper.h
@@ -137,6 +137,14 @@ class ImportHelper {
   void setTo(std::string const& to) { _toCollectionPrefix = to; }
 
   //////////////////////////////////////////////////////////////////////////////
+  /// @brief set if we want to overwrite existing collection prefixes
+  //////////////////////////////////////////////////////////////////////////////
+
+  void setOverwritePrefix(bool overwrite) {
+    _overwriteCollectionPrefix = overwrite;
+  }
+
+  //////////////////////////////////////////////////////////////////////////////
   /// @brief whether or not backslashes can be used for escaping quotes
   //////////////////////////////////////////////////////////////////////////////
 
@@ -368,6 +376,7 @@ class ImportHelper {
   std::string _collectionName;
   std::string _fromCollectionPrefix;
   std::string _toCollectionPrefix;
+  bool _overwriteCollectionPrefix;
   arangodb::basics::StringBuffer _lineBuffer;
   arangodb::basics::StringBuffer _outputBuffer;
   std::string _firstLine;

--- a/js/client/modules/@arangodb/testsuites/importing.js
+++ b/js/client/modules/@arangodb/testsuites/importing.js
@@ -301,6 +301,24 @@ const impTodos = [{
   type: 'json',
   create: 'false'
 }, {
+  id: 'edgeRewriteOn',
+  data: tu.makePathUnix(fs.join(testPaths.importing[1], 'import-edges.json')),
+  coll: 'UnitTestsImportEdgeRewriteCollectionOn',
+  type: 'json',
+  create: 'false',
+  ["from-collection-prefix"]: 'UnitTestsImportJson1',
+  ["to-collection-prefix"]: 'UnitTestsImportJson2',
+  ["overwrite-collection-prefix"]: true
+}, {
+  id: 'edgeRewriteOff',
+  data: tu.makePathUnix(fs.join(testPaths.importing[1], 'import-edges.json')),
+  coll: 'UnitTestsImportEdgeRewriteCollectionOff',
+  type: 'json',
+  create: 'false',
+  ["from-collection-prefix"]: 'UnitTestsImportJson1',
+  ["to-collection-prefix"]: 'UnitTestsImportJson2'
+  /* This tests the default value of overwrite-collection-prefix, by default this value is false */
+}, {
   id: 'unique',
   data: tu.makePathUnix(fs.join(testPaths.importing[1], 'import-ignore.json')),
   coll: 'UnitTestsImportIgnore',

--- a/js/client/modules/@arangodb/testutils/process-utils.js
+++ b/js/client/modules/@arangodb/testutils/process-utils.js
@@ -144,6 +144,16 @@ class ConfigBuilder {
     if (what.batchSize !== undefined) {
       this.config['batch-size'] = what.batchSize;
     }
+
+    if (what["from-collection-prefix"] !== undefined) {
+      this.config["from-collection-prefix"] = what["from-collection-prefix"];
+    }
+    if (what["to-collection-prefix"] !== undefined) {
+      this.config["to-collection-prefix"] = what["to-collection-prefix"];
+    }
+    if (what["overwrite-collection-prefix"] !== undefined) {
+      this.config["overwrite-collection-prefix"] = what["overwrite-collection-prefix"];
+    }
   }
 
   setAuth(username, password) {

--- a/lib/Basics/StaticStrings.cpp
+++ b/lib/Basics/StaticStrings.cpp
@@ -61,6 +61,8 @@ std::string const StaticStrings::SilentString("silent");
 std::string const StaticStrings::WaitForSyncString("waitForSync");
 std::string const StaticStrings::SkipDocumentValidation(
     "skipDocumentValidation");
+std::string const StaticStrings::OverwriteCollectionPrefix(
+    "overwriteCollectionPrefix");
 std::string const StaticStrings::IsSynchronousReplicationString(
     "isSynchronousReplication");
 std::string const StaticStrings::Group("group");

--- a/lib/Basics/StaticStrings.h
+++ b/lib/Basics/StaticStrings.h
@@ -66,6 +66,7 @@ class StaticStrings {
   static std::string const SilentString;
   static std::string const WaitForSyncString;
   static std::string const SkipDocumentValidation;
+  static std::string const OverwriteCollectionPrefix;
   static std::string const IsSynchronousReplicationString;
   static std::string const Group;
   static std::string const Namespace;

--- a/tests/js/server/import/import-setup.js
+++ b/tests/js/server/import/import-setup.js
@@ -66,15 +66,17 @@
   db._drop("UnitTestsImportVertex");
   db._drop("UnitTestsImportEdge");
   db._drop("UnitTestsImportEdgeGz");
+  db._drop("UnitTestsImportEdgeRewriteCollectionOn");
+  db._drop("UnitTestsImportEdgeRewriteCollectionOff");
   db._drop("UnitTestsImportIgnore");
   db._drop("UnitTestsImportUniqueConstraints");
   db._drop("UnitTestsImportRemoveAttribute");
   db._drop("UnitTestsImportRemoveAttribute");
-  
+
   let dbs = {
-    "maçã": true, 
+    "maçã": true,
     "😀": true,
-    "ﻚﻠﺑ ﻞﻄﻴﻓ": false, 
+    "ﻚﻠﺑ ﻞﻄﻴﻓ": false,
     "abc mötor !\" ' & <>": false, 
     "UnitTestImportCreateDatabase": false
   };
@@ -104,14 +106,15 @@
   db._create("UnitTestsImportDataBatchSizeWithHeaderFile2");
   db._createEdgeCollection("UnitTestsImportEdge");
   db._createEdgeCollection("UnitTestsImportEdgeGz");
+  db._createEdgeCollection("UnitTestsImportEdgeRewriteCollectionOn");
+  db._createEdgeCollection("UnitTestsImportEdgeRewriteCollectionOff");
   db._create("UnitTestsImportIgnore");
-  db.UnitTestsImportIgnore.ensureIndex({ type: "hash", fields: [ "value" ], unique: true });
+  db.UnitTestsImportIgnore.ensureIndex({type: "hash", fields: ["value"], unique: true});
   db._create("UnitTestsImportUniqueConstraints");
-  db.UnitTestsImportUniqueConstraints.ensureIndex({ type: "hash", fields: [ "value" ], unique: true });
+  db.UnitTestsImportUniqueConstraints.ensureIndex({type: "hash", fields: ["value"], unique: true});
   db._create("UnitTestsImportCsvMergeAttributes");
 })();
 
 return {
   status: true
 };
-

--- a/tests/js/server/import/import-teardown.js
+++ b/tests/js/server/import/import-teardown.js
@@ -66,18 +66,20 @@
   db._drop("UnitTestsImportVertex");
   db._drop("UnitTestsImportEdge");
   db._drop("UnitTestsImportEdgeGz");
+  db._drop("UnitTestsImportEdgeRewriteCollectionOn");
+  db._drop("UnitTestsImportEdgeRewriteCollectionOff");
   db._drop("UnitTestsImportIgnore");
   db._drop("UnitTestsImportUniqueConstraints");
-  
+
   let dbs = ["maçã", "😀", "ﻚﻠﺑ ﻞﻄﻴﻓ", "abc mötor !\" ' & <>", "UnitTestImportCreateDatabase"];
   dbs.forEach((name) => {
     try {
       db._dropDatabase(name);
-    } catch(err) {}
+    } catch (err) {
+    }
   });
 })();
 
 return {
   status: true
 };
-


### PR DESCRIPTION
### Scope & Purpose

arangoimport now supports an additional option "--overwrite-collection-prefix".
  This option will only help while importing edge collections, and if it is used
  together with "--to-collection-prefix" or "--from-collection-prefix". If there
  are vertex collection prefixes in the file you want to import (e.g. you just
  exported an edge collection from ArangoDB) you allow arangoimport to overwrite
  those with the commandline prefixes. If the option is false (default value)
  only _from and _to values without a prefix will be prefixed by the handed in
  values.

Use-case we have in mind: someone wants to export and reimport a graph (e.g. to move from community to 3.10 enterprise graph) but wants to change collection names during this process. Having the above helper will allow to do this under the hood without manipulating the exported files anymore.

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [x] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [x] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*
  - [ ] Backport for 3.7: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

