### PR TITLE
BTS-1046: print test-info, correct invoking of exports

### DIFF
--- a/js/client/modules/@arangodb/testsuites/export.js
+++ b/js/client/modules/@arangodb/testsuites/export.js
@@ -36,11 +36,13 @@ const tu = require('@arangodb/testutils/test-utils');
 const im = require('@arangodb/testutils/instance-manager');
 const xmldom = require('@xmldom/xmldom');
 const zlib = require('zlib');
+const internal = require('internal');
 
-const CYAN = require('internal').COLORS.COLOR_CYAN;
-const RESET = require('internal').COLORS.COLOR_RESET;
+const CYAN = internal.COLORS.COLOR_CYAN;
+const RESET = internal.COLORS.COLOR_RESET;
+const GREEN = internal.COLORS.COLOR_GREEN;
 
-const toArgv = require('internal').toArgv;
+const toArgv = internal.toArgv;
 
 const testPaths = {
   'export': [tu.pathForTesting('server/export')] // we have to be fuzzy...
@@ -65,6 +67,7 @@ class exportRunner extends tu.runInArangoshRunner {
   }
 
   run() {
+    const timeout = 60;
     const tmpPath = fs.join(this.options.testOutputDirectory, 'export');
     const DOMParser = new xmldom.DOMParser({
       locator: {},
@@ -152,11 +155,13 @@ class exportRunner extends tu.runInArangoshRunner {
         args['collection'] = 'UnitTestsExport';
         args['type'] = 'json';
         testName = "exportJson" + idx;
-        results[testName] = pu.executeAndWait(pu.ARANGOEXPORT_BIN, toArgv(args), this.options, 'arangosh', tmpPath, this.options.coreCheck);
+        print(GREEN + Date() + " Executing " + testName + RESET);
+        results[testName] = pu.executeAndWait(pu.ARANGOEXPORT_BIN, toArgv(args), this.options, false, tmpPath, this.options.coreCheck, timeout);
         results[testName].failed = results[testName].status ? 0 : 1;
       }
       {
         testName = "parseJson" + idx;
+        print(GREEN + Date() + " Executing " + testName + RESET);
         try {
           JSON.parse(fs.read(fs.join(tmpPath, 'UnitTestsExport.json')));
           results[testName] = {
@@ -180,12 +185,14 @@ class exportRunner extends tu.runInArangoshRunner {
         args['collection'] = 'UnitTestsExport';
         args['type'] = 'json';
         testName = "exportJsonGz" + idx;
-        results[testName] = pu.executeAndWait(pu.ARANGOEXPORT_BIN, toArgv(args), this.options, 'arangosh', tmpPath, this.options.coreCheck);
+        print(GREEN + Date() + " Executing " + testName + RESET);
+        results[testName] = pu.executeAndWait(pu.ARANGOEXPORT_BIN, toArgv(args), this.options, false, tmpPath, this.options.coreCheck, timeout);
         results[testName].failed = results[testName].status ? 0 : 1;
 
       }
       {
         testName = "parseJsonGz" + idx;
+        print(GREEN + Date() + " Executing " + testName + RESET);
         try {
           const zipBuffer = fs.readGzip(fs.join(tmpPath, 'UnitTestsExport.json.gz'));
           JSON.parse(zipBuffer);
@@ -215,12 +222,14 @@ class exportRunner extends tu.runInArangoshRunner {
             }
 
             testName = "exportJsonEncrypt" + idx;
-            results[testName] = pu.executeAndWait(pu.ARANGOEXPORT_BIN, toArgv(args), this.options, 'arangosh', tmpPath, this.options.coreCheck);
+            print(GREEN + Date() + " Executing " + testName + RESET);
+            results[testName] = pu.executeAndWait(pu.ARANGOEXPORT_BIN, toArgv(args), this.options, false, tmpPath, this.options.coreCheck, timeout);
             results[testName].failed = results[testName].status ? 0 : 1;
 
           }
           {
             testName = "parseJsonEncrypt" + idx;
+            print(GREEN + Date() + " Executing " + testName + RESET);
             try {
               const decBuffer = fs.readDecrypt(fs.join(tmpPath, 'UnitTestsExport.json'), keyfile);
               JSON.parse(decBuffer);
@@ -249,11 +258,13 @@ class exportRunner extends tu.runInArangoshRunner {
         args['type'] = 'jsonl';
         args['collection'] = 'UnitTestsExport';
         testName = "exportJsonl" + idx;
-        results[testName] = pu.executeAndWait(pu.ARANGOEXPORT_BIN, toArgv(args), this.options, 'arangosh', tmpPath, this.options.coreCheck);
+        print(GREEN + Date() + " Executing " + testName + RESET);
+        results[testName] = pu.executeAndWait(pu.ARANGOEXPORT_BIN, toArgv(args), this.options, false, tmpPath, this.options.coreCheck, timeout);
         results[testName].failed = results[testName].status ? 0 : 1;
       }
       {
         testName = "parseJsonl" + idx;
+        print(GREEN + Date() + " Executing " + testName + RESET);
         try {
           fs.read(fs.join(tmpPath, 'UnitTestsExport.jsonl')).split('\n')
             .filter(line => line.trim() !== '')
@@ -280,11 +291,13 @@ class exportRunner extends tu.runInArangoshRunner {
         args['collection'] = 'UnitTestsExport';
         args['type'] = 'jsonl';
         testName = "exportJsonlGz" + idx;
-        results[testName] = pu.executeAndWait(pu.ARANGOEXPORT_BIN, toArgv(args), this.options, 'arangosh', tmpPath, this.options.coreCheck);
+        print(GREEN + Date() + " Executing " + testName + RESET);
+        results[testName] = pu.executeAndWait(pu.ARANGOEXPORT_BIN, toArgv(args), this.options, false, tmpPath, this.options.coreCheck, timeout);
         results[testName].failed = results[testName].status ? 0 : 1;
       }
       {
         testName = "parseJsonlGz" + idx;
+        print(GREEN + Date() + " Executing " + testName + RESET);
         try {
           fs.readGzip(fs.join(tmpPath, 'UnitTestsExport.jsonl.gz')).split('\n')
             .filter(line => line.trim() !== '')
@@ -311,11 +324,13 @@ class exportRunner extends tu.runInArangoshRunner {
         args['graph-name'] = 'UnitTestsExport';
         args['collection'] = 'UnitTestsExport';
         testName = "exportXgmml" + idx;
-        results[testName] = pu.executeAndWait(pu.ARANGOEXPORT_BIN, toArgv(args), this.options, 'arangosh', tmpPath, this.options.coreCheck);
+        print(GREEN + Date() + " Executing " + testName + RESET);
+        results[testName] = pu.executeAndWait(pu.ARANGOEXPORT_BIN, toArgv(args), this.options, false, tmpPath, this.options.coreCheck, timeout);
         results[testName].failed = results[testName].status ? 0 : 1;
       }
       {
         testName = "parseXgmml" + idx;
+        print(GREEN + Date() + " Executing " + testName + RESET);
         try {
           const filesContent = fs.read(fs.join(tmpPath, 'UnitTestsExport.xgmml'));
           DOMParser.parseFromString(filesContent);
@@ -348,11 +363,13 @@ class exportRunner extends tu.runInArangoshRunner {
         args['collection'] = 'UnitTestsExport';
         args['type'] = 'xgmml';
         testName = "exportXgmmlGz" + idx;
-        results[testName] = pu.executeAndWait(pu.ARANGOEXPORT_BIN, toArgv(args), this.options, 'arangosh', tmpPath, this.options.coreCheck);
+        print(GREEN + Date() + " Executing " + testName + RESET);
+        results[testName] = pu.executeAndWait(pu.ARANGOEXPORT_BIN, toArgv(args), this.options, false, tmpPath, this.options.coreCheck, timeout);
         results[testName].failed = results[testName].status ? 0 : 1;
       }
       {
         testName = "parseXgmmlGz" + idx;
+        print(GREEN + Date() + " Executing " + testName + RESET);
         try {
           const filesContent = fs.readGzip(fs.join(tmpPath, 'UnitTestsExport.xgmml.gz'));
           DOMParser.parseFromString(filesContent);
@@ -386,12 +403,14 @@ class exportRunner extends tu.runInArangoshRunner {
         args['type'] = 'jsonl';
         args['custom-query-file'] = tempFile;
         testName = "exportQueryFile" + idx;
-        results[testName] = pu.executeAndWait(pu.ARANGOEXPORT_BIN, toArgv(args), this.options, 'arangosh', tmpPath, this.options.coreCheck);
+        print(GREEN + Date() + " Executing " + testName + RESET);
+        results[testName] = pu.executeAndWait(pu.ARANGOEXPORT_BIN, toArgv(args), this.options, false, tmpPath, this.options.coreCheck, timeout);
         results[testName].failed = results[testName].status ? 0 : 1;
       }
 
       {
         testName = "parseQueryFile" + idx;
+        print(GREEN + Date() + " Executing " + testName + RESET);
         try {
           fs.read(fs.join(tmpPath, 'query.jsonl')).split('\n')
             .filter(line => line.trim() !== '')
@@ -417,12 +436,14 @@ class exportRunner extends tu.runInArangoshRunner {
         args['type'] = 'jsonl';
         args['custom-query'] = 'FOR doc IN UnitTestsExport RETURN doc';
         testName = "exportQuery" + idx;
-        results[testName] = pu.executeAndWait(pu.ARANGOEXPORT_BIN, toArgv(args), this.options, 'arangosh', tmpPath, this.options.coreCheck);
+        print(GREEN + Date() + " Executing " + testName + RESET);
+        results[testName] = pu.executeAndWait(pu.ARANGOEXPORT_BIN, toArgv(args), this.options, false, tmpPath, this.options.coreCheck, timeout);
         results[testName].failed = results[testName].status ? 0 : 1;
       }
 
       {
         testName = "parseQuery" + idx;
+        print(GREEN + Date() + " Executing " + testName + RESET);
         try {
           fs.read(fs.join(tmpPath, 'query.jsonl')).split('\n')
             .filter(line => line.trim() !== '')
@@ -452,11 +473,13 @@ class exportRunner extends tu.runInArangoshRunner {
         args['custom-query-bindvars'] = '{"@@collectionName": "UnitTestsExport", "value2": "this is export"}';
 
         testName = "exportQueryWithBindvars" + idx;
-        results[testName] = pu.executeAndWait(pu.ARANGOEXPORT_BIN, toArgv(args), this.options, 'arangosh', tmpPath, this.options.coreCheck);
+        print(GREEN + Date() + " Executing " + testName + RESET);
+        results[testName] = pu.executeAndWait(pu.ARANGOEXPORT_BIN, toArgv(args), this.options, false, tmpPath, this.options.coreCheck, timeout);
         results[testName].failed = results[testName].status ? 0 : 1;
       }
       {
         testName = "parseQueryWithBindvars" + idx;
+        print(GREEN + Date() + " Executing " + testName + RESET);
         try {
           fs.read(fs.join(tmpPath, 'query.jsonl')).split('\n')
             .filter(line => line.trim() !== '')
@@ -483,11 +506,13 @@ class exportRunner extends tu.runInArangoshRunner {
         args['compress-output'] = 'true';
         args['custom-query'] = 'FOR doc IN UnitTestsExport RETURN doc';
         testName = "exportQueryGz" + idx;
-        results[testName] = pu.executeAndWait(pu.ARANGOEXPORT_BIN, toArgv(args), this.options, 'arangosh', tmpPath, this.options.coreCheck);
+        print(GREEN + Date() + " Executing " + testName + RESET);
+        results[testName] = pu.executeAndWait(pu.ARANGOEXPORT_BIN, toArgv(args), this.options, false, tmpPath, this.options.coreCheck, timeout);
         results[testName].failed = results[testName].status ? 0 : 1;
       }
       {
         testName = "parseQueryGz" + idx;
+        print(GREEN + Date() + " Executing " + testName + RESET);
         try {
           fs.readGzip(fs.join(tmpPath, 'query.jsonl.gz')).split('\n')
             .filter(line => line.trim() !== '')
@@ -514,7 +539,8 @@ class exportRunner extends tu.runInArangoshRunner {
         args['fields'] = '_key,value1,value2,value3,value4';
 
         testName = "exportCsv" + idx;
-        results[testName] = pu.executeAndWait(pu.ARANGOEXPORT_BIN, toArgv(args), this.options, 'arangosh', tmpPath, false, this.options.coreCheck);
+        print(GREEN + Date() + " Executing " + testName + RESET);
+        results[testName] = pu.executeAndWait(pu.ARANGOEXPORT_BIN, toArgv(args), this.options, false, tmpPath, false, this.options.coreCheck, timeout);
         results[testName].failed = results[testName].status ? 0 : 1;
       }
       {
@@ -544,7 +570,8 @@ class exportRunner extends tu.runInArangoshRunner {
         args['fields'] = 'value1,value2,value3,value4';
 
         testName = "exportCsvEscaped" + idx;
-        results[testName] = pu.executeAndWait(pu.ARANGOEXPORT_BIN, toArgv(args), this.options, 'arangosh', tmpPath, false, this.options.coreCheck);
+        print(GREEN + Date() + " Executing " + testName + RESET);
+        results[testName] = pu.executeAndWait(pu.ARANGOEXPORT_BIN, toArgv(args), this.options, false, tmpPath, false, this.options.coreCheck, timeout);
         results[testName].failed = results[testName].status ? 0 : 1;
       }
       {
@@ -579,7 +606,8 @@ class exportRunner extends tu.runInArangoshRunner {
         args['fields'] = 'value1,value2,value3,value4';
 
         testName = "exportCsvEscapedFormulae" + idx;
-        results[testName] = pu.executeAndWait(pu.ARANGOEXPORT_BIN, toArgv(args), this.options, 'arangosh', tmpPath, false, this.options.coreCheck);
+        print(GREEN + Date() + " Executing " + testName + RESET);
+        results[testName] = pu.executeAndWait(pu.ARANGOEXPORT_BIN, toArgv(args), this.options, false, tmpPath, false, this.options.coreCheck, timeout);
         results[testName].failed = results[testName].status ? 0 : 1;
       }
       {
@@ -614,7 +642,8 @@ class exportRunner extends tu.runInArangoshRunner {
         args['fields'] = 'value1,value2,value3,value4';
 
         testName = "exportCsvUnescapedFormulae" + idx;
-        results[testName] = pu.executeAndWait(pu.ARANGOEXPORT_BIN, toArgv(args), this.options, 'arangosh', tmpPath, false, this.options.coreCheck);
+        print(GREEN + Date() + " Executing " + testName + RESET);
+        results[testName] = pu.executeAndWait(pu.ARANGOEXPORT_BIN, toArgv(args), this.options, false, tmpPath, false, this.options.coreCheck, timeout);
         results[testName].failed = results[testName].status ? 0 : 1;
       }
       {
@@ -648,7 +677,8 @@ class exportRunner extends tu.runInArangoshRunner {
         args['custom-query-max-runtime'] = '2.0';
 
         testName = "exportQueryMaxRuntimeFail" + idx;
-        results[testName] = pu.executeAndWait(pu.ARANGOEXPORT_BIN, toArgv(args), this.options, 'arangosh', tmpPath, this.options.coreCheck);
+        print(GREEN + Date() + " Executing " + testName + RESET);
+        results[testName] = pu.executeAndWait(pu.ARANGOEXPORT_BIN, toArgv(args), this.options, false, tmpPath, this.options.coreCheck, timeout);
         // we expect a failure here!
         results[testName].status = !results[testName].status;
         results[testName].failed = results[testName].status ? 0 : 1;
@@ -661,7 +691,8 @@ class exportRunner extends tu.runInArangoshRunner {
         args['custom-query'] = 'RETURN SLEEP(3)';
         args['custom-query-max-runtime'] = '20.0';
         testName = "exportQueryMaxRuntimeOk" + idx;
-        results[testName] = pu.executeAndWait(pu.ARANGOEXPORT_BIN, toArgv(args), this.options, 'arangosh', tmpPath, this.options.coreCheck);
+        print(GREEN + Date() + " Executing " + testName + RESET);
+        results[testName] = pu.executeAndWait(pu.ARANGOEXPORT_BIN, toArgv(args), this.options, false, tmpPath, this.options.coreCheck, timeout);
         results[testName].failed = results[testName].status ? 0 : 1;
       }
     });


### PR DESCRIPTION
### Scope & Purpose

- Parameters weren't properly aligned
- specify proper timeouts
- no information connecting the result to the part of the log was printed

- [x] :hankey: Bugfix
- [ ] Backports
  - [ ] Backport for 3.10: *(Please link PR)*
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*
