### PR TITLE
DOC-266 | Documentation 3.10/arangosearch column cache

### DIFF
--- a/Documentation/DocuBlocks/Rest/Indexes/post_api_index_inverted.md
+++ b/Documentation/DocuBlocks/Rest/Indexes/post_api_index_inverted.md
@@ -84,6 +84,17 @@ all elements are searched for a match.
 
 Default: the value defined by the top-level `trackListPositions` option.
 
+@RESTSTRUCT{cache,post_api_index_inverted_fields,boolean,optional,}
+Enable this option to always cache the field normalization values in memory
+for this specific field. This can improve the performance of scoring and
+ranking queries.
+
+Normalization values are computed for fields which are processed with Analyzers
+that have the `"norm"` feature enabled. These values are used to score fairer if
+the same tokens occur repeatedly, to emphasize these documents less.
+
+Default: the value defined by the top-level `cache` option.
+
 @RESTSTRUCT{nested,post_api_index_inverted_fields,array,optional,post_api_index_inverted_nested}
 Index the specified sub-objects that are stored in an array. Other than with the
 `fields` property, the values get indexed in a way that lets you query for
@@ -126,6 +137,13 @@ You cannot use an array expansion if `searchField` is enabled.
 
 Default: the value defined by the top-level `searchField` option.
 
+@RESTSTRUCT{cache,post_api_index_inverted_nested,boolean,optional,}
+Enable this option to always cache the field normalization values in memory
+for this specific nested field. This can improve the performance of scoring and
+ranking queries.
+
+Default: the value defined by the top-level `cache` option.
+
 @RESTSTRUCT{nested,post_api_index_inverted_nested,array,optional,object}
 You can recursively index sub-objects. See the above description of the
 `nested` option.
@@ -145,6 +163,17 @@ You cannot use an array expansion if `searchField` is enabled.
 
 Default: `false`
 
+@RESTBODYPARAM{cache,boolean,optional,}
+Enable this option to always cache the field normalization values in memory
+for all fields by default. This can improve the performance of scoring and
+ranking queries.
+
+Normalization values are computed for fields which are processed with Analyzers
+that have the `"norm"` feature enabled. These values are used to score fairer if
+the same tokens occur repeatedly, to emphasize these documents less.
+
+Default: `false`
+
 @RESTBODYPARAM{storedValues,array,optional,post_api_index_inverted_storedvalues}
 The optional `storedValues` attribute can contain an array of paths to additional 
 attributes to store in the index. These additional attributes cannot be used for
@@ -158,6 +187,12 @@ A list of attribute paths. The `.` character denotes sub-attributes.
 Defines how to compress the attribute values. Possible values:
 - `"lz4"` (default): use LZ4 fast compression.
 - `"none"`: disable compression to trade space for speed.
+
+@RESTSTRUCT{cache,post_api_index_inverted_storedvalues,boolean,optional,}
+Enable this option to always cache stored values in memory. This can improve the
+query performance if stored values are involved.
+
+Default: `false`
 
 @RESTBODYPARAM{primarySort,object,optional,post_api_index_inverted_primarysort}
 You can define a primary sort order to enable an AQL optimization. If a query
@@ -180,6 +215,18 @@ The sorting direction. Possible values:
 Defines how to compress the primary sort data. Possible values:
 - `"lz4"` (default): use LZ4 fast compression.
 - `"none"`: disable compression to trade space for speed.
+
+@RESTSTRUCT{cache,post_api_index_inverted_primarysort,boolean,optional,}
+Enable this option to always cache the primary sort columns in memory. This can
+improve the performance of queries that utilize the primary sort order.
+
+Default: `false`
+
+@RESTBODYPARAM{primaryKeyCache,boolean,optional,}
+Enable this option to always cache the primary key column in memory. This can
+improve the performance of queries that return many documents.
+
+Default: `false`
 
 @RESTBODYPARAM{analyzer,string,optional,string}
 The name of an Analyzer to use by default. This Analyzer is applied to the

--- a/Documentation/DocuBlocks/Rest/User Management/README.md
+++ b/Documentation/DocuBlocks/Rest/User Management/README.md
@@ -498,8 +498,8 @@ modified by end users, as custom attributes will not be preserved.
 
 @RESTDESCRIPTION
 Replaces the data of an existing user. You need server access level
-*Administrate* in order to execute this REST call. Additionally, a user can
-change his/her own data.
+*Administrate* in order to execute this REST call. Additionally, users can
+change their own data.
 
 @RESTRETURNCODES
 
@@ -562,8 +562,8 @@ modified by end users, as custom attributes will not be preserved.
 
 @RESTDESCRIPTION
 Partially updates the data of an existing user. You need server access level
-*Administrate* in order to execute this REST call. Additionally, a user can
-change his/her own data.
+*Administrate* in order to execute this REST call. Additionally, users can
+change their own data.
 
 @RESTRETURNCODES
 

--- a/Documentation/DocuBlocks/Rest/Views/post_api_view_arangosearch.md
+++ b/Documentation/DocuBlocks/Rest/Views/post_api_view_arangosearch.md
@@ -20,7 +20,7 @@ for details.
 A primary sort order can be defined to enable an AQL optimization. If a query
 iterates over all documents of a View, wants to sort them by attribute values
 and the (left-most) fields to sort by as well as their sorting direction match
-with the *primarySort* definition, then the `SORT` operation is optimized away.
+with the `primarySort` definition, then the `SORT` operation is optimized away.
 This option is immutable.
 
 Expects an array of objects, each specifying a field (attribute path) and a
@@ -30,9 +30,33 @@ sort direction (`"asc` for ascending, `"desc"` for descending):
 @RESTBODYPARAM{primarySortCompression,string,optional,string}
 Defines how to compress the primary sort data (introduced in v3.7.1).
 ArangoDB v3.5 and v3.6 always compress the index using LZ4.
+
 This option is immutable.
+
 - `"lz4"` (default): use LZ4 fast compression.
 - `"none"`: disable compression to trade space for speed.
+
+@RESTBODYPARAM{primarySortCache,boolean,optional,}
+If you enable this option, then the primary sort columns are always cached in
+memory (introduced in v3.9.6, Enterprise Edition only). This can improve the
+performance of queries that utilize the primary sort order. Otherwise, these
+values are memory-mapped and it is up to the operating system to load them from
+disk into memory and to evict them from memory.
+
+This option is immutable.
+
+See the `--arangosearch.columns-cache-limit` startup option to control the
+memory consumption of this cache.
+
+@RESTBODYPARAM{primaryKeyCache,boolean,optional,}
+If you enable this option, then the primary key columns are always cached in
+memory (introduced in v3.9.6, Enterprise Edition only). This can improve the
+performance of queries that return many documents. Otherwise, these values are
+memory-mapped and it is up to the operating system to load them from disk into
+memory and to evict them from memory.
+
+See the `--arangosearch.columns-cache-limit` startup option to control the
+memory consumption of this cache.
 
 @RESTBODYPARAM{storedValues,array,optional,object}
 An array of objects to describe which document attributes to store in the View
@@ -40,18 +64,30 @@ index (introduced in v3.7.1). It can then cover search queries, which means the
 data can be taken from the index directly and accessing the storage engine can
 be avoided.
 
-Each object is expected in the form
-`{ "fields": [ "attr1", "attr2", ... "attrN" ], "compression": "none" }`,
-where the required `fields` attribute is an array of strings with one or more
-document attribute paths. The specified attributes are placed into a single
-column of the index. A column with all fields that are involved in common
-search queries is ideal for performance. The column should not include too many
-unneeded fields however. The optional `compression` attribute defines the
-compression type used for the internal column-store, which can be `"lz4"`
-(LZ4 fast compression, default) or `"none"` (no compression).
+This option is immutable.
 
-This option is immutable. Not to be confused with `storeValues`, which allows
-to store meta data about attribute values in the View index.
+Each object is expected in the following form:
+
+`{ "fields": [ "attr1", "attr2", ... "attrN" ], "compression": "none", "cache": false }`
+
+- The required `fields` attribute is an array of strings with one or more
+  document attribute paths. The specified attributes are placed into a single
+  column of the index. A column with all fields that are involved in common
+  search queries is ideal for performance. The column should not include too
+  many unneeded fields, however.
+
+- The optional `compression` attribute defines the compression type used for
+  the internal column-store, which can be `"lz4"` (LZ4 fast compression, default)
+  or `"none"` (no compression).
+
+- The optional `cache` attribute allows you to always cache stored values in
+  memory (introduced in v3.9.5, Enterprise Edition only). This can improve
+  the query performance if stored values are involved. See the
+  `--arangosearch.columns-cache-limit` startup option
+  to control the memory consumption of this cache.
+
+The `storedValues` option is not to be confused with the `storeValues` option,
+which allows to store meta data about attribute values in the View index.
 
 @RESTBODYPARAM{cleanupIntervalStep,integer,optional,int64}
 Wait at least this many commits between removing unused files in the

--- a/Documentation/DocuBlocks/Rest/Views/post_api_view_arangosearch.md
+++ b/Documentation/DocuBlocks/Rest/Views/post_api_view_arangosearch.md
@@ -55,6 +55,8 @@ performance of queries that return many documents. Otherwise, these values are
 memory-mapped and it is up to the operating system to load them from disk into
 memory and to evict them from memory.
 
+This option is immutable.
+
 See the `--arangosearch.columns-cache-limit` startup option to control the
 memory consumption of this cache.
 


### PR DESCRIPTION
Backport of https://github.com/arangodb/arangodb/pull/17683

Forward port of https://github.com/arangodb/arangodb/pull/17603, plus ArangoSearch caching options for inverted indexes
