### PR TITLE
BTS-1002: make timeout in tests progressive if we monitor test progress

### DIFF
--- a/tests/js/server/shell/shell-index-background.js
+++ b/tests/js/server/shell/shell-index-background.js
@@ -35,18 +35,43 @@ function backgroundIndexSuite() {
   const cn = "UnitTestsCollectionIdx";
   const tasks = require("@arangodb/tasks");
   const tasksCompleted = () => {
-    return 0 === tasks.get().filter((task) => {
+    return tasks.get().filter((task) => {
+      //print(task)
       return (task.id.match(/^UnitTest/) || task.name.match(/^UnitTest/));
     }).length;
   };
   const waitForTasks = () => {
     const time = internal.time;
     const start = time();
-    while (!tasksCompleted()) {
-      if (time() - start > 300) { // wait for 5 minutes maximum
-        fail("Timeout after 5 minutes");
+    let c = db[cn];
+    let oldCount = c.count();
+    let deadline = 300;
+    let count = 0;
+    // wait for 5 minutes + progress maximum
+    let noTasksCompleted = tasksCompleted();
+    while (true) {
+      let newTasksCompleted = tasksCompleted();
+      if (newTasksCompleted === 0) {
+        break;
+      }
+      if (time() - start > deadline) { 
+        fail(`Timeout after ${deadline / 60} minutes`);
       }
       internal.wait(0.5, false);
+      count += 1;
+      if (newTasksCompleted !== noTasksCompleted) {
+        // one more minute per completed task!
+        noTasksCompleted = newTasksCompleted;
+        deadline += 60;
+      }
+      if (count % 2 === 0) {
+        let newCount = c.count();
+        if (newCount > oldCount) {
+          // 10 more seconds for added documents
+          oldCount = newCount;
+          deadline += 10;
+        }
+      }
     }
     internal.wal.flush(true, true);
     // wait an extra second for good measure

--- a/tests/js/server/shell/shell-index-background.js
+++ b/tests/js/server/shell/shell-index-background.js
@@ -36,7 +36,6 @@ function backgroundIndexSuite() {
   const tasks = require("@arangodb/tasks");
   const tasksCompleted = () => {
     return tasks.get().filter((task) => {
-      //print(task)
       return (task.id.match(/^UnitTest/) || task.name.match(/^UnitTest/));
     }).length;
   };


### PR DESCRIPTION
### Scope & Purpose

static timeouts don't work well on small hardware.
Increase timeout if we see progress.

- [x] :hankey: Bugfix
- [x] backport: 3.10 https://github.com/arangodb/arangodb/pull/17044