### PR TITLE
Bug fix/search 325 fields as strings

### DIFF
--- a/arangod/IResearch/IResearchInvertedIndexMeta.cpp
+++ b/arangod/IResearch/IResearchInvertedIndexMeta.cpp
@@ -340,12 +340,6 @@ bool IResearchInvertedIndexMeta::init(arangodb::ArangodServer& server,
       }
     }
   }
-  // for index there is no recursive struct and fields array is mandatory
-  auto field = slice.get(kFieldsFieldName);
-  if (!field.isArray() || field.isEmptyArray()) {
-    errorField = kFieldsFieldName;
-    return false;
-  }
   auto& analyzers = server.getFeature<IResearchAnalyzerFeature>();
 
   if (!InvertedIndexField::init(slice, _analyzerDefinitions, _version,
@@ -353,7 +347,6 @@ bool IResearchInvertedIndexMeta::init(arangodb::ArangodServer& server,
                                 true, errorField)) {
     return false;
   }
-
   _hasNested = std::find_if(_fields.begin(), _fields.end(),
                             [](InvertedIndexField const& r) {
                               return !r._fields.empty();
@@ -818,6 +811,10 @@ bool InvertedIndexField::init(
         return false;
       }
     }
+  }
+  if (rootMode && _fields.empty() && !_includeAllFields) {
+    errorField = kFieldsFieldName;
+    return false;
   }
   return true;
 }

--- a/arangod/IResearch/IResearchRocksDBInvertedIndex.cpp
+++ b/arangod/IResearch/IResearchRocksDBInvertedIndex.cpp
@@ -136,7 +136,7 @@ Result IResearchRocksDBInvertedIndexFactory::normalize(
   TRI_ASSERT(normalized.isOpenObject());
 
   auto res = IndexFactory::validateFieldsDefinition(
-      definition, arangodb::StaticStrings::IndexFields, 1, SIZE_MAX, true);
+      definition, arangodb::StaticStrings::IndexFields, 0, SIZE_MAX, true);
   if (res.fail()) {
     return res;
   }

--- a/arangod/Indexes/IndexFactory.cpp
+++ b/arangod/Indexes/IndexFactory.cpp
@@ -377,7 +377,7 @@ Result IndexFactory::validateFieldsDefinition(VPackSlice definition,
   auto fieldsSlice = definition.get(attributeName);
   auto const idxType = Index::type(
       definition.get(arangodb::StaticStrings::IndexType).stringView());
-  auto const fieldIsObject = Index::TRI_IDX_TYPE_INVERTED_INDEX == idxType;
+  auto const fieldMaybeObject = Index::TRI_IDX_TYPE_INVERTED_INDEX == idxType;
 
   if (fieldsSlice.isArray()) {
     std::regex const idRegex("^(.+\\.)?" + StaticStrings::IdString + "$",
@@ -385,11 +385,11 @@ Result IndexFactory::validateFieldsDefinition(VPackSlice definition,
 
     // "fields" is a list of fields
     for (VPackSlice it : VPackArrayIterator(fieldsSlice)) {
-      if (fieldIsObject && !it.isObject()) {
+      if (!fieldMaybeObject && it.isObject()) {
         return Result(TRI_ERROR_BAD_PARAMETER,
-                      "inverted index: field must be an object");
+                      "index field names must be only strings");
       }
-      auto fieldName = fieldIsObject ? it.get("name") : it;
+      auto fieldName = it.isObject() ? it.get("name") : it;
       if (!fieldName.isString()) {
         return Result(TRI_ERROR_BAD_PARAMETER,
                       "index field names must be non-empty strings");

--- a/tests/IResearch/IResearchInvertedIndexMetaTest.cpp
+++ b/tests/IResearch/IResearchInvertedIndexMetaTest.cpp
@@ -502,8 +502,58 @@ TEST_F(IResearchInvertedIndexMetaTest, testCorrectDefinitions) {
     ]
    })";
 
+  // empty fields but includeAllFields
+  constexpr std::string_view kDefinition8 = R"(
+  {
+    "fields": [ ],
+    "includeAllFields":true,
+    "analyzerDefinitions":[
+      {
+        "name":"myAnalyzer",
+        "type":"stem",
+        "properties": {
+          "locale": "en.utf-8"
+        },
+        "features": ["norm"]
+      },
+      {
+        "name":"myAnalyzer",
+        "type":"delimiter",
+        "properties": {
+          "delimiter" : "."
+        },
+        "features": ["frequency"]
+      }
+    ]
+   })";
+
+  // missing fields but includeAllFields
+  constexpr std::string_view kDefinition9 = R"(
+  {
+    "includeAllFields":true,
+    "analyzerDefinitions":[
+      {
+        "name":"myAnalyzer",
+        "type":"stem",
+        "properties": {
+          "locale": "en.utf-8"
+        },
+        "features": ["norm"]
+      },
+      {
+        "name":"myAnalyzer",
+        "type":"delimiter",
+        "properties": {
+          "delimiter" : "."
+        },
+        "features": ["frequency"]
+      }
+    ]
+   })";
+
   constexpr std::array jsons{kDefinition1, kDefinition2, kDefinition3,
-                             kDefinition6, kDefinition7};
+                             kDefinition6, kDefinition7, kDefinition8,
+                             kDefinition9};
 
   for (auto jsonD : jsons) {
     auto json = VPackParser::fromJson(jsonD.data(), jsonD.size());

--- a/tests/js/server/aql/aql-inverted-index.js
+++ b/tests/js/server/aql/aql-inverted-index.js
@@ -1,4 +1,4 @@
-/* global AQL_EXPLAIN*/
+/* global fail, AQL_EXPLAIN*/
 ////////////////////////////////////////////////////////////////////////////////
 /// DISCLAIMER
 ///
@@ -34,6 +34,7 @@ const removeFilterCoveredByIndex = "remove-filter-covered-by-index";
 const moveFiltersIntoEnumerate = "move-filters-into-enumerate";
 const useIndexForSort = "use-index-for-sort";
 const sleep = require('internal').sleep;
+const errors = require('internal').errors;
 
 function optimizerRuleInvertedIndexTestSuite() {
   const colName = 'UnitTestInvertedIndexCollection';
@@ -193,6 +194,40 @@ function optimizerRuleInvertedIndexTestSuite() {
         assertTrue(executeRes[i-1].count > executeRes[i].count);
       }
     },
+    testEmptyFields: function() {
+      col.ensureIndex({type: 'inverted',
+                       name: 'AllFieldsEmpty',
+                       includeAllFields:true,
+                       fields: [],
+                       primarySort:{fields:[{field: "count", direction:"desc"}]}});
+      col.dropIndex('AllFieldsEmpty');
+      col.ensureIndex({type: 'inverted',
+                       name: 'AllFieldsEmpty2',
+                       includeAllFields:true,
+                       primarySort:{fields:[{field: "count", direction:"desc"}]}});
+      col.dropIndex('AllFieldsEmpty2');
+      try {
+        col.ensureIndex({type: 'inverted',
+                       name: 'AllFieldsEmpty3',
+                       includeAllFields:false,
+                       fields: [],
+                       primarySort:{fields:[{field: "count", direction:"desc"}]}});
+        fail();
+      } catch(e) {
+        assertEqual(errors.ERROR_BAD_PARAMETER.code,
+                    e.errorNum);
+      }
+      try {
+        col.ensureIndex({type: 'inverted',
+                       name: 'AllFieldsEmpty4',
+                       includeAllFields:false,
+                       primarySort:{fields:[{field: "count", direction:"desc"}]}});
+        fail();
+      } catch(e) {
+        assertEqual(errors.ERROR_BAD_PARAMETER.code,
+                    e.errorNum);
+      }
+    }
   };
 }
 

--- a/tests/js/server/aql/aql-inverted-index.js
+++ b/tests/js/server/aql/aql-inverted-index.js
@@ -45,12 +45,12 @@ function optimizerRuleInvertedIndexTestSuite() {
       analyzers.save("my_geo", "geojson",{type: 'point'}, ["frequency", "norm", "position"]);
       col.ensureIndex({type: 'inverted',
                        name: 'InvertedIndexUnsorted',
-                       fields: [{name:'data_field'},
+                       fields: ['data_field',
                                 {name:'geo_field', analyzer:'my_geo'},
                                 {name:'custom_field', analyzer:'text_en'}]});
       col.ensureIndex({type: 'inverted',
                        name: 'InvertedIndexSorted',
-                       fields: [{name:'data_field'},
+                       fields: ['data_field',
                                 {name:'geo_field', analyzer:'my_geo'},
                                 {name:'custom_field', analyzer:'text_en'}],
                         primarySort:{fields:[{field: "count", direction:"desc"}]}});


### PR DESCRIPTION
### Scope & Purpose

Allow to define fields as strings in inverted indexes
Allow to have index with empty fields definition but includeAllFields set

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [x] Tests
  - [x] **Regression tests**
  - [x] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*
  - [ ] Backport for 3.7: *(Please link PR)*

