### PR TITLE
fix a compile warning in replication2 tests

### DIFF
--- a/tests/Replication2/ReplicatedState/DocumentStateMachineTest.cpp
+++ b/tests/Replication2/ReplicatedState/DocumentStateMachineTest.cpp
@@ -190,7 +190,7 @@ struct MockDocumentStateHandlersFactory : IDocumentStateHandlersFactory {
       -> std::unique_ptr<IDocumentStateTransactionHandler> override {
     auto th = std::make_unique<MockDocumentStateTransactionHandler>();
     transactionHandler = th.get();
-    return std::move(th);
+    return th;
   }
 
   std::shared_ptr<IDocumentStateAgencyHandler> agencyHandler;


### PR DESCRIPTION
### Scope & Purpose

Fixes compile warning in replication2 tests:
``` 
/home/jan/ArangoDevel/tests/Replication2/ReplicatedState/DocumentStateMachineTest.cpp: In member function ‘virtual std::unique_ptr<arangodb::replication2::replicated_state::document::IDocumentStateTransactionHandler> MockDocumentStateHandlersFactory::createTransactionHandler(arangodb::replication2::GlobalLogIdentifier)’:
/home/jan/ArangoDevel/tests/Replication2/ReplicatedState/DocumentStateMachineTest.cpp:193:21: warning: redundant move in return statement [-Wredundant-move]
  193 |     return std::move(th);
      |            ~~~~~~~~~^~~~
/home/jan/ArangoDevel/tests/Replication2/ReplicatedState/DocumentStateMachineTest.cpp:193:21: note: remove ‘std::move’ call
```

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: -
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

