### PR TITLE
attempt to fix a TSan issue

### DIFF
--- a/arangod/RestServer/TtlFeature.cpp
+++ b/arangod/RestServer/TtlFeature.cpp
@@ -468,6 +468,8 @@ void TtlFeature::validateOptions(std::shared_ptr<ProgramOptions> options) {
     FATAL_ERROR_EXIT();
   }
 
+  MUTEX_LOCKER(locker, _propertiesMutex);
+
   if (_properties.frequency > 0 &&
       _properties.frequency < TtlProperties::minFrequency) {
     LOG_TOPIC("ea696", FATAL, arangodb::Logger::STARTUP)
@@ -494,9 +496,13 @@ void TtlFeature::start() {
     return;
   }
 
-  // a frequency of 0 means the thread is not started at all
-  if (_properties.frequency == 0) {
-    return;
+  {
+    MUTEX_LOCKER(locker, _propertiesMutex);
+
+    // a frequency of 0 means the thread is not started at all
+    if (_properties.frequency == 0) {
+      return;
+    }
   }
 
   MUTEX_LOCKER(locker, _threadMutex);


### PR DESCRIPTION
### Scope & Purpose

Attempt to fix a TSan issue in TtlFeature. Some properties were accessed without holding a mutex during startup.
This should be safe (as there should be no concurrency at startup), but doesn't match the mutex usage in other code locations.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: *(Please link PR)*
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 