### PR TITLE
add a test for aborting a truncate operation in a trx

### DIFF
--- a/tests/js/client/shell/transaction/shell-transaction.js
+++ b/tests/js/client/shell/transaction/shell-transaction.js
@@ -2118,7 +2118,7 @@ function transactionOperationsSuite (dbParams) {
       assertEqual(0, c1.count());
       assertEqual([ ], sortedKeys(c1));
     },
-
+    
     // //////////////////////////////////////////////////////////////////////////////
     // / @brief test: trx with truncate operation
     // //////////////////////////////////////////////////////////////////////////////
@@ -2223,7 +2223,43 @@ function transactionOperationsSuite (dbParams) {
       assertEqual(1, c1.count());
       let doc = c1.document("1");
       assertEqual(doc.updated, 1);
-    }
+    },
+
+    // //////////////////////////////////////////////////////////////////////////////
+    // / @brief test: trx with truncate operation
+    // //////////////////////////////////////////////////////////////////////////////
+
+    testTruncateAbort: function () {
+      c1 = db._create(cn1, {numberOfShards: 4, replicationFactor: 2});
+
+      for (let i = 0; i < 100; ++i) {
+        c1.save({ a: i });
+      }
+
+      let obj = {
+        collections: {
+          write: [ cn1 ]
+        }
+      };
+      
+      let trx;
+      try {
+        trx = db._createTransaction(obj);
+        let tc1 = trx.collection(c1.name());
+        
+        tc1.truncate({ compact: false });
+
+      } catch(err) {
+        fail("Transaction failed with: " + JSON.stringify(err));
+      } finally {
+        if (trx) {
+          trx.abort();
+        }
+      }
+
+      assertEqual(100, c1.count());
+    },
+
 
   };
 }


### PR DESCRIPTION
### Scope & Purpose

This PR adds a test for a truncate operation inside a transaction that gets aborted.
This doesn't seem to have been covered before.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [x] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -
  - [ ] Backport for 3.7: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 