### PR TITLE
fix potential data races in dump/restore queue

### DIFF
--- a/client-tools/Dump/DumpFeature.cpp
+++ b/client-tools/Dump/DumpFeature.cpp
@@ -1104,8 +1104,10 @@ Result DumpFeature::storeViews(VPackSlice const& views) const {
 
 void DumpFeature::reportError(Result const& error) {
   try {
-    MUTEX_LOCKER(lock, _workerErrorLock);
-    _workerErrors.emplace(error);
+    {
+      MUTEX_LOCKER(lock, _workerErrorLock);
+      _workerErrors.emplace_back(error);
+    }
     _clientTaskQueue.clearQueue();
   } catch (...) {
   }

--- a/client-tools/Dump/DumpFeature.h
+++ b/client-tools/Dump/DumpFeature.h
@@ -153,7 +153,7 @@ class DumpFeature final : public ArangoDumpFeature {
   Options _options;
   Stats _stats;
   Mutex _workerErrorLock;
-  std::queue<Result> _workerErrors;
+  std::vector<Result> _workerErrors;
   std::unique_ptr<maskings::Maskings> _maskings;
 
   Result runClusterDump(httpclient::SimpleHttpClient& client,

--- a/client-tools/Dump/DumpFeature.h
+++ b/client-tools/Dump/DumpFeature.h
@@ -36,6 +36,7 @@
 
 #include <memory>
 #include <string>
+#include <vector>
 
 namespace arangodb {
 namespace httpclient {

--- a/client-tools/Restore/RestoreFeature.cpp
+++ b/client-tools/Restore/RestoreFeature.cpp
@@ -2260,7 +2260,7 @@ void RestoreFeature::reportError(Result const& error) {
   try {
     {
       MUTEX_LOCKER(lock, _workerErrorLock);
-      _workerErrors.emplace(error);
+      _workerErrors.emplace_back(error);
     }
     _clientTaskQueue.clearQueue();
   } catch (...) {

--- a/client-tools/Restore/RestoreFeature.cpp
+++ b/client-tools/Restore/RestoreFeature.cpp
@@ -37,6 +37,8 @@
 
 #include "ApplicationFeatures/ApplicationServer.h"
 #include "Basics/FileUtils.h"
+#include "Basics/Mutex.h"
+#include "Basics/MutexLocker.h"
 #include "Basics/NumberOfCores.h"
 #include "Basics/Result.h"
 #include "Basics/StaticStrings.h"

--- a/client-tools/Restore/RestoreFeature.cpp
+++ b/client-tools/Restore/RestoreFeature.cpp
@@ -2256,8 +2256,10 @@ ClientTaskQueue<RestoreFeature::RestoreJob>& RestoreFeature::taskQueue() {
 
 void RestoreFeature::reportError(Result const& error) {
   try {
-    MUTEX_LOCKER(lock, _workerErrorLock);
-    _workerErrors.emplace(error);
+    {
+      MUTEX_LOCKER(lock, _workerErrorLock);
+      _workerErrors.emplace(error);
+    }
     _clientTaskQueue.clearQueue();
   } catch (...) {
   }

--- a/client-tools/Restore/RestoreFeature.h
+++ b/client-tools/Restore/RestoreFeature.h
@@ -256,7 +256,7 @@ class RestoreFeature final : public ArangoRestoreFeature {
   Options _options;
   Stats _stats;
   Mutex mutable _workerErrorLock;
-  std::queue<Result> _workerErrors;
+  std::vector<Result> _workerErrors;
 
   Mutex _buffersLock;
   std::vector<std::unique_ptr<basics::StringBuffer>> _buffers;

--- a/client-tools/Utils/ClientTaskQueue.h
+++ b/client-tools/Utils/ClientTaskQueue.h
@@ -229,6 +229,8 @@ ClientTaskQueue<JobData>::~ClientTaskQueue() {
   for (auto& worker : _workers) {
     worker->beginShutdown();
   }
+
+  clearQueue();
   _jobsCondition.broadcast();
 }
 


### PR DESCRIPTION
### Scope & Purpose

Fix potential data races in task queue used by arangodump & arangorestore.
There could have been a race between the main arangodump/arangorestore thread checking if all jobs have been finished, and a queue worker thread popping a job from the job queue and only afterwards reporting as busy.

Tries to fix https://jenkins01.arangodb.biz/job/arangodb-ANY-linux-san.x86-64/1228/EDITION=enterprise,SAN_MODE=TSan,STORAGE_ENGINE=rocksdb,TEST_SUITE=single,limit=linux&&test&&x86-64/artifact/tsan.log.arangorestore.139376.log

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: -
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
