### PR TITLE
Make MacOs link again.

### DIFF
--- a/arangod/Cluster/ClusterInfo.cpp
+++ b/arangod/Cluster/ClusterInfo.cpp
@@ -1536,7 +1536,7 @@ void ClusterInfo::loadPlan() {
         }
 
         auto shardIDs = newCollection->shardIds();
-        auto shards = std::make_shared<std::vector<std::string>>();
+        auto shards = std::make_shared<std::vector<ServerID>>();
         shards->reserve(shardIDs->size());
         newShardToName.reserve(shardIDs->size());
 


### PR DESCRIPTION
### Scope & Purpose

*Could not link on my Mac anymore. For some reason the typedef of ServerID == std::string was not taken into account to figure out that std::vector<std::string> is equal to std::vector<ServerID> and the template implementation sortShardNamesNumerically<ServerID> could be used*

I cannot explain why Jenkins did not detect this, it built just fine. 🤷 

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: *(Please link PR)*
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

