### PR TITLE
Introduce ThreadGuard 

### DIFF
--- a/lib/Basics/ThreadGuard.h
+++ b/lib/Basics/ThreadGuard.h
@@ -1,0 +1,65 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2021-2021 ArangoDB GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Markus Pfeiffer
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include <thread>
+#include <vector>
+
+namespace arangodb {
+
+// A thread guard is a wrapper around a std::vector<std::thread> that
+// facilitates joining all joinable threads on destruction or when
+// the member function joinAll is called.
+struct ThreadGuard {
+  ThreadGuard() = default;
+  explicit ThreadGuard(size_t reserve) { threads.reserve(reserve); }
+  ~ThreadGuard() {
+    // Note that this might throw, and then we're in trouble;
+    // We accept this risk here, because if joining a thread
+    // inside the destructor of ThreadGuard fails, we're in a
+    // very bad place, regardless.
+    joinAll();
+  }
+
+  template<typename Function, typename... Args>
+  auto emplace(Function&& f, Args&&... args)
+      -> std::vector<std::thread>::reference {
+    return threads.emplace_back(std::forward<Function>(f),
+                                std::forward<Args>(args)...);
+  }
+
+  void joinAll() {
+    for (auto& t : threads) {
+      if (t.joinable()) {
+        t.join();
+      }
+    }
+    threads.clear();
+  }
+
+  [[nodiscard]] auto size() const -> size_t { return threads.size(); }
+
+  std::vector<std::thread> threads;
+};
+
+}  // namespace arangodb

--- a/tests/Basics/MemoryUsageTest.cpp
+++ b/tests/Basics/MemoryUsageTest.cpp
@@ -28,6 +28,7 @@
 #include "Basics/GlobalResourceMonitor.h"
 #include "Basics/ResourceUsage.h"
 #include "Basics/voc-errors.h"
+#include "Basics/ScopeGuard.h"
 
 #include <algorithm>
 #include <atomic>
@@ -199,6 +200,17 @@ TEST(ResourceUsageTest, testConcurrencyRestricted) {
 
   std::vector<std::thread> threads;
   threads.reserve(::numThreads);
+  arangodb::ScopeGuard scope{[&]() noexcept {
+    for (auto& t : threads) {
+      if (t.joinable()) {
+        try {
+          t.join();
+        } catch (...) {
+        }
+      }
+    }
+  }};
+
   for (size_t i = 0; i < ::numThreads; ++i) {
     threads.emplace_back([&]() {
       while (!go.load()) {
@@ -224,9 +236,7 @@ TEST(ResourceUsageTest, testConcurrencyRestricted) {
 
   go.store(true);
 
-  for (auto& thread : threads) {
-    thread.join();
-  }
+  scope.fire();
 
   // should be down to 0 now
   EXPECT_EQ(0, monitor.current());
@@ -246,6 +256,17 @@ TEST(ResourceUsageTest, testConcurrencyUnrestricted) {
 
   std::vector<std::thread> threads;
   threads.reserve(::numThreads);
+  arangodb::ScopeGuard scope{[&]() noexcept {
+    for (auto& t : threads) {
+      if (t.joinable()) {
+        try {
+          t.join();
+        } catch (...) {
+        }
+      }
+    }
+  }};
+
   for (size_t i = 0; i < ::numThreads; ++i) {
     threads.emplace_back([&]() {
       while (!go.load()) {
@@ -262,9 +283,7 @@ TEST(ResourceUsageTest, testConcurrencyUnrestricted) {
 
   go.store(true);
 
-  for (auto& thread : threads) {
-    thread.join();
-  }
+  scope.fire();
 
   // should be down to 0 now
   ASSERT_EQ(0, monitor.current());
@@ -475,6 +494,17 @@ TEST(GlobalResourceMonitorTest, testConcurrencyRestricted) {
 
   std::vector<std::thread> threads;
   threads.reserve(::numThreads);
+  arangodb::ScopeGuard scope{[&]() noexcept {
+    for (auto& t : threads) {
+      if (t.joinable()) {
+        try {
+          t.join();
+        } catch (...) {
+        }
+      }
+    }
+  }};
+
   for (size_t i = 0; i < ::numThreads; ++i) {
     threads.emplace_back([&]() {
       while (!go.load()) {
@@ -500,9 +530,7 @@ TEST(GlobalResourceMonitorTest, testConcurrencyRestricted) {
 
   go.store(true);
 
-  for (auto& thread : threads) {
-    thread.join();
-  }
+  scope.fire();
 
   // should be down to 0 now
   ASSERT_EQ(0, monitor.current());
@@ -518,6 +546,17 @@ TEST(GlobalResourceMonitorTest, testConcurrencyUnrestricted) {
 
   std::vector<std::thread> threads;
   threads.reserve(::numThreads);
+  arangodb::ScopeGuard scope{[&]() noexcept {
+    for (auto& t : threads) {
+      if (t.joinable()) {
+        try {
+          t.join();
+        } catch (...) {
+        }
+      }
+    }
+  }};
+
   for (size_t i = 0; i < ::numThreads; ++i) {
     threads.emplace_back([&]() {
       while (!go.load()) {
@@ -535,9 +574,7 @@ TEST(GlobalResourceMonitorTest, testConcurrencyUnrestricted) {
 
   go.store(true);
 
-  for (auto& thread : threads) {
-    thread.join();
-  }
+  scope.fire();
 
   // should be down to 0 now
   ASSERT_EQ(0, monitor.current());

--- a/tests/Basics/RecursiveLockerTest.cpp
+++ b/tests/Basics/RecursiveLockerTest.cpp
@@ -28,6 +28,7 @@
 #include "Basics/RecursiveLocker.h"
 
 #include "gtest/gtest.h"
+#include "Basics/ScopeGuard.h"
 
 #include <atomic>
 #include <thread>
@@ -121,6 +122,17 @@ TEST(RecursiveLockerTest, testRecursiveMutexMultiThreaded) {
   constexpr int iterations = 100000;
 
   std::vector<std::thread> threads;
+  threads.reserve(n);
+  arangodb::ScopeGuard scope{[&]() noexcept {
+    for (auto& t : threads) {
+      if (t.joinable()) {
+        try {
+          t.join();
+        } catch (...) {
+        }
+      }
+    }
+  }};
 
   for (int i = 0; i < n; ++i) {
     threads.emplace_back([&]() {
@@ -145,9 +157,7 @@ TEST(RecursiveLockerTest, testRecursiveMutexMultiThreaded) {
     });
   }
 
-  for (int i = 0; i < n; ++i) {
-    threads[i].join();
-  }
+  scope.fire();
 
   ASSERT_EQ(n * iterations, total);
   ASSERT_EQ(n * iterations * 2, x);
@@ -239,6 +249,17 @@ TEST(RecursiveLockerTest, testRecursiveWriteLockMultiThreaded) {
   constexpr int iterations = 100000;
 
   std::vector<std::thread> threads;
+  threads.reserve(n);
+  arangodb::ScopeGuard scope{[&]() noexcept {
+    for (auto& t : threads) {
+      if (t.joinable()) {
+        try {
+          t.join();
+        } catch (...) {
+        }
+      }
+    }
+  }};
 
   for (int i = 0; i < n; ++i) {
     threads.emplace_back([&]() {
@@ -263,9 +284,7 @@ TEST(RecursiveLockerTest, testRecursiveWriteLockMultiThreaded) {
     });
   }
 
-  for (int i = 0; i < n; ++i) {
-    threads[i].join();
-  }
+  scope.fire();
 
   ASSERT_EQ(n * iterations, total);
   ASSERT_EQ(n * iterations * 2, x);
@@ -302,6 +321,17 @@ TEST(RecursiveLockerTest, testRecursiveWriteLockMultiThreadedWriteRead) {
   constexpr int iterations = 100000;
 
   std::vector<std::thread> threads;
+  threads.reserve(n);
+  arangodb::ScopeGuard scope{[&]() noexcept {
+    for (auto& t : threads) {
+      if (t.joinable()) {
+        try {
+          t.join();
+        } catch (...) {
+        }
+      }
+    }
+  }};
 
   for (int i = 0; i < n; ++i) {
     threads.emplace_back([&]() {
@@ -326,9 +356,7 @@ TEST(RecursiveLockerTest, testRecursiveWriteLockMultiThreadedWriteRead) {
     });
   }
 
-  for (int i = 0; i < n; ++i) {
-    threads[i].join();
-  }
+  scope.fire();
 
   ASSERT_EQ(n * iterations, total);
   ASSERT_EQ(n * iterations, x);
@@ -349,6 +377,17 @@ TEST(RecursiveLockerTest, testRecursiveWriteLockMultiThreadedWriteAndReadMix) {
   constexpr int iterations = 100000;
 
   std::vector<std::thread> threads;
+  threads.reserve(n);
+  arangodb::ScopeGuard scope{[&]() noexcept {
+    for (auto& t : threads) {
+      if (t.joinable()) {
+        try {
+          t.join();
+        } catch (...) {
+        }
+      }
+    }
+  }};
 
   for (int i = 0; i < n; ++i) {
     threads.emplace_back(
@@ -378,9 +417,7 @@ TEST(RecursiveLockerTest, testRecursiveWriteLockMultiThreadedWriteAndReadMix) {
         i);
   }
 
-  for (int i = 0; i < n; ++i) {
-    threads[i].join();
-  }
+  scope.fire();
 
   ASSERT_EQ((n / 2) * iterations, total);
   ASSERT_EQ((n / 2) * iterations, x);
@@ -401,6 +438,17 @@ TEST(RecursiveLockerTest, testRecursiveReadLockMultiThreadedWriteAndReadMix) {
   constexpr int iterations = 100000;
 
   std::vector<std::thread> threads;
+  threads.reserve(n);
+  arangodb::ScopeGuard scope{[&]() noexcept {
+    for (auto& t : threads) {
+      if (t.joinable()) {
+        try {
+          t.join();
+        } catch (...) {
+        }
+      }
+    }
+  }};
 
   for (int i = 0; i < n; ++i) {
     threads.emplace_back(
@@ -454,9 +502,7 @@ TEST(RecursiveLockerTest, testRecursiveReadLockMultiThreadedWriteAndReadMix) {
         i);
   }
 
-  for (int i = 0; i < n; ++i) {
-    threads[i].join();
-  }
+  scope.fire();
 
   ASSERT_EQ(iterations, total);
   ASSERT_EQ(iterations, x);

--- a/tests/Metrics/MetricsTest.cpp
+++ b/tests/Metrics/MetricsTest.cpp
@@ -30,7 +30,7 @@
 #include "Metrics/Histogram.h"
 #include "Metrics/LinScale.h"
 #include "Metrics/LogScale.h"
-#include "Basics/ScopeGuard.h"
+#include "Basics/ThreadGuard.h"
 
 #include <algorithm>
 #include <atomic>
@@ -47,6 +47,7 @@ constexpr size_t numThreads = 4;
 constexpr uint64_t numOpsPerThread = 25 * 1000 * 1000;
 }  // namespace
 
+using namespace arangodb;
 using namespace arangodb::metrics;
 
 TEST(MetricsTest, test_counter_concurrency) {
@@ -56,21 +57,10 @@ TEST(MetricsTest, test_counter_concurrency) {
 
   std::atomic<bool> go = false;
 
-  std::vector<std::thread> threads;
-  threads.reserve(::numThreads);
-  arangodb::ScopeGuard scope{[&]() noexcept {
-    for (auto& t : threads) {
-      if (t.joinable()) {
-        try {
-          t.join();
-        } catch (...) {
-        }
-      }
-    }
-  }};
+  auto threads = ThreadGuard(::numThreads);
 
   for (size_t i = 0; i < ::numThreads; ++i) {
-    threads.emplace_back([&]() {
+    threads.emplace([&]() {
       while (!go.load()) {
         // wait until all threads are created, so they can
         // start at the approximate same time
@@ -83,7 +73,7 @@ TEST(MetricsTest, test_counter_concurrency) {
 
   go.store(true);
 
-  scope.fire();
+  threads.joinAll();
 
   ASSERT_EQ(c.load(), ::numThreads * ::numOpsPerThread);
 }
@@ -99,21 +89,10 @@ TEST(MetricsTest, test_histogram_concurrency_same) {
 
   std::atomic<bool> go = false;
 
-  std::vector<std::thread> threads;
-  threads.reserve(::numThreads);
-  arangodb::ScopeGuard scope{[&]() noexcept {
-    for (auto& t : threads) {
-      if (t.joinable()) {
-        try {
-          t.join();
-        } catch (...) {
-        }
-      }
-    }
-  }};
+  auto threads = ThreadGuard(::numThreads);
 
   for (size_t i = 0; i < ::numThreads; ++i) {
-    threads.emplace_back([&]() {
+    threads.emplace([&]() {
       while (!go.load()) {
         // wait until all threads are created, so they can
         // start at the approximate same time
@@ -126,7 +105,7 @@ TEST(MetricsTest, test_histogram_concurrency_same) {
 
   go.store(true);
 
-  scope.fire();
+  threads.joinAll();
 
   ASSERT_EQ(h.load(0), ::numThreads * ::numOpsPerThread);
   ASSERT_EQ(h.load(1), 0);
@@ -145,21 +124,10 @@ TEST(MetricsTest, test_histogram_concurrency_distributed) {
 
   std::atomic<bool> go = false;
 
-  std::vector<std::thread> threads;
-  threads.reserve(::numThreads);
-  arangodb::ScopeGuard scope{[&]() noexcept {
-    for (auto& t : threads) {
-      if (t.joinable()) {
-        try {
-          t.join();
-        } catch (...) {
-        }
-      }
-    }
-  }};
+  auto threads = ThreadGuard(::numThreads);
 
   for (size_t i = 0; i < ::numThreads; ++i) {
-    threads.emplace_back(
+    threads.emplace(
         [&](uint64_t value) {
           while (!go.load()) {
             // wait until all threads are created, so they can
@@ -174,7 +142,7 @@ TEST(MetricsTest, test_histogram_concurrency_distributed) {
 
   go.store(true);
 
-  scope.fire();
+  threads.joinAll();
 
   ASSERT_EQ(h.load(0), ::numOpsPerThread);
   ASSERT_EQ(h.load(1), (::numThreads > 1 ? 1 : 0) * ::numOpsPerThread);

--- a/tests/Replication2/ModelChecker/ModelChecker.h
+++ b/tests/Replication2/ModelChecker/ModelChecker.h
@@ -21,11 +21,11 @@
 ////////////////////////////////////////////////////////////////////////////////
 #pragma once
 
-#include "Basics/debugging.h"
 #include "Basics/NumberOfCores.h"
 #include "Basics/SourceLocation.h"
+#include "Basics/ThreadGuard.h"
+#include "Basics/debugging.h"
 #include "Random/RandomGenerator.h"
-#include "Basics/ScopeGuard.h"
 
 #include <chrono>
 #include <cstdint>
@@ -584,18 +584,8 @@ struct RandomEnumerator {
     auto const numThreads = std::min<decltype(NumberOfCores::getValue() +
                                               randomParameters.iterations)>(
         NumberOfCores::getValue(), randomParameters.iterations);
-    auto threads = std::vector<std::thread>();
-    threads.reserve(numThreads);
-    arangodb::ScopeGuard scope{[&]() noexcept {
-      for (auto& t : threads) {
-        if (t.joinable()) {
-          try {
-            t.join();
-          } catch (...) {
-          }
-        }
-      }
-    }};
+
+    auto threads = ThreadGuard(numThreads);
 
     auto results = std::vector<std::optional<Result>>(numThreads, std::nullopt);
     auto iterationsLeftToDistribute = randomParameters.iterations;
@@ -605,8 +595,8 @@ struct RandomEnumerator {
       // threadSeed) given here are deterministic.
       auto const iters = iterationsLeftToDistribute / (numThreads - thrIdx);
       iterationsLeftToDistribute -= iters;
-      threads.emplace_back([&driver, initialObserver, initialState, iters,
-                            threadSeed = gen(), result = &results[thrIdx]] {
+      threads.emplace([&driver, initialObserver, initialState, iters,
+                       threadSeed = gen(), result = &results[thrIdx]] {
         // use an additional PRNG, so we can report the seed that can be
         // used to create the failed path
         auto gen = std::mt19937(threadSeed);
@@ -632,7 +622,7 @@ struct RandomEnumerator {
 
     TRI_ASSERT(iterationsLeftToDistribute == 0);
 
-    scope.fire();
+    threads.joinAll();
 
     for (auto const& result : results) {
       TRI_ASSERT(result.has_value());


### PR DESCRIPTION
### Scope & Purpose

In #16913 @MBkkt addressed an issue where threads created in a test were potentially not joined if an exception was thrown and the test scope was left.

This PR attempts to improve the suggested code a little bit by introducing a `ThreadGuard`, which is just a struct that wraps a vector of threads and joins them on request and on destruction.


- [X] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification


