### PR TITLE
fix an invalid attribute access

### DIFF
--- a/arangod/Aql/Ast.cpp
+++ b/arangod/Aql/Ast.cpp
@@ -2601,7 +2601,7 @@ void Ast::validateAndOptimize(transaction::Methods& trx,
 
     // indexed access, e.g. a[0] or a['foo']
     if (node->type == NODE_TYPE_INDEXED_ACCESS) {
-      return this->optimizeIndexedAccess(node);
+      return this->optimizeIndexedAccess(node, ctx->variableDefinitions);
     }
 
     // LET
@@ -3836,7 +3836,9 @@ AstNode* Ast::optimizeFunctionCall(
 }
 
 /// @brief optimizes indexed access, e.g. a[0] or a['foo']
-AstNode* Ast::optimizeIndexedAccess(AstNode* node) {
+AstNode* Ast::optimizeIndexedAccess(
+    AstNode* node, std::unordered_map<Variable const*, AstNode const*> const&
+                       variableDefinitions) {
   TRI_ASSERT(node != nullptr);
   TRI_ASSERT(node->type == NODE_TYPE_INDEXED_ACCESS);
   TRI_ASSERT(node->numMembers() == 2);
@@ -3854,8 +3856,9 @@ AstNode* Ast::optimizeIndexedAccess(AstNode* node) {
       // we have to be careful with numeric values here...
       // e.g. array['0'] is not the same as array.0 but must remain a['0'] or
       // (a[0])
-      return createNodeAttributeAccess(node->getMember(0),
-                                       index->getStringView());
+      return this->optimizeAttributeAccess(
+          createNodeAttributeAccess(node->getMember(0), indexValue),
+          variableDefinitions);
     }
   }
 

--- a/arangod/Aql/Ast.h
+++ b/arangod/Aql/Ast.h
@@ -565,7 +565,9 @@ class Ast {
                                 ValidateAndOptimizeOptions const& options);
 
   /// @brief optimizes indexed access, e.g. a[0] or a['foo']
-  AstNode* optimizeIndexedAccess(AstNode*);
+  AstNode* optimizeIndexedAccess(
+      AstNode* node, std::unordered_map<Variable const*, AstNode const*> const&
+                         variableDefinitions);
 
   /// @brief optimizes the FILTER statement
   AstNode* optimizeFilter(AstNode*);

--- a/tests/js/server/aql/aql-queries-optimizer.js
+++ b/tests/js/server/aql/aql-queries-optimizer.js
@@ -53,6 +53,12 @@ function ahuacatlOptimizerTestSuite () {
       assertEqual([ 'baz' ], actual);
     },
 
+    testAttributeAccessOptimizationWithIndexLookup : function () {
+      let query = `LET data = { "a": [ { "id":123,"search":"","data":[] }, { "id":456,"search":"","data":[] } ], "b": [] } FOR d IN data["a"] RETURN d`;
+      let actual = getQueryResults(query);
+      assertEqual([ { "data" : [ ], "id" : 123, "search" : "" }, { "data" : [ ], "id" : 456, "search" : "" } ], actual);
+    },
+
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief test special case "empty for loop"
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
### Scope & Purpose

Fix an invalid attribute access in query optimization.
Without the fix, an input query such as
```
LET data = { 
  "a": [ 
    { "id":123,"search":"","data":[] }, 
    { "id":456,"search":"","data":[] } 
  ], 
  "b": [] 
} 
FOR d IN data["a"] 
  RETURN d
```
could fail with error "invalid operand to FOR loop, expecting Array".

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [x] Backports
  - [x] Backport for 3.10: https://github.com/arangodb/arangodb/pull/16748
  - [x] Backport for 3.9: https://github.com/arangodb/arangodb/pull/16749
  - [x] Backport for 3.8: https://github.com/arangodb/arangodb/pull/16750

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
