### PR TITLE
BTS-824: make sure all are dead on abort

### DIFF
--- a/js/client/modules/@arangodb/testutils/instance-manager.js
+++ b/js/client/modules/@arangodb/testutils/instance-manager.js
@@ -712,6 +712,21 @@ class instanceManager {
       this.arangods.forEach(arangod => { arangod.serverCrashedLocal = true;});
       forceTerminate = true;
     }
+    try {
+      return this._shutdownInstance(forceTerminate);
+    }
+    catch (e) {
+      if (e instanceof ArangoError && e.errorNum === internal.errors.ERROR_DISABLED.code) {
+        let timeoutReached = internal.SetGlobalExecutionDeadlineTo(0.0);
+        if (timeoutReached) {
+          print(RED + Date() + ' Deadline reached during shutdown! Forcefully shutting down NOW!' + RESET);
+        }
+        return this._shutdownInstance(true);
+      }
+    }
+  }
+
+  _shutdownInstance (forceTerminate) {
     let shutdownSuccess = !forceTerminate;
 
     // we need to find the leading server

--- a/js/client/modules/@arangodb/testutils/process-utils.js
+++ b/js/client/modules/@arangodb/testutils/process-utils.js
@@ -459,6 +459,10 @@ function killRemainingProcesses(results) {
   results.status = results.status && (running.length === 0);
   let i = 0;
   for (i = 0; i < running.length; i++) {
+    let timeoutReached = internal.SetGlobalExecutionDeadlineTo(0.0);
+    if (timeoutReached) {
+      print(RED + Date() + ' external deadline reached!' + RESET);
+    }
     let status = internal.statusExternal(running[i].pid, false);
     if (status.status === "TERMINATED") {
       print("process exited without us joining it (marking crashy): " + JSON.stringify(running[i]) + JSON.stringify(status));


### PR DESCRIPTION
### Scope & Purpose

- killRemainingProcesses() needs to make sure the deadline is not engaged.
- instanceManager.shutdownInstance() should revert to force terminate, if anything goes wrong during shutdown.

Related:
- aftermath of https://github.com/arangodb/arangodb/pull/16566
- https://github.com/arangodb/arangodb/pull/15979

- [x] :hankey: Bugfix
