### PR TITLE
Inverted index stats and metric backport for 3.10

### DIFF
--- a/arangod/IResearch/IResearchDataStore.h
+++ b/arangod/IResearch/IResearchDataStore.h
@@ -99,6 +99,10 @@ struct IResearchTrxState final : public TransactionState::Cookie {
   }
 };
 
+void clusterCollectionName(LogicalCollection const& collection, ClusterInfo* ci,
+                           uint64_t id, bool indexIdAttribute,
+                           std::string& name);
+
 class IResearchDataStore {
  public:
   using AsyncLinkPtr = std::shared_ptr<AsyncLinkHandle>;
@@ -421,6 +425,8 @@ class IResearchDataStore {
   /// @note Unsafe, can only be called is _asyncSelf is locked
   ////////////////////////////////////////////////////////////////////////////////
   Stats updateStatsUnsafe() const;
+
+  void initClusterMetrics() const;
 
   //////////////////////////////////////////////////////////////////////////////
   /// @brief insert metrics to MetricsFeature

--- a/arangod/IResearch/IResearchLink.cpp
+++ b/arangod/IResearch/IResearchLink.cpp
@@ -45,10 +45,6 @@
 #include "IResearch/IResearchView.h"
 #include "IResearch/IResearchViewCoordinator.h"
 #include "IResearch/VelocyPackHelper.h"
-#include "Metrics/Batch.h"
-#include "Metrics/GaugeBuilder.h"
-#include "Metrics/Guard.h"
-#include "Metrics/MetricsFeature.h"
 #include "RestServer/DatabaseFeature.h"
 #include "RestServer/DatabasePathFeature.h"
 #include "RestServer/FlushFeature.h"
@@ -63,26 +59,6 @@ using namespace std::literals;
 
 namespace arangodb::iresearch {
 namespace {
-
-DECLARE_GAUGE(arangodb_search_num_docs, uint64_t, "Number of documents");
-DECLARE_GAUGE(arangodb_search_num_live_docs, uint64_t,
-              "Number of live documents");
-DECLARE_GAUGE(arangodb_search_num_segments, uint64_t, "Number of segments");
-DECLARE_GAUGE(arangodb_search_num_files, uint64_t, "Number of files");
-DECLARE_GAUGE(arangodb_search_index_size, uint64_t,
-              "Size of the index in bytes");
-DECLARE_GAUGE(arangodb_search_num_failed_commits, uint64_t,
-              "Number of failed commits");
-DECLARE_GAUGE(arangodb_search_num_failed_cleanups, uint64_t,
-              "Number of failed cleanups");
-DECLARE_GAUGE(arangodb_search_num_failed_consolidations, uint64_t,
-              "Number of failed consolidations");
-DECLARE_GAUGE(arangodb_search_commit_time, uint64_t,
-              "Average time of few last commits");
-DECLARE_GAUGE(arangodb_search_cleanup_time, uint64_t,
-              "Average time of few last cleanups");
-DECLARE_GAUGE(arangodb_search_consolidation_time, uint64_t,
-              "Average time of few last consolidations");
 
 // Ensures that all referenced analyzer features are consistent.
 [[maybe_unused]] void checkAnalyzerFeatures(IResearchLinkMeta const& meta) {
@@ -115,8 +91,6 @@ DECLARE_GAUGE(arangodb_search_consolidation_time, uint64_t,
   checkFieldFeatures(meta, checkFieldFeatures);
 }
 
-constexpr std::string_view kSearchStats = "arangodb_search_link_stats";
-
 template<typename T>
 T getMetric(IResearchLink const& link) {
   T metric;
@@ -132,33 +106,6 @@ std::string getLabels(IResearchLink const& link) {
          "\",view=\"" + link.getViewId() +                //
          "\",collection=\"" + link.getCollectionName() +  //
          "\",shard=\"" + link.getShardName() + "\"";
-}
-
-void initCollectionName(LogicalCollection const& collection, ClusterInfo* ci,
-                        IResearchLinkMeta& meta, uint64_t linkId) {
-  // Upgrade step for old link definition without collection name
-  // could be received from agency while shard of the collection was moved
-  // or added to the server. New links already has collection name set,
-  // but here we must get this name on our own.
-  auto& name = meta._collectionName;
-  if (name.empty()) {
-    name = ci ? ci->getCollectionNameForShard(collection.name())
-              : collection.name();
-    LOG_TOPIC("86ece", TRACE, TOPIC) << "Setting collection name '" << name
-                                     << "' for new link '" << linkId << "'";
-    if (ADB_UNLIKELY(name.empty())) {
-      LOG_TOPIC_IF("67da6", WARN, TOPIC, meta.willIndexIdAttribute())
-          << "Failed to init collection name for the link '" << linkId
-          << "'. Link will not index '_id' attribute."
-             "Please recreate the link if this is necessary!";
-    }
-#ifdef USE_ENTERPRISE
-    // enterprise name is not used in _id so should not be here!
-    if (ADB_LIKELY(!name.empty())) {
-      ClusterMethods::realNameFromSmartName(name);
-    }
-#endif
-  }
 }
 
 Result linkWideCluster(LogicalCollection const& logical, IResearchView* view) {
@@ -249,7 +196,8 @@ Result IResearchLink::initDBServer(bool& pathExists, InitCallback const& init) {
   std::shared_ptr<IResearchView> view;
   if (clusterEnabled) {
     auto& ci = server.getFeature<ClusterFeature>().clusterInfo();
-    initCollectionName(_collection, wide ? nullptr : &ci, _meta, id().id());
+    clusterCollectionName(_collection, wide ? nullptr : &ci, id().id(),
+                          _meta.willIndexIdAttribute(), _meta._collectionName);
     if (auto r = toView(ci.getView(vocbase.name(), _viewGuid), view); !r.ok()) {
       return r;
     }
@@ -522,12 +470,22 @@ IResearchViewStoredValues const& IResearchLink::storedValues() const noexcept {
   return _meta._storedValues;
 }
 
+std::string const& IResearchLink::getDbName() const noexcept {
+  return _collection.vocbase().name();
+}
+
 std::string const& IResearchLink::getViewId() const noexcept {
   return _viewGuid;
 }
 
-std::string const& IResearchLink::getDbName() const {
-  return _collection.vocbase().name();
+std::string IResearchLink::getCollectionName() const {
+  if (ServerState::instance()->isSingleServer()) {
+    return std::to_string(_collection.id().id());
+  }
+  if (ServerState::instance()->isDBServer()) {
+    return _meta._collectionName;
+  }
+  return _collection.name();
 }
 
 std::string const& IResearchLink::getShardName() const noexcept {
@@ -535,13 +493,6 @@ std::string const& IResearchLink::getShardName() const noexcept {
     return _collection.name();
   }
   return arangodb::StaticStrings::Empty;
-}
-
-std::string IResearchLink::getCollectionName() const {
-  if (ServerState::instance()->isSingleServer()) {
-    return std::to_string(_collection.id().id());
-  }
-  return _meta._collectionName;
 }
 
 bool IResearchLink::hasNested() const noexcept {

--- a/arangod/IResearch/IResearchLink.h
+++ b/arangod/IResearch/IResearchLink.h
@@ -164,10 +164,11 @@ class IResearchLink : public IResearchDataStore {
   Result insert(transaction::Methods& trx, LocalDocumentId documentId,
                 velocypack::Slice doc);
 
+  std::string const& getDbName() const noexcept;
   std::string const& getViewId() const noexcept;
-  std::string const& getDbName() const;
-  std::string const& getShardName() const noexcept;
   std::string getCollectionName() const;
+  std::string const& getShardName() const noexcept;
+
   bool hasNested() const noexcept;
 
  protected:

--- a/arangod/IResearch/IResearchLinkCoordinator.h
+++ b/arangod/IResearch/IResearchLinkCoordinator.h
@@ -92,7 +92,7 @@ class IResearchLinkCoordinator final : public arangodb::ClusterIndex,
       std::underlying_type<arangodb::Index::Serialize>::type flags) const final;
 
   void toVelocyPackFigures(velocypack::Builder& builder) const final {
-    IResearchLink::toVelocyPackStats(builder);
+    IResearchDataStore::toVelocyPackStats(builder);
   }
 
   IndexType type() const final { return IResearchLink::type(); }

--- a/arangod/IResearch/IResearchMetricStats.h
+++ b/arangod/IResearch/IResearchMetricStats.h
@@ -28,6 +28,10 @@
 #include "Metrics/Guard.h"
 #include "RestServer/arangod.h"
 #include "ApplicationFeatures/ApplicationServer.h"
+#include "Metrics/Batch.h"
+#include "Metrics/GaugeBuilder.h"
+#include "Metrics/Guard.h"
+#include "Metrics/MetricsFeature.h"
 
 namespace arangodb::iresearch {
 
@@ -113,5 +117,27 @@ class MetricStats : public metrics::Guard<IResearchDataStore::Stats> {
       "gauge", "gauge", "gauge", "gauge", "gauge",
   };
 };
+
+DECLARE_GAUGE(arangodb_search_num_docs, uint64_t, "Number of documents");
+DECLARE_GAUGE(arangodb_search_num_live_docs, uint64_t,
+              "Number of live documents");
+DECLARE_GAUGE(arangodb_search_num_segments, uint64_t, "Number of segments");
+DECLARE_GAUGE(arangodb_search_num_files, uint64_t, "Number of files");
+DECLARE_GAUGE(arangodb_search_index_size, uint64_t,
+              "Size of the index in bytes");
+DECLARE_GAUGE(arangodb_search_num_failed_commits, uint64_t,
+              "Number of failed commits");
+DECLARE_GAUGE(arangodb_search_num_failed_cleanups, uint64_t,
+              "Number of failed cleanups");
+DECLARE_GAUGE(arangodb_search_num_failed_consolidations, uint64_t,
+              "Number of failed consolidations");
+DECLARE_GAUGE(arangodb_search_commit_time, uint64_t,
+              "Average time of few last commits");
+DECLARE_GAUGE(arangodb_search_cleanup_time, uint64_t,
+              "Average time of few last cleanups");
+DECLARE_GAUGE(arangodb_search_consolidation_time, uint64_t,
+              "Average time of few last consolidations");
+
+inline constexpr std::string_view kSearchStats = "arangodb_search_link_stats";
 
 }  // namespace arangodb::iresearch

--- a/arangod/IResearch/IResearchRocksDBInvertedIndex.cpp
+++ b/arangod/IResearch/IResearchRocksDBInvertedIndex.cpp
@@ -30,6 +30,7 @@
 #include "RocksDBEngine/RocksDBEngine.h"
 #include "StorageEngine/EngineSelectorFeature.h"
 #include "VocBase/LogicalCollection.h"
+#include "IResearch/IResearchMetricStats.h"
 
 namespace arangodb {
 namespace iresearch {
@@ -103,6 +104,15 @@ std::shared_ptr<Index> IResearchRocksDBInvertedIndexFactory::instantiate(
         index->drop();
       }
     });
+
+    bool wide = collection.id() == collection.planId() && collection.isAStub();
+    auto& ci = collection.vocbase()
+                   .server()
+                   .getFeature<ClusterFeature>()
+                   .clusterInfo();
+    clusterCollectionName(collection, wide ? nullptr : &ci,
+                          index->Index::id().id(), false,
+                          index->_collectionName);
 
     auto initRes = index->init(
         definition, pathExists, [this]() -> irs::directory_attributes {
@@ -209,6 +219,94 @@ IResearchRocksDBInvertedIndex::IResearchRocksDBInvertedIndex(
                        .server()
                        .getFeature<EngineSelectorFeature>()
                        .engine<RocksDBEngine>()) {}
+namespace {
+
+template<typename T>
+T getMetric(IResearchRocksDBInvertedIndex const& index) {
+  T metric;
+  metric.addLabel("db", index.getDbName());
+  metric.addLabel("index", index.name());
+  metric.addLabel("collection", index.getCollectionName());
+  metric.addLabel("shard", index.getShardName());
+  return metric;
+}
+
+std::string getLabels(IResearchRocksDBInvertedIndex const& index) {
+  return absl::StrCat(  // clang-format off
+      "db=\"", index.getDbName(), "\","
+      "index=\"", index.name(), "\","
+      "collection=\"", index.getCollectionName(), "\","
+      "shard=\"", index.getShardName(), "\"");  // clang-format on
+}
+
+}  // namespace
+
+std::string IResearchRocksDBInvertedIndex::getCollectionName() const {
+  if (ServerState::instance()->isSingleServer()) {
+    return std::to_string(Index::_collection.id().id());
+  }
+  return _collectionName;
+}
+
+std::string const& IResearchRocksDBInvertedIndex::getShardName()
+    const noexcept {
+  if (ServerState::instance()->isDBServer()) {
+    return Index::_collection.name();
+  }
+  return arangodb::StaticStrings::Empty;
+}
+
+void IResearchRocksDBInvertedIndex::insertMetrics() {
+  auto& metric = Index::_collection.vocbase()
+                     .server()
+                     .getFeature<metrics::MetricsFeature>();
+  _numFailedCommits =
+      &metric.add(getMetric<arangodb_search_num_failed_commits>(*this));
+  _numFailedCleanups =
+      &metric.add(getMetric<arangodb_search_num_failed_cleanups>(*this));
+  _numFailedConsolidations =
+      &metric.add(getMetric<arangodb_search_num_failed_consolidations>(*this));
+  _avgCommitTimeMs = &metric.add(getMetric<arangodb_search_commit_time>(*this));
+  _avgCleanupTimeMs =
+      &metric.add(getMetric<arangodb_search_cleanup_time>(*this));
+  _avgConsolidationTimeMs =
+      &metric.add(getMetric<arangodb_search_consolidation_time>(*this));
+  _metricStats = &metric.batchAdd<MetricStats>(kSearchStats, getLabels(*this));
+}
+
+void IResearchRocksDBInvertedIndex::removeMetrics() {
+  auto& metric = Index::_collection.vocbase()
+                     .server()
+                     .getFeature<metrics::MetricsFeature>();
+  if (_numFailedCommits) {
+    _numFailedCommits = nullptr;
+    metric.remove(getMetric<arangodb_search_num_failed_commits>(*this));
+  }
+  if (_numFailedCleanups) {
+    _numFailedCleanups = nullptr;
+    metric.remove(getMetric<arangodb_search_num_failed_cleanups>(*this));
+  }
+  if (_numFailedConsolidations) {
+    _numFailedConsolidations = nullptr;
+    metric.remove(getMetric<arangodb_search_num_failed_consolidations>(*this));
+  }
+  if (_avgCommitTimeMs) {
+    _avgCommitTimeMs = nullptr;
+    metric.remove(getMetric<arangodb_search_commit_time>(*this));
+  }
+  if (_avgCleanupTimeMs) {
+    _avgCleanupTimeMs = nullptr;
+    metric.remove(getMetric<arangodb_search_cleanup_time>(*this));
+  }
+  if (_avgConsolidationTimeMs) {
+    _avgConsolidationTimeMs = nullptr;
+    metric.remove(getMetric<arangodb_search_consolidation_time>(*this));
+  }
+  if (_metricStats) {
+    _metricStats = nullptr;
+    metric.batchRemove(kSearchStats, getLabels(*this));
+  }
+}
 
 void IResearchRocksDBInvertedIndex::toVelocyPack(
     VPackBuilder& builder,
@@ -234,6 +332,12 @@ void IResearchRocksDBInvertedIndex::toVelocyPack(
               arangodb::velocypack::Value(name()));
   builder.add(arangodb::StaticStrings::IndexUnique, VPackValue(unique()));
   builder.add(arangodb::StaticStrings::IndexSparse, VPackValue(sparse()));
+
+  if (Index::hasFlag(flags, Index::Serialize::Figures)) {
+    builder.add("figures", VPackValue(VPackValueType::Object));
+    toVelocyPackFigures(builder);
+    builder.close();
+  }
 }
 
 Result IResearchRocksDBInvertedIndex::drop() /*noexcept*/ {
@@ -268,5 +372,6 @@ bool IResearchRocksDBInvertedIndex::matchesDefinition(
   return IResearchInvertedIndex::matchesDefinition(
       other, IResearchDataStore::_collection.vocbase());
 }
+
 }  // namespace iresearch
 }  // namespace arangodb

--- a/arangod/IResearch/IResearchRocksDBInvertedIndex.h
+++ b/arangod/IResearch/IResearchRocksDBInvertedIndex.h
@@ -59,6 +59,16 @@ class IResearchRocksDBInvertedIndex final : public IResearchInvertedIndex,
     return Index::TRI_IDX_TYPE_INVERTED_INDEX;
   }
 
+  std::string getCollectionName() const;
+  std::string const& getShardName() const noexcept;
+
+  void insertMetrics() final;
+  void removeMetrics() final;
+
+  void toVelocyPackFigures(velocypack::Builder& builder) const final {
+    IResearchDataStore::toVelocyPackStats(builder);
+  }
+
   void toVelocyPack(
       VPackBuilder& builder,
       std::underlying_type<Index::Serialize>::type flags) const override;
@@ -151,6 +161,9 @@ class IResearchRocksDBInvertedIndex final : public IResearchInvertedIndex,
     *const_cast<std::vector<std::vector<arangodb::basics::AttributeName>>*>(
         &_fields) = IResearchInvertedIndex::fields(meta());
   }
+
+  std::string _collectionName;
 };
+
 }  // namespace iresearch
 }  // namespace arangodb

--- a/arangod/IResearch/IResearchRocksDBLink.h
+++ b/arangod/IResearch/IResearchRocksDBLink.h
@@ -94,8 +94,8 @@ class IResearchRocksDBLink final : public RocksDBIndex, public IResearchLink {
       VPackBuilder& builder,
       std::underlying_type<Index::Serialize>::type flags) const override;
 
-  void toVelocyPackFigures(VPackBuilder& builder) const override {
-    IResearchLink::toVelocyPackStats(builder);
+  void toVelocyPackFigures(velocypack::Builder& builder) const final {
+    IResearchDataStore::toVelocyPackStats(builder);
   }
 
   IndexType type() const override { return IResearchLink::type(); }

--- a/arangod/Metrics/ClusterMetricsFeature.h
+++ b/arangod/Metrics/ClusterMetricsFeature.h
@@ -70,6 +70,15 @@ class ClusterMetricsFeature final : public ArangodFeature {
     Values values;
 
     void toVelocyPack(VPackBuilder& builder) const;
+
+    template<typename T>
+    T get(std::string_view key, std::string_view labels) const {
+      auto it = values.find(MetricKeyView{key, labels});
+      if (it != values.end()) {
+        return std::get<T>(it->second);
+      }
+      return {};
+    }
   };
 
   struct Data final {

--- a/tests/Mocks/IResearchInvertedIndexMock.cpp
+++ b/tests/Mocks/IResearchInvertedIndexMock.cpp
@@ -52,6 +52,12 @@ void IResearchInvertedIndexMock::toVelocyPack(
               arangodb::velocypack::Value(name()));
   builder.add(arangodb::StaticStrings::IndexUnique, VPackValue(unique()));
   builder.add(arangodb::StaticStrings::IndexSparse, VPackValue(sparse()));
+
+  if (Index::hasFlag(flags, Index::Serialize::Figures)) {
+    builder.add("figures", VPackValue(VPackValueType::Object));
+    toVelocyPackFigures(builder);
+    builder.close();
+  }
 }
 
 Index::IndexType IResearchInvertedIndexMock::type() const {
@@ -139,11 +145,6 @@ Result IResearchInvertedIndexMock::insert(transaction::Methods& trx,
 AnalyzerPool::ptr IResearchInvertedIndexMock::findAnalyzer(
     AnalyzerPool const& analyzer) const {
   return IResearchInvertedIndex::findAnalyzer(analyzer);
-}
-
-void IResearchInvertedIndexMock::toVelocyPackFigures(
-    velocypack::Builder& builder) const {
-  IResearchInvertedIndex::toVelocyPackStats(builder);
 }
 
 void IResearchInvertedIndexMock::unload() { shutdownDataStore(); }

--- a/tests/Mocks/IResearchInvertedIndexMock.h
+++ b/tests/Mocks/IResearchInvertedIndexMock.h
@@ -53,6 +53,10 @@ class IResearchInvertedIndexMock final : public Index,
       VPackBuilder& builder,
       std::underlying_type<Index::Serialize>::type flags) const final;
 
+  void toVelocyPackFigures(velocypack::Builder& builder) const final {
+    IResearchDataStore::toVelocyPackStats(builder);
+  }
+
   IndexType type() const final;
 
   // CHECK IT
@@ -101,8 +105,6 @@ class IResearchInvertedIndexMock final : public Index,
                 velocypack::Slice doc);
 
   AnalyzerPool::ptr findAnalyzer(AnalyzerPool const& analyzer) const final;
-
-  void toVelocyPackFigures(velocypack::Builder& builder) const final;
 
   void unload() final;
 

--- a/tests/Mocks/IResearchLinkMock.h
+++ b/tests/Mocks/IResearchLinkMock.h
@@ -90,8 +90,8 @@ class IResearchLinkMock final : public arangodb::Index, public IResearchLink {
       arangodb::velocypack::Builder& builder,
       std::underlying_type<arangodb::Index::Serialize>::type) const override;
 
-  void toVelocyPackFigures(velocypack::Builder& builder) const override {
-    IResearchLink::toVelocyPackStats(builder);
+  void toVelocyPackFigures(velocypack::Builder& builder) const final {
+    IResearchDataStore::toVelocyPackStats(builder);
   }
 
   IndexType type() const override { return IResearchLink::type(); }

--- a/tests/js/common/aql/aql-view-arangosearch-ddl-cluster.js
+++ b/tests/js/common/aql/aql-view-arangosearch-ddl-cluster.js
@@ -947,15 +947,26 @@ function IResearchFeatureDDLTestSuite() {
         consolidationIntervalMsec: 0, // disable consolidation
         cleanupIntervalStep: 0        // disable cleanup
       });
-      view.properties({ links: { [colName]: { includeAllFields: true } } });
+      view.properties({links: {[colName]: {includeAllFields: true}}});
+
+      const idx = col.ensureIndex({
+        name: "TestIndex",
+        type: "inverted",
+        includeAllFields: true,
+        commitIntervalMsec: 1,
+        consolidationIntervalMsec: 0, // disable consolidation
+        cleanupIntervalStep: 0        // disable cleanup
+      });
+
+      const types = ["arangosearch", "inverted"];
 
       triggerMetrics();
 
       // check link stats
-      {
+      for (const type of types) {
         let figures = db.TestCollection.getIndexes(true, true)
-                                    .find(e => e.type === 'arangosearch')
-                                    .figures;
+          .find(e => e.type === type)
+          .figures;
         assertNotEqual(null, figures);
         assertTrue(Object === figures.constructor);
         assertEqual(5, Object.keys(figures).length);
@@ -967,15 +978,14 @@ function IResearchFeatureDDLTestSuite() {
       }
 
       // insert documents
-      col.save({ foo: 'bar' });
-      col.save({ foo: 'baz' });
+      col.save([{foo: 'bar'}, {foo: 'baz'}]);
 
       triggerMetrics();
 
       // check link stats
       {
         let figures = db.TestCollection.getIndexes(true, true)
-                                    .find(e => e.type === 'arangosearch')
+          .find(e => e.type === "arangosearch")
                                     .figures;
         assertNotEqual(null, figures);
         assertTrue(Object === figures.constructor);
@@ -987,19 +997,30 @@ function IResearchFeatureDDLTestSuite() {
         assertEqual(0, figures.numSegments);
       }
 
+      let syncIndex = function (expected) {
+        const syncQuery = `FOR d IN TestCollection OPTIONS {indexHint: "TestIndex"}
+                            FILTER d.foo != "unknown" COLLECT WITH COUNT INTO c RETURN c`;
+        let syncWait = 100;
+        let count = db._query(syncQuery).toArray()[0];
+        while (count < expected && (--syncWait) > 0) {
+          require("internal").sleep(1);
+          count = db._query(syncQuery).toArray()[0];
+        }
+      };
       // ensure data is synchronized
       var res = db._query("FOR d IN TestView OPTIONS {waitForSync:true} SORT d.foo RETURN d").toArray();
       assertEqual(2, res.length);
       assertEqual('bar', res[0].foo);
       assertEqual('baz', res[1].foo);
+      syncIndex(2);
 
       triggerMetrics();
 
       // check link stats
-      {
+      for (const type of types) {
         let figures = db.TestCollection.getIndexes(true, true)
-                                    .find(e => e.type === 'arangosearch')
-                                    .figures;
+          .find(e => e.type === type)
+          .figures;
         assertNotEqual(null, figures);
         assertTrue(Object === figures.constructor);
         assertEqual(5, Object.keys(figures).length);
@@ -1017,14 +1038,15 @@ function IResearchFeatureDDLTestSuite() {
       res = db._query("FOR d IN TestView OPTIONS {waitForSync:true} SORT d.foo RETURN d").toArray();
       assertEqual(1, res.length);
       assertEqual('baz', res[0].foo);
+      syncIndex(1);
 
       triggerMetrics();
 
       // check link stats
-      {
+      for (const type of types) {
         let figures = db.TestCollection.getIndexes(true, true)
-                                    .find(e => e.type === 'arangosearch')
-                                    .figures;
+          .find(e => e.type === type)
+          .figures;
         assertNotEqual(null, figures);
         assertTrue(Object === figures.constructor);
         assertEqual(5, Object.keys(figures).length);
@@ -1041,14 +1063,15 @@ function IResearchFeatureDDLTestSuite() {
       // ensure data is synchronized
       res = db._query("FOR d IN TestView OPTIONS {waitForSync:true} SORT d.foo RETURN d").toArray();
       assertEqual(0, res.length);
+      syncIndex(0);
 
       triggerMetrics();
 
       // check link stats
-      {
+      for (const type of types) {
         let figures = db.TestCollection.getIndexes(true, true)
-                                    .find(e => e.type === 'arangosearch')
-                                    .figures;
+          .find(e => e.type === type)
+          .figures;
         assertNotEqual(null, figures);
         assertTrue(Object === figures.constructor);
         assertEqual(5, Object.keys(figures).length);


### PR DESCRIPTION
### Scope & Purpose

* SEARCH-341 Stats for inverted index are not shown in arangosh
* SEARCH-340 Metrics for inverted index do not exist

cherry picked from commit dcbce7f28a51aa47b736cb4b891a59c91a0c930a

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: *(Please link PR)*
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

