### PR TITLE
fix dumping of active failover agency

### DIFF
--- a/js/client/modules/@arangodb/testsuites/resilience.js
+++ b/js/client/modules/@arangodb/testsuites/resilience.js
@@ -139,7 +139,7 @@ function activeFailover (options) {
   localOptions.disableMonitor = true;
   localOptions.Agency = true;
   let testCases = tu.scanTestPaths(testPaths.active_failover, localOptions);
-  let rc = new tu.runInArangoshRunner(localOptions, 'client_resilience',  Object.assign({}, {
+  let rc = new tu.runInArangoshRunner(localOptions, 'active_failover',  Object.assign({}, {
       'javascript.allow-external-process-control': 'true',
       'javascript.allow-port-testing': 'true',
       'javascript.allow-admin-execute': 'true',

--- a/js/client/modules/@arangodb/testutils/instance.js
+++ b/js/client/modules/@arangodb/testutils/instance.js
@@ -794,6 +794,8 @@ class instance {
     };
     if (this.args.hasOwnProperty('authOpts')) {
       opts['jwt'] = crypto.jwtEncode(this.authOpts['server.jwt-secret'], {'server_id': 'none', 'iss': 'arangodb'}, 'HS256');
+    } else if (this.args.hasOwnProperty('server.jwt-secret')) {
+      opts['jwt'] = crypto.jwtEncode(this.args['server.jwt-secret'], {'server_id': 'none', 'iss': 'arangodb'}, 'HS256');
     }
     print('--------------------------------- '+ fn + ' -----------------------------------------------');
     let agencyReply = download(this.url + path, method === 'POST' ? '[["/"]]' : '', opts);


### PR DESCRIPTION
### Scope & Purpose

at the end of the test we should dump the agency - just in case. This fixes the authentification to fix dumping.

- [x] :hankey: Bugfix
