### PR TITLE
log failed queries

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,18 @@ v3.9.4 (XXXX-XX-XX)
 * Fixed BTS-852 (user's saved queries used to disappear after updating user
   profile).
 
+* Added startup option `--query.log-failed` to optionally log all failed AQL
+  queries to the server log. The option is turned off by default.
+
+* Added startup option `--query.log-memory-usage-threshold` to optionally log
+  all AQL queries that have a peak memory usage larger than the configured
+  value. The default value is 4GB.
+
+* Added startup option `--query.max-artefact-log-length` to control the
+  maximum length of logged query strings and bind parameter values.
+  This allows truncating overly long query strings and bind parameter values
+  to a reasonable length. Previously the cutoff length was hard-coded.
+
 * Changed the encoding of revision ids returned by the following REST APIs:
   - GET /_api/collection/<collection-name>/revision: the revision id was
     previously returned as numeric value, and now it will be returned as

--- a/arangod/Aql/Query.cpp
+++ b/arangod/Aql/Query.cpp
@@ -71,7 +71,9 @@
 #include "VocBase/ticks.h"
 #include "VocBase/vocbase.h"
 
+#include <velocypack/Dumper.h>
 #include <velocypack/Iterator.h>
+#include <velocypack/Sink.h>
 
 #include <optional>
 
@@ -104,6 +106,7 @@ Query::Query(QueryId id, std::shared_ptr<transaction::Context> ctx,
       _queryOptions(std::move(options)),
       _trx(nullptr),
       _startTime(currentSteadyClockValue()),
+      _endTime(0.0),
       _resultMemoryUsage(0),
       _queryHash(DontCache),
       _shutdownState(ShutdownState::None),
@@ -114,8 +117,13 @@ Query::Query(QueryId id, std::shared_ptr<transaction::Context> ctx,
       _embeddedQuery(_transactionContext->isV8Context() &&
                      transaction::V8Context::isEmbedded()),
       _registeredInV8Context(false),
-      _queryKilled(false),
-      _queryHashCalculated(false) {
+      _queryHashCalculated(false),
+      _registeredQueryInTrx(false),
+#ifdef ARANGODB_ENABLE_FAILURE_TESTS
+      _wasDebugKilled(false),
+      _wasDestroyed(false),
+#endif
+      _queryKilled(false) {
   if (!_transactionContext) {
     THROW_ARANGO_EXCEPTION_MESSAGE(
         TRI_ERROR_INTERNAL, "failed to create query transaction context");
@@ -279,6 +287,19 @@ void Query::kill() {
 
 /// @brief return the start time of the query (steady clock value)
 double Query::startTime() const noexcept { return _startTime; }
+
+double Query::executionTime() const noexcept {
+  // should only be called once _endTime has been set
+  TRI_ASSERT(_endTime > 0.0);
+  return _endTime - _startTime;
+}
+
+void Query::ensureExecutionTime() noexcept {
+  if (_endTime == 0.0) {
+    _endTime = currentSteadyClockValue();
+    TRI_ASSERT(_endTime > 0.0);
+  }
+}
 
 void Query::prepareQuery(SerializationFormat format) {
   try {
@@ -461,7 +482,7 @@ ExecutionState Query::execute(QueryResult& queryResult) {
           prepareQuery(SerializationFormat::SHADOWROWS);
         }
 
-        log();
+        logAtStart();
         // NOTE: If the options have a shorter lifetime than the builder, it
         // gets invalid (at least set() and close() are broken).
         queryResult.data = std::make_shared<VPackBuilder>(&vpackOptions());
@@ -575,6 +596,8 @@ ExecutionState Query::execute(QueryResult& queryResult) {
           _cacheEntry->_stats = queryResult.extra;
           QueryCache::instance()->store(&_vocbase, std::move(_cacheEntry));
         }
+
+        logAtEnd(queryResult);
         return state;
       }
     }
@@ -606,6 +629,7 @@ ExecutionState Query::execute(QueryResult& queryResult) {
     cleanupPlanAndEngine(TRI_ERROR_INTERNAL, /*sync*/ true);
   }
 
+  logAtEnd(queryResult);
   return ExecutionState::DONE;
 }
 
@@ -676,7 +700,7 @@ QueryResultV8 Query::executeV8(v8::Isolate* isolate) {
     // will throw if it fails
     prepareQuery(SerializationFormat::SHADOWROWS);
 
-    log();
+    logAtStart();
 
     if (useQueryCache && (isModificationQuery() || !_warnings.empty() ||
                           !_ast->root()->isCacheable())) {
@@ -841,10 +865,13 @@ QueryResultV8 Query::executeV8(v8::Isolate* isolate) {
     cleanupPlanAndEngine(TRI_ERROR_INTERNAL, /*sync*/ true);
   }
 
+  logAtEnd(queryResult);
   return queryResult;
 }
 
 ExecutionState Query::finalize(VPackBuilder& extras) {
+  ensureExecutionTime();
+
   if (_queryProfile != nullptr &&
       _shutdownState.load(std::memory_order_relaxed) == ShutdownState::None) {
     // the following call removes the query from the list of currently
@@ -864,7 +891,7 @@ ExecutionState Query::finalize(VPackBuilder& extras) {
   if (!_snippets.empty()) {
     _execStats.requests += _numRequests.load(std::memory_order_relaxed);
     _execStats.setPeakMemoryUsage(_resourceMonitor.peak());
-    _execStats.setExecutionTime(elapsedSince(_startTime));
+    _execStats.setExecutionTime(executionTime());
     for (auto& engine : _snippets) {
       engine->collectExecutionStats(_execStats);
     }
@@ -1176,11 +1203,116 @@ uint64_t Query::hash() {
 }
 
 /// @brief log a query
-void Query::log() {
-  if (!_queryString.empty()) {
-    LOG_TOPIC("8a86a", TRACE, Logger::QUERIES)
-        << "executing query " << _queryId << ": '" << _queryString.extract(1024)
-        << "'";
+void Query::logAtStart() {
+  if (_queryString.empty()) {
+    return;
+  }
+  if (!vocbase().server().hasFeature<QueryRegistryFeature>()) {
+    return;
+  }
+  auto const& feature = vocbase().server().getFeature<QueryRegistryFeature>();
+  size_t maxLength = feature.maxQueryStringLength();
+
+  LOG_TOPIC("8a86a", TRACE, Logger::QUERIES)
+      << "executing query " << _queryId << ": '"
+      << _queryString.extract(maxLength) << "'";
+}
+
+void Query::logAtEnd(QueryResult const& queryResult) const {
+  if (_queryString.empty()) {
+    // nothing to log
+    return;
+  }
+  if (!vocbase().server().hasFeature<QueryRegistryFeature>()) {
+    return;
+  }
+
+  auto const& feature = vocbase().server().getFeature<QueryRegistryFeature>();
+
+  // log failed queries?
+  bool logFailed = feature.logFailedQueries() && queryResult.result.fail();
+  // log queries exceeded memory usage threshold
+  bool logMemoryUsage =
+      resourceMonitor().peak() >= feature.peakMemoryUsageThreshold();
+
+  if (!logFailed && !logMemoryUsage) {
+    return;
+  }
+
+  size_t maxLength = feature.maxQueryStringLength();
+
+  std::string bindParameters;
+  if (feature.trackBindVars()) {
+    // also log bind variables
+    stringifyBindParameters(bindParameters, ", bind vars: ", maxLength);
+  }
+
+  std::string dataSources;
+  if (feature.trackDataSources()) {
+    stringifyDataSources(dataSources, ", data sources: ");
+  }
+
+  if (logFailed) {
+    LOG_TOPIC("d499d", WARN, Logger::QUERIES)
+        << "AQL " << (queryOptions().stream ? "streaming " : "") << "query '"
+        << extractQueryString(maxLength, feature.trackQueryString()) << "'"
+        << bindParameters << dataSources << ", database: " << vocbase().name()
+        << ", user: " << user() << ", id: " << _queryId << ", token: QRY"
+        << _queryId << ", peak memory usage: " << resourceMonitor().peak()
+        << " failed with exit code " << queryResult.result.errorNumber() << ": "
+        << queryResult.result.errorMessage()
+        << ", took: " << Logger::FIXED(executionTime());
+  } else {
+    LOG_TOPIC("e0b7c", WARN, Logger::QUERIES)
+        << "AQL " << (queryOptions().stream ? "streaming " : "") << "query '"
+        << extractQueryString(maxLength, feature.trackQueryString()) << "'"
+        << bindParameters << dataSources << ", database: " << vocbase().name()
+        << ", user: " << user() << ", id: " << _queryId << ", token: QRY"
+        << _queryId << ", peak memory usage: " << resourceMonitor().peak()
+        << " used more memory than configured memory usage alerting threshold "
+        << feature.peakMemoryUsageThreshold()
+        << ", took: " << Logger::FIXED(executionTime());
+  }
+}
+
+std::string Query::extractQueryString(size_t maxLength, bool show) const {
+  if (!show) {
+    return "<hidden>";
+  }
+  return queryString().extract(maxLength);
+}
+
+void Query::stringifyBindParameters(std::string& out, std::string_view prefix,
+                                    size_t maxLength) const {
+  auto bp = bindParameters();
+  if (bp != nullptr && !bp->slice().isNone()) {
+    out.append(prefix);
+    bp->slice().toJson(out);
+    if (out.size() > maxLength) {
+      out.resize(maxLength - 3);
+      out.append("...");
+    }
+  }
+}
+
+void Query::stringifyDataSources(std::string& out,
+                                 std::string_view prefix) const {
+  auto const d = collectionNames();
+  if (!d.empty()) {
+    out.append(prefix);
+    out.push_back('[');
+
+    velocypack::StringSink sink(&out);
+    velocypack::Dumper dumper(&sink);
+    size_t i = 0;
+    for (auto const& dn : d) {
+      if (i > 0) {
+        out.push_back(',');
+      }
+      dumper.appendString(dn.data(), dn.size());
+      ++i;
+    }
+    out.push_back(']');
   }
 }
 
@@ -1258,7 +1390,9 @@ void Query::enterState(QueryExecutionState::ValueType state) {
 
 /// @brief cleanup plan and engine for current query
 ExecutionState Query::cleanupPlanAndEngine(ErrorCode errorCode, bool sync) {
-  if (!_resultCode.has_value()) {
+  ensureExecutionTime();
+
+  if (!_resultCode.has_value()) {  // TODO possible data race here
     // result code not yet set.
     _resultCode = errorCode;
   }

--- a/arangod/Aql/Query.h
+++ b/arangod/Aql/Query.h
@@ -41,7 +41,10 @@
 #include <velocypack/Builder.h>
 #include <velocypack/Slice.h>
 
+#include <atomic>
+#include <memory>
 #include <optional>
+#include <vector>
 
 struct TRI_vocbase_t;
 
@@ -120,6 +123,15 @@ class Query : public QueryContext, public std::enable_shared_from_this<Query> {
 
   /// @brief return the start time of the query (steady clock value)
   double startTime() const noexcept;
+
+  /// @brief return the total execution time of the query (until
+  /// the start of finalize)
+  double executionTime() const noexcept;
+
+  /// @brief make sure that the query execution time is set.
+  /// only the first call to this function will set the time.
+  /// every following call will be ignored.
+  void ensureExecutionTime() noexcept;
 
   void prepareQuery(SerializationFormat format);
 
@@ -215,6 +227,17 @@ class Query : public QueryContext, public std::enable_shared_from_this<Query> {
   // so user actually has a chance to kill it here.
   void debugKillQuery() override;
 
+  /// @brief convert query bind parameters to a string representation
+  void stringifyBindParameters(std::string& out, std::string_view prefix,
+                               size_t maxLength) const;
+
+  /// @brief convert query data sources to a string representation
+  void stringifyDataSources(std::string& out, std::string_view prefix) const;
+
+  /// @brief extract query string up to maxLength bytes. if show is false,
+  /// returns "<hidden>" regardless of maxLength
+  std::string extractQueryString(size_t maxLength, bool show) const;
+
  protected:
   /// @brief initializes the query
   void init(bool createProfile);
@@ -230,9 +253,6 @@ class Query : public QueryContext, public std::enable_shared_from_this<Query> {
   /// to be able to only prepare a query from VelocyPack and then store it in
   /// the QueryRegistry.
   std::unique_ptr<ExecutionPlan> preparePlan();
-
-  /// @brief log a query
-  void log();
 
   /// @brief calculate a hash value for the query string and bind parameters
   uint64_t calculateHash() const;
@@ -258,6 +278,12 @@ class Query : public QueryContext, public std::enable_shared_from_this<Query> {
   // ExecutionNode::K_SHORTEST_PATHS - in case the GraphNode does not contain
   // a vertex collection yet. This can happen e.g. during anonymous traversal.
   void injectVertexCollectionIntoGraphNodes(ExecutionPlan& plan);
+
+  // log the start of a query (trace mode only)
+  void logAtStart();
+
+  // log the end of a query (warnings only)
+  void logAtEnd(QueryResult const& queryResult) const;
 
  protected:
   AqlItemBlockManager _itemBlockManager;
@@ -309,6 +335,10 @@ class Query : public QueryContext, public std::enable_shared_from_this<Query> {
   /// @brief query start time (steady clock value)
   double const _startTime;
 
+  /// @brief query end time (steady clock value), only set once finalize()
+  /// is reached
+  double _endTime;
+
   /// @brief total memory used for building the (partial) result
   size_t _resultMemoryUsage;
 
@@ -328,6 +358,9 @@ class Query : public QueryContext, public std::enable_shared_from_this<Query> {
   /// > 0 = error, one of TRI_ERROR_...)
   std::optional<ErrorCode> _resultCode;
 
+  /// @brief user that started the query
+  std::string _user;
+
   /// @brief whether or not someone else has acquired a V8 context for us
   bool const _contextOwnedByExterior;
 
@@ -338,16 +371,10 @@ class Query : public QueryContext, public std::enable_shared_from_this<Query> {
   /// in a v8 context
   bool _registeredInV8Context;
 
-  /// @brief was this query killed
-  std::atomic<bool> _queryKilled;
-
   /// @brief whether or not the hash was already calculated
   bool _queryHashCalculated;
 
-  /// @brief user that started the query
-  std::string _user;
-
-  bool _registeredQueryInTrx{false};
+  bool _registeredQueryInTrx;
 
 #ifdef ARANGODB_ENABLE_FAILURE_TESTS
   // Intentionally initialized here to not
@@ -355,8 +382,13 @@ class Query : public QueryContext, public std::enable_shared_from_this<Query> {
   // Indicator if a query was already killed
   // via a debug failure. This should not
   // retrigger a kill.
-  bool _wasDebugKilled{false};
+  bool _wasDebugKilled;
+
+  bool _wasDestroyed;
 #endif
+
+  /// @brief was this query killed (can only be set once)
+  std::atomic<bool> _queryKilled;
 };
 
 }  // namespace aql

--- a/arangod/Aql/QueryContext.h
+++ b/arangod/Aql/QueryContext.h
@@ -70,7 +70,9 @@ class QueryContext {
 
   virtual ~QueryContext();
 
-  arangodb::ResourceMonitor& resourceMonitor() noexcept {
+  ResourceMonitor& resourceMonitor() noexcept { return _resourceMonitor; }
+
+  ResourceMonitor const& resourceMonitor() const noexcept {
     return _resourceMonitor;
   }
 
@@ -148,7 +150,7 @@ class QueryContext {
 
  protected:
   /// @brief current resources and limits used by query
-  arangodb::ResourceMonitor _resourceMonitor;
+  ResourceMonitor _resourceMonitor;
 
   TRI_voc_tick_t const _queryId;
 

--- a/arangod/Aql/QueryList.cpp
+++ b/arangod/Aql/QueryList.cpp
@@ -28,6 +28,7 @@
 #include "Aql/Timing.h"
 #include "Basics/Exceptions.h"
 #include "Basics/ReadLocker.h"
+#include "Basics/ResourceUsage.h"
 #include "Basics/Result.h"
 #include "Basics/StringUtils.h"
 #include "Basics/WriteLocker.h"
@@ -111,7 +112,7 @@ QueryList::QueryList(QueryRegistryFeature& feature)
       _slowQueryThreshold(feature.slowQueryThreshold()),
       _slowStreamingQueryThreshold(feature.slowStreamingQueryThreshold()),
       _maxSlowQueries(defaultMaxSlowQueries),
-      _maxQueryStringLength(defaultMaxQueryStringLength) {
+      _maxQueryStringLength(feature.maxQueryStringLength()) {
   _current.reserve(32);
 }
 
@@ -163,7 +164,7 @@ void QueryList::remove(Query& query) {
   }
 
   // elapsed time since query start
-  double const elapsed = elapsedSince(query.startTime());
+  double const elapsed = query.executionTime();
 
   _queryRegistryFeature.trackQueryEnd(elapsed);
 
@@ -194,38 +195,18 @@ void QueryList::remove(Query& query) {
       size_t const maxQueryStringLength =
           _maxQueryStringLength.load(std::memory_order_relaxed);
 
-      std::string q = extractQueryString(query, maxQueryStringLength);
+      std::string q =
+          query.extractQueryString(maxQueryStringLength, trackQueryString());
       std::string bindParameters;
       if (_trackBindVars) {
         // also log bind variables
-        auto bp = query.bindParameters();
-        if (bp != nullptr && !bp->slice().isNone()) {
-          bindParameters.append(", bind vars: ");
-          bp->slice().toJson(bindParameters);
-          if (bindParameters.size() > maxQueryStringLength) {
-            bindParameters.resize(maxQueryStringLength - 3);
-            bindParameters.append("...");
-          }
-        }
+        query.stringifyBindParameters(bindParameters,
+                                      ", bind vars: ", maxQueryStringLength);
       }
 
       std::string dataSources;
       if (_trackDataSources) {
-        auto const d = query.collectionNames();
-        if (!d.empty()) {
-          size_t i = 0;
-          dataSources = ", data sources: [";
-          arangodb::velocypack::StringSink sink(&dataSources);
-          arangodb::velocypack::Dumper dumper(&sink);
-          for (auto const& dn : d) {
-            if (i > 0) {
-              dataSources.push_back(',');
-            }
-            dumper.appendString(dn.data(), dn.size());
-            ++i;
-          }
-          dataSources.push_back(']');
-        }
+        query.stringifyDataSources(dataSources, ", data sources: ");
       }
 
       auto resultCode = query.resultCode();
@@ -235,7 +216,9 @@ void QueryList::remove(Query& query) {
           << "'" << bindParameters << dataSources
           << ", database: " << query.vocbase().name()
           << ", user: " << query.user() << ", id: " << query.id()
-          << ", token: QRY" << query.id() << ", exit code: " << resultCode
+          << ", token: QRY" << query.id()
+          << ", peak memory usage: " << query.resourceMonitor().peak()
+          << ", exit code: " << resultCode
           << ", took: " << Logger::FIXED(elapsed) << " s";
 
       // acquire the query list lock again
@@ -313,13 +296,14 @@ std::vector<QueryEntryCopy> QueryList::listCurrent() {
   // later
   result.reserve(16);
 
-  size_t const maxLength =
-      _maxQueryStringLength.load(std::memory_order_relaxed);
+  auto const maxLength = _maxQueryStringLength.load(std::memory_order_relaxed);
+  auto showQueryString = trackQueryString();
   double const now = TRI_microtime();
 
   {
     READ_LOCKER(readLocker, _lock);
     // reserve the actually needed space
+    //
     result.reserve(_current.size());
 
     for (auto const& it : _current) {
@@ -336,7 +320,7 @@ std::vector<QueryEntryCopy> QueryList::listCurrent() {
       // query inside the Query object.
       result.emplace_back(
           query->id(), query->vocbase().name(), query->user(),
-          extractQueryString(*query, maxLength),
+          query->extractQueryString(maxLength, showQueryString),
           _trackBindVars ? query->bindParameters() : nullptr,
           _trackDataSources ? query->collectionNames()
                             : std::vector<std::string>(),
@@ -383,17 +367,9 @@ size_t QueryList::count() {
   return _current.size();
 }
 
-std::string QueryList::extractQueryString(Query const& query,
-                                          size_t maxLength) const {
-  if (trackQueryString()) {
-    return query.queryString().extract(maxLength);
-  }
-  return "<hidden>";
-}
-
 void QueryList::killQuery(Query& query, size_t maxLength, bool silent) {
   std::string msg = "killing AQL query '" +
-                    extractQueryString(query, maxLength) +
+                    query.extractQueryString(maxLength, trackQueryString()) +
                     "', id: " + std::to_string(query.id()) + ", token: QRY" +
                     std::to_string(query.id());
 

--- a/arangod/Aql/QueryList.h
+++ b/arangod/Aql/QueryList.h
@@ -77,64 +77,63 @@ class QueryList {
   /// @brief destroy a query list
   ~QueryList() = default;
 
- public:
   /// @brief whether or not queries are tracked
   /// we're not using a lock here for performance reasons - thus concurrent
   /// modifications of this variable are possible but are considered unharmful
-  inline bool enabled() const {
+  bool enabled() const noexcept {
     return _enabled.load(std::memory_order_relaxed);
   }
 
   /// @brief toggle query tracking
   /// we're not using a lock here for performance reasons - thus concurrent
   /// modifications of this variable are possible but are considered unharmful
-  inline void enabled(bool value) { _enabled.store(value); }
+  void enabled(bool value) noexcept { _enabled.store(value); }
 
   /// @brief whether or not slow queries are tracked
   /// we're not using a lock here for performance reasons - thus concurrent
   /// modifications of this variable are possible but are considered unharmful
-  inline bool trackSlowQueries() const {
+  bool trackSlowQueries() const noexcept {
     return _trackSlowQueries.load(std::memory_order_relaxed);
   }
 
   /// @brief toggle slow query tracking
   /// we're not using a lock here for performance reasons - thus concurrent
   /// modifications of this variable are possible but are considered unharmful
-  inline void trackSlowQueries(bool value) { _trackSlowQueries.store(value); }
+  void trackSlowQueries(bool value) noexcept { _trackSlowQueries.store(value); }
 
   /// @brief whether to track the full query string
-  inline bool trackQueryString() const {
+  bool trackQueryString() const noexcept {
     return _trackQueryString.load(std::memory_order_relaxed);
   }
 
   /// @brief toggle slow query tracking
   /// we're not using a lock here for performance reasons - thus concurrent
   /// modifications of this variable are possible but are considered unharmful
-  inline void trackQueryString(bool value) { _trackQueryString.store(value); }
+  void trackQueryString(bool value) noexcept { _trackQueryString.store(value); }
 
   /// @brief whether or not bind vars are tracked with queries
   /// we're not using a lock here for performance reasons - thus concurrent
   /// modifications of this variable are possible but are considered unharmful
-  inline bool trackBindVars() const {
+  bool trackBindVars() const noexcept {
     return _trackBindVars.load(std::memory_order_relaxed);
   }
 
   /// @brief toggle query bind vars tracking
   /// we're not using a lock here for performance reasons - thus concurrent
   /// modifications of this variable are possible but are considered unharmful
-  inline void trackBindVars(bool value) { _trackBindVars.store(value); }
+  void trackBindVars(bool value) noexcept { _trackBindVars.store(value); }
 
   /// @brief threshold for slow queries (in seconds)
   /// we're not using a lock here for performance reasons - thus concurrent
   /// modifications of this variable are possible but are considered unharmful
-  inline double slowQueryThreshold() const {
+  double slowQueryThreshold() const noexcept {
     return _slowQueryThreshold.load(std::memory_order_relaxed);
   }
 
   /// @brief set the slow query threshold
   /// we're not using a lock here for performance reasons - thus concurrent
   /// modifications of this variable are possible but are considered unharmful
-  inline void slowQueryThreshold(double value) {
+  void slowQueryThreshold(double value) noexcept {
     if (value < 0.0 || value == HUGE_VAL || value != value) {
       // only let useful values pass
       value = 0.0;
@@ -145,14 +144,14 @@ class QueryList {
   /// @brief threshold for slow streaming queries (in seconds)
   /// we're not using a lock here for performance reasons - thus concurrent
   /// modifications of this variable are possible but are considered unharmful
-  inline double slowStreamingQueryThreshold() const {
+  double slowStreamingQueryThreshold() const noexcept {
     return _slowStreamingQueryThreshold.load(std::memory_order_relaxed);
   }
 
   /// @brief set the slow streaming query threshold
   /// we're not using a lock here for performance reasons - thus concurrent
   /// modifications of this variable are possible but are considered unharmful
-  inline void slowStreamingQueryThreshold(double value) {
+  void slowStreamingQueryThreshold(double value) noexcept {
     if (value < 0.0 || value == HUGE_VAL || value != value) {
       // basic checks
       value = 0.0;
@@ -163,14 +162,14 @@ class QueryList {
   /// @brief return the max number of slow queries to keep
   /// we're not using a lock here for performance reasons - thus concurrent
   /// modifications of this variable are possible but are considered unharmful
-  inline size_t maxSlowQueries() const {
+  size_t maxSlowQueries() const noexcept {
     return _maxSlowQueries.load(std::memory_order_relaxed);
   }
 
   /// @brief set the max number of slow queries to keep
   /// we're not using a lock here for performance reasons - thus concurrent
   /// modifications of this variable are possible but are considered unharmful
-  inline void maxSlowQueries(size_t value) {
+  void maxSlowQueries(size_t value) noexcept {
     if (value > 16384) {
       // basic checks
       value = 16384;
@@ -181,21 +180,16 @@ class QueryList {
   /// @brief return the max length of query strings that are stored / returned
   /// we're not using a lock here for performance reasons - thus concurrent
   /// modifications of this variable are possible but are considered unharmful
-  inline size_t maxQueryStringLength() const {
+  size_t maxQueryStringLength() const noexcept {
     return _maxQueryStringLength.load(std::memory_order_relaxed);
   }
 
   /// @brief set the max length of query strings that are stored / returned
   /// we're not using a lock here for performance reasons - thus concurrent
-  /// modifications of this variable are possible but are considered unharmful
-  inline void maxQueryStringLength(size_t value) {
+  /// modifications of this variable are possible.
+  void maxQueryStringLength(size_t value) noexcept {
     // basic checks
-    if (value < 64) {
-      value = 64;
-    } else if (value >= 8 * 1024 * 1024) {
-      value = 8 * 1024 * 1024;
-    }
-
+    value = std::clamp<size_t>(value, 64, 32 * 1024 * 1024);
     _maxQueryStringLength.store(value);
   }
 
@@ -224,17 +218,11 @@ class QueryList {
   size_t count();
 
  private:
-  std::string extractQueryString(Query const& query, size_t maxLength) const;
-
   void killQuery(Query& query, size_t maxLength, bool silent);
 
   /// @brief default maximum number of slow queries to keep in list
   static constexpr size_t defaultMaxSlowQueries = 64;
 
-  /// @brief default max length of a query when returning it
-  static constexpr size_t defaultMaxQueryStringLength = 4096;
-
- private:
   /// @brief query registry, for keeping track of slow queries counter
   QueryRegistryFeature& _queryRegistryFeature;
 

--- a/arangod/Aql/QueryProfile.h
+++ b/arangod/Aql/QueryProfile.h
@@ -45,7 +45,6 @@ struct QueryProfile {
 
   ~QueryProfile();
 
- public:
   void registerInQueryList();
 
   /// @brief unregister the query from the list of queries, if entered

--- a/arangod/Aql/QueryString.cpp
+++ b/arangod/Aql/QueryString.cpp
@@ -68,7 +68,7 @@ std::string QueryString::extract(size_t maxLength) const {
 
     // start of a multi-byte sequence
     if ((c & 192) == 192) {
-      // decrease length by one more, so we the string contains the
+      // decrease length by one more, so the string contains the
       // last part of the previous (multi-byte?) sequence
       break;
     }

--- a/arangod/Graph/BaseOptions.cpp
+++ b/arangod/Graph/BaseOptions.cpp
@@ -39,7 +39,6 @@
 #include "Cluster/ClusterEdgeCursor.h"
 #include "Containers/HashSet.h"
 #include "Graph/ShortestPathOptions.h"
-#include "Graph/SingleServerEdgeCursor.h"
 #include "Graph/TraverserCache.h"
 #include "Graph/TraverserCacheFactory.h"
 #include "Graph/TraverserOptions.h"

--- a/arangod/Graph/BaseOptions.h
+++ b/arangod/Graph/BaseOptions.h
@@ -53,7 +53,6 @@ class Slice;
 namespace graph {
 
 class EdgeCursor;
-class SingleServerEdgeCursor;
 class TraverserCache;
 
 /**

--- a/arangod/RestServer/QueryRegistryFeature.cpp
+++ b/arangod/RestServer/QueryRegistryFeature.cpp
@@ -179,6 +179,9 @@ QueryRegistryFeature::QueryRegistryFeature(
       _parallelizeTraversals(true),
 #endif
       _allowCollectionsInExpressions(false),
+      _logFailedQueries(false),
+      _maxQueryStringLength(4096),
+      _peakMemoryUsageThreshold(4294967296),  // 4GB
       _queryGlobalMemoryLimit(
           defaultMemoryLimit(PhysicalMemory::getValue(), 0.1, 0.90)),
       _queryMemoryLimit(
@@ -400,6 +403,46 @@ void QueryRegistryFeature::collectOptions(
           arangodb::options::makeDefaultFlags(arangodb::options::Flags::Hidden))
       .setIntroducedIn(30800)
       .setDeprecatedIn(30900);
+
+  options
+      ->addOption("--query.max-artefact-log-length",
+                  "maximum length of query strings and bind parameter values "
+                  "in logs before they get truncated",
+                  new UInt64Parameter(&_maxQueryStringLength),
+                  arangodb::options::makeFlags(
+                      arangodb::options::Flags::DefaultNoComponents,
+                      arangodb::options::Flags::OnAgent,
+                      arangodb::options::Flags::OnCoordinator,
+                      arangodb::options::Flags::OnSingle))
+      .setIntroducedIn(30905)
+      .setIntroducedIn(31002)
+      .setIntroducedIn(31100);
+
+  options
+      ->addOption("--query.log-memory-usage-threshold",
+                  "log queries that have a peak memory usage larger than this "
+                  "threshold",
+                  new UInt64Parameter(&_peakMemoryUsageThreshold),
+                  arangodb::options::makeFlags(
+                      arangodb::options::Flags::DefaultNoComponents,
+                      arangodb::options::Flags::OnAgent,
+                      arangodb::options::Flags::OnCoordinator,
+                      arangodb::options::Flags::OnSingle))
+      .setIntroducedIn(30905)
+      .setIntroducedIn(31002)
+      .setIntroducedIn(31100);
+
+  options
+      ->addOption("--query.log-failed", "log failed AQL queries",
+                  new BooleanParameter(&_logFailedQueries),
+                  arangodb::options::makeFlags(
+                      arangodb::options::Flags::DefaultNoComponents,
+                      arangodb::options::Flags::OnAgent,
+                      arangodb::options::Flags::OnCoordinator,
+                      arangodb::options::Flags::OnSingle))
+      .setIntroducedIn(30905)
+      .setIntroducedIn(31002)
+      .setIntroducedIn(31100);
 }
 
 void QueryRegistryFeature::validateOptions(

--- a/arangod/RestServer/QueryRegistryFeature.h
+++ b/arangod/RestServer/QueryRegistryFeature.h
@@ -56,30 +56,41 @@ class QueryRegistryFeature final
   // tracks a slow query, using execution time
   void trackSlowQuery(double time);
 
-  bool trackingEnabled() const { return _trackingEnabled; }
-  bool trackSlowQueries() const { return _trackSlowQueries; }
-  bool trackQueryString() const { return _trackQueryString; }
-  bool trackBindVars() const { return _trackBindVars; }
-  bool trackDataSources() const { return _trackDataSources; }
-  double slowQueryThreshold() const { return _slowQueryThreshold; }
-  double slowStreamingQueryThreshold() const {
+  bool trackingEnabled() const noexcept { return _trackingEnabled; }
+  bool trackSlowQueries() const noexcept { return _trackSlowQueries; }
+  bool trackQueryString() const noexcept { return _trackQueryString; }
+  bool trackBindVars() const noexcept { return _trackBindVars; }
+  bool trackDataSources() const noexcept { return _trackDataSources; }
+  double slowQueryThreshold() const noexcept { return _slowQueryThreshold; }
+  double slowStreamingQueryThreshold() const noexcept {
     return _slowStreamingQueryThreshold;
   }
-  bool failOnWarning() const { return _failOnWarning; }
-  bool requireWith() const { return _requireWith; }
+  size_t maxQueryStringLength() const noexcept {
+    return static_cast<size_t>(_maxQueryStringLength);
+  }
+  uint64_t peakMemoryUsageThreshold() const noexcept {
+    return _peakMemoryUsageThreshold;
+  }
+  bool failOnWarning() const noexcept { return _failOnWarning; }
+  bool requireWith() const noexcept { return _requireWith; }
 #ifdef USE_ENTERPRISE
-  bool smartJoins() const { return _smartJoins; }
-  bool parallelizeTraversals() const { return _parallelizeTraversals; }
+  bool smartJoins() const noexcept { return _smartJoins; }
+  bool parallelizeTraversals() const noexcept { return _parallelizeTraversals; }
 #endif
-  bool allowCollectionsInExpressions() const {
+  bool allowCollectionsInExpressions() const noexcept {
     return _allowCollectionsInExpressions;
   }
-  uint64_t queryGlobalMemoryLimit() const { return _queryGlobalMemoryLimit; }
-  uint64_t queryMemoryLimit() const { return _queryMemoryLimit; }
-  double queryMaxRuntime() const { return _queryMaxRuntime; }
-  uint64_t maxQueryPlans() const { return _maxQueryPlans; }
-  aql::QueryRegistry* queryRegistry() const { return _queryRegistry.get(); }
-  uint64_t maxParallelism() const { return _maxParallelism; }
+  bool logFailedQueries() const noexcept { return _logFailedQueries; }
+  uint64_t queryGlobalMemoryLimit() const noexcept {
+    return _queryGlobalMemoryLimit;
+  }
+  uint64_t queryMemoryLimit() const noexcept { return _queryMemoryLimit; }
+  double queryMaxRuntime() const noexcept { return _queryMaxRuntime; }
+  uint64_t maxQueryPlans() const noexcept { return _maxQueryPlans; }
+  aql::QueryRegistry* queryRegistry() const noexcept {
+    return _queryRegistry.get();
+  }
+  uint64_t maxParallelism() const noexcept { return _maxParallelism; }
 
  private:
   bool _trackingEnabled;
@@ -96,6 +107,9 @@ class QueryRegistryFeature final
   bool _parallelizeTraversals;
 #endif
   bool _allowCollectionsInExpressions;
+  bool _logFailedQueries;
+  uint64_t _maxQueryStringLength;
+  uint64_t _peakMemoryUsageThreshold;
   uint64_t _queryGlobalMemoryLimit;
   uint64_t _queryMemoryLimit;
   double _queryMaxRuntime;

--- a/tests/js/client/server_parameters/log-queries-failed-and-memory.js
+++ b/tests/js/client/server_parameters/log-queries-failed-and-memory.js
@@ -1,0 +1,145 @@
+/*jshint globalstrict:false, strict:false */
+/* global getOptions, assertTrue, assertFalse, arango, assertEqual */
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief test for server startup options
+///
+/// DISCLAIMER
+///
+/// Copyright 2010-2012 triagens GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB Inc, Cologne, Germany
+///
+/// @author Jan Steemann
+/// @author Copyright 2019, ArangoDB Inc, Cologne, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+const fs = require('fs');
+
+if (getOptions === true) {
+  return {
+    'query.log-failed': 'true',
+    'query.log-memory-usage-threshold': '1048576',
+    'query.max-artefact-log-length': '1024',
+  };
+}
+
+const jsunity = require('jsunity');
+
+function LoggerSuite() {
+  'use strict';
+
+  let getLogLines = function () {
+    const res = arango.POST("/_admin/execute?returnBodyAsJSON=true", `
+require('console').log("testmann: start"); 
+let db = require('internal').db;
+db._query("/*LOG TEST ok query*/ RETURN CONCAT('a', 'b', 'c')");
+try {
+  db._query("/*LOG TEST failed query*/ RETURN PIFF()");
+  throw "failed!";
+} catch (err) {}
+
+db._query("/*LOG TEST low memory usage*/ FOR i IN 1..1024 RETURN i");
+db._query("/*LOG TEST high memory usage*/ FOR i IN 1..1048576 RETURN i");
+
+let values = [];
+for (let i = 0; i < 1024; ++i) {
+  values.push(i);
+}
+db._query("/*LOG TEST large bind1*/ FOR i IN 1..1024 FILTER i IN @values RETURN i", { values });
+
+try {
+  db._query("/*LOG TEST large bind2*/ FOR i IN 1..1024 FILTER i IN @values RETURN PIFF()", { values });
+  throw "failed!";
+} catch (err) {}
+
+require('console').log("testmann: done"); 
+return require('internal').options()["log.output"];
+`);
+
+    assertTrue(Array.isArray(res));
+    assertTrue(res.length > 0);
+
+    let logfile = res[res.length - 1].replace(/^file:\/\//, '');
+
+    // log is buffered, so give it a few tries until the log messages appear
+    let tries = 0;
+    let lines;
+    while (++tries < 60) {
+      let content = fs.readFileSync(logfile, 'ascii');
+
+      lines = content.split('\n');
+
+      let filtered = lines.filter((line) => {
+        return line.match(/testmann: /);
+      });
+
+      if (filtered.length === 2) {
+        break;
+      }
+
+      require("internal").sleep(0.5);
+    }
+    return lines.filter((line) => {
+      return line.match(/LOG TEST/);
+    });
+  };
+
+  let oldLogLevel;
+
+  return {
+    setUpAll : function() {
+      oldLogLevel = arango.GET("/_admin/log/level").general;
+      // must ramp up log levels because otherwise everything is hidden by
+      // default during testing
+      arango.PUT("/_admin/log/level", { general: "info", queries: "warn" });
+    },
+
+    tearDownAll : function () {
+      // restore previous log level for "general" topic;
+      arango.PUT("/_admin/log/level", { general: oldLogLevel });
+    },
+
+    testLoggedQueries: function () {
+      const lines = getLogLines();
+
+      // should not be logged:
+      //   /*LOG TEST ok query*/ RETURN CONCAT('a', 'b', 'c')
+      assertEqual(0, lines.filter((line) => line.match(/LOG TEST ok query/)).length);
+
+      // should be logged:
+      //   /*LOG TEST failed query*/ RETURN PIFF()
+      assertEqual(1, lines.filter((line) => line.match(/LOG TEST failed query/)).length);
+
+      // should not be logged:
+      //   /*LOG TEST low memory usage*/ FOR i IN 1..1024 RETURN i
+      assertEqual(0, lines.filter((line) => line.match(/LOG TEST low memory usage/)).length);
+      
+      // should not be logged:
+      //   /*LOG TEST large bind1*/ FOR i IN 1..1024 FILTER i IN @values RETURN i
+      assertEqual(0, lines.filter((line) => line.match(/LOG TEST large bind1/)).length);
+      
+      // should be logged:
+      //   /*LOG TEST large bind1*/ FOR i IN 1..1024 FILTER i IN @values RETURN PIFF()
+      assertEqual(1, lines.filter((line) => line.match(/LOG TEST large bind2/)).length);
+  
+      // test truncation after 1024 chars:
+      assertEqual(1, lines.filter((line) => line.includes("/*LOG TEST large bind2*/ FOR i IN 1..1024 FILTER i IN @values RETURN PIFF()', bind vars: {\"values\":[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99,100,101,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,121,122,123,124,125,126,127,128,129,130,131,132,133,134,135,136,137,138,139,140,141,142,143,144,145,146,147,148,149,150,151,152,153,154,155,156,157,158,159,160,161,162,163,164,165,166,167,168,169,170,171,172,173,174,175,176,177,178,179,180,181,182,183,184,185,186,187,188,189,190,191,192,193,194,195,196,197,198,199,200,201,202,203,204,205,206,207,208,209,210,211,212,213,214,215,216,217,218,219,220,221,222,223,224,225,226,227,228,229,230,231,232,233,234,235,236,237,238,239,240,241,242,243,244,245,246,247,248,249,250,251,252,253,254,255,256,257,258,259,260,261,262,263,264,265,266,267,268,269,270,271,272,273,274,275,276...")).length);
+    },
+  };
+}
+
+jsunity.run(LoggerSuite);
+return jsunity.done();


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/17300
Docs PR: https://github.com/arangodb/docs/pull/1140

* Added startup option `--query.log-failed` to optionally log **all** failed AQL queries to the server log. The option is turned off by default, by can be turned on for development or debugging.
* Added startup option `--query.log-memory-usage-threshold` to optionally log all AQL queries that have a peak memory usage larger than the configured value.
* Added startup option `--query.max-artefact-log-length` to control the cutoff length for logged query strings and bind parameter values. This allows truncating large query strings and bind parameter values to reasonable lengths. Previously the cutoff value was hard-coded.
* Additionally logs peak memory usage of queries for slow queries and failed queries.

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [x] Backports
  - [x] Backport for 3.10: https://github.com/arangodb/arangodb/pull/17387
  - [x] Backport for 3.9: this PR
  - [ ] Backport for 3.8: -

#### Related Information

- [x] Docs PR: https://github.com/arangodb/docs/pull/1140
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 