### PR TITLE
[PREGEL] Aggregate response results

### DIFF
--- a/arangod/Pregel/Conductor/States/ComputingState.cpp
+++ b/arangod/Pregel/Conductor/States/ComputingState.cpp
@@ -7,6 +7,7 @@
 #include "Pregel/PregelFeature.h"
 #include "Pregel/WorkerConductorMessages.h"
 #include "velocypack/Builder.h"
+#include "velocypack/Iterator.h"
 
 using namespace arangodb::pregel::conductor;
 
@@ -72,25 +73,29 @@ auto Computing::_prepareGlobalSuperStep()
                                  .vertexCount = conductor._totalVerticesCount,
                                  .edgeCount = conductor._totalEdgesCount})
       .thenValue([&](auto results) -> ResultT<VPackBuilder> {
-        VPackBuilder messagesFromWorkers;
-        for (auto const& result : results) {
-          if (result.get().fail()) {
-            return Result{
-                result.get().errorNumber(),
-                fmt::format("Got unsuccessful response from worker "
-                            "while preparing global super step {}: {}\n",
-                            conductor._globalSuperstep,
-                            result.get().errorMessage())};
+        auto globalSuperStepPrepared = GlobalSuperStepPrepared{};
+        {
+          for (auto const& result : results) {
+            if (result.get().fail()) {
+              return Result{
+                  result.get().errorNumber(),
+                  fmt::format("Got unsuccessful response from worker "
+                              "while preparing global super step {}: {}\n",
+                              conductor._globalSuperstep,
+                              result.get().errorMessage())};
+            }
+            globalSuperStepPrepared.add(result.get().get());
           }
-          auto gssPrepared = result.get().get();
-          conductor._aggregators->aggregateValues(
-              gssPrepared.aggregators.slice());
-          messagesFromWorkers.add(gssPrepared.messages.slice());
-          conductor._statistics.accumulateActiveCounts(gssPrepared.activeCount);
-          conductor._totalVerticesCount += gssPrepared.vertexCount;
-          conductor._totalEdgesCount += gssPrepared.edgeCount;
         }
-        return messagesFromWorkers;
+        auto aggregators = globalSuperStepPrepared.aggregators.slice();
+        for (auto aggregator : VPackArrayIterator(aggregators)) {
+          conductor._aggregators->aggregateValues(aggregator);
+        }
+        conductor._statistics.accumulateActiveCounts(
+            globalSuperStepPrepared.activeCount);
+        conductor._totalVerticesCount += globalSuperStepPrepared.vertexCount;
+        conductor._totalEdgesCount += globalSuperStepPrepared.edgeCount;
+        return globalSuperStepPrepared.messages;
       });
 }
 
@@ -127,6 +132,7 @@ auto Computing::_runGlobalSuperStep(bool activateAll)
       << "Initiate starting GSS: " << startCommand.slice().toJson();
   return conductor._workers.runGlobalSuperStep(runGlobalSuperStepCommand)
       .thenValue([&](auto results) -> Result {
+        auto globalSuperStepFinished = GlobalSuperStepFinished{};
         for (auto const& result : results) {
           if (result.get().fail()) {
             return Result{result.get().errorNumber(),
@@ -135,9 +141,9 @@ auto Computing::_runGlobalSuperStep(bool activateAll)
                                       conductor._globalSuperstep,
                                       result.get().errorMessage())};
           }
-          auto finished = result.get().get();
-          conductor._statistics.accumulate(finished.messageStats);
+          globalSuperStepFinished.add(result.get().get());
         }
+        conductor._statistics.accumulate(globalSuperStepFinished.messageStats);
         conductor._timing.gss.back().finish();
         LOG_PREGEL_CONDUCTOR("39385", DEBUG)
             << "Finished gss " << conductor._globalSuperstep << " in "

--- a/arangod/Pregel/Conductor/States/FatalErrorState.cpp
+++ b/arangod/Pregel/Conductor/States/FatalErrorState.cpp
@@ -16,24 +16,18 @@ FatalError::FatalError(Conductor& conductor) : conductor{conductor} {
 auto FatalError::getResults(bool withId) -> ResultT<PregelResults> {
   return conductor._workers.results(CollectPregelResults{.withId = withId})
       .thenValue([&](auto responses) -> ResultT<PregelResults> {
-        VPackBuilder pregelResults;
-        {
-          VPackArrayBuilder ab(&pregelResults);
-          for (auto const& response : responses) {
-            if (response.get().fail()) {
-              return Result{TRI_ERROR_INTERNAL,
-                            fmt::format("Got unsuccessful response from worker "
-                                        "while requesting results: "
-                                        "{}",
-                                        response.get().errorMessage())};
-            }
-            if (auto slice = response.get().get().results.slice();
-                slice.isArray()) {
-              pregelResults.add(VPackArrayIterator(slice));
-            }
+        PregelResults pregelResults;
+        for (auto const& response : responses) {
+          if (response.get().fail()) {
+            return Result{TRI_ERROR_INTERNAL,
+                          fmt::format("Got unsuccessful response from worker "
+                                      "while requesting results: "
+                                      "{}",
+                                      response.get().errorMessage())};
           }
+          pregelResults.add(response.get().get());
         }
-        return PregelResults{pregelResults};
+        return pregelResults;
       })
       .get();
 }

--- a/arangod/Pregel/Conductor/States/FatalErrorState.cpp
+++ b/arangod/Pregel/Conductor/States/FatalErrorState.cpp
@@ -15,17 +15,11 @@ FatalError::FatalError(Conductor& conductor) : conductor{conductor} {
 
 auto FatalError::getResults(bool withId) -> ResultT<PregelResults> {
   return conductor._workers.results(CollectPregelResults{.withId = withId})
-      .thenValue([&](auto responses) -> ResultT<PregelResults> {
-        PregelResults pregelResults;
-        for (auto const& response : responses) {
-          if (response.get().fail()) {
-            return Result{TRI_ERROR_INTERNAL,
-                          fmt::format("Got unsuccessful response from worker "
-                                      "while requesting results: "
-                                      "{}",
-                                      response.get().errorMessage())};
-          }
-          pregelResults.add(response.get().get());
+      .thenValue([&](auto pregelResults) -> ResultT<PregelResults> {
+        if (pregelResults.fail()) {
+          return Result{pregelResults.errorNumber(),
+                        fmt::format("While requesting pregel results: {}",
+                                    pregelResults.errorMessage())};
         }
         return pregelResults;
       })

--- a/arangod/Pregel/Conductor/States/LoadingState.cpp
+++ b/arangod/Pregel/Conductor/States/LoadingState.cpp
@@ -59,20 +59,14 @@ auto Loading::_createWorkers() -> futures::Future<Result> {
 
 auto Loading::_loadGraph() -> futures::Future<Result> {
   return conductor._workers.loadGraph(LoadGraph{})
-      .thenValue([&](auto results) -> Result {
-        auto graphLoaded = GraphLoaded{};
-        for (auto const& result : results) {
-          if (result.get().fail()) {
-            return Result{result.get().errorNumber(),
-                          fmt::format("Got unsuccessful response from worker "
-                                      "while loading graph: "
-                                      "{}\n",
-                                      result.get().errorMessage())};
-          }
-          graphLoaded.add(result.get().get());
+      .thenValue([&](auto graphLoaded) -> Result {
+        if (graphLoaded.fail()) {
+          return Result{graphLoaded.errorNumber(),
+                        fmt::format("While loading graph: {}",
+                                    graphLoaded.errorMessage())};
         }
-        conductor._totalVerticesCount += graphLoaded.vertexCount;
-        conductor._totalEdgesCount += graphLoaded.edgeCount;
+        conductor._totalVerticesCount += graphLoaded.get().vertexCount;
+        conductor._totalEdgesCount += graphLoaded.get().edgeCount;
         return Result{};
       });
 }


### PR DESCRIPTION
When a worker responds to a conductor request, the similar actions are executed, regardless of the request type that was send. Therefore, this PR moves these actions defined in the different conductor states to a single point: the Worker API.
After all workers responded back, the responses are first aggregated (via the new add function of the messages) and only the aggregate is given back to the conductor state where the conductor properties are changed depending on the aggregate.
This has several advantages:
- The states do not have to worry about responses from single workers, this is all handled inside the worker API
- The Worker API implements the NewIWorker interface
- The actions executed when workers respond back are now streamlined for all message types send by workers to the conductor
 
This implementation will probably change a bit when we now want to use the Actor model. But this refactoring is still helpful because it moves the similar actions that are executed in every conductor state to a single place.