### PR TITLE
clean up gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,14 +2,13 @@
 VERSION eol=lf
 VERSIONS eol=lf
 scripts/unittest eol=lf
-*.groovy eol=lf
 *.csv binary
 *.json eol=lf
 VERSION merge=ours
 STARTER_REV merge=ours
-lib/V8/v8-json.cpp merge=ours
 arangod/Aql/tokens.cpp merge=ours
 arangod/Aql/grammar.cpp merge=ours
 js/apps/system/_admin/aardvark/APP/api-docs.json merge=ours
+js/node/node_modules/* linguist-vendored
 tests/* linguist-vendored
 3rdParty/* linguist-vendored


### PR DESCRIPTION
### Scope & Purpose

Remove references to non-existing files from .gitattributes, and add `node_modules` as vendored.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: -
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 