### PR TITLE
[PREGEL] PregelShard and PregelId

### DIFF
--- a/arangod/Pregel/Algos/DMID/DMIDMessageFormat.h
+++ b/arangod/Pregel/Algos/DMID/DMIDMessageFormat.h
@@ -48,11 +48,11 @@ struct DMIDMessageFormat : public MessageFormat<DMIDMessage> {
   void addValue(VPackBuilder& arrayBuilder,
                 DMIDMessage const& message) const override {
     arrayBuilder.openArray();
-    arrayBuilder.add(VPackValue(message.senderId.shard));
+    arrayBuilder.add(VPackValue(message.senderId.shard._shard));
     arrayBuilder.add(VPackValuePair(message.senderId.key.data(),
                                     message.senderId.key.size(),
                                     VPackValueType::String));
-    arrayBuilder.add(VPackValue(message.leaderId.shard));
+    arrayBuilder.add(VPackValue(message.leaderId.shard._shard));
     arrayBuilder.add(VPackValuePair(message.leaderId.key.data(),
                                     message.leaderId.key.size(),
                                     VPackValueType::String));

--- a/arangod/Pregel/Algos/DMID/VertexSumAggregator.h
+++ b/arangod/Pregel/Algos/DMID/VertexSumAggregator.h
@@ -57,7 +57,7 @@ struct VertexSumAggregator : public IAggregator {
 
   void parseAggregate(VPackSlice const& slice) override {
     for (auto const& pair : VPackObjectIterator(slice)) {
-      PregelShard shard = std::stoi(pair.key.copyString());
+      auto shard = PregelShard(std::stoi(pair.key.copyString()));
       std::string key;
       VPackValueLength i = 0;
       for (VPackSlice const& val : VPackArrayIterator(pair.value)) {
@@ -75,7 +75,7 @@ struct VertexSumAggregator : public IAggregator {
 
   void setAggregatedValue(VPackSlice const& slice) override {
     for (auto const& pair : VPackObjectIterator(slice)) {
-      PregelShard shard = std::stoi(pair.key.copyString());
+      auto shard = PregelShard(std::stoi(pair.key.copyString()));
       std::string key;
       VPackValueLength i = 0;
       for (VPackSlice const& val : VPackArrayIterator(pair.value)) {
@@ -92,7 +92,7 @@ struct VertexSumAggregator : public IAggregator {
   void serialize(VPackBuilder& builder) const override {
     VPackObjectBuilder b(&builder);
     for (auto const& pair1 : _entries) {
-      builder.add(std::to_string(pair1.first),
+      builder.add(std::to_string(pair1.first._shard),
                   VPackValue(VPackValueType::Array));
       for (auto const& pair2 : pair1.second) {
         builder.add(VPackValuePair(pair2.first.data(), pair2.first.size(),
@@ -105,7 +105,7 @@ struct VertexSumAggregator : public IAggregator {
   void serialize(std::string const& key, VPackBuilder& builder) const override {
     builder.add(key, VPackValue(VPackValueType::Object));
     for (auto const& pair1 : _entries) {
-      builder.add(std::to_string(pair1.first),
+      builder.add(std::to_string(pair1.first._shard),
                   VPackValue(VPackValueType::Array));
       for (auto const& pair2 : pair1.second) {
         builder.add(VPackValuePair(pair2.first.data(), pair2.first.size(),

--- a/arangod/Pregel/Algos/EffectiveCloseness/HLLCounter.cpp
+++ b/arangod/Pregel/Algos/EffectiveCloseness/HLLCounter.cpp
@@ -57,7 +57,7 @@ inline uint8_t _get_leading_zero_count(uint32_t x, uint8_t b) {
 static uint32_t hashPregelId(PregelID const& pregelId) {
   uint32_t h1 =
       fasthash32(pregelId.key.data(), pregelId.key.length(), 0xf007ba11UL);
-  uint64_t h2 = fasthash64_uint64(pregelId.shard, 0xdefec7edUL);
+  uint64_t h2 = fasthash64_uint64(pregelId.shard._shard, 0xdefec7edUL);
   uint32_t h3 = (uint32_t)(h2 - (h2 >> 32));
   return h1 ^ (h3 << 1);
 }

--- a/arangod/Pregel/CommonFormats.h
+++ b/arangod/Pregel/CommonFormats.h
@@ -152,7 +152,7 @@ struct SenderMessageFormat : public MessageFormat<SenderMessage<T>> {
   void addValue(VPackBuilder& arrayBuilder,
                 SenderMessage<T> const& senderVal) const override {
     arrayBuilder.openArray();
-    arrayBuilder.add(VPackValue(senderVal.senderId.shard));
+    arrayBuilder.add(VPackValue(senderVal.senderId.shard._shard));
     arrayBuilder.add(VPackValuePair(senderVal.senderId.key.data(),
                                     senderVal.senderId.key.size(),
                                     VPackValueType::String));

--- a/arangod/Pregel/Messaging/PregelId.h
+++ b/arangod/Pregel/Messaging/PregelId.h
@@ -1,0 +1,59 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2022 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Markus Pfeiffer
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include <Inspection/VPackWithErrorT.h>
+
+#include "PregelShard.h"
+
+namespace arangodb::pregel {
+
+struct PregelID {
+  PregelShard shard;
+  std::string key;
+
+  PregelID() = default;
+  PregelID(PregelShard s, std::string k) : shard(s), key(std::move(k)) {}
+
+  [[nodiscard]] bool operator==(const PregelID& rhs) const = default;
+
+  bool operator<(const PregelID& rhs) const {
+    return shard < rhs.shard || (shard == rhs.shard && key < rhs.key);
+  }
+
+  [[nodiscard]] bool isValid() const { return shard.isValid() && !key.empty(); }
+};
+
+}  // namespace arangodb::pregel
+
+namespace std {
+template<>
+struct hash<arangodb::pregel::PregelID> {
+  std::size_t operator()(const arangodb::pregel::PregelID& k) const noexcept {
+    size_t h1 = std::hash<arangodb::pregel::PregelShard>()(k.shard);
+    size_t h2 = std::hash<std::string>()(k.key);
+    return h2 ^ (h1 << 1);
+  }
+};
+}  // namespace std

--- a/arangod/Pregel/Messaging/PregelShard.h
+++ b/arangod/Pregel/Messaging/PregelShard.h
@@ -1,0 +1,58 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2022 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Markus Pfeiffer
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include <Inspection/VPackWithErrorT.h>
+
+namespace arangodb::pregel {
+
+struct PregelShard {
+  PregelShard() : _shard(InvalidPregelShard){};
+  explicit PregelShard(uint16_t shard) : _shard(shard) {}
+
+  [[nodiscard]] auto isValid() const { return _shard != InvalidPregelShard; };
+
+  [[nodiscard]] auto operator<=>(const PregelShard& rhs) const = default;
+
+  static const std::uint16_t InvalidPregelShard = -1;
+  std::uint16_t _shard = InvalidPregelShard;
+};
+
+template<typename Inspector>
+auto inspect(Inspector& f, PregelShard& x) {
+  return f.object(x).fields(f.field("shard", x._shard));
+}
+
+}  // namespace arangodb::pregel
+
+namespace std {
+template<>
+struct hash<arangodb::pregel::PregelShard> {
+  std::size_t operator()(
+      const arangodb::pregel::PregelShard& k) const noexcept {
+    return std::hash<std::uint16_t>()(k._shard);
+  }
+};
+
+}  // namespace std

--- a/arangod/Pregel/OutgoingCache.cpp
+++ b/arangod/Pregel/OutgoingCache.cpp
@@ -68,7 +68,7 @@ template<typename M>
 void ArrayOutCache<M>::appendMessage(PregelShard shard,
                                      std::string_view const& key,
                                      M const& data) {
-  _sendCountPerShard[this->_config->globalShardIDs()[shard]]++;
+  _sendCountPerShard[this->_config->globalShardIDs()[shard._shard]]++;
   if (this->_config->isLocalVertexShard(shard)) {
     if (this->_sendToNextGSS) {  // I use the global cache, we need locking
       this->_localCacheNextGSS->storeMessage(shard, key, data);
@@ -133,7 +133,7 @@ void ArrayOutCache<M>::flushMessages() {
     auto [shardMessageCount, messageVPack] = messagesToVPack(vertexMessageMap);
     responses.emplace_back(connection.sendWithoutRetry(
         Destination{Destination::Type::shard,
-                    this->_config->globalShardIDs()[shard]},
+                    this->_config->globalShardIDs()[shard._shard]},
         ModernMessage{.executionNumber = this->_config->executionNumber(),
                       .payload = PregelMessage{
                           .senderId = ServerState::instance()->getId(),
@@ -177,7 +177,7 @@ void CombiningOutCache<M>::appendMessage(PregelShard shard,
                                          std::string_view const& key,
                                          M const& data) {
   if (this->_config->isLocalVertexShard(shard)) {
-    _sendCountPerShard[this->_config->globalShardIDs()[shard]]++;
+    _sendCountPerShard[this->_config->globalShardIDs()[shard._shard]]++;
     if (this->_sendToNextGSS) {
       this->_localCacheNextGSS->storeMessage(shard, key, data);
       this->_sendCountNextGSS++;
@@ -193,7 +193,7 @@ void CombiningOutCache<M>::appendMessage(PregelShard shard,
       auto& ref = (*it).second;  // will be modified by combine(...)
       _combiner->combine(ref, data);
     } else {  // first message for this vertex
-      _sendCountPerShard[this->_config->globalShardIDs()[shard]]++;
+      _sendCountPerShard[this->_config->globalShardIDs()[shard._shard]]++;
       vertexMap.try_emplace(key, data);
 
       if (++(this->_containedMessages) >= this->_batchSize) {
@@ -242,7 +242,7 @@ void CombiningOutCache<M>::flushMessages() {
 
     responses.emplace_back(connection.sendWithoutRetry(
         Destination{Destination::Type::shard,
-                    this->_config->globalShardIDs()[shard]},
+                    this->_config->globalShardIDs()[shard._shard]},
         ModernMessage{.executionNumber = this->_config->executionNumber(),
                       .payload = PregelMessage{
                           .senderId = ServerState::instance()->getId(),

--- a/arangod/Pregel/Worker/GraphStore.cpp
+++ b/arangod/Pregel/Worker/GraphStore.cpp
@@ -101,7 +101,7 @@ auto ClusterShardResolver::getShard(DocumentId const& documentId,
             TRI_errno_string(res)));
   }
   auto shard = config->shardId(responsibleShard);
-  if (shard == InvalidPregelShard) {
+  if (!shard.isValid()) {
     return ResultT<PregelShard>::error(
         TRI_ERROR_CLUSTER_SHARD_GONE, "Could not resolve target shard of edge");
   }
@@ -112,7 +112,7 @@ auto SingleServerShardResolver::getShard(DocumentId const& documentId,
                                          WorkerConfig* config)
     -> ResultT<PregelShard> {
   auto shard = config->shardId(documentId._collectionName);
-  if (shard == InvalidPregelShard) {
+  if (!shard.isValid()) {
     return ResultT<PregelShard>::error(
         TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND,
         "Could not resolve target collection of edge");
@@ -589,7 +589,7 @@ auto GraphStore<V, E>::storeVertices(
   std::unique_ptr<arangodb::SingleCollectionTransaction> trx;
 
   ShardID shard;
-  PregelShard currentShard = InvalidPregelShard;
+  PregelShard currentShard;
   Result res;
 
   VPackBuilder builder;
@@ -657,7 +657,7 @@ auto GraphStore<V, E>::storeVertices(
       }
 
       currentShard = it->shard();
-      shard = globalShards[currentShard];
+      shard = globalShards[currentShard._shard];
 
       auto ctx =
           transaction::StandaloneContext::Create(_vocbaseGuard.database());

--- a/arangod/Pregel/Worker/Worker.cpp
+++ b/arangod/Pregel/Worker/Worker.cpp
@@ -577,8 +577,8 @@ auto Worker<V, E, M>::_resultsFct(CollectPregelResults const& message) const
   for (; it.hasMore(); ++it) {
     Vertex<V, E> const* vertexEntry = *it;
 
-    TRI_ASSERT(vertexEntry->shard() < _config.globalShardIDs().size());
-    ShardID const& shardId = _config.globalShardIDs()[vertexEntry->shard()];
+    TRI_ASSERT(vertexEntry->shard()._shard < _config.globalShardIDs().size());
+    ShardID const& shardId = _config.globalShardIDs()[vertexEntry->shard()._shard];
 
     result.openObject(/*unindexed*/ true);
 

--- a/arangod/Pregel/Worker/WorkerConfig.cpp
+++ b/arangod/Pregel/Worker/WorkerConfig.cpp
@@ -53,9 +53,9 @@ void WorkerConfig::updateConfig(PregelFeature& feature,
   // list of all shards, equal on all workers. Used to avoid storing strings of
   // shard names
   // Instead we have an index identifying a shard name in this vector
-  PregelShard i = 0;
+  size_t i = 0;
   for (auto const& shard : _globalShardIDs) {
-    _pregelShardIDs.try_emplace(shard, i++);  // Cache these ids
+    _pregelShardIDs.try_emplace(shard, PregelShard(i++));  // Cache these ids
   }
 
   // To access information based on a user defined collection name we need the

--- a/arangod/Pregel/Worker/WorkerConfig.h
+++ b/arangod/Pregel/Worker/WorkerConfig.h
@@ -119,7 +119,7 @@ class WorkerConfig {
 
   inline PregelShard shardId(ShardID const& responsibleShard) const {
     auto const& it = _pregelShardIDs.find(responsibleShard);
-    return it != _pregelShardIDs.end() ? it->second : InvalidPregelShard;
+    return it != _pregelShardIDs.end() ? it->second : PregelShard{};
   }
 
   // index in globalShardIDs


### PR DESCRIPTION
### Scope & Purpose

Wrap the `uint16_t` that was posing as `PregelShard` in a struct and move `PregelId` into its own include.

This is part of the rewrite of GraphStore.