### PR TITLE
[CMAKE] Build Zkd Test with its own CMakeLists.txt

### DIFF
--- a/js/client/modules/@arangodb/testsuites/gtest.js
+++ b/js/client/modules/@arangodb/testsuites/gtest.js
@@ -114,7 +114,7 @@ function getGTestResults(fileName, defaultResults) {
 
 function gtestRunner (testname, options) {
   let results = { failed: 0 };
-  let rootDir = fs.join(fs.getTempPath(), 'gtest');
+  let rootDir = fs.join(fs.getTempPath(), 'gtest', testname);
   let testResultJsonFile = fs.join(rootDir, 'testResults.json');
 
   const run = locateGTest(testname);
@@ -128,10 +128,6 @@ function gtestRunner (testname, options) {
         argv.push('--gtest_filter='+options.testCase);
       } else {
         argv.push('--gtest_filter=-*_LongRunning');
-        /*let greylist =   readGreylist();
-        greylist.forEach(function(greyItem) {
-          argv.push('--gtest_filter=-'+greyItem);
-        });*/
       }
       // all non gtest args have to come last
       argv.push('--log.line-number');
@@ -148,7 +144,7 @@ function gtestRunner (testname, options) {
       results.basics = {
         failed: 1,
         status: false,
-        message: 'binary "arangodbtests" not found when trying to run suite "all-gtest"'
+        message: `binary ${testname} not found when trying to run suite "all-gtest"`
       };
     }
   }
@@ -157,12 +153,13 @@ function gtestRunner (testname, options) {
 
 exports.setup = function (testFns, defaultFns, opts, fnDocs, optionsDoc, allTestPaths) {
   Object.assign(allTestPaths, testPaths);
+
+  const tests = [ 'arangodbtests_zkd' ];
+
+  tests.forEach(name => testFns[name] = x => gtestRunner(name, x));
   testFns['gtest'] = x => gtestRunner('arangodbtests', x);
-  testFns['catch'] = x => gtestRunner('arangodbtests', x);
-  testFns['boost'] = x => gtestRunner('arangodbtests', x);
 
   opts['skipGtest'] = false;
-  opts['skipGeo'] = false; // not used anymore - only here for downwards-compatibility
 
   defaultFns.push('gtest');
 

--- a/js/client/modules/@arangodb/testsuites/gtest.js
+++ b/js/client/modules/@arangodb/testsuites/gtest.js
@@ -156,7 +156,9 @@ exports.setup = function (testFns, defaultFns, opts, fnDocs, optionsDoc, allTest
 
   const tests = [ 'arangodbtests_zkd' ];
 
-  tests.forEach(name => testFns[name] = x => gtestRunner(name, x));
+  for(const test of tests) {
+    testFns[test] = x => gtestRunner(test, x);
+  }
   testFns['gtest'] = x => gtestRunner('arangodbtests', x);
 
   opts['skipGtest'] = false;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -44,6 +44,8 @@ target_include_directories(fuertetest SYSTEM PRIVATE
 )
 
 
+add_subdirectory(Zkd)
+
 # ----------------------------------------
 # Link directories
 # ----------------------------------------

--- a/tests/Zkd/CMakeLists.txt
+++ b/tests/Zkd/CMakeLists.txt
@@ -1,0 +1,12 @@
+add_executable(arangodbtests_zkd
+  Conversion.cpp
+  Library.cpp
+  main.cpp)
+
+target_link_libraries(arangodbtests_zkd
+  arango_rocksdb
+  gtest)
+
+target_include_directories(arangodbtests_zkd PRIVATE
+  ${PROJECT_SOURCE_DIR}/arangod)
+

--- a/tests/Zkd/Conversion.cpp
+++ b/tests/Zkd/Conversion.cpp
@@ -151,9 +151,9 @@ TEST(Zkd_byte_string_conversion, bit_reader_test) {
 
   BitReader r(s);
   auto v = r.read_big_endian_bits(4);
-  EXPECT_EQ(0b1110, v);
+  EXPECT_EQ(0b1110u, v);
   auto v2 = r.read_big_endian_bits(5);
-  EXPECT_EQ(0b10101, v2);
+  EXPECT_EQ(0b10101u, v2);
 }
 
 TEST(Zkd_byte_string_conversion, bit_reader_test_different_sizes) {
@@ -162,12 +162,12 @@ TEST(Zkd_byte_string_conversion, bit_reader_test_different_sizes) {
   {
     BitReader r(s);
     auto v = r.read_big_endian_bits(1);
-    EXPECT_EQ(1, v);
+    EXPECT_EQ(1u, v);
   }
   {
     BitReader r(s);
     auto v = r.read_big_endian_bits(8);
-    EXPECT_EQ(1 << 7, v);
+    EXPECT_EQ(1u << 7, v);
   }
   {
     BitReader r(s);

--- a/tests/Zkd/main.cpp
+++ b/tests/Zkd/main.cpp
@@ -27,5 +27,5 @@ int main(int argc, char* argv[]) {
   ::testing::InitGoogleTest(&argc, argv);
   GTEST_FLAG_SET(death_test_style, "threadsafe");
 
-  return RUN_ALL_TESTS(); 
+  return RUN_ALL_TESTS();
 }

--- a/tests/Zkd/main.cpp
+++ b/tests/Zkd/main.cpp
@@ -25,10 +25,7 @@
 
 int main(int argc, char* argv[]) {
   ::testing::InitGoogleTest(&argc, argv);
-  // our gtest version is old and doesn't have the GTEST_FLAG_SET macro yet,
-  // thus this funny workaround for now.
-  // GTEST_FLAG_SET(death_test_style, "threadsafe");
-  (void)(::testing::GTEST_FLAG(death_test_style) = "threadsafe");
+  GTEST_FLAG_SET(death_test_style, "threadsafe");
 
   return RUN_ALL_TESTS(); 
 }

--- a/tests/Zkd/main.cpp
+++ b/tests/Zkd/main.cpp
@@ -1,0 +1,34 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2022 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Markus Pfeiffer
+////////////////////////////////////////////////////////////////////////////////
+
+#include "gtest/gtest.h"
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  // our gtest version is old and doesn't have the GTEST_FLAG_SET macro yet,
+  // thus this funny workaround for now.
+  // GTEST_FLAG_SET(death_test_style, "threadsafe");
+  (void)(::testing::GTEST_FLAG(death_test_style) = "threadsafe");
+
+  return RUN_ALL_TESTS(); 
+}


### PR DESCRIPTION
### Scope & Purpose

Build a binary `arangodb_zkd` using its own `CMakeLists.txt`.

Also build in a way to run this binary via the unittests script;

The Zkd tests are intentionally not yet removed from the full blown `arangodbtests` executable until there is a reliable way to run separate test binaries on jenkins.