### PR TITLE
make it clear in query explain output that there are document lookups

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,12 @@
 v3.9.3 (XXXX-XX-XX)
 -------------------
 
+* Make AQL query explainer display "index scan + document lookup" for queries
+  that use an index for filtering, but need to fetch more document data from
+  the storage engine. Previously, those were labeled only as "index scan",
+  obfuscating the fact that there are document lookups needed.
+  Covering-index queries are still labeled "index scan, index only" as before.
+
 * Disable optimization rule to avoid crash (BTS-951).
 
 * Fix SEARCH-350: Crash during consolidation.

--- a/js/common/modules/@arangodb/aql/explainer.js
+++ b/js/common/modules/@arangodb/aql/explainer.js
@@ -1124,7 +1124,7 @@ function processQuery(query, explain, planIndex) {
   };
 
   var iterateIndexes = function (idx, i, node, types, variable) {
-    var what = (node.reverse ? 'reverse ' : '') + idx.type + ' index scan' + ((node.producesResult || !node.hasOwnProperty('producesResult')) ? (node.indexCoversProjections ? ', index only' : '') : ', scan only');
+    var what = (node.reverse ? 'reverse ' : '') + idx.type + ' index scan' + ((node.producesResult || !node.hasOwnProperty('producesResult')) ? (node.indexCoversProjections ? ', index only' : ' + document lookup') : ', scan only');
     if (node.readOwnWrites) {
       what += "; read own writes";
     }
@@ -1971,7 +1971,6 @@ function processQuery(query, explain, planIndex) {
     if (['EnumerateCollectionNode',
       'EnumerateListNode',
       'EnumerateViewNode',
-      'IndexRangeNode',
       'IndexNode',
       'TraversalNode',
       'SubqueryStartNode',


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/16957

Following a suggestion by @joerg84 , make the AQL query explainer show that a non-covering index scan requires extra document lookups. The explainer will now not only display "index scan" in this case, but "index + document lookup".
Hopefully this helps understanding the execution plans and their costs better.

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [x] Backports
  - [x] Backport for 3.10: https://github.com/arangodb/arangodb/pull/16958
  - [x] Backport for 3.9: this PR
  - [ ] Backport for 3.8: .

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 