### PR TITLE
JS API: Fix undefined reference and logic of collection.iterate()

### DIFF
--- a/js/common/modules/@arangodb/arango-collection-common.js
+++ b/js/common/modules/@arangodb/arango-collection-common.js
@@ -33,7 +33,6 @@ var arangodb = require('@arangodb');
 
 var ArangoError = arangodb.ArangoError;
 var sprintf = arangodb.sprintf;
-var db = arangodb.db;
 
 var simple = require('@arangodb/simple-query');
 
@@ -322,8 +321,8 @@ ArangoCollection.prototype.iterate = function (iterator, options) {
     if (probability >= 1.0) {
       cursor = this.all();
     }else {
-      stmt = sprintf('FOR d IN %s FILTER rand() >= @prob RETURN d', this.name());
-      stmt = db._createStatement({ query: stmt });
+      stmt = sprintf('FOR d IN %s FILTER rand() <= @prob RETURN d', this.name());
+      stmt = arangodb.db._createStatement({ query: stmt });
 
       if (probability < 1.0) {
         stmt.bind('prob', probability);
@@ -343,9 +342,9 @@ ArangoCollection.prototype.iterate = function (iterator, options) {
     if (probability >= 1.0) {
       cursor = this.all().limit(limit);
     }else {
-      stmt = sprintf('FOR d IN %s FILTER rand() >= @prob LIMIT %d RETURN d',
+      stmt = sprintf('FOR d IN %s FILTER rand() <= @prob LIMIT %d RETURN d',
         this.name(), limit);
-      stmt = db._createStatement({ query: stmt });
+      stmt = arangodb.db._createStatement({ query: stmt });
 
       if (probability < 1.0) {
         stmt.bind('prob', probability);


### PR DESCRIPTION
### Scope & Purpose

To celebrate the **10th anniversary** of this bug, let's fix it so that we can actually show how the `collection.iterate()` method works in the documentation 🎉 

- `db` is undefined despite the `require("@arangodb").db` import
- higher probability values make it less likely to pick a document  (unless it's >= 1.0)

Commit from January 2013 that added the code (and example): https://github.com/arangodb/arangodb/commit/9c87607f461a34e20fd1c62123e107f166b58e3a

- [x] :hankey: Bugfix

### Checklist

I think we can ignore all of the below because no one noticed until Chris found the confusing example in the docs this year.
I manually tested the fix in `arangosh` and `arangod --console`.

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: *(Please link PR)*
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*

#### Related Information

- [x] Docs PR: https://github.com/arangodb/docs/pull/1133
- [ ] Enterprise PR:
- [x] GitHub issue / Jira ticket: https://github.com/arangodb/docs/issues/1119
- [ ] Design document: 

