### PR TITLE
test must not assert during test setup to get proper results!

### DIFF
--- a/tests/js/client/active-failover/basic.js
+++ b/tests/js/client/active-failover/basic.js
@@ -427,14 +427,17 @@ function installFoxx(mountpoint, which, mode) {
 // the active failover functionality. It is designed as a quicker
 // variant of the node resilience tests (for active failover).
 function ActiveFailoverSuite() {
-  let servers = getClusterEndpoints();
-  assertTrue(servers.length >= 4, "This test expects four single instances");
-  let firstLeader = servers[0];
+  let servers;
+  let firstLeader;
   let suspended = [];
-  let currentLead = leaderInAgency();
+  let currentLead;
 
   return {
     setUpAll: function () {
+      servers = getClusterEndpoints();
+      assertTrue(servers.length >= 4, "This test expects four single instances " + JSON.stringify(servers));
+      firstLeader = servers[0];
+      currentLead = leaderInAgency();
       db._create(cname);
     },
 

--- a/tests/js/client/active-failover/readonly.js
+++ b/tests/js/client/active-failover/readonly.js
@@ -277,14 +277,17 @@ function setReadOnly(endpoint, ro) {
 // Testsuite that checks the read-only mode in the context
 // of the active-failover setup
 function ActiveFailoverSuite() {
-  let servers = getClusterEndpoints();
-  assertTrue(servers.length >= 4, "This test expects four single instances");
-  let firstLeader = servers[0];
+  let servers;
+  let firstLeader;
   let suspended = [];
-  let currentLead = leaderInAgency();
+  let currentLead;
 
   return {
     setUpAll: function () {
+      servers = getClusterEndpoints();
+      assertTrue(servers.length >= 4, "This test expects four single instances " + JSON.stringify(servers));
+      firstLeader = servers[0];
+      currentLead = leaderInAgency();
       db._create(cname);
     },
 


### PR DESCRIPTION
### Scope & Purpose

test would run code outside of regular test plans, and hence produce broken results. Move code to `setUpAll`.

- [x] :hankey: Bugfix
