### PR TITLE
Build Snappy with RTTI (and fix MacOS exceptions)

### DIFF
--- a/3rdParty/README_maintainers.md
+++ b/3rdParty/README_maintainers.md
@@ -455,6 +455,38 @@ index 672561e62fc..d6341fd1d7a 100644
  check_symbol_exists("mmap" "sys/mman.h" HAVE_FUNC_MMAP)
  ```
 
+and the following patch to enable building with RTTI, because mixing RTTI and non-RTTI code
+leads to unpredictable problems.
+
+``` 
+diff --git a/3rdParty/snappy/snappy-1.1.9/CMakeLists.txt b/3rdParty/snappy/snappy-1.1.9/CMakeLists.txt
+index 55c7bc88a10..5c3cf68f879 100644
+--- a/3rdParty/snappy/snappy-1.1.9/CMakeLists.txt
++++ b/3rdParty/snappy/snappy-1.1.9/CMakeLists.txt
+@@ -53,8 +53,8 @@ if(MSVC)
+   add_definitions(-D_HAS_EXCEPTIONS=0)
+ 
+   # Disable RTTI.
+-  string(REGEX REPLACE "/GR" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /GR-")
++  #string(REGEX REPLACE "/GR" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
++  #set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /GR-")
+ else(MSVC)
+   # Use -Wall for clang and gcc.
+   if(NOT CMAKE_CXX_FLAGS MATCHES "-Wall")
+@@ -78,8 +78,8 @@ else(MSVC)
+   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-exceptions")
+ 
+   # Disable RTTI.
+-  string(REGEX REPLACE "-frtti" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti")
++  #string(REGEX REPLACE "-frtti" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
++  #set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti")
+ endif(MSVC)
+ 
+ # BUILD_SHARED_LIBS is a standard CMake variable, but we declare it here to make
+```
+
 ## snowball
 
 Don't forget to update `iresearch.build/modules.h`, see [iresearch.build](#iresearchbuild)!

--- a/3rdParty/snappy/snappy-1.1.9/CMakeLists.txt
+++ b/3rdParty/snappy/snappy-1.1.9/CMakeLists.txt
@@ -53,8 +53,8 @@ if(MSVC)
   add_definitions(-D_HAS_EXCEPTIONS=0)
 
   # Disable RTTI.
-  string(REGEX REPLACE "/GR" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /GR-")
+  #string(REGEX REPLACE "/GR" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+  #set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /GR-")
 else(MSVC)
   # Use -Wall for clang and gcc.
   if(NOT CMAKE_CXX_FLAGS MATCHES "-Wall")
@@ -78,8 +78,8 @@ else(MSVC)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-exceptions")
 
   # Disable RTTI.
-  string(REGEX REPLACE "-frtti" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti")
+  #string(REGEX REPLACE "-frtti" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+  #set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti")
 endif(MSVC)
 
 # BUILD_SHARED_LIBS is a standard CMake variable, but we declare it here to make

--- a/3rdParty/snappy/snappy-1.1.9/CMakeLists.txt
+++ b/3rdParty/snappy/snappy-1.1.9/CMakeLists.txt
@@ -52,6 +52,9 @@ if(MSVC)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /EHs-c-")
   add_definitions(-D_HAS_EXCEPTIONS=0)
 
+  # Mixing -fno-rtti with -frtti (the default for C++) leads to unwanted
+  # consequences, in particular with exception handling. Since the snappy
+  # developers will not allow fixes in theri repository, we fix it here.
   # Disable RTTI.
   #string(REGEX REPLACE "/GR" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
   #set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /GR-")
@@ -77,6 +80,9 @@ else(MSVC)
   string(REGEX REPLACE "-fexceptions" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-exceptions")
 
+  # Mixing -fno-rtti with -frtti (the default for C++) leads to unwanted
+  # consequences, in particular with exception handling. Since the snappy
+  # developers will not allow fixes in theri repository, we fix it here.
   # Disable RTTI.
   #string(REGEX REPLACE "-frtti" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
   #set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti")

--- a/3rdParty/snappy/snappy-1.1.9/CMakeLists.txt
+++ b/3rdParty/snappy/snappy-1.1.9/CMakeLists.txt
@@ -54,7 +54,7 @@ if(MSVC)
 
   # Mixing -fno-rtti with -frtti (the default for C++) leads to unwanted
   # consequences, in particular with exception handling. Since the snappy
-  # developers will not allow fixes in theri repository, we fix it here.
+  # developers will not allow fixes in their repository, we fix it here.
   # Disable RTTI.
   #string(REGEX REPLACE "/GR" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
   #set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /GR-")

--- a/3rdParty/snappy/snappy-1.1.9/CMakeLists.txt
+++ b/3rdParty/snappy/snappy-1.1.9/CMakeLists.txt
@@ -82,7 +82,7 @@ else(MSVC)
 
   # Mixing -fno-rtti with -frtti (the default for C++) leads to unwanted
   # consequences, in particular with exception handling. Since the snappy
-  # developers will not allow fixes in theri repository, we fix it here.
+  # developers will not allow fixes in their repository, we fix it here.
   # Disable RTTI.
   #string(REGEX REPLACE "-frtti" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
   #set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti")

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -199,26 +199,6 @@ add_library(arango STATIC
   Zip/zip.cpp
 )
 
-# The following is necessary to compile MerkleTree.cpp without RTTI.
-# RTTI needs to be disabled because the file contains a class that
-# is derived from some Snappy base class, which itself is compiled
-# with -fno-rtti. Mixing RTTI code and non-RTTI code can cause
-# problems during linking. Here is what "man g++" has to say:
-#     Mixing code compiled with -frtti with that compiled with
-#     -fno-rtti may not work. For example, programs may fail to
-#     link if a class compiled with -fno-rtti is used as a
-#     base for a class compiled with -frtti.
-if(MSVC)
-  set_source_files_properties(
-    Containers/MerkleTreeHelpers.cpp
-    PROPERTIES COMPILE_FLAGS "/GR-")
-else()
-  set_source_files_properties(
-    Containers/MerkleTreeHelpers.cpp
-    PROPERTIES COMPILE_FLAGS "-fno-rtti")
-endif()
-
-
 target_link_libraries(arango PUBLIC
   s2
   boost_system


### PR DESCRIPTION
### Scope & Purpose

As an alternative to #17256 we could build snappy with RTTI and just keep our hands off these fragile games with mixing -fno-rtti code with -frtti.

Probably much more robust than the hack in #17256, except that the next update to snappy will break this again...