### PR TITLE
fix UB in collection properties updating

### DIFF
--- a/arangod/ClusterEngine/ClusterIndex.cpp
+++ b/arangod/ClusterEngine/ClusterIndex.cpp
@@ -49,6 +49,11 @@ ClusterIndex::ClusterIndex(IndexId id, LogicalCollection& collection,
       _clusterSelectivity(/* default */ 0.1) {
   TRI_ASSERT(_info.slice().isObject());
   TRI_ASSERT(_info.isClosed());
+  TRI_ASSERT(_engineType == ClusterEngineType::RocksDBEngine ||
+             _engineType == ClusterEngineType::MockEngine);
+#ifndef ARANGODB_USE_GOOGLE_TESTS
+  TRI_ASSERT(_engineType == ClusterEngineType::RocksDBEngine);
+#endif
 
   if (_engineType == ClusterEngineType::RocksDBEngine) {
     if (_indexType == TRI_IDX_TYPE_EDGE_INDEX) {
@@ -193,6 +198,8 @@ bool ClusterIndex::isSorted() const {
 void ClusterIndex::updateProperties(velocypack::Slice const& slice) {
   VPackBuilder merge;
   merge.openObject();
+
+  TRI_ASSERT(_engineType == ClusterEngineType::RocksDBEngine);
 
   if (_engineType == ClusterEngineType::RocksDBEngine) {
     merge.add(StaticStrings::CacheEnabled,

--- a/arangod/ClusterEngine/ClusterIndex.h
+++ b/arangod/ClusterEngine/ClusterIndex.h
@@ -40,6 +40,9 @@ class ClusterIndex : public Index {
                ClusterEngineType engineType, Index::IndexType type,
                arangodb::velocypack::Slice info);
 
+  ClusterIndex(ClusterIndex const&) = delete;
+  ClusterIndex& operator=(ClusterIndex const&) = delete;
+
   ~ClusterIndex();
 
   void toVelocyPackFigures(velocypack::Builder& builder) const override;

--- a/tests/js/common/shell/shell-collection.js
+++ b/tests/js/common/shell/shell-collection.js
@@ -1298,14 +1298,25 @@ function CollectionCacheSuite () {
       c.properties({cacheEnabled:false});
       p = c.properties();
       assertFalse(p.cacheEnabled, p);
-    }
+    },
+
+    testCollectionModifyPropertiesWithInvertedIndex : function () {
+      let c = db._create(cn);
+      c.ensureIndex({ type: "inverted", fields: [{ name: "value1" }], cacheEnabled: true });
+      let idx = c.indexes();
+      assertEqual("inverted", idx[1].type);
+      assertFalse(idx[1].hasOwnProperty("cacheEnabled"));
+
+      // update properties of collection
+      c.properties({ cacheEnabled: true });
+      // verify that cacheEnabledProperty is not there
+      idx = c.indexes();
+      assertEqual("inverted", idx[1].type);
+      assertFalse(idx[1].hasOwnProperty("cacheEnabled"));
+    },
+
   };
 }
-
-
-////////////////////////////////////////////////////////////////////////////////
-/// @brief executes the test suites
-////////////////////////////////////////////////////////////////////////////////
 
 jsunity.run(CollectionSuiteErrorHandling);
 jsunity.run(CollectionSuite);


### PR DESCRIPTION
### Scope & Purpose

Fix UB in collection properties updating if the collection had at least one inverted index and the operation was carried out in a cluster

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.10: https://github.com/arangodb/arangodb/pull/16709
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
