### PR TITLE
Added startup option `--rocksdb.periodic-compaction-ttl`

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,10 +2,9 @@ v3.9.3 (XXXX-XX-XX)
 -------------------
       
 * Added startup option `--rocksdb.periodic-compaction-ttl`.
-  This option controls the TTL (in seconds) for periodic compaction of 
-  .sst files in RocksDB, based on the .sst file age. The default value
-  from RocksDB is ~30 days. To avoid periodic auto-compaction, the option
-  can be set to 0.
+  This option controls the TTL (in seconds) for periodic compaction of .sst
+  files in RocksDB, based on the .sst file age. The default value from RocksDB
+  is ~30 days. To avoid periodic auto-compaction, the option can be set to 0.
 
 * Fixed SEARCH-366: Fixed extracting sub-attributes using projections for the
   `_id` attribute (e.g. `RETURN doc.sub._id`).

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,11 @@
 v3.9.3 (XXXX-XX-XX)
 -------------------
+      
+* Added startup option `--rocksdb.periodic-compaction-ttl`.
+  This option controls the TTL (in seconds) for periodic compaction of 
+  .sst files in RocksDB, based on the .sst file age. The default value
+  from RocksDB is ~30 days. To avoid periodic auto-compaction, the option
+  can be set to 0.
 
 * Fixed SEARCH-366: Fixed extracting sub-attributes using projections for the
   `_id` attribute (e.g. `RETURN doc.sub._id`).

--- a/arangod/RocksDBEngine/RocksDBEngine.cpp
+++ b/arangod/RocksDBEngine/RocksDBEngine.cpp
@@ -938,6 +938,8 @@ void RocksDBEngine::start() {
                     &cfFamilies](RocksDBColumnFamilyManager::Family family) {
     rocksdb::ColumnFamilyOptions specialized =
         opts.columnFamilyOptions(family, _options, tableOptions);
+    // set TTL for .sst file compaction
+    specialized.ttl = opts._periodicCompactionTtl;
     std::string name = RocksDBColumnFamilyManager::name(family);
     cfFamilies.emplace_back(name, specialized);
   };

--- a/arangod/RocksDBEngine/RocksDBOptionFeature.cpp
+++ b/arangod/RocksDBEngine/RocksDBOptionFeature.cpp
@@ -545,7 +545,7 @@ void RocksDBOptionFeature::collectOptions(
                   "TTL (in seconds) for periodic compaction of .sst files, "
                   "based on file age (0 = no periodic compaction)",
                   new UInt64Parameter(&_periodicCompactionTtl))
-      .setIntroducedIn(30904);
+      .setIntroducedIn(30903);
 
   //////////////////////////////////////////////////////////////////////////////
   /// add column family-specific options now

--- a/arangod/RocksDBEngine/RocksDBOptionFeature.cpp
+++ b/arangod/RocksDBEngine/RocksDBOptionFeature.cpp
@@ -159,6 +159,9 @@ RocksDBOptionFeature::RocksDBOptionFeature(
       _level0StopTrigger(256),
       _pendingCompactionBytesSlowdownTrigger(128 * 1024ull),
       _pendingCompactionBytesStopTrigger(16 * 1073741824ull),
+      // note: this is a default value from RocksDB (db/column_family.cc,
+      // kAdjustedTtl):
+      _periodicCompactionTtl(30 * 24 * 60 * 60),
       _recycleLogFileNum(rocksDBDefaults.recycle_log_file_num),
       _enforceBlockCacheSizeLimit(false),
       _cacheIndexAndFilterBlocks(
@@ -537,6 +540,13 @@ void RocksDBOptionFeature::collectOptions(
       .setIntroducedIn(30504)
       .setDeprecatedIn(30800);
 
+  options
+      ->addOption("--rocksdb.periodic-compaction-ttl",
+                  "TTL (in seconds) for periodic compaction of .sst files, "
+                  "based on file age (0 = no periodic compaction)",
+                  new UInt64Parameter(&_periodicCompactionTtl))
+      .setIntroducedIn(30904);
+
   //////////////////////////////////////////////////////////////////////////////
   /// add column family-specific options now
   //////////////////////////////////////////////////////////////////////////////
@@ -698,6 +708,7 @@ void RocksDBOptionFeature::start() {
       << ", compaction_read_ahead_size: " << _compactionReadaheadSize
       << ", level0_compaction_trigger: " << _level0CompactionTrigger
       << ", level0_slowdown_trigger: " << _level0SlowdownTrigger
+      << ", periodic_compaction_ttl: " << _periodicCompactionTtl
       << ", enable_pipelined_write: " << _enablePipelinedWrite
       << ", optimize_filters_for_hits: " << std::boolalpha
       << _optimizeFiltersForHits << ", use_direct_reads: " << std::boolalpha

--- a/arangod/RocksDBEngine/RocksDBOptionFeature.h
+++ b/arangod/RocksDBEngine/RocksDBOptionFeature.h
@@ -93,6 +93,7 @@ class RocksDBOptionFeature final
   int64_t _level0StopTrigger;
   uint64_t _pendingCompactionBytesSlowdownTrigger;
   uint64_t _pendingCompactionBytesStopTrigger;
+  uint64_t _periodicCompactionTtl;
   bool _recycleLogFileNum;
   bool _enforceBlockCacheSizeLimit;
   bool _cacheIndexAndFilterBlocks;


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/16982
Docs PR: https://github.com/arangodb/docs/pull/1104

Added startup option `--rocksdb.periodic-compaction-ttl`

This option controls the TTL (in seconds) for periodic compaction of .sst files in RocksDB, based on the .sst file age. The default value from RocksDB is ~30 days. To avoid periodic auto-compaction, the option can be set to 0.

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [x] Backports
  - [x] Backport for 3.10: https://github.com/arangodb/arangodb/pull/16981
  - [x] Backport for 3.9: this PR
  - [ ] Backport for 3.8: -

#### Related Information

- [x] Docs PR: https://github.com/arangodb/docs/pull/1104
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 