### PR TITLE
Added serverId for _admin/log/level

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -14,6 +14,9 @@ devel
 
 * Updated Rclone to v1.59.0.
 
+* Add serverId parameter to _admin/log/level. Allows you to forward the request to
+  other servers.
+
 * Updated OpenSSL to 1.1.1q and OpenLDAP to 2.6.3.
 
 * Updated arangosync to v2.12.0-preview-2.

--- a/Documentation/DocuBlocks/Rest/Administration/get_admin_log.md
+++ b/Documentation/DocuBlocks/Rest/Administration/get_admin_log.md
@@ -165,6 +165,11 @@ is returned if there are insufficient privileges to access the logs.
 
 @RESTHEADER{GET /_admin/log/level, Return the current server log level}
 
+@RESTQUERYPARAMETERS
+
+@RESTQUERYPARAM{serverId,string,optional}
+Forwards the request to the specified server.
+
 @RESTDESCRIPTION
 Returns the server's current log level settings.
 The result is a JSON object with the log topics being the object keys, and
@@ -189,6 +194,11 @@ is returned if there are insufficient privileges to read log levels.
 @brief modifies the current log level settings
 
 @RESTHEADER{PUT /_admin/log/level, Modify and return the current server log level}
+
+@RESTQUERYPARAMETERS
+
+@RESTQUERYPARAM{serverId,string,optional}
+Forwards the request to the specified server.
 
 @RESTDESCRIPTION
 Modifies and returns the server's current log level settings.

--- a/arangod/RestHandler/RestAdminLogHandler.cpp
+++ b/arangod/RestHandler/RestAdminLogHandler.cpp
@@ -111,7 +111,7 @@ RestStatus RestAdminLogHandler::execute() {
     } else if (suffixes.size() == 1 && suffixes[0] == "entries") {
       return reportLogs(/*newFormat*/ true);
     } else if (suffixes.size() == 1 && suffixes[0] == "level") {
-      handleLogLevel();
+      return handleLogLevel();
     } else if (suffixes.size() == 1 && suffixes[0] == "structured") {
       handleLogStructuredParams();
     } else {
@@ -123,7 +123,7 @@ RestStatus RestAdminLogHandler::execute() {
   } else if (type == rest::RequestType::PUT) {
     if (suffixes.size() == 1) {
       if (suffixes[0] == "level") {
-        handleLogLevel();
+        return handleLogLevel();
       } else if (suffixes[0] == "structured") {
         handleLogStructuredParams();
       } else {
@@ -428,16 +428,88 @@ RestStatus RestAdminLogHandler::reportLogs(bool newFormat) {
   return RestStatus::DONE;
 }
 
-void RestAdminLogHandler::handleLogLevel() {
+RestStatus RestAdminLogHandler::handleLogLevel() {
   std::vector<std::string> const& suffixes = _request->suffixes();
-
   // was validated earlier
   TRI_ASSERT(!suffixes.empty());
 
   if (suffixes[0] != "level") {
     generateError(rest::ResponseCode::BAD, TRI_ERROR_HTTP_SUPERFLUOUS_SUFFICES,
                   "superfluous suffix, expecting /_admin/log/level");
-    return;
+    return RestStatus::DONE;
+  }
+
+  bool foundServerIdParameter;
+  std::string const& serverId =
+      _request->value("serverId", foundServerIdParameter);
+
+  if (ServerState::instance()->isCoordinator() && foundServerIdParameter) {
+    if (serverId != ServerState::instance()->getId()) {
+      // not ourselves! - need to pass through the request
+      auto& ci = server().getFeature<ClusterFeature>().clusterInfo();
+
+      bool found = false;
+      for (auto const& srv : ci.getServers()) {
+        // validate if server id exists
+        if (srv.first == serverId) {
+          found = true;
+          break;
+        }
+      }
+
+      if (!found) {
+        generateError(rest::ResponseCode::NOT_FOUND,
+                      TRI_ERROR_HTTP_BAD_PARAMETER,
+                      std::string("unknown serverId supplied."));
+        return RestStatus::DONE;
+      }
+
+      NetworkFeature const& nf = server().getFeature<NetworkFeature>();
+      network::ConnectionPool* pool = nf.pool();
+      if (pool == nullptr) {
+        THROW_ARANGO_EXCEPTION(TRI_ERROR_SHUTTING_DOWN);
+      }
+
+      network::RequestOptions options;
+      options.timeout = network::Timeout(30.0);
+      options.database = _request->databaseName();
+      options.parameters = _request->parameters();
+
+      auto requestType = fuerte::from_string(
+          GeneralRequest::translateMethod(_request->requestType()));
+
+      auto body = std::invoke([&]() -> std::optional<VPackBuffer<uint8_t>> {
+        if (_request->requestType() == rest::RequestType::GET) {
+          return VPackBuffer<uint8_t>{};
+        }
+
+        bool parseSuccess = false;
+        VPackSlice slice = this->parseVPackBody(parseSuccess);
+        if (!parseSuccess) {
+          return std::nullopt;  // error message generated in parseVPackBody
+        }
+        auto buffer = VPackBuffer<uint8_t>{};
+        buffer.append(slice.start(), slice.byteSize());
+        return buffer;
+      });
+
+      if (!body.has_value()) {
+        return RestStatus::DONE;  // error message from vpack parser
+      }
+
+      auto f = network::sendRequestRetry(
+          pool, "server:" + serverId, requestType, _request->requestPath(),
+          std::move(*body), options, buildHeaders(_request->headers()));
+      return waitForFuture(std::move(f).thenValue(
+          [self = std::dynamic_pointer_cast<RestAdminLogHandler>(
+               shared_from_this())](network::Response const& r) {
+            if (r.fail()) {
+              self->generateError(r.combinedResult());
+            } else {
+              self->generateResult(rest::ResponseCode::OK, r.slice());
+            }
+          }));
+    }
   }
 
   auto const type = _request->requestType();
@@ -459,7 +531,7 @@ void RestAdminLogHandler::handleLogLevel() {
     bool parseSuccess = false;
     VPackSlice slice = this->parseVPackBody(parseSuccess);
     if (!parseSuccess) {
-      return;  // error message generated in parseVPackBody
+      return RestStatus::DONE;  // error message generated in parseVPackBody
     }
 
     if (slice.isString()) {
@@ -497,6 +569,8 @@ void RestAdminLogHandler::handleLogLevel() {
     generateError(rest::ResponseCode::METHOD_NOT_ALLOWED,
                   TRI_ERROR_HTTP_METHOD_NOT_ALLOWED);
   }
+
+  return RestStatus::DONE;
 }
 
 void RestAdminLogHandler::handleLogStructuredParams() {

--- a/arangod/RestHandler/RestAdminLogHandler.h
+++ b/arangod/RestHandler/RestAdminLogHandler.h
@@ -46,7 +46,7 @@ class RestAdminLogHandler : public RestBaseHandler {
   arangodb::Result verifyPermitted();
   void clearLogs();
   RestStatus reportLogs(bool newFormat);
-  void handleLogLevel();
+  RestStatus handleLogLevel();
   void handleLogStructuredParams();
 };
 }  // namespace arangodb

--- a/tests/js/client/shell/shell-admin-log.js
+++ b/tests/js/client/shell/shell-admin-log.js
@@ -29,7 +29,6 @@ const request = require('@arangodb/request');
 const helper = require('@arangodb/test-helper');
 const _ = require("lodash");
 
-
 const dbservers = (function () {
   const isType = (d) => (d.instanceRole.toLowerCase() === "dbserver");
   const instanceInfo = JSON.parse(internal.env.INSTANCEINFO);
@@ -106,6 +105,9 @@ function adminLogSuite() {
     },
 
     testPutAdminLogLevelOtherServer: function () {
+      if (dbservers.length === 0) {
+        return;
+      }
       const server = dbservers[0];
       const url = helper.getEndpointById(server);
       const old = request.get(`${url}/_admin/log/level`);

--- a/tests/js/client/shell/shell-admin-log.js
+++ b/tests/js/client/shell/shell-admin-log.js
@@ -24,43 +24,54 @@
 // //////////////////////////////////////////////////////////////////////////////
 
 const jsunity = require('jsunity');
+const internal = require("internal");
+const request = require('@arangodb/request');
+const helper = require('@arangodb/test-helper');
+const _ = require("lodash");
+
+
+const dbservers = (function () {
+  const isType = (d) => (d.instanceRole.toLowerCase() === "dbserver");
+  const instanceInfo = JSON.parse(internal.env.INSTANCEINFO);
+  return instanceInfo.arangods.filter(isType).map((x) => x.id);
+})();
 
 function adminLogSuite() {
   'use strict';
-      
-  let log = function(level) {
+
+  let log = function (level) {
     arango.POST("/_admin/execute", `for (let i = 0; i < 50; ++i) require('console')._log('general=${level}', 'testi');`);
   };
 
   let oldLogLevel;
 
   return {
-    setUpAll : function() {
+    setUpAll: function () {
       oldLogLevel = arango.GET("/_admin/log/level").general;
-      arango.PUT("/_admin/log/level", { general: "info" });
+      arango.PUT("/_admin/log/level", {general: "info"});
     },
 
-    tearDownAll : function () {
+    tearDownAll: function () {
       // restore previous log level for "general" topic;
-      arango.PUT("/_admin/log/level", { general: oldLogLevel });
+      arango.PUT("/_admin/log/level", {general: oldLogLevel});
     },
 
-    setUp : function() {
+    setUp: function () {
       arango.DELETE("/_admin/log");
     },
-    
+
     testPutAdminSetAllLevels: function () {
       let previous = arango.GET("/_admin/log/level");
       try {
         // set all log levels to trace
-        let res = arango.PUT("/_admin/log/level", { all: "trace" });
+        let res = arango.PUT("/_admin/log/level", {all: "trace"});
         Object.keys(res).forEach((topic) => {
           assertEqual(res[topic], "TRACE");
         });
-      
+
         // delete all exiting log messages
         arango.DELETE("/_admin/log");
-      
+
         log("trace");
         // wait until we have at least 5 log messages (should not
         // take long with all log levels set to trace)
@@ -80,7 +91,7 @@ function adminLogSuite() {
         Object.keys(res).forEach((topic) => {
           assertEqual(res[topic], "TRACE");
         });
-        res = arango.PUT("/_admin/log/level", { all: "info", syscall: "trace" });
+        res = arango.PUT("/_admin/log/level", {all: "info", syscall: "trace"});
         Object.keys(res).forEach((topic) => {
           if (topic === "syscall") {
             assertEqual(res[topic], "TRACE");
@@ -92,6 +103,23 @@ function adminLogSuite() {
         // cleanup
         arango.PUT("/_admin/log/level", previous);
       }
+    },
+
+    testPutAdminLogLevelOtherServer: function () {
+      const server = dbservers[0];
+      const url = helper.getEndpointById(server);
+      const old = request.get(`${url}/_admin/log/level`);
+      // change the value via coordinator
+      let res = arango.PUT(`/_admin/log/level?serverId=${server}`, {"trx": "trace"});
+      assertEqual(res.trx, "TRACE");
+      // read directly from dbserver
+      const newValue = request.get(`${url}/_admin/log/level`);
+      assertEqual(newValue.json.trx, "TRACE");
+      // restore old value
+      request.put(`${url}/_admin/log/level`, {body: {"trx": old.json.trx}, json: true});
+      // now read the restored value
+      const newOld = arango.GET(`/_admin/log/level?serverId=${server}`);
+      assertEqual(old.json.trx, newOld.trx);
     },
 
     testGetAdminLogOldFormat: function () {
@@ -107,7 +135,7 @@ function adminLogSuite() {
       assertEqual(50, res.text.length, res);
       res.text.forEach((t) => assertMatch(/testi/, t, res));
     },
-    
+
     testGetAdminLogNewFormat: function () {
       log("warn");
       let res = arango.GET("/_admin/log/entries?upto=warning");
@@ -126,20 +154,20 @@ function adminLogSuite() {
         assertMatch(/testi/, entry.message);
       });
     },
-    
+
     testGetAdminLogNewFormatUpToFatal: function () {
       log("fatal");
-      
+
       let res = arango.GET("/_admin/log/entries?upto=fatal");
       assertTrue(Array.isArray(res.messages));
       assertEqual(50, res.messages.length);
       assertEqual(50, res.total);
-      
+
       res = arango.GET("/_admin/log/entries?upto=err");
       assertTrue(Array.isArray(res.messages));
       assertEqual(50, res.messages.length);
       assertEqual(50, res.total);
-      
+
       res = arango.GET("/_admin/log/entries?upto=warning");
       assertTrue(Array.isArray(res.messages));
       assertEqual(50, res.messages.length);
@@ -150,20 +178,20 @@ function adminLogSuite() {
       assertEqual(50, res.messages.length);
       assertEqual(50, res.total);
     },
-    
+
     testGetAdminLogNewFormatUpToErr: function () {
       log("error");
-      
+
       let res = arango.GET("/_admin/log/entries?upto=fatal");
       assertTrue(Array.isArray(res.messages));
       assertEqual(0, res.messages.length);
       assertEqual(0, res.total);
-      
+
       res = arango.GET("/_admin/log/entries?upto=error");
       assertTrue(Array.isArray(res.messages));
       assertEqual(50, res.messages.length);
       assertEqual(50, res.total);
-      
+
       res = arango.GET("/_admin/log/entries?upto=warning");
       assertTrue(Array.isArray(res.messages));
       assertEqual(50, res.messages.length);
@@ -174,20 +202,20 @@ function adminLogSuite() {
       assertEqual(50, res.messages.length);
       assertEqual(50, res.total);
     },
-    
+
     testGetAdminLogNewFormatUpToWarn: function () {
       log("warn");
-      
+
       let res = arango.GET("/_admin/log/entries?upto=fatal");
       assertTrue(Array.isArray(res.messages));
       assertEqual(0, res.messages.length);
       assertEqual(0, res.total);
-      
+
       res = arango.GET("/_admin/log/entries?upto=err");
       assertTrue(Array.isArray(res.messages));
       assertEqual(0, res.messages.length);
       assertEqual(0, res.total);
-      
+
       res = arango.GET("/_admin/log/entries?upto=warning");
       assertTrue(Array.isArray(res.messages));
       assertEqual(50, res.messages.length);
@@ -198,20 +226,20 @@ function adminLogSuite() {
       assertEqual(50, res.messages.length);
       assertEqual(50, res.total);
     },
-    
+
     testGetAdminLogNewFormatUpToInfo: function () {
       log("info");
-      
+
       let res = arango.GET("/_admin/log/entries?upto=fatal");
       assertTrue(Array.isArray(res.messages));
       assertEqual(0, res.messages.length);
       assertEqual(0, res.total);
-      
+
       res = arango.GET("/_admin/log/entries?upto=err");
       assertTrue(Array.isArray(res.messages));
       assertEqual(0, res.messages.length);
       assertEqual(0, res.total);
-      
+
       res = arango.GET("/_admin/log/entries?upto=warning");
       assertTrue(Array.isArray(res.messages));
       assertEqual(0, res.messages.length);
@@ -222,7 +250,7 @@ function adminLogSuite() {
       assertEqual(50, res.messages.length);
       assertEqual(50, res.total);
     },
-    
+
     testGetAdminLogNewFormatReverse: function () {
       log("warn");
       let res = arango.GET("/_admin/log/entries?upto=warning&sort=desc");
@@ -241,7 +269,7 @@ function adminLogSuite() {
         assertMatch(/testi/, entry.message);
       });
     },
-    
+
     testGetAdminLogNewFormatSearch: function () {
       log("warn");
       let res = arango.GET("/_admin/log/entries?upto=warning&search=testi");
@@ -252,7 +280,7 @@ function adminLogSuite() {
       res.messages.forEach((entry) => {
         assertMatch(/testi/, entry.message);
       });
-      
+
       res = arango.GET("/_admin/log/entries?upto=warning&search=testi&size=5");
       assertTrue(Array.isArray(res.messages));
       assertEqual(5, res.messages.length);
@@ -261,13 +289,13 @@ function adminLogSuite() {
       res.messages.forEach((entry) => {
         assertMatch(/testi/, entry.message);
       });
-      
+
       res = arango.GET("/_admin/log/entries?upto=warning&search=fuxxmann");
       assertTrue(Array.isArray(res.messages));
       assertEqual(0, res.total);
       assertEqual(0, res.messages.length);
     },
-    
+
     testGetAdminLogNewFormatSize: function () {
       log("warn");
       let res = arango.GET("/_admin/log/entries?upto=warning&size=4");
@@ -279,23 +307,23 @@ function adminLogSuite() {
       assertTrue(Array.isArray(res.messages));
       assertEqual(10, res.messages.length);
       assertEqual(50, res.total);
-      
+
       res = arango.GET("/_admin/log/entries?upto=warning&size=50");
       assertTrue(Array.isArray(res.messages));
       assertEqual(50, res.messages.length);
       assertEqual(50, res.total);
-      
+
       res = arango.GET("/_admin/log/entries?upto=warning&size=52");
       assertTrue(Array.isArray(res.messages));
       assertEqual(50, res.messages.length);
       assertEqual(50, res.total);
-      
+
       res = arango.GET("/_admin/log/entries?upto=warning&size=100000");
       assertTrue(Array.isArray(res.messages));
       assertEqual(50, res.messages.length);
       assertEqual(50, res.total);
     },
-   
+
     testGetAdminLogNewFormatOffset: function () {
       log("warn");
       let res = arango.GET("/_admin/log/entries?upto=warning&offset=0&size=4");
@@ -307,57 +335,57 @@ function adminLogSuite() {
       assertTrue(Array.isArray(res.messages));
       assertEqual(10, res.messages.length);
       assertEqual(50, res.total);
-      
+
       res = arango.GET("/_admin/log/entries?upto=warning&offset=0&size=49");
       assertTrue(Array.isArray(res.messages));
       assertEqual(49, res.messages.length);
       assertEqual(50, res.total);
-      
+
       res = arango.GET("/_admin/log/entries?upto=warning&offset=0&size=50");
       assertTrue(Array.isArray(res.messages));
       assertEqual(50, res.messages.length);
       assertEqual(50, res.total);
-      
+
       res = arango.GET("/_admin/log/entries?upto=warning&offset=0&size=51");
       assertTrue(Array.isArray(res.messages));
       assertEqual(50, res.messages.length);
       assertEqual(50, res.total);
-      
+
       res = arango.GET("/_admin/log/entries?upto=warning&offset=0&size=100000");
       assertTrue(Array.isArray(res.messages));
       assertEqual(50, res.messages.length);
       assertEqual(50, res.total);
-      
+
       res = arango.GET("/_admin/log/entries?upto=warning&offset=48&size=0");
       assertTrue(Array.isArray(res.messages));
       assertEqual(0, res.messages.length);
       assertEqual(50, res.total);
-      
+
       res = arango.GET("/_admin/log/entries?upto=warning&offset=48&size=1");
       assertTrue(Array.isArray(res.messages));
       assertEqual(1, res.messages.length);
       assertEqual(50, res.total);
-      
+
       res = arango.GET("/_admin/log/entries?upto=warning&offset=48&size=2");
       assertTrue(Array.isArray(res.messages));
       assertEqual(2, res.messages.length);
       assertEqual(50, res.total);
-      
+
       res = arango.GET("/_admin/log/entries?upto=warning&offset=48&size=3");
       assertTrue(Array.isArray(res.messages));
       assertEqual(2, res.messages.length);
       assertEqual(50, res.total);
-      
+
       res = arango.GET("/_admin/log/entries?upto=warning&offset=49&size=0");
       assertTrue(Array.isArray(res.messages));
       assertEqual(0, res.messages.length);
       assertEqual(50, res.total);
-      
+
       res = arango.GET("/_admin/log/entries?upto=warning&offset=49&size=1");
       assertTrue(Array.isArray(res.messages));
       assertEqual(1, res.messages.length);
       assertEqual(50, res.total);
-      
+
       res = arango.GET("/_admin/log/entries?upto=warning&offset=49&size=2");
       assertTrue(Array.isArray(res.messages));
       assertEqual(1, res.messages.length);
@@ -367,18 +395,18 @@ function adminLogSuite() {
       assertTrue(Array.isArray(res.messages));
       assertEqual(0, res.messages.length);
       assertEqual(50, res.total);
-      
+
       res = arango.GET("/_admin/log/entries?upto=warning&offset=50&size=1");
       assertTrue(Array.isArray(res.messages));
       assertEqual(0, res.messages.length);
       assertEqual(50, res.total);
-      
+
       res = arango.GET("/_admin/log/entries?upto=warning&offset=50&size=100");
       assertTrue(Array.isArray(res.messages));
       assertEqual(0, res.messages.length);
       assertEqual(50, res.total);
     },
-    
+
   };
 }
 


### PR DESCRIPTION
### Scope & Purpose
Allows you to forward the request to another server. On Coordinators we can use normal user authentication. This is not available on DBServers and therefore until know it was necessary to work with JWT headers.