### PR TITLE
avoid static init order fiasco (#17114)

### DIFF
--- a/lib/ProgramOptions/Parameters.cpp
+++ b/lib/ProgramOptions/Parameters.cpp
@@ -25,19 +25,21 @@
 
 #include <regex>
 
-namespace {
-std::regex const removeComments("#.*$", std::regex::ECMAScript);
-std::regex const removeTabs("^[ \t]+|[ \t]+$", std::regex::ECMAScript);
-}
-
 namespace arangodb {
 namespace options {
 
 std::string removeCommentsFromNumber(std::string const& value) {
+  // note:
+  // this function is already called during static initialization.
+  // the following regex objects are function-local statics, because
+  // we cannot have them statically initialized on the TU level.
+  static std::regex const removeComments("#.*$", std::regex::ECMAScript);
+  static std::regex const removeTabs("^[ \t]+|[ \t]+$", std::regex::ECMAScript);
+
   // replace trailing comments
-  auto noComment = std::regex_replace(value, ::removeComments, "");
+  auto noComment = std::regex_replace(value, removeComments, "");
   // replace leading spaces, replace trailing spaces
-  return std::regex_replace(noComment, ::removeTabs, "");
+  return std::regex_replace(noComment, removeTabs, "");
 }
 
 }


### PR DESCRIPTION
### Scope & Purpose

Avoid a static init order fiasco.
This change has already been made in other versions before.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: *(Please link PR)*
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 