### PR TITLE
[3.10][ES-1195] Add sorting by history

### DIFF
--- a/js/apps/system/_admin/aardvark/APP/frontend/js/templates/queryView.ejs
+++ b/js/apps/system/_admin/aardvark/APP/frontend/js/templates/queryView.ejs
@@ -3,6 +3,12 @@
       <div class="pull-left">
         <button id="toggleQueries1" class="button-primary"><i class="fa fa-star-o"></i>Queries</button>
         <button id="toggleQueries2" class="button-primary" style="display: none"><i class="fa fa-star"></i>Queries</button>
+        <div id="sortByHistoryContainer" style="float: right; padding: 4px 0px; margin-left: 8px; display: none;">
+          <label className="checkbox checkboxLabel" for="sortByHistory">
+            <input className="css-checkbox" type="checkbox" id="sortByHistory" style="margin: -2px 0px 0px 0px;" />
+            Sort by history
+          </label>
+        </div>
         <button id="createNewQuery" class="button-warning">New</button>
         <button id="updateCurrentQuery" class="button-success" style="display: none"><i class="fa fa-save"></i>Save</button>
         <button id="saveCurrentQuery" class="button-success"><i class="fa fa-save"></i>Save as</button>

--- a/js/apps/system/_admin/aardvark/APP/frontend/js/views/queryView.js
+++ b/js/apps/system/_admin/aardvark/APP/frontend/js/views/queryView.js
@@ -63,6 +63,7 @@
 
     aqlEditor: null,
     queryPreview: null,
+    sortByHistory: false,
 
     initialize: function () {
       this.refreshAQL();
@@ -82,6 +83,7 @@
       'click .outputEditorWrapper .closeResult': 'closeResult',
       'click #toggleQueries1': 'toggleQueries',
       'click #toggleQueries2': 'toggleQueries',
+      'click #sortByHistory': 'toggleSortByHistory',
       'click #createNewQuery': 'createAQL',
       'click #saveCurrentQuery': 'addAQL',
       'click #updateCurrentQuery': 'updateAQL',
@@ -106,6 +108,12 @@
 
     clearQuery: function () {
       this.aqlEditor.setValue('', 1);
+    },
+
+    toggleSortByHistory: function () {
+      this.sortByHistory = !this.sortByHistory;
+      this.updateQueryTable();
+      this.resize();
     },
 
     closeProfile: function (e) {
@@ -302,7 +310,7 @@
         'aqlEditor', 'queryTable', 'previewWrapper', 'querySpotlight',
         'bindParamEditor', 'toggleQueries1', 'toggleQueries2', 'createNewQuery',
         'saveCurrentQuery', 'querySize', 'executeQuery', 'switchTypes',
-        'explainQuery', 'profileQuery', 'debugQuery', 'importQuery', 'exportQuery'
+        'explainQuery', 'profileQuery', 'debugQuery', 'importQuery', 'exportQuery', 'sortByHistoryContainer'
       ];
       _.each(divs, function (div) {
         $('#' + div).toggle();
@@ -1453,6 +1461,10 @@
       this.updateLocalQueries();
 
       this.myQueriesTableDesc.rows = this.customQueries;
+      
+      // Reverse order: Last added query shall be displayed first
+      self.customQueries.reverse();
+
       _.each(this.myQueriesTableDesc.rows, function (k) {
         k.secondRow = '<span class="spanWrapper">' +
           '<span id="copyQuery" title="Copy query"><i class="fa fa-copy"></i></span>' +
@@ -1478,7 +1490,9 @@
         return x;
       }
 
-      this.myQueriesTableDesc.rows.sort(compare);
+      if(!this.sortByHistory) {
+        this.myQueriesTableDesc.rows.sort(compare);
+      }
 
       _.each(this.queries, function (val) {
         if (val.hasOwnProperty('parameter')) {


### PR DESCRIPTION
### Scope & Purpose

Backport of #17089

It is very difficult to find and remember the query a user has been saving recently. I added a checkbox (and the logic) to toggle sorting alphabetically and sorting by history (last query saved displayed first). 

- [x] :pizza: New feature

### Checklist

- [x] Manually tested

#### Related Information

- [x] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/ES-1195
- [x] Screenshot 1: Sorting alphabetically
<img width="515" alt="image" src="https://user-images.githubusercontent.com/56896586/190208727-4580257f-edb1-4145-9a8f-76f6e55d4a2f.png">

- [x] Screenshot 2: Sorting by history
<img width="530" alt="image" src="https://user-images.githubusercontent.com/56896586/190208969-716952da-0bd9-49e8-b05c-ef849c9b4635.png">
