### PR TITLE
Fix replication of SmartGraph edge collection data

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,11 @@
 v3.8.8 (XXXX-XX-XX)
 -------------------
 
+* Fix encoding and decoding of revision ids in replication of SmartGraph
+  edge collection data using the Merkle tree incremental sync protocol.
+  Previously, the encoding of revision ids could be ambiguous under some
+  circumstances.
+
 * Fix an issue with replication of arangosearch view change entries in single
   server replication and active failover. Previously, when changing the
   properties of existing views, the changes were not properly picked up by

--- a/arangod/Replication/utilities.cpp
+++ b/arangod/Replication/utilities.cpp
@@ -129,19 +129,18 @@ arangodb::Result handleLeaderStateResponse(arangodb::replutils::Connection const
   }
 
   std::string const versionString(version.copyString());
-  auto v = arangodb::rest::Version::parseVersionString(versionString);
-  int major = v.first;
-  int minor = v.second;
+  auto v = arangodb::rest::Version::parseFullVersionString(versionString);
 
-  if (major != 3) {
+  if (v.major != 3) {
     // we can connect to 3.x only
     return Result(TRI_ERROR_REPLICATION_LEADER_INCOMPATIBLE,
                   std::string("got incompatible leader version") +
                       endpointString + ": '" + versionString + "'");
   }
-
-  leader.majorVersion = major;
-  leader.minorVersion = minor;
+  
+  leader.majorVersion = v.major;
+  leader.minorVersion = v.minor;
+  leader.patchVersion = v.patch;
   leader.serverId = leaderId;
   leader.lastLogTick = lastLogTick;
 

--- a/arangod/Replication/utilities.cpp
+++ b/arangod/Replication/utilities.cpp
@@ -444,7 +444,7 @@ LeaderInfo::LeaderInfo(ReplicationApplierConfiguration const& applierConfig) {
 }
 
 uint64_t LeaderInfo::version() const {
-  return majorVersion * 10000 + minorVersion * 100;
+  return majorVersion * 10000 + minorVersion * 100 + patchVersion;
 }
 
 /// @brief get leader state

--- a/arangod/Replication/utilities.h
+++ b/arangod/Replication/utilities.h
@@ -132,6 +132,7 @@ struct LeaderInfo {
   ServerId serverId{0};
   int majorVersion{0};
   int minorVersion{0};
+  int patchVersion{0};
   TRI_voc_tick_t lastLogTick{0}; // only used during initialSync
 
   explicit LeaderInfo(ReplicationApplierConfiguration const& applierConfig);

--- a/arangod/RestHandler/RestVocbaseBaseHandler.cpp
+++ b/arangod/RestHandler/RestVocbaseBaseHandler.cpp
@@ -550,7 +550,7 @@ RevisionId RestVocbaseBaseHandler::extractRevision(char const* header, bool& isV
     RevisionId rid = RevisionId::none();
 
     bool isOld;
-    rid = RevisionId::fromString(s, e - s, isOld, false);
+    rid = RevisionId::fromString({s, static_cast<size_t>(e - s)}, isOld, false);
     isValid = (rid.isSet() && rid != RevisionId::max());
 
     return rid;

--- a/arangod/V8Server/v8-util.cpp
+++ b/arangod/V8Server/v8-util.cpp
@@ -167,7 +167,8 @@ bool ExtractDocumentHandle(v8::Isolate* isolate, v8::Handle<v8::Value> const val
     }
     v8::String::Utf8Value str(isolate, revObj);
     bool isOld;
-    RevisionId rid = RevisionId::fromString(*str, str.length(), isOld, false);
+    RevisionId rid = RevisionId::fromString(
+        {*str, static_cast<size_t>(str.length())}, isOld, false);
 
     if (rid.empty()) {
       return false;

--- a/arangod/VocBase/Identifiers/RevisionId.h
+++ b/arangod/VocBase/Identifiers/RevisionId.h
@@ -31,6 +31,9 @@
 #include "Basics/HybridLogicalClock.h"
 #include "Basics/Identifier.h"
 
+#include <cstdint>
+#include <string_view>
+
 namespace arangodb {
 class ClusterInfo;
 class LocalDocumentId;
@@ -54,21 +57,28 @@ class RevisionId : public arangodb::basics::Identifier {
   // @brief get the previous revision id in sequence (this - 1)
   RevisionId previous() const;
 
-  /// @brief Convert a revision ID to a string
-  std::string toString() const;
+  /// @brief Convert a revision ID to a string.
+  /// this method can produce an ambiguous result - do not use it
+  /// for future code
+  [[deprecated]] std::string toString() const;
 
   /// @brief Convert a revision ID to a string
   /// the buffer should be at least arangodb::basics::maxUInt64StringSize
   /// bytes long
   /// the length of the encoded value and the start position into
-  /// the result buffer are returned
-  std::pair<size_t, size_t> toString(char* buffer) const;
+  /// the result buffer are returned.
+  /// this method can produce an ambiguous result - do not use it
+  /// for future code
+  [[deprecated]] std::pair<size_t, size_t> toString(char* buffer) const;
 
   /// @brief Convert revision ID to a string using the provided buffer,
   /// returning the result as a value pair for convenience
   /// the buffer should be at least arangodb::basics::maxUInt64StringSize
   /// bytes long
-  arangodb::velocypack::ValuePair toValuePair(char* buffer) const;
+  /// this method can produce an ambiguous result - do not use it
+  /// for future code
+  [[deprecated]] arangodb::velocypack::ValuePair toValuePair(
+      char* buffer) const;
 
   /// @brief Write revision ID to string for storage with correct endianness
   void toPersistent(std::string& buffer) const;
@@ -92,20 +102,17 @@ class RevisionId : public arangodb::basics::Identifier {
   static RevisionId createClusterWideUnique(ClusterInfo& ci);
 
   /// @brief Convert a string into a revision ID, returns none() if invalid
-  static RevisionId fromString(std::string const& ridStr);
+  static RevisionId fromString(std::string_view rid);
 
   /// @brief Convert a string into a revision ID, returns none() if invalid
-  static RevisionId fromString(std::string const& ridStr, bool& isOld, bool warn);
+  static RevisionId fromString(std::string_view rid, bool& isOld, bool warn);
 
   /// @brief Convert a string into a revision ID, no check variant
   static RevisionId fromString(char const* p, size_t len, bool warn);
 
-  /// @brief Convert a string into a revision ID, returns none() if invalid
-  static RevisionId fromString(char const* p, size_t len, bool& isOld, bool warn);
-
   /// @brief extract revision from slice; expects either an integer or string,
   /// or an object with a string or integer _rev attribute
-  static RevisionId fromSlice(velocypack::Slice const slice);
+  static RevisionId fromSlice(velocypack::Slice slice);
 
   /// @brief extract revision from persistent storage (proper endianness)
   static RevisionId fromPersistent(char const* data);

--- a/lib/Basics/HybridLogicalClock.h
+++ b/lib/Basics/HybridLogicalClock.h
@@ -28,6 +28,7 @@
 #include <atomic>
 #include <chrono>
 #include <string>
+#include <string_view>
 
 #include <velocypack/Slice.h>
 #include <velocypack/Value.h>
@@ -132,11 +133,11 @@ class HybridLogicalClock {
     return velocypack::ValuePair(&r[0] + p.first, p.second, velocypack::ValueType::String);
   }
 
-  static uint64_t decodeTimeStamp(std::string const& s) {
+  static uint64_t decodeTimeStamp(std::string_view s) {
     return decodeTimeStamp(s.data(), s.size());
   }
 
-  static uint64_t decodeTimeStamp(velocypack::Slice const& s) {
+  static uint64_t decodeTimeStamp(velocypack::Slice s) {
     if (!s.isString()) {
       return std::numeric_limits<std::uint64_t>::max();
     }

--- a/lib/Basics/HybridLogicalClock.h
+++ b/lib/Basics/HybridLogicalClock.h
@@ -120,7 +120,6 @@ class HybridLogicalClock {
   /// the result buffer are returned
   static std::pair<size_t, size_t> encodeTimeStamp(uint64_t t, char* r) {
     size_t pos = 11;
-    r[pos - 1] = '\0';
     while (t > 0) {
       TRI_ASSERT(pos > 0);
       r[--pos] = encodeTable[static_cast<uint8_t>(t & 0x3ful)];

--- a/lib/Basics/StaticStrings.cpp
+++ b/lib/Basics/StaticStrings.cpp
@@ -334,6 +334,7 @@ std::string const StaticStrings::RevisionTreeRangeMin("rangeMin");
 std::string const StaticStrings::RevisionTreeInitialRangeMin("initialRangeMin");
 std::string const StaticStrings::RevisionTreeRanges("ranges");
 std::string const StaticStrings::RevisionTreeResume("resume");
+std::string const StaticStrings::RevisionTreeResumeHLC("resumeHLC");
 std::string const StaticStrings::RevisionTreeVersion("version");
 std::string const StaticStrings::FollowingTermId("followingTermId");
 

--- a/lib/Basics/StaticStrings.h
+++ b/lib/Basics/StaticStrings.h
@@ -312,7 +312,10 @@ class StaticStrings {
   static std::string const RevisionTreeRangeMin;
   static std::string const RevisionTreeInitialRangeMin;
   static std::string const RevisionTreeRanges;
+  // deprecated
   static std::string const RevisionTreeResume;
+
+  static std::string const RevisionTreeResumeHLC;
   static std::string const RevisionTreeVersion;
   static std::string const FollowingTermId;
 

--- a/lib/Rest/Version.cpp
+++ b/lib/Rest/Version.cpp
@@ -84,6 +84,53 @@ std::pair<int, int> Version::parseVersionString(std::string const& str) {
   return result;
 }
 
+/// parse a full version string into major, minor, patch
+/// returns -1, -1, -1 when the version string has an invalid format
+/// returns major, -1, -1 when only the major version can be determined,
+/// returns major, minor, -1 when only the major and minor version can be
+/// determined.
+FullVersion Version::parseFullVersionString(std::string const& str) {
+  FullVersion result{-1, -1, -1};
+  int tmp;
+
+  if (!str.empty()) {
+    char const* p = str.c_str();
+    char const* q = p;
+    tmp = 0;
+    while (*q >= '0' && *q <= '9') {
+      tmp = tmp * 10 + *q++ - '0';
+    }
+    if (p != q) {
+      result.major = tmp;
+      tmp = 0;
+
+      if (*q == '.') {
+        ++q;
+      }
+      p = q;
+      while (*q >= '0' && *q <= '9') {
+        tmp = tmp * 10 + *q++ - '0';
+      }
+      if (p != q) {
+        result.minor = tmp;
+        tmp = 0;
+        if (*q == '.') {
+          ++q;
+        }
+        p = q;
+        while (*q >= '0' && *q <= '9') {
+          tmp = tmp * 10 + *q++ - '0';
+        }
+        if (p != q) {
+          result.patch = tmp;
+        }
+      }
+    }
+  }
+
+  return result;
+}
+
 /// @brief initialize
 void Version::initialize() {
   if (!Values.empty()) {

--- a/lib/Rest/Version.h
+++ b/lib/Rest/Version.h
@@ -77,6 +77,12 @@ class Builder;
 
 namespace rest {
 
+struct FullVersion {
+  int major;
+  int minor;
+  int patch;
+};
+
 class Version {
  private:
   /// @brief create the version information
@@ -88,6 +94,13 @@ class Version {
   /// @brief parse a version string into major, minor
   /// returns -1, -1 when the version string has an invalid format
   static std::pair<int, int> parseVersionString(std::string const&);
+  
+  // parse a full version string into major, minor, patch
+  /// returns -1, -1, -1 when the version string has an invalid format
+  /// returns major, -1, -1 when only the major version can be determined,
+  /// returns major, minor, -1 when only the major and minor version can be
+  /// determined.
+  static FullVersion parseFullVersionString(std::string const&);
 
   /// @brief initialize
   static void initialize();

--- a/tests/Basics/HybridLogicalClockTest.cpp
+++ b/tests/Basics/HybridLogicalClockTest.cpp
@@ -1,0 +1,172 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2020 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Jan Steemann
+/// @author Copyright 2012, triAGENS GmbH, Cologne, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+#include "Basics/Common.h"
+
+#include "gtest/gtest.h"
+
+#include "Basics/HybridLogicalClock.h"
+
+#include <velocypack/Builder.h>
+#include <velocypack/Value.h>
+
+#include <cstdint>
+#include <string_view>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+using namespace arangodb;
+
+TEST(HybridLogicalClockTest, test_encode_decode_timestamp) {
+  std::vector<std::pair<uint64_t, std::string_view>> values = {
+      {0ULL, ""},
+      {1ULL, "_"},
+      {2ULL, "A"},
+      {10ULL, "I"},
+      {100ULL, "_i"},
+      {100000ULL, "WYe"},
+      {1000000ULL, "ByH-"},
+      {10000000ULL, "kHY-"},
+      {100000000ULL, "D7cC-"},
+      {1000000000ULL, "5kqm-"},
+      {10000000000ULL, "HSA8O-"},
+      {100000000000ULL, "_bGbse-"},
+      {1000000000000ULL, "MhSnP--"},
+      {10000000000000ULL, "APfMao--"},
+      {100000000000000ULL, "UtKOci--"},
+      {1000000000000000ULL, "BhV4ivm--"},
+      {10000000000000000ULL, "hftHtuO--"},
+      {100000000000000000ULL, "DhPVfbge--"},
+      {1000000000000000000ULL, "1erpMlX---"},
+      {10000000000000000000ULL, "GpFGuQH4---"},
+      {18446744073709551614ULL, "N9999999998"},
+      {18446744073709551615ULL, "N9999999999"},
+  };
+
+  velocypack::Builder b;
+
+  for (auto const& value : values) {
+    // encode
+    std::string encoded =
+        basics::HybridLogicalClock::encodeTimeStamp(value.first);
+    ASSERT_EQ(value.second, encoded);
+
+    // encode into a buffer using a velocypack::ValuePair
+    char buffer[11];
+    b.clear();
+    b.add(basics::HybridLogicalClock::encodeTimeStampToValuePair(value.first,
+                                                                 &buffer[0]));
+    ASSERT_EQ(value.first,
+              basics::HybridLogicalClock::decodeTimeStamp(b.slice()));
+
+    // decode
+    ASSERT_EQ(value.first,
+              basics::HybridLogicalClock::decodeTimeStamp(encoded));
+
+    // decode from velocypack string
+    b.clear();
+    b.add(velocypack::Value(value.second));
+    ASSERT_EQ(value.first,
+              basics::HybridLogicalClock::decodeTimeStamp(b.slice()));
+  }
+}
+
+TEST(HybridLogicalClockTest, test_decode_invalid) {
+  std::vector<std::pair<uint64_t, std::string_view>> values = {
+      {0ULL, ""},
+      {UINT64_MAX, " "},
+      {51ULL, "x"},
+      {869219571ULL, "xxxxx"},
+      {UINT64_MAX, "xxxxxxxxxxxxxxxxxxxxxxxxxxxx"},
+      {UINT64_MAX, "N9999999999"},
+      {17813666640376327606ULL, "Na000000000"},
+      {988218432520154550ULL, "O0000000000"},
+  };
+
+  for (auto const& value : values) {
+    uint64_t decoded =
+        basics::HybridLogicalClock::decodeTimeStamp(std::string(value.second));
+    ASSERT_EQ(value.first, decoded);
+  }
+}
+
+TEST(HybridLogicalClockTest, test_extract_time_and_count) {
+  std::vector<std::tuple<uint64_t, uint64_t, uint64_t>> values = {
+      {0ULL, 0ULL, 0ULL},
+      {1ULL, 0ULL, 1ULL},
+      {2ULL, 0ULL, 2ULL},
+      {10ULL, 0ULL, 10ULL},
+      {100ULL, 0ULL, 100ULL},
+      {100000ULL, 0ULL, 100000ULL},
+      {1000000ULL, 0ULL, 1000000ULL},
+      {10000000ULL, 9ULL, 562816ULL},
+      {100000000ULL, 95ULL, 385280ULL},
+      {1000000000ULL, 953ULL, 707072ULL},
+      {10000000000ULL, 9536ULL, 779264ULL},
+      {100000000000ULL, 95367ULL, 452608ULL},
+      {1000000000000ULL, 953674ULL, 331776ULL},
+      {10000000000000ULL, 9536743ULL, 172032ULL},
+      {100000000000000ULL, 95367431ULL, 671744ULL},
+      {1000000000000000ULL, 953674316ULL, 425984ULL},
+      {10000000000000000ULL, 9536743164ULL, 65536ULL},
+      {100000000000000000ULL, 95367431640ULL, 655360ULL},
+      {1000000000000000000ULL, 953674316406ULL, 262144ULL},
+      {10000000000000000000ULL, 9536743164062ULL, 524288ULL},
+      {18446744073709551614ULL, 17592186044415ULL, 1048574ULL},
+      {18446744073709551615ULL, 17592186044415ULL, 1048575ULL},
+  };
+
+  for (auto const& it : values) {
+    uint64_t timePart =
+        basics::HybridLogicalClock::extractTime(std::get<0>(it));
+    ASSERT_EQ(std::get<1>(it), timePart);
+
+    uint64_t countPart =
+        basics::HybridLogicalClock::extractCount(std::get<0>(it));
+    ASSERT_EQ(std::get<2>(it), countPart);
+
+    ASSERT_EQ(std::get<0>(it), basics::HybridLogicalClock::assembleTimeStamp(
+                                   timePart, countPart));
+  }
+}
+
+TEST(HybridLogicalClockTest, test_get_timestamp) {
+  // arbitrary timestamp from Sep 30, 2022, that is supposed to
+  // be in the past whenever this test runs
+  constexpr uint64_t dateInThePast = 1664561862434ULL;
+
+  basics::HybridLogicalClock hlc;
+
+  uint64_t initial = hlc.getTimeStamp();
+
+  for (size_t i = 0; i < 4'000'000; ++i) {
+    uint64_t stamp = hlc.getTimeStamp();
+    // every stamp generated must be >= than current time
+    ASSERT_GT(stamp, dateInThePast);
+    // stamps must be increasing
+    ASSERT_GT(stamp, initial);
+    initial = stamp;
+  }
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -180,6 +180,7 @@ set(ARANGODB_TESTS_SOURCES
   Basics/CpuUsageSnapshotTest.cpp
   Basics/EndpointTest.cpp
   Basics/FixedSizeAllocatorTest.cpp
+  Basics/HybridLogicalClockTest.cpp
   Basics/InifileParserTest.cpp
   Basics/LoggerTest.cpp
   Basics/MemoryUsageTest.cpp

--- a/tests/js/server/replication/sync/replication-sync-malarkey.js
+++ b/tests/js/server/replication/sync/replication-sync-malarkey.js
@@ -1409,12 +1409,36 @@ function ReplicationIncrementalMalarkeyNewFormatIntermediateCommits() {
   return suite;
 }
 
+function ReplicationIncrementalMalarkeyNoHLC() {
+  'use strict';
+
+  let suite = {
+    setUp: function () {
+      connectToFollower();
+      // clear all failure points except the one that will lead to the follower
+      // sending requests without forced HLCs
+      clearFailurePoints();
+      setFailurePoint("SyncerNoEncodeAsHLC");
+      db._drop(cn);
+
+      connectToLeader();
+      // clear all failure points
+      clearFailurePoints();
+      db._drop(cn);
+    },
+  };
+
+  deriveTestSuite(BaseTestConfig(), suite, '_NoHLC');
+  return suite;
+}
+
 let res = arango.GET("/_admin/debug/failat");
 if (res === true) {
   // tests only work when compiled with -DUSE_FAILURE_TESTS
   jsunity.run(ReplicationIncrementalMalarkeyOldFormat);
   jsunity.run(ReplicationIncrementalMalarkeyNewFormat);
   jsunity.run(ReplicationIncrementalMalarkeyNewFormatIntermediateCommits);
+  jsunity.run(ReplicationIncrementalMalarkeyNoHLC);
 }
 
 return jsunity.done();


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/17243

Fix replication of SmartGraph edge collection data
    
Fix encoding and decoding of revision ids in replication of SmartGraph edge collection data using the Merkle tree incremental sync protocol. Previously, the encoding of revision ids could be ambiguous under some circumstances.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [x] Backports
  - [x] Backport for 3.10: https://github.com/arangodb/arangodb/pull/17251
  - [x] Backport for 3.9: https://github.com/arangodb/arangodb/pull/17252
  - [x] Backport for 3.8: this PR

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 