### PR TITLE
[PREGEL] Hide (de)serialization of messages inside Conductor::sendToAllDBServers function

### DIFF
--- a/arangod/Aql/Functions.cpp
+++ b/arangod/Aql/Functions.cpp
@@ -59,10 +59,12 @@
 #include "IResearch/IResearchPDP.h"
 #include "IResearch/VelocyPackHelper.h"
 #include "Indexes/Index.h"
+#include "Inspection/VPack.h"
 #include "Logger/Logger.h"
 #include "Pregel/Conductor.h"
 #include "Pregel/PregelFeature.h"
 #include "Pregel/Worker.h"
+#include "Pregel/WorkerConductorMessages.h"
 #include "Random/UniformCharacter.h"
 #include "Rest/Version.h"
 #include "RestServer/SystemDatabaseFeature.h"
@@ -8701,7 +8703,11 @@ AqlValue functions::PregelResult(ExpressionContext* expressionContext,
       registerWarning(expressionContext, AFN, TRI_ERROR_HTTP_NOT_FOUND);
       return AqlValue(AqlValueHintEmptyArray());
     }
-    worker->aqlResult(builder, withId);
+    VPackBuilder response;
+    worker->aqlResult(response, withId);
+    builder.openArray();
+    builder.add(VPackArrayIterator(response.slice().get("results")));
+    builder.close();
   }
 
   if (builder.isEmpty()) {

--- a/arangod/Pregel/Conductor.h
+++ b/arangod/Pregel/Conductor.h
@@ -145,11 +145,9 @@ class Conductor : public std::enable_shared_from_this<Conductor> {
   bool _startGlobalStep();
   ErrorCode _initializeWorkers(std::string const& suffix,
                                VPackSlice additional);
-  ErrorCode _sendToAllDBServers(std::string const& path,
-                                VPackBuilder const& message);
-  ErrorCode _sendToAllDBServers(std::string const& path,
-                                VPackBuilder const& message,
-                                std::function<void(VPackSlice)> handle);
+  template<typename OutType, typename InType>
+  auto _sendToAllDBServers(std::string const& path, InType const& message)
+      -> ResultT<std::vector<OutType>>;
   void _ensureUniqueResponse(std::string const& body);
   auto _startGssEvent(bool activateAll) const -> StartGss;
 

--- a/arangod/Pregel/Conductor/DoneState.cpp
+++ b/arangod/Pregel/Conductor/DoneState.cpp
@@ -4,6 +4,8 @@
 #include "Pregel/AggregatorHandler.h"
 #include "Pregel/Conductor.h"
 #include "Pregel/WorkerConductorMessages.h"
+#include "velocypack/Builder.h"
+#include "velocypack/Iterator.h"
 
 using namespace arangodb::pregel::conductor;
 
@@ -54,19 +56,17 @@ auto Done::receive(Message const& message) -> void {
 auto Done::getResults(bool withId, VPackBuilder& out) -> void {
   auto collectPregelResultsCommand = CollectPregelResults{
       .executionNumber = conductor._executionNumber, .withId = withId};
-  VPackBuilder message;
-  serialize(message, collectPregelResultsCommand);
-
-  // merge results from DBServers
-  out.openArray();
-  auto res = conductor._sendToAllDBServers(
-      Utils::aqlResultsPath, message, [&](VPackSlice const& payload) {
-        if (payload.isArray()) {
-          out.add(VPackArrayIterator(payload));
-        }
-      });
-  out.close();
-  if (res != TRI_ERROR_NO_ERROR) {
-    THROW_ARANGO_EXCEPTION(res);
+  auto response = conductor._sendToAllDBServers<PregelResults>(
+      Utils::aqlResultsPath, collectPregelResultsCommand);
+  if (response.fail()) {
+    THROW_ARANGO_EXCEPTION(response.errorNumber());
+  }
+  {
+    VPackArrayBuilder ab(&out);
+    for (auto const& message : response.get()) {
+      if (message.results.slice().isArray()) {
+        out.add(VPackArrayIterator(message.results.slice()));
+      }
+    }
   }
 }

--- a/arangod/Pregel/Conductor/StoringState.cpp
+++ b/arangod/Pregel/Conductor/StoringState.cpp
@@ -28,14 +28,15 @@ auto Storing::run() -> void {
 
   LOG_PREGEL_CONDUCTOR("fc187", DEBUG) << "Finalizing workers";
 
-  auto finalizeExecutionCommand =
-      FinalizeExecution{.executionNumber = conductor._executionNumber,
-                        .gss = conductor._globalSuperstep,
-                        .withStoring = true};
-  VPackBuilder command;
-  serialize(command, finalizeExecutionCommand);
-
-  conductor._sendToAllDBServers(Utils::finalizeExecutionPath, command);
+  auto startCleanupCommand =
+      StartCleanup{.executionNumber = conductor._executionNumber,
+                   .gss = conductor._globalSuperstep,
+                   .withStoring = true};
+  auto response = conductor._sendToAllDBServers<CleanupStarted>(
+      Utils::finalizeExecutionPath, startCleanupCommand);
+  if (response.fail()) {
+    LOG_PREGEL_CONDUCTOR("f382d", ERR) << "Cleanup could not be started";
+  }
 }
 
 auto Storing::receive(Message const& message) -> void {

--- a/arangod/Pregel/PregelFeature.cpp
+++ b/arangod/Pregel/PregelFeature.cpp
@@ -55,6 +55,7 @@
 #include "VocBase/LogicalCollection.h"
 #include "VocBase/ticks.h"
 #include "Metrics/MetricsFeature.h"
+#include "velocypack/Builder.h"
 
 using namespace arangodb;
 using namespace arangodb::options;
@@ -736,16 +737,26 @@ void PregelFeature::handleWorkerRequest(TRI_vocbase_t& vocbase,
     w->prepareGlobalStep(body, outBuilder);
   } else if (path == Utils::startGSSPath) {
     w->startGlobalStep(body);
+    auto response = GssStarted{};
+    serialize(outBuilder, response);
   } else if (path == Utils::messagesPath) {
     w->receivedMessages(body);
   } else if (path == Utils::cancelGSSPath) {
     w->cancelGlobalStep(body);
+    auto response = GssCanceled{};
+    serialize(outBuilder, response);
   } else if (path == Utils::finalizeExecutionPath) {
     w->finalizeExecution(body, [this, exeNum]() { cleanupWorker(exeNum); });
+    auto response = CleanupStarted{};
+    serialize(outBuilder, response);
   } else if (path == Utils::continueRecoveryPath) {
     w->compensateStep(body);
+    auto response = RecoveryContinued{};
+    serialize(outBuilder, response);
   } else if (path == Utils::finalizeRecoveryPath) {
     w->finalizeRecovery(body);
+    auto response = RecoveryFinalized{};
+    serialize(outBuilder, response);
   } else if (path == Utils::aqlResultsPath) {
     auto command = deserialize<CollectPregelResults>(body);
     w->aqlResult(outBuilder, command.withId);

--- a/arangod/Pregel/Statistics.h
+++ b/arangod/Pregel/Statistics.h
@@ -78,14 +78,8 @@ struct MessageStats {
 };
 
 struct StatsManager {
-  void accumulateActiveCounts(VPackSlice data) {
-    VPackSlice sender = data.get(Utils::senderKey);
-    if (sender.isString()) {
-      VPackSlice active = data.get(Utils::activeCountKey);
-      if (active.isInteger()) {
-        _activeStats[sender.copyString()] += active.getUInt();
-      }
-    }
+  void accumulateActiveCounts(std::string const& sender, uint64_t count) {
+    _activeStats[sender] += count;
   }
 
   void accumulateMessageStats(std::string const& senderId, VPackSlice data) {

--- a/arangod/Pregel/WorkerConductorMessages.h
+++ b/arangod/Pregel/WorkerConductorMessages.h
@@ -164,6 +164,63 @@ auto inspect(Inspector& f, StatusUpdated& x) {
       f.field("status", x.status));
 }
 
+// worker -> conductor as immediate answer
+
+struct GssPrepared {
+  std::string senderId;
+  uint64_t activeCount;
+  uint64_t vertexCount;
+  uint64_t edgeCount;
+  VPackBuilder messages;
+  VPackBuilder aggregators;
+};
+template<typename Inspector>
+auto inspect(Inspector& f, GssPrepared& x) {
+  return f.object(x).fields(
+      f.field(Utils::senderKey, x.senderId),
+      f.field("activeCount", x.activeCount),
+      f.field("vertexCount", x.vertexCount), f.field("edgeCount", x.edgeCount),
+      f.field("messages", x.messages), f.field("aggregators", x.aggregators));
+}
+
+struct PregelResults {
+  VPackBuilder results;
+};
+template<typename Inspector>
+auto inspect(Inspector& f, PregelResults& x) {
+  return f.object(x).fields(f.field("results", x.results));
+}
+
+struct GssStarted {};
+template<typename Inspector>
+auto inspect(Inspector& f, GssStarted& x) {
+  return f.object(x).fields();
+}
+
+struct CleanupStarted {};
+template<typename Inspector>
+auto inspect(Inspector& f, CleanupStarted& x) {
+  return f.object(x).fields();
+}
+
+struct GssCanceled {};
+template<typename Inspector>
+auto inspect(Inspector& f, GssCanceled& x) {
+  return f.object(x).fields();
+}
+
+struct RecoveryFinalized {};
+template<typename Inspector>
+auto inspect(Inspector& f, RecoveryFinalized& x) {
+  return f.object(x).fields();
+}
+
+struct RecoveryContinued {};
+template<typename Inspector>
+auto inspect(Inspector& f, RecoveryContinued& x) {
+  return f.object(x).fields();
+}
+
 // ------ commands sent from conductor to worker -------
 
 struct PrepareGss {
@@ -214,14 +271,14 @@ auto inspect(Inspector& f, CancelGss& x) {
       f.field(Utils::globalSuperstepKey, x.gss));
 }
 
-struct FinalizeExecution {
+struct StartCleanup {
   uint64_t executionNumber;
   uint64_t gss;
   bool withStoring;
 };
 
 template<typename Inspector>
-auto inspect(Inspector& f, FinalizeExecution& x) {
+auto inspect(Inspector& f, StartCleanup& x) {
   return f.object(x).fields(
       f.field(Utils::executionNumberKey, x.executionNumber),
       f.field(Utils::globalSuperstepKey, x.gss),


### PR DESCRIPTION
Rewrite Conductor::sendToAllDBServers function to get a struct (the message that is send to all workers) and return a vector of structs (the responses from all servers) instead of handling with VPackBuilders and callbacks.