### PR TITLE
Testframework: Fix handling in crash analysis

### DIFF
--- a/js/client/modules/@arangodb/testutils/crash-utils.js
+++ b/js/client/modules/@arangodb/testutils/crash-utils.js
@@ -575,7 +575,7 @@ function generateCrashDump (binary, instanceInfo, options, checkStr) {
     stats.residentSize < 140000000
   ) || stats.virtualSize === 0;
   if (options.test !== undefined) {
-    print(CYAN + this.name + " - in single test mode, hard killing." + RESET);
+    print(CYAN + instanceInfo.name + " - in single test mode, hard killing." + RESET);
     instanceInfo.exitStatus = killExternal(instanceInfo.pid, termSignal);
   } else if (platform.substr(0, 3) === 'win') {
     if (!options.disableMonitor) {

--- a/js/client/modules/@arangodb/testutils/instance-manager.js
+++ b/js/client/modules/@arangodb/testutils/instance-manager.js
@@ -899,12 +899,13 @@ class instanceManager {
             localTimeout = localTimeout + 60;
           }
           if ((internal.time() - shutdownTime) > localTimeout) {
-            this.dumpAgency();
             print(Date() + ' forcefully terminating ' + yaml.safeDump(arangod.getStructure()) +
                   ' after ' + timeout + 's grace period; marking crashy.');
+            this.dumpAgency();
             arangod.serverCrashedLocal = true;
             shutdownSuccess = false;
             arangod.killWithCoreDump('forced shutdown');
+            crashUtils.aggregateDebugger(arangod, this.options);
             crashed = true;
             if (!arangod.isAgent()) {
               nonAgenciesCount--;

--- a/js/client/modules/@arangodb/testutils/instance-manager.js
+++ b/js/client/modules/@arangodb/testutils/instance-manager.js
@@ -764,8 +764,10 @@ class instanceManager {
       arangod.serverCrashedLocal = true;
     });
     this.arangods.forEach((arangod) => {
-      crashUtils.aggregateDebugger(arangod, this.options);
-      arangod.waitForExitAfterDebugKill();
+      if (arangod.checkArangoAlive()) {
+        crashUtils.aggregateDebugger(arangod, this.options);
+        arangod.waitForExitAfterDebugKill();
+      }
     });
     return true;
   }

--- a/js/client/modules/@arangodb/testutils/instance.js
+++ b/js/client/modules/@arangodb/testutils/instance.js
@@ -705,6 +705,10 @@ class instance {
     // testing.js sapwned-PID-monitoring adjusted.
     print("waiting for exit - " + this.pid);
     try {
+      let ret = statusExternal(this.pid, false);
+      // OK, something has gone wrong, process still alive. anounce and force kill:
+      print(RED+`was expecting the process ${this.pid} to be gone, but ${JSON.stringify(ret)}` + RESET);
+      killExternal(this.pid, abortSignal);
       print(statusExternal(this.pid, true));
     } catch(ex) {
       print(ex);


### PR DESCRIPTION
### Scope & Purpose

- we would show errnous process flow when the arangod died in advance.
  This patch detects it, and avoids the situation alltogether. 
- properly print the instance name in information message
- aggregate the debugger processes when we shutdown-deadline-kill an arangod
- if the debugger is unable to terminate the process, we must not hand, but hard kill the process on our own.

- [x] :hankey: Bugfix
- [x]  backport 3.10: https://github.com/arangodb/arangodb/pull/17087
