### PR TITLE
Separate sending and receiving messages when cleaning up

### DIFF
--- a/arangod/Pregel/Conductor/States/CanceledState.cpp
+++ b/arangod/Pregel/Conductor/States/CanceledState.cpp
@@ -6,6 +6,15 @@
 
 using namespace arangodb::pregel::conductor;
 
+namespace {
+template<class... Ts>
+struct overloaded : Ts... {
+  using Ts::operator()...;
+};
+template<class... Ts>
+overloaded(Ts...) -> overloaded<Ts...>;
+}  // namespace
+
 Canceled::Canceled(Conductor& conductor) : conductor{conductor} {
   expiration = std::chrono::system_clock::now() + conductor._ttl;
   if (not conductor._timing.total.hasFinished()) {
@@ -17,22 +26,56 @@ auto Canceled::run() -> std::optional<std::unique_ptr<State>> {
   LOG_PREGEL_CONDUCTOR_STATE("dd721", WARN)
       << "Execution was canceled, conductor and workers are discarded.";
 
-  return _cleanupUntilTimeout(std::chrono::steady_clock::now())
-      .thenValue([&](auto result) -> std::optional<std::unique_ptr<State>> {
-        if (result.fail()) {
-          LOG_PREGEL_CONDUCTOR_STATE("f8b3c", ERR) << result.errorMessage();
-          return std::nullopt;
-        }
-
-        LOG_PREGEL_CONDUCTOR_STATE("6928f", DEBUG) << "Conductor is erased";
-        conductor._feature.cleanupConductor(conductor._executionNumber);
-        return std::nullopt;
-      })
-      .get();
+  auto cleanup = _cleanupUntilTimeout(std::chrono::steady_clock::now());
+  if (cleanup.fail()) {
+    LOG_PREGEL_CONDUCTOR_STATE("f8b3c", ERR) << cleanup.errorMessage();
+    return std::nullopt;
+  }
+  return std::nullopt;
 }
 
+auto Canceled::receive(MessagePayload message)
+    -> std::optional<std::unique_ptr<State>> {
+  return std::visit(
+      overloaded{
+          [&](ResultT<CleanupFinished> const& x)
+              -> std::optional<std::unique_ptr<State>> {
+            auto explicitMessage = getResultTMessage<CleanupFinished>(message);
+            if (explicitMessage.fail()) {
+              LOG_PREGEL_CONDUCTOR_STATE("7698e", ERR)
+                  << explicitMessage.errorMessage();
+              return std::nullopt;
+            }
+            auto finishedAggregate = _aggregate.doUnderLock(
+                [message = std::move(explicitMessage).get()](auto& agg) {
+                  return agg.aggregate(message);
+                });
+            if (!finishedAggregate.has_value()) {
+              return std::nullopt;
+            }
+
+            LOG_PREGEL_CONDUCTOR_STATE("6928f", DEBUG) << "Conductor is erased";
+            conductor._feature.cleanupConductor(conductor._executionNumber);
+            return std::nullopt;
+          },
+          [&](ResultT<WorkerCreated> const& x)
+              -> std::optional<std::unique_ptr<State>> {
+            // This is a final error state for the Loading state: It is possible
+            // that this state receives WorkerCreated messages and this state
+            // needs to ignore them in the receive fct.
+            return std::nullopt;
+          },
+          [&](auto const& x) -> std::optional<std::unique_ptr<State>> {
+            LOG_PREGEL_CONDUCTOR_STATE("a698e", ERR)
+                << "Received unexpected message type";
+            return std::make_unique<FatalError>(conductor);
+          },
+      },
+      message);
+};
+
 auto Canceled::_cleanupUntilTimeout(std::chrono::steady_clock::time_point start)
-    -> futures::Future<Result> {
+    -> Result {
   if (conductor._feature.isStopping()) {
     LOG_PREGEL_CONDUCTOR_STATE("bd540", DEBUG)
         << "Feature is stopping, workers are already shutting down, no need to "
@@ -41,21 +84,21 @@ auto Canceled::_cleanupUntilTimeout(std::chrono::steady_clock::time_point start)
   }
 
   LOG_PREGEL_CONDUCTOR_STATE("fc187", DEBUG) << "Cleanup workers";
-  return conductor._workers.cleanup(Cleanup{}).thenValue(
-      [&](auto cleanupFinished) {
-        if (cleanupFinished.fail()) {
-          LOG_PREGEL_CONDUCTOR_STATE("1c495", ERR) << fmt::format(
-              "While cleaning up: {}", cleanupFinished.errorMessage());
-          if (std::chrono::steady_clock::now() - start >= _timeout) {
-            return Result{
-                TRI_ERROR_INTERNAL,
-                fmt::format(
-                    "Failed to cancel worker execution for {}, giving up",
-                    _timeout)};
-          }
-          std::this_thread::sleep_for(_retryInterval);
-          return _cleanupUntilTimeout(start).get();
-        }
-        return Result{};
-      });
+  return _aggregate.doUnderLock([&](auto& agg) -> Result {
+    auto aggregate = conductor._workers.cleanup(Cleanup{});
+    if (aggregate.fail()) {
+      LOG_PREGEL_CONDUCTOR_STATE("1c495", ERR)
+          << fmt::format("While cleaning up: {}", aggregate.errorMessage());
+      if (std::chrono::steady_clock::now() - start >= _timeout) {
+        return Result{
+            TRI_ERROR_INTERNAL,
+            fmt::format("Failed to cancel worker execution for {}, giving up",
+                        _timeout)};
+      }
+      std::this_thread::sleep_for(_retryInterval);
+      return _cleanupUntilTimeout(start);
+    }
+    agg = aggregate.get();
+    return Result{};
+  });
 }

--- a/arangod/Pregel/Conductor/States/CanceledState.h
+++ b/arangod/Pregel/Conductor/States/CanceledState.h
@@ -24,6 +24,8 @@
 
 #include <chrono>
 
+#include "Basics/Guarded.h"
+#include "Pregel/Messaging/Aggregate.h"
 #include "State.h"
 
 namespace arangodb::pregel {
@@ -38,13 +40,8 @@ struct Canceled : State {
   Canceled(Conductor& conductor);
   ~Canceled() = default;
   auto run() -> std::optional<std::unique_ptr<State>> override;
-  // This is a final error state for the Loading state: It is possible that this
-  // state receives WorkerCreated messages and this state needs to ignore them
-  // in the receive fct.
   auto receive(MessagePayload message)
-      -> std::optional<std::unique_ptr<State>> override {
-    return std::nullopt;
-  };
+      -> std::optional<std::unique_ptr<State>> override;
   auto canBeCanceled() -> bool override { return false; }
   auto name() const -> std::string override { return "canceled"; };
   auto isRunning() const -> bool override { return false; }
@@ -56,8 +53,9 @@ struct Canceled : State {
  private:
   std::chrono::nanoseconds _retryInterval = std::chrono::seconds(1);
   std::chrono::nanoseconds _timeout = std::chrono::minutes(5);
+  Guarded<Aggregate<CleanupFinished>> _aggregate;
   auto _cleanupUntilTimeout(std::chrono::steady_clock::time_point start)
-      -> futures::Future<Result>;
+      -> Result;
 };
 
 }  // namespace conductor

--- a/arangod/Pregel/Conductor/States/StoringState.cpp
+++ b/arangod/Pregel/Conductor/States/StoringState.cpp
@@ -8,6 +8,15 @@
 
 using namespace arangodb::pregel::conductor;
 
+namespace {
+template<class... Ts>
+struct overloaded : Ts... {
+  using Ts::operator()...;
+};
+template<class... Ts>
+overloaded(Ts...) -> overloaded<Ts...>;
+}  // namespace
+
 Storing::Storing(Conductor& conductor) : conductor{conductor} {
   conductor._timing.storing.start();
   conductor._feature.metrics()->pregelConductorsStoringNumber->fetch_add(1);
@@ -33,36 +42,60 @@ auto Storing::run() -> std::optional<std::unique_ptr<State>> {
 
 auto Storing::receive(MessagePayload message)
     -> std::optional<std::unique_ptr<State>> {
-  auto explicitMessage = getResultTMessage<Stored>(message);
-  if (explicitMessage.fail()) {
-    LOG_PREGEL_CONDUCTOR_STATE("7698e", ERR) << explicitMessage.errorMessage();
-    return std::make_unique<FatalError>(conductor);
-  }
-  auto finishedAggregate =
-      _aggregate.doUnderLock([message = std::move(explicitMessage).get()](
-                                 auto& agg) { return agg.aggregate(message); });
-  if (!finishedAggregate.has_value()) {
-    return std::nullopt;
-  }
+  return std::visit(
+      overloaded{
+          [&](ResultT<Stored> const& x)
+              -> std::optional<std::unique_ptr<State>> {
+            auto explicitMessage = getResultTMessage<Stored>(message);
+            if (explicitMessage.fail()) {
+              LOG_PREGEL_CONDUCTOR_STATE("7698e", ERR)
+                  << explicitMessage.errorMessage();
+              return std::make_unique<FatalError>(conductor);
+            }
+            auto finishedAggregate = _aggregate.doUnderLock(
+                [message = std::move(explicitMessage).get()](auto& agg) {
+                  return agg.aggregate(message);
+                });
+            if (!finishedAggregate.has_value()) {
+              return std::nullopt;
+            }
 
-  LOG_PREGEL_CONDUCTOR_STATE("fc187", DEBUG) << "Cleanup workers";
-  auto cleanup = _cleanup().get();
-  if (cleanup.fail()) {
-    LOG_PREGEL_CONDUCTOR_STATE("4b34d", ERR) << cleanup.errorMessage();
-    return std::make_unique<FatalError>(conductor);
-  }
+            LOG_PREGEL_CONDUCTOR_STATE("fc187", DEBUG) << "Cleanup workers";
+            return _cleanupAggregate.doUnderLock(
+                [&](auto& agg) -> std::optional<std::unique_ptr<State>> {
+                  auto aggregate = conductor._workers.cleanup(Cleanup{});
+                  if (aggregate.fail()) {
+                    LOG_PREGEL_CONDUCTOR_STATE("dddad", ERR)
+                        << aggregate.errorMessage();
+                    return std::make_unique<FatalError>(conductor);
+                  }
+                  agg = aggregate.get();
+                  return std::nullopt;
+                });
+          },
+          [&](ResultT<ResultT<CleanupFinished>> const& x)
+              -> std::optional<std::unique_ptr<State>> {
+            auto explicitMessage = getResultTMessage<CleanupFinished>(message);
+            if (explicitMessage.fail()) {
+              LOG_PREGEL_CONDUCTOR_STATE("dde4a", ERR)
+                  << explicitMessage.errorMessage();
+              return std::make_unique<FatalError>(conductor);
+            }
+            auto finishedAggregate = _cleanupAggregate.doUnderLock(
+                [message = std::move(explicitMessage).get()](auto& agg) {
+                  return agg.aggregate(message);
+                });
+            if (!finishedAggregate.has_value()) {
+              return std::nullopt;
+            }
 
-  return std::make_unique<Done>(conductor);
-}
-
-auto Storing::_cleanup() -> futures::Future<Result> {
-  return conductor._workers.cleanup(Cleanup{}).thenValue(
-      [&](auto cleanupFinished) -> Result {
-        if (cleanupFinished.fail()) {
-          return Result{cleanupFinished.errorNumber(),
-                        fmt::format("While cleaning up: {}",
-                                    cleanupFinished.errorMessage())};
-        }
-        return Result{};
-      });
+            return std::make_unique<Done>(conductor);
+          },
+          [&](auto const& x) -> std::optional<std::unique_ptr<State>> {
+            LOG_PREGEL_CONDUCTOR_STATE("a698e", ERR)
+                << "Received unexpected message type";
+            return std::make_unique<FatalError>(conductor);
+          },
+      },
+      message);
 }

--- a/arangod/Pregel/Conductor/States/StoringState.h
+++ b/arangod/Pregel/Conductor/States/StoringState.h
@@ -50,6 +50,7 @@ struct Storing : State {
  private:
   auto _cleanup() -> futures::Future<Result>;
   Guarded<Aggregate<Stored>> _aggregate;
+  Guarded<Aggregate<CleanupFinished>> _cleanupAggregate;
 };
 }  // namespace conductor
 }  // namespace arangodb::pregel

--- a/arangod/Pregel/Conductor/WorkerApi.cpp
+++ b/arangod/Pregel/Conductor/WorkerApi.cpp
@@ -142,8 +142,8 @@ auto WorkerApi::store(Store const& message) -> ResultT<Aggregate<Stored>> {
 }
 
 auto WorkerApi::cleanup(Cleanup const& message)
-    -> futures::Future<ResultT<CleanupFinished>> {
-  return sendToAll_old<CleanupFinished>(message);
+    -> ResultT<Aggregate<CleanupFinished>> {
+  return collectAllOks<CleanupFinished>(sendToAll(message));
 }
 
 auto WorkerApi::results(CollectPregelResults const& message) const

--- a/arangod/Pregel/Conductor/WorkerApi.h
+++ b/arangod/Pregel/Conductor/WorkerApi.h
@@ -56,7 +56,7 @@ struct WorkerApi {
       -> ResultT<Aggregate<GlobalSuperStepFinished>>;
   [[nodiscard]] auto store(Store const& message) -> ResultT<Aggregate<Stored>>;
   [[nodiscard]] auto cleanup(Cleanup const& message)
-      -> futures::Future<ResultT<CleanupFinished>>;
+      -> ResultT<Aggregate<CleanupFinished>>;
   [[nodiscard]] auto results(CollectPregelResults const& message) const
       -> futures::Future<ResultT<PregelResults>>;
 

--- a/arangod/Pregel/PregelFeature.h
+++ b/arangod/Pregel/PregelFeature.h
@@ -88,8 +88,7 @@ class PregelFeature final : public ArangodFeature {
   std::shared_ptr<IWorker> worker(ExecutionNumber executionNumber);
 
   void cleanupConductor(ExecutionNumber executionNumber);
-  auto cleanupWorker(ExecutionNumber executionNumber)
-      -> futures::Future<futures::Unit>;
+  auto cleanupWorker(ExecutionNumber executionNumber) -> void;
 
   auto process(ModernMessage message, TRI_vocbase_t& vocbase)
       -> ResultT<ModernMessage>;

--- a/arangod/Pregel/Worker/Worker.cpp
+++ b/arangod/Pregel/Worker/Worker.cpp
@@ -537,15 +537,13 @@ void Worker<V, E, M>::cancelGlobalStep(VPackSlice const& data) {
 
 template<typename V, typename E, typename M>
 auto Worker<V, E, M>::cleanup(Cleanup const& command)
-    -> futures::Future<ResultT<CleanupFinished>> {
+    -> ResultT<CleanupFinished> {
   // Only expect serial calls from the conductor.
   // Lock to prevent malicious activity
   MUTEX_LOCKER(guard, _commandMutex);
   LOG_PREGEL("4067a", DEBUG) << "Removing worker";
-  return _feature.cleanupWorker(_config.executionNumber())
-      .thenValue([](auto _) -> ResultT<CleanupFinished> {
-        return {CleanupFinished{}};
-      });
+  _feature.cleanupWorker(_config.executionNumber());
+  return CleanupFinished{};
 }
 
 template<typename V, typename E, typename M>

--- a/arangod/Pregel/Worker/Worker.h
+++ b/arangod/Pregel/Worker/Worker.h
@@ -59,7 +59,7 @@ class IWorker : public std::enable_shared_from_this<IWorker> {
       -> ResultT<GlobalSuperStepFinished> = 0;
   [[nodiscard]] virtual auto store(Store const& message) -> ResultT<Stored> = 0;
   [[nodiscard]] virtual auto cleanup(Cleanup const& message)
-      -> futures::Future<ResultT<CleanupFinished>> = 0;
+      -> ResultT<CleanupFinished> = 0;
   [[nodiscard]] virtual auto results(CollectPregelResults const& message) const
       -> futures::Future<ResultT<PregelResults>> = 0;
   virtual auto send(MessagePayload message) -> void = 0;
@@ -178,8 +178,7 @@ class Worker : public IWorker {
   auto runGlobalSuperStep(RunGlobalSuperStep const& data)
       -> ResultT<GlobalSuperStepFinished> override;
   auto store(Store const& message) -> ResultT<Stored> override;
-  auto cleanup(Cleanup const& message)
-      -> futures::Future<ResultT<CleanupFinished>> override;
+  auto cleanup(Cleanup const& message) -> ResultT<CleanupFinished> override;
   auto results(CollectPregelResults const& message) const
       -> futures::Future<ResultT<PregelResults>> override;
 


### PR DESCRIPTION
This PR continues the refactoring to use the actor model for communication between conductor and workers (see initial PR https://github.com/arangodb/arangodb/pull/17280): This adapts the communication when cleaning up the Workers (in Storing and Canceled state): sending Cleanup from Conductor to Workers and CleanupFinished from Workers to Conductor.
