### PR TITLE
try to fix issues reported by cppcheck (#16879)

### DIFF
--- a/arangod/IResearch/GeoAnalyzer.cpp
+++ b/arangod/IResearch/GeoAnalyzer.cpp
@@ -70,7 +70,7 @@ using GeoJSONTypeEnumDeserializer =
 
 struct GeoOptionsValidator {
   std::optional<deserialize_error> operator()(GeoOptions const& opts) const {
-    if (opts.minLevel < 0 || opts.maxCells < 0 || opts.maxCells < 0) {
+    if (opts.minLevel < 0 || opts.maxLevel < 0 || opts.maxCells < 0) {
       return deserialize_error{
           "'minLevel', 'maxLevel', 'maxCells' must be a positive integer"};
     }

--- a/arangod/RestServer/EnvironmentFeature.cpp
+++ b/arangod/RestServer/EnvironmentFeature.cpp
@@ -35,6 +35,7 @@
 #include "Basics/PhysicalMemory.h"
 #include "Basics/Result.h"
 #include "Basics/StringUtils.h"
+#include "Basics/application-exit.h"
 #include "Basics/operating-system.h"
 #include "Basics/process-utils.h"
 #include "Logger/LogMacros.h"
@@ -177,10 +178,11 @@ void EnvironmentFeature::prepare() {
           }
         }
         while (end < cpuAlignment.size()) {
-          ++end;
           if (cpuAlignment[end] < '0' || cpuAlignment[end] > '9') {
+            ++end;
             break;
           }
+          ++end;
         }
 
         int64_t alignment =

--- a/arangod/Utils/UrlHelper.cpp
+++ b/arangod/Utils/UrlHelper.cpp
@@ -38,18 +38,20 @@ std::ostream& Query::toStream(std::ostream& ostream) const {
   struct output {
     std::ostream& ostream;
 
-    std::ostream& operator()(QueryString const& queryString) {
-      return ostream << queryString.value();
+    void operator()(QueryString const& queryString) {
+      ostream << queryString.value();
     }
-    std::ostream& operator()(QueryParameters const& queryParameters) {
-      return ostream << queryParameters;
+    void operator()(QueryParameters const& queryParameters) {
+      ostream << queryParameters;
     }
   };
-  return std::visit(output{ostream}, _content);
+  std::visit(output{ostream}, _content);
+  return ostream;
 }
 
-Query::Query(QueryString queryString) : _content(queryString) {}
-Query::Query(QueryParameters queryParameters) : _content(queryParameters) {}
+Query::Query(QueryString queryString) : _content(std::move(queryString)) {}
+Query::Query(QueryParameters queryParameters)
+    : _content(std::move(queryParameters)) {}
 
 bool Query::empty() const noexcept {
   struct output {

--- a/lib/VPackDeserializer/parameter-list.h
+++ b/lib/VPackDeserializer/parameter-list.h
@@ -373,7 +373,8 @@ struct parameter_list_executor<I, K, parameter_list<P, Ps...>, H, FullList> {
 
     // expect_value does not have a value
     if constexpr (executor::has_value) {
-      auto result = executor::unpack(s, hints, std::forward<C>(ctx));
+      auto result = executor::unpack(
+          s, hints, std::as_const<std::remove_reference_t<C>>(ctx));
       if (result) {
         auto& [value, read_value] = result.get();
         std::get<I>(t) = value;
@@ -393,7 +394,8 @@ struct parameter_list_executor<I, K, parameter_list<P, Ps...>, H, FullList> {
           "during read of "s + std::to_string(I) + "th parameters value (" +
           P::name + ")")};
     } else {
-      auto result = executor::unpack(s, hints, std::forward<C>(ctx));
+      auto result = executor::unpack(
+          s, hints, std::as_const<std::remove_reference_t<C>>(ctx));
       if (result) {
         return parameter_list_executor<I, K + 1, parameter_list<Ps...>, H,
                                        FullList>::unpack(t, s, hints,


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/16879

Fix issues uncovered by cppcheck:

```
12:21:48 duplicateExpression: Same expression "opts.maxCells<0" found multiple times in chain of "||" operators.
12:21:48     arangod/IResearch/GeoAnalyzer.cpp:73
12:21:48 
12:21:48 accessForwarded: Access of forwarded variable "ctx".
12:21:48     lib/VPackDeserializer/parameter-list.h:400
12:21:48     lib/VPackDeserializer/parameter-list.h:396
12:21:48 
12:21:48 returnTempReference: Reference to temporary returned.
12:21:48     arangod/Utils/UrlHelper.cpp:48
12:21:48 
12:21:48 containerOutOfBounds: Either the condition "end<cpuAlignment.size()" is redundant or "end" can have the value cpuAlignment.size(). Expression "cpuAlignment[end]" cause access out of bounds.
12:21:48     arangod/RestServer/EnvironmentFeature.cpp:181
12:21:48     arangod/RestServer/EnvironmentFeature.cpp:180
12:21:48     arangod/RestServer/EnvironmentFeature.cpp:179
```

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [x] Backports
  - [x] Backport for 3.10: this PR
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 