### PR TITLE
Bug fix/search 328 fix cookie key

### DIFF
--- a/arangod/IResearch/IResearchInvertedIndex.cpp
+++ b/arangod/IResearch/IResearchInvertedIndex.cpp
@@ -282,11 +282,14 @@ class IResearchInvertedIndexIteratorBase : public IndexIterator {
     auto& state = *(_trx->state());
 
     // TODO FIXME find a better way to look up a State
-    auto* ctx = basics::downCast<IResearchSnapshotState>(state.cookie(_index));
+    // we cannot use _index pointer as key - the same is used for storing removes/inserts
+    // so we add 1 to the value (we need just something unique after all)
+    void const* key = reinterpret_cast<uint8_t const*>(_index) + 1;
+    auto* ctx = basics::downCast<IResearchSnapshotState>(state.cookie(key));
     if (!ctx) {
       auto ptr = irs::memory::make_unique<IResearchSnapshotState>();
       ctx = ptr.get();
-      state.cookie(_index, std::move(ptr));
+      state.cookie(key, std::move(ptr));
 
       if (!ctx) {
         LOG_TOPIC("d7061", WARN, arangodb::iresearch::TOPIC)

--- a/arangod/IResearch/IResearchInvertedIndex.cpp
+++ b/arangod/IResearch/IResearchInvertedIndex.cpp
@@ -282,8 +282,9 @@ class IResearchInvertedIndexIteratorBase : public IndexIterator {
     auto& state = *(_trx->state());
 
     // TODO FIXME find a better way to look up a State
-    // we cannot use _index pointer as key - the same is used for storing removes/inserts
-    // so we add 1 to the value (we need just something unique after all)
+    // we cannot use _index pointer as key - the same is used for storing
+    // removes/inserts so we add 1 to the value (we need just something unique
+    // after all)
     void const* key = reinterpret_cast<uint8_t const*>(_index) + 1;
     auto* ctx = basics::downCast<IResearchSnapshotState>(state.cookie(key));
     if (!ctx) {


### PR DESCRIPTION
### Scope & Purpose

Fixes SEARCH-328.
Both FILTER and REMOVE use "index pointer" as cookie key for storing  data in the AQL transaction context. 
So there will be conflict for query like FOR d IN  col OPTIONS { indexHint : "boo" } FILTER d.foo == '1' REMOVE d IN col

As a solution "cookie key" for snapshot is  now [index pointer + 1]

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [x] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [x] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: *(Please link PR)*
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

