### PR TITLE
Delay MoveShard job until old and new leader ready

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,11 @@
 devel
 -----
 
+* Delay a MoveShard operation for leader change, until the old leader has
+  actually assumed its leadership and until the new leader is actually in
+  sync. This fixes a bug which could block a shard under certain circumstances.
+  This fixes BTS-1110.
+
 * Removed assertions from cluster rebalance js test that obligated the rebalance
   plan to always have moves, but there were cases in which all there are none.
 

--- a/arangod/Agency/MoveShard.cpp
+++ b/arangod/Agency/MoveShard.cpp
@@ -391,6 +391,58 @@ bool MoveShard::start(bool&) {
     }
   }
 
+  if (_isLeader && _toServerIsFollower) {
+    // Further checks, before we can begin, we must make sure that the
+    // _fromServer has accepted its leadership already for all shards in the
+    // shard group and that the _toServer is actually in sync. Otherwise,
+    // if this job here asks the leader to resign, we would be stuck.
+    // If the _toServer is not in sync, the job would take overly long.
+    bool ok = true;
+    for (auto const& s : shardsLikeMe) {
+      auto sharedPath = _database + "/" + s.collection + "/";
+      auto currentServersPath =
+          curColPrefix + sharedPath + s.shard + "/servers";
+      auto serverList = _snapshot.hasAsArray(currentServersPath);
+      if (serverList && (*serverList).length() > 0) {
+        if (_from != (*serverList)[0].stringView()) {
+          LOG_TOPIC("55261", DEBUG, Logger::SUPERVISION)
+              << "MoveShard: From server " << _from
+              << " has not yet assumed leadership for collection "
+              << s.collection << " shard " << s.shard
+              << ", delaying start of MoveShard job for shard " << _shard;
+          ok = false;
+          break;
+        }
+        bool toFound = false;
+        for (auto server : VPackArrayIterator(*serverList)) {
+          if (_to == server.stringView()) {
+            toFound = true;
+            break;
+          }
+        }
+        if (!toFound) {
+          LOG_TOPIC("55262", DEBUG, Logger::SUPERVISION)
+              << "MoveShard: To server " << _to
+              << " is not in sync for collection " << s.collection << " shard "
+              << s.shard << ", delaying start of MoveShard job for shard "
+              << _shard;
+          ok = false;
+          break;
+        }
+      } else {
+        LOG_TOPIC("55263", INFO, Logger::SUPERVISION)
+            << "MoveShard: Did not find a non-empty server list in Current "
+               "for collection "
+            << s.collection << " and shard " << s.shard;
+        ok = false;  // not even a server list found
+      }
+    }
+    if (!ok) {
+      return false;  // Do not start job, but leave it in Todo.
+                     // Log messages already written.
+    }
+  }
+
   // Copy todo to pending
   Builder todo, pending;
 
@@ -732,7 +784,8 @@ JOB_STATUS MoveShard::pendingLeader() {
   if (plan.isArray() &&
       Job::countGoodOrBadServersInList(_snapshot, plan) < plan.length()) {
     LOG_TOPIC("de056", DEBUG, Logger::SUPERVISION)
-        << "MoveShard (leader): found FAILED server in Plan, aborting job, db: "
+        << "MoveShard (leader): found FAILED server in Plan, aborting job, "
+           "db: "
         << _database << " coll: " << _collection << " shard: " << _shard;
     abort("failed server in Plan");
     return FAILED;
@@ -839,12 +892,12 @@ JOB_STATUS MoveShard::pendingLeader() {
 
     // We need to switch leaders:
     {
-      // First make sure that the server we want to go to is still in Current
-      // for all shards. This is important, since some transaction which the
-      // leader has still executed before its resignation might have dropped a
-      // follower for some shard, and this could have been our new leader. In
-      // this case we must abort and go back to the original leader, which is
-      // still perfectly safe.
+      // First make sure that the server we want to go to is still in
+      // Current for all shards. This is important, since some transaction
+      // which the leader has still executed before its resignation might
+      // have dropped a follower for some shard, and this could have been
+      // our new leader. In this case we must abort and go back to the
+      // original leader, which is still perfectly safe.
       for (auto const& sh : shardsLikeMe) {
         auto const shardPath =
             curColPrefix + _database + "/" + sh.collection + "/" + sh.shard;
@@ -953,7 +1006,8 @@ JOB_STATUS MoveShard::pendingLeader() {
                   }
                 } else {
                   LOG_TOPIC("3294e", WARN, Logger::SUPERVISION)
-                      << "failed to iterate through current shard servers for "
+                      << "failed to iterate through current shard servers "
+                         "for "
                          "shard "
                       << _shard << " or one of its clones";
                   TRI_ASSERT(false);
@@ -1063,7 +1117,8 @@ JOB_STATUS MoveShard::pendingFollower() {
   if (plan.isArray() &&
       Job::countGoodOrBadServersInList(_snapshot, plan) < plan.length()) {
     LOG_TOPIC("f8c22", DEBUG, Logger::SUPERVISION)
-        << "MoveShard (follower): found FAILED server in Plan, aborting job, "
+        << "MoveShard (follower): found FAILED server in Plan, aborting "
+           "job, "
            "db: "
         << _database << " coll: " << _collection << " shard: " << _shard;
     abort("failed server in Plan");
@@ -1242,8 +1297,8 @@ arangodb::Result MoveShard::abort(std::string const& reason) {
                 trx.add(VPackValue(_from));
                 if (plan.isArray()) {
                   for (VPackSlice srv : VPackArrayIterator(plan)) {
-                    // from could be in plan as <from> or <_from>. Exclude to
-                    // server always.
+                    // from could be in plan as <from> or <_from>. Exclude
+                    // to server always.
                     if (srv.isEqualString(_from) ||
                         srv.isEqualString("_" + _from) ||
                         srv.isEqualString(_to)) {
@@ -1259,8 +1314,8 @@ arangodb::Result MoveShard::abort(std::string const& reason) {
                   TRI_ASSERT(false);
                   return;
                 }
-                // Add to server last. Will be removed by removeFollower if to
-                // much
+                // Add to server last. Will be removed by removeFollower if
+                // to much
                 trx.add(VPackValue(_to));
               }
             });
@@ -1312,8 +1367,8 @@ arangodb::Result MoveShard::abort(std::string const& reason) {
       VPackObjectBuilder preconditionObj(&trx);
       addMoveShardToServerCanUnLock(trx);
       addMoveShardFromServerCanUnLock(trx);
-      // If the collection is gone in the meantime, we do nothing here, but the
-      // round will move the job to Finished anyway:
+      // If the collection is gone in the meantime, we do nothing here, but
+      // the round will move the job to Finished anyway:
       addPreconditionCollectionStillThere(trx, _database, _collection);
     }
   }
@@ -1331,19 +1386,20 @@ arangodb::Result MoveShard::abort(std::string const& reason) {
       LOG_TOPIC("513e6", INFO, Logger::SUPERVISION)
           << "Precondition failed on MoveShard::abort() for shard " << _shard
           << " of collection " << _collection
-          << ", if the collection has been deleted in the meantime, the job "
+          << ", if the collection has been deleted in the meantime, the "
+             "job "
              "will be finished soon, if this message repeats, tell us.";
       result = Result(
           TRI_ERROR_SUPERVISION_GENERAL_FAILURE,
           std::string("Precondition failed while aborting moveShard job ") +
               _jobId);
       return result;
-      // We intentionally do not move the job object to Failed or Finished here!
-      // The failed precondition can either be one of the read locks, which
-      // suggests a fundamental problem, and in which case we will log this
-      // message in every round of the supervision. Or the collection has been
-      // dropped since we took the snapshot, in this case we will move the job
-      // to Finished in the next round.
+      // We intentionally do not move the job object to Failed or Finished
+      // here! The failed precondition can either be one of the read locks,
+      // which suggests a fundamental problem, and in which case we will log
+      // this message in every round of the supervision. Or the collection
+      // has been dropped since we took the snapshot, in this case we will
+      // move the job to Finished in the next round.
     }
     result = Result(
         TRI_ERROR_SUPERVISION_GENERAL_FAILURE,


### PR DESCRIPTION
This addresses https://arangodb.atlassian.net/browse/BTS-1110 .
The problem is that if a MoveShard which switches leadership begins to
work, although the supposed leader has not yet assumed its leadership,
then we get stuck. The old leader does no longer assume leadership and
as a consequence cannot resign and the MoveShard job is stuck.

- Delay start of MoveShard if supposed leader not in Current.
- Delay start of MoveShard if new leader not in sync.
- CHANGELOG.

### Scope & Purpose

*(Please describe the changes in this PR for reviewers, motivation, rationale - **mandatory**)*

- [*] :hankey: Bugfix

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [*] :book: CHANGELOG entry made
- [*] Backports
  - [ ] Backport for 3.10:
  - [ ] Backport for 3.9:
  - [ ] Backport for 3.8:

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [*] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/BTS-1110
- [*] Design document: https://github.com/arangodb/documents/pull/120

