### PR TITLE
Fixed issue #17394

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,7 @@
 devel
 -----
 
-* Fixed issue #17934: Unnecessary document-lookup instead of Index-Only query.
+* Fixed issue #17394: Unnecessary document-lookup instead of Index-Only query.
   This change improves projection handling so that more projections can be
   served from indexes.
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 devel
 -----
 
+* Fixed issue #17934: Unnecessary document-lookup instead of Index-Only query.
+  This change improves projection handling so that more projections can be
+  served from indexes.
+
 * Updated arangosync to v2.13.0-preview-2.
 
 * BTS-1070: Fixed query explain not dealing with an aggregate function without

--- a/arangod/Aql/AttributeNamePath.cpp
+++ b/arangod/Aql/AttributeNamePath.cpp
@@ -27,6 +27,7 @@
 #include "Basics/fasthash.h"
 
 #include <algorithm>
+#include <iostream>
 
 namespace arangodb {
 namespace aql {
@@ -136,6 +137,15 @@ AttributeNamePath& AttributeNamePath::shortenTo(size_t length) {
     ++numEqual;
   }
   return numEqual;
+}
+
+std::ostream& operator<<(std::ostream& stream, AttributeNamePath const& path) {
+  stream << "[";
+  for (auto const& it : path.path) {
+    stream << ' ' << it;
+  }
+  stream << " ]";
+  return stream;
 }
 
 }  // namespace aql

--- a/arangod/Aql/AttributeNamePath.h
+++ b/arangod/Aql/AttributeNamePath.h
@@ -24,6 +24,7 @@
 #pragma once
 
 #include <functional>
+#include <iosfwd>
 #include <string>
 #include <vector>
 
@@ -96,6 +97,8 @@ struct AttributeNamePath {
 
   std::vector<std::string> path;
 };
+
+std::ostream& operator<<(std::ostream& stream, AttributeNamePath const& path);
 
 }  // namespace arangodb::aql
 

--- a/arangod/Aql/Projections.cpp
+++ b/arangod/Aql/Projections.cpp
@@ -29,11 +29,14 @@
 #include "Transaction/Helpers.h"
 #include "Transaction/Methods.h"
 
+#include "Logger/LogMacros.h"
+
 #include <velocypack/Builder.h>
 #include <velocypack/Iterator.h>
 #include <velocypack/Slice.h>
 
 #include <algorithm>
+#include <iostream>
 
 namespace {
 
@@ -42,12 +45,11 @@ constexpr std::string_view projectionsKey("projections");
 
 }  // namespace
 
-namespace arangodb {
-namespace aql {
+namespace arangodb::aql {
 
 Projections::Projections() {}
 
-Projections::Projections(std::vector<arangodb::aql::AttributeNamePath> paths) {
+Projections::Projections(std::vector<AttributeNamePath> paths) {
   _projections.reserve(paths.size());
   for (auto& path : paths) {
     if (path.empty()) {
@@ -58,10 +60,17 @@ Projections::Projections(std::vector<arangodb::aql::AttributeNamePath> paths) {
     // categorize the projection, based on the attribute name.
     // we do this here only once in order to not do expensive string
     // comparisons at runtime later
-    arangodb::aql::AttributeNamePath::Type type = path.type();
+    AttributeNamePath::Type type = path.type();
+    size_t length = path.size();
+    if (length >= std::numeric_limits<uint16_t>::max()) {
+      THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_BAD_PARAMETER,
+                                     "attribute path too long for projection");
+    }
     // take over the projection
     _projections.emplace_back(
-        Projection{std::move(path), kNoCoveringIndexPosition, 0, type});
+        Projection{std::move(path), kNoCoveringIndexPosition,
+                   /*coveringIndexCutoff*/ 0, /*startsAtLevel*/ 0,
+                   /*levelsToClose*/ static_cast<uint16_t>(length - 1), type});
   }
 
   TRI_ASSERT(_projections.size() <= paths.size());
@@ -69,8 +78,7 @@ Projections::Projections(std::vector<arangodb::aql::AttributeNamePath> paths) {
   init();
 }
 
-Projections::Projections(
-    std::unordered_set<arangodb::aql::AttributeNamePath> const& paths) {
+Projections::Projections(std::unordered_set<AttributeNamePath> paths) {
   _projections.reserve(paths.size());
   for (auto& path : paths) {
     if (path.empty()) {
@@ -81,10 +89,17 @@ Projections::Projections(
     // categorize the projection, based on the attribute name.
     // we do this here only once in order to not do expensive string
     // comparisons at runtime later
-    arangodb::aql::AttributeNamePath::Type type = path.type();
+    AttributeNamePath::Type type = path.type();
+    size_t length = path.size();
+    if (length >= std::numeric_limits<uint16_t>::max()) {
+      THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_BAD_PARAMETER,
+                                     "attribute path too long for projection");
+    }
     // take over the projection
     _projections.emplace_back(
-        Projection{std::move(path), kNoCoveringIndexPosition, 0, type});
+        Projection{std::move(path), kNoCoveringIndexPosition,
+                   /*coveringIndexCutoff*/ 0, /*startsAtLevel*/ 0,
+                   /*levelsToClose*/ static_cast<uint16_t>(length - 1), type});
   }
 
   TRI_ASSERT(_projections.size() <= paths.size());
@@ -103,8 +118,8 @@ void Projections::clear() noexcept {
 }
 
 /// @brief set the index context for projections using an index
-void Projections::setCoveringContext(
-    DataSourceId const& id, std::shared_ptr<arangodb::Index> const& index) {
+void Projections::setCoveringContext(DataSourceId const& id,
+                                     std::shared_ptr<Index> const& index) {
   _datasourceId = id;
   _index = index;
 }
@@ -115,7 +130,7 @@ bool Projections::contains(Projection const& other) const noexcept {
 }
 
 /// @brief checks if we have a single attribute projection on the attribute
-bool Projections::isSingle(std::string const& attribute) const noexcept {
+bool Projections::isSingle(std::string_view attribute) const noexcept {
   return _projections.size() == 1 && _projections[0].path[0] == attribute;
 }
 
@@ -136,10 +151,12 @@ uint16_t Projections::coveringIndexPosition(
 }
 
 void Projections::toVelocyPackFromDocument(
-    arangodb::velocypack::Builder& b, arangodb::velocypack::Slice slice,
+    velocypack::Builder& b, velocypack::Slice slice,
     transaction::Methods const* trxPtr) const {
   TRI_ASSERT(b.isOpenObject());
   TRI_ASSERT(slice.isObject());
+
+  size_t levelsOpen = 0;
 
   // the single-attribute projections are easy. we dispatch here based on the
   // attribute type there are a few optimized functions for retrieving _key,
@@ -147,24 +164,29 @@ void Projections::toVelocyPackFromDocument(
   for (auto const& it : _projections) {
     if (it.type == AttributeNamePath::Type::IdAttribute) {
       // projection for "_id"
+      TRI_ASSERT(levelsOpen == 0);
       TRI_ASSERT(it.path.size() == 1);
       b.add(it.path[0], VPackValue(transaction::helpers::extractIdString(
                             trxPtr->resolver(), slice, slice)));
 
     } else if (it.type == AttributeNamePath::Type::KeyAttribute) {
       // projection for "_key"
+      TRI_ASSERT(levelsOpen == 0);
       TRI_ASSERT(it.path.size() == 1);
       b.add(it.path[0], transaction::helpers::extractKeyFromDocument(slice));
     } else if (it.type == AttributeNamePath::Type::FromAttribute) {
       // projection for "_from"
+      TRI_ASSERT(levelsOpen == 0);
       TRI_ASSERT(it.path.size() == 1);
       b.add(it.path[0], transaction::helpers::extractFromFromDocument(slice));
     } else if (it.type == AttributeNamePath::Type::ToAttribute) {
       // projection for "_to"
+      TRI_ASSERT(levelsOpen == 0);
       TRI_ASSERT(it.path.size() == 1);
       b.add(it.path[0], transaction::helpers::extractToFromDocument(slice));
     } else if (it.type == AttributeNamePath::Type::SingleAttribute) {
       // projection for any other top-level attribute
+      TRI_ASSERT(levelsOpen == 0);
       TRI_ASSERT(it.path.size() == 1);
       VPackSlice found = slice.get(it.path.path[0]);
       if (found.isNone()) {
@@ -180,63 +202,59 @@ void Projections::toVelocyPackFromDocument(
       // multiple sub-objects, e.g. a projection on the sub-attribute a.b.c
       // needs to build
       //   { a: { b: { c: valueOfC } } }
-      // when we get here it is guaranteed that there will be no projections for
-      // sub-attributes with the same prefix, e.g. a.b.c and a.x.y. This would
-      // complicate the logic here even further, so it is not supported.
+      TRI_ASSERT(levelsOpen <= it.startsAtLevel);
       TRI_ASSERT(it.type == AttributeNamePath::Type::MultiAttribute);
       TRI_ASSERT(it.path.size() > 1);
-      size_t level = 0;
-      VPackSlice found = slice;
-      VPackSlice prev;
-      size_t const n = it.path.size();
-      while (level < n) {
-        // look up attribute/sub-attribute
-        found = found.get(it.path[level]);
 
-        if (found.isNone()) {
-          // not found. we can exit early
-          b.add(it.path[level], VPackValue(VPackValueType::Null));
+      VPackSlice found = slice;
+      VPackSlice prev = found;
+      size_t level = 0;
+      while (level < it.path.size()) {
+        found = found.get(it.path[level]);
+        if (found.isNone() || level == it.path.size() - 1 ||
+            !found.isObject()) {
           break;
         }
-        if (level < n - 1 && !found.isObject()) {
-          // we would to recurse into a sub-attribute, but what we found
-          // is no object... that means we can already stop here.
-          b.add(it.path[level], VPackValue(VPackValueType::Null));
-          break;
+        if (level >= levelsOpen) {
+          b.add(it.path[level], VPackValue(VPackValueType::Object));
+          ++levelsOpen;
         }
-        if (level == n - 1) {
-          // target value
-          if (found.isCustom()) {
-            b.add(it.path[level],
-                  VPackValue(transaction::helpers::extractIdString(
-                      trxPtr->resolver(), found, prev)));
-          } else {
-            b.add(it.path[level], found);
-          }
-          break;
-        }
-        // recurse into sub-attribute object
-        TRI_ASSERT(level < n - 1);
-        b.add(it.path[level], VPackValue(VPackValueType::Object));
         ++level;
         prev = found;
       }
+      if (level >= it.startsAtLevel) {
+        if (found.isCustom()) {
+          b.add(it.path[level],
+                VPackValue(transaction::helpers::extractIdString(
+                    trxPtr->resolver(), found, prev)));
+        } else {
+          if (found.isNone()) {
+            found = VPackSlice::nullSlice();
+          }
+          b.add(it.path[level], found);
+        }
+      }
 
-      // close all that we opened ourselves, so that the next projection can
-      // again start at the top level
-      while (level-- > 0) {
+      TRI_ASSERT(it.path.size() > it.levelsToClose);
+      size_t closeUntil = it.path.size() - it.levelsToClose;
+      while (levelsOpen >= closeUntil) {
         b.close();
+        --levelsOpen;
       }
     }
   }
+
+  TRI_ASSERT(levelsOpen == 0);
 }
 
 /// @brief projections from a covering index
 void Projections::toVelocyPackFromIndex(
-    arangodb::velocypack::Builder& b, IndexIteratorCoveringData& covering,
+    velocypack::Builder& b, IndexIteratorCoveringData& covering,
     transaction::Methods const* trxPtr) const {
   TRI_ASSERT(_index != nullptr);
   TRI_ASSERT(b.isOpenObject());
+
+  size_t levelsOpen = 0;
 
   bool const isArray = covering.isArray();
   for (auto const& it : _projections) {
@@ -254,20 +272,38 @@ void Projections::toVelocyPackFromIndex(
       if (found.isNone()) {
         found = VPackSlice::nullSlice();
       }
+
+      TRI_ASSERT(levelsOpen <= it.startsAtLevel);
+      size_t level = 0;
       size_t const n =
           std::min(it.path.size(), static_cast<size_t>(it.coveringIndexCutoff));
-      TRI_ASSERT(n > 0);
-      for (size_t i = 0; i < n - 1; ++i) {
-        b.add(it.path[i], VPackValue(VPackValueType::Object));
+      while (level < n) {
+        if (level == n - 1) {
+          break;
+        }
+        if (level >= levelsOpen) {
+          b.add(it.path[level], VPackValue(VPackValueType::Object));
+          ++levelsOpen;
+        }
+        ++level;
       }
-      b.add(it.path[n - 1], found);
-      for (size_t i = 0; i < n - 1; ++i) {
+      if (level >= it.startsAtLevel) {
+        b.add(it.path[level], found);
+      }
+
+      TRI_ASSERT(it.path.size() > it.levelsToClose);
+      size_t closeUntil = it.path.size() - it.levelsToClose;
+      while (levelsOpen >= closeUntil) {
         b.close();
+        --levelsOpen;
       }
     } else {
       // no array Slice... this case will be triggered for indexes that
       // contain simple string values, such as the primary index or the
       // edge index
+      TRI_ASSERT(levelsOpen == 0);
+      TRI_ASSERT(it.path.size() == 1);
+
       auto slice = covering.value();
       if (it.type == AttributeNamePath::Type::IdAttribute) {
         b.add(it.path[0], VPackValue(transaction::helpers::makeIdFromParts(
@@ -280,13 +316,15 @@ void Projections::toVelocyPackFromIndex(
       }
     }
   }
+
+  TRI_ASSERT(levelsOpen == 0);
 }
 
-void Projections::toVelocyPack(arangodb::velocypack::Builder& b) const {
+void Projections::toVelocyPack(velocypack::Builder& b) const {
   toVelocyPack(b, ::projectionsKey);
 }
 
-void Projections::toVelocyPack(arangodb::velocypack::Builder& b,
+void Projections::toVelocyPack(velocypack::Builder& b,
                                std::string_view key) const {
   b.add(key, VPackValue(VPackValueType::Array));
   for (auto const& it : _projections) {
@@ -307,24 +345,22 @@ void Projections::toVelocyPack(arangodb::velocypack::Builder& b,
   b.close();
 }
 
-/*static*/ Projections Projections::fromVelocyPack(
-    arangodb::velocypack::Slice slice) {
+/*static*/ Projections Projections::fromVelocyPack(velocypack::Slice slice) {
   return fromVelocyPack(slice, ::projectionsKey);
 }
 
-/*static*/ Projections Projections::fromVelocyPack(
-    arangodb::velocypack::Slice slice, std::string_view key) {
-  std::vector<arangodb::aql::AttributeNamePath> projections;
+/*static*/ Projections Projections::fromVelocyPack(velocypack::Slice slice,
+                                                   std::string_view key) {
+  std::vector<AttributeNamePath> projections;
 
   VPackSlice p = slice.get(key);
   if (p.isArray()) {
-    for (auto const& it : arangodb::velocypack::ArrayIterator(p)) {
+    for (auto const& it : velocypack::ArrayIterator(p)) {
       if (it.isString()) {
-        projections.emplace_back(
-            arangodb::aql::AttributeNamePath(it.copyString()));
+        projections.emplace_back(AttributeNamePath(it.copyString()));
       } else if (it.isArray()) {
-        arangodb::aql::AttributeNamePath path;
-        for (auto const& it2 : arangodb::velocypack::ArrayIterator(it)) {
+        AttributeNamePath path;
+        for (auto const& it2 : velocypack::ArrayIterator(it)) {
           path.path.emplace_back(it2.copyString());
         }
         projections.emplace_back(std::move(path));
@@ -332,7 +368,7 @@ void Projections::toVelocyPack(arangodb::velocypack::Builder& b,
     }
   }
 
-  return arangodb::aql::Projections(std::move(projections));
+  return Projections(std::move(projections));
 }
 
 /// @brief shared init function
@@ -344,7 +380,7 @@ void Projections::init() {
 #endif
 
   if (_projections.size() <= 1) {
-    return;
+    //    return;
   }
 
   // sort projections by attribute path, so we have similar prefixes next to
@@ -359,74 +395,56 @@ void Projections::init() {
   std::sort(
       _projections.begin(), _projections.end(),
       [](auto const& lhs, auto const& rhs) { return lhs.path < rhs.path; });
-
-  removeSharedPrefixes();
-
-#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
-  // make sure all our projections are for distinct top-level attributes.
-  // we currently don't support multiple projections for the same top-level
-  // attribute, e.g. a.b.c and a.x.y.
-  // this would complicate the logic for attribute extraction considerably,
-  // so in this case we will just have combined the two projections into a
-  // single projection on attribute a before.
-  for (auto it = _projections.begin(); it != _projections.end(); ++it) {
-    // we expect all our projections to not have any common prefixes,
-    // because that would immensely complicate the logic inside the
-    // actual projection data extraction functions
-    auto const& current = (*it).path;
-    // this is a quadratic algorithm (:gut:), but it is only activated
-    // as a safety check in maintainer mode, plus we are guaranteed to have
-    // at most five projections right now
-    auto it2 = std::find_if(_projections.begin(), _projections.end(),
-                            [&current](auto const& other) {
-                              return other.path[0] == current.path[0] &&
-                                     other.path.size() != current.path.size();
-                            });
-    TRI_ASSERT(it2 == _projections.end());
-  }
-
-  // validate that no projection contains an empty attribute
-  std::for_each(_projections.begin(), _projections.end(),
-                [](auto const& it) { TRI_ASSERT(!it.path.empty()); });
-#endif
+  handleSharedPrefixes();
 }
 
-/// @brief clean up projections, so that there are no 2 projections with a
-/// shared prefix
-void Projections::removeSharedPrefixes() {
-  TRI_ASSERT(_projections.size() >= 2);
-
+/// @brief clean up projections, so that there are no 2 projections where one
+/// is a true prefix of another. also sets level attributes
+void Projections::handleSharedPrefixes() {
+  size_t levelsOpen = 0;
   auto current = _projections.begin();
 
   while (current != _projections.end()) {
     auto next = current + 1;
+
+    (*current).startsAtLevel = levelsOpen;
+    size_t const currentLength = (*current).path.size();
+    TRI_ASSERT(currentLength >= 1);
+
     if (next == _projections.end()) {
       // done
+      (*current).levelsToClose = currentLength - 1;
       break;
     }
 
     size_t commonPrefixLength =
-        arangodb::aql::AttributeNamePath::commonPrefixLength((*current).path,
-                                                             (*next).path);
+        AttributeNamePath::commonPrefixLength((*current).path, (*next).path);
     if (commonPrefixLength > 0) {
-      // common prefix detected. now remove the longer of the paths
-      if ((*current).path.size() > (*next).path.size()) {
-        // shorten the other attribute to the shard prefix length
-        (*next).path.shortenTo(commonPrefixLength);
-        (*next).type = (*next).path.type();
-        // current already adjusted
-        current = _projections.erase(current);
-      } else {
+      if (commonPrefixLength == currentLength &&
+          currentLength == (*next).path.size()) {
+        // both projections are exactly identical. remove the second one
         TRI_ASSERT(current != next);
-        (*current).path.shortenTo(commonPrefixLength);
-        (*current).type = (*current).path.type();
         _projections.erase(next);
         // don't move current forward here
+        continue;
+      } else if (commonPrefixLength == currentLength &&
+                 currentLength < (*next).path.size()) {
+        // current is a true prefix of next
+        TRI_ASSERT(current != next);
+        _projections.erase(next);
+        // don't move current forward here
+        continue;
       }
+
+      TRI_ASSERT(currentLength - commonPrefixLength >= 1);
+      (*current).levelsToClose = currentLength - commonPrefixLength - 1;
+      levelsOpen = commonPrefixLength;
     } else {
-      ++current;
-      // move to next element
+      (*current).levelsToClose = currentLength - 1;
+      levelsOpen = 0;
     }
+    ++current;
+    // move to next element
   }
 }
 
@@ -440,5 +458,28 @@ Projections::Projection& Projections::operator[](size_t index) {
   return _projections[index];
 }
 
-}  // namespace aql
-}  // namespace arangodb
+std::vector<Projections::Projection> const& Projections::projections()
+    const noexcept {
+  return _projections;
+}
+
+std::ostream& operator<<(std::ostream& stream,
+                         Projections::Projection const& projection) {
+  stream << projection.path;
+  return stream;
+}
+
+std::ostream& operator<<(std::ostream& stream, Projections const& projections) {
+  stream << "[ ";
+  size_t i = 0;
+  for (auto const& it : projections.projections()) {
+    if (i++ != 0) {
+      stream << ", ";
+    }
+    stream << it;
+  }
+  stream << " ]";
+  return stream;
+}
+
+}  // namespace arangodb::aql

--- a/arangod/Aql/Projections.h
+++ b/arangod/Aql/Projections.h
@@ -62,6 +62,9 @@ class Projections {
     /// @brief attribute length in a covering index entry. this can be shorter
     /// than the projection
     uint16_t coveringIndexCutoff;
+
+    uint16_t startsAtLevel;
+    uint16_t levelsToClose;
     /// @brief attribute type
     AttributeNamePath::Type type;
   };
@@ -73,9 +76,8 @@ class Projections {
 
   /// @brief create projections from the vector of attributes passed.
   /// attributes will be sorted and made unique inside
-  explicit Projections(std::vector<arangodb::aql::AttributeNamePath> paths);
-  explicit Projections(
-      std::unordered_set<arangodb::aql::AttributeNamePath> const& paths);
+  explicit Projections(std::vector<AttributeNamePath> paths);
+  explicit Projections(std::unordered_set<AttributeNamePath> paths);
 
   Projections(Projections&&) = default;
   Projections& operator=(Projections&&) = default;
@@ -89,11 +91,10 @@ class Projections {
 
   /// @brief set covering index context for these projections
   void setCoveringContext(DataSourceId const& id,
-                          std::shared_ptr<arangodb::Index> const& index);
+                          std::shared_ptr<Index> const& index);
 
   /// @brief whether or not the projections are backed by the specific index
-  bool usesCoveringIndex(
-      std::shared_ptr<arangodb::Index> const& index) const noexcept {
+  bool usesCoveringIndex(std::shared_ptr<Index> const& index) const noexcept {
     return _index == index;
   }
 
@@ -109,7 +110,7 @@ class Projections {
   bool contains(Projection const& other) const noexcept;
 
   /// @brief checks if we have a single attribute projection on the attribute
-  bool isSingle(std::string const& attribute) const noexcept;
+  bool isSingle(std::string_view attribute) const noexcept;
 
   // return the covering index position for a specific attribute type.
   // will throw if the index does not cover!
@@ -122,39 +123,40 @@ class Projections {
   Projection& operator[](size_t index);
 
   /// @brief extract projections from a full document
-  void toVelocyPackFromDocument(arangodb::velocypack::Builder& b,
-                                arangodb::velocypack::Slice slice,
+  void toVelocyPackFromDocument(velocypack::Builder& b, velocypack::Slice slice,
                                 transaction::Methods const* trxPtr) const;
 
   /// @brief extract projections from a covering index
-  void toVelocyPackFromIndex(arangodb::velocypack::Builder& b,
+  void toVelocyPackFromIndex(velocypack::Builder& b,
                              IndexIteratorCoveringData& covering,
                              transaction::Methods const* trxPtr) const;
 
   /// @brief serialize the projections to velocypack, under the attribute
   /// name "projections"
-  void toVelocyPack(arangodb::velocypack::Builder& b) const;
+  void toVelocyPack(velocypack::Builder& b) const;
   /// @brief serialize the projections to velocypack, under a custom
   /// attribute name
-  void toVelocyPack(arangodb::velocypack::Builder& b,
+  void toVelocyPack(velocypack::Builder& b,
                     std::string_view attributeName) const;
+
+  std::vector<Projection> const& projections() const noexcept;
 
   /// @brief build projections from velocypack, looking for the attribute
   /// name "projections"
-  static Projections fromVelocyPack(arangodb::velocypack::Slice slice);
+  static Projections fromVelocyPack(velocypack::Slice slice);
 
   /// @brief build projections from velocypack, looking for a custom
   /// attribute name
-  static Projections fromVelocyPack(arangodb::velocypack::Slice slice,
+  static Projections fromVelocyPack(velocypack::Slice slice,
                                     std::string_view attributeName);
 
  private:
   /// @brief shared init function
   void init();
 
-  /// @brief clean up projections, so that there are no 2 projections with a
-  /// shared prefix
-  void removeSharedPrefixes();
+  /// @brief clean up projections, so that there are no 2 projections where one
+  /// is a true prefix of another. also sets level attributes
+  void handleSharedPrefixes();
 
   /// @brief all our projections (sorted, unique)
   std::vector<Projection> _projections;
@@ -164,8 +166,13 @@ class Projections {
   DataSourceId _datasourceId;
 
   /// @brief whether or not the projections are backed by a covering index
-  std::shared_ptr<arangodb::Index> _index;
+  std::shared_ptr<Index> _index;
 };
+
+std::ostream& operator<<(std::ostream& stream,
+                         Projections::Projection const& projection);
+
+std::ostream& operator<<(std::ostream& stream, Projections const& projections);
 
 }  // namespace aql
 }  // namespace arangodb

--- a/arangod/Indexes/Index.cpp
+++ b/arangod/Indexes/Index.cpp
@@ -973,12 +973,6 @@ bool Index::covers(aql::Projections& projections) const {
   // check if we can use covering indexes
   auto const& covered = coveredFields();
 
-  if (n > covered.size()) {
-    // we have more projections than attributes in the index, so we already know
-    // that the index cannot support all the projections
-    return false;
-  }
-
   for (size_t i = 0; i < n; ++i) {
     bool found = false;
     for (size_t j = 0; j < covered.size(); ++j) {

--- a/arangod/RocksDBEngine/RocksDBOptimizerRules.cpp
+++ b/arangod/RocksDBEngine/RocksDBOptimizerRules.cpp
@@ -108,7 +108,7 @@ void RocksDBOptimizerRules::reduceExtractionToProjectionRule(
 
     if (foundProjections && !attributes.empty() &&
         attributes.size() <= e->maxProjections()) {
-      Projections projections(attributes);
+      Projections projections(std::move(attributes));
 
       if (n->getType() == ExecutionNode::ENUMERATE_COLLECTION &&
           !isRandomOrder) {
@@ -179,6 +179,7 @@ void RocksDBOptimizerRules::reduceExtractionToProjectionRule(
           if (!picked && !forced) {
             for (auto const& idx : indexes) {
               if (selectIndexIfPossible(idx)) {
+                TRI_ASSERT(picked != nullptr);
                 break;
               }
             }
@@ -284,6 +285,7 @@ void RocksDBOptimizerRules::reduceExtractionToProjectionRule(
         if (!picked && !forced) {
           for (auto const& idx : indexes) {
             if (selectIndexIfPossible(idx)) {
+              TRI_ASSERT(picked != nullptr);
               break;
             }
           }

--- a/tests/Aql/ProjectionsTest.cpp
+++ b/tests/Aql/ProjectionsTest.cpp
@@ -28,15 +28,20 @@
 
 #include "Aql/Projections.h"
 
+#include <velocypack/Builder.h>
+#include <velocypack/Parser.h>
+#include <velocypack/Slice.h>
+
+using namespace arangodb;
 using namespace arangodb::aql;
 
 TEST(ProjectionsTest, buildEmpty) {
   Projections p;
 
-  ASSERT_EQ(0, p.size());
-  ASSERT_TRUE(p.empty());
-  ASSERT_FALSE(p.isSingle("a"));
-  ASSERT_FALSE(p.isSingle("_key"));
+  EXPECT_EQ(0, p.size());
+  EXPECT_TRUE(p.empty());
+  EXPECT_FALSE(p.isSingle("a"));
+  EXPECT_FALSE(p.isSingle("_key"));
 }
 
 TEST(ProjectionsTest, buildSingleKey) {
@@ -45,12 +50,12 @@ TEST(ProjectionsTest, buildSingleKey) {
   };
   Projections p(std::move(attributes));
 
-  ASSERT_EQ(1, p.size());
-  ASSERT_FALSE(p.empty());
-  ASSERT_EQ(AttributeNamePath("_key"), p[0].path);
-  ASSERT_EQ(arangodb::aql::AttributeNamePath::Type::KeyAttribute, p[0].type);
-  ASSERT_FALSE(p.isSingle("a"));
-  ASSERT_TRUE(p.isSingle("_key"));
+  EXPECT_EQ(1, p.size());
+  EXPECT_FALSE(p.empty());
+  EXPECT_EQ(AttributeNamePath("_key"), p[0].path);
+  EXPECT_EQ(arangodb::aql::AttributeNamePath::Type::KeyAttribute, p[0].type);
+  EXPECT_FALSE(p.isSingle("a"));
+  EXPECT_TRUE(p.isSingle("_key"));
 }
 
 TEST(ProjectionsTest, buildSingleId) {
@@ -59,12 +64,12 @@ TEST(ProjectionsTest, buildSingleId) {
   };
   Projections p(std::move(attributes));
 
-  ASSERT_EQ(1, p.size());
-  ASSERT_FALSE(p.empty());
-  ASSERT_EQ(AttributeNamePath("_id"), p[0].path);
-  ASSERT_EQ(arangodb::aql::AttributeNamePath::Type::IdAttribute, p[0].type);
-  ASSERT_FALSE(p.isSingle("a"));
-  ASSERT_TRUE(p.isSingle("_id"));
+  EXPECT_EQ(1, p.size());
+  EXPECT_FALSE(p.empty());
+  EXPECT_EQ(AttributeNamePath("_id"), p[0].path);
+  EXPECT_EQ(arangodb::aql::AttributeNamePath::Type::IdAttribute, p[0].type);
+  EXPECT_FALSE(p.isSingle("a"));
+  EXPECT_TRUE(p.isSingle("_id"));
 }
 
 TEST(ProjectionsTest, buildSingleFrom) {
@@ -73,12 +78,12 @@ TEST(ProjectionsTest, buildSingleFrom) {
   };
   Projections p(std::move(attributes));
 
-  ASSERT_EQ(1, p.size());
-  ASSERT_FALSE(p.empty());
-  ASSERT_EQ(AttributeNamePath("_from"), p[0].path);
-  ASSERT_EQ(arangodb::aql::AttributeNamePath::Type::FromAttribute, p[0].type);
-  ASSERT_FALSE(p.isSingle("a"));
-  ASSERT_TRUE(p.isSingle("_from"));
+  EXPECT_EQ(1, p.size());
+  EXPECT_FALSE(p.empty());
+  EXPECT_EQ(AttributeNamePath("_from"), p[0].path);
+  EXPECT_EQ(arangodb::aql::AttributeNamePath::Type::FromAttribute, p[0].type);
+  EXPECT_FALSE(p.isSingle("a"));
+  EXPECT_TRUE(p.isSingle("_from"));
 }
 
 TEST(ProjectionsTest, buildSingleTo) {
@@ -87,12 +92,12 @@ TEST(ProjectionsTest, buildSingleTo) {
   };
   Projections p(std::move(attributes));
 
-  ASSERT_EQ(1, p.size());
-  ASSERT_FALSE(p.empty());
-  ASSERT_EQ(AttributeNamePath("_to"), p[0].path);
-  ASSERT_EQ(arangodb::aql::AttributeNamePath::Type::ToAttribute, p[0].type);
-  ASSERT_FALSE(p.isSingle("a"));
-  ASSERT_TRUE(p.isSingle("_to"));
+  EXPECT_EQ(1, p.size());
+  EXPECT_FALSE(p.empty());
+  EXPECT_EQ(AttributeNamePath("_to"), p[0].path);
+  EXPECT_EQ(arangodb::aql::AttributeNamePath::Type::ToAttribute, p[0].type);
+  EXPECT_FALSE(p.isSingle("a"));
+  EXPECT_TRUE(p.isSingle("_to"));
 }
 
 TEST(ProjectionsTest, buildSingleOther) {
@@ -101,12 +106,12 @@ TEST(ProjectionsTest, buildSingleOther) {
   };
   Projections p(std::move(attributes));
 
-  ASSERT_EQ(1, p.size());
-  ASSERT_FALSE(p.empty());
-  ASSERT_EQ(AttributeNamePath("piff"), p[0].path);
-  ASSERT_EQ(arangodb::aql::AttributeNamePath::Type::SingleAttribute, p[0].type);
-  ASSERT_FALSE(p.isSingle("a"));
-  ASSERT_TRUE(p.isSingle("piff"));
+  EXPECT_EQ(1, p.size());
+  EXPECT_FALSE(p.empty());
+  EXPECT_EQ(AttributeNamePath("piff"), p[0].path);
+  EXPECT_EQ(arangodb::aql::AttributeNamePath::Type::SingleAttribute, p[0].type);
+  EXPECT_FALSE(p.isSingle("a"));
+  EXPECT_TRUE(p.isSingle("piff"));
 }
 
 TEST(ProjectionsTest, buildMulti) {
@@ -117,18 +122,18 @@ TEST(ProjectionsTest, buildMulti) {
   };
   Projections p(std::move(attributes));
 
-  ASSERT_EQ(3, p.size());
-  ASSERT_FALSE(p.empty());
-  ASSERT_EQ(AttributeNamePath("a"), p[0].path);
-  ASSERT_EQ(arangodb::aql::AttributeNamePath::Type::SingleAttribute, p[0].type);
-  ASSERT_EQ(AttributeNamePath("b"), p[1].path);
-  ASSERT_EQ(arangodb::aql::AttributeNamePath::Type::SingleAttribute, p[1].type);
-  ASSERT_EQ(AttributeNamePath("c"), p[2].path);
-  ASSERT_EQ(arangodb::aql::AttributeNamePath::Type::SingleAttribute, p[2].type);
-  ASSERT_FALSE(p.isSingle("a"));
-  ASSERT_FALSE(p.isSingle("b"));
-  ASSERT_FALSE(p.isSingle("c"));
-  ASSERT_FALSE(p.isSingle("_key"));
+  EXPECT_EQ(3, p.size());
+  EXPECT_FALSE(p.empty());
+  EXPECT_EQ(AttributeNamePath("a"), p[0].path);
+  EXPECT_EQ(arangodb::aql::AttributeNamePath::Type::SingleAttribute, p[0].type);
+  EXPECT_EQ(AttributeNamePath("b"), p[1].path);
+  EXPECT_EQ(arangodb::aql::AttributeNamePath::Type::SingleAttribute, p[1].type);
+  EXPECT_EQ(AttributeNamePath("c"), p[2].path);
+  EXPECT_EQ(arangodb::aql::AttributeNamePath::Type::SingleAttribute, p[2].type);
+  EXPECT_FALSE(p.isSingle("a"));
+  EXPECT_FALSE(p.isSingle("b"));
+  EXPECT_FALSE(p.isSingle("c"));
+  EXPECT_FALSE(p.isSingle("_key"));
 }
 
 TEST(ProjectionsTest, buildReverse) {
@@ -139,18 +144,18 @@ TEST(ProjectionsTest, buildReverse) {
   };
   Projections p(std::move(attributes));
 
-  ASSERT_EQ(3, p.size());
-  ASSERT_FALSE(p.empty());
-  ASSERT_EQ(AttributeNamePath("a"), p[0].path);
-  ASSERT_EQ(arangodb::aql::AttributeNamePath::Type::SingleAttribute, p[0].type);
-  ASSERT_EQ(AttributeNamePath("b"), p[1].path);
-  ASSERT_EQ(arangodb::aql::AttributeNamePath::Type::SingleAttribute, p[1].type);
-  ASSERT_EQ(AttributeNamePath("c"), p[2].path);
-  ASSERT_EQ(arangodb::aql::AttributeNamePath::Type::SingleAttribute, p[2].type);
-  ASSERT_FALSE(p.isSingle("a"));
-  ASSERT_FALSE(p.isSingle("b"));
-  ASSERT_FALSE(p.isSingle("c"));
-  ASSERT_FALSE(p.isSingle("_key"));
+  EXPECT_EQ(3, p.size());
+  EXPECT_FALSE(p.empty());
+  EXPECT_EQ(AttributeNamePath("a"), p[0].path);
+  EXPECT_EQ(arangodb::aql::AttributeNamePath::Type::SingleAttribute, p[0].type);
+  EXPECT_EQ(AttributeNamePath("b"), p[1].path);
+  EXPECT_EQ(arangodb::aql::AttributeNamePath::Type::SingleAttribute, p[1].type);
+  EXPECT_EQ(AttributeNamePath("c"), p[2].path);
+  EXPECT_EQ(arangodb::aql::AttributeNamePath::Type::SingleAttribute, p[2].type);
+  EXPECT_FALSE(p.isSingle("a"));
+  EXPECT_FALSE(p.isSingle("b"));
+  EXPECT_FALSE(p.isSingle("c"));
+  EXPECT_FALSE(p.isSingle("_key"));
 }
 
 TEST(ProjectionsTest, buildWithSystem) {
@@ -161,17 +166,17 @@ TEST(ProjectionsTest, buildWithSystem) {
   };
   Projections p(std::move(attributes));
 
-  ASSERT_EQ(3, p.size());
-  ASSERT_FALSE(p.empty());
-  ASSERT_EQ(AttributeNamePath("_id"), p[0].path);
-  ASSERT_EQ(arangodb::aql::AttributeNamePath::Type::IdAttribute, p[0].type);
-  ASSERT_EQ(AttributeNamePath("_key"), p[1].path);
-  ASSERT_EQ(arangodb::aql::AttributeNamePath::Type::KeyAttribute, p[1].type);
-  ASSERT_EQ(AttributeNamePath("a"), p[2].path);
-  ASSERT_EQ(arangodb::aql::AttributeNamePath::Type::SingleAttribute, p[2].type);
-  ASSERT_FALSE(p.isSingle("a"));
-  ASSERT_FALSE(p.isSingle("_key"));
-  ASSERT_FALSE(p.isSingle("_id"));
+  EXPECT_EQ(3, p.size());
+  EXPECT_FALSE(p.empty());
+  EXPECT_EQ(AttributeNamePath("_id"), p[0].path);
+  EXPECT_EQ(arangodb::aql::AttributeNamePath::Type::IdAttribute, p[0].type);
+  EXPECT_EQ(AttributeNamePath("_key"), p[1].path);
+  EXPECT_EQ(arangodb::aql::AttributeNamePath::Type::KeyAttribute, p[1].type);
+  EXPECT_EQ(AttributeNamePath("a"), p[2].path);
+  EXPECT_EQ(arangodb::aql::AttributeNamePath::Type::SingleAttribute, p[2].type);
+  EXPECT_FALSE(p.isSingle("a"));
+  EXPECT_FALSE(p.isSingle("_key"));
+  EXPECT_FALSE(p.isSingle("_id"));
 }
 
 TEST(ProjectionsTest, buildNested1) {
@@ -182,15 +187,20 @@ TEST(ProjectionsTest, buildNested1) {
   };
   Projections p(std::move(attributes));
 
-  ASSERT_EQ(2, p.size());
-  ASSERT_FALSE(p.empty());
-  ASSERT_EQ(AttributeNamePath("_key"), p[0].path);
-  ASSERT_EQ(arangodb::aql::AttributeNamePath::Type::KeyAttribute, p[0].type);
-  ASSERT_EQ(AttributeNamePath("a"), p[1].path);
-  ASSERT_EQ(arangodb::aql::AttributeNamePath::Type::SingleAttribute, p[1].type);
-  ASSERT_FALSE(p.isSingle("a"));
-  ASSERT_FALSE(p.isSingle("_key"));
-  ASSERT_FALSE(p.isSingle("z"));
+  EXPECT_EQ(3, p.size());
+  EXPECT_FALSE(p.empty());
+  EXPECT_EQ(AttributeNamePath("_key"), p[0].path);
+  EXPECT_EQ(arangodb::aql::AttributeNamePath::Type::KeyAttribute, p[0].type);
+  EXPECT_EQ(AttributeNamePath(std::vector<std::string>({{"a"}, {"b"}})),
+            p[1].path);
+  EXPECT_EQ(AttributeNamePath(std::vector<std::string>({{"a"}, {"z"}, {"A"}})),
+            p[2].path);
+  EXPECT_EQ(arangodb::aql::AttributeNamePath::Type::MultiAttribute, p[1].type);
+  EXPECT_EQ(arangodb::aql::AttributeNamePath::Type::MultiAttribute, p[2].type);
+  EXPECT_FALSE(p.isSingle("a"));
+  EXPECT_FALSE(p.isSingle("b"));
+  EXPECT_FALSE(p.isSingle("z"));
+  EXPECT_FALSE(p.isSingle("_key"));
 }
 
 TEST(ProjectionsTest, buildNested2) {
@@ -202,18 +212,18 @@ TEST(ProjectionsTest, buildNested2) {
   };
   Projections p(std::move(attributes));
 
-  ASSERT_EQ(4, p.size());
-  ASSERT_FALSE(p.empty());
-  ASSERT_EQ(AttributeNamePath("A"), p[0].path);
-  ASSERT_EQ(arangodb::aql::AttributeNamePath::Type::SingleAttribute, p[0].type);
-  ASSERT_EQ(AttributeNamePath("_key"), p[1].path);
-  ASSERT_EQ(arangodb::aql::AttributeNamePath::Type::KeyAttribute, p[1].type);
-  ASSERT_EQ(AttributeNamePath(std::vector<std::string>({{"a"}, {"z"}, {"A"}})),
+  EXPECT_EQ(4, p.size());
+  EXPECT_FALSE(p.empty());
+  EXPECT_EQ(AttributeNamePath("A"), p[0].path);
+  EXPECT_EQ(arangodb::aql::AttributeNamePath::Type::SingleAttribute, p[0].type);
+  EXPECT_EQ(AttributeNamePath("_key"), p[1].path);
+  EXPECT_EQ(arangodb::aql::AttributeNamePath::Type::KeyAttribute, p[1].type);
+  EXPECT_EQ(AttributeNamePath(std::vector<std::string>({{"a"}, {"z"}, {"A"}})),
             p[2].path);
-  ASSERT_EQ(arangodb::aql::AttributeNamePath::Type::MultiAttribute, p[2].type);
-  ASSERT_EQ(AttributeNamePath(std::vector<std::string>({{"b"}, {"b"}})),
+  EXPECT_EQ(arangodb::aql::AttributeNamePath::Type::MultiAttribute, p[2].type);
+  EXPECT_EQ(AttributeNamePath(std::vector<std::string>({{"b"}, {"b"}})),
             p[3].path);
-  ASSERT_EQ(arangodb::aql::AttributeNamePath::Type::MultiAttribute, p[3].type);
+  EXPECT_EQ(arangodb::aql::AttributeNamePath::Type::MultiAttribute, p[3].type);
 }
 
 TEST(ProjectionsTest, buildOverlapping1) {
@@ -223,9 +233,9 @@ TEST(ProjectionsTest, buildOverlapping1) {
   };
   Projections p(std::move(attributes));
 
-  ASSERT_EQ(1, p.size());
-  ASSERT_EQ(AttributeNamePath("a"), p[0].path);
-  ASSERT_EQ(arangodb::aql::AttributeNamePath::Type::SingleAttribute, p[0].type);
+  EXPECT_EQ(1, p.size());
+  EXPECT_EQ(AttributeNamePath("a"), p[0].path);
+  EXPECT_EQ(arangodb::aql::AttributeNamePath::Type::SingleAttribute, p[0].type);
 }
 
 TEST(ProjectionsTest, buildOverlapping2) {
@@ -235,9 +245,9 @@ TEST(ProjectionsTest, buildOverlapping2) {
   };
   Projections p(std::move(attributes));
 
-  ASSERT_EQ(1, p.size());
-  ASSERT_EQ(AttributeNamePath("a"), p[0].path);
-  ASSERT_EQ(arangodb::aql::AttributeNamePath::Type::SingleAttribute, p[0].type);
+  EXPECT_EQ(1, p.size());
+  EXPECT_EQ(AttributeNamePath("a"), p[0].path);
+  EXPECT_EQ(arangodb::aql::AttributeNamePath::Type::SingleAttribute, p[0].type);
 }
 
 TEST(ProjectionsTest, buildOverlapping3) {
@@ -247,10 +257,10 @@ TEST(ProjectionsTest, buildOverlapping3) {
   };
   Projections p(std::move(attributes));
 
-  ASSERT_EQ(1, p.size());
-  ASSERT_EQ(AttributeNamePath(std::vector<std::string>({{"a"}, {"b"}})),
+  EXPECT_EQ(1, p.size());
+  EXPECT_EQ(AttributeNamePath(std::vector<std::string>({{"a"}, {"b"}})),
             p[0].path);
-  ASSERT_EQ(arangodb::aql::AttributeNamePath::Type::MultiAttribute, p[0].type);
+  EXPECT_EQ(arangodb::aql::AttributeNamePath::Type::MultiAttribute, p[0].type);
 }
 
 TEST(ProjectionsTest, buildOverlapping4) {
@@ -262,12 +272,200 @@ TEST(ProjectionsTest, buildOverlapping4) {
   };
   Projections p(std::move(attributes));
 
-  ASSERT_EQ(3, p.size());
-  ASSERT_EQ(AttributeNamePath(std::vector<std::string>({{"a"}, {"b"}, {"c"}})),
+  EXPECT_EQ(3, p.size());
+  EXPECT_EQ(AttributeNamePath(std::vector<std::string>({{"a"}, {"b"}, {"c"}})),
             p[0].path);
-  ASSERT_EQ(arangodb::aql::AttributeNamePath::Type::MultiAttribute, p[0].type);
-  ASSERT_EQ(AttributeNamePath("b"), p[1].path);
-  ASSERT_EQ(arangodb::aql::AttributeNamePath::Type::SingleAttribute, p[1].type);
-  ASSERT_EQ(AttributeNamePath("m"), p[2].path);
-  ASSERT_EQ(arangodb::aql::AttributeNamePath::Type::SingleAttribute, p[2].type);
+  EXPECT_EQ(arangodb::aql::AttributeNamePath::Type::MultiAttribute, p[0].type);
+  EXPECT_EQ(AttributeNamePath("b"), p[1].path);
+  EXPECT_EQ(arangodb::aql::AttributeNamePath::Type::SingleAttribute, p[1].type);
+  EXPECT_EQ(AttributeNamePath("m"), p[2].path);
+  EXPECT_EQ(arangodb::aql::AttributeNamePath::Type::SingleAttribute, p[2].type);
+}
+
+TEST(ProjectionsTest, buildOverlapping5) {
+  std::vector<arangodb::aql::AttributeNamePath> attributes = {
+      AttributeNamePath("a"),
+      AttributeNamePath(std::vector<std::string>({"a", "b"})),
+      AttributeNamePath(std::vector<std::string>({"a", "c"})),
+  };
+  Projections p(std::move(attributes));
+
+  EXPECT_EQ(1, p.size());
+  EXPECT_EQ(AttributeNamePath("a"), p[0].path);
+}
+
+TEST(ProjectionsTest, buildOverlapping6) {
+  std::vector<arangodb::aql::AttributeNamePath> attributes = {
+      AttributeNamePath(std::vector<std::string>({"a", "c"})),
+      AttributeNamePath(std::vector<std::string>({"a", "b"})),
+  };
+  Projections p(std::move(attributes));
+
+  EXPECT_EQ(2, p.size());
+  EXPECT_EQ(AttributeNamePath(std::vector<std::string>({{"a"}, {"b"}})),
+            p[0].path);
+  EXPECT_EQ(AttributeNamePath(std::vector<std::string>({{"a"}, {"c"}})),
+            p[1].path);
+}
+
+TEST(ProjectionsTest, toVelocyPackFromDocumentSimple1) {
+  std::vector<arangodb::aql::AttributeNamePath> attributes = {
+      AttributeNamePath(std::vector<std::string>({"a"})),
+      AttributeNamePath(std::vector<std::string>({"b"})),
+      AttributeNamePath(std::vector<std::string>({"c"})),
+  };
+  Projections p(std::move(attributes));
+
+  velocypack::Builder out;
+
+  auto prepareResult = [&p](std::string_view json, velocypack::Builder& out) {
+    auto document = velocypack::Parser::fromJson(json.data(), json.size());
+    out.clear();
+    out.openObject();
+    p.toVelocyPackFromDocument(out, document->slice(), nullptr);
+    out.close();
+    return out.slice();
+  };
+
+  {
+    VPackSlice s = prepareResult("{}", out);
+    EXPECT_EQ(3, s.length());
+    EXPECT_TRUE(s.hasKey("a"));
+    EXPECT_TRUE(s.get("a").isNull());
+    EXPECT_TRUE(s.hasKey("b"));
+    EXPECT_TRUE(s.get("b").isNull());
+    EXPECT_TRUE(s.hasKey("c"));
+    EXPECT_TRUE(s.get("c").isNull());
+  }
+
+  {
+    VPackSlice s = prepareResult("{\"z\":1}", out);
+    EXPECT_EQ(3, s.length());
+    EXPECT_TRUE(s.hasKey("a"));
+    EXPECT_TRUE(s.get("a").isNull());
+    EXPECT_TRUE(s.hasKey("b"));
+    EXPECT_TRUE(s.get("b").isNull());
+    EXPECT_TRUE(s.hasKey("c"));
+    EXPECT_TRUE(s.get("c").isNull());
+  }
+
+  {
+    VPackSlice s = prepareResult("{\"a\":null,\"b\":1,\"c\":true}", out);
+    EXPECT_EQ(3, s.length());
+    EXPECT_TRUE(s.get("a").isNull());
+    EXPECT_TRUE(s.get("b").isInteger());
+    EXPECT_TRUE(s.get("c").getBool());
+  }
+
+  {
+    VPackSlice s = prepareResult("{\"a\":1,\"b\":false,\"z\":\"foo\"}", out);
+    EXPECT_EQ(3, s.length());
+    EXPECT_TRUE(s.get("a").isInteger());
+    EXPECT_FALSE(s.get("b").getBool());
+    EXPECT_TRUE(s.get("c").isNull());
+  }
+
+  {
+    VPackSlice s = prepareResult(
+        "{\"a\":{\"subA\":1},\"b\":{\"subB\":false},\"c\":{\"subC\":\"foo\"}}",
+        out);
+    EXPECT_EQ(3, s.length());
+    EXPECT_TRUE(s.get("a").isObject());
+    EXPECT_TRUE(s.get({"a", "subA"}).isInteger());
+    EXPECT_TRUE(s.get("b").isObject());
+    EXPECT_TRUE(s.get({"b", "subB"}).isBoolean());
+    EXPECT_TRUE(s.get("c").isObject());
+    EXPECT_TRUE(s.get({"c", "subC"}).isString());
+  }
+}
+
+TEST(ProjectionsTest, toVelocyPackFromDocument) {
+  std::vector<arangodb::aql::AttributeNamePath> attributes = {
+      AttributeNamePath(std::vector<std::string>({"a", "b", "c"})),
+      AttributeNamePath(std::vector<std::string>({"a", "b", "d"})),
+      AttributeNamePath(std::vector<std::string>({"a", "c"})),
+      AttributeNamePath(std::vector<std::string>({"a", "d", "e", "f"})),
+      AttributeNamePath(std::vector<std::string>({"a", "z"})),
+  };
+  Projections p(std::move(attributes));
+
+  velocypack::Builder out;
+
+  auto prepareResult = [&p](std::string_view json, velocypack::Builder& out) {
+    auto document = velocypack::Parser::fromJson(json.data(), json.size());
+    out.clear();
+    out.openObject();
+    p.toVelocyPackFromDocument(out, document->slice(), nullptr);
+    out.close();
+    return out.slice();
+  };
+
+  {
+    VPackSlice s = prepareResult("{}", out);
+    EXPECT_EQ(1, s.length());
+    EXPECT_TRUE(s.hasKey("a"));
+    EXPECT_TRUE(s.get("a").isNull());
+  }
+
+  {
+    VPackSlice s = prepareResult("{\"z\":1}", out);
+    EXPECT_EQ(1, s.length());
+    EXPECT_TRUE(s.hasKey("a"));
+    EXPECT_TRUE(s.get("a").isNull());
+  }
+
+  {
+    VPackSlice s = prepareResult("{\"a\":null}", out);
+    EXPECT_EQ(1, s.length());
+    EXPECT_TRUE(s.hasKey("a"));
+    EXPECT_TRUE(s.get("a").isNull());
+  }
+
+  {
+    VPackSlice s = prepareResult("{\"a\":1}", out);
+    EXPECT_EQ(1, s.length());
+    EXPECT_TRUE(s.hasKey("a"));
+    EXPECT_TRUE(s.get("a").isInteger());
+  }
+
+  {
+    VPackSlice s = prepareResult("{\"a\":\"foo\"}", out);
+    EXPECT_EQ(1, s.length());
+    EXPECT_TRUE(s.hasKey("a"));
+    EXPECT_TRUE(s.get("a").isString());
+  }
+
+  {
+    VPackSlice s = prepareResult(
+        "{\"a\":{\"b\":{\"c\":1,\"d\":2},\"c\":\"foo\",\"d\":{\"e\":\"fuxx\"},"
+        "\"z\":\"raton\"}}",
+        out);
+    EXPECT_EQ(1, s.length());
+    EXPECT_TRUE(s.hasKey("a"));
+    EXPECT_TRUE(s.get("a").isObject());
+    EXPECT_TRUE(s.get({"a", "b"}).isObject());
+    EXPECT_TRUE(s.get({"a", "b", "c"}).isInteger());
+    EXPECT_TRUE(s.get({"a", "b", "d"}).isInteger());
+    EXPECT_TRUE(s.get({"a", "c"}).isString());
+    EXPECT_TRUE(s.get({"a", "d", "e"}).isString());
+    EXPECT_TRUE(s.get({"a", "d", "f"}).isNone());
+    EXPECT_TRUE(s.get({"a", "z"}).isString());
+  }
+
+  {
+    VPackSlice s = prepareResult(
+        "{\"a\":{\"b\":{\"c\":1,\"d\":2},\"c\":\"foo\",\"d\":{\"e\":{\"f\":4}},"
+        "\"z\":\"raton\"}}",
+        out);
+    EXPECT_EQ(1, s.length());
+    EXPECT_TRUE(s.hasKey("a"));
+    EXPECT_TRUE(s.get("a").isObject());
+    EXPECT_TRUE(s.get({"a", "b"}).isObject());
+    EXPECT_TRUE(s.get({"a", "b", "c"}).isInteger());
+    EXPECT_TRUE(s.get({"a", "b", "d"}).isInteger());
+    EXPECT_TRUE(s.get({"a", "c"}).isString());
+    EXPECT_TRUE(s.get({"a", "d"}).isObject());
+    EXPECT_TRUE(s.get({"a", "d", "e", "f"}).isInteger());
+    EXPECT_TRUE(s.get({"a", "z"}).isString());
+  }
 }

--- a/tests/js/common/shell/shell-index-stored-values.js
+++ b/tests/js/common/shell/shell-index-stored-values.js
@@ -677,7 +677,7 @@ function indexStoredValuesResultsSuite() {
       assertEqual(1, nodes.filter((n) => n.type === 'IndexNode').length);
       assertEqual(0, nodes.filter((n) => n.type === 'EnumerateCollectionNode').length);
       assertTrue(nodes[1].indexCoversProjections);
-      assertEqual(["value"], nodes[1].projections.sort());
+      assertEqual([["value", "sub1"], ["value", "sub2"], ["value", "sub3"], ["value", "sub4"]], nodes[1].projections.sort());
       
       for (let i = 0; i < 10; ++i) {
         let result = db._query(query, { value: i }).toArray();
@@ -700,8 +700,8 @@ function indexStoredValuesResultsSuite() {
       let nodes = AQL_EXPLAIN(query, { value: 0 }).plan.nodes;
       assertEqual(1, nodes.filter((n) => n.type === 'IndexNode').length);
       assertEqual(0, nodes.filter((n) => n.type === 'EnumerateCollectionNode').length);
-      assertFalse(nodes[1].indexCoversProjections);
-      assertEqual(["value"], nodes[1].projections);
+      assertTrue(nodes[1].indexCoversProjections);
+      assertEqual([["value", "sub1"], ["value", "sub2"], ["value", "sub3"], ["value", "sub4"]], nodes[1].projections.sort());
       
       for (let i = 0; i < 10; ++i) {
         let result = db._query(query, { value: i }).toArray();
@@ -724,8 +724,8 @@ function indexStoredValuesResultsSuite() {
       let nodes = AQL_EXPLAIN(query, { value: 0 }).plan.nodes;
       assertEqual(1, nodes.filter((n) => n.type === 'IndexNode').length);
       assertEqual(0, nodes.filter((n) => n.type === 'EnumerateCollectionNode').length);
-      assertFalse(nodes[1].indexCoversProjections);
-      assertEqual(["value"], nodes[1].projections);
+      assertTrue(nodes[1].indexCoversProjections);
+      assertEqual([["value", "a"], ["value", "sub1", "a"], ["value", "sub1", "sub2", "sub3"]], nodes[1].projections);
       
       for (let i = 0; i < 10; ++i) {
         let result = db._query(query, { value: i }).toArray();

--- a/tests/js/server/aql/aql-filter-projections.js
+++ b/tests/js/server/aql/aql-filter-projections.js
@@ -177,8 +177,8 @@ function filterProjectionsPlansTestSuite () {
     testPersistentStoredValuesSubAttributesMulti : function () {
       c.ensureIndex({ type: "persistent", fields: ["foo.bar"], storedValues: ["moo"] });
       let queries = [
-        [`FOR doc IN ${cn} FILTER doc.foo.bar == 1 FILTER doc.moo.baz != 1 FILTER doc.moo.qux == 2 RETURN doc.value`, 'persistent', ['moo'], ['value'] ],
-        [`FOR doc IN ${cn} FILTER doc.foo.bar == 1 FILTER doc.moo.baz != 1 FILTER doc.moo.qux != 3 RETURN [doc.foo.bar, doc.value]`, 'persistent', ['moo'], [['foo', 'bar'], 'value'] ],
+        [`FOR doc IN ${cn} FILTER doc.foo.bar == 1 FILTER doc.moo.baz != 1 FILTER doc.moo.qux == 2 RETURN doc.value`, 'persistent', [['moo', 'baz'], ['moo', 'qux']], ['value'] ],
+        [`FOR doc IN ${cn} FILTER doc.foo.bar == 1 FILTER doc.moo.baz != 1 FILTER doc.moo.qux != 3 RETURN [doc.foo.bar, doc.value]`, 'persistent', [['moo', 'baz'], ['moo', 'qux']], [['foo', 'bar'], 'value'] ],
       ];
 
       queries.forEach(function(query) {

--- a/tests/js/server/aql/aql-projections.js
+++ b/tests/js/server/aql/aql-projections.js
@@ -221,7 +221,7 @@ function projectionsPlansTestSuite () {
       let queries = [
         [`FOR doc IN ${cn} RETURN doc.foo.bar`, 'persistent', [['foo', 'bar']], true ],
         [`FOR doc IN ${cn} RETURN doc.foo.bar.baz`, 'persistent', [['foo', 'bar', 'baz']], true ],
-        [`FOR doc IN ${cn} RETURN [doc.foo.bar.baz, doc.foo.bar.bat]`, 'persistent', [['foo', 'bar']], true ],
+        [`FOR doc IN ${cn} RETURN [doc.foo.bar.baz, doc.foo.bar.bat]`, 'persistent', [['foo', 'bar', 'bat'], ['foo', 'bar', 'baz']], true ],
         [`FOR doc IN ${cn} RETURN [doc.foo.bar, doc.foo.bar.baz]`, 'persistent', [['foo', 'bar']], true ],
         [`FOR doc IN ${cn} FILTER doc.foo.bar == 1 RETURN doc.foo.bar`, 'persistent', [['foo', 'bar']], true ],
         [`FOR doc IN ${cn} FILTER doc.foo.bar == 1 RETURN 1`, 'persistent', [], false ],
@@ -266,13 +266,16 @@ function projectionsPlansTestSuite () {
         [`FOR doc IN ${cn} RETURN doc.foo.baz`, 'persistent', [['foo', 'baz']], true ],
         [`FOR doc IN ${cn} RETURN doc.foo.bar.baz`, 'persistent', [['foo', 'bar', 'baz']], true ],
         [`FOR doc IN ${cn} RETURN doc.foo.baz.bar`, 'persistent', [['foo', 'baz', 'bar']], true ],
-        [`FOR doc IN ${cn} RETURN [doc.foo.bar.baz, doc.foo.bar.bat]`, 'persistent', [['foo', 'bar']], true ],
-        [`FOR doc IN ${cn} RETURN [doc.foo.baz.bar, doc.foo.baz.bat]`, 'persistent', [['foo', 'baz']], true ],
+        [`FOR doc IN ${cn} RETURN [doc.foo.bar.baz, doc.foo.bar.bat]`, 'persistent', [['foo', 'bar', 'bat'], ['foo', 'bar', 'baz']], true ],
+        [`FOR doc IN ${cn} RETURN [doc.foo.baz.bar, doc.foo.baz.bat]`, 'persistent', [['foo', 'baz', 'bar'], ['foo', 'baz', 'bat']], true ],
         [`FOR doc IN ${cn} FILTER doc.foo.bar == 1 RETURN doc.foo.bar`, 'persistent', [['foo', 'bar']], true ],
         [`FOR doc IN ${cn} FILTER doc.foo.bar == 1 RETURN doc.foo.baz`, 'persistent', [['foo', 'baz']], true ],
         [`FOR doc IN ${cn} FILTER doc.foo.baz == 1 RETURN doc.foo.baz`, 'persistent', [['foo', 'baz']], true ],
         [`FOR doc IN ${cn} FILTER doc.foo.bar == 1 RETURN 1`, 'persistent', [], false ],
         [`FOR doc IN ${cn} FILTER doc.foo.baz == 1 RETURN 1`, 'persistent', [['foo', 'baz']], true ],
+        [`FOR doc IN ${cn} RETURN [doc.foo.bar, doc.foo.baz]`, 'persistent', [['foo', 'bar'], ['foo', 'baz']], true ],
+        [`FOR doc IN ${cn} RETURN [doc.foo.bar, doc.foo.baz.bar]`, 'persistent', [['foo', 'bar'], ['foo', 'baz', 'bar']], true ],
+        [`FOR doc IN ${cn} FILTER doc.foo.baz == 1 RETURN doc.foo.bar`, 'persistent', [['foo', 'bar'], ['foo', 'baz']], true ],
       ];
 
       queries.forEach(function(query) {
@@ -297,13 +300,11 @@ function projectionsPlansTestSuite () {
         [`FOR doc IN ${cn} RETURN doc.foo.moo`, [['foo', 'moo']] ],
         [`FOR doc IN ${cn} RETURN doc.bar`, ['bar'] ],
         [`FOR doc IN ${cn} RETURN doc.baz`, ['baz'] ],
-        [`FOR doc IN ${cn} RETURN [doc.foo.bar, doc.foo.baz]`, ['foo'] ],
-        [`FOR doc IN ${cn} RETURN [doc.foo.bar, doc.foo.baz.bar]`, ['foo'] ],
         [`FOR doc IN ${cn} RETURN [doc.foo.bar, doc.unrelated]`, [['foo', 'bar'], 'unrelated'] ],
         [`FOR doc IN ${cn} RETURN [doc.foo.baz, doc.unrelated]`, [['foo', 'baz'], 'unrelated'] ],
-        [`FOR doc IN ${cn} RETURN [doc.foo.bar, doc.foo.baz, doc.unrelated]`, ['foo', 'unrelated'] ],
-        [`FOR doc IN ${cn} FILTER doc.foo.baz == 1 RETURN doc.foo.bar`, ['foo'] ],
+        [`FOR doc IN ${cn} RETURN [doc.foo.bar, doc.foo.baz, doc.unrelated]`, [['foo', 'bar'], ['foo', 'baz'], 'unrelated'] ],
       ];
+
 
       queries.forEach(function(query) {
         let plan = AQL_EXPLAIN(query[0]).plan;
@@ -519,7 +520,7 @@ function projectionsPlansTestSuite () {
         [`FOR doc IN ${cn} FILTER doc.foo.bar == 1 RETURN doc.foo.bar`, [['foo', 'bar']] ],
         [`FOR doc IN ${cn} FILTER doc.moo == 1 RETURN doc.foo.bar`, [['foo', 'bar'], 'moo'] ],
         [`FOR doc IN ${cn} FILTER doc.moo == 1 RETURN doc.moo.bar`, ['moo'] ],
-        [`FOR doc IN ${cn} RETURN [doc.foo.a, doc.foo.b, doc.moo]`, ['foo', 'moo'] ],
+        [`FOR doc IN ${cn} RETURN [doc.foo.a, doc.foo.b, doc.moo]`, [['foo', 'a'], ['foo', 'b'], 'moo'] ],
         [`FOR doc IN ${cn} RETURN [doc.a, doc.b, doc.moo]`, ['a', 'b', 'moo'] ],
         [`FOR doc IN ${cn} RETURN [doc.a, doc.b, doc.moo.far]`, ['a', 'b', ['moo', 'far']] ],
       ];
@@ -605,8 +606,8 @@ function projectionsExtractionTestSuite () {
         [`FOR doc IN ${cn} RETURN doc.foo.bar`, [['foo', 'bar']], true, bar ],
         [`FOR doc IN ${cn} RETURN doc.foo.bar.a`, [['foo', 'bar', 'a']], true, barA ],
         [`FOR doc IN ${cn} RETURN doc.foo.baz`, [['foo', 'baz']], true, baz ],
-        [`FOR doc IN ${cn} RETURN [doc.foo.bar.a, doc.foo.bar.b]`, [['foo', 'bar']], true, barAB ],
-        [`FOR doc IN ${cn} RETURN [doc.foo.baz, doc.foo.bar.a]`, ['foo'], true, bazBarA ],
+        [`FOR doc IN ${cn} RETURN [doc.foo.bar.a, doc.foo.bar.b]`, [['foo', 'bar', 'a'], ['foo', 'bar', 'b']], true, barAB ],
+        [`FOR doc IN ${cn} RETURN [doc.foo.baz, doc.foo.bar.a]`, [['foo', 'bar', 'a'], ['foo', 'baz']], true, bazBarA ],
       ];
 
       queries.forEach(function(query) {
@@ -637,8 +638,8 @@ function projectionsExtractionTestSuite () {
         [`FOR doc IN ${cn} RETURN doc.foo.bar`, [['foo', 'bar']], true, bar ],
         [`FOR doc IN ${cn} RETURN doc.foo.baz`, [['foo', 'baz']], false, baz ],
         [`FOR doc IN ${cn} RETURN doc.foo.bar.a`, [['foo', 'bar', 'a']], true, barA ],
-        [`FOR doc IN ${cn} RETURN [doc.foo.bar.a, doc.foo.baz]`, ['foo'], false, barBaz ],
-        [`FOR doc IN ${cn} RETURN [doc.foo.bar.a, doc.foo.bar.b]`, [['foo', 'bar']], true, barBaz ],
+        [`FOR doc IN ${cn} RETURN [doc.foo.bar.a, doc.foo.baz]`, [['foo', 'bar', 'a'], ['foo', 'baz']], false, barBaz ],
+        [`FOR doc IN ${cn} RETURN [doc.foo.bar.a, doc.foo.bar.b]`, [['foo', 'bar', 'a'], ['foo', 'bar', 'b']], true, barBaz ],
       ];
 
       queries.forEach(function(query) {


### PR DESCRIPTION
### Scope & Purpose

Fixed issue #17394: Unnecessary document-lookup instead of Index-Only query. This change improves projection handling so that more projections can be served from indexes.
This also required a few adjustments of existing tests. From the test adjustments it can be seen that now we can serve projections from indexes in more cases than before.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [x] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [x] Tests
  - [ ] **Regression tests**
  - [x] C++ **Unit tests**
  - [x] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: -
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [x] GitHub issue / Jira ticket: #17394 
- [ ] Design document: 