### PR TITLE
[CINFRA-593] Compaction Test Fix

### DIFF
--- a/tests/js/common/shell/shell-replicated-logs-cluster.js
+++ b/tests/js/common/shell/shell-replicated-logs-cluster.js
@@ -30,6 +30,33 @@ const db = arangodb.db;
 const ERRORS = arangodb.errors;
 const database = "replication2_test_db";
 
+const getLeaderStatus = function (log) {
+  let status = log.status();
+  const leaderId = status.leaderId;
+  if (leaderId === undefined) {
+    console.error(`leader not available for replicated log ${log.id()}`);
+    console.error(JSON.stringify(status));
+    return null;
+  }
+  if (status.participants === undefined || status.participants[leaderId] === undefined) {
+    console.error(`participants status not available for replicated log ${log.id()}`);
+    console.error(JSON.stringify(status));
+    return null;
+  }
+  const leaderResponse = status.participants[leaderId].response;
+  if (leaderResponse === undefined || leaderResponse.role !== "leader") {
+    console.error(`leader not available for replicated log ${log.id()}`);
+    console.error(JSON.stringify(status));
+    return null;
+  }
+  if (!leaderResponse.leadershipEstablished) {
+    console.error(`leadership not yet established`);
+    console.error(JSON.stringify(status));
+    return null;
+  }
+  return status.participants[leaderId].response;
+};
+
 const {setUpAll, tearDownAll} = (function () {
   let previousDatabase, databaseExisted = true;
   return {
@@ -95,33 +122,6 @@ function ReplicatedLogsWriteSuite() {
 
   let log = null;
 
-  const getLeaderStatus = function () {
-    let status = log.status();
-    const leaderId = status.leaderId;
-    if (leaderId === undefined) {
-      console.error(`leader not available for replicated log ${log.id()}`);
-      console.error(JSON.stringify(status));
-      return null;
-    }
-    if (status.participants === undefined || status.participants[leaderId] === undefined) {
-      console.error(`participants status not available for replicated log ${log.id()}`);
-      console.error(JSON.stringify(status));
-      return null;
-    }
-    const leaderResponse = status.participants[leaderId].response;
-    if (leaderResponse === undefined || leaderResponse.role !== "leader") {
-      console.error(`leader not available for replicated log ${log.id()}`);
-      console.error(JSON.stringify(status));
-      return null;
-    }
-    if (!leaderResponse.leadershipEstablished) {
-      console.error(`leadership not yet established`);
-      console.error(JSON.stringify(status));
-      return null;
-    }
-    return status.participants[leaderId].response;
-  };
-
   return {
     setUpAll, tearDownAll,
     setUp: function () {
@@ -132,7 +132,7 @@ function ReplicatedLogsWriteSuite() {
     },
 
     testStatus: function () {
-      let leaderStatus = getLeaderStatus();
+      let leaderStatus = getLeaderStatus(log);
       assertEqual(leaderStatus.local.commitIndex, 1, `log ${log.id()}, leader status: ${JSON.stringify(leaderStatus)}`);
       let globalStatus = log.globalStatus();
       assertEqual(globalStatus.specification.source, "RemoteAgency",
@@ -159,7 +159,7 @@ function ReplicatedLogsWriteSuite() {
         assertTrue(next > index);
         index = next;
       }
-      let leaderStatus = getLeaderStatus();
+      let leaderStatus = getLeaderStatus(log);
       assertTrue(leaderStatus.local.commitIndex >= index);
     },
 
@@ -177,7 +177,7 @@ function ReplicatedLogsWriteSuite() {
             indexes[1] < indexes[2]);
         index = indexes[indexes.length - 1];
       }
-      let leaderStatus = getLeaderStatus();
+      let leaderStatus = getLeaderStatus(log);
       assertTrue(leaderStatus.local.commitIndex >= index);
     },
 
@@ -247,28 +247,14 @@ function ReplicatedLogsWriteSuite() {
       for (let i = 0; i < 2000; i++) {
         log.insert({foo: i});
       }
-      let s1 = getLeaderStatus();
+      let s1 = getLeaderStatus(log);
       assertEqual(s1.local.firstIndex, 1);
       log.release(1500);
-      let s2 = getLeaderStatus();
+      let s2 = getLeaderStatus(log);
       assertEqual(s2.local.firstIndex, 1501);
     },
 
-    testCompact: function () {
-      for (let i = 0; i < 100; i++) {
-        log.insert({foo: i});
-      }
-      const s1 = getLeaderStatus();
-      assertEqual(s1.local.firstIndex, 1);
-      log.release(100);
-      const s2 = getLeaderStatus();
-      assertEqual(s2.local.firstIndex, 1);
-      log.compact();
-      const s3 = getLeaderStatus();
-      assertEqual(s3.local.firstIndex, 101);
-    },
-
-    testPoll: function () {
+   testPoll: function () {
       let index = 0;
       for (let i = 0; i < 100; i++) {
         let next = log.insert({foo: i}).index;
@@ -288,7 +274,45 @@ function ReplicatedLogsWriteSuite() {
   };
 }
 
+function ReplicatedLogsCompactSuite() {
+  'use strict';
+
+  const config = {
+    writeConcern: 3,
+    softWriteConcern: 3,
+    waitForSync: true
+  };
+
+  let log = null;
+
+  return {
+    setUpAll, tearDownAll,
+    setUp: function () {
+      log = db._createReplicatedLog({config});
+    },
+    tearDown: function () {
+      db._replicatedLog(log.id()).drop();
+    },
+
+    testCompact: function () {
+      // It is important the writeConcern is set to maximum, otherwise this test might fail.
+      for (let i = 0; i < 100; i++) {
+        log.insert({foo: i});
+      }
+      const s1 = getLeaderStatus(log);
+      assertEqual(s1.local.firstIndex, 1, JSON.stringify(s1));
+      log.release(100);
+      const s2 = getLeaderStatus(log);
+      assertEqual(s2.local.firstIndex, 1, JSON.stringify(s2));
+      log.compact();
+      const s3 = getLeaderStatus(log);
+      assertEqual(s3.local.firstIndex, 101, JSON.stringify(s3));
+    }
+  };
+}
+
 jsunity.run(ReplicatedLogsCreateSuite);
 jsunity.run(ReplicatedLogsWriteSuite);
+jsunity.run(ReplicatedLogsCompactSuite);
 
 return jsunity.done();


### PR DESCRIPTION
### Scope & Purpose

This PR changes the configuration of a test, which could fail from time to time due to a race.
After compaction, we expected the `firstIndex` of the log to be the highest possible. Because `compactionStop` is calculated as `min(lowestIndexToKeep, releaseIndex)` and `lowestIndexToKeep` depends on the last acknowledged commit index of all followers, WC is now set to 3, so we make sure that all followers have the entire log, which allows us to run full compaction.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [x] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: *(Please link PR)*
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*