### PR TITLE
SEARCH-368 fix handling of array comparison

### DIFF
--- a/arangod/Aql/OptimizerUtils.cpp
+++ b/arangod/Aql/OptimizerUtils.cpp
@@ -704,52 +704,83 @@ void extractNonConstPartsOfJunctionCondition(
 
 void extractNonConstPartsOfLeafNode(
     Ast* ast, std::unordered_map<VariableId, VarInfo> const& varInfo,
-    bool evaluateFCalls, bool sorted, AstNode const* leaf,
+    bool evaluateFCalls, bool sorted, AstNode* leaf,
     Variable const* indexVariable,
     std::vector<size_t> const& selectedMembersFromRoot,
     NonConstExpressionContainer& result) {
-  // FCALL at this level is most likely a geo index
-  if (leaf->type == NODE_TYPE_FCALL) {
-    captureFCallArgumentExpressions(ast, varInfo, leaf, selectedMembersFromRoot,
-                                    indexVariable, result);
+  if (leaf->isConstant()) {
     return;
-  } else if (leaf->type == NODE_TYPE_EXPANSION && leaf->numMembers() > 2 &&
-             leaf->isAttributeAccessForVariable(indexVariable, false)) {
-    // we need to gather all expressions from nested filter
-    auto filter = leaf->getMemberUnchecked(2);
-    TRI_ASSERT(filter->type == NODE_TYPE_ARRAY_FILTER);
-    if (ADB_LIKELY(filter->type == NODE_TYPE_ARRAY_FILTER)) {
-      auto path = selectedMembersFromRoot;
-      path.emplace_back(2);
-      captureArrayFilterArgumentExpressions(ast, varInfo, filter,
-                                            std::move(path), evaluateFCalls,
-                                            indexVariable, result);
-    }
-    return;
-  } else if (leaf->type == NODE_TYPE_OPERATOR_UNARY_NOT) {
-    TRI_ASSERT(leaf->numMembers() == 1);
-    auto negatedNode = leaf->getMemberUnchecked(0);
-    TRI_ASSERT(negatedNode);
-    if (negatedNode->isConstant()) {
+  }
+
+  switch (leaf->type) {
+    case NODE_TYPE_FCALL:
+      // FCALL at this level is most likely a geo index
+      captureFCallArgumentExpressions(
+          ast, varInfo, leaf, selectedMembersFromRoot, indexVariable, result);
       return;
-    }
-    auto path = selectedMembersFromRoot;
-    path.emplace_back(0);
-    if (negatedNode->type == NODE_TYPE_OPERATOR_NARY_AND ||
-        negatedNode->type == NODE_TYPE_OPERATOR_NARY_OR) {
-      extractNonConstPartsOfJunctionCondition(
-          ast, varInfo, evaluateFCalls, sorted, negatedNode, indexVariable,
-          std::move(path), result);
-    } else {
+    case NODE_TYPE_EXPANSION:
+      if (leaf->numMembers() > 2 &&
+          leaf->isAttributeAccessForVariable(indexVariable, false)) {
+        // we need to gather all expressions from nested filter
+        auto filter = leaf->getMemberUnchecked(2);
+        TRI_ASSERT(filter->type == NODE_TYPE_ARRAY_FILTER);
+        if (ADB_LIKELY(filter->type == NODE_TYPE_ARRAY_FILTER)) {
+          auto path = selectedMembersFromRoot;
+          path.emplace_back(2);
+          captureArrayFilterArgumentExpressions(ast, varInfo, filter,
+                                                std::move(path), evaluateFCalls,
+                                                indexVariable, result);
+        }
+      }
+      // we don't care about other expansion types
+      return;
+    case NODE_TYPE_OPERATOR_UNARY_NOT: {
+      TRI_ASSERT(leaf->numMembers() == 1);
+      auto negatedNode = leaf->getMemberUnchecked(0);
+      TRI_ASSERT(negatedNode);
+      if (ADB_UNLIKELY(negatedNode->isConstant())) {
+        return;
+      }
+      auto path = selectedMembersFromRoot;
+      path.emplace_back(0);
       extractNonConstPartsOfLeafNode(ast, varInfo, evaluateFCalls, sorted,
                                      negatedNode, indexVariable,
                                      std::move(path), result);
+      return;
     }
-    return;
-  } else if (leaf->numMembers() != 2) {
-    // The Index cannot solve non-binary operators.
-    TRI_ASSERT(false);
-    return;
+    case NODE_TYPE_OPERATOR_BINARY_ARRAY_IN:
+    case NODE_TYPE_OPERATOR_BINARY_ARRAY_NIN:
+    case NODE_TYPE_OPERATOR_BINARY_ARRAY_EQ:
+    case NODE_TYPE_OPERATOR_BINARY_ARRAY_NE:
+    case NODE_TYPE_OPERATOR_BINARY_ARRAY_LT:
+    case NODE_TYPE_OPERATOR_BINARY_ARRAY_LE:
+    case NODE_TYPE_OPERATOR_BINARY_ARRAY_GT:
+    case NODE_TYPE_OPERATOR_BINARY_ARRAY_GE: {
+      TRI_ASSERT(leaf->numMembers() == 3);
+      auto arrayNode = leaf->getMemberUnchecked(0);
+      TRI_ASSERT(arrayNode);
+      TRI_ASSERT(arrayNode->type == NODE_TYPE_ARRAY);
+      if (!arrayNode->isConstant()) {
+        auto path = selectedMembersFromRoot;
+        path.emplace_back(0);
+        captureNonConstExpression(ast, varInfo, arrayNode, std::move(path),
+                                  result);
+      }
+      return;
+    }
+    case NODE_TYPE_OPERATOR_NARY_OR:
+    case NODE_TYPE_OPERATOR_NARY_AND:
+      extractNonConstPartsOfJunctionCondition(ast, varInfo, evaluateFCalls,
+                                              sorted, leaf, indexVariable,
+                                              selectedMembersFromRoot, result);
+      return;
+    default:
+      if (leaf->numMembers() != 2) {
+        // The Index cannot solve non-binary operators.
+        TRI_ASSERT(false);
+        return;
+      }
+      break;
   }
 
   // We only support binary conditions

--- a/tests/js/server/aql/aql-inverted-index.js
+++ b/tests/js/server/aql/aql-inverted-index.js
@@ -367,7 +367,7 @@ function optimizerRuleInvertedIndexTestSuite() {
       assertTrue(appliedRules.includes(useIndexes));
       assertTrue(appliedRules.includes(removeFilterCoveredByIndex));
       let executeRes = db._query(query.query, query.bindVars).toArray();
-      // value0 and value 1will be rejected
+      // value0 and value1 will be rejected
       assertEqual(docs - docs/50, executeRes.length);
     },
         testIndexHintedArrayComparisonAnyEQ: function () {

--- a/tests/js/server/aql/aql-inverted-index.js
+++ b/tests/js/server/aql/aql-inverted-index.js
@@ -262,7 +262,7 @@ function optimizerRuleInvertedIndexTestSuite() {
                     e.errorNum);
       }
     },
-        testIndexHintedArrayComparisonAnyIn: function () {
+    testIndexHintedArrayComparisonAnyIn: function () {
       const query = aql`
         FOR d IN ${col} OPTIONS {indexHint: "InvertedIndexUnsorted"}
           FILTER [NOEVAL('value1'), 'value2'] ANY IN d.data_field

--- a/tests/js/server/aql/aql-inverted-index.js
+++ b/tests/js/server/aql/aql-inverted-index.js
@@ -353,7 +353,8 @@ function optimizerRuleInvertedIndexTestSuite() {
       assertTrue(appliedRules.includes(useIndexes));
       assertTrue(appliedRules.includes(removeFilterCoveredByIndex));
       let executeRes = db._query(query.query, query.bindVars).toArray();
-      assertEqual(docs/50, executeRes.length);
+      // value0 will be rejected
+      assertEqual(docs - docs/100, executeRes.length);
     },
     testIndexHintedArrayComparisonAnyLT: function () {
       const query = aql`
@@ -366,6 +367,7 @@ function optimizerRuleInvertedIndexTestSuite() {
       assertTrue(appliedRules.includes(useIndexes));
       assertTrue(appliedRules.includes(removeFilterCoveredByIndex));
       let executeRes = db._query(query.query, query.bindVars).toArray();
+      // value0 and value 1will be rejected
       assertEqual(docs - docs/50, executeRes.length);
     },
         testIndexHintedArrayComparisonAnyEQ: function () {

--- a/tests/js/server/aql/aql-inverted-index.js
+++ b/tests/js/server/aql/aql-inverted-index.js
@@ -261,7 +261,139 @@ function optimizerRuleInvertedIndexTestSuite() {
         assertEqual(errors.ERROR_BAD_PARAMETER.code,
                     e.errorNum);
       }
-    }
+    },
+        testIndexHintedArrayComparisonAnyIn: function () {
+      const query = aql`
+        FOR d IN ${col} OPTIONS {indexHint: "InvertedIndexUnsorted"}
+          FILTER [NOEVAL('value1'), 'value2'] ANY IN d.data_field
+          SORT d.count DESC
+          RETURN d`;
+      const res = AQL_EXPLAIN(query.query, query.bindVars);
+      const appliedRules = res.plan.rules;
+      assertTrue(appliedRules.includes(useIndexes));
+      assertTrue(appliedRules.includes(removeFilterCoveredByIndex));
+      let executeRes = db._query(query.query, query.bindVars).toArray();
+      assertEqual(docs / 50, executeRes.length);
+    },
+    testIndexHintedArrayComparisonAllIn: function () {
+      const query = aql`
+        FOR d IN ${col} OPTIONS {indexHint: "InvertedIndexUnsorted"}
+          FILTER [NOEVAL('value1'), 'value2'] ALL IN d.data_field
+          SORT d.count DESC
+          RETURN d`;
+      const res = AQL_EXPLAIN(query.query, query.bindVars);
+      const appliedRules = res.plan.rules;
+      assertTrue(appliedRules.includes(useIndexes));
+      assertTrue(appliedRules.includes(removeFilterCoveredByIndex));
+      let executeRes = db._query(query.query, query.bindVars).toArray();
+      assertEqual(0, executeRes.length);
+    },
+    testIndexHintedArrayComparisonNoneIn: function () {
+      const query = aql`
+        FOR d IN ${col} OPTIONS {indexHint: "InvertedIndexUnsorted"}
+          FILTER [NOEVAL('value1'), 'value2'] NONE IN d.data_field
+          SORT d.count DESC
+          RETURN d`;
+      const res = AQL_EXPLAIN(query.query, query.bindVars);
+      const appliedRules = res.plan.rules;
+      assertTrue(appliedRules.includes(useIndexes));
+      assertTrue(appliedRules.includes(removeFilterCoveredByIndex));
+      let executeRes = db._query(query.query, query.bindVars).toArray();
+      assertEqual(docs - docs / 50, executeRes.length);
+    },
+    testIndexHintedArrayComparisonAnyNotIn: function () {
+      const query = aql`
+        FOR d IN ${col} OPTIONS {indexHint: "InvertedIndexUnsorted"}
+          FILTER [NOEVAL('value1'), 'value2'] ANY NOT IN d.data_field
+          SORT d.count DESC
+          RETURN d`;
+      const res = AQL_EXPLAIN(query.query, query.bindVars);
+      const appliedRules = res.plan.rules;
+      assertTrue(appliedRules.includes(useIndexes));
+      assertTrue(appliedRules.includes(removeFilterCoveredByIndex));
+      let executeRes = db._query(query.query, query.bindVars).toArray();
+      assertEqual(docs, executeRes.length);
+    },
+    testIndexHintedArrayComparisonAnyGE: function () {
+      const query = aql`
+        FOR d IN ${col} OPTIONS {indexHint: "InvertedIndexUnsorted"}
+          FILTER [NOEVAL('value1'), 'value2'] ANY >= d.data_field
+          SORT d.count DESC
+          RETURN d`;
+      const res = AQL_EXPLAIN(query.query, query.bindVars);
+      const appliedRules = res.plan.rules;
+      assertTrue(appliedRules.includes(useIndexes));
+      assertTrue(appliedRules.includes(removeFilterCoveredByIndex));
+      let executeRes = db._query(query.query, query.bindVars).toArray();
+      // value2, value1, value0, value10..value19
+      assertEqual(1300, executeRes.length);
+    },
+    testIndexHintedArrayComparisonAnyGT: function () {
+      const query = aql`
+        FOR d IN ${col} OPTIONS {indexHint: "InvertedIndexUnsorted"}
+          FILTER [NOEVAL('value1'), 'value2'] ANY > d.data_field
+          SORT d.count DESC
+          RETURN d`;
+      const res = AQL_EXPLAIN(query.query, query.bindVars);
+      const appliedRules = res.plan.rules;
+      assertTrue(appliedRules.includes(useIndexes));
+      assertTrue(appliedRules.includes(removeFilterCoveredByIndex));
+      let executeRes = db._query(query.query, query.bindVars).toArray();
+      // value1, value0, value10..value19
+      assertEqual(docs/100 * 12, executeRes.length);
+    },
+    testIndexHintedArrayComparisonAnyLE: function () {
+      const query = aql`
+        FOR d IN ${col} OPTIONS {indexHint: "InvertedIndexUnsorted"}
+          FILTER [NOEVAL('value1'), 'value2'] ANY <= d.data_field
+          SORT d.count DESC
+          RETURN d`;
+      const res = AQL_EXPLAIN(query.query, query.bindVars);
+      const appliedRules = res.plan.rules;
+      assertTrue(appliedRules.includes(useIndexes));
+      assertTrue(appliedRules.includes(removeFilterCoveredByIndex));
+      let executeRes = db._query(query.query, query.bindVars).toArray();
+      assertEqual(docs/50, executeRes.length);
+    },
+    testIndexHintedArrayComparisonAnyLT: function () {
+      const query = aql`
+        FOR d IN ${col} OPTIONS {indexHint: "InvertedIndexUnsorted"}
+          FILTER [NOEVAL('value1'), 'value2'] ANY < d.data_field
+          SORT d.count DESC
+          RETURN d`;
+      const res = AQL_EXPLAIN(query.query, query.bindVars);
+      const appliedRules = res.plan.rules;
+      assertTrue(appliedRules.includes(useIndexes));
+      assertTrue(appliedRules.includes(removeFilterCoveredByIndex));
+      let executeRes = db._query(query.query, query.bindVars).toArray();
+      assertEqual(docs - docs/50, executeRes.length);
+    },
+        testIndexHintedArrayComparisonAnyEQ: function () {
+      const query = aql`
+        FOR d IN ${col} OPTIONS {indexHint: "InvertedIndexUnsorted"}
+          FILTER [NOEVAL('value1'), 'value2'] ANY == d.data_field
+          SORT d.count DESC
+          RETURN d`;
+      const res = AQL_EXPLAIN(query.query, query.bindVars);
+      const appliedRules = res.plan.rules;
+      assertTrue(appliedRules.includes(useIndexes));
+      assertTrue(appliedRules.includes(removeFilterCoveredByIndex));
+      let executeRes = db._query(query.query, query.bindVars).toArray();
+      assertEqual(docs/50, executeRes.length);
+    },
+    testIndexHintedArrayComparisonAnyNE: function () {
+      const query = aql`
+        FOR d IN ${col} OPTIONS {indexHint: "InvertedIndexUnsorted"}
+          FILTER [NOEVAL('value1'), 'value2'] ANY != d.data_field
+          SORT d.count DESC
+          RETURN d`;
+      const res = AQL_EXPLAIN(query.query, query.bindVars);
+      const appliedRules = res.plan.rules;
+      assertTrue(appliedRules.includes(useIndexes));
+      assertTrue(appliedRules.includes(removeFilterCoveredByIndex));
+      let executeRes = db._query(query.query, query.bindVars).toArray();
+      assertEqual(docs, executeRes.length);
+    },
   };
 }
 


### PR DESCRIPTION
### Scope & Purpose

Adds handling of possibly non-const array comparison operators to the index

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [x] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [x] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: *(Please link PR)*
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

