### PR TITLE
Feature/add debug scripts install target2

### DIFF
--- a/cmake/ArangoDBInstall.cmake
+++ b/cmake/ArangoDBInstall.cmake
@@ -170,21 +170,39 @@ install(
 
 install(
   DIRECTORY
-    ${PROJECT_SOURCE_DIR}/js/client/modules/@arangodb/testsuites
     ${PROJECT_SOURCE_DIR}/js/client/modules/@arangodb/testutils
+  DESTINATION ${CMAKE_INSTALL_DATAROOTDIR_ARANGO}/${ARANGODB_JS_VERSION}/js/client/modules/@arangodb/testutils
+  COMPONENT testsuites
+  EXCLUDE_FROM_ALL
+)
+install(
+  DIRECTORY
+    ${PROJECT_SOURCE_DIR}/js/client/modules/@arangodb/testsuites
+  DESTINATION ${CMAKE_INSTALL_DATAROOTDIR_ARANGO}/${ARANGODB_JS_VERSION}/js/client/modules/@arangodb/testsuites
+  COMPONENT testsuites
+  EXCLUDE_FROM_ALL
+)
+install(
+  DIRECTORY
     ${PROJECT_SOURCE_DIR}/tests/js/
-  DESTINATION ${CMAKE_INSTALL_DATAROOTDIR_ARANGO}/${ARANGODB_JS_VERSION}
+  DESTINATION ${CMAKE_INSTALL_DATAROOTDIR_ARANGO}/${ARANGODB_JS_VERSION}/tests/js
+  COMPONENT testsuites
+  EXCLUDE_FROM_ALL
+)
+install(
+  DIRECTORY
+    ${PROJECT_SOURCE_DIR}/tests/rb/
+  DESTINATION ${CMAKE_INSTALL_DATAROOTDIR_ARANGO}/${ARANGODB_JS_VERSION}/tests/rb
   COMPONENT testsuites
   EXCLUDE_FROM_ALL
 )
 install(
   DIRECTORY
     ${PROJECT_SOURCE_DIR}/UnitTests
-  DESTINATION ${CMAKE_INSTALL_DATAROOTDIR_ARANGO}/${ARANGODB_JS_VERSION}/Unittests
+  DESTINATION ${CMAKE_INSTALL_DATAROOTDIR_ARANGO}/${ARANGODB_JS_VERSION}/UnitTests
   COMPONENT testsuites
   EXCLUDE_FROM_ALL
   )
-
 
 configure_file(
     ${PROJECT_SOURCE_DIR}/scripts/_unittests.in
@@ -199,6 +217,12 @@ install(
   EXCLUDE_FROM_ALL
 )
 
+install(
+  DIRECTORY ${PROJECT_SOURCE_DIR}/etc/relative/
+  DESTINATION ${CMAKE_INSTALL_SYSCONFDIR}/relative
+  COMPONENT testsuites
+  EXCLUDE_FROM_ALL
+)
 
 ################################################################################
 ### @brief detect if we're on a systemd enabled system; if install unit file.

--- a/cmake/ArangoDBInstall.cmake
+++ b/cmake/ArangoDBInstall.cmake
@@ -163,6 +163,43 @@ install(
     ${CMAKE_INSTALL_LOCALSTATEDIR}/lib
 )
 
+
+################################################################################
+### @brief if you want to install the integration tests:
+################################################################################
+
+install(
+  DIRECTORY
+    ${PROJECT_SOURCE_DIR}/js/client/modules/@arangodb/testsuites
+    ${PROJECT_SOURCE_DIR}/js/client/modules/@arangodb/testutils
+    ${PROJECT_SOURCE_DIR}/tests/js/
+  DESTINATION ${CMAKE_INSTALL_DATAROOTDIR_ARANGO}/${ARANGODB_JS_VERSION}
+  COMPONENT testsuites
+  EXCLUDE_FROM_ALL
+)
+install(
+  DIRECTORY
+    ${PROJECT_SOURCE_DIR}/UnitTests
+  DESTINATION ${CMAKE_INSTALL_DATAROOTDIR_ARANGO}/${ARANGODB_JS_VERSION}/Unittests
+  COMPONENT testsuites
+  EXCLUDE_FROM_ALL
+  )
+
+
+configure_file(
+    ${PROJECT_SOURCE_DIR}/scripts/_unittests.in
+    "${PROJECT_BINARY_DIR}/unittests"
+    NEWLINE_STYLE UNIX
+    @ONLY)
+
+install(
+  FILES "${PROJECT_BINARY_DIR}/unittests"
+  DESTINATION ${CMAKE_INSTALL_BINDIR}/
+  COMPONENT testsuites
+  EXCLUDE_FROM_ALL
+)
+
+
 ################################################################################
 ### @brief detect if we're on a systemd enabled system; if install unit file.
 ################################################################################

--- a/js/client/modules/@arangodb/testutils/process-utils.js
+++ b/js/client/modules/@arangodb/testutils/process-utils.js
@@ -304,10 +304,12 @@ let cleanupDirectories = [];
 let isEnterpriseClient = false;
 
 let BIN_DIR;
+let SBIN_DIR;
 let ARANGOBACKUP_BIN;
 let ARANGOBENCH_BIN;
 let ARANGODUMP_BIN;
 let ARANGOD_BIN;
+let ARANGO_SECURE_INSTALLATION_BIN;
 let ARANGOIMPORT_BIN;
 let ARANGORESTORE_BIN;
 let ARANGOEXPORT_BIN;
@@ -323,9 +325,24 @@ let UNITTESTS_DIR;
 
 const TOP_DIR = (function findTopDir () {
   const topDir = fs.normalize(fs.makeAbsolute('.'));
+  print(topDir)
+  const isSourceDir = fs.exists('3rdParty') &&
+        fs.exists('arangod') &&
+        fs.exists('client-tools') &&
+        fs.exists('tests');
+  const isInstallDir =
+        fs.exists('bin/') &&
+        fs.exists('etc/') &&
+        fs.exists('js/') &&
+        fs.exists('lib/') &&
+        fs.exists('out/') &&
+        fs.exists('sbin/') &&
+        fs.exists('share/') &&
+        fs.exists('testing/') &&
+        fs.exists('tests/') &&
+        fs.exists('var/');
 
-  if (!fs.exists('3rdParty') && !fs.exists('arangod') &&
-    !fs.exists('client-tools') && !fs.exists('tests')) {
+  if (!isSourceDir && !isInstallDir) {
     throw new Error('Must be in ArangoDB topdir to execute tests.');
   }
 
@@ -377,6 +394,10 @@ function setupBinaries (builddir, buildType, configDir) {
   if (!fs.exists(BIN_DIR)) {
     BIN_DIR = fs.join(TOP_DIR, 'bin');
   }
+  SBIN_DIR = BIN_DIR.replace('bin', 'sbin');
+  if (!fs.exists(SBIN_DIR)) {
+    SBIN_DIR = BIN_DIR;
+  }
 
   UNITTESTS_DIR = fs.join(fs.join(builddir, 'tests'));
   if (!fs.exists(UNITTESTS_DIR)) {
@@ -395,7 +416,9 @@ function setupBinaries (builddir, buildType, configDir) {
   ARANGOBACKUP_BIN = fs.join(BIN_DIR, 'arangobackup' + executableExt);
   ARANGOBENCH_BIN = fs.join(BIN_DIR, 'arangobench' + executableExt);
   ARANGODUMP_BIN = fs.join(BIN_DIR, 'arangodump' + executableExt);
-  ARANGOD_BIN = fs.join(BIN_DIR, 'arangod' + executableExt);
+  ARANGOD_BIN = fs.join(SBIN_DIR, 'arangod' + executableExt);
+  ARANGO_SECURE_INSTALLATION_BIN = fs.join(SBIN_DIR, 'arango-secure-installation' + executableExt);
+
   ARANGOIMPORT_BIN = fs.join(BIN_DIR, 'arangoimport' + executableExt);
   ARANGORESTORE_BIN = fs.join(BIN_DIR, 'arangorestore' + executableExt);
   ARANGOEXPORT_BIN = fs.join(BIN_DIR, 'arangoexport' + executableExt);
@@ -914,6 +937,7 @@ Object.defineProperty(exports, 'ARANGOD_BIN', {get: () => ARANGOD_BIN});
 Object.defineProperty(exports, 'ARANGOEXPORT_BIN', {get: () => ARANGOEXPORT_BIN});
 Object.defineProperty(exports, 'ARANGOIMPORT_BIN', {get: () => ARANGOIMPORT_BIN});
 Object.defineProperty(exports, 'ARANGORESTORE_BIN', {get: () => ARANGORESTORE_BIN});
+Object.defineProperty(exports, 'ARANGO_SECURE_INSTALLATION_BIN', {get: () => ARANGO_SECURE_INSTALLATION_BIN});
 Object.defineProperty(exports, 'ARANGOSH_BIN', {get: () => ARANGOSH_BIN});
 Object.defineProperty(exports, 'ARANGO_SECURE_INSTALLATION_BIN', {get: () => ARANGO_SECURE_INSTALLATION_BIN});
 Object.defineProperty(exports, 'CONFIG_DIR', {get: () => CONFIG_DIR});
@@ -921,6 +945,7 @@ Object.defineProperty(exports, 'TOP_DIR', {get: () => TOP_DIR});
 Object.defineProperty(exports, 'LOGS_DIR', {get: () => LOGS_DIR});
 Object.defineProperty(exports, 'UNITTESTS_DIR', {get: () => UNITTESTS_DIR});
 Object.defineProperty(exports, 'BIN_DIR', {get: () => BIN_DIR});
+Object.defineProperty(exports, 'SBIN_DIR', {get: () => SBIN_DIR});
 Object.defineProperty(exports, 'CONFIG_ARANGODB_DIR', {get: () => CONFIG_ARANGODB_DIR});
 Object.defineProperty(exports, 'CONFIG_RELATIVE_DIR', {get: () => CONFIG_RELATIVE_DIR});
 Object.defineProperty(exports, 'serverCrashed', {get: () => serverCrashedLocal, set: (value) => { serverCrashedLocal = value; } });

--- a/js/client/modules/@arangodb/testutils/process-utils.js
+++ b/js/client/modules/@arangodb/testutils/process-utils.js
@@ -325,7 +325,7 @@ let UNITTESTS_DIR;
 
 const TOP_DIR = (function findTopDir () {
   const topDir = fs.normalize(fs.makeAbsolute('.'));
-  print(topDir)
+
   const isSourceDir = fs.exists('3rdParty') &&
         fs.exists('arangod') &&
         fs.exists('client-tools') &&

--- a/scripts/_unittests.in
+++ b/scripts/_unittests.in
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+export PID=$$
+export GLIBCXX_FORCE_NEW=1
+
+SED=sed
+isMac=0
+if test "$(uname)" == "Darwin"; then
+    isMac=1
+    SED=gsed
+fi
+
+if test -n "$ORIGINAL_PATH"; then
+    # running in cygwin...
+    PS='\'
+    export EXT=".exe"
+else
+    export EXT=""
+    PS='/'
+fi;
+
+export PORT=`expr 1024 + $RANDOM`
+
+NUMA=""
+
+if $(which numactl > /dev/null 2>&1); then
+    NUMA="numactl --interleave=all"
+fi
+
+if [ `uname -s` == "Darwin" ]; then
+  EXEC_PATH="$(dirname "$(dirname "$0")")"
+else
+  EXEC_PATH="$(dirname "$(dirname "$(readlink -m "$0")")")"
+fi
+declare -a EXTRA_ARGS
+
+if [ -z "${ARANGOSH}" ];  then
+    if [ -x build/bin/arangosh -a ! -d build/bin/arangosh ];  then
+        ARANGOSH="build/bin/arangosh${EXT}"
+    elif [ -x bin/arangosh -a ! -d bin/arangosh ];  then
+        ARANGOSH="bin/arangosh${EXT}"
+    elif [ -x arangosh -a ! -d arangosh ]; then
+        ARANGOSH="arangosh${EXT}"
+    elif [ -x usr/bin/arangosh -a ! -d usr/bin/arangosh ];  then
+        ARANGOSH="usr/bin/arangosh${EXT}"
+    else
+        ARANGOSH="$(find "${EXEC_PATH}" -name "arangosh${EXT}" -perm -001 -type f | head -n 1)"
+        [ -x "${ARANGOSH}" ] || {
+          echo "$0: cannot locate arangosh"
+          exit 1
+        }
+    fi
+fi
+
+[ "$(uname -s)" != "Darwin" -a -x "${ARANGOSH}" ] && ARANGOSH="$(readlink -m "${ARANGOSH}")"
+[ "$(uname -s)" = "Darwin" -a -x "${ARANGOSH}" ] && ARANGOSH="$(cd -P -- "$(dirname -- "${ARANGOSH}")" && pwd -P)/$(basename -- "${ARANGOSH}")"
+
+[[ " $@ " =~ "--build" ]] || {
+  BUILD_PATH="$(dirname "$(dirname "${ARANGOSH}")")"
+  BUILD_PATH="${BUILD_PATH#${EXEC_PATH}/}"
+
+  if test -n "$ORIGINAL_PATH"; then
+    # running in cygwin...
+      BUILD_PATH=$(cygpath --windows "$BUILD_PATH")
+  fi
+  EXTRA_ARGS=("--build" "${BUILD_PATH}")
+}
+
+(
+  cd "${EXEC_PATH}"
+  exec $NUMA $ARANGOSH \
+       --log.level warning \
+       --server.endpoint none \
+       --javascript.allow-external-process-control true \
+       --javascript.execute @CMAKE_INSTALL_DATAROOTDIR_ARANGO@${PS}@ARANGODB_JS_VERSION@${PS}UnitTests${PS}unittest.js \
+       -- \
+       "$@" "${EXTRA_ARGS[@]}"
+)

--- a/scripts/_unittests.in
+++ b/scripts/_unittests.in
@@ -68,10 +68,13 @@ fi
 (
   cd "${EXEC_PATH}"
   exec $NUMA $ARANGOSH \
+       -c $(pwd)${PS}etc${PS}testing${PS}arangosh.conf \
        --log.level warning \
        --server.endpoint none \
+       --javascript.startup-directory $(pwd)${PS}@CMAKE_INSTALL_DATAROOTDIR_ARANGO@${PS}@ARANGODB_JS_VERSION@ \
+       --javascript.allow-port-testing true \
        --javascript.allow-external-process-control true \
-       --javascript.execute @CMAKE_INSTALL_DATAROOTDIR_ARANGO@${PS}@ARANGODB_JS_VERSION@${PS}UnitTests${PS}unittest.js \
+       --javascript.execute $(pwd)${PS}@CMAKE_INSTALL_DATAROOTDIR_ARANGO@${PS}@ARANGODB_JS_VERSION@${PS}UnitTests${PS}UnitTests${PS}unittest.js \
        -- \
        "$@" "${EXTRA_ARGS[@]}"
 )

--- a/tests/js/server/aql/aql-functions-date.js
+++ b/tests/js/server/aql/aql-functions-date.js
@@ -1,5 +1,5 @@
 /* jshint globalstrict:false, strict:false, maxlen: 500 */
-/* global assertEqual, assertNotEqual, assertNotNull */
+/* global assertEqual, assertNotEqual, assertNotNull, assertTrue */
 // //////////////////////////////////////////////////////////////////////////////
 // / @brief tests for query language, functions
 // /
@@ -2641,7 +2641,7 @@ function ahuacatlDateFunctionsTestSuite () {
         if (res.match(/UTC/)) {
           res = "UTC";
         }
-        assertEqual(systemtz, res);
+        assertTrue(systemtz.find(res) >= 0);
       } else {
         assertNotNull(res);
       }


### PR DESCRIPTION
### Scope & Purpose

This adds an additional install target, which will install all tests when specialy commanded:

```
cmake  -DCMAKE_INSTALL_PREFIX=`pwd`/blarg .; cmake --install . --component testsuites
```

- [x] :pizza: New feature (requires CHANGELOG entry, feature documentation and release notes)

brings https://github.com/arangodb/arangodb/pull/13594 to the current source stage