### PR TITLE
DOC-123 | Add `computedValues` collection property for Computed Values

### DIFF
--- a/Documentation/DocuBlocks/Rest/Collections/1_structs.md
+++ b/Documentation/DocuBlocks/Rest/Collections/1_structs.md
@@ -5,7 +5,7 @@ documents will wait until the data has been synchronized to disk.
 @RESTSTRUCT{schema,collection_info,object,optional,}
 The collection level schema for documents.
 
-@RESTBODYPARAM{computedFields,array,optional,computed_field}
+@RESTSTRUCT{computedFields,collection_info,array,optional,computed_field}
 A list of objects, each representing a computed value.
 
 @RESTSTRUCT{name,computed_field,string,required,}

--- a/Documentation/DocuBlocks/Rest/Collections/1_structs.md
+++ b/Documentation/DocuBlocks/Rest/Collections/1_structs.md
@@ -5,7 +5,7 @@ documents will wait until the data has been synchronized to disk.
 @RESTSTRUCT{schema,collection_info,object,optional,}
 The collection level schema for documents.
 
-@RESTSTRUCT{computedFields,collection_info,array,optional,computed_field}
+@RESTSTRUCT{computedValues,collection_info,array,optional,computed_field}
 A list of objects, each representing a computed value.
 
 @RESTSTRUCT{name,computed_field,string,required,}

--- a/Documentation/DocuBlocks/Rest/Collections/1_structs.md
+++ b/Documentation/DocuBlocks/Rest/Collections/1_structs.md
@@ -14,7 +14,7 @@ The name of the target attribute.
 @RESTSTRUCT{expression,computed_field,string,required,}
 An AQL `RETURN` operation with an expression that computes the desired value.
 
-@RESTSTRUCT{override,computed_field,boolean,required,}
+@RESTSTRUCT{overwrite,computed_field,boolean,required,}
 Whether the computed value takes precedence over a user-provided or
 existing attribute.
 

--- a/Documentation/DocuBlocks/Rest/Collections/1_structs.md
+++ b/Documentation/DocuBlocks/Rest/Collections/1_structs.md
@@ -5,6 +5,29 @@ documents will wait until the data has been synchronized to disk.
 @RESTSTRUCT{schema,collection_info,object,optional,}
 The collection level schema for documents.
 
+@RESTBODYPARAM{computedFields,array,optional,computed_field}
+A list of objects, each representing a computed value.
+
+@RESTSTRUCT{name,computed_field,string,required,}
+The name of the target attribute.
+
+@RESTSTRUCT{expression,computed_field,string,required,}
+An AQL `RETURN` operation with an expression that computes the desired value.
+
+@RESTSTRUCT{override,computed_field,boolean,required,}
+Whether the computed value takes precedence over a user-provided or
+existing attribute.
+
+@RESTSTRUCT{computeOn,computed_field,array,optional,string}
+An array of strings that defines on which write operations the value is
+computed. The possible values are `"insert"`, `"update"`, and `"replace"`.
+
+@RESTSTRUCT{keepNull,computed_field,boolean,optional,}
+Whether the result of the expression is stored if it evaluates to `null`.
+
+@RESTSTRUCT{failOnWarning,computed_field,boolean,optional,}
+Whether the write operation fails if the expression produces a warning.
+
 @RESTSTRUCT{keyOptions,collection_info,object,required,key_generator_type}
 A object which contains key generation options
 

--- a/Documentation/DocuBlocks/Rest/Collections/1_structs.md
+++ b/Documentation/DocuBlocks/Rest/Collections/1_structs.md
@@ -23,7 +23,7 @@ An array of strings that defines on which write operations the value is
 computed. The possible values are `"insert"`, `"update"`, and `"replace"`.
 
 @RESTSTRUCT{keepNull,computed_field,boolean,optional,}
-Whether the result of the expression is stored if it evaluates to `null`.
+Whether the target attribute is set if the expression evaluates to `null`.
 
 @RESTSTRUCT{failOnWarning,computed_field,boolean,optional,}
 Whether the write operation fails if the expression produces a warning.

--- a/Documentation/DocuBlocks/Rest/Collections/post_api_collection.md
+++ b/Documentation/DocuBlocks/Rest/Collections/post_api_collection.md
@@ -45,7 +45,7 @@ or a shard key attribute.
 An AQL `RETURN` operation with an expression that computes the desired value.
 See [Computed Value Expressions](https://www.arangodb.com/docs/devel/data-modeling-documents-computed-values.html#computed-value-expressions) for details.
 
-@RESTSTRUCT{override,post_api_collection_computed_field,boolean,required,}
+@RESTSTRUCT{overwrite,post_api_collection_computed_field,boolean,required,}
 Whether the computed value shall take precedence over a user-provided or
 existing attribute.
 

--- a/Documentation/DocuBlocks/Rest/Collections/post_api_collection.md
+++ b/Documentation/DocuBlocks/Rest/Collections/post_api_collection.md
@@ -31,7 +31,32 @@ collections in very special occasions, but normally a regular collection will do
 @RESTBODYPARAM{schema,object,optional,}
 Optional object that specifies the collection level schema for
 documents. The attribute keys `rule`, `level` and `message` must follow the
-rules documented in [Document Schema Validation](https://www.arangodb.com/docs/stable/document-schema-validation.html)
+rules documented in [Document Schema Validation](https://www.arangodb.com/docs/stable/documents-schema-validation.html)
+
+@RESTBODYPARAM{computedFields,array,optional,post_api_collection_computed_field}
+An optional list of objects, each representing a computed value.
+
+@RESTSTRUCT{name,post_api_collection_computed_field,string,required,}
+The name of the target attribute. Can only be a top-level attribute, but you
+may return a nested object. Cannot be `_key`, `_id`, `_rev`, `_from`, `_to`,
+or a shard key attribute.
+
+@RESTSTRUCT{expression,post_api_collection_computed_field,string,required,}
+An AQL `RETURN` operation with an expression that computes the desired value.
+See [Computed Value Expressions](https://www.arangodb.com/docs/devel/data-modeling-documents-computed-values.html#computed-value-expressions) for details.
+
+@RESTSTRUCT{override,post_api_collection_computed_field,boolean,required,}
+Whether the computed value shall take precedence over a user-provided or
+existing attribute.
+
+@RESTSTRUCT{computeOn,post_api_collection_computed_field,array,optional,string}
+An array of strings to define on which write operations the value shall be
+computed. The possible values are `"insert"`, `"update"`, and `"replace"`.
+The default is `["insert", "update", "replace"]`.
+
+@RESTSTRUCT{keepNull,post_api_collection_computed_field,boolean,optional,}
+Whether the result of the expression shall be stored if it evaluates to `null`.
+This can be used to skip the value computation if any pre-conditions are not met.
 
 @RESTBODYPARAM{keyOptions,object,optional,post_api_collection_opts}
 additional options for key generation. If specified, then `keyOptions`

--- a/Documentation/DocuBlocks/Rest/Collections/post_api_collection.md
+++ b/Documentation/DocuBlocks/Rest/Collections/post_api_collection.md
@@ -33,7 +33,7 @@ Optional object that specifies the collection level schema for
 documents. The attribute keys `rule`, `level` and `message` must follow the
 rules documented in [Document Schema Validation](https://www.arangodb.com/docs/stable/documents-schema-validation.html)
 
-@RESTBODYPARAM{computedFields,array,optional,post_api_collection_computed_field}
+@RESTBODYPARAM{computedValues,array,optional,post_api_collection_computed_field}
 An optional list of objects, each representing a computed value.
 
 @RESTSTRUCT{name,post_api_collection_computed_field,string,required,}

--- a/Documentation/DocuBlocks/Rest/Collections/post_api_collection.md
+++ b/Documentation/DocuBlocks/Rest/Collections/post_api_collection.md
@@ -55,8 +55,13 @@ computed. The possible values are `"insert"`, `"update"`, and `"replace"`.
 The default is `["insert", "update", "replace"]`.
 
 @RESTSTRUCT{keepNull,post_api_collection_computed_field,boolean,optional,}
-Whether the result of the expression shall be stored if it evaluates to `null`.
-This can be used to skip the value computation if any pre-conditions are not met.
+Whether the target attribute shall be set if the expression evaluates to `null`.
+You can set the option to `false` to not set (or unset) the target attribute if
+the expression returns `null`. The default is `true`.
+
+@RESTSTRUCT{failOnWarning,post_api_collection_computed_field,boolean,optional,}
+Whether to let the write operation fail if the expression produces a warning.
+The default is `false`.
 
 @RESTBODYPARAM{keyOptions,object,optional,post_api_collection_opts}
 additional options for key generation. If specified, then `keyOptions`

--- a/Documentation/DocuBlocks/Rest/Collections/put_api_collection_properties.md
+++ b/Documentation/DocuBlocks/Rest/Collections/put_api_collection_properties.md
@@ -63,6 +63,10 @@ The default is `["insert", "update", "replace"]`.
 Whether the result of the expression shall be stored if it evaluates to `null`.
 This can be used to skip the value computation if any pre-conditions are not met.
 
+@RESTSTRUCT{failOnWarning,put_api_collection_properties_computed_field,boolean,optional,}
+Whether to let the write operation fail if the expression produces a warning.
+The default is `false`.
+
 @RESTBODYPARAM{replicationFactor,integer,optional,int64}
 (The default is *1*): in a cluster, this attribute determines how many copies
 of each shard are kept on different DB-Servers. The value 1 means that only one

--- a/Documentation/DocuBlocks/Rest/Collections/put_api_collection_properties.md
+++ b/Documentation/DocuBlocks/Rest/Collections/put_api_collection_properties.md
@@ -50,7 +50,7 @@ or a shard key attribute.
 An AQL `RETURN` operation with an expression that computes the desired value.
 See [Computed Value Expressions](https://www.arangodb.com/docs/devel/data-modeling-documents-computed-values.html#computed-value-expressions) for details.
 
-@RESTSTRUCT{override,put_api_collection_properties_computed_field,boolean,required,}
+@RESTSTRUCT{overwrite,put_api_collection_properties_computed_field,boolean,required,}
 Whether the computed value shall take precedence over a user-provided or
 existing attribute.
 

--- a/Documentation/DocuBlocks/Rest/Collections/put_api_collection_properties.md
+++ b/Documentation/DocuBlocks/Rest/Collections/put_api_collection_properties.md
@@ -38,7 +38,7 @@ Optional object that specifies the collection level schema for
 documents. The attribute keys `rule`, `level` and `message` must follow the
 rules documented in [Document Schema Validation](https://www.arangodb.com/docs/stable/data-modeling-documents-schema-validation.html)
 
-@RESTBODYPARAM{computedFields,array,optional,put_api_collection_properties_computed_field}
+@RESTBODYPARAM{computedValues,array,optional,put_api_collection_properties_computed_field}
 An optional list of objects, each representing a computed value.
 
 @RESTSTRUCT{name,put_api_collection_properties_computed_field,string,required,}
@@ -60,8 +60,9 @@ computed. The possible values are `"insert"`, `"update"`, and `"replace"`.
 The default is `["insert", "update", "replace"]`.
 
 @RESTSTRUCT{keepNull,put_api_collection_properties_computed_field,boolean,optional,}
-Whether the result of the expression shall be stored if it evaluates to `null`.
-This can be used to skip the value computation if any pre-conditions are not met.
+Whether the target attribute shall be set if the expression evaluates to `null`.
+You can set the option to `false` to not set (or unset) the target attribute if
+the expression returns `null`. The default is `true`.
 
 @RESTSTRUCT{failOnWarning,put_api_collection_properties_computed_field,boolean,optional,}
 Whether to let the write operation fail if the expression produces a warning.

--- a/Documentation/DocuBlocks/Rest/Collections/put_api_collection_properties.md
+++ b/Documentation/DocuBlocks/Rest/Collections/put_api_collection_properties.md
@@ -36,7 +36,32 @@ costs.
 @RESTBODYPARAM{schema,object,optional,}
 Optional object that specifies the collection level schema for
 documents. The attribute keys `rule`, `level` and `message` must follow the
-rules documented in [Document Schema Validation](https://www.arangodb.com/docs/stable/document-schema-validation.html)
+rules documented in [Document Schema Validation](https://www.arangodb.com/docs/stable/data-modeling-documents-schema-validation.html)
+
+@RESTBODYPARAM{computedFields,array,optional,put_api_collection_properties_computed_field}
+An optional list of objects, each representing a computed value.
+
+@RESTSTRUCT{name,put_api_collection_properties_computed_field,string,required,}
+The name of the target attribute. Can only be a top-level attribute, but you
+may return a nested object. Cannot be `_key`, `_id`, `_rev`, `_from`, `_to`,
+or a shard key attribute.
+
+@RESTSTRUCT{expression,put_api_collection_properties_computed_field,string,required,}
+An AQL `RETURN` operation with an expression that computes the desired value.
+See [Computed Value Expressions](https://www.arangodb.com/docs/devel/data-modeling-documents-computed-values.html#computed-value-expressions) for details.
+
+@RESTSTRUCT{override,put_api_collection_properties_computed_field,boolean,required,}
+Whether the computed value shall take precedence over a user-provided or
+existing attribute.
+
+@RESTSTRUCT{computeOn,put_api_collection_properties_computed_field,array,optional,string}
+An array of strings to define on which write operations the value shall be
+computed. The possible values are `"insert"`, `"update"`, and `"replace"`.
+The default is `["insert", "update", "replace"]`.
+
+@RESTSTRUCT{keepNull,put_api_collection_properties_computed_field,boolean,optional,}
+Whether the result of the expression shall be stored if it evaluates to `null`.
+This can be used to skip the value computation if any pre-conditions are not met.
 
 @RESTBODYPARAM{replicationFactor,integer,optional,int64}
 (The default is *1*): in a cluster, this attribute determines how many copies


### PR DESCRIPTION
Docs PR: https://github.com/arangodb/docs/pull/1065 (will be copied from 3.10 when version 3.11 is created in the docs repo)