### PR TITLE
Bug-fix 3.9 BTS-1125

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 v3.9.6 (XXXX-XX-XX)
 -------------------
 
+* Fixed BTS-1125 Fixes handling of primarySortCache and primaryKeyCache properties in ArangoSearch views
+
 * Do not query vertex data in K_PATHS queries if vertex data is not needed.
 
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,8 @@
 v3.9.6 (XXXX-XX-XX)
 -------------------
 
-* Fixed BTS-1125 Fixes handling of primarySortCache and primaryKeyCache properties in ArangoSearch views
+* Fixed BTS-1125 Fixes handling of primarySortCache and primaryKeyCache
+  properties in ArangoSearch views.
 
 * Do not query vertex data in K_PATHS queries if vertex data is not needed.
 

--- a/arangod/IResearch/IResearchFeature.h
+++ b/arangod/IResearch/IResearchFeature.h
@@ -115,6 +115,14 @@ class IResearchFeature final : public application_features::ApplicationFeature {
 
 #ifdef USE_ENTERPRISE
   bool trackColumnsCacheUsage(int64_t diff) noexcept;
+#ifdef ARANGODB_USE_GOOGLE_TESTS
+  auto columnsCacheUsage() const noexcept {
+    return _columnsCacheMemoryUsed.load();
+  }
+  void setCacheUsageLimit(uint64_t limit) noexcept {
+    _columnsCacheLimit = limit;
+  }
+#endif
 #endif
  private:
   void registerRecoveryHelper();

--- a/arangod/IResearch/IResearchLinkHelper.cpp
+++ b/arangod/IResearch/IResearchLinkHelper.cpp
@@ -229,7 +229,8 @@ Result modifyLinks(std::unordered_set<DataSourceId>& modified, ViewType& view,
             "error parsing link parameters from json for arangosearch view '") +
             view.name() + "'"};
   }
-
+  auto const pkCache = view.pkCache();
+  auto const sortCache = view.sortCache();
   std::vector<std::string> collectionsToLock;
   std::vector<std::pair<velocypack::Builder, IResearchLinkMeta>>
       linkDefinitions;
@@ -270,8 +271,8 @@ Result modifyLinks(std::unordered_set<DataSourceId>& modified, ViewType& view,
     auto res = IResearchLinkHelper::normalize(
         normalized, link, true, view.vocbase(), defaultVersion,
         &view.primarySort(), &view.primarySortCompression(),
-        &view.storedValues(), link.get(arangodb::StaticStrings::IndexId),
-        collectionName);
+        &view.storedValues(), &pkCache, &sortCache,
+        link.get(arangodb::StaticStrings::IndexId), collectionName);
 
     if (!res.ok()) {
       return res;
@@ -664,7 +665,8 @@ namespace iresearch {
     IResearchViewSort const* primarySort, /* = nullptr */
     irs::type_info::type_id const* primarySortCompression /*= nullptr*/,
     IResearchViewStoredValues const* storedValues, /* = nullptr */
-    velocypack::Slice idSlice,                     /* = velocypack::Slice()*/
+    bool const* pkCache /* = nullptr */, bool const* sortCache /* = nullptr */,
+    velocypack::Slice idSlice, /* = velocypack::Slice()*/
     irs::string_ref collectionName /*= irs::string_ref::NIL*/) {
   if (!normalized.isOpenObject()) {
     return {TRI_ERROR_BAD_PARAMETER,
@@ -737,6 +739,16 @@ namespace iresearch {
     // normalize stored values if specified
     meta._storedValues = *storedValues;
   }
+
+#ifdef USE_ENTERPRISE
+  if (pkCache) {
+    meta._pkCache = *pkCache;
+  }
+
+  if (sortCache) {
+    meta._sortCache = *sortCache;
+  }
+#endif
 
   // 'isCreation' is set when forPersistence
   if (!meta.json(vocbase.server(), normalized, isCreation, nullptr, &vocbase)) {

--- a/arangod/IResearch/IResearchLinkHelper.h
+++ b/arangod/IResearch/IResearchLinkHelper.h
@@ -96,6 +96,7 @@ struct IResearchLinkHelper {
       IResearchViewSort const* primarySort = nullptr,
       irs::type_info::type_id const* primarySortCompression = nullptr,
       IResearchViewStoredValues const* storedValues = nullptr,
+      bool const* pkCache = nullptr, bool const* sortCache = nullptr,
       velocypack::Slice idSlice = velocypack::Slice(),
       irs::string_ref collectionName = irs::string_ref::NIL);
 

--- a/arangod/IResearch/IResearchView.h
+++ b/arangod/IResearch/IResearchView.h
@@ -183,6 +183,21 @@ class IResearchView final : public LogicalView {
     return _meta._primarySortCompression;
   }
 
+  bool pkCache() const noexcept {
+#ifdef USE_ENTERPRISE
+    return _meta._pkCache;
+#else
+    return false;
+#endif
+  }
+
+  bool sortCache() const noexcept {
+#ifdef USE_ENTERPRISE
+    return _meta._sortCache;
+#else
+    return false;
+#endif
+  }
   ///////////////////////////////////////////////////////////////////////////////
   /// @return stored values from links collections
   ///////////////////////////////////////////////////////////////////////////////

--- a/arangod/IResearch/IResearchViewCoordinator.h
+++ b/arangod/IResearch/IResearchViewCoordinator.h
@@ -90,6 +90,22 @@ class IResearchViewCoordinator final : public LogicalView {
     return _meta._primarySortCompression;
   }
 
+  bool pkCache() const noexcept {
+#ifdef USE_ENTERPRISE
+    return _meta._pkCache;
+#else
+    return false;
+#endif
+  }
+
+  bool sortCache() const noexcept {
+#ifdef USE_ENTERPRISE
+    return _meta._sortCache;
+#else
+    return false;
+#endif
+  }
+
   ///////////////////////////////////////////////////////////////////////////////
   /// @return stored values from links collections
   ///////////////////////////////////////////////////////////////////////////////

--- a/arangod/IResearch/IResearchViewMeta.h
+++ b/arangod/IResearch/IResearchViewMeta.h
@@ -88,6 +88,11 @@ struct IResearchViewMeta {
     bool _primarySort;
     bool _storedValues;
     bool _primarySortCompression;
+#ifdef USE_ENTERPRISE
+    bool _sortCache;
+    bool _pkCache;
+#endif
+
     explicit Mask(bool mask = false) noexcept;
   };
 
@@ -109,6 +114,10 @@ struct IResearchViewMeta {
   IResearchViewSort _primarySort;
   IResearchViewStoredValues _storedValues;
   irs::type_info::type_id _primarySortCompression{};
+#ifdef USE_ENTERPRISE
+  bool _sortCache{false};
+  bool _pkCache{false};
+#endif
   // NOTE: if adding fields don't forget to modify the default constructor !!!
   // NOTE: if adding fields don't forget to modify the copy constructor !!!
   // NOTE: if adding fields don't forget to modify the move constructor !!!

--- a/tests/IResearch/IResearchViewMeta-test.cpp
+++ b/tests/IResearch/IResearchViewMeta-test.cpp
@@ -91,6 +91,10 @@ TEST_F(IResearchViewMetaTest, test_defaults) {
   EXPECT_TRUE(64 == meta._writebufferIdle);
   EXPECT_TRUE(32 * (size_t(1) << 20) == meta._writebufferSizeMax);
   EXPECT_TRUE(meta._primarySort.empty());
+#ifdef USE_ENTERPRISE
+  EXPECT_FALSE(meta._pkCache);
+  EXPECT_FALSE(meta._sortCache);
+#endif
 }
 
 TEST_F(IResearchViewMetaTest, test_inheritDefaults) {
@@ -470,6 +474,24 @@ TEST_F(IResearchViewMetaTest, test_readCustomizedValues) {
     EXPECT_EQ("storedValues[1]", errorField);
   }
 
+#ifdef USE_ENTERPRISE
+  {
+    std::string errorField;
+    auto json =
+        arangodb::velocypack::Parser::fromJson("{\"primarySortCache\":1}");
+    EXPECT_TRUE(metaState.init(json->slice(), errorField));
+    EXPECT_FALSE(meta.init(json->slice(), errorField));
+    EXPECT_EQ("primarySortCache", errorField);
+  }
+  {
+    std::string errorField;
+    auto json = arangodb::velocypack::Parser::fromJson(
+        "{\"primaryKeyCache\":{\"a\":1}}");
+    EXPECT_TRUE(metaState.init(json->slice(), errorField));
+    EXPECT_FALSE(meta.init(json->slice(), errorField));
+    EXPECT_EQ("primaryKeyCache", errorField);
+  }
+#endif
   // .............................................................................
   // test valid value
   // .............................................................................
@@ -564,6 +586,24 @@ TEST_F(IResearchViewMetaTest, test_readCustomizedValues) {
       EXPECT_TRUE(true == meta._primarySort.direction(3));
     }
   }
+#ifdef USE_ENTERPRISE
+  {
+    std::string errorField;
+    auto json =
+        arangodb::velocypack::Parser::fromJson("{\"primaryKeyCache\":true}");
+    EXPECT_TRUE(meta.init(json->slice(), errorField));
+    EXPECT_TRUE(meta._pkCache);
+    EXPECT_FALSE(meta._sortCache);
+  }
+  {
+    std::string errorField;
+    auto json =
+        arangodb::velocypack::Parser::fromJson("{\"primarySortCache\":true}");
+    EXPECT_TRUE(meta.init(json->slice(), errorField));
+    EXPECT_TRUE(meta._sortCache);
+    EXPECT_FALSE(meta._pkCache);
+  }
+#endif
 }
 
 TEST_F(IResearchViewMetaTest, test_writeDefaults) {
@@ -645,6 +685,10 @@ TEST_F(IResearchViewMetaTest, test_writeCustomizedValues) {
             std::move(*arangodb::velocypack::Parser::fromJson(
                 "{ \"type\": \"bytes_accum\", \"threshold\": 0.2 }")));
 
+#ifdef USE_ENTERPRISE
+    meta._pkCache = true;
+#endif
+
     arangodb::velocypack::Builder builder;
     arangodb::velocypack::Slice tmpSlice;
     arangodb::velocypack::Slice tmpSlice2;
@@ -669,6 +713,11 @@ TEST_F(IResearchViewMetaTest, test_writeCustomizedValues) {
     tmpSlice2 = tmpSlice.get("type");
     EXPECT_TRUE((tmpSlice2.isString() &&
                  std::string("bytes_accum") == tmpSlice2.copyString()));
+#ifdef USE_ENTERPRISE
+    tmpSlice = slice.get("primaryKeyCache");
+    EXPECT_TRUE(tmpSlice.isBool() && tmpSlice.getBool());
+    EXPECT_FALSE(slice.hasKey("primarySortCache"));
+#endif
   }
 
   arangodb::iresearch::IResearchViewMeta meta;
@@ -709,6 +758,10 @@ TEST_F(IResearchViewMetaTest, test_writeCustomizedValues) {
   meta._storedValues.fromVelocyPack(storedValuesJSON->slice(), error);
   EXPECT_TRUE(error.empty());
 
+#ifdef USE_ENTERPRISE
+  meta._sortCache = true;
+#endif
+
   std::unordered_set<arangodb::DataSourceId> expectedCollections = {
       arangodb::DataSourceId{42}, arangodb::DataSourceId{52},
       arangodb::DataSourceId{62}};
@@ -723,7 +776,11 @@ TEST_F(IResearchViewMetaTest, test_writeCustomizedValues) {
 
   auto slice = builder.slice();
 
+#ifdef USE_ENTERPRISE
+  EXPECT_EQ(13, slice.length());
+#else
   EXPECT_EQ(12, slice.length());
+#endif
   tmpSlice = slice.get("collections");
   EXPECT_TRUE((true == tmpSlice.isArray() && 3 == tmpSlice.length()));
 
@@ -797,6 +854,12 @@ TEST_F(IResearchViewMetaTest, test_writeCustomizedValues) {
       "{\"fields\":[\"a.a\", \"b.b\"], \"compression\":\"none\"}]");
   EXPECT_TRUE(arangodb::basics::VelocyPackHelper::equal(
       expectedStoredValue->slice(), tmpSlice, true));
+
+#ifdef USE_ENTERPRISE
+  tmpSlice = slice.get("primarySortCache");
+  EXPECT_TRUE(tmpSlice.isBool() && tmpSlice.getBool());
+  EXPECT_FALSE(slice.hasKey("primaryKeyCache"));
+#endif
 }
 
 TEST_F(IResearchViewMetaTest, test_readMaskAll) {
@@ -839,6 +902,10 @@ TEST_F(IResearchViewMetaTest, test_readMaskAll) {
   EXPECT_TRUE(mask._primarySort);
   EXPECT_TRUE(mask._storedValues);
   EXPECT_TRUE(mask._primarySortCompression);
+#ifdef USE_ENTERPRISE
+  EXPECT_FALSE(mask._pkCache);
+  EXPECT_FALSE(mask._sortCache);
+#endif
 }
 
 TEST_F(IResearchViewMetaTest, test_readMaskNone) {
@@ -866,6 +933,10 @@ TEST_F(IResearchViewMetaTest, test_readMaskNone) {
   EXPECT_FALSE(mask._primarySort);
   EXPECT_FALSE(mask._storedValues);
   EXPECT_FALSE(mask._primarySortCompression);
+#ifdef USE_ENTERPRISE
+  EXPECT_FALSE(mask._pkCache);
+  EXPECT_FALSE(mask._sortCache);
+#endif
 }
 
 TEST_F(IResearchViewMetaTest, test_writeMaskAll) {
@@ -896,6 +967,10 @@ TEST_F(IResearchViewMetaTest, test_writeMaskAll) {
   EXPECT_TRUE(slice.hasKey("primarySort"));
   EXPECT_TRUE(slice.hasKey("storedValues"));
   EXPECT_TRUE(slice.hasKey("primarySortCompression"));
+#ifdef USE_ENTERPRISE
+  EXPECT_FALSE(slice.hasKey("primarySortCache"));
+  EXPECT_FALSE(slice.hasKey("primaryKeyCache"));
+#endif
 }
 
 TEST_F(IResearchViewMetaTest, test_writeMaskNone) {


### PR DESCRIPTION
### Scope & Purpose
Fixes handling of primarySortCache and primaryKeyCache properties

Enterprise PR: https://github.com/arangodb/enterprise/pull/1146

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [x] Tests
  - [ ] **Regression tests**
  - [x] C++ **Unit tests**
  - [x] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: *(Please link PR)*
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*




