### PR TITLE
[PREGEL] Delete unused master context methods

### DIFF
--- a/arangod/Pregel/Algos/ShortestPath.cpp
+++ b/arangod/Pregel/Algos/ShortestPath.cpp
@@ -57,7 +57,6 @@ struct SPComputation : public VertexComputation<int64_t, int64_t, int64_t> {
       if (this->pregelId() == _target) {
         // TODO extend pregel to update certain aggregators during a GSS
         aggregate(spUpperPathBound, current);
-        enterNextGlobalSuperstep();
         LOG_TOPIC("0267f", DEBUG, Logger::PREGEL) << "Found target " << current;
         return;
       }

--- a/arangod/Pregel/Conductor/Conductor.h
+++ b/arangod/Pregel/Conductor/Conductor.h
@@ -65,7 +65,6 @@ struct Error {
 };
 
 struct PostGlobalSuperStepResult {
-  bool activateAll;
   bool finished;
 };
 
@@ -119,7 +118,6 @@ class Conductor : public std::enable_shared_from_this<Conductor> {
   uint64_t _maxSuperstep = 500;
   bool _useMemoryMaps = true;
   bool _storeResults = false;
-  bool _inErrorAbort = false;
 
   /// persistent tracking of active vertices, send messages, runtimes
   StatsManager _statistics;
@@ -139,9 +137,8 @@ class Conductor : public std::enable_shared_from_this<Conductor> {
 
   auto _changeState(std::unique_ptr<conductor::State> newState) -> void;
   auto _initializeWorkers() -> futures::Future<Result>;
-  auto _preGlobalSuperStep() -> bool;
-  auto _postGlobalSuperStep(VPackBuilder messagesFromWorkers)
-      -> PostGlobalSuperStepResult;
+  auto _preGlobalSuperStep() -> void;
+  auto _postGlobalSuperStep() -> PostGlobalSuperStepResult;
   void _cleanup();
 
   // === REST callbacks ===

--- a/arangod/Pregel/Conductor/States/CanceledState.cpp
+++ b/arangod/Pregel/Conductor/States/CanceledState.cpp
@@ -59,10 +59,6 @@ auto Canceled::_cleanupUntilTimeout(std::chrono::steady_clock::time_point start)
           std::this_thread::sleep_for(_retryInterval);
           return _cleanupUntilTimeout(start).get();
         }
-
-        if (conductor._inErrorAbort) {
-          return Result{TRI_ERROR_INTERNAL, "Conductor in error"};
-        }
         return Result{};
       });
 }

--- a/arangod/Pregel/Conductor/States/ComputingState.cpp
+++ b/arangod/Pregel/Conductor/States/ComputingState.cpp
@@ -27,28 +27,22 @@ Computing::~Computing() {
 
 auto Computing::run() -> std::optional<std::unique_ptr<State>> {
   do {
-    auto messages = _prepareGlobalSuperStep().get();
-    if (messages.fail()) {
-      LOG_PREGEL_CONDUCTOR("04189", ERR) << messages.errorMessage();
+    auto prepared = _prepareGlobalSuperStep().get();
+    if (prepared.fail()) {
+      LOG_PREGEL_CONDUCTOR("04189", ERR) << prepared.errorMessage();
       return std::make_unique<FatalError>(conductor);
     }
 
-    auto post = conductor._postGlobalSuperStep(messages.get());
+    auto post = conductor._postGlobalSuperStep();
     if (post.finished) {
       if (conductor._storeResults) {
         return std::make_unique<Storing>(conductor);
       }
-      if (conductor._inErrorAbort) {
-        return std::make_unique<FatalError>(conductor);
-      }
       return std::make_unique<Done>(conductor);
     }
-    bool preGlobalSuperStep = conductor._preGlobalSuperStep();
-    if (!preGlobalSuperStep) {
-      return std::make_unique<FatalError>(conductor);
-    }
+    conductor._preGlobalSuperStep();
 
-    auto runGlobalSuperStep = _runGlobalSuperStep(post.activateAll).get();
+    auto runGlobalSuperStep = _runGlobalSuperStep().get();
     if (runGlobalSuperStep.fail()) {
       LOG_PREGEL_CONDUCTOR("f34bb", ERR) << runGlobalSuperStep.errorMessage();
       return std::make_unique<FatalError>(conductor);
@@ -56,8 +50,7 @@ auto Computing::run() -> std::optional<std::unique_ptr<State>> {
   } while (true);
 }
 
-auto Computing::_prepareGlobalSuperStep()
-    -> futures::Future<ResultT<VPackBuilder>> {
+auto Computing::_prepareGlobalSuperStep() -> futures::Future<Result> {
   if (conductor._feature.isStopping()) {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_SHUTTING_DOWN);
   }
@@ -72,7 +65,7 @@ auto Computing::_prepareGlobalSuperStep()
           PrepareGlobalSuperStep{.gss = conductor._globalSuperstep,
                                  .vertexCount = conductor._totalVerticesCount,
                                  .edgeCount = conductor._totalEdgesCount})
-      .thenValue([&](auto globalSuperStepPrepared) -> ResultT<VPackBuilder> {
+      .thenValue([&](auto globalSuperStepPrepared) -> Result {
         if (globalSuperStepPrepared.fail()) {
           return Result{globalSuperStepPrepared.errorNumber(),
                         fmt::format("While preparing global super step {}: {}",
@@ -88,19 +81,11 @@ auto Computing::_prepareGlobalSuperStep()
         conductor._totalVerticesCount +=
             globalSuperStepPrepared.get().vertexCount;
         conductor._totalEdgesCount += globalSuperStepPrepared.get().edgeCount;
-        return globalSuperStepPrepared.get().messages;
+        return Result{};
       });
 }
 
-auto Computing::_runGlobalSuperStepCommand(bool activateAll)
-    -> RunGlobalSuperStep {
-  VPackBuilder toWorkerMessages;
-  {
-    VPackObjectBuilder ob(&toWorkerMessages);
-    if (conductor._masterContext) {
-      conductor._masterContext->preGlobalSuperstepMessage(toWorkerMessages);
-    }
-  }
+auto Computing::_runGlobalSuperStepCommand() -> RunGlobalSuperStep {
   VPackBuilder aggregators;
   {
     VPackObjectBuilder ob(&aggregators);
@@ -109,14 +94,11 @@ auto Computing::_runGlobalSuperStepCommand(bool activateAll)
   return RunGlobalSuperStep{.gss = conductor._globalSuperstep,
                             .vertexCount = conductor._totalVerticesCount,
                             .edgeCount = conductor._totalEdgesCount,
-                            .activateAll = activateAll,
-                            .toWorkerMessages = std::move(toWorkerMessages),
                             .aggregators = std::move(aggregators)};
 }
 
-auto Computing::_runGlobalSuperStep(bool activateAll)
-    -> futures::Future<Result> {
-  auto runGlobalSuperStepCommand = _runGlobalSuperStepCommand(activateAll);
+auto Computing::_runGlobalSuperStep() -> futures::Future<Result> {
+  auto runGlobalSuperStepCommand = _runGlobalSuperStepCommand();
   conductor._timing.gss.emplace_back(Duration{
       ._start = std::chrono::steady_clock::now(), ._finish = std::nullopt});
   VPackBuilder startCommand;

--- a/arangod/Pregel/Conductor/States/ComputingState.h
+++ b/arangod/Pregel/Conductor/States/ComputingState.h
@@ -44,9 +44,9 @@ struct Computing : State {
   }
 
  private:
-  auto _prepareGlobalSuperStep() -> futures::Future<ResultT<VPackBuilder>>;
-  auto _runGlobalSuperStepCommand(bool activateAll) -> RunGlobalSuperStep;
-  auto _runGlobalSuperStep(bool activateAll) -> futures::Future<Result>;
+  auto _prepareGlobalSuperStep() -> futures::Future<Result>;
+  auto _runGlobalSuperStepCommand() -> RunGlobalSuperStep;
+  auto _runGlobalSuperStep() -> futures::Future<Result>;
 };
 
 }  // namespace conductor

--- a/arangod/Pregel/Conductor/States/StoringState.cpp
+++ b/arangod/Pregel/Conductor/States/StoringState.cpp
@@ -58,9 +58,6 @@ auto Storing::_cleanup() -> futures::Future<Result> {
                         fmt::format("While cleaning up: {}",
                                     cleanupFinished.errorMessage())};
         }
-        if (conductor._inErrorAbort) {
-          return Result{TRI_ERROR_INTERNAL, "Conductor in error"};
-        }
         return Result{};
       });
 }

--- a/arangod/Pregel/MasterContext.h
+++ b/arangod/Pregel/MasterContext.h
@@ -40,7 +40,6 @@ class MasterContext {
   uint64_t _vertexCount = 0;
   uint64_t _edgeCount = 0;
   // Should cause the master to tell everyone to enter the next phase
-  bool _enterNextGSS = false;
   AggregatorHandler* _aggregators = nullptr;
 
  public:
@@ -97,45 +96,17 @@ class MasterContext {
 #endif
   }
 
-  inline void enterNextGlobalSuperstep() { _enterNextGSS = true; }
-
   virtual void preApplication() {}
 
   /// @brief called before supersteps
   virtual void preGlobalSuperstep() {}
-  /// @return true to continue the computation
-  virtual bool preGlobalSuperstepWithResult() {
-    preGlobalSuperstep();
-    return true;
-  }
-  /// @brief called before supersteps; message that is put
-  ///        in msg is sent to all WorkerContexts
-  virtual void preGlobalSuperstepMessage(VPackBuilder& msg) {}
   /// @brief called after supersteps
   /// @return true to continue the computation
   virtual bool postGlobalSuperstep() { return true; }
 
-  /// @brief called after supersteps, VPackSlice contains array of all
-  ///        worker messages received
-  virtual bool postGlobalSuperstepMessage(VPackSlice workerMsgs) {
-    return true;
-  }
-
   virtual void postApplication() {}
 
   virtual void serializeValues(VPackBuilder& b) {}
-
-  enum class ContinuationResult {
-    CONTINUE,
-    ABORT,
-    DONT_CARE,
-    ACTIVATE_ALL,
-    ERROR_ABORT,
-  };
-
-  virtual ContinuationResult postGlobalSuperstep(bool allVertexesVotedHalt) {
-    return ContinuationResult::DONT_CARE;
-  }
 
   /// should indicate if compensation is supposed to start by returning true
   virtual bool preCompensation() { return true; }

--- a/arangod/Pregel/Statistics.h
+++ b/arangod/Pregel/Statistics.h
@@ -66,7 +66,7 @@ auto inspect(Inspector& f, MessageStats& x) {
 
 struct StatsManager {
   void accumulate(MessageStats const& data) { _stats.accumulate(data); }
-  void accumulateActiveCounts(uint64_t counts) { _activeCounts += counts; }
+  void setActiveCounts(uint64_t counts) { _activeCounts = counts; }
 
   bool allMessagesProcessed() const { return _stats.allMessagesProcessed(); }
 

--- a/arangod/Pregel/VertexComputation.h
+++ b/arangod/Pregel/VertexComputation.h
@@ -120,7 +120,6 @@ template<typename V, typename E, typename M>
 class VertexComputation : public VertexContext<V, E, M> {
   friend class Worker<V, E, M>;
   OutCache<M>* _cache = nullptr;
-  bool _enterNextGSS = false;
 
  public:
   virtual ~VertexComputation() = default;
@@ -140,17 +139,6 @@ class VertexComputation : public VertexContext<V, E, M> {
     for (; edges.hasMore(); ++edges) {
       Edge<E> const* edge = *edges;
       _cache->appendMessage(edge->targetShard(), edge->toKey(), data);
-    }
-  }
-
-  /// Causes messages to be available in GSS+1.
-  /// Only valid in async mode, a no-op otherwise
-  void enterNextGlobalSuperstep() {
-    // _enterNextGSS is true when we are not in async mode
-    // making this a no-op
-    if (!_enterNextGSS) {
-      _enterNextGSS = true;
-      _cache->sendToNextGSS(true);
     }
   }
 

--- a/arangod/Pregel/Worker/Worker.cpp
+++ b/arangod/Pregel/Worker/Worker.cpp
@@ -99,8 +99,7 @@ Worker<V, E, M>::Worker(TRI_vocbase_t& vocbase, Algorithm<V, E, M>* algo,
     : _feature(feature),
       _state(WorkerState::IDLE),
       _config(&vocbase),
-      _algorithm(algo),
-      _requestedNextGSS(false) {
+      _algorithm(algo) {
   _config.updateConfig(_feature, initConfig);
 
   MUTEX_LOCKER(guard, _commandMutex);
@@ -222,15 +221,10 @@ auto Worker<V, E, M>::_prepareGlobalSuperStepFct(
   std::swap(_readCache, _writeCache);
   _config._localSuperstep = gss;
 
-  VPackBuilder messageToMaster;
   // only place where is makes sense to call this, since startGlobalSuperstep
   // might not be called again
-  {
-    VPackObjectBuilder ob(&messageToMaster);
-    if (_workerContext && gss > 0) {
-      _workerContext->postGlobalSuperstep(gss - 1);
-      _workerContext->postGlobalSuperstepMasterMessage(messageToMaster);
-    }
+  if (_workerContext && gss > 0) {
+    _workerContext->postGlobalSuperstep(gss - 1);
   }
 
   // responds with info which allows the conductor to decide whether
@@ -241,8 +235,7 @@ auto Worker<V, E, M>::_prepareGlobalSuperStepFct(
     _workerAggregators->serializeValues(aggregators);
   }
   return GlobalSuperStepPrepared{_activeCount, _graphStore->localVertexCount(),
-                                 _graphStore->localEdgeCount(),
-                                 std::move(messageToMaster), aggregators};
+                                 _graphStore->localEdgeCount(), aggregators};
 }
 
 template<typename V, typename E, typename M>
@@ -266,12 +259,6 @@ auto Worker<V, E, M>::_preGlobalSuperStep(RunGlobalSuperStep const& message)
   if (gss != _config.globalSuperstep()) {
     return Result{TRI_ERROR_BAD_PARAMETER, "Wrong GSS"};
   }
-  if (message.activateAll) {
-    for (auto vertices = _graphStore->vertexIterator(); vertices.hasMore();
-         ++vertices) {
-      vertices->setActive(true);
-    }
-  }
   _workerAggregators->resetValues();
   _conductorAggregators->setAggregatedValues(message.aggregators.slice());
   // execute context
@@ -279,8 +266,6 @@ auto Worker<V, E, M>::_preGlobalSuperStep(RunGlobalSuperStep const& message)
     _workerContext->_vertexCount = message.vertexCount;
     _workerContext->_edgeCount = message.edgeCount;
     _workerContext->preGlobalSuperstep(gss);
-    _workerContext->preGlobalSuperstepMasterMessage(
-        message.toWorkerMessages.slice());
   }
   return Result{};
 }
@@ -398,8 +383,6 @@ auto Worker<V, E, M>::_processVertices(
   _initializeVertexContext(vertexComputation.get());
   vertexComputation->_writeAggregators = &workerAggregator;
   vertexComputation->_cache = outCache;
-  // Should cause enterNextGlobalSuperstep to do nothing
-  vertexComputation->_enterNextGSS = true;
 
   size_t activeCount = 0;
   for (; vertexIterator.hasMore(); ++vertexIterator) {
@@ -432,9 +415,6 @@ auto Worker<V, E, M>::_processVertices(
   outCache->flushMessages();
   if (ADB_UNLIKELY(!_writeCache)) {  // ~Worker was called
     return Result{TRI_ERROR_INTERNAL, "Worker execution aborted prematurely."};
-  }
-  if (vertexComputation->_enterNextGSS) {
-    _requestedNextGSS = true;
   }
 
   // double t = TRI_microtime();

--- a/arangod/Pregel/Worker/Worker.h
+++ b/arangod/Pregel/Worker/Worker.h
@@ -158,9 +158,6 @@ class Worker : public IWorker {
       -> ResultT<VerticesProcessed>;
   auto _finishProcessing() -> ResultT<GlobalSuperStepFinished>;
   void _callConductor(VPackBuilder const& message);
-  void _callConductorWithResponse(std::string const& path,
-                                  VPackBuilder const& message,
-                                  std::function<void(VPackSlice slice)> handle);
   [[nodiscard]] auto _observeStatus() -> Status const;
   [[nodiscard]] auto _makeStatusCallback() -> std::function<void()>;
 

--- a/arangod/Pregel/Worker/Worker.h
+++ b/arangod/Pregel/Worker/Worker.h
@@ -145,8 +145,6 @@ class Worker : public IWorker {
   uint64_t _activeCount = 0;
   /// current number of running threads
   size_t _runningThreads = 0;
-  /// if the worker has started sendng messages to the next GSS
-  std::atomic<bool> _requestedNextGSS;
   Scheduler::WorkHandle _workHandle;
 
   using VerticesProcessedFuture =

--- a/arangod/Pregel/Worker/WorkerContext.h
+++ b/arangod/Pregel/Worker/WorkerContext.h
@@ -55,9 +55,7 @@ class WorkerContext {
 
   virtual void preApplication() {}
   virtual void preGlobalSuperstep(uint64_t gss) {}
-  virtual void preGlobalSuperstepMasterMessage(VPackSlice msg) {}
   virtual void postGlobalSuperstep(uint64_t gss) {}
-  virtual void postGlobalSuperstepMasterMessage(VPackBuilder& msg) {}
   virtual void postApplication() {}
 
  public:

--- a/arangod/Pregel/WorkerConductorMessages.h
+++ b/arangod/Pregel/WorkerConductorMessages.h
@@ -63,22 +63,18 @@ struct GlobalSuperStepPrepared {
   uint64_t activeCount;
   uint64_t vertexCount;
   uint64_t edgeCount;
-  VPackBuilder messages;
   VPackBuilder aggregators;
   GlobalSuperStepPrepared() noexcept = default;
   GlobalSuperStepPrepared(uint64_t activeCount, uint64_t vertexCount,
-                          uint64_t edgeCount, VPackBuilder messages,
-                          VPackBuilder aggregators)
+                          uint64_t edgeCount, VPackBuilder aggregators)
       : activeCount{activeCount},
         vertexCount{vertexCount},
         edgeCount{edgeCount},
-        messages{std::move(messages)},
         aggregators{std::move(aggregators)} {}
   auto add(GlobalSuperStepPrepared const& other) -> void {
     activeCount += other.activeCount;
     vertexCount += other.vertexCount;
     edgeCount += other.edgeCount;
-    messages.add(other.messages.slice());
     // TODO directly aggregate in here when aggregators have an inspector
     VPackBuilder newAggregators;
     {
@@ -93,10 +89,10 @@ struct GlobalSuperStepPrepared {
 };
 template<typename Inspector>
 auto inspect(Inspector& f, GlobalSuperStepPrepared& x) {
-  return f.object(x).fields(
-      f.field("activeCount", x.activeCount),
-      f.field("vertexCount", x.vertexCount), f.field("edgeCount", x.edgeCount),
-      f.field("messages", x.messages), f.field("aggregators", x.aggregators));
+  return f.object(x).fields(f.field("activeCount", x.activeCount),
+                            f.field("vertexCount", x.vertexCount),
+                            f.field("edgeCount", x.edgeCount),
+                            f.field("aggregators", x.aggregators));
 }
 
 struct GlobalSuperStepFinished {
@@ -219,19 +215,15 @@ struct RunGlobalSuperStep {
   uint64_t gss;
   uint64_t vertexCount;
   uint64_t edgeCount;
-  bool activateAll;
-  VPackBuilder toWorkerMessages;
   VPackBuilder aggregators;
 };
 
 template<typename Inspector>
 auto inspect(Inspector& f, RunGlobalSuperStep& x) {
-  return f.object(x).fields(
-      f.field(Utils::globalSuperstepKey, x.gss),
-      f.field("vertexCount", x.vertexCount), f.field("edgeCount", x.edgeCount),
-      f.field("activateAll", x.activateAll),
-      f.field("masterToWorkerMessages", x.toWorkerMessages),
-      f.field("aggregators", x.aggregators));
+  return f.object(x).fields(f.field(Utils::globalSuperstepKey, x.gss),
+                            f.field("vertexCount", x.vertexCount),
+                            f.field("edgeCount", x.edgeCount),
+                            f.field("aggregators", x.aggregators));
 }
 
 struct Store {};

--- a/tests/js/client/load-balancing/load-balancing-pregel-noauth-cluster.js
+++ b/tests/js/client/load-balancing/load-balancing-pregel-noauth-cluster.js
@@ -177,7 +177,6 @@ function PregelSuite () {
 
       assertFalse(result === undefined || result === {});
       assertEqual(result.status, 200);
-      assertTrue(result.body.state === "loading" || result.body.state === "running");
 
       require('internal').wait(5.0, false);
 
@@ -211,7 +210,6 @@ function PregelSuite () {
 
       assertFalse(result === undefined || result === {});
       assertEqual(result.status, 200);
-      assertTrue(result.body.state === "loading" || result.body.state === "running");
 
       require('internal').wait(5.0, false);
 


### PR DESCRIPTION
This PR deletes unused methods in the conductor and worker master contexts, most of them were remnants of async mode.
Additionally, I did some small changes: Fixed two brittle tests that failed on my machine (The algorithm is finished so fast that the status is already done when we query the pregel status where we assert that the status is still loading or running), Deleted another unused worker method and refactored a small part in the conductor computation state.