### PR TITLE
[CINFRA] Fix compiler warningns in SupervisionModelChecker tests

### DIFF
--- a/tests/Replication2/ReplicatedLog/SupervisionSimulationTest.cpp
+++ b/tests/Replication2/ReplicatedLog/SupervisionSimulationTest.cpp
@@ -58,7 +58,8 @@ struct ReplicatedLogSupervisionSimulationTest
   auto makeAgencyState(Log const& log,
                        replicated_log::ParticipantsHealth health)
       -> AgencyState {
-    return AgencyState{.replicatedLog = log,
+    return AgencyState{.replicatedState = std::nullopt, 
+                       .replicatedLog = log,
                        .health = std::move(health),
                        .logLeaderWriteConcern = std::nullopt};
   }

--- a/tests/Replication2/ReplicatedLog/SupervisionSimulationTest.cpp
+++ b/tests/Replication2/ReplicatedLog/SupervisionSimulationTest.cpp
@@ -58,7 +58,7 @@ struct ReplicatedLogSupervisionSimulationTest
   auto makeAgencyState(Log const& log,
                        replicated_log::ParticipantsHealth health)
       -> AgencyState {
-    return AgencyState{.replicatedState = std::nullopt, 
+    return AgencyState{.replicatedState = std::nullopt,
                        .replicatedLog = log,
                        .health = std::move(health),
                        .logLeaderWriteConcern = std::nullopt};

--- a/tests/Replication2/ReplicatedState/SupervisionModelChecker.cpp
+++ b/tests/Replication2/ReplicatedState/SupervisionModelChecker.cpp
@@ -75,7 +75,8 @@ TEST_F(ReplicatedStateModelCheckerTest, check_state_and_log) {
                                              .notIsFailed = true});
   auto initState = AgencyState{.replicatedState = state.get(),
                                .replicatedLog = std::nullopt,
-                               .health = std::move(health)};
+                               .health = std::move(health),
+                               .logLeaderWriteConcern = std::nullopt};
 
   auto driver = model_checker::ActorDriver{
       SupervisionActor{},
@@ -115,7 +116,9 @@ TEST_F(ReplicatedStateModelCheckerTest, check_state_and_log_with_leader) {
                                              .notIsFailed = true});
   auto initState = AgencyState{.replicatedState = state.get(),
                                .replicatedLog = std::nullopt,
-                               .health = std::move(health)};
+                               .health = std::move(health),
+                               .logLeaderWriteConcern = std::nullopt};
+;
 
   auto driver = model_checker::ActorDriver{
       SupervisionActor{},
@@ -155,7 +158,8 @@ TEST_F(ReplicatedStateModelCheckerTest, check_state_and_log_kill_any) {
                                              .notIsFailed = true});
   auto initState = AgencyState{.replicatedState = state.get(),
                                .replicatedLog = std::nullopt,
-                               .health = std::move(health)};
+                               .health = std::move(health),
+                               .logLeaderWriteConcern = std::nullopt};
 
   auto driver = model_checker::ActorDriver{
       SupervisionActor{}, KillAnyServerActor{}, DBServerActor{"A"},
@@ -191,7 +195,8 @@ TEST_F(ReplicatedStateModelCheckerTest, check_state_and_log_kill_server) {
                                              .notIsFailed = true});
   auto initState = AgencyState{.replicatedState = state.get(),
                                .replicatedLog = std::nullopt,
-                               .health = std::move(health)};
+                               .health = std::move(health),
+                               .logLeaderWriteConcern = std::nullopt};
 
   auto driver = model_checker::ActorDriver{
       SupervisionActor{}, KillLeaderActor{},  DBServerActor{"A"},
@@ -246,7 +251,8 @@ TEST_F(ReplicatedStateModelCheckerTest, everything_ok_kill_server) {
                                              .notIsFailed = true});
   auto initState = AgencyState{.replicatedState = state.get(),
                                .replicatedLog = log.get(),
-                               .health = std::move(health)};
+                               .health = std::move(health),
+                               .logLeaderWriteConcern = std::nullopt};
 
   auto driver = model_checker::ActorDriver{
       SupervisionActor{}, KillLeaderActor{},  DBServerActor{"A"},
@@ -300,7 +306,8 @@ TEST_F(ReplicatedStateModelCheckerTest, change_leader) {
                                              .notIsFailed = true});
   auto initState = AgencyState{.replicatedState = state.get(),
                                .replicatedLog = log.get(),
-                               .health = std::move(health)};
+                               .health = std::move(health),
+                               .logLeaderWriteConcern = std::nullopt};
 
   auto driver = model_checker::ActorDriver{
       SupervisionActor{}, KillServerActor{"A"}, DBServerActor{"A"},
@@ -352,7 +359,8 @@ TEST_F(ReplicatedStateModelCheckerTest, everything_ok_replace_server) {
                                              .notIsFailed = true});
   auto initState = AgencyState{.replicatedState = state.get(),
                                .replicatedLog = log.get(),
-                               .health = std::move(health)};
+                               .health = std::move(health),
+                               .logLeaderWriteConcern = std::nullopt};
 
   auto driver = model_checker::ActorDriver{
       SupervisionActor{}, ReplaceSpecificServerActor{"B", "C"},
@@ -431,7 +439,8 @@ TEST_F(ReplicatedStateModelCheckerTest, everything_ok_replace_leader) {
 
   auto initState = AgencyState{.replicatedState = state.get(),
                                .replicatedLog = log.get(),
-                               .health = std::move(health)};
+                               .health = std::move(health),
+                               .logLeaderWriteConcern = std::nullopt};
 
   auto driver = model_checker::ActorDriver{
       SupervisionActor{}, ReplaceSpecificServerActor{"A", "C"},
@@ -499,7 +508,8 @@ TEST_F(ReplicatedStateModelCheckerTest, start_with_nothing_replace_server) {
 
   auto initState = AgencyState{.replicatedState = state.get(),
                                .replicatedLog = std::nullopt,
-                               .health = std::move(health)};
+                               .health = std::move(health),
+                               .logLeaderWriteConcern = std::nullopt};
   auto driver = model_checker::ActorDriver{
       SupervisionActor{}, ReplaceSpecificServerActor{"B", "C"},
       DBServerActor{"A"}, DBServerActor{"B"},
@@ -566,7 +576,8 @@ TEST_F(ReplicatedStateModelCheckerTest, start_with_nothing_replace_leader) {
 
   auto initState = AgencyState{.replicatedState = state.get(),
                                .replicatedLog = std::nullopt,
-                               .health = std::move(health)};
+                               .health = std::move(health),
+                               .logLeaderWriteConcern = std::nullopt};
   auto driver = model_checker::ActorDriver{
       SupervisionActor{}, ReplaceSpecificServerActor{"A", "C"},
       DBServerActor{"A"}, DBServerActor{"B"},

--- a/tests/Replication2/ReplicatedState/SupervisionModelChecker.cpp
+++ b/tests/Replication2/ReplicatedState/SupervisionModelChecker.cpp
@@ -118,7 +118,6 @@ TEST_F(ReplicatedStateModelCheckerTest, check_state_and_log_with_leader) {
                                .replicatedLog = std::nullopt,
                                .health = std::move(health),
                                .logLeaderWriteConcern = std::nullopt};
-;
 
   auto driver = model_checker::ActorDriver{
       SupervisionActor{},


### PR DESCRIPTION
### Scope & Purpose

This fixes some warnings about uninitialized fields in the Supervision Model Checker.