### PR TITLE
[CINFRA-495] Unintentional Dirty Read

### DIFF
--- a/arangod/Replication2/StateMachines/Prototype/PrototypeStateMethods.cpp
+++ b/arangod/Replication2/StateMachines/Prototype/PrototypeStateMethods.cpp
@@ -96,6 +96,12 @@ struct PrototypeStateMethodsDBServer final : PrototypeStateMethods {
     if (leader != nullptr) {
       return leader->get(std::move(keys), readOptions.waitForApplied);
     }
+
+    if (!readOptions.allowDirtyRead) {
+      THROW_ARANGO_EXCEPTION(
+          TRI_ERROR_REPLICATION_REPLICATED_LOG_NOT_THE_LEADER);
+    }
+
     auto follower = stateMachine->getFollower();
     if (follower != nullptr) {
       return follower->get(std::move(keys), readOptions.waitForApplied);
@@ -283,6 +289,7 @@ struct PrototypeStateMethodsCoordinator final
     opts.database = _vocbase.name();
     opts.param("waitForApplied",
                std::to_string(readOptions.waitForApplied.value));
+    opts.param("allowDirtyRead", std::to_string(readOptions.allowDirtyRead));
 
     VPackBuilder builder{};
     {
@@ -607,14 +614,14 @@ auto PrototypeStateMethods::createInstance(TRI_vocbase_t& vocbase)
 [[nodiscard]] auto PrototypeStateMethods::get(LogId id, std::string key,
                                               LogIndex waitForApplied) const
     -> futures::Future<ResultT<std::optional<std::string>>> {
-  return get(id, std::move(key), {waitForApplied, std::nullopt});
+  return get(id, std::move(key), {waitForApplied, false, std::nullopt});
 }
 
 [[nodiscard]] auto PrototypeStateMethods::get(LogId id,
                                               std::vector<std::string> keys,
                                               LogIndex waitForApplied) const
     -> futures::Future<ResultT<std::unordered_map<std::string, std::string>>> {
-  return get(id, std::move(keys), {waitForApplied, std::nullopt});
+  return get(id, std::move(keys), {waitForApplied, false, std::nullopt});
 }
 
 [[nodiscard]] auto PrototypeStateMethods::get(

--- a/arangod/Replication2/StateMachines/Prototype/PrototypeStateMethods.h
+++ b/arangod/Replication2/StateMachines/Prototype/PrototypeStateMethods.h
@@ -95,6 +95,7 @@ struct PrototypeStateMethods {
 
   struct ReadOptions {
     LogIndex waitForApplied{0};
+    bool allowDirtyRead{false};
     std::optional<ParticipantId> readFrom{};
   };
 

--- a/arangod/RestHandler/RestPrototypeStateHandler.cpp
+++ b/arangod/RestHandler/RestPrototypeStateHandler.cpp
@@ -291,6 +291,8 @@ RestStatus RestPrototypeStateHandler::handlePostRetrieveMulti(
   readOptions.waitForApplied = LogIndex{
       _request->parsedValue<decltype(LogIndex::value)>("waitForApplied")
           .value_or(0)};
+  readOptions.allowDirtyRead =
+      _request->parsedValue<bool>("allowDirtyRead").value_or(false);
   readOptions.readFrom = _request->parsedValue<ParticipantId>("readFrom");
 
   return waitForFuture(
@@ -366,6 +368,8 @@ RestStatus RestPrototypeStateHandler::handleGetEntry(
   readOptions.waitForApplied = LogIndex{
       _request->parsedValue<decltype(LogIndex::value)>("waitForApplied")
           .value_or(0)};
+  readOptions.allowDirtyRead =
+      _request->parsedValue<bool>("allowDirtyRead").value_or(false);
   readOptions.readFrom = _request->parsedValue<ParticipantId>("readFrom");
 
   return waitForFuture(

--- a/arangod/V8Server/v8-prototype-states.cpp
+++ b/arangod/V8Server/v8-prototype-states.cpp
@@ -344,6 +344,9 @@ static void JS_ReadInternal(v8::FunctionCallbackInfo<v8::Value> const& args) {
     if (auto slice = options.get("waitForApplied"); !slice.isNone()) {
       readOptions.waitForApplied = slice.extract<LogIndex>();
     }
+    if (auto slice = options.get("allowDirtyRead"); !slice.isNone()) {
+      readOptions.allowDirtyRead = slice.extract<bool>();
+    }
     if (auto slice = options.get("readFrom"); !slice.isNone()) {
       readOptions.readFrom = slice.extract<ParticipantId>();
     }

--- a/js/client/modules/@arangodb/arango-prototype-state.js
+++ b/js/client/modules/@arangodb/arango-prototype-state.js
@@ -78,6 +78,9 @@ ArangoPrototypeState.prototype._readInternal = function (keys, options) {
   if (options.readFrom !== undefined) {
     query += `&readFrom=${encodeURIComponent(options.readFrom)}`;
   }
+  if (options.allowDirtyRead !== undefined) {
+    query += `&allowDirtyRead=${options.allowDirtyRead}`;
+  }
   let requestResult = this._database._connection.POST(this._baseurl() + query, keys);
   arangosh.checkRequestResult(requestResult);
   return requestResult.result;

--- a/tests/js/common/shell/shell-prototype-state-cluster.js
+++ b/tests/js/common/shell/shell-prototype-state-cluster.js
@@ -126,7 +126,8 @@ function PrototypeStateTestSuite() {
       const status = db._replicatedLog(state.id()).status();
       const follower = _.sample(_.without(Object.keys(status.participants), status.leaderId));
 
-      const {A: valueA, B: valueB, C: valueC} = state.read(["A", "B", "C"], {waitForApplied: idx, readFrom: follower});
+      const {A: valueA, B: valueB, C: valueC} = state.read(["A", "B", "C"],
+        {waitForApplied: idx, allowDirtyRead: true, readFrom: follower});
       assertEqual(valueA, "1");
       assertEqual(valueB, "2");
       assertEqual(valueC, "3");

--- a/tests/js/server/replication2/replication2-prototype-replicated-state-cluster.js
+++ b/tests/js/server/replication2/replication2-prototype-replicated-state-cluster.js
@@ -52,15 +52,15 @@ const compareExchange = function (url, stateId, payload) {
   });
 };
 
-const getEntry = function (url, stateId, entry, waitForApplied) {
-  if (waitForApplied === undefined) {
-    return request.get({url: `${url}/_db/${database}/_api/prototype-state/${stateId}/entry/${entry}`});
-  }
-  return request.get({url: `${url}/_db/${database}/_api/prototype-state/${stateId}/entry/${entry}?waitForApplied=${waitForApplied}`});
+const getEntry = function (url, stateId, entry, allowDirtyRead,  waitForApplied) {
+  let params = `?allowDirtyRead=${allowDirtyRead}`
+  params += (waitForApplied === undefined ? '' : `&waitForApplied=${waitForApplied}`);
+  return request.get({url:`${url}/_db/${database}/_api/prototype-state/${stateId}/entry/${entry}${params}`});
 };
 
-const getEntries = function (url, stateId, entries, waitForApplied) {
-  let params = (waitForApplied === undefined ? '' : `?waitForApplied=${waitForApplied}`);
+const getEntries = function (url, stateId, entries, allowDirtyRead, waitForApplied) {
+  let params = `?allowDirtyRead=${allowDirtyRead}`
+  params += (waitForApplied === undefined ? '' : `&waitForApplied=${waitForApplied}`);
   return request.post({
     url: `${url}/_db/${database}/_api/prototype-state/${stateId}/multi-get${params}`,
     body: entries,
@@ -165,28 +165,28 @@ const replicatedStateSuite = function () {
       let index = result.json.result.index;
       assertEqual(index, 2);
 
-      result = getEntry(leaderUrl, stateId, "foo0", index);
+      result = getEntry(leaderUrl, stateId, "foo0", false, index);
       lh.checkRequestResult(result);
       assertEqual(result.json.result.foo0,  "bar0");
 
-      result = getEntry(followerUrl, stateId, "foo0", index);
+      result = getEntry(followerUrl, stateId, "foo0", true, index);
       lh.checkRequestResult(result);
       assertEqual(result.json.result.foo0,  "bar0");
 
-      result = getEntries(leaderUrl, stateId, ["foo1", "foo2"], index);
+      result = getEntries(leaderUrl, stateId, ["foo1", "foo2"], false, index);
       lh.checkRequestResult(result);
       assertEqual(result.json.result, {foo1: "bar1", foo2: "bar2"});
 
-      result = getEntries(followerUrl, stateId, ["foo1", "foo2"], index);
+      result = getEntries(followerUrl, stateId, ["foo1", "foo2"], true, index);
       lh.checkRequestResult(result);
       assertEqual(result.json.result, {foo1: "bar1", foo2: "bar2"});
 
-      result = removeEntry(leaderUrl, stateId, "foo0");
+      result = removeEntry(leaderUrl, stateId, "foo0", false);
       lh.checkRequestResult(result);
       index = result.json.result.index;
       assertEqual(index, 3);
 
-      result = getEntry(leaderUrl, stateId, "foo0", index);
+      result = getEntry(leaderUrl, stateId, "foo0", false, index);
       assertEqual(result.json.code, 404);
 
       result = removeEntries(leaderUrl, stateId, ["foo1", "foo2"]);
@@ -194,7 +194,7 @@ const replicatedStateSuite = function () {
       index = result.json.result.index;
       assertEqual(index, 4);
 
-      result = getEntry(leaderUrl, stateId, "foo2", index);
+      result = getEntry(leaderUrl, stateId, "foo2", false, index);
       assertEqual(result.json.code, 404);
 
       result = insertEntries(coordUrl, stateId, {foo100: "bar100", foo200: "bar200", foo300: "bar300", foo400: "bar400"});
@@ -202,11 +202,11 @@ const replicatedStateSuite = function () {
       index = result.json.result.index;
       assertEqual(index, 5);
 
-      result = getEntry(coordUrl, stateId, "foo100", index);
+      result = getEntry(coordUrl, stateId, "foo100", false, index);
       lh.checkRequestResult(result);
       assertEqual(result.json.result.foo100,  "bar100");
 
-      result = getEntries(coordUrl, stateId, ["foo200", "foo300"], index);
+      result = getEntries(coordUrl, stateId, ["foo200", "foo300"], false, index);
       lh.checkRequestResult(result);
       assertEqual(result.json.result.foo200,  "bar200");
       assertEqual(result.json.result.foo300,  "bar300");
@@ -221,7 +221,7 @@ const replicatedStateSuite = function () {
       index = result.json.result.index;
       assertEqual(index, 7);
 
-      result = getEntry(leaderUrl, stateId, "foo400", index);
+      result = getEntry(leaderUrl, stateId, "foo400", false, index);
       lh.checkRequestResult(result);
       assertEqual(result.json.result.foo400,  "bar400");
 
@@ -242,13 +242,13 @@ const replicatedStateSuite = function () {
       lh.checkRequestResult(result);
       index = result.json.result.index;
       assertEqual(index, 9);
-      result = getEntry(coordUrl, stateId, "foo400", index);
+      result = getEntry(coordUrl, stateId, "foo400", false, index);
       lh.checkRequestResult(result);
       assertEqual(result.json.result.foo400,  "foobar");
 
       result = compareExchange(leaderUrl, stateId, {"foo400": {"oldValue": "bar400", "newValue": "foobar"}});
       assertEqual(result.json.code, 409);
-      result = getEntry(coordUrl, stateId, "foo400", index);
+      result = getEntry(coordUrl, stateId, "foo400", false, index);
       lh.checkRequestResult(result);
       assertEqual(result.json.result.foo400,  "foobar");
 

--- a/tests/js/server/replication2/replication2-prototype-replicated-state-cluster.js
+++ b/tests/js/server/replication2/replication2-prototype-replicated-state-cluster.js
@@ -53,13 +53,13 @@ const compareExchange = function (url, stateId, payload) {
 };
 
 const getEntry = function (url, stateId, entry, allowDirtyRead,  waitForApplied) {
-  let params = `?allowDirtyRead=${allowDirtyRead}`
+  let params = `?allowDirtyRead=${allowDirtyRead}`;
   params += (waitForApplied === undefined ? '' : `&waitForApplied=${waitForApplied}`);
   return request.get({url:`${url}/_db/${database}/_api/prototype-state/${stateId}/entry/${entry}${params}`});
 };
 
 const getEntries = function (url, stateId, entries, allowDirtyRead, waitForApplied) {
-  let params = `?allowDirtyRead=${allowDirtyRead}`
+  let params = `?allowDirtyRead=${allowDirtyRead}`;
   params += (waitForApplied === undefined ? '' : `&waitForApplied=${waitForApplied}`);
   return request.post({
     url: `${url}/_db/${database}/_api/prototype-state/${stateId}/multi-get${params}`,


### PR DESCRIPTION
### Scope & Purpose

In `PrototypeStateMethods`, if the leader state is not available, we read from the follower, without checking if the user intended that. While a request is in flight, a leader can become a follower, thus we might return obsolete data.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*
  - [ ] Backport for 3.7: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

