### PR TITLE
[PREGEL] Delete brittle pregel test assertion

### DIFF
--- a/tests/js/client/load-balancing/load-balancing-pregel-noauth-cluster.js
+++ b/tests/js/client/load-balancing/load-balancing-pregel-noauth-cluster.js
@@ -153,11 +153,6 @@ function PregelSuite () {
         assertFalse(result.body.error);
         assertEqual(result.status, 200);
       });
-      
-      url = baseUrl;
-      result = sendRequest('GET', url, {}, false);
-      assertEqual(result.status, 200);
-      assertEqual([], result.body);
     },
 
     testPregelForwarding: function() {


### PR DESCRIPTION
After sending the request to delete a pregel run, the run is beeing canceled and deletes all its components. This deletion can take an unknown amount of time. Therefore requesting the pregel status directly after the deletion request run can still show the deleted run.

### Scope & Purpose

*(Please describe the changes in this PR for reviewers, motivation, rationale - **mandatory**)*

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: *(Please link PR)*
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

