### PR TITLE
Add an explicit compact API call for logs.

### DIFF
--- a/arangod/Replication2/Methods.cpp
+++ b/arangod/Replication2/Methods.cpp
@@ -201,6 +201,11 @@ struct ReplicatedLogMethodsDBServer final
     return {idx};
   }
 
+  auto compact(LogId id) const -> futures::Future<Result> {
+    auto log = vocbase.getReplicatedLogById(id);
+    return log->getParticipant()->compact();
+  }
+
   auto release(LogId id, LogIndex index) const
       -> futures::Future<Result> override {
     auto log = vocbase.getReplicatedLogById(id);
@@ -681,6 +686,46 @@ struct ReplicatedLogMethodsCoordinator final
                                 opts)
         .thenValue(
             [](network::Response&& resp) { return resp.combinedResult(); });
+  }
+
+  auto compact(LogId id) const -> futures::Future<Result> override {
+    auto spec = clusterInfo.getReplicatedLogPlanSpecification(id).get();
+
+    auto const compactParticipant =
+        [&](ParticipantId const& participant) -> futures::Future<Result> {
+      auto path = basics::StringUtils::joinT("/", "_api/log", id, "compact");
+      network::RequestOptions opts;
+      opts.database = vocbase.name();
+      opts.timeout = std::chrono::seconds{5};
+      VPackBufferUInt8 buffer;
+      {
+        VPackBuilder builder(buffer);
+        builder.add(VPackSlice::emptyObjectSlice());
+      }
+      return network::sendRequest(pool, "server:" + participant,
+                                  fuerte::RestVerb::Post, path, buffer, opts)
+          .thenValue([participant](network::Response&& resp) {
+            return resp.combinedResult().withError([&](auto& err) {
+              return err.appendErrorMessage("; compaction for participant " +
+                                            participant);
+            });
+          });
+    };
+
+    std::vector<futures::Future<Result>> futs;
+    for (auto const& [participant, p] : spec->participantsConfig.participants) {
+      futs.emplace_back(compactParticipant(participant));
+    }
+
+    return futures::collectAll(std::move(futs)).thenValue([](auto&& results) {
+      // return first error
+      for (auto const& tryRes : results) {
+        if (auto res = tryRes.get(); res.fail()) {
+          return res;
+        }
+      }
+      return Result{};
+    });
   }
 
   explicit ReplicatedLogMethodsCoordinator(TRI_vocbase_t& vocbase)

--- a/arangod/Replication2/Methods.h
+++ b/arangod/Replication2/Methods.h
@@ -130,6 +130,7 @@ struct ReplicatedLogMethods {
       -> futures::Future<LogIndex> = 0;
 
   virtual auto release(LogId, LogIndex) const -> futures::Future<Result> = 0;
+  virtual auto compact(LogId) const -> futures::Future<Result> = 0;
 
   /*
    * Wait until the supervision reports that the replicated log has converged

--- a/arangod/Replication2/ReplicatedLog/ILogInterfaces.h
+++ b/arangod/Replication2/ReplicatedLog/ILogInterfaces.h
@@ -89,6 +89,7 @@ struct ILogParticipant {
 
   [[nodiscard]] virtual auto copyInMemoryLog() const -> InMemoryLog = 0;
   [[nodiscard]] virtual auto release(LogIndex doneWithIdx) -> Result = 0;
+  [[nodiscard]] virtual auto compact() -> Result = 0;
 };
 
 /**

--- a/arangod/Replication2/ReplicatedLog/LogFollower.cpp
+++ b/arangod/Replication2/ReplicatedLog/LogFollower.cpp
@@ -686,6 +686,15 @@ auto LogFollower::copyInMemoryLog() const -> InMemoryLog {
   return _guardedFollowerData.getLockedGuard()->_inMemoryLog;
 }
 
+auto LogFollower::compact() -> Result {
+  auto guard = _guardedFollowerData.getLockedGuard();
+  auto compactionStop =
+      std::min(guard->_lowestIndexToKeep, guard->_releaseIndex + 1);
+  LOG_CTX("aed29", INFO, _loggerContext)
+      << "starting explicit compaction up to index " << compactionStop;
+  return guard->runCompaction(compactionStop);
+}
+
 auto replicated_log::LogFollower::GuardedFollowerData::getLocalStatistics()
     const noexcept -> LogStatistics {
   auto result = LogStatistics{};
@@ -708,6 +717,11 @@ auto LogFollower::GuardedFollowerData::checkCompaction() -> Result {
         << _inMemoryLog.getFirstIndex();
     return {};
   }
+  return runCompaction(compactionStop);
+}
+
+auto LogFollower::GuardedFollowerData::runCompaction(LogIndex compactionStop)
+    -> Result {
   auto const numberOfCompactedEntries =
       compactionStop.value - _inMemoryLog.getFirstIndex().value;
   auto newLog = _inMemoryLog.release(compactionStop);
@@ -721,6 +735,7 @@ auto LogFollower::GuardedFollowerData::checkCompaction() -> Result {
       << "compaction result = " << res.errorMessage();
   return res;
 }
+
 auto LogFollower::GuardedFollowerData::waitForResign()
     -> std::pair<futures::Future<futures::Unit>, DeferredAction> {
   if (!didResign()) {

--- a/arangod/Replication2/ReplicatedLog/LogFollower.h
+++ b/arangod/Replication2/ReplicatedLog/LogFollower.h
@@ -81,6 +81,7 @@ class LogFollower : public ILogFollower,
 
   [[nodiscard]] auto copyInMemoryLog() const -> InMemoryLog override;
   [[nodiscard]] auto release(LogIndex doneWithIdx) -> Result override;
+  [[nodiscard]] auto compact() -> Result override;
 
   /// @brief Resolved when the leader has committed at least one entry.
   auto waitForLeaderAcked() -> WaitForFuture override;
@@ -102,6 +103,7 @@ class LogFollower : public ILogFollower,
     [[nodiscard]] auto getCommittedLogIterator(LogIndex firstIndex) const
         -> std::unique_ptr<LogRangeIterator>;
     [[nodiscard]] auto checkCompaction() -> Result;
+    [[nodiscard]] auto runCompaction(LogIndex compactionStop) -> Result;
     auto checkCommitIndex(LogIndex newCommitIndex, LogIndex newLITK,
                           std::unique_ptr<WaitForQueue> outQueue) noexcept
         -> DeferredAction;

--- a/arangod/Replication2/ReplicatedLog/LogLeader.cpp
+++ b/arangod/Replication2/ReplicatedLog/LogLeader.cpp
@@ -996,6 +996,31 @@ auto replicated_log::LogLeader::release(LogIndex doneWithIdx) -> Result {
   });
 }
 
+auto replicated_log::LogLeader::compact() -> Result {
+  auto guard = _guardedLeaderData.getLockedGuard();
+  auto compactionStop =
+      std::min(guard->_lowestIndexToKeep, guard->_releaseIndex + 1);
+  LOG_CTX("01e09", INFO, _logContext)
+      << "starting explicit compaction up to index " << compactionStop;
+  return guard->runCompaction(compactionStop);
+}
+
+[[nodiscard]] auto replicated_log::LogLeader::GuardedLeaderData::runCompaction(
+    LogIndex compactionStop) -> Result {
+  auto const numberOfCompactedEntries =
+      compactionStop.value - _inMemoryLog.getFirstIndex().value;
+  auto newLog = _inMemoryLog.release(compactionStop);
+  auto res = _self._localFollower->release(compactionStop);
+  if (res.ok()) {
+    _inMemoryLog = std::move(newLog);
+    _self._logMetrics->replicatedLogNumberCompactedEntries->count(
+        numberOfCompactedEntries);
+  }
+  LOG_CTX("f1029", TRACE, _self._logContext)
+      << "compaction result = " << res.errorMessage();
+  return res;
+}
+
 auto replicated_log::LogLeader::GuardedLeaderData::checkCompaction() -> Result {
   auto const compactionStop = std::min(_lowestIndexToKeep, _releaseIndex + 1);
   LOG_CTX("080d6", TRACE, _self._logContext)
@@ -1010,18 +1035,7 @@ auto replicated_log::LogLeader::GuardedLeaderData::checkCompaction() -> Result {
     return {};
   }
 
-  auto const numberOfCompactedEntries =
-      compactionStop.value - _inMemoryLog.getFirstIndex().value;
-  auto newLog = _inMemoryLog.release(compactionStop);
-  auto res = _self._localFollower->release(compactionStop);
-  if (res.ok()) {
-    _inMemoryLog = std::move(newLog);
-    _self._logMetrics->replicatedLogNumberCompactedEntries->count(
-        numberOfCompactedEntries);
-  }
-  LOG_CTX("f1029", TRACE, _self._logContext)
-      << "compaction result = " << res.errorMessage();
-  return res;
+  return runCompaction(compactionStop);
 }
 
 auto replicated_log::LogLeader::GuardedLeaderData::calculateCommitLag()

--- a/arangod/Replication2/ReplicatedLog/LogLeader.h
+++ b/arangod/Replication2/ReplicatedLog/LogLeader.h
@@ -143,6 +143,7 @@ class LogLeader : public std::enable_shared_from_this<LogLeader>,
   [[nodiscard]] auto getParticipantId() const noexcept -> ParticipantId const&;
 
   [[nodiscard]] auto release(LogIndex doneWithIdx) -> Result override;
+  [[nodiscard]] auto compact() -> Result override;
 
   [[nodiscard]] auto copyInMemoryLog() const -> InMemoryLog override;
 
@@ -285,6 +286,7 @@ class LogLeader : public std::enable_shared_from_this<LogLeader>,
     [[nodiscard]] auto collectFollowerStates() const
         -> std::pair<LogIndex, std::vector<algorithms::ParticipantState>>;
     [[nodiscard]] auto checkCompaction() -> Result;
+    [[nodiscard]] auto runCompaction(LogIndex compactionStop) -> Result;
 
     [[nodiscard]] auto updateCommitIndexLeader(
         LogIndex newIndex, std::shared_ptr<QuorumData> quorum)

--- a/arangod/Replication2/ReplicatedLog/LogUnconfiguredParticipant.cpp
+++ b/arangod/Replication2/ReplicatedLog/LogUnconfiguredParticipant.cpp
@@ -74,6 +74,10 @@ auto LogUnconfiguredParticipant::release(LogIndex doneWithIdx) -> Result {
   THROW_ARANGO_EXCEPTION(TRI_ERROR_REPLICATION_REPLICATED_LOG_UNCONFIGURED);
 }
 
+auto LogUnconfiguredParticipant::compact() -> Result {
+  THROW_ARANGO_EXCEPTION(TRI_ERROR_REPLICATION_REPLICATED_LOG_UNCONFIGURED);
+}
+
 auto LogUnconfiguredParticipant::getCommitIndex() const noexcept -> LogIndex {
   return LogIndex{0};  // index 0 is always committed.
 }

--- a/arangod/Replication2/ReplicatedLog/LogUnconfiguredParticipant.h
+++ b/arangod/Replication2/ReplicatedLog/LogUnconfiguredParticipant.h
@@ -55,6 +55,7 @@ struct LogUnconfiguredParticipant final
       -> WaitForFuture override;
   [[nodiscard]] auto release(arangodb::replication2::LogIndex doneWithIdx)
       -> arangodb::Result override;
+  [[nodiscard]] auto compact() -> Result override;
   [[nodiscard]] auto waitForIterator(arangodb::replication2::LogIndex index)
       -> WaitForIteratorFuture override;
   [[nodiscard]] auto waitForResign() -> futures::Future<futures::Unit> override;

--- a/arangod/RestHandler/RestLogHandler.cpp
+++ b/arangod/RestHandler/RestLogHandler.cpp
@@ -97,6 +97,8 @@ RestStatus RestLogHandler::handlePostRequest(
     return handlePostInsert(methods, logId, body);
   } else if (verb == "release") {
     return handlePostRelease(methods, logId);
+  } else if (verb == "compact") {
+    return handlePostCompact(methods, logId);
   } else if (verb == "multi-insert") {
     return handlePostInsertMulti(methods, logId, body);
   } else {
@@ -192,6 +194,17 @@ RestStatus RestLogHandler::handlePostRelease(
           generateOk(rest::ResponseCode::ACCEPTED, VPackSlice::noneSlice());
         }
       }));
+}
+
+RestStatus RestLogHandler::handlePostCompact(
+    ReplicatedLogMethods const& methods, replication2::LogId logId) {
+  return waitForFuture(methods.compact(logId).thenValue([this](Result&& res) {
+    if (res.fail()) {
+      generateError(res);
+    } else {
+      generateOk(rest::ResponseCode::ACCEPTED, VPackSlice::noneSlice());
+    }
+  }));
 }
 
 RestStatus RestLogHandler::handlePost(ReplicatedLogMethods const& methods,

--- a/arangod/RestHandler/RestLogHandler.h
+++ b/arangod/RestHandler/RestLogHandler.h
@@ -61,6 +61,9 @@ class RestLogHandler : public RestVocbaseBaseHandler {
   RestStatus handlePostRelease(
       replication2::ReplicatedLogMethods const& methods,
       replication2::LogId logId);
+  RestStatus handlePostCompact(
+      replication2::ReplicatedLogMethods const& methods,
+      replication2::LogId logId);
 
   RestStatus handleGet(replication2::ReplicatedLogMethods const& methods);
   RestStatus handleGetPoll(replication2::ReplicatedLogMethods const& methods,

--- a/arangod/V8Server/v8-replicated-logs.cpp
+++ b/arangod/V8Server/v8-replicated-logs.cpp
@@ -599,7 +599,7 @@ static void JS_Compact(v8::FunctionCallbackInfo<v8::Value> const& args) {
 
   LogIndex index;
   if (args.Length() != 0) {
-    TRI_V8_THROW_EXCEPTION_USAGE("release()");
+    TRI_V8_THROW_EXCEPTION_USAGE("compact()");
   }
 
   auto result =

--- a/arangod/V8Server/v8-replicated-logs.cpp
+++ b/arangod/V8Server/v8-replicated-logs.cpp
@@ -585,6 +585,31 @@ static void JS_Release(v8::FunctionCallbackInfo<v8::Value> const& args) {
   TRI_V8_TRY_CATCH_END
 }
 
+static void JS_Compact(v8::FunctionCallbackInfo<v8::Value> const& args) {
+  TRI_V8_TRY_CATCH_BEGIN(isolate);
+
+  v8::HandleScope scope(isolate);
+  auto& vocbase = GetContextVocBase(isolate);
+  auto id = UnwrapReplicatedLog(isolate, args.Holder());
+  if (!arangodb::ExecContext::current().isAdminUser()) {
+    TRI_V8_THROW_EXCEPTION_MESSAGE(
+        TRI_ERROR_FORBIDDEN,
+        std::string("No access to replicated log '") + to_string(id) + "'");
+  }
+
+  LogIndex index;
+  if (args.Length() != 0) {
+    TRI_V8_THROW_EXCEPTION_USAGE("release()");
+  }
+
+  auto result =
+      ReplicatedLogMethods::createInstance(vocbase)->compact(id).get();
+  if (result.fail()) {
+    THROW_ARANGO_EXCEPTION(result);
+  }
+  TRI_V8_TRY_CATCH_END
+}
+
 void TRI_InitV8ReplicatedLogs(TRI_v8_global_t* v8g, v8::Isolate* isolate) {
   auto db = v8::Local<v8::ObjectTemplate>::New(isolate, v8g->VocbaseTempl);
   TRI_AddMethodVocbase(isolate, db,
@@ -624,6 +649,8 @@ void TRI_InitV8ReplicatedLogs(TRI_v8_global_t* v8g, v8::Isolate* isolate) {
   TRI_AddMethodVocbase(isolate, rt, TRI_V8_ASCII_STRING(isolate, "at"), JS_At);
   TRI_AddMethodVocbase(isolate, rt, TRI_V8_ASCII_STRING(isolate, "release"),
                        JS_Release);
+  TRI_AddMethodVocbase(isolate, rt, TRI_V8_ASCII_STRING(isolate, "compact"),
+                       JS_Compact);
   TRI_AddMethodVocbase(isolate, rt, TRI_V8_ASCII_STRING(isolate, "poll"),
                        JS_Poll);
 

--- a/js/client/modules/@arangodb/replicated-logs.js
+++ b/js/client/modules/@arangodb/replicated-logs.js
@@ -139,6 +139,11 @@ ArangoReplicatedLog.prototype.release = function(index) {
   arangosh.checkRequestResult(requestResult);
 };
 
+ArangoReplicatedLog.prototype.compact = function() {
+  let requestResult = this._database._connection.POST(this._baseurl() + `/compact`, {});
+  arangosh.checkRequestResult(requestResult);
+};
+
 ArangoReplicatedLog.prototype.insert = function (payload, {waitForSync = false, dontWaitForCommit = false} = {}) {
   let str = JSON.stringify(payload);
   let requestResult = this._database._connection.POST(this._baseurl() + `/insert?waitForSync=${waitForSync}&dontWaitForCommit=${dontWaitForCommit}`, str);

--- a/tests/Replication2/Mocks/AsyncFollower.cpp
+++ b/tests/Replication2/Mocks/AsyncFollower.cpp
@@ -55,6 +55,8 @@ auto AsyncFollower::release(arangodb::replication2::LogIndex doneWithIdx)
   return _follower->release(doneWithIdx);
 }
 
+auto AsyncFollower::compact() -> Result { return _follower->compact(); }
+
 auto AsyncFollower::getParticipantId() const noexcept -> ParticipantId const& {
   return _follower->getParticipantId();
 }

--- a/tests/Replication2/Mocks/AsyncFollower.h
+++ b/tests/Replication2/Mocks/AsyncFollower.h
@@ -41,6 +41,7 @@ struct AsyncFollower : replicated_log::ILogFollower {
                                  DeferredAction> override;
   auto waitFor(LogIndex index) -> WaitForFuture override;
   auto release(LogIndex doneWithIdx) -> Result override;
+  auto compact() -> Result override;
   [[nodiscard]] auto getParticipantId() const noexcept
       -> ParticipantId const& override;
   auto appendEntries(replicated_log::AppendEntriesRequest request)

--- a/tests/Replication2/Mocks/AsyncLeader.cpp
+++ b/tests/Replication2/Mocks/AsyncLeader.cpp
@@ -53,6 +53,7 @@ replication2::LogIndex test::AsyncLeader::getCommitIndex() const noexcept {
 Result test::AsyncLeader::release(replication2::LogIndex doneWithIdx) {
   return _leader->release(doneWithIdx);
 }
+Result test::AsyncLeader::compact() { return _leader->compact(); }
 replication2::LogIndex test::AsyncLeader::insert(
     replication2::LogPayload payload, bool waitForSync) {
   return _leader->insert(payload, waitForSync);

--- a/tests/Replication2/Mocks/AsyncLeader.h
+++ b/tests/Replication2/Mocks/AsyncLeader.h
@@ -49,6 +49,7 @@ struct AsyncLeader : replicated_log::ILogLeader,
   auto waitForResign() -> futures::Future<futures::Unit> override;
   [[nodiscard]] auto getCommitIndex() const noexcept -> LogIndex override;
   auto release(LogIndex doneWithIdx) -> Result override;
+  auto compact() -> Result override;
   auto insert(LogPayload payload, bool waitForSync) -> LogIndex override;
   auto insert(LogPayload payload, bool waitForSync,
               DoNotTriggerAsyncReplication replication) -> LogIndex override;

--- a/tests/Replication2/Mocks/FakeFollower.h
+++ b/tests/Replication2/Mocks/FakeFollower.h
@@ -49,6 +49,9 @@ struct FakeFollower final : replicated_log::ILogFollower,
   auto getCommitIndex() const noexcept -> LogIndex override;
 
   auto release(LogIndex doneWithIdx) -> Result override;
+  auto compact() -> Result override {
+    THROW_ARANGO_EXCEPTION(TRI_ERROR_NOT_IMPLEMENTED);
+  }
 
   auto waitForLeaderAcked() -> WaitForFuture override;
 

--- a/tests/Replication2/Mocks/FakeLeader.h
+++ b/tests/Replication2/Mocks/FakeLeader.h
@@ -51,6 +51,9 @@ struct FakeLeader final : replicated_log::ILogLeader,
   void triggerAsyncReplication() override;
   auto isLeadershipEstablished() const noexcept -> bool override;
   auto waitForLeadership() -> WaitForFuture override;
+  auto compact() -> Result override {
+    THROW_ARANGO_EXCEPTION(TRI_ERROR_NOT_IMPLEMENTED);
+  }
 
   template<typename State>
   auto insertMultiplexedValue(typename State::EntryType const& t) -> LogIndex {

--- a/tests/Replication2/Mocks/FakeReplicatedLog.h
+++ b/tests/Replication2/Mocks/FakeReplicatedLog.h
@@ -145,6 +145,7 @@ struct DelayedFollowerLog : replicated_log::AbstractFollower,
   auto release(LogIndex doneWithIdx) -> Result override {
     return _follower->release(doneWithIdx);
   }
+  auto compact() -> Result override { return _follower->compact(); }
 
  private:
   Guarded<std::deque<std::shared_ptr<AsyncRequest>>> _asyncQueue;

--- a/tests/js/common/shell/shell-replicated-logs-cluster.js
+++ b/tests/js/common/shell/shell-replicated-logs-cluster.js
@@ -254,6 +254,20 @@ function ReplicatedLogsWriteSuite() {
       assertEqual(s2.local.firstIndex, 1501);
     },
 
+    testCompact: function () {
+      for (let i = 0; i < 100; i++) {
+        log.insert({foo: i});
+      }
+      const s1 = getLeaderStatus();
+      assertEqual(s1.local.firstIndex, 1);
+      log.release(100);
+      const s2 = getLeaderStatus();
+      assertEqual(s2.local.firstIndex, 1);
+      log.compact();
+      const s3 = getLeaderStatus();
+      assertEqual(s3.local.firstIndex, 101);
+    },
+
     testPoll: function () {
       let index = 0;
       for (let i = 0; i < 100; i++) {


### PR DESCRIPTION
### Scope & Purpose
This PR adds an explicit `compact` API. When this api is called, all participants compact as many log entries as possible. Compaction might be blocked by the state machine. 

If called on a coordinator, the request is forwarded to all participants.