### PR TITLE
Change default output format of arangoexport from `json` to `jsonl`

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 devel
 -----
 
+* Change default output format of arangoexport from `json` to `jsonl`.
+
 * Added startup option `--query.log-failed` to optionally log all failed AQL
   queries to the server log. The option is turned off by default.
 

--- a/client-tools/Export/ExportFeature.cpp
+++ b/client-tools/Export/ExportFeature.cpp
@@ -68,7 +68,7 @@ namespace arangodb {
 ExportFeature::ExportFeature(Server& server, int* result)
     : ArangoExportFeature{server, *this},
       _xgmmlLabelAttribute("label"),
-      _typeExport("json"),
+      _typeExport("jsonl"),
       _customQueryMaxRuntime(0.0),
       _useMaxRuntime(false),
       _escapeCsvFormulae(true),


### PR DESCRIPTION
### Scope & Purpose

Change default output format of arangoexport from `json` to `jsonl`.
This allows more efficient processing (streaming input processing) when reading back such files with arangoimport.
This change won't be backported.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: -
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 