### PR TITLE
remove obsolete files from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,10 +29,6 @@ build
 *.lnk
 Thumbs.db
 
-lib/Basics/error-registry.h
-lib/Basics/exitcodes.h
-lib/Basics/voc-errors.h
-
 cppcheck.xml
 
 enterprise


### PR DESCRIPTION
### Scope & Purpose

The following files can now be removed from `.gitignore`, as they are not generated inside the source directory anymore:

* lib/Basics/error-registry.h
* lib/Basics/exitcodes.h
* lib/Basics/voc-errors.h

Nowadays these files are auto-generated inside the build directory, so they do not need to be git-ignored.
Ignoring the files has the downside of ArangoDB builds potentially including outdated versions of these files should they still exist in the file system (e.g. after switching from an older branch to devel). Git-ignoring these files then just hides this problem.

This issue was randomly found during development, but will not affect anyone but developers that switch between old branches and devel in the same checkout directory.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: -
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

