### PR TITLE
ES-1312: fix handling of reaching WAL archive capacity limit

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 devel
 -----
 
+* ES-1312: fix handling of reaching the WAL archive capacity limit.
+
 * BTS-941: The HTTP API now delivers the correct list of the collection's
   shards in case a collection from an EnterpriseGraph, SmartGraph, Disjoint
   EnterpriseGraph, Disjoint SmartGraph or SatelliteGraph is being used.

--- a/arangod/RocksDBEngine/RocksDBEngine.cpp
+++ b/arangod/RocksDBEngine/RocksDBEngine.cpp
@@ -2373,8 +2373,8 @@ void RocksDBEngine::determinePrunableWalFiles(TRI_voc_tick_t minTickExternal) {
       << "number of prunable files: " << _prunableWalFiles.size();
 
   if (_maxWalArchiveSizeLimit > 0 &&
-      totalArchiveSize <= _maxWalArchiveSizeLimit) {
-    // size of the archive is restricted.
+      totalArchiveSize > _maxWalArchiveSizeLimit) {
+    // size of the archive is restricted, and we overflowed the limit.
 
     // print current archive size
     LOG_TOPIC("8d71b", TRACE, Logger::ENGINES)
@@ -2406,13 +2406,19 @@ void RocksDBEngine::determinePrunableWalFiles(TRI_voc_tick_t minTickExternal) {
       }
 
       if (doPrint) {
+        TRI_ASSERT(totalArchiveSize > _maxWalArchiveSizeLimit);
+
+        // never change this id without adjusting wal-archive-size-limit tests
+        // in tests/js/client/server-parameters
         LOG_TOPIC("d9793", WARN, Logger::ENGINES)
             << "forcing removal of RocksDB WAL file '" << f->PathName()
             << "' with start sequence " << f->StartSequence()
             << " because of overflowing archive. configured maximum archive "
                "size is "
             << _maxWalArchiveSizeLimit
-            << ", actual archive size is: " << totalArchiveSize;
+            << ", actual archive size is: " << totalArchiveSize
+            << ". if these warnings persist, try to increase the value of "
+            << "the startup option `--rocksdb.wal-archive-size-limit`";
       }
 
       TRI_ASSERT(totalArchiveSize >= f->SizeFileBytes());

--- a/tests/js/client/server_parameters/wal-archive-size-limit-large-noncluster.js
+++ b/tests/js/client/server_parameters/wal-archive-size-limit-large-noncluster.js
@@ -1,0 +1,122 @@
+/*jshint globalstrict:false, strict:false */
+/* global getOptions, assertTrue, assertFalse, arango, assertMatch, assertEqual */
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief test for server startup options
+///
+/// DISCLAIMER
+///
+/// Copyright 2010-2012 triagens GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB Inc, Cologne, Germany
+///
+/// @author Jan Steemann
+/// @author Copyright 2019, ArangoDB Inc, Cologne, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+const fs = require('fs');
+
+if (getOptions === true) {
+  return {
+    'log.output': 'file://' + fs.getTempFile() + '.$PID',
+    'rocksdb.wal-archive-size-limit': '32000000000', // roughly 32GB
+    'rocksdb.wal-file-timeout-initial': '10',
+  };
+}
+
+const jsunity = require('jsunity');
+
+function WalArchiveSizeLimitSuite() {
+  'use strict';
+      
+  const db = require("internal").db;
+  let oldLogLevel;
+
+  return {
+    setUpAll : function() {
+      oldLogLevel = arango.GET("/_admin/log/level").general;
+      // adjusting log levels is necessary to find the messages in the
+      // logs later - otherwise they would be suppressed
+      arango.PUT("/_admin/log/level", { general: "info", engines: "warning" });
+    },
+    
+    tearDownAll : function () {
+      // restore previous log level for "general" topic;
+      arango.PUT("/_admin/log/level", { general: oldLogLevel });
+    },
+      
+    setUp : function () {
+      db._create("UnitTestsCollection");
+    },
+
+    tearDown : function () {
+      db._drop("UnitTestsCollection");
+    },
+
+    testDoesNotForceDeleteWalFiles: function() {
+      // insert larger amounts of data on the server
+      let res = arango.POST("/_admin/execute?returnBodyAsJSON=true", `
+require('console').log("testmann: start"); 
+let docs = [];
+for (let i = 0; i < 1000; ++i) {
+  docs.push({ value1: "test" + i, payload: Array(512).join("x") });
+}
+let db = require("internal").db;
+let time = require("internal").time;
+let start = time();
+do {
+  db.UnitTestsCollection.insert(docs);
+} while (time() - start < 20);
+  
+require('console').log("testmann: done"); 
+return require('internal').options()["log.output"];
+`);
+
+      assertTrue(Array.isArray(res));
+      assertTrue(res.length > 0);
+
+      let logfile = res[res.length - 1].replace(/^file:\/\//, '');
+
+      // log is buffered, so give it a few tries until the log messages appear
+      let tries = 0;
+      let filtered = [];
+      while (++tries < 60) {
+        let content = fs.readFileSync(logfile, 'ascii');
+        let lines = content.split('\n');
+
+        filtered = lines.filter((line) => {
+          // logId "d9793" from RocksDBEngine.cpp
+          return line.match(/(testmann: |d9793)/);
+        });
+
+        if (filtered.length >= 2) {
+          break;
+        }
+
+        require("internal").sleep(0.5);
+      }
+
+      // this will fail if warning d9793 was logged
+      assertEqual(2, filtered.length);
+          
+      assertTrue(filtered[0].match(/testmann: start/));
+      assertTrue(filtered[1].match(/testmann: done/));
+    },
+
+  };
+}
+
+jsunity.run(WalArchiveSizeLimitSuite);
+return jsunity.done();

--- a/tests/js/client/server_parameters/wal-archive-size-limit-small-noncluster.js
+++ b/tests/js/client/server_parameters/wal-archive-size-limit-small-noncluster.js
@@ -1,0 +1,128 @@
+/*jshint globalstrict:false, strict:false */
+/* global getOptions, assertTrue, assertFalse, arango, assertMatch, assertEqual */
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief test for server startup options
+///
+/// DISCLAIMER
+///
+/// Copyright 2010-2012 triagens GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB Inc, Cologne, Germany
+///
+/// @author Jan Steemann
+/// @author Copyright 2019, ArangoDB Inc, Cologne, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+const fs = require('fs');
+
+if (getOptions === true) {
+  return {
+    'log.output': 'file://' + fs.getTempFile() + '.$PID',
+    'rocksdb.wal-archive-size-limit': '10000000', // roughly 10MB
+    'rocksdb.wal-file-timeout-initial': '10',
+  };
+}
+
+const jsunity = require('jsunity');
+
+function WalArchiveSizeLimitSuite() {
+  'use strict';
+      
+  const db = require("internal").db;
+  let oldLogLevel;
+
+  return {
+    setUpAll : function() {
+      oldLogLevel = arango.GET("/_admin/log/level").general;
+      // adjusting log levels is necessary to find the messages in the
+      // logs later - otherwise they would be suppressed
+      arango.PUT("/_admin/log/level", { general: "info", engines: "warning" });
+    },
+    
+    tearDownAll : function () {
+      // restore previous log level for "general" topic;
+      arango.PUT("/_admin/log/level", { general: oldLogLevel });
+    },
+      
+    setUp : function () {
+      db._create("UnitTestsCollection");
+    },
+
+    tearDown : function () {
+      db._drop("UnitTestsCollection");
+    },
+
+    testDoesNotForceDeleteWalFiles: function() {
+      // insert larger amounts of data on the server
+      let res = arango.POST("/_admin/execute?returnBodyAsJSON=true", `
+require('console').log("testmann: start"); 
+let docs = [];
+for (let i = 0; i < 1000; ++i) {
+  docs.push({ value1: "test" + i, payload: Array(512).join("x") });
+}
+let db = require("internal").db;
+let time = require("internal").time;
+let start = time();
+do {
+  db.UnitTestsCollection.insert(docs);
+} while (time() - start < 20);
+  
+require('console').log("testmann: done"); 
+return require('internal').options()["log.output"];
+`);
+
+      assertTrue(Array.isArray(res));
+      assertTrue(res.length > 0);
+
+      let logfile = res[res.length - 1].replace(/^file:\/\//, '');
+
+      // log is buffered, so give it a few tries until the log messages appear
+      let tries = 0;
+      let filtered = [];
+      while (++tries < 60) {
+        let content = fs.readFileSync(logfile, 'ascii');
+        let lines = content.split('\n');
+
+        filtered = lines.filter((line) => {
+          // logId "d9793" from RocksDBEngine.cpp
+          return line.match(/(testmann: |d9793)/);
+        });
+
+        if (filtered.length >= 2) {
+          break;
+        }
+
+        require("internal").sleep(0.5);
+      }
+
+      // this will fail if warning d9793 was *not* logged
+      let found = false;
+      assertTrue(filtered[0].match(/testmann: start/));
+      for (let i = 0; i < filtered.length; ++i) {
+        if (filtered[i].match(/d9793/)) {
+          found = true;
+          break;
+        }
+      }
+
+      assertTrue(found);
+    },
+
+  };
+}
+
+jsunity.run(WalArchiveSizeLimitSuite);
+return jsunity.done();


### PR DESCRIPTION
### Scope & Purpose

Fixed issue https://arangodb.atlassian.net/browse/ES-1312

Fix handling of reaching the WAL archive capacity limit.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.10: https://github.com/arangodb/arangodb/pull/17353
  - [x] Backport for 3.9: https://github.com/arangodb/arangodb/pull/17354
  - [x] Backport for 3.8: https://github.com/arangodb/arangodb/pull/17355

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [x] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/ES-1312
- [ ] Design document: 