### PR TITLE
Bugfix 3.10/pregel result is empty when store equals true

### DIFF
--- a/arangod/Aql/Functions.cpp
+++ b/arangod/Aql/Functions.cpp
@@ -8611,7 +8611,7 @@ AqlValue functions::PregelResult(ExpressionContext* expressionContext,
   VPackBuffer<uint8_t> buffer;
   VPackBuilder builder(buffer);
   if (ServerState::instance()->isCoordinator()) {
-    std::shared_ptr<pregel::Conductor> c = feature.conductor(execNr);
+    auto c = feature.conductor(execNr);
     if (!c) {
       registerWarning(expressionContext, AFN, TRI_ERROR_HTTP_NOT_FOUND);
       return AqlValue(AqlValueHintEmptyArray());

--- a/arangod/Pregel/Conductor.cpp
+++ b/arangod/Pregel/Conductor.cpp
@@ -930,6 +930,10 @@ void Conductor::collectAQLResults(VPackBuilder& outBuilder, bool withId) {
     return;
   }
 
+  if (_storeResults) {
+    return;
+  }
+
   VPackBuilder b;
   b.openObject();
   b.add(Utils::executionNumberKey, VPackValue(_executionNumber));

--- a/tests/js/common/shell/shell-pregel-basics-example.js
+++ b/tests/js/common/shell/shell-pregel-basics-example.js
@@ -175,7 +175,7 @@ function basicTestSuite() {
     },
 
     // test the PREGEL_RESULT AQL function
-    testPageRankAQLResult: function () {
+    test_AQL_pregel_result_contains_pregel_results_when_they_are_not_stored_in_the_database: function () {
       var pid = pregel.start("pagerank", graphName, { threshold: EPS / 10, store: false });
       var i = 10000;
       do {
@@ -185,28 +185,31 @@ function basicTestSuite() {
           assertEqual(stats.vertexCount, 11, stats);
           assertEqual(stats.edgeCount, 17, stats);
 
+          // pregel results are not written to the database
+
           let vertices = db._collection(vColl);
-          // no result was written to the default result field
           vertices.all().toArray().forEach(d => assertTrue(!d.result));
+
+          // pregel results can be queried with PREGEL_RESULT in AQL
 
           let array = db._query("RETURN PREGEL_RESULT(@id)", { "id": pid }).toArray();
           assertEqual(array.length, 1);
           let results = array[0];
           assertEqual(results.length, 11);
 
-          // verify results
           results.forEach(function (d) {
             let v = vertices.document(d._key);
             assertTrue(v !== null);
             assertTrue(Math.abs(v.pagerank - d.result) < EPS);
           });
 
+          // PREGEL_RESULT(<handle>, true) additionally returns vertex _id for each result
+
           array = db._query("RETURN PREGEL_RESULT(@id, true)", { "id": pid }).toArray();
           assertEqual(array.length, 1);
           results = array[0];
           assertEqual(results.length, 11);
 
-          // verify results
           results.forEach(function (d) {
             let v = vertices.document(d._key);
             assertTrue(v !== null);
@@ -216,12 +219,40 @@ function basicTestSuite() {
             assertEqual(v, v2);
           });
 
-          pregel.cancel(pid); // delete contents
+          // after cancelling the pregel run, PREGEL_RESULT is empty
+
+          pregel.cancel(pid);
           internal.sleep(5.0);
 
           array = db._query("RETURN PREGEL_RESULT(@id)", { "id": pid }).toArray();
           assertEqual(array.length, 1);
           results = array[0];
+          assertEqual(results.length, 0);
+
+          break;
+        }
+      } while (i-- >= 0);
+      if (i === 0) {
+        assertTrue(false, "timeout in pregel execution");
+      }
+    },
+
+    test_AQL_pregel_result_is_empty_after_ttl_expires: function () {
+			// set ttl to one second
+      var pid = pregel.start("pagerank", graphName, { threshold: EPS / 10, store: false, ttl: 1 });
+      var i = 10000;
+      do {
+        internal.sleep(0.2);
+        var stats = pregel.status(pid);
+        if (stats.state === "done") {
+          assertEqual(stats.vertexCount, 11, stats);
+          assertEqual(stats.edgeCount, 17, stats);
+
+          // garbage collection runs every 20s, therefore we should wait at least that long plus the ttl given
+          internal.sleep(25);
+          let array = db._query("RETURN PREGEL_RESULT(@id)", { "id": pid }).toArray();
+          assertEqual(array.length, 1);
+          let results = array[0];
           assertEqual(results.length, 0);
 
           break;


### PR DESCRIPTION
### Scope & Purpose

Bug: When running pregel with store: true, PREGEL_RESULT throwed an error in cluster-mode, but not in single-server-mode (there the PREGEL_RESULT is just empty)
With this PR, PREGEL_RESULT will always return an empty array if store: true was used in the config.

Additionally, it adds some more tests regarding querying PREGEL_RESULT

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [x] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*
  - [ ] Backport for 3.7: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [x] Docs PR: https://github.com/arangodb/docs/pull/1062
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

