### PR TITLE
fix potential data races in dump/restore queue (#16775)

### DIFF
--- a/client-tools/Dump/DumpFeature.cpp
+++ b/client-tools/Dump/DumpFeature.cpp
@@ -1104,8 +1104,10 @@ Result DumpFeature::storeViews(VPackSlice const& views) const {
 
 void DumpFeature::reportError(Result const& error) {
   try {
-    MUTEX_LOCKER(lock, _workerErrorLock);
-    _workerErrors.emplace(error);
+    {
+      MUTEX_LOCKER(lock, _workerErrorLock);
+      _workerErrors.emplace_back(error);
+    }
     _clientTaskQueue.clearQueue();
   } catch (...) {
   }

--- a/client-tools/Dump/DumpFeature.h
+++ b/client-tools/Dump/DumpFeature.h
@@ -36,6 +36,7 @@
 
 #include <memory>
 #include <string>
+#include <vector>
 
 namespace arangodb {
 namespace httpclient {
@@ -153,7 +154,7 @@ class DumpFeature final : public ArangoDumpFeature {
   Options _options;
   Stats _stats;
   Mutex _workerErrorLock;
-  std::queue<Result> _workerErrors;
+  std::vector<Result> _workerErrors;
   std::unique_ptr<maskings::Maskings> _maskings;
 
   Result runClusterDump(httpclient::SimpleHttpClient& client,

--- a/client-tools/Restore/RestoreFeature.cpp
+++ b/client-tools/Restore/RestoreFeature.cpp
@@ -37,6 +37,8 @@
 
 #include "ApplicationFeatures/ApplicationServer.h"
 #include "Basics/FileUtils.h"
+#include "Basics/Mutex.h"
+#include "Basics/MutexLocker.h"
 #include "Basics/NumberOfCores.h"
 #include "Basics/Result.h"
 #include "Basics/StaticStrings.h"
@@ -2256,8 +2258,10 @@ ClientTaskQueue<RestoreFeature::RestoreJob>& RestoreFeature::taskQueue() {
 
 void RestoreFeature::reportError(Result const& error) {
   try {
-    MUTEX_LOCKER(lock, _workerErrorLock);
-    _workerErrors.emplace(error);
+    {
+      MUTEX_LOCKER(lock, _workerErrorLock);
+      _workerErrors.emplace_back(error);
+    }
     _clientTaskQueue.clearQueue();
   } catch (...) {
   }

--- a/client-tools/Restore/RestoreFeature.h
+++ b/client-tools/Restore/RestoreFeature.h
@@ -256,7 +256,7 @@ class RestoreFeature final : public ArangoRestoreFeature {
   Options _options;
   Stats _stats;
   Mutex mutable _workerErrorLock;
-  std::queue<Result> _workerErrors;
+  std::vector<Result> _workerErrors;
 
   Mutex _buffersLock;
   std::vector<std::unique_ptr<basics::StringBuffer>> _buffers;


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/16775

Fix potential data races in task queue used by arangodump & arangorestore.
There could have been a race between the main arangodump/arangorestore thread checking if all jobs have been finished, and a queue worker thread popping a job from the job queue and only afterwards reporting as busy.

Tries to fix https://jenkins01.arangodb.biz/job/arangodb-ANY-linux-san.x86-64/1228/EDITION=enterprise,SAN_MODE=TSan,STORAGE_ENGINE=rocksdb,TEST_SUITE=single,limit=linux&&test&&x86-64/artifact/tsan.log.arangorestore.139376.log

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [x] Backports
  - [x] Backport for 3.10: this PR
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
