### PR TITLE
use std::string_view for warnings/errors

### DIFF
--- a/arangod/Aql/AqlFunctionsInternalCache.h
+++ b/arangod/Aql/AqlFunctionsInternalCache.h
@@ -29,12 +29,9 @@
 
 #include <unicode/regex.h>
 #include <memory>
+#include <string_view>
 
 namespace arangodb {
-
-namespace transaction {
-class Methods;
-}
 
 namespace aql {
 
@@ -52,9 +49,9 @@ class AqlFunctionsInternalCache final {
 
   void clear() noexcept;
 
-  icu::RegexMatcher* buildRegexMatcher(char const* ptr, size_t length,
+  icu::RegexMatcher* buildRegexMatcher(std::string_view expr,
                                        bool caseInsensitive);
-  icu::RegexMatcher* buildLikeMatcher(char const* ptr, size_t length,
+  icu::RegexMatcher* buildLikeMatcher(std::string_view expr,
                                       bool caseInsensitive);
   icu::RegexMatcher* buildSplitMatcher(AqlValue const& splitExpression,
                                        velocypack::Options const* opts,
@@ -75,8 +72,7 @@ class AqlFunctionsInternalCache final {
   /// - second: true if the found wildcard is the last byte in the pattern,
   ///   false otherwise. can only be true if first is also true
   static std::pair<bool, bool> inspectLikePattern(std::string& out,
-                                                  char const* ptr,
-                                                  size_t length);
+                                                  std::string_view expr);
 
  private:
   /// @brief get matcher from cache, or insert a new matcher for the specified
@@ -86,9 +82,9 @@ class AqlFunctionsInternalCache final {
       std::unordered_map<std::string, std::unique_ptr<icu::RegexMatcher>>&
           cache);
 
-  static void buildRegexPattern(std::string& out, char const* ptr,
-                                size_t length, bool caseInsensitive);
-  static void buildLikePattern(std::string& out, char const* ptr, size_t length,
+  static void buildRegexPattern(std::string& out, std::string_view expr,
+                                bool caseInsensitive);
+  static void buildLikePattern(std::string& out, std::string_view expr,
                                bool caseInsensitive);
 
  private:

--- a/arangod/Aql/Ast.cpp
+++ b/arangod/Aql/Ast.cpp
@@ -96,7 +96,7 @@ auto doNothingVisitor = [](AstNode const*) {};
   // TODO: if we get rid of vsprintf in FillExceptionString, we don't
   // need to pass a raw C-style string into it
   std::string temp(details);
-  std::string msg = basics::FillExceptionString(code, temp.c_str());
+  std::string msg = basics::Exception::FillExceptionString(code, temp.c_str());
   query.warnings().registerError(code, msg);
 }
 

--- a/arangod/Aql/Ast.cpp
+++ b/arangod/Aql/Ast.cpp
@@ -92,8 +92,11 @@ auto doNothingVisitor = [](AstNode const*) {};
 [[noreturn]] void throwFormattedError(arangodb::aql::QueryContext& query,
                                       ErrorCode code,
                                       std::string_view details) {
-  std::string msg =
-      arangodb::aql::QueryWarnings::buildFormattedString(code, details);
+  // ensure that details is null-terminated
+  // TODO: if we get rid of vsprintf in FillExceptionString, we don't
+  // need to pass a raw C-style string into it
+  std::string temp(details);
+  std::string msg = basics::FillExceptionString(code, temp.c_str());
   query.warnings().registerError(code, msg);
 }
 
@@ -3767,7 +3770,7 @@ AstNode* Ast::optimizeFunctionCall(
       std::string unescapedPattern;
       bool wildcardFound;
       bool wildcardIsLastChar;
-      std::tie(wildcardFound, wildcardIsLastChar) = AqlFunctionsInternalCache::inspectLikePattern(unescapedPattern, patternArg->getStringValue(), patternArg->getStringLength());
+      std::tie(wildcardFound, wildcardIsLastChar) = AqlFunctionsInternalCache::inspectLikePattern(unescapedPattern, patternArg->getStringView());
 
       if (!wildcardFound) {
         TRI_ASSERT(!wildcardIsLastChar);

--- a/arangod/Aql/ExpressionContext.h
+++ b/arangod/Aql/ExpressionContext.h
@@ -25,6 +25,7 @@
 
 #include "Basics/ErrorCode.h"
 
+#include <string_view>
 #include <unicode/regex.h>
 
 struct TRI_vocbase_t;
@@ -52,18 +53,17 @@ class ExpressionContext {
   virtual AqlValue getVariableValue(Variable const* variable, bool doCopy,
                                     bool& mustDestroy) const = 0;
 
-  virtual void registerWarning(ErrorCode errorCode, char const* msg) = 0;
-  virtual void registerError(ErrorCode errorCode, char const* msg) = 0;
+  virtual void registerWarning(ErrorCode errorCode, std::string_view msg) = 0;
+  virtual void registerError(ErrorCode errorCode, std::string_view msg) = 0;
 
-  virtual icu::RegexMatcher* buildRegexMatcher(char const* ptr, size_t length,
+  virtual icu::RegexMatcher* buildRegexMatcher(std::string_view expr,
                                                bool caseInsensitive) = 0;
-  virtual icu::RegexMatcher* buildLikeMatcher(char const* ptr, size_t length,
+  virtual icu::RegexMatcher* buildLikeMatcher(std::string_view expr,
                                               bool caseInsensitive) = 0;
   virtual icu::RegexMatcher* buildSplitMatcher(AqlValue splitExpression,
                                                velocypack::Options const* opts,
                                                bool& isEmptyExpression) = 0;
-  virtual arangodb::ValidatorBase* buildValidator(
-      arangodb::velocypack::Slice const&) = 0;
+  virtual arangodb::ValidatorBase* buildValidator(velocypack::Slice) = 0;
 
   virtual TRI_vocbase_t& vocbase() const = 0;
   virtual transaction::Methods& trx() const = 0;
@@ -74,7 +74,7 @@ class ExpressionContext {
   // the caller has to make sure the data behind the slice remains
   // valid until clearVariable() is called or the context is discarded.
   virtual void setVariable(Variable const* variable,
-                           arangodb::velocypack::Slice value) = 0;
+                           velocypack::Slice value) = 0;
 
   // unregister a temporary variable from the ExpressionContext.
   virtual void clearVariable(Variable const* variable) noexcept = 0;

--- a/arangod/Aql/Functions.cpp
+++ b/arangod/Aql/Functions.cpp
@@ -242,14 +242,14 @@ bool isValidDocument(VPackSlice slice) {
 }
 
 void registerICUWarning(ExpressionContext* expressionContext,
-                        char const* functionName, UErrorCode status) {
+                        std::string_view functionName, UErrorCode status) {
   std::string msg;
   msg.append("in function '");
   msg.append(functionName);
   msg.append("()': ");
   msg.append(basics::Exception::FillExceptionString(TRI_ERROR_ARANGO_ICU_ERROR,
                                                     u_errorName(status)));
-  expressionContext->registerWarning(TRI_ERROR_ARANGO_ICU_ERROR, msg.c_str());
+  expressionContext->registerWarning(TRI_ERROR_ARANGO_ICU_ERROR, msg);
 }
 
 /// @brief convert a number value into an AqlValue
@@ -1357,7 +1357,7 @@ AqlValue const& extractFunctionParameterValue(
   return parameters[position];
 }
 
-std::string_view getFunctionName(const AstNode& node) noexcept {
+std::string_view getFunctionName(AstNode const& node) noexcept {
   TRI_ASSERT(aql::NODE_TYPE_FCALL == node.type);
   auto const* impl = static_cast<aql::Function*>(node.getData());
   TRI_ASSERT(impl != nullptr);
@@ -1366,33 +1366,41 @@ std::string_view getFunctionName(const AstNode& node) noexcept {
 
 /// @brief register warning
 void registerWarning(ExpressionContext* expressionContext,
-                     char const* functionName, Result const& rr) {
+                     std::string_view functionName, Result const& rr) {
   std::string msg = "in function '";
   msg.append(functionName);
   msg.append("()': ");
   msg.append(rr.errorMessage());
-  expressionContext->registerWarning(rr.errorNumber(), msg.c_str());
+  expressionContext->registerWarning(rr.errorNumber(), msg);
 }
 
 /// @brief register warning
 void registerWarning(ExpressionContext* expressionContext,
-                     char const* functionName, ErrorCode code) {
+                     std::string_view functionName, ErrorCode code) {
   if (code != TRI_ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH &&
       code != TRI_ERROR_QUERY_FUNCTION_ARGUMENT_NUMBER_MISMATCH) {
     registerWarning(expressionContext, functionName, Result(code));
     return;
   }
 
-  std::string msg = basics::Exception::FillExceptionString(code, functionName);
-  expressionContext->registerWarning(code, msg.c_str());
+  // ensure that function name is null-terminated
+  // TODO: if we get rid of vsprintf in FillExceptionString, we don't
+  // need to pass a raw C-style string into it
+  std::string fname(functionName);
+  std::string msg = basics::Exception::FillExceptionString(code, fname.c_str());
+  expressionContext->registerWarning(code, msg);
 }
 
 void registerError(ExpressionContext* expressionContext,
-                   char const* functionName, ErrorCode code) {
+                   std::string_view functionName, ErrorCode code) {
   std::string msg;
 
   if (code == TRI_ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH) {
-    msg = aql::QueryWarnings::buildFormattedString(code, functionName);
+    // ensure that function name is null-terminated
+    // TODO: if we get rid of vsprintf in FillExceptionString, we don't
+    // need to pass a raw C-style string into it
+    std::string fname(functionName);
+    msg = basics::Exception::FillExceptionString(code, fname.c_str());
   } else {
     msg.append("in function '");
     msg.append(functionName);
@@ -1400,12 +1408,12 @@ void registerError(ExpressionContext* expressionContext,
     msg.append(TRI_errno_string(code));
   }
 
-  expressionContext->registerError(code, msg.c_str());
+  expressionContext->registerError(code, msg);
 }
 
 /// @brief register usage of an invalid function argument
 void registerInvalidArgumentWarning(ExpressionContext* expressionContext,
-                                    char const* functionName) {
+                                    std::string_view functionName) {
   registerWarning(expressionContext, functionName,
                   TRI_ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH);
 }
@@ -1415,8 +1423,7 @@ void registerInvalidArgumentWarning(ExpressionContext* expressionContext,
 
 /// @brief append the VelocyPack value to a string buffer
 void functions::Stringify(VPackOptions const* vopts,
-                          velocypack::StringSink& buffer,
-                          VPackSlice const& slice) {
+                          velocypack::StringSink& buffer, VPackSlice slice) {
   if (slice.isNull()) {
     // null is the empty string
     return;
@@ -3174,8 +3181,8 @@ AqlValue functions::Like(ExpressionContext* expressionContext, AstNode const&,
   ::appendAsString(vopts, adapter, regex);
 
   // the matcher is owned by the context!
-  icu::RegexMatcher* matcher = expressionContext->buildLikeMatcher(
-      buffer->data(), buffer->length(), caseInsensitive);
+  icu::RegexMatcher* matcher =
+      expressionContext->buildLikeMatcher(*buffer, caseInsensitive);
 
   if (matcher == nullptr) {
     // compiling regular expression failed
@@ -3369,8 +3376,8 @@ AqlValue functions::RegexMatches(ExpressionContext* expressionContext,
   bool isEmptyExpression = (buffer->length() == 0);
 
   // the matcher is owned by the context!
-  icu::RegexMatcher* matcher = expressionContext->buildRegexMatcher(
-      buffer->data(), buffer->length(), caseInsensitive);
+  icu::RegexMatcher* matcher =
+      expressionContext->buildRegexMatcher(*buffer, caseInsensitive);
 
   if (matcher == nullptr) {
     registerWarning(expressionContext, AFN, TRI_ERROR_QUERY_INVALID_REGEX);
@@ -3467,8 +3474,8 @@ AqlValue functions::RegexSplit(ExpressionContext* expressionContext,
   bool isEmptyExpression = (buffer->length() == 0);
 
   // the matcher is owned by the context!
-  icu::RegexMatcher* matcher = expressionContext->buildRegexMatcher(
-      buffer->data(), buffer->length(), caseInsensitive);
+  icu::RegexMatcher* matcher =
+      expressionContext->buildRegexMatcher(*buffer, caseInsensitive);
 
   if (matcher == nullptr) {
     registerWarning(expressionContext, AFN, TRI_ERROR_QUERY_INVALID_REGEX);
@@ -3568,8 +3575,8 @@ AqlValue functions::RegexTest(ExpressionContext* expressionContext,
   ::appendAsString(vopts, adapter, regex);
 
   // the matcher is owned by the context!
-  icu::RegexMatcher* matcher = expressionContext->buildRegexMatcher(
-      buffer->data(), buffer->length(), caseInsensitive);
+  icu::RegexMatcher* matcher =
+      expressionContext->buildRegexMatcher(*buffer, caseInsensitive);
 
   if (matcher == nullptr) {
     // compiling regular expression failed
@@ -3612,8 +3619,8 @@ AqlValue functions::RegexReplace(ExpressionContext* expressionContext,
   ::appendAsString(vopts, adapter, regex);
 
   // the matcher is owned by the context!
-  icu::RegexMatcher* matcher = expressionContext->buildRegexMatcher(
-      buffer->data(), buffer->length(), caseInsensitive);
+  icu::RegexMatcher* matcher =
+      expressionContext->buildRegexMatcher(*buffer, caseInsensitive);
 
   if (matcher == nullptr) {
     // compiling regular expression failed

--- a/arangod/Aql/Functions.h
+++ b/arangod/Aql/Functions.h
@@ -31,6 +31,7 @@
 #include "Containers/SmallVector.h"
 
 #include <span>
+#include <string_view>
 
 namespace arangodb {
 class Result;
@@ -51,13 +52,13 @@ typedef AqlValue (*FunctionImplementation)(arangodb::aql::ExpressionContext*,
                                            VPackFunctionParametersView);
 
 void registerError(ExpressionContext* expressionContext,
-                   char const* functionName, ErrorCode code);
+                   std::string_view functionName, ErrorCode code);
 void registerWarning(ExpressionContext* expressionContext,
-                     char const* functionName, ErrorCode code);
+                     std::string_view functionName, ErrorCode code);
 void registerWarning(ExpressionContext* expressionContext,
-                     char const* functionName, Result const& rr);
+                     std::string_view functionName, Result const& rr);
 void registerInvalidArgumentWarning(ExpressionContext* expressionContext,
-                                    char const* functionName);
+                                    std::string_view functionName);
 
 // Returns zero-terminated function name from the given FCALL node.
 std::string_view getFunctionName(const AstNode& node) noexcept;
@@ -70,7 +71,7 @@ namespace functions {
 /// @brief helper function. not callable as a "normal" AQL function
 void Stringify(velocypack::Options const* vopts,
                arangodb::velocypack::StringSink& buffer,
-               arangodb::velocypack::Slice const& slice);
+               arangodb::velocypack::Slice slice);
 
 AqlValue IsNull(arangodb::aql::ExpressionContext*, AstNode const&,
                 VPackFunctionParametersView);

--- a/arangod/Aql/QueryExpressionContext.cpp
+++ b/arangod/Aql/QueryExpressionContext.cpp
@@ -32,25 +32,23 @@ using namespace arangodb;
 using namespace arangodb::aql;
 
 void QueryExpressionContext::registerWarning(ErrorCode errorCode,
-                                             char const* msg) {
+                                             std::string_view msg) {
   _query.warnings().registerWarning(errorCode, msg);
 }
 
 void QueryExpressionContext::registerError(ErrorCode errorCode,
-                                           char const* msg) {
+                                           std::string_view msg) {
   _query.warnings().registerError(errorCode, msg);
 }
 
 icu::RegexMatcher* QueryExpressionContext::buildRegexMatcher(
-    char const* ptr, size_t length, bool caseInsensitive) {
-  return _aqlFunctionsInternalCache.buildRegexMatcher(ptr, length,
-                                                      caseInsensitive);
+    std::string_view expr, bool caseInsensitive) {
+  return _aqlFunctionsInternalCache.buildRegexMatcher(expr, caseInsensitive);
 }
 
 icu::RegexMatcher* QueryExpressionContext::buildLikeMatcher(
-    char const* ptr, size_t length, bool caseInsensitive) {
-  return _aqlFunctionsInternalCache.buildLikeMatcher(ptr, length,
-                                                     caseInsensitive);
+    std::string_view expr, bool caseInsensitive) {
+  return _aqlFunctionsInternalCache.buildLikeMatcher(expr, caseInsensitive);
 }
 
 icu::RegexMatcher* QueryExpressionContext::buildSplitMatcher(
@@ -61,7 +59,7 @@ icu::RegexMatcher* QueryExpressionContext::buildSplitMatcher(
 }
 
 arangodb::ValidatorBase* QueryExpressionContext::buildValidator(
-    arangodb::velocypack::Slice const& params) {
+    arangodb::velocypack::Slice params) {
   return _aqlFunctionsInternalCache.buildValidator(params);
 }
 

--- a/arangod/Aql/QueryExpressionContext.h
+++ b/arangod/Aql/QueryExpressionContext.h
@@ -30,6 +30,8 @@
 
 #include <velocypack/Slice.h>
 
+#include <string_view>
+
 namespace arangodb {
 struct ValidatorBase;
 namespace aql {
@@ -49,19 +51,20 @@ class QueryExpressionContext : public aql::ExpressionContext {
         _query(query),
         _aqlFunctionsInternalCache(cache) {}
 
-  void registerWarning(ErrorCode errorCode, char const* msg) override final;
-  void registerError(ErrorCode errorCode, char const* msg) override final;
+  void registerWarning(ErrorCode errorCode,
+                       std::string_view msg) override final;
+  void registerError(ErrorCode errorCode, std::string_view msg) override final;
 
-  icu::RegexMatcher* buildRegexMatcher(char const* ptr, size_t length,
+  icu::RegexMatcher* buildRegexMatcher(std::string_view expr,
                                        bool caseInsensitive) override final;
-  icu::RegexMatcher* buildLikeMatcher(char const* ptr, size_t length,
+  icu::RegexMatcher* buildLikeMatcher(std::string_view expr,
                                       bool caseInsensitive) override final;
   icu::RegexMatcher* buildSplitMatcher(AqlValue splitExpression,
                                        velocypack::Options const* opts,
                                        bool& isEmptyExpression) override final;
 
   arangodb::ValidatorBase* buildValidator(
-      arangodb::velocypack::Slice const&) override final;
+      arangodb::velocypack::Slice) override final;
 
   TRI_vocbase_t& vocbase() const override final;
   // may be inaccessible on some platforms

--- a/arangod/Aql/QueryWarnings.cpp
+++ b/arangod/Aql/QueryWarnings.cpp
@@ -23,6 +23,7 @@
 
 #include "QueryWarnings.h"
 
+#include "Aql/ExecutionNodeId.h"
 #include "Aql/QueryOptions.h"
 #include "Basics/debugging.h"
 #include "Basics/Exceptions.h"
@@ -36,19 +37,15 @@ QueryWarnings::QueryWarnings()
     : _maxWarningCount(std::numeric_limits<size_t>::max()),
       _failOnWarning(false) {}
 
-/// @brief register an error
-/// this also makes the query abort
+// register an error
+// this also makes the query abort
 void QueryWarnings::registerError(ErrorCode code, std::string_view details) {
   TRI_ASSERT(code != TRI_ERROR_NO_ERROR);
-
-  if (details.data() == nullptr) {
-    THROW_ARANGO_EXCEPTION(code);
-  }
 
   THROW_ARANGO_EXCEPTION_MESSAGE(code, details);
 }
 
-/// @brief register a warning
+// register a warning
 void QueryWarnings::registerWarning(ErrorCode code, std::string_view details) {
   TRI_ASSERT(code != TRI_ERROR_NO_ERROR);
 
@@ -56,9 +53,6 @@ void QueryWarnings::registerWarning(ErrorCode code, std::string_view details) {
 
   if (_failOnWarning) {
     // make an error from each warning if requested
-    if (details.data() == nullptr) {
-      THROW_ARANGO_EXCEPTION(code);
-    }
     THROW_ARANGO_EXCEPTION_MESSAGE(code, details);
   }
 
@@ -66,7 +60,7 @@ void QueryWarnings::registerWarning(ErrorCode code, std::string_view details) {
     return;
   }
 
-  if (details.data() == nullptr) {
+  if (details.empty()) {
     _list.emplace_back(code, TRI_errno_string(code));
   } else {
     _list.emplace_back(code, details);
@@ -102,11 +96,4 @@ void QueryWarnings::updateOptions(QueryOptions const& opts) {
 std::vector<std::pair<ErrorCode, std::string>> QueryWarnings::all() const {
   std::lock_guard<std::mutex> guard(_mutex);
   return _list;
-}
-
-std::string QueryWarnings::buildFormattedString(ErrorCode code,
-                                                std::string_view details) {
-  // std::string_view is not necessarily NUL-terminated
-  std::string temp(details);
-  return arangodb::basics::Exception::FillExceptionString(code, temp.c_str());
 }

--- a/arangod/Aql/QueryWarnings.cpp
+++ b/arangod/Aql/QueryWarnings.cpp
@@ -42,6 +42,9 @@ QueryWarnings::QueryWarnings()
 void QueryWarnings::registerError(ErrorCode code, std::string_view details) {
   TRI_ASSERT(code != TRI_ERROR_NO_ERROR);
 
+  if (details.empty()) {
+    THROW_ARANGO_EXCEPTION(code);
+  }
   THROW_ARANGO_EXCEPTION_MESSAGE(code, details);
 }
 

--- a/arangod/Aql/QueryWarnings.h
+++ b/arangod/Aql/QueryWarnings.h
@@ -35,7 +35,6 @@ class Builder;
 }
 
 namespace aql {
-
 struct QueryOptions;
 
 class QueryWarnings final {
@@ -43,14 +42,15 @@ class QueryWarnings final {
   QueryWarnings& operator=(QueryWarnings const&) = delete;
 
  public:
-  explicit QueryWarnings();
+  QueryWarnings();
   ~QueryWarnings() = default;
 
-  /// @brief register an error
-  /// this also makes the query abort
+  // register an error
+  // this also makes the query abort
   [[noreturn]] void registerError(ErrorCode code,
                                   std::string_view details = {});
-  /// @brief register a warning
+
+  // register a warning
   void registerWarning(ErrorCode code, std::string_view details = {});
 
   void toVelocyPack(arangodb::velocypack::Builder& b) const;
@@ -61,13 +61,10 @@ class QueryWarnings final {
 
   std::vector<std::pair<ErrorCode, std::string>> all() const;
 
-  static std::string buildFormattedString(ErrorCode code,
-                                          std::string_view details);
-
  private:
   mutable std::mutex _mutex;
 
-  /// @brief warnings collected during execution
+  // warnings collected during execution
   std::vector<std::pair<ErrorCode, std::string>> _list;
 
   size_t _maxWarningCount;

--- a/arangod/Aql/TraversalExecutor.cpp
+++ b/arangod/Aql/TraversalExecutor.cpp
@@ -158,7 +158,7 @@ TraversalExecutorInfos::traversalEnumerator() const {
 
 bool TraversalExecutorInfos::usesOutputRegister(
     TraversalExecutorInfosHelper::OutputName type) const {
-  return _registerMapping.find(type) != _registerMapping.end();
+  return _registerMapping.contains(type);
 }
 
 bool TraversalExecutorInfos::useVertexOutput() const {

--- a/arangod/Aql/TraversalNode.cpp
+++ b/arangod/Aql/TraversalNode.cpp
@@ -649,9 +649,9 @@ std::unique_ptr<ExecutionBlock> TraversalNode::createBlock(
         checkPruneAvailability,
     std::function<void(std::shared_ptr<aql::PruneExpressionEvaluator>&)> const&
         checkPostFilterAvailability,
-    const std::unordered_map<
-        TraversalExecutorInfosHelper::OutputName, RegisterId,
-        TraversalExecutorInfosHelper::OutputNameHash>& outputRegisterMapping,
+    std::unordered_map<TraversalExecutorInfosHelper::OutputName, RegisterId,
+                       TraversalExecutorInfosHelper::OutputNameHash> const&
+        outputRegisterMapping,
     RegisterId inputRegister, RegisterInfos registerInfos,
     std::unordered_map<ServerID, aql::EngineId> const* engines,
     bool isSmart) const {

--- a/arangod/IResearch/IResearchExpressionContext.cpp
+++ b/arangod/IResearch/IResearchExpressionContext.cpp
@@ -42,25 +42,23 @@ using namespace arangodb::aql;
 // -----------------------------------------------------------------------------
 
 void ViewExpressionContextBase::registerWarning(ErrorCode errorCode,
-                                                char const* msg) {
+                                                std::string_view msg) {
   _query->warnings().registerWarning(errorCode, msg);
 }
 
 void ViewExpressionContextBase::registerError(ErrorCode errorCode,
-                                              char const* msg) {
+                                              std::string_view msg) {
   _query->warnings().registerError(errorCode, msg);
 }
 
 icu::RegexMatcher* ViewExpressionContextBase::buildRegexMatcher(
-    char const* ptr, size_t length, bool caseInsensitive) {
-  return _aqlFunctionsInternalCache->buildRegexMatcher(ptr, length,
-                                                       caseInsensitive);
+    std::string_view expr, bool caseInsensitive) {
+  return _aqlFunctionsInternalCache->buildRegexMatcher(expr, caseInsensitive);
 }
 
 icu::RegexMatcher* ViewExpressionContextBase::buildLikeMatcher(
-    char const* ptr, size_t length, bool caseInsensitive) {
-  return _aqlFunctionsInternalCache->buildLikeMatcher(ptr, length,
-                                                      caseInsensitive);
+    std::string_view expr, bool caseInsensitive) {
+  return _aqlFunctionsInternalCache->buildLikeMatcher(expr, caseInsensitive);
 }
 
 icu::RegexMatcher* ViewExpressionContextBase::buildSplitMatcher(
@@ -71,7 +69,7 @@ icu::RegexMatcher* ViewExpressionContextBase::buildSplitMatcher(
 }
 
 arangodb::ValidatorBase* ViewExpressionContextBase::buildValidator(
-    arangodb::velocypack::Slice const& params) {
+    arangodb::velocypack::Slice params) {
   return _aqlFunctionsInternalCache->buildValidator(params);
 }
 

--- a/arangod/IResearch/IResearchExpressionContext.h
+++ b/arangod/IResearch/IResearchExpressionContext.h
@@ -63,19 +63,20 @@ struct ViewExpressionContextBase : public arangodb::aql::ExpressionContext {
         _query(query),
         _aqlFunctionsInternalCache(cache) {}
 
-  void registerWarning(ErrorCode errorCode, char const* msg) override final;
-  void registerError(ErrorCode errorCode, char const* msg) override final;
+  void registerWarning(ErrorCode errorCode,
+                       std::string_view msg) override final;
+  void registerError(ErrorCode errorCode, std::string_view msg) override final;
 
-  icu::RegexMatcher* buildRegexMatcher(char const* ptr, size_t length,
+  icu::RegexMatcher* buildRegexMatcher(std::string_view expr,
                                        bool caseInsensitive) override final;
-  icu::RegexMatcher* buildLikeMatcher(char const* ptr, size_t length,
+  icu::RegexMatcher* buildLikeMatcher(std::string_view expr,
                                       bool caseInsensitive) override final;
   icu::RegexMatcher* buildSplitMatcher(aql::AqlValue splitExpression,
                                        velocypack::Options const* opts,
                                        bool& isEmptyExpression) override final;
 
   arangodb::ValidatorBase* buildValidator(
-      arangodb::velocypack::Slice const&) override final;
+      arangodb::velocypack::Slice) override final;
 
   TRI_vocbase_t& vocbase() const override final;
   /// may be inaccessible on some platforms

--- a/arangod/VocBase/ComputedValues.cpp
+++ b/arangod/VocBase/ComputedValues.cpp
@@ -85,7 +85,7 @@ transaction::Methods& ComputedValuesExpressionContext::trx() const {
 }
 
 void ComputedValuesExpressionContext::registerWarning(ErrorCode errorCode,
-                                                      char const* msg) {
+                                                      std::string_view msg) {
   if (_failOnWarning) {
     // treat as an error if we are supposed to treat warnings as errors
     registerError(errorCode, msg);
@@ -96,7 +96,7 @@ void ComputedValuesExpressionContext::registerWarning(ErrorCode errorCode,
 }
 
 void ComputedValuesExpressionContext::registerError(ErrorCode errorCode,
-                                                    char const* msg) {
+                                                    std::string_view msg) {
   TRI_ASSERT(errorCode != TRI_ERROR_NO_ERROR);
 
   std::string error = buildLogMessage("error", msg);
@@ -105,31 +105,25 @@ void ComputedValuesExpressionContext::registerError(ErrorCode errorCode,
 }
 
 std::string ComputedValuesExpressionContext::buildLogMessage(
-    std::string_view type, char const* msg) const {
+    std::string_view type, std::string_view msg) const {
   // note: on DB servers, the error message will contain the shard name
   // rather than the collection name.
-  std::string error =
-      absl::StrCat("computed values expression evaluation produced a runtime ",
-                   type, " for attribute '", _name, "' of collection '",
-                   _collection.vocbase().name(), "/", _collection.name(), "'");
-
-  if (msg != nullptr) {
-    absl::StrAppend(&error, ": ", msg);
-  }
+  std::string error = absl::StrCat(
+      "computed values expression evaluation produced a runtime ", type,
+      " for attribute '", _name, "' of collection '",
+      _collection.vocbase().name(), "/", _collection.name(), "': ", msg);
 
   return error;
 }
 
 icu::RegexMatcher* ComputedValuesExpressionContext::buildRegexMatcher(
-    char const* ptr, size_t length, bool caseInsensitive) {
-  return _aqlFunctionsInternalCache.buildRegexMatcher(ptr, length,
-                                                      caseInsensitive);
+    std::string_view expr, bool caseInsensitive) {
+  return _aqlFunctionsInternalCache.buildRegexMatcher(expr, caseInsensitive);
 }
 
 icu::RegexMatcher* ComputedValuesExpressionContext::buildLikeMatcher(
-    char const* ptr, size_t length, bool caseInsensitive) {
-  return _aqlFunctionsInternalCache.buildLikeMatcher(ptr, length,
-                                                     caseInsensitive);
+    std::string_view expr, bool caseInsensitive) {
+  return _aqlFunctionsInternalCache.buildLikeMatcher(expr, caseInsensitive);
 }
 
 icu::RegexMatcher* ComputedValuesExpressionContext::buildSplitMatcher(
@@ -140,7 +134,7 @@ icu::RegexMatcher* ComputedValuesExpressionContext::buildSplitMatcher(
 }
 
 ValidatorBase* ComputedValuesExpressionContext::buildValidator(
-    velocypack::Slice const& params) {
+    velocypack::Slice params) {
   return _aqlFunctionsInternalCache.buildValidator(params);
 }
 

--- a/arangod/VocBase/ComputedValues.h
+++ b/arangod/VocBase/ComputedValues.h
@@ -74,25 +74,25 @@ class ComputedValuesExpressionContext final : public aql::ExpressionContext {
   explicit ComputedValuesExpressionContext(transaction::Methods& trx,
                                            LogicalCollection& collection);
 
-  void registerWarning(ErrorCode errorCode, char const* msg) override;
+  void registerWarning(ErrorCode errorCode, std::string_view msg) override;
 
-  void registerError(ErrorCode errorCode, char const* msg) override;
+  void registerError(ErrorCode errorCode, std::string_view msg) override;
 
   void failOnWarning(bool value) noexcept { _failOnWarning = value; }
 
   void setName(std::string_view name) noexcept { _name = name; }
 
-  icu::RegexMatcher* buildRegexMatcher(char const* ptr, size_t length,
+  icu::RegexMatcher* buildRegexMatcher(std::string_view expr,
                                        bool caseInsensitive) override;
 
-  icu::RegexMatcher* buildLikeMatcher(char const* ptr, size_t length,
+  icu::RegexMatcher* buildLikeMatcher(std::string_view expr,
                                       bool caseInsensitive) override;
 
   icu::RegexMatcher* buildSplitMatcher(aql::AqlValue splitExpression,
                                        velocypack::Options const* opts,
                                        bool& isEmptyExpression) override;
 
-  ValidatorBase* buildValidator(velocypack::Slice const& params) override;
+  ValidatorBase* buildValidator(velocypack::Slice params) override;
 
   TRI_vocbase_t& vocbase() const override;
 
@@ -110,7 +110,8 @@ class ComputedValuesExpressionContext final : public aql::ExpressionContext {
   void clearVariable(aql::Variable const* variable) noexcept override;
 
  private:
-  std::string buildLogMessage(std::string_view type, char const* msg) const;
+  std::string buildLogMessage(std::string_view type,
+                              std::string_view msg) const;
 
   transaction::Methods& _trx;
   LogicalCollection& _collection;

--- a/tests/Aql/BitFunctionsTest.cpp
+++ b/tests/Aql/BitFunctionsTest.cpp
@@ -62,7 +62,7 @@ AqlValue callFn(AstNode const& node, char const* input1,
   fakeit::Mock<ExpressionContext> expressionContextMock;
   ExpressionContext& expressionContext = expressionContextMock.get();
   fakeit::When(Method(expressionContextMock, registerWarning))
-      .AlwaysDo([](ErrorCode, char const*) {});
+      .AlwaysDo([](ErrorCode, std::string_view) {});
 
   VPackOptions options;
   fakeit::Mock<transaction::Context> trxCtxMock;

--- a/tests/Aql/DecaysFunctionTest.cpp
+++ b/tests/Aql/DecaysFunctionTest.cpp
@@ -92,7 +92,7 @@ AqlValue evaluateDecayFunction(std::span<AqlValue const> params,
   fakeit::Mock<ExpressionContext> expressionContextMock;
   ExpressionContext& expressionContext = expressionContextMock.get();
   fakeit::When(Method(expressionContextMock, registerWarning))
-      .AlwaysDo([](ErrorCode, char const*) {});
+      .AlwaysDo([](ErrorCode, std::string_view) {});
 
   VPackOptions options;
   fakeit::Mock<transaction::Context> trxCtxMock;

--- a/tests/Aql/DistanceFunctionTest.cpp
+++ b/tests/Aql/DistanceFunctionTest.cpp
@@ -91,7 +91,7 @@ AqlValue evaluateDistanceFunction(std::span<AqlValue const> params,
   fakeit::Mock<ExpressionContext> expressionContextMock;
   ExpressionContext& expressionContext = expressionContextMock.get();
   fakeit::When(Method(expressionContextMock, registerWarning))
-      .AlwaysDo([](ErrorCode, char const*) {});
+      .AlwaysDo([](ErrorCode, std::string_view) {});
 
   VPackOptions options;
   fakeit::Mock<transaction::Context> trxCtxMock;

--- a/tests/Aql/InRangeFunctionTest.cpp
+++ b/tests/Aql/InRangeFunctionTest.cpp
@@ -57,7 +57,7 @@ class InRangeFunctionTest : public ::testing::Test {
     fakeit::Mock<ExpressionContext> expressionContextMock;
     ExpressionContext& expressionContext = expressionContextMock.get();
     fakeit::When(Method(expressionContextMock, registerWarning))
-        .AlwaysDo([warnings](ErrorCode c, char const*) {
+        .AlwaysDo([warnings](ErrorCode c, std::string_view) {
           if (warnings) {
             warnings->insert(static_cast<int>(c));
           }

--- a/tests/Aql/JaccardFunctionTest.cpp
+++ b/tests/Aql/JaccardFunctionTest.cpp
@@ -48,7 +48,7 @@ AqlValue evaluate(AqlValue const& lhs, AqlValue const& rhs) {
   fakeit::Mock<ExpressionContext> expressionContextMock;
   ExpressionContext& expressionContext = expressionContextMock.get();
   fakeit::When(Method(expressionContextMock, registerWarning))
-      .AlwaysDo([](ErrorCode, char const*) {});
+      .AlwaysDo([](ErrorCode, std::string_view) {});
 
   VPackOptions options;
   fakeit::Mock<transaction::Context> trxCtxMock;

--- a/tests/Aql/LevenshteinMatchFunctionTest.cpp
+++ b/tests/Aql/LevenshteinMatchFunctionTest.cpp
@@ -50,7 +50,7 @@ AqlValue evaluate(AqlValue const& lhs, AqlValue const& rhs,
   fakeit::Mock<ExpressionContext> expressionContextMock;
   ExpressionContext& expressionContext = expressionContextMock.get();
   fakeit::When(Method(expressionContextMock, registerWarning))
-      .AlwaysDo([](ErrorCode, char const*) {});
+      .AlwaysDo([](ErrorCode, std::string_view) {});
 
   std::string buffer;
   VPackOptions options;

--- a/tests/Aql/MinHashFunctionsTest.cpp
+++ b/tests/Aql/MinHashFunctionsTest.cpp
@@ -66,7 +66,7 @@ void assertFuncThrow(std::span<const AqlValue> args,
   fakeit::Mock<ExpressionContext> expressionContextMock;
   ExpressionContext& expressionContext = expressionContextMock.get();
   fakeit::When(Method(expressionContextMock, registerWarning))
-      .AlwaysDo([](ErrorCode, char const*) {});
+      .AlwaysDo([](ErrorCode, std::string_view) {});
 
   VPackOptions options;
   fakeit::Mock<transaction::Context> trxCtxMock;

--- a/tests/Aql/NgramMatchFunctionTest.cpp
+++ b/tests/Aql/NgramMatchFunctionTest.cpp
@@ -83,7 +83,7 @@ class NgramMatchFunctionTest : public ::testing::Test {
     fakeit::Mock<ExpressionContext> expressionContextMock;
     ExpressionContext& expressionContext = expressionContextMock.get();
     fakeit::When(Method(expressionContextMock, registerWarning))
-        .AlwaysDo([warnings](ErrorCode c, char const*) {
+        .AlwaysDo([warnings](ErrorCode c, std::string_view) {
           if (warnings) {
             warnings->insert(static_cast<int>(c));
           }

--- a/tests/Aql/NgramPosSimilarityFunctionTest.cpp
+++ b/tests/Aql/NgramPosSimilarityFunctionTest.cpp
@@ -56,7 +56,7 @@ class NgramPosSimilarityFunctionTest : public ::testing::Test {
     fakeit::Mock<ExpressionContext> expressionContextMock;
     ExpressionContext& expressionContext = expressionContextMock.get();
     fakeit::When(Method(expressionContextMock, registerWarning))
-        .AlwaysDo([warnings](ErrorCode c, char const*) {
+        .AlwaysDo([warnings](ErrorCode c, std::string_view) {
           if (warnings) {
             warnings->insert(static_cast<int>(c));
           }

--- a/tests/Aql/NgramSimilarityFunctionTest.cpp
+++ b/tests/Aql/NgramSimilarityFunctionTest.cpp
@@ -56,7 +56,7 @@ class NgramSimilarityFunctionTest : public ::testing::Test {
     fakeit::Mock<ExpressionContext> expressionContextMock;
     ExpressionContext& expressionContext = expressionContextMock.get();
     fakeit::When(Method(expressionContextMock, registerWarning))
-        .AlwaysDo([warnings](ErrorCode c, char const*) {
+        .AlwaysDo([warnings](ErrorCode c, std::string_view) {
           if (warnings) {
             warnings->insert(static_cast<int>(c));
           }

--- a/tests/Geo/GeoConstructorTest.cpp
+++ b/tests/Geo/GeoConstructorTest.cpp
@@ -89,7 +89,7 @@ class GeoPointTest : public GeoConstructorTest {
     funNode.setData(static_cast<void const*>(&fun));
 
     fakeit::When(Method(expressionContextMock, registerWarning))
-        .Do([&](ErrorCode code, char const* msg) -> void {
+        .Do([&](ErrorCode code, std::string_view) -> void {
           ASSERT_EQ(code, TRI_ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH);
         });
   }
@@ -610,7 +610,7 @@ TEST_F(GeoMultipointTest, checking_points_representing_points_in_cologne) {
 }
 TEST_F(GeoMultipointTest, checking_array_with_1_position) {
   fakeit::When(Method(expressionContextMock, registerWarning))
-      .Do([&](ErrorCode code, char const* msg) -> void {
+      .Do([&](ErrorCode code, std::string_view) -> void {
         ASSERT_EQ(code, TRI_ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH);
       });
 
@@ -632,7 +632,7 @@ TEST_F(GeoMultipointTest, checking_array_with_1_position) {
 
 TEST_F(GeoMultipointTest, checking_array_with_positions_and_invalid_bool) {
   fakeit::When(Method(expressionContextMock, registerWarning))
-      .Do([&](ErrorCode code, char const* msg) -> void {
+      .Do([&](ErrorCode code, std::string_view) -> void {
         ASSERT_EQ(code, TRI_ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH);
       });
 
@@ -654,7 +654,7 @@ TEST_F(GeoMultipointTest, checking_array_with_positions_and_invalid_bool) {
 
 TEST_F(GeoMultipointTest, checking_array_with_positions_and_invalid_bool_2) {
   fakeit::When(Method(expressionContextMock, registerWarning))
-      .Do([&](ErrorCode code, char const* msg) -> void {
+      .Do([&](ErrorCode code, std::string_view) -> void {
         ASSERT_EQ(code, TRI_ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH);
       });
 
@@ -676,7 +676,7 @@ TEST_F(GeoMultipointTest, checking_array_with_positions_and_invalid_bool_2) {
 
 TEST_F(GeoMultipointTest, checking_array_with_0_positions_nested) {
   fakeit::When(Method(expressionContextMock, registerWarning))
-      .Do([&](ErrorCode code, char const* msg) -> void {
+      .Do([&](ErrorCode code, std::string_view) -> void {
         ASSERT_EQ(code, TRI_ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH);
       });
 
@@ -698,7 +698,7 @@ TEST_F(GeoMultipointTest, checking_array_with_0_positions_nested) {
 
 TEST_F(GeoMultipointTest, checking_array_with_0_positions) {
   fakeit::When(Method(expressionContextMock, registerWarning))
-      .Do([&](ErrorCode code, char const* msg) -> void {
+      .Do([&](ErrorCode code, std::string_view) -> void {
         ASSERT_EQ(code, TRI_ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH);
       });
 
@@ -720,7 +720,7 @@ TEST_F(GeoMultipointTest, checking_array_with_0_positions) {
 
 TEST_F(GeoMultipointTest, checking_bool) {
   fakeit::When(Method(expressionContextMock, registerWarning))
-      .Do([&](ErrorCode code, char const* msg) -> void {
+      .Do([&](ErrorCode code, std::string_view) -> void {
         ASSERT_EQ(code, TRI_ERROR_QUERY_ARRAY_EXPECTED);
       });
 
@@ -742,7 +742,7 @@ TEST_F(GeoMultipointTest, checking_bool) {
 
 TEST_F(GeoMultipointTest, checking_number) {
   fakeit::When(Method(expressionContextMock, registerWarning))
-      .Do([&](ErrorCode code, char const* msg) -> void {
+      .Do([&](ErrorCode code, std::string_view) -> void {
         ASSERT_EQ(code, TRI_ERROR_QUERY_ARRAY_EXPECTED);
       });
 
@@ -768,7 +768,7 @@ TEST_F(GeoMultipointTest, checking_number) {
 
 TEST_F(GeoMultipointTest, checking_object) {
   fakeit::When(Method(expressionContextMock, registerWarning))
-      .Do([&](ErrorCode code, char const* msg) -> void {
+      .Do([&](ErrorCode code, std::string_view) -> void {
         ASSERT_EQ(code, TRI_ERROR_QUERY_ARRAY_EXPECTED);
       });
 
@@ -809,7 +809,7 @@ class GeoPolygonTest : public GeoConstructorTest {
 
 TEST_F(GeoPolygonTest, checking_polygon_with_3_positive_tuples) {
   fakeit::When(Method(expressionContextMock, registerWarning))
-      .Do([&](ErrorCode code, char const* msg) -> void {
+      .Do([&](ErrorCode code, std::string_view) -> void {
         ASSERT_EQ(code, TRI_ERROR_BAD_PARAMETER);
       });
 
@@ -860,7 +860,7 @@ TEST_F(GeoPolygonTest, checking_polygon_representing_cologne) {
 
 TEST_F(GeoPolygonTest, checking_polygon_with_3_negative_positions) {
   fakeit::When(Method(expressionContextMock, registerWarning))
-      .Do([&](ErrorCode code, char const* msg) -> void {
+      .Do([&](ErrorCode code, std::string_view) -> void {
         ASSERT_EQ(code, TRI_ERROR_BAD_PARAMETER);
       });
 
@@ -882,7 +882,7 @@ TEST_F(GeoPolygonTest, checking_polygon_with_3_negative_positions) {
 
 TEST_F(GeoPolygonTest, checking_polygons_with_2x3_negative_positions) {
   fakeit::When(Method(expressionContextMock, registerWarning))
-      .Do([&](ErrorCode code, char const* msg) -> void {
+      .Do([&](ErrorCode code, std::string_view) -> void {
         ASSERT_EQ(code, TRI_ERROR_BAD_PARAMETER);
       });
 
@@ -907,7 +907,7 @@ TEST_F(GeoPolygonTest, checking_polygons_with_2x3_negative_positions) {
 
 TEST_F(GeoPolygonTest, checking_polygon_with_1_positive_position) {
   fakeit::When(Method(expressionContextMock, registerWarning))
-      .Do([&](ErrorCode code, char const* msg) -> void {
+      .Do([&](ErrorCode code, std::string_view) -> void {
         ASSERT_EQ(code, TRI_ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH);
       });
 
@@ -929,7 +929,7 @@ TEST_F(GeoPolygonTest, checking_polygon_with_1_positive_position) {
 
 TEST_F(GeoPolygonTest, checking_polygon_with_1_negative_position) {
   fakeit::When(Method(expressionContextMock, registerWarning))
-      .Do([&](ErrorCode code, char const* msg) -> void {
+      .Do([&](ErrorCode code, std::string_view) -> void {
         ASSERT_EQ(code, TRI_ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH);
       });
 
@@ -951,7 +951,7 @@ TEST_F(GeoPolygonTest, checking_polygon_with_1_negative_position) {
 
 TEST_F(GeoPolygonTest, checking_polygon_with_2_positive_tuples) {
   fakeit::When(Method(expressionContextMock, registerWarning))
-      .Do([&](ErrorCode code, char const* msg) -> void {
+      .Do([&](ErrorCode code, std::string_view) -> void {
         ASSERT_EQ(code, TRI_ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH);
       });
 
@@ -973,7 +973,7 @@ TEST_F(GeoPolygonTest, checking_polygon_with_2_positive_tuples) {
 
 TEST_F(GeoPolygonTest, checking_polygon_with_2_negative_tuples) {
   fakeit::When(Method(expressionContextMock, registerWarning))
-      .Do([&](ErrorCode code, char const* msg) -> void {
+      .Do([&](ErrorCode code, std::string_view) -> void {
         ASSERT_EQ(code, TRI_ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH);
       });
 
@@ -995,7 +995,7 @@ TEST_F(GeoPolygonTest, checking_polygon_with_2_negative_tuples) {
 
 TEST_F(GeoPolygonTest, checking_polygon_with_empty_input) {
   fakeit::When(Method(expressionContextMock, registerWarning))
-      .Do([&](ErrorCode code, char const* msg) -> void {
+      .Do([&](ErrorCode code, std::string_view) -> void {
         ASSERT_EQ(code, TRI_ERROR_QUERY_ARRAY_EXPECTED);
       });
 
@@ -1017,7 +1017,7 @@ TEST_F(GeoPolygonTest, checking_polygon_with_empty_input) {
 
 TEST_F(GeoPolygonTest, checking_polygon_with_boolean) {
   fakeit::When(Method(expressionContextMock, registerWarning))
-      .Do([&](ErrorCode code, char const* msg) -> void {
+      .Do([&](ErrorCode code, std::string_view) -> void {
         ASSERT_EQ(code, TRI_ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH);
       });
 
@@ -1039,7 +1039,7 @@ TEST_F(GeoPolygonTest, checking_polygon_with_boolean) {
 
 TEST_F(GeoPolygonTest, checking_polygon_with_booleans) {
   fakeit::When(Method(expressionContextMock, registerWarning))
-      .Do([&](ErrorCode code, char const* msg) -> void {
+      .Do([&](ErrorCode code, std::string_view) -> void {
         ASSERT_EQ(code, TRI_ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH);
       });
 
@@ -1061,7 +1061,7 @@ TEST_F(GeoPolygonTest, checking_polygon_with_booleans) {
 
 TEST_F(GeoPolygonTest, checking_polygon_with_nested_booleans) {
   fakeit::When(Method(expressionContextMock, registerWarning))
-      .Do([&](ErrorCode code, char const* msg) -> void {
+      .Do([&](ErrorCode code, std::string_view) -> void {
         ASSERT_EQ(code, TRI_ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH);
       });
 
@@ -1083,7 +1083,7 @@ TEST_F(GeoPolygonTest, checking_polygon_with_nested_booleans) {
 
 TEST_F(GeoPolygonTest, checking_object_with_single_boolean) {
   fakeit::When(Method(expressionContextMock, registerWarning))
-      .Do([&](ErrorCode code, char const* msg) -> void {
+      .Do([&](ErrorCode code, std::string_view) -> void {
         ASSERT_EQ(code, TRI_ERROR_QUERY_ARRAY_EXPECTED);
       });
 
@@ -1105,7 +1105,7 @@ TEST_F(GeoPolygonTest, checking_object_with_single_boolean) {
 
 TEST_F(GeoPolygonTest, checking_object_with_single_number) {
   fakeit::When(Method(expressionContextMock, registerWarning))
-      .Do([&](ErrorCode code, char const* msg) -> void {
+      .Do([&](ErrorCode code, std::string_view) -> void {
         ASSERT_EQ(code, TRI_ERROR_QUERY_ARRAY_EXPECTED);
       });
 
@@ -1127,7 +1127,7 @@ TEST_F(GeoPolygonTest, checking_object_with_single_number) {
 
 TEST_F(GeoPolygonTest, checking_object_with_string) {
   fakeit::When(Method(expressionContextMock, registerWarning))
-      .Do([&](ErrorCode code, char const* msg) -> void {
+      .Do([&](ErrorCode code, std::string_view) -> void {
         ASSERT_EQ(code, TRI_ERROR_QUERY_ARRAY_EXPECTED);
       });
 
@@ -1149,7 +1149,7 @@ TEST_F(GeoPolygonTest, checking_object_with_string) {
 
 TEST_F(GeoPolygonTest, checking_object_with_null) {
   fakeit::When(Method(expressionContextMock, registerWarning))
-      .Do([&](ErrorCode code, char const* msg) -> void {
+      .Do([&](ErrorCode code, std::string_view) -> void {
         ASSERT_EQ(code, TRI_ERROR_QUERY_ARRAY_EXPECTED);
       });
 
@@ -1171,7 +1171,7 @@ TEST_F(GeoPolygonTest, checking_object_with_null) {
 
 TEST_F(GeoPolygonTest, checking_object_with_some_data) {
   fakeit::When(Method(expressionContextMock, registerWarning))
-      .Do([&](ErrorCode code, char const* msg) -> void {
+      .Do([&](ErrorCode code, std::string_view) -> void {
         ASSERT_EQ(code, TRI_ERROR_QUERY_ARRAY_EXPECTED);
       });
 
@@ -1261,7 +1261,7 @@ TEST_F(GeoLinestringTest, checking_linestring_representing_cologne) {
 
 TEST_F(GeoLinestringTest, checking_array_with_1_position) {
   fakeit::When(Method(expressionContextMock, registerWarning))
-      .Do([&](ErrorCode code, char const* msg) -> void {
+      .Do([&](ErrorCode code, std::string_view) -> void {
         ASSERT_EQ(code, TRI_ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH);
       });
 
@@ -1283,7 +1283,7 @@ TEST_F(GeoLinestringTest, checking_array_with_1_position) {
 
 TEST_F(GeoLinestringTest, checking_array_with_positions_and_invalid_bool) {
   fakeit::When(Method(expressionContextMock, registerWarning))
-      .Do([&](ErrorCode code, char const* msg) -> void {
+      .Do([&](ErrorCode code, std::string_view) -> void {
         ASSERT_EQ(code, TRI_ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH);
       });
 
@@ -1305,7 +1305,7 @@ TEST_F(GeoLinestringTest, checking_array_with_positions_and_invalid_bool) {
 
 TEST_F(GeoLinestringTest, checking_array_with_positions_and_invalid_bool_2) {
   fakeit::When(Method(expressionContextMock, registerWarning))
-      .Do([&](ErrorCode code, char const* msg) -> void {
+      .Do([&](ErrorCode code, std::string_view) -> void {
         ASSERT_EQ(code, TRI_ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH);
       });
 
@@ -1327,7 +1327,7 @@ TEST_F(GeoLinestringTest, checking_array_with_positions_and_invalid_bool_2) {
 
 TEST_F(GeoLinestringTest, checking_empty_nested_array) {
   fakeit::When(Method(expressionContextMock, registerWarning))
-      .Do([&](ErrorCode code, char const* msg) -> void {
+      .Do([&](ErrorCode code, std::string_view) -> void {
         ASSERT_EQ(code, TRI_ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH);
       });
 
@@ -1349,7 +1349,7 @@ TEST_F(GeoLinestringTest, checking_empty_nested_array) {
 
 TEST_F(GeoLinestringTest, checking_empty_array) {
   fakeit::When(Method(expressionContextMock, registerWarning))
-      .Do([&](ErrorCode code, char const* msg) -> void {
+      .Do([&](ErrorCode code, std::string_view) -> void {
         ASSERT_EQ(code, TRI_ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH);
       });
 
@@ -1371,7 +1371,7 @@ TEST_F(GeoLinestringTest, checking_empty_array) {
 
 TEST_F(GeoLinestringTest, checking_bool) {
   fakeit::When(Method(expressionContextMock, registerWarning))
-      .Do([&](ErrorCode code, char const* msg) -> void {
+      .Do([&](ErrorCode code, std::string_view) -> void {
         ASSERT_EQ(code, TRI_ERROR_QUERY_ARRAY_EXPECTED);
       });
 
@@ -1393,7 +1393,7 @@ TEST_F(GeoLinestringTest, checking_bool) {
 
 TEST_F(GeoLinestringTest, checking_number) {
   fakeit::When(Method(expressionContextMock, registerWarning))
-      .Do([&](ErrorCode code, char const* msg) -> void {
+      .Do([&](ErrorCode code, std::string_view) -> void {
         ASSERT_EQ(code, TRI_ERROR_QUERY_ARRAY_EXPECTED);
       });
 
@@ -1415,7 +1415,7 @@ TEST_F(GeoLinestringTest, checking_number) {
 
 TEST_F(GeoLinestringTest, checking_object) {
   fakeit::When(Method(expressionContextMock, registerWarning))
-      .Do([&](ErrorCode code, char const* msg) -> void {
+      .Do([&](ErrorCode code, std::string_view) -> void {
         ASSERT_EQ(code, TRI_ERROR_QUERY_ARRAY_EXPECTED);
       });
 
@@ -1520,7 +1520,7 @@ TEST_F(GeoMultilinestringTest, checking_multilinestrings_with_2x2_positions_2) {
 
 TEST_F(GeoMultilinestringTest, checking_object) {
   fakeit::When(Method(expressionContextMock, registerWarning))
-      .Do([&](ErrorCode code, char const* msg) -> void {
+      .Do([&](ErrorCode code, std::string_view) -> void {
         ASSERT_EQ(code, TRI_ERROR_QUERY_ARRAY_EXPECTED);
       });
 
@@ -1543,7 +1543,7 @@ TEST_F(GeoMultilinestringTest, checking_object) {
 
 TEST_F(GeoMultilinestringTest, checking_polygon_with_0_positions_nested) {
   fakeit::When(Method(expressionContextMock, registerWarning))
-      .Do([&](ErrorCode code, char const* msg) -> void {
+      .Do([&](ErrorCode code, std::string_view) -> void {
         ASSERT_EQ(code, TRI_ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH);
       });
 
@@ -1566,7 +1566,7 @@ TEST_F(GeoMultilinestringTest, checking_polygon_with_0_positions_nested) {
 
 TEST_F(GeoMultilinestringTest, checking_polygon_with_0_positions) {
   fakeit::When(Method(expressionContextMock, registerWarning))
-      .Do([&](ErrorCode code, char const* msg) -> void {
+      .Do([&](ErrorCode code, std::string_view) -> void {
         ASSERT_EQ(code, TRI_ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH);
       });
 
@@ -1589,7 +1589,7 @@ TEST_F(GeoMultilinestringTest, checking_polygon_with_0_positions) {
 
 TEST_F(GeoMultilinestringTest, checking_bool) {
   fakeit::When(Method(expressionContextMock, registerWarning))
-      .Do([&](ErrorCode code, char const* msg) -> void {
+      .Do([&](ErrorCode code, std::string_view) -> void {
         ASSERT_EQ(code, TRI_ERROR_QUERY_ARRAY_EXPECTED);
       });
 
@@ -1612,7 +1612,7 @@ TEST_F(GeoMultilinestringTest, checking_bool) {
 
 TEST_F(GeoMultilinestringTest, checking_number) {
   fakeit::When(Method(expressionContextMock, registerWarning))
-      .Do([&](ErrorCode code, char const* msg) -> void {
+      .Do([&](ErrorCode code, std::string_view) -> void {
         ASSERT_EQ(code, TRI_ERROR_QUERY_ARRAY_EXPECTED);
       });
 

--- a/tests/Geo/GeoFunctionsTest.cpp
+++ b/tests/Geo/GeoFunctionsTest.cpp
@@ -427,7 +427,7 @@ TEST_F(GeoEqualsPolygonTest,
 
 TEST_F(GeoEqualsPolygonTest, checking_only_one_polygon_first_parameter) {
   fakeit::When(Method(expressionContextMock, registerWarning))
-      .Do([&](ErrorCode code, char const* msg) -> void {
+      .Do([&](ErrorCode code, std::string_view) -> void {
         ASSERT_EQ(code, TRI_ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH);
       });
 
@@ -455,7 +455,7 @@ TEST_F(GeoEqualsPolygonTest, checking_only_one_polygon_first_parameter) {
 
 TEST_F(GeoEqualsPolygonTest, checking_only_one_polygon_second_parameter) {
   fakeit::When(Method(expressionContextMock, registerWarning))
-      .Do([&](ErrorCode code, char const* msg) -> void {
+      .Do([&](ErrorCode code, std::string_view) -> void {
         ASSERT_EQ(code, TRI_ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH);
       });
 
@@ -618,7 +618,7 @@ struct GeoEqualsMixedTypeTest : public GeoEqualsTest {
 
 TEST_F(GeoEqualsMixedTypeTest, checking_polygon_with_multilinestring) {
   fakeit::When(Method(expressionContextMock, registerWarning))
-      .Do([&](ErrorCode code, char const* msg) -> void {
+      .Do([&](ErrorCode code, std::string_view) -> void {
         ASSERT_EQ(code, TRI_ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH);
       });
 
@@ -659,7 +659,7 @@ TEST_F(GeoEqualsMixedTypeTest, checking_polygon_with_multilinestring) {
 
 TEST_F(GeoEqualsMixedTypeTest, checking_multipoint_with_multilinestring) {
   fakeit::When(Method(expressionContextMock, registerWarning))
-      .Do([&](ErrorCode code, char const* msg) -> void {
+      .Do([&](ErrorCode code, std::string_view) -> void {
         ASSERT_EQ(code, TRI_ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH);
       });
 
@@ -730,7 +730,7 @@ TEST(GeoInRangeTest, test) {
 
   {
     fakeit::When(Method(expressionContextMock, registerWarning))
-        .Do([&](ErrorCode code, char const*) -> void {
+        .Do([&](ErrorCode code, std::string_view) -> void {
           ASSERT_EQ(code, TRI_ERROR_QUERY_FUNCTION_ARGUMENT_NUMBER_MISMATCH);
         });
 
@@ -749,7 +749,7 @@ TEST(GeoInRangeTest, test) {
 
   {
     fakeit::When(Method(expressionContextMock, registerWarning))
-        .Do([&](ErrorCode code, char const*) -> void {
+        .Do([&](ErrorCode code, std::string_view) -> void {
           ASSERT_EQ(code, TRI_ERROR_QUERY_FUNCTION_ARGUMENT_NUMBER_MISMATCH);
         });
     containers::SmallVector<AqlValue, 4> params = {
@@ -769,7 +769,7 @@ TEST(GeoInRangeTest, test) {
 
   {
     fakeit::When(Method(expressionContextMock, registerWarning))
-        .Do([&](ErrorCode code, char const*) -> void {
+        .Do([&](ErrorCode code, std::string_view) -> void {
           ASSERT_EQ(code, TRI_ERROR_QUERY_FUNCTION_ARGUMENT_NUMBER_MISMATCH);
         });
 
@@ -791,7 +791,7 @@ TEST(GeoInRangeTest, test) {
 
   {
     fakeit::When(Method(expressionContextMock, registerWarning))
-        .Do([&](ErrorCode code, char const*) -> void {
+        .Do([&](ErrorCode code, std::string_view) -> void {
           ASSERT_EQ(code, TRI_ERROR_QUERY_FUNCTION_ARGUMENT_NUMBER_MISMATCH);
         });
 
@@ -1128,7 +1128,7 @@ TEST(GeoInRangeTest, test) {
 
   {
     fakeit::When(Method(expressionContextMock, registerWarning))
-        .Do([&](ErrorCode code, char const*) -> void {
+        .Do([&](ErrorCode code, std::string_view) -> void {
           ASSERT_EQ(code, TRI_ERROR_QUERY_FUNCTION_ARGUMENT_NUMBER_MISMATCH);
         });
 
@@ -1156,7 +1156,7 @@ TEST(GeoInRangeTest, test) {
 
   {
     fakeit::When(Method(expressionContextMock, registerWarning))
-        .Do([&](ErrorCode code, char const*) -> void {
+        .Do([&](ErrorCode code, std::string_view) -> void {
           ASSERT_EQ(code, TRI_ERROR_BAD_PARAMETER);
         });
 
@@ -1187,7 +1187,7 @@ TEST(GeoInRangeTest, test) {
 
   {
     fakeit::When(Method(expressionContextMock, registerWarning))
-        .Do([&](ErrorCode code, char const*) -> void {
+        .Do([&](ErrorCode code, std::string_view) -> void {
           ASSERT_EQ(code, TRI_ERROR_BAD_PARAMETER);
         });
 
@@ -1214,7 +1214,7 @@ TEST(GeoInRangeTest, test) {
 
   {
     fakeit::When(Method(expressionContextMock, registerWarning))
-        .Do([&](ErrorCode code, char const*) -> void {
+        .Do([&](ErrorCode code, std::string_view) -> void {
           ASSERT_EQ(code, TRI_ERROR_BAD_PARAMETER);
         });
 
@@ -1245,7 +1245,7 @@ TEST(GeoInRangeTest, test) {
 
   {
     fakeit::When(Method(expressionContextMock, registerWarning))
-        .Do([&](ErrorCode code, char const*) -> void {
+        .Do([&](ErrorCode code, std::string_view) -> void {
           ASSERT_EQ(code, TRI_ERROR_BAD_PARAMETER);
         });
 
@@ -1272,7 +1272,7 @@ TEST(GeoInRangeTest, test) {
 
   {
     fakeit::When(Method(expressionContextMock, registerWarning))
-        .Do([&](ErrorCode code, char const*) -> void {
+        .Do([&](ErrorCode code, std::string_view) -> void {
           ASSERT_EQ(code, TRI_ERROR_BAD_PARAMETER);
         });
 
@@ -1299,7 +1299,7 @@ TEST(GeoInRangeTest, test) {
 
   {
     fakeit::When(Method(expressionContextMock, registerWarning))
-        .Do([&](ErrorCode code, char const*) -> void {
+        .Do([&](ErrorCode code, std::string_view) -> void {
           ASSERT_EQ(code, TRI_ERROR_BAD_PARAMETER);
         });
 
@@ -1326,7 +1326,7 @@ TEST(GeoInRangeTest, test) {
 
   {
     fakeit::When(Method(expressionContextMock, registerWarning))
-        .Do([&](ErrorCode code, char const*) -> void {
+        .Do([&](ErrorCode code, std::string_view) -> void {
           ASSERT_EQ(code, TRI_ERROR_BAD_PARAMETER);
         });
 
@@ -1353,7 +1353,7 @@ TEST(GeoInRangeTest, test) {
 
   {
     fakeit::When(Method(expressionContextMock, registerWarning))
-        .Do([&](ErrorCode code, char const*) -> void {
+        .Do([&](ErrorCode code, std::string_view) -> void {
           ASSERT_EQ(code, TRI_ERROR_BAD_PARAMETER);
         });
 


### PR DESCRIPTION
### Scope & Purpose

Enterprise companion PR: https://github.com/arangodb/enterprise/pull/1060
Adjust internal APIs for reporting query warnings/errors from C-style pointer/length values to std::string_view.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [x] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: -
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -

#### Related Information

- [ ] Docs PR: 
- [x] Enterprise PR: https://github.com/arangodb/enterprise/pull/1060
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 