### PR TITLE
make it clear in query explain output that there are document lookups

### DIFF
--- a/js/common/modules/@arangodb/aql/explainer.js
+++ b/js/common/modules/@arangodb/aql/explainer.js
@@ -1177,7 +1177,9 @@ function processQuery(query, explain, planIndex) {
     if (node.producesResult || !node.hasOwnProperty('producesResult')) {
       if (node.indexCoversProjections) {
         what += ', index only';
-      } 
+      } else {
+        what += ', index scan + document lookup';
+      }
     } else {
       what += ', scan only';
     }
@@ -2061,7 +2063,6 @@ function processQuery(query, explain, planIndex) {
     if (['EnumerateCollectionNode',
       'EnumerateListNode',
       'EnumerateViewNode',
-      'IndexRangeNode',
       'IndexNode',
       'TraversalNode',
       'SubqueryStartNode',


### PR DESCRIPTION
### Scope & Purpose

Following a suggestion by @joerg84 , make the AQL query explainer show that a non-covering index scan requires extra document lookups. The explainer will now not only display "index scan" in this case, but "index + document lookup".
Hopefully this helps understanding the execution plans and their costs better.

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [x] Backports
  - [x] Backport for 3.10: https://github.com/arangodb/arangodb/pull/16958
  - [x] Backport for 3.9: https://github.com/arangodb/arangodb/pull/16959
  - [ ] Backport for 3.8: .

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 