### PR TITLE
adjust target version and messages

### DIFF
--- a/Documentation/Metrics/arangodb_search_num_out_of_sync_links.yaml
+++ b/Documentation/Metrics/arangodb_search_num_out_of_sync_links.yaml
@@ -1,5 +1,5 @@
 name: arangodb_search_num_out_of_sync_links
-introducedIn: "3.11.0"
+introducedIn: "3.9.4"
 help: |
   Number of out-of-sync arangosearch links/inverted indexes.
 unit: number

--- a/arangod/IResearch/IResearchFeature.cpp
+++ b/arangod/IResearch/IResearchFeature.cpp
@@ -949,21 +949,22 @@ void IResearchFeature::collectOptions(
           "the pseudo-entry 'all' will disable recovery for all view "
           "links/inverted indexes. "
           "all links/inverted indexes skipped during recovery will be marked "
-          "as failed when "
+          "as out of sync when "
           "the recovery is completed. these links/indexes will need to be "
           "recreated manually "
           "afterwards (note: using this option will cause data of affected "
-          "links/inverted indexes to become unavailable for querying until "
+          "links/inverted indexes to become incomplete or more incomplete "
+          "until "
           "they have been manually recreated)",
           new options::VectorParameter<options::StringParameter>(
               &_skipRecoveryItems))
-      .setIntroducedIn(31100);
+      .setIntroducedIn(30904);
   options
       ->addOption(FAIL_ON_OUT_OF_SYNC,
                   "whether or not retrieval queries on out of sync "
                   "links/indexes should fail",
                   new options::BooleanParameter(&_failQueriesOnOutOfSync))
-      .setIntroducedIn(31100);
+      .setIntroducedIn(30904);
 }
 
 void IResearchFeature::validateOptions(
@@ -1230,7 +1231,7 @@ void IResearchFeature::registerRecoveryHelper() {
         << SKIP_RECOVERY << "' startup option for the following links/indexes: "
         << _skipRecoveryItems
         << ". all affected links/indexes that are touched during "
-           "recovery will be marked as failed and will need to be recreated "
+           "recovery will be marked as out of sync and should be recreated "
            "manually when the recovery is finished.";
   }
 


### PR DESCRIPTION
### Scope & Purpose

Adjust target version for new arangosearch options (3.9.4) and also a few message texts ("failed" => "out of sync").
For 3.10, the changes will be included in https://github.com/arangodb/arangodb/pull/16900

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: https://github.com/arangodb/arangodb/pull/16900
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
