### PR TITLE
[GWEN] Feature/fast wcc

### DIFF
--- a/arangod/Pregel/tests/CMakeLists.txt
+++ b/arangod/Pregel/tests/CMakeLists.txt
@@ -10,4 +10,16 @@ target_include_directories(arangodbtests_wcc PRIVATE
   ${PROJECT_BINARY_DIR}/lib
   ${PROJECT_SOURCE_DIR}/arangod/Pregel)
 
+target_include_directories(arangodbtests_scc PRIVATE
+        ${PROJECT_SOURCE_DIR}/lib
+        ${PROJECT_BINARY_DIR}/lib
+        ${PROJECT_SOURCE_DIR}/arangod/Pregel)
+
+target_include_directories(arangodbtests_disjoint_set PRIVATE
+        ${PROJECT_SOURCE_DIR}/lib
+        ${PROJECT_BINARY_DIR}/lib
+        ${PROJECT_SOURCE_DIR}/arangod/Pregel)
+
 target_link_libraries(arangodbtests_wcc velocypack fmt gtest)
+target_link_libraries(arangodbtests_scc velocypack fmt gtest)
+target_link_libraries(arangodbtests_disjoint_set velocypack fmt gtest)

--- a/arangod/Pregel/tests/CMakeLists.txt
+++ b/arangod/Pregel/tests/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_executable(arangodbtests_wcc
   ${PROJECT_SOURCE_DIR}/lib/Basics/VelocyPackStringLiteral.cpp
+  GraphsSource.cpp
   WeaklyConnectedComponentsTest.cpp
   Graph.cpp
   WCCGraph.cpp

--- a/arangod/Pregel/tests/CMakeLists.txt
+++ b/arangod/Pregel/tests/CMakeLists.txt
@@ -1,6 +1,8 @@
 add_executable(arangodbtests_wcc
   ${PROJECT_SOURCE_DIR}/lib/Basics/VelocyPackStringLiteral.cpp
-  WeaklyConnectedComponentsTest.cpp)
+  WeaklyConnectedComponentsTest.cpp
+  Graph.cpp
+  DisjointSet.cpp)
 
 target_include_directories(arangodbtests_wcc PRIVATE
   ${PROJECT_SOURCE_DIR}/lib

--- a/arangod/Pregel/tests/CMakeLists.txt
+++ b/arangod/Pregel/tests/CMakeLists.txt
@@ -11,16 +11,4 @@ target_include_directories(arangodbtests_wcc PRIVATE
   ${PROJECT_BINARY_DIR}/lib
   ${PROJECT_SOURCE_DIR}/arangod/Pregel)
 
-target_include_directories(arangodbtests_scc PRIVATE
-        ${PROJECT_SOURCE_DIR}/lib
-        ${PROJECT_BINARY_DIR}/lib
-        ${PROJECT_SOURCE_DIR}/arangod/Pregel)
-
-target_include_directories(arangodbtests_disjoint_set PRIVATE
-        ${PROJECT_SOURCE_DIR}/lib
-        ${PROJECT_BINARY_DIR}/lib
-        ${PROJECT_SOURCE_DIR}/arangod/Pregel)
-
 target_link_libraries(arangodbtests_wcc velocypack fmt gtest)
-target_link_libraries(arangodbtests_scc velocypack fmt gtest)
-target_link_libraries(arangodbtests_disjoint_set velocypack fmt gtest)

--- a/arangod/Pregel/tests/CMakeLists.txt
+++ b/arangod/Pregel/tests/CMakeLists.txt
@@ -2,6 +2,7 @@ add_executable(arangodbtests_wcc
   ${PROJECT_SOURCE_DIR}/lib/Basics/VelocyPackStringLiteral.cpp
   WeaklyConnectedComponentsTest.cpp
   Graph.cpp
+  WCCGraph.cpp
   DisjointSet.cpp)
 
 target_include_directories(arangodbtests_wcc PRIVATE

--- a/arangod/Pregel/tests/CMakeLists.txt
+++ b/arangod/Pregel/tests/CMakeLists.txt
@@ -1,3 +1,9 @@
+add_executable(arangodbtests_graph
+        ${PROJECT_SOURCE_DIR}/lib/Basics/VelocyPackStringLiteral.cpp
+        GraphTest.cpp
+        GraphsSource.cpp
+        Graph.cpp)
+
 add_executable(arangodbtests_wcc
   ${PROJECT_SOURCE_DIR}/lib/Basics/VelocyPackStringLiteral.cpp
   GraphsSource.cpp
@@ -6,9 +12,26 @@ add_executable(arangodbtests_wcc
   WCCGraph.cpp
   DisjointSet.cpp)
 
+add_executable(arangodbtests_disjoint_set
+        ${PROJECT_SOURCE_DIR}/lib/Basics/VelocyPackStringLiteral.cpp
+        DisjointSetTest.cpp
+        GraphsSource.cpp
+        DisjointSet.cpp)
+
+target_include_directories(arangodbtests_graph PRIVATE
+        ${PROJECT_SOURCE_DIR}/lib
+        ${PROJECT_BINARY_DIR}/lib
+        ${PROJECT_SOURCE_DIR}/arangod/Pregel)
+
 target_include_directories(arangodbtests_wcc PRIVATE
   ${PROJECT_SOURCE_DIR}/lib
   ${PROJECT_BINARY_DIR}/lib
   ${PROJECT_SOURCE_DIR}/arangod/Pregel)
 
+target_include_directories(arangodbtests_disjoint_set PRIVATE
+        ${PROJECT_SOURCE_DIR}/lib
+        ${PROJECT_BINARY_DIR}/lib
+        ${PROJECT_SOURCE_DIR}/arangod/Pregel)
+
+target_link_libraries(arangodbtests_graph velocypack fmt gtest)
 target_link_libraries(arangodbtests_wcc velocypack fmt gtest)

--- a/arangod/Pregel/tests/DisjointSet.cpp
+++ b/arangod/Pregel/tests/DisjointSet.cpp
@@ -37,7 +37,7 @@ auto DisjointSet::addSingleton(size_t element, size_t hintSize) -> bool {
     return false;
   }
   _parent[element] = element;
-  _rank[element] = 1; // 0 reserved for "not added"
+  _rank[element] = 1;  // 0 reserved for "not added"
   return true;
 }
 

--- a/arangod/Pregel/tests/DisjointSet.cpp
+++ b/arangod/Pregel/tests/DisjointSet.cpp
@@ -2,7 +2,7 @@
 #include <iostream>
 #include "DisjointSet.h"
 
-DisjointSet::DisjointSet(size_t hintSize) {
+DisjointSet::DisjointSet(size_t hintSize) : _parent(), _rank() {
   if (hintSize != 0) {
     _parent.resize(hintSize);
     _rank.resize(hintSize, 0);

--- a/arangod/Pregel/tests/DisjointSet.cpp
+++ b/arangod/Pregel/tests/DisjointSet.cpp
@@ -1,0 +1,64 @@
+#include <stdexcept>
+#include "DisjointSet.h"
+
+DisjointSet::DisjointSet(size_t hintSize) {
+  if (hintSize != 0) {
+    _parent.resize(hintSize);
+    _rank.resize(hintSize, 0);
+  }
+}
+
+auto DisjointSet::capacity() -> size_t { return _parent.size(); }
+
+auto DisjointSet::contains(size_t element) -> bool {
+  return element < capacity() and _rank[element] != 0;
+}
+
+auto DisjointSet::addSingleton(size_t element, size_t hintSize) -> bool {
+  if (hintSize != 0 and element < hintSize and capacity() < hintSize) {
+    _parent.resize(hintSize);
+    _rank.resize(hintSize, 0);
+  } else if (capacity() <= element) {
+    _parent.resize(element + 1);
+    _rank.resize(element + 1, 0);
+  }
+  if (contains(element)) {
+    // already added
+    return false;
+  }
+  _parent[element] = element;
+  _rank[element] = 1; // 0 reserved for "not added"
+  return true;
+}
+
+auto DisjointSet::representative(size_t element) -> size_t {
+  if (element >= capacity() or not contains(element)) {
+    throw std::runtime_error(
+        "Asked for representative of an element that was not stored: " +
+        std::to_string(element));
+  }
+  size_t running = element;
+  // path splitting
+  while (running != _parent[running]) {
+    auto tmp = _parent[running];
+    _parent[running] = _parent[_parent[running]];
+    _rank[running] = (_rank[running] + 1) / 2;
+    running = tmp;
+  }
+  return running;
+}
+
+auto DisjointSet::merge(size_t first, size_t second) -> void {
+  size_t repr_first = representative(first);
+  size_t repr_second = representative(second);
+  if (repr_first == repr_second) {
+    return;
+  }
+  if (_rank[repr_first] > _rank[repr_second]) {
+    std::swap(repr_first, repr_second);
+  }
+  _parent[repr_first] = repr_second;
+  if (_rank[repr_first] == _rank[repr_second]) {
+    _rank[repr_second]++;
+  }
+}

--- a/arangod/Pregel/tests/DisjointSet.cpp
+++ b/arangod/Pregel/tests/DisjointSet.cpp
@@ -1,4 +1,5 @@
 #include <stdexcept>
+#include <iostream>
 #include "DisjointSet.h"
 
 DisjointSet::DisjointSet(size_t hintSize) {
@@ -12,6 +13,15 @@ auto DisjointSet::capacity() -> size_t { return _parent.size(); }
 
 auto DisjointSet::contains(size_t element) -> bool {
   return element < capacity() and _rank[element] != 0;
+}
+
+auto DisjointSet::print() -> void {
+  for (uint64_t i = 0; i < capacity(); ++i) {
+    if (contains(i)) {
+      std::cout << " " << i << ":" << representative(i);
+    }
+    std::cout << std::endl;
+  }
 }
 
 auto DisjointSet::addSingleton(size_t element, size_t hintSize) -> bool {

--- a/arangod/Pregel/tests/DisjointSet.cpp
+++ b/arangod/Pregel/tests/DisjointSet.cpp
@@ -1,5 +1,4 @@
 #include <stdexcept>
-#include <iostream>
 #include "DisjointSet.h"
 
 DisjointSet::DisjointSet(size_t hintSize) : _parent(), _rank() {
@@ -9,18 +8,15 @@ DisjointSet::DisjointSet(size_t hintSize) : _parent(), _rank() {
   }
 }
 
-auto DisjointSet::capacity() -> size_t { return _parent.size(); }
+auto DisjointSet::capacity() const -> size_t { return _parent.size(); }
 
-auto DisjointSet::contains(size_t element) -> bool {
+auto DisjointSet::contains(size_t element) const -> bool {
   return element < capacity() and _rank[element] != 0;
 }
 
-auto DisjointSet::print() -> void {
-  for (uint64_t i = 0; i < capacity(); ++i) {
-    if (contains(i)) {
-      std::cout << " " << i << ":" << representative(i);
-    }
-    std::cout << std::endl;
+auto DisjointSet::removeElement(size_t element) -> void {
+  if (contains(element)) {
+    _rank[element] = 0;
   }
 }
 
@@ -58,11 +54,11 @@ auto DisjointSet::representative(size_t element) -> size_t {
   return running;
 }
 
-auto DisjointSet::merge(size_t first, size_t second) -> void {
+auto DisjointSet::merge(size_t first, size_t second) -> size_t {
   size_t repr_first = representative(first);
   size_t repr_second = representative(second);
   if (repr_first == repr_second) {
-    return;
+    return repr_first;
   }
   if (_rank[repr_first] > _rank[repr_second]) {
     std::swap(repr_first, repr_second);
@@ -71,4 +67,5 @@ auto DisjointSet::merge(size_t first, size_t second) -> void {
   if (_rank[repr_first] == _rank[repr_second]) {
     _rank[repr_second]++;
   }
+  return repr_second;
 }

--- a/arangod/Pregel/tests/DisjointSet.h
+++ b/arangod/Pregel/tests/DisjointSet.h
@@ -6,7 +6,7 @@ class DisjointSet {
  public:
   DisjointSet(size_t hintSize = 0);
 
-  auto addSingleton(size_t element, size_t hintSize=0) -> bool;
+  auto addSingleton(size_t element, size_t hintSize = 0) -> bool;
 
   /**
    * Get the representative of element, compress the path from element to the
@@ -25,6 +25,7 @@ class DisjointSet {
 
   [[nodiscard]] auto capacity() -> size_t;
   [[nodiscard]] auto contains(size_t element) -> bool;
+  auto print() -> void;
 
  private:
   std::vector<size_t> _parent;

--- a/arangod/Pregel/tests/DisjointSet.h
+++ b/arangod/Pregel/tests/DisjointSet.h
@@ -1,10 +1,34 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2022 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Roman Rabinovich
+////////////////////////////////////////////////////////////////////////////////
+
 #pragma once
 
 #include <vector>
 
 class DisjointSet {
  public:
-  DisjointSet(size_t hintSize = 0);
+  explicit DisjointSet(size_t hintSize = 0);
 
   auto addSingleton(size_t element, size_t hintSize = 0) -> bool;
 
@@ -20,12 +44,21 @@ class DisjointSet {
    * Makes the set of first and the set of second be one set.
    * @param first an element
    * @param second another element
+   * @return the representative of the united set
    */
-  auto merge(size_t first, size_t second) -> void;
+  auto merge(size_t first, size_t second) -> size_t;
 
-  [[nodiscard]] auto capacity() -> size_t;
-  [[nodiscard]] auto contains(size_t element) -> bool;
+  [[nodiscard]] auto capacity() const -> size_t;
+  [[nodiscard]] auto contains(size_t element) const -> bool;
+  /**
+   * Remove an element from its set. If the element is not in any set, do
+   * nothing.
+   * @param element
+   */
+  auto removeElement(size_t element) -> void;
   auto print() -> void;
+
+  auto writeSCCIntoVertices() -> size_t;
 
  private:
   std::vector<size_t> _parent;

--- a/arangod/Pregel/tests/DisjointSet.h
+++ b/arangod/Pregel/tests/DisjointSet.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <vector>
+
+class DisjointSet {
+ public:
+  DisjointSet(size_t hintSize = 0);
+
+  auto addSingleton(size_t element, size_t hintSize=0) -> bool;
+
+  /**
+   * Get the representative of element, compress the path from element to the
+   * representative.
+   * @param element an element
+   * @return the representative
+   */
+  [[nodiscard]] auto representative(size_t element) -> size_t;
+
+  /**
+   * Makes the set of first and the set of second be one set.
+   * @param first an element
+   * @param second another element
+   */
+  auto merge(size_t first, size_t second) -> void;
+
+  [[nodiscard]] auto capacity() -> size_t;
+  [[nodiscard]] auto contains(size_t element) -> bool;
+
+ private:
+  std::vector<size_t> _parent;
+  // rank 0 means: element not in any set
+  // rank 1 means: the root (the representative)
+  std::vector<size_t> _rank;
+};

--- a/arangod/Pregel/tests/DisjointSetTest.cpp
+++ b/arangod/Pregel/tests/DisjointSetTest.cpp
@@ -1,0 +1,90 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2022 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Roman Rabinovich
+////////////////////////////////////////////////////////////////////////////////
+
+#include <gtest/gtest.h>
+
+#include "DisjointSet.h"
+
+TEST(GWEN_DISJOINT_SET, test_constructor) {
+  auto ds = DisjointSet(10);
+  EXPECT_EQ(ds.capacity(), static_cast<size_t>(10));
+  auto ds0 = DisjointSet();
+  EXPECT_EQ(ds0.capacity(), static_cast<size_t>(0));
+}
+
+TEST(GWEN_DISJOINT_SET, test_add_singleton) {
+  auto ds = DisjointSet();
+  EXPECT_TRUE(ds.addSingleton(2));
+  EXPECT_EQ(ds.capacity(), 3u);
+  EXPECT_FALSE(ds.addSingleton(2));
+  EXPECT_TRUE(ds.addSingleton(1));
+  EXPECT_EQ(ds.capacity(), 3u);
+  EXPECT_TRUE(ds.addSingleton(4));
+  EXPECT_EQ(ds.capacity(), 5u);
+  EXPECT_TRUE(ds.addSingleton(0));
+  EXPECT_EQ(ds.capacity(), 5u);
+  EXPECT_TRUE(ds.addSingleton(5, 6));
+  EXPECT_EQ(ds.capacity(), 6u);
+  EXPECT_TRUE(ds.addSingleton(6, 8));
+  EXPECT_EQ(ds.capacity(), 8u);
+  EXPECT_TRUE(ds.addSingleton(3, 5));
+  EXPECT_EQ(ds.capacity(), 8u);
+  EXPECT_TRUE(ds.addSingleton(7, 5));
+  EXPECT_EQ(ds.capacity(), 8u);
+}
+
+TEST(GWEN_DISJOINT_SET, test_merge_and_representatives) {
+  // todo: test return value of merge
+  auto ds = DisjointSet(10);
+  for (size_t i = 0; i < 10; ++i) {
+    ds.addSingleton(i);
+  }
+  ds.merge(0, 0);
+  EXPECT_EQ(ds.representative(0), 0u);
+  ds.merge(0, 1);
+  // 0 and 1 have the same rank, so the second parameter
+  // becomes the representative
+  EXPECT_EQ(ds.representative(0), 1u);
+  EXPECT_EQ(ds.representative(1), 1u);
+  ds.merge(0, 1);
+  EXPECT_EQ(ds.representative(0), 1u);
+  EXPECT_EQ(ds.representative(1), 1u);
+  ds.merge(1, 2);
+  EXPECT_EQ(ds.representative(0), 1u);
+  EXPECT_EQ(ds.representative(1), 1u);
+  // 1 has a higher rank
+  EXPECT_EQ(ds.representative(2), 1u);
+  ds.merge(3, 4);
+  ds.merge(5, 6);
+  ds.merge(3, 5);
+  ds.merge(2, 3);
+  // the representative of 3 has a higher rank than that of 2
+  EXPECT_EQ(ds.representative(2), 6u);
+}
+
+auto main(int argc, char** argv) -> int {
+  testing::InitGoogleTest();
+
+  return RUN_ALL_TESTS();
+}

--- a/arangod/Pregel/tests/Graph.cpp
+++ b/arangod/Pregel/tests/Graph.cpp
@@ -1,0 +1,76 @@
+#include "WCCGraph.h"
+#include <Inspection/VPackPure.h>
+
+
+template<typename EdgeProperties>
+void WCCGraph<EdgeProperties>::_checkEdgeEnds(
+    Edge<EdgeProperties> edge,
+    std::map<VertexKey, size_t> const& vertexPosition) {
+  if (not vertexPosition.contains(edge._from)) {
+    throw std::runtime_error("Edge " + edge._key + " has a _from vertex " +
+                             edge._from +
+                             " that is not declared in the list of vertices.");
+  }
+
+  if (not vertexPosition.contains(edge._to)) {
+    throw std::runtime_error("Edge " + edge._key + " has a _to vertex " +
+                             edge._to +
+                             " that is not declared in the list of vertices.");
+  }
+}
+
+template<typename EdgeProperties>
+WCCGraph<EdgeProperties>::WCCGraph(SharedSlice graphJson,
+                                   bool checkDuplicateVertices) {
+  auto vs = graphJson["vertices"];
+  for (size_t i = 0; i < vs.length(); ++i) {
+    WCCVertex vertex;
+    auto result = deserializeWithStatus<WCCVertex>(vs[i].slice(), vertex);
+    if (not result.ok()) {
+      throw std::runtime_error("Could not red vertex: " + result.error());
+    }
+    if (checkDuplicateVertices) {
+      if (_vertexPosition.contains(vertex._key)) {
+        throw std::runtime_error("Vertex with _key " + vertex._key +
+                                 " appears "
+                                 "more than once.");
+      }
+    }
+    size_t const vertexPosition = vertices.size();
+    _vertexPosition[vertex._key] = vertexPosition;
+    vertices.push_back(vertex);
+    _wccs.addSingleton(vertexPosition);
+  }
+
+  auto es = graphJson["edges"];
+  for (size_t i = 0; i < es.length(); ++i) {
+    Edge<EmptyEdgeProperties> edge;
+    auto result =
+        deserializeWithStatus<Edge<EmptyEdgeProperties>>(es[i].slice(), edge);
+    if (not result.ok()) {
+      throw std::runtime_error("Could not read edge: " + result.error());
+    }
+
+    _checkEdgeEnds(edge, _vertexPosition);
+    _wccs.merge(_vertexPosition[edge._from], _vertexPosition[edge._to]);
+  }
+}
+
+template<typename EdgeProperties>
+auto WCCGraph<EdgeProperties>::computeWCC() -> size_t {
+  std::unordered_map<size_t, size_t> markedRepresentatives;
+  size_t counter = 0;
+  for (size_t i = 0; i < vertices.size(); ++i) {
+    auto id = markedRepresentatives.find(_wccs.representative(i));
+    if (id == markedRepresentatives.end()) {
+      size_t const newId = counter++;
+      vertices[i].properties.value = newId;
+      vertices[_wccs.representative(i)].properties.value = newId;
+    } else {
+      vertices[i].properties.value = id->second;
+    }
+  }
+  return counter;
+}
+
+template class WCCGraph<EmptyEdgeProperties>;

--- a/arangod/Pregel/tests/Graph.cpp
+++ b/arangod/Pregel/tests/Graph.cpp
@@ -1,7 +1,6 @@
 #include "WCCGraph.h"
 #include <Inspection/VPackPure.h>
 
-
 template<typename EdgeProperties>
 void WCCGraph<EdgeProperties>::_checkEdgeEnds(
     Edge<EdgeProperties> edge,

--- a/arangod/Pregel/tests/Graph.cpp
+++ b/arangod/Pregel/tests/Graph.cpp
@@ -73,4 +73,9 @@ auto WCCGraph<EdgeProperties>::computeWCC() -> size_t {
   return counter;
 }
 
+template<typename EdgeProperties>
+auto WCCGraph<EdgeProperties>::printWccs() -> void {
+  _wccs.print();
+}
+
 template class WCCGraph<EmptyEdgeProperties>;

--- a/arangod/Pregel/tests/Graph.cpp
+++ b/arangod/Pregel/tests/Graph.cpp
@@ -58,16 +58,17 @@ WCCGraph<EdgeProperties>::WCCGraph(SharedSlice graphJson,
 
 template<typename EdgeProperties>
 auto WCCGraph<EdgeProperties>::computeWCC() -> size_t {
-  std::unordered_map<size_t, size_t> markedRepresentatives;
+  std::unordered_set<size_t> markedRepresentatives;
   size_t counter = 0;
   for (size_t i = 0; i < vertices.size(); ++i) {
-    auto id = markedRepresentatives.find(_wccs.representative(i));
-    if (id == markedRepresentatives.end()) {
+    size_t const representative = _wccs.representative(i);
+    if (markedRepresentatives.contains(representative)) {
+      vertices[i].properties.value = vertices[representative].properties.value;
+    } else {
       size_t const newId = counter++;
       vertices[i].properties.value = newId;
-      vertices[_wccs.representative(i)].properties.value = newId;
-    } else {
-      vertices[i].properties.value = id->second;
+      vertices[representative].properties.value = newId;
+      markedRepresentatives.insert(representative);
     }
   }
   return counter;

--- a/arangod/Pregel/tests/Graph.cpp
+++ b/arangod/Pregel/tests/Graph.cpp
@@ -1,8 +1,11 @@
+#include <unordered_set>
 #include "Graph.h"
+#include "SCCGraph.h"
+#include "WCCGraph.h"
 
 template<typename EdgeProperties, typename VertexProperties>
 void Graph<EdgeProperties, VertexProperties>::_checkEdgeEnds(
-    GraphEdge edge, std::map<VertexKey, size_t> const& vertexPosition) {
+    Edge edge, std::map<VertexKey, size_t> const& vertexPosition) {
   if (not vertexPosition.contains(edge._from)) {
     throw std::runtime_error("Edge " + edge._key + " has a _from vertex " +
                              edge._from +
@@ -19,15 +22,15 @@ void Graph<EdgeProperties, VertexProperties>::_checkEdgeEnds(
 template<typename EdgeProperties, typename VertexProperties>
 size_t Graph<EdgeProperties, VertexProperties>::readEdges(
     const SharedSlice& graphJson, bool checkEdgeEnds,
-    std::function<void(GraphEdge edge)> onReadEdge) {
+    std::function<void(Edge edge)> onReadEdge) {
   auto es = graphJson["edges"];
   if (not es.isArray()) {
     throw std::runtime_error("The input graph slice " + es.toString() +
                              " has not field \"edges\"");
   }
   for (EdgeIndex i = 0; i < es.length(); ++i) {
-    GraphEdge edge;
-    auto result = deserializeWithStatus<GraphEdge>(es[i].slice(), edge);
+    Edge edge;
+    auto result = deserializeWithStatus<Edge>(es[i].slice(), edge);
     if (not result.ok()) {
       throw std::runtime_error("Could not read edge: " + result.error());
     }
@@ -37,6 +40,7 @@ size_t Graph<EdgeProperties, VertexProperties>::readEdges(
     }
     onReadEdge(edge);
   }
+  return es.length();
 }
 
 template<typename EdgeProperties, typename VertexProperties>
@@ -44,8 +48,8 @@ auto Graph<EdgeProperties, VertexProperties>::readVertices(
     const SharedSlice& graphJson, bool checkDuplicateVertices) -> void {
   auto vs = graphJson["vertices"];
   for (VertexIndex i = 0; i < vs.length(); ++i) {
-    GraphVertex vertex;
-    auto result = deserializeWithStatus<GraphVertex>(vs[i].slice(), vertex);
+    Vertex vertex;
+    auto result = deserializeWithStatus<Vertex>(vs[i].slice(), vertex);
     if (not result.ok()) {
       throw std::runtime_error("Could not red vertex: " + result.error());
     }
@@ -61,7 +65,27 @@ auto Graph<EdgeProperties, VertexProperties>::readVertices(
     vertices.push_back(vertex);
   }
 }
-
-#include "WCCGraph.h"
+template<typename EdgeProperties, typename VertexProperties>
+auto Graph<EdgeProperties, VertexProperties>::
+    writeEquivalenceRelationIntoVertices(DisjointSet& eqRel) -> size_t {
+  // todo: if a lot of (small) connected components, it may be better to use a
+  //  bitset
+  std::unordered_set<size_t> markedRepresentatives;
+  size_t counter = 0;
+  for (size_t i = 0; i < this->vertices.size(); ++i) {
+    size_t const representative = eqRel.representative(i);
+    if (markedRepresentatives.contains(representative)) {
+      this->vertices[i].properties.value =
+          this->vertices[representative].properties.value;
+    } else {
+      size_t const newId = counter++;
+      this->vertices[i].properties.value = newId;
+      this->vertices[representative].properties.value = newId;
+      markedRepresentatives.insert(representative);
+    }
+  }
+  return counter;
+}
 
 template class Graph<EmptyEdgeProperties, WCCVertexProperties>;
+template class Graph<EmptyEdgeProperties, SCCVertexProperties>;

--- a/arangod/Pregel/tests/Graph.h
+++ b/arangod/Pregel/tests/Graph.h
@@ -1,13 +1,32 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2022 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Roman Rabinovich
+////////////////////////////////////////////////////////////////////////////////
+
 #pragma once
 
-#include <string>
-#include <unordered_set>
 #include <map>
 
 #include <Basics/VelocyPackStringLiteral.h>
-#include <Inspection/VPackPure.h>
-#include <fmt/core.h>
-#include <fmt/format.h>
 
 #include "DisjointSet.h"
 
@@ -19,11 +38,11 @@ using VertexKey = std::string;
 using EdgeKey = std::string;
 
 template<typename VertexProperties>
-struct Vertex {
+struct BaseVertex {
   VertexKey _key;
   VertexProperties properties;
 
-  auto operator==(Vertex const& other) { return _key == other._key; }
+  auto operator==(BaseVertex const& other) { return _key == other._key; }
 };
 
 template<typename VertexProperties>
@@ -34,7 +53,7 @@ concept VertexPropertiesWithValue = requires(VertexProperties t) {
                                     };
 
 template<typename EdgeProperties = EmptyEdgeProperties>
-struct Edge {
+struct BaseEdge {
   EdgeKey _key;
   VertexKey _from;
   VertexKey _to;
@@ -47,8 +66,8 @@ using EdgeIndex = size_t;
 template<typename EdgeProperties, typename VertexProperties>
 class Graph {
  public:
-  using GraphVertex = Vertex<VertexProperties>;
-  using GraphEdge = Edge<EdgeProperties>;
+  using Vertex = BaseVertex<VertexProperties>;
+  using Edge = BaseEdge<EdgeProperties>;
 
   Graph() = default;
 
@@ -56,26 +75,39 @@ class Graph {
       -> void;
 
   size_t readEdges(const SharedSlice& graphJson, bool checkEdgeEnds,
-                   std::function<void(GraphEdge edge)> onReadEdge);
+                   std::function<void(Edge edge)> onReadEdge);
 
   auto getVertexPosition(VertexKey const& key) -> VertexIndex {
     return _vertexPosition[key];
   }
   auto clearVertexPositions() -> void { _vertexPosition.clear(); }
 
-  std::vector<GraphVertex> vertices;
+  std::vector<Vertex> vertices;
+
+  /**
+   * Write
+   * Compute the weakly connected components. Each component has an id of type
+   * size_t and is written into the value property of each of its vertices.
+   * @return the number of weakly connected components.
+   */
+
+  auto writeEquivalenceRelationIntoVertices(DisjointSet& eqRel) -> size_t;
 
  private:
   std::map<VertexKey, VertexIndex> _vertexPosition;
 
  protected:
-  auto _checkEdgeEnds(GraphEdge,
-                      std::map<VertexKey, size_t> const& vertexPosition)
+  auto _checkEdgeEnds(Edge, std::map<VertexKey, size_t> const& vertexPosition)
       -> void;
 };
 
+template<typename EdgeProperties, VertexPropertiesWithValue VertexProperties>
+class ValuedGraph : public Graph<EdgeProperties, VertexProperties> {
+
+};
+
 template<typename Inspector, typename VertexProperties>
-auto inspect(Inspector& f, Vertex<VertexProperties>& p) {
+auto inspect(Inspector& f, BaseVertex<VertexProperties>& p) {
   return f.object(p).fields(f.field("_key", p._key),
                             f.embedFields(p.properties));
 }
@@ -86,7 +118,7 @@ auto inspect(Inspector& f, EmptyEdgeProperties& x) {
 }
 
 template<typename Inspector, typename EdgeProperties = EmptyEdgeProperties>
-auto inspect(Inspector& f, Edge<EdgeProperties>& p) {
+auto inspect(Inspector& f, BaseEdge<EdgeProperties>& p) {
   return f.object(p).fields(f.field("_key", p._key), f.field("_from", p._from),
                             f.field("_to", p._to), f.embedFields(p.properties));
 }

--- a/arangod/Pregel/tests/Graph.h
+++ b/arangod/Pregel/tests/Graph.h
@@ -1,0 +1,92 @@
+#pragma once
+
+#include <string>
+#include <unordered_set>
+#include <map>
+
+#include <Basics/VelocyPackStringLiteral.h>
+#include <Inspection/VPackPure.h>
+#include <fmt/core.h>
+#include <fmt/format.h>
+
+#include "DisjointSet.h"
+
+using namespace arangodb::velocypack;
+
+struct EmptyEdgeProperties {};
+
+using VertexKey = std::string;
+using EdgeKey = std::string;
+
+template<typename VertexProperties>
+struct Vertex {
+  VertexKey _key;
+  VertexProperties properties;
+
+  auto operator==(Vertex const& other) { return _key == other._key; }
+};
+
+template<typename VertexProperties>
+concept VertexPropertiesWithValue = requires(VertexProperties t) {
+                                      {
+                                        t.value
+                                        } -> std::convertible_to<size_t>;
+                                    };
+
+template<typename EdgeProperties = EmptyEdgeProperties>
+struct Edge {
+  EdgeKey _key;
+  VertexKey _from;
+  VertexKey _to;
+  EdgeProperties properties;
+};
+
+using VertexIndex = size_t;
+using EdgeIndex = size_t;
+
+template<typename EdgeProperties, typename VertexProperties>
+class Graph {
+ public:
+  using GraphVertex = Vertex<VertexProperties>;
+  using GraphEdge = Edge<EdgeProperties>;
+
+  Graph() = default;
+
+  auto readVertices(const SharedSlice& graphJson, bool checkDuplicateVertices)
+      -> void;
+
+  size_t readEdges(const SharedSlice& graphJson, bool checkEdgeEnds,
+                   std::function<void(GraphEdge edge)> onReadEdge);
+
+  auto getVertexPosition(VertexKey const& key) -> VertexIndex {
+    return _vertexPosition[key];
+  }
+  auto clearVertexPositions() -> void { _vertexPosition.clear(); }
+
+  std::vector<GraphVertex> vertices;
+
+ private:
+  std::map<VertexKey, VertexIndex> _vertexPosition;
+
+ protected:
+  auto _checkEdgeEnds(GraphEdge,
+                      std::map<VertexKey, size_t> const& vertexPosition)
+      -> void;
+};
+
+template<typename Inspector, typename VertexProperties>
+auto inspect(Inspector& f, Vertex<VertexProperties>& p) {
+  return f.object(p).fields(f.field("_key", p._key),
+                            f.embedFields(p.properties));
+}
+
+template<typename Inspector>
+auto inspect(Inspector& f, EmptyEdgeProperties& x) {
+  return f.object(x).fields();
+}
+
+template<typename Inspector, typename EdgeProperties = EmptyEdgeProperties>
+auto inspect(Inspector& f, Edge<EdgeProperties>& p) {
+  return f.object(p).fields(f.field("_key", p._key), f.field("_from", p._from),
+                            f.field("_to", p._to), f.embedFields(p.properties));
+}

--- a/arangod/Pregel/tests/GraphTest.cpp
+++ b/arangod/Pregel/tests/GraphTest.cpp
@@ -1,0 +1,99 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2022 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Roman Rabinovich
+////////////////////////////////////////////////////////////////////////////////
+
+#include <gtest/gtest.h>
+#include <variant>
+#include <fstream>
+#include "Graph.h"
+#include "GraphsSource.h"
+#include "fmt/format.h"
+#include "WCCGraph.h"
+
+using namespace arangodb::slicegraph;
+
+namespace {
+auto testReadFromFile(SharedSlice const& graphSlice,
+                      bool checkDuplicateVertices, bool checkEdgeEnds) {
+  size_t expectedNumVertices = GraphSliceHelper::getNumVertices(graphSlice);
+  size_t expectedNumEdges = GraphSliceHelper::getNumEdges(graphSlice);
+  std::string const vertexFileName = "skdjf444bvl4dkj456fbv4r43k";
+  std::string const edgeFileName = "kdjfljdkjcdkjdkjoki349023kd";
+  {
+    std::ofstream vertexFile(vertexFileName);
+    vertexFile.clear();
+    auto const vs = graphSlice["vertices"];
+    for (size_t i = 0; i < vs.length(); ++i) {
+      vertexFile << vs[i].toJson() << '\n';
+    }
+    vertexFile.close();
+  }
+
+  {
+    std::ofstream edgeFile(edgeFileName);
+    edgeFile.clear();
+    auto const es = graphSlice["edges"];
+    for (size_t i = 0; i < es.length(); ++i) {
+      edgeFile << es[i].toJson() << '\n';
+    }
+    edgeFile.close();
+  }
+  Graph<EmptyEdgeProperties, WCCVertexProperties> graph{};
+  std::ifstream vertexFile(vertexFileName);
+  graph.readVertices(vertexFile, checkDuplicateVertices);
+  EXPECT_EQ(graph.vertices.size(), expectedNumVertices);
+
+  std::ifstream edgeFile(edgeFileName);
+  size_t numEdges = graph.readEdges(
+      edgeFile, checkEdgeEnds,
+      [&](const Graph<EmptyEdgeProperties, WCCVertexProperties>::Edge&) {});
+  EXPECT_EQ(numEdges, expectedNumEdges);
+  try {
+    std::remove(vertexFileName.c_str());
+    std::remove(edgeFileName.c_str());
+  } catch (...) {
+    std::cerr << fmt::format("Could not remove files {} and {}.",
+                             vertexFileName, edgeFileName);
+  }
+}
+}  // namespace
+
+TEST(GWEN_GRAPH, test_graph_read_from_file_2path) {
+  bool checkDuplicateVertices = true;
+  bool checkEdgeEnds = true;
+  auto graphSlice = arangodb::slicegraph::setup2Path();
+  testReadFromFile(graphSlice, checkDuplicateVertices, checkEdgeEnds);
+}
+
+TEST(GWEN_GRAPH, test_graph_read_from_file_alternatingTree) {
+  bool checkDuplicateVertices = true;
+  bool checkEdgeEnds = true;
+  auto graphSlice = setup1AlternatingTree();
+  testReadFromFile(graphSlice, checkDuplicateVertices, checkEdgeEnds);
+}
+
+auto main(int argc, char** argv) -> int {
+  testing::InitGoogleTest();
+
+  return RUN_ALL_TESTS();
+}

--- a/arangod/Pregel/tests/GraphsSource.cpp
+++ b/arangod/Pregel/tests/GraphsSource.cpp
@@ -24,27 +24,34 @@
 
 #include <Basics/VelocyPackStringLiteral.h>
 #include "GraphsSource.h"
+#include "Inspection/VPackPure.h"
+#include "fmt/format.h"
 
 using namespace arangodb::velocypack;
+using namespace arangodb::slicegraph;
 
-SharedSlice setup2Path() {
+SharedSlice arangodb::slicegraph::setup2Path() {
   return
       R"({ "vertices": [ {"_key": "A", "value": 5},
                          {"_key": "B", "value": 10},
                          {"_key": "C", "value": 15} ],
+           "numVertices": 3,
            "edges":    [ {"_key": "", "_from": "A", "_to": "B"},
-                         {"_key": "", "_from": "B", "_to": "C"} ] })"_vpack;
+                         {"_key": "", "_from": "B", "_to": "C"} ],
+           "numEdges": 2 })"_vpack;
 }
 
-SharedSlice setupUndirectedEdge() {
+SharedSlice arangodb::slicegraph::setupUndirectedEdge() {
   return
       R"({ "vertices": [ {"_key": "A", "value": 5},
                          {"_key": "B", "value": 10} ],
+           "numVertices": 2,
            "edges":    [ {"_key": "", "_from": "A", "_to": "B"},
-                         {"_key": "", "_from": "B", "_to": "A"} ] })"_vpack;
+                         {"_key": "", "_from": "B", "_to": "A"} ],
+           "numEdges": 2 })"_vpack;
 }
 
-SharedSlice setupThreeDisjointDirectedCycles() {
+SharedSlice arangodb::slicegraph::setupThreeDisjointDirectedCycles() {
   return
       R"({ "vertices": [ {"_key": "a0", "value": 0},
                          {"_key": "a1", "value": 0},
@@ -58,6 +65,7 @@ SharedSlice setupThreeDisjointDirectedCycles() {
                          {"_key": "c2", "value": 0},
                          {"_key": "c3", "value": 0},
                          {"_key": "c4", "value": 0}],
+           "numVertices": 12,
            "edges":    [ {"_key": "", "_from": "a0", "_to": "a1"},
                          {"_key": "", "_from": "a1", "_to": "a2"},
                          {"_key": "", "_from": "a2", "_to": "a0"},
@@ -69,10 +77,11 @@ SharedSlice setupThreeDisjointDirectedCycles() {
                          {"_key": "", "_from": "c1", "_to": "c2"},
                          {"_key": "", "_from": "c2", "_to": "c3"},
                          {"_key": "", "_from": "c3", "_to": "c4"},
-                         {"_key": "", "_from": "c4", "_to": "c0"}] })"_vpack;
+                         {"_key": "", "_from": "c4", "_to": "c0"} ],
+           "numEdges": 12 })"_vpack;
 }
 
-SharedSlice setupThreeDisjointAlternatingCycles() {
+SharedSlice arangodb::slicegraph::setupThreeDisjointAlternatingCycles() {
   return
       R"({ "vertices": [ {"_key": "a0", "value": 0},
                          {"_key": "a1", "value": 0},
@@ -86,6 +95,7 @@ SharedSlice setupThreeDisjointAlternatingCycles() {
                          {"_key": "c2", "value": 0},
                          {"_key": "c3", "value": 0},
                          {"_key": "c4", "value": 0}],
+           "numVertices": 12,
            "edges":    [ {"_key": "", "_from": "a0", "_to": "a1"},
                          {"_key": "", "_from": "a2", "_to": "a1"},
                          {"_key": "", "_from": "a2", "_to": "a0"},
@@ -97,23 +107,28 @@ SharedSlice setupThreeDisjointAlternatingCycles() {
                          {"_key": "", "_from": "c2", "_to": "c1"},
                          {"_key": "", "_from": "c2", "_to": "c3"},
                          {"_key": "", "_from": "c4", "_to": "c3"},
-                         {"_key": "", "_from": "c0", "_to": "c4"}] })"_vpack;
+                         {"_key": "", "_from": "c0", "_to": "c4"} ],
+           "numEdges": 12 })"_vpack;
 }
 
-SharedSlice setup1SingleVertex() {
+SharedSlice arangodb::slicegraph::setup1SingleVertex() {
   return
       R"({ "vertices": [ {"_key": "A", "value": 0} ],
-           "edges":    [ ] })"_vpack;
+           "numVertices": 1,
+           "edges":    [ ],
+           "numEdges": 0 })"_vpack;
 }
 
-SharedSlice setup2IsolatedVertices() {
+SharedSlice arangodb::slicegraph::setup2IsolatedVertices() {
   return
       R"({ "vertices": [ {"_key": "A", "value": 0},
                          {"_key": "B", "value": 0} ],
-           "edges":    [ ] })"_vpack;
+           "numVertices": 2,
+           "edges":    [ ],
+           "numEdges": 0 })"_vpack;
 }
 
-SharedSlice setup1DirectedTree() {
+SharedSlice arangodb::slicegraph::setup1DirectedTree() {
   return
       R"({ "vertices": [ {"_key": "a", "value": 5},
                          {"_key": "a0", "value": 10},
@@ -130,6 +145,7 @@ SharedSlice setup1DirectedTree() {
                          {"_key": "a101", "value": 15},
                          {"_key": "a110", "value": 10},
                          {"_key": "a111", "value": 15} ],
+           "numVertices": 15,
            "edges":   [ {"_key": "", "_from": "a", "_to": "a0"},
                         {"_key": "", "_from": "a", "_to": "a1"},
                         {"_key": "", "_from": "a0", "_to": "a00"},
@@ -143,10 +159,11 @@ SharedSlice setup1DirectedTree() {
                         {"_key": "", "_from": "a10", "_to": "a100"},
                         {"_key": "", "_from": "a10", "_to": "a101"},
                         {"_key": "", "_from": "a11", "_to": "a110"},
-                        {"_key": "", "_from": "a11", "_to": "a111"} ] })"_vpack;
+                        {"_key": "", "_from": "a11", "_to": "a111"} ],
+           "numEdges": 14 })"_vpack;
 }
 
-SharedSlice setup1AlternatingTree() {
+SharedSlice arangodb::slicegraph::setup1AlternatingTree() {
   return
       R"({ "vertices": [ {"_key": "a", "value": 5},
                          {"_key": "a0", "value": 10},
@@ -163,6 +180,7 @@ SharedSlice setup1AlternatingTree() {
                          {"_key": "a101", "value": 15},
                          {"_key": "a110", "value": 10},
                          {"_key": "a111", "value": 15} ],
+           "numVertices": 15,
            "edges":    [ {"_key": "", "_from": "a", "_to": "a0"},
                          {"_key": "", "_from": "a", "_to": "a1"},
                          {"_key": "", "_from": "a00", "_to": "a0"},
@@ -176,18 +194,19 @@ SharedSlice setup1AlternatingTree() {
                          {"_key": "", "_from": "a10", "_to": "a100"},
                          {"_key": "", "_from": "a10", "_to": "a101"},
                          {"_key": "", "_from": "a11", "_to": "a110"},
-                         {"_key": "", "_from": "a11", "_to": "a111"} ] })"_vpack;
+                         {"_key": "", "_from": "a11", "_to": "a111"} ],
+           "numEdges": 14 })"_vpack;
 }
 
-SharedSlice setup2CliquesConnectedByDirectedEdge() {
+SharedSlice arangodb::slicegraph::setup2CliquesConnectedByDirectedEdge() {
   return
       R"({ "vertices": [ {"_key": "a0", "value": 5},
                          {"_key": "a1", "value": 10},
                          {"_key": "a2", "value": 15},
                          {"_key": "b0", "value": 5},
                          {"_key": "b1", "value": 10},
-                         {"_key": "b2", "value": 15}
- ],
+                         {"_key": "b2", "value": 15} ],
+           "numVertices": 6,
            "edges":    [ {"_key": "", "_from": "a0", "_to": "a1"},
                          {"_key": "", "_from": "a1", "_to": "a0"},
                          {"_key": "", "_from": "a0", "_to": "a2"},
@@ -200,12 +219,43 @@ SharedSlice setup2CliquesConnectedByDirectedEdge() {
                          {"_key": "", "_from": "b2", "_to": "b0"},
                          {"_key": "", "_from": "b1", "_to": "b2"},
                          {"_key": "", "_from": "b2", "_to": "b1"},
-                         {"_key": "", "_from": "a0", "_to": "b0"} ] })"_vpack;
+                         {"_key": "", "_from": "a0", "_to": "b0"} ],
+           "numEdges": 13 })"_vpack;
 }
 
-SharedSlice setupDuplicateVertices() {
+SharedSlice arangodb::slicegraph::setupDuplicateVertices() {
   return
       R"({ "vertices": [ {"_key": "A", "value": 5},
                          {"_key": "A", "value": 10} ],
-           "edges":    [ ] })"_vpack;
+           "numVertices": 2,
+           "edges":    [ ],
+           "numEdges": 0 })"_vpack;
+}
+
+auto GraphSliceHelper::getNumVertices(SharedSlice const& graphSlice) -> size_t {
+  size_t expectedNumVertices;
+  {
+    auto result = deserializeWithStatus<size_t>(
+        graphSlice.slice()["numVertices"], expectedNumVertices);
+    if (not result.ok()) {
+      throw std::runtime_error(
+          fmt::format("Could not get numVertices from the graph slice {}",
+                      graphSlice.toString()));
+    }
+  }
+  return expectedNumVertices;
+}
+
+auto GraphSliceHelper::getNumEdges(SharedSlice const& graphSlice) -> size_t {
+  size_t expectedNumEdges;
+  {
+    auto result = deserializeWithStatus<size_t>(
+        graphSlice.slice()["numEdges"], expectedNumEdges);
+    if (not result.ok()) {
+      throw std::runtime_error(
+          fmt::format("Could not get numEdges from the graph slice {}",
+                      graphSlice.toString()));
+    }
+  }
+  return expectedNumEdges;
 }

--- a/arangod/Pregel/tests/GraphsSource.cpp
+++ b/arangod/Pregel/tests/GraphsSource.cpp
@@ -1,0 +1,211 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2022 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Roman Rabinovich
+////////////////////////////////////////////////////////////////////////////////
+
+#include <Basics/VelocyPackStringLiteral.h>
+#include "GraphsSource.h"
+
+using namespace arangodb::velocypack;
+
+SharedSlice setup2Path() {
+  return
+      R"({ "vertices": [ {"_key": "A", "value": 5},
+                         {"_key": "B", "value": 10},
+                         {"_key": "C", "value": 15} ],
+           "edges":    [ {"_key": "", "_from": "A", "_to": "B"},
+                         {"_key": "", "_from": "B", "_to": "C"} ] })"_vpack;
+}
+
+SharedSlice setupUndirectedEdge() {
+  return
+      R"({ "vertices": [ {"_key": "A", "value": 5},
+                         {"_key": "B", "value": 10} ],
+           "edges":    [ {"_key": "", "_from": "A", "_to": "B"},
+                         {"_key": "", "_from": "B", "_to": "A"} ] })"_vpack;
+}
+
+SharedSlice setupThreeDisjointDirectedCycles() {
+  return
+      R"({ "vertices": [ {"_key": "a0", "value": 0},
+                         {"_key": "a1", "value": 0},
+                         {"_key": "a2", "value": 0},
+                         {"_key": "b0", "value": 0},
+                         {"_key": "b1", "value": 0},
+                         {"_key": "b2", "value": 0},
+                         {"_key": "b3", "value": 0},
+                         {"_key": "c0", "value": 0},
+                         {"_key": "c1", "value": 0},
+                         {"_key": "c2", "value": 0},
+                         {"_key": "c3", "value": 0},
+                         {"_key": "c4", "value": 0}],
+           "edges":    [ {"_key": "", "_from": "a0", "_to": "a1"},
+                         {"_key": "", "_from": "a1", "_to": "a2"},
+                         {"_key": "", "_from": "a2", "_to": "a0"},
+                         {"_key": "", "_from": "b0", "_to": "b1"},
+                         {"_key": "", "_from": "b1", "_to": "b2"},
+                         {"_key": "", "_from": "b2", "_to": "b3"},
+                         {"_key": "", "_from": "b3", "_to": "b0"},
+                         {"_key": "", "_from": "c0", "_to": "c1"},
+                         {"_key": "", "_from": "c1", "_to": "c2"},
+                         {"_key": "", "_from": "c2", "_to": "c3"},
+                         {"_key": "", "_from": "c3", "_to": "c4"},
+                         {"_key": "", "_from": "c4", "_to": "c0"}] })"_vpack;
+}
+
+SharedSlice setupThreeDisjointAlternatingCycles() {
+  return
+      R"({ "vertices": [ {"_key": "a0", "value": 0},
+                         {"_key": "a1", "value": 0},
+                         {"_key": "a2", "value": 0},
+                         {"_key": "b0", "value": 0},
+                         {"_key": "b1", "value": 0},
+                         {"_key": "b2", "value": 0},
+                         {"_key": "b3", "value": 0},
+                         {"_key": "c0", "value": 0},
+                         {"_key": "c1", "value": 0},
+                         {"_key": "c2", "value": 0},
+                         {"_key": "c3", "value": 0},
+                         {"_key": "c4", "value": 0}],
+           "edges":    [ {"_key": "", "_from": "a0", "_to": "a1"},
+                         {"_key": "", "_from": "a2", "_to": "a1"},
+                         {"_key": "", "_from": "a2", "_to": "a0"},
+                         {"_key": "", "_from": "b0", "_to": "b1"},
+                         {"_key": "", "_from": "b2", "_to": "b1"},
+                         {"_key": "", "_from": "b2", "_to": "b3"},
+                         {"_key": "", "_from": "b0", "_to": "b3"},
+                         {"_key": "", "_from": "c0", "_to": "c1"},
+                         {"_key": "", "_from": "c2", "_to": "c1"},
+                         {"_key": "", "_from": "c2", "_to": "c3"},
+                         {"_key": "", "_from": "c4", "_to": "c3"},
+                         {"_key": "", "_from": "c0", "_to": "c4"}] })"_vpack;
+}
+
+SharedSlice setup1SingleVertex() {
+  return
+      R"({ "vertices": [ {"_key": "A", "value": 0} ],
+           "edges":    [ ] })"_vpack;
+}
+
+SharedSlice setup2IsolatedVertices() {
+  return
+      R"({ "vertices": [ {"_key": "A", "value": 0},
+                         {"_key": "B", "value": 0} ],
+           "edges":    [ ] })"_vpack;
+}
+
+SharedSlice setup1DirectedTree() {
+  return
+      R"({ "vertices": [ {"_key": "a", "value": 5},
+                         {"_key": "a0", "value": 10},
+                         {"_key": "a1", "value": 15},
+                         {"_key": "a00", "value": 10},
+                         {"_key": "a01", "value": 15},
+                         {"_key": "a10", "value": 10},
+                         {"_key": "a11", "value": 15},
+                         {"_key": "a000", "value": 10},
+                         {"_key": "a001", "value": 15},
+                         {"_key": "a010", "value": 10},
+                         {"_key": "a011", "value": 15},
+                         {"_key": "a100", "value": 10},
+                         {"_key": "a101", "value": 15},
+                         {"_key": "a110", "value": 10},
+                         {"_key": "a111", "value": 15} ],
+           "edges":   [ {"_key": "", "_from": "a", "_to": "a0"},
+                        {"_key": "", "_from": "a", "_to": "a1"},
+                        {"_key": "", "_from": "a0", "_to": "a00"},
+                        {"_key": "", "_from": "a0", "_to": "a01"},
+                        {"_key": "", "_from": "a1", "_to": "a10"},
+                        {"_key": "", "_from": "a1", "_to": "a11"},
+                        {"_key": "", "_from": "a00", "_to": "a000"},
+                        {"_key": "", "_from": "a00", "_to": "a001"},
+                        {"_key": "", "_from": "a01", "_to": "a010"},
+                        {"_key": "", "_from": "a01", "_to": "a011"},
+                        {"_key": "", "_from": "a10", "_to": "a100"},
+                        {"_key": "", "_from": "a10", "_to": "a101"},
+                        {"_key": "", "_from": "a11", "_to": "a110"},
+                        {"_key": "", "_from": "a11", "_to": "a111"} ] })"_vpack;
+}
+
+SharedSlice setup1AlternatingTree() {
+  return
+      R"({ "vertices": [ {"_key": "a", "value": 5},
+                         {"_key": "a0", "value": 10},
+                         {"_key": "a1", "value": 15},
+                         {"_key": "a00", "value": 10},
+                         {"_key": "a01", "value": 15},
+                         {"_key": "a10", "value": 10},
+                         {"_key": "a11", "value": 15},
+                         {"_key": "a000", "value": 10},
+                         {"_key": "a001", "value": 15},
+                         {"_key": "a010", "value": 10},
+                         {"_key": "a011", "value": 15},
+                         {"_key": "a100", "value": 10},
+                         {"_key": "a101", "value": 15},
+                         {"_key": "a110", "value": 10},
+                         {"_key": "a111", "value": 15} ],
+           "edges":    [ {"_key": "", "_from": "a", "_to": "a0"},
+                         {"_key": "", "_from": "a", "_to": "a1"},
+                         {"_key": "", "_from": "a00", "_to": "a0"},
+                         {"_key": "", "_from": "a01", "_to": "a0"},
+                         {"_key": "", "_from": "a10", "_to": "a1"},
+                         {"_key": "", "_from": "a11", "_to": "a1"},
+                         {"_key": "", "_from": "a00", "_to": "a000"},
+                         {"_key": "", "_from": "a00", "_to": "a001"},
+                         {"_key": "", "_from": "a01", "_to": "a010"},
+                         {"_key": "", "_from": "a01", "_to": "a011"},
+                         {"_key": "", "_from": "a10", "_to": "a100"},
+                         {"_key": "", "_from": "a10", "_to": "a101"},
+                         {"_key": "", "_from": "a11", "_to": "a110"},
+                         {"_key": "", "_from": "a11", "_to": "a111"} ] })"_vpack;
+}
+
+SharedSlice setup2CliquesConnectedByDirectedEdge() {
+  return
+      R"({ "vertices": [ {"_key": "a0", "value": 5},
+                         {"_key": "a1", "value": 10},
+                         {"_key": "a2", "value": 15},
+                         {"_key": "b0", "value": 5},
+                         {"_key": "b1", "value": 10},
+                         {"_key": "b2", "value": 15}
+ ],
+           "edges":    [ {"_key": "", "_from": "a0", "_to": "a1"},
+                         {"_key": "", "_from": "a1", "_to": "a0"},
+                         {"_key": "", "_from": "a0", "_to": "a2"},
+                         {"_key": "", "_from": "a2", "_to": "a0"},
+                         {"_key": "", "_from": "a1", "_to": "a2"},
+                         {"_key": "", "_from": "a2", "_to": "a1"},
+                         {"_key": "", "_from": "b0", "_to": "b1"},
+                         {"_key": "", "_from": "b1", "_to": "b0"},
+                         {"_key": "", "_from": "b0", "_to": "b2"},
+                         {"_key": "", "_from": "b2", "_to": "b0"},
+                         {"_key": "", "_from": "b1", "_to": "b2"},
+                         {"_key": "", "_from": "b2", "_to": "b1"},
+                         {"_key": "", "_from": "a0", "_to": "b0"} ] })"_vpack;
+}
+
+SharedSlice setupDuplicateVertices() {
+  return
+      R"({ "vertices": [ {"_key": "A", "value": 5},
+                         {"_key": "A", "value": 10} ],
+           "edges":    [ ] })"_vpack;
+}

--- a/arangod/Pregel/tests/GraphsSource.h
+++ b/arangod/Pregel/tests/GraphsSource.h
@@ -28,6 +28,7 @@
 
 using namespace arangodb::velocypack;
 
+namespace arangodb::slicegraph {
 SharedSlice setup2Path();
 
 SharedSlice setupUndirectedEdge();
@@ -47,3 +48,12 @@ SharedSlice setup1AlternatingTree();
 SharedSlice setup2CliquesConnectedByDirectedEdge();
 
 SharedSlice setupDuplicateVertices();
+
+struct GraphSliceHelper {
+  static auto getNumVertices(SharedSlice const& graphSlice) -> size_t;
+
+  static auto getNumEdges(SharedSlice const& graphSlice) -> size_t;
+
+};
+
+} // namespace arangodb::slicegraph

--- a/arangod/Pregel/tests/GraphsSource.h
+++ b/arangod/Pregel/tests/GraphsSource.h
@@ -1,0 +1,49 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2022 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Roman Rabinovich
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include <Basics/VelocyPackStringLiteral.h>
+
+using namespace arangodb::velocypack;
+
+SharedSlice setup2Path();
+
+SharedSlice setupUndirectedEdge();
+
+SharedSlice setupThreeDisjointDirectedCycles();
+
+SharedSlice setupThreeDisjointAlternatingCycles();
+
+SharedSlice setup1SingleVertex();
+
+SharedSlice setup2IsolatedVertices();
+
+SharedSlice setup1DirectedTree();
+
+SharedSlice setup1AlternatingTree();
+
+SharedSlice setup2CliquesConnectedByDirectedEdge();
+
+SharedSlice setupDuplicateVertices();

--- a/arangod/Pregel/tests/WCCGraph.cpp
+++ b/arangod/Pregel/tests/WCCGraph.cpp
@@ -1,9 +1,8 @@
 #include "WCCGraph.h"
-#include <Inspection/VPackPure.h>
 
 template<typename EdgeProperties, typename VertexProperties>
 void Graph<EdgeProperties, VertexProperties>::_checkEdgeEnds(
-    GraphEdge edge, std::map<VertexKey, size_t> const& vertexPosition) {
+    Edge edge, std::map<VertexKey, size_t> const& vertexPosition) {
   if (not vertexPosition.contains(edge._from)) {
     throw std::runtime_error("Edge " + edge._key + " has a _from vertex " +
                              edge._from +
@@ -19,41 +18,17 @@ void Graph<EdgeProperties, VertexProperties>::_checkEdgeEnds(
 
 template<typename EdgeProperties, VertexPropertiesWithValue VertexProperties>
 WCCGraph<EdgeProperties, VertexProperties>::WCCGraph(
-    const SharedSlice& graphJson, bool checkDuplicateVertices) : _wccs() {
+    const SharedSlice& graphJson, bool checkDuplicateVertices) : wccs() {
   this->readVertices(graphJson, checkDuplicateVertices);
   for (EdgeIndex idx = 0; idx < this->vertices.size(); ++idx) {
-    _wccs.addSingleton(idx);
+    wccs.addSingleton(idx);
   }
 
-  this->readEdges(graphJson, true,   [&](GraphEdge edge) {
-    _wccs.merge(this->getVertexPosition(edge._from),
+  this->readEdges(graphJson, true,   [&](WCCEdge edge) {
+    wccs.merge(this->getVertexPosition(edge._from),
                 this->getVertexPosition(edge._to));
   });
   this->clearVertexPositions();
-}
-
-template<typename EdgeProperties, VertexPropertiesWithValue VertexProperties>
-auto WCCGraph<EdgeProperties, VertexProperties>::computeWCC() -> size_t {
-  std::unordered_set<size_t> markedRepresentatives;
-  size_t counter = 0;
-  for (size_t i = 0; i < this->vertices.size(); ++i) {
-    size_t const representative = _wccs.representative(i);
-    if (markedRepresentatives.contains(representative)) {
-      this->vertices[i].properties.value =
-          this->vertices[representative].properties.value;
-    } else {
-      size_t const newId = counter++;
-      this->vertices[i].properties.value = newId;
-      this->vertices[representative].properties.value = newId;
-      markedRepresentatives.insert(representative);
-    }
-  }
-  return counter;
-}
-
-template<typename EdgeProperties, VertexPropertiesWithValue VertexProperties>
-auto WCCGraph<EdgeProperties, VertexProperties>::printWccs() -> void {
-  _wccs.print();
 }
 
 template class WCCGraph<EmptyEdgeProperties, WCCVertexProperties>;

--- a/arangod/Pregel/tests/WCCGraph.cpp
+++ b/arangod/Pregel/tests/WCCGraph.cpp
@@ -1,0 +1,59 @@
+#include "WCCGraph.h"
+#include <Inspection/VPackPure.h>
+
+template<typename EdgeProperties, typename VertexProperties>
+void Graph<EdgeProperties, VertexProperties>::_checkEdgeEnds(
+    GraphEdge edge, std::map<VertexKey, size_t> const& vertexPosition) {
+  if (not vertexPosition.contains(edge._from)) {
+    throw std::runtime_error("Edge " + edge._key + " has a _from vertex " +
+                             edge._from +
+                             " that is not declared in the list of vertices.");
+  }
+
+  if (not vertexPosition.contains(edge._to)) {
+    throw std::runtime_error("Edge " + edge._key + " has a _to vertex " +
+                             edge._to +
+                             " that is not declared in the list of vertices.");
+  }
+}
+
+template<typename EdgeProperties, VertexPropertiesWithValue VertexProperties>
+WCCGraph<EdgeProperties, VertexProperties>::WCCGraph(
+    const SharedSlice& graphJson, bool checkDuplicateVertices) : _wccs() {
+  this->readVertices(graphJson, checkDuplicateVertices);
+  for (EdgeIndex idx = 0; idx < this->vertices.size(); ++idx) {
+    _wccs.addSingleton(idx);
+  }
+
+  this->readEdges(graphJson, true,   [&](GraphEdge edge) {
+    _wccs.merge(this->getVertexPosition(edge._from),
+                this->getVertexPosition(edge._to));
+  });
+  this->clearVertexPositions();
+}
+
+template<typename EdgeProperties, VertexPropertiesWithValue VertexProperties>
+auto WCCGraph<EdgeProperties, VertexProperties>::computeWCC() -> size_t {
+  std::unordered_set<size_t> markedRepresentatives;
+  size_t counter = 0;
+  for (size_t i = 0; i < this->vertices.size(); ++i) {
+    size_t const representative = _wccs.representative(i);
+    if (markedRepresentatives.contains(representative)) {
+      this->vertices[i].properties.value =
+          this->vertices[representative].properties.value;
+    } else {
+      size_t const newId = counter++;
+      this->vertices[i].properties.value = newId;
+      this->vertices[representative].properties.value = newId;
+      markedRepresentatives.insert(representative);
+    }
+  }
+  return counter;
+}
+
+template<typename EdgeProperties, VertexPropertiesWithValue VertexProperties>
+auto WCCGraph<EdgeProperties, VertexProperties>::printWccs() -> void {
+  _wccs.print();
+}
+
+template class WCCGraph<EmptyEdgeProperties, WCCVertexProperties>;

--- a/arangod/Pregel/tests/WCCGraph.h
+++ b/arangod/Pregel/tests/WCCGraph.h
@@ -54,6 +54,8 @@ class WCCGraph {
 
   std::vector<WCCVertex> vertices;
 
+  auto printWccs() -> void;
+
  private:
   std::map<VertexKey, size_t> _vertexPosition;
   DisjointSet _wccs;

--- a/arangod/Pregel/tests/WCCGraph.h
+++ b/arangod/Pregel/tests/WCCGraph.h
@@ -1,13 +1,31 @@
-#pragma once
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2022 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
 
-#include <string>
-#include <unordered_set>
-#include <map>
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Roman Rabinovich
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
 
 #include <Basics/VelocyPackStringLiteral.h>
 #include <Inspection/VPackPure.h>
-#include <fmt/core.h>
-#include <fmt/format.h>
 
 #include "Graph.h"
 #include "DisjointSet.h"
@@ -29,22 +47,12 @@ auto inspect(Inspector& f, WCCVertexProperties& x) {
 }
 
 template<typename EdgeProperties, VertexPropertiesWithValue VertexProperties>
-class WCCGraph : public Graph<EdgeProperties, VertexProperties> {
+class WCCGraph : public ValuedGraph<EdgeProperties, VertexProperties> {
  public:
-  using GraphVertex = Vertex<VertexProperties>;
-  using GraphEdge = Edge<EdgeProperties>;
+  using WCCEdge = BaseEdge<EdgeProperties>;
 
   WCCGraph(SharedSlice const& graphJson, bool checkDuplicateVertices);
-  /**
-   * Compute the weakly connected components. Each component has an id of type
-   * size_t and is written into the value property of each of its vertices.
-   * @return the number of weakly connected components.
-   */
-  auto computeWCC() -> size_t;
 
-  auto printWccs() -> void;
-
- private:
-  DisjointSet _wccs;
+  DisjointSet wccs;
 };
 

--- a/arangod/Pregel/tests/WCCGraph.h
+++ b/arangod/Pregel/tests/WCCGraph.h
@@ -32,10 +32,8 @@
 
 using namespace arangodb::velocypack;
 
-
 using VertexIndex = size_t;
 using EdgeIndex = size_t;
-
 
 struct WCCVertexProperties {
   uint64_t value;
@@ -46,6 +44,18 @@ auto inspect(Inspector& f, WCCVertexProperties& x) {
   return f.object(x).fields(f.field("value", x.value));
 }
 
+/**
+ * The class is intended solely to compute WCCs. This is on-the-fly while
+ * reading graph edges. The algorithm is performed directly in the constructor.
+ * It uses a UnionFind structure. First, the vertices are read: each vertex is
+ * added to the structure as a singleton. Then the edges are read. When an edge
+ * is read, the sets of the UnionFind structure containing the ends of the edge
+ * are merged if necessary. When the WCCs are computed, they can be written into
+ * the vertices as properties using the function
+ * writeEquivalenceRelationIntoVertices of the parent class.
+ * @tparam EdgeProperties
+ * @tparam VertexProperties
+ */
 template<typename EdgeProperties, VertexPropertiesWithValue VertexProperties>
 class WCCGraph : public ValuedGraph<EdgeProperties, VertexProperties> {
  public:
@@ -55,4 +65,3 @@ class WCCGraph : public ValuedGraph<EdgeProperties, VertexProperties> {
 
   DisjointSet wccs;
 };
-

--- a/arangod/Pregel/tests/WCCGraph.h
+++ b/arangod/Pregel/tests/WCCGraph.h
@@ -1,0 +1,86 @@
+#pragma once
+
+#include <string>
+#include <unordered_set>
+#include <map>
+
+#include <Basics/VelocyPackStringLiteral.h>
+#include <Inspection/VPackPure.h>
+#include <fmt/core.h>
+#include <fmt/format.h>
+
+#include "DisjointSet.h"
+
+using namespace arangodb::velocypack;
+
+struct WCCVertexProperties {
+  uint64_t value;
+};
+
+struct EmptyEdgeProperties {};
+
+using VertexKey = std::string;
+using EdgeKey = std::string;
+
+template<typename VertexProperties>
+struct Vertex {
+  VertexKey _key;
+  VertexProperties properties;
+
+  auto operator==(Vertex const& other) { return _key == other._key; }
+};
+
+using WCCVertex = Vertex<WCCVertexProperties>;
+
+template<typename EdgeProperties = EmptyEdgeProperties>
+struct Edge {
+  EdgeKey _key;
+  VertexKey _from;
+  VertexKey _to;
+  EdgeProperties properties;
+};
+
+template<typename EdgeProperties>
+class WCCGraph {
+ public:
+  WCCGraph() = default;
+  WCCGraph(SharedSlice graphJson, bool checkDuplicateVertices);
+  /**
+   * Compute the weakly connected components. Each component has an id of type
+   * size_t and is written into the value property of each of its vertices.
+   * @return the number of weakly connected components.
+   */
+  auto computeWCC() -> size_t;
+
+  std::vector<WCCVertex> vertices;
+
+ private:
+  std::map<VertexKey, size_t> _vertexPosition;
+  DisjointSet _wccs;
+
+  auto _checkEdgeEnds(Edge<EdgeProperties>,
+                      std::map<VertexKey, size_t> const& vertexPosition)
+      -> void;
+};
+
+template<typename Inspector>
+auto inspect(Inspector& f, WCCVertexProperties& x) {
+  return f.object(x).fields(f.field("value", x.value));
+}
+
+template<typename Inspector, typename VertexProperties>
+auto inspect(Inspector& f, Vertex<VertexProperties>& p) {
+  return f.object(p).fields(f.field("_key", p._key),
+                            f.embedFields(p.properties));
+}
+
+template<typename Inspector>
+auto inspect(Inspector& f, EmptyEdgeProperties& x) {
+  return f.object(x).fields();
+}
+
+template<typename Inspector, typename EdgeProperties = EmptyEdgeProperties>
+auto inspect(Inspector& f, Edge<EdgeProperties>& p) {
+  return f.object(p).fields(f.field("_key", p._key), f.field("_from", p._from),
+                            f.field("_to", p._to), f.embedFields(p.properties));
+}

--- a/arangod/Pregel/tests/WCCGraph.h
+++ b/arangod/Pregel/tests/WCCGraph.h
@@ -9,60 +9,18 @@
 #include <fmt/core.h>
 #include <fmt/format.h>
 
+#include "Graph.h"
 #include "DisjointSet.h"
 
 using namespace arangodb::velocypack;
 
+
+using VertexIndex = size_t;
+using EdgeIndex = size_t;
+
+
 struct WCCVertexProperties {
   uint64_t value;
-};
-
-struct EmptyEdgeProperties {};
-
-using VertexKey = std::string;
-using EdgeKey = std::string;
-
-template<typename VertexProperties>
-struct Vertex {
-  VertexKey _key;
-  VertexProperties properties;
-
-  auto operator==(Vertex const& other) { return _key == other._key; }
-};
-
-using WCCVertex = Vertex<WCCVertexProperties>;
-
-template<typename EdgeProperties = EmptyEdgeProperties>
-struct Edge {
-  EdgeKey _key;
-  VertexKey _from;
-  VertexKey _to;
-  EdgeProperties properties;
-};
-
-template<typename EdgeProperties>
-class WCCGraph {
- public:
-  WCCGraph() = default;
-  WCCGraph(SharedSlice graphJson, bool checkDuplicateVertices);
-  /**
-   * Compute the weakly connected components. Each component has an id of type
-   * size_t and is written into the value property of each of its vertices.
-   * @return the number of weakly connected components.
-   */
-  auto computeWCC() -> size_t;
-
-  std::vector<WCCVertex> vertices;
-
-  auto printWccs() -> void;
-
- private:
-  std::map<VertexKey, size_t> _vertexPosition;
-  DisjointSet _wccs;
-
-  auto _checkEdgeEnds(Edge<EdgeProperties>,
-                      std::map<VertexKey, size_t> const& vertexPosition)
-      -> void;
 };
 
 template<typename Inspector>
@@ -70,19 +28,23 @@ auto inspect(Inspector& f, WCCVertexProperties& x) {
   return f.object(x).fields(f.field("value", x.value));
 }
 
-template<typename Inspector, typename VertexProperties>
-auto inspect(Inspector& f, Vertex<VertexProperties>& p) {
-  return f.object(p).fields(f.field("_key", p._key),
-                            f.embedFields(p.properties));
-}
+template<typename EdgeProperties, VertexPropertiesWithValue VertexProperties>
+class WCCGraph : public Graph<EdgeProperties, VertexProperties> {
+ public:
+  using GraphVertex = Vertex<VertexProperties>;
+  using GraphEdge = Edge<EdgeProperties>;
 
-template<typename Inspector>
-auto inspect(Inspector& f, EmptyEdgeProperties& x) {
-  return f.object(x).fields();
-}
+  WCCGraph(SharedSlice const& graphJson, bool checkDuplicateVertices);
+  /**
+   * Compute the weakly connected components. Each component has an id of type
+   * size_t and is written into the value property of each of its vertices.
+   * @return the number of weakly connected components.
+   */
+  auto computeWCC() -> size_t;
 
-template<typename Inspector, typename EdgeProperties = EmptyEdgeProperties>
-auto inspect(Inspector& f, Edge<EdgeProperties>& p) {
-  return f.object(p).fields(f.field("_key", p._key), f.field("_from", p._from),
-                            f.field("_to", p._to), f.embedFields(p.properties));
-}
+  auto printWccs() -> void;
+
+ private:
+  DisjointSet _wccs;
+};
+

--- a/arangod/Pregel/tests/WeaklyConnectedComponentsTest.cpp
+++ b/arangod/Pregel/tests/WeaklyConnectedComponentsTest.cpp
@@ -1,3 +1,27 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2022 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Markus Pfeiffer
+////////////////////////////////////////////////////////////////////////////////
+
 #include <gtest/gtest.h>
 
 #include <Basics/VelocyPackStringLiteral.h>
@@ -6,6 +30,86 @@
 
 #include <fmt/core.h>
 #include <fmt/format.h>
+
+#include <Inspection/VPack.h>
+
+#include "Algorithm.h"
+#include <string>
+#include <variant>
+
+using namespace arangodb::velocypack;
+
+struct VertexProperties {
+  uint64_t value;
+};
+template<typename Inspector>
+auto inspect(Inspector& f, VertexProperties& x) {
+  return f.object(x).fields(f.field("value", x.value));
+}
+
+struct EmptyEdgeProperties {};
+template<typename Inspector>
+auto inspect(Inspector& f, EmptyEdgeProperties& x) {
+  return f.object(x).fields();
+}
+
+using VertexKey = std::string;
+using EdgeKey = std::string;
+
+template<typename VertexProperties>
+struct Vertex {
+  VertexKey _key;
+  VertexProperties properties;
+};
+
+template<typename Inspector, typename VertexProperties>
+auto inspect(Inspector& f, Vertex<VertexProperties>& p) {
+  return f.object(p).fields(f.field("_key", p._key),
+                            f.embedFields(p.properties));
+}
+
+template<typename EdgeProperties = EmptyEdgeProperties>
+struct Edge {
+  EdgeKey _key;
+  VertexKey _from;
+  VertexKey _to;
+  EdgeProperties properties;
+};
+
+template<typename Inspector, typename EdgeProperties=EmptyEdgeProperties>
+auto inspect(Inspector& f, Edge<EdgeProperties>& p) {
+  return f.object(p).fields(f.field("_key", p._key),
+                            f.field("_from", p._from),
+                            f.field("_to", p._to),
+                            f.embedFields(p.properties));
+}
+
+template<typename VertexProperties, typename EdgeProperties>
+struct Graph {
+  std::vector<Vertex<VertexProperties>> vertices;
+  std::vector<Edge<EdgeProperties>> edges;
+};
+
+void setup_graph() {
+  auto graphJson =
+      R"({ "vertices": [ {"_key": "A", "value": 5},
+                         {"_key": "B", "value": 10},
+                         {"_key": "C", "value": 15} ],
+           "edges":    [ {"_key": "", "_from": "A", "_to": "B"},
+                         {"_key": "", "_from": "B", "_to": "C"} ] })"_vpack;
+
+  auto graph = Graph<VertexProperties, EmptyEdgeProperties>{};
+
+  auto vs = graphJson["vertices"];
+//  for (size_t i = 0; i < vs.length(); ++i) {
+//    auto res = readVertex(graph, vs[i]);
+//  }
+
+  auto es = graphJson["edges"];
+  for (size_t i = 0; i < es.length(); ++i) {
+    auto res = deserialize<Edge<EmptyEdgeProperties>>(es[i]);
+  }
+}
 
 
 using namespace arangodb::velocypack;

--- a/arangod/Pregel/tests/WeaklyConnectedComponentsTest.cpp
+++ b/arangod/Pregel/tests/WeaklyConnectedComponentsTest.cpp
@@ -107,7 +107,7 @@ void setup_graph() {
   auto es = graphJson["edges"];
   for (size_t i = 0; i < es.length(); ++i) {
     auto edge = Edge<EmptyEdgeProperties>{};
-//    auto res = deserializeWithStatus(es[i], edge);
+    auto res = deserializeWithStatus(es[i].slice(), edge);
   }
 }
 

--- a/arangod/Pregel/tests/WeaklyConnectedComponentsTest.cpp
+++ b/arangod/Pregel/tests/WeaklyConnectedComponentsTest.cpp
@@ -31,9 +31,8 @@
 #include <fmt/core.h>
 #include <fmt/format.h>
 
-#include <Inspection/VPack.h>
+#include <Inspection/VPackPure.h>
 
-#include "Algorithm.h"
 #include <string>
 #include <variant>
 
@@ -107,7 +106,8 @@ void setup_graph() {
 
   auto es = graphJson["edges"];
   for (size_t i = 0; i < es.length(); ++i) {
-    auto res = deserialize<Edge<EmptyEdgeProperties>>(es[i]);
+    auto edge = Edge<EmptyEdgeProperties>{};
+//    auto res = deserializeWithStatus(es[i], edge);
   }
 }
 

--- a/arangod/Pregel/tests/WeaklyConnectedComponentsTest.cpp
+++ b/arangod/Pregel/tests/WeaklyConnectedComponentsTest.cpp
@@ -24,250 +24,25 @@
 
 #include <gtest/gtest.h>
 #include <variant>
-#include <Inspection/VPackPure.h>
 #include "WCCGraph.h"
-#include "DisjointSet.h"
-
-TEST(GWEN_DISJOINT_SET, test_constructor) {
-  auto ds = DisjointSet(10);
-  EXPECT_EQ(ds.capacity(), static_cast<size_t>(10));
-  auto ds0 = DisjointSet();
-  EXPECT_EQ(ds0.capacity(), static_cast<size_t>(0));
-}
-
-TEST(GWEN_DISJOINT_SET, test_add_singleton) {
-  auto ds = DisjointSet();
-  EXPECT_TRUE(ds.addSingleton(2));
-  EXPECT_EQ(ds.capacity(), 3u);
-  EXPECT_FALSE(ds.addSingleton(2));
-  EXPECT_TRUE(ds.addSingleton(1));
-  EXPECT_EQ(ds.capacity(), 3u);
-  EXPECT_TRUE(ds.addSingleton(4));
-  EXPECT_EQ(ds.capacity(), 5u);
-  EXPECT_TRUE(ds.addSingleton(0));
-  EXPECT_EQ(ds.capacity(), 5u);
-  EXPECT_TRUE(ds.addSingleton(5, 6));
-  EXPECT_EQ(ds.capacity(), 6u);
-  EXPECT_TRUE(ds.addSingleton(6, 8));
-  EXPECT_EQ(ds.capacity(), 8u);
-  EXPECT_TRUE(ds.addSingleton(3, 5));
-  EXPECT_EQ(ds.capacity(), 8u);
-  EXPECT_TRUE(ds.addSingleton(7, 5));
-  EXPECT_EQ(ds.capacity(), 8u);
-}
-
-TEST(GWEN_DISJOINT_SET, test_merge_and_representatives) {
-  auto ds = DisjointSet(10);
-  for (size_t i = 0; i < 10; ++i) {
-    ds.addSingleton(i);
-  }
-  ds.merge(0, 0);
-  EXPECT_EQ(ds.representative(0), 0u);
-  ds.merge(0, 1);
-  // 0 and 1 have the same rank, so the second parameter
-  // becomes the representative
-  EXPECT_EQ(ds.representative(0), 1u);
-  EXPECT_EQ(ds.representative(1), 1u);
-  ds.merge(0, 1);
-  EXPECT_EQ(ds.representative(0), 1u);
-  EXPECT_EQ(ds.representative(1), 1u);
-  ds.merge(1, 2);
-  EXPECT_EQ(ds.representative(0), 1u);
-  EXPECT_EQ(ds.representative(1), 1u);
-  // 1 has a higher rank
-  EXPECT_EQ(ds.representative(2), 1u);
-  ds.merge(3, 4);
-  ds.merge(5, 6);
-  ds.merge(3, 5);
-  ds.merge(2, 3);
-  // the representative of 3 has a higher rank than that of 2
-  EXPECT_EQ(ds.representative(2), 6u);
-}
-
-SharedSlice setup2Path() {
-  return
-      R"({ "vertices": [ {"_key": "A", "value": 5},
-                         {"_key": "B", "value": 10},
-                         {"_key": "C", "value": 15} ],
-           "edges":    [ {"_key": "", "_from": "A", "_to": "B"},
-                         {"_key": "", "_from": "B", "_to": "C"} ] })"_vpack;
-}
-
-SharedSlice setupThreeDisjointDirectedCycles() {
-  return
-      R"({ "vertices": [ {"_key": "a0", "value": 0},
-                         {"_key": "a1", "value": 0},
-                         {"_key": "a2", "value": 0},
-                         {"_key": "b0", "value": 0},
-                         {"_key": "b1", "value": 0},
-                         {"_key": "b2", "value": 0},
-                         {"_key": "b3", "value": 0},
-                         {"_key": "c0", "value": 0},
-                         {"_key": "c1", "value": 0},
-                         {"_key": "c2", "value": 0},
-                         {"_key": "c3", "value": 0},
-                         {"_key": "c4", "value": 0}],
-           "edges":    [ {"_key": "", "_from": "a0", "_to": "a1"},
-                         {"_key": "", "_from": "a1", "_to": "a2"},
-                         {"_key": "", "_from": "a2", "_to": "a0"},
-                         {"_key": "", "_from": "b0", "_to": "b1"},
-                         {"_key": "", "_from": "b1", "_to": "b2"},
-                         {"_key": "", "_from": "b2", "_to": "b3"},
-                         {"_key": "", "_from": "b3", "_to": "b0"},
-                         {"_key": "", "_from": "c0", "_to": "c1"},
-                         {"_key": "", "_from": "c1", "_to": "c2"},
-                         {"_key": "", "_from": "c2", "_to": "c3"},
-                         {"_key": "", "_from": "c3", "_to": "c4"},
-                         {"_key": "", "_from": "c4", "_to": "c0"}] })"_vpack;
-}
-
-SharedSlice setupThreeDisjointAlternatingCycles() {
-  return
-      R"({ "vertices": [ {"_key": "a0", "value": 0},
-                         {"_key": "a1", "value": 0},
-                         {"_key": "a2", "value": 0},
-                         {"_key": "b0", "value": 0},
-                         {"_key": "b1", "value": 0},
-                         {"_key": "b2", "value": 0},
-                         {"_key": "b3", "value": 0},
-                         {"_key": "c0", "value": 0},
-                         {"_key": "c1", "value": 0},
-                         {"_key": "c2", "value": 0},
-                         {"_key": "c3", "value": 0},
-                         {"_key": "c4", "value": 0}],
-           "edges":    [ {"_key": "", "_from": "a0", "_to": "a1"},
-                         {"_key": "", "_from": "a2", "_to": "a1"},
-                         {"_key": "", "_from": "a2", "_to": "a0"},
-                         {"_key": "", "_from": "b0", "_to": "b1"},
-                         {"_key": "", "_from": "b2", "_to": "b1"},
-                         {"_key": "", "_from": "b2", "_to": "b3"},
-                         {"_key": "", "_from": "b0", "_to": "b3"},
-                         {"_key": "", "_from": "c0", "_to": "c1"},
-                         {"_key": "", "_from": "c2", "_to": "c1"},
-                         {"_key": "", "_from": "c2", "_to": "c3"},
-                         {"_key": "", "_from": "c4", "_to": "c3"},
-                         {"_key": "", "_from": "c0", "_to": "c4"}] })"_vpack;
-}
-
-SharedSlice setup1SingleVertex() {
-  return
-      R"({ "vertices": [ {"_key": "A", "value": 0} ],
-           "edges":    [ ] })"_vpack;
-}
-
-SharedSlice setup2IsolatedVertices() {
-  return
-      R"({ "vertices": [ {"_key": "A", "value": 0},
-                         {"_key": "B", "value": 0} ],
-           "edges":    [ ] })"_vpack;
-}
-
-SharedSlice setup1DirectedTree() {
-  return
-      R"({ "vertices": [ {"_key": "a", "value": 5},
-                         {"_key": "a0", "value": 10},
-                         {"_key": "a1", "value": 15},
-                         {"_key": "a00", "value": 10},
-                         {"_key": "a01", "value": 15},
-                         {"_key": "a10", "value": 10},
-                         {"_key": "a11", "value": 15},
-                         {"_key": "a000", "value": 10},
-                         {"_key": "a001", "value": 15},
-                         {"_key": "a010", "value": 10},
-                         {"_key": "a011", "value": 15},
-                         {"_key": "a100", "value": 10},
-                         {"_key": "a101", "value": 15},
-                         {"_key": "a110", "value": 10},
-                         {"_key": "a111", "value": 15} ],
-           "edges":   [ {"_key": "", "_from": "a", "_to": "a0"},
-                        {"_key": "", "_from": "a", "_to": "a1"},
-                        {"_key": "", "_from": "a0", "_to": "a00"},
-                        {"_key": "", "_from": "a0", "_to": "a01"},
-                        {"_key": "", "_from": "a1", "_to": "a10"},
-                        {"_key": "", "_from": "a1", "_to": "a11"},
-                        {"_key": "", "_from": "a00", "_to": "a000"},
-                        {"_key": "", "_from": "a00", "_to": "a001"},
-                        {"_key": "", "_from": "a01", "_to": "a010"},
-                        {"_key": "", "_from": "a01", "_to": "a011"},
-                        {"_key": "", "_from": "a10", "_to": "a100"},
-                        {"_key": "", "_from": "a10", "_to": "a101"},
-                        {"_key": "", "_from": "a11", "_to": "a110"},
-                        {"_key": "", "_from": "a11", "_to": "a111"} ] })"_vpack;
-}
-
-SharedSlice setup1AlternatingTree() {
-  return
-      R"({ "vertices": [ {"_key": "a", "value": 5},
-                         {"_key": "a0", "value": 10},
-                         {"_key": "a1", "value": 15},
-                         {"_key": "a00", "value": 10},
-                         {"_key": "a01", "value": 15},
-                         {"_key": "a10", "value": 10},
-                         {"_key": "a11", "value": 15},
-                         {"_key": "a000", "value": 10},
-                         {"_key": "a001", "value": 15},
-                         {"_key": "a010", "value": 10},
-                         {"_key": "a011", "value": 15},
-                         {"_key": "a100", "value": 10},
-                         {"_key": "a101", "value": 15},
-                         {"_key": "a110", "value": 10},
-                         {"_key": "a111", "value": 15} ],
-           "edges":    [ {"_key": "", "_from": "a", "_to": "a0"},
-                         {"_key": "", "_from": "a", "_to": "a1"},
-                         {"_key": "", "_from": "a00", "_to": "a0"},
-                         {"_key": "", "_from": "a01", "_to": "a0"},
-                         {"_key": "", "_from": "a10", "_to": "a1"},
-                         {"_key": "", "_from": "a11", "_to": "a1"},
-                         {"_key": "", "_from": "a00", "_to": "a000"},
-                         {"_key": "", "_from": "a00", "_to": "a001"},
-                         {"_key": "", "_from": "a01", "_to": "a010"},
-                         {"_key": "", "_from": "a01", "_to": "a011"},
-                         {"_key": "", "_from": "a10", "_to": "a100"},
-                         {"_key": "", "_from": "a10", "_to": "a101"},
-                         {"_key": "", "_from": "a11", "_to": "a110"},
-                         {"_key": "", "_from": "a11", "_to": "a111"} ] })"_vpack;
-}
-
-SharedSlice setup2CliquesConnectedByDirectedEdge() {
-  return
-      R"({ "vertices": [ {"_key": "a0", "value": 5},
-                         {"_key": "a1", "value": 10},
-                         {"_key": "a2", "value": 15},
-                         {"_key": "b0", "value": 5},
-                         {"_key": "b1", "value": 10},
-                         {"_key": "b2", "value": 15}
- ],
-           "edges":    [ {"_key": "", "_from": "a0", "_to": "a1"},
-                         {"_key": "", "_from": "a1", "_to": "a0"},
-                         {"_key": "", "_from": "a0", "_to": "a2"},
-                         {"_key": "", "_from": "a2", "_to": "a0"},
-                         {"_key": "", "_from": "a1", "_to": "a2"},
-                         {"_key": "", "_from": "a2", "_to": "a1"},
-                         {"_key": "", "_from": "b0", "_to": "b1"},
-                         {"_key": "", "_from": "b1", "_to": "b0"},
-                         {"_key": "", "_from": "b0", "_to": "b2"},
-                         {"_key": "", "_from": "b2", "_to": "b0"},
-                         {"_key": "", "_from": "b1", "_to": "b2"},
-                         {"_key": "", "_from": "b2", "_to": "b1"},
-                         {"_key": "", "_from": "a0", "_to": "b0"} ] })"_vpack;
-}
+#include "GraphsSource.h"
 
 TEST(GWEN_WCC, test_wcc_2_path) {
   bool const checkDuplicateVertices = true;
   WCCGraph<EmptyEdgeProperties, WCCVertexProperties> graph(
       setup2Path(), checkDuplicateVertices);
-  size_t numComponents = graph.computeWCC();
-  ASSERT_EQ(numComponents, 1);
+  size_t numComponents = graph.writeEquivalenceRelationIntoVertices(graph.wccs);
+  ASSERT_EQ(numComponents, 1u);
 }
 
 template<typename EdgeProperties>
 auto testWCC(WCCGraph<EdgeProperties, WCCVertexProperties>& graph,
              size_t expectedNumComponents) {
-  size_t numComponents = graph.computeWCC();
+  size_t numComponents = graph.writeEquivalenceRelationIntoVertices(graph.wccs);
   ASSERT_EQ(numComponents, expectedNumComponents);
   std::unordered_map<char, uint64_t> value;
   for (auto const& v : graph.vertices) {
-    EXPECT_GE(v._key.size(), 1);
+    EXPECT_GE(v._key.size(), 1u);
     if (value.contains(v._key[0])) {
       ASSERT_EQ(v.properties.value, value[v._key[0]]);
     } else {

--- a/arangod/Pregel/tests/WeaklyConnectedComponentsTest.cpp
+++ b/arangod/Pregel/tests/WeaklyConnectedComponentsTest.cpp
@@ -254,13 +254,15 @@ SharedSlice setup2CliquesConnectedByDirectedEdge() {
 
 TEST(GWEN_WCC, test_wcc_2_path) {
   bool const checkDuplicateVertices = true;
-  WCCGraph<EmptyEdgeProperties> graph(setup2Path(), checkDuplicateVertices);
+  WCCGraph<EmptyEdgeProperties, WCCVertexProperties> graph(
+      setup2Path(), checkDuplicateVertices);
   size_t numComponents = graph.computeWCC();
   ASSERT_EQ(numComponents, 1);
 }
 
 template<typename EdgeProperties>
-auto testWCC(WCCGraph<EdgeProperties>& graph, size_t expectedNumComponents) {
+auto testWCC(WCCGraph<EdgeProperties, WCCVertexProperties>& graph,
+             size_t expectedNumComponents) {
   size_t numComponents = graph.computeWCC();
   ASSERT_EQ(numComponents, expectedNumComponents);
   std::unordered_map<char, uint64_t> value;
@@ -276,56 +278,56 @@ auto testWCC(WCCGraph<EdgeProperties>& graph, size_t expectedNumComponents) {
 
 TEST(GWEN_WCC, test_wcc_three_disjoint_directed_cycles) {
   bool const checkDuplicateVertices = true;
-  WCCGraph<EmptyEdgeProperties> graph(setupThreeDisjointDirectedCycles(),
-                                      checkDuplicateVertices);
+  WCCGraph<EmptyEdgeProperties, WCCVertexProperties> graph(
+      setupThreeDisjointDirectedCycles(), checkDuplicateVertices);
   size_t const expectedNumComponents = 3;
   testWCC(graph, expectedNumComponents);
 }
 
 TEST(GWEN_WCC, test_wcc_three_disjoint_alternating_cycles) {
   bool const checkDuplicateVertices = true;
-  WCCGraph<EmptyEdgeProperties> graph(setupThreeDisjointAlternatingCycles(),
-                                      checkDuplicateVertices);
+  WCCGraph<EmptyEdgeProperties, WCCVertexProperties> graph(
+      setupThreeDisjointAlternatingCycles(), checkDuplicateVertices);
   size_t const expectedNumComponents = 3;
   testWCC(graph, expectedNumComponents);
 }
 
 TEST(GWEN_WCC, test_wcc_one_single_vertex) {
   bool const checkDuplicateVertices = true;
-  WCCGraph<EmptyEdgeProperties> graph(setup1SingleVertex(),
-                                      checkDuplicateVertices);
+  WCCGraph<EmptyEdgeProperties, WCCVertexProperties> graph(
+      setup1SingleVertex(), checkDuplicateVertices);
   size_t const expectedNumComponents = 1;
   testWCC(graph, expectedNumComponents);
 }
 
 TEST(GWEN_WCC, test_wcc_two_isolated_vertices) {
   bool const checkDuplicateVertices = true;
-  WCCGraph<EmptyEdgeProperties> graph(setup2IsolatedVertices(),
-                                      checkDuplicateVertices);
+  WCCGraph<EmptyEdgeProperties, WCCVertexProperties> graph(
+      setup2IsolatedVertices(), checkDuplicateVertices);
   size_t const expectedNumComponents = 2;
   testWCC(graph, expectedNumComponents);
 }
 
 TEST(GWEN_WCC, test_wcc_one_directed_tree) {
   bool const checkDuplicateVertices = true;
-  WCCGraph<EmptyEdgeProperties> graph(setup1DirectedTree(),
-                                      checkDuplicateVertices);
+  WCCGraph<EmptyEdgeProperties, WCCVertexProperties> graph(
+      setup1DirectedTree(), checkDuplicateVertices);
   size_t const expectedNumComponents = 1;
   testWCC(graph, expectedNumComponents);
 }
 
 TEST(GWEN_WCC, test_wcc_one_alternating_tree) {
   bool const checkDuplicateVertices = true;
-  WCCGraph<EmptyEdgeProperties> graph(setup1AlternatingTree(),
-                                      checkDuplicateVertices);
+  WCCGraph<EmptyEdgeProperties, WCCVertexProperties> graph(
+      setup1AlternatingTree(), checkDuplicateVertices);
   size_t const expectedNumComponents = 1;
   testWCC(graph, expectedNumComponents);
 }
 
 TEST(GWEN_WCC, test_wcc_2_cliques_connected_by_directed_edge) {
   bool const checkDuplicateVertices = true;
-  WCCGraph<EmptyEdgeProperties> graph(setup2CliquesConnectedByDirectedEdge(),
-                                      checkDuplicateVertices);
+  WCCGraph<EmptyEdgeProperties, WCCVertexProperties> graph(
+      setup2CliquesConnectedByDirectedEdge(), checkDuplicateVertices);
   size_t const expectedNumComponents = 1;
   testWCC(graph, expectedNumComponents);
 }

--- a/arangod/Pregel/tests/WeaklyConnectedComponentsTest.cpp
+++ b/arangod/Pregel/tests/WeaklyConnectedComponentsTest.cpp
@@ -27,6 +27,8 @@
 #include "WCCGraph.h"
 #include "GraphsSource.h"
 
+using namespace arangodb::slicegraph;
+
 TEST(GWEN_WCC, test_wcc_2_path) {
   bool const checkDuplicateVertices = true;
   WCCGraph<EmptyEdgeProperties, WCCVertexProperties> graph(

--- a/lib/Inspection/VPackPure.h
+++ b/lib/Inspection/VPackPure.h
@@ -1,0 +1,159 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2020 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Manuel Pöter
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "Inspection/VPackLoadInspector.h"
+#include "Inspection/VPackSaveInspector.h"
+
+namespace arangodb::velocypack {
+
+template<class T>
+[[nodiscard]] auto serialize(T& value) -> SharedSlice {
+  auto builder = Builder();
+  serialize(builder, value);
+  return std::move(builder).sharedSlice();
+}
+
+namespace detail {
+
+template<class Inspector, class T>
+[[nodiscard]] inspection::Status deserializeWithStatus(Inspector& inspector,
+                                                       T& result) {
+  return inspector.apply(result);
+}
+
+template<class Inspector, class T>
+void deserialize(Slice slice, T& result, inspection::ParseOptions options) {
+  Inspector inspector(slice, options);
+  deserialize(inspector, result);
+}
+
+template<class Inspector, class T, class Context>
+void deserialize(Slice slice, T& result, inspection::ParseOptions options,
+                 Context const& context) {
+  Inspector inspector(slice, options, context);
+  deserialize(inspector, result);
+}
+
+template<class Inspector, class T>
+T deserialize(Slice slice, inspection::ParseOptions options) {
+  T result;
+  detail::deserialize<Inspector, T>(slice, result, options);
+  return result;
+}
+
+template<class Inspector, class T, class Context>
+T deserialize(Slice slice, inspection::ParseOptions options,
+              Context const& context) {
+  T result;
+  detail::deserialize<Inspector, T>(slice, result, options, context);
+  return result;
+}
+
+template<class Inspector, class T>
+[[nodiscard]] inspection::Status deserializeWithStatus(
+    Slice slice, T& result, inspection::ParseOptions options) {
+  Inspector inspector(slice, options);
+  return deserializeWithStatus(inspector, result);
+}
+
+template<class Inspector, class T, class Context>
+[[nodiscard]] inspection::Status deserializeWithStatus(
+    Slice slice, T& result, inspection::ParseOptions options,
+    Context const& context) {
+  Inspector inspector(slice, options, context);
+  return deserializeWithStatus(inspector, result);
+}
+
+}  // namespace detail
+
+template<class T>
+void deserialize(Slice slice, T& result,
+                 inspection::ParseOptions options = {}) {
+  detail::deserialize<inspection::VPackLoadInspector<>>(slice, result, options);
+}
+
+template<class T, class Context>
+void deserialize(Slice slice, T& result, inspection::ParseOptions options,
+                 Context const& context) {
+  detail::deserialize<inspection::VPackLoadInspector<Context>>(
+      slice, result, options, context);
+}
+
+template<class T>
+[[nodiscard]] inspection::Status deserializeWithStatus(
+    Slice slice, T& result, inspection::ParseOptions options = {}) {
+  return detail::deserializeWithStatus<inspection::VPackLoadInspector<>>(
+      slice, result, options);
+}
+
+template<class T, class Context>
+[[nodiscard]] inspection::Status deserializeWithStatus(
+    Slice slice, T& result, inspection::ParseOptions options,
+    Context const& context) {
+  return detail::deserializeWithStatus<inspection::VPackLoadInspector<Context>>(
+      slice, result, options, context);
+}
+
+template<class T>
+void deserializeUnsafe(Slice slice, T& result,
+                       inspection::ParseOptions options = {}) {
+  detail::deserialize<inspection::VPackUnsafeLoadInspector<>>(slice, result,
+                                                              options);
+}
+
+template<class T, class Context>
+void deserializeUnsafe(Slice slice, T& result, inspection::ParseOptions options,
+                       Context const& context) {
+  detail::deserialize<inspection::VPackUnsafeLoadInspector<Context>>(
+      slice, result, options, context);
+}
+
+template<class T>
+T deserialize(Slice slice, inspection::ParseOptions options = {}) {
+  return detail::deserialize<inspection::VPackLoadInspector<>, T>(slice,
+                                                                  options);
+}
+
+template<class T, class Context>
+T deserialize(Slice slice, inspection::ParseOptions options,
+              Context const& context) {
+  return detail::deserialize<inspection::VPackLoadInspector<Context>, T>(
+      slice, options, context);
+}
+
+template<class T>
+T deserializeUnsafe(Slice slice, inspection::ParseOptions options = {}) {
+  return detail::deserialize<inspection::VPackUnsafeLoadInspector<>, T>(
+      slice, options);
+}
+
+template<class T, class Context>
+T deserializeUnsafe(Slice slice, inspection::ParseOptions options,
+                    Context const& context) {
+  return detail::deserialize<inspection::VPackUnsafeLoadInspector<Context>, T>(
+      slice, options, context);
+}
+
+}  // namespace arangodb::velocypack


### PR DESCRIPTION
### Scope & Purpose

Implements an experimental WCC algorithm without Pregel. Currently, the graph should be given by a `SharedSlice` of the form 
```c++
R"({ "vertices": [ {"_key": "A", "value": 5}, ... ],  "edges":    [ {"_key": "", "_from": "A", "_to": "B"}, ... ] })"_vpack
```
the intention is to have an algorithm faster than a Pregel implementation. The algorithm uses a UnionFind structure (aka disjoint sets). Initially, each vertex is its own component. When an edge is read, the sets containing the ends of the edge are merged (the union operation). At the end, each disjoint set is a weakly connected component. An advantage of this algorithm is that it is online with respect to edges. 

- [x] :pizza: New feature
- [x] :fire: Performance improvement (to be tested)

### Checklist

- [x] C++ **Unit tests**
- [x] :book: CHANGELOG entry made (to be done if decide to incorporate)
- [x] :books: documentation written in the header file
