### PR TITLE
improve estimate for EnumerateCollectionNode

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,15 +1,15 @@
 devel
 -----
 
+* Improve cardinality estimate for AQL EnumerateCollectionNode in case a
+  `SORT RAND() LIMIT 1` is used. Here, the estimated number of items is at
+  most 1.
+
 * ES-1312: fix handling of reaching the WAL archive capacity limit.
 
 * BTS-941: The HTTP API now delivers the correct list of the collection's
   shards in case a collection from an EnterpriseGraph, SmartGraph, Disjoint
   EnterpriseGraph, Disjoint SmartGraph or SatelliteGraph is being used.
-
-* Improve cardinality estimate for AQL EnumerateCollectionNode in case a
-  `SORT RAND() LIMIT 1` is used. Here, the estimated number of items is at
-  most 1.
 
 * Changed the encoding of revision ids returned by the following REST APIs:
   - GET /_api/collection/<collection-name>/revision: the revision id was

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,10 @@ devel
   shards in case a collection from an EnterpriseGraph, SmartGraph, Disjoint
   EnterpriseGraph, Disjoint SmartGraph or SatelliteGraph is being used.
 
+* Improve cardinality estimate for AQL EnumerateCollectionNode in case a
+  `SORT RAND() LIMIT 1` is used. Here, the estimated number of items is at
+  most 1.
+
 * Changed the encoding of revision ids returned by the following REST APIs:
   - GET /_api/collection/<collection-name>/revision: the revision id was
     previously returned as numeric value, and now it will be returned as

--- a/arangod/Aql/ExecutionNode.cpp
+++ b/arangod/Aql/ExecutionNode.cpp
@@ -1778,9 +1778,13 @@ CostEstimate EnumerateCollectionNode::estimateCost() const {
 
   TRI_ASSERT(!_dependencies.empty());
   CostEstimate estimate = _dependencies.at(0)->getCost();
-  auto const estimatedNrItems =
+  auto estimatedNrItems =
       collection()->count(&trx, transaction::CountType::TryCache);
-  if (!doCount()) {
+  if (_random) {
+    // we retrieve at most one random document from the collection.
+    // so the estimate is at most 1
+    estimatedNrItems = 1;
+  } else if (!doCount()) {
     // if "count" mode is active, the estimated number of items from above
     // must not be multiplied with the number of items in this collection
     estimate.estimatedNrItems *= estimatedNrItems;

--- a/tests/js/server/aql/aql-optimizer-rule-remove-sort-rand-limit.js
+++ b/tests/js/server/aql/aql-optimizer-rule-remove-sort-rand-limit.js
@@ -103,6 +103,7 @@ function optimizerRuleTestSuite () {
         let collectionNode = result.plan.nodes.map(function(node) { return node.type; }).indexOf("EnumerateCollectionNode");
         if (collectionNode !== -1) {
           assertTrue(result.plan.nodes[collectionNode].random); // check for random iteration flag
+          assertTrue(result.plan.nodes[collectionNode].estimatedNrItems <= 1);
         }
       });
     },


### PR DESCRIPTION
### Scope & Purpose

* Improve cardinality estimate for AQL EnumerateCollectionNode in case a `SORT RAND() LIMIT 1` is used. Here, the estimated number of items is at most 1.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.10: https://github.com/arangodb/arangodb/pull/17374
  - [x] Backport for 3.9: https://github.com/arangodb/arangodb/pull/17373
  - [ ] Backport for 3.8: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 