### PR TITLE
log reason for rocksdb flushes

### DIFF
--- a/arangod/RocksDBEngine/Listeners/RocksDBMetricsListener.cpp
+++ b/arangod/RocksDBEngine/Listeners/RocksDBMetricsListener.cpp
@@ -99,7 +99,7 @@ void RocksDBMetricsListener::OnStallConditionsChanged(
 
 void RocksDBMetricsListener::handleFlush(
     std::string_view phase, rocksdb::FlushJobInfo const& info) const {
-  auto buildReason = [](auto const& info) {
+  auto buildReason = [](auto const& info) noexcept {
     std::string_view reason = "unknown";
 
     switch (info.flush_reason) {
@@ -156,7 +156,7 @@ void RocksDBMetricsListener::handleFlush(
 
 void RocksDBMetricsListener::handleCompaction(
     std::string_view phase, rocksdb::CompactionJobInfo const& info) const {
-  auto buildReason = [](auto const& info) {
+  auto buildReason = [](auto const& info) noexcept {
     std::string_view reason = "unknown";
 
     switch (info.compaction_reason) {

--- a/arangod/RocksDBEngine/Listeners/RocksDBMetricsListener.cpp
+++ b/arangod/RocksDBEngine/Listeners/RocksDBMetricsListener.cpp
@@ -44,6 +44,16 @@ RocksDBMetricsListener::RocksDBMetricsListener(ArangodServer& server)
       _writeStops(server.getFeature<metrics::MetricsFeature>().add(
           arangodb_rocksdb_write_stops_total{})) {}
 
+void RocksDBMetricsListener::OnFlushBegin(rocksdb::DB*,
+                                          rocksdb::FlushJobInfo const& info) {
+  handleFlush("begin", info);
+}
+
+void RocksDBMetricsListener::OnFlushCompleted(
+    rocksdb::DB*, rocksdb::FlushJobInfo const& info) {
+  handleFlush("completed", info);
+}
+
 void RocksDBMetricsListener::OnCompactionBegin(
     rocksdb::DB*, rocksdb::CompactionJobInfo const& info) {
   handleCompaction("begin", info);
@@ -85,6 +95,63 @@ void RocksDBMetricsListener::OnStallConditionsChanged(
           << info.cf_name << "'";
     }
   }
+}
+
+void RocksDBMetricsListener::handleFlush(
+    std::string_view phase, rocksdb::FlushJobInfo const& info) const {
+  auto buildReason = [](auto const& info) {
+    std::string_view reason = "unknown";
+
+    switch (info.flush_reason) {
+      case rocksdb::FlushReason::kOthers:
+        reason = "others";
+        break;
+      case rocksdb::FlushReason::kGetLiveFiles:
+        reason = "GetLiveFiles";
+        break;
+      case rocksdb::FlushReason::kShutDown:
+        reason = "shutdown";
+        break;
+      case rocksdb::FlushReason::kExternalFileIngestion:
+        reason = "external file ingestion";
+        break;
+      case rocksdb::FlushReason::kManualCompaction:
+        reason = "manual compaction";
+        break;
+      case rocksdb::FlushReason::kWriteBufferManager:
+        reason = "WriteBufferManager";
+        break;
+      case rocksdb::FlushReason::kWriteBufferFull:
+        reason = "WriteBuffer full";
+        break;
+      case rocksdb::FlushReason::kDeleteFiles:
+        reason = "DeleteFiles";
+        break;
+      case rocksdb::FlushReason::kAutoCompaction:
+        reason = "auto compaction";
+        break;
+      case rocksdb::FlushReason::kManualFlush:
+        reason = "manual flush";
+        break;
+      case rocksdb::FlushReason::kErrorRecovery:
+      case rocksdb::FlushReason::kErrorRecoveryRetryFlush:
+        reason = "error recovery";
+        break;
+      case rocksdb::FlushReason::kWalFull:
+        reason = "WAL full";
+        break;
+      default:
+        break;
+    }
+
+    TRI_ASSERT(!reason.empty());
+
+    return reason;
+  };
+
+  LOG_TOPIC("33d1f", DEBUG, Logger::ENGINES)
+      << "rocksdb flush " << phase << " in column family " << info.cf_name
+      << ", reason: " << buildReason(info);
 }
 
 void RocksDBMetricsListener::handleCompaction(

--- a/arangod/RocksDBEngine/Listeners/RocksDBMetricsListener.h
+++ b/arangod/RocksDBEngine/Listeners/RocksDBMetricsListener.h
@@ -34,6 +34,7 @@
 namespace rocksdb {
 struct CompactionJobInfo;
 class DB;
+struct FlushJobInfo;
 }  // namespace rocksdb
 
 namespace arangodb {
@@ -47,6 +48,10 @@ class RocksDBMetricsListener : public rocksdb::EventListener {
  public:
   explicit RocksDBMetricsListener(ArangodServer&);
 
+  void OnFlushBegin(rocksdb::DB*, rocksdb::FlushJobInfo const& info) override;
+  void OnFlushCompleted(rocksdb::DB*,
+                        rocksdb::FlushJobInfo const& info) override;
+
   void OnCompactionBegin(rocksdb::DB*,
                          rocksdb::CompactionJobInfo const&) override;
   void OnCompactionCompleted(rocksdb::DB*,
@@ -54,6 +59,9 @@ class RocksDBMetricsListener : public rocksdb::EventListener {
   void OnStallConditionsChanged(rocksdb::WriteStallInfo const& info) override;
 
  private:
+  void handleFlush(std::string_view phase,
+                   rocksdb::FlushJobInfo const& info) const;
+
   void handleCompaction(std::string_view phase,
                         rocksdb::CompactionJobInfo const& info) const;
 


### PR DESCRIPTION
### Scope & Purpose

Log reason for RocksDB flushes to ArangoDB log file

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: *(Please link PR)*
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 