### PR TITLE
make Pregel log ids unique again

### DIFF
--- a/arangod/Pregel/Conductor.cpp
+++ b/arangod/Pregel/Conductor.cpp
@@ -417,7 +417,7 @@ VPackBuilder Conductor::finishedWorkerStep(VPackSlice const& data) {
   if (_asyncMode == false) {  // in async mode we wait for all responded
     _ensureUniqueResponse(data);
     ServerID sender = data.get(Utils::senderKey).copyString();
-    LOG_PREGEL("08142", WARN)
+    LOG_PREGEL("faeb0", WARN)
         << fmt::format("finishedWorkerStep, got response from {}.", sender);
 
     // wait for the last worker to respond
@@ -865,7 +865,7 @@ void Conductor::finishedWorkerFinalize(VPackSlice data) {
   }
 
   ServerID sender = data.get(Utils::senderKey).copyString();
-  LOG_PREGEL("08142", WARN)
+  LOG_PREGEL("60f0c", WARN)
       << fmt::format("finishedWorkerFinalize, got response from {}.", sender);
 
   _ensureUniqueResponse(data);


### PR DESCRIPTION
### Scope & Purpose

Make log IDs unique again in Pregel.
Not a real issue, but log ids are supposed to be unique across the entire code.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: *(Please link PR)*
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

