### PR TITLE
optionally log failed AQL queries

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 devel
 -----
 
+* Added startup option `--query.log-failed-queries` to optionally log all
+  failed AQL queries to the server log. The option is turned off by default.
+
 * BTS-977: Added an error message for when an unauthorized user makes an 
   HTTP GET request to current database from a database name that exists which 
   the user can't access and from a database name that doesn't exist, so both

--- a/arangod/Aql/Query.h
+++ b/arangod/Aql/Query.h
@@ -257,6 +257,8 @@ class Query : public QueryContext, public std::enable_shared_from_this<Query> {
   // a vertex collection yet. This can happen e.g. during anonymous traversal.
   void injectVertexCollectionIntoGraphNodes(ExecutionPlan& plan);
 
+  void logError(QueryResult const& queryResult) const;
+
   enum class ExecutionPhase { INITIALIZE, EXECUTE, FINALIZE };
 
  protected:

--- a/arangod/RestServer/QueryRegistryFeature.cpp
+++ b/arangod/RestServer/QueryRegistryFeature.cpp
@@ -179,6 +179,7 @@ QueryRegistryFeature::QueryRegistryFeature(Server& server)
       _parallelizeTraversals(true),
 #endif
       _allowCollectionsInExpressions(false),
+      _logFailedQueries(false),
       _queryGlobalMemoryLimit(
           defaultMemoryLimit(PhysicalMemory::getValue(), 0.1, 0.90)),
       _queryMemoryLimit(
@@ -403,6 +404,16 @@ void QueryRegistryFeature::collectOptions(
                       arangodb::options::Flags::Uncommon))
       .setIntroducedIn(30800)
       .setDeprecatedIn(30900);
+
+  options
+      ->addOption("--query.log-failed-queries", "log failed AQL queries",
+                  new BooleanParameter(&_logFailedQueries),
+                  arangodb::options::makeFlags(
+                      arangodb::options::Flags::DefaultNoComponents,
+                      arangodb::options::Flags::OnAgent,
+                      arangodb::options::Flags::OnCoordinator,
+                      arangodb::options::Flags::OnSingle))
+      .setIntroducedIn(31100);
 }
 
 void QueryRegistryFeature::validateOptions(

--- a/arangod/RestServer/QueryRegistryFeature.h
+++ b/arangod/RestServer/QueryRegistryFeature.h
@@ -56,30 +56,35 @@ class QueryRegistryFeature final : public ArangodFeature {
   // tracks a slow query, using execution time
   void trackSlowQuery(double time);
 
-  bool trackingEnabled() const { return _trackingEnabled; }
-  bool trackSlowQueries() const { return _trackSlowQueries; }
-  bool trackQueryString() const { return _trackQueryString; }
-  bool trackBindVars() const { return _trackBindVars; }
-  bool trackDataSources() const { return _trackDataSources; }
-  double slowQueryThreshold() const { return _slowQueryThreshold; }
-  double slowStreamingQueryThreshold() const {
+  bool trackingEnabled() const noexcept { return _trackingEnabled; }
+  bool trackSlowQueries() const noexcept { return _trackSlowQueries; }
+  bool trackQueryString() const noexcept { return _trackQueryString; }
+  bool trackBindVars() const noexcept { return _trackBindVars; }
+  bool trackDataSources() const noexcept { return _trackDataSources; }
+  double slowQueryThreshold() const noexcept { return _slowQueryThreshold; }
+  double slowStreamingQueryThreshold() const noexcept {
     return _slowStreamingQueryThreshold;
   }
-  bool failOnWarning() const { return _failOnWarning; }
-  bool requireWith() const { return _requireWith; }
+  bool failOnWarning() const noexcept { return _failOnWarning; }
+  bool requireWith() const noexcept { return _requireWith; }
 #ifdef USE_ENTERPRISE
-  bool smartJoins() const { return _smartJoins; }
-  bool parallelizeTraversals() const { return _parallelizeTraversals; }
+  bool smartJoins() const noexcept { return _smartJoins; }
+  bool parallelizeTraversals() const noexcept { return _parallelizeTraversals; }
 #endif
-  bool allowCollectionsInExpressions() const {
+  bool allowCollectionsInExpressions() const noexcept {
     return _allowCollectionsInExpressions;
   }
-  uint64_t queryGlobalMemoryLimit() const { return _queryGlobalMemoryLimit; }
-  uint64_t queryMemoryLimit() const { return _queryMemoryLimit; }
-  double queryMaxRuntime() const { return _queryMaxRuntime; }
-  uint64_t maxQueryPlans() const { return _maxQueryPlans; }
-  aql::QueryRegistry* queryRegistry() const { return _queryRegistry.get(); }
-  uint64_t maxParallelism() const { return _maxParallelism; }
+  bool logFailedQueries() const noexcept { return _logFailedQueries; }
+  uint64_t queryGlobalMemoryLimit() const noexcept {
+    return _queryGlobalMemoryLimit;
+  }
+  uint64_t queryMemoryLimit() const noexcept { return _queryMemoryLimit; }
+  double queryMaxRuntime() const noexcept { return _queryMaxRuntime; }
+  uint64_t maxQueryPlans() const noexcept { return _maxQueryPlans; }
+  aql::QueryRegistry* queryRegistry() const noexcept {
+    return _queryRegistry.get();
+  }
+  uint64_t maxParallelism() const noexcept { return _maxParallelism; }
 
  private:
   bool _trackingEnabled;
@@ -96,6 +101,7 @@ class QueryRegistryFeature final : public ArangodFeature {
   bool _parallelizeTraversals;
 #endif
   bool _allowCollectionsInExpressions;
+  bool _logFailedQueries;
   uint64_t _queryGlobalMemoryLimit;
   uint64_t _queryMemoryLimit;
   double _queryMaxRuntime;


### PR DESCRIPTION
### Scope & Purpose

* Added startup option `--query.log-failed-queries` to optionally log all failed AQL queries to the server log. The option is turned off by default.

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: -
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 