### PR TITLE
bug-fix/FE-139 Apply node color correctly after receiving data

### DIFF
--- a/js/apps/system/_admin/aardvark/APP/aardvark.js
+++ b/js/apps/system/_admin/aardvark/APP/aardvark.js
@@ -1334,6 +1334,7 @@ authRouter.get('/g6graph/:name', function (req, res) {
         sizeCategory: sizeCategory || '',
         style: {
           fill: calculatedNodeColor,
+          stroke: calculatedNodeColor,
           label: {
             value: nodeLabel
           }


### PR DESCRIPTION
### Scope & Purpose

After clicking the "run"-button an unwanted stroke was added in the wrong color to the nodes. This PR fixes the issue.

- [x] :hankey: Bugfix

### Checklist

- [x] Manually tested

#### Related Information

- [x] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/FE-139

