### PR TITLE
fix puzzling error message

### DIFF
--- a/js/client/modules/@arangodb/testutils/instance.js
+++ b/js/client/modules/@arangodb/testutils/instance.js
@@ -517,7 +517,7 @@ class instance {
     let size = fs.size(this.logFile);
     if (this.options.maxLogFileSize !== 0 && size > this.options.maxLogFileSize) {
       // File bigger 500k? this needs to be a bug in the tests.
-      let err=`ERROR: ${this.logFile} is bigger than ${this.options.maxLogFileSize/1024}kB! - %{size/1024} Bytes!`;
+      let err=`ERROR: ${this.logFile} is bigger than ${this.options.maxLogFileSize/1024}kB! - ${size/1024} kBytes!`;
       this.assertLines.push(err);
       print(RED + err + RESET);
       return;


### PR DESCRIPTION
### Scope & Purpose

Fix a puzzling error message in testing.js.
String substitution wasn't used correctly, and the unit for the file size returned was also wrong.
The error message only appears during tests, so this fix does not need to be backported.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: *(Please link PR)*
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
