### PR TITLE
[CINFRA-588] Document State vocbase race

### DIFF
--- a/arangod/Replication2/ReplicatedState/FollowerStateManager.tpp
+++ b/arangod/Replication2/ReplicatedState/FollowerStateManager.tpp
@@ -103,6 +103,10 @@ void FollowerStateManager<S>::run() noexcept {
         LOG_CTX("2feb8", FATAL, self->loggerContext)
             << "Caught unhandled exception in replicated state machine: "
             << ex.message();
+        if (ex.code() == TRI_ERROR_ARANGO_DATABASE_NOT_FOUND) {
+          // TODO this is a temporary fix, see CINFRA-588
+          return;
+        }
         FATAL_ERROR_EXIT();
       } catch (std::exception const& ex) {
         LOG_CTX("8c611", FATAL, self->loggerContext)

--- a/arangod/Replication2/ReplicatedState/LeaderStateManager.tpp
+++ b/arangod/Replication2/ReplicatedState/LeaderStateManager.tpp
@@ -65,6 +65,10 @@ void LeaderStateManager<S>::run() noexcept {
         LOG_CTX("0dcf7", FATAL, self->loggerContext)
             << "Caught unhandled exception in replicated state machine: "
             << ex.message() << " (exception location: " << ex.location() << ")";
+        if (ex.code() == TRI_ERROR_ARANGO_DATABASE_NOT_FOUND) {
+          // TODO this is a temporary fix, see CINFRA-588
+          return;
+        }
         FATAL_ERROR_EXIT();
       } catch (std::exception const& ex) {
         LOG_CTX("506c2", FATAL, self->loggerContext)

--- a/arangod/Replication2/StateMachines/Document/DocumentFollowerState.cpp
+++ b/arangod/Replication2/StateMachines/Document/DocumentFollowerState.cpp
@@ -78,22 +78,32 @@ auto DocumentFollowerState::acquireSnapshot(ParticipantId const& destination,
 
 auto DocumentFollowerState::applyEntries(
     std::unique_ptr<EntryIterator> ptr) noexcept -> futures::Future<Result> {
-  return _guardedData.doUnderLock(
-      [self = shared_from_this(),
-       ptr = std::move(ptr)](auto& data) -> futures::Future<Result> {
-        if (data.didResign()) {
-          return {TRI_ERROR_CLUSTER_NOT_FOLLOWER};
-        }
+  return _guardedData.doUnderLock([self = shared_from_this(),
+                                   ptr = std::move(ptr)](
+                                      auto& data) -> futures::Future<Result> {
+    if (data.didResign()) {
+      return {TRI_ERROR_CLUSTER_NOT_FOLLOWER};
+    }
 
-        while (auto entry = ptr->next()) {
-          auto doc = entry->second;
-          auto res = self->_transactionHandler->applyEntry(doc);
-          if (res.fail()) {
-            return res;
-          }
-        }
-        return {TRI_ERROR_NO_ERROR};
-      });
+    if (self->_transactionHandler == nullptr) {
+      return Result{
+          TRI_ERROR_ARANGO_DATABASE_NOT_FOUND,
+          fmt::format("Transaction handler is missing from "
+                      "DocumentFollowerState during applyEntries "
+                      "{}! This happens if the vocbase cannot be found during "
+                      "DocumentState construction.",
+                      to_string(data.core->getGid()))};
+    }
+
+    while (auto entry = ptr->next()) {
+      auto doc = entry->second;
+      auto res = self->_transactionHandler->applyEntry(doc);
+      if (res.fail()) {
+        return res;
+      }
+    }
+    return {TRI_ERROR_NO_ERROR};
+  });
 }
 
 #include "Replication2/ReplicatedState/ReplicatedState.tpp"


### PR DESCRIPTION
### Scope & Purpose

This serves as a temporary fix. If the vocbase has been already dropped, we return instead of causing the dbserver to stop. The replicated state is about to be destroyed anyway.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification