### PR TITLE
bug-fix/FE-141 Add a help modal

### DIFF
--- a/js/apps/system/_admin/aardvark/APP/react/src/views/g6graphs/Headerinfo.js
+++ b/js/apps/system/_admin/aardvark/APP/react/src/views/g6graphs/Headerinfo.js
@@ -10,6 +10,7 @@ import ParameterEdgeLabelByCollection from "./ParameterEdgeLabelByCollection";
 import ParameterEdgeColorByCollection from "./ParameterEdgeColorByCollection";
 import ParameterNodeLabel from "./ParameterNodeLabel";
 import ParameterEdgeLabel from "./ParameterEdgeLabel";
+import { HelpModal } from "./HelpModal";
 import ParameterNodeColorAttribute from "./ParameterNodeColorAttribute";
 import ParameterEdgeColorAttribute from "./ParameterEdgeColorAttribute";
 import ParameterNodeColor from "./ParameterNodeColor";
@@ -26,6 +27,7 @@ import LoadingSpinner from './LoadingSpinner.js';
 export const Headerinfo = ({ graphName, graphData, responseDuration, nodesColorAttributes, edgesColorAttributes, onDownloadScreenshot, onDownloadFullScreenshot, onChangeLayout, onChangeGraphData, onLoadFullGraph, onDocumentSelect, onNodeSearched, onEdgeSearched, onEdgeStyleChanged, onGraphLayoutChange, onGraphDataLoaded, onIsLoadingData }) => {
   
   const [isLoadingData, setIsLoadingData] = useState(false);
+  const [showHelpModal, setShowHelpModal] = useState(false);
   const { TabPane } = Tabs;
 
   const enterFullscreen = (element) => {
@@ -90,6 +92,14 @@ const screenshotMenu = (
 
   return (
     <>
+      <HelpModal
+        shouldShow={showHelpModal}
+        onRequestClose={() => {
+          setShowHelpModal(false);
+        }}
+      >
+        <strong>Help texts (example at ANALYZERS)</strong>
+      </HelpModal>
       <PageHeader
         id="headerinfo"
         className="site-page-header-responsive"
@@ -117,6 +127,14 @@ const screenshotMenu = (
                 onClick={() => {
                   window.location.href = `/_db/_system/_admin/aardvark/index.html#graph/${graphName}`;
                 }}><RollbackOutlined />
+              </Button>
+            </Tooltip>
+
+            <Tooltip placement="left" title={"Get instructions and support on how to use the graph viewer"} overlayClassName='graph-border-box' >
+              <Button key="5"
+                onClick={() => {
+                  setShowHelpModal(true);
+                }}><i class="fa fa-question-circle" style={{ 'fontSize': '18px', 'marginTop': '1px' }}></i>
               </Button>
             </Tooltip>
           </>

--- a/js/apps/system/_admin/aardvark/APP/react/src/views/g6graphs/Headerinfo.js
+++ b/js/apps/system/_admin/aardvark/APP/react/src/views/g6graphs/Headerinfo.js
@@ -98,7 +98,6 @@ const screenshotMenu = (
           setShowHelpModal(false);
         }}
       >
-        <strong>Help texts (example at ANALYZERS)</strong>
       </HelpModal>
       <PageHeader
         id="headerinfo"

--- a/js/apps/system/_admin/aardvark/APP/react/src/views/g6graphs/HelpModal.js
+++ b/js/apps/system/_admin/aardvark/APP/react/src/views/g6graphs/HelpModal.js
@@ -1,0 +1,44 @@
+/* global arangoHelper, $ */
+import React, { useState, useRef } from 'react';
+import styled from "styled-components";
+
+const ModalBackground = styled.div`
+  position: fixed;
+  z-index: 1;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  overflow: auto;
+  background-color: rgba(0, 0, 0, 0.5);
+`;
+
+const ModalBody = styled.div`
+  background-color: white;
+  margin: 5% auto;
+  padding: 20px;
+  width: 50%;
+`;
+
+const StyledButton = styled.button`
+  margin-left: 15px !important;
+  color: white !important;
+`;
+
+export const HelpModal = ({ shouldShow, onRequestClose, children }) => {
+
+  return shouldShow ? (
+    <ModalBackground onClick={onRequestClose}>
+      <ModalBody onClick={(e) => e.stopPropagation()}>
+        <div>
+          {children}<br />
+          <strong>content from the modal</strong>
+        </div>
+        <div style={{ 'marginTop': '38px', 'textAlign': 'right' }}>
+          <StyledButton className="button-success" onClick={onRequestClose}>Close</StyledButton>
+        </div>
+      </ModalBody>
+    </ModalBackground>
+  ) : null;
+  
+};

--- a/js/apps/system/_admin/aardvark/APP/react/src/views/g6graphs/HelpModal.js
+++ b/js/apps/system/_admin/aardvark/APP/react/src/views/g6graphs/HelpModal.js
@@ -31,8 +31,18 @@ export const HelpModal = ({ shouldShow, onRequestClose, children }) => {
     <ModalBackground onClick={onRequestClose}>
       <ModalBody onClick={(e) => e.stopPropagation()}>
         <div>
-          {children}<br />
-          <strong>content from the modal</strong>
+          <span class="arangoHeader">Instructions</span>
+          <hr />
+          <dl>
+            <dt>Creating an edge</dt>
+            <dd>
+              Press and hold shift, then click the two nodes you want to connect with an edge. The first node will be the <code>_from</code> node and the second one the <code>_to</code> node. A modal opens to:
+              <ul>
+                <li>Set a "_key" (optional) </li>
+                <li>Select the edge collection you want the edge to be saved in</li>
+              </ul>
+            </dd>
+          </dl>
         </div>
         <div style={{ 'marginTop': '38px', 'textAlign': 'right' }}>
           <StyledButton className="button-success" onClick={onRequestClose}>Close</StyledButton>


### PR DESCRIPTION
### Scope & Purpose

To give users instructions on how to for example draw an edge between two nodes I added a help button that opens a modal with help and instructions.

- [x] :hankey: Bugfix

### Checklist

- [x] Manually tested

#### Related Information

- [x] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/FE-141

