### PR TITLE
Testframework: if we timeout waiting for an instance shutdown, properly pick up the debugger again

### DIFF
--- a/js/client/modules/@arangodb/testutils/instance.js
+++ b/js/client/modules/@arangodb/testutils/instance.js
@@ -950,12 +950,16 @@ class instance {
         print(Date() + ' Server "' + this.name + '" shutdown: detected irregular death by monitor: pid', this.pid);
       }
       if (this.exitStatus.status === 'TERMINATED') {
-        return;
+        return true;
       }
       sleep(1);
       timeout--;
     }
     this.shutDownOneInstance({nonAgenciesCount: 1}, true, 0);
+    crashUtils.aggregateDebugger(this, this.options);
+    this.waitForExitAfterDebugKill();
+    this.pid = null;
+    return false;
   }
 
   shutDownOneInstance(counters, forceTerminate, timeout) {

--- a/tests/js/client/restart/test-soft-shutdown-pregel-cluster.js
+++ b/tests/js/client/restart/test-soft-shutdown-pregel-cluster.js
@@ -141,11 +141,14 @@ function testSuitePregel() {
     tearDown: function () {
       // The soft shutdown initiated in the test
       // should just take care of shutting down
-      coordinator.waitForInstanceShutdown(30);
-      coordinator.restartOneInstance();
-      coordinator.checkArangoConnection(10);
-
-      graph_module._drop(graphName, true);
+      if (coordinator.waitForInstanceShutdown(30)) {
+        coordinator.restartOneInstance();
+        coordinator.checkArangoConnection(10);
+        
+        graph_module._drop(graphName, true);
+      } else {
+        throw new Error("instance shutdown of coordinator failed!");
+      }
     },
 
     testPageRank: function () {


### PR DESCRIPTION
backport of https://github.com/arangodb/arangodb/pull/17091