### PR TITLE
[CINFRA] Fixing CI

### DIFF
--- a/tests/Replication2/CMakeLists.txt
+++ b/tests/Replication2/CMakeLists.txt
@@ -95,8 +95,14 @@ target_link_libraries(arango_tests_replication2
     velocypack
     fmt)
 
-add_executable(arangodbtests_replication2
-  EXCLUDE_FROM_ALL)
+option(USE_SEPARATE_REPLICATION2_TESTS_BINARY
+        "Write a separate binary 'arangodbtests_replication2', containing only the Replication 2.0 tests.")
+if (USE_SEPARATE_REPLICATION2_TESTS_BINARY)
+    add_executable(arangodbtests_replication2)
+else()
+    add_executable(arangodbtests_replication2
+            EXCLUDE_FROM_ALL)
+endif()
 
 target_link_libraries(arangodbtests_replication2
     gtest

--- a/tests/test-definitions-rlog.txt
+++ b/tests/test-definitions-rlog.txt
@@ -1,6 +1,6 @@
 gtest_replication2 priority=1000
 replication2_client cluster
-replication2_server cluster -- --dumpAgencyOnError true
+replication2_server cluster buckets=3 -- --dumpAgencyOnError true
 
 # execute single test suites
 auto cluster suffix=rlog-cluster -- --dumpAgencyOnError true --test shell-replicated-logs-cluster.js

--- a/tests/test-definitions.txt
+++ b/tests/test-definitions.txt
@@ -74,7 +74,7 @@ load_balancing priority=500 cluster -- --dumpAgencyOnError true
 load_balancing_auth priority=500 cluster -- --dumpAgencyOnError true
 
 replication2_client cluster
-replication2_server cluster -- --dumpAgencyOnError true
+replication2_server cluster buckets=3 -- --dumpAgencyOnError true
 
 resilience_analyzers priority=500 cluster -- --dumpAgencyOnError true
 resilience_failover priority=750 cluster -- --dumpAgencyOnError true


### PR DESCRIPTION
### Scope & Purpose
Due to a previous change, the separate arangodb replication2 tests were not build. This PR fixes that.