### PR TITLE
Prefetch for revision trees - BTS-989

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,12 +1,12 @@
 v3.10.0 (XXXX-XX-XX)
 --------------------
 
-* Implement prefetch for revision trees, in case a batch is created with
-  a distinguished collection as for `SynchronizeShard`. This ensures that
-  the revision tree for the batch will be available when needed, even though
-  the revision tree for the collection might already have advanced beyond
-  the sequence number of the snapshot in the batch. This ensures that
-  shards can get in sync more reliably and more quickly.
+* Implement prefetch for revision trees, in case a batch is created with a
+  distinguished collection as for `SynchronizeShard`. This ensures that the
+  revision tree for the batch will be available when needed, even though the
+  revision tree for the collection might already have advanced beyond the
+  sequence number of the snapshot in the batch. This ensures that shards can get
+  in sync more reliably and more quickly.
 
 * Added startup option `--rocksdb.periodic-compaction-ttl`.
   This option controls the TTL (in seconds) for periodic compaction of .sst

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,13 @@
 v3.10.0 (XXXX-XX-XX)
 --------------------
 
+* Implement prefetch for revision trees, in case a batch is created with
+  a distinguished collection as for `SynchronizeShard`. This ensures that
+  the revision tree for the batch will be available when needed, even though
+  the revision tree for the collection might already have advanced beyond
+  the sequence number of the snapshot in the batch. This ensures that
+  shards can get in sync more reliably and more quickly.
+
 * Added startup option `--rocksdb.periodic-compaction-ttl`.
   This option controls the TTL (in seconds) for periodic compaction of .sst
   files in RocksDB, based on the .sst file age. The default value from RocksDB

--- a/arangod/RocksDBEngine/RocksDBMetaCollection.cpp
+++ b/arangod/RocksDBEngine/RocksDBMetaCollection.cpp
@@ -403,20 +403,7 @@ std::unique_ptr<containers::RevisionTree> RocksDBMetaCollection::revisionTree(
 }
 
 std::unique_ptr<containers::RevisionTree> RocksDBMetaCollection::revisionTree(
-    uint64_t batchId) {
-  RocksDBEngine& engine = _logicalCollection.vocbase()
-                              .server()
-                              .getFeature<EngineSelectorFeature>()
-                              .engine<RocksDBEngine>();
-  RocksDBReplicationManager* manager = engine.replicationManager();
-  RocksDBReplicationContext* ctx =
-      batchId == 0 ? nullptr : manager->find(batchId);
-  if (!ctx) {
-    return nullptr;
-  }
-  auto guard =
-      scopeGuard([manager, ctx]() noexcept -> void { manager->release(ctx); });
-  rocksdb::SequenceNumber trxSeq = ctx->snapshotTick();
+    rocksdb::SequenceNumber trxSeq) {
   TRI_ASSERT(trxSeq != 0);
 
   return revisionTree(

--- a/arangod/RocksDBEngine/RocksDBMetaCollection.h
+++ b/arangod/RocksDBEngine/RocksDBMetaCollection.h
@@ -78,7 +78,7 @@ class RocksDBMetaCollection : public PhysicalCollection {
   std::unique_ptr<containers::RevisionTree> revisionTree(
       transaction::Methods& trx) override;
   std::unique_ptr<containers::RevisionTree> revisionTree(
-      uint64_t batchId) override;
+      rocksdb::SequenceNumber trxSeq) override;
   std::unique_ptr<containers::RevisionTree> computeRevisionTree(
       uint64_t batchId) override;
 

--- a/arangod/RocksDBEngine/RocksDBReplicationContext.cpp
+++ b/arangod/RocksDBEngine/RocksDBReplicationContext.cpp
@@ -300,6 +300,20 @@ RocksDBReplicationContext::bindCollectionIncremental(TRI_vocbase_t& vocbase,
   cIter->numberDocumentsDumped = 0;
   cIter->documentCountAdjustmentTicket = documentCountAdjustmentTicket;
 
+  // Prefetch the revision tree of the collection:
+  _collectionGuidOfPrefetchedRevisionTree.clear();
+  _prefetchedRevisionTree = rcoll->revisionTree(_snapshot->GetSequenceNumber());
+  if (_prefetchedRevisionTree != nullptr) {
+    LOG_TOPIC("123aa", DEBUG, Logger::ENGINES)
+        << "Have successfully prefetched revision tree for collection "
+        << logical->guid();
+    _collectionGuidOfPrefetchedRevisionTree = logical->guid();
+  } else {
+    LOG_TOPIC("123ab", INFO, Logger::ENGINES)
+        << "Could not prefetch revision tree for collection "
+        << logical->guid();
+  }
+
   // we should have a valid iterator if there are documents in here
   TRI_ASSERT(numberDocuments == 0 || cIter->hasMore());
   return std::make_tuple(Result{}, cid, numberDocuments);
@@ -1332,4 +1346,20 @@ void RocksDBReplicationContext::releaseDumpIterator(CollectionIterator* it) {
       it->release();
     }
   }
+}
+
+std::unique_ptr<containers::RevisionTree>
+RocksDBReplicationContext::getPrefetchedRevisionTree(
+    std::string const& collectionGuid) {
+  if (collectionGuid == _collectionGuidOfPrefetchedRevisionTree) {
+    LOG_TOPIC("456aa", DEBUG, Logger::ENGINES)
+        << "Delivering prefetched revision tree for collection "
+        << collectionGuid;
+    _collectionGuidOfPrefetchedRevisionTree.clear();
+    return std::move(_prefetchedRevisionTree);
+  }
+  LOG_TOPIC("456ab", DEBUG, Logger::ENGINES)
+      << "No prefetched revision tree available for collection "
+      << collectionGuid;
+  return {nullptr};
 }

--- a/arangod/RocksDBEngine/RocksDBRestReplicationHandler.cpp
+++ b/arangod/RocksDBEngine/RocksDBRestReplicationHandler.cpp
@@ -888,13 +888,27 @@ void RocksDBRestReplicationHandler::handleCommandRevisionTree() {
   // smaller and thus improve efficiency)
   bool onlyPopulated = _request->parsedValue("onlyPopulated", false);
 
-  auto tree = ctx.collection->getPhysical()->revisionTree(ctx.batchId);
+  std::string collectionGuid = _request->value("collection");
+
+  std::unique_ptr<containers::RevisionTree> tree;
 
   {
     RocksDBReplicationContext* c = _manager->find(ctx.batchId);
     RocksDBReplicationContextGuard guard(_manager, c);
+    if (c != nullptr) {  // we have the RocksDBReplicationContext!
+      // See if we can get the revision tree from the context:
+      tree = c->getPrefetchedRevisionTree(collectionGuid);
+      // This might return a nullptr!
+    }
+    if (tree == nullptr) {  // Still not there, try to get it directly:
+      auto* snapshot = c->snapshot();
+      if (snapshot != nullptr) {
+        tree = ctx.collection->getPhysical()->revisionTree(
+            snapshot->GetSequenceNumber());
+      }
+    }
     if (c != nullptr) {
-      c->removeBlocker(_request->databaseName(), _request->value("collection"));
+      c->removeBlocker(_request->databaseName(), collectionGuid);
     }
   }
 

--- a/arangod/RocksDBEngine/RocksDBRestReplicationHandler.cpp
+++ b/arangod/RocksDBEngine/RocksDBRestReplicationHandler.cpp
@@ -901,11 +901,7 @@ void RocksDBRestReplicationHandler::handleCommandRevisionTree() {
       // This might return a nullptr!
     }
     if (tree == nullptr) {  // Still not there, try to get it directly:
-      auto* snapshot = c->snapshot();
-      if (snapshot != nullptr) {
-        tree = ctx.collection->getPhysical()->revisionTree(
-            snapshot->GetSequenceNumber());
-      }
+      tree = ctx.collection->getPhysical()->revisionTree(c->snapshotTick());
     }
     if (c != nullptr) {
       c->removeBlocker(_request->databaseName(), collectionGuid);

--- a/arangod/RocksDBEngine/RocksDBV8Functions.cpp
+++ b/arangod/RocksDBEngine/RocksDBV8Functions.cpp
@@ -298,11 +298,7 @@ static void JS_CollectionRevisionTreeVerification(
     try {
       auto* physical = toRocksDBCollection(*collection);
       auto batchId = ctx->id();
-      auto* snapshot = ctx->snapshot();
-      if (snapshot == nullptr) {
-        TRI_V8_THROW_EXCEPTION_INTERNAL("Did not find shapshot in batch!");
-      }
-      storedTree = physical->revisionTree(snapshot->GetSequenceNumber());
+      storedTree = physical->revisionTree(ctx->snapshotTick());
       computedTree = physical->computeRevisionTree(batchId);
       ctx->setDeleted();
     } catch (...) {

--- a/arangod/RocksDBEngine/RocksDBV8Functions.cpp
+++ b/arangod/RocksDBEngine/RocksDBV8Functions.cpp
@@ -298,7 +298,11 @@ static void JS_CollectionRevisionTreeVerification(
     try {
       auto* physical = toRocksDBCollection(*collection);
       auto batchId = ctx->id();
-      storedTree = physical->revisionTree(batchId);
+      auto* snapshot = ctx->snapshot();
+      if (snapshot == nullptr) {
+        TRI_V8_THROW_EXCEPTION_INTERNAL("Did not find shapshot in batch!");
+      }
+      storedTree = physical->revisionTree(snapshot->GetSequenceNumber());
       computedTree = physical->computeRevisionTree(batchId);
       ctx->setDeleted();
     } catch (...) {

--- a/arangod/StorageEngine/PhysicalCollection.cpp
+++ b/arangod/StorageEngine/PhysicalCollection.cpp
@@ -173,7 +173,7 @@ std::unique_ptr<containers::RevisionTree> PhysicalCollection::revisionTree(
 }
 
 std::unique_ptr<containers::RevisionTree> PhysicalCollection::revisionTree(
-    uint64_t batchId) {
+    rocksdb::SequenceNumber) {
   return nullptr;
 }
 

--- a/arangod/StorageEngine/PhysicalCollection.h
+++ b/arangod/StorageEngine/PhysicalCollection.h
@@ -33,6 +33,7 @@
 #include "Futures/Future.h"
 #include "Indexes/Index.h"
 #include "Indexes/IndexIterator.h"
+#include "RocksDBEngine/RocksDBReplicationContext.h"
 #include "StorageEngine/ReplicationIterator.h"
 #include "Utils/OperationResult.h"
 #include "VocBase/Identifiers/IndexId.h"
@@ -229,7 +230,7 @@ class PhysicalCollection {
   virtual std::unique_ptr<containers::RevisionTree> revisionTree(
       transaction::Methods& trx);
   virtual std::unique_ptr<containers::RevisionTree> revisionTree(
-      uint64_t batchId);
+      rocksdb::SequenceNumber trxSeq);
   virtual std::unique_ptr<containers::RevisionTree> computeRevisionTree(
       uint64_t batchId);
 


### PR DESCRIPTION
This PR attacks the problem described in
  https://arangodb.atlassian.net/browse/BTS-989
The problem is that if one orders a batch (aka
RocksDBReplicationContext), which includes a snapshot of RocksDB, it is
not guaranteed that one can subsequently fetch a revision tree for some
collection/shard which corresponds to the sequence number of the
snapshot in this batch. This is because the revision tree of the
collection might already have been rolled forward.

This PR makes it so that in case a batch is bound to a specific
collection (which happens when SynchronizeShard on the follower
tries to get in sync with the leader), then the revision tree for
that collection is prefetched and buffered in the batch.

This means that later when the revision tree is requested by the
follower, it is guaranteed that it is still available, and that we do
not have to stop revision trees from being rolled forward.

- Implement prefetch.
- CHANGELOG.

This is the backport for 3.10.

### Scope & Purpose

- [*] :hankey: Bugfix

### Checklist

- [*] Tests (code already covered)
  - [*] **integration tests**
  - [*] **resilience tests**
- [*] :book: CHANGELOG entry made
- [*] Backports
  - [*] This is the backport for 3.10

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [*] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/BTS-989
- [*] Devel PR: https://github.com/arangodb/arangodb/pull/17016


