### PR TITLE
Enable "collect-in-cluster" optimizer rule for SmartGraph edge collections

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 devel
 -----
 
+* Enable "collect-in-cluster" optimizer rule for SmartGraph edge collections.
+
 * Improve performance and memory usage of IN list lookups for hash, skiplist
   and persistent indexes.
 

--- a/arangod/Aql/OptimizerRules.cpp
+++ b/arangod/Aql/OptimizerRules.cpp
@@ -4556,19 +4556,23 @@ void arangodb::aql::collectInClusterRule(Optimizer* opt,
           auto p = previous;
           while (p != nullptr) {
             switch (p->getType()) {
-              case ExecutionNode::REMOTE:
+              case ExecutionNode::REMOTE: {
                 hasFoundMultipleShards = true;
                 break;
+              }
               case ExecutionNode::ENUMERATE_COLLECTION:
               case ExecutionNode::INDEX: {
                 auto col = getCollection(p);
-                if (col->numberOfShards() > 1) {
+                if (col->numberOfShards() > 1 ||
+                    (col->type() == TRI_COL_TYPE_EDGE && col->isSmart())) {
                   hasFoundMultipleShards = true;
                 }
-              } break;
-              case ExecutionNode::TRAVERSAL:
+                break;
+              }
+              case ExecutionNode::TRAVERSAL: {
                 hasFoundMultipleShards = true;
                 break;
+              }
               case ExecutionNode::ENUMERATE_IRESEARCH_VIEW: {
                 auto& viewNode = *ExecutionNode::castTo<IResearchViewNode*>(p);
                 auto collections = viewNode.collections();
@@ -4579,7 +4583,8 @@ void arangodb::aql::collectInClusterRule(Optimizer* opt,
                   hasFoundMultipleShards =
                       collections.front().first.get().numberOfShards() > 1;
                 }
-              } break;
+                break;
+              }
               default:
                 break;
             }

--- a/tests/js/server/aql/aql-optimizer-collect-count.js
+++ b/tests/js/server/aql/aql-optimizer-collect-count.js
@@ -28,12 +28,12 @@
 /// @author Copyright 2012, triAGENS GmbH, Cologne, Germany
 ////////////////////////////////////////////////////////////////////////////////
 
-var jsunity = require("jsunity");
-var internal = require("internal");
-var errors = internal.errors;
-var db = require("@arangodb").db;
-var helper = require("@arangodb/aql-helper");
-var assertQueryError = helper.assertQueryError;
+const jsunity = require("jsunity");
+const internal = require("internal");
+const errors = internal.errors;
+const db = require("@arangodb").db;
+const helper = require("@arangodb/aql-helper");
+const assertQueryError = helper.assertQueryError;
 const isCluster = require("@arangodb/cluster").isCluster();
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -41,7 +41,7 @@ const isCluster = require("@arangodb/cluster").isCluster();
 ////////////////////////////////////////////////////////////////////////////////
 
 function optimizerCountTestSuite () {
-  var c;
+  let c;
 
   return {
     setUpAll : function () {
@@ -52,7 +52,7 @@ function optimizerCountTestSuite () {
       for (var i = 0; i < 1000; ++i) {
         docs.push({ group: "test" + (i % 10), value: i });
       }
-      c.save(docs);
+      c.insert(docs);
     },
 
     tearDownAll : function () {
@@ -690,10 +690,6 @@ function optimizerDoubleCollectTestSuite() {
     },
   };
 }
-
-////////////////////////////////////////////////////////////////////////////////
-/// @brief executes the test suite
-////////////////////////////////////////////////////////////////////////////////
 
 jsunity.run(optimizerCountTestSuite);
 jsunity.run(optimizerCountWriteTestSuite);

--- a/tests/js/server/aql/aql-optimizer-rule-collect-in-cluster.js
+++ b/tests/js/server/aql/aql-optimizer-rule-collect-in-cluster.js
@@ -379,7 +379,15 @@ function optimizerCollectInClusterSingleShardSuite(isSearchAlias) {
       });
 
       assertEqual(-1, plan.rules.indexOf("collect-in-cluster"));
-      assertEqual(["SingletonNode", "EnumerateCollectionNode", "CalculationNode", "CollectNode", "SortNode", "CalculationNode", "RemoteNode", "GatherNode", "ReturnNode"], nodeTypes);
+
+      if (internal.isEnterprise()) {
+        assertNotEqual(-1, plan.rules.indexOf("cluster-one-shard"));
+        // one shard rule has kicked in as well and modified the plan accordingly
+        assertEqual(["SingletonNode", "EnumerateCollectionNode", "CalculationNode", "CollectNode", "SortNode", "CalculationNode", "RemoteNode", "GatherNode", "ReturnNode"], nodeTypes);
+      } else {
+        assertEqual(-1, plan.rules.indexOf("cluster-one-shard"));
+        assertEqual(["SingletonNode", "EnumerateCollectionNode", "CalculationNode", "RemoteNode", "GatherNode", "CollectNode", "SortNode", "CalculationNode", "ReturnNode"], nodeTypes);
+      }
     },
 
     testSingleDistinct: function () {

--- a/tests/js/server/aql/aql-optimizer-rule-collect-in-cluster.js
+++ b/tests/js/server/aql/aql-optimizer-rule-collect-in-cluster.js
@@ -28,18 +28,14 @@
 /// @author Copyright 2012, triAGENS GmbH, Cologne, Germany
 ////////////////////////////////////////////////////////////////////////////////
 
-var jsunity = require("jsunity");
-var internal = require("internal");
-var errors = internal.errors;
-var db = require("@arangodb").db;
-var helper = require("@arangodb/aql-helper");
-var assertQueryError = helper.assertQueryError;
+const jsunity = require("jsunity");
+const internal = require("internal");
+const errors = internal.errors;
+const db = require("@arangodb").db;
+const helper = require("@arangodb/aql-helper");
+const assertQueryError = helper.assertQueryError;
 const isCluster = require("@arangodb/cluster").isCluster();
 const deriveTestSuite = require('@arangodb/test-helper').deriveTestSuite;
-
-////////////////////////////////////////////////////////////////////////////////
-/// @brief test suite
-////////////////////////////////////////////////////////////////////////////////
 
 function optimizerCollectInClusterSuite(isSearchAlias) {
   let c;
@@ -76,9 +72,11 @@ function optimizerCollectInClusterSuite(isSearchAlias) {
           });
       }
 
+      let docs = [];
       for (let i = 0; i < 1000; ++i) {
-        c.save({group: "test" + (i % 10), value: i});
+        docs.push({group: "test" + (i % 10), value: i});
       }
+      c.insert(docs);
 
       // sync the view
       db._query("FOR d IN UnitTestViewSorted OPTIONS {waitForSync:true} LIMIT 1 RETURN d");
@@ -151,6 +149,26 @@ function optimizerCollectInClusterSuite(isSearchAlias) {
 
       assertNotEqual(-1, plan.rules.indexOf("collect-in-cluster"));
       assertEqual(["SingletonNode", "EnumerateViewNode", "RemoteNode", "GatherNode", "ScatterNode", "RemoteNode", "EnumerateViewNode", "CollectNode", "RemoteNode", "GatherNode", "CollectNode", "ReturnNode"], nodeTypes);
+    },
+    
+    testCountGroups: function () {
+      let query = "FOR doc IN " + c.name() + " COLLECT value = doc.group WITH COUNT INTO length SORT value RETURN { value, length }";
+      let results = AQL_EXECUTE(query);
+      
+      let expected = [];
+      for (let i = 0; i < 10; ++i) {
+        expected.push({ value: "test" + i, length: 100 });
+      }
+      assertEqual(expected.length, results.json.length);
+      assertEqual(expected, results.json);
+
+      let plan = AQL_EXPLAIN(query).plan;
+      let nodeTypes = plan.nodes.map(function (node) {
+        return node.type === 'IndexNode' ? 'EnumerateCollectionNode' : node.type;
+      });
+
+      assertNotEqual(-1, plan.rules.indexOf("collect-in-cluster"));
+      assertEqual(["SingletonNode", "EnumerateCollectionNode", "CalculationNode", "CollectNode", "RemoteNode", "GatherNode", "CollectNode", "SortNode", "CalculationNode", "ReturnNode"], nodeTypes);
     },
 
     testDistinct: function () {
@@ -265,9 +283,12 @@ function optimizerCollectInClusterSingleShardSuite(isSearchAlias) {
           });
       }
 
+      let docs = [];
       for (let i = 0; i < 1000; ++i) {
-        c.save({group: "test" + (i % 10), value: i});
+        docs.push({group: "test" + (i % 10), value: i});
       }
+      c.insert(docs);
+
       // sync the view
       db._query("FOR d IN UnitTestViewSorted OPTIONS {waitForSync:true} LIMIT 1 RETURN d");
     },
@@ -339,6 +360,26 @@ function optimizerCollectInClusterSingleShardSuite(isSearchAlias) {
 
       assertNotEqual(-1, plan.rules.indexOf("collect-in-cluster"));
       assertEqual(["SingletonNode", "EnumerateViewNode", "RemoteNode", "GatherNode", "ScatterNode", "RemoteNode", "EnumerateViewNode", "CollectNode", "RemoteNode", "GatherNode", "CollectNode", "ReturnNode"], nodeTypes);
+    },
+    
+    testSingleCountGroups: function () {
+      let query = "FOR doc IN " + c.name() + " COLLECT value = doc.group WITH COUNT INTO length SORT value RETURN { value, length }";
+      let results = AQL_EXECUTE(query);
+      
+      let expected = [];
+      for (let i = 0; i < 10; ++i) {
+        expected.push({ value: "test" + i, length: 100 });
+      }
+      assertEqual(expected.length, results.json.length);
+      assertEqual(expected, results.json);
+
+      let plan = AQL_EXPLAIN(query).plan;
+      let nodeTypes = plan.nodes.map(function (node) {
+        return node.type === 'IndexNode' ? 'EnumerateCollectionNode' : node.type;
+      });
+
+      assertEqual(-1, plan.rules.indexOf("collect-in-cluster"));
+      assertEqual(["SingletonNode", "EnumerateCollectionNode", "CalculationNode", "CollectNode", "SortNode", "CalculationNode", "RemoteNode", "GatherNode", "ReturnNode"], nodeTypes);
     },
 
     testSingleDistinct: function () {
@@ -416,6 +457,130 @@ function optimizerCollectInClusterSingleShardSuite(isSearchAlias) {
   };
 }
 
+function optimizerCollectInClusterSuiteSmartGraph() {
+  const vn = "UnitTestsVertex";
+  const en = "UnitTestsEdge";
+  const gn = "UnitTestsSmartGraph";
+  const smrt = require("@arangodb/smart-graph");
+
+  return {
+    setUpAll: function () {
+      try {
+        smrt._drop(gn, true);
+      } catch (err) {}
+
+      smrt._create(gn, [smrt._relation(en, vn, vn)], [], { smartGraphAttribute: "group", numberOfShards: 3, isSmart: true });
+
+      let docs = [];
+      for (let i = 0; i < 1000; ++i) {
+        docs.push({group: "test" + (i % 10), value: i});
+      }
+      let keys = db[vn].insert(docs);
+      assertEqual(1000, db[vn].count());
+      
+      docs = [];
+      for (let i = 0; i < 1000; ++i) {
+        docs.push({_from: keys[i]._id, _to: keys[keys.length - i - 1]._id, value: i, group: "test" + (i % 10)});
+      }
+      db[en].insert(docs);
+
+      assertEqual(1000, db[en].count());
+    },
+
+    tearDownAll: function () {
+      smrt._drop(gn, true);
+    },
+
+    testCount: function () {
+      let query = "FOR doc IN " + en + " COLLECT WITH COUNT INTO length RETURN length";
+
+      let results = AQL_EXECUTE(query);
+      assertEqual(1, results.json.length);
+      assertEqual(1000, results.json[0]);
+
+      let plan = AQL_EXPLAIN(query).plan;
+      let nodeTypes = plan.nodes.map(function (node) {
+        return node.type === 'IndexNode' ? 'EnumerateCollectionNode' : node.type;
+      });
+
+      assertNotEqual(-1, plan.rules.indexOf("collect-in-cluster"));
+      assertEqual(["SingletonNode", "EnumerateCollectionNode", "CollectNode", "RemoteNode", "GatherNode", "CollectNode", "ReturnNode"], nodeTypes);
+    },
+
+    testCountMulti: function () {
+      let query = "FOR doc1 IN " + en + " FILTER doc1.value < 10 FOR doc2 IN " + en + " COLLECT WITH COUNT INTO length RETURN length";
+      let results = AQL_EXECUTE(query);
+      assertEqual(1, results.json.length);
+      assertEqual(10000, results.json[0]);
+
+      let plan = AQL_EXPLAIN(query).plan;
+      let nodeTypes = plan.nodes.map(function (node) {
+        return node.type === 'IndexNode' ? 'EnumerateCollectionNode' : node.type;
+      });
+
+      assertNotEqual(-1, plan.rules.indexOf("collect-in-cluster"));
+      assertEqual(["SingletonNode", "EnumerateCollectionNode", "RemoteNode", "GatherNode", "ScatterNode", "RemoteNode", "EnumerateCollectionNode", "CollectNode", "RemoteNode", "GatherNode", "CollectNode", "ReturnNode"], nodeTypes);
+    },
+    
+    testCountGroups: function () {
+      let query = "FOR doc IN " + en + " COLLECT value = doc.group WITH COUNT INTO length SORT value RETURN { value, length }";
+      let results = AQL_EXECUTE(query);
+      
+      let expected = [];
+      for (let i = 0; i < 10; ++i) {
+        expected.push({ value: "test" + i, length: 100 });
+      }
+      assertEqual(expected.length, results.json.length);
+      assertEqual(expected, results.json);
+
+      let plan = AQL_EXPLAIN(query).plan;
+      let nodeTypes = plan.nodes.map(function (node) {
+        return node.type === 'IndexNode' ? 'EnumerateCollectionNode' : node.type;
+      });
+
+      assertNotEqual(-1, plan.rules.indexOf("collect-in-cluster"));
+      assertEqual(["SingletonNode", "EnumerateCollectionNode", "CalculationNode", "CollectNode", "RemoteNode", "GatherNode", "CollectNode", "SortNode", "CalculationNode", "ReturnNode"], nodeTypes);
+    },
+
+    testDistinct: function () {
+      let query = "FOR doc IN " + en + " SORT doc.value RETURN DISTINCT doc.value";
+
+      let results = AQL_EXECUTE(query);
+      assertEqual(1000, results.json.length);
+      for (let i = 0; i < 1000; ++i) {
+        assertEqual(i, results.json[i]);
+      }
+
+      let plan = AQL_EXPLAIN(query).plan;
+      let nodeTypes = plan.nodes.map(function (node) {
+        return node.type;
+      });
+
+      assertNotEqual(-1, plan.rules.indexOf("collect-in-cluster"));
+      assertEqual(["SingletonNode", "EnumerateCollectionNode", "CalculationNode", "SortNode", "CollectNode", "RemoteNode", "GatherNode", "CollectNode", "ReturnNode"], nodeTypes);
+    },
+
+    testDistinctMulti: function () {
+      let query = "FOR doc1 IN " + en + " FILTER doc1.value < 10 FOR doc2 IN " + en + " SORT doc2.value RETURN DISTINCT doc2.value";
+
+      let results = AQL_EXECUTE(query, null, {optimizer: {rules: ["-interchange-adjacent-enumerations"]}});
+      assertEqual(1000, results.json.length);
+      for (let i = 0; i < 1000; ++i) {
+        assertEqual(i, results.json[i]);
+      }
+
+      let plan = AQL_EXPLAIN(query).plan;
+      let nodeTypes = plan.nodes.map(function (node) {
+        return node.type;
+      });
+
+      assertNotEqual(-1, plan.rules.indexOf("collect-in-cluster"));
+      assertEqual(["SingletonNode", "EnumerateCollectionNode", "RemoteNode", "GatherNode", "ScatterNode", "RemoteNode", "EnumerateCollectionNode", "CalculationNode", "SortNode", "CollectNode", "RemoteNode", "GatherNode", "CollectNode", "ReturnNode"], nodeTypes);
+    },
+
+  };
+}
+
 
 function optimizerCollectInClusterArangoSearchSuite() {
   let suite = {};
@@ -461,5 +626,8 @@ jsunity.run(optimizerCollectInClusterArangoSearchSuite);
 jsunity.run(optimizerCollectInClusterSearchAliasSuite);
 jsunity.run(optimizerCollectInClusterSingleShardArangoSearchSuite);
 jsunity.run(optimizerCollectInClusterSingleShardSearchAliasSuite);
+if (internal.isEnterprise()) {
+  jsunity.run(optimizerCollectInClusterSuiteSmartGraph);
+}
 
 return jsunity.done();


### PR DESCRIPTION
### Scope & Purpose

Enable "collect-in-cluster" optimizer rule for SmartGraph edge collections, too.
Previously SmartGraph edge collections were excluded from the optimization because they report to have 0 shards.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [x] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [x] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: -
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 