### PR TITLE
prevent a startup failure with invalid computed values

### DIFF
--- a/arangod/VocBase/LogicalCollection.cpp
+++ b/arangod/VocBase/LogicalCollection.cpp
@@ -35,6 +35,7 @@
 #include "Cluster/ClusterMethods.h"
 #include "Cluster/FollowerInfo.h"
 #include "Cluster/ServerState.h"
+#include "Logger/LogMacros.h"
 #include "Replication/ReplicationFeature.h"
 #include "Replication2/ReplicatedLog/LogCommon.h"
 #include "Replication2/StateMachines/Document/DocumentStateMachine.h"
@@ -228,7 +229,11 @@ LogicalCollection::LogicalCollection(TRI_vocbase_t& vocbase, VPackSlice info,
   // computed values
   if (auto res = updateComputedValues(info.get(StaticStrings::ComputedValues));
       res.fail()) {
-    THROW_ARANGO_EXCEPTION(res);
+    LOG_TOPIC("4c73f", WARN, Logger::FIXME)
+        << "collection '" << this->vocbase().name() << "/" << name() << ": "
+        << res.errorMessage()
+        << " - disabling computed values for this collection";
+    TRI_ASSERT(_computedValues == nullptr);
   }
 }
 

--- a/arangod/VocBase/LogicalCollection.cpp
+++ b/arangod/VocBase/LogicalCollection.cpp
@@ -229,10 +229,11 @@ LogicalCollection::LogicalCollection(TRI_vocbase_t& vocbase, VPackSlice info,
   // computed values
   if (auto res = updateComputedValues(info.get(StaticStrings::ComputedValues));
       res.fail()) {
-    LOG_TOPIC("4c73f", WARN, Logger::FIXME)
+    LOG_TOPIC("4c73f", ERR, Logger::FIXME)
         << "collection '" << this->vocbase().name() << "/" << name() << ": "
         << res.errorMessage()
-        << " - disabling computed values for this collection";
+        << " - disabling computed values for this collection. original value: "
+        << info.get(StaticStrings::ComputedValues).toJson();
     TRI_ASSERT(_computedValues == nullptr);
   }
 }


### PR DESCRIPTION
### Scope & Purpose

Prevent a startup failure when there are invalid computed values definitions stored for a collection.
While it is not possible for a user to store an invalid computed values definition for a collection, an existing computed values definition may become unintentionally invalid after an upgrade, for example if in a future ArangoDB version the computed values' AQL query string becomes invalid for some reason (introduction of new keywords, disallowed language constructs etc.).
In that case, starting an instance would immediately fail because of the invalid computed values definition, and there is no way anymore to make it start.
This PR instead disables the computed values in that case, logs an error the log containing the problem and the original computed values description, and continues the startup. So that the invalid computed values definitions can be fixed later, but availability of the instance is not affected.

- [x] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -
  - [ ] Backport for 3.7: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
