### PR TITLE
Fix version to 3.10.0

### DIFF
--- a/arangod/GeneralServer/GeneralServer.cpp
+++ b/arangod/GeneralServer/GeneralServer.cpp
@@ -51,15 +51,21 @@ using namespace arangodb::rest;
 // -----------------------------------------------------------------------------
 
 GeneralServer::GeneralServer(GeneralServerFeature& feature,
-                             uint64_t numIoThreads)
-    : _feature(feature) {
+                             uint64_t numIoThreads, bool allowEarlyConnections)
+    : _feature(feature), _allowEarlyConnections(allowEarlyConnections) {
   auto& server = feature.server();
+
+  _contexts.reserve(numIoThreads);
   for (size_t i = 0; i < numIoThreads; ++i) {
     _contexts.emplace_back(server);
   }
 }
 
 GeneralServer::~GeneralServer() = default;
+
+bool GeneralServer::allowEarlyConnections() const noexcept {
+  return _allowEarlyConnections;
+}
 
 void GeneralServer::registerTask(std::shared_ptr<CommTask> task) {
   if (_feature.server().isStopping()) {

--- a/arangod/GeneralServer/GeneralServer.h
+++ b/arangod/GeneralServer/GeneralServer.h
@@ -50,10 +50,10 @@ class GeneralServer {
   GeneralServer const& operator=(GeneralServer const&) = delete;
 
  public:
-  explicit GeneralServer(GeneralServerFeature&, uint64_t numIoThreads);
+  explicit GeneralServer(GeneralServerFeature&, uint64_t numIoThreads,
+                         bool allowEarlyConnections);
   ~GeneralServer();
 
- public:
   void registerTask(std::shared_ptr<rest::CommTask>);
   void unregisterTask(rest::CommTask*);
   void startListening(EndpointList& list);  /// start accepting connections
@@ -61,6 +61,7 @@ class GeneralServer {
   void stopConnections();                   /// stop connections
   void stopWorking();
 
+  bool allowEarlyConnections() const noexcept;
   IoContext& selectIoContext();
   SslServerFeature::SslContextList sslContexts();
   SSL_CTX* getSSL_CTX(size_t index);
@@ -75,6 +76,7 @@ class GeneralServer {
  private:
   GeneralServerFeature& _feature;
   std::vector<IoContext> _contexts;
+  bool const _allowEarlyConnections;
 
   std::recursive_mutex _tasksLock;
   std::vector<std::unique_ptr<Acceptor>> _acceptors;

--- a/arangod/GeneralServer/GeneralServerFeature.cpp
+++ b/arangod/GeneralServer/GeneralServerFeature.cpp
@@ -508,7 +508,8 @@ void GeneralServerFeature::buildServers() {
     ssl.verifySslOptions();
   }
 
-  _servers.emplace_back(std::make_unique<GeneralServer>(*this, _numIoThreads));
+  _servers.emplace_back(std::make_unique<GeneralServer>(
+      *this, _numIoThreads, _allowEarlyConnections));
 }
 
 void GeneralServerFeature::startListening() {


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/16659

when using `--server.early-connections`, the REST API is opened
early during startup and returns HTTP 200 for requests to `/_api/version`
and `/_admin/status`. this is as advertised, however, later in the
startup procedure the server will switch to maintenance mode, and then
it returned HTTP 503 for the same requests. this is inconsistent.
now, when using `--server.early-connections`, the server will keep
responding with HTTP 200 to the mentioned APIs during the entire
startup phase.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -
  - [ ] Backport for 3.7: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
