### PR TITLE
[CINFRA-523] Set assumedWaitForSync when creating replicated log

### DIFF
--- a/arangod/Replication2/ReplicatedLog/SupervisionAction.h
+++ b/arangod/Replication2/ReplicatedLog/SupervisionAction.h
@@ -112,6 +112,7 @@ struct AddLogToPlanAction {
         [&](LogCurrentSupervision& currentSupervision) {
           currentSupervision.assumedWriteConcern =
               _config.effectiveWriteConcern;
+          currentSupervision.assumedWaitForSync = _config.waitForSync;
         });
   }
 };

--- a/tests/Replication2/Helper/ModelChecker/Predicates.h
+++ b/tests/Replication2/Helper/ModelChecker/Predicates.h
@@ -203,4 +203,18 @@ static inline auto isPlannedWriteConcern(bool concern) {
   });
 }
 
+static inline auto isAssumedWaitForSyncFalse() {
+  return MC_BOOL_PRED(global, {
+    AgencyState const& state = global.state;
+    if (state.replicatedLog && state.replicatedLog->current &&
+        state.replicatedLog->current->supervision) {
+      return false ==
+             state.replicatedLog->current->supervision->assumedWaitForSync;
+    }
+    // This is intentional as it's ok for current to not exist, and we
+    // want to make sure that assumedWaitForSync is never *set* to *true*
+    return true;
+  });
+}
+
 }  // namespace arangodb::test::mcpreds

--- a/tests/Replication2/ReplicatedLog/SupervisionSimulationTest.cpp
+++ b/tests/Replication2/ReplicatedLog/SupervisionSimulationTest.cpp
@@ -103,6 +103,49 @@ TEST_F(ReplicatedLogSupervisionSimulationTest, check_log_created) {
   std::cout << result.stats << std::endl;
 }
 
+// Create a log with waitForSync = false in the configuration and
+// check that assumedWaitForSync is never true
+TEST_F(ReplicatedLogSupervisionSimulationTest,
+       check_log_created_with_correct_assumedwaitforsync) {
+  AgencyLogBuilder log;
+  log.setTargetConfig(LogTargetConfig(2, 2, false))
+      .setId(logId)
+      .setTargetParticipant("A", defaultFlags)
+      .setTargetParticipant("B", defaultFlags)
+      .setTargetParticipant("C", defaultFlags);
+
+  replicated_log::ParticipantsHealth health;
+  health._health.emplace(
+      "A", replicated_log::ParticipantHealth{.rebootId = RebootId(0),
+                                             .notIsFailed = true});
+  health._health.emplace(
+      "B", replicated_log::ParticipantHealth{.rebootId = RebootId(0),
+                                             .notIsFailed = true});
+  health._health.emplace(
+      "C", replicated_log::ParticipantHealth{.rebootId = RebootId(0),
+                                             .notIsFailed = true});
+
+  auto initState = makeAgencyState(log.get(), std::move(health));
+
+  auto driver = model_checker::ActorDriver{
+      SupervisionActor{},
+      DBServerActor{"A"},
+      DBServerActor{"B"},
+      DBServerActor{"C"},
+  };
+
+  auto allTests = model_checker::combined{
+      MC_ALWAYS(mcpreds::isAssumedWaitForSyncFalse()),
+      MC_EVENTUALLY_ALWAYS(mcpreds::isLeaderHealth()),
+  };
+  using Engine = model_checker::ActorEngine<model_checker::DFSEnumerator,
+                                            AgencyState, AgencyTransition>;
+
+  auto result = Engine::run(driver, allTests, initState);
+  EXPECT_FALSE(result.failed) << *result.failed;
+  std::cout << result.stats << std::endl;
+}
+
 TEST_F(ReplicatedLogSupervisionSimulationTest, check_log_leader_fails) {
   AgencyLogBuilder log;
   log.setTargetConfig(LogTargetConfig(2, 2, true))


### PR DESCRIPTION
### Scope & Purpose

Set `assumedWaitForSync` on log creation