### PR TITLE
improve internal Agent APIs

### DIFF
--- a/arangod/Agency/ActiveFailoverJob.cpp
+++ b/arangod/Agency/ActiveFailoverJob.cpp
@@ -29,6 +29,7 @@
 #include "Agency/Store.h"
 #include "Basics/TimeString.h"
 #include "Cluster/ClusterHelpers.h"
+#include "Logger/LogMacros.h"
 #include "VocBase/voc-types.h"
 
 using namespace arangodb;
@@ -292,13 +293,13 @@ std::string ActiveFailoverJob::findBestFollower() {
   std::vector<ServerTick> ticks;
   try {
     // collect tick values from transient state
-    query_t trx = std::make_unique<VPackBuilder>();
+    velocypack::Builder trx;
     {
-      VPackArrayBuilder transactions(trx.get());
-      VPackArrayBuilder operations(trx.get());
-      trx->add(VPackValue("/" + Job::agencyPrefix + asyncReplTransientPrefix));
+      VPackArrayBuilder transactions(&trx);
+      VPackArrayBuilder operations(&trx);
+      trx.add(VPackValue("/" + Job::agencyPrefix + asyncReplTransientPrefix));
     }
-    trans_ret_t res = _agent->transient(std::move(trx));
+    trans_ret_t res = _agent->transient(trx.slice());
     if (!res.accepted) {
       LOG_TOPIC("dbce2", ERR, Logger::SUPERVISION)
           << "could not read from transient while"

--- a/arangod/Agency/AddFollower.cpp
+++ b/arangod/Agency/AddFollower.cpp
@@ -27,6 +27,7 @@
 #include "Agency/Job.h"
 #include "Basics/StaticStrings.h"
 #include "Basics/TimeString.h"
+#include "Logger/LogMacros.h"
 #include "Random/RandomGenerator.h"
 
 using namespace arangodb::consensus;

--- a/arangod/Agency/Agent.cpp
+++ b/arangod/Agency/Agent.cpp
@@ -160,6 +160,17 @@ Agent::Agent(ArangodServer& server, config_t const& config)
                                    notifySupervision);
 }
 
+/// Dtor shuts down thread
+Agent::~Agent() {
+  waitForThreadsStop();
+  // This usually was already done called from AgencyFeature::unprepare,
+  // but since this only waits for the threads to stop, it can be done
+  // multiple times, and we do it just in case the Agent object was
+  // created but never really started. Here, we exit with a fatal error
+  // if the threads do not stop in time.
+  shutdown();  // wait for the main Agent thread to terminate
+}
+
 /// This agent's id
 std::string Agent::id() const { return _config.id(); }
 
@@ -188,15 +199,11 @@ bool Agent::mergeConfiguration(VPackSlice persisted) {
   return res;
 }
 
-/// Dtor shuts down thread
-Agent::~Agent() {
-  waitForThreadsStop();
-  // This usually was already done called from AgencyFeature::unprepare,
-  // but since this only waits for the threads to stop, it can be done
-  // multiple times, and we do it just in case the Agent object was
-  // created but never really started. Here, we exit with a fatal error
-  // if the threads do not stop in time.
-  shutdown();  // wait for the main Agent thread to terminate
+/// Wakeup main loop of the agent (needed from Constituent)
+void Agent::wakeupMainLoop() {
+  CONDITION_LOCKER(guard, _appendCV);
+  _agentNeedsWakeup = true;
+  _appendCV.broadcast();
 }
 
 /// Wait until threads are terminated:
@@ -243,7 +250,7 @@ std::string Agent::endpoint() const { return _config.endpoint(); }
 /// Handle voting
 priv_rpc_ret_t Agent::requestVote(term_t termOfPeer, std::string const& id,
                                   index_t lastLogIndex, index_t lastLogTerm,
-                                  query_t const& query, int64_t timeoutMult) {
+                                  int64_t timeoutMult) {
   if (timeoutMult != -1 && timeoutMult != _config.timeoutMult()) {
     adjustTimeoutMult(timeoutMult);
     LOG_TOPIC("81f2a", WARN, Logger::AGENCY)
@@ -500,7 +507,7 @@ priv_rpc_ret_t Agent::recvAppendEntriesRPC(term_t term,
                                            std::string const& leaderId,
                                            index_t prevIndex, term_t prevTerm,
                                            index_t leaderCommitIndex,
-                                           query_t const& queries) {
+                                           velocypack::Slice payload) {
   using namespace std::chrono;
   using clock = high_resolution_clock;
 
@@ -513,8 +520,6 @@ priv_rpc_ret_t Agent::recvAppendEntriesRPC(term_t term,
     LOG_TOPIC("7e96c", DEBUG, Logger::AGENCY) << "Agent is not ready yet.";
     return priv_rpc_ret_t(false, t);
   }
-
-  VPackSlice const payload = queries->slice();
 
   // Update commit index
   if (payload.type() != VPackValueType::Array) {
@@ -1236,7 +1241,7 @@ void Agent::lastAckedAgo(Builder& ret) const {
   }
 }
 
-trans_ret_t Agent::transact(query_t const& queries) {
+trans_ret_t Agent::transact(velocypack::Slice qs) {
   arangodb::consensus::index_t maxind = 0;  // maximum write index
 
   // Note that we are leading (_constituent.leading()) if and only
@@ -1256,7 +1261,6 @@ trans_ret_t Agent::transact(query_t const& queries) {
   }
 
   // Apply to spearhead and get indices for log entries
-  auto qs = queries->slice();
   addTrxsOngoing(qs);  // remember that these are ongoing
   size_t failed;
   auto ret = std::make_shared<arangodb::velocypack::Builder>();
@@ -1286,7 +1290,7 @@ trans_ret_t Agent::transact(query_t const& queries) {
     _tiLock.assertNotLockedByCurrentThread();
     MUTEX_LOCKER(ioLocker, _ioLock);
 
-    for (const auto& query : VPackArrayIterator(qs)) {
+    for (auto query : VPackArrayIterator(qs)) {
       // Check that we are actually still the leader:
       if (!leading()) {
         return trans_ret_t(false, NO_LEADER);
@@ -1323,7 +1327,7 @@ trans_ret_t Agent::transact(query_t const& queries) {
 }
 
 // Non-persistent write to non-persisted key-value store
-trans_ret_t Agent::transient(query_t const& queries) {
+trans_ret_t Agent::transient(velocypack::Slice queries) {
   // Note that we are leading (_constituent.leading()) if and only
   // if _constituent.leaderId == our own ID. Therefore, we do not have
   // to use leading() or _constituent.leading() here, but can simply
@@ -1355,7 +1359,7 @@ trans_ret_t Agent::transient(query_t const& queries) {
     MUTEX_LOCKER(transientLocker, _transientLock);
 
     // Read and writes
-    for (const auto& query : VPackArrayIterator(queries->slice())) {
+    for (auto query : VPackArrayIterator(queries)) {
       if (query[0].isObject()) {
         ret->add(VPackValue(_transient.applyTransaction(query).successful()));
       } else if (query[0].isString()) {
@@ -1367,7 +1371,7 @@ trans_ret_t Agent::transient(query_t const& queries) {
   return trans_ret_t(true, id(), 0, 0, std::move(ret));
 }
 
-write_ret_t Agent::inquire(query_t const& query) {
+write_ret_t Agent::inquire(velocypack::Slice query) {
   // Note that we are leading (_constituent.leading()) if and only
   // if _constituent.leaderId == our own ID. Therefore, we do not have
   // to use leading() or _constituent.leading() here, but can simply
@@ -1382,7 +1386,7 @@ write_ret_t Agent::inquire(query_t const& query) {
   while (true) {
     // Check ongoing ones:
     bool found = false;
-    for (VPackSlice s : VPackArrayIterator(query->slice())) {
+    for (VPackSlice s : VPackArrayIterator(query)) {
       std::string ss = s.copyString();
       if (isTrxOngoing(ss)) {
         found = true;
@@ -1412,7 +1416,7 @@ write_ret_t Agent::inquire(query_t const& query) {
 bool Agent::loaded() const { return _loaded.load(); }
 
 /// Write new entries to replicated state and store
-write_ret_t Agent::write(query_t const& query, WriteMode const& wmode) {
+write_ret_t Agent::write(velocypack::Slice query, WriteMode const& wmode) {
   using namespace std::chrono;
   std::vector<apply_ret_t> applied;
   std::vector<index_t> indices;
@@ -1437,10 +1441,9 @@ write_ret_t Agent::write(query_t const& query, WriteMode const& wmode) {
   }
 
   {
-    auto slice = query->slice();
-    addTrxsOngoing(slice);  // remember that these are ongoing
+    addTrxsOngoing(query);  // remember that these are ongoing
     auto sg =
-        arangodb::scopeGuard([&]() noexcept { removeTrxsOngoing(slice); });
+        arangodb::scopeGuard([&]() noexcept { removeTrxsOngoing(query); });
     // Note that once the transactions are in our log, we can remove them
     // from the list of ongoing ones, although they might not yet be committed.
     // This is because then, inquire will find them in the log and draw its
@@ -1448,7 +1451,7 @@ write_ret_t Agent::write(query_t const& query, WriteMode const& wmode) {
     // from when we receive the request until we have appended the trxs
     // ourselves.
 
-    size_t ntrans = slice.length();
+    size_t ntrans = query.length();
     size_t npacks = ntrans / _config.maxAppendSize();
     if (ntrans % _config.maxAppendSize() != 0) {
       npacks++;
@@ -1472,7 +1475,7 @@ write_ret_t Agent::write(query_t const& query, WriteMode const& wmode) {
         VPackArrayBuilder b(&chunk);
         for (size_t j = 0; j < _config.maxAppendSize() && l < ntrans;
              ++j, ++l) {
-          chunk.add(slice.at(l));
+          chunk.add(query.at(l));
         }
       }
 
@@ -1521,7 +1524,7 @@ write_ret_t Agent::write(query_t const& query, WriteMode const& wmode) {
 }
 
 /// Read from store
-read_ret_t Agent::read(query_t const& query) {
+read_ret_t Agent::read(velocypack::Slice query) {
   // Note that we are leading (_constituent.leading()) if and only
   // if _constituent.leaderId == our own ID. Therefore, we do not have
   // to use leading() or _constituent.leading() here, but can simply
@@ -1553,7 +1556,7 @@ read_ret_t Agent::read(query_t const& query) {
   READ_LOCKER(oLocker, _outputLock);
 
   // Retrieve data from readDB
-  std::vector<bool> success = _readDB.readMultiple(query->slice(), *result);
+  std::vector<bool> success = _readDB.readMultiple(query, *result);
 
   ++_read_ok;
   return read_ret_t(true, std::move(leader), std::move(success),
@@ -1717,28 +1720,27 @@ void Agent::run() {
 
 void Agent::persistConfiguration(term_t t) {
   // Agency configuration
-  auto agency = std::make_shared<Builder>();
+  velocypack::Builder agency;
   {
-    VPackArrayBuilder trxs(agency.get());
+    VPackArrayBuilder trxs(&agency);
     {
-      VPackArrayBuilder trx(agency.get());
+      VPackArrayBuilder trx(&agency);
       {
-        VPackObjectBuilder oper(agency.get());
-        agency->add(VPackValue(RECONFIGURE));
+        VPackObjectBuilder oper(&agency);
+        agency.add(VPackValue(RECONFIGURE));
         {
-          VPackObjectBuilder a(agency.get());
-          agency->add("op", VPackValue("set"));
-          agency->add(VPackValue("new"));
+          VPackObjectBuilder a(&agency);
+          agency.add("op", VPackValue("set"));
+          agency.add(VPackValue("new"));
           {
-            VPackObjectBuilder aa(agency.get());
-            agency->add("term", VPackValue(t));
-            agency->add(config_t::idStr, VPackValue(id()));
-            agency->add(config_t::activeStr,
-                        _config.activeToBuilder()->slice());
-            agency->add(config_t::poolStr, _config.poolToBuilder()->slice());
-            agency->add("size", VPackValue(size()));
-            agency->add(config_t::timeoutMultStr,
-                        VPackValue(_config.timeoutMult()));
+            VPackObjectBuilder aa(&agency);
+            agency.add("term", VPackValue(t));
+            agency.add(config_t::idStr, VPackValue(id()));
+            agency.add(config_t::activeStr, _config.activeToBuilder()->slice());
+            agency.add(config_t::poolStr, _config.poolToBuilder()->slice());
+            agency.add("size", VPackValue(size()));
+            agency.add(config_t::timeoutMultStr,
+                       VPackValue(_config.timeoutMult()));
           }
         }
       }
@@ -1756,7 +1758,7 @@ void Agent::persistConfiguration(term_t t) {
   }
   // In case we've lost leadership, no harm will arise as the failed write
   // prevents bogus agency configuration to be replicated among agents. ***
-  write(agency, WriteMode(true, true));
+  write(agency.slice(), WriteMode(true, true));
 }
 
 /// Orderly shutdown
@@ -1855,26 +1857,25 @@ int64_t Agent::leaderFor() const {
          _leaderSince;
 }
 
-void Agent::updatePeerEndpoint(query_t const& message) {
-  VPackSlice slice = message->slice();
-
-  if (!slice.isObject() || slice.length() == 0) {
+void Agent::updatePeerEndpoint(velocypack::Slice message) {
+  if (!message.isObject() || message.length() == 0) {
     THROW_ARANGO_EXCEPTION_MESSAGE(
         TRI_ERROR_AGENCY_INFORM_MUST_BE_OBJECT,
-        std::string("Improper greeting: ") + slice.toJson());
+        std::string("Improper greeting: ") + message.toJson());
   }
 
-  std::string uuid, endpoint;
+  std::string uuid;
   try {
-    uuid = slice.keyAt(0).copyString();
+    uuid = message.keyAt(0).copyString();
   } catch (std::exception const& e) {
     THROW_ARANGO_EXCEPTION_MESSAGE(
         TRI_ERROR_AGENCY_INFORM_MUST_BE_OBJECT,
         std::string("Cannot deal with UUID: ") + e.what());
   }
 
+  std::string endpoint;
   try {
-    endpoint = slice.valueAt(0).copyString();
+    endpoint = message.valueAt(0).copyString();
   } catch (std::exception const& e) {
     THROW_ARANGO_EXCEPTION_MESSAGE(
         TRI_ERROR_AGENCY_INFORM_MUST_BE_OBJECT,
@@ -1896,38 +1897,36 @@ void Agent::updatePeerEndpoint(std::string const& id, std::string const& ep) {
   }
 }
 
-void Agent::notify(query_t const& message) {
-  VPackSlice slice = message->slice();
-
-  if (!slice.isObject()) {
+void Agent::notify(velocypack::Slice message) {
+  if (!message.isObject()) {
     THROW_ARANGO_EXCEPTION_MESSAGE(
         TRI_ERROR_AGENCY_INFORM_MUST_BE_OBJECT,
         std::string("Inform message must be an object. Incoming type is ") +
-            slice.typeName());
+            message.typeName());
   }
 
-  if (!slice.hasKey("id") || !slice.get("id").isString()) {
+  if (!message.get("id").isString()) {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_AGENCY_INFORM_MUST_CONTAIN_ID);
   }
-  if (!slice.hasKey("term")) {
+  if (!message.hasKey("term")) {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_AGENCY_INFORM_MUST_CONTAIN_TERM);
   }
-  _constituent.update(slice.get("id").copyString(),
-                      slice.get("term").getUInt());
+  _constituent.update(message.get("id").copyString(),
+                      message.get("term").getUInt());
 
-  if (!slice.hasKey("active") || !slice.get("active").isArray()) {
+  if (!message.get("active").isArray()) {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_AGENCY_INFORM_MUST_CONTAIN_ACTIVE);
   }
-  if (!slice.hasKey("pool") || !slice.get("pool").isObject()) {
+  if (!message.get("pool").isObject()) {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_AGENCY_INFORM_MUST_CONTAIN_POOL);
   }
-  if (!slice.hasKey("min ping") || !slice.get("min ping").isNumber()) {
+  if (!message.get("min ping").isNumber()) {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_AGENCY_INFORM_MUST_CONTAIN_MIN_PING);
   }
-  if (!slice.hasKey("max ping") || !slice.get("max ping").isNumber()) {
+  if (!message.get("max ping").isNumber()) {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_AGENCY_INFORM_MUST_CONTAIN_MAX_PING);
   }
-  if (!slice.hasKey("timeoutMult") || !slice.get("timeoutMult").isInteger()) {
+  if (!message.get("timeoutMult").isInteger()) {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_AGENCY_INFORM_MUST_CONTAIN_TIMEOUT_MULT);
   }
 
@@ -2238,21 +2237,22 @@ query_t Agent::gossip(VPackSlice slice, bool isCallback, size_t version) {
       } else {  // leader magic
         auto tmp = _config;
         tmp.upsertPool(pslice, id);
-        auto query = std::make_shared<VPackBuilder>();
+
+        velocypack::Builder query;
         {
-          VPackArrayBuilder trs(query.get());
+          VPackArrayBuilder trs(&query);
           {
-            VPackArrayBuilder tr(query.get());
+            VPackArrayBuilder tr(&query);
             {
-              VPackObjectBuilder o(query.get());
-              query->add(VPackValue(RECONFIGURE));
+              VPackObjectBuilder o(&query);
+              query.add(VPackValue(RECONFIGURE));
               {
-                VPackObjectBuilder o(query.get());
-                query->add("op", VPackValue("set"));
-                query->add(VPackValue("new"));
+                VPackObjectBuilder o(&query);
+                query.add("op", VPackValue("set"));
+                query.add(VPackValue("new"));
                 {
-                  VPackObjectBuilder c(query.get());
-                  tmp.toBuilder(*query);
+                  VPackObjectBuilder c(&query);
+                  tmp.toBuilder(query);
                 }
               }
             }
@@ -2261,12 +2261,12 @@ query_t Agent::gossip(VPackSlice slice, bool isCallback, size_t version) {
 
         LOG_TOPIC("e85f0", DEBUG, Logger::AGENCY)
             << "persisting new agency configuration via RAFT: "
-            << query->toJson();
+            << query.toJson();
 
         // Do write
         write_ret_t ret;
         try {
-          ret = write(query, WriteMode(false, true));
+          ret = write(query.slice(), WriteMode(false, true));
           arangodb::consensus::index_t max_index = 0;
           if (ret.indices.size() > 0) {
             max_index =
@@ -2402,7 +2402,7 @@ void Agent::emptyCbTrashBin() {
                      [&server = server(), envelope = std::move(envelope)] {
                        auto* agent = server.getFeature<AgencyFeature>().agent();
                        if (!server.isStopping() && agent) {
-                         agent->write(envelope);
+                         agent->write(envelope->slice());
                        }
                      });
   }
@@ -2492,7 +2492,7 @@ void Agent::updateConfiguration(Slice slice) {
   syncActiveAndAcknowledged();
 }
 
-void Agent::updateSomeConfigValues(VPackSlice data) {
+void Agent::updateSomeConfigValues(velocypack::Slice data) {
   if (!data.isObject()) {
     return;
   }

--- a/arangod/Agency/Agent.h
+++ b/arangod/Agency/Agent.h
@@ -33,15 +33,24 @@
 #include "Agency/State.h"
 #include "Agency/Store.h"
 #include "Futures/Promise.h"
-#include "Basics/ConditionLocker.h"
+#include "Basics/ConditionVariable.h"
 #include "Basics/ReadWriteLock.h"
 #include "RestServer/arangod.h"
 #include "Metrics/Fwd.h"
 
-struct TRI_vocbase_t;
+#include <atomic>
+#include <chrono>
+#include <map>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
 
-namespace arangodb {
-namespace consensus {
+namespace arangodb::velocypack {
+class Slice;
+}
+
+namespace arangodb::consensus {
 
 class Supervision;
 
@@ -65,7 +74,7 @@ class Agent final : public arangodb::ServerThread<ArangodServer>,
 
   /// @brief Vote request
   priv_rpc_ret_t requestVote(term_t, std::string const&, index_t, index_t,
-                             query_t const&, int64_t timeoutMult);
+                             int64_t timeoutMult);
 
   /// @brief Provide configuration
   config_t const config() const;
@@ -114,16 +123,16 @@ class Agent final : public arangodb::ServerThread<ArangodServer>,
   void load();
 
   /// @brief Unpersisted key-value-store
-  trans_ret_t transient(query_t const&) override;
+  trans_ret_t transient(velocypack::Slice query) override;
 
   /// @brief Attempt write
   ///        Startup flag should NEVER be discarded solely for purpose of
   ///        persisting the agency configuration
-  write_ret_t write(query_t const&,
+  write_ret_t write(velocypack::Slice query,
                     WriteMode const& wmode = WriteMode()) override;
 
   /// @brief Read from agency
-  read_ret_t read(query_t const&);
+  read_ret_t read(velocypack::Slice query);
 
   /// @brief Long pool for higher index than given if leader or else empty
   /// builder and false
@@ -131,10 +140,10 @@ class Agent final : public arangodb::ServerThread<ArangodServer>,
                                                                double timeout);
 
   /// @brief Inquire success of logs given clientIds
-  write_ret_t inquire(query_t const&);
+  write_ret_t inquire(velocypack::Slice query);
 
   /// @brief Attempt read/write transaction
-  trans_ret_t transact(query_t const&) override;
+  trans_ret_t transact(velocypack::Slice qs) override;
 
   /// @brief Put trxs into list of ongoing ones.
   void addTrxsOngoing(Slice trxs);
@@ -150,7 +159,7 @@ class Agent final : public arangodb::ServerThread<ArangodServer>,
   priv_rpc_ret_t recvAppendEntriesRPC(term_t term, std::string const& leaderId,
                                       index_t prevIndex, term_t prevTerm,
                                       index_t leaderCommitIndex,
-                                      query_t const& queries);
+                                      velocypack::Slice payload);
 
   /// @brief Resign leadership
   void resign(term_t otherTerm = 0);
@@ -272,7 +281,7 @@ class Agent final : public arangodb::ServerThread<ArangodServer>,
   index_t readDB(Node&) const;
 
   /// @brief Get read store and compaction index
-  index_t readDB(VPackBuilder&) const;
+  index_t readDB(velocypack::Builder&) const;
 
   /// @brief Get read store
   ///  WARNING: this assumes caller holds appropriate
@@ -294,7 +303,7 @@ class Agent final : public arangodb::ServerThread<ArangodServer>,
   bool serveActiveAgent();
 
   /// @brief Get notification as inactive pool member
-  void notify(query_t const&);
+  void notify(velocypack::Slice message);
 
   /// @brief Get copy of log entries starting with begin ending on end
   std::vector<log_t> logs(
@@ -317,7 +326,7 @@ class Agent final : public arangodb::ServerThread<ArangodServer>,
   int64_t leaderFor() const;
 
   /// @brief Update a peers endpoint in my configuration
-  void updatePeerEndpoint(query_t const& message);
+  void updatePeerEndpoint(velocypack::Slice message);
 
   /// @brief Update a peers endpoint in my configuration
   void updatePeerEndpoint(std::string const& id, std::string const& ep);
@@ -354,22 +363,18 @@ class Agent final : public arangodb::ServerThread<ArangodServer>,
   bool mergeConfiguration(VPackSlice persisted);
 
   /// @brief Wakeup main loop of the agent (needed from Constituent)
-  void wakeupMainLoop() {
-    CONDITION_LOCKER(guard, _appendCV);
-    _agentNeedsWakeup = true;
-    _appendCV.broadcast();
-  }
+  void wakeupMainLoop();
 
   /// @brief Activate this agent in single agent mode.
   void activateAgency();
 
   /// @brief add agent to configuration (from State after successful local
   /// persistence)
-  void updateConfiguration(VPackSlice slice);
+  void updateConfiguration(velocypack::Slice slice);
 
   /// @brief patch some configuration values, this is for manual interaction
   /// with the agency leader.
-  void updateSomeConfigValues(VPackSlice data);
+  void updateSomeConfigValues(velocypack::Slice data);
 
   metrics::Histogram<metrics::LogScale<float>>& commitHist() const;
 
@@ -565,5 +570,5 @@ class Agent final : public arangodb::ServerThread<ArangodServer>,
   metrics::Histogram<metrics::LogScale<float>>& _compaction_hist_msec;
   metrics::Gauge<uint64_t>& _local_index;
 };
-}  // namespace consensus
-}  // namespace arangodb
+
+}  // namespace arangodb::consensus

--- a/arangod/Agency/AgentConfiguration.cpp
+++ b/arangod/Agency/AgentConfiguration.cpp
@@ -385,11 +385,10 @@ bool config_t::updateEndpoint(std::string const& id, std::string const& ep) {
   return false;
 }
 
-void config_t::update(query_t const& message) {
-  VPackSlice slice = message->slice();
+void config_t::update(velocypack::Slice message) {
   std::unordered_map<std::string, std::string> pool;
   bool changed = false;
-  for (auto const& p : VPackObjectIterator(slice.get(poolStr))) {
+  for (auto p : VPackObjectIterator(message.get(poolStr))) {
     auto const& id = p.key.copyString();
     if (id != _id) {
       pool[id] = p.value.copyString();
@@ -398,12 +397,12 @@ void config_t::update(query_t const& message) {
     }
   }
   std::vector<std::string> active;
-  for (auto const& a : VPackArrayIterator(slice.get(activeStr))) {
+  for (auto a : VPackArrayIterator(message.get(activeStr))) {
     active.push_back(a.copyString());
   }
-  double minPing = slice.get(minPingStr).getNumber<double>();
-  double maxPing = slice.get(maxPingStr).getNumber<double>();
-  int64_t timeoutMult = slice.get(timeoutMultStr).getNumber<int64_t>();
+  double minPing = message.get(minPingStr).getNumber<double>();
+  double maxPing = message.get(maxPingStr).getNumber<double>();
+  int64_t timeoutMult = message.get(timeoutMultStr).getNumber<int64_t>();
   WRITE_LOCKER(writeLocker, _lock);
   if (pool != _pool) {
     _pool = pool;
@@ -686,13 +685,13 @@ bool config_t::merge(VPackSlice const& conf) {
   return true;
 }
 
-void config_t::updateConfiguration(VPackSlice const& other) {
+void config_t::updateConfiguration(velocypack::Slice other) {
   WRITE_LOCKER(writeLocker, _lock);
 
   auto pool = other.get(poolStr);
   TRI_ASSERT(pool.isObject());
   _pool.clear();
-  for (auto const p : VPackObjectIterator(pool)) {
+  for (auto p : VPackObjectIterator(pool)) {
     _pool[p.key.copyString()] = p.value.copyString();
   }
   _poolSize = _pool.size();
@@ -700,7 +699,7 @@ void config_t::updateConfiguration(VPackSlice const& other) {
   auto active = other.get(activeStr);
   TRI_ASSERT(active.isArray());
   _active.clear();
-  for (auto const id : VPackArrayIterator(active)) {
+  for (auto id : VPackArrayIterator(active)) {
     _active.push_back(id.copyString());
   }
   _agencySize = _pool.size();

--- a/arangod/Agency/AgentConfiguration.h
+++ b/arangod/Agency/AgentConfiguration.h
@@ -31,8 +31,7 @@
 #include <map>
 #include <string>
 
-namespace arangodb {
-namespace consensus {
+namespace arangodb::consensus {
 
 struct config_t {
  private:
@@ -108,7 +107,7 @@ struct config_t {
   config_t& operator=(config_t&&);
 
   /// @brief update leadership changes
-  void update(query_t const&);
+  void update(velocypack::Slice message);
 
   /// @brief agent id
   std::string id() const;
@@ -244,7 +243,7 @@ struct config_t {
   bool updateEndpoint(std::string const&, std::string const&);
 
   /// @brief Update configuration with an other
-  void updateConfiguration(VPackSlice const& other);
+  void updateConfiguration(velocypack::Slice other);
 };
-}  // namespace consensus
-}  // namespace arangodb
+
+}  // namespace arangodb::consensus

--- a/arangod/Agency/AgentInterface.h
+++ b/arangod/Agency/AgentInterface.h
@@ -25,48 +25,52 @@
 
 #include "Agency/AgencyCommon.h"
 
-namespace arangodb {
-namespace consensus {
+namespace arangodb::velocypack {
+class Slice;
+}
+
+namespace arangodb::consensus {
+
 class AgentInterface {
  public:
+  // Suffice warnings
+  virtual ~AgentInterface() = default;
+
   /// @brief Possible outcome of write process
   enum raft_commit_t { OK, UNKNOWN, TIMEOUT };
 
   struct WriteMode {
     bool _discardStartup;
     bool _privileged;
-    WriteMode(bool d = false, bool p = false)
+    WriteMode(bool d = false, bool p = false) noexcept
         : _discardStartup(d), _privileged(p) {}
-    bool privileged() const { return _privileged; }
-    bool discardStartup() const { return _discardStartup; }
-    bool operator==(WriteMode const& other) const {
+    bool privileged() const noexcept { return _privileged; }
+    bool discardStartup() const noexcept { return _discardStartup; }
+    bool operator==(WriteMode const& other) const noexcept {
       return other._discardStartup == _discardStartup &&
              other._privileged == _privileged;
     }
-    bool operator!=(WriteMode const& other) const {
+    bool operator!=(WriteMode const& other) const noexcept {
       return other._discardStartup != _discardStartup ||
              other._privileged != _privileged;
     }
   };
 
   /// @brief Attempt write
-  virtual write_ret_t write(query_t const&,
+  virtual write_ret_t write(velocypack::Slice query,
                             WriteMode const& mode = WriteMode()) = 0;
 
   /// @brief Attempt write
-  virtual trans_ret_t transient(query_t const&) = 0;
+  virtual trans_ret_t transient(velocypack::Slice query) = 0;
 
   /// @brief Attempt write
-  virtual trans_ret_t transact(query_t const&) = 0;
+  virtual trans_ret_t transact(velocypack::Slice qs) = 0;
 
   /// @brief Wait for followers to confirm appended entries
   virtual raft_commit_t waitFor(index_t last_entry, double timeout = 2.0) = 0;
 
   /// @brief Wait for followers to confirm appended entries
   virtual bool isCommitted(index_t last_entry) const = 0;
-
-  // Suffice warnings
-  virtual ~AgentInterface() = default;
 };
-}  // namespace consensus
-}  // namespace arangodb
+
+}  // namespace arangodb::consensus

--- a/arangod/Agency/CleanOutServer.cpp
+++ b/arangod/Agency/CleanOutServer.cpp
@@ -30,6 +30,7 @@
 #include "Agency/MoveShard.h"
 #include "Basics/StaticStrings.h"
 #include "Basics/TimeString.h"
+#include "Logger/LogMacros.h"
 #include "Random/RandomGenerator.h"
 
 using namespace arangodb::consensus;

--- a/arangod/Agency/FailedServer.cpp
+++ b/arangod/Agency/FailedServer.cpp
@@ -31,6 +31,7 @@
 #include "Agency/Job.h"
 #include "Basics/StaticStrings.h"
 #include "Basics/TimeString.h"
+#include "Logger/LogMacros.h"
 
 using namespace arangodb::consensus;
 

--- a/arangod/Agency/Inception.cpp
+++ b/arangod/Agency/Inception.cpp
@@ -398,18 +398,18 @@ bool Inception::restartingActiveAgent() {
                 theirConfig = comres.slice();
               }
               auto const& lcc = theirConfig.get("configuration");
-              auto agency = std::make_shared<Builder>();
+              velocypack::Builder agency;
               {
-                VPackObjectBuilder b(agency.get());
-                agency->add("term", theirConfig.get("term"));
-                agency->add("id", VPackValue(theirLeaderId));
-                agency->add("active", lcc.get("active"));
-                agency->add("pool", lcc.get("pool"));
-                agency->add("min ping", lcc.get("min ping"));
-                agency->add("max ping", lcc.get("max ping"));
-                agency->add("timeoutMult", lcc.get("timeoutMult"));
+                VPackObjectBuilder b(&agency);
+                agency.add("term", theirConfig.get("term"));
+                agency.add("id", VPackValue(theirLeaderId));
+                agency.add("active", lcc.get("active"));
+                agency.add("pool", lcc.get("pool"));
+                agency.add("min ping", lcc.get("min ping"));
+                agency.add("max ping", lcc.get("max ping"));
+                agency.add("timeoutMult", lcc.get("timeoutMult"));
               }
-              _agent.notify(agency);
+              _agent.notify(agency.slice());
               return true;
             }
 

--- a/arangod/Agency/Job.cpp
+++ b/arangod/Agency/Job.cpp
@@ -21,29 +21,39 @@
 /// @author Kaveh Vahedipour
 ////////////////////////////////////////////////////////////////////////////////
 
+#include <algorithm>
 #include <chrono>
 #include <cstdint>
 #include <iterator>
 #include <numeric>
-#include <tuple>
 #include <unordered_map>
 #include <utility>
 
 #include "Job.h"
 
+#include "Agency/AgentInterface.h"
 #include "Agency/Node.h"
 #include "Agency/Supervision.h"
 #include "AgencyStrings.h"
 #include "Basics/Exceptions.h"
 #include "Basics/StringUtils.h"
 #include "Basics/TimeString.h"
+#include "Basics/debugging.h"
 #include "Basics/voc-errors.h"
+#include "Logger/LogMacros.h"
+#include "Logger/Logger.h"
+#include "Logger/LoggerStream.h"
 #include "Random/RandomGenerator.h"
 
-static std::string const DBServer = "DBServer";
+#include <velocypack/Iterator.h>
+#include <velocypack/Slice.h>
 
-namespace arangodb {
-namespace consensus {
+namespace {
+std::vector<std::string> const jobStatus{"ToDo", "Pending", "Finished",
+                                         "Failed"};
+}
+
+namespace arangodb::consensus {
 
 std::string const mapUniqueToShortID = "/Target/MapUniqueToShortID/";
 std::string const pendingPrefix = "/Target/Pending/";
@@ -72,8 +82,131 @@ std::string const asyncReplLeader = "/Plan/AsyncReplication/Leader";
 std::string const asyncReplTransientPrefix = "/AsyncReplication/";
 std::string const planAnalyzersPrefix = "/Plan/Analyzers/";
 
-}  // namespace consensus
-}  // namespace arangodb
+write_ret_t singleWriteTransaction(AgentInterface* _agent,
+                                   velocypack::Builder const& transaction,
+                                   bool waitForCommit) {
+  velocypack::Builder envelope;
+
+  velocypack::Slice trx = transaction.slice();
+  try {
+    {
+      VPackArrayBuilder listOfTrxs(&envelope);
+      VPackArrayBuilder onePair(&envelope);
+      {
+        VPackObjectBuilder mutationPart(&envelope);
+        for (auto pair : VPackObjectIterator(trx[0])) {
+          envelope.add("/" + Job::agencyPrefix + pair.key.copyString(),
+                       pair.value);
+        }
+      }
+      if (trx.length() > 1) {
+        VPackObjectBuilder preconditionPart(&envelope);
+        for (auto pair : VPackObjectIterator(trx[1])) {
+          envelope.add("/" + Job::agencyPrefix + pair.key.copyString(),
+                       pair.value);
+        }
+      }
+    }
+  } catch (std::exception const& e) {
+    LOG_TOPIC("5be90", ERR, Logger::SUPERVISION)
+        << "Supervision failed to build single-write transaction: " << e.what();
+  }
+
+  auto ret = _agent->write(envelope.slice());
+  if (waitForCommit && !ret.indices.empty()) {
+    auto maximum = *std::max_element(ret.indices.begin(), ret.indices.end());
+    if (maximum > 0) {  // some baby has worked
+      _agent->waitFor(maximum);
+    }
+  }
+  return ret;
+}
+
+trans_ret_t generalTransaction(AgentInterface* _agent,
+                               velocypack::Builder const& transaction) {
+  velocypack::Builder envelope;
+  velocypack::Slice trx = transaction.slice();
+
+  try {
+    {
+      VPackArrayBuilder listOfTrxs(&envelope);
+      for (auto singleTrans : VPackArrayIterator(trx)) {
+        TRI_ASSERT(singleTrans.isArray() && singleTrans.length() > 0);
+        if (singleTrans[0].isObject()) {
+          VPackArrayBuilder onePair(&envelope);
+          {
+            VPackObjectBuilder mutationPart(&envelope);
+            for (auto pair : VPackObjectIterator(singleTrans[0])) {
+              envelope.add("/" + Job::agencyPrefix + pair.key.copyString(),
+                           pair.value);
+            }
+          }
+          if (singleTrans.length() > 1) {
+            VPackObjectBuilder preconditionPart(&envelope);
+            for (auto pair : VPackObjectIterator(singleTrans[1])) {
+              envelope.add("/" + Job::agencyPrefix + pair.key.copyString(),
+                           pair.value);
+            }
+          }
+        } else if (singleTrans[0].isString()) {
+          VPackArrayBuilder reads(&envelope);
+          for (auto path : VPackArrayIterator(singleTrans)) {
+            envelope.add(
+                VPackValue("/" + Job::agencyPrefix + path.copyString()));
+          }
+        }
+      }
+    }
+  } catch (std::exception const& e) {
+    LOG_TOPIC("aae99", ERR, Logger::SUPERVISION)
+        << "Supervision failed to build transaction: " << e.what();
+  }
+
+  auto ret = _agent->transact(envelope.slice());
+
+  // This is for now disabled to speed up things. We wait after a full
+  // Supervision run, which is good enough.
+  // if (ret.maxind > 0) {
+  //   _agent->waitFor(ret.maxind);
+  // }
+
+  return ret;
+}
+
+trans_ret_t transient(AgentInterface* _agent,
+                      velocypack::Builder const& transaction) {
+  velocypack::Builder envelope;
+
+  velocypack::Slice trx = transaction.slice();
+  try {
+    {
+      VPackArrayBuilder listOfTrxs(&envelope);
+      VPackArrayBuilder onePair(&envelope);
+      {
+        VPackObjectBuilder mutationPart(&envelope);
+        for (auto pair : VPackObjectIterator(trx[0])) {
+          envelope.add("/" + Job::agencyPrefix + pair.key.copyString(),
+                       pair.value);
+        }
+      }
+      if (trx.length() > 1) {
+        VPackObjectBuilder preconditionPart(&envelope);
+        for (auto pair : VPackObjectIterator(trx[1])) {
+          envelope.add("/" + Job::agencyPrefix + pair.key.copyString(),
+                       pair.value);
+        }
+      }
+    }
+  } catch (std::exception const& e) {
+    LOG_TOPIC("d03d5", ERR, Logger::SUPERVISION)
+        << "Supervision failed to build transaction for transient: "
+        << e.what();
+  }
+
+  return _agent->transient(envelope.slice());
+}
+
+}  // namespace arangodb::consensus
 
 using namespace arangodb::basics;
 using namespace arangodb::consensus;
@@ -94,23 +227,52 @@ std::string Job::agencyPrefix = "arango";
 
 bool Job::considerCancellation() {
   // Allow for cancellation of shard moves
-  auto val = _snapshot.hasAsBool(std::string("/Target/") + jobStatus[_status] +
-                                 "/" + _jobId + "/abort");
+  auto val = _snapshot.hasAsBool(
+      std::string("/Target/") + ::jobStatus[_status] + "/" + _jobId + "/abort");
   auto cancelled = val && val.value();
   if (cancelled) {
     abort("Killed via API");
   }
   return cancelled;
-};
+}
+
+void Job::runHelper(std::string const& server, std::string const& shard,
+                    bool& aborts) {
+  if (_status == FAILED) {  // happens when the constructor did not work
+    return;
+  }
+  try {
+    status();  // This runs everything to to with state PENDING if needed!
+  } catch (std::exception const& e) {
+    LOG_TOPIC("e2d06", WARN, Logger::AGENCY)
+        << "Exception caught in status() method: " << e.what();
+    finish(server, shard, false, e.what());
+  }
+  try {
+    if (_status == TODO) {
+      start(aborts);
+    } else if (_status == NOTFOUND) {
+      if (create(nullptr)) {
+        start(aborts);
+      }
+    }
+  } catch (std::exception const& e) {
+    LOG_TOPIC("5ac04", WARN, Logger::AGENCY)
+        << "Exception caught in create() or "
+           "start() method: "
+        << e.what();
+    finish("", "", false, e.what());
+  }
+}
 
 bool Job::finish(std::string const& server, std::string const& shard,
                  bool success, std::string const& reason,
-                 query_t const payload) {
+                 query_t const& payload) {
   try {  // protect everything, just in case
-    Builder pending, finished;
 
     // Get todo entry
     bool started = false;
+    VPackBuilder pending;
     {
       VPackArrayBuilder guard(&pending);
       if (_snapshot.exists(pendingPrefix + _jobId).size() == 3) {
@@ -157,6 +319,7 @@ bool Job::finish(std::string const& server, std::string const& shard,
     }
 
     // Prepare pending entry, block toserver
+    VPackBuilder finished;
     {
       VPackArrayBuilder guard(&finished);
 
@@ -170,8 +333,8 @@ bool Job::finish(std::string const& server, std::string const& shard,
         addRemoveJobFromSomewhere(finished, "Pending", _jobId);
 
         if (operations.length() > 0) {
-          for (auto const& oper : VPackObjectIterator(operations)) {
-            finished.add(oper.key.copyString(), oper.value);
+          for (auto oper : VPackObjectIterator(operations)) {
+            finished.add(oper.key.stringView(), oper.value);
           }
         }
 
@@ -188,8 +351,8 @@ bool Job::finish(std::string const& server, std::string const& shard,
       if (preconditions.isObject() &&
           preconditions.length() > 0) {  // preconditions --
         VPackObjectBuilder precguard(&finished);
-        for (auto const& prec : VPackObjectIterator(preconditions)) {
-          finished.add(prec.key.copyString(), prec.value);
+        for (auto prec : VPackObjectIterator(preconditions)) {
+          finished.add(prec.key.stringView(), prec.value);
         }
       }  // -- preconditions
     }
@@ -262,7 +425,7 @@ std::string Job::randomIdleAvailableServer(
 // The following counts in a given server list how many of the servers are
 // in Status "GOOD" or "BAD".
 size_t Job::countGoodOrBadServersInList(Node const& snap,
-                                        VPackSlice const& serverList) {
+                                        VPackSlice serverList) {
   size_t count = 0;
   if (!serverList.isArray()) {
     // No array, strange, return 0
@@ -273,7 +436,7 @@ size_t Job::countGoodOrBadServersInList(Node const& snap,
   // Do we have a Health substructure?
   if (health) {
     Node::Children const& healthData = *health;  // List of servers in Health
-    for (VPackSlice const serverName : VPackArrayIterator(serverList)) {
+    for (VPackSlice serverName : VPackArrayIterator(serverList)) {
       if (serverName.isString()) {
         // serverName not a string? Then don't count
         std::string serverStr = serverName.copyString();
@@ -423,13 +586,13 @@ std::vector<size_t> idxsort(const std::vector<T>& v) {
 std::vector<std::string> sortedShardList(Node const& shards) {
   std::vector<size_t> sids;
   auto const& shardMap = shards.children();
-  for (const auto& shard : shardMap) {
+  for (auto const& shard : shardMap) {
     sids.push_back(StringUtils::uint64(shard.first.substr(1)));
   }
 
   std::vector<size_t> idx(idxsort(sids));
   std::vector<std::string> sorted;
-  for (const auto& i : idx) {
+  for (auto const& i : idx) {
     auto x = shardMap.begin();
     std::advance(x, i);
     sorted.push_back(x->first);
@@ -453,7 +616,7 @@ std::vector<Job::shard_t> Job::clones(Node const& snapshot,
   auto steps = std::distance(
       myshards.begin(), std::find(myshards.begin(), myshards.end(), shard));
 
-  for (const auto& colptr :
+  for (auto const& colptr :
        snapshot.hasAsChildren(databasePath).value().get()) {  // collections
 
     auto const& col = *colptr.second;
@@ -462,7 +625,7 @@ std::vector<Job::shard_t> Job::clones(Node const& snapshot,
     if (otherCollection != collection &&
         col.has("distributeShardsLike") &&  // use .has() form to prevent
                                             // logging of missing
-        col.hasAsSlice("distributeShardsLike").value().copyString() ==
+        col.hasAsSlice("distributeShardsLike").value().stringView() ==
             collection) {
       auto const& theirshards =
           sortedShardList(col.hasAsNode("shards").value().get());
@@ -493,12 +656,12 @@ Job::findNonblockedCommonHealthyInSyncFollower(  // Which is in "GOOD" health
   auto nclones = cs.size();               // #clones
   std::unordered_map<std::string, bool> good;
 
-  for (const auto& i : snap.hasAsChildren(healthPrefix).value().get()) {
+  for (auto const& i : snap.hasAsChildren(healthPrefix).value().get()) {
     good[i.first] = ((*i.second).hasAsString("Status").value() == "GOOD");
   }
 
   std::unordered_map<std::string, size_t> currentServers;
-  for (const auto& clone : cs) {
+  for (auto const& clone : cs) {
     auto sharedPath = db + "/" + clone.collection + "/";
     auto currentShardPath =
         curColPrefix + sharedPath + clone.shard + "/servers";
@@ -530,7 +693,7 @@ Job::findNonblockedCommonHealthyInSyncFollower(  // Which is in "GOOD" health
     // Guaranteed by if above
     TRI_ASSERT(serverList->isArray());
 
-    for (const auto& server : VPackArrayIterator(*serverList)) {
+    for (auto server : VPackArrayIterator(*serverList)) {
       auto id = server.copyString();
       if (id == serverToAvoid) {
         // Skip current leader for which we are seeking a replacement
@@ -555,7 +718,7 @@ Job::findNonblockedCommonHealthyInSyncFollower(  // Which is in "GOOD" health
       // check if it is also part of the plan...because if not the soon-to-be
       // leader will drop the collection
       bool found = false;
-      for (const auto& plannedServer :
+      for (auto const& plannedServer :
            VPackArrayIterator(snap.hasAsArray(plannedShardPath).value())) {
         if (plannedServer.isEqualString(server.stringView())) {
           found = true;
@@ -588,14 +751,14 @@ std::vector<std::string> Job::findAllInSyncReplicas(
   std::vector<std::string> result;
 
   bool first = true;
-  for (const auto& clone : shardsLikeMe) {
+  for (auto const& clone : shardsLikeMe) {
     auto sharedPath = db + "/" + clone.collection + "/";
     auto currentPath = curColPrefix + sharedPath + clone.shard + "/servers";
     // If we do have failover candidates, we should use them
     auto serverList = snap.hasAsArray(currentPath);
     if (serverList) {
       std::unordered_set<std::string> setHere;
-      for (const auto& server : VPackArrayIterator(*serverList)) {
+      for (auto server : VPackArrayIterator(*serverList)) {
         auto id = server.copyString();
         if (first) {
           result.push_back(id);
@@ -628,16 +791,15 @@ std::unordered_set<std::string> Job::findAllFailoverCandidates(
     std::vector<Job::shard_t> const& shardsLikeMe) {
   std::unordered_set<std::string> result;
 
-  for (const auto& clone : shardsLikeMe) {
+  for (auto const& clone : shardsLikeMe) {
     auto sharedPath = db + "/" + clone.collection + "/";
     auto currentFailoverCandidatesPath =
         curColPrefix + sharedPath + clone.shard + "/failoverCandidates";
     // If we do have failover candidates, we should use them
     auto serverList = snap.hasAsArray(currentFailoverCandidatesPath);
     if (serverList) {
-      for (const auto& server : VPackArrayIterator(*serverList)) {
-        auto id = server.copyString();
-        result.insert(id);
+      for (auto server : VPackArrayIterator(*serverList)) {
+        result.insert(server.copyString());
       }
     }
   }
@@ -759,8 +921,8 @@ void Job::addPutJobIntoSomewhere(Builder& trx, std::string const& where,
       trx.add("timeFinished",
               VPackValue(timepointToString(std::chrono::system_clock::now())));
     }
-    for (auto const& obj : VPackObjectIterator(job)) {
-      trx.add(obj.key.copyString(), obj.value);
+    for (auto obj : VPackObjectIterator(job)) {
+      trx.add(obj.key.stringView(), obj.value);
     }
     if (!reason.empty()) {
       trx.add("reason", VPackValue(reason));

--- a/arangod/Agency/Job.h
+++ b/arangod/Agency/Job.h
@@ -23,34 +23,30 @@
 
 #pragma once
 
-#include <stddef.h>
-#include <algorithm>
+#include <cstddef>
 #include <functional>
 #include <memory>
 #include <string>
 #include <vector>
 
 #include <velocypack/Builder.h>
-#include <velocypack/Iterator.h>
-#include <velocypack/Slice.h>
 
 #include "Agency/AgencyCommon.h"
-#include "Agency/AgentInterface.h"
 #include "Basics/Result.h"
-#include "Basics/debugging.h"
-#include "Logger/LogMacros.h"
-#include "Logger/Logger.h"
-#include "Logger/LoggerStream.h"
 
-namespace arangodb {
-namespace consensus {
+namespace arangodb::velocypack {
+class Slice;
+}
+
+namespace arangodb::consensus {
+class AgentInterface;
 class Node;
 
 enum JOB_STATUS { TODO, PENDING, FINISHED, FAILED, NOTFOUND };
-const std::vector<std::string> jobStatus{"ToDo", "Pending", "Finished",
-                                         "Failed"};
-const std::vector<std::string> pos({"/Target/ToDo/", "/Target/Pending/",
+
+std::vector<std::string> const pos({"/Target/ToDo/", "/Target/Pending/",
                                     "/Target/Finished/", "/Target/Failed/"});
+
 extern std::string const mapUniqueToShortID;
 extern std::string const pendingPrefix;
 extern std::string const failedPrefix;
@@ -95,40 +91,14 @@ struct Job {
   bool considerCancellation();
 
   void runHelper(std::string const& server, std::string const& shard,
-                 bool& aborts) {
-    if (_status == FAILED) {  // happens when the constructor did not work
-      return;
-    }
-    try {
-      status();  // This runs everything to to with state PENDING if needed!
-    } catch (std::exception const& e) {
-      LOG_TOPIC("e2d06", WARN, Logger::AGENCY)
-          << "Exception caught in status() method: " << e.what();
-      finish(server, shard, false, e.what());
-    }
-    try {
-      if (_status == TODO) {
-        start(aborts);
-      } else if (_status == NOTFOUND) {
-        if (create(nullptr)) {
-          start(aborts);
-        }
-      }
-    } catch (std::exception const& e) {
-      LOG_TOPIC("5ac04", WARN, Logger::AGENCY)
-          << "Exception caught in create() or "
-             "start() method: "
-          << e.what();
-      finish("", "", false, e.what());
-    }
-  }
+                 bool& aborts);
 
   virtual Result abort(std::string const& reason) = 0;
 
   virtual bool finish(std::string const& server, std::string const& shard,
                       bool success = true,
                       std::string const& reason = std::string(),
-                      query_t const payload = nullptr);
+                      query_t const& payload = nullptr);
 
   virtual JOB_STATUS status() = 0;
 
@@ -147,8 +117,8 @@ struct Job {
   static std::string randomIdleAvailableServer(
       Node const& snap, std::vector<std::string> const& exclude);
 
-  static size_t countGoodOrBadServersInList(
-      Node const& snap, velocypack::Slice const& serverList);
+  static size_t countGoodOrBadServersInList(Node const& snap,
+                                            velocypack::Slice serverList);
   static size_t countGoodOrBadServersInList(
       Node const& snap, std::vector<std::string> const& serverList);
 
@@ -156,12 +126,10 @@ struct Job {
                              std::string const& server, bool isArray);
 
   /// @brief Get servers from plan, which are not failed or cleaned out
-  static std::vector<std::string> availableServers(
-      const arangodb::consensus::Node&);
+  static std::vector<std::string> availableServers(Node const&);
 
   /// @brief Get servers from Supervision with health status GOOD
-  static std::vector<std::string> healthyServers(
-      arangodb::consensus::Node const&);
+  static std::vector<std::string> healthyServers(Node const&);
 
   static std::vector<shard_t> clones(Node const& snap, std::string const& db,
                                      std::string const& col,
@@ -244,7 +212,7 @@ struct Job {
   static void addPreconditionServerNotBlocked(velocypack::Builder& pre,
                                               std::string const& server);
   static void addPreconditionCurrentReplicaShardGroup(
-      VPackBuilder& pre, std::string const& database,
+      velocypack::Builder& pre, std::string const& database,
       std::vector<shard_t> const&, std::string const& server);
   static void addPreconditionServerHealth(velocypack::Builder& pre,
                                           std::string const& server,
@@ -272,129 +240,14 @@ struct Job {
                                        std::string const& server);
 };
 
-inline arangodb::consensus::write_ret_t singleWriteTransaction(
-    AgentInterface* _agent, velocypack::Builder const& transaction,
-    bool waitForCommit = true) {
-  query_t envelope = std::make_shared<velocypack::Builder>();
+write_ret_t singleWriteTransaction(AgentInterface* _agent,
+                                   velocypack::Builder const& transaction,
+                                   bool waitForCommit = true);
 
-  velocypack::Slice trx = transaction.slice();
-  try {
-    {
-      VPackArrayBuilder listOfTrxs(envelope.get());
-      VPackArrayBuilder onePair(envelope.get());
-      {
-        VPackObjectBuilder mutationPart(envelope.get());
-        for (auto const& pair : VPackObjectIterator(trx[0])) {
-          envelope->add("/" + Job::agencyPrefix + pair.key.copyString(),
-                        pair.value);
-        }
-      }
-      if (trx.length() > 1) {
-        VPackObjectBuilder preconditionPart(envelope.get());
-        for (auto const& pair : VPackObjectIterator(trx[1])) {
-          envelope->add("/" + Job::agencyPrefix + pair.key.copyString(),
-                        pair.value);
-        }
-      }
-    }
-  } catch (std::exception const& e) {
-    LOG_TOPIC("5be90", ERR, Logger::SUPERVISION)
-        << "Supervision failed to build single-write transaction: " << e.what();
-  }
+trans_ret_t generalTransaction(AgentInterface* _agent,
+                               velocypack::Builder const& transaction);
 
-  auto ret = _agent->write(envelope);
-  if (waitForCommit && !ret.indices.empty()) {
-    auto maximum = *std::max_element(ret.indices.begin(), ret.indices.end());
-    if (maximum > 0) {  // some baby has worked
-      _agent->waitFor(maximum);
-    }
-  }
-  return ret;
-}
+trans_ret_t transient(AgentInterface* _agent,
+                      velocypack::Builder const& transaction);
 
-inline arangodb::consensus::trans_ret_t generalTransaction(
-    AgentInterface* _agent, velocypack::Builder const& transaction) {
-  query_t envelope = std::make_shared<velocypack::Builder>();
-  velocypack::Slice trx = transaction.slice();
-
-  try {
-    {
-      VPackArrayBuilder listOfTrxs(envelope.get());
-      for (auto const& singleTrans : VPackArrayIterator(trx)) {
-        TRI_ASSERT(singleTrans.isArray() && singleTrans.length() > 0);
-        if (singleTrans[0].isObject()) {
-          VPackArrayBuilder onePair(envelope.get());
-          {
-            VPackObjectBuilder mutationPart(envelope.get());
-            for (auto const& pair : VPackObjectIterator(singleTrans[0])) {
-              envelope->add("/" + Job::agencyPrefix + pair.key.copyString(),
-                            pair.value);
-            }
-          }
-          if (singleTrans.length() > 1) {
-            VPackObjectBuilder preconditionPart(envelope.get());
-            for (auto const& pair : VPackObjectIterator(singleTrans[1])) {
-              envelope->add("/" + Job::agencyPrefix + pair.key.copyString(),
-                            pair.value);
-            }
-          }
-        } else if (singleTrans[0].isString()) {
-          VPackArrayBuilder reads(envelope.get());
-          for (auto const& path : VPackArrayIterator(singleTrans)) {
-            envelope->add(
-                VPackValue("/" + Job::agencyPrefix + path.copyString()));
-          }
-        }
-      }
-    }
-  } catch (std::exception const& e) {
-    LOG_TOPIC("aae99", ERR, Logger::SUPERVISION)
-        << "Supervision failed to build transaction: " << e.what();
-  }
-
-  auto ret = _agent->transact(envelope);
-
-  // This is for now disabled to speed up things. We wait after a full
-  // Supervision run, which is good enough.
-  // if (ret.maxind > 0) {
-  // _agent->waitFor(ret.maxind);
-  //
-
-  return ret;
-}
-
-inline arangodb::consensus::trans_ret_t transient(
-    AgentInterface* _agent, velocypack::Builder const& transaction) {
-  query_t envelope = std::make_shared<velocypack::Builder>();
-
-  velocypack::Slice trx = transaction.slice();
-  try {
-    {
-      VPackArrayBuilder listOfTrxs(envelope.get());
-      VPackArrayBuilder onePair(envelope.get());
-      {
-        VPackObjectBuilder mutationPart(envelope.get());
-        for (auto const& pair : VPackObjectIterator(trx[0])) {
-          envelope->add("/" + Job::agencyPrefix + pair.key.copyString(),
-                        pair.value);
-        }
-      }
-      if (trx.length() > 1) {
-        VPackObjectBuilder preconditionPart(envelope.get());
-        for (auto const& pair : VPackObjectIterator(trx[1])) {
-          envelope->add("/" + Job::agencyPrefix + pair.key.copyString(),
-                        pair.value);
-        }
-      }
-    }
-  } catch (std::exception const& e) {
-    LOG_TOPIC("d03d5", ERR, Logger::SUPERVISION)
-        << "Supervision failed to build transaction for transient: "
-        << e.what();
-  }
-
-  return _agent->transient(envelope);
-}
-
-}  // namespace consensus
-}  // namespace arangodb
+}  // namespace arangodb::consensus

--- a/arangod/Agency/JobContext.cpp
+++ b/arangod/Agency/JobContext.cpp
@@ -32,6 +32,7 @@
 #include "Agency/MoveShard.h"
 #include "Agency/RemoveFollower.h"
 #include "Agency/ResignLeadership.h"
+#include "Logger/LogMacros.h"
 
 using namespace arangodb::consensus;
 

--- a/arangod/Agency/MoveShard.cpp
+++ b/arangod/Agency/MoveShard.cpp
@@ -28,6 +28,7 @@
 #include "Basics/StaticStrings.h"
 #include "Basics/TimeString.h"
 #include "Cluster/ClusterHelpers.h"
+#include "Logger/LogMacros.h"
 
 using namespace arangodb;
 using namespace arangodb::consensus;

--- a/arangod/Agency/RemoveFollower.cpp
+++ b/arangod/Agency/RemoveFollower.cpp
@@ -27,6 +27,7 @@
 #include "Agency/Job.h"
 #include "Basics/StaticStrings.h"
 #include "Cluster/ClusterInfo.h"
+#include "Logger/LogMacros.h"
 #include "Random/RandomGenerator.h"
 
 using namespace arangodb::consensus;

--- a/arangod/Agency/ResignLeadership.cpp
+++ b/arangod/Agency/ResignLeadership.cpp
@@ -30,6 +30,7 @@
 #include "Agency/JobContext.h"
 #include "Agency/MoveShard.h"
 #include "Basics/TimeString.h"
+#include "Logger/LogMacros.h"
 #include "Random/RandomGenerator.h"
 
 using namespace arangodb::consensus;
@@ -285,8 +286,8 @@ bool ResignLeadership::start(bool& aborts) {
     // will not be in the snapshot under ToDo, but in this case we find it
     // in _jb:
     if (_jb == nullptr) {
-      auto tmp_todo = _snapshot.hasAsBuilder(toDoPrefix + _jobId, todo);
-      if (!tmp_todo) {
+      auto tmpTodo = _snapshot.hasAsBuilder(toDoPrefix + _jobId, todo);
+      if (!tmpTodo) {
         // Just in case, this is never going to happen, since we will only
         // call the start() method if the job is already in ToDo.
         LOG_TOPIC("deadb", INFO, Logger::SUPERVISION)

--- a/arangod/Agency/State.cpp
+++ b/arangod/Agency/State.cpp
@@ -1625,20 +1625,20 @@ query_t State::allLogs() const {
   return everything;
 }
 
-std::vector<index_t> State::inquire(query_t const& query) const {
-  if (!query->slice().isArray()) {
+std::vector<index_t> State::inquire(velocypack::Slice query) const {
+  if (!query.isArray()) {
     THROW_ARANGO_EXCEPTION_MESSAGE(
         TRI_ERROR_AGENCY_MALFORMED_INQUIRE_REQUEST,
         std::string(
             "Inquiry handles a list of string clientIds: [<clientId>] ") +
-            ". We got " + query->toJson());
+            ". We got " + query.toJson());
   }
 
   std::vector<index_t> result;
   size_t pos = 0;
 
   MUTEX_LOCKER(mutexLocker, _logLock);  // Cannot be read lock (Compaction)
-  for (auto const& i : VPackArrayIterator(query->slice())) {
+  for (auto i : VPackArrayIterator(query)) {
     if (!i.isString()) {
       THROW_ARANGO_EXCEPTION_MESSAGE(
           TRI_ERROR_AGENCY_MALFORMED_INQUIRE_REQUEST,

--- a/arangod/Agency/State.h
+++ b/arangod/Agency/State.h
@@ -24,7 +24,7 @@
 #pragma once
 
 #include "Agency/Store.h"
-#include "AgencyCommon.h"
+#include "Agency/AgencyCommon.h"
 #include "Metrics/Fwd.h"
 #include "RestServer/arangod.h"
 #include "Utils/OperationOptions.h"
@@ -128,8 +128,7 @@ class State {
   /// @brief Has entry with index und term
   bool has(index_t, term_t) const;
 
-  /// @brief Get log entries by client Id
-  std::vector<index_t> inquire(query_t const&) const;
+  std::vector<index_t> inquire(velocypack::Slice query) const;
 
   /// @brief Get complete logged commands by lower and upper bounds.
   ///        Default: [first, last]

--- a/arangod/Agency/Supervision.h
+++ b/arangod/Agency/Supervision.h
@@ -101,6 +101,16 @@ class Supervision : public arangodb::Thread {
   /// @brief remove hotbackup lock in agency, if expired
   void unlockHotBackup();
 
+  /**
+   * @brief Helper function to build transaction removing no longer
+   *        present servers from health monitoring
+   *
+   * @param  del       Agency transaction builder
+   * @param  todelete  List of servers to be removed
+   */
+  static void removeTransactionBuilder(
+      velocypack::Builder& del, std::vector<std::string> const& todelete);
+
   static constexpr char const* HEALTH_STATUS_GOOD = "GOOD";
   static constexpr char const* HEALTH_STATUS_BAD = "BAD";
   static constexpr char const* HEALTH_STATUS_FAILED = "FAILED";
@@ -307,15 +317,6 @@ class Supervision : public arangodb::Thread {
       _supervision_runtime_wait_for_sync_msec;
   metrics::Counter& _supervision_failed_server_counter;
 };
-
-/**
- * @brief Helper function to build transaction removing no longer
- *        present servers from health monitoring
- *
- * @param  todelete  List of servers to be removed
- * @return           Agency transaction
- */
-query_t removeTransactionBuilder(std::vector<std::string> const&);
 
 }  // namespace consensus
 }  // namespace arangodb

--- a/arangod/Agency/v8-agency.cpp
+++ b/arangod/Agency/v8-agency.cpp
@@ -145,10 +145,10 @@ static void JS_ReadAgent(v8::FunctionCallbackInfo<v8::Value> const& args) {
         std::string("couldn't access agency feature: ") + e.what());
   }
 
-  query_t query = std::make_shared<Builder>();
-  TRI_V8ToVPack(isolate, *query, args[0], false);
+  velocypack::Builder query;
+  TRI_V8ToVPack(isolate, query, args[0], false);
 
-  read_ret_t ret = agent->read(query);
+  read_ret_t ret = agent->read(query.slice());
 
   if (ret.accepted) {  // Leading
     TRI_V8_RETURN(TRI_VPackToV8(isolate, ret.result->slice()));
@@ -182,10 +182,10 @@ static void JS_WriteAgent(v8::FunctionCallbackInfo<v8::Value> const& args) {
         std::string("couldn't access agency feature: ") + e.what());
   }
 
-  query_t query = std::make_shared<Builder>();
-  TRI_V8ToVPack(isolate, *query, args[0], false);
+  velocypack::Builder query;
+  TRI_V8ToVPack(isolate, query, args[0], false);
 
-  write_ret_t ret = agent->write(query);
+  write_ret_t ret = agent->write(query.slice());
 
   if (ret.accepted) {  // Leading
     Builder body;

--- a/tests/Agency/ActiveFailoverTest.cpp
+++ b/tests/Agency/ActiveFailoverTest.cpp
@@ -120,20 +120,20 @@ TEST_F(ActiveFailover, creating_a_job_should_create_a_job_in_todo) {
   Mock<AgentInterface> mockAgent;
 
   When(Method(mockAgent, write))
-      .AlwaysDo([&](query_t const& q,
+      .AlwaysDo([&](velocypack::Slice q,
                     consensus::AgentInterface::WriteMode w) -> write_ret_t {
         auto expectedJobKey = "/arango/Target/ToDo/" + jobId;
-        EXPECT_EQ(typeName(q->slice()), "array");
-        EXPECT_EQ(q->slice().length(), 1);
-        EXPECT_EQ(typeName(q->slice()[0]), "array");
+        EXPECT_EQ(typeName(q), "array");
+        EXPECT_EQ(q.length(), 1);
+        EXPECT_EQ(typeName(q[0]), "array");
         // operations + preconditions
-        EXPECT_EQ(q->slice()[0].length(), 2);
-        EXPECT_EQ(typeName(q->slice()[0][0]), "object");
-        EXPECT_EQ(q->slice()[0][0].length(),
+        EXPECT_EQ(q[0].length(), 2);
+        EXPECT_EQ(typeName(q[0][0]), "object");
+        EXPECT_EQ(q[0][0].length(),
                   2);  // should do an entry in todo and failedservers
-        EXPECT_EQ(typeName(q->slice()[0][0].get(expectedJobKey)), "object");
+        EXPECT_EQ(typeName(q[0][0].get(expectedJobKey)), "object");
 
-        auto job = q->slice()[0][0].get(expectedJobKey);
+        auto job = q[0][0].get(expectedJobKey);
         EXPECT_EQ(typeName(job.get("creator")), "string");
         EXPECT_EQ(typeName(job.get("type")), "string");
         EXPECT_EQ(job.get("type").copyString(), "activeFailover");
@@ -167,23 +167,23 @@ TEST_F(ActiveFailover,
 
   Mock<AgentInterface> mockAgent;
   When(Method(mockAgent, write))
-      .AlwaysDo([&](query_t const& q,
+      .AlwaysDo([&](velocypack::Slice q,
                     consensus::AgentInterface::WriteMode w) -> write_ret_t {
-        EXPECT_EQ(typeName(q->slice()), "array");
-        EXPECT_EQ(q->slice().length(), 1);
-        EXPECT_EQ(typeName(q->slice()[0]), "array");
+        EXPECT_EQ(typeName(q), "array");
+        EXPECT_EQ(q.length(), 1);
+        EXPECT_EQ(typeName(q[0]), "array");
         // operations + preconditions
-        EXPECT_EQ(q->slice()[0].length(), 2);
-        EXPECT_EQ(typeName(q->slice()[0][0]), "object");
-        EXPECT_EQ(typeName(q->slice()[0][1]), "object");
+        EXPECT_EQ(q[0].length(), 2);
+        EXPECT_EQ(typeName(q[0][0]), "object");
+        EXPECT_EQ(typeName(q[0][1]), "object");
 
-        auto writes = q->slice()[0][0];
+        auto writes = q[0][0];
         EXPECT_EQ(typeName(writes.get("/arango/Target/ToDo/1")), "object");
         EXPECT_EQ(
             writes.get("/arango/Target/ToDo/1").get("server").copyString(),
             LEADER);
 
-        auto precond = q->slice()[0][1];
+        auto precond = q[0][1];
         EXPECT_TRUE(typeName(precond.get(
                         "/arango/Supervision/Health/SNGL-leader/Status")) ==
                     "object");
@@ -219,23 +219,23 @@ TEST_F(ActiveFailover, server_is_healthy_again_job_finishes) {
 
   Mock<AgentInterface> mockAgent;
   When(Method(mockAgent, write))
-      .Do([&](query_t const& q,
+      .Do([&](velocypack::Slice q,
               consensus::AgentInterface::WriteMode w) -> write_ret_t {
-        EXPECT_EQ(typeName(q->slice()), "array");
-        EXPECT_EQ(q->slice().length(), 1);
-        EXPECT_EQ(typeName(q->slice()[0]), "array");
+        EXPECT_EQ(typeName(q), "array");
+        EXPECT_EQ(q.length(), 1);
+        EXPECT_EQ(typeName(q[0]), "array");
         // operations + preconditions
-        EXPECT_EQ(q->slice()[0].length(), 2);
-        EXPECT_EQ(typeName(q->slice()[0][0]), "object");
-        EXPECT_EQ(typeName(q->slice()[0][1]), "object");
+        EXPECT_EQ(q[0].length(), 2);
+        EXPECT_EQ(typeName(q[0][0]), "object");
+        EXPECT_EQ(typeName(q[0][1]), "object");
 
-        auto writes = q->slice()[0][0];
+        auto writes = q[0][0];
         EXPECT_EQ(typeName(writes.get("/arango/Target/ToDo/1")), "object");
         EXPECT_EQ(
             writes.get("/arango/Target/ToDo/1").get("server").copyString(),
             LEADER);
 
-        auto precond = q->slice()[0][1];
+        auto precond = q[0][1];
         EXPECT_TRUE(typeName(precond.get(
                         "/arango/Supervision/Health/SNGL-leader/Status")) ==
                     "object");
@@ -261,10 +261,10 @@ TEST_F(ActiveFailover, server_is_healthy_again_job_finishes) {
   Verify(Method(mockAgent, write)).Exactly(1);
 
   When(Method(mockAgent, write))
-      .Do([&](query_t const& q,
+      .Do([&](velocypack::Slice q,
               consensus::AgentInterface::WriteMode w) -> write_ret_t {
         // check that the job finishes now, without changing leader
-        VPackSlice writes = q->slice()[0][0];
+        VPackSlice writes = q[0][0];
         EXPECT_TRUE(typeName(writes.get("/arango/Target/ToDo/1").get("op")) ==
                     "string");
         EXPECT_EQ(typeName(writes.get("/arango/Target/Finished/1")), "object");
@@ -287,23 +287,23 @@ TEST_F(ActiveFailover, current_leader_is_different_from_server_in_job) {
 
   Mock<AgentInterface> mockAgent;
   When(Method(mockAgent, write))
-      .Do([&](query_t const& q,
+      .Do([&](velocypack::Slice q,
               consensus::AgentInterface::WriteMode w) -> write_ret_t {
-        EXPECT_EQ(typeName(q->slice()), "array");
-        EXPECT_EQ(q->slice().length(), 1);
-        EXPECT_EQ(typeName(q->slice()[0]), "array");
+        EXPECT_EQ(typeName(q), "array");
+        EXPECT_EQ(q.length(), 1);
+        EXPECT_EQ(typeName(q[0]), "array");
         // operations + preconditions
-        EXPECT_EQ(q->slice()[0].length(), 2);
-        EXPECT_EQ(typeName(q->slice()[0][0]), "object");
-        EXPECT_EQ(typeName(q->slice()[0][1]), "object");
+        EXPECT_EQ(q[0].length(), 2);
+        EXPECT_EQ(typeName(q[0][0]), "object");
+        EXPECT_EQ(typeName(q[0][1]), "object");
 
-        auto writes = q->slice()[0][0];
+        auto writes = q[0][0];
         EXPECT_EQ(typeName(writes.get("/arango/Target/ToDo/1")), "object");
         EXPECT_EQ(
             writes.get("/arango/Target/ToDo/1").get("server").copyString(),
             LEADER);
 
-        auto precond = q->slice()[0][1];
+        auto precond = q[0][1];
         EXPECT_TRUE(typeName(precond.get(
                         "/arango/Supervision/Health/SNGL-leader/Status")) ==
                     "object");
@@ -330,10 +330,10 @@ TEST_F(ActiveFailover, current_leader_is_different_from_server_in_job) {
   Verify(Method(mockAgent, write)).Exactly(1);
 
   When(Method(mockAgent, write))
-      .Do([&](query_t const& q,
+      .Do([&](velocypack::Slice q,
               consensus::AgentInterface::WriteMode w) -> write_ret_t {
         // check that the job finishes now, without changing leader
-        VPackSlice writes = q->slice()[0][0];
+        VPackSlice writes = q[0][0];
         EXPECT_TRUE(typeName(writes.get("/arango/Target/ToDo/1").get("op")) ==
                     "string");
         EXPECT_EQ(typeName(writes.get("/arango/Target/Finished/1")), "object");
@@ -357,23 +357,23 @@ TEST_F(ActiveFailover, no_in_sync_follower_found_job_retries) {
 
   Mock<AgentInterface> mockAgent;
   When(Method(mockAgent, write))
-      .Do([&](query_t const& q,
+      .Do([&](velocypack::Slice q,
               consensus::AgentInterface::WriteMode w) -> write_ret_t {
-        EXPECT_EQ(typeName(q->slice()), "array");
-        EXPECT_EQ(q->slice().length(), 1);
-        EXPECT_EQ(typeName(q->slice()[0]), "array");
+        EXPECT_EQ(typeName(q), "array");
+        EXPECT_EQ(q.length(), 1);
+        EXPECT_EQ(typeName(q[0]), "array");
         // operations + preconditions
-        EXPECT_EQ(q->slice()[0].length(), 2);
-        EXPECT_EQ(typeName(q->slice()[0][0]), "object");
-        EXPECT_EQ(typeName(q->slice()[0][1]), "object");
+        EXPECT_EQ(q[0].length(), 2);
+        EXPECT_EQ(typeName(q[0][0]), "object");
+        EXPECT_EQ(typeName(q[0][1]), "object");
 
-        auto writes = q->slice()[0][0];
+        auto writes = q[0][0];
         EXPECT_EQ(typeName(writes.get("/arango/Target/ToDo/1")), "object");
         EXPECT_EQ(
             writes.get("/arango/Target/ToDo/1").get("server").copyString(),
             LEADER);
 
-        auto precond = q->slice()[0][1];
+        auto precond = q[0][1];
         EXPECT_TRUE(typeName(precond.get(
                         "/arango/Supervision/Health/SNGL-leader/Status")) ==
                     "object");
@@ -400,10 +400,10 @@ TEST_F(ActiveFailover, no_in_sync_follower_found_job_retries) {
 
   When(Method(mockAgent, transient)).Return(fakeTransient);
   When(Method(mockAgent, write))
-      .Do([&](query_t const& q,
+      .Do([&](velocypack::Slice q,
               consensus::AgentInterface::WriteMode w) -> write_ret_t {
         // check that the job fails now
-        auto writes = q->slice()[0][0];
+        auto writes = q[0][0];
         EXPECT_TRUE(
             std::string(
                 writes.get("/arango/Target/ToDo/1").get("op").typeName()) ==
@@ -428,23 +428,23 @@ TEST_F(ActiveFailover, follower_with_best_tick_value_used) {
 
   Mock<AgentInterface> mockAgent;
   When(Method(mockAgent, write))
-      .Do([&](query_t const& q,
+      .Do([&](velocypack::Slice q,
               consensus::AgentInterface::WriteMode w) -> write_ret_t {
-        EXPECT_EQ(typeName(q->slice()), "array");
-        EXPECT_EQ(q->slice().length(), 1);
-        EXPECT_EQ(typeName(q->slice()[0]), "array");
+        EXPECT_EQ(typeName(q), "array");
+        EXPECT_EQ(q.length(), 1);
+        EXPECT_EQ(typeName(q[0]), "array");
         // we always simply override! no preconditions...
-        EXPECT_EQ(q->slice()[0].length(), 2);
-        EXPECT_EQ(typeName(q->slice()[0][0]), "object");
-        EXPECT_EQ(typeName(q->slice()[0][1]), "object");
+        EXPECT_EQ(q[0].length(), 2);
+        EXPECT_EQ(typeName(q[0][0]), "object");
+        EXPECT_EQ(typeName(q[0][1]), "object");
 
-        auto writes = q->slice()[0][0];
+        auto writes = q[0][0];
         EXPECT_EQ(typeName(writes.get("/arango/Target/ToDo/1")), "object");
         EXPECT_EQ(
             writes.get("/arango/Target/ToDo/1").get("server").copyString(),
             LEADER);
 
-        auto precond = q->slice()[0][1];
+        auto precond = q[0][1];
         EXPECT_TRUE(typeName(precond.get(
                         "/arango/Supervision/Health/SNGL-leader/Status")) ==
                     "object");
@@ -471,18 +471,18 @@ TEST_F(ActiveFailover, follower_with_best_tick_value_used) {
 
   When(Method(mockAgent, transient)).Return(fakeTransient);
   When(Method(mockAgent, write))
-      .Do([&](query_t const& q,
+      .Do([&](velocypack::Slice q,
               consensus::AgentInterface::WriteMode w) -> write_ret_t {
-        EXPECT_EQ(typeName(q->slice()), "array");
-        EXPECT_EQ(q->slice().length(), 1);
-        EXPECT_EQ(typeName(q->slice()[0]), "array");
+        EXPECT_EQ(typeName(q), "array");
+        EXPECT_EQ(q.length(), 1);
+        EXPECT_EQ(typeName(q[0]), "array");
         // we always simply override! no preconditions...
-        EXPECT_EQ(q->slice()[0].length(), 2);
-        EXPECT_EQ(typeName(q->slice()[0][0]), "object");
-        EXPECT_EQ(typeName(q->slice()[0][1]), "object");
+        EXPECT_EQ(q[0].length(), 2);
+        EXPECT_EQ(typeName(q[0][0]), "object");
+        EXPECT_EQ(typeName(q[0][1]), "object");
 
         // check that the job succeeds now
-        auto writes = q->slice()[0][0];
+        auto writes = q[0][0];
         EXPECT_TRUE(typeName(writes.get("/arango/Target/ToDo/1").get("op")) ==
                     "string");
         EXPECT_EQ(typeName(writes.get("/arango/Target/Finished/1")), "object");
@@ -492,7 +492,7 @@ TEST_F(ActiveFailover, follower_with_best_tick_value_used) {
             writes.get("/arango/Plan/AsyncReplication/Leader").copyString(),
             FOLLOWER1);
 
-        auto precond = q->slice()[0][1];
+        auto precond = q[0][1];
         EXPECT_TRUE(typeName(precond.get(
                         "/arango/Supervision/Health/SNGL-leader/Status")) ==
                     "object");

--- a/tests/Agency/AddFollowerTest.cpp
+++ b/tests/Agency/AddFollowerTest.cpp
@@ -129,20 +129,20 @@ TEST_F(AddFollowerTest, creating_a_job_should_create_a_job_in_todo) {
   Mock<AgentInterface> mockAgent;
 
   When(Method(mockAgent, write))
-      .AlwaysDo([&](query_t const& q,
+      .AlwaysDo([&](velocypack::Slice q,
                     consensus::AgentInterface::WriteMode w) -> write_ret_t {
         auto expectedJobKey = "/arango/Target/ToDo/" + jobId;
-        EXPECT_EQ(typeName(q->slice()), "array");
-        EXPECT_EQ(q->slice().length(), 1);
-        EXPECT_EQ(typeName(q->slice()[0]), "array");
-        EXPECT_EQ(q->slice()[0].length(),
+        EXPECT_EQ(typeName(q), "array");
+        EXPECT_EQ(q.length(), 1);
+        EXPECT_EQ(typeName(q[0]), "array");
+        EXPECT_EQ(q[0].length(),
                   1);  // we always simply override! no preconditions...
-        EXPECT_EQ(typeName(q->slice()[0][0]), "object");
-        EXPECT_EQ(q->slice()[0][0].length(),
+        EXPECT_EQ(typeName(q[0][0]), "object");
+        EXPECT_EQ(q[0][0].length(),
                   1);  // should ONLY do an entry in todo
-        EXPECT_EQ(typeName(q->slice()[0][0].get(expectedJobKey)), "object");
+        EXPECT_EQ(typeName(q[0][0].get(expectedJobKey)), "object");
 
-        auto job = q->slice()[0][0].get(expectedJobKey);
+        auto job = q[0][0].get(expectedJobKey);
         EXPECT_EQ(typeName(job.get("creator")), "string");
         EXPECT_EQ(typeName(job.get("type")), "string");
         EXPECT_EQ(job.get("type").copyString(), "addFollower");
@@ -202,16 +202,16 @@ TEST_F(AddFollowerTest, collection_still_exists) {
 
   Mock<AgentInterface> mockAgent;
   When(Method(mockAgent, write))
-      .AlwaysDo([&](query_t const& q,
+      .AlwaysDo([&](velocypack::Slice q,
                     consensus::AgentInterface::WriteMode w) -> write_ret_t {
-        EXPECT_EQ(typeName(q->slice()), "array");
-        EXPECT_EQ(q->slice().length(), 1);
-        EXPECT_EQ(typeName(q->slice()[0]), "array");
+        EXPECT_EQ(typeName(q), "array");
+        EXPECT_EQ(q.length(), 1);
+        EXPECT_EQ(typeName(q[0]), "array");
         // we always simply override! no preconditions...
-        EXPECT_EQ(q->slice()[0].length(), 1);
-        EXPECT_EQ(typeName(q->slice()[0][0]), "object");
+        EXPECT_EQ(q[0].length(), 1);
+        EXPECT_EQ(typeName(q[0][0]), "object");
 
-        auto writes = q->slice()[0][0];
+        auto writes = q[0][0];
         EXPECT_EQ(typeName(writes.get("/arango/Target/ToDo/1")), "object");
         EXPECT_TRUE(typeName(writes.get("/arango/Target/ToDo/1").get("op")) ==
                     "string");
@@ -260,16 +260,16 @@ TEST_F(AddFollowerTest, collection_has_nonempty_distributeshardslike) {
 
   Mock<AgentInterface> mockAgent;
   When(Method(mockAgent, write))
-      .AlwaysDo([&](query_t const& q,
+      .AlwaysDo([&](velocypack::Slice q,
                     consensus::AgentInterface::WriteMode w) -> write_ret_t {
-        EXPECT_EQ(typeName(q->slice()), "array");
-        EXPECT_EQ(q->slice().length(), 1);
-        EXPECT_EQ(typeName(q->slice()[0]), "array");
-        EXPECT_EQ(q->slice()[0].length(),
+        EXPECT_EQ(typeName(q), "array");
+        EXPECT_EQ(q.length(), 1);
+        EXPECT_EQ(typeName(q[0]), "array");
+        EXPECT_EQ(q[0].length(),
                   1);  // we always simply override! no preconditions...
-        EXPECT_EQ(typeName(q->slice()[0][0]), "object");
+        EXPECT_EQ(typeName(q[0][0]), "object");
 
-        auto writes = q->slice()[0][0];
+        auto writes = q[0][0];
         EXPECT_EQ(typeName(writes.get("/arango/Target/ToDo/1")), "object");
         EXPECT_TRUE(typeName(writes.get("/arango/Target/ToDo/1").get("op")) ==
                     "string");
@@ -324,16 +324,16 @@ TEST_F(AddFollowerTest, condition_still_holds) {
 
   Mock<AgentInterface> mockAgent;
   When(Method(mockAgent, write))
-      .AlwaysDo([&](query_t const& q,
+      .AlwaysDo([&](velocypack::Slice q,
                     consensus::AgentInterface::WriteMode w) -> write_ret_t {
-        EXPECT_EQ(typeName(q->slice()), "array");
-        EXPECT_EQ(q->slice().length(), 1);
-        EXPECT_EQ(typeName(q->slice()[0]), "array");
-        EXPECT_EQ(q->slice()[0].length(),
+        EXPECT_EQ(typeName(q), "array");
+        EXPECT_EQ(q.length(), 1);
+        EXPECT_EQ(typeName(q[0]), "array");
+        EXPECT_EQ(q[0].length(),
                   1);  // we always simply override! no preconditions...
-        EXPECT_EQ(typeName(q->slice()[0][0]), "object");
+        EXPECT_EQ(typeName(q[0][0]), "object");
 
-        auto writes = q->slice()[0][0];
+        auto writes = q[0][0];
         EXPECT_EQ(typeName(writes.get("/arango/Target/ToDo/1")), "object");
         EXPECT_TRUE(typeName(writes.get("/arango/Target/ToDo/1").get("op")) ==
                     "string");
@@ -388,16 +388,16 @@ TEST_F(AddFollowerTest, if_no_job_under_shard_leave_job_in_todo) {
 
   Mock<AgentInterface> mockAgent;
   When(Method(mockAgent, write))
-      .AlwaysDo([&](query_t const& q,
+      .AlwaysDo([&](velocypack::Slice q,
                     consensus::AgentInterface::WriteMode w) -> write_ret_t {
-        EXPECT_EQ(typeName(q->slice()), "array");
-        EXPECT_EQ(q->slice().length(), 1);
-        EXPECT_EQ(typeName(q->slice()[0]), "array");
-        EXPECT_EQ(q->slice()[0].length(),
+        EXPECT_EQ(typeName(q), "array");
+        EXPECT_EQ(q.length(), 1);
+        EXPECT_EQ(typeName(q[0]), "array");
+        EXPECT_EQ(q[0].length(),
                   1);  // we always simply override! no preconditions...
-        EXPECT_EQ(typeName(q->slice()[0][0]), "object");
+        EXPECT_EQ(typeName(q[0][0]), "object");
 
-        auto writes = q->slice()[0][0];
+        auto writes = q[0][0];
         EXPECT_EQ(typeName(writes.get("/arango/Target/ToDo/1")), "object");
         EXPECT_EQ(writes.get("/arango/Target/Finished/1")
                       .get("collection")
@@ -446,16 +446,16 @@ TEST_F(AddFollowerTest, we_can_find_one_with_status_good) {
 
   Mock<AgentInterface> mockAgent;
   When(Method(mockAgent, write))
-      .AlwaysDo([&](query_t const& q,
+      .AlwaysDo([&](velocypack::Slice q,
                     consensus::AgentInterface::WriteMode w) -> write_ret_t {
-        EXPECT_EQ(typeName(q->slice()), "array");
-        EXPECT_EQ(q->slice().length(), 1);
-        EXPECT_EQ(typeName(q->slice()[0]), "array");
-        EXPECT_EQ(q->slice()[0].length(),
+        EXPECT_EQ(typeName(q), "array");
+        EXPECT_EQ(q.length(), 1);
+        EXPECT_EQ(typeName(q[0]), "array");
+        EXPECT_EQ(q[0].length(),
                   1);  // we always simply override! no preconditions...
-        EXPECT_EQ(typeName(q->slice()[0][0]), "object");
+        EXPECT_EQ(typeName(q[0][0]), "object");
 
-        auto writes = q->slice()[0][0];
+        auto writes = q[0][0];
         EXPECT_EQ(typeName(writes.get("/arango/Target/ToDo/1")), "object");
         EXPECT_EQ(writes.get("/arango/Target/Finished/1")
                       .get("collection")
@@ -498,16 +498,16 @@ TEST_F(AddFollowerTest, job_performed_immediately_in_a_single_transaction) {
 
   Mock<AgentInterface> mockAgent;
   When(Method(mockAgent, write))
-      .AlwaysDo([&](query_t const& q,
+      .AlwaysDo([&](velocypack::Slice q,
                     consensus::AgentInterface::WriteMode w) -> write_ret_t {
-        EXPECT_EQ(typeName(q->slice()), "array");
-        EXPECT_EQ(q->slice().length(), 1);
-        EXPECT_EQ(typeName(q->slice()[0]), "array");
-        EXPECT_EQ(q->slice()[0].length(),
+        EXPECT_EQ(typeName(q), "array");
+        EXPECT_EQ(q.length(), 1);
+        EXPECT_EQ(typeName(q[0]), "array");
+        EXPECT_EQ(q[0].length(),
                   2);  // we always simply override! no preconditions...
-        EXPECT_EQ(typeName(q->slice()[0][0]), "object");
+        EXPECT_EQ(typeName(q[0][0]), "object");
 
-        auto writes = q->slice()[0][0];
+        auto writes = q[0][0];
         EXPECT_EQ(typeName(writes.get("/arango/Target/ToDo/1")), "object");
         EXPECT_TRUE(typeName(writes.get("/arango/Target/ToDo/1").get("op")) ==
                     "string");
@@ -557,16 +557,16 @@ TEST_F(AddFollowerTest, job_can_still_be_safely_aborted) {
 
   Mock<AgentInterface> mockAgent;
   When(Method(mockAgent, write))
-      .AlwaysDo([&](query_t const& q,
+      .AlwaysDo([&](velocypack::Slice q,
                     consensus::AgentInterface::WriteMode w) -> write_ret_t {
-        EXPECT_EQ(typeName(q->slice()), "array");
-        EXPECT_EQ(q->slice().length(), 1);
-        EXPECT_EQ(typeName(q->slice()[0]), "array");
-        EXPECT_EQ(q->slice()[0].length(),
+        EXPECT_EQ(typeName(q), "array");
+        EXPECT_EQ(q.length(), 1);
+        EXPECT_EQ(typeName(q[0]), "array");
+        EXPECT_EQ(q[0].length(),
                   1);  // we always simply override! no preconditions...
-        EXPECT_EQ(typeName(q->slice()[0][0]), "object");
+        EXPECT_EQ(typeName(q[0][0]), "object");
 
-        auto writes = q->slice()[0][0];
+        auto writes = q[0][0];
         EXPECT_EQ(typeName(writes.get("/arango/Target/Failed/1")), "object");
         EXPECT_EQ(writes.get("/arango/Target/Failed/1")
                       .get("collection")
@@ -620,16 +620,16 @@ TEST_F(AddFollowerTest, job_cannot_be_aborted) {
 
   Mock<AgentInterface> mockAgent;
   When(Method(mockAgent, write))
-      .AlwaysDo([&](query_t const& q,
+      .AlwaysDo([&](velocypack::Slice q,
                     consensus::AgentInterface::WriteMode w) -> write_ret_t {
-        EXPECT_EQ(typeName(q->slice()), "array");
-        EXPECT_EQ(q->slice().length(), 1);
-        EXPECT_EQ(typeName(q->slice()[0]), "array");
-        EXPECT_EQ(q->slice()[0].length(),
+        EXPECT_EQ(typeName(q), "array");
+        EXPECT_EQ(q.length(), 1);
+        EXPECT_EQ(typeName(q[0]), "array");
+        EXPECT_EQ(q[0].length(),
                   1);  // we always simply override! no preconditions...
-        EXPECT_EQ(typeName(q->slice()[0][0]), "object");
+        EXPECT_EQ(typeName(q[0][0]), "object");
 
-        auto writes = q->slice()[0][0];
+        auto writes = q[0][0];
         EXPECT_EQ(typeName(writes.get("/arango/Target/Failed/1")), "object");
         EXPECT_EQ(writes.get("/arango/Target/Failed/1")
                       .get("collection")

--- a/tests/Agency/CleanOutServerTest.cpp
+++ b/tests/Agency/CleanOutServerTest.cpp
@@ -77,15 +77,15 @@ VPackBuilder createMoveShardJob() {
   return builder;
 }
 
-void checkFailed(JOB_STATUS status, query_t const& q) {
-  ASSERT_EQ(std::string(q->slice().typeName()), "array");
-  ASSERT_EQ(q->slice().length(), 1);
-  ASSERT_EQ(std::string(q->slice()[0].typeName()), "array");
-  ASSERT_EQ(q->slice()[0].length(),
+void checkFailed(JOB_STATUS status, velocypack::Slice q) {
+  ASSERT_EQ(std::string(q.typeName()), "array");
+  ASSERT_EQ(q.length(), 1);
+  ASSERT_EQ(std::string(q[0].typeName()), "array");
+  ASSERT_EQ(q[0].length(),
             1);  // we always simply override! no preconditions...
-  ASSERT_EQ(std::string(q->slice()[0][0].typeName()), "object");
+  ASSERT_EQ(std::string(q[0][0].typeName()), "object");
 
-  auto writes = q->slice()[0][0];
+  auto writes = q[0][0];
   if (status == JOB_STATUS::PENDING) {
     ASSERT_TRUE(std::string(writes.get("/arango/Supervision/DBServers/leader")
                                 .get("op")
@@ -221,7 +221,7 @@ TEST_F(CleanOutServerTest,
 
   Mock<AgentInterface> mockAgent;
   When(Method(mockAgent, write))
-      .Do([&](query_t const& q,
+      .Do([&](velocypack::Slice q,
               consensus::AgentInterface::WriteMode w) -> write_ret_t {
         checkFailed(JOB_STATUS::TODO, q);
         return fakeWriteResult;
@@ -348,7 +348,7 @@ TEST_F(CleanOutServerTest,
 
   Mock<AgentInterface> mockAgent;
   When(Method(mockAgent, write))
-      .Do([&](query_t const& q,
+      .Do([&](velocypack::Slice q,
               consensus::AgentInterface::WriteMode w) -> write_ret_t {
         checkFailed(JOB_STATUS::TODO, q);
         return fakeWriteResult;
@@ -392,7 +392,7 @@ TEST_F(CleanOutServerTest,
 
   Mock<AgentInterface> mockAgent;
   When(Method(mockAgent, write))
-      .Do([&](query_t const& q,
+      .Do([&](velocypack::Slice q,
               consensus::AgentInterface::WriteMode w) -> write_ret_t {
         checkFailed(JOB_STATUS::TODO, q);
         return fakeWriteResult;
@@ -438,7 +438,7 @@ TEST_F(CleanOutServerTest,
 
   Mock<AgentInterface> mockAgent;
   When(Method(mockAgent, write))
-      .Do([&](query_t const& q,
+      .Do([&](velocypack::Slice q,
               consensus::AgentInterface::WriteMode w) -> write_ret_t {
         checkFailed(JOB_STATUS::TODO, q);
         return fakeWriteResult;
@@ -485,7 +485,7 @@ TEST_F(CleanOutServerTest,
 
   Mock<AgentInterface> mockAgent;
   When(Method(mockAgent, write))
-      .Do([&](query_t const& q,
+      .Do([&](velocypack::Slice q,
               consensus::AgentInterface::WriteMode w) -> write_ret_t {
         checkFailed(JOB_STATUS::TODO, q);
         return fakeWriteResult;
@@ -532,7 +532,7 @@ TEST_F(CleanOutServerTest,
 
   Mock<AgentInterface> mockAgent;
   When(Method(mockAgent, write))
-      .Do([&](query_t const& q,
+      .Do([&](velocypack::Slice q,
               consensus::AgentInterface::WriteMode w) -> write_ret_t {
         checkFailed(JOB_STATUS::TODO, q);
         return fakeWriteResult;
@@ -573,15 +573,15 @@ TEST_F(CleanOutServerTest, cleanout_server_job_should_move_into_pending_if_ok) {
 
   Mock<AgentInterface> mockAgent;
   When(Method(mockAgent, write))
-      .Do([&](query_t const& q,
+      .Do([&](velocypack::Slice q,
               consensus::AgentInterface::WriteMode w) -> write_ret_t {
-        EXPECT_EQ(std::string(q->slice().typeName()), "array");
-        EXPECT_EQ(q->slice().length(), 1);
-        EXPECT_EQ(std::string(q->slice()[0].typeName()), "array");
-        EXPECT_EQ(q->slice()[0].length(), 2);  // we have preconditions
-        EXPECT_EQ(std::string(q->slice()[0][0].typeName()), "object");
+        EXPECT_EQ(std::string(q.typeName()), "array");
+        EXPECT_EQ(q.length(), 1);
+        EXPECT_EQ(std::string(q[0].typeName()), "array");
+        EXPECT_EQ(q[0].length(), 2);  // we have preconditions
+        EXPECT_EQ(std::string(q[0][0].typeName()), "object");
 
-        auto writes = q->slice()[0][0];
+        auto writes = q[0][0];
         EXPECT_TRUE(
             std::string(writes.get("/arango/Target/ToDo/1").typeName()) ==
             "object");
@@ -617,7 +617,7 @@ TEST_F(CleanOutServerTest, cleanout_server_job_should_move_into_pending_if_ok) {
         // second collection is not touched because of replicationVersion == 2
         EXPECT_TRUE(writes.get("/arango/Target/ToDo/1-1").isNone());
 
-        auto preconditions = q->slice()[0][1];
+        auto preconditions = q[0][1];
         EXPECT_TRUE(preconditions.get("/arango/Supervision/DBServers/leader")
                         .get("oldEmpty")
                         .getBool() == true);
@@ -680,18 +680,18 @@ TEST_F(CleanOutServerTest, test_cancel_pending_job) {
   int qCount = 0;
   Mock<AgentInterface> mockAgent;
   When(Method(mockAgent, write))
-      .AlwaysDo([&](query_t const& q,
+      .AlwaysDo([&](velocypack::Slice q,
                     consensus::AgentInterface::WriteMode w) -> write_ret_t {
         if (qCount++ == 0) {
           // first the moveShard job should be aborted
-          EXPECT_EQ(std::string(q->slice().typeName()), "array");
-          EXPECT_EQ(q->slice().length(), 1);
-          EXPECT_EQ(std::string(q->slice()[0].typeName()), "array");
-          EXPECT_EQ(q->slice()[0].length(),
+          EXPECT_EQ(std::string(q.typeName()), "array");
+          EXPECT_EQ(q.length(), 1);
+          EXPECT_EQ(std::string(q[0].typeName()), "array");
+          EXPECT_EQ(q[0].length(),
                     2);  // precondition that still in ToDo
-          EXPECT_EQ(std::string(q->slice()[0][0].typeName()), "object");
+          EXPECT_EQ(std::string(q[0][0].typeName()), "object");
 
-          auto writes = q->slice()[0][0];
+          auto writes = q[0][0];
           EXPECT_TRUE(
               std::string(writes.get("/arango/Target/ToDo/1-0").typeName()) ==
               "object");
@@ -705,7 +705,7 @@ TEST_F(CleanOutServerTest, test_cancel_pending_job) {
           // a not yet started job will be moved to finished
           EXPECT_TRUE(std::string(writes.get("/arango/Target/Finished/1-0")
                                       .typeName()) == "object");
-          auto preconds = q->slice()[0][1];
+          auto preconds = q[0][1];
           EXPECT_TRUE(preconds.get("/arango/Target/ToDo/1-0")
                           .get("oldEmpty")
                           .isFalse());
@@ -767,7 +767,7 @@ TEST_F(CleanOutServerTest, test_cancel_todo_job) {
   int qCount = 0;
   Mock<AgentInterface> mockAgent;
   When(Method(mockAgent, write))
-      .AlwaysDo([&](query_t const& q,
+      .AlwaysDo([&](velocypack::Slice q,
                     consensus::AgentInterface::WriteMode w) -> write_ret_t {
         if (qCount++ == 0) {
           checkFailed(JOB_STATUS::TODO, q);
@@ -854,16 +854,16 @@ TEST_F(CleanOutServerTest,
   };
   Mock<AgentInterface> mockAgent;
   When(Method(mockAgent, write))
-      .Do([&](query_t const& q,
+      .Do([&](velocypack::Slice q,
               consensus::AgentInterface::WriteMode w) -> write_ret_t {
-        EXPECT_EQ(std::string(q->slice().typeName()), "array");
-        EXPECT_EQ(q->slice().length(), 1);
-        EXPECT_EQ(std::string(q->slice()[0].typeName()), "array");
-        EXPECT_EQ(q->slice()[0].length(),
+        EXPECT_EQ(std::string(q.typeName()), "array");
+        EXPECT_EQ(q.length(), 1);
+        EXPECT_EQ(std::string(q[0].typeName()), "array");
+        EXPECT_EQ(q[0].length(),
                   1);  // we always simply override! no preconditions...
-        EXPECT_EQ(std::string(q->slice()[0][0].typeName()), "object");
+        EXPECT_EQ(std::string(q[0][0].typeName()), "object");
 
-        auto writes = q->slice()[0][0];
+        auto writes = q[0][0];
         EXPECT_TRUE(
             std::string(writes.get("/arango/Supervision/DBServers/leader")
                             .get("op")
@@ -924,7 +924,7 @@ TEST_F(CleanOutServerTest, failed_subjob_should_also_fail_job) {
   };
   Mock<AgentInterface> mockAgent;
   When(Method(mockAgent, write))
-      .Do([&](query_t const& q,
+      .Do([&](velocypack::Slice q,
               consensus::AgentInterface::WriteMode w) -> write_ret_t {
         checkFailed(JOB_STATUS::PENDING, q);
         return fakeWriteResult;
@@ -969,18 +969,18 @@ TEST_F(CleanOutServerTest,
   Mock<AgentInterface> mockAgent;
   int qCount = 0;
   When(Method(mockAgent, write))
-      .AlwaysDo([&](query_t const& q,
+      .AlwaysDo([&](velocypack::Slice q,
                     consensus::AgentInterface::WriteMode w) -> write_ret_t {
         if (qCount++ == 0) {
           // first the moveShard job should be aborted
-          EXPECT_EQ(std::string(q->slice().typeName()), "array");
-          EXPECT_EQ(q->slice().length(), 1);
-          EXPECT_EQ(std::string(q->slice()[0].typeName()), "array");
-          EXPECT_EQ(q->slice()[0].length(),
+          EXPECT_EQ(std::string(q.typeName()), "array");
+          EXPECT_EQ(q.length(), 1);
+          EXPECT_EQ(std::string(q[0].typeName()), "array");
+          EXPECT_EQ(q[0].length(),
                     2);  // precondition that still in ToDo
-          EXPECT_EQ(std::string(q->slice()[0][0].typeName()), "object");
+          EXPECT_EQ(std::string(q[0][0].typeName()), "object");
 
-          auto writes = q->slice()[0][0];
+          auto writes = q[0][0];
           EXPECT_TRUE(
               std::string(writes.get("/arango/Target/ToDo/1-0").typeName()) ==
               "object");
@@ -995,7 +995,7 @@ TEST_F(CleanOutServerTest,
           EXPECT_TRUE(
               std::string(writes.get("/arango/Target/Failed/1-0").typeName()) ==
               "object");
-          auto preconds = q->slice()[0][1];
+          auto preconds = q[0][1];
           EXPECT_TRUE(preconds.get("/arango/Target/ToDo/1-0")
                           .get("oldEmpty")
                           .isFalse());

--- a/tests/Agency/CleanUpLostCollectionTest.cpp
+++ b/tests/Agency/CleanUpLostCollectionTest.cpp
@@ -91,7 +91,7 @@ TEST_F(CleanUpLostCollectionTest,
   Mock<AgentInterface> mockAgent;
 
   When(Method(mockAgent, write))
-      .AlwaysDo([&](query_t const& q,
+      .AlwaysDo([&](velocypack::Slice trxs,
                     consensus::AgentInterface::WriteMode w) -> write_ret_t {
         // What do we expect here:
         // We expect two transactions:
@@ -110,7 +110,6 @@ TEST_F(CleanUpLostCollectionTest,
         //        empty: /arango/Plan/Collections/database/collection/shards/s99
         //        old: /arango/Supervision/Health/leader/Status == "FAILED"
 
-        auto const& trxs = q->slice();
         EXPECT_EQ(trxs.length(), 1);
 
         auto const& trx1 = trxs[0];

--- a/tests/Agency/FailedFollowerTest.cpp
+++ b/tests/Agency/FailedFollowerTest.cpp
@@ -144,22 +144,21 @@ TEST_F(FailedFollowerTest, creating_a_job_should_create_a_job_in_todo) {
 
   std::string jobId = "1";
   When(Method(mockAgent, write))
-      .AlwaysDo([&](query_t const& q,
+      .AlwaysDo([&](velocypack::Slice q,
                     consensus::AgentInterface::WriteMode w) -> write_ret_t {
         auto expectedJobKey = "/arango/Target/ToDo/" + jobId;
-        EXPECT_EQ(std::string(q->slice().typeName()), "array");
-        EXPECT_EQ(q->slice().length(), 1);
-        EXPECT_EQ(std::string(q->slice()[0].typeName()), "array");
-        EXPECT_EQ(q->slice()[0].length(),
+        EXPECT_EQ(std::string(q.typeName()), "array");
+        EXPECT_EQ(q.length(), 1);
+        EXPECT_EQ(std::string(q[0].typeName()), "array");
+        EXPECT_EQ(q[0].length(),
                   1);  // we always simply override! no preconditions...
-        EXPECT_EQ(std::string(q->slice()[0][0].typeName()), "object");
-        EXPECT_EQ(q->slice()[0][0].length(),
+        EXPECT_EQ(std::string(q[0][0].typeName()), "object");
+        EXPECT_EQ(q[0][0].length(),
                   1);  // should ONLY do an entry in todo
-        EXPECT_TRUE(
-            std::string(q->slice()[0][0].get(expectedJobKey).typeName()) ==
-            "object");
+        EXPECT_TRUE(std::string(q[0][0].get(expectedJobKey).typeName()) ==
+                    "object");
 
-        auto job = q->slice()[0][0].get(expectedJobKey);
+        auto job = q[0][0].get(expectedJobKey);
         EXPECT_EQ(std::string(job.get("creator").typeName()), "string");
         EXPECT_EQ(std::string(job.get("type").typeName()), "string");
         EXPECT_EQ(job.get("type").copyString(), "failedFollower");
@@ -224,16 +223,16 @@ TEST_F(FailedFollowerTest, if_collection_is_missing_job_should_just_finish) {
 
   Mock<AgentInterface> mockAgent;
   When(Method(mockAgent, write))
-      .AlwaysDo([&](query_t const& q,
+      .AlwaysDo([&](velocypack::Slice q,
                     consensus::AgentInterface::WriteMode w) -> write_ret_t {
-        EXPECT_EQ(std::string(q->slice().typeName()), "array");
-        EXPECT_EQ(q->slice().length(), 1);
-        EXPECT_EQ(std::string(q->slice()[0].typeName()), "array");
-        EXPECT_EQ(q->slice()[0].length(),
+        EXPECT_EQ(std::string(q.typeName()), "array");
+        EXPECT_EQ(q.length(), 1);
+        EXPECT_EQ(std::string(q[0].typeName()), "array");
+        EXPECT_EQ(q[0].length(),
                   1);  // we always simply override! no preconditions...
-        EXPECT_EQ(std::string(q->slice()[0][0].typeName()), "object");
+        EXPECT_EQ(std::string(q[0][0].typeName()), "object");
 
-        auto writes = q->slice()[0][0];
+        auto writes = q[0][0];
         EXPECT_TRUE(
             std::string(writes.get("/arango/Target/ToDo/1").typeName()) ==
             "object");
@@ -294,16 +293,16 @@ TEST_F(FailedFollowerTest, distributeshardslike_should_fail_immediately) {
 
   Mock<AgentInterface> mockAgent;
   When(Method(mockAgent, write))
-      .AlwaysDo([&](query_t const& q,
+      .AlwaysDo([&](velocypack::Slice q,
                     consensus::AgentInterface::WriteMode w) -> write_ret_t {
-        EXPECT_EQ(std::string(q->slice().typeName()), "array");
-        EXPECT_EQ(q->slice().length(), 1);
-        EXPECT_EQ(std::string(q->slice()[0].typeName()), "array");
-        EXPECT_EQ(q->slice()[0].length(),
+        EXPECT_EQ(std::string(q.typeName()), "array");
+        EXPECT_EQ(q.length(), 1);
+        EXPECT_EQ(std::string(q[0].typeName()), "array");
+        EXPECT_EQ(q[0].length(),
                   1);  // we always simply override! no preconditions...
-        EXPECT_EQ(std::string(q->slice()[0][0].typeName()), "object");
+        EXPECT_EQ(std::string(q[0][0].typeName()), "object");
 
-        auto writes = q->slice()[0][0];
+        auto writes = q[0][0];
         EXPECT_TRUE(
             std::string(writes.get("/arango/Target/ToDo/1").typeName()) ==
             "object");
@@ -363,8 +362,8 @@ TEST_F(FailedFollowerTest, if_follower_is_healthy_again_we_fail_the_job) {
   Node agency = createNodeFromBuilder(*builder);
 
   Mock<AgentInterface> mockAgent;
-  When(Method(mockAgent, transact)).Do([&](query_t const& q) -> trans_ret_t {
-    auto preconditions = q->slice()[0][1];
+  When(Method(mockAgent, transact)).Do([&](velocypack::Slice q) -> trans_ret_t {
+    auto preconditions = q[0][1];
     EXPECT_TRUE(
         preconditions
             .get("/arango/Supervision/Health/" + SHARD_FOLLOWER1 + "/Status")
@@ -374,12 +373,12 @@ TEST_F(FailedFollowerTest, if_follower_is_healthy_again_we_fail_the_job) {
     char const* json =
         R"=([{"arango":{"Supervision":{"Health":{"follower1":{"Status":"GOOD"}}}}}])=";
     auto transBuilder = std::make_shared<Builder>(createBuilder(json));
-    return trans_ret_t(true, "", 0, 1, transBuilder);
+    return trans_ret_t(true, "", 0, 1, std::move(transBuilder));
   });
   When(Method(mockAgent, write))
-      .Do([&](query_t const& q,
+      .Do([&](velocypack::Slice q,
               consensus::AgentInterface::WriteMode w) -> write_ret_t {
-        auto writes = q->slice()[0][0];
+        auto writes = q[0][0];
         EXPECT_TRUE(
             std::string(
                 writes.get("/arango/Target/ToDo/1").get("op").typeName()) ==
@@ -439,16 +438,15 @@ TEST_F(FailedFollowerTest,
 
   Mock<AgentInterface> mockAgent;
   When(Method(mockAgent, write))
-      .Do([&](query_t const& q,
+      .Do([&](velocypack::Slice q,
               consensus::AgentInterface::WriteMode w) -> write_ret_t {
         // check that moveshard is being moved to failed
-        EXPECT_EQ(std::string(q->slice().typeName()), "array");
-        EXPECT_EQ(q->slice().length(), 1);
-        EXPECT_EQ(std::string(q->slice()[0].typeName()), "array");
-        EXPECT_EQ(std::string(q->slice()[0][0].typeName()), "object");
+        EXPECT_EQ(std::string(q.typeName()), "array");
+        EXPECT_EQ(q.length(), 1);
+        EXPECT_EQ(std::string(q[0].typeName()), "array");
+        EXPECT_EQ(std::string(q[0][0].typeName()), "object");
         EXPECT_TRUE(
-            std::string(
-                q->slice()[0][0].get("/arango/Target/Failed/1").typeName()) ==
+            std::string(q[0][0].get("/arango/Target/Failed/1").typeName()) ==
             "object");
         return fakeWriteResult;
       });
@@ -504,16 +502,15 @@ TEST_F(FailedFollowerTest,
 
   Mock<AgentInterface> mockAgent;
   When(Method(mockAgent, write))
-      .Do([&](query_t const& q,
+      .Do([&](velocypack::Slice q,
               consensus::AgentInterface::WriteMode w) -> write_ret_t {
         // check that moveshard is being moved to failed
-        EXPECT_EQ(std::string(q->slice().typeName()), "array");
-        EXPECT_EQ(q->slice().length(), 1);
-        EXPECT_EQ(std::string(q->slice()[0].typeName()), "array");
-        EXPECT_EQ(std::string(q->slice()[0][0].typeName()), "object");
+        EXPECT_EQ(std::string(q.typeName()), "array");
+        EXPECT_EQ(q.length(), 1);
+        EXPECT_EQ(std::string(q[0].typeName()), "array");
+        EXPECT_EQ(std::string(q[0][0].typeName()), "object");
         EXPECT_TRUE(
-            std::string(
-                q->slice()[0][0].get("/arango/Target/Failed/1").typeName()) ==
+            std::string(q[0][0].get("/arango/Target/Failed/1").typeName()) ==
             "object");
         return fakeWriteResult;
       });
@@ -530,18 +527,17 @@ TEST_F(FailedFollowerTest, abort_any_moveshard_job_blocking) {
   Mock<AgentInterface> moveShardMockAgent;
   Builder moveShardBuilder;
   When(Method(moveShardMockAgent, write))
-      .Do([&](query_t const& q,
+      .Do([&](velocypack::Slice q,
               consensus::AgentInterface::WriteMode w) -> write_ret_t {
-        EXPECT_EQ(std::string(q->slice().typeName()), "array");
-        EXPECT_EQ(q->slice().length(), 1);
-        EXPECT_EQ(std::string(q->slice()[0].typeName()), "array");
-        EXPECT_TRUE(q->slice()[0].length() > 0);  // preconditions!
-        EXPECT_EQ(std::string(q->slice()[0][0].typeName()), "object");
+        EXPECT_EQ(std::string(q.typeName()), "array");
+        EXPECT_EQ(q.length(), 1);
+        EXPECT_EQ(std::string(q[0].typeName()), "array");
+        EXPECT_TRUE(q[0].length() > 0);  // preconditions!
+        EXPECT_EQ(std::string(q[0][0].typeName()), "object");
         EXPECT_TRUE(
-            std::string(
-                q->slice()[0][0].get("/arango/Target/ToDo/2").typeName()) ==
+            std::string(q[0][0].get("/arango/Target/ToDo/2").typeName()) ==
             "object");
-        moveShardBuilder.add(q->slice()[0][0].get("/arango/Target/ToDo/2"));
+        moveShardBuilder.add(q[0][0].get("/arango/Target/ToDo/2"));
         return fakeWriteResult;
       });
   When(Method(moveShardMockAgent, waitFor)).Return();
@@ -592,19 +588,19 @@ TEST_F(FailedFollowerTest, abort_any_moveshard_job_blocking) {
   // nothing should happen
   Mock<AgentInterface> mockAgent;
   When(Method(mockAgent, write))
-      .AlwaysDo(
-          [&](query_t const& q,
-              consensus::AgentInterface::WriteMode const& w) -> write_ret_t {
-            // check that moveshard is being moved to failed
-            EXPECT_EQ(std::string(q->slice().typeName()), "array");
-            EXPECT_EQ(q->slice().length(), 1);
-            EXPECT_EQ(std::string(q->slice()[0].typeName()), "array");
-            EXPECT_EQ(std::string(q->slice()[0][0].typeName()), "object");
-            EXPECT_TRUE(std::string(q->slice()[0][0]
-                                        .get("/arango/Target/Failed/2")
-                                        .typeName()) == "object");
-            return fakeWriteResult;
-          });
+      .AlwaysDo([&](velocypack::Slice q,
+                    consensus::AgentInterface::WriteMode const& w)
+                    -> write_ret_t {
+        // check that moveshard is being moved to failed
+        EXPECT_EQ(std::string(q.typeName()), "array");
+        EXPECT_EQ(q.length(), 1);
+        EXPECT_EQ(std::string(q[0].typeName()), "array");
+        EXPECT_EQ(std::string(q[0][0].typeName()), "object");
+        EXPECT_TRUE(
+            std::string(q[0][0].get("/arango/Target/Failed/2").typeName()) ==
+            "object");
+        return fakeWriteResult;
+      });
 
   AgentInterface& agent = mockAgent.get();
   auto failedFollower = FailedFollower(agency.getOrCreate(PREFIX), &agent,
@@ -648,9 +644,9 @@ TEST_F(FailedFollowerTest, successfully_started_jbo_should_finish_immediately) {
   Node agency = createNodeFromBuilder(*builder);
 
   Mock<AgentInterface> mockAgent;
-  When(Method(mockAgent, transact)).Do([&](query_t const& q) -> trans_ret_t {
+  When(Method(mockAgent, transact)).Do([&](velocypack::Slice q) -> trans_ret_t {
     // check that the job is now pending
-    auto writes = q->slice()[0][0];
+    auto writes = q[0][0];
     auto planEntry = "/arango/Plan/Collections/" + DATABASE + "/" + COLLECTION +
                      "/shards/" + SHARD;
     EXPECT_TRUE(
@@ -670,7 +666,7 @@ TEST_F(FailedFollowerTest, successfully_started_jbo_should_finish_immediately) {
         std::string(writes.get("/arango/Target/Finished/1").typeName()) ==
         "object");
 
-    auto preconditions = q->slice()[0][1];
+    auto preconditions = q[0][1];
     EXPECT_EQ(std::string(preconditions.typeName()), "object");
     auto healthStat =
         std::string("/arango/Supervision/Health/") + freeEntry + "/Status";
@@ -754,9 +750,9 @@ TEST_F(FailedFollowerTest, job_should_handle_distributeshardslike) {
   Node agency = createNodeFromBuilder(*builder);
 
   Mock<AgentInterface> mockAgent;
-  When(Method(mockAgent, transact)).Do([&](query_t const& q) -> trans_ret_t {
+  When(Method(mockAgent, transact)).Do([&](velocypack::Slice q) -> trans_ret_t {
     // check that the job is now pending
-    auto writes = q->slice()[0][0];
+    auto writes = q[0][0];
     EXPECT_TRUE(
         std::string(writes.get("/arango/Target/Finished/1").typeName()) ==
         "object");
@@ -827,7 +823,7 @@ TEST_F(FailedFollowerTest, job_should_handle_distributeshardslike) {
         std::string(writes.get("/arango/Target/Finished/1").typeName()) ==
         "object");
 
-    auto preconditions = q->slice()[0][1];
+    auto preconditions = q[0][1];
     EXPECT_EQ(std::string(preconditions.typeName()), "object");
     auto healthStat =
         std::string("/arango/Supervision/Health/") + freeEntry + "/Status";
@@ -911,10 +907,10 @@ TEST_F(FailedFollowerTest, job_should_timeout_after_a_while) {
 
   Mock<AgentInterface> mockAgent;
   When(Method(mockAgent, write))
-      .Do([&](query_t const& q,
+      .Do([&](velocypack::Slice q,
               consensus::AgentInterface::WriteMode w) -> write_ret_t {
         // check that the job is now pending
-        auto writes = q->slice()[0][0];
+        auto writes = q[0][0];
         EXPECT_TRUE(
             std::string(writes.get("/arango/Target/Failed/1").typeName()) ==
             "object");
@@ -967,10 +963,10 @@ TEST_F(FailedFollowerTest, job_should_be_abortable_in_todo) {
 
   Mock<AgentInterface> mockAgent;
   When(Method(mockAgent, write))
-      .Do([&](query_t const& q,
+      .Do([&](velocypack::Slice q,
               consensus::AgentInterface::WriteMode w) -> write_ret_t {
         // check that the job is now pending
-        auto writes = q->slice()[0][0];
+        auto writes = q[0][0];
         EXPECT_TRUE(
             std::string(writes.get("/arango/Target/Failed/1").typeName()) ==
             "object");

--- a/tests/Agency/FailedServerTest.cpp
+++ b/tests/Agency/FailedServerTest.cpp
@@ -129,18 +129,18 @@ TEST_F(FailedServerTest, creating_a_job_should_create_a_job_in_todo) {
 
   std::string jobId = "1";
   When(Method(mockAgent, write))
-      .AlwaysDo([&](query_t const& q,
+      .AlwaysDo([&](velocypack::Slice q,
                     consensus::AgentInterface::WriteMode w) -> write_ret_t {
         auto expectedJobKey = PREFIX + toDoPrefix + jobId;
-        EXPECT_EQ(typeName(q->slice()), "array");
-        EXPECT_EQ(q->slice().length(), 1);
-        EXPECT_EQ(typeName(q->slice()[0]), "array");
-        EXPECT_EQ(q->slice()[0].length(), 2);
-        EXPECT_EQ(typeName(q->slice()[0][0]), "object");
-        EXPECT_EQ(q->slice()[0][0].length(), 2);
-        EXPECT_EQ(typeName(q->slice()[0][0].get(expectedJobKey)), "object");
+        EXPECT_EQ(typeName(q), "array");
+        EXPECT_EQ(q.length(), 1);
+        EXPECT_EQ(typeName(q[0]), "array");
+        EXPECT_EQ(q[0].length(), 2);
+        EXPECT_EQ(typeName(q[0][0]), "object");
+        EXPECT_EQ(q[0][0].length(), 2);
+        EXPECT_EQ(typeName(q[0][0].get(expectedJobKey)), "object");
 
-        auto job = q->slice()[0][0].get(expectedJobKey);
+        auto job = q[0][0].get(expectedJobKey);
         EXPECT_EQ(typeName(job.get("creator")), "string");
         EXPECT_EQ(typeName(job.get("type")), "string");
         EXPECT_EQ(job.get("type").copyString(), "failedServer");
@@ -197,23 +197,23 @@ TEST_F(
 
   Mock<AgentInterface> mockAgent;
   When(Method(mockAgent, write))
-      .AlwaysDo([&](query_t const& q,
+      .AlwaysDo([&](velocypack::Slice q,
                     consensus::AgentInterface::WriteMode w) -> write_ret_t {
-        EXPECT_EQ(typeName(q->slice()), "array");
-        EXPECT_EQ(q->slice().length(), 1);
-        EXPECT_EQ(typeName(q->slice()[0]), "array");
+        EXPECT_EQ(typeName(q), "array");
+        EXPECT_EQ(q.length(), 1);
+        EXPECT_EQ(typeName(q[0]), "array");
         // we always simply override! no preconditions...
-        EXPECT_EQ(q->slice()[0].length(), 2);
-        EXPECT_EQ(typeName(q->slice()[0][0]), "object");
-        EXPECT_EQ(typeName(q->slice()[0][1]), "object");
+        EXPECT_EQ(q[0].length(), 2);
+        EXPECT_EQ(typeName(q[0][0]), "object");
+        EXPECT_EQ(typeName(q[0][1]), "object");
 
-        auto writes = q->slice()[0][0];
+        auto writes = q[0][0];
         EXPECT_EQ(typeName(writes.get("/arango/Target/ToDo/1")), "object");
         EXPECT_EQ(
             writes.get("/arango/Target/ToDo/1").get("server").copyString(),
             SHARD_LEADER);
 
-        auto precond = q->slice()[0][1];
+        auto precond = q[0][1];
         EXPECT_TRUE(
             typeName(precond.get("/arango/Supervision/Health/leader/Status")) ==
             "object");
@@ -273,23 +273,23 @@ TEST_F(
 
   Mock<AgentInterface> mockAgent;
   When(Method(mockAgent, write))
-      .AlwaysDo([&](query_t const& q,
+      .AlwaysDo([&](velocypack::Slice q,
                     consensus::AgentInterface::WriteMode w) -> write_ret_t {
-        EXPECT_EQ(typeName(q->slice()), "array");
-        EXPECT_EQ(q->slice().length(), 1);
-        EXPECT_EQ(typeName(q->slice()[0]), "array");
+        EXPECT_EQ(typeName(q), "array");
+        EXPECT_EQ(q.length(), 1);
+        EXPECT_EQ(typeName(q[0]), "array");
         // we always simply override! no preconditions...
-        EXPECT_EQ(q->slice()[0].length(), 2);
-        EXPECT_EQ(typeName(q->slice()[0][0]), "object");
-        EXPECT_EQ(typeName(q->slice()[0][1]), "object");
+        EXPECT_EQ(q[0].length(), 2);
+        EXPECT_EQ(typeName(q[0][0]), "object");
+        EXPECT_EQ(typeName(q[0][1]), "object");
 
-        auto writes = q->slice()[0][0];
+        auto writes = q[0][0];
         EXPECT_EQ(typeName(writes.get("/arango/Target/ToDo/1")), "object");
         EXPECT_EQ(
             writes.get("/arango/Target/ToDo/1").get("server").copyString(),
             SHARD_LEADER);
 
-        auto precond = q->slice()[0][1];
+        auto precond = q[0][1];
         EXPECT_TRUE(
             typeName(precond.get("/arango/Supervision/Health/leader/Status")) ==
             "object");
@@ -349,16 +349,16 @@ TEST_F(FailedServerTest,
 
   Mock<AgentInterface> mockAgent;
   When(Method(mockAgent, write))
-      .AlwaysDo([&](query_t const& q,
+      .AlwaysDo([&](velocypack::Slice q,
                     consensus::AgentInterface::WriteMode w) -> write_ret_t {
-        EXPECT_EQ(typeName(q->slice()), "array");
-        EXPECT_EQ(q->slice().length(), 1);
-        EXPECT_EQ(typeName(q->slice()[0]), "array");
+        EXPECT_EQ(typeName(q), "array");
+        EXPECT_EQ(q.length(), 1);
+        EXPECT_EQ(typeName(q[0]), "array");
         // we always simply override! no preconditions...
-        EXPECT_EQ(q->slice()[0].length(), 1);
-        EXPECT_EQ(typeName(q->slice()[0][0]), "object");
+        EXPECT_EQ(q[0].length(), 1);
+        EXPECT_EQ(typeName(q[0][0]), "object");
 
-        auto writes = q->slice()[0][0];
+        auto writes = q[0][0];
         EXPECT_EQ(typeName(writes.get("/arango/Target/ToDo/1")), "object");
         EXPECT_TRUE(typeName(writes.get("/arango/Target/ToDo/1").get("op")) ==
                     "string");
@@ -420,16 +420,16 @@ TEST_F(FailedServerTest,
 
   Mock<AgentInterface> mockAgent;
   When(Method(mockAgent, write))
-      .AlwaysDo([&](query_t const& q,
+      .AlwaysDo([&](velocypack::Slice q,
                     consensus::AgentInterface::WriteMode w) -> write_ret_t {
-        EXPECT_EQ(typeName(q->slice()), "array");
-        EXPECT_EQ(q->slice().length(), 1);
-        EXPECT_EQ(typeName(q->slice()[0]), "array");
+        EXPECT_EQ(typeName(q), "array");
+        EXPECT_EQ(q.length(), 1);
+        EXPECT_EQ(typeName(q[0]), "array");
         // we always simply override! no preconditions...
-        EXPECT_EQ(q->slice()[0].length(), 1);
-        EXPECT_EQ(typeName(q->slice()[0][0]), "object");
+        EXPECT_EQ(q[0].length(), 1);
+        EXPECT_EQ(typeName(q[0][0]), "object");
 
-        auto writes = q->slice()[0][0];
+        auto writes = q[0][0];
         EXPECT_EQ(typeName(writes.get("/arango/Target/ToDo/1")), "object");
         EXPECT_TRUE(typeName(writes.get("/arango/Target/ToDo/1").get("op")) ==
                     "string");

--- a/tests/Agency/MoveShardTest.cpp
+++ b/tests/Agency/MoveShardTest.cpp
@@ -81,12 +81,12 @@ Node createAgencyFromBuilder(VPackBuilder const& builder) {
   std::string sourceKey = "/arango/Target/";                                   \
   sourceKey += source;                                                         \
   sourceKey += "/1";                                                           \
-  EXPECT_EQ(std::string(q->slice().typeName()), "array");                      \
-  EXPECT_EQ(q->slice().length(), 1);                                           \
-  EXPECT_EQ(std::string(q->slice()[0].typeName()), "array");                   \
-  EXPECT_EQ(q->slice()[0].length(), 1);                                        \
-  EXPECT_EQ(std::string(q->slice()[0][0].typeName()), "object");               \
-  auto writes = q->slice()[0][0];                                              \
+  EXPECT_EQ(std::string(q.typeName()), "array");                               \
+  EXPECT_EQ(q.length(), 1);                                                    \
+  EXPECT_EQ(std::string(q[0].typeName()), "array");                            \
+  EXPECT_EQ(q[0].length(), 1);                                                 \
+  EXPECT_EQ(std::string(q[0][0].typeName()), "object");                        \
+  auto writes = q[0][0];                                                       \
   EXPECT_EQ(std::string(writes.get(sourceKey).typeName()), "object");          \
   EXPECT_TRUE(std::string(writes.get(sourceKey).get("op").typeName()) ==       \
               "string");                                                       \
@@ -174,7 +174,7 @@ TEST_F(MoveShardTest, the_job_should_fail_if_toserver_does_not_exist) {
   Mock<AgentInterface> mockAgent;
   AgentInterface& agent = mockAgent.get();
   When(Method(mockAgent, write))
-      .AlwaysDo([&](query_t const& q,
+      .AlwaysDo([&](velocypack::Slice q,
                     consensus::AgentInterface::WriteMode w) -> write_ret_t {
         CHECK_FAILURE("ToDo", q);
         return fakeWriteResult;
@@ -220,7 +220,7 @@ TEST_F(MoveShardTest, the_job_should_fail_if_servers_are_planned_followers) {
   Mock<AgentInterface> mockAgent;
   AgentInterface& agent = mockAgent.get();
   When(Method(mockAgent, write))
-      .AlwaysDo([&](query_t const& q,
+      .AlwaysDo([&](velocypack::Slice q,
                     consensus::AgentInterface::WriteMode w) -> write_ret_t {
         CHECK_FAILURE("ToDo", q);
         return fakeWriteResult;
@@ -312,7 +312,7 @@ TEST_F(MoveShardTest, the_job_should_fail_if_fromserver_is_not_in_plan) {
   Mock<AgentInterface> mockAgent;
   AgentInterface& agent = mockAgent.get();
   When(Method(mockAgent, write))
-      .AlwaysDo([&](query_t const& q,
+      .AlwaysDo([&](velocypack::Slice q,
                     consensus::AgentInterface::WriteMode w) -> write_ret_t {
         CHECK_FAILURE("ToDo", q);
         return fakeWriteResult;
@@ -357,16 +357,16 @@ TEST_F(MoveShardTest, the_job_should_fail_if_fromserver_does_not_exist_2) {
   Mock<AgentInterface> mockAgent;
   AgentInterface& agent = mockAgent.get();
   When(Method(mockAgent, write))
-      .AlwaysDo([&](query_t const& q,
+      .AlwaysDo([&](velocypack::Slice q,
                     consensus::AgentInterface::WriteMode w) -> write_ret_t {
-        EXPECT_EQ(std::string(q->slice().typeName()), "array");
-        EXPECT_EQ(q->slice().length(), 1);
-        EXPECT_EQ(std::string(q->slice()[0].typeName()), "array");
-        EXPECT_EQ(q->slice()[0].length(),
+        EXPECT_EQ(std::string(q.typeName()), "array");
+        EXPECT_EQ(q.length(), 1);
+        EXPECT_EQ(std::string(q[0].typeName()), "array");
+        EXPECT_EQ(q[0].length(),
                   1);  // we always simply override! no preconditions...
-        EXPECT_EQ(std::string(q->slice()[0][0].typeName()), "object");
+        EXPECT_EQ(std::string(q[0][0].typeName()), "object");
 
-        auto writes = q->slice()[0][0];
+        auto writes = q[0][0];
         EXPECT_TRUE(
             std::string(writes.get("/arango/Target/ToDo/1").typeName()) ==
             "object");
@@ -512,7 +512,7 @@ TEST_F(MoveShardTest, the_job_should_fail_if_target_server_was_cleaned_out) {
 
   Mock<AgentInterface> mockAgent;
   When(Method(mockAgent, write))
-      .AlwaysDo([&](query_t const& q,
+      .AlwaysDo([&](velocypack::Slice q,
                     consensus::AgentInterface::WriteMode w) -> write_ret_t {
         CHECK_FAILURE("ToDo", q);
         return fakeWriteResult;
@@ -563,7 +563,7 @@ TEST_F(MoveShardTest, the_job_should_fail_if_the_target_server_is_failed) {
 
   Mock<AgentInterface> mockAgent;
   When(Method(mockAgent, write))
-      .AlwaysDo([&](query_t const& q,
+      .AlwaysDo([&](velocypack::Slice q,
                     consensus::AgentInterface::WriteMode w) -> write_ret_t {
         CHECK_FAILURE("ToDo", q);
         return fakeWriteResult;
@@ -614,7 +614,7 @@ TEST_F(MoveShardTest, the_job_should_wait_until_the_target_server_is_good) {
 
   Mock<AgentInterface> mockAgent;
   When(Method(mockAgent, write))
-      .AlwaysDo([&](query_t const& q,
+      .AlwaysDo([&](velocypack::Slice q,
                     consensus::AgentInterface::WriteMode w) -> write_ret_t {
         CHECK_FAILURE("ToDo", q);
         return fakeWriteResult;
@@ -665,7 +665,7 @@ TEST_F(
 
   Mock<AgentInterface> mockAgent;
   When(Method(mockAgent, write))
-      .AlwaysDo([&](query_t const& q,
+      .AlwaysDo([&](velocypack::Slice q,
                     consensus::AgentInterface::WriteMode w) -> write_ret_t {
         CHECK_FAILURE("ToDo", q);
         return fakeWriteResult;
@@ -713,17 +713,17 @@ TEST_F(MoveShardTest,
 
   Mock<AgentInterface> mockAgent;
   When(Method(mockAgent, write))
-      .AlwaysDo([&](query_t const& q,
+      .AlwaysDo([&](velocypack::Slice q,
                     consensus::AgentInterface::WriteMode w) -> write_ret_t {
         std::string sourceKey = "/arango/Target/ToDo/1";
-        EXPECT_EQ(std::string(q->slice().typeName()), "array");
-        EXPECT_EQ(q->slice().length(), 1);
-        EXPECT_EQ(std::string(q->slice()[0].typeName()), "array");
-        EXPECT_EQ(q->slice()[0].length(), 2);
-        EXPECT_EQ(std::string(q->slice()[0][0].typeName()), "object");
-        EXPECT_EQ(std::string(q->slice()[0][1].typeName()), "object");
+        EXPECT_EQ(std::string(q.typeName()), "array");
+        EXPECT_EQ(q.length(), 1);
+        EXPECT_EQ(std::string(q[0].typeName()), "array");
+        EXPECT_EQ(q[0].length(), 2);
+        EXPECT_EQ(std::string(q[0][0].typeName()), "object");
+        EXPECT_EQ(std::string(q[0][1].typeName()), "object");
 
-        auto writes = q->slice()[0][0];
+        auto writes = q[0][0];
         EXPECT_EQ(std::string(writes.get(sourceKey).typeName()), "object");
         EXPECT_TRUE(std::string(writes.get(sourceKey).get("op").typeName()) ==
                     "string");
@@ -765,7 +765,7 @@ TEST_F(MoveShardTest,
         }
         EXPECT_TRUE(found);
 
-        auto preconditions = q->slice()[0][1];
+        auto preconditions = q[0][1];
         EXPECT_TRUE(preconditions.get("/arango/Target/CleanedServers")
                         .get("old")
                         .toJson() == "[]");
@@ -836,9 +836,9 @@ TEST_F(MoveShardTest, moving_from_a_follower_should_be_possible) {
 
   Mock<AgentInterface> mockAgent;
   When(Method(mockAgent, write))
-      .AlwaysDo([&](query_t const& q,
+      .AlwaysDo([&](velocypack::Slice q,
                     consensus::AgentInterface::WriteMode w) -> write_ret_t {
-        auto writes = q->slice()[0][0];
+        auto writes = q[0][0];
         EXPECT_TRUE(writes
                         .get("/arango/Plan/Collections/" + DATABASE + "/" +
                              COLLECTION + "/shards/" + SHARD)
@@ -981,9 +981,9 @@ TEST_F(
 
   Mock<AgentInterface> mockAgent;
   When(Method(mockAgent, write))
-      .AlwaysDo([&](query_t const& q,
+      .AlwaysDo([&](velocypack::Slice q,
                     consensus::AgentInterface::WriteMode w) -> write_ret_t {
-        auto writes = q->slice()[0][0];
+        auto writes = q[0][0];
         EXPECT_TRUE(writes
                         .get("/arango/Plan/Collections/" + DATABASE + "/" +
                              COLLECTION + "/shards/" + SHARD)
@@ -1331,9 +1331,9 @@ TEST_F(MoveShardTest, if_the_job_is_done_it_should_properly_finish_itself) {
   Mock<AgentInterface> mockAgent;
   When(Method(mockAgent, waitFor)).AlwaysReturn();
   When(Method(mockAgent, write))
-      .Do([&](query_t const& q,
+      .Do([&](velocypack::Slice q,
               consensus::AgentInterface::WriteMode w) -> write_ret_t {
-        auto writes = q->slice()[0][0];
+        auto writes = q[0][0];
         EXPECT_TRUE(
             writes.get("/arango/Target/Pending/1").get("op").copyString() ==
             "delete");
@@ -1351,7 +1351,7 @@ TEST_F(MoveShardTest, if_the_job_is_done_it_should_properly_finish_itself) {
                         .get("op")
                         .isEqualString("read-unlock"));
 
-        auto preconditions = q->slice()[0][1];
+        auto preconditions = q[0][1];
         EXPECT_TRUE(preconditions
                         .get("/arango/Plan/Collections/" + DATABASE + "/" +
                              COLLECTION + "/shards/" + SHARD)
@@ -1656,9 +1656,9 @@ TEST_F(
   Mock<AgentInterface> mockAgent;
   When(Method(mockAgent, waitFor)).AlwaysReturn();
   When(Method(mockAgent, write))
-      .Do([&](query_t const& q,
+      .Do([&](velocypack::Slice q,
               consensus::AgentInterface::WriteMode w) -> write_ret_t {
-        auto writes = q->slice()[0][0];
+        auto writes = q[0][0];
         EXPECT_TRUE(
             writes.get("/arango/Target/Pending/1").get("op").copyString() ==
             "delete");
@@ -1683,7 +1683,7 @@ TEST_F(
                         .isNone());
         EXPECT_TRUE(writes.get("/arango/Supervision/Shards/s100").isNone());
 
-        auto preconditions = q->slice()[0][1];
+        auto preconditions = q[0][1];
         EXPECT_TRUE(preconditions
                         .get("/arango/Plan/Collections/" + DATABASE + "/" +
                              COLLECTION + "/shards/" + SHARD)
@@ -1749,18 +1749,18 @@ TEST_F(MoveShardTest,
   Mock<AgentInterface> mockAgent;
   When(Method(mockAgent, waitFor)).AlwaysReturn();
   When(Method(mockAgent, write))
-      .Do([&](query_t const& q,
+      .Do([&](velocypack::Slice q,
               consensus::AgentInterface::WriteMode w) -> write_ret_t {
-        EXPECT_EQ(q->slice()[0].length(),
+        EXPECT_EQ(q[0].length(),
                   2);  // we always simply override! no preconditions...
-        auto writes = q->slice()[0][0];
+        auto writes = q[0][0];
         EXPECT_TRUE(
             writes.get("/arango/Target/ToDo/1").get("op").copyString() ==
             "delete");
         EXPECT_TRUE(
             std::string(writes.get("/arango/Target/Failed/1").typeName()) ==
             "object");
-        auto precond = q->slice()[0][1];
+        auto precond = q[0][1];
         EXPECT_TRUE(
             precond.get("/arango/Target/ToDo/1").get("oldEmpty").isFalse());
 
@@ -1830,13 +1830,13 @@ TEST_F(
   Mock<AgentInterface> mockAgent;
   When(Method(mockAgent, waitFor)).AlwaysReturn();
   When(Method(mockAgent, write))
-      .Do([&](query_t const& q,
+      .Do([&](velocypack::Slice q,
               consensus::AgentInterface::WriteMode w) -> write_ret_t {
-        auto writes = q->slice()[0][0];
+        auto writes = q[0][0];
         EXPECT_TRUE(
             writes.get("/arango/Target/Pending/1").get("op").copyString() ==
             "delete");
-        EXPECT_EQ(q->slice()[0].length(),
+        EXPECT_EQ(q[0].length(),
                   2);  // Precondition: to Server not leader yet
         EXPECT_TRUE(writes.get("/arango/Supervision/DBServers/" + FREE_SERVER)
                         .get("op")
@@ -1942,9 +1942,9 @@ TEST_F(MoveShardTest,
   Mock<AgentInterface> mockAgent;
   When(Method(mockAgent, waitFor)).AlwaysReturn();
   When(Method(mockAgent, write))
-      .Do([&](query_t const& q,
+      .Do([&](velocypack::Slice q,
               consensus::AgentInterface::WriteMode w) -> write_ret_t {
-        auto writes = q->slice()[0][0];
+        auto writes = q[0][0];
         EXPECT_TRUE(
             std::string(writes
                             .get("/arango/Plan/Collections/" + DATABASE + "/" +
@@ -1967,8 +1967,8 @@ TEST_F(MoveShardTest,
                              COLLECTION + "/shards/" + SHARD)[2]
                         .copyString() == FREE_SERVER);
 
-        EXPECT_EQ(q->slice()[0].length(), 2);
-        auto preconditions = q->slice()[0][1];
+        EXPECT_EQ(q[0].length(), 2);
+        auto preconditions = q[0][1];
         EXPECT_TRUE(
             std::string(preconditions
                             .get("/arango/Plan/Collections/" + DATABASE + "/" +
@@ -2211,13 +2211,13 @@ TEST_F(
   Mock<AgentInterface> mockAgent;
   When(Method(mockAgent, waitFor)).AlwaysReturn();
   When(Method(mockAgent, write))
-      .Do([&](query_t const& q,
+      .Do([&](velocypack::Slice q,
               consensus::AgentInterface::WriteMode w) -> write_ret_t {
-        auto writes = q->slice()[0][0];
+        auto writes = q[0][0];
         EXPECT_TRUE(
             writes.get("/arango/Target/Pending/1").get("op").copyString() ==
             "delete");
-        EXPECT_EQ(q->slice()[0].length(),
+        EXPECT_EQ(q[0].length(),
                   2);  // Precondition: to Server not leader yet
         EXPECT_TRUE(writes.get("/arango/Supervision/DBServers/" + FREE_SERVER)
                         .get("op")
@@ -2321,12 +2321,12 @@ TEST_F(
   Mock<AgentInterface> mockAgent;
   When(Method(mockAgent, waitFor)).AlwaysReturn();
   When(Method(mockAgent, write))
-      .Do([&](query_t const& q,
+      .Do([&](velocypack::Slice q,
               consensus::AgentInterface::WriteMode w) -> write_ret_t {
-        auto writes = q->slice()[0][0];
+        auto writes = q[0][0];
         EXPECT_EQ(writes.get("/arango/Target/Pending/1").get("op").copyString(),
                   "delete");
-        EXPECT_EQ(q->slice()[0].length(),
+        EXPECT_EQ(q[0].length(),
                   2);  // Precondition: to Server not leader yet
         EXPECT_EQ(writes.get("/arango/Supervision/Shards/" + SHARD)
                       .get("op")
@@ -2413,9 +2413,9 @@ TEST_F(
   Mock<AgentInterface> mockAgent;
   When(Method(mockAgent, waitFor)).AlwaysReturn();
   When(Method(mockAgent, write))
-      .Do([&](query_t const& q,
+      .Do([&](velocypack::Slice q,
               consensus::AgentInterface::WriteMode w) -> write_ret_t {
-        auto writes = q->slice()[0][0];
+        auto writes = q[0][0];
         EXPECT_TRUE(
             std::string(writes
                             .get("/arango/Plan/Collections/" + DATABASE + "/" +
@@ -2434,8 +2434,8 @@ TEST_F(
                              COLLECTION + "/shards/" + SHARD)[1]
                         .copyString() == SHARD_FOLLOWER1);
 
-        EXPECT_EQ(q->slice()[0].length(), 2);
-        auto preconditions = q->slice()[0][1];
+        EXPECT_EQ(q[0].length(), 2);
+        auto preconditions = q[0][1];
         EXPECT_TRUE(
             std::string(preconditions
                             .get("/arango/Plan/Collections/" + DATABASE + "/" +
@@ -2539,9 +2539,9 @@ TEST_F(MoveShardTest, if_the_new_leader_took_over_finish_the_job) {
   Mock<AgentInterface> mockAgent;
   When(Method(mockAgent, waitFor)).AlwaysReturn();
   When(Method(mockAgent, write))
-      .Do([&](query_t const& q,
+      .Do([&](velocypack::Slice q,
               consensus::AgentInterface::WriteMode w) -> write_ret_t {
-        auto writes = q->slice()[0][0];
+        auto writes = q[0][0];
 
         EXPECT_EQ(writes.length(), 5);
         EXPECT_TRUE(
@@ -2557,8 +2557,8 @@ TEST_F(MoveShardTest, if_the_new_leader_took_over_finish_the_job) {
                         .get("op")
                         .copyString() == "delete");
 
-        EXPECT_EQ(q->slice()[0].length(), 2);
-        auto preconditions = q->slice()[0][1];
+        EXPECT_EQ(q[0].length(), 2);
+        auto preconditions = q[0][1];
         EXPECT_TRUE(
             std::string(preconditions
                             .get("/arango/Plan/Collections/" + DATABASE + "/" +
@@ -2612,11 +2612,11 @@ TEST_F(MoveShardTest, it_should_be_possible_to_create_a_new_moveshard_job) {
   Mock<AgentInterface> mockAgent;
   When(Method(mockAgent, waitFor)).AlwaysReturn();
   When(Method(mockAgent, write))
-      .Do([&](query_t const& q,
+      .Do([&](velocypack::Slice q,
               consensus::AgentInterface::WriteMode w) -> write_ret_t {
-        EXPECT_EQ(q->slice()[0].length(), 1);
+        EXPECT_EQ(q[0].length(), 1);
 
-        auto writes = q->slice()[0][0];
+        auto writes = q[0][0];
         EXPECT_EQ(writes.length(), 1);
         EXPECT_TRUE(
             std::string(writes.get("/arango/Target/ToDo/1").typeName()) ==
@@ -2745,14 +2745,14 @@ TEST_F(
   Mock<AgentInterface> mockAgent;
   When(Method(mockAgent, waitFor)).AlwaysReturn();
   When(Method(mockAgent, write))
-      .Do([&](query_t const& q,
+      .Do([&](velocypack::Slice q,
               consensus::AgentInterface::WriteMode w) -> write_ret_t {
-        auto writes = q->slice()[0][0];
+        auto writes = q[0][0];
         EXPECT_TRUE(
             writes.get("/arango/Target/Pending/1").get("op").copyString() ==
             "delete");
-        EXPECT_EQ(q->slice()[0].length(), 2);
-        auto preconditions = q->slice()[0][1];
+        EXPECT_EQ(q[0].length(), 2);
+        auto preconditions = q[0][1];
         EXPECT_TRUE(
             preconditions
                 .get("/arango/Plan/Collections/" + DATABASE + "/" + COLLECTION)
@@ -2851,7 +2851,7 @@ TEST_F(MoveShardTest, if_aborting_failed_report_it_back_properly) {
   Mock<AgentInterface> mockAgent;
   When(Method(mockAgent, waitFor)).AlwaysReturn();
   When(Method(mockAgent, write))
-      .Do([&](query_t const& q,
+      .Do([&](velocypack::Slice q,
               consensus::AgentInterface::WriteMode w) -> write_ret_t {
         return {true, "", std::vector<apply_ret_t>{APPLIED},
                 std::vector<index_t>{0}};
@@ -2920,7 +2920,7 @@ TEST_F(MoveShardTest,
   Mock<AgentInterface> mockAgent;
   When(Method(mockAgent, waitFor)).AlwaysReturn();
   When(Method(mockAgent, write))
-      .Do([&](query_t const& q,
+      .Do([&](velocypack::Slice q,
               consensus::AgentInterface::WriteMode w) -> write_ret_t {
         return {false, "", std::vector<apply_ret_t>{APPLIED},
                 std::vector<index_t>{1}};
@@ -2988,7 +2988,7 @@ TEST_F(MoveShardTest, trying_to_abort_a_finished_should_result_in_failure) {
   Mock<AgentInterface> mockAgent;
   When(Method(mockAgent, waitFor)).AlwaysReturn();
   When(Method(mockAgent, write))
-      .Do([&](query_t const& q,
+      .Do([&](velocypack::Slice q,
               consensus::AgentInterface::WriteMode w) -> write_ret_t {
         return {false, "", std::vector<apply_ret_t>{APPLIED},
                 std::vector<index_t>{1}};
@@ -3186,11 +3186,11 @@ TEST_F(
   Mock<AgentInterface> mockAgent;
   When(Method(mockAgent, waitFor)).AlwaysReturn();
   When(Method(mockAgent, write))
-      .Do([&](query_t const& q,
+      .Do([&](velocypack::Slice q,
               consensus::AgentInterface::WriteMode w) -> write_ret_t {
-        EXPECT_EQ(q->slice()[0].length(), 2);
+        EXPECT_EQ(q[0].length(), 2);
 
-        auto writes = q->slice()[0][0];
+        auto writes = q[0][0];
         EXPECT_TRUE(
             std::string(writes
                             .get("/arango/Plan/Collections/" + DATABASE + "/" +
@@ -3213,7 +3213,7 @@ TEST_F(
                              COLLECTION + "/shards/" + SHARD)[2]
                         .copyString() == SHARD_LEADER);
 
-        auto preconditions = q->slice()[0][1];
+        auto preconditions = q[0][1];
         EXPECT_TRUE(
             std::string(preconditions
                             .get("/arango/Plan/Collections/" + DATABASE + "/" +

--- a/tests/Agency/RemoveFollowerTest.cpp
+++ b/tests/Agency/RemoveFollowerTest.cpp
@@ -130,20 +130,20 @@ TEST_F(RemoveFollowerTest, creating_a_job_should_create_a_job_in_todo) {
   Mock<AgentInterface> mockAgent;
 
   When(Method(mockAgent, write))
-      .AlwaysDo([&](query_t const& q,
+      .AlwaysDo([&](velocypack::Slice q,
                     consensus::AgentInterface::WriteMode w) -> write_ret_t {
         auto expectedJobKey = "/arango/Target/ToDo/" + jobId;
-        EXPECT_EQ(typeName(q->slice()), "array");
-        EXPECT_EQ(q->slice().length(), 1);
-        EXPECT_EQ(typeName(q->slice()[0]), "array");
-        EXPECT_EQ(q->slice()[0].length(),
+        EXPECT_EQ(typeName(q), "array");
+        EXPECT_EQ(q.length(), 1);
+        EXPECT_EQ(typeName(q[0]), "array");
+        EXPECT_EQ(q[0].length(),
                   1);  // we always simply override! no preconditions...
-        EXPECT_EQ(typeName(q->slice()[0][0]), "object");
-        EXPECT_EQ(q->slice()[0][0].length(),
+        EXPECT_EQ(typeName(q[0][0]), "object");
+        EXPECT_EQ(q[0][0].length(),
                   1);  // should ONLY do an entry in todo
-        EXPECT_EQ(typeName(q->slice()[0][0].get(expectedJobKey)), "object");
+        EXPECT_EQ(typeName(q[0][0].get(expectedJobKey)), "object");
 
-        auto job = q->slice()[0][0].get(expectedJobKey);
+        auto job = q[0][0].get(expectedJobKey);
         EXPECT_EQ(typeName(job.get("creator")), "string");
         EXPECT_EQ(typeName(job.get("type")), "string");
         EXPECT_EQ(job.get("type").copyString(), "removeFollower");
@@ -203,16 +203,16 @@ TEST_F(RemoveFollowerTest,
 
   Mock<AgentInterface> mockAgent;
   When(Method(mockAgent, write))
-      .AlwaysDo([&](query_t const& q,
+      .AlwaysDo([&](velocypack::Slice q,
                     consensus::AgentInterface::WriteMode w) -> write_ret_t {
-        EXPECT_EQ(typeName(q->slice()), "array");
-        EXPECT_EQ(q->slice().length(), 1);
-        EXPECT_EQ(typeName(q->slice()[0]), "array");
+        EXPECT_EQ(typeName(q), "array");
+        EXPECT_EQ(q.length(), 1);
+        EXPECT_EQ(typeName(q[0]), "array");
         // we always simply override! no preconditions...
-        EXPECT_EQ(q->slice()[0].length(), 1);
-        EXPECT_EQ(typeName(q->slice()[0][0]), "object");
+        EXPECT_EQ(q[0].length(), 1);
+        EXPECT_EQ(typeName(q[0][0]), "object");
 
-        auto writes = q->slice()[0][0];
+        auto writes = q[0][0];
         EXPECT_EQ(typeName(writes.get("/arango/Target/ToDo/1")), "object");
         EXPECT_TRUE(typeName(writes.get("/arango/Target/ToDo/1").get("op")) ==
                     "string");
@@ -263,16 +263,16 @@ TEST_F(
 
   Mock<AgentInterface> mockAgent;
   When(Method(mockAgent, write))
-      .AlwaysDo([&](query_t const& q,
+      .AlwaysDo([&](velocypack::Slice q,
                     consensus::AgentInterface::WriteMode w) -> write_ret_t {
-        EXPECT_EQ(typeName(q->slice()), "array");
-        EXPECT_EQ(q->slice().length(), 1);
-        EXPECT_EQ(typeName(q->slice()[0]), "array");
-        EXPECT_EQ(q->slice()[0].length(),
+        EXPECT_EQ(typeName(q), "array");
+        EXPECT_EQ(q.length(), 1);
+        EXPECT_EQ(typeName(q[0]), "array");
+        EXPECT_EQ(q[0].length(),
                   1);  // we always simply override! no preconditions...
-        EXPECT_EQ(typeName(q->slice()[0][0]), "object");
+        EXPECT_EQ(typeName(q[0][0]), "object");
 
-        auto writes = q->slice()[0][0];
+        auto writes = q[0][0];
         EXPECT_EQ(typeName(writes.get("/arango/Target/ToDo/1")), "object");
         EXPECT_TRUE(typeName(writes.get("/arango/Target/ToDo/1").get("op")) ==
                     "string");
@@ -329,16 +329,16 @@ TEST_F(RemoveFollowerTest,
 
   Mock<AgentInterface> mockAgent;
   When(Method(mockAgent, write))
-      .AlwaysDo([&](query_t const& q,
+      .AlwaysDo([&](velocypack::Slice q,
                     consensus::AgentInterface::WriteMode w) -> write_ret_t {
-        EXPECT_EQ(typeName(q->slice()), "array");
-        EXPECT_EQ(q->slice().length(), 1);
-        EXPECT_EQ(typeName(q->slice()[0]), "array");
-        EXPECT_EQ(q->slice()[0].length(),
+        EXPECT_EQ(typeName(q), "array");
+        EXPECT_EQ(q.length(), 1);
+        EXPECT_EQ(typeName(q[0]), "array");
+        EXPECT_EQ(q[0].length(),
                   1);  // we always simply override! no preconditions...
-        EXPECT_EQ(typeName(q->slice()[0][0]), "object");
+        EXPECT_EQ(typeName(q[0][0]), "object");
 
-        auto writes = q->slice()[0][0];
+        auto writes = q[0][0];
         EXPECT_EQ(typeName(writes.get("/arango/Target/ToDo/1")), "object");
         EXPECT_TRUE(typeName(writes.get("/arango/Target/ToDo/1").get("op")) ==
                     "string");
@@ -388,15 +388,15 @@ TEST_F(
 
   Mock<AgentInterface> mockAgent;
   When(Method(mockAgent, write))
-      .AlwaysDo([&](query_t const& q,
+      .AlwaysDo([&](velocypack::Slice q,
                     consensus::AgentInterface::WriteMode w) -> write_ret_t {
-        EXPECT_EQ(typeName(q->slice()), "array");
-        EXPECT_EQ(q->slice().length(), 1);
-        EXPECT_EQ(typeName(q->slice()[0]), "array");
-        EXPECT_EQ(q->slice()[0].length(), 2);  // precondition
-        EXPECT_EQ(typeName(q->slice()[0][0]), "object");
+        EXPECT_EQ(typeName(q), "array");
+        EXPECT_EQ(q.length(), 1);
+        EXPECT_EQ(typeName(q[0]), "array");
+        EXPECT_EQ(q[0].length(), 2);  // precondition
+        EXPECT_EQ(typeName(q[0][0]), "object");
 
-        auto writes = q->slice()[0][0];
+        auto writes = q[0][0];
         EXPECT_EQ(typeName(writes.get("/arango/Target/ToDo/1")), "object");
         EXPECT_TRUE(typeName(writes.get("/arango/Target/ToDo/1").get("op")) ==
                     "string");
@@ -409,7 +409,7 @@ TEST_F(
                   COLLECTION);
         EXPECT_EQ(typeName(writes.get("/arango/Target/Failed/1")), "none");
 
-        auto precond = q->slice()[0][1];
+        auto precond = q[0][1];
         EXPECT_EQ(typeName(precond), "object");
         EXPECT_TRUE(typeName(precond.get(
                         "/arango/Supervision/Health/follower1/Status")) ==
@@ -452,16 +452,16 @@ TEST_F(RemoveFollowerTest, all_good_should_remove_folower) {
 
   Mock<AgentInterface> mockAgent;
   When(Method(mockAgent, write))
-      .AlwaysDo([&](query_t const& q,
+      .AlwaysDo([&](velocypack::Slice q,
                     consensus::AgentInterface::WriteMode w) -> write_ret_t {
-        EXPECT_EQ(typeName(q->slice()), "array");
-        EXPECT_EQ(q->slice().length(), 1);
-        EXPECT_EQ(typeName(q->slice()[0]), "array");
-        EXPECT_EQ(q->slice()[0].length(),
+        EXPECT_EQ(typeName(q), "array");
+        EXPECT_EQ(q.length(), 1);
+        EXPECT_EQ(typeName(q[0]), "array");
+        EXPECT_EQ(q[0].length(),
                   2);  // we always simply override! no preconditions...
-        EXPECT_EQ(typeName(q->slice()[0][0]), "object");
+        EXPECT_EQ(typeName(q[0][0]), "object");
 
-        auto writes = q->slice()[0][0];
+        auto writes = q[0][0];
         EXPECT_EQ(typeName(writes.get("/arango/Target/ToDo/1")), "object");
         EXPECT_TRUE(typeName(writes.get("/arango/Target/ToDo/1").get("op")) ==
                     "string");
@@ -528,16 +528,16 @@ TEST(RemoveFollowerLargeTest, an_agency_with_12_dbservers) {
 
   Mock<AgentInterface> mockAgent;
   When(Method(mockAgent, write))
-      .AlwaysDo([&](query_t const& q,
+      .AlwaysDo([&](velocypack::Slice q,
                     consensus::AgentInterface::WriteMode w) -> write_ret_t {
-        EXPECT_EQ(typeName(q->slice()), "array");
-        EXPECT_EQ(q->slice().length(), 1);
-        EXPECT_EQ(typeName(q->slice()[0]), "array");
-        EXPECT_EQ(q->slice()[0].length(),
+        EXPECT_EQ(typeName(q), "array");
+        EXPECT_EQ(q.length(), 1);
+        EXPECT_EQ(typeName(q[0]), "array");
+        EXPECT_EQ(q[0].length(),
                   2);  // we always simply override! no preconditions...
-        EXPECT_EQ(typeName(q->slice()[0][0]), "object");
+        EXPECT_EQ(typeName(q[0][0]), "object");
 
-        Slice writes = q->slice()[0][0];
+        Slice writes = q[0][0];
         EXPECT_EQ(typeName(writes.get("/arango/Target/ToDo/1")), "object");
         EXPECT_TRUE(typeName(writes.get("/arango/Target/ToDo/1").get("op")) ==
                     "string");

--- a/tests/Agency/StoreTestAPI.cpp
+++ b/tests/Agency/StoreTestAPI.cpp
@@ -22,6 +22,7 @@
 /// @author Max Neunhoeffer
 /// @author Copyright 2021, ArangoDB GmbH, Cologne, Germany
 ////////////////////////////////////////////////////////////////////////////////
+
 #include "gtest/gtest.h"
 
 #include "Agency/Store.h"
@@ -47,11 +48,11 @@ class StoreTestAPI : public ::testing::Test {
 
   std::shared_ptr<VPackBuilder> read(std::string const& json) {
     try {
-      consensus::query_t q{VPackParser::fromJson(json)};
+      auto q{VPackParser::fromJson(json)};
       auto result = std::make_shared<VPackBuilder>();
       _store.readMultiple(q->slice(), *result);
       return result;
-    } catch (std::exception& ex) {
+    } catch (std::exception const& ex) {
       throw std::runtime_error(std::string(ex.what()) +
                                " while trying to read " + json);
     }
@@ -61,7 +62,7 @@ class StoreTestAPI : public ::testing::Test {
     try {
       auto q = VPackParser::fromJson(json);
       return _store.applyTransactions(q->slice());
-    } catch (std::exception& err) {
+    } catch (std::exception const& err) {
       throw std::runtime_error(std::string(err.what()) + " while parsing " +
                                json);
     }
@@ -100,7 +101,7 @@ class StoreTestAPI : public ::testing::Test {
     try {
       auto q = VPackParser::fromJson(json);
       return _store.applyTransactions(q->slice());
-    } catch (std::exception& ex) {
+    } catch (std::exception const& ex) {
       throw std::runtime_error(std::string(ex.what()) +
                                ", transact failed processing " + json);
     }
@@ -116,7 +117,7 @@ class StoreTestAPI : public ::testing::Test {
       if (!applied_all) {
         throw std::runtime_error("This didn't work: " + json);
       }
-    } catch (std::exception& ex) {
+    } catch (std::exception const& ex) {
       throw std::runtime_error(std::string(ex.what()) + " processing " + json);
     }
   }

--- a/tests/Agency/SupervisionTest.cpp
+++ b/tests/Agency/SupervisionTest.cpp
@@ -42,8 +42,9 @@ std::vector<std::string> servers{"XXX-XXX-XXX", "XXX-XXX-XXY"};
 
 TEST(SupervisionTest, checking_for_the_delete_transaction_0_servers) {
   std::vector<std::string> todelete;
-  auto const& transaction = removeTransactionBuilder(todelete);
-  auto const& slice = transaction->slice();
+  velocypack::Builder builder;
+  Supervision::removeTransactionBuilder(builder, todelete);
+  auto slice = builder.slice();
 
   ASSERT_TRUE(slice.isArray());
   ASSERT_EQ(slice.length(), 1);
@@ -55,8 +56,9 @@ TEST(SupervisionTest, checking_for_the_delete_transaction_0_servers) {
 
 TEST(SupervisionTest, checking_for_the_delete_transaction_1_server) {
   std::vector<std::string> todelete{servers[0]};
-  auto const& transaction = removeTransactionBuilder(todelete);
-  auto const& slice = transaction->slice();
+  velocypack::Builder builder;
+  Supervision::removeTransactionBuilder(builder, todelete);
+  auto slice = builder.slice();
 
   ASSERT_TRUE(slice.isArray());
   ASSERT_EQ(slice.length(), 1);
@@ -76,8 +78,9 @@ TEST(SupervisionTest, checking_for_the_delete_transaction_1_server) {
 
 TEST(SupervisionTest, checking_for_the_delete_transaction_2_servers) {
   std::vector<std::string> todelete = servers;
-  auto const& transaction = removeTransactionBuilder(todelete);
-  auto const& slice = transaction->slice();
+  velocypack::Builder builder;
+  Supervision::removeTransactionBuilder(builder, todelete);
+  auto slice = builder.slice();
 
   ASSERT_TRUE(slice.isArray());
   ASSERT_EQ(slice.length(), 1);


### PR DESCRIPTION
### Scope & Purpose

improve internal Agent APIs

* do not require shared_ptrs in Agent write operation APIs. this helps avoiding unnecessary memory allocations when using these APIs.
* move inline functions from Job.h into Job.cpp, to make the header more compact and reduce its dependencies. this also reduces redundant code at the call sites.
* add missing includes to files

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [x] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: *(Please link PR)*
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 