### PR TITLE
[SEARCH-406] Fix handling of removals in presence of primary sort

### DIFF
--- a/3rdParty/iresearch/core/index/index_writer.cpp
+++ b/3rdParty/iresearch/core/index/index_writer.cpp
@@ -1061,30 +1061,21 @@ uint64_t index_writer::segment_context::flush() {
     return 0; // skip flushing an empty writer
   }
 
-  auto flushed_docs_count = flushed_update_contexts_.size();
-
-  assert(std::numeric_limits<doc_id_t>::max() >= writer_->docs_cached());
-  flushed_update_contexts_.reserve(flushed_update_contexts_.size() + writer_->docs_cached());
+  assert(writer_->docs_cached() <= doc_limits::eof());
   flushed_.emplace_back(std::move(writer_meta_.meta));
-
-  // copy over update_contexts
-  for (size_t doc_id = doc_limits::min(),
-       doc_id_end = writer_->docs_cached() + doc_limits::min();
-       doc_id < doc_id_end;
-       ++doc_id) {
-    assert(doc_id <= std::numeric_limits<doc_id_t>::max());
-    flushed_update_contexts_.emplace_back(writer_->doc_context(doc_id_t(doc_id)));
-  }
 
   auto& segment = flushed_.back();
 
   // flush segment_writer
   try {
     writer_->flush(segment);
+
+    auto& ctxs = writer_->docs_context();
+    flushed_update_contexts_.insert(flushed_update_contexts_.end(),
+                                    ctxs.begin(), ctxs.end());
   } catch (...) {
     // failed to flush segment
     flushed_.pop_back();
-    flushed_update_contexts_.resize(flushed_docs_count);
 
     throw;
   }

--- a/3rdParty/iresearch/core/index/segment_writer.cpp
+++ b/3rdParty/iresearch/core/index/segment_writer.cpp
@@ -316,7 +316,10 @@ void segment_writer::flush(index_meta::index_segment_t& segment) {
     fields_.flush_features(*col_writer_, docmap, buffer);
 
     meta.sort = sort_.id; // store sorted column id in segment meta
+
+    if (!docmap.empty()) {
       reorder(docs_context_, docmap);
+    }
   }
 
   // flush columnstore

--- a/3rdParty/iresearch/core/index/segment_writer.cpp
+++ b/3rdParty/iresearch/core/index/segment_writer.cpp
@@ -57,6 +57,8 @@ void reorder(std::vector<segment_writer::update_context>& ctxs,
   }
 }
 
+}
+
 namespace iresearch {
 
 segment_writer::stored_column::stored_column(

--- a/3rdParty/iresearch/core/index/segment_writer.cpp
+++ b/3rdParty/iresearch/core/index/segment_writer.cpp
@@ -35,6 +35,30 @@
 #include "utils/type_limits.hpp"
 #include "utils/version_utils.hpp"
 
+#include "index/norm.hpp"
+
+namespace {
+
+using namespace irs;
+
+void reorder(std::vector<segment_writer::update_context>& ctxs,
+             const doc_map& docmap) {
+  assert(!docmap.empty());
+
+  for (size_t doc = doc_limits::min(); doc <= ctxs.size(); ++doc) {
+    assert(doc < docmap.size());
+    const auto new_doc = docmap[doc];
+    assert(!doc_limits::eof(new_doc));
+
+    if (new_doc > doc) {
+      assert(new_doc > 0);
+      assert(new_doc <= ctxs.size());
+      std::swap(ctxs[doc - doc_limits::min()],
+                ctxs[new_doc - doc_limits::min()]);
+    }
+  }
+}
+
 namespace iresearch {
 
 segment_writer::stored_column::stored_column(
@@ -292,6 +316,7 @@ void segment_writer::flush(index_meta::index_segment_t& segment) {
     fields_.flush_features(*col_writer_, docmap, buffer);
 
     meta.sort = sort_.id; // store sorted column id in segment meta
+      reorder(docs_context_, docmap);
   }
 
   // flush columnstore

--- a/3rdParty/iresearch/core/index/segment_writer.cpp
+++ b/3rdParty/iresearch/core/index/segment_writer.cpp
@@ -35,8 +35,6 @@
 #include "utils/type_limits.hpp"
 #include "utils/version_utils.hpp"
 
-#include "index/norm.hpp"
-
 namespace {
 
 using namespace irs;

--- a/3rdParty/iresearch/core/index/segment_writer.hpp
+++ b/3rdParty/iresearch/core/index/segment_writer.hpp
@@ -216,6 +216,9 @@ class IRESEARCH_API segment_writer: util::noncopyable {
 
   void flush(index_meta::index_segment_t& segment);
 
+  const update_contexts& docs_context() noexcept {
+    return docs_context_;
+  };
   const std::string& name() const noexcept { return seg_name_; }
   size_t docs_cached() const noexcept { return docs_context_.size(); }
   bool initialized() const noexcept { return initialized_; }

--- a/tests/IResearch/IResearchView-test.cpp
+++ b/tests/IResearch/IResearchView-test.cpp
@@ -2341,6 +2341,87 @@ TEST_F(IResearchViewTest, test_insert) {
   }
 }
 
+TEST_F(IResearchViewTest, test_remove_within_trx) {
+  using namespace arangodb;
+
+  auto collectionJson =
+      velocypack::Parser::fromJson(R"({ "name": "testCollection" })");
+  auto linkJson = velocypack::Parser::fromJson(
+      R"({ "view": "testView",
+           "includeAllFields": true,
+           "primarySort": [ { "field" : "name", "asc": false } ] })");
+  auto json = velocypack::Parser::fromJson(
+      R"({ "name": "testView", "type":"arangosearch", "cleanupIntervalStep":0, "commitIntervalMsec": 0, "consolidationIntervalMsec" : 0 })");
+
+  Vocbase vocbase(TRI_vocbase_type_e::TRI_VOCBASE_TYPE_NORMAL,
+                  testDBInfo(server.server()));
+  auto logicalCollection = vocbase.createCollection(collectionJson->slice());
+  ASSERT_NE(nullptr, logicalCollection);
+  auto logicalView = vocbase.createView(json->slice());
+  ASSERT_NE(nullptr, logicalView);
+  auto* view =
+      dynamic_cast<arangodb::iresearch::IResearchView*>(logicalView.get());
+  ASSERT_NE(nullptr, view);
+  auto index = StorageEngineMock::buildLinkMock(IndexId{42}, *logicalCollection,
+                                                linkJson->slice());
+  ASSERT_NE(nullptr, index.get());
+  auto link =
+      std::dynamic_pointer_cast<arangodb::iresearch::IResearchLink>(index);
+  ASSERT_NE(nullptr, link);
+
+  // transaction
+  {
+    std::vector<std::string> const empty;
+
+    auto doc0 = velocypack::Parser::fromJson(R"({ "name": "a" })");
+    auto doc1 = velocypack::Parser::fromJson(R"({ "name": "b" })");
+    auto doc2 = velocypack::Parser::fromJson(R"({ "name": "c" })");
+
+    transaction::Methods trx(transaction::StandaloneContext::Create(vocbase),
+                             empty, empty, empty, transaction::Options());
+    EXPECT_TRUE(trx.begin().ok());
+    EXPECT_TRUE(link->insert(trx, LocalDocumentId(0), doc0->slice()).ok());
+    EXPECT_TRUE(link->remove(trx, LocalDocumentId(0),
+                             velocypack::Slice::emptyObjectSlice())
+                    .ok());
+    EXPECT_TRUE(link->insert(trx, LocalDocumentId(1), doc1->slice()).ok());
+    EXPECT_TRUE(link->remove(trx, LocalDocumentId(1),
+                             velocypack::Slice::emptyObjectSlice())
+                    .ok());
+    EXPECT_TRUE(link->insert(trx, LocalDocumentId(2), doc2->slice()).ok());
+    EXPECT_TRUE(trx.commit().ok());
+    EXPECT_TRUE(link->commit().ok());
+  }
+
+  // only doc2 must remain
+  {
+    auto snapshot = link->snapshot();
+    auto reader = snapshot.getDirectoryReader();
+    ASSERT_EQ(1, reader->size());
+    ASSERT_EQ(3, reader->docs_count());
+    ASSERT_EQ(1, reader->live_docs_count());
+
+    auto& segment = reader[0];
+    const auto* column = segment.sort();
+    ASSERT_NE(nullptr, column);
+    ASSERT_TRUE(column->name().null());
+    ASSERT_EQ(0, column->payload().size());
+    auto values = column->iterator(false);
+    ASSERT_NE(nullptr, values);
+    auto* value = irs::get<irs::payload>(*values);
+    ASSERT_NE(nullptr, value);
+
+    auto docs = segment.docs_iterator();
+    ASSERT_NE(nullptr, docs);
+    ASSERT_TRUE(docs->next());
+    ASSERT_EQ(docs->value(), values->seek(docs->value()));
+    VPackSlice const slice{value->value.c_str()};
+    ASSERT_TRUE(slice.isString());
+    ASSERT_EQ("c", slice.stringView());
+    ASSERT_FALSE(docs->next());
+  }
+}
+
 TEST_F(IResearchViewTest, test_remove) {
   static std::vector<std::string> const EMPTY;
   auto collectionJson = arangodb::velocypack::Parser::fromJson("{ \"name\": \"testCollection\" }");

--- a/tests/IResearch/IResearchView-test.cpp
+++ b/tests/IResearch/IResearchView-test.cpp
@@ -2396,7 +2396,7 @@ TEST_F(IResearchViewTest, test_remove_within_trx) {
   // only doc2 must remain
   {
     auto snapshot = link->snapshot();
-    auto reader = snapshot.getDirectoryReader();
+    auto reader = static_cast<irs::directory_reader>(snapshot);
     ASSERT_EQ(1, reader->size());
     ASSERT_EQ(3, reader->docs_count());
     ASSERT_EQ(1, reader->live_docs_count());

--- a/tests/IResearch/IResearchView-test.cpp
+++ b/tests/IResearch/IResearchView-test.cpp
@@ -2403,10 +2403,8 @@ TEST_F(IResearchViewTest, test_remove_within_trx) {
 
     auto& segment = reader[0];
     const auto* column = segment.sort();
-    ASSERT_NE(nullptr, column);
-    ASSERT_TRUE(column->name().null());
-    ASSERT_EQ(0, column->payload().size());
-    auto values = column->iterator(false);
+    ASSERT_NE(nullptr, column);    
+    auto values = column->iterator();
     ASSERT_NE(nullptr, values);
     auto* value = irs::get<irs::payload>(*values);
     ASSERT_NE(nullptr, value);


### PR DESCRIPTION
### Scope & Purpose

Fix handling of removals in presence of primary sort

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: *(Please link PR)*
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

