### PR TITLE
[PREGEL] Use message structs everywhere possible

### DIFF
--- a/arangod/Pregel/Conductor.cpp
+++ b/arangod/Pregel/Conductor.cpp
@@ -125,7 +125,7 @@ Conductor::Conductor(
                                    "Algorithm not found");
   }
   _masterContext.reset(_algorithm->masterContext(config));
-  _aggregators = std::make_shared<AggregatorHandler>(_algorithm.get());
+  _aggregators = std::make_unique<AggregatorHandler>(_algorithm.get());
 
   _maxSuperstep =
       VelocyPackHelper::getNumericValue(config, "maxGSS", _maxSuperstep);

--- a/arangod/Pregel/Conductor.cpp
+++ b/arangod/Pregel/Conductor.cpp
@@ -347,12 +347,6 @@ void Conductor::finishedWorkerStartup(VPackSlice const& data) {
 
   auto loadedEvent = deserialize<GraphLoaded>(data);
 
-  receive(loadedEvent);
-
-  // TODO remove when rest of function is moved to Computing state
-  if (_respondedServers.size() != _dbServers.size()) {
-    return;
-  }
   state->receive(loadedEvent);
 }
 

--- a/arangod/Pregel/Conductor.h
+++ b/arangod/Pregel/Conductor.h
@@ -111,7 +111,7 @@ class Conductor : public std::enable_shared_from_this<Conductor> {
       _edgeCollectionRestrictions;
 
   // initialized on startup
-  std::shared_ptr<AggregatorHandler> _aggregators;
+  std::unique_ptr<AggregatorHandler> _aggregators;
   std::unique_ptr<MasterContext> _masterContext;
   /// tracks the servers which responded, only used for stages where we expect
   /// an unique response, not necessarily during the async mode

--- a/arangod/Pregel/Conductor.h
+++ b/arangod/Pregel/Conductor.h
@@ -30,6 +30,7 @@
 #include "Cluster/ClusterInfo.h"
 #include "Pregel/Reports.h"
 #include "Pregel/Statistics.h"
+#include "Pregel/WorkerConductorMessages.h"
 #include "Scheduler/Scheduler.h"
 #include "Utils/DatabaseGuard.h"
 
@@ -150,7 +151,7 @@ class Conductor : public std::enable_shared_from_this<Conductor> {
                                 VPackBuilder const& message,
                                 std::function<void(VPackSlice)> handle);
   void _ensureUniqueResponse(std::string const& body);
-  void _createStartGssCommand(VPackBuilder& b, bool activateAll);
+  auto _startGssEvent(bool activateAll) const -> StartGss;
 
   // === REST callbacks ===
   void workerStatusUpdate(VPackSlice const& data);

--- a/arangod/Pregel/Conductor/CanceledState.cpp
+++ b/arangod/Pregel/Conductor/CanceledState.cpp
@@ -52,6 +52,18 @@ auto Canceled::receive(Message const& message) -> void {
         << static_cast<int>(message.type());
     return;
   }
+  auto event = static_cast<CleanupFinished const&>(message);
+  conductor._ensureUniqueResponse(event.senderId);
+  {
+    auto reports = event.reports.slice();
+    if (reports.isArray()) {
+      conductor._reports.appendFromSlice(reports);
+    }
+  }
+  if (conductor._respondedServers.size() != conductor._dbServers.size()) {
+    return;
+  }
+
   if (conductor._inErrorAbort) {
     conductor.changeState(StateType::FatalError);
     return;

--- a/arangod/Pregel/Conductor/StoringState.cpp
+++ b/arangod/Pregel/Conductor/StoringState.cpp
@@ -46,6 +46,18 @@ auto Storing::receive(Message const& message) -> void {
         << static_cast<int>(message.type());
     return;
   }
+  auto event = static_cast<CleanupFinished const&>(message);
+  conductor._ensureUniqueResponse(event.senderId);
+  {
+    auto reports = event.reports.slice();
+    if (reports.isArray()) {
+      conductor._reports.appendFromSlice(reports);
+    }
+  }
+  if (conductor._respondedServers.size() != conductor._dbServers.size()) {
+    return;
+  }
+
   if (conductor._inErrorAbort) {
     conductor.changeState(StateType::FatalError);
     return;

--- a/arangod/Pregel/Statistics.h
+++ b/arangod/Pregel/Statistics.h
@@ -25,6 +25,7 @@
 
 #include <velocypack/Builder.h>
 #include <velocypack/Slice.h>
+#include <cstdint>
 
 #include "Pregel/Utils.h"
 #include "Logger/LogMacros.h"
@@ -87,11 +88,8 @@ struct StatsManager {
     }
   }
 
-  void accumulateMessageStats(VPackSlice data) {
-    VPackSlice sender = data.get(Utils::senderKey);
-    if (sender.isString()) {
-      _serverStats[sender.copyString()].accumulate(data);
-    }
+  void accumulateMessageStats(std::string const& senderId, VPackSlice data) {
+    _serverStats[senderId].accumulate(data);
   }
 
   void serializeValues(VPackBuilder& b) const {

--- a/arangod/Pregel/Statistics.h
+++ b/arangod/Pregel/Statistics.h
@@ -89,6 +89,7 @@ struct StatsManager {
   }
 
   void accumulateMessageStats(std::string const& senderId, VPackSlice data) {
+    // inserts senderId into map if it does not exist
     _serverStats[senderId].accumulate(data);
   }
 

--- a/arangod/Pregel/Worker.h
+++ b/arangod/Pregel/Worker.h
@@ -32,6 +32,7 @@
 #include "Pregel/Algorithm.h"
 #include "Pregel/Statistics.h"
 #include "Pregel/Status/Status.h"
+#include "Pregel/WorkerConductorMessages.h"
 #include "Pregel/WorkerConfig.h"
 #include "Pregel/WorkerContext.h"
 #include "Reports.h"
@@ -159,8 +160,8 @@ class Worker : public IWorker {
   [[nodiscard]] auto _observeStatus() -> Status const;
   [[nodiscard]] auto _makeStatusCallback() -> std::function<void()>;
 
-  void _createGssFinishedEvent(VPackBuilder& b);
-  void _createExecutionFinishedEvent(VPackBuilder& b);
+  auto _gssFinishedEvent() const -> GssFinished;
+  auto _cleanupFinishedEvent() const -> CleanupFinished;
 
  public:
   Worker(TRI_vocbase_t& vocbase, Algorithm<V, E, M>* algorithm,

--- a/arangod/Pregel/Worker.h
+++ b/arangod/Pregel/Worker.h
@@ -113,8 +113,8 @@ class Worker : public IWorker {
   // where new vertices were inserted
   size_t _preRecoveryTotal = 0;
 
-  std::shared_ptr<AggregatorHandler> _conductorAggregators;
-  std::shared_ptr<AggregatorHandler> _workerAggregators;
+  std::unique_ptr<AggregatorHandler> _conductorAggregators;
+  std::unique_ptr<AggregatorHandler> _workerAggregators;
   std::unique_ptr<GraphStore<V, E>> _graphStore;
   std::unique_ptr<MessageFormat<M>> _messageFormat;
   std::unique_ptr<MessageCombiner<M>> _messageCombiner;
@@ -162,6 +162,7 @@ class Worker : public IWorker {
 
   auto _gssFinishedEvent() const -> GssFinished;
   auto _cleanupFinishedEvent() const -> CleanupFinished;
+  auto _recoveryFinishedEvent() const -> RecoveryFinished;
 
  public:
   Worker(TRI_vocbase_t& vocbase, Algorithm<V, E, M>* algorithm,

--- a/arangod/Pregel/WorkerConductorMessages.h
+++ b/arangod/Pregel/WorkerConductorMessages.h
@@ -211,7 +211,7 @@ auto inspect(Inspector& f, StartGss& x) {
       f.field(Utils::executionNumberKey, x.executionNumber),
       f.field(Utils::globalSuperstepKey, x.gss),
       f.field("vertexCount", x.vertexCount), f.field("edgeCount", x.edgeCount),
-      f.field("reset-all-active", x.activateAll),
+      f.field("activateAll", x.activateAll),
       f.field("masterToWorkerMessages", x.toWorkerMessages),
       f.field("aggregators", x.aggregators));
 }

--- a/lib/Inspection/Access.h
+++ b/lib/Inspection/Access.h
@@ -35,6 +35,7 @@
 #include <velocypack/Value.h>
 
 #include "Inspection/detail/traits.h"
+#include "velocypack/Builder.h"
 #include "velocypack/Slice.h"
 
 namespace arangodb::inspection {
@@ -306,6 +307,24 @@ struct Access<std::monostate> : AccessBase<std::monostate> {
     } else {
       f.builder().add(VPackSlice::emptyObjectSlice());
       return Status::Success{};
+    }
+  }
+};
+
+template<>
+struct Access<VPackBuilder> : AccessBase<VPackBuilder> {
+  template<class Inspector>
+  static auto apply(Inspector& f, VPackBuilder& x) {
+    if constexpr (Inspector::isLoading) {
+      x.clear();
+      x.add(f.slice());
+      return Status{};
+    } else {
+      if (!x.isClosed()) {
+        return Status{"Expected closed VPackBuilder"};
+      }
+      f.builder().add(x.slice());
+      return Status{};
     }
   }
 };


### PR DESCRIPTION
- Make inspector able to read and write VPackBuilder to ease the use of Inspectors for nested data structures
- Use message structs for StartGss, GssFinished and CleanupFinished messages
- Use VPackBuilder for aggregators in other structs (here I revert a change I made before to be able to create messages: Now with the VPackBuilder ability for Inspectors, we can change the aggregators back to be unique_ptrs (as they were originally).