### PR TITLE
Drop replicated states during database shutdown

### DIFF
--- a/arangod/Replication2/ReplicatedState/ReplicatedState.h
+++ b/arangod/Replication2/ReplicatedState/ReplicatedState.h
@@ -71,7 +71,9 @@ struct ReplicatedStateBase {
   virtual void start(
       std::unique_ptr<ReplicatedStateToken> token,
       std::optional<velocypack::SharedSlice> const& coreParameter) = 0;
-  virtual void drop() = 0;
+  virtual void drop() && = 0;
+  [[nodiscard]] virtual auto
+  resign() && -> std::unique_ptr<ReplicatedStateToken> = 0;
   virtual void rebuildMe(IStateManagerBase const* caller) noexcept = 0;
   [[nodiscard]] virtual auto getStatus() -> std::optional<StateStatus> = 0;
   [[nodiscard]] auto getLeader()
@@ -114,7 +116,9 @@ struct ReplicatedState final
   void start(
       std::unique_ptr<ReplicatedStateToken> token,
       std::optional<velocypack::SharedSlice> const& coreParameter) override;
-  void drop() override;
+  void drop() && override;
+  [[nodiscard]] auto
+  resign() && -> std::unique_ptr<ReplicatedStateToken> override;
   /**
    * Returns the follower state machine. Returns nullptr if no follower state
    * machine is present. (i.e. this server is not a follower)

--- a/arangod/VocBase/vocbase.cpp
+++ b/arangod/VocBase/vocbase.cpp
@@ -174,7 +174,7 @@ struct arangodb::VocBaseLogManager {
   auto resignStates() {
     _guardedData.doUnderLock([](auto& self) {
       for (auto&& [id, state] : self.states) {
-        state->drop();
+        std::ignore = std::move(*state).resign();
       }
       self.states.clear();
     });
@@ -255,7 +255,7 @@ struct arangodb::VocBaseLogManager {
         _server.getFeature<EngineSelectorFeature>().engine();
     return _guardedData.doUnderLock([&](GuardedData& data) {
       if (auto iter = data.states.find(id); iter != data.states.end()) {
-        iter->second->drop();
+        std::move(*iter->second).drop();
         auto res = engine.dropReplicatedState(_vocbase, id);
         if (res.fail()) {
           return res;

--- a/arangod/VocBase/vocbase.cpp
+++ b/arangod/VocBase/vocbase.cpp
@@ -171,7 +171,14 @@ struct arangodb::VocBaseLogManager {
                                   id.id());
   }
 
-  auto resignStates() { _guardedData.getLockedGuard()->states.clear(); }
+  auto resignStates() {
+    _guardedData.doUnderLock([](auto& self) {
+      for (auto&& [id, state] : self.states) {
+        state->drop();
+      }
+      self.states.clear();
+    });
+  }
 
   auto resignAll() {
     auto guard = _guardedData.getLockedGuard();

--- a/tests/Replication2/ReplicatedState/StateCleanupTest.cpp
+++ b/tests/Replication2/ReplicatedState/StateCleanupTest.cpp
@@ -86,7 +86,7 @@ TEST_F(ReplicatedStateCleanupTest, complete_run_without_resign) {
   state->start(std::make_unique<ReplicatedStateToken>(stateGeneration),
                std::nullopt);
 
-  state->drop();
+  std::move(*state).drop();
   auto cleanupHandler = factory->lastCleanupHandler;
   ASSERT_NE(cleanupHandler, nullptr);
   EXPECT_EQ(cleanupHandler->cores.size(), 1);


### PR DESCRIPTION
### Scope & Purpose

Drop replicated states during database shutdown. Without this, a replicated state could be kept alive after the database is gone, possibly resulting in unexpected errors.

- [X] :hankey: Bugfix
