### PR TITLE
fix invocation of golang tests

### DIFF
--- a/js/client/modules/@arangodb/testsuites/go.js
+++ b/js/client/modules/@arangodb/testsuites/go.js
@@ -72,7 +72,7 @@ function goDriver (options) {
     runOneTest(file) {
       process.env['TEST_ENDPOINTS'] = this.instanceManager.urls.join(',');
       process.env['TEST_AUTHENTICATION'] = 'basic:root:';
-      let jwt = pu.getJwtSecret(this.options);
+      let jwt = this.instanceManager.JWT; 
       if (jwt) {
         process.env['TEST_JWTSECRET'] = jwt;
       }


### PR DESCRIPTION
### Scope & Purpose

Fix invocation of golang tests via `scripts/unittest`. They previously failed because they called a non-existing function. The function was removed by some previous refactoring.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*
  - [ ] Backport for 3.7: *(Please link PR)*

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
