### PR TITLE
[GWEN] Feature/fast scc

### DIFF
--- a/arangod/Pregel/Conductor/Conductor.cpp
+++ b/arangod/Pregel/Conductor/Conductor.cpp
@@ -148,6 +148,23 @@ Conductor::Conductor(
 
   _feature.metrics()->pregelConductorsNumber->fetch_add(1);
 
+  _state = std::make_unique<conductor::Initial>(*this);
+
+  // initialize worker api
+  if (ServerState::instance()->getRole() == ServerState::ROLE_SINGLE) {
+    _workers = conductor::WorkerApi{
+        _executionNumber,
+        std::make_unique<DirectConnection>(_feature, _vocbaseGuard.database())};
+  } else {
+    network::RequestOptions reqOpts;
+    reqOpts.timeout = network::Timeout(5.0 * 60.0);
+    reqOpts.database = _vocbaseGuard.database().name();
+    _workers = conductor::WorkerApi{
+        _executionNumber,
+        std::make_unique<NetworkConnection>(
+            Utils::apiPrefix, std::move(reqOpts), _vocbaseGuard.database())};
+  }
+
   LOG_PREGEL("00f5f", INFO)
       << "Starting " << _algorithm->name() << " in database '" << vocbase.name()
       << "', ttl: " << _ttl.count() << "s"
@@ -169,19 +186,16 @@ Conductor::~Conductor() {
 
 void Conductor::start() {
   MUTEX_LOCKER(guard, _callbackMutex);
-  _timing.total.start();
-  _changeState(std::make_unique<conductor::Loading>(*this));
+  _run();
 }
 
 auto Conductor ::_postGlobalSuperStep() -> PostGlobalSuperStepResult {
   // workers are done if all messages were processed and no active vertices
   // are left to process
-  bool done = _globalSuperstep > 0 && _statistics.noActiveVertices() &&
-              _statistics.allMessagesProcessed();
+  bool done =
+      _statistics.noActiveVertices() && _statistics.allMessagesProcessed();
   bool proceed = true;
-  if (_masterContext &&
-      _globalSuperstep > 0) {  // ask algorithm to evaluate aggregated values
-    _masterContext->_globalSuperstep = _globalSuperstep - 1;
+  if (_masterContext) {  // ask algorithm to evaluate aggregated values
     proceed = _masterContext->postGlobalSuperstep();
     if (!proceed) {
       LOG_PREGEL("0aa8e", DEBUG) << "Master context ended execution";
@@ -211,7 +225,7 @@ void Conductor::workerStatusUpdated(StatusUpdated const& data) {
 
   VPackBuilder event;
   serialize(event, data);
-  LOG_PREGEL("76632", DEBUG)
+  LOG_PREGEL("76632", TRACE)
       << fmt::format("Update received {}", event.toJson());
 
   _status.updateWorkerStatus(data.senderId, data.status);
@@ -221,124 +235,6 @@ void Conductor::cancel() {
   MUTEX_LOCKER(guard, _callbackMutex);
   if (_state->canBeCanceled()) {
     _changeState(std::make_unique<conductor::Canceled>(*this));
-  }
-}
-
-// resolves into an ordered list of shards for each collection on each
-// server
-static void resolveInfo(
-    TRI_vocbase_t* vocbase, CollectionID const& collectionID,
-    std::unordered_map<CollectionID, std::string>& collectionPlanIdMap,
-    std::map<ServerID, std::map<CollectionID, std::vector<ShardID>>>& serverMap,
-    std::vector<ShardID>& allShards) {
-  ServerState* ss = ServerState::instance();
-  if (!ss->isRunningInCluster()) {  // single server mode
-    auto lc = vocbase->lookupCollection(collectionID);
-
-    if (lc == nullptr || lc->deleted()) {
-      THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND,
-                                     collectionID);
-    }
-
-    collectionPlanIdMap.try_emplace(collectionID,
-                                    std::to_string(lc->planId().id()));
-    allShards.push_back(collectionID);
-    serverMap[ss->getId()][collectionID].push_back(collectionID);
-
-  } else if (ss->isCoordinator()) {  // we are in the cluster
-
-    ClusterInfo& ci =
-        vocbase->server().getFeature<ClusterFeature>().clusterInfo();
-    std::shared_ptr<LogicalCollection> lc =
-        ci.getCollection(vocbase->name(), collectionID);
-    if (lc->deleted()) {
-      THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND,
-                                     collectionID);
-    }
-    collectionPlanIdMap.try_emplace(collectionID,
-                                    std::to_string(lc->planId().id()));
-
-    std::shared_ptr<std::vector<ShardID>> shardIDs =
-        ci.getShardList(std::to_string(lc->id().id()));
-    allShards.insert(allShards.end(), shardIDs->begin(), shardIDs->end());
-
-    for (auto const& shard : *shardIDs) {
-      std::shared_ptr<std::vector<ServerID> const> servers =
-          ci.getResponsibleServer(shard);
-      if (servers->size() > 0) {
-        serverMap[(*servers)[0]][lc->name()].push_back(shard);
-      }
-    }
-  } else {
-    THROW_ARANGO_EXCEPTION(TRI_ERROR_CLUSTER_ONLY_ON_COORDINATOR);
-  }
-}
-
-/// should cause workers to start a new execution
-auto Conductor::_initializeWorkers() -> futures::Future<Result> {
-  _callbackMutex.assertLockedByCurrentThread();
-
-  // int64_t vertexCount = 0, edgeCount = 0;
-  std::unordered_map<CollectionID, std::string> collectionPlanIdMap;
-  std::map<ServerID, std::map<CollectionID, std::vector<ShardID>>> vertexMap,
-      edgeMap;
-  std::vector<ShardID> shardList;
-
-  // resolve plan id's and shards on the servers
-  for (CollectionID const& collectionID : _vertexCollections) {
-    resolveInfo(&(_vocbaseGuard.database()), collectionID, collectionPlanIdMap,
-                vertexMap,
-                shardList);  // store or
-  }
-  for (CollectionID const& collectionID : _edgeCollections) {
-    resolveInfo(&(_vocbaseGuard.database()), collectionID, collectionPlanIdMap,
-                edgeMap,
-                shardList);  // store or
-  }
-
-  auto servers = std::vector<ServerID>{};
-  for (auto const& [server, _] : vertexMap) {
-    servers.push_back(server);
-  }
-  _status = ConductorStatus::forWorkers(servers);
-
-  if (ServerState::instance()->getRole() == ServerState::ROLE_SINGLE) {
-    TRI_ASSERT(servers.size() == 1);
-    _workers = conductor::WorkerApi{
-        _executionNumber,
-        std::make_unique<DirectConnection>(_feature, _vocbaseGuard.database())};
-  } else {
-    network::RequestOptions reqOpts;
-    reqOpts.timeout = network::Timeout(5.0 * 60.0);
-    reqOpts.database = _vocbaseGuard.database().name();
-    _workers = conductor::WorkerApi{
-        _executionNumber,
-        std::make_unique<NetworkConnection>(
-            Utils::apiPrefix, std::move(reqOpts), _vocbaseGuard.database())};
-  }
-
-  auto createWorkers = std::unordered_map<ServerID, CreateWorker>{};
-  for (auto const& [server, vertexShards] : vertexMap) {
-    auto const& edgeShards = edgeMap[server];
-    createWorkers.emplace(
-        server,
-        CreateWorker{.executionNumber = _executionNumber,
-                     .algorithm = _algorithm->name(),
-                     .userParameters = _userParams,
-                     .coordinatorId = ServerState::instance()->getId(),
-                     .useMemoryMaps = _useMemoryMaps,
-                     .edgeCollectionRestrictions = _edgeCollectionRestrictions,
-                     .vertexShards = vertexShards,
-                     .edgeShards = edgeShards,
-                     .collectionPlanIds = collectionPlanIdMap,
-                     .allShards = shardList});
-  }
-  return _workers.createWorkers(createWorkers);
-}
-
-void Conductor::_cleanup() {
-  if (_masterContext) {
-    _masterContext->postApplication();
   }
 }
 
@@ -450,10 +346,21 @@ std::vector<ShardID> Conductor::getShardIds(ShardID const& collection) const {
   return result;
 }
 
-auto Conductor::_changeState(std::unique_ptr<conductor::State> state) -> void {
-  _state = std::move(state);
+auto Conductor::receive(MessagePayload message) -> void {
+  auto newState = _state->receive(message);
+  if (newState.has_value()) {
+    _changeState(std::move(newState.value()));
+  }
+}
+
+auto Conductor::_run() -> void {
   auto nextState = _state->run();
   if (nextState.has_value()) {
     _changeState(std::move(nextState.value()));
   }
+}
+
+auto Conductor::_changeState(std::unique_ptr<conductor::State> state) -> void {
+  _state = std::move(state);
+  _run();
 }

--- a/arangod/Pregel/Conductor/Conductor.h
+++ b/arangod/Pregel/Conductor/Conductor.h
@@ -79,8 +79,7 @@ class Conductor : public std::enable_shared_from_this<Conductor> {
   friend struct conductor::FatalError;
 
   conductor::WorkerApi _workers;
-  std::unique_ptr<conductor::State> _state =
-      std::make_unique<conductor::Initial>(*this);
+  std::unique_ptr<conductor::State> _state;
   PregelFeature& _feature;
   std::chrono::system_clock::time_point _created;
   std::chrono::seconds _ttl = std::chrono::seconds(300);
@@ -135,11 +134,12 @@ class Conductor : public std::enable_shared_from_this<Conductor> {
   // with the Inspecotr framework
   ConductorStatus _status;
 
+  std::unordered_map<ShardID, ServerID> _leadingServerForShard;
+
+  auto _run() -> void;
   auto _changeState(std::unique_ptr<conductor::State> newState) -> void;
-  auto _initializeWorkers() -> futures::Future<Result>;
   auto _preGlobalSuperStep() -> void;
   auto _postGlobalSuperStep() -> PostGlobalSuperStepResult;
-  void _cleanup();
 
   std::vector<ShardID> getShardIds(ShardID const& collection) const;
 
@@ -154,6 +154,7 @@ class Conductor : public std::enable_shared_from_this<Conductor> {
 
   ~Conductor();
 
+  auto receive(MessagePayload message) -> void;
   void start();
   void cancel();
   auto collectAQLResults(bool withId) -> ResultT<PregelResults>;

--- a/arangod/Pregel/Conductor/States/CanceledState.cpp
+++ b/arangod/Pregel/Conductor/States/CanceledState.cpp
@@ -6,6 +6,15 @@
 
 using namespace arangodb::pregel::conductor;
 
+namespace {
+template<class... Ts>
+struct overloaded : Ts... {
+  using Ts::operator()...;
+};
+template<class... Ts>
+overloaded(Ts...) -> overloaded<Ts...>;
+}  // namespace
+
 Canceled::Canceled(Conductor& conductor) : conductor{conductor} {
   expiration = std::chrono::system_clock::now() + conductor._ttl;
   if (not conductor._timing.total.hasFinished()) {
@@ -14,50 +23,82 @@ Canceled::Canceled(Conductor& conductor) : conductor{conductor} {
 }
 
 auto Canceled::run() -> std::optional<std::unique_ptr<State>> {
-  LOG_PREGEL_CONDUCTOR("dd721", WARN)
+  LOG_PREGEL_CONDUCTOR_STATE("dd721", WARN)
       << "Execution was canceled, conductor and workers are discarded.";
 
-  return _cleanupUntilTimeout(std::chrono::steady_clock::now())
-      .thenValue([&](auto result) -> std::optional<std::unique_ptr<State>> {
-        if (result.fail()) {
-          LOG_PREGEL_CONDUCTOR("f8b3c", ERR) << result.errorMessage();
-          return std::nullopt;
-        }
-
-        LOG_PREGEL_CONDUCTOR("6928f", DEBUG) << "Conductor is erased";
-        conductor._feature.cleanupConductor(conductor._executionNumber);
-        return std::nullopt;
-      })
-      .get();
+  auto cleanup = _cleanupUntilTimeout(std::chrono::steady_clock::now());
+  if (cleanup.fail()) {
+    LOG_PREGEL_CONDUCTOR_STATE("f8b3c", ERR) << cleanup.errorMessage();
+    return std::nullopt;
+  }
+  return std::nullopt;
 }
 
-auto Canceled::_cleanupUntilTimeout(std::chrono::steady_clock::time_point start)
-    -> futures::Future<Result> {
-  conductor._cleanup();
+auto Canceled::receive(MessagePayload message)
+    -> std::optional<std::unique_ptr<State>> {
+  return std::visit(
+      overloaded{
+          [&](ResultT<CleanupFinished> const& x)
+              -> std::optional<std::unique_ptr<State>> {
+            auto explicitMessage = getResultTMessage<CleanupFinished>(message);
+            if (explicitMessage.fail()) {
+              LOG_PREGEL_CONDUCTOR_STATE("7698e", ERR)
+                  << explicitMessage.errorMessage();
+              return std::nullopt;
+            }
+            auto finishedAggregate = _aggregate.doUnderLock(
+                [message = std::move(explicitMessage).get()](auto& agg) {
+                  return agg.aggregate(message);
+                });
+            if (!finishedAggregate.has_value()) {
+              return std::nullopt;
+            }
 
+            LOG_PREGEL_CONDUCTOR_STATE("6928f", DEBUG) << "Conductor is erased";
+            conductor._feature.cleanupConductor(conductor._executionNumber);
+            return std::nullopt;
+          },
+          [&](ResultT<WorkerCreated> const& x)
+              -> std::optional<std::unique_ptr<State>> {
+            // This is a final error state for the Loading state: It is possible
+            // that this state receives WorkerCreated messages and this state
+            // needs to ignore them in the receive fct.
+            return std::nullopt;
+          },
+          [&](auto const& x) -> std::optional<std::unique_ptr<State>> {
+            LOG_PREGEL_CONDUCTOR_STATE("a698e", ERR)
+                << "Received unexpected message type";
+            return std::make_unique<FatalError>(conductor);
+          },
+      },
+      message);
+};
+
+auto Canceled::_cleanupUntilTimeout(std::chrono::steady_clock::time_point start)
+    -> Result {
   if (conductor._feature.isStopping()) {
-    LOG_PREGEL_CONDUCTOR("bd540", DEBUG)
+    LOG_PREGEL_CONDUCTOR_STATE("bd540", DEBUG)
         << "Feature is stopping, workers are already shutting down, no need to "
            "clean them up.";
     return Result{};
   }
 
-  LOG_PREGEL_CONDUCTOR("fc187", DEBUG) << "Cleanup workers";
-  return conductor._workers.cleanup(Cleanup{}).thenValue(
-      [&](auto cleanupFinished) {
-        if (cleanupFinished.fail()) {
-          LOG_PREGEL_CONDUCTOR("1c495", ERR) << fmt::format(
-              "While cleaning up: {}", cleanupFinished.errorMessage());
-          if (std::chrono::steady_clock::now() - start >= _timeout) {
-            return Result{
-                TRI_ERROR_INTERNAL,
-                fmt::format(
-                    "Failed to cancel worker execution for {}, giving up",
-                    _timeout)};
-          }
-          std::this_thread::sleep_for(_retryInterval);
-          return _cleanupUntilTimeout(start).get();
-        }
-        return Result{};
-      });
+  LOG_PREGEL_CONDUCTOR_STATE("fc187", DEBUG) << "Cleanup workers";
+  return _aggregate.doUnderLock([&](auto& agg) -> Result {
+    auto aggregate = conductor._workers.cleanup(Cleanup{});
+    if (aggregate.fail()) {
+      LOG_PREGEL_CONDUCTOR_STATE("1c495", ERR)
+          << fmt::format("While cleaning up: {}", aggregate.errorMessage());
+      if (std::chrono::steady_clock::now() - start >= _timeout) {
+        return Result{
+            TRI_ERROR_INTERNAL,
+            fmt::format("Failed to cancel worker execution for {}, giving up",
+                        _timeout)};
+      }
+      std::this_thread::sleep_for(_retryInterval);
+      return _cleanupUntilTimeout(start);
+    }
+    agg = aggregate.get();
+    return Result{};
+  });
 }

--- a/arangod/Pregel/Conductor/States/CanceledState.h
+++ b/arangod/Pregel/Conductor/States/CanceledState.h
@@ -24,6 +24,8 @@
 
 #include <chrono>
 
+#include "Basics/Guarded.h"
+#include "Pregel/Messaging/Aggregate.h"
 #include "State.h"
 
 namespace arangodb::pregel {
@@ -38,6 +40,8 @@ struct Canceled : State {
   Canceled(Conductor& conductor);
   ~Canceled() = default;
   auto run() -> std::optional<std::unique_ptr<State>> override;
+  auto receive(MessagePayload message)
+      -> std::optional<std::unique_ptr<State>> override;
   auto canBeCanceled() -> bool override { return false; }
   auto name() const -> std::string override { return "canceled"; };
   auto isRunning() const -> bool override { return false; }
@@ -49,8 +53,9 @@ struct Canceled : State {
  private:
   std::chrono::nanoseconds _retryInterval = std::chrono::seconds(1);
   std::chrono::nanoseconds _timeout = std::chrono::minutes(5);
+  Guarded<Aggregate<CleanupFinished>> _aggregate;
   auto _cleanupUntilTimeout(std::chrono::steady_clock::time_point start)
-      -> futures::Future<Result>;
+      -> Result;
 };
 
 }  // namespace conductor

--- a/arangod/Pregel/Conductor/States/DoneState.cpp
+++ b/arangod/Pregel/Conductor/States/DoneState.cpp
@@ -22,10 +22,10 @@ auto Done::run() -> std::optional<std::unique_ptr<State>> {
   }
   auto stats = velocypack::serialize(conductor._statistics);
 
-  LOG_PREGEL_CONDUCTOR("063b5", INFO)
-      << "Done. We did " << conductor._globalSuperstep << " rounds."
+  LOG_PREGEL_CONDUCTOR_STATE("063b5", INFO)
+      << fmt::format("Done. We did {} rounds.", conductor._globalSuperstep)
       << (conductor._timing.loading.hasStarted()
-              ? fmt::format("Startup time: {}s",
+              ? fmt::format(" Startup time: {}s",
                             conductor._timing.loading.elapsedSeconds().count())
               : "")
       << (conductor._timing.computation.hasStarted()
@@ -37,10 +37,9 @@ auto Done::run() -> std::optional<std::unique_ptr<State>> {
               ? fmt::format(", storage time: {}s",
                             conductor._timing.storing.elapsedSeconds().count())
               : "")
-      << ", overall: " << conductor._timing.total.elapsedSeconds().count()
-      << "s"
-      << ", stats: " << stats.toJson()
-      << ", aggregators: " << debugOut.toJson();
+      << fmt::format(", overall: {}s, stats: {}, aggregators: {}",
+                     conductor._timing.total.elapsedSeconds().count(),
+                     stats.toJson(), debugOut.toJson());
   return std::nullopt;
 }
 

--- a/arangod/Pregel/Conductor/States/FatalErrorState.h
+++ b/arangod/Pregel/Conductor/States/FatalErrorState.h
@@ -38,6 +38,13 @@ struct FatalError : State {
   auto run() -> std::optional<std::unique_ptr<State>> override {
     return std::nullopt;
   };
+  // This is a final error state: This state can receive any message that was
+  // supposed to be handled by another state and this state needs to ignore them
+  // in the receive fct.
+  auto receive(MessagePayload message)
+      -> std::optional<std::unique_ptr<State>> override {
+    return std::nullopt;
+  };
   auto canBeCanceled() -> bool override { return true; }
   auto getResults(bool withId) -> ResultT<PregelResults> override;
   auto name() const -> std::string override { return "fatal error"; };

--- a/arangod/Pregel/Conductor/States/InitialState.cpp
+++ b/arangod/Pregel/Conductor/States/InitialState.cpp
@@ -1,10 +1,150 @@
 #include "InitialState.h"
+#include "ApplicationFeatures/ApplicationServer.h"
+#include "Cluster/ServerState.h"
+#include "Pregel/Algorithm.h"
 #include "Pregel/Conductor/Conductor.h"
+#include "VocBase/LogicalCollection.h"
 
 using namespace arangodb::pregel::conductor;
 
-Initial::Initial(Conductor& conductor) : conductor{conductor} {}
+Initial::Initial(Conductor& conductor) : conductor{conductor} {
+  conductor._timing.total.start();
+}
 
 auto Initial::run() -> std::optional<std::unique_ptr<State>> {
+  auto const& [workerInitializations, leadingServerForShard] =
+      _workerInitializations();
+
+  conductor._leadingServerForShard = leadingServerForShard;
+  auto servers = std::vector<ServerID>{};
+  for (auto const& [server, _] : workerInitializations) {
+    servers.push_back(server);
+  }
+  conductor._status = ConductorStatus::forWorkers(servers);
+
+  return _aggregate.doUnderLock(
+      [&, workerInitializations = std::move(workerInitializations)](
+          auto& agg) -> std::optional<std::unique_ptr<State>> {
+        auto aggregate =
+            conductor._workers.createWorkers(workerInitializations);
+        if (aggregate.fail()) {
+          LOG_PREGEL_CONDUCTOR_STATE("ae855", ERR)
+              << fmt::format("Initial state: {}", aggregate.errorMessage());
+          return std::make_unique<Canceled>(conductor);
+        }
+        agg = aggregate.get();
+        return std::nullopt;
+      });
+}
+
+auto Initial::receive(MessagePayload message)
+    -> std::optional<std::unique_ptr<State>> {
+  auto explicitMessage = getResultTMessage<WorkerCreated>(message);
+  if (explicitMessage.fail()) {
+    LOG_PREGEL_CONDUCTOR_STATE("7698e", ERR) << explicitMessage.errorMessage();
+    return std::make_unique<Canceled>(conductor);
+  }
+
+  auto finishedAggregate = _aggregate.doUnderLock(
+      [&](auto& agg) { return agg.aggregate(explicitMessage.get()); });
+
+  if (!finishedAggregate) {
+    return std::nullopt;
+  }
+
   return std::make_unique<Loading>(conductor);
+}
+
+namespace {
+using namespace arangodb;
+auto resolveInfo(
+    TRI_vocbase_t* vocbase, CollectionID const& collectionID,
+    std::unordered_map<CollectionID, std::string>& collectionPlanIdMap,
+    std::map<ServerID, std::map<CollectionID, std::vector<ShardID>>>& serverMap,
+    std::vector<ShardID>& allShards) -> void {
+  ServerState* ss = ServerState::instance();
+  if (!ss->isRunningInCluster()) {
+    auto lc = vocbase->lookupCollection(collectionID);
+
+    if (lc == nullptr || lc->deleted()) {
+      THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND,
+                                     collectionID);
+    }
+
+    collectionPlanIdMap.try_emplace(collectionID,
+                                    std::to_string(lc->planId().id()));
+    allShards.push_back(collectionID);
+    serverMap[ss->getId()][collectionID].push_back(collectionID);
+
+  } else if (ss->isCoordinator()) {
+    ClusterInfo& ci =
+        vocbase->server().getFeature<ClusterFeature>().clusterInfo();
+    std::shared_ptr<LogicalCollection> lc =
+        ci.getCollection(vocbase->name(), collectionID);
+    if (lc->deleted()) {
+      THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND,
+                                     collectionID);
+    }
+    collectionPlanIdMap.try_emplace(collectionID,
+                                    std::to_string(lc->planId().id()));
+
+    std::shared_ptr<std::vector<ShardID>> shardIDs =
+        ci.getShardList(std::to_string(lc->id().id()));
+    allShards.insert(allShards.end(), shardIDs->begin(), shardIDs->end());
+
+    for (auto const& shard : *shardIDs) {
+      std::shared_ptr<std::vector<ServerID> const> servers =
+          ci.getResponsibleServer(shard);
+      if (servers->size() > 0) {
+        serverMap[(*servers)[0]][lc->name()].push_back(shard);
+      }
+    }
+  } else {
+    THROW_ARANGO_EXCEPTION(TRI_ERROR_CLUSTER_ONLY_ON_COORDINATOR);
+  }
+}
+}  // namespace
+
+auto Initial::_workerInitializations() const
+    -> std::tuple<std::unordered_map<ServerID, CreateWorker>,
+                  std::unordered_map<ShardID, ServerID>> {
+  std::unordered_map<CollectionID, std::string> collectionPlanIdMap;
+  std::map<ServerID, std::map<CollectionID, std::vector<ShardID>>> vertexMap,
+      edgeMap;
+  std::vector<ShardID> shardList;
+
+  // resolve plan id's and shards on the servers
+  for (CollectionID const& collectionID : conductor._vertexCollections) {
+    resolveInfo(&(conductor._vocbaseGuard.database()), collectionID,
+                collectionPlanIdMap, vertexMap, shardList);
+  }
+  for (CollectionID const& collectionID : conductor._edgeCollections) {
+    resolveInfo(&(conductor._vocbaseGuard.database()), collectionID,
+                collectionPlanIdMap, edgeMap, shardList);
+  }
+
+  auto createWorkers = std::unordered_map<ServerID, CreateWorker>{};
+  auto leadingServerForShard = std::unordered_map<ShardID, ServerID>{};
+  for (auto const& [server, vertexShards] : vertexMap) {
+    auto const& edgeShards = edgeMap[server];
+    createWorkers.emplace(
+        server, CreateWorker{.executionNumber = conductor._executionNumber,
+                             .algorithm = conductor._algorithm->name(),
+                             .userParameters = conductor._userParams,
+                             .coordinatorId = ServerState::instance()->getId(),
+                             .useMemoryMaps = conductor._useMemoryMaps,
+                             .edgeCollectionRestrictions =
+                                 conductor._edgeCollectionRestrictions,
+                             .vertexShards = vertexShards,
+                             .edgeShards = edgeShards,
+                             .collectionPlanIds = collectionPlanIdMap,
+                             .allShards = shardList});
+    for (auto const& [_, shards] : vertexShards) {
+      for (auto const& shard : shards) {
+        leadingServerForShard[shard] = server;
+      }
+    }
+  }
+
+  return make_tuple(createWorkers, leadingServerForShard);
 }

--- a/arangod/Pregel/Conductor/States/InitialState.h
+++ b/arangod/Pregel/Conductor/States/InitialState.h
@@ -22,6 +22,8 @@
 ////////////////////////////////////////////////////////////////////////////////
 #pragma once
 
+#include "Basics/Guarded.h"
+#include "Pregel/Messaging/Aggregate.h"
 #include "State.h"
 
 namespace arangodb::pregel {
@@ -35,6 +37,8 @@ struct Initial : State {
   Initial(Conductor& conductor);
   ~Initial() = default;
   auto run() -> std::optional<std::unique_ptr<State>> override;
+  auto receive(MessagePayload message)
+      -> std::optional<std::unique_ptr<State>> override;
   auto canBeCanceled() -> bool override { return false; }
   auto name() const -> std::string override { return "initial"; };
   auto isRunning() const -> bool override { return true; }
@@ -42,6 +46,12 @@ struct Initial : State {
       -> std::optional<std::chrono::system_clock::time_point> override {
     return std::nullopt;
   }
+
+ private:
+  Guarded<AggregateCount<WorkerCreated>> _aggregate;
+  auto _workerInitializations() const
+      -> std::tuple<std::unordered_map<ServerID, CreateWorker>,
+                    std::unordered_map<ShardID, ServerID>>;
 };
 
 }  // namespace conductor

--- a/arangod/Pregel/Conductor/States/LoadingState.cpp
+++ b/arangod/Pregel/Conductor/States/LoadingState.cpp
@@ -3,7 +3,6 @@
 #include <fmt/format.h>
 #include <memory>
 #include <optional>
-#include "Pregel/Algorithm.h"
 #include "Pregel/Conductor/Conductor.h"
 #include "Metrics/Gauge.h"
 #include "Pregel/MasterContext.h"
@@ -24,63 +23,42 @@ Loading::~Loading() {
 }
 
 auto Loading::run() -> std::optional<std::unique_ptr<State>> {
-  auto create = _createWorkers().get();
-  if (create.fail()) {
-    LOG_PREGEL_CONDUCTOR("ae855", ERR)
-        << fmt::format("Loading state: {}", create.errorMessage());
-    return std::make_unique<Canceled>(conductor);
-  }
-
-  LOG_PREGEL_CONDUCTOR("3a255", DEBUG) << "Telling workers to load the data";
+  LOG_PREGEL_CONDUCTOR_STATE("3a255", DEBUG)
+      << "Telling workers to load the data";
   return _aggregate.doUnderLock(
       [&](auto& agg) -> std::optional<std::unique_ptr<State>> {
-        auto graphLoadedAggregate = conductor._workers.loadGraph(LoadGraph{});
-        if (graphLoadedAggregate.fail()) {
-          LOG_PREGEL_CONDUCTOR("dddad", ERR) << fmt::format(
-              "Loading state: {}", graphLoadedAggregate.errorMessage());
-          return std::make_unique<Canceled>(conductor);
+        auto aggregate = conductor._workers.loadGraph(LoadGraph{});
+        if (aggregate.fail()) {
+          LOG_PREGEL_CONDUCTOR_STATE("dddad", ERR) << aggregate.errorMessage();
+          return std::make_unique<FatalError>(conductor);
         }
-        agg = graphLoadedAggregate.get();
+        agg = aggregate.get();
         return std::nullopt;
       });
-}
-
-auto Loading::_createWorkers() -> futures::Future<Result> {
-  return conductor._initializeWorkers().thenValue([&](auto result) -> Result {
-    if (result.fail()) {
-      return Result{result.errorNumber(), result.errorMessage()};
-    }
-    return Result{};
-  });
 }
 
 auto Loading::receive(MessagePayload message)
     -> std::optional<std::unique_ptr<State>> {
   auto explicitMessage = getResultTMessage<GraphLoaded>(message);
   if (explicitMessage.fail()) {
-    // TODO The state changes to Canceled if this message fails, but there can
-    // still be other GraphLoaded messages that are/will be sent from workers,
-    // what happens to them? Currently: in Canceled state any received messages
-    // are ignored, this is fine but we have to be careful to change this
-    LOG_PREGEL_CONDUCTOR("7698e", ERR)
-        << fmt::format("Loading state: {}", explicitMessage.errorMessage());
-    return std::make_unique<Canceled>(conductor);
+    LOG_PREGEL_CONDUCTOR_STATE("7698e", ERR) << explicitMessage.errorMessage();
+    return std::make_unique<FatalError>(conductor);
   }
-  auto finishedAggregate = _aggregate.doUnderLock(
-      [&](auto& agg) { return agg.aggregate(explicitMessage.get()); });
-  if (finishedAggregate.has_value()) {
-    conductor._totalVerticesCount += finishedAggregate.value().vertexCount;
-    conductor._totalEdgesCount += finishedAggregate.value().edgeCount;
-    LOG_PREGEL_CONDUCTOR("76631", INFO)
-        << "Running Pregel " << conductor._algorithm->name() << " with "
-        << conductor._totalVerticesCount << " vertices, "
-        << conductor._totalEdgesCount << " edges";
-    if (conductor._masterContext) {
-      conductor._masterContext->initialize(conductor._totalVerticesCount,
-                                           conductor._totalEdgesCount,
-                                           conductor._aggregators.get());
-    }
-    return std::make_unique<Computing>(conductor);
+  auto finishedAggregate =
+      _aggregate.doUnderLock([message = std::move(explicitMessage).get()](
+                                 auto& agg) { return agg.aggregate(message); });
+  if (!finishedAggregate.has_value()) {
+    return std::nullopt;
   }
-  return std::nullopt;
+
+  auto graphLoadedData = finishedAggregate.value();
+  conductor._totalVerticesCount += graphLoadedData.vertexCount;
+  conductor._totalEdgesCount += graphLoadedData.edgeCount;
+
+  if (conductor._masterContext) {
+    conductor._masterContext->initialize(conductor._totalVerticesCount,
+                                         conductor._totalEdgesCount,
+                                         conductor._aggregators.get());
+  }
+  return std::make_unique<Computing>(conductor);
 }

--- a/arangod/Pregel/Conductor/States/LoadingState.h
+++ b/arangod/Pregel/Conductor/States/LoadingState.h
@@ -48,7 +48,6 @@ struct Loading : State {
   }
 
  private:
-  auto _createWorkers() -> futures::Future<Result>;
   Guarded<Aggregate<GraphLoaded>> _aggregate;
 };
 

--- a/arangod/Pregel/Conductor/States/State.h
+++ b/arangod/Pregel/Conductor/States/State.h
@@ -38,9 +38,10 @@ struct Message;
 
 namespace conductor {
 
-#define LOG_PREGEL_CONDUCTOR(logId, level) \
-  LOG_TOPIC(logId, level, Logger::PREGEL)  \
-      << "[job " << conductor._executionNumber << "] "
+#define LOG_PREGEL_CONDUCTOR_STATE(logId, level)                           \
+  LOG_TOPIC(logId, level, Logger::PREGEL)                                  \
+      << "[job " << conductor._executionNumber << "] Conductor " << name() \
+      << " state "
 
 struct State {
   virtual auto run() -> std::optional<std::unique_ptr<State>> = 0;

--- a/arangod/Pregel/Conductor/States/StoringState.cpp
+++ b/arangod/Pregel/Conductor/States/StoringState.cpp
@@ -8,6 +8,15 @@
 
 using namespace arangodb::pregel::conductor;
 
+namespace {
+template<class... Ts>
+struct overloaded : Ts... {
+  using Ts::operator()...;
+};
+template<class... Ts>
+overloaded(Ts...) -> overloaded<Ts...>;
+}  // namespace
+
 Storing::Storing(Conductor& conductor) : conductor{conductor} {
   conductor._timing.storing.start();
   conductor._feature.metrics()->pregelConductorsStoringNumber->fetch_add(1);
@@ -19,44 +28,74 @@ Storing::~Storing() {
 }
 
 auto Storing::run() -> std::optional<std::unique_ptr<State>> {
-  conductor._cleanup();
-
-  auto store = _store().get();
-  if (store.fail()) {
-    LOG_PREGEL_CONDUCTOR("bc495", ERR) << store.errorMessage();
-    return std::make_unique<FatalError>(conductor);
-  }
-
-  LOG_PREGEL_CONDUCTOR("fc187", DEBUG) << "Cleanup workers";
-  auto cleanup = _cleanup().get();
-  if (cleanup.fail()) {
-    LOG_PREGEL_CONDUCTOR("4b34d", ERR) << cleanup.errorMessage();
-    return std::make_unique<FatalError>(conductor);
-  }
-
-  return std::make_unique<Done>(conductor);
-}
-
-auto Storing::_store() -> futures::Future<Result> {
-  return conductor._workers.store(Store{}).thenValue(
-      [&](auto stored) -> Result {
-        if (stored.fail()) {
-          return Result{
-              stored.errorNumber(),
-              fmt::format("While storing graph: {}", stored.errorMessage())};
+  return _aggregate.doUnderLock(
+      [&](auto& agg) -> std::optional<std::unique_ptr<State>> {
+        auto aggregate = conductor._workers.store(Store{});
+        if (aggregate.fail()) {
+          LOG_PREGEL_CONDUCTOR_STATE("dddad", ERR) << aggregate.errorMessage();
+          return std::make_unique<FatalError>(conductor);
         }
-        return Result{};
+        agg = aggregate.get();
+        return std::nullopt;
       });
 }
 
-auto Storing::_cleanup() -> futures::Future<Result> {
-  return conductor._workers.cleanup(Cleanup{}).thenValue(
-      [&](auto cleanupFinished) -> Result {
-        if (cleanupFinished.fail()) {
-          return Result{cleanupFinished.errorNumber(),
-                        fmt::format("While cleaning up: {}",
-                                    cleanupFinished.errorMessage())};
-        }
-        return Result{};
-      });
+auto Storing::receive(MessagePayload message)
+    -> std::optional<std::unique_ptr<State>> {
+  return std::visit(
+      overloaded{
+          [&](ResultT<Stored> const& x)
+              -> std::optional<std::unique_ptr<State>> {
+            auto explicitMessage = getResultTMessage<Stored>(message);
+            if (explicitMessage.fail()) {
+              LOG_PREGEL_CONDUCTOR_STATE("7698e", ERR)
+                  << explicitMessage.errorMessage();
+              return std::make_unique<FatalError>(conductor);
+            }
+            auto finishedAggregate = _aggregate.doUnderLock(
+                [message = std::move(explicitMessage).get()](auto& agg) {
+                  return agg.aggregate(message);
+                });
+            if (!finishedAggregate.has_value()) {
+              return std::nullopt;
+            }
+
+            LOG_PREGEL_CONDUCTOR_STATE("fc187", DEBUG) << "Cleanup workers";
+            return _cleanupAggregate.doUnderLock(
+                [&](auto& agg) -> std::optional<std::unique_ptr<State>> {
+                  auto aggregate = conductor._workers.cleanup(Cleanup{});
+                  if (aggregate.fail()) {
+                    LOG_PREGEL_CONDUCTOR_STATE("dddad", ERR)
+                        << aggregate.errorMessage();
+                    return std::make_unique<FatalError>(conductor);
+                  }
+                  agg = aggregate.get();
+                  return std::nullopt;
+                });
+          },
+          [&](ResultT<CleanupFinished> const& x)
+              -> std::optional<std::unique_ptr<State>> {
+            auto explicitMessage = getResultTMessage<CleanupFinished>(message);
+            if (explicitMessage.fail()) {
+              LOG_PREGEL_CONDUCTOR_STATE("dde4a", ERR)
+                  << explicitMessage.errorMessage();
+              return std::make_unique<FatalError>(conductor);
+            }
+            auto finishedAggregate = _cleanupAggregate.doUnderLock(
+                [message = std::move(explicitMessage).get()](auto& agg) {
+                  return agg.aggregate(message);
+                });
+            if (!finishedAggregate.has_value()) {
+              return std::nullopt;
+            }
+
+            return std::make_unique<Done>(conductor);
+          },
+          [&](auto const& x) -> std::optional<std::unique_ptr<State>> {
+            LOG_PREGEL_CONDUCTOR_STATE("a698e", ERR)
+                << "Received unexpected message type";
+            return std::make_unique<FatalError>(conductor);
+          },
+      },
+      message);
 }

--- a/arangod/Pregel/Conductor/States/StoringState.h
+++ b/arangod/Pregel/Conductor/States/StoringState.h
@@ -22,6 +22,8 @@
 ////////////////////////////////////////////////////////////////////////////////
 #pragma once
 
+#include "Basics/Guarded.h"
+#include "Pregel/Messaging/Aggregate.h"
 #include "State.h"
 
 namespace arangodb::pregel {
@@ -35,6 +37,8 @@ struct Storing : State {
   Storing(Conductor& conductor);
   ~Storing();
   auto run() -> std::optional<std::unique_ptr<State>> override;
+  auto receive(MessagePayload message)
+      -> std::optional<std::unique_ptr<State>> override;
   auto canBeCanceled() -> bool override { return true; }
   auto name() const -> std::string override { return "storing"; };
   auto isRunning() const -> bool override { return true; }
@@ -44,8 +48,9 @@ struct Storing : State {
   }
 
  private:
-  auto _store() -> futures::Future<Result>;
   auto _cleanup() -> futures::Future<Result>;
+  Guarded<Aggregate<Stored>> _aggregate;
+  Guarded<Aggregate<CleanupFinished>> _cleanupAggregate;
 };
 }  // namespace conductor
 }  // namespace arangodb::pregel

--- a/arangod/Pregel/Messaging/Aggregate.h
+++ b/arangod/Pregel/Messaging/Aggregate.h
@@ -60,6 +60,7 @@ struct Aggregate {
 
 template<typename T>
 struct AggregateCount {
+  AggregateCount() = default;
   AggregateCount(uint64_t countUntilFinished)
       : _countUntilFinished{countUntilFinished} {}
   auto aggregate(T message) -> bool {

--- a/arangod/Pregel/Messaging/ConductorMessages.h
+++ b/arangod/Pregel/Messaging/ConductorMessages.h
@@ -80,15 +80,16 @@ struct RunGlobalSuperStep {
   uint64_t gss;
   uint64_t vertexCount;
   uint64_t edgeCount;
+  uint64_t sendCount;
   VPackBuilder aggregators;
 };
 
 template<typename Inspector>
 auto inspect(Inspector& f, RunGlobalSuperStep& x) {
-  return f.object(x).fields(f.field(Utils::globalSuperstepKey, x.gss),
-                            f.field("vertexCount", x.vertexCount),
-                            f.field("edgeCount", x.edgeCount),
-                            f.field("aggregators", x.aggregators));
+  return f.object(x).fields(
+      f.field(Utils::globalSuperstepKey, x.gss),
+      f.field("vertexCount", x.vertexCount), f.field("edgeCount", x.edgeCount),
+      f.field("sendCount", x.sendCount), f.field("aggregators", x.aggregators));
 }
 
 struct Store {};

--- a/arangod/Pregel/Messaging/WorkerMessages.h
+++ b/arangod/Pregel/Messaging/WorkerMessages.h
@@ -45,8 +45,8 @@ struct GraphLoaded {
   GraphLoaded(uint64_t vertexCount, uint64_t edgeCount)
       : vertexCount{vertexCount}, edgeCount{edgeCount} {}
   auto add(GraphLoaded const& other) -> void {
-    vertexCount = other.vertexCount;
-    edgeCount = other.edgeCount;
+    vertexCount += other.vertexCount;
+    edgeCount += other.edgeCount;
   }
 };
 
@@ -94,17 +94,51 @@ auto inspect(Inspector& f, GlobalSuperStepPrepared& x) {
 
 struct GlobalSuperStepFinished {
   MessageStats messageStats;
+  std::unordered_map<ShardID, uint64_t> sendCountPerShard;
+  uint64_t activeCount;
+  uint64_t vertexCount;
+  uint64_t edgeCount;
+  VPackBuilder aggregators;
   GlobalSuperStepFinished() noexcept = default;
-  GlobalSuperStepFinished(MessageStats messageStats)
-      : messageStats{std::move(messageStats)} {}
+  GlobalSuperStepFinished(MessageStats messageStats,
+                          std::unordered_map<ServerID, uint64_t> sentCounts,
+                          uint64_t activeCount, uint64_t vertexCount,
+                          uint64_t edgeCount, VPackBuilder aggregators)
+      : messageStats{std::move(messageStats)},
+        sendCountPerShard{std::move(sentCounts)},
+        activeCount{activeCount},
+        vertexCount{vertexCount},
+        edgeCount{edgeCount},
+        aggregators{std::move(aggregators)} {}
   auto add(GlobalSuperStepFinished const& other) -> void {
     messageStats.accumulate(other.messageStats);
+    for (auto& [shard, count] : other.sendCountPerShard) {
+      sendCountPerShard[shard] += count;
+    }
+    activeCount += other.activeCount;
+    vertexCount += other.vertexCount;
+    edgeCount += other.edgeCount;
+    // TODO directly aggregate in here when aggregators have an inspector
+    VPackBuilder newAggregators;
+    {
+      VPackArrayBuilder ab(&newAggregators);
+      if (!aggregators.isEmpty()) {
+        newAggregators.add(VPackArrayIterator(aggregators.slice()));
+      }
+      newAggregators.add(other.aggregators.slice());
+    }
+    aggregators = newAggregators;
   }
 };
 
 template<typename Inspector>
 auto inspect(Inspector& f, GlobalSuperStepFinished& x) {
-  return f.object(x).fields(f.field("messageStats", x.messageStats));
+  return f.object(x).fields(f.field("messageStats", x.messageStats),
+                            f.field("sentCounts", x.sendCountPerShard),
+                            f.field("activeCount", x.activeCount),
+                            f.field("vertexCount", x.vertexCount),
+                            f.field("edgeCount", x.edgeCount),
+                            f.field("aggregators", x.aggregators));
 }
 
 struct Stored {

--- a/arangod/Pregel/PregelFeature.h
+++ b/arangod/Pregel/PregelFeature.h
@@ -88,8 +88,7 @@ class PregelFeature final : public ArangodFeature {
   std::shared_ptr<IWorker> worker(ExecutionNumber executionNumber);
 
   void cleanupConductor(ExecutionNumber executionNumber);
-  auto cleanupWorker(ExecutionNumber executionNumber)
-      -> futures::Future<futures::Unit>;
+  auto cleanupWorker(ExecutionNumber executionNumber) -> void;
 
   auto process(ModernMessage message, TRI_vocbase_t& vocbase)
       -> ResultT<ModernMessage>;

--- a/arangod/Pregel/Worker/ConductorApi.cpp
+++ b/arangod/Pregel/Worker/ConductorApi.cpp
@@ -2,8 +2,7 @@
 
 using namespace arangodb::pregel::worker;
 
-auto ConductorApi::graphLoaded(ResultT<GraphLoaded> const& data) const
-    -> Result {
+auto ConductorApi::send(MessagePayload data) const -> Result {
   return _connection
       ->post(
           Destination{Destination::Type::server, _server},

--- a/arangod/Pregel/Worker/ConductorApi.h
+++ b/arangod/Pregel/Worker/ConductorApi.h
@@ -24,7 +24,7 @@
 
 #include "Pregel/Connection/Connection.h"
 #include "Pregel/ExecutionNumber.h"
-#include "Pregel/Messaging/WorkerMessages.h"
+#include "Pregel/Messaging/Message.h"
 
 namespace arangodb::pregel::worker {
 
@@ -35,7 +35,7 @@ struct ConductorApi {
       : _server{std::move(conductorServer)},
         _executionNumber{std::move(executionNumber)},
         _connection{std::move(connection)} {}
-  auto graphLoaded(ResultT<GraphLoaded> const& data) const -> Result;
+  auto send(MessagePayload data) const -> Result;
 
  private:
   ServerID _server;

--- a/arangod/Pregel/Worker/GraphStore.h
+++ b/arangod/Pregel/Worker/GraphStore.h
@@ -147,7 +147,7 @@ class GraphStore final {
   /// Write results to database
   auto storeResults(WorkerConfig* config,
                     std::function<void()> const& statusUpdateCallback)
-      -> futures::Future<Result>;
+      -> ResultT<Stored>;
 
  private:
   void loadVertices(ShardID const& vertexShard,

--- a/arangod/Pregel/Worker/Worker.cpp
+++ b/arangod/Pregel/Worker/Worker.cpp
@@ -33,6 +33,7 @@
 #include "Pregel/Connection/NetworkConnection.h"
 #include "Pregel/Messaging/Message.h"
 #include "Pregel/IncomingCache.h"
+#include "Pregel/Messaging/WorkerMessages.h"
 #include "Pregel/OutgoingCache.h"
 #include "Pregel/PregelFeature.h"
 #include "Pregel/Status/Status.h"
@@ -53,6 +54,7 @@
 #include "velocypack/Builder.h"
 
 #include "fmt/core.h"
+#include <chrono>
 #include <variant>
 
 using namespace arangodb;
@@ -178,78 +180,30 @@ void Worker<V, E, M>::_initializeMessageCaches() {
 }
 
 template<typename V, typename E, typename M>
-auto Worker<V, E, M>::prepareGlobalSuperStep(
-    PrepareGlobalSuperStep const& message)
-    -> futures::Future<ResultT<GlobalSuperStepPrepared>> {
-  return futures::makeFuture(_prepareGlobalSuperStepFct(message));
-}
-
-template<typename V, typename E, typename M>
-auto Worker<V, E, M>::_prepareGlobalSuperStepFct(
-    PrepareGlobalSuperStep const& message) -> ResultT<GlobalSuperStepPrepared> {
-  if (_state != WorkerState::IDLE) {
-    return Result{TRI_ERROR_INTERNAL,
-                  "Cannot prepare a gss when the worker is not idle"};
-  }
-  VPackBuilder serializedMessage;
-  serialize(serializedMessage, message);
-  _state = WorkerState::PREPARING;  // stop any running step
-  LOG_PREGEL("f16f2", DEBUG)
-      << "Received prepare GSS: " << serializedMessage.toJson();
-  const uint64_t gss = message.gss;
-  if (_expectedGSS != gss) {
-    return Result{
-        TRI_ERROR_BAD_PARAMETER,
-        fmt::format(
-            "Seems like this worker missed a gss, expected %u. Data = %s ",
-            _expectedGSS, serializedMessage.toJson().c_str())};
-  }
-
-  // initialize worker context
-  if (_workerContext && gss == 0 && _config.localSuperstep() == 0) {
-    _workerContext->_readAggregators = _conductorAggregators.get();
-    _workerContext->_writeAggregators = _workerAggregators.get();
-    _workerContext->_vertexCount = message.vertexCount;
-    _workerContext->_edgeCount = message.edgeCount;
-    _workerContext->preApplication();
-  }
-
-  // make us ready to receive messages
-  _config._globalSuperstep = gss;
-  // write cache becomes the readable cache
-  MY_WRITE_LOCKER(wguard, _cacheRWLock);
-  TRI_ASSERT(_readCache->containedMessageCount() == 0);
-  std::swap(_readCache, _writeCache);
-  _config._localSuperstep = gss;
-
-  // only place where is makes sense to call this, since startGlobalSuperstep
-  // might not be called again
-  if (_workerContext && gss > 0) {
-    _workerContext->postGlobalSuperstep(gss - 1);
-  }
-
-  // responds with info which allows the conductor to decide whether
-  // to start the next GSS or end the execution
-  VPackBuilder aggregators;
-  {
-    VPackObjectBuilder ob(&aggregators);
-    _workerAggregators->serializeValues(aggregators);
-  }
-  return GlobalSuperStepPrepared{_activeCount, _graphStore->localVertexCount(),
-                                 _graphStore->localEdgeCount(), aggregators};
-}
-
-template<typename V, typename E, typename M>
 void Worker<V, E, M>::receivedMessages(PregelMessage const& message) {
-  if (message.gss != _config._globalSuperstep) {
+  if (message.gss != _config._globalSuperstep &&
+      message.gss != _config._globalSuperstep + 1) {
     LOG_PREGEL("ecd34", ERR)
         << "Expected: " << _config._globalSuperstep << " Got: " << message.gss;
     THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_BAD_PARAMETER,
                                    "Superstep out of sync");
   }
-  // make sure the pointer is not changed while parsing messages
+
+  // make sure the cache and gss are not changed while parsing messages
   MY_READ_LOCKER(guard, _cacheRWLock);
-  // handles locking for us
+
+  // queue message if read and write cache are not swapped yet, otherwise you
+  // will loose this message
+  if (message.gss == _config._globalSuperstep + 1 ||
+      // if config.gss == 0 and _computationStarted == false: read and write
+      // cache are not swapped yet, config.gss is currently 0 only due to its
+      // initialization
+      (_config._globalSuperstep == 0 && !_computationStarted)) {
+    _messagesForNextGss.doUnderLock(
+        [&](auto& messages) { messages.push_back(message); });
+    return;
+  }
+
   _writeCache->parseMessages(message);
 }
 
@@ -257,12 +211,52 @@ template<typename V, typename E, typename M>
 auto Worker<V, E, M>::_preGlobalSuperStep(RunGlobalSuperStep const& message)
     -> Result {
   const uint64_t gss = message.gss;
-  if (gss != _config.globalSuperstep()) {
-    return Result{TRI_ERROR_BAD_PARAMETER, "Wrong GSS"};
+
+  // wait until worker received all messages that were sent to it
+  auto timeout = std::chrono::minutes(5);
+  auto start = std::chrono::steady_clock::now();
+  while (message.sendCount != _writeCache->containedMessageCount()) {
+    if (std::chrono::steady_clock::now() - start >= timeout) {
+      return Result{
+          TRI_ERROR_INTERNAL,
+          fmt::format("gss {}: Worker did not receive all the messages that "
+                      "were send to it. Received count {} != send count {}.",
+                      _config._globalSuperstep,
+                      _writeCache->containedMessageCount(), message.sendCount)};
+    }
   }
+
+  // write cache becomes the readable cache
+  {
+    MY_WRITE_LOCKER(wguard, _cacheRWLock);
+    TRI_ASSERT(_readCache->containedMessageCount() == 0);
+    std::swap(_readCache, _writeCache);
+    _config._globalSuperstep = gss;
+    _config._localSuperstep = gss;
+    if (gss == 0) {
+      // now config.gss is set explicitely to 0 and the computation started
+      _computationStarted = true;
+    }
+  }
+
+  // process all queued messages
+  _messagesForNextGss.doUnderLock([&](auto& messages) {
+    for (auto const& message : messages) {
+      receivedMessages(message);
+    }
+    messages.clear();
+  });
+
+  if (gss == 0 && _workerContext) {
+    _workerContext->_readAggregators = _conductorAggregators.get();
+    _workerContext->_writeAggregators = _workerAggregators.get();
+    _workerContext->_vertexCount = message.vertexCount;
+    _workerContext->_edgeCount = message.edgeCount;
+    _workerContext->preApplication();
+  }
+
   _workerAggregators->resetValues();
   _conductorAggregators->setAggregatedValues(message.aggregators.slice());
-  // execute context
   if (_workerContext) {
     _workerContext->_vertexCount = message.vertexCount;
     _workerContext->_edgeCount = message.edgeCount;
@@ -273,11 +267,12 @@ auto Worker<V, E, M>::_preGlobalSuperStep(RunGlobalSuperStep const& message)
 
 template<typename V, typename E, typename M>
 auto Worker<V, E, M>::runGlobalSuperStep(RunGlobalSuperStep const& message)
-    -> futures::Future<ResultT<GlobalSuperStepFinished>> {
+    -> ResultT<GlobalSuperStepFinished> {
   MUTEX_LOCKER(guard, _commandMutex);
-  if (_state != WorkerState::PREPARING) {
+
+  if (_state != WorkerState::IDLE) {
     return Result{TRI_ERROR_INTERNAL,
-                  "Cannot start a gss when the worker is not prepared"};
+                  "Cannot start a gss when the worker is not idle"};
   }
   VPackBuilder serializedMessage;
   serialize(serializedMessage, message);
@@ -289,12 +284,13 @@ auto Worker<V, E, M>::runGlobalSuperStep(RunGlobalSuperStep const& message)
   }
   LOG_PREGEL("39e20", DEBUG) << "Worker starts new gss: " << message.gss;
 
-  return _processVerticesInThreads().thenValue(
-      [&](auto results) -> ResultT<GlobalSuperStepFinished> {
+  return _processVerticesInThreads()
+      .thenValue([&](auto results) -> ResultT<GlobalSuperStepFinished> {
         if (_state != WorkerState::COMPUTING) {
           return Result{TRI_ERROR_INTERNAL,
                         "Worker execution aborted prematurely."};
         }
+        std::unordered_map<ShardID, uint64_t> sendCountPerShard;
         for (auto& result : results) {
           if (result.get().fail()) {
             return Result{result.get().errorNumber(),
@@ -307,10 +303,15 @@ auto Worker<V, E, M>::runGlobalSuperStep(RunGlobalSuperStep const& message)
           _workerAggregators->aggregateValues(
               verticesProcessed.aggregator.slice());
           _messageStats.accumulate(verticesProcessed.stats);
+          for (auto const& [shard, count] :
+               verticesProcessed.sendCountPerShard) {
+            sendCountPerShard[shard] += count;
+          }
           _activeCount += verticesProcessed.activeCount;
         }
-        return _finishProcessing();
-      });
+        return _finishProcessing(sendCountPerShard);
+      })
+      .get();
 }
 
 /// WARNING only call this while holding the _commandMutex
@@ -376,6 +377,7 @@ auto Worker<V, E, M>::_processVertices(
   outCache->setBatchSize(_messageBatchSize);
   outCache->setLocalCache(inCache);
   TRI_ASSERT(outCache->sendCount() == 0);
+  TRI_ASSERT(outCache->sendCountPerShard().empty());
 
   AggregatorHandler workerAggregator(_algorithm.get());
   // TODO look if we can avoid instantiating this
@@ -431,21 +433,26 @@ auto Worker<V, E, M>::_processVertices(
   _currentGssObservables.memoryBytesUsedForMessages +=
       outCache->sendCount() * sizeof(M);
   stats.superstepRuntimeSecs = TRI_microtime() - start;
-  inCache->clear();
-  outCache->clear();
 
   VPackBuilder aggregatorVPack;
   {
     VPackObjectBuilder ob(&aggregatorVPack);
     workerAggregator.serializeValues(aggregatorVPack);
   }
-  return VerticesProcessed{std::move(aggregatorVPack), std::move(stats),
-                           activeCount};
+  auto out = VerticesProcessed{std::move(aggregatorVPack), std::move(stats),
+                               outCache->sendCountPerShard(), activeCount};
+
+  inCache->clear();
+  outCache->clear();
+
+  return out;
 }
 
 // called at the end of a worker thread, needs mutex
 template<typename V, typename E, typename M>
-auto Worker<V, E, M>::_finishProcessing() -> ResultT<GlobalSuperStepFinished> {
+auto Worker<V, E, M>::_finishProcessing(
+    std::unordered_map<ShardID, uint64_t> sendCountPerShard)
+    -> ResultT<GlobalSuperStepFinished> {
   {
     MUTEX_LOCKER(guard, _threadMutex);
     if (_runningThreads != 0) {
@@ -460,6 +467,10 @@ auto Worker<V, E, M>::_finishProcessing() -> ResultT<GlobalSuperStepFinished> {
                   "Worker in wrong state"};  // probably canceled
   }
 
+  if (_workerContext) {
+    _workerContext->postGlobalSuperstep(_config._globalSuperstep);
+  }
+
   // count all received messages
   _messageStats.receivedCount = _readCache->containedMessageCount();
   _feature.metrics()->pregelMessagesReceived->count(
@@ -472,13 +483,22 @@ auto Worker<V, E, M>::_finishProcessing() -> ResultT<GlobalSuperStepFinished> {
   _makeStatusCallback()();
 
   _readCache->clear();  // no need to keep old messages around
-  _expectedGSS = _config._globalSuperstep + 1;
   _config._localSuperstep++;
   // only set the state here, because _processVertices checks for it
   _state = WorkerState::IDLE;
 
+  VPackBuilder aggregators;
+  {
+    VPackObjectBuilder ob(&aggregators);
+    _workerAggregators->serializeValues(aggregators);
+  }
   GlobalSuperStepFinished gssFinishedEvent =
-      GlobalSuperStepFinished{_messageStats};
+      GlobalSuperStepFinished{_messageStats,
+                              sendCountPerShard,
+                              _activeCount,
+                              _graphStore->localVertexCount(),
+                              _graphStore->localEdgeCount(),
+                              aggregators};
   VPackBuilder event;
   serialize(event, gssFinishedEvent);
   LOG_PREGEL("2de5b", DEBUG) << "Finished GSS: " << event.toJson();
@@ -493,22 +513,19 @@ auto Worker<V, E, M>::_finishProcessing() -> ResultT<GlobalSuperStepFinished> {
 }
 
 template<typename V, typename E, typename M>
-auto Worker<V, E, M>::store(Store const& message)
-    -> futures::Future<ResultT<Stored>> {
+auto Worker<V, E, M>::store(Store const& message) -> ResultT<Stored> {
   _feature.metrics()->pregelWorkersStoringNumber->fetch_add(1);
   LOG_PREGEL("91264", DEBUG) << "Storing results";
-  // tell graphstore to remove read locks
-  return _graphStore->storeResults(&_config, _makeStatusCallback())
-      .thenValue([&](auto result) -> ResultT<Stored> {
-        _feature.metrics()->pregelWorkersStoringNumber->fetch_sub(1);
-        if (result.fail()) {
-          return result;
-        }
 
-        _state = WorkerState::DONE;
+  auto stored = _graphStore->storeResults(&_config, _makeStatusCallback());
 
-        return Stored{};
-      });
+  _feature.metrics()->pregelWorkersStoringNumber->fetch_sub(1);
+  if (stored.fail()) {
+    return stored;
+  }
+  _state = WorkerState::DONE;
+
+  return stored;
 }
 
 template<typename V, typename E, typename M>
@@ -520,15 +537,13 @@ void Worker<V, E, M>::cancelGlobalStep(VPackSlice const& data) {
 
 template<typename V, typename E, typename M>
 auto Worker<V, E, M>::cleanup(Cleanup const& command)
-    -> futures::Future<ResultT<CleanupFinished>> {
+    -> ResultT<CleanupFinished> {
   // Only expect serial calls from the conductor.
   // Lock to prevent malicious activity
   MUTEX_LOCKER(guard, _commandMutex);
   LOG_PREGEL("4067a", DEBUG) << "Removing worker";
-  return _feature.cleanupWorker(_config.executionNumber())
-      .thenValue([](auto _) -> ResultT<CleanupFinished> {
-        return {CleanupFinished{}};
-      });
+  _feature.cleanupWorker(_config.executionNumber());
+  return CleanupFinished{};
 }
 
 template<typename V, typename E, typename M>
@@ -627,18 +642,30 @@ auto Worker<V, E, M>::_observeStatus() -> Status const {
 }
 
 template<typename V, typename E, typename M>
-auto Worker<V, E, M>::loadGraph(LoadGraph const& graph) -> void {
+auto Worker<V, E, M>::loadGraph(LoadGraph const& graph)
+    -> ResultT<GraphLoaded> {
   _feature.metrics()->pregelWorkersLoadingNumber->fetch_add(1);
-
   LOG_PREGEL("52070", DEBUG) << fmt::format(
       "Worker for execution number {} is loading", _config.executionNumber());
+
   auto graphLoaded = _graphStore->loadShards(&_config, _makeStatusCallback());
+
   LOG_PREGEL("52062", DEBUG)
       << fmt::format("Worker for execution number {} has finished loading.",
                      _config.executionNumber());
   _makeStatusCallback()();
   _feature.metrics()->pregelWorkersLoadingNumber->fetch_sub(1);
-  _conductor.graphLoaded(graphLoaded);
+  return graphLoaded;
+}
+
+template<typename V, typename E, typename M>
+auto Worker<V, E, M>::send(MessagePayload message) -> void {
+  auto response = _conductor.send(message);
+  if (response.fail()) {
+    LOG_PREGEL("ef90a", DEBUG) << fmt::format(
+        "Got unsuccessful response from Conductor after sending message {}",
+        velocypack::serialize(message).toJson());
+  }
 }
 
 // template types to create

--- a/arangod/Pregel/tests/CMakeLists.txt
+++ b/arangod/Pregel/tests/CMakeLists.txt
@@ -26,6 +26,20 @@ add_executable(arangodbtests_disjoint_set
         GraphsSource.cpp
         DisjointSet.cpp)
 
+add_executable(arangodbtests_scc
+        ${PROJECT_SOURCE_DIR}/lib/Basics/VelocyPackStringLiteral.cpp
+        GraphsSource.cpp
+        StronglyConnectedComponentsTest.cpp
+        Graph.cpp
+        SCCGraph.cpp
+        DisjointSet.cpp)
+
+add_executable(arangodbtests_disjoint_set
+        ${PROJECT_SOURCE_DIR}/lib/Basics/VelocyPackStringLiteral.cpp
+        DisjointSetTest.cpp
+        GraphsSource.cpp
+        DisjointSet.cpp)
+
 target_include_directories(arangodbtests_graph PRIVATE
         ${PROJECT_SOURCE_DIR}/lib
         ${PROJECT_BINARY_DIR}/lib
@@ -50,3 +64,4 @@ target_link_libraries(arangodbtests_graph velocypack fmt gtest)
 target_link_libraries(arangodbtests_graph velocypack fmt gtest)
 target_link_libraries(arangodbtests_wcc velocypack fmt gtest)
 target_link_libraries(arangodbtests_scc velocypack fmt gtest)
+target_link_libraries(arangodbtests_disjoint_set velocypack fmt gtest)

--- a/arangod/Pregel/tests/CMakeLists.txt
+++ b/arangod/Pregel/tests/CMakeLists.txt
@@ -26,20 +26,6 @@ add_executable(arangodbtests_disjoint_set
         GraphsSource.cpp
         DisjointSet.cpp)
 
-add_executable(arangodbtests_scc
-        ${PROJECT_SOURCE_DIR}/lib/Basics/VelocyPackStringLiteral.cpp
-        GraphsSource.cpp
-        StronglyConnectedComponentsTest.cpp
-        Graph.cpp
-        SCCGraph.cpp
-        DisjointSet.cpp)
-
-add_executable(arangodbtests_disjoint_set
-        ${PROJECT_SOURCE_DIR}/lib/Basics/VelocyPackStringLiteral.cpp
-        DisjointSetTest.cpp
-        GraphsSource.cpp
-        DisjointSet.cpp)
-
 target_include_directories(arangodbtests_graph PRIVATE
         ${PROJECT_SOURCE_DIR}/lib
         ${PROJECT_BINARY_DIR}/lib

--- a/arangod/Pregel/tests/CMakeLists.txt
+++ b/arangod/Pregel/tests/CMakeLists.txt
@@ -47,11 +47,6 @@ target_include_directories(arangodbtests_disjoint_set PRIVATE
         ${PROJECT_SOURCE_DIR}/arangod/Pregel)
 
 target_link_libraries(arangodbtests_graph velocypack fmt gtest)
-target_include_directories(arangodbtests_disjoint_set PRIVATE
-        ${PROJECT_SOURCE_DIR}/lib
-        ${PROJECT_BINARY_DIR}/lib
-        ${PROJECT_SOURCE_DIR}/arangod/Pregel)
-
 target_link_libraries(arangodbtests_graph velocypack fmt gtest)
 target_link_libraries(arangodbtests_wcc velocypack fmt gtest)
 target_link_libraries(arangodbtests_scc velocypack fmt gtest)

--- a/arangod/Pregel/tests/CMakeLists.txt
+++ b/arangod/Pregel/tests/CMakeLists.txt
@@ -12,6 +12,14 @@ add_executable(arangodbtests_wcc
   WCCGraph.cpp
   DisjointSet.cpp)
 
+add_executable(arangodbtests_scc
+        ${PROJECT_SOURCE_DIR}/lib/Basics/VelocyPackStringLiteral.cpp
+        GraphsSource.cpp
+        StronglyConnectedComponentsTest.cpp
+        Graph.cpp
+        SCCGraph.cpp
+        DisjointSet.cpp)
+
 add_executable(arangodbtests_disjoint_set
         ${PROJECT_SOURCE_DIR}/lib/Basics/VelocyPackStringLiteral.cpp
         DisjointSetTest.cpp
@@ -28,6 +36,17 @@ target_include_directories(arangodbtests_wcc PRIVATE
   ${PROJECT_BINARY_DIR}/lib
   ${PROJECT_SOURCE_DIR}/arangod/Pregel)
 
+target_include_directories(arangodbtests_scc PRIVATE
+        ${PROJECT_SOURCE_DIR}/lib
+        ${PROJECT_BINARY_DIR}/lib
+        ${PROJECT_SOURCE_DIR}/arangod/Pregel)
+
+target_include_directories(arangodbtests_disjoint_set PRIVATE
+        ${PROJECT_SOURCE_DIR}/lib
+        ${PROJECT_BINARY_DIR}/lib
+        ${PROJECT_SOURCE_DIR}/arangod/Pregel)
+
+target_link_libraries(arangodbtests_graph velocypack fmt gtest)
 target_include_directories(arangodbtests_disjoint_set PRIVATE
         ${PROJECT_SOURCE_DIR}/lib
         ${PROJECT_BINARY_DIR}/lib
@@ -35,3 +54,4 @@ target_include_directories(arangodbtests_disjoint_set PRIVATE
 
 target_link_libraries(arangodbtests_graph velocypack fmt gtest)
 target_link_libraries(arangodbtests_wcc velocypack fmt gtest)
+target_link_libraries(arangodbtests_scc velocypack fmt gtest)

--- a/arangod/Pregel/tests/CMakeLists.txt
+++ b/arangod/Pregel/tests/CMakeLists.txt
@@ -11,16 +11,4 @@ target_include_directories(arangodbtests_wcc PRIVATE
   ${PROJECT_BINARY_DIR}/lib
   ${PROJECT_SOURCE_DIR}/arangod/Pregel)
 
-target_include_directories(arangodbtests_scc PRIVATE
-        ${PROJECT_SOURCE_DIR}/lib
-        ${PROJECT_BINARY_DIR}/lib
-        ${PROJECT_SOURCE_DIR}/arangod/Pregel)
-
-target_include_directories(arangodbtests_disjoint_set PRIVATE
-        ${PROJECT_SOURCE_DIR}/lib
-        ${PROJECT_BINARY_DIR}/lib
-        ${PROJECT_SOURCE_DIR}/arangod/Pregel)
-
 target_link_libraries(arangodbtests_wcc velocypack fmt gtest)
-target_link_libraries(arangodbtests_scc velocypack fmt gtest)
-target_link_libraries(arangodbtests_disjoint_set velocypack fmt gtest)

--- a/arangod/Pregel/tests/CMakeLists.txt
+++ b/arangod/Pregel/tests/CMakeLists.txt
@@ -1,3 +1,9 @@
+add_executable(arangodbtests_graph
+        ${PROJECT_SOURCE_DIR}/lib/Basics/VelocyPackStringLiteral.cpp
+        GraphTest.cpp
+        GraphsSource.cpp
+        Graph.cpp)
+
 add_executable(arangodbtests_wcc
   ${PROJECT_SOURCE_DIR}/lib/Basics/VelocyPackStringLiteral.cpp
   GraphsSource.cpp
@@ -6,9 +12,26 @@ add_executable(arangodbtests_wcc
   WCCGraph.cpp
   DisjointSet.cpp)
 
+add_executable(arangodbtests_disjoint_set
+        ${PROJECT_SOURCE_DIR}/lib/Basics/VelocyPackStringLiteral.cpp
+        DisjointSetTest.cpp
+        GraphsSource.cpp
+        DisjointSet.cpp)
+
+target_include_directories(arangodbtests_graph PRIVATE
+        ${PROJECT_SOURCE_DIR}/lib
+        ${PROJECT_BINARY_DIR}/lib
+        ${PROJECT_SOURCE_DIR}/arangod/Pregel)
+
 target_include_directories(arangodbtests_wcc PRIVATE
   ${PROJECT_SOURCE_DIR}/lib
   ${PROJECT_BINARY_DIR}/lib
   ${PROJECT_SOURCE_DIR}/arangod/Pregel)
 
+target_include_directories(arangodbtests_disjoint_set PRIVATE
+        ${PROJECT_SOURCE_DIR}/lib
+        ${PROJECT_BINARY_DIR}/lib
+        ${PROJECT_SOURCE_DIR}/arangod/Pregel)
+
+target_link_libraries(arangodbtests_graph velocypack fmt gtest)
 target_link_libraries(arangodbtests_wcc velocypack fmt gtest)

--- a/arangod/Pregel/tests/Graph.cpp
+++ b/arangod/Pregel/tests/Graph.cpp
@@ -3,6 +3,7 @@
 
 #include "Graph.h"
 #include "WCCGraph.h"
+#include "SCCGraph.h"
 #include "velocypack/Parser.h"
 
 template<typename EdgeProperties, typename VertexProperties>

--- a/arangod/Pregel/tests/Graph.cpp
+++ b/arangod/Pregel/tests/Graph.cpp
@@ -129,3 +129,4 @@ auto Graph<EdgeProperties, VertexProperties>::readVertices(
 
 template class Graph<EmptyEdgeProperties, EmptyVertexProperties>;
 template class Graph<EmptyEdgeProperties, WCCVertexProperties>;
+template class Graph<EmptyEdgeProperties, SCCVertexProperties>;

--- a/arangod/Pregel/tests/GraphTest.cpp
+++ b/arangod/Pregel/tests/GraphTest.cpp
@@ -1,0 +1,99 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2022 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Roman Rabinovich
+////////////////////////////////////////////////////////////////////////////////
+
+#include <gtest/gtest.h>
+#include <variant>
+#include <fstream>
+#include "Graph.h"
+#include "GraphsSource.h"
+#include "fmt/format.h"
+#include "WCCGraph.h"
+
+using namespace arangodb::slicegraph;
+
+namespace {
+auto testReadFromFile(SharedSlice const& graphSlice,
+                      bool checkDuplicateVertices, bool checkEdgeEnds) {
+  size_t expectedNumVertices = GraphSliceHelper::getNumVertices(graphSlice);
+  size_t expectedNumEdges = GraphSliceHelper::getNumEdges(graphSlice);
+  std::string const vertexFileName = "skdjf444bvl4dkj456fbv4r43k";
+  std::string const edgeFileName = "kdjfljdkjcdkjdkjoki349023kd";
+  {
+    std::ofstream vertexFile(vertexFileName);
+    vertexFile.clear();
+    auto const vs = graphSlice["vertices"];
+    for (size_t i = 0; i < vs.length(); ++i) {
+      vertexFile << vs[i].toJson() << '\n';
+    }
+    vertexFile.close();
+  }
+
+  {
+    std::ofstream edgeFile(edgeFileName);
+    edgeFile.clear();
+    auto const es = graphSlice["edges"];
+    for (size_t i = 0; i < es.length(); ++i) {
+      edgeFile << es[i].toJson() << '\n';
+    }
+    edgeFile.close();
+  }
+  Graph<EmptyEdgeProperties, WCCVertexProperties> graph{};
+  std::ifstream vertexFile(vertexFileName);
+  graph.readVertices(vertexFile, checkDuplicateVertices);
+  EXPECT_EQ(graph.vertices.size(), expectedNumVertices);
+
+  std::ifstream edgeFile(edgeFileName);
+  size_t numEdges = graph.readEdges(
+      edgeFile, checkEdgeEnds,
+      [&](const Graph<EmptyEdgeProperties, WCCVertexProperties>::Edge&) {});
+  EXPECT_EQ(numEdges, expectedNumEdges);
+  try {
+    std::remove(vertexFileName.c_str());
+    std::remove(edgeFileName.c_str());
+  } catch (...) {
+    std::cerr << fmt::format("Could not remove files {} and {}.",
+                             vertexFileName, edgeFileName);
+  }
+}
+}  // namespace
+
+TEST(GWEN_GRAPH, test_graph_read_from_file_2path) {
+  bool checkDuplicateVertices = true;
+  bool checkEdgeEnds = true;
+  auto graphSlice = arangodb::slicegraph::setup2Path();
+  testReadFromFile(graphSlice, checkDuplicateVertices, checkEdgeEnds);
+}
+
+TEST(GWEN_GRAPH, test_graph_read_from_file_alternatingTree) {
+  bool checkDuplicateVertices = true;
+  bool checkEdgeEnds = true;
+  auto graphSlice = setup1AlternatingTree();
+  testReadFromFile(graphSlice, checkDuplicateVertices, checkEdgeEnds);
+}
+
+auto main(int argc, char** argv) -> int {
+  testing::InitGoogleTest();
+
+  return RUN_ALL_TESTS();
+}

--- a/arangod/Pregel/tests/GraphsSource.cpp
+++ b/arangod/Pregel/tests/GraphsSource.cpp
@@ -24,27 +24,34 @@
 
 #include <Basics/VelocyPackStringLiteral.h>
 #include "GraphsSource.h"
+#include "Inspection/VPackPure.h"
+#include "fmt/format.h"
 
 using namespace arangodb::velocypack;
+using namespace arangodb::slicegraph;
 
-SharedSlice setup2Path() {
+SharedSlice arangodb::slicegraph::setup2Path() {
   return
       R"({ "vertices": [ {"_key": "A", "value": 5},
                          {"_key": "B", "value": 10},
                          {"_key": "C", "value": 15} ],
+           "numVertices": 3,
            "edges":    [ {"_key": "", "_from": "A", "_to": "B"},
-                         {"_key": "", "_from": "B", "_to": "C"} ] })"_vpack;
+                         {"_key": "", "_from": "B", "_to": "C"} ],
+           "numEdges": 2 })"_vpack;
 }
 
-SharedSlice setupUndirectedEdge() {
+SharedSlice arangodb::slicegraph::setupUndirectedEdge() {
   return
       R"({ "vertices": [ {"_key": "A", "value": 5},
                          {"_key": "B", "value": 10} ],
+           "numVertices": 2,
            "edges":    [ {"_key": "", "_from": "A", "_to": "B"},
-                         {"_key": "", "_from": "B", "_to": "A"} ] })"_vpack;
+                         {"_key": "", "_from": "B", "_to": "A"} ],
+           "numEdges": 2 })"_vpack;
 }
 
-SharedSlice setupThreeDisjointDirectedCycles() {
+SharedSlice arangodb::slicegraph::setupThreeDisjointDirectedCycles() {
   return
       R"({ "vertices": [ {"_key": "a0", "value": 0},
                          {"_key": "a1", "value": 0},
@@ -58,6 +65,7 @@ SharedSlice setupThreeDisjointDirectedCycles() {
                          {"_key": "c2", "value": 0},
                          {"_key": "c3", "value": 0},
                          {"_key": "c4", "value": 0}],
+           "numVertices": 12,
            "edges":    [ {"_key": "", "_from": "a0", "_to": "a1"},
                          {"_key": "", "_from": "a1", "_to": "a2"},
                          {"_key": "", "_from": "a2", "_to": "a0"},
@@ -69,10 +77,11 @@ SharedSlice setupThreeDisjointDirectedCycles() {
                          {"_key": "", "_from": "c1", "_to": "c2"},
                          {"_key": "", "_from": "c2", "_to": "c3"},
                          {"_key": "", "_from": "c3", "_to": "c4"},
-                         {"_key": "", "_from": "c4", "_to": "c0"}] })"_vpack;
+                         {"_key": "", "_from": "c4", "_to": "c0"} ],
+           "numEdges": 12 })"_vpack;
 }
 
-SharedSlice setupThreeDisjointAlternatingCycles() {
+SharedSlice arangodb::slicegraph::setupThreeDisjointAlternatingCycles() {
   return
       R"({ "vertices": [ {"_key": "a0", "value": 0},
                          {"_key": "a1", "value": 0},
@@ -86,6 +95,7 @@ SharedSlice setupThreeDisjointAlternatingCycles() {
                          {"_key": "c2", "value": 0},
                          {"_key": "c3", "value": 0},
                          {"_key": "c4", "value": 0}],
+           "numVertices": 12,
            "edges":    [ {"_key": "", "_from": "a0", "_to": "a1"},
                          {"_key": "", "_from": "a2", "_to": "a1"},
                          {"_key": "", "_from": "a2", "_to": "a0"},
@@ -97,23 +107,28 @@ SharedSlice setupThreeDisjointAlternatingCycles() {
                          {"_key": "", "_from": "c2", "_to": "c1"},
                          {"_key": "", "_from": "c2", "_to": "c3"},
                          {"_key": "", "_from": "c4", "_to": "c3"},
-                         {"_key": "", "_from": "c0", "_to": "c4"}] })"_vpack;
+                         {"_key": "", "_from": "c0", "_to": "c4"} ],
+           "numEdges": 12 })"_vpack;
 }
 
-SharedSlice setup1SingleVertex() {
+SharedSlice arangodb::slicegraph::setup1SingleVertex() {
   return
       R"({ "vertices": [ {"_key": "A", "value": 0} ],
-           "edges":    [ ] })"_vpack;
+           "numVertices": 1,
+           "edges":    [ ],
+           "numEdges": 0 })"_vpack;
 }
 
-SharedSlice setup2IsolatedVertices() {
+SharedSlice arangodb::slicegraph::setup2IsolatedVertices() {
   return
       R"({ "vertices": [ {"_key": "A", "value": 0},
                          {"_key": "B", "value": 0} ],
-           "edges":    [ ] })"_vpack;
+           "numVertices": 2,
+           "edges":    [ ],
+           "numEdges": 0 })"_vpack;
 }
 
-SharedSlice setup1DirectedTree() {
+SharedSlice arangodb::slicegraph::setup1DirectedTree() {
   return
       R"({ "vertices": [ {"_key": "a", "value": 5},
                          {"_key": "a0", "value": 10},
@@ -130,6 +145,7 @@ SharedSlice setup1DirectedTree() {
                          {"_key": "a101", "value": 15},
                          {"_key": "a110", "value": 10},
                          {"_key": "a111", "value": 15} ],
+           "numVertices": 15,
            "edges":   [ {"_key": "", "_from": "a", "_to": "a0"},
                         {"_key": "", "_from": "a", "_to": "a1"},
                         {"_key": "", "_from": "a0", "_to": "a00"},
@@ -143,10 +159,11 @@ SharedSlice setup1DirectedTree() {
                         {"_key": "", "_from": "a10", "_to": "a100"},
                         {"_key": "", "_from": "a10", "_to": "a101"},
                         {"_key": "", "_from": "a11", "_to": "a110"},
-                        {"_key": "", "_from": "a11", "_to": "a111"} ] })"_vpack;
+                        {"_key": "", "_from": "a11", "_to": "a111"} ],
+           "numEdges": 14 })"_vpack;
 }
 
-SharedSlice setup1AlternatingTree() {
+SharedSlice arangodb::slicegraph::setup1AlternatingTree() {
   return
       R"({ "vertices": [ {"_key": "a", "value": 5},
                          {"_key": "a0", "value": 10},
@@ -163,6 +180,7 @@ SharedSlice setup1AlternatingTree() {
                          {"_key": "a101", "value": 15},
                          {"_key": "a110", "value": 10},
                          {"_key": "a111", "value": 15} ],
+           "numVertices": 15,
            "edges":    [ {"_key": "", "_from": "a", "_to": "a0"},
                          {"_key": "", "_from": "a", "_to": "a1"},
                          {"_key": "", "_from": "a00", "_to": "a0"},
@@ -176,18 +194,19 @@ SharedSlice setup1AlternatingTree() {
                          {"_key": "", "_from": "a10", "_to": "a100"},
                          {"_key": "", "_from": "a10", "_to": "a101"},
                          {"_key": "", "_from": "a11", "_to": "a110"},
-                         {"_key": "", "_from": "a11", "_to": "a111"} ] })"_vpack;
+                         {"_key": "", "_from": "a11", "_to": "a111"} ],
+           "numEdges": 14 })"_vpack;
 }
 
-SharedSlice setup2CliquesConnectedByDirectedEdge() {
+SharedSlice arangodb::slicegraph::setup2CliquesConnectedByDirectedEdge() {
   return
       R"({ "vertices": [ {"_key": "a0", "value": 5},
                          {"_key": "a1", "value": 10},
                          {"_key": "a2", "value": 15},
                          {"_key": "b0", "value": 5},
                          {"_key": "b1", "value": 10},
-                         {"_key": "b2", "value": 15}
- ],
+                         {"_key": "b2", "value": 15} ],
+           "numVertices": 6,
            "edges":    [ {"_key": "", "_from": "a0", "_to": "a1"},
                          {"_key": "", "_from": "a1", "_to": "a0"},
                          {"_key": "", "_from": "a0", "_to": "a2"},
@@ -200,12 +219,43 @@ SharedSlice setup2CliquesConnectedByDirectedEdge() {
                          {"_key": "", "_from": "b2", "_to": "b0"},
                          {"_key": "", "_from": "b1", "_to": "b2"},
                          {"_key": "", "_from": "b2", "_to": "b1"},
-                         {"_key": "", "_from": "a0", "_to": "b0"} ] })"_vpack;
+                         {"_key": "", "_from": "a0", "_to": "b0"} ],
+           "numEdges": 13 })"_vpack;
 }
 
-SharedSlice setupDuplicateVertices() {
+SharedSlice arangodb::slicegraph::setupDuplicateVertices() {
   return
       R"({ "vertices": [ {"_key": "A", "value": 5},
                          {"_key": "A", "value": 10} ],
-           "edges":    [ ] })"_vpack;
+           "numVertices": 2,
+           "edges":    [ ],
+           "numEdges": 0 })"_vpack;
+}
+
+auto GraphSliceHelper::getNumVertices(SharedSlice const& graphSlice) -> size_t {
+  size_t expectedNumVertices;
+  {
+    auto result = deserializeWithStatus<size_t>(
+        graphSlice.slice()["numVertices"], expectedNumVertices);
+    if (not result.ok()) {
+      throw std::runtime_error(
+          fmt::format("Could not get numVertices from the graph slice {}",
+                      graphSlice.toString()));
+    }
+  }
+  return expectedNumVertices;
+}
+
+auto GraphSliceHelper::getNumEdges(SharedSlice const& graphSlice) -> size_t {
+  size_t expectedNumEdges;
+  {
+    auto result = deserializeWithStatus<size_t>(
+        graphSlice.slice()["numEdges"], expectedNumEdges);
+    if (not result.ok()) {
+      throw std::runtime_error(
+          fmt::format("Could not get numEdges from the graph slice {}",
+                      graphSlice.toString()));
+    }
+  }
+  return expectedNumEdges;
 }

--- a/arangod/Pregel/tests/GraphsSource.h
+++ b/arangod/Pregel/tests/GraphsSource.h
@@ -28,6 +28,7 @@
 
 using namespace arangodb::velocypack;
 
+namespace arangodb::slicegraph {
 SharedSlice setup2Path();
 
 SharedSlice setupUndirectedEdge();
@@ -47,3 +48,12 @@ SharedSlice setup1AlternatingTree();
 SharedSlice setup2CliquesConnectedByDirectedEdge();
 
 SharedSlice setupDuplicateVertices();
+
+struct GraphSliceHelper {
+  static auto getNumVertices(SharedSlice const& graphSlice) -> size_t;
+
+  static auto getNumEdges(SharedSlice const& graphSlice) -> size_t;
+
+};
+
+} // namespace arangodb::slicegraph

--- a/arangod/Pregel/tests/SCCGraph.cpp
+++ b/arangod/Pregel/tests/SCCGraph.cpp
@@ -162,6 +162,8 @@ auto SCCGraph<EdgeProperties, VertexProperties>::readEdgesBuildSCCs(
 
   // remaining streams
   while (changedTree) {
+    //      not _nextStream.empty() /*todo: test (or read paper) if this is
+    //      correct*/ or changedTree) {
     changedTree = false;
     std::swap(_currentStream, _nextStream);
 

--- a/arangod/Pregel/tests/SCCGraph.cpp
+++ b/arangod/Pregel/tests/SCCGraph.cpp
@@ -162,8 +162,6 @@ auto SCCGraph<EdgeProperties, VertexProperties>::readEdgesBuildSCCs(
 
   // remaining streams
   while (changedTree) {
-    //      not _nextStream.empty() /*todo: test (or read paper) if this is
-    //      correct*/ or changedTree) {
     changedTree = false;
     std::swap(_currentStream, _nextStream);
 

--- a/arangod/Pregel/tests/SCCGraph.cpp
+++ b/arangod/Pregel/tests/SCCGraph.cpp
@@ -20,7 +20,7 @@ SCCGraph<EdgeProperties, VertexProperties>::SCCGraph(
  * another node on the path from X to the root.
  *
  * Recall that tree edges go from a representative of the source scc to, in
-// general, any vertex in the target scc.
+ * general, any vertex in the target scc.
  * @tparam EdgeProperties
  * @tparam VertexProperties
  * @param from

--- a/arangod/Pregel/tests/SCCGraph.cpp
+++ b/arangod/Pregel/tests/SCCGraph.cpp
@@ -1,0 +1,180 @@
+#include "SCCGraph.h"
+
+template<typename EdgeProperties, VertexPropertiesWithValue VertexProperties>
+SCCGraph<EdgeProperties, VertexProperties>::SCCGraph(
+    const SharedSlice& graphJson, bool checkDuplicateVertices)
+    : sccs(), _idxDummyRoot{graphJson["vertices"].length()} {
+  this->readVertices(graphJson, checkDuplicateVertices);
+  for (VertexIndex idx = 0; idx <= _idxDummyRoot; ++idx) {
+    sccs.addSingleton(idx);
+    this->getTreeParent(idx) = _idxDummyRoot;  // root is its own parent
+  }
+}
+
+/**
+ * Returns the type of the edge. We run from both edge ends in parallel towards
+ * the root. The result depends on
+ * (1) which end (call it X) reaches the least common predecessor (LCP, the
+ * intersecting point of both paths) first, and
+ * (2) if the other end (that reaches LCP later, call it Y) meets X itself or
+ * another node on the path from X to the root.
+ *
+ * Recall that tree edges go from a representative of the source scc to, in
+// general, any vertex in the target scc.
+ * @tparam EdgeProperties
+ * @tparam VertexProperties
+ * @param from
+ * @param to
+ * @return
+ */
+template<typename EdgeProperties, VertexPropertiesWithValue VertexProperties>
+auto SCCGraph<EdgeProperties, VertexProperties>::edgeType(VertexIndex from,
+                                                          VertexIndex to)
+    -> EdgeType {
+  from = sccs.representative(from);
+  to = sccs.representative(to);
+  if (from == to) {
+    return EdgeType::FORWARD_OR_SELF_LOOP;  // self-loop
+  }
+
+  // run from nodes from and to in parallel the paths towards the root
+  // until the paths intersect or until the root is reached
+  auto runningFrom = from;
+  auto runningTo = to;
+  std::unordered_set<VertexIndex> traceOfFrom{runningFrom};
+  std::unordered_set<VertexIndex> traceOfTo{runningTo};
+  while (not traceOfTo.contains(runningFrom) and
+         not traceOfFrom.contains(runningTo) and
+         runningFrom != _idxDummyRoot and runningTo != _idxDummyRoot) {
+    runningFrom = sccs.representative(this->getTreeParent(runningFrom));
+    traceOfFrom.insert(runningFrom);
+    runningTo = sccs.representative(this->getTreeParent(runningTo));
+    traceOfTo.insert(runningTo);
+  }
+
+  // analyse why we left the while loop
+  if (runningFrom == to) {
+    // special case, in particular, traceOfTo.contains(runningFrom)
+    return EdgeType::BACKWARD;
+  }
+
+  if (runningTo == from) {
+    // special case, in particular, traceOfFrom.contains(runningTo)
+    return EdgeType::FORWARD_OR_SELF_LOOP;  // forward
+  }
+
+  if (traceOfTo.contains(runningFrom)) {
+    return EdgeType::CROSS_NON_FORWARD;
+  }
+
+  if (traceOfFrom.contains(runningTo)) {
+    return EdgeType::CROSS_FORWARD;
+  }
+
+  // remaining cases: one of runningFrom and runningTo reached the root
+  if (runningFrom == _idxDummyRoot) {
+    while (not traceOfFrom.contains(runningTo)) {
+      runningTo = sccs.representative(this->getTreeParent(runningTo));
+    }
+    if (runningTo == from) {
+      return EdgeType::FORWARD_OR_SELF_LOOP;  // forward
+    }
+    return EdgeType::CROSS_FORWARD;
+  } else {
+    // runningTo == _idxDummyRoot
+    while (not traceOfTo.contains(runningFrom)) {
+      runningFrom = sccs.representative(this->getTreeParent(runningFrom));
+    }
+    if (runningFrom == to) {
+      return EdgeType::BACKWARD;
+    }
+    return EdgeType::CROSS_NON_FORWARD;
+  }
+}
+
+template<typename EdgeProperties, VertexPropertiesWithValue VertexProperties>
+auto SCCGraph<EdgeProperties, VertexProperties>::collapse(VertexIndex from,
+                                                          VertexIndex to)
+    -> void {
+  VertexIndex running = from;
+  VertexIndex newRepresentative;
+  while (running != to) {
+    newRepresentative = sccs.merge(running, to);
+    running = this->getTreeParent(running);
+  }
+  // note: we leave this->getTreeParent(running)
+  // for running != newRepresentative as junk
+  this->getTreeParent(newRepresentative) = this->getTreeParent(to);
+}
+
+template<typename EdgeProperties, VertexPropertiesWithValue VertexProperties>
+auto SCCGraph<EdgeProperties, VertexProperties>::processEdge(
+    VertexIndex from, VertexIndex to,
+    std::queue<std::pair<VertexIndex, VertexIndex>>& outputQueue) -> void {
+  auto representativeFrom = sccs.representative(from);
+  auto representativeTo = sccs.representative(to);
+  VertexIndex parentTo = this->getTreeParent(to);
+  VertexIndex parentFrom = this->getTreeParent(from);
+
+  /* the paper doesn't mention the second condition in the following "if",
+   * but otherwise the tree structure can be destroyed if at the beginning
+   * the edges (u,v) and then (v,u) appear. */
+  if (parentTo == _idxDummyRoot and parentFrom == _idxDummyRoot) {
+    this->getTreeParent(representativeTo) = from;
+  } else {
+    switch (edgeType(representativeFrom, representativeTo)) {
+      case EdgeType::BACKWARD: {
+        changedTree = true;
+        collapse(representativeFrom, representativeTo);
+        return;
+      }
+      case EdgeType::CROSS_FORWARD: {
+        outputQueue.push(std::make_pair(representativeFrom, representativeTo));
+        return;
+      }
+      case EdgeType::CROSS_NON_FORWARD: {
+        changedTree = true;
+        this->getTreeParent(representativeTo) = representativeFrom;
+        outputQueue.push(
+            std::make_pair(sccs.representative(parentTo), representativeTo));
+        return;
+      }
+      default:
+        return;  // forward edge or self-loop: do nothing, return no
+                 // changes at the tree
+    }
+  }
+}
+
+template<typename EdgeProperties, VertexPropertiesWithValue VertexProperties>
+auto SCCGraph<EdgeProperties, VertexProperties>::onReadEdge(SCCEdge const& edge)
+    -> void {
+  VertexIndex from = this->getVertexPosition(edge._from);
+  VertexIndex to = this->getVertexPosition(edge._to);
+  processEdge(from, to, this->_nextStream);
+}
+
+template<typename EdgeProperties, VertexPropertiesWithValue VertexProperties>
+auto SCCGraph<EdgeProperties, VertexProperties>::readEdgesBuildSCCs(
+    SharedSlice const& graphJson) -> void {
+  // first stream: input from graphJson, output to _nextStream
+  this->readEdges(graphJson, true, [&](SCCEdge edge) { onReadEdge(edge); });
+
+  // remaining streams
+  while (changedTree) {
+    //      not _nextStream.empty() /*todo: test (or read paper) if this is
+    //      correct*/ or changedTree) {
+    changedTree = false;
+    std::swap(_currentStream, _nextStream);
+
+    while (not _currentStream.empty()) {
+      std::pair<VertexIndex, VertexIndex> edge = _currentStream.front();
+      _currentStream.pop();
+      // this may set changedTree = true
+      processEdge(edge.first, edge.second, _nextStream);
+    }
+  }
+  sccs.removeElement(_idxDummyRoot);
+}
+
+template class SCCGraph<EmptyEdgeProperties, SCCVertexProperties>;

--- a/arangod/Pregel/tests/SCCGraph.h
+++ b/arangod/Pregel/tests/SCCGraph.h
@@ -98,8 +98,8 @@ auto inspect(Inspector& f, SCCVertexProperties& x) {
  * The authors of the paper claim that the time complexity of the algorithm is
  * O(h*m + (n*log n)) where n is the number of vertices, m the number of edges
  * and h the maximal height of the tree that is reached during the algorithm
- * run. Theoretically, the best upper bound for h is n, however, the authors
- * claim that in their experiments it is close to log n.
+ * run. Theoretically, the best known upper bound for h is n, however, the
+ * authors claim that in their experiments it is close to log n.
  *
  * Discussion.
  *

--- a/arangod/Pregel/tests/SCCGraph.h
+++ b/arangod/Pregel/tests/SCCGraph.h
@@ -44,6 +44,92 @@ auto inspect(Inspector& f, SCCVertexProperties& x) {
   return f.object(x).fields(f.field("value", x.value));
 }
 
+/**
+ * The class is intended solely to compute SCCs. This is on-the-fly while
+ * reading graph edges. The algorithm is taken from the paper
+ * Laura, L., Santaroni, F. (2011). Computing Strongly Connected Components in
+ * the Streaming Model. In: Marchetti-Spaccamela, A., Segal, M. (eds) Theory and
+ * Practice of Algorithms in (Computer) Systems. TAPAS 2011. Lecture Notes in
+ * Computer Science, vol 6595. Springer, Berlin, Heidelberg.
+ * https://doi.org/10.1007/978-3-642-19754-3_20
+ *
+ * Description of the algorithm.
+ *
+ * The algorithm uses two data structures: UnionFind and a tree whose nodes are
+ * vertices that represent SCCs computed so far. The graph vertex that
+ * serves as a node in the tree is contained in the SCC it represents but is not
+ * necessarily the representative of the SCC which is returned for the SCC by
+ * the UnionFind.
+ *
+ * Globally, the run of the algorithm consists of a series of edge stream reads.
+ * The first edge stream comes from the input. It may produce the next stream,
+ * which is read and may produce the next stream and so on. While reading edges
+ * from a stream, the tree is updated. In some cases it signals that we found a
+ * cycle whose vertices are added to the corresponding SCC. The algorithm stops
+ * when for a stream there were no tree updates (even if there is a remaining
+ * unread stream!).
+ *
+ * Initially, the vertices are read and put into UnionFind as singletons and
+ * into the tree as children of the auxiliary root. When an edge is read from a
+ * stream, we determine its type with respect to the tree: backward, forward or
+ * self-loop, cross forward or cross non-forward. Note that even if the graph
+ * has no self-loops, we may obtain a self-loop in the tree because its nodes
+ * represent (potentially non-trivial) strongly connected sets.
+ *
+ * The edges of the tree are thought of as going from the root to the leaves
+ * (for this description we ignore that in our implementation they are directed
+ * the other way around). Backward and forward edges connect nodes on the same
+ * tree branch: the backward ones go up the tree and the forward ones down the
+ * tree. Cross edges connect nodes in different branches. Cross (non-)forward
+ * edges go from a node to another node that has a (smaller) bigger height.
+ *
+ * Forward edges and self-loops are ignored. Backward edges mean that strongly
+ * connected sets of the graph represented by the nodes of the tree that are
+ * between the edge ends all belong to the same SCC. For such edges, the
+ * corresponding sets in UnionFind are merged and the (sub-)path of the tree
+ * between the edge ends is collapsed to one node. Cross forward edges are just
+ * added to the next steam, no tree update happens. Cross non-forward edges
+ * (a,b) constitute the most involved case. Let us say, b's parent is p. (Then
+ * p is not a because (a, b) is a cross edge.) Then the tree edge (p, b) is
+ * replaced by the edge (a, b) and (p, b) is added to the next stream.
+ *
+ * Complexity.
+ *
+ * The authors of the paper claim that the time complexity of the algorithm is
+ * O(h*m + (n*log n)) where n is the number of vertices, m the number of edges
+ * and h the maximal height of the tree that is reached during the algorithm
+ * run. Theoretically, the best upper bound for h is n, however, the authors
+ * claim that in their experiments it is close to log n.
+ *
+ * Discussion.
+ *
+ * For the given practical upper bound, the asymptotic running time is by a
+ * factor of log n worse than that of a classical algorithm as, e.g., Tarjan's
+ * algorithm. The advantages are that
+ * (1) we can start computing while the edges
+ * are still being read and
+ * (2) potentially we can parallelize the algorithm,
+ * see http://snap.stanford.edu/class/cs224w-2017/projects/cs224w-9-final.pdf.
+ *
+ * Implementation details.
+ *
+ * The constructor only reads the vertices of the graph because reading the
+ * edges is tightly associated with the first stream. The remainder is performed
+ * in the function readEdgesBuildSCCs. The first stream is read directly from
+ * the input in the member function readEdges from the parent class. It gets the
+ * function onReadEdge, which is passed as a parameter and is executed on
+ * each edge. The output is written into the next stream that is a queue.
+ *
+ * Back to readEdgesBuildSCCs, other streams are read from the input queue and
+ * the output is written into the output queue. The roles of the queues are
+ * switched between the iterations.
+ *
+ * The most involved function edgeType is described in the comments to the
+ * function.
+ *
+ * @tparam EdgeProperties
+ * @tparam VertexProperties
+ */
 template<typename EdgeProperties, VertexPropertiesWithValue VertexProperties>
 class SCCGraph : public ValuedGraph<EdgeProperties, VertexProperties> {
  public:
@@ -76,9 +162,9 @@ class SCCGraph : public ValuedGraph<EdgeProperties, VertexProperties> {
    * @param edge
    */
   auto onReadEdge(SCCEdge const& edge) -> void;
-  auto processEdge(
-      VertexIndex from, VertexIndex to,
-      std::queue<std::pair<VertexIndex, VertexIndex>>& outputQueue) -> void;
+  auto processEdge(VertexIndex from, VertexIndex to,
+                   std::queue<std::pair<VertexIndex, VertexIndex>>& outputQueue)
+      -> void;
   auto getTreeParent(VertexIndex idx) -> VertexIndex& {
     return this->vertices[idx].properties.treeParent;
   };

--- a/arangod/Pregel/tests/SCCGraph.h
+++ b/arangod/Pregel/tests/SCCGraph.h
@@ -1,0 +1,87 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2022 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Roman Rabinovich
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include <unordered_set>
+#include <queue>
+
+#include "Graph.h"
+
+using namespace arangodb::velocypack;
+
+using VertexIndex = size_t;
+using EdgeIndex = size_t;
+
+struct SCCVertexProperties {
+  uint64_t value{};
+  VertexIndex treeParent{};
+};
+
+template<typename Inspector>
+auto inspect(Inspector& f, SCCVertexProperties& x) {
+  return f.object(x).fields(f.field("value", x.value));
+}
+
+template<typename EdgeProperties, VertexPropertiesWithValue VertexProperties>
+class SCCGraph : public ValuedGraph<EdgeProperties, VertexProperties> {
+ public:
+  using SCCEdge = BaseEdge<EdgeProperties>;
+
+  enum class EdgeType {
+    BACKWARD,
+    CROSS_FORWARD,
+    CROSS_NON_FORWARD,
+    FORWARD_OR_SELF_LOOP
+  };
+
+  SCCGraph(SharedSlice const& graphJson, bool checkDuplicateVertices);
+
+  DisjointSet sccs;
+  auto readEdgesBuildSCCs(SharedSlice const& graphJson) -> void;
+
+ private:
+  std::queue<std::pair<VertexIndex, VertexIndex>>
+      _currentStream;  // S_i from the paper
+  std::queue<std::pair<VertexIndex, VertexIndex>>
+      _nextStream;  // S_{i+1} from the paper
+  VertexIndex const _idxDummyRoot;
+
+  bool changedTree = true;
+  /**
+   * Executes the body from the main algorithm loop on the given edge from the
+   * initial queue (S_0 from the paper) given in the graph input string and
+   * fills _nextQueue as S_{i+1} from the paper.
+   * @param edge
+   */
+  auto onReadEdge(SCCEdge const& edge) -> void;
+  auto processEdge(
+      VertexIndex from, VertexIndex to,
+      std::queue<std::pair<VertexIndex, VertexIndex>>& outputQueue) -> void;
+  auto getTreeParent(VertexIndex idx) -> VertexIndex& {
+    return this->vertices[idx].properties.treeParent;
+  };
+  auto edgeType(VertexIndex from, VertexIndex to) -> EdgeType;
+  auto collapse(VertexIndex from, VertexIndex to) -> void;
+};

--- a/arangod/Pregel/tests/StronglyConnectedComponentsTest.cpp
+++ b/arangod/Pregel/tests/StronglyConnectedComponentsTest.cpp
@@ -1,0 +1,145 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2022 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Roman Rabinovich
+////////////////////////////////////////////////////////////////////////////////
+
+#include <gtest/gtest.h>
+#include "SCCGraph.h"
+#include "GraphsSource.h"
+
+TEST(GWEN_SCC, test_readVertices_2path) {
+  bool const checkDuplicateVertices = true;
+  auto graph = SCCGraph<EmptyEdgeProperties, SCCVertexProperties>(
+      setup2Path(), checkDuplicateVertices);
+  EXPECT_EQ(graph.vertices.size(), 3u);
+  std::set<VertexKey> vertices;
+  for (auto const& vertex : graph.vertices) {
+    vertices.insert(vertex._key);
+  }
+  std::set<VertexKey> expectedVertices{"A", "B", "C"};
+  EXPECT_EQ(vertices, expectedVertices);
+  EXPECT_EQ(graph.getVertexPosition("A"), 0u);
+  EXPECT_EQ(graph.getVertexPosition("B"), 1u);
+  EXPECT_EQ(graph.getVertexPosition("C"), 2u);
+}
+
+TEST(GWEN_SCC, test_readVertices_ThreeDisjointDirectedCycles) {
+  bool const checkDuplicateVertices = true;
+  auto graph = SCCGraph<EmptyEdgeProperties, SCCVertexProperties>(
+      setupThreeDisjointDirectedCycles(), checkDuplicateVertices);
+  EXPECT_EQ(graph.vertices.size(), 12u);
+  std::set<VertexKey> vertices;
+  for (auto const& vertex : graph.vertices) {
+    vertices.insert(vertex._key);
+  }
+  std::set<VertexKey> expectedVertices{"a0", "a1", "a2", "b0", "b1", "b2",
+                                       "b3", "c0", "c1", "c2", "c3", "c4"};
+  EXPECT_EQ(vertices, expectedVertices);
+  EXPECT_EQ(graph.getVertexPosition("a0"), 0u);
+}
+
+TEST(GWEN_SCC, test_readVertices_DuplicateVertices) {
+  bool const checkDuplicateVertices = true;
+  auto graphJSON = setupDuplicateVertices();
+  using SCCSimpleGraph = SCCGraph<EmptyEdgeProperties, SCCVertexProperties>;
+  EXPECT_THROW((SCCSimpleGraph{graphJSON, checkDuplicateVertices}),
+               std::runtime_error);
+  EXPECT_NO_THROW((SCCSimpleGraph{graphJSON, false}));
+}
+
+TEST(GWEN_SCC, test_number_sccs_undirectedEdge) {
+  bool const checkDuplicateVertices = true;
+  auto graphJSON = setupUndirectedEdge();
+  auto graph = SCCGraph<EmptyEdgeProperties, SCCVertexProperties>(
+      graphJSON, checkDuplicateVertices);
+  graph.readEdgesBuildSCCs(graphJSON);
+  EXPECT_EQ(graph.writeEquivalenceRelationIntoVertices(graph.sccs), 1u);
+}
+
+TEST(GWEN_SCC, test_number_sccs_2Path) {
+  bool const checkDuplicateVertices = true;
+  auto graphJSON = setup2Path();
+  auto graph = SCCGraph<EmptyEdgeProperties, SCCVertexProperties>(
+      graphJSON, checkDuplicateVertices);
+  graph.readEdgesBuildSCCs(graphJSON);
+  EXPECT_EQ(graph.writeEquivalenceRelationIntoVertices(graph.sccs), 3u);
+}
+
+TEST(GWEN_SCC, test_number_sccs_1SingleVertex) {
+  bool const checkDuplicateVertices = true;
+  auto graphJSON = setup1SingleVertex();
+  auto graph = SCCGraph<EmptyEdgeProperties, SCCVertexProperties>(
+      graphJSON, checkDuplicateVertices);
+  graph.readEdgesBuildSCCs(graphJSON);
+  EXPECT_EQ(graph.writeEquivalenceRelationIntoVertices(graph.sccs), 1u);
+}
+
+TEST(GWEN_SCC, test_number_sccs_2IsolatedVertices) {
+  bool const checkDuplicateVertices = true;
+  auto graphJSON = setup2IsolatedVertices();
+  auto graph = SCCGraph<EmptyEdgeProperties, SCCVertexProperties>(
+      graphJSON, checkDuplicateVertices);
+  graph.readEdgesBuildSCCs(graphJSON);
+  EXPECT_EQ(graph.writeEquivalenceRelationIntoVertices(graph.sccs), 2u);
+}
+
+TEST(GWEN_SCC, test_number_sccs_directedTree) {
+  bool const checkDuplicateVertices = true;
+  auto graphJSON = setup1DirectedTree();
+  auto graph = SCCGraph<EmptyEdgeProperties, SCCVertexProperties>(
+      graphJSON, checkDuplicateVertices);
+  graph.readEdgesBuildSCCs(graphJSON);
+  EXPECT_EQ(graph.writeEquivalenceRelationIntoVertices(graph.sccs), 15u);
+}
+
+TEST(GWEN_SCC, test_number_sccs_alternatingTree) {
+  bool const checkDuplicateVertices = true;
+  auto graphJSON = setup1AlternatingTree();
+  auto graph = SCCGraph<EmptyEdgeProperties, SCCVertexProperties>(
+      graphJSON, checkDuplicateVertices);
+  graph.readEdgesBuildSCCs(graphJSON);
+  EXPECT_EQ(graph.writeEquivalenceRelationIntoVertices(graph.sccs), 15u);
+}
+
+TEST(GWEN_SCC, test_number_sccs_2CliquesConnectedByDirectedEdge) {
+  bool const checkDuplicateVertices = true;
+  auto graphJSON = setup2CliquesConnectedByDirectedEdge();
+  auto graph = SCCGraph<EmptyEdgeProperties, SCCVertexProperties>(
+      graphJSON, checkDuplicateVertices);
+  graph.readEdgesBuildSCCs(graphJSON);
+  EXPECT_EQ(graph.writeEquivalenceRelationIntoVertices(graph.sccs), 2u);
+}
+
+TEST(GWEN_SCC, test_number_sccs_threeDisjointDirectedCycles) {
+  bool const checkDuplicateVertices = true;
+  auto graphJSON = setupThreeDisjointDirectedCycles();
+  auto graph = SCCGraph<EmptyEdgeProperties, SCCVertexProperties>(
+      graphJSON, checkDuplicateVertices);
+  graph.readEdgesBuildSCCs(graphJSON);
+  EXPECT_EQ(graph.writeEquivalenceRelationIntoVertices(graph.sccs), 3u);
+}
+
+auto main(int argc, char** argv) -> int {
+  testing::InitGoogleTest();
+
+  return RUN_ALL_TESTS();
+}

--- a/arangod/Pregel/tests/StronglyConnectedComponentsTest.cpp
+++ b/arangod/Pregel/tests/StronglyConnectedComponentsTest.cpp
@@ -26,11 +26,15 @@
 #include "SCCGraph.h"
 #include "GraphsSource.h"
 
+using namespace arangodb::slicegraph;
+
 TEST(GWEN_SCC, test_readVertices_2path) {
   bool const checkDuplicateVertices = true;
+  auto sliceGraph = setup2Path();
   auto graph = SCCGraph<EmptyEdgeProperties, SCCVertexProperties>(
-      setup2Path(), checkDuplicateVertices);
-  EXPECT_EQ(graph.vertices.size(), 3u);
+      sliceGraph, checkDuplicateVertices);
+  EXPECT_EQ(graph.vertices.size(),
+            GraphSliceHelper::getNumVertices(sliceGraph));
   std::set<VertexKey> vertices;
   for (auto const& vertex : graph.vertices) {
     vertices.insert(vertex._key);
@@ -44,9 +48,11 @@ TEST(GWEN_SCC, test_readVertices_2path) {
 
 TEST(GWEN_SCC, test_readVertices_ThreeDisjointDirectedCycles) {
   bool const checkDuplicateVertices = true;
+  auto sliceGraph = setupThreeDisjointDirectedCycles();
   auto graph = SCCGraph<EmptyEdgeProperties, SCCVertexProperties>(
-      setupThreeDisjointDirectedCycles(), checkDuplicateVertices);
-  EXPECT_EQ(graph.vertices.size(), 12u);
+      sliceGraph, checkDuplicateVertices);
+  EXPECT_EQ(graph.vertices.size(),
+            GraphSliceHelper::getNumVertices(sliceGraph));
   std::set<VertexKey> vertices;
   for (auto const& vertex : graph.vertices) {
     vertices.insert(vertex._key);
@@ -59,82 +65,82 @@ TEST(GWEN_SCC, test_readVertices_ThreeDisjointDirectedCycles) {
 
 TEST(GWEN_SCC, test_readVertices_DuplicateVertices) {
   bool const checkDuplicateVertices = true;
-  auto graphJSON = setupDuplicateVertices();
+  auto sliceGraph = setupDuplicateVertices();
   using SCCSimpleGraph = SCCGraph<EmptyEdgeProperties, SCCVertexProperties>;
-  EXPECT_THROW((SCCSimpleGraph{graphJSON, checkDuplicateVertices}),
+  EXPECT_THROW((SCCSimpleGraph{sliceGraph, checkDuplicateVertices}),
                std::runtime_error);
-  EXPECT_NO_THROW((SCCSimpleGraph{graphJSON, false}));
+  EXPECT_NO_THROW((SCCSimpleGraph{sliceGraph, false}));
 }
 
 TEST(GWEN_SCC, test_number_sccs_undirectedEdge) {
   bool const checkDuplicateVertices = true;
-  auto graphJSON = setupUndirectedEdge();
+  auto sliceGraph = setupUndirectedEdge();
   auto graph = SCCGraph<EmptyEdgeProperties, SCCVertexProperties>(
-      graphJSON, checkDuplicateVertices);
-  graph.readEdgesBuildSCCs(graphJSON);
+      sliceGraph, checkDuplicateVertices);
+  graph.readEdgesBuildSCCs(sliceGraph);
   EXPECT_EQ(graph.writeEquivalenceRelationIntoVertices(graph.sccs), 1u);
 }
 
 TEST(GWEN_SCC, test_number_sccs_2Path) {
   bool const checkDuplicateVertices = true;
-  auto graphJSON = setup2Path();
+  auto sliceGraph = setup2Path();
   auto graph = SCCGraph<EmptyEdgeProperties, SCCVertexProperties>(
-      graphJSON, checkDuplicateVertices);
-  graph.readEdgesBuildSCCs(graphJSON);
+      sliceGraph, checkDuplicateVertices);
+  graph.readEdgesBuildSCCs(sliceGraph);
   EXPECT_EQ(graph.writeEquivalenceRelationIntoVertices(graph.sccs), 3u);
 }
 
 TEST(GWEN_SCC, test_number_sccs_1SingleVertex) {
   bool const checkDuplicateVertices = true;
-  auto graphJSON = setup1SingleVertex();
+  auto sliceGraph = setup1SingleVertex();
   auto graph = SCCGraph<EmptyEdgeProperties, SCCVertexProperties>(
-      graphJSON, checkDuplicateVertices);
-  graph.readEdgesBuildSCCs(graphJSON);
+      sliceGraph, checkDuplicateVertices);
+  graph.readEdgesBuildSCCs(sliceGraph);
   EXPECT_EQ(graph.writeEquivalenceRelationIntoVertices(graph.sccs), 1u);
 }
 
 TEST(GWEN_SCC, test_number_sccs_2IsolatedVertices) {
   bool const checkDuplicateVertices = true;
-  auto graphJSON = setup2IsolatedVertices();
+  auto sliceGraph = setup2IsolatedVertices();
   auto graph = SCCGraph<EmptyEdgeProperties, SCCVertexProperties>(
-      graphJSON, checkDuplicateVertices);
-  graph.readEdgesBuildSCCs(graphJSON);
+      sliceGraph, checkDuplicateVertices);
+  graph.readEdgesBuildSCCs(sliceGraph);
   EXPECT_EQ(graph.writeEquivalenceRelationIntoVertices(graph.sccs), 2u);
 }
 
 TEST(GWEN_SCC, test_number_sccs_directedTree) {
   bool const checkDuplicateVertices = true;
-  auto graphJSON = setup1DirectedTree();
+  auto sliceGraph = setup1DirectedTree();
   auto graph = SCCGraph<EmptyEdgeProperties, SCCVertexProperties>(
-      graphJSON, checkDuplicateVertices);
-  graph.readEdgesBuildSCCs(graphJSON);
+      sliceGraph, checkDuplicateVertices);
+  graph.readEdgesBuildSCCs(sliceGraph);
   EXPECT_EQ(graph.writeEquivalenceRelationIntoVertices(graph.sccs), 15u);
 }
 
 TEST(GWEN_SCC, test_number_sccs_alternatingTree) {
   bool const checkDuplicateVertices = true;
-  auto graphJSON = setup1AlternatingTree();
+  auto sliceGraph = setup1AlternatingTree();
   auto graph = SCCGraph<EmptyEdgeProperties, SCCVertexProperties>(
-      graphJSON, checkDuplicateVertices);
-  graph.readEdgesBuildSCCs(graphJSON);
+      sliceGraph, checkDuplicateVertices);
+  graph.readEdgesBuildSCCs(sliceGraph);
   EXPECT_EQ(graph.writeEquivalenceRelationIntoVertices(graph.sccs), 15u);
 }
 
 TEST(GWEN_SCC, test_number_sccs_2CliquesConnectedByDirectedEdge) {
   bool const checkDuplicateVertices = true;
-  auto graphJSON = setup2CliquesConnectedByDirectedEdge();
+  auto sliceGraph = setup2CliquesConnectedByDirectedEdge();
   auto graph = SCCGraph<EmptyEdgeProperties, SCCVertexProperties>(
-      graphJSON, checkDuplicateVertices);
-  graph.readEdgesBuildSCCs(graphJSON);
+      sliceGraph, checkDuplicateVertices);
+  graph.readEdgesBuildSCCs(sliceGraph);
   EXPECT_EQ(graph.writeEquivalenceRelationIntoVertices(graph.sccs), 2u);
 }
 
 TEST(GWEN_SCC, test_number_sccs_threeDisjointDirectedCycles) {
   bool const checkDuplicateVertices = true;
-  auto graphJSON = setupThreeDisjointDirectedCycles();
+  auto sliceGraph = setupThreeDisjointDirectedCycles();
   auto graph = SCCGraph<EmptyEdgeProperties, SCCVertexProperties>(
-      graphJSON, checkDuplicateVertices);
-  graph.readEdgesBuildSCCs(graphJSON);
+      sliceGraph, checkDuplicateVertices);
+  graph.readEdgesBuildSCCs(sliceGraph);
   EXPECT_EQ(graph.writeEquivalenceRelationIntoVertices(graph.sccs), 3u);
 }
 

--- a/arangod/Pregel/tests/WeaklyConnectedComponentsTest.cpp
+++ b/arangod/Pregel/tests/WeaklyConnectedComponentsTest.cpp
@@ -27,6 +27,8 @@
 #include "WCCGraph.h"
 #include "GraphsSource.h"
 
+using namespace arangodb::slicegraph;
+
 TEST(GWEN_WCC, test_wcc_2_path) {
   bool const checkDuplicateVertices = true;
   WCCGraph<EmptyEdgeProperties, WCCVertexProperties> graph(


### PR DESCRIPTION
### Scope & Purpose

The following is copied from `SCCGraph.h`.

 The class is intended solely to compute SCCs. This is on-the-fly while reading graph edges. The algorithm is taken from the paper Laura, L., Santaroni, F. (2011). Computing Strongly Connected Components in the Streaming Model. In: Marchetti-Spaccamela, A., Segal, M. (eds) Theory and  Practice of Algorithms in (Computer) Systems. TAPAS 2011. Lecture Notes in
 Computer Science, vol 6595. Springer, Berlin, Heidelberg.  https://doi.org/10.1007/978-3-642-19754-3_20

#### Description of the algorithm

 The algorithm uses two data structures: UnionFind and a tree whose nodes are vertices that represent SCCs computed so far. The graph vertex that serves as a node in the tree is contained in the SCC it represents but is not necessarily the representative of the SCC which is returned for the SCC by the UnionFind.

 Globally, the run of the algorithm consists of a series of edge stream reads. The first edge stream comes from the input. It may produce the next stream, which is read and may produce the next stream and so on. While reading edges from a stream, the tree is updated. In some cases it signals that we found a cycle whose vertices are added to the corresponding SCC. The algorithm stops  when for a stream there were no tree updates (even if there is a remaining unread stream!).

 Initially, the vertices are read and put into UnionFind as singletons and into the tree as children of the auxiliary root. When an edge is read from a stream, we determine its type with respect to the tree: backward, forward or self-loop, cross forward or cross non-forward. Note that even if the graph has no self-loops, we may obtain a self-loop in the tree because its nodes represent (potentially non-trivial) strongly connected sets.

 The edges of the tree are thought of as going from the root to the leaves (for this description we ignore that in our implementation they are directed the other way around). Backward and forward edges connect nodes on the same
 tree branch: the backward ones go up the tree and the forward ones down the tree. Cross edges connect nodes in different branches. Cross (non-)forward edges go from a node to another node that has a (smaller) bigger height.

 Forward edges and self-loops are ignored. Backward edges mean that strongly connected sets of the graph represented by the nodes of the tree that are between the edge ends all belong to the same SCC. For such edges, the corresponding sets in UnionFind are merged and the (sub-)path of the tree between the edge ends is collapsed to one node. Cross forward edges are just added to the next steam, no tree update happens. Cross non-forward edges `(a,b)` constitute the most involved case. Let us say, `b`'s parent is `p`. (Then `p` is not `a` because `(a, b)` is a cross edge.) Then the tree edge `(p, b)` is replaced by the edge `(a, b)` and `(p, b)` is added to the next stream.

#### Complexity

 The authors of the paper claim that the time complexity of the algorithm is `O(h*m + (n*log n))` where `n` is the number of vertices, `m` the number of edges and `h` the maximal height of the tree that is reached during the algorithm run. Theoretically, the best known upper bound for `h` is `n`, however, the authors claim that in their experiments it is close to `log n`.

#### Discussion

 For the given practical upper bound, the asymptotic running time is by a factor of `log n` worse than that of a classical algorithm as, e.g., Tarjan's algorithm. The advantages are that 
(1) we can start computing while the edges are still being read and
(2) potentially we can parallelize the algorithm, see http://snap.stanford.edu/class/cs224w-2017/projects/cs224w-9-final.pdf.

#### Implementation details

 The constructor only reads the vertices of the graph because reading the edges is tightly associated with the first stream. The remainder is performed in the function `readEdgesBuildSCCs`. The first stream is read directly from the input in the member function `readEdges` from the parent class. It gets the function `onReadEdge`, which is passed as a parameter and is executed on each edge. The output is written into the next stream that is a queue.

 Back to `readEdgesBuildSCCs`, other streams are read from the input queue and the output is written into the output queue. The roles of the queues are switched between the iterations.

 The most involved function `edgeType` is described in the comments to the function: Returns the type of the edge. We run from both edge ends in parallel towards the root. The result depends on (1) which end (call it `X`) reaches the least common  predecessor (LCP, the intersecting point of both paths) first, and (2) if the other end (that reaches LCP later, call it `Y`) meets `X` itself or another node on the path from `X` to the root.

 Recall that tree edges go from a representative of the source scc to, in general, any vertex in the target scc.

- [x] :pizza: New feature
- [x] :fire: Performance improvement (possibly, to be tested)

### Checklist

- [x] C++ **Unit tests**

