### PR TITLE
BTS-1000: wait for agency to give us a good state before we start firing up the rest of the instance

### DIFF
--- a/js/client/modules/@arangodb/testsuites/server_permissions.js
+++ b/js/client/modules/@arangodb/testsuites/server_permissions.js
@@ -267,9 +267,12 @@ function server_secrets(options) {
 
   let secretsDir = fs.join(fs.getTempPath(), 'arango_jwt_secrets');
   fs.makeDirectory(secretsDir);
-
-  fs.write(fs.join(secretsDir, 'secret1'), 'jwtsecret-1');
-  fs.write(fs.join(secretsDir, 'secret2'), 'jwtsecret-2');
+  let secretFiles = [
+    fs.join(secretsDir, 'secret1'),
+    fs.join(secretsDir, 'secret2')
+  ];
+  fs.write(secretFiles[0], 'jwtsecret-1');
+  fs.write(secretFiles[1], 'jwtsecret-2');
 
   process.env["jwt-secret-folder"] = secretsDir;
 
@@ -285,6 +288,7 @@ function server_secrets(options) {
   let copyOptions = _.clone(options);
   // necessary to fix shitty process-utils handling
   copyOptions['server.jwt-secret-folder'] = secretsDir;
+  copyOptions['jwtFiles'] = secretFiles;
   copyOptions['protocol'] = "ssl";
 
   const testCases = tu.scanTestPaths([tu.pathForTesting('client/server_secrets')], copyOptions);

--- a/js/client/modules/@arangodb/testsuites/server_permissions.js
+++ b/js/client/modules/@arangodb/testsuites/server_permissions.js
@@ -94,6 +94,7 @@ class permissionsRunner extends tu.runLocalInArangoshRunner {
         let paramsSecondRun = executeScript(content, true, te);
         let rootDir = fs.join(fs.getTempPath(), count.toString());
         let runSetup = paramsSecondRun.hasOwnProperty('runSetup');
+        clonedOpts['startupMaxCount'] = 600; // Slow startups may occur on slower machines.
         if (paramsSecondRun.hasOwnProperty('server.jwt-secret')) {
           clonedOpts['server.jwt-secret'] = paramsSecondRun['server.jwt-secret'];
         }

--- a/js/client/modules/@arangodb/testutils/crash-utils.js
+++ b/js/client/modules/@arangodb/testutils/crash-utils.js
@@ -216,8 +216,16 @@ Crash analysis of: ` + JSON.stringify(instanceInfo.getStructure()) + '\n';
 // / We assume the system has core files in /cores/, and we have a lldb.
 // //////////////////////////////////////////////////////////////////////////////
 
-function generateCoreDumpMac (instanceInfo, options, storeArangodPath, pid) {
+function generateCoreDumpMac (instanceInfo, options, storeArangodPath, pid, generateCoreDump) {
   let lldbOutputFile = fs.getTempFile();
+  let gcore = '';
+  if (generateCoreDump) {
+    if (options.coreDirectory === '') {
+      gcore = ` process save-core core.${instanceInfo.pid}\\n`;
+    } else {
+      gcore = ` process save-core ${options.coreDirectory}/core.${instanceInfo.pid}\\n`;
+    }
+  }
 
   let command;
   command = '(';
@@ -228,7 +236,7 @@ function generateCoreDumpMac (instanceInfo, options, storeArangodPath, pid) {
     command += 'frame variable\\n up \\n';
   }
   command += ` thread backtrace all\\n`;
-  command += ` process save-core /cores/core.${pid}\\n`;
+  command += gcore;
   command += ` kill\\n';`;
   command += 'sleep 10;';
   command += 'echo quit;';

--- a/js/client/modules/@arangodb/testutils/crash-utils.js
+++ b/js/client/modules/@arangodb/testutils/crash-utils.js
@@ -234,7 +234,7 @@ function generateCoreDumpMac (instanceInfo, options, storeArangodPath, pid) {
   command += 'echo quit;';
   command += 'sleep 2';
   command += ') | lldb ';
-  command += ` --attach-pid ${pid}`;
+  command += ` --attach-pid ${pid} `;
   command += storeArangodPath;
   command += ' > ' + lldbOutputFile + ' 2>&1';
   const args = ['-c', command];

--- a/js/client/modules/@arangodb/testutils/crash-utils.js
+++ b/js/client/modules/@arangodb/testutils/crash-utils.js
@@ -606,10 +606,22 @@ function aggregateDebugger(instanceInfo, options) {
   GDB_OUTPUT += `
 --------------------------------------------------------------------------------
 Crash analysis of: ` + JSON.stringify(instanceInfo.getStructure()) + '\n';
-  let thisDump = fs.read(instanceInfo.debuggerInfo.file);
-  GDB_OUTPUT += thisDump;
-  if (options.extremeVerbosity === true && instanceInfo.debuggerInfo.verbosePrint) {
-    print(thisDump);
+  const buf = fs.readBuffer(instanceInfo.debuggerInfo.file);
+  let lineStart = 0;
+  let maxBuffer = buf.length;
+
+  for (let j = 0; j < maxBuffer; j++) {
+    if (buf[j] === 10) { // \n
+      const line = buf.asciiSlice(lineStart, j);
+      lineStart = j + 1;
+      if (line.search('bytes of data for memory region at') !== -1) {
+        continue;
+      }
+      GDB_OUTPUT += line + '\n';
+      if (options.extremeVerbosity === true && instanceInfo.debuggerInfo.verbosePrint) {
+        print(line);
+      }
+    }
   }
   return instanceInfo.debuggerInfo.hint;
 }

--- a/js/client/modules/@arangodb/testutils/instance-manager.js
+++ b/js/client/modules/@arangodb/testutils/instance-manager.js
@@ -976,7 +976,7 @@ class instanceManager {
         let reply = this.agencyConfig.agencyInstances[agentIndex].getAgent('/_api/agency/state', 'GET');
         if (this.options.extremeVerbosity) {
           print("Response ====> ");
-          print(res);
+          print(reply);
         }
         if (!reply.error && reply.code === 200) {
           let res = JSON.parse(reply.body);

--- a/js/client/modules/@arangodb/testutils/instance-manager.js
+++ b/js/client/modules/@arangodb/testutils/instance-manager.js
@@ -995,7 +995,7 @@ class instanceManager {
       jwt: crypto.jwtEncode(this.arangods[0].args['server.jwt-secret'], {'server_id': 'none', 'iss': 'arangodb'}, 'HS256'),
       headers: {'content-type': 'application/json' }
     };
-    let count = 20;
+    let count = 60;
     while (count > 0) {
       let reply = download(this.agencyConfig.urls[0] + '/_api/agency/read', '[["/arango/Plan/AsyncReplication/Leader"]]', opts);
 

--- a/js/client/modules/@arangodb/testutils/instance-manager.js
+++ b/js/client/modules/@arangodb/testutils/instance-manager.js
@@ -83,6 +83,11 @@ class instanceManager {
     this.tcpdump = null;
     this.JWT = null;
     this.cleanup = options.cleanup && options.server === undefined;
+    if (!options.hasOwnProperty('startupMaxCount')) {
+      this.startupMaxCount = 300;
+    } else {
+      this.startupMaxCount = options.startupMaxCount;
+    }
     if (addArgs.hasOwnProperty('server.jwt-secret')) {
       this.JWT = addArgs['server.jwt-secret'];
     }
@@ -969,22 +974,22 @@ class instanceManager {
     while (count > 0) {
       for (let agentIndex = 0; agentIndex < this.agencyConfig.agencySize; agentIndex ++) {
         let reply = this.agencyConfig.agencyInstances[agentIndex].getAgent('/_api/agency/state', 'GET');
+        if (this.options.extremeVerbosity) {
+          print("Response ====> ");
+          print(res);
+        }
         if (!reply.error && reply.code === 200) {
           let res = JSON.parse(reply.body);
-          if (this.options.extremeVerbosity) {
-            print("Response ====> ");
-            print(res);
-          }
           if (res.hasOwnProperty('agency')){
             print("Agency Up!");
             return;
           }
-          count --;
           if (count === 0) {
             throw new Error("Agency didn't come alive in time!");
           }
         }
         sleep(0.5);
+        count --;
       }
     }
   }
@@ -1275,7 +1280,7 @@ class instanceManager {
               throw new Error('startup failed! bailing out!');
             }
           }
-          if (count === 300) {
+          if (count === this.startupMaxCount) {
             throw new Error('startup timed out! bailing out!');
           }
         }

--- a/js/client/modules/@arangodb/testutils/instance-manager.js
+++ b/js/client/modules/@arangodb/testutils/instance-manager.js
@@ -984,9 +984,9 @@ class instanceManager {
             print("Agency Up!");
             return;
           }
-          if (count === 0) {
-            throw new Error("Agency didn't come alive in time!");
-          }
+        }
+        if (count === 0) {
+          throw new Error("Agency didn't come alive in time!");
         }
         sleep(0.5);
         count --;

--- a/js/client/modules/@arangodb/testutils/instance.js
+++ b/js/client/modules/@arangodb/testutils/instance.js
@@ -215,13 +215,14 @@ class instance {
     if (process.env.hasOwnProperty('COREDIR')) {
       this.coreDirectory = process.env['COREDIR'];
     }
+    this.JWT = null;
+    this.jwtFiles = null;
     this._makeArgsArangod();
     
     this.name = instanceRole + ' - ' + this.port;
     this.pid = null;
     this.exitStatus = null;
     this.serverCrashedLocal = false;
-    this.JWT = null;
     this.netstat = {'in':{}, 'out': {}};
   }
 
@@ -248,6 +249,7 @@ class instance {
       pid: this.pid,
       id: this.id,
       JWT: this.JWT,
+      jwtFiles: this.jwtFiles,
       exitStatus: this.exitStatus,
       serverCrashedLocal: this.serverCrashedLocal
     };
@@ -274,6 +276,7 @@ class instance {
     this.pid = struct['pid'];
     this.id = struct['id'];
     this.JWT = struct['JWT'];
+    this.jwtFiles = struct['jwtFiles'];
     this.exitStatus = struct['exitStatus'];
     this.serverCrashedLocal = struct['serverCrashedLocal'];
   }
@@ -354,12 +357,15 @@ class instance {
     if (this.options.encryptionAtRest && !this.args.hasOwnProperty('rocksdb.encryption-keyfile')) {
       this.args['rocksdb.encryption-keyfile'] = this.restKeyFile;
     }
+
     if (this.restKeyFile && !this.args.hasOwnProperty('server.jwt-secret')) {
       this.args['server.jwt-secret'] = this.restKeyFile;
     }
-    //TODO server_secrets else if (addArgs['server.jwt-secret-folder'] && !instanceInfo.authOpts['server.jwt-secret-folder']) {
+    else if (this.options.hasOwnProperty('jwtFiles')) {
+      this.jwtFiles = this.options['jwtFiles'];
     // instanceInfo.authOpts['server.jwt-secret-folder'] = addArgs['server.jwt-secret-folder'];
-    //}
+    }
+
     this.args = Object.assign(this.args, this.options.extraArgs);
 
     if (this.options.verbose) {
@@ -811,25 +817,20 @@ class instance {
     let opts = {
       method: method
     };
+
     if (this.args.hasOwnProperty('authOpts')) {
       opts['jwt'] = crypto.jwtEncode(this.authOpts['server.jwt-secret'], {'server_id': 'none', 'iss': 'arangodb'}, 'HS256');
     } else if (this.args.hasOwnProperty('server.jwt-secret')) {
       opts['jwt'] = crypto.jwtEncode(this.args['server.jwt-secret'], {'server_id': 'none', 'iss': 'arangodb'}, 'HS256');
+    } else if (this.jwtFiles) {
+      opts['jwt'] = crypto.jwtEncode(fs.read(this.jwtFiles[0]), {'server_id': 'none', 'iss': 'arangodb'}, 'HS256');
     }
     return download(this.url + path, method === 'POST' ? '[["/"]]' : '', opts);
   }
 
   dumpAgent(path, method, fn) {
-    let opts = {
-      method: method
-    };
-    if (this.args.hasOwnProperty('authOpts')) {
-      opts['jwt'] = crypto.jwtEncode(this.authOpts['server.jwt-secret'], {'server_id': 'none', 'iss': 'arangodb'}, 'HS256');
-    } else if (this.args.hasOwnProperty('server.jwt-secret')) {
-      opts['jwt'] = crypto.jwtEncode(this.args['server.jwt-secret'], {'server_id': 'none', 'iss': 'arangodb'}, 'HS256');
-    }
     print('--------------------------------- '+ fn + ' -----------------------------------------------');
-    let agencyReply = download(this.url + path, method === 'POST' ? '[["/"]]' : '', opts);
+    let agencyReply = this.getAgent(path, method);
     if (agencyReply.code === 200) {
       let agencyValue = JSON.parse(agencyReply.body);
       fs.write(fs.join(this.options.testOutputDirectory, fn + '_' + this.pid + ".json"), JSON.stringify(agencyValue, null, 2));


### PR DESCRIPTION
### Scope & Purpose

On slower systems firing up all instances at once and waiting for the dust to settle doesn't seem to work out in all cases.
 - first start the agency and wait for it to be ready.
 - add a way to dynamically wait for instance readyness for `server_parameter` tests and copying of javascript files
 - fix lldb attach + coredump
 - filter verbose lldb writing coredump messages
 - give more time for active failover to detect a leader
 - fix managing of agency URLs in agency config

- [x] :hankey: Bugfix
