### PR TITLE
Put connected PRs to the top in the PR template

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,7 @@
+### Connected PRs
+- [ ] Enterprise PR:
+- [ ] Docs PR: 
+
 ### Scope & Purpose
 
 *(Please describe the changes in this PR for reviewers, motivation, rationale - **mandatory**)*
@@ -24,9 +28,6 @@
 #### Related Information
 
 *(Please reference tickets / specification / other PRs etc)*
-
-- [ ] Docs PR: 
-- [ ] Enterprise PR:
 - [ ] GitHub issue / Jira ticket:
 - [ ] Design document: 
 


### PR DESCRIPTION
### Scope & Purpose

Improves PR template by putting "Connected PRs" to the top. So if would be harder to miss that Enterprise/Docs PR exists

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: *(Please link PR)*
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

