### PR TITLE
[PREGEL]: Add cancel function to state machine

### DIFF
--- a/arangod/Pregel/Conductor/Conductor.cpp
+++ b/arangod/Pregel/Conductor/Conductor.cpp
@@ -231,13 +231,6 @@ void Conductor::workerStatusUpdated(StatusUpdated const& data) {
   _status.updateWorkerStatus(data.senderId, data.status);
 }
 
-void Conductor::cancel() {
-  MUTEX_LOCKER(guard, _callbackMutex);
-  if (_state->canBeCanceled()) {
-    _changeState(std::make_unique<conductor::Canceled>(*this));
-  }
-}
-
 bool Conductor::canBeGarbageCollected() const {
   // we don't want to block other operations for longer, so if we can't
   // immediately acuqire the mutex here, we assume a conductor cannot be
@@ -357,6 +350,13 @@ auto Conductor::_run() -> void {
   auto nextState = _state->run();
   if (nextState.has_value()) {
     _changeState(std::move(nextState.value()));
+  }
+}
+
+void Conductor::cancel() {
+  auto newState = _state->cancel();
+  if (newState.has_value()) {
+    _changeState(std::move(newState.value()));
   }
 }
 

--- a/arangod/Pregel/Conductor/States/CanceledState.h
+++ b/arangod/Pregel/Conductor/States/CanceledState.h
@@ -42,7 +42,9 @@ struct Canceled : State {
   auto run() -> std::optional<std::unique_ptr<State>> override;
   auto receive(MessagePayload message)
       -> std::optional<std::unique_ptr<State>> override;
-  auto canBeCanceled() -> bool override { return false; }
+  auto cancel() -> std::optional<std::unique_ptr<State>> override {
+    return std::nullopt;
+  }
   auto name() const -> std::string override { return "canceled"; };
   auto isRunning() const -> bool override { return false; }
   auto getExpiration() const

--- a/arangod/Pregel/Conductor/States/ComputingState.cpp
+++ b/arangod/Pregel/Conductor/States/ComputingState.cpp
@@ -131,3 +131,7 @@ auto Computing::_transformSendCountFromShardToServer(
   }
   return sendCountPerServer;
 }
+
+auto Computing::cancel() -> std::optional<std::unique_ptr<State>> {
+  return std::make_unique<Canceled>(conductor);
+}

--- a/arangod/Pregel/Conductor/States/ComputingState.h
+++ b/arangod/Pregel/Conductor/States/ComputingState.h
@@ -39,7 +39,7 @@ struct Computing : State {
   auto run() -> std::optional<std::unique_ptr<State>> override;
   auto receive(MessagePayload message)
       -> std::optional<std::unique_ptr<State>> override;
-  auto canBeCanceled() -> bool override { return true; }
+  auto cancel() -> std::optional<std::unique_ptr<State>> override;
   auto name() const -> std::string override { return "running"; };
   auto isRunning() const -> bool override { return true; }
   auto getExpiration() const

--- a/arangod/Pregel/Conductor/States/DoneState.cpp
+++ b/arangod/Pregel/Conductor/States/DoneState.cpp
@@ -43,6 +43,10 @@ auto Done::run() -> std::optional<std::unique_ptr<State>> {
   return std::nullopt;
 }
 
+auto Done::cancel() -> std::optional<std::unique_ptr<State>> {
+  return std::make_unique<Canceled>(conductor);
+}
+
 auto Done::getResults(bool withId) -> ResultT<PregelResults> {
   return conductor._workers.results(CollectPregelResults{.withId = withId})
       .thenValue([&](auto pregelResults) -> ResultT<PregelResults> {

--- a/arangod/Pregel/Conductor/States/DoneState.h
+++ b/arangod/Pregel/Conductor/States/DoneState.h
@@ -36,7 +36,7 @@ struct Done : State {
   Done(Conductor& conductor);
   ~Done() = default;
   auto run() -> std::optional<std::unique_ptr<State>> override;
-  auto canBeCanceled() -> bool override { return true; }
+  auto cancel() -> std::optional<std::unique_ptr<State>> override;
   auto getResults(bool withId) -> ResultT<PregelResults> override;
   auto name() const -> std::string override { return "done"; };
   auto isRunning() const -> bool override { return false; }

--- a/arangod/Pregel/Conductor/States/FatalErrorState.cpp
+++ b/arangod/Pregel/Conductor/States/FatalErrorState.cpp
@@ -12,6 +12,10 @@ FatalError::FatalError(Conductor& conductor) : conductor{conductor} {
   }
 }
 
+auto FatalError::cancel() -> std::optional<std::unique_ptr<State>> {
+  return std::make_unique<Canceled>(conductor);
+}
+
 auto FatalError::getResults(bool withId) -> ResultT<PregelResults> {
   return conductor._workers.results(CollectPregelResults{.withId = withId})
       .thenValue([&](auto pregelResults) -> ResultT<PregelResults> {

--- a/arangod/Pregel/Conductor/States/FatalErrorState.h
+++ b/arangod/Pregel/Conductor/States/FatalErrorState.h
@@ -45,7 +45,7 @@ struct FatalError : State {
       -> std::optional<std::unique_ptr<State>> override {
     return std::nullopt;
   };
-  auto canBeCanceled() -> bool override { return true; }
+  auto cancel() -> std::optional<std::unique_ptr<State>> override;
   auto getResults(bool withId) -> ResultT<PregelResults> override;
   auto name() const -> std::string override { return "fatal error"; };
   auto isRunning() const -> bool override { return false; }

--- a/arangod/Pregel/Conductor/States/InitialState.h
+++ b/arangod/Pregel/Conductor/States/InitialState.h
@@ -39,7 +39,9 @@ struct Initial : State {
   auto run() -> std::optional<std::unique_ptr<State>> override;
   auto receive(MessagePayload message)
       -> std::optional<std::unique_ptr<State>> override;
-  auto canBeCanceled() -> bool override { return false; }
+  auto cancel() -> std::optional<std::unique_ptr<State>> override {
+    return std::nullopt;
+  }
   auto name() const -> std::string override { return "initial"; };
   auto isRunning() const -> bool override { return true; }
   auto getExpiration() const

--- a/arangod/Pregel/Conductor/States/LoadingState.cpp
+++ b/arangod/Pregel/Conductor/States/LoadingState.cpp
@@ -1,10 +1,7 @@
 #include "LoadingState.h"
 
-#include <fmt/format.h>
-#include <memory>
-#include <optional>
-#include "Pregel/Conductor/Conductor.h"
 #include "Metrics/Gauge.h"
+#include "Pregel/Conductor/Conductor.h"
 #include "Pregel/MasterContext.h"
 #include "Pregel/Messaging/Message.h"
 #include "Pregel/Messaging/WorkerMessages.h"
@@ -61,4 +58,8 @@ auto Loading::receive(MessagePayload message)
                                          conductor._aggregators.get());
   }
   return std::make_unique<Computing>(conductor);
+}
+
+auto Loading::cancel() -> std::optional<std::unique_ptr<State>> {
+  return std::make_unique<Canceled>(conductor);
 }

--- a/arangod/Pregel/Conductor/States/LoadingState.h
+++ b/arangod/Pregel/Conductor/States/LoadingState.h
@@ -39,7 +39,7 @@ struct Loading : State {
   auto run() -> std::optional<std::unique_ptr<State>> override;
   auto receive(MessagePayload message)
       -> std::optional<std::unique_ptr<State>> override;
-  auto canBeCanceled() -> bool override { return false; }
+  auto cancel() -> std::optional<std::unique_ptr<State>> override;
   auto name() const -> std::string override { return "loading"; };
   auto isRunning() const -> bool override { return true; }
   auto getExpiration() const

--- a/arangod/Pregel/Conductor/States/State.h
+++ b/arangod/Pregel/Conductor/States/State.h
@@ -49,7 +49,7 @@ struct State {
       -> std::optional<std::unique_ptr<State>> {
     return std::nullopt;
   }
-  virtual auto canBeCanceled() -> bool = 0;
+  virtual auto cancel() -> std::optional<std::unique_ptr<State>> = 0;
   virtual auto getResults(bool withId) -> ResultT<PregelResults> {
     VPackBuilder emptyArray;
     { VPackArrayBuilder ab(&emptyArray); }

--- a/arangod/Pregel/Conductor/States/StoringState.cpp
+++ b/arangod/Pregel/Conductor/States/StoringState.cpp
@@ -99,3 +99,7 @@ auto Storing::receive(MessagePayload message)
       },
       message);
 }
+
+auto Storing::cancel() -> std::optional<std::unique_ptr<State>> {
+  return std::make_unique<Canceled>(conductor);
+}

--- a/arangod/Pregel/Conductor/States/StoringState.h
+++ b/arangod/Pregel/Conductor/States/StoringState.h
@@ -39,7 +39,7 @@ struct Storing : State {
   auto run() -> std::optional<std::unique_ptr<State>> override;
   auto receive(MessagePayload message)
       -> std::optional<std::unique_ptr<State>> override;
-  auto canBeCanceled() -> bool override { return true; }
+  auto cancel() -> std::optional<std::unique_ptr<State>> override;
   auto name() const -> std::string override { return "storing"; };
   auto isRunning() const -> bool override { return true; }
   auto getExpiration() const


### PR DESCRIPTION
This PR is a preparation of the coming PR: It makes the conductor states responsible to change into the Cancel state by adding a function cancel to the state machine.