### PR TITLE
avoid static init order fiasco

### DIFF
--- a/lib/ProgramOptions/Parameters.cpp
+++ b/lib/ProgramOptions/Parameters.cpp
@@ -28,18 +28,17 @@
 namespace arangodb::options {
 
 std::string removeCommentsFromNumber(std::string const& value) {
-  // note: these regex objects are built upon every invocation of this function.
-  // this is necessary because this function is called during static
-  // initialization, and we need to avoid an init order fiasco with TU-local
-  // regexes and other TUs.
+  // note:
+  // this function is already called during static initialization.
+  // the following regex objects are function-local statics, because
+  // we cannot have them statically initialized on the TU level.
+  static std::regex const removeComments("#.*$", std::regex::ECMAScript);
+  static std::regex const removeTabs("^[ \t]+|[ \t]+$", std::regex::ECMAScript);
 
   // replace trailing comments
-  auto noComment =
-      std::regex_replace(value, std::regex("#.*$", std::regex::ECMAScript), "");
-
+  auto noComment = std::regex_replace(value, removeComments, "");
   // replace leading spaces, replace trailing spaces
-  return std::regex_replace(
-      noComment, std::regex("^[ \t]+|[ \t]+$", std::regex::ECMAScript), "");
+  return std::regex_replace(noComment, removeTabs, "");
 }
 
 }  // namespace arangodb::options

--- a/lib/ProgramOptions/Parameters.cpp
+++ b/lib/ProgramOptions/Parameters.cpp
@@ -25,20 +25,21 @@
 
 #include <regex>
 
-namespace {
-std::regex const removeComments("#.*$", std::regex::ECMAScript);
-std::regex const removeTabs("^[ \t]+|[ \t]+$", std::regex::ECMAScript);
-}  // namespace
-
-namespace arangodb {
-namespace options {
+namespace arangodb::options {
 
 std::string removeCommentsFromNumber(std::string const& value) {
+  // note: these regex objects are built upon every invocation of this function.
+  // this is necessary because this function is called during static
+  // initialization, and we need to avoid an init order fiasco with TU-local
+  // regexes and other TUs.
+
   // replace trailing comments
-  auto noComment = std::regex_replace(value, ::removeComments, "");
+  auto noComment =
+      std::regex_replace(value, std::regex("#.*$", std::regex::ECMAScript), "");
+
   // replace leading spaces, replace trailing spaces
-  return std::regex_replace(noComment, ::removeTabs, "");
+  return std::regex_replace(
+      noComment, std::regex("^[ \t]+|[ \t]+$", std::regex::ECMAScript), "");
 }
 
-}  // namespace options
-}  // namespace arangodb
+}  // namespace arangodb::options


### PR DESCRIPTION
### Scope & Purpose

Avoid potential static initialization order fiasco between PhysicalMemory.cpp and Parameters.cpp

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [x] Backports
  - [x] Backport for 3.10: https://github.com/arangodb/arangodb/pull/17113
  - [x] Backport for 3.9: https://github.com/arangodb/arangodb/pull/17115
  - [ ] Backport for 3.8: 

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 