### PR TITLE
[CINFRA-511] Improve transaction handling in leader state

### DIFF
--- a/arangod/Replication2/StateMachines/Document/DocumentLeaderState.cpp
+++ b/arangod/Replication2/StateMachines/Document/DocumentLeaderState.cpp
@@ -49,7 +49,7 @@ DocumentLeaderState::DocumentLeaderState(
 
 auto DocumentLeaderState::resign() && noexcept
     -> std::unique_ptr<DocumentCore> {
-  auto transactions = _activeTransactions.getLockedGuard().get();
+  auto transactions = getActiveTransactions();
   for (auto trx : transactions) {
     try {
       _transactionManager.abortManagedTrx(trx, gid.database);

--- a/arangod/Replication2/StateMachines/Document/DocumentLeaderState.cpp
+++ b/arangod/Replication2/StateMachines/Document/DocumentLeaderState.cpp
@@ -103,7 +103,6 @@ auto DocumentLeaderState::recoverEntries(std::unique_ptr<EntryIterator> ptr)
           }
         }
 
-        // TODO Add a tombstone to the TransactionManager
         return {TRI_ERROR_NO_ERROR};
       });
 }

--- a/arangod/Replication2/StateMachines/Document/DocumentLeaderState.cpp
+++ b/arangod/Replication2/StateMachines/Document/DocumentLeaderState.cpp
@@ -24,9 +24,11 @@
 #include "Replication2/StateMachines/Document/DocumentLeaderState.h"
 
 #include "Replication2/StateMachines/Document/DocumentFollowerState.h"
+#include "Replication2/StateMachines/Document/DocumentLogEntry.h"
 #include "Replication2/StateMachines/Document/DocumentStateMachine.h"
 #include "Replication2/StateMachines/Document/DocumentStateHandlersFactory.h"
 #include "Replication2/StateMachines/Document/DocumentStateTransactionHandler.h"
+#include "Transaction/Manager.h"
 
 #include <Futures/Future.h>
 #include <Logger/LogContextKeys.h>
@@ -35,16 +37,29 @@ using namespace arangodb::replication2::replicated_state::document;
 
 DocumentLeaderState::DocumentLeaderState(
     std::unique_ptr<DocumentCore> core,
-    std::shared_ptr<IDocumentStateHandlersFactory> handlersFactory)
+    std::shared_ptr<IDocumentStateHandlersFactory> handlersFactory,
+    transaction::IManager& transactionManager)
     : loggerContext(
           core->loggerContext.with<logContextKeyStateComponent>("LeaderState")),
       shardId(core->getShardId()),
       gid(core->getGid()),
       _handlersFactory(std::move(handlersFactory)),
-      _guardedData(std::move(core)) {}
+      _guardedData(std::move(core)),
+      _transactionManager(transactionManager) {}
 
 auto DocumentLeaderState::resign() && noexcept
     -> std::unique_ptr<DocumentCore> {
+  _activeTransactions.doUnderLock([this](auto& transactions) {
+    for (auto trx : transactions) {
+      try {
+        _transactionManager.abortManagedTrx(trx, gid.database);
+      } catch (...) {
+        LOG_CTX("7341f", WARN, loggerContext)
+            << "failed to abort active transaction " << gid << " during resign";
+      }
+    }
+  });
+
   return _guardedData.doUnderLock([](auto& data) {
     if (data.didResign()) {
       THROW_ARANGO_EXCEPTION(TRI_ERROR_CLUSTER_NOT_LEADER);
@@ -91,6 +106,14 @@ auto DocumentLeaderState::replicateOperation(velocypack::SharedSlice payload,
     -> futures::Future<LogIndex> {
   auto entry = DocumentLogEntry{std::string(shardId), operation,
                                 std::move(payload), transactionId};
+
+  TRI_ASSERT(operation != OperationType::kAbortAllOngoingTrx);
+  if (operation == OperationType::kCommit ||
+      operation == OperationType::kAbort) {
+    _activeTransactions.getLockedGuard()->erase(transactionId);
+  } else {
+    _activeTransactions.getLockedGuard()->emplace(transactionId);
+  }
   auto stream = getStream();
   auto idx = stream->insert(entry);
 

--- a/arangod/Replication2/StateMachines/Document/DocumentLeaderState.h
+++ b/arangod/Replication2/StateMachines/Document/DocumentLeaderState.h
@@ -54,6 +54,8 @@ struct DocumentLeaderState
                           OperationType operation, TransactionId transactionId,
                           ReplicationOptions opts) -> futures::Future<LogIndex>;
 
+  std::unordered_set<TransactionId> getActiveTransactions() const;
+
   LoggerContext const loggerContext;
   std::string_view const shardId;
   GlobalLogIdentifier const gid;

--- a/arangod/Replication2/StateMachines/Document/DocumentLeaderState.h
+++ b/arangod/Replication2/StateMachines/Document/DocumentLeaderState.h
@@ -29,6 +29,11 @@
 #include "Basics/UnshackledMutex.h"
 
 #include <memory>
+#include <unordered_set>
+
+namespace arangodb::transaction {
+struct IManager;
+}
 
 namespace arangodb::replication2::replicated_state::document {
 struct DocumentLeaderState
@@ -36,7 +41,8 @@ struct DocumentLeaderState
       std::enable_shared_from_this<DocumentLeaderState> {
   explicit DocumentLeaderState(
       std::unique_ptr<DocumentCore> core,
-      std::shared_ptr<IDocumentStateHandlersFactory> handlersFactory);
+      std::shared_ptr<IDocumentStateHandlersFactory> handlersFactory,
+      transaction::IManager& transactionManager);
 
   [[nodiscard]] auto resign() && noexcept
       -> std::unique_ptr<DocumentCore> override;
@@ -63,5 +69,7 @@ struct DocumentLeaderState
 
   std::shared_ptr<IDocumentStateHandlersFactory> _handlersFactory;
   Guarded<GuardedData, basics::UnshackledMutex> _guardedData;
+  Guarded<std::unordered_set<TransactionId>, std::mutex> _activeTransactions;
+  transaction::IManager& _transactionManager;
 };
 }  // namespace arangodb::replication2::replicated_state::document

--- a/arangod/Replication2/StateMachines/Document/DocumentStateMachine.h
+++ b/arangod/Replication2/StateMachines/Document/DocumentStateMachine.h
@@ -28,6 +28,10 @@
 
 #include <memory>
 
+namespace arangodb::transaction {
+struct IManager;
+}
+
 namespace arangodb::replication2::replicated_state {
 /**
  * The Document State Machine is used as a middle-man between a shard and a
@@ -75,7 +79,8 @@ struct DocumentCoreParameters {
 
 struct DocumentFactory {
   explicit DocumentFactory(
-      std::shared_ptr<IDocumentStateHandlersFactory> handlersFactory);
+      std::shared_ptr<IDocumentStateHandlersFactory> handlersFactory,
+      transaction::IManager& transactionManager);
 
   auto constructFollower(std::unique_ptr<DocumentCore> core)
       -> std::shared_ptr<DocumentFollowerState>;
@@ -88,6 +93,7 @@ struct DocumentFactory {
 
  private:
   std::shared_ptr<IDocumentStateHandlersFactory> const _handlersFactory;
+  transaction::IManager& _transactionManager;
 };
 }  // namespace document
 

--- a/arangod/Replication2/StateMachines/Document/DocumentStateMachineFeature.cpp
+++ b/arangod/Replication2/StateMachines/Document/DocumentStateMachineFeature.cpp
@@ -27,6 +27,8 @@
 #include "Cluster/ClusterFeature.h"
 #include "Cluster/ServerState.h"
 #include "Cluster/MaintenanceFeature.h"
+#include "Transaction/Manager.h"
+#include "Transaction/ManagerFeature.h"
 #include "RestServer/DatabaseFeature.h"
 
 #include "Replication2/StateMachines/Document/DocumentStateMachineFeature.h"
@@ -50,7 +52,8 @@ void DocumentStateMachineFeature::start() {
   replicatedStateFeature.registerStateType<DocumentState>(
       std::string{DocumentState::NAME},
       std::make_shared<DocumentStateHandlersFactory>(
-          s, clusterFeature, maintenanceFeature, databaseFeature));
+          s, clusterFeature, maintenanceFeature, databaseFeature),
+      *transaction::ManagerFeature::manager());
 }
 
 DocumentStateMachineFeature::DocumentStateMachineFeature(Server& server)

--- a/arangod/Transaction/Manager.h
+++ b/arangod/Transaction/Manager.h
@@ -55,8 +55,14 @@ class ManagerFeature;
 class Hints;
 struct Options;
 
+struct IManager {
+  virtual ~IManager() = default;
+  virtual Result abortManagedTrx(TransactionId,
+                                 std::string const& database) = 0;
+};
+
 /// @brief Tracks TransasctionState instances
-class Manager final {
+class Manager final : public IManager {
   static constexpr size_t numBuckets = 16;
   static constexpr double tombstoneTTL = 10.0 * 60.0;              // 10 minutes
   static constexpr size_t maxTransactionSize = 128 * 1024 * 1024;  // 128 MiB
@@ -176,7 +182,7 @@ class Manager final {
                                           std::string const& database) const;
 
   Result commitManagedTrx(TransactionId, std::string const& database);
-  Result abortManagedTrx(TransactionId, std::string const& database);
+  Result abortManagedTrx(TransactionId, std::string const& database) override;
 
   /// @brief collect forgotten transactions
   bool garbageCollect(bool abortAll);

--- a/tests/Replication2/ReplicatedLog/RocksDBLogTest.cpp
+++ b/tests/Replication2/ReplicatedLog/RocksDBLogTest.cpp
@@ -30,6 +30,8 @@
 #include <RocksDBEngine/RocksDBFormat.h>
 #include <RocksDBEngine/RocksDBPersistedLog.h>
 
+#include "Replication2/ReplicatedLog/TestHelper.h"
+
 using namespace arangodb;
 using namespace arangodb::replication2;
 using namespace arangodb::replication2::replicated_log;
@@ -89,29 +91,6 @@ std::string RocksDBLogTest::_path = {};
 rocksdb::DB* RocksDBLogTest::_db = nullptr;
 std::shared_ptr<RocksDBLogPersistor> RocksDBLogTest::_persistor = nullptr;
 
-namespace {
-template<typename I>
-struct SimpleIterator : PersistedLogIterator {
-  SimpleIterator(I begin, I end) : current(begin), end(end) {}
-  ~SimpleIterator() override = default;
-
-  auto next() -> std::optional<PersistingLogEntry> override {
-    if (current == end) {
-      return std::nullopt;
-    }
-
-    return *(current++);
-  }
-
-  I current, end;
-};
-
-template<typename C, typename Iter = typename C::const_iterator>
-auto make_iterator(C const& c) -> std::shared_ptr<SimpleIterator<Iter>> {
-  return std::make_shared<SimpleIterator<Iter>>(c.begin(), c.end());
-}
-}  // namespace
-
 TEST_F(RocksDBLogTest, insert_iterate) {
   auto log = createUniqueLog();
 
@@ -126,7 +105,7 @@ TEST_F(RocksDBLogTest, insert_iterate) {
         PersistingLogEntry{LogTerm{2}, LogIndex{1000},
                            LogPayload::createFromString("thousand")},
     };
-    auto iter = make_iterator(entries);
+    auto iter = test::make_iterator(entries);
 
     auto res = log->insert(*iter, {});
     ASSERT_TRUE(res.ok());
@@ -181,7 +160,7 @@ TEST_F(RocksDBLogTest, insert_remove_iterate) {
         PersistingLogEntry{LogTerm{2}, LogIndex{1000},
                            LogPayload::createFromString("thousand")},
     };
-    auto iter = make_iterator(entries);
+    auto iter = test::make_iterator(entries);
 
     auto res = log->insert(*iter, {});
     ASSERT_TRUE(res.ok());
@@ -223,7 +202,7 @@ TEST_F(RocksDBLogTest, insert_iterate_remove_iterate) {
         PersistingLogEntry{LogTerm{2}, LogIndex{1000},
                            LogPayload::createFromString("thousand")},
     };
-    auto iter = make_iterator(entries);
+    auto iter = test::make_iterator(entries);
 
     auto res = log->insert(*iter, {});
     ASSERT_TRUE(res.ok());
@@ -299,7 +278,7 @@ TEST_F(RocksDBLogTest, insert_iterate_with_meta) {
         PersistingLogEntry{LogTerm{2}, LogIndex{3},
                            LogPayload::createFromString("third")},
     };
-    auto iter = make_iterator(entries);
+    auto iter = test::make_iterator(entries);
 
     auto res = log->insert(*iter, {});
     ASSERT_TRUE(res.ok());

--- a/tests/Replication2/ReplicatedLog/TestHelper.h
+++ b/tests/Replication2/ReplicatedLog/TestHelper.h
@@ -51,6 +51,26 @@ namespace arangodb::replication2::test {
 
 using namespace replicated_log;
 
+template<typename I>
+struct SimpleIterator : PersistedLogIterator {
+  SimpleIterator(I begin, I end) : current(begin), end(end) {}
+  ~SimpleIterator() override = default;
+
+  auto next() -> std::optional<PersistingLogEntry> override {
+    if (current == end) {
+      return std::nullopt;
+    }
+
+    return *(current++);
+  }
+
+  I current, end;
+};
+template<typename C, typename Iter = typename C::const_iterator>
+auto make_iterator(C const& c) -> std::shared_ptr<SimpleIterator<Iter>> {
+  return std::make_shared<SimpleIterator<Iter>>(c.begin(), c.end());
+}
+
 struct ReplicatedLogTest : ::testing::Test {
   template<typename MockLogT = MockLog>
   auto makeLogCore(LogId id) -> std::unique_ptr<LogCore> {


### PR DESCRIPTION
### Scope & Purpose

Abort transactions and register tombstones in the transaction manager for any remaining transactions when the leader resigns, as well as transactions that are still pending after finishing recovery.

- [x] :hankey: Bugfix

### Checklist

- [x] Tests
  - [x] C++ **Unit tests**