### PR TITLE
[testing] the replication sync test takes very long, launch it right at the start

### DIFF
--- a/js/client/modules/@arangodb/testsuites/replication.js
+++ b/js/client/modules/@arangodb/testsuites/replication.js
@@ -209,6 +209,7 @@ function replicationStatic (options) {
 
 function replicationSync (options) {
   let testCases = tu.scanTestPaths(testPaths.replication_sync, options);
+  testCases = tu.splitBuckets(options, testCases);
 
   return new replicationRunner(options, 'replication_sync').run(testCases);
 }

--- a/tests/test-definitions.txt
+++ b/tests/test-definitions.txt
@@ -16,7 +16,7 @@ replication_ongoing_frompresent parallelity=3 single -- --extraArgs:log.level re
 replication_ongoing_global priority=500 parallelity=3 single -- --extraArgs:log.level replication=trace
 replication_ongoing_global_spec parallelity=3 single -- --extraArgs:log.level replication=trace
 replication_static priority=500 parallelity=3 single -- --extraArgs:log.level replication=trace
-replication_sync priority=8000 parallelity=3 single -- --extraArgs:log.level replication=trace
+replication_sync priority=8000 buckets=2 parallelity=3 single -- --extraArgs:log.level replication=trace
 shell_replication parallelity=3 single 
 http_replication priority=500 parallelity=3 single
 

--- a/tests/test-definitions.txt
+++ b/tests/test-definitions.txt
@@ -16,7 +16,7 @@ replication_ongoing_frompresent parallelity=3 single -- --extraArgs:log.level re
 replication_ongoing_global priority=500 parallelity=3 single -- --extraArgs:log.level replication=trace
 replication_ongoing_global_spec parallelity=3 single -- --extraArgs:log.level replication=trace
 replication_static priority=500 parallelity=3 single -- --extraArgs:log.level replication=trace
-replication_sync priority=500 parallelity=3 single -- --extraArgs:log.level replication=trace
+replication_sync priority=8000 parallelity=3 single -- --extraArgs:log.level replication=trace
 shell_replication parallelity=3 single 
 http_replication priority=500 parallelity=3 single
 


### PR DESCRIPTION
### Scope & Purpose

This test runs very long, hence start it from the very beginning, so it doesn't run alone (up to 10 minutes observed in runs) wasting machine time. 
However, its only launched 30s in, try to split it by buckets - though its only 2 suites
Needed to add splitter code to the suite.

- [x] :hankey: Bugfix
