### PR TITLE
Fix incorrect destroy order that cause data race

### DIFF
--- a/arangod/IResearch/IResearchDataStore.cpp
+++ b/arangod/IResearch/IResearchDataStore.cpp
@@ -1414,7 +1414,10 @@ Result IResearchDataStore::insert(transaction::Methods& trx,
   }
 
   if (state.hasHint(transaction::Hints::Hint::INDEX_CREATION)) {
-    auto lock = _asyncSelf->lock();
+    auto linkLock = _asyncSelf->lock();
+    if (!linkLock) {
+      return {TRI_ERROR_INTERNAL};
+    }
     auto ctx = _dataStore._writer->documents();
     TRI_IF_FAILURE("ArangoSearch::MisreportCreationInsertAsFailed") {
       auto res = insertImpl(ctx);  // we need insert to succeed, so  we have

--- a/arangod/IResearch/IResearchDataStore.h
+++ b/arangod/IResearch/IResearchDataStore.h
@@ -82,13 +82,13 @@ using LinkLock = AsyncValue<IResearchDataStore>::Value;
 /// @brief container storing the index state for a given TransactionState
 ////////////////////////////////////////////////////////////////////////////////
 struct IResearchTrxState final : public TransactionState::Cookie {
-  irs::index_writer::documents_context _ctx;
   // prevent data-store deallocation (lock @ AsyncSelf)
-  LinkLock _linkLock;
+  LinkLock _linkLock;  // should be first field to destroy last
+  irs::index_writer::documents_context _ctx;
   PrimaryKeyFilterContainer _removals;  // list of document removals
 
   IResearchTrxState(LinkLock&& linkLock, irs::index_writer& writer) noexcept
-      : _ctx{writer.documents()}, _linkLock{std::move(linkLock)} {}
+      : _linkLock{std::move(linkLock)}, _ctx{writer.documents()} {}
 
   ~IResearchTrxState() final {
     if (_removals.empty()) {


### PR DESCRIPTION
### Scope & Purpose

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: https://github.com/arangodb/arangodb/pull/16684
  - [ ] Backport for 3.9: https://github.com/arangodb/arangodb/pull/16681
  - [ ] Backport for 3.8: https://github.com/arangodb/arangodb/pull/16682

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

