### PR TITLE
SEARCH-427 fix and test

### DIFF
--- a/arangod/IResearch/AqlHelper.cpp
+++ b/arangod/IResearch/AqlHelper.cpp
@@ -748,7 +748,8 @@ bool nameFromAttributeAccess(
   if (visitRes && !ctx.isSearchQuery) {
     auto const fields = ctx.fields;
     auto const it = getNested(name, fields);
-    visitRes = it != std::end(fields) && !it->_isSearchField;
+    visitRes = it != std::end(fields) && !it->_isSearchField &&
+               !it->_trackListPositions;
     if (visitRes && subFields) {
       *subFields = it->_fields;
     }


### PR DESCRIPTION
### Scope & Purpose

Fixes SEARCH-427 by ensuring that trackListPositions enabled field is not used in FILTER coverage
Enterprise PR: https://github.com/arangodb/enterprise/pull/1151

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [x] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [x] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.10: *(Please link PR)*
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*

#### Related Information



