### PR TITLE
Fixing rr debugger arguments

### DIFF
--- a/js/client/modules/@arangodb/testutils/instance.js
+++ b/js/client/modules/@arangodb/testutils/instance.js
@@ -630,7 +630,7 @@ class instance {
       argv = toArgv(valgrindOpts, true).concat([cmd]).concat(toArgv(args));
       cmd = this.options.valgrind;
     } else if (this.options.rr) {
-      argv = [cmd].concat(args);
+      argv = [cmd].concat(toArgv(args));
       cmd = 'rr';
     } else {
       argv = toArgv(args);


### PR DESCRIPTION
### Scope & Purpose

Currently tests will fail when passing the `--rr true` argument to `unittest`: `2022-12-01T11:15:15Z [13119] INFO [24783] {general} created database directory '[object Object]'`
This PR fixes the command line arguments passed to arangod, when rr is used.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
