### PR TITLE
Make two deprecated `--server.disable-authentication*` server startup options obsolete

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,12 @@
 devel
 -----
 
+* Make the deprecated `--server.disable-authentication-unix-sockets` and
+  `--server.disable-authentication` startup options obsolete. They were
+  deprecated in v3.0 and mapped to `--server.authentication` and
+  `--server.authentication-unix-sockets`, which made them do the opposite
+  of what their names suggest.
+
 * Removed more assertions from cluster rebalance js test that obligated the 
   rebalance plan to always have moves, but there were cases in which all 
   there are none.

--- a/arangod/GeneralServer/AuthenticationFeature.cpp
+++ b/arangod/GeneralServer/AuthenticationFeature.cpp
@@ -71,10 +71,13 @@ AuthenticationFeature::AuthenticationFeature(Server& server)
 
 void AuthenticationFeature::collectOptions(
     std::shared_ptr<ProgramOptions> options) {
-  options->addOldOption("server.disable-authentication",
-                        "server.authentication");
-  options->addOldOption("server.disable-authentication-unix-sockets",
-                        "server.authentication-unix-sockets");
+  options->addObsoleteOption(
+      "server.disable-authentication",
+      "Whether to use authentication for all client requests.", false);
+  options->addObsoleteOption(
+      "server.disable-authentication-unix-sockets",
+      "Whether to use authentication for requests via UNIX domain sockets.",
+      false);
   options->addOldOption("server.authenticate-system-only",
                         "server.authentication-system-only");
 


### PR DESCRIPTION
### Scope & Purpose

`--server.disable-authentication-unix-sockets` and `--server.disable-authentication` were deprecated in v3.0 and mapped to `--server.authentication` and `--server.authentication-unix-sockets`, which made them do the opposite of what their names suggest. It's time to remove them.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [x] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
  - [x] Manually tested (warnings are raised on startup that the options are obsolete)
    <img width="1304" alt="image" src="https://user-images.githubusercontent.com/7819991/203383469-38ab1c8f-b04c-4dfb-896e-83764b783810.png">

- [x] :book: CHANGELOG entry made
- [x] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: *(Please link PR)*
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [x] Docs PR: https://github.com/arangodb/docs/pull/1202
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

