### PR TITLE
exclude some tests from TSan runs as well

### DIFF
--- a/js/client/modules/@arangodb/testutils/test-utils.js
+++ b/js/client/modules/@arangodb/testutils/test-utils.js
@@ -187,8 +187,10 @@ function filterTestcaseByOptions (testname, options, whichFilter) {
     return false;
   }
 
-  if ((testname.indexOf('-noasan') !== -1) && global.ARANGODB_CLIENT_VERSION(true).asan === 'true') {
-    whichFilter.filter = 'skip when built with asan';
+  if ((testname.indexOf('-noasan') !== -1) && 
+    (global.ARANGODB_CLIENT_VERSION(true).asan === 'true') ||
+    (global.ARANGODB_CLIENT_VERSION(true).tsan === 'true')) {
+    whichFilter.filter = 'skip when built with asan or tsan';
     return false;
   }
 


### PR DESCRIPTION
### Scope & Purpose

Exclude crash recovery tests from TSan runs as well (they were already excluded from ASan runs).

- [x] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: *(Please link PR)*
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
