### PR TITLE
Build googletest like CMake exists

### DIFF
--- a/3rdParty/CMakeLists.txt
+++ b/3rdParty/CMakeLists.txt
@@ -26,27 +26,8 @@ endif ()
 ################################################################################
 
 UpdateModule(${GIT_EXECUTABLE} "gtest" ${CMAKE_CURRENT_SOURCE_DIR} "README.md")
-
-set(GOOGLETEST_ROOT 3rdParty/gtest/googletest CACHE STRING "Google Test source root")
-set(GOOGLEMOCK_ROOT 3rdParty/gtest/googlemock CACHE STRING "Google Mock source root")
-
-set(GTEST_SOURCES
-        ${PROJECT_SOURCE_DIR}/${GOOGLETEST_ROOT}/src/gtest-all.cc
-        ${PROJECT_SOURCE_DIR}/${GOOGLEMOCK_ROOT}/src/gmock-all.cc
-        )
-
-foreach(_source ${GTEST_SOURCES})
-  set_source_files_properties(${_source} PROPERTIES GENERATED 1)
-endforeach()
-
-add_library(gtest ${GTEST_SOURCES})
-target_include_directories(gtest
-        PUBLIC
-        ${PROJECT_SOURCE_DIR}/${GOOGLETEST_ROOT}/include
-        ${PROJECT_SOURCE_DIR}/${GOOGLEMOCK_ROOT}/include
-        ${PROJECT_SOURCE_DIR}/${GOOGLETEST_ROOT}
-        ${PROJECT_SOURCE_DIR}/${GOOGLEMOCK_ROOT}
-        )
+set(INSTALL_GTEST, "OFF")
+add_subdirectory(gtest)
 
 ################################################################################
 ## ZLIB

--- a/3rdParty/CMakeLists.txt
+++ b/3rdParty/CMakeLists.txt
@@ -26,7 +26,8 @@ endif ()
 ################################################################################
 
 UpdateModule(${GIT_EXECUTABLE} "gtest" ${CMAKE_CURRENT_SOURCE_DIR} "README.md")
-set(INSTALL_GTEST, "OFF")
+set(INSTALL_GTEST "OFF")
+set(BUILD_GMOCK "ON")
 add_subdirectory(gtest)
 
 ################################################################################

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -363,8 +363,6 @@ endif()
 target_include_directories(arangodbtests SYSTEM PRIVATE
   ${V8_INTERNAL_INCLUDE_DIR}
   ${CMAKE_SOURCE_DIR}/3rdParty/fakeit-gtest
-  ${CMAKE_SOURCE_DIR}/${GOOGLETEST_ROOT}/include
-  ${CMAKE_SOURCE_DIR}/${GOOGLEMOCK_ROOT}/include
 )
 
 target_link_libraries(arangodbtests v8_interface)

--- a/tests/Replication2/CMakeLists.txt
+++ b/tests/Replication2/CMakeLists.txt
@@ -89,6 +89,7 @@ target_include_directories(arango_tests_replication2 PUBLIC
 
 target_link_libraries(arango_tests_replication2
     gtest
+    gmock
     arango
     arango_replication2
     velocypack


### PR DESCRIPTION
### Scope & Purpose

Builds gtest directly using cmake without going through a custom bit of CMake code.