### PR TITLE
Add embedFields support for inspector

### DIFF
--- a/lib/Inspection/InspectorBase.h
+++ b/lib/Inspection/InspectorBase.h
@@ -26,7 +26,9 @@
 #include <array>
 #include <cstddef>
 #include <functional>
+#include <memory>
 #include <string_view>
+#include <tuple>
 #include <type_traits>
 #include <variant>
 
@@ -34,6 +36,7 @@
 
 #include "Inspection/Access.h"
 #include "Inspection/Types.h"
+#include "Inspection/detail/Fields.h"
 
 namespace arangodb::inspection {
 
@@ -65,7 +68,7 @@ struct EMPTY_BASE ContextContainer<NoContext> {
 };
 }  // namespace detail
 
-template<class Derived, class Context>
+template<class Derived, class Context, class TargetInspector = Derived>
 struct InspectorBase : detail::ContextContainer<Context> {
  protected:
   template<class T>
@@ -74,18 +77,35 @@ struct InspectorBase : detail::ContextContainer<Context> {
   template<class... Ts>
   struct Variant;
 
-  template<typename T>
-  struct RawField;
-
-  struct IgnoreField;
-
-  struct Keep {};
-
   // TODO - support virtual fields with getter/setter
   // template<typename T>
   // struct VirtualField : BasicField<VirtualField<T>> {
   //   using value_type = T;
   // };
+
+  using Keep = detail::Keep;
+
+  using IgnoreField = detail::IgnoreField;
+
+  template<class T>
+  using RawField = detail::RawField<TargetInspector, T>;
+
+  template<class InnerField, class Transformer>
+  using TransformField =
+      detail::TransformField<TargetInspector, InnerField, Transformer>;
+
+  template<class InnerField, class FallbackValue>
+  using FallbackField =
+      detail::FallbackField<TargetInspector, InnerField, FallbackValue>;
+
+  template<class InnerField, class FallbackFactory>
+  using FallbackFactoryField =
+      detail::FallbackFactoryField<TargetInspector, InnerField,
+                                   FallbackFactory>;
+
+  template<class InnerField, class Invariant>
+  using InvariantField =
+      detail::InvariantField<TargetInspector, InnerField, Invariant>;
 
  public:
   InspectorBase() = default;
@@ -124,42 +144,19 @@ struct InspectorBase : detail::ContextContainer<Context> {
     return RawField<T>{{name}, value};
   }
 
+  template<class T>
+  [[nodiscard]] auto embedFields(T& value) const;
+
   [[nodiscard]] IgnoreField ignoreField(std::string_view name) const noexcept {
     return IgnoreField{name};
   }
 
  protected:
-  template<class InnerField, class Transformer>
-  struct TransformField;
-
-  template<class InnerField, class FallbackValue>
-  struct FallbackField;
-
-  template<class InnerField, class FallbackFactory>
-  struct FallbackFactoryField;
-
   Derived& self() { return static_cast<Derived&>(*this); }
 
   template<class T>
-  struct IsRawField : std::false_type {};
-  template<class T>
-  struct IsRawField<RawField<T>> : std::true_type {};
-
-  template<class T>
-  struct IsTransformField : std::false_type {};
-  template<class T, class U>
-  struct IsTransformField<TransformField<T, U>> : std::true_type {};
-
-  template<class T>
-  struct IsFallbackField : std::false_type {};
-  template<class T, class U>
-  struct IsFallbackField<FallbackField<T, U>> : std::true_type {};
-  template<class T, class Fn>
-  struct IsFallbackField<FallbackFactoryField<T, Fn>> : std::true_type {};
-
-  template<class T>
   static std::string_view getFieldName(T& field) noexcept {
-    if constexpr (IsRawField<std::remove_cvref_t<T>>::value ||
+    if constexpr (detail::IsRawField<std::remove_cvref_t<T>>::value ||
                   std::is_same_v<IgnoreField, std::remove_cvref_t<T>>) {
       return field.name;
     } else {
@@ -169,7 +166,7 @@ struct InspectorBase : detail::ContextContainer<Context> {
 
   template<class T>
   static auto& getFieldValue(T& field) noexcept {
-    if constexpr (IsRawField<std::remove_cvref_t<T>>::value) {
+    if constexpr (detail::IsRawField<std::remove_cvref_t<T>>::value) {
       return field.value;
     } else {
       return getFieldValue(field.inner);
@@ -179,9 +176,9 @@ struct InspectorBase : detail::ContextContainer<Context> {
   template<class T>
   static decltype(auto) getFallbackField(T& field) noexcept {
     using TT = std::remove_cvref_t<T>;
-    if constexpr (IsFallbackField<TT>::value) {
+    if constexpr (detail::IsFallbackField<TT>::value) {
       return field;
-    } else if constexpr (!IsRawField<TT>::value) {
+    } else if constexpr (!detail::IsRawField<TT>::value) {
       return getFallbackField(field.inner);
     }
   }
@@ -189,171 +186,15 @@ struct InspectorBase : detail::ContextContainer<Context> {
   template<class T>
   static decltype(auto) getTransformer(T& field) noexcept {
     using TT = std::remove_cvref_t<T>;
-    if constexpr (IsTransformField<TT>::value) {
+    if constexpr (detail::IsTransformField<TT>::value) {
       auto& result = field.transformer;  // We want to return a reference!
       return result;
-    } else if constexpr (!IsRawField<TT>::value) {
+    } else if constexpr (!detail::IsRawField<TT>::value) {
       return getTransformer(field.inner);
     }
   }
 
- private:
-  template<class Field>
-  struct EMPTY_BASE InvariantMixin {
-    template<class Predicate>
-    [[nodiscard]] auto invariant(Predicate predicate) && {
-      return InvariantField<Field, Predicate>(
-          std::move(static_cast<Field&>(*this)), std::move(predicate));
-    }
-  };
-
-  template<class Field, class = void>
-  struct HasInvariantMethod : std::false_type {};
-
-  struct AlwaysTrue {
-    template<class... Ts>
-    [[nodiscard]] constexpr bool operator()(Ts&&...) const noexcept {
-      return true;
-    }
-  };
-
-  template<class Field>
-  struct HasInvariantMethod<
-      Field,
-      std::void_t<decltype(std::declval<Field>().invariant(AlwaysTrue{}))>>
-      : std::true_type {};
-
-  template<class Inner>
-  using WithInvariant =
-      std::conditional_t<HasInvariantMethod<Inner>::value, std::monostate,
-                         InvariantMixin<Inner>>;
-
-  template<class Field>
-  struct EMPTY_BASE FallbackMixin {
-    template<class U>
-    [[nodiscard]] auto fallback(U&& val) && {
-      static_assert(std::is_constructible_v<typename Field::value_type, U> ||
-                    std::is_same_v<Keep, U>);
-
-      return FallbackField<Field, U>(std::move(static_cast<Field&>(*this)),
-                                     std::forward<U>(val));
-    }
-
-    template<class Fn>
-    [[nodiscard]] auto fallbackFactory(Fn&& fn) && {
-      static_assert(std::is_constructible_v<typename Field::value_type,
-                                            std::invoke_result_t<Fn>>);
-
-      return FallbackFactoryField<Field, Fn>(
-          std::move(static_cast<Field&>(*this)), std::forward<Fn>(fn));
-    }
-  };
-
-  template<class Field, class = void>
-  struct HasFallbackMethod : std::false_type {};
-
-  template<class Field>
-  struct HasFallbackMethod<Field,
-                           std::void_t<decltype(std::declval<Field>().fallback(
-                               std::declval<typename Field::value_type>()))>>
-      : std::true_type {};
-
-  template<class Inner>
-  using WithFallback = std::conditional_t<HasFallbackMethod<Inner>::value,
-                                          std::monostate, FallbackMixin<Inner>>;
-
-  template<class Field>
-  struct EMPTY_BASE TransformMixin {
-    template<class T>
-    [[nodiscard]] auto transformWith(T transformer) && {
-      return TransformField<Field, T>(std::move(static_cast<Field&>(*this)),
-                                      std::move(transformer));
-    }
-  };
-
-  template<class Field, class = void>
-  struct HasTransformMethod : std::false_type {};
-
-  template<class Field>
-  struct HasTransformMethod<
-      Field, std::void_t<decltype(std::declval<Field>().transformWith)>>
-      : std::true_type {};
-
-  template<class Inner>
-  using WithTransform =
-      std::conditional_t<HasTransformMethod<Inner>::value, std::monostate,
-                         TransformMixin<Inner>>;
-
  protected:
-  template<class InnerField, class FallbackValue>
-  struct EMPTY_BASE FallbackField
-      : Derived::template FallbackContainer<FallbackValue>,
-        WithInvariant<FallbackField<InnerField, FallbackValue>>,
-        WithTransform<FallbackField<InnerField, FallbackValue>> {
-    FallbackField(InnerField inner, FallbackValue&& val)
-        : Derived::template FallbackContainer<FallbackValue>(std::move(val)),
-          inner(std::move(inner)) {}
-    using value_type = typename InnerField::value_type;
-    InnerField inner;
-  };
-
-  template<class InnerField, class FallbackFactory>
-  struct EMPTY_BASE FallbackFactoryField
-      : Derived::template FallbackFactoryContainer<FallbackFactory>,
-        WithInvariant<FallbackFactoryField<InnerField, FallbackFactory>>,
-        WithTransform<FallbackFactoryField<InnerField, FallbackFactory>> {
-    FallbackFactoryField(InnerField inner, FallbackFactory&& fn)
-        : Derived::template FallbackFactoryContainer<FallbackFactory>(
-              std::move(fn)),
-          inner(std::move(inner)) {}
-    using value_type = typename InnerField::value_type;
-    InnerField inner;
-  };
-
-  template<class InnerField, class Invariant>
-  struct EMPTY_BASE InvariantField
-      : Derived::template InvariantContainer<Invariant>,
-        WithFallback<InvariantField<InnerField, Invariant>>,
-        WithTransform<InvariantField<InnerField, Invariant>> {
-    InvariantField(InnerField inner, Invariant&& invariant)
-        : Derived::template InvariantContainer<Invariant>(std::move(invariant)),
-          inner(std::move(inner)) {}
-    using value_type = typename InnerField::value_type;
-    InnerField inner;
-  };
-
-  template<class InnerField, class Transformer>
-  struct EMPTY_BASE TransformField
-      : WithInvariant<TransformField<InnerField, Transformer>>,
-        WithFallback<TransformField<InnerField, Transformer>> {
-    TransformField(InnerField inner, Transformer&& transformer)
-        : inner(std::move(inner)), transformer(std::move(transformer)) {}
-    using value_type = typename InnerField::value_type;
-    InnerField inner;
-    Transformer transformer;
-  };
-
-  template<typename DerivedField>
-  struct EMPTY_BASE BasicField : InvariantMixin<DerivedField>,
-                                 FallbackMixin<DerivedField>,
-                                 TransformMixin<DerivedField> {
-    explicit BasicField(std::string_view name) : name(name) {}
-    std::string_view name;
-  };
-
-  template<typename T>
-  struct EMPTY_BASE RawField : BasicField<RawField<T>> {
-    RawField(std::string_view name, T& value)
-        : BasicField<RawField>(name), value(value) {}
-    using value_type = T;
-    T& value;
-  };
-
-  struct IgnoreField {
-    explicit IgnoreField(std::string_view name) : name(name) {}
-    std::string_view name;
-  };
-
   template<class T>
   struct FieldsResult {
     template<class Invariant>
@@ -473,6 +314,110 @@ struct InspectorBase : detail::ContextContainer<Context> {
     }
   }
 };
+
+namespace detail {
+
+template<class Inspector>
+struct Fields {
+  virtual ~Fields() = default;
+  virtual Status apply(Inspector&) = 0;
+};
+
+template<class Inspector, class... Ts>
+struct EmbeddedFields : Fields<Inspector> {
+  template<class... Args>
+  explicit EmbeddedFields(Args&&... args)
+      : fields(std::forward<Args>(args)...) {}
+
+  Status apply(Inspector& inspector) override {
+    return [&inspector, this]<std::size_t... I>(std::index_sequence<I...>) {
+      return inspector.applyFields(std::get<I>(fields)...);
+    }
+    (std::make_index_sequence<sizeof...(Ts)>{});
+  }
+  std::tuple<Ts...> fields;
+};
+
+template<class Parent>
+struct EmbeddedFieldInspector
+    : InspectorBase<EmbeddedFieldInspector<Parent>, Parent> {
+  using Base = InspectorBase<EmbeddedFieldInspector<Parent>, Parent>;
+
+  static constexpr bool isLoading = Parent::isLoading;
+
+  [[nodiscard]] Status::Success beginObject() { return {}; }
+
+  [[nodiscard]] Status::Success endObject() { return {}; }
+
+  template<class T>
+  auto value(T&) {
+    return fail();
+  }
+
+  auto beginArray() { return fail(); }
+
+  auto endArray() { return fail(); }
+
+  template<class T>
+  auto list(T& list) {
+    return fail();
+  }
+
+  template<class T>
+  auto map(T& map) {
+    return fail();
+  }
+
+  template<class T>
+  auto tuple(T& data) {
+    return fail();
+  }
+
+  template<class U>
+  using FallbackContainer = typename Parent::template FallbackContainer<U>;
+  template<class Func>
+  using InvariantContainer = typename Parent::template InvariantContainer<Func>;
+
+  template<class... Args>
+  Status applyFields(Args&&... args) {
+    fields = std::make_unique<EmbeddedFields<Parent, Args...>>(
+        std::forward<Args>(args)...);
+    return {};
+  }
+
+  template<class... Ts, class... Args>
+  auto processVariant(
+      typename Base::template UnqualifiedVariant<Ts...>& variant,
+      Args&&... args) {
+    return fail();
+  }
+
+  template<class... Ts, class... Args>
+  auto processVariant(typename Base::template QualifiedVariant<Ts...>& variant,
+                      Args&&... args) {
+    return fail();
+  }
+
+  std::unique_ptr<Fields<Parent>> fields;
+
+ private:
+  template<bool Fail = true>
+  Status::Success fail() {
+    static_assert(!Fail, "embedFields can only be used for objects");
+    return {};
+  }
+};
+
+}  // namespace detail
+
+template<class Derived, class TargetInspector>
+template<class T>
+auto InspectorBase<Derived, TargetInspector>::embedFields(T& value) const {
+  detail::EmbeddedFieldInspector<Derived> insp;
+  auto res = insp.apply(value);
+  TRI_ASSERT(res.ok());
+  return std::move(insp.fields);
+}
 
 #undef EMPTY_BASE
 

--- a/lib/Inspection/VPackLoadInspector.h
+++ b/lib/Inspection/VPackLoadInspector.h
@@ -329,6 +329,8 @@ struct VPackLoadInspectorImpl
   friend struct detail::EmbeddedFieldsImpl;
   template<class, class, class>
   friend struct detail::EmbeddedFieldsWithObjectInvariant;
+  template<class, class>
+  friend struct detail::EmbeddedFieldInspector;
 
   using FieldsMap =
       std::unordered_map<std::string_view, std::pair<velocypack::Slice, bool>>;

--- a/lib/Inspection/VPackLoadInspector.h
+++ b/lib/Inspection/VPackLoadInspector.h
@@ -445,7 +445,7 @@ struct VPackLoadInspectorImpl
 
   template<class T>
   auto checkInvariant(T& field) {
-    if constexpr (!Base::template IsRawField<std::remove_cvref_t<T>>::value) {
+    if constexpr (!detail::IsRawField<std::remove_cvref_t<T>>::value) {
       return checkInvariant(field.inner);
     } else {
       return Status::Success{};

--- a/lib/Inspection/VPackSaveInspector.h
+++ b/lib/Inspection/VPackSaveInspector.h
@@ -134,14 +134,6 @@ struct VPackSaveInspector
 
   auto applyFields() { return Status::Success{}; }
 
-  template<class... Args>
-  auto applyFields(
-      std::unique_ptr<detail::EmbeddedFields<VPackSaveInspector>>&& fields,
-      Args&&... args) {
-    EmbeddedParam param;
-    return fields->apply(*this, param);
-  }
-
   template<class Arg, class... Args>
   auto applyFields(Arg&& arg, Args&&... args) {
     auto res = applyField(std::forward<Arg>(arg));
@@ -211,12 +203,21 @@ struct VPackSaveInspector
   friend struct detail::EmbeddedFieldsImpl;
   template<class, class, class>
   friend struct detail::EmbeddedFieldsWithObjectInvariant;
+  template<class, class>
+  friend struct detail::EmbeddedFieldInspector;
 
   using EmbeddedParam = std::monostate;
 
   template<class... Args>
   auto processEmbeddedFields(EmbeddedParam&, Args&&... args) {
     return applyFields(std::forward<Args>(args)...);
+  }
+
+  [[nodiscard]] auto applyField(
+      std::unique_ptr<detail::EmbeddedFields<VPackSaveInspector>> const&
+          fields) {
+    EmbeddedParam param;
+    return fields->apply(*this, param);
   }
 
   template<class T>

--- a/lib/Inspection/VPackSaveInspector.h
+++ b/lib/Inspection/VPackSaveInspector.h
@@ -137,8 +137,8 @@ struct VPackSaveInspector
   template<class... Args>
   auto applyFields(std::unique_ptr<detail::Fields<VPackSaveInspector>>&& fields,
                    Args&&... args) {
-    // TODO
-    return fields->apply(*this);
+    EmbeddedParam param;
+    return fields->apply(*this, param);
   }
 
   template<class Arg, class... Args>
@@ -199,6 +199,18 @@ struct VPackSaveInspector
   };
 
  private:
+  template<class>
+  friend struct detail::Fields;
+  template<class, class...>
+  friend struct detail::EmbeddedFields;
+
+  using EmbeddedParam = std::monostate;
+
+  template<class... Args>
+  auto processEmbeddedFields(EmbeddedParam&, Args&&... args) {
+    return applyFields(std::forward<Args>(args)...);
+  }
+
   template<class T>
   [[nodiscard]] auto applyField(T const& field) {
     if constexpr (std::is_same_v<typename Base::IgnoreField, T>) {

--- a/lib/Inspection/VPackSaveInspector.h
+++ b/lib/Inspection/VPackSaveInspector.h
@@ -24,6 +24,7 @@
 
 #pragma once
 
+#include <memory>
 #include <optional>
 #include <string_view>
 #include <tuple>
@@ -132,6 +133,13 @@ struct VPackSaveInspector
   }
 
   auto applyFields() { return Status::Success{}; }
+
+  template<class... Args>
+  auto applyFields(std::unique_ptr<detail::Fields<VPackSaveInspector>>&& fields,
+                   Args&&... args) {
+    // TODO
+    return fields->apply(*this);
+  }
 
   template<class Arg, class... Args>
   auto applyFields(Arg&& arg, Args&&... args) {

--- a/lib/Inspection/VPackSaveInspector.h
+++ b/lib/Inspection/VPackSaveInspector.h
@@ -135,8 +135,9 @@ struct VPackSaveInspector
   auto applyFields() { return Status::Success{}; }
 
   template<class... Args>
-  auto applyFields(std::unique_ptr<detail::Fields<VPackSaveInspector>>&& fields,
-                   Args&&... args) {
+  auto applyFields(
+      std::unique_ptr<detail::EmbeddedFields<VPackSaveInspector>>&& fields,
+      Args&&... args) {
     EmbeddedParam param;
     return fields->apply(*this, param);
   }
@@ -198,11 +199,18 @@ struct VPackSaveInspector
     explicit InvariantContainer(Fn&&) {}
   };
 
+  template<class Fn, class T>
+  Status objectInvariant(T& object, Fn&&, Status result) {
+    return result;
+  }
+
  private:
   template<class>
-  friend struct detail::Fields;
-  template<class, class...>
   friend struct detail::EmbeddedFields;
+  template<class, class...>
+  friend struct detail::EmbeddedFieldsImpl;
+  template<class, class, class>
+  friend struct detail::EmbeddedFieldsWithObjectInvariant;
 
   using EmbeddedParam = std::monostate;
 

--- a/lib/Inspection/ValidateInspector.h
+++ b/lib/Inspection/ValidateInspector.h
@@ -153,7 +153,7 @@ struct ValidateInspector : InspectorBase<ValidateInspector<Context>, Context> {
 
   template<class T>
   auto checkInvariant(T& field) {
-    if constexpr (!Base::template IsRawField<std::remove_cvref_t<T>>::value) {
+    if constexpr (!detail::IsRawField<std::remove_cvref_t<T>>::value) {
       return checkInvariant(field.inner);
     } else {
       return Status::Success{};

--- a/lib/Inspection/ValidateInspector.h
+++ b/lib/Inspection/ValidateInspector.h
@@ -92,9 +92,6 @@ struct ValidateInspector : InspectorBase<ValidateInspector<Context>, Context> {
     explicit InvariantContainer(Invariant&& invariant)
         : invariantFunc(std::move(invariant)) {}
     Invariant invariantFunc;
-
-    static constexpr const char InvariantFailedError[] =
-        "Field invariant failed";
   };
 
   template<class... Args>
@@ -114,6 +111,16 @@ struct ValidateInspector : InspectorBase<ValidateInspector<Context>, Context> {
       typename Base::template QualifiedVariant<Ts...>& variant,
       Args&&... args) {
     return {};
+  }
+
+  template<class Invariant, class T>
+  Status objectInvariant(T& object, Invariant&& func, Status result) {
+    if (result.ok()) {
+      result =
+          Base::template checkInvariant<detail::ObjectInvariantFailedError>(
+              std::forward<Invariant>(func), object);
+    }
+    return result;
   }
 
  protected:
@@ -147,7 +154,7 @@ struct ValidateInspector : InspectorBase<ValidateInspector<Context>, Context> {
   template<class T, class U>
   Status checkInvariant(typename Base::template InvariantField<T, U>& field) {
     using Field = typename Base::template InvariantField<T, U>;
-    return Base::template checkInvariant<Field, Field::InvariantFailedError>(
+    return Base::template checkInvariant<detail::FieldInvariantFailedError>(
         field.invariantFunc, Base::getFieldValue(field));
   }
 

--- a/lib/Inspection/detail/Fields.h
+++ b/lib/Inspection/detail/Fields.h
@@ -259,7 +259,7 @@ struct EmbeddedFieldsImpl : EmbeddedFields<Inspector> {
   Status apply(Inspector& inspector,
                typename Inspector::EmbeddedParam& param) override {
     return [&inspector, &param, this]<std::size_t... I>(std::index_sequence<I...>) {
-      return inspector.processEmbeddedFields(param, std::get<I>(fields)...);
+      return inspector.processEmbeddedFields(param, std::get<I>(std::move(fields))...);
     }(std::make_index_sequence<sizeof...(Ts)>{});
   }
 

--- a/lib/Inspection/detail/Fields.h
+++ b/lib/Inspection/detail/Fields.h
@@ -1,0 +1,240 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2022 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Manuel Pöter
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include <string_view>
+#include <type_traits>
+#include <utility>
+#include <variant>
+
+namespace arangodb::inspection::detail {
+
+#ifdef _MSC_VER
+#define EMPTY_BASE __declspec(empty_bases)
+#else
+#define EMPTY_BASE
+#endif
+
+struct Keep {};
+
+struct IgnoreField;
+
+template<class Inspector, class T>
+struct RawField;
+
+template<class Inspector, class InnerField, class Transformer>
+struct TransformField;
+
+template<class Inspector, class InnerField, class FallbackValue>
+struct FallbackField;
+
+template<class Inspector, class InnerField, class FallbackFactory>
+struct FallbackFactoryField;
+
+template<class Inspector, class InnerField, class Invariant>
+struct InvariantField;
+
+template<class Inspector, class Field>
+struct EMPTY_BASE InvariantMixin {
+  template<class Predicate>
+  [[nodiscard]] auto invariant(Predicate predicate) && {
+    return InvariantField<Inspector, Field, Predicate>(
+        std::move(static_cast<Field&>(*this)), std::move(predicate));
+  }
+};
+
+template<class Inspector, class Field>
+struct EMPTY_BASE FallbackMixin {
+  template<class U>
+  [[nodiscard]] auto fallback(U&& val) && {
+    static_assert(std::is_constructible_v<typename Field::value_type, U> ||
+                  std::is_same_v<Keep, U>);
+
+    return FallbackField<Inspector, Field, U>(
+        std::move(static_cast<Field&>(*this)), std::forward<U>(val));
+  }
+
+  template<class Fn>
+  [[nodiscard]] auto fallbackFactory(Fn&& fn) && {
+    static_assert(std::is_constructible_v<typename Field::value_type,
+                                          std::invoke_result_t<Fn>>);
+
+    return FallbackFactoryField<Inspector, Field, Fn>(
+        std::move(static_cast<Field&>(*this)), std::forward<Fn>(fn));
+  }
+};
+
+template<class Inspector, class Field>
+struct EMPTY_BASE TransformMixin {
+  template<class T>
+  [[nodiscard]] auto transformWith(T transformer) && {
+    return TransformField<Inspector, Field, T>(
+        std::move(static_cast<Field&>(*this)), std::move(transformer));
+  }
+};
+
+template<class Field, class = void>
+struct HasInvariantMethod : std::false_type {};
+
+struct AlwaysTrue {
+  template<class... Ts>
+  [[nodiscard]] constexpr bool operator()(Ts&&...) const noexcept {
+    return true;
+  }
+};
+
+template<class Field>
+struct HasInvariantMethod<
+    Field, std::void_t<decltype(std::declval<Field>().invariant(AlwaysTrue{}))>>
+    : std::true_type {};
+
+template<class Inspector, class Inner>
+using WithInvariant =
+    std::conditional_t<HasInvariantMethod<Inner>::value, std::monostate,
+                       InvariantMixin<Inspector, Inner>>;
+
+template<class Field, class = void>
+struct HasFallbackMethod : std::false_type {};
+
+template<class Field>
+struct HasFallbackMethod<Field,
+                         std::void_t<decltype(std::declval<Field>().fallback(
+                             std::declval<typename Field::value_type>()))>>
+    : std::true_type {};
+
+template<class Inspector, class Inner>
+using WithFallback =
+    std::conditional_t<HasFallbackMethod<Inner>::value, std::monostate,
+                       FallbackMixin<Inspector, Inner>>;
+
+template<class Field, class = void>
+struct HasTransformMethod : std::false_type {};
+
+template<class Field>
+struct HasTransformMethod<
+    Field, std::void_t<decltype(std::declval<Field>().transformWith)>>
+    : std::true_type {};
+
+template<class Inspector, class Inner>
+using WithTransform =
+    std::conditional_t<HasTransformMethod<Inner>::value, std::monostate,
+                       TransformMixin<Inspector, Inner>>;
+
+template<class Inspector, typename DerivedField>
+struct EMPTY_BASE BasicField : InvariantMixin<Inspector, DerivedField>,
+                               FallbackMixin<Inspector, DerivedField>,
+                               TransformMixin<Inspector, DerivedField> {
+  explicit BasicField(std::string_view name) : name(name) {}
+  std::string_view name;
+};
+
+template<class Inspector, typename T>
+struct EMPTY_BASE RawField : BasicField<Inspector, RawField<Inspector, T>> {
+  RawField(std::string_view name, T& value)
+      : BasicField<Inspector, RawField>(name), value(value) {}
+  using value_type = T;
+  T& value;
+};
+
+struct IgnoreField {
+  explicit IgnoreField(std::string_view name) : name(name) {}
+  std::string_view name;
+};
+
+template<class Inspector, class InnerField, class FallbackValue>
+struct EMPTY_BASE FallbackField
+    : Inspector::template FallbackContainer<FallbackValue>,
+      WithInvariant<Inspector,
+                    FallbackField<Inspector, InnerField, FallbackValue>>,
+      WithTransform<Inspector,
+                    FallbackField<Inspector, InnerField, FallbackValue>> {
+  FallbackField(InnerField inner, FallbackValue&& val)
+      : Inspector::template FallbackContainer<FallbackValue>(std::move(val)),
+        inner(std::move(inner)) {}
+  using value_type = typename InnerField::value_type;
+  InnerField inner;
+};
+
+template<class Inspector, class InnerField, class FallbackFactory>
+struct EMPTY_BASE FallbackFactoryField
+    : Inspector::template FallbackFactoryContainer<FallbackFactory>,
+      WithInvariant<Inspector, FallbackFactoryField<Inspector, InnerField,
+                                                    FallbackFactory>>,
+      WithTransform<Inspector, FallbackFactoryField<Inspector, InnerField,
+                                                    FallbackFactory>> {
+  FallbackFactoryField(InnerField inner, FallbackFactory&& fn)
+      : Inspector::template FallbackFactoryContainer<FallbackFactory>(
+            std::move(fn)),
+        inner(std::move(inner)) {}
+  using value_type = typename InnerField::value_type;
+  InnerField inner;
+};
+
+template<class Inspector, class InnerField, class Invariant>
+struct EMPTY_BASE InvariantField
+    : Inspector::template InvariantContainer<Invariant>,
+      WithFallback<Inspector, InvariantField<Inspector, InnerField, Invariant>>,
+      WithTransform<Inspector,
+                    InvariantField<Inspector, InnerField, Invariant>> {
+  InvariantField(InnerField inner, Invariant&& invariant)
+      : Inspector::template InvariantContainer<Invariant>(std::move(invariant)),
+        inner(std::move(inner)) {}
+  using value_type = typename InnerField::value_type;
+  InnerField inner;
+};
+
+template<class Inspector, class InnerField, class Transformer>
+struct EMPTY_BASE TransformField
+    : WithInvariant<Inspector,
+                    TransformField<Inspector, InnerField, Transformer>>,
+      WithFallback<Inspector,
+                   TransformField<Inspector, InnerField, Transformer>> {
+  TransformField(InnerField inner, Transformer&& transformer)
+      : inner(std::move(inner)), transformer(std::move(transformer)) {}
+  using value_type = typename InnerField::value_type;
+  InnerField inner;
+  Transformer transformer;
+};
+
+#undef EMPTY_BASE
+
+template<class T>
+struct IsRawField : std::false_type {};
+template<class Inspector, class T>
+struct IsRawField<RawField<Inspector, T>> : std::true_type {};
+
+template<class T>
+struct IsTransformField : std::false_type {};
+template<class Inspector, class T, class U>
+struct IsTransformField<TransformField<Inspector, T, U>> : std::true_type {};
+
+template<class T>
+struct IsFallbackField : std::false_type {};
+template<class Inspector, class T, class U>
+struct IsFallbackField<FallbackField<Inspector, T, U>> : std::true_type {};
+template<class Inspector, class T, class Fn>
+struct IsFallbackField<FallbackFactoryField<Inspector, T, Fn>>
+    : std::true_type {};
+
+}  // namespace arangodb::inspection::detail

--- a/tests/Basics/InspectionTest.cpp
+++ b/tests/Basics/InspectionTest.cpp
@@ -2348,6 +2348,30 @@ TEST_F(ValidateInspectorTest, validate_object_with_nested_invariant) {
   }
 }
 
+TEST_F(ValidateInspectorTest, validate_embedded_object) {
+  NestedEmbedding n{.e = {.a = 1, .inner = {.i = 42, .s = "foobar"}, .b = 2}};
+  auto result = inspector.apply(n);
+  ASSERT_TRUE(result.ok());
+}
+
+TEST_F(ValidateInspectorTest,
+       validate_embedded_object_with_invariant_not_fulfilled) {
+  NestedEmbedding n{.e = {.a = 1, .inner = {.i = 0, .s = "foobar"}, .b = 2}};
+  auto result = inspector.apply(n);
+  ASSERT_FALSE(result.ok());
+  EXPECT_EQ("Field invariant failed", result.error());
+  EXPECT_EQ("i", result.path());
+}
+
+TEST_F(ValidateInspectorTest,
+       validate_embedded_object_with_object_invariant_not_fulfilled) {
+  NestedEmbeddingWithObjectInvariant o{
+      .e = {.a = 1, .inner = {.i = 42, .s = ""}, .b = 2}};
+  auto result = inspector.apply(o);
+  ASSERT_FALSE(result.ok());
+  EXPECT_EQ("Object invariant failed", result.error());
+}
+
 struct WithContext {
   int i;
   std::string s;

--- a/tests/Basics/InspectionTest.cpp
+++ b/tests/Basics/InspectionTest.cpp
@@ -488,6 +488,16 @@ auto inspect(Inspector& f, Embedded& v) {
   return f.object(v).fields(f.field("x", v.x), f.embedFields(v.inner));
 }
 
+struct EmbeddedObjectInvariant {
+  int x;
+  ObjectInvariant inner;
+};
+
+template<class Inspector>
+auto inspect(Inspector& f, EmbeddedObjectInvariant& v) {
+  return f.object(v).fields(f.field("x", v.x), f.embedFields(v.inner));
+}
+
 }  // namespace
 
 namespace {
@@ -2037,6 +2047,21 @@ TEST_F(VPackLoadInspectorTest,
   ASSERT_FALSE(result.ok());
   EXPECT_EQ("Field invariant failed", result.error());
   EXPECT_EQ("i", result.path());
+}
+
+TEST_F(VPackLoadInspectorTest,
+       load_embedded_object_with_object_invariant_not_fulfilled) {
+  builder.openObject();
+  builder.add("x", 1);
+  builder.add("i", 42);
+  builder.add("s", "");
+  builder.close();
+  VPackLoadInspector inspector{builder};
+
+  EmbeddedObjectInvariant o;
+  auto result = inspector.apply(o);
+  ASSERT_FALSE(result.ok());
+  EXPECT_EQ("Object invariant failed", result.error());
 }
 
 struct VPackInspectionTest : public ::testing::Test {};


### PR DESCRIPTION
### Scope & Purpose

Add support for embedding fields for inner structs with a separate inspect function. E.g.:
```
struct Inner {
   int i;
  std:: string s;
};

template<class Inspector>
auto inspect(Inspector& f, Inner & x) {
  return f.object(x).fields(f.field("i", x.i), f.field("s", x.s));
}

struct Embedded {
  int a;
  Inner inner;
  int b;
};

template<class Inspector>
auto inspect(Inspector& f, Embedded& v) {
  return f.object(v).fields(f.field("a", v.a), f.embedFields(v.inner),
                            f.field("b", v.b));
}
```
will handle objects that look like this  `{ a: ..., i: ..., s: ..., b: ...}`

- [x] :pizza: New feature

### Checklist

- [x] Tests
  - [x] C++ **Unit tests**
