### PR TITLE
[3.10] APM-517: Show values upon hover on blue attribute labels

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 v3.10.0 (XXXX-XX-XX)
 --------------------
 
+* APM-517: Add tooltips with values of the displayed properties after
+  clicking a node or an edge in the graph viewer.
+
 * Updated arangosync to v2.12.0.
 
 * Improve upload and download speed of hotbackup by changing the way we use

--- a/js/apps/system/_admin/aardvark/APP/frontend/js/arango/arango.js
+++ b/js/apps/system/_admin/aardvark/APP/frontend/js/arango/arango.js
@@ -993,8 +993,8 @@
       // timezone can see that it is UTC time
     },
 
-    escapeHtml: function (val) {
-      if (typeof val !== 'string') {
+    escapeHtml: function (val, stringify = true) {
+      if (typeof val !== 'string' && stringify) {
         val = JSON.stringify(val, null, 2);
       }
 

--- a/js/apps/system/_admin/aardvark/APP/frontend/js/views/graphViewer.js
+++ b/js/apps/system/_admin/aardvark/APP/frontend/js/views/graphViewer.js
@@ -2120,7 +2120,7 @@
                   }
                   _.each(data.documents[0], function (value, key) {
                     if (key !== '_key' && key !== '_id' && key !== '_rev' && key !== '_from' && key !== '_to') {
-                      attributes += '<span class="nodeAttribute" title="' + arangoHelper.escapeHtml(value) + '">' + arangoHelper.escapeHtml(key) + '</span>';
+                      attributes += '<span class="nodeAttribute" title="' + arangoHelper.escapeHtml(value, false) + '">' + arangoHelper.escapeHtml(key, false) + '</span>';
                     }
                   });
                   var string = '<div id="nodeInfoDiv" class="nodeInfoDiv" style="display: none;">' + attributes + '</div>';

--- a/js/apps/system/_admin/aardvark/APP/frontend/js/views/graphViewer.js
+++ b/js/apps/system/_admin/aardvark/APP/frontend/js/views/graphViewer.js
@@ -2120,7 +2120,7 @@
                   }
                   _.each(data.documents[0], function (value, key) {
                     if (key !== '_key' && key !== '_id' && key !== '_rev' && key !== '_from' && key !== '_to') {
-                      attributes += '<span class="nodeAttribute">' + key + '</span>';
+                      attributes += '<span class="nodeAttribute">' + key + ': ' + value + '</span>';
                     }
                   });
                   var string = '<div id="nodeInfoDiv" class="nodeInfoDiv" style="display: none;">' + attributes + '</div>';

--- a/js/apps/system/_admin/aardvark/APP/frontend/js/views/graphViewer.js
+++ b/js/apps/system/_admin/aardvark/APP/frontend/js/views/graphViewer.js
@@ -2120,12 +2120,13 @@
                   }
                   _.each(data.documents[0], function (value, key) {
                     if (key !== '_key' && key !== '_id' && key !== '_rev' && key !== '_from' && key !== '_to') {
-                      attributes += '<span class="nodeAttribute">' + key + ': ' + value + '</span>';
+                      attributes += '<span class="nodeAttribute" title="' + arangoHelper.escapeHtml(value) + '">' + arangoHelper.escapeHtml(key) + '</span>';
                     }
                   });
                   var string = '<div id="nodeInfoDiv" class="nodeInfoDiv" style="display: none;">' + attributes + '</div>';
 
                   $('#graph-container').append(string);
+                  arangoHelper.fixTooltips('.nodeAttribute', 'top');
                   if (self.isFullscreen) {
                     $('.nodeInfoDiv').css('top', '10px');
                     $('.nodeInfoDiv').css('left', '10px');


### PR DESCRIPTION
### Scope & Purpose

Backport of #17031

After clicking a node or an edge in the graph viewer the properties are displayed in blue tags underneath the canvas. With this PR on hover over these tags the values will be displayed in a tooltip.

- [x] :pizza: New feature

### Checklist

- [x] Manually tested
- [x] :book: CHANGELOG entry made
- [ ] Backports
  - [ ] Backport for 3.10: ToDo
  - [ ] Backport for 3.9: ToDo
  - [ ] Backport for 3.8: ToDo

#### Related Information

- [x] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/APM-517

