### PR TITLE
[PREGEL] Delete workers only via garbage collection

### DIFF
--- a/arangod/Aql/Functions.cpp
+++ b/arangod/Aql/Functions.cpp
@@ -8587,13 +8587,14 @@ AqlValue Functions::PregelResult(ExpressionContext* expressionContext,
     THROW_ARANGO_EXCEPTION_PARAMS(
         TRI_ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH, AFN);
   }
+  uint64_t execNr = arg1.toInt64();
+
   bool withId = false;
   AqlValue arg2 = extractFunctionParameterValue(parameters, 1);
   if (arg2.isBoolean()) {
     withId = arg2.slice().getBool();
   }
 
-  uint64_t execNr = arg1.toInt64();
   auto& server = expressionContext->trx().vocbase().server();
   if (!server.hasFeature<pregel::PregelFeature>()) {
     registerWarning(expressionContext, AFN, TRI_ERROR_FAILED);

--- a/arangod/Pregel/PregelFeature.cpp
+++ b/arangod/Pregel/PregelFeature.cpp
@@ -625,16 +625,6 @@ void PregelFeature::cleanupConductor(uint64_t executionNumber) {
   _workers.erase(executionNumber);
 }
 
-void PregelFeature::cleanupWorker(uint64_t executionNumber) {
-  // unmapping etc might need a few seconds
-  TRI_ASSERT(SchedulerFeature::SCHEDULER != nullptr);
-  Scheduler* scheduler = SchedulerFeature::SCHEDULER;
-  scheduler->queue(RequestLane::INTERNAL_LOW, [this, executionNumber] {
-    MUTEX_LOCKER(guard, _mutex);
-    _workers.erase(executionNumber);
-  });
-}
-
 void PregelFeature::handleConductorRequest(TRI_vocbase_t& vocbase,
                                            std::string const& path,
                                            VPackSlice const& body,
@@ -740,7 +730,7 @@ void PregelFeature::handleWorkerRequest(TRI_vocbase_t& vocbase,
   } else if (path == Utils::cancelGSSPath) {
     w->cancelGlobalStep(body);
   } else if (path == Utils::finalizeExecutionPath) {
-    w->finalizeExecution(body, [this, exeNum]() { cleanupWorker(exeNum); });
+    w->finalizeExecution(body);
   } else if (path == Utils::continueRecoveryPath) {
     w->compensateStep(body);
   } else if (path == Utils::finalizeRecoveryPath) {

--- a/arangod/Pregel/PregelFeature.h
+++ b/arangod/Pregel/PregelFeature.h
@@ -84,7 +84,6 @@ class PregelFeature final : public ArangodFeature {
   std::shared_ptr<IWorker> worker(uint64_t executionNumber);
 
   void cleanupConductor(uint64_t executionNumber);
-  void cleanupWorker(uint64_t executionNumber);
 
   RecoveryManager* recoveryManager() {
     return _recoveryManagerPtr.load(std::memory_order_acquire);

--- a/arangod/Pregel/Worker.cpp
+++ b/arangod/Pregel/Worker.cpp
@@ -630,14 +630,12 @@ void Worker<V, E, M>::_continueAsync() {
 }
 
 template<typename V, typename E, typename M>
-void Worker<V, E, M>::finalizeExecution(VPackSlice const& body,
-                                        std::function<void()> cb) {
+void Worker<V, E, M>::finalizeExecution(VPackSlice const& body) {
   // Only expect serial calls from the conductor.
   // Lock to prevent malicious activity
   MUTEX_LOCKER(guard, _commandMutex);
   if (_state == WorkerState::DONE) {
     LOG_PREGEL("4067a", DEBUG) << "removing worker";
-    cb();
     return;
   }
 
@@ -657,7 +655,6 @@ void Worker<V, E, M>::finalizeExecution(VPackSlice const& body,
     _reports.clear();
     body.close();
     _callConductor(Utils::finishedWorkerFinalizationPath, body);
-    cb();
   };
 
   std::function<void()> statusUpdateCallback = [self = shared_from_this(),

--- a/arangod/Pregel/Worker.h
+++ b/arangod/Pregel/Worker.h
@@ -56,8 +56,7 @@ class IWorker : public std::enable_shared_from_this<IWorker> {
   virtual void cancelGlobalStep(
       VPackSlice const& data) = 0;  // called by coordinator
   virtual void receivedMessages(VPackSlice const& data) = 0;
-  virtual void finalizeExecution(VPackSlice const& data,
-                                 std::function<void()> cb) = 0;
+  virtual void finalizeExecution(VPackSlice const& data) = 0;
   virtual void startRecovery(VPackSlice const& data) = 0;
   virtual void compensateStep(VPackSlice const& data) = 0;
   virtual void finalizeRecovery(VPackSlice const& data) = 0;
@@ -163,8 +162,7 @@ class Worker : public IWorker {
   void startGlobalStep(VPackSlice const& data) override;
   void cancelGlobalStep(VPackSlice const& data) override;
   void receivedMessages(VPackSlice const& data) override;
-  void finalizeExecution(VPackSlice const& data,
-                         std::function<void()> cb) override;
+  void finalizeExecution(VPackSlice const& data) override;
   void startRecovery(VPackSlice const& data) override;
   void compensateStep(VPackSlice const& data) override;
   void finalizeRecovery(VPackSlice const& data) override;


### PR DESCRIPTION
PREGEL_RESULT can be used in AQL to get result from a finished Pregel
run. For this to work, the conductor and workers of this Pregel run
still need to exist. A garbadge collection exists for Pregel which
runs every 20 seconds and only deletes Pregel runs (conductor and
workers) if their TTL is exceeded.
Bug: Directly after the Pregel run finished, its workers were deleted
without checking the TTL. This PR changes that such that only the garbage
collection deletes workers.
