### PR TITLE
fix wrong type for geoJson attribute (string -> boolean)

### DIFF
--- a/Documentation/DocuBlocks/Rest/Indexes/post_api_index_geo.md
+++ b/Documentation/DocuBlocks/Rest/Indexes/post_api_index_geo.md
@@ -27,7 +27,7 @@ the attribute *latitude* and of the attribute *longitude* must a
 double. All documents, which do not have the attribute paths or which
 values are not suitable, are ignored.
 
-@RESTBODYPARAM{geoJson,string,optional,string}
+@RESTBODYPARAM{geoJson,boolean,optional,}
 If a geo-spatial index on a *location* is constructed
 and *geoJson* is *true*, then the order within the array is longitude
 followed by latitude. This corresponds to the format described in


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/17012
Fix wrong type for geoJson attribute (string -> boolean) in API documentation.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [x] Backports
  - [x] Backport for 3.10: https://github.com/arangodb/arangodb/pull/17013
  - [x] Backport for 3.9: https://github.com/arangodb/arangodb/pull/17014
  - [x] Backport for 3.8: this PR

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
