### PR TITLE
Fix loophole for creating duplicate keys

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,22 @@
 v3.9.3 (XXXX-XX-XX)
 -------------------
 
+* Since ArangoDB 3.8 there was a loophole for creating duplicate keys in the
+  same collection. The requirements were:
+  - cluster deployment
+  - needs at least two collections (source and target), and the target
+    collection must have more than one shard and must use a custom shard key.
+  - inserting documents into the target collection must have happened via an
+    AQL query like `FOR doc IN source INSERT doc INTO target`.
+  In this particular combination, the document keys (`_key` attribute) from 
+  the source collection were used as-is for insertion into the target 
+  collection. However, as the target collection is not sharded by `_key` and
+  uses a custom shard key, it is actually not allowed to specify user-defined 
+  values for `_key`. That check was missing since 3.8 in this particular
+  combination and has now been added back. AQL queries attempting to insert 
+  documents into a collection like this will now fail with the error "must not
+  specifiy _key for this collection", as they used to do before 3.8.
+
 * Updated OpenSSL to 1.1.1q and OpenLDAP to 2.6.3.
 
 * Updated arangosync to v2.11.0.

--- a/arangod/Aql/OptimizerRules.cpp
+++ b/arangod/Aql/OptimizerRules.cpp
@@ -8806,7 +8806,12 @@ void arangodb::aql::insertDistributeInputCalculation(ExecutionPlan& plan) {
       // If our input variable is set by a collection/index enumeration, it is
       // guaranteed to be an object with a _key attribute, so we don't need to
       // do anything.
-      return;
+      if (!createKeys || collection->usesDefaultSharding()) {
+        // no need to insert an extra calculation node in this case.
+        return;
+      }
+      // in case we have a collection that is not sharded by _key,
+      // the keys need to be created/validated by the coordinator.
     }
 
     auto* ast = plan.getAst();


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/16764

Since ArangoDB 3.8 there was a loophole for creating duplicate keys in the same collection. The requirements were:
- cluster deployment
- needs at least two collections (source and target), and the target collection must have more than one shard and must use a custom shard key.
- inserting documents into the target collection must have happened via an AQL query like `FOR doc IN source INSERT doc INTO target`.
  In this particular combination, the document keys (`_key` attribute) from the source collection were used as-is for insertion into the target collection. However, as the target collection is not sharded by `_key` and uses a custom shard key, it is actually not allowed to specify user-defined values for `_key`. That check was missing since 3.8 in this particular combination and has now been added back. AQL queries attempting to insert documents into a collection like this will now fail with the error "must not specifiy _key for this collection", as they used to do before 3.8.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [x] :books: documentation written (release notes, API changes, ...)
- [x] Backports
  - [x] Backport for 3.10: https://github.com/arangodb/arangodb/pull/16765
  - [x] Backport for 3.9: this PR
  - [x] Backport for 3.8: https://github.com/arangodb/arangodb/pull/16768

#### Related Information

- [x] Docs PR: https://github.com/arangodb/docs/pull/1087
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 