### PR TITLE
BTS-1061: fixed recoginition of ARM on Apple M1

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,12 +1,12 @@
 v3.10.1 (XXXX-XX-XX)
 --------------------
 
+* BTS-1061: ARM was not recognized on Apple M1.
+
 * Fix an issue with replication of arangosearch view change entries in single
   server replication and active failover. Previously, when changing the
   properties of existing views, the changes were not properly picked up by
   followers in these setups. Cluster setups were not affected.
-
-* BTS-1061: ARM was not recognized on Apple M1.
 
 
 v3.10.0 (2022-09-29)

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,8 @@ v3.10.1 (XXXX-XX-XX)
   properties of existing views, the changes were not properly picked up by
   followers in these setups. Cluster setups were not affected.
 
+* BTS-1061: ARM was not recognized on Apple M1.
+
 
 v3.10.0 (2022-09-29)
 --------------------
@@ -174,7 +176,7 @@ v3.10.0-beta.1 (2022-09-14)
 
 * Fixed SEARCH-347 Cycle variable reference in nested search query is properly
   detected and rejected.
-  
+
 * Fixed SEARCH-364 Fixed index fields match check for inverted index.
 
 * Web UI: Reduce size and initial render height of a modal (fixes BTS-940).
@@ -246,12 +248,12 @@ v3.10.0-alpha.1 (2022-08-17)
 * Fixed an invalid attribute access in AQL query optimization.
   Without the fix, a query such as
 
-      LET data = { 
-        "a": [ 
+      LET data = {
+        "a": [
           ...
-        ], 
-      } 
-      FOR d IN data["a"] 
+        ],
+      }
+      FOR d IN data["a"]
         RETURN d
 
   could fail with error "invalid operand to FOR loop, expecting Array".
@@ -336,12 +338,12 @@ v3.10.0-alpha.1 (2022-08-17)
   "underscore". We recommend always bundling your own copy of third-party
   modules as all previously included third-party modules are now considered
   deprecated and may be removed in future versions of ArangoD
-  
+
 * APM-84: Added option to spill intermediate AQL query results from RAM to disk
   when their size exceeds certain thresholds. Currently the only AQL operation
   that can make use of this is the SortExecutor (AQL SORT operation without
   using a LIMIT). Further AQL executor types will be supported in future
-  releases. 
+  releases.
 
   Spilling over query results from RAM to disk is off by default and currently
   in an experimental stage. In order to opt in to the feature, it is required to
@@ -403,7 +405,7 @@ v3.10.0-alpha.1 (2022-08-17)
   values.
 
 * Added startup option `--rocksdb.compaction-style` to configure the compaction
-  style which is used to pick the next file(s) to be compacted. 
+  style which is used to pick the next file(s) to be compacted.
 
 * BugFix in Pregel's Label Propagation: the union of three undirected cliques of
   size at least three connected by an undirected triangle now returns three
@@ -589,7 +591,7 @@ v3.10.0-alpha.1 (2022-08-17)
   directory (`temp-directory`), which may not provide enough capacity for larger
   Pregel jobs.
   It may be more sensible to configure a custom directory for memory-mapped
-  files and provide the necessary disk space there (`custom`). Such custom 
+  files and provide the necessary disk space there (`custom`). Such custom
   directory can be mounted on ephemeral storage, as the files are only needed
   temporarily.
   There is also the option to use a subdirectory of the database directory as
@@ -662,7 +664,7 @@ v3.10.0-alpha.1 (2022-08-17)
 
 * Added new optimization rule "arangosearch-constrained-sort" to perform sorting
   & limiting inside ArangoSearch View enumeration node in case of using just
-  scoring for sort. 
+  scoring for sort.
 
 * Updated lz4 to version 1.9.3.
 
@@ -1086,7 +1088,7 @@ v3.10.0-alpha.1 (2022-08-17)
 v3.9.2 (2022-06-07)
 -------------------
 
-* Enterprise only: Restricted behavior of Hybrid Disjoint Smart Graphs. Within a 
+* Enterprise only: Restricted behavior of Hybrid Disjoint Smart Graphs. Within a
   single traversal or path query we now restrict that you can only switch
   between Smart and Satellite sharding once, all queries where more than one
   switch is (in theory) possible will be rejected. e.g:
@@ -1370,9 +1372,9 @@ v3.9.1 (2022-04-04)
 
 * Replaced internal JS dependency xmldom with @xmldom/xmldom.
 
-* Fixed BTS-750: Fixed the issue restricted to cluster mode in which queries 
+* Fixed BTS-750: Fixed the issue restricted to cluster mode in which queries
   containing the keywords UPDATE or REPLACE together with the keyword WITH and
-  the same key value would result in an error. For example: 
+  the same key value would result in an error. For example:
   `UPDATE 'key1' WITH {_key: 'key1'} IN Collection`
   because the same key used to update was provided in the object to update the
   document with.
@@ -1560,7 +1562,7 @@ v3.9.0-beta.1 (2022-01-06)
   a new deployment to provide the license. After that period, the read-only mode
   will be enforced.
 
-* Added startup options to adjust previously hard-coded parameters for the 
+* Added startup options to adjust previously hard-coded parameters for the
   RocksDB throttle:
   - `--rocksdb.throttle-frequency`: frequency for write-throttle calculations
     (in milliseconds, default value is 60000, i.e. 60 seconds).
@@ -1574,7 +1576,7 @@ v3.9.0-beta.1 (2022-01-06)
     The actual write rate will be the minimum of this value and the value the
     throttle calculation produces.
   - `--rocksdb.throttle-slow-down-writes-trigger`: number of level 0 files whose
-    payload is not considered in throttle calculations when penalizing the 
+    payload is not considered in throttle calculations when penalizing the
     presence of L0 files. There is normally no need to change this value.
 
   All these options will only have an effect if `--rocksdb.throttle` is enabled
@@ -1602,7 +1604,7 @@ v3.9.0-beta.1 (2022-01-06)
   This addresses a potential security issue when exporting specially crafted
   documents to CSV, opening the CSV file in MS Excel or OpenOffice and then
   clicking links in any of the tainted cells.
-  
+
   This change also adds a new option `--escape-csv-formulae` to toggle the
   escaping behavior for potential formulae values. The option is turned on by
   default.
@@ -1619,7 +1621,7 @@ v3.9.0-beta.1 (2022-01-06)
   modification nodes and don't read their own writes. This fixed the execution
   of a query without the splicing-subqueries option being faster than the
   execution of a query with this option (after version 3.8, this option cannot
-  be switched off). 
+  be switched off).
 
 * Added the following metrics for revision trees:
   - `arangodb_revision_tree_hibernations_total`: number of times a revision tree
@@ -1880,7 +1882,7 @@ v3.9.0-alpha.1 (2021-11-30)
 * The server now has two flags to control the escaping control and Unicode
   characters in the log. The flag `--log.escape` is now deprecated and, instead,
   the new flags `--log.escape-control-chars` and `--log.escape-unicode-chars`
-  should be used. 
+  should be used.
 
   - `--log.escape-control-chars`: this flag applies to the control characters,
     which have hex code below `\x20`, and also the character DEL, with hex code
@@ -1985,7 +1987,7 @@ v3.9.0-alpha.1 (2021-11-30)
   - arangorestore
   - arangosh
   More tools and the drivers shipped by ArangoDB will be added to the list in
-  the future. 
+  the future.
 
   Please note that the extended names for databases should not be turned on
   during upgrades from previous versions, but only once the upgrade has been
@@ -2031,9 +2033,9 @@ v3.9.0-alpha.1 (2021-11-30)
 
   When invoking arangoimport with the startup options
 
-      --datatype key=string 
-      --datatype price=number 
-      --datatype weight=number 
+      --datatype key=string
+      --datatype price=number
+      --datatype weight=number
       --datatype fk=string
 
   it will turn the numeric-looking values in "key" into strings (so that they
@@ -2050,7 +2052,7 @@ v3.9.0-alpha.1 (2021-11-30)
 
 * Fixed issue BTS-531 "Error happens during EXE package installation if
   non-ASCII characters are present in target path".
-  
+
 * Fix active failover, so that the new host actually has working Foxx services
   (BTS-558).
 

--- a/arangod/RestServer/EnvironmentFeature.cpp
+++ b/arangod/RestServer/EnvironmentFeature.cpp
@@ -136,7 +136,7 @@ void EnvironmentFeature::prepare() {
         << "address significantly bigger regions of memory";
   }
 
-#ifdef __arm__
+#if defined(__arm__) || defined(__arm64__) || defined(__aarch64__)
   // detect alignment settings for ARM
   {
     LOG_TOPIC("6aec3", TRACE, arangodb::Logger::MEMORY)

--- a/lib/Basics/operating-system.h
+++ b/lib/Basics/operating-system.h
@@ -43,7 +43,8 @@
 
 // aligned / unaligned access
 
-#if defined(__sparc__) || defined(__arm__) || defined(__arm64__) || defined(__aarch64__)
+#if defined(__sparc__) || defined(__arm__) || defined(__arm64__) || \
+    defined(__aarch64__)
 /* unaligned accesses not allowed */
 #undef TRI_UNALIGNED_ACCESS
 #elif defined(__ppc__) || defined(__POWERPC__) || defined(_M_PPC)

--- a/lib/Basics/operating-system.h
+++ b/lib/Basics/operating-system.h
@@ -43,7 +43,7 @@
 
 // aligned / unaligned access
 
-#if defined(__sparc__) || defined(__arm__)
+#if defined(__sparc__) || defined(__arm__) || defined(__arm64__) || defined(__aarch64__)
 /* unaligned accesses not allowed */
 #undef TRI_UNALIGNED_ACCESS
 #elif defined(__ppc__) || defined(__POWERPC__) || defined(_M_PPC)
@@ -62,7 +62,7 @@
 // --Section--                                                       v8 features
 // -----------------------------------------------------------------------------
 
-#if defined(__arm__) || defined(__aarch64__)
+#if defined(__arm__) || defined(__arm64__) || defined(__aarch64__)
 #define TRI_V8_MAXHEAP 1 * 1024
 #elif TRI_PADDING_32
 #define TRI_V8_MAXHEAP 1 * 1024

--- a/lib/Rest/Version.cpp
+++ b/lib/Rest/Version.cpp
@@ -139,7 +139,7 @@ void Version::initialize() {
 
   Values["architecture"] =
       (sizeof(void*) == 4 ? "32" : "64") + std::string("bit");
-#ifdef __arm__
+#if defined(__arm__) || defined(__arm64__) || defined(__aarch64__)
   Values["arm"] = "true";
 #else
   Values["arm"] = "false";


### PR DESCRIPTION
### Scope & Purpose

This fixes BTS 1061. On MAC and Linux ARM was not correctly recognised and not reported correctly in "--version".

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: *(Please link PR)*
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [x] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/BTS-1061
- [ ] Design document: 

