### PR TITLE
BTS-325 Collection Validation Edge/Vertex API Gharial

### DIFF
--- a/arangod/Graph/GraphOperations.cpp
+++ b/arangod/Graph/GraphOperations.cpp
@@ -212,6 +212,18 @@ Result GraphOperations::checkEdgeCollectionAvailability(
 
 Result GraphOperations::checkVertexCollectionAvailability(
     std::string const& vertexCollectionName) {
+  // first check whether the collection is part of the graph
+  bool found = false;
+  if (_graph.vertexCollections().contains(vertexCollectionName) ||
+      _graph.orphanCollections().contains(vertexCollectionName)) {
+    found = true;
+  }
+
+  if (!found) {
+    return Result(TRI_ERROR_GRAPH_REFERENCED_VERTEX_COLLECTION_NOT_USED);
+  }
+
+  // check if the collection is available
   std::shared_ptr<LogicalCollection> def =
       GraphManager::getCollectionByName(_vocbase, vertexCollectionName);
 
@@ -795,7 +807,7 @@ std::pair<OperationResult, bool> GraphOperations::validateEdgeContent(
   VPackSlice toStringSlice = document.get(StaticStrings::ToString);
   OperationOptions options(ExecContext::current());
 
-  if (fromStringSlice.isNone() || toStringSlice.isNone()) {
+  if (!fromStringSlice.isString() || !toStringSlice.isString()) {
     if (isUpdate) {
       return std::make_pair(OperationResult(TRI_ERROR_NO_ERROR, options),
                             false);
@@ -804,6 +816,7 @@ std::pair<OperationResult, bool> GraphOperations::validateEdgeContent(
         OperationResult(TRI_ERROR_ARANGO_INVALID_EDGE_ATTRIBUTE, options),
         false);
   }
+
   std::string fromString = fromStringSlice.copyString();
   std::string toString = toStringSlice.copyString();
 
@@ -858,6 +871,13 @@ std::pair<OperationResult, bool> GraphOperations::validateEdgeContent(
 OperationResult GraphOperations::createEdge(const std::string& definitionName,
                                             VPackSlice document,
                                             bool waitForSync, bool returnNew) {
+  // check if edgeCollection is available in the graph definition
+  OperationOptions options(ExecContext::current());
+  Result checkEdgeRes = checkEdgeCollectionAvailability(definitionName);
+  if (checkEdgeRes.fail()) {
+    return OperationResult(checkEdgeRes, options);
+  }
+
   auto [res, trx] = validateEdge(definitionName, document, waitForSync, false);
   if (res.fail()) {
     return std::move(res);
@@ -916,6 +936,13 @@ OperationResult GraphOperations::createVertex(const std::string& collectionName,
                                               VPackSlice document,
                                               bool waitForSync,
                                               bool returnNew) {
+  // check if the vertex collection is part of the graph
+  OperationOptions options(ExecContext::current());
+  Result checkVertexRes = checkVertexCollectionAvailability(collectionName);
+  if (checkVertexRes.fail()) {
+    return OperationResult(checkVertexRes, options);
+  }
+
   transaction::Options trxOptions;
 
   std::vector<std::string> writeCollections;

--- a/lib/Rest/GeneralResponse.cpp
+++ b/lib/Rest/GeneralResponse.cpp
@@ -371,8 +371,6 @@ rest::ResponseCode GeneralResponse::responseCode(ErrorCode code) {
         TRI_ERROR_CLUSTER_MUST_NOT_CHANGE_SMART_JOIN_ATTRIBUTE):
     case static_cast<int>(TRI_ERROR_VALIDATION_FAILED):
     case static_cast<int>(TRI_ERROR_VALIDATION_BAD_PARAMETER):
-    case static_cast<int>(
-        TRI_ERROR_GRAPH_REFERENCED_VERTEX_COLLECTION_NOT_USED):
       return ResponseCode::BAD;
 
     case static_cast<int>(TRI_ERROR_ARANGO_USE_SYSTEM_DATABASE):
@@ -400,6 +398,8 @@ rest::ResponseCode GeneralResponse::responseCode(ErrorCode code) {
     case static_cast<int>(TRI_ERROR_GRAPH_VERTEX_COL_DOES_NOT_EXIST):
     case static_cast<int>(TRI_ERROR_GRAPH_NO_GRAPH_COLLECTION):
     case static_cast<int>(TRI_ERROR_GRAPH_EDGE_COLLECTION_NOT_USED):
+    case static_cast<int>(
+        TRI_ERROR_GRAPH_REFERENCED_VERTEX_COLLECTION_NOT_USED):
     case static_cast<int>(TRI_ERROR_REPLICATION_REPLICATED_LOG_NOT_FOUND):
     case static_cast<int>(TRI_ERROR_REPLICATION_REPLICATED_STATE_NOT_FOUND):
       return ResponseCode::NOT_FOUND;


### PR DESCRIPTION
### Scope & Purpose

Fixed edge/vertex documents not checked origin collection during creation.
Added missing type-check (isString) during creation. Added tests for both cases. Changed HTTP Code for ERROR_GRAPH_REFERENCED_VERTEX_COLLECTION_NOT_USED from 400 to 404 do be in sync with the way we handle the edges as well.

- [x] :hankey: Bugfix

### Checklist

- [x] Tests
  - [x] **integration tests**
- [ ] :book: CHANGELOG entry made
- [x] Backports
  - [ ] Backport for 3.10: *(required)*
  - [ ] Backport for 3.9: *(required)*
  - [ ] Backport for 3.8: *(required)*

#### Related Information

- [x] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/BTS-325

