### PR TITLE
[3.10] Revert "Use std::semaphore for UnshackledMutex"

### DIFF
--- a/lib/Basics/UnshackledMutex.cpp
+++ b/lib/Basics/UnshackledMutex.cpp
@@ -27,10 +27,27 @@
 
 namespace arangodb::basics {
 
-void UnshackledMutex::lock() { _sem.acquire(); }
+void UnshackledMutex::lock() noexcept {
+  // cppcheck-suppress throwInNoexceptFunction
+  auto func = +[](bool const* locked) noexcept { return !*locked; };
+  absl::MutexLock guard{&_mutex,
+                        absl::Condition{func, &std::as_const(_locked)}};
+  _locked = true;
+}
 
-void UnshackledMutex::unlock() { _sem.release(); }
+void UnshackledMutex::unlock() noexcept {
+  absl::MutexLock guard{&_mutex};
+  TRI_ASSERT(_locked);
+  _locked = false;
+}
 
-bool UnshackledMutex::try_lock() noexcept { return _sem.try_acquire(); }
+bool UnshackledMutex::try_lock() noexcept {
+  if (!_mutex.TryLock()) {
+    return false;
+  }
+  bool const was_locked = std::exchange(_locked, true);
+  _mutex.Unlock();
+  return !was_locked;
+}
 
 }  // namespace arangodb::basics

--- a/lib/Basics/UnshackledMutex.h
+++ b/lib/Basics/UnshackledMutex.h
@@ -23,7 +23,7 @@
 
 #pragma once
 
-#include <semaphore>
+#include <absl/synchronization/mutex.h>
 
 namespace arangodb::basics {
 
@@ -33,12 +33,13 @@ namespace arangodb::basics {
 // This mutex lifts this requirement and can be unlocked from another thread.
 class UnshackledMutex {
  public:
-  void lock();
-  void unlock();
+  void lock() noexcept;
+  void unlock() noexcept;
   bool try_lock() noexcept;
 
  private:
-  std::binary_semaphore _sem{1};
+  absl::Mutex _mutex;
+  bool _locked{false};
 };
 
 }  // namespace arangodb::basics


### PR DESCRIPTION
Reverts arangodb/arangodb#16554

This is necessary because the libstdc++ and libc++ semaphore implementations are currently broken (see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=104928).

Backport of #16642