### PR TITLE
Inspector formatting (pedestrian #[derive(Debug)])

### DIFF
--- a/lib/Inspection/Format.h
+++ b/lib/Inspection/Format.h
@@ -73,8 +73,8 @@ struct inspection_formatter : fmt::formatter<VPackSlice> {
            typename Inspector = VPackSaveInspector<NoContext>>
   requires detail::HasInspectOverload<T, Inspector>::value auto format(
       const T& value, FormatContext& ctx) const -> decltype(ctx.out()) {
-    auto builder = arangodb::velocypack::serialize(value);
-    return fmt::formatter<VPackSlice>::format(builder->slice(), ctx);
+    auto sharedSlice = arangodb::velocypack::serialize(value);
+    return fmt::formatter<VPackSlice>::format(sharedSlice.slice(), ctx);
   }
 };
 }  // namespace arangodb::inspection

--- a/lib/Inspection/Format.h
+++ b/lib/Inspection/Format.h
@@ -1,0 +1,80 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2022 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Markus Pfeiffer
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include <fmt/core.h>
+#include <fmt/format.h>
+
+#include <Inspection/VPack.h>
+#include "Inspection/VPackSaveInspector.h"
+#include "Inspection/detail/traits.h"
+
+template<>
+struct fmt::formatter<VPackBuilder> {
+  void set_debug_format() = delete;
+
+  enum class Presentation { NotPretty, Pretty };
+  // Presentation format: 'u' - use toJson, 'p' - use toString.
+  Presentation presentation = Presentation::NotPretty;
+
+  constexpr auto parse(fmt::format_parse_context& ctx)
+      -> decltype(ctx.begin()) {
+    auto it = ctx.begin(), end = ctx.end();
+    if (it != end) {
+      if (*it == 'u') {
+        presentation = Presentation::NotPretty;
+        it++;
+      } else if (*it == 'p') {
+        presentation = Presentation::Pretty;
+        it++;
+      }
+    }
+    if (it != end && *it != '}') throw fmt::format_error("invalid format");
+    return it;
+  }
+
+  template<typename FormatContext>
+  auto format(VPackBuilder const& builder, FormatContext& ctx) const
+      -> decltype(ctx.out()) {
+    switch (presentation) {
+      case Presentation::NotPretty:
+        return fmt::format_to(ctx.out(), "{}", builder.toJson());
+      case Presentation::Pretty:
+        return fmt::format_to(ctx.out(), "{}", builder.toString());
+    }
+  }
+};
+
+namespace arangodb::inspection {
+// Formats an object of type T that has an overloaded inspector.
+struct inspection_formatter : fmt::formatter<VPackBuilder> {
+  template<typename T, typename FormatContext,
+           typename Inspector = VPackSaveInspector<NoContext>>
+  requires detail::HasInspectOverload<T, Inspector>::value auto format(
+      const T& value, FormatContext& ctx) const -> decltype(ctx.out()) {
+    auto builder = arangodb::velocypack::serialize(value);
+    return fmt::formatter<VPackBuilder>::format(*builder, ctx);
+  }
+};
+}  // namespace arangodb::inspection

--- a/lib/Inspection/Format.h
+++ b/lib/Inspection/Format.h
@@ -58,11 +58,12 @@ struct fmt::formatter<VPackSlice> {
   auto format(VPackSlice const& slice, FormatContext& ctx) const
       -> decltype(ctx.out()) {
     switch (presentation) {
-      case Presentation::NotPretty:
-        return fmt::format_to(ctx.out(), "{}", slice.toJson());
       case Presentation::Pretty:
         return fmt::format_to(ctx.out(), "{}", slice.toString());
-    }
+      case Presentation::NotPretty:
+      default:
+        return fmt::format_to(ctx.out(), "{}", slice.toJson());
+     }
   }
 };
 

--- a/lib/Inspection/Format.h
+++ b/lib/Inspection/Format.h
@@ -63,7 +63,7 @@ struct fmt::formatter<VPackSlice> {
       case Presentation::NotPretty:
       default:
         return fmt::format_to(ctx.out(), "{}", slice.toJson());
-     }
+    }
   }
 };
 

--- a/lib/Inspection/Format.h
+++ b/lib/Inspection/Format.h
@@ -26,12 +26,12 @@
 #include <fmt/core.h>
 #include <fmt/format.h>
 
-#include <Inspection/VPack.h>
 #include "Inspection/VPackSaveInspector.h"
 #include "Inspection/detail/traits.h"
+#include <Inspection/VPack.h>
 
 template<>
-struct fmt::formatter<VPackBuilder> {
+struct fmt::formatter<VPackSlice> {
   void set_debug_format() = delete;
 
   enum class Presentation { NotPretty, Pretty };
@@ -55,26 +55,26 @@ struct fmt::formatter<VPackBuilder> {
   }
 
   template<typename FormatContext>
-  auto format(VPackBuilder const& builder, FormatContext& ctx) const
+  auto format(VPackSlice const& slice, FormatContext& ctx) const
       -> decltype(ctx.out()) {
     switch (presentation) {
       case Presentation::NotPretty:
-        return fmt::format_to(ctx.out(), "{}", builder.toJson());
+        return fmt::format_to(ctx.out(), "{}", slice.toJson());
       case Presentation::Pretty:
-        return fmt::format_to(ctx.out(), "{}", builder.toString());
+        return fmt::format_to(ctx.out(), "{}", slice.toString());
     }
   }
 };
 
 namespace arangodb::inspection {
 // Formats an object of type T that has an overloaded inspector.
-struct inspection_formatter : fmt::formatter<VPackBuilder> {
+struct inspection_formatter : fmt::formatter<VPackSlice> {
   template<typename T, typename FormatContext,
            typename Inspector = VPackSaveInspector<NoContext>>
   requires detail::HasInspectOverload<T, Inspector>::value auto format(
       const T& value, FormatContext& ctx) const -> decltype(ctx.out()) {
     auto builder = arangodb::velocypack::serialize(value);
-    return fmt::formatter<VPackBuilder>::format(*builder, ctx);
+    return fmt::formatter<VPackSlice>::format(builder->slice(), ctx);
   }
 };
 }  // namespace arangodb::inspection

--- a/lib/Inspection/VPack.h
+++ b/lib/Inspection/VPack.h
@@ -43,7 +43,7 @@ void serialize(Builder& builder, T& value) {
 }
 
 template<class T>
-auto serialize(T& value) -> std::shared_ptr<Builder> {
+[[nodiscard]] auto serialize(T& value) -> std::shared_ptr<Builder> {
   auto builder = std::make_shared<Builder>();
   serialize(*builder, value);
   return builder;

--- a/lib/Inspection/VPack.h
+++ b/lib/Inspection/VPack.h
@@ -43,10 +43,10 @@ void serialize(Builder& builder, T& value) {
 }
 
 template<class T>
-[[nodiscard]] auto serialize(T& value) -> std::shared_ptr<Builder> {
-  auto builder = std::make_shared<Builder>();
-  serialize(*builder, value);
-  return builder;
+[[nodiscard]] auto serialize(T& value) -> SharedSlice {
+  auto builder = Builder();
+  serialize(builder, value);
+  return builder.sharedSlice();
 }
 
 namespace detail {

--- a/lib/Inspection/VPack.h
+++ b/lib/Inspection/VPack.h
@@ -46,7 +46,7 @@ template<class T>
 [[nodiscard]] auto serialize(T& value) -> SharedSlice {
   auto builder = Builder();
   serialize(builder, value);
-  return builder.sharedSlice();
+  return std::move(builder).sharedSlice();
 }
 
 namespace detail {

--- a/lib/Inspection/VPack.h
+++ b/lib/Inspection/VPack.h
@@ -42,6 +42,13 @@ void serialize(Builder& builder, T& value) {
   }
 }
 
+template<class T>
+auto serialize(T& value) -> std::shared_ptr<Builder> {
+  auto builder = std::make_shared<Builder>();
+  serialize(*builder, value);
+  return builder;
+}
+
 namespace detail {
 template<class Inspector, class T>
 void deserialize(Inspector& inspector, T& result) {

--- a/tests/Basics/InspectionTest.cpp
+++ b/tests/Basics/InspectionTest.cpp
@@ -2010,14 +2010,13 @@ TEST_F(VPackInspectionTest, serialize) {
 
 TEST_F(VPackInspectionTest, serialize_to_builder) {
   Dummy const d{.i = 42, .d = 123.456, .b = true, .s = "cheese"};
-  auto builder = arangodb::velocypack::serialize(d);
-  auto slice = builder->slice();
+  auto sharedSlice = arangodb::velocypack::serialize(d);
 
-  ASSERT_TRUE(slice.isObject());
-  EXPECT_EQ(d.i, slice["i"].getInt());
-  EXPECT_EQ(d.d, slice["d"].getDouble());
-  EXPECT_EQ(d.b, slice["b"].getBool());
-  EXPECT_EQ(d.s, slice["s"].copyString());
+  ASSERT_TRUE(sharedSlice.isObject());
+  EXPECT_EQ(d.i, sharedSlice["i"].getInt());
+  EXPECT_EQ(d.d, sharedSlice["d"].getDouble());
+  EXPECT_EQ(d.b, sharedSlice["b"].getBool());
+  EXPECT_EQ(d.s, sharedSlice["s"].copyString());
 }
 
 TEST_F(VPackInspectionTest, formatter) {
@@ -2034,8 +2033,8 @@ TEST_F(VPackInspectionTest, formatter) {
 
   auto pretty = fmt::format("My name is {:p}", d);
   EXPECT_EQ(pretty,
-            "My name is {\n  \"b\" : true,\n  \"d\" : 123.456,\n  \"i\" : "
-            "42,\n  \"s\" : \"cheese\"\n}");
+            "My name is {\n  \"i\" : 42,\n  \"d\" : 123.456,\n  \"b\" : "
+            "true,\n  \"s\" : \"cheese\"\n}");
 }
 
 TEST_F(VPackInspectionTest, deserialize) {

--- a/tests/Basics/InspectionTest.cpp
+++ b/tests/Basics/InspectionTest.cpp
@@ -2001,6 +2001,18 @@ TEST_F(VPackInspectionTest, serialize) {
   EXPECT_EQ(d.s, slice["s"].copyString());
 }
 
+TEST_F(VPackInspectionTest, serialize_to_builder) {
+  Dummy const d{.i = 42, .d = 123.456, .b = true, .s = "cheese"};
+  auto builder = arangodb::velocypack::serialize(d);
+  auto slice = builder->slice();
+
+  ASSERT_TRUE(slice.isObject());
+  EXPECT_EQ(d.i, slice["i"].getInt());
+  EXPECT_EQ(d.d, slice["d"].getDouble());
+  EXPECT_EQ(d.b, slice["b"].getBool());
+  EXPECT_EQ(d.s, slice["s"].copyString());
+}
+
 TEST_F(VPackInspectionTest, deserialize) {
   velocypack::Builder builder;
   builder.openObject();


### PR DESCRIPTION
### Scope & Purpose

* Adds `auto serialize(T& v) -> SharedSlice` for inspectable `T`.
* Adds `inspection_formatter` that allows explicit specialisation of `fmt::formatter` for types that are inspectable. This is inspired by the `ostream_formatter` from `fmt 9.1.0`.
* Requires `fmt-9.1.0` which is added in #17123 

The helper formats using the added `serialize` function and either `toJson` (not pretty) or `toString` (prettier) using format strings `{:u}` and `{:p}`.
```
struct Foo { uint32_t v; };

template<typename Inspector>
auto inspect(Inspector f, Foo& v) {
  return f.object(v).fields(f.field("v", v.v));
}

template<>
struct fmt::formatter<Foo> : arangodb::inspection::inspection_formatter {};

fmt::print("A Foo: {}", Foo{.v = 15});
```

It is worth keeping in mind that every serialisation will create a VPackBuilder and serialise the whole object into it before printing, which might be quite inefficient. Future iterations could use a special FormattingInspector.
