### PR TITLE
remove StringUtils::isPrefix & StringUtils::isSuffix

### DIFF
--- a/arangod/RestServer/EnvironmentFeature.cpp
+++ b/arangod/RestServer/EnvironmentFeature.cpp
@@ -482,7 +482,7 @@ void EnvironmentFeature::prepare() {
         auto where = first.find(' ');
 
         if (where != std::string::npos &&
-            !StringUtils::isPrefix(first.substr(where), " interleave")) {
+            !first.substr(where).starts_with(" interleave")) {
           LOG_TOPIC("3e451", WARN, Logger::MEMORY)
               << "It is recommended to set NUMA to interleaved.";
           LOG_TOPIC("b25a4", WARN, Logger::MEMORY)

--- a/lib/ApplicationFeatures/ConfigFeature.cpp
+++ b/lib/ApplicationFeatures/ConfigFeature.cpp
@@ -146,7 +146,7 @@ void ConfigFeature::loadConfigFile(std::shared_ptr<ProgramOptions> options,
   std::string basename = progname;
   bool checkArangoImp = (progname == "arangoimport");
 
-  if (!StringUtils::isSuffix(basename, ".conf")) {
+  if (!basename.ends_with(".conf")) {
     basename += ".conf";
   }
 

--- a/lib/Basics/StringUtils.cpp
+++ b/lib/Basics/StringUtils.cpp
@@ -732,27 +732,6 @@ std::string toupper(std::string_view str) {
 
 void toupperInPlace(std::string& str) { StringUtils::toupper(str, str); }
 
-bool isPrefix(std::string_view str, std::string_view prefix) {
-  if (prefix.length() > str.length()) {
-    return false;
-  } else if (prefix.length() == str.length()) {
-    return str == prefix;
-  } else {
-    return str.compare(0, prefix.length(), prefix) == 0;
-  }
-}
-
-bool isSuffix(std::string_view str, std::string_view postfix) {
-  if (postfix.length() > str.length()) {
-    return false;
-  } else if (postfix.length() == str.length()) {
-    return str == postfix;
-  } else {
-    return str.compare(str.size() - postfix.length(), postfix.length(),
-                       postfix) == 0;
-  }
-}
-
 std::string urlDecodePath(std::string_view str) {
   std::string result;
   // reserve enough room so we do not need to re-alloc

--- a/lib/Basics/StringUtils.h
+++ b/lib/Basics/StringUtils.h
@@ -233,12 +233,6 @@ template<typename T1, typename T2>
   return (result == 0);
 }
 
-/// @brief checks for a prefix
-bool isPrefix(std::string_view str, std::string_view prefix);
-
-/// @brief checks for a suffix
-bool isSuffix(std::string_view str, std::string_view postfix);
-
 /// @brief url decodes the string
 std::string urlDecodePath(std::string_view str);
 std::string urlDecode(std::string_view str);

--- a/lib/Endpoint/Endpoint.cpp
+++ b/lib/Endpoint/Endpoint.cpp
@@ -65,17 +65,17 @@ Endpoint::Endpoint(DomainType domainType, EndpointType type,
 }
 
 std::string Endpoint::uriForm(std::string const& endpoint) {
-  if (StringUtils::isPrefix(endpoint, "http+tcp://")) {
+  if (endpoint.starts_with("http+tcp://")) {
     return "http://" + endpoint.substr(11);
-  } else if (StringUtils::isPrefix(endpoint, "http+ssl://")) {
+  } else if (endpoint.starts_with("http+ssl://")) {
     return "https://" + endpoint.substr(11);
-  } else if (StringUtils::isPrefix(endpoint, "tcp://")) {
+  } else if (endpoint.starts_with("tcp://")) {
     return "http://" + endpoint.substr(6);
-  } else if (StringUtils::isPrefix(endpoint, "ssl://")) {
+  } else if (endpoint.starts_with("ssl://")) {
     return "https://" + endpoint.substr(6);
-  } else if (StringUtils::isPrefix(endpoint, "unix://")) {
+  } else if (endpoint.starts_with("unix://")) {
     return endpoint;
-  } else if (StringUtils::isPrefix(endpoint, "http+unix://")) {
+  } else if (endpoint.starts_with("http+unix://")) {
     return "unix://" + endpoint.substr(12);
   } else {
     return StaticStrings::Empty;
@@ -109,22 +109,21 @@ std::string Endpoint::unifiedForm(std::string const& specification) {
   std::string schema = StringUtils::tolower(copy.substr(0, pos + 3));
 
   // read protocol from string
-  if (StringUtils::isPrefix(schema, "http+") ||
-      StringUtils::isPrefix(schema, "http@")) {
+  if (schema.starts_with("http+") || schema.starts_with("http@")) {
     protocol = TransportType::HTTP;
     prefix = "http+";
     copy = copy.substr(5);
     schema = schema.substr(5);
   }
 
-  if (StringUtils::isPrefix(schema, "vst+")) {
+  if (schema.starts_with("vst+")) {
     protocol = TransportType::VST;
     prefix = "vst+";
     copy = copy.substr(4);
     schema = schema.substr(4);
   }
 
-  if (StringUtils::isPrefix(schema, "unix://")) {
+  if (schema.starts_with("unix://")) {
 #if ARANGODB_HAVE_DOMAIN_SOCKETS
     return prefix + schema + copy.substr(7);
 #else
@@ -133,7 +132,7 @@ std::string Endpoint::unifiedForm(std::string const& specification) {
 #endif
   }
 
-  if (StringUtils::isPrefix(schema, "srv://")) {
+  if (schema.starts_with("srv://")) {
 #ifndef _WIN32
     return prefix + schema + copy.substr(6);
 #else
@@ -142,9 +141,9 @@ std::string Endpoint::unifiedForm(std::string const& specification) {
   }
 
   // strip tcp:// or ssl://
-  if (StringUtils::isPrefix(schema, "ssl://")) {
+  if (schema.starts_with("ssl://")) {
     prefix.append("ssl://");
-  } else if (StringUtils::isPrefix(schema, "tcp://")) {
+  } else if (schema.starts_with("tcp://")) {
     prefix.append("tcp://");
   } else {
     return StaticStrings::Empty;
@@ -239,7 +238,7 @@ Endpoint* Endpoint::factory(Endpoint::EndpointType type,
   std::string copy = unifiedForm(specification);
   TransportType protocol = TransportType::HTTP;
 
-  if (StringUtils::isPrefix(copy, "http+")) {
+  if (copy.starts_with("http+")) {
     copy = copy.substr(5);
   } else {
     // invalid protocol
@@ -248,7 +247,7 @@ Endpoint* Endpoint::factory(Endpoint::EndpointType type,
 
   EncryptionType encryption = EncryptionType::NONE;
 
-  if (StringUtils::isPrefix(copy, "unix://")) {
+  if (copy.starts_with("unix://")) {
 #if ARANGODB_HAVE_DOMAIN_SOCKETS
     return new EndpointUnixDomain(type, listenBacklog, copy.substr(7));
 #else
@@ -257,7 +256,7 @@ Endpoint* Endpoint::factory(Endpoint::EndpointType type,
 #endif
   }
 
-  if (StringUtils::isPrefix(copy, "srv://")) {
+  if (copy.starts_with("srv://")) {
     if (type != EndpointType::CLIENT) {
       return nullptr;
     }
@@ -269,9 +268,9 @@ Endpoint* Endpoint::factory(Endpoint::EndpointType type,
 #endif
   }
 
-  if (StringUtils::isPrefix(copy, "ssl://")) {
+  if (copy.starts_with("ssl://")) {
     encryption = EncryptionType::SSL;
-  } else if (!StringUtils::isPrefix(copy, "tcp://")) {
+  } else if (!copy.starts_with("tcp://")) {
     // invalid type
     return nullptr;
   }

--- a/lib/Logger/LoggerFeature.cpp
+++ b/lib/Logger/LoggerFeature.cpp
@@ -440,7 +440,7 @@ void LoggerFeature::prepare() {
   Logger::setUseJson(_useJson);
 
   for (auto const& definition : _output) {
-    if (_supervisor && StringUtils::isPrefix(definition, "file://")) {
+    if (_supervisor && definition.starts_with("file://")) {
       LogAppender::addAppender(Logger::defaultLogGroup(),
                                definition + ".supervisor");
     } else {

--- a/lib/ProgramOptions/IniFileParser.cpp
+++ b/lib/ProgramOptions/IniFileParser.cpp
@@ -135,7 +135,7 @@ bool IniFileParser::parseContent(std::string const& filename,
       // found include
       std::string include(match[1].str());
 
-      if (!basics::StringUtils::isSuffix(include, ".conf")) {
+      if (!include.ends_with(".conf")) {
         include += ".conf";
       }
       if (_seen.find(include) != _seen.end()) {

--- a/lib/Utilities/ShellBase.cpp
+++ b/lib/Utilities/ShellBase.cpp
@@ -35,7 +35,6 @@
 #include "Utilities/LinenoiseShell.h"
 
 using namespace arangodb;
-using namespace arangodb::basics;
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief creates a shell

--- a/lib/Utilities/ShellBase.cpp
+++ b/lib/Utilities/ShellBase.cpp
@@ -30,7 +30,6 @@
 
 #include "Basics/operating-system.h"
 
-#include "Basics/StringUtils.h"
 #include "Basics/files.h"
 #include "Utilities/Completer.h"
 #include "Utilities/LinenoiseShell.h"
@@ -127,12 +126,12 @@ std::string ShellBase::prompt(std::string const& prompt,
     // remove any prompt at the beginning of the line
     size_t pos = std::string::npos;
 
-    if (StringUtils::isPrefix(line, plain)) {
+    if (line.starts_with(plain)) {
       pos = line.find('>');
       // The documentation has this, so we ignore it:
-    } else if (StringUtils::isPrefix(line, "arangosh>")) {
+    } else if (line.starts_with("arangosh>")) {
       pos = line.find('>');
-    } else if (StringUtils::isPrefix(line, "...")) {
+    } else if (line.starts_with("...")) {
       pos = line.find('>');
     }
 


### PR DESCRIPTION
### Scope & Purpose

Enterprise companion PR: https://github.com/arangodb/enterprise/pull/1088

Remove functions StringUtils::isPrefix and StringUtils::isSuffix, and replace them with std::string::starts_with and std::string_ends_with.
This will not be backported.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: -
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -

#### Related Information

- [ ] Docs PR: 
- [x] Enterprise PR: https://github.com/arangodb/enterprise/pull/1088
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 