### PR TITLE
Add missing metrics for traffic accounting - BTS-1133

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,12 @@
 v3.9.6 (XXXX-XX-XX)
 -------------------
 
+* Add missing metrics for user traffic: Histograms:
+    `arangodb_client_user_connection_statistics_bytes_received`
+    `arangodb_client_user_connection_statistics_bytes_sent`
+  These numbers were so far only published via the statistics API.
+  This is needed for Oasis traffic accounting.
+
 * Fix HTTP/VST traffic accounting in internal statistics / metrics.
 
 * Delay a MoveShard operation for leader change, until the old leader has

--- a/Documentation/Metrics/arangodb_client_connection_statistics_bytes_received.yaml
+++ b/Documentation/Metrics/arangodb_client_connection_statistics_bytes_received.yaml
@@ -1,7 +1,7 @@
 name: arangodb_client_connection_statistics_bytes_received
 introducedIn: "3.8.0"
 help: |
-  Bytes received for a request.
+  Bytes received for requests.
 unit: bytes
 type: histogram
 category: Statistics

--- a/Documentation/Metrics/arangodb_client_connection_statistics_bytes_sent.yaml
+++ b/Documentation/Metrics/arangodb_client_connection_statistics_bytes_sent.yaml
@@ -1,7 +1,7 @@
 name: arangodb_client_connection_statistics_bytes_sent
 introducedIn: "3.8.0"
 help: |
-  Bytes sent for a request.
+  Bytes sent for responses.
 unit: bytes
 type: histogram
 category: Statistics

--- a/Documentation/Metrics/arangodb_client_user_connection_statistics_bytes_received.yaml
+++ b/Documentation/Metrics/arangodb_client_user_connection_statistics_bytes_received.yaml
@@ -1,0 +1,16 @@
+name: arangodb_client_user_connection_statistics_bytes_received
+introducedIn: "3.9.6"
+help: |
+  Bytes received for requests, only user traffic.
+unit: bytes
+type: histogram
+category: Statistics
+complexity: simple
+exposedBy:
+  - coordinator
+  - dbserver
+  - agent
+  - single
+description: |
+  Histogram of the received request sizes in bytes, only considering user
+  traffic, i.e. traffic authenticated with a real user (or role).

--- a/Documentation/Metrics/arangodb_client_user_connection_statistics_bytes_sent.yaml
+++ b/Documentation/Metrics/arangodb_client_user_connection_statistics_bytes_sent.yaml
@@ -1,0 +1,16 @@
+name: arangodb_client_user_connection_statistics_bytes_sent
+introducedIn: "3.9.6"
+help: |
+  Bytes sent for responses, only user traffic.
+unit: bytes
+type: histogram
+category: Statistics
+complexity: simple
+exposedBy:
+  - coordinator
+  - dbserver
+  - agent
+  - single
+description: |
+  Histogram of the sent response sizes in bytes, only user traffic, i.e.
+  traffic that has been authenticated with a real user (or role).

--- a/arangod/Statistics/StatisticsFeature.cpp
+++ b/arangod/Statistics/StatisticsFeature.cpp
@@ -945,9 +945,9 @@ void StatisticsFeature::toPrometheus(std::string& result, double const& now,
     RequestStatistics::getSnapshot(requestStatsUser,
                                    stats::RequestStatisticsSource::USER);
     appendHistogram(result, requestStatsUser.bytesSent, "bytesSentUser",
-                    {"250", "1000", "2000", "5000", "10000", "+Inf"}, true);
+                    {"250", "1000", "2000", "5000", "10000", "+Inf"}, v2, true);
     appendHistogram(result, requestStatsUser.bytesReceived, "bytesReceivedUser",
-                    {"250", "1000", "2000", "5000", "10000", "+Inf"}, true);
+                    {"250", "1000", "2000", "5000", "10000", "+Inf"}, v2, true);
 
     // _httpStatistics()
     using rest::RequestType;

--- a/arangod/Statistics/StatisticsFeature.cpp
+++ b/arangod/Statistics/StatisticsFeature.cpp
@@ -142,9 +142,15 @@ struct RequestTimeScale {
 };
 
 DECLARE_HISTOGRAM(arangodb_client_connection_statistics_bytes_received,
-                  BytesReceivedScale, "Bytes received for a request");
+                  BytesReceivedScale, "Bytes received for requests");
 DECLARE_HISTOGRAM(arangodb_client_connection_statistics_bytes_sent,
-                  BytesSentScale, "Bytes sent for a request");
+                  BytesSentScale, "Bytes sent for responses");
+DECLARE_HISTOGRAM(arangodb_client_user_connection_statistics_bytes_received,
+                  BytesReceivedScale,
+                  "Bytes received for requests, only user traffic");
+DECLARE_HISTOGRAM(arangodb_client_user_connection_statistics_bytes_sent,
+                  BytesSentScale,
+                  "Bytes sent for responses, only user traffic");
 DECLARE_COUNTER(
     arangodb_process_statistics_minor_page_faults_total,
     "The number of minor faults the process has made which have not required "
@@ -251,10 +257,16 @@ auto const statStrings = std::map<std::string_view,
                                   std::vector<std::string_view>>{
     {"bytesReceived",
      {"arangodb_client_connection_statistics_bytes_received", "histogram",
-      "Bytes received for a request"}},
+      "Bytes received for requests"}},
     {"bytesSent",
      {"arangodb_client_connection_statistics_bytes_sent", "histogram",
-      "Bytes sent for a request"}},
+      "Bytes sent for responses"}},
+    {"bytesReceivedUser",
+     {"arangodb_client_user_connection_statistics_bytes_received", "histogram",
+      "Bytes received for requests, only user traffic"}},
+    {"bytesSentUser",
+     {"arangodb_client_user_connection_statistics_bytes_sent", "histogram",
+      "Bytes sent for responses, only user traffic"}},
     {"minorPageFaults",
      {"arangodb_process_statistics_minor_page_faults", "gauge/counter",
       "The number of minor faults the process has made which have not required "
@@ -439,6 +451,10 @@ auto const statBuilder = makeStatBuilder({
     {"bytesReceived",
      new arangodb_client_connection_statistics_bytes_received()},
     {"bytesSent", new arangodb_client_connection_statistics_bytes_sent()},
+    {"bytesReceivedUser",
+     new arangodb_client_user_connection_statistics_bytes_received()},
+    {"bytesSentUser",
+     new arangodb_client_user_connection_statistics_bytes_sent()},
     {"minorPageFaults",
      new arangodb_process_statistics_minor_page_faults_total()},
     {"majorPageFaults",
@@ -924,6 +940,14 @@ void StatisticsFeature::toPrometheus(std::string& result, double const& now,
                     {"250", "1000", "2000", "5000", "10000", "+Inf"}, v2, true);
     appendHistogram(result, requestStats.bytesReceived, "bytesReceived",
                     {"250", "1000", "2000", "5000", "10000", "+Inf"}, v2, true);
+
+    RequestStatistics::Snapshot requestStatsUser;
+    RequestStatistics::getSnapshot(requestStatsUser,
+                                   stats::RequestStatisticsSource::USER);
+    appendHistogram(result, requestStatsUser.bytesSent, "bytesSentUser",
+                    {"250", "1000", "2000", "5000", "10000", "+Inf"}, true);
+    appendHistogram(result, requestStatsUser.bytesReceived, "bytesReceivedUser",
+                    {"250", "1000", "2000", "5000", "10000", "+Inf"}, true);
 
     // _httpStatistics()
     using rest::RequestType;

--- a/tests/js/client/shell/traffic/shell-check-metrics-move-noncluster.js
+++ b/tests/js/client/shell/traffic/shell-check-metrics-move-noncluster.js
@@ -117,6 +117,7 @@ function checkMetricsMoveSuite() {
         let stats = getStats();
         let count = getMetric("arangodb_client_connection_statistics_bytes_sent_count");
         let metric = getMetric("arangodb_client_connection_statistics_bytes_sent_sum");
+        let metricUser = getMetric("arangodb_client_user_connection_statistics_bytes_sent_sum");
 
         // Do a few requests:
         for (let i = 0; i < 1000; ++i) {
@@ -127,6 +128,7 @@ function checkMetricsMoveSuite() {
         let stats2 = getStats();
         let count2 = getMetric("arangodb_client_connection_statistics_bytes_sent_count");
         let metric2 = getMetric("arangodb_client_connection_statistics_bytes_sent_sum");
+        let metric2User = getMetric("arangodb_client_user_connection_statistics_bytes_sent_sum");
 
         // Why 3000000? We have read 1000 docs, and the response body
         // contains a string of 3 * 1024 bytes, so 3000000 is a solid lower limit.
@@ -134,6 +136,7 @@ function checkMetricsMoveSuite() {
         assertTrue(stats2.bytesSent - stats.bytesSent > 3000000, { stats, stats2, diff: stats2.bytesSent - stats.bytesSent });
         assertTrue(stats2.bytesSent - stats.bytesSent < 2 * 3000000, { stats, stats2, diff: stats2.bytesSent - stats.bytesSent });
         assertTrue(metric2 - metric > 3000000, { metric, metric2, diff: metric2 - metric });
+        assertTrue(metric2User - metricUser > 3000000, { metricUser, metric2User, diff: metric2User - metricUser });
         assertTrue(count2 - count >= 1000, { count, count2 });
       } finally {
         db._drop(cn);
@@ -156,6 +159,7 @@ function checkMetricsMoveSuite() {
         let stats = getStats();
         let count = getMetric("arangodb_client_connection_statistics_bytes_received_count");
         let metric = getMetric("arangodb_client_connection_statistics_bytes_received_sum");
+        let metricUser = getMetric("arangodb_client_user_connection_statistics_bytes_received_sum");
 
         // Do a few requests:
         for (let i = 0; i < 1000; ++i) {
@@ -166,6 +170,7 @@ function checkMetricsMoveSuite() {
         let stats2 = getStats();
         let count2 = getMetric("arangodb_client_connection_statistics_bytes_received_count");
         let metric2 = getMetric("arangodb_client_connection_statistics_bytes_received_sum");
+        let metric2User = getMetric("arangodb_client_user_connection_statistics_bytes_received_sum");
 
         // Why 3000000? We have written 1000 docs, and the request body
         // contains a string of 3 * 1024 bytes, so 3000000 is a solid lower limit.
@@ -173,6 +178,7 @@ function checkMetricsMoveSuite() {
         assertTrue(stats2.bytesReceived - stats.bytesReceived > 3000000, { stats, stats2, diff: stats2.bytesReceived - stats.bytesReceived });
         assertTrue(stats2.bytesReceived - stats.bytesReceived < 2 * 3000000, { stats, stats2, diff: stats2.bytesReceived - stats.bytesReceived });
         assertTrue(metric2 - metric > 3000000, { metric, metric2, diff: metric2 - metric });
+        assertTrue(metric2User - metricUser > 3000000, { metricUser, metric2User, diff: metric2User - metricUser });
         assertTrue(count2 - count >= 1000, { count, count2 });
       } finally {
         db._drop(cn);


### PR DESCRIPTION
This addresses https://arangodb.atlassian.net/browse/BTS-1133

We need user only request traffic accounting, which is so far 
only in `/_admin/statistics` and not in metrics.

* Add missing metrics for user traffic: Histograms:
    `arangodb_client_user_connection_statistics_bytes_received`
    `arangodb_client_user_connection_statistics_bytes_sent`
  These numbers were so far only published via the statistics API.
  This is needed for Oasis traffic accounting.

### Scope & Purpose

*(Please describe the changes in this PR for reviewers, motivation, rationale - **mandatory**)*

- [*] :hankey: Bugfix

### Checklist

- [*] :book: CHANGELOG entry made
- [*] :books: documentation written (release notes, API changes, ...)
- [*] Backports
  - [*] Backport for 3.9: This is the backport for 3.9

#### Related Information

- [*] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/BTS-1133



