### PR TITLE
remove always-true subcondition

### DIFF
--- a/arangod/RestHandler/RestDocumentStateHandler.cpp
+++ b/arangod/RestHandler/RestDocumentStateHandler.cpp
@@ -88,7 +88,7 @@ RestStatus RestDocumentStateHandler::handleGetSnapshot(
   auto waitForIndexParam =
       _request->parsedValue<decltype(replication2::LogIndex::value)>(
           "waitForIndex");
-  if (!waitForIndexParam.has_value() || waitForIndexParam.value() < 0) {
+  if (!waitForIndexParam.has_value()) {
     generateError(rest::ResponseCode::BAD, TRI_ERROR_HTTP_BAD_PARAMETER,
                   "invalid waitForIndex parameter");
     return RestStatus::DONE;


### PR DESCRIPTION
### Scope & Purpose

Remove always-true subcondition.

Fixes compile warning
``` 
arangod/RestHandler/RestDocumentStateHandler.cpp: In member function ‘arangodb::RestStatus arangodb::RestDocumentStateHandler::handleGetSnapshot(const arangodb::replication2::DocumentStateMethods&, arangodb::replication2::LogId)’:
arangod/RestHandler/RestDocumentStateHandler.cpp:91:67: warning: comparison of unsigned expression in ‘< 0’ is always false [-Wtype-limits]
   91 |   if (!waitForIndexParam.has_value() || waitForIndexParam.value() < 0) {
      |                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~
```

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: -
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 