### PR TITLE
js test for search-alias dump/restore

### DIFF
--- a/tests/js/server/dump/dump-setup-common.inc
+++ b/tests/js/server/dump/dump-setup-common.inc
@@ -400,7 +400,21 @@ function createView() {
 function createSearch() {
   db._useDatabase("UnitTestsDumpSrc");
 
+  var analyzers = require("@arangodb/analyzers");
+  var a = analyzers.save("AqlAnalyzerRound", "aql", { queryString: "RETURN ROUND(@param)" }, ["frequency", "norm", "position"]);
+  var b = analyzers.save("myDelimiterAnalyzer", "delimiter", { delimiter: " " }, ["frequency", "norm", "position"]);
+  var c = analyzers.save("AqlAnalyzerHash", "aql", { queryString: "return to_hex(to_string(@param))" }, []);
+  var d = analyzers.save("norm_lower", "norm", {locale: "de.utf-8", case: "lower"}, ["frequency", "norm", "position"]);
+
+  // create collections
+  var collection_documents_0 = db._create("collection_documents_0", { 
+    replicationFactor:3, 
+    writeConcern:1, 
+    numberOfShards : 3});
+
   let collection = db._create("searchCollection");
+
+  // create indexes
   let index = collection.ensureIndex({
     type: "inverted",
     name: "searchIndex",
@@ -409,11 +423,112 @@ function createSearch() {
     includeAllFields: true,
     analyzer: "text_en"
   });
+
+  db.collection_documents_0.ensureIndex(
+    {
+        "type":"inverted",
+        "name":"collection_documents_0_all",
+        "fields": [
+            {
+                "analyzer": "AqlAnalyzerHash",
+                "name": "_key",
+                "features": [
+                    "norm"
+                ]
+            },
+            {
+                "name": "_rev",
+                "features": [
+                    "position", "frequency"
+                ]
+            },
+            {
+                "name": "Familie.Mutter",
+                "includeAllFields": true
+            },
+            {
+                "name": "Familie.Mutter.Name",
+                "includeAllFields": true
+            },
+            {
+                "name": "Familie.Vater.Name",
+                "includeAllFields": true,
+                "trackListPositions": true,
+                "analyzer": "AqlAnalyzerHash"
+            },
+            {
+                "name": "Familie.Ehefrau.Setzt[*].Titel",
+                "analyzer": "AqlAnalyzerHash"
+            },
+            {
+                "name": "Familie.Bruder.Name",
+                "analyzer": "norm_lower"
+            },
+            {
+                "name": "Familie.Bruder.Familienname",
+                "analyzer": "AqlAnalyzerHash"
+            },
+            {
+                "name": "Familie.Bruder.Setzt[*].istGut",
+                "analyzer": "AqlAnalyzerRound"
+    
+            },
+            {
+                "name": "Setzt",
+                "nested": [
+                    {
+                        "name": "Titel",
+                        "analyzer": "AqlAnalyzerHash"
+                    },
+                    {
+                        "name": "Bezeichnung",
+                        "analyzer": "norm_lower"
+                    }
+                ]
+            },
+            {
+              "name": "Haustiere",
+              "nested": [
+                {
+                  "name": "Tiere",
+                  "analyzer": "norm_lower",
+                  "features": []
+                },
+                "Alt",
+                {
+                  "name": "name",
+                  "analyzer": "AqlAnalyzerHash",
+                  "features": []
+                }
+              ]
+            }
+        ],
+        "includeAllFields": false,
+        "trackListPositions": false,
+        "features": [],
+        "analyzer": "myDelimiterAnalyzer"
+    }
+  );
+
+  // create views  
   let search = db._createView("searchSearch", "search-alias",
    { indexes: [ { collection: collection.name(), index: index.name } ] });
 
+  db._createView('v_collection_documents_0_all', 'search-alias', {   
+    'indexes': [
+        {
+            'collection': 'collection_documents_0',
+            'index': 'collection_documents_0_all'
+        }
+    ]
+  });
+
+  // insert data
   collection.save({value: -1, text: "the red foxx jumps over the pond"});
   collection.save(Array(5000).fill().map((e, i, a) => Object({_key: "test" + i, value: i})));
+
+  collection_documents_0.save({value: -1, text: "the red foxx jumps over the pond"});
+  collection_documents_0.save(Array(5000).fill().map((e, i, a) => Object({_key: "test" + i, value: i})));
 }
 
 function createReplicationFactors() {

--- a/tests/js/server/dump/dump-test.inc
+++ b/tests/js/server/dump/dump-test.inc
@@ -767,26 +767,44 @@
       ////////////////////////////////////////////////////////////////////////////////
 
       testSearch: function () {
-        let collection = db._collection("searchCollection");
+        let collection1 = db._collection("searchCollection");
         assertNotEqual(null, collection);
 
-        let index = collection.index("searchIndex");
-        assertTrue(index.includeAllFields);
-        assertEqual(index.consolidationIntervalMsec, 0);
-        assertEqual(index.cleanupIntervalStep, 42);
+        let collection2 = db._collection("v_collection_documents_0_all");
+        assertNotEqual(null, collection);
 
-        let search = db._view("searchSearch");
-        assertNotEqual(null, search);
-        assertEqual("searchSearch", search.name());
-        let props = search.properties();
+        let index1 = collection1.index("searchIndex");
+        assertTrue(index1.includeAllFields);
+        assertEqual(index1.consolidationIntervalMsec, 0);
+        assertEqual(index1.cleanupIntervalStep, 42);
+
+        let index2 = collection2.index("collection_documents_0_all");
+        assertTrue(index2.includeAllFields);
+        assertEqual(index2.consolidationIntervalMsec, 0);
+        assertEqual(index2.cleanupIntervalStep, 42);
+
+        let search1 = db._view("searchSearch");
+        assertNotEqual(null, search1);
+        assertEqual("searchSearch", search1.name());
+        let props = search1.properties();
         assertEqual(props.indexes, [{ collection: "searchCollection", index: "searchIndex" }]);
+
+        let search2 = db._view("v_collection_documents_0_all");
+        assertNotEqual(null, search2);
+        assertEqual("v_collection_documents_0_all", search2.name());
+        let props = search2.properties();
+        assertEqual(props.indexes, [ { 'collection': 'collection_documents_0', 'index': 'collection_documents_0_all' }]);
 
         // After a restore, the Inverted index needs to be rebuilt, therefore
         // we cannot expect that the data is immediately visible. We can only
         // hope that the data will be there in due course:
 
-        let res = db._query("FOR doc IN " + search.name() + " SEARCH doc.value >= 0 OPTIONS { waitForSync: true } RETURN doc").toArray();
+        let res1 = db._query("FOR doc IN " + search1.name() + " SEARCH doc.value >= 0 OPTIONS { waitForSync: true } RETURN doc").toArray();
         assertEqual(5000, res.length);
+
+        let res2 = db._query("FOR doc IN " + search2.name() + " SEARCH doc.value >= 0 OPTIONS { waitForSync: true } RETURN doc").toArray();
+        assertEqual(5000, res.length);
+
 
         if (isServer) {
           request({
@@ -802,29 +820,48 @@
             getRawMetric(c, '?mode=trigger_global');
           }
         }
-        let figures;
+        let figures1;
+        let figures2;
         for (let i = 0; i < 100; ++i) {
           require("internal").sleep(0.5);
-          figures = collection.getIndexes(true, true)
+          figures1 = collection.getIndexes(true, true)
             .find(e => e.name === "searchIndex")
+            .figures;
+          figures2 = collection.getIndexes(true, true)
+            .find(e => e.name === "collection_documents_0_all")
             .figures;
           if (figures.numDocs > 5000) {
             break;
           }
         }
-        assertEqual(figures.numDocs, 5001);
-        assertEqual(figures.numLiveDocs, 5001);
-        assertTrue(figures.numSegments >= 1);
-        assertTrue(figures.numFiles >= 7);
-        assertTrue(figures.indexSize > 0);
+        assertEqual(figures1.numDocs, 5001);
+        assertEqual(figures1.numLiveDocs, 5001);
+        assertTrue(figures1.numSegments >= 1);
+        assertTrue(figures1.numFiles >= 7);
+        assertTrue(figures1.indexSize > 0);
 
-        res = db._query("FOR doc IN " + search.name() + " SEARCH doc.value >= 2500 RETURN doc").toArray();
+        assertEqual(figures2.numDocs, 5001);
+        assertEqual(figures2.numLiveDocs, 5001);
+        assertTrue(figures2.numSegments >= 1);
+        assertTrue(figures2.numFiles >= 7);
+        assertTrue(figures2.indexSize > 0);
+
+        res = db._query("FOR doc IN " + search1.name() + " SEARCH doc.value >= 2500 RETURN doc").toArray();
         assertEqual(2500, res.length);
 
-        res = db._query("FOR doc IN " + search.name() + " SEARCH doc.value >= 5000 RETURN doc").toArray();
+        res = db._query("FOR doc IN " + search1.name() + " SEARCH doc.value >= 5000 RETURN doc").toArray();
         assertEqual(0, res.length);
 
-        res = db._query("FOR doc IN " + search.name() + " SEARCH PHRASE(doc.text, 'foxx jumps over', 'text_en') RETURN doc").toArray();
+        res = db._query("FOR doc IN " + search1.name() + " SEARCH PHRASE(doc.text, 'foxx jumps over', 'text_en') RETURN doc").toArray();
+        assertEqual(1, res.length);
+      
+        res = db._query("FOR doc IN " + search2.name() + " SEARCH doc.value >= 2500 RETURN doc").toArray();
+        assertEqual(2500, res.length);
+
+        res = db._query("FOR doc IN " + search2.name() + " SEARCH doc.value >= 5000 RETURN doc").toArray();
+        assertEqual(0, res.length);
+
+        res = db._query("FOR doc IN " + search2.name() + " SEARCH PHRASE(doc.text, 'foxx jumps over', 'text_en') RETURN doc").toArray();
         assertEqual(1, res.length);
       },
 

--- a/tests/js/server/dump/dump-test.inc
+++ b/tests/js/server/dump/dump-test.inc
@@ -279,7 +279,7 @@
         db._useDatabase("_system");
         try {
           db._useDatabase("UnitTestsDumpProperties1");
-          let props = db._properties();
+          var props = db._properties();
           assertEqual(1, props.replicationFactor);
           assertEqual(1, props.writeConcern);
           db._useDatabase("UnitTestsDumpProperties2");

--- a/tests/js/server/dump/dump-test.inc
+++ b/tests/js/server/dump/dump-test.inc
@@ -279,7 +279,7 @@
         db._useDatabase("_system");
         try {
           db._useDatabase("UnitTestsDumpProperties1");
-          var props = db._properties();
+          let props = db._properties();
           assertEqual(1, props.replicationFactor);
           assertEqual(1, props.writeConcern);
           db._useDatabase("UnitTestsDumpProperties2");
@@ -859,7 +859,7 @@
         let search2 = db._view("v_collection_documents_0_all");
         assertNotEqual(null, search2);
         assertEqual("v_collection_documents_0_all", search2.name());
-        let props = search2.properties();
+        props = search2.properties();
         assertEqual(props.indexes, [ { 'collection': 'collection_documents_0', 'index': 'collection_documents_0_all' }]);
 
         // After a restore, the Inverted index needs to be rebuilt, therefore

--- a/tests/js/server/dump/dump-test.inc
+++ b/tests/js/server/dump/dump-test.inc
@@ -835,10 +835,10 @@
 
       testSearch: function () {
         let collection1 = db._collection("searchCollection");
-        assertNotEqual(null, collection);
+        assertNotEqual(null, collection1);
 
         let collection2 = db._collection("v_collection_documents_0_all");
-        assertNotEqual(null, collection);
+        assertNotEqual(null, collection2);
 
         let index1 = collection1.index("searchIndex");
         assertTrue(index1.includeAllFields);
@@ -867,10 +867,10 @@
         // hope that the data will be there in due course:
 
         let res1 = db._query("FOR doc IN " + search1.name() + " SEARCH doc.value >= 0 OPTIONS { waitForSync: true } RETURN doc").toArray();
-        assertEqual(5000, res.length);
+        assertEqual(5000, res1.length);
 
         let res2 = db._query("FOR doc IN " + search2.name() + " SEARCH doc.value >= 0 OPTIONS { waitForSync: true } RETURN doc").toArray();
-        assertEqual(5000, res.length);
+        assertEqual(5000, res2.length);
 
 
         if (isServer) {
@@ -891,13 +891,13 @@
         let figures2;
         for (let i = 0; i < 100; ++i) {
           require("internal").sleep(0.5);
-          figures1 = collection.getIndexes(true, true)
+          figures1 = collection1.getIndexes(true, true)
             .find(e => e.name === "searchIndex")
             .figures;
-          figures2 = collection.getIndexes(true, true)
+          figures2 = collection2.getIndexes(true, true)
             .find(e => e.name === "collection_documents_0_all")
             .figures;
-          if (figures.numDocs > 5000) {
+          if (figures1.numDocs > 5000 && figures2.numDocs > 5000) {
             break;
           }
         }
@@ -913,7 +913,7 @@
         assertTrue(figures2.numFiles >= 7);
         assertTrue(figures2.indexSize > 0);
 
-        res = db._query("FOR doc IN " + search1.name() + " SEARCH doc.value >= 2500 RETURN doc").toArray();
+        let res = db._query("FOR doc IN " + search1.name() + " SEARCH doc.value >= 2500 RETURN doc").toArray();
         assertEqual(2500, res.length);
 
         res = db._query("FOR doc IN " + search1.name() + " SEARCH doc.value >= 5000 RETURN doc").toArray();


### PR DESCRIPTION
### Scope & Purpose

This PR add test which helps to reveal dump/restore bug: https://arangodb.atlassian.net/browse/SEARCH-401

- [ ] :hankey: Bugfix
- [X] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [X] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [X] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: *(Please link PR)*
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [X] Enterprise PR: https://github.com/arangodb/enterprise/pull/1082
- [X] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/SEARCH-401
- [ ] Design document: 

