### PR TITLE
[Inspector] Add inline types for variants

### DIFF
--- a/lib/Inspection/Format.h
+++ b/lib/Inspection/Format.h
@@ -57,12 +57,15 @@ struct fmt::formatter<VPackSlice> {
   template<typename FormatContext>
   auto format(VPackSlice const& slice, FormatContext& ctx) const
       -> decltype(ctx.out()) {
+    arangodb::velocypack::Options options =
+        arangodb::velocypack::Options::Defaults;
+    options.dumpAttributesInIndexOrder = false;
     switch (presentation) {
       case Presentation::Pretty:
-        return fmt::format_to(ctx.out(), "{}", slice.toString());
+        return fmt::format_to(ctx.out(), "{}", slice.toString(&options));
       case Presentation::NotPretty:
       default:
-        return fmt::format_to(ctx.out(), "{}", slice.toJson());
+        return fmt::format_to(ctx.out(), "{}", slice.toJson(&options));
     }
   }
 };

--- a/lib/Inspection/README.md
+++ b/lib/Inspection/README.md
@@ -355,8 +355,10 @@ else. But if none of these checks fail, we simply have to try to parse into an
 instance of the current target type, so we have to create a default constructed
 instance.
 
-Inline types are always checked first. Only if none of those could be parsed
-we move on to the non-inline types.
+Inline types are always checked first (and therefore also _must_ be listed
+before the non-inline types, otherwise you will get a compiler error pointing
+this out). Only if none of those could be parsed we move on to the non-inline
+types.
 
 In "qualified" form the variant is serialized as an object with two attributes
 as specified in the `qualified` call. For example:

--- a/lib/Inspection/README.md
+++ b/lib/Inspection/README.md
@@ -340,7 +340,9 @@ straightforward, but for parsing we somehow have to determine the type based
 on the data. Basically how this is done is that we simply try to parse each of
 the inline types (in the order in which they are specified). If the parse was
 successful, then that is the type and value that we use, otherwise we continue
-with the next type.
+with the next type. So if you have two types `A` and `B` where `A` is a
+supertype of `B` (i.e., every possible value for `B` would also be a possible
+value for `A` - for example double/int), then `B` must be listed before `A`.
 
 Note: _any_ errors (including failed invariants) that occur while trying to
 parse inline types are _ignored_ and the type is dismissed!

--- a/lib/Inspection/README.md
+++ b/lib/Inspection/README.md
@@ -312,7 +312,11 @@ wrapped type is created and inspected recursively.
 
 Even though support for variants is built-in, the inspection library needs some
 additional information about the variant type. There is an API to describe
-variants - very similar to what we previously saw for objects.
+variants - very similar to what we previously saw for objects. There are
+different ways how a variant value can be encoded. There are inline types and
+non-inline types. The latter have a dedicated type indicator field while the
+first ones do not. Non-inline types can come in three different forms -
+"qualified", "unqualified" and "embedded".
 
 Consider the following example:
 ```cpp
@@ -322,20 +326,42 @@ template<class Inspector>
 auto inspect(Inspector& f, MyVariant& x) {
   namespace insp = arangodb::inspection;
   return f.variant(x).qualified("type", "value").alternatives(
-      insp::type<std::string>("string"),
+      insp::inlineType<std::string>(),
       insp::type<int>("int"),
       insp::type<Struct1>("Struct1"));
 }
 ```
-This serializes/deserializes the variant in "qualified form". At the moment
-there are three supported forms - "qualified", "unqualified" and "embedded".
+This serializes/deserializes the variant in "qualified form", where `string` is
+defined as an inline type, while `int` and `Struct1` are non-inline types.
+
+As already mentioned, inline types do not have a type indicator, but instead
+the values are just directly stored as-is. So writing inline types is very
+straightforward, but for parsing we somehow have to determine the type based
+on the data. Basically how this is done is that we simply try to parse each of
+the inline types (in the order in which they are specified). If the parse was
+successful, then that is the type and value that we use, otherwise we continue
+with the next type.
+
+Note: _any_ errors (including failed invariants) that occur while trying to
+parse inline types are _ignored_ and the type is dismissed!
+
+Inline types are primarily useful for scalar types like `string`, `int` or
+`bool`, but you can actually use it for arbitrary types. We try to be smart and
+rule out some cases that we know will fail to parse based on the velocypack
+type, e.g., if our target type is `string` and the velocypack type is something
+else. But if none of these checks fail, we simply have to try to parse into an
+instance of the current target type, so we have to create a default constructed
+instance.
+
+Inline types are always checked first. Only if none of those could be parsed
+we move on to the non-inline types.
 
 In "qualified" form the variant is serialized as an object with two attributes
 as specified in the `qualified` call. For example:
 ```
 {
-  "type": "string",
-  "value: "foobar"
+  "type": "int",
+  "value: 42
 }
 ```
 In "unqualified" form the variant is also serialized as an object, but only
@@ -357,9 +383,9 @@ Then the generated result would instead look like this:
   "string": "foobar"
 }
 ```
-The "embedded" form can only be used if all types in the variant are inspected
-as objects. In this form the type indicator field is then serialized on the
-same level as the object fields:
+The "embedded" form can only be used if all types (except for the inline types)
+in the variant are inspected as objects. In this form the type indicator field
+is then serialized on the same level as the object fields:
 ```cpp
 struct Struct1 { int a; }:
 struct Struct2 { int b; }:

--- a/lib/Inspection/Types.h
+++ b/lib/Inspection/Types.h
@@ -31,13 +31,25 @@ namespace detail {
 template<class T>
 struct AlternativeType {
   using Type = T;
+  static constexpr bool isInlineType = false;
   std::string_view const tag;
+};
+
+template<class T>
+struct AlternativeInlineType {
+  using Type = T;
+  static constexpr bool isInlineType = true;
 };
 }  // namespace detail
 
 template<class T>
 detail::AlternativeType<T> type(std::string_view tag) {
   return detail::AlternativeType<T>{tag};
+}
+
+template<class T>
+detail::AlternativeInlineType<T> inlineType() {
+  return detail::AlternativeInlineType<T>{};
 }
 
 }  // namespace arangodb::inspection

--- a/lib/Inspection/VPackLoadInspector.h
+++ b/lib/Inspection/VPackLoadInspector.h
@@ -40,6 +40,7 @@
 
 #include "Inspection/InspectorBase.h"
 #include "Inspection/Status.h"
+#include "Inspection/detail/traits.h"
 #include "velocypack/ValueType.h"
 
 namespace arangodb::inspection {
@@ -556,8 +557,10 @@ struct VPackLoadInspectorImpl
       return isInt(type);
     } else if constexpr (std::is_floating_point_v<T>) {
       return type == ValueType::Double || isInt(type);
-    } else if constexpr (detail::IsListLike<T>::value ||
-                         detail::IsTuple<T>::value) {
+    } else if constexpr (detail::IsTuple<T>::value) {
+      return type == ValueType::Array &&
+             detail::TupleSize<T>::value == _slice.length();
+    } else if constexpr (detail::IsListLike<T>::value) {
       return type == ValueType::Array;
     } else if constexpr (detail::IsMapLike<T>::value) {
       return type == ValueType::Object;

--- a/lib/Inspection/VPackSaveInspector.h
+++ b/lib/Inspection/VPackSaveInspector.h
@@ -150,7 +150,7 @@ struct VPackSaveInspector
       typename Base::template UnqualifiedVariant<Ts...>& variant,
       Args&&... args) {
     return std::visit(
-        overload{[this, &args](typename Args::Type& v) {
+        overload{[&](typename Args::Type& v) {
           if constexpr (Args::isInlineType) {
             return this->apply(v);
           } else {
@@ -165,7 +165,7 @@ struct VPackSaveInspector
   template<class... Ts, class... Args>
   auto processVariant(typename Base::template QualifiedVariant<Ts...>& variant,
                       Args&&... args) {
-    return std::visit(overload{[this, &args, &variant](typename Args::Type& v) {
+    return std::visit(overload{[&](typename Args::Type& v) {
                         if constexpr (Args::isInlineType) {
                           return this->apply(v);
                         } else {
@@ -185,7 +185,7 @@ struct VPackSaveInspector
   template<class... Ts, class... Args>
   auto processVariant(typename Base::template EmbeddedVariant<Ts...>& variant,
                       Args&&... args) {
-    return std::visit(overload{[this, &variant, &args](typename Args::Type& v) {
+    return std::visit(overload{[&](typename Args::Type& v) {
                         if constexpr (Args::isInlineType) {
                           return this->apply(v);
                         } else {

--- a/lib/Inspection/VPackSaveInspector.h
+++ b/lib/Inspection/VPackSaveInspector.h
@@ -149,47 +149,57 @@ struct VPackSaveInspector
   auto processVariant(
       typename Base::template UnqualifiedVariant<Ts...>& variant,
       Args&&... args) {
-    return beginObject()  //
-           |
-           [&]() {
-             return std::visit(overload{[this, &args](typename Args::Type& v) {
-                                 return applyFields(this->field(args.tag, v));
-                               }...},
-                               variant.value);
-           }  //
-           | [&]() { return endObject(); };
+    return std::visit(
+        overload{[this, &args](typename Args::Type& v) {
+          if constexpr (Args::isInlineType) {
+            return this->apply(v);
+          } else {
+            return beginObject()                                             //
+                   | [&]() { return applyField(this->field(args.tag, v)); }  //
+                   | [&]() { return endObject(); };
+          }
+        }...},
+        variant.value);
   }
 
   template<class... Ts, class... Args>
   auto processVariant(typename Base::template QualifiedVariant<Ts...>& variant,
                       Args&&... args) {
-    return beginObject()  //
-           |
-           [&]() {
-             return std::visit(
-                 overload{[this, &variant, &args](typename Args::Type& v) {
-                   return applyFields(this->field(variant.typeField, args.tag),
-                                      this->field(variant.valueField, v));
-                 }...},
-                 variant.value);
-           }  //
-           | [&]() { return endObject(); };
+    return std::visit(overload{[this, &args, &variant](typename Args::Type& v) {
+                        if constexpr (Args::isInlineType) {
+                          return this->apply(v);
+                        } else {
+                          auto storeFields = [&]() {
+                            return applyFields(
+                                this->field(variant.typeField, args.tag),
+                                this->field(variant.valueField, v));
+                          };
+                          return beginObject()  //
+                                 | storeFields  //
+                                 | [&]() { return endObject(); };
+                        }
+                      }...},
+                      variant.value);
   }
 
   template<class... Ts, class... Args>
   auto processVariant(typename Base::template EmbeddedVariant<Ts...>& variant,
                       Args&&... args) {
-    return beginObject()  //
-           |
-           [&]() {
-             return std::visit(
-                 overload{[this, &variant, &args](typename Args::Type& v) {
-                   return applyFields(this->field(variant.typeField, args.tag),
-                                      this->embedFields(v));
-                 }...},
-                 variant.value);
-           }  //
-           | [&]() { return endObject(); };
+    return std::visit(overload{[this, &variant, &args](typename Args::Type& v) {
+                        if constexpr (Args::isInlineType) {
+                          return this->apply(v);
+                        } else {
+                          auto storeFields = [&]() {
+                            return applyFields(
+                                this->field(variant.typeField, args.tag),
+                                this->embedFields(v));
+                          };
+                          return beginObject()  //
+                                 | storeFields  //
+                                 | [&]() { return endObject(); };
+                        }
+                      }...},
+                      variant.value);
   }
 
   velocypack::Builder& builder() noexcept { return _builder; }

--- a/lib/Inspection/detail/traits.h
+++ b/lib/Inspection/detail/traits.h
@@ -110,6 +110,24 @@ template<class T>
 struct IsTuple<T, std::void_t<typename std::tuple_size<T>::type>>
     : std::true_type {};
 
+template<class T>
+struct TupleSize;
+
+template<class T, std::size_t Size>
+struct TupleSize<std::array<T, Size>> {
+  static constexpr std::size_t value = Size;
+};
+
+template<class... Ts>
+struct TupleSize<std::tuple<Ts...>> {
+  static constexpr std::size_t value = sizeof...(Ts);
+};
+
+template<class T1, class T2>
+struct TupleSize<std::pair<T1, T2>> {
+  static constexpr std::size_t value = 2;
+};
+
 template<class T, std::size_t = sizeof(T)>
 std::true_type IsCompleteTypeImpl(T*);
 

--- a/tests/Basics/InspectionTest.cpp
+++ b/tests/Basics/InspectionTest.cpp
@@ -481,8 +481,8 @@ template<class Inspector>
 auto inspect(Inspector& f, MyUnqualifiedVariant& x) {
   namespace insp = arangodb::inspection;
   return f.variant(x).unqualified().alternatives(
-      insp::type<std::string>("string"),   //
       insp::inlineType<int>(),             //
+      insp::type<std::string>("string"),   //
       insp::type<Struct1>("Struct1"),      //
       insp::type<Struct2>("Struct2"),      //
       insp::type<std::monostate>("nil"));  //
@@ -508,10 +508,10 @@ template<class Inspector>
 auto inspect(Inspector& f, MyEmbeddedVariant& x) {
   namespace insp = arangodb::inspection;
   return f.variant(x).embedded("t").alternatives(
-      insp::type<Struct1>("Struct1"),  //
-      insp::type<Struct2>("Struct2"),  //
-      insp::type<Struct3>("Struct3"),  //
-      insp::inlineType<bool>());       //
+      insp::inlineType<bool>(),         //
+      insp::type<Struct1>("Struct1"),   //
+      insp::type<Struct2>("Struct2"),   //
+      insp::type<Struct3>("Struct3"));  //
 }
 
 template<class Inspector>

--- a/tests/Basics/InspectionTest.cpp
+++ b/tests/Basics/InspectionTest.cpp
@@ -2658,17 +2658,17 @@ TEST_F(VPackInspectionTest, formatter) {
 
   auto def = fmt::format("My name is {}", d);
   EXPECT_EQ(def,
-            "My name is {\"b\":true,\"d\":123.456,\"i\":42,\"s\":\"cheese\"}");
+            "My name is {\"i\":42,\"d\":123.456,\"b\":true,\"s\":\"cheese\"}");
 
   auto notPretty = fmt::format("My name is {:u}", d);
   EXPECT_EQ(notPretty,
-            "My name is {\"b\":true,\"d\":123.456,\"i\":42,\"s\":\"cheese\"}");
+            "My name is {\"i\":42,\"d\":123.456,\"b\":true,\"s\":\"cheese\"}");
   EXPECT_EQ(def, notPretty);
 
   auto pretty = fmt::format("My name is {:p}", d);
   EXPECT_EQ(pretty,
-            "My name is {\n  \"b\" : true,\n  \"d\" : 123.456,\n  \"i\" : "
-            "42,\n  \"s\" : \"cheese\"\n}");
+            "My name is {\n  \"i\" : 42,\n  \"d\" : 123.456,\n  \"b\" : "
+            "true,\n  \"s\" : \"cheese\"\n}");
 }
 
 TEST_F(VPackInspectionTest, deserialize) {


### PR DESCRIPTION
### Scope & Purpose

Adds the concept of variant "inline types" to the inspector. Inline types are types without a dedicated type field and are instead parsed by "trying" to parse each type. This is particularly useful for scalar types like string, int, etc.

- [x] :pizza: New feature

### Checklist

- [x] Tests
  - [x] C++ **Unit tests**
  