### PR TITLE
give the cluster fuzzer tests more resources

### DIFF
--- a/tests/test-definitions.txt
+++ b/tests/test-definitions.txt
@@ -116,7 +116,8 @@ audit_server -- --dumpAgencyOnError true
 
 
 # Full Tests Single Server
-shell_fuzzer full priority=500 -- --dumpAgencyOnError true
+shell_fuzzer full cluster priority=500 parallelity=6 -- --dumpAgencyOnError true
+shell_fuzzer full single priority=500 -- --dumpAgencyOnError true
 authentication_parameters single full priority=1000
 authentication_server single full priority=1000
 config single full priority=1000


### PR DESCRIPTION
### Scope & Purpose

The cluster fuzzer may create many shards and thus use more resources than an average cluster test.

- [x] :hankey: Bugfix
