### PR TITLE
[BUILD] Add CMakePresets.json

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -7,33 +7,124 @@
   },
   "configurePresets": [
     {
-      "name": "default",
-      "displayName": "Default Config",
-      "binaryDir": "${sourceDir}/build/default",
+      "name": "community",
+      "displayName": "Build ArangoDB Community Edition",
+      "binaryDir": "${sourceDir}/build/community",
       "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+        "CMAKE_BUILD_TYPE": "Release",
         "USE_ENTERPRISE": "Off",
         "USE_JEMALLOC": "On",
-        "USE_MAINTAINER_MODE": "Off",
-        "USE_FAILURE_TESTS": "Off",
-        "USE_FAIL_ON_WARNINGS": "Off",
-        "USE_IPO": "Off"
-      },
-      "environment": {
-
+        "USE_IPO": "On"
+      }
+    },
+    {
+      "name": "enterprise",
+      "displayName": "Build ArangoDB Enterprise Edition",
+      "binaryDir": "${sourceDir}/build/enterprise",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "USE_ENTERPRISE": "On",
+        "USE_JEMALLOC": "On",
+        "USE_IPO": "On"
+      }
+    },
+    {
+      "name": "community-developer",
+      "inherits": "community",
+      "displayName": "Build ArangoDB Community Edition (Developer Build)",
+      "binaryDir": "${sourceDir}/build/community-developer",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+        "USE_IPO": "Off",
+        "USE_MAINTAINER_MODE": "On",
+        "USE_FAIL_ON_WARNINGS": "On",
+        "USE_SEPARATE_REPLICATION2_TESTS_BINARY": "On"
+      }
+    },
+    {
+      "name": "enterprise-developer",
+      "inherits": "enterprise",
+      "displayName": "Build ArangoDB Enterprise Edition (Developer Build)",
+      "binaryDir": "${sourceDir}/build/enterprise-developer",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+        "USE_IPO": "Off",
+        "USE_MAINTAINER_MODE": "On",
+        "USE_FAIL_ON_WARNINGS": "On",
+        "USE_SEPARATE_REPLICATION2_TESTS_BINARY": "On"
+      }
+    },
+    {
+      "name": "community-developer-tsan",
+      "inherits": "community-developer",
+      "displayName": "Build ArangoDB Community Edition (TSAN Build)",
+      "cacheVariables": {
+        "CMAKE_CXX_FLAGS": "-fsanitize=thread"
+      }
+    },
+    {
+      "name": "enterprise-developer-tsan",
+      "inherits": "enterprise-developer",
+      "displayName": "Build ArangoDB Enterprise Edition (TSAN Build)",
+      "cacheVariables": {
+        "CMAKE_CXX_FLAGS": "-fsanitize=thread"
+      }
+    },
+    {
+      "name": "community-developer-asan-ubsan",
+      "inherits": "community-developer",
+      "displayName": "Build ArangoDB Community Edition (ASAN and UBSAN Build)",
+      "cacheVariables": {
+        "CMAKE_CXX_FLAGS": "-fsanitize=address -fsanitize=leak -fsanitize=undefined -fsanitize=float-divide-by-zero -fno-sanitize-address-use-after-scope -fno-sanitize=alignment -fno-var-tracking-assignments -fno-sanitize=vptr"
+      }
+    },
+    {
+      "name": "enterprise-developer-asan-ubsan",
+      "inherits": "enterprise-developer",
+      "displayName": "Build ArangoDB Enterprise Edition (ASAN and UBSAN Build)",
+      "cacheVariables": {
+        "CMAKE_CXX_FLAGS": "-fsanitize=address -fsanitize=leak -fsanitize=undefined -fsanitize=float-divide-by-zero -fno-sanitize-address-use-after-scope -fno-sanitize=alignment -fno-var-tracking-assignments -fno-sanitize=vptr"
       }
     }
   ],
   "buildPresets": [
     {
-      "name": "default",
-      "configurePreset": "default"
+      "name": "community",
+      "configurePreset": "community"
+    },
+    {
+      "name": "enterprise",
+      "configurePreset": "enterprise"
+    },
+    {
+      "name": "community-developer",
+      "configurePreset": "community-developer"
+    },
+    {
+      "name": "enterprise-developer",
+      "configurePreset": "enterprise-developer"
+    },
+    {
+      "name": "community-developer-tsan",
+      "configurePreset": "community-developer-tsan"
+    },
+    {
+      "name": "enterprise-developer-tsan",
+      "configurePreset": "enterprise-developer-tsan"
+    },
+    {
+      "name": "community-developer-asan-uban",
+      "configurePreset": "community-developer-asan-ubsan"
+    },
+    {
+      "name": "enterprise-developer-asan",
+      "configurePreset": "enterprise-developer-asan-ubsan"
     }
   ],
   "testPresets": [
     {
-      "name": "default",
-      "configurePreset": "default"
+      "name": "enterprise",
+      "configurePreset": "enterprise"
     }
   ]
 }

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,39 @@
+{
+  "version": 3,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 20,
+    "patch": 0
+  },
+  "configurePresets": [
+    {
+      "name": "default",
+      "displayName": "Default Config",
+      "binaryDir": "${sourceDir}/build/default",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+        "USE_ENTERPRISE": "Off",
+        "USE_JEMALLOC": "On",
+        "USE_MAINTAINER_MODE": "Off",
+        "USE_FAILURE_TESTS": "Off",
+        "USE_FAIL_ON_WARNINGS": "Off",
+        "USE_IPO": "Off"
+      },
+      "environment": {
+
+      }
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "default",
+      "configurePreset": "default"
+    }
+  ],
+  "testPresets": [
+    {
+      "name": "default",
+      "configurePreset": "default"
+    }
+  ]
+}

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -33,14 +33,13 @@
       "inherits": "community",
       "displayName": "Build ArangoDB Community Edition (Developer Build)",
       "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+        "CMAKE_BUILD_TYPE": "Debug",
         "USE_IPO": "Off",
         "USE_MAINTAINER_MODE": "On",
         "USE_FAIL_ON_WARNINGS": "On",
 	"USE_GOOGLE_TESTS": "On",
 	"USE_FAILURE_TESTS": "On",
-	"USE_STRICT_OPENSSL_VERSION": "Off",
-        "USE_SEPARATE_REPLICATION2_TESTS_BINARY": "On"
+	"USE_STRICT_OPENSSL_VERSION": "Off"
       }
     },
     {
@@ -48,14 +47,13 @@
       "inherits": "enterprise",
       "displayName": "Build ArangoDB Enterprise Edition (Developer Build)",
       "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+        "CMAKE_BUILD_TYPE": "Debug",
         "USE_IPO": "Off",
         "USE_MAINTAINER_MODE": "On",
         "USE_FAIL_ON_WARNINGS": "On",
 	"USE_GOOGLE_TESTS": "On",
 	"USE_FAILURE_TESTS": "On",
-	"USE_STRICT_OPENSSL_VERSION": "Off",
-        "USE_SEPARATE_REPLICATION2_TESTS_BINARY": "On"
+	"USE_STRICT_OPENSSL_VERSION": "Off"
       }
     },
     {

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -37,9 +37,9 @@
         "USE_IPO": "Off",
         "USE_MAINTAINER_MODE": "On",
         "USE_FAIL_ON_WARNINGS": "On",
-	"USE_GOOGLE_TESTS": "On",
-	"USE_FAILURE_TESTS": "On",
-	"USE_STRICT_OPENSSL_VERSION": "Off"
+        "USE_GOOGLE_TESTS": "On",
+        "USE_FAILURE_TESTS": "On",
+        "USE_STRICT_OPENSSL_VERSION": "Off"
       }
     },
     {
@@ -51,9 +51,9 @@
         "USE_IPO": "Off",
         "USE_MAINTAINER_MODE": "On",
         "USE_FAIL_ON_WARNINGS": "On",
-	"USE_GOOGLE_TESTS": "On",
-	"USE_FAILURE_TESTS": "On",
-	"USE_STRICT_OPENSSL_VERSION": "Off"
+        "USE_GOOGLE_TESTS": "On",
+        "USE_FAILURE_TESTS": "On",
+        "USE_STRICT_OPENSSL_VERSION": "Off"
       }
     },
     {

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -9,7 +9,7 @@
     {
       "name": "community",
       "displayName": "Build ArangoDB Community Edition",
-      "binaryDir": "${sourceDir}/build/community",
+      "binaryDir": "${sourceDir}/build/${presetName}",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Release",
         "USE_ENTERPRISE": "Off",
@@ -19,8 +19,8 @@
     },
     {
       "name": "enterprise",
+      "inherits": "community",
       "displayName": "Build ArangoDB Enterprise Edition",
-      "binaryDir": "${sourceDir}/build/enterprise",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Release",
         "USE_ENTERPRISE": "On",
@@ -32,7 +32,6 @@
       "name": "community-developer",
       "inherits": "community",
       "displayName": "Build ArangoDB Community Edition (Developer Build)",
-      "binaryDir": "${sourceDir}/build/community-developer",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "RelWithDebInfo",
         "USE_IPO": "Off",
@@ -45,7 +44,6 @@
       "name": "enterprise-developer",
       "inherits": "enterprise",
       "displayName": "Build ArangoDB Enterprise Edition (Developer Build)",
-      "binaryDir": "${sourceDir}/build/enterprise-developer",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "RelWithDebInfo",
         "USE_IPO": "Off",
@@ -58,7 +56,6 @@
       "name": "community-developer-tsan",
       "inherits": "community-developer",
       "displayName": "Build ArangoDB Community Edition (TSAN Build)",
-      "binaryDir": "${sourceDir}/build/community-developer-tsan",
       "cacheVariables": {
         "CMAKE_CXX_FLAGS": "-fsanitize=thread"
       }
@@ -67,7 +64,6 @@
       "name": "enterprise-developer-tsan",
       "inherits": "enterprise-developer",
       "displayName": "Build ArangoDB Enterprise Edition (TSAN Build)",
-      "binaryDir": "${sourceDir}/build/enterprise-developer-tsan",
       "cacheVariables": {
         "CMAKE_CXX_FLAGS": "-fsanitize=thread"
       }
@@ -76,7 +72,6 @@
       "name": "community-developer-asan-ubsan",
       "inherits": "community-developer",
       "displayName": "Build ArangoDB Community Edition (ASAN and UBSAN Build)",
-      "binaryDir": "${sourceDir}/build/community-developer-asan-ubsan",
       "cacheVariables": {
         "CMAKE_CXX_FLAGS": "-fsanitize=address -fsanitize=leak -fsanitize=undefined -fsanitize=float-divide-by-zero -fno-sanitize-address-use-after-scope -fno-sanitize=alignment -fno-var-tracking-assignments -fno-sanitize=vptr"
       }
@@ -85,7 +80,6 @@
       "name": "enterprise-developer-asan-ubsan",
       "inherits": "enterprise-developer",
       "displayName": "Build ArangoDB Enterprise Edition (ASAN and UBSAN Build)",
-      "binaryDir": "${sourceDir}/build/enterprise-developer-asan-ubsan",
       "cacheVariables": {
         "CMAKE_CXX_FLAGS": "-fsanitize=address -fsanitize=leak -fsanitize=undefined -fsanitize=float-divide-by-zero -fno-sanitize-address-use-after-scope -fno-sanitize=alignment -fno-var-tracking-assignments -fno-sanitize=vptr"
       }

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -37,6 +37,9 @@
         "USE_IPO": "Off",
         "USE_MAINTAINER_MODE": "On",
         "USE_FAIL_ON_WARNINGS": "On",
+	"USE_GOOGLE_TESTS": "On",
+	"USE_FAILURE_TESTS": "On",
+	"USE_STRICT_OPENSSL_VERSION": "Off",
         "USE_SEPARATE_REPLICATION2_TESTS_BINARY": "On"
       }
     },
@@ -49,6 +52,9 @@
         "USE_IPO": "Off",
         "USE_MAINTAINER_MODE": "On",
         "USE_FAIL_ON_WARNINGS": "On",
+	"USE_GOOGLE_TESTS": "On",
+	"USE_FAILURE_TESTS": "On",
+	"USE_STRICT_OPENSSL_VERSION": "Off",
         "USE_SEPARATE_REPLICATION2_TESTS_BINARY": "On"
       }
     },

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -58,6 +58,7 @@
       "name": "community-developer-tsan",
       "inherits": "community-developer",
       "displayName": "Build ArangoDB Community Edition (TSAN Build)",
+      "binaryDir": "${sourceDir}/build/community-developer-tsan",
       "cacheVariables": {
         "CMAKE_CXX_FLAGS": "-fsanitize=thread"
       }
@@ -66,6 +67,7 @@
       "name": "enterprise-developer-tsan",
       "inherits": "enterprise-developer",
       "displayName": "Build ArangoDB Enterprise Edition (TSAN Build)",
+      "binaryDir": "${sourceDir}/build/enterprise-developer-tsan",
       "cacheVariables": {
         "CMAKE_CXX_FLAGS": "-fsanitize=thread"
       }
@@ -74,6 +76,7 @@
       "name": "community-developer-asan-ubsan",
       "inherits": "community-developer",
       "displayName": "Build ArangoDB Community Edition (ASAN and UBSAN Build)",
+      "binaryDir": "${sourceDir}/build/community-developer-asan-ubsan",
       "cacheVariables": {
         "CMAKE_CXX_FLAGS": "-fsanitize=address -fsanitize=leak -fsanitize=undefined -fsanitize=float-divide-by-zero -fno-sanitize-address-use-after-scope -fno-sanitize=alignment -fno-var-tracking-assignments -fno-sanitize=vptr"
       }
@@ -82,6 +85,7 @@
       "name": "enterprise-developer-asan-ubsan",
       "inherits": "enterprise-developer",
       "displayName": "Build ArangoDB Enterprise Edition (ASAN and UBSAN Build)",
+      "binaryDir": "${sourceDir}/build/enterprise-developer-asan-ubsan",
       "cacheVariables": {
         "CMAKE_CXX_FLAGS": "-fsanitize=address -fsanitize=leak -fsanitize=undefined -fsanitize=float-divide-by-zero -fno-sanitize-address-use-after-scope -fno-sanitize=alignment -fno-var-tracking-assignments -fno-sanitize=vptr"
       }


### PR DESCRIPTION
### Scope & Purpose

This PR adds `CMakePresets` which can be used to share settings for building ArangoDB between platforms and developers and make for a consistent build environment.

Example use

```
# cmake --list-presets
Available configure presets:

  "community"                       - Build ArangoDB Community Edition
  "enterprise"                      - Build ArangoDB Enterprise Edition
  "community-developer"             - Build ArangoDB Community Edition (Developer Build)
  "enterprise-developer"            - Build ArangoDB Enterprise Edition (Developer Build)
  "community-developer-tsan"        - Build ArangoDB Community Edition (TSAN Build)
  "enterprise-developer-tsan"       - Build ArangoDB Enterprise Edition (TSAN Build)
  "community-developer-asan-ubsan"  - Build ArangoDB Community Edition (ASAN and UBSAN Build)
  "enterprise-developer-asan-ubsan" - Build ArangoDB Enterprise Edition (ASAN and UBSAN Build)

# cmake --preset community-developer

...

# cmake --build --preset community-developer --parallel 4

...

# build/community-developer/bin/arangod --database.directory /tmp/foo
2022-08-08T13:34:31Z [1866168] INFO [e52b0] {general} ArangoDB 3.11.0-devel [linux] 64bit maintainer mode, using jemalloc, build heads/feature/cmake-presets-for-great-good-0-g8121a5cecf6, VPack 0.1.36, RocksDB 7.2.0, ICU 64.2, V8 7.9.317, OpenSSL 1.1.1q  5 Jul 2022

```
