### PR TITLE
centralize options checks in new ApplicationFeature

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 devel
 -----
 
+* Log startup warnings for any experimental, deprecated, obsolete or renamed
+  options at startup of arangod or any of the client tools.
+
 * Fix setting query memory limit to 0 for certain queries if a global memory
   limit is set, but overriding the memory limit is allowed.
 

--- a/arangod/RestServer/EnvironmentFeature.cpp
+++ b/arangod/RestServer/EnvironmentFeature.cpp
@@ -74,6 +74,8 @@ std::string_view trimProcName(std::string_view content) {
 using namespace arangodb::basics;
 
 namespace arangodb {
+class OptionsCheckFeature;
+class SharedPRNGFeature;
 
 EnvironmentFeature::EnvironmentFeature(Server& server)
     : ArangodFeature{server, *this} {
@@ -82,6 +84,7 @@ EnvironmentFeature::EnvironmentFeature(Server& server)
 
   startsAfter<LogBufferFeature>();
   startsAfter<MaxMapCountFeature>();
+  startsAfter<OptionsCheckFeature>();
   startsAfter<SharedPRNGFeature>();
 }
 

--- a/arangod/RestServer/arangod.h
+++ b/arangod/RestServer/arangod.h
@@ -92,6 +92,7 @@ class MaintenanceFeature;
 class MaxMapCountFeature;
 class NetworkFeature;
 class NonceFeature;
+class OptionsCheckFeature;
 class PrivilegeFeature;
 class QueryRegistryFeature;
 class RandomFeature;
@@ -233,6 +234,7 @@ using ArangodFeatures = TypeList<
     MaxMapCountFeature,
     NetworkFeature,
     NonceFeature,
+    OptionsCheckFeature,
     PrivilegeFeature,
     QueryRegistryFeature,
     RandomFeature,

--- a/arangod/RestServer/arangod_includes.h
+++ b/arangod/RestServer/arangod_includes.h
@@ -37,6 +37,7 @@
 #include "ApplicationFeatures/GreetingsFeature.h"
 #include "ApplicationFeatures/GreetingsFeaturePhase.h"
 #include "ApplicationFeatures/LanguageFeature.h"
+#include "ApplicationFeatures/OptionsCheckFeature.h"
 #include "ApplicationFeatures/ShellColorsFeature.h"
 #include "ApplicationFeatures/ShutdownFeature.h"
 #include "ApplicationFeatures/TempFeature.h"

--- a/client-tools/Backup/arangobackup.cpp
+++ b/client-tools/Backup/arangobackup.cpp
@@ -32,6 +32,7 @@
 #include "ApplicationFeatures/ConfigFeature.h"
 #include "ApplicationFeatures/FileSystemFeature.h"
 #include "ApplicationFeatures/GreetingsFeaturePhase.h"
+#include "ApplicationFeatures/OptionsCheckFeature.h"
 #include "ApplicationFeatures/ShellColorsFeature.h"
 #include "ApplicationFeatures/ShutdownFeature.h"
 #include "ApplicationFeatures/VersionFeature.h"

--- a/client-tools/Benchmark/arangobench.cpp
+++ b/client-tools/Benchmark/arangobench.cpp
@@ -36,6 +36,7 @@
 #include "ApplicationFeatures/ConfigFeature.h"
 #include "ApplicationFeatures/FileSystemFeature.h"
 #include "ApplicationFeatures/GreetingsFeaturePhase.h"
+#include "ApplicationFeatures/OptionsCheckFeature.h"
 #include "ApplicationFeatures/ShellColorsFeature.h"
 #include "ApplicationFeatures/ShutdownFeature.h"
 #include "ApplicationFeatures/TempFeature.h"

--- a/client-tools/Dump/arangodump.cpp
+++ b/client-tools/Dump/arangodump.cpp
@@ -32,6 +32,7 @@
 #include "ApplicationFeatures/ConfigFeature.h"
 #include "ApplicationFeatures/FileSystemFeature.h"
 #include "ApplicationFeatures/GreetingsFeaturePhase.h"
+#include "ApplicationFeatures/OptionsCheckFeature.h"
 #include "ApplicationFeatures/ShellColorsFeature.h"
 #include "ApplicationFeatures/ShutdownFeature.h"
 #include "ApplicationFeatures/VersionFeature.h"

--- a/client-tools/Export/arangoexport.cpp
+++ b/client-tools/Export/arangoexport.cpp
@@ -32,6 +32,7 @@
 #include "ApplicationFeatures/ConfigFeature.h"
 #include "ApplicationFeatures/FileSystemFeature.h"
 #include "ApplicationFeatures/GreetingsFeaturePhase.h"
+#include "ApplicationFeatures/OptionsCheckFeature.h"
 #include "ApplicationFeatures/ShellColorsFeature.h"
 #include "ApplicationFeatures/ShutdownFeature.h"
 #include "ApplicationFeatures/TempFeature.h"

--- a/client-tools/Import/arangoimport.cpp
+++ b/client-tools/Import/arangoimport.cpp
@@ -32,6 +32,7 @@
 #include "ApplicationFeatures/ConfigFeature.h"
 #include "ApplicationFeatures/FileSystemFeature.h"
 #include "ApplicationFeatures/GreetingsFeaturePhase.h"
+#include "ApplicationFeatures/OptionsCheckFeature.h"
 #include "ApplicationFeatures/ShellColorsFeature.h"
 #include "ApplicationFeatures/ShutdownFeature.h"
 #include "ApplicationFeatures/TempFeature.h"

--- a/client-tools/Restore/arangorestore.cpp
+++ b/client-tools/Restore/arangorestore.cpp
@@ -32,6 +32,7 @@
 #include "ApplicationFeatures/ConfigFeature.h"
 #include "ApplicationFeatures/FileSystemFeature.h"
 #include "ApplicationFeatures/GreetingsFeaturePhase.h"
+#include "ApplicationFeatures/OptionsCheckFeature.h"
 #include "ApplicationFeatures/ShellColorsFeature.h"
 #include "ApplicationFeatures/ShutdownFeature.h"
 #include "ApplicationFeatures/TempFeature.h"

--- a/client-tools/Shell/arangosh.cpp
+++ b/client-tools/Shell/arangosh.cpp
@@ -33,6 +33,7 @@
 #include "ApplicationFeatures/FileSystemFeature.h"
 #include "ApplicationFeatures/GreetingsFeaturePhase.h"
 #include "ApplicationFeatures/LanguageFeature.h"
+#include "ApplicationFeatures/OptionsCheckFeature.h"
 #include "ApplicationFeatures/ShellColorsFeature.h"
 #include "ApplicationFeatures/ShutdownFeature.h"
 #include "ApplicationFeatures/TempFeature.h"

--- a/client-tools/Utils/ArangoClient.h
+++ b/client-tools/Utils/ArangoClient.h
@@ -38,8 +38,8 @@ class GreetingsFeaturePhase;
 class ClientFeature;
 class ConfigFeature;
 class FileSystemFeature;
-class ShellConsoleFeature;
 class LoggerFeature;
+class OptionsCheckFeature;
 class RandomFeature;
 class ShellColorsFeature;
 class ShutdownFeature;
@@ -57,6 +57,7 @@ using ArangoClientFeatures = TypeList<
     // Features
     VersionFeature,  // VersionFeature must go first
     HttpEndpointProvider, ConfigFeature, FileSystemFeature, LoggerFeature,
-    RandomFeature, ShellColorsFeature, ShutdownFeature, SslFeature, T...>;
+    OptionsCheckFeature, RandomFeature, ShellColorsFeature, ShutdownFeature,
+    SslFeature, T...>;
 
 }  // namespace arangodb

--- a/client-tools/VPack/arangovpack.cpp
+++ b/client-tools/VPack/arangovpack.cpp
@@ -31,6 +31,7 @@
 #include "ApplicationFeatures/ConfigFeature.h"
 #include "ApplicationFeatures/FileSystemFeature.h"
 #include "ApplicationFeatures/GreetingsFeaturePhase.h"
+#include "ApplicationFeatures/OptionsCheckFeature.h"
 #include "ApplicationFeatures/ShellColorsFeature.h"
 #include "ApplicationFeatures/ShutdownFeature.h"
 #include "ApplicationFeatures/VersionFeature.h"

--- a/client-tools/VPack/arangovpack.h
+++ b/client-tools/VPack/arangovpack.h
@@ -34,8 +34,9 @@ using namespace application_features;
 
 using ArangoVPackFeatures =
     TypeList<BasicFeaturePhaseClient, GreetingsFeaturePhase, VersionFeature,
-             ConfigFeature, LoggerFeature, FileSystemFeature, RandomFeature,
-             ShellColorsFeature, ShutdownFeature, VPackFeature>;
+             ConfigFeature, LoggerFeature, OptionsCheckFeature,
+             FileSystemFeature, RandomFeature, ShellColorsFeature,
+             ShutdownFeature, VPackFeature>;
 
 using ArangoVPackServer = ApplicationServerT<ArangoVPackFeatures>;
 using ArangoVPackFeature = ApplicationFeatureT<ArangoVPackServer>;

--- a/lib/ApplicationFeatures/ApplicationServer.cpp
+++ b/lib/ApplicationFeatures/ApplicationServer.cpp
@@ -437,31 +437,6 @@ void ApplicationServer::validateOptions() {
       feature.state(ApplicationFeature::State::VALIDATED);
     }
   }
-
-  auto const& modernizedOptions = _options->modernizedOptions();
-  if (!modernizedOptions.empty()) {
-    for (auto const& it : modernizedOptions) {
-      LOG_TOPIC("3e342", WARN, Logger::STARTUP)
-          << "please note that the specified option '--" << it.first
-          << " has been renamed to '--" << it.second
-          << "' in this ArangoDB version";
-    }
-
-    LOG_TOPIC("27c9c", INFO, Logger::STARTUP)
-        << "please be sure to read the manual section about changed options";
-  }
-
-  // inform about obsolete options
-  _options->walk(
-      [](Section const&, Option const& option) {
-        if (option.hasFlag(arangodb::options::Flags::Obsolete)) {
-          LOG_TOPIC("6843e", WARN, Logger::STARTUP)
-              << "obsolete option '" << option.displayName()
-              << "' used in configuration. "
-              << "setting this option will not have any effect.";
-        }
-      },
-      true, true);
 }
 
 // setup and validate all feature dependencies, determine feature order

--- a/lib/ApplicationFeatures/OptionsCheckFeature.cpp
+++ b/lib/ApplicationFeatures/OptionsCheckFeature.cpp
@@ -39,8 +39,7 @@ void OptionsCheckFeature::prepare() {
     for (auto const& it : modernizedOptions) {
       LOG_TOPIC("3e342", WARN, Logger::STARTUP)
           << "please note that the specified option '--" << it.first
-          << " has been renamed to '--" << it.second
-          << "' in this ArangoDB version";
+          << " has been renamed to '--" << it.second << "'";
     }
 
     LOG_TOPIC("27c9c", INFO, Logger::STARTUP)

--- a/lib/ApplicationFeatures/OptionsCheckFeature.cpp
+++ b/lib/ApplicationFeatures/OptionsCheckFeature.cpp
@@ -64,7 +64,7 @@ void OptionsCheckFeature::prepare() {
           LOG_TOPIC("6843e", WARN, Logger::STARTUP)
               << "obsolete option '" << option.displayName()
               << "' used in configuration. "
-              << "setting this option will not have any effect.";
+              << "Setting this option does not have any effect.";
         }
       },
       true, true);

--- a/lib/ApplicationFeatures/OptionsCheckFeature.cpp
+++ b/lib/ApplicationFeatures/OptionsCheckFeature.cpp
@@ -44,7 +44,7 @@ void OptionsCheckFeature::prepare() {
     }
 
     LOG_TOPIC("27c9c", INFO, Logger::STARTUP)
-        << "please be sure to read the manual section about changed options";
+        << "please read the release notes about changed options";
   }
 
   options->walk(

--- a/lib/ApplicationFeatures/OptionsCheckFeature.cpp
+++ b/lib/ApplicationFeatures/OptionsCheckFeature.cpp
@@ -1,0 +1,74 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2022 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Jan Steemann
+////////////////////////////////////////////////////////////////////////////////
+
+#include "ApplicationFeatures/OptionsCheckFeature.h"
+
+#include "ApplicationFeatures/ApplicationServer.h"
+#include "ProgramOptions/ProgramOptions.h"
+#include "Logger/LogMacros.h"
+
+using namespace arangodb::options;
+
+namespace arangodb {
+
+void OptionsCheckFeature::prepare() {
+  auto const& options = server().options();
+
+  auto const& modernizedOptions = options->modernizedOptions();
+  if (!modernizedOptions.empty()) {
+    for (auto const& it : modernizedOptions) {
+      LOG_TOPIC("3e342", WARN, Logger::STARTUP)
+          << "please note that the specified option '--" << it.first
+          << " has been renamed to '--" << it.second
+          << "' in this ArangoDB version";
+    }
+
+    LOG_TOPIC("27c9c", INFO, Logger::STARTUP)
+        << "please be sure to read the manual section about changed options";
+  }
+
+  // inform about obsolete options
+  options->walk(
+      [](Section const&, Option const& option) {
+        if (option.hasFlag(arangodb::options::Flags::Obsolete)) {
+          LOG_TOPIC("6843e", WARN, Logger::STARTUP)
+              << "obsolete option '" << option.displayName()
+              << "' used in configuration. "
+              << "setting this option will not have any effect.";
+        }
+      },
+      true, true);
+
+  // inform about experimental options
+  options->walk(
+      [](Section const&, Option const& option) {
+        if (option.hasFlag(arangodb::options::Flags::Experimental)) {
+          LOG_TOPIC("de8f3", WARN, Logger::STARTUP)
+              << "experimental option '" << option.displayName()
+              << "' used in configuration.";
+        }
+      },
+      true, true);
+}
+
+}  // namespace arangodb

--- a/lib/ApplicationFeatures/OptionsCheckFeature.cpp
+++ b/lib/ApplicationFeatures/OptionsCheckFeature.cpp
@@ -47,6 +47,16 @@ void OptionsCheckFeature::prepare() {
         << "please be sure to read the manual section about changed options";
   }
 
+  options->walk(
+      [](Section const&, Option const& option) {
+        if (option.hasDeprecatedIn()) {
+          LOG_TOPIC("78b1e", WARN, Logger::STARTUP)
+              << "option '" << option.displayName() << "' is deprecated since "
+              << option.deprecatedInString();
+        }
+      },
+      true, true);
+
   // inform about obsolete options
   options->walk(
       [](Section const&, Option const& option) {

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -71,6 +71,7 @@ add_library(arango STATIC
   ApplicationFeatures/FileSystemFeature.cpp
   ApplicationFeatures/GreetingsFeature.cpp
   ApplicationFeatures/LanguageFeature.cpp
+  ApplicationFeatures/OptionsCheckFeature.cpp
   ApplicationFeatures/ShellColorsFeature.cpp
   ApplicationFeatures/ShutdownFeature.cpp
   ApplicationFeatures/TempFeature.cpp

--- a/tests/js/server/recovery/check-warnings-exitzero.js
+++ b/tests/js/server/recovery/check-warnings-exitzero.js
@@ -88,6 +88,11 @@ function recoverySuite () {
           // intentionally ignore "This is an unlicensed ArangoDB instance...
           return false;
         }
+        if (line.match(/\[de8f3\].*experimental option/)) {
+          // intentionally ignore experimental options warnings
+          return false;
+        }
+
         if (line.match(/\[d72fb\].*Your license will expire/)) {
           // intentionally ignore "This is an unlicensed ArangoDB instance...
           return false;


### PR DESCRIPTION
### Scope & Purpose

Centralize checking options in new ApplicationFeature.
This is a new central place that can be used to check all startup options for appropriateness, e.g.
* if an option is obsolete
* if an option is deprecated
* if an option is experimental
* if an option is renamed

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: -
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 