### PR TITLE
fix startup option name

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 v3.10.1 (XXXX-XX-XX)
 --------------------
 
+* Remove superfluous dash character from startup option name
+  `--temp.-intermediate-results-encryption-hardware-acceleration`.
+
 * BTS-941: The HTTP API now delivers the correct list of the collection's shards
   in case a collection from an EnterpriseGraph, SmartGraph, Disjoint
   EnterpriseGraph, Disjoint SmartGraph or SatelliteGraph is being used.

--- a/arangod/RestServer/TemporaryStorageFeature.cpp
+++ b/arangod/RestServer/TemporaryStorageFeature.cpp
@@ -179,7 +179,7 @@ void TemporaryStorageFeature::collectOptions(
 
   options
       ->addOption(
-          "--temp.-intermediate-results-encryption-hardware-acceleration",
+          "--temp.intermediate-results-encryption-hardware-acceleration",
           "use Intel intrinsics-based encryption, requiring a CPU with "
           "the AES-NI instruction set. "
           "If turned off, then OpenSSL is used, which may use "
@@ -189,6 +189,11 @@ void TemporaryStorageFeature::collectOptions(
               arangodb::options::Flags::Enterprise,
               arangodb::options::Flags::Experimental))
       .setIntroducedIn(31000);
+
+  // this fixes an option with a typo in 3.10.x
+  options->addOldOption(
+      "temp.-intermediate-results-encryption-hardware-acceleration",
+      "temp.intermediate-results-encryption-hardware-acceleration");
 #endif
 }
 


### PR DESCRIPTION
### Scope & Purpose

Fix typo in startup option name.
The old (mistyped) option name will still be usable within the 3.10 release series.
The option was introduced in 3.10.0. No need to backport the change.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: -
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 