### PR TITLE
[PREGEL] implement load graph with future

### DIFF
--- a/arangod/Pregel/Conductor/States/LoadingState.h
+++ b/arangod/Pregel/Conductor/States/LoadingState.h
@@ -36,7 +36,7 @@ struct Loading : State {
   Loading(Conductor& conductor);
   ~Loading();
   auto run() -> void override;
-  auto receive(Message const& message) -> void override;
+  auto receive(Message const& message) -> void override{};
   auto name() const -> std::string override { return "loading"; };
   auto isRunning() const -> bool override { return true; }
   auto getExpiration() const

--- a/arangod/Pregel/GraphStore.h
+++ b/arangod/Pregel/GraphStore.h
@@ -33,6 +33,7 @@
 #include "Pregel/Status/Status.h"
 #include "Pregel/TypedBuffer.h"
 #include "Pregel/Worker/WorkerConfig.h"
+#include "Pregel/WorkerConductorMessages.h"
 #include "Utils/DatabaseGuard.h"
 
 #include <atomic>
@@ -130,9 +131,9 @@ class GraphStore final {
   GraphFormat<V, E> const* graphFormat() { return _graphFormat.get(); }
 
   // ====================== NOT THREAD SAFE ===========================
-  void loadShards(WorkerConfig* config,
-                  std::function<void()> const& statusUpdateCallback,
-                  std::function<void()> const& finishedLoadingCallback);
+  auto loadShards(WorkerConfig* config,
+                  std::function<void()> const& statusUpdateCallback)
+      -> futures::Future<ResultT<GraphLoaded>>;
   void loadDocument(WorkerConfig* config, std::string const& documentID);
   void loadDocument(WorkerConfig* config, PregelShard sourceShard,
                     std::string_view key);

--- a/arangod/Pregel/Worker/Worker.h
+++ b/arangod/Pregel/Worker/Worker.h
@@ -33,8 +33,9 @@
 #include "Pregel/Statistics.h"
 #include "Pregel/Status/Status.h"
 #include "Pregel/WorkerConductorMessages.h"
-#include "WorkerConfig.h"
-#include "WorkerContext.h"
+#include "Pregel/Worker/WorkerConfig.h"
+#include "Pregel/Worker/WorkerContext.h"
+#include "Pregel/WorkerInterface.h"
 #include "Pregel/Reports.h"
 #include "Scheduler/Scheduler.h"
 
@@ -51,7 +52,8 @@ class PregelFeature;
 class IWorker : public std::enable_shared_from_this<IWorker> {
  public:
   virtual ~IWorker() = default;
-  virtual void setupWorker() = 0;
+  [[nodiscard]] virtual auto loadGraph(LoadGraph const& graph)
+      -> futures::Future<ResultT<GraphLoaded>> = 0;
   virtual void prepareGlobalStep(VPackSlice const& data,
                                  VPackBuilder& result) = 0;
   virtual void startGlobalStep(
@@ -161,7 +163,8 @@ class Worker : public IWorker {
   ~Worker();
 
   // ====== called by rest handler =====
-  void setupWorker() override;
+  auto loadGraph(LoadGraph const& graph)
+      -> futures::Future<ResultT<GraphLoaded>> override;
   void prepareGlobalStep(VPackSlice const& data, VPackBuilder& result) override;
   void startGlobalStep(VPackSlice const& data) override;
   void cancelGlobalStep(VPackSlice const& data) override;

--- a/arangod/Pregel/WorkerConductorMessages.h
+++ b/arangod/Pregel/WorkerConductorMessages.h
@@ -50,7 +50,7 @@ struct GraphLoaded : Message {
   ExecutionNumber executionNumber;
   uint64_t vertexCount;
   uint64_t edgeCount;
-  GraphLoaded(){};
+  GraphLoaded() noexcept {};
   GraphLoaded(std::string const& senderId, ExecutionNumber executionNumber,
               uint64_t vertexCount, uint64_t edgeCount)
       : senderId{senderId},
@@ -180,6 +180,17 @@ auto inspect(Inspector& f, GssCanceled& x) {
 }
 
 // ------ commands sent from conductor to worker -------
+
+struct LoadGraph {
+  ExecutionNumber executionNumber;
+  VPackBuilder details;
+};
+template<typename Inspector>
+auto inspect(Inspector& f, LoadGraph& x) {
+  return f.object(x).fields(
+      f.field(Utils::executionNumberKey, x.executionNumber),
+      f.field("details", x.details));
+}
 
 struct PrepareGss {
   ExecutionNumber executionNumber;

--- a/arangod/Pregel/WorkerInterface.h
+++ b/arangod/Pregel/WorkerInterface.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "Pregel/WorkerConductorMessages.h"
+
+#include <Futures/Future.h>
+
+namespace arangodb::pregel {
+
+class NewIWorker {
+ public:
+  virtual ~NewIWorker() = default;
+  [[nodiscard]] virtual auto loadGraph(LoadGraph const& graph)
+      -> futures::Future<ResultT<GraphLoaded>> = 0;
+};
+
+}  // namespace arangodb::pregel


### PR DESCRIPTION
This PR introduces futures to load the graph. This is used initialize the loading at the conductor, request loading the graph for all workers and continue the work on the conductor as soon as all workers have finished loading.

This PR includes the inspector for ResultT because I need it here already. I already created a PR for devel on that (https://github.com/arangodb/arangodb/pull/16891), so you don't have to look at the code changes in lib in this PR.