### PR TITLE
[PREGEL] Bugfix: stop total pregel time correctly when not storing results

### DIFF
--- a/arangod/Pregel/Conductor.cpp
+++ b/arangod/Pregel/Conductor.cpp
@@ -277,6 +277,7 @@ bool Conductor::_startGlobalStep() {
     } else {  // just stop the timer
       updateState(_inErrorAbort ? ExecutionState::FATAL_ERROR
                                 : ExecutionState::DONE);
+      _timing.total.finish();
       LOG_PREGEL("9e82c", INFO)
           << "Done, execution took: " << _timing.total.elapsedSeconds().count()
           << " s";
@@ -864,8 +865,8 @@ void Conductor::finishedWorkerFinalize(VPackSlice data) {
     didStore = true;
     _timing.storing.finish();
     _feature.metrics()->pregelConductorsStoringNumber->fetch_sub(1);
+    _timing.total.finish();
   }
-  _timing.total.finish();
 
   VPackBuilder debugOut;
   debugOut.openObject();

--- a/arangod/Pregel/Status/Status.h
+++ b/arangod/Pregel/Status/Status.h
@@ -115,7 +115,7 @@ template<typename Inspector>
 auto inspect(Inspector& f, GraphStoreStatus& x) {
   return f.object(x).fields(f.field("verticesLoaded", x.verticesLoaded),
                             f.field("edgesLoaded", x.edgesLoaded),
-                            f.field("memoryUsed", x.memoryBytesUsed),
+                            f.field("memoryBytesUsed", x.memoryBytesUsed),
                             f.field("verticesStored", x.verticesStored));
 }
 


### PR DESCRIPTION
When store=false, Done state directly follows Running state without
cleaning up. Cleanup just happens when run is canceled, therefore the
total timer ran until the Pregel run was canceled and not - as it
should - until the computation is done.
Now the total timer stops directly when entering Done state and not storing.

Additionally, correct memory label in status output