### PR TITLE
add a way to generate stacktraces and coredumps via the debugger

### DIFF
--- a/js/client/modules/@arangodb/testutils/crash-utils.js
+++ b/js/client/modules/@arangodb/testutils/crash-utils.js
@@ -77,6 +77,7 @@ function analyzeCoreDump (instanceInfo, options, storeArangodPath, pid) {
   // send some line breaks in case of gdb wanting to paginate...
   command += 'printf \'\\n\\n\\n\\n' +
     'set pagination off\\n' +
+    'set confirm off\\n' +
     'set logging file ' + gdbOutputFile + '\\n' +
     'set logging on\\n' +
     'bt\\n' +
@@ -137,6 +138,7 @@ function generateCoreDumpGDB (instanceInfo, options, storeArangodPath, pid, gene
   // send some line breaks in case of gdb wanting to paginate...
   command += 'printf \'\\n\\n\\n\\n' +
     'set pagination off\\n' +
+    'set confirm off\\n' +
     'set logging file ' + gdbOutputFile + '\\n' +
     'set logging on\\n' +
     'bt\\n' +

--- a/js/client/modules/@arangodb/testutils/crash-utils.js
+++ b/js/client/modules/@arangodb/testutils/crash-utils.js
@@ -416,19 +416,17 @@ Crash analysis of: ` + JSON.stringify(instanceInfo.getStructure()) + '\n';
   return 'cdb ' + args.join(' ');
 }
 
-function generateCoreDumpWindows (instanceInfo, generateCoreDump) {
+function generateCoreDumpWindows (instanceInfo) {
   let cdbOutputFile = fs.getTempFile();
   let dbgCmds = [
     '.logopen ' + cdbOutputFile,
     '!analyze -v', // print verbose analysis
     'dv', // analyze local variables (if)
     '~*kb', // print all threads stack traces
+    `.dump /mFhtipcy ${instanceInfo.coreFilePattern}`, // write a compact dump file
+    '.kill', // terminate the debugged process
+    'q' // quit the debugger
   ];
-  if (generateCoreDump) {
-    dbgCmds.push(`.dump /mFhtipcy ${instanceInfo.coreFilePattern}`);
-  }
-  dbgCmds.push('.kill');
-  dbgCmds.push('q'); // quit the debugger
 
   const args = [
     '-p',
@@ -585,7 +583,7 @@ function generateCrashDump (binary, instanceInfo, options, checkStr) {
     if (!options.disableMonitor) {
       stopProcdump(options, instanceInfo, true);
     }
-    generateCoreDumpWindows(instanceInfo, generateCoreDump);
+    generateCoreDumpWindows(instanceInfo);
     instanceInfo.exitStatus = { status: 'TERMINATED'};
   } else if (platform === 'darwin') {
     generateCoreDumpMac(instanceInfo, options, binary, instanceInfo.pid, generateCoreDump);

--- a/js/client/modules/@arangodb/testutils/crash-utils.js
+++ b/js/client/modules/@arangodb/testutils/crash-utils.js
@@ -237,14 +237,14 @@ function generateCoreDumpMac (instanceInfo, options, storeArangodPath, pid) {
   for (var i = 0; i < 5; i++) {
     command += 'frame variable\\n up \\n';
   }
-  command += ' thread backtrace all\\n\';';
+  command += ` thread backtrace all\\n`;
+  command += ` process save-core /cores/core.${pid}\\n`;
+  command += ` kill\\n';`;
   command += 'sleep 10;';
-  command += `process save-core /cores/core.${pid};`;
-  command += 'kill;';
   command += 'echo quit;';
   command += 'sleep 2';
   command += ') | lldb ' + storeArangodPath;
-  command += ` --pid ${pid}`;
+  command += ` --attach-pid ${pid}`;
   command += ' > ' + lldbOutputFile + ' 2>&1';
   const args = ['-c', command];
   print(JSON.stringify(args));

--- a/js/client/modules/@arangodb/testutils/crash-utils.js
+++ b/js/client/modules/@arangodb/testutils/crash-utils.js
@@ -575,8 +575,8 @@ function generateCrashDump (binary, instanceInfo, options, checkStr) {
   const stats = statisticsExternal(instanceInfo.pid);
   // picking some arbitrary number of a running arangod doubling it
   const generateCoreDump = (
-    stats.virtualSize < 3100000 &&
-    stats.residentSize < 1400000
+    stats.virtualSize  < 310000000 &&
+    stats.residentSize < 140000000
   ) || stats.virtualSize === 0;
   if (options.test !== undefined) {
     print(CYAN + this.name + " - in single test mode, hard killing." + RESET);

--- a/js/client/modules/@arangodb/testutils/crash-utils.js
+++ b/js/client/modules/@arangodb/testutils/crash-utils.js
@@ -149,7 +149,7 @@ function generateCoreDumpGDB (instanceInfo, options, storeArangodPath, pid, gene
   command += 'sleep 10;';
   command += 'echo quit;';
   command += 'sleep 2';
-  command += ') | gdb ' + storeArangodPath + ' ';
+  command += ') | gdb ' + storeArangodPath + ' -p ' + instanceInfo.pid;
 
 
   const args = ['-c', command];

--- a/js/client/modules/@arangodb/testutils/crash-utils.js
+++ b/js/client/modules/@arangodb/testutils/crash-utils.js
@@ -389,10 +389,9 @@ function analyzeCoreDumpWindows (instanceInfo) {
 
   const dbgCmds = [
     '.logopen ' + cdbOutputFile,
-    'kp', // print curren threads backtrace with arguments
-    '~*kb', // print all threads stack traces
-    'dv', // analyze local variables (if)
     '!analyze -v', // print verbose analysis
+    'dv', // analyze local variables (if)
+    '~*kb', // print all threads stack traces
     'q' // quit the debugger
   ];
 
@@ -421,13 +420,12 @@ function generateCoreDumpWindows (instanceInfo, generateCoreDump) {
   let cdbOutputFile = fs.getTempFile();
   let dbgCmds = [
     '.logopen ' + cdbOutputFile,
-    'kp', // print curren threads backtrace with arguments
-    '~*kb', // print all threads stack traces
-    'dv', // analyze local variables (if)
     '!analyze -v', // print verbose analysis
+    'dv', // analyze local variables (if)
+    '~*kb', // print all threads stack traces
   ];
   if (generateCoreDump) {
-    dbgCmds.push(`.dump ${instanceInfo.coreFilePattern}`);
+    dbgCmds.push(`.dump /mFhtipcy ${instanceInfo.coreFilePattern}`);
   }
   dbgCmds.push('.kill');
   dbgCmds.push('q'); // quit the debugger

--- a/js/client/modules/@arangodb/testutils/instance.js
+++ b/js/client/modules/@arangodb/testutils/instance.js
@@ -815,23 +815,12 @@ class instance {
       print(agencyReply);
     }
   }
-  killWithCoreDump () {
+  killWithCoreDump (message) {
     if (this.pid === null) {
       print(RED + Date() + this.name + " is not running, doesn't have a PID" + RESET);
       return;
     }
-    if (platform.substr(0, 3) === 'win') {
-      if (!this.options.disableMonitor) {
-        crashUtils.stopProcdump (this.options, this, true);
-      }
-      crashUtils.runProcdump (this.options, this, this.coreDirectory, this.pid, true);
-    }
-    if (this.options.test !== undefined) {
-      print(CYAN + this.name + " - in single test mode, hard killing." + RESET);
-      this.exitStatus = killExternal(this.pid, termSignal);
-    } else {
-      this.exitStatus = killExternal(this.pid, abortSignal);
-    }
+    crashUtils.generateCrashDump(pu.ARANGOD_BIN, this.instanceInfo, this.options, message);
   }
   // //////////////////////////////////////////////////////////////////////////////
   // / @brief commands a server to shut down via webcall
@@ -858,8 +847,7 @@ class instance {
         (this.exitStatus.status === 'RUNNING')) {
       if (forceTerminate) {
         let sockStat = this.getSockStat("Force killing - sockstat before: ");
-        this.killWithCoreDump();
-        this.analyzeServerCrash('shutdown timeout; instance forcefully KILLED because of fatal timeout in testrun ' + sockStat);
+        this.killWithCoreDump('shutdown timeout; instance forcefully KILLED because of fatal timeout in testrun ' + sockStat);
         this.pid = null;
       } else if (this.options.useKillExternal) {
         let sockStat = this.getSockStat("Shutdown by kill - sockstat before: ");
@@ -978,11 +966,9 @@ class instance {
               ' after ' + timeout + 's grace period; marking crashy.');
         this.serverCrashedLocal = true;
         counters.shutdownSuccess = false;
-        this.killWithCoreDump();
-        this.analyzeServerCrash('shutdown timeout; instance "' +
-                                   this.name +
-                                   '" forcefully KILLED after 60s - ' +
-                                   this.exitStatus.signal);
+        this.killWithCoreDump('shutdown timeout; instance "' +
+                              this.name +
+                              '" forcefully KILLED after 60s');
         if (!this.isAgent()) {
           counters.nonAgenciesCount--;
         }

--- a/js/client/modules/@arangodb/testutils/instance.js
+++ b/js/client/modules/@arangodb/testutils/instance.js
@@ -694,6 +694,17 @@ class instance {
     this.url = pu.endpointToURL(this.endpoint);
   };
 
+  waitForExitAfterDebugKill() {
+    // Crashutils debugger kills our instance, but we neet to get
+    // testing.js sapwned-PID-monitoring adjusted.
+    print("waiting for exit - " + this.pid);
+    try {
+      print(statusExternal(this.pid, true));
+    } catch(ex) {
+      print(ex);
+    }
+    print('done');
+  }
   waitForExit() {
     if (this.pid === null) {
       this.exitStatus = null;

--- a/js/client/modules/@arangodb/testutils/instance.js
+++ b/js/client/modules/@arangodb/testutils/instance.js
@@ -820,7 +820,7 @@ class instance {
       print(RED + Date() + this.name + " is not running, doesn't have a PID" + RESET);
       return;
     }
-    crashUtils.generateCrashDump(pu.ARANGOD_BIN, this.instanceInfo, this.options, message);
+    crashUtils.generateCrashDump(pu.ARANGOD_BIN, this, this.options, message);
   }
   // //////////////////////////////////////////////////////////////////////////////
   // / @brief commands a server to shut down via webcall

--- a/tests/test-definitions.txt
+++ b/tests/test-definitions.txt
@@ -21,9 +21,9 @@ shell_replication wweight=2 single
 http_replication weight=500 wweight=2 single
 
 # Misc single server tests
-active_failover single
-agency weight=350 wweight=2 single -- --dumpAgencyOnError true
-agency-restart weight=250 single
+active_failover wweight=3 single
+agency weight=350 wweight=3 single -- --dumpAgencyOnError true
+agency-restart weight=250 wweight=3 single
 arangobench wweight=2 weight=1000 single
 arangosh single
 authentication weight=1000 single


### PR DESCRIPTION
### Scope & Purpose

so far we would use the default coredump generation process in order to generate coredumps. 
This 
- doesn't always work on mac
- generates coredumps regardless of the expected filesize
- if one wouldn't generate the coredump, all information would be lost hence attach the debugger to the process

- [x] :pizza: New feature
- [x] Test infrastructure