### PR TITLE
Bug fix/limit size of arangodlogs

### DIFF
--- a/js/client/modules/@arangodb/testutils/instance.js
+++ b/js/client/modules/@arangodb/testutils/instance.js
@@ -515,9 +515,9 @@ class instance {
 
   readAssertLogLines () {
     let size = fs.size(this.logFile);
-    if (size > 500000) {
+    if (size > this.options.maxLogFileSize) {
       // File bigger 500k? this needs to be a bug in the tests.
-      let err=`ERROR: ${this.logFile} is bigger than 500kB! - %{size} Bytes!`;
+      let err=`ERROR: ${this.logFile} is bigger than ${this.options.maxLogFileSize/1000}kB! - %{size/1000} Bytes!`;
       this.assertLines.push(err);
       print(RED + err + RESET);
       return;

--- a/js/client/modules/@arangodb/testutils/instance.js
+++ b/js/client/modules/@arangodb/testutils/instance.js
@@ -514,9 +514,10 @@ class instance {
   // //////////////////////////////////////////////////////////////////////////////
 
   readAssertLogLines () {
-    if (fs.size(this.logFile) > 500000) {
+    let size = fs.size(this.logFile);
+    if (size > 500000) {
       // File bigger 500k? this needs to be a bug in the tests.
-      let err=`ERROR: ${this.logFile} is bigger than 500kB!`;
+      let err=`ERROR: ${this.logFile} is bigger than 500kB! - %{size} Bytes!`;
       this.assertLines.push(err);
       print(RED + err + RESET);
       return;

--- a/js/client/modules/@arangodb/testutils/instance.js
+++ b/js/client/modules/@arangodb/testutils/instance.js
@@ -515,7 +515,7 @@ class instance {
 
   readAssertLogLines () {
     let size = fs.size(this.logFile);
-    if (this.options.maxLogFileSize != 0 && size > this.options.maxLogFileSize) {
+    if (this.options.maxLogFileSize !== 0 && size > this.options.maxLogFileSize) {
       // File bigger 500k? this needs to be a bug in the tests.
       let err=`ERROR: ${this.logFile} is bigger than ${this.options.maxLogFileSize/1024}kB! - %{size/1024} Bytes!`;
       this.assertLines.push(err);

--- a/js/client/modules/@arangodb/testutils/instance.js
+++ b/js/client/modules/@arangodb/testutils/instance.js
@@ -514,6 +514,13 @@ class instance {
   // //////////////////////////////////////////////////////////////////////////////
 
   readAssertLogLines () {
+    if (fs.size(this.logFile) > 500000) {
+      // File bigger 500k? this needs to be a bug in the tests.
+      let err=`ERROR: ${this.logFile} is bigger than 500kB!`;
+      this.assertLines.push(err);
+      print(RED + err + RESET);
+      return;
+    }
     try {
       const buf = fs.readBuffer(this.logFile);
       let lineStart = 0;
@@ -535,8 +542,9 @@ class instance {
         }
       }
     } catch (ex) {
-      print("failed to read " + this.logFile + " -> " + ex);
-      this.assertLines.push("failed to read " + this.logFile + " -> " + ex);
+      let err="failed to read " + this.logFile + " -> " + ex;
+      this.assertLines.push(err);
+      print(RED+err+RESET);
     }
   }
   terminateInstance() {

--- a/js/client/modules/@arangodb/testutils/instance.js
+++ b/js/client/modules/@arangodb/testutils/instance.js
@@ -515,9 +515,9 @@ class instance {
 
   readAssertLogLines () {
     let size = fs.size(this.logFile);
-    if (size > this.options.maxLogFileSize) {
+    if (this.options.maxLogFileSize != 0 && size > this.options.maxLogFileSize) {
       // File bigger 500k? this needs to be a bug in the tests.
-      let err=`ERROR: ${this.logFile} is bigger than ${this.options.maxLogFileSize/1000}kB! - %{size/1000} Bytes!`;
+      let err=`ERROR: ${this.logFile} is bigger than ${this.options.maxLogFileSize/1024}kB! - %{size/1024} Bytes!`;
       this.assertLines.push(err);
       print(RED + err + RESET);
       return;

--- a/js/client/modules/@arangodb/testutils/testing.js
+++ b/js/client/modules/@arangodb/testutils/testing.js
@@ -59,6 +59,7 @@ let optionsDocumentation = [
   '   - `testOutput`: set the output directory for testresults, defaults to `out`',
   '   - `force`: if set to true the tests are continued even if one fails',
   '',
+  '   - `maxLogFileSize`: how big logs should be at max - 500k by default',
   "   - `skipLogAnalysis`: don't try to crawl the server logs",
   '   - `skipMemoryIntense`: tests using lots of resources will be skipped.',
   '   - `skipNightly`: omit the nightly tests',
@@ -207,6 +208,7 @@ const optionsDefaults = {
   'sniffDevice': undefined,
   'sniffProgram': undefined,
   'skipLogAnalysis': true,
+  'maxLogFileSize': 500000, // 500k
   'skipMemoryIntense': false,
   'skipNightly': true,
   'skipNondeterministic': false,

--- a/js/client/modules/@arangodb/testutils/testing.js
+++ b/js/client/modules/@arangodb/testutils/testing.js
@@ -208,7 +208,7 @@ const optionsDefaults = {
   'sniffDevice': undefined,
   'sniffProgram': undefined,
   'skipLogAnalysis': true,
-  'maxLogFileSize': 500000, // 500k
+  'maxLogFileSize': 500 * 1024,
   'skipMemoryIntense': false,
   'skipNightly': true,
   'skipNondeterministic': false,


### PR DESCRIPTION
### Scope & Purpose

as seen previously forgetting debug logging in tests leads to unstable CI. Assert this for green tests.

- [x] :hankey: Bugfix
