### PR TITLE
[PREGEL] Combine prepare and run superstep

### DIFF
--- a/arangod/Pregel/Conductor/Conductor.cpp
+++ b/arangod/Pregel/Conductor/Conductor.cpp
@@ -176,12 +176,10 @@ void Conductor::start() {
 auto Conductor ::_postGlobalSuperStep() -> PostGlobalSuperStepResult {
   // workers are done if all messages were processed and no active vertices
   // are left to process
-  bool done = _globalSuperstep > 0 && _statistics.noActiveVertices() &&
-              _statistics.allMessagesProcessed();
+  bool done =
+      _statistics.noActiveVertices() && _statistics.allMessagesProcessed();
   bool proceed = true;
-  if (_masterContext &&
-      _globalSuperstep > 0) {  // ask algorithm to evaluate aggregated values
-    _masterContext->_globalSuperstep = _globalSuperstep - 1;
+  if (_masterContext) {  // ask algorithm to evaluate aggregated values
     proceed = _masterContext->postGlobalSuperstep();
     if (!proceed) {
       LOG_PREGEL("0aa8e", DEBUG) << "Master context ended execution";

--- a/arangod/Pregel/Conductor/States/ComputingState.h
+++ b/arangod/Pregel/Conductor/States/ComputingState.h
@@ -44,7 +44,6 @@ struct Computing : State {
   }
 
  private:
-  auto _prepareGlobalSuperStep() -> futures::Future<Result>;
   auto _runGlobalSuperStepCommand() -> RunGlobalSuperStep;
   auto _runGlobalSuperStep() -> futures::Future<Result>;
 };

--- a/arangod/Pregel/Conductor/WorkerApi.cpp
+++ b/arangod/Pregel/Conductor/WorkerApi.cpp
@@ -98,11 +98,6 @@ auto WorkerApi::loadGraph(LoadGraph const& data)
       .get();
 }
 
-auto WorkerApi::prepareGlobalSuperStep(PrepareGlobalSuperStep const& data)
-    -> futures::Future<ResultT<GlobalSuperStepPrepared>> {
-  return sendToAll<GlobalSuperStepPrepared>(data);
-}
-
 auto WorkerApi::runGlobalSuperStep(RunGlobalSuperStep const& data)
     -> futures::Future<ResultT<GlobalSuperStepFinished>> {
   return sendToAll<GlobalSuperStepFinished>(data);

--- a/arangod/Pregel/Conductor/WorkerApi.h
+++ b/arangod/Pregel/Conductor/WorkerApi.h
@@ -50,8 +50,6 @@ struct WorkerApi {
       -> futures::Future<Result>;
   [[nodiscard]] auto loadGraph(LoadGraph const& graph)
       -> ResultT<Aggregate<GraphLoaded>>;
-  [[nodiscard]] auto prepareGlobalSuperStep(PrepareGlobalSuperStep const& data)
-      -> futures::Future<ResultT<GlobalSuperStepPrepared>>;
   [[nodiscard]] auto runGlobalSuperStep(RunGlobalSuperStep const& data)
       -> futures::Future<ResultT<GlobalSuperStepFinished>>;
   [[nodiscard]] auto store(Store const& message)

--- a/arangod/Pregel/PregelFeature.cpp
+++ b/arangod/Pregel/PregelFeature.cpp
@@ -704,13 +704,6 @@ auto PregelFeature::apply(ExecutionNumber const& executionNumber,
                              });
             return {Ok{}};
           },
-          [&](PrepareGlobalSuperStep const& x) -> ResultT<MessagePayload> {
-            auto w = worker(executionNumber);
-            if (!w) {
-              return workerNotFound(executionNumber, message);
-            }
-            return {w->prepareGlobalSuperStep(x).get()};
-          },
           [&](RunGlobalSuperStep const& x) -> ResultT<MessagePayload> {
             auto w = worker(executionNumber);
             if (!w) {

--- a/arangod/Pregel/Worker/Worker.cpp
+++ b/arangod/Pregel/Worker/Worker.cpp
@@ -204,13 +204,6 @@ template<typename V, typename E, typename M>
 auto Worker<V, E, M>::_preGlobalSuperStep(RunGlobalSuperStep const& message)
     -> Result {
   const uint64_t gss = message.gss;
-  if (_expectedGSS != gss) {
-    return Result{
-        TRI_ERROR_BAD_PARAMETER,
-        fmt::format(
-            "Seems like this worker missed a gss, expected {} but got {}",
-            _expectedGSS, gss)};
-  }
 
   // write cache becomes the readable cache
   {
@@ -453,7 +446,6 @@ auto Worker<V, E, M>::_finishProcessing() -> ResultT<GlobalSuperStepFinished> {
   _makeStatusCallback()();
 
   _readCache->clear();  // no need to keep old messages around
-  _expectedGSS = _config._globalSuperstep + 1;
   _config._localSuperstep++;
   // only set the state here, because _processVertices checks for it
   _state = WorkerState::IDLE;

--- a/arangod/Pregel/Worker/Worker.h
+++ b/arangod/Pregel/Worker/Worker.h
@@ -53,9 +53,6 @@ class IWorker : public std::enable_shared_from_this<IWorker> {
  public:
   virtual ~IWorker() = default;
   virtual auto loadGraph(LoadGraph const& graph) -> void = 0;
-  [[nodiscard]] virtual auto prepareGlobalSuperStep(
-      PrepareGlobalSuperStep const& data)
-      -> futures::Future<ResultT<GlobalSuperStepPrepared>> = 0;
   [[nodiscard]] virtual auto runGlobalSuperStep(RunGlobalSuperStep const& data)
       -> futures::Future<ResultT<GlobalSuperStepFinished>> = 0;
   [[nodiscard]] virtual auto store(Store const& message)
@@ -98,7 +95,6 @@ class Worker : public IWorker {
   enum WorkerState {
     DEFAULT,    // only initial
     IDLE,       // do nothing
-    PREPARING,  // before starting GSS
     COMPUTING,  // during a superstep
     DONE        // after calling finished
   };
@@ -134,6 +130,7 @@ class Worker : public IWorker {
   std::vector<InCache<M>*> _inCaches;
   // preallocated ootgoing caches
   std::vector<OutCache<M>*> _outCaches;
+  Guarded<std::vector<PregelMessage>> _messagesForNextGss;
 
   GssObservables _currentGssObservables;
   Guarded<AllGssStatus> _allGssStatus;
@@ -172,8 +169,6 @@ class Worker : public IWorker {
 
   // ====== called by rest handler =====
   auto loadGraph(LoadGraph const& graph) -> void override;
-  auto prepareGlobalSuperStep(PrepareGlobalSuperStep const& data)
-      -> futures::Future<ResultT<GlobalSuperStepPrepared>> override;
   auto runGlobalSuperStep(RunGlobalSuperStep const& data)
       -> futures::Future<ResultT<GlobalSuperStepFinished>> override;
   auto store(Store const& message) -> futures::Future<ResultT<Stored>> override;

--- a/arangod/Pregel/Worker/Worker.h
+++ b/arangod/Pregel/Worker/Worker.h
@@ -103,7 +103,6 @@ class Worker : public IWorker {
   PregelFeature& _feature;
   std::atomic<WorkerState> _state = WorkerState::DEFAULT;
   WorkerConfig _config;
-  uint64_t _expectedGSS = 0;
   uint32_t _messageBatchSize = 500;
   std::unique_ptr<Algorithm<V, E, M>> _algorithm;
   std::unique_ptr<WorkerContext> _workerContext;


### PR DESCRIPTION
This PR tidies up the Computing state:
- Inside the conductor Computing state, it adjusts the code order to the actual execution order, thus making it more readable: For each superstep (gss) there is first a preGss action on the conductor side, then data is exchanged with the workers when first preparing the gss and then running the gss and finally a postGss action is executed on the conductor.
- It merges the prepareGss and runGss message send from the conductor to the workers into a single message from conductor to workers. 
Before, the prepareGss message was used as a synchronization point: It made sure that each worker got the new gss number and exchanged its read and write cache before the real computation (initiated with the runGss message) started. 
Now we don't have this synchronization point any more and it can happen that in a worker the gss is not yet updated and the caches are not yet exchanged when a message from another worker for the new gss arrives. This PR solves this by adding a message buffer in the worker (_messageForNextGss) that collects messages if the gss and caches are not updated yet. This adds a lock - _messageForNextGss is guarded.
- It deletes the _expcectedGss property in the worker, this was only relevant for async mode.