### PR TITLE
improve test execution performance by limiting amount of startvertices

### DIFF
--- a/js/server/modules/@arangodb/testutils/aql-graph-traversal-generic-tests.js
+++ b/js/server/modules/@arangodb/testutils/aql-graph-traversal-generic-tests.js
@@ -2596,7 +2596,7 @@ const executeParallelQuery = (makeQuery, expectedTotalNumberOfNodes = -1) => {
   // We are using 10.000 start nodes here, to give all worker threads something to work on.
   // The input will most likely be split into batches of 1000 nodes each (implementation detail)
   // so with the above batch-size there should be enough work to distribute on 4 threads.
-  const numberOfStartNodes = 10000;
+  const numberOfStartNodes = 1100;
 
   const query = makeQuery(true, numberOfStartNodes);
   const nonParallelQuery = makeQuery(false, numberOfStartNodes);


### PR DESCRIPTION
### Scope & Purpose

Improve test execution performance by reducing amount of start nodes our parallelExecution test framework.

- [x] :fire: Performance improvement

### Checklist

- [x] Backports
  - [x] Backport for 3.10: *https://github.com/arangodb/arangodb/pull/17245

