### PR TITLE
make sure a hit deadline produces a bad result

### DIFF
--- a/js/client/modules/@arangodb/testutils/instance-manager.js
+++ b/js/client/modules/@arangodb/testutils/instance-manager.js
@@ -709,6 +709,7 @@ class instanceManager {
     let timeoutReached = internal.SetGlobalExecutionDeadlineTo(0.0);
     if (timeoutReached) {
       print(RED + Date() + ' Deadline reached! Forcefully shutting down!' + RESET);
+      this.arangods.forEach(arangod => { arangod.serverCrashedLocal = true;});
       forceTerminate = true;
     }
     let shutdownSuccess = !forceTerminate;

--- a/js/client/modules/@arangodb/testutils/testrunner.js
+++ b/js/client/modules/@arangodb/testutils/testrunner.js
@@ -618,6 +618,9 @@ class testRunner {
       clonedOpts['server.jwt-secret'] = this.serverOptions['server.jwt-secret'];
     }
     this.results.shutdown = this.results.shutdown && this.instanceManager.shutdownInstance(forceTerminate);
+    if (!this.results.shutdown) {
+      this.results.status = false;
+    }
 
     this.loadClusterTestStabilityInfo();
 


### PR DESCRIPTION
### Scope & Purpose

aftermath of https://github.com/arangodb/arangodb/pull/16566 : when handling deadlines, make sure the test result turns to crashy.

- [x] :hankey: Bugfix
