### PR TITLE
[PREGEL] Separate worker creation from loading graph

### DIFF
--- a/arangod/Pregel/AlgoRegistry.cpp
+++ b/arangod/Pregel/AlgoRegistry.cpp
@@ -93,13 +93,13 @@ IAlgorithm* AlgoRegistry::createAlgorithm(
 
 template<typename V, typename E, typename M>
 /*static*/ std::shared_ptr<IWorker> AlgoRegistry::createWorker(
-    TRI_vocbase_t& vocbase, Algorithm<V, E, M>* algo, LoadGraph const& body,
+    TRI_vocbase_t& vocbase, Algorithm<V, E, M>* algo, CreateWorker const& body,
     PregelFeature& feature) {
   return std::make_shared<Worker<V, E, M>>(vocbase, algo, body, feature);
 }
 
 /*static*/ std::shared_ptr<IWorker> AlgoRegistry::createWorker(
-    TRI_vocbase_t& vocbase, LoadGraph const& data, PregelFeature& feature) {
+    TRI_vocbase_t& vocbase, CreateWorker const& data, PregelFeature& feature) {
   auto userParams = data.userParameters.slice();
   auto algorithm = data.algorithm;
   std::transform(algorithm.begin(), algorithm.end(), algorithm.begin(),

--- a/arangod/Pregel/AlgoRegistry.h
+++ b/arangod/Pregel/AlgoRegistry.h
@@ -40,14 +40,14 @@ struct AlgoRegistry {
       application_features::ApplicationServer& server,
       std::string const& algorithm, VPackSlice userParams);
   static std::shared_ptr<IWorker> createWorker(TRI_vocbase_t& vocbase,
-                                               LoadGraph const& body,
+                                               CreateWorker const& body,
                                                PregelFeature& feature);
 
  private:
   template<typename V, typename E, typename M>
   static std::shared_ptr<IWorker> createWorker(TRI_vocbase_t& vocbase,
                                                Algorithm<V, E, M>* algo,
-                                               LoadGraph const& body,
+                                               CreateWorker const& body,
                                                PregelFeature& feature);
 };
 

--- a/arangod/Pregel/AlgoRegistry.h
+++ b/arangod/Pregel/AlgoRegistry.h
@@ -26,6 +26,7 @@
 #include <string>
 #include "Algorithm.h"
 #include "Pregel/Worker/Worker.h"
+#include "Pregel/WorkerConductorMessages.h"
 
 struct TRI_vocbase_t;
 
@@ -39,14 +40,14 @@ struct AlgoRegistry {
       application_features::ApplicationServer& server,
       std::string const& algorithm, VPackSlice userParams);
   static std::shared_ptr<IWorker> createWorker(TRI_vocbase_t& vocbase,
-                                               VPackSlice body,
+                                               LoadGraph const& body,
                                                PregelFeature& feature);
 
  private:
   template<typename V, typename E, typename M>
   static std::shared_ptr<IWorker> createWorker(TRI_vocbase_t& vocbase,
                                                Algorithm<V, E, M>* algo,
-                                               VPackSlice body,
+                                               LoadGraph const& body,
                                                PregelFeature& feature);
 };
 

--- a/arangod/Pregel/Conductor/Conductor.h
+++ b/arangod/Pregel/Conductor/Conductor.h
@@ -94,7 +94,6 @@ class Conductor : public std::enable_shared_from_this<Conductor> {
 
   std::vector<CollectionID> _vertexCollections;
   std::vector<CollectionID> _edgeCollections;
-  std::vector<ShardID> _allShards;  // persistent shard list
 
   // maps from vertex collection name to a list of edge collections that this
   // vertex collection is restricted to. only use for a collection if there is
@@ -142,7 +141,7 @@ class Conductor : public std::enable_shared_from_this<Conductor> {
       futures::Try<arangodb::ResultT<arangodb::pregel::GraphLoaded>>>>;
 
   auto _changeState(std::unique_ptr<conductor::State> newState) -> void;
-  auto _initializeWorkers(VPackSlice additional) -> GraphLoadedFuture;
+  auto _initializeWorkers() -> GraphLoadedFuture;
   auto _preGlobalSuperStep() -> bool;
   auto _postGlobalSuperStep(VPackBuilder messagesFromWorkers)
       -> PostGlobalSuperStepResult;

--- a/arangod/Pregel/Conductor/Conductor.h
+++ b/arangod/Pregel/Conductor/Conductor.h
@@ -137,11 +137,8 @@ class Conductor : public std::enable_shared_from_this<Conductor> {
   // with the Inspecotr framework
   ConductorStatus _status;
 
-  using GraphLoadedFuture = futures::Future<std::vector<
-      futures::Try<arangodb::ResultT<arangodb::pregel::GraphLoaded>>>>;
-
   auto _changeState(std::unique_ptr<conductor::State> newState) -> void;
-  auto _initializeWorkers() -> GraphLoadedFuture;
+  auto _initializeWorkers() -> futures::Future<ResultT<WorkerCreated>>;
   auto _preGlobalSuperStep() -> bool;
   auto _postGlobalSuperStep(VPackBuilder messagesFromWorkers)
       -> PostGlobalSuperStepResult;

--- a/arangod/Pregel/Conductor/Conductor.h
+++ b/arangod/Pregel/Conductor/Conductor.h
@@ -138,7 +138,7 @@ class Conductor : public std::enable_shared_from_this<Conductor> {
   ConductorStatus _status;
 
   auto _changeState(std::unique_ptr<conductor::State> newState) -> void;
-  auto _initializeWorkers() -> futures::Future<ResultT<WorkerCreated>>;
+  auto _initializeWorkers() -> futures::Future<Result>;
   auto _preGlobalSuperStep() -> bool;
   auto _postGlobalSuperStep(VPackBuilder messagesFromWorkers)
       -> PostGlobalSuperStepResult;

--- a/arangod/Pregel/Conductor/States/LoadingState.cpp
+++ b/arangod/Pregel/Conductor/States/LoadingState.cpp
@@ -23,7 +23,7 @@ Loading::~Loading() {
 
 auto Loading::run() -> std::optional<std::unique_ptr<State>> {
   LOG_PREGEL_CONDUCTOR("3a255", DEBUG) << "Telling workers to load the data";
-  return conductor._initializeWorkers(VPackSlice())
+  return conductor._initializeWorkers()
       .thenValue([&](auto results) -> std::unique_ptr<State> {
         for (auto const& result : results) {
           if (result.get().fail()) {

--- a/arangod/Pregel/Conductor/States/LoadingState.cpp
+++ b/arangod/Pregel/Conductor/States/LoadingState.cpp
@@ -22,32 +22,56 @@ Loading::~Loading() {
 }
 
 auto Loading::run() -> std::optional<std::unique_ptr<State>> {
+  auto create = _createWorkers().get();
+  if (create.fail()) {
+    LOG_PREGEL_CONDUCTOR("ae855", ERR) << create.errorMessage();
+    return std::make_unique<Canceled>(conductor);
+  }
+
   LOG_PREGEL_CONDUCTOR("3a255", DEBUG) << "Telling workers to load the data";
-  return conductor._initializeWorkers()
-      .thenValue([&](auto results) -> std::unique_ptr<State> {
+  auto loadGraph = _loadGraph().get();
+  if (loadGraph.fail()) {
+    LOG_PREGEL_CONDUCTOR("8e855", ERR) << loadGraph.errorMessage();
+    return std::make_unique<Canceled>(conductor);
+  }
+
+  LOG_PREGEL_CONDUCTOR("76631", INFO)
+      << "Running Pregel " << conductor._algorithm->name() << " with "
+      << conductor._totalVerticesCount << " vertices, "
+      << conductor._totalEdgesCount << " edges";
+  if (conductor._masterContext) {
+    conductor._masterContext->initialize(conductor._totalVerticesCount,
+                                         conductor._totalEdgesCount,
+                                         conductor._aggregators.get());
+  }
+
+  return std::make_unique<Computing>(conductor);
+}
+
+auto Loading::_createWorkers() -> futures::Future<Result> {
+  return conductor._initializeWorkers().thenValue([&](auto result) -> Result {
+    if (result.fail()) {
+      return Result{result.errorNumber(), result.errorMessage()};
+    }
+    return Result{};
+  });
+}
+
+auto Loading::_loadGraph() -> futures::Future<Result> {
+  return conductor._workers.loadGraph(LoadGraph{})
+      .thenValue([&](auto results) -> Result {
         for (auto const& result : results) {
           if (result.get().fail()) {
-            LOG_PREGEL_CONDUCTOR("8e855", ERR) << fmt::format(
-                "Got unsuccessful response from worker while loading graph: "
-                "{}\n",
-                result.get().errorMessage());
-            return std::make_unique<Canceled>(conductor);
+            return Result{result.get().errorNumber(),
+                          fmt::format("Got unsuccessful response from worker "
+                                      "while loading graph: "
+                                      "{}\n",
+                                      result.get().errorMessage())};
           }
           auto graphLoaded = result.get().get();
           conductor._totalVerticesCount += graphLoaded.vertexCount;
           conductor._totalEdgesCount += graphLoaded.edgeCount;
         }
-
-        LOG_PREGEL_CONDUCTOR("76631", INFO)
-            << "Running Pregel " << conductor._algorithm->name() << " with "
-            << conductor._totalVerticesCount << " vertices, "
-            << conductor._totalEdgesCount << " edges";
-        if (conductor._masterContext) {
-          conductor._masterContext->initialize(conductor._totalVerticesCount,
-                                               conductor._totalEdgesCount,
-                                               conductor._aggregators.get());
-        }
-        return std::make_unique<Computing>(conductor);
-      })
-      .get();
+        return Result{};
+      });
 }

--- a/arangod/Pregel/Conductor/States/LoadingState.h
+++ b/arangod/Pregel/Conductor/States/LoadingState.h
@@ -42,6 +42,10 @@ struct Loading : State {
       -> std::optional<std::chrono::system_clock::time_point> override {
     return std::nullopt;
   }
+
+ private:
+  auto _createWorkers() -> futures::Future<Result>;
+  auto _loadGraph() -> futures::Future<Result>;
 };
 
 }  // namespace conductor

--- a/arangod/Pregel/Conductor/WorkerApi.cpp
+++ b/arangod/Pregel/Conductor/WorkerApi.cpp
@@ -6,10 +6,6 @@
 
 using namespace arangodb::pregel::conductor;
 
-// This template enforces In and Out type of the function:
-// 'In' enforces which type of message is sent
-// 'Out' defines the expected response type:
-// The function returns an error if this expectation is not fulfilled
 template<typename Out, typename In>
 auto WorkerApi::sendToAll(In const& in) const -> FutureOfWorkerResults<Out> {
   auto results = std::vector<futures::Future<ResultT<Out>>>{};

--- a/arangod/Pregel/Conductor/WorkerApi.cpp
+++ b/arangod/Pregel/Conductor/WorkerApi.cpp
@@ -6,6 +6,10 @@
 
 using namespace arangodb::pregel::conductor;
 
+// This template enforces In and Out type of the function:
+// 'In' enforces which type of message is sent
+// 'Out' defines the expected response type:
+// The function returns an error if this expectation is not fulfilled
 template<typename Out, typename In>
 auto WorkerApi::sendToAll(In const& in) const -> FutureOfWorkerResults<Out> {
   auto results = std::vector<futures::Future<ResultT<Out>>>{};

--- a/arangod/Pregel/Conductor/WorkerApi.h
+++ b/arangod/Pregel/Conductor/WorkerApi.h
@@ -38,14 +38,13 @@ using FutureOfWorkerResults =
 
 struct WorkerApi {
   WorkerApi() = default;
-  WorkerApi(std::vector<ServerID> servers, ExecutionNumber executionNumber,
+  WorkerApi(ExecutionNumber executionNumber,
             std::unique_ptr<Connection> connection)
-      : _servers{std::move(servers)},
-        _executionNumber{std::move(executionNumber)},
+      : _executionNumber{std::move(executionNumber)},
         _connection{std::move(connection)} {}
   [[nodiscard]] auto createWorkers(
       std::unordered_map<ServerID, CreateWorker> const& data)
-      -> futures::Future<ResultT<WorkerCreated>>;
+      -> futures::Future<Result>;
   [[nodiscard]] auto loadGraph(LoadGraph const& graph)
       -> FutureOfWorkerResults<GraphLoaded>;
   [[nodiscard]] auto prepareGlobalSuperStep(PrepareGlobalSuperStep const& data)
@@ -60,7 +59,7 @@ struct WorkerApi {
       -> FutureOfWorkerResults<PregelResults>;
 
  private:
-  std::vector<ServerID> _servers;
+  std::vector<ServerID> _servers = {};
   ExecutionNumber _executionNumber;
   std::unique_ptr<Connection> _connection;
 

--- a/arangod/Pregel/Conductor/WorkerApi.h
+++ b/arangod/Pregel/Conductor/WorkerApi.h
@@ -42,10 +42,12 @@ struct WorkerApi {
             std::unique_ptr<Connection> connection)
       : _servers{std::move(servers)},
         _executionNumber{std::move(executionNumber)},
-        _connection{std::move(connection)},
-        _loadGraphIterator{_servers.begin()} {}
+        _connection{std::move(connection)} {}
+  [[nodiscard]] auto createWorkers(
+      std::unordered_map<ServerID, CreateWorker> const& data)
+      -> futures::Future<ResultT<WorkerCreated>>;
   [[nodiscard]] auto loadGraph(LoadGraph const& graph)
-      -> futures::Future<ResultT<GraphLoaded>>;
+      -> FutureOfWorkerResults<GraphLoaded>;
   [[nodiscard]] auto prepareGlobalSuperStep(PrepareGlobalSuperStep const& data)
       -> FutureOfWorkerResults<GlobalSuperStepPrepared>;
   [[nodiscard]] auto runGlobalSuperStep(RunGlobalSuperStep const& data)
@@ -61,7 +63,6 @@ struct WorkerApi {
   std::vector<ServerID> _servers;
   ExecutionNumber _executionNumber;
   std::unique_ptr<Connection> _connection;
-  std::vector<ServerID>::iterator _loadGraphIterator;
 
   // TODO accumulate results inside and return Future<ResultT<Out>> directly.
   // This can be done when AggregatorHandler, StatsManager and ReportManager can

--- a/arangod/Pregel/Connection/Connection.h
+++ b/arangod/Pregel/Connection/Connection.h
@@ -36,10 +36,10 @@ struct Destination {
 
  private:
   Type _type;
-  ServerID _id;
   const char* typeString[2] = {"server", "shard"};
 
  public:
+  ServerID _id;
   Destination(Type type, ServerID id) : _type{type}, _id{std::move(id)} {}
   auto toString() const -> std::string;
 };

--- a/arangod/Pregel/Connection/DirectConnection.cpp
+++ b/arangod/Pregel/Connection/DirectConnection.cpp
@@ -13,8 +13,8 @@ auto DirectConnection::send(Destination const& destination,
   if (std::holds_alternative<LoadGraph>(message.payload)) {
     try {
       auto created = AlgoRegistry::createWorker(
-          _vocbaseGuard.database(),
-          std::get<LoadGraph>(message.payload).details.slice(), _feature);
+          _vocbaseGuard.database(), std::get<LoadGraph>(message.payload),
+          _feature);
       TRI_ASSERT(created.get() != nullptr);
       _feature.addWorker(std::move(created), message.executionNumber);
     } catch (basics::Exception& e) {

--- a/arangod/Pregel/Connection/DirectConnection.cpp
+++ b/arangod/Pregel/Connection/DirectConnection.cpp
@@ -10,13 +10,15 @@ using namespace arangodb::pregel;
 auto DirectConnection::send(Destination const& destination,
                             ModernMessage&& message) const
     -> futures::Future<ResultT<ModernMessage>> {
-  if (std::holds_alternative<LoadGraph>(message.payload)) {
+  if (std::holds_alternative<CreateWorker>(message.payload)) {
     try {
       auto created = AlgoRegistry::createWorker(
-          _vocbaseGuard.database(), std::get<LoadGraph>(message.payload),
+          _vocbaseGuard.database(), std::get<CreateWorker>(message.payload),
           _feature);
       TRI_ASSERT(created.get() != nullptr);
       _feature.addWorker(std::move(created), message.executionNumber);
+      return ModernMessage{.executionNumber = message.executionNumber,
+                           .payload = WorkerCreated{}};
     } catch (basics::Exception& e) {
       return Result{e.code(), e.message()};
     }

--- a/arangod/Pregel/Connection/DirectConnection.cpp
+++ b/arangod/Pregel/Connection/DirectConnection.cpp
@@ -17,8 +17,9 @@ auto DirectConnection::send(Destination const& destination,
           _feature);
       TRI_ASSERT(created.get() != nullptr);
       _feature.addWorker(std::move(created), message.executionNumber);
-      return ModernMessage{.executionNumber = message.executionNumber,
-                           .payload = WorkerCreated{}};
+      return ModernMessage{
+          .executionNumber = message.executionNumber,
+          .payload = WorkerCreated{.senderId = destination._id}};
     } catch (basics::Exception& e) {
       return Result{e.code(), e.message()};
     }

--- a/arangod/Pregel/PregelFeature.cpp
+++ b/arangod/Pregel/PregelFeature.cpp
@@ -702,7 +702,8 @@ void PregelFeature::handleWorkerRequest(TRI_vocbase_t& vocbase,
                   vocbase, std::get<CreateWorker>(message.payload), *this),
               message.executionNumber);
     auto workerCreated = ModernMessage{
-        .executionNumber = message.executionNumber, .payload = WorkerCreated{}};
+        .executionNumber = message.executionNumber,
+        .payload = WorkerCreated{.senderId = ServerState::instance()->getId()}};
     serialize(outBuilder, workerCreated);
     return;
   }

--- a/arangod/Pregel/PregelFeature.cpp
+++ b/arangod/Pregel/PregelFeature.cpp
@@ -697,10 +697,14 @@ void PregelFeature::handleWorkerRequest(TRI_vocbase_t& vocbase,
   }
 
   auto message = deserialize<ModernMessage>(body);
-  if (std::holds_alternative<LoadGraph>(message.payload)) {
+  if (std::holds_alternative<CreateWorker>(message.payload)) {
     addWorker(AlgoRegistry::createWorker(
-                  vocbase, std::get<LoadGraph>(message.payload), *this),
+                  vocbase, std::get<CreateWorker>(message.payload), *this),
               message.executionNumber);
+    auto workerCreated = ModernMessage{
+        .executionNumber = message.executionNumber, .payload = WorkerCreated{}};
+    serialize(outBuilder, workerCreated);
+    return;
   }
   auto w = worker(message.executionNumber);
   if (std::holds_alternative<Cleanup>(message.payload)) {

--- a/arangod/Pregel/PregelFeature.cpp
+++ b/arangod/Pregel/PregelFeature.cpp
@@ -699,8 +699,7 @@ void PregelFeature::handleWorkerRequest(TRI_vocbase_t& vocbase,
   auto message = deserialize<ModernMessage>(body);
   if (std::holds_alternative<LoadGraph>(message.payload)) {
     addWorker(AlgoRegistry::createWorker(
-                  vocbase, std::get<LoadGraph>(message.payload).details.slice(),
-                  *this),
+                  vocbase, std::get<LoadGraph>(message.payload), *this),
               message.executionNumber);
   }
   auto w = worker(message.executionNumber);

--- a/arangod/Pregel/Utils.cpp
+++ b/arangod/Pregel/Utils.cpp
@@ -28,6 +28,7 @@
 #include "Logger/LogMacros.h"
 #include "VocBase/LogicalCollection.h"
 #include "VocBase/vocbase.h"
+#include "Pregel/Worker/WorkerConfig.h"
 
 using namespace arangodb;
 using namespace arangodb::pregel;

--- a/arangod/Pregel/Utils.h
+++ b/arangod/Pregel/Utils.h
@@ -27,13 +27,14 @@
 
 #include "Basics/Common.h"
 #include "Cluster/ClusterInfo.h"
-#include "Pregel/Worker/WorkerConfig.h"
 
 struct TRI_vocbase_t;
 
 namespace arangodb {
 class LogicalCollection;
 namespace pregel {
+
+class WorkerConfig;
 
 class Utils {
   Utils() = delete;

--- a/arangod/Pregel/Worker/Worker.cpp
+++ b/arangod/Pregel/Worker/Worker.cpp
@@ -95,7 +95,7 @@ std::function<void()> Worker<V, E, M>::_makeStatusCallback() {
 
 template<typename V, typename E, typename M>
 Worker<V, E, M>::Worker(TRI_vocbase_t& vocbase, Algorithm<V, E, M>* algo,
-                        LoadGraph const& initConfig, PregelFeature& feature)
+                        CreateWorker const& initConfig, PregelFeature& feature)
     : _feature(feature),
       _state(WorkerState::IDLE),
       _config(&vocbase),

--- a/arangod/Pregel/Worker/Worker.cpp
+++ b/arangod/Pregel/Worker/Worker.cpp
@@ -95,7 +95,7 @@ std::function<void()> Worker<V, E, M>::_makeStatusCallback() {
 
 template<typename V, typename E, typename M>
 Worker<V, E, M>::Worker(TRI_vocbase_t& vocbase, Algorithm<V, E, M>* algo,
-                        VPackSlice initConfig, PregelFeature& feature)
+                        LoadGraph const& initConfig, PregelFeature& feature)
     : _feature(feature),
       _state(WorkerState::IDLE),
       _config(&vocbase),
@@ -105,9 +105,7 @@ Worker<V, E, M>::Worker(TRI_vocbase_t& vocbase, Algorithm<V, E, M>* algo,
 
   MUTEX_LOCKER(guard, _commandMutex);
 
-  VPackSlice userParams = initConfig.get(Utils::userParametersKey);
-
-  _workerContext.reset(algo->workerContext(userParams));
+  _workerContext.reset(algo->workerContext(initConfig.userParameters.slice()));
   _messageFormat.reset(algo->messageFormat());
   _messageCombiner.reset(algo->messageCombiner());
   _conductorAggregators = std::make_unique<AggregatorHandler>(algo);

--- a/arangod/Pregel/Worker/Worker.h
+++ b/arangod/Pregel/Worker/Worker.h
@@ -174,7 +174,7 @@ class Worker : public IWorker {
 
  public:
   Worker(TRI_vocbase_t& vocbase, Algorithm<V, E, M>* algorithm,
-         LoadGraph const& params, PregelFeature& feature);
+         CreateWorker const& params, PregelFeature& feature);
   ~Worker();
 
   // ====== called by rest handler =====

--- a/arangod/Pregel/Worker/Worker.h
+++ b/arangod/Pregel/Worker/Worker.h
@@ -174,7 +174,7 @@ class Worker : public IWorker {
 
  public:
   Worker(TRI_vocbase_t& vocbase, Algorithm<V, E, M>* algorithm,
-         VPackSlice params, PregelFeature& feature);
+         LoadGraph const& params, PregelFeature& feature);
   ~Worker();
 
   // ====== called by rest handler =====

--- a/arangod/Pregel/Worker/WorkerConfig.cpp
+++ b/arangod/Pregel/Worker/WorkerConfig.cpp
@@ -26,6 +26,7 @@
 #include "Pregel/Algorithm.h"
 #include "Pregel/PregelFeature.h"
 #include "Pregel/Utils.h"
+#include "Pregel/WorkerConductorMessages.h"
 #include "VocBase/vocbase.h"
 
 using namespace arangodb;
@@ -40,100 +41,50 @@ WorkerConfig::WorkerConfig(TRI_vocbase_t* vocbase) : _vocbase(vocbase) {}
 
 std::string const& WorkerConfig::database() const { return _vocbase->name(); }
 
-void WorkerConfig::updateConfig(PregelFeature& feature, VPackSlice params) {
-  VPackSlice coordID = params.get(Utils::coordinatorIdKey);
-  VPackSlice vertexShardMap = params.get(Utils::vertexShardsKey);
-  VPackSlice edgeShardMap = params.get(Utils::edgeShardsKey);
-  VPackSlice edgeCollectionRestrictions =
-      params.get(Utils::edgeCollectionRestrictionsKey);
-  VPackSlice execNum = params.get(Utils::executionNumberKey);
-  VPackSlice collectionPlanIdMap = params.get(Utils::collectionPlanIdMapKey);
-  VPackSlice globalShards = params.get(Utils::globalShardListKey);
-
-  if (!coordID.isString() || !edgeShardMap.isObject() ||
-      !vertexShardMap.isObject() || !execNum.isInteger() ||
-      !collectionPlanIdMap.isObject() || !globalShards.isArray()) {
-    THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_BAD_PARAMETER,
-                                   "Supplied bad parameters to worker");
-  }
-  _executionNumber = ExecutionNumber(execNum.getUInt());
-  _coordinatorId = coordID.copyString();
-
-  // memory mapping
-  // start off with default value
-  _useMemoryMaps = feature.useMemoryMaps();
-  if (VPackSlice memoryMaps = params.get(Utils::useMemoryMapsKey);
-      memoryMaps.isBoolean()) {
-    // update from user config if specified there
-    _useMemoryMaps = memoryMaps.getBool();
-  }
-
-  VPackSlice userParams = params.get(Utils::userParametersKey);
-
-  // parallelism
-  _parallelism = WorkerConfig::parallelism(feature, userParams);
+void WorkerConfig::updateConfig(PregelFeature& feature,
+                                LoadGraph const& params) {
+  _executionNumber = params.executionNumber;
+  _coordinatorId = params.coordinatorId;
+  _useMemoryMaps = params.useMemoryMaps;
+  _parallelism =
+      WorkerConfig::parallelism(feature, params.userParameters.slice());
+  _globalShardIDs = params.allShards;
 
   // list of all shards, equal on all workers. Used to avoid storing strings of
   // shard names
   // Instead we have an index identifying a shard name in this vector
   PregelShard i = 0;
-  for (VPackSlice shard : VPackArrayIterator(globalShards)) {
-    ShardID s = shard.copyString();
-    _globalShardIDs.push_back(s);
-    _pregelShardIDs.try_emplace(s, i++);  // Cache these ids
+  for (auto const& shard : _globalShardIDs) {
+    _pregelShardIDs.try_emplace(shard, i++);  // Cache these ids
   }
 
   // To access information based on a user defined collection name we need the
-  for (auto it : VPackObjectIterator(collectionPlanIdMap)) {
-    _collectionPlanIdMap.try_emplace(it.key.copyString(),
-                                     it.value.copyString());
-  }
+  _collectionPlanIdMap = params.collectionPlanIds;
 
   // Ordered list of shards for each vertex collection on the CURRENT db server
   // Order matters because the for example the third vertex shard, will only
   // every have
   // edges in the third edge shard. This should speed up the startup
-  for (auto pair : VPackObjectIterator(vertexShardMap)) {
-    CollectionID cname = pair.key.copyString();
-
-    std::vector<ShardID> shards;
-    for (VPackSlice shardSlice : VPackArrayIterator(pair.value)) {
-      ShardID shard = shardSlice.copyString();
-      shards.push_back(shard);
+  _vertexCollectionShards = params.vertexShards;
+  for (auto const& [collection, shards] : _vertexCollectionShards) {
+    for (auto const& shard : shards) {
       _localVertexShardIDs.push_back(shard);
       _localPregelShardIDs.insert(_pregelShardIDs[shard]);
       _localPShardIDs_hash.insert(_pregelShardIDs[shard]);
-      _shardToCollectionName.try_emplace(shard, cname);
+      _shardToCollectionName.try_emplace(shard, collection);
     }
-    _vertexCollectionShards.try_emplace(std::move(cname), std::move(shards));
   }
 
   // Ordered list of edge shards for each collection
-  for (auto pair : VPackObjectIterator(edgeShardMap)) {
-    CollectionID cname = pair.key.copyString();
-
-    std::vector<ShardID> shards;
-    for (VPackSlice shardSlice : VPackArrayIterator(pair.value)) {
-      ShardID shard = shardSlice.copyString();
-      shards.push_back(shard);
+  _edgeCollectionShards = params.edgeShards;
+  for (auto const& [collection, shards] : _edgeCollectionShards) {
+    for (auto const& shard : shards) {
       _localEdgeShardIDs.push_back(shard);
-      _shardToCollectionName.try_emplace(shard, cname);
-    }
-    _edgeCollectionShards.try_emplace(std::move(cname), std::move(shards));
-  }
-
-  if (edgeCollectionRestrictions.isObject()) {
-    for (auto pair : VPackObjectIterator(edgeCollectionRestrictions)) {
-      CollectionID cname = pair.key.copyString();
-
-      std::vector<ShardID> shards;
-      for (VPackSlice shardSlice : VPackArrayIterator(pair.value)) {
-        shards.push_back(shardSlice.copyString());
-      }
-      _edgeCollectionRestrictions.try_emplace(std::move(cname),
-                                              std::move(shards));
+      _shardToCollectionName.try_emplace(shard, collection);
     }
   }
+
+  _edgeCollectionRestrictions = params.edgeCollectionRestrictions;
 }
 
 size_t WorkerConfig::parallelism(PregelFeature& feature, VPackSlice params) {

--- a/arangod/Pregel/Worker/WorkerConfig.cpp
+++ b/arangod/Pregel/Worker/WorkerConfig.cpp
@@ -42,7 +42,7 @@ WorkerConfig::WorkerConfig(TRI_vocbase_t* vocbase) : _vocbase(vocbase) {}
 std::string const& WorkerConfig::database() const { return _vocbase->name(); }
 
 void WorkerConfig::updateConfig(PregelFeature& feature,
-                                LoadGraph const& params) {
+                                CreateWorker const& params) {
   _executionNumber = params.executionNumber;
   _coordinatorId = params.coordinatorId;
   _useMemoryMaps = params.useMemoryMaps;

--- a/arangod/Pregel/Worker/WorkerConfig.h
+++ b/arangod/Pregel/Worker/WorkerConfig.h
@@ -31,6 +31,7 @@
 #include "Cluster/ClusterInfo.h"
 #include "Pregel/ExecutionNumber.h"
 #include "Pregel/Graph.h"
+#include "Pregel/WorkerConductorMessages.h"
 
 struct TRI_vocbase_t;
 
@@ -49,7 +50,7 @@ class WorkerConfig {
 
  public:
   explicit WorkerConfig(TRI_vocbase_t* vocbase);
-  void updateConfig(PregelFeature& feature, VPackSlice updated);
+  void updateConfig(PregelFeature& feature, LoadGraph const& updated);
 
   // get effective parallelism from Pregel feature and params
   static size_t parallelism(PregelFeature& feature, VPackSlice params);

--- a/arangod/Pregel/Worker/WorkerConfig.h
+++ b/arangod/Pregel/Worker/WorkerConfig.h
@@ -50,7 +50,7 @@ class WorkerConfig {
 
  public:
   explicit WorkerConfig(TRI_vocbase_t* vocbase);
-  void updateConfig(PregelFeature& feature, LoadGraph const& updated);
+  void updateConfig(PregelFeature& feature, CreateWorker const& updated);
 
   // get effective parallelism from Pregel feature and params
   static size_t parallelism(PregelFeature& feature, VPackSlice params);

--- a/arangod/Pregel/WorkerConductorMessages.h
+++ b/arangod/Pregel/WorkerConductorMessages.h
@@ -40,10 +40,12 @@ namespace arangodb::pregel {
 
 // ------ events sent from worker to conductor -------
 
-struct WorkerCreated {};
+struct WorkerCreated {
+  ServerID senderId;
+};
 template<typename Inspector>
 auto inspect(Inspector& f, WorkerCreated& x) {
-  return f.object(x).fields();
+  return f.object(x).fields(f.field("onServer", x.senderId));
 }
 
 struct GraphLoaded {

--- a/arangod/Pregel/WorkerConductorMessages.h
+++ b/arangod/Pregel/WorkerConductorMessages.h
@@ -147,11 +147,31 @@ auto inspect(Inspector& f, GssStarted& x) {
 // ------ commands sent from conductor to worker -------
 
 struct LoadGraph {
-  VPackBuilder details;
+  ExecutionNumber executionNumber;
+  std::string algorithm;
+  VPackBuilder userParameters;
+  std::string coordinatorId;
+  bool useMemoryMaps;
+  std::unordered_map<CollectionID, std::vector<ShardID>>
+      edgeCollectionRestrictions;
+  std::map<CollectionID, std::vector<ShardID>> vertexShards;
+  std::map<CollectionID, std::vector<ShardID>> edgeShards;
+  std::unordered_map<CollectionID, std::string> collectionPlanIds;
+  std::vector<ShardID> allShards;
 };
 template<typename Inspector>
 auto inspect(Inspector& f, LoadGraph& x) {
-  return f.object(x).fields(f.field("details", x.details));
+  return f.object(x).fields(
+      f.field("executionNumber", x.executionNumber),
+      f.field("algorithm", x.algorithm),
+      f.field("userParameters", x.userParameters),
+      f.field("coordinatorId", x.coordinatorId),
+      f.field("useMemoryMaps", x.useMemoryMaps),
+      f.field("edgeCollectionRestrictions", x.edgeCollectionRestrictions),
+      f.field("vertexShards", x.vertexShards),
+      f.field("edgeShards", x.edgeShards),
+      f.field("collectionPlanIds", x.collectionPlanIds),
+      f.field("allShards", x.allShards));
 }
 
 struct PrepareGlobalSuperStep {


### PR DESCRIPTION
This PR separates the worker creation from the graph loading: This makes more clear what is happening: The conductor first asks to create the workers and only when this is successful the conductor asks the workers to load the graph.
Also, the payload to create workers is now a proper struct.