### PR TITLE
fixed issue #17291

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,13 @@ devel
 -----
 
 * Fixed issue #17291: Server crash on error in the PRUNE expression.
+  Traversal PRUNE expressions containing JavaScript user-defined functions
+  (UDFs) are now properly rejected in single server and cluster mode.
+  PRUNE expressions that use UDFs require a V8 context for execution,
+  which is not available on DB-servers in a cluster, and also isn't
+  necessarily available for regular queries on single servers (a V8 context
+  is only available if a query was executed inside Foxx or from inside a JS
+  transaction, but not otherwise).
 
 * Fix setting query memory limit to 0 for certain queries if a global memory
   limit is set, but overriding the memory limit is allowed.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 devel
 -----
 
+* Fixed issue #17291: Server crash on error in the PRUNE expression.
+
 * Updated arangosync to v2.13.0-preview-5.
 
 * Added option to exclude system collection from rebalance shards plan.

--- a/arangod/Aql/Expression.cpp
+++ b/arangod/Aql/Expression.cpp
@@ -42,6 +42,7 @@
 #include "Basics/NumberUtils.h"
 #include "Basics/VelocyPackHelper.h"
 #include "Containers/FlatHashSet.h"
+#include "Cluster/ServerState.h"
 #include "Transaction/Context.h"
 #include "Transaction/Helpers.h"
 #include "Transaction/Methods.h"
@@ -943,6 +944,15 @@ AqlValue Expression::invokeV8Function(
 AqlValue Expression::executeSimpleExpressionFCallJS(ExpressionContext& ctx,
                                                     AstNode const* node,
                                                     bool& mustDestroy) {
+  if (ServerState::instance()->isDBServer()) {
+    // we actually should not get here, but in case we do due to some changes,
+    // it is better to abort the query with a proper error rather than crashing
+    // with assertion failure or segfault.
+    THROW_ARANGO_EXCEPTION_MESSAGE(
+        TRI_ERROR_NOT_IMPLEMENTED,
+        "user-defined functions cannot be executed on DB-Servers");
+  }
+
   auto member = node->getMemberUnchecked(0);
   TRI_ASSERT(member->type == NODE_TYPE_ARRAY);
 
@@ -1876,10 +1886,21 @@ bool Expression::willUseV8() {
   return (_type == SIMPLE && _node->willUseV8());
 }
 
-bool Expression::canBeUsedInPrune(bool isOneShard) {
-  if (willUseV8() || !canRunOnDBServer(isOneShard)) {
+bool Expression::canBeUsedInPrune(bool isOneShard, std::string& errorReason) {
+  errorReason.clear();
+
+  if (willUseV8()) {
+    errorReason = "JavaScript expressions cannot be used inside PRUNE";
     return false;
   }
+  if (!canRunOnDBServer(isOneShard)) {
+    errorReason =
+        "PRUNE expression contains a function that cannot be used on "
+        "DB-Servers";
+    return false;
+  }
+
+  TRI_ASSERT(errorReason.empty());
   return true;
 }
 

--- a/arangod/Aql/Expression.h
+++ b/arangod/Aql/Expression.h
@@ -97,7 +97,7 @@ class Expression {
   bool willUseV8();
 
   /// @brief whether or not the expression can be used inside a PRUNE statement
-  bool canBeUsedInPrune(bool isOneShard);
+  bool canBeUsedInPrune(bool isOneShard, std::string& errorReason);
 
   /// @brief clone the expression, needed to clone execution plans
   std::unique_ptr<Expression> clone(Ast* ast, bool deepCopy = false);

--- a/tests/js/common/aql/aql-prune-expressions.js
+++ b/tests/js/common/aql/aql-prune-expressions.js
@@ -30,7 +30,6 @@ const jsunity = require("jsunity");
 const db = require("@arangodb").db;
 const internal = require("internal");
 const errors = internal.errors;
-const isCoordinator = require('@arangodb/cluster').isCoordinator();
   
 function PruneExpressionsSuite() {
   const vn = "UnitTestsVertex";

--- a/tests/js/server/aql/aql-prune-expressions.js
+++ b/tests/js/server/aql/aql-prune-expressions.js
@@ -1,0 +1,109 @@
+/*jshint globalstrict:false, strict:false, maxlen: 500 */
+/*global AQL_EXPLAIN, assertEqual, fail */
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief tests for traversal optimization
+///
+/// DISCLAIMER
+///
+/// Copyright 2010-2014 triagens GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is triAGENS GmbH, Cologne, Germany
+///
+/// @author Jan Steemann
+/// @author Copyright 2020, triAGENS GmbH, Cologne, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+const jsunity = require("jsunity");
+const db = require("@arangodb").db;
+const internal = require("internal");
+const errors = internal.errors;
+const isCoordinator = require('@arangodb/cluster').isCoordinator();
+  
+function PruneExpressionsSuite() {
+  const vn = "UnitTestsVertex";
+  const en = "UnitTestsEdge";
+  const udf = "test::fuchs";
+
+  let cleanup = function () {
+    db._drop(en);
+    db._drop(vn);
+
+    try {
+      require("@arangodb/aql/functions").unregister(udf);
+    } catch (err) {}
+  };
+
+  return {
+    setUpAll : function () {
+      cleanup();
+    
+      require("@arangodb/aql/functions").register(udf, function() { return '0'; });
+      
+      db._create(vn, { numberOfShards: 1 });
+      db._createEdgeCollection(en, { distributeShardsLike: vn, numberOfShards: 1 });
+
+      db[vn].insert({ _key: "test1", value: 1 });
+      db[vn].insert({ _key: "test2", value: 2 });
+      db[vn].insert({ _key: "test3", value: 3 });
+
+      db[en].insert({ _from: vn + "/test1", _to: vn + "/test2", value: 1 });
+      db[en].insert({ _from: vn + "/test2", _to: vn + "/test3", value: 0 });
+    },
+    
+    tearDownAll : function () {
+      cleanup();
+    },
+
+    testAllowedExpression: function () {
+      let q = `WITH ${vn} FOR v, e, p IN 1..3 OUTBOUND '${vn}/test1' ${en} PRUNE e.value == '0' RETURN v`;
+      let res = db._query(q).toArray();
+      assertEqual(2, res.length);
+    },
+
+    testV8Expression: function () {
+      let q = `WITH ${vn} FOR v, e, p IN 1..3 OUTBOUND '${vn}/test1' ${en} PRUNE e.value == V8('0') RETURN v`;
+      try {
+        db._query(q);
+        fail();
+      } catch (err) {
+        assertEqual(err.errorNum, errors.ERROR_QUERY_PARSE.code);
+      }
+    },
+    
+    testUDFExpression: function () {
+      let q = `WITH ${vn} FOR v, e, p IN 1..3 OUTBOUND '${vn}/test1' ${en} PRUNE e.value == ${udf}() RETURN v`;
+      try {
+        db._query(q);
+        fail();
+      } catch (err) {
+        assertEqual(err.errorNum, errors.ERROR_QUERY_PARSE.code);
+      }
+    },
+    
+    testSubqueryExpression: function () {
+      let q = `WITH ${vn} FOR v, e, p IN 1..3 OUTBOUND '${vn}/test1' ${en} PRUNE e.value == (FOR i IN 1..1 RETURN '0') RETURN v`;
+      try {
+        db._query(q);
+        fail();
+      } catch (err) {
+        assertEqual(err.errorNum, errors.ERROR_QUERY_PARSE.code);
+      }
+    },
+  };
+}
+
+jsunity.run(PruneExpressionsSuite);
+return jsunity.done();


### PR DESCRIPTION
### Scope & Purpose

Fix issue #17291 

Traversal PRUNE expressions containing JavaScript user-defined functions (UDFs) are now properly rejected in single server and cluster mode. PRUNE expressions that use UDFs require a V8 context for execution, which is not available on DB-servers in a cluster, and also isn't necessarily available for regular queries on single servers (a V8 context is only available if such query was executed inside Foxx or from inside a JS transaction, but not otherwise).

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [x] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [x] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.10: https://github.com/arangodb/arangodb/pull/17618
  - [x] Backport for 3.9: https://github.com/arangodb/arangodb/pull/17617
  - [x] Backport for 3.8: https://github.com/arangodb/arangodb/pull/17623

#### Related Information

- [x] Docs PR: https://github.com/arangodb/docs/pull/1193
- [ ] Enterprise PR:
- [x] GitHub issue / Jira ticket: #17291 
- [ ] Design document: 