### PR TITLE
[PREGEL] Add fatal error state and getResults method to conductor state machine

### DIFF
--- a/arangod/CMakeLists.txt
+++ b/arangod/CMakeLists.txt
@@ -301,6 +301,7 @@ set(LIB_ARANGO_PREGEL_SOURCES
   Pregel/Conductor/DoneState.cpp
   Pregel/Conductor/InErrorState.cpp
   Pregel/Conductor/RecoveringState.cpp
+  Pregel/Conductor/FatalErrorState.cpp
   RestHandler/RestControlPregelHandler.cpp
   RestHandler/RestPregelHandler.cpp
 )

--- a/arangod/Pregel/Conductor.cpp
+++ b/arangod/Pregel/Conductor.cpp
@@ -73,7 +73,7 @@
 #include <Inspection/VPack.h>
 #include <velocypack/Iterator.h>
 
-    using namespace arangodb;
+using namespace arangodb;
 using namespace arangodb::pregel;
 using namespace arangodb::basics;
 
@@ -727,28 +727,7 @@ bool Conductor::canBeGarbageCollected() const {
 
 void Conductor::collectAQLResults(VPackBuilder& outBuilder, bool withId) {
   MUTEX_LOCKER(guard, _callbackMutex);
-
-  if (_state != ExecutionState::DONE && _state != ExecutionState::FATAL_ERROR) {
-    return;
-  }
-
-  auto collectPregelResultsCommand = CollectPregelResults{
-      .executionNumber = _executionNumber, .withId = withId};
-  VPackBuilder message;
-  serialize(message, collectPregelResultsCommand);
-
-  // merge results from DBServers
-  outBuilder.openArray();
-  auto res = _sendToAllDBServers(
-      Utils::aqlResultsPath, message, [&](VPackSlice const& payload) {
-        if (payload.isArray()) {
-          outBuilder.add(VPackArrayIterator(payload));
-        }
-      });
-  outBuilder.close();
-  if (res != TRI_ERROR_NO_ERROR) {
-    THROW_ARANGO_EXCEPTION(res);
-  }
+  state->getResults(withId, outBuilder);
 }
 
 void Conductor::toVelocyPack(VPackBuilder& result) const {

--- a/arangod/Pregel/Conductor.h
+++ b/arangod/Pregel/Conductor.h
@@ -42,6 +42,7 @@
 #include "Pregel/Conductor/DoneState.h"
 #include "Pregel/Conductor/InErrorState.h"
 #include "Pregel/Conductor/RecoveringState.h"
+#include "Pregel/Conductor/FatalErrorState.h"
 #include "velocypack/Builder.h"
 
 #include <chrono>
@@ -79,6 +80,7 @@ class Conductor : public std::enable_shared_from_this<Conductor> {
   friend struct conductor::Done;
   friend struct conductor::InError;
   friend struct conductor::Recovering;
+  friend struct conductor::FatalError;
 
   ExecutionState _state = ExecutionState::DEFAULT;
   PregelFeature& _feature;

--- a/arangod/Pregel/Conductor/CanceledState.cpp
+++ b/arangod/Pregel/Conductor/CanceledState.cpp
@@ -14,8 +14,6 @@ Canceled::Canceled(Conductor& conductor) : conductor{conductor} {
   }
 }
 
-Canceled::~Canceled() {}
-
 auto Canceled::run() -> void {
   conductor._callbackMutex.assertLockedByCurrentThread();
   LOG_PREGEL_CONDUCTOR("dd721", WARN)

--- a/arangod/Pregel/Conductor/CanceledState.cpp
+++ b/arangod/Pregel/Conductor/CanceledState.cpp
@@ -52,9 +52,7 @@ auto Canceled::receive(Message const& message) -> void {
     return;
   }
   if (conductor._inErrorAbort) {
-    conductor.updateState(ExecutionState::FATAL_ERROR);
-    // TODO change to FatalErrorState
-    conductor.changeState(StateType::Placeholder);
+    conductor.changeState(StateType::FatalError);
     return;
   }
 

--- a/arangod/Pregel/Conductor/CanceledState.h
+++ b/arangod/Pregel/Conductor/CanceledState.h
@@ -33,10 +33,11 @@ namespace conductor {
 struct Canceled : State {
   Conductor& conductor;
   Canceled(Conductor& conductor);
-  ~Canceled();
+  ~Canceled() = default;
   auto run() -> void override;
   auto receive(Message const& message) -> void override;
   auto recover() -> void override{};
+  auto getResults(bool withId, VPackBuilder& out) -> void override{};
 };
 
 }  // namespace conductor

--- a/arangod/Pregel/Conductor/DoneState.cpp
+++ b/arangod/Pregel/Conductor/DoneState.cpp
@@ -45,7 +45,7 @@ auto Done::run() -> void {
 }
 
 auto Done::receive(Message const& message) -> void {
-  LOG_PREGEL_CONDUCTOR("14df4", WARN)
+  LOG_PREGEL_CONDUCTOR("88f66", WARN)
       << "When done, we expect no messages, but received message type "
       << static_cast<int>(message.type());
 }

--- a/arangod/Pregel/Conductor/DoneState.h
+++ b/arangod/Pregel/Conductor/DoneState.h
@@ -33,10 +33,11 @@ namespace conductor {
 struct Done : State {
   Conductor& conductor;
   Done(Conductor& conductor);
-  ~Done();
+  ~Done() = default;
   auto run() -> void override;
   auto receive(Message const& message) -> void override;
   auto recover() -> void override{};
+  auto getResults(bool withId, VPackBuilder& out) -> void override;
 };
 
 }  // namespace conductor

--- a/arangod/Pregel/Conductor/FatalErrorState.cpp
+++ b/arangod/Pregel/Conductor/FatalErrorState.cpp
@@ -17,3 +17,23 @@ auto FatalError::receive(Message const& message) -> void {
                                          "messages, but received message type "
                                       << static_cast<int>(message.type());
 }
+
+auto FatalError::getResults(bool withId, VPackBuilder& out) -> void {
+  auto collectPregelResultsCommand = CollectPregelResults{
+      .executionNumber = conductor._executionNumber, .withId = withId};
+  VPackBuilder message;
+  serialize(message, collectPregelResultsCommand);
+
+  // merge results from DBServers
+  out.openArray();
+  auto res = conductor._sendToAllDBServers(
+      Utils::aqlResultsPath, message, [&](VPackSlice const& payload) {
+        if (payload.isArray()) {
+          out.add(VPackArrayIterator(payload));
+        }
+      });
+  out.close();
+  if (res != TRI_ERROR_NO_ERROR) {
+    THROW_ARANGO_EXCEPTION(res);
+  }
+}

--- a/arangod/Pregel/Conductor/FatalErrorState.cpp
+++ b/arangod/Pregel/Conductor/FatalErrorState.cpp
@@ -1,0 +1,19 @@
+#include "FatalErrorState.h"
+
+#include "Pregel/Conductor.h"
+#include "Pregel/WorkerConductorMessages.h"
+
+using namespace arangodb::pregel::conductor;
+
+FatalError::FatalError(Conductor& conductor) : conductor{conductor} {
+  conductor.updateState(ExecutionState::FATAL_ERROR);
+  if (not conductor._timing.total.hasFinished()) {
+    conductor._timing.total.finish();
+  }
+}
+
+auto FatalError::receive(Message const& message) -> void {
+  LOG_PREGEL_CONDUCTOR("6363d", WARN) << "When in fatal error, we expect no "
+                                         "messages, but received message type "
+                                      << static_cast<int>(message.type());
+}

--- a/arangod/Pregel/Conductor/FatalErrorState.h
+++ b/arangod/Pregel/Conductor/FatalErrorState.h
@@ -37,6 +37,7 @@ struct FatalError : State {
   auto run() -> void override{};
   auto receive(Message const& message) -> void override;
   auto recover() -> void override{};
+  auto getResults(bool withId, VPackBuilder& out) -> void override;
 };
 
 }  // namespace conductor

--- a/arangod/Pregel/Conductor/FatalErrorState.h
+++ b/arangod/Pregel/Conductor/FatalErrorState.h
@@ -22,39 +22,20 @@
 ////////////////////////////////////////////////////////////////////////////////
 #pragma once
 
-#include <string>
+#include "Pregel/Conductor/State.h"
 
 namespace arangodb::pregel {
 
-struct Message;
+class Conductor;
 
 namespace conductor {
 
-#define LOG_PREGEL_CONDUCTOR(logId, level) \
-  LOG_TOPIC(logId, level, Logger::PREGEL)  \
-      << "[job " << conductor._executionNumber << "] "
-
-enum class StateType {
-  Loading,
-  Placeholder,
-  Storing,
-  Canceled,
-  Done,
-  InError,
-  Recovering,
-  FatalError
-};
-
-struct State {
-  virtual auto run() -> void = 0;
-  virtual auto receive(Message const& message) -> void = 0;
-  virtual auto recover() -> void = 0;
-  virtual ~State(){};
-};
-
-struct Placeholder : State {
+struct FatalError : State {
+  Conductor& conductor;
+  FatalError(Conductor& conductor);
+  ~FatalError(){};
   auto run() -> void override{};
-  auto receive(Message const& message) -> void override{};
+  auto receive(Message const& message) -> void override;
   auto recover() -> void override{};
 };
 

--- a/arangod/Pregel/Conductor/InErrorState.cpp
+++ b/arangod/Pregel/Conductor/InErrorState.cpp
@@ -10,7 +10,7 @@ InError::InError(Conductor& conductor) : conductor{conductor} {
 }
 
 auto InError::receive(Message const& message) -> void {
-  LOG_PREGEL_CONDUCTOR("14df4", WARN)
+  LOG_PREGEL_CONDUCTOR("563ac", WARN)
       << "When in error, we expect no messages, but received message type "
       << static_cast<int>(message.type());
 }

--- a/arangod/Pregel/Conductor/InErrorState.h
+++ b/arangod/Pregel/Conductor/InErrorState.h
@@ -37,6 +37,7 @@ struct InError : State {
   auto run() -> void override{};
   auto receive(Message const& message) -> void override;
   auto recover() -> void override;
+  auto getResults(bool withId, VPackBuilder& out) -> void override{};
 };
 
 }  // namespace conductor

--- a/arangod/Pregel/Conductor/LoadingState.h
+++ b/arangod/Pregel/Conductor/LoadingState.h
@@ -37,6 +37,7 @@ struct Loading : State {
   auto run() -> void override;
   auto receive(Message const& message) -> void override;
   auto recover() -> void override{};
+  auto getResults(bool withId, VPackBuilder& out) -> void override{};
 };
 
 }  // namespace conductor

--- a/arangod/Pregel/Conductor/RecoveringState.cpp
+++ b/arangod/Pregel/Conductor/RecoveringState.cpp
@@ -87,7 +87,7 @@ auto Recovering::run() -> void {
 
 auto Recovering::receive(Message const& message) -> void {
   if (message.type() != MessageType::RecoveryFinished) {
-    LOG_PREGEL_CONDUCTOR("14df4", WARN)
+    LOG_PREGEL_CONDUCTOR("2c9ee", WARN)
         << "When recovering, we expect a RecoveryFinished "
            "message, but we received message type "
         << static_cast<int>(message.type());

--- a/arangod/Pregel/Conductor/RecoveringState.cpp
+++ b/arangod/Pregel/Conductor/RecoveringState.cpp
@@ -14,8 +14,6 @@ Recovering::Recovering(Conductor& conductor) : conductor{conductor} {
   conductor.updateState(ExecutionState::RECOVERING);
 }
 
-Recovering::~Recovering() {}
-
 auto Recovering::run() -> void {
   if (conductor._algorithm->supportsCompensation() == false) {
     LOG_PREGEL_CONDUCTOR("12e0e", ERR) << "Algorithm does not support recovery";

--- a/arangod/Pregel/Conductor/RecoveringState.h
+++ b/arangod/Pregel/Conductor/RecoveringState.h
@@ -33,10 +33,11 @@ namespace conductor {
 struct Recovering : State {
   Conductor& conductor;
   Recovering(Conductor& conductor);
-  ~Recovering();
+  ~Recovering(){};
   auto run() -> void override;
   auto receive(Message const& message) -> void override;
   auto recover() -> void override{};
+  auto getResults(bool withId, VPackBuilder& out) -> void override{};
 };
 
 }  // namespace conductor

--- a/arangod/Pregel/Conductor/State.h
+++ b/arangod/Pregel/Conductor/State.h
@@ -23,6 +23,7 @@
 #pragma once
 
 #include <string>
+#include "velocypack/Builder.h"
 
 namespace arangodb::pregel {
 
@@ -49,6 +50,7 @@ struct State {
   virtual auto run() -> void = 0;
   virtual auto receive(Message const& message) -> void = 0;
   virtual auto recover() -> void = 0;
+  virtual auto getResults(bool withId, VPackBuilder& out) -> void = 0;
   virtual ~State(){};
 };
 
@@ -56,6 +58,7 @@ struct Placeholder : State {
   auto run() -> void override{};
   auto receive(Message const& message) -> void override{};
   auto recover() -> void override{};
+  auto getResults(bool withId, VPackBuilder& out) -> void override{};
 };
 
 }  // namespace conductor

--- a/arangod/Pregel/Conductor/StoringState.cpp
+++ b/arangod/Pregel/Conductor/StoringState.cpp
@@ -40,16 +40,14 @@ auto Storing::run() -> void {
 
 auto Storing::receive(Message const& message) -> void {
   if (message.type() != MessageType::CleanupFinished) {
-    LOG_PREGEL_CONDUCTOR("14df4", WARN)
+    LOG_PREGEL_CONDUCTOR("1b831", WARN)
         << "When storing, we expect a CleanupFinished "
            "message, but we received message type "
         << static_cast<int>(message.type());
     return;
   }
   if (conductor._inErrorAbort) {
-    conductor.updateState(ExecutionState::FATAL_ERROR);
-    // TODO change to FatalErrorState
-    conductor.changeState(StateType::Placeholder);
+    conductor.changeState(StateType::FatalError);
     return;
   }
   conductor.changeState(StateType::Done);

--- a/arangod/Pregel/Conductor/StoringState.h
+++ b/arangod/Pregel/Conductor/StoringState.h
@@ -37,6 +37,7 @@ struct Storing : State {
   auto run() -> void override;
   auto receive(Message const& message) -> void override;
   auto recover() -> void override{};
+  auto getResults(bool withId, VPackBuilder& out) -> void override{};
 };
 
 }  // namespace conductor


### PR DESCRIPTION
Sixth PR for adding a state machine to the pregel conductor.
- Adds FatalError to conductor state machine. 
- Pregel results are only given via the conductor state to AQL. This ensures that the results are only given if the conductor is in the Done or FatalError state (although I'm really not sure why FatalError - in my opinion results should only be available in the Done state).