### PR TITLE
Updates C++ version in cppcheck

### DIFF
--- a/utils/cppcheck.sh
+++ b/utils/cppcheck.sh
@@ -15,6 +15,7 @@ else
   files=( arangod/ client-tools/ lib/ enterprise/ )
 fi
 
+echo "cppcheck version: $(cppcheck --version)"
 cppcheck "$@" \
   -j $threads \
   --xml --xml-version=2 \
@@ -27,7 +28,7 @@ cppcheck "$@" \
   -I lib \
   -D USE_PLAN_CACHE \
   -D DEFINE_FACTORY_DEFAULT \
-  --std=c++17 \
+  --std=c++20 \
   --enable=warning,performance,portability,missingInclude \
   --force \
   --quiet \


### PR DESCRIPTION
Updates C++ version to C++20 in cppcheck skript.  PR
https://github.com/arangodb/arangodb/pull/16891 used constraints for
the first time (in ResultT.h) - a C++20 feature. The old cppcheck used
C++17 and therefore generated an error for ResultT.h when running.
-------

### Scope & Purpose

*(Please describe the changes in this PR for reviewers, motivation, rationale - **mandatory**)*

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.10: *(Please link PR)*: Original PR: #16891
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: