### PR TITLE
[CINFRA-579] Enabling range deletes on followers

### DIFF
--- a/arangod/Replication2/StateMachines/Document/DocumentStateHandlersFactory.cpp
+++ b/arangod/Replication2/StateMachines/Document/DocumentStateHandlersFactory.cpp
@@ -77,7 +77,10 @@ auto DocumentStateHandlersFactory::createTransaction(
   auto ctx = std::make_shared<transaction::ReplicatedContext>(doc.tid, state);
 
   auto methods = std::make_unique<transaction::Methods>(
-      std::move(ctx), doc.shardId, AccessMode::Type::WRITE);
+      std::move(ctx), doc.shardId,
+      doc.operation == OperationType::kTruncate ? AccessMode::Type::EXCLUSIVE
+                                                : AccessMode::Type::WRITE);
+  methods->addHint(transaction::Hints::Hint::ALLOW_RANGE_DELETE);
 
   // TODO Why is GLOBAL_MANAGED necessary?
   methods->addHint(transaction::Hints::Hint::GLOBAL_MANAGED);


### PR DESCRIPTION
### Scope & Purpose

This PR enables range deletes for truncate operations on followers. Before this, the followers always used remove operations, regardless of what the leader did.

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
