### PR TITLE
fix warning about potentially uninitialized variable

### DIFF
--- a/3rdParty/fuerte/include/fuerte/message.h
+++ b/3rdParty/fuerte/include/fuerte/message.h
@@ -49,7 +49,6 @@ struct MessageHeader {
   short version() const { return _version; }
   void setVersion(short v) { _version = v; }
 
- public:
   // Header metadata helpers#
   template <typename K, typename V>
   void addMeta(K&& key, V&& value) {
@@ -89,7 +88,7 @@ struct MessageHeader {
 
  protected:
   StringMap _meta;  /// Header meta data (equivalent to HTTP headers)
-  short _version;
+  short _version = 0; // vst protocol version. only used by vst
   ContentType _contentType = ContentType::Unset;
   ContentType _acceptType = ContentType::VPack;
   ContentEncoding _contentEncoding = ContentEncoding::Identity;
@@ -108,7 +107,6 @@ struct RequestHeader final : public MessageHeader {
   /// HTTP method
   RestVerb restVerb = RestVerb::Illegal;
 
- public:
   // accept header accessors
   ContentType acceptType() const { return _acceptType; }
   void acceptType(ContentType type) { _acceptType = type; }

--- a/arangod/Network/Methods.cpp
+++ b/arangod/Network/Methods.cpp
@@ -212,7 +212,7 @@ static std::unique_ptr<fuerte::Response> buildResponse(
   fuerte::ResponseHeader responseHeader;
   responseHeader.responseCode = statusCode;
   responseHeader.contentType(ContentType::VPack);
-  auto resp = std::make_unique<fuerte::Response>(responseHeader);
+  auto resp = std::make_unique<fuerte::Response>(std::move(responseHeader));
   resp->setPayload(std::move(buffer), 0);
   return resp;
 }


### PR DESCRIPTION
### Scope & Purpose

```
fix warning about potentially uninitialized variable

In file included from arangod/Network/Methods.h:33,
                 from arangod/Network/Methods.cpp:24:
In copy constructor ‘arangodb::fuerte::v1::MessageHeader::MessageHeader(const arangodb::fuerte::v1::MessageHeader&)’,
    inlined from ‘arangodb::fuerte::v1::ResponseHeader::ResponseHeader(const arangodb::fuerte::v1::ResponseHeader&)’ at 3rdParty/fuerte/include/fuerte/message.h:122:8,
    inlined from ‘typename std::_MakeUniq<_Tp>::__single_object std::make_unique(_Args&& ...) [with _Tp = arangodb::fuerte::v1::Response; _Args = {arangodb::fuerte::v1::ResponseHeader&}]’ at /usr/include/c++/11/bits/unique_ptr.h:962:69,
    inlined from ‘std::unique_ptr<arangodb::fuerte::v1::Response> arangodb::network::buildResponse(arangodb::fuerte::v1::StatusCode, const arangodb::Result&)’ at arangod/Network/Methods.cpp:215:64:
3rdParty/fuerte/include/fuerte/message.h:47:8: warning: ‘responseHeader.arangodb::fuerte::v1::ResponseHeader::<unnamed>.arangodb::fuerte::v1::MessageHeader::_version’ may be used uninitialized [-Wmaybe-uninitialized]
   47 | struct MessageHeader {
      |        ^~~~~~~~~~~~~
arangod/Network/Methods.cpp: In function ‘std::unique_ptr<arangodb::fuerte::v1::Response> arangodb::network::buildResponse(arangodb::fuerte::v1::StatusCode, const arangodb::Result&)’:
arangod/Network/Methods.cpp:212:26: note: ‘responseHeader’ declared here
  212 |   fuerte::ResponseHeader responseHeader;
      |                          ^~~~~~~~~~~~~~
[ 73%] Linking CXX static library ../../bin/libarango_network.a
```

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: *(Please link PR)*
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 