### PR TITLE
put crashdump into json file; put reason string into crashinfo (#17172)

### DIFF
--- a/js/client/modules/@arangodb/testutils/crash-utils.js
+++ b/js/client/modules/@arangodb/testutils/crash-utils.js
@@ -565,6 +565,7 @@ function analyzeCrash (binary, instanceInfo, options, checkStr) {
 }
 
 function generateCrashDump (binary, instanceInfo, options, checkStr) {
+  GDB_OUTPUT += `${instanceInfo.pid}: ${checkStr}\n`;
   if (instanceInfo.hasOwnProperty('debuggerInfo')) {
     throw new Error("this process is already debugged: " + JSON.stringify(instanceInfo.getStructure()));
   }
@@ -652,4 +653,4 @@ exports.runProcdump = runProcdump;
 exports.stopProcdump = stopProcdump;
 exports.isEnabledWindowsMonitor = isEnabledWindowsMonitor;
 exports.calculateMonitorValues = calculateMonitorValues;
-Object.defineProperty(exports, 'GDB_OUTPUT', {get: () => GDB_OUTPUT});
+Object.defineProperty(exports, 'GDB_OUTPUT', { get: () => GDB_OUTPUT, set: (value) => { GDB_OUTPUT = value; }});

--- a/js/client/modules/@arangodb/testutils/result-processing.js
+++ b/js/client/modules/@arangodb/testutils/result-processing.js
@@ -47,6 +47,7 @@ const RESET = internal.COLORS.COLOR_RESET;
 const YELLOW = internal.COLORS.COLOR_YELLOW;
 
 const internalMembers = [
+  'crashreport',
   'code',
   'error',
   'status',
@@ -1004,6 +1005,9 @@ function dumpAllResults(options, results) {
   let j;
 
   try {
+    if (cu.GDB_OUTPUT !== '') {
+      results['crashreport'] = cu.GDB_OUTPUT;
+    }
     j = JSON.stringify(results);
   } catch (err) {
     j = inspect(results);

--- a/scripts/examine_results.js
+++ b/scripts/examine_results.js
@@ -7,6 +7,7 @@ const fs = require('fs');
 const internal = require('internal');
 const rp = require('@arangodb/testutils/result-processing');
 const yaml = require('js-yaml');
+let cu = require('@arangodb/testutils/crash-utils');
 
 const optionsDefaults = require('@arangodb/testutils/testing').optionsDefaults;
 
@@ -80,7 +81,11 @@ function main (argv) {
       
     let results;
     try {
+      cu.GDB_OUTPUT = "";
       results = JSON.parse(resultsDump);
+      if (results.hasOwnProperty('crashreport')) {
+        cu.GDB_OUTPUT = results['crashreport'];
+      }
     }
     catch (ex) {
       print(RED + "Failed to parse " + file + " - " + ex.message + RESET + "\n");


### PR DESCRIPTION
backport of https://github.com/arangodb/arangodb/pull/new/bug-fix-3.10/put-info-string-into-crashdump