### PR TITLE
Fix loophole for creating duplicate keys

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,22 @@
 v3.8.8 (XXXX-XX-XX)
 -------------------
 
+* Since ArangoDB 3.8 there was a loophole for creating duplicate keys in the
+  same collection. The requirements were:
+  - cluster deployment
+  - needs at least two collections (source and target), and the target
+    collection must have more than one shard and must use a custom shard key.
+  - inserting documents into the target collection must have happened via an
+    AQL query like `FOR doc IN source INSERT doc INTO target`.
+  In this particular combination, the document keys (`_key` attribute) from 
+  the source collection were used as-is for insertion into the target 
+  collection. However, as the target collection is not sharded by `_key` and
+  uses a custom shard key, it is actually not allowed to specify user-defined 
+  values for `_key`. That check was missing since 3.8 in this particular
+  combination and has now been added back. AQL queries attempting to insert 
+  documents into a collection like this will now fail with the error "must not
+  specifiy _key for this collection", as they used to do before 3.8.
+
 * Updated OpenSSL to 1.1.1q and OpenLDAP to 2.6.3.
 
 * Updated arangosync to v2.11.0.

--- a/arangod/Aql/OptimizerRules.cpp
+++ b/arangod/Aql/OptimizerRules.cpp
@@ -8607,9 +8607,15 @@ void arangodb::aql::insertDistributeInputCalculation(ExecutionPlan& plan) {
     if (setter == nullptr || // this can happen for $smartHandOver
         setter->getType() == EN::ENUMERATE_COLLECTION ||
         setter->getType() == EN::INDEX) {
-      // If our input variable is set by a collection/index enumeration, it is guaranteed to be an object
-      // with a _key attribute, so we don't need to do anything.
-      return;
+      // If our input variable is set by a collection/index enumeration, it is
+      // guaranteed to be an object with a _key attribute, so we don't need to
+      // do anything.
+      if (!createKeys || collection->usesDefaultSharding()) {
+        // no need to insert an extra calculation node in this case.
+        return;
+      }
+      // in case we have a collection that is not sharded by _key,
+      // the keys need to be created/validated by the coordinator.
     }
     
     // We insert an additional calculation node to create the input for our distribute node.

--- a/tests/js/server/aql/aql-optimizer-rule-distribute-in-cluster.js
+++ b/tests/js/server/aql/aql-optimizer-rule-distribute-in-cluster.js
@@ -1,5 +1,5 @@
 /*jshint globalstrict:false, strict:false, maxlen: 500 */
-/*global assertEqual, assertTrue, AQL_EXPLAIN, AQL_EXECUTE */
+/*global assertEqual, assertNotEqual, assertTrue, assertMatch, AQL_EXPLAIN, AQL_EXECUTE */
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief tests for optimizer rules
@@ -28,45 +28,40 @@
 /// @author Copyright 2014, triAGENS GmbH, Cologne, Germany
 ////////////////////////////////////////////////////////////////////////////////
 
-var db = require("@arangodb").db;
-var jsunity = require("jsunity");
-var helper = require("@arangodb/aql-helper");
+const db = require("@arangodb").db;
+const jsunity = require("jsunity");
+const helper = require("@arangodb/aql-helper");
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief test suite
 ////////////////////////////////////////////////////////////////////////////////
 
 function optimizerRuleTestSuite () {
-  var ruleName = "distribute-in-cluster";
+  const ruleName = "distribute-in-cluster";
   // various choices to control the optimizer: 
-  var rulesNone        = { optimizer: { rules: [ "-all" ] } };
-  var rulesAll         = { optimizer: { rules: [ "+all", "-reduce-extraction-to-projection", "-parallelize-gather" ] } };
-  var thisRuleEnabled  = { optimizer: { rules: [ "-all", "+" + ruleName ] } };
-  var thisRuleDisabled = { optimizer: { rules: [ "+all", "-reduce-extraction-to-projection", "-parallelize-gather", "-" + ruleName ] } };
-  var maxPlans         = { optimizer: { rules: [ "-all" ] }, maxNumberOfPlans: 1 };
+  const rulesNone        = { optimizer: { rules: [ "-all" ] } };
+  const rulesAll         = { optimizer: { rules: [ "+all", "-reduce-extraction-to-projection", "-parallelize-gather" ] } };
+  const thisRuleEnabled  = { optimizer: { rules: [ "-all", "+" + ruleName ] } };
+  const thisRuleDisabled = { optimizer: { rules: [ "+all", "-reduce-extraction-to-projection", "-parallelize-gather", "-" + ruleName ] } };
+  const maxPlans         = { optimizer: { rules: [ "-all" ] }, maxNumberOfPlans: 1 };
 
-  var cn1 = "UnitTestsAqlOptimizerRuleUndist1";
-  var cn2 = "UnitTestsAqlOptimizerRuleUndist2";
-  var c1, c2;
+  const cn1 = "UnitTestsAqlOptimizerRuleUndist1";
+  const cn2 = "UnitTestsAqlOptimizerRuleUndist2";
+  let c1, c2;
   
-  var explain = function (result) {
+  const explain = function (result) {
     return helper.getCompactPlan(result).map(function(node) 
         { return node.type; });
   };
 
   return {
 
-    ////////////////////////////////////////////////////////////////////////////////
-    /// @brief set up
-    ////////////////////////////////////////////////////////////////////////////////
-
     setUpAll : function () {
-      var i;
       db._drop(cn1);
       db._drop(cn2);
       c1 = db._create(cn1, {numberOfShards:9});
       c2 = db._create(cn2, {numberOfShards:9, shardKeys:["a","b"]});
-      for (i = 0; i < 10; i++) { 
+      for (let i = 0; i < 10; ++i) { 
         c1.insert({Hallo1:i});
         c2.insert({Hallo2:i});
       }
@@ -79,6 +74,81 @@ function optimizerRuleTestSuite () {
     tearDownAll : function () {
       db._drop(cn1);
       db._drop(cn2);
+    },
+    
+    testKeyGenerationOnInsertDefaultShardKey : function () {
+      const temp = "UnitTestsTarget";
+
+      let queries = [
+        // [ query string, must have calculation node ],
+        [ "FOR d IN " + cn1 + " INSERT d IN " + temp, false ],
+        [ "FOR d IN " + cn1 + " INSERT { _key: d._key } IN " + temp, true ],
+        [ "FOR d IN " + cn1 + " INSERT d._key IN " + temp, true ],
+        [ "FOR d IN 1..10 INSERT { _key: CONCAT('test', d) } IN " + temp, true ],
+        [ "FOR d IN 1..10 LET doc = { _key: CONCAT('test', d) } INSERT NOOPT(doc) IN " + temp, true ],
+        [ "FOR d IN " + cn1 + " INSERT UNSET(d, ['_key']) IN " + temp, true ],
+        [ "FOR d IN " + cn1 + " INSERT { fuchs: d._key } IN " + temp, true ],
+      ];
+
+      for (let i = 1; i <= 3; ++i) {
+        let c = db._create(temp, { numberOfShards: i });
+        try {
+          queries.forEach(function(query) {
+            let result = AQL_EXPLAIN(query[0], {}, thisRuleEnabled);
+            assertNotEqual(-1, explain(result).indexOf("DistributeNode"));
+            if (query[1]) {
+              assertMatch(/MAKE_DISTRIBUTE_INPUT_WITH_KEY_CREATION/, JSON.stringify(result.plan.nodes));
+            }
+            
+            c.truncate();
+
+            // the execute command must not fail
+            AQL_EXECUTE(query[0], {}, thisRuleEnabled);
+          });
+        } finally {
+          db._drop(temp);
+        }
+      }
+    },
+    
+    testKeyGenerationOnInsertCustomShardKey : function () {
+      const temp = "UnitTestsTarget";
+
+      let queries = [
+        // [ query string, query will execute successfully ]
+        [ "FOR d IN " + cn1 + " INSERT d IN " + temp, false ],
+        [ "FOR d IN " + cn1 + " INSERT { _key: d._key } IN " + temp, false ],
+        [ "FOR d IN " + cn1 + " INSERT d._key IN " + temp, false ],
+        [ "FOR d IN 1..10 INSERT { _key: CONCAT('test', d) } IN " + temp, false ],
+        [ "FOR d IN 1..10 LET doc = { _key: CONCAT('test', d) } INSERT NOOPT(doc) IN " + temp, false ],
+
+        [ "FOR d IN " + cn1 + " INSERT UNSET(d, ['_key']) IN " + temp, true ],
+        [ "FOR d IN " + cn1 + " INSERT { fuchs: d._key } IN " + temp, true ],
+      ];
+
+      for (let i = 1; i <= 3; ++i) {
+        let c = db._create(temp, { numberOfShards: i, shardKeys: ["testi"] });
+        try {
+          queries.forEach(function(query) {
+            let result = AQL_EXPLAIN(query[0], {}, thisRuleEnabled);
+            assertNotEqual(-1, explain(result).indexOf("DistributeNode"));
+            assertMatch(/MAKE_DISTRIBUTE_INPUT_WITH_KEY_CREATION/, JSON.stringify(result.plan.nodes));
+
+            c.truncate();
+            let success = true;
+            try {
+              // the execute command can fail for some of the queries
+              AQL_EXECUTE(query[0], {}, thisRuleEnabled);
+            } catch (err) {
+              success = false;
+            }
+
+            assertEqual(query[1], success, query);
+          });
+        } finally {
+          db._drop(temp);
+        }
+      }
     },
     
     ////////////////////////////////////////////////////////////////////////////////
@@ -215,6 +285,7 @@ function optimizerRuleTestSuite () {
                               "EnumerateCollectionNode", 
                               "RemoteNode", 
                               "GatherNode",
+                              "CalculationNode",
                               "DistributeNode",
                               "RemoteNode",
                               "InsertNode",
@@ -393,6 +464,7 @@ function optimizerRuleTestSuite () {
                               "EnumerateCollectionNode", 
                               "RemoteNode", 
                               "GatherNode", 
+                              "CalculationNode",
                               "DistributeNode", 
                               "RemoteNode", 
                               "InsertNode", 
@@ -491,6 +563,7 @@ function optimizerRuleTestSuite () {
                               "EnumerateCollectionNode", 
                               "RemoteNode", 
                               "GatherNode", 
+                              "CalculationNode",
                               "DistributeNode", 
                               "RemoteNode", 
                               "InsertNode", 
@@ -590,6 +663,7 @@ function optimizerRuleTestSuite () {
                               "EnumerateCollectionNode", 
                               "RemoteNode", 
                               "GatherNode", 
+                              "CalculationNode",
                               "DistributeNode", 
                               "RemoteNode", 
                               "InsertNode", 
@@ -1222,6 +1296,7 @@ function interactionOtherRulesTestSuite () {
     }
   };
 }
+
 jsunity.run(optimizerRuleTestSuite);
 jsunity.run(interactionOtherRulesTestSuite);
 


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/16764

Since ArangoDB 3.8 there was a loophole for creating duplicate keys in the same collection. The requirements were:
- cluster deployment
- needs at least two collections (source and target), and the target collection must have more than one shard and must use a custom shard key.
- inserting documents into the target collection must have happened via an AQL query like `FOR doc IN source INSERT doc INTO target`.
  In this particular combination, the document keys (`_key` attribute) from the source collection were used as-is for insertion into the target collection. However, as the target collection is not sharded by `_key` and uses a custom shard key, it is actually not allowed to specify user-defined values for `_key`. That check was missing since 3.8 in this particular combination and has now been added back. AQL queries attempting to insert documents into a collection like this will now fail with the error "must not specifiy _key for this collection", as they used to do before 3.8.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [x] :books: documentation written (release notes, API changes, ...)
- [x] Backports
  - [x] Backport for 3.10: https://github.com/arangodb/arangodb/pull/16765
  - [x] Backport for 3.9: https://github.com/arangodb/arangodb/pull/16767
  - [x] Backport for 3.8: this PR

#### Related Information

- [x] Docs PR: https://github.com/arangodb/docs/pull/1087
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 