### PR TITLE
BTS-944: fix disk space metrics on macOS

### DIFF
--- a/lib/Basics/files.cpp
+++ b/lib/Basics/files.cpp
@@ -2626,8 +2626,16 @@ arangodb::Result TRI_GetDiskSpaceInfo(std::string const& path,
     TRI_set_errno(TRI_ERROR_SYS_ERROR);
     return {TRI_errno(), TRI_last_error()};
   }
-  totalSpace = static_cast<uint64_t>(stat.f_bsize) *
-               static_cast<uint64_t>(stat.f_blocks);
+
+#ifdef __APPLE__
+  // at least on macOS f_bsize produces incorrect results. it is unclear
+  // yet if we need to use f_frsize on Linux as well.
+  uint64_t factor = static_cast<uint64_t>(stat.f_frsize);
+#else
+  uint64_t factor = static_cast<uint64_t>(stat.f_bsize);
+#endif
+
+  totalSpace = factor * static_cast<uint64_t>(stat.f_blocks);
 
   // sbuf.bfree is total free space available to root
   // sbuf.bavail is total free space available to unprivileged user
@@ -2635,12 +2643,10 @@ arangodb::Result TRI_GetDiskSpaceInfo(std::string const& path,
   if (geteuid()) {
     // non-zero user is unprivileged, or -1 if error. take more conservative
     // size
-    freeSpace = static_cast<uint64_t>(stat.f_bsize) *
-                static_cast<uint64_t>(stat.f_bavail);
+    freeSpace = factor * static_cast<uint64_t>(stat.f_bavail);
   } else {
     // root user can access all disk space
-    freeSpace = static_cast<uint64_t>(stat.f_bsize) *
-                static_cast<uint64_t>(stat.f_bfree);
+    freeSpace = factor * static_cast<uint64_t>(stat.f_bfree);
   }
 #endif
   return {};

--- a/lib/Basics/files.cpp
+++ b/lib/Basics/files.cpp
@@ -2630,9 +2630,9 @@ arangodb::Result TRI_GetDiskSpaceInfo(std::string const& path,
 #ifdef __APPLE__
   // at least on macOS f_bsize produces incorrect results. it is unclear
   // yet if we need to use f_frsize on Linux as well.
-  uint64_t factor = static_cast<uint64_t>(stat.f_frsize);
+  auto const factor = static_cast<uint64_t>(stat.f_frsize);
 #else
-  uint64_t factor = static_cast<uint64_t>(stat.f_bsize);
+  auto const factor = static_cast<uint64_t>(stat.f_bsize);
 #endif
 
   totalSpace = factor * static_cast<uint64_t>(stat.f_blocks);


### PR DESCRIPTION
### Scope & Purpose

Fix BTS-944: https://arangodb.atlassian.net/browse/BTS-944

Fix disk space metrics `rocksdb_free_disk_space` and `rocksdb_total_disk_space` on macOS. Previously, they seem to have reported wrong values.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [x] Backports
  - [x] Backport for 3.10: https://github.com/arangodb/arangodb/pull/17543
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [x] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/BTS-944
- [ ] Design document: 