### PR TITLE
Do not drop follower shard after too many failed shard sync attempts.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 v3.9.3 (XXXX-XX-XX)
 -------------------
 
+* Do not drop follower shard after too many failed shard synchronization
+  attempts.
+
 * Disable optimization rule to avoid crash (BTS-951).
 
 * Fix SEARCH-350: Crash during consolidation.

--- a/Documentation/Metrics/arangodb_sync_rebuilds_total.yaml
+++ b/Documentation/Metrics/arangodb_sync_rebuilds_total.yaml
@@ -13,11 +13,13 @@ exposedBy:
 description: |
   Number of times a follower shard needed to be completely rebuilt
   because of too many subsequent shard synchronization failures.
-  If this metric is non-zero, it means that a follower shard could
+  This metric is always zero from version 3.9.3 onwards. In previous
+  releases, a non-zero vlaue indicates that a follower shard could
   not get in sync with the leader even after many attempts. When
-  the metric gets increased, the follower shard is dropped and
+  the metric got increased, the follower shard was dropped and
   completely rebuilt from leader data, in order to increase its
   chances of getting in sync.
 troubleshoot: |
-  Normally, this number will always be 0. If it is not, then something
-  is wrong, please contact ArangoDB customer support in this case.
+  This number will always be 0 from version 3.9.3 onwards. If it is
+  non-zero in previous versions, then something is wrong, please 
+  contact ArangoDB customer support in this case.

--- a/arangod/Cluster/SynchronizeShard.cpp
+++ b/arangod/Cluster/SynchronizeShard.cpp
@@ -718,39 +718,6 @@ bool SynchronizeShard::first() {
   // from this many number of failures in a row, we will step on the brake
   constexpr size_t delayThreshold = 4;
 
-  if (failuresInRow >= MaintenanceFeature::maxReplicationErrorsPerShard) {
-    auto& df = _feature.server().getFeature<DatabaseFeature>();
-    DatabaseGuard guard(df, database);
-    auto vocbase = &guard.database();
-
-    auto collection = vocbase->lookupCollection(shard);
-    if (collection != nullptr) {
-      LOG_TOPIC("7a2cf", WARN, Logger::MAINTENANCE)
-          << "SynchronizeShard: synchronizing shard '" << database << "/"
-          << shard << "' for central '" << database << "/" << planId
-          << "' encountered " << failuresInRow
-          << " failures in a row. now dropping follower shard for "
-          << "a full rebuild";
-
-      // remove these failure points for testing
-      TRI_RemoveFailurePointDebugging("SynchronizeShard::wrongChecksum");
-      TRI_RemoveFailurePointDebugging("disableCountAdjustment");
-
-      // remove all recorded failures, so in next run we can start with a clean
-      // state
-      _feature.removeReplicationError(getDatabase(), getShard());
-
-      ++_feature.server()
-            .getFeature<ClusterFeature>()
-            .followersTotalRebuildCounter();
-
-      // drop shard (💥)
-      methods::Collections::drop(*collection, false, 3.0);
-      result(TRI_ERROR_REPLICATION_WRONG_CHECKSUM);
-      return false;
-    }
-  }
-
   if (failuresInRow >= delayThreshold) {
     // shard synchronization has failed several times in a row.
     // now step on the brake a bit. this blocks our maintenance thread, but
@@ -758,6 +725,7 @@ bool SynchronizeShard::first() {
     // maintenance tasks.
     double sleepTime = 2.0 + 0.1 * (failuresInRow * (failuresInRow + 1) / 2);
 
+    // cap sleep time to 15 seconds
     sleepTime = std::min<double>(sleepTime, 15.0);
 
     LOG_TOPIC("40376", INFO, Logger::MAINTENANCE)

--- a/tests/js/client/shell/shell-collection-counts-cluster.js
+++ b/tests/js/client/shell/shell-collection-counts-cluster.js
@@ -957,7 +957,7 @@ function BaseTestConfig () {
       }
       assertEqual(2 * 101, total);
     },
-    
+   
     testWrongCountOnFollowerIncrementalSyncManyFailures : function () {
       let c = db._create(cn, { numberOfShards: 1, replicationFactor: 2 }); 
 
@@ -996,7 +996,6 @@ function BaseTestConfig () {
       assertEqual(200, result.status);
       assertEqual(0, result.json.count);
       
-      let rebuildFailuresBefore = getMetric(followerUrl, "arangodb_sync_rebuilds_total");
       let checksumFailuresBefore = getMetric(followerUrl, "arangodb_sync_wrong_checksum_total");
       
       // set a failure point on the leader to drop the follower
@@ -1015,22 +1014,35 @@ function BaseTestConfig () {
 
       assertEqual(101, c.toArray().length);
       assertEqual(101, c.count());
-    
+   
+      let cleanup = () => {
+        let result = request({ method: "DELETE", url: followerUrl + "/_admin/debug/failat/SynchronizeShard%3A%3AwrongChecksum" });
+        assertEqual(200, result.status);
+        result = request({ method: "DELETE", url: followerUrl + "/_admin/debug/failat/disableCountAdjustment" });
+        assertEqual(200, result.status);
+      };
+
       tries = 0;
-      let rebuildFailuresAfter;
-      let checksumFailuresAfter;
-      while (tries++ < 120) {
-        rebuildFailuresAfter = getMetric(followerUrl, "arangodb_sync_rebuilds_total");
-        checksumFailuresAfter = getMetric(followerUrl, "arangodb_sync_wrong_checksum_total");
+      try {
+        let checksumFailuresAfter;
+        while (tries++ < 120) {
+          checksumFailuresAfter = getMetric(followerUrl, "arangodb_sync_wrong_checksum_total");
 
-        if (rebuildFailuresAfter > rebuildFailuresBefore) {
-          break;
+          if (checksumFailuresAfter > checksumFailuresBefore) {
+            break;
+          }
+
+          if (tries === 15) {
+            cleanup();
+          }
+
+          require("internal").sleep(0.25);
         }
-        require("internal").sleep(0.25);
+          
+        assertTrue(checksumFailuresAfter > checksumFailuresBefore);
+      } finally {
+        cleanup();
       }
-
-      assertTrue(rebuildFailuresAfter > rebuildFailuresBefore);
-      assertTrue(checksumFailuresAfter > checksumFailuresBefore);
 
       // follower count must be ok now
       tries = 0;


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/16955

Do not drop follower shard after too many failed shard sync attempts.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [x] Backports
  - [x] Backport for 3.10: https://github.com/arangodb/arangodb/pull/16954
  - [x] Backport for 3.9: this PR
  - [x] Backport for 3.8: https://github.com/arangodb/arangodb/pull/16953

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

