### PR TITLE
Enable "collect-in-cluster" optimizer rule for SmartGraph edge collections

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 v3.9.5 (XXXX-XX-XX)
 -------------------
 
+* Enable "collect-in-cluster" optimizer rule for SmartGraph edge collections.
+
 * Updated OpenSSL to 1.1.1s.
 
 * Added startup option `--query.log-failed` to optionally log all failed AQL

--- a/arangod/Aql/OptimizerRules.cpp
+++ b/arangod/Aql/OptimizerRules.cpp
@@ -4512,19 +4512,23 @@ void arangodb::aql::collectInClusterRule(Optimizer* opt,
           auto p = previous;
           while (p != nullptr) {
             switch (p->getType()) {
-              case ExecutionNode::REMOTE:
+              case ExecutionNode::REMOTE: {
                 hasFoundMultipleShards = true;
                 break;
+              }
               case ExecutionNode::ENUMERATE_COLLECTION:
               case ExecutionNode::INDEX: {
                 auto col = getCollection(p);
-                if (col->numberOfShards() > 1) {
+                if (col->numberOfShards() > 1 ||
+                    (col->type() == TRI_COL_TYPE_EDGE && col->isSmart())) {
                   hasFoundMultipleShards = true;
                 }
-              } break;
-              case ExecutionNode::TRAVERSAL:
+                break;
+              }
+              case ExecutionNode::TRAVERSAL: {
                 hasFoundMultipleShards = true;
                 break;
+              }
               case ExecutionNode::ENUMERATE_IRESEARCH_VIEW: {
                 auto& viewNode = *ExecutionNode::castTo<IResearchViewNode*>(p);
                 auto collections = viewNode.collections();
@@ -4536,7 +4540,8 @@ void arangodb::aql::collectInClusterRule(Optimizer* opt,
                   hasFoundMultipleShards =
                       collections.front().get().numberOfShards() > 1;
                 }
-              } break;
+                break;
+              }
               default:
                 break;
             }

--- a/tests/js/server/aql/aql-optimizer-collect-count.js
+++ b/tests/js/server/aql/aql-optimizer-collect-count.js
@@ -28,12 +28,12 @@
 /// @author Copyright 2012, triAGENS GmbH, Cologne, Germany
 ////////////////////////////////////////////////////////////////////////////////
 
-var jsunity = require("jsunity");
-var internal = require("internal");
-var errors = internal.errors;
-var db = require("@arangodb").db;
-var helper = require("@arangodb/aql-helper");
-var assertQueryError = helper.assertQueryError;
+const jsunity = require("jsunity");
+const internal = require("internal");
+const errors = internal.errors;
+const db = require("@arangodb").db;
+const helper = require("@arangodb/aql-helper");
+const assertQueryError = helper.assertQueryError;
 const isCluster = require("@arangodb/cluster").isCluster();
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -41,16 +41,18 @@ const isCluster = require("@arangodb/cluster").isCluster();
 ////////////////////////////////////////////////////////////////////////////////
 
 function optimizerCountTestSuite () {
-  var c;
+  let c;
 
   return {
     setUp : function () {
       db._drop("UnitTestsCollection");
       c = db._create("UnitTestsCollection", { numberOfShards: 4 });
 
-      for (var i = 0; i < 1000; ++i) {
-        c.save({ group: "test" + (i % 10), value: i });
+      let docs = [];
+      for (let i = 0; i < 1000; ++i) {
+        docs.push({ group: "test" + (i % 10), value: i });
       }
+      c.insert(docs);
     },
 
     tearDown : function () {
@@ -660,10 +662,6 @@ function optimizerDoubleCollectTestSuite() {
     },
   };
 }
-
-////////////////////////////////////////////////////////////////////////////////
-/// @brief executes the test suite
-////////////////////////////////////////////////////////////////////////////////
 
 jsunity.run(optimizerCountTestSuite);
 jsunity.run(optimizerDoubleCollectTestSuite);


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/17515

Enable "collect-in-cluster" optimizer rule for SmartGraph edge collections, too.
Previously SmartGraph edge collections were excluded from the optimization because they report to have 0 shards.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [x] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [x] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.10: https://github.com/arangodb/arangodb/pull/17517
  - [x] Backport for 3.9: this PR
  - [ ] Backport for 3.8: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 