### PR TITLE
adjust permission checking of search-alias views

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,16 @@
 devel
 -----
 
+* Adjust permissions for "search-alias" views.
+
+  Previously, "search-alias" views were visible to users that didn't have read
+  permissions on the underlying referenced collections. This was inconsistent, 
+  because "arangosearch" views weren't shown to users that didn't have read 
+  permissions on the underlying links. 
+  Now, the behavior for "search-alias" views is the same as for "arangosearch" 
+  views, i.e. "search-alias" views are not shown and are not accessible for 
+  users that don't have at least read permissions on the underlying collections.
+
 * BTS-742: Added restriction for, when in smart graph, not accepting satellites
   in invalid format when storing a graph (like `{satellites: null}`).
 

--- a/js/common/modules/@arangodb/mocha-runner.js
+++ b/js/common/modules/@arangodb/mocha-runner.js
@@ -93,11 +93,13 @@ function logSuite (suite, indentLevel) {
       }
     }
   }
-  for (let sub of suite.suites) {
-    logSuite(sub, indentLevel + 1);
-  }
-  if (suite.suites.length) {
-    print();
+  if (suite.suites != null && typeof suite.suites[Symbol.iterator] === 'function') {
+    for (let sub of suite.suites) {
+      logSuite(sub, indentLevel + 1);
+    }
+    if (suite.suites.length) {
+      print();
+    }
   }
 }
 

--- a/js/common/modules/@arangodb/mocha-runner.js
+++ b/js/common/modules/@arangodb/mocha-runner.js
@@ -68,14 +68,10 @@ function logSuite (suite, indentLevel) {
   if (suite.title) {
     print(`${indent(indentLevel - 1)}${
       COLORS.COLOR_BOLD_WHITE}${suite.title}${COLORS.COLOR_RESET
-    }`);
+      }`);
   }
 
-  if (suite.tests) {
-    if (suite.tests != null && typeof suite.tests[Symbol.iterator] !== 'function') {
-      console.error("suite.tests is not iterable: ", suite.tests, JSON.stringify(suite.tests));
-    }
-
+  if (suite.tests != null && typeof suite.tests[Symbol.iterator] === 'function') {
     for (let test of suite.tests) {
       if (test.result === 'pass') {
         print(`${indent(indentLevel)}${
@@ -97,13 +93,11 @@ function logSuite (suite, indentLevel) {
       }
     }
   }
-  if (suite.suites) {
-    for (let sub of suite.suites) {
-      logSuite(sub, indentLevel + 1);
-    }
-    if (suite.suites.length) {
-      print();
-    }
+  for (let sub of suite.suites) {
+    logSuite(sub, indentLevel + 1);
+  }
+  if (suite.suites.length) {
+    print();
   }
 }
 

--- a/js/common/modules/@arangodb/mocha-runner.js
+++ b/js/common/modules/@arangodb/mocha-runner.js
@@ -68,38 +68,33 @@ function logSuite (suite, indentLevel) {
   if (suite.title) {
     print(`${indent(indentLevel - 1)}${
       COLORS.COLOR_BOLD_WHITE}${suite.title}${COLORS.COLOR_RESET
-      }`);
+    }`);
   }
-
-  if (suite.tests != null && typeof suite.tests[Symbol.iterator] === 'function') {
-    for (let test of suite.tests) {
-      if (test.result === 'pass') {
-        print(`${indent(indentLevel)}${
-          COLORS.COLOR_GREEN}[PASS] ${test.title}${COLORS.COLOR_RESET
-          }`);
-      } else if (test.result === 'pending') {
-        print(`${indent(indentLevel)}${
-          COLORS.COLOR_CYAN}[SKIP] ${test.title}${COLORS.COLOR_RESET
-          }`);
-      } else {
-        print(`${indent(indentLevel)}${
-          COLORS.COLOR_RED}[${test.result.toUpperCase()}] ${test.title}${COLORS.COLOR_RESET
-          }`);
-        for (let line of test.err.stack.split(/\n/)) {
-          print(`${indent(indentLevel + 1)}${
-            COLORS.COLOR_RED}${line}${COLORS.COLOR_RESET
-            }`);
-        }
+  for (let test of suite.tests) {
+    if (test.result === 'pass') {
+      print(`${indent(indentLevel)}${
+        COLORS.COLOR_GREEN}[PASS] ${test.title}${COLORS.COLOR_RESET
+      }`);
+    } else if (test.result === 'pending') {
+      print(`${indent(indentLevel)}${
+        COLORS.COLOR_CYAN}[SKIP] ${test.title}${COLORS.COLOR_RESET
+      }`);
+    } else {
+      print(`${indent(indentLevel)}${
+        COLORS.COLOR_RED}[${test.result.toUpperCase()}] ${test.title}${COLORS.COLOR_RESET
+      }`);
+      for (let line of test.err.stack.split(/\n/)) {
+        print(`${indent(indentLevel + 1)}${
+          COLORS.COLOR_RED}${line}${COLORS.COLOR_RESET
+        }`);
       }
     }
   }
-  if (suite.suites != null && typeof suite.suites[Symbol.iterator] === 'function') {
-    for (let sub of suite.suites) {
-      logSuite(sub, indentLevel + 1);
-    }
-    if (suite.suites.length) {
-      print();
-    }
+  for (let sub of suite.suites) {
+    logSuite(sub, indentLevel + 1);
+  }
+  if (suite.suites.length) {
+    print();
   }
 }
 

--- a/js/common/modules/@arangodb/mocha-runner.js
+++ b/js/common/modules/@arangodb/mocha-runner.js
@@ -70,31 +70,36 @@ function logSuite (suite, indentLevel) {
       COLORS.COLOR_BOLD_WHITE}${suite.title}${COLORS.COLOR_RESET
     }`);
   }
-  for (let test of suite.tests) {
-    if (test.result === 'pass') {
-      print(`${indent(indentLevel)}${
-        COLORS.COLOR_GREEN}[PASS] ${test.title}${COLORS.COLOR_RESET
-      }`);
-    } else if (test.result === 'pending') {
-      print(`${indent(indentLevel)}${
-        COLORS.COLOR_CYAN}[SKIP] ${test.title}${COLORS.COLOR_RESET
-      }`);
-    } else {
-      print(`${indent(indentLevel)}${
-        COLORS.COLOR_RED}[${test.result.toUpperCase()}] ${test.title}${COLORS.COLOR_RESET
-      }`);
-      for (let line of test.err.stack.split(/\n/)) {
-        print(`${indent(indentLevel + 1)}${
-          COLORS.COLOR_RED}${line}${COLORS.COLOR_RESET
-        }`);
+
+  if (suite.tests) {
+    for (let test of suite.tests) {
+      if (test.result === 'pass') {
+        print(`${indent(indentLevel)}${
+          COLORS.COLOR_GREEN}[PASS] ${test.title}${COLORS.COLOR_RESET
+          }`);
+      } else if (test.result === 'pending') {
+        print(`${indent(indentLevel)}${
+          COLORS.COLOR_CYAN}[SKIP] ${test.title}${COLORS.COLOR_RESET
+          }`);
+      } else {
+        print(`${indent(indentLevel)}${
+          COLORS.COLOR_RED}[${test.result.toUpperCase()}] ${test.title}${COLORS.COLOR_RESET
+          }`);
+        for (let line of test.err.stack.split(/\n/)) {
+          print(`${indent(indentLevel + 1)}${
+            COLORS.COLOR_RED}${line}${COLORS.COLOR_RESET
+            }`);
+        }
       }
     }
   }
-  for (let sub of suite.suites) {
-    logSuite(sub, indentLevel + 1);
-  }
-  if (suite.suites.length) {
-    print();
+  if (suite.suites) {
+    for (let sub of suite.suites) {
+      logSuite(sub, indentLevel + 1);
+    }
+    if (suite.suites.length) {
+      print();
+    }
   }
 }
 

--- a/js/common/modules/@arangodb/mocha-runner.js
+++ b/js/common/modules/@arangodb/mocha-runner.js
@@ -72,6 +72,10 @@ function logSuite (suite, indentLevel) {
   }
 
   if (suite.tests) {
+    if (suite.tests != null && typeof suite.tests[Symbol.iterator] !== 'function') {
+      console.error("suite.tests is not iterable: ", suite.tests, JSON.stringify(suite.tests));
+    }
+
     for (let test of suite.tests) {
       if (test.result === 'pass') {
         print(`${indent(indentLevel)}${

--- a/tests/js/client/authentication/user-access-right-drop-view-arangosearch-spec.js
+++ b/tests/js/client/authentication/user-access-right-drop-view-arangosearch-spec.js
@@ -39,9 +39,9 @@ const namePrefix = helper.namePrefix;
 const dbName = helper.dbName;
 const rightLevels = helper.rightLevels;
 const testViewName = `${namePrefix}ViewNew`;
-const testViewType = "arangosearch";
 const testCol1Name = `${namePrefix}Col1New`;
 const testCol2Name = `${namePrefix}Col2New`;
+const indexName = `${namePrefix}Inverted`;
 
 const userSet = helper.userSet;
 const systemLevel = helper.systemLevel;
@@ -59,11 +59,7 @@ helper.switchUser('root', '_system');
 helper.removeAllUsers();
 helper.generateAllUsers();
 
-function hasIResearch (db) {
-  return !(db._views() === 0); // arangosearch views are not supported
-}
-
-!hasIResearch(db) ? describe.skip : describe('User Rights Management', () => {
+describe('User Rights Management', () => {
   it('should check if all users are created', () => {
     helper.switchUser('root', '_system');
     expect(userSet.size).to.be.greaterThan(0); 
@@ -74,210 +70,220 @@ function hasIResearch (db) {
   });
 
   it('should test rights for', () => {
-      for (let name of userSet) {
-        try {
+    for (let testViewType of ["arangosearch", "search-alias"]) {
+      describe(`view type ${testViewType}`, () => {
+        for (let name of userSet) {
+          try {
             helper.switchUser(name, dbName);
-        } catch (e) {
+          } catch (e) {
             continue;
+          }
+
+          describe(`user ${name}`, () => {
+            before(() => {
+              helper.switchUser(name, dbName);
+            });
+
+            describe('administrate on db level', () => {
+              const rootTestCollection = (colName, switchBack = true) => {
+                helper.switchUser('root', dbName);
+                let col = db._collection(colName);
+                if (switchBack) {
+                  helper.switchUser(name, dbName);
+                }
+                return col !== null;
+              };
+
+              const rootCreateCollection = (colName) => {
+                if (!rootTestCollection(colName, false)) {
+                  let c = db._create(colName);
+                  if (colName === testCol1Name) {
+                    c.ensureIndex({ type: "inverted", name: indexName, fields: [ { name: "value" } ] });
+                  }
+                  if (colLevel['none'].has(name)) {
+                    if (helper.isLdapEnabledExternal()) {
+                      users.grantCollection(':role:' + name, dbName, colName, 'none');
+                    } else {
+                      users.grantCollection(name, dbName, colName, 'none');
+                    }
+                  } else if (colLevel['ro'].has(name)) {
+                    if (helper.isLdapEnabledExternal()) {
+                      users.grantCollection(':role:' + name, dbName, colName, 'ro');
+                    } else {
+                      users.grantCollection(name, dbName, colName, 'ro');
+                    }
+                  } else if (colLevel['rw'].has(name)) {
+                    if (helper.isLdapEnabledExternal()) {
+                      users.grantCollection(':role:' + name, dbName, colName, 'rw');
+                    } else {
+                      users.grantCollection(name, dbName, colName, 'rw');
+                    }
+                  }
+                }
+                helper.switchUser(name, dbName);
+              };
+
+              const rootDropCollection = (colName) => {
+                helper.switchUser('root', dbName);
+                try {
+                  db._collection(colName).drop();
+                } catch (ignored) { }
+                helper.switchUser(name, dbName);
+              };
+
+              const rootGrantCollection = (colName, user, explicitRight = '') => {
+                if (rootTestCollection(colName, false)) {
+                  if (explicitRight !== '' && rightLevels.includes(explicitRight)) {
+                    if (helper.isLdapEnabledExternal()) {
+                      users.grantCollection(':role:' + user, dbName, colName, explicitRight);
+                    } else {
+                      users.grantCollection(user, dbName, colName, explicitRight);
+                    }
+                  }
+                }
+                helper.switchUser(user, dbName);
+              };
+
+              const rootTestView = (viewName = testViewName, switchBack = true) => {
+                helper.switchUser('root', dbName);
+                let view = db._view(viewName);
+                if (switchBack) {
+                  helper.switchUser(name, dbName);
+                }
+                return view !== null;
+              };
+
+              const rootCreateView = (viewName, viewType, properties = null) => {
+                if (rootTestView(viewName, false)) {
+                  db._dropView(viewName);
+                }
+                let view =  db._createView(viewName, viewType, {});
+                if (properties !== null) {
+                  view.properties(properties, false);
+                }
+                helper.switchUser(name, dbName);
+              };
+
+              const rootDropView = (viewName = testViewName) => {
+                helper.switchUser('root', dbName);
+                try {
+                  db._dropView(viewName);
+                } catch (ignored) { }
+                helper.switchUser(name, dbName);
+              };
+
+              const checkError = (e) => {
+                expect(e.code).to.be.oneOf([403], "Expected to get forbidden or internal REST error code, but got another one");
+                expect(e.errorNum).to.oneOf([errors.ERROR_FORBIDDEN.code, errors.ERROR_ARANGO_READ_ONLY.code], "Expected to get forbidden error number, but got another one");
+              };
+
+              describe('drop a', () => {
+                before(() => {
+                  db._useDatabase(dbName);
+                });
+
+                after(() => {
+                  rootDropView(testViewName);
+                  rootDropCollection(testCol1Name);
+                  rootDropCollection(testCol2Name);
+                });
+
+                it('view without links', () => {
+                  rootCreateView(testViewName, testViewType);
+                  expect(rootTestView(testViewName)).to.equal(true, 'Precondition failed, the view doesn not exist');
+                  if (dbLevel['rw'].has(name)) {
+                    db._dropView(testViewName);
+                    expect(rootTestView(testViewName)).to.equal(false, 'View deletion reported success, but view was found afterwards');
+                  } else {
+                    try {
+                      db._dropView(testViewName);
+                    } catch (e) {
+                      checkError(e);
+                      return;
+                    }
+                    expect(rootTestView(testViewName)).to.equal(true, `${name} was able to delete a view with insufficent rights`);
+                  }
+                });
+
+                if (testViewType === 'arangosearch') {
+                  it('view with link to non-existing collection', () => {
+                    rootDropView(testViewName);
+                    rootCreateCollection("NonExistentCol");
+                    rootCreateView(testViewName, testViewType, { links: { "NonExistentCol" : { includeAllFields: true } } });
+                    rootDropCollection("NonExistentCol");
+                    expect(rootTestView(testViewName)).to.equal(true, 'Precondition failed, the view doesn not exist');
+                    if (dbLevel['rw'].has(name)) {
+                      db._dropView(testViewName);
+                      expect(rootTestView(testViewName)).to.equal(false, 'View deletion reported success, but view was found afterwards');
+                    } else {
+                      try {
+                        db._dropView(testViewName);
+                      } catch (e) {
+                        checkError(e);
+                        return;
+                      }
+                      if (!dbLevel['rw'].has(name)) {
+                        expect(rootTestView(testViewName)).to.equal(true, `${name} was able to delete a view with insufficent rights`);
+                      }
+                    }
+                  });
+
+                  it('view with link to existing collection', () => {
+                    rootDropView(testViewName);
+                    rootDropCollection(testCol1Name);
+
+                    rootCreateCollection(testCol1Name);
+                    rootCreateView(testViewName, testViewType, { links: { [testCol1Name]: { includeAllFields: true } } });
+                    expect(rootTestView(testViewName)).to.equal(true, 'Precondition failed, the view doesn not exist');
+                    if (dbLevel['rw'].has(name) && (colLevel['rw'].has(name) || colLevel['ro'].has(name))) {
+                      db._dropView(testViewName);
+                      expect(rootTestView(testViewName)).to.equal(false, 'View deletion reported success, but view was found afterwards');
+                    } else {
+                      try {
+                        db._dropView(testViewName);
+                      } catch (e) {
+                        checkError(e);
+                        return;
+                      } finally {
+                        expect(rootTestView(testViewName)).to.equal(true, `${name} was able to drop a view with insufficent rights`);
+                      }
+                    }
+                  });
+
+                  let itName = 'view with links to multiple collections (switching 1 of them as RW during RO/NONE of a user collection level)';
+                  !(colLevel['ro'].has(name) || colLevel['none'].has(name)) ? it.skip(itName) :
+                    it(itName, () => {
+                      rootDropView(testViewName);
+                      rootDropCollection(testCol1Name);
+
+                      rootCreateCollection(testCol1Name);
+                      rootCreateCollection(testCol2Name);
+                      rootCreateView(testViewName, testViewType, { links: { [testCol1Name]: { includeAllFields: true }, [testCol2Name]: { includeAllFields: true } } });
+                      expect(rootTestView(testViewName)).to.equal(true, 'Precondition failed, the view doesn not exist');
+
+                      rootGrantCollection(testCol2Name, name, 'rw');
+                      if (dbLevel['rw'].has(name) && colLevel['ro'].has(name)) {
+                        db._dropView(testViewName);
+                        expect(rootTestView(testViewName)).to.equal(false, 'View deletion reported success, but view was found afterwards');
+                      } else {
+                        try {
+                          db._dropView(testViewName);
+                        } catch (e) {
+                          checkError(e);
+                          return;
+                        } finally {
+                          expect(rootTestView(testViewName)).to.equal(true, `${name} was able to drop a view with insufficent rights`);
+                        }
+                      }
+                    });
+                }
+              });
+            });
+          });
         }
 
-        describe(`user ${name}`, () => {
-          before(() => {
-            helper.switchUser(name, dbName);
-          });
-
-        describe('administrate on db level', () => {
-          const rootTestCollection = (colName, switchBack = true) => {
-            helper.switchUser('root', dbName);
-            let col = db._collection(colName);
-            if (switchBack) {
-                helper.switchUser(name, dbName);
-            }
-            return col !== null;
-          };
-
-          const rootCreateCollection = (colName) => {
-            if (!rootTestCollection(colName, false)) {
-              db._create(colName);
-              if (colLevel['none'].has(name)) {
-                if (helper.isLdapEnabledExternal()) {
-                  users.grantCollection(':role:' + name, dbName, colName, 'none');
-                } else {
-                  users.grantCollection(name, dbName, colName, 'none');
-                }
-              } else if (colLevel['ro'].has(name)) {
-                if (helper.isLdapEnabledExternal()) {
-                  users.grantCollection(':role:' + name, dbName, colName, 'ro');
-                } else {
-                  users.grantCollection(name, dbName, colName, 'ro');
-                }
-              } else if (colLevel['rw'].has(name)) {
-                if (helper.isLdapEnabledExternal()) {
-                  users.grantCollection(':role:' + name, dbName, colName, 'rw');
-                } else {
-                  users.grantCollection(name, dbName, colName, 'rw');
-                }
-              }
-            }
-            helper.switchUser(name, dbName);
-          };
-
-          const rootDropCollection = (colName) => {
-            helper.switchUser('root', dbName);
-            try {
-              db._collection(colName).drop();
-            } catch (ignored) { }
-            helper.switchUser(name, dbName);
-          };
-
-          const rootGrantCollection = (colName, user, explicitRight = '') => {
-            if (rootTestCollection(colName, false)) {
-              if (explicitRight !== '' && rightLevels.includes(explicitRight))
-              {
-                if (helper.isLdapEnabledExternal()) {
-                  users.grantCollection(':role:' + user, dbName, colName, explicitRight);
-                } else {
-                  users.grantCollection(user, dbName, colName, explicitRight);
-                }
-              }
-            }
-            helper.switchUser(user, dbName);
-          };
-
-          const rootTestView = (viewName = testViewName, switchBack = true) => {
-            helper.switchUser('root', dbName);
-            let view = db._view(viewName);
-            if (switchBack) {
-                helper.switchUser(name, dbName);
-            }
-            return view != null;
-          };
-
-          const rootCreateView = (viewName = testViewName, properties = null) => {
-            if (rootTestView(viewName, false)) {
-              db._dropView(viewName);
-            }
-            let view =  db._createView(viewName, testViewType, {});
-            if (properties != null) {
-              view.properties(properties, false);
-            }
-            helper.switchUser(name, dbName);
-          };
-
-          const rootDropView = (viewName = testViewName) => {
-            helper.switchUser('root', dbName);
-            try {
-              db._dropView(viewName);
-            } catch (ignored) { }
-            helper.switchUser(name, dbName);
-          };
-
-        const checkError = (e) => {
-          expect(e.code).to.be.oneOf([403], "Expected to get forbidden or internal REST error code, but got another one");
-          expect(e.errorNum).to.oneOf([errors.ERROR_FORBIDDEN.code, errors.ERROR_ARANGO_READ_ONLY.code], "Expected to get forbidden error number, but got another one");
-        };
-
-          describe('drop a', () => {
-            before(() => {
-              db._useDatabase(dbName);
-            });
-
-            after(() => {
-              rootDropView(testViewName);
-              rootDropCollection(testCol1Name);
-              rootDropCollection(testCol2Name);
-            });
-
-            it('view without links', () => {
-              rootCreateView(testViewName);
-              expect(rootTestView(testViewName)).to.equal(true, 'Precondition failed, the view doesn not exist');
-              if (dbLevel['rw'].has(name)) {
-                db._dropView(testViewName);
-                expect(rootTestView(testViewName)).to.equal(false, 'View deletion reported success, but view was found afterwards');
-              } else {
-                try {
-                  db._dropView(testViewName);
-                } catch (e) {
-                  checkError(e);
-                  return;
-                }
-                expect(rootTestView(testViewName)).to.equal(true, `${name} was able to delete a view with insufficent rights`);
-              }
-            });
-
-            it('view with link to non-existing collection', () => {
-              rootDropView(testViewName);
-              rootCreateCollection("NonExistentCol");
-              rootCreateView(testViewName, { links: { "NonExistentCol" : { includeAllFields: true } } });
-              rootDropCollection("NonExistentCol");
-              expect(rootTestView(testViewName)).to.equal(true, 'Precondition failed, the view doesn not exist');
-              if (dbLevel['rw'].has(name)) {
-                db._dropView(testViewName);
-                expect(rootTestView(testViewName)).to.equal(false, 'View deletion reported success, but view was found afterwards');
-              } else {
-                try {
-                  db._dropView(testViewName);
-                } catch (e) {
-                  checkError(e);
-                  return;
-                }
-                if(!dbLevel['rw'].has(name)) {
-                  expect(rootTestView(testViewName)).to.equal(true, `${name} was able to delete a view with insufficent rights`);
-                }
-              }
-            });
-
-            it('view with link to existing collection', () => {
-              rootDropView(testViewName);
-              rootDropCollection(testCol1Name);
-
-              rootCreateCollection(testCol1Name);
-              rootCreateView(testViewName, { links: { [testCol1Name]: { includeAllFields: true } } });
-              expect(rootTestView(testViewName)).to.equal(true, 'Precondition failed, the view doesn not exist');
-              if (dbLevel['rw'].has(name) && (colLevel['rw'].has(name) || colLevel['ro'].has(name))) {
-                db._dropView(testViewName);
-                expect(rootTestView(testViewName)).to.equal(false, 'View deletion reported success, but view was found afterwards');
-              } else {
-                try {
-                  db._dropView(testViewName);
-                } catch (e) {
-                  checkError(e);
-                  return;
-                } finally {
-                  expect(rootTestView(testViewName)).to.equal(true, `${name} was able to drop a view with insufficent rights`);
-                }
-              }
-            });
-
-            var itName = 'view with links to multiple collections (switching 1 of them as RW during RO/NONE of a user collection level)';
-            !(colLevel['ro'].has(name) || colLevel['none'].has(name)) ? it.skip(itName) :
-            it(itName, () => {
-              rootDropView(testViewName);
-              rootDropCollection(testCol1Name);
-
-              rootCreateCollection(testCol1Name);
-              rootCreateCollection(testCol2Name);
-              rootCreateView(testViewName, { links: { [testCol1Name]: { includeAllFields: true }, [testCol2Name]: { includeAllFields: true } } });
-              expect(rootTestView(testViewName)).to.equal(true, 'Precondition failed, the view doesn not exist');
-
-              rootGrantCollection(testCol2Name, name, 'rw');
-              if (dbLevel['rw'].has(name) && colLevel['ro'].has(name)) {
-                  db._dropView(testViewName);
-                  expect(rootTestView(testViewName)).to.equal(false, 'View deletion reported success, but view was found afterwards');
-              } else {
-                try {
-                  db._dropView(testViewName);
-                } catch (e) {
-                  checkError(e);
-                  return;
-                } finally {
-                  expect(rootTestView(testViewName)).to.equal(true, `${name} was able to drop a view with insufficent rights`);
-                }
-              }
-            });
-          });
-        });
       });
+
     }
   });
 });

--- a/tests/js/client/authentication/user-access-right-read-view-arangosearch-spec.js
+++ b/tests/js/client/authentication/user-access-right-read-view-arangosearch-spec.js
@@ -40,9 +40,9 @@ const dbName = helper.dbName;
 const rightLevels = helper.rightLevels;
 const testView1Name = `${namePrefix}View1New`;
 const testView2Name = `${namePrefix}View2New`;
-const testViewType = "arangosearch";
 const testCol1Name = `${namePrefix}Col1New`;
 const testCol2Name = `${namePrefix}Col2New`;
+const indexName = `${namePrefix}Inverted`;
 const testNumDocs = 3;
 
 const userSet = helper.userSet;
@@ -62,16 +62,9 @@ helper.switchUser('root', '_system');
 helper.removeAllUsers();
 helper.generateAllUsers();
 
-function hasIResearch (db) {
-  return !(db._views() === 0); // arangosearch views are not supported
-}
-
-!hasIResearch(db) ? describe.skip : describe('User Rights Management', () => {
+describe('User Rights Management', () => {
   it('should check if all users are created', () => {
     helper.switchUser('root', '_system');
-    if (db._views() === 0) {
-      return; // arangosearch views are not supported
-    }
     expect(userSet.size).to.be.greaterThan(0); 
     expect(userSet.size).to.equal(helper.userCount);
     for (let name of userSet) {
@@ -80,227 +73,241 @@ function hasIResearch (db) {
   });
 
   it('should test rights for', () => {
-      for (let name of userSet) {
-        try {
+    for (let testViewType of ["arangosearch", "search-alias"]) {
+      describe(`view type ${testViewType}`, () => {
+        for (let name of userSet) {
+          try {
             helper.switchUser(name, dbName);
-        } catch (e) {
+          } catch (e) {
             continue;
+          }
+
+          describe(`user ${name}`, () => {
+            before(() => {
+              helper.switchUser(name, dbName);
+            });
+
+            describe('administrate on db level', () => {
+              before(() => {
+                db._useDatabase(dbName);
+                rootCreateCollection(testCol1Name);
+                rootCreateCollection(testCol2Name);
+                let properties = { properties : {} };
+                if (testViewType === "arangosearch") {
+                  properties['links'] = {};
+                  properties['links'][testCol1Name] = { includeAllFields: true };
+                  rootCreateView(testView1Name, testViewType, properties);
+                  properties['links'][testCol2Name] = { includeAllFields: true };
+                  rootCreateView(testView2Name, testViewType, properties);
+                } else {
+                  properties['indexes'] = [ { collection: testCol1Name, index: indexName } ];
+                  rootCreateView(testView1Name, testViewType, properties);
+                }
+                rootPrepareCollection(testCol1Name, testNumDocs);
+                rootPrepareCollection(testCol2Name, testNumDocs, false);
+              });
+
+              after(() => {
+                rootDropView(testView1Name);
+                rootDropView(testView2Name);
+                rootDropCollection(testCol1Name);
+                rootDropCollection(testCol2Name);
+              });
+
+              const rootTestCollection = (colName, switchBack = true) => {
+                helper.switchUser('root', dbName);
+                let col = db._collection(colName);
+                if (switchBack) {
+                  helper.switchUser(name, dbName);
+                }
+                return col !== null;
+              };
+
+              const rootCreateCollection = (colName, explicitRight = '') => {
+                if (!rootTestCollection(colName, false)) {
+                  let c = db._create(colName);
+                  if (colName === testCol1Name) {
+                    c.ensureIndex({ type: "inverted", name: indexName, fields: [ { name: "value" } ] });
+                  }
+                  if (explicitRight !== '' && rightLevels.has(explicitRight)) {
+                    if (helper.isLdapEnabledExternal()) {
+                      users.grantCollection(':role:' + name, dbName, colName, explicitRight);
+                    } else {
+                      users.grantCollection(name, dbName, colName, explicitRight);
+                    }
+                  } else {
+                    if (colLevel['none'].has(name)) {
+                      if (helper.isLdapEnabledExternal()) {
+                        users.grantCollection(':role:' + name, dbName, colName, 'none');
+                      } else {
+                        users.grantCollection(name, dbName, colName, 'none');
+                      }
+                    } else if (colLevel['ro'].has(name)) {
+                      if (helper.isLdapEnabledExternal()) {
+                        users.grantCollection(':role:' + name, dbName, colName, 'ro');
+                      } else {
+                        users.grantCollection(name, dbName, colName, 'ro');
+                      }
+                    } else if (colLevel['rw'].has(name)) {
+                      if (helper.isLdapEnabledExternal()) {
+                        users.grantCollection(':role:' + name, dbName, colName, 'rw');
+                      } else {
+                        users.grantCollection(name, dbName, colName, 'rw');
+                      }
+                    }
+                  }
+                }
+                helper.switchUser(name, dbName);
+              };
+
+              const rootGrantCollection = (colName, user, explicitRight = '') => {
+                if (rootTestCollection(colName, false)) {
+                  if (explicitRight !== '' && rightLevels.includes(explicitRight)) {
+                    if (helper.isLdapEnabledExternal()) {
+                      users.grantCollection(':role:' + user, dbName, colName, explicitRight);
+                    } else {
+                      users.grantCollection(user, dbName, colName, explicitRight);
+                    }
+                  }
+                }
+                helper.switchUser(user, dbName);
+              };
+
+              const rootPrepareCollection = (colName, numDocs = 1, defKey = true) => {
+                if (rootTestCollection(colName, false)) {
+                  db._collection(colName).truncate({ compact: false });
+                  let docs = [];
+                  for (let i = 0; i < numDocs; ++i) {
+                    let doc = {prop1: colName + "_1", propI: i, plink: "lnk" + i};
+                    if (!defKey) {
+                      doc._key = colName + i;
+                    }
+                    docs.push(doc);
+                  }
+                  db._collection(colName).insert(docs);
+                }
+                helper.switchUser(name, dbName);
+              };
+
+              const rootDropCollection = (colName) => {
+                helper.switchUser('root', dbName);
+                try {
+                  db._collection(colName).drop();
+                } catch (ignored) { }
+                helper.switchUser(name, dbName);
+              };
+
+              const rootTestView = (viewName, switchBack = true) => {
+                helper.switchUser('root', dbName);
+                let view = db._view(viewName);
+                if (switchBack) {
+                  helper.switchUser(name, dbName);
+                }
+                return view !== null;
+              };
+
+              const rootCreateView = (viewName, viewType, properties = null) => {
+                if (rootTestView(viewName, false)) {
+                  db._dropView(viewName);
+                }
+                let view =  db._createView(viewName, viewType, {});
+                if (properties !== null) {
+                  view.properties(properties, false);
+                }
+                helper.switchUser(name, dbName);
+              };
+
+              const rootDropView = (viewName) => {
+                helper.switchUser('root', dbName);
+                try {
+                  db._dropView(viewName);
+                } catch (ignored) { }
+                helper.switchUser(name, dbName);
+              };
+
+              const checkError = (e) => {
+                expect(e.code).to.be.oneOf([403, 404], "Expected to get forbidden OR not found REST error code, but got another one");
+                expect(e.errorNum).to.equal(errors.ERROR_FORBIDDEN.code, "Expected to get forbidden error number, but got another one");
+              };
+
+              describe('read a view', () => {
+                before(() => {
+                  db._useDatabase(dbName);
+                });
+
+                it('by AQL with link to single collection', () => {
+                  expect(rootTestView(testView1Name)).to.equal(true, 'Precondition failed, the view doesn\'t exist');
+                  let query = `FOR d IN  ${testView1Name} RETURN d`;
+                  if ((dbLevel['rw'].has(name) || dbLevel['ro'].has(name)) && (colLevel['rw'].has(name) || colLevel['ro'].has(name))) {
+                    db._query(query);
+                    //FIXME: issue #429 (https://github.com/arangodb/backlog/issues/429)
+                    //let result = db._query(query).toArray();
+                    //expect(result.length).to.equal(testNumDocs, 'View read failed');
+                  } else {
+                    try {
+                      db._query(query);
+                    } catch (e) {
+                      checkError(e);
+                      return;
+                    }
+                    expect(false).to.equal(true, `${name} managed to perform a query on view with insufficient rights`);
+                  }
+                });
+
+                if (testViewType === 'arangosearch') {
+                  it('by AQL with links to multiple collections with same access level', () => {
+                    expect(rootTestView(testView2Name)).to.equal(true, 'Precondition failed, the view doesn\'t exist');
+                    let query = `FOR d IN  ${testView2Name} RETURN d`;
+                    if ((dbLevel['rw'].has(name) || dbLevel['ro'].has(name)) && (colLevel['rw'].has(name) || colLevel['ro'].has(name))) {
+                      db._query(query, null, { waitForSync: true });
+                      //FIXME: issue #429 (https://github.com/arangodb/backlog/issues/429)
+                      //let result = db._query(query, null, { waitForSync: true }).toArray();
+                      //expect(result.length).to.equal(testNumDocs*2, 'View read failed');
+                    } else {
+                      try {
+                        db._query(query);
+                      } catch (e) {
+                        checkError(e);
+                        return;
+                      }
+                      expect(false).to.equal(true, `${name} managed to perform a query on view with insufficient rights`);
+                    }
+                  });
+
+                  let descName = 'view with links to multiple collections with NONE access level to one of them';
+                  !(colLevel['rw'].has(name) || colLevel['ro'].has(name)) ? describe(descName, () => {}) :
+                    describe(descName, () => {
+                      before(() => {
+                        rootGrantCollection(testCol2Name, name, 'none');
+                        expect(rootTestView(testView2Name)).to.equal(true, 'Precondition failed, the view doesn\'t exist');
+                      });
+
+                      it('by AQL query (data)', () => {
+                        let query = `FOR d IN  ${testView2Name} RETURN d`;
+                        try {
+                          db._query(query);
+                        } catch (e) {
+                          checkError(e);
+                          return;
+                        }
+                        expect(false).to.equal(true, `${name} managed to perform a query on view with insufficient rights`);
+                      });
+                      it('by its properties', () => {
+                        try {
+                          db._view(testView2Name).properties();
+                        } catch (e) {
+                          checkError(e);
+                          return;
+                        }
+                        expect(false).to.equal(true, `${name} managed to get the view properties with insufficient rights`);
+                      });
+                    });
+                }
+              });
+            });
+          });
         }
 
-        describe(`user ${name}`, () => {
-          before(() => {
-            helper.switchUser(name, dbName);
-          });
-
-        describe('administrate on db level', () => {
-          before(() => {
-            db._useDatabase(dbName);
-            rootCreateCollection(testCol1Name);
-            rootCreateCollection(testCol2Name);
-            var properties = { properties : {} };
-            properties['links'] = {};
-            properties['links'][testCol1Name] = { includeAllFields: true };
-            rootCreateView(testView1Name, properties);
-            properties['links'][testCol2Name] = { includeAllFields: true };
-            rootCreateView(testView2Name, properties);
-            rootPrepareCollection(testCol1Name, testNumDocs);
-            rootPrepareCollection(testCol2Name, testNumDocs, false);
-          });
-
-          after(() => {
-            rootDropView(testView1Name);
-            rootDropView(testView2Name);
-            rootDropCollection(testCol1Name);
-            rootDropCollection(testCol2Name);
-          });
-
-          const rootTestCollection = (colName, switchBack = true) => {
-            helper.switchUser('root', dbName);
-            let col = db._collection(colName);
-            if (switchBack) {
-                helper.switchUser(name, dbName);
-            }
-            return col !== null;
-          };
-
-          const rootCreateCollection = (colName, explicitRight = '') => {
-            if (!rootTestCollection(colName, false)) {
-              db._create(colName);
-              if (explicitRight !== '' && rightLevels.has(explicitRight))
-              {
-                if (helper.isLdapEnabledExternal()) {
-                  users.grantCollection(':role:' + name, dbName, colName, explicitRight);
-                } else {
-                  users.grantCollection(name, dbName, colName, explicitRight);
-                }
-              } else {
-                if (colLevel['none'].has(name)) {
-                  if (helper.isLdapEnabledExternal()) {
-                    users.grantCollection(':role:' + name, dbName, colName, 'none');
-                  } else {
-                    users.grantCollection(name, dbName, colName, 'none');
-                  }
-                } else if (colLevel['ro'].has(name)) {
-                  if (helper.isLdapEnabledExternal()) {
-                    users.grantCollection(':role:' + name, dbName, colName, 'ro');
-                  } else {
-                    users.grantCollection(name, dbName, colName, 'ro');
-                  }
-                } else if (colLevel['rw'].has(name)) {
-                  if (helper.isLdapEnabledExternal()) {
-                    users.grantCollection(':role:' + name, dbName, colName, 'rw');
-                  } else {
-                    users.grantCollection(name, dbName, colName, 'rw');
-                  }
-                }
-              }
-            }
-            helper.switchUser(name, dbName);
-          };
-
-          const rootGrantCollection = (colName, user, explicitRight = '') => {
-            if (rootTestCollection(colName, false)) {
-              if (explicitRight !== '' && rightLevels.includes(explicitRight))
-              {
-                if (helper.isLdapEnabledExternal()) {
-                  users.grantCollection(':role:' + user, dbName, colName, explicitRight);
-                } else {
-                  users.grantCollection(user, dbName, colName, explicitRight);
-                }
-              }
-            }
-            helper.switchUser(user, dbName);
-          };
-
-          const rootPrepareCollection = (colName, numDocs = 1, defKey = true) => {
-              if (rootTestCollection(colName, false)) {
-                db._collection(colName).truncate({ compact: false });
-                for(var i = 0; i < numDocs; ++i)
-                {
-                  var doc = {prop1: colName + "_1", propI: i, plink: "lnk" + i};
-                  if (!defKey) {
-                    doc._key = colName + i;
-                  }
-                  db._collection(colName).save(doc, {waitForSync: true});
-                }
-              }
-              helper.switchUser(name, dbName);
-          };
-
-          const rootDropCollection = (colName) => {
-            helper.switchUser('root', dbName);
-            try {
-              db._collection(colName).drop();
-            } catch (ignored) { }
-            helper.switchUser(name, dbName);
-          };
-
-          const rootTestView = (viewName, switchBack = true) => {
-            helper.switchUser('root', dbName);
-            let view = db._view(viewName);
-            if (switchBack) {
-                helper.switchUser(name, dbName);
-            }
-            return view != null;
-          };
-
-          const rootCreateView = (viewName, properties = null) => {
-            if (rootTestView(viewName, false)) {
-              db._dropView(viewName);
-            }
-            let view =  db._createView(viewName, testViewType, {});
-            if (properties != null) {
-              view.properties(properties, false);
-            }
-            helper.switchUser(name, dbName);
-          };
-
-          const rootDropView = (viewName) => {
-            helper.switchUser('root', dbName);
-            try {
-              db._dropView(viewName);
-            } catch (ignored) { }
-            helper.switchUser(name, dbName);
-          };
-
-          const checkError = (e) => {
-            expect(e.code).to.be.oneOf([403, 404], "Expected to get forbidden OR not found REST error code, but got another one");
-            expect(e.errorNum).to.equal(errors.ERROR_FORBIDDEN.code, "Expected to get forbidden error number, but got another one");
-          };
-
-          describe('read a view', () => {
-            before(() => {
-              db._useDatabase(dbName);
-            });
-
-            it('by AQL with link to single collection', () => {
-              expect(rootTestView(testView1Name)).to.equal(true, 'Precondition failed, the view doesn\'t exist');
-              let query = `FOR d IN  ${testView1Name} RETURN d`;
-              if ((dbLevel['rw'].has(name) || dbLevel['ro'].has(name)) && (colLevel['rw'].has(name) || colLevel['ro'].has(name))) {
-                db._query(query);
-                //FIXME: issue #429 (https://github.com/arangodb/backlog/issues/429)
-                //let result = db._query(query).toArray();
-                //expect(result.length).to.equal(testNumDocs, 'View read failed');
-              } else {
-                try {
-                  db._query(query);
-                } catch (e) {
-                  checkError(e);
-                  return;
-                }
-                expect(false).to.equal(true, `${name} managed to perform a query on view with insufficient rights`);
-              }
-            });
-
-            it('by AQL with links to multiple collections with same access level', () => {
-              expect(rootTestView(testView2Name)).to.equal(true, 'Precondition failed, the view doesn\'t exist');
-              let query = `FOR d IN  ${testView2Name} RETURN d`;
-              if ((dbLevel['rw'].has(name) || dbLevel['ro'].has(name)) && (colLevel['rw'].has(name) || colLevel['ro'].has(name))) {
-                db._query(query, null, { waitForSync: true });
-                //FIXME: issue #429 (https://github.com/arangodb/backlog/issues/429)
-                //let result = db._query(query, null, { waitForSync: true }).toArray();
-                //expect(result.length).to.equal(testNumDocs*2, 'View read failed');
-              } else {
-                try {
-                  db._query(query);
-                } catch (e) {
-                  checkError(e);
-                  return;
-                }
-                expect(false).to.equal(true, `${name} managed to perform a query on view with insufficient rights`);
-              }
-            });
-
-            var descName = 'view with links to multiple collections with NONE access level to one of them';
-            !(colLevel['rw'].has(name) || colLevel['ro'].has(name)) ? describe(descName, () => {}) :
-            describe(descName, () => {
-              before(() => {
-                  rootGrantCollection(testCol2Name, name, 'none');
-                  expect(rootTestView(testView2Name)).to.equal(true, 'Precondition failed, the view doesn\'t exist');
-              });
-
-              it('by AQL query (data)', () => {
-                let query = `FOR d IN  ${testView2Name} RETURN d`;
-                try {
-                  db._query(query);
-                } catch (e) {
-                  checkError(e);
-                  return;
-                }
-                expect(false).to.equal(true, `${name} managed to perform a query on view with insufficient rights`);
-              });
-              it('by its properties', () => {
-                try {
-                  db._view(testView2Name).properties();
-                } catch (e) {
-                  checkError(e);
-                  return;
-                }
-                expect(false).to.equal(true, `${name} managed to get the view properties with insufficient rights`);
-              });
-            });
-          });
-        });
       });
     }
   });

--- a/tests/js/client/authentication/user-access-right-task-create-view-arangosearch-search-alias-spec.js
+++ b/tests/js/client/authentication/user-access-right-task-create-view-arangosearch-search-alias-spec.js
@@ -1,0 +1,310 @@
+/* jshint globalstrict:true, strict:true, maxlen: 5000 */
+/* global describe, before, after, it, require*/
+
+// //////////////////////////////////////////////////////////////////////////////
+// / @brief tests for user access rights
+// /
+// / @file
+// /
+// / DISCLAIMER
+// /
+// / Copyright 2018 ArangoDB GmbH, Cologne, Germany
+// /
+// / Licensed under the Apache License, Version 2.0 (the "License");
+// / you may not use this file except in compliance with the License.
+// / You may obtain a copy of the License at
+// /
+// /     http://www.apache.org/licenses/LICENSE-2.0
+// /
+// / Unless required by applicable law or agreed to in writing, software
+// / distributed under the License is distributed on an "AS IS" BASIS,
+// / WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// / See the License for the specific language governing permissions and
+// / limitations under the License.
+// /
+// / Copyright holder is ArangoDB GmbH, Cologne, Germany
+// /
+// / @author Vadim Kondratyev
+// / @author Copyright 2018, ArangoDB GmbH, Cologne, Germany
+// //////////////////////////////////////////////////////////////////////////////
+
+'use strict';
+
+const expect = require('chai').expect;
+const users = require('@arangodb/users');
+const helper = require('@arangodb/testutils/user-helper');
+const tasks = require('@arangodb/tasks');
+const pu = require('@arangodb/testutils/process-utils');
+const download = require('internal').download;
+const errors = require('@arangodb').errors;
+const db = require('@arangodb').db;
+const namePrefix = helper.namePrefix;
+const dbName = helper.dbName;
+const rightLevels = helper.rightLevels;
+const testViewName = `${namePrefix}ViewNew`;
+const testColName = `${namePrefix}ColNew`;
+const testColNameAnother = `${namePrefix}ColAnotherNew`;
+const indexName = `${namePrefix}Inverted`;
+const keySpaceId = 'task_create_view_keyspace';
+
+const userSet = helper.userSet;
+const systemLevel = helper.systemLevel;
+const dbLevel = helper.dbLevel;
+const colLevel = helper.colLevel;
+
+const arango = require('internal').arango;
+for (let l of rightLevels) {
+  systemLevel[l] = new Set();
+  dbLevel[l] = new Set();
+  colLevel[l] = new Set();
+}
+
+const wait = (keySpaceId, key) => {
+  for (let i = 0; i < 200; i++) {
+    if (getKey(keySpaceId, key)) {
+      break;
+    }
+    require('internal').wait(0.1);
+  }
+};
+
+const createKeySpace = (keySpaceId) => {
+  return executeJS(`return global.KEYSPACE_CREATE('${keySpaceId}', 128, true);`).body === 'true';
+};
+
+const dropKeySpace = (keySpaceId) => {
+  executeJS(`global.KEYSPACE_DROP('${keySpaceId}');`);
+};
+
+const getKey = (keySpaceId, key) => {
+  return executeJS(`return global.KEY_GET('${keySpaceId}', '${key}');`).body === 'true';
+};
+
+const setKey = (keySpaceId, name) => {
+  return executeJS(`global.KEY_SET('${keySpaceId}', '${name}', false);`);
+};
+
+const executeJS = (code) => {
+  let httpOptions = pu.makeAuthorizationHeaders({
+    username: 'root',
+    password: ''
+  }, {});
+  httpOptions.method = 'POST';
+  httpOptions.timeout = 1800;
+  httpOptions.returnBodyOnError = true;
+  return download(arango.getEndpoint().replace('tcp', 'http') + `/_db/${dbName}/_admin/execute?returnAsJSON=true`,
+    code,
+    httpOptions);
+};
+
+helper.switchUser('root', '_system');
+helper.removeAllUsers();
+helper.generateAllUsers();
+
+const testViewType = "search-alias";
+
+describe('User Rights Management', () => {
+  it('should check if all users are created', () => {
+    helper.switchUser('root', '_system');
+    expect(userSet.size).to.be.greaterThan(0); 
+    expect(userSet.size).to.equal(helper.userCount);
+    for (let name of userSet) {
+      expect(users.document(name), `Could not find user: ${name}`).to.not.be.undefined;
+    }
+  });
+
+  it('should test rights for', () => {
+    expect(userSet.size).to.be.greaterThan(0);
+    for (let name of userSet) {
+      let canUse = false;
+      try {
+        helper.switchUser(name, dbName);
+        canUse = true;
+      } catch (e) {
+        canUse = false;
+      }
+
+      if (canUse) {
+        describe(`user ${name}`, () => {
+          before(() => {
+            helper.switchUser(name, dbName);
+            expect(createKeySpace(keySpaceId)).to.equal(true, 'keySpace creation failed!');
+          });
+
+          after(() => {
+            dropKeySpace(keySpaceId);
+          });
+
+          describe('administrate on db level', () => {
+            const rootTestCollection = (colName, switchBack = true) => {
+              helper.switchUser('root', dbName);
+              let col = db._collection(colName);
+              if (switchBack) {
+                helper.switchUser(name, dbName);
+              }
+              return col !== null;
+            };
+
+            const rootCreateCollection = (colName = testColName) => {
+              if (!rootTestCollection(colName, false)) {
+                let c = db._create(colName);
+                if (colName === testColName) {
+                  c.ensureIndex({ type: "inverted", name: indexName, fields: [ { name: "value" } ] });
+                }
+                if (colLevel['none'].has(name)) {
+                  if (helper.isLdapEnabledExternal()) {
+                    users.grantCollection(':role:' + name, dbName, colName, 'none');
+                  } else {
+                    users.grantCollection(name, dbName, colName, 'none');
+                  }
+                } else if (colLevel['ro'].has(name)) {
+                  if (helper.isLdapEnabledExternal()) {
+                    users.grantCollection(':role:' + name, dbName, colName, 'ro');
+                  } else {
+                    users.grantCollection(name, dbName, colName, 'ro');
+                  }
+                } else if (colLevel['rw'].has(name)) {
+                  if (helper.isLdapEnabledExternal()) {
+                    users.grantCollection(':role:' + name, dbName, colName, 'rw');
+                  } else {
+                    users.grantCollection(name, dbName, colName, 'rw');
+                  }
+                }
+              }
+              helper.switchUser(name, dbName);
+            };
+
+            const rootDropCollection = (colName = testColName) => {
+              if (rootTestCollection(colName, false)) {
+                try {
+                  db._collection(colName).drop();
+                } catch (ignored) { }
+              }
+              helper.switchUser(name, dbName);
+            };
+
+            const rootTestView = (viewName = testViewName) => {
+              helper.switchUser('root', dbName);
+              const view = db._view(viewName);
+              helper.switchUser(name, dbName);
+              return view !== null;
+            };
+
+            const rootTestViewHasLinks = (viewName = testViewName, links) => {
+              helper.switchUser('root', dbName);
+              let view = db._view(viewName);
+              if (view !== null) {
+                links.every(function(link) {
+                  const links = view.properties().links;
+                  if (links !== null && links.hasOwnProperty([link])){
+                    return true;
+                  } else {
+                    view = null;
+                    return false;
+                  }
+                });
+              }
+              helper.switchUser(name, dbName);
+              return view !== null;
+            };
+
+            const rootTestViewLinksEmpty = (viewName = testViewName) => {
+              helper.switchUser('root', dbName);
+              let view = db._view(viewName);
+              return Object.keys(view.properties().links).length === 0;
+            };
+
+            const rootDropView = () => {
+              helper.switchUser('root', dbName);
+              try {
+                db._dropView(testViewName);
+              } catch (ignored) { }
+              helper.switchUser(name, dbName);
+            };
+
+            const rootGetViewProps = (viewName, switchBack = true) => {
+              helper.switchUser('root', dbName);
+              let properties = db._view(viewName).properties();
+              if (switchBack) {
+                helper.switchUser(name, dbName);
+              }
+              return properties;
+            };
+
+            const rootGrantCollection = (colName, user, explicitRight = '') => {
+              if (rootTestCollection(colName, false)) {
+                if (explicitRight !== '' && rightLevels.includes(explicitRight)) {
+                  if (helper.isLdapEnabledExternal()) {
+                    users.grantCollection(':role:' + user, dbName, colName, explicitRight);
+                  } else {
+                    users.grantCollection(user, dbName, colName, explicitRight);
+                  }
+                }
+              }
+              helper.switchUser(user, dbName);
+            };
+
+            const checkError = (e) => {
+              expect(e.code).to.equal(403, "Expected to get forbidden REST error code, but got another one");
+              expect(e.errorNum).to.equal(errors.ERROR_FORBIDDEN.code, "Expected to get forbidden error number, but got another one");
+            };
+
+            describe('create a', () => {
+              before(() => {
+                db._useDatabase(dbName);
+              });
+
+              after(() => {
+                rootDropView(testViewName);
+                rootDropCollection(testColName);
+              });
+
+              const key = `${name}`;
+
+              it('view with empty (default) parameters', () => {
+                expect(rootTestView(testViewName)).to.equal(false, 'Precondition failed, the view still exists');
+
+                setKey(keySpaceId, name);
+                const taskId = 'task_create_view_default_params_' + key;
+                const task = {
+                  id: taskId,
+                  name: taskId,
+                  command: `(function (params) {
+                    try {
+                      const db = require('@arangodb').db;
+                      db._createView('${testViewName}', '${testViewType}', {});
+                      global.KEY_SET('${keySpaceId}', '${key}_status', true);
+                    } catch (e) {
+                      global.KEY_SET('${keySpaceId}', '${key}_status', false);
+                    } finally {
+                      global.KEY_SET('${keySpaceId}', '${key}', true);
+                    }
+                  })(params);`
+                };
+
+                if (dbLevel['rw'].has(name)) {
+                  tasks.register(task);
+                  wait(keySpaceId, key);
+                  expect(getKey(keySpaceId, `${key}_status`)).to.equal(true, `${name} could not create the view with sufficient rights`);
+                  expect(rootTestView(testViewName)).to.equal(true, 'View creation reported success, but view was not found afterwards');
+                } else {
+                  try {
+                    tasks.register(task);
+                    wait(keySpaceId, key);
+                  } catch (e) {
+                    checkError(e);
+                    return;
+                  } finally {
+                    expect(rootTestView(testViewName)).to.equal(false, `${name} was able to create a view with insufficent rights`);
+                  }
+                  expect(false).to.equal(true, `${name} managed to register a task with insufficient rights`);
+                }
+              });
+
+            });
+          });
+        });
+      }
+    }
+  });
+});

--- a/tests/js/client/authentication/user-access-right-task-create-view-arangosearch-spec.js
+++ b/tests/js/client/authentication/user-access-right-task-create-view-arangosearch-spec.js
@@ -42,9 +42,9 @@ const namePrefix = helper.namePrefix;
 const dbName = helper.dbName;
 const rightLevels = helper.rightLevels;
 const testViewName = `${namePrefix}ViewNew`;
-const testViewType = "arangosearch";
 const testColName = `${namePrefix}ColNew`;
 const testColNameAnother = `${namePrefix}ColAnotherNew`;
+const indexName = `${namePrefix}Inverted`;
 const keySpaceId = 'task_create_view_keyspace';
 
 const userSet = helper.userSet;
@@ -61,7 +61,9 @@ for (let l of rightLevels) {
 
 const wait = (keySpaceId, key) => {
   for (let i = 0; i < 200; i++) {
-    if (getKey(keySpaceId, key)) break;
+    if (getKey(keySpaceId, key)) {
+      break;
+    }
     require('internal').wait(0.1);
   }
 };
@@ -99,16 +101,9 @@ helper.switchUser('root', '_system');
 helper.removeAllUsers();
 helper.generateAllUsers();
 
-function hasIResearch (db) {
-  return !(db._views() === 0); // arangosearch views are not supported
-}
-
-!hasIResearch(db) ? describe.skip : describe('User Rights Management', () => {
+describe('User Rights Management', () => {
   it('should check if all users are created', () => {
     helper.switchUser('root', '_system');
-    if (db._views() === 0) {
-      return; // arangosearch views are not supported
-    }
     expect(userSet.size).to.be.greaterThan(0); 
     expect(userSet.size).to.equal(helper.userCount);
     for (let name of userSet) {
@@ -118,468 +113,478 @@ function hasIResearch (db) {
 
   it('should test rights for', () => {
     expect(userSet.size).to.be.greaterThan(0);
-    for (let name of userSet) {
-      let canUse = false;
-      try {
-        helper.switchUser(name, dbName);
-        canUse = true;
-      } catch (e) {
-        canUse = false;
-      }
-
-      if (canUse) {
-        describe(`user ${name}`, () => {
-          before(() => {
+    for (let testViewType of ["arangosearch", "search-alias"]) {
+      describe(`view type ${testViewType}`, () => {
+        for (let name of userSet) {
+          let canUse = false;
+          try {
             helper.switchUser(name, dbName);
-            expect(createKeySpace(keySpaceId)).to.equal(true, 'keySpace creation failed!');
-          });
+            canUse = true;
+          } catch (e) {
+            canUse = false;
+          }
 
-          after(() => {
-            dropKeySpace(keySpaceId);
-          });
-
-          describe('administrate on db level', () => {
-            const rootTestCollection = (colName, switchBack = true) => {
-              helper.switchUser('root', dbName);
-              let col = db._collection(colName);
-              if (switchBack) {
-                helper.switchUser(name, dbName);
-              }
-              return col !== null;
-            };
-
-            const rootCreateCollection = (colName = testColName) => {
-              if (!rootTestCollection(colName, false)) {
-                db._create(colName);
-                if (colLevel['none'].has(name)) {
-                    if (helper.isLdapEnabledExternal()) {
-                      users.grantCollection(':role:' + name, dbName, colName, 'none');
-                    } else {
-                      users.grantCollection(name, dbName, colName, 'none');
-                    }
-                } else if (colLevel['ro'].has(name)) {
-                  if (helper.isLdapEnabledExternal()) {
-                    users.grantCollection(':role:' + name, dbName, colName, 'ro');
-                  } else {
-                    users.grantCollection(name, dbName, colName, 'ro');
-                  }
-                } else if (colLevel['rw'].has(name)) {
-                  if (helper.isLdapEnabledExternal()) {
-                    users.grantCollection(':role:' + name, dbName, colName, 'rw');
-                  } else {
-                    users.grantCollection(name, dbName, colName, 'rw');
-                  }
-                }
-              }
-              helper.switchUser(name, dbName);
-            };
-
-            const rootDropCollection = (colName = testColName) => {
-              if (rootTestCollection(colName, false)) {
-                try {
-                  db._collection(colName).drop();
-                } catch (ignored) { }
-              }
-              helper.switchUser(name, dbName);
-            };
-
-            const rootTestView = (viewName = testViewName) => {
-              helper.switchUser('root', dbName);
-              const view = db._view(viewName);
-              helper.switchUser(name, dbName);
-              return view != null;
-            };
-
-            const rootTestViewHasLinks = (viewName = testViewName, links) => {
-              helper.switchUser('root', dbName);
-              var view = db._view(viewName);
-              if (view != null) {
-                links.every(function(link) {
-                  const links = view.properties().links;
-                  if (links != null && links.hasOwnProperty([link])){
-                    return true;
-                  } else {
-                    view = null;
-                    return false;
-                  }
-                });
-              }
-              helper.switchUser(name, dbName);
-              return view != null;
-            };
-
-            const rootTestViewLinksEmpty = (viewName = testViewName) => {
-              helper.switchUser('root', dbName);
-              var view = db._view(viewName);
-              return Object.keys(view.properties().links).length === 0;
-            };
-
-            const rootDropView = () => {
-              helper.switchUser('root', dbName);
-              try {
-                db._dropView(testViewName);
-              } catch (ignored) { }
-              helper.switchUser(name, dbName);
-            };
-
-            const rootGetViewProps = (viewName, switchBack = true) => {
-              helper.switchUser('root', dbName);
-              let properties = db._view(viewName).properties();
-              if (switchBack) {
-                  helper.switchUser(name, dbName);
-              }
-              return properties;
-            };
-
-            const rootGrantCollection = (colName, user, explicitRight = '') => {
-              if (rootTestCollection(colName, false)) {
-                if (explicitRight !== '' && rightLevels.includes(explicitRight))
-                {
-                  if (helper.isLdapEnabledExternal()) {
-                    users.grantCollection(':role:' + user, dbName, colName, explicitRight);
-                  } else {
-                    users.grantCollection(user, dbName, colName, explicitRight);
-                  }
-                }
-              }
-              helper.switchUser(user, dbName);
-            };
-
-            const checkError = (e) => {
-              expect(e.code).to.equal(403, "Expected to get forbidden REST error code, but got another one");
-              expect(e.errorNum).to.equal(errors.ERROR_FORBIDDEN.code, "Expected to get forbidden error number, but got another one");
-            };
-
-            describe('create a', () => {
+          if (canUse) {
+            describe(`user ${name}`, () => {
               before(() => {
-                db._useDatabase(dbName);
+                helper.switchUser(name, dbName);
+                expect(createKeySpace(keySpaceId)).to.equal(true, 'keySpace creation failed!');
               });
 
               after(() => {
-                rootDropView(testViewName);
-                rootDropCollection(testColName);
+                dropKeySpace(keySpaceId);
               });
 
-              it('view with empty (default) parameters', () => {
-                expect(rootTestView(testViewName)).to.equal(false, 'Precondition failed, the view still exists');
+              describe('administrate on db level', () => {
+                const rootTestCollection = (colName, switchBack = true) => {
+                  helper.switchUser('root', dbName);
+                  let col = db._collection(colName);
+                  if (switchBack) {
+                    helper.switchUser(name, dbName);
+                  }
+                  return col !== null;
+                };
 
-                setKey(keySpaceId, name);
-                const taskId = 'task_create_view_default_params_' + name;
-                const task = {
-                  id: taskId,
-                  name: taskId,
-                  command: `(function (params) {
+                const rootCreateCollection = (colName = testColName) => {
+                  if (!rootTestCollection(colName, false)) {
+                    let c = db._create(colName);
+                    if (colName === testColName) {
+                      c.ensureIndex({ type: "inverted", name: indexName, fields: [ { name: "value" } ] });
+                    }
+                    if (colLevel['none'].has(name)) {
+                      if (helper.isLdapEnabledExternal()) {
+                        users.grantCollection(':role:' + name, dbName, colName, 'none');
+                      } else {
+                        users.grantCollection(name, dbName, colName, 'none');
+                      }
+                    } else if (colLevel['ro'].has(name)) {
+                      if (helper.isLdapEnabledExternal()) {
+                        users.grantCollection(':role:' + name, dbName, colName, 'ro');
+                      } else {
+                        users.grantCollection(name, dbName, colName, 'ro');
+                      }
+                    } else if (colLevel['rw'].has(name)) {
+                      if (helper.isLdapEnabledExternal()) {
+                        users.grantCollection(':role:' + name, dbName, colName, 'rw');
+                      } else {
+                        users.grantCollection(name, dbName, colName, 'rw');
+                      }
+                    }
+                  }
+                  helper.switchUser(name, dbName);
+                };
+
+                const rootDropCollection = (colName = testColName) => {
+                  if (rootTestCollection(colName, false)) {
+                    try {
+                      db._collection(colName).drop();
+                    } catch (ignored) { }
+                  }
+                  helper.switchUser(name, dbName);
+                };
+
+                const rootTestView = (viewName = testViewName) => {
+                  helper.switchUser('root', dbName);
+                  const view = db._view(viewName);
+                  helper.switchUser(name, dbName);
+                  return view !== null;
+                };
+
+                const rootTestViewHasLinks = (viewName = testViewName, links) => {
+                  helper.switchUser('root', dbName);
+                  let view = db._view(viewName);
+                  if (view !== null) {
+                    links.every(function(link) {
+                      const links = view.properties().links;
+                      if (links !== null && links.hasOwnProperty([link])){
+                        return true;
+                      } else {
+                        view = null;
+                        return false;
+                      }
+                    });
+                  }
+                  helper.switchUser(name, dbName);
+                  return view !== null;
+                };
+
+                const rootTestViewLinksEmpty = (viewName = testViewName) => {
+                  helper.switchUser('root', dbName);
+                  let view = db._view(viewName);
+                  return Object.keys(view.properties().links).length === 0;
+                };
+
+                const rootDropView = () => {
+                  helper.switchUser('root', dbName);
+                  try {
+                    db._dropView(testViewName);
+                  } catch (ignored) { }
+                  helper.switchUser(name, dbName);
+                };
+
+                const rootGetViewProps = (viewName, switchBack = true) => {
+                  helper.switchUser('root', dbName);
+                  let properties = db._view(viewName).properties();
+                  if (switchBack) {
+                    helper.switchUser(name, dbName);
+                  }
+                  return properties;
+                };
+
+                const rootGrantCollection = (colName, user, explicitRight = '') => {
+                  if (rootTestCollection(colName, false)) {
+                    if (explicitRight !== '' && rightLevels.includes(explicitRight)) {
+                      if (helper.isLdapEnabledExternal()) {
+                        users.grantCollection(':role:' + user, dbName, colName, explicitRight);
+                      } else {
+                        users.grantCollection(user, dbName, colName, explicitRight);
+                      }
+                    }
+                  }
+                  helper.switchUser(user, dbName);
+                };
+
+                const checkError = (e) => {
+                  expect(e.code).to.equal(403, "Expected to get forbidden REST error code, but got another one");
+                  expect(e.errorNum).to.equal(errors.ERROR_FORBIDDEN.code, "Expected to get forbidden error number, but got another one");
+                };
+
+                describe('create a', () => {
+                  before(() => {
+                    db._useDatabase(dbName);
+                  });
+
+                  after(() => {
+                    rootDropView(testViewName);
+                    rootDropCollection(testColName);
+                  });
+
+                  const key = `${testViewType}_${name}`;
+
+                  it('view with empty (default) parameters', () => {
+                    expect(rootTestView(testViewName)).to.equal(false, 'Precondition failed, the view still exists');
+
+                    setKey(keySpaceId, name);
+                    const taskId = 'task_create_view_default_params_' + key;
+                    const task = {
+                      id: taskId,
+                      name: taskId,
+                      command: `(function (params) {
                     try {
                       const db = require('@arangodb').db;
                       db._createView('${testViewName}', '${testViewType}', {});
-                      global.KEY_SET('${keySpaceId}', '${name}_status', true);
+                      global.KEY_SET('${keySpaceId}', '${key}_status', true);
                     } catch (e) {
-                      global.KEY_SET('${keySpaceId}', '${name}_status', false);
+                      global.KEY_SET('${keySpaceId}', '${key}_status', false);
                     } finally {
-                      global.KEY_SET('${keySpaceId}', '${name}', true);
+                      global.KEY_SET('${keySpaceId}', '${key}', true);
                     }
                   })(params);`
-                };
+                    };
 
-                if (dbLevel['rw'].has(name)) {
-                  tasks.register(task);
-                  wait(keySpaceId, name);
-                  expect(getKey(keySpaceId, `${name}_status`)).to.equal(true, `${name} could not create the view with sufficient rights`);
-                  expect(rootTestView(testViewName)).to.equal(true, 'View creation reported success, but view was not found afterwards');
-                } else {
-                  try {
-                    tasks.register(task);
-                    wait(keySpaceId, name);
-                  } catch (e) {
-                    checkError(e);
-                    return;
-                  } finally {
-                    expect(rootTestView(testViewName)).to.equal(false, `${name} was able to create a view with insufficent rights`);
-                  }
-                  expect(false).to.equal(true, `${name} managed to register a task with insufficient rights`);
-                }
-              });
+                    if (dbLevel['rw'].has(name)) {
+                      tasks.register(task);
+                      wait(keySpaceId, key);
+                      expect(getKey(keySpaceId, `${key}_status`)).to.equal(true, `${name} could not create the view with sufficient rights`);
+                      expect(rootTestView(testViewName)).to.equal(true, 'View creation reported success, but view was not found afterwards');
+                    } else {
+                      try {
+                        tasks.register(task);
+                        wait(keySpaceId, key);
+                      } catch (e) {
+                        checkError(e);
+                        return;
+                      } finally {
+                        expect(rootTestView(testViewName)).to.equal(false, `${name} was able to create a view with insufficent rights`);
+                      }
+                      expect(false).to.equal(true, `${name} managed to register a task with insufficient rights`);
+                    }
+                  });
 
-              it('view with non-empty parameters (except links)', () => {
-                rootDropView(testViewName);
-                rootDropCollection(testColName);
+                  if (testViewType === 'arangosearch') {
+                    it('view with non-empty parameters (except links)', () => {
+                      rootDropView(testViewName);
+                      rootDropCollection(testColName);
 
-                expect(rootTestView(testViewName)).to.equal(false, 'Precondition failed, the view still exists');
+                      expect(rootTestView(testViewName)).to.equal(false, 'Precondition failed, the view still exists');
 
-                setKey(keySpaceId, name);
-                const taskId = 'task_create_view_non_default_params_except_links_' + name;
-                const task = {
-                  id: taskId,
-                  name: taskId,
-                  command: `(function (params) {
+                      setKey(keySpaceId, key);
+                      const taskId = 'task_create_view_non_default_params_except_links_' + key;
+                      const task = {
+                        id: taskId,
+                        name: taskId,
+                        command: `(function (params) {
                     try {
                       const db = require('@arangodb').db;
                       db._createView('${testViewName}', '${testViewType}', { cleanupIntervalStep: 20 });
-                      global.KEY_SET('${keySpaceId}', '${name}_status', true);
+                      global.KEY_SET('${keySpaceId}', '${key}_status', true);
                     } catch (e) {
-                      global.KEY_SET('${keySpaceId}', '${name}_status', false);
+                      global.KEY_SET('${keySpaceId}', '${key}_status', false);
                     } finally {
-                      global.KEY_SET('${keySpaceId}', '${name}', true);
+                      global.KEY_SET('${keySpaceId}', '${key}', true);
                     }
                   })(params);`
-                };
+                      };
 
-                if (dbLevel['rw'].has(name)) {
-                  tasks.register(task);
-                  wait(keySpaceId, name);
-                  expect(getKey(keySpaceId, `${name}_status`)).to.equal(true, `${name} could not create the view with sufficient rights`);
-                  expect(rootTestView(testViewName)).to.equal(true, 'View creation reported success, but view was not found afterwards');
-                  expect(rootGetViewProps(testViewName, true)["cleanupIntervalStep"]).to.equal(20, 'View creation reported success, but view property was not set as expected during creation');
-                } else {
-                  try {
-                    tasks.register(task);
-                    wait(keySpaceId, name);
-                  } catch (e) {
-                    checkError(e);
-                    return;
-                  } finally {
-                    expect(rootTestView(testViewName)).to.equal(false, `${name} was able to create a view with insufficent rights`);
-                  }
-                  expect(false).to.equal(true, `${name} managed to register a task with insufficient rights`);
-                }
-              });
+                      if (dbLevel['rw'].has(name)) {
+                        tasks.register(task);
+                        wait(keySpaceId, key);
+                        expect(getKey(keySpaceId, `${key}_status`)).to.equal(true, `${name} could not create the view with sufficient rights`);
+                        expect(rootTestView(testViewName)).to.equal(true, 'View creation reported success, but view was not found afterwards');
+                        expect(rootGetViewProps(testViewName, true)["cleanupIntervalStep"]).to.equal(20, 'View creation reported success, but view property was not set as expected during creation');
+                      } else {
+                        try {
+                          tasks.register(task);
+                          wait(keySpaceId, key);
+                        } catch (e) {
+                          checkError(e);
+                          return;
+                        } finally {
+                          expect(rootTestView(testViewName)).to.equal(false, `${name} was able to create a view with insufficent rights`);
+                        }
+                        expect(false).to.equal(true, `${name} managed to register a task with insufficient rights`);
+                      }
+                    });
 
-              // FIXME: uncomment after PR 6199 is done with respectful changes
-              /*
-              it('view with links to existing collection', () => {
-                rootDropView(testViewName);
-                rootDropCollection(testColName);
+                    it('view with links to existing collection', () => {
+                      rootDropView(testViewName);
+                      rootDropCollection(testColName);
 
-                rootCreateCollection(testColName);
-                expect(rootTestView(testViewName)).to.equal(false, 'Precondition failed, the view still exists');
-                expect(rootTestCollection(testColName)).to.equal(true, 'Precondition failed, the collection still not exists')
+                      rootCreateCollection(testColName);
+                      expect(rootTestView(testViewName)).to.equal(false, 'Precondition failed, the view still exists');
+                      expect(rootTestCollection(testColName)).to.equal(true, 'Precondition failed, the collection still not exists');
 
-                setKey(keySpaceId, name);
-                const taskId = 'task_create_view_with_links_to_existing_collection_' + name;
-                const task = {
-                  id: taskId,
-                  name: taskId,
-                  command: `(function (params) {
+                      setKey(keySpaceId, key);
+                      const taskId = 'task_create_view_with_links_to_existing_collection_' + key;
+                      const task = {
+                        id: taskId,
+                        name: taskId,
+                        command: `(function (params) {
                     try {
                       const db = require('@arangodb').db;
                       var view = db._createView('${testViewName}', '${testViewType}', { links: { '${testColName}': { includeAllFields: true } } });
-                    global.KEY_SET('${keySpaceId}', '${name}_status', true);
+                      global.KEY_SET('${keySpaceId}', '${key}_status', true);
                     } catch (e) {
-                      global.KEY_SET('${keySpaceId}', '${name}_status', false);
+                      global.KEY_SET('${keySpaceId}', '${key}_status', false);
                     } finally {
-                      global.KEY_SET('${keySpaceId}', '${name}', true);
+                      global.KEY_SET('${keySpaceId}', '${key}', true);
                     }
                   })(params);`
-                };
+                      };
 
-                if (dbLevel['rw'].has(name)) {
-                  if (colLevel['rw'].has(name) || colLevel['ro'].has(name)) {
-                    tasks.register(task);
-                    wait(keySpaceId, name);
-                    expect(getKey(keySpaceId, `${name}_status`)).to.equal(true, `${name} could not create the view with sufficient rights`);
-                    expect(rootTestView(testViewName)).to.equal(true, 'View creation reported success, but view was not found afterwards');
-                    expect(rootTestViewHasLinks(testViewName, [`${testColName}`])).to.equal(true, 'View links expected to be visible, but were not found afterwards');
-                  } else {
-                    tasks.register(task);
-                    wait(keySpaceId, name);
-                    expect(getKey(keySpaceId, `${name}_status`)).to.equal(false, `${name} could create the view with insufficient rights`);
-                    expect(rootTestView(testViewName)).to.equal(false, `${name} was able to create a view with insufficent rights`);
-                  }
-                } else {
-                  try {
-                    tasks.register(task);
-                    wait(keySpaceId, name);
-                  } catch (e) {
-                    checkError(e);
-                    return;
-                  } finally {
-                    expect(rootTestView(testViewName)).to.equal(false, `${name} was able to create a view with insufficent rights`);
-                  }
-                  expect(false).to.equal(true, `${name} managed to register a task with insufficient rights`);
-                }
-              });
+                      if (dbLevel['rw'].has(name)) {
+                        if (colLevel['rw'].has(name) || colLevel['ro'].has(name)) {
+                          tasks.register(task);
+                          wait(keySpaceId, key);
+                          expect(getKey(keySpaceId, `${key}_status`)).to.equal(true, `${name} could not create the view with sufficient rights`);
+                          expect(rootTestView(testViewName)).to.equal(true, 'View creation reported success, but view was not found afterwards');
+                          expect(rootTestViewHasLinks(testViewName, [`${testColName}`])).to.equal(true, 'View links expected to be visible, but were not found afterwards');
+                        } else {
+                          tasks.register(task);
+                          wait(keySpaceId, key);
+                          expect(getKey(keySpaceId, `${key}_status`)).to.equal(false, `${name} could create the view with insufficient rights`);
+                          expect(rootTestView(testViewName)).to.equal(false, `${name} was able to create a view with insufficent rights`);
+                        }
+                      } else {
+                        try {
+                          tasks.register(task);
+                          wait(keySpaceId, key);
+                        } catch (e) {
+                          checkError(e);
+                          return;
+                        } finally {
+                          expect(rootTestView(testViewName)).to.equal(false, `${name} was able to create a view with insufficent rights`);
+                        }
+                        expect(false).to.equal(true, `${name} managed to register a task with insufficient rights`);
+                      }
+                    });
 
-              it('view with links to multiple collections with same access level', () => {
-                rootDropView(testViewName);
-                rootDropCollection(testColName);
+                    it('view with links to multiple collections with same access level', () => {
+                      rootDropView(testViewName);
+                      rootDropCollection(testColName);
 
-                rootCreateCollection(testColName);
-                rootCreateCollection(testColNameAnother);
+                      rootCreateCollection(testColName);
+                      rootCreateCollection(testColNameAnother);
 
-                expect(rootTestView(testViewName)).to.equal(false, 'Precondition failed, the view still exists');
-                expect(rootTestCollection(testColName)).to.equal(true, 'Precondition failed, the collection still not exists');
-                expect(rootTestCollection(testColNameAnother)).to.equal(true, 'Precondition failed, the collection still not exists');
+                      expect(rootTestView(testViewName)).to.equal(false, 'Precondition failed, the view still exists');
+                      expect(rootTestCollection(testColName)).to.equal(true, 'Precondition failed, the collection still not exists');
+                      expect(rootTestCollection(testColNameAnother)).to.equal(true, 'Precondition failed, the collection still not exists');
 
-                setKey(keySpaceId, name);
-                const taskId = 'task_create_view_with_links_to_existing_collections_with_same_access_level_' + name;
-                const task = {
-                  id: taskId,
-                  name: taskId,
-                  command: `(function (params) {
+                      setKey(keySpaceId, key);
+                      const taskId = 'task_create_view_with_links_to_existing_collections_with_same_access_level_' + key;
+                      const task = {
+                        id: taskId,
+                        name: taskId,
+                        command: `(function (params) {
                     try {
                       const db = require('@arangodb').db;
                       var view = db._createView('${testViewName}', '${testViewType}', { links: { 
                         '${testColName}': { includeAllFields: true }, '${testColNameAnother}': { includeAllFields: true } 
                         }
                       });
-                      global.KEY_SET('${keySpaceId}', '${name}_status', true);
+                      global.KEY_SET('${keySpaceId}', '${key}_status', true);
                     } catch (e) {
-                      global.KEY_SET('${keySpaceId}', '${name}_status', false);
+                      global.KEY_SET('${keySpaceId}', '${key}_status', false);
                     } finally {
-                      global.KEY_SET('${keySpaceId}', '${name}', true);
+                      global.KEY_SET('${keySpaceId}', '${key}', true);
                     }
                   })(params);`
-                };
+                      };
 
-                if (dbLevel['rw'].has(name)) {
-                  if (colLevel['rw'].has(name) || colLevel['ro'].has(name)) {
-                    tasks.register(task);
-                    wait(keySpaceId, name);
-                    expect(getKey(keySpaceId, `${name}_status`)).to.equal(true, `${name} could not create the view with sufficient rights`);
-                    expect(rootTestView(testViewName)).to.equal(true, 'View creation reported success, but view was not found afterwards');
-                    expect(rootTestViewHasLinks(testViewName, [`${testColName}`, `${testColNameAnother}`])).to.equal(true, 'View links expected to be visible, but were not found afterwards');
-                  } else {
-                    tasks.register(task);
-                    wait(keySpaceId, name);
-                    expect(getKey(keySpaceId, `${name}_status`)).to.equal(false, `${name} could create the view with insufficient rights`);
-                    expect(rootTestView(testViewName)).to.equal(false, `${name} was able to create a view with insufficent rights`);
-                  }
-                } else {
-                  try {
-                    tasks.register(task);
-                    wait(keySpaceId, name);
-                  } catch (e) {
-                    checkError(e);
-                    return;
-                  } finally {
-                    expect(rootTestView(testViewName)).to.equal(false, `${name} was able to create a view with insufficent rights`);
-                  }
-                  expect(false).to.equal(true, `${name} managed to register a task with insufficient rights`);
-                }
-              });
+                      if (dbLevel['rw'].has(name)) {
+                        if (colLevel['rw'].has(name) || colLevel['ro'].has(name)) {
+                          tasks.register(task);
+                          wait(keySpaceId, key);
+                          expect(getKey(keySpaceId, `${key}_status`)).to.equal(true, `${name} could not create the view with sufficient rights`);
+                          expect(rootTestView(testViewName)).to.equal(true, 'View creation reported success, but view was not found afterwards');
+                          expect(rootTestViewHasLinks(testViewName, [`${testColName}`, `${testColNameAnother}`])).to.equal(true, 'View links expected to be visible, but were not found afterwards');
+                        } else {
+                          tasks.register(task);
+                          wait(keySpaceId, key);
+                          expect(getKey(keySpaceId, `${key}_status`)).to.equal(false, `${name} could create the view with insufficient rights`);
+                          expect(rootTestView(testViewName)).to.equal(false, `${name} was able to create a view with insufficent rights`);
+                        }
+                      } else {
+                        try {
+                          tasks.register(task);
+                          wait(keySpaceId, key);
+                        } catch (e) {
+                          checkError(e);
+                          return;
+                        } finally {
+                          expect(rootTestView(testViewName)).to.equal(false, `${name} was able to create a view with insufficent rights`);
+                        }
+                        expect(false).to.equal(true, `${name} managed to register a task with insufficient rights`);
+                      }
+                    });
 
-              var itName = 'view with links to multiple collections with RO access level to one of them';
-              !(colLevel['rw'].has(name) || colLevel['none'].has(name)) ? it.skip(itName) :
-              it(itName, () => {
-                rootDropView(testViewName);
-                rootDropCollection(testColName);
-                rootDropCollection(testColNameAnother);
 
-                rootCreateCollection(testColName);
-                rootCreateCollection(testColNameAnother);
-                rootGrantCollection(testColNameAnother, name, "ro");
+                    let itName = 'view with links to multiple collections with RO access level to one of them';
+                    !(colLevel['rw'].has(name) || colLevel['none'].has(name)) ? it.skip(itName) :
+                      it(itName, () => {
+                        rootDropView(testViewName);
+                        rootDropCollection(testColName);
+                        rootDropCollection(testColNameAnother);
 
-                expect(rootTestView(testViewName)).to.equal(false, 'Precondition failed, the view still exists');
-                expect(rootTestCollection(testColName)).to.equal(true, 'Precondition failed, the collection still not exists');
-                expect(rootTestCollection(testColNameAnother)).to.equal(true, 'Precondition failed, the collection still not exists');
+                        rootCreateCollection(testColName);
+                        rootCreateCollection(testColNameAnother);
+                        rootGrantCollection(testColNameAnother, name, "ro");
 
-                setKey(keySpaceId, name);
-                const taskId = 'task_create_view_with_links_to_existing_collections_with_RO_access_level_to_one_of_them_' + name;
-                const task = {
-                  id: taskId,
-                  name: taskId,
-                  command: `(function (params) {
+                        expect(rootTestView(testViewName)).to.equal(false, 'Precondition failed, the view still exists');
+                        expect(rootTestCollection(testColName)).to.equal(true, 'Precondition failed, the collection still not exists');
+                        expect(rootTestCollection(testColNameAnother)).to.equal(true, 'Precondition failed, the collection still not exists');
+
+                        setKey(keySpaceId, key);
+                        const taskId = 'task_create_view_with_links_to_existing_collections_with_RO_access_level_to_one_of_them_' + key;
+                        const task = {
+                          id: taskId,
+                          name: taskId,
+                          command: `(function (params) {
                     try {
                       const db = require('@arangodb').db;
                       var view = db._createView('${testViewName}', '${testViewType}', { links: { 
                         '${testColName}': { includeAllFields: true }, '${testColNameAnother}': { includeAllFields: true } 
                         }
                       });
-                      global.KEY_SET('${keySpaceId}', '${name}_status', true);
+                      global.KEY_SET('${keySpaceId}', '${key}_status', true);
                     } catch (e) {
-                      global.KEY_SET('${keySpaceId}', '${name}_status', false);
+                      global.KEY_SET('${keySpaceId}', '${key}_status', false);
                     } finally {
-                      global.KEY_SET('${keySpaceId}', '${name}', true);
+                      global.KEY_SET('${keySpaceId}', '${key}', true);
                     }
                   })(params);`
-                };
+                        };
 
-                if (dbLevel['rw'].has(name)) {
-                  if (colLevel['rw'].has(name)) {
-                    tasks.register(task);
-                    wait(keySpaceId, name);
-                    expect(getKey(keySpaceId, `${name}_status`)).to.equal(true, `${name} could not create the view with sufficient rights`);
-                    expect(rootTestView(testViewName)).to.equal(true, 'View creation reported success, but view was not found afterwards');
-                    expect(rootTestViewHasLinks(testViewName, [`${testColName}`, `${testColNameAnother}`])).to.equal(true, 'View links expected to be visible, but were not found afterwards');
-                  } else {
-                    tasks.register(task);
-                    wait(keySpaceId, name);
-                    expect(getKey(keySpaceId, `${name}_status`)).to.equal(false, `${name} could create the view with insufficient rights`);
-                    expect(rootTestView(testViewName)).to.equal(false, `${name} was able to create a view with insufficent rights`);
-                  }
-                } else {
-                  try {
-                    tasks.register(task);
-                    wait(keySpaceId, name);
-                  } catch (e) {
-                    checkError(e);
-                    return;
-                  } finally {
-                    expect(rootTestView(testViewName)).to.equal(false, `${name} was able to create a view with insufficent rights`);
-                  }
-                  expect(false).to.equal(true, `${name} managed to register a task with insufficient rights`);
-                }
-              });
+                        if (dbLevel['rw'].has(name)) {
+                          if (colLevel['rw'].has(name)) {
+                            tasks.register(task);
+                            wait(keySpaceId, key);
+                            expect(getKey(keySpaceId, `${key}_status`)).to.equal(true, `${name} could not create the view with sufficient rights`);
+                            expect(rootTestView(testViewName)).to.equal(true, 'View creation reported success, but view was not found afterwards');
+                            expect(rootTestViewHasLinks(testViewName, [`${testColName}`, `${testColNameAnother}`])).to.equal(true, 'View links expected to be visible, but were not found afterwards');
+                          } else {
+                            tasks.register(task);
+                            wait(keySpaceId, key);
+                            expect(getKey(keySpaceId, `${key}_status`)).to.equal(false, `${name} could create the view with insufficient rights`);
+                            expect(rootTestView(testViewName)).to.equal(false, `${name} was able to create a view with insufficent rights`);
+                          }
+                        } else {
+                          try {
+                            tasks.register(task);
+                            wait(keySpaceId, key);
+                          } catch (e) {
+                            checkError(e);
+                            return;
+                          } finally {
+                            expect(rootTestView(testViewName)).to.equal(false, `${name} was able to create a view with insufficent rights`);
+                          }
+                          expect(false).to.equal(true, `${name} managed to register a task with insufficient rights`);
+                        }
+                      });
 
-              var itName = 'view with links to multiple collections with NONE access level to one of them';
-              !(colLevel['rw'].has(name) || colLevel['ro'].has(name)) ? it.skip(itName) :
-              it(itName, () => {
-                rootDropView(testViewName);
-                rootDropCollection(testColName);
-                rootDropCollection(testColNameAnother);
+                    itName = 'view with links to multiple collections with NONE access level to one of them';
+                    !(colLevel['rw'].has(name) || colLevel['ro'].has(name)) ? it.skip(itName) :
+                      it(itName, () => {
+                        rootDropView(testViewName);
+                        rootDropCollection(testColName);
+                        rootDropCollection(testColNameAnother);
 
-                rootCreateCollection(testColName);
-                rootCreateCollection(testColNameAnother);
-                rootGrantCollection(testColNameAnother, name, "none");
-                
-                expect(rootTestView(testViewName)).to.equal(false, 'Precondition failed, the view still exists');
-                expect(rootTestCollection(testColName)).to.equal(true, 'Precondition failed, the collection still not exists');
-                expect(rootTestCollection(testColNameAnother)).to.equal(true, 'Precondition failed, the collection still not exists');
+                        rootCreateCollection(testColName);
+                        rootCreateCollection(testColNameAnother);
+                        rootGrantCollection(testColNameAnother, name, "none");
 
-                setKey(keySpaceId, name);
-                const taskId = 'task_create_view_with_links_to_existing_collections_with_NONE_access_level_to_one_of_them_' + name;
-                const task = {
-                  id: taskId,
-                  name: taskId,
-                  command: `(function (params) {
+                        expect(rootTestView(testViewName)).to.equal(false, 'Precondition failed, the view still exists');
+                        expect(rootTestCollection(testColName)).to.equal(true, 'Precondition failed, the collection still not exists');
+                        expect(rootTestCollection(testColNameAnother)).to.equal(true, 'Precondition failed, the collection still not exists');
+
+                        setKey(keySpaceId, key);
+                        const taskId = 'task_create_view_with_links_to_existing_collections_with_NONE_access_level_to_one_of_them_' + key;
+                        const task = {
+                          id: taskId,
+                          name: taskId,
+                          command: `(function (params) {
                     try {
                       const db = require('@arangodb').db;
                       var view = db._createView('${testViewName}', '${testViewType}', { links: { 
                         '${testColName}': { includeAllFields: true }, '${testColNameAnother}': { includeAllFields: true } 
                         }
                       });
-                      global.KEY_SET('${keySpaceId}', '${name}_status', true);
+                      global.KEY_SET('${keySpaceId}', '${key}_status', true);
                     } catch (e) {
-                      global.KEY_SET('${keySpaceId}', '${name}_status', false);
+                      global.KEY_SET('${keySpaceId}', '${key}_status', false);
                     } finally {
-                      global.KEY_SET('${keySpaceId}', '${name}', true);
+                      global.KEY_SET('${keySpaceId}', '${key}', true);
                     }
                   })(params);`
-                };
+                        };
 
-                if (dbLevel['rw'].has(name)) {
-                  tasks.register(task);
-                  wait(keySpaceId, name);
-                  expect(getKey(keySpaceId, `${name}_status`)).to.equal(false, `${name} could create the view with insufficient rights`);
-                  expect(rootTestView(testViewName)).to.equal(false, `${name} was able to create a view with insufficent rights`);
-                } else {
-                  try {
-                    tasks.register(task);
-                    wait(keySpaceId, name);
-                  } catch (e) {
-                    checkError(e);
-                    return;
-                  } finally {
-                    expect(rootTestView(testViewName)).to.equal(false, `${name} was able to create a view with insufficent rights`);
+                        if (dbLevel['rw'].has(name)) {
+                          tasks.register(task);
+                          wait(keySpaceId, key);
+                          expect(getKey(keySpaceId, `${key}_status`)).to.equal(false, `${name} could create the view with insufficient rights`);
+                          expect(rootTestView(testViewName)).to.equal(false, `${name} was able to create a view with insufficent rights`);
+                        } else {
+                          try {
+                            tasks.register(task);
+                            wait(keySpaceId, key);
+                          } catch (e) {
+                            checkError(e);
+                            return;
+                          } finally {
+                            expect(rootTestView(testViewName)).to.equal(false, `${name} was able to create a view with insufficent rights`);
+                          }
+                          expect(false).to.equal(true, `${name} managed to register a task with insufficient rights`);
+                        }
+                      });
+
                   }
-                  expect(false).to.equal(true, `${name} managed to register a task with insufficient rights`);
-                }
+
+                });
               });
-              */
             });
-          });
-        });
-      }
+          }
+        }
+      }); 
     }
   });
 });

--- a/tests/js/client/authentication/user-access-right-task-drop-view-arangosearch-spec.js
+++ b/tests/js/client/authentication/user-access-right-task-drop-view-arangosearch-spec.js
@@ -42,9 +42,9 @@ const namePrefix = helper.namePrefix;
 const dbName = helper.dbName;
 const rightLevels = helper.rightLevels;
 const testViewName = `${namePrefix}ViewNew`;
-const testViewType = "arangosearch";
 const testCol1Name = `${namePrefix}Col1New`;
 const testCol2Name = `${namePrefix}Col2New`;
+const indexName = `${namePrefix}Inverted`;
 const keySpaceId = 'task_drop_view_keyspace';
 
 const userSet = helper.userSet;
@@ -61,7 +61,9 @@ for (let l of rightLevels) {
 
 const wait = (keySpaceId, key) => {
   for (let i = 0; i < 200; i++) {
-    if (getKey(keySpaceId, key)) break;
+    if (getKey(keySpaceId, key)) {
+      break;
+    }
     require('internal').wait(0.1);
   }
 };
@@ -99,11 +101,7 @@ helper.switchUser('root', '_system');
 helper.removeAllUsers();
 helper.generateAllUsers();
 
-function hasIResearch (db) {
-  return !(db._views() === 0); // arangosearch views are not supported
-}
-
-!hasIResearch(db) ? describe.skip : describe('User Rights Management', () => {
+describe('User Rights Management', () => {
   it('should check if all users are created', () => {
     helper.switchUser('root', '_system');
     expect(userSet.size).to.be.greaterThan(0); 
@@ -115,316 +113,327 @@ function hasIResearch (db) {
 
   it('should test rights for', () => {
     expect(userSet.size).to.be.greaterThan(0);
-    for (let name of userSet) {
-      let canUse = false;
-      try {
-        helper.switchUser(name, dbName);
-        canUse = true;
-      } catch (e) {
-        canUse = false;
-      }
-
-      if (canUse) {
-        describe(`user ${name}`, () => {
-          before(() => {
+    for (let testViewType of ["arangosearch", "search-alias"]) {
+      describe(`view type ${testViewType}`, () => {
+        for (let name of userSet) {
+          let canUse = false;
+          try {
             helper.switchUser(name, dbName);
-            expect(createKeySpace(keySpaceId)).to.equal(true, 'keySpace creation failed!');
-          });
+            canUse = true;
+          } catch (e) {
+            canUse = false;
+          }
 
-          after(() => {
-            dropKeySpace(keySpaceId);
-          });
-
-          describe('administrate on db level', () => {
-            const rootTestCollection = (colName, switchBack = true) => {
-              helper.switchUser('root', dbName);
-              let col = db._collection(colName);
-              if (switchBack) {
-                  helper.switchUser(name, dbName);
-              }
-              return col !== null;
-            };
-
-            const rootCreateCollection = (colName) => {
-              if (!rootTestCollection(colName, false)) {
-                db._create(colName);
-                if (colLevel['none'].has(name)) {
-                  if (helper.isLdapEnabledExternal()) {
-                    users.grantCollection(':role:' + name, dbName, colName, 'none');
-                  } else {
-                    users.grantCollection(name, dbName, colName, 'none');
-                  }
-                } else if (colLevel['ro'].has(name)) {
-                  if (helper.isLdapEnabledExternal()) {
-                    users.grantCollection(':role:' + name, dbName, colName, 'ro');
-                  } else {
-                    users.grantCollection(name, dbName, colName, 'ro');
-                  }
-                } else if (colLevel['rw'].has(name)) {
-                  if (helper.isLdapEnabledExternal()) {
-                    users.grantCollection(':role:' + name, dbName, colName, 'rw');
-                  } else {
-                    users.grantCollection(name, dbName, colName, 'rw');
-                  }
-                }
-              }
-              helper.switchUser(name, dbName);
-            };
-
-            const rootDropCollection = (colName) => {
-              helper.switchUser('root', dbName);
-              try {
-                db._collection(colName).drop();
-              } catch (ignored) { }
-              helper.switchUser(name, dbName);
-            };
-
-            const rootGrantCollection = (colName, user, explicitRight = '') => {
-              if (rootTestCollection(colName, false)) {
-                if (explicitRight !== '' && rightLevels.includes(explicitRight))
-                {
-                  if (helper.isLdapEnabledExternal()) {
-                    users.grantCollection(':role:' + user, dbName, colName, explicitRight);
-                  } else {
-                    users.grantCollection(user, dbName, colName, explicitRight);
-                  }
-                }
-              }
-              helper.switchUser(user, dbName);
-            };
-
-            const rootTestView = (viewName = testViewName, switchBack = true) => {
-              helper.switchUser('root', dbName);
-              delete db[viewName];
-              let view = db._view(viewName);
-              if (switchBack) {
-                  helper.switchUser(name, dbName);
-              }
-              return view !== null;
-            };
-
-            const rootCreateView = (viewName = testViewName, properties = null) => {
-              if (rootTestView(viewName, false)) {
-                db._dropView(viewName);
-              }
-              let view =  db._createView(viewName, testViewType, {});
-              if (properties != null) {
-                view.properties(properties, false);
-              }
-              helper.switchUser(name, dbName);
-            };
-
-            const rootDropView = (viewName = testViewName) => {
-              helper.switchUser('root', dbName);
-              try {
-                db._dropView(viewName);
-              } catch (ignored) { }
-              helper.switchUser(name, dbName);
-            };
-
-          const checkError = (e) => {
-            expect(e.code).to.equal(403, "Expected to get forbidden REST error code, but got another one");
-            expect(e.errorNum).to.equal(errors.ERROR_FORBIDDEN.code, "Expected to get forbidden error number, but got another one");
-          };
-
-            describe('drop a', () => {
+          if (canUse) {
+            describe(`user ${name}`, () => {
               before(() => {
-                db._useDatabase(dbName);
+                helper.switchUser(name, dbName);
+                expect(createKeySpace(keySpaceId)).to.equal(true, 'keySpace creation failed!');
               });
 
               after(() => {
-                rootDropView(testViewName);
-                rootDropCollection(testCol1Name);
-                rootDropCollection(testCol2Name);
+                dropKeySpace(keySpaceId);
               });
 
-              it('view without links', () => {
-                rootCreateView(testViewName);
-                expect(rootTestView(testViewName)).to.equal(true, 'Precondition failed, the view doesn not exist');
-                setKey(keySpaceId, name);
-                const taskId = 'task_drop_view_without_links_' + name;
-                const task = {
-                  id: taskId,
-                  name: taskId,
-                  command: `(function (params) {
+              describe('administrate on db level', () => {
+                const rootTestCollection = (colName, switchBack = true) => {
+                  helper.switchUser('root', dbName);
+                  let col = db._collection(colName);
+                  if (switchBack) {
+                    helper.switchUser(name, dbName);
+                  }
+                  return col !== null;
+                };
+
+                const rootCreateCollection = (colName) => {
+                  if (!rootTestCollection(colName, false)) {
+                    let c = db._create(colName);
+                    if (colName === testCol1Name) {
+                      c.ensureIndex({ type: "inverted", name: indexName, fields: [ { name: "value" } ] });
+                    }
+                    if (colLevel['none'].has(name)) {
+                      if (helper.isLdapEnabledExternal()) {
+                        users.grantCollection(':role:' + name, dbName, colName, 'none');
+                      } else {
+                        users.grantCollection(name, dbName, colName, 'none');
+                      }
+                    } else if (colLevel['ro'].has(name)) {
+                      if (helper.isLdapEnabledExternal()) {
+                        users.grantCollection(':role:' + name, dbName, colName, 'ro');
+                      } else {
+                        users.grantCollection(name, dbName, colName, 'ro');
+                      }
+                    } else if (colLevel['rw'].has(name)) {
+                      if (helper.isLdapEnabledExternal()) {
+                        users.grantCollection(':role:' + name, dbName, colName, 'rw');
+                      } else {
+                        users.grantCollection(name, dbName, colName, 'rw');
+                      }
+                    }
+                  }
+                  helper.switchUser(name, dbName);
+                };
+
+                const rootDropCollection = (colName) => {
+                  helper.switchUser('root', dbName);
+                  try {
+                    db._collection(colName).drop();
+                  } catch (ignored) { }
+                  helper.switchUser(name, dbName);
+                };
+
+                const rootGrantCollection = (colName, user, explicitRight = '') => {
+                  if (rootTestCollection(colName, false)) {
+                    if (explicitRight !== '' && rightLevels.includes(explicitRight)) {
+                      if (helper.isLdapEnabledExternal()) {
+                        users.grantCollection(':role:' + user, dbName, colName, explicitRight);
+                      } else {
+                        users.grantCollection(user, dbName, colName, explicitRight);
+                      }
+                    }
+                  }
+                  helper.switchUser(user, dbName);
+                };
+
+                const rootTestView = (viewName = testViewName, switchBack = true) => {
+                  helper.switchUser('root', dbName);
+                  delete db[viewName];
+                  let view = db._view(viewName);
+                  if (switchBack) {
+                    helper.switchUser(name, dbName);
+                  }
+                  return view !== null;
+                };
+
+                const rootCreateView = (viewName, viewType, properties = null) => {
+                  if (rootTestView(viewName, false)) {
+                    db._dropView(viewName);
+                  }
+                  let view =  db._createView(viewName, viewType, {});
+                  if (properties !== null) {
+                    view.properties(properties, false);
+                  }
+                  helper.switchUser(name, dbName);
+                };
+
+                const rootDropView = (viewName = testViewName) => {
+                  helper.switchUser('root', dbName);
+                  try {
+                    db._dropView(viewName);
+                  } catch (ignored) { }
+                  helper.switchUser(name, dbName);
+                };
+
+                const checkError = (e) => {
+                  expect(e.code).to.equal(403, "Expected to get forbidden REST error code, but got another one");
+                  expect(e.errorNum).to.equal(errors.ERROR_FORBIDDEN.code, "Expected to get forbidden error number, but got another one");
+                };
+
+                describe('drop a', () => {
+                  before(() => {
+                    db._useDatabase(dbName);
+                  });
+
+                  after(() => {
+                    rootDropView(testViewName);
+                    rootDropCollection(testCol1Name);
+                    rootDropCollection(testCol2Name);
+                  });
+
+                  const key = `${testViewType}_${name}`;
+
+                  it('view without links', () => {
+                    rootCreateView(testViewName, testViewType);
+                    expect(rootTestView(testViewName)).to.equal(true, 'Precondition failed, the view doesn not exist');
+                    setKey(keySpaceId, key);
+                    const taskId = 'task_drop_view_without_links_' + key;
+                    const task = {
+                      id: taskId,
+                      name: taskId,
+                      command: `(function (params) {
                     try {
                       const db = require('@arangodb').db;
                       db._dropView('${testViewName}');
-                      global.KEY_SET('${keySpaceId}', '${name}_status', true);
+                      global.KEY_SET('${keySpaceId}', '${key}_status', true);
                     } catch (e) {
-                      global.KEY_SET('${keySpaceId}', '${name}_status', false);
+                      global.KEY_SET('${keySpaceId}', '${key}_status', false);
                     } finally {
-                      global.KEY_SET('${keySpaceId}', '${name}', true);
+                      global.KEY_SET('${keySpaceId}', '${key}', true);
                     }
                   })(params);`
-                };
-                if (dbLevel['rw'].has(name)) {
-                  tasks.register(task);
-                  wait(keySpaceId, name);
-                  expect(getKey(keySpaceId, `${name}_status`)).to.equal(true, `${name} could not drop the view with sufficient rights`);
-                  expect(rootTestView(testViewName)).to.equal(false, 'View deletion reported success, but view was found afterwards');
-                } else {
-                  try {
-                    tasks.register(task);
-                    wait(keySpaceId, name);
-                  } catch (e) {
-                    checkError(e);
-                    return;
-                  } finally {
-                    expect(rootTestView(testViewName)).to.equal(true, `${name} was able to drop a view with insufficent rights`);
-                  }
-                  expect(false).to.equal(true, `${name} managed to register a task with insufficient rights`);
-                }
-              });
+                    };
+                    if (dbLevel['rw'].has(name)) {
+                      tasks.register(task);
+                      wait(keySpaceId, key);
+                      expect(getKey(keySpaceId, `${key}_status`)).to.equal(true, `${name} could not drop the view with sufficient rights`);
+                      expect(rootTestView(testViewName)).to.equal(false, 'View deletion reported success, but view was found afterwards');
+                    } else {
+                      try {
+                        tasks.register(task);
+                        wait(keySpaceId, key);
+                      } catch (e) {
+                        checkError(e);
+                        return;
+                      } finally {
+                        expect(rootTestView(testViewName)).to.equal(true, `${name} was able to drop a view with insufficent rights`);
+                      }
+                      expect(false).to.equal(true, `${name} managed to register a task with insufficient rights`);
+                    }
+                  });
 
-              it('view with link to non-existing collection', () => {
-                rootDropView(testViewName);
-                rootCreateCollection("NonExistentCol");
-                rootCreateView(testViewName, { links: { "NonExistentCol" : { includeAllFields: true } } });
-                rootDropCollection("NonExistentCol");
-                expect(rootTestView(testViewName)).to.equal(true, 'Precondition failed, the view doesn not exist');
-                setKey(keySpaceId, name);
-                const taskId = 'task_drop_view_with_link_to_nonexist_col' + name;
-                const task = {
-                  id: taskId,
-                  name: taskId,
-                  command: `(function (params) {
+                  if (testViewType === 'arangosearch') {
+                    it('view with link to non-existing collection', () => {
+                      rootDropView(testViewName);
+                      rootCreateCollection("NonExistentCol");
+                      rootCreateView(testViewName, testViewType, { links: { "NonExistentCol" : { includeAllFields: true } } });
+                      rootDropCollection("NonExistentCol");
+                      expect(rootTestView(testViewName)).to.equal(true, 'Precondition failed, the view doesn not exist');
+                      setKey(keySpaceId, key);
+                      const taskId = 'task_drop_view_with_link_to_nonexist_col' + key;
+                      const task = {
+                        id: taskId,
+                        name: taskId,
+                        command: `(function (params) {
                     try {
                       const db = require('@arangodb').db;
                       db._dropView('${testViewName}');
-                      global.KEY_SET('${keySpaceId}', '${name}_status', true);
+                      global.KEY_SET('${keySpaceId}', '${key}_status', true);
                     } catch (e) {
-                      global.KEY_SET('${keySpaceId}', '${name}_status', false);
+                      global.KEY_SET('${keySpaceId}', '${key}_status', false);
                     } finally {
-                      global.KEY_SET('${keySpaceId}', '${name}', true);
+                      global.KEY_SET('${keySpaceId}', '${key}', true);
                     }
                   })(params);`
-                };
-                if (dbLevel['rw'].has(name)) {
-                  tasks.register(task);
-                  wait(keySpaceId, name);
-                  expect(rootTestView(testViewName)).to.equal(false, 'View deletion reported success, but view was found afterwards');
-                } else {
-                  try {
-                    tasks.register(task);
-                    wait(keySpaceId, name);
-                  } catch (e) {
-                    checkError(e);
-                    return;
-                  } finally {
-                    expect(rootTestView(testViewName)).to.equal(true, `${name} was able to drop a view with insufficent rights`);
-                  }
-                  expect(false).to.equal(true, `${name} managed to register a task with insufficient rights`);
-                }
-              });
+                      };
+                      if (dbLevel['rw'].has(name)) {
+                        tasks.register(task);
+                        wait(keySpaceId, key);
+                        expect(rootTestView(testViewName)).to.equal(false, 'View deletion reported success, but view was found afterwards');
+                      } else {
+                        try {
+                          tasks.register(task);
+                          wait(keySpaceId, key);
+                        } catch (e) {
+                          checkError(e);
+                          return;
+                        } finally {
+                          expect(rootTestView(testViewName)).to.equal(true, `${name} was able to drop a view with insufficent rights`);
+                        }
+                        expect(false).to.equal(true, `${name} managed to register a task with insufficient rights`);
+                      }
+                    });
 
-              it('view with link to existing collection', () => {
-                rootDropView(testViewName);
-                rootDropCollection(testCol1Name);
+                    it('view with link to existing collection', () => {
+                      rootDropView(testViewName);
+                      rootDropCollection(testCol1Name);
 
-                rootCreateCollection(testCol1Name);
-                rootCreateView(testViewName, { links: { [testCol1Name]: { includeAllFields: true } } });
-                expect(rootTestView(testViewName)).to.equal(true, 'Precondition failed, the view doesn not exist');
-                setKey(keySpaceId, name);
-                const taskId = 'task_drop_view_with_link_to_existing_col' + name;
-                const task = {
-                  id: taskId,
-                  name: taskId,
-                  command: `(function (params) {
+                      rootCreateCollection(testCol1Name);
+                      rootCreateView(testViewName, testViewType, { links: { [testCol1Name]: { includeAllFields: true } } });
+                      expect(rootTestView(testViewName)).to.equal(true, 'Precondition failed, the view doesn not exist');
+                      setKey(keySpaceId, key);
+                      const taskId = 'task_drop_view_with_link_to_existing_col' + key;
+                      const task = {
+                        id: taskId,
+                        name: taskId,
+                        command: `(function (params) {
                     try {
                       const db = require('@arangodb').db;
                       db._dropView('${testViewName}');
-                      global.KEY_SET('${keySpaceId}', '${name}_status', true);
+                      global.KEY_SET('${keySpaceId}', '${key}_status', true);
                     } catch (e) {
-                      global.KEY_SET('${keySpaceId}', '${name}_status', false);
+                      global.KEY_SET('${keySpaceId}', '${key}_status', false);
                     } finally {
-                      global.KEY_SET('${keySpaceId}', '${name}', true);
+                      global.KEY_SET('${keySpaceId}', '${key}', true);
                     }
                   })(params);`
-                };
-                if (dbLevel['rw'].has(name)) {
-                  if(colLevel['rw'].has(name) || colLevel['ro'].has(name)){
-                    tasks.register(task);
-                    wait(keySpaceId, name);
-                    expect(rootTestView(testViewName)).to.equal(false, 'View deletion reported success, but view was found afterwards');
-                  } else {
-                    tasks.register(task);
-                    wait(keySpaceId, name);
-                    expect(getKey(keySpaceId, `${name}_status`)).to.equal(false, `${name} managed to drop the view with insufficient rights`);
-                    expect(rootTestView(testViewName)).to.equal(true, 'View deletion reported success, but view was found afterwards');
-                  }
-                } else {
-                  try {
-                    tasks.register(task);
-                    wait(keySpaceId, name);
-                  } catch (e) {
-                    checkError(e);
-                    return;
-                  } finally {
-                    expect(rootTestView(testViewName)).to.equal(true, `${name} was able to drop a view with insufficent rights`);
-                  }
-                  expect(false).to.equal(true, `${name} managed to register a task with insufficient rights`);
-                }
-              });
+                      };
+                      if (dbLevel['rw'].has(name)) {
+                        if(colLevel['rw'].has(name) || colLevel['ro'].has(name)){
+                          tasks.register(task);
+                          wait(keySpaceId, key);
+                          expect(rootTestView(testViewName)).to.equal(false, 'View deletion reported success, but view was found afterwards');
+                        } else {
+                          tasks.register(task);
+                          wait(keySpaceId, key);
+                          expect(getKey(keySpaceId, `${key}_status`)).to.equal(false, `${name} managed to drop the view with insufficient rights`);
+                          expect(rootTestView(testViewName)).to.equal(true, 'View deletion reported success, but view was found afterwards');
+                        }
+                      } else {
+                        try {
+                          tasks.register(task);
+                          wait(keySpaceId, key);
+                        } catch (e) {
+                          checkError(e);
+                          return;
+                        } finally {
+                          expect(rootTestView(testViewName)).to.equal(true, `${name} was able to drop a view with insufficent rights`);
+                        }
+                        expect(false).to.equal(true, `${name} managed to register a task with insufficient rights`);
+                      }
+                    });
 
-              var itName = 'view with links to multiple collections (switching 1 of them as RW during RO/NONE of a user collection level)';
-              !(colLevel['ro'].has(name) || colLevel['none'].has(name)) ? it.skip(itName) :
-              it(itName, () => {
-                rootDropView(testViewName);
-                rootDropCollection(testCol1Name);
+                    let itName = 'view with links to multiple collections (switching 1 of them as RW during RO/NONE of a user collection level)';
+                    !(colLevel['ro'].has(name) || colLevel['none'].has(name)) ? it.skip(itName) :
+                      it(itName, () => {
+                        rootDropView(testViewName);
+                        rootDropCollection(testCol1Name);
 
-                rootCreateCollection(testCol1Name);
-                rootCreateCollection(testCol2Name);
-                rootCreateView(testViewName, { links: { [testCol1Name]: { includeAllFields: true }, [testCol2Name]: { includeAllFields: true } } });
-                expect(rootTestView(testViewName)).to.equal(true, 'Precondition failed, the view doesn not exist');
-                rootGrantCollection(testCol2Name, name, 'rw');
+                        rootCreateCollection(testCol1Name);
+                        rootCreateCollection(testCol2Name);
+                        rootCreateView(testViewName, testViewType, { links: { [testCol1Name]: { includeAllFields: true }, [testCol2Name]: { includeAllFields: true } } });
+                        expect(rootTestView(testViewName)).to.equal(true, 'Precondition failed, the view doesn not exist');
+                        rootGrantCollection(testCol2Name, name, 'rw');
 
-                setKey(keySpaceId, name);
-                const taskId = 'task_drop_view_with_link_to_existing_diff_col' + name;
-                const task = {
-                  id: taskId,
-                  name: taskId,
-                  command: `(function (params) {
+                        setKey(keySpaceId, key);
+                        const taskId = 'task_drop_view_with_link_to_existing_diff_col' + key;
+                        const task = {
+                          id: taskId,
+                          name: taskId,
+                          command: `(function (params) {
                     try {
                       const db = require('@arangodb').db;
                       db._dropView('${testViewName}');
-                      global.KEY_SET('${keySpaceId}', '${name}_status', true);
+                      global.KEY_SET('${keySpaceId}', '${key}_status', true);
                     } catch (e) {
-                      global.KEY_SET('${keySpaceId}', '${name}_status', false);
+                      global.KEY_SET('${keySpaceId}', '${key}_status', false);
                     } finally {
-                      global.KEY_SET('${keySpaceId}', '${name}', true);
+                      global.KEY_SET('${keySpaceId}', '${key}', true);
                     }
                   })(params);`
-                };
-                if (dbLevel['rw'].has(name)) {
-                  if(colLevel['ro'].has(name))
-                  {
-                    tasks.register(task);
-                    wait(keySpaceId, name);
-                    expect(rootTestView(testViewName)).to.equal(false, 'View deletion reported success, but view was found afterwards');
-                  } else {
-                    tasks.register(task);
-                    wait(keySpaceId, name);
-                    expect(getKey(keySpaceId, `${name}_status`)).to.equal(false, `${name} could drop the view with insufficient rights`);
-                    expect(rootTestView(testViewName)).to.equal(true, `${name} was able to drop a view with insufficent rights`);
+                        };
+                        if (dbLevel['rw'].has(name)) {
+                          if (colLevel['ro'].has(name)) {
+                            tasks.register(task);
+                            wait(keySpaceId, key);
+                            expect(rootTestView(testViewName)).to.equal(false, 'View deletion reported success, but view was found afterwards');
+                          } else {
+                            tasks.register(task);
+                            wait(keySpaceId, key);
+                            expect(getKey(keySpaceId, `${key}_status`)).to.equal(false, `${name} could drop the view with insufficient rights`);
+                            expect(rootTestView(testViewName)).to.equal(true, `${name} was able to drop a view with insufficent rights`);
+                          }
+                        } else {
+                          try {
+                            tasks.register(task);
+                            wait(keySpaceId, key);
+                          } catch (e) {
+                            checkError(e);
+                            return;
+                          } finally {
+                            expect(getKey(keySpaceId, `${key}_status`)).to.equal(false, `${name} could drop the view with insufficient rights`);
+                          }
+                          expect(false).to.equal(true, `${name} managed to register a task with insufficient rights`);
+                        }
+                      });
+
                   }
-                } else {
-                  try {
-                    tasks.register(task);
-                    wait(keySpaceId, name);
-                  } catch (e) {
-                    checkError(e);
-                    return;
-                  } finally {
-                    expect(getKey(keySpaceId, `${name}_status`)).to.equal(false, `${name} could drop the view with insufficient rights`);
-                  }
-                  expect(false).to.equal(true, `${name} managed to register a task with insufficient rights`);
-                }
+                });
               });
             });
-          });
-        });
-      }
+          }
+        }
+
+      });
     }
   });
 });

--- a/tests/js/client/authentication/user-access-right-task-read-view-arangosearch-spec.js
+++ b/tests/js/client/authentication/user-access-right-task-read-view-arangosearch-spec.js
@@ -46,6 +46,7 @@ const testView2Name = `${namePrefix}View2New`;
 const testViewType = "arangosearch";
 const testCol1Name = `${namePrefix}Col1New`;
 const testCol2Name = `${namePrefix}Col2New`;
+const indexName = `${namePrefix}Inverted`;
 const testNumDocs = 3;
 const keySpaceId = 'task_read_view_keyspace';
 
@@ -64,7 +65,9 @@ for (let l of rightLevels) {
 
 const wait = (keySpaceId, key) => {
   for (let i = 0; i < 200; i++) {
-    if (getKey(keySpaceId, key)) break;
+    if (getKey(keySpaceId, key)) { 
+      break;
+    }
     require('internal').wait(0.1);
   }
 };
@@ -110,16 +113,9 @@ helper.switchUser('root', '_system');
 helper.removeAllUsers();
 helper.generateAllUsers();
 
-function hasIResearch (db) {
-  return !(db._views() === 0); // arangosearch views are not supported
-}
-
-!hasIResearch(db) ? describe.skip : describe('User Rights Management', () => {
+describe('User Rights Management', () => {
   it('should check if all users are created', () => {
     helper.switchUser('root', '_system');
-    if (db._views() === 0) {
-      return; // arangosearch views are not supported
-    }
     expect(userSet.size).to.be.greaterThan(0); 
     expect(userSet.size).to.equal(helper.userCount);
     for (let name of userSet) {
@@ -129,347 +125,358 @@ function hasIResearch (db) {
 
   it('should test rights for', () => {
     expect(userSet.size).to.be.greaterThan(0);
-    for (let name of userSet) {
-      let canUse = false;
-      try {
-        helper.switchUser(name, dbName);
-        canUse = true;
-      } catch (e) {
-        canUse = false;
-      }
+    for (let testViewType of ["arangosearch", "search-alias"]) {
+      describe(`view type ${testViewType}`, () => {
+        for (let name of userSet) {
+          let canUse = false;
+          try {
+            helper.switchUser(name, dbName);
+            canUse = true;
+          } catch (e) {
+            canUse = false;
+          }
 
-        if (canUse) {
-          describe(`user ${name}`, () => {
-            before(() => {
-              helper.switchUser(name, dbName);
-              expect(createKeySpace(keySpaceId)).to.equal(true, 'keySpace creation failed!');
-            });
-
-          after(() => {
-            dropKeySpace(keySpaceId);
-          });
-
-          describe('administrate on db level', () => {
-            before(() => {
-              db._useDatabase(dbName);
-              rootCreateCollection(testCol1Name);
-              rootCreateCollection(testCol2Name);
-              var properties = { properties : {} };
-              properties['links'] = {};
-              properties['links'][testCol1Name] = { includeAllFields: true };
-              rootCreateView(testView1Name, properties);
-              properties['links'][testCol2Name] = { includeAllFields: true };
-              rootCreateView(testView2Name, properties);
-              rootPrepareCollection(testCol1Name, testNumDocs);
-              rootPrepareCollection(testCol2Name, testNumDocs, false);
-            });
-
-            after(() => {
-              rootDropView(testView1Name);
-              rootDropView(testView2Name);
-              rootDropCollection(testCol1Name);
-              rootDropCollection(testCol2Name);
-            });
-
-            const rootTestCollection = (colName, switchBack = true) => {
-              helper.switchUser('root', dbName);
-              let col = db._collection(colName);
-              if (switchBack) {
-                  helper.switchUser(name, dbName);
-              }
-              return col !== null;
-            };
-
-            const rootCreateCollection = (colName, explicitRight = '') => {
-              if (!rootTestCollection(colName, false)) {
-                db._create(colName);
-                if (explicitRight !== '' && rightLevels.has(explicitRight))
-                {
-                  if (helper.isLdapEnabledExternal()) {
-                    users.grantCollection(':role:' + name, dbName, colName, explicitRight);
-                  } else {
-                    users.grantCollection(name, dbName, colName, explicitRight);
-                  }
-                } else {
-                  if (colLevel['none'].has(name)) {
-                    if (helper.isLdapEnabledExternal()) {
-                      users.grantCollection(':role:' + name, dbName, colName, 'none');
-                    } else {
-                      users.grantCollection(name, dbName, colName, 'none');
-                    }
-                  } else if (colLevel['ro'].has(name)) {
-                    if (helper.isLdapEnabledExternal()) {
-                      users.grantCollection(':role:' + name, dbName, colName, 'ro');
-                    } else {
-                      users.grantCollection(name, dbName, colName, 'ro');
-                    }
-                  } else if (colLevel['rw'].has(name)) {
-                    if (helper.isLdapEnabledExternal()) {
-                      users.grantCollection(':role:' + name, dbName, colName, 'rw');
-                    } else {
-                      users.grantCollection(name, dbName, colName, 'rw');
-                    }
-                  }
-                }
-              }
-              helper.switchUser(name, dbName);
-            };
-
-            const rootGrantCollection = (colName, user, explicitRight = '') => {
-              if (rootTestCollection(colName, false)) {
-                if (explicitRight !== '' && rightLevels.includes(explicitRight))
-                {
-                  if (helper.isLdapEnabledExternal()) {
-                    users.grantCollection(':role:' + user, dbName, colName, explicitRight);
-                  } else {
-                    users.grantCollection(user, dbName, colName, explicitRight);
-                  }
-                }
-              }
-              helper.switchUser(user, dbName);
-            };
-
-            const rootPrepareCollection = (colName, numDocs = 1, defKey = true) => {
-                if (rootTestCollection(colName, false)) {
-                  db._collection(colName).truncate({ compact: false });
-                  for(var i = 0; i < numDocs; ++i)
-                  {
-                    var doc = {prop1: colName + "_1", propI: i, plink: "lnk" + i};
-                    if (!defKey) {
-                      doc._key = colName + i;
-                    }
-                    db._collection(colName).save(doc, {waitForSync: true});
-                  }
-                }
-                helper.switchUser(name, dbName);
-            };
-
-            const rootDropCollection = (colName) => {
-              helper.switchUser('root', dbName);
-              try {
-                db._collection(colName).drop();
-              } catch (ignored) { }
-              helper.switchUser(name, dbName);
-            };
-
-            const rootTestView = (viewName, switchBack = true) => {
-              helper.switchUser('root', dbName);
-              let view = db._view(viewName);
-              if (switchBack) {
-                  helper.switchUser(name, dbName);
-              }
-              return view != null;
-            };
-
-            const rootCreateView = (viewName, properties = null) => {
-              if (rootTestView(viewName, false)) {
-                db._dropView(viewName);
-              }
-              let view =  db._createView(viewName, testViewType, {});
-              if (properties != null) {
-                view.properties(properties, false);
-              }
-              helper.switchUser(name, dbName);
-            };
-
-            const rootDropView = (viewName) => {
-              helper.switchUser('root', dbName);
-              try {
-                db._dropView(viewName);
-              } catch (ignored) { }
-              helper.switchUser(name, dbName);
-            };
-
-            const checkError = (e) => {
-              expect(e.code).to.equal(403, "Expected to get forbidden REST error code, but got another one");
-              expect(e.errorNum).to.equal(errors.ERROR_FORBIDDEN.code, "Expected to get forbidden error number, but got another one");
-            };
-
-            describe('read a view', () => {
+          if (canUse) {
+            describe(`user ${name}`, () => {
               before(() => {
-                db._useDatabase(dbName);
+                helper.switchUser(name, dbName);
+                expect(createKeySpace(keySpaceId)).to.equal(true, 'keySpace creation failed!');
               });
 
-              it('by AQL with link to single collection', () => {
-                expect(rootTestView(testView1Name)).to.equal(true, 'Precondition failed, the view doesn\'t exist');
-                setKey(keySpaceId, name);
-                const taskId = 'task_read_view_single_collection_' + name;
-                const task = {
-                  id: taskId,
-                  name: taskId,
-                  command: `(function (params) {
+              after(() => {
+                dropKeySpace(keySpaceId);
+              });
+
+              describe('administrate on db level', () => {
+                before(() => {
+                  db._useDatabase(dbName);
+                  rootCreateCollection(testCol1Name);
+                  rootCreateCollection(testCol2Name);
+                  let properties = { properties : {} };
+                  if (testViewType === "arangosearch") {
+                    properties['links'] = {};
+                    properties['links'][testCol1Name] = { includeAllFields: true };
+                    rootCreateView(testView1Name, testViewType, properties);
+                    properties['links'][testCol2Name] = { includeAllFields: true };
+                    rootCreateView(testView2Name, testViewType, properties);
+                  } else {
+                    properties['indexes'] = [ { collection: testCol1Name, index: indexName } ];
+                    rootCreateView(testView1Name, testViewType, properties);
+                  }
+                  rootPrepareCollection(testCol1Name, testNumDocs);
+                  rootPrepareCollection(testCol2Name, testNumDocs, false);
+                });
+
+                after(() => {
+                  rootDropView(testView1Name);
+                  rootDropView(testView2Name);
+                  rootDropCollection(testCol1Name);
+                  rootDropCollection(testCol2Name);
+                });
+
+                const rootTestCollection = (colName, switchBack = true) => {
+                  helper.switchUser('root', dbName);
+                  let col = db._collection(colName);
+                  if (switchBack) {
+                    helper.switchUser(name, dbName);
+                  }
+                  return col !== null;
+                };
+
+                const rootCreateCollection = (colName, explicitRight = '') => {
+                  if (!rootTestCollection(colName, false)) {
+                    db._create(colName);
+                    if (explicitRight !== '' && rightLevels.has(explicitRight))
+                    {
+                      if (helper.isLdapEnabledExternal()) {
+                        users.grantCollection(':role:' + name, dbName, colName, explicitRight);
+                      } else {
+                        users.grantCollection(name, dbName, colName, explicitRight);
+                      }
+                    } else {
+                      if (colLevel['none'].has(name)) {
+                        if (helper.isLdapEnabledExternal()) {
+                          users.grantCollection(':role:' + name, dbName, colName, 'none');
+                        } else {
+                          users.grantCollection(name, dbName, colName, 'none');
+                        }
+                      } else if (colLevel['ro'].has(name)) {
+                        if (helper.isLdapEnabledExternal()) {
+                          users.grantCollection(':role:' + name, dbName, colName, 'ro');
+                        } else {
+                          users.grantCollection(name, dbName, colName, 'ro');
+                        }
+                      } else if (colLevel['rw'].has(name)) {
+                        if (helper.isLdapEnabledExternal()) {
+                          users.grantCollection(':role:' + name, dbName, colName, 'rw');
+                        } else {
+                          users.grantCollection(name, dbName, colName, 'rw');
+                        }
+                      }
+                    }
+                  }
+                  helper.switchUser(name, dbName);
+                };
+
+                const rootGrantCollection = (colName, user, explicitRight = '') => {
+                  if (rootTestCollection(colName, false)) {
+                    if (explicitRight !== '' && rightLevels.includes(explicitRight))
+                    {
+                      if (helper.isLdapEnabledExternal()) {
+                        users.grantCollection(':role:' + user, dbName, colName, explicitRight);
+                      } else {
+                        users.grantCollection(user, dbName, colName, explicitRight);
+                      }
+                    }
+                  }
+                  helper.switchUser(user, dbName);
+                };
+
+                const rootPrepareCollection = (colName, numDocs = 1, defKey = true) => {
+                  if (rootTestCollection(colName, false)) {
+                    db._collection(colName).truncate({ compact: false });
+                    let docs = [];
+                    for (let i = 0; i < numDocs; ++i) {
+                      let doc = {prop1: colName + "_1", propI: i, plink: "lnk" + i};
+                      if (!defKey) {
+                        doc._key = colName + i;
+                      }
+                      docs.push(doc);
+                    }
+                    db._collection(colName).insert(docs);
+                  }
+                  helper.switchUser(name, dbName);
+                };
+
+                const rootDropCollection = (colName) => {
+                  helper.switchUser('root', dbName);
+                  try {
+                    db._collection(colName).drop();
+                  } catch (ignored) { }
+                  helper.switchUser(name, dbName);
+                };
+
+                const rootTestView = (viewName, switchBack = true) => {
+                  helper.switchUser('root', dbName);
+                  let view = db._view(viewName);
+                  if (switchBack) {
+                    helper.switchUser(name, dbName);
+                  }
+                  return view !== null;
+                };
+
+                const rootCreateView = (viewName, viewType, properties = null) => {
+                  if (rootTestView(viewName, false)) {
+                    db._dropView(viewName);
+                  }
+                  let view =  db._createView(viewName, viewType, {});
+                  if (properties !== null) {
+                    view.properties(properties, false);
+                  }
+                  helper.switchUser(name, dbName);
+                };
+
+                const rootDropView = (viewName) => {
+                  helper.switchUser('root', dbName);
+                  try {
+                    db._dropView(viewName);
+                  } catch (ignored) { }
+                  helper.switchUser(name, dbName);
+                };
+
+                const checkError = (e) => {
+                  expect(e.code).to.equal(403, "Expected to get forbidden REST error code, but got another one");
+                  expect(e.errorNum).to.equal(errors.ERROR_FORBIDDEN.code, "Expected to get forbidden error number, but got another one");
+                };
+
+                describe('read a view', () => {
+                  before(() => {
+                    db._useDatabase(dbName);
+                  });
+                    
+                  const key = `${testViewType}_${name}`;
+
+                  it('by AQL with link to single collection', () => {
+                    expect(rootTestView(testView1Name)).to.equal(true, 'Precondition failed, the view doesn\'t exist');
+                    setKey(keySpaceId, key);
+                    const taskId = 'task_read_view_single_collection_' + key;
+                    const task = {
+                      id: taskId,
+                      name: taskId,
+                      command: `(function (params) {
                     try {
                       const db = require('@arangodb').db;
                       let query = \"FOR d IN  ${testView1Name} RETURN d\";
                       let result = db._query(query);
-                      global.KEY_SET('${keySpaceId}', '${name}_length', result.toArray().length);
-                      global.KEY_SET('${keySpaceId}', '${name}_status', true);
+                      global.KEY_SET('${keySpaceId}', '${key}_length', result.toArray().length);
+                      global.KEY_SET('${keySpaceId}', '${key}_status', true);
                     } catch (e) {
-                      global.KEY_SET('${keySpaceId}', '${name}_status', false);
+                      global.KEY_SET('${keySpaceId}', '${key}_status', false);
                     } finally {
-                      global.KEY_SET('${keySpaceId}', '${name}', true);
+                      global.KEY_SET('${keySpaceId}', '${key}', true);
                     }
                   })(params);`
-                };
-                if (dbLevel['rw'].has(name)) {
-                  if(colLevel['rw'].has(name) || colLevel['ro'].has(name))
-                  {
-                    tasks.register(task);
-                    wait(keySpaceId, name);
-                    expect(getKey(keySpaceId, `${name}_status`)).to.equal(true, `${name} could not read the view with sufficient rights`);
-                    //FIXME: issue #429 (https://github.com/arangodb/backlog/issues/429)
-                    //expect(getNumericKey(keySpaceId, `${name}_length`)).to.equal(testNumDocs, 'View read failed');
-                  } else {
-                    tasks.register(task);
-                    wait(keySpaceId, name);
-                    expect(getKey(keySpaceId, `${name}_status`)).to.not.equal(true, `${name} managed to read the view with insufficient rights`);
-                  }
-                } else {
-                  try {
-                    tasks.register(task);
-                    wait(keySpaceId, name);
-                  } catch (e) {
-                    checkError(e);
-                    return;
-                  } finally {
-                    expect(getKey(keySpaceId, `${name}_status`)).to.equal(false, `${name} could read the view with insufficient rights`);
-                  }
-                  expect(false).to.equal(true, `${name} managed to register a task with insufficient rights`);
-                }
-              });
+                    };
+                    if (dbLevel['rw'].has(name)) {
+                      if (colLevel['rw'].has(name) || colLevel['ro'].has(name)) {
+                        tasks.register(task);
+                        wait(keySpaceId, key);
+                        expect(getKey(keySpaceId, `${key}_status`)).to.equal(true, `${name} could not read the view with sufficient rights`);
+                        //FIXME: issue #429 (https://github.com/arangodb/backlog/issues/429)
+                        //expect(getNumericKey(keySpaceId, `${name}_length`)).to.equal(testNumDocs, 'View read failed');
+                      } else {
+                        tasks.register(task);
+                        wait(keySpaceId, key);
+                        expect(getKey(keySpaceId, `${key}_status`)).to.not.equal(true, `${name} managed to read the view with insufficient rights`);
+                      }
+                    } else {
+                      try {
+                        tasks.register(task);
+                        wait(keySpaceId, key);
+                      } catch (e) {
+                        checkError(e);
+                        return;
+                      } finally {
+                        expect(getKey(keySpaceId, `${key}_status`)).to.equal(false, `${name} could read the view with insufficient rights`);
+                      }
+                      expect(false).to.equal(true, `${key} managed to register a task with insufficient rights`);
+                    }
+                  });
 
-              it('by AQL with links to multiple collections with same access level', () => {
-                expect(rootTestView(testView2Name)).to.equal(true, 'Precondition failed, the view doesn\'t exist');
-                setKey(keySpaceId, name);
-                const taskId = 'task_read_view_multi_collections_same_access_' + name;
-                const task = {
-                  id: taskId,
-                  name: taskId,
-                  command: `(function (params) {
+                  it('by AQL with links to multiple collections with same access level', () => {
+                    expect(rootTestView(testView2Name)).to.equal(true, 'Precondition failed, the view doesn\'t exist');
+                    setKey(keySpaceId, key);
+                    const taskId = 'task_read_view_multi_collections_same_access_' + key;
+                    const task = {
+                      id: taskId,
+                      name: taskId,
+                      command: `(function (params) {
                     try {
                       const db = require('@arangodb').db;
                       let query = \"FOR d IN  ${testView2Name} RETURN d\";
                       let result = db._query(query);
-                      global.KEY_SET('${keySpaceId}', '${name}_length', result.toArray().length);
-                      global.KEY_SET('${keySpaceId}', '${name}_status', true);
+                      global.KEY_SET('${keySpaceId}', '${key}_length', result.toArray().length);
+                      global.KEY_SET('${keySpaceId}', '${key}_status', true);
                     } catch (e) {
-                      global.KEY_SET('${keySpaceId}', '${name}_status', false);
+                      global.KEY_SET('${keySpaceId}', '${key}_status', false);
                     }finally {
-                      global.KEY_SET('${keySpaceId}', '${name}', true);
+                      global.KEY_SET('${keySpaceId}', '${key}', true);
                     }
                   })(params);`
-                };
-                if (dbLevel['rw'].has(name)) {
-                  if(colLevel['rw'].has(name) || colLevel['ro'].has(name))
-                  {
-                    tasks.register(task);
-                    wait(keySpaceId, name);
-                    expect(getKey(keySpaceId, `${name}_status`)).to.equal(true, `${name} could not read the view with sufficient rights`);
-                    //FIXME: issue #429 (https://github.com/arangodb/backlog/issues/429)
-                    //expect(getNumericKey(keySpaceId, `${name}_length`)).to.equal(testNumDocs*2, 'View read failed');
-                  } else {
-                    tasks.register(task);
-                    wait(keySpaceId, name);
-                    expect(getKey(keySpaceId, `${name}_status`)).to.equal(false, `${name} managed to read the view with insufficient rights`);
-                  }
-                } else {
-                  try {
-                    tasks.register(task);
-                    wait(keySpaceId, name);
-                  } catch (e) {
-                    checkError(e);
-                    return;
-                  } finally {
-                    expect(getKey(keySpaceId, `${name}_status`)).to.equal(false, `${name} managed to read the view with insufficient rights`);
-                  }
-                  expect(false).to.equal(true, `${name} managed to register a task with insufficient rights`);
-                }
-              });
+                    };
+                    if (dbLevel['rw'].has(name)) {
+                      if (colLevel['rw'].has(name) || colLevel['ro'].has(name)) {
+                        tasks.register(task);
+                        wait(keySpaceId, key);
+                        expect(getKey(keySpaceId, `${key}_status`)).to.equal(true, `${name} could not read the view with sufficient rights`);
+                        //FIXME: issue #429 (https://github.com/arangodb/backlog/issues/429)
+                        //expect(getNumericKey(keySpaceId, `${name}_length`)).to.equal(testNumDocs*2, 'View read failed');
+                      } else {
+                        tasks.register(task);
+                        wait(keySpaceId, key);
+                        expect(getKey(keySpaceId, `${key}_status`)).to.equal(false, `${name} managed to read the view with insufficient rights`);
+                      }
+                    } else {
+                      try {
+                        tasks.register(task);
+                        wait(keySpaceId, key);
+                      } catch (e) {
+                        checkError(e);
+                        return;
+                      } finally {
+                        expect(getKey(keySpaceId, `${key}_status`)).to.equal(false, `${name} managed to read the view with insufficient rights`);
+                      }
+                      expect(false).to.equal(true, `${key} managed to register a task with insufficient rights`);
+                    }
+                  });
 
-              var descName = 'view with links to multiple collections with NONE access level to one of them';
-              !(colLevel['rw'].has(name) || colLevel['ro'].has(name)) ? describe(descName, () => {}) :
-              describe(descName, () => {
-                before(() => {
-                    rootGrantCollection(testCol2Name, name, 'none');
-                    expect(rootTestView(testView2Name)).to.equal(true, 'Precondition failed, the view doesn\'t exist');
-                });
+                  let descName = 'view with links to multiple collections with NONE access level to one of them';
+                  !(colLevel['rw'].has(name) || colLevel['ro'].has(name)) ? describe(descName, () => {}) :
+                    describe(descName, () => {
+                      before(() => {
+                        rootGrantCollection(testCol2Name, name, 'none');
+                        expect(rootTestView(testView2Name)).to.equal(true, 'Precondition failed, the view doesn\'t exist');
+                      });
 
-                it('by AQL query (data)', () => {
-                  setKey(keySpaceId, name);
-                  const taskId = 'task_read_view_multi_collections_with_1_of_none_access_data_' + name;
-                  const task = {
-                    id: taskId,
-                    name: taskId,
-                    command: `(function (params) {
+                      it('by AQL query (data)', () => {
+                        setKey(keySpaceId, key);
+                        const taskId = 'task_read_view_multi_collections_with_1_of_none_access_data_' + key;
+                        const task = {
+                          id: taskId,
+                          name: taskId,
+                          command: `(function (params) {
                       try {
                         const db = require('@arangodb').db;
                         let query = \"FOR d IN  ${testView2Name} RETURN d\";
                         let result = db._query(query);
-                        global.KEY_SET('${keySpaceId}', '${name}_status', true);
+                        global.KEY_SET('${keySpaceId}', '${key}_status', true);
                       } catch (e) {
-                        global.KEY_SET('${keySpaceId}', '${name}_status', false);
+                        global.KEY_SET('${keySpaceId}', '${key}_status', false);
                       }finally {
-                        global.KEY_SET('${keySpaceId}', '${name}', true);
+                        global.KEY_SET('${keySpaceId}', '${key}', true);
                       }
                     })(params);`
-                  };
-                  if (dbLevel['rw'].has(name)) {
-                    tasks.register(task);
-                    wait(keySpaceId, name);
-                    expect(getKey(keySpaceId, `${name}_status`)).to.equal(false, `${name} managed to perform a query on view with insufficient rights`);
-                  } else {
-                    try {
-                      tasks.register(task);
-                      wait(keySpaceId, name);
-                    } catch (e) {
-                      checkError(e);
-                      return;
-                    } finally {
-                      expect(getKey(keySpaceId, `${name}_status`)).to.equal(false, `${name} managed to read the view with insufficient rights`);
-                    }
-                    expect(false).to.equal(true, `${name} managed to register a task with insufficient rights`);
-                  }
-                });
-                it('by its properties', () => {
-                  setKey(keySpaceId, name);
-                  const taskId = 'task_read_view_multi_collections_with_1of_none_access_props_' + name;
-                  const task = {
-                    id: taskId,
-                    name: taskId,
-                    command: `(function (params) {
+                        };
+                        if (dbLevel['rw'].has(name)) {
+                          tasks.register(task);
+                          wait(keySpaceId, key);
+                          expect(getKey(keySpaceId, `${key}_status`)).to.equal(false, `${name} managed to perform a query on view with insufficient rights`);
+                        } else {
+                          try {
+                            tasks.register(task);
+                            wait(keySpaceId, key);
+                          } catch (e) {
+                            checkError(e);
+                            return;
+                          } finally {
+                            expect(getKey(keySpaceId, `${key}_status`)).to.equal(false, `${name} managed to read the view with insufficient rights`);
+                          }
+                          expect(false).to.equal(true, `${name} managed to register a task with insufficient rights`);
+                        }
+                      });
+                      it('by its properties', () => {
+                        setKey(keySpaceId, key);
+                        const taskId = 'task_read_view_multi_collections_with_1of_none_access_props_' + key;
+                        const task = {
+                          id: taskId,
+                          name: taskId,
+                          command: `(function (params) {
                       try {
                         const db = require('@arangodb').db;
                         db._view('${testView2Name}').properties();
-                        global.KEY_SET('${keySpaceId}', '${name}_status', true);
+                        global.KEY_SET('${keySpaceId}', '${key}_status', true);
                       } catch (e) {
-                        global.KEY_SET('${keySpaceId}', '${name}_status', false);
+                        global.KEY_SET('${keySpaceId}', '${key}_status', false);
                       }finally {
-                        global.KEY_SET('${keySpaceId}', '${name}', true);
+                        global.KEY_SET('${keySpaceId}', '${key}', true);
                       }
                     })(params);`
-                  };
-                  if (dbLevel['rw'].has(name)) {
-                    tasks.register(task);
-                    wait(keySpaceId, name);
-                    expect(getKey(keySpaceId, `${name}_status`)).to.not.equal(true, `${name} managed to get a view properties with insufficient rights`);
-                  } else {
-                    try {
-                      tasks.register(task);
-                      wait(keySpaceId, name);
-                    } catch (e) {
-                      checkError(e);
-                      return;
-                    } finally {
-                      expect(getKey(keySpaceId, `${name}_status`)).to.equal(false, `${name} managed to get the view properties with insufficient rights`);
-                    }
-                    expect(false).to.equal(true, `${name} managed to register a task with insufficient rights`);
-                  }
+                        };
+                        if (dbLevel['rw'].has(name)) {
+                          tasks.register(task);
+                          wait(keySpaceId, key);
+                          expect(getKey(keySpaceId, `${key}_status`)).to.not.equal(true, `${name} managed to get a view properties with insufficient rights`);
+                        } else {
+                          try {
+                            tasks.register(task);
+                            wait(keySpaceId, key);
+                          } catch (e) {
+                            checkError(e);
+                            return;
+                          } finally {
+                            expect(getKey(keySpaceId, `${key}_status`)).to.equal(false, `${name} managed to get the view properties with insufficient rights`);
+                          }
+                          expect(false).to.equal(true, `${key} managed to register a task with insufficient rights`);
+                        }
+                      });
+                    });
                 });
               });
             });
-          });
-        });
-      }
+          }
+        }
+
+      });
     }
   });
 });

--- a/tests/js/client/authentication/user-access-right-task-update-view-arangosearch.js
+++ b/tests/js/client/authentication/user-access-right-task-update-view-arangosearch.js
@@ -29,8 +29,7 @@
 // //////////////////////////////////////////////////////////////////////////////
 
 'use strict';
-var jsunity = require('jsunity');
-var analyzers = require("@arangodb/analyzers");
+const jsunity = require('jsunity');
 const testHelper = require('@arangodb/test-helper');
 const isEqual = testHelper.isEqual;
 const deriveTestSuite = testHelper.deriveTestSuite;
@@ -50,6 +49,7 @@ const testViewRename = `${namePrefix}ViewRename`;
 const testViewType = "arangosearch";
 const testCol1Name = `${namePrefix}Col1New`;
 const testCol2Name = `${namePrefix}Col2New`;
+const indexName = `${namePrefix}inverted`;
 const keySpaceId = 'task_update_view_keyspace';
 const userSet = helper.userSet;
 const systemLevel = helper.systemLevel;
@@ -58,9 +58,9 @@ const colLevel = helper.colLevel;
 
 const arango = require('internal').arango;
 for (let l of rightLevels) {
-    systemLevel[l] = new Set();
-    dbLevel[l] = new Set();
-    colLevel[l] = new Set();
+  systemLevel[l] = new Set();
+  dbLevel[l] = new Set();
+  colLevel[l] = new Set();
 }
 
 const wait = (keySpaceId, key) => {
@@ -73,163 +73,162 @@ const wait = (keySpaceId, key) => {
 };
 
 const createKeySpace = (keySpaceId) => {
-    return executeJS(`return global.KEYSPACE_CREATE('${keySpaceId}', 128, true);`).body === 'true';
+  return executeJS(`return global.KEYSPACE_CREATE('${keySpaceId}', 128, true);`).body === 'true';
 };
 
 const dropKeySpace = (keySpaceId) => {
-    executeJS(`global.KEYSPACE_DROP('${keySpaceId}');`);
+  executeJS(`global.KEYSPACE_DROP('${keySpaceId}');`);
 };
 
 const getKey = (keySpaceId, key) => {
-    return executeJS(`return global.KEY_GET('${keySpaceId}', '${key}');`).body === 'true';
+  return executeJS(`return global.KEY_GET('${keySpaceId}', '${key}');`).body === 'true';
 };
 
 const setKey = (keySpaceId, name) => {
-    return executeJS(`global.KEY_SET('${keySpaceId}', '${name}', false);`);
+  return executeJS(`global.KEY_SET('${keySpaceId}', '${name}', false);`);
 };
 
 const executeJS = (code) => {
-    let httpOptions = pu.makeAuthorizationHeaders({
-      username: 'root',
-      password: ''
-    }, {});
-    httpOptions.method = 'POST';
-    httpOptions.timeout = 1800;
-    httpOptions.returnBodyOnError = true;
-    return download(arango.getEndpoint().replace('tcp', 'http') + `/_db/${dbName}/_admin/execute?returnAsJSON=true`,
-                    code, httpOptions);
+  let httpOptions = pu.makeAuthorizationHeaders({
+    username: 'root',
+    password: ''
+  }, {});
+  httpOptions.method = 'POST';
+  httpOptions.timeout = 1800;
+  httpOptions.returnBodyOnError = true;
+  return download(arango.getEndpoint().replace('tcp', 'http') + `/_db/${dbName}/_admin/execute?returnAsJSON=true`,
+    code, httpOptions);
 };
 
 
-function hasIResearch (db) {
-    return !(db._views() === 0); // arangosearch views are not supported
-}
 let name = "";
 function rootTestCollection (colName, switchBack = true) {
-    helper.switchUser('root', dbName);
-    let col = db._collection(colName);
-    if (switchBack) {
-        helper.switchUser(name, dbName);
-    }
-    return col !== null;
+  helper.switchUser('root', dbName);
+  let col = db._collection(colName);
+  if (switchBack) {
+    helper.switchUser(name, dbName);
+  }
+  return col !== null;
 };
 
 function rootCreateCollection (colName) {
-    if (!rootTestCollection(colName, false)) {
-        db._create(colName);
-        if (colLevel['none'].has(name)) {
-            if (helper.isLdapEnabledExternal()) {
-                users.grantCollection(':role:' + name, dbName, colName, 'none');
-            } else {
-                users.grantCollection(name, dbName, colName, 'none');
-            }
-        } else if (colLevel['ro'].has(name)) {
-            if (helper.isLdapEnabledExternal()) {
-                users.grantCollection(':role:' + name, dbName, colName, 'ro');
-            } else {
-                users.grantCollection(name, dbName, colName, 'ro');
-            }
-        } else if (colLevel['rw'].has(name)) {
-            if (helper.isLdapEnabledExternal()) {
-                users.grantCollection(':role:' + name, dbName, colName, 'rw');
-            } else {
-                users.grantCollection(name, dbName, colName, 'rw');
-            }
-        }
+  if (!rootTestCollection(colName, false)) {
+    let c = db._create(colName);
+    if (colName === testCol1Name) {
+      c.ensureIndex({ type: "inverted", name: indexName, fields: [ { name: "value" } ] });
     }
-    helper.switchUser(name, dbName);
+    if (colLevel['none'].has(name)) {
+      if (helper.isLdapEnabledExternal()) {
+        users.grantCollection(':role:' + name, dbName, colName, 'none');
+      } else {
+        users.grantCollection(name, dbName, colName, 'none');
+      }
+    } else if (colLevel['ro'].has(name)) {
+      if (helper.isLdapEnabledExternal()) {
+        users.grantCollection(':role:' + name, dbName, colName, 'ro');
+      } else {
+        users.grantCollection(name, dbName, colName, 'ro');
+      }
+    } else if (colLevel['rw'].has(name)) {
+      if (helper.isLdapEnabledExternal()) {
+        users.grantCollection(':role:' + name, dbName, colName, 'rw');
+      } else {
+        users.grantCollection(name, dbName, colName, 'rw');
+      }
+    }
+  }
+  helper.switchUser(name, dbName);
 };
 
 function rootPrepareCollection (colName, numDocs = 1, defKey = true) {
-    if (rootTestCollection(colName, false)) {
-        db._collection(colName).truncate({ compact: false });
-        for(var i = 0; i < numDocs; ++i)
-        {
-            var doc = {prop1: colName + "_1", propI: i, plink: "lnk" + i};
-            if (!defKey) {
-                doc._key = colName + i;
-            }
-            db._collection(colName).save(doc, {waitForSync: true});
-        }
+  if (rootTestCollection(colName, false)) {
+    db._collection(colName).truncate({ compact: false });
+    for(var i = 0; i < numDocs; ++i)
+    {
+      var doc = {prop1: colName + "_1", propI: i, plink: "lnk" + i};
+      if (!defKey) {
+        doc._key = colName + i;
+      }
+      db._collection(colName).save(doc, {waitForSync: true});
     }
-    helper.switchUser(name, dbName);
+  }
+  helper.switchUser(name, dbName);
 };
 
 function rootGrantCollection (colName, user, explicitRight = '') {
-    if (rootTestCollection(colName, false)) {
-        if (explicitRight !== '' && rightLevels.includes(explicitRight))
-        {
-            if (helper.isLdapEnabledExternal()) {
-                users.grantCollection(':role:' + user, dbName, colName, explicitRight);
-            } else {
-                users.grantCollection(user, dbName, colName, explicitRight);
-            }
-        }
+  if (rootTestCollection(colName, false)) {
+    if (explicitRight !== '' && rightLevels.includes(explicitRight))
+    {
+      if (helper.isLdapEnabledExternal()) {
+        users.grantCollection(':role:' + user, dbName, colName, explicitRight);
+      } else {
+        users.grantCollection(user, dbName, colName, explicitRight);
+      }
     }
-    helper.switchUser(user, dbName);
+  }
+  helper.switchUser(user, dbName);
 };
 
 function rootDropCollection (colName) {
-    helper.switchUser('root', dbName);
-    try {
-        db._collection(colName).drop();
-    } catch (ignored) { }
-    helper.switchUser(name, dbName);
+  helper.switchUser('root', dbName);
+  db._drop(colName);
+  helper.switchUser(name, dbName);
 };
 
 function rootTestView (viewName, switchBack = true) {
-    helper.switchUser('root', dbName);
-    let view = db._view(viewName);
-    if (switchBack) {
-        helper.switchUser(name, dbName);
-    }
-    return view !== null;
+  helper.switchUser('root', dbName);
+  let view = db._view(viewName);
+  if (switchBack) {
+    helper.switchUser(name, dbName);
+  }
+  return view !== null;
 };
 
 function rootGetViewProps (viewName, switchBack = true) {
-    helper.switchUser('root', dbName);
-    let properties = db._view(viewName).properties();
-    if (switchBack) {
-        helper.switchUser(name, dbName);
-    }
-    return properties;
-};
-
-function rootCreateView (viewName, properties = null) {
-    if (rootTestView(viewName, false)) {
-        try {
-            db._dropView(viewName);
-        } catch (ignored) {}
-    }
-    let view =  db._createView(viewName, testViewType, {});
-    if (properties !== null) {
-        view.properties(properties, false);
-    }
+  helper.switchUser('root', dbName);
+  let properties = db._view(viewName).properties();
+  if (switchBack) {
     helper.switchUser(name, dbName);
+  }
+  return properties;
 };
 
-function rootGetDefaultViewProps () {
-    helper.switchUser('root', dbName);
+function rootCreateView (viewName, viewType, properties = null) {
+  if (rootTestView(viewName, false)) {
     try {
-        var tmpView = db._createView(this.title + "_tmpView", testViewType, {});
-        var properties = tmpView.properties();
-        db._dropView(this.title + "_tmpView");
-    } catch (ignored) { }
-    helper.switchUser(name, dbName);
-    return properties;
+      db._dropView(viewName);
+    } catch (ignored) {}
+  }
+  let view =  db._createView(viewName, viewType, {});
+  if (properties !== null) {
+    view.properties(properties, false);
+  }
+  helper.switchUser(name, dbName);
+};
+
+function rootGetDefaultViewProps (viewType) {
+  helper.switchUser('root', dbName);
+  let properties;
+  try {
+    let tmpView = db._createView(this.title + "_tmpView", viewType, {});
+    properties = tmpView.properties();
+    db._dropView(this.title + "_tmpView");
+  } catch (ignored) { }
+  helper.switchUser(name, dbName);
+  return properties;
 };
 
 function rootDropView (viewName) {
-    helper.switchUser('root', dbName);
-    try {
-        db._dropView(viewName);
-    } catch (ignored) { }
-    helper.switchUser(name, dbName);
+  helper.switchUser('root', dbName);
+  try {
+    db._dropView(viewName);
+  } catch (ignored) { }
+  helper.switchUser(name, dbName);
 };
 
 const checkError = (e) => {
-    assertEqual(e.code, 403, "Expected to get forbidden REST error code, but got another one");
-    assertEqual(e.errorNum, errors.ERROR_FORBIDDEN.code, "Expected to get forbidden error number, but got another one");
+  assertEqual(e.code, 403, "Expected to get forbidden REST error code, but got another one");
+  assertEqual(e.errorNum, errors.ERROR_FORBIDDEN.code, "Expected to get forbidden error number, but got another one");
 };
 
 function UserRightsManagement(name) {
@@ -244,17 +243,13 @@ function UserRightsManagement(name) {
       rootPrepareCollection(testCol2Name);
     },
 
-    setUp: function() {
-      rootCreateView(testViewName, { links: { [testCol1Name] : {includeAllFields: true } } });
-      helper.switchUser('root', dbName);
-    },
-
     tearDownAll: function() {
       rootDropCollection(testCol1Name);
       rootDropCollection(testCol2Name);
 
       dropKeySpace(keySpaceId);
     },
+
     tearDown: function() {
       rootDropView(testViewRename);
       rootDropView(testViewName);
@@ -272,20 +267,22 @@ function UserRightsManagement(name) {
 };
 
     
-if (hasIResearch(db)) {
-  helper.switchUser('root', '_system');
-  helper.removeAllUsers();
-  helper.generateAllUsers();
+helper.switchUser('root', '_system');
+helper.removeAllUsers();
+helper.generateAllUsers();
 
-  jsunity.run(function() {
-    let suite = {};
+jsunity.run(function() {
+  let suite = {};
 
-    deriveTestSuite(
-      UserRightsManagement(name),
-      suite,
-      "_-_" + name);
-    return suite;
-  });
+  deriveTestSuite(
+    UserRightsManagement(name),
+    suite,
+    "_-_" + name);
+  return suite;
+});
+
+for (let testViewType of ["arangosearch", "search-alias"]) {
+  // note: name is a global variable here
   for (name of userSet) {
     let canUse = true;
     try {
@@ -295,235 +292,258 @@ if (hasIResearch(db)) {
     }
 
     if (canUse) {
+      const key = `${testViewType}_${name}`;
+
       let suite = {
         testCheckAdministrateOnDBLevel: function() {
           assertTrue(userSet.size > 0);
           assertEqual(rootTestView(testViewName), true, 'Precondition failed, view was not found');
-          setKey(keySpaceId, name);
-          const taskId = 'task_update_view_name_' + name;
+          setKey(keySpaceId, key);
+          const taskId = 'task_update_view_name_' + key;
           const task = {
             id: taskId,
             name: taskId,
             command: `(function (params) {
-                    try {
-                      const db = require('@arangodb').db;
+                  try {
+                    const db = require('@arangodb').db;
 
-                      db._view('${testViewName}').rename('${testViewRename}');
-                      global.KEY_SET('${keySpaceId}', '${name}_status', true);
-                    } catch (e) {
-                      //FIXME: remove IF block after renaming will work in cluster
-                      if (e.errorNum === 1470) {
-                        global.KEY_SET('${keySpaceId}', '${name}_no_cluster_rename', true);
-                        global.KEY_SET('${keySpaceId}', '${name}_status', true);
-                      } else {
-                        global.KEY_SET('${keySpaceId}', '${name}_no_cluster_rename', false);
-                        global.KEY_SET('${keySpaceId}', '${name}_status', false);
-                      }
-                    } finally {
-                      global.KEY_SET('${keySpaceId}', '${name}', true);
+                    db._view('${testViewName}').rename('${testViewRename}');
+                    global.KEY_SET('${keySpaceId}', '${key}_status', true);
+                  } catch (e) {
+                    //FIXME: remove IF block after renaming will work in cluster
+                    if (e.errorNum === 1470) {
+                      global.KEY_SET('${keySpaceId}', '${key}_no_cluster_rename', true);
+                      global.KEY_SET('${keySpaceId}', '${key}_status', true);
+                    } else {
+                      global.KEY_SET('${keySpaceId}', '${key}_no_cluster_rename', false);
+                      global.KEY_SET('${keySpaceId}', '${key}_status', false);
                     }
-                  })(params);`
+                  } finally {
+                    global.KEY_SET('${keySpaceId}', '${key}', true);
+                  }
+                })(params);`
           };
           if (dbLevel['rw'].has(name)) {
             tasks.register(task);
-            wait(keySpaceId, name);
-            if(!getKey(keySpaceId, `${name}_no_cluster_rename`)) {
-              assertEqual(getKey(keySpaceId, `${name}_status`), colLevel['ro'].has(name) || colLevel['rw'].has(name), `${name} could update the view with sufficient rights`);
+            wait(keySpaceId, key);
+            if (!getKey(keySpaceId, `${key}_no_cluster_rename`)) {
+              assertEqual(getKey(keySpaceId, `${key}_status`), colLevel['ro'].has(name) || colLevel['rw'].has(name), `${name} could update the view with sufficient rights`);
               assertEqual(rootTestView(testViewRename), colLevel['ro'].has(name) || colLevel['rw'].has(name), 'View renaming reported success, but updated view was not found afterwards');
             }
           } else {
             try {
               tasks.register(task);
-              wait(keySpaceId, name);
+              wait(keySpaceId, key);
               assertFail(`${name} managed to register a task with insufficient rights`);
             } catch (e) {
               checkError(e);
             } finally {
-              assertFalse(getKey(keySpaceId, `${name}_status`), `${name} could update the view with insufficient rights`);
+              assertFalse(getKey(keySpaceId, `${key}_status`), `${name} could update the view with insufficient rights`);
             }
           }
         },
-        testViewPropertyExceptLinksPartial: function() {
+      };
+
+      if (testViewType === 'arangosearch') {
+        // specific handling for views of type "arangosearch"
+        suite.setUp = function() {
+          rootCreateView(testViewName, testViewType, { links: { [testCol1Name] : {includeAllFields: true } } });
+          helper.switchUser('root', dbName);
+        };
+
+        suite.testViewPropertyExceptLinksPartial = function() {
           assertTrue(rootTestView(testViewName), 'Precondition failed, view was not found');
-          setKey(keySpaceId, name);
-          const taskId = 'task_update_view_property_not_links_partial_' + name;
+          setKey(keySpaceId, key);
+          const taskId = 'task_update_view_property_not_links_partial_' + key;
           const task = {
             id: taskId,
             name: taskId,
             command: `(function (params) {
-                    try {
-                      const db = require('@arangodb').db;
-                      db._view('${testViewName}').properties({ "cleanupIntervalStep": 1 }, true);
-                      global.KEY_SET('${keySpaceId}', '${name}_status', true);
-                    } catch (e) {
-                      global.KEY_SET('${keySpaceId}', '${name}_status', false);
-                    }finally {
-                      global.KEY_SET('${keySpaceId}', '${name}', true);
-                    }
-                  })(params);`
+                  try {
+                    const db = require('@arangodb').db;
+                    db._view('${testViewName}').properties({ "cleanupIntervalStep": 1 }, true);
+                    global.KEY_SET('${keySpaceId}', '${key}_status', true);
+                  } catch (e) {
+                    global.KEY_SET('${keySpaceId}', '${key}_status', false);
+                  }finally {
+                    global.KEY_SET('${keySpaceId}', '${key}', true);
+                  }
+                })(params);`
           };
           if (dbLevel['rw'].has(name)) {
-            if(colLevel['rw'].has(name) || colLevel['ro'].has(name)){
+            if (colLevel['rw'].has(name) || colLevel['ro'].has(name)) {
               tasks.register(task);
-              wait(keySpaceId, name);
-              assertTrue(getKey(keySpaceId, `${name}_status`), `${name} could not update the view with sufficient rights`);
+              wait(keySpaceId, key);
+              assertTrue(getKey(keySpaceId, `${key}_status`), `${name} could not update the view with sufficient rights`);
               assertEqual(rootGetViewProps(testViewName)["cleanupIntervalStep"], 1, 'View property update reported success, but property was not updated');
             } else {
               tasks.register(task);
-              wait(keySpaceId, name);
-              assertFalse(getKey(keySpaceId, `${name}_status`), `${name} could update the view with insufficient rights`);
+              wait(keySpaceId, key);
+              assertFalse(getKey(keySpaceId, `${key}_status`), `${name} could update the view with insufficient rights`);
             }
           } else {
             try {
               tasks.register(task);
-              wait(keySpaceId, name);
-              assertFail( `${name} managed to register a task with insufficient rights`);
+              wait(keySpaceId, key);
+              assertFail(`${name} managed to register a task with insufficient rights`);
             } catch (e) {
               checkError(e);
             } finally {
-              assertFalse(getKey(keySpaceId, `${name}_status`), `${name} could update the view with insufficient rights`);
+              assertFalse(getKey(keySpaceId, `${key}_status`), `${name} could update the view with insufficient rights`);
             }
           }
-        },
-        testViewByPropertyExceptLinksFull: function() {
+        };
+
+        suite.testViewByPropertyExceptLinksFull = function() {
           assertTrue(rootTestView(testViewName), 'Precondition failed, view was not found');
-          setKey(keySpaceId, name);
-          const taskId = 'task_update_view_property_not_links_full_' + name;
+          setKey(keySpaceId, key);
+          const taskId = 'task_update_view_property_not_links_full_' + key;
           const task = {
             id: taskId,
             name: taskId,
             command: `(function (params) {
-                    try {
-                      const db = require('@arangodb').db;
-                      db._view('${testViewName}').properties({ "cleanupIntervalStep": 1 }, false);
-                      global.KEY_SET('${keySpaceId}', '${name}_status', true);
-                    } catch (e) {
-                      global.KEY_SET('${keySpaceId}', '${name}_status', false);
-                    }finally {
-                      global.KEY_SET('${keySpaceId}', '${name}', true);
-                    }
-                  })(params);`
+                  try {
+                    const db = require('@arangodb').db;
+                    db._view('${testViewName}').properties({ "cleanupIntervalStep": 1 }, false);
+                    global.KEY_SET('${keySpaceId}', '${key}_status', true);
+                  } catch (e) {
+                    global.KEY_SET('${keySpaceId}', '${key}_status', false);
+                  }finally {
+                    global.KEY_SET('${keySpaceId}', '${key}', true);
+                  }
+                })(params);`
           };
           if (dbLevel['rw'].has(name)) {
-            if(colLevel['rw'].has(name) || colLevel['ro'].has(name)){
+            if (colLevel['rw'].has(name) || colLevel['ro'].has(name)) {
               tasks.register(task);
-              wait(keySpaceId, name);
-              assertTrue(getKey(keySpaceId, `${name}_status`), `${name} could not update the view with sufficient rights`);
+              wait(keySpaceId, key);
+              assertTrue(getKey(keySpaceId, `${key}_status`), `${name} could not update the view with sufficient rights`);
               assertEqual(rootGetViewProps(testViewName)["cleanupIntervalStep"], 1, 'View property update reported success, but property was not updated');
             } else {
               tasks.register(task);
-              wait(keySpaceId, name);
-              assertFalse(getKey(keySpaceId, `${name}_status`), `${name} could update the view with insufficient rights`);
+              wait(keySpaceId, key);
+              assertFalse(getKey(keySpaceId, `${key}_status`), `${name} could update the view with insufficient rights`);
             }
           } else {
             try {
               tasks.register(task);
-              wait(keySpaceId, name);
+              wait(keySpaceId, key);
               assertFail(`${name} managed to register a task with insufficient rights`);
             } catch (e) {
               checkError(e);
               return;
             } finally {
-              assertFalse(getKey(keySpaceId, `${name}_status`), `${name} could update the view with insufficient rights`);
+              assertFalse(getKey(keySpaceId, `${key}_status`), `${name} could update the view with insufficient rights`);
             }
           }
-        },
-        testViewBypPropertiesRemoveFull: function() {
+        };
+
+        suite.testViewByPropertiesRemoveFull = function() {
           assertTrue(rootTestView(testViewName), 'Precondition failed, view was not found');
-          setKey(keySpaceId, name);
-          const taskId = 'task_update_view_properties_remove_full_' + name;
+          setKey(keySpaceId, key);
+          const taskId = 'task_update_view_properties_remove_full_' + key;
           const task = {
             id: taskId,
             name: taskId,
             command: `(function (params) {
-                    try {
-                      const db = require('@arangodb').db;
-                      db._view('${testViewName}').properties({}, false);
-                      global.KEY_SET('${keySpaceId}', '${name}_status', true);
-                    } catch (e) {
-                      global.KEY_SET('${keySpaceId}', '${name}_status', false);
-                    }finally {
-                      global.KEY_SET('${keySpaceId}', '${name}', true);
-                    }
-                  })(params);`
+                  try {
+                    const db = require('@arangodb').db;
+                    db._view('${testViewName}').properties({}, false);
+                    global.KEY_SET('${keySpaceId}', '${key}_status', true);
+                  } catch (e) {
+                    global.KEY_SET('${keySpaceId}', '${key}_status', false);
+                  }finally {
+                    global.KEY_SET('${keySpaceId}', '${key}', true);
+                  }
+                })(params);`
           };
           if (dbLevel['rw'].has(name)) {
-            if(colLevel['rw'].has(name) || colLevel['ro'].has(name)){
+            if (colLevel['rw'].has(name) || colLevel['ro'].has(name)) {
               tasks.register(task);
-              wait(keySpaceId, name);
-              assertTrue(getKey(keySpaceId, `${name}_status`), `${name} could not update the view with sufficient rights`);
-              assertTrue(isEqual(rootGetViewProps(testViewName, true), rootGetDefaultViewProps()),
+              wait(keySpaceId, key);
+              assertTrue(getKey(keySpaceId, `${key}_status`), `${name} could not update the view with sufficient rights`);
+              assertTrue(isEqual(rootGetViewProps(testViewName, true), rootGetDefaultViewProps(testViewType)),
                 'View properties update reported success, but properties were not updated');
             } else {
               tasks.register(task);
-              wait(keySpaceId, name);
-              assertFalse(getKey(keySpaceId, `${name}_status`), `${name} could update the view with insufficient rights`);
+              wait(keySpaceId, key);
+              assertFalse(getKey(keySpaceId, `${key}_status`), `${name} could update the view with insufficient rights`);
             }
           } else {
             try {
               tasks.register(task);
-              wait(keySpaceId, name);
+              wait(keySpaceId, key);
               assertFail(`${name} managed to register a task with insufficient rights`);
             } catch (e) {
               checkError(e);
               return;
             } finally {
-              assertFalse(getKey(keySpaceId, `${name}_status`), `${name} could update the view with insufficient rights`);
+              assertFalse(getKey(keySpaceId, `${key}_status`), `${name} could update the view with insufficient rights`);
             }
           }
-        },
-        testViewByExistingLinkUpdatePartial: function() {
+        };
+
+        suite.testViewByExistingLinkUpdatePartial = function() {
           assertTrue(rootTestView(testViewName), 'Precondition failed, view was not found');
-          setKey(keySpaceId, name);
-          const taskId = 'task_update_view_existing_link_partial_' + name;
+          setKey(keySpaceId, key);
+          const taskId = 'task_update_view_existing_link_partial_' + key;
           const task = {
             id: taskId,
             name: taskId,
             command: `(function (params) {
-                    try {
-                      const db = require('@arangodb').db;
-                      db._view('${testViewName}').properties({ links: { ['${testCol1Name}']: { includeAllFields: true, analyzers: ['text_de','text_en'] } } }, true);
-                      global.KEY_SET('${keySpaceId}', '${name}_status', true);
-                    } catch (e) {
-                      global.KEY_SET('${keySpaceId}', '${name}_status', false);
-                    }finally {
-                      global.KEY_SET('${keySpaceId}', '${name}', true);
-                    }
-                  })(params);`
+                  try {
+                    const db = require('@arangodb').db;
+                    db._view('${testViewName}').properties({ links: { ['${testCol1Name}']: { includeAllFields: true, analyzers: ['text_de','text_en'] } } }, true);
+                    global.KEY_SET('${keySpaceId}', '${key}_status', true);
+                  } catch (e) {
+                    global.KEY_SET('${keySpaceId}', '${key}_status', false);
+                  }finally {
+                    global.KEY_SET('${keySpaceId}', '${key}', true);
+                  }
+                })(params);`
           };
           if (dbLevel['rw'].has(name)) {
-            if(colLevel['rw'].has(name) || colLevel['ro'].has(name))
+            if (colLevel['rw'].has(name) || colLevel['ro'].has(name))
             {
               tasks.register(task);
-              wait(keySpaceId, name);
-              assertTrue(getKey(keySpaceId, `${name}_status`), `${name} could not update the view with sufficient rights`);
+              wait(keySpaceId, key);
+              assertTrue(getKey(keySpaceId, `${key}_status`), `${name} could not update the view with sufficient rights`);
               assertEqual(rootGetViewProps(testViewName)["links"][testCol1Name]["analyzers"], ["text_de", "text_en"], 'View link update reported success, but property was not updated');
             } else {
               tasks.register(task);
-              wait(keySpaceId, name);
-              assertFalse(getKey(keySpaceId, `${name}_status`), `${name} could update the view with insufficient rights`);
+              wait(keySpaceId, key);
+              assertFalse(getKey(keySpaceId, `${key}_status`), `${name} could update the view with insufficient rights`);
             }
           } else {
             try {
               tasks.register(task);
-              wait(keySpaceId, name);
+              wait(keySpaceId, key);
               assertFail(`${name} managed to register a task with insufficient rights`);
             } catch (e) {
               checkError(e);
             } finally {
-              assertFalse(getKey(keySpaceId, `${name}_status`), `${name} could update the view with insufficient rights`);
+              assertFalse(getKey(keySpaceId, `${key}_status`), `${name} could update the view with insufficient rights`);
             }
 
           }
-        }
-      };
+        };
+
+      } else {
+        // specific handling for views of type "search-alias"
+        suite.setUp = function() {
+          rootCreateView(testViewName, testViewType, { indexes: [ { collection: testCol1Name, index: indexName } ] });
+          helper.switchUser('root', dbName);
+        };
+      }
+
       jsunity.run(function() {
         return deriveTestSuiteWithnamespace(
           UserRightsManagement(name),
           suite,
-          "_-_" + name);
+          "_-_" + key);
       });
     }
   }
+
 }
 return jsunity.done();

--- a/tests/js/client/authentication/user-access-right-update-view-arangosearch.js
+++ b/tests/js/client/authentication/user-access-right-update-view-arangosearch.js
@@ -46,10 +46,9 @@ const namePrefix = helper.namePrefix;
 const dbName = helper.dbName;
 const testViewName = `${namePrefix}ViewNew`;
 const testViewRename = `${namePrefix}ViewRename`;
-const testViewType = "arangosearch";
 const testCol1Name = `${namePrefix}Col1New`;
 const testCol2Name = `${namePrefix}Col2New`;
-
+const indexName = `${namePrefix}Inverted`;
 
 const userSet = helper.userSet;
 
@@ -69,13 +68,6 @@ for (let l of rightLevels) {
   colLevel[l] = new Set();
 }
 
-// Use this function to inspect sets
-function logSet(x){
-  x.forEach( (value1, value2, set) => {
-    require("internal").print('s[' + value1 + '] = ' + value2);
-  });
-}
-
 // helper functions ///////////////////////////////////////////////////////////
 
 const assertFail = (text) => { assertTrue(false, text); };
@@ -91,7 +83,11 @@ function rootTestCollection (colName, switchBack = true) {
 
 function rootCreateCollection (colName) {
   if (!rootTestCollection(colName, false)) {
-    db._create(colName);
+    let c = db._create(colName);
+    if (colName === testCol1Name) {
+      c.ensureIndex({ type: "inverted", name: indexName, fields: [ { name: "value" } ] });
+    }
+
     if (colLevel['none'].has(name)) {
       if (helper.isLdapEnabledExternal()) {
         users.grantCollection(':role:' + name, dbName, colName, 'none');
@@ -119,19 +115,19 @@ function rootPrepareCollection (colName, numDocs = 1, defKey = true) {
   if (rootTestCollection(colName, false)) {
     db._collection(colName).truncate({ compact: false });
     let docs = [];
-    for(var i = 0; i < numDocs; ++i) {
-      var doc = {prop1: colName + "_1", propI: i, plink: "lnk" + i};
+    for (let i = 0; i < numDocs; ++i) {
+      let doc = {prop1: colName + "_1", propI: i, plink: "lnk" + i};
       if (!defKey) {
         doc._key = colName + i;
       }
       docs.push(doc);
     }
-    db._collection(colName).insert(docs, {waitForSync: true});
+    db._collection(colName).insert(docs);
   }
   helper.switchUser(name, dbName);
 };
 
-function rootGrantCollection (colName, user, explicitRight = '')  {
+function rootGrantCollection (colName, user, explicitRight = '') {
   if (rootTestCollection(colName, false)) {
     if (explicitRight !== '' && rightLevels.includes(explicitRight)) {
       if (helper.isLdapEnabledExternal()) {
@@ -144,7 +140,7 @@ function rootGrantCollection (colName, user, explicitRight = '')  {
   helper.switchUser(user, dbName);
 };
 
-function rootDropCollection (colName)  {
+function rootDropCollection (colName) {
   helper.switchUser('root', dbName);
   try {
     db._collection(colName).drop();
@@ -152,7 +148,7 @@ function rootDropCollection (colName)  {
   helper.switchUser(name, dbName);
 };
 
-function rootTestView (viewName, switchBack = true)  {
+function rootTestView (viewName, switchBack = true) {
   helper.switchUser('root', dbName);
   let view = db._view(viewName);
   if (switchBack) {
@@ -161,7 +157,7 @@ function rootTestView (viewName, switchBack = true)  {
   return view !== null;
 };
 
-function rootGetViewProps (viewName, switchBack = true)  {
+function rootGetViewProps (viewName, switchBack = true) {
   helper.switchUser('root', dbName);
   let properties = db._view(viewName).properties();
   if (switchBack) {
@@ -170,24 +166,25 @@ function rootGetViewProps (viewName, switchBack = true)  {
   return properties;
 };
 
-function rootCreateView (viewName, properties = null)  {
+function rootCreateView (viewName, viewType, properties = null) {
   if (rootTestView(viewName, false)) {
     try {
       db._dropView(viewName);
     } catch (ignored) {}
   }
-  let view =  db._createView(viewName, testViewType, {});
+  let view =  db._createView(viewName, viewType, {});
   if (properties != null) {
     view.properties(properties, false);
   }
   helper.switchUser(name, dbName);
 };
 
-function rootGetDefaultViewProps ()  {
+function rootGetDefaultViewProps (viewType) {
   helper.switchUser('root', dbName);
+  let properties;
   try {
-    var tmpView = db._createView(this.title + "_tmpView", testViewType, {});
-    var properties = tmpView.properties();
+    let tmpView = db._createView(this.title + "_tmpView", viewType, {});
+    properties = tmpView.properties();
     db._dropView(this.title + "_tmpView");
   } catch (ignored) { }
   helper.switchUser(name, dbName);
@@ -210,10 +207,6 @@ function checkError (e) {
               "Expected to get forbidden error number, but got another one");
 };
 
-function hasIResearch (db) {
-  return !(db._views() === 0); // arangosearch views are not supported
-}
-
 // start of tests /////////////////////////////////////////////////////////////
 
 function UserRightsManagement(name) {
@@ -225,16 +218,12 @@ function UserRightsManagement(name) {
       rootPrepareCollection(testCol1Name);
       rootPrepareCollection(testCol2Name);
     },
-    setUp: function() {
-      rootCreateView(testViewName, { links: { [testCol1Name] : {includeAllFields: true } } });
-      db._useDatabase(dbName);
-      helper.switchUser('root', dbName);
-    },
 
     tearDown: function() {
       rootDropView(testViewRename);
       rootDropView(testViewName);
     },
+
     tearDownAll: function () {
       rootDropCollection(testCol1Name);
       rootDropCollection(testCol2Name);
@@ -243,11 +232,7 @@ function UserRightsManagement(name) {
     testCheckAllUsersAreCreated: function() {
       helper.switchUser('root', '_system');
 
-      if (db._views() === 0) {
-        return; // arangosearch views are not supported
-      }
-
-      assertTrue(userSet.size>0);
+      assertTrue(userSet.size > 0);
       assertEqual(userSet.size, helper.userCount);
 
       for (let name of userSet) {
@@ -256,10 +241,6 @@ function UserRightsManagement(name) {
     }
   };
 };
-
-if (!hasIResearch(db)) {
-  return;
-}
 
 helper.switchUser('root', '_system');
 helper.removeAllUsers();
@@ -272,194 +253,191 @@ jsunity.run(function(){
   return suite;
 });
 
+for (let testViewType of ["arangosearch", "search-alias"]) {
+  for (name of userSet) {
+    try {
+      helper.switchUser(name, dbName);
+    } catch (e) {
+      continue;
+    }
+  
+    const key = `${testViewType}_${name}`;
 
-for (name of userSet) {
-  try {
-    helper.switchUser(name, dbName);
-  } catch (e) {
-    continue;
-  }
+    let suite = {
+      testUpdateViewByName: function() {
+        // require('internal').sleep(2);
 
-  let suite = {
-    testUpdateViewByName: function() {
-      require('internal').sleep(2);
+        assertTrue(rootTestView(testViewName),
+          'Precondition failed, view was not found');
 
-      assertTrue(rootTestView(testViewName),
-                 'Precondition failed, view was not found');
-
-      if (dbLevel['rw'].has(name)) {
-        try {
-          db._view(testViewName).rename(testViewRename);
-        } catch (e) {
-          //FIXME: remove try/catch block after renaming will work in cluster
-          if (e.code === 501 && e.errorNum === 1470) {
-            return;
-          } else if (e.code === 403) {
-            return; // not authorised is valid if a non-read collection is present in the view
-          } else {
-            throw e;
-          }
-        }
-
-        assertTrue(rootTestView(testViewRename),
-                   'View renaming reported success, but updated view was not found afterwards');
-
-        analyzers.save("more_text_de", "text",
-                     { locale: "de.UTF-8", stopwords: [ ] },
-                     [ "frequency", "norm", "position" ]);
-
-      } else {
-        try {
-          db._view(testViewName).rename(testViewRename);
-        } catch (e) {
-          checkError(e);
-          return;
-        }
-
-        assertFalse(rootTestView(testViewRename),
-                    `${name} was able to rename a view with insufficent rights`);
-
-      }
-    }, // testUpdateViewByName
-
-    testAnalyzerPermisssions: function() {
-
-      assertTrue(rootTestView(testViewName),
-                         'Precondition failed, view was not found');
-
-      if ( systemLevel['rw'].has(name) && dbLevel['rw'].has(name) && colLevel['rw'].has(name) ) {
-        // create additional analyzer
-        let res = analyzers.save("more_text_de", "text",
-                             { locale: "de.UTF-8", stopwords: [ ] },
-                             [ "frequency", "norm", "position" ]);
-
-      } else if( (systemLevel['ro'].has(name)) &&
-                 (dbLevel['ro'].has(name))     &&
-                 (colLevel['ro'].has(name)) ) {
-        try {
-          let res = analyzers.save("more_text_de", "text",
-                               { locale: "de.UTF-8", stopwords: [ ] },
-                               [ "frequency", "norm", "position" ]);
-
-          assertFalse(true, `${name} was able to change analyzer although we had insufficent rights`);
-        } catch (e) {
-          assertEqual(e.errorNum, errors.ERROR_FORBIDDEN.code,
-                      "Expected to get forbidden error number, but got another one");
-          checkError(e);
-        }
-      } else if( systemLevel['ro'].has(name) && dbLevel['ro'].has(name) && colLevel['ro'].has(name) ) {
-        let res = arango.DELETE("/_db/" + db._name()+ "/_api/analyzer/text_de");
-        assertEqual(403, res.code, `${name} was able to delete analyzer although we had insufficient rights`);
-      }
-    },
-
-    testUpdateViewByPropertyExceptPartialLinks: function() {
-
-      assertTrue(rootTestView(testViewName),
-                         'Precondition failed, view was not found');
-
-      if (dbLevel['rw'].has(name) && (colLevel['rw'].has(name) || colLevel['ro'].has(name))) {
-        db._view(testViewName).properties({ "cleanupIntervalStep": 1 }, true);
-        assertEqual(rootGetViewProps(testViewName, true)["cleanupIntervalStep"],
-                    1, 'View property update reported success, but property was not updated');
-      } else {
-        try {
-          db._view(testViewName).properties({ "cleanupIntervalStep": 1 }, true);
-          assertFail(`${name} was able to update a view with insufficent rights`);
-        } catch (e) {
-          checkError(e);
-        }
-      }
-    },
-
-    testViewByPropertyExceptLinksFull: function() {
-      assertTrue(rootTestView(testViewName),
-                 'Precondition failed, view was not found');
-
-      if (dbLevel['rw'].has(name) && (colLevel['rw'].has(name) || colLevel['ro'].has(name))) {
-        db._view(testViewName).properties({ "cleanupIntervalStep": 1 }, false);
-        assertEqual(rootGetViewProps(testViewName, true)["cleanupIntervalStep"],
-                    1, 'View property update reported success, but property was not updated');
-      } else {
-        try {
-          db._view(testViewName).properties({ "cleanupIntervalStep": 1 }, false);
-          assertFail(`${name} was able to update a view with insufficent rights`);
-        } catch (e) {
-          checkError(e);
-        }
-      }
-    },
-
-    testViewByPropertiesRemoveFull: function() {
-      assertTrue(rootTestView(testViewName),
-                 'Precondition failed, view was not found');
-
-      if (dbLevel['rw'].has(name) && (colLevel['rw'].has(name) || colLevel['ro'].has(name))) {
-        db._view(testViewName).properties({}, false);
-        assertTrue(isEqual(rootGetViewProps(testViewName, true), rootGetDefaultViewProps()),
-                   'View properties update reported success, but properties were not updated');
-      } else {
-        try {
-          db._view(testViewName).properties({}, false);
-          assertFail(`${name} was able to update a view with insufficent rights`);
-        } catch (e) {
-          checkError(e);
-        }
-      }
-    },
-
-    testViewByExistingLinkUpdatePartial: function() {
-      assertTrue(rootTestView(testViewName), 'Precondition failed, view was not found');
-      if (dbLevel['rw'].has(name) && (colLevel['rw'].has(name) || colLevel['ro'].has(name))) {
-        db._view(testViewName).properties({
-          links: {
-            [testCol1Name]: {
-              includeAllFields: true,
-              analyzers: ["text_de","text_en"]
+        if (dbLevel['rw'].has(name)) {
+          try {
+            db._view(testViewName).rename(testViewRename);
+          } catch (e) {
+            //FIXME: remove try/catch block after renaming will work in cluster
+            if (e.code === 501 && e.errorNum === 1470) {
+              return;
+            } else if (e.code === 403) {
+              return; // not authorised is valid if a non-read collection is present in the view
+            } else {
+              throw e;
             }
           }
-        }, true);
 
-        assertEqual(rootGetViewProps(testViewName, true)["links"][testCol1Name]["analyzers"],
-                    ["text_de", "text_en"],
-                    'View link update reported success, but property was not updated');
-      } else {
-        try {
+          assertTrue(rootTestView(testViewRename),
+            'View renaming reported success, but updated view was not found afterwards');
+
+          analyzers.save("more_text_de", "text",
+            { locale: "de.UTF-8", stopwords: [ ] },
+            [ "frequency", "norm", "position" ]);
+
+        } else {
+          try {
+            db._view(testViewName).rename(testViewRename);
+          } catch (e) {
+            checkError(e);
+            return;
+          }
+
+          assertFalse(rootTestView(testViewRename),
+            `${name} was able to rename a view with insufficent rights`);
+
+        }
+      },
+
+      testViewByPropertiesRemoveFull: function() {
+        assertTrue(rootTestView(testViewName),
+          'Precondition failed, view was not found');
+
+        if (dbLevel['rw'].has(name) && (colLevel['rw'].has(name) || colLevel['ro'].has(name))) {
+          db._view(testViewName).properties({}, false);
+          assertTrue(isEqual(rootGetViewProps(testViewName, true), rootGetDefaultViewProps(testViewType)),
+            'View properties update reported success, but properties were not updated');
+        } else {
+          try {
+            db._view(testViewName).properties({}, false);
+            assertFail(`${name} was able to update a view with insufficent rights`);
+          } catch (e) {
+            checkError(e);
+          }
+        }
+      },
+
+    };
+
+    if (testViewType === 'arangosearch') {
+      // specific handling for views of type "arangosearch"
+
+      suite.setUp = function() {
+        rootCreateView(testViewName, testViewType, { links: { [testCol1Name] : {includeAllFields: true } } });
+        db._useDatabase(dbName);
+        helper.switchUser('root', dbName);
+      };
+
+      suite.testAnalyzerPermisssions = function() {
+        assertTrue(rootTestView(testViewName),
+          'Precondition failed, view was not found');
+
+        if (systemLevel['rw'].has(name) && dbLevel['rw'].has(name) && colLevel['rw'].has(name)) {
+          // create additional analyzer
+          let res = analyzers.save("more_text_de", "text",
+            { locale: "de.UTF-8", stopwords: [ ] },
+            [ "frequency", "norm", "position" ]);
+
+        } else if( (systemLevel['ro'].has(name)) &&
+          (dbLevel['ro'].has(name))     &&
+          (colLevel['ro'].has(name))) {
+          try {
+            let res = analyzers.save("more_text_de", "text",
+              { locale: "de.UTF-8", stopwords: [ ] },
+              [ "frequency", "norm", "position" ]);
+
+            assertFalse(true, `${name} was able to change analyzer although we had insufficent rights`);
+          } catch (e) {
+            assertEqual(e.errorNum, errors.ERROR_FORBIDDEN.code,
+              "Expected to get forbidden error number, but got another one");
+            checkError(e);
+          }
+        } else if( systemLevel['ro'].has(name) && dbLevel['ro'].has(name) && colLevel['ro'].has(name)) {
+          let res = arango.DELETE("/_db/" + db._name()+ "/_api/analyzer/text_de");
+          assertEqual(403, res.code, `${name} was able to delete analyzer although we had insufficient rights`);
+        }
+      };
+      
+      suite.testUpdateViewByPropertyExceptPartialLinks = function() {
+        assertTrue(rootTestView(testViewName),
+          'Precondition failed, view was not found');
+
+        if (dbLevel['rw'].has(name) && (colLevel['rw'].has(name) || colLevel['ro'].has(name))) {
+          db._view(testViewName).properties({ "cleanupIntervalStep": 1 }, true);
+          assertEqual(rootGetViewProps(testViewName, true)["cleanupIntervalStep"],
+            1, 'View property update reported success, but property was not updated');
+        } else {
+          try {
+            db._view(testViewName).properties({ "cleanupIntervalStep": 1 }, true);
+            assertFail(`${name} was able to update a view with insufficent rights`);
+          } catch (e) {
+            checkError(e);
+          }
+        }
+      };
+
+      suite.testViewByPropertyExceptLinksFull = function() {
+        assertTrue(rootTestView(testViewName),
+          'Precondition failed, view was not found');
+
+        if (dbLevel['rw'].has(name) && (colLevel['rw'].has(name) || colLevel['ro'].has(name))) {
+          db._view(testViewName).properties({ "cleanupIntervalStep": 1 }, false);
+          assertEqual(rootGetViewProps(testViewName, true)["cleanupIntervalStep"],
+            1, 'View property update reported success, but property was not updated');
+        } else {
+          try {
+            db._view(testViewName).properties({ "cleanupIntervalStep": 1 }, false);
+            assertFail(`${name} was able to update a view with insufficent rights`);
+          } catch (e) {
+            checkError(e);
+          }
+        }
+      };
+
+      suite.testViewByExistingLinkUpdatePartial = function() {
+        assertTrue(rootTestView(testViewName), 'Precondition failed, view was not found');
+        if (dbLevel['rw'].has(name) && (colLevel['rw'].has(name) || colLevel['ro'].has(name))) {
           db._view(testViewName).properties({
             links: {
-              [testCol1Name] : {
+              [testCol1Name]: {
                 includeAllFields: true,
-                analyzers: ["text_de","text_en"] 
+                analyzers: ["text_de","text_en"]
               }
             }
           }, true);
 
-          assertFail(`${name} was able to update a view with insufficent rights`);
-        } catch (e) {
-          checkError(e);
-        }
-      }
-    },
+          assertEqual(rootGetViewProps(testViewName, true)["links"][testCol1Name]["analyzers"],
+            ["text_de", "text_en"],
+            'View link update reported success, but property was not updated');
+        } else {
+          try {
+            db._view(testViewName).properties({
+              links: {
+                [testCol1Name] : {
+                  includeAllFields: true,
+                  analyzers: ["text_de","text_en"] 
+                }
+              }
+            }, true);
 
-    testViewByExistingLinkUpdateFull: function() {
-      assertTrue(rootTestView(testViewName),
-                 'Precondition failed, view was not found');
-
-      if (dbLevel['rw'].has(name) && (colLevel['rw'].has(name) || colLevel['ro'].has(name))) {
-        db._view(testViewName).properties({
-          links: {
-            [testCol1Name]: {
-              includeAllFields: true,
-              analyzers: ["text_de","text_en"]
-            }
+            assertFail(`${name} was able to update a view with insufficent rights`);
+          } catch (e) {
+            checkError(e);
           }
-        }, false);
+        }
+      };
 
-        assertEqual(rootGetViewProps(testViewName, true)["links"][testCol1Name]["analyzers"],
-                    ["text_de", "text_en"],
-                    'View link update reported success, but property was not updated');
-      } else {
-        try {
+      suite.testViewByExistingLinkUpdateFull = function() {
+        assertTrue(rootTestView(testViewName),
+          'Precondition failed, view was not found');
+
+        if (dbLevel['rw'].has(name) && (colLevel['rw'].has(name) || colLevel['ro'].has(name))) {
           db._view(testViewName).properties({
             links: {
               [testCol1Name]: {
@@ -468,33 +446,33 @@ for (name of userSet) {
               }
             }
           }, false);
-          assertFail(`${name} was able to update a view with insufficent rights`);
-        } catch (e) {
-          checkError(e);
-        }
-      }
-    },
 
-    testViewByNewLinkToRWCollectionPartial: function() {
-      if (colLevel['ro'].has(name) && colLevel['none'].has(name)) {
-        assertTrue(rootTestView(testViewName), 'Precondition failed, view was not found');
-        rootGrantCollection(testCol2Name, name, 'rw');
-
-        if (dbLevel['rw'].has(name) && colLevel['ro'].has(name)) {
-          db._view(testViewName).properties({
-            links: {
-              [testCol2Name]: {
-                includeAllFields: true,
-                analyzers: ["text_de"]
-              }
-            }
-          }, true);
-
-          assertEqual(rootGetViewProps(testViewName, true)["links"][testCol2Name]["analyzers"],
-                     [db._name() + "::text_de"],
-                     'View link update reported success, but property was not updated');
+          assertEqual(rootGetViewProps(testViewName, true)["links"][testCol1Name]["analyzers"],
+            ["text_de", "text_en"],
+            'View link update reported success, but property was not updated');
         } else {
           try {
+            db._view(testViewName).properties({
+              links: {
+                [testCol1Name]: {
+                  includeAllFields: true,
+                  analyzers: ["text_de","text_en"]
+                }
+              }
+            }, false);
+            assertFail(`${name} was able to update a view with insufficent rights`);
+          } catch (e) {
+            checkError(e);
+          }
+        }
+      };
+
+      suite.testViewByNewLinkToRWCollectionPartial = function() {
+        if (colLevel['ro'].has(name) && colLevel['none'].has(name)) {
+          assertTrue(rootTestView(testViewName), 'Precondition failed, view was not found');
+          rootGrantCollection(testCol2Name, name, 'rw');
+
+          if (dbLevel['rw'].has(name) && colLevel['ro'].has(name)) {
             db._view(testViewName).properties({
               links: {
                 [testCol2Name]: {
@@ -504,23 +482,47 @@ for (name of userSet) {
               }
             }, true);
 
-            assertFail(`${name} was able to update a view with insufficent rights`);
-          } catch (e) {
-            checkError(e);
-            return;
+            assertEqual(rootGetViewProps(testViewName, true)["links"][testCol2Name]["analyzers"],
+              [db._name() + "::text_de"],
+              'View link update reported success, but property was not updated');
+          } else {
+            try {
+              db._view(testViewName).properties({
+                links: {
+                  [testCol2Name]: {
+                    includeAllFields: true,
+                    analyzers: ["text_de"]
+                  }
+                }
+              }, true);
+
+              assertFail(`${name} was able to update a view with insufficent rights`);
+            } catch (e) {
+              checkError(e);
+              return;
+            }
           }
         }
-      }
-    }
-  };
+      };
 
-  jsunity.run(function() {
-    return deriveTestSuiteWithnamespace(
-      UserRightsManagement(name),
-      suite,
-      "_-_" + name
-    );
-  });
+    } else {
+      // specific handling for views of type "search-alias"
+      suite.setUp = function() {
+        rootCreateView(testViewName, testViewType, { indexes: [ { collection: testCol1Name, index: indexName } ] });
+        db._useDatabase(dbName);
+        helper.switchUser('root', dbName);
+      };
+    }
+
+    jsunity.run(function() {
+      return deriveTestSuiteWithnamespace(
+        UserRightsManagement(name),
+        suite,
+        "_-_" + key
+      );
+    });
+  }
+
 }
 
 return jsunity.done();


### PR DESCRIPTION
### Scope & Purpose

Previously, "search-alias" views were visible to users that didn't have read permissions on the underlying referenced collections. This was inconsistent, because "arangosearch" views weren't shown to users that didn't have read permissions on the underlying links. Now, the behavior for "search-alias" views is the same as for "arangosearch" views, i.e. "search-alias" views are not shown and are not accessible for users that don't have at least read permissions on the underlying collections.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: *(Please link PR)*
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

