### PR TITLE
Fixed a rare traversal issue (Satellite -> DisjointSmartGraph & OneShard rule)

### DIFF
--- a/arangod/Aql/GraphNode.cpp
+++ b/arangod/Aql/GraphNode.cpp
@@ -184,6 +184,7 @@ GraphNode::GraphNode(ExecutionPlan* plan, ExecutionNodeId id,
       _optionsBuilt(false),
       _isSmart(false),
       _isDisjoint(false),
+      _enabledClusterOneShardRule(false),
       _options(std::move(options)) {
   // Direction is already the correct Integer.
   // Is not inserted by user but by enum.
@@ -371,7 +372,10 @@ GraphNode::GraphNode(ExecutionPlan* plan,
       _isSmart(arangodb::basics::VelocyPackHelper::getBooleanValue(
           base, StaticStrings::IsSmart, false)),
       _isDisjoint(arangodb::basics::VelocyPackHelper::getBooleanValue(
-          base, StaticStrings::IsDisjoint, false)) {
+          base, StaticStrings::IsDisjoint, false)),
+      _enabledClusterOneShardRule(
+          arangodb::basics::VelocyPackHelper::getBooleanValue(
+              base, StaticStrings::IsDisjoint, false)) {
   if (!ServerState::instance()->isDBServer()) {
     // Graph Information. Do we need to reload the graph here?
     std::string graphName;
@@ -533,6 +537,7 @@ GraphNode::GraphNode(ExecutionPlan* plan, ExecutionNodeId id,
       _optionsBuilt(false),
       _isSmart(false),
       _isDisjoint(false),
+      _enabledClusterOneShardRule(false),
       _directions(std::move(directions)),
       _options(std::move(options)) {
   setGraphInfoAndCopyColls(edgeColls, vertexColls);
@@ -542,6 +547,7 @@ GraphNode::GraphNode(ExecutionPlan* plan, ExecutionNodeId id,
 void GraphNode::determineEnterpriseFlags(AstNode const*) {
   _isSmart = false;
   _isDisjoint = false;
+  _enabledClusterOneShardRule = false;
 }
 #endif
 
@@ -576,6 +582,7 @@ GraphNode::GraphNode(ExecutionPlan& plan, GraphNode const& other,
       _optionsBuilt(false),
       _isSmart(other.isSmart()),
       _isDisjoint(other.isDisjoint()),
+      _enabledClusterOneShardRule(other.isClusterOneShardRuleEnabled()),
       _directions(other._directions),
       _options(std::move(options)),
       _collectionToShard(other._collectionToShard) {
@@ -1029,5 +1036,9 @@ bool GraphNode::isLocalGraphNode() const { return false; }
 
 void GraphNode::waitForSatelliteIfRequired(
     ExecutionEngine const* engine) const {}
+
+void GraphNode::enableClusterOneShardRule(bool enable) { TRI_ASSERT(false); }
+
+bool GraphNode::isClusterOneShardRuleEnabled() const { return false; }
 
 #endif

--- a/arangod/Aql/GraphNode.h
+++ b/arangod/Aql/GraphNode.h
@@ -212,6 +212,10 @@ class GraphNode : public ExecutionNode {
 
   void setIsDisjoint(bool target) { _isDisjoint = target; }
 #endif
+
+  void enableClusterOneShardRule(bool enable);
+  bool isClusterOneShardRuleEnabled() const;
+
  protected:
   void doToVelocyPack(arangodb::velocypack::Builder& nodes,
                       unsigned flags) const override;
@@ -278,6 +282,10 @@ class GraphNode : public ExecutionNode {
 
   /// @brief flag, if graph is smart *and* disjoint (Enterprise Edition only!)
   bool _isDisjoint;
+
+  /// @brief flag, if the graph being used inside the clusterOneShardRule
+  /// optimization (Enterprise Edition only!)
+  bool _enabledClusterOneShardRule;
 
   /// @brief The directions edges are followed
   std::vector<TRI_edge_direction_e> _directions;

--- a/arangod/Aql/QueryOptions.cpp
+++ b/arangod/Aql/QueryOptions.cpp
@@ -221,7 +221,8 @@ void QueryOptions::fromVelocyPack(VPackSlice slice) {
   // note: skipAudit is intentionally not read here.
   // the end user cannot override this setting
 
-  if (value = slice.get("forceOneShardAttributeValue"); value.isString()) {
+  if (value = slice.get(StaticStrings::ForceOneShardAttributeValue);
+      value.isString()) {
     forceOneShardAttributeValue = value.copyString();
   }
 
@@ -294,7 +295,7 @@ void QueryOptions::toVelocyPack(VPackBuilder& builder,
   builder.add("fullCount", VPackValue(fullCount));
   builder.add("count", VPackValue(count));
   if (!forceOneShardAttributeValue.empty()) {
-    builder.add("forceOneShardAttributeValue",
+    builder.add(StaticStrings::ForceOneShardAttributeValue,
                 VPackValue(forceOneShardAttributeValue));
   }
 

--- a/arangod/Aql/TraversalNode.cpp
+++ b/arangod/Aql/TraversalNode.cpp
@@ -674,7 +674,7 @@ std::unique_ptr<ExecutionBlock> TraversalNode::createBlock(
 
   PathValidatorOptions validatorOptions{
       opts->tmpVar(), opts->getExpressionCtx(), isDisjointIsSat.first,
-      isDisjointIsSat.second};
+      isDisjointIsSat.second, isClusterOneShardRuleEnabled()};
 
   // Prune Section
   if (pruneExpression() != nullptr) {

--- a/arangod/Graph/PathManagement/PathValidator.h
+++ b/arangod/Graph/PathManagement/PathValidator.h
@@ -131,7 +131,15 @@ class PathValidator {
       -> arangodb::graph::ValidationResult::Type;
 
   auto isDisjoint() const { return _options.isDisjoint(); }
-  auto isSatelliteLeader() const { return _options.isSatelliteLeader(); }
+  auto isSatelliteLeader() const {
+    if (_options.isClusterOneShardRuleEnabled()) {
+      // In case the cluster one shard rule is enabled, we will declare
+      // any shard as "a leader" - which means it can be used and in this
+      // particular case, we are sure that we cannot produce duplicate results
+      return true;
+    }
+    return _options.isSatelliteLeader();
+  }
 };
 }  // namespace graph
 }  // namespace arangodb

--- a/arangod/Graph/PathManagement/PathValidatorOptions.cpp
+++ b/arangod/Graph/PathManagement/PathValidatorOptions.cpp
@@ -36,17 +36,19 @@ PathValidatorOptions::PathValidatorOptions(
       _tmpVar(tmpVar),
       _expressionCtx(expressionContext),
       _isDisjoint(false),
-      _isSatelliteLeader(false) {}
+      _isSatelliteLeader(false),
+      _enabledClusterOneShardRule(false) {}
 
 PathValidatorOptions::PathValidatorOptions(
     aql::Variable const* tmpVar,
     arangodb::aql::FixedVarExpressionContext& expressionContext,
-    bool isDisjoint, bool isSatelliteLeader)
+    bool isDisjoint, bool isSatelliteLeader, bool enabledClusterOneShardRule)
     : _allowedVertexCollections{},
       _tmpVar(tmpVar),
       _expressionCtx(expressionContext),
       _isDisjoint(isDisjoint),
-      _isSatelliteLeader(isSatelliteLeader) {}
+      _isSatelliteLeader(isSatelliteLeader),
+      _enabledClusterOneShardRule(enabledClusterOneShardRule) {}
 
 void PathValidatorOptions::setAllVerticesExpression(
     std::unique_ptr<aql::Expression> expression) {

--- a/arangod/Graph/PathManagement/PathValidatorOptions.h
+++ b/arangod/Graph/PathManagement/PathValidatorOptions.h
@@ -50,7 +50,7 @@ class PathValidatorOptions {
   PathValidatorOptions(
       aql::Variable const* tmpVar,
       arangodb::aql::FixedVarExpressionContext& expressionContext,
-      bool isDisjoint, bool isSatelliteLeader);
+      bool isDisjoint, bool isSatelliteLeader, bool enabledClusterOneShardRule);
   ~PathValidatorOptions() = default;
   PathValidatorOptions(PathValidatorOptions&&) = default;
   PathValidatorOptions(PathValidatorOptions const&) = default;
@@ -139,6 +139,9 @@ class PathValidatorOptions {
 
   bool isDisjoint() const { return _isDisjoint; }
   bool isSatelliteLeader() const { return _isSatelliteLeader; }
+  bool isClusterOneShardRuleEnabled() const {
+    return _enabledClusterOneShardRule;
+  }
 
  private:
   // Vertex expression section
@@ -157,6 +160,7 @@ class PathValidatorOptions {
 
   bool _isDisjoint;
   bool _isSatelliteLeader;
+  bool _enabledClusterOneShardRule;
 };
 }  // namespace graph
 }  // namespace arangodb

--- a/lib/Basics/StaticStrings.cpp
+++ b/lib/Basics/StaticStrings.cpp
@@ -165,6 +165,8 @@ std::string const StaticStrings::ProducesResult("producesResult");
 std::string const StaticStrings::ReadOwnWrites("readOwnWrites");
 std::string const StaticStrings::UseCache("useCache");
 std::string const StaticStrings::Parallelism("parallelism");
+std::string const StaticStrings::ForceOneShardAttributeValue(
+    "forceOneShardAttributeValue");
 
 // HTTP headers
 std::string const StaticStrings::Accept("accept");

--- a/lib/Basics/StaticStrings.h
+++ b/lib/Basics/StaticStrings.h
@@ -163,6 +163,7 @@ class StaticStrings {
   static std::string const ReadOwnWrites;
   static std::string const UseCache;
   static std::string const Parallelism;
+  static std::string const ForceOneShardAttributeValue;
 
   // HTTP headers
   static std::string const Accept;


### PR DESCRIPTION
### Scope & Purpose

Fixed some rare traversal edge case which lead to wrong results.

Details: When a traversal inside a Disjoint SmartGraph starts in a satellite component and stays there for the complete graph search, we we're not able to return the paths in case the "ClusterOneShardRule" has been enabled by the user during query execution. 

- [x] :hankey: Bugfix

### Checklist

- [x] Tests
  - [ ] **integration tests**
- [ ] :book: CHANGELOG entry made
- [x] Backports (Yes, required for all supported versions)
  - [ ] Backport for 3.10: *(Please link PR)*
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

