### PR TITLE
remove special handling for is-wsl node module (#17054)

### DIFF
--- a/cmake/InstallArangoDBJSClient.cmake
+++ b/cmake/InstallArangoDBJSClient.cmake
@@ -31,15 +31,17 @@ if (USE_ENTERPRISE)
   )
 endif ()
 
-# For the node modules we need all files:
+# For the node modules we need all files except the following:
 install(
   DIRECTORY ${ARANGODB_SOURCE_DIR}/js/node
   DESTINATION ${CMAKE_INSTALL_DATAROOTDIR_ARANGO}/${ARANGODB_JS_VERSION}
+  REGEX "^.*/ansi_up"                                      EXCLUDE
   REGEX "^.*/eslint"                                       EXCLUDE
   REGEX "^.*/node-netstat"                                 EXCLUDE
-  REGEX "^.*/is-wsl"                                       EXCLUDE
-  REGEX "^.*/.npmignore"                                   EXCLUDE
+  REGEX "^.*/parse-prometheus-text-format"                 EXCLUDE
+  REGEX "^.*/@xmldom"                                      EXCLUDE
   REGEX "^.*/.bin"                                         EXCLUDE
+  REGEX "^.*/.npmignore"                                   EXCLUDE
   REGEX "^.*/.*-no-eslint"                                 EXCLUDE
   REGEX "^.*js/node/package.*.json"                        EXCLUDE
 )


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/17054

* Remove special handling for `is-wsl` node module during packaging. There is no `is-wsl` module directly underneath `js/node/node_modules`. There is only one in `js/node/node_modules/node-netstat/node_modules/is-wsl`, but `node-netstat` is already excluded from packaging.
* Also exclude `parse-prometheus-text-format` from packaging, as it is only used from the UI and for testing.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [x] Backports
  - [x] Backport for 3.10: this PR
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 