### PR TITLE
Update fmt to version 9.1.0

### DIFF
--- a/arangod/VocBase/LogicalCollection.cpp
+++ b/arangod/VocBase/LogicalCollection.cpp
@@ -1303,7 +1303,7 @@ auto LogicalCollection::getDocumentStateLeader() -> std::shared_ptr<
                      "Replicated state {} is not available as leader, accessed "
                      "from {}/{}. Status is {}.",
                      shardIdToStateId(name()), vocbase().name(), name(),
-                     *status);
+                     fmt::streamed(*status));
   }
 
   auto leader = stateMachine->getLeader();


### PR DESCRIPTION
### Scope & Purpose

Update fmt to 9.1.0; 

This requires a small fix in the LogicalCollection code: automatic use of `ostream<<` for `fmt` has been deprecated because of problems with ODR violations.

Two options exist: either explicit formatter specialisation with a helper struct `ostream_formatter` or using `fmt::streamed`; the latter seemed less intrusive for now.
