### PR TITLE
[CINFRA-538] Resign and apply race condition

### DIFF
--- a/arangod/Replication2/StateMachines/Document/DocumentFollowerState.h
+++ b/arangod/Replication2/StateMachines/Document/DocumentFollowerState.h
@@ -32,7 +32,8 @@ namespace arangodb::replication2::replicated_state::document {
 struct IDocumentStateTransactionHandler;
 
 struct DocumentFollowerState
-    : replicated_state::IReplicatedFollowerState<DocumentState> {
+    : replicated_state::IReplicatedFollowerState<DocumentState>,
+      std::enable_shared_from_this<DocumentFollowerState> {
   explicit DocumentFollowerState(
       std::unique_ptr<DocumentCore> core,
       std::shared_ptr<IDocumentStateHandlersFactory> handlersFactory);

--- a/arangod/Replication2/StateMachines/Document/DocumentLeaderState.h
+++ b/arangod/Replication2/StateMachines/Document/DocumentLeaderState.h
@@ -32,7 +32,8 @@
 
 namespace arangodb::replication2::replicated_state::document {
 struct DocumentLeaderState
-    : replicated_state::IReplicatedLeaderState<DocumentState> {
+    : replicated_state::IReplicatedLeaderState<DocumentState>,
+      std::enable_shared_from_this<DocumentLeaderState> {
   explicit DocumentLeaderState(
       std::unique_ptr<DocumentCore> core,
       std::shared_ptr<IDocumentStateHandlersFactory> handlersFactory);


### PR DESCRIPTION
### Scope & Purpose

On the follower, it is possible to `resign` during `applyEntries`.
On the leader, it is possible to `resign` during `recoverEntries`.
This PR fixes these issues, by using a lock on the core.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification