### PR TITLE
Fix replication of SmartGraph edge collection data

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,12 @@
+v3.10.0 (XXXX-XX-XX)
+--------------------
+
+* Fix encoding and decoding of revision ids in replication of SmartGraph
+  edge collection data using the Merkle tree incremental sync protocol.
+  Previously, the encoding of revision ids could be ambiguous under some
+  circumstances.
+
+
 v3.10.0-rc.1 (2022-09-25)
 -------------------------
 

--- a/arangod/Replication/DatabaseInitialSyncer.cpp
+++ b/arangod/Replication/DatabaseInitialSyncer.cpp
@@ -420,7 +420,13 @@ arangodb::Result fetchRevisions(
         {
           VPackArrayBuilder list(&requestBuilder);
           for (auto const& r : v) {
-            requestBuilder.add(r.toValuePair(ridBuffer));
+            if (encodeAsHLC) {
+              requestBuilder.add(VPackValue(
+                  arangodb::basics::HybridLogicalClock::encodeTimeStamp(
+                      r.id())));
+            } else {
+              requestBuilder.add(r.toValuePair(ridBuffer));
+            }
           }
         }
 

--- a/arangod/Replication/DatabaseInitialSyncer.cpp
+++ b/arangod/Replication/DatabaseInitialSyncer.cpp
@@ -156,7 +156,7 @@ arangodb::Result fetchRevisions(
     arangodb::DatabaseInitialSyncer::Configuration& config,
     arangodb::Syncer::SyncerState& state,
     arangodb::LogicalCollection& collection, std::string const& leader,
-    std::vector<arangodb::RevisionId>& toFetch,
+    bool encodeAsHLC, std::vector<arangodb::RevisionId>& toFetch,
     arangodb::ReplicationMetricsFeature::InitialSyncStats& stats) {
   using arangodb::PhysicalCollection;
   using arangodb::RestReplicationHandler;
@@ -249,6 +249,7 @@ arangodb::Result fetchRevisions(
        config.leader.patchVersion < 1)) {
     queueSize = 1;
   }
+
   while (current < toFetch.size() || !futures.empty()) {
     // Send some requests off if not enough in flight and something to go
     while (futures.size() < queueSize && current < toFetch.size()) {
@@ -259,7 +260,14 @@ arangodb::Result fetchRevisions(
         VPackArrayBuilder list(&requestBuilder);
         std::size_t i;
         for (i = 0; i < 5000 && current + i < toFetch.size(); ++i) {
-          requestBuilder.add(toFetch[current + i].toValuePair(ridBuffer));
+          if (encodeAsHLC) {
+            requestBuilder.add(VPackValue(
+                arangodb::basics::HybridLogicalClock::encodeTimeStamp(
+                    toFetch[current + i].id())));
+          } else {
+            // deprecated, ambiguous format
+            requestBuilder.add(toFetch[current + i].toValuePair(ridBuffer));
+          }
           shoppingList.insert(toFetch[current + i]);
           ++count;
         }
@@ -269,7 +277,8 @@ arangodb::Result fetchRevisions(
       arangodb::network::RequestOptions reqOptions;
       reqOptions.param("collection", leader)
           .param("serverId", state.localServerIdString)
-          .param("batchId", std::to_string(config.batch.id));
+          .param("batchId", std::to_string(config.batch.id))
+          .param("encodeAsHLC", encodeAsHLC ? "true" : "false");
       reqOptions.database = config.vocbase.name();
       reqOptions.timeout = arangodb::network::Timeout(25.0);
       auto buffer = requestBuilder.steal();
@@ -418,7 +427,8 @@ arangodb::Result fetchRevisions(
         arangodb::network::RequestOptions reqOptions;
         reqOptions.param("collection", leader)
             .param("serverId", state.localServerIdString)
-            .param("batchId", std::to_string(config.batch.id));
+            .param("batchId", std::to_string(config.batch.id))
+            .param("encodeAsHLC", encodeAsHLC ? "true" : "false");
         reqOptions.timeout = arangodb::network::Timeout(25.0);
         reqOptions.database = config.vocbase.name();
         auto buffer = requestBuilder.steal();
@@ -1567,9 +1577,25 @@ void DatabaseInitialSyncer::fetchRevisionsChunk(
 
     using ::arangodb::basics::StringUtils::urlEncode;
 
-    // assemble URL to call
+    // assemble URL to call.
+    // note that the URL contains both the "resume" and "resumeHLC" parameters.
+    // "resume" contains the stringified revision id value for where to resume
+    // from. that stringification can be ambiguous and is thus deprecated.
+    // we also send a "resumeHLC" parameter now, which always contains a
+    // base64-encoded logical clock value. this is the preferred way to encode
+    // the resume value, and once all leaders support it, we can remove the
+    // "resume" parameter from the protocol
+    bool appendResumeHLC = true;
     std::string url = baseUrl + "&" + StaticStrings::RevisionTreeResume + "=" +
                       urlEncode(requestResume.toString());
+
+    TRI_IF_FAILURE("SyncerNoEncodeAsHLC") { appendResumeHLC = false; }
+
+    if (appendResumeHLC) {
+      url += "&" + StaticStrings::RevisionTreeResumeHLC + "=" +
+             urlEncode(basics::HybridLogicalClock::encodeTimeStamp(
+                 requestResume.id()));
+    }
 
     bool isVPack = false;
     auto headers = replutils::createHeaders();
@@ -1612,8 +1638,8 @@ void DatabaseInitialSyncer::fetchRevisionsChunk(
   }
 }
 
-/// @brief incrementally fetch data from a collection using keys as the primary
-/// document identifier
+/// @brief incrementally fetch data from a collection using keys as the
+/// primary document identifier
 Result DatabaseInitialSyncer::fetchCollectionSyncByRevisions(
     arangodb::LogicalCollection* coll, std::string const& leaderColl,
     TRI_voc_tick_t maxTick) {
@@ -1793,7 +1819,8 @@ Result DatabaseInitialSyncer::fetchCollectionSyncByRevisions(
   // std::pair<std::size_t, std::size_t> fullRange = treeLeader->range();
   auto treeLocal = physical->revisionTree(*trx);
   if (!treeLocal) {
-    // local collection does not support syncing by revision, fall back to keys
+    // local collection does not support syncing by revision, fall back to
+    // keys
     guard.fire();
     return fetchCollectionSyncByKeys(coll, leaderColl, maxTick);
   }
@@ -1808,8 +1835,26 @@ Result DatabaseInitialSyncer::fetchCollectionSyncByRevisions(
     return Result{};
   }
 
-  // now lets get the actual ranges and handle the differences
+  // encoding revisions as HLC timestamps is supported from the following
+  // versions:
+  // - 3.8.8 or higher
+  // - 3.9.4 or higher
+  // - 3.10.1 or higher
+  // - 3.11.0 or higher
+  // - 4.0 higher
+  bool encodeAsHLC =
+      _config.leader.majorVersion >= 4 ||
+      (_config.leader.majorVersion >= 3 && _config.leader.minorVersion >= 11) ||
+      (_config.leader.majorVersion >= 3 && _config.leader.minorVersion >= 10 &&
+       _config.leader.patchVersion >= 1) ||
+      (_config.leader.majorVersion >= 3 && _config.leader.minorVersion >= 9 &&
+       _config.leader.patchVersion >= 4) ||
+      (_config.leader.majorVersion >= 3 && _config.leader.minorVersion >= 8 &&
+       _config.leader.patchVersion >= 8);
 
+  TRI_IF_FAILURE("SyncerNoEncodeAsHLC") { encodeAsHLC = false; }
+
+  // now lets get the actual ranges and handle the differences
   {
     VPackBuilder requestBuilder;
     {
@@ -2039,7 +2084,7 @@ Result DatabaseInitialSyncer::fetchCollectionSyncByRevisions(
       toRemove.clear();
 
       res = ::fetchRevisions(nf, *trx, _config, _state, *coll, leaderColl,
-                             toFetch, stats);
+                             encodeAsHLC, toFetch, stats);
       if (res.fail()) {
         return res;
       }
@@ -2180,8 +2225,8 @@ Result DatabaseInitialSyncer::handleCollection(VPackSlice const& parameters,
 
   // phase handling
   if (phase == PHASE_VALIDATE) {
-    // validation phase just returns ok if we got here (aborts above if data is
-    // invalid)
+    // validation phase just returns ok if we got here (aborts above if data
+    // is invalid)
     _config.progress.processedCollections.try_emplace(leaderCid, leaderName);
 
     return Result();
@@ -2222,9 +2267,9 @@ Result DatabaseInitialSyncer::handleCollection(VPackSlice const& parameters,
           bool truncate = false;
 
           if (col->name() == StaticStrings::UsersCollection) {
-            // better not throw away the _users collection. otherwise it is gone
-            // and this may be a problem if the
-            // server crashes in-between.
+            // better not throw away the _users collection. otherwise it is
+            // gone and this may be a problem if the server crashes
+            // in-between.
             truncate = true;
           }
 
@@ -2422,8 +2467,9 @@ arangodb::Result DatabaseInitialSyncer::fetchInventory(VPackBuilder& builder) {
     url += "&includeFoxxQueues=true";
   }
 
-  // use an optmization here for shard synchronization: only fetch the inventory
-  // including a single shard. this can greatly reduce the size of the response.
+  // use an optmization here for shard synchronization: only fetch the
+  // inventory including a single shard. this can greatly reduce the size of
+  // the response.
   if (ServerState::instance()->isDBServer() && !_config.isChild() &&
       _config.applier._skipCreateDrop &&
       _config.applier._restrictType ==
@@ -2550,8 +2596,8 @@ Result DatabaseInitialSyncer::handleCollectionsAndViews(
   // STEP 1: validate collection declarations from leader
   // ----------------------------------------------------------------------------------
 
-  // STEP 2: drop and re-create collections locally if they are also present on
-  // the leader
+  // STEP 2: drop and re-create collections locally if they are also present
+  // on the leader
   //  ------------------------------------------------------------------------------------
 
   // iterate over all collections from the leader...

--- a/arangod/Replication/utilities.cpp
+++ b/arangod/Replication/utilities.cpp
@@ -474,7 +474,7 @@ LeaderInfo::LeaderInfo(
     ReplicationApplierConfiguration const& /*applierConfig*/) {}
 
 uint64_t LeaderInfo::version() const {
-  return majorVersion * 10000 + minorVersion * 100;
+  return majorVersion * 10000 + minorVersion * 100 + patchVersion;
 }
 
 /// @brief get leader state

--- a/arangod/RestHandler/RestReplicationHandler.cpp
+++ b/arangod/RestHandler/RestReplicationHandler.cpp
@@ -3063,10 +3063,25 @@ bool RestReplicationHandler::prepareRevisionOperation(
     return false;
   }
 
-  // get resume
-  std::string const& resumeString = _request->value("resume", found);
+  // get resume.
+  // we first try the parameter "resumeHLC" - if set, this will contain a
+  // timestamp-encoded HLC value
+  std::string const& resumeString =
+      _request->value(StaticStrings::RevisionTreeResumeHLC, found);
   if (found) {
-    ctx.resume = RevisionId::fromString(resumeString);
+    // "resumeHLC" is set. use it
+    uint64_t value = HybridLogicalClock::decodeTimeStamp(resumeString);
+    TRI_ASSERT(value != UINT64_MAX);
+    ctx.resume = RevisionId{value};
+  } else {
+    // "resumeHLC" is not set. now fall back to the parameter "resume". this
+    // parameter contains either a numeric value of a timestamp-encoded HLC
+    // value
+    std::string const& resumeString =
+        _request->value(StaticStrings::RevisionTreeResume, found);
+    if (found) {
+      ctx.resume = RevisionId::fromString(resumeString);
+    }
   }
 
   // print request
@@ -3159,8 +3174,8 @@ void RestReplicationHandler::handleCommandRevisionRanges() {
         badFormat = true;
         break;
       }
-      RevisionId left = RevisionId::fromSlice(first);
-      RevisionId right = RevisionId::fromSlice(second);
+      RevisionId left{HybridLogicalClock::decodeTimeStamp(first)};
+      RevisionId right{HybridLogicalClock::decodeTimeStamp(second)};
       if (left == RevisionId::max() || right == RevisionId::max() ||
           left >= right || left < previousRight) {
         badFormat = true;
@@ -3276,6 +3291,14 @@ void RestReplicationHandler::handleCommandRevisionDocuments() {
     return;
   }
 
+  // the "encodeAsHLC" parameter is sent from the following versions onwards:
+  // - 3.8.8 or higher
+  // - 3.9.4 or higher
+  // - 3.10.1 or higher
+  // - 3.11.0 or higher
+  // - 4.0 higher
+  bool encodeAsHLC = _request->parsedValue("encodeAsHLC", false);
+
   bool success = false;
   VPackSlice const body = this->parseVPackBody(success);
   if (!success) {
@@ -3289,7 +3312,15 @@ void RestReplicationHandler::handleCommandRevisionDocuments() {
         badFormat = true;
         break;
       }
-      RevisionId rev = RevisionId::fromSlice(entry);
+      RevisionId rev;
+      if (encodeAsHLC) {
+        uint64_t value =
+            basics::HybridLogicalClock::decodeTimeStamp(entry.stringView());
+        TRI_ASSERT(value != UINT64_MAX);
+        rev = RevisionId{value};
+      } else {
+        rev = RevisionId::fromSlice(entry);
+      }
       if (rev == RevisionId::max()) {
         badFormat = true;
         break;
@@ -3324,7 +3355,15 @@ void RestReplicationHandler::handleCommandRevisionDocuments() {
     VPackArrayBuilder docs(&response);
 
     for (VPackSlice entry : VPackArrayIterator(body)) {
-      RevisionId rev = RevisionId::fromSlice(entry);
+      RevisionId rev;
+      if (encodeAsHLC) {
+        uint64_t value =
+            basics::HybridLogicalClock::decodeTimeStamp(entry.stringView());
+        TRI_ASSERT(value != UINT64_MAX);
+        rev = RevisionId{value};
+      } else {
+        rev = RevisionId::fromSlice(entry);
+      }
       // We assume that the rev is actually present, otherwise it would not
       // have been ordered. But we want this code to work if revisions in
       // the list arrive in some arbitrary order. However, in most cases

--- a/arangod/RestHandler/RestVocbaseBaseHandler.cpp
+++ b/arangod/RestHandler/RestVocbaseBaseHandler.cpp
@@ -530,7 +530,7 @@ RevisionId RestVocbaseBaseHandler::extractRevision(char const* header,
     RevisionId rid = RevisionId::none();
 
     bool isOld;
-    rid = RevisionId::fromString(s, e - s, isOld, false);
+    rid = RevisionId::fromString({s, static_cast<size_t>(e - s)}, isOld, false);
     isValid = (rid.isSet() && rid != RevisionId::max());
 
     return rid;

--- a/arangod/V8Server/v8-util.cpp
+++ b/arangod/V8Server/v8-util.cpp
@@ -175,7 +175,8 @@ bool ExtractDocumentHandle(v8::Isolate* isolate,
     }
     v8::String::Utf8Value str(isolate, revObj);
     bool isOld;
-    RevisionId rid = RevisionId::fromString(*str, str.length(), isOld, false);
+    RevisionId rid = RevisionId::fromString(
+        {*str, static_cast<size_t>(str.length())}, isOld, false);
 
     if (rid.empty()) {
       return false;

--- a/arangod/VocBase/Identifiers/RevisionId.cpp
+++ b/arangod/VocBase/Identifiers/RevisionId.cpp
@@ -38,8 +38,9 @@
 namespace {
 /// @brief Convert a revision ID to a string
 constexpr static arangodb::RevisionId::BaseType TickLimit =
-    static_cast<arangodb::RevisionId::BaseType>(2016ULL - 1970ULL) * 1000ULL *
-    60ULL * 60ULL * 24ULL * 365ULL;
+    (static_cast<arangodb::RevisionId::BaseType>(2016ULL - 1970ULL) * 1000ULL *
+     60ULL * 60ULL * 24ULL * 365ULL)
+    << 20ULL;
 }  // namespace
 
 namespace arangodb {
@@ -56,6 +57,8 @@ RevisionId RevisionId::next() const { return RevisionId{id() + 1}; }
 // @brief get the previous revision id in sequence (this - 1)
 RevisionId RevisionId::previous() const { return RevisionId{id() - 1}; }
 
+/// @brief this method can produce an ambiguous result - do not use it
+/// for future code
 std::string RevisionId::toString() const {
   if (id() <= ::TickLimit) {
     return arangodb::basics::StringUtils::itoa(id());
@@ -67,7 +70,9 @@ std::string RevisionId::toString() const {
 /// the buffer should be at least arangodb::basics::maxUInt64StringSize
 /// bytes long.
 /// the length of the encoded value and the start position into
-/// the result buffer are returned by the function
+/// the result buffer are returned by the function.
+/// this method can produce an ambiguous result - do not use it
+/// for future code
 std::pair<size_t, size_t> RevisionId::toString(char* buffer) const {
   if (id() <= ::TickLimit) {
     std::pair<size_t, size_t> pos{0, 0};
@@ -80,7 +85,9 @@ std::pair<size_t, size_t> RevisionId::toString(char* buffer) const {
 /// encodes the uint64_t timestamp into a temporary velocypack ValuePair,
 /// using the specific temporary result buffer
 /// the result buffer should be at least
-/// arangodb::basics::maxUInt64StringSize bytes long
+/// arangodb::basics::maxUInt64StringSize bytes long.
+/// this method can produce an ambiguous result - do not use it
+/// for future code
 arangodb::velocypack::ValuePair RevisionId::toValuePair(char* buffer) const {
   auto positions = toString(buffer);
   return arangodb::velocypack::ValuePair(&buffer[0] + positions.first,
@@ -107,33 +114,34 @@ RevisionId RevisionId::createClusterWideUnique(ClusterInfo& ci) {
 /// @brief Convert a string into a revision ID, no check variant
 RevisionId RevisionId::fromString(char const* p, size_t len, bool warn) {
   [[maybe_unused]] bool isOld;
-  return fromString(p, len, isOld, warn);
+  return fromString({p, len}, isOld, warn);
 }
 
 /// @brief Convert a string into a revision ID, returns 0 if format invalid
-RevisionId RevisionId::fromString(std::string const& ridStr) {
+RevisionId RevisionId::fromString(std::string_view rid) {
   [[maybe_unused]] bool isOld;
-  return fromString(ridStr.c_str(), ridStr.size(), isOld, false);
+  return fromString(rid, isOld, false);
 }
 
 /// @brief Convert a string into a revision ID, returns 0 if format invalid
-RevisionId RevisionId::fromString(std::string const& ridStr, bool& isOld,
+RevisionId RevisionId::fromString(std::string_view rid, bool& isOld,
                                   bool warn) {
-  return fromString(ridStr.c_str(), ridStr.size(), isOld, warn);
-}
-
-/// @brief Convert a string into a revision ID, returns 0 if format invalid
-RevisionId RevisionId::fromString(char const* p, size_t len, bool& isOld,
-                                  bool warn) {
+  char const* p = rid.data();
+  size_t len = rid.size();
   if (len > 0 && *p >= '1' && *p <= '9') {
-    BaseType r = NumberUtils::atoi_positive_unchecked<BaseType>(p, p + len);
-    if (warn && r > ::TickLimit) {
-      // An old tick value that could be confused with a time stamp
-      LOG_TOPIC("66a3a", WARN, arangodb::Logger::FIXME)
-          << "Saw old _rev value that could be confused with a time stamp!";
+    bool isValid = false;
+    BaseType r = NumberUtils::atoi_positive<BaseType>(p, p + len, isValid);
+    if (isValid) {
+      if (warn && r > ::TickLimit) {
+        // An old tick value that could be confused with a time stamp
+        LOG_TOPIC("66a3a", WARN, arangodb::Logger::FIXME)
+            << "Saw old _rev value that could be confused with a time stamp!";
+      }
+      isOld = true;
+      return RevisionId{r};
     }
-    isOld = true;
-    return RevisionId{r};
+    // value consists not only of numeric digits. now fall through to
+    // the string decoding
   }
   isOld = false;
   return RevisionId{basics::HybridLogicalClock::decodeTimeStamp(p, len)};
@@ -144,22 +152,17 @@ RevisionId RevisionId::fromString(char const* p, size_t len, bool& isOld,
 RevisionId RevisionId::fromSlice(velocypack::Slice slice) {
   slice = slice.resolveExternal();
 
+  if (slice.isObject()) {
+    slice = slice.get(StaticStrings::RevString);
+  }
+
   if (slice.isInteger()) {
     return RevisionId{slice.getNumber<BaseType>()};
-  } else if (slice.isString()) {
+  }
+  if (slice.isString()) {
     velocypack::ValueLength l;
     char const* p = slice.getStringUnchecked(l);
     return fromString(p, l, false);
-  } else if (slice.isObject()) {
-    velocypack::Slice r(slice.get(StaticStrings::RevString));
-    if (r.isString()) {
-      velocypack::ValueLength l;
-      char const* p = r.getStringUnchecked(l);
-      return fromString(p, l, false);
-    }
-    if (r.isInteger()) {
-      return RevisionId{r.getNumber<BaseType>()};
-    }
   }
 
   return RevisionId::none();

--- a/arangod/VocBase/Identifiers/RevisionId.h
+++ b/arangod/VocBase/Identifiers/RevisionId.h
@@ -29,6 +29,9 @@
 #include "Basics/HybridLogicalClock.h"
 #include "Basics/Identifier.h"
 
+#include <cstdint>
+#include <string_view>
+
 namespace arangodb {
 class ClusterInfo;
 class LocalDocumentId;
@@ -52,21 +55,28 @@ class RevisionId final : public arangodb::basics::Identifier {
   // @brief get the previous revision id in sequence (this - 1)
   RevisionId previous() const;
 
-  /// @brief Convert a revision ID to a string
-  std::string toString() const;
+  /// @brief Convert a revision ID to a string.
+  /// this method can produce an ambiguous result - do not use it
+  /// for future code
+  [[deprecated]] std::string toString() const;
 
   /// @brief Convert a revision ID to a string
   /// the buffer should be at least arangodb::basics::maxUInt64StringSize
   /// bytes long
   /// the length of the encoded value and the start position into
-  /// the result buffer are returned
-  std::pair<size_t, size_t> toString(char* buffer) const;
+  /// the result buffer are returned.
+  /// this method can produce an ambiguous result - do not use it
+  /// for future code
+  [[deprecated]] std::pair<size_t, size_t> toString(char* buffer) const;
 
   /// @brief Convert revision ID to a string using the provided buffer,
   /// returning the result as a value pair for convenience
   /// the buffer should be at least arangodb::basics::maxUInt64StringSize
   /// bytes long
-  arangodb::velocypack::ValuePair toValuePair(char* buffer) const;
+  /// this method can produce an ambiguous result - do not use it
+  /// for future code
+  [[deprecated]] arangodb::velocypack::ValuePair toValuePair(
+      char* buffer) const;
 
   /// @brief create a not-set revision id
   static constexpr RevisionId none() { return RevisionId{0}; }
@@ -86,18 +96,13 @@ class RevisionId final : public arangodb::basics::Identifier {
   static RevisionId createClusterWideUnique(ClusterInfo& ci);
 
   /// @brief Convert a string into a revision ID, returns none() if invalid
-  static RevisionId fromString(std::string const& ridStr);
+  static RevisionId fromString(std::string_view rid);
 
   /// @brief Convert a string into a revision ID, returns none() if invalid
-  static RevisionId fromString(std::string const& ridStr, bool& isOld,
-                               bool warn);
+  static RevisionId fromString(std::string_view rid, bool& isOld, bool warn);
 
   /// @brief Convert a string into a revision ID, no check variant
   static RevisionId fromString(char const* p, size_t len, bool warn);
-
-  /// @brief Convert a string into a revision ID, returns none() if invalid
-  static RevisionId fromString(char const* p, size_t len, bool& isOld,
-                               bool warn);
 
   /// @brief extract revision from slice; expects either an integer or string,
   /// or an object with a string or integer _rev attribute

--- a/lib/Basics/HybridLogicalClock.h
+++ b/lib/Basics/HybridLogicalClock.h
@@ -33,9 +33,9 @@
 #include <velocypack/Value.h>
 
 #include "Basics/Common.h"
+#include "Basics/debugging.h"
 
-namespace arangodb {
-namespace basics {
+namespace arangodb::basics {
 
 class HybridLogicalClock {
  public:
@@ -109,13 +109,11 @@ class HybridLogicalClock {
 
   /// encodes the uint64_t timestamp into a new string
   static std::string encodeTimeStamp(uint64_t t) {
-    std::string r(11, '\x00');
-    size_t pos = 11;
-    while (t > 0) {
-      r[--pos] = encodeTable[static_cast<uint8_t>(t & 0x3ful)];
-      t >>= 6;
-    }
-    return r.substr(pos, 11 - pos);
+    // use this temporary buffer for the encoding
+    char buffer[11];
+    auto [pos, length] = encodeTimeStamp(t, &buffer[0]);
+    // return a self-contained std::string with the data
+    return {&buffer[0] + pos, length};
   }
 
   /// encodes the uint64_t timestamp into the provided result buffer
@@ -124,7 +122,9 @@ class HybridLogicalClock {
   /// the result buffer are returned
   static std::pair<size_t, size_t> encodeTimeStamp(uint64_t t, char* r) {
     size_t pos = 11;
+    r[pos - 1] = '\0';
     while (t > 0) {
+      TRI_ASSERT(pos > 0);
       r[--pos] = encodeTable[static_cast<uint8_t>(t & 0x3ful)];
       t >>= 6;
     }
@@ -192,5 +192,5 @@ class HybridLogicalClock {
 
   static signed char decodeTable[256];
 };
-}  // namespace basics
-}  // namespace arangodb
+
+}  // namespace arangodb::basics

--- a/lib/Basics/HybridLogicalClock.h
+++ b/lib/Basics/HybridLogicalClock.h
@@ -27,6 +27,7 @@
 #include <atomic>
 #include <chrono>
 #include <string>
+#include <string_view>
 
 #include <velocypack/Slice.h>
 #include <velocypack/Value.h>
@@ -136,11 +137,11 @@ class HybridLogicalClock {
                                  velocypack::ValueType::String);
   }
 
-  static uint64_t decodeTimeStamp(std::string const& s) {
+  static uint64_t decodeTimeStamp(std::string_view s) {
     return decodeTimeStamp(s.data(), s.size());
   }
 
-  static uint64_t decodeTimeStamp(velocypack::Slice const& s) {
+  static uint64_t decodeTimeStamp(velocypack::Slice s) {
     if (!s.isString()) {
       return std::numeric_limits<std::uint64_t>::max();
     }

--- a/lib/Basics/HybridLogicalClock.h
+++ b/lib/Basics/HybridLogicalClock.h
@@ -122,7 +122,6 @@ class HybridLogicalClock {
   /// the result buffer are returned
   static std::pair<size_t, size_t> encodeTimeStamp(uint64_t t, char* r) {
     size_t pos = 11;
-    r[pos - 1] = '\0';
     while (t > 0) {
       TRI_ASSERT(pos > 0);
       r[--pos] = encodeTable[static_cast<uint8_t>(t & 0x3ful)];

--- a/lib/Basics/StaticStrings.cpp
+++ b/lib/Basics/StaticStrings.cpp
@@ -379,6 +379,7 @@ std::string const StaticStrings::RevisionTreeRangeMin("rangeMin");
 std::string const StaticStrings::RevisionTreeInitialRangeMin("initialRangeMin");
 std::string const StaticStrings::RevisionTreeRanges("ranges");
 std::string const StaticStrings::RevisionTreeResume("resume");
+std::string const StaticStrings::RevisionTreeResumeHLC("resumeHLC");
 std::string const StaticStrings::RevisionTreeVersion("version");
 std::string const StaticStrings::FollowingTermId("followingTermId");
 

--- a/lib/Basics/StaticStrings.h
+++ b/lib/Basics/StaticStrings.h
@@ -352,7 +352,10 @@ class StaticStrings {
   static std::string const RevisionTreeRangeMin;
   static std::string const RevisionTreeInitialRangeMin;
   static std::string const RevisionTreeRanges;
+  // deprecated
   static std::string const RevisionTreeResume;
+
+  static std::string const RevisionTreeResumeHLC;
   static std::string const RevisionTreeVersion;
   static std::string const FollowingTermId;
 

--- a/tests/Basics/HybridLogicalClockTest.cpp
+++ b/tests/Basics/HybridLogicalClockTest.cpp
@@ -1,0 +1,172 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2020 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Jan Steemann
+/// @author Copyright 2012, triAGENS GmbH, Cologne, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+#include "Basics/Common.h"
+
+#include "gtest/gtest.h"
+
+#include "Basics/HybridLogicalClock.h"
+
+#include <velocypack/Builder.h>
+#include <velocypack/Value.h>
+
+#include <cstdint>
+#include <string_view>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+using namespace arangodb;
+
+TEST(HybridLogicalClockTest, test_encode_decode_timestamp) {
+  std::vector<std::pair<uint64_t, std::string_view>> values = {
+      {0ULL, ""},
+      {1ULL, "_"},
+      {2ULL, "A"},
+      {10ULL, "I"},
+      {100ULL, "_i"},
+      {100000ULL, "WYe"},
+      {1000000ULL, "ByH-"},
+      {10000000ULL, "kHY-"},
+      {100000000ULL, "D7cC-"},
+      {1000000000ULL, "5kqm-"},
+      {10000000000ULL, "HSA8O-"},
+      {100000000000ULL, "_bGbse-"},
+      {1000000000000ULL, "MhSnP--"},
+      {10000000000000ULL, "APfMao--"},
+      {100000000000000ULL, "UtKOci--"},
+      {1000000000000000ULL, "BhV4ivm--"},
+      {10000000000000000ULL, "hftHtuO--"},
+      {100000000000000000ULL, "DhPVfbge--"},
+      {1000000000000000000ULL, "1erpMlX---"},
+      {10000000000000000000ULL, "GpFGuQH4---"},
+      {18446744073709551614ULL, "N9999999998"},
+      {18446744073709551615ULL, "N9999999999"},
+  };
+
+  velocypack::Builder b;
+
+  for (auto const& value : values) {
+    // encode
+    std::string encoded =
+        basics::HybridLogicalClock::encodeTimeStamp(value.first);
+    ASSERT_EQ(value.second, encoded);
+
+    // encode into a buffer using a velocypack::ValuePair
+    char buffer[11];
+    b.clear();
+    b.add(basics::HybridLogicalClock::encodeTimeStampToValuePair(value.first,
+                                                                 &buffer[0]));
+    ASSERT_EQ(value.first,
+              basics::HybridLogicalClock::decodeTimeStamp(b.slice()));
+
+    // decode
+    ASSERT_EQ(value.first,
+              basics::HybridLogicalClock::decodeTimeStamp(encoded));
+
+    // decode from velocypack string
+    b.clear();
+    b.add(VPackValue(value.second));
+    ASSERT_EQ(value.first,
+              basics::HybridLogicalClock::decodeTimeStamp(b.slice()));
+  }
+}
+
+TEST(HybridLogicalClockTest, test_decode_invalid) {
+  std::vector<std::pair<uint64_t, std::string_view>> values = {
+      {0ULL, ""},
+      {UINT64_MAX, " "},
+      {51ULL, "x"},
+      {869219571ULL, "xxxxx"},
+      {UINT64_MAX, "xxxxxxxxxxxxxxxxxxxxxxxxxxxx"},
+      {UINT64_MAX, "N9999999999"},
+      {17813666640376327606ULL, "Na000000000"},
+      {988218432520154550ULL, "O0000000000"},
+  };
+
+  for (auto const& value : values) {
+    uint64_t decoded =
+        basics::HybridLogicalClock::decodeTimeStamp(std::string(value.second));
+    ASSERT_EQ(value.first, decoded);
+  }
+}
+
+TEST(HybridLogicalClockTest, test_extract_time_and_count) {
+  std::vector<std::tuple<uint64_t, uint64_t, uint64_t>> values = {
+      {0ULL, 0ULL, 0ULL},
+      {1ULL, 0ULL, 1ULL},
+      {2ULL, 0ULL, 2ULL},
+      {10ULL, 0ULL, 10ULL},
+      {100ULL, 0ULL, 100ULL},
+      {100000ULL, 0ULL, 100000ULL},
+      {1000000ULL, 0ULL, 1000000ULL},
+      {10000000ULL, 9ULL, 562816ULL},
+      {100000000ULL, 95ULL, 385280ULL},
+      {1000000000ULL, 953ULL, 707072ULL},
+      {10000000000ULL, 9536ULL, 779264ULL},
+      {100000000000ULL, 95367ULL, 452608ULL},
+      {1000000000000ULL, 953674ULL, 331776ULL},
+      {10000000000000ULL, 9536743ULL, 172032ULL},
+      {100000000000000ULL, 95367431ULL, 671744ULL},
+      {1000000000000000ULL, 953674316ULL, 425984ULL},
+      {10000000000000000ULL, 9536743164ULL, 65536ULL},
+      {100000000000000000ULL, 95367431640ULL, 655360ULL},
+      {1000000000000000000ULL, 953674316406ULL, 262144ULL},
+      {10000000000000000000ULL, 9536743164062ULL, 524288ULL},
+      {18446744073709551614ULL, 17592186044415ULL, 1048574ULL},
+      {18446744073709551615ULL, 17592186044415ULL, 1048575ULL},
+  };
+
+  for (auto const& it : values) {
+    uint64_t timePart =
+        basics::HybridLogicalClock::extractTime(std::get<0>(it));
+    ASSERT_EQ(std::get<1>(it), timePart);
+
+    uint64_t countPart =
+        basics::HybridLogicalClock::extractCount(std::get<0>(it));
+    ASSERT_EQ(std::get<2>(it), countPart);
+
+    ASSERT_EQ(std::get<0>(it), basics::HybridLogicalClock::assembleTimeStamp(
+                                   timePart, countPart));
+  }
+}
+
+TEST(HybridLogicalClockTest, test_get_timestamp) {
+  // arbitrary timestamp from Sep 30, 2022, that is supposed to
+  // be in the past whenever this test runs
+  constexpr uint64_t dateInThePast = 1664561862434ULL;
+
+  basics::HybridLogicalClock hlc;
+
+  uint64_t initial = hlc.getTimeStamp();
+
+  for (size_t i = 0; i < 4'000'000; ++i) {
+    uint64_t stamp = hlc.getTimeStamp();
+    // every stamp generated must be >= than current time
+    ASSERT_GT(stamp, dateInThePast);
+    // stamps must be increasing
+    ASSERT_GT(stamp, initial);
+    initial = stamp;
+  }
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -179,6 +179,7 @@ set(ARANGODB_TESTS_SOURCES
   Basics/FilesTest.cpp
   Basics/FpConvTest.cpp
   Basics/HashesTest.cpp
+  Basics/HybridLogicalClockTest.cpp
   Basics/OverloadTest.cpp
   Basics/PriorityQueueTest.cpp
   Basics/StringBufferTest.cpp

--- a/tests/js/server/replication/sync/replication-sync-malarkey.js
+++ b/tests/js/server/replication/sync/replication-sync-malarkey.js
@@ -1411,12 +1411,36 @@ function ReplicationIncrementalMalarkeyNewFormatIntermediateCommits() {
   return suite;
 }
 
+function ReplicationIncrementalMalarkeyNoHLC() {
+  'use strict';
+
+  let suite = {
+    setUp: function () {
+      connectToFollower();
+      // clear all failure points except the one that will lead to the follower
+      // sending requests without forced HLCs
+      clearFailurePoints();
+      setFailurePoint("SyncerNoEncodeAsHLC");
+      db._drop(cn);
+
+      connectToLeader();
+      // clear all failure points
+      clearFailurePoints();
+      db._drop(cn);
+    },
+  };
+
+  deriveTestSuite(BaseTestConfig(), suite, '_NoHLC');
+  return suite;
+}
+
 let res = arango.GET("/_admin/debug/failat");
 if (res === true) {
   // tests only work when compiled with -DUSE_FAILURE_TESTS
   jsunity.run(ReplicationIncrementalMalarkeyOldFormat);
   jsunity.run(ReplicationIncrementalMalarkeyNewFormat);
   jsunity.run(ReplicationIncrementalMalarkeyNewFormatIntermediateCommits);
+  jsunity.run(ReplicationIncrementalMalarkeyNoHLC);
 }
 
 return jsunity.done();


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/17243

Fix replication of SmartGraph edge collection data
    
Fix encoding and decoding of revision ids in replication of SmartGraph edge collection data using the Merkle tree incremental sync protocol. Previously, the encoding of revision ids could be ambiguous under some circumstances.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [x] Backports
  - [x] Backport for 3.10: this PR
  - [x] Backport for 3.9: https://github.com/arangodb/arangodb/pull/17252
  - [x] Backport for 3.8: https://github.com/arangodb/arangodb/pull/17253

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 