### PR TITLE
 [testing][documentation] fix link to the oskar documentation

### DIFF
--- a/tests/test-definitions.txt
+++ b/tests/test-definitions.txt
@@ -1,6 +1,6 @@
 # test_suite [flags ...] -- [additional-params...]
 # for possible flags and params see
-# scripts/generateJenkinsScripts.py --help-flags
+# https://github.com/arangodb/oskar#testing
 
 
 # Single Server only Tests


### PR DESCRIPTION
this comment of the test-defitions.txt was left over from a previous development stage.
