### PR TITLE
[3.10] Introduce ThreadGuard

### DIFF
--- a/lib/Basics/ThreadGuard.h
+++ b/lib/Basics/ThreadGuard.h
@@ -1,0 +1,65 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2021-2021 ArangoDB GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Markus Pfeiffer
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include <thread>
+#include <vector>
+
+namespace arangodb {
+
+// A thread guard is a wrapper around a std::vector<std::thread> that
+// facilitates joining all joinable threads on destruction or when
+// the member function joinAll is called.
+struct ThreadGuard {
+  ThreadGuard() = default;
+  explicit ThreadGuard(size_t reserve) { threads.reserve(reserve); }
+  ~ThreadGuard() {
+    // Note that this might throw, and then we're in trouble;
+    // We accept this risk here, because if joining a thread
+    // inside the destructor of ThreadGuard fails, we're in a
+    // very bad place, regardless.
+    joinAll();
+  }
+
+  template<typename Function, typename... Args>
+  auto emplace(Function&& f, Args&&... args)
+      -> std::vector<std::thread>::reference {
+    return threads.emplace_back(std::forward<Function>(f),
+                                std::forward<Args>(args)...);
+  }
+
+  void joinAll() {
+    for (auto& t : threads) {
+      if (t.joinable()) {
+        t.join();
+      }
+    }
+    threads.clear();
+  }
+
+  [[nodiscard]] auto size() const -> size_t { return threads.size(); }
+
+  std::vector<std::thread> threads;
+};
+
+}  // namespace arangodb

--- a/tests/Fuerte/ConnectionConcurrentTest.cpp
+++ b/tests/Fuerte/ConnectionConcurrentTest.cpp
@@ -27,6 +27,9 @@
 
 #include "gtest/gtest.h"
 #include "ConnectionTest.h"
+#include "Basics/ThreadGuard.h"
+
+using namespace arangodb;
 
 // Tesuite checks the thread-safety properties of the connection
 // implementations. Try to send requests on the same connection object
@@ -72,11 +75,12 @@ TEST_P(ConcurrentConnectionF, ApiVersionParallel) {
     connections.push_back(createConnection());
   }
 
-  std::vector<std::thread> joins;
+  auto joins = ThreadGuard(threads());
+
   for (size_t t = 0; t < threads(); t++) {
     const size_t rep = repeat();
     wg.add((unsigned)rep);
-    joins.emplace_back([=] {
+    joins.emplace([&] {
       for (size_t i = 0; i < rep; i++) {
         auto request = fu::createRequest(fu::RestVerb::Get, "/_api/version");
         auto& conn = *connections[i % connections.size()];
@@ -91,9 +95,7 @@ TEST_P(ConcurrentConnectionF, ApiVersionParallel) {
       std::chrono::seconds(300)));  // wait for all threads to return
 
   // wait for all threads to end
-  for (std::thread& t : joins) {
-    t.join();
-  }
+  joins.joinAll();
 
   ASSERT_EQ(repeat() * threads(), counter);
 }
@@ -127,10 +129,11 @@ TEST_P(ConcurrentConnectionF, CreateDocumentsParallel) {
     connections.push_back(createConnection());
   }
 
-  std::vector<std::thread> joins;
+  auto joins = ThreadGuard(threads());
+
   for (size_t t = 0; t < threads(); t++) {
     wg.add(repeat());
-    joins.emplace_back([=, this] {
+    joins.emplace([=, this] {
       for (size_t i = 0; i < repeat(); i++) {
         auto request =
             fu::createRequest(fu::RestVerb::Post, "/_api/document/concurrent");
@@ -147,9 +150,7 @@ TEST_P(ConcurrentConnectionF, CreateDocumentsParallel) {
       std::chrono::seconds(300)));  // wait for all threads to return
 
   // wait for all threads to end
-  for (std::thread& t : joins) {
-    t.join();
-  }
+  joins.joinAll();
 
   ASSERT_EQ(repeat() * threads(), counter);
 }


### PR DESCRIPTION
This is a backport of #16918 

* Introduce ThreadGuard

A ThreadGuard is a struct that wraps a vector of threads and ensures
all threads are (tried to be) joined if the scope is left.

This is for example important if an excpetion is thrown and the scope
is left without completing the control flow.

Co-authored-by: Valery Mironov <valera.mironow@gmail.com>

**IMPORTANT**: when this PR gets merged, please also merge https://github.com/arangodb/arangodb/pull/16933!