### PR TITLE
Bugfix/bts 902

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 devel
 -----
+* Fixed BTS-902 (clicking on the search icon in the analyzers filter input used to take the user to the collections view).
 
 * Updated arangosync to v2.12.0-preview-2.
 

--- a/js/apps/system/_admin/aardvark/APP/react/src/views/analyzers/AnalyzersReactView.jsx
+++ b/js/apps/system/_admin/aardvark/APP/react/src/views/analyzers/AnalyzersReactView.jsx
@@ -111,7 +111,7 @@ const AnalyzersReactView = () => {
         <div className="search-field">
           <input type={'text'} id={'filterInput'} className={'search-input'} value={filterExpr}
                  onChange={getChangeHandler(setFilterExpr)} placeholder={'Filter...'}/>
-          <i id="searchSubmit" className="fa fa-search"/>
+          <i className="fa fa-search" style={{ cursor: 'default' }}/>
         </div>
         <div className="headerButtonBar">
           <ul className="headerButtonList">
@@ -175,7 +175,8 @@ const AnalyzersReactView = () => {
                       <ArangoTD seq={1}>{analyzer.name}</ArangoTD>
                       <ArangoTD seq={2}>{typeNameMap[analyzer.type]}</ArangoTD>
                       <ArangoTD seq={3}>
-                        <Actions analyzer={analyzer} permission={permissions} modalCidSuffix={analyzer.name}/>
+                        <Actions analyzer={analyzer} permission={permissions}
+                                 modalCidSuffix={analyzer.name}/>
                       </ArangoTD>
                     </tr>
                   ))


### PR DESCRIPTION
### Scope & Purpose

Fixes BTS-902 (clicking on the search icon in the analyzers filter input used to take the user to the collections view).

The filter is auto-triggered on keyboard input, so a separate click handler on the search icon is not required. The search icon's id was getting bound to the collections search handler (if the user had navigated to the collection page any time earlier during the session).

The fix was to simply remove the id attribute from the search icon in the analyzers page, since it is merely cosmetic.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: *(Please link PR)*
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [x] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/BTS-902
- [ ] Design document: 

