### PR TITLE
fix use-after-scope in test

### DIFF
--- a/tests/Aql/AqlSharedExecutionBlockImplTest.cpp
+++ b/tests/Aql/AqlSharedExecutionBlockImplTest.cpp
@@ -103,6 +103,7 @@ class AqlSharedExecutionBlockImplTest : public ::testing::Test {
           TRI_ASSERT(col != nullptr);  // failed to add collection
         }
       })};
+  arangodb::TemporaryStorageFeature tempStorage{fakedQuery->vocbase().server()};
   std::vector<std::unique_ptr<ExecutionNode>> _execNodes;
 
   // Used for AllRowsFetcherCases
@@ -253,7 +254,6 @@ class AqlSharedExecutionBlockImplTest : public ::testing::Test {
           std::move(buildRegisterInfos(nestingLevel)), std::move(execInfos)};
     }
     if constexpr (std::is_same_v<ExecutorType, SortExecutor>) {
-      TemporaryStorageFeature tempStorage(fakedQuery->vocbase().server());
       std::vector<SortRegister> sortRegisters{};
       // We do not care for sorting, we skip anyways.
       sortRegisters.emplace_back(SortRegister{0, SortElement{nullptr, true}});


### PR DESCRIPTION
### Scope & Purpose

Fix use-after-scope in test
```
=================================================================
==arangodbtests==79553==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x7fff5e966ff8 at pc 0x5597cca6ba32 bp 0x7fff5e963160 sp 0x7fff5e963150
READ of size 8 at 0x7fff5e966ff8 thread T0
    #0 0x5597cca6ba31 in std::__uniq_ptr_impl<arangodb::RocksDBTempStorage, std::default_delete<arangodb::RocksDBTempStorage> >::_M_ptr() const /usr/include/c++/11/bits/unique_ptr.h:173
    #1 0x5597cca6ba31 in std::unique_ptr<arangodb::RocksDBTempStorage, std::default_delete<arangodb::RocksDBTempStorage> >::get() const /usr/include/c++/11/bits/unique_ptr.h:422
    #2 0x5597cca6ba31 in std::unique_ptr<arangodb::RocksDBTempStorage, std::default_delete<arangodb::RocksDBTempStorage> >::operator*() const /usr/include/c++/11/bits/unique_ptr.h:408
    #3 0x5597cca6ba31 in std::unique_ptr<arangodb::aql::SortedRowsStorageBackend, std::default_delete<arangodb::aql::SortedRowsStorageBackend> > arangodb::TemporaryStorageFeature::getSortedRowsStorage<arangodb::aql::SortExecutorInfos&>(arangodb::aql::SortExecutorInfos&) /work/ArangoDB/arangod/RestServer/TemporaryStorageFeature.h:94
    #4 0x5597cca6ba31 in arangodb::aql::SortExecutor::SortExecutor(arangodb::aql::SingleRowFetcher<(arangodb::aql::BlockPassthrough)0>&, arangodb::aql::SortExecutorInfos&) /work/ArangoDB/arangod/Aql/SortExecutor.cpp:116
    #5 0x5597c97fd39f in void arangodb::aql::InitializeCursor<false>::init<arangodb::aql::SortExecutor>(arangodb::aql::SortExecutor&, arangodb::aql::SortExecutor::Fetcher&, arangodb::aql::SortExecutor::Infos&) /work/ArangoDB/arangod/Aql/ExecutionBlockImpl.cpp:310
    #6 0x5597c97fd39f in arangodb::aql::ExecutionBlockImpl<arangodb::aql::SortExecutor>::resetExecutor() /work/ArangoDB/arangod/Aql/ExecutionBlockImpl.cpp:2103
    #7 0x5597c9fef9b8 in arangodb::aql::ExecutionBlockImpl<arangodb::aql::SortExecutor>::executeWithoutTrace(arangodb::aql::AqlCallStack const&) /work/ArangoDB/arangod/Aql/ExecutionBlockImpl.cpp:1469
    #8 0x5597c9ff6c81 in arangodb::aql::ExecutionBlockImpl<arangodb::aql::SortExecutor>::execute(arangodb::aql::AqlCallStack const&) /work/ArangoDB/arangod/Aql/ExecutionBlockImpl.cpp:418
    #9 0x5597b6da47dc in arangodb::tests::aql::AqlSharedExecutionBlockImplTest<arangodb::aql::SortExecutor>::runLeftoverTest(arangodb::aql::ExecutionBlockImpl<arangodb::aql::SortExecutor>&, arangodb::aql::SharedAqlItemBlockPtr, arangodb::aql::AqlCallStack, arangodb::aql::SkipResult, arangodb::aql::SharedAqlItemBlockPtr) /work/ArangoDB/tests/Aql/AqlSharedExecutionBlockImplTest.cpp:350
```

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [x] Backports
  - [x] Backport for 3.10: TO DO
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
