### PR TITLE
log document counts in replication

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 v3.9.4 (XXXX-XX-XX)
 -------------------
 
+* Log the documents counts on leader and follower shards at the end of each
+  successful shard synchronization.
+
 * Fixed BTS-852 (user's saved queries used to disappear after updating user
   profile).
 

--- a/arangod/Cluster/SynchronizeShard.cpp
+++ b/arangod/Cluster/SynchronizeShard.cpp
@@ -123,7 +123,10 @@ SynchronizeShard::SynchronizeShard(MaintenanceFeature& feature,
     : ActionBase(feature, desc),
       ShardDefinition(desc.get(DATABASE), desc.get(SHARD)),
       _followingTermId(0),
-      _tailingUpperBoundTick(0) {
+      _tailingUpperBoundTick(0),
+      _initialDocCountOnLeader(0),
+      _initialDocCountOnFollower(0),
+      _docCountAtEnd(0) {
   std::stringstream error;
 
   if (!desc.has(COLLECTION)) {
@@ -231,7 +234,8 @@ static arangodb::Result addShardFollower(
     network::ConnectionPool* pool, std::string const& endpoint,
     std::string const& database, std::string const& shard, uint64_t lockJobId,
     std::string const& clientId, SyncerId const syncerId,
-    std::string const& clientInfoString, double timeout = 120.0) {
+    std::string const& clientInfoString, double timeout,
+    uint64_t& docCountAtEnd) {
   if (pool == nullptr) {  // nullptr only happens during controlled shutdown
     return arangodb::Result(TRI_ERROR_SHUTTING_DOWN,
                             "startReadLockOnLeader: Shutting down");
@@ -262,6 +266,8 @@ static arangodb::Result addShardFollower(
     if (res.fail()) {
       return res;
     }
+
+    docCountAtEnd = docCount;
 
     VPackBuilder body;
     {
@@ -883,6 +889,8 @@ bool SynchronizeShard::first() {
       return false;
     }
 
+    _initialDocCountOnLeader = docCountOnLeader;
+
     uint64_t docCount = 0;
     if (Result res = collectionCount(*collection, docCount); res.fail()) {
       std::stringstream error;
@@ -893,6 +901,8 @@ bool SynchronizeShard::first() {
       result(res.errorNumber(), error.str());
       return false;
     }
+
+    _initialDocCountOnFollower = docCount;
 
     if (_priority != maintenance::SLOW_OP_PRIORITY &&
         docCount != docCountOnLeader &&
@@ -1377,8 +1387,9 @@ Result SynchronizeShard::catchupWithExclusiveLock(
 
   NetworkFeature& nf = _feature.server().getFeature<NetworkFeature>();
   network::ConnectionPool* pool = nf.pool();
-  res = addShardFollower(pool, ep, getDatabase(), getShard(), lockJobId,
-                         clientId, syncerId, _clientInfoString, 60.0);
+  res =
+      addShardFollower(pool, ep, getDatabase(), getShard(), lockJobId, clientId,
+                       syncerId, _clientInfoString, 60.0, _docCountAtEnd);
 
   TRI_IF_FAILURE("SynchronizeShard::wrongChecksum") {
     res.reset(TRI_ERROR_REPLICATION_WRONG_CHECKSUM);
@@ -1512,7 +1523,11 @@ void SynchronizeShard::setState(ActionState state) {
     if (COMPLETE == state) {
       LOG_TOPIC("50827", INFO, Logger::MAINTENANCE)
           << "SynchronizeShard: synchronization completed for shard "
-          << getDatabase() << "/" << getShard();
+          << getDatabase() << "/" << getShard()
+          << ", initial document count on leader: " << _initialDocCountOnLeader
+          << ", initial document count on follower: "
+          << _initialDocCountOnFollower
+          << ", document count at end: " << _docCountAtEnd;
 
       // because we succeeded now, we can wipe out all past failures
       _feature.removeReplicationError(getDatabase(), getShard());

--- a/arangod/Cluster/SynchronizeShard.h
+++ b/arangod/Cluster/SynchronizeShard.h
@@ -95,6 +95,14 @@ class SynchronizeShard : public ActionBase, public ShardDefinition {
   /// "no restriction"
   uint64_t _tailingUpperBoundTick;
 
+  /// @brief initial number of documents on leader
+  uint64_t _initialDocCountOnLeader;
+  /// @brief initial number of documents on follower
+  uint64_t _initialDocCountOnFollower;
+  /// @brief number of documents on follower at end of (successful)
+  /// synchronization
+  uint64_t _docCountAtEnd;
+
   /// @brief end time (timestamp in seconds)
   std::chrono::time_point<std::chrono::steady_clock> _endTimeForAttempt;
 };


### PR DESCRIPTION
### Scope & Purpose

Log documents counts from leader and follower at the end of each successful shard synchronization.

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: 
  - [x] Backport for 3.9: this PR
  - [ ] Backport for 3.8: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 