### PR TITLE
Docs: Fix `/_api/control_pregel` HTTP API descriptions

### DIFF
--- a/Documentation/DocuBlocks/Rest/Documents/delete_mutliple_documents.md
+++ b/Documentation/DocuBlocks/Rest/Documents/delete_mutliple_documents.md
@@ -172,10 +172,9 @@ Unknown documents:
 
     var body = [ "1", "other/2" ];
     var response = logCurlRequest('DELETE', url, body);
-    var parsedBody = JSON.parse(response.body);
 
     assert(response.code === 202);
-  | parsedBody.forEach(function(doc) {
+  | response.parsedBody.forEach(function(doc) {
   |   assert(doc.error === true);
   |   assert(doc.errorNum === 1202);
     });
@@ -232,10 +231,9 @@ Revision conflict:
     ];
 
     var response = logCurlRequest('DELETE', url, body);
-    var parsedBody = JSON.parse(response.body);
 
     assert(response.code === 202);
-  | parsedBody.forEach(function(doc) {
+  | response.parsedBody.forEach(function(doc) {
   |   assert(doc.error === true);
   |   assert(doc.errorNum === 1200);
     });

--- a/Documentation/DocuBlocks/Rest/Pregel/1_struct.md
+++ b/Documentation/DocuBlocks/Rest/Pregel/1_struct.md
@@ -57,7 +57,7 @@ Is shown when the storing started.
 @RESTSTRUCT{gssTimes,get_api_control_pregel,array,optional,number}
 Computation time of each global super step. Is shown when the computation started.
 
-@RESTSTRUCT{reports,get_api_control_pregel,object,array,}
+@RESTSTRUCT{reports,get_api_control_pregel,array,required,object}
 This attribute is used by Programmable Pregel Algorithms (`air`, experimental).
 The value is only populated once the algorithm has finished.
 

--- a/Documentation/DocuBlocks/Rest/Pregel/1_struct.md
+++ b/Documentation/DocuBlocks/Rest/Pregel/1_struct.md
@@ -1,0 +1,117 @@
+@RESTSTRUCT{id,get_api_control_pregel,string,required,string}
+The ID of the Pregel job, as a string.
+
+@RESTSTRUCT{algorithm,get_api_control_pregel,string,required,string}
+The algorithm used by the job.
+
+@RESTSTRUCT{created,get_api_control_pregel,string,required,string}
+The date and time when the job was created.
+
+@RESTSTRUCT{expires,get_api_control_pregel,string,optional,string}
+The date and time when the job results expire. The expiration date is only
+meaningful for jobs that were completed, canceled or resulted in an error. Such jobs
+are cleaned up by the garbage collection when they reach their expiration date/time.
+
+@RESTSTRUCT{ttl,get_api_control_pregel,number,required,float}
+The TTL (time to live) value for the job results, specified in seconds.
+The TTL is used to calculate the expiration date for the job's results.
+
+@RESTSTRUCT{state,get_api_control_pregel,string,required,string}
+The state of the execution. The following values can be returned:
+- `"none"`: The Pregel run did not yet start.
+- `"loading"`: The graph is loaded from the database into memory before the execution of the algorithm.
+- `"running"`: The algorithm is executing normally.
+- `"storing"`: The algorithm finished, but the results are still being written
+  back into the collections. Occurs only if the store parameter is set to true.
+- `"done"`: The execution is done. In version 3.7.1 and later, this means that
+  storing is also done. In earlier versions, the results may not be written back
+  into the collections yet. This event is announced in the server log (requires
+  at least info log level for the `pregel` log topic).
+- `"canceled"`: The execution was permanently canceled, either by the user or by
+  an error.
+- `"fatal error"`: The execution has failed and cannot recover.
+- `"in error"`: The execution is in an error state. This can be
+  caused by DB-Servers being not reachable or being non responsive. The execution
+  might recover later, or switch to `"canceled"` if it was not able to recover
+  successfully. 
+- `"recovering"` (currently unused): The execution is actively recovering and
+  switches back to `running` if the recovery is successful.
+
+@RESTSTRUCT{gss,get_api_control_pregel,integer,required,int64}
+The number of global supersteps executed.
+
+@RESTSTRUCT{totalRuntime,get_api_control_pregel,number,required,float}
+The total runtime of the execution up to now (if the execution is still ongoing).
+
+@RESTSTRUCT{startupTime,get_api_control_pregel,number,required,float}
+The startup runtime of the execution.
+The startup time includes the data loading time and can be substantial.
+
+@RESTSTRUCT{computationTime,get_api_control_pregel,number,required,float}
+The algorithm execution time. Is shown when the computation started. 
+
+@RESTSTRUCT{storageTime,get_api_control_pregel,number,optional,float}
+The time for storing the results if the job includes results storage.
+Is shown when the storing started.
+
+@RESTSTRUCT{gssTimes,get_api_control_pregel,array,optional,number}
+Computation time of each global super step. Is shown when the computation started.
+
+@RESTSTRUCT{reports,get_api_control_pregel,object,array,}
+This attribute is used by Programmable Pregel Algorithms (`air`, experimental).
+The value is only populated once the algorithm has finished.
+
+@RESTSTRUCT{vertexCount,get_api_control_pregel,integer,optional,int64}
+The total number of vertices processed.
+
+@RESTSTRUCT{edgeCount,get_api_control_pregel,integer,optional,int64}
+The total number of edges processed.
+
+@RESTSTRUCT{detail,get_api_control_pregel,object,required,get_api_control_pregel_detail}
+The Pregel run details.
+
+@RESTSTRUCT{aggregatedStatus,get_api_control_pregel_detail,object,required,get_api_control_pregel_detail_aggregated}
+The aggregated details of the full Pregel run. The values are totals of all the
+DB-Server.
+
+@RESTSTRUCT{timeStamp,get_api_control_pregel_detail_aggregated,string,required,date-time}
+The time at which the status was measured.
+
+@RESTSTRUCT{graphStoreStatus,get_api_control_pregel_detail_aggregated,object,optional,get_api_control_pregel_detail_aggregated_store}
+The status of the in memory graph.
+
+@RESTSTRUCT{verticesLoaded,get_api_control_pregel_detail_aggregated_store,integer,optional,int64}
+The number of vertices that are loaded from the database into memory.
+
+@RESTSTRUCT{edgesLoaded,get_api_control_pregel_detail_aggregated_store,integer,optional,int64}
+The number of edges that are loaded from the database into memory.
+
+@RESTSTRUCT{memoryBytesUsed,get_api_control_pregel_detail_aggregated_store,integer,optional,int64}
+The number of bytes used in-memory for the loaded graph.
+
+@RESTSTRUCT{verticesStored,get_api_control_pregel_detail_aggregated_store,integer,optional,int64}
+The number of vertices that are written back to the database after the Pregel
+computation finished. It is only set if the `store` parameter is set to `true`.
+
+@RESTSTRUCT{allGssStatus,get_api_control_pregel_detail_aggregated,object,optional,get_api_control_pregel_detail_aggregated_gss}
+Information about the global supersteps.
+
+@RESTSTRUCT{items,get_api_control_pregel_detail_aggregated_gss,array,optional,get_api_control_pregel_detail_aggregated_gss_items}
+A list of objects with details for each global superstep.
+
+@RESTSTRUCT{verticesProcessed,get_api_control_pregel_detail_aggregated_gss_items,integer,optional,int64}
+The number of vertices that have been processed in this step.
+
+@RESTSTRUCT{messagesSent,get_api_control_pregel_detail_aggregated_gss_items,integer,optional,int64}
+The number of messages sent in this step.
+
+@RESTSTRUCT{messagesReceived,get_api_control_pregel_detail_aggregated_gss_items,integer,optional,int64}
+The number of messages received in this step.
+
+@RESTSTRUCT{memoryBytesUsedForMessages,get_api_control_pregel_detail_aggregated_gss_items,integer,optional,int64}
+The number of bytes used in memory for the messages in this step.
+
+@RESTSTRUCT{workerStatus,get_api_control_pregel_detail,object,required,}
+The details of the Pregel for every DB-Server. Each object key is a DB-Server ID,
+and each value is a nested object similar to the `aggregatedStatus` attribute.
+In a single server deployment, there is only a single entry with an empty string as key.

--- a/Documentation/DocuBlocks/Rest/Pregel/delete_api_control_pregel_cancel.md
+++ b/Documentation/DocuBlocks/Rest/Pregel/delete_api_control_pregel_cancel.md
@@ -57,7 +57,7 @@ started with `"store": false` and is in the done state:
   assert(response.code === 200);
 
   logJsonResponse(response);
-~ examples.dropGraph("connectedComponentsGraph");
+  examples.dropGraph("connectedComponentsGraph");
 
 @END_EXAMPLE_ARANGOSH_RUN
 

--- a/Documentation/DocuBlocks/Rest/Pregel/get_api_control_pregel_overview.md
+++ b/Documentation/DocuBlocks/Rest/Pregel/get_api_control_pregel_overview.md
@@ -15,67 +15,39 @@ Is returned when the list of jobs can be retrieved successfully.
 @RESTREPLYBODY{,array,required,get_api_control_pregel}
 A list of objects describing the Pregel jobs.
 
-@RESTSTRUCT{id,get_api_control_pregel,string,required,string}
-The ID of the Pregel job, as a string.
+@EXAMPLES
 
-@RESTSTRUCT{algorithm,get_api_control_pregel,string,required,string}
-The algorithm used by the job.
+Get the status of all active Pregel jobs:
 
-@RESTSTRUCT{created,get_api_control_pregel,string,required,string}
-The date and time when the job was created.
+@EXAMPLE_ARANGOSH_RUN{RestPregelStatusAllConnectedComponents}
 
-@RESTSTRUCT{expires,get_api_control_pregel,string,optional,string}
-The date and time when the job results expire. The expiration date is only
-meaningful for jobs that were completed, canceled or resulted in an error. Such jobs
-are cleaned up by the garbage collection when they reach their expiration date/time.
+  var assertInstanceOf = require("jsunity").jsUnity.assertions.assertInstanceOf;
+  var examples = require("@arangodb/graph-examples/example-graph.js");
+  var graph = examples.loadGraph("connectedComponentsGraph");
 
-@RESTSTRUCT{ttl,get_api_control_pregel,number,required,float}
-The TTL (time to live) value for the job results, specified in seconds.
-The TTL is used to calculate the expiration date for the job's results.
+  var url = "/_api/control_pregel";
+  var body = {
+    algorithm: "wcc",
+    graphName: "connectedComponentsGraph",
+    params: {
+      maxGSS: graph.components.count(),
+      resultField: "component"
+    }
+  };
+  var id = internal.arango.POST(url, body);
 
-@RESTSTRUCT{state,get_api_control_pregel,string,required,string}
-The state of the execution. The following values can be returned:
-- `"none"`: The Pregel run did not yet start.
-- `"loading"`: The graph is loaded from the database into memory before the execution of the algorithm.
-- `"running"`: The algorithm is executing normally.
-- `"storing"`: The algorithm finished, but the results are still being written
-  back into the collections. Occurs only if the store parameter is set to true.
-- `"done"`: The execution is done. In version 3.7.1 and later, this means that
-  storing is also done. In earlier versions, the results may not be written back
-  into the collections yet. This event is announced in the server log (requires
-  at least info log level for the `pregel` log topic).
-- `"canceled"`: The execution was permanently canceled, either by the user or by
-  an error.
-- `"fatal error"`: The execution has failed and cannot recover.
-- `"in error"`: The execution is in an error state. This can be
-  caused by DB-Servers being not reachable or being non responsive. The execution
-  might recover later, or switch to `"canceled"` if it was not able to recover
-  successfully.
-- `"recovering"` (currently unused): The execution is actively recovering and
-  switches back to `running` if the recovery is successful.
+  var url = "/_api/control_pregel/";
 
-@RESTSTRUCT{gss,get_api_control_pregel,integer,required,int64}
-The number of global supersteps executed.
+  var response = logCurlRequest("GET", url);
+  assert(response.code === 200);
+  assertInstanceOf(Array, response.parsedBody);
+  assert(response.parsedBody.length > 0);
 
-@RESTSTRUCT{totalRuntime,get_api_control_pregel,number,required,float}
-The total runtime of the execution up to now (if the execution is still ongoing).
+  internal.arango.DELETE(url + id);
 
-@RESTSTRUCT{startupTime,get_api_control_pregel,number,required,float}
-The startup runtime of the execution.
-The startup time includes the data loading time and can be substantial.
+  logJsonResponse(response);
+  examples.dropGraph("connectedComponentsGraph");
 
-@RESTSTRUCT{computationTime,get_api_control_pregel,number,required,float}
-The algorithm execution time. Is shown when the computation started.
-
-@RESTSTRUCT{storageTime,get_api_control_pregel,number,optional,float}
-The time for storing the results if the job includes results storage.
-Is shown when the storing started.
-
-@RESTSTRUCT{gssTimes,get_api_control_pregel,array,optional,number}
-Computation time of each global super step. Is shown when the computation started.
-
-@RESTSTRUCT{reports,get_api_control_pregel,object,optional,}
-Statistics about the Pregel execution. The value is only populated once
-the algorithm has finished.
+@END_EXAMPLE_ARANGOSH_RUN
 
 @endDocuBlock

--- a/Documentation/DocuBlocks/Rest/Pregel/get_api_control_pregel_status.md
+++ b/Documentation/DocuBlocks/Rest/Pregel/get_api_control_pregel_status.md
@@ -19,123 +19,7 @@ received messages.
 HTTP 200 is returned in case the job execution ID was valid and the state is
 returned along with the response.
 
-@RESTREPLYBODY{id,string,required,string}
-The ID of the Pregel job, as a string.
-
-@RESTREPLYBODY{algorithm,string,required,string}
-The algorithm used by the job.
-
-@RESTREPLYBODY{created,string,required,string}
-The date and time when the job was created.
-
-@RESTREPLYBODY{expires,string,optional,string}
-The date and time when the job results expire. The expiration date is only
-meaningful for jobs that were completed, canceled or resulted in an error. Such jobs
-are cleaned up by the garbage collection when they reach their expiration date/time.
-
-@RESTREPLYBODY{ttl,number,required,float}
-The TTL (time to live) value for the job results, specified in seconds.
-The TTL is used to calculate the expiration date for the job's results.
-
-@RESTREPLYBODY{state,string,required,string}
-The state of the execution. The following values can be returned:
-- `"none"`: The Pregel run did not yet start.
-- `"loading"`: The graph is loaded from the database into memory before the execution of the algorithm.
-- `"running"`: The algorithm is executing normally.
-- `"storing"`: The algorithm finished, but the results are still being written
-  back into the collections. Occurs only if the store parameter is set to true.
-- `"done"`: The execution is done. In version 3.7.1 and later, this means that
-  storing is also done. In earlier versions, the results may not be written back
-  into the collections yet. This event is announced in the server log (requires
-  at least info log level for the `pregel` log topic).
-- `"canceled"`: The execution was permanently canceled, either by the user or by
-  an error.
-- `"fatal error"`: The execution has failed and cannot recover.
-- `"in error"`: The execution is in an error state. This can be
-  caused by DB-Servers being not reachable or being non responsive. The execution
-  might recover later, or switch to `"canceled"` if it was not able to recover
-  successfully. 
-- `"recovering"` (currently unused): The execution is actively recovering and
-  switches back to `running` if the recovery is successful.
-
-@RESTREPLYBODY{gss,integer,required,int64}
-The number of global supersteps executed.
-
-@RESTREPLYBODY{totalRuntime,number,required,float}
-The total runtime of the execution up to now (if the execution is still ongoing).
-
-@RESTREPLYBODY{startupTime,number,required,float}
-The startup runtime of the execution.
-The startup time includes the data loading time and can be substantial.
-
-@RESTREPLYBODY{computationTime,number,required,float}
-The algorithm execution time. Is shown when the computation started.
-
-@RESTREPLYBODY{storageTime,number,optional,float}
-The time for storing the results if the job includes results storage.
-Is shown when the storing started.
-
-@RESTREPLYBODY{gssTimes,array,optional,number}
-Computation time of each global super step. Is shown when the computation started.
-
-@RESTREPLYBODY{reports,object,optional,get_api_control_pregel_reports}
-Statistics about the Pregel execution. The value is only populated once
-the algorithm has finished.
-
-@RESTSTRUCT{vertexCount,get_api_control_pregel_reports,integer,optional,int64}
-The total number of vertices processed.
-
-@RESTSTRUCT{edgeCount,get_api_control_pregel_reports,integer,optional,int64}
-The total number of edges processed.
-
-@RESTREPLYBODY{detail,object,required,get_api_control_pregel_detail}
-The Pregel run details.
-
-@RESTSTRUCT{aggregatedStatus,get_api_control_pregel_detail,object,required,get_api_control_pregel_detail_aggregated}
-The aggregated details of the full Pregel run. The values are totals of all the
-DB-Server.
-
-@RESTSTRUCT{timeStamp,get_api_control_pregel_detail_aggregated,string,required,date-time}
-The time at which the status was measured.
-
-@RESTSTRUCT{graphStoreStatus,get_api_control_pregel_detail_aggregated,object,optional,get_api_control_pregel_detail_aggregated_store}
-The status of the in memory graph.
-
-@RESTSTRUCT{verticesLoaded,get_api_control_pregel_detail_aggregated_store,integer,optional,int64}
-The number of vertices that are loaded from the database into memory.
-
-@RESTSTRUCT{edgesLoaded,get_api_control_pregel_detail_aggregated_store,integer,optional,int64}
-The number of edges that are loaded from the database into memory.
-
-@RESTSTRUCT{memoryBytesUsed,get_api_control_pregel_detail_aggregated_store,integer,optional,int64}
-The number of bytes used in-memory for the loaded graph.
-
-@RESTSTRUCT{verticesStored,get_api_control_pregel_detail_aggregated_store,integer,optional,int64}
-The number of vertices that are written back to the database after the Pregel
-computation finished. It is only set if the `store` parameter is set to `true`.
-
-@RESTSTRUCT{allGssStatus,get_api_control_pregel_detail_aggregated,object,optional,get_api_control_pregel_detail_aggregated_gss}
-Information about the global supersteps.
-
-@RESTSTRUCT{items,get_api_control_pregel_detail_aggregated_gss,array,optional,get_api_control_pregel_detail_aggregated_gss_items}
-A list of objects with details for each global superstep.
-
-@RESTSTRUCT{verticesProcessed,get_api_control_pregel_detail_aggregated_gss_items,integer,optional,int64}
-The number of vertices that have been processed in this step.
-
-@RESTSTRUCT{messagesSent,get_api_control_pregel_detail_aggregated_gss_items,integer,optional,int64}
-The number of messages sent in this step.
-
-@RESTSTRUCT{messagesReceived,get_api_control_pregel_detail_aggregated_gss_items,integer,optional,int64}
-The number of messages received in this step.
-
-@RESTSTRUCT{memoryBytesUsedForMessages,get_api_control_pregel_detail_aggregated_gss_items,integer,optional,int64}
-The number of bytes used in memory for the messages in this step.
-
-@RESTSTRUCT{workerStatus,get_api_control_pregel_detail,object,required,}
-The details of the Pregel for every DB-Server. Each object key is a DB-Server ID,
-and each value is a nested object similar to the `aggregatedStatus` attribute.
-In a single server deployment, there is only a single entry with an empty string as key.
+@RESTREPLYBODY{,object,required,get_api_control_pregel}
 
 @RESTRETURNCODE{404}
 An HTTP 404 error is returned if no Pregel job with the specified execution number
@@ -176,7 +60,7 @@ Get the execution status of a Pregel job:
   assert(response.code === 200);
 
   logJsonResponse(response);
-~ examples.dropGraph("connectedComponentsGraph");
+  examples.dropGraph("connectedComponentsGraph");
 
 @END_EXAMPLE_ARANGOSH_RUN
 

--- a/Documentation/DocuBlocks/Rest/Pregel/post_api_control_pregel_start.md
+++ b/Documentation/DocuBlocks/Rest/Pregel/post_api_control_pregel_start.md
@@ -116,7 +116,7 @@ the results in the vertices as attribute `component`:
       internal.sleep(0.5);
     }
   }
-~ examples.dropGraph("connectedComponentsGraph");
+  examples.dropGraph("connectedComponentsGraph");
 
 @END_EXAMPLE_ARANGOSH_RUN
 


### PR DESCRIPTION
- The Pregel status overview endpoint includes the `detail` attribute
- `vertexCount` and `edgeCount` are top-level attributes
- `reports` is only used by Custom Pregel / AIR
- Create a shared struct for Pregel status