### PR TITLE
QA-273: fall forward the shutdown procedure to 'force' if we reach the global deadline

### DIFF
--- a/js/client/modules/@arangodb/testutils/instance-manager.js
+++ b/js/client/modules/@arangodb/testutils/instance-manager.js
@@ -271,6 +271,7 @@ class instanceManager {
     }
   }
   launchInstance() {
+    internal.env['INSTANCEINFO'] = JSON.stringify(this.getStructure());
     const startTime = time();
     try {
       this.arangods.forEach(arangod => arangod.startArango());
@@ -705,6 +706,11 @@ class instanceManager {
     if (forceTerminate === undefined) {
       forceTerminate = false;
     }
+    let timeoutReached = internal.SetGlobalExecutionDeadlineTo(0.0);
+    if (timeoutReached) {
+      print(RED + Date() + ' Deadline reached! Forcefully shutting down!' + RESET);
+      forceTerminate = true;
+    }
     let shutdownSuccess = !forceTerminate;
 
     // we need to find the leading server
@@ -718,7 +724,7 @@ class instanceManager {
       }
     }
 
-    if (!this.checkInstanceAlive()) {
+    if (!forceTerminate && !this.checkInstanceAlive()) {
       print(Date() + ' Server already dead, doing nothing. This shouldn\'t happen?');
     }
 


### PR DESCRIPTION
### Scope & Purpose

once the global deadline is reached, instance manager should not be friendly to SUT anymore. 
Hence `forceterminate` is engaged. In case of `forceterminate` we also should no longer talk to instances.
We also reset the deadline, so we get to know whether we reached it, and become able to launch debuggers again.
(subprocess handling will throw with a triggered deadline - hence we need to push the pin back in.)

- [x] :pizza: New feature
