### PR TITLE
SEARCH-329 fix prev-doc tracking

### DIFF
--- a/arangod/IResearch/IResearchDataStore.cpp
+++ b/arangod/IResearch/IResearchDataStore.cpp
@@ -22,9 +22,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 #include "IResearchDataStore.h"
 #include "IResearchDocument.h"
-#ifdef USE_ENTERPRISE
-#include "Enterprise/IResearch/IResearchDocumentEE.h"
-#endif
 #include "IResearchKludge.h"
 #include "IResearchFeature.h"
 #include "ApplicationFeatures/ApplicationServer.h"
@@ -43,6 +40,10 @@
 #include "Transaction/Helpers.h"
 #include "Transaction/Methods.h"
 #include "VocBase/LogicalCollection.h"
+
+#ifdef USE_ENTERPRISE
+#include "Enterprise/IResearch/IResearchDocumentEE.h"
+#endif
 
 #include <index/column_info.hpp>
 #include <store/mmap_directory.hpp>

--- a/arangod/IResearch/IResearchDataStore.cpp
+++ b/arangod/IResearch/IResearchDataStore.cpp
@@ -25,6 +25,7 @@
 #ifdef USE_ENTERPRISE
 #include "Enterprise/IResearch/IResearchDocumentEE.h"
 #endif
+#include "IResearchKludge.h"
 #include "IResearchFeature.h"
 #include "ApplicationFeatures/ApplicationServer.h"
 #include "Basics/ReadLocker.h"
@@ -55,10 +56,6 @@ using namespace std::literals;
 
 namespace arangodb::iresearch {
 namespace {
-
-#ifndef USE_ENTERPRISE
-inline bool needTrackPrevDoc(irs::string_ref) { return false; }
-#endif
 
 class IResearchFlushSubscription final : public FlushSubscription {
  public:
@@ -933,7 +930,7 @@ Result IResearchDataStore::deleteDataStore() noexcept {
 
 Result IResearchDataStore::initDataStore(
     bool& pathExists, InitCallback const& initCallback, uint32_t version,
-    bool sorted,
+    bool sorted, bool nested,
     std::vector<IResearchViewStoredValues::StoredColumn> const& storedColumns,
     irs::type_info::type_id primarySortCompression) {
   std::atomic_store(&_flushSubscription, {});
@@ -1083,7 +1080,7 @@ Result IResearchDataStore::initDataStore(
   auto const encrypt =
       (nullptr != _dataStore._directory->attributes().encryption());
   options.column_info =
-      [encrypt, compressionMap = std::move(compressionMap),
+      [nested, encrypt, compressionMap = std::move(compressionMap),
        primarySortCompression](irs::string_ref name) -> irs::column_info {
     if (name.null()) {
       return {.compression = primarySortCompression(),
@@ -1097,12 +1094,12 @@ Result IResearchDataStore::initDataStore(
       return {.compression = compress->second(),
               .options = {},
               .encryption = encrypt && (DocumentPrimaryKey::PK() != name),
-              .track_prev_doc = false};
+              .track_prev_doc = kludge::needTrackPrevDoc(name, nested)};
     }
     return {.compression = getDefaultCompression()(),
             .options = {},
             .encryption = encrypt && (DocumentPrimaryKey::PK() != name),
-            .track_prev_doc = needTrackPrevDoc(name)};
+            .track_prev_doc = kludge::needTrackPrevDoc(name, nested)};
   };
 
   auto openFlags = irs::OM_APPEND;

--- a/arangod/IResearch/IResearchDataStore.h
+++ b/arangod/IResearch/IResearchDataStore.h
@@ -362,7 +362,7 @@ class IResearchDataStore {
   //////////////////////////////////////////////////////////////////////////////
   Result initDataStore(
       bool& pathExists, InitCallback const& initCallback, uint32_t version,
-      bool sorted,
+      bool sorted, bool nested,
       std::vector<IResearchViewStoredValues::StoredColumn> const& storedColumns,
       irs::type_info::type_id primarySortCompression);
 

--- a/arangod/IResearch/IResearchInvertedIndex.cpp
+++ b/arangod/IResearch/IResearchInvertedIndex.cpp
@@ -786,9 +786,10 @@ Result IResearchInvertedIndex::init(
   }
 
   TRI_ASSERT(_meta._sort.sortCompression());
-  auto r = initDataStore(
-      pathExists, initCallback, static_cast<uint32_t>(_meta._version),
-      isSorted(), _meta._storedValues.columns(), _meta._sort.sortCompression());
+  auto r = initDataStore(pathExists, initCallback,
+                         static_cast<uint32_t>(_meta._version), isSorted(),
+                         _meta.hasNested(), _meta._storedValues.columns(),
+                         _meta._sort.sortCompression());
   if (r.ok()) {
     _comparer.reset(_meta._sort);
   }

--- a/arangod/IResearch/IResearchKludge.cpp
+++ b/arangod/IResearch/IResearchKludge.cpp
@@ -23,6 +23,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #include "IResearchKludge.h"
+#include "IResearchDocument.h"
 #include "IResearchRocksDBLink.h"
 #include "IResearchRocksDBInvertedIndex.h"
 #include "Basics/DownCast.h"
@@ -108,6 +109,15 @@ void mangleNested(std::string& name) {
   name += kNestedDelimiter;
 }
 #endif
+
+bool needTrackPrevDoc(irs::string_ref name, bool nested) noexcept {
+#ifdef USE_ENTERPRISE
+  return (!name.empty() && name.back() == kNestedDelimiter) ||
+         (nested && name == DocumentPrimaryKey::PK());
+#else
+  return false;
+#endif
+}
 
 void mangleField(std::string& name, bool isOldMangling,
                  iresearch::FieldMeta::Analyzer const& analyzer) {

--- a/arangod/IResearch/IResearchKludge.h
+++ b/arangod/IResearch/IResearchKludge.h
@@ -38,6 +38,8 @@ namespace arangodb::iresearch::kludge {
 #ifdef USE_ENTERPRISE
 void mangleNested(std::string& name);
 #endif
+
+bool needTrackPrevDoc(irs::string_ref name, bool nested) noexcept;
 void mangleType(std::string& name);
 void mangleAnalyzer(std::string& name);
 

--- a/arangod/IResearch/IResearchLink.cpp
+++ b/arangod/IResearch/IResearchLink.cpp
@@ -209,7 +209,8 @@ Result IResearchLink::toView(std::shared_ptr<LogicalView> const& logical,
 Result IResearchLink::initAndLink(bool& pathExists, InitCallback const& init,
                                   IResearchView* view) {
   auto r = initDataStore(pathExists, init, _meta._version, !_meta._sort.empty(),
-                         _meta._storedValues.columns(), _meta._sortCompression);
+                         _meta._hasNested, _meta._storedValues.columns(),
+                         _meta._sortCompression);
   if (r.ok() && view) {
     r = view->link(_asyncSelf);
   }

--- a/arangod/IResearch/IResearchLink.cpp
+++ b/arangod/IResearch/IResearchLink.cpp
@@ -209,8 +209,12 @@ Result IResearchLink::toView(std::shared_ptr<LogicalView> const& logical,
 Result IResearchLink::initAndLink(bool& pathExists, InitCallback const& init,
                                   IResearchView* view) {
   auto r = initDataStore(pathExists, init, _meta._version, !_meta._sort.empty(),
-                         _meta._hasNested, _meta._storedValues.columns(),
-                         _meta._sortCompression);
+#ifdef USE_ENTERPRISE
+                         _meta._hasNested,
+#else
+                         false,
+#endif
+                         _meta._storedValues.columns(), _meta._sortCompression);
   if (r.ok() && view) {
     r = view->link(_asyncSelf);
   }


### PR DESCRIPTION
### Scope & Purpose

Fix prev doc tracking  in PK column used for removals

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [x] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [x] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: *(Please link PR)*
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*

#### Related Information

- [ ] Docs PR: 
- [x] Enterprise PR: https://github.com/arangodb/enterprise/pull/1020
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

