### PR TITLE
Disable replication1 specific test for replication2

### DIFF
--- a/tests/js/client/shell/shell-following-term-id-cluster.js
+++ b/tests/js/client/shell/shell-following-term-id-cluster.js
@@ -239,5 +239,7 @@ function followingTermIdSuite() {
   };
 }
 
-jsunity.run(followingTermIdSuite);
+if (db._properties().replicationVersion !== "2") {
+  jsunity.run(followingTermIdSuite);
+}
 return jsunity.done();


### PR DESCRIPTION
### Scope & Purpose

Disable shell-following-term-id-cluster tests when running with replication 2.0 since these are specific to the old replication protocol.

- [x] :hankey: Bugfix
