### PR TITLE
Rename: search to search-alias

### DIFF
--- a/arangod/Aql/IResearchViewNode.cpp
+++ b/arangod/Aql/IResearchViewNode.cpp
@@ -688,7 +688,7 @@ ViewSnapshotPtr snapshotSingleServer(IResearchViewNode const& node,
     return {};
   }
   auto links = [&] {
-    if (view.type() == ViewType::kView) {
+    if (view.type() == ViewType::kArangoSearch) {
       auto const& viewImpl = basics::downCast<IResearchView>(view);
       return viewImpl.getLinks();
     } else {
@@ -706,7 +706,7 @@ ViewSnapshotPtr snapshotSingleServer(IResearchViewNode const& node,
 
 std::shared_ptr<SearchMeta const> getMeta(
     std::shared_ptr<LogicalView const> const& view) {
-  if (!view || view->type() != ViewType::kSearch) {
+  if (!view || view->type() != ViewType::kSearchAlias) {
     return {};
   }
   return basics::downCast<Search>(*view).meta();
@@ -716,11 +716,11 @@ IResearchSortBase const& primarySort(
     std::shared_ptr<SearchMeta const> const& meta,
     std::shared_ptr<LogicalView const> const& view) {
   if (meta) {
-    TRI_ASSERT(!view || view->type() == ViewType::kSearch);
+    TRI_ASSERT(!view || view->type() == ViewType::kSearchAlias);
     return meta->primarySort;
   }
   TRI_ASSERT(view);
-  TRI_ASSERT(view->type() == ViewType::kView);
+  TRI_ASSERT(view->type() == ViewType::kArangoSearch);
   if (ServerState::instance()->isCoordinator()) {
     auto const& viewImpl = basics::downCast<IResearchViewCoordinator>(*view);
     return viewImpl.primarySort();
@@ -733,11 +733,11 @@ IResearchViewStoredValues const& storedValues(
     std::shared_ptr<SearchMeta const> const& meta,
     std::shared_ptr<LogicalView const> const& view) {
   if (meta) {
-    TRI_ASSERT(!view || view->type() == ViewType::kSearch);
+    TRI_ASSERT(!view || view->type() == ViewType::kSearchAlias);
     return meta->storedValues;
   }
   TRI_ASSERT(view);
-  TRI_ASSERT(view->type() == ViewType::kView);
+  TRI_ASSERT(view->type() == ViewType::kArangoSearch);
   if (ServerState::instance()->isCoordinator()) {
     auto const& viewImpl = basics::downCast<IResearchViewCoordinator>(*view);
     return viewImpl.storedValues();
@@ -1068,7 +1068,7 @@ IResearchViewNode::IResearchViewNode(
   // FIXME any other way to validate options before object creation???
   std::string error;
   TRI_ASSERT(_view);
-  TRI_ASSERT(_meta || _view->type() != ViewType::kSearch);
+  TRI_ASSERT(_meta || _view->type() != ViewType::kSearchAlias);
   if (!parseOptions(ast->query(), *_view, options, _options, error)) {
     THROW_ARANGO_EXCEPTION_MESSAGE(
         TRI_ERROR_BAD_PARAMETER,
@@ -1355,7 +1355,7 @@ void IResearchViewNode::doToVelocyPack(VPackBuilder& nodes,
   // system info
   nodes.add(NODE_DATABASE_PARAM, VPackValue(_vocbase.name()));
   TRI_ASSERT(_view);
-  TRI_ASSERT(_meta || _view->type() != ViewType::kSearch);
+  TRI_ASSERT(_meta || _view->type() != ViewType::kSearchAlias);
   // need 'view' field to correctly print view name in JS explanation
   nodes.add(NODE_VIEW_NAME_PARAM, VPackValue(_view->name()));
   if (!_meta) {

--- a/arangod/Aql/IResearchViewOptimizerRules.cpp
+++ b/arangod/Aql/IResearchViewOptimizerRules.cpp
@@ -68,11 +68,11 @@ IResearchSortBase const& primarySort(
     std::shared_ptr<SearchMeta const> const& meta,
     std::shared_ptr<LogicalView const> const& view) {
   if (meta) {
-    TRI_ASSERT(!view || view->type() == ViewType::kSearch);
+    TRI_ASSERT(!view || view->type() == ViewType::kSearchAlias);
     return meta->primarySort;
   }
   TRI_ASSERT(view);
-  TRI_ASSERT(view->type() == ViewType::kView);
+  TRI_ASSERT(view->type() == ViewType::kArangoSearch);
   if (ServerState::instance()->isCoordinator()) {
     auto const& viewImpl = basics::downCast<IResearchViewCoordinator>(*view);
     return viewImpl.primarySort();
@@ -85,11 +85,11 @@ IResearchViewStoredValues const& storedValues(
     std::shared_ptr<SearchMeta const> const& meta,
     std::shared_ptr<LogicalView const> const& view) {
   if (meta) {
-    TRI_ASSERT(!view || view->type() == ViewType::kSearch);
+    TRI_ASSERT(!view || view->type() == ViewType::kSearchAlias);
     return meta->storedValues;
   }
   TRI_ASSERT(view);
-  TRI_ASSERT(view->type() == ViewType::kView);
+  TRI_ASSERT(view->type() == ViewType::kArangoSearch);
   if (ServerState::instance()->isCoordinator()) {
     auto const& viewImpl = basics::downCast<IResearchViewCoordinator>(*view);
     return viewImpl.storedValues();

--- a/arangod/Cluster/ClusterInfo.cpp
+++ b/arangod/Cluster/ClusterInfo.cpp
@@ -1284,7 +1284,7 @@ void ClusterInfo::loadPlan() {
 
   // Ensure "arangosearch" views are being created BEFORE collections
   // to allow collection's links find them
-  ensureViews(iresearch::StaticStrings::ViewType);
+  ensureViews(iresearch::StaticStrings::ViewArangoSearchType);
 
   // "Plan":{"Analyzers": {
   //  "_system": {
@@ -1636,10 +1636,10 @@ void ClusterInfo::loadPlan() {
                                     std::move(databaseCollections));
   }
 
-  // Ensure "search" views are being created AFTER collections
+  // Ensure "search-alias" views are being created AFTER collections
   // to allow views find collection's inverted indexes
   if (ServerState::instance()->isCoordinator()) {
-    ensureViews(iresearch::StaticStrings::SearchType);
+    ensureViews(iresearch::StaticStrings::ViewSearchAliasType);
   }
 
   // And now for replicated logs

--- a/arangod/IResearch/IResearchCommon.cpp
+++ b/arangod/IResearch/IResearchCommon.cpp
@@ -27,7 +27,7 @@
 namespace arangodb {
 namespace iresearch {
 
-LogTopic TOPIC{std::string{StaticStrings::ViewType}, LogLevel::INFO};
+LogTopic TOPIC{std::string{"arangosearch"}, LogLevel::INFO};
 
 }  // namespace iresearch
 }  // namespace arangodb

--- a/arangod/IResearch/IResearchCommon.h
+++ b/arangod/IResearch/IResearchCommon.h
@@ -93,8 +93,8 @@ constexpr std::string_view getFormat(LinkVersion version) noexcept {
 }
 
 struct StaticStrings {
-  static constexpr std::string_view ViewType = "arangosearch";
-  static constexpr std::string_view SearchType = "search";
+  static constexpr std::string_view ViewArangoSearchType = "arangosearch";
+  static constexpr std::string_view ViewSearchAliasType = "search-alias";
 
   ////////////////////////////////////////////////////////////////////////////////
   /// @brief the name of the field in the IResearch View definition denoting the

--- a/arangod/IResearch/IResearchDataStore.cpp
+++ b/arangod/IResearch/IResearchDataStore.cpp
@@ -1662,7 +1662,7 @@ irs::utf8_path getPersistedPath(DatabasePathFeature const& dbPathFeature,
   dataPath /= "databases";
   dataPath /= "database-";
   dataPath += std::to_string(link.collection().vocbase().id());
-  dataPath /= StaticStrings::ViewType;
+  dataPath /= StaticStrings::ViewArangoSearchType;
   dataPath += "-";
   // has to be 'id' since this can be a per-shard collection
   dataPath += std::to_string(link.collection().id().id());

--- a/arangod/IResearch/IResearchFeature.cpp
+++ b/arangod/IResearch/IResearchFeature.cpp
@@ -469,7 +469,7 @@ bool upgradeSingleServerArangoSearchView0_1(
     dataPath /= "databases";
     dataPath /= "database-";
     dataPath += std::to_string(vocbase.id());
-    dataPath /= arangodb::iresearch::StaticStrings::ViewType;
+    dataPath /= arangodb::iresearch::StaticStrings::ViewArangoSearchType;
     dataPath += "-";
     dataPath += std::to_string(view->id().id());
 
@@ -587,7 +587,8 @@ void registerSingleFactory(
     auto& engine = server.getFeature<T>();
     auto& engineFactory = const_cast<IndexFactory&>(engine.indexFactory());
     Result res = engineFactory.emplace(
-        std::string{arangodb::iresearch::StaticStrings::ViewType}, factory);
+        std::string{arangodb::iresearch::StaticStrings::ViewArangoSearchType},
+        factory);
     if (!res.ok()) {
       THROW_ARANGO_EXCEPTION_MESSAGE(
           res.errorNumber(),
@@ -727,20 +728,25 @@ void registerViewFactory(ArangodServer& server) {
   // DB server in custer or single-server
   auto& viewTypes = server.getFeature<ViewTypesFeature>();
   if (ServerState::instance()->isCoordinator()) {
-    r = viewTypes.emplace(arangodb::iresearch::StaticStrings::ViewType,
-                          IResearchViewCoordinator::factory());
+    r = viewTypes.emplace(
+        arangodb::iresearch::StaticStrings::ViewArangoSearchType,
+        IResearchViewCoordinator::factory());
     check();
-    r = viewTypes.emplace(arangodb::iresearch::StaticStrings::SearchType,
-                          Search::factory());
+    r = viewTypes.emplace(
+        arangodb::iresearch::StaticStrings::ViewSearchAliasType,
+        Search::factory());
   } else if (ServerState::instance()->isSingleServer()) {
-    r = viewTypes.emplace(arangodb::iresearch::StaticStrings::ViewType,
-                          IResearchView::factory());
+    r = viewTypes.emplace(
+        arangodb::iresearch::StaticStrings::ViewArangoSearchType,
+        IResearchView::factory());
     check();
-    r = viewTypes.emplace(arangodb::iresearch::StaticStrings::SearchType,
-                          Search::factory());
+    r = viewTypes.emplace(
+        arangodb::iresearch::StaticStrings::ViewSearchAliasType,
+        Search::factory());
   } else if (ServerState::instance()->isDBServer()) {
-    r = viewTypes.emplace(arangodb::iresearch::StaticStrings::ViewType,
-                          IResearchView::factory());
+    r = viewTypes.emplace(
+        arangodb::iresearch::StaticStrings::ViewArangoSearchType,
+        IResearchView::factory());
   } else {
     THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_FAILED,
                                    "Invalid role for view creation.");
@@ -764,10 +770,10 @@ Result transactionDataSourceRegistrationCallback(LogicalDataSource& dataSource,
     return {TRI_ERROR_INTERNAL};
   }
 
-  if (view->type() == ViewType::kSearch) {
+  if (view->type() == ViewType::kSearchAlias) {
     auto& impl = basics::downCast<Search>(*view);
     return {impl.apply(trx) ? TRI_ERROR_NO_ERROR : TRI_ERROR_INTERNAL};
-  } else if (view->type() == ViewType::kView) {
+  } else if (view->type() == ViewType::kArangoSearch) {
     auto& impl = basics::downCast<IResearchView>(*view);
     return {impl.apply(trx) ? TRI_ERROR_NO_ERROR : TRI_ERROR_INTERNAL};
   }

--- a/arangod/IResearch/IResearchLink.cpp
+++ b/arangod/IResearch/IResearchLink.cpp
@@ -195,7 +195,7 @@ Result IResearchLink::toView(std::shared_ptr<LogicalView> const& logical,
   if (!logical) {
     return {};
   }
-  if (logical->type() != ViewType::kView) {
+  if (logical->type() != ViewType::kArangoSearch) {
     return {TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND,
             "error finding view: '" + _viewGuid + "' for link '" +
                 std::to_string(_id.id()) + "' : no such view"};
@@ -429,7 +429,8 @@ Result IResearchLink::properties(velocypack::Builder& builder,
   builder.add(arangodb::StaticStrings::IndexId,
               velocypack::Value(std::to_string(_id.id())));
   builder.add(arangodb::StaticStrings::IndexType,
-              velocypack::Value(arangodb::iresearch::StaticStrings::ViewType));
+              velocypack::Value(
+                  arangodb::iresearch::StaticStrings::ViewArangoSearchType));
   builder.add(StaticStrings::ViewIdField, velocypack::Value(_viewGuid));
 
   return {};
@@ -440,7 +441,9 @@ Index::IndexType IResearchLink::type() {
   return Index::TRI_IDX_TYPE_IRESEARCH_LINK;
 }
 
-char const* IResearchLink::typeName() { return StaticStrings::ViewType.data(); }
+char const* IResearchLink::typeName() {
+  return StaticStrings::ViewArangoSearchType.data();
+}
 
 bool IResearchLink::setCollectionName(irs::string_ref name) noexcept {
   TRI_ASSERT(!name.empty());

--- a/arangod/IResearch/IResearchLinkHelper.cpp
+++ b/arangod/IResearch/IResearchLinkHelper.cpp
@@ -184,7 +184,8 @@ Result createLink(LogicalCollection& collection,
   velocypack::Builder builder;
   builder.openObject();
   builder.add(arangodb::StaticStrings::IndexType,
-              velocypack::Value(arangodb::iresearch::StaticStrings::ViewType));
+              velocypack::Value(
+                  arangodb::iresearch::StaticStrings::ViewArangoSearchType));
   builder.add(arangodb::iresearch::StaticStrings::ViewIdField,
               velocypack::Value(view.guid()));
   if (!mergeSliceSkipKeys(builder, definition, acceptor)) {
@@ -328,7 +329,8 @@ Result modifyLinks(std::unordered_set<DataSourceId>& modified, ViewType& view,
     namedJson.openObject();
     namedJson.add(
         arangodb::StaticStrings::IndexType,
-        velocypack::Value(arangodb::iresearch::StaticStrings::ViewType));
+        velocypack::Value(
+            arangodb::iresearch::StaticStrings::ViewArangoSearchType));
     namedJson.add(arangodb::iresearch::StaticStrings::ViewIdField,
                   velocypack::Value(view.guid()));
     if (!mergeSliceSkipKeys(namedJson, link, acceptor)) {
@@ -609,7 +611,8 @@ namespace iresearch {
   }
   builder.add(arangodb::StaticStrings::IndexFields, fieldsBuilder.slice());
   builder.add(arangodb::StaticStrings::IndexType,
-              velocypack::Value(arangodb::iresearch::StaticStrings::ViewType));
+              velocypack::Value(
+                  arangodb::iresearch::StaticStrings::ViewArangoSearchType));
   builder.close();
   return builder;
 }
@@ -727,9 +730,9 @@ namespace iresearch {
     return res;
   }
 
-  normalized.add(
-      arangodb::StaticStrings::IndexType,
-      velocypack::Value(arangodb::iresearch::StaticStrings::ViewType));
+  normalized.add(arangodb::StaticStrings::IndexType,
+                 velocypack::Value(
+                     arangodb::iresearch::StaticStrings::ViewArangoSearchType));
 
   if (ServerState::instance()->isClusterRole() && isCreation &&
       !collectionName.empty() && meta._collectionName.empty()) {

--- a/arangod/IResearch/IResearchView.h
+++ b/arangod/IResearch/IResearchView.h
@@ -83,7 +83,7 @@ class IResearchView final : public LogicalView {
 
  public:
   static constexpr std::pair<ViewType, std::string_view> typeInfo() noexcept {
-    return {ViewType::kView, StaticStrings::ViewType};
+    return {ViewType::kArangoSearch, StaticStrings::ViewArangoSearchType};
   }
 
   ~IResearchView() final;

--- a/arangod/IResearch/IResearchViewCoordinator.h
+++ b/arangod/IResearch/IResearchViewCoordinator.h
@@ -49,7 +49,7 @@ class IResearchLink;
 class IResearchViewCoordinator final : public LogicalView {
  public:
   static constexpr std::pair<ViewType, std::string_view> typeInfo() noexcept {
-    return {ViewType::kView, StaticStrings::ViewType};
+    return {ViewType::kArangoSearch, StaticStrings::ViewArangoSearchType};
   }
 
   //////////////////////////////////////////////////////////////////////////////

--- a/arangod/IResearch/Search.h
+++ b/arangod/IResearch/Search.h
@@ -54,7 +54,7 @@ class Search final : public LogicalView {
 
  public:
   static constexpr std::pair<ViewType, std::string_view> typeInfo() noexcept {
-    return {ViewType::kSearch, StaticStrings::SearchType};
+    return {ViewType::kSearchAlias, StaticStrings::ViewSearchAliasType};
   }
 
   //////////////////////////////////////////////////////////////////////////////

--- a/arangod/Indexes/Index.cpp
+++ b/arangod/Indexes/Index.cpp
@@ -327,7 +327,7 @@ Index::IndexType Index::type(std::string_view type) {
   if (type == "zkd") {
     return TRI_IDX_TYPE_ZKD_INDEX;
   }
-  if (type == iresearch::StaticStrings::ViewType) {
+  if (type == iresearch::StaticStrings::ViewArangoSearchType) {
     return TRI_IDX_TYPE_IRESEARCH_LINK;
   }
   if (type == "noaccess") {
@@ -369,7 +369,7 @@ char const* Index::oldtypeName(Index::IndexType type) {
     case TRI_IDX_TYPE_GEO_INDEX:
       return "geo";
     case TRI_IDX_TYPE_IRESEARCH_LINK:
-      return iresearch::StaticStrings::ViewType.data();
+      return iresearch::StaticStrings::ViewArangoSearchType.data();
     case TRI_IDX_TYPE_NO_ACCESS_INDEX:
       return "noaccess";
     case TRI_IDX_TYPE_ZKD_INDEX:

--- a/arangod/Replication/DatabaseInitialSyncer.cpp
+++ b/arangod/Replication/DatabaseInitialSyncer.cpp
@@ -2583,14 +2583,15 @@ Result DatabaseInitialSyncer::handleCollectionsAndViews(
 
   // STEP 4: now that the collections exist create the "arangosearch" views
   // this should be faster than re-indexing afterwards
-  // We don't create "search" view because inverted indexes don't exist yet
+  // We don't create "search-alias" view because inverted indexes don't exist
+  // yet
   // ----------------------------------------------------------------------------------
 
   if (!_config.applier._skipCreateDrop &&
       _config.applier._restrictCollections.empty() && viewSlices.isArray()) {
     // views are optional, and 3.3 and before will not send any view data
-    auto r = handleViewCreation(viewSlices,
-                                arangodb::iresearch::StaticStrings::ViewType);
+    auto r = handleViewCreation(
+        viewSlices, arangodb::iresearch::StaticStrings::ViewArangoSearchType);
     if (r.fail()) {
       LOG_TOPIC("96cda", ERR, Logger::REPLICATION)
           << "Error during initial sync view creation: " << r.errorMessage();
@@ -2608,10 +2609,10 @@ Result DatabaseInitialSyncer::handleCollectionsAndViews(
     return r;
   }
 
-  // STEP 6 load "search" views
+  // STEP 6 load "search-alias" views
   // ----------------------------------------------------------------------------------
-  return handleViewCreation(viewSlices,
-                            arangodb::iresearch::StaticStrings::SearchType);
+  return handleViewCreation(
+      viewSlices, arangodb::iresearch::StaticStrings::ViewSearchAliasType);
 }
 
 /// @brief iterate over all collections from an array and apply an action

--- a/arangod/RocksDBEngine/RocksDBEngine.cpp
+++ b/arangod/RocksDBEngine/RocksDBEngine.cpp
@@ -1338,7 +1338,7 @@ ErrorCode RocksDBEngine::getViews(TRI_vocbase_t& vocbase,
     if (ServerState::instance()->isDBServer() &&
         arangodb::basics::VelocyPackHelper::getStringView(
             slice, StaticStrings::DataSourceType, {}) !=
-            arangodb::iresearch::StaticStrings::ViewType) {
+            arangodb::iresearch::StaticStrings::ViewArangoSearchType) {
       continue;
     }
     result.add(slice);
@@ -2702,7 +2702,7 @@ std::unique_ptr<TRI_vocbase_t> RocksDBEngine::openExistingDatabase(
   };
 
   // scan the database path for "arangosearch" views
-  scanViews(iresearch::StaticStrings::ViewType);
+  scanViews(iresearch::StaticStrings::ViewArangoSearchType);
 
   // scan the database path for replicated logs
   try {
@@ -2779,9 +2779,9 @@ std::unique_ptr<TRI_vocbase_t> RocksDBEngine::openExistingDatabase(
     throw;
   }
 
-  // scan the database path for "search" views
+  // scan the database path for "search-alias" views
   if (ServerState::instance()->isSingleServer()) {
-    scanViews(iresearch::StaticStrings::SearchType);
+    scanViews(iresearch::StaticStrings::ViewSearchAliasType);
   }
 
   return vocbase;

--- a/arangod/VocBase/voc-types.h
+++ b/arangod/VocBase/voc-types.h
@@ -87,8 +87,8 @@ enum TRI_vocbase_col_status_e : int {
 namespace arangodb {
 
 enum class ViewType {
-  kView = 0,
-  kSearch = 1,
+  kArangoSearch = 0,
+  kSearchAlias = 1,
 };
 
 }  // namespace arangodb

--- a/tests/IResearch/IResearchFeatureTest.cpp
+++ b/tests/IResearch/IResearchFeatureTest.cpp
@@ -112,7 +112,7 @@ class IResearchFeatureTest
     dataPath /= "databases";
     dataPath /= "database-";
     dataPath += std::to_string(view.vocbase().id());
-    dataPath /= arangodb::iresearch::StaticStrings::ViewType;
+    dataPath /= arangodb::iresearch::StaticStrings::ViewArangoSearchType;
     dataPath += "-";
     dataPath += std::to_string(view.id().id());
     return dataPath;
@@ -126,7 +126,7 @@ class IResearchFeatureTest
     dataPath /= "databases";
     dataPath /= "database-";
     dataPath += std::to_string(link.collection().vocbase().id());
-    dataPath /= arangodb::iresearch::StaticStrings::ViewType;
+    dataPath /= arangodb::iresearch::StaticStrings::ViewArangoSearchType;
     dataPath += "-";
     dataPath += std::to_string(link.collection().id().id());
     dataPath += "_";
@@ -2537,8 +2537,9 @@ TEST_F(IResearchFeatureTestCoordinator, test_upgrade0_1) {
   auto& factory = server.getFeature<arangodb::iresearch::IResearchFeature>()
                       .factory<arangodb::ClusterEngine>();
   const_cast<arangodb::IndexFactory&>(engine.indexFactory())
-      .emplace(std::string{arangodb::iresearch::StaticStrings::ViewType},
-               factory);
+      .emplace(
+          std::string{arangodb::iresearch::StaticStrings::ViewArangoSearchType},
+          factory);
   auto& ci = server.getFeature<arangodb::ClusterFeature>().clusterInfo();
   TRI_vocbase_t* vocbase;  // will be owned by DatabaseFeature
 
@@ -2690,7 +2691,7 @@ class IResearchFeatureTestDBServer
     dataPath /= "databases";
     dataPath /= "database-";
     dataPath += std::to_string(view.vocbase().id());
-    dataPath /= arangodb::iresearch::StaticStrings::ViewType;
+    dataPath /= arangodb::iresearch::StaticStrings::ViewArangoSearchType;
     dataPath += "-";
     dataPath += std::to_string(view.id().id());
     return dataPath;
@@ -2704,7 +2705,7 @@ class IResearchFeatureTestDBServer
     dataPath /= "databases";
     dataPath /= "database-";
     dataPath += std::to_string(link.collection().vocbase().id());
-    dataPath /= arangodb::iresearch::StaticStrings::ViewType;
+    dataPath /= arangodb::iresearch::StaticStrings::ViewArangoSearchType;
     dataPath += "-";
     dataPath += std::to_string(link.collection().id().id());
     dataPath += "_";

--- a/tests/IResearch/IResearchLinkCoordinatorTest.cpp
+++ b/tests/IResearch/IResearchLinkCoordinatorTest.cpp
@@ -210,8 +210,8 @@ TEST_F(IResearchLinkCoordinatorTest, test_create_drop) {
     EXPECT_TRUE(true == index->sparse());
     EXPECT_TRUE((arangodb::Index::IndexType::TRI_IDX_TYPE_IRESEARCH_LINK ==
                  index->type()));
-    EXPECT_TRUE(
-        (arangodb::iresearch::StaticStrings::ViewType == index->typeName()));
+    EXPECT_TRUE((arangodb::iresearch::StaticStrings::ViewArangoSearchType ==
+                 index->typeName()));
     EXPECT_TRUE((false == index->unique()));
 
     arangodb::iresearch::IResearchLinkMeta actualMeta;
@@ -361,8 +361,8 @@ TEST_F(IResearchLinkCoordinatorTest, test_create_drop) {
     EXPECT_TRUE(true == index->sparse());
     EXPECT_TRUE((arangodb::Index::IndexType::TRI_IDX_TYPE_IRESEARCH_LINK ==
                  index->type()));
-    EXPECT_TRUE(
-        (arangodb::iresearch::StaticStrings::ViewType == index->typeName()));
+    EXPECT_TRUE((arangodb::iresearch::StaticStrings::ViewArangoSearchType ==
+                 index->typeName()));
     EXPECT_TRUE((false == index->unique()));
 
     {

--- a/tests/IResearch/IResearchLinkTest.cpp
+++ b/tests/IResearch/IResearchLinkTest.cpp
@@ -218,7 +218,7 @@ TEST_F(IResearchLinkTest, test_defaults) {
     EXPECT_TRUE(link->sparse());
     EXPECT_TRUE(arangodb::Index::IndexType::TRI_IDX_TYPE_IRESEARCH_LINK ==
                 link->type());
-    EXPECT_TRUE(arangodb::iresearch::StaticStrings::ViewType ==
+    EXPECT_TRUE(arangodb::iresearch::StaticStrings::ViewArangoSearchType ==
                 link->typeName());
     EXPECT_FALSE(link->unique());
     auto* impl = dynamic_cast<arangodb::iresearch::IResearchLink*>(link.get());
@@ -292,7 +292,7 @@ TEST_F(IResearchLinkTest, test_defaults) {
     EXPECT_TRUE(link->sparse());
     EXPECT_TRUE(arangodb::Index::IndexType::TRI_IDX_TYPE_IRESEARCH_LINK ==
                 link->type());
-    EXPECT_TRUE(arangodb::iresearch::StaticStrings::ViewType ==
+    EXPECT_TRUE(arangodb::iresearch::StaticStrings::ViewArangoSearchType ==
                 link->typeName());
     EXPECT_FALSE(link->unique());
     auto* impl = dynamic_cast<arangodb::iresearch::IResearchLink*>(link.get());
@@ -366,7 +366,8 @@ TEST_F(IResearchLinkTest, test_defaults) {
     EXPECT_TRUE(link->sparse());
     EXPECT_EQ(arangodb::Index::IndexType::TRI_IDX_TYPE_IRESEARCH_LINK,
               link->type());
-    EXPECT_EQ(arangodb::iresearch::StaticStrings::ViewType, link->typeName());
+    EXPECT_EQ(arangodb::iresearch::StaticStrings::ViewArangoSearchType,
+              link->typeName());
     EXPECT_FALSE(link->unique());
 
     {

--- a/tests/IResearch/IResearchQueryAggregateTest.cpp
+++ b/tests/IResearch/IResearchQueryAggregateTest.cpp
@@ -143,12 +143,12 @@ class QueryAggregate : public QueryTest {
 
 class QueryAggregateView : public QueryAggregate {
  protected:
-  ViewType type() const final { return arangodb::ViewType::kView; }
+  ViewType type() const final { return arangodb::ViewType::kArangoSearch; }
 };
 
 class QueryAggregateSearch : public QueryAggregate {
  protected:
-  ViewType type() const final { return arangodb::ViewType::kSearch; }
+  ViewType type() const final { return arangodb::ViewType::kSearchAlias; }
 };
 
 TEST_P(QueryAggregateView, Test) {

--- a/tests/IResearch/IResearchQueryAndTest.cpp
+++ b/tests/IResearch/IResearchQueryAndTest.cpp
@@ -262,12 +262,12 @@ class QueryAnd : public QueryTest {
 
 class QueryAndView : public QueryAnd {
  protected:
-  ViewType type() const final { return arangodb::ViewType::kView; }
+  ViewType type() const final { return arangodb::ViewType::kArangoSearch; }
 };
 
 class QueryAndSearch : public QueryAnd {
  protected:
-  ViewType type() const final { return arangodb::ViewType::kSearch; }
+  ViewType type() const final { return arangodb::ViewType::kSearchAlias; }
 };
 
 TEST_P(QueryAndView, Test) {

--- a/tests/IResearch/IResearchQueryBooleanTermTest.cpp
+++ b/tests/IResearch/IResearchQueryBooleanTermTest.cpp
@@ -1470,12 +1470,12 @@ class QueryBooleanTerm : public QueryTest {
 
 class QueryBooleanTermView : public QueryBooleanTerm {
  protected:
-  ViewType type() const final { return arangodb::ViewType::kView; }
+  ViewType type() const final { return arangodb::ViewType::kArangoSearch; }
 };
 
 class QueryBooleanTermSearch : public QueryBooleanTerm {
  protected:
-  ViewType type() const final { return arangodb::ViewType::kSearch; }
+  ViewType type() const final { return arangodb::ViewType::kSearchAlias; }
 };
 
 TEST_P(QueryBooleanTermView, Test) {

--- a/tests/IResearch/IResearchQueryCommon.h
+++ b/tests/IResearch/IResearchQueryCommon.h
@@ -74,7 +74,9 @@ class IResearchQueryTest
  protected:
   arangodb::tests::mocks::MockAqlServer server;
 
-  virtual arangodb::ViewType type() const { return arangodb::ViewType::kView; }
+  virtual arangodb::ViewType type() const {
+    return arangodb::ViewType::kArangoSearch;
+  }
 
   IResearchQueryTest() : server{false} {
     arangodb::tests::init(true);
@@ -379,8 +381,8 @@ class QueryTest : public IResearchQueryTest {
   }
 
   void createSearch() {
-    auto createJson =
-        VPackParser::fromJson(R"({ "name": "testView", "type": "search" })");
+    auto createJson = VPackParser::fromJson(
+        R"({ "name": "testView", "type": "search-alias" })");
     auto logicalView = _vocbase.createView(createJson->slice(), false);
     ASSERT_TRUE(logicalView);
     auto& implView = basics::downCast<iresearch::Search>(*logicalView);

--- a/tests/IResearch/IResearchQueryComplexBooleanTest.cpp
+++ b/tests/IResearch/IResearchQueryComplexBooleanTest.cpp
@@ -261,12 +261,12 @@ class QueryComplexBool : public QueryTest {
 
 class QueryComplexBoolView : public QueryComplexBool {
  protected:
-  ViewType type() const final { return ViewType::kView; }
+  ViewType type() const final { return ViewType::kArangoSearch; }
 };
 
 class QueryComplexBoolSearch : public QueryComplexBool {
  protected:
-  ViewType type() const final { return ViewType::kSearch; }
+  ViewType type() const final { return ViewType::kSearchAlias; }
 };
 
 TEST_P(QueryComplexBoolView, Test) {

--- a/tests/IResearch/IResearchQueryExistsTest.cpp
+++ b/tests/IResearch/IResearchQueryExistsTest.cpp
@@ -124,14 +124,14 @@ class QueryExists : public QueryTest {
           empty));
     }
     // test non-existent (text analyzer)
-    if (type() == ViewType::kView) {  // TODO kSearch check error
+    if (type() == ViewType::kArangoSearch) {  // TODO kSearch check error
       EXPECT_TRUE(runQuery(
           "FOR d IN testView SEARCH ANALYZER(EXISTS(d.seq, 'analyzer'), "
           "'text_en') SORT BM25(d) ASC, TFIDF(d) DESC, d.seq RETURN d",
           empty));
     }
     // test non-existent (analyzer) via []
-    if (type() == ViewType::kView) {  // TODO kSearch check error
+    if (type() == ViewType::kArangoSearch) {  // TODO kSearch check error
       EXPECT_TRUE(runQuery(
           "FOR d IN testView SEARCH ANALYZER(EXISTS(d['seq'], 'analyzer'), "
           "'text_en') SORT BM25(d) ASC, TFIDF(d) DESC, d.seq RETURN d",
@@ -1687,12 +1687,12 @@ class QueryExists : public QueryTest {
 
 class QueryExistsView : public QueryExists {
  protected:
-  ViewType type() const final { return ViewType::kView; }
+  ViewType type() const final { return ViewType::kArangoSearch; }
 };
 
 class QueryExistsSearch : public QueryExists {
  protected:
-  ViewType type() const final { return ViewType::kSearch; }
+  ViewType type() const final { return ViewType::kSearchAlias; }
 };
 
 TEST_P(QueryExistsView, Test) {

--- a/tests/IResearch/IResearchQueryFilterTest.cpp
+++ b/tests/IResearch/IResearchQueryFilterTest.cpp
@@ -155,12 +155,12 @@ class QueryFilter : public QueryTest {
 
 class QueryFilterView : public QueryFilter {
  protected:
-  ViewType type() const final { return ViewType::kView; }
+  ViewType type() const final { return ViewType::kArangoSearch; }
 };
 
 class QueryFilterSearch : public QueryFilter {
  protected:
-  ViewType type() const final { return ViewType::kSearch; }
+  ViewType type() const final { return ViewType::kSearchAlias; }
 };
 
 TEST_P(QueryFilterView, Test) {

--- a/tests/IResearch/IResearchQueryGeoDistanceTest.cpp
+++ b/tests/IResearch/IResearchQueryGeoDistanceTest.cpp
@@ -131,10 +131,10 @@ class QueryGeoDistance : public QueryTest {
               .result.ok());
     }
     // EXISTS will also work
-    if (type() == ViewType::kView) {
+    if (type() == ViewType::kArangoSearch) {
       EXPECT_TRUE(runQuery(
           R"(FOR d IN testView SEARCH EXISTS(d.geometry, 'string') RETURN d)"));
-    } else if (type() == ViewType::kSearch) {
+    } else if (type() == ViewType::kSearchAlias) {
       // Because for search/inverted-index
       // we consider strings can be found as normal fields,
       // so them all have suffix \0_s,
@@ -148,7 +148,7 @@ class QueryGeoDistance : public QueryTest {
     // test missing analyzer
     {
       std::vector<VPackSlice> expected;
-      if (type() == ViewType::kSearch) {
+      if (type() == ViewType::kSearchAlias) {
         expected = {_insertedDocs[16].slice(), _insertedDocs[17].slice()};
       }
       EXPECT_TRUE(runQuery(R"(LET origin = GEO_POINT(37.607768, 55.70892)
@@ -160,7 +160,7 @@ class QueryGeoDistance : public QueryTest {
     // test missing analyzer
     {
       std::vector<VPackSlice> expected;
-      if (type() == ViewType::kSearch) {
+      if (type() == ViewType::kSearchAlias) {
         expected = {_insertedDocs[16].slice(), _insertedDocs[17].slice()};
       }
       EXPECT_TRUE(runQuery(R"(LET origin = GEO_POINT(37.607768, 55.70892)
@@ -179,7 +179,7 @@ class QueryGeoDistance : public QueryTest {
       auto view = _vocbase.lookupView("testView");
       ASSERT_TRUE(view);
       auto links = [&] {
-        if (view->type() == ViewType::kSearch) {
+        if (view->type() == ViewType::kSearchAlias) {
           auto& impl = basics::downCast<iresearch::Search>(*view);
           return impl.getLinks();
         }
@@ -228,7 +228,7 @@ class QueryGeoDistance : public QueryTest {
           R"(FOR d IN testView SEARCH EXISTS(d.geometry, 'analyzer', "mygeojson") RETURN d)"));
     }
     // test missing field
-    if (type() == ViewType::kView) {  // TODO kSearch check error
+    if (type() == ViewType::kArangoSearch) {  // TODO kSearch check error
       EXPECT_TRUE(runQuery(R"(LET origin = GEO_POINT(37.607768, 55.70892)
         FOR d IN testView
         SEARCH ANALYZER(GEO_DISTANCE(d.missing, origin) < 300, 'mygeojson')
@@ -236,7 +236,7 @@ class QueryGeoDistance : public QueryTest {
                            empty));
     }
     // test missing field
-    if (type() == ViewType::kView) {  // TODO kSearch check error
+    if (type() == ViewType::kArangoSearch) {  // TODO kSearch check error
       EXPECT_TRUE(runQuery(R"(LET origin = GEO_POINT(37.607768, 55.70892)
         FOR d IN testView
         SEARCH ANALYZER(GEO_DISTANCE(origin, d.missing) < 300, 'mygeojson')
@@ -477,7 +477,7 @@ class QueryGeoDistance : public QueryTest {
 
 class QueryGeoDistanceView : public QueryGeoDistance {
  protected:
-  ViewType type() const final { return ViewType::kView; }
+  ViewType type() const final { return ViewType::kArangoSearch; }
 
   void createView() {
     auto createJson = VPackParser::fromJson(
@@ -500,7 +500,7 @@ class QueryGeoDistanceView : public QueryGeoDistance {
 
 class QueryGeoDistanceSearch : public QueryGeoDistance {
  protected:
-  ViewType type() const final { return ViewType::kSearch; }
+  ViewType type() const final { return ViewType::kSearchAlias; }
 
   void createIndexes(std::string_view analyzer) {
     bool created = false;
@@ -518,8 +518,8 @@ class QueryGeoDistanceSearch : public QueryGeoDistance {
   }
 
   void createSearch() {
-    auto createJson =
-        VPackParser::fromJson(R"({ "name": "testView", "type": "search" })");
+    auto createJson = VPackParser::fromJson(
+        R"({ "name": "testView", "type": "search-alias" })");
     auto logicalView = _vocbase.createView(createJson->slice(), false);
     ASSERT_FALSE(!logicalView);
     auto& implView = basics::downCast<iresearch::Search>(*logicalView);

--- a/tests/IResearch/IResearchQueryGeoInRangeTest.cpp
+++ b/tests/IResearch/IResearchQueryGeoInRangeTest.cpp
@@ -159,10 +159,10 @@ class QueryGeoInRange : public QueryTest {
         RETURN d)"));
     }
     // EXISTS will also work
-    if (type() == ViewType::kView) {
+    if (type() == ViewType::kArangoSearch) {
       EXPECT_TRUE(runQuery(
           R"(FOR d IN testView SEARCH EXISTS(d.geometry, 'string') RETURN d)"));
-    } else if (type() == ViewType::kSearch) {
+    } else if (type() == ViewType::kSearchAlias) {
       // Because for search/inverted-index
       // we consider strings can be found as normal fields,
       // so them all have suffix \0_s,
@@ -176,7 +176,7 @@ class QueryGeoInRange : public QueryTest {
     // test missing analyzer
     {
       std::vector<velocypack::Slice> expected;
-      if (type() == ViewType::kSearch) {
+      if (type() == ViewType::kSearchAlias) {
         expected = {_insertedDocs[16].slice(), _insertedDocs[17].slice()};
       }
       EXPECT_TRUE(runQuery(R"(LET origin = GEO_POINT(37.607768, 55.70892)
@@ -189,7 +189,7 @@ class QueryGeoInRange : public QueryTest {
     // test missing analyzer
     {
       std::vector<velocypack::Slice> expected;
-      if (type() == ViewType::kSearch) {
+      if (type() == ViewType::kSearchAlias) {
         expected = {_insertedDocs[16].slice(), _insertedDocs[17].slice()};
       }
       EXPECT_TRUE(runQuery(R"(LET origin = GEO_POINT(37.607768, 55.70892)
@@ -209,7 +209,7 @@ class QueryGeoInRange : public QueryTest {
       auto view = _vocbase.lookupView("testView");
       ASSERT_TRUE(view);
       auto links = [&] {
-        if (view->type() == ViewType::kSearch) {
+        if (view->type() == ViewType::kSearchAlias) {
           auto& impl = basics::downCast<iresearch::Search>(*view);
           return impl.getLinks();
         }
@@ -254,7 +254,7 @@ class QueryGeoInRange : public QueryTest {
         RETURN d)"));
     }
     // test missing field
-    if (type() == ViewType::kView) {  // TODO kSearch check error
+    if (type() == ViewType::kArangoSearch) {  // TODO kSearch check error
       EXPECT_TRUE(runQuery(R"(LET origin = GEO_POINT(37.607768, 55.70892)
         FOR d IN testView
         SEARCH ANALYZER(GEO_IN_RANGE(d.missing, origin, 0, 300), 'mygeojson')
@@ -263,7 +263,7 @@ class QueryGeoInRange : public QueryTest {
                            empty));
     }
     // test missing field
-    if (type() == ViewType::kView) {  // TODO kSearch check error
+    if (type() == ViewType::kArangoSearch) {  // TODO kSearch check error
       EXPECT_TRUE(runQuery(R"(LET origin = GEO_POINT(37.607768, 55.70892)
         FOR d IN testView
         SEARCH ANALYZER(GEO_IN_RANGE(origin, d.missing, 0, 300), 'mygeojson')
@@ -461,7 +461,7 @@ class QueryGeoInRange : public QueryTest {
     auto view = _vocbase.lookupView("testView");
     ASSERT_TRUE(view);
     auto links = [&] {
-      if (view->type() == ViewType::kSearch) {
+      if (view->type() == ViewType::kSearchAlias) {
         auto& impl = basics::downCast<iresearch::Search>(*view);
         return impl.getLinks();
       }
@@ -509,7 +509,7 @@ class QueryGeoInRange : public QueryTest {
 
       ASSERT_TRUE(trx.commit().ok());
     }
-    if (type() == ViewType::kView) {  // TODO kSearch check error
+    if (type() == ViewType::kArangoSearch) {  // TODO kSearch check error
       EXPECT_TRUE(runQuery(R"(FOR d IN testView
         SEARCH EXISTS(d.geometry)
         RETURN d)"));
@@ -521,10 +521,10 @@ class QueryGeoInRange : public QueryTest {
         RETURN d)"));
     }
     // EXISTS will also work
-    if (type() == ViewType::kView) {
+    if (type() == ViewType::kArangoSearch) {
       EXPECT_TRUE(runQuery(R"(FOR d IN testView
         SEARCH EXISTS(d.geometry.coordinates, 'string') RETURN d)"));
-    } else if (type() == ViewType::kSearch) {
+    } else if (type() == ViewType::kSearchAlias) {
       // Because for search/inverted-index
       // we consider strings can be found as normal fields,
       // so them all have suffix \0_s,
@@ -542,7 +542,7 @@ class QueryGeoInRange : public QueryTest {
         RETURN d)"));
     }
     // test missing field
-    if (type() == ViewType::kView) {  // TODO kSearch check error
+    if (type() == ViewType::kArangoSearch) {  // TODO kSearch check error
       EXPECT_TRUE(runQuery(R"(LET origin = GEO_POINT(37.607768, 55.70892)
         FOR d IN testView
         SEARCH ANALYZER(GEO_IN_RANGE(d.missing, origin, 0, 300), 'mygeopoint')
@@ -551,7 +551,7 @@ class QueryGeoInRange : public QueryTest {
                            empty));
     }
     // test missing field
-    if (type() == ViewType::kView) {  // TODO kSearch check error
+    if (type() == ViewType::kArangoSearch) {  // TODO kSearch check error
       EXPECT_TRUE(runQuery(R"(LET origin = GEO_POINT(37.607768, 55.70892)
         FOR d IN testView
         SEARCH ANALYZER(GEO_IN_RANGE(origin, d.missing, 0, 300), 'mygeopoint')
@@ -562,7 +562,7 @@ class QueryGeoInRange : public QueryTest {
     // test missing analyzer
     {
       std::vector<VPackSlice> expected;
-      if (type() == ViewType::kSearch) {
+      if (type() == ViewType::kSearchAlias) {
         expected = {_insertedDocs[16].slice(), _insertedDocs[17].slice()};
       }
       EXPECT_TRUE(runQuery(R"(LET origin = GEO_POINT(37.607768, 55.70892)
@@ -575,7 +575,7 @@ class QueryGeoInRange : public QueryTest {
     // test missing analyzer
     {
       std::vector<VPackSlice> expected;
-      if (type() == ViewType::kSearch) {
+      if (type() == ViewType::kSearchAlias) {
         expected = {_insertedDocs[16].slice(), _insertedDocs[17].slice()};
       }
       EXPECT_TRUE(runQuery(R"(LET origin = GEO_POINT(37.607768, 55.70892)
@@ -756,7 +756,7 @@ class QueryGeoInRange : public QueryTest {
     auto view = _vocbase.lookupView("testView");
     ASSERT_TRUE(view);
     auto links = [&] {
-      if (view->type() == ViewType::kSearch) {
+      if (view->type() == ViewType::kSearchAlias) {
         auto& impl = basics::downCast<iresearch::Search>(*view);
         return impl.getLinks();
       }
@@ -810,10 +810,10 @@ class QueryGeoInRange : public QueryTest {
         RETURN d)"));
     }
     // EXISTS will also work
-    if (type() == ViewType::kView) {
+    if (type() == ViewType::kArangoSearch) {
       EXPECT_TRUE(runQuery(
           R"(FOR d IN testView SEARCH EXISTS(d.geometry, 'string') RETURN d)"));
-    } else if (type() == ViewType::kSearch) {
+    } else if (type() == ViewType::kSearchAlias) {
       // Because for search/inverted-index
       // we consider strings can be found as normal fields,
       // so them all have suffix \0_s,
@@ -831,7 +831,7 @@ class QueryGeoInRange : public QueryTest {
         RETURN d)"));
     }
     // test missing field
-    if (type() == ViewType::kView) {  // TODO kSearch check error
+    if (type() == ViewType::kArangoSearch) {  // TODO kSearch check error
       EXPECT_TRUE(runQuery(R"(LET origin = GEO_POINT(37.607768, 55.70892)
         FOR d IN testView
         SEARCH ANALYZER(GEO_IN_RANGE(d.missing, origin, 0, 300), 'mygeopoint')
@@ -840,7 +840,7 @@ class QueryGeoInRange : public QueryTest {
                            empty));
     }
     // test missing field
-    if (type() == ViewType::kView) {  // TODO kSearch check error
+    if (type() == ViewType::kArangoSearch) {  // TODO kSearch check error
       EXPECT_TRUE(runQuery(R"(LET origin = GEO_POINT(37.607768, 55.70892)
         FOR d IN testView
         SEARCH ANALYZER(GEO_IN_RANGE(origin, d.missing, 0, 300), 'mygeopoint')
@@ -851,7 +851,7 @@ class QueryGeoInRange : public QueryTest {
     // test missing analyzer
     {
       std::vector<VPackSlice> expected;
-      if (type() == ViewType::kSearch) {
+      if (type() == ViewType::kSearchAlias) {
         expected = {_insertedDocs[16].slice(), _insertedDocs[17].slice()};
       }
       EXPECT_TRUE(runQuery(R"(LET origin = GEO_POINT(37.607768, 55.70892)
@@ -864,7 +864,7 @@ class QueryGeoInRange : public QueryTest {
     // test missing analyzer
     {
       std::vector<VPackSlice> expected;
-      if (type() == ViewType::kSearch) {
+      if (type() == ViewType::kSearchAlias) {
         expected = {_insertedDocs[16].slice(), _insertedDocs[17].slice()};
       }
       EXPECT_TRUE(runQuery(R"(LET origin = GEO_POINT(37.607768, 55.70892)
@@ -987,7 +987,7 @@ class QueryGeoInRange : public QueryTest {
 
 class QueryGeoInRangeView : public QueryGeoInRange {
  protected:
-  ViewType type() const final { return ViewType::kView; }
+  ViewType type() const final { return ViewType::kArangoSearch; }
 
   void createView(std::string_view fields) {
     auto createJson = VPackParser::fromJson(
@@ -1009,7 +1009,7 @@ class QueryGeoInRangeView : public QueryGeoInRange {
 
 class QueryGeoInRangeSearch : public QueryGeoInRange {
  protected:
-  ViewType type() const final { return ViewType::kSearch; }
+  ViewType type() const final { return ViewType::kSearchAlias; }
 
   void createIndexes(std::string_view fields) {
     bool created = false;
@@ -1026,8 +1026,8 @@ class QueryGeoInRangeSearch : public QueryGeoInRange {
   }
 
   void createSearch() {
-    auto createJson =
-        VPackParser::fromJson(R"({ "name": "testView", "type": "search" })");
+    auto createJson = VPackParser::fromJson(
+        R"({ "name": "testView", "type": "search-alias" })");
     auto logicalView = _vocbase.createView(createJson->slice(), false);
     ASSERT_FALSE(!logicalView);
     auto& implView = basics::downCast<iresearch::Search>(*logicalView);

--- a/tests/IResearch/IResearchQueryGeoIntersectsTest.cpp
+++ b/tests/IResearch/IResearchQueryGeoIntersectsTest.cpp
@@ -117,7 +117,7 @@ class QueryGeoIntersects : public QueryTest {
     auto view = _vocbase.lookupView("testView");
     ASSERT_TRUE(view);
     auto links = [&] {
-      if (view->type() == ViewType::kSearch) {
+      if (view->type() == ViewType::kSearchAlias) {
         auto& impl = basics::downCast<iresearch::Search>(*view);
         return impl.getLinks();
       }
@@ -164,7 +164,7 @@ class QueryGeoIntersects : public QueryTest {
         RETURN d)"));
     }
     // EXISTS will also work
-    if (type() == ViewType::kView) {  // TODO kSearch check error
+    if (type() == ViewType::kArangoSearch) {  // TODO kSearch check error
       EXPECT_TRUE(runQuery(R"(FOR d IN testView
         SEARCH EXISTS(d.geometry, 'string')
         RETURN d)"));
@@ -176,7 +176,7 @@ class QueryGeoIntersects : public QueryTest {
         RETURN d)"));
     }
     // test missing field
-    if (type() == ViewType::kView) {  // TODO kSearch check error
+    if (type() == ViewType::kArangoSearch) {  // TODO kSearch check error
       EXPECT_TRUE(runQuery(R"(LET box = GEO_POLYGON([
           [37.602682, 55.706853],
           [37.613025, 55.706853],
@@ -190,7 +190,7 @@ class QueryGeoIntersects : public QueryTest {
                            empty));
     }
     // test missing field
-    if (type() == ViewType::kView) {  // TODO kSearch check error
+    if (type() == ViewType::kArangoSearch) {  // TODO kSearch check error
       EXPECT_TRUE(runQuery(R"(LET box = GEO_POLYGON([
           [37.602682, 55.706853],
           [37.613025, 55.706853],
@@ -206,7 +206,7 @@ class QueryGeoIntersects : public QueryTest {
     // test missing analyzer
     {
       std::vector<velocypack::Slice> expected;
-      if (type() == ViewType::kSearch) {
+      if (type() == ViewType::kSearchAlias) {
         expected = {_insertedDocs[16].slice(), _insertedDocs[17].slice(),
                     _insertedDocs[28].slice()};
       }
@@ -225,7 +225,7 @@ class QueryGeoIntersects : public QueryTest {
     // test missing analyzer
     {
       std::vector<velocypack::Slice> expected;
-      if (type() == ViewType::kSearch) {
+      if (type() == ViewType::kSearchAlias) {
         expected = {_insertedDocs[16].slice(), _insertedDocs[17].slice(),
                     _insertedDocs[28].slice()};
       }
@@ -308,7 +308,7 @@ class QueryGeoIntersects : public QueryTest {
 
 class QueryGeoIntersectsView : public QueryGeoIntersects {
  protected:
-  ViewType type() const final { return ViewType::kView; }
+  ViewType type() const final { return ViewType::kArangoSearch; }
 
   void createView() {
     auto createJson = velocypack::Parser::fromJson(
@@ -332,7 +332,7 @@ class QueryGeoIntersectsView : public QueryGeoIntersects {
 
 class QueryGeoIntersectsSearch : public QueryGeoIntersects {
  protected:
-  ViewType type() const final { return ViewType::kSearch; }
+  ViewType type() const final { return ViewType::kSearchAlias; }
 
   void createIndexes() {
     bool created = false;
@@ -352,7 +352,7 @@ class QueryGeoIntersectsSearch : public QueryGeoIntersects {
 
   void createSearch() {
     auto createJson = velocypack::Parser::fromJson(
-        R"({ "name": "testView", "type": "search" })");
+        R"({ "name": "testView", "type": "search-alias" })");
     auto logicalView = _vocbase.createView(createJson->slice(), false);
     ASSERT_TRUE(logicalView);
     auto& implView = basics::downCast<iresearch::Search>(*logicalView);

--- a/tests/IResearch/IResearchQueryInRangeTest.cpp
+++ b/tests/IResearch/IResearchQueryInRangeTest.cpp
@@ -847,12 +847,12 @@ class QueryInRange : public QueryTest {
 
 class QueryInRangeView : public QueryInRange {
  protected:
-  ViewType type() const final { return ViewType::kView; }
+  ViewType type() const final { return ViewType::kArangoSearch; }
 };
 
 class QueryInRangeSearch : public QueryInRange {
  protected:
-  ViewType type() const final { return ViewType::kSearch; }
+  ViewType type() const final { return ViewType::kSearchAlias; }
 };
 
 TEST_P(QueryInRangeView, Test) {

--- a/tests/IResearch/IResearchQueryInTest.cpp
+++ b/tests/IResearch/IResearchQueryInTest.cpp
@@ -487,12 +487,12 @@ class QueryIn : public QueryTest {
 
 class QueryInView : public QueryIn {
  protected:
-  ViewType type() const final { return ViewType::kView; }
+  ViewType type() const final { return ViewType::kArangoSearch; }
 };
 
 class QueryInSearch : public QueryIn {
  protected:
-  ViewType type() const final { return ViewType::kSearch; }
+  ViewType type() const final { return ViewType::kSearchAlias; }
 };
 
 TEST_P(QueryInView, Test) {

--- a/tests/IResearch/IResearchQueryJoinTest.cpp
+++ b/tests/IResearch/IResearchQueryJoinTest.cpp
@@ -1682,7 +1682,7 @@ class QueryJoin : public QueryTest {
 
 class QueryJoinView : public QueryJoin {
  protected:
-  ViewType type() const final { return ViewType::kView; }
+  ViewType type() const final { return ViewType::kArangoSearch; }
 
   void createView1() {
     {
@@ -1750,7 +1750,7 @@ class QueryJoinView : public QueryJoin {
 
 class QueryJoinSearch : public QueryJoin {
  protected:
-  ViewType type() const final { return ViewType::kSearch; }
+  ViewType type() const final { return ViewType::kSearchAlias; }
 
   void createSearch1() {
     auto createIndexName = [&](std::string_view name) {
@@ -1767,8 +1767,8 @@ class QueryJoinSearch : public QueryJoin {
       ASSERT_TRUE(created);
     };
     auto createSearchName = [&](std::string_view name) {
-      auto createJson = velocypack::Parser::fromJson(
-          absl::Substitute(R"({ "name": "$0_view", "type": "search" })", name));
+      auto createJson = velocypack::Parser::fromJson(absl::Substitute(
+          R"({ "name": "$0_view", "type": "search-alias" })", name));
       auto logicalView = _vocbase.createView(createJson->slice(), false);
       ASSERT_FALSE(!logicalView);
       auto& implView = basics::downCast<iresearch::Search>(*logicalView);

--- a/tests/IResearch/IResearchQueryLateMaterializationTest.cpp
+++ b/tests/IResearch/IResearchQueryLateMaterializationTest.cpp
@@ -71,7 +71,7 @@ class IResearchQueryLateMaterializationTest : public IResearchQueryTest {
     auto slice = builder.slice();
     EXPECT_TRUE(slice.isObject());
     EXPECT_TRUE(slice.get("type").copyString() ==
-                arangodb::iresearch::StaticStrings::ViewType);
+                arangodb::iresearch::StaticStrings::ViewArangoSearchType);
     EXPECT_TRUE(slice.get("deleted").isNone());  // no system properties
     auto tmpSlice = slice.get("links");
     EXPECT_TRUE(tmpSlice.isObject() && 2 == tmpSlice.length());

--- a/tests/IResearch/IResearchQueryNoMaterializationTest.cpp
+++ b/tests/IResearch/IResearchQueryNoMaterializationTest.cpp
@@ -75,7 +75,7 @@ class IResearchQueryNoMaterializationTest : public IResearchQueryTest {
     auto slice = builder.slice();
     EXPECT_TRUE(slice.isObject());
     EXPECT_TRUE(slice.get("type").copyString() ==
-                arangodb::iresearch::StaticStrings::ViewType);
+                arangodb::iresearch::StaticStrings::ViewArangoSearchType);
     EXPECT_TRUE(slice.get("deleted").isNone());  // no system properties
     auto tmpSlice = slice.get("links");
     EXPECT_TRUE(tmpSlice.isObject() && 2 == tmpSlice.length());
@@ -460,7 +460,7 @@ TEST_P(IResearchQueryNoMaterializationTest, testStoredValuesRecord) {
   auto slice = builder.slice();
   EXPECT_TRUE(slice.isObject());
   EXPECT_TRUE(slice.get("type").copyString() ==
-              arangodb::iresearch::StaticStrings::ViewType);
+              arangodb::iresearch::StaticStrings::ViewArangoSearchType);
   EXPECT_TRUE(slice.get("deleted").isNone());  // no system properties
   auto tmpSlice = slice.get("links");
   EXPECT_TRUE(tmpSlice.isObject() && 1 == tmpSlice.length());
@@ -622,7 +622,7 @@ TEST_P(IResearchQueryNoMaterializationTest,
   auto slice = builder.slice();
   EXPECT_TRUE(slice.isObject());
   EXPECT_TRUE(slice.get("type").copyString() ==
-              arangodb::iresearch::StaticStrings::ViewType);
+              arangodb::iresearch::StaticStrings::ViewArangoSearchType);
   EXPECT_TRUE(slice.get("deleted").isNone());  // no system properties
   auto tmpSlice = slice.get("links");
   EXPECT_TRUE(tmpSlice.isObject() && 1 == tmpSlice.length());

--- a/tests/IResearch/IResearchQueryNumericTermTest.cpp
+++ b/tests/IResearch/IResearchQueryNumericTermTest.cpp
@@ -117,7 +117,7 @@ TEST_P(IResearchQueryNumericTermTest, test) {
     EXPECT_TRUE(slice.isObject());
     EXPECT_EQ(slice.get("name").copyString(), "testView");
     EXPECT_TRUE(slice.get("type").copyString() ==
-                arangodb::iresearch::StaticStrings::ViewType);
+                arangodb::iresearch::StaticStrings::ViewArangoSearchType);
     EXPECT_TRUE(slice.get("deleted").isNone());  // no system properties
     auto tmpSlice = slice.get("links");
     EXPECT_TRUE(tmpSlice.isObject() && 2 == tmpSlice.length());

--- a/tests/IResearch/IResearchQueryOptimizationTest.cpp
+++ b/tests/IResearch/IResearchQueryOptimizationTest.cpp
@@ -105,7 +105,7 @@ class IResearchQueryOptimizationTest : public IResearchQueryTest {
     EXPECT_TRUE(slice.isObject());
     EXPECT_EQ(slice.get("name").copyString(), "testView");
     EXPECT_TRUE(slice.get("type").copyString() ==
-                arangodb::iresearch::StaticStrings::ViewType);
+                arangodb::iresearch::StaticStrings::ViewArangoSearchType);
     EXPECT_TRUE(slice.get("deleted").isNone());  // no system properties
     auto tmpSlice = slice.get("links");
     EXPECT_TRUE(tmpSlice.isObject() && 1 == tmpSlice.length());

--- a/tests/IResearch/IResearchQueryOptionsTest.cpp
+++ b/tests/IResearch/IResearchQueryOptionsTest.cpp
@@ -113,7 +113,7 @@ TEST_P(IResearchQueryOptionsTest, Collections) {
     EXPECT_TRUE(slice.isObject());
     EXPECT_EQ(slice.get("name").copyString(), "testView");
     EXPECT_TRUE(slice.get("type").copyString() ==
-                arangodb::iresearch::StaticStrings::ViewType);
+                arangodb::iresearch::StaticStrings::ViewArangoSearchType);
     EXPECT_TRUE(slice.get("deleted").isNone());  // no system properties
     auto tmpSlice = slice.get("links");
     EXPECT_TRUE(tmpSlice.isObject() && 2 == tmpSlice.length());
@@ -806,7 +806,7 @@ TEST_P(IResearchQueryOptionsTest, WaitForSync) {
     EXPECT_TRUE(slice.isObject());
     EXPECT_EQ(slice.get("name").copyString(), "testView");
     EXPECT_TRUE(slice.get("type").copyString() ==
-                arangodb::iresearch::StaticStrings::ViewType);
+                arangodb::iresearch::StaticStrings::ViewArangoSearchType);
     EXPECT_TRUE(slice.get("deleted").isNone());  // no system properties
     auto tmpSlice = slice.get("links");
     EXPECT_TRUE(tmpSlice.isObject() && 2 == tmpSlice.length());
@@ -1041,7 +1041,7 @@ TEST_P(IResearchQueryOptionsTest, noMaterialization) {
     EXPECT_TRUE(slice.isObject());
     EXPECT_EQ(slice.get("name").copyString(), "testView");
     EXPECT_TRUE(slice.get("type").copyString() ==
-                arangodb::iresearch::StaticStrings::ViewType);
+                arangodb::iresearch::StaticStrings::ViewArangoSearchType);
     EXPECT_TRUE(slice.get("deleted").isNone());  // no system properties
     auto tmpSlice = slice.get("links");
     EXPECT_TRUE(tmpSlice.isObject() && 2 == tmpSlice.length());

--- a/tests/IResearch/IResearchQueryOrTest.cpp
+++ b/tests/IResearch/IResearchQueryOrTest.cpp
@@ -116,7 +116,7 @@ TEST_P(IResearchQueryOrTest, test) {
     EXPECT_TRUE(slice.isObject());
     EXPECT_EQ(slice.get("name").copyString(), "testView");
     EXPECT_TRUE(slice.get("type").copyString() ==
-                arangodb::iresearch::StaticStrings::ViewType);
+                arangodb::iresearch::StaticStrings::ViewArangoSearchType);
     EXPECT_TRUE(slice.get("deleted").isNone());  // no system properties
     auto tmpSlice = slice.get("links");
     EXPECT_TRUE(tmpSlice.isObject() && 2 == tmpSlice.length());

--- a/tests/IResearch/IResearchQueryScorerTest.cpp
+++ b/tests/IResearch/IResearchQueryScorerTest.cpp
@@ -131,7 +131,7 @@ TEST_P(IResearchQueryScorerTest, test) {
     EXPECT_TRUE(slice.isObject());
     EXPECT_EQ(slice.get("name").copyString(), "testView");
     EXPECT_TRUE(slice.get("type").copyString() ==
-                arangodb::iresearch::StaticStrings::ViewType);
+                arangodb::iresearch::StaticStrings::ViewArangoSearchType);
     EXPECT_TRUE(slice.get("deleted").isNone());  // no system properties
     auto tmpSlice = slice.get("links");
     EXPECT_TRUE(tmpSlice.isObject() && 2 == tmpSlice.length());

--- a/tests/IResearch/IResearchQuerySelectAllTest.cpp
+++ b/tests/IResearch/IResearchQuerySelectAllTest.cpp
@@ -108,7 +108,7 @@ TEST_P(IResearchQuerySelectAllTest, test) {
     EXPECT_TRUE(slice.isObject());
     EXPECT_EQ(slice.get("name").copyString(), "testView");
     EXPECT_TRUE(slice.get("type").copyString() ==
-                arangodb::iresearch::StaticStrings::ViewType);
+                arangodb::iresearch::StaticStrings::ViewArangoSearchType);
     EXPECT_TRUE(slice.get("deleted").isNone());  // no system properties
     auto tmpSlice = slice.get("links");
     EXPECT_TRUE(tmpSlice.isObject() && 2 == tmpSlice.length());

--- a/tests/IResearch/IResearchQueryStartsWithTest.cpp
+++ b/tests/IResearch/IResearchQueryStartsWithTest.cpp
@@ -107,7 +107,7 @@ TEST_P(IResearchQueryStartsWithTest, test) {
     EXPECT_TRUE(slice.isObject());
     EXPECT_EQ(slice.get("name").copyString(), "testView");
     EXPECT_TRUE(slice.get("type").copyString() ==
-                arangodb::iresearch::StaticStrings::ViewType);
+                arangodb::iresearch::StaticStrings::ViewArangoSearchType);
     EXPECT_TRUE(slice.get("deleted").isNone());  // no system properties
     auto tmpSlice = slice.get("links");
     EXPECT_TRUE(tmpSlice.isObject() && 2 == tmpSlice.length());

--- a/tests/IResearch/IResearchQueryStringTermTest.cpp
+++ b/tests/IResearch/IResearchQueryStringTermTest.cpp
@@ -119,7 +119,7 @@ TEST_P(IResearchQueryStringTermTest, test) {
     EXPECT_TRUE(slice.isObject());
     EXPECT_EQ(slice.get("name").copyString(), "testView");
     EXPECT_TRUE(slice.get("type").copyString() ==
-                arangodb::iresearch::StaticStrings::ViewType);
+                arangodb::iresearch::StaticStrings::ViewArangoSearchType);
     EXPECT_TRUE(slice.get("deleted").isNone());  // no system properties
     auto tmpSlice = slice.get("links");
     EXPECT_TRUE(tmpSlice.isObject() && 2 == tmpSlice.length());

--- a/tests/IResearch/IResearchViewCoordinatorTest.cpp
+++ b/tests/IResearch/IResearchViewCoordinatorTest.cpp
@@ -112,9 +112,9 @@ class IResearchViewCoordinatorTest : public ::testing::Test {
 // -----------------------------------------------------------------------------
 
 TEST_F(IResearchViewCoordinatorTest, test_type) {
-  static_assert(
-      arangodb::iresearch::IResearchViewCoordinator::typeInfo() ==
-      std::pair{arangodb::ViewType::kView, std::string_view{"arangosearch"}});
+  static_assert(arangodb::iresearch::IResearchViewCoordinator::typeInfo() ==
+                std::pair{arangodb::ViewType::kArangoSearch,
+                          std::string_view{"arangosearch"}});
 }
 
 TEST_F(IResearchViewCoordinatorTest, test_rename) {
@@ -136,7 +136,7 @@ TEST_F(IResearchViewCoordinatorTest, test_rename) {
   EXPECT_TRUE("testView" == view->name());
   EXPECT_TRUE(false == view->deleted());
   EXPECT_TRUE(1 == view->id().id());
-  EXPECT_TRUE(arangodb::ViewType::kView == view->type());
+  EXPECT_TRUE(arangodb::ViewType::kArangoSearch == view->type());
   EXPECT_TRUE(arangodb::LogicalDataSource::Category::kView == view->category());
   EXPECT_TRUE(&vocbase == &view->vocbase());
 
@@ -199,7 +199,7 @@ TEST_F(IResearchViewCoordinatorTest, visit_collections) {
   EXPECT_TRUE("testView" == view->name());
   EXPECT_TRUE(false == view->deleted());
   EXPECT_TRUE(1 == view->id().id());
-  EXPECT_TRUE(arangodb::ViewType::kView == view->type());
+  EXPECT_TRUE(arangodb::ViewType::kArangoSearch == view->type());
   EXPECT_TRUE(arangodb::LogicalDataSource::Category::kView == view->category());
   EXPECT_TRUE(vocbase == &view->vocbase());
 
@@ -251,7 +251,7 @@ TEST_F(IResearchViewCoordinatorTest, test_defaults) {
     EXPECT_TRUE(("testView" == view->name()));
     EXPECT_TRUE((false == view->deleted()));
     EXPECT_TRUE((1 == view->id().id()));
-    EXPECT_TRUE((arangodb::ViewType::kView == view->type()));
+    EXPECT_TRUE((arangodb::ViewType::kArangoSearch == view->type()));
     EXPECT_TRUE(
         (arangodb::LogicalDataSource::Category::kView == view->category()));
     EXPECT_TRUE((&vocbase == &view->vocbase()));
@@ -288,7 +288,7 @@ TEST_F(IResearchViewCoordinatorTest, test_defaults) {
                    false == slice.get("isSystem").getBoolean()));
       EXPECT_TRUE((slice.get("name").copyString() == "testView"));
       EXPECT_TRUE((slice.get("type").copyString() ==
-                   arangodb::iresearch::StaticStrings::ViewType));
+                   arangodb::iresearch::StaticStrings::ViewArangoSearchType));
       EXPECT_TRUE((slice.hasKey("planId")));
       EXPECT_TRUE((false == slice.get("deleted").getBool()));
       EXPECT_TRUE((!slice.hasKey("links")));  // for persistence so no links
@@ -318,7 +318,7 @@ TEST_F(IResearchViewCoordinatorTest, test_defaults) {
       EXPECT_TRUE((slice.get("id").copyString() == "1"));
       EXPECT_TRUE((slice.get("name").copyString() == "testView"));
       EXPECT_TRUE((slice.get("type").copyString() ==
-                   arangodb::iresearch::StaticStrings::ViewType));
+                   arangodb::iresearch::StaticStrings::ViewArangoSearchType));
       EXPECT_TRUE((!slice.hasKey("planId")));
       EXPECT_TRUE((!slice.hasKey("deleted")));
       EXPECT_TRUE((slice.hasKey("links") && slice.get("links").isObject() &&
@@ -345,7 +345,7 @@ TEST_F(IResearchViewCoordinatorTest, test_defaults) {
       EXPECT_TRUE((slice.get("id").copyString() == "1"));
       EXPECT_TRUE((slice.get("name").copyString() == "testView"));
       EXPECT_TRUE((slice.get("type").copyString() ==
-                   arangodb::iresearch::StaticStrings::ViewType));
+                   arangodb::iresearch::StaticStrings::ViewArangoSearchType));
       EXPECT_TRUE((!slice.hasKey("planId")));
       EXPECT_TRUE((!slice.hasKey("deleted")));
       EXPECT_TRUE((!slice.hasKey("properties")));
@@ -574,7 +574,7 @@ TEST_F(IResearchViewCoordinatorTest, test_create_drop_view) {
     EXPECT_TRUE("testView" == view->name());
     EXPECT_TRUE(false == view->deleted());
     EXPECT_TRUE(viewId == std::to_string(view->id().id()));
-    EXPECT_TRUE(arangodb::ViewType::kView == view->type());
+    EXPECT_TRUE(arangodb::ViewType::kArangoSearch == view->type());
     EXPECT_TRUE(arangodb::LogicalDataSource::Category::kView ==
                 view->category());
     EXPECT_TRUE(vocbase == &view->vocbase());
@@ -622,7 +622,7 @@ TEST_F(IResearchViewCoordinatorTest, test_create_drop_view) {
     EXPECT_TRUE("testView" == view->name());
     EXPECT_TRUE(false == view->deleted());
     EXPECT_TRUE(42 == view->id().id());
-    EXPECT_TRUE(arangodb::ViewType::kView == view->type());
+    EXPECT_TRUE(arangodb::ViewType::kArangoSearch == view->type());
     EXPECT_TRUE(arangodb::LogicalDataSource::Category::kView ==
                 view->category());
     EXPECT_TRUE(vocbase == &view->vocbase());
@@ -919,7 +919,7 @@ TEST_F(IResearchViewCoordinatorTest, test_update_properties) {
     EXPECT_TRUE("testView" == view->name());
     EXPECT_TRUE(false == view->deleted());
     EXPECT_TRUE(viewId == std::to_string(view->id().id()));
-    EXPECT_TRUE(arangodb::ViewType::kView == view->type());
+    EXPECT_TRUE(arangodb::ViewType::kArangoSearch == view->type());
     EXPECT_TRUE(arangodb::LogicalDataSource::Category::kView ==
                 view->category());
     EXPECT_TRUE(vocbase == &view->vocbase());
@@ -959,7 +959,8 @@ TEST_F(IResearchViewCoordinatorTest, test_update_properties) {
       EXPECT_TRUE("testView" == fullyUpdatedView->name());
       EXPECT_TRUE(false == fullyUpdatedView->deleted());
       EXPECT_TRUE(viewId == std::to_string(fullyUpdatedView->id().id()));
-      EXPECT_TRUE(arangodb::ViewType::kView == fullyUpdatedView->type());
+      EXPECT_TRUE(arangodb::ViewType::kArangoSearch ==
+                  fullyUpdatedView->type());
       EXPECT_TRUE(arangodb::LogicalDataSource::Category::kView ==
                   fullyUpdatedView->category());
       EXPECT_TRUE(vocbase == &fullyUpdatedView->vocbase());
@@ -1017,7 +1018,8 @@ TEST_F(IResearchViewCoordinatorTest, test_update_properties) {
       EXPECT_TRUE("testView" == partiallyUpdatedView->name());
       EXPECT_TRUE(false == partiallyUpdatedView->deleted());
       EXPECT_TRUE(viewId == std::to_string(partiallyUpdatedView->id().id()));
-      EXPECT_TRUE(arangodb::ViewType::kView == partiallyUpdatedView->type());
+      EXPECT_TRUE(arangodb::ViewType::kArangoSearch ==
+                  partiallyUpdatedView->type());
       EXPECT_TRUE(arangodb::LogicalDataSource::Category::kView ==
                   partiallyUpdatedView->category());
       EXPECT_TRUE(vocbase == &partiallyUpdatedView->vocbase());
@@ -2832,7 +2834,7 @@ TEST_F(IResearchViewCoordinatorTest, test_overwrite_immutable_properties) {
   EXPECT_EQ("testView", view->name());
   EXPECT_FALSE(view->deleted());
   EXPECT_EQ(viewId, std::to_string(view->id().id()));
-  EXPECT_EQ(arangodb::ViewType::kView, view->type());
+  EXPECT_EQ(arangodb::ViewType::kArangoSearch, view->type());
   EXPECT_EQ(arangodb::LogicalDataSource::Category::kView, view->category());
   EXPECT_EQ(vocbase, &view->vocbase());
 
@@ -2936,7 +2938,7 @@ TEST_F(IResearchViewCoordinatorTest, test_overwrite_immutable_properties) {
     EXPECT_EQ("testView", fullyUpdatedView->name());
     EXPECT_FALSE(fullyUpdatedView->deleted());
     EXPECT_EQ(viewId, std::to_string(fullyUpdatedView->id().id()));
-    EXPECT_EQ(arangodb::ViewType::kView, fullyUpdatedView->type());
+    EXPECT_EQ(arangodb::ViewType::kArangoSearch, fullyUpdatedView->type());
     EXPECT_EQ(arangodb::LogicalDataSource::Category::kView,
               fullyUpdatedView->category());
     EXPECT_EQ(vocbase, &fullyUpdatedView->vocbase());
@@ -3122,7 +3124,7 @@ TEST_F(IResearchViewCoordinatorTest, test_update_links_partial_remove) {
   EXPECT_TRUE("testView" == view->name());
   EXPECT_TRUE(false == view->deleted());
   EXPECT_TRUE(42 == view->id().id());
-  EXPECT_TRUE(arangodb::ViewType::kView == view->type());
+  EXPECT_TRUE(arangodb::ViewType::kArangoSearch == view->type());
   EXPECT_TRUE(arangodb::LogicalDataSource::Category::kView == view->category());
   EXPECT_TRUE(vocbase == &view->vocbase());
 
@@ -3226,8 +3228,8 @@ TEST_F(IResearchViewCoordinatorTest, test_update_links_partial_remove) {
     EXPECT_TRUE((true == index->sparse()));
     EXPECT_TRUE((arangodb::Index::IndexType::TRI_IDX_TYPE_IRESEARCH_LINK ==
                  index->type()));
-    EXPECT_TRUE(
-        (arangodb::iresearch::StaticStrings::ViewType == index->typeName()));
+    EXPECT_TRUE((arangodb::iresearch::StaticStrings::ViewArangoSearchType ==
+                 index->typeName()));
     EXPECT_TRUE((false == index->unique()));
 
     arangodb::iresearch::IResearchLinkMeta expectedMeta;
@@ -3288,8 +3290,8 @@ TEST_F(IResearchViewCoordinatorTest, test_update_links_partial_remove) {
     EXPECT_TRUE((true == index->sparse()));
     EXPECT_TRUE((arangodb::Index::IndexType::TRI_IDX_TYPE_IRESEARCH_LINK ==
                  index->type()));
-    EXPECT_TRUE(
-        (arangodb::iresearch::StaticStrings::ViewType == index->typeName()));
+    EXPECT_TRUE((arangodb::iresearch::StaticStrings::ViewArangoSearchType ==
+                 index->typeName()));
     EXPECT_TRUE((false == index->unique()));
 
     arangodb::iresearch::IResearchLinkMeta expectedMeta;
@@ -3350,8 +3352,8 @@ TEST_F(IResearchViewCoordinatorTest, test_update_links_partial_remove) {
     EXPECT_TRUE((true == index->sparse()));
     EXPECT_TRUE((arangodb::Index::IndexType::TRI_IDX_TYPE_IRESEARCH_LINK ==
                  index->type()));
-    EXPECT_TRUE(
-        (arangodb::iresearch::StaticStrings::ViewType == index->typeName()));
+    EXPECT_TRUE((arangodb::iresearch::StaticStrings::ViewArangoSearchType ==
+                 index->typeName()));
     EXPECT_TRUE((false == index->unique()));
 
     arangodb::iresearch::IResearchLinkMeta expectedMeta;
@@ -3423,7 +3425,7 @@ TEST_F(IResearchViewCoordinatorTest, test_update_links_partial_remove) {
   EXPECT_TRUE("testView" == view->name());
   EXPECT_TRUE(false == view->deleted());
   EXPECT_TRUE(42 == view->id().id());
-  EXPECT_TRUE(arangodb::ViewType::kView == view->type());
+  EXPECT_TRUE(arangodb::ViewType::kArangoSearch == view->type());
   EXPECT_TRUE(arangodb::LogicalDataSource::Category::kView == view->category());
   EXPECT_TRUE(vocbase == &view->vocbase());
 
@@ -3512,8 +3514,8 @@ TEST_F(IResearchViewCoordinatorTest, test_update_links_partial_remove) {
     EXPECT_TRUE((true == index->sparse()));
     EXPECT_TRUE((arangodb::Index::IndexType::TRI_IDX_TYPE_IRESEARCH_LINK ==
                  index->type()));
-    EXPECT_TRUE(
-        (arangodb::iresearch::StaticStrings::ViewType == index->typeName()));
+    EXPECT_TRUE((arangodb::iresearch::StaticStrings::ViewArangoSearchType ==
+                 index->typeName()));
     EXPECT_TRUE((false == index->unique()));
 
     arangodb::iresearch::IResearchLinkMeta expectedMeta;
@@ -3575,8 +3577,8 @@ TEST_F(IResearchViewCoordinatorTest, test_update_links_partial_remove) {
     EXPECT_TRUE((true == index->sparse()));
     EXPECT_TRUE((arangodb::Index::IndexType::TRI_IDX_TYPE_IRESEARCH_LINK ==
                  index->type()));
-    EXPECT_TRUE(
-        (arangodb::iresearch::StaticStrings::ViewType == index->typeName()));
+    EXPECT_TRUE((arangodb::iresearch::StaticStrings::ViewArangoSearchType ==
+                 index->typeName()));
     EXPECT_TRUE((false == index->unique()));
 
     arangodb::iresearch::IResearchLinkMeta expectedMeta;
@@ -3794,7 +3796,7 @@ TEST_F(IResearchViewCoordinatorTest, test_update_links_partial_add) {
   EXPECT_TRUE("testView" == view->name());
   EXPECT_TRUE(false == view->deleted());
   EXPECT_TRUE(42 == view->id().id());
-  EXPECT_TRUE(arangodb::ViewType::kView == view->type());
+  EXPECT_TRUE(arangodb::ViewType::kArangoSearch == view->type());
   EXPECT_TRUE(arangodb::LogicalDataSource::Category::kView == view->category());
   EXPECT_TRUE(vocbase == &view->vocbase());
 
@@ -3883,8 +3885,8 @@ TEST_F(IResearchViewCoordinatorTest, test_update_links_partial_add) {
     EXPECT_TRUE((true == index->sparse()));
     EXPECT_TRUE((arangodb::Index::IndexType::TRI_IDX_TYPE_IRESEARCH_LINK ==
                  index->type()));
-    EXPECT_TRUE(
-        (arangodb::iresearch::StaticStrings::ViewType == index->typeName()));
+    EXPECT_TRUE((arangodb::iresearch::StaticStrings::ViewArangoSearchType ==
+                 index->typeName()));
     EXPECT_TRUE((false == index->unique()));
 
     arangodb::iresearch::IResearchLinkMeta expectedMeta;
@@ -3945,8 +3947,8 @@ TEST_F(IResearchViewCoordinatorTest, test_update_links_partial_add) {
     EXPECT_TRUE((true == index->sparse()));
     EXPECT_TRUE((arangodb::Index::IndexType::TRI_IDX_TYPE_IRESEARCH_LINK ==
                  index->type()));
-    EXPECT_TRUE(
-        (arangodb::iresearch::StaticStrings::ViewType == index->typeName()));
+    EXPECT_TRUE((arangodb::iresearch::StaticStrings::ViewArangoSearchType ==
+                 index->typeName()));
     EXPECT_TRUE((false == index->unique()));
 
     arangodb::iresearch::IResearchLinkMeta expectedMeta;
@@ -4019,7 +4021,7 @@ TEST_F(IResearchViewCoordinatorTest, test_update_links_partial_add) {
   EXPECT_TRUE("testView" == view->name());
   EXPECT_TRUE(false == view->deleted());
   EXPECT_TRUE(42 == view->id().id());
-  EXPECT_TRUE(arangodb::ViewType::kView == view->type());
+  EXPECT_TRUE(arangodb::ViewType::kArangoSearch == view->type());
   EXPECT_TRUE(arangodb::LogicalDataSource::Category::kView == view->category());
   EXPECT_TRUE(vocbase == &view->vocbase());
 
@@ -4123,8 +4125,8 @@ TEST_F(IResearchViewCoordinatorTest, test_update_links_partial_add) {
     EXPECT_TRUE((true == index->sparse()));
     EXPECT_TRUE((arangodb::Index::IndexType::TRI_IDX_TYPE_IRESEARCH_LINK ==
                  index->type()));
-    EXPECT_TRUE(
-        (arangodb::iresearch::StaticStrings::ViewType == index->typeName()));
+    EXPECT_TRUE((arangodb::iresearch::StaticStrings::ViewArangoSearchType ==
+                 index->typeName()));
     EXPECT_TRUE((false == index->unique()));
 
     arangodb::iresearch::IResearchLinkMeta expectedMeta;
@@ -4186,8 +4188,8 @@ TEST_F(IResearchViewCoordinatorTest, test_update_links_partial_add) {
     EXPECT_TRUE((true == index->sparse()));
     EXPECT_TRUE((arangodb::Index::IndexType::TRI_IDX_TYPE_IRESEARCH_LINK ==
                  index->type()));
-    EXPECT_TRUE(
-        (arangodb::iresearch::StaticStrings::ViewType == index->typeName()));
+    EXPECT_TRUE((arangodb::iresearch::StaticStrings::ViewArangoSearchType ==
+                 index->typeName()));
     EXPECT_TRUE((false == index->unique()));
 
     arangodb::iresearch::IResearchLinkMeta expectedMeta;
@@ -4249,8 +4251,8 @@ TEST_F(IResearchViewCoordinatorTest, test_update_links_partial_add) {
     EXPECT_TRUE((true == index->sparse()));
     EXPECT_TRUE((arangodb::Index::IndexType::TRI_IDX_TYPE_IRESEARCH_LINK ==
                  index->type()));
-    EXPECT_TRUE(
-        (arangodb::iresearch::StaticStrings::ViewType == index->typeName()));
+    EXPECT_TRUE((arangodb::iresearch::StaticStrings::ViewArangoSearchType ==
+                 index->typeName()));
     EXPECT_TRUE((false == index->unique()));
 
     arangodb::iresearch::IResearchLinkMeta expectedMeta;
@@ -4535,7 +4537,7 @@ TEST_F(IResearchViewCoordinatorTest, test_update_links_replace) {
   EXPECT_TRUE("testView" == view->name());
   EXPECT_TRUE(false == view->deleted());
   EXPECT_TRUE(42 == view->id().id());
-  EXPECT_TRUE(arangodb::ViewType::kView == view->type());
+  EXPECT_TRUE(arangodb::ViewType::kArangoSearch == view->type());
   EXPECT_TRUE(arangodb::LogicalDataSource::Category::kView == view->category());
   EXPECT_TRUE(vocbase == &view->vocbase());
 
@@ -4624,8 +4626,8 @@ TEST_F(IResearchViewCoordinatorTest, test_update_links_replace) {
     EXPECT_TRUE((true == index->sparse()));
     EXPECT_TRUE((arangodb::Index::IndexType::TRI_IDX_TYPE_IRESEARCH_LINK ==
                  index->type()));
-    EXPECT_TRUE(
-        (arangodb::iresearch::StaticStrings::ViewType == index->typeName()));
+    EXPECT_TRUE((arangodb::iresearch::StaticStrings::ViewArangoSearchType ==
+                 index->typeName()));
     EXPECT_TRUE((false == index->unique()));
 
     arangodb::iresearch::IResearchLinkMeta expectedMeta;
@@ -4686,8 +4688,8 @@ TEST_F(IResearchViewCoordinatorTest, test_update_links_replace) {
     EXPECT_TRUE((true == index->sparse()));
     EXPECT_TRUE((arangodb::Index::IndexType::TRI_IDX_TYPE_IRESEARCH_LINK ==
                  index->type()));
-    EXPECT_TRUE(
-        (arangodb::iresearch::StaticStrings::ViewType == index->typeName()));
+    EXPECT_TRUE((arangodb::iresearch::StaticStrings::ViewArangoSearchType ==
+                 index->typeName()));
     EXPECT_TRUE((false == index->unique()));
 
     arangodb::iresearch::IResearchLinkMeta expectedMeta;
@@ -4780,7 +4782,7 @@ TEST_F(IResearchViewCoordinatorTest, test_update_links_replace) {
   EXPECT_TRUE("testView" == view->name());
   EXPECT_TRUE(false == view->deleted());
   EXPECT_TRUE(42 == view->id().id());
-  EXPECT_TRUE(arangodb::ViewType::kView == view->type());
+  EXPECT_TRUE(arangodb::ViewType::kArangoSearch == view->type());
   EXPECT_TRUE(arangodb::LogicalDataSource::Category::kView == view->category());
   EXPECT_TRUE(vocbase == &view->vocbase());
 
@@ -4855,8 +4857,8 @@ TEST_F(IResearchViewCoordinatorTest, test_update_links_replace) {
     EXPECT_TRUE((true == index->sparse()));
     EXPECT_TRUE((arangodb::Index::IndexType::TRI_IDX_TYPE_IRESEARCH_LINK ==
                  index->type()));
-    EXPECT_TRUE(
-        (arangodb::iresearch::StaticStrings::ViewType == index->typeName()));
+    EXPECT_TRUE((arangodb::iresearch::StaticStrings::ViewArangoSearchType ==
+                 index->typeName()));
     EXPECT_TRUE((false == index->unique()));
 
     arangodb::iresearch::IResearchLinkMeta expectedMeta;
@@ -4933,7 +4935,7 @@ TEST_F(IResearchViewCoordinatorTest, test_update_links_replace) {
   EXPECT_TRUE("testView" == view->name());
   EXPECT_TRUE(false == view->deleted());
   EXPECT_TRUE(42 == view->id().id());
-  EXPECT_TRUE(arangodb::ViewType::kView == view->type());
+  EXPECT_TRUE(arangodb::ViewType::kArangoSearch == view->type());
   EXPECT_TRUE(arangodb::LogicalDataSource::Category::kView == view->category());
   EXPECT_TRUE(vocbase == &view->vocbase());
 
@@ -5008,8 +5010,8 @@ TEST_F(IResearchViewCoordinatorTest, test_update_links_replace) {
     EXPECT_TRUE((true == index->sparse()));
     EXPECT_TRUE((arangodb::Index::IndexType::TRI_IDX_TYPE_IRESEARCH_LINK ==
                  index->type()));
-    EXPECT_TRUE(
-        (arangodb::iresearch::StaticStrings::ViewType == index->typeName()));
+    EXPECT_TRUE((arangodb::iresearch::StaticStrings::ViewArangoSearchType ==
+                 index->typeName()));
     EXPECT_TRUE((false == index->unique()));
 
     arangodb::iresearch::IResearchLinkMeta expectedMeta;
@@ -5230,7 +5232,7 @@ TEST_F(IResearchViewCoordinatorTest, test_update_links_clear) {
   EXPECT_TRUE("testView" == view->name());
   EXPECT_TRUE(false == view->deleted());
   EXPECT_TRUE(42 == view->id().id());
-  EXPECT_TRUE(arangodb::ViewType::kView == view->type());
+  EXPECT_TRUE(arangodb::ViewType::kArangoSearch == view->type());
   EXPECT_TRUE(arangodb::LogicalDataSource::Category::kView == view->category());
   EXPECT_TRUE(vocbase == &view->vocbase());
 
@@ -5334,8 +5336,8 @@ TEST_F(IResearchViewCoordinatorTest, test_update_links_clear) {
     EXPECT_TRUE((true == index->sparse()));
     EXPECT_TRUE((arangodb::Index::IndexType::TRI_IDX_TYPE_IRESEARCH_LINK ==
                  index->type()));
-    EXPECT_TRUE(
-        (arangodb::iresearch::StaticStrings::ViewType == index->typeName()));
+    EXPECT_TRUE((arangodb::iresearch::StaticStrings::ViewArangoSearchType ==
+                 index->typeName()));
     EXPECT_TRUE((false == index->unique()));
 
     arangodb::iresearch::IResearchLinkMeta expectedMeta;
@@ -5397,8 +5399,8 @@ TEST_F(IResearchViewCoordinatorTest, test_update_links_clear) {
     EXPECT_TRUE((true == index->sparse()));
     EXPECT_TRUE((arangodb::Index::IndexType::TRI_IDX_TYPE_IRESEARCH_LINK ==
                  index->type()));
-    EXPECT_TRUE(
-        (arangodb::iresearch::StaticStrings::ViewType == index->typeName()));
+    EXPECT_TRUE((arangodb::iresearch::StaticStrings::ViewArangoSearchType ==
+                 index->typeName()));
     EXPECT_TRUE((false == index->unique()));
 
     arangodb::iresearch::IResearchLinkMeta expectedMeta;
@@ -5459,8 +5461,8 @@ TEST_F(IResearchViewCoordinatorTest, test_update_links_clear) {
     EXPECT_TRUE((true == index->sparse()));
     EXPECT_TRUE((arangodb::Index::IndexType::TRI_IDX_TYPE_IRESEARCH_LINK ==
                  index->type()));
-    EXPECT_TRUE(
-        (arangodb::iresearch::StaticStrings::ViewType == index->typeName()));
+    EXPECT_TRUE((arangodb::iresearch::StaticStrings::ViewArangoSearchType ==
+                 index->typeName()));
     EXPECT_TRUE((false == index->unique()));
 
     arangodb::iresearch::IResearchLinkMeta expectedMeta;
@@ -5550,7 +5552,7 @@ TEST_F(IResearchViewCoordinatorTest, test_update_links_clear) {
   EXPECT_TRUE("testView" == view->name());
   EXPECT_TRUE(false == view->deleted());
   EXPECT_TRUE(42 == view->id().id());
-  EXPECT_TRUE(arangodb::ViewType::kView == view->type());
+  EXPECT_TRUE(arangodb::ViewType::kArangoSearch == view->type());
   EXPECT_TRUE(arangodb::LogicalDataSource::Category::kView == view->category());
   EXPECT_TRUE(vocbase == &view->vocbase());
 
@@ -5699,7 +5701,7 @@ TEST_F(IResearchViewCoordinatorTest, test_drop_link) {
     EXPECT_TRUE("testView" == view->name());
     EXPECT_TRUE(false == view->deleted());
     EXPECT_TRUE(42 == view->id().id());
-    EXPECT_TRUE(arangodb::ViewType::kView == view->type());
+    EXPECT_TRUE(arangodb::ViewType::kArangoSearch == view->type());
     EXPECT_TRUE(arangodb::LogicalDataSource::Category::kView ==
                 view->category());
     EXPECT_TRUE(vocbase == &view->vocbase());
@@ -5778,8 +5780,8 @@ TEST_F(IResearchViewCoordinatorTest, test_drop_link) {
       EXPECT_TRUE((true == index->sparse()));
       EXPECT_TRUE((arangodb::Index::IndexType::TRI_IDX_TYPE_IRESEARCH_LINK ==
                    index->type()));
-      EXPECT_TRUE(
-          (arangodb::iresearch::StaticStrings::ViewType == index->typeName()));
+      EXPECT_TRUE((arangodb::iresearch::StaticStrings::ViewArangoSearchType ==
+                   index->typeName()));
       EXPECT_TRUE((false == index->unique()));
 
       arangodb::iresearch::IResearchLinkMeta expectedMeta;
@@ -5855,7 +5857,7 @@ TEST_F(IResearchViewCoordinatorTest, test_drop_link) {
     EXPECT_TRUE("testView" == view->name());
     EXPECT_TRUE(false == view->deleted());
     EXPECT_TRUE(42 == view->id().id());
-    EXPECT_TRUE(arangodb::ViewType::kView == view->type());
+    EXPECT_TRUE(arangodb::ViewType::kArangoSearch == view->type());
     EXPECT_TRUE(arangodb::LogicalDataSource::Category::kView ==
                 view->category());
     EXPECT_TRUE(vocbase == &view->vocbase());
@@ -7770,7 +7772,7 @@ TEST_F(IResearchViewCoordinatorTest, IResearchViewNode_createBlock) {
     EXPECT_TRUE("testView" == view->name());
     EXPECT_TRUE(false == view->deleted());
     EXPECT_TRUE(viewId == std::to_string(view->id().id()));
-    EXPECT_TRUE(arangodb::ViewType::kView == view->type());
+    EXPECT_TRUE(arangodb::ViewType::kArangoSearch == view->type());
     EXPECT_TRUE(arangodb::LogicalDataSource::Category::kView ==
                 view->category());
     EXPECT_TRUE(vocbase == &view->vocbase());

--- a/tests/IResearch/IResearchViewCountApproximateTest.cpp
+++ b/tests/IResearch/IResearchViewCountApproximateTest.cpp
@@ -245,7 +245,7 @@ class IResearchViewCountApproximateTest : public IResearchQueryTest {
     auto slice = builder.slice();
     EXPECT_TRUE(slice.isObject());
     EXPECT_TRUE(slice.get("type").copyString() ==
-                arangodb::iresearch::StaticStrings::ViewType);
+                arangodb::iresearch::StaticStrings::ViewArangoSearchType);
     EXPECT_TRUE(slice.get("deleted").isNone());  // no system properties
     auto tmpSlice = slice.get("links");
     EXPECT_TRUE(tmpSlice.isObject() && 2 == tmpSlice.length());

--- a/tests/IResearch/IResearchViewDBServerTest.cpp
+++ b/tests/IResearch/IResearchViewDBServerTest.cpp
@@ -347,8 +347,9 @@ TEST_F(IResearchViewDBServerTest, test_make) {
     EXPECT_FALSE(view->deleted());
     EXPECT_EQ(viewId, view->id().id());
     EXPECT_EQ(impl->id(), view->planId());  // same as view ID
-    EXPECT_EQ(arangodb::iresearch::StaticStrings::ViewType, view->typeName());
-    EXPECT_EQ(arangodb::ViewType::kView, view->type());
+    EXPECT_EQ(arangodb::iresearch::StaticStrings::ViewArangoSearchType,
+              view->typeName());
+    EXPECT_EQ(arangodb::ViewType::kArangoSearch, view->type());
     EXPECT_EQ(&vocbase, &(view->vocbase()));
   }
 }
@@ -875,7 +876,7 @@ TEST_F(IResearchViewDBServerTest, test_toVelocyPack) {
     EXPECT_TRUE((slice.hasKey("name") && slice.get("name").isString() &&
                  std::string("testView") == slice.get("name").copyString()));
     EXPECT_TRUE((slice.hasKey("type") && slice.get("type").isString() &&
-                 arangodb::iresearch::StaticStrings::ViewType ==
+                 arangodb::iresearch::StaticStrings::ViewArangoSearchType ==
                      slice.get("type").copyString()));
   }
 
@@ -914,7 +915,7 @@ TEST_F(IResearchViewDBServerTest, test_toVelocyPack) {
     EXPECT_TRUE((slice.hasKey("name") && slice.get("name").isString() &&
                  std::string("testView") == slice.get("name").copyString()));
     EXPECT_TRUE((slice.hasKey("type") && slice.get("type").isString() &&
-                 arangodb::iresearch::StaticStrings::ViewType ==
+                 arangodb::iresearch::StaticStrings::ViewArangoSearchType ==
                      slice.get("type").copyString()));
     auto expectedStoredValue = arangodb::velocypack::Parser::fromJson(
         "[{ \"fields\":[\"test.t\"], \"compression\":\"none\"}, "
@@ -964,7 +965,7 @@ TEST_F(IResearchViewDBServerTest, test_toVelocyPack) {
     EXPECT_TRUE(slice.hasKey("planId") && slice.get("planId").isString() &&
                 std::string("3") == slice.get("planId").copyString());
     EXPECT_TRUE(slice.hasKey("type") && slice.get("type").isString() &&
-                arangodb::iresearch::StaticStrings::ViewType ==
+                arangodb::iresearch::StaticStrings::ViewArangoSearchType ==
                     slice.get("type").copyString());
     EXPECT_TRUE(slice.hasKey("cleanupIntervalStep") &&
                 slice.get("cleanupIntervalStep").isNumber());

--- a/tests/IResearch/IResearchViewSortedTest.cpp
+++ b/tests/IResearch/IResearchViewSortedTest.cpp
@@ -213,7 +213,7 @@ TEST_P(IResearchViewSortedTest, SingleField) {
     EXPECT_TRUE(slice.isObject());
     EXPECT_EQ(slice.get("name").copyString(), "testView");
     EXPECT_TRUE(slice.get("type").copyString() ==
-                arangodb::iresearch::StaticStrings::ViewType);
+                arangodb::iresearch::StaticStrings::ViewArangoSearchType);
     EXPECT_TRUE(slice.get("deleted").isNone());  // no system properties
     auto tmpSlice = slice.get("links");
     EXPECT_TRUE(tmpSlice.isObject() && 2 == tmpSlice.length());
@@ -519,7 +519,7 @@ TEST_P(IResearchViewSortedTest, MultipleFields) {
     EXPECT_TRUE(slice.isObject());
     EXPECT_EQ(slice.get("name").copyString(), "testView");
     EXPECT_TRUE(slice.get("type").copyString() ==
-                arangodb::iresearch::StaticStrings::ViewType);
+                arangodb::iresearch::StaticStrings::ViewArangoSearchType);
     EXPECT_TRUE(slice.get("deleted").isNone());  // no system properties
     auto tmpSlice = slice.get("links");
     EXPECT_TRUE(tmpSlice.isObject() && 2 == tmpSlice.length());

--- a/tests/IResearch/IResearchViewTest.cpp
+++ b/tests/IResearch/IResearchViewTest.cpp
@@ -194,9 +194,9 @@ class IResearchViewTest
 // -----------------------------------------------------------------------------
 
 TEST_F(IResearchViewTest, test_type) {
-  static_assert(
-      arangodb::iresearch::IResearchView::typeInfo() ==
-      std::pair{arangodb::ViewType::kView, std::string_view{"arangosearch"}});
+  static_assert(arangodb::iresearch::IResearchView::typeInfo() ==
+                std::pair{arangodb::ViewType::kArangoSearch,
+                          std::string_view{"arangosearch"}});
 }
 
 TEST_F(IResearchViewTest, test_defaults) {
@@ -233,7 +233,7 @@ TEST_F(IResearchViewTest, test_defaults) {
                  false == slice.get("globallyUniqueId").copyString().empty()));
     EXPECT_TRUE(slice.get("name").copyString() == "testView");
     EXPECT_TRUE(slice.get("type").copyString() ==
-                arangodb::iresearch::StaticStrings::ViewType);
+                arangodb::iresearch::StaticStrings::ViewArangoSearchType);
     EXPECT_TRUE(false == slice.get("deleted").getBool());
     EXPECT_TRUE(false == slice.get("isSystem").getBool());
     EXPECT_TRUE((!slice.hasKey("links")));  // for persistence so no links
@@ -271,7 +271,7 @@ TEST_F(IResearchViewTest, test_defaults) {
                  false == slice.get("globallyUniqueId").copyString().empty()));
     EXPECT_TRUE(slice.get("name").copyString() == "testView");
     EXPECT_TRUE(slice.get("type").copyString() ==
-                arangodb::iresearch::StaticStrings::ViewType);
+                arangodb::iresearch::StaticStrings::ViewArangoSearchType);
     EXPECT_TRUE((false == slice.hasKey("deleted")));
     EXPECT_TRUE((meta.init(slice, error) && expectedMeta == meta));
 
@@ -399,7 +399,7 @@ TEST_F(IResearchViewTest, test_defaults) {
                  !slice.get("globallyUniqueId").copyString().empty()));
     EXPECT_TRUE((slice.get("name").copyString() == "testView"));
     EXPECT_TRUE((slice.get("type").copyString() ==
-                 arangodb::iresearch::StaticStrings::ViewType));
+                 arangodb::iresearch::StaticStrings::ViewArangoSearchType));
     EXPECT_TRUE((false == slice.hasKey("deleted")));
     EXPECT_TRUE((meta.init(slice, error) && expectedMeta == meta));
 
@@ -4385,7 +4385,7 @@ TEST_F(IResearchViewTest, test_register_link) {
       EXPECT_TRUE(slice.get("id").copyString() == "101");
       EXPECT_TRUE(slice.get("name").copyString() == "testView");
       EXPECT_TRUE(slice.get("type").copyString() ==
-                  arangodb::iresearch::StaticStrings::ViewType);
+                  arangodb::iresearch::StaticStrings::ViewArangoSearchType);
       EXPECT_TRUE(slice.get("deleted").isNone());  // no system properties
     }
 
@@ -4467,7 +4467,7 @@ TEST_F(IResearchViewTest, test_register_link) {
       EXPECT_TRUE(slice.get("id").copyString() == "101");
       EXPECT_TRUE(slice.get("name").copyString() == "testView");
       EXPECT_TRUE(slice.get("type").copyString() ==
-                  arangodb::iresearch::StaticStrings::ViewType);
+                  arangodb::iresearch::StaticStrings::ViewArangoSearchType);
       EXPECT_TRUE(slice.get("deleted").isNone());  // no system properties
     }
 
@@ -6048,7 +6048,7 @@ TEST_F(IResearchViewTest, test_update_overwrite) {
              false == slice.get("globallyUniqueId").copyString().empty()));
         EXPECT_TRUE(slice.get("name").copyString() == "testView");
         EXPECT_TRUE(slice.get("type").copyString() ==
-                    arangodb::iresearch::StaticStrings::ViewType);
+                    arangodb::iresearch::StaticStrings::ViewArangoSearchType);
         EXPECT_TRUE(slice.get("deleted").isNone());  // no system properties
         EXPECT_TRUE((meta.init(slice, error) && expectedMeta == meta));
         auto tmpSlice = slice.get("links");
@@ -6073,7 +6073,7 @@ TEST_F(IResearchViewTest, test_update_overwrite) {
         EXPECT_EQ(19, slice.length());
         EXPECT_TRUE(slice.get("name").copyString() == "testView");
         EXPECT_TRUE(slice.get("type").copyString() ==
-                    arangodb::iresearch::StaticStrings::ViewType);
+                    arangodb::iresearch::StaticStrings::ViewArangoSearchType);
         EXPECT_TRUE(
             (slice.hasKey("deleted") && slice.get("deleted").isBoolean() &&
              false ==
@@ -6119,7 +6119,7 @@ TEST_F(IResearchViewTest, test_update_overwrite) {
              false == slice.get("globallyUniqueId").copyString().empty()));
         EXPECT_TRUE(slice.get("name").copyString() == "testView");
         EXPECT_TRUE(slice.get("type").copyString() ==
-                    arangodb::iresearch::StaticStrings::ViewType);
+                    arangodb::iresearch::StaticStrings::ViewArangoSearchType);
         EXPECT_TRUE(slice.get("deleted").isNone());  // no system properties
         EXPECT_TRUE((meta.init(slice, error) && expectedMeta == meta));
         auto tmpSlice = slice.get("links");
@@ -6144,7 +6144,7 @@ TEST_F(IResearchViewTest, test_update_overwrite) {
         EXPECT_EQ(19, slice.length());
         EXPECT_TRUE(slice.get("name").copyString() == "testView");
         EXPECT_TRUE(slice.get("type").copyString() ==
-                    arangodb::iresearch::StaticStrings::ViewType);
+                    arangodb::iresearch::StaticStrings::ViewArangoSearchType);
         EXPECT_TRUE(
             (slice.hasKey("deleted") && slice.get("deleted").isBoolean() &&
              false ==
@@ -6203,7 +6203,7 @@ TEST_F(IResearchViewTest, test_update_overwrite) {
            false == slice.get("globallyUniqueId").copyString().empty()));
       EXPECT_TRUE((slice.get("name").copyString() == "testView"));
       EXPECT_TRUE((slice.get("type").copyString() ==
-                   arangodb::iresearch::StaticStrings::ViewType));
+                   arangodb::iresearch::StaticStrings::ViewArangoSearchType));
       EXPECT_TRUE((slice.get("deleted").isNone()));  // no system properties
       EXPECT_TRUE((meta.init(slice, error) && expectedMeta == meta));
       auto tmpSlice = slice.get("links");
@@ -6228,7 +6228,7 @@ TEST_F(IResearchViewTest, test_update_overwrite) {
       EXPECT_EQ(19, slice.length());
       EXPECT_TRUE((slice.get("name").copyString() == "testView"));
       EXPECT_TRUE((slice.get("type").copyString() ==
-                   arangodb::iresearch::StaticStrings::ViewType));
+                   arangodb::iresearch::StaticStrings::ViewArangoSearchType));
       EXPECT_TRUE(
           (slice.hasKey("deleted") && slice.get("deleted").isBoolean() &&
            false ==
@@ -6290,7 +6290,7 @@ TEST_F(IResearchViewTest, test_update_overwrite) {
            false == slice.get("globallyUniqueId").copyString().empty()));
       EXPECT_TRUE((slice.get("name").copyString() == "testView"));
       EXPECT_TRUE((slice.get("type").copyString() ==
-                   arangodb::iresearch::StaticStrings::ViewType));
+                   arangodb::iresearch::StaticStrings::ViewArangoSearchType));
       EXPECT_TRUE((slice.get("deleted").isNone()));  // no system properties
       EXPECT_TRUE((meta.init(slice, error) && expectedMeta == meta));
       auto tmpSlice = slice.get("links");
@@ -6315,7 +6315,7 @@ TEST_F(IResearchViewTest, test_update_overwrite) {
       EXPECT_EQ(19, slice.length());
       EXPECT_TRUE((slice.get("name").copyString() == "testView"));
       EXPECT_TRUE((slice.get("type").copyString() ==
-                   arangodb::iresearch::StaticStrings::ViewType));
+                   arangodb::iresearch::StaticStrings::ViewArangoSearchType));
       EXPECT_TRUE(
           (slice.hasKey("deleted") && slice.get("deleted").isBoolean() &&
            false ==
@@ -6378,7 +6378,7 @@ TEST_F(IResearchViewTest, test_update_overwrite) {
            false == slice.get("globallyUniqueId").copyString().empty()));
       EXPECT_TRUE((slice.get("name").copyString() == "testView"));
       EXPECT_TRUE((slice.get("type").copyString() ==
-                   arangodb::iresearch::StaticStrings::ViewType));
+                   arangodb::iresearch::StaticStrings::ViewArangoSearchType));
       EXPECT_TRUE((slice.get("deleted").isNone()));  // no system properties
       EXPECT_TRUE((meta.init(slice, error) && expectedMeta == meta));
       auto tmpSlice = slice.get("links");
@@ -6407,7 +6407,7 @@ TEST_F(IResearchViewTest, test_update_overwrite) {
       EXPECT_EQ(19, slice.length());
       EXPECT_TRUE((slice.get("name").copyString() == "testView"));
       EXPECT_TRUE((slice.get("type").copyString() ==
-                   arangodb::iresearch::StaticStrings::ViewType));
+                   arangodb::iresearch::StaticStrings::ViewArangoSearchType));
       EXPECT_TRUE(
           (slice.hasKey("deleted") && slice.get("deleted").isBoolean() &&
            false ==
@@ -6470,7 +6470,7 @@ TEST_F(IResearchViewTest, test_update_overwrite) {
              false == slice.get("globallyUniqueId").copyString().empty()));
         EXPECT_TRUE((slice.get("name").copyString() == "testView"));
         EXPECT_TRUE((slice.get("type").copyString() ==
-                     arangodb::iresearch::StaticStrings::ViewType));
+                     arangodb::iresearch::StaticStrings::ViewArangoSearchType));
         EXPECT_TRUE((slice.get("deleted").isNone()));  // no system properties
         EXPECT_TRUE((meta.init(slice, error) && expectedMeta == meta));
 
@@ -6511,7 +6511,7 @@ TEST_F(IResearchViewTest, test_update_overwrite) {
         EXPECT_EQ(19, slice.length());
         EXPECT_TRUE((slice.get("name").copyString() == "testView"));
         EXPECT_TRUE((slice.get("type").copyString() ==
-                     arangodb::iresearch::StaticStrings::ViewType));
+                     arangodb::iresearch::StaticStrings::ViewArangoSearchType));
         EXPECT_TRUE(
             (slice.hasKey("deleted") && slice.get("deleted").isBoolean() &&
              false ==
@@ -6561,7 +6561,7 @@ TEST_F(IResearchViewTest, test_update_overwrite) {
              false == slice.get("globallyUniqueId").copyString().empty()));
         EXPECT_TRUE((slice.get("name").copyString() == "testView"));
         EXPECT_TRUE((slice.get("type").copyString() ==
-                     arangodb::iresearch::StaticStrings::ViewType));
+                     arangodb::iresearch::StaticStrings::ViewArangoSearchType));
         EXPECT_TRUE((slice.get("deleted").isNone()));  // no system properties
         EXPECT_TRUE((meta.init(slice, error) && expectedMeta == meta));
         auto tmpSlice = slice.get("links");
@@ -6586,7 +6586,7 @@ TEST_F(IResearchViewTest, test_update_overwrite) {
         EXPECT_EQ(19, slice.length());
         EXPECT_TRUE((slice.get("name").copyString() == "testView"));
         EXPECT_TRUE((slice.get("type").copyString() ==
-                     arangodb::iresearch::StaticStrings::ViewType));
+                     arangodb::iresearch::StaticStrings::ViewArangoSearchType));
         EXPECT_TRUE(
             (slice.hasKey("deleted") && slice.get("deleted").isBoolean() &&
              false ==
@@ -6656,7 +6656,7 @@ TEST_F(IResearchViewTest, test_update_overwrite) {
              false == slice.get("globallyUniqueId").copyString().empty()));
         EXPECT_TRUE(slice.get("name").copyString() == "testView");
         EXPECT_TRUE(slice.get("type").copyString() ==
-                    arangodb::iresearch::StaticStrings::ViewType);
+                    arangodb::iresearch::StaticStrings::ViewArangoSearchType);
         EXPECT_TRUE(slice.get("deleted").isNone());  // no system properties
         EXPECT_TRUE((meta.init(slice, error) && expectedMeta == meta));
 
@@ -6697,7 +6697,7 @@ TEST_F(IResearchViewTest, test_update_overwrite) {
         EXPECT_EQ(19, slice.length());
         EXPECT_TRUE(slice.get("name").copyString() == "testView");
         EXPECT_TRUE(slice.get("type").copyString() ==
-                    arangodb::iresearch::StaticStrings::ViewType);
+                    arangodb::iresearch::StaticStrings::ViewArangoSearchType);
         EXPECT_TRUE(
             (slice.hasKey("deleted") && slice.get("deleted").isBoolean() &&
              false ==
@@ -6748,7 +6748,7 @@ TEST_F(IResearchViewTest, test_update_overwrite) {
              false == slice.get("globallyUniqueId").copyString().empty()));
         EXPECT_TRUE(slice.get("name").copyString() == "testView");
         EXPECT_TRUE(slice.get("type").copyString() ==
-                    arangodb::iresearch::StaticStrings::ViewType);
+                    arangodb::iresearch::StaticStrings::ViewArangoSearchType);
         EXPECT_TRUE(slice.get("deleted").isNone());  // no system properties
         EXPECT_TRUE((meta.init(slice, error) && expectedMeta == meta));
 
@@ -6789,7 +6789,7 @@ TEST_F(IResearchViewTest, test_update_overwrite) {
         EXPECT_EQ(19, slice.length());
         EXPECT_TRUE(slice.get("name").copyString() == "testView");
         EXPECT_TRUE(slice.get("type").copyString() ==
-                    arangodb::iresearch::StaticStrings::ViewType);
+                    arangodb::iresearch::StaticStrings::ViewArangoSearchType);
         EXPECT_TRUE(
             (slice.hasKey("deleted") && slice.get("deleted").isBoolean() &&
              false ==
@@ -6844,7 +6844,7 @@ TEST_F(IResearchViewTest, test_update_overwrite) {
              false == slice.get("globallyUniqueId").copyString().empty()));
         EXPECT_TRUE(slice.get("name").copyString() == "testView");
         EXPECT_TRUE(slice.get("type").copyString() ==
-                    arangodb::iresearch::StaticStrings::ViewType);
+                    arangodb::iresearch::StaticStrings::ViewArangoSearchType);
         EXPECT_TRUE(slice.get("deleted").isNone());  // no system properties
         auto tmpSlice = slice.get("links");
         EXPECT_TRUE((true == tmpSlice.isObject() && 1 == tmpSlice.length()));
@@ -6869,7 +6869,7 @@ TEST_F(IResearchViewTest, test_update_overwrite) {
         EXPECT_EQ(19, slice.length());
         EXPECT_TRUE(slice.get("name").copyString() == "testView");
         EXPECT_TRUE(slice.get("type").copyString() ==
-                    arangodb::iresearch::StaticStrings::ViewType);
+                    arangodb::iresearch::StaticStrings::ViewArangoSearchType);
         EXPECT_TRUE(
             (slice.hasKey("deleted") && slice.get("deleted").isBoolean() &&
              false ==
@@ -6903,7 +6903,7 @@ TEST_F(IResearchViewTest, test_update_overwrite) {
              false == slice.get("globallyUniqueId").copyString().empty()));
         EXPECT_TRUE(slice.get("name").copyString() == "testView");
         EXPECT_TRUE(slice.get("type").copyString() ==
-                    arangodb::iresearch::StaticStrings::ViewType);
+                    arangodb::iresearch::StaticStrings::ViewArangoSearchType);
         EXPECT_TRUE(slice.get("deleted").isNone());  // no system properties
         auto tmpSlice = slice.get("links");
         EXPECT_TRUE((true == tmpSlice.isObject() && 1 == tmpSlice.length()));
@@ -6927,7 +6927,7 @@ TEST_F(IResearchViewTest, test_update_overwrite) {
         EXPECT_EQ(19, slice.length());
         EXPECT_TRUE(slice.get("name").copyString() == "testView");
         EXPECT_TRUE(slice.get("type").copyString() ==
-                    arangodb::iresearch::StaticStrings::ViewType);
+                    arangodb::iresearch::StaticStrings::ViewArangoSearchType);
         EXPECT_TRUE(
             (slice.hasKey("deleted") && slice.get("deleted").isBoolean() &&
              false ==
@@ -7842,7 +7842,7 @@ TEST_F(IResearchViewTest, test_update_partial) {
            false == slice.get("globallyUniqueId").copyString().empty()));
       EXPECT_TRUE(slice.get("name").copyString() == "testView");
       EXPECT_TRUE(slice.get("type").copyString() ==
-                  arangodb::iresearch::StaticStrings::ViewType);
+                  arangodb::iresearch::StaticStrings::ViewArangoSearchType);
       EXPECT_TRUE(slice.get("deleted").isNone());  // no system properties
       EXPECT_TRUE((meta.init(slice, error) && expectedMeta == meta));
       auto tmpSlice = slice.get("links");
@@ -7867,7 +7867,7 @@ TEST_F(IResearchViewTest, test_update_partial) {
       EXPECT_EQ(19, slice.length());
       EXPECT_TRUE(slice.get("name").copyString() == "testView");
       EXPECT_TRUE(slice.get("type").copyString() ==
-                  arangodb::iresearch::StaticStrings::ViewType);
+                  arangodb::iresearch::StaticStrings::ViewArangoSearchType);
       EXPECT_TRUE(
           (slice.hasKey("deleted") && slice.get("deleted").isBoolean() &&
            false ==
@@ -7921,7 +7921,7 @@ TEST_F(IResearchViewTest, test_update_partial) {
            false == slice.get("globallyUniqueId").copyString().empty()));
       EXPECT_TRUE((slice.get("name").copyString() == "testView"));
       EXPECT_TRUE((slice.get("type").copyString() ==
-                   arangodb::iresearch::StaticStrings::ViewType));
+                   arangodb::iresearch::StaticStrings::ViewArangoSearchType));
       EXPECT_TRUE((slice.get("deleted").isNone()));  // no system properties
       EXPECT_TRUE((meta.init(slice, error) && expectedMeta == meta));
       auto tmpSlice = slice.get("links");
@@ -7946,7 +7946,7 @@ TEST_F(IResearchViewTest, test_update_partial) {
       EXPECT_EQ(19, slice.length());
       EXPECT_TRUE((slice.get("name").copyString() == "testView"));
       EXPECT_TRUE((slice.get("type").copyString() ==
-                   arangodb::iresearch::StaticStrings::ViewType));
+                   arangodb::iresearch::StaticStrings::ViewArangoSearchType));
       EXPECT_TRUE(
           (slice.hasKey("deleted") && slice.get("deleted").isBoolean() &&
            false ==
@@ -8004,7 +8004,7 @@ TEST_F(IResearchViewTest, test_update_partial) {
            false == slice.get("globallyUniqueId").copyString().empty()));
       EXPECT_TRUE((slice.get("name").copyString() == "testView"));
       EXPECT_TRUE((slice.get("type").copyString() ==
-                   arangodb::iresearch::StaticStrings::ViewType));
+                   arangodb::iresearch::StaticStrings::ViewArangoSearchType));
       EXPECT_TRUE((slice.get("deleted").isNone()));  // no system properties
       EXPECT_TRUE((meta.init(slice, error) && expectedMeta == meta));
       auto tmpSlice = slice.get("links");
@@ -8029,7 +8029,7 @@ TEST_F(IResearchViewTest, test_update_partial) {
       EXPECT_EQ(19, slice.length());
       EXPECT_TRUE((slice.get("name").copyString() == "testView"));
       EXPECT_TRUE((slice.get("type").copyString() ==
-                   arangodb::iresearch::StaticStrings::ViewType));
+                   arangodb::iresearch::StaticStrings::ViewArangoSearchType));
       EXPECT_TRUE(
           (slice.hasKey("deleted") && slice.get("deleted").isBoolean() &&
            false ==
@@ -8092,7 +8092,7 @@ TEST_F(IResearchViewTest, test_update_partial) {
            false == slice.get("globallyUniqueId").copyString().empty()));
       EXPECT_TRUE((slice.get("name").copyString() == "testView"));
       EXPECT_TRUE((slice.get("type").copyString() ==
-                   arangodb::iresearch::StaticStrings::ViewType));
+                   arangodb::iresearch::StaticStrings::ViewArangoSearchType));
       EXPECT_TRUE((slice.get("deleted").isNone()));  // no system properties
       EXPECT_TRUE((meta.init(slice, error) && expectedMeta == meta));
       auto tmpSlice = slice.get("links");
@@ -8117,7 +8117,7 @@ TEST_F(IResearchViewTest, test_update_partial) {
       EXPECT_EQ(19, slice.length());
       EXPECT_TRUE((slice.get("name").copyString() == "testView"));
       EXPECT_TRUE((slice.get("type").copyString() ==
-                   arangodb::iresearch::StaticStrings::ViewType));
+                   arangodb::iresearch::StaticStrings::ViewArangoSearchType));
       EXPECT_TRUE(
           (slice.hasKey("deleted") && slice.get("deleted").isBoolean() &&
            false ==
@@ -8180,7 +8180,7 @@ TEST_F(IResearchViewTest, test_update_partial) {
              false == slice.get("globallyUniqueId").copyString().empty()));
         EXPECT_TRUE((slice.get("name").copyString() == "testView"));
         EXPECT_TRUE((slice.get("type").copyString() ==
-                     arangodb::iresearch::StaticStrings::ViewType));
+                     arangodb::iresearch::StaticStrings::ViewArangoSearchType));
         EXPECT_TRUE((slice.get("deleted").isNone()));  // no system properties
         EXPECT_TRUE((meta.init(slice, error) && expectedMeta == meta));
 
@@ -8221,7 +8221,7 @@ TEST_F(IResearchViewTest, test_update_partial) {
         EXPECT_EQ(19, slice.length());
         EXPECT_TRUE((slice.get("name").copyString() == "testView"));
         EXPECT_TRUE((slice.get("type").copyString() ==
-                     arangodb::iresearch::StaticStrings::ViewType));
+                     arangodb::iresearch::StaticStrings::ViewArangoSearchType));
         EXPECT_TRUE(
             (slice.hasKey("deleted") && slice.get("deleted").isBoolean() &&
              false ==
@@ -8275,7 +8275,7 @@ TEST_F(IResearchViewTest, test_update_partial) {
              false == slice.get("globallyUniqueId").copyString().empty()));
         EXPECT_TRUE((slice.get("name").copyString() == "testView"));
         EXPECT_TRUE((slice.get("type").copyString() ==
-                     arangodb::iresearch::StaticStrings::ViewType));
+                     arangodb::iresearch::StaticStrings::ViewArangoSearchType));
         EXPECT_TRUE((slice.get("deleted").isNone()));  // no system properties
         EXPECT_TRUE((meta.init(slice, error) && expectedMeta == meta));
 
@@ -8316,7 +8316,7 @@ TEST_F(IResearchViewTest, test_update_partial) {
         EXPECT_EQ(19, slice.length());
         EXPECT_TRUE((slice.get("name").copyString() == "testView"));
         EXPECT_TRUE((slice.get("type").copyString() ==
-                     arangodb::iresearch::StaticStrings::ViewType));
+                     arangodb::iresearch::StaticStrings::ViewArangoSearchType));
         EXPECT_TRUE(
             (slice.hasKey("deleted") && slice.get("deleted").isBoolean() &&
              false ==
@@ -8376,7 +8376,7 @@ TEST_F(IResearchViewTest, test_update_partial) {
            false == slice.get("globallyUniqueId").copyString().empty()));
       EXPECT_TRUE(slice.get("name").copyString() == "testView");
       EXPECT_TRUE(slice.get("type").copyString() ==
-                  arangodb::iresearch::StaticStrings::ViewType);
+                  arangodb::iresearch::StaticStrings::ViewArangoSearchType);
       EXPECT_TRUE(slice.get("deleted").isNone());  // no system properties
       EXPECT_TRUE(slice.isObject());
       EXPECT_TRUE((true == slice.hasKey("links") &&
@@ -8398,7 +8398,7 @@ TEST_F(IResearchViewTest, test_update_partial) {
       EXPECT_EQ(19, slice.length());
       EXPECT_TRUE(slice.get("name").copyString() == "testView");
       EXPECT_TRUE(slice.get("type").copyString() ==
-                  arangodb::iresearch::StaticStrings::ViewType);
+                  arangodb::iresearch::StaticStrings::ViewArangoSearchType);
       EXPECT_TRUE(
           (slice.hasKey("deleted") && slice.get("deleted").isBoolean() &&
            false ==
@@ -8460,7 +8460,7 @@ TEST_F(IResearchViewTest, test_update_partial) {
            false == slice.get("globallyUniqueId").copyString().empty()));
       EXPECT_TRUE(slice.get("name").copyString() == "testView");
       EXPECT_TRUE(slice.get("type").copyString() ==
-                  arangodb::iresearch::StaticStrings::ViewType);
+                  arangodb::iresearch::StaticStrings::ViewArangoSearchType);
       EXPECT_TRUE(slice.get("deleted").isNone());  // no system properties
       EXPECT_TRUE((meta.init(slice, error) && expectedMeta == meta));
 
@@ -8500,7 +8500,7 @@ TEST_F(IResearchViewTest, test_update_partial) {
       EXPECT_EQ(19, slice.length());
       EXPECT_TRUE(slice.get("name").copyString() == "testView");
       EXPECT_TRUE(slice.get("type").copyString() ==
-                  arangodb::iresearch::StaticStrings::ViewType);
+                  arangodb::iresearch::StaticStrings::ViewArangoSearchType);
       EXPECT_TRUE(
           (slice.hasKey("deleted") && slice.get("deleted").isBoolean() &&
            false ==
@@ -8582,7 +8582,7 @@ TEST_F(IResearchViewTest, test_update_partial) {
            false == slice.get("globallyUniqueId").copyString().empty()));
       EXPECT_TRUE(slice.get("name").copyString() == "testView");
       EXPECT_TRUE(slice.get("type").copyString() ==
-                  arangodb::iresearch::StaticStrings::ViewType);
+                  arangodb::iresearch::StaticStrings::ViewArangoSearchType);
       EXPECT_TRUE(slice.get("deleted").isNone());  // no system properties
       EXPECT_TRUE((meta.init(slice, error) && expectedMeta == meta));
 
@@ -8622,7 +8622,7 @@ TEST_F(IResearchViewTest, test_update_partial) {
       EXPECT_EQ(19, slice.length());
       EXPECT_TRUE(slice.get("name").copyString() == "testView");
       EXPECT_TRUE(slice.get("type").copyString() ==
-                  arangodb::iresearch::StaticStrings::ViewType);
+                  arangodb::iresearch::StaticStrings::ViewArangoSearchType);
       EXPECT_TRUE(
           (slice.hasKey("deleted") && slice.get("deleted").isBoolean() &&
            false ==
@@ -8680,7 +8680,7 @@ TEST_F(IResearchViewTest, test_update_partial) {
            false == slice.get("globallyUniqueId").copyString().empty()));
       EXPECT_TRUE(slice.get("name").copyString() == "testView");
       EXPECT_TRUE(slice.get("type").copyString() ==
-                  arangodb::iresearch::StaticStrings::ViewType);
+                  arangodb::iresearch::StaticStrings::ViewArangoSearchType);
       EXPECT_TRUE(slice.get("deleted").isNone());  // no system properties
       EXPECT_TRUE((meta.init(slice, error) && expectedMeta == meta));
       auto tmpSlice = slice.get("links");
@@ -8705,7 +8705,7 @@ TEST_F(IResearchViewTest, test_update_partial) {
       EXPECT_EQ(19, slice.length());
       EXPECT_TRUE(slice.get("name").copyString() == "testView");
       EXPECT_TRUE(slice.get("type").copyString() ==
-                  arangodb::iresearch::StaticStrings::ViewType);
+                  arangodb::iresearch::StaticStrings::ViewArangoSearchType);
       EXPECT_TRUE(
           (slice.hasKey("deleted") && slice.get("deleted").isBoolean() &&
            false ==
@@ -8760,7 +8760,7 @@ TEST_F(IResearchViewTest, test_update_partial) {
            false == slice.get("globallyUniqueId").copyString().empty()));
       EXPECT_TRUE(slice.get("name").copyString() == "testView");
       EXPECT_TRUE(slice.get("type").copyString() ==
-                  arangodb::iresearch::StaticStrings::ViewType);
+                  arangodb::iresearch::StaticStrings::ViewArangoSearchType);
       EXPECT_TRUE(slice.get("deleted").isNone());  // no system properties
       EXPECT_TRUE((true == slice.hasKey("links") &&
                    slice.get("links").isObject() &&
@@ -8797,7 +8797,7 @@ TEST_F(IResearchViewTest, test_update_partial) {
            false == slice.get("globallyUniqueId").copyString().empty()));
       EXPECT_TRUE(slice.get("name").copyString() == "testView");
       EXPECT_TRUE(slice.get("type").copyString() ==
-                  arangodb::iresearch::StaticStrings::ViewType);
+                  arangodb::iresearch::StaticStrings::ViewArangoSearchType);
       EXPECT_TRUE(slice.get("deleted").isNone());  // no system properties
       EXPECT_TRUE((true == slice.hasKey("links") &&
                    slice.get("links").isObject() &&
@@ -8853,7 +8853,7 @@ TEST_F(IResearchViewTest, test_update_partial) {
              false == slice.get("globallyUniqueId").copyString().empty()));
         EXPECT_TRUE(slice.get("name").copyString() == "testView");
         EXPECT_TRUE(slice.get("type").copyString() ==
-                    arangodb::iresearch::StaticStrings::ViewType);
+                    arangodb::iresearch::StaticStrings::ViewArangoSearchType);
         EXPECT_TRUE(slice.get("deleted").isNone());  // no system properties
         EXPECT_TRUE((meta.init(slice, error) && expectedMeta == meta));
         auto tmpSlice = slice.get("links");
@@ -8878,7 +8878,7 @@ TEST_F(IResearchViewTest, test_update_partial) {
         EXPECT_EQ(19, slice.length());
         EXPECT_TRUE(slice.get("name").copyString() == "testView");
         EXPECT_TRUE(slice.get("type").copyString() ==
-                    arangodb::iresearch::StaticStrings::ViewType);
+                    arangodb::iresearch::StaticStrings::ViewArangoSearchType);
         EXPECT_TRUE(
             (slice.hasKey("deleted") && slice.get("deleted").isBoolean() &&
              false ==
@@ -8923,7 +8923,7 @@ TEST_F(IResearchViewTest, test_update_partial) {
              false == slice.get("globallyUniqueId").copyString().empty()));
         EXPECT_TRUE(slice.get("name").copyString() == "testView");
         EXPECT_TRUE(slice.get("type").copyString() ==
-                    arangodb::iresearch::StaticStrings::ViewType);
+                    arangodb::iresearch::StaticStrings::ViewArangoSearchType);
         EXPECT_TRUE(slice.get("deleted").isNone());  // no system properties
         EXPECT_TRUE((meta.init(slice, error) && expectedMeta == meta));
         auto tmpSlice = slice.get("links");
@@ -8948,7 +8948,7 @@ TEST_F(IResearchViewTest, test_update_partial) {
         EXPECT_EQ(19, slice.length());
         EXPECT_TRUE(slice.get("name").copyString() == "testView");
         EXPECT_TRUE(slice.get("type").copyString() ==
-                    arangodb::iresearch::StaticStrings::ViewType);
+                    arangodb::iresearch::StaticStrings::ViewArangoSearchType);
         EXPECT_TRUE(
             (slice.hasKey("deleted") && slice.get("deleted").isBoolean() &&
              false ==
@@ -9003,7 +9003,7 @@ TEST_F(IResearchViewTest, test_update_partial) {
            false == slice.get("globallyUniqueId").copyString().empty()));
       EXPECT_TRUE(slice.get("name").copyString() == "testView");
       EXPECT_TRUE(slice.get("type").copyString() ==
-                  arangodb::iresearch::StaticStrings::ViewType);
+                  arangodb::iresearch::StaticStrings::ViewArangoSearchType);
       EXPECT_TRUE(slice.get("deleted").isNone());  // no system properties
       EXPECT_TRUE((meta.init(slice, error) && expectedMeta == meta));
       auto tmpSlice = slice.get("links");
@@ -9028,7 +9028,7 @@ TEST_F(IResearchViewTest, test_update_partial) {
       EXPECT_EQ(19, slice.length());
       EXPECT_TRUE(slice.get("name").copyString() == "testView");
       EXPECT_TRUE(slice.get("type").copyString() ==
-                  arangodb::iresearch::StaticStrings::ViewType);
+                  arangodb::iresearch::StaticStrings::ViewArangoSearchType);
       EXPECT_TRUE(
           (slice.hasKey("deleted") && slice.get("deleted").isBoolean() &&
            false ==
@@ -9084,7 +9084,7 @@ TEST_F(IResearchViewTest, test_update_partial) {
            false == slice.get("globallyUniqueId").copyString().empty()));
       EXPECT_TRUE(slice.get("name").copyString() == "testView");
       EXPECT_TRUE(slice.get("type").copyString() ==
-                  arangodb::iresearch::StaticStrings::ViewType);
+                  arangodb::iresearch::StaticStrings::ViewArangoSearchType);
       EXPECT_TRUE(slice.get("deleted").isNone());  // no system properties
       EXPECT_TRUE((meta.init(slice, error) && expectedMeta == meta));
       auto tmpSlice = slice.get("links");
@@ -9109,7 +9109,7 @@ TEST_F(IResearchViewTest, test_update_partial) {
       EXPECT_EQ(19, slice.length());
       EXPECT_TRUE(slice.get("name").copyString() == "testView");
       EXPECT_TRUE(slice.get("type").copyString() ==
-                  arangodb::iresearch::StaticStrings::ViewType);
+                  arangodb::iresearch::StaticStrings::ViewArangoSearchType);
       EXPECT_TRUE(
           (slice.hasKey("deleted") && slice.get("deleted").isBoolean() &&
            false ==
@@ -9156,7 +9156,7 @@ TEST_F(IResearchViewTest, test_update_partial) {
              false == slice.get("globallyUniqueId").copyString().empty()));
         EXPECT_TRUE(slice.get("name").copyString() == "testView");
         EXPECT_TRUE(slice.get("type").copyString() ==
-                    arangodb::iresearch::StaticStrings::ViewType);
+                    arangodb::iresearch::StaticStrings::ViewArangoSearchType);
         EXPECT_TRUE(slice.get("deleted").isNone());  // no system properties
         auto tmpSlice = slice.get("links");
         EXPECT_TRUE((true == tmpSlice.isObject() && 1 == tmpSlice.length()));
@@ -9176,7 +9176,7 @@ TEST_F(IResearchViewTest, test_update_partial) {
         EXPECT_EQ(19, slice.length());
         EXPECT_TRUE(slice.get("name").copyString() == "testView");
         EXPECT_TRUE(slice.get("type").copyString() ==
-                    arangodb::iresearch::StaticStrings::ViewType);
+                    arangodb::iresearch::StaticStrings::ViewArangoSearchType);
         EXPECT_TRUE(
             (slice.hasKey("deleted") && slice.get("deleted").isBoolean() &&
              false ==
@@ -9219,7 +9219,7 @@ TEST_F(IResearchViewTest, test_update_partial) {
              false == slice.get("globallyUniqueId").copyString().empty()));
         EXPECT_TRUE(slice.get("name").copyString() == "testView");
         EXPECT_TRUE(slice.get("type").copyString() ==
-                    arangodb::iresearch::StaticStrings::ViewType);
+                    arangodb::iresearch::StaticStrings::ViewArangoSearchType);
         EXPECT_TRUE(slice.get("deleted").isNone());  // no system properties
         auto tmpSlice = slice.get("links");
         EXPECT_TRUE((true == tmpSlice.isObject() && 1 == tmpSlice.length()));
@@ -9239,7 +9239,7 @@ TEST_F(IResearchViewTest, test_update_partial) {
         EXPECT_EQ(19, slice.length());
         EXPECT_TRUE(slice.get("name").copyString() == "testView");
         EXPECT_TRUE(slice.get("type").copyString() ==
-                    arangodb::iresearch::StaticStrings::ViewType);
+                    arangodb::iresearch::StaticStrings::ViewArangoSearchType);
         EXPECT_TRUE(
             (slice.hasKey("deleted") && slice.get("deleted").isBoolean() &&
              false ==
@@ -9296,7 +9296,7 @@ TEST_F(IResearchViewTest, test_update_partial) {
              false == slice.get("globallyUniqueId").copyString().empty()));
         EXPECT_TRUE(slice.get("name").copyString() == "testView");
         EXPECT_TRUE(slice.get("type").copyString() ==
-                    arangodb::iresearch::StaticStrings::ViewType);
+                    arangodb::iresearch::StaticStrings::ViewArangoSearchType);
         EXPECT_TRUE(slice.get("deleted").isNone());  // no system properties
         auto tmpSlice = slice.get("links");
         EXPECT_TRUE((true == tmpSlice.isObject() && 1 == tmpSlice.length()));
@@ -9321,7 +9321,7 @@ TEST_F(IResearchViewTest, test_update_partial) {
         EXPECT_EQ(19, slice.length());
         EXPECT_TRUE(slice.get("name").copyString() == "testView");
         EXPECT_TRUE(slice.get("type").copyString() ==
-                    arangodb::iresearch::StaticStrings::ViewType);
+                    arangodb::iresearch::StaticStrings::ViewArangoSearchType);
         EXPECT_TRUE(
             (slice.hasKey("deleted") && slice.get("deleted").isBoolean() &&
              false ==
@@ -9345,7 +9345,7 @@ TEST_F(IResearchViewTest, test_update_partial) {
         EXPECT_EQ(15, slice.length());
         EXPECT_TRUE(slice.get("name").copyString() == "testView");
         EXPECT_TRUE(slice.get("type").copyString() ==
-                    arangodb::iresearch::StaticStrings::ViewType);
+                    arangodb::iresearch::StaticStrings::ViewArangoSearchType);
         EXPECT_TRUE(slice.hasKey("links"));
         auto linksSlice = slice.get("links");
         ASSERT_TRUE(linksSlice.isObject());
@@ -9381,7 +9381,7 @@ TEST_F(IResearchViewTest, test_update_partial) {
              false == slice.get("globallyUniqueId").copyString().empty()));
         EXPECT_TRUE(slice.get("name").copyString() == "testView");
         EXPECT_TRUE(slice.get("type").copyString() ==
-                    arangodb::iresearch::StaticStrings::ViewType);
+                    arangodb::iresearch::StaticStrings::ViewArangoSearchType);
         EXPECT_TRUE(slice.get("deleted").isNone());  // no system properties
         auto tmpSlice = slice.get("links");
         EXPECT_TRUE((true == tmpSlice.isObject() && 1 == tmpSlice.length()));
@@ -9406,7 +9406,7 @@ TEST_F(IResearchViewTest, test_update_partial) {
         EXPECT_EQ(19, slice.length());
         EXPECT_TRUE(slice.get("name").copyString() == "testView");
         EXPECT_TRUE(slice.get("type").copyString() ==
-                    arangodb::iresearch::StaticStrings::ViewType);
+                    arangodb::iresearch::StaticStrings::ViewArangoSearchType);
         EXPECT_TRUE(
             (slice.hasKey("deleted") && slice.get("deleted").isBoolean() &&
              false ==
@@ -9430,7 +9430,7 @@ TEST_F(IResearchViewTest, test_update_partial) {
         EXPECT_EQ(15, slice.length());
         EXPECT_TRUE(slice.get("name").copyString() == "testView");
         EXPECT_TRUE(slice.get("type").copyString() ==
-                    arangodb::iresearch::StaticStrings::ViewType);
+                    arangodb::iresearch::StaticStrings::ViewArangoSearchType);
         EXPECT_TRUE(slice.hasKey("links"));
         auto linksSlice = slice.get("links");
         ASSERT_TRUE(linksSlice.isObject());
@@ -9466,7 +9466,7 @@ TEST_F(IResearchViewTest, test_update_partial) {
              false == slice.get("globallyUniqueId").copyString().empty()));
         EXPECT_TRUE(slice.get("name").copyString() == "testView");
         EXPECT_TRUE(slice.get("type").copyString() ==
-                    arangodb::iresearch::StaticStrings::ViewType);
+                    arangodb::iresearch::StaticStrings::ViewArangoSearchType);
         EXPECT_TRUE(slice.get("deleted").isNone());  // no system properties
         auto tmpSlice = slice.get("links");
         EXPECT_TRUE((true == tmpSlice.isObject() && 1 == tmpSlice.length()));
@@ -9491,7 +9491,7 @@ TEST_F(IResearchViewTest, test_update_partial) {
         EXPECT_EQ(19, slice.length());
         EXPECT_TRUE(slice.get("name").copyString() == "testView");
         EXPECT_TRUE(slice.get("type").copyString() ==
-                    arangodb::iresearch::StaticStrings::ViewType);
+                    arangodb::iresearch::StaticStrings::ViewArangoSearchType);
         EXPECT_TRUE(
             (slice.hasKey("deleted") && slice.get("deleted").isBoolean() &&
              false ==
@@ -9515,7 +9515,7 @@ TEST_F(IResearchViewTest, test_update_partial) {
         EXPECT_EQ(15, slice.length());
         EXPECT_TRUE(slice.get("name").copyString() == "testView");
         EXPECT_TRUE(slice.get("type").copyString() ==
-                    arangodb::iresearch::StaticStrings::ViewType);
+                    arangodb::iresearch::StaticStrings::ViewArangoSearchType);
         EXPECT_TRUE(slice.hasKey("links"));
         auto linksSlice = slice.get("links");
         ASSERT_TRUE(linksSlice.isObject());
@@ -9551,7 +9551,7 @@ TEST_F(IResearchViewTest, test_update_partial) {
              false == slice.get("globallyUniqueId").copyString().empty()));
         EXPECT_TRUE(slice.get("name").copyString() == "testView");
         EXPECT_TRUE(slice.get("type").copyString() ==
-                    arangodb::iresearch::StaticStrings::ViewType);
+                    arangodb::iresearch::StaticStrings::ViewArangoSearchType);
         EXPECT_TRUE(slice.get("deleted").isNone());  // no system properties
         auto tmpSlice = slice.get("links");
         EXPECT_TRUE((true == tmpSlice.isObject() && 1 == tmpSlice.length()));
@@ -9576,7 +9576,7 @@ TEST_F(IResearchViewTest, test_update_partial) {
         EXPECT_EQ(19, slice.length());
         EXPECT_TRUE(slice.get("name").copyString() == "testView");
         EXPECT_TRUE(slice.get("type").copyString() ==
-                    arangodb::iresearch::StaticStrings::ViewType);
+                    arangodb::iresearch::StaticStrings::ViewArangoSearchType);
         EXPECT_TRUE(
             (slice.hasKey("deleted") && slice.get("deleted").isBoolean() &&
              false ==
@@ -9600,7 +9600,7 @@ TEST_F(IResearchViewTest, test_update_partial) {
         EXPECT_EQ(15, slice.length());
         EXPECT_TRUE(slice.get("name").copyString() == "testView");
         EXPECT_TRUE(slice.get("type").copyString() ==
-                    arangodb::iresearch::StaticStrings::ViewType);
+                    arangodb::iresearch::StaticStrings::ViewArangoSearchType);
         EXPECT_TRUE(slice.hasKey("links"));
         auto linksSlice = slice.get("links");
         ASSERT_TRUE(linksSlice.isObject());
@@ -9636,7 +9636,7 @@ TEST_F(IResearchViewTest, test_update_partial) {
              false == slice.get("globallyUniqueId").copyString().empty()));
         EXPECT_TRUE(slice.get("name").copyString() == "testView");
         EXPECT_TRUE(slice.get("type").copyString() ==
-                    arangodb::iresearch::StaticStrings::ViewType);
+                    arangodb::iresearch::StaticStrings::ViewArangoSearchType);
         EXPECT_TRUE(slice.get("deleted").isNone());  // no system properties
         auto tmpSlice = slice.get("links");
         EXPECT_TRUE((true == tmpSlice.isObject() && 1 == tmpSlice.length()));
@@ -9661,7 +9661,7 @@ TEST_F(IResearchViewTest, test_update_partial) {
         EXPECT_EQ(19, slice.length());
         EXPECT_TRUE(slice.get("name").copyString() == "testView");
         EXPECT_TRUE(slice.get("type").copyString() ==
-                    arangodb::iresearch::StaticStrings::ViewType);
+                    arangodb::iresearch::StaticStrings::ViewArangoSearchType);
         EXPECT_TRUE(
             (slice.hasKey("deleted") && slice.get("deleted").isBoolean() &&
              false ==
@@ -9685,7 +9685,7 @@ TEST_F(IResearchViewTest, test_update_partial) {
         EXPECT_EQ(15, slice.length());
         EXPECT_TRUE(slice.get("name").copyString() == "testView");
         EXPECT_TRUE(slice.get("type").copyString() ==
-                    arangodb::iresearch::StaticStrings::ViewType);
+                    arangodb::iresearch::StaticStrings::ViewArangoSearchType);
         EXPECT_TRUE(slice.hasKey("links"));
         auto linksSlice = slice.get("links");
         ASSERT_TRUE(linksSlice.isObject());

--- a/tests/Mocks/Servers.cpp
+++ b/tests/Mocks/Servers.cpp
@@ -551,8 +551,8 @@ void MockClusterServer::startFeatures() {
   auto& indexFactory = const_cast<IndexFactory&>(_engine.indexFactory());
   auto& factory =
       getFeature<iresearch::IResearchFeature>().factory<ClusterEngine>();
-  indexFactory.emplace(std::string{iresearch::StaticStrings::ViewType},
-                       factory);
+  indexFactory.emplace(
+      std::string{iresearch::StaticStrings::ViewArangoSearchType}, factory);
   _server.getFeature<ClusterFeature>().clusterInfo().startSyncers();
 }
 

--- a/tests/Mocks/StorageEngineMock.cpp
+++ b/tests/Mocks/StorageEngineMock.cpp
@@ -1051,7 +1051,7 @@ std::shared_ptr<arangodb::Index> PhysicalCollectionMock::createIndex(
   } else if (type == "inverted") {
     index =
         StorageEngineMock::buildInvertedIndexMock(id, _logicalCollection, info);
-  } else if (type == arangodb::iresearch::StaticStrings::ViewType) {
+  } else if (type == arangodb::iresearch::StaticStrings::ViewArangoSearchType) {
     try {
       auto& server = _logicalCollection.vocbase().server();
       if (arangodb::ServerState::instance()->isCoordinator()) {


### PR DESCRIPTION
### Scope & Purpose

Details:

* "search" -> "search-alias"
* ViewType::kView -> ViewType::kArangoSearch
* ViewType::kSearch -> ViewType::kSearchAlias
* ViewType -> ViewArangoSearchType
* SearchType -> ViewSearchAliasType

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: *(Please link PR)*
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

