### PR TITLE
use more specific exit codes for invalid startup options

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,30 @@
 devel
 -----
 
+* Added more specific process exit codes for arangod and all client tools,
+  and changed the executables' exit code for the following situations:
+  
+  - an unknown startup option name is used: previously the exit code was 1.
+    Now the exit code when using an invalid option is 3 (symbolic exit code 
+    name EXIT_INVALID_OPTION_NAME).
+  - an invalid value is used for a startup option (e.g. a number that is 
+    outside the allowed range for the option's underlying value type, or a 
+    string value is used for a numeric option): previously the exit code was
+    1. Now the exit code for these case is 4 (symbolic exit code name
+    EXIT_INVALID_OPTION_VALUE).
+  - a config file is specified that does not exist: previously the exit code
+    was either 1 or 6 (symbolic exit code name EXIT_CONFIG_NOT_FOUND). Now
+    the exit code in this case is always 6 (EXIT_CONFIG_NOT_FOUND).
+  - a structurally invalid config file is used, e.g. the config file contains
+    a line that cannot be parsed: previously the exit code in this situation
+    was 1. Now it is always 6 (symbolic exit code name EXIT_CONFIG_NOT_FOUND).
+
+  Note that this change can affect any custom scripts that check for startup
+  failures using the specific exit code 1. These scripts should be adjusted so
+  that they check for a non-zero exit code. They can opt in to more specific
+  error handling using the additional exit codes mentioned above, in order to
+  distinguish between different kinds of startup errors.
+
 * arangoimport now supports the option --remove-attribute on type JSON as well.
   Before it was restricted to TSV and CSV only.
 

--- a/lib/ApplicationFeatures/ApplicationServer.cpp
+++ b/lib/ApplicationFeatures/ApplicationServer.cpp
@@ -384,7 +384,7 @@ void ApplicationServer::parseOptions(int argc, char* argv[]) {
   if (!parser.parse(argc, argv)) {
     // command-line option parsing failed. an error was already printed
     // by now, so we can exit
-    exit(EXIT_FAILURE);
+    FATAL_ERROR_EXIT_CODE(_options->processingResult().exitCodeOrFailure());
   }
 
   if (_dumpDependencies) {

--- a/lib/ApplicationFeatures/ConfigFeature.cpp
+++ b/lib/ApplicationFeatures/ConfigFeature.cpp
@@ -23,8 +23,6 @@
 
 #include "ApplicationFeatures/ConfigFeature.h"
 
-#include <stdlib.h>
-
 #include "ApplicationFeatures/ApplicationServer.h"
 #include "ApplicationFeatures/VersionFeature.h"
 #include "Basics/ArangoGlobalContext.h"
@@ -41,6 +39,8 @@
 #include "ProgramOptions/Parameters.h"
 #include "ProgramOptions/ProgramOptions.h"
 #include "ProgramOptions/Translator.h"
+
+#include <cstdlib>
 
 using namespace arangodb::basics;
 using namespace arangodb::options;
@@ -114,7 +114,7 @@ void ConfigFeature::loadConfigFile(std::shared_ptr<ProgramOptions> options,
           << "loading override '" << local << "'";
 
       if (!parser.parse(local, true)) {
-        FATAL_ERROR_EXIT();
+        FATAL_ERROR_EXIT_CODE(options->processingResult().exitCodeOrFailure());
       }
     }
 
@@ -122,7 +122,7 @@ void ConfigFeature::loadConfigFile(std::shared_ptr<ProgramOptions> options,
         << "using user supplied config file '" << _file << "'";
 
     if (!parser.parse(_file, true)) {
-      FATAL_ERROR_EXIT();
+      FATAL_ERROR_EXIT_CODE(options->processingResult().exitCodeOrFailure());
     }
 
     return;
@@ -148,6 +148,7 @@ void ConfigFeature::loadConfigFile(std::shared_ptr<ProgramOptions> options,
   }
 
   std::vector<std::string> locations;
+  locations.reserve(4);
 
   std::string current = FileUtils::currentDirectory().result();
   // ./etc/relative/ is always first choice, if it exists
@@ -184,7 +185,9 @@ void ConfigFeature::loadConfigFile(std::shared_ptr<ProgramOptions> options,
           << "found config file '" << name << "'";
       filename = name;
       break;
-    } else if (checkArangoImp) {
+    }
+
+    if (checkArangoImp) {
       name = FileUtils::buildFilename(location, "arangoimp.conf");
       LOG_TOPIC("b629e", TRACE, Logger::CONFIG)
           << "checking config file '" << name << "'";
@@ -212,7 +215,7 @@ void ConfigFeature::loadConfigFile(std::shared_ptr<ProgramOptions> options,
         << "loading override '" << local << "'";
 
     if (!parser.parse(local, true)) {
-      FATAL_ERROR_EXIT();
+      FATAL_ERROR_EXIT_CODE(options->processingResult().exitCodeOrFailure());
     }
   } else {
     LOG_TOPIC("d601e", TRACE, Logger::CONFIG) << "no override file found";
@@ -231,15 +234,16 @@ void ConfigFeature::loadConfigFile(std::shared_ptr<ProgramOptions> options,
         locationMsg += "'" + FileUtils::buildFilename(it, basename) + "'";
       }
       locationMsg += ")";
-      options->failNotice("cannot find configuration file\n\n" + locationMsg);
-      exit(EXIT_FAILURE);
+      options->failNotice(TRI_EXIT_CONFIG_NOT_FOUND,
+                          "cannot find configuration file\n\n" + locationMsg);
+      FATAL_ERROR_EXIT_CODE(options->processingResult().exitCodeOrFailure());
     } else {
       return;
     }
   }
 
   if (!parser.parse(filename, true)) {
-    exit(EXIT_FAILURE);
+    FATAL_ERROR_EXIT_CODE(options->processingResult().exitCodeOrFailure());
   }
 }
 

--- a/lib/Basics/exitcodes.dat
+++ b/lib/Basics/exitcodes.dat
@@ -6,9 +6,10 @@
 EXIT_SUCCESS,0,"success","No error has occurred."
 EXIT_FAILED,1,"exit with error","Will be returned when a general error occurred."
 EXIT_CODE_RESOLVING_FAILED,2,"exit code resolving failed","unspecified exit code"
-
+EXIT_INVALID_OPTION_NAME,3,"invalid startup option name","invalid/unknown startup option name was used"
+EXIT_INVALID_OPTION_VALUE,4,"invalid startup option value","invalid startup option value was used"
 EXIT_BINARY_NOT_FOUND,5,"binary not found","Will be returned if a referenced binary was not found"
-EXIT_CONFIG_NOT_FOUND,6,"config not found","Will be returned if no valid configuration was found"
+EXIT_CONFIG_NOT_FOUND,6,"config not found or invalid","Will be returned if no valid configuration was found or its contents are structurally invalid"
 
 # internal
 EXIT_UPGRADE_FAILED,10,"upgrade failed","Will be returned when the database upgrade failed"

--- a/lib/ProgramOptions/ArgumentParser.h
+++ b/lib/ProgramOptions/ArgumentParser.h
@@ -24,11 +24,13 @@
 #pragma once
 
 #include "Basics/Common.h"
+#include "Basics/exitcodes.h"
 
 #include "ProgramOptions/ProgramOptions.h"
 
-namespace arangodb {
-namespace options {
+#include <string>
+
+namespace arangodb::options {
 
 class ArgumentParser {
  public:
@@ -150,8 +152,9 @@ class ArgumentParser {
 
     // we got some previous option, but no value was specified for it
     if (!lastOption.empty()) {
-      return _options->fail("no value specified for option '--" + lastOption +
-                            "'");
+      _options->fail(TRI_EXIT_INVALID_OPTION_VALUE,
+                     "no value specified for option '--" + lastOption + "'");
+      return false;
     }
 
     // all is well
@@ -162,5 +165,5 @@ class ArgumentParser {
  private:
   ProgramOptions* _options;
 };
-}  // namespace options
-}  // namespace arangodb
+
+}  // namespace arangodb::options


### PR DESCRIPTION
### Scope & Purpose

Docs PR: https://github.com/arangodb/docs/pull/1073

Added more specific process exit codes for arangod and all client tools, and changed the executables' exit code for the following situations:

- an unknown startup option name is used: previously the exit code was 1. Now the exit code when using an invalid option is 3 (symbolic exit code name EXIT_INVALID_OPTION_NAME).
- an invalid value is used for a startup option (e.g. a number that is outside the allowed range for the option's underlying value type, or a string value is used for a numeric option): previously the exit code was 1. Now the exit code for these case is 4 (symbolic exit code name EXIT_INVALID_OPTION_VALUE).
- a config file is specified that does not exist: previously the exit code was either 1 or 6 (symbolic exit code name EXIT_CONFIG_NOT_FOUND). Now the exit code in this case is always 6 (EXIT_CONFIG_NOT_FOUND).
- a structurally invalid config file is used, e.g. the config file contains a line that cannot be parsed: previously the exit code in this situation was 1. Now it is always 6 (symbolic exit code name EXIT_CONFIG_NOT_FOUND).

Note that this change can affect any custom scripts that check for startup failures using the specific exit code 1. These scripts should be adjusted so that they check for a non-zero exit code. They can opt in to more specific error handling using the additional exit codes mentioned above, in order to distinguish between different kinds of startup errors.

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [x] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -
  - [ ] Backport for 3.7: -

#### Related Information

- [x] Docs PR: https://github.com/arangodb/docs/pull/1073
- [ ] Enterprise PR:
- [x] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/GT-99
- [ ] Design document: 