### PR TITLE
fix flow after shutdown by gdb; don't deadlock on gone instances

### DIFF
--- a/js/client/modules/@arangodb/testutils/crash-utils.js
+++ b/js/client/modules/@arangodb/testutils/crash-utils.js
@@ -79,7 +79,7 @@ function analyzeCoreDump (instanceInfo, options, storeArangodPath, pid) {
     'set pagination off\\n' +
     'set confirm off\\n' +
     'set logging file ' + gdbOutputFile + '\\n' +
-    'set logging on\\n' +
+    'set logging enabled\\n' +
     'bt\\n' +
     'thread apply all bt\\n'+
     'bt full\\n' +
@@ -140,7 +140,7 @@ function generateCoreDumpGDB (instanceInfo, options, storeArangodPath, pid, gene
     'set pagination off\\n' +
     'set confirm off\\n' +
     'set logging file ' + gdbOutputFile + '\\n' +
-    'set logging on\\n' +
+    'set logging enabled\\n' +
     'bt\\n' +
     'thread apply all bt\\n'+
     'bt full\\n' +
@@ -599,11 +599,11 @@ function aggregateDebugger(instanceInfo, options) {
     print("No debugger info persisted to " + JSON.stringify(instanceInfo.getStructure()));
     return false;
   }
-  print("waiting for debugger to terminate: " + JSON.stringify(instanceInfo.debuggerInfo));
+  print(`waiting for debugger of ${instanceInfo.pid} to terminate: ${JSON.stringify(instanceInfo.debuggerInfo)}`);
   let tearDownTimeout = 180; // s
   while (tearDownTimeout > 0) {
     let ret = statusExternal(instanceInfo.debuggerInfo.pid.pid, false);
-    print(ret);
+    print(`Debugger ${instanceInfo.debuggerInfo.pid.pid} Status => ${JSON.stringify(ret)}`);
     if (ret.status === "RUNNING") {
       sleep(1);
       tearDownTimeout -= 1;

--- a/js/client/modules/@arangodb/testutils/instance.js
+++ b/js/client/modules/@arangodb/testutils/instance.js
@@ -707,12 +707,15 @@ class instance {
     try {
       let ret = statusExternal(this.pid, false);
       // OK, something has gone wrong, process still alive. anounce and force kill:
-      print(RED+`was expecting the process ${this.pid} to be gone, but ${JSON.stringify(ret)}` + RESET);
-      killExternal(this.pid, abortSignal);
-      print(statusExternal(this.pid, true));
+      if (ret.status !== "ABORTED") {
+        print(RED+`was expecting the process ${this.pid} to be gone, but ${JSON.stringify(ret)}` + RESET);
+        killExternal(this.pid, abortSignal);
+        print(statusExternal(this.pid, true));
+      }
     } catch(ex) {
       print(ex);
     }
+    this.pid = null;
     print('done');
   }
   waitForExit() {


### PR DESCRIPTION
### Scope & Purpose

- handle the state that arangoshs waitpid on killed arangod may output after the debugger terminating it
- improve messages so we better know which process we loop on
- reset pid of instance after its really gone
- check for instance being alive before trying to http-request it
- non-force shutdown only if all instances survived to the end of the test

- [x] :hankey: Bugfix
