### PR TITLE
[PREGEL] In conductor states: put incoming messages in queue

### DIFF
--- a/arangod/Pregel/Conductor/Conductor.cpp
+++ b/arangod/Pregel/Conductor/Conductor.cpp
@@ -181,10 +181,7 @@ Conductor::~Conductor() {
   _feature.metrics()->pregelConductorsNumber->fetch_sub(1);
 }
 
-void Conductor::start() {
-  MUTEX_LOCKER(guard, _callbackMutex);
-  _run();
-}
+void Conductor::start() { _run(); }
 
 auto Conductor ::_postGlobalSuperStep() -> PostGlobalSuperStepResult {
   // workers are done if all messages were processed and no active vertices
@@ -337,10 +334,7 @@ std::vector<ShardID> Conductor::getShardIds(ShardID const& collection) const {
 }
 
 auto Conductor::receive(MessagePayload message) -> void {
-  auto newState = _state->receive(message);
-  if (newState.has_value()) {
-    _changeState(std::move(newState.value()));
-  }
+  _state->receive(message);
 }
 
 auto Conductor::_run() -> void {

--- a/arangod/Pregel/Conductor/States/CanceledState.h
+++ b/arangod/Pregel/Conductor/States/CanceledState.h
@@ -39,8 +39,7 @@ struct Canceled : State {
   Canceled(Conductor& conductor, WorkerApi<CleanupFinished>&& workerApi);
   ~Canceled() = default;
   auto run() -> std::optional<std::unique_ptr<State>> override;
-  auto receive(MessagePayload message)
-      -> std::optional<std::unique_ptr<State>> override;
+  auto receive(MessagePayload message) -> void override;
   auto cancel() -> std::optional<std::unique_ptr<State>> override {
     return std::nullopt;
   }

--- a/arangod/Pregel/Conductor/States/ComputingState.cpp
+++ b/arangod/Pregel/Conductor/States/ComputingState.cpp
@@ -1,5 +1,7 @@
 #include "ComputingState.h"
+#include <cstdint>
 
+#include "Cluster/ClusterTypes.h"
 #include "Pregel/Conductor/Conductor.h"
 #include "Metrics/Gauge.h"
 #include "Pregel/MasterContext.h"
@@ -7,20 +9,18 @@
 
 using namespace arangodb::pregel::conductor;
 
+Computing::Computing(Conductor& conductor, SendCountPerServer count,
+                     WorkerApi<GlobalSuperStepFinished>&& workerApi)
+    : conductor{conductor},
+      _sendCountPerServer{std::move(count)},
+      _workerApi{std::move(workerApi)} {}
+
 Computing::Computing(Conductor& conductor,
                      WorkerApi<GlobalSuperStepFinished>&& workerApi)
-    : conductor{conductor}, _workerApi{std::move(workerApi)} {
-  if (!conductor._timing.computation.hasStarted()) {
-    conductor._timing.computation.start();
-  }
-  conductor._feature.metrics()->pregelConductorsRunningNumber->fetch_add(1);
-}
 
-Computing::~Computing() {
-  if (!conductor._timing.computation.hasFinished()) {
-    conductor._timing.computation.finish();
-  }
-  conductor._feature.metrics()->pregelConductorsRunningNumber->fetch_sub(1);
+    : conductor{conductor}, _workerApi{std::move(workerApi)} {
+  conductor._timing.computation.start();
+  conductor._feature.metrics()->pregelConductorsRunningNumber->fetch_add(1);
 }
 
 auto Computing::run() -> std::optional<std::unique_ptr<State>> {
@@ -39,37 +39,22 @@ auto Computing::run() -> std::optional<std::unique_ptr<State>> {
     LOG_PREGEL_CONDUCTOR_STATE("f34bb", ERR) << sent.errorMessage();
     return std::make_unique<FatalError>(conductor, std::move(_workerApi));
   }
-  return std::nullopt;
-}
 
-auto Computing::receive(MessagePayload message)
-    -> std::optional<std::unique_ptr<State>> {
-  auto explicitMessage = getResultTMessage<GlobalSuperStepFinished>(message);
-  if (explicitMessage.fail()) {
-    LOG_PREGEL_CONDUCTOR_STATE("7698e", ERR) << explicitMessage.errorMessage();
+  auto aggregate = _workerApi.aggregateAllResponses();
+  if (aggregate.fail()) {
+    LOG_PREGEL_CONDUCTOR_STATE("ff1000", ERR) << aggregate.errorMessage();
     return std::make_unique<FatalError>(conductor, std::move(_workerApi));
   }
 
-  auto aggregatedMessage = _workerApi.collect(explicitMessage.get());
-  if (!aggregatedMessage.has_value()) {
-    return std::nullopt;
-  }
-
-  auto messageValue = aggregatedMessage.value();
-  conductor._statistics.accumulate(messageValue.messageStats);
+  auto workerData = aggregate.get();
+  conductor._statistics.accumulate(workerData.messageStats);
   conductor._aggregators->resetValues();
-  for (auto aggregator : VPackArrayIterator(messageValue.aggregators.slice())) {
+  for (auto aggregator : VPackArrayIterator(workerData.aggregators.slice())) {
     conductor._aggregators->aggregateValues(aggregator);
   }
-  conductor._statistics.setActiveCounts(messageValue.activeCount);
-  conductor._totalVerticesCount = messageValue.vertexCount;
-  conductor._totalEdgesCount = messageValue.edgeCount;
-  auto sendCountPerServer = std::unordered_map<ServerID, uint64_t>{};
-  for (auto const& [shard, counts] : messageValue.sendCountPerShard) {
-    sendCountPerServer[conductor._leadingServerForShard[shard]] += counts;
-  }
-  _sendCountPerServer = _transformSendCountFromShardToServer(
-      std::move(messageValue.sendCountPerShard));
+  conductor._statistics.setActiveCounts(workerData.activeCount);
+  conductor._totalVerticesCount = workerData.vertexCount;
+  conductor._totalEdgesCount = workerData.edgeCount;
 
   auto post = conductor._postGlobalSuperStep();
 
@@ -82,6 +67,9 @@ auto Computing::receive(MessagePayload message)
     if (conductor._masterContext) {
       conductor._masterContext->postApplication();
     }
+    conductor._timing.computation.finish();
+    conductor._feature.metrics()->pregelConductorsRunningNumber->fetch_sub(1);
+
     if (conductor._storeResults) {
       return std::make_unique<Storing>(conductor, std::move(_workerApi));
     }
@@ -89,7 +77,18 @@ auto Computing::receive(MessagePayload message)
   }
 
   conductor._globalSuperstep++;
-  return run();
+  return std::make_unique<Computing>(
+      conductor,
+      _transformSendCountFromShardToServer(
+          std::move(workerData.sendCountPerShard)),
+      std::move(_workerApi));
+}
+
+auto Computing::receive(MessagePayload message) -> void {
+  auto queued = _workerApi.queue(message);
+  if (queued.fail()) {
+    LOG_PREGEL_CONDUCTOR_STATE("7698e", ERR) << queued.errorMessage();
+  }
 }
 
 auto Computing::cancel() -> std::optional<std::unique_ptr<State>> {

--- a/arangod/Pregel/Conductor/States/ComputingState.h
+++ b/arangod/Pregel/Conductor/States/ComputingState.h
@@ -32,13 +32,17 @@ class Conductor;
 namespace conductor {
 
 struct Computing : State {
+ private:
+  using SendCountPerServer = std::unordered_map<ServerID, uint64_t>;
+
+ public:
   Conductor& conductor;
   Computing(Conductor& conductor,
             WorkerApi<GlobalSuperStepFinished>&& workerApi);
-  ~Computing();
+  Computing(Conductor& conductor, SendCountPerServer count,
+            WorkerApi<GlobalSuperStepFinished>&& workerApi);
   auto run() -> std::optional<std::unique_ptr<State>> override;
-  auto receive(MessagePayload message)
-      -> std::optional<std::unique_ptr<State>> override;
+  auto receive(MessagePayload message) -> void override;
   auto cancel() -> std::optional<std::unique_ptr<State>> override;
   auto name() const -> std::string override { return "running"; };
   auto isRunning() const -> bool override { return true; }
@@ -48,8 +52,8 @@ struct Computing : State {
   }
 
  private:
-  WorkerApi<GlobalSuperStepFinished> _workerApi;
   std::unordered_map<ServerID, uint64_t> _sendCountPerServer;
+  WorkerApi<GlobalSuperStepFinished> _workerApi;
   auto _runGlobalSuperStepCommand() const
       -> std::unordered_map<ServerID, RunGlobalSuperStep>;
   auto _runGlobalSuperStep() -> futures::Future<Result>;

--- a/arangod/Pregel/Conductor/States/FatalErrorState.h
+++ b/arangod/Pregel/Conductor/States/FatalErrorState.h
@@ -39,13 +39,6 @@ struct FatalError : State {
   auto run() -> std::optional<std::unique_ptr<State>> override {
     return std::nullopt;
   };
-  // This is a final error state: This state can receive any message that was
-  // supposed to be handled by another state and this state needs to ignore them
-  // in the receive fct.
-  auto receive(MessagePayload message)
-      -> std::optional<std::unique_ptr<State>> override {
-    return std::nullopt;
-  };
   auto cancel() -> std::optional<std::unique_ptr<State>> override;
   auto getResults(bool withId) -> ResultT<PregelResults> override;
   auto name() const -> std::string override { return "fatal error"; };

--- a/arangod/Pregel/Conductor/States/InitialState.h
+++ b/arangod/Pregel/Conductor/States/InitialState.h
@@ -36,8 +36,7 @@ struct Initial : State {
   Initial(Conductor& conductor, WorkerApi<WorkerCreated>&& workerApi);
   ~Initial() = default;
   auto run() -> std::optional<std::unique_ptr<State>> override;
-  auto receive(MessagePayload message)
-      -> std::optional<std::unique_ptr<State>> override;
+  auto receive(MessagePayload message) -> void override;
   auto cancel() -> std::optional<std::unique_ptr<State>> override {
     return std::nullopt;
   }

--- a/arangod/Pregel/Conductor/States/LoadingState.h
+++ b/arangod/Pregel/Conductor/States/LoadingState.h
@@ -36,8 +36,7 @@ struct Loading : State {
   Loading(Conductor& conductor, WorkerApi<GraphLoaded>&& workerApi);
   ~Loading();
   auto run() -> std::optional<std::unique_ptr<State>> override;
-  auto receive(MessagePayload message)
-      -> std::optional<std::unique_ptr<State>> override;
+  auto receive(MessagePayload message) -> void override;
   auto cancel() -> std::optional<std::unique_ptr<State>> override;
   auto name() const -> std::string override { return "loading"; };
   auto isRunning() const -> bool override { return true; }

--- a/arangod/Pregel/Conductor/States/State.h
+++ b/arangod/Pregel/Conductor/States/State.h
@@ -45,10 +45,7 @@ namespace conductor {
 
 struct State {
   virtual auto run() -> std::optional<std::unique_ptr<State>> = 0;
-  virtual auto receive(MessagePayload message)
-      -> std::optional<std::unique_ptr<State>> {
-    return std::nullopt;
-  }
+  virtual auto receive(MessagePayload message) -> void {}
   virtual auto cancel() -> std::optional<std::unique_ptr<State>> = 0;
   virtual auto getResults(bool withId) -> ResultT<PregelResults> {
     VPackBuilder emptyArray;

--- a/arangod/Pregel/Conductor/States/StoringState.h
+++ b/arangod/Pregel/Conductor/States/StoringState.h
@@ -36,8 +36,7 @@ struct Storing : State {
   Storing(Conductor& conductor, WorkerApi<Stored>&& workerApi);
   ~Storing();
   auto run() -> std::optional<std::unique_ptr<State>> override;
-  auto receive(MessagePayload message)
-      -> std::optional<std::unique_ptr<State>> override;
+  auto receive(MessagePayload message) -> void override;
   auto cancel() -> std::optional<std::unique_ptr<State>> override;
   auto name() const -> std::string override { return "storing"; };
   auto isRunning() const -> bool override { return true; }

--- a/arangod/Pregel/Messaging/Message.h
+++ b/arangod/Pregel/Messaging/Message.h
@@ -92,18 +92,4 @@ auto inspect(Inspector& f, ModernMessage& x) {
       f.field("payload", x.payload));
 }
 
-template<typename T>
-auto getResultTMessage(MessagePayload const& message) -> ResultT<T> {
-  if (!std::holds_alternative<ResultT<T>>(message)) {
-    return Result{TRI_ERROR_INTERNAL, "Received unexpected message type"};
-  }
-  auto expectedMessage = std::get<ResultT<T>>(message);
-  if (expectedMessage.fail()) {
-    return Result{expectedMessage.errorNumber(),
-                  fmt::format("Got unsuccessful message: {}",
-                              expectedMessage.errorMessage())};
-  }
-  return expectedMessage.get();
-}
-
 }  // namespace arangodb::pregel

--- a/arangod/Pregel/Messaging/MessageQueue.h
+++ b/arangod/Pregel/Messaging/MessageQueue.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <condition_variable>
+#include <deque>
+#include <mutex>
+
+namespace arangodb::pregel {
+
+// The pop-fct of this queue blocks if the queue is empty and returns a value as
+// soon as a new value is pushed into the queue.
+
+template<typename T>
+struct MessageQueue {
+ public:
+  auto push(T message) -> void {
+    {
+      std::lock_guard lk(m);
+      _queue.emplace_back(message);
+      pushed = true;
+    }
+    cv.notify_one();
+  }
+  auto pop() -> T {
+    std::unique_lock lk(m);
+    if (_queue.empty()) {
+      do {
+        cv.wait(lk, [&] { return pushed; });
+      } while (!pushed);
+    }
+    pushed = false;
+    auto message = _queue.front();
+    _queue.pop_front();
+    return message;
+  }
+
+ private:
+  std::deque<T> _queue = {};
+  std::mutex m;
+  std::condition_variable cv;
+  bool pushed = false;
+};
+}  // namespace arangodb::pregel

--- a/arangod/Pregel/PregelFeature.cpp
+++ b/arangod/Pregel/PregelFeature.cpp
@@ -688,11 +688,8 @@ auto PregelFeature::apply(ExecutionNumber const& executionNumber,
               if (!w) {
                 return workerNotFound(executionNumber, message);
               }
-              scheduler->queue(
-                  RequestLane::INTERNAL_LOW, [w = w->shared_from_this()] {
-                    w->send(WorkerCreated{
-                        .senderId = ServerState::instance()->getId()});
-                  });
+              w->send(
+                  WorkerCreated{.senderId = ServerState::instance()->getId()});
               return {Ok{}};
             } catch (basics::Exception& e) {
               return Result{e.code(), e.message()};
@@ -739,10 +736,7 @@ auto PregelFeature::apply(ExecutionNumber const& executionNumber,
               // started
               return {CleanupFinished{}};
             }
-            scheduler->queue(RequestLane::INTERNAL_LOW,
-                             [w = w->shared_from_this(), x = std::move(x)] {
-                               w->send(w->cleanup(x));
-                             });
+            w->send(w->cleanup(x));
             return {Ok{}};
           },
           [&](CollectPregelResults const& x) -> ResultT<MessagePayload> {
@@ -773,10 +767,7 @@ auto PregelFeature::apply(ExecutionNumber const& executionNumber,
             if (!c) {
               return conductorNotFound(executionNumber, message);
             }
-            scheduler->queue(RequestLane::INTERNAL_LOW,
-                             [c = c->shared_from_this(), x = std::move(x)] {
-                               c->receive(x);
-                             });
+            c->receive(x);
             return {Ok{}};
           },
           [&](ResultT<GraphLoaded> const& x) -> ResultT<MessagePayload> {
@@ -784,10 +775,7 @@ auto PregelFeature::apply(ExecutionNumber const& executionNumber,
             if (!c) {
               return conductorNotFound(executionNumber, message);
             }
-            scheduler->queue(RequestLane::INTERNAL_LOW,
-                             [c = c->shared_from_this(), x = std::move(x)] {
-                               c->receive(x);
-                             });
+            c->receive(x);
             return {Ok{}};
           },
           [&](ResultT<GlobalSuperStepFinished> const& x)
@@ -796,10 +784,7 @@ auto PregelFeature::apply(ExecutionNumber const& executionNumber,
             if (!c) {
               return conductorNotFound(executionNumber, message);
             }
-            scheduler->queue(RequestLane::INTERNAL_LOW,
-                             [c = c->shared_from_this(), x = std::move(x)] {
-                               c->receive(x);
-                             });
+            c->receive(x);
             return {Ok{}};
           },
           [&](ResultT<Stored> const& x) -> ResultT<MessagePayload> {
@@ -807,10 +792,7 @@ auto PregelFeature::apply(ExecutionNumber const& executionNumber,
             if (!c) {
               return conductorNotFound(executionNumber, message);
             }
-            scheduler->queue(RequestLane::INTERNAL_LOW,
-                             [c = c->shared_from_this(), x = std::move(x)] {
-                               c->receive(x);
-                             });
+            c->receive(x);
             return {Ok{}};
           },
           [&](ResultT<CleanupFinished> const& x) -> ResultT<MessagePayload> {
@@ -819,10 +801,7 @@ auto PregelFeature::apply(ExecutionNumber const& executionNumber,
               // garbage collection already deleted the conductor
               return {Ok{}};
             }
-            scheduler->queue(RequestLane::INTERNAL_LOW,
-                             [c = c->shared_from_this(), x = std::move(x)] {
-                               c->receive(x);
-                             });
+            c->receive(x);
             return {Ok{}};
           },
           [&](auto const& x) -> ResultT<MessagePayload> {

--- a/tests/Pregel/Messaging/CMakeLists.txt
+++ b/tests/Pregel/Messaging/CMakeLists.txt
@@ -1,9 +1,11 @@
 target_sources(arangodbtests PRIVATE
   MessageTest.cpp
-  AggregateTest.cpp)
+  AggregateTest.cpp
+  MessageQueueTest.cpp)
 
 if (USE_SEPARATE_PREGEL_TESTS_BINARY)
   target_sources(arangodbtests_pregel PRIVATE
     MessageTest.cpp
-    AggregateTest.cpp)
+    AggregateTest.cpp
+    MessageQueueTest.cpp)
 endif()

--- a/tests/Pregel/Messaging/MessageQueueTest.cpp
+++ b/tests/Pregel/Messaging/MessageQueueTest.cpp
@@ -1,0 +1,49 @@
+#include <thread>
+#include "gtest/gtest.h"
+
+#include "Pregel/Messaging/MessageQueue.h"
+
+using namespace arangodb;
+using namespace arangodb::pregel;
+
+TEST(PregelMessageQueue, pops_first_item) {
+  auto queue = MessageQueue<int>{};
+  queue.push(2);
+  queue.push(3);
+  ASSERT_EQ(queue.pop(), 2);
+  ASSERT_EQ(queue.pop(), 3);
+}
+
+TEST(PregelMessageQueue, pushes_item) {
+  auto queue = MessageQueue<int>{};
+  queue.push(6);
+  ASSERT_EQ(queue.pop(), 6);
+}
+
+TEST(PregelMessageQueue, pushes_item_at_end) {
+  auto queue = MessageQueue<int>{};
+  queue.push(3);
+  queue.push(6);
+  ASSERT_EQ(queue.pop(), 3);
+  ASSERT_EQ(queue.pop(), 6);
+}
+
+TEST(PregelMessageQueue, waits_for_item_if_queue_is_empty) {
+  using namespace std::chrono_literals;
+  auto queue = MessageQueue<int>{};
+  queue.push(9);
+  std::jthread other_thread([&]() {
+    std::this_thread::sleep_for(1000ms);
+    queue.push(3);
+  });
+  ASSERT_EQ(queue.pop(), 9);
+  ASSERT_EQ(queue.pop(), 3);
+}
+
+TEST(PregelMessageQueue, can_push_from_front_and_pop_to_back_simulatneously) {
+  auto queue = MessageQueue<int>{};
+  queue.push(5);
+  std::jthread other_thread([&]() { queue.push(8); });
+  ASSERT_EQ(queue.pop(), 5);
+  ASSERT_EQ(queue.pop(), 8);
+}


### PR DESCRIPTION
This PR puts all messages that a the conductor state receives into a new message queue. The run function in the state processes each message in the queue synchronously, aggregates these messages and changes into a new state if all expected messages arrived (in the `WorkerApi::aggregateAllResponses` function). This way, we don't need any mutex inside the state (before we used a `Guarded<Aggregate<T>>` inside the WorkerApi that is part of each state). The receive function in the state is now very simple and only adds the message to the queue and cannot change the state any more.
The PR also changes the Computing state a bit: Now for each gss step a new Computation state is created.