### PR TITLE
fix an invalid attribute access

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,19 @@
 v3.9.3 (XXXX-XX-XX)
 -------------------
 
+* Fixed an invalid attribute access in AQL query optimization.
+  Without the fix, a query such as
+
+      LET data = { 
+        "a": [ 
+          ...
+        ], 
+      } 
+      FOR d IN data["a"] 
+        RETURN d
+
+  could fail with error "invalid operand to FOR loop, expecting Array".
+
 * Updated OpenSSL to 1.1.1q and OpenLDAP to 2.6.3.
 
 * Updated arangosync to v2.11.0.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,12 +4,12 @@ v3.9.3 (XXXX-XX-XX)
 * Fixed an invalid attribute access in AQL query optimization.
   Without the fix, a query such as
 
-      LET data = { 
-        "a": [ 
+      LET data = {
+        "a": [
           ...
-        ], 
-      } 
-      FOR d IN data["a"] 
+        ],
+      }
+      FOR d IN data["a"]
         RETURN d
 
   could fail with error "invalid operand to FOR loop, expecting Array".

--- a/arangod/Aql/Ast.cpp
+++ b/arangod/Aql/Ast.cpp
@@ -2432,7 +2432,7 @@ void Ast::validateAndOptimize(transaction::Methods& trx) {
 
     // indexed access, e.g. a[0] or a['foo']
     if (node->type == NODE_TYPE_INDEXED_ACCESS) {
-      return this->optimizeIndexedAccess(node);
+      return this->optimizeIndexedAccess(node, ctx->variableDefinitions);
     }
 
     // LET
@@ -3717,7 +3717,9 @@ AstNode* Ast::optimizeReference(AstNode* node) {
 }
 
 /// @brief optimizes indexed access, e.g. a[0] or a['foo']
-AstNode* Ast::optimizeIndexedAccess(AstNode* node) {
+AstNode* Ast::optimizeIndexedAccess(
+    AstNode* node, std::unordered_map<Variable const*, AstNode const*> const&
+                       variableDefinitions) {
   TRI_ASSERT(node != nullptr);
   TRI_ASSERT(node->type == NODE_TYPE_INDEXED_ACCESS);
   TRI_ASSERT(node->numMembers() == 2);
@@ -3736,9 +3738,10 @@ AstNode* Ast::optimizeIndexedAccess(AstNode* node) {
       // we have to be careful with numeric values here...
       // e.g. array['0'] is not the same as array.0 but must remain a['0'] or
       // (a[0])
-      return createNodeAttributeAccess(node->getMember(0),
-                                       index->getStringValue(),
-                                       index->getStringLength());
+      return this->optimizeAttributeAccess(
+          createNodeAttributeAccess(node->getMember(0), index->getStringValue(),
+                                    index->getStringLength()),
+          variableDefinitions);
     }
   }
 

--- a/arangod/Aql/Ast.h
+++ b/arangod/Aql/Ast.h
@@ -570,7 +570,9 @@ class Ast {
   AstNode* optimizeReference(AstNode*);
 
   /// @brief optimizes indexed access, e.g. a[0] or a['foo']
-  AstNode* optimizeIndexedAccess(AstNode*);
+  AstNode* optimizeIndexedAccess(
+      AstNode* node, std::unordered_map<Variable const*, AstNode const*> const&
+                         variableDefinitions);
 
   /// @brief optimizes the LET statement
   AstNode* optimizeLet(AstNode*);

--- a/tests/js/server/aql/aql-queries-optimizer.js
+++ b/tests/js/server/aql/aql-queries-optimizer.js
@@ -53,6 +53,12 @@ function ahuacatlOptimizerTestSuite () {
       assertEqual([ 'baz' ], actual);
     },
 
+    testAttributeAccessOptimizationWithIndexLookup : function () {
+      let query = `LET data = { "a": [ { "id":123,"search":"","data":[] }, { "id":456,"search":"","data":[] } ], "b": [] } FOR d IN data["a"] RETURN d`;
+      let actual = getQueryResults(query);
+      assertEqual([ { "data" : [ ], "id" : 123, "search" : "" }, { "data" : [ ], "id" : 456, "search" : "" } ], actual);
+    },
+
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief test special case "empty for loop"
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/16746

Fix an invalid attribute access in query optimization.
Without the fix, an input query such as
```
LET data = { 
  "a": [ 
    { "id":123,"search":"","data":[] }, 
    { "id":456,"search":"","data":[] } 
  ], 
  "b": [] 
} 
FOR d IN data["a"] 
  RETURN d
```
could fail with error "invalid operand to FOR loop, expecting Array".

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [x] Backports
  - [x] Backport for 3.10: https://github.com/arangodb/arangodb/pull/16748
  - [x] Backport for 3.9: this PR
  - [x] Backport for 3.8: https://github.com/arangodb/arangodb/pull/16750

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
