### PR TITLE
[PREGEL] Add Conductor state machine and use it for the Loading state

### DIFF
--- a/arangod/CMakeLists.txt
+++ b/arangod/CMakeLists.txt
@@ -295,6 +295,7 @@ set(LIB_ARANGO_PREGEL_SOURCES
   Pregel/Utils.cpp
   Pregel/Worker.cpp
   Pregel/WorkerConfig.cpp
+  Pregel/Conductor/LoadingState.cpp
   RestHandler/RestControlPregelHandler.cpp
   RestHandler/RestPregelHandler.cpp
 )

--- a/arangod/Pregel/Conductor.h
+++ b/arangod/Pregel/Conductor.h
@@ -35,6 +35,8 @@
 
 #include "Pregel/Status/ConductorStatus.h"
 #include "Pregel/Status/ExecutionStatus.h"
+#include "Pregel/Conductor/State.h"
+#include "Pregel/Conductor/LoadingState.h"
 #include "velocypack/Builder.h"
 
 #include <chrono>
@@ -66,6 +68,7 @@ struct Error {
 
 class Conductor : public std::enable_shared_from_this<Conductor> {
   friend class PregelFeature;
+  friend struct conductor::Loading;
 
   ExecutionState _state = ExecutionState::DEFAULT;
   PregelFeature& _feature;
@@ -167,6 +170,11 @@ class Conductor : public std::enable_shared_from_this<Conductor> {
  private:
   void cancelNoLock();
   void updateState(ExecutionState state);
+
+  std::unique_ptr<conductor::State> state;
+  auto changeState(conductor::StateType name) -> void;
+  auto run() -> void { state->run(); }
+  auto receive(Message const& message) -> void { state->receive(message); }
 };
 }  // namespace pregel
 }  // namespace arangodb

--- a/arangod/Pregel/Conductor/LoadingState.cpp
+++ b/arangod/Pregel/Conductor/LoadingState.cpp
@@ -1,0 +1,57 @@
+#include "LoadingState.h"
+
+#include "Pregel/Algorithm.h"
+#include "Pregel/Conductor.h"
+#include "Metrics/Gauge.h"
+#include "Pregel/Conductor/State.h"
+#include "Pregel/PregelFeature.h"
+#include "Pregel/WorkerConductorMessages.h"
+
+using namespace arangodb::pregel::conductor;
+
+Loading::Loading(Conductor& conductor) : conductor{conductor} {
+  conductor.updateState(ExecutionState::LOADING);
+  conductor._timing.loading.start();
+  conductor._feature.metrics()->pregelConductorsLoadingNumber->fetch_add(1);
+}
+
+Loading::~Loading() {
+  conductor._timing.loading.finish();
+  conductor._feature.metrics()->pregelConductorsLoadingNumber->fetch_sub(1);
+}
+
+auto Loading::run() -> void {
+  LOG_PREGEL_CONDUCTOR("3a255", DEBUG) << "Telling workers to load the data";
+  auto res =
+      conductor._initializeWorkers(Utils::startExecutionPath, VPackSlice());
+  if (res != TRI_ERROR_NO_ERROR) {
+    LOG_PREGEL_CONDUCTOR("30171", ERR)
+        << "Not all DBServers started the execution";
+    // TODO change state to Canceled
+    conductor.changeState(StateType::Placeholder);
+  }
+}
+
+auto Loading::receive(Message const& message) -> void {
+  if (message.type() != MessageType::GraphLoaded) {
+    LOG_PREGEL_CONDUCTOR("14df4", WARN)
+        << "When loading, we expect a GraphLoaded "
+           "message, but we received message type "
+        << message.type();
+    return;
+  }
+  auto loadedMessage = static_cast<GraphLoaded const&>(message);
+  conductor._ensureUniqueResponse(loadedMessage.senderId);
+  conductor._totalVerticesCount += loadedMessage.vertexCount;
+  conductor._totalEdgesCount += loadedMessage.edgeCount;
+  if (conductor._respondedServers.size() != conductor._dbServers.size()) {
+    return;
+  }
+  LOG_PREGEL_CONDUCTOR("76631", INFO)
+      << "Running Pregel " << conductor._algorithm->name() << " with "
+      << conductor._totalVerticesCount << " vertices, "
+      << conductor._totalEdgesCount << " edges";
+  conductor.updateState(ExecutionState::RUNNING);
+  // TODO change to ComputingState
+  conductor.changeState(StateType::Placeholder);
+}

--- a/arangod/Pregel/Conductor/LoadingState.h
+++ b/arangod/Pregel/Conductor/LoadingState.h
@@ -1,0 +1,42 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2022 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Julia Volmer
+////////////////////////////////////////////////////////////////////////////////
+#pragma once
+
+#include "Pregel/Conductor/State.h"
+
+namespace arangodb::pregel {
+
+class Conductor;
+
+namespace conductor {
+
+struct Loading : State {
+  Conductor& conductor;
+  Loading(Conductor& conductor);
+  ~Loading();
+  auto run() -> void override;
+  auto receive(Message const& message) -> void override;
+};
+
+}  // namespace conductor
+}  // namespace arangodb::pregel

--- a/arangod/Pregel/Conductor/State.h
+++ b/arangod/Pregel/Conductor/State.h
@@ -1,0 +1,51 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2022 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Julia Volmer
+////////////////////////////////////////////////////////////////////////////////
+#pragma once
+
+#include <string>
+
+namespace arangodb::pregel {
+
+struct Message;
+
+namespace conductor {
+
+#define LOG_PREGEL_CONDUCTOR(logId, level) \
+  LOG_TOPIC(logId, level, Logger::PREGEL)  \
+      << "[job " << conductor._executionNumber << "] "
+
+enum class StateType { Loading, Placeholder };
+
+struct State {
+  virtual auto run() -> void = 0;
+  virtual auto receive(Message const& message) -> void = 0;
+  virtual ~State(){};
+};
+
+struct Placeholder : State {
+  auto run() -> void override{};
+  auto receive(Message const& message) -> void override{};
+};
+
+}  // namespace conductor
+}  // namespace arangodb::pregel

--- a/arangod/Pregel/Worker.cpp
+++ b/arangod/Pregel/Worker.cpp
@@ -178,11 +178,9 @@ template<typename V, typename E, typename M>
 void Worker<V, E, M>::setupWorker() {
   std::function<void()> graphLoadedCallback = [self = shared_from_this(),
                                                this] {
-    auto graphLoadedEvent =
-        GraphLoaded{.senderId = ServerState::instance()->getId(),
-                    .executionNumber = _config.executionNumber(),
-                    .vertexCount = _graphStore->localVertexCount(),
-                    .edgeCount = _graphStore->localEdgeCount()};
+    auto graphLoadedEvent = GraphLoaded{
+        ServerState::instance()->getId(), _config.executionNumber(),
+        _graphStore->localVertexCount(), _graphStore->localEdgeCount()};
     VPackBuilder event;
     serialize(event, graphLoadedEvent);
     _callConductor(Utils::finishedStartupPath, event);


### PR DESCRIPTION
Adds a finite state machine to the conductor to improve readability: The behavior of the conductor will now be determined by the conductor state. Before, the conductor only had a enum type `_state`, which had to be checked many times. Now state changes will be defined inside a specific conductor state and can happen when the state runs or gets a message.
This is only the first PR concerning the state machine: It adds only the LoadingState and AnotherState which is just a placeholder for the following state - it will be removed later on. This PR will not break anything, the old enum type `_state` will be deleted once all conductor states are added.