### PR TITLE
BTS-1073: Fix revision ids in replication

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,30 @@
 v3.8.8 (XXXX-XX-XX)
 -------------------
 
+* Changed the encoding of revision ids returned by the following REST APIs:
+  - GET /_api/collection/<collection-name>/revision: the revision id was
+    previously returned as numeric value, and now it will be returned as
+    a string value with either numeric encoding or HLC-encoding inside.
+  - GET /_api/collection/<collection-name>/checksum: the revision id in
+    the "revision" attribute was previously encoded as a numeric value
+    in single server, and as a string in cluster. This is now unified so
+    that the "revision" attribute always contains a string value with
+    either numeric encoding or HLC-encoding inside.
+
+* Fixed handling of empty URL parameters in HTTP request handling.
+
+* Fixed diffing of completely non-overlapping revision trees, which could
+  lead to out-of-bounds reads at the right end of the first (smaller) tree.
+
+* Fixed aborting the server process if an exception was thrown in C++ code
+  that was invoked from the llhttp C code dispatcher. That dispatcher code
+  couldn't handle C++ exceptions properly.
+
+* Fixed BTS-1073: Fix encoding and decoding of revision ids in replication 
+  incremental sync protocol. Previously, the encoding of revision ids could 
+  be ambiguous under some circumstances, which could prevent shards from 
+  getting into sync.
+
 * Fixed BTS-850: Fixed the removal of already deleted orphan collections out of
   a graph definition. The removal of an already deleted orphan collection out of
   a graph definition failed and has been rejected in case the collection got

--- a/Documentation/DocuBlocks/Rest/Collections/get_api_collection_revision.md
+++ b/Documentation/DocuBlocks/Rest/Collections/get_api_collection_revision.md
@@ -16,10 +16,9 @@ You should reference them via their names instead.
 The name of the collection.
 
 @RESTDESCRIPTION
-In addition to the above, the result will also contain the
-collection's revision id. The revision id is a server-generated
-string that clients can use to check whether data in a collection
-has changed since the last revision check.
+The response will contain the collection's latest used revision id. 
+The revision id is a server-generated string that clients can use to 
+check whether data in a collection has changed since the last revision check.
 
 - *revision*: The collection revision id as a string.
 

--- a/arangod/Cluster/ClusterMethods.cpp
+++ b/arangod/Cluster/ClusterMethods.cpp
@@ -978,15 +978,13 @@ futures::Future<OperationResult> revisionOnCoordinator(ClusterFeature& feature,
         [](Result& result, VPackBuilder& builder, ShardID const&, VPackSlice answer) -> void {
           if (answer.isObject()) {
             VPackSlice r = answer.get("revision");
-            if (r.isString()) {
-              VPackValueLength len;
-              char const* p = r.getString(len);
-              RevisionId cmp = RevisionId::fromString(p, len, false);
+            if (r.isString() || r.isInteger()) {
+              RevisionId cmp = RevisionId::fromSlice(r);
               RevisionId rid = RevisionId::fromSlice(builder.slice());
               if (cmp != RevisionId::max() && cmp > rid) {
                 // get the maximum value
                 builder.clear();
-                builder.add(VPackValue(cmp.id()));
+                builder.add(VPackValue(cmp.toString()));
               }
             }
           } else {
@@ -1076,8 +1074,7 @@ futures::Future<OperationResult> checksumOnCoordinator(ClusterFeature& feature,
       builder.clear();
       VPackObjectBuilder b(&builder);
       builder.add("checksum", VPackValue(checksum));
-      builder.add("revision", VPackValue(rid.id()));
-    
+      builder.add("revision", VPackValue(rid.toString()));
     };
     return handleResponsesFromAllShards(options, results, handler, pre);
   };

--- a/arangod/GeneralServer/HttpCommTask.cpp
+++ b/arangod/GeneralServer/HttpCommTask.cpp
@@ -72,7 +72,7 @@ rest::RequestType llhttpToRequestType(llhttp_t* p) {
 }  // namespace
 
 template <SocketType T>
-int HttpCommTask<T>::on_message_began(llhttp_t* p) {
+int HttpCommTask<T>::on_message_began(llhttp_t* p) try {
   HttpCommTask<T>* me = static_cast<HttpCommTask<T>*>(p->data);
   me->_lastHeaderField.clear();
   me->_lastHeaderValue.clear();
@@ -89,10 +89,14 @@ int HttpCommTask<T>::on_message_began(llhttp_t* p) {
   me->acquireStatistics(1UL).SET_READ_START(TRI_microtime());
 
   return HPE_OK;
+} catch (...) {
+  // the caller of this function is a C function, which doesn't know
+  // exceptions. we must not let an exception escape from here.
+  return HPE_INTERNAL;
 }
 
 template <SocketType T>
-int HttpCommTask<T>::on_url(llhttp_t* p, const char* at, size_t len) {
+int HttpCommTask<T>::on_url(llhttp_t* p, const char* at, size_t len) try {
   HttpCommTask<T>* me = static_cast<HttpCommTask<T>*>(p->data);
   me->_request->setRequestType(llhttpToRequestType(p));
   if (me->_request->requestType() == RequestType::ILLEGAL) {
@@ -104,6 +108,10 @@ int HttpCommTask<T>::on_url(llhttp_t* p, const char* at, size_t len) {
 
   me->_url.append(at, len);
   return HPE_OK;
+} catch (...) {
+  // the caller of this function is a C function, which doesn't know
+  // exceptions. we must not let an exception escape from here.
+  return HPE_INTERNAL;
 }
 
 template <SocketType T>
@@ -113,7 +121,7 @@ int HttpCommTask<T>::on_status(llhttp_t* p, const char* at, size_t len) {
 }
 
 template <SocketType T>
-int HttpCommTask<T>::on_header_field(llhttp_t* p, const char* at, size_t len) {
+int HttpCommTask<T>::on_header_field(llhttp_t* p, const char* at, size_t len) try {
   HttpCommTask<T>* me = static_cast<HttpCommTask<T>*>(p->data);
   if (me->_lastHeaderWasValue) {
     me->_request->setHeaderV2(std::move(me->_lastHeaderField),
@@ -124,10 +132,14 @@ int HttpCommTask<T>::on_header_field(llhttp_t* p, const char* at, size_t len) {
   }
   me->_lastHeaderWasValue = false;
   return HPE_OK;
+} catch (...) {
+  // the caller of this function is a C function, which doesn't know
+  // exceptions. we must not let an exception escape from here.
+  return HPE_INTERNAL;
 }
 
 template <SocketType T>
-int HttpCommTask<T>::on_header_value(llhttp_t* p, const char* at, size_t len) {
+int HttpCommTask<T>::on_header_value(llhttp_t* p, const char* at, size_t len) try {
   HttpCommTask<T>* me = static_cast<HttpCommTask<T>*>(p->data);
   if (me->_lastHeaderWasValue) {
     me->_lastHeaderValue.append(at, len);
@@ -136,10 +148,14 @@ int HttpCommTask<T>::on_header_value(llhttp_t* p, const char* at, size_t len) {
   }
   me->_lastHeaderWasValue = true;
   return HPE_OK;
+} catch (...) {
+  // the caller of this function is a C function, which doesn't know
+  // exceptions. we must not let an exception escape from here.
+  return HPE_INTERNAL;
 }
 
 template <SocketType T>
-int HttpCommTask<T>::on_header_complete(llhttp_t* p) {
+int HttpCommTask<T>::on_header_complete(llhttp_t* p) try {
   HttpCommTask<T>* me = static_cast<HttpCommTask<T>*>(p->data);
   me->_response.reset();
   if (!me->_lastHeaderField.empty()) {
@@ -182,17 +198,25 @@ int HttpCommTask<T>::on_header_complete(llhttp_t* p) {
     return 1;  // 1 is defined by parser
   }
   return HPE_OK;
+} catch (...) {
+  // the caller of this function is a C function, which doesn't know
+  // exceptions. we must not let an exception escape from here.
+  return HPE_INTERNAL;
 }
 
 template <SocketType T>
-int HttpCommTask<T>::on_body(llhttp_t* p, const char* at, size_t len) {
+int HttpCommTask<T>::on_body(llhttp_t* p, const char* at, size_t len) try {
   HttpCommTask<T>* me = static_cast<HttpCommTask<T>*>(p->data);
   me->_request->body().append(at, len);
   return HPE_OK;
+} catch (...) {
+  // the caller of this function is a C function, which doesn't know
+  // exceptions. we must not let an exception escape from here.
+  return HPE_INTERNAL;
 }
 
 template <SocketType T>
-int HttpCommTask<T>::on_message_complete(llhttp_t* p) {
+int HttpCommTask<T>::on_message_complete(llhttp_t* p) try {
   HttpCommTask<T>* me = static_cast<HttpCommTask<T>*>(p->data);
   me->_request->parseUrl(me->_url.data(), me->_url.size());
 
@@ -200,6 +224,10 @@ int HttpCommTask<T>::on_message_complete(llhttp_t* p) {
   me->_messageDone = true;
 
   return HPE_PAUSED;
+} catch (...) {
+  // the caller of this function is a C function, which doesn't know
+  // exceptions. we must not let an exception escape from here.
+  return HPE_INTERNAL;
 }
 
 template <SocketType T>

--- a/arangod/GeneralServer/VstCommTask.cpp
+++ b/arangod/GeneralServer/VstCommTask.cpp
@@ -25,7 +25,6 @@
 #include "VstCommTask.h"
 
 #include "ApplicationFeatures/ApplicationServer.h"
-#include "Basics/HybridLogicalClock.h"
 #include "Basics/Result.h"
 #include "Basics/ScopeGuard.h"
 #include "Basics/VelocyPackHelper.h"

--- a/arangod/Replication/utilities.cpp
+++ b/arangod/Replication/utilities.cpp
@@ -129,19 +129,18 @@ arangodb::Result handleLeaderStateResponse(arangodb::replutils::Connection const
   }
 
   std::string const versionString(version.copyString());
-  auto v = arangodb::rest::Version::parseVersionString(versionString);
-  int major = v.first;
-  int minor = v.second;
+  auto v = arangodb::rest::Version::parseFullVersionString(versionString);
 
-  if (major != 3) {
+  if (v.major != 3) {
     // we can connect to 3.x only
     return Result(TRI_ERROR_REPLICATION_LEADER_INCOMPATIBLE,
                   std::string("got incompatible leader version") +
                       endpointString + ": '" + versionString + "'");
   }
 
-  leader.majorVersion = major;
-  leader.minorVersion = minor;
+  leader.majorVersion = v.major;
+  leader.minorVersion = v.minor;
+  leader.patchVersion = v.patch;
   leader.serverId = leaderId;
   leader.lastLogTick = lastLogTick;
 
@@ -445,7 +444,7 @@ LeaderInfo::LeaderInfo(ReplicationApplierConfiguration const& applierConfig) {
 }
 
 uint64_t LeaderInfo::version() const {
-  return majorVersion * 10000 + minorVersion * 100;
+  return majorVersion * 10000 + minorVersion * 100 + patchVersion;
 }
 
 /// @brief get leader state

--- a/arangod/Replication/utilities.h
+++ b/arangod/Replication/utilities.h
@@ -132,6 +132,7 @@ struct LeaderInfo {
   ServerId serverId{0};
   int majorVersion{0};
   int minorVersion{0};
+  int patchVersion{0};
   TRI_voc_tick_t lastLogTick{0}; // only used during initialSync
 
   explicit LeaderInfo(ReplicationApplierConfiguration const& applierConfig);

--- a/arangod/RestHandler/RestCollectionHandler.cpp
+++ b/arangod/RestHandler/RestCollectionHandler.cpp
@@ -254,7 +254,7 @@ RestStatus RestCollectionHandler::handleCommandGet() {
           RevisionId rid = RevisionId::fromSlice(res.slice());
           {
             VPackObjectBuilder obj(&_builder, true);
-            obj->add("revision", VPackValue(StringUtils::itoa(rid.id())));
+            obj->add("revision", VPackValue(rid.toString()));
 
             // no need to use async variant
             collectionRepresentation(*_ctxt, /*showProperties*/ true,

--- a/arangod/RestHandler/RestGraphHandler.cpp
+++ b/arangod/RestHandler/RestGraphHandler.cpp
@@ -1009,7 +1009,7 @@ std::optional<RevisionId> RestGraphHandler::handleRevision() const {
     bool found = false;
     std::string const& revString = _request->value("rev", found);
     if (found) {
-      revision = RevisionId::fromString(revString.data(), revString.size(), false);
+      revision = RevisionId::fromString(revString);
     }
   }
   return revision.isSet() ? std::optional{revision} : std::nullopt;

--- a/arangod/RestHandler/RestReplicationHandler.cpp
+++ b/arangod/RestHandler/RestReplicationHandler.cpp
@@ -2933,7 +2933,7 @@ bool RestReplicationHandler::prepareRevisionOperation(RevisionOperationContext& 
     ctx.resume = RevisionId::fromHLC(resumeString);
   } else {
     // "resumeHLC" is not set. now fall back to the parameter "resume". this
-    // parameter contains either a numeric value of a timestamp-encoded HLC
+    // parameter contains either a numeric value or a timestamp-encoded HLC
     // value
     std::string const& resumeString =
         _request->value(StaticStrings::RevisionTreeResume, found);

--- a/arangod/RestHandler/RestReplicationHandler.cpp
+++ b/arangod/RestHandler/RestReplicationHandler.cpp
@@ -26,7 +26,6 @@
 #include "ApplicationFeatures/ApplicationServer.h"
 #include "Aql/Query.h"
 #include "Basics/ConditionLocker.h"
-#include "Basics/HybridLogicalClock.h"
 #include "Basics/NumberUtils.h"
 #include "Basics/ReadLocker.h"
 #include "Basics/Result.h"
@@ -2924,10 +2923,23 @@ bool RestReplicationHandler::prepareRevisionOperation(RevisionOperationContext& 
     return false;
   }
 
-  // get resume
-  std::string const& resumeString = _request->value("resume", found);
+  // get resume.
+  // we first try the parameter "resumeHLC" - if set, this will contain a
+  // timestamp-encoded HLC value
+  std::string const& resumeString =
+      _request->value(StaticStrings::RevisionTreeResumeHLC, found);
   if (found) {
-    ctx.resume = RevisionId::fromString(resumeString);
+    // "resumeHLC" is set. use it
+    ctx.resume = RevisionId::fromHLC(resumeString);
+  } else {
+    // "resumeHLC" is not set. now fall back to the parameter "resume". this
+    // parameter contains either a numeric value of a timestamp-encoded HLC
+    // value
+    std::string const& resumeString =
+        _request->value(StaticStrings::RevisionTreeResume, found);
+    if (found) {
+      ctx.resume = RevisionId::fromString(resumeString);
+    }
   }
 
   // print request
@@ -3018,8 +3030,10 @@ void RestReplicationHandler::handleCommandRevisionRanges() {
         badFormat = true;
         break;
       }
-      RevisionId left = RevisionId::fromSlice(first);
-      RevisionId right = RevisionId::fromSlice(second);
+      // note: always decoding as HLC timestamps is fine here, because the
+      // sender side unconditionally encodes the revisions using HLC-encoding
+      RevisionId left = RevisionId::fromHLC(first.stringView());
+      RevisionId right = RevisionId::fromHLC(second.stringView());
       if (left == RevisionId::max() ||
           right == RevisionId::max() || left >= right ||
           left < previousRight) {
@@ -3039,6 +3053,8 @@ void RestReplicationHandler::handleCommandRevisionRanges() {
     return;
   }
 
+  bool encodeAsHLC = _request->parsedValue("encodeAsHLC", false);
+
   RevisionReplicationIterator& it =
       *static_cast<RevisionReplicationIterator*>(ctx.iter.get());
   it.seek(ctx.resume);
@@ -3054,8 +3070,9 @@ void RestReplicationHandler::handleCommandRevisionRanges() {
     RevisionId right;
     auto setRange = [&body, &range, &left, &right](std::size_t index) -> void {
       range = body.at(index);
-      left = RevisionId::fromSlice(range.at(0));
-      right = RevisionId::fromSlice(range.at(1));
+      // the sender side always encodes the revisions here using HLC encoding
+      left = RevisionId::fromHLC(range.at(0).stringView());
+      right = RevisionId::fromHLC(range.at(1).stringView());
     };
     setRange(current);
 
@@ -3079,7 +3096,11 @@ void RestReplicationHandler::handleCommandRevisionRanges() {
         }
 
         if (it.hasMore() && it.revision() >= left && it.revision() <= right) {
-          response.add(it.revision().toValuePair(ridBuffer));
+          if (encodeAsHLC) {
+            response.add(VPackValue(it.revision().toHLC()));
+          } else {
+            response.add(it.revision().toValuePair(ridBuffer));
+          }
           ++total;
           resumeNext = it.revision().next();
           it.next();
@@ -3115,6 +3136,8 @@ void RestReplicationHandler::handleCommandRevisionRanges() {
       setRange(body.length() - 1);
       if (body.length() > 0 && resumeNext <= right) {
         response.add(StaticStrings::RevisionTreeResume, resumeNext.toValuePair(ridBuffer));
+        response.add(StaticStrings::RevisionTreeResumeHLC,
+                     VPackValue(resumeNext.toHLC()));
       }
     }
   }
@@ -3134,6 +3157,14 @@ void RestReplicationHandler::handleCommandRevisionDocuments() {
     return;
   }
 
+  // the "encodeAsHLC" parameter is sent from the following versions onwards:
+  // - 3.8.8 or higher
+  // - 3.9.4 or higher
+  // - 3.10.1 or higher
+  // - 3.11.0 or higher
+  // - 4.0 higher
+  bool encodeAsHLC = _request->parsedValue("encodeAsHLC", false);
+
   bool success = false;
   VPackSlice const body = this->parseVPackBody(success);
   if (!success) {
@@ -3147,7 +3178,12 @@ void RestReplicationHandler::handleCommandRevisionDocuments() {
         badFormat = true;
         break;
       }
-      RevisionId rev = RevisionId::fromSlice(entry);
+      RevisionId rev;
+      if (encodeAsHLC) {
+        rev = RevisionId::fromHLC(entry.stringView());
+      } else {
+        rev = RevisionId::fromSlice(entry);
+      }
       if (rev == RevisionId::max()) {
         badFormat = true;
         break;
@@ -3182,7 +3218,12 @@ void RestReplicationHandler::handleCommandRevisionDocuments() {
     VPackArrayBuilder docs(&response);
 
     for (VPackSlice entry : VPackArrayIterator(body)) {
-      RevisionId rev = RevisionId::fromSlice(entry);
+      RevisionId rev;
+      if (encodeAsHLC) {
+        rev = RevisionId::fromHLC(entry.stringView());
+      } else {
+        rev = RevisionId::fromSlice(entry);
+      }
       if (it.hasMore() && it.revision() < rev) {
         it.seek(rev);
       }

--- a/arangod/RestHandler/RestVocbaseBaseHandler.cpp
+++ b/arangod/RestHandler/RestVocbaseBaseHandler.cpp
@@ -547,10 +547,7 @@ RevisionId RestVocbaseBaseHandler::extractRevision(char const* header, bool& isV
       --e;
     }
 
-    RevisionId rid = RevisionId::none();
-
-    bool isOld;
-    rid = RevisionId::fromString(s, e - s, isOld, false);
+    RevisionId rid = RevisionId::fromString({s, static_cast<size_t>(e - s)});
     isValid = (rid.isSet() && rid != RevisionId::max());
 
     return rid;

--- a/arangod/StorageEngine/PhysicalCollection.cpp
+++ b/arangod/StorageEngine/PhysicalCollection.cpp
@@ -269,9 +269,7 @@ Result PhysicalCollection::mergeObjectsForUpdate(
     VPackSlice s = newValue.get(StaticStrings::RevString);
     if (s.isString()) {
       b.add(StaticStrings::RevString, s);
-      VPackValueLength l;
-      char const* p = s.getStringUnchecked(l);
-      revisionId = RevisionId::fromString(p, l, false);
+      revisionId = RevisionId::fromString(s.stringView());
       handled = true;
     }
   }
@@ -431,9 +429,7 @@ Result PhysicalCollection::newObjectForInsert(transaction::Methods*,
     s = value.get(StaticStrings::RevString);
     if (s.isString()) {
       builder.add(StaticStrings::RevString, s);
-      VPackValueLength l;
-      char const* str = s.getStringUnchecked(l);
-      revisionId = RevisionId::fromString(str, l, false);
+      revisionId = RevisionId::fromString(s.stringView());
       handled = true;
     }
   }
@@ -519,9 +515,7 @@ Result PhysicalCollection::newObjectForReplace(transaction::Methods*,
     s = newValue.get(StaticStrings::RevString);
     if (s.isString()) {
       builder.add(StaticStrings::RevString, s);
-      VPackValueLength l;
-      char const* p = s.getStringUnchecked(l);
-      revisionId = RevisionId::fromString(p, l, false);
+      revisionId = RevisionId::fromString(s.stringView());
       handled = true;
     }
   }

--- a/arangod/Transaction/Helpers.cpp
+++ b/arangod/Transaction/Helpers.cpp
@@ -290,9 +290,8 @@ void transaction::helpers::extractKeyAndRevFromDocument(VPackSlice slice, VPackS
   // fall back to regular lookup
   {
     keySlice = slice.get(StaticStrings::KeyString);
-    VPackValueLength l;
-    char const* p = slice.get(StaticStrings::RevString).getString(l);
-    revisionId = RevisionId::fromString(p, l, false);
+    revisionId = RevisionId::fromString(
+        slice.get(StaticStrings::RevString).stringView());
   }
 }
 

--- a/arangod/V8Server/v8-util.cpp
+++ b/arangod/V8Server/v8-util.cpp
@@ -166,8 +166,8 @@ bool ExtractDocumentHandle(v8::Isolate* isolate, v8::Handle<v8::Value> const val
       return true;
     }
     v8::String::Utf8Value str(isolate, revObj);
-    bool isOld;
-    RevisionId rid = RevisionId::fromString(*str, str.length(), isOld, false);
+    RevisionId rid = 
+        RevisionId::fromString({*str, static_cast<size_t>(str.length())});
 
     if (rid.empty()) {
       return false;

--- a/arangod/VocBase/Identifiers/RevisionId.cpp
+++ b/arangod/VocBase/Identifiers/RevisionId.cpp
@@ -32,16 +32,8 @@
 #include "Basics/StringUtils.h"
 #include "Basics/debugging.h"
 #include "Cluster/ClusterInfo.h"
-#include "Logger/LogMacros.h"
 #include "RocksDBEngine/RocksDBFormat.h"
 #include "VocBase/Identifiers/LocalDocumentId.h"
-
-namespace {
-/// @brief Convert a revision ID to a string
-constexpr static arangodb::RevisionId::BaseType TickLimit =
-    static_cast<arangodb::RevisionId::BaseType>(2016ULL - 1970ULL) * 1000ULL *
-    60ULL * 60ULL * 24ULL * 365ULL;
-}  // namespace
 
 namespace arangodb {
 
@@ -58,10 +50,10 @@ RevisionId RevisionId::next() const { return RevisionId{id() + 1}; }
 RevisionId RevisionId::previous() const { return RevisionId{id() - 1}; }
 
 std::string RevisionId::toString() const {
-  if (id() <= ::TickLimit) {
+  if (id() <= tickLimit) {
     return arangodb::basics::StringUtils::itoa(id());
   }
-  return basics::HybridLogicalClock::encodeTimeStamp(id());
+  return toHLC();
 }
 
 /// encodes the uint64_t timestamp into the provided result buffer
@@ -70,12 +62,16 @@ std::string RevisionId::toString() const {
 /// the length of the encoded value and the start position into
 /// the result buffer are returned by the function
 std::pair<size_t, size_t> RevisionId::toString(char* buffer) const {
-  if (id() <= ::TickLimit) {
+  if (id() <= tickLimit) {
     std::pair<size_t, size_t> pos{0, 0};
     pos.second = basics::StringUtils::itoa(id(), buffer);
     return pos;
   }
   return basics::HybridLogicalClock::encodeTimeStamp(id(), buffer);
+}
+
+std::string RevisionId::toHLC() const {
+  return basics::HybridLogicalClock::encodeTimeStamp(id());
 }
 
 /// encodes the uint64_t timestamp into a temporary velocypack ValuePair,
@@ -97,7 +93,7 @@ void RevisionId::toPersistent(std::string& buffer) const {
 RevisionId RevisionId::lowerBound() { 
   // "2021-01-01T00:00:00.000Z" => 1609459200000 milliseconds since the epoch
   RevisionId value{uint64_t(1609459200000ULL) << 20ULL};
-  TRI_ASSERT(value.id() > ::TickLimit);
+  TRI_ASSERT(value.id() > (tickLimit << 20ULL));
   return value;
 }
 
@@ -109,37 +105,21 @@ RevisionId RevisionId::createClusterWideUnique(ClusterInfo& ci) {
   return RevisionId{ci.uniqid()};
 }
 
-/// @brief Convert a string into a revision ID, no check variant
-RevisionId RevisionId::fromString(char const* p, size_t len, bool warn) {
-  [[maybe_unused]] bool isOld;
-  return fromString(p, len, isOld, warn);
-}
-
 /// @brief Convert a string into a revision ID, returns 0 if format invalid
-RevisionId RevisionId::fromString(std::string const& ridStr) {
-  [[maybe_unused]] bool isOld;
-  return fromString(ridStr.c_str(), ridStr.size(), isOld, false);
-}
-
-/// @brief Convert a string into a revision ID, returns 0 if format invalid
-RevisionId RevisionId::fromString(std::string const& ridStr, bool& isOld, bool warn) {
-  return fromString(ridStr.c_str(), ridStr.size(), isOld, warn);
-}
-
-/// @brief Convert a string into a revision ID, returns 0 if format invalid
-RevisionId RevisionId::fromString(char const* p, size_t len, bool& isOld, bool warn) {
+RevisionId RevisionId::fromString(std::string_view rid) {
+  char const* p = rid.data();
+  size_t len = rid.size();
   if (len > 0 && *p >= '1' && *p <= '9') {
     BaseType r = NumberUtils::atoi_positive_unchecked<BaseType>(p, p + len);
-    if (warn && r > ::TickLimit) {
-      // An old tick value that could be confused with a time stamp
-      LOG_TOPIC("66a3a", WARN, arangodb::Logger::FIXME)
-          << "Saw old _rev value that could be confused with a time stamp!";
-    }
-    isOld = true;
     return RevisionId{r};
   }
-  isOld = false;
-  return RevisionId{basics::HybridLogicalClock::decodeTimeStamp(p, len)};
+  return fromHLC(rid);
+}
+
+/// @brief Convert a HLC-encoded string into a revision ID, returns 0 if format
+/// invalid
+RevisionId RevisionId::fromHLC(std::string_view rid) {
+  return RevisionId{basics::HybridLogicalClock::decodeTimeStamp(rid)};
 }
 
 /// @brief extract revision from slice; expects either an integer, or an object
@@ -147,22 +127,14 @@ RevisionId RevisionId::fromString(char const* p, size_t len, bool& isOld, bool w
 RevisionId RevisionId::fromSlice(velocypack::Slice slice) {
   slice = slice.resolveExternal();
 
+  if (slice.isObject()) {
+    slice = slice.get(StaticStrings::RevString);
+  }
   if (slice.isInteger()) {
     return RevisionId{slice.getNumber<BaseType>()};
-  } else if (slice.isString()) {
-    velocypack::ValueLength l;
-    char const* p = slice.getStringUnchecked(l);
-    return fromString(p, l, false);
-  } else if (slice.isObject()) {
-    velocypack::Slice r(slice.get(StaticStrings::RevString));
-    if (r.isString()) {
-      velocypack::ValueLength l;
-      char const* p = r.getStringUnchecked(l);
-      return fromString(p, l, false);
-    }
-    if (r.isInteger()) {
-      return RevisionId{r.getNumber<BaseType>()};
-    }
+  }
+  if (slice.isString()) {
+    return fromString(slice.stringView());
   }
 
   return RevisionId::none();

--- a/lib/Basics/StaticStrings.cpp
+++ b/lib/Basics/StaticStrings.cpp
@@ -334,6 +334,7 @@ std::string const StaticStrings::RevisionTreeRangeMin("rangeMin");
 std::string const StaticStrings::RevisionTreeInitialRangeMin("initialRangeMin");
 std::string const StaticStrings::RevisionTreeRanges("ranges");
 std::string const StaticStrings::RevisionTreeResume("resume");
+std::string const StaticStrings::RevisionTreeResumeHLC("resumeHLC");
 std::string const StaticStrings::RevisionTreeVersion("version");
 std::string const StaticStrings::FollowingTermId("followingTermId");
 

--- a/lib/Basics/StaticStrings.h
+++ b/lib/Basics/StaticStrings.h
@@ -312,7 +312,10 @@ class StaticStrings {
   static std::string const RevisionTreeRangeMin;
   static std::string const RevisionTreeInitialRangeMin;
   static std::string const RevisionTreeRanges;
+  // deprecated
   static std::string const RevisionTreeResume;
+
+  static std::string const RevisionTreeResumeHLC;
   static std::string const RevisionTreeVersion;
   static std::string const FollowingTermId;
 

--- a/lib/Containers/MerkleTree.cpp
+++ b/lib/Containers/MerkleTree.cpp
@@ -681,10 +681,10 @@ std::vector<std::pair<std::uint64_t, std::uint64_t>> MerkleTree<Hasher, Branchin
   std::shared_lock<std::shared_mutex> guard1(_dataLock);
   std::shared_lock<std::shared_mutex> guard2(other._dataLock);
 
-  if (this->meta().depth != other.meta().depth) {
+  std::uint64_t depth = this->meta().depth;
+  if (depth != other.meta().depth) {
     throw std::invalid_argument("Expecting two trees with same depth.");
   }
-  std::uint64_t depth = this->meta().depth;
 
   while (true) {  // left by break
     std::uint64_t width = this->meta().rangeMax - this->meta().rangeMin;
@@ -725,6 +725,8 @@ std::vector<std::pair<std::uint64_t, std::uint64_t>> MerkleTree<Hasher, Branchin
   
   TRI_ASSERT(tree1->meta().rangeMin <= tree2->meta().rangeMin);
 
+  TRI_ASSERT(tree1->numberOfShards() == tree2->numberOfShards());
+
   std::vector<std::pair<std::uint64_t, std::uint64_t>> result;
   std::uint64_t n = nodeCountAtDepth(depth);
 
@@ -746,7 +748,8 @@ std::vector<std::pair<std::uint64_t, std::uint64_t>> MerkleTree<Hasher, Branchin
     = (tree1->meta().rangeMax - tree1->meta().rangeMin) / n;
   std::uint64_t index1 = 0;
   std::uint64_t pos =  tree1->meta().rangeMin;
-  for ( ; pos < tree2->meta().rangeMin; pos += keysPerBucket) {
+  for (; pos < tree2->meta().rangeMin && pos < tree1->meta().rangeMax;
+       pos += keysPerBucket) {
     Node const& node1 = tree1->node(index1);
     if (node1.count != 0) {
       addRange(pos, pos + keysPerBucket - 1);
@@ -754,9 +757,14 @@ std::vector<std::pair<std::uint64_t, std::uint64_t>> MerkleTree<Hasher, Branchin
     ++index1;
   }
   // Now the buckets they both have:
+  TRI_ASSERT(pos == tree2->meta().rangeMin ||
+             (pos == tree1->meta().rangeMax &&
+              tree2->meta().rangeMin > tree1->meta().rangeMax));
+  // note that pos can be < tree2->meta().rangeMin if the trees do not overlap
+  // at all
   std::uint64_t index2 = 0;
-  TRI_ASSERT(pos == tree2->meta().rangeMin);
-  for ( ; pos < tree1->meta().rangeMax; pos += keysPerBucket) {
+  for (pos = tree2->meta().rangeMin; pos < tree1->meta().rangeMax;
+       pos += keysPerBucket) {
     Node const& node1 = tree1->node(index1);
     Node const& node2 = tree2->node(index2);
     if (node1.hash != node2.hash || node1.count != node2.count) {
@@ -1246,6 +1254,11 @@ bool MerkleTree<Hasher, BranchingBits>::modifyLocal(
 template <typename Hasher, std::uint64_t const BranchingBits>
 void MerkleTree<Hasher, BranchingBits>::leftCombine(bool withShift) {
   // not thread-safe, lock nodes from outside
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+#ifdef PARANOID_TREE_CHECKS
+  checkInternalConsistency();
+#endif
+#endif
 
   // First to depth:
   auto const depth = meta().depth;
@@ -1321,6 +1334,12 @@ template <typename Hasher, std::uint64_t const BranchingBits>
 void MerkleTree<Hasher, BranchingBits>::growRight(std::uint64_t key) {
   std::unique_lock<std::shared_mutex> guard(_dataLock);
 
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+#ifdef PARANOID_TREE_CHECKS
+  checkInternalConsistency();
+#endif
+#endif
+
   std::uint64_t depth = meta().depth;
   std::uint64_t rangeMin = meta().rangeMin;
   std::uint64_t rangeMax = meta().rangeMax;
@@ -1379,6 +1398,11 @@ void MerkleTree<Hasher, BranchingBits>::growRight(std::uint64_t key) {
 template <typename Hasher, std::uint64_t const BranchingBits>
 void MerkleTree<Hasher, BranchingBits>::rightCombine(bool withShift) {
   // not thread-safe, lock nodes from outside
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+#ifdef PARANOID_TREE_CHECKS
+  checkInternalConsistency();
+#endif
+#endif
 
   // First to depth:
   auto const depth = meta().depth;
@@ -1453,6 +1477,12 @@ void MerkleTree<Hasher, BranchingBits>::rightCombine(bool withShift) {
 template <typename Hasher, std::uint64_t const BranchingBits>
 void MerkleTree<Hasher, BranchingBits>::growLeft(std::uint64_t key) {
   std::unique_lock<std::shared_mutex> guard(_dataLock);
+
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+#ifdef PARANOID_TREE_CHECKS
+  checkInternalConsistency();
+#endif
+#endif
 
   std::uint64_t depth = meta().depth;
   std::uint64_t rangeMin = meta().rangeMin;
@@ -1537,6 +1567,7 @@ void MerkleTree<Hasher, BranchingBits>::checkInternalConsistency() const {
   std::uint64_t rangeMin = meta().rangeMin;
   std::uint64_t rangeMax = meta().rangeMax;
   std::uint64_t initialRangeMin = meta().initialRangeMin;
+  std::uint64_t width = rangeMax - rangeMin;
   
   if (depth < 2) {
     throw std::invalid_argument("Invalid tree depth");
@@ -1551,6 +1582,11 @@ void MerkleTree<Hasher, BranchingBits>::checkInternalConsistency() const {
       ((rangeMax - rangeMin) / nodeCountAtDepth(depth)) != 0) {
     throw std::invalid_argument("Expecting difference between initial min and min to be divisible by (max-min)/nodeCountAt(depth)");
   }
+
+  TRI_ASSERT(width > 0);
+  TRI_ASSERT(numberOfShards() > 0);
+  std::size_t shardSize = width / numberOfShards();
+  TRI_ASSERT(width % shardSize == 0);
 
   std::uint64_t totalCount = 0;
   std::uint64_t totalHash = 0;

--- a/lib/Rest/HttpRequest.cpp
+++ b/lib/Rest/HttpRequest.cpp
@@ -474,8 +474,12 @@ void HttpRequest::parseUrl(const char* path, size_t length) {
       continue;
     }
 
-    if (q + 1 == end || *(q + 1) == '&') {
-      ++q; // skip ahead
+    bool isAmpersand = (*q == '&');
+
+    if (q + 1 == end || *(q + 1) == '&' || isAmpersand) {
+      if (!isAmpersand) {
+        ++q;  // skip ahead
+      }
 
       std::string val = ::url_decode(valueBegin, q);
       if (keyEnd - keyBegin > 2 && *(keyEnd - 2) == '[' && *(keyEnd - 1) == ']') {
@@ -487,7 +491,10 @@ void HttpRequest::parseUrl(const char* path, size_t length) {
       }
       keyPhase = true;
       keyBegin = q + 1;
-      continue;
+
+      if (!isAmpersand) {
+        continue;
+      }
     }
     ++q;
   }

--- a/lib/Rest/Version.cpp
+++ b/lib/Rest/Version.cpp
@@ -84,6 +84,53 @@ std::pair<int, int> Version::parseVersionString(std::string const& str) {
   return result;
 }
 
+/// parse a full version string into major, minor, patch
+/// returns -1, -1, -1 when the version string has an invalid format
+/// returns major, -1, -1 when only the major version can be determined,
+/// returns major, minor, -1 when only the major and minor version can be
+/// determined.
+FullVersion Version::parseFullVersionString(std::string const& str) {
+  FullVersion result{-1, -1, -1};
+  int tmp;
+
+  if (!str.empty()) {
+    char const* p = str.c_str();
+    char const* q = p;
+    tmp = 0;
+    while (*q >= '0' && *q <= '9') {
+      tmp = tmp * 10 + *q++ - '0';
+    }
+    if (p != q) {
+      result.major = tmp;
+      tmp = 0;
+
+      if (*q == '.') {
+        ++q;
+      }
+      p = q;
+      while (*q >= '0' && *q <= '9') {
+        tmp = tmp * 10 + *q++ - '0';
+      }
+      if (p != q) {
+        result.minor = tmp;
+        tmp = 0;
+        if (*q == '.') {
+          ++q;
+        }
+        p = q;
+        while (*q >= '0' && *q <= '9') {
+          tmp = tmp * 10 + *q++ - '0';
+        }
+        if (p != q) {
+          result.patch = tmp;
+        }
+      }
+    }
+  }
+
+  return result;
+}
+
 /// @brief initialize
 void Version::initialize() {
   if (!Values.empty()) {

--- a/lib/Rest/Version.h
+++ b/lib/Rest/Version.h
@@ -77,6 +77,12 @@ class Builder;
 
 namespace rest {
 
+struct FullVersion {
+  int major;
+  int minor;
+  int patch;
+};
+
 class Version {
  private:
   /// @brief create the version information
@@ -88,6 +94,13 @@ class Version {
   /// @brief parse a version string into major, minor
   /// returns -1, -1 when the version string has an invalid format
   static std::pair<int, int> parseVersionString(std::string const&);
+
+  // parse a full version string into major, minor, patch
+  /// returns -1, -1, -1 when the version string has an invalid format
+  /// returns major, -1, -1 when only the major version can be determined,
+  /// returns major, minor, -1 when only the major and minor version can be
+  /// determined.
+  static FullVersion parseFullVersionString(std::string const&);
 
   /// @brief initialize
   static void initialize();

--- a/tests/Basics/HybridLogicalClockTest.cpp
+++ b/tests/Basics/HybridLogicalClockTest.cpp
@@ -1,0 +1,172 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2020 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Jan Steemann
+/// @author Copyright 2012, triAGENS GmbH, Cologne, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+#include "Basics/Common.h"
+
+#include "gtest/gtest.h"
+
+#include "Basics/HybridLogicalClock.h"
+
+#include <velocypack/Builder.h>
+#include <velocypack/Value.h>
+
+#include <cstdint>
+#include <string_view>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+using namespace arangodb;
+
+TEST(HybridLogicalClockTest, test_encode_decode_timestamp) {
+  std::vector<std::pair<uint64_t, std::string_view>> values = {
+      {0ULL, ""},
+      {1ULL, "_"},
+      {2ULL, "A"},
+      {10ULL, "I"},
+      {100ULL, "_i"},
+      {100000ULL, "WYe"},
+      {1000000ULL, "ByH-"},
+      {10000000ULL, "kHY-"},
+      {100000000ULL, "D7cC-"},
+      {1000000000ULL, "5kqm-"},
+      {10000000000ULL, "HSA8O-"},
+      {100000000000ULL, "_bGbse-"},
+      {1000000000000ULL, "MhSnP--"},
+      {10000000000000ULL, "APfMao--"},
+      {100000000000000ULL, "UtKOci--"},
+      {1000000000000000ULL, "BhV4ivm--"},
+      {10000000000000000ULL, "hftHtuO--"},
+      {100000000000000000ULL, "DhPVfbge--"},
+      {1000000000000000000ULL, "1erpMlX---"},
+      {10000000000000000000ULL, "GpFGuQH4---"},
+      {18446744073709551614ULL, "N9999999998"},
+      {18446744073709551615ULL, "N9999999999"},
+  };
+
+  velocypack::Builder b;
+
+  for (auto const& value : values) {
+    // encode
+    std::string encoded =
+        basics::HybridLogicalClock::encodeTimeStamp(value.first);
+    ASSERT_EQ(value.second, encoded);
+
+    // encode into a buffer using a velocypack::ValuePair
+    char buffer[11];
+    b.clear();
+    b.add(basics::HybridLogicalClock::encodeTimeStampToValuePair(value.first,
+                                                                 &buffer[0]));
+    ASSERT_EQ(value.first,
+              basics::HybridLogicalClock::decodeTimeStamp(b.slice()));
+
+    // decode
+    ASSERT_EQ(value.first,
+              basics::HybridLogicalClock::decodeTimeStamp(encoded));
+
+    // decode from velocypack string
+    b.clear();
+    b.add(velocypack::Value(value.second));
+    ASSERT_EQ(value.first,
+              basics::HybridLogicalClock::decodeTimeStamp(b.slice()));
+  }
+}
+
+TEST(HybridLogicalClockTest, test_decode_invalid) {
+  std::vector<std::pair<uint64_t, std::string_view>> values = {
+      {0ULL, ""},
+      {UINT64_MAX, " "},
+      {51ULL, "x"},
+      {869219571ULL, "xxxxx"},
+      {UINT64_MAX, "xxxxxxxxxxxxxxxxxxxxxxxxxxxx"},
+      {UINT64_MAX, "N9999999999"},
+      {17813666640376327606ULL, "Na000000000"},
+      {988218432520154550ULL, "O0000000000"},
+  };
+
+  for (auto const& value : values) {
+    uint64_t decoded =
+        basics::HybridLogicalClock::decodeTimeStamp(std::string(value.second));
+    ASSERT_EQ(value.first, decoded);
+  }
+}
+
+TEST(HybridLogicalClockTest, test_extract_time_and_count) {
+  std::vector<std::tuple<uint64_t, uint64_t, uint64_t>> values = {
+      {0ULL, 0ULL, 0ULL},
+      {1ULL, 0ULL, 1ULL},
+      {2ULL, 0ULL, 2ULL},
+      {10ULL, 0ULL, 10ULL},
+      {100ULL, 0ULL, 100ULL},
+      {100000ULL, 0ULL, 100000ULL},
+      {1000000ULL, 0ULL, 1000000ULL},
+      {10000000ULL, 9ULL, 562816ULL},
+      {100000000ULL, 95ULL, 385280ULL},
+      {1000000000ULL, 953ULL, 707072ULL},
+      {10000000000ULL, 9536ULL, 779264ULL},
+      {100000000000ULL, 95367ULL, 452608ULL},
+      {1000000000000ULL, 953674ULL, 331776ULL},
+      {10000000000000ULL, 9536743ULL, 172032ULL},
+      {100000000000000ULL, 95367431ULL, 671744ULL},
+      {1000000000000000ULL, 953674316ULL, 425984ULL},
+      {10000000000000000ULL, 9536743164ULL, 65536ULL},
+      {100000000000000000ULL, 95367431640ULL, 655360ULL},
+      {1000000000000000000ULL, 953674316406ULL, 262144ULL},
+      {10000000000000000000ULL, 9536743164062ULL, 524288ULL},
+      {18446744073709551614ULL, 17592186044415ULL, 1048574ULL},
+      {18446744073709551615ULL, 17592186044415ULL, 1048575ULL},
+  };
+
+  for (auto const& it : values) {
+    uint64_t timePart =
+        basics::HybridLogicalClock::extractTime(std::get<0>(it));
+    ASSERT_EQ(std::get<1>(it), timePart);
+
+    uint64_t countPart =
+        basics::HybridLogicalClock::extractCount(std::get<0>(it));
+    ASSERT_EQ(std::get<2>(it), countPart);
+
+    ASSERT_EQ(std::get<0>(it), basics::HybridLogicalClock::assembleTimeStamp(
+                                   timePart, countPart));
+  }
+}
+
+TEST(HybridLogicalClockTest, test_get_timestamp) {
+  // arbitrary timestamp from Sep 30, 2022, that is supposed to
+  // be in the past whenever this test runs
+  constexpr uint64_t dateInThePast = 1664561862434ULL;
+
+  basics::HybridLogicalClock hlc;
+
+  uint64_t initial = hlc.getTimeStamp();
+
+  for (size_t i = 0; i < 4'000'000; ++i) {
+    uint64_t stamp = hlc.getTimeStamp();
+    // every stamp generated must be >= than current time
+    ASSERT_GT(stamp, dateInThePast);
+    // stamps must be increasing
+    ASSERT_GT(stamp, initial);
+    initial = stamp;
+  }
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -180,6 +180,7 @@ set(ARANGODB_TESTS_SOURCES
   Basics/CpuUsageSnapshotTest.cpp
   Basics/EndpointTest.cpp
   Basics/FixedSizeAllocatorTest.cpp
+  Basics/HybridLogicalClockTest.cpp
   Basics/InifileParserTest.cpp
   Basics/LoggerTest.cpp
   Basics/MemoryUsageTest.cpp
@@ -253,6 +254,7 @@ set(ARANGODB_TESTS_SOURCES
   Network/UtilsTest.cpp
   Pregel/typedbuffer.cpp
   Replication/ReplicationClientsProgressTrackerTest.cpp
+  Rest/HttpRequestTest.cpp
   RestHandler/RestAnalyzerHandler-test.cpp
   RestHandler/RestDocumentHandler-test.cpp
   RestHandler/RestUsersHandler-test.cpp

--- a/tests/Containers/MerkleTreeTest.cpp
+++ b/tests/Containers/MerkleTreeTest.cpp
@@ -32,6 +32,7 @@
 #include "Basics/hashes.h"
 #include "Containers/MerkleTree.h"
 #include "Logger/LogMacros.h"
+#include "VocBase/Identifiers/RevisionId.h"
 
 #include <velocypack/Builder.h>
 #include <velocypack/Iterator.h>
@@ -1656,7 +1657,74 @@ TEST(MerkleTreeTest, overflow_underflow) {
     std::string msg{exc.what()};
     EXPECT_TRUE(msg.find("underflow") != std::string::npos);
   }
-};
+}
+
+TEST(MerkleTreeTest, tree_with_small_and_large_revisions) {
+  ::arangodb::containers::MerkleTree<::arangodb::containers::FnvHashProvider, 3>
+      t1(6, RevisionId::none().id());
+
+  // test what happens if a tree with very low revision ids get added
+  // some very high revision ids
+  for (uint64_t i = 1ULL; i < 100'000ULL; ++i) {
+    t1.insert(i);
+  }
+  for (uint64_t i = 100'000ULL; i < 100'000'000ULL; i += 100'000ULL) {
+    t1.insert(i);
+  }
+  for (uint64_t i = 100'000'000ULL; i < 1'000'000'000ULL; i += 1'000'000ULL) {
+    t1.insert(i);
+  }
+
+  auto t2 = t1.clone();
+  uint64_t offset = 1152921504606846976ULL;
+  for (uint64_t i = offset; i < offset + 10'000'000'000ULL; i += 10'000'000) {
+    t2->insert(i);
+  }
+
+  std::vector<std::pair<std::uint64_t, std::uint64_t>> d1 = t1.diff(*t2);
+
+  EXPECT_EQ(1, d1.size());
+  std::pair<std::uint64_t, std::uint64_t> expected = {1152921504606846976ULL,
+                                                      1152930300699869183ULL};
+  EXPECT_EQ(expected, d1.front());
+}
+
+TEST(MerkleTreeTest, tree_with_small_and_large_revisions_2) {
+  ::arangodb::containers::MerkleTree<::arangodb::containers::FnvHashProvider, 3>
+      t1(6, RevisionId::none().id());
+
+  // test what happens if a tree with very low revision ids get added
+  // some very high revision ids
+  for (uint64_t i = 1ULL; i < 100'000ULL; ++i) {
+    t1.insert(i);
+  }
+  for (uint64_t i = 100'000ULL; i < 100'000'000ULL; i += 100'000ULL) {
+    t1.insert(i);
+  }
+  for (uint64_t i = 100'000'000ULL; i < 1'000'000'000ULL; i += 1'000'000ULL) {
+    t1.insert(i);
+  }
+
+  ::arangodb::containers::MerkleTree<::arangodb::containers::FnvHashProvider, 3>
+      t2(6, RevisionId::lowerBound().id());
+
+  uint64_t offset = 1152921504606846976ULL;
+  for (uint64_t i = offset; i < offset + 10'000'000'000ULL; i += 10'000'000) {
+    t2.insert(i);
+  }
+
+  std::vector<std::pair<std::uint64_t, std::uint64_t>> d1 = t1.diff(t2);
+
+  EXPECT_EQ(2, d1.size());
+
+  std::pair<std::uint64_t, std::uint64_t> expected1 = {0ULL, 2199023255551ULL};
+  EXPECT_EQ(expected1, d1[0]);
+
+  std::pair<std::uint64_t, std::uint64_t> expected2 = {1152921397232664576ULL,
+                                                       1152923596255920127ULL};
+
+  EXPECT_EQ(expected2, d1[1]);
+}
 
 class MerkleTreeSpecialGrowTests
     : public ::arangodb::containers::MerkleTree<::arangodb::containers::FnvHashProvider, 3>,

--- a/tests/Rest/HttpRequestTest.cpp
+++ b/tests/Rest/HttpRequestTest.cpp
@@ -1,0 +1,134 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2021 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Jan Steemann
+/// @author Copyright 2021, ArangoDB GmbH, Cologne, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+#include "gtest/gtest.h"
+
+#include "Basics/Exceptions.h"
+#include "Endpoint/ConnectionInfo.h"
+#include "Rest/HttpRequest.h"
+
+#include <string_view>
+
+using namespace arangodb;
+
+TEST(HttpRequestTest, testMessageId) {
+  ConnectionInfo ci;
+  HttpRequest request(ci, 43, true);
+
+  EXPECT_EQ(43, request.messageId());
+}
+
+TEST(HttpRequestTest, testEmptyUrl) {
+  ConnectionInfo ci;
+  HttpRequest request(ci, 1, true);
+
+  std::string_view url("/");
+
+  request.parseUrl(url.data(), url.size());
+  EXPECT_EQ("/", request.fullUrl());
+  EXPECT_EQ("/", request.requestUrl());
+  EXPECT_TRUE(request.values().empty());
+}
+
+TEST(HttpRequestTest, testPathOnlyUrl) {
+  ConnectionInfo ci;
+  HttpRequest request(ci, 1, true);
+
+  std::string_view url("/a/foo/bar");
+
+  request.parseUrl(url.data(), url.size());
+  EXPECT_EQ("/a/foo/bar", request.fullUrl());
+  EXPECT_EQ("/a/foo/bar", request.requestUrl());
+  EXPECT_TRUE(request.values().empty());
+}
+
+TEST(HttpRequestTest, testDuplicateForwardSlashesInUrl) {
+  ConnectionInfo ci;
+  HttpRequest request(ci, 1, true);
+
+  std::string_view url("//a//foo//bar");
+
+  request.parseUrl(url.data(), url.size());
+  EXPECT_EQ("/a/foo/bar", request.fullUrl());
+  EXPECT_EQ("/a/foo/bar", request.requestUrl());
+  EXPECT_TRUE(request.values().empty());
+}
+
+TEST(HttpRequestTest, testUrlParameters) {
+  ConnectionInfo ci;
+  HttpRequest request(ci, 1, true);
+
+  std::string_view url("/foo/bar/baz?a=1&b=23&c=d&e=foobar&f=baz&bark=quxxxx");
+
+  request.parseUrl(url.data(), url.size());
+
+  EXPECT_EQ("1", request.value("a"));
+  EXPECT_EQ("23", request.value("b"));
+  EXPECT_EQ("d", request.value("c"));
+  EXPECT_EQ("foobar", request.value("e"));
+  EXPECT_EQ("baz", request.value("f"));
+  EXPECT_EQ("quxxxx", request.value("bark"));
+}
+
+TEST(HttpRequestTest, testEmptyUrlParameters) {
+  ConnectionInfo ci;
+  HttpRequest request(ci, 1, true);
+
+  std::string_view url("/?a=&b=&c=d&e=foobar&f=");
+
+  request.parseUrl(url.data(), url.size());
+
+  EXPECT_EQ("", request.value("a"));
+  EXPECT_EQ("", request.value("b"));
+  EXPECT_EQ("d", request.value("c"));
+  EXPECT_EQ("foobar", request.value("e"));
+  EXPECT_EQ("", request.value("f"));
+}
+
+TEST(HttpRequestTest, testUrlEncoding) {
+  ConnectionInfo ci;
+  HttpRequest request(ci, 1, true);
+
+  std::string_view url(
+      "/foo/bar/"
+      "baz?a=%2fa%2eb%2ec&1=abc&foo=foo+bar&bark=%2Fa%5B%5D%3D%3F%26&uff=%09");
+
+  request.parseUrl(url.data(), url.size());
+
+  EXPECT_EQ("/a.b.c", request.value("a"));
+  EXPECT_EQ("abc", request.value("1"));
+  EXPECT_EQ("foo bar", request.value("foo"));
+  EXPECT_EQ("/a[]=?&", request.value("bark"));
+  EXPECT_EQ("\x09", request.value("uff"));
+}
+
+TEST(HttpRequestTest, testWrongUrlEncoding) {
+  ConnectionInfo ci;
+  HttpRequest request(ci, 1, true);
+
+  std::string_view url("/foo/?a=%fg");
+
+  EXPECT_THROW(request.parseUrl(url.data(), url.size()),
+               arangodb::basics::Exception);
+}

--- a/tests/Rest/HttpRequestTest.cpp
+++ b/tests/Rest/HttpRequestTest.cpp
@@ -129,6 +129,5 @@ TEST(HttpRequestTest, testWrongUrlEncoding) {
 
   std::string_view url("/foo/?a=%fg");
 
-  EXPECT_THROW(request.parseUrl(url.data(), url.size()),
-               arangodb::basics::Exception);
+  EXPECT_EQ("", request.value("a"));
 }

--- a/tests/Rest/HttpRequestTest.cpp
+++ b/tests/Rest/HttpRequestTest.cpp
@@ -128,6 +128,8 @@ TEST(HttpRequestTest, testWrongUrlEncoding) {
   HttpRequest request(ci, 1, true);
 
   std::string_view url("/foo/?a=%fg");
+  // parseUrl doesn't throw on invalid encodings in 3.8
+  request.parseUrl(url.data(), url.size());
 
-  EXPECT_EQ("", request.value("a"));
+  EXPECT_EQ("p", request.value("a"));
 }

--- a/tests/js/server/replication/sync/replication-sync-malarkey.js
+++ b/tests/js/server/replication/sync/replication-sync-malarkey.js
@@ -1409,12 +1409,36 @@ function ReplicationIncrementalMalarkeyNewFormatIntermediateCommits() {
   return suite;
 }
 
+function ReplicationIncrementalMalarkeyNoHLC() {
+  'use strict';
+
+  let suite = {
+    setUp: function () {
+      connectToFollower();
+      // clear all failure points except the one that will lead to the follower
+      // sending requests without forced HLCs
+      clearFailurePoints();
+      setFailurePoint("SyncerNoEncodeAsHLC");
+      db._drop(cn);
+
+      connectToLeader();
+      // clear all failure points
+      clearFailurePoints();
+      db._drop(cn);
+    },
+  };
+
+  deriveTestSuite(BaseTestConfig(), suite, '_NoHLC');
+  return suite;
+}
+
 let res = arango.GET("/_admin/debug/failat");
 if (res === true) {
   // tests only work when compiled with -DUSE_FAILURE_TESTS
   jsunity.run(ReplicationIncrementalMalarkeyOldFormat);
   jsunity.run(ReplicationIncrementalMalarkeyNewFormat);
   jsunity.run(ReplicationIncrementalMalarkeyNewFormatIntermediateCommits);
+  jsunity.run(ReplicationIncrementalMalarkeyNoHLC);
 }
 
 return jsunity.done();


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/17310
Fixes BTS-1073: https://arangodb.atlassian.net/browse/BTS-1073

* Fix encoding and decoding of revision ids in replication incremental sync protocol. Previously, the encoding of revision ids could be ambiguous under some circumstances when sending them to the `/_api/replication/ranges` leader API endpoint, which could prevent shards from getting into sync. The fix is validated by a new test suite.
* Fixed parsing of empty URL parameters in incoming HTTP requests, which previously produced a wrong result. For example, sending `?a=b&c=&d=e` produced `["a":"b", "c": "&d", "d":"e" ]` (i.e. the value of `c` was wrong). The fix is validated by new tests.
* Fixed aborting the server process if an exception was thrown in C++ code that was invoked from the llhttp C code dispatcher. That dispatcher code couldn't handle C++ exceptions properly, and thus aborted the entire process when an exception occurred during HTTP request processing.
* Fixed diffing of completely non-overlapping revision trees, which could lead to out-of-bounds reads at the right end of the first (smaller) tree (undefined behavior). This was discovered by accident while doing some experiments with different revision id ranges and putting them into revision trees. The fix is validated by a new test.

The PRs also add some tests for the hybrid logical clock (HLC).
Apart from that, the PR cleans up some revision id-related code, but doesn't change/fix the behavior of how revision ids are encoded/decoded.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [x] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [x] Backports
  - [x] Backport for 3.10: https://github.com/arangodb/arangodb/pull/17320
  - [x] Backport for 3.9: https://github.com/arangodb/arangodb/pull/17301
  - [x] Backport for 3.8: this PR

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [x] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/BTS-1073
- [ ] Design document: 