### PR TITLE
Removing intentional sleep from tests

### DIFF
--- a/tests/js/client/shell/transaction/shell-transaction.js
+++ b/tests/js/client/shell/transaction/shell-transaction.js
@@ -4871,15 +4871,6 @@ function makeTestSuites(testSuite) {
   // for the transaction. Since this class is currently not covered by unittests, these tests are
   // parameterized to cover both cases.
   deriveTestSuite(testSuite({replicationVersion: "2"}), suiteV2, "_V2");
-
-  // TODO this is a temporary workaround to prevent deleting the collection while followers
-  //  are still processing entries
-  const tearDown = suiteV2.tearDown;
-  suiteV2.tearDown = function() {
-    internal.sleep(1);
-    tearDown();
-  };
-
   return [suiteV1, suiteV2];
 }
 

--- a/tests/js/server/replication2/replication2-supervision-replicated-log-target-cluster.js
+++ b/tests/js/server/replication2/replication2-supervision-replicated-log-target-cluster.js
@@ -277,7 +277,6 @@ const replicatedLogSuite = function () {
           expectedDocumentsInserted[quorum.index] = secondDoc;
           assertTrue(quorum.result.quorum.quorum.indexOf(followers[0]) === -1);
         }
-        print(log.status());
       }
 
       // now stop the leader


### PR DESCRIPTION
### Scope & Purpose

Previously, we had to wait a second after each replication2 test, making sure that the collection is not deleted while the follower is still processing ongoing transactions. This wait is no longer needed, because the replicated state is now responsible for removing its own collection.