### PR TITLE
Add inspector for ResultT

### DIFF
--- a/lib/Basics/ErrorCode.h
+++ b/lib/Basics/ErrorCode.h
@@ -65,6 +65,9 @@ class ErrorCode {
 
   friend auto to_string(::ErrorCode value) -> std::string;
 
+  template<typename Inspector>
+  friend auto inspect(Inspector& f, ErrorCode& x);
+
  private:
   ValueType _value;
 };
@@ -79,3 +82,17 @@ struct hash<ErrorCode> {
 }  // namespace std
 
 auto operator<<(std::ostream& out, ::ErrorCode const& res) -> std::ostream&;
+
+template<typename Inspector>
+auto inspect(Inspector& f, ErrorCode& x) {
+  if constexpr (Inspector::isLoading) {
+    auto v = 0;
+    auto res = f.apply(v);
+    if (res.ok()) {
+      x = ErrorCode{v};
+    }
+    return res;
+  } else {
+    return f.apply(x._value);
+  }
+}

--- a/lib/Basics/Result.cpp
+++ b/lib/Basics/Result.cpp
@@ -160,6 +160,17 @@ auto Result::errorMessage() && noexcept -> std::string {
   }
 }
 
+bool Result::operator==(const Result& other) const {
+  if (ok() && other.ok()) {
+    return true;
+  }
+  if (errorMessage() == other.errorMessage() &&
+      errorNumber() == other.errorNumber()) {
+    return true;
+  }
+  return false;
+}
+
 auto arangodb::operator<<(std::ostream& out, arangodb::Result const& result)
     -> std::ostream& {
   VPackBuilder dump;

--- a/lib/Basics/Result.h
+++ b/lib/Basics/Result.h
@@ -181,6 +181,7 @@ class Result final {
 
     return *this;
   }
+  bool operator==(const Result&) const;
 
  private:
   std::unique_ptr<arangodb::result::Error> _error = nullptr;
@@ -192,5 +193,40 @@ class Result final {
  */
 auto operator<<(std::ostream& out, arangodb::Result const& result)
     -> std::ostream&;
+
+struct ResultSerializer {
+  int number;
+  std::string_view message;
+};
+template<typename Inspector>
+auto inspect(Inspector& f, arangodb::ResultSerializer& x) {
+  return f.object(x).fields(f.field("number", x.number),
+                            f.field("message", x.message));
+}
+struct ResultDeserializer {
+  int number;
+  std::string message;
+};
+template<typename Inspector>
+auto inspect(Inspector& f, arangodb::ResultDeserializer& x) {
+  return f.object(x).fields(f.field("number", x.number),
+                            f.field("message", x.message));
+}
+template<typename Inspector>
+auto inspect(Inspector& f, arangodb::Result& x) {
+  if constexpr (Inspector::isLoading) {
+    auto v = ResultDeserializer{};
+    auto res = f.apply(v);
+    if (res.ok()) {
+      x = arangodb::Result{ErrorCode{std::move(v.number)},
+                           std::move(v.message)};
+    }
+    return res;
+  } else {
+    auto v = ResultSerializer{.number = (int)x.errorNumber(),
+                              .message = x.errorMessage()};
+    return f.apply(v);
+  }
+}
 
 }  // namespace arangodb

--- a/lib/Basics/ResultError.h
+++ b/lib/Basics/ResultError.h
@@ -27,6 +27,7 @@
 #include <string_view>
 
 #include "Basics/ErrorCode.h"
+#include "Basics/voc-errors.h"
 
 namespace arangodb::result {
 
@@ -36,6 +37,8 @@ class Error final {
  public:
   explicit Error(ErrorCode errorNumber) noexcept(
       noexcept(std::string::allocator_type()));
+
+  Error() : _errorNumber{TRI_ERROR_NO_ERROR}, _errorMessage{""} {};
 
   Error(ErrorCode errorNumber, std::string_view errorMessage);
 
@@ -60,9 +63,17 @@ class Error final {
     _errorMessage += std::forward<S>(msg);
   }
 
+  template<typename Inspector>
+  friend auto inspect(Inspector& f, Error& x);
+
  private:
   ErrorCode _errorNumber;
   std::string _errorMessage;
 };
 
+template<typename Inspector>
+auto inspect(Inspector& f, Error& x) {
+  return f.object(x).fields(f.field("number", x._errorNumber),
+                            f.field("message", x._errorMessage));
+}
 }  // namespace arangodb::result

--- a/lib/Basics/ResultT.h
+++ b/lib/Basics/ResultT.h
@@ -156,14 +156,9 @@ class ResultT {
 
   // Default constructor calls default constructor of T
   // If T is not default constructable, ResultT cannot be default constructable
-  template<typename U = T,
-           std::enable_if_t<std::is_nothrow_default_constructible<U>::value,
-                            bool> = true>
-  ResultT() : _val{T{}} {}
-  template<typename U = T,
-           std::enable_if_t<!std::is_nothrow_default_constructible<U>::value,
-                            bool> = true>
-  ResultT() = delete;
+  ResultT() requires(std::is_nothrow_default_constructible<T>::value)
+      : _val{T{}} {}
+  ResultT() requires(!std::is_nothrow_default_constructible<T>::value) = delete;
 
   ResultT& operator=(T const& val_) {
     _val = val_;
@@ -293,6 +288,7 @@ class ResultT {
       : _result(std::move(result)), _val(std::move(val_)) {}
 };
 
+namespace detail {
 template<typename T>
 struct ResultTSerializer
     : std::variant<std::reference_wrapper<const arangodb::Result>,
@@ -312,10 +308,11 @@ auto inspect(Inspector& f, ResultTDeserializer<T>& x) {
       arangodb::inspection::type<T>("value"),
       arangodb::inspection::type<arangodb::Result>("error"));
 }
+}  // namespace detail
 template<typename Inspector, typename T>
 auto inspect(Inspector& f, arangodb::ResultT<T>& x) {
   if constexpr (Inspector::isLoading) {
-    auto v = ResultTDeserializer<T>{};
+    auto v = detail::ResultTDeserializer<T>{};
     auto res = f.apply(v);
     if (res.ok()) {
       if (std::holds_alternative<arangodb::Result>(v)) {
@@ -326,7 +323,7 @@ auto inspect(Inspector& f, arangodb::ResultT<T>& x) {
     }
     return res;
   } else {
-    auto variant = [&]() -> ResultTSerializer<T> {
+    auto variant = [&]() -> detail::ResultTSerializer<T> {
       if (x.fail()) {
         return {std::ref(x.result())};
       }

--- a/lib/Inspection/Access.h
+++ b/lib/Inspection/Access.h
@@ -329,6 +329,18 @@ struct Access<VPackBuilder> : AccessBase<VPackBuilder> {
   }
 };
 
+// only works for serialization: a reference cannot be default constructed
+// which is required for the deserialization result type
+template<typename T>
+struct Access<std::reference_wrapper<T>>
+    : AccessBase<std::reference_wrapper<T>> {
+  template<class Inspector>
+  static auto apply(Inspector& f, std::reference_wrapper<T>& x) {
+    static_assert(!Inspector::isLoading);
+    return f.apply(x.get());
+  }
+};
+
 template<class T, class StorageT>
 struct StorageTransformerAccess {
   static_assert(std::is_same_v<T, typename StorageT::MemoryType>);

--- a/lib/Inspection/Access.h
+++ b/lib/Inspection/Access.h
@@ -329,14 +329,15 @@ struct Access<VPackBuilder> : AccessBase<VPackBuilder> {
   }
 };
 
-// only works for serialization: a reference cannot be default constructed
-// which is required for the deserialization result type
 template<typename T>
 struct Access<std::reference_wrapper<T>>
     : AccessBase<std::reference_wrapper<T>> {
   template<class Inspector>
   static auto apply(Inspector& f, std::reference_wrapper<T>& x) {
-    static_assert(!Inspector::isLoading);
+    static_assert(!Inspector::isLoading,
+                  "a reference_wrapper cannot be deserialized because it "
+                  "cannot be default constructed (default construction is "
+                  "required for the deserialization result type)");
     return f.apply(x.get());
   }
 };

--- a/tests/Basics/InspectionTest.cpp
+++ b/tests/Basics/InspectionTest.cpp
@@ -2096,13 +2096,13 @@ TEST_F(VPackInspectionTest, StructIncludingVPackBuilder) {
   }
 }
 
-TEST(VPackInspectionTest, Result) {
+TEST_F(VPackInspectionTest, Result) {
   arangodb::Result result = {TRI_ERROR_INTERNAL, "some error message"};
   VPackBuilder expectedSerlized;
   {
     VPackObjectBuilder ob(&expectedSerlized);
-    expectedSerlized.add("message", "some error message");
     expectedSerlized.add("number", TRI_ERROR_INTERNAL);
+    expectedSerlized.add("message", "some error message");
   }
 
   VPackBuilder serialized;
@@ -2115,7 +2115,7 @@ TEST(VPackInspectionTest, Result) {
   EXPECT_EQ(result, deserialized);
 }
 
-TEST(VPackInspectionTest, ResultTWithResultInside) {
+TEST_F(VPackInspectionTest, ResultTWithResultInside) {
   arangodb::ResultT<uint64_t> result =
       arangodb::Result{TRI_ERROR_INTERNAL, "some error message"};
   VPackBuilder expectedSerlized;
@@ -2124,8 +2124,8 @@ TEST(VPackInspectionTest, ResultTWithResultInside) {
     expectedSerlized.add(VPackValue("error"));
     {
       VPackObjectBuilder ob2(&expectedSerlized);
-      expectedSerlized.add("message", "some error message");
       expectedSerlized.add("number", TRI_ERROR_INTERNAL);
+      expectedSerlized.add("message", "some error message");
     }
   }
 
@@ -2139,7 +2139,7 @@ TEST(VPackInspectionTest, ResultTWithResultInside) {
   EXPECT_EQ(result, deserialized);
 }
 
-TEST(VPackInspectionTest, ResultTWithTInside) {
+TEST_F(VPackInspectionTest, ResultTWithTInside) {
   arangodb::ResultT<uint64_t> result = 45;
   VPackBuilder expectedSerlized;
   {


### PR DESCRIPTION
### Scope & Purpose

This PR adds a VPack Inspector for Result and ResultT types, such that serialization and deserialization of those types is easy.

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [x] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: *(Please link PR)*
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

