### PR TITLE
Allow children to have children

### DIFF
--- a/lib/Basics/process-utils.cpp
+++ b/lib/Basics/process-utils.cpp
@@ -34,6 +34,7 @@
 #include <type_traits>
 
 #include "process-utils.h"
+#include "signals.h"
 #include "Basics/system-functions.h"
 
 #if defined(TRI_HAVE_MACOS_MEM_STATS)
@@ -298,6 +299,8 @@ static void StartExternalProcess(
     for (auto const& it : additionalEnv) {
       putenv(TRI_DuplicateString(it.c_str(), it.size()));
     }
+
+    arangodb::signals::unmaskAllSignals();
 
     // execute worker
     execvp(external->_executable.c_str(), external->_arguments);


### PR DESCRIPTION
ArangoDB is very trigger happy with blocking signals on startup by calling `maskAllSignals`; this propagates to children, and thus prevented me from running `ctest` from the `unittests` script.

This is an attempt at a fix: just `unmaskAllSignals` in the child after a fork.
