### PR TITLE
Do not query vertex data in K_PATHS queries if vertex data is not needed

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 devel
 -----
 
+* Do not query vertex data in K_PATHS queries if vertex data is not needed.
+
 * Removed assertions from cluster rebalance js test that obligated the rebalance
   plan to always have moves, but there were cases in which all there are none.
 

--- a/arangod/Aql/Ast.cpp
+++ b/arangod/Aql/Ast.cpp
@@ -69,7 +69,7 @@ struct RecursiveAttributeFinderContext {
   bool couldExtractAttributePath;
   std::string_view expectedAttribute;
   containers::SmallVector<AstNode const*, 128> seen;
-  std::unordered_set<arangodb::aql::AttributeNamePath>& attributes;
+  containers::FlatHashSet<arangodb::aql::AttributeNamePath>& attributes;
 };
 
 struct ValidateAndOptimizeContext {
@@ -2769,7 +2769,7 @@ size_t Ast::countReferences(AstNode const* node, Variable const* search) {
 bool Ast::getReferencedAttributesRecursive(
     AstNode const* node, Variable const* variable,
     std::string_view expectedAttribute,
-    std::unordered_set<arangodb::aql::AttributeNamePath>& attributes) {
+    containers::FlatHashSet<arangodb::aql::AttributeNamePath>& attributes) {
   RecursiveAttributeFinderContext state{variable,
                                         /*couldExtractAttributePath*/ true,
                                         expectedAttribute,

--- a/arangod/Aql/Ast.h
+++ b/arangod/Aql/Ast.h
@@ -42,6 +42,7 @@
 #include "Aql/VariableGenerator.h"
 #include "Aql/types.h"
 #include "Basics/AttributeNameParser.h"
+#include "Containers/FlatHashSet.h"
 #include "Containers/HashSet.h"
 #include "Graph/PathType.h"
 #include "VocBase/AccessMode.h"
@@ -473,7 +474,7 @@ class Ast {
   /// for the specified variable
   static bool getReferencedAttributesRecursive(
       AstNode const*, Variable const*, std::string_view expectedAttribute,
-      std::unordered_set<arangodb::aql::AttributeNamePath>&);
+      containers::FlatHashSet<arangodb::aql::AttributeNamePath>&);
 
   /// @brief replace an attribute access with just the variable
   static AstNode* replaceAttributeAccess(

--- a/arangod/Aql/EnumeratePathsNode.cpp
+++ b/arangod/Aql/EnumeratePathsNode.cpp
@@ -421,12 +421,13 @@ std::unique_ptr<ExecutionBlock> EnumeratePathsNode::createBlock(
       SingleServerBaseProviderOptions forwardProviderOptions(
           opts->tmpVar(), std::move(usedIndexes), opts->getExpressionCtx(), {},
           opts->collectionToShard(), opts->getVertexProjections(),
-          opts->getEdgeProjections());
+          opts->getEdgeProjections(), opts->produceVertices());
 
       SingleServerBaseProviderOptions backwardProviderOptions(
           opts->tmpVar(), std::move(reversedUsedIndexes),
           opts->getExpressionCtx(), {}, opts->collectionToShard(),
-          opts->getVertexProjections(), opts->getEdgeProjections());
+          opts->getVertexProjections(), opts->getEdgeProjections(),
+          opts->produceVertices());
 
       using Provider = SingleServerProvider<SingleServerProviderStep>;
       if (opts->query().queryOptions().getTraversalProfileLevel() ==

--- a/arangod/Aql/EnumeratePathsNode.cpp
+++ b/arangod/Aql/EnumeratePathsNode.cpp
@@ -589,12 +589,13 @@ std::unique_ptr<ExecutionBlock> EnumeratePathsNode::createBlock(
       SingleServerBaseProviderOptions forwardProviderOptions(
           opts->tmpVar(), std::move(usedIndexes), opts->getExpressionCtx(), {},
           opts->collectionToShard(), opts->getVertexProjections(),
-          opts->getEdgeProjections());
+          opts->getEdgeProjections(), opts->produceVertices());
 
       SingleServerBaseProviderOptions backwardProviderOptions(
           opts->tmpVar(), std::move(reversedUsedIndexes),
           opts->getExpressionCtx(), {}, opts->collectionToShard(),
-          opts->getVertexProjections(), opts->getEdgeProjections());
+          opts->getVertexProjections(), opts->getEdgeProjections(),
+          opts->produceVertices());
 
       // TODO [GraphRefactor]: Optimize useWeight section
       if (opts->useWeight()) {

--- a/arangod/Aql/IndexNode.cpp
+++ b/arangod/Aql/IndexNode.cpp
@@ -43,6 +43,7 @@
 #include "Basics/AttributeNameParser.h"
 #include "Basics/StringUtils.h"
 #include "Basics/VelocyPackHelper.h"
+#include "Containers/FlatHashSet.h"
 #include "Indexes/Index.h"
 #include "StorageEngine/EngineSelectorFeature.h"
 #include "StorageEngine/StorageEngine.h"
@@ -587,7 +588,7 @@ void IndexNode::prepareProjections() {
     // if we have a covering index and a post-filter condition,
     // extract which projections we will need just to execute
     // the filter condition
-    std::unordered_set<AttributeNamePath> attributes;
+    containers::FlatHashSet<AttributeNamePath> attributes;
 
     if (Ast::getReferencedAttributesRecursive(
             this->filter()->node(), this->outVariable(),

--- a/arangod/Aql/OptimizerRule.h
+++ b/arangod/Aql/OptimizerRule.h
@@ -202,6 +202,10 @@ struct OptimizerRule {
 
     // merge filters into graph traversals
     optimizeTraversalsRule,
+
+    // optimize K_PATHS
+    optimizePathsRule,
+
     // remove redundant filters statements
     removeFiltersCoveredByTraversal,
 

--- a/arangod/Aql/OptimizerRules.cpp
+++ b/arangod/Aql/OptimizerRules.cpp
@@ -62,6 +62,7 @@
 #include "Basics/ScopeGuard.h"
 #include "Basics/StaticStrings.h"
 #include "Cluster/ClusterInfo.h"
+#include "Containers/FlatHashSet.h"
 #include "Containers/HashSet.h"
 #include "Containers/SmallUnorderedMap.h"
 #include "Containers/SmallVector.h"
@@ -887,7 +888,8 @@ bool shouldApplyHeapOptimization(arangodb::aql::SortNode& sortNode,
 bool applyGraphProjections(arangodb::aql::TraversalNode* traversal) {
   auto* options =
       static_cast<arangodb::traverser::TraverserOptions*>(traversal->options());
-  std::unordered_set<arangodb::aql::AttributeNamePath> attributes;
+  arangodb::containers::FlatHashSet<arangodb::aql::AttributeNamePath>
+      attributes;
   bool modified = false;
   size_t maxProjections = options->getMaxProjections();
   auto pathOutVariable = traversal->pathOutVariable();
@@ -1005,7 +1007,7 @@ bool optimizeTraversalPathVariable(
 
   // path is used later, but lets check which of its sub-attributes
   // "vertices" or "edges" are in use (or the complete path)
-  std::unordered_set<AttributeNamePath> attributes;
+  containers::FlatHashSet<AttributeNamePath> attributes;
   VarSet vars;
 
   ExecutionNode* current = traversal->getFirstParent();
@@ -6362,7 +6364,7 @@ void arangodb::aql::optimizePathsRule(Optimizer* opt,
 
     Variable const* variable = &(ksp->pathOutVariable());
 
-    std::unordered_set<AttributeNamePath> attributes;
+    containers::FlatHashSet<AttributeNamePath> attributes;
     VarSet vars;
     bool canOptimize = true;
 
@@ -6402,8 +6404,7 @@ void arangodb::aql::optimizePathsRule(Optimizer* opt,
 
     if (canOptimize) {
       bool produceVertices =
-          (attributes.find(StaticStrings::GraphQueryVertices) !=
-           attributes.end());
+          attributes.contains(StaticStrings::GraphQueryVertices);
 
       if (!produceVertices) {
         auto* options = ksp->options();

--- a/arangod/Aql/OptimizerRules.cpp
+++ b/arangod/Aql/OptimizerRules.cpp
@@ -66,6 +66,7 @@
 #include "Containers/SmallUnorderedMap.h"
 #include "Containers/SmallVector.h"
 #include "Geo/GeoParams.h"
+#include "Graph/ShortestPathOptions.h"
 #include "Graph/TraverserOptions.h"
 #include "Indexes/Index.h"
 #include "StorageEngine/EngineSelectorFeature.h"
@@ -6330,6 +6331,85 @@ void arangodb::aql::optimizeTraversalsRule(Optimizer* opt,
     for (auto const& n : nodes) {
       TraversalConditionFinder finder(plan.get(), &modified);
       n->walk(finder);
+    }
+  }
+
+  opt->addPlan(std::move(plan), rule, modified);
+}
+
+/// @brief optimizes away unused K_PATHS things
+void arangodb::aql::optimizePathsRule(Optimizer* opt,
+                                      std::unique_ptr<ExecutionPlan> plan,
+                                      OptimizerRule const& rule) {
+  containers::SmallVector<ExecutionNode*, 8> nodes;
+  plan->findNodesOfType(nodes, EN::ENUMERATE_PATHS, true);
+
+  if (nodes.empty()) {
+    // no traversals present
+    opt->addPlan(std::move(plan), rule, false);
+    return;
+  }
+
+  bool modified = false;
+
+  // first make a pass over all traversal nodes and remove unused
+  // variables from them
+  for (auto const& n : nodes) {
+    EnumeratePathsNode* ksp = ExecutionNode::castTo<EnumeratePathsNode*>(n);
+    if (!ksp->usesPathOutVariable()) {
+      continue;
+    }
+
+    Variable const* variable = &(ksp->pathOutVariable());
+
+    std::unordered_set<AttributeNamePath> attributes;
+    VarSet vars;
+    bool canOptimize = true;
+
+    ExecutionNode* current = ksp->getFirstParent();
+    while (current != nullptr && canOptimize) {
+      switch (current->getType()) {
+        case EN::CALCULATION: {
+          vars.clear();
+          current->getVariablesUsedHere(vars);
+          if (vars.find(variable) != vars.end()) {
+            // path variable used here
+            Expression* exp =
+                ExecutionNode::castTo<CalculationNode*>(current)->expression();
+            AstNode const* node = exp->node();
+            if (!Ast::getReferencedAttributesRecursive(
+                    node, variable, /*expectedAttributes*/ "", attributes)) {
+              // full path variable is used, or accessed in a way that we don't
+              // understand, e.g. "p" or "p[0]" or "p[*]..."
+              canOptimize = false;
+            }
+          }
+          break;
+        }
+        default: {
+          // if the path is used by any other node type, we don't know what to
+          // do and will not optimize parts of it away
+          vars.clear();
+          current->getVariablesUsedHere(vars);
+          if (vars.find(variable) != vars.end()) {
+            canOptimize = false;
+          }
+          break;
+        }
+      }
+      current = current->getFirstParent();
+    }
+
+    if (canOptimize) {
+      bool produceVertices =
+          (attributes.find(StaticStrings::GraphQueryVertices) !=
+           attributes.end());
+
+      if (!produceVertices) {
+        auto* options = ksp->options();
+        options->setProduceVertices(false);
+        modified = true;
+      }
     }
   }
 

--- a/arangod/Aql/OptimizerRules.h
+++ b/arangod/Aql/OptimizerRules.h
@@ -286,6 +286,10 @@ void skipInaccessibleCollectionsRule(Optimizer*, std::unique_ptr<ExecutionPlan>,
 void optimizeTraversalsRule(Optimizer* opt, std::unique_ptr<ExecutionPlan> plan,
                             OptimizerRule const&);
 
+/// @brief optimizes away unused K_PATHS things
+void optimizePathsRule(Optimizer* opt, std::unique_ptr<ExecutionPlan> plan,
+                       OptimizerRule const&);
+
 /// @brief removes filter nodes already covered by the traversal and removes
 /// unused variables
 void removeFiltersCoveredByTraversal(Optimizer* opt,

--- a/arangod/Aql/OptimizerRulesFeature.cpp
+++ b/arangod/Aql/OptimizerRulesFeature.cpp
@@ -307,6 +307,11 @@ void OptimizerRulesFeature::addRules() {
                OptimizerRule::optimizeTraversalsRule,
                OptimizerRule::makeFlags(OptimizerRule::Flags::CanBeDisabled));
 
+  // optimize K_PATHS
+  registerRule("optimize-paths", optimizePathsRule,
+               OptimizerRule::optimizePathsRule,
+               OptimizerRule::makeFlags(OptimizerRule::Flags::CanBeDisabled));
+
   // optimize unneccessary filters already applied by the traversal
   registerRule("remove-filter-covered-by-traversal",
                removeFiltersCoveredByTraversal,

--- a/arangod/Aql/OptimizerUtils.cpp
+++ b/arangod/Aql/OptimizerUtils.cpp
@@ -37,7 +37,6 @@
 #include "Aql/SortCondition.h"
 #include "Aql/TraversalNode.h"
 #include "Aql/Variable.h"
-#include "Containers/SmallVector.h"
 #include "Indexes/Index.h"
 #include "IResearch/IResearchFeature.h"
 
@@ -905,7 +904,7 @@ namespace arangodb::aql::utils {
 bool findProjections(ExecutionNode* n, Variable const* v,
                      std::string_view expectedAttribute,
                      bool excludeStartNodeFilterCondition,
-                     std::unordered_set<AttributeNamePath>& attributes) {
+                     containers::FlatHashSet<AttributeNamePath>& attributes) {
   using EN = aql::ExecutionNode;
 
   VarSet vars;

--- a/arangod/Aql/OptimizerUtils.h
+++ b/arangod/Aql/OptimizerUtils.h
@@ -23,7 +23,9 @@
 
 #pragma once
 
+#include "Aql/AttributeNamePath.h"
 #include "Aql/types.h"
+#include "Containers/FlatHashSet.h"
 
 #include <cstdint>
 #include <memory>
@@ -66,7 +68,7 @@ namespace utils {
 bool findProjections(ExecutionNode* n, Variable const* v,
                      std::string_view expectedAttribute,
                      bool excludeStartNodeFilterCondition,
-                     std::unordered_set<AttributeNamePath>& attributes);
+                     containers::FlatHashSet<AttributeNamePath>& attributes);
 
 /// @brief Gets the best fitting index for an AQL condition.
 /// note: the contents of  root  may be modified by this function if

--- a/arangod/Aql/Projections.cpp
+++ b/arangod/Aql/Projections.cpp
@@ -29,8 +29,6 @@
 #include "Transaction/Helpers.h"
 #include "Transaction/Methods.h"
 
-#include "Logger/LogMacros.h"
-
 #include <velocypack/Builder.h>
 #include <velocypack/Iterator.h>
 #include <velocypack/Slice.h>
@@ -47,64 +45,18 @@ constexpr std::string_view projectionsKey("projections");
 
 namespace arangodb::aql {
 
-Projections::Projections() {}
+Projections::Projections() = default;
 
 Projections::Projections(std::vector<AttributeNamePath> paths) {
-  _projections.reserve(paths.size());
-  for (auto& path : paths) {
-    if (path.empty()) {
-      // ignore all completely empty paths
-      continue;
-    }
-
-    // categorize the projection, based on the attribute name.
-    // we do this here only once in order to not do expensive string
-    // comparisons at runtime later
-    AttributeNamePath::Type type = path.type();
-    size_t length = path.size();
-    if (length >= std::numeric_limits<uint16_t>::max()) {
-      THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_BAD_PARAMETER,
-                                     "attribute path too long for projection");
-    }
-    // take over the projection
-    _projections.emplace_back(
-        Projection{std::move(path), kNoCoveringIndexPosition,
-                   /*coveringIndexCutoff*/ 0, /*startsAtLevel*/ 0,
-                   /*levelsToClose*/ static_cast<uint16_t>(length - 1), type});
-  }
-
-  TRI_ASSERT(_projections.size() <= paths.size());
-
-  init();
+  init(std::move(paths));
 }
 
 Projections::Projections(std::unordered_set<AttributeNamePath> paths) {
-  _projections.reserve(paths.size());
-  for (auto& path : paths) {
-    if (path.empty()) {
-      // ignore all completely empty paths
-      continue;
-    }
+  init(std::move(paths));
+}
 
-    // categorize the projection, based on the attribute name.
-    // we do this here only once in order to not do expensive string
-    // comparisons at runtime later
-    AttributeNamePath::Type type = path.type();
-    size_t length = path.size();
-    if (length >= std::numeric_limits<uint16_t>::max()) {
-      THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_BAD_PARAMETER,
-                                     "attribute path too long for projection");
-    }
-    // take over the projection
-    _projections.emplace_back(
-        Projection{std::move(path), kNoCoveringIndexPosition,
-                   /*coveringIndexCutoff*/ 0, /*startsAtLevel*/ 0,
-                   /*levelsToClose*/ static_cast<uint16_t>(length - 1), type});
-  }
-
-  TRI_ASSERT(_projections.size() <= paths.size());
-
-  init();
+Projections::Projections(containers::FlatHashSet<AttributeNamePath> paths) {
+  init(std::move(paths));
 }
 
 bool Projections::isCoveringIndexPosition(uint16_t position) noexcept {
@@ -372,7 +324,33 @@ void Projections::toVelocyPack(velocypack::Builder& b,
 }
 
 /// @brief shared init function
-void Projections::init() {
+template<typename T>
+void Projections::init(T paths) {
+  _projections.reserve(paths.size());
+  for (auto& path : paths) {
+    if (path.empty()) {
+      // ignore all completely empty paths
+      continue;
+    }
+
+    // categorize the projection, based on the attribute name.
+    // we do this here only once in order to not do expensive string
+    // comparisons at runtime later
+    AttributeNamePath::Type type = path.type();
+    size_t length = path.size();
+    if (length >= std::numeric_limits<uint16_t>::max()) {
+      THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_BAD_PARAMETER,
+                                     "attribute path too long for projection");
+    }
+    // take over the projection
+    _projections.emplace_back(
+        Projection{std::move(path), kNoCoveringIndexPosition,
+                   /*coveringIndexCutoff*/ 0, /*startsAtLevel*/ 0,
+                   /*levelsToClose*/ static_cast<uint16_t>(length - 1), type});
+  }
+
+  TRI_ASSERT(_projections.size() <= paths.size());
+
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   // validate that no projection contains an empty attribute
   std::for_each(_projections.begin(), _projections.end(),
@@ -481,5 +459,12 @@ std::ostream& operator<<(std::ostream& stream, Projections const& projections) {
   stream << " ]";
   return stream;
 }
+
+template void Projections::init<std::vector<AttributeNamePath>>(
+    std::vector<AttributeNamePath> paths);
+template void Projections::init<std::unordered_set<AttributeNamePath>>(
+    std::unordered_set<AttributeNamePath> paths);
+template void Projections::init<containers::FlatHashSet<AttributeNamePath>>(
+    containers::FlatHashSet<AttributeNamePath> paths);
 
 }  // namespace arangodb::aql

--- a/arangod/Aql/Projections.h
+++ b/arangod/Aql/Projections.h
@@ -24,6 +24,7 @@
 #pragma once
 
 #include "Aql/AttributeNamePath.h"
+#include "Containers/FlatHashSet.h"
 #include "VocBase/Identifiers/DataSourceId.h"
 
 #include <cstdint>
@@ -78,6 +79,7 @@ class Projections {
   /// attributes will be sorted and made unique inside
   explicit Projections(std::vector<AttributeNamePath> paths);
   explicit Projections(std::unordered_set<AttributeNamePath> paths);
+  explicit Projections(containers::FlatHashSet<AttributeNamePath> paths);
 
   Projections(Projections&&) = default;
   Projections& operator=(Projections&&) = default;
@@ -152,7 +154,8 @@ class Projections {
 
  private:
   /// @brief shared init function
-  void init();
+  template<typename T>
+  void init(T paths);
 
   /// @brief clean up projections, so that there are no 2 projections where one
   /// is a true prefix of another. also sets level attributes

--- a/arangod/Aql/TraversalNode.cpp
+++ b/arangod/Aql/TraversalNode.cpp
@@ -661,8 +661,8 @@ std::unique_ptr<ExecutionBlock> TraversalNode::createBlock(
     bool isSmart) const {
   TraverserOptions* opts = this->options();
 
-  arangodb::graph::OneSidedEnumeratorOptions options{
-      opts->minDepth, opts->maxDepth, opts->produceVertices()};
+  arangodb::graph::OneSidedEnumeratorOptions options{opts->minDepth,
+                                                     opts->maxDepth};
   /*
    * PathValidator Disjoint Helper (TODO [GraphRefactor]: Copy from createBlock)
    * Clean this up as soon we clean up the whole TraversalNode as well.

--- a/arangod/Aql/TraversalNode.cpp
+++ b/arangod/Aql/TraversalNode.cpp
@@ -661,8 +661,8 @@ std::unique_ptr<ExecutionBlock> TraversalNode::createBlock(
     bool isSmart) const {
   TraverserOptions* opts = this->options();
 
-  arangodb::graph::OneSidedEnumeratorOptions options{opts->minDepth,
-                                                     opts->maxDepth};
+  arangodb::graph::OneSidedEnumeratorOptions options{
+      opts->minDepth, opts->maxDepth, opts->produceVertices()};
   /*
    * PathValidator Disjoint Helper (TODO [GraphRefactor]: Copy from createBlock)
    * Clean this up as soon we clean up the whole TraversalNode as well.
@@ -779,7 +779,8 @@ TraversalNode::getSingleServerBaseProviderOptions(
           filterConditionVariables,
           opts->collectionToShard(),
           opts->getVertexProjections(),
-          opts->getEdgeProjections()};
+          opts->getEdgeProjections(),
+          opts->produceVertices()};
 }
 
 /// @brief creates corresponding ExecutionBlock

--- a/arangod/Graph/Cache/RefactoredTraverserCache.cpp
+++ b/arangod/Graph/Cache/RefactoredTraverserCache.cpp
@@ -76,7 +76,7 @@ RefactoredTraverserCache::RefactoredTraverserCache(
     std::unordered_map<std::string, std::vector<std::string>> const&
         collectionToShardMap,
     arangodb::aql::Projections const& vertexProjections,
-    arangodb::aql::Projections const& edgeProjections)
+    arangodb::aql::Projections const& edgeProjections, bool produceVertices)
     : _query(query),
       _trx(trx),
       _stringHeap(
@@ -84,6 +84,7 @@ RefactoredTraverserCache::RefactoredTraverserCache(
           4096), /* arbitrary block-size may be adjusted for performance */
       _collectionToShardMap(collectionToShardMap),
       _resourceMonitor(resourceMonitor),
+      _produceVertices(produceVertices),
       _allowImplicitCollections(ServerState::instance()->isSingleServer() &&
                                 !_query->vocbase()
                                      .server()
@@ -226,6 +227,11 @@ bool RefactoredTraverserCache::appendVertex(
   }
 
   auto findDocumentInShard = [&](std::string const& collectionName) -> bool {
+    if (!_produceVertices) {
+      // we don't need any vertex data, return quickly
+      result.add(VPackSlice::nullSlice());
+      return true;
+    }
     try {
       transaction::AllowImplicitCollectionsSwitcher disallower(
           _trx->state()->options(), _allowImplicitCollections);

--- a/arangod/Graph/Cache/RefactoredTraverserCache.h
+++ b/arangod/Graph/Cache/RefactoredTraverserCache.h
@@ -74,7 +74,7 @@ class RefactoredTraverserCache {
       std::unordered_map<std::string, std::vector<std::string>> const&
           collectionToShardMap,
       arangodb::aql::Projections const& vertexProjections,
-      arangodb::aql::Projections const& edgeProjections);
+      arangodb::aql::Projections const& edgeProjections, bool produceVertices);
 
   ~RefactoredTraverserCache();
 
@@ -186,6 +186,9 @@ class RefactoredTraverserCache {
   std::unordered_map<std::string, std::vector<std::string>> const&
       _collectionToShardMap;
   arangodb::ResourceMonitor& _resourceMonitor;
+
+  /// @brief whether or not to produce vertices
+  bool const _produceVertices;
 
   /// @brief whether or not to allow adding of previously unknown collections
   /// during the traversal

--- a/arangod/Graph/Enumerators/OneSidedEnumerator.cpp
+++ b/arangod/Graph/Enumerators/OneSidedEnumerator.cpp
@@ -122,7 +122,7 @@ auto OneSidedEnumerator<Configuration>::computeNeighbourhoodOfNextVertex()
     // Will throw all network errors here
     std::vector<Step*> preparedEnds = std::move(futureEnds.get());
     TRI_ASSERT(preparedEnds.size() != 0);
-    TRI_ASSERT(!_options.produceVertices() || _queue.firstIsVertexFetched());
+    TRI_ASSERT(_queue.firstIsVertexFetched());
   }
 
   TRI_ASSERT(!_queue.isEmpty());

--- a/arangod/Graph/Enumerators/OneSidedEnumerator.cpp
+++ b/arangod/Graph/Enumerators/OneSidedEnumerator.cpp
@@ -121,11 +121,11 @@ auto OneSidedEnumerator<Configuration>::computeNeighbourhoodOfNextVertex()
 
     // Will throw all network errors here
     std::vector<Step*> preparedEnds = std::move(futureEnds.get());
-
     TRI_ASSERT(preparedEnds.size() != 0);
-    TRI_ASSERT(_queue.firstIsVertexFetched());
+    TRI_ASSERT(!_options.produceVertices() || _queue.firstIsVertexFetched());
   }
 
+  TRI_ASSERT(!_queue.isEmpty());
   auto tmp = _queue.pop();
   auto posPrevious = _interior.append(std::move(tmp));
   auto& step = _interior.getStepReference(posPrevious);

--- a/arangod/Graph/Options/OneSidedEnumeratorOptions.cpp
+++ b/arangod/Graph/Options/OneSidedEnumeratorOptions.cpp
@@ -28,11 +28,8 @@ using namespace arangodb;
 using namespace arangodb::graph;
 
 OneSidedEnumeratorOptions::OneSidedEnumeratorOptions(size_t minDepth,
-                                                     size_t maxDepth,
-                                                     bool produceVertices)
-    : _minDepth(minDepth),
-      _maxDepth(maxDepth),
-      _produceVertices(produceVertices) {}
+                                                     size_t maxDepth)
+    : _minDepth(minDepth), _maxDepth(maxDepth) {}
 
 OneSidedEnumeratorOptions::~OneSidedEnumeratorOptions() = default;
 
@@ -41,7 +38,4 @@ size_t OneSidedEnumeratorOptions::getMinDepth() const noexcept {
 }
 size_t OneSidedEnumeratorOptions::getMaxDepth() const noexcept {
   return _maxDepth;
-}
-bool OneSidedEnumeratorOptions::produceVertices() const noexcept {
-  return _produceVertices;
 }

--- a/arangod/Graph/Options/OneSidedEnumeratorOptions.cpp
+++ b/arangod/Graph/Options/OneSidedEnumeratorOptions.cpp
@@ -28,10 +28,20 @@ using namespace arangodb;
 using namespace arangodb::graph;
 
 OneSidedEnumeratorOptions::OneSidedEnumeratorOptions(size_t minDepth,
-                                                     size_t maxDepth)
-    : _minDepth(minDepth), _maxDepth(maxDepth) {}
+                                                     size_t maxDepth,
+                                                     bool produceVertices)
+    : _minDepth(minDepth),
+      _maxDepth(maxDepth),
+      _produceVertices(produceVertices) {}
 
 OneSidedEnumeratorOptions::~OneSidedEnumeratorOptions() = default;
 
-size_t OneSidedEnumeratorOptions::getMinDepth() const { return _minDepth; }
-size_t OneSidedEnumeratorOptions::getMaxDepth() const { return _maxDepth; }
+size_t OneSidedEnumeratorOptions::getMinDepth() const noexcept {
+  return _minDepth;
+}
+size_t OneSidedEnumeratorOptions::getMaxDepth() const noexcept {
+  return _maxDepth;
+}
+bool OneSidedEnumeratorOptions::produceVertices() const noexcept {
+  return _produceVertices;
+}

--- a/arangod/Graph/Options/OneSidedEnumeratorOptions.h
+++ b/arangod/Graph/Options/OneSidedEnumeratorOptions.h
@@ -24,24 +24,23 @@
 
 #pragma once
 
-#include <numeric>
 #include <cstddef>
 
-namespace arangodb {
-
-namespace graph {
+namespace arangodb::graph {
 
 struct OneSidedEnumeratorOptions {
  public:
-  OneSidedEnumeratorOptions(size_t minDepth, size_t maxDepth);
+  OneSidedEnumeratorOptions(size_t minDepth, size_t maxDepth,
+                            bool produceVertices);
   ~OneSidedEnumeratorOptions();
 
-  [[nodiscard]] size_t getMinDepth() const;
-  [[nodiscard]] size_t getMaxDepth() const;
+  [[nodiscard]] size_t getMinDepth() const noexcept;
+  [[nodiscard]] size_t getMaxDepth() const noexcept;
+  [[nodiscard]] bool produceVertices() const noexcept;
 
  private:
-  size_t _minDepth;
-  size_t _maxDepth;
+  size_t const _minDepth;
+  size_t const _maxDepth;
+  bool const _produceVertices;
 };
-}  // namespace graph
-}  // namespace arangodb
+}  // namespace arangodb::graph

--- a/arangod/Graph/Options/OneSidedEnumeratorOptions.h
+++ b/arangod/Graph/Options/OneSidedEnumeratorOptions.h
@@ -30,17 +30,14 @@ namespace arangodb::graph {
 
 struct OneSidedEnumeratorOptions {
  public:
-  OneSidedEnumeratorOptions(size_t minDepth, size_t maxDepth,
-                            bool produceVertices);
+  OneSidedEnumeratorOptions(size_t minDepth, size_t maxDepth);
   ~OneSidedEnumeratorOptions();
 
   [[nodiscard]] size_t getMinDepth() const noexcept;
   [[nodiscard]] size_t getMaxDepth() const noexcept;
-  [[nodiscard]] bool produceVertices() const noexcept;
 
  private:
   size_t const _minDepth;
   size_t const _maxDepth;
-  bool const _produceVertices;
 };
 }  // namespace arangodb::graph

--- a/arangod/Graph/Providers/BaseProviderOptions.cpp
+++ b/arangod/Graph/Providers/BaseProviderOptions.cpp
@@ -86,7 +86,7 @@ SingleServerBaseProviderOptions::SingleServerBaseProviderOptions(
     std::unordered_map<std::string, std::vector<std::string>> const&
         collectionToShardMap,
     aql::Projections const& vertexProjections,
-    aql::Projections const& edgeProjections)
+    aql::Projections const& edgeProjections, bool produceVertices)
     : _temporaryVariable(tmpVar),
       _indexInformation(std::move(indexInfo)),
       _expressionContext(expressionContext),
@@ -94,7 +94,8 @@ SingleServerBaseProviderOptions::SingleServerBaseProviderOptions(
       _weightCallback(std::nullopt),
       _filterConditionVariables(filterConditionVariables),
       _vertexProjections{vertexProjections},
-      _edgeProjections{edgeProjections} {}
+      _edgeProjections{edgeProjections},
+      _produceVertices(produceVertices) {}
 
 aql::Variable const* SingleServerBaseProviderOptions::tmpVar() const {
   return _temporaryVariable;
@@ -117,8 +118,12 @@ SingleServerBaseProviderOptions::expressionContext() const {
   return _expressionContext;
 }
 
-bool SingleServerBaseProviderOptions::hasWeightMethod() const {
+bool SingleServerBaseProviderOptions::hasWeightMethod() const noexcept {
   return _weightCallback.has_value();
+}
+
+bool SingleServerBaseProviderOptions::produceVertices() const noexcept {
+  return _produceVertices;
 }
 
 void SingleServerBaseProviderOptions::setWeightEdgeCallback(
@@ -195,9 +200,11 @@ RefactoredClusterTraverserCache* ClusterBaseProviderOptions::getCache() {
   return _cache.get();
 }
 
-bool ClusterBaseProviderOptions::isBackward() const { return _backward; }
+bool ClusterBaseProviderOptions::isBackward() const noexcept {
+  return _backward;
+}
 
-bool ClusterBaseProviderOptions::produceVertices() const {
+bool ClusterBaseProviderOptions::produceVertices() const noexcept {
   return _produceVertices;
 }
 

--- a/arangod/Graph/Providers/BaseProviderOptions.h
+++ b/arangod/Graph/Providers/BaseProviderOptions.h
@@ -95,7 +95,7 @@ struct SingleServerBaseProviderOptions {
       std::unordered_map<std::string, std::vector<std::string>> const&
           collectionToShardMap,
       aql::Projections const& vertexProjections,
-      aql::Projections const& edgeProjections);
+      aql::Projections const& edgeProjections, bool produceVertices);
 
   SingleServerBaseProviderOptions(SingleServerBaseProviderOptions const&) =
       delete;
@@ -114,7 +114,9 @@ struct SingleServerBaseProviderOptions {
   void prepareContext(aql::InputAqlItemRow input);
   void unPrepareContext();
 
-  bool hasWeightMethod() const;
+  bool hasWeightMethod() const noexcept;
+
+  bool produceVertices() const noexcept;
 
   double weightEdge(double prefixWeight,
                     arangodb::velocypack::Slice edge) const;
@@ -160,6 +162,8 @@ struct SingleServerBaseProviderOptions {
   /// @brief Projections used on edge data.
   /// Ownership of this struct is at the BaseOptions
   aql::Projections const& _edgeProjections;
+
+  bool const _produceVertices;
 };
 
 struct ClusterBaseProviderOptions {
@@ -182,9 +186,9 @@ struct ClusterBaseProviderOptions {
 
   RefactoredClusterTraverserCache* getCache();
 
-  bool isBackward() const;
+  bool isBackward() const noexcept;
 
-  bool produceVertices() const;
+  bool produceVertices() const noexcept;
 
   [[nodiscard]] std::unordered_map<ServerID, aql::EngineId> const* engines()
       const;
@@ -215,9 +219,9 @@ struct ClusterBaseProviderOptions {
 
   std::unordered_map<ServerID, aql::EngineId> const* _engines;
 
-  bool _backward;
+  bool const _backward;
 
-  bool _produceVertices;
+  bool const _produceVertices;
 
   // [GraphRefactor] Note: All vars below used in SingleServer && Cluster case
   aql::FixedVarExpressionContext* _expressionContext;

--- a/arangod/Graph/Providers/ClusterProvider.cpp
+++ b/arangod/Graph/Providers/ClusterProvider.cpp
@@ -130,20 +130,40 @@ auto ClusterProvider<StepImpl>::startVertex(const VertexType& vertex,
 template<class StepImpl>
 void ClusterProvider<StepImpl>::fetchVerticesFromEngines(
     std::vector<Step*> const& looseEnds, std::vector<Step*>& result) {
-  auto const* engines = _opts.engines();
   // slow path, sharding not deducable from _id
+  bool mustSend = false;
+
   transaction::BuilderLeaser leased(trx());
   leased->openObject();
-  leased->add("keys", VPackValue(VPackValueType::Array));
-  for (auto const& looseEnd : looseEnds) {
-    auto const& vertexId = looseEnd->getVertex().getID();
-    if (!_opts.getCache()->isVertexCached(vertexId)) {
-      leased->add(VPackValuePair(vertexId.data(), vertexId.length(),
-                                 VPackValueType::String));
+
+  if (_opts.produceVertices()) {
+    // slow path, sharding not deducable from _id
+    leased->add("keys", VPackValue(VPackValueType::Array));
+    for (auto const& looseEnd : looseEnds) {
+      TRI_ASSERT(looseEnd->isLooseEnd());
+      auto const& vertexId = looseEnd->getVertex().getID();
+      if (!_opts.getCache()->isVertexCached(vertexId)) {
+        leased->add(VPackValuePair(vertexId.data(), vertexId.size(),
+                                   VPackValueType::String));
+        mustSend = true;
+      }
     }
+    leased->close();  // 'keys' Array
   }
-  leased->close();  // 'keys' Array
   leased->close();  // base object
+
+  if (!mustSend) {
+    // nothing to send. save requests...
+    for (auto& looseEnd : looseEnds) {
+      auto const& vertexId = looseEnd->getVertex().getID();
+      if (!_opts.getCache()->isVertexCached(vertexId)) {
+        _opts.getCache()->cacheVertex(vertexId, VPackSlice::nullSlice());
+      }
+      result.emplace_back(looseEnd);
+      looseEnd->setVertexFetched();
+    }
+    return;
+  }
 
   auto* pool =
       trx()->vocbase().server().template getFeature<NetworkFeature>().pool();
@@ -152,6 +172,7 @@ void ClusterProvider<StepImpl>::fetchVerticesFromEngines(
   reqOpts.database = trx()->vocbase().name();
   reqOpts.skipScheduler = true;  // hack to avoid scheduler queue
 
+  auto const* engines = _opts.engines();
   std::vector<Future<network::Response>> futures;
   futures.reserve(engines->size());
 
@@ -218,18 +239,20 @@ void ClusterProvider<StepImpl>::fetchVerticesFromEngines(
   futures.clear();
 
   // put back all looseEnds. We were able to cache
-  for (auto& lE : looseEnds) {
-    if (!_opts.getCache()->isVertexCached(lE->getVertexIdentifier())) {
+  for (auto& looseEnd : looseEnds) {
+    auto const& vertexId = looseEnd->getVertex().getID();
+    if (!_opts.getCache()->isVertexCached(vertexId)) {
       // if we end up here. We were not able to cache the requested vertex
       // (e.g. it does not exist)
       _query->warnings().registerWarning(TRI_ERROR_ARANGO_DOCUMENT_NOT_FOUND,
-                                         lE->getVertexIdentifier().toString());
-      _opts.getCache()->cacheVertex(lE->getVertexIdentifier(),
-                                    VPackSlice::nullSlice());
+                                         vertexId.toString());
+      _opts.getCache()->cacheVertex(vertexId, VPackSlice::nullSlice());
     }
-    result.emplace_back(lE);
-    lE->setVertexFetched();
+    result.emplace_back(looseEnd);
+    looseEnd->setVertexFetched();
   }
+
+  _stats.incrHttpRequests(_opts.engines()->size());
 }
 
 template<class StepImpl>
@@ -424,7 +447,6 @@ auto ClusterProvider<StepImpl>::fetchVertices(
       }
     } else {
       fetchVerticesFromEngines(looseEnds, result);
-      _stats.incrHttpRequests(_opts.engines()->size() * looseEnds.size());
     }
   }
   return result;

--- a/arangod/Graph/Providers/SingleServerProvider.cpp
+++ b/arangod/Graph/Providers/SingleServerProvider.cpp
@@ -90,7 +90,7 @@ SingleServerProvider<Step>::SingleServerProvider(
       _opts(std::move(opts)),
       _cache(_trx.get(), &queryContext, resourceMonitor, _stats,
              _opts.collectionToShardMap(), _opts.getVertexProjections(),
-             _opts.getEdgeProjections()),
+             _opts.getEdgeProjections(), _opts.produceVertices()),
       _stats{} {
   // TODO CHECK RefactoredTraverserCache (will be discussed in the future, need
   // to do benchmarks if affordable) activateCache(false);
@@ -138,8 +138,6 @@ auto SingleServerProvider<Step>::fetch(std::vector<Step*> const& looseEnds)
   LOG_TOPIC("c9160", TRACE, Logger::GRAPHS)
       << "<SingleServerProvider> Fetching...";
   std::vector<Step*> result{};
-  result.reserve(looseEnds.size());
-
   return futures::makeFuture(std::move(result));
 }
 

--- a/arangod/Graph/Queues/LifoQueue.h
+++ b/arangod/Graph/Queues/LifoQueue.h
@@ -74,7 +74,7 @@ class LifoQueue {
   }
 
   bool firstIsVertexFetched() const {
-    if (not isEmpty()) {
+    if (!isEmpty()) {
       auto const& first = _queue.front();
       return first.vertexFetched();
     }

--- a/arangod/Graph/ShortestPathOptions.cpp
+++ b/arangod/Graph/ShortestPathOptions.cpp
@@ -67,6 +67,8 @@ ShortestPathOptions::ShortestPathOptions(aql::QueryContext& query,
       VelocyPackHelper::getStringValue(info, "weightAttribute", ""));
   setDefaultWeight(
       VelocyPackHelper::getNumericValue<double>(info, "defaultWeight", 1));
+  setProduceVertices(
+      VPackHelper::getBooleanValue(info, "produceVertices", true));
 }
 
 ShortestPathOptions::ShortestPathOptions(aql::QueryContext& query,
@@ -88,6 +90,8 @@ ShortestPathOptions::ShortestPathOptions(aql::QueryContext& query,
       VelocyPackHelper::getStringValue(info, "weightAttribute", ""));
   setDefaultWeight(
       VelocyPackHelper::getNumericValue<double>(info, "defaultWeight", 1));
+  setProduceVertices(
+      VPackHelper::getBooleanValue(info, "produceVertices", true));
 
   VPackSlice read = info.get("reverseLookupInfos");
   if (!read.isArray()) {
@@ -132,6 +136,7 @@ void ShortestPathOptions::toVelocyPack(VPackBuilder& builder) const {
   builder.add("maxDepth", VPackValue(maxDepth));
   builder.add("weightAttribute", VPackValue(getWeightAttribute()));
   builder.add("defaultWeight", VPackValue(getDefaultWeight()));
+  builder.add("produceVertices", VPackValue(produceVertices()));
   builder.add("type", VPackValue("shortestPath"));
 }
 

--- a/arangod/Graph/Steps/ClusterProviderStep.cpp
+++ b/arangod/Graph/Steps/ClusterProviderStep.cpp
@@ -34,11 +34,11 @@ auto operator<<(std::ostream& out, ClusterProviderStep const& step)
 }
 }  // namespace arangodb::graph
 
-ClusterProviderStep::ClusterProviderStep(const VertexType& v)
+ClusterProviderStep::ClusterProviderStep(VertexType const& v)
     : _vertex(v), _edge(), _fetchedStatus(FetchedType::UNFETCHED) {}
 
-ClusterProviderStep::ClusterProviderStep(const VertexType& v,
-                                         const EdgeType& edge, size_t prev)
+ClusterProviderStep::ClusterProviderStep(VertexType const& v,
+                                         EdgeType const& edge, size_t prev)
     : BaseStep(prev),
       _vertex(v),
       _edge(edge),
@@ -76,9 +76,15 @@ ClusterProviderStep::ClusterProviderStep(VertexType v, size_t depth,
 
 ClusterProviderStep::~ClusterProviderStep() = default;
 
-VertexType const& ClusterProviderStep::Vertex::getID() const { return _vertex; }
+VertexType const& ClusterProviderStep::Vertex::getID() const noexcept {
+  return _vertex;
+}
 
-ClusterProviderStep::EdgeType const& ClusterProviderStep::Edge::getID() const {
+ClusterProviderStep::EdgeType const& ClusterProviderStep::Edge::getID()
+    const noexcept {
   return _edge;
 }
-bool ClusterProviderStep::Edge::isValid() const { return !_edge.empty(); };
+
+bool ClusterProviderStep::Edge::isValid() const noexcept {
+  return !_edge.empty();
+}

--- a/arangod/Graph/Steps/ClusterProviderStep.h
+++ b/arangod/Graph/Steps/ClusterProviderStep.h
@@ -44,7 +44,7 @@ class ClusterProviderStep
    public:
     explicit Vertex(VertexType v) : _vertex(std::move(v)) {}
 
-    [[nodiscard]] VertexType const& getID() const;
+    [[nodiscard]] VertexType const& getID() const noexcept;
 
     bool operator<(Vertex const& other) const noexcept {
       return _vertex < other._vertex;
@@ -61,12 +61,12 @@ class ClusterProviderStep
   class Edge {
    public:
     explicit Edge(EdgeType tkn) : _edge(std::move(tkn)) {}
-    Edge() : _edge() {}
+    Edge() = default;
 
     [[nodiscard]] EdgeType const& getID()
-        const;  // TODO: Performance Test compare EdgeType
-                // <-> EdgeDocumentToken
-    [[nodiscard]] bool isValid() const;
+        const noexcept;  // TODO: Performance Test compare EdgeType
+                         // <-> EdgeDocumentToken
+    [[nodiscard]] bool isValid() const noexcept;
 
    private:
     EdgeType _edge;
@@ -77,13 +77,13 @@ class ClusterProviderStep
   ClusterProviderStep(VertexType v, size_t depth, double weight = 0.0);
 
  private:
-  ClusterProviderStep(const VertexType& v, const EdgeType& edge, size_t prev);
+  ClusterProviderStep(VertexType const& v, EdgeType const& edge, size_t prev);
   ClusterProviderStep(VertexType v, EdgeType edge, size_t prev,
                       FetchedType fetched);
   ClusterProviderStep(VertexType v, EdgeType edge, size_t prev,
                       FetchedType fetched, size_t depth);
 
-  explicit ClusterProviderStep(const VertexType& v);
+  explicit ClusterProviderStep(VertexType const& v);
 
  public:
   ~ClusterProviderStep();
@@ -92,34 +92,37 @@ class ClusterProviderStep
     return _vertex < other._vertex;
   }
 
-  [[nodiscard]] Vertex const& getVertex() const { return _vertex; }
-  [[nodiscard]] Edge const& getEdge() const { return _edge; }
+  [[nodiscard]] Vertex const& getVertex() const noexcept { return _vertex; }
+  [[nodiscard]] Edge const& getEdge() const noexcept { return _edge; }
 
   [[nodiscard]] std::string toString() const {
     return "<Step><Vertex>: " + _vertex.getID().toString();
   }
 
-  bool vertexFetched() const {
+  bool vertexFetched() const noexcept {
     return _fetchedStatus == FetchedType::VERTEX_FETCHED ||
            _fetchedStatus == FetchedType::VERTEX_AND_EDGES_FETCHED;
   }
 
-  bool edgeFetched() const {
+  bool edgeFetched() const noexcept {
     return _fetchedStatus == FetchedType::EDGES_FETCHED ||
            _fetchedStatus == FetchedType::VERTEX_AND_EDGES_FETCHED;
   }
 
   // todo: rename
-  [[nodiscard]] bool isProcessable() const { return !isLooseEnd(); }
-  [[nodiscard]] bool isLooseEnd() const {
+  [[nodiscard]] bool isProcessable() const noexcept { return !isLooseEnd(); }
+  [[nodiscard]] bool isLooseEnd() const noexcept {
     return _fetchedStatus == FetchedType::UNFETCHED ||
            _fetchedStatus == FetchedType::EDGES_FETCHED ||
            _fetchedStatus == FetchedType::VERTEX_FETCHED;
   }
 
+  // beware: returns a *copy* of the vertex id
   [[nodiscard]] VertexType getVertexIdentifier() const {
     return _vertex.getID();
   }
+
+  // beware: returns a *copy* of the edge id
   [[nodiscard]] EdgeType getEdgeIdentifier() const { return _edge.getID(); }
 
   [[nodiscard]] std::string getCollectionName() const {
@@ -128,19 +131,19 @@ class ClusterProviderStep
       THROW_ARANGO_EXCEPTION(collectionNameResult.result());
     }
     return collectionNameResult.get().first;
-  };
+  }
 
   friend auto operator<<(std::ostream& out, ClusterProviderStep const& step)
       -> std::ostream&;
 
-  void setVertexFetched() {
+  void setVertexFetched() noexcept {
     if (edgeFetched()) {
       _fetchedStatus = FetchedType::VERTEX_AND_EDGES_FETCHED;
     } else {
       _fetchedStatus = FetchedType::VERTEX_FETCHED;
     }
   }
-  void setEdgesFetched() {
+  void setEdgesFetched() noexcept {
     if (vertexFetched()) {
       _fetchedStatus = FetchedType::VERTEX_AND_EDGES_FETCHED;
     } else {

--- a/arangod/Graph/Steps/SingleServerProviderStep.cpp
+++ b/arangod/Graph/Steps/SingleServerProviderStep.cpp
@@ -79,9 +79,3 @@ void SingleServerProviderStep::Edge::addToBuilder(
     arangodb::velocypack::Builder& builder) const {
   provider.insertEdgeIntoResult(getID(), builder);
 }
-
-#if 0
-bool SingleServerProviderStep::isResponsible(transaction::Methods*) const noexcept {
-  return true;
-}
-#endif

--- a/arangod/Graph/Steps/SingleServerProviderStep.cpp
+++ b/arangod/Graph/Steps/SingleServerProviderStep.cpp
@@ -61,18 +61,18 @@ SingleServerProviderStep::SingleServerProviderStep(VertexType v,
 
 SingleServerProviderStep::~SingleServerProviderStep() = default;
 
-VertexType const& SingleServerProviderStep::Vertex::getID() const {
+VertexType const& SingleServerProviderStep::Vertex::getID() const noexcept {
   return _vertex;
 }
 
 SingleServerProviderStep::EdgeType const&
-SingleServerProviderStep::Edge::getID() const {
+SingleServerProviderStep::Edge::getID() const noexcept {
   return _token;
 }
 
-bool SingleServerProviderStep::Edge::isValid() const {
+bool SingleServerProviderStep::Edge::isValid() const noexcept {
   return getID().isValid();
-};
+}
 
 void SingleServerProviderStep::Edge::addToBuilder(
     SingleServerProvider<SingleServerProviderStep>& provider,
@@ -80,6 +80,8 @@ void SingleServerProviderStep::Edge::addToBuilder(
   provider.insertEdgeIntoResult(getID(), builder);
 }
 
-bool SingleServerProviderStep::isResponsible(transaction::Methods*) const {
+#if 0
+bool SingleServerProviderStep::isResponsible(transaction::Methods*) const noexcept {
   return true;
-};
+}
+#endif

--- a/arangod/Graph/Steps/SingleServerProviderStep.h
+++ b/arangod/Graph/Steps/SingleServerProviderStep.h
@@ -113,10 +113,6 @@ class SingleServerProviderStep
     return collectionNameResult.get().first;
   };
 
-#if 0
-  bool isResponsible(transaction::Methods*) const noexcept;
-#endif
-
   friend auto operator<<(std::ostream& out,
                          SingleServerProviderStep const& step) -> std::ostream&;
 

--- a/arangod/Graph/Steps/SingleServerProviderStep.h
+++ b/arangod/Graph/Steps/SingleServerProviderStep.h
@@ -45,7 +45,7 @@ class SingleServerProviderStep
    public:
     explicit Vertex(VertexType v) : _vertex(v) {}
 
-    VertexType const& getID() const;
+    VertexType const& getID() const noexcept;
 
     bool operator<(Vertex const& other) const noexcept {
       return _vertex < other._vertex;
@@ -66,8 +66,8 @@ class SingleServerProviderStep
 
     void addToBuilder(SingleServerProvider<SingleServerProviderStep>& provider,
                       arangodb::velocypack::Builder& builder) const;
-    EdgeType const& getID() const;
-    bool isValid() const;
+    EdgeType const& getID() const noexcept;
+    bool isValid() const noexcept;
 
    private:
     EdgeDocumentToken _token;
@@ -94,10 +94,10 @@ class SingleServerProviderStep
   bool isProcessable() const { return !isLooseEnd(); }
   bool isLooseEnd() const { return false; }
 
-  ::arangodb::graph::VertexType getVertexIdentifier() const {
-    return _vertex.getID();
-  }
+  // beware: will return a *copy* of the vertex id
+  VertexType getVertexIdentifier() const { return _vertex.getID(); }
 
+  // beware: will return a *copy* of the edge id
   EdgeType getEdgeIdentifier() const { return _edge.getID(); }
 
   std::string getCollectionName() const {
@@ -113,14 +113,16 @@ class SingleServerProviderStep
     return collectionNameResult.get().first;
   };
 
-  bool isResponsible(transaction::Methods*) const;
+#if 0
+  bool isResponsible(transaction::Methods*) const noexcept;
+#endif
 
   friend auto operator<<(std::ostream& out,
                          SingleServerProviderStep const& step) -> std::ostream&;
 
-  static bool vertexFetched() { return true; }
+  static bool vertexFetched() noexcept { return true; }
 
-  static bool edgeFetched() { return true; }
+  static bool edgeFetched() noexcept { return true; }
 
  private:
   Vertex _vertex;

--- a/arangod/RocksDBEngine/RocksDBOptimizerRules.cpp
+++ b/arangod/RocksDBEngine/RocksDBOptimizerRules.cpp
@@ -41,7 +41,7 @@
 #include "Aql/Query.h"
 #include "Aql/SortNode.h"
 #include "Basics/StaticStrings.h"
-#include "Containers/HashSet.h"
+#include "Containers/FlatHashSet.h"
 #include "Indexes/Index.h"
 #include "VocBase/LogicalCollection.h"
 
@@ -85,7 +85,7 @@ void RocksDBOptimizerRules::reduceExtractionToProjectionRule(
 
   bool modified = false;
   VarSet vars;
-  std::unordered_set<arangodb::aql::AttributeNamePath> attributes;
+  containers::FlatHashSet<arangodb::aql::AttributeNamePath> attributes;
 
   for (auto n : nodes) {
     // isDeterministic is false for EnumerateCollectionNodes when the "random"

--- a/tests/Graph/DFSFinderTest.cpp
+++ b/tests/Graph/DFSFinderTest.cpp
@@ -172,7 +172,8 @@ class DFSFinderTest
   }
 
   auto pathFinder(size_t minDepth, size_t maxDepth) -> DFSFinder {
-    arangodb::graph::OneSidedEnumeratorOptions options{minDepth, maxDepth};
+    arangodb::graph::OneSidedEnumeratorOptions options{
+        minDepth, maxDepth, /*produceVertices*/ true};
     PathValidatorOptions validatorOpts{&_tmpVar, _expressionContext};
     return DFSFinder(
         {*_query.get(),

--- a/tests/Graph/DFSFinderTest.cpp
+++ b/tests/Graph/DFSFinderTest.cpp
@@ -172,8 +172,7 @@ class DFSFinderTest
   }
 
   auto pathFinder(size_t minDepth, size_t maxDepth) -> DFSFinder {
-    arangodb::graph::OneSidedEnumeratorOptions options{
-        minDepth, maxDepth, /*produceVertices*/ true};
+    arangodb::graph::OneSidedEnumeratorOptions options{minDepth, maxDepth};
     PathValidatorOptions validatorOpts{&_tmpVar, _expressionContext};
     return DFSFinder(
         {*_query.get(),

--- a/tests/Graph/GenericGraphProviderTest.cpp
+++ b/tests/Graph/GenericGraphProviderTest.cpp
@@ -136,7 +136,7 @@ class GraphProviderTest : public ::testing::Test {
               std::move(usedIndexes),
               std::unordered_map<uint64_t, std::vector<IndexAccessor>>{}),
           *_expressionContext.get(), {}, _emptyShardMap, _vertexProjections,
-          _edgeProjections);
+          _edgeProjections, /*produceVertices*/ true);
       return SingleServerProvider<SingleServerProviderStep>(
           *query.get(), std::move(opts), resourceMonitor);
     }

--- a/tests/Graph/GenericGraphProviderTest.cpp
+++ b/tests/Graph/GenericGraphProviderTest.cpp
@@ -275,9 +275,9 @@ TYPED_TEST(GraphProviderTest, no_results_if_graph_is_empty) {
     result.emplace_back(std::move(n));
   });
 
-  EXPECT_EQ(result.size(), 0);
+  EXPECT_EQ(result.size(), 0U);
   TraversalStats stats = testee.stealStats();
-  EXPECT_EQ(stats.getFiltered(), 0);
+  EXPECT_EQ(stats.getFiltered(), 0U);
 
   if constexpr (std::is_same_v<TypeParam, SingleServerProvider<
                                               SingleServerProviderStep>> ||
@@ -288,7 +288,7 @@ TYPED_TEST(GraphProviderTest, no_results_if_graph_is_empty) {
   }
 
   // We have no edges, so nothing scanned in the Index.
-  EXPECT_EQ(stats.getScannedIndex(), 0);
+  EXPECT_EQ(stats.getScannedIndex(), 0U);
 }
 
 TYPED_TEST(GraphProviderTest, should_enumerate_a_single_edge) {
@@ -326,7 +326,7 @@ TYPED_TEST(GraphProviderTest, should_enumerate_a_single_edge) {
 
   {
     TraversalStats stats = testee.stealStats();
-    EXPECT_EQ(stats.getFiltered(), 0);
+    EXPECT_EQ(stats.getFiltered(), 0U);
     if constexpr (std::is_same_v<TypeParam, SingleServerProvider<
                                                 SingleServerProviderStep>> ||
                   std::is_same_v<TypeParam, MockGraphProvider>) {
@@ -340,19 +340,19 @@ TYPED_TEST(GraphProviderTest, should_enumerate_a_single_edge) {
                                                 SingleServerProviderStep>> ||
                   std::is_same_v<TypeParam, MockGraphProvider>) {
       // We have 1 edge, this shall be counted
-      EXPECT_EQ(stats.getScannedIndex(), 1);
+      EXPECT_EQ(stats.getScannedIndex(), 1U);
     } else if (std::is_same_v<TypeParam,
                               ClusterProvider<ClusterProviderStep>>) {
-      EXPECT_EQ(stats.getScannedIndex(), 2);  // we count edge + start vertex
+      EXPECT_EQ(stats.getScannedIndex(), 2U);  // we count edge + start vertex
     }
   }
   {
     // Make sure stats are reset after we stole them
     // So steal again works, but on empty statistics
     TraversalStats stats = testee.stealStats();
-    EXPECT_EQ(stats.getFiltered(), 0);
-    EXPECT_EQ(stats.getHttpRequests(), 0);
-    EXPECT_EQ(stats.getScannedIndex(), 0);
+    EXPECT_EQ(stats.getFiltered(), 0U);
+    EXPECT_EQ(stats.getHttpRequests(), 0U);
+    EXPECT_EQ(stats.getScannedIndex(), 0U);
   }
 }
 
@@ -402,7 +402,7 @@ TYPED_TEST(GraphProviderTest, should_enumerate_all_edges) {
 
   {
     TraversalStats stats = testee.stealStats();
-    EXPECT_EQ(stats.getFiltered(), 0);
+    EXPECT_EQ(stats.getFiltered(), 0U);
     if constexpr (std::is_same_v<TypeParam, SingleServerProvider<
                                                 SingleServerProviderStep>> ||
                   std::is_same_v<TypeParam, MockGraphProvider>) {
@@ -415,10 +415,10 @@ TYPED_TEST(GraphProviderTest, should_enumerate_all_edges) {
                                                 SingleServerProviderStep>> ||
                   std::is_same_v<TypeParam, MockGraphProvider>) {
       // We have 3 edges, this shall be counted
-      EXPECT_EQ(stats.getScannedIndex(), 3);
+      EXPECT_EQ(stats.getScannedIndex(), 3U);
     } else if (std::is_same_v<TypeParam,
                               ClusterProvider<ClusterProviderStep>>) {
-      EXPECT_EQ(stats.getScannedIndex(), 4);  // we count edge + start vertex
+      EXPECT_EQ(stats.getScannedIndex(), 4U);  // we count edge + start vertex
     }
   }
 }

--- a/tests/Graph/KShortestPathsFinder.cpp
+++ b/tests/Graph/KShortestPathsFinder.cpp
@@ -154,7 +154,7 @@ class KShortestPathsFinderTest : public ::testing::Test {
             std::move(forwardUsedIndexes),
             std::unordered_map<uint64_t, std::vector<IndexAccessor>>{}),
         *_expressionContextForward.get(), {}, _emptyShardMap,
-        _vertexProjections, _edgeProjections);
+        _vertexProjections, _edgeProjections, /*produceVertices*/ true);
 
     SingleServerBaseProviderOptions backwardOpts(
         _tmpVarBackward,
@@ -162,7 +162,7 @@ class KShortestPathsFinderTest : public ::testing::Test {
             std::move(backwardUsedIndexes),
             std::unordered_map<uint64_t, std::vector<IndexAccessor>>{}),
         *_expressionContextBackward.get(), {}, _emptyShardMap,
-        _vertexProjections, _edgeProjections);
+        _vertexProjections, _edgeProjections, /*produceVertices*/ true);
 
     finder = new KShortestPathsFinder<
         SingleServerProvider<SingleServerProviderStep>>(
@@ -374,7 +374,7 @@ class KShortestPathsFinderTestWeights : public ::testing::Test {
             std::move(forwardUsedIndexes),
             std::unordered_map<uint64_t, std::vector<IndexAccessor>>{}),
         *_expressionContextForward.get(), {}, _emptyShardMap,
-        _vertexProjections, _edgeProjections);
+        _vertexProjections, _edgeProjections, /*produceVertices*/ true);
 
     SingleServerBaseProviderOptions backwardOpts(
         _tmpVarBackward,
@@ -382,7 +382,7 @@ class KShortestPathsFinderTestWeights : public ::testing::Test {
             std::move(backwardUsedIndexes),
             std::unordered_map<uint64_t, std::vector<IndexAccessor>>{}),
         *_expressionContextBackward.get(), {}, _emptyShardMap,
-        _vertexProjections, _edgeProjections);
+        _vertexProjections, _edgeProjections, /*produceVertices*/ true);
 
     forwardOpts.setWeightEdgeCallback(
         [weightAttribute = usedWeightAttribute, usedDefaultWeight](

--- a/tests/Graph/SingleServerProviderTest.cpp
+++ b/tests/Graph/SingleServerProviderTest.cpp
@@ -117,7 +117,7 @@ class SingleServerProviderTest : public ::testing::Test {
             std::move(usedIndexes),
             std::unordered_map<uint64_t, std::vector<IndexAccessor>>{}),
         *_expressionContext.get(), {}, _emptyShardMap, _vertexProjections,
-        _edgeProjections);
+        _edgeProjections, /*produceVertices*/ true);
     return {*query.get(), std::move(opts), _resourceMonitor};
   }
 

--- a/tests/Graph/TraverserCacheTest.cpp
+++ b/tests/Graph/TraverserCacheTest.cpp
@@ -65,7 +65,8 @@ class TraverserCacheTest : public ::testing::Test {
     _monitor = &query->resourceMonitor();
     traverserCache = std::make_unique<RefactoredTraverserCache>(
         trx.get(), query.get(), query->resourceMonitor(), stats,
-        collectionToShardMap, _vertexProjections, _edgeProjections);
+        collectionToShardMap, _vertexProjections, _edgeProjections,
+        /*produceVertices*/ true);
   }
 
   ~TraverserCacheTest() = default;

--- a/tests/Replication2/ReplicatedLog/SimpleInsertTests.cpp
+++ b/tests/Replication2/ReplicatedLog/SimpleInsertTests.cpp
@@ -207,10 +207,10 @@ TEST_F(ReplicatedLogTest, write_single_entry_to_follower) {
     // Finally, the LCI is updated with another round of requests.
     auto numAppendEntries =
         countHistogramEntries(_logMetricsMock->replicatedLogAppendEntriesRttUs);
-    EXPECT_EQ(numAppendEntries, 6);
+    EXPECT_EQ(numAppendEntries, 6U);
     auto numFollowerAppendEntries = countHistogramEntries(
         _logMetricsMock->replicatedLogFollowerAppendEntriesRtUs);
-    EXPECT_EQ(numFollowerAppendEntries, 6);
+    EXPECT_EQ(numFollowerAppendEntries, 6U);
   }
 }
 
@@ -276,7 +276,7 @@ TEST_F(ReplicatedLogTest, wake_up_as_leader_with_persistent_data) {
     // AppendEntries with prevLogIndex 0 -> success = true
     // AppendEntries with new commitIndex
     // AppendEntries with new LCI
-    EXPECT_EQ(number_of_runs, 4);
+    EXPECT_EQ(number_of_runs, 4U);
   }
 
   {
@@ -519,7 +519,7 @@ TEST_F(ReplicatedLogTest,
     // AppendEntries with prevLogIndex 2 -> success = false, replicated log
     // empty AppendEntries with prevLogIndex 2 -> success = true, including
     // commit index AppendEntries with LCI
-    EXPECT_EQ(number_of_runs, 3);
+    EXPECT_EQ(number_of_runs, 3U);
   }
 
   {


### PR DESCRIPTION
### Scope & Purpose

Enterprise companion PR: https://github.com/arangodb/enterprise/pull/1140

Don't query vertex data in K_PATHS cluster implementation in case the query doesn't need them.
This is an experimental change and needs more testing! Do not yet use in production.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [x] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.10: https://github.com/arangodb/arangodb/pull/17546
  - [x] Backport for 3.9: https://github.com/arangodb/arangodb/pull/17521
  - [ ] Backport for 3.8: -

#### Related Information

- [ ] Docs PR: 
- [x] Enterprise PR: https://github.com/arangodb/enterprise/pull/1140
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 