### PR TITLE
[PREGEL] Use future to prepare global super step

### DIFF
--- a/arangod/Pregel/CMakeLists.txt
+++ b/arangod/Pregel/CMakeLists.txt
@@ -10,7 +10,8 @@ add_library(arango_pregel STATIC
   PregelMetrics.cpp
   Reports.cpp
   Reports.h
-  Utils.cpp)
+  Utils.cpp
+  NetworkConnection.cpp)
 
 target_link_libraries(arango_pregel
 	arango

--- a/arangod/Pregel/Conductor/CMakeLists.txt
+++ b/arangod/Pregel/Conductor/CMakeLists.txt
@@ -1,4 +1,6 @@
 target_sources(arango_pregel PRIVATE
-	Conductor.cpp)
+  Conductor.cpp
+  SingleServerWorkerApi.cpp
+  ClusterWorkerApi.cpp)
 
 add_subdirectory(States)

--- a/arangod/Pregel/Conductor/ClusterWorkerApi.cpp
+++ b/arangod/Pregel/Conductor/ClusterWorkerApi.cpp
@@ -1,0 +1,17 @@
+#include "ClusterWorkerApi.h"
+
+#include "Pregel/WorkerConductorMessages.h"
+#include "Pregel/NetworkConnection.h"
+
+using namespace arangodb::pregel::conductor;
+
+[[nodiscard]] auto ClusterWorkerApi::loadGraph(LoadGraph const& graph)
+    -> futures::Future<ResultT<GraphLoaded>> {
+  return _connection.post<GraphLoaded>(graph);
+}
+
+[[nodiscard]] auto ClusterWorkerApi::prepareGlobalSuperStep(
+    PrepareGlobalSuperStep const& data)
+    -> futures::Future<ResultT<GlobalSuperStepPrepared>> {
+  return _connection.post<GlobalSuperStepPrepared>(data);
+}

--- a/arangod/Pregel/Conductor/ClusterWorkerApi.h
+++ b/arangod/Pregel/Conductor/ClusterWorkerApi.h
@@ -1,0 +1,22 @@
+#include "Cluster/ClusterTypes.h"
+#include "Futures/Future.h"
+#include "Pregel/ExecutionNumber.h"
+#include "Pregel/WorkerConductorMessages.h"
+#include "Pregel/WorkerInterface.h"
+#include "Utils/DatabaseGuard.h"
+#include "Pregel/NetworkConnection.h"
+
+namespace arangodb::pregel::conductor {
+
+struct ClusterWorkerApi : NewIWorker {
+  ClusterWorkerApi(Connection network) : _connection{std::move(network)} {}
+  [[nodiscard]] auto loadGraph(LoadGraph const& graph)
+      -> futures::Future<ResultT<GraphLoaded>> override;
+  [[nodiscard]] auto prepareGlobalSuperStep(PrepareGlobalSuperStep const& data)
+      -> futures::Future<ResultT<GlobalSuperStepPrepared>> override;
+
+ private:
+  Connection _connection;
+};
+
+}  // namespace arangodb::pregel::conductor

--- a/arangod/Pregel/Conductor/SingleServerWorkerApi.cpp
+++ b/arangod/Pregel/Conductor/SingleServerWorkerApi.cpp
@@ -1,0 +1,41 @@
+#include "SingleServerWorkerApi.h"
+
+#include "Pregel/AlgoRegistry.h"
+#include "Pregel/PregelFeature.h"
+#include "Pregel/Worker/Worker.h"  // TODO include WorkerInterface instead when future refactoring is finished
+#include "velocypack/Builder.h"
+
+using namespace arangodb::pregel::conductor;
+
+[[nodiscard]] auto SingleServerWorkerApi::loadGraph(LoadGraph const& graph)
+    -> futures::Future<ResultT<GraphLoaded>> {
+  if (_feature.isStopping()) {
+    return Result{TRI_ERROR_SHUTTING_DOWN};
+  }
+
+  std::shared_ptr<IWorker> worker = _feature.worker(_executionNumber);
+  if (worker) {
+    return Result{TRI_ERROR_INTERNAL,
+                  "a worker with this execution number already exists."};
+  }
+
+  try {
+    auto created = AlgoRegistry::createWorker(_vocbaseGuard.database(),
+                                              graph.details.slice(), _feature);
+    TRI_ASSERT(created.get() != nullptr);
+    _feature.addWorker(std::move(created), _executionNumber);
+    worker = _feature.worker(_executionNumber);
+    TRI_ASSERT(worker);
+    return worker->loadGraph(graph);
+  } catch (basics::Exception& e) {
+    return Result{e.code(), e.message()};
+  }
+}
+
+[[nodiscard]] auto SingleServerWorkerApi::prepareGlobalSuperStep(
+    PrepareGlobalSuperStep const& message)
+    -> futures::Future<ResultT<GlobalSuperStepPrepared>> {
+  VPackBuilder out;
+  auto worker = _feature.worker(_executionNumber);
+  return worker->prepareGlobalSuperStep(message);
+}

--- a/arangod/Pregel/Conductor/SingleServerWorkerApi.h
+++ b/arangod/Pregel/Conductor/SingleServerWorkerApi.h
@@ -1,0 +1,29 @@
+#include "Cluster/ClusterTypes.h"
+#include "Futures/Future.h"
+#include "Pregel/ExecutionNumber.h"
+#include "Pregel/WorkerConductorMessages.h"
+#include "Pregel/WorkerInterface.h"
+#include "Utils/DatabaseGuard.h"
+
+struct TRI_vocbase_t;
+
+namespace arangodb::pregel::conductor {
+
+struct SingleServerWorkerApi : NewIWorker {
+  SingleServerWorkerApi(ExecutionNumber executionNumber, PregelFeature& feature,
+                        TRI_vocbase_t& vocbase)
+      : _executionNumber{std::move(executionNumber)},
+        _feature{feature},
+        _vocbaseGuard{vocbase} {}
+  [[nodiscard]] auto loadGraph(LoadGraph const& graph)
+      -> futures::Future<ResultT<GraphLoaded>> override;
+  [[nodiscard]] auto prepareGlobalSuperStep(PrepareGlobalSuperStep const& data)
+      -> futures::Future<ResultT<GlobalSuperStepPrepared>> override;
+
+ private:
+  ExecutionNumber _executionNumber;
+  PregelFeature& _feature;
+  const DatabaseGuard _vocbaseGuard;
+};
+
+}  // namespace arangodb::pregel::conductor

--- a/arangod/Pregel/Conductor/States/LoadingState.cpp
+++ b/arangod/Pregel/Conductor/States/LoadingState.cpp
@@ -34,7 +34,6 @@ auto Loading::run() -> void {
             conductor.changeState(StateType::Canceled);
           }
           auto graphLoaded = result.get().get();
-          auto sender = graphLoaded.senderId;
           conductor._totalVerticesCount += graphLoaded.vertexCount;
           conductor._totalEdgesCount += graphLoaded.edgeCount;
         }

--- a/arangod/Pregel/NetworkConnection.cpp
+++ b/arangod/Pregel/NetworkConnection.cpp
@@ -1,0 +1,71 @@
+#include "NetworkConnection.h"
+
+#include "Network/NetworkFeature.h"
+#include "Network/Methods.h"
+#include "Pregel/WorkerConductorMessages.h"
+#include "VocBase/voc-types.h"
+#include "VocBase/vocbase.h"
+#include "ApplicationFeatures/ApplicationServer.h"
+
+using namespace arangodb::pregel;
+
+Connection::Connection(ServerID destinationId, std::string baseUrl,
+                       network::RequestOptions requestOptions,
+                       network::ConnectionPool* connectionPool)
+    : _destinationId{std::move(destinationId)},
+      _baseUrl{std::move(baseUrl)},
+      _requestOptions{std::move(requestOptions)},
+      _connectionPool{connectionPool} {}
+auto Connection::create(ServerID const& destinationId,
+                        std::string const& baseUrl, TRI_vocbase_t& vocbase)
+    -> Connection {
+  network::RequestOptions reqOpts;
+  reqOpts.timeout = network::Timeout(5.0 * 60.0);
+  reqOpts.database = vocbase.name();
+  auto const& nf = vocbase.server().getFeature<NetworkFeature>();
+  return Connection{destinationId, baseUrl, reqOpts, nf.pool()};
+}
+
+template<typename OutType, RestMessage InType>
+auto Connection::post(InType const& message)
+    -> futures::Future<ResultT<OutType>> {
+  VPackBuffer<uint8_t> messageBuffer;
+  VPackBuilder serializedMessage(messageBuffer);
+  try {
+    serialize(serializedMessage, message);
+  } catch (basics::Exception& e) {
+    return {Result{TRI_ERROR_INTERNAL,
+                   fmt::format("REST message type cannot be serialized: {}",
+                               typeid(message).name())}};
+  }
+  auto request = network::sendRequestRetry(
+      _connectionPool, "server:" + _destinationId, fuerte::RestVerb::Post,
+      _baseUrl + message.path, std::move(messageBuffer), _requestOptions);
+
+  return std::move(request).thenValue([](auto&& result)
+                                          -> futures::Future<ResultT<OutType>> {
+    if (result.fail()) {
+      return {Result{TRI_ERROR_INTERNAL,
+                     fmt::format("REST request to worker failed: {}",
+                                 fuerte::to_string(result.error))}};
+    }
+    if (result.statusCode() >= 400) {
+      return {Result{
+          TRI_ERROR_FAILED,
+          fmt::format("REST request to worker returned an error code {}: {}",
+                      result.statusCode(), result.slice().toJson())}};
+    }
+    try {
+      return deserialize<ResultT<OutType>>(result.slice());
+    } catch (basics::Exception& e) {
+      return {Result{TRI_ERROR_INTERNAL,
+                     fmt::format("REST response cannot be deserialized: {}",
+                                 result.slice().toJson())}};
+    }
+  });
+}
+
+template auto Connection::post(LoadGraph const& message)
+    -> futures::Future<ResultT<GraphLoaded>>;
+template auto Connection::post(PrepareGlobalSuperStep const& message)
+    -> futures::Future<ResultT<GlobalSuperStepPrepared>>;

--- a/arangod/Pregel/PregelFeature.cpp
+++ b/arangod/Pregel/PregelFeature.cpp
@@ -731,7 +731,9 @@ void PregelFeature::handleWorkerRequest(TRI_vocbase_t& vocbase,
   }
 
   if (path == Utils::prepareGSSPath) {
-    w->prepareGlobalStep(body, outBuilder);
+    auto message = deserialize<PrepareGlobalSuperStep>(body);
+    auto response = w->prepareGlobalSuperStep(message).get();
+    serialize(outBuilder, response);
   } else if (path == Utils::startGSSPath) {
     w->startGlobalStep(body);
     auto response = GssStarted{};

--- a/arangod/Pregel/Worker/Worker.h
+++ b/arangod/Pregel/Worker/Worker.h
@@ -54,8 +54,9 @@ class IWorker : public std::enable_shared_from_this<IWorker> {
   virtual ~IWorker() = default;
   [[nodiscard]] virtual auto loadGraph(LoadGraph const& graph)
       -> futures::Future<ResultT<GraphLoaded>> = 0;
-  virtual void prepareGlobalStep(VPackSlice const& data,
-                                 VPackBuilder& result) = 0;
+  [[nodiscard]] virtual auto prepareGlobalSuperStep(
+      PrepareGlobalSuperStep const& data)
+      -> futures::Future<ResultT<GlobalSuperStepPrepared>> = 0;
   virtual void startGlobalStep(
       VPackSlice const& data) = 0;  // called by coordinator
   virtual void cancelGlobalStep(
@@ -162,7 +163,8 @@ class Worker : public IWorker {
   // ====== called by rest handler =====
   auto loadGraph(LoadGraph const& graph)
       -> futures::Future<ResultT<GraphLoaded>> override;
-  void prepareGlobalStep(VPackSlice const& data, VPackBuilder& result) override;
+  auto prepareGlobalSuperStep(PrepareGlobalSuperStep const& data)
+      -> futures::Future<ResultT<GlobalSuperStepPrepared>> override;
   void startGlobalStep(VPackSlice const& data) override;
   void cancelGlobalStep(VPackSlice const& data) override;
   void receivedMessages(VPackSlice const& data) override;

--- a/arangod/Pregel/WorkerConductorMessages.h
+++ b/arangod/Pregel/WorkerConductorMessages.h
@@ -136,16 +136,26 @@ auto inspect(Inspector& f, StatusUpdated& x) {
 
 // worker -> conductor as immediate answer
 
-struct GssPrepared {
+struct GlobalSuperStepPrepared {
   std::string senderId;
   uint64_t activeCount;
   uint64_t vertexCount;
   uint64_t edgeCount;
   VPackBuilder messages;
   VPackBuilder aggregators;
+  GlobalSuperStepPrepared() noexcept = default;
+  GlobalSuperStepPrepared(std::string senderId, uint64_t activeCount,
+                          uint64_t vertexCount, uint64_t edgeCount,
+                          VPackBuilder messages, VPackBuilder aggregators)
+      : senderId{std::move(senderId)},
+        activeCount{activeCount},
+        vertexCount{vertexCount},
+        edgeCount{edgeCount},
+        messages{std::move(messages)},
+        aggregators{std::move(aggregators)} {}
 };
 template<typename Inspector>
-auto inspect(Inspector& f, GssPrepared& x) {
+auto inspect(Inspector& f, GlobalSuperStepPrepared& x) {
   return f.object(x).fields(
       f.field(Utils::senderKey, x.senderId),
       f.field("activeCount", x.activeCount),
@@ -184,6 +194,7 @@ auto inspect(Inspector& f, GssCanceled& x) {
 struct LoadGraph {
   ExecutionNumber executionNumber;
   VPackBuilder details;
+  const std::string path = Utils::startExecutionPath;
 };
 template<typename Inspector>
 auto inspect(Inspector& f, LoadGraph& x) {
@@ -192,15 +203,16 @@ auto inspect(Inspector& f, LoadGraph& x) {
       f.field("details", x.details));
 }
 
-struct PrepareGss {
+struct PrepareGlobalSuperStep {
   ExecutionNumber executionNumber;
   uint64_t gss;
   uint64_t vertexCount;
   uint64_t edgeCount;
+  const std::string path = Utils::prepareGSSPath;
 };
 
 template<typename Inspector>
-auto inspect(Inspector& f, PrepareGss& x) {
+auto inspect(Inspector& f, PrepareGlobalSuperStep& x) {
   return f.object(x).fields(
       f.field(Utils::executionNumberKey, x.executionNumber),
       f.field(Utils::globalSuperstepKey, x.gss),

--- a/arangod/Pregel/WorkerInterface.h
+++ b/arangod/Pregel/WorkerInterface.h
@@ -11,6 +11,9 @@ class NewIWorker {
   virtual ~NewIWorker() = default;
   [[nodiscard]] virtual auto loadGraph(LoadGraph const& graph)
       -> futures::Future<ResultT<GraphLoaded>> = 0;
+  [[nodiscard]] virtual auto prepareGlobalSuperStep(
+      PrepareGlobalSuperStep const& data)
+      -> futures::Future<ResultT<GlobalSuperStepPrepared>> = 0;
 };
 
 }  // namespace arangodb::pregel


### PR DESCRIPTION
### Scope & Purpose

Use future to prepare the global super step

Move ConductorWorkers into their own files and in the conductor namespace and rename them to ClusterWorkerApi and SingleServerWorkerApi.