### PR TITLE
experimental: automatically refill index cache entries

### DIFF
--- a/arangod/Aql/ExecutionPlan.cpp
+++ b/arangod/Aql/ExecutionPlan.cpp
@@ -955,6 +955,8 @@ ModificationOptions ExecutionPlan::parseModificationOptions(
           options.validate = !value->isTrue();
         } else if (name == StaticStrings::KeepNullString) {
           options.keepNull = value->isTrue();
+        } else if (name == StaticStrings::RefillIndexCachesString) {
+          options.refillIndexCaches = value->isTrue();
         } else if (name == StaticStrings::MergeObjectsString) {
           options.mergeObjects = value->isTrue();
         } else if (name == StaticStrings::Overwrite) {

--- a/arangod/Aql/ModificationExecutorHelpers.cpp
+++ b/arangod/Aql/ModificationExecutorHelpers.cpp
@@ -216,6 +216,7 @@ OperationOptions ModificationExecutorHelpers::convertOptions(
   // in.exclusive;
   out.overwriteMode = in.overwriteMode;
   out.ignoreRevs = in.ignoreRevs;
+  out.refillIndexCaches = in.refillIndexCaches;
 
   out.returnNew = (outVariableNew != nullptr);
   out.returnOld = (outVariableOld != nullptr);

--- a/arangod/Aql/ModificationOptions.cpp
+++ b/arangod/Aql/ModificationOptions.cpp
@@ -48,6 +48,8 @@ ModificationOptions::ModificationOptions(VPackSlice const& slice)
       obj, StaticStrings::IgnoreRevsString, true);
   isRestore = basics::VelocyPackHelper::getBooleanValue(
       obj, StaticStrings::IsRestoreString, false);
+  refillIndexCaches = basics::VelocyPackHelper::getBooleanValue(
+      obj, StaticStrings::RefillIndexCachesString, false);
   overwriteMode = OperationOptions::determineOverwriteMode(
       VPackStringRef(basics::VelocyPackHelper::getStringValue(
           obj, StaticStrings::OverwriteMode, "")));
@@ -71,6 +73,8 @@ void ModificationOptions::toVelocyPack(VPackBuilder& builder) const {
   builder.add(StaticStrings::KeepNullString, VPackValue(keepNull));
   builder.add(StaticStrings::MergeObjectsString, VPackValue(mergeObjects));
   builder.add(StaticStrings::IgnoreRevsString, VPackValue(ignoreRevs));
+  builder.add(StaticStrings::RefillIndexCachesString,
+              VPackValue(refillIndexCaches));
   builder.add(StaticStrings::IsRestoreString, VPackValue(isRestore));
 
   if (overwriteMode != OperationOptions::OverwriteMode::Unknown) {

--- a/arangod/Cluster/ClusterMethods.cpp
+++ b/arangod/Cluster/ClusterMethods.cpp
@@ -1574,7 +1574,9 @@ futures::Future<OperationResult> createDocumentOnCoordinator(
         .param(StaticStrings::MergeObjectsString,
                (options.mergeObjects ? "true" : "false"))
         .param(StaticStrings::SkipDocumentValidation,
-               (options.validate ? "false" : "true"));
+               (options.validate ? "false" : "true"))
+        .param(StaticStrings::RefillIndexCachesString,
+               (options.refillIndexCaches ? "true" : "false"));
     if (options.isOverwriteModeSet()) {
       reqOpts.parameters.insert_or_assign(
           StaticStrings::OverwriteMode,
@@ -2511,6 +2513,8 @@ futures::Future<OperationResult> modifyDocumentOnCoordinator(
              (options.ignoreRevs ? "true" : "false"))
       .param(StaticStrings::SkipDocumentValidation,
              (options.validate ? "false" : "true"))
+      .param(StaticStrings::RefillIndexCachesString,
+             (options.refillIndexCaches ? "true" : "false"))
       .param(StaticStrings::IsRestoreString,
              (options.isRestore ? "true" : "false"));
 

--- a/arangod/RestHandler/RestDocumentHandler.cpp
+++ b/arangod/RestHandler/RestDocumentHandler.cpp
@@ -190,6 +190,8 @@ RestStatus RestDocumentHandler::insertDocument() {
   opOptions.returnNew =
       _request->parsedValue(StaticStrings::ReturnNewString, false);
   opOptions.silent = _request->parsedValue(StaticStrings::SilentString, false);
+  opOptions.refillIndexCaches =
+      _request->parsedValue(StaticStrings::RefillIndexCachesString, false);
 
   if (_request->parsedValue(StaticStrings::Overwrite, false)) {
     // the default behavior if just "overwrite" is set
@@ -511,6 +513,8 @@ RestStatus RestDocumentHandler::modifyDocument(bool isPatch) {
   opOptions.returnOld =
       _request->parsedValue(StaticStrings::ReturnOldString, false);
   opOptions.silent = _request->parsedValue(StaticStrings::SilentString, false);
+  opOptions.refillIndexCaches =
+      _request->parsedValue(StaticStrings::RefillIndexCachesString, false);
   extractStringParameter(StaticStrings::IsSynchronousReplicationString,
                          opOptions.isSynchronousReplicationFrom);
 

--- a/arangod/RocksDBEngine/CMakeLists.txt
+++ b/arangod/RocksDBEngine/CMakeLists.txt
@@ -60,6 +60,7 @@ set(ROCKSDB_SOURCES
   RocksDBEngine/RocksDBGeoIndex.cpp
   RocksDBEngine/RocksDBIncrementalSync.cpp
   RocksDBEngine/RocksDBIndex.cpp
+  RocksDBEngine/RocksDBIndexCacheRefiller.cpp
   RocksDBEngine/RocksDBIndexFactory.cpp
   RocksDBEngine/RocksDBIterators.cpp
   RocksDBEngine/RocksDBKey.cpp

--- a/arangod/RocksDBEngine/RocksDBEdgeIndex.h
+++ b/arangod/RocksDBEngine/RocksDBEdgeIndex.h
@@ -122,12 +122,15 @@ class RocksDBEdgeIndex final : public RocksDBIndex {
 
   Result insert(transaction::Methods& trx, RocksDBMethods* methods,
                 LocalDocumentId const& documentId, velocypack::Slice doc,
-                OperationOptions const& /*options*/,
+                OperationOptions const& options,
                 bool /*performChecks*/) override;
 
   Result remove(transaction::Methods& trx, RocksDBMethods* methods,
                 LocalDocumentId const& documentId,
                 velocypack::Slice doc) override;
+
+  void refillCache(transaction::Methods& trx,
+                   std::vector<std::string> const& keys) override;
 
  private:
   /// @brief create the iterator

--- a/arangod/RocksDBEngine/RocksDBEngine.h
+++ b/arangod/RocksDBEngine/RocksDBEngine.h
@@ -53,6 +53,7 @@ namespace arangodb {
 class PhysicalCollection;
 class RocksDBBackgroundErrorListener;
 class RocksDBBackgroundThread;
+class RocksDBIndexCacheRefiller;
 class RocksDBKey;
 class RocksDBLogValue;
 class RocksDBRecoveryHelper;
@@ -242,6 +243,10 @@ class RocksDBEngine final : public StorageEngine {
   Result prepareDropDatabase(TRI_vocbase_t& vocbase) override;
   Result dropDatabase(TRI_vocbase_t& database) override;
 
+  void trackIndexCacheRefill(
+      std::shared_ptr<LogicalCollection> const& collection, IndexId iid,
+      std::vector<std::string> keys);
+
   // wal in recovery
   RecoveryState recoveryState() noexcept override;
 
@@ -359,6 +364,8 @@ class RocksDBEngine final : public StorageEngine {
 
   void trackRevisionTreeMemoryIncrease(std::uint64_t value) noexcept;
   void trackRevisionTreeMemoryDecrease(std::uint64_t value) noexcept;
+
+  bool refillIndexCaches() const noexcept;
 
 #ifdef USE_ENTERPRISE
   bool encryptionKeyRotationEnabled() const;
@@ -492,6 +499,8 @@ class RocksDBEngine final : public StorageEngine {
   /// @brief Local wal access abstraction
   std::unique_ptr<RocksDBWalAccess> _walAccess;
 
+  std::unique_ptr<RocksDBIndexCacheRefiller> _indexRefiller;
+
   /// Background thread handling garbage collection etc
   std::unique_ptr<RocksDBBackgroundThread> _backgroundThread;
   uint64_t _maxTransactionSize;       // maximum allowed size for a transaction
@@ -572,6 +581,8 @@ class RocksDBEngine final : public StorageEngine {
 
   // whether or not to issue range delete markers in the write-ahead log
   bool _useRangeDeleteInWal;
+
+  bool _refillIndexCaches;
 
   /// @brief whether or not the last health check was successful.
   /// this is used to determine when to execute the potentially expensive

--- a/arangod/RocksDBEngine/RocksDBIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBIndex.cpp
@@ -330,6 +330,9 @@ Result RocksDBIndex::update(transaction::Methods& trx, RocksDBMethods* mthd,
   return insert(trx, mthd, newDocumentId, newDoc, options, performChecks);
 }
 
+void RocksDBIndex::refillCache(transaction::Methods& trx,
+                               std::vector<std::string> const& /*keys*/) {}
+
 /// @brief return the memory usage of the index
 size_t RocksDBIndex::memory() const {
   auto& selector =

--- a/arangod/RocksDBEngine/RocksDBIndex.h
+++ b/arangod/RocksDBEngine/RocksDBIndex.h
@@ -131,6 +131,9 @@ class RocksDBIndex : public Index {
                         velocypack::Slice newDoc,
                         OperationOptions const& options, bool performChecks);
 
+  virtual void refillCache(transaction::Methods& trx,
+                           std::vector<std::string> const& keys);
+
   rocksdb::ColumnFamilyHandle* columnFamily() const { return _cf; }
 
   rocksdb::Comparator const* comparator() const;

--- a/arangod/RocksDBEngine/RocksDBIndexCacheRefiller.cpp
+++ b/arangod/RocksDBEngine/RocksDBIndexCacheRefiller.cpp
@@ -1,0 +1,150 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2021 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Jan Steemann
+////////////////////////////////////////////////////////////////////////////////
+
+#include "RocksDBIndexCacheRefiller.h"
+#include "Basics/ConditionLocker.h"
+#include "Indexes/Index.h"
+#include "Logger/LogMacros.h"
+#include "RestServer/DatabaseFeature.h"
+#include "RocksDBEngine/RocksDBIndex.h"
+#include "Transaction/StandaloneContext.h"
+#include "Utils/DatabaseGuard.h"
+#include "Utils/SingleCollectionTransaction.h"
+#include "VocBase/AccessMode.h"
+#include "VocBase/LogicalCollection.h"
+
+using namespace arangodb;
+
+RocksDBIndexCacheRefiller::RocksDBIndexCacheRefiller(
+    DatabaseFeature& databaseFeature)
+    : Thread(databaseFeature.server(), "RocksDBCacheRefiller"),
+      _databaseFeature(databaseFeature),
+      _numQueued(0) {}
+
+RocksDBIndexCacheRefiller::~RocksDBIndexCacheRefiller() { shutdown(); }
+
+void RocksDBIndexCacheRefiller::beginShutdown() {
+  Thread::beginShutdown();
+
+  // wake up the thread that may be waiting in run()
+  CONDITION_LOCKER(guard, _condition);
+  guard.broadcast();
+}
+
+void RocksDBIndexCacheRefiller::trackIndexCacheRefill(
+    std::shared_ptr<LogicalCollection> const& collection, IndexId iid,
+    std::vector<std::string> keys) {
+  TRI_ASSERT(!keys.empty());
+
+  CONDITION_LOCKER(guard, _condition);
+
+  // will be created if it doesn't exist yet
+  auto& target = _operations[collection->vocbase().id()][collection->id()][iid];
+
+  size_t minSize = target.size() + keys.size();
+  size_t newCapacity = std::max(size_t(8), target.capacity());
+  while (newCapacity < minSize) {
+    newCapacity *= 2;
+  }
+  target.reserve(newCapacity);
+  for (auto& key : keys) {
+    target.emplace_back(std::move(key));
+    ++_numQueued;
+  }
+
+  guard.signal();
+}
+
+void RocksDBIndexCacheRefiller::refill(TRI_vocbase_t& vocbase, DataSourceId cid,
+                                       IndexValues const& data) {
+  auto ctx = transaction::StandaloneContext::Create(vocbase);
+  SingleCollectionTransaction trx(ctx, std::to_string(cid.id()),
+                                  AccessMode::Type::READ);
+  Result res = trx.begin();
+
+  if (!res.ok()) {
+    return;
+  }
+
+  for (auto const& it : data) {
+    auto idx = trx.documentCollection()->lookupIndex(it.first);
+    if (idx == nullptr) {
+      continue;
+    }
+    static_cast<RocksDBIndex*>(idx.get())->refillCache(trx, it.second);
+  }
+}
+
+void RocksDBIndexCacheRefiller::refill(TRI_vocbase_t& vocbase,
+                                       CollectionValues const& data) {
+  for (auto const& it : data) {
+    try {
+      refill(vocbase, it.first, it.second);
+    } catch (...) {
+      // possible that some collections get deleted in the middle
+    }
+  }
+}
+
+void RocksDBIndexCacheRefiller::refill(DatabaseValues const& data) {
+  for (auto const& it : data) {
+    try {
+      DatabaseGuard guard(_databaseFeature, it.first);
+      refill(guard.database(), it.second);
+    } catch (...) {
+      // possible that some databases get deleted in the middle
+    }
+  }
+}
+
+void RocksDBIndexCacheRefiller::run() {
+  while (!isStopping()) {
+    try {
+      DatabaseValues operations;
+      size_t numQueued = 0;
+
+      {
+        CONDITION_LOCKER(guard, _condition);
+        operations = std::move(_operations);
+        numQueued = _numQueued;
+        _numQueued = 0;
+      }
+
+      if (!operations.empty()) {
+        refill(operations);
+
+        LOG_TOPIC("9b2f5", TRACE, Logger::ENGINES)
+            << "(re-)inserted " << numQueued << " entries into index caches";
+      }
+
+      CONDITION_LOCKER(guard, _condition);
+      guard.wait();
+    } catch (std::exception const& ex) {
+      LOG_TOPIC("443da", ERR, Logger::ENGINES)
+          << "caught exception in RocksDBIndexCacheRefiller: " << ex.what();
+    } catch (...) {
+      LOG_TOPIC("6627f", ERR, Logger::ENGINES)
+          << "caught unknown exception in RocksDBIndexCacheRefiller";
+    }
+  }
+}

--- a/arangod/RocksDBEngine/RocksDBIndexCacheRefiller.h
+++ b/arangod/RocksDBEngine/RocksDBIndexCacheRefiller.h
@@ -1,0 +1,75 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2021 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Jan Steemann
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "Basics/Common.h"
+#include "Basics/ConditionVariable.h"
+#include "Basics/Thread.h"
+#include "VocBase/Identifiers/DataSourceId.h"
+#include "VocBase/Identifiers/IndexId.h"
+#include "VocBase/voc-types.h"
+
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+struct TRI_vocbase_t;
+
+namespace arangodb {
+class DatabaseFeature;
+class LogicalCollection;
+
+class RocksDBIndexCacheRefiller final : public Thread {
+ public:
+  explicit RocksDBIndexCacheRefiller(DatabaseFeature& databaseFeature);
+
+  ~RocksDBIndexCacheRefiller();
+
+  void beginShutdown() override;
+
+  void trackIndexCacheRefill(
+      std::shared_ptr<LogicalCollection> const& collection, IndexId iid,
+      std::vector<std::string> keys);
+
+ protected:
+  void run() override;
+
+ private:
+  DatabaseFeature& _databaseFeature;
+
+  using IndexValues = std::unordered_map<IndexId, std::vector<std::string>>;
+  using CollectionValues = std::unordered_map<DataSourceId, IndexValues>;
+  using DatabaseValues = std::unordered_map<TRI_voc_tick_t, CollectionValues>;
+
+  void refill(TRI_vocbase_t& vocbase, DataSourceId cid,
+              IndexValues const& data);
+  void refill(TRI_vocbase_t& vocbase, CollectionValues const& data);
+  void refill(DatabaseValues const& data);
+
+  basics::ConditionVariable _condition;
+  DatabaseValues _operations;
+  size_t _numQueued;
+};
+}  // namespace arangodb

--- a/arangod/RocksDBEngine/RocksDBTransactionCollection.h
+++ b/arangod/RocksDBEngine/RocksDBTransactionCollection.h
@@ -120,6 +120,8 @@ class RocksDBTransactionCollection final : public TransactionCollection {
   ///        Used to update the estimate after the trx commited
   void trackIndexRemove(IndexId iid, uint64_t hash);
 
+  void trackIndexCacheRefill(IndexId iid, std::string_view key);
+
   /// @brief tracked index operations
   struct TrackedIndexOperations {
     std::vector<uint64_t> inserts;
@@ -134,6 +136,8 @@ class RocksDBTransactionCollection final : public TransactionCollection {
     _trackedIndexOperations.swap(empty);
     return empty;
   }
+
+  void handleCacheRefills();
 
  private:
   /// @brief request a lock for a collection
@@ -161,6 +165,8 @@ class RocksDBTransactionCollection final : public TransactionCollection {
   /// @brief A list where all indexes with estimates can store their operations
   ///        Will be applied to the inserter on commit and not applied on abort
   IndexOperationsMap _trackedIndexOperations;
+
+  std::unordered_map<IndexId, std::vector<std::string>> _trackedCacheRefills;
 
   bool _usageLocked;
   bool _exclusiveWrites;

--- a/arangod/RocksDBEngine/RocksDBTransactionState.h
+++ b/arangod/RocksDBEngine/RocksDBTransactionState.h
@@ -161,6 +161,9 @@ class RocksDBTransactionState final : public TransactionState {
   ///        Used to update the estimate after the trx committed
   void trackIndexRemove(DataSourceId cid, IndexId idxObjectId, uint64_t hash);
 
+  void trackCacheRefill(DataSourceId cid, IndexId idxObjectId,
+                        std::string_view key);
+
   bool isOnlyExclusiveTransaction() const;
 
   rocksdb::SequenceNumber beginSeq() const;

--- a/arangod/Utils/OperationOptions.h
+++ b/arangod/Utils/OperationOptions.h
@@ -172,6 +172,8 @@ struct OperationOptions {
   // index.
   bool canDisableIndexing = true;
 
+  bool refillIndexCaches = false;
+
   // schema used for validation during INSERT/UPDATE/REPLACE. this value is only
   // set temporarily.
   std::shared_ptr<ValidatorBase> schema = nullptr;

--- a/arangod/V8Server/v8-collection.cpp
+++ b/arangod/V8Server/v8-collection.cpp
@@ -188,6 +188,12 @@ static void getOperationOptionsFromObject(v8::Isolate* isolate,
         TRI_ObjectToBoolean(isolate, optionsObject->Get(context, SilentKey)
                                          .FromMaybe(v8::Local<v8::Value>()));
   }
+  TRI_GET_GLOBAL_STRING(RefillIndexCachesKey);
+  if (TRI_HasProperty(context, isolate, optionsObject, RefillIndexCachesKey)) {
+    options.refillIndexCaches = TRI_ObjectToBoolean(
+        isolate, optionsObject->Get(context, RefillIndexCachesKey)
+                     .FromMaybe(v8::Local<v8::Value>()));
+  }
   TRI_GET_GLOBAL_STRING(IsSynchronousReplicationKey);
   if (TRI_HasProperty(context, isolate, optionsObject,
                       IsSynchronousReplicationKey)) {
@@ -2081,6 +2087,13 @@ static void InsertVocbaseCol(v8::Isolate* isolate,
                               optionsObject->Get(context, ReturnOldKey)
                                   .FromMaybe(v8::Local<v8::Value>())) &&
           options.isOverwriteModeUpdateReplace();
+    }
+    TRI_GET_GLOBAL_STRING(RefillIndexCachesKey);
+    if (TRI_HasProperty(context, isolate, optionsObject,
+                        RefillIndexCachesKey)) {
+      options.refillIndexCaches = TRI_ObjectToBoolean(
+          isolate, optionsObject->Get(context, RefillIndexCachesKey)
+                       .FromMaybe(v8::Local<v8::Value>()));
     }
     TRI_GET_GLOBAL_STRING(IsRestoreKey);
     if (TRI_HasProperty(context, isolate, optionsObject, IsRestoreKey)) {

--- a/js/client/modules/@arangodb/arango-collection.js
+++ b/js/client/modules/@arangodb/arango-collection.js
@@ -916,7 +916,7 @@ ArangoCollection.prototype.save =
       url = appendSyncParameter(url, options.waitForSync);
     }
 
-    ["skipDocumentValidation", "returnNew", "returnOld", "silent", "overwrite", "isRestore"].forEach(function(key) {
+    ["skipDocumentValidation", "returnNew", "returnOld", "silent", "overwrite", "isRestore", "refillIndexCaches"].forEach(function(key) {
       if (options[key]) {
         url = appendBoolParameter(url, key, options[key]);
       }
@@ -1182,6 +1182,9 @@ ArangoCollection.prototype.replace = function (id, data, overwrite, waitForSync)
   if (options.returnNew) {
     url = appendBoolParameter(url, 'returnNew', options.returnNew);
   }
+  if (options.refillIndexCaches) {
+    url = appendBoolParameter(url, 'refillIndexCaches', options.refillIndexCaches);
+  }
   if (options.silent) {
     url = appendBoolParameter(url, 'silent', options.silent);
   }
@@ -1307,6 +1310,9 @@ ArangoCollection.prototype.update = function (id, data, overwrite, keepNull, wai
   }
   if (options.returnNew) {
     url = appendBoolParameter(url, 'returnNew', options.returnNew);
+  }
+  if (options.refillIndexCaches) {
+    url = appendBoolParameter(url, 'refillIndexCaches', options.refillIndexCaches);
   }
   if (options.silent) {
     url = appendBoolParameter(url, 'silent', options.silent);

--- a/js/client/modules/@arangodb/arango-database.js
+++ b/js/client/modules/@arangodb/arango-database.js
@@ -852,6 +852,7 @@ ArangoDatabase.prototype._replace = function (id, data, overwrite, waitForSync) 
   url = appendBoolParameter(url, 'ignoreRevs', true);
   url = appendBoolParameter(url, 'returnOld', options.returnOld);
   url = appendBoolParameter(url, 'returnNew', options.returnNew);
+  url = appendBoolParameter(url, 'refillIndexCaches', options.refillIndexCaches);
 
   if (rev === null || ignoreRevs) {
     requestResult = this._connection.PUT(url, data);
@@ -932,6 +933,7 @@ ArangoDatabase.prototype._update = function (id, data, overwrite, keepNull, wait
   url = appendBoolParameter(url, 'ignoreRevs', true);
   url = appendBoolParameter(url, 'returnOld', options.returnOld);
   url = appendBoolParameter(url, 'returnNew', options.returnNew);
+  url = appendBoolParameter(url, 'refillIndexCaches', options.refillIndexCaches);
 
   if (rev === null || ignoreRevs) {
     requestResult = this._connection.PATCH(url, data);

--- a/lib/Basics/StaticStrings.cpp
+++ b/lib/Basics/StaticStrings.cpp
@@ -63,6 +63,7 @@ std::string const StaticStrings::SkipDocumentValidation(
     "skipDocumentValidation");
 std::string const StaticStrings::IsSynchronousReplicationString(
     "isSynchronousReplication");
+std::string const StaticStrings::RefillIndexCachesString("refillIndexCaches");
 std::string const StaticStrings::Group("group");
 std::string const StaticStrings::Namespace("namespace");
 std::string const StaticStrings::Prefix("prefix");

--- a/lib/Basics/StaticStrings.h
+++ b/lib/Basics/StaticStrings.h
@@ -66,6 +66,7 @@ class StaticStrings {
   static std::string const WaitForSyncString;
   static std::string const SkipDocumentValidation;
   static std::string const IsSynchronousReplicationString;
+  static std::string const RefillIndexCachesString;
   static std::string const Group;
   static std::string const Namespace;
   static std::string const Prefix;

--- a/lib/V8/v8-globals.cpp
+++ b/lib/V8/v8-globals.cpp
@@ -98,9 +98,10 @@ TRI_v8_global_t::TRI_v8_global_t(
       PortKey(),
       PortTypeKey(),
       ProtocolKey(),
-      RawSuffixKey(),
-      RequestBodyKey(),
       RawRequestBodyKey(),
+      RawSuffixKey(),
+      RefillIndexCachesKey(),
+      RequestBodyKey(),
       RequestTypeKey(),
       ResponseCodeKey(),
       ReturnNewKey(),
@@ -202,6 +203,9 @@ TRI_v8_global_t::TRI_v8_global_t(
   PortTypeKey.Reset(isolate, TRI_V8_ASCII_STRING(isolate, "portType"));
   ProtocolKey.Reset(isolate, TRI_V8_ASCII_STRING(isolate, "protocol"));
   RawSuffixKey.Reset(isolate, TRI_V8_ASCII_STRING(isolate, "rawSuffix"));
+  RefillIndexCachesKey.Reset(
+      isolate, TRI_V8_ASCII_STD_STRING(
+                   isolate, arangodb::StaticStrings::RefillIndexCachesString));
   RequestBodyKey.Reset(isolate, TRI_V8_ASCII_STRING(isolate, "requestBody"));
   RawRequestBodyKey.Reset(isolate,
                           TRI_V8_ASCII_STRING(isolate, "rawRequestBody"));

--- a/lib/V8/v8-globals.h
+++ b/lib/V8/v8-globals.h
@@ -721,14 +721,16 @@ struct TRI_v8_global_t {
   /// @brief "protocol" key name
   v8::Persistent<v8::String> ProtocolKey;
 
+  /// @brief "rawRequestBody" key name
+  v8::Persistent<v8::String> RawRequestBodyKey;
+
   /// @brief "rawSuffix" key name
   v8::Persistent<v8::String> RawSuffixKey;
 
+  v8::Persistent<v8::String> RefillIndexCachesKey;
+
   /// @brief "requestBody" key name
   v8::Persistent<v8::String> RequestBodyKey;
-
-  /// @brief "rawRequestBody" key name
-  v8::Persistent<v8::String> RawRequestBodyKey;
 
   /// @brief "requestType" key name
   v8::Persistent<v8::String> RequestTypeKey;


### PR DESCRIPTION
### Scope & Purpose

Add experimental new option `refillIndexCaches` to 

* AQL INSERT/UPDATE/REPLACE modification operations
* single-document insert, update and replace operations
* multi-document insert, update and replace operations

If the option is set for an operation, a currently running transaction will keep track of which edge cache index entries were invalidated by the transaction, and will try to (re-)populate them later.
Example usages:
* `db.<collection>.insert({ _from: ..., _to: ..., ... }, { refillIndexCaches: true });`
* `db.<collection>.update(key, { _from: ..., _to: ..., ... }, { refillIndexCaches: true });`
* `db.<collection>.replace(key, { _from: ..., _to: ..., ... }, { refillIndexCaches: true });`
* `INSERT { ... } INTO <collection> OPTIONS { refillIndexCaches: true }`
* `UPDATE { ... } WITH { ... } INTO <collection> OPTIONS { refillIndexCaches: true }`
* `REPLACE { ... } WITH { ... } INTO <collection> OPTIONS { refillIndexCaches: true }`

The repopulating of the in-memory edge caches is performed by a background thread, so the modification operations shouldn't be slowed down a lot. The background thread may however cause additional I/O for looking up the data in RocksDB and repopulating the caches.
The background repopulating is done in a best-effort way and is not guaranteed to always succeed, e.g. if there is no memory available memory for the cache subsystem, or when an in-memory cache table is currently in a migration phase (grow/shrink operation).
Currently only edge indexes are supported.

For testing, there is an experimental startup option `--rocksdb.refill-index-caches` for DB servers, which currently defaults to `false`. If it is set to true, the cache repopulation will be turned on automatically for all modification operations, so that it doesn't need to be specified on the per-operation/per-query level.

Please mind the following caveats:
* the option `refillIndexCaches` is currently not forwarded to followers, because it is unclear if this is needed. Forwarding the option would be trivial to add later though.
* when (re)starting an instance, it currently doesn't automatically populate its in-memory caches for edge indexes. This still has to be done manually.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [x] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: -
  - [x] Backport for 3.9: this PR
  - [ ] Backport for 3.8: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 