### PR TITLE
QA-326: [testing] add way to specify per instance extra arg

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -871,12 +871,14 @@ using valgrind could look like this. Options are passed as regular long values
 in the syntax --option value --sub:option value. Using Valgrind could look like
 this:
 
-    ./scripts/unittest single_server --test tests/js/server/aql/aql-escaping.js \
+    ./scripts/unittest shell_client --test tests/js/server/aql/aql-escaping.js \
+      --cluster true \
       --extraArgs:server.threads 1 \
       --extraArgs:scheduler.threads 1 \
       --extraArgs:javascript.gc-frequency 1000000 \
       --extraArgs:javascript.gc-interval 65536 \
-      --extraArgs:log.level debug \
+      --extraArgs:agent.log.level trace \
+      --extraArgs:log.level request=debug \
       --extraArgs:log.force-direct true \
       --javascript.v8-contexts 2 \
       --valgrind /usr/bin/valgrind \
@@ -886,9 +888,18 @@ this:
 - We specify some arangod arguments via --extraArgs which increase the server performance
 - We specify to run using valgrind (this is supported by all facilities)
 - We specify some valgrind commandline arguments
-- We set the log level to debug
+- We set the log levels for agents to `trace` (the Instance type can be specified by:
+  - `single`
+  - `agent`
+  - `dbserver`
+  - `coordinator`
+  - `activefailover`
+  )
+- We set the `requests` log level to debug on all instances
 - We force the logging not to happen asynchronous
 - Eventually you may still add temporary `console.log()` statements to tests you debug.
+
+
 
 #### Running a Single Unittest Suite
 

--- a/js/client/modules/@arangodb/testutils/instance.js
+++ b/js/client/modules/@arangodb/testutils/instance.js
@@ -370,7 +370,7 @@ class instance {
       let splitkey = key.split('.');
       if (splitkey.length !== 2) {
         if (splitkey[0] === this.instanceRole) {
-          this.args[splitkey[1] + '.' + splitkey[2]] = value;
+          this.args[splitkey.slice(1).join('.')] = value;
         }
       } else {
         this.args[key] = value;

--- a/js/client/modules/@arangodb/testutils/instance.js
+++ b/js/client/modules/@arangodb/testutils/instance.js
@@ -366,7 +366,16 @@ class instance {
     // instanceInfo.authOpts['server.jwt-secret-folder'] = addArgs['server.jwt-secret-folder'];
     }
 
-    this.args = Object.assign(this.args, this.options.extraArgs);
+    for (const [key, value] of Object.entries(this.options.extraArgs)) {
+      let splitkey = key.split('.');
+      if (splitkey.length !== 2) {
+        if (splitkey[0] === this.instanceRole) {
+          this.args[splitkey[1] + '.' + splitkey[2]] = value;
+        }
+      } else {
+        this.args[key] = value;
+      }
+    }
 
     if (this.options.verbose) {
       this.args['log.level'] = 'debug';


### PR DESCRIPTION
### Scope & Purpose

we so far can put args to arangods launched by testing.js one could specify `--extraArgs:log.level debug` - now one can set this per instance type to be launched.

- [x] :pizza: New feature
