### PR TITLE
[CINFRA-613] Leader stream can throw in replicateOperation

### DIFF
--- a/arangod/RocksDBEngine/ReplicatedRocksDBTransactionCollection.cpp
+++ b/arangod/RocksDBEngine/ReplicatedRocksDBTransactionCollection.cpp
@@ -232,13 +232,19 @@ ReplicatedRocksDBTransactionCollection::performIntermediateCommitIfRequired() {
         kIntermediateCommit;
     auto options = replication2::replicated_state::document::ReplicationOptions{
         .waitForCommit = true};
-    return leader
-        ->replicateOperation(velocypack::SharedSlice{}, operation,
-                             _transaction->id(), options)
-        .thenValue([state = _transaction->shared_from_this(),
-                    this](auto&& res) -> Result {
-          return _rocksMethods->triggerIntermediateCommit();
-        });
+    try {
+      return leader
+          ->replicateOperation(velocypack::SharedSlice{}, operation,
+                               _transaction->id(), options)
+          .thenValue([state = _transaction->shared_from_this(),
+                      this](auto&& res) -> Result {
+            return _rocksMethods->triggerIntermediateCommit();
+          });
+    } catch (basics::Exception const& e) {
+      return Result{e.code(), e.what()};
+    } catch (std::exception const& e) {
+      return Result{TRI_ERROR_INTERNAL, e.what()};
+    }
   }
   return Result{};
 }

--- a/arangod/RocksDBEngine/ReplicatedRocksDBTransactionState.cpp
+++ b/arangod/RocksDBEngine/ReplicatedRocksDBTransactionState.cpp
@@ -88,25 +88,43 @@ futures::Future<Result> ReplicatedRocksDBTransactionState::doCommit() {
   auto options = replication2::replicated_state::document::ReplicationOptions{
       .waitForCommit = true};
   std::vector<futures::Future<Result>> commits;
-  allCollections([&](TransactionCollection& tc) {
-    auto& rtc = static_cast<ReplicatedRocksDBTransactionCollection&>(tc);
-    if (rtc.accessType() != AccessMode::Type::READ) {
-      // We have to write to the log and wait for the log entry to be committed
-      // (in the log sense), before we can commit locally.
-      auto leader = rtc.leaderState();
-      commits.emplace_back(leader
-                               ->replicateOperation(velocypack::SharedSlice{},
-                                                    operation, id(), options)
-                               .thenValue([&rtc](auto&& res) -> Result {
-                                 return rtc.commitTransaction();
-                               }));
-    } else {
-      // For read-only transactions the commit is a no-op, but we still have to
-      // call it to ensure cleanup.
-      rtc.commitTransaction();
+
+  // We need the guard to ensure that the underlying collections are available
+  // in replicateOperation futures, even if we return early
+  ScopeGuard guard{[&]() noexcept {
+    try {
+      futures::collectAll(commits).get();
+    } catch (std::exception const&) {
     }
-    return true;
-  });
+  }};
+
+  try {
+    allCollections([&](TransactionCollection& tc) {
+      auto& rtc = static_cast<ReplicatedRocksDBTransactionCollection&>(tc);
+      if (rtc.accessType() != AccessMode::Type::READ) {
+        // We have to write to the log and wait for the log entry to be
+        // committed (in the log sense), before we can commit locally.
+        auto leader = rtc.leaderState();
+        commits.emplace_back(leader
+                                 ->replicateOperation(velocypack::SharedSlice{},
+                                                      operation, id(), options)
+                                 .thenValue([&rtc](auto&& res) -> Result {
+                                   return rtc.commitTransaction();
+                                 }));
+      } else {
+        // For read-only transactions the commit is a no-op, but we still have
+        // to call it to ensure cleanup.
+        rtc.commitTransaction();
+      }
+      return true;
+    });
+  } catch (basics::Exception const& e) {
+    return Result{e.code(), e.what()};
+  } catch (std::exception const& e) {
+    return Result{TRI_ERROR_INTERNAL, e.what()};
+  }
+
+  guard.cancel();
 
   // We are capturing a shared pointer to this state so we prevent reclamation
   // while we are waiting for the commit operations.
@@ -153,8 +171,14 @@ Result ReplicatedRocksDBTransactionState::doAbort() {
     auto& rtc = static_cast<ReplicatedRocksDBTransactionCollection&>(*col);
     if (rtc.accessType() != AccessMode::Type::READ) {
       auto leader = rtc.leaderState();
-      leader->replicateOperation(velocypack::SharedSlice{}, operation, id(),
-                                 options);
+      try {
+        leader->replicateOperation(velocypack::SharedSlice{}, operation, id(),
+                                   options);
+      } catch (basics::Exception const& e) {
+        return Result{e.code(), e.what()};
+      } catch (std::exception const& e) {
+        return Result{TRI_ERROR_INTERNAL, e.what()};
+      }
     }
     auto r = rtc.abortTransaction();
     if (r.fail()) {

--- a/arangod/Transaction/Methods.cpp
+++ b/arangod/Transaction/Methods.cpp
@@ -2514,11 +2514,17 @@ Future<OperationResult> transaction::Methods::truncateLocal(
       VPackObjectBuilder ob(&body);
       body.add("collection", collectionName);
     }
-    leaderState->replicateOperation(
-        body.sharedSlice(),
-        replication2::replicated_state::document::OperationType::kTruncate,
-        state()->id(),
-        replication2::replicated_state::document::ReplicationOptions{});
+    try {
+      leaderState->replicateOperation(
+          body.sharedSlice(),
+          replication2::replicated_state::document::OperationType::kTruncate,
+          state()->id(),
+          replication2::replicated_state::document::ReplicationOptions{});
+    } catch (basics::Exception const& e) {
+      return OperationResult(Result{e.code(), e.what()}, options);
+    } catch (std::exception const& e) {
+      return OperationResult(Result{TRI_ERROR_INTERNAL, e.what()}, options);
+    }
     return OperationResult{Result{}, options};
   }
 
@@ -3003,12 +3009,18 @@ Future<Result> Methods::replicateOperations(
     auto& rtc = static_cast<ReplicatedRocksDBTransactionCollection&>(
         transactionCollection);
     auto leaderState = rtc.leaderState();
-    leaderState->replicateOperation(
-        replicationData.sharedSlice(),
-        replication2::replicated_state::document::fromDocumentOperation(
-            operation),
-        state()->id(),
-        replication2::replicated_state::document::ReplicationOptions{});
+    try {
+      leaderState->replicateOperation(
+          replicationData.sharedSlice(),
+          replication2::replicated_state::document::fromDocumentOperation(
+              operation),
+          state()->id(),
+          replication2::replicated_state::document::ReplicationOptions{});
+    } catch (basics::Exception const& e) {
+      return Result{e.code(), e.what()};
+    } catch (std::exception const& e) {
+      return Result{TRI_ERROR_INTERNAL, e.what()};
+    }
     return performIntermediateCommitIfRequired(collection->id());
   }
 


### PR DESCRIPTION
### Scope & Purpose

In case the leader resigns while inside `replicateOperation`, accessing the stream will throw an exception. This is now handled by all callers of this method, which was pretty easy to implement since all of them already return some type of `Result`.

For the `doCommit`, we need a `ScopeGuard` that makes sure all ongoing futures are resolved before returning from the function. This is because the underlying `TransactionCollection`'s are captured by reference and might not be around when the `thenValue` is executed. 

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
