### PR TITLE
display progress during link recovery

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 v3.10.0 (XXXX-XX-XX)
 --------------------
 
+* Display progress during Arangosearch link and inverted index recovery.
+
 * Fixed SEARCH-374 and SEARCH-358 Fixed a rare case of wrong seek operation in
   the sparse_bitset during query ArangoSearch execution.
 

--- a/arangod/IResearch/IResearchDataStore.cpp
+++ b/arangod/IResearch/IResearchDataStore.cpp
@@ -399,7 +399,7 @@ void CommitTask::operator()() {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
   }
   // run commit ('_asyncSelf' locked by async task)
-  auto [res, timeMs] = linkLock->commitUnsafe(false, &code);
+  auto [res, timeMs] = linkLock->commitUnsafe(false, nullptr, code);
 
   if (res.ok()) {
     LOG_TOPIC("7e323", TRACE, TOPIC)
@@ -715,7 +715,7 @@ Result IResearchDataStore::commit(LinkLock& linkLock, bool wait) {
 
   // must be valid if _asyncSelf->lock() is valid
   CommitResult code = CommitResult::UNDEFINED;
-  auto result = linkLock->commitUnsafe(wait, &code).result;
+  auto result = linkLock->commitUnsafe(wait, nullptr, code).result;
   size_t commitMsec = 0;
   size_t cleanupStep = 0;
   {
@@ -739,9 +739,10 @@ Result IResearchDataStore::commit(LinkLock& linkLock, bool wait) {
 /// @note assumes that '_asyncSelf' is read-locked (for use with async tasks)
 ////////////////////////////////////////////////////////////////////////////////
 IResearchDataStore::UnsafeOpResult IResearchDataStore::commitUnsafe(
-    bool wait, CommitResult* code) {
+    bool wait, irs::index_writer::progress_report_callback const& progress,
+    CommitResult& code) {
   auto begin = std::chrono::steady_clock::now();
-  auto result = commitUnsafeImpl(wait, code);
+  auto result = commitUnsafeImpl(wait, progress, code);
   uint64_t timeMs = std::chrono::duration_cast<std::chrono::milliseconds>(
                         std::chrono::steady_clock::now() - begin)
                         .count();
@@ -771,7 +772,7 @@ IResearchDataStore::UnsafeOpResult IResearchDataStore::commitUnsafe(
 
   if (bool ok = result.ok(); !ok && _numFailedCommits != nullptr) {
     _numFailedCommits->fetch_add(1, std::memory_order_relaxed);
-  } else if (ok && *code == CommitResult::DONE && _avgCommitTimeMs != nullptr) {
+  } else if (ok && code == CommitResult::DONE && _avgCommitTimeMs != nullptr) {
     _avgCommitTimeMs->store(computeAvg(_commitTimeNum, timeMs),
                             std::memory_order_relaxed);
   }
@@ -781,7 +782,9 @@ IResearchDataStore::UnsafeOpResult IResearchDataStore::commitUnsafe(
 ////////////////////////////////////////////////////////////////////////////////
 /// @note assumes that '_asyncSelf' is read-locked (for use with async tasks)
 ////////////////////////////////////////////////////////////////////////////////
-Result IResearchDataStore::commitUnsafeImpl(bool wait, CommitResult* code) {
+Result IResearchDataStore::commitUnsafeImpl(
+    bool wait, irs::index_writer::progress_report_callback const& progress,
+    CommitResult& code) {
   // NOTE: assumes that '_asyncSelf' is read-locked (for use with async tasks)
   TRI_ASSERT(_dataStore);  // must be valid if _asyncSelf->get() is valid
 
@@ -789,7 +792,7 @@ Result IResearchDataStore::commitUnsafeImpl(bool wait, CommitResult* code) {
 
   if (!subscription) {
     // already released
-    *code = CommitResult::NO_CHANGES;
+    code = CommitResult::NO_CHANGES;
     return {};
   }
 
@@ -803,7 +806,7 @@ Result IResearchDataStore::commitUnsafeImpl(bool wait, CommitResult* code) {
             << "commit for arangosearch link '" << id()
             << "' is already in progress, skipping";
 
-        *code = CommitResult::IN_PROGRESS;
+        code = CommitResult::IN_PROGRESS;
         return {};
       }
 
@@ -818,15 +821,15 @@ Result IResearchDataStore::commitUnsafeImpl(bool wait, CommitResult* code) {
 
     try {
       // _lastCommittedTick is being updated in '_before_commit'
-      *code = _dataStore._writer->commit() ? CommitResult::DONE
-                                           : CommitResult::NO_CHANGES;
+      code = _dataStore._writer->commit(progress) ? CommitResult::DONE
+                                                  : CommitResult::NO_CHANGES;
     } catch (...) {
       // restore last committed tick in case of any error
       _lastCommittedTick = lastCommittedTick;
       throw;
     }
 
-    if (CommitResult::NO_CHANGES == *code) {
+    if (CommitResult::NO_CHANGES == code) {
       LOG_TOPIC("7e319", TRACE, iresearch::TOPIC)
           << "no changes registered for arangosearch link '" << id()
           << "' got last operation tick '" << _lastCommittedTick << "'";
@@ -1311,7 +1314,7 @@ Result IResearchDataStore::initDataStore(
         if (outOfSync) {
           // mark link as out of sync
           linkLock->setOutOfSync();
-          // persist "failed" flag in RocksDB. note: if this fails, it will
+          // persist "out of sync" flag in RocksDB. note: if this fails, it will
           // throw an exception and abort the recovery & startup.
           linkLock->_engine->changeCollection(linkLock->collection().vocbase(),
                                               linkLock->collection(), true);
@@ -1323,11 +1326,18 @@ Result IResearchDataStore::initDataStore(
           }
         }
 
+        irs::index_writer::progress_report_callback progress =
+            [id = linkLock->id(), asyncFeature](std::string_view phase,
+                                                size_t current, size_t total) {
+              // forward progress reporting to asyncFeature
+              asyncFeature->reportRecoveryProgress(id, phase, current, total);
+            };
+
         LOG_TOPIC("5b59c", TRACE, iresearch::TOPIC)
             << "starting sync for arangosearch link '" << linkLock->id() << "'";
 
         CommitResult code{CommitResult::UNDEFINED};
-        auto [res, timeMs] = linkLock->commitUnsafe(true, &code);
+        auto [res, timeMs] = linkLock->commitUnsafe(true, progress, code);
 
         LOG_TOPIC("0e0ca", TRACE, iresearch::TOPIC)
             << "finished sync for arangosearch link '" << linkLock->id() << "'";

--- a/arangod/IResearch/IResearchDataStore.h
+++ b/arangod/IResearch/IResearchDataStore.h
@@ -332,7 +332,9 @@ class IResearchDataStore {
   /// @param wait even if other thread is committing
   /// @note assumes that '_asyncSelf' is read-locked (for use with async tasks)
   //////////////////////////////////////////////////////////////////////////////
-  UnsafeOpResult commitUnsafe(bool wait, CommitResult* code);
+  UnsafeOpResult commitUnsafe(
+      bool wait, irs::index_writer::progress_report_callback const& progress,
+      CommitResult& code);
 
   //////////////////////////////////////////////////////////////////////////////
   /// @brief run segment consolidation on the data store
@@ -354,7 +356,9 @@ class IResearchDataStore {
   /// @param wait even if other thread is committing
   /// @note assumes that '_asyncSelf' is read-locked (for use with async tasks)
   //////////////////////////////////////////////////////////////////////////////
-  Result commitUnsafeImpl(bool wait, CommitResult* code);
+  Result commitUnsafeImpl(
+      bool wait, irs::index_writer::progress_report_callback const& progress,
+      CommitResult& code);
 
   //////////////////////////////////////////////////////////////////////////////
   /// @brief run segment consolidation on the data store

--- a/arangod/IResearch/IResearchFeature.cpp
+++ b/arangod/IResearch/IResearchFeature.cpp
@@ -1142,6 +1142,27 @@ void IResearchFeature::unprepare() {
   _running.store(false);
 }
 
+void IResearchFeature::reportRecoveryProgress(arangodb::IndexId id,
+                                              std::string_view phase,
+                                              size_t current, size_t total) {
+  TRI_ASSERT(total != 0);
+  auto now = std::chrono::system_clock::now();
+
+  if (id != _progressState.lastReportId ||
+      now - _progressState.lastReportTime >= std::chrono::minutes(1)) {
+    // report progress only when index/link id changes or one minute has passed
+
+    auto progress = static_cast<size_t>(100.0 * current / total);
+    LOG_TOPIC("d1f18", INFO, TOPIC)
+        << "recovering arangosearch index " << id << ", " << phase
+        << ": operation " << (current + 1) << "/" << total << " (" << progress
+        << "%)...";
+
+    _progressState.lastReportId = id;
+    _progressState.lastReportTime = now;
+  }
+}
+
 bool IResearchFeature::queue(ThreadGroup id,
                              std::chrono::steady_clock::duration delay,
                              std::function<void()>&& fn) {

--- a/arangod/IResearch/IResearchFeature.h
+++ b/arangod/IResearch/IResearchFeature.h
@@ -24,15 +24,18 @@
 
 #pragma once
 
-#include "StorageEngine/StorageEngine.h"
 #include "Metrics/Fwd.h"
 #include "RestServer/arangod.h"
+#include "StorageEngine/StorageEngine.h"
+#include "VocBase/Identifiers/IndexId.h"
 #include "VocBase/voc-types.h"
 
 #include <atomic>
+#include <chrono>
 #include <cstdint>
 #include <memory>
 #include <string>
+#include <string_view>
 #include <vector>
 
 namespace arangodb {
@@ -106,6 +109,12 @@ class IResearchFeature final : public ArangodFeature {
   void validateOptions(std::shared_ptr<options::ProgramOptions>) override;
 
   //////////////////////////////////////////////////////////////////////////////
+  /// @brief report progress during recovery phase
+  //////////////////////////////////////////////////////////////////////////////
+  void reportRecoveryProgress(arangodb::IndexId id, std::string_view phase,
+                              size_t current, size_t total);
+
+  //////////////////////////////////////////////////////////////////////////////
   /// @brief schedule an asynchronous task for execution
   /// @param id thread group to handle the execution
   /// @param fn the function to execute
@@ -165,6 +174,12 @@ class IResearchFeature final : public ArangodFeature {
 
   // helper object, only useful during WAL recovery
   std::shared_ptr<IResearchRocksDBRecoveryHelper> _recoveryHelper;
+
+  // state used for progress reporting only
+  struct ProgressReportState {
+    arangodb::IndexId lastReportId{0};
+    std::chrono::time_point<std::chrono::system_clock> lastReportTime{};
+  } _progressState;
 };
 
 }  // namespace iresearch


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/16994

Displays progress report during arangosearch link recovery, e.g.
```
...
2022-09-05T18:02:00Z [65850] INFO [d1f18] {arangosearch} recovering arangosearch link 4792073 (stage1, operation 1/1 (0%)
2022-09-05T18:03:00Z [65850] INFO [d1f18] {arangosearch} recovering arangosearch link 4792073 (stage3, operation 67/209 (31%)
2022-09-05T18:04:01Z [65850] INFO [d1f18] {arangosearch} recovering arangosearch link 4792073 (stage3, operation 136/209 (64%)
2022-09-05T18:05:01Z [65850] INFO [d1f18] {arangosearch} recovering arangosearch link 4792073 (stage3, operation 208/209 (99%)
2022-09-05T18:05:03Z [65850] INFO [d1f18] {arangosearch} recovering arangosearch link 5507397 (stage1, operation 1/1 (0%)
2022-09-05T18:06:04Z [65850] INFO [d1f18] {arangosearch} recovering arangosearch link 5507397 (stage3, operation 68/209 (32%)
2022-09-05T18:07:05Z [65850] INFO [d1f18] {arangosearch} recovering arangosearch link 5507397 (stage3, operation 137/209 (65%)
2022-09-05T18:08:05Z [65850] INFO [d1f18] {arangosearch} recovering arangosearch link 5507397 (stage3, operation 209/209 (99%)
2022-09-05T18:08:07Z [65850] INFO [d1f18] {arangosearch} recovering arangosearch link 5507407 (stage1, operation 1/1 (0%)
2022-09-05T18:09:07Z [65850] INFO [d1f18] {arangosearch} recovering arangosearch link 5507407 (stage3, operation 63/210 (29%)
2022-09-05T18:10:08Z [65850] INFO [d1f18] {arangosearch} recovering arangosearch link 5507407 (stage3, operation 123/210 (58%)
2022-09-05T18:11:08Z [65850] INFO [d1f18] {arangosearch} recovering arangosearch link 5507407 (stage3, operation 192/210 (90%)
```

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [x] Backports
  - [x] Backport for 3.10: this PR
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
