### PR TITLE
fix extracing _id sub attribute with projections

### DIFF
--- a/arangod/Aql/Projections.cpp
+++ b/arangod/Aql/Projections.cpp
@@ -150,6 +150,7 @@ void Projections::toVelocyPackFromDocument(
       TRI_ASSERT(it.path.size() == 1);
       b.add(it.path[0], VPackValue(transaction::helpers::extractIdString(
                             trxPtr->resolver(), slice, slice)));
+
     } else if (it.type == AttributeNamePath::Type::KeyAttribute) {
       // projection for "_key"
       TRI_ASSERT(it.path.size() == 1);
@@ -186,10 +187,12 @@ void Projections::toVelocyPackFromDocument(
       TRI_ASSERT(it.path.size() > 1);
       size_t level = 0;
       VPackSlice found = slice;
+      VPackSlice prev;
       size_t const n = it.path.size();
       while (level < n) {
         // look up attribute/sub-attribute
         found = found.get(it.path[level]);
+
         if (found.isNone()) {
           // not found. we can exit early
           b.add(it.path[level], VPackValue(VPackValueType::Null));
@@ -203,13 +206,20 @@ void Projections::toVelocyPackFromDocument(
         }
         if (level == n - 1) {
           // target value
-          b.add(it.path[level], found);
+          if (found.isCustom()) {
+            b.add(it.path[level],
+                  VPackValue(transaction::helpers::extractIdString(
+                      trxPtr->resolver(), found, prev)));
+          } else {
+            b.add(it.path[level], found);
+          }
           break;
         }
         // recurse into sub-attribute object
         TRI_ASSERT(level < n - 1);
         b.add(it.path[level], VPackValue(VPackValueType::Object));
         ++level;
+        prev = found;
       }
 
       // close all that we opened ourselves, so that the next projection can

--- a/tests/js/server/aql/aql-optimizer-rule-reduce-extraction-to-projection.js
+++ b/tests/js/server/aql/aql-optimizer-rule-reduce-extraction-to-projection.js
@@ -333,7 +333,7 @@ function optimizerRuleTestSuite () {
 
     testSearch366: function () {
       c.truncate();
-      let doc = c.insert({ i:0 }); 
+      let doc = c.insert({ i: 0 }); 
       // store document as sub-document
       db._query("FOR doc IN @@cn UPDATE doc WITH { sub: doc } IN @@cn", { "@cn": cn }); 
 
@@ -352,6 +352,35 @@ function optimizerRuleTestSuite () {
       results = db._query("FOR doc IN @@cn RETURN doc.sub.i", { "@cn": cn }).toArray();
       assertEqual(1, results.length);
       assertEqual(0, results[0]);
+
+      c.truncate();
+      doc = c.insert({ i: 0 }); 
+      // store document as sub-document
+      db._query("FOR doc1 IN @@cn FOR doc2 IN @@cn INSERT { k: { kk: doc1, ll: { dd: doc2 } } } IN @@cn", { "@cn": cn }); 
+
+      results = db._query("FOR doc IN @@cn FILTER doc.i != 0 RETURN doc.k.kk._id", { "@cn": cn }).toArray();
+      assertEqual(1, results.length);
+      assertEqual(doc._id, results[0]);
+      
+      results = db._query("FOR doc IN @@cn FILTER doc.i != 0 RETURN doc.k.kk._key", { "@cn": cn }).toArray();
+      assertEqual(1, results.length);
+      assertEqual(doc._key, results[0]);
+      
+      results = db._query("FOR doc IN @@cn FILTER doc.i != 0 RETURN doc.k.kk._rev", { "@cn": cn }).toArray();
+      assertEqual(1, results.length);
+      assertEqual(doc._rev, results[0]);
+      
+      results = db._query("FOR doc IN @@cn FILTER doc.i != 0 RETURN doc.k.ll.dd._id", { "@cn": cn }).toArray();
+      assertEqual(1, results.length);
+      assertEqual(doc._id, results[0]);
+      
+      results = db._query("FOR doc IN @@cn FILTER doc.i != 0 RETURN doc.k.ll.dd._key", { "@cn": cn }).toArray();
+      assertEqual(1, results.length);
+      assertEqual(doc._key, results[0]);
+      
+      results = db._query("FOR doc IN @@cn FILTER doc.i != 0 RETURN doc.k.ll.dd._rev", { "@cn": cn }).toArray();
+      assertEqual(1, results.length);
+      assertEqual(doc._rev, results[0]);
     },
 
   };

--- a/tests/js/server/aql/aql-optimizer-rule-reduce-extraction-to-projection.js
+++ b/tests/js/server/aql/aql-optimizer-rule-reduce-extraction-to-projection.js
@@ -331,6 +331,29 @@ function optimizerRuleTestSuite () {
       assertEqual({ resultStatus: "ok", requestStatus: "ok", count: 1 }, result[1]);
     },
 
+    testSearch366: function () {
+      c.truncate();
+      let doc = c.insert({ i:0 }); 
+      // store document as sub-document
+      db._query("FOR doc IN @@cn UPDATE doc WITH { sub: doc } IN @@cn", { "@cn": cn }); 
+
+      let results = db._query("FOR doc IN @@cn RETURN doc.sub._id", { "@cn": cn }).toArray();
+      assertEqual(1, results.length);
+      assertEqual(doc._id, results[0]);
+      
+      results = db._query("FOR doc IN @@cn RETURN doc.sub._key", { "@cn": cn }).toArray();
+      assertEqual(1, results.length);
+      assertEqual(doc._key, results[0]);
+      
+      results = db._query("FOR doc IN @@cn RETURN doc.sub._rev", { "@cn": cn }).toArray();
+      assertEqual(1, results.length);
+      assertEqual(doc._rev, results[0]);
+      
+      results = db._query("FOR doc IN @@cn RETURN doc.sub.i", { "@cn": cn }).toArray();
+      assertEqual(1, results.length);
+      assertEqual(0, results[0]);
+    },
+
   };
 }
 


### PR DESCRIPTION
### Scope & Purpose

Fix extracing `_id` sub-attribute with projections.
Fixes https://arangodb.atlassian.net/browse/SEARCH-366

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [x] Backports
  - [x] Backport for 3.10: https://github.com/arangodb/arangodb/pull/16936
  - [x] Backport for 3.9: https://github.com/arangodb/arangodb/pull/16937
  - [x] Backport for 3.8: https://github.com/arangodb/arangodb/pull/16938

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [x] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/SEARCH-366
- [ ] Design document: 