### PR TITLE
add optional log output for RocksDB compactions

### DIFF
--- a/arangod/RocksDBEngine/Listeners/RocksDBMetricsListener.cpp
+++ b/arangod/RocksDBEngine/Listeners/RocksDBMetricsListener.cpp
@@ -24,6 +24,7 @@
 #include "RocksDBMetricsListener.h"
 
 #include "ApplicationFeatures/ApplicationServer.h"
+#include "Basics/debugging.h"
 #include "Logger/LogMacros.h"
 #include "Metrics/CounterBuilder.h"
 #include "Metrics/MetricsFeature.h"
@@ -43,8 +44,18 @@ RocksDBMetricsListener::RocksDBMetricsListener(ArangodServer& server)
       _writeStops(server.getFeature<metrics::MetricsFeature>().add(
           arangodb_rocksdb_write_stops_total{})) {}
 
+void RocksDBMetricsListener::OnCompactionBegin(
+    rocksdb::DB*, rocksdb::CompactionJobInfo const& info) {
+  handleCompaction("begin", info);
+}
+
+void RocksDBMetricsListener::OnCompactionCompleted(
+    rocksdb::DB*, rocksdb::CompactionJobInfo const& info) {
+  handleCompaction("completed", info);
+}
+
 void RocksDBMetricsListener::OnStallConditionsChanged(
-    const rocksdb::WriteStallInfo& info) {
+    rocksdb::WriteStallInfo const& info) {
   // we should only get here if there's an actual change
   TRI_ASSERT(info.condition.cur != info.condition.prev);
 
@@ -74,6 +85,82 @@ void RocksDBMetricsListener::OnStallConditionsChanged(
           << info.cf_name << "'";
     }
   }
+}
+
+void RocksDBMetricsListener::handleCompaction(
+    std::string_view phase, rocksdb::CompactionJobInfo const& info) const {
+  auto buildReason = [](auto const& info) {
+    std::string_view reason = "unknown";
+
+    switch (info.compaction_reason) {
+      case rocksdb::CompactionReason::kUnknown:
+        break;
+      case rocksdb::CompactionReason::kLevelL0FilesNum:
+        // [Level] number of L0 files > level0_file_num_compaction_trigger
+        reason = "number of L0 files > level0_file_num_compaction_trigger";
+        break;
+      case rocksdb::CompactionReason::kLevelMaxLevelSize:
+        // [Level] total size of level > MaxBytesForLevel()
+        reason = "total size of level > MaxBytesForLevel()";
+        break;
+      case rocksdb::CompactionReason::kManualCompaction:
+        // Manual compaction
+        reason = "manual compaction";
+        break;
+      case rocksdb::CompactionReason::kFilesMarkedForCompaction:
+        // DB::SuggestCompactRange() marked files for compaction
+        reason = "DB::SuggestCompactRange() marked files for compaction";
+        break;
+      case rocksdb::CompactionReason::kBottommostFiles:
+        // [Level] Automatic compaction within bottommost level to cleanup
+        // duplicate versions of same user key, usually due to a released
+        // snapshot.
+        reason =
+            "automatic compaction within bottommost level to cleanup duplicate "
+            "versions of same user key";
+        break;
+      case rocksdb::CompactionReason::kTtl:
+        // Compaction based on TTL
+        reason = "compaction based on TTL";
+        break;
+      case rocksdb::CompactionReason::kFlush:
+        // According to the comments in flush_job.cc, RocksDB treats flush as
+        // a level 0 compaction in internal stats.
+        reason = "flush";
+        break;
+      case rocksdb::CompactionReason::kExternalSstIngestion:
+        // Compaction caused by external sst file ingestion
+        reason = "external sst file ingestion";
+        break;
+      case rocksdb::CompactionReason::kPeriodicCompaction:
+        // Compaction due to SST file being too old
+        reason = "compaction due to SST file being too old";
+        break;
+      case rocksdb::CompactionReason::kChangeTemperature:
+        // Compaction in order to move files to temperature
+        reason = "compaction in order to move files to temperature";
+        break;
+      case rocksdb::CompactionReason::kForcedBlobGC:
+        // Compaction scheduled to force garbage collection of blob files
+        reason =
+            "compaction scheduled to force garbage collection of blob files";
+        break;
+      default:
+        break;
+    }
+
+    TRI_ASSERT(!reason.empty());
+
+    return reason;
+  };
+
+  LOG_TOPIC("1367c", DEBUG, Logger::ENGINES)
+      << "rocksdb compaction " << phase << " in column family " << info.cf_name
+      << " from base input level " << info.base_input_level
+      << " to output level " << info.output_level
+      << ", input files: " << info.input_files.size()
+      << ", output files: " << info.output_files.size()
+      << ", reason: " << buildReason(info);
 }
 
 }  // namespace arangodb

--- a/arangod/RocksDBEngine/Listeners/RocksDBMetricsListener.h
+++ b/arangod/RocksDBEngine/Listeners/RocksDBMetricsListener.h
@@ -29,6 +29,13 @@
 #include "Metrics/Fwd.h"
 #include "RestServer/arangod.h"
 
+#include <string_view>
+
+namespace rocksdb {
+struct CompactionJobInfo;
+class DB;
+}  // namespace rocksdb
+
 namespace arangodb {
 namespace application_features {
 class ApplicationServer;
@@ -40,7 +47,15 @@ class RocksDBMetricsListener : public rocksdb::EventListener {
  public:
   explicit RocksDBMetricsListener(ArangodServer&);
 
-  void OnStallConditionsChanged(const rocksdb::WriteStallInfo& info) override;
+  void OnCompactionBegin(rocksdb::DB*,
+                         rocksdb::CompactionJobInfo const&) override;
+  void OnCompactionCompleted(rocksdb::DB*,
+                             rocksdb::CompactionJobInfo const&) override;
+  void OnStallConditionsChanged(rocksdb::WriteStallInfo const& info) override;
+
+ private:
+  void handleCompaction(std::string_view phase,
+                        rocksdb::CompactionJobInfo const& info) const;
 
  protected:
   metrics::Counter& _writeStalls;


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/16996

Add optional log messages whenever RocksDB begins or completes a compaction. The log messages will show the base level and target level plus the number of files and reason for the compaction.
Log message will look like:
```
2022-09-06T10:34:35Z [24630] DEBUG [1367c] {engines} rocksdb compaction begin in column family Documents from base input level 5 to output level 6, input files: 3, output files: 0, reason: total size of level > MaxBytesForLevel()
```
Log messages will only be displayed if log level ENGINES <= debug

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [x] Backports
  - [x] Backport for 3.10: this PR
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

