### PR TITLE
BTS-1003: make test use less memory

### DIFF
--- a/tests/js/server/aql/aql-vector-functions.js
+++ b/tests/js/server/aql/aql-vector-functions.js
@@ -103,7 +103,7 @@ function BaseTestConfig (f) {
     },
 
     testWithLargeArrays : function() {
-      const vals = [ 100, 1000, 10000, 100000, 1000000, 10000000 ];
+      const vals = [ 100, 1000, 10000, 100000, 1000000 ];
       const q = `RETURN ${fn}(@val, @val)`; 
       vals.forEach((n) => { 
         let res = db._query(q, { val: buildArray(n) }); 


### PR DESCRIPTION
### Scope & Purpose

Make a specific AQL test use less memory, by reducing the maximum array size used in the test by one order of magnitude.
The change only affects tests.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [x] Backports
  - [x] Backport for 3.10: this PR
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
