### PR TITLE
[CMAKE] Compiler Checks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -611,49 +611,6 @@ if (MSVC)
   endif()
 endif ()
 
-# FIXME: refactor/cleanup check below
-if (CMAKE_COMPILER_IS_GNUCC)
-  if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "11.0")
-    message(WARNING "ArangoDB requires g++ 11.0 or newer, building with older compiler versions is unsupported")
-  elseif(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER "11.9.9")
-    message(WARNING "ArangoDB doesn't support g++ 12.0 yet, building with newer compiler versions is unsupported")
-  endif()
-  set(BASE_C_FLAGS "${BASE_C_FLAGS}")
-endif ()
-
-if(MSVC)
-  # MSVC2018.1 - MSVC2018.7 does not correctly support alignas()
-  if (MSVC_VERSION VERSION_LESS 1915)
-    message(FATAL_ERROR "ArangoDB doesn't support MSVC less than 2017 update 15.8!")
-  elseif (MSVC_VERSION VERSION_GREATER_EQUAL 1915 AND MSVC_VERSION VERSION_LESS 1920)
-    message(WARNING "ArangoDB requires MSVC 2019 update 16.4 or newer, building with older compiler versions is unsupported")
-    # according to https://developercommunity.visualstudio.com/solutions/616098/view.html,
-    # the following define is not necessary anymore, as it should be fixed in MSVC 16.0:
-    # MSVC2018.8 requires the following define
-    add_definitions(-D_ENABLE_EXTENDED_ALIGNED_STORAGE)
-  elseif (MSVC_VERSION VERSION_GREATER_EQUAL 1920 AND MSVC_VERSION VERSION_LESS 1924)
-    message(FATAL_ERROR "ArangoDB requires at least MSVC 2019 update 16.4!")
-  endif()
-endif()
-
-if (CMAKE_COMPILER_IS_CLANG AND NOT MSVC) # exclude clang-cl
-  if (APPLE)
-    if (NOT DEFINED ENV{MACOSX_DEPLOYMENT_TARGET} OR ENV{MACOSX_DEPLOYMENT_TARGET} STREQUAL "")
-      set(BASE_CXX_FLAGS "${BASE_CXX_FLAGS} -stdlib=libc++")
-    else ()
-      set(BASE_C_FLAGS "${BASE_C_FLAGS} -mmacosx-version-min=$ENV{MACOSX_DEPLOYMENT_TARGET}")
-      set(BASE_CXX_FLAGS "${BASE_CXX_FLAGS} -stdlib=libc++ -mmacosx-version-min=$ENV{MACOSX_DEPLOYMENT_TARGET}")
-      set(BASE_LD_FLAGS "${BASE_LD_FLAGS} -mmacosx-version-min=$ENV{MACOSX_DEPLOYMENT_TARGET}")
-    endif ()
-    add_definitions("-Wno-deprecated-declarations")
-  else ()
-    if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "10.0")
-      message(WARNING "ArangoDB requires clang 10.0 or newer, building with older compiler versions is unsupported")
-    endif()
-    list(APPEND BASE_LIBS atomic)
-  endif ()
-endif ()
-
 # need c++20
 # XXX this should really be set on a per target level using cmake compile_features capabilties
 set(CMAKE_CXX_STANDARD 20)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -591,13 +591,12 @@ set(BASE_CXX_FLAGS "${CMAKE_CXX_FLAGS} $ENV{CXXFLAGS}" CACHE STRING "base C++ fl
 set(BASE_LD_FLAGS                     "$ENV{LDFLAGS}"  CACHE STRING "base linker flags")
 set(BASE_LIBS                         "$ENV{LIBS}"     CACHE STRING "base libraries")
 
-include(CheckCompilerVersion)
 
-CheckCompilerVersion(
-  11.2 # GCC
-  14.0 # Clang
-  19.32 # MSVC
-)
+set(ARANGODB_MIN_GCC_VERSION 11.2)
+set(ARANGODB_MIN_CLANG_VERSION 14.0)
+set(ARANGODB_MIN_MSVC_VERSION 19.32)
+
+include(CheckCompilerVersion)
 
 if (MSVC)
   set(BASE_FLAGS     "${BASE_FLAGS} /D WIN32 /D _WINDOWS /W3 /MP")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -592,11 +592,29 @@ set(BASE_LD_FLAGS                     "$ENV{LDFLAGS}"  CACHE STRING "base linker
 set(BASE_LIBS                         "$ENV{LIBS}"     CACHE STRING "base libraries")
 
 
+#
+# Check for the compiler versions required to build ArangoDB
+#
+# The compiler versions checked here are the ones used in the Jenkins CI and as
+# such the "source of truth" as to which compilers must work; this does not mean
+# that other compilers will not.
+#
+# This check is designed to error out early if someone tries to compile with an
+# untested version to make sure they do not waste their time waiting for half
+# an hour for an obscure compiler error.
+#
+# This check can be disabled by using -DARANGODB_JUST_WARN_COMPILER_CHECK=ON to
+# turn this error into a warning.
+#
+include(CheckCompilerVersion)
+
 set(ARANGODB_MIN_GCC_VERSION 11.2)
 set(ARANGODB_MIN_CLANG_VERSION 14.0)
 set(ARANGODB_MIN_MSVC_VERSION 19.32)
 
-include(CheckCompilerVersion)
+CheckCompilerVersion(ARANGODB_MIN_GCC_VERSION,
+                     ARANGODB_MIN_CLANG_VERSION
+                     ARANGODB_MIN_MSVC_VERSION)
 
 if (MSVC)
   set(BASE_FLAGS     "${BASE_FLAGS} /D WIN32 /D _WINDOWS /W3 /MP")

--- a/cmake/CheckCompilerVersion.cmake
+++ b/cmake/CheckCompilerVersion.cmake
@@ -1,25 +1,47 @@
-macro(CheckCompilerVersion MIN_GCC_VERSION MIN_CLANG_VERSION MIN_MSVC_VERSION)
 
-if (CMAKE_C_COMPILER_ID STREQUAL "GNU")
-  set(MIN_VERSION ${MIN_GCC_VERSION})
-elseif (CMAKE_C_COMPILER_ID STREQUAL "Clang")
-  set(MIN_VERSION ${MIN_CLANG_VERSION})
-elseif (CMAKE_C_COMPILER_ID STREQUAL "MSVC")
-  set(MIN_VERSION ${MIN_MSVC_VERSION})
-endif()
+option(ARANGODB_SKIP_COMPILER_CHECK "Skip compiler support check.")
 
-if(NOT WIN32)
-  string(ASCII 27 ESC)
-  set(COLOR_RESET "${ESC}[m")
-  set(RED        "${ESC}[31m")
-endif()
+macro(CheckMinVersionsSet)
+  if(NOT DEFINED ARANGODB_MIN_GCC_VERSION)
+    message(FATAL_ERROR "Please define ARANGODB_MIN_GCC_VERSION in CMakeLists.txt.")
+  endif()
+  if(NOT DEFINED ARANGODB_MIN_CLANG_VERSION)
+    message(FATAL_ERROR "Please define ARANGODB_MIN_CLANG_VERSION in CMakeLists.txt.")
+  endif()
+  if(NOT DEFINED ARANGODB_MIN_MSVC_VERSION)
+    message(FATAL_ERROR "Please define ARANGODB_MIN_MSVC_VERSION in CMakeLists.txt.")
+  endif()
+endmacro()
 
-if (NOT DEFINED MIN_VERSION)
-  message(WARNING "${RED}${CMAKE_C_COMPILER_ID}/${CMAKE_CXX_COMPILER_ID} compiler is not supported.${COLOR_RESET}")
-endif()
+macro(CheckMinCompilerVersionInner MIN_VERSION)
+  if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS ${MIN_VERSION})
+    message(
+      FATAL_ERROR
+        "ArangoDB requires at least ${CMAKE_CXX_COMPILER_ID} version ${MIN_VERSION},"
+        " detected ${CMAKE_CXX_COMPILER_VERSION}."
+        "\nYou can use ARANGODB_SKIP_COMPILER_CHECK to skip this check.")
+  endif()
+endmacro()
 
-if ((CMAKE_C_COMPILER_VERSION VERSION_LESS ${MIN_VERSION}) OR (CMAKE_CXX_COMPILER_VERSION VERSION_LESS ${MIN_VERSION}))
-  message(WARNING "${RED}${CMAKE_C_COMPILER_ID} compiler version C(${CMAKE_C_COMPILER_VERSION})/C++(${CMAKE_C_COMPILER_VERSION}) is too old. Need at least ${MIN_VERSION}.${COLOR_RESET}")
-endif()
+macro(CheckCompilerVersion)
+
+  if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    CheckMinCompilerVersionInner(${ARANGODB_MIN_GCC_VERSION})
+  elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    CheckMinCompilerVersionInner(${ARANGODB_MIN_CLANG_VERSION})
+  elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+    CheckMinCompilerVersionInner(${ARANGODB_MIN_MSVC_VERSION})
+  else()
+    message(
+      FATAL_ERROR
+        "ArangoDB does not support CMAKE_CXX_COMPILER_ID ${CMAKE_CXX_COMPILER_ID}"
+    )
+  endif()
 
 endmacro()
+
+CheckMinVersionsSet()
+
+if (NOT ${ARANGODB_SKIP_COMPILER_CHECK})
+  CheckCompilerVersion()
+endif()

--- a/cmake/CheckCompilerVersion.cmake
+++ b/cmake/CheckCompilerVersion.cmake
@@ -1,5 +1,6 @@
 
-option(ARANGODB_SKIP_COMPILER_CHECK "Skip compiler support check.")
+option(ARANGODB_JUST_WARN_COMPILER_CHECK "Do not exit with FATAL_ERROR and just WARN "
+	                                 "if the compiler is not recent enough.")
 
 macro(CheckMinVersionsSet)
   if(NOT DEFINED ARANGODB_MIN_GCC_VERSION)
@@ -15,11 +16,16 @@ endmacro()
 
 macro(CheckMinCompilerVersionInner MIN_VERSION)
   if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS ${MIN_VERSION})
-    message(
-      FATAL_ERROR
-        "ArangoDB requires at least ${CMAKE_CXX_COMPILER_ID} version ${MIN_VERSION},"
-        " detected ${CMAKE_CXX_COMPILER_VERSION}."
-        "\nYou can use ARANGODB_SKIP_COMPILER_CHECK to skip this check.")
+    set(MESSAGE "ArangoDB requires at least ${CMAKE_CXX_COMPILER_ID} version ${MIN_VERSION},"
+                " detected ${CMAKE_CXX_COMPILER_VERSION}.")
+
+    if(${ARANGODB_WARN_COMPILER_CHECK})
+      message(WARN ${MESSAGE})
+    else()
+      message(FATAL_ERROR
+        ${MESSAGE}
+	"\nYou can use -DARANGODB_JUST_WARN_COMPILER_CHECK to turn this error into a warning.")
+    endif()
   endif()
 endmacro()
 
@@ -34,14 +40,11 @@ macro(CheckCompilerVersion)
   else()
     message(
       FATAL_ERROR
-        "ArangoDB does not support CMAKE_CXX_COMPILER_ID ${CMAKE_CXX_COMPILER_ID}"
-    )
+        "ArangoDB does not support CMAKE_CXX_COMPILER_ID ${CMAKE_CXX_COMPILER_ID}")
   endif()
 
 endmacro()
 
 CheckMinVersionsSet()
 
-if (NOT ${ARANGODB_SKIP_COMPILER_CHECK})
-  CheckCompilerVersion()
-endif()
+CheckCompilerVersion()

--- a/cmake/CheckCompilerVersion.cmake
+++ b/cmake/CheckCompilerVersion.cmake
@@ -2,18 +2,6 @@
 option(ARANGODB_JUST_WARN_COMPILER_CHECK "Do not exit with FATAL_ERROR and just WARN "
 	                                 "if the compiler is not recent enough.")
 
-macro(CheckMinVersionsSet)
-  if(NOT DEFINED ARANGODB_MIN_GCC_VERSION)
-    message(FATAL_ERROR "Please define ARANGODB_MIN_GCC_VERSION in CMakeLists.txt.")
-  endif()
-  if(NOT DEFINED ARANGODB_MIN_CLANG_VERSION)
-    message(FATAL_ERROR "Please define ARANGODB_MIN_CLANG_VERSION in CMakeLists.txt.")
-  endif()
-  if(NOT DEFINED ARANGODB_MIN_MSVC_VERSION)
-    message(FATAL_ERROR "Please define ARANGODB_MIN_MSVC_VERSION in CMakeLists.txt.")
-  endif()
-endmacro()
-
 macro(CheckMinCompilerVersionInner MIN_VERSION)
   if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS ${MIN_VERSION})
     set(MESSAGE "ArangoDB requires at least ${CMAKE_CXX_COMPILER_ID} version ${MIN_VERSION},"
@@ -29,22 +17,26 @@ macro(CheckMinCompilerVersionInner MIN_VERSION)
   endif()
 endmacro()
 
-macro(CheckCompilerVersion)
+function(CheckCompilerVersion ...)
+  if(ARGC LESS 3)
+	  message(FATAL_ERROR "CheckCompilerVersion: Not enough arguments\n"
+	                      "usage:\n"
+			      "  CheckCompilerVersion(MIN_GCC_VERSION MIN_CLANG_VERSION MIN_MSVC_VERSION)")
+  endif()
+  set(MIN_GCC_VERSION ARG0)
+  set(MIN_CLANG_VERSION ARG1)
+  set(MIN_MSVC_VERSION ARG2)
 
   if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-    CheckMinCompilerVersionInner(${ARANGODB_MIN_GCC_VERSION})
+    CheckMinCompilerVersionInner(MIN_GCC_VERSION)
   elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-    CheckMinCompilerVersionInner(${ARANGODB_MIN_CLANG_VERSION})
+    CheckMinCompilerVersionInner(MIN_CLANG_VERSION)
   elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-    CheckMinCompilerVersionInner(${ARANGODB_MIN_MSVC_VERSION})
+    CheckMinCompilerVersionInner(MIN_MSVC_VERSION)
   else()
     message(
       FATAL_ERROR
         "ArangoDB does not support CMAKE_CXX_COMPILER_ID ${CMAKE_CXX_COMPILER_ID}")
   endif()
+endfunction()
 
-endmacro()
-
-CheckMinVersionsSet()
-
-CheckCompilerVersion()


### PR DESCRIPTION
### Scope & Purpose

Improves and cleans up compiler version checks.

We define the minimum required version of each supported compiler (currently Clang, GCC, MSVC), and a CMake macro checks whether the compiler is supported and recent enough. 

When it is not, CMake terminates with an error message.

For the adventurous user there is he option `ARANGODB_SKIP_COMPILER_CHECK` which allows users to disable the check and run CMake anyway. 

Also remove all the compiler checks that have accumulated over time and are not used anymore.