### PR TITLE
[PREGEL] Bugfix: Lock future creation

### DIFF
--- a/arangod/Pregel/Conductor/States/ComputingState.cpp
+++ b/arangod/Pregel/Conductor/States/ComputingState.cpp
@@ -1,6 +1,5 @@
 #include "ComputingState.h"
 
-#include "Pregel/Algorithm.h"
 #include "Pregel/Conductor/Conductor.h"
 #include "Metrics/Gauge.h"
 #include "Pregel/MasterContext.h"
@@ -25,11 +24,6 @@ Computing::~Computing() {
 }
 
 auto Computing::run() -> std::optional<std::unique_ptr<State>> {
-  LOG_PREGEL_CONDUCTOR_STATE("76631", INFO)
-      << fmt::format("Start running Pregel {} with {} vertices, {} edges",
-                     conductor._algorithm->name(),
-                     conductor._totalVerticesCount, conductor._totalEdgesCount);
-
   conductor._timing.gss.emplace_back(Duration{
       ._start = std::chrono::steady_clock::now(), ._finish = std::nullopt});
 

--- a/arangod/Pregel/Conductor/States/LoadingState.cpp
+++ b/arangod/Pregel/Conductor/States/LoadingState.cpp
@@ -1,6 +1,7 @@
 #include "LoadingState.h"
 
 #include "Metrics/Gauge.h"
+#include "Pregel/Algorithm.h"
 #include "Pregel/Conductor/Conductor.h"
 #include "Pregel/MasterContext.h"
 #include "Pregel/PregelFeature.h"
@@ -51,6 +52,12 @@ auto Loading::receive(MessagePayload message)
                                          conductor._totalEdgesCount,
                                          conductor._aggregators.get());
   }
+
+  LOG_PREGEL_CONDUCTOR_STATE("76631", INFO)
+      << fmt::format("Start running Pregel {} with {} vertices, {} edges",
+                     conductor._algorithm->name(),
+                     conductor._totalVerticesCount, conductor._totalEdgesCount);
+
   return std::make_unique<Computing>(conductor, std::move(_workerApi));
 }
 


### PR DESCRIPTION
When sending messages from conductor to workers via worker api: Wrap lock around both future creation and getting the future because it is not defined when the future will resolve.
Additionally, improve some logging.