### PR TITLE
do not query vertices on K_PATHS if not needed

### DIFF
--- a/arangod/Aql/KShortestPathsNode.cpp
+++ b/arangod/Aql/KShortestPathsNode.cpp
@@ -441,10 +441,10 @@ std::unique_ptr<ExecutionBlock> KShortestPathsNode::createBlock(
     } else {
       auto cache = std::make_shared<RefactoredClusterTraverserCache>(
           opts->query().resourceMonitor());
-      ClusterBaseProviderOptions forwardProviderOptions(cache, engines(),
-                                                        false);
-      ClusterBaseProviderOptions backwardProviderOptions(cache, engines(),
-                                                         true);
+      ClusterBaseProviderOptions forwardProviderOptions(
+          cache, engines(), false, opts->produceVertices());
+      ClusterBaseProviderOptions backwardProviderOptions(
+          cache, engines(), true, opts->produceVertices());
 
       if (opts->query().queryOptions().getTraversalProfileLevel() ==
           TraversalProfileLevel::None) {

--- a/arangod/Aql/OptimizerRule.h
+++ b/arangod/Aql/OptimizerRule.h
@@ -200,6 +200,10 @@ struct OptimizerRule {
 
     // merge filters into graph traversals
     optimizeTraversalsRule,
+
+    // optimize K_PATHS
+    optimizePathsRule,
+
     // remove redundant filters statements
     removeFiltersCoveredByTraversal,
 

--- a/arangod/Aql/OptimizerRules.cpp
+++ b/arangod/Aql/OptimizerRules.cpp
@@ -66,6 +66,7 @@
 #include "Containers/SmallUnorderedMap.h"
 #include "Containers/SmallVector.h"
 #include "Geo/GeoParams.h"
+#include "Graph/ShortestPathOptions.h"
 #include "Graph/TraverserOptions.h"
 #include "Indexes/Index.h"
 #include "StorageEngine/EngineSelectorFeature.h"
@@ -6287,6 +6288,90 @@ void arangodb::aql::optimizeTraversalsRule(Optimizer* opt,
     for (auto const& n : nodes) {
       TraversalConditionFinder finder(plan.get(), &modified);
       n->walk(finder);
+    }
+  }
+
+  opt->addPlan(std::move(plan), rule, modified);
+}
+
+/// @brief optimizes away unused K_PATHS things
+void arangodb::aql::optimizePathsRule(Optimizer* opt,
+                                      std::unique_ptr<ExecutionPlan> plan,
+                                      OptimizerRule const& rule) {
+  ::arangodb::containers::SmallVector<
+      ExecutionNode*>::allocator_type::arena_type a;
+  ::arangodb::containers::SmallVector<ExecutionNode*> nodes{a};
+  plan->findNodesOfType(nodes, EN::K_SHORTEST_PATHS, true);
+
+  if (nodes.empty()) {
+    // no traversals present
+    opt->addPlan(std::move(plan), rule, false);
+    return;
+  }
+
+  bool modified = false;
+
+  // first make a pass over all traversal nodes and remove unused
+  // variables from them
+  for (auto const& n : nodes) {
+    KShortestPathsNode* ksp = ExecutionNode::castTo<KShortestPathsNode*>(n);
+    if (ksp->shortestPathType() != graph::ShortestPathType::Type::KPaths) {
+      // we are only interested in K_PATHS nodes here
+      continue;
+    }
+    if (!ksp->usesPathOutVariable()) {
+      continue;
+    }
+
+    Variable const* variable = &(ksp->pathOutVariable());
+
+    std::unordered_set<std::string> attributes;
+    VarSet vars;
+    bool canOptimize = true;
+
+    ExecutionNode* current = ksp->getFirstParent();
+    while (current != nullptr && canOptimize) {
+      switch (current->getType()) {
+        case EN::CALCULATION: {
+          vars.clear();
+          current->getVariablesUsedHere(vars);
+          if (vars.find(variable) != vars.end()) {
+            // path variable used here
+            Expression* exp =
+                ExecutionNode::castTo<CalculationNode*>(current)->expression();
+            AstNode const* node = exp->node();
+            if (!Ast::getReferencedAttributes(node, variable, attributes)) {
+              // full path variable is used, or accessed in a way that we don't
+              // understand, e.g. "p" or "p[0]" or "p[*]..."
+              canOptimize = false;
+            }
+          }
+          break;
+        }
+        default: {
+          // if the path is used by any other node type, we don't know what to
+          // do and will not optimize parts of it away
+          vars.clear();
+          current->getVariablesUsedHere(vars);
+          if (vars.find(variable) != vars.end()) {
+            canOptimize = false;
+          }
+          break;
+        }
+      }
+      current = current->getFirstParent();
+    }
+
+    if (canOptimize) {
+      bool produceVertices =
+          (attributes.find(StaticStrings::GraphQueryVertices) !=
+           attributes.end());
+
+      if (!produceVertices) {
+        auto* options = ksp->options();
+        options->setProduceVertices(false);
+        modified = true;
+      }
     }
   }
 

--- a/arangod/Aql/OptimizerRules.h
+++ b/arangod/Aql/OptimizerRules.h
@@ -278,6 +278,10 @@ void skipInaccessibleCollectionsRule(Optimizer*, std::unique_ptr<ExecutionPlan>,
 void optimizeTraversalsRule(Optimizer* opt, std::unique_ptr<ExecutionPlan> plan,
                             OptimizerRule const&);
 
+/// @brief optimizes away unused K_PATHS things
+void optimizePathsRule(Optimizer* opt, std::unique_ptr<ExecutionPlan> plan,
+                       OptimizerRule const&);
+
 /// @brief removes filter nodes already covered by the traversal and removes
 /// unused variables
 void removeFiltersCoveredByTraversal(Optimizer* opt,

--- a/arangod/Aql/OptimizerRulesFeature.cpp
+++ b/arangod/Aql/OptimizerRulesFeature.cpp
@@ -314,6 +314,11 @@ void OptimizerRulesFeature::addRules() {
                OptimizerRule::optimizeTraversalsRule,
                OptimizerRule::makeFlags(OptimizerRule::Flags::CanBeDisabled));
 
+  // optimize K_PATHS
+  registerRule("optimize-paths", optimizePathsRule,
+               OptimizerRule::optimizePathsRule,
+               OptimizerRule::makeFlags(OptimizerRule::Flags::CanBeDisabled));
+
   // optimize unneccessary filters already applied by the traversal
   registerRule("remove-filter-covered-by-traversal",
                removeFiltersCoveredByTraversal,

--- a/arangod/Graph/Providers/BaseProviderOptions.cpp
+++ b/arangod/Graph/Providers/BaseProviderOptions.cpp
@@ -123,8 +123,12 @@ double BaseProviderOptions::weightEdge(double prefixWeight,
 
 ClusterBaseProviderOptions::ClusterBaseProviderOptions(
     std::shared_ptr<RefactoredClusterTraverserCache> cache,
-    std::unordered_map<ServerID, aql::EngineId> const* engines, bool backward)
-    : _cache(std::move(cache)), _engines(engines), _backward(backward) {
+    std::unordered_map<ServerID, aql::EngineId> const* engines, bool backward,
+    bool produceVertices)
+    : _cache(std::move(cache)),
+      _engines(engines),
+      _backward(backward),
+      _produceVertices(produceVertices) {
   TRI_ASSERT(_cache != nullptr);
   TRI_ASSERT(_engines != nullptr);
 }
@@ -134,7 +138,13 @@ RefactoredClusterTraverserCache* ClusterBaseProviderOptions::getCache() {
   return _cache.get();
 }
 
-bool ClusterBaseProviderOptions::isBackward() const { return _backward; }
+bool ClusterBaseProviderOptions::isBackward() const noexcept {
+  return _backward;
+}
+
+bool ClusterBaseProviderOptions::produceVertices() const noexcept {
+  return _produceVertices;
+}
 
 std::unordered_map<ServerID, aql::EngineId> const*
 ClusterBaseProviderOptions::engines() const {

--- a/arangod/Graph/Providers/BaseProviderOptions.h
+++ b/arangod/Graph/Providers/BaseProviderOptions.h
@@ -131,12 +131,14 @@ struct ClusterBaseProviderOptions {
  public:
   ClusterBaseProviderOptions(
       std::shared_ptr<RefactoredClusterTraverserCache> cache,
-      std::unordered_map<ServerID, aql::EngineId> const* engines,
-      bool backward);
+      std::unordered_map<ServerID, aql::EngineId> const* engines, bool backward,
+      bool produceVertices);
 
   RefactoredClusterTraverserCache* getCache();
 
-  bool isBackward() const;
+  bool isBackward() const noexcept;
+
+  bool produceVertices() const noexcept;
 
   [[nodiscard]] std::unordered_map<ServerID, aql::EngineId> const* engines()
       const;
@@ -146,7 +148,9 @@ struct ClusterBaseProviderOptions {
 
   std::unordered_map<ServerID, aql::EngineId> const* _engines;
 
-  bool _backward;
+  bool const _backward;
+
+  bool const _produceVertices;
 };
 
 }  // namespace graph

--- a/tests/Graph/GenericGraphProviderTest.cpp
+++ b/tests/Graph/GenericGraphProviderTest.cpp
@@ -228,8 +228,8 @@ class GraphProviderTest : public ::testing::Test {
       auto clusterCache =
           std::make_shared<RefactoredClusterTraverserCache>(resourceMonitor);
 
-      ClusterBaseProviderOptions opts(clusterCache, clusterEngines.get(),
-                                      false);
+      ClusterBaseProviderOptions opts(clusterCache, clusterEngines.get(), false,
+                                      /*produceVertices*/ true);
       return ClusterProvider(*query.get(), std::move(opts), resourceMonitor);
     }
     THROW_ARANGO_EXCEPTION(TRI_ERROR_NOT_IMPLEMENTED);


### PR DESCRIPTION
### Scope & Purpose

Don't query vertex data in K_PATHS cluster implementation in case the query doesn't need them.
This is an experimental change and needs more testing! Do not yet use in production.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [x] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: *(Please link PR)*
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 