### PR TITLE
add proper brackets to fix asan test

### DIFF
--- a/js/client/modules/@arangodb/testutils/test-utils.js
+++ b/js/client/modules/@arangodb/testutils/test-utils.js
@@ -187,9 +187,10 @@ function filterTestcaseByOptions (testname, options, whichFilter) {
     return false;
   }
 
-  if ((testname.indexOf('-noasan') !== -1) && 
-    (global.ARANGODB_CLIENT_VERSION(true).asan === 'true') ||
-    (global.ARANGODB_CLIENT_VERSION(true).tsan === 'true')) {
+  if ((testname.indexOf('-noasan') !== -1) && (
+      (global.ARANGODB_CLIENT_VERSION(true).asan === 'true') ||
+      (global.ARANGODB_CLIENT_VERSION(true).tsan === 'true')
+  )) {
     whichFilter.filter = 'skip when built with asan or tsan';
     return false;
   }


### PR DESCRIPTION
### Scope & Purpose

impropper brackets would disable all tests from running under asan / tsan; this fixes that.

- [x] :hankey: Bugfix
