### PR TITLE
allow rvalue contexts when creating AqlTransaction

### DIFF
--- a/arangod/Aql/AqlTransaction.cpp
+++ b/arangod/Aql/AqlTransaction.cpp
@@ -38,24 +38,24 @@ using namespace arangodb;
 using namespace arangodb::aql;
 
 std::unique_ptr<AqlTransaction> AqlTransaction::create(
-    std::shared_ptr<transaction::Context> const& transactionContext,
+    std::shared_ptr<transaction::Context> transactionContext,
     aql::Collections const& collections, transaction::Options const& options,
     std::unordered_set<std::string> inaccessibleCollections) {
 #ifdef USE_ENTERPRISE
   if (!inaccessibleCollections.empty()) {
     return std::make_unique<transaction::IgnoreNoAccessAqlTransaction>(
-        transactionContext, collections, options,
+        std::move(transactionContext), collections, options,
         std::move(inaccessibleCollections));
   }
 #endif
-  return std::make_unique<AqlTransaction>(transactionContext, collections,
-                                          options);
+  return std::make_unique<AqlTransaction>(std::move(transactionContext),
+                                          collections, options);
 }
 
 AqlTransaction::AqlTransaction(
-    std::shared_ptr<transaction::Context> const& transactionContext,
+    std::shared_ptr<transaction::Context> transactionContext,
     transaction::Options const& options)
-    : transaction::Methods(transactionContext, options) {
+    : transaction::Methods(std::move(transactionContext), options) {
   if (options.isIntermediateCommitEnabled()) {
     addHint(transaction::Hints::Hint::INTERMEDIATE_COMMITS);
   }
@@ -63,9 +63,9 @@ AqlTransaction::AqlTransaction(
 
 /// protected so we can create different subclasses
 AqlTransaction::AqlTransaction(
-    std::shared_ptr<transaction::Context> const& transactionContext,
+    std::shared_ptr<transaction::Context> transactionContext,
     aql::Collections const& collections, transaction::Options const& options)
-    : transaction::Methods(transactionContext, options) {
+    : transaction::Methods(std::move(transactionContext), options) {
   TRI_ASSERT(state() != nullptr);
   if (options.isIntermediateCommitEnabled()) {
     addHint(transaction::Hints::Hint::INTERMEDIATE_COMMITS);

--- a/arangod/Aql/AqlTransaction.h
+++ b/arangod/Aql/AqlTransaction.h
@@ -27,6 +27,7 @@
 #include "Transaction/Methods.h"
 
 #include <memory>
+#include <string>
 #include <unordered_set>
 
 namespace arangodb {
@@ -46,19 +47,18 @@ class AqlTransaction : public transaction::Methods {
   /// @brief create the transaction and add all collections
   /// from the query context
   static std::unique_ptr<AqlTransaction> create(
-      std::shared_ptr<transaction::Context> const& transactionContext,
+      std::shared_ptr<transaction::Context> transactionContext,
       aql::Collections const& collections, transaction::Options const& options,
       std::unordered_set<std::string> inaccessibleCollections =
           std::unordered_set<std::string>());
 
-  AqlTransaction(
-      std::shared_ptr<transaction::Context> const& transactionContext,
-      transaction::Options const& options);
+  AqlTransaction(std::shared_ptr<transaction::Context> transactionContext,
+                 transaction::Options const& options);
 
   /// protected so we can create different subclasses
-  AqlTransaction(
-      std::shared_ptr<transaction::Context> const& transactionContext,
-      aql::Collections const& collections, transaction::Options const& options);
+  AqlTransaction(std::shared_ptr<transaction::Context> transactionContext,
+                 aql::Collections const& collections,
+                 transaction::Options const& options);
 
  protected:
   /// @brief add a collection to the transaction

--- a/arangod/Aql/BlocksWithClients.cpp
+++ b/arangod/Aql/BlocksWithClients.cpp
@@ -25,7 +25,6 @@
 
 #include "Aql/AqlCallStack.h"
 #include "Aql/AqlItemBlock.h"
-#include "Aql/AqlTransaction.h"
 #include "Aql/AqlValue.h"
 #include "Aql/Collection.h"
 #include "Aql/DistributeExecutor.h"

--- a/arangod/Cluster/TraverserEngine.cpp
+++ b/arangod/Cluster/TraverserEngine.cpp
@@ -22,7 +22,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #include "TraverserEngine.h"
-#include "Aql/AqlTransaction.h"
 #include "Aql/Ast.h"
 #include "Aql/Query.h"
 #include "Aql/QueryString.h"

--- a/arangod/Graph/BaseOptions.cpp
+++ b/arangod/Graph/BaseOptions.cpp
@@ -23,7 +23,6 @@
 
 #include "BaseOptions.h"
 
-#include "Aql/AqlTransaction.h"
 #include "Aql/AqlValueMaterializer.h"
 #include "Aql/Ast.h"
 #include "Aql/Collection.h"


### PR DESCRIPTION
### Scope & Purpose

Allow passing transaction::Context shared_ptr as rvalue reference when creating an AqlTransaction instance.
In the best case, this saves an atomic value update. In the worst case, it doesn't change anything.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: -
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 