### PR TITLE
adjust callstack split limit for macos

### DIFF
--- a/arangod/Aql/QueryOptions.cpp
+++ b/arangod/Aql/QueryOptions.cpp
@@ -38,7 +38,7 @@ size_t QueryOptions::defaultMaxNumberOfPlans = 128;
 #ifdef __APPLE__
 // On OSX the default stack size for worker threads (non-main thread) is 512kb
 // which is rather low, so we have to use a lower default
-size_t QueryOptions::defaultMaxNodesPerCallstack = 150;
+size_t QueryOptions::defaultMaxNodesPerCallstack = 100;
 #else
 size_t QueryOptions::defaultMaxNodesPerCallstack = 250;
 #endif


### PR DESCRIPTION
### Scope & Purpose

This PR limits the number of AQL execution nodes to be executed together inside the stack / thread, for macOS only.
This is an attempt to find out if we are limiting by too small stacks on macOS during test execution.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: *(Please link PR)*
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
