### PR TITLE
fix handling of parameters for `db._profileQuery(object)`

### DIFF
--- a/js/client/modules/@arangodb/arango-database.js
+++ b/js/client/modules/@arangodb/arango-database.js
@@ -28,15 +28,13 @@
 // / @author Copyright 2012-2013, triAGENS GmbH, Cologne, Germany
 // //////////////////////////////////////////////////////////////////////////////
 
-var internal = require('internal');
-var arangosh = require('@arangodb/arangosh');
+const internal = require('internal');
+const arangosh = require('@arangodb/arangosh');
+const _ = require('lodash');
 
 // //////////////////////////////////////////////////////////////////////////////
 // / @brief constructor
 // //////////////////////////////////////////////////////////////////////////////
-
-var ArangoCollection;
-var ArangoView;
 
 function ArangoDatabase (connection) {
   Object.defineProperty(this, "_dbProperties", {
@@ -50,12 +48,12 @@ function ArangoDatabase (connection) {
 exports.ArangoDatabase = ArangoDatabase;
 
 // load after exporting ArangoDatabase
-ArangoCollection = require('@arangodb/arango-collection').ArangoCollection;
+const ArangoCollection = require('@arangodb/arango-collection').ArangoCollection;
 const ArangoReplicatedLog = require('@arangodb/replicated-logs').ArangoReplicatedLog;
-ArangoView = require('@arangodb/arango-view').ArangoView;
-var ArangoError = require('@arangodb').ArangoError;
-var ArangoStatement = require('@arangodb/arango-statement').ArangoStatement;
-let ArangoTransaction = require('@arangodb/arango-transaction').ArangoTransaction;
+const ArangoView = require('@arangodb/arango-view').ArangoView;
+const ArangoError = require('@arangodb').ArangoError;
+const ArangoStatement = require('@arangodb/arango-statement').ArangoStatement;
+const ArangoTransaction = require('@arangodb/arango-transaction').ArangoTransaction;
 const ArangoPrototypeState = require("@arangodb/arango-prototype-state").ArangoPrototypeState;
 
 // //////////////////////////////////////////////////////////////////////////////
@@ -154,7 +152,7 @@ ArangoDatabase.prototype._viewurl = function (id) {
 // //////////////////////////////////////////////////////////////////////////////
 
 ArangoDatabase.prototype._documenturl = function (id, expectedName) {
-  var s = id.split('/');
+  let s = id.split('/');
 
   if (s.length !== 2) {
     throw new ArangoError({
@@ -190,7 +188,7 @@ ArangoDatabase.prototype._documenturl = function (id, expectedName) {
 
 ArangoDatabase.prototype._indexurl = function (id, expectedName) {
   if (typeof id === 'string') {
-    var pa = ArangoDatabase.indexRegex.exec(id);
+    let pa = ArangoDatabase.indexRegex.exec(id);
 
     if (pa === null && expectedName !== undefined && !id.startsWith(expectedName + '/')) {
       id = expectedName + '/' + id;
@@ -200,7 +198,7 @@ ArangoDatabase.prototype._indexurl = function (id, expectedName) {
     id = expectedName + '/' + id;
   }
 
-  var s = id.split('/');
+  let s = id.split('/');
 
   if (s.length !== 2) {
     // invalid index handle
@@ -227,7 +225,7 @@ ArangoDatabase.prototype._indexurl = function (id, expectedName) {
 // / @brief prints the help for ArangoDatabase
 // //////////////////////////////////////////////////////////////////////////////
 
-var helpArangoDatabase = arangosh.createHelpHeadline('ArangoDatabase (db) help') +
+const helpArangoDatabase = arangosh.createHelpHeadline('ArangoDatabase (db) help') +
   'Administration Functions:                                                 ' + '\n' +
   '  _help()                               this help                         ' + '\n' +
   '  _flushCache()                         flush and refill collection cache ' + '\n' +
@@ -288,9 +286,7 @@ ArangoDatabase.prototype.toString = function () {
 // //////////////////////////////////////////////////////////////////////////////
 
 ArangoDatabase.prototype._getLicense = function (options) {
-  let url = "/_admin/license";
-  var requestResult = this._connection.GET(url, {});
-
+  let requestResult = this._connection.GET("/_admin/license", {});
   arangosh.checkRequestResult(requestResult);
 
   return requestResult;
@@ -314,7 +310,7 @@ ArangoDatabase.prototype._setLicense = function (data, options) {
         "License body must be a string. It is however " + (typeof data) + "."});
   }
 
-  var requestResult = this._connection.PUT(url, JSON.stringify(data));
+  let requestResult = this._connection.PUT(url, JSON.stringify(data));
   arangosh.checkRequestResult(requestResult);
 
   return requestResult.result;
@@ -332,8 +328,7 @@ ArangoDatabase.prototype._compact = function (options) {
   if (options && options.bottomMost) {
     url += "bottomMost=true";
   }
-  var requestResult = this._connection.PUT(url, {});
-
+  let requestResult = this._connection.PUT(url, {});
   arangosh.checkRequestResult(requestResult);
 
   return requestResult.result;
@@ -344,17 +339,16 @@ ArangoDatabase.prototype._compact = function (options) {
 // //////////////////////////////////////////////////////////////////////////////
 
 ArangoDatabase.prototype._collections = function () {
-  var requestResult = this._connection.GET(this._collectionurl(), {"x-arango-frontend": "true"});
+  let requestResult = this._connection.GET(this._collectionurl(), {"x-arango-frontend": "true"});
 
   arangosh.checkRequestResult(requestResult);
 
   if (requestResult.result !== undefined) {
-    var collections = requestResult.result;
-    var result = [];
-    var i;
+    let collections = requestResult.result;
+    let result = [];
 
     // add all collections to object
-    for (i = 0;  i < collections.length;  ++i) {
+    for (let i = 0;  i < collections.length;  ++i) {
       var collection = new ArangoCollection(this, collections[i]);
       this[collection._name] = collection;
       result.push(collection);
@@ -381,7 +375,7 @@ ArangoDatabase.prototype._collection = function (id) {
       this.hasOwnProperty(id) && this[id] && this[id] instanceof ArangoCollection) {
     return this[id];
   }
-  var requestResult = this._connection.GET(this._collectionurl(id));
+  let requestResult = this._connection.GET(this._collectionurl(id));
 
   // return null in case of not found
   if (requestResult !== null
@@ -393,8 +387,7 @@ ArangoDatabase.prototype._collection = function (id) {
   // check all other errors and throw them
   arangosh.checkRequestResult(requestResult);
 
-  var name = requestResult.name;
-
+  let name = requestResult.name;
   if (name !== undefined) {
     this[name] = new ArangoCollection(this, requestResult);
     return this[name];
@@ -408,7 +401,7 @@ ArangoDatabase.prototype._collection = function (id) {
 // //////////////////////////////////////////////////////////////////////////////
 
 ArangoDatabase.prototype._replicatedLog = function (id) {
-  var requestResult = this._connection.GET(this._replicatedlogurl(id));
+  let requestResult = this._connection.GET(this._replicatedlogurl(id));
 
   // return null in case of not found
   if (requestResult !== null
@@ -428,7 +421,7 @@ ArangoDatabase.prototype._replicatedLog = function (id) {
 // //////////////////////////////////////////////////////////////////////////////
 
 ArangoDatabase.prototype._prototypeState = function (id) {
-  var requestResult = this._connection.GET(this._prototypestateurl(id));
+  let requestResult = this._connection.GET(this._prototypestateurl(id));
 
   // return null in case of not found
   if (requestResult !== null
@@ -558,15 +551,13 @@ ArangoDatabase.prototype._createEdgeCollection = function (name, properties) {
 // //////////////////////////////////////////////////////////////////////////////
 
 ArangoDatabase.prototype._truncate = function (id) {
-  var name;
-
   if (typeof id !== 'string') {
     id = id._id;
   }
 
-  for (name in this) {
+  for (let name in this) {
     if (this.hasOwnProperty(name)) {
-      var collection = this[name];
+      let collection = this[name];
 
       if (collection instanceof ArangoCollection) {
         if (collection._id === id || collection._name === id) {
@@ -584,11 +575,9 @@ ArangoDatabase.prototype._truncate = function (id) {
 // //////////////////////////////////////////////////////////////////////////////
 
 ArangoDatabase.prototype._drop = function (id, options) {
-  var name;
-
-  for (name in this) {
+  for (let name in this) {
     if (this.hasOwnProperty(name)) {
-      var collection = this[name];
+      let collection = this[name];
 
       if (collection instanceof ArangoCollection) {
         if (collection._id === id || collection._name === id) {
@@ -598,7 +587,7 @@ ArangoDatabase.prototype._drop = function (id, options) {
     }
   }
 
-  var c = this._collection(id);
+  let c = this._collection(id);
   if (c) {
     return c.drop(options);
   }
@@ -611,11 +600,9 @@ ArangoDatabase.prototype._drop = function (id, options) {
 // //////////////////////////////////////////////////////////////////////////////
 
 ArangoDatabase.prototype._flushCache = function () {
-  var name;
-
-  for (name in this) {
+  for (let name in this) {
     if (this.hasOwnProperty(name)) {
-      var collOrView = this[name];
+      let collOrView = this[name];
 
       if (collOrView instanceof ArangoCollection ||
          collOrView instanceof ArangoView) {
@@ -640,8 +627,7 @@ ArangoDatabase.prototype._flushCache = function () {
 
 ArangoDatabase.prototype._queryProperties = function (force) {
   if (force || this._dbProperties === null) {
-    var url = '/_api/database/current';
-    var requestResult = this._connection.GET(url);
+    let requestResult = this._connection.GET('/_api/database/current');
 
     arangosh.checkRequestResult(requestResult);
     this._dbProperties = requestResult.result;
@@ -691,8 +677,7 @@ ArangoDatabase.prototype._index = function (id) {
     id = id.id;
   }
 
-  var requestResult = this._connection.GET(this._indexurl(id));
-
+  let requestResult = this._connection.GET(this._indexurl(id));
   arangosh.checkRequestResult(requestResult);
 
   return requestResult;
@@ -707,8 +692,7 @@ ArangoDatabase.prototype._dropIndex = function (id) {
     id = id.id;
   }
 
-  var requestResult = this._connection.DELETE(this._indexurl(id));
-
+  let requestResult = this._connection.DELETE(this._indexurl(id));
   if (requestResult !== null
     && requestResult.error === true
     && requestResult.errorNum === internal.errors.ERROR_ARANGO_INDEX_NOT_FOUND.code) {
@@ -725,8 +709,7 @@ ArangoDatabase.prototype._dropIndex = function (id) {
 // //////////////////////////////////////////////////////////////////////////////
 
 ArangoDatabase.prototype._engine = function () {
-  var requestResult = this._connection.GET('/_api/engine');
-
+  let requestResult = this._connection.GET('/_api/engine');
   arangosh.checkRequestResult(requestResult);
 
   return requestResult;
@@ -737,8 +720,7 @@ ArangoDatabase.prototype._engine = function () {
 // //////////////////////////////////////////////////////////////////////////////
 
 ArangoDatabase.prototype._engineStats = function () {
-  var requestResult = this._connection.GET('/_api/engine/stats');
-
+  let requestResult = this._connection.GET('/_api/engine/stats');
   arangosh.checkRequestResult(requestResult);
 
   return requestResult;
@@ -749,9 +731,8 @@ ArangoDatabase.prototype._engineStats = function () {
 // //////////////////////////////////////////////////////////////////////////////
 
 ArangoDatabase.prototype._version = function (details) {
-  var requestResult = this._connection.GET('/_api/version' +
+  let requestResult = this._connection.GET('/_api/version' +
                         (details ? '?details=true' : ''));
-
   arangosh.checkRequestResult(requestResult);
 
   return details ? requestResult : requestResult.version;
@@ -762,8 +743,7 @@ ArangoDatabase.prototype._version = function (details) {
 // //////////////////////////////////////////////////////////////////////////////
 
 ArangoDatabase.prototype._document = function (id) {
-  var rev = null;
-  var requestResult;
+  let rev = null;
 
   if (typeof id === 'object') {
     if (id.hasOwnProperty('_rev')) {
@@ -774,6 +754,7 @@ ArangoDatabase.prototype._document = function (id) {
     }
   }
 
+  let requestResult;
   if (rev === null) {
     requestResult = this._connection.GET(this._documenturl(id));
   } else {
@@ -797,8 +778,7 @@ ArangoDatabase.prototype._document = function (id) {
 // //////////////////////////////////////////////////////////////////////////////
 
 ArangoDatabase.prototype._exists = function (id) {
-  var rev = null;
-  var requestResult;
+  let rev = null;
 
   if (typeof id === 'object') {
     if (id.hasOwnProperty('_rev')) {
@@ -809,6 +789,7 @@ ArangoDatabase.prototype._exists = function (id) {
     }
   }
 
+  let requestResult;
   if (rev === null) {
     requestResult = this._connection.HEAD(this._documenturl(id));
   } else {
@@ -835,8 +816,7 @@ ArangoDatabase.prototype._exists = function (id) {
 // //////////////////////////////////////////////////////////////////////////////
 
 ArangoDatabase.prototype._remove = function (id, overwrite, waitForSync) {
-  var rev = null;
-  var requestResult;
+  let rev = null;
 
   if (typeof id === 'object') {
     if (Array.isArray(id)) {
@@ -855,9 +835,9 @@ ArangoDatabase.prototype._remove = function (id, overwrite, waitForSync) {
     }
   }
 
-  var params = '';
-  var ignoreRevs = false;
-  var options;
+  let params = '';
+  let ignoreRevs = false;
+  let options;
 
   if (typeof overwrite === 'object') {
     if (typeof waitForSync !== 'undefined') {
@@ -878,11 +858,12 @@ ArangoDatabase.prototype._remove = function (id, overwrite, waitForSync) {
     options = {};
   }
 
-  var url = this._documenturl(id) + params;
+  let url = this._documenturl(id) + params;
   url = appendSyncParameter(url, waitForSync);
   url = appendBoolParameter(url, 'ignoreRevs', ignoreRevs);
   url = appendBoolParameter(url, 'returnOld', options.returnOld);
 
+  let requestResult;
   if (rev === null || ignoreRevs) {
     requestResult = this._connection.DELETE(url);
   } else {
@@ -906,8 +887,7 @@ ArangoDatabase.prototype._remove = function (id, overwrite, waitForSync) {
 // //////////////////////////////////////////////////////////////////////////////
 
 ArangoDatabase.prototype._replace = function (id, data, overwrite, waitForSync) {
-  var rev = null;
-  var requestResult;
+  let rev = null;
 
   if (typeof id === 'object') {
     if (Array.isArray(id)) {
@@ -926,9 +906,9 @@ ArangoDatabase.prototype._replace = function (id, data, overwrite, waitForSync) 
     }
   }
 
-  var params = '';
-  var ignoreRevs = false;
-  var options;
+  let params = '';
+  let ignoreRevs = false;
+  let options;
 
   if (typeof overwrite === 'object') {
     if (typeof waitForSync !== 'undefined') {
@@ -948,12 +928,13 @@ ArangoDatabase.prototype._replace = function (id, data, overwrite, waitForSync) 
     }
     options = {};
   }
-  var url = this._documenturl(id) + params;
+  let url = this._documenturl(id) + params;
   url = appendSyncParameter(url, waitForSync);
   url = appendBoolParameter(url, 'ignoreRevs', true);
   url = appendBoolParameter(url, 'returnOld', options.returnOld);
   url = appendBoolParameter(url, 'returnNew', options.returnNew);
 
+  let requestResult;
   if (rev === null || ignoreRevs) {
     requestResult = this._connection.PUT(url, data);
   } else {
@@ -977,8 +958,7 @@ ArangoDatabase.prototype._replace = function (id, data, overwrite, waitForSync) 
 // //////////////////////////////////////////////////////////////////////////////
 
 ArangoDatabase.prototype._update = function (id, data, overwrite, keepNull, waitForSync) {
-  var rev = null;
-  var requestResult;
+  let rev = null;
 
   if (typeof id === 'object') {
     if (Array.isArray(id)) {
@@ -997,9 +977,9 @@ ArangoDatabase.prototype._update = function (id, data, overwrite, keepNull, wait
     }
   }
 
-  var params = '';
-  var ignoreRevs = false;
-  var options;
+  let params = '';
+  let ignoreRevs = false;
+  let options;
   if (typeof overwrite === 'object') {
     if (typeof keepNull !== 'undefined') {
       throw 'too many arguments';
@@ -1028,12 +1008,13 @@ ArangoDatabase.prototype._update = function (id, data, overwrite, keepNull, wait
     }
     options = {};
   }
-  var url = this._documenturl(id) + params;
+  let url = this._documenturl(id) + params;
   url = appendSyncParameter(url, waitForSync);
   url = appendBoolParameter(url, 'ignoreRevs', true);
   url = appendBoolParameter(url, 'returnOld', options.returnOld);
   url = appendBoolParameter(url, 'returnNew', options.returnNew);
 
+  let requestResult;
   if (rev === null || ignoreRevs) {
     requestResult = this._connection.PATCH(url, data);
   } else {
@@ -1065,7 +1046,7 @@ ArangoDatabase.prototype._createStatement = function (data) {
 // //////////////////////////////////////////////////////////////////////////////
 
 ArangoDatabase.prototype._query = function (query, bindVars, cursorOptions, options) {
-  var payload = {
+  let payload = {
     query,
     bindVars: bindVars || undefined
   };
@@ -1091,15 +1072,35 @@ ArangoDatabase.prototype._query = function (query, bindVars, cursorOptions, opti
   return new ArangoStatement(this, payload).execute();
 };
 
+const buildQueryPayload = (query, bindVars, options) => { 
+  let payload = {};
+  
+  if (typeof query === 'object' && query.hasOwnProperty('query')) {
+    payload = query;
+  } else {
+    payload = { query, bindVars, options };
+  }
+  // query
+  if (typeof payload.query === 'object' && typeof payload.query.toAQL === 'function') {
+    payload.query = payload.query.toAQL();
+  }
+  if (payload.options) {
+    // options may be modified by the caller later
+    payload.options = _.clone(payload.options);
+  } else {
+    payload.options = {};
+  }
+  return payload;
+};
+
 // //////////////////////////////////////////////////////////////////////////////
 // / @brief queryProfile execute a query with profiling information
 // //////////////////////////////////////////////////////////////////////////////
 
 ArangoDatabase.prototype._profileQuery = function (query, bindVars, options) {
-  options = options || {};
-  options.profile = 2;
-  query = { query: query, bindVars: bindVars, options: options };
-  require('@arangodb/aql/explainer').profileQuery(query);
+  let payload = buildQueryPayload(query, bindVars, options);
+  payload.options.profile = 2;
+  require('@arangodb/aql/explainer').profileQuery(payload);
 };
 
 // //////////////////////////////////////////////////////////////////////////////
@@ -1107,15 +1108,8 @@ ArangoDatabase.prototype._profileQuery = function (query, bindVars, options) {
 // //////////////////////////////////////////////////////////////////////////////
 
 ArangoDatabase.prototype._explain = function (query, bindVars, options) {
-  if (typeof query === 'object' && typeof query.toAQL === 'function') {
-    query = { query: query.toAQL() };
-  }
-
-  if (arguments.length > 1) {
-    query = { query: query, bindVars: bindVars, options: options };
-  }
-
-  require('@arangodb/aql/explainer').explain(query);
+  let payload = buildQueryPayload(query, bindVars, options);
+  require('@arangodb/aql/explainer').explain(payload);
 };
 
 // //////////////////////////////////////////////////////////////////////////////
@@ -1183,7 +1177,7 @@ ArangoDatabase.prototype._dropDatabase = function (name) {
 // //////////////////////////////////////////////////////////////////////////////
 
 ArangoDatabase.prototype._databases = function () {
-  var requestResult = this._connection.GET('/_api/database');
+  let requestResult = this._connection.GET('/_api/database');
 
   if (requestResult !== null && requestResult.error === true) {
     throw new ArangoError(requestResult);
@@ -1208,7 +1202,7 @@ ArangoDatabase.prototype._properties = function () {
 // //////////////////////////////////////////////////////////////////////////////
 
 ArangoDatabase.prototype._useDatabase = function (name) {
-  var old = this._connection.getDatabaseName();
+  let old = this._connection.getDatabaseName();
 
   // no change
   if (name === old) {
@@ -1245,8 +1239,7 @@ ArangoDatabase.prototype._useDatabase = function (name) {
 // //////////////////////////////////////////////////////////////////////////////
 
 ArangoDatabase.prototype._endpoints = function () {
-  var requestResult = this._connection.GET('/_api/endpoint');
-
+  let requestResult = this._connection.GET('/_api/endpoint');
   if (requestResult !== null && requestResult.error === true) {
     throw new ArangoError(requestResult);
   }
@@ -1313,8 +1306,7 @@ ArangoDatabase.prototype._executeTransaction = function (data) {
     data.action = String(data.action);
   }
 
-  var requestResult = this._connection.POST('/_api/transaction', data);
-
+  let requestResult = this._connection.POST('/_api/transaction', data);
   if (requestResult !== null && requestResult.error === true) {
     throw new ArangoError(requestResult);
   }
@@ -1338,8 +1330,7 @@ ArangoDatabase.prototype._createTransaction = function (data) {
 // //////////////////////////////////////////////////////////////////////////////
 
 ArangoDatabase.prototype._transactions = function () {
-  var requestResult = this._connection.GET("/_api/transaction");
-
+  let requestResult = this._connection.GET("/_api/transaction");
   arangosh.checkRequestResult(requestResult);
   return requestResult.transactions;
 };
@@ -1382,11 +1373,9 @@ ArangoDatabase.prototype._createView = function (name, type, properties) {
 // //////////////////////////////////////////////////////////////////////////////
 
 ArangoDatabase.prototype._dropView = function (id) {
-  var name;
-
-  for (name in this) {
+  for (let name in this) {
     if (this.hasOwnProperty(name)) {
-      var view = this[name];
+      let view = this[name];
 
       if (view instanceof ArangoView) {
         if (view._id === id || view._name === id) {
@@ -1396,7 +1385,7 @@ ArangoDatabase.prototype._dropView = function (id) {
     }
   }
 
-  var v = this._view(id);
+  let v = this._view(id);
 
   if (v) {
     return v.drop();
@@ -1410,17 +1399,15 @@ ArangoDatabase.prototype._dropView = function (id) {
 // //////////////////////////////////////////////////////////////////////////////
 
 ArangoDatabase.prototype._views = function () {
-  var requestResult = this._connection.GET(this._viewurl());
-
+  let requestResult = this._connection.GET(this._viewurl());
   arangosh.checkRequestResult(requestResult);
 
-  var result = [];
+  let result = [];
   if (requestResult !== undefined) {
-    var views = requestResult.result;
-    var i;
+    let views = requestResult.result;
 
     // add all views to object
-    for (i = 0;  i < views.length;  ++i) {
+    for (let i = 0;  i < views.length;  ++i) {
       var view = new ArangoView(this, views[i]);
       this[view._name] = view;
       result.push(view);
@@ -1450,8 +1437,8 @@ ArangoDatabase.prototype._view = function (id) {
     return this[id];
   }
 
-  var url = this._viewurl(id);
-  var requestResult = this._connection.GET(url);
+  let url = this._viewurl(id);
+  let requestResult = this._connection.GET(url);
 
   // return null in case of not found
   if (requestResult !== null
@@ -1463,7 +1450,7 @@ ArangoDatabase.prototype._view = function (id) {
   // check all other errors and throw them
   arangosh.checkRequestResult(requestResult);
 
-  var name = requestResult.name;
+  let name = requestResult.name;
 
   if (name !== undefined) {
     this[name] = new ArangoView(this, requestResult);


### PR DESCRIPTION
### Scope & Purpose

Previously, `db._profileQuery(...)` only accepted positional parameters. This is in contrast to `db._query(...)` and `db._explain(...)`, which both accept positional parameters and named parameters inside an object input parameter.

With this PR, one can now do:

    db._profileQuery(queryString, bindVars, options);
as well as

    db._profileQuery({ query: queryString, bindVars: bindVars, options: options });

This PR also fixes the issue that profiling modifies the `options` input parameter, so that when it is used for multiple calls, it is not treated as const.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: -
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 