### PR TITLE
Bug fix/fe 142 remove edge after cancel

### DIFF
--- a/js/apps/system/_admin/aardvark/APP/react/src/views/g6graphs/AddEdgeModal.js
+++ b/js/apps/system/_admin/aardvark/APP/react/src/views/g6graphs/AddEdgeModal.js
@@ -28,7 +28,7 @@ const StyledButton = styled.button`
   color: white !important;
 `;
 
-export const AddEdgeModal = ({ edgeModelToAdd, shouldShow, onUpdateEdge, onRequestClose, edge, edgeCollections, edgeData, editorContent, children, edgeKey, edgeCollection, onEdgeCreation, graphName, graphData, nodeFrom, nodeTo }) => {
+export const AddEdgeModal = ({ edgeModelToAdd, shouldShow, onUpdateEdge, onRequestClose, edge, edgeCollections, edgeData, editorContent, children, edgeKey, edgeCollection, onEdgeCreation, graphName, graphData, nodeFrom, nodeTo, onEdgeCreationCancellation }) => {
 
   const { Option } = Select;
   const keyInputRef = useRef();
@@ -70,6 +70,11 @@ export const AddEdgeModal = ({ edgeModelToAdd, shouldShow, onUpdateEdge, onReque
         arangoHelper.arangoError('Graph', 'Could not create edge.');
       }
     });
+  }
+
+  const cancelEdge = (updateEdgeId) => {
+    onEdgeCreationCancellation(edgeModelToAdd);
+    onRequestClose();
   }
 
   const handleChange = (value) => {
@@ -126,7 +131,7 @@ export const AddEdgeModal = ({ edgeModelToAdd, shouldShow, onUpdateEdge, onReque
           }
         </div>
         <div style={{ 'marginTop': '38px', 'textAlign': 'right' }}>
-          <StyledButton className="button-close" onClick={onRequestClose}>Cancel</StyledButton>
+          <StyledButton className="button-close" onClick={() => cancelEdge(edge)}>Cancel</StyledButton>
           <StyledButton className="button-success" onClick={() => { addEdge(edge) }}>Create</StyledButton>
         </div>
       </ModalBody>

--- a/js/apps/system/_admin/aardvark/APP/react/src/views/g6graphs/AddEdgeModal.js
+++ b/js/apps/system/_admin/aardvark/APP/react/src/views/g6graphs/AddEdgeModal.js
@@ -63,7 +63,7 @@ export const AddEdgeModal = ({ edgeModelToAdd, shouldShow, onUpdateEdge, onReque
         };
         openNotificationWithIcon(response.edge._id);
         onEdgeCreation(edgeModel);
-        onRequestClose();
+        onRequestClose(true);
       },
       error: function (response) {
         console.log("Error: Could not create edge: ", response);
@@ -72,9 +72,9 @@ export const AddEdgeModal = ({ edgeModelToAdd, shouldShow, onUpdateEdge, onReque
     });
   }
 
-  const cancelEdge = (updateEdgeId) => {
-    onEdgeCreationCancellation(edgeModelToAdd);
-    onRequestClose();
+  const cancelEdge = () => {
+    onEdgeCreationCancellation();
+    onRequestClose(false);
   }
 
   const handleChange = (value) => {
@@ -82,7 +82,7 @@ export const AddEdgeModal = ({ edgeModelToAdd, shouldShow, onUpdateEdge, onReque
   }
 
   return shouldShow ? (
-    <ModalBackground onClick={onRequestClose}>
+    <ModalBackground onClick={() => onRequestClose(false)}>
       <ModalBody onClick={(e) => e.stopPropagation()}>
         <div>
           {children}<br />
@@ -131,7 +131,7 @@ export const AddEdgeModal = ({ edgeModelToAdd, shouldShow, onUpdateEdge, onReque
           }
         </div>
         <div style={{ 'marginTop': '38px', 'textAlign': 'right' }}>
-          <StyledButton className="button-close" onClick={() => cancelEdge(edge)}>Cancel</StyledButton>
+          <StyledButton className="button-close" onClick={() => cancelEdge()}>Cancel</StyledButton>
           <StyledButton className="button-success" onClick={() => { addEdge(edge) }}>Create</StyledButton>
         </div>
       </ModalBody>

--- a/js/apps/system/_admin/aardvark/APP/react/src/views/g6graphs/G6JsGraph.jsx
+++ b/js/apps/system/_admin/aardvark/APP/react/src/views/g6graphs/G6JsGraph.jsx
@@ -188,6 +188,40 @@ const G6JsGraph = () => {
     setGraphData(newGraphData);
   }
 
+  const removeDrawnEdge = (newEdge) => {
+    // Add edge first to register it in graphData
+    const currentNodes = graphData.nodes;
+    const newGraphData = {
+      nodes: [
+        ...currentNodes,
+      ],
+      edges: [
+        ...graphData.edges,
+        newEdge
+      ]
+    };
+    setGraphData(newGraphData);
+
+    // Remove edge first to register it in graphData
+    const edgesWithoutRemovedEdge = graphData.edges.filter(edges => edges.id !== newEdge);
+    const currentNodes2 = graphData.nodes;
+    const currentSettings = graphData.settings;
+
+    const newGraphData2 = {
+      nodes: [
+        ...currentNodes2
+      ],
+      edges: [
+        ...edgesWithoutRemovedEdge
+      ],
+      settings: [
+        currentSettings
+      ]
+    };
+
+    setGraphData(newGraphData2);
+  }
+
   const updateGraphDataNodes = (newNodes) => {
     const currentEdges = graphData.edges;
     const newGraphData = {
@@ -541,6 +575,9 @@ const G6JsGraph = () => {
           edgeData={{}}
           graphName={graphName}
           graphData={graphData}
+          onEdgeCreationCancellation={(newEdge) => {
+            removeDrawnEdge(newEdge);
+          }}
         >
           <strong>Add edge</strong>
         </AddEdgeModal>

--- a/js/apps/system/_admin/aardvark/APP/react/src/views/g6graphs/G6JsGraph.jsx
+++ b/js/apps/system/_admin/aardvark/APP/react/src/views/g6graphs/G6JsGraph.jsx
@@ -188,38 +188,9 @@ const G6JsGraph = () => {
     setGraphData(newGraphData);
   }
 
-  const removeDrawnEdge = (newEdge) => {
-    // Add edge first to register it in graphData
-    const currentNodes = graphData.nodes;
-    const newGraphData = {
-      nodes: [
-        ...currentNodes,
-      ],
-      edges: [
-        ...graphData.edges,
-        newEdge
-      ]
-    };
-    setGraphData(newGraphData);
-
-    // Remove edge first to register it in graphData
-    const edgesWithoutRemovedEdge = graphData.edges.filter(edges => edges.id !== newEdge);
-    const currentNodes2 = graphData.nodes;
-    const currentSettings = graphData.settings;
-
-    const newGraphData2 = {
-      nodes: [
-        ...currentNodes2
-      ],
-      edges: [
-        ...edgesWithoutRemovedEdge
-      ],
-      settings: [
-        currentSettings
-      ]
-    };
-
-    setGraphData(newGraphData2);
+  const removeDrawnEdge = () => {
+    // reset to previous saved data
+    setGraphData({...graphData});
   }
 
   const updateGraphDataNodes = (newNodes) => {
@@ -561,8 +532,9 @@ const G6JsGraph = () => {
         <AddEdgeModal
           edgeModelToAdd={edgeModelToAdd}
           shouldShow={showEdgeToAddModal}
-          onRequestClose={() => {
+          onRequestClose={(isTriggeredOnSave) => {
             setShowEdgeToAddModal(false);
+            !isTriggeredOnSave && removeDrawnEdge();
           }}
           edgeCollections={edgeCollections}
           editorContent={'edgeToEdit'}
@@ -575,8 +547,8 @@ const G6JsGraph = () => {
           edgeData={{}}
           graphName={graphName}
           graphData={graphData}
-          onEdgeCreationCancellation={(newEdge) => {
-            removeDrawnEdge(newEdge);
+          onEdgeCreationCancellation={() => {
+            removeDrawnEdge();
           }}
         >
           <strong>Add edge</strong>


### PR DESCRIPTION
### Scope & Purpose

A After pressing the SHIFT key on the keyboard and clicking two nodes in the canvas the drawn edge would not be removed after cancelling the process in the popped up modal. This fix solves the issue.

- [x] :hankey: Bugfix

### Checklist

- [x] Manually tested

#### Related Information

- [x] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/FE-142

