### PR TITLE
Cleanup of ast-modifications in TraversalExecutor (3.10)

### DIFF
--- a/arangod/Aql/TraversalExecutor.cpp
+++ b/arangod/Aql/TraversalExecutor.cpp
@@ -74,7 +74,6 @@ TraversalExecutorInfos::TraversalExecutorInfos(
     : _registerMapping(std::move(registerMapping)),
       _fixedSource(std::move(fixedSource)),
       _inputRegister(inputRegister),
-      _ast(ast),
       _uniqueVertices(vertexUniqueness),
       _uniqueEdges(edgeUniqueness),
       _order(order),
@@ -89,8 +88,6 @@ TraversalExecutorInfos::TraversalExecutorInfos(
   TRI_ASSERT(_fixedSource.empty() ||
              (!_fixedSource.empty() &&
               _inputRegister.value() == RegisterId::maxRegisterId));
-  // All Nodes are located in the AST it cannot be non-existing.
-  TRI_ASSERT(_ast != nullptr);
 
   /*
    * In the refactored variant we need to parse the correct enumerator type
@@ -124,7 +121,6 @@ TraversalExecutorInfos::TraversalExecutorInfos(
     : _registerMapping(std::move(registerMapping)),
       _fixedSource(std::move(fixedSource)),
       _inputRegister(inputRegister),
-      _ast(ast),
       _uniqueVertices(vertexUniqueness),
       _uniqueEdges(edgeUniqueness),
       _order(order),
@@ -137,8 +133,6 @@ TraversalExecutorInfos::TraversalExecutorInfos(
   TRI_ASSERT(_fixedSource.empty() ||
              (!_fixedSource.empty() &&
               _inputRegister.value() == RegisterId::maxRegisterId));
-  // All Nodes are located in the AST it cannot be non-existing.
-  TRI_ASSERT(_ast != nullptr);
 
   TRI_ASSERT(!ServerState::instance()->isCoordinator());
   /*
@@ -178,8 +172,6 @@ bool TraversalExecutorInfos::useEdgeOutput() const {
 bool TraversalExecutorInfos::usePathOutput() const {
   return usesOutputRegister(TraversalExecutorInfosHelper::OutputName::PATH);
 }
-
-Ast* TraversalExecutorInfos::getAst() const { return _ast; }
 
 std::string TraversalExecutorInfos::typeToString(
     TraversalExecutorInfosHelper::OutputName type) {
@@ -254,6 +246,11 @@ TraverserOptions::Order TraversalExecutorInfos::getOrder() const {
 }
 
 transaction::Methods* TraversalExecutorInfos::getTrx() { return _trx; }
+
+arangodb::aql::QueryContext& TraversalExecutorInfos::getQuery() {
+  return _query;
+}
+
 arangodb::aql::QueryWarnings& TraversalExecutorInfos::getWarnings() {
   return _query.warnings();
 }
@@ -372,6 +369,7 @@ auto TraversalExecutorInfos::parseTraversalEnumeratorCluster(
 
 TraversalExecutor::TraversalExecutor(Fetcher& fetcher, Infos& infos)
     : _infos(infos),
+      _ast(infos.getQuery()),
       _inputRow{CreateInvalidInputRowHint{}},
       _traversalEnumerator(nullptr) {
   // reset the traverser, so that no residual state is left in it. This is
@@ -526,7 +524,8 @@ bool TraversalExecutor::initTraverser(AqlItemBlockInputRange& input) {
                                            "allowed");
     } else {
       // prepare index
-      traversalEnumerator()->prepareIndexExpressions(_infos.getAst());
+      _ast.clearMost();
+      traversalEnumerator()->prepareIndexExpressions(&_ast);
 
       // start actual search
       traversalEnumerator()->reset(toHashedStringRef(

--- a/arangod/Aql/TraversalExecutor.h
+++ b/arangod/Aql/TraversalExecutor.h
@@ -25,6 +25,7 @@
 
 #include "Aql/AqlCall.h"
 #include "Aql/AqlItemBlockInputRange.h"
+#include "Aql/Ast.h"
 #include "Aql/ExecutionState.h"
 #include "Aql/InputAqlItemRow.h"
 #include "Aql/RegisterInfos.h"
@@ -128,8 +129,6 @@ class TraversalExecutorInfos {
 
   RegisterId getInputRegister() const;
 
-  Ast* getAst() const;
-
   auto parseTraversalEnumeratorSingleServer(
       traverser::TraverserOptions::Order order,
       traverser::TraverserOptions::UniquenessLevel uniqueVertices,
@@ -156,6 +155,7 @@ class TraversalExecutorInfos {
   traverser::TraverserOptions::UniquenessLevel getUniqueEdges() const;
   traverser::TraverserOptions::Order getOrder() const;
   transaction::Methods* getTrx();
+  arangodb::aql::QueryContext& getQuery();
   arangodb::aql::QueryWarnings& getWarnings();
 
  private:
@@ -173,8 +173,6 @@ class TraversalExecutorInfos {
       _registerMapping;
   std::string _fixedSource;
   RegisterId _inputRegister;
-
-  Ast* _ast;
   traverser::TraverserOptions::UniquenessLevel _uniqueVertices;
   traverser::TraverserOptions::UniquenessLevel _uniqueEdges;
   traverser::TraverserOptions::Order _order;
@@ -200,8 +198,8 @@ class TraversalExecutor {
   using Stats = TraversalStats;
 
   TraversalExecutor() = delete;
-  TraversalExecutor(TraversalExecutor&&) = default;
-  TraversalExecutor(TraversalExecutor const&) = default;
+  TraversalExecutor(TraversalExecutor&&) = delete;
+  TraversalExecutor(TraversalExecutor const&) = delete;
   TraversalExecutor(Fetcher& fetcher, Infos&);
   ~TraversalExecutor();
 
@@ -223,6 +221,10 @@ class TraversalExecutor {
 
  private:
   Infos& _infos;
+
+  // an AST owned by the TraversalExecutor, used to store data of index
+  // expressions
+  Ast _ast;
   InputAqlItemRow _inputRow;
 
   /// @brief the refactored finder variant.

--- a/arangod/Graph/Enumerators/OneSidedEnumerator.cpp
+++ b/arangod/Graph/Enumerators/OneSidedEnumerator.cpp
@@ -85,7 +85,7 @@ void OneSidedEnumerator<Configuration>::clear(bool keepPathStore) {
 
   if (!keepPathStore) {
     _interior.reset();
-    clearProvider();  // TODO: Check usage of keepPathStore (if necessary)
+    clearProvider();
   }
 }
 


### PR DESCRIPTION
Backport of: https://github.com/arangodb/arangodb/pull/16774