### PR TITLE
[CINFRA-506] Add index to status.

### DIFF
--- a/arangod/Replication2/ReplicatedState/FollowerStateManager.tpp
+++ b/arangod/Replication2/ReplicatedState/FollowerStateManager.tpp
@@ -355,6 +355,7 @@ auto FollowerStateManager<S>::getStatus() const -> StateStatus {
     status.managerState.detail = std::nullopt;
     status.generation = data.token->generation;
     status.snapshot = data.token->snapshot;
+    status.lastAppliedIndex = data._nextWaitForIndex.saturatedDecrement();
 
     if (data.lastError.has_value()) {
       status.managerState.detail = basics::StringUtils::concatT(

--- a/arangod/Replication2/ReplicatedState/StateStatus.h
+++ b/arangod/Replication2/ReplicatedState/StateStatus.h
@@ -39,6 +39,8 @@ namespace arangodb::replication2::replicated_state {
 namespace static_strings {
 inline constexpr auto StringDetail = std::string_view{"detail"};
 inline constexpr auto StringManager = std::string_view{"manager"};
+inline constexpr auto StringLastAppliedIndex =
+    std::string_view{"lastAppliedIndex"};
 inline constexpr auto StringLastChange = std::string_view{"lastChange"};
 inline constexpr auto StringManagerState = std::string_view{"managerState"};
 inline constexpr auto StringSnapshot = std::string_view{"snapshot"};
@@ -131,6 +133,7 @@ struct FollowerStatus {
   ManagerState managerState;
   StateGeneration generation;
   SnapshotInfo snapshot;
+  LogIndex lastAppliedIndex;
 };
 
 template<class Inspector>
@@ -140,6 +143,7 @@ auto inspect(Inspector& f, FollowerStatus& x) {
       f.field(static_strings::StringGeneration, x.generation),
       f.field(static_strings::StringSnapshot, x.snapshot),
       f.field(static_strings::StringManager, x.managerState),
+      f.field(static_strings::StringLastAppliedIndex, x.lastAppliedIndex),
       f.field(static_strings::StringRole, role));
 }
 

--- a/tests/Replication2/ReplicatedState/FollowerSnapshotTest.cpp
+++ b/tests/Replication2/ReplicatedState/FollowerSnapshotTest.cpp
@@ -146,6 +146,7 @@ TEST_F(FollowerSnapshotDeathTest, basic_follower_manager_test) {
     EXPECT_EQ(status.managerState.state,
               FollowerInternalState::kWaitForNewEntries);
     EXPECT_EQ(status.snapshot.status, SnapshotStatus::kCompleted);
+    EXPECT_EQ(status.lastAppliedIndex, LogIndex{0});
   }
   ASSERT_NE(nullptr, manager->getFollowerState())
       << "follower state should be available";
@@ -169,6 +170,7 @@ TEST_F(FollowerSnapshotDeathTest, basic_follower_manager_test) {
     auto status = *manager->getStatus().asFollowerStatus();
     EXPECT_EQ(status.managerState.state,
               FollowerInternalState::kWaitForNewEntries);
+    EXPECT_EQ(status.lastAppliedIndex, LogIndex{3});
   }
 }
 

--- a/tests/js/server/replication2/replication2-replicated-state-http-api-cluster.js
+++ b/tests/js/server/replication2/replication2-replicated-state-http-api-cluster.js
@@ -122,6 +122,7 @@ const replicatedStateSuite = function (stateType) {
         assertEqual(status.snapshot.status, "Completed");
         assertTrue(status.snapshot.timestamp !== undefined);
         assertEqual(status.generation, 1);
+        assertTrue(status.lastAppliedIndex !== undefined);
       }
     },
 


### PR DESCRIPTION
### Scope & Purpose
Expose the lastAppliedIndex in the replicated state status object. This is usefull for testing.