### PR TITLE
[3.10] Fix stack-use-after-scope in fuertetest

### DIFF
--- a/tests/Fuerte/ConnectionConcurrentTest.cpp
+++ b/tests/Fuerte/ConnectionConcurrentTest.cpp
@@ -77,10 +77,10 @@ TEST_P(ConcurrentConnectionF, ApiVersionParallel) {
 
   auto joins = ThreadGuard(threads());
 
+  const size_t rep = repeat();
   for (size_t t = 0; t < threads(); t++) {
-    const size_t rep = repeat();
     wg.add((unsigned)rep);
-    joins.emplace([&] {
+    joins.emplace([&connections, rep, &cb] {
       for (size_t i = 0; i < rep; i++) {
         auto request = fu::createRequest(fu::RestVerb::Get, "/_api/version");
         auto& conn = *connections[i % connections.size()];


### PR DESCRIPTION
Backport of #16932 to be merged after #16926 

When introducing the ThreadGuard I changed a lambda capture from [=] to
[&] overlooking an implicitly captured variable.

This patch changes the code to explicitly capture variables.

### Scope & Purpose

*(Please describe the changes in this PR for reviewers, motivation, rationale - **mandatory**)*

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
