### PR TITLE
[CINFRA-508] LeaderElection sets write concern

### DIFF
--- a/arangod/Replication2/ReplicatedLog/Supervision.cpp
+++ b/arangod/Replication2/ReplicatedLog/Supervision.cpp
@@ -264,10 +264,16 @@ auto checkLeaderPresent(SupervisionContext& ctx, Log const& log,
         election.electibleLeaderSet.at(RandomGenerator::interval(maxIdx));
     auto const& newLeaderRebootId = health.getRebootId(newLeader);
 
+    auto effectiveWriteConcern = computeEffectiveWriteConcern(
+        log.target.config, plan.participantsConfig.participants, health);
+
     if (newLeaderRebootId.has_value()) {
       ctx.reportStatus<LogCurrentSupervision::LeaderElectionSuccess>(election);
       ctx.createAction<LeaderElectionAction>(
           LogPlanTermSpecification::Leader(newLeader, *newLeaderRebootId),
+          effectiveWriteConcern,
+          std::min(current.supervision->assumedWriteConcern,
+                   effectiveWriteConcern),
           election);
       return;
     } else {

--- a/arangod/Replication2/ReplicatedLog/SupervisionAction.h
+++ b/arangod/Replication2/ReplicatedLog/SupervisionAction.h
@@ -173,17 +173,31 @@ struct LeaderElectionAction {
   static constexpr std::string_view name = "LeaderElectionAction";
 
   LeaderElectionAction(LogPlanTermSpecification::Leader electedLeader,
+                       size_t effectiveWriteConcern, size_t assumedWriteConcern,
                        LogCurrentSupervisionElection const& electionReport)
-      : _electedLeader{electedLeader}, _electionReport(electionReport){};
+      : _electedLeader{electedLeader},
+        _effectiveWriteConcern{effectiveWriteConcern},
+        _assumedWriteConcern{assumedWriteConcern},
+        _electionReport(electionReport){};
 
   LogPlanTermSpecification::Leader _electedLeader;
+  size_t _effectiveWriteConcern;
+  size_t _assumedWriteConcern;
   LogCurrentSupervisionElection _electionReport;
 
   auto execute(ActionContext& ctx) const -> void {
     ctx.modify<LogPlanSpecification>([&](LogPlanSpecification& plan) {
       plan.currentTerm->term = LogTerm{plan.currentTerm->term.value + 1};
       plan.currentTerm->leader = _electedLeader;
+      plan.participantsConfig.generation =
+          plan.participantsConfig.generation + 1;
+      plan.participantsConfig.config.effectiveWriteConcern =
+          _effectiveWriteConcern;
     });
+    ctx.modify<LogCurrentSupervision>(
+        [&](LogCurrentSupervision& currentSupervision) {
+          currentSupervision.assumedWriteConcern = _assumedWriteConcern;
+        });
   }
 };
 template<typename Inspector>

--- a/tests/Replication2/Helper/AgencyLogBuilder.h
+++ b/tests/Replication2/Helper/AgencyLogBuilder.h
@@ -119,6 +119,14 @@ struct AgencyLogBuilder {
     return *this;
   }
 
+  auto setEmptyTerm() -> AgencyLogBuilder& {
+    auto& term = makeTerm();
+
+    term.leader.reset();
+    term.term.value++;
+    return *this;
+  }
+
   auto acknowledgeTerm(replication2::ParticipantId const& id)
       -> AgencyLogBuilder& {
     auto& current = makeCurrent();


### PR DESCRIPTION
This patch causes the supervision to set `effectiveWriteConcern` and `assumedWriteConcern` right when the leader election happens;

### Scope & Purpose

*(Please describe the changes in this PR for reviewers, motivation, rationale - **mandatory**)*

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [x] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: *(Please link PR)*
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

