### PR TITLE
Activate and fix LockStressTest.cpp

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -206,6 +206,7 @@ set(ARANGODB_TESTS_SOURCES
   Cache/BucketState.cpp
   Cache/CachedValue.cpp
   Cache/FrequencyBuffer.cpp
+  Cache/LockStressTest.cpp
   Cache/Manager.cpp
   Cache/Metadata.cpp
   Cache/MockScheduler.cpp

--- a/tests/Cache/LockStressTest.cpp
+++ b/tests/Cache/LockStressTest.cpp
@@ -30,6 +30,7 @@
 #include <thread>
 #include <vector>
 
+#include "Basics/ThreadGuard.h"
 #include "Cache/Manager.h"
 #include "Cache/Rebalancer.h"
 #include "Random/RandomGenerator.h"
@@ -86,17 +87,14 @@ TEST(CacheLockStressTest, test_transactionality_for_mixed_load) {
 
   auto start = std::chrono::high_resolution_clock::now();
 
-  std::vector<std::thread*> threads;
+  auto threads = ThreadGuard(readerCount);
+
   // dispatch reader threads
   for (std::size_t i = 0; i < readerCount; i++) {
-    threads.push_back(new std::thread(readWorker));
+    threads.emplace(readWorker);
   }
 
-  // join threads
-  for (auto t : threads) {
-    t->join();
-    delete t;
-  }
+  threads.joinAll();
 
   auto end = std::chrono::high_resolution_clock::now();
   std::cout << "time: "


### PR DESCRIPTION
### Scope & Purpose

`Cache/LockStressTest.cpp` wasn't listed in CMakeLists.txt, and hence neither compiled nor run.

It was also broken.