### PR TITLE
fix tests; need to load the UUID from the file

### DIFF
--- a/js/client/modules/@arangodb/test-helper.js
+++ b/js/client/modules/@arangodb/test-helper.js
@@ -32,6 +32,7 @@ const internal = require('internal'); // OK: processCsvFile
 const { 
   getServerById,
   getServersByType,
+  getUrlById,
   getEndpointById,
   getEndpointsByType,
   Helper,
@@ -45,7 +46,8 @@ const fs = require('fs');
 const pu = require('@arangodb/testutils/process-utils');
 const _ = require('lodash');
 const inst = require('@arangodb/testutils/instance');
-    
+
+exports.getUrlById = getUrlById;
 exports.getServerById = getServerById;
 exports.getServersByType = getServersByType;
 exports.getEndpointById = getEndpointById;

--- a/js/common/modules/@arangodb/test-helper-common.js
+++ b/js/common/modules/@arangodb/test-helper-common.js
@@ -64,6 +64,13 @@ exports.getEndpointById = function (id) {
     .map(toEndpoint)[0];
 };
 
+exports.getUrlById = function (id) {
+  const toUrl = (d) => (d.url);
+  const instanceInfo = getInstanceInfo();
+  return instanceInfo.arangods.filter((d) => (d.id === id))
+    .map(toUrl)[0];
+};
+
 exports.getEndpointsByType = function (type) {
   const isType = (d) => (d.instanceRole.toLowerCase() === type);
   const toEndpoint = (d) => (d.endpoint);

--- a/js/common/modules/@arangodb/test-helper-common.js
+++ b/js/common/modules/@arangodb/test-helper-common.js
@@ -30,35 +30,36 @@
 
 let internal = require('internal'); // OK: processCsvFile
 const request = require('@arangodb/request');
+const fs = require('fs');
+
+let instanceInfo = null;
+
+function getInstanceInfo() {
+  if (instanceInfo === null) {
+    instanceInfo = JSON.parse(internal.env.INSTANCEINFO);
+    instanceInfo.arangods.forEach(arangod => {
+      arangod.id = fs.readFileSync(fs.join(arangod.dataDir, 'UUID')).toString();
+    });
+  }
+  return instanceInfo;
+}
 
 exports.getServerById = function (id) {
-  const instanceInfo = JSON.parse(internal.env.INSTANCEINFO);
+  const instanceInfo = getInstanceInfo();
   return instanceInfo.arangods.filter((d) => (d.id === id))[0];
 };
 
 exports.getServersByType = function (type) {
   const isType = (d) => (d.instanceRole.toLowerCase() === type);
-  const instanceInfo = JSON.parse(internal.env.INSTANCEINFO);
+  const instanceInfo = getInstanceInfo();
   return instanceInfo.arangods.filter(isType);
 };
 
 exports.getEndpointById = function (id) {
   const toEndpoint = (d) => (d.endpoint);
-  const endpointToURL = (endpoint) => {
-    if (endpoint.substr(0, 6) === 'ssl://') {
-      return 'https://' + endpoint.substr(6);
-    }
-    let pos = endpoint.indexOf('://');
-    if (pos === -1) {
-      return 'http://' + endpoint;
-    }
-    return 'http' + endpoint.substr(pos);
-  };
-
-  const instanceInfo = JSON.parse(internal.env.INSTANCEINFO);
+  const instanceInfo = getInstanceInfo();
   return instanceInfo.arangods.filter((d) => (d.id === id))
-                              .map(toEndpoint)
-                              .map(endpointToURL)[0];
+    .map(toEndpoint)[0];
 };
 
 exports.getEndpointsByType = function (type) {
@@ -75,7 +76,7 @@ exports.getEndpointsByType = function (type) {
     return 'http' + endpoint.substr(pos);
   };
 
-  const instanceInfo = JSON.parse(internal.env.INSTANCEINFO);
+  const instanceInfo = getInstanceInfo();
   return instanceInfo.arangods.filter(isType)
                               .map(toEndpoint)
                               .map(endpointToURL);

--- a/js/common/modules/@arangodb/test-helper-common.js
+++ b/js/common/modules/@arangodb/test-helper-common.js
@@ -37,9 +37,11 @@ let instanceInfo = null;
 function getInstanceInfo() {
   if (instanceInfo === null) {
     instanceInfo = JSON.parse(internal.env.INSTANCEINFO);
-    instanceInfo.arangods.forEach(arangod => {
-      arangod.id = fs.readFileSync(fs.join(arangod.dataDir, 'UUID')).toString();
-    });
+    if (instanceInfo.arangods.length > 2) {
+      instanceInfo.arangods.forEach(arangod => {
+        arangod.id = fs.readFileSync(fs.join(arangod.dataDir, 'UUID')).toString();
+      });
+    }
   }
   return instanceInfo;
 }

--- a/tests/js/client/shell/shell-replication-responses-cluster.js
+++ b/tests/js/client/shell/shell-replication-responses-cluster.js
@@ -28,7 +28,7 @@ const internal = require('internal');
 const arangodb = require('@arangodb');
 const _ = require('lodash');
 const db = arangodb.db;
-const { debugCanUseFailAt, debugClearFailAt, debugSetFailAt, getEndpointById, getEndpointsByType } = require('@arangodb/test-helper');
+const { debugCanUseFailAt, debugClearFailAt, debugSetFailAt, getEndpointById, getUrlById, getEndpointsByType } = require('@arangodb/test-helper');
 const request = require('@arangodb/request');
 
 function followerResponsesSuite() {
@@ -57,12 +57,13 @@ function followerResponsesSuite() {
       let follower = servers[1];
       
       let endpoint = getEndpointById(follower);
+      let url = getUrlById(follower);
       debugSetFailAt(endpoint, "synchronousReplication::neverRefuseOnFollower");
 
       // send a single document replication insert request
       let response = request({
         method: "post",
-        url: endpoint + "/_api/document/" + shard + "?isSynchronousReplication=" + encodeURIComponent(leader),
+        url: url + "/_api/document/" + shard + "?isSynchronousReplication=" + encodeURIComponent(leader),
         body: { _key: "test1" },
         json: true
       });
@@ -73,7 +74,7 @@ function followerResponsesSuite() {
       // send multi document replication insert request
       response = request({
         method: "post",
-        url: endpoint + "/_api/document/" + shard + "?isSynchronousReplication=" + encodeURIComponent(leader),
+        url: url + "/_api/document/" + shard + "?isSynchronousReplication=" + encodeURIComponent(leader),
         body: [ { _key: "test2" }, { _key: "test3" } ],
         json: true
       });
@@ -98,12 +99,13 @@ function followerResponsesSuite() {
       let follower = servers[1];
       
       let endpoint = getEndpointById(follower);
+      let url = getUrlById(follower);
       debugSetFailAt(endpoint, "synchronousReplication::neverRefuseOnFollower");
 
       // send a single document replication update request
       let response = request({
         method: "patch",
-        url: endpoint + "/_api/document/" + shard + "/test1?isSynchronousReplication=" + encodeURIComponent(leader),
+        url: url + "/_api/document/" + shard + "/test1?isSynchronousReplication=" + encodeURIComponent(leader),
         body: { _key: "test1" },
         json: true
       });
@@ -114,7 +116,7 @@ function followerResponsesSuite() {
       // send multi document replication update request
       response = request({
         method: "patch",
-        url: endpoint + "/_api/document/" + shard + "?isSynchronousReplication=" + encodeURIComponent(leader),
+        url: url + "/_api/document/" + shard + "?isSynchronousReplication=" + encodeURIComponent(leader),
         body: [ { _key: "test2" }, { _key: "test3" } ],
         json: true
       });
@@ -139,12 +141,13 @@ function followerResponsesSuite() {
       let follower = servers[1];
       
       let endpoint = getEndpointById(follower);
+      let url = getUrlById(follower);
       debugSetFailAt(endpoint, "synchronousReplication::neverRefuseOnFollower");
 
       // send a single document replication remove request
       let response = request({
         method: "delete",
-        url: endpoint + "/_api/document/" + shard + "/test1?isSynchronousReplication=" + encodeURIComponent(leader),
+        url: url + "/_api/document/" + shard + "/test1?isSynchronousReplication=" + encodeURIComponent(leader),
         body: {},
         json: true
       });
@@ -155,7 +158,7 @@ function followerResponsesSuite() {
       // send multi document replication remove request
       response = request({
         method: "delete",
-        url: endpoint + "/_api/document/" + shard + "?isSynchronousReplication=" + encodeURIComponent(leader),
+        url: url + "/_api/document/" + shard + "?isSynchronousReplication=" + encodeURIComponent(leader),
         body: [ { _key: "test2" }, { _key: "test3" } ],
         json: true
       });

--- a/tests/js/server/resilience/failover-failure/resilience-synchronous-repl-failureAt-cluster.js
+++ b/tests/js/server/resilience/failover-failure/resilience-synchronous-repl-failureAt-cluster.js
@@ -1,5 +1,5 @@
 /*jshint globalstrict:false, strict:false */
-/*global assertTrue, assertFalse, assertEqual, fail, instanceInfo, arango */
+/*global assertTrue, assertFalse, assertEqual, fail, instanceManager, arango */
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief test synchronous replication in the cluster
@@ -33,6 +33,7 @@ const db = arangodb.db;
 const ERRORS = arangodb.errors;
 const _ = require("lodash");
 const wait = require("internal").wait;
+const instanceRoledbServer = 'dbserver';
 const suspendExternal = require("internal").suspendExternal;
 const continueExternal = require("internal").continueExternal;
 let { getEndpointById,
@@ -43,7 +44,6 @@ let { getEndpointById,
       debugSetFailAt,
       debugClearFailAt,
       reconnectRetry,
-      getDBServers
     } = require('@arangodb/test-helper');
 
 
@@ -119,17 +119,16 @@ function SynchronousReplicationSuite() {
 
   function failFollower(failAt = null, follower = null) {
     if (follower == null) follower = cinfo.shards[shards[0]][1];
-    var endpoint = global.ArangoClusterInfo.getServerEndpoint(follower);
-
-    // Now look for instanceInfo:
-    var pos = _.findIndex(global.instanceInfo.arangods,
-      x => x.endpoint === endpoint);
+    var endpoint = getEndpointById(follower);
+    // Now look for instanceManager:
+    var pos = _.findIndex(global.instanceManager.arangods,
+                          x => x.endpoint === endpoint);
     assertTrue(pos >= 0);
     if (failAt) {
       debugSetFailAt(endpoint.replace('tcp://', 'http://'), failAt);
       console.info("Have added failure in follower", follower, " at ", failAt);
     } else {
-      assertTrue(suspendExternal(global.instanceInfo.arangods[pos].pid));
+      assertTrue(suspendExternal(global.instanceManager.arangods[pos].pid));
       console.info("Have failed follower", follower);
     }
     failedState.follower = { failAt: (failAt ? failAt : null), failedServer: follower };
@@ -142,15 +141,15 @@ function SynchronousReplicationSuite() {
   function healFollower(failAt = null, follower = null) {
     if (follower == null) follower = cinfo.shards[shards[0]][1];
     var endpoint = global.ArangoClusterInfo.getServerEndpoint(follower);
-    // Now look for instanceInfo:
-    var pos = _.findIndex(global.instanceInfo.arangods,
+    // Now look for instanceManager:
+    var pos = _.findIndex(global.instanceManager.arangods,
       x => x.endpoint === endpoint);
     assertTrue(pos >= 0);
     if (failAt) {
       debugRemoveFailAt(endpoint.replace('tcp://', 'http://'), failAt);
       console.info("Have removed failure in follower", follower, " at ", failAt);
     } else {
-      assertTrue(continueExternal(global.instanceInfo.arangods[pos].pid));
+      assertTrue(continueExternal(global.instanceManager.arangods[pos].pid));
       console.info("Have healed follower", follower);
     }
     failedState.follower = null;
@@ -163,15 +162,15 @@ function SynchronousReplicationSuite() {
   function failLeader(failAt = null, leader = null) {
     if (leader == null) leader = cinfo.shards[shards[0]][0];
     var endpoint = global.ArangoClusterInfo.getServerEndpoint(leader);
-    // Now look for instanceInfo:
-    var pos = _.findIndex(global.instanceInfo.arangods,
+    // Now look for instanceManager:
+    var pos = _.findIndex(global.instanceManager.arangods,
       x => x.endpoint === endpoint);
     assertTrue(pos >= 0);
     if (failAt) {
       debugSetFailAt(endpoint.replace('tcp://', 'http://'), failAt);
       console.info("Have failed leader", leader, " at ", failAt);
     } else {
-      assertTrue(suspendExternal(global.instanceInfo.arangods[pos].pid));
+      assertTrue(suspendExternal(global.instanceManager.arangods[pos].pid));
       console.info("Have failed leader", leader);
     }
     failedState.leader = { failAt: (failAt ? failAt : null), failedServer: leader };
@@ -185,15 +184,15 @@ function SynchronousReplicationSuite() {
   function healLeader(failAt = null, leader = null) {
     if (leader == null) leader = cinfo.shards[shards[0]][0];
     var endpoint = global.ArangoClusterInfo.getServerEndpoint(leader);
-    // Now look for instanceInfo:
-    var pos = _.findIndex(global.instanceInfo.arangods,
+    // Now look for instanceManager:
+    var pos = _.findIndex(global.instanceManager.arangods,
       x => x.endpoint === endpoint);
     assertTrue(pos >= 0);
     if (failAt) {
       debugRemoveFailAt(endpoint.replace('tcp://', 'http://'), failAt);
       console.info("Have removed failure in leader", leader, " at ", failAt);
     } else {
-      assertTrue(continueExternal(global.instanceInfo.arangods[pos].pid));
+      assertTrue(continueExternal(global.instanceManager.arangods[pos].pid));
       console.info("Have healed leader", leader);
     }
     failedState.leader = null;
@@ -352,7 +351,7 @@ function SynchronousReplicationSuite() {
     ////////////////////////////////////////////////////////////////////////////////
 
     tearDown: function () {
-      var servers = global.ArangoClusterInfo.getDBServers();
+      var servers = getServersByType(instanceRoledbServer);
       servers.forEach(s => {
         let endpoint = global.ArangoClusterInfo.getServerEndpoint(s.serverId);
         debugClearFailAt(endpoint.replace('tcp://', 'http://'));
@@ -364,10 +363,10 @@ function SynchronousReplicationSuite() {
     },
 
     ////////////////////////////////////////////////////////////////////////////////
-    /// @brief check whether we have access to global.instanceInfo
+    /// @brief check whether we have access to global.instanceManager
     ////////////////////////////////////////////////////////////////////////////////
     testCheckInstanceInfo: function () {
-      assertTrue(global.instanceInfo !== undefined);
+      assertTrue(global.instanceManager !== undefined);
     },
 
     ////////////////////////////////////////////////////////////////////////////////
@@ -376,7 +375,7 @@ function SynchronousReplicationSuite() {
 
     testSetup: function () {
       for (var count = 0; count < 120; ++count) {
-        let dbservers = getDBServers();
+        let dbservers = getServersByType(instanceRoledbServer);
         if (dbservers.length === 5) {
           assertTrue(waitForSynchronousReplication("_system"));
           return;


### PR DESCRIPTION
### Scope & Purpose

`resilience-synchronous-repl-failureAt-cluster.js` would be broken by the [instance rework](https://github.com/arangodb/arangodb/pull/16566). this fixes it.

- [x] :hankey: Bugfix
