### PR TITLE
[CINFRA-493] Missing Stream if snapshot complete

### DIFF
--- a/arangod/Replication2/ReplicatedState/FollowerStateManager.tpp
+++ b/arangod/Replication2/ReplicatedState/FollowerStateManager.tpp
@@ -167,6 +167,7 @@ void FollowerStateManager<S>::run() noexcept {
             if (needsSnapshot()) {
               return FollowerInternalState::kTransferSnapshot;
             } else {
+              startService();
               return FollowerInternalState::kWaitForNewEntries;
             }
           }))

--- a/tests/Replication2/Mocks/FakeReplicatedState.h
+++ b/tests/Replication2/Mocks/FakeReplicatedState.h
@@ -191,6 +191,8 @@ struct FakeFollowerType : replicated_state::IReplicatedFollowerState<S> {
   AsyncOperationMarker<std::unique_ptr<EntryIterator>, Result> apply;
   AsyncOperationMarker<std::pair<ParticipantId, LogIndex>, Result> acquire;
 
+  using replicated_state::IReplicatedFollowerState<S>::getStream;
+
  protected:
   auto applyEntries(std::unique_ptr<EntryIterator> ptr) noexcept
       -> futures::Future<Result> override {

--- a/tests/Replication2/ReplicatedState/FollowerSnapshotTest.cpp
+++ b/tests/Replication2/ReplicatedState/FollowerSnapshotTest.cpp
@@ -110,6 +110,10 @@ TEST_F(FollowerSnapshotTest, basic_follower_manager_test) {
   ASSERT_EQ(nullptr, manager->getFollowerState())
       << "follower state should not be available yet";
 
+  // furthermore the state should have access to the stream
+  ASSERT_ANY_THROW({ std::ignore = state->getStream(); })
+      << "stream must not be available";
+
   // first trigger an error
   state->acquire.resolveWithAndReset(
       Result{TRI_ERROR_HTTP_SERVICE_UNAVAILABLE});
@@ -144,6 +148,9 @@ TEST_F(FollowerSnapshotTest, basic_follower_manager_test) {
   ASSERT_NE(nullptr, manager->getFollowerState())
       << "follower state should be available";
   EXPECT_FALSE(state->apply.wasTriggered());
+
+  // furthermore the state should have access to the stream
+  ASSERT_NE(state->getStream(), nullptr) << "stream is still nullptr";
 
   follower->updateCommitIndex(LogIndex{3});
   {
@@ -188,4 +195,75 @@ TEST_F(FollowerSnapshotTest, follower_resign_before_leadership_acked) {
 
   // follower resign
   follower->resign();
+}
+
+TEST_F(FollowerSnapshotTest,
+       basic_follower_manager_test_with_completed_snapshot) {
+  auto follower =
+      std::make_shared<test::FakeFollower>("follower", "leader", LogTerm{1});
+  follower->insertMultiplexedValue<State>(
+      test::DefaultEntryType{.key = "A", .value = "a"});
+  follower->insertMultiplexedValue<State>(
+      test::DefaultEntryType{.key = "B", .value = "b"});
+  follower->insertMultiplexedValue<State>(
+      test::DefaultEntryType{.key = "C", .value = "c"});
+  follower->insertMultiplexedValue<State>(
+      test::DefaultEntryType{.key = "D", .value = "d"});
+
+  auto token = std::make_unique<ReplicatedStateToken>(
+      ReplicatedStateToken::withExplicitSnapshotStatus(
+          StateGeneration{1},
+          SnapshotInfo{.status = SnapshotStatus::kCompleted,
+                       .timestamp = SnapshotInfo::clock ::now(),
+                       .error = std::nullopt}));
+  auto manager = std::make_shared<FollowerStateManager<State>>(
+      loggerCtx, nullptr, follower, std::move(core), std::move(token), factory,
+      _metrics);
+  manager->run();
+  {
+    auto status = *manager->getStatus().asFollowerStatus();
+    EXPECT_EQ(status.managerState.state,
+              FollowerInternalState::kWaitForLeaderConfirmation);
+    EXPECT_EQ(status.snapshot.status, SnapshotStatus::kCompleted);
+  }
+
+  // required for leader to become established
+  follower->triggerLeaderAcked();
+
+  // the snapshot is already available, we expect it to be complete
+  {
+    auto status = *manager->getStatus().asFollowerStatus();
+    EXPECT_EQ(status.managerState.state,
+              FollowerInternalState::kWaitForNewEntries);
+    EXPECT_EQ(status.snapshot.status, SnapshotStatus::kCompleted);
+  }
+
+  // now here we expect that the state is internally created and available
+  // to the user
+  auto state = factory->getLatestFollower();
+  ASSERT_NE(state, nullptr) << "expect state to be created";
+
+  ASSERT_NE(nullptr, manager->getFollowerState())
+      << "follower state should be available";
+  EXPECT_FALSE(state->apply.wasTriggered());
+
+  // furthermore the state should have access to the stream
+  ASSERT_NE(state->getStream(), nullptr) << "stream is still nullptr";
+
+  follower->updateCommitIndex(LogIndex{3});
+  {
+    auto status = *manager->getStatus().asFollowerStatus();
+    EXPECT_EQ(status.managerState.state,
+              FollowerInternalState::kApplyRecentEntries);
+  }
+  EXPECT_TRUE(state->apply.wasTriggered());
+  EXPECT_EQ(state->apply.inspectValue()->range(),
+            LogRange(LogIndex{1}, LogIndex{4}));
+
+  state->apply.resolveWith(Result{});  // resolve with ok
+  {
+    auto status = *manager->getStatus().asFollowerStatus();
+    EXPECT_EQ(status.managerState.state,
+              FollowerInternalState::kWaitForNewEntries);
+  }
 }

--- a/tests/Replication2/ReplicatedState/FollowerSnapshotTest.cpp
+++ b/tests/Replication2/ReplicatedState/FollowerSnapshotTest.cpp
@@ -110,7 +110,7 @@ TEST_F(FollowerSnapshotTest, basic_follower_manager_test) {
   ASSERT_EQ(nullptr, manager->getFollowerState())
       << "follower state should not be available yet";
 
-  // furthermore the state should have access to the stream
+  // furthermore the state should not have access to the stream
   ASSERT_ANY_THROW({ std::ignore = state->getStream(); })
       << "stream must not be available";
 


### PR DESCRIPTION
### Scope & Purpose
This PR fixes two things:
1. The prototype states `applyEntries` is declared as noexcept but wasn't. This is because `getStream` could throw an exception. 
2. This pointed at another problem: the follower state manager did not properly initialise the stream reference on the state after it was constructed **and** the snapshot was already available. Added tests for that.