### PR TITLE
[testing]allso put assert lines into GDB_OUTPUT so they end up in the testfailures.txt

### DIFF
--- a/js/client/modules/@arangodb/testsuites/recovery_cluster.js
+++ b/js/client/modules/@arangodb/testsuites/recovery_cluster.js
@@ -154,6 +154,7 @@ function runArangodRecovery (params, useEncryption) {
                                                             params.count.toString()));
     params.instanceManager.prepareInstance();
     params.instanceManager.launchTcpDump("");
+    params.instanceManager.nonfatalAssertSearch();
     if (!params.instanceManager.launchInstance()) {
       params.instanceManager.destructor(false);
       return {

--- a/js/client/modules/@arangodb/testutils/instance-manager.js
+++ b/js/client/modules/@arangodb/testutils/instance-manager.js
@@ -97,6 +97,7 @@ class instanceManager {
       fs.write(this.restKeyFile, "Open Sesame!Open Sesame!Open Ses");
     }
     this.httpAuthOptions = pu.makeAuthorizationHeaders(this.options, addArgs);
+    this.expectAsserts = false;
   }
 
   destructor(cleanup) {
@@ -276,6 +277,9 @@ class instanceManager {
     }
   }
 
+  nonfatalAssertSearch() {
+    this.expectAsserts = true;
+  }
   launchInstance() {
     if (this.options.hasOwnProperty('server')) {
       print("external server configured - not testing readyness! " + this.options.server);
@@ -994,7 +998,7 @@ class instanceManager {
       });
     }
     this.arangods.forEach(arangod => {
-      arangod.readAssertLogLines();
+      arangod.readAssertLogLines(this.expectAsserts);
     });
     this.cleanup = this.cleanup && shutdownSuccess;
     return shutdownSuccess;

--- a/js/client/modules/@arangodb/testutils/instance.js
+++ b/js/client/modules/@arangodb/testutils/instance.js
@@ -518,7 +518,7 @@ class instance {
   // / @brief scans the log files for assert lines
   // //////////////////////////////////////////////////////////////////////////////
 
-  readAssertLogLines () {
+  readAssertLogLines (expectAsserts) {
     let size = fs.size(this.logFile);
     if (this.options.maxLogFileSize !== 0 && size > this.options.maxLogFileSize) {
       // File bigger 500k? this needs to be a bug in the tests.
@@ -544,7 +544,9 @@ class instance {
               print("ERROR: " + line);
             }
             this.assertLines.push(line);
-            crashUtils.GDB_OUTPUT += line;
+            if (!expectAsserts) {
+              crashUtils.GDB_OUTPUT += line + '\n';
+            }
           }
         }
       }


### PR DESCRIPTION
### Scope & Purpose

Asserts may abort SUT-arangods. We already search for these; However it seems its not yet put into `testfailures.txt` - change that.

- [x] :hankey: Bugfix
