### PR TITLE
[PREGEL]replaced "PageRank" by "pagerank" everywhere in the API

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 devel
 -----
 
+* Now the Pregel API returns `{... algorithm: "pagerank", ...}` instead of
+`{... algorithm: "PageRank", ...}` when the Page Rank algorithm is run
+(in accordance to the documentation).
+
 * Updated arangosync to v2.12.0-preview-11.
 
 * Added integration tests for `--log.escape-control-chars` and 

--- a/arangod/Pregel/Algos/ConnectedComponents.h
+++ b/arangod/Pregel/Algos/ConnectedComponents.h
@@ -39,7 +39,7 @@ struct ConnectedComponents
  public:
   explicit ConnectedComponents(application_features::ApplicationServer& server,
                                VPackSlice userParams)
-      : SimpleAlgorithm(server, "ConnectedComponents", userParams) {}
+      : SimpleAlgorithm(server, "connectedcomponents", userParams) {}
 
   bool supportsAsyncMode() const override { return true; }
   bool supportsCompensation() const override { return true; }

--- a/arangod/Pregel/Algos/EffectiveCloseness/EffectiveCloseness.h
+++ b/arangod/Pregel/Algos/EffectiveCloseness/EffectiveCloseness.h
@@ -36,7 +36,7 @@ struct EffectiveCloseness
   explicit EffectiveCloseness(application_features::ApplicationServer& server,
                               VPackSlice params)
       : SimpleAlgorithm<ECValue, int8_t, HLLCounter>(
-            server, "EffectiveCloseness", params) {}
+            server, "effectivecloseness", params) {}
 
   GraphFormat<ECValue, int8_t>* inputFormat() const override;
   MessageFormat<HLLCounter>* messageFormat() const override;

--- a/arangod/Pregel/Algos/HITS.h
+++ b/arangod/Pregel/Algos/HITS.h
@@ -49,7 +49,7 @@ struct HITS : public SimpleAlgorithm<HITSValue, int8_t, SenderMessage<double>> {
   explicit HITS(application_features::ApplicationServer& server,
                 VPackSlice userParams)
       : SimpleAlgorithm<HITSValue, int8_t, SenderMessage<double>>(
-            server, "HITS", userParams) {}
+            server, "hits", userParams) {}
 
   GraphFormat<HITSValue, int8_t>* inputFormat() const override;
   MessageFormat<SenderMessage<double>>* messageFormat() const override {

--- a/arangod/Pregel/Algos/LabelPropagation.h
+++ b/arangod/Pregel/Algos/LabelPropagation.h
@@ -42,7 +42,7 @@ struct LabelPropagation : public SimpleAlgorithm<LPValue, int8_t, uint64_t> {
  public:
   explicit LabelPropagation(application_features::ApplicationServer& server,
                             VPackSlice userParams)
-      : SimpleAlgorithm<LPValue, int8_t, uint64_t>(server, "LabelPropagation",
+      : SimpleAlgorithm<LPValue, int8_t, uint64_t>(server, "labelpropagation",
                                                    userParams) {}
 
   GraphFormat<LPValue, int8_t>* inputFormat() const override;

--- a/arangod/Pregel/Algos/LineRank.cpp
+++ b/arangod/Pregel/Algos/LineRank.cpp
@@ -41,7 +41,7 @@ static const float EPS = 0.0000001f;
 
 LineRank::LineRank(application_features::ApplicationServer& server,
                    arangodb::velocypack::Slice params)
-    : SimpleAlgorithm(server, "LineRank", params) {
+    : SimpleAlgorithm(server, "linerank", params) {
   // VPackSlice t = params.get("convergenceThreshold");
   //_threshold = t.isNumber() ? t.getNumber<float>() : 0.000002f;
 }

--- a/arangod/Pregel/Algos/PageRank.cpp
+++ b/arangod/Pregel/Algos/PageRank.cpp
@@ -53,7 +53,7 @@ struct PRWorkerContext : public WorkerContext {
 
 PageRank::PageRank(application_features::ApplicationServer& server,
                    VPackSlice const& params)
-    : SimpleAlgorithm(server, "PageRank", params),
+    : SimpleAlgorithm(server, "pagerank", params),
       _useSource(params.hasKey("sourceField")) {}
 
 /// will use a seed value for pagerank if available

--- a/arangod/Pregel/Algos/RecoveringPageRank.h
+++ b/arangod/Pregel/Algos/RecoveringPageRank.h
@@ -34,7 +34,7 @@ namespace algos {
 struct RecoveringPageRank : public SimpleAlgorithm<float, float, float> {
   explicit RecoveringPageRank(application_features::ApplicationServer& server,
                               arangodb::velocypack::Slice params)
-      : SimpleAlgorithm(server, "PageRank", params) {}
+      : SimpleAlgorithm(server, "pagerank", params) {}
 
   bool supportsCompensation() const override { return true; }
   MasterContext* masterContext(VPackSlice userParams) const override;

--- a/arangod/Pregel/Algos/SCC.h
+++ b/arangod/Pregel/Algos/SCC.h
@@ -49,7 +49,7 @@ struct SCC : public SimpleAlgorithm<SCCValue, int8_t, SenderMessage<uint64_t>> {
   explicit SCC(application_features::ApplicationServer& server,
                VPackSlice userParams)
       : SimpleAlgorithm<SCCValue, int8_t, SenderMessage<uint64_t>>(
-            server, "SCC", userParams) {}
+            server, "scc", userParams) {}
 
   GraphFormat<SCCValue, int8_t>* inputFormat() const override;
   MessageFormat<SenderMessage<uint64_t>>* messageFormat() const override {

--- a/arangod/Pregel/Algos/SSSP.h
+++ b/arangod/Pregel/Algos/SSSP.h
@@ -38,7 +38,7 @@ class SSSPAlgorithm : public Algorithm<int64_t, int64_t, int64_t> {
  public:
   explicit SSSPAlgorithm(application_features::ApplicationServer& server,
                          VPackSlice userParams)
-      : Algorithm(server, "SSSP") {
+      : Algorithm(server, "sssp") {
     if (!userParams.isObject() || !userParams.hasKey("source")) {
       THROW_ARANGO_EXCEPTION_MESSAGE(
           TRI_ERROR_BAD_PARAMETER,

--- a/arangod/Pregel/Algos/WCC.h
+++ b/arangod/Pregel/Algos/WCC.h
@@ -39,7 +39,7 @@ struct WCC
  public:
   explicit WCC(application_features::ApplicationServer& server,
                VPackSlice userParams)
-      : SimpleAlgorithm(server, "WCC", userParams) {}
+      : SimpleAlgorithm(server, "wcc", userParams) {}
 
   bool supportsAsyncMode() const override { return false; }
   bool supportsCompensation() const override { return false; }

--- a/js/client/modules/@arangodb/air/single-source-shortest-paths.js
+++ b/js/client/modules/@arangodb/air/single-source-shortest-paths.js
@@ -147,7 +147,7 @@ function exec_test_shortest_path_impl(graphSpec) {
     "Air SSSP",
     single_source_shortest_paths(
       graphSpec.name,
-      "SSSP",
+      "sssp",
       from_vertex,
     ));
 

--- a/js/client/modules/@arangodb/air/strongly-connected-components.js
+++ b/js/client/modules/@arangodb/air/strongly-connected-components.js
@@ -194,7 +194,7 @@ function strongly_connected_components(graphName, resultField) {
 function exec_test_scc_on_graph(graphSpec, components = []) {
   let status = testhelpers.wait_for_pregel(
     "Air Strongly Connected Components",
-    strongly_connected_components(graphSpec.name, "SCC")
+    strongly_connected_components(graphSpec.name, "scc")
   );
 
   // TODO: Verify SSC result

--- a/tests/js/client/load-balancing/load-balancing-pregel-noauth-cluster.js
+++ b/tests/js/client/load-balancing/load-balancing-pregel-noauth-cluster.js
@@ -127,7 +127,7 @@ function PregelSuite () {
       assertEqual(result.status, 200);
       assertEqual(5, result.body.length);
       result.body.forEach((task) => {
-        assertEqual("PageRank", task.algorithm);
+        assertEqual("pagerank", task.algorithm);
         assertEqual(db._name(), task.database);
         assertNotEqual(-1, ids.indexOf(task.id));
       });

--- a/tests/js/common/shell/shell-pregel-random.js
+++ b/tests/js/common/shell/shell-pregel-random.js
@@ -246,7 +246,7 @@ function randomTestSuite() {
       assertTrue(stats.hasOwnProperty('id'));
       assertEqual(stats.id, key);
       assertEqual("_system", stats.database);
-      assertEqual("HITS", stats.algorithm);
+      assertEqual("hits", stats.algorithm);
       assertTrue(stats.hasOwnProperty('created'));
       assertTrue(stats.hasOwnProperty('ttl'));
       assertEqual(15, stats.ttl);
@@ -299,7 +299,7 @@ function randomTestSuite() {
           if (initialIds.indexOf(job.id) === -1) {
             assertEqual(5, job.ttl);
             assertEqual("_system", job.database);
-            assertEqual("HITS", job.algorithm);
+            assertEqual("hits", job.algorithm);
             found.push(job.id);
           }
         });


### PR DESCRIPTION
### Scope & Purpose

Replaced "PageRank" by "pagerank" in the internal and the API of Pregel. 

Now when the PageRank algorithm is run, `... GET /_api/control_pregel/{id}` returns 
```
{
...
	"algorithm": "pagerank",
...
}
```
instead of 
```
{
...
	"algorithm": "PageRank",
...
}
```
- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: *(Please link PR)*
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [x] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/BTS-971
- [ ] Design document: 

