### PR TITLE
const&  as per style guide in TimeZoneFeature.cpp

### DIFF
--- a/arangod/RestServer/TimeZoneFeature.cpp
+++ b/arangod/RestServer/TimeZoneFeature.cpp
@@ -119,7 +119,7 @@ void TimeZoneFeature::prepare() {
 void TimeZoneFeature::start() {
   try {
     date::reload_tzdb();
-  } catch (const std::runtime_error& ex) {
+  } catch (std::runtime_error const& ex) {
     LOG_TOPIC("67bdd", FATAL, arangodb::Logger::STARTUP) << ex.what();
     FATAL_ERROR_EXIT_CODE(TRI_EXIT_TZDATA_INITIALIZATION_FAILED);
   }


### PR DESCRIPTION
### Scope & Purpose

*(Please describe the changes in this PR for reviewers, motivation, rationale - **mandatory**)*

currently:
```cpp
} catch (const std::runtime_error& ex) {
```
proposed change:
```cpp
} catch (std::runtime_error const& ex) {
```

A long time ago I read a PR comment in this repository that `const` should look like this.  
I also found a reference in the [STYLEGUIDE.md](https://github.com/arangodb/arangodb/blob/devel/STYLEGUIDE.md) 

Question: sould line 112 and 113
```cpp
  std::string binaryExecutionPath = context->getBinaryPath();
  std::string binaryName = context->binaryName();
```
also be const?

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*
  - [ ] Backport for 3.7: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 