### PR TITLE
Bug fix/handle not in nested search and SEARCH-346

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -596,7 +596,7 @@ include(CheckCompilerVersion)
 CheckCompilerVersion(
   11.2 # GCC
   14.0 # Clang
-  1932 # MSVC
+  19.32 # MSVC
 )
 
 if (MSVC)

--- a/arangod/Aql/OptimizerUtils.cpp
+++ b/arangod/Aql/OptimizerUtils.cpp
@@ -817,6 +817,10 @@ void extractNonConstPartsOfJunctionCondition(
   if (condition->type == NODE_TYPE_OPERATOR_NARY_OR) {
     for (size_t i = 0; i < condition->numMembers(); ++i) {
       auto andNode = condition->getMemberUnchecked(i);
+      TRI_ASSERT(andNode);
+      if (andNode->isConstant()) {
+        continue;
+      }
       auto path = selectedMembersFromRoot;
       path.emplace_back(i);
       extractNonConstPartsOfAndPart(ast, varInfo, evaluateFCalls, sorted,

--- a/arangod/RocksDBEngine/RocksDBCollection.cpp
+++ b/arangod/RocksDBEngine/RocksDBCollection.cpp
@@ -512,6 +512,15 @@ std::shared_ptr<Index> RocksDBCollection::createIndex(VPackSlice info,
   TRI_ASSERT(newIdx->type() != Index::IndexType::TRI_IDX_TYPE_PRIMARY_INDEX);
   TRI_ASSERT(newIdx->type() != Index::IndexType::TRI_IDX_TYPE_EDGE_INDEX);
 
+  // cleanup newly instanciated object
+  auto indexCleanup = ScopeGuard([&newIdx]() noexcept {
+    try {
+      newIdx->drop();
+    } catch (...) {
+      TRI_ASSERT(false);
+    }
+  });
+
   {
     // Step 2. Check for existing matching index
     RECURSIVE_READ_LOCKER(_indexesLock, _indexesLockWriteOwner);
@@ -558,7 +567,6 @@ std::shared_ptr<Index> RocksDBCollection::createIndex(VPackSlice info,
 
   // until here we have been completely read only.
   // modifications start now...
-
   Result res = arangodb::basics::catchToResult([&]() -> Result {
     Result res;
 
@@ -670,6 +678,7 @@ std::shared_ptr<Index> RocksDBCollection::createIndex(VPackSlice info,
 
   if (res.ok()) {
     created = true;
+    indexCleanup.cancel();
     return newIdx;
   }
 
@@ -679,7 +688,6 @@ std::shared_ptr<Index> RocksDBCollection::createIndex(VPackSlice info,
     RECURSIVE_WRITE_LOCKER(_indexesLock, _indexesLockWriteOwner);
     removeIndex(_indexes, newIdx->id());
   }
-  newIdx->drop();
   THROW_ARANGO_EXCEPTION(res);
 }
 

--- a/arangod/RocksDBEngine/RocksDBCollection.cpp
+++ b/arangod/RocksDBEngine/RocksDBCollection.cpp
@@ -512,7 +512,7 @@ std::shared_ptr<Index> RocksDBCollection::createIndex(VPackSlice info,
   TRI_ASSERT(newIdx->type() != Index::IndexType::TRI_IDX_TYPE_PRIMARY_INDEX);
   TRI_ASSERT(newIdx->type() != Index::IndexType::TRI_IDX_TYPE_EDGE_INDEX);
 
-  // cleanup newly instanciated object
+  // cleanup newly instantiated object
   auto indexCleanup = ScopeGuard([&newIdx]() noexcept {
     try {
       newIdx->drop();

--- a/tests/js/server/aql/aql-inverted-index.js
+++ b/tests/js/server/aql/aql-inverted-index.js
@@ -96,11 +96,12 @@ function optimizerRuleInvertedIndexTestSuite() {
       try { analyzers.remove("my_geo", true); } catch (e) {}
     },
     testCreateDuplicate: function () {
-       col.ensureIndex({type: 'inverted',
+       let idx = col.ensureIndex({type: 'inverted',
                         name: 'InvertedIndexUnsorted_duplicate',
                         fields: ['data_field',
                                 {name:'geo_field', analyzer:'my_geo'},
                                 {name:'custom_field', analyzer:'text_en'}]});
+       assertEqual("InvertedIndexUnsorted", idx.name);       
     },
     testIndexNotHinted: function () {
       const query = aql`

--- a/tests/js/server/aql/aql-inverted-index.js
+++ b/tests/js/server/aql/aql-inverted-index.js
@@ -95,6 +95,13 @@ function optimizerRuleInvertedIndexTestSuite() {
       col.drop();
       try { analyzers.remove("my_geo", true); } catch (e) {}
     },
+    testCreateDuplicate: function () {
+       col.ensureIndex({type: 'inverted',
+                        name: 'InvertedIndexUnsorted_duplicate',
+                        fields: ['data_field',
+                                {name:'geo_field', analyzer:'my_geo'},
+                                {name:'custom_field', analyzer:'text_en'}]});
+    },
     testIndexNotHinted: function () {
       const query = aql`
         FOR d IN ${col}


### PR DESCRIPTION
### Scope & Purpose

Adds handling of NOT operator for  nested search 
fixes SEARCH-346
fixes MSVC version check

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [x] Tests
  - [ ] **Regression tests**
  - [x] C++ **Unit tests**
  - [x] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: *(Please link PR)*
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*

#### Related Information

- [ ] Enterprise PR: https://github.com/arangodb/enterprise/pull/1013


