### PR TITLE
[CINFRA-443] Fix remaining concurrency issues

### DIFF
--- a/arangod/Replication2/LoggerContext.h
+++ b/arangod/Replication2/LoggerContext.h
@@ -62,6 +62,8 @@ struct LogNameValuePair : LoggableValue {
 
 struct LoggerContext {
   explicit LoggerContext(LogTopic const& topic) : topic(topic) {}
+  LoggerContext(LoggerContext const&) = default;
+  LoggerContext(LoggerContext&&) noexcept = default;
 
   template<const char N[], typename T>
   auto with(T&& t) const -> LoggerContext {

--- a/arangod/Replication2/ReplicatedState/FollowerStateManager.tpp
+++ b/arangod/Replication2/ReplicatedState/FollowerStateManager.tpp
@@ -630,7 +630,8 @@ FollowerStateManager<S>::GuardedData::GuardedData(
 template<typename S>
 void FollowerStateManager<S>::waitForLogFollowerResign() {
   logFollower->waitForResign().thenFinal(
-      [weak = this->weak_from_this()](futures::Try<futures::Unit> const&) noexcept {
+      [weak = this->weak_from_this()](
+          futures::Try<futures::Unit> const&) noexcept {
         if (auto self = weak.lock(); self != nullptr) {
           if (auto parentPtr = self->parent.lock(); parentPtr != nullptr) {
             LOG_CTX("654fb", TRACE, self->loggerContext)

--- a/arangod/Replication2/ReplicatedState/FollowerStateManager.tpp
+++ b/arangod/Replication2/ReplicatedState/FollowerStateManager.tpp
@@ -635,8 +635,8 @@ void FollowerStateManager<S>::waitForLogFollowerResign() {
           if (auto parentPtr = self->parent.lock(); parentPtr != nullptr) {
             LOG_CTX("654fb", TRACE, self->loggerContext)
                 << "forcing rebuild because participant resigned";
-            static_assert(noexcept(parentPtr->forceRebuild(self.get())));
-            parentPtr->forceRebuild(self.get());
+            static_assert(noexcept(parentPtr->rebuildMe(self.get())));
+            parentPtr->rebuildMe(self.get());
           }
         }
       });

--- a/arangod/Replication2/ReplicatedState/LeaderStateManager.tpp
+++ b/arangod/Replication2/ReplicatedState/LeaderStateManager.tpp
@@ -220,7 +220,7 @@ auto LeaderStateManager<S>::startService() -> Result {
         data.token->snapshot.updateStatus(SnapshotStatus::kCompleted);
         data.recoveryRange = std::nullopt;
         TRI_ASSERT(data.state != nullptr);
-        data.state->_stream = data.stream;
+        data.state->setStream(data.stream);
         return data.state;
       });
 

--- a/arangod/Replication2/ReplicatedState/LeaderStateManager.tpp
+++ b/arangod/Replication2/ReplicatedState/LeaderStateManager.tpp
@@ -303,13 +303,15 @@ auto LeaderStateManager<S>::resign() && noexcept
 
 template<typename S>
 void LeaderStateManager<S>::beginWaitingForLogLeaderResigned() {
-  logLeader->waitForResign().thenFinal([weak = this->weak_from_this()](auto&&) {
-    if (auto self = weak.lock(); self != nullptr) {
-      if (auto parentPtr = self->parent.lock(); parentPtr != nullptr) {
-        parentPtr->forceRebuild();
-      }
-    }
-  });
+  logLeader->waitForResign().thenFinal(
+      [weak = this->weak_from_this()](auto&&) noexcept {
+        if (auto self = weak.lock(); self != nullptr) {
+          if (auto parentPtr = self->parent.lock(); parentPtr != nullptr) {
+            static_assert(noexcept(parentPtr->forceRebuild(self.get())));
+            parentPtr->forceRebuild(self.get());
+          }
+        }
+      });
 }
 
 template<typename S>

--- a/arangod/Replication2/ReplicatedState/LeaderStateManager.tpp
+++ b/arangod/Replication2/ReplicatedState/LeaderStateManager.tpp
@@ -307,8 +307,8 @@ void LeaderStateManager<S>::beginWaitingForLogLeaderResigned() {
       [weak = this->weak_from_this()](auto&&) noexcept {
         if (auto self = weak.lock(); self != nullptr) {
           if (auto parentPtr = self->parent.lock(); parentPtr != nullptr) {
-            static_assert(noexcept(parentPtr->forceRebuild(self.get())));
-            parentPtr->forceRebuild(self.get());
+            static_assert(noexcept(parentPtr->rebuildMe(self.get())));
+            parentPtr->rebuildMe(self.get());
           }
         }
       });

--- a/arangod/Replication2/ReplicatedState/ReplicatedState.h
+++ b/arangod/Replication2/ReplicatedState/ReplicatedState.h
@@ -58,6 +58,8 @@ struct ReplicatedStateMetrics;
 struct IReplicatedLeaderStateBase;
 struct IReplicatedFollowerStateBase;
 
+struct IStateManagerBase {};
+
 /**
  * Common base class for all ReplicatedStates, hiding the type information.
  */
@@ -68,7 +70,7 @@ struct ReplicatedStateBase {
   virtual void start(
       std::unique_ptr<ReplicatedStateToken> token,
       std::optional<velocypack::SharedSlice> const& coreParameter) = 0;
-  virtual void forceRebuild() = 0;
+  virtual void forceRebuild(IStateManagerBase const* caller) noexcept = 0;
   [[nodiscard]] virtual auto getStatus() -> std::optional<StateStatus> = 0;
   [[nodiscard]] auto getLeader()
       -> std::shared_ptr<IReplicatedLeaderStateBase> {
@@ -126,9 +128,9 @@ struct ReplicatedState final
   /**
    * Rebuilds the managers. Called when the managers participant is gone.
    */
-  void forceRebuild() override;
+  void forceRebuild(IStateManagerBase const* caller) noexcept override;
 
-  struct IStateManager {
+  struct IStateManager : IStateManagerBase {
     virtual ~IStateManager() = default;
     virtual void run() = 0;
 
@@ -155,24 +157,26 @@ struct ReplicatedState final
   std::shared_ptr<replicated_log::ReplicatedLog> const log{};
 
   struct GuardedData {
-    auto forceRebuild() -> DeferredAction;
+    auto forceRebuild(IStateManagerBase const* caller) noexcept
+        -> DeferredAction;
 
     auto runLeader(std::shared_ptr<replicated_log::ILogLeader> logLeader,
                    std::unique_ptr<CoreType>,
-                   std::unique_ptr<ReplicatedStateToken> token)
+                   std::unique_ptr<ReplicatedStateToken> token) noexcept
         -> DeferredAction;
     auto runFollower(std::shared_ptr<replicated_log::ILogFollower> logFollower,
                      std::unique_ptr<CoreType>,
-                     std::unique_ptr<ReplicatedStateToken> token)
+                     std::unique_ptr<ReplicatedStateToken> token) noexcept
         -> DeferredAction;
     auto runUnconfigured(
         std::shared_ptr<replicated_log::LogUnconfiguredParticipant>
             unconfiguredParticipant,
         std::unique_ptr<CoreType> core,
-        std::unique_ptr<ReplicatedStateToken> token) -> DeferredAction;
+        std::unique_ptr<ReplicatedStateToken> token) noexcept -> DeferredAction;
 
     auto rebuild(std::unique_ptr<CoreType> core,
-                 std::unique_ptr<ReplicatedStateToken> token) -> DeferredAction;
+                 std::unique_ptr<ReplicatedStateToken> token) noexcept
+        -> DeferredAction;
 
     auto flush(StateGeneration planGeneration) -> DeferredAction;
 

--- a/arangod/Replication2/ReplicatedState/ReplicatedState.h
+++ b/arangod/Replication2/ReplicatedState/ReplicatedState.h
@@ -70,7 +70,7 @@ struct ReplicatedStateBase {
   virtual void start(
       std::unique_ptr<ReplicatedStateToken> token,
       std::optional<velocypack::SharedSlice> const& coreParameter) = 0;
-  virtual void forceRebuild(IStateManagerBase const* caller) noexcept = 0;
+  virtual void rebuildMe(IStateManagerBase const* caller) noexcept = 0;
   [[nodiscard]] virtual auto getStatus() -> std::optional<StateStatus> = 0;
   [[nodiscard]] auto getLeader()
       -> std::shared_ptr<IReplicatedLeaderStateBase> {
@@ -126,9 +126,9 @@ struct ReplicatedState final
   [[nodiscard]] auto getStatus() -> std::optional<StateStatus> final;
 
   /**
-   * Rebuilds the managers. Called when the managers participant is gone.
+   * Rebuilds the managers. Called by the manager when its participant is gone.
    */
-  void forceRebuild(IStateManagerBase const* caller) noexcept override;
+  void rebuildMe(IStateManagerBase const* caller) noexcept override;
 
   struct IStateManager : IStateManagerBase {
     virtual ~IStateManager() = default;
@@ -157,8 +157,7 @@ struct ReplicatedState final
   std::shared_ptr<replicated_log::ReplicatedLog> const log{};
 
   struct GuardedData {
-    auto forceRebuild(IStateManagerBase const* caller) noexcept
-        -> DeferredAction;
+    auto rebuildMe(IStateManagerBase const* caller) noexcept -> DeferredAction;
 
     auto runLeader(std::shared_ptr<replicated_log::ILogLeader> logLeader,
                    std::unique_ptr<CoreType>,

--- a/arangod/Replication2/ReplicatedState/ReplicatedState.tpp
+++ b/arangod/Replication2/ReplicatedState/ReplicatedState.tpp
@@ -52,23 +52,21 @@
 namespace arangodb::replication2::replicated_state {
 
 template<typename S>
-auto IReplicatedLeaderState<S>::getStream() const
+auto IReplicatedLeaderState<S>::getStream() const noexcept
     -> std::shared_ptr<Stream> const& {
-  if (_stream) {
-    return _stream;
-  }
+  ADB_PROD_ASSERT(_stream != nullptr)
+      << "Replicated leader state: stream accessed before service was started.";
 
-  THROW_ARANGO_EXCEPTION(TRI_ERROR_CLUSTER_BACKEND_UNAVAILABLE);
+  return _stream;
 }
 
 template<typename S>
-auto IReplicatedFollowerState<S>::getStream() const
+auto IReplicatedFollowerState<S>::getStream() const noexcept
     -> std::shared_ptr<Stream> const& {
-  if (_stream) {
-    return _stream;
-  }
+  ADB_PROD_ASSERT(_stream != nullptr) << "Replicated follower state: stream "
+                                         "accessed before service was started.";
 
-  THROW_ARANGO_EXCEPTION(TRI_ERROR_CLUSTER_BACKEND_UNAVAILABLE);
+  return _stream;
 }
 
 template<typename S>

--- a/arangod/Replication2/ReplicatedState/ReplicatedState.tpp
+++ b/arangod/Replication2/ReplicatedState/ReplicatedState.tpp
@@ -152,9 +152,23 @@ auto ReplicatedState<S>::getStatus() -> std::optional<StateStatus> {
 }
 
 template<typename S>
-void ReplicatedState<S>::forceRebuild() {
+void ReplicatedState<S>::forceRebuild(
+    IStateManagerBase const* const caller) noexcept {
   LOG_CTX("8041a", TRACE, loggerContext) << "Force rebuild of replicated state";
-  auto deferred = guardedData.getLockedGuard()->forceRebuild();
+  static_assert(noexcept(
+      // get type of `deferred` by repeating the right-hand-side
+      decltype(guardedData.getLockedGuard()->forceRebuild(caller))
+      // call its copy constructor
+      (
+          // right-hand-side value
+          // note thate getLockedGuard() isn't noexcept, but we consciously
+          // ignore locks throwing exceptions.
+          std::declval<decltype(guardedData.getLockedGuard())>()->forceRebuild(
+              caller)  //
+          )            //
+      ));
+  auto deferred = guardedData.getLockedGuard()->forceRebuild(caller);
+  static_assert(noexcept(deferred.fire()));
   // execute *after* the lock has been released
   deferred.fire();
 }
@@ -194,16 +208,28 @@ ReplicatedState<S>::~ReplicatedState() {
 
 template<typename S>
 auto ReplicatedState<S>::GuardedData::rebuild(
-    std::unique_ptr<CoreType> core, std::unique_ptr<ReplicatedStateToken> token)
-    -> DeferredAction try {
+    std::unique_ptr<CoreType> core,
+    std::unique_ptr<ReplicatedStateToken> token) noexcept -> DeferredAction {
   LOG_CTX("edaef", TRACE, _self.loggerContext)
       << "replicated state rebuilding - query participant";
-  auto participant = _self.log->getParticipant();
+  auto participant = decltype(_self.log->getParticipant())(nullptr);
+  try {
+    participant = _self.log->getParticipant();
+  } catch (replicated_log::ParticipantResignedException const& ex) {
+    LOG_CTX("eacb9", TRACE, _self.loggerContext)
+        << "Replicated log participant is gone. Replicated state will go "
+           "soon as well. Error code: "
+        << ex.code();
+    currentManager = nullptr;
+    return {};
+  }
   if (auto leader =
           std::dynamic_pointer_cast<replicated_log::ILogLeader>(participant);
       leader) {
     LOG_CTX("99890", TRACE, _self.loggerContext)
         << "obtained leader participant";
+    static_assert(noexcept(
+        runLeader(std::move(leader), std::move(core), std::move(token))));
     return runLeader(std::move(leader), std::move(core), std::move(token));
   } else if (auto follower =
                  std::dynamic_pointer_cast<replicated_log::ILogFollower>(
@@ -211,12 +237,17 @@ auto ReplicatedState<S>::GuardedData::rebuild(
              follower) {
     LOG_CTX("f5328", TRACE, _self.loggerContext)
         << "obtained follower participant";
+    static_assert(noexcept(
+        runFollower(std::move(follower), std::move(core), std::move(token))));
     return runFollower(std::move(follower), std::move(core), std::move(token));
   } else if (auto unconfiguredLogParticipant = std::dynamic_pointer_cast<
                  replicated_log::LogUnconfiguredParticipant>(participant);
              unconfiguredLogParticipant) {
     LOG_CTX("ad84b", TRACE, _self.loggerContext)
         << "obtained unconfigured participant";
+    static_assert(
+        noexcept(runUnconfigured(std::move(unconfiguredLogParticipant),
+                                 std::move(core), std::move(token))));
     return runUnconfigured(std::move(unconfiguredLogParticipant),
                            std::move(core), std::move(token));
   } else {
@@ -224,95 +255,106 @@ auto ReplicatedState<S>::GuardedData::rebuild(
         << "Replicated log has an unhandled participant type.";
     std::abort();
   }
-} catch (replication2::replicated_log::ParticipantResignedException const& ex) {
-  LOG_CTX("eacb9", TRACE, _self.loggerContext)
-      << "Replicated log participant is gone. Replicated state will go soon "
-         "as well. Error code: "
-      << ex.code();
-  currentManager = nullptr;
-  return {};
-} catch (...) {
-  throw;
 }
 
 template<typename S>
 auto ReplicatedState<S>::GuardedData::runFollower(
     std::shared_ptr<replicated_log::ILogFollower> logFollower,
-    std::unique_ptr<CoreType> core, std::unique_ptr<ReplicatedStateToken> token)
-    -> DeferredAction try {
+    std::unique_ptr<CoreType> core,
+    std::unique_ptr<ReplicatedStateToken> token) noexcept -> DeferredAction
+    try {
   LOG_CTX("95b9d", DEBUG, _self.loggerContext) << "create follower state";
 
   auto loggerCtx =
       _self.loggerContext.template with<logContextKeyStateComponent>(
           "follower-manager");
+  auto&& self = _self.shared_from_this();
+  static_assert(noexcept(FollowerStateManager<S>(
+      std::move(loggerCtx), std::move(self), std::move(logFollower),
+      std::move(core), std::move(token), _self.factory, _self.metrics)));
   auto manager = std::make_shared<FollowerStateManager<S>>(
-      std::move(loggerCtx), _self.shared_from_this(), std::move(logFollower),
+      std::move(loggerCtx), std::move(self), std::move(logFollower),
       std::move(core), std::move(token), _self.factory, _self.metrics);
   currentManager = manager;
 
   static_assert(noexcept(manager->run()));
   return DeferredAction([manager]() noexcept { manager->run(); });
 } catch (std::exception const& e) {
-  LOG_CTX("ab9de", DEBUG, _self.loggerContext)
+  LOG_CTX("ab9de", FATAL, _self.loggerContext)
       << "runFollower caught exception: " << e.what();
-  throw;
+  FATAL_ERROR_ABORT();
 }
 
 template<typename S>
 auto ReplicatedState<S>::GuardedData::runLeader(
     std::shared_ptr<replicated_log::ILogLeader> logLeader,
-    std::unique_ptr<CoreType> core, std::unique_ptr<ReplicatedStateToken> token)
-    -> DeferredAction try {
+    std::unique_ptr<CoreType> core,
+    std::unique_ptr<ReplicatedStateToken> token) noexcept -> DeferredAction
+    try {
   LOG_CTX("95b9d", DEBUG, _self.loggerContext) << "create leader state";
 
   auto loggerCtx =
       _self.loggerContext.template with<logContextKeyStateComponent>(
           "leader-manager");
+  auto&& self = _self.shared_from_this();
+  static_assert(noexcept(LeaderStateManager<S>(
+      std::move(loggerCtx), std::move(self), std::move(logLeader),
+      std::move(core), std::move(token), _self.factory, _self.metrics)));
   auto manager = std::make_shared<LeaderStateManager<S>>(
-      std::move(loggerCtx), _self.shared_from_this(), std::move(logLeader),
+      std::move(loggerCtx), std::move(self), std::move(logLeader),
       std::move(core), std::move(token), _self.factory, _self.metrics);
   currentManager = manager;
 
   static_assert(noexcept(manager->run()));
   return DeferredAction([manager]() noexcept { manager->run(); });
 } catch (std::exception const& e) {
-  LOG_CTX("016f3", DEBUG, _self.loggerContext)
+  LOG_CTX("016f3", FATAL, _self.loggerContext)
       << "run leader caught exception: " << e.what();
-  throw;
+  FATAL_ERROR_ABORT();
 }
 
 template<typename S>
 auto ReplicatedState<S>::GuardedData::runUnconfigured(
     std::shared_ptr<replicated_log::LogUnconfiguredParticipant>
         unconfiguredParticipant,
-    std::unique_ptr<CoreType> core, std::unique_ptr<ReplicatedStateToken> token)
-    -> DeferredAction try {
+    std::unique_ptr<CoreType> core,
+    std::unique_ptr<ReplicatedStateToken> token) noexcept -> DeferredAction
+    try {
   LOG_CTX("5d7c6", DEBUG, _self.loggerContext) << "create unconfigured state";
+  auto&& self = _self.shared_from_this();
+  static_assert(noexcept((UnconfiguredStateManager<S>(
+      std::move(self), std::move(unconfiguredParticipant), std::move(core),
+      std::move(token)))));
   auto manager = std::make_shared<UnconfiguredStateManager<S>>(
-      _self.shared_from_this(), std::move(unconfiguredParticipant),
-      std::move(core), std::move(token));
+      std::move(self), std::move(unconfiguredParticipant), std::move(core),
+      std::move(token));
   currentManager = manager;
 
   static_assert(noexcept(manager->run()));
   return DeferredAction([manager]() noexcept { manager->run(); });
 } catch (std::exception const& e) {
-  LOG_CTX("6f1eb", DEBUG, _self.loggerContext)
+  LOG_CTX("6f1eb", FATAL, _self.loggerContext)
       << "run unconfigured caught exception: " << e.what();
-  throw;
+  FATAL_ERROR_ABORT();
 }
 
 template<typename S>
-auto ReplicatedState<S>::GuardedData::forceRebuild() -> DeferredAction {
-  try {
-    auto [core, token, queueAction] = std::move(*currentManager).resign();
-    auto runAction = rebuild(std::move(core), std::move(token));
-    return DeferredAction::combine(std::move(queueAction),
-                                   std::move(runAction));
-  } catch (std::exception const& e) {
-    LOG_CTX("af348", DEBUG, _self.loggerContext)
-        << "forced rebuild caught exception: " << e.what();
-    throw;
+auto ReplicatedState<S>::GuardedData::forceRebuild(
+    IStateManagerBase const* const caller) noexcept -> DeferredAction try {
+  if (caller != currentManager.get()) {
+    // Do nothing if the manager changed: A manager may only rebuild itself.
+    return {};
   }
+  static_assert(noexcept(std::move(*currentManager).resign()));
+  auto [core, token, queueAction] = std::move(*currentManager).resign();
+  static_assert(noexcept(decltype(rebuild(std::move(core), std::move(token)))(
+      rebuild(std::move(core), std::move(token)))));
+  auto runAction = rebuild(std::move(core), std::move(token));
+  return DeferredAction::combine(std::move(queueAction), std::move(runAction));
+} catch (std::exception const& e) {
+  LOG_CTX("af348", FATAL, _self.loggerContext)
+      << "forced rebuild caught exception: " << e.what();
+  FATAL_ERROR_ABORT();
 }
 
 template<typename S>

--- a/arangod/Replication2/ReplicatedState/StateInterfaces.h
+++ b/arangod/Replication2/ReplicatedState/StateInterfaces.h
@@ -75,7 +75,8 @@ struct IReplicatedLeaderState : IReplicatedLeaderStateBase {
   virtual auto recoverEntries(std::unique_ptr<EntryIterator>)
       -> futures::Future<Result> = 0;
 
-  auto getStream() const -> std::shared_ptr<Stream> const&;
+  [[nodiscard]] auto getStream() const noexcept
+      -> std::shared_ptr<Stream> const&;
 
   [[nodiscard]] virtual auto resign() && noexcept
       -> std::unique_ptr<CoreType> = 0;
@@ -85,9 +86,13 @@ struct IReplicatedLeaderState : IReplicatedLeaderStateBase {
    * state has been updated. The underlying stream is guaranteed to have been
    * initialized.
    */
-  virtual void onSnapshotCompleted(){};
+  virtual void onSnapshotCompleted() noexcept {};
 
-  // TODO make private
+  void setStream(std::shared_ptr<Stream> stream) noexcept {
+    _stream = std::move(stream);
+  }
+
+ private:
   std::shared_ptr<Stream> _stream;
 };
 
@@ -138,7 +143,8 @@ struct IReplicatedFollowerState : IReplicatedFollowerStateBase {
       -> std::unique_ptr<CoreType> = 0;
 
  protected:
-  [[nodiscard]] auto getStream() const -> std::shared_ptr<Stream> const&;
+  [[nodiscard]] auto getStream() const noexcept
+      -> std::shared_ptr<Stream> const&;
 
  private:
   friend struct FollowerStateManager<S>;

--- a/arangod/Replication2/ReplicatedState/UnconfiguredStateManager.h
+++ b/arangod/Replication2/ReplicatedState/UnconfiguredStateManager.h
@@ -55,7 +55,7 @@ struct UnconfiguredStateManager
       std::shared_ptr<replicated_log::LogUnconfiguredParticipant>
           unconfiguredParticipant,
       std::unique_ptr<CoreType> core,
-      std::unique_ptr<ReplicatedStateToken> token);
+      std::unique_ptr<ReplicatedStateToken> token) noexcept;
 
   void run() noexcept override;
 

--- a/arangod/Replication2/ReplicatedState/UnconfiguredStateManager.tpp
+++ b/arangod/Replication2/ReplicatedState/UnconfiguredStateManager.tpp
@@ -33,7 +33,8 @@ UnconfiguredStateManager<S>::UnconfiguredStateManager(
     std::shared_ptr<ReplicatedState<S>> const& parent,
     std::shared_ptr<replicated_log::LogUnconfiguredParticipant>
         unconfiguredParticipant,
-    std::unique_ptr<CoreType> core, std::unique_ptr<ReplicatedStateToken> token)
+    std::unique_ptr<CoreType> core,
+    std::unique_ptr<ReplicatedStateToken> token) noexcept
     : _parent(parent),
       _unconfiguredParticipant(std::move(unconfiguredParticipant)),
       _core(std::move(core)),
@@ -42,11 +43,15 @@ UnconfiguredStateManager<S>::UnconfiguredStateManager(
 template<typename S>
 void UnconfiguredStateManager<S>::run() noexcept {
   _unconfiguredParticipant->waitForResign().thenFinal(
-      [weak = _parent](futures::Try<futures::Unit>&& result) {
+      [weak = this->weak_from_this()](
+          futures::Try<futures::Unit>&& result) noexcept {
         TRI_ASSERT(result.valid());
         if (result.hasValue()) {
           if (auto self = weak.lock(); self != nullptr) {
-            self->forceRebuild();
+            if (auto parentPtr = self->_parent.lock(); parentPtr != nullptr) {
+              static_assert(noexcept(parentPtr->forceRebuild(self.get())));
+              parentPtr->forceRebuild(self.get());
+            }
           }
         } else if (result.hasException()) {
           // This can be a FutureException(ErrorCode::BrokenPromise), or

--- a/arangod/Replication2/ReplicatedState/UnconfiguredStateManager.tpp
+++ b/arangod/Replication2/ReplicatedState/UnconfiguredStateManager.tpp
@@ -49,8 +49,8 @@ void UnconfiguredStateManager<S>::run() noexcept {
         if (result.hasValue()) {
           if (auto self = weak.lock(); self != nullptr) {
             if (auto parentPtr = self->_parent.lock(); parentPtr != nullptr) {
-              static_assert(noexcept(parentPtr->forceRebuild(self.get())));
-              parentPtr->forceRebuild(self.get());
+              static_assert(noexcept(parentPtr->rebuildMe(self.get())));
+              parentPtr->rebuildMe(self.get());
             }
           }
         } else if (result.hasException()) {

--- a/arangod/Replication2/StateMachines/Prototype/PrototypeLeaderState.h
+++ b/arangod/Replication2/StateMachines/Prototype/PrototypeLeaderState.h
@@ -46,7 +46,7 @@ struct PrototypeLeaderState
   auto recoverEntries(std::unique_ptr<EntryIterator> ptr)
       -> futures::Future<Result> override;
 
-  void onSnapshotCompleted() override;
+  void onSnapshotCompleted() noexcept override;
 
   auto set(std::unordered_map<std::string, std::string> entries,
            PrototypeStateMethods::PrototypeWriteOptions)

--- a/tests/Replication2/ReplicatedState/FollowerSnapshotTest.cpp
+++ b/tests/Replication2/ReplicatedState/FollowerSnapshotTest.cpp
@@ -26,6 +26,7 @@
 
 #include "Logger/LogMacros.h"
 #include "LogLevels.h"
+#include "Death_Test.h"
 
 #include "Replication2/Mocks/FakeFollower.h"
 #include "Replication2/Mocks/FakeReplicatedState.h"
@@ -60,7 +61,9 @@ struct FollowerSnapshotTest
       std::make_shared<ReplicatedStateMetricsMock>("foo");
 };
 
-TEST_F(FollowerSnapshotTest, basic_follower_manager_test) {
+using FollowerSnapshotDeathTest = FollowerSnapshotTest;
+
+TEST_F(FollowerSnapshotDeathTest, basic_follower_manager_test) {
   auto follower =
       std::make_shared<test::FakeFollower>("follower", "leader", LogTerm{1});
   follower->insertMultiplexedValue<State>(
@@ -111,8 +114,8 @@ TEST_F(FollowerSnapshotTest, basic_follower_manager_test) {
       << "follower state should not be available yet";
 
   // furthermore the state should not have access to the stream
-  ASSERT_ANY_THROW({ std::ignore = state->getStream(); })
-      << "stream must not be available";
+  ASSERT_DEATH_CORE_FREE(std::ignore = state->getStream(),
+                         "stream must not be available");
 
   // first trigger an error
   state->acquire.resolveWithAndReset(

--- a/tests/Replication2/ReplicatedState/FollowerSnapshotTest.cpp
+++ b/tests/Replication2/ReplicatedState/FollowerSnapshotTest.cpp
@@ -114,8 +114,7 @@ TEST_F(FollowerSnapshotDeathTest, basic_follower_manager_test) {
       << "follower state should not be available yet";
 
   // furthermore the state should not have access to the stream
-  ASSERT_DEATH_CORE_FREE(std::ignore = state->getStream(),
-                         "stream must not be available");
+  ASSERT_DEATH_CORE_FREE(std::ignore = state->getStream(), "");
 
   // first trigger an error
   state->acquire.resolveWithAndReset(

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -80,6 +80,10 @@ char const* ARGV0 = "";
 
 int main(int argc, char* argv[]) {
   ::testing::InitGoogleTest(&argc, argv);
+  // our gtest version is old and doesn't have the GTEST_FLAG_SET macro yet,
+  // thus this funny workaround for now.
+  // GTEST_FLAG_SET(death_test_style, "threadsafe");
+  (void)(::testing::GTEST_FLAG(death_test_style) = "threadsafe");
 
   TRI_GET_ARGV(argc, argv);
   int subargc = 0;


### PR DESCRIPTION
### Scope & Purpose

* Prevent situations where a resigned manager could trigger a rebuild of its successor, possibly even resulting in a rebuild-loop.
* Make onSnapshotComplete `noexcept`, to make it more explicity that every exception but a `ParticipantResignedException`, which can be silently ignored, would result in an abort anyway.
* Renamed `forceRebuild` to `rebuildMe`

- [X] :hankey: Bugfix

