### PR TITLE
disable test until deadlock is fixed

### DIFF
--- a/tests/test-definitions.txt
+++ b/tests/test-definitions.txt
@@ -68,7 +68,7 @@ load_balancing priority=500 cluster -- --dumpAgencyOnError true
 load_balancing_auth priority=500 cluster -- --dumpAgencyOnError true
 
 replication2_client cluster
-replication2_server cluster -- --dumpAgencyOnError true
+# replication2_server cluster -- --dumpAgencyOnError true
 
 resilience_analyzers priority=500 cluster -- --dumpAgencyOnError true
 resilience_failover priority=750 cluster -- --dumpAgencyOnError true


### PR DESCRIPTION
### Scope & Purpose

This test will deadlock and destabilize the CI in terms of runtime and crashreport sizes.
Hence disabling it for now. 