### PR TITLE
[BTS-1043] Fix index executor

### DIFF
--- a/tests/js/server/aql/aql-index-skip-regression.js
+++ b/tests/js/server/aql/aql-index-skip-regression.js
@@ -1,0 +1,109 @@
+/*jshint globalstrict:false, strict:false, maxlen: 500 */
+/*global assertEqual, AQL_EXECUTE, assertTrue, fail */
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief tests for regression returning blocks to the manager
+///
+/// @file
+///
+/// DISCLAIMER
+///
+/// Copyright 2010-2014 triagens GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is triAGENS GmbH, Cologne, Germany
+///
+/// @author Markus Pfeiffer
+////////////////////////////////////////////////////////////////////////////////
+
+var jsunity = require("jsunity");
+var internal = require("internal");
+var errors = internal.errors;
+var db = require("@arangodb").db,
+  indexId;
+
+// This example was produced by Jan Steeman to reproduce a
+// crash in the TraversalExecutor code
+const movieCollectionName = "MOVIE";
+
+var cleanup = function() {
+  db._drop(movieCollectionName);
+};
+
+var createData = function() {
+  db._createDocumentCollection(movieCollectionName, {});
+
+  var data = [];
+
+  for(let i = 1; i <= 321; i++) {
+    data.push({ test_node: null});
+  }
+  for(let i = 1; i <= 1679; i++) {
+    data.push({ test_node: i});
+  }
+  db._collection(movieCollectionName).save(data);
+};
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief test suite
+////////////////////////////////////////////////////////////////////////////////
+
+function indexSkipRegressionSuite() {
+  return {
+    ////////////////////////////////////////////////////////////////////////////////
+    /// @brief set up
+    ////////////////////////////////////////////////////////////////////////////////
+
+    setUpAll: function() {
+      cleanup();
+      createData();
+    },
+
+    ////////////////////////////////////////////////////////////////////////////////
+    /// @brief tear down
+    ////////////////////////////////////////////////////////////////////////////////
+
+    tearDownAll: function() {
+      cleanup();
+    },
+
+    ////////////////////////////////////////////////////////////////////////////////
+    /// @brief test object access for path object
+    ////////////////////////////////////////////////////////////////////////////////
+    testIndexSkipCrashes: function() {
+      const query = `FOR doc IN @@value0
+                         FILTER doc['test_node'] != @value1
+			 SORT doc._key ASC
+			 LIMIT 1680, 10
+                         RETURN doc`;
+
+      const bindVars = {
+        "@value0": movieCollectionName,
+        "value1": null
+      };
+
+      var actual = db._query(query, bindVars);
+      var foo = actual.toArray();
+      assertEqual(foo.length, 0, "Expecting query result to contain 0 documents");
+    }
+  };
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief executes the test suite
+////////////////////////////////////////////////////////////////////////////////
+
+jsunity.run(indexSkipRegressionSuite);
+
+return jsunity.done();

--- a/tests/js/server/aql/aql-index-skip-regression.js
+++ b/tests/js/server/aql/aql-index-skip-regression.js
@@ -8,6 +8,7 @@
 ///
 /// DISCLAIMER
 ///
+/// Copyright 2015-2022 ArangoDB GmbH, Cologne, Germany
 /// Copyright 2010-2014 triagens GmbH, Cologne, Germany
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,37 +23,29 @@
 /// See the License for the specific language governing permissions and
 /// limitations under the License.
 ///
-/// Copyright holder is triAGENS GmbH, Cologne, Germany
-///
 /// @author Markus Pfeiffer
 ////////////////////////////////////////////////////////////////////////////////
 
-var jsunity = require("jsunity");
-var internal = require("internal");
-var errors = internal.errors;
-var db = require("@arangodb").db,
-  indexId;
+const jsunity = require("jsunity");
+const db = require("@arangodb").db;
 
-// This example was produced by Jan Steeman to reproduce a
-// crash in the TraversalExecutor code
 const movieCollectionName = "MOVIE";
 
-var cleanup = function() {
+const cleanup = function() {
   db._drop(movieCollectionName);
 };
 
-var createData = function() {
-  db._createDocumentCollection(movieCollectionName, {});
+const createData = function() {
+  let c = db._createDocumentCollection(movieCollectionName);
 
-  var data = [];
-
+  let data = [];
   for(let i = 1; i <= 321; i++) {
-    data.push({ test_node: null});
+    data.push({ test_node: null });
   }
   for(let i = 1; i <= 1679; i++) {
     data.push({ test_node: i});
   }
-  db._collection(movieCollectionName).save(data);
+  c.insert(data);
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -93,9 +86,8 @@ function indexSkipRegressionSuite() {
         "value1": null
       };
 
-      var actual = db._query(query, bindVars);
-      var foo = actual.toArray();
-      assertEqual(foo.length, 0, "Expecting query result to contain 0 documents");
+      var actual = db._query(query, bindVars).toArray();
+      assertEqual(actual.length, 0, "Expecting query result to contain 0 documents");
     }
   };
 }


### PR DESCRIPTION
### Scope & Purpose

This fixes the `IndexExecutor` so that it skips as many rows as it can.

Before this patch the IndexExecutor only skipped once, leading to unpredictable skips and assertions being triggered in maintainer mode.

This bug should not have any impact on correctness of returned results, just on performance.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [x] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [x] Tests
  - [x] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
