### PR TITLE
[CINFRA-528] Add commandline option to set default replication version.

### DIFF
--- a/arangod/Replication2/Version.h
+++ b/arangod/Replication2/Version.h
@@ -26,6 +26,9 @@
 #include <string>
 #include <string_view>
 
+#include <ProgramOptions/Parameters.h>
+#include <Basics/ResultT.h>
+
 namespace arangodb {
 template<typename T>
 class ResultT;
@@ -42,5 +45,37 @@ auto parseVersion(std::string_view version) -> ResultT<replication::Version>;
 auto parseVersion(velocypack::Slice version) -> ResultT<replication::Version>;
 
 auto versionToString(Version version) -> std::string_view;
+
+struct ReplicationVersionParameter : public options::Parameter {
+  typedef Version ValueType;
+
+  explicit ReplicationVersionParameter(ValueType* ptr) : ptr(ptr) {}
+
+  std::string name() const override { return "replicationVersion"; }
+  std::string valueString() const override {
+    return std::string{versionToString(*ptr)};
+  }
+
+  std::string set(std::string const& value) override {
+    auto r = parseVersion(value);
+    if (r.ok()) {
+      *ptr = r.get();
+      return "";
+    } else {
+      return std::string{r.errorMessage()};
+    }
+  }
+
+  std::string typeDescription() const override {
+    return Parameter::typeDescription();
+  }
+
+  void toVelocyPack(VPackBuilder& builder, bool detailed) const override {
+    builder.add(VPackValue(versionToString(*ptr)));
+  }
+
+  ValueType* ptr;
+  bool required;
+};
 
 }  // namespace arangodb::replication

--- a/arangod/RestServer/DatabaseFeature.cpp
+++ b/arangod/RestServer/DatabaseFeature.cpp
@@ -39,7 +39,6 @@
 #include "Basics/WriteLocker.h"
 #include "Basics/application-exit.h"
 #include "Basics/files.h"
-#include "Basics/StaticStrings.h"
 #include "Cluster/ServerState.h"
 #include "GeneralServer/AuthenticationFeature.h"
 #include "IResearch/IResearchAnalyzerFeature.h"
@@ -473,12 +472,16 @@ DatabaseFeature::~DatabaseFeature() {
 void DatabaseFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
   options->addSection("database", "database options");
 
-  options->addOption(
-      "--database.default-replication-version",
-      "default replication version, can be overwritten "
-      "when creating a new database",
-      new replication::ReplicationVersionParameter(&_defaultReplicationVersion),
-      arangodb::options::makeDefaultFlags(arangodb::options::Flags::Uncommon));
+  options
+      ->addOption("--database.default-replication-version",
+                  "default replication version, can be overwritten "
+                  "when creating a new database, possible values: 1, 2",
+                  new replication::ReplicationVersionParameter(
+                      &_defaultReplicationVersion),
+                  arangodb::options::makeDefaultFlags(
+                      arangodb::options::Flags::Uncommon,
+                      arangodb::options::Flags::Experimental))
+      .setIntroducedIn(31100);
 
   options->addOption(
       "--database.wait-for-sync",

--- a/arangod/RestServer/DatabaseFeature.cpp
+++ b/arangod/RestServer/DatabaseFeature.cpp
@@ -53,15 +53,16 @@
 #include "ProgramOptions/Section.h"
 #include "Replication/ReplicationClients.h"
 #include "Replication/ReplicationFeature.h"
+#include "Replication2/Version.h"
 #include "RestServer/DatabaseFeature.h"
 #include "RestServer/DatabasePathFeature.h"
 #include "RestServer/QueryRegistryFeature.h"
 #include "StorageEngine/EngineSelectorFeature.h"
 #include "StorageEngine/StorageEngine.h"
+#include "Utilities/NameValidator.h"
 #include "Utils/CollectionNameResolver.h"
 #include "Utils/CursorRepository.h"
 #include "Utils/Events.h"
-#include "Utilities/NameValidator.h"
 #include "V8Server/V8DealerFeature.h"
 #include "VocBase/LogicalCollection.h"
 #include "VocBase/ticks.h"
@@ -448,6 +449,7 @@ DatabaseFeature::DatabaseFeature(Server& server)
       _isInitiallyEmpty(false),
       _checkVersion(false),
       _upgrade(false),
+      _defaultReplicationVersion(replication::Version::ONE),
       _extendedNamesForDatabases(false),
       _performIOHeartbeat(true),
       _databasesLists(new DatabasesLists()),
@@ -470,6 +472,13 @@ DatabaseFeature::~DatabaseFeature() {
 
 void DatabaseFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
   options->addSection("database", "database options");
+
+  options->addOption(
+      "--database.default-replication-version",
+      "default replication version, can be overwritten "
+      "when creating a new database",
+      new replication::ReplicationVersionParameter(&_defaultReplicationVersion),
+      arangodb::options::makeDefaultFlags(arangodb::options::Flags::Uncommon));
 
   options->addOption(
       "--database.wait-for-sync",

--- a/arangod/RestServer/DatabaseFeature.h
+++ b/arangod/RestServer/DatabaseFeature.h
@@ -30,6 +30,7 @@
 #include "Metrics/Counter.h"
 #include "Metrics/Histogram.h"
 #include "Metrics/LogScale.h"
+#include "Replication2/Version.h"
 #include "RestServer/arangod.h"
 #include "Utils/VersionTracker.h"
 #include "VocBase/voc-types.h"
@@ -182,6 +183,9 @@ class DatabaseFeature : public ArangodFeature {
   bool forceSyncProperties() const { return _forceSyncProperties; }
   void forceSyncProperties(bool value) { _forceSyncProperties = value; }
   bool waitForSync() const { return _defaultWaitForSync; }
+  replication::Version defaultReplicationVersion() const {
+    return _defaultReplicationVersion;
+  }
 
   /// @brief whether or not extended names for databases can be used
   bool extendedNamesForDatabases() const { return _extendedNamesForDatabases; }
@@ -244,6 +248,7 @@ class DatabaseFeature : public ArangodFeature {
   bool _isInitiallyEmpty;
   bool _checkVersion;
   bool _upgrade;
+  replication::Version _defaultReplicationVersion;
 
   /// @brief whether or not the allow extended database names
   bool _extendedNamesForDatabases;

--- a/arangod/VocBase/VocbaseInfo.cpp
+++ b/arangod/VocBase/VocbaseInfo.cpp
@@ -318,7 +318,9 @@ VocbaseOptions getVocbaseOptions(ArangodServer& server, VPackSlice options) {
   vocbaseOptions.replicationFactor = 1;
   vocbaseOptions.writeConcern = 1;
   vocbaseOptions.sharding = "";
-  vocbaseOptions.replicationVersion = replication::Version::ONE;
+
+  vocbaseOptions.replicationVersion =
+      server.getFeature<DatabaseFeature>().defaultReplicationVersion();
 
   //  sanitize input for vocbase creation
   //  sharding -- must be "", "flexible" or "single"


### PR DESCRIPTION
### Scope & Purpose

When starting `arangod` one can now give the parameter `--database.default-replication-version <replicationVersion>` to set the default replication to either `1` or `2`.