### PR TITLE
fix shutdown memleak for temp storage db

### DIFF
--- a/arangod/RocksDBEngine/RocksDBTempStorage.cpp
+++ b/arangod/RocksDBEngine/RocksDBTempStorage.cpp
@@ -135,7 +135,7 @@ RocksDBTempStorage::RocksDBTempStorage(std::string const& basePath,
       _db(nullptr),
       _comparator(std::make_unique<::KeysComparator>()) {}
 
-RocksDBTempStorage::~RocksDBTempStorage() = default;
+RocksDBTempStorage::~RocksDBTempStorage() { close(); }
 
 Result RocksDBTempStorage::init() {
   // path for temporary files, not managed by RocksDB, but by us.
@@ -258,8 +258,12 @@ Result RocksDBTempStorage::init() {
 }
 
 void RocksDBTempStorage::close() {
-  TRI_ASSERT(_db != nullptr);
-  _db->Close();
+  if (_db != nullptr) {
+    _db->Close();
+
+    delete _db;
+    _db = nullptr;
+  }
 }
 
 std::unique_ptr<RocksDBSortedRowsStorageContext>

--- a/arangod/RocksDBEngine/RocksDBTempStorage.cpp
+++ b/arangod/RocksDBEngine/RocksDBTempStorage.cpp
@@ -259,6 +259,10 @@ Result RocksDBTempStorage::init() {
 
 void RocksDBTempStorage::close() {
   if (_db != nullptr) {
+    for (auto* handle : _cfHandles) {
+      _db->DestroyColumnFamilyHandle(handle);
+    }
+
     _db->Close();
 
     delete _db;


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/16742
Fix a shutdown memleak in case the temporary storage for RocksDB is used.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [x] Backports
  - [x] Backport for 3.10: this PR
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
