### PR TITLE
log extra diagnosis data when duplicate endpoints are configured

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 v3.9.4 (XXXX-XX-XX)
 -------------------
 
+* Log better diagnosis information in case multiple servers in a cluster are
+  configured to use the same endpoint.
+
 * BTS-908: Fixed WebUI GraphViewer not being able to create a new edge relation
   between two nodes in cases where only one edge definition has been defined
   inside the graph definition.

--- a/arangod/Cluster/ServerState.cpp
+++ b/arangod/Cluster/ServerState.cpp
@@ -554,9 +554,13 @@ bool ServerState::integrateIntoCluster(ServerState::RoleEnum role,
           // duplicate entry!
           LOG_TOPIC("9a134", WARN, Logger::CLUSTER)
               << "found duplicate server entry for endpoint '"
-              << endpointSlice.copyString()
-              << "', already used by other server " << idIter->second
-              << ". it looks like this is a (mis)configuration issue";
+              << endpointSlice.stringView()
+              << "' when processing endpoints configuration "
+              << "for server " << serverId << ": already used by other server "
+              << idIter->second
+              << ". it looks like this is a (mis)configuration issue. "
+              << "full servers registered configuration: "
+              << valueSlice.toJson();
           // anyway, continue with startup
         }
       }


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/17336

Usability improvements for cluster start problems diagnosis.

If upon cluster instance start, it is detected that two servers use the same endpoint (IP address), a warning message was logged. This warning message only mentioned one of the servers of the duplicate pair, but not both. 
With this PR, both servers will be mentioned in the error message, and the full endpoints configuration is also logged in addition for better diagnosis.

Before:
```
WARNING [9a134] {cluster} found duplicate server entry for endpoint 'tcp://[::1]:8629', already used by other server CRDN-9343808f-98fc-4409-a64e-3d4a49d65f3d. it looks like this is a (mis)configuration issue
```

After:
```
WARNING [9a134] {cluster} found duplicate server entry for endpoint 'tcp://[::1]:8629' when processing endpoints configuration for server PRMR-f84ce6b5-9768-41fd-82be-ecf503bb2efa: already used by other server CRDN-9343808f-98fc-4409-a64e-3d4a49d65f3d. it looks like this is a (mis)configuration issue. full servers registered configuration: {"CRDN-9343808f-98fc-4409-a64e-3d4a49d65f3d":{"versionString":"3.8.8","timestamp":"2022-10-12T19:42:43Z","host":"aa80d529cef445148694d501db937f2d","version":30808,"engine":"rocksdb","endpoint":"tcp://[::1]:8629","advertisedEndpoint":""},"PRMR-f84ce6b5-9768-41fd-82be-ecf503bb2efa":{"versionString":"3.8.8","timestamp":"2022-10-12T19:15:22Z","host":"aa80d529cef445148694d501db937f2d","version":30808,"engine":"rocksdb","endpoint":"tcp://[::1]:8629","advertisedEndpoint":""},"PRMR-613a6dc9-611b-42c0-b5e3-37432a45cc65":{"versionString":"3.8.8","timestamp":"2022-10-12T19:15:20Z","host":"aa80d529cef445148694d501db937f2d","version":30808,"engine":"rocksdb","endpoint":"tcp://[::1]:8630","advertisedEndpoint":""},"Version":1}
```

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [x] Backports
  - [x] Backport for 3.10: https://github.com/arangodb/arangodb/pull/17335
  - [x] Backport for 3.9: this PR
  - [x] Backport for 3.8: https://github.com/arangodb/arangodb/pull/17333

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 