### PR TITLE
Fix v8 environment variable buffer overrun 

### DIFF
--- a/lib/V8/v8-environment.cpp
+++ b/lib/V8/v8-environment.cpp
@@ -100,7 +100,8 @@ static void EnvGetter(v8::Local<v8::Name> property,
   // happen. If result == 0 and result != ERROR_SUCCESS the variable was not
   // not found.
   if ((result > 0 || GetLastError() == ERROR_SUCCESS) && result < bufferSize) {
-    uint16_t const* two_byte_buffer = reinterpret_cast<uint16_t const*>(buffer_ptr);
+    uint16_t const* two_byte_buffer =
+        reinterpret_cast<uint16_t const*>(buffer_ptr);
     TRI_V8_RETURN(TRI_V8_STRING_UTF16(isolate, two_byte_buffer, result));
   }
 #endif

--- a/lib/V8/v8-environment.cpp
+++ b/lib/V8/v8-environment.cpp
@@ -79,17 +79,28 @@ static void EnvGetter(v8::Local<v8::Name> property,
   }
 #else  // _WIN32
   v8::String::Value key(isolate, property);
-  WCHAR buffer[32767];  // The maximum size allowed for environment variables.
+  // static buffer. should be ok for most cases
+  WCHAR buffer[8192];
+  DWORD bufferSize{static_cast<DWORD>(std::size(buffer))};
+  std::vector<WCHAR> dynamicBuffer;
+  WCHAR* buffer_ptr = buffer;
   DWORD result = GetEnvironmentVariableW(reinterpret_cast<const WCHAR*>(*key),
-                                         buffer, sizeof(buffer));
+                                         buffer_ptr, bufferSize);
 
+  if (result > bufferSize) {
+    // static was small. We will go dynamic
+    dynamicBuffer.resize(result);
+    bufferSize = result;
+    buffer_ptr = dynamicBuffer.data();
+    result = GetEnvironmentVariableW(reinterpret_cast<const WCHAR*>(*key),
+                                     buffer_ptr, bufferSize);
+  }
   // ERROR_ENVVAR_NOT_FOUND is possibly returned.
   // If result >= sizeof buffer the buffer was too small. That should never
   // happen. If result == 0 and result != ERROR_SUCCESS the variable was not
   // not found.
-  if ((result > 0 || GetLastError() == ERROR_SUCCESS) &&
-      result < sizeof(buffer)) {
-    uint16_t const* two_byte_buffer = reinterpret_cast<uint16_t const*>(buffer);
+  if ((result > 0 || GetLastError() == ERROR_SUCCESS) && result < bufferSize) {
+    uint16_t const* two_byte_buffer = reinterpret_cast<uint16_t const*>(buffer_ptr);
     TRI_V8_RETURN(TRI_V8_STRING_UTF16(isolate, two_byte_buffer, result));
   }
 #endif

--- a/tests/test-definitions.txt
+++ b/tests/test-definitions.txt
@@ -87,7 +87,7 @@ recovery_cluster priority=2000 cluster buckets=8 -- --test search
 shell_server_aql priority=1000 cluster buckets=16 -- --dumpAgencyOnError true
 shell_client priority=500 cluster buckets=5 -- --dumpAgencyOnError true
 shell_client_transaction priority=500 cluster parallelity=5 buckets=5 -- --dumpAgencyOnError true
-#shell_client_replication2_recovery priority=500 cluster buckets=5 -- --dumpAgencyOnError true
+shell_client_replication2_recovery priority=500 cluster buckets=5 -- --dumpAgencyOnError true
 shell_server priority=500 cluster buckets=5 -- --dumpAgencyOnError true
 
 # Common Tests


### PR DESCRIPTION
### Scope & Purpose

Fixes reading environment variable for windows.
First attempt is made via static 8k buffer. And only if it is not enough dynamic allocation is made.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [x] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: *(Please link PR)*
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

