### PR TITLE
Fix view properties change replication

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,11 @@
 v3.9.4 (XXXX-XX-XX)
 -------------------
 
+* Fix an issue with replication of arangosearch view change entries in single
+  server replication and active failover. Previously, when changing the
+  properties of existing views, the changes were not properly picked up by
+  followers in these setups. Cluster setups were not affected.
+
 * Improve upload and download speed of hotbackup by changing the way we use
   rclone. Empty hash files are now uploaded or downloaded by pattern, and all
   other files are done in batches without remote directory listing, which allows

--- a/arangod/Replication/TailingSyncer.cpp
+++ b/arangod/Replication/TailingSyncer.cpp
@@ -960,14 +960,7 @@ Result TailingSyncer::changeView(VPackSlice const& slice) {
     }
   }
 
-  VPackSlice properties = data.get("properties");
-
-  if (properties.isObject()) {
-    // always a full-update
-    return view->properties(properties, false, false);
-  }
-
-  return {};
+  return view->properties(data, false, true);
 }
 
 /// @brief apply a single marker from the continuous log

--- a/tests/js/server/replication/static/replication-static.js
+++ b/tests/js/server/replication/static/replication-static.js
@@ -1927,7 +1927,7 @@ function BaseTestConfig () {
         }
       );
     },
-
+    
     testViewBasic: function () {
       compare(
         function (state) {
@@ -1951,7 +1951,7 @@ function BaseTestConfig () {
           }
 
           let view = db._view('UnitTestsSyncView');
-          assertTrue(view !== null);
+          assertNotNull(view);
           let props = view.properties();
           assertEqual(Object.keys(props.links).length, 1);
           assertTrue(props.hasOwnProperty('links'));


### PR DESCRIPTION
### Scope & Purpose

Fix issue https://arangodb.atlassian.net/browse/BTS-1036
Partial backport of https://github.com/arangodb/arangodb/pull/17177

* Fix an issue with replication of arangosearch view change entries in single server replication and active failover. Previously, when changing the properties of existing views, the changes were not properly picked up by followers in these setups. Cluster setups were not affected.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [x] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [x] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [x] Backports
  - [x] Backport for 3.10: https://github.com/arangodb/arangodb/pull/17202
  - [x] Backport for 3.9: this PR
  - [x] Backport for 3.8: https://github.com/arangodb/arangodb/pull/17211

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [x] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/BTS-1036
- [ ] Design document: 