### PR TITLE
Added docublocks for HTTP Graph creation API

### DIFF
--- a/Documentation/DocuBlocks/Rest/Graph/general_graph_create_http_examples.md
+++ b/Documentation/DocuBlocks/Rest/Graph/general_graph_create_http_examples.md
@@ -178,14 +178,14 @@ A message created for this error.
   graph._drop("myGraph", true);
 @END_EXAMPLE_ARANGOSH_RUN
 
-@EXAMPLE_ARANGOSH_RUN{HttpGharialCreate2}
+@EXAMPLE_ARANGOSH_RUN{HttpGharialCreateSmart}
   var graph = require("@arangodb/general-graph");
-| if (graph._exists("myGraph")) {
-|    graph._drop("myGraph", true);
+| if (graph._exists("smartGraph")) {
+|    graph._drop("smartGraph", true);
   }
   var url = "/_api/gharial";
   body = {
-    name: "myGraph",
+    name: "smartGraph",
     edgeDefinitions: [{
       collection: "edges",
       from: [ "startVertices" ],
@@ -206,7 +206,129 @@ A message created for this error.
 
   logJsonResponse(response);
 
-  graph._drop("myGraph", true);
+  graph._drop("smartGraph", true);
+@END_EXAMPLE_ARANGOSH_RUN
+
+@EXAMPLE_ARANGOSH_RUN{HttpGharialCreateDisjointSmart}
+var graph = require("@arangodb/general-graph");
+| if (graph._exists("disjointSmartGraph")) {
+|    graph._drop("disjointSmartGraph", true);
+}
+var url = "/_api/gharial";
+body = {
+name: "disjointSmartGraph",
+edgeDefinitions: [{
+collection: "edges",
+from: [ "startVertices" ],
+to: [ "endVertices" ]
+}],
+orphanCollections: [ "orphanVertices" ],
+isSmart: true,
+options: {
+isDisjoint: true,
+replicationFactor: 2,
+numberOfShards: 9,
+smartGraphAttribute: "region"
+}
+};
+
+var response = logCurlRequest('POST', url, body);
+
+assert(response.code === 202);
+
+logJsonResponse(response);
+
+graph._drop("disjointSmartGraph", true);
+@END_EXAMPLE_ARANGOSH_RUN
+
+@EXAMPLE_ARANGOSH_RUN{HttpGharialCreateSmartWithSatellites}
+var graph = require("@arangodb/general-graph");
+| if (graph._exists("smartGraph")) {
+|    graph._drop("smartGraph", true);
+}
+var url = "/_api/gharial";
+body = {
+name: "smartGraph",
+edgeDefinitions: [{
+collection: "edges",
+from: [ "startVertices" ],
+to: [ "endVertices" ]
+}],
+orphanCollections: [ "orphanVertices" ],
+isSmart: true,
+options: {
+replicationFactor: 2,
+numberOfShards: 9,
+smartGraphAttribute: "region",
+satellites: [ "endVertices" ]
+}
+};
+
+var response = logCurlRequest('POST', url, body);
+
+assert(response.code === 202);
+
+logJsonResponse(response);
+
+graph._drop("smartGraph", true);
+@END_EXAMPLE_ARANGOSH_RUN
+
+@EXAMPLE_ARANGOSH_RUN{HttpGharialCreateEnterprise}
+var graph = require("@arangodb/general-graph");
+| if (graph._exists("enterpriseGraph")) {
+|    graph._drop("enterpriseGraph", true);
+}
+var url = "/_api/gharial";
+body = {
+name: "enterpriseGraph",
+edgeDefinitions: [{
+collection: "edges",
+from: [ "startVertices" ],
+to: [ "endVertices" ]
+}],
+orphanCollections: [ ],
+isSmart: true,
+options: {
+replicationFactor: 2,
+numberOfShards: 9,
+}
+};
+
+var response = logCurlRequest('POST', url, body);
+
+assert(response.code === 202);
+
+logJsonResponse(response);
+
+graph._drop("enterpriseGraph", true);
+@END_EXAMPLE_ARANGOSH_RUN
+
+@EXAMPLE_ARANGOSH_RUN{HttpGharialCreateSatellite}
+var graph = require("@arangodb/general-graph");
+| if (graph._exists("satelliteGraph")) {
+|    graph._drop("satelliteGraph", true);
+}
+var url = "/_api/gharial";
+body = {
+name: "satelliteGraph",
+edgeDefinitions: [{
+collection: "edges",
+from: [ "startVertices" ],
+to: [ "endVertices" ]
+}],
+orphanCollections: [ ],
+options: {
+replicationFactor: "satellite"
+}
+};
+
+var response = logCurlRequest('POST', url, body);
+
+assert(response.code === 202);
+
+logJsonResponse(response);
+
+graph._drop("satelliteGraph", true);
 @END_EXAMPLE_ARANGOSH_RUN
 
 @endDocuBlock


### PR DESCRIPTION
### Scope & Purpose

*THis is a documentation only PR, it adds new DocuBlocks to describe creation of the different graph types over HTTP (that's the only place where thy differ API wise)*

This Branch on purpose has no JENKINS, as it does not touch any Production code.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: *(Please link PR)*
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

