### PR TITLE
fix compile warnings with g++-11.3

### DIFF
--- a/arangod/Agency/Job.cpp
+++ b/arangod/Agency/Job.cpp
@@ -1168,7 +1168,7 @@ Job::readStateTarget(Node const& snap, std::string const& db,
   auto target = velocypack::deserialize<
       arangodb::replication2::replicated_state::agency::Target>(
       targetNode->get().toBuilder().slice());
-  return std::move(target);
+  return target;
 }
 
 std::optional<arangodb::replication2::replicated_state::agency::Plan>
@@ -1182,7 +1182,7 @@ Job::readStatePlan(Node const& snap, std::string const& db,
   auto plan = velocypack::deserialize<
       arangodb::replication2::replicated_state::agency::Plan>(
       planNode->get().toBuilder().slice());
-  return std::move(plan);
+  return plan;
 }
 
 std::optional<arangodb::replication2::agency::LogPlanSpecification>
@@ -1196,7 +1196,7 @@ Job::readLogPlan(Node const& snap, std::string const& db,
   auto plan = velocypack::deserialize<
       arangodb::replication2::agency::LogPlanSpecification>(
       planNode->get().toBuilder().slice());
-  return std::move(plan);
+  return plan;
 }
 
 std::string Job::findOtherHealthyParticipant(Node const& snap,


### PR DESCRIPTION
### Scope & Purpose

Fix compile warnings with g++-11.3
``` 
[ 89%] Building CXX object arangod/Agency/CMakeFiles/arango_agency.dir/Job.cpp.o
/home/jan/ArangoDevel/arangod/Agency/Job.cpp: In static member function ‘static std::optional<arangodb::replication2::replicated_state::agency::Target> arangodb::consensus::Job::readStateTarget(const arangodb::consensus::Node&, const string&, arangodb::replication2::LogId)’:
/home/jan/ArangoDevel/arangod/Agency/Job.cpp:1171:19: warning: redundant move in return statement [-Wredundant-move]
 1171 |   return std::move(target);
      |          ~~~~~~~~~^~~~~~~~
/home/jan/ArangoDevel/arangod/Agency/Job.cpp:1171:19: note: remove ‘std::move’ call
/home/jan/ArangoDevel/arangod/Agency/Job.cpp: In static member function ‘static std::optional<arangodb::replication2::replicated_state::agency::Plan> arangodb::consensus::Job::readStatePlan(const arangodb::consensus::Node&, const string&, arangodb::replication2::LogId)’:
/home/jan/ArangoDevel/arangod/Agency/Job.cpp:1185:19: warning: redundant move in return statement [-Wredundant-move]
 1185 |   return std::move(plan);
      |          ~~~~~~~~~^~~~~~
/home/jan/ArangoDevel/arangod/Agency/Job.cpp:1185:19: note: remove ‘std::move’ call
/home/jan/ArangoDevel/arangod/Agency/Job.cpp: In static member function ‘static std::optional<arangodb::replication2::agency::LogPlanSpecification> arangodb::consensus::Job::readLogPlan(const arangodb::consensus::Node&, const string&, arangodb::replication2::LogId)’:
/home/jan/ArangoDevel/arangod/Agency/Job.cpp:1199:19: warning: redundant move in return statement [-Wredundant-move]
 1199 |   return std::move(plan);
      |          ~~~~~~~~~^~~~~~
/home/jan/ArangoDevel/arangod/Agency/Job.cpp:1199:19: note: remove ‘std::move’ call
```

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: -
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

