### PR TITLE
[PREGEL] Cast PregelShard input explicitly to uint16_t

### DIFF
--- a/arangod/Pregel/Algos/DMID/DMIDMessageFormat.h
+++ b/arangod/Pregel/Algos/DMID/DMIDMessageFormat.h
@@ -39,9 +39,11 @@ struct DMIDMessageFormat : public MessageFormat<DMIDMessage> {
   DMIDMessageFormat() {}
   void unwrapValue(VPackSlice s, DMIDMessage& message) const override {
     VPackArrayIterator array(s);
-    message.senderId.shard = (PregelShard)((*array).getUInt());
+    message.senderId.shard =
+        PregelShard{static_cast<uint16_t>((*array).getUInt())};
     message.senderId.key = (*(++array)).copyString();
-    message.leaderId.shard = (PregelShard)(*array).getUInt();
+    message.leaderId.shard =
+        PregelShard{static_cast<uint16_t>((*array).getUInt())};
     message.leaderId.key = (*(++array)).copyString();
     message.weight = (*(++array)).getNumber<float>();
   }

--- a/arangod/Pregel/Algos/DMID/VertexSumAggregator.h
+++ b/arangod/Pregel/Algos/DMID/VertexSumAggregator.h
@@ -57,7 +57,8 @@ struct VertexSumAggregator : public IAggregator {
 
   void parseAggregate(VPackSlice const& slice) override {
     for (auto const& pair : VPackObjectIterator(slice)) {
-      auto shard = PregelShard(std::stoi(pair.key.copyString()));
+      auto shard =
+          PregelShard{static_cast<uint16_t>(std::stoi(pair.key.copyString()))};
       std::string key;
       VPackValueLength i = 0;
       for (VPackSlice const& val : VPackArrayIterator(pair.value)) {
@@ -75,7 +76,8 @@ struct VertexSumAggregator : public IAggregator {
 
   void setAggregatedValue(VPackSlice const& slice) override {
     for (auto const& pair : VPackObjectIterator(slice)) {
-      auto shard = PregelShard(std::stoi(pair.key.copyString()));
+      auto shard =
+          PregelShard{static_cast<uint16_t>(std::stoi(pair.key.copyString()))};
       std::string key;
       VPackValueLength i = 0;
       for (VPackSlice const& val : VPackArrayIterator(pair.value)) {

--- a/arangod/Pregel/CommonFormats.h
+++ b/arangod/Pregel/CommonFormats.h
@@ -145,7 +145,8 @@ struct SenderMessageFormat : public MessageFormat<SenderMessage<T>> {
   SenderMessageFormat() {}
   void unwrapValue(VPackSlice s, SenderMessage<T>& senderVal) const override {
     VPackArrayIterator array(s);
-    senderVal.senderId.shard = (PregelShard)((*array).getUInt());
+    senderVal.senderId.shard =
+        PregelShard{static_cast<uint16_t>((*array).getUInt())};
     senderVal.senderId.key = (*(++array)).copyString();
     senderVal.value = (*(++array)).getNumber<T>();
   }

--- a/arangod/Pregel/Worker/GraphStore.cpp
+++ b/arangod/Pregel/Worker/GraphStore.cpp
@@ -356,7 +356,7 @@ void GraphStore<V, E>::loadVertices(
     THROW_ARANGO_EXCEPTION(res);
   }
 
-  PregelShard sourceShard = (PregelShard)_config->shardId(vertexShard);
+  PregelShard sourceShard = _config->shardId(vertexShard);
   auto cursor =
       trx.indexScan(_resourceMonitor, vertexShard,
                     transaction::Methods::CursorType::ALL, ReadOwnWrites::no);

--- a/arangod/Pregel/Worker/WorkerConfig.cpp
+++ b/arangod/Pregel/Worker/WorkerConfig.cpp
@@ -53,8 +53,7 @@ void WorkerConfig::updateConfig(PregelFeature& feature,
   // list of all shards, equal on all workers. Used to avoid storing strings of
   // shard names
   // Instead we have an index identifying a shard name in this vector
-  size_t i = 0;
-  for (auto const& shard : _globalShardIDs) {
+  for (uint16_t i = 0; auto const& shard : _globalShardIDs) {
     _pregelShardIDs.try_emplace(shard, PregelShard(i++));  // Cache these ids
   }
 


### PR DESCRIPTION
Cast PregelShard input explicitly to uint16_t to fix windows build that treats this as an error