### PR TITLE
Removing debuggerInfo dereference

### DIFF
--- a/js/client/modules/@arangodb/testutils/crash-utils.js
+++ b/js/client/modules/@arangodb/testutils/crash-utils.js
@@ -596,7 +596,7 @@ function generateCrashDump (binary, instanceInfo, options, checkStr) {
 function aggregateDebugger(instanceInfo, options) {
   print("collecting debugger info for: " + JSON.stringify(instanceInfo.getStructure()));
   if (!instanceInfo.hasOwnProperty('debuggerInfo')) {
-    print("No debugger info persisted to " + instanceInfo.debuggerInfo.getStructure());
+    print("No debugger info persisted to " + instanceInfo.getStructure());
     return false;
   }
   print("waiting for debugger to terminate: " + JSON.stringify(instanceInfo.debuggerInfo));


### PR DESCRIPTION
### Scope & Purpose

This causes some tests to fail.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification