### PR TITLE
fixed issue #17291

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,13 +2,13 @@ v3.8.9 (XXXX-XX-XX)
 -------------------
 
 * Fixed issue #17291: Server crash on error in the PRUNE expression.
-  Traversal PRUNE expressions containing JavaScript user-defined functions 
-  (UDFs) are now properly rejected in single server and cluster mode. 
-  PRUNE expressions that use UDFs require a V8 context for execution, 
-  which is not available on DB-servers in a cluster, and also isn't 
-  necessarily available for regular queries on single servers (a V8 context
-  is only available if a query was executed inside Foxx or from inside a JS 
-  transaction, but not otherwise).
+  Traversal PRUNE expressions containing JavaScript user-defined functions
+  (UDFs) are now properly rejected in single server and cluster mode.
+  PRUNE expressions that use UDFs require a V8 context for execution, which is
+  not available on DB-servers in a cluster, and also isn't necessarily available
+  for regular queries on single servers (a V8 context is only available if a
+  query was executed inside Foxx or from inside a JS transaction, but not
+  otherwise).
 
 * Updated OpenSSL to 1.1.1s.
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,15 @@
 v3.8.9 (XXXX-XX-XX)
 -------------------
 
+* Fixed issue #17291: Server crash on error in the PRUNE expression.
+  Traversal PRUNE expressions containing JavaScript user-defined functions 
+  (UDFs) are now properly rejected in single server and cluster mode. 
+  PRUNE expressions that use UDFs require a V8 context for execution, 
+  which is not available on DB-servers in a cluster, and also isn't 
+  necessarily available for regular queries on single servers (a V8 context
+  is only available if a query was executed inside Foxx or from inside a JS 
+  transaction, but not otherwise).
+
 * Updated OpenSSL to 1.1.1s.
 
 * Solve a case of excessive memory consumption in certain AQL queries with IN

--- a/arangod/Aql/ExecutionPlan.cpp
+++ b/arangod/Aql/ExecutionPlan.cpp
@@ -1191,6 +1191,18 @@ ExecutionNode* ExecutionPlan::fromNodeTraversal(ExecutionNode* previous, AstNode
   std::unique_ptr<Expression> pruneExpression =
       createPruneExpression(this, _ast, node->getMember(3));
 
+  std::string errorReason;
+  if (pruneExpression != nullptr &&
+      !pruneExpression->canBeUsedInPrune(_ast->query().vocbase().isOneShard(),
+                                         errorReason)) {
+    // PRUNE is designed to be executed inside a DBServer. Therefore, we need a
+    // check here and abort in cases which are just not allowed, e.g. execution
+    // of user defined JavaScript method or V8 based methods.
+    THROW_ARANGO_EXCEPTION_MESSAGE(
+        TRI_ERROR_QUERY_PARSE,
+        std::string("Invalid PRUNE expression: ") + errorReason);
+  }
+
   auto options =
       createTraversalOptions(getAst(), direction, node->getMember(4));
 

--- a/arangod/Aql/Expression.h
+++ b/arangod/Aql/Expression.h
@@ -100,6 +100,9 @@ class Expression {
   /// @brief whether or not the expression will use V8
   bool willUseV8();
 
+  /// @brief whether or not the expression can be used inside a PRUNE statement
+  bool canBeUsedInPrune(bool isOneShard, std::string& errorReason);
+
   /// @brief clone the expression, needed to clone execution plans
   std::unique_ptr<Expression> clone(Ast* ast, bool deepCopy = false);
 

--- a/tests/js/common/aql/aql-prune-expressions.js
+++ b/tests/js/common/aql/aql-prune-expressions.js
@@ -1,0 +1,108 @@
+/*jshint globalstrict:false, strict:false, maxlen: 500 */
+/*global AQL_EXPLAIN, assertEqual, fail */
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief tests for traversal optimization
+///
+/// DISCLAIMER
+///
+/// Copyright 2010-2014 triagens GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is triAGENS GmbH, Cologne, Germany
+///
+/// @author Jan Steemann
+/// @author Copyright 2020, triAGENS GmbH, Cologne, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+const jsunity = require("jsunity");
+const db = require("@arangodb").db;
+const internal = require("internal");
+const errors = internal.errors;
+  
+function PruneExpressionsSuite() {
+  const vn = "UnitTestsVertex";
+  const en = "UnitTestsEdge";
+  const udf = "test::fuchs";
+
+  let cleanup = function () {
+    db._drop(en);
+    db._drop(vn);
+
+    try {
+      require("@arangodb/aql/functions").unregister(udf);
+    } catch (err) {}
+  };
+
+  return {
+    setUpAll : function () {
+      cleanup();
+    
+      require("@arangodb/aql/functions").register(udf, function() { return '0'; });
+      
+      db._create(vn, { numberOfShards: 1 });
+      db._createEdgeCollection(en, { distributeShardsLike: vn, numberOfShards: 1 });
+
+      db[vn].insert({ _key: "test1", value: 1 });
+      db[vn].insert({ _key: "test2", value: 2 });
+      db[vn].insert({ _key: "test3", value: 3 });
+
+      db[en].insert({ _from: vn + "/test1", _to: vn + "/test2", value: 1 });
+      db[en].insert({ _from: vn + "/test2", _to: vn + "/test3", value: 0 });
+    },
+    
+    tearDownAll : function () {
+      cleanup();
+    },
+
+    testAllowedExpression: function () {
+      let q = `WITH ${vn} FOR v, e, p IN 1..3 OUTBOUND '${vn}/test1' ${en} PRUNE e.value == '0' RETURN v`;
+      let res = db._query(q).toArray();
+      assertEqual(2, res.length);
+    },
+
+    testV8Expression: function () {
+      let q = `WITH ${vn} FOR v, e, p IN 1..3 OUTBOUND '${vn}/test1' ${en} PRUNE e.value == V8('0') RETURN v`;
+      try {
+        db._query(q);
+        fail();
+      } catch (err) {
+        assertEqual(err.errorNum, errors.ERROR_QUERY_PARSE.code);
+      }
+    },
+    
+    testUDFExpression: function () {
+      let q = `WITH ${vn} FOR v, e, p IN 1..3 OUTBOUND '${vn}/test1' ${en} PRUNE e.value == ${udf}() RETURN v`;
+      try {
+        db._query(q);
+        fail();
+      } catch (err) {
+        assertEqual(err.errorNum, errors.ERROR_QUERY_PARSE.code);
+      }
+    },
+    
+    testSubqueryExpression: function () {
+      let q = `WITH ${vn} FOR v, e, p IN 1..3 OUTBOUND '${vn}/test1' ${en} PRUNE e.value == (FOR i IN 1..1 RETURN '0') RETURN v`;
+      try {
+        db._query(q);
+        fail();
+      } catch (err) {
+        assertEqual(err.errorNum, errors.ERROR_QUERY_PARSE.code);
+      }
+    },
+  };
+}
+
+jsunity.run(PruneExpressionsSuite);
+return jsunity.done();


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/17619

Fix issue #17291 

Traversal PRUNE expressions containing JavaScript user-defined functions (UDFs) are now properly rejected in single server and cluster mode. PRUNE expressions that use UDFs require a V8 context for execution, which is not available on DB-servers in a cluster, and also isn't necessarily available for regular queries on single servers (a V8 context is only available if such query was executed inside Foxx or from inside a JS transaction, but not otherwise).

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [x] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [x] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.10: https://github.com/arangodb/arangodb/pull/17618
  - [x] Backport for 3.9: https://github.com/arangodb/arangodb/pull/17617
  - [x] Backport for 3.8: this PR

#### Related Information

- [x] Docs PR: https://github.com/arangodb/docs/pull/1193
- [ ] Enterprise PR:
- [x] GitHub issue / Jira ticket: #17291 
- [ ] Design document: 