### PR TITLE
rename "override" attribute for computed values to "overwrite"

### DIFF
--- a/arangod/VocBase/ComputedValues.cpp
+++ b/arangod/VocBase/ComputedValues.cpp
@@ -170,13 +170,13 @@ ComputedValues::ComputedValue::ComputedValue(TRI_vocbase_t& vocbase,
                                              std::string_view name,
                                              std::string_view expressionString,
                                              ComputeValuesOn mustComputeOn,
-                                             bool doOverride,
-                                             bool failOnWarning, bool keepNull)
+                                             bool overwrite, bool failOnWarning,
+                                             bool keepNull)
     : _vocbase(vocbase),
       _name(name),
       _expressionString(expressionString),
       _mustComputeOn(mustComputeOn),
-      _override(doOverride),
+      _overwrite(overwrite),
       _failOnWarning(failOnWarning),
       _keepNull(keepNull),
       _queryContext(aql::StandaloneCalculation::buildQueryContext(_vocbase)),
@@ -266,7 +266,7 @@ void ComputedValues::ComputedValue::toVelocyPack(
     result.add(VPackValue("replace"));
   }
   result.close();  // computeOn
-  result.add("override", VPackValue(_override));
+  result.add("overwrite", VPackValue(_overwrite));
   result.add("failOnWarning", VPackValue(_failOnWarning));
   result.add("keepNull", VPackValue(_keepNull));
   result.close();
@@ -276,8 +276,8 @@ std::string_view ComputedValues::ComputedValue::name() const noexcept {
   return _name;
 }
 
-bool ComputedValues::ComputedValue::doOverride() const noexcept {
-  return _override;
+bool ComputedValues::ComputedValue::overwrite() const noexcept {
+  return _overwrite;
 }
 
 bool ComputedValues::ComputedValue::failOnWarning() const noexcept {
@@ -379,7 +379,7 @@ void ComputedValues::mergeComputedAttributes(
       } else {
         auto itCompute = attributes.find(key.stringView());
         if (itCompute == attributes.end() ||
-            !_values[itCompute->second].doOverride()) {
+            !_values[itCompute->second].overwrite()) {
           // only add these attributes from the original document
           // that we are not going to overwrite
           output.addUnchecked(key, it.value());
@@ -394,7 +394,7 @@ void ComputedValues::mergeComputedAttributes(
 
   for (auto const& it : attributes) {
     auto const& cv = _values[it.second];
-    if (cv.doOverride() || !keysWritten.contains(cv.name())) {
+    if (cv.overwrite() || !keysWritten.contains(cv.name())) {
       // update "failOnWarning" flag for each computation
       cvec.failOnWarning(cv.failOnWarning());
       // update "name" vlaue for each computation (for errors/warnings)
@@ -453,10 +453,10 @@ Result ComputedValues::buildDefinitions(TRI_vocbase_t& vocbase,
       }
     }
 
-    VPackSlice doOverride = it.get("override");
-    if (!doOverride.isBoolean()) {
+    VPackSlice overwrite = it.get("overwrite");
+    if (!overwrite.isBoolean()) {
       return {TRI_ERROR_BAD_PARAMETER,
-              "invalid 'computedValues' entry: 'override' must be a boolean"};
+              "invalid 'computedValues' entry: 'overwrite' must be a boolean"};
     }
 
     ComputeValuesOn mustComputeOn = ComputeValuesOn::kNever;
@@ -547,8 +547,8 @@ Result ComputedValues::buildDefinitions(TRI_vocbase_t& vocbase,
 
     try {
       _values.emplace_back(vocbase, name.stringView(), expression.stringView(),
-                           mustComputeOn, doOverride.getBoolean(),
-                           failOnWarning, keepNull);
+                           mustComputeOn, overwrite.getBoolean(), failOnWarning,
+                           keepNull);
     } catch (std::exception const& ex) {
       return {TRI_ERROR_BAD_PARAMETER,
               absl::StrCat("invalid 'computedValues' entry: ", ex.what())};

--- a/arangod/VocBase/ComputedValues.h
+++ b/arangod/VocBase/ComputedValues.h
@@ -129,7 +129,7 @@ class ComputedValues {
    public:
     ComputedValue(TRI_vocbase_t& vocbase, std::string_view name,
                   std::string_view expressionString,
-                  ComputeValuesOn mustComputeOn, bool doOverride,
+                  ComputeValuesOn mustComputeOn, bool overwrite,
                   bool failOnWarning, bool keepNull);
     ComputedValue(ComputedValue const&) = delete;
     ComputedValue& operator=(ComputedValue const&) = delete;
@@ -141,7 +141,7 @@ class ComputedValues {
     void computeAttribute(aql::ExpressionContext& ctx, velocypack::Slice input,
                           velocypack::Builder& output) const;
     std::string_view name() const noexcept;
-    bool doOverride() const noexcept;
+    bool overwrite() const noexcept;
     bool failOnWarning() const noexcept;
     bool keepNull() const noexcept;
     aql::Variable const* tempVariable() const noexcept;
@@ -151,7 +151,7 @@ class ComputedValues {
     std::string _name;
     std::string _expressionString;
     ComputeValuesOn _mustComputeOn;
-    bool _override;
+    bool _overwrite;
     bool _failOnWarning;
     bool _keepNull;
     std::unique_ptr<aql::QueryContext> _queryContext;

--- a/tests/js/client/shell/shell-computed-values-cluster.js
+++ b/tests/js/client/shell/shell-computed-values-cluster.js
@@ -26,7 +26,7 @@ function collectionComputedValuesClusterSuite() {
         numberOfShards: 1, replicationFactor: 2, computedValues: [{
           name: "randValue",
           expression: "RETURN TO_STRING(RAND())",
-          override: false
+          overwrite: false
         }]
       });
       let docs = [];

--- a/tests/js/client/shell/shell-dump-integration.js
+++ b/tests/js/client/shell/shell-dump-integration.js
@@ -284,11 +284,11 @@ function dumpIntegrationSuite() {
           computedValues: [{
             name: "value3",
             expression: "RETURN CONCAT(@doc.value1, '+', @doc.value2)",
-            override: false
+            overwrite: false
           }, {
             name: "value4",
             expression: "RETURN CONCAT(@doc.value2, ' ', @doc.value1)",
-            override: true
+            overwrite: true
           }]
         });
         docs = [];

--- a/tests/js/client/shell/shell-restore-integration.js
+++ b/tests/js/client/shell/shell-restore-integration.js
@@ -322,13 +322,13 @@ function restoreIntegrationSuite() {
               name: "value3",
               expression: "RETURN CONCAT(@doc.value1, '+', @doc.value2)",
               computeOn: ["insert"],
-              override: false,
+              overwrite: false,
               failOnWarning: false
             }, {
               name: "value4",
               expression: "RETURN CONCAT(@doc.value2, ' ', @doc.value1)",
               computeOn: ["insert"],
-              override: true,
+              overwrite: true,
               failOnWarning: false
             }]
           }

--- a/tests/js/common/shell/shell-collection-computed-values.js
+++ b/tests/js/common/shell/shell-collection-computed-values.js
@@ -32,7 +32,7 @@ function ComputedValuesAfterCreateCollectionTestSuite() {
             {
               name: "newValue",
               expression: "CONCAT(@doc.value1, '+')",
-              override: false
+              overwrite: false
             }
           ]
         });
@@ -48,7 +48,7 @@ function ComputedValuesAfterCreateCollectionTestSuite() {
           {
             name: "newValue",
             expression: "RETURN @doc.foxx",
-            override: true,
+            overwrite: true,
             keepNull: true,
           }
         ]
@@ -79,7 +79,7 @@ function ComputedValuesAfterCreateCollectionTestSuite() {
           {
             name: "newValue",
             expression: "RETURN @doc.foxx",
-            override: true,
+            overwrite: true,
             keepNull: false,
           }
         ]
@@ -111,7 +111,7 @@ function ComputedValuesAfterCreateCollectionTestSuite() {
           {
             name: "value",
             expression: "RETURN ASSERT(false, 'piff!')",
-            override: false,
+            overwrite: false,
           }
         ]
       });
@@ -146,7 +146,7 @@ function ComputedValuesAfterCreateCollectionTestSuite() {
           {
             name: "newValue",
             expression: "RETURN 42 / @doc.value",
-            override: false,
+            overwrite: false,
             failOnWarning: false,
           }
         ]
@@ -176,7 +176,7 @@ function ComputedValuesAfterCreateCollectionTestSuite() {
           {
             name: "newValue",
             expression: "RETURN 42 / @doc.value",
-            override: false,
+            overwrite: false,
             failOnWarning: true,
           }
         ]
@@ -212,7 +212,7 @@ function ComputedValuesAfterCreateCollectionTestSuite() {
           {
             name: "value",
             expression: "RETURN 'foo'",
-            override: false,
+            overwrite: false,
             // computeOn not set
           }
         ]
@@ -239,7 +239,7 @@ function ComputedValuesAfterCreateCollectionTestSuite() {
             {
               name: "value",
               expression: "RETURN 'foo'",
-              override: false,
+              overwrite: false,
               computeOn: "insert",
             }
           ]
@@ -256,7 +256,7 @@ function ComputedValuesAfterCreateCollectionTestSuite() {
           {
             name: "value",
             expression: "RETURN 'foo'",
-            override: false,
+            overwrite: false,
             computeOn: ["insert", "replace"],
           }
         ]
@@ -282,7 +282,7 @@ function ComputedValuesAfterCreateCollectionTestSuite() {
           {
             name: "concatValues",
             expression: "RETURN CONCAT(@doc.value1, '+', @doc.value2)",
-            override: false
+            overwrite: false
           }
         ]
       });
@@ -330,7 +330,7 @@ function ComputedValuesAfterCreateCollectionTestSuite() {
           {
             name: "concatValues",
             expression: "RETURN CONCAT(@doc.value1, '+', @doc.value2)",
-            override: true,
+            overwrite: true,
             computeOn: ["insert"]
           }
         ]
@@ -378,7 +378,7 @@ function ComputedValuesAfterCreateCollectionTestSuite() {
           {
             name: "concatValues",
             expression: "RETURN CONCAT(@doc.value1, '+', @doc.value2)",
-            override: true,
+            overwrite: true,
             computeOn: ["update"]
           }
         ]
@@ -426,7 +426,7 @@ function ComputedValuesAfterCreateCollectionTestSuite() {
           {
             name: "concatValues",
             expression: "RETURN CONCAT(@doc.value1, '+', @doc.value2)",
-            override: true,
+            overwrite: true,
             computeOn: ["replace"]
           }
         ]
@@ -472,7 +472,7 @@ function ComputedValuesAfterCreateCollectionTestSuite() {
           {
             name: "value3",
             expression: "RETURN CONCAT(LEFT(@doc.value1, 3), RIGHT(@doc.value2.animal, 2))",
-            override: false
+            overwrite: false
           }
         ]
       });
@@ -514,7 +514,7 @@ function ComputedValuesAfterCreateCollectionTestSuite() {
           {
             name: "concatValues",
             expression: "RETURN CONCAT(@doc.value1, '+', @doc.value2)",
-            override: false
+            overwrite: false
           }
         ]
       });
@@ -558,7 +558,7 @@ function ComputedValuesAfterCreateCollectionTestSuite() {
             {
               name: "_rev",
               expression: "RETURN CONCAT(@doc.value1, '+')",
-              override: false
+              overwrite: false
             }
           ]
         });
@@ -575,7 +575,7 @@ function ComputedValuesAfterCreateCollectionTestSuite() {
             {
               name: "_key",
               expression: "RETURN CONCAT(@doc.value1, '+')",
-              override: false
+              overwrite: false
             }
           ]
         });
@@ -592,7 +592,7 @@ function ComputedValuesAfterCreateCollectionTestSuite() {
             {
               name: "_id",
               expression: "RETURN CONCAT(@doc.value1, '+')",
-              override: false
+              overwrite: false
             }
           ]
         });
@@ -609,7 +609,7 @@ function ComputedValuesAfterCreateCollectionTestSuite() {
             {
               name: "newValue",
               expression: "RETURN (RETURN CONCAT(@doc.value1, '+'))",
-              override: false
+              overwrite: false
             }
           ]
         });
@@ -626,7 +626,7 @@ function ComputedValuesAfterCreateCollectionTestSuite() {
             {
               name: "newValue",
               expression: "RETURN (FOR i IN 1..10 RETURN i)",
-              override: false
+              overwrite: false
             }
           ]
         });
@@ -643,7 +643,7 @@ function ComputedValuesAfterCreateCollectionTestSuite() {
             {
               name: "newValue",
               expression: "RETURN (LET temp1 = (RETURN 1))",
-              override: false
+              overwrite: false
             }
           ]
         });
@@ -653,7 +653,7 @@ function ComputedValuesAfterCreateCollectionTestSuite() {
       }
     },
 
-    testSchemaValidationWithComputedValuesOverride: function() {
+    testSchemaValidationWithComputedValuesoverwrite: function() {
       collection.properties({
         schema: {
           "rule": {
@@ -671,7 +671,7 @@ function ComputedValuesAfterCreateCollectionTestSuite() {
           {
             name: "value1",
             expression: "RETURN CONCAT(@doc.value1, '+', @doc.value2)",
-            override: true
+            overwrite: true
           }
         ]
       });
@@ -704,7 +704,7 @@ function ComputedValuesAfterCreateCollectionTestSuite() {
       assertEqual(res.length, 0);
     },
 
-    testSchemaValidationWithComputedValuesNoOverride: function() {
+    testSchemaValidationWithComputedValuesNooverwrite: function() {
       collection.properties({
         schema: {
           "rule": {
@@ -725,7 +725,7 @@ function ComputedValuesAfterCreateCollectionTestSuite() {
           {
             name: "value1",
             expression: "RETURN CONCAT(@doc.value1, '+', @doc.value2)",
-            override: false
+            overwrite: false
           }
         ]
       });
@@ -759,17 +759,17 @@ function ComputedValuesAfterCreateCollectionTestSuite() {
     },
 
 
-    testRedefineComputedValueUpdateOverride: function() {
+    testRedefineComputedValueUpdateoverwrite: function() {
       collection.properties({
         computedValues: [
           {
             name: "concatValues",
             expression: "RETURN CONCAT(@doc.value1, '+', @doc.value2)",
-            override: false
+            overwrite: false
           }, {
             name: "value3",
             expression: "return CONCAT(@doc.concatValues, ' ')",
-            override: false
+            overwrite: false
           }
         ]
       });
@@ -807,12 +807,12 @@ function ComputedValuesAfterCreateCollectionTestSuite() {
             name: "concatValues",
             expression: "RETURN CONCAT(@doc.value1, '+', @doc.value2)",
             computeOn: ["update"],
-            override: true
+            overwrite: true
           }, {
             name: "value3",
             expression: "return CONCAT(@doc.concatValues, '+', @doc.value1)",
             computeOn: ["update"],
-            override: true
+            overwrite: true
           }
         ]
       });
@@ -834,17 +834,17 @@ function ComputedValuesAfterCreateCollectionTestSuite() {
       });
     },
 
-    testRedefineComputedValueUpdateNoOverride: function() {
+    testRedefineComputedValueUpdateNooverwrite: function() {
       collection.properties({
         computedValues: [
           {
             name: "concatValues",
             expression: "RETURN CONCAT(@doc.value1, '+', @doc.value2)",
-            override: false
+            overwrite: false
           }, {
             name: "value3",
             expression: "return CONCAT(@doc.concatValues, ' ')",
-            override: false
+            overwrite: false
           }
         ]
       });
@@ -882,12 +882,12 @@ function ComputedValuesAfterCreateCollectionTestSuite() {
             name: "concatValues",
             expression: "RETURN CONCAT(@doc.value1, '+', @doc.value2)",
             computeOn: ["update"],
-            override: false
+            overwrite: false
           }, {
             name: "value3",
             expression: "return CONCAT(@doc.concatValues, '+', @doc.value1)",
             computeOn: ["update"],
-            override: false
+            overwrite: false
           }
         ]
       });
@@ -915,11 +915,11 @@ function ComputedValuesAfterCreateCollectionTestSuite() {
           {
             name: "concatValues",
             expression: "RETURN CONCAT(@doc.value1, '+', @doc.value2)",
-            override: false
+            overwrite: false
           }, {
             name: "value3",
             expression: "return CONCAT(@doc.concatValues, ' ')",
-            override: false
+            overwrite: false
           }
         ]
       });
@@ -975,7 +975,7 @@ function ComputedValuesAfterCreateCollectionTestSuite() {
               {
                 name: "newValue",
                 expression: `RETURN ${el}`,
-                override: false,
+                overwrite: false,
                 computeOn: ["insert"]
               }
             ]
@@ -997,7 +997,7 @@ function ComputedValuesAfterCreateCollectionTestSuite() {
             {
               name: "newValue",
               expression: `RETURN UnitTests::cv(1)`,
-              override: false,
+              overwrite: false,
               computeOn: ["insert"]
             }
           ]
@@ -1016,7 +1016,7 @@ function ComputedValuesAfterCreateCollectionTestSuite() {
           {
             name: "newValue",
             expression: `RETURN @doc.values[* RETURN CURRENT]`,
-            override: false,
+            overwrite: false,
             computeOn: ["insert"]
           }
         ]
@@ -1054,7 +1054,7 @@ function ComputedValuesAfterCreateCollectionTestSuite() {
           {
             name: "newValue",
             expression: `RETURN @doc.values[* FILTER CURRENT % 2 == 0 LIMIT 0,1 RETURN CURRENT]`,
-            override: false,
+            overwrite: false,
             computeOn: ["insert"]
           }
         ]
@@ -1092,7 +1092,7 @@ function ComputedValuesAfterCreateCollectionTestSuite() {
           {
             name: "newValue",
             expression: `RETURN @doc.values[* LIMIT 1,3 RETURN CURRENT]`,
-            override: false,
+            overwrite: false,
             computeOn: ["insert"]
           }
         ]
@@ -1137,7 +1137,7 @@ function ComputedValuesAfterCreateCollectionTestSuite() {
           {
             name: "newValue",
             expression: `RETURN TO_STRING(RAND())`,
-            override: false,
+            overwrite: false,
             computeOn: ["insert"]
           }
         ]
@@ -1176,7 +1176,7 @@ function ComputedValuesAfterCreateCollectionTestSuite() {
           {
             name: "newValue",
             expression: `RETURN TO_STRING(DATE_NOW())`,
-            override: false,
+            overwrite: false,
             computeOn: ["insert"]
           }
         ]
@@ -1203,7 +1203,7 @@ function ComputedValuesAfterCreateCollectionTestSuite() {
   };
 }
 
-function ComputedValuesOnCollectionCreationOverrideTestSuite() {
+function ComputedValuesOnCollectionCreationoverwriteTestSuite() {
   'use strict';
 
   let collection = null;
@@ -1216,7 +1216,7 @@ function ComputedValuesOnCollectionCreationOverrideTestSuite() {
             name: "concatValues",
             expression: "RETURN CONCAT(@doc.value1, '+', @doc.value2)",
             computeOn: ["insert", "update", "replace"],
-            override: true
+            overwrite: true
           }
         ]
       });
@@ -1257,7 +1257,7 @@ function ComputedValuesOnCollectionCreationOverrideTestSuite() {
       });
     },
 
-    testOverrideOnAllOperations: function() {
+    testoverwriteOnAllOperations: function() {
       const colProperties = collection.properties();
       assertTrue(colProperties.hasOwnProperty("computedValues"));
       assertEqual(colProperties.computedValues.length, 1);
@@ -1288,7 +1288,7 @@ function ComputedValuesOnCollectionCreationOverrideTestSuite() {
   };
 }
 
-function ComputedValuesOnCollectionCreationNoOverrideTestSuite() {
+function ComputedValuesOnCollectionCreationNooverwriteTestSuite() {
   'use strict';
 
   let collection = null;
@@ -1301,7 +1301,7 @@ function ComputedValuesOnCollectionCreationNoOverrideTestSuite() {
             name: "concatValues",
             expression: "RETURN CONCAT(@doc.value1, '+', @doc.value2)",
             computeOn: ["insert", "update", "replace"],
-            override: false
+            overwrite: false
           }
         ]
       });
@@ -1342,7 +1342,7 @@ function ComputedValuesOnCollectionCreationNoOverrideTestSuite() {
       });
     },
 
-    testNoOverrideOnAllOperations: function() {
+    testNooverwriteOnAllOperations: function() {
       const colProperties = collection.properties();
       assertTrue(colProperties.hasOwnProperty("computedValues"));
       assertEqual(colProperties.computedValues.length, 1);
@@ -1395,7 +1395,7 @@ function ComputedValuesClusterShardsTestSuite() {
             {
               name: "value1",
               expression: "RETURN CONCAT(@doc.value1, '+', @doc.value2)",
-              override: false
+              overwrite: false
             }
           ]
         });
@@ -1407,8 +1407,8 @@ function ComputedValuesClusterShardsTestSuite() {
   };
 }
 
-jsunity.run(ComputedValuesOnCollectionCreationOverrideTestSuite);
-jsunity.run(ComputedValuesOnCollectionCreationNoOverrideTestSuite);
+jsunity.run(ComputedValuesOnCollectionCreationoverwriteTestSuite);
+jsunity.run(ComputedValuesOnCollectionCreationNooverwriteTestSuite);
 jsunity.run(ComputedValuesAfterCreateCollectionTestSuite);
 if (isCluster) {
   jsunity.run(ComputedValuesClusterShardsTestSuite);

--- a/tests/js/server/dump/dump-setup-common.inc
+++ b/tests/js/server/dump/dump-setup-common.inc
@@ -186,12 +186,12 @@ function createComputedValues() {
     computedValues: [{
       name: "value3",
       expression: "RETURN CONCAT(@doc.value1, '+', @doc.value2)",
-      override: false
+      overwrite: false
     },
     {
       name: "value4",
       expression: "RETURN CONCAT(@doc.value2, ' ', @doc.value1)",
-      override: true
+      overwrite: true
     }]
    });
    let docs = [];

--- a/tests/js/server/dump/dump-test.inc
+++ b/tests/js/server/dump/dump-test.inc
@@ -462,8 +462,8 @@
         assertEqual(p.computedValues.length, 2);
         assertEqual(p.computedValues[0].name, "value3");
         assertEqual(p.computedValues[1].name, "value4");
-        assertFalse(p.computedValues[0].override);
-        assertTrue(p.computedValues[1].override);
+        assertFalse(p.computedValues[0].overwrite);
+        assertTrue(p.computedValues[1].overwrite);
         assertEqual(p.computedValues[0].expression, "RETURN CONCAT(@doc.value1, '+', @doc.value2)");
         assertEqual(p.computedValues[1].expression, "RETURN CONCAT(@doc.value2, ' ', @doc.value1)");
 


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/16600

Rename "override" attribute for computed values to "overwrite", as decided by @ansoboleva and @joerg84.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -
  - [ ] Backport for 3.7: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 