### PR TITLE
[PREGEL] Send general messages between worker and conductor

### DIFF
--- a/arangod/Pregel/Conductor/ClusterWorkerApi.cpp
+++ b/arangod/Pregel/Conductor/ClusterWorkerApi.cpp
@@ -1,22 +1,47 @@
 #include "ClusterWorkerApi.h"
+#include <variant>
 
 #include "Pregel/WorkerConductorMessages.h"
 #include "Pregel/NetworkConnection.h"
 
 using namespace arangodb::pregel::conductor;
 
+// This template enforces In and Out type of the function:
+// In enforces which type of message is sent
+// Out defines the expected response type:
+// The function returns an error if this expectation is not fulfilled
+template<typename Out, typename In>
+auto ClusterWorkerApi::execute(In const& in) -> futures::Future<ResultT<Out>> {
+  return _connection
+      .post(ModernMessage{.executionNumber = _executionNumber, .payload = {in}})
+      .thenValue([](auto&& response) -> futures::Future<ResultT<Out>> {
+        if (response.fail()) {
+          return Result{response.errorNumber(), response.errorMessage()};
+        }
+        if (!std::holds_alternative<ResultT<Out>>(response.get().payload)) {
+          return Result{
+              TRI_ERROR_INTERNAL,
+              fmt::format(
+                  "Message from worker does not include the expected {} "
+                  "type",
+                  typeid(Out).name())};
+        }
+        return std::get<ResultT<Out>>(response.get().payload);
+      });
+}
+
 auto ClusterWorkerApi::loadGraph(LoadGraph const& graph)
     -> futures::Future<ResultT<GraphLoaded>> {
-  return _connection.post<GraphLoaded>(graph);
+  return execute<GraphLoaded>(graph);
 }
 
 auto ClusterWorkerApi::prepareGlobalSuperStep(
     PrepareGlobalSuperStep const& data)
     -> futures::Future<ResultT<GlobalSuperStepPrepared>> {
-  return _connection.post<GlobalSuperStepPrepared>(data);
+  return execute<GlobalSuperStepPrepared>(data);
 }
 
 auto ClusterWorkerApi::runGlobalSuperStep(RunGlobalSuperStep const& data)
     -> futures::Future<ResultT<GlobalSuperStepFinished>> {
-  return _connection.post<GlobalSuperStepFinished>(data);
+  return execute<GlobalSuperStepFinished>(data);
 }

--- a/arangod/Pregel/Conductor/ClusterWorkerApi.h
+++ b/arangod/Pregel/Conductor/ClusterWorkerApi.h
@@ -9,7 +9,9 @@
 namespace arangodb::pregel::conductor {
 
 struct ClusterWorkerApi : NewIWorker {
-  ClusterWorkerApi(Connection network) : _connection{std::move(network)} {}
+  ClusterWorkerApi(ExecutionNumber executionNumber, Connection network)
+      : _executionNumber{std::move(executionNumber)},
+        _connection{std::move(network)} {}
   [[nodiscard]] auto loadGraph(LoadGraph const& graph)
       -> futures::Future<ResultT<GraphLoaded>> override;
   [[nodiscard]] auto prepareGlobalSuperStep(PrepareGlobalSuperStep const& data)
@@ -18,7 +20,11 @@ struct ClusterWorkerApi : NewIWorker {
       -> futures::Future<ResultT<GlobalSuperStepFinished>> override;
 
  private:
+  ExecutionNumber _executionNumber;
   Connection _connection;
+
+  template<typename Out, typename In>
+  auto execute(In const& in) -> futures::Future<ResultT<Out>>;
 };
 
 }  // namespace arangodb::pregel::conductor

--- a/arangod/Pregel/Conductor/Conductor.h
+++ b/arangod/Pregel/Conductor/Conductor.h
@@ -166,8 +166,6 @@ class Conductor : public std::enable_shared_from_this<Conductor> {
 
   // === REST callbacks ===
   void workerStatusUpdate(VPackSlice const& data);
-  void finishedWorkerStartup(VPackSlice const& data);
-  VPackBuilder finishedWorkerStep(VPackSlice const& data);
   void finishedWorkerFinalize(VPackSlice data);
 
   std::vector<ShardID> getShardIds(ShardID const& collection) const;

--- a/arangod/Pregel/Conductor/States/ComputingState.cpp
+++ b/arangod/Pregel/Conductor/States/ComputingState.cpp
@@ -36,8 +36,7 @@ auto Computing::_prepareGlobalSuperStep() -> GlobalSuperStepPreparedFuture {
   conductor._totalEdgesCount = 0;
 
   auto prepareGssCommand =
-      PrepareGlobalSuperStep{.executionNumber = conductor._executionNumber,
-                             .gss = conductor._globalSuperstep,
+      PrepareGlobalSuperStep{.gss = conductor._globalSuperstep,
                              .vertexCount = conductor._totalVerticesCount,
                              .edgeCount = conductor._totalEdgesCount};
   auto results =
@@ -63,8 +62,7 @@ auto Computing::_runGlobalSuperStep(bool activateAll)
     conductor._aggregators->serializeValues(aggregators);
   }
   auto startGssCommand =
-      RunGlobalSuperStep{.executionNumber = conductor._executionNumber,
-                         .gss = conductor._globalSuperstep,
+      RunGlobalSuperStep{.gss = conductor._globalSuperstep,
                          .vertexCount = conductor._totalVerticesCount,
                          .edgeCount = conductor._totalEdgesCount,
                          .activateAll = activateAll,

--- a/arangod/Pregel/GraphStore.cpp
+++ b/arangod/Pregel/GraphStore.cpp
@@ -233,9 +233,7 @@ auto GraphStore<V, E>::loadShards(
       }
     }
   }
-  auto graphLoaded =
-      GraphLoaded{ServerState::instance()->getId(), _executionNumber,
-                  localVertexCount(), localEdgeCount()};
+  auto graphLoaded = GraphLoaded{localVertexCount(), localEdgeCount()};
   futures::Promise<ResultT<GraphLoaded>> promise;
   promise.setValue(ResultT<GraphLoaded>{graphLoaded});
   return promise.getFuture();

--- a/arangod/Pregel/NetworkConnection.cpp
+++ b/arangod/Pregel/NetworkConnection.cpp
@@ -1,5 +1,6 @@
 #include "NetworkConnection.h"
 
+#include "Logger/LogMacros.h"
 #include "Network/NetworkFeature.h"
 #include "Network/Methods.h"
 #include "Pregel/WorkerConductorMessages.h"
@@ -26,48 +27,41 @@ auto Connection::create(ServerID const& destinationId,
   return Connection{destinationId, baseUrl, reqOpts, nf.pool()};
 }
 
-template<typename OutType, RestMessage InType>
-auto Connection::post(InType const& message)
-    -> futures::Future<ResultT<OutType>> {
+auto Connection::post(ModernMessage&& message)
+    -> futures::Future<ResultT<ModernMessage>> {
   VPackBuffer<uint8_t> messageBuffer;
   VPackBuilder serializedMessage(messageBuffer);
   try {
     serialize(serializedMessage, message);
   } catch (basics::Exception& e) {
     return {Result{TRI_ERROR_INTERNAL,
-                   fmt::format("REST message type cannot be serialized: {}",
-                               typeid(message).name())}};
+                   fmt::format("REST message cannot be serialized")}};
   }
   auto request = network::sendRequestRetry(
       _connectionPool, "server:" + _destinationId, fuerte::RestVerb::Post,
-      _baseUrl + message.path, std::move(messageBuffer), _requestOptions);
+      _baseUrl + Utils::modernMessagingPath, std::move(messageBuffer),
+      _requestOptions);
 
-  return std::move(request).thenValue([](auto&& result)
-                                          -> futures::Future<ResultT<OutType>> {
-    if (result.fail()) {
-      return {Result{TRI_ERROR_INTERNAL,
-                     fmt::format("REST request to worker failed: {}",
-                                 fuerte::to_string(result.error))}};
-    }
-    if (result.statusCode() >= 400) {
-      return {Result{
-          TRI_ERROR_FAILED,
-          fmt::format("REST request to worker returned an error code {}: {}",
-                      result.statusCode(), result.slice().toJson())}};
-    }
-    try {
-      return deserialize<ResultT<OutType>>(result.slice());
-    } catch (basics::Exception& e) {
-      return {Result{TRI_ERROR_INTERNAL,
-                     fmt::format("REST response cannot be deserialized: {}",
-                                 result.slice().toJson())}};
-    }
-  });
+  return std::move(request).thenValue(
+      [](auto&& result) -> futures::Future<ResultT<ModernMessage>> {
+        if (result.fail()) {
+          return {Result{TRI_ERROR_INTERNAL,
+                         fmt::format("REST request to worker failed: {}",
+                                     fuerte::to_string(result.error))}};
+        }
+        if (result.statusCode() >= 400) {
+          return {
+              Result{TRI_ERROR_FAILED,
+                     fmt::format(
+                         "REST request to worker returned an error code {}: {}",
+                         result.statusCode(), result.slice().toJson())}};
+        }
+        try {
+          return deserialize<ModernMessage>(result.slice());
+        } catch (basics::Exception& e) {
+          return {Result{TRI_ERROR_INTERNAL,
+                         fmt::format("REST response cannot be deserialized: {}",
+                                     result.slice().toJson())}};
+        }
+      });
 }
-
-template auto Connection::post(LoadGraph const& message)
-    -> futures::Future<ResultT<GraphLoaded>>;
-template auto Connection::post(PrepareGlobalSuperStep const& message)
-    -> futures::Future<ResultT<GlobalSuperStepPrepared>>;
-template auto Connection::post(RunGlobalSuperStep const& message)
-    -> futures::Future<ResultT<GlobalSuperStepFinished>>;

--- a/arangod/Pregel/NetworkConnection.h
+++ b/arangod/Pregel/NetworkConnection.h
@@ -28,6 +28,7 @@
 #include "Cluster/ClusterTypes.h"
 #include "Futures/Future.h"
 #include "Network/ConnectionPool.h"
+#include "Pregel/WorkerConductorMessages.h"
 #include "velocypack/Builder.h"
 #include "Network/Methods.h"
 
@@ -45,8 +46,7 @@ struct Connection {
   Connection(ServerID destinationId, std::string baseUrl,
              network::RequestOptions requestOptions,
              network::ConnectionPool* connectionPool);
-  template<typename OutType, RestMessage InType>
-  auto post(InType const& message) -> futures::Future<ResultT<OutType>>;
+  auto post(ModernMessage&& message) -> futures::Future<ResultT<ModernMessage>>;
 
  private:
   ServerID _destinationId;

--- a/arangod/Pregel/Utils.cpp
+++ b/arangod/Pregel/Utils.cpp
@@ -35,12 +35,10 @@ using namespace arangodb::pregel;
 std::string const Utils::apiPrefix = "/_api/pregel/";
 std::string const Utils::conductorPrefix = "conductor";
 std::string const Utils::workerPrefix = "worker";
+std::string const Utils::modernMessagingPath = "modern";
 
-std::string const Utils::startExecutionPath = "startExecution";
 std::string const Utils::finishedStartupPath = "finishedStartup";
 std::string const Utils::statusUpdatePath = "statusUpdate";
-std::string const Utils::prepareGSSPath = "prepareGSS";
-std::string const Utils::startGSSPath = "startGSS";
 std::string const Utils::finishedWorkerStepPath = "finishedStep";
 std::string const Utils::finishedWorkerFinalizationPath =
     "finishedFinalization";

--- a/arangod/Pregel/Utils.h
+++ b/arangod/Pregel/Utils.h
@@ -43,13 +43,11 @@ class Utils {
   static std::string const apiPrefix;
   static std::string const conductorPrefix;
   static std::string const workerPrefix;
+  static std::string const modernMessagingPath;
 
   static std::string const edgeShardingKey;
-  static std::string const startExecutionPath;
   static std::string const statusUpdatePath;
   static std::string const finishedStartupPath;
-  static std::string const prepareGSSPath;
-  static std::string const startGSSPath;
   static std::string const finishedWorkerStepPath;
   static std::string const finishedWorkerFinalizationPath;
   static std::string const cancelGSSPath;

--- a/arangod/Pregel/Worker/Worker.h
+++ b/arangod/Pregel/Worker/Worker.h
@@ -52,6 +52,8 @@ class PregelFeature;
 class IWorker : public std::enable_shared_from_this<IWorker> {
  public:
   virtual ~IWorker() = default;
+  [[nodiscard]] virtual auto process(MessagePayload const& message)
+      -> ResultT<ModernMessage> = 0;
   [[nodiscard]] virtual auto loadGraph(LoadGraph const& graph)
       -> futures::Future<ResultT<GraphLoaded>> = 0;
   [[nodiscard]] virtual auto prepareGlobalSuperStep(
@@ -172,6 +174,8 @@ class Worker : public IWorker {
   ~Worker();
 
   // ====== called by rest handler =====
+  auto process(MessagePayload const& message)
+      -> ResultT<ModernMessage> override;
   auto loadGraph(LoadGraph const& graph)
       -> futures::Future<ResultT<GraphLoaded>> override;
   auto prepareGlobalSuperStep(PrepareGlobalSuperStep const& data)


### PR DESCRIPTION
Adds a general message (and a response) that includes an std::variant of different message types. This way, message handling in the feature becomes more readable: We can use the same Rest path for all message types and Feature::handleWorkerRequests delegates the decision what happens with the message to the worker. The worker does pattern matching (with std::visit) on the message type to decide what to do with which message type.
This PR uses this general messages only where we already use futures. A second PR will convert the rest.