### PR TITLE
[PREGEL] Wait until Worker received all messages that were sent to it

### DIFF
--- a/arangod/Pregel/Conductor/Conductor.cpp
+++ b/arangod/Pregel/Conductor/Conductor.cpp
@@ -209,7 +209,7 @@ void Conductor::workerStatusUpdated(StatusUpdated const& data) {
 
   VPackBuilder event;
   serialize(event, data);
-  LOG_PREGEL("76632", DEBUG)
+  LOG_PREGEL("76632", TRACE)
       << fmt::format("Update received {}", event.toJson());
 
   _status.updateWorkerStatus(data.senderId, data.status);

--- a/arangod/Pregel/Conductor/Conductor.cpp
+++ b/arangod/Pregel/Conductor/Conductor.cpp
@@ -295,8 +295,13 @@ auto Conductor::_initializeWorkers() -> futures::Future<Result> {
   }
 
   auto servers = std::vector<ServerID>{};
-  for (auto const& [server, _] : vertexMap) {
+  for (auto const& [server, shardsPerCollection] : vertexMap) {
     servers.push_back(server);
+    for (auto const& [_, shards] : shardsPerCollection) {
+      for (auto const& shard : shards) {
+        _leadingServerForShard[shard] = server;
+      }
+    }
   }
   _status = ConductorStatus::forWorkers(servers);
 

--- a/arangod/Pregel/Conductor/Conductor.h
+++ b/arangod/Pregel/Conductor/Conductor.h
@@ -135,6 +135,8 @@ class Conductor : public std::enable_shared_from_this<Conductor> {
   // with the Inspecotr framework
   ConductorStatus _status;
 
+  std::unordered_map<ShardID, ServerID> _leadingServerForShard;
+
   auto _changeState(std::unique_ptr<conductor::State> newState) -> void;
   auto _initializeWorkers() -> futures::Future<Result>;
   auto _preGlobalSuperStep() -> void;

--- a/arangod/Pregel/Conductor/States/ComputingState.h
+++ b/arangod/Pregel/Conductor/States/ComputingState.h
@@ -46,6 +46,7 @@ struct Computing : State {
  private:
   auto _runGlobalSuperStepCommand() -> RunGlobalSuperStep;
   auto _runGlobalSuperStep() -> futures::Future<Result>;
+  std::unordered_map<ServerID, uint64_t> _sendCountPerServer;
 };
 
 }  // namespace conductor

--- a/arangod/Pregel/Conductor/WorkerApi.h
+++ b/arangod/Pregel/Conductor/WorkerApi.h
@@ -50,7 +50,9 @@ struct WorkerApi {
       -> futures::Future<Result>;
   [[nodiscard]] auto loadGraph(LoadGraph const& graph)
       -> ResultT<Aggregate<GraphLoaded>>;
-  [[nodiscard]] auto runGlobalSuperStep(RunGlobalSuperStep const& data)
+  [[nodiscard]] auto runGlobalSuperStep(
+      RunGlobalSuperStep const& data,
+      std::unordered_map<ServerID, uint64_t> const& sendCountPerServer)
       -> futures::Future<ResultT<GlobalSuperStepFinished>>;
   [[nodiscard]] auto store(Store const& message)
       -> futures::Future<ResultT<Stored>>;

--- a/arangod/Pregel/Messaging/ConductorMessages.h
+++ b/arangod/Pregel/Messaging/ConductorMessages.h
@@ -80,15 +80,16 @@ struct RunGlobalSuperStep {
   uint64_t gss;
   uint64_t vertexCount;
   uint64_t edgeCount;
+  uint64_t sendCount;
   VPackBuilder aggregators;
 };
 
 template<typename Inspector>
 auto inspect(Inspector& f, RunGlobalSuperStep& x) {
-  return f.object(x).fields(f.field(Utils::globalSuperstepKey, x.gss),
-                            f.field("vertexCount", x.vertexCount),
-                            f.field("edgeCount", x.edgeCount),
-                            f.field("aggregators", x.aggregators));
+  return f.object(x).fields(
+      f.field(Utils::globalSuperstepKey, x.gss),
+      f.field("vertexCount", x.vertexCount), f.field("edgeCount", x.edgeCount),
+      f.field("sendCount", x.sendCount), f.field("aggregators", x.aggregators));
 }
 
 struct Store {};

--- a/arangod/Pregel/Messaging/WorkerMessages.h
+++ b/arangod/Pregel/Messaging/WorkerMessages.h
@@ -94,21 +94,27 @@ auto inspect(Inspector& f, GlobalSuperStepPrepared& x) {
 
 struct GlobalSuperStepFinished {
   MessageStats messageStats;
+  std::unordered_map<ShardID, uint64_t> sendCountPerShard;
   uint64_t activeCount;
   uint64_t vertexCount;
   uint64_t edgeCount;
   VPackBuilder aggregators;
   GlobalSuperStepFinished() noexcept = default;
-  GlobalSuperStepFinished(MessageStats messageStats, uint64_t activeCount,
-                          uint64_t vertexCount, uint64_t edgeCount,
-                          VPackBuilder aggregators)
+  GlobalSuperStepFinished(MessageStats messageStats,
+                          std::unordered_map<ServerID, uint64_t> sentCounts,
+                          uint64_t activeCount, uint64_t vertexCount,
+                          uint64_t edgeCount, VPackBuilder aggregators)
       : messageStats{std::move(messageStats)},
+        sendCountPerShard{std::move(sentCounts)},
         activeCount{activeCount},
         vertexCount{vertexCount},
         edgeCount{edgeCount},
         aggregators{std::move(aggregators)} {}
   auto add(GlobalSuperStepFinished const& other) -> void {
     messageStats.accumulate(other.messageStats);
+    for (auto& [shard, count] : other.sendCountPerShard) {
+      sendCountPerShard[shard] += count;
+    }
     activeCount += other.activeCount;
     vertexCount += other.vertexCount;
     edgeCount += other.edgeCount;
@@ -128,6 +134,7 @@ struct GlobalSuperStepFinished {
 template<typename Inspector>
 auto inspect(Inspector& f, GlobalSuperStepFinished& x) {
   return f.object(x).fields(f.field("messageStats", x.messageStats),
+                            f.field("sentCounts", x.sendCountPerShard),
                             f.field("activeCount", x.activeCount),
                             f.field("vertexCount", x.vertexCount),
                             f.field("edgeCount", x.edgeCount),

--- a/arangod/Pregel/Messaging/WorkerMessages.h
+++ b/arangod/Pregel/Messaging/WorkerMessages.h
@@ -45,8 +45,8 @@ struct GraphLoaded {
   GraphLoaded(uint64_t vertexCount, uint64_t edgeCount)
       : vertexCount{vertexCount}, edgeCount{edgeCount} {}
   auto add(GraphLoaded const& other) -> void {
-    vertexCount = other.vertexCount;
-    edgeCount = other.edgeCount;
+    vertexCount += other.vertexCount;
+    edgeCount += other.edgeCount;
   }
 };
 

--- a/arangod/Pregel/Worker/Worker.h
+++ b/arangod/Pregel/Worker/Worker.h
@@ -85,6 +85,7 @@ class VertexContext;
 struct VerticesProcessed {
   VPackBuilder aggregator;
   MessageStats stats;
+  std::unordered_map<ShardID, uint64_t> sendCountPerShard;
   size_t activeCount;
 };
 
@@ -141,6 +142,10 @@ class Worker : public IWorker {
   /// current number of running threads
   size_t _runningThreads = 0;
   Scheduler::WorkHandle _workHandle;
+  // distinguishes config.globalSuperStep being initialized to 0 and
+  // config.globalSuperStep being explicitely set to 0 when the first superstep
+  // starts: needed to process incoming messages in its dedicated gss
+  bool _computationStarted = false;
 
   using VerticesProcessedFuture =
       futures::Future<std::vector<futures::Try<ResultT<VerticesProcessed>>>>;
@@ -151,7 +156,9 @@ class Worker : public IWorker {
   [[nodiscard]] auto _processVertices(
       size_t threadId, RangeIterator<Vertex<V, E>>& vertexIterator)
       -> ResultT<VerticesProcessed>;
-  auto _finishProcessing() -> ResultT<GlobalSuperStepFinished>;
+  auto _finishProcessing(
+      std::unordered_map<ShardID, uint64_t> sendCountPerShard)
+      -> ResultT<GlobalSuperStepFinished>;
   void _callConductor(ModernMessage message);
   [[nodiscard]] auto _observeStatus() -> Status const;
   [[nodiscard]] auto _makeStatusCallback() -> std::function<void()>;

--- a/arangod/Pregel/Worker/Worker.h
+++ b/arangod/Pregel/Worker/Worker.h
@@ -163,8 +163,6 @@ class Worker : public IWorker {
   [[nodiscard]] auto _observeStatus() -> Status const;
   [[nodiscard]] auto _makeStatusCallback() -> std::function<void()>;
 
-  [[nodiscard]] auto _prepareGlobalSuperStepFct(
-      PrepareGlobalSuperStep const& data) -> ResultT<GlobalSuperStepPrepared>;
   [[nodiscard]] auto _resultsFct(CollectPregelResults const& message) const
       -> ResultT<PregelResults>;
 


### PR DESCRIPTION
The previous PR #17332 merges the prepareGss and runGss message send from the conductor to the workers into a single message from conductor to workers. It turned out that when running the pregel tests several times in cluster mode, not all messages were delivered. We never check inside the Worker that for every superstep all send messages are also received. Before merging the two messages, there was possibly enough time to deliver all messages, but now this missing check results sometimes in wrong results.
This PR fixes this: In the worker - or more exact in the OutCache - we have a counter for each send message in a gss. When the worker is finished with its gss, it send this count back to the conductor - more exact the ComputingState. In the next gss, the Computing states sends to each worker the number of messages that were send to this worker. Inside the worker, before the worker actually updates its gss, it waits until all send messages are received. (Special for the CombiningOutCache: send count should is not increased when message is just combined, only when it is send to another worker).
Caveat: The worker sends messages to shards, not servers - it does not know which leader shard can be found on which server. Therefore inside the worker we count the number of messages send to each shard, send that to the conductor and here convert this map into a number of messages send to each server. (During initialization of the workers, the conductor knows the assignment of which leader shard is located on which server, we just have to save that in a conductor property to use it later during the computation).
Another annoying thing: The worker is already initialized with gss = 0. Therefore we cannot differentiate between a worker that was just initialized and gets a message from the conductor to change to gss=0 and a worker that has just finished gss=0 and gets a message from the conductor to change to gss=1. This is relevant to receive each message in its dedicated gss. I solved this by adding a new property to the worker _computationStarted that just changes to true after the message from the condctor with gss=0 arrived. When we have the Worker state machine, we should improve that code and get rid of this _computationStarted variable.