### PR TITLE
more efficient access to stream buffer

### DIFF
--- a/lib/Logger/Logger.cpp
+++ b/lib/Logger/Logger.cpp
@@ -677,7 +677,7 @@ void Logger::log(char const* logid, char const* function, char const* file,
       // sure that the dynamic text part is truncated and not the
       // entries JSON thing
       size_t maxMessageLength = defaultLogGroup().maxLogEntryLength();
-      // cut of prologue, the quotes ('"' --- ' '") and the final '}'
+      // cut off prologue, the quotes ('"' --- ' '") and the final '}'
       if (maxMessageLength >= out.size() + 3) {
         maxMessageLength -= out.size() + 3;
       }

--- a/lib/Logger/LoggerStream.cpp
+++ b/lib/Logger/LoggerStream.cpp
@@ -160,9 +160,7 @@ LoggerStream::~LoggerStream() {
 #endif
 
   try {
-    // TODO: with c++20, we can get a view on the stream's underlying buffer,
-    // without copying it
-    Logger::log(_logid, _function, _file, _line, _level, _topicId, _out.str());
+    Logger::log(_logid, _function, _file, _line, _level, _topicId, _out.view());
   } catch (...) {
     try {
       // logging the error may fail as well, and we should never throw in the


### PR DESCRIPTION
### Scope & Purpose

Try to log messages without copying the stream buffer.
Internal change only.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [x] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: -
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 