### PR TITLE
Hotbackup up/download speedup - BTS-987

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,12 @@
 v3.10.0 (XXXX-XX-XX)
 --------------------
 
+* Improve upload and download speed of hotbackup by changing the way we use
+  rclone. Empty hash files are now uploaded or downloaded by pattern, and
+  all other files are done in batches without remote directory listing,
+  which allows rclone to parallelize and avoid a lot of unnecessary network
+  traffic. The format of hotbackups does not change at all.
+
 * Fixed SEARCH-392 Fixed field features propagation.
 
 * Fixed SEARCH-388 Fixed handling nested subfields.

--- a/lib/Basics/process-utils.cpp
+++ b/lib/Basics/process-utils.cpp
@@ -251,9 +251,9 @@ static bool CreatePipes(int* pipe_server_to_child, int* pipe_child_to_server) {
 /// @brief starts external process
 ////////////////////////////////////////////////////////////////////////////////
 
-static void StartExternalProcess(
-    ExternalProcess* external, bool usePipes,
-    std::vector<std::string> const& additionalEnv) {
+static void StartExternalProcess(ExternalProcess* external, bool usePipes,
+                                 std::vector<std::string> const& additionalEnv,
+                                 std::string const& fileForStdErr) {
   int pipe_server_to_child[2];
   int pipe_child_to_server[2];
 
@@ -287,11 +287,23 @@ static void StartExternalProcess(
     } else {
       {  // "close" stdin, but avoid fd 0 being reused!
         int fd = open("/dev/null", O_RDONLY);
-        dup2(fd, 0);
-        close(fd);
+        if (fd >= 0) {
+          dup2(fd, 0);
+          close(fd);
+        }
       }
       fcntl(1, F_SETFD, 0);
       fcntl(2, F_SETFD, 0);
+    }
+    if (!fileForStdErr.empty()) {
+      // Redirect stderr:
+      int fd = open(fileForStdErr.c_str(), O_CREAT | O_WRONLY | O_TRUNC, 0644);
+      if (fd >= 0) {
+        dup2(fd, 2);  // note that 2 was open before, so fd is not equal to 2,
+                      // and the previous 2 is now silently being closed!
+                      // Furthermore, if this fails, we stay on the other one.
+        close(fd);    // need to get rid of the second file descriptor.
+      }
     }
 
     // add environment variables
@@ -554,7 +566,8 @@ static bool startProcess(ExternalProcess* external, HANDLE rd, HANDLE wr) {
 
 static void StartExternalProcess(
     ExternalProcess* external, bool usePipes,
-    std::vector<std::string> const& additionalEnv) {
+    std::vector<std::string> const& additionalEnv,
+    std::string const& /* fileForStdErr ignored for now on Windows */) {
   HANDLE hChildStdinRd = NULL, hChildStdinWr = NULL;
   HANDLE hChildStdoutRd = NULL, hChildStdoutWr = NULL;
   bool fSuccess;
@@ -910,7 +923,8 @@ void TRI_SetProcessTitle(char const* title) {
 void TRI_CreateExternalProcess(char const* executable,
                                std::vector<std::string> const& arguments,
                                std::vector<std::string> const& additionalEnv,
-                               bool usePipes, ExternalId* pid) {
+                               bool usePipes, ExternalId* pid,
+                               std::string const& fileForStdErr) {
   size_t const n = arguments.size();
   // create the external structure
   auto external = std::make_unique<ExternalProcess>();
@@ -948,7 +962,7 @@ void TRI_CreateExternalProcess(char const* executable,
   external->_arguments[n + 1] = nullptr;
   external->_status = TRI_EXT_NOT_STARTED;
 
-  StartExternalProcess(external.get(), usePipes, additionalEnv);
+  StartExternalProcess(external.get(), usePipes, additionalEnv, fileForStdErr);
 
   if (external->_status != TRI_EXT_RUNNING) {
     pid->_pid = TRI_INVALID_PROCESS_ID;

--- a/lib/Basics/process-utils.h
+++ b/lib/Basics/process-utils.h
@@ -166,12 +166,14 @@ void TRI_SetProcessTitle(char const* title);
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief starts an external process
+/// `fileForStdErr` is a file name, to which we will redirect stderr of the
+/// external process, if the string is non-empty.
 ////////////////////////////////////////////////////////////////////////////////
 
-void TRI_CreateExternalProcess(char const* executable,
-                               std::vector<std::string> const& arguments,
-                               std::vector<std::string> const& additionalEnv,
-                               bool usePipes, ExternalId* pid);
+void TRI_CreateExternalProcess(
+    char const* executable, std::vector<std::string> const& arguments,
+    std::vector<std::string> const& additionalEnv, bool usePipes,
+    ExternalId* pid, std::string const& fileForStdErr = std::string());
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief Reads from the pipe of processes


### PR DESCRIPTION
### Scope & Purpose

This is a backport to 3.10 from devel.

This attacks the problem described in
  https://arangodb.atlassian.net/browse/BTS-987

Namely, the usage of `rclone` is changed. We use
  - `--include *.hash --include *.crc64ir` for bulk upload of empty hash files
  - we batch not only small files, but all files
  - we use `--files-from FILEWITHNAMES --no-traverse` for batches to make
    use of parallelism in `rclone` and avoid remote directory listing
    for each batch

These changes are in the accompanying enterprise PR: https://github.com/arangodb/enterprise/pull/1084

We need some changes in the main repository to improve error handling of
the rclone calls. Now, the standard error output of rclone is reported
back to `arangod` and thus the user.

There are also new tests.

This is a relatively local change
- [*] :hankey: Bugfix
- [*] :fire: Performance improvement

### Checklist

- [*] Tests
  - [ ] **Regression tests**
  - [*] C++ **Unit tests**
  - [x] **integration tests**
  - [ ] **resilience tests**
- [*] :book: CHANGELOG entry made
- [*] Backports
  - [*] Backport for 3.10: This PR.

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [*] Enterprise PR: https://github.com/arangodb/enterprise/pull/1084
- [*] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/BTS-987


