### PR TITLE
Fix setting query memory limit to 0 (unbounded)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 v3.9.6 (XXXX-XX-XX)
 -------------------
 
+* Fix setting query memory limit to 0 for certain queries if a global memory
+  limit is set, but overriding the memory limit is allowed.
+
 * Do not query vertex data in K_PATHS queries if vertex data is not needed.
 
 

--- a/arangod/Aql/QueryOptions.cpp
+++ b/arangod/Aql/QueryOptions.cpp
@@ -118,12 +118,15 @@ void QueryOptions::fromVelocyPack(VPackSlice slice) {
   value = slice.get("memoryLimit");
   if (value.isNumber()) {
     size_t v = value.getNumber<size_t>();
-    if (v > 0 && (allowMemoryLimitOverride || v < memoryLimit)) {
+    if (allowMemoryLimitOverride) {
+      memoryLimit = v;
+    } else if (v > 0 && v < memoryLimit) {
       // only allow increasing the memory limit if the respective startup option
-      // is set. and if it is set, only allow decreasing the memory limit
+      // is set. and if it is not set, only allow decreasing the memory limit
       memoryLimit = v;
     }
   }
+
   value = slice.get("maxNumberOfPlans");
   if (value.isNumber()) {
     maxNumberOfPlans = value.getNumber<size_t>();

--- a/tests/js/client/server_parameters/test-memory-limit.js
+++ b/tests/js/client/server_parameters/test-memory-limit.js
@@ -29,7 +29,7 @@
 if (getOptions === true) {
   return {
     'query.global-memory-limit': "0",
-    'query.memory-limit': "5000000"
+    'query.memory-limit': "5000000",
   };
 }
 const jsunity = require('jsunity');
@@ -67,6 +67,14 @@ function testSuite() {
       
       const currentValue = getMetric("arangodb_aql_local_query_memory_limit_reached_total");
       assertTrue(currentValue > previousValue);
+    },
+    
+    testQueryAboveLimitButAllowed: function() {
+      let crsr = db._query("LET testi = (FOR i IN 1..10000 FOR j IN 1..100 RETURN CONCAT('testmann-der-fuxxx', i, j)) RETURN testi", {}, {memoryLimit: 0});
+      let result = crsr.toArray();
+      assertEqual(1, result.length);
+      assertEqual(10000 * 100, result[0].length);
+      assertTrue(crsr.getExtra().stats.peakMemoryUsage > 5000000);
     },
     
   };


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/17613

* Fix setting query memory limit to 0 for certain queries if a global memory limit is set, but overriding the memory limit is allowed.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [x] Backports
  - [x] Backport for 3.10: https://github.com/arangodb/arangodb/pull/17614
  - [x] Backport for 3.9: this PR
  - [ ] Backport for 3.8: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 