### PR TITLE
DOC-266 | Documentation 3.9/arangosearch column cache

### DIFF
--- a/Documentation/DocuBlocks/Rest/Views/post_api_view_arangosearch.md
+++ b/Documentation/DocuBlocks/Rest/Views/post_api_view_arangosearch.md
@@ -55,6 +55,8 @@ performance of queries that return many documents. Otherwise, these values are
 memory-mapped and it is up to the operating system to load them from disk into
 memory and to evict them from memory.
 
+This option is immutable.
+
 See the `--arangosearch.columns-cache-limit` startup option to control the
 memory consumption of this cache.
 


### PR DESCRIPTION
Minor follow-up to #17603 