### PR TITLE
improve summary message of arangoexport

### DIFF
--- a/client-tools/Export/ExportFeature.cpp
+++ b/client-tools/Export/ExportFeature.cpp
@@ -338,10 +338,12 @@ void ExportFeature::start() {
             << std::endl;
 
   uint64_t exportedSize = 0;
+  std::string progressDetails;
 
   if (_typeExport == "json" || _typeExport == "jsonl" || _typeExport == "xml" ||
       _typeExport == "csv") {
     if (_collections.size()) {
+      progressDetails = std::to_string(_collections.size()) + " collection(s)";
       collectionExport(httpClient.get());
 
       for (auto const& collection : _collections) {
@@ -357,6 +359,7 @@ void ExportFeature::start() {
         }
       }
     } else if (!_customQuery.empty()) {
+      progressDetails = "1 query";
       queryExport(httpClient.get());
 
       std::string filePath =
@@ -367,6 +370,7 @@ void ExportFeature::start() {
       exportedSize += TRI_SizeFile(filePath.c_str());
     }
   } else if (_typeExport == "xgmml" && _graphName.size()) {
+    progressDetails = "1 graph";
     graphExport(httpClient.get());
     std::string filePath = _outputDirectory + TRI_DIR_SEPARATOR_STR +
                            _graphName + "." + _typeExport;
@@ -382,7 +386,7 @@ void ExportFeature::start() {
 
   using arangodb::basics::StringUtils::formatSize;
 
-  std::cout << "Processed " << _collections.size() << " collection(s), wrote "
+  std::cout << "Processed " << progressDetails << ", wrote "
             << formatSize(exportedSize) << ", " << _httpRequestsDone
             << " HTTP request(s)" << std::endl;
 


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/17079

Improve summary message of arangoexport
It previously always displayed "Processed 0 collection(s)" even when running a custom query or exporting a graph. this was misleading. it will now display either "Processed x collection(s)", "Processed 1 query" or "Processed 1 graph", depending on the invocation.

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [x] Backports
  - [x] Backport for 3.10: this PR
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 