### PR TITLE
[SEARCH-407] [SEARCH-405] [SEARCH-404] Fix handling of ALL quantifier 

### DIFF
--- a/arangod/IResearch/IResearchKludge.cpp
+++ b/arangod/IResearch/IResearchKludge.cpp
@@ -100,12 +100,12 @@ void mangleString(std::string& name) {
   name.append(kStringSuffix);
 }
 
-#ifdef USE_ENTERPRISE
 void mangleNested(std::string& name) {
   normalizeExpansion(name);
   name += kNestedDelimiter;
 }
 
+#ifdef USE_ENTERPRISE
 bool isNestedField(irs::string_ref name) noexcept {
   return !name.empty() && name.back() == kNestedDelimiter;
 }

--- a/arangod/IResearch/IResearchKludge.h
+++ b/arangod/IResearch/IResearchKludge.h
@@ -38,10 +38,10 @@ namespace arangodb::iresearch::kludge {
 #ifdef USE_ENTERPRISE
 inline constexpr char kNestedDelimiter = '\2';
 bool isNestedField(irs::string_ref name) noexcept;
-void mangleNested(std::string& name);
 #endif
 
 bool needTrackPrevDoc(irs::string_ref name, bool nested) noexcept;
+void mangleNested(std::string& name);
 void mangleType(std::string& name);
 void mangleAnalyzer(std::string& name);
 

--- a/arangod/IResearch/IResearchKludge.h
+++ b/arangod/IResearch/IResearchKludge.h
@@ -35,8 +35,9 @@
 
 namespace arangodb::iresearch::kludge {
 
-#ifdef USE_ENTERPRISE
 inline constexpr char kNestedDelimiter = '\2';
+
+#ifdef USE_ENTERPRISE
 bool isNestedField(irs::string_ref name) noexcept;
 #endif
 

--- a/tests/IResearch/ExpressionFilterTest.cpp
+++ b/tests/IResearch/ExpressionFilterTest.cpp
@@ -447,7 +447,7 @@ TEST_F(IResearchExpressionFilterTest, test) {
   // open reader
   auto reader = irs::directory_reader::open(dir);
   ASSERT_TRUE(reader);
-  ASSERT_EQ(1, reader->size());
+  ASSERT_EQ(1U, reader->size());
   auto& segment = (*reader)[0];
   EXPECT_TRUE(reader->docs_count() > 0);
 

--- a/tests/IResearch/GeoDistanceFilterTest.cpp
+++ b/tests/IResearch/GeoDistanceFilterTest.cpp
@@ -471,7 +471,7 @@ TEST(GeoDistanceFilterTest, query) {
 
   auto reader = irs::directory_reader::open(dir);
   ASSERT_NE(nullptr, reader);
-  ASSERT_EQ(2, reader->size());
+  ASSERT_EQ(2U, reader->size());
   ASSERT_EQ(docs->slice().length(), reader->docs_count());
   ASSERT_EQ(docs->slice().length(), reader->live_docs_count());
 

--- a/tests/IResearch/GeoFilterTest.cpp
+++ b/tests/IResearch/GeoFilterTest.cpp
@@ -390,7 +390,7 @@ TEST(GeoFilterTest, query) {
 
   auto reader = irs::directory_reader::open(dir);
   ASSERT_NE(nullptr, reader);
-  ASSERT_EQ(2, reader->size());
+  ASSERT_EQ(2U, reader->size());
   ASSERT_EQ(docs->slice().length(), reader->docs_count());
   ASSERT_EQ(docs->slice().length(), reader->live_docs_count());
 

--- a/tests/IResearch/IResearchFilterFunctionTest.cpp
+++ b/tests/IResearch/IResearchFilterFunctionTest.cpp
@@ -1446,6 +1446,37 @@ TEST_F(IResearchFilterFunctionTest, Exists) {
         "RETURN d");
   }
 
+  // field + nested
+  {
+    irs::Or expected;
+    auto& exists = expected.add<irs::by_column_existence>();
+    *exists.mutable_field() = mangleNested("name");
+
+    assertFilterSuccess(
+        vocbase(), "FOR d IN myView FILTER exists(d.name, 'nested') RETURN d",
+        expected);
+    assertFilterSuccess(
+        vocbase(), "FOR d IN myView FILTER eXists(d.name, 'nested') RETURN d",
+        expected);
+    assertFilterSuccess(
+        vocbase(), "FOR d IN myView FILTER exists(d.name, 'Nested') RETURN d",
+        expected);
+    assertFilterSuccess(
+        vocbase(), "FOR d IN myView FILTER exists(d.name, 'NESTED') RETURN d",
+        expected);
+    assertFilterSuccess(
+        vocbase(),
+        "FOR d IN myView FILTER analyzer(exists(d.name, 'NESTED'), "
+        "'test_analyzer') RETURN d",
+        expected);
+
+    // invalid 3rd argument
+    assertFilterFail(
+        vocbase(),
+        "FOR d IN myView FILTER exists(d.name, 'nested', 'test_analyzer') "
+        "RETURN d");
+  }
+
   // invalid 2nd argument
   assertFilterFail(vocbase(),
                    "FOR d IN myView FILTER exists(d.name, 'foo') RETURN d");

--- a/tests/IResearch/IResearchFilterNestedTest.cpp
+++ b/tests/IResearch/IResearchFilterNestedTest.cpp
@@ -42,6 +42,7 @@
 #include "Aql/Function.h"
 #include "IResearch/common.h"
 #include "IResearch/IResearchCommon.h"
+#include "IResearch/IResearchFilterFactoryCommon.h"
 #include "IResearch/ExpressionContextMock.h"
 #include "RestServer/DatabaseFeature.h"
 #include "VocBase/Methods/Collections.h"

--- a/tests/IResearch/common.cpp
+++ b/tests/IResearch/common.cpp
@@ -175,7 +175,8 @@ std::ostream& operator<<(std::ostream& os, empty const&) {
 
 std::ostream& operator<<(std::ostream& os,
                          irs::by_column_existence const& filter) {
-  os << "EXISTS[" << filter.field() << "]";
+  os << "EXISTS[" << filter.field() << ", " << size_t(filter.options().acceptor)
+     << "]";
   return os;
 }
 
@@ -672,12 +673,10 @@ std::string mangleNumeric(std::string name) {
   return name;
 }
 
-#ifdef USE_ENTERPRISE
 std::string mangleNested(std::string name) {
   arangodb::iresearch::kludge::mangleNested(name);
   return name;
 }
-#endif
 
 std::string mangleString(std::string name, std::string_view suffix) {
   arangodb::iresearch::kludge::mangleAnalyzer(name);


### PR DESCRIPTION
### Scope & Purpose

* Fix handling of ALL quantifier for boolean expansion for views.
* Allow `EXISTS` function to check presence of nested fields.
* Allow using ALL quantifier for arangosearch views.

- [x] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.10: *(Please link PR)*
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [x] Enterprise PR: https://github.com/arangodb/enterprise/pull/1110
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

