### PR TITLE
prevent a startup failure with invalid computed values

### DIFF
--- a/arangod/Aql/Ast.cpp
+++ b/arangod/Aql/Ast.cpp
@@ -3698,6 +3698,11 @@ AstNode* Ast::optimizeFunctionCall(
   TRI_ASSERT(node->type == NODE_TYPE_FCALL);
   TRI_ASSERT(node->numMembers() == 1);
 
+  if (!options.optimizeFunctionCalls) {
+    // function call optimization not allowed
+    return node;
+  }
+
   auto func = static_cast<Function*>(node->getData());
   TRI_ASSERT(func != nullptr);
 

--- a/arangod/Aql/Ast.h
+++ b/arangod/Aql/Ast.h
@@ -92,6 +92,8 @@ class Ast {
     // most use cases, but we cannot activate this for computed values, as
     // we need a freshly calculated value every time.
     bool optimizeNonCacheable = true;
+    // whether or not to optimize function calls
+    bool optimizeFunctionCalls = true;
   };
 
   // frees all data

--- a/arangod/Aql/StandaloneCalculation.cpp
+++ b/arangod/Aql/StandaloneCalculation.cpp
@@ -243,8 +243,9 @@ Result StandaloneCalculation::validateQuery(TRI_vocbase_t& vocbase,
     auto qs = arangodb::aql::QueryString(queryString);
     Parser parser(queryContext, *ast, qs);
     parser.parse();
-    ast->validateAndOptimize(queryContext.trxForOptimization(),
-                             {.optimizeNonCacheable = false});
+    ast->validateAndOptimize(
+        queryContext.trxForOptimization(),
+        {.optimizeNonCacheable = false, .optimizeFunctionCalls = false});
     AstNode* astRoot = const_cast<AstNode*>(ast->root());
     TRI_ASSERT(astRoot);
     TRI_ASSERT(astRoot->type == NODE_TYPE_ROOT);

--- a/arangod/Sharding/ShardingInfo.h
+++ b/arangod/Sharding/ShardingInfo.h
@@ -29,9 +29,12 @@
 
 #include <velocypack/Builder.h>
 #include <velocypack/Slice.h>
+
+#include <atomic>
+#include <string>
 #include <unordered_map>
 #include <unordered_set>
-#include <atomic>
+#include <vector>
 
 namespace arangodb {
 class LogicalCollection;
@@ -75,8 +78,6 @@ class ShardingInfo {
   void setWriteConcernAndReplicationFactor(size_t writeConcern,
                                            size_t replicationFactor);
 
-  std::pair<bool, bool>
-  makeSatellite();  // Return note booleans: (isError, isASatellite)
   bool isSatellite() const noexcept;
 
   size_t numberOfShards() const noexcept;
@@ -114,7 +115,16 @@ class ShardingInfo {
 
   static void sortShardNamesNumerically(std::vector<ShardID>& list);
 
+  static Result extractReplicationFactor(velocypack::Slice info, bool isSmart,
+                                         size_t& replicationFactor);
+
+  static Result extractShardKeys(velocypack::Slice info,
+                                 size_t replicationFactor,
+                                 std::vector<std::string>& shardKeys);
+
  private:
+  void makeSatellite();
+
   // @brief the logical collection we are working for
   LogicalCollection* _collection;
 

--- a/arangod/VocBase/ComputedValues.h
+++ b/arangod/VocBase/ComputedValues.h
@@ -28,6 +28,7 @@
 #include "Aql/ExpressionContext.h"
 #include "Basics/ErrorCode.h"
 #include "Basics/Result.h"
+#include "Basics/ResultT.h"
 #include "Containers/FlatHashMap.h"
 #include "Containers/FlatHashSet.h"
 
@@ -183,6 +184,10 @@ class ComputedValues {
       velocypack::Slice input,
       containers::FlatHashSet<std::string_view> const& keysWritten,
       ComputeValuesOn mustComputeOn, velocypack::Builder& output) const;
+
+  static ResultT<std::shared_ptr<ComputedValues>> buildInstance(
+      TRI_vocbase_t& vocbase, std::vector<std::string> const& shardKeys,
+      velocypack::Slice computedValues);
 
  private:
   void mergeComputedAttributes(

--- a/arangod/VocBase/LogicalCollection.cpp
+++ b/arangod/VocBase/LogicalCollection.cpp
@@ -63,8 +63,6 @@
 #include <velocypack/Collection.h>
 #include <velocypack/Utf8Helper.h>
 
-#include <span>
-
 using namespace arangodb;
 using Helper = basics::VelocyPackHelper;
 
@@ -277,39 +275,15 @@ Result LogicalCollection::updateSchema(VPackSlice schema) {
 }
 
 Result LogicalCollection::updateComputedValues(VPackSlice computedValues) {
-  if (!computedValues.isNone()) {
-    if (computedValues.isNull()) {
-      computedValues = VPackSlice::emptyArraySlice();
-    }
-    if (!computedValues.isArray()) {
-      return {TRI_ERROR_BAD_PARAMETER,
-              "Computed values description is not an array."};
-    }
+  auto result =
+      ComputedValues::buildInstance(vocbase(), shardKeys(), computedValues);
 
-    TRI_ASSERT(computedValues.isArray());
-
-    std::shared_ptr<ComputedValues> newValue;
-
-    // computed values will be removed if empty array is given
-    if (!computedValues.isEmptyArray()) {
-      auto const& sk = shardKeys();
-      try {
-        newValue =
-            std::make_shared<ComputedValues>(vocbase()
-                                                 .server()
-                                                 .getFeature<DatabaseFeature>()
-                                                 .getCalculationVocbase(),
-                                             std::span(sk), computedValues);
-      } catch (std::exception const& ex) {
-        return {
-            TRI_ERROR_BAD_PARAMETER,
-            absl::StrCat("Error when validating computedValues: ", ex.what())};
-      }
-    }
-
-    std::atomic_store_explicit(&_computedValues, newValue,
-                               std::memory_order_release);
+  if (result.fail()) {
+    return result.result();
   }
+
+  std::atomic_store_explicit(&_computedValues, result.get(),
+                             std::memory_order_release);
 
   return {};
 }

--- a/arangod/VocBase/LogicalCollection.cpp
+++ b/arangod/VocBase/LogicalCollection.cpp
@@ -35,6 +35,7 @@
 #include "Cluster/ClusterMethods.h"
 #include "Cluster/FollowerInfo.h"
 #include "Cluster/ServerState.h"
+#include "Logger/LogMacros.h"
 #include "Replication/ReplicationFeature.h"
 #include "Replication2/ReplicatedLog/LogCommon.h"
 #include "Replication2/StateMachines/Document/DocumentStateMachine.h"
@@ -228,7 +229,11 @@ LogicalCollection::LogicalCollection(TRI_vocbase_t& vocbase, VPackSlice info,
   // computed values
   if (auto res = updateComputedValues(info.get(StaticStrings::ComputedValues));
       res.fail()) {
-    THROW_ARANGO_EXCEPTION(res);
+    LOG_TOPIC("4c73f", WARN, Logger::FIXME)
+        << "collection '" << this->vocbase().name() << "/" << name() << ": "
+        << res.errorMessage()
+        << " - disabling computed values for this collection";
+    TRI_ASSERT(_computedValues == nullptr);
   }
 }
 

--- a/arangod/VocBase/LogicalCollection.cpp
+++ b/arangod/VocBase/LogicalCollection.cpp
@@ -229,10 +229,11 @@ LogicalCollection::LogicalCollection(TRI_vocbase_t& vocbase, VPackSlice info,
   // computed values
   if (auto res = updateComputedValues(info.get(StaticStrings::ComputedValues));
       res.fail()) {
-    LOG_TOPIC("4c73f", WARN, Logger::FIXME)
+    LOG_TOPIC("4c73f", ERR, Logger::FIXME)
         << "collection '" << this->vocbase().name() << "/" << name() << ": "
         << res.errorMessage()
-        << " - disabling computed values for this collection";
+        << " - disabling computed values for this collection. original value: "
+        << info.get(StaticStrings::ComputedValues).toJson();
     TRI_ASSERT(_computedValues == nullptr);
   }
 }

--- a/arangod/VocBase/Methods/Collections.cpp
+++ b/arangod/VocBase/Methods/Collections.cpp
@@ -56,6 +56,7 @@
 #include "Utils/ExecContext.h"
 #include "Utils/SingleCollectionTransaction.h"
 #include "V8Server/V8Context.h"
+#include "VocBase/ComputedValues.h"
 #include "VocBase/LogicalCollection.h"
 #include "VocBase/Methods/CollectionCreationInfo.h"
 #include "VocBase/vocbase.h"
@@ -102,7 +103,7 @@ bool isSystemName(CollectionCreationInfo const& info) {
 }
 
 Result validateCreationInfo(CollectionCreationInfo const& info,
-                            TRI_vocbase_t const& vocbase,
+                            TRI_vocbase_t& vocbase,
                             bool isSingleServerSmartGraph,
                             bool enforceReplicationFactor,
                             bool isLocalCollection, bool isSystemName,
@@ -126,13 +127,37 @@ Result validateCreationInfo(CollectionCreationInfo const& info,
     return {TRI_ERROR_ARANGO_COLLECTION_TYPE_INVALID};
   }
 
-  // validate shards factor and replication factor
+  // validate number of shards and replication factor
   if (ServerState::instance()->isCoordinator() || isSingleServerSmartGraph) {
     Result res = ShardingInfo::validateShardsAndReplicationFactor(
         info.properties, vocbase.server(), enforceReplicationFactor);
     if (res.fail()) {
       return res;
     }
+  }
+
+  std::vector<std::string> shardKeys;
+  if (ServerState::instance()->isCoordinator()) {
+    bool isSmart = basics::VelocyPackHelper::getBooleanValue(
+        info.properties, StaticStrings::IsSmart, false);
+    size_t replicationFactor = 1;
+    Result res = ShardingInfo::extractReplicationFactor(
+        info.properties, isSmart, replicationFactor);
+    if (res.ok()) {
+      // extract shard keys
+      res = ShardingInfo::extractShardKeys(info.properties, replicationFactor,
+                                           shardKeys);
+    }
+    if (res.fail()) {
+      return res;
+    }
+  }
+
+  // validate computed values
+  auto result = ComputedValues::buildInstance(
+      vocbase, shardKeys, info.properties.get(StaticStrings::ComputedValues));
+  if (result.fail()) {
+    return result.result();
   }
 
   // All collections on a single server should be local collections.
@@ -182,9 +207,8 @@ Result validateCreationInfo(CollectionCreationInfo const& info,
 // validate collection parameters. if the validation fails, it will audit-log
 // the failure.
 Result validateAllCollectionsInfo(
-    TRI_vocbase_t const& vocbase,
-    std::vector<CollectionCreationInfo> const& infos, bool allowSystem,
-    bool allowEnterpriseCollectionsOnSingleServer,
+    TRI_vocbase_t& vocbase, std::vector<CollectionCreationInfo> const& infos,
+    bool allowSystem, bool allowEnterpriseCollectionsOnSingleServer,
     bool enforceReplicationFactor) {
   Result res;
 
@@ -640,7 +664,7 @@ Result Collections::create(
   VPackBuilder builder = createCollectionProperties(
       vocbase, infos, allowEnterpriseCollectionsOnSingleServer);
 
-  VPackSlice const infoSlice = builder.slice();
+  VPackSlice infoSlice = builder.slice();
 
   TRI_ASSERT(infoSlice.isArray());
   TRI_ASSERT(infoSlice.length() >= 1);

--- a/tests/js/common/shell/shell-collection-computed-values.js
+++ b/tests/js/common/shell/shell-collection-computed-values.js
@@ -967,7 +967,24 @@ function ComputedValuesAfterCreateCollectionTestSuite() {
         "level": "moderate",
         "message": "Schema validation failed"
       };
-      const specialFunctions = ["COLLECTIONS", "CURRENT_DATABASE", "CURRENT_USER", "VERSION", `CALL("SUBSTRING", @doc.value1, 0, 2)`, `APPLY("SUBSTRING", [@doc.value1, 0, 2])`, `DOCUMENT(${cn}, "test")`, `V8(1 + 1)`, `SCHEMA_GET(${cn}`, `SCHEMA_VALIDATE(@doc, ${schemaTest}`, `COLLECTION_COUNT(${cn}`, `NEAR(${cn}, @doc.latitude, @doc.longitude)`, `WITHIN(${cn}, @doc.latitude, @doc.longitude, 123)`, `WITHIN_RECTANGLE(${cn}, @doc.latitude, @doc.longitude, @doc.latitude, @doc.longitude)`, `PREGEL_RESULT("abc", true)`];
+      const specialFunctions = [
+        "COLLECTIONS", 
+        "CURRENT_DATABASE", 
+        "CURRENT_USER", 
+        "VERSION", 
+        `CALL("SUBSTRING", @doc.value1, 0, 2)`, 
+        `APPLY("SUBSTRING", [@doc.value1, 0, 2])`, 
+        `DOCUMENT(${cn}, "test")`, `V8(1 + 1)`, 
+        `SCHEMA_GET(${cn}`, 
+        `SCHEMA_VALIDATE(@doc, ${schemaTest}`, 
+        `COLLECTION_COUNT(${cn}`, 
+        `NEAR(${cn}, @doc.latitude, @doc.longitude)`, 
+        `TOKENS(@doc, 'text_en')`,
+        `TOKENS("foo bar", 'text_en')`,
+        `WITHIN(${cn}, @doc.latitude, @doc.longitude, 123)`, 
+        `WITHIN_RECTANGLE(${cn}, @doc.latitude, @doc.longitude, @doc.latitude, @doc.longitude)`, 
+        `PREGEL_RESULT("abc", true)`
+      ];
       specialFunctions.forEach((el) => {
         try {
           collection.properties({


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/16639

Prevent a startup failure when there are invalid computed values definitions stored for a collection.
While it is not possible for a user to store an invalid computed values definition for a collection, an existing computed values definition may become unintentionally invalid after an upgrade, for example if in a future ArangoDB version the computed values' AQL query string becomes invalid for some reason (introduction of new keywords, disallowed language constructs etc.).
In that case, starting an instance would immediately fail because of the invalid computed values definition, and there is no way anymore to make it start.
This PR instead disables the computed values in that case, logs an error the log containing the problem and the original computed values description, and continues the startup. So that the invalid computed values definitions can be fixed later, but availability of the instance is not affected.

- [x] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -
  - [ ] Backport for 3.7: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
