### PR TITLE
disable unstable test on Windows

### DIFF
--- a/tests/IResearch/IResearchLinkTest.cpp
+++ b/tests/IResearch/IResearchLinkTest.cpp
@@ -2412,7 +2412,7 @@ TEST_F(IResearchLinkMetricsTest, TimeCommit) {
     EXPECT_LT(indexSize1, indexSize0);
 
 #if !GTEST_OS_WINDOWS
-    // TODO FIXME: this test currently is unstable on Windows
+    // TODO(MBkkt) this test currently is unstable on Windows
     timeMs += remove(10000, 10100);
     auto [commitTime2, cleanupTime2, consolidationTime2] = l->avgTime();
     EXPECT_LE(commitTime2, timeMs / 4.0);

--- a/tests/IResearch/IResearchLinkTest.cpp
+++ b/tests/IResearch/IResearchLinkTest.cpp
@@ -2411,6 +2411,8 @@ TEST_F(IResearchLinkMetricsTest, TimeCommit) {
     EXPECT_LT(0, indexSize1);
     EXPECT_LT(indexSize1, indexSize0);
 
+#if !GTEST_OS_WINDOWS
+    // TODO FIXME: this test currently is unstable on Windows
     timeMs += remove(10000, 10100);
     auto [commitTime2, cleanupTime2, consolidationTime2] = l->avgTime();
     EXPECT_LE(commitTime2, timeMs / 4.0);
@@ -2421,6 +2423,7 @@ TEST_F(IResearchLinkMetricsTest, TimeCommit) {
     EXPECT_LT(numFiles2, numFiles1);
     EXPECT_LT(0, indexSize2);
     EXPECT_LT(indexSize2, indexSize1);
+#endif
   }
 }
 


### PR DESCRIPTION
### Scope & Purpose

Disable unstable test on Windows

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: -
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 