### PR TITLE
SEARCH-322 fix empty nested condition

### DIFF
--- a/arangod/IResearch/IResearchFilterFactory.cpp
+++ b/arangod/IResearch/IResearchFilterFactory.cpp
@@ -239,15 +239,6 @@ void appendTerms(irs::by_phrase& filter, irs::string_ref value,
   }
 }
 
-FORCE_INLINE void appendExpression(irs::boolean_filter& filter,
-                                   aql::AstNode const& node,
-                                   QueryContext const& ctx,
-                                   FilterContext const& filterCtx) {
-  auto& exprFilter = filter.add<ByExpression>();
-  exprFilter.init(*ctx.ast, const_cast<aql::AstNode&>(node));
-  exprFilter.boost(filterCtx.boost);
-}
-
 Result byTerm(irs::by_term* filter, std::string&& name,
               ScopedAqlValue const& value, QueryContext const& ctx,
               FilterContext const& filterCtx) {
@@ -4076,6 +4067,13 @@ Result fromExpansion(irs::boolean_filter* filter, QueryContext const& ctx,
 
 namespace arangodb {
 namespace iresearch {
+
+void appendExpression(irs::boolean_filter& filter, aql::AstNode const& node,
+                      QueryContext const& ctx, FilterContext const& filterCtx) {
+  auto& exprFilter = filter.add<ByExpression>();
+  exprFilter.init(*ctx.ast, const_cast<aql::AstNode&>(node));
+  exprFilter.boost(filterCtx.boost);
+}
 
 Result fromExpression(irs::boolean_filter* filter, QueryContext const& ctx,
                       FilterContext const& filterCtx,

--- a/arangod/IResearch/IResearchFilterFactory.h
+++ b/arangod/IResearch/IResearchFilterFactory.h
@@ -87,5 +87,8 @@ struct FilterConstants {
   static constexpr int64_t DefaultStartsWithMinMatchCount{1};
 };
 
+void appendExpression(irs::boolean_filter& filter, aql::AstNode const& node,
+                      QueryContext const& ctx, FilterContext const& filterCtx);
+
 }  // namespace iresearch
 }  // namespace arangodb


### PR DESCRIPTION
### Scope & Purpose

Fixes handling of empty nested filter ( "[?]" ) Before it was silently converted to "all documents". that is wrong as this filter should return all documents having any array as a field. So now it is forced to ByExpression filter

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [x] Tests
  - [ ] **Regression tests**
  - [x] C++ **Unit tests**
  - [x] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: *(Please link PR)*
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [x] Enterprise PR: https://github.com/arangodb/enterprise/pull/1044
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

