### PR TITLE
[PREGEL] Combine worker apis

### DIFF
--- a/arangod/Pregel/Conductor/Conductor.h
+++ b/arangod/Pregel/Conductor/Conductor.h
@@ -79,7 +79,7 @@ class Conductor : public std::enable_shared_from_this<Conductor> {
   friend struct conductor::Done;
   friend struct conductor::FatalError;
 
-  std::unordered_map<ServerID, conductor::WorkerApi> _workers;
+  conductor::WorkerApi _workers;
   std::unique_ptr<conductor::State> _state =
       std::make_unique<conductor::Initial>(*this);
   PregelFeature& _feature;
@@ -94,7 +94,6 @@ class Conductor : public std::enable_shared_from_this<Conductor> {
 
   std::vector<CollectionID> _vertexCollections;
   std::vector<CollectionID> _edgeCollections;
-  std::vector<ServerID> _dbServers;
   std::vector<ShardID> _allShards;  // persistent shard list
 
   // maps from vertex collection name to a list of edge collections that this

--- a/arangod/Pregel/Conductor/States/CanceledState.h
+++ b/arangod/Pregel/Conductor/States/CanceledState.h
@@ -47,9 +47,6 @@ struct Canceled : State {
   };
 
  private:
-  using CleanupFuture = futures::Future<std::vector<
-      futures::Try<arangodb::ResultT<arangodb::pregel::CleanupFinished>>>>;
-  auto _cleanup() -> CleanupFuture;
   std::chrono::nanoseconds _retryInterval = std::chrono::seconds(1);
   std::chrono::nanoseconds _timeout = std::chrono::minutes(5);
   auto _cleanupUntilTimeout(std::chrono::steady_clock::time_point start)

--- a/arangod/Pregel/Conductor/States/ComputingState.h
+++ b/arangod/Pregel/Conductor/States/ComputingState.h
@@ -44,14 +44,9 @@ struct Computing : State {
   }
 
  private:
-  using GlobalSuperStepPreparedFuture =
-      futures::Future<std::vector<futures::Try<
-          arangodb::ResultT<arangodb::pregel::GlobalSuperStepPrepared>>>>;
-  auto _prepareGlobalSuperStep() -> GlobalSuperStepPreparedFuture;
-
-  using GlobalSuperStepFinishedFuture = futures::Future<
-      std::vector<futures::Try<ResultT<GlobalSuperStepFinished>>>>;
-  auto _runGlobalSuperStep(bool activateAll) -> GlobalSuperStepFinishedFuture;
+  auto _prepareGlobalSuperStep() -> futures::Future<ResultT<VPackBuilder>>;
+  auto _runGlobalSuperStepCommand(bool activateAll) -> RunGlobalSuperStep;
+  auto _runGlobalSuperStep(bool activateAll) -> futures::Future<Result>;
 };
 
 }  // namespace conductor

--- a/arangod/Pregel/Conductor/States/DoneState.cpp
+++ b/arangod/Pregel/Conductor/States/DoneState.cpp
@@ -45,17 +45,8 @@ auto Done::run() -> std::optional<std::unique_ptr<State>> {
   return std::nullopt;
 }
 
-auto Done::_results(bool withId) -> ResultsFuture {
-  auto results = std::vector<futures::Future<ResultT<PregelResults>>>{};
-  for (auto&& [_, worker] : conductor._workers) {
-    results.emplace_back(
-        worker.results(CollectPregelResults{.withId = withId}));
-  }
-  return futures::collectAll(results);
-}
-
 auto Done::getResults(bool withId) -> ResultT<PregelResults> {
-  return _results(withId)
+  return conductor._workers.results(CollectPregelResults{.withId = withId})
       .thenValue([&](auto responses) -> ResultT<PregelResults> {
         VPackBuilder pregelResults;
         {

--- a/arangod/Pregel/Conductor/States/DoneState.h
+++ b/arangod/Pregel/Conductor/States/DoneState.h
@@ -44,11 +44,6 @@ struct Done : State {
       -> std::optional<std::chrono::system_clock::time_point> override {
     return expiration;
   };
-
- private:
-  using ResultsFuture = futures::Future<std::vector<
-      futures::Try<arangodb::ResultT<arangodb::pregel::PregelResults>>>>;
-  auto _results(bool withId) -> ResultsFuture;
 };
 }  // namespace conductor
 }  // namespace arangodb::pregel

--- a/arangod/Pregel/Conductor/States/FatalErrorState.cpp
+++ b/arangod/Pregel/Conductor/States/FatalErrorState.cpp
@@ -13,17 +13,8 @@ FatalError::FatalError(Conductor& conductor) : conductor{conductor} {
   }
 }
 
-auto FatalError::_results(bool withId) -> ResultsFuture {
-  auto results = std::vector<futures::Future<ResultT<PregelResults>>>{};
-  for (auto&& [_, worker] : conductor._workers) {
-    results.emplace_back(
-        worker.results(CollectPregelResults{.withId = withId}));
-  }
-  return futures::collectAll(results);
-}
-
 auto FatalError::getResults(bool withId) -> ResultT<PregelResults> {
-  return _results(withId)
+  return conductor._workers.results(CollectPregelResults{.withId = withId})
       .thenValue([&](auto responses) -> ResultT<PregelResults> {
         VPackBuilder pregelResults;
         {

--- a/arangod/Pregel/Conductor/States/FatalErrorState.h
+++ b/arangod/Pregel/Conductor/States/FatalErrorState.h
@@ -46,11 +46,6 @@ struct FatalError : State {
       -> std::optional<std::chrono::system_clock::time_point> override {
     return expiration;
   };
-
- private:
-  using ResultsFuture = futures::Future<std::vector<
-      futures::Try<arangodb::ResultT<arangodb::pregel::PregelResults>>>>;
-  auto _results(bool withId) -> ResultsFuture;
 };
 
 }  // namespace conductor

--- a/arangod/Pregel/Conductor/States/StoringState.h
+++ b/arangod/Pregel/Conductor/States/StoringState.h
@@ -44,13 +44,8 @@ struct Storing : State {
   }
 
  private:
-  using StoredFuture = futures::Future<
-      std::vector<futures::Try<arangodb::ResultT<arangodb::pregel::Stored>>>>;
-  auto _store() -> StoredFuture;
-  using CleanupFuture = futures::Future<std::vector<
-      futures::Try<arangodb::ResultT<arangodb::pregel::CleanupFinished>>>>;
-  auto _cleanup() -> CleanupFuture;
+  auto _store() -> futures::Future<Result>;
+  auto _cleanup() -> futures::Future<Result>;
 };
-
 }  // namespace conductor
 }  // namespace arangodb::pregel

--- a/arangod/Pregel/Conductor/WorkerApi.cpp
+++ b/arangod/Pregel/Conductor/WorkerApi.cpp
@@ -6,15 +6,21 @@
 
 using namespace arangodb::pregel::conductor;
 
-// This template enforces In and Out type of the function:
-// 'In' enforces which type of message is sent
-// 'Out' defines the expected response type:
-// The function returns an error if this expectation is not fulfilled
 template<typename Out, typename In>
-auto WorkerApi::execute(In const& in) const -> futures::Future<ResultT<Out>> {
+auto WorkerApi::sendToAll(In const& in) const -> FutureOfWorkerResults<Out> {
+  auto results = std::vector<futures::Future<ResultT<Out>>>{};
+  for (auto&& server : _servers) {
+    results.emplace_back(send<Out>(server, in));
+  }
+  return futures::collectAll(results);
+}
+
+template<typename Out, typename In>
+auto WorkerApi::send(ServerID const& server, In const& in) const
+    -> futures::Future<ResultT<Out>> {
   return _connection
       ->send(
-          Destination{Destination::Type::server, _server},
+          Destination{Destination::Type::server, server},
           ModernMessage{.executionNumber = _executionNumber, .payload = {in}})
       .thenValue([](auto&& response) -> futures::Future<ResultT<Out>> {
         if (response.fail()) {
@@ -34,30 +40,29 @@ auto WorkerApi::execute(In const& in) const -> futures::Future<ResultT<Out>> {
 
 auto WorkerApi::loadGraph(LoadGraph const& graph)
     -> futures::Future<ResultT<GraphLoaded>> {
-  return execute<GraphLoaded>(graph);
+  return send<GraphLoaded>(*_loadGraphIterator++, graph);
 }
 
 auto WorkerApi::prepareGlobalSuperStep(PrepareGlobalSuperStep const& data)
-    -> futures::Future<ResultT<GlobalSuperStepPrepared>> {
-  return execute<GlobalSuperStepPrepared>(data);
+    -> FutureOfWorkerResults<GlobalSuperStepPrepared> {
+  return sendToAll<GlobalSuperStepPrepared>(data);
 }
 
 auto WorkerApi::runGlobalSuperStep(RunGlobalSuperStep const& data)
-    -> futures::Future<ResultT<GlobalSuperStepFinished>> {
-  return execute<GlobalSuperStepFinished>(data);
+    -> FutureOfWorkerResults<GlobalSuperStepFinished> {
+  return sendToAll<GlobalSuperStepFinished>(data);
 }
 
-auto WorkerApi::store(Store const& message)
-    -> futures::Future<ResultT<Stored>> {
-  return execute<Stored>(message);
+auto WorkerApi::store(Store const& message) -> FutureOfWorkerResults<Stored> {
+  return sendToAll<Stored>(message);
 }
 
 auto WorkerApi::cleanup(Cleanup const& message)
-    -> futures::Future<ResultT<CleanupFinished>> {
-  return execute<CleanupFinished>(message);
+    -> FutureOfWorkerResults<CleanupFinished> {
+  return sendToAll<CleanupFinished>(message);
 }
 
 auto WorkerApi::results(CollectPregelResults const& message) const
-    -> futures::Future<ResultT<PregelResults>> {
-  return execute<PregelResults>(message);
+    -> FutureOfWorkerResults<PregelResults> {
+  return sendToAll<PregelResults>(message);
 }

--- a/arangod/Pregel/Conductor/WorkerApi.cpp
+++ b/arangod/Pregel/Conductor/WorkerApi.cpp
@@ -7,8 +7,8 @@
 using namespace arangodb::pregel::conductor;
 
 // This template enforces In and Out type of the function:
-// In enforces which type of message is sent
-// Out defines the expected response type:
+// 'In' enforces which type of message is sent
+// 'Out' defines the expected response type:
 // The function returns an error if this expectation is not fulfilled
 template<typename Out, typename In>
 auto WorkerApi::execute(In const& in) const -> futures::Future<ResultT<Out>> {

--- a/arangod/Pregel/WorkerConductorMessages.h
+++ b/arangod/Pregel/WorkerConductorMessages.h
@@ -38,22 +38,14 @@
 
 namespace arangodb::pregel {
 
-enum class MessageType { GraphLoaded, CleanupFinished, GssFinished };
-
-struct Message {
-  virtual auto type() const -> MessageType = 0;
-  virtual ~Message(){};
-};
-
 // ------ events sent from worker to conductor -------
 
-struct GraphLoaded : Message {
+struct GraphLoaded {
   uint64_t vertexCount;
   uint64_t edgeCount;
   GraphLoaded() noexcept = default;
   GraphLoaded(uint64_t vertexCount, uint64_t edgeCount)
       : vertexCount{vertexCount}, edgeCount{edgeCount} {}
-  auto type() const -> MessageType override { return MessageType::GraphLoaded; }
 };
 
 template<typename Inspector>
@@ -89,19 +81,18 @@ auto inspect(Inspector& f, GlobalSuperStepPrepared& x) {
       f.field("messages", x.messages), f.field("aggregators", x.aggregators));
 }
 
-struct GlobalSuperStepFinished : Message {
+struct GlobalSuperStepFinished {
   std::string senderId;
   uint64_t gss;
   VPackBuilder messageStats;
   VPackBuilder aggregators;
-  GlobalSuperStepFinished() noexcept {};
+  GlobalSuperStepFinished() noexcept = default;
   GlobalSuperStepFinished(std::string senderId, uint64_t gss,
                           VPackBuilder messageStats, VPackBuilder aggregators)
       : senderId{std::move(senderId)},
         gss{gss},
         messageStats{std::move(messageStats)},
         aggregators{std::move(aggregators)} {}
-  auto type() const -> MessageType override { return MessageType::GssFinished; }
 };
 
 template<typename Inspector>
@@ -118,11 +109,8 @@ auto inspect(Inspector& f, Stored& x) {
   return f.object(x).fields();
 }
 
-struct CleanupFinished : Message {
+struct CleanupFinished {
   CleanupFinished() noexcept = default;
-  auto type() const -> MessageType override {
-    return MessageType::CleanupFinished;
-  }
 };
 template<typename Inspector>
 auto inspect(Inspector& f, CleanupFinished& x) {


### PR DESCRIPTION
This PR combines the worker apis into one api:
When we call the workers from the conductor, we send the same message to all workers (with one exception). This PR combines the worker apis into one api such that the conductor (or mostly the conductor states) don't have to manage sending the messages to the correct workers, but leave that to the worker api.
There is one exception: When loading the graph, we send different messages to each worker: Each worker gets a list of shards on its DBServer of the vertex and edge collections involved. The solution used here is not robust, it is fixed in the next PR: https://github.com/arangodb/arangodb/pull/17175.

I also made the run functions of the condcutor states better readable.

And I deleted the unused message interface inside WorkerConductorMessages.h.