### PR TITLE
Do not drop follower shard after too many failed shard sync attempts.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 v3.10.0 (XXXX-XX-XX)
 --------------------
 
+* Do not drop follower shard after too many failed shard synchronization
+  attempts.
+
 * Updated arangosync to v2.12.0-preview-11.
 
 * Fixed SEARCH-369: add a compatibility check to the search-alias view for

--- a/Documentation/Metrics/arangodb_sync_rebuilds_total.yaml
+++ b/Documentation/Metrics/arangodb_sync_rebuilds_total.yaml
@@ -13,11 +13,13 @@ exposedBy:
 description: |
   Number of times a follower shard needed to be completely rebuilt
   because of too many subsequent shard synchronization failures.
-  If this metric is non-zero, it means that a follower shard could
+  This metric is always zero from version 3.9.3 onwards. In previous
+  releases, a non-zero vlaue indicates that a follower shard could
   not get in sync with the leader even after many attempts. When
-  the metric gets increased, the follower shard is dropped and
+  the metric got increased, the follower shard was dropped and
   completely rebuilt from leader data, in order to increase its
   chances of getting in sync.
 troubleshoot: |
-  Normally, this number will always be 0. If it is not, then something
-  is wrong, please contact ArangoDB customer support in this case.
+  This number will always be 0 from version 3.9.3 onwards. If it is
+  non-zero in previous versions, then something is wrong, please 
+  contact ArangoDB customer support in this case.

--- a/Documentation/Metrics/arangodb_sync_rebuilds_total.yaml
+++ b/Documentation/Metrics/arangodb_sync_rebuilds_total.yaml
@@ -14,7 +14,7 @@ description: |
   Number of times a follower shard needed to be completely rebuilt
   because of too many subsequent shard synchronization failures.
   This metric is always zero from version 3.9.3 onwards. In previous
-  releases, a non-zero vlaue indicates that a follower shard could
+  releases, a non-zero value indicates that a follower shard could
   not get in sync with the leader even after many attempts. When
   the metric got increased, the follower shard was dropped and
   completely rebuilt from leader data, in order to increase its

--- a/arangod/Cluster/SynchronizeShard.cpp
+++ b/arangod/Cluster/SynchronizeShard.cpp
@@ -707,39 +707,6 @@ bool SynchronizeShard::first() {
   // from this many number of failures in a row, we will step on the brake
   constexpr size_t delayThreshold = 4;
 
-  if (failuresInRow >= MaintenanceFeature::maxReplicationErrorsPerShard) {
-    auto& df = _feature.server().getFeature<DatabaseFeature>();
-    DatabaseGuard guard(df, database);
-    auto vocbase = &guard.database();
-
-    auto collection = vocbase->lookupCollection(shard);
-    if (collection != nullptr) {
-      LOG_TOPIC("7a2cf", WARN, Logger::MAINTENANCE)
-          << "SynchronizeShard: synchronizing shard '" << database << "/"
-          << shard << "' for central '" << database << "/" << planId
-          << "' encountered " << failuresInRow
-          << " failures in a row. now dropping follower shard for "
-          << "a full rebuild";
-
-      // remove these failure points for testing
-      TRI_RemoveFailurePointDebugging("SynchronizeShard::wrongChecksum");
-      TRI_RemoveFailurePointDebugging("disableCountAdjustment");
-
-      // remove all recorded failures, so in next run we can start with a clean
-      // state
-      _feature.removeReplicationError(getDatabase(), getShard());
-
-      ++_feature.server()
-            .getFeature<ClusterFeature>()
-            .followersTotalRebuildCounter();
-
-      // drop shard (💥)
-      methods::Collections::drop(*collection, false, 3.0);
-      result(TRI_ERROR_REPLICATION_WRONG_CHECKSUM);
-      return false;
-    }
-  }
-
   if (failuresInRow >= delayThreshold) {
     // shard synchronization has failed several times in a row.
     // now step on the brake a bit. this blocks our maintenance thread, but
@@ -747,6 +714,7 @@ bool SynchronizeShard::first() {
     // maintenance tasks.
     double sleepTime = 2.0 + 0.1 * (failuresInRow * (failuresInRow + 1) / 2);
 
+    // cap sleep time to 15 seconds
     sleepTime = std::min<double>(sleepTime, 15.0);
 
     LOG_TOPIC("40376", INFO, Logger::MAINTENANCE)


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/16955

Do not drop follower shard after too many failed shard sync attempts.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [x] Backports
  - [x] Backport for 3.10: this PR
  - [x] Backport for 3.9: https://github.com/arangodb/arangodb/pull/16952
  - [x] Backport for 3.8: https://github.com/arangodb/arangodb/pull/16953

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 