### PR TITLE
[PREGEL] Separate sending and receiving messages to run gss

### DIFF
--- a/arangod/Pregel/Conductor/Conductor.cpp
+++ b/arangod/Pregel/Conductor/Conductor.cpp
@@ -453,6 +453,13 @@ std::vector<ShardID> Conductor::getShardIds(ShardID const& collection) const {
   return result;
 }
 
+auto Conductor::receive(MessagePayload message) -> void {
+  auto newState = _state->receive(message);
+  if (newState.has_value()) {
+    _changeState(std::move(newState.value()));
+  }
+}
+
 auto Conductor::_changeState(std::unique_ptr<conductor::State> state) -> void {
   _state = std::move(state);
   auto nextState = _state->run();

--- a/arangod/Pregel/Conductor/Conductor.h
+++ b/arangod/Pregel/Conductor/Conductor.h
@@ -156,6 +156,7 @@ class Conductor : public std::enable_shared_from_this<Conductor> {
 
   ~Conductor();
 
+  auto receive(MessagePayload message) -> void;
   void start();
   void cancel();
   auto collectAQLResults(bool withId) -> ResultT<PregelResults>;

--- a/arangod/Pregel/Conductor/States/ComputingState.cpp
+++ b/arangod/Pregel/Conductor/States/ComputingState.cpp
@@ -1,5 +1,8 @@
 #include "ComputingState.h"
+#include <cstdint>
+#include <optional>
 
+#include "Cluster/ClusterTypes.h"
 #include "Pregel/Conductor/Conductor.h"
 #include "Metrics/Gauge.h"
 #include "Pregel/Conductor/States/State.h"
@@ -25,14 +28,64 @@ Computing::~Computing() {
 }
 
 auto Computing::run() -> std::optional<std::unique_ptr<State>> {
-  do {
-    conductor._preGlobalSuperStep();
+  conductor._timing.gss.emplace_back(Duration{
+      ._start = std::chrono::steady_clock::now(), ._finish = std::nullopt});
 
-    auto runGlobalSuperStep = _runGlobalSuperStep().get();
-    if (runGlobalSuperStep.fail()) {
-      LOG_PREGEL_CONDUCTOR("f34bb", ERR) << runGlobalSuperStep.errorMessage();
-      return std::make_unique<FatalError>(conductor);
+  conductor._preGlobalSuperStep();
+
+  auto const runGlobalSuperStepCommand = _runGlobalSuperStepCommand();
+  VPackBuilder startCommand;
+  serialize(startCommand, runGlobalSuperStepCommand);
+  LOG_PREGEL_CONDUCTOR("d98de", DEBUG)
+      << "Initiate starting GSS: " << startCommand.slice().toJson();
+
+  return _aggregate.doUnderLock(
+      [&](auto& agg) -> std::optional<std::unique_ptr<State>> {
+        auto aggregate = conductor._workers.runGlobalSuperStep(
+            runGlobalSuperStepCommand, _sendCountPerServer);
+        if (aggregate.fail()) {
+          LOG_PREGEL_CONDUCTOR("f34bb", ERR)
+              << fmt::format("Computing state: {}", aggregate.errorMessage());
+          return std::make_unique<FatalError>(conductor);
+        }
+        agg = aggregate.get();
+        return std::nullopt;
+      });
+}
+
+auto Computing::receive(MessagePayload message)
+    -> std::optional<std::unique_ptr<State>> {
+  auto explicitMessage = getResultTMessage<GlobalSuperStepFinished>(message);
+  if (explicitMessage.fail()) {
+    // TODO The state changes to Canceled if this message fails, but there can
+    // still be other GraphLoaded messages that are/will be sent from workers,
+    // what happens to them? Currently: in Canceled state any received messages
+    // are ignored, this is fine but we have to be careful to change this
+    LOG_PREGEL_CONDUCTOR("7698e", ERR)
+        << fmt::format("Computing state: {}", explicitMessage.errorMessage());
+    return std::make_unique<FatalError>(conductor);
+  }
+  auto finishedAggregate = _aggregate.doUnderLock(
+      [&](auto& agg) { return agg.aggregate(explicitMessage.get()); });
+
+  if (finishedAggregate.has_value()) {
+    conductor._statistics.accumulate(finishedAggregate.value().messageStats);
+    conductor._aggregators->resetValues();
+    for (auto aggregator :
+         VPackArrayIterator(finishedAggregate.value().aggregators.slice())) {
+      conductor._aggregators->aggregateValues(aggregator);
     }
+    conductor._statistics.setActiveCounts(
+        finishedAggregate.value().activeCount);
+    conductor._totalVerticesCount = finishedAggregate.value().vertexCount;
+    conductor._totalEdgesCount = finishedAggregate.value().edgeCount;
+    auto sendCountPerServer = std::unordered_map<ServerID, uint64_t>{};
+    for (auto const& [shard, counts] :
+         finishedAggregate.value().sendCountPerShard) {
+      sendCountPerServer[conductor._leadingServerForShard[shard]] += counts;
+    }
+    _sendCountPerServer = _transformSendCountFromShardToServer(
+        std::move(finishedAggregate.value().sendCountPerShard));
 
     auto post = conductor._postGlobalSuperStep();
     if (post.finished) {
@@ -42,12 +95,17 @@ auto Computing::run() -> std::optional<std::unique_ptr<State>> {
       return std::make_unique<Done>(conductor);
     }
 
+    conductor._timing.gss.back().finish();
+    LOG_PREGEL_CONDUCTOR("39385", DEBUG)
+        << "Finished gss " << conductor._globalSuperstep << " in "
+        << conductor._timing.gss.back().elapsedSeconds().count() << "s";
     conductor._globalSuperstep++;
-
-  } while (true);
+    return run();
+  };
+  return std::nullopt;
 }
 
-auto Computing::_runGlobalSuperStepCommand() -> RunGlobalSuperStep {
+auto Computing::_runGlobalSuperStepCommand() const -> RunGlobalSuperStep {
   VPackBuilder aggregators;
   {
     VPackObjectBuilder ob(&aggregators);
@@ -60,45 +118,12 @@ auto Computing::_runGlobalSuperStepCommand() -> RunGlobalSuperStep {
                             .aggregators = std::move(aggregators)};
 }
 
-auto Computing::_runGlobalSuperStep() -> futures::Future<Result> {
-  auto runGlobalSuperStepCommand = _runGlobalSuperStepCommand();
-  conductor._timing.gss.emplace_back(Duration{
-      ._start = std::chrono::steady_clock::now(), ._finish = std::nullopt});
-  VPackBuilder startCommand;
-  serialize(startCommand, runGlobalSuperStepCommand);
-  LOG_PREGEL_CONDUCTOR("d98de", DEBUG)
-      << "Initiate starting GSS: " << startCommand.slice().toJson();
-  return conductor._workers
-      .runGlobalSuperStep(runGlobalSuperStepCommand, _sendCountPerServer)
-      .thenValue([&](auto globalSuperStepFinished) -> Result {
-        if (globalSuperStepFinished.fail()) {
-          return Result{globalSuperStepFinished.errorNumber(),
-                        fmt::format("While running global super step {}: {}",
-                                    conductor._globalSuperstep,
-                                    globalSuperStepFinished.errorMessage())};
-        }
-        conductor._statistics.accumulate(
-            globalSuperStepFinished.get().messageStats);
-        conductor._aggregators->resetValues();
-        for (auto aggregator : VPackArrayIterator(
-                 globalSuperStepFinished.get().aggregators.slice())) {
-          conductor._aggregators->aggregateValues(aggregator);
-        }
-        auto sendCountPerServer = std::unordered_map<ServerID, uint64_t>{};
-        for (auto const& [shard, counts] :
-             globalSuperStepFinished.get().sendCountPerShard) {
-          sendCountPerServer[conductor._leadingServerForShard[shard]] += counts;
-        }
-        _sendCountPerServer = std::move(sendCountPerServer);
-        conductor._statistics.setActiveCounts(
-            globalSuperStepFinished.get().activeCount);
-        conductor._totalVerticesCount =
-            globalSuperStepFinished.get().vertexCount;
-        conductor._totalEdgesCount = globalSuperStepFinished.get().edgeCount;
-        conductor._timing.gss.back().finish();
-        LOG_PREGEL_CONDUCTOR("39385", DEBUG)
-            << "Finished gss " << conductor._globalSuperstep << " in "
-            << conductor._timing.gss.back().elapsedSeconds().count() << "s";
-        return Result{};
-      });
+auto Computing::_transformSendCountFromShardToServer(
+    std::unordered_map<ShardID, uint64_t> sendCountPerShard) const
+    -> std::unordered_map<ServerID, uint64_t> {
+  auto sendCountPerServer = std::unordered_map<ServerID, uint64_t>{};
+  for (auto const& [shard, counts] : sendCountPerShard) {
+    sendCountPerServer[conductor._leadingServerForShard[shard]] += counts;
+  }
+  return sendCountPerServer;
 }

--- a/arangod/Pregel/Conductor/States/ComputingState.h
+++ b/arangod/Pregel/Conductor/States/ComputingState.h
@@ -22,6 +22,8 @@
 ////////////////////////////////////////////////////////////////////////////////
 #pragma once
 
+#include "Basics/Guarded.h"
+#include "Pregel/Messaging/Aggregate.h"
 #include "State.h"
 
 namespace arangodb::pregel {
@@ -35,6 +37,8 @@ struct Computing : State {
   Computing(Conductor& conductor);
   ~Computing();
   auto run() -> std::optional<std::unique_ptr<State>> override;
+  auto receive(MessagePayload message)
+      -> std::optional<std::unique_ptr<State>> override;
   auto canBeCanceled() -> bool override { return true; }
   auto name() const -> std::string override { return "running"; };
   auto isRunning() const -> bool override { return true; }
@@ -44,8 +48,12 @@ struct Computing : State {
   }
 
  private:
-  auto _runGlobalSuperStepCommand() -> RunGlobalSuperStep;
+  auto _runGlobalSuperStepCommand() const -> RunGlobalSuperStep;
   auto _runGlobalSuperStep() -> futures::Future<Result>;
+  auto _transformSendCountFromShardToServer(
+      std::unordered_map<ShardID, uint64_t> sendCountPerShard) const
+      -> std::unordered_map<ServerID, uint64_t>;
+  Guarded<Aggregate<GlobalSuperStepFinished>> _aggregate;
   std::unordered_map<ServerID, uint64_t> _sendCountPerServer;
 };
 

--- a/arangod/Pregel/Conductor/States/LoadingState.cpp
+++ b/arangod/Pregel/Conductor/States/LoadingState.cpp
@@ -68,6 +68,7 @@ auto Loading::receive(MessagePayload message)
   }
   auto finishedAggregate = _aggregate.doUnderLock(
       [&](auto& agg) { return agg.aggregate(explicitMessage.get()); });
+
   if (finishedAggregate.has_value()) {
     conductor._totalVerticesCount += finishedAggregate.value().vertexCount;
     conductor._totalEdgesCount += finishedAggregate.value().edgeCount;

--- a/arangod/Pregel/Conductor/WorkerApi.h
+++ b/arangod/Pregel/Conductor/WorkerApi.h
@@ -53,7 +53,7 @@ struct WorkerApi {
   [[nodiscard]] auto runGlobalSuperStep(
       RunGlobalSuperStep const& data,
       std::unordered_map<ServerID, uint64_t> const& sendCountPerServer)
-      -> futures::Future<ResultT<GlobalSuperStepFinished>>;
+      -> ResultT<Aggregate<GlobalSuperStepFinished>>;
   [[nodiscard]] auto store(Store const& message)
       -> futures::Future<ResultT<Stored>>;
   [[nodiscard]] auto cleanup(Cleanup const& message)
@@ -67,7 +67,12 @@ struct WorkerApi {
   std::unique_ptr<Connection> _connection;
 
   template<Addable Out, typename In>
-  auto sendToAll(In const& in) const -> futures::Future<ResultT<Out>>;
+  auto sendToAll_old(In const& in) const -> futures::Future<ResultT<Out>>;
+  template<typename In>
+  auto sendToAll(In const& in) const -> std::vector<futures::Future<Result>>;
+  template<Addable Out>
+  auto collectAllOks(std::vector<futures::Future<Result>> responses)
+      -> ResultT<Aggregate<Out>>;
 
   // This template enforces In and Out type of the function:
   // 'In' enforces which type of message is sent

--- a/arangod/Pregel/Worker/ConductorApi.cpp
+++ b/arangod/Pregel/Worker/ConductorApi.cpp
@@ -2,8 +2,7 @@
 
 using namespace arangodb::pregel::worker;
 
-auto ConductorApi::graphLoaded(ResultT<GraphLoaded> const& data) const
-    -> Result {
+auto ConductorApi::send(MessagePayload data) const -> Result {
   return _connection
       ->post(
           Destination{Destination::Type::server, _server},

--- a/arangod/Pregel/Worker/ConductorApi.h
+++ b/arangod/Pregel/Worker/ConductorApi.h
@@ -24,7 +24,7 @@
 
 #include "Pregel/Connection/Connection.h"
 #include "Pregel/ExecutionNumber.h"
-#include "Pregel/Messaging/WorkerMessages.h"
+#include "Pregel/Messaging/Message.h"
 
 namespace arangodb::pregel::worker {
 
@@ -35,7 +35,7 @@ struct ConductorApi {
       : _server{std::move(conductorServer)},
         _executionNumber{std::move(executionNumber)},
         _connection{std::move(connection)} {}
-  auto graphLoaded(ResultT<GraphLoaded> const& data) const -> Result;
+  auto send(MessagePayload data) const -> Result;
 
  private:
   ServerID _server;


### PR DESCRIPTION
This PR continues the refactoring to use the actor model for communication between conductor and workers (see previous PR https://github.com/arangodb/arangodb/pull/17280)
This adapts the communication in the computation state: sending RunGlobalSuperstep from Conductor to Workers and GlobalSuperStepFinished from Workers to Conductor.