### PR TITLE
fix a potential nullptr dereference in revision tree fetching

### DIFF
--- a/arangod/RocksDBEngine/RocksDBRestReplicationHandler.cpp
+++ b/arangod/RocksDBEngine/RocksDBRestReplicationHandler.cpp
@@ -899,11 +899,11 @@ void RocksDBRestReplicationHandler::handleCommandRevisionTree() {
       // See if we can get the revision tree from the context:
       tree = c->getPrefetchedRevisionTree(collectionGuid);
       // This might return a nullptr!
-    }
-    if (tree == nullptr) {  // Still not there, try to get it directly:
-      tree = ctx.collection->getPhysical()->revisionTree(c->snapshotTick());
-    }
-    if (c != nullptr) {
+
+      if (tree == nullptr) {  // Still not there, try to get it directly:
+        tree = ctx.collection->getPhysical()->revisionTree(c->snapshotTick());
+      }
+
       c->removeBlocker(_request->databaseName(), collectionGuid);
     }
   }


### PR DESCRIPTION
### Scope & Purpose

Fix a potential nullptr dereferencing in revision tree prefetching.
The issue was found during testing (https://jenkins01.arangodb.biz/job/arangodb-matrix-pr-linux.aarch64/2895/EDITION=community,STORAGE_ENGINE=rocksdb,TEST_SUITE=cluster,limit=linux&&test&&aarch64/artifact/testfailures.txt):
```
...
#9  0x0000000003a57ba4 in abort () at src/exit/abort.c:11
#10 0x0000000002379f34 in killProcess () at /work/ArangoDB/lib/Basics/CrashHandler.cpp:138
#11 0x000000000237ade0 in crashHandlerSignalHandler () at /work/ArangoDB/lib/Basics/CrashHandler.cpp:518
#12 <signal handler called>
#13 arangodb::Mutex::lock () at /work/ArangoDB/lib/Basics/Mutex.cpp:67
#14 0x0000000000535eb4 in arangodb::basics::MutexLocker<arangodb::Mutex>::lock () at /work/ArangoDB/lib/Basics/MutexLocker.h:110
#15 arangodb::basics::MutexLocker<arangodb::Mutex>::MutexLocker () at /work/ArangoDB/lib/Basics/MutexLocker.h:71
#16 0x00000000018db4a0 in arangodb::RocksDBReplicationContext::snapshotTick () at /work/ArangoDB/arangod/RocksDBEngine/RocksDBReplicationContext.cpp:173
#17 0x0000000001844500 in arangodb::RocksDBRestReplicationHandler::handleCommandRevisionTree () at /work/ArangoDB/arangod/RocksDBEngine/RocksDBRestReplicationHandler.cpp:904
#18 0x000000000191d2a0 in arangodb::RestReplicationHandler::execute () at /work/ArangoDB/arangod/RestHandler/RestReplicationHandler.cpp:444
...
``

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [x] Backports
  - [x] Backport for 3.10: this PR
  - [x] Backport for 3.9: https://github.com/arangodb/arangodb/pull/17019
  - [ ] Backport for 3.8: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

