### PR TITLE
Make collection name available for inverted index on DBServer

### DIFF
--- a/arangod/IResearch/IResearchInvertedIndex.cpp
+++ b/arangod/IResearch/IResearchInvertedIndex.cpp
@@ -770,6 +770,14 @@ Result IResearchInvertedIndex::init(
                    errField + "': " + definition.toString()));
     return {TRI_ERROR_BAD_PARAMETER, errField};
   }
+  auto& cf = _collection.vocbase().server().getFeature<ClusterFeature>();
+  if (cf.isEnabled() && ServerState::instance()->isDBServer()) {
+    bool const wide =
+        _collection.id() == _collection.planId() && _collection.isAStub();
+    clusterCollectionName(_collection, wide ? nullptr : &cf.clusterInfo(),
+                          id().id(), false /*TODO meta.willIndexIdAttribute()*/,
+                          _meta._collectionName);
+  }
   if (ServerState::instance()->isSingleServer() ||
       ServerState::instance()->isDBServer()) {
     TRI_ASSERT(_meta._sort.sortCompression());

--- a/arangod/IResearch/IResearchInvertedIndexMeta.cpp
+++ b/arangod/IResearch/IResearchInvertedIndexMeta.cpp
@@ -143,6 +143,16 @@ bool IResearchInvertedIndexMeta::init(arangodb::ArangodServer& server,
     return false;
   }
 
+  if (ServerState::instance()->isDBServer()) {
+    auto collectionName = slice.get(StaticStrings::CollectionNameField);
+    if (collectionName.isString()) {
+      _collectionName = collectionName.stringView();
+    } else if (!collectionName.isNone()) {
+      errorField = StaticStrings::CollectionNameField;
+      return false;
+    }
+  }
+
   // consistency (optional)
   {
     auto consistencySlice = slice.get(kConsistencyFieldName);
@@ -186,9 +196,10 @@ bool IResearchInvertedIndexMeta::init(arangodb::ArangodServer& server,
         errorField = kVersionFieldName;
         return false;
       }
-      _version = static_cast<LinkVersion>(version);
+      _version = static_cast<uint32_t>(static_cast<LinkVersion>(version));
     } else if (field.isNone()) {
-      _version = LinkVersion::MAX;  // not present -> last version
+      // not present -> last version
+      _version = static_cast<uint32_t>(LinkVersion::MAX);
     } else {
       errorField = kVersionFieldName;
       return false;
@@ -201,7 +212,8 @@ bool IResearchInvertedIndexMeta::init(arangodb::ArangodServer& server,
   AnalyzerPool::ptr versionSpecificIdentity;
 
   auto const res = IResearchAnalyzerFeature::copyAnalyzerPool(
-      versionSpecificIdentity, identity, _version, extendedNames);
+      versionSpecificIdentity, identity, static_cast<LinkVersion>(_version),
+      extendedNames);
 
   if (res.fail() || !versionSpecificIdentity) {
     TRI_ASSERT(false);
@@ -326,8 +338,8 @@ bool IResearchInvertedIndexMeta::init(arangodb::ArangodServer& server,
 
         AnalyzerPool::ptr analyzer;
         auto const res = IResearchAnalyzerFeature::createAnalyzerPool(
-            analyzer, name, type, properties, revision, features, _version,
-            extendedNames);
+            analyzer, name, type, properties, revision, features,
+            static_cast<LinkVersion>(_version), extendedNames);
 
         if (res.fail() || !analyzer) {
           errorField =
@@ -343,9 +355,9 @@ bool IResearchInvertedIndexMeta::init(arangodb::ArangodServer& server,
   }
   auto& analyzers = server.getFeature<IResearchAnalyzerFeature>();
 
-  if (!InvertedIndexField::init(slice, _analyzerDefinitions, _version,
-                                extendedNames, analyzers, *this, defaultVocbase,
-                                true, errorField)) {
+  if (!InvertedIndexField::init(
+          slice, _analyzerDefinitions, static_cast<LinkVersion>(_version),
+          extendedNames, analyzers, *this, defaultVocbase, true, errorField)) {
     return false;
   }
   _hasNested = std::find_if(_fields.begin(), _fields.end(),
@@ -404,12 +416,18 @@ bool IResearchInvertedIndexMeta::json(
   //  }
   //}
 
+  if (writeAnalyzerDefinition && ServerState::instance()->isDBServer() &&
+      !_collectionName.empty()) {
+    builder.add(StaticStrings::CollectionNameField,
+                velocypack::Value{_collectionName});
+  }
+
   return InvertedIndexField::json(server, builder, *this, true, defaultVocbase);
 }
 
 bool IResearchInvertedIndexMeta::operator==(
     IResearchInvertedIndexMeta const& other) const noexcept {
-  return _consistency == other._consistency && _version == other._version &&
+  return _consistency == other._consistency &&
          (static_cast<IResearchDataStoreMeta const&>(*this) ==
           static_cast<IResearchDataStoreMeta const&>(other)) &&
          (static_cast<InvertedIndexField const&>(*this) ==
@@ -486,8 +504,8 @@ bool InvertedIndexField::json(
       name = IResearchAnalyzerFeature::normalize(_analyzers[0]._pool->name(),
                                                  defaultVocbase->name(), false);
     } else {
-      name =
-          _analyzers[0]._pool->name();  // verbatim (assume already normalized)
+      // verbatim (assume already normalized)
+      name = _analyzers[0]._pool->name();
     }
 
     builder.add(kAnalyzerFieldName, VPackValue(name));

--- a/arangod/IResearch/IResearchInvertedIndexMeta.h
+++ b/arangod/IResearch/IResearchInvertedIndexMeta.h
@@ -199,7 +199,6 @@ struct IResearchInvertedIndexMeta : public IResearchDataStoreMeta,
   /// just name
   /// @param defaultVocbase fallback vocbase for analyzer name normalization
   ///                       nullptr == do not normalize
-  /// @param defaultVocbase fallback vocbase
   ////////////////////////////////////////////////////////////////////////////////
   bool json(arangodb::ArangodServer& server, VPackBuilder& builder,
             bool writeAnalyzerDefinition,
@@ -219,9 +218,7 @@ struct IResearchInvertedIndexMeta : public IResearchDataStoreMeta,
   IResearchInvertedIndexSort _sort;
   // stored values associated with the link
   IResearchViewStoredValues _storedValues;
-  // the version of the iresearch interface e.g. which how data is stored in
-  // iresearch (default == MAX) IResearchInvertedIndexMeta
-  LinkVersion _version{LinkVersion::MAX};
+  mutable std::string _collectionName;
   Consistency _consistency{Consistency::kEventual};
   bool _hasNested{false};
 };

--- a/arangod/IResearch/IResearchLinkMeta.h
+++ b/arangod/IResearch/IResearchLinkMeta.h
@@ -150,10 +150,9 @@ struct FieldMeta {
   ///        return success or set TRI_set_errno(...) and return false
   /// @param server underlying application server
   /// @param builder output buffer
+  /// @param ignoreEqual values to ignore if equal
   /// @param defaultVocbase fallback vocbase for analyzer name normalization
   ///                       nullptr == do not normalize
-  /// @param ignoreEqual values to ignore if equal
-  /// @param defaultVocbase fallback vocbase
   /// @param mask if set reflects which fields were initialized from JSON
   ////////////////////////////////////////////////////////////////////////////////
   bool json(ArangodServer& server, velocypack::Builder& builder,
@@ -225,8 +224,8 @@ struct IResearchLinkMeta : public FieldMeta {
   uint32_t _version;
 
   // Linked collection name. Stored here for cluster deployment only.
-  // For sigle server collection could be renamed so can`t store it here or
-  // syncronisation will be needed. For cluster rename is not possible so
+  // For single server collection could be renamed so can`t store it here or
+  // synchronisation will be needed. For cluster rename is not possible so
   // there is no problem but solved recovery issue - we will be able to index
   // _id attribute without doing agency request for collection name
   std::string _collectionName;
@@ -248,7 +247,7 @@ struct IResearchLinkMeta : public FieldMeta {
   ///        return success or set 'errorField' to specific field with error
   ///        on failure state is undefined
   /// @param slice definition
-  /// @param erroField field causing error (out-param)
+  /// @param errorField field causing error (out-param)
   /// @param defaultVocbase fallback vocbase for analyzer name normalization
   ///                       nullptr == do not normalize
   /// @param defaultVersion fallback version if not present in definition

--- a/arangod/IResearch/IResearchRocksDBInvertedIndex.cpp
+++ b/arangod/IResearch/IResearchRocksDBInvertedIndex.cpp
@@ -105,15 +105,6 @@ std::shared_ptr<Index> IResearchRocksDBInvertedIndexFactory::instantiate(
       }
     });
 
-    bool wide = collection.id() == collection.planId() && collection.isAStub();
-    auto& ci = collection.vocbase()
-                   .server()
-                   .getFeature<ClusterFeature>()
-                   .clusterInfo();
-    clusterCollectionName(collection, wide ? nullptr : &ci,
-                          index->Index::id().id(), false,
-                          index->_collectionName);
-
     auto initRes = index->init(
         definition, pathExists, [this]() -> irs::directory_attributes {
           auto& selector = _server.getFeature<EngineSelectorFeature>();
@@ -245,7 +236,7 @@ std::string IResearchRocksDBInvertedIndex::getCollectionName() const {
   if (ServerState::instance()->isSingleServer()) {
     return std::to_string(Index::_collection.id().id());
   }
-  return _collectionName;
+  return meta()._collectionName;
 }
 
 std::string const& IResearchRocksDBInvertedIndex::getShardName()

--- a/arangod/IResearch/IResearchRocksDBInvertedIndex.h
+++ b/arangod/IResearch/IResearchRocksDBInvertedIndex.h
@@ -161,8 +161,6 @@ class IResearchRocksDBInvertedIndex final : public IResearchInvertedIndex,
     *const_cast<std::vector<std::vector<arangodb::basics::AttributeName>>*>(
         &_fields) = IResearchInvertedIndex::fields(meta());
   }
-
-  std::string _collectionName;
 };
 
 }  // namespace iresearch

--- a/tests/IResearch/IResearchInvertedIndexMetaTest.cpp
+++ b/tests/IResearch/IResearchInvertedIndexMetaTest.cpp
@@ -811,7 +811,8 @@ TEST_F(IResearchInvertedIndexMetaTest, testDefaults) {
   ASSERT_EQ(irs::type<irs::compression::lz4>::id(),
             meta._sort.sortCompression());
   ASSERT_FALSE(meta.dense());
-  ASSERT_EQ(arangodb::iresearch::LinkVersion::MAX, meta._version);
+  ASSERT_EQ(static_cast<uint32_t>(arangodb::iresearch::LinkVersion::MAX),
+            meta._version);
   ASSERT_EQ(2, meta._cleanupIntervalStep);
   ASSERT_EQ(1000, meta._commitIntervalMsec);
   ASSERT_EQ(1000, meta._consolidationIntervalMsec);
@@ -891,7 +892,8 @@ TEST_F(IResearchInvertedIndexMetaTest, testReadDefaults) {
               meta._sort.sortCompression());
     ASSERT_TRUE(meta._analyzerDefinitions.empty());
     ASSERT_FALSE(meta.dense());
-    ASSERT_EQ(arangodb::iresearch::LinkVersion::MAX, meta._version);
+    ASSERT_EQ(static_cast<uint32_t>(arangodb::iresearch::LinkVersion::MAX),
+              meta._version);
     ASSERT_EQ(Consistency::kEventual, meta._consistency);
     ASSERT_FALSE(meta._analyzers.empty());
     ASSERT_EQ(meta._analyzers[0]._shortName, "identity");
@@ -916,7 +918,8 @@ TEST_F(IResearchInvertedIndexMetaTest, testReadDefaults) {
               meta._sort.sortCompression());
     ASSERT_TRUE(meta._analyzerDefinitions.empty());
     ASSERT_FALSE(meta.dense());
-    ASSERT_EQ(arangodb::iresearch::LinkVersion::MAX, meta._version);
+    ASSERT_EQ(static_cast<uint32_t>(arangodb::iresearch::LinkVersion::MAX),
+              meta._version);
     ASSERT_EQ(Consistency::kEventual, meta._consistency);
     ASSERT_FALSE(meta._analyzers.empty());
     ASSERT_EQ(meta._analyzers[0]._shortName, "identity");
@@ -966,7 +969,8 @@ TEST_F(IResearchInvertedIndexMetaTest, testDataStoreMetaFields) {
   ASSERT_EQ(meta._sort.sortCompression(),
             irs::type<irs::compression::lz4>::id());
   ASSERT_FALSE(meta.dense());
-  ASSERT_EQ(arangodb::iresearch::LinkVersion::MAX, meta._version);
+  ASSERT_EQ(static_cast<uint32_t>(arangodb::iresearch::LinkVersion::MAX),
+            meta._version);
   ASSERT_EQ(meta._consistency, Consistency::kEventual);
   ASSERT_FALSE(meta._analyzers.empty());
   ASSERT_EQ(meta._analyzers[0]._shortName, "identity");


### PR DESCRIPTION
### Scope & Purpose

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: *(Please link PR)*
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR: https://github.com/arangodb/enterprise/pull/1067
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

