### PR TITLE
[Pregel] Add recovering to conductor state machine

### DIFF
--- a/arangod/CMakeLists.txt
+++ b/arangod/CMakeLists.txt
@@ -299,6 +299,7 @@ set(LIB_ARANGO_PREGEL_SOURCES
   Pregel/Conductor/StoringState.cpp
   Pregel/Conductor/CanceledState.cpp
   Pregel/Conductor/DoneState.cpp
+  Pregel/Conductor/InErrorState.cpp
   RestHandler/RestControlPregelHandler.cpp
   RestHandler/RestPregelHandler.cpp
 )

--- a/arangod/CMakeLists.txt
+++ b/arangod/CMakeLists.txt
@@ -300,6 +300,7 @@ set(LIB_ARANGO_PREGEL_SOURCES
   Pregel/Conductor/CanceledState.cpp
   Pregel/Conductor/DoneState.cpp
   Pregel/Conductor/InErrorState.cpp
+  Pregel/Conductor/RecoveringState.cpp
   RestHandler/RestControlPregelHandler.cpp
   RestHandler/RestPregelHandler.cpp
 )

--- a/arangod/Pregel/Conductor.h
+++ b/arangod/Pregel/Conductor.h
@@ -40,6 +40,8 @@
 #include "Pregel/Conductor/StoringState.h"
 #include "Pregel/Conductor/CanceledState.h"
 #include "Pregel/Conductor/DoneState.h"
+#include "Pregel/Conductor/InErrorState.h"
+#include "Pregel/Conductor/RecoveringState.h"
 #include "velocypack/Builder.h"
 
 #include <chrono>
@@ -75,6 +77,8 @@ class Conductor : public std::enable_shared_from_this<Conductor> {
   friend struct conductor::Storing;
   friend struct conductor::Canceled;
   friend struct conductor::Done;
+  friend struct conductor::InError;
+  friend struct conductor::Recovering;
 
   ExecutionState _state = ExecutionState::DEFAULT;
   PregelFeature& _feature;

--- a/arangod/Pregel/Conductor/CanceledState.h
+++ b/arangod/Pregel/Conductor/CanceledState.h
@@ -36,6 +36,7 @@ struct Canceled : State {
   ~Canceled();
   auto run() -> void override;
   auto receive(Message const& message) -> void override;
+  auto recover() -> void override{};
 };
 
 }  // namespace conductor

--- a/arangod/Pregel/Conductor/DoneState.h
+++ b/arangod/Pregel/Conductor/DoneState.h
@@ -36,6 +36,7 @@ struct Done : State {
   ~Done();
   auto run() -> void override;
   auto receive(Message const& message) -> void override;
+  auto recover() -> void override{};
 };
 
 }  // namespace conductor

--- a/arangod/Pregel/Conductor/InErrorState.cpp
+++ b/arangod/Pregel/Conductor/InErrorState.cpp
@@ -14,3 +14,6 @@ auto InError::receive(Message const& message) -> void {
       << "When in error, we expect no messages, but received message type "
       << static_cast<int>(message.type());
 }
+auto InError::recover() -> void {
+  conductor.changeState(StateType::Recovering);
+}

--- a/arangod/Pregel/Conductor/InErrorState.cpp
+++ b/arangod/Pregel/Conductor/InErrorState.cpp
@@ -1,0 +1,16 @@
+#include "InErrorState.h"
+
+#include "Pregel/Conductor.h"
+#include "Pregel/WorkerConductorMessages.h"
+
+using namespace arangodb::pregel::conductor;
+
+InError::InError(Conductor& conductor) : conductor{conductor} {
+  conductor.updateState(ExecutionState::IN_ERROR);
+}
+
+auto InError::receive(Message const& message) -> void {
+  LOG_PREGEL_CONDUCTOR("14df4", WARN)
+      << "When in error, we expect no messages, but received message type "
+      << static_cast<int>(message.type());
+}

--- a/arangod/Pregel/Conductor/InErrorState.h
+++ b/arangod/Pregel/Conductor/InErrorState.h
@@ -33,9 +33,10 @@ namespace conductor {
 struct InError : State {
   Conductor& conductor;
   InError(Conductor& conductor);
-  ~InError();
-  auto run() -> void override;
+  ~InError(){};
+  auto run() -> void override{};
   auto receive(Message const& message) -> void override;
+  auto recover() -> void override;
 };
 
 }  // namespace conductor

--- a/arangod/Pregel/Conductor/InErrorState.h
+++ b/arangod/Pregel/Conductor/InErrorState.h
@@ -22,29 +22,20 @@
 ////////////////////////////////////////////////////////////////////////////////
 #pragma once
 
-#include <string>
+#include "Pregel/Conductor/State.h"
 
 namespace arangodb::pregel {
 
-struct Message;
+class Conductor;
 
 namespace conductor {
 
-#define LOG_PREGEL_CONDUCTOR(logId, level) \
-  LOG_TOPIC(logId, level, Logger::PREGEL)  \
-      << "[job " << conductor._executionNumber << "] "
-
-enum class StateType { Loading, Placeholder, Storing, Canceled, Done, InError };
-
-struct State {
-  virtual auto run() -> void = 0;
-  virtual auto receive(Message const& message) -> void = 0;
-  virtual ~State(){};
-};
-
-struct Placeholder : State {
-  auto run() -> void override{};
-  auto receive(Message const& message) -> void override{};
+struct InError : State {
+  Conductor& conductor;
+  InError(Conductor& conductor);
+  ~InError();
+  auto run() -> void override;
+  auto receive(Message const& message) -> void override;
 };
 
 }  // namespace conductor

--- a/arangod/Pregel/Conductor/LoadingState.h
+++ b/arangod/Pregel/Conductor/LoadingState.h
@@ -36,6 +36,7 @@ struct Loading : State {
   ~Loading();
   auto run() -> void override;
   auto receive(Message const& message) -> void override;
+  auto recover() -> void override{};
 };
 
 }  // namespace conductor

--- a/arangod/Pregel/Conductor/RecoveringState.cpp
+++ b/arangod/Pregel/Conductor/RecoveringState.cpp
@@ -1,0 +1,152 @@
+#include "RecoveringState.h"
+
+#include "Pregel/Algorithm.h"
+#include "Pregel/Conductor.h"
+#include "Pregel/Conductor/State.h"
+#include "Pregel/MasterContext.h"
+#include "Pregel/PregelFeature.h"
+#include "Pregel/Recovery.h"
+#include "Pregel/WorkerConductorMessages.h"
+
+using namespace arangodb::pregel::conductor;
+
+Recovering::Recovering(Conductor& conductor) : conductor{conductor} {
+  conductor.updateState(ExecutionState::RECOVERING);
+}
+
+Recovering::~Recovering() {}
+
+auto Recovering::run() -> void {
+  if (conductor._algorithm->supportsCompensation() == false) {
+    LOG_PREGEL_CONDUCTOR("12e0e", ERR) << "Algorithm does not support recovery";
+    conductor.changeState(conductor::StateType::Canceled);
+    return;
+  }
+
+  // we lost a DBServer, we need to reconfigure all remainging servers
+  // so they load the data for the lost machine
+  conductor._statistics.reset();
+
+  TRI_ASSERT(SchedulerFeature::SCHEDULER != nullptr);
+
+  // let's wait for a final state in the cluster
+  conductor._workHandle = SchedulerFeature::SCHEDULER->queueDelayed(
+      RequestLane::CLUSTER_AQL, std::chrono::seconds(2),
+      [this, self = conductor.shared_from_this()](bool cancelled) {
+        if (cancelled) {
+          return;
+        }
+        std::vector<ServerID> goodServers;
+        auto res = conductor._feature.recoveryManager()->filterGoodServers(
+            conductor._dbServers, goodServers);
+        if (res != TRI_ERROR_NO_ERROR) {
+          LOG_PREGEL_CONDUCTOR("3d08b", ERR) << "Recovery proceedings failed";
+          conductor.changeState(conductor::StateType::Canceled);
+          return;
+        }
+        conductor._dbServers = goodServers;
+
+        auto cancelGssCommand =
+            CancelGss{.executionNumber = conductor._executionNumber,
+                      .gss = conductor._globalSuperstep};
+        VPackBuilder command;
+        serialize(command, cancelGssCommand);
+        conductor._sendToAllDBServers(Utils::cancelGSSPath, command);
+        // TODO somehow test here that state is not Canceled
+        if (conductor._state != ExecutionState::RECOVERING) {
+          return;  // seems like we are canceled
+        }
+
+        // Let's try recovery
+        if (conductor._masterContext) {
+          bool proceed = conductor._masterContext->preCompensation();
+          if (!proceed) {
+            conductor.changeState(conductor::StateType::Canceled);
+            return;
+          }
+        }
+
+        VPackBuilder additionalKeys;
+        additionalKeys.openObject();
+        additionalKeys.add(Utils::recoveryMethodKey,
+                           VPackValue(Utils::compensate));
+        additionalKeys.close();
+        conductor._aggregators->resetValues();
+
+        // initialize workers will reconfigure the workers and set the
+        // _dbServers list to the new primary DBServers
+        res = conductor._initializeWorkers(Utils::startRecoveryPath,
+                                           additionalKeys.slice());
+        if (res != TRI_ERROR_NO_ERROR) {
+          LOG_PREGEL_CONDUCTOR("fefc6", ERR) << "Compensation failed";
+          conductor.changeState(conductor::StateType::Canceled);
+          return;
+        }
+      });
+}
+
+auto Recovering::receive(Message const& message) -> void {
+  if (message.type() != MessageType::RecoveryFinished) {
+    LOG_PREGEL_CONDUCTOR("14df4", WARN)
+        << "When recovering, we expect a RecoveryFinished "
+           "message, but we received message type "
+        << static_cast<int>(message.type());
+    return;
+  }
+  auto finishedMessage = static_cast<RecoveryFinished const&>(message);
+
+  conductor._ensureUniqueResponse(finishedMessage.senderId);
+  // the recovery mechanism might be gathering state information
+  conductor._aggregators = finishedMessage.aggregators.aggregators;
+  if (conductor._respondedServers.size() != conductor._dbServers.size()) {
+    return;
+  }
+
+  // only compensations supported
+  bool proceed = false;
+  if (conductor._masterContext) {
+    proceed = proceed || conductor._masterContext->postCompensation();
+  }
+
+  if (!proceed) {
+    LOG_PREGEL_CONDUCTOR("6ecf2", INFO)
+        << "Recovery finished. Proceeding normally";
+
+    // build the message, works for all cases
+    auto finalizeRecoveryCommand =
+        FinalizeRecovery{.executionNumber = conductor._executionNumber,
+                         .gss = conductor._globalSuperstep};
+    VPackBuilder message;
+    serialize(message, finalizeRecoveryCommand);
+    if (conductor._sendToAllDBServers(Utils::finalizeRecoveryPath, message) !=
+        TRI_ERROR_NO_ERROR) {
+      LOG_PREGEL_CONDUCTOR("7f97e", INFO) << "Recovery failed";
+      conductor.changeState(conductor::StateType::Canceled);
+      return;
+    }
+    conductor.updateState(ExecutionState::RUNNING);
+    // TODO change state to Computing
+    conductor.changeState(StateType::Placeholder);
+    conductor._startGlobalStep();
+    return;
+  }
+
+  // reset values which are calculated during the superstep
+  conductor._aggregators->resetValues();
+  if (conductor._masterContext) {
+    conductor._masterContext->preCompensation();
+  }
+
+  auto continueRecoveryCommand =
+      ContinueRecovery{.executionNumber = conductor._executionNumber,
+                       .aggregators = {conductor._aggregators}};
+  VPackBuilder command;
+  serialize(command, continueRecoveryCommand);
+  // first allow all workers to run worker level operations
+  if (conductor._sendToAllDBServers(Utils::continueRecoveryPath, command) !=
+      TRI_ERROR_NO_ERROR) {
+    LOG_PREGEL_CONDUCTOR("7f97e", INFO) << "Recovery failed";
+    conductor.changeState(conductor::StateType::Canceled);
+    return;
+  }
+}

--- a/arangod/Pregel/Conductor/RecoveringState.h
+++ b/arangod/Pregel/Conductor/RecoveringState.h
@@ -30,10 +30,10 @@ class Conductor;
 
 namespace conductor {
 
-struct Storing : State {
+struct Recovering : State {
   Conductor& conductor;
-  Storing(Conductor& conductor);
-  ~Storing();
+  Recovering(Conductor& conductor);
+  ~Recovering();
   auto run() -> void override;
   auto receive(Message const& message) -> void override;
   auto recover() -> void override{};

--- a/arangod/Pregel/Conductor/State.h
+++ b/arangod/Pregel/Conductor/State.h
@@ -34,17 +34,27 @@ namespace conductor {
   LOG_TOPIC(logId, level, Logger::PREGEL)  \
       << "[job " << conductor._executionNumber << "] "
 
-enum class StateType { Loading, Placeholder, Storing, Canceled, Done, InError };
+enum class StateType {
+  Loading,
+  Placeholder,
+  Storing,
+  Canceled,
+  Done,
+  InError,
+  Recovering
+};
 
 struct State {
   virtual auto run() -> void = 0;
   virtual auto receive(Message const& message) -> void = 0;
+  virtual auto recover() -> void = 0;
   virtual ~State(){};
 };
 
 struct Placeholder : State {
   auto run() -> void override{};
   auto receive(Message const& message) -> void override{};
+  auto recover() -> void override{};
 };
 
 }  // namespace conductor


### PR DESCRIPTION
Fifth PR for adding a state machine to the pregel conductor.
Adds InError and Recovering states to conductor state machine. Recovering is triggered from outside and is just allowed when state is Running or InError, therefore I created a new state-machine method recover(), which starts the Recovery state only from InError and Running (not yet implemented) state.