### PR TITLE
[CINFRA-586] Leader Change Test Fix

### DIFF
--- a/js/common/modules/@arangodb/testutils/replicated-logs-predicates.js
+++ b/js/common/modules/@arangodb/testutils/replicated-logs-predicates.js
@@ -94,7 +94,7 @@ const replicatedLogLeaderEstablished = function (database, logId, term, particip
       }
     }
 
-    if (!current.leader) {
+    if (!current.leader || !current.leader.term === term) {
       return Error("Leader has not yet established its term");
     }
     if (!current.leader.leadershipEstablished) {


### PR DESCRIPTION
### Scope & Purpose

This missing condition affects the `testTransactionLeaderChangeBeforeCommit` test from `shell-transaction-cluster.js`. It is possible that no leader exchange occurred since we bumped the term, thus the test fails.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification