### PR TITLE
[testing]if after a restore attempt the server isn't healthy anymore properly abort the test so we don't clean up

### DIFF
--- a/js/client/modules/@arangodb/testsuites/dump.js
+++ b/js/client/modules/@arangodb/testsuites/dump.js
@@ -369,6 +369,10 @@ class DumpRestoreHelper extends tu.runInArangoshRunner {
     let retryCount = 0;
     do {
       this.results.restore = this.arangorestore();
+      if (!this.instanceManager.checkInstanceAlive()) {
+        this.results.failed = true;
+        return false;
+      }
       if (this.results.restore.exitCode === 38) {
         retryCount += 1;
         if (retryCount === 21) {


### PR DESCRIPTION
### Scope & Purpose

we would recently see servers fail during asan dump_with_crashes runs. 
However, logfiles would be cleared, hence no post mortem analysis of the incident would be possible.
This PR will check the server health and turn the status to bad if the server is gone. 

- [x] :hankey: Bugfix
