### PR TITLE
BTS-1075: unify behavior of DOCUMENT() function with empty keys

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 v3.10.2 (XXXX-XX-XX)
 --------------------
 
+* BTS-1075: AQL: RETURN DOCUMENT ("") inconsistent - single server vs cluster.
+
 * Fixed issue #17367: FILTER fails when using negation (!) on variable whose
   name starts with "in". Add trailing context to NOT IN token.
 

--- a/arangod/Aql/Functions.cpp
+++ b/arangod/Aql/Functions.cpp
@@ -894,6 +894,8 @@ void getDocumentByIdentifier(transaction::Methods* trx,
     if (ignoreError) {
       if (res.errorNumber() == TRI_ERROR_ARANGO_DOCUMENT_NOT_FOUND ||
           res.errorNumber() == TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND ||
+          res.errorNumber() == TRI_ERROR_ARANGO_DOCUMENT_KEY_BAD ||
+          res.errorNumber() == TRI_ERROR_ARANGO_DOCUMENT_HANDLE_BAD ||
           res.errorNumber() == TRI_ERROR_ARANGO_CROSS_COLLECTION_REQUEST) {
         return;
       }
@@ -6975,7 +6977,7 @@ AqlValue functions::Document(ExpressionContext* expressionContext,
       AqlValueMaterializer materializer(vopts);
       VPackSlice idSlice = materializer.slice(id, false);
       builder->openArray();
-      for (auto const& next : VPackArrayIterator(idSlice)) {
+      for (auto next : VPackArrayIterator(idSlice)) {
         if (next.isString()) {
           std::string identifier = next.copyString();
           std::string colName;

--- a/tests/js/server/aql/aql-document.js
+++ b/tests/js/server/aql/aql-document.js
@@ -1,5 +1,5 @@
 /*jshint globalstrict:false, strict:false, maxlen: 500 */
-/*global assertEqual, AQL_EXECUTE */
+/*global assertEqual, assertNull, AQL_EXECUTE */
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief tests for DOCUMENT function
@@ -41,6 +41,26 @@ function ahuacatlDocumentSuite () {
 
     tearDown : function () {
       db._drop(cn);
+    },
+    
+    testDocumentEmptyKey : function () {
+      let res = AQL_EXECUTE("RETURN DOCUMENT('')").json;
+      let doc = res[0];
+      assertNull(doc);
+      
+      res = AQL_EXECUTE("RETURN DOCUMENT('" + cn + "', '')").json;
+      doc = res[0];
+      assertNull(doc);
+    },
+    
+    testDocumentEmptyKeys : function () {
+      let res = AQL_EXECUTE("RETURN DOCUMENT(['', ''])").json;
+      let doc = res[0];
+      assertEqual([], doc);
+      
+      res = AQL_EXECUTE("RETURN DOCUMENT('" + cn + "', ['', ''])").json;
+      doc = res[0];
+      assertEqual([], doc);
     },
 
     testDocumentSingleShard : function () {


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/17566/

Fixes https://arangodb.atlassian.net/browse/BTS-1075
BTS-1075: unify behavior of DOCUMENT() function with empty keys

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [x] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.10: this PR
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [x] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/BTS-1075
- [ ] Design document: 