### PR TITLE
Make inspector able to read and write VPackBuilder

### DIFF
--- a/lib/Inspection/Access.h
+++ b/lib/Inspection/Access.h
@@ -35,6 +35,7 @@
 #include <velocypack/Value.h>
 
 #include "Inspection/detail/traits.h"
+#include "velocypack/Builder.h"
 #include "velocypack/Slice.h"
 
 namespace arangodb::inspection {
@@ -306,6 +307,24 @@ struct Access<std::monostate> : AccessBase<std::monostate> {
     } else {
       f.builder().add(VPackSlice::emptyObjectSlice());
       return Status::Success{};
+    }
+  }
+};
+
+template<>
+struct Access<VPackBuilder> : AccessBase<VPackBuilder> {
+  template<class Inspector>
+  static auto apply(Inspector& f, VPackBuilder& x) {
+    if constexpr (Inspector::isLoading) {
+      x.clear();
+      x.add(f.slice());
+      return Status{};
+    } else {
+      if (!x.isClosed()) {
+        return Status{"Exected closed VPackBuilder"};
+      }
+      f.builder().add(x.slice());
+      return Status{};
     }
   }
 };


### PR DESCRIPTION
### Scope & Purpose

Make the inspector able to handle a VPackBuilder inside a struct. This makes refactoring of old code to use Inspectors easier: Nested datastructures don't need to be refactored all the way down to use Inspectors, just put them inside a VPackBuilder in the struct. Then you can refactor this nested datastructure at another point and don't have to do it all at once.

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [x] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: *(Please link PR)*
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

