### PR TITLE
[CINFRA] Ping Replicated Log

### DIFF
--- a/arangod/Replication2/Methods.cpp
+++ b/arangod/Replication2/Methods.cpp
@@ -612,7 +612,7 @@ struct ReplicatedLogMethodsCoordinator final
   auto ping(LogId id, std::optional<std::string> message) const
       -> futures::Future<
           std::pair<LogIndex, replicated_log::WaitForResult>> override {
-    auto path = basics::StringUtils::joinT("/", "_api/log", id, "insert");
+    auto path = basics::StringUtils::joinT("/", "_api/log", id, "ping");
 
     VPackBufferUInt8 payload;
     if (message) {

--- a/arangod/Replication2/Methods.h
+++ b/arangod/Replication2/Methods.h
@@ -110,6 +110,9 @@ struct ReplicatedLogMethods {
   virtual auto tail(LogId, std::size_t limit) const
       -> futures::Future<std::unique_ptr<PersistedLogIterator>> = 0;
 
+  virtual auto ping(LogId, std::optional<std::string> message) const
+      -> futures::Future<
+          std::pair<LogIndex, replicated_log::WaitForResult>> = 0;
   virtual auto insert(LogId, LogPayload, bool waitForSync) const
       -> futures::Future<
           std::pair<LogIndex, replicated_log::WaitForResult>> = 0;

--- a/arangod/Replication2/ReplicatedLog/ILogInterfaces.h
+++ b/arangod/Replication2/ReplicatedLog/ILogInterfaces.h
@@ -115,7 +115,7 @@ struct ILogLeader : ILogParticipant {
   virtual auto insert(LogPayload payload, bool waitForSync,
                       DoNotTriggerAsyncReplication) -> LogIndex = 0;
   virtual void triggerAsyncReplication() = 0;
-  virtual auto ping(std::optional<std::string> message) -> WaitForFuture = 0;
+  virtual auto ping(std::optional<std::string> message) -> LogIndex = 0;
 
   [[nodiscard]] virtual auto isLeadershipEstablished() const noexcept
       -> bool = 0;

--- a/arangod/Replication2/ReplicatedLog/ILogInterfaces.h
+++ b/arangod/Replication2/ReplicatedLog/ILogInterfaces.h
@@ -115,6 +115,7 @@ struct ILogLeader : ILogParticipant {
   virtual auto insert(LogPayload payload, bool waitForSync,
                       DoNotTriggerAsyncReplication) -> LogIndex = 0;
   virtual void triggerAsyncReplication() = 0;
+  virtual auto ping(std::optional<std::string> message) -> WaitForFuture = 0;
 
   [[nodiscard]] virtual auto isLeadershipEstablished() const noexcept
       -> bool = 0;

--- a/arangod/Replication2/ReplicatedLog/LogEntries.cpp
+++ b/arangod/Replication2/ReplicatedLog/LogEntries.cpp
@@ -203,63 +203,12 @@ auto LogEntryView::clonePayload() const -> LogPayload {
   return LogPayload::createFromSlice(_payload);
 }
 
-namespace {
-constexpr std::string_view StringFirstIndexOfTerm = "FirstIndexOfTerm";
-constexpr std::string_view StringUpdateParticipantsConfig =
-    "UpdateParticipantsConfig";
-}  // namespace
-
 auto LogMetaPayload::fromVelocyPack(velocypack::Slice s) -> LogMetaPayload {
-  auto typeSlice = s.get(StaticStrings::IndexType);
-  if (typeSlice.isEqualString(StringFirstIndexOfTerm)) {
-    return {FirstEntryOfTerm::fromVelocyPack(s)};
-  } else if (typeSlice.isEqualString(StringUpdateParticipantsConfig)) {
-    return {UpdateParticipantsConfig::fromVelocyPack(s)};
-  } else {
-    TRI_ASSERT(false);
-    THROW_ARANGO_EXCEPTION(TRI_ERROR_BAD_PARAMETER);
-  }
+  return velocypack::deserialize<LogMetaPayload>(s);
 }
 
 void LogMetaPayload::toVelocyPack(velocypack::Builder& builder) const {
-  std::visit([&](auto const& v) { v.toVelocyPack(builder); }, info);
-}
-
-void LogMetaPayload::FirstEntryOfTerm::toVelocyPack(
-    velocypack::Builder& b) const {
-  velocypack::ObjectBuilder ob(&b);
-  b.add(StaticStrings::IndexType, velocypack::Value(StringFirstIndexOfTerm));
-  b.add(StaticStrings::Leader, velocypack::Value(leader));
-  b.add(velocypack::Value(StaticStrings::Participants));
-  velocypack::serialize(b, participants);
-}
-
-void LogMetaPayload::UpdateParticipantsConfig::toVelocyPack(
-    velocypack::Builder& b) const {
-  velocypack::ObjectBuilder ob(&b);
-  b.add(StaticStrings::IndexType,
-        velocypack::Value(StringUpdateParticipantsConfig));
-  b.add(velocypack::Value(StaticStrings::Participants));
-  velocypack::serialize(b, participants);
-}
-
-auto LogMetaPayload::UpdateParticipantsConfig::fromVelocyPack(
-    velocypack::Slice s) -> UpdateParticipantsConfig {
-  TRI_ASSERT(s.get(StaticStrings::IndexType)
-                 .isEqualString(StringUpdateParticipantsConfig));
-  auto participants = velocypack::deserialize<agency::ParticipantsConfig>(
-      s.get(StaticStrings::Participants));
-  return UpdateParticipantsConfig{std::move(participants)};
-}
-
-auto LogMetaPayload::FirstEntryOfTerm::fromVelocyPack(velocypack::Slice s)
-    -> FirstEntryOfTerm {
-  TRI_ASSERT(
-      s.get(StaticStrings::IndexType).isEqualString(StringFirstIndexOfTerm));
-  auto leader = s.get(StaticStrings::Leader).copyString();
-  auto participants = velocypack::deserialize<agency::ParticipantsConfig>(
-      s.get(StaticStrings::Participants));
-  return FirstEntryOfTerm{std::move(leader), std::move(participants)};
+  velocypack::serialize(builder, *this);
 }
 
 auto LogMetaPayload::withFirstEntryOfTerm(ParticipantId leader,
@@ -273,4 +222,10 @@ auto LogMetaPayload::withUpdateParticipantsConfig(
     agency::ParticipantsConfig config) -> LogMetaPayload {
   return LogMetaPayload{
       UpdateParticipantsConfig{.participants = std::move(config)}};
+}
+
+auto LogMetaPayload::withPing(std::string message,
+                              Ping::clock::time_point tp) noexcept
+    -> LogMetaPayload {
+  return LogMetaPayload{Ping{std::move(message), tp}};
 }

--- a/arangod/Replication2/ReplicatedLog/LogEntries.cpp
+++ b/arangod/Replication2/ReplicatedLog/LogEntries.cpp
@@ -224,7 +224,7 @@ auto LogMetaPayload::withUpdateParticipantsConfig(
       UpdateParticipantsConfig{.participants = std::move(config)}};
 }
 
-auto LogMetaPayload::withPing(std::string message,
+auto LogMetaPayload::withPing(std::optional<std::string> message,
                               Ping::clock::time_point tp) noexcept
     -> LogMetaPayload {
   return LogMetaPayload{Ping{std::move(message), tp}};

--- a/arangod/Replication2/ReplicatedLog/LogEntries.cpp
+++ b/arangod/Replication2/ReplicatedLog/LogEntries.cpp
@@ -23,6 +23,7 @@
 
 #include "LogEntries.h"
 #include "Inspection/VPack.h"
+#include "Logger/LogMacros.h"
 
 #include <Basics/StaticStrings.h>
 #include <Basics/StringUtils.h>
@@ -117,7 +118,7 @@ auto PersistingLogEntry::fromVelocyPack(velocypack::Slice slice)
     return {termIndex, LogPayload::createFromSlice(payload)};
   } else {
     auto meta = slice.get("meta");
-    TRI_ASSERT(!meta.isNone());
+    TRI_ASSERT(!meta.isNone()) << slice.toJson();
     return {termIndex, LogMetaPayload::fromVelocyPack(meta)};
   }
 }
@@ -144,7 +145,7 @@ PersistingLogEntry::PersistingLogEntry(LogIndex index,
     _payload = LogPayload::createFromSlice(payload);
   } else {
     auto meta = persisted.get("meta");
-    TRI_ASSERT(!meta.isNone());
+    TRI_ASSERT(!meta.isNone()) << persisted.toJson();
     _payload = LogMetaPayload::fromVelocyPack(meta);
   }
 }
@@ -195,8 +196,7 @@ void LogEntryView::toVelocyPack(velocypack::Builder& builder) const {
 }
 
 auto LogEntryView::fromVelocyPack(velocypack::Slice slice) -> LogEntryView {
-  return LogEntryView(slice.get("logIndex").extract<LogIndex>(),
-                      slice.get("payload"));
+  return {slice.get("logIndex").extract<LogIndex>(), slice.get("payload")};
 }
 
 auto LogEntryView::clonePayload() const -> LogPayload {

--- a/arangod/Replication2/ReplicatedLog/LogEntries.h
+++ b/arangod/Replication2/ReplicatedLog/LogEntries.h
@@ -26,6 +26,7 @@
 #include <string_view>
 #include <velocypack/Buffer.h>
 #include <velocypack/Slice.h>
+#include <Inspection/VPack.h>
 
 #include "Replication2/ReplicatedLog/AgencyLogSpecification.h"
 #include "Replication2/ReplicatedLog/LogCommon.h"
@@ -60,11 +61,14 @@ struct LogMetaPayload {
     ParticipantId leader;
     agency::ParticipantsConfig participants;
 
-    static auto fromVelocyPack(velocypack::Slice) -> FirstEntryOfTerm;
-    void toVelocyPack(velocypack::Builder&) const;
-
     friend auto operator==(FirstEntryOfTerm const&,
                            FirstEntryOfTerm const&) noexcept -> bool = default;
+
+    template<typename Inspector>
+    friend auto inspect(Inspector& f, FirstEntryOfTerm& x) {
+      return f.object(x).fields(f.field("leader", x.leader),
+                                f.field("participants", x.participants));
+    }
   };
 
   static auto withFirstEntryOfTerm(ParticipantId leader,
@@ -74,21 +78,50 @@ struct LogMetaPayload {
   struct UpdateParticipantsConfig {
     agency::ParticipantsConfig participants;
 
-    static auto fromVelocyPack(velocypack::Slice) -> UpdateParticipantsConfig;
-    void toVelocyPack(velocypack::Builder&) const;
-
     friend auto operator==(UpdateParticipantsConfig const&,
                            UpdateParticipantsConfig const&) noexcept
         -> bool = default;
+    template<typename Inspector>
+    friend auto inspect(Inspector& f, UpdateParticipantsConfig& x) {
+      return f.object(x).fields(f.field("participants", x.participants));
+    }
   };
 
   static auto withUpdateParticipantsConfig(agency::ParticipantsConfig config)
       -> LogMetaPayload;
 
+  struct Ping {
+    using clock = std::chrono::system_clock;
+    std::optional<std::string> message;
+    clock::time_point time;
+
+    friend auto operator==(Ping const&, Ping const&) noexcept -> bool = default;
+    template<typename Inspector>
+    friend auto inspect(Inspector& f, Ping& x) {
+      return f.object(x).fields(
+          f.field("message", x.message),
+          f.field("time", x.time)
+              .transformWith(inspection::TimeStampTransformer{}));
+    }
+  };
+
+  static auto withPing(std::string message,
+                       Ping::clock::time_point = Ping::clock::now()) noexcept
+      -> LogMetaPayload;
+
   static auto fromVelocyPack(velocypack::Slice) -> LogMetaPayload;
   void toVelocyPack(velocypack::Builder&) const;
 
-  std::variant<FirstEntryOfTerm, UpdateParticipantsConfig> info;
+  std::variant<FirstEntryOfTerm, UpdateParticipantsConfig, Ping> info;
+
+  template<typename Inspector>
+  friend auto inspect(Inspector& f, LogMetaPayload& x) {
+    namespace insp = arangodb::inspection;
+    return f.variant(x.info).embedded("type").alternatives(
+        insp::type<FirstEntryOfTerm>("FirstEntryOfTerm"),
+        insp::type<UpdateParticipantsConfig>("UpdateParticipantsConfig"),
+        insp::type<Ping>("Ping"));
+  }
 
   friend auto operator==(LogMetaPayload const&, LogMetaPayload const&) noexcept
       -> bool = default;

--- a/arangod/Replication2/ReplicatedLog/LogEntries.h
+++ b/arangod/Replication2/ReplicatedLog/LogEntries.h
@@ -105,7 +105,7 @@ struct LogMetaPayload {
     }
   };
 
-  static auto withPing(std::string message,
+  static auto withPing(std::optional<std::string> message,
                        Ping::clock::time_point = Ping::clock::now()) noexcept
       -> LogMetaPayload;
 

--- a/arangod/Replication2/ReplicatedLog/LogLeader.cpp
+++ b/arangod/Replication2/ReplicatedLog/LogLeader.cpp
@@ -1491,14 +1491,14 @@ auto replicated_log::LogLeader::waitForResign()
 }
 
 auto replicated_log::LogLeader::ping(std::optional<std::string> message)
-    -> replicated_log::ILogParticipant::WaitForFuture {
+    -> LogIndex {
   auto index = _guardedLeaderData.doUnderLock([&](GuardedLeaderData& leader) {
     auto meta = LogMetaPayload::withPing(message);
     return leader.insertInternal(std::move(meta), false, std::nullopt);
   });
 
   triggerAsyncReplication();
-  return waitFor(index);
+  return index;
 }
 
 auto replicated_log::LogLeader::LocalFollower::release(LogIndex stop) const

--- a/arangod/Replication2/ReplicatedLog/LogLeader.h
+++ b/arangod/Replication2/ReplicatedLog/LogLeader.h
@@ -154,6 +154,7 @@ class LogLeader : public std::enable_shared_from_this<LogLeader>,
   auto waitForLeadership() -> WaitForFuture override;
 
   [[nodiscard]] auto waitForResign() -> futures::Future<futures::Unit> override;
+  auto ping(std::optional<std::string> message) -> WaitForFuture override;
 
   // This function returns the current commit index. Do NOT poll this function,
   // use waitFor(idx) instead. This function is used in tests.

--- a/arangod/Replication2/ReplicatedLog/LogLeader.h
+++ b/arangod/Replication2/ReplicatedLog/LogLeader.h
@@ -154,7 +154,7 @@ class LogLeader : public std::enable_shared_from_this<LogLeader>,
   auto waitForLeadership() -> WaitForFuture override;
 
   [[nodiscard]] auto waitForResign() -> futures::Future<futures::Unit> override;
-  auto ping(std::optional<std::string> message) -> WaitForFuture override;
+  auto ping(std::optional<std::string> message) -> LogIndex override;
 
   // This function returns the current commit index. Do NOT poll this function,
   // use waitFor(idx) instead. This function is used in tests.

--- a/arangod/RestHandler/RestLogHandler.cpp
+++ b/arangod/RestHandler/RestLogHandler.cpp
@@ -104,9 +104,9 @@ RestStatus RestLogHandler::handlePostRequest(
   } else if (verb == "multi-insert") {
     return handlePostInsertMulti(methods, logId, body);
   } else {
-    generateError(
-        rest::ResponseCode::NOT_FOUND, TRI_ERROR_HTTP_NOT_FOUND,
-        "expecting one of the resources 'insert', 'release', 'multi-insert'");
+    generateError(rest::ResponseCode::NOT_FOUND, TRI_ERROR_HTTP_NOT_FOUND,
+                  "expecting one of the resources 'insert', 'release', "
+                  "'multi-insert', 'compact', 'ping'");
   }
   return RestStatus::DONE;
 }

--- a/arangod/RestHandler/RestLogHandler.h
+++ b/arangod/RestHandler/RestLogHandler.h
@@ -55,6 +55,9 @@ class RestLogHandler : public RestVocbaseBaseHandler {
   RestStatus handlePostInsert(replication2::ReplicatedLogMethods const& methods,
                               replication2::LogId logId,
                               velocypack::Slice payload);
+  RestStatus handlePostPing(replication2::ReplicatedLogMethods const& methods,
+                            replication2::LogId logId,
+                            velocypack::Slice payload);
   RestStatus handlePostInsertMulti(
       replication2::ReplicatedLogMethods const& methods,
       replication2::LogId logId, velocypack::Slice payload);

--- a/arangod/V8Server/v8-replicated-logs.cpp
+++ b/arangod/V8Server/v8-replicated-logs.cpp
@@ -265,6 +265,45 @@ static void JS_Insert(v8::FunctionCallbackInfo<v8::Value> const& args) {
   TRI_V8_TRY_CATCH_END
 }
 
+static void JS_Ping(v8::FunctionCallbackInfo<v8::Value> const& args) {
+  TRI_V8_TRY_CATCH_BEGIN(isolate);
+  v8::HandleScope scope(isolate);
+
+  auto& vocbase = GetContextVocBase(isolate);
+  auto id = UnwrapReplicatedLog(isolate, args.Holder());
+  if (!arangodb::ExecContext::current().isAdminUser()) {
+    TRI_V8_THROW_EXCEPTION_MESSAGE(
+        TRI_ERROR_FORBIDDEN,
+        std::string("No access to replicated log '") + to_string(id) + "'");
+  }
+
+  if (args.Length() > 1) {
+    TRI_V8_THROW_EXCEPTION_USAGE("ping([message])");
+  }
+
+  std::optional<std::string> message;
+
+  if (args.Length() > 0) {
+    VPackBuilder builder;
+    TRI_V8ToVPack(isolate, builder, args[0], false, false);
+    message = builder.slice().copyString();
+  }
+
+  auto result = ReplicatedLogMethods::createInstance(vocbase)
+                    ->ping(id, std::move(message))
+                    .get();
+  VPackBuilder response;
+  {
+    VPackObjectBuilder ob(&response);
+    response.add("index", VPackValue(result.first));
+    response.add(VPackValue("result"));
+    result.second.toVelocyPack(response);
+  }
+  TRI_V8_RETURN(TRI_VPackToV8(isolate, response.slice()));
+
+  TRI_V8_TRY_CATCH_END
+}
+
 static void JS_MultiInsert(v8::FunctionCallbackInfo<v8::Value> const& args) {
   TRI_V8_TRY_CATCH_BEGIN(isolate)
   v8::HandleScope scope(isolate);
@@ -632,6 +671,8 @@ void TRI_InitV8ReplicatedLogs(TRI_v8_global_t* v8g, v8::Isolate* isolate) {
                        JS_Drop);
   TRI_AddMethodVocbase(isolate, rt, TRI_V8_ASCII_STRING(isolate, "insert"),
                        JS_Insert);
+  TRI_AddMethodVocbase(isolate, rt, TRI_V8_ASCII_STRING(isolate, "ping"),
+                       JS_Ping);
   TRI_AddMethodVocbase(isolate, rt, TRI_V8_ASCII_STRING(isolate, "multiInsert"),
                        JS_MultiInsert);
   TRI_AddMethodVocbase(isolate, rt, TRI_V8_ASCII_STRING(isolate, "status"),

--- a/js/client/modules/@arangodb/replicated-logs.js
+++ b/js/client/modules/@arangodb/replicated-logs.js
@@ -151,6 +151,13 @@ ArangoReplicatedLog.prototype.insert = function (payload, {waitForSync = false, 
   return requestResult.result;
 };
 
+ArangoReplicatedLog.prototype.ping = function (message) {
+  let str = JSON.stringify({message});
+  let requestResult = this._database._connection.POST(this._baseurl() + `/ping`, str);
+  arangosh.checkRequestResult(requestResult);
+  return requestResult.result;
+};
+
 ArangoReplicatedLog.prototype.multiInsert = function(payload, {waitForSync = false, dontWaitForCommit = false} = {}) {
   let str = JSON.stringify(payload);
   let requestResult = this._database._connection.POST(this._baseurl() + `/multi-insert?waitForSync=${waitForSync}&dontWaitForCommit=${dontWaitForCommit}`, str);

--- a/tests/Replication2/Mocks/AsyncLeader.h
+++ b/tests/Replication2/Mocks/AsyncLeader.h
@@ -50,7 +50,7 @@ struct AsyncLeader : replicated_log::ILogLeader,
   [[nodiscard]] auto getCommitIndex() const noexcept -> LogIndex override;
   auto release(LogIndex doneWithIdx) -> Result override;
   auto compact() -> Result override;
-  auto ping(std::optional<std::string> message) -> WaitForFuture override {
+  auto ping(std::optional<std::string> message) -> LogIndex override {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_NOT_IMPLEMENTED);
   }
   auto insert(LogPayload payload, bool waitForSync) -> LogIndex override;

--- a/tests/Replication2/Mocks/AsyncLeader.h
+++ b/tests/Replication2/Mocks/AsyncLeader.h
@@ -50,6 +50,9 @@ struct AsyncLeader : replicated_log::ILogLeader,
   [[nodiscard]] auto getCommitIndex() const noexcept -> LogIndex override;
   auto release(LogIndex doneWithIdx) -> Result override;
   auto compact() -> Result override;
+  auto ping(std::optional<std::string> message) -> WaitForFuture override {
+    THROW_ARANGO_EXCEPTION(TRI_ERROR_NOT_IMPLEMENTED);
+  }
   auto insert(LogPayload payload, bool waitForSync) -> LogIndex override;
   auto insert(LogPayload payload, bool waitForSync,
               DoNotTriggerAsyncReplication replication) -> LogIndex override;

--- a/tests/Replication2/Mocks/FakeLeader.h
+++ b/tests/Replication2/Mocks/FakeLeader.h
@@ -55,6 +55,10 @@ struct FakeLeader final : replicated_log::ILogLeader,
     THROW_ARANGO_EXCEPTION(TRI_ERROR_NOT_IMPLEMENTED);
   }
 
+  auto ping(std::optional<std::string> message) -> WaitForFuture override {
+    THROW_ARANGO_EXCEPTION(TRI_ERROR_NOT_IMPLEMENTED);
+  }
+
   template<typename State>
   auto insertMultiplexedValue(typename State::EntryType const& t) -> LogIndex {
     using streamSpec =

--- a/tests/Replication2/Mocks/FakeLeader.h
+++ b/tests/Replication2/Mocks/FakeLeader.h
@@ -55,7 +55,7 @@ struct FakeLeader final : replicated_log::ILogLeader,
     THROW_ARANGO_EXCEPTION(TRI_ERROR_NOT_IMPLEMENTED);
   }
 
-  auto ping(std::optional<std::string> message) -> WaitForFuture override {
+  auto ping(std::optional<std::string> message) -> LogIndex override {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_NOT_IMPLEMENTED);
   }
 

--- a/tests/js/common/shell/shell-replicated-logs-cluster.js
+++ b/tests/js/common/shell/shell-replicated-logs-cluster.js
@@ -163,6 +163,16 @@ function ReplicatedLogsWriteSuite() {
       assertTrue(leaderStatus.local.commitIndex >= index);
     },
 
+    testPing: function () {
+      let result = log.ping("foo bar");
+      assertTrue('quorum' in result.result &&
+          'commitIndex' in result.result);
+      const tail = log.tail();
+      assertEqual(tail[1].meta.type, "Ping");
+      assertEqual(tail[1].meta.message, "foo bar");
+      assertTrue(tail[1].meta.time !== undefined);
+    },
+
     testMultiInsert: function () {
       let index = 0;
       for (let i = 0; i < 100; i += 3) {

--- a/tests/js/server/replication2/replication2-replicated-log-entry-cluster.js
+++ b/tests/js/server/replication2/replication2-replicated-log-entry-cluster.js
@@ -75,7 +75,7 @@ const replicatedLogEntrySuite = function () {
       assertEqual(head.length, 1);
       const [firstEntry] = head;
       assertEqual(firstEntry.logIndex, 1);
-      assertTrue([1,2].includes(firstEntry.logTerm));
+      assertTrue([1, 2].includes(firstEntry.logTerm));
       assertEqual(firstEntry.logPayload, undefined);
       assertTrue(firstEntry.meta !== undefined);
       const meta = firstEntry.meta;
@@ -106,7 +106,7 @@ const replicatedLogEntrySuite = function () {
       assertEqual(head.length, 2);
       const entry = head[1];
       assertEqual(entry.logIndex, 2);
-      assertTrue([1,2].includes(entry.logTerm));
+      assertTrue([1, 2].includes(entry.logTerm));
       assertEqual(entry.logPayload, undefined);
       assertTrue(entry.meta !== undefined);
       const meta = entry.meta;
@@ -114,6 +114,22 @@ const replicatedLogEntrySuite = function () {
       assertEqual(meta.leader, undefined);
       assertEqual(meta.participants.generation, 2);
       assertEqual(Object.keys(meta.participants.participants).sort(), servers.sort());
+      lh.replicatedLogDeleteTarget(database, logId);
+    },
+
+    testCheckPingLog: function () {
+      const {logId} = lh.createReplicatedLog(database, targetConfig);
+      waitForReplicatedLogAvailable(logId);
+      const result = db._replicatedLog(logId).ping("message");
+      assertEqual(result.index, 2);
+      const head = db._replicatedLog(logId).head();
+      assertEqual(head.length, 2);
+      const entry = head[1];
+      print(entry);
+      assertEqual(entry.logPayload, undefined);
+      assertTrue(entry.meta !== undefined);
+      const meta = entry.meta;
+      assertEqual(meta.type, "Ping");
       lh.replicatedLogDeleteTarget(database, logId);
     }
   };

--- a/tests/js/server/replication2/replication2-replicated-log-entry-cluster.js
+++ b/tests/js/server/replication2/replication2-replicated-log-entry-cluster.js
@@ -79,7 +79,7 @@ const replicatedLogEntrySuite = function () {
       assertEqual(firstEntry.logPayload, undefined);
       assertTrue(firstEntry.meta !== undefined);
       const meta = firstEntry.meta;
-      assertEqual(meta.type, "FirstIndexOfTerm");
+      assertEqual(meta.type, "FirstEntryOfTerm");
       assertEqual(meta.leader, leader);
       assertEqual(meta.participants.generation, 1);
       assertEqual(Object.keys(meta.participants.participants).sort(), servers.sort());

--- a/tests/js/server/replication2/replication2-replicated-log-entry-cluster.js
+++ b/tests/js/server/replication2/replication2-replicated-log-entry-cluster.js
@@ -125,7 +125,6 @@ const replicatedLogEntrySuite = function () {
       const head = db._replicatedLog(logId).head();
       assertEqual(head.length, 2);
       const entry = head[1];
-      print(entry);
       assertEqual(entry.logPayload, undefined);
       assertTrue(entry.meta !== undefined);
       const meta = entry.meta;


### PR DESCRIPTION
### Scope & Purpose
This PR adds a new `ping` function on a replicated log. This function inserts an meta log entry and is designed for debugging. It does not interfere with the state machine based on the replicated log. The javascript function accepts an optional string parameter `message` that is put into the ping log entry. The rest handler optionally accepts an object with key `message`.
