### PR TITLE
[SEARCH-396] Use warnings instead of errors for search-alias views

### DIFF
--- a/arangod/Aql/IResearchViewExecutor.cpp
+++ b/arangod/Aql/IResearchViewExecutor.cpp
@@ -553,12 +553,12 @@ IResearchViewExecutorBase<Impl, ExecutionTraits>::IResearchViewExecutorBase(
         vocbase.server().getFeature<IResearchAnalyzerFeature>();
     TRI_ASSERT(_trx.state());
     auto const& revision = _trx.state()->analyzersRevision();
-    auto getAnalyzer = [&](std::string_view shortName) {
+    auto getAnalyzer = [&](std::string_view shortName) -> FieldMeta::Analyzer {
       auto analyzer = analyzerFeature.get(shortName, vocbase, revision);
       if (!analyzer) {
-        return emptyAnalyzer();
+        return makeEmptyAnalyzer();
       }
-      return FieldMeta::Analyzer{std::move(analyzer), std::string{shortName}};
+      return {std::move(analyzer), std::string{shortName}};
     };
     _provider = meta->createProvider(getAnalyzer);
   }
@@ -742,11 +742,12 @@ void IResearchViewExecutorBase<Impl, ExecutionTraits>::reset() {
 
     // The analyzer is referenced in the FilterContext and used during the
     // following ::makeFilter() call, so can't be a temporary.
+    auto const emptyAnalyzer = makeEmptyAnalyzer();
     AnalyzerProvider* fieldAnalyzerProvider = nullptr;
     auto const* contextAnalyzer = &FieldMeta::identity();
     if (!infos().isOldMangling()) {
       fieldAnalyzerProvider = &_provider;
-      contextAnalyzer = &emptyAnalyzer();
+      contextAnalyzer = &emptyAnalyzer;
     }
     FilterContext const filterCtx{
         .fieldAnalyzerProvider = fieldAnalyzerProvider,

--- a/arangod/Aql/IResearchViewExecutor.cpp
+++ b/arangod/Aql/IResearchViewExecutor.cpp
@@ -742,9 +742,8 @@ void IResearchViewExecutorBase<Impl, ExecutionTraits>::reset() {
 
     // The analyzer is referenced in the FilterContext and used during the
     // following ::makeFilter() call, so can't be a temporary.
-    FieldMeta::Analyzer const identity{IResearchAnalyzerFeature::identity()};
     AnalyzerProvider* fieldAnalyzerProvider = nullptr;
-    auto const* contextAnalyzer = &identity;
+    auto const* contextAnalyzer = &FieldMeta::identity();
     if (!infos().isOldMangling()) {
       fieldAnalyzerProvider = &_provider;
       contextAnalyzer = &emptyAnalyzer();

--- a/arangod/Aql/IResearchViewOptimizerRules.cpp
+++ b/arangod/Aql/IResearchViewOptimizerRules.cpp
@@ -240,8 +240,7 @@ bool optimizeSearchCondition(IResearchViewNode& viewNode,
 
     // The analyzer is referenced in the FilterContext and used during the
     // following ::makeFilter() call, so may not be a temporary.
-    FieldMeta::Analyzer analyzer{IResearchAnalyzerFeature::identity()};
-    FilterContext const filterCtx{.contextAnalyzer = analyzer};
+    FilterContext const filterCtx{.contextAnalyzer = FieldMeta::identity()};
 
     auto filterCreated =
         FilterFactory::filter(nullptr, ctx, filterCtx, *searchCondition.root());

--- a/arangod/IResearch/IResearchFilterFactory.cpp
+++ b/arangod/IResearch/IResearchFilterFactory.cpp
@@ -104,25 +104,33 @@ Result fromFuncMinHashMatch(char const* funcName, irs::boolean_filter* filter,
                             aql::AstNode const& args);
 
 FieldMeta::Analyzer const& FilterContext::fieldAnalyzer(
-    std::string_view name, Result& r) const noexcept {
+    std::string_view name, aql::ExpressionContext* ctx) const noexcept {
+  // FIXME(gnusi): refactor this function
+
   if (!fieldAnalyzerProvider) {
-    if (ADB_UNLIKELY(!contextAnalyzer)) {
-      TRI_ASSERT(false);
-      r = {TRI_ERROR_INTERNAL, "Malformed search/filter context"};
-    }
+    // Only possible with ArangoSearch view
     return contextAnalyzer;
   }
+
+  auto registerWarning = [ctx](std::string_view error) {
+    if (ctx) {
+      ctx->registerWarning(TRI_ERROR_BAD_PARAMETER, error);
+    }
+  };
+
   auto const& analyzer = (*fieldAnalyzerProvider)(name);
+  if (!analyzer) {
+    // Only possible with SearchAlias views
+    registerWarning(absl::StrCat("Analyzer for field '", name, "' isn't set"));
+    return FieldMeta::identity();
+  }
   if (ADB_UNLIKELY(contextAnalyzer &&
                    contextAnalyzer._pool != analyzer._pool)) {
-    r = {TRI_ERROR_BAD_PARAMETER,
-         absl::StrCat("Context analyzer '", contextAnalyzer->name(),
-                      "' doesn't match field '", name, "' analyzer '",
-                      analyzer ? analyzer->name() : "", "'")};
-  }
-  if (!analyzer) {
-    r = {TRI_ERROR_BAD_PARAMETER,
-         absl::StrCat("Analyzer for field '", name, "' isn't set")};
+    // Only possible with SearchAlias views
+    registerWarning(absl::StrCat("Context analyzer '", contextAnalyzer->name(),
+                                 "' doesn't match field '", name,
+                                 "' analyzer '",
+                                 analyzer ? analyzer->name() : "", "'"));
   }
   return analyzer;
 }
@@ -293,12 +301,10 @@ Result byTerm(irs::by_term* filter, std::string&& name,
           return {TRI_ERROR_BAD_PARAMETER, "could not get string value"};
         }
 
-        Result r;
-        auto& analyzer = filterCtx.fieldAnalyzer(name, r);
-        if (!r.ok()) {
-          return r;
+        auto& analyzer = filterCtx.fieldAnalyzer(name, ctx.ctx);
+        if (!analyzer) {
+          return {TRI_ERROR_INTERNAL, "Malformed search/filter context"};
         }
-        TRI_ASSERT(analyzer);
 
         kludge::mangleField(name, ctx.isOldMangling, analyzer);
         *filter->mutable_field() = std::move(name);
@@ -479,12 +485,10 @@ Result byRange(irs::boolean_filter* filter, aql::AstNode const& attributeNode,
           return {TRI_ERROR_BAD_PARAMETER, "failed to get string value"};
         }
 
-        Result r;
-        auto& analyzer = filterCtx.fieldAnalyzer(name, r);
-        if (!r.ok()) {
-          return r;
+        auto& analyzer = filterCtx.fieldAnalyzer(name, ctx.ctx);
+        if (!analyzer) {
+          return {TRI_ERROR_INTERNAL, "Malformed search/filter context"};
         }
-        TRI_ASSERT(analyzer);
 
         auto& range = filter->add<irs::by_range>();
         kludge::mangleField(name, ctx.isOldMangling, analyzer);
@@ -644,12 +648,10 @@ Result byRange(irs::boolean_filter* filter, std::string name,
           return {TRI_ERROR_BAD_PARAMETER, "could not parse string value"};
         }
 
-        Result r;
-        auto& analyzer = filterCtx.fieldAnalyzer(name, r);
-        if (!r.ok()) {
-          return r;
+        auto& analyzer = filterCtx.fieldAnalyzer(name, ctx.ctx);
+        if (!analyzer) {
+          return {TRI_ERROR_INTERNAL, "Malformed search/filter context"};
         }
-        TRI_ASSERT(analyzer);
 
         irs::by_range* range{nullptr};
         if (ctx.isSearchQuery || Min) {
@@ -819,12 +821,10 @@ Result fromFuncGeoInRange(char const* funcName, irs::boolean_filter* filter,
     return error::failedToGenerateName(funcName, fieldNodeIdx);
   }
   if (filter) {
-    Result r;
-    auto& analyzer = filterCtx.fieldAnalyzer(name, r);
-    if (!r.ok()) {
-      return r;
+    auto& analyzer = filterCtx.fieldAnalyzer(name, ctx.ctx);
+    if (!analyzer) {
+      return {TRI_ERROR_INTERNAL, "Malformed search/filter context"};
     }
-    TRI_ASSERT(analyzer);
 
     auto& geo_filter = filter->add<GeoDistanceFilter>();
     geo_filter.boost(filterCtx.boost);
@@ -927,12 +927,10 @@ Result fromGeoDistanceInterval(irs::boolean_filter* filter,
     return error::failedToGenerateName(GEO_DISTANCE_FUNC, fieldNodeIdx);
   }
   if (filter) {
-    Result r;
-    auto& analyzer = filterCtx.fieldAnalyzer(name, r);
-    if (!r.ok()) {
-      return r;
+    auto& analyzer = filterCtx.fieldAnalyzer(name, ctx.ctx);
+    if (!analyzer) {
+      return {TRI_ERROR_INTERNAL, "Malformed search/filter context"};
     }
-    TRI_ASSERT(analyzer);
 
     auto& geo_filter =
         (aql::NODE_TYPE_OPERATOR_BINARY_NE == node.cmp
@@ -2014,7 +2012,7 @@ Result fromFuncAnalyzer(char const* funcName, irs::boolean_filter* filter,
   }
 
   // default analyzer
-  FieldMeta::Analyzer analyzer{IResearchAnalyzerFeature::identity()};
+  FieldMeta::Analyzer analyzer{FieldMeta::identity()};
   if (filter || analyzerIdValue.isConstant()) {
     TRI_ASSERT(ctx.trx);
     auto& vocbase = ctx.trx->vocbase();
@@ -2147,12 +2145,10 @@ Result fromFuncExists(char const* funcName, irs::boolean_filter* filter,
     return error::failedToGenerateName(funcName, 1);
   }
 
-  Result r;
-  auto analyzer = filterCtx.fieldAnalyzer(fieldName, r);
-  if (!r.ok()) {
-    return r;
+  auto analyzer = filterCtx.fieldAnalyzer(fieldName, ctx.ctx);
+  if (!analyzer) {
+    return {TRI_ERROR_INTERNAL, "Malformed search/filter context"};
   }
-  TRI_ASSERT(analyzer);
 
   if (argc > 1) {
     // 2nd argument defines a type (if present)
@@ -3309,12 +3305,10 @@ Result fromFuncPhrase(char const* funcName, irs::boolean_filter* filter,
     // now get the actual analyzer for the known field name if it is not
     // overridden
     if (!analyzerPool._pool) {
-      Result r;
-      analyzerPool = filterCtx.fieldAnalyzer(name, r);
-      if (!r.ok()) {
-        return r;
+      analyzerPool = filterCtx.fieldAnalyzer(name, ctx.ctx);
+      if (!analyzerPool) {
+        return {TRI_ERROR_INTERNAL, "Malformed search/filter context"};
       }
-      TRI_ASSERT(analyzerPool);
     }
 
     analyzer = analyzerPool->get();
@@ -3471,12 +3465,10 @@ Result fromFuncNgramMatch(char const* funcName, irs::boolean_filter* filter,
 
   if (filter) {
     if (!analyzerPool) {
-      Result r;
-      analyzerPool = filterCtx.fieldAnalyzer(name, r);
-      if (!r.ok()) {
-        return r;
+      analyzerPool = filterCtx.fieldAnalyzer(name, ctx.ctx);
+      if (!analyzerPool) {
+        return {TRI_ERROR_INTERNAL, "Malformed search/filter context"};
       }
-      TRI_ASSERT(analyzerPool);
     }
 
     auto analyzer = analyzerPool->get();
@@ -3639,12 +3631,10 @@ Result fromFuncStartsWith(char const* funcName, irs::boolean_filter* filter,
   }
 
   if (filter) {
-    Result r;
-    auto& analyzer = filterCtx.fieldAnalyzer(name, r);
-    if (!r.ok()) {
-      return r;
+    auto& analyzer = filterCtx.fieldAnalyzer(name, ctx.ctx);
+    if (!analyzer) {
+      return {TRI_ERROR_INTERNAL, "Malformed search/filter context"};
     }
-    TRI_ASSERT(analyzer);
     kludge::mangleField(name, ctx.isOldMangling, analyzer);
 
     // Try to optimize us away
@@ -3754,12 +3744,10 @@ Result fromFuncLike(char const* funcName, irs::boolean_filter* filter,
   }
 
   if (filter) {
-    Result r;
-    auto& analyzer = filterCtx.fieldAnalyzer(name, r);
-    if (!r.ok()) {
-      return r;
+    auto& analyzer = filterCtx.fieldAnalyzer(name, ctx.ctx);
+    if (!analyzer) {
+      return {TRI_ERROR_INTERNAL, "Malformed search/filter context"};
     }
-    TRI_ASSERT(analyzer);
 
     auto& wildcardFilter = filter->add<irs::by_wildcard>();
     kludge::mangleField(name, ctx.isOldMangling, analyzer);
@@ -3799,12 +3787,10 @@ Result fromFuncLevenshteinMatch(char const* funcName,
   }
 
   if (filter) {
-    Result r;
-    auto& analyzer = filterCtx.fieldAnalyzer(name, r);
-    if (!r.ok()) {
-      return r;
+    auto& analyzer = filterCtx.fieldAnalyzer(name, ctx.ctx);
+    if (!analyzer) {
+      return {TRI_ERROR_INTERNAL, "Malformed search/filter context"};
     }
-    TRI_ASSERT(analyzer);
 
     auto& levenshtein_filter = filter->add<irs::by_edit_distance>();
     levenshtein_filter.boost(filterCtx.boost);
@@ -3912,12 +3898,10 @@ Result fromFuncGeoContainsIntersect(char const* funcName,
   }
 
   if (filter) {
-    Result r;
-    auto& analyzer = filterCtx.fieldAnalyzer(name, r);
-    if (!r.ok()) {
-      return r;
+    auto& analyzer = filterCtx.fieldAnalyzer(name, ctx.ctx);
+    if (!analyzer) {
+      return {TRI_ERROR_INTERNAL, "Malformed search/filter context"};
     }
-    TRI_ASSERT(analyzer);
 
     auto& geo_filter = filter->add<GeoFilter>();
     geo_filter.boost(filterCtx.boost);

--- a/arangod/IResearch/IResearchFilterFactory.h
+++ b/arangod/IResearch/IResearchFilterFactory.h
@@ -36,7 +36,7 @@
 
 namespace iresearch {
 
-class boolean_filter;  // forward declaration
+class boolean_filter;
 
 }  // namespace iresearch
 
@@ -45,7 +45,8 @@ class Result;
 
 namespace aql {
 
-struct AstNode;  // forward declaration
+struct AstNode;
+class ExpressionContext;
 
 }  // namespace aql
 
@@ -57,8 +58,8 @@ using AnalyzerProvider =
     fu2::unique_function<FieldMeta::Analyzer const&(std::string_view)>;
 
 struct FilterContext {
-  FieldMeta::Analyzer const& fieldAnalyzer(std::string_view name,
-                                           Result& r) const noexcept;
+  FieldMeta::Analyzer const& fieldAnalyzer(
+      std::string_view name, aql::ExpressionContext* ctx) const noexcept;
 
   AnalyzerProvider* fieldAnalyzerProvider{};
   // need shared_ptr since pool could be deleted from the feature

--- a/arangod/IResearch/IResearchFilterFactory.h
+++ b/arangod/IResearch/IResearchFilterFactory.h
@@ -54,8 +54,8 @@ namespace iresearch {
 
 struct QueryContext;
 
-using AnalyzerProvider =
-    fu2::unique_function<FieldMeta::Analyzer const&(std::string_view)>;
+using AnalyzerProvider = fu2::unique_function<FieldMeta::Analyzer const&(
+    std::string_view, aql::ExpressionContext*, FieldMeta::Analyzer const&)>;
 
 struct FilterContext {
   FieldMeta::Analyzer const& fieldAnalyzer(

--- a/arangod/IResearch/IResearchInvertedIndex.cpp
+++ b/arangod/IResearch/IResearchInvertedIndex.cpp
@@ -54,15 +54,13 @@ using namespace arangodb;
 using namespace arangodb::iresearch;
 
 AnalyzerProvider makeAnalyzerProvider(IResearchInvertedIndexMeta const& meta) {
-  static FieldMeta::Analyzer const defaultAnalyzer{
-      IResearchAnalyzerFeature::identity()};
   return [&meta](std::string_view fieldPath) -> FieldMeta::Analyzer const& {
     for (auto const& field : meta._fields) {
       if (field.path() == fieldPath) {
         return field.analyzer();
       }
     }
-    return defaultAnalyzer;
+    return FieldMeta::identity();
   };
 }
 

--- a/arangod/IResearch/IResearchInvertedIndex.cpp
+++ b/arangod/IResearch/IResearchInvertedIndex.cpp
@@ -54,7 +54,8 @@ using namespace arangodb;
 using namespace arangodb::iresearch;
 
 AnalyzerProvider makeAnalyzerProvider(IResearchInvertedIndexMeta const& meta) {
-  return [&meta](std::string_view fieldPath) -> FieldMeta::Analyzer const& {
+  return [&meta](std::string_view fieldPath, aql::ExpressionContext*,
+                 FieldMeta::Analyzer const&) -> FieldMeta::Analyzer const& {
     for (auto const& field : meta._fields) {
       if (field.path() == fieldPath) {
         return field.analyzer();
@@ -88,8 +89,9 @@ bool supportsFilterNode(
 
   // The analyzer is referenced in the FilterContext and used during the
   // following ::makeFilter() call, so may not be a temporary.
+  auto emptyAnalyzer = makeEmptyAnalyzer();
   FilterContext const filterCtx{.fieldAnalyzerProvider = provider,
-                                .contextAnalyzer = emptyAnalyzer(),
+                                .contextAnalyzer = emptyAnalyzer,
                                 .fields = metaFields};
 
   auto rv = FilterFactory::filter(nullptr, queryCtx, filterCtx, *node);
@@ -306,9 +308,10 @@ class IResearchInvertedIndexIteratorBase : public IndexIterator {
            condition->type != aql::NODE_TYPE_OPERATOR_NARY_OR)) {
         // The analyzer is referenced in the FilterContext and used during the
         // following FilterFactory::::filter() call, so may not be a temporary.
+        auto emptyAnalyzer = makeEmptyAnalyzer();
         FilterContext const filterCtx{
             .fieldAnalyzerProvider = &analyzerProvider,
-            .contextAnalyzer = emptyAnalyzer(),
+            .contextAnalyzer = emptyAnalyzer,
             .fields = _indexMeta->_fields};
         auto rv = FilterFactory::filter(&root, queryCtx, filterCtx, *condition);
 
@@ -343,9 +346,10 @@ class IResearchInvertedIndexIteratorBase : public IndexIterator {
           conditionJoiner = &root.add<irs::Or>();
         }
 
+        auto emptyAnalyzer = makeEmptyAnalyzer();
         FilterContext const filterCtx{
             .fieldAnalyzerProvider = &analyzerProvider,
-            .contextAnalyzer = emptyAnalyzer(),
+            .contextAnalyzer = emptyAnalyzer,
             .fields = _indexMeta->_fields};
 
         auto& mutable_root = conditionJoiner->add<irs::Or>();
@@ -385,9 +389,10 @@ class IResearchInvertedIndexIteratorBase : public IndexIterator {
 
           // The analyzer is referenced in the FilterContext and used during the
           // following ::filter() call, so may not be a temporary.
+          auto emptyAnalyzer = makeEmptyAnalyzer();
           FilterContext const filterCtx{
               .fieldAnalyzerProvider = &analyzerProvider,
-              .contextAnalyzer = emptyAnalyzer()};
+              .contextAnalyzer = emptyAnalyzer};
 
           for (int64_t i = 0; i < conditionSize; ++i) {
             if (i != _mutableConditionIdx) {

--- a/arangod/IResearch/IResearchInvertedIndexMeta.cpp
+++ b/arangod/IResearch/IResearchInvertedIndexMeta.cpp
@@ -126,11 +126,12 @@ const IResearchInvertedIndexMeta& IResearchInvertedIndexMeta::DEFAULT() {
   return meta;
 }
 
-IResearchInvertedIndexMeta::IResearchInvertedIndexMeta() {
-  _analyzers[0] = IResearchAnalyzerFeature::identity();
-  _primitiveOffset = 1;
-  _indexingContext =
-      std::make_unique<IResearchInvertedIndexMetaIndexingContext>(this, false);
+IResearchInvertedIndexMeta::IResearchInvertedIndexMeta()
+    : _indexingContext{
+          std::make_unique<IResearchInvertedIndexMetaIndexingContext>(this,
+                                                                      false)} {
+  _analyzers[0] = FieldMeta::identity();
+  _primitiveOffset = _analyzers.size();
 }
 
 // FIXME(Dronplane): make all constexpr defines consistent

--- a/arangod/IResearch/IResearchLinkMeta.cpp
+++ b/arangod/IResearch/IResearchLinkMeta.cpp
@@ -120,6 +120,11 @@ bool operator<(irs::string_ref lhs,
 namespace arangodb {
 namespace iresearch {
 
+FieldMeta::Analyzer const& FieldMeta::identity() {
+  static Analyzer kIdentity{IResearchAnalyzerFeature::identity()};
+  return kIdentity;
+}
+
 bool FieldMeta::operator==(FieldMeta const& rhs) const noexcept {
   if (!equalAnalyzers(_analyzers, rhs._analyzers)) {
     return false;
@@ -634,7 +639,7 @@ size_t FieldMeta::memory() const noexcept {
 
 IResearchLinkMeta::IResearchLinkMeta()
     : _version{static_cast<uint32_t>(LinkVersion::MIN)} {
-  _analyzers.emplace_back(IResearchAnalyzerFeature::identity());
+  _analyzers.emplace_back(FieldMeta::identity());
   _primitiveOffset = _analyzers.size();
 }
 

--- a/arangod/IResearch/IResearchLinkMeta.h
+++ b/arangod/IResearch/IResearchLinkMeta.h
@@ -111,6 +111,8 @@ struct FieldMeta {
     bool _storeValues;
   };
 
+  [[nodiscard]] static Analyzer const& identity();
+
   FieldMeta() = default;
   FieldMeta(FieldMeta const&) = default;
   FieldMeta(FieldMeta&&) = default;

--- a/arangod/IResearch/IResearchLinkMeta.h
+++ b/arangod/IResearch/IResearchLinkMeta.h
@@ -190,10 +190,7 @@ struct FieldMeta {
 #endif
 };
 
-inline FieldMeta::Analyzer const& emptyAnalyzer() noexcept {
-  static FieldMeta::Analyzer const empty{{}, {}};
-  return empty;
-}
+inline FieldMeta::Analyzer makeEmptyAnalyzer() { return {{}, {}}; }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief metadata describing how to process a field in a collection

--- a/arangod/IResearch/Search.cpp
+++ b/arangod/IResearch/Search.cpp
@@ -315,8 +315,11 @@ AnalyzerProvider SearchMeta::createProvider(
   };
   containers::FlatHashMap<std::string_view, Field> analyzers;
   for (auto const& [name, field] : fieldToAnalyzer) {
-    analyzers.emplace(
-        name, Field{getAnalyzer(field.analyzer), field.includeAllFields});
+    auto analyzer = getAnalyzer(field.analyzer);
+    if (analyzer) {
+      analyzers.emplace(name,
+                        Field{std::move(analyzer), field.includeAllFields});
+    }
   }
   VectorFst const* fst = getFst();
   TRI_ASSERT(fst);

--- a/arangod/IResearch/Search.cpp
+++ b/arangod/IResearch/Search.cpp
@@ -33,6 +33,7 @@
 #endif
 
 #include "ApplicationFeatures/ApplicationServer.h"
+#include "Aql/ExpressionContext.h"
 #include "Aql/QueryCache.h"
 #include "Basics/ScopeGuard.h"
 #include "Basics/Result.h"
@@ -322,18 +323,42 @@ AnalyzerProvider SearchMeta::createProvider(
   // we don't use provider in parallel, so create matcher here is thread safe
   auto matcher = std::make_unique<ExplicitMatcher>(fst, fst::MATCH_INPUT);
   return [analyzers = std::move(analyzers), matcher = std::move(matcher)](
-             std::string_view field) mutable -> FieldMeta::Analyzer const& {
+             std::string_view field, aql::ExpressionContext* ctx,
+             FieldMeta::Analyzer const& contextAnalyzer) mutable
+         -> FieldMeta::Analyzer const& {
+    auto registerWarning = [ctx](std::string_view error) {
+      if (ctx) {
+        ctx->registerWarning(TRI_ERROR_BAD_PARAMETER, error);
+      }
+    };
+
     auto it = analyzers.find(field);  // fast-path O(1)
-    if (it != analyzers.end()) {
-      return it->second.analyzer;
+
+    if (it == analyzers.end()) {
+      // Omega(prefix.size())
+      auto const prefix = findLongestCommonPrefix(*matcher, field);
+      it = analyzers.find(prefix);
+      if (it != analyzers.end() && !it->second.includeAllFields) {
+        it = analyzers.end();
+      }
     }
-    // Omega(prefix.size())
-    auto const prefix = findLongestCommonPrefix(*matcher, field);
-    it = analyzers.find(prefix);
-    if (it != analyzers.end() && it->second.includeAllFields) {
-      return it->second.analyzer;
+
+    if (it == analyzers.end()) {
+      registerWarning(
+          absl::StrCat("Analyzer for field '", field, "' isn't set"));
+      return contextAnalyzer ? contextAnalyzer : FieldMeta::identity();
     }
-    return emptyAnalyzer();
+
+    auto& analyzer = it->second.analyzer;
+    if (ADB_UNLIKELY(contextAnalyzer &&
+                     contextAnalyzer._pool != analyzer._pool)) {
+      registerWarning(
+          absl::StrCat("Context analyzer '", contextAnalyzer->name(),
+                       "' doesn't match field '", field, "' analyzer '",
+                       analyzer ? analyzer->name() : "", "'"));
+    }
+
+    return analyzer;
   };
 }
 

--- a/tests/js/common/aql/aql-view-arangosearch-cluster.inc
+++ b/tests/js/common/aql/aql-view-arangosearch-cluster.inc
@@ -174,7 +174,6 @@
         db.UnitTestsCollection.ensureIndex({ 
           type: "inverted",
           name: "invertedIndex",
-          includeAllFields:true,
           fields: [ { name: "text", analyzer: "text_en" } ] });
         db._dropView("UnitTestsViewAlias");
         db._createView("UnitTestsViewAlias", "search-alias", { 
@@ -674,10 +673,21 @@
         assertEqual(result0[0].name, 'full');
   
         var result1i = db._query("FOR doc IN UnitTestsCollection OPTIONS { indexHint: 'invertedIndex', waitForSync : true } FILTER PHRASE(doc.text, [ 'quick brown fox jumps' ], 'text_en') RETURN doc").toArray();
-  
         assertEqual(result1i.length, 1);
         assertEqual(result1i[0].name, 'full');
-  
+
+        // non-indexed field
+        {
+          let emptyResult = db._query("FOR doc IN UnitTestsViewAlias SEARCH doc.missingField == TOKENS('quick')[0] OPTIONS { waitForSync : true } RETURN doc");
+          assertEqual(emptyResult.toArray().length, 0);
+          let warnings = emptyResult.getExtra().warnings;
+          assertNotEqual(warnings.length, 0);
+          warnings.forEach(v => {
+            assertEqual(v.code, 10);
+            assertEqual(v.message, "Analyzer for field 'missingField' isn't set");
+          });
+        }
+
         var result1 = db._query("FOR doc IN UnitTestsViewAlias SEARCH PHRASE(doc.text, [ 'quick brown fox jumps' ], 'text_en') OPTIONS { waitForSync : true } RETURN doc").toArray();
   
         assertEqual(result1.length, 1);


### PR DESCRIPTION
### Scope & Purpose

Use warnings instead of errors for search-alias views

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: *(Please link PR)*
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR: https://github.com/arangodb/enterprise/pull/1080
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

