### PR TITLE
fix extracing _id sub attribute with projections

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 v3.9.3 (XXXX-XX-XX)
 -------------------
 
+* Fixed SEARCH-366: Fixed extracting sub-attributes using projections for
+  the `_id` attribute (e.g. `RETURN doc.sub._id`).
+
 * Disable optimization rule to avoid crash (BTS-951).
 
 * Fix SEARCH-350: Crash during consolidation.

--- a/tests/js/server/aql/aql-optimizer-rule-reduce-extraction-to-projection.js
+++ b/tests/js/server/aql/aql-optimizer-rule-reduce-extraction-to-projection.js
@@ -333,7 +333,7 @@ function optimizerRuleTestSuite () {
 
     testSearch366: function () {
       c.truncate();
-      let doc = c.insert({ i:0 }); 
+      let doc = c.insert({ i: 0 }); 
       // store document as sub-document
       db._query("FOR doc IN @@cn UPDATE doc WITH { sub: doc } IN @@cn", { "@cn": cn }); 
 
@@ -352,6 +352,35 @@ function optimizerRuleTestSuite () {
       results = db._query("FOR doc IN @@cn RETURN doc.sub.i", { "@cn": cn }).toArray();
       assertEqual(1, results.length);
       assertEqual(0, results[0]);
+
+      c.truncate();
+      doc = c.insert({ i: 0 }); 
+      // store document as sub-document
+      db._query("FOR doc1 IN @@cn FOR doc2 IN @@cn INSERT { k: { kk: doc1, ll: { dd: doc2 } } } IN @@cn", { "@cn": cn }); 
+
+      results = db._query("FOR doc IN @@cn FILTER doc.i != 0 RETURN doc.k.kk._id", { "@cn": cn }).toArray();
+      assertEqual(1, results.length);
+      assertEqual(doc._id, results[0]);
+      
+      results = db._query("FOR doc IN @@cn FILTER doc.i != 0 RETURN doc.k.kk._key", { "@cn": cn }).toArray();
+      assertEqual(1, results.length);
+      assertEqual(doc._key, results[0]);
+      
+      results = db._query("FOR doc IN @@cn FILTER doc.i != 0 RETURN doc.k.kk._rev", { "@cn": cn }).toArray();
+      assertEqual(1, results.length);
+      assertEqual(doc._rev, results[0]);
+      
+      results = db._query("FOR doc IN @@cn FILTER doc.i != 0 RETURN doc.k.ll.dd._id", { "@cn": cn }).toArray();
+      assertEqual(1, results.length);
+      assertEqual(doc._id, results[0]);
+      
+      results = db._query("FOR doc IN @@cn FILTER doc.i != 0 RETURN doc.k.ll.dd._key", { "@cn": cn }).toArray();
+      assertEqual(1, results.length);
+      assertEqual(doc._key, results[0]);
+      
+      results = db._query("FOR doc IN @@cn FILTER doc.i != 0 RETURN doc.k.ll.dd._rev", { "@cn": cn }).toArray();
+      assertEqual(1, results.length);
+      assertEqual(doc._rev, results[0]);
     },
 
   };

--- a/tests/js/server/aql/aql-optimizer-rule-reduce-extraction-to-projection.js
+++ b/tests/js/server/aql/aql-optimizer-rule-reduce-extraction-to-projection.js
@@ -331,6 +331,29 @@ function optimizerRuleTestSuite () {
       assertEqual({ resultStatus: "ok", requestStatus: "ok", count: 1 }, result[1]);
     },
 
+    testSearch366: function () {
+      c.truncate();
+      let doc = c.insert({ i:0 }); 
+      // store document as sub-document
+      db._query("FOR doc IN @@cn UPDATE doc WITH { sub: doc } IN @@cn", { "@cn": cn }); 
+
+      let results = db._query("FOR doc IN @@cn RETURN doc.sub._id", { "@cn": cn }).toArray();
+      assertEqual(1, results.length);
+      assertEqual(doc._id, results[0]);
+      
+      results = db._query("FOR doc IN @@cn RETURN doc.sub._key", { "@cn": cn }).toArray();
+      assertEqual(1, results.length);
+      assertEqual(doc._key, results[0]);
+      
+      results = db._query("FOR doc IN @@cn RETURN doc.sub._rev", { "@cn": cn }).toArray();
+      assertEqual(1, results.length);
+      assertEqual(doc._rev, results[0]);
+      
+      results = db._query("FOR doc IN @@cn RETURN doc.sub.i", { "@cn": cn }).toArray();
+      assertEqual(1, results.length);
+      assertEqual(0, results[0]);
+    },
+
   };
 }
 


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/16935

Fix extracing `_id` sub-attribute with projections.
Fixes https://arangodb.atlassian.net/browse/SEARCH-366

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [x] Backports
  - [x] Backport for 3.10: https://github.com/arangodb/arangodb/pull/16936
  - [x] Backport for 3.9: this PR
  - [x] Backport for 3.8: https://github.com/arangodb/arangodb/pull/16938

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [x] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/SEARCH-366
- [ ] Design document: 