### PR TITLE
Make SUBSTRING_BYTES work similar to SUBSTRING

### DIFF
--- a/arangod/Aql/AqlFunctionFeature.cpp
+++ b/arangod/Aql/AqlFunctionFeature.cpp
@@ -170,7 +170,7 @@ void AqlFunctionFeature::addStringFunctions() {
   add({"LOWER", ".", flags, &functions::Lower});
   add({"UPPER", ".", flags, &functions::Upper});
   add({"SUBSTRING", ".,.|.", flags, &functions::Substring});
-  add({"SUBSTRING_BYTES", ".,.,.", flags, &functions::SubstringBytes});
+  add({"SUBSTRING_BYTES", ".,.|.", flags, &functions::SubstringBytes});
   add({"CONTAINS", ".,.|.", flags, &functions::Contains});
   add({"LIKE", ".,.|.", flags, &functions::Like});
   add({"REGEX_MATCHES", ".,.|.", flags, &functions::RegexMatches});

--- a/arangod/Aql/Functions.cpp
+++ b/arangod/Aql/Functions.cpp
@@ -2633,7 +2633,9 @@ AqlValue functions::SubstringBytes(ExpressionContext* ctx, AstNode const& node,
     return true;
   };
 
-  auto const subStr = str.substr(offset, length);
+  auto const subStr =
+      str.substr(offset, std::min(static_cast<uint32_t>(length),
+                                  static_cast<uint32_t>(str.size()) - offset));
 
   if (!validate(subStr)) {
     registerWarning(ctx, getFunctionName(node).data(), TRI_ERROR_BAD_PARAMETER);

--- a/arangod/Aql/Functions.cpp
+++ b/arangod/Aql/Functions.cpp
@@ -2615,7 +2615,7 @@ AqlValue functions::SubstringBytes(ExpressionContext* ctx, AstNode const& node,
     }
   }();
 
-  if (length < 0 || offset >= str.size()) {
+  if (length <= 0 || offset >= str.size()) {
     return AqlValue{velocypack::Slice::emptyStringSlice()};
   }
 

--- a/tests/IResearch/IResearchQueryAndTest.cpp
+++ b/tests/IResearch/IResearchQueryAndTest.cpp
@@ -274,59 +274,6 @@ class QueryAndSearch : public QueryAnd {
   ViewType type() const final { return arangodb::ViewType::kSearchAlias; }
 };
 
-template<typename NormyType>
-auto getIndexFeatures() {
-  return [](irs::type_info::type_id id) {
-    TRI_ASSERT(irs::type<NormyType>::id() == id ||
-               irs::type<irs::granularity_prefix>::id() == id);
-    const irs::column_info info{
-        irs::type<irs::compression::none>::get(), {}, false};
-
-    if (irs::type<NormyType>::id() == id) {
-      return std::make_pair(info, &NormyType::MakeWriter);
-    }
-
-    return std::make_pair(info, irs::feature_writer_factory_t{});
-  };
-}
-
-TEST_P(QueryAndView, ggg) {
-  irs::mmap_directory dir{
-      "/home/gnusi/Downloads/database-21960739/arangosearch-24030124_19751373"};
-
-  auto rdr = irs::directory_reader::open(dir);
-
-  std::cerr << "docs: " << rdr->docs_count() << ", segments " << rdr->size()
-            << std::endl;
-
-  arangodb::iresearch::IResearchViewSort sort;
-  sort.emplace_back(std::vector{arangodb::basics::AttributeName{"createdAt"}},
-                    true);
-  arangodb::iresearch::VPackComparer comparer{sort};
-
-  irs::index_writer::init_options options;
-  // Set 256MB limit during recovery. Actual "operational" limit will be set
-  // later when this link will be added to the view.
-  options.segment_memory_max = 256 * (size_t{1} << 20);
-  // Do not lock index, ArangoDB has its own lock.
-  options.lock_repository = false;
-  // Set comparator if requested.
-  options.comparator = &comparer;
-  // Set index features.
-  options.features = getIndexFeatures<irs::Norm2>();
-
-  auto codec = irs::formats::get("1_4simd");
-  ASSERT_NE(nullptr, codec);
-  auto writer =
-      irs::index_writer::make(dir, codec, irs::OpenMode::OM_APPEND, options);
-
-  const irs::index_utils::consolidate_count consolidate_all;
-  auto res = writer->consolidate(
-      irs::index_utils::consolidation_policy(consolidate_all));
-  ASSERT_TRUE(res);
-  writer->commit();
-}
-
 TEST_P(QueryAndView, Test) {
   createCollections();
   createView(R"("analyzers": [ "test_analyzer",  "identity" ],

--- a/tests/js/server/aql/aql-functions-string.js
+++ b/tests/js/server/aql/aql-functions-string.js
@@ -1876,14 +1876,31 @@ function ahuacatlStringFunctionsTestSuite () {
 
     testSubstringBytes: function () {
       assertEqual([ '🤡'  ], getQueryResults(`RETURN SUBSTRING_BYTES('🤡', 0, 4)`));
+      assertEqual([ '🤡'  ], getQueryResults(`RETURN SUBSTRING_BYTES('🤡', 0)`));
       assertEqual([ '🤡f' ], getQueryResults(`RETURN SUBSTRING_BYTES('🤡foo', 0, 5)`));
-      assertEqual([ 'fo'  ], getQueryResults(`RETURN SUBSTRING_BYTES('🤡foo', 4, 6)`));
+      assertEqual([ 'fo'  ], getQueryResults(`RETURN SUBSTRING_BYTES('🤡foo', 4, 2)`));
       assertEqual([ '' ], getQueryResults(`RETURN SUBSTRING_BYTES('', 0, 0)`));
       assertEqual([ '' ], getQueryResults(`RETURN SUBSTRING_BYTES('', 0, 1)`));
 
+      // negative offsets
+      assertEqual([ 'o' ], getQueryResults(`RETURN SUBSTRING_BYTES('🤡foo', -1, 1)`));
+      assertEqual([ 'oo' ], getQueryResults(`RETURN SUBSTRING_BYTES('🤡foo', -2, 2)`));
+      assertEqual([ '🤡foo' ], getQueryResults(`RETURN SUBSTRING_BYTES('🤡foo', -42)`));
+      assertEqual([ '🤡foo' ], getQueryResults(`RETURN SUBSTRING_BYTES('🤡foo', 0)`));
+      assertEqual([ 'fo' ], getQueryResults(`RETURN SUBSTRING_BYTES('🤡foo', -3, 2)`));
+      assertEqual([ '🤡' ], getQueryResults(`RETURN SUBSTRING_BYTES('🤡foo', -42, 4)`));
+      assertEqual([ '🤡' ], getQueryResults(`RETURN SUBSTRING_BYTES('🤡foo', null, 4)`));
+      assertEqual([ '🤡' ], getQueryResults(`RETURN SUBSTRING_BYTES('🤡foo', 'foobar', 4)`));
+
+      // negative length
+      assertEqual([ '' ], getQueryResults(`RETURN SUBSTRING_BYTES('🤡foo', -2, -2)`));
+      assertEqual([ '' ], getQueryResults(`RETURN SUBSTRING_BYTES('🤡foo', -2, "foobar")`));
+
       // invalid utf8 offset
-      assertEqual([ null  ], getQueryResults(`RETURN SUBSTRING_BYTES('🤡', 1, 2)`)); 
-      assertEqual([ null  ], getQueryResults(`RETURN SUBSTRING_BYTES('🤡', 0, 2)`));
+      assertEqual([ null ], getQueryResults(`RETURN SUBSTRING_BYTES('🤡', 1, 2)`)); 
+      assertEqual([ null ], getQueryResults(`RETURN SUBSTRING_BYTES('🤡', 0, 2)`));
+      assertEqual([ null ], getQueryResults(`RETURN SUBSTRING_BYTES('🤡foo', -4, 2)`));
+      assertEqual([ null ], getQueryResults(`RETURN SUBSTRING_BYTES('🤡foo', -42, 2)`));
 
       // invalid argument types
       assertEqual([ null  ], getQueryResults(`RETURN SUBSTRING_BYTES(['🤡'], 1, 2)`)); 

--- a/tests/js/server/aql/aql-functions-string.js
+++ b/tests/js/server/aql/aql-functions-string.js
@@ -1879,12 +1879,13 @@ function ahuacatlStringFunctionsTestSuite () {
       assertEqual([ '🤡'  ], getQueryResults(`RETURN SUBSTRING_BYTES('🤡', 0)`));
       assertEqual([ '🤡f' ], getQueryResults(`RETURN SUBSTRING_BYTES('🤡foo', 0, 5)`));
       assertEqual([ 'fo'  ], getQueryResults(`RETURN SUBSTRING_BYTES('🤡foo', 4, 2)`));
+      assertEqual([ ''  ], getQueryResults(`RETURN SUBSTRING_BYTES('🤡foo', 42, 2)`));
       assertEqual([ '' ], getQueryResults(`RETURN SUBSTRING_BYTES('', 0, 0)`));
       assertEqual([ '' ], getQueryResults(`RETURN SUBSTRING_BYTES('', 0, 1)`));
 
       // negative offsets
       assertEqual([ 'o' ], getQueryResults(`RETURN SUBSTRING_BYTES('🤡foo', -1, 1)`));
-      assertEqual([ 'oo' ], getQueryResults(`RETURN SUBSTRING_BYTES('🤡foo', -2, 2)`));
+      assertEqual([ 'vo' ], getQueryResults(`RETURN SUBSTRING_BYTES('🤡fvo', -2, 2)`));
       assertEqual([ '🤡foo' ], getQueryResults(`RETURN SUBSTRING_BYTES('🤡foo', -42)`));
       assertEqual([ '🤡foo' ], getQueryResults(`RETURN SUBSTRING_BYTES('🤡foo', 0)`));
       assertEqual([ 'fo' ], getQueryResults(`RETURN SUBSTRING_BYTES('🤡foo', -3, 2)`));


### PR DESCRIPTION
### Scope & Purpose

Make SUBSTRING_BYTES work similar to SUBSTRING

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [x] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [x] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: *(Please link PR)*
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [x] Enterprise PR: https://github.com/arangodb/enterprise/pull/1040
- [ ] GitHub issue / Jira ticket: 
- [ ] Design document: 

