### PR TITLE
ad-hoc fix for BTS-1073 improvement

### DIFF
--- a/arangod/Replication/DatabaseInitialSyncer.cpp
+++ b/arangod/Replication/DatabaseInitialSyncer.cpp
@@ -2030,13 +2030,19 @@ Result DatabaseInitialSyncer::fetchCollectionSyncByRevisions(
         RevisionId removalBound =
             leaderSlice.isEmptyArray()
                 ? RevisionId{currentRange.second}.next()
-                : RevisionId::fromSlice(leaderSlice.at(0));
+                : (encodeAsHLC
+                       ? RevisionId::fromHLC(leaderSlice.at(0).stringView())
+                       : RevisionId::fromSlice(leaderSlice.at(0)));
         TRI_ASSERT(RevisionId{currentRange.first} <= removalBound);
         TRI_ASSERT(removalBound <= RevisionId{currentRange.second}.next());
-        RevisionId mixedBound = leaderSlice.isEmptyArray()
-                                    ? RevisionId{currentRange.second}
-                                    : RevisionId::fromSlice(leaderSlice.at(
-                                          leaderSlice.length() - 1));
+        RevisionId mixedBound =
+            leaderSlice.isEmptyArray()
+                ? RevisionId{currentRange.second}
+                : (encodeAsHLC ? RevisionId::fromHLC(
+                                     leaderSlice.at(leaderSlice.length() - 1)
+                                         .stringView())
+                               : RevisionId::fromSlice(
+                                     leaderSlice.at(leaderSlice.length() - 1)));
         TRI_ASSERT(RevisionId{currentRange.first} <= mixedBound);
         TRI_ASSERT(mixedBound <= RevisionId{currentRange.second});
 
@@ -2048,7 +2054,12 @@ Result DatabaseInitialSyncer::fetchCollectionSyncByRevisions(
 
         std::size_t index = 0;
         while (local.hasMore() && local.revision() <= mixedBound) {
-          RevisionId leaderRev = RevisionId::fromSlice(leaderSlice.at(index));
+          RevisionId leaderRev;
+          if (encodeAsHLC) {
+            leaderRev = RevisionId::fromHLC(leaderSlice.at(index).stringView());
+          } else {
+            leaderRev = RevisionId::fromSlice(leaderSlice.at(index));
+          }
 
           if (local.revision() < leaderRev) {
             toRemove.emplace_back(local.revision());
@@ -2067,7 +2078,12 @@ Result DatabaseInitialSyncer::fetchCollectionSyncByRevisions(
           }
         }
         for (; index < leaderSlice.length(); ++index) {
-          RevisionId leaderRev = RevisionId::fromSlice(leaderSlice.at(index));
+          RevisionId leaderRev;
+          if (encodeAsHLC) {
+            leaderRev = RevisionId::fromHLC(leaderSlice.at(index).stringView());
+          } else {
+            leaderRev = RevisionId::fromSlice(leaderSlice.at(index));
+          }
           // fetch any leftovers
           toFetch.emplace_back(leaderRev);
           iterResume = std::max(iterResume, leaderRev.next());

--- a/arangod/RestHandler/RestReplicationHandler.cpp
+++ b/arangod/RestHandler/RestReplicationHandler.cpp
@@ -3367,7 +3367,6 @@ void RestReplicationHandler::handleCommandRevisionDocuments() {
       RevisionId rev;
       if (encodeAsHLC) {
         rev = RevisionId::fromHLC(entry.stringView());
-        ;
       } else {
         rev = RevisionId::fromSlice(entry);
       }


### PR DESCRIPTION
### Scope & Purpose

Because the Ranges protocol can now return only-HLC encoded values, the follower should react on that.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: *(Please link PR)*
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 