### PR TITLE
[BTS-1104] Undo ResignLeadership

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,12 @@
 v3.9.6 (XXXX-XX-XX)
 -------------------
 
+* Added a feature to the ResignLeadership job. By default, it will now
+  undo the leader changes automatically after the server is restarted,
+  unless the option `undoMoves` is set to `false`. This will help to
+  make rolling upgrades and restarts less troublesome, since the shard
+  leaderships will not get unbalanced.
+
 * Add missing metrics for user traffic: Histograms:
     `arangodb_client_user_connection_statistics_bytes_received`
     `arangodb_client_user_connection_statistics_bytes_sent`

--- a/arangod/Agency/Job.cpp
+++ b/arangod/Agency/Job.cpp
@@ -67,6 +67,7 @@ std::string const healthPrefix = "/Supervision/Health/";
 std::string const asyncReplLeader = "/Plan/AsyncReplication/Leader";
 std::string const asyncReplTransientPrefix = "/AsyncReplication/";
 std::string const planAnalyzersPrefix = "/Plan/Analyzers/";
+std::string const returnLeadershipPrefix = "/Target/ReturnLeadership/";
 
 }  // namespace consensus
 }  // namespace arangodb

--- a/arangod/Agency/Job.h
+++ b/arangod/Agency/Job.h
@@ -74,6 +74,7 @@ extern std::string const healthPrefix;
 extern std::string const asyncReplLeader;
 extern std::string const asyncReplTransientPrefix;
 extern std::string const planAnalyzersPrefix;
+extern std::string const returnLeadershipPrefix;
 
 struct Job {
   struct shard_t {

--- a/arangod/Agency/MoveShard.cpp
+++ b/arangod/Agency/MoveShard.cpp
@@ -462,7 +462,7 @@ bool MoveShard::start(bool&) {
       VPackArrayBuilder guard0(&todo);
       VPackObjectBuilder guard(&todo);
       for (auto p : VPackObjectIterator(todo2.slice()[0])) {
-        std::string_view key = p.key.stringView();
+        std::string key = p.key.copyString();
         if (key != "tryUndo") {
           todo.add(key, p.value);
         } else {

--- a/arangod/Agency/MoveShard.cpp
+++ b/arangod/Agency/MoveShard.cpp
@@ -37,7 +37,8 @@ MoveShard::MoveShard(Node const& snapshot, AgentInterface* agent,
                      std::string const& jobId, std::string const& creator,
                      std::string const& database, std::string const& collection,
                      std::string const& shard, std::string const& from,
-                     std::string const& to, bool isLeader, bool remainsFollower)
+                     std::string const& to, bool isLeader, bool remainsFollower,
+                     bool tryUndo)
     : Job(NOTFOUND, snapshot, agent, jobId, creator),
       _database(database),
       _collection(collection),
@@ -47,23 +48,8 @@ MoveShard::MoveShard(Node const& snapshot, AgentInterface* agent,
       _isLeader(
           isLeader),  // will be initialized properly when information known
       _remainsFollower(remainsFollower),
-      _toServerIsFollower(false) {}
-
-MoveShard::MoveShard(Node const& snapshot, AgentInterface* agent,
-                     std::string const& jobId, std::string const& creator,
-                     std::string const& database, std::string const& collection,
-                     std::string const& shard, std::string const& from,
-                     std::string const& to, bool isLeader)
-    : Job(NOTFOUND, snapshot, agent, jobId, creator),
-      _database(database),
-      _collection(collection),
-      _shard(shard),
-      _from(id(from)),
-      _to(id(to)),
-      _isLeader(
-          isLeader),  // will be initialized properly when information known
-      _remainsFollower(isLeader),
-      _toServerIsFollower(false) {}
+      _toServerIsFollower(false),
+      _tryUndo(tryUndo) {}
 
 MoveShard::MoveShard(Node const& snapshot, AgentInterface* agent,
                      JOB_STATUS status, std::string const& jobId)
@@ -79,6 +65,7 @@ MoveShard::MoveShard(Node const& snapshot, AgentInterface* agent,
   auto tmp_remainsFollower = _snapshot.hasAsSlice(path + "remainsFollower");
   auto tmp_creator = _snapshot.hasAsString(path + "creator");
   auto tmp_parent = _snapshot.hasAsString(path + PARENT_JOB_ID);
+  auto tmp_tryUndo = _snapshot.hasAsBool(path + "tryUndo");
 
   if (tmp_database && tmp_collection && tmp_from && tmp_to && tmp_shard &&
       tmp_creator && tmp_isLeader) {
@@ -95,6 +82,9 @@ MoveShard::MoveShard(Node const& snapshot, AgentInterface* agent,
     _creator = tmp_creator.value();
     if (tmp_parent) {
       _parentJobId = std::move(*tmp_parent);
+    }
+    if (tmp_tryUndo) {
+      _tryUndo = tmp_tryUndo.value();
     }
   } else {
     std::stringstream err;
@@ -159,6 +149,7 @@ bool MoveShard::create(std::shared_ptr<VPackBuilder> envelope) {
     _jb->add("remainsFollower", VPackValue(_remainsFollower));
     _jb->add("jobId", VPackValue(_jobId));
     _jb->add("timeCreated", VPackValue(now));
+    _jb->add("tryUndo", VPackValue(_tryUndo));
     if (!_parentJobId.empty()) {
       _jb->add(PARENT_JOB_ID, VPackValue(_parentJobId));
     }
@@ -453,6 +444,30 @@ bool MoveShard::start(bool&) {
         LOG_TOPIC("34af0", WARN, Logger::SUPERVISION)
             << e.what() << ": " << __FILE__ << ":" << __LINE__;
         return false;
+      }
+    }
+  }
+
+  // We do not want to honour `_tryUndo` if this is not a leader swap,
+  // i.e. !_isLeader
+  if (_tryUndo && !_toServerIsFollower) {
+    // Unfortunately, we have to rewrite the `todo` velocypack now,
+    // we keep everything, but we unset _tryUndo:
+    _tryUndo = false;
+    Builder todo2;
+    TRI_ASSERT(todo.slice().isArray() && todo.slice()[0].isObject());
+    todo2.add(todo.slice());
+    todo.clear();  // Builder does not have a swap!
+    {
+      VPackArrayBuilder guard0(&todo);
+      VPackObjectBuilder guard(&todo);
+      for (auto p : VPackObjectIterator(todo2.slice()[0])) {
+        std::string_view key = p.key.stringView();
+        if (key != "tryUndo") {
+          todo.add(key, p.value);
+        } else {
+          todo.add("tryUndo", VPackValue(false));
+        }
       }
     }
   }
@@ -900,6 +915,10 @@ JOB_STATUS MoveShard::pendingLeader() {
         addMoveShardFromServerUnLock(trx);
         addMoveShardToServerCanUnLock(pre);
         addMoveShardFromServerCanUnLock(pre);
+
+        if (_tryUndo) {
+          addUndoMoveShard(trx, job);
+        }
       }
       // Add precondition to transaction:
       trx.add(pre.slice());
@@ -1290,4 +1309,39 @@ bool MoveShard::moveShardFinish(bool unlock, bool success,
   }
 
   return finish("", "", success, msg, std::move(payload));
+}
+
+void MoveShard::addUndoMoveShard(Builder& ops, Builder const& job) const {
+  // If we are here, we have `_isLeader` set to `true`. We also know
+  // that this was a leader swap with an in sync follower, so we can
+  // assume that.
+  std::string path = returnLeadershipPrefix + _shard;
+  // Briefly check that the place in Target is still empty:
+  if (_snapshot.has(path)) {
+    // This should not happen, since we have a lock on the `_toServer`.
+    LOG_TOPIC("abbcc", WARN, Logger::SUPERVISION)
+        << "failed to schedule undo job for shard " << _shard
+        << " since there was already one.";
+    return;
+  }
+  std::string now(timepointToString(std::chrono::system_clock::now()));
+  std::string deadline(timepointToString(std::chrono::system_clock::now() +
+                                         std::chrono::minutes(20)));
+  auto rebootId = _snapshot.hasAsUInt(basics::StringUtils::concatT(
+      curServersKnown, _from, "/", StaticStrings::RebootId));
+  if (!rebootId) {
+    // This should not happen, since we should have a rebootId for this.
+    LOG_TOPIC("abbcd", WARN, Logger::SUPERVISION)
+        << "failed to schedule undo job for shard " << _shard
+        << " since there was no rebootId for server " << _from;
+    return;
+  }
+  ops.add(VPackValue(path));
+  {
+    VPackObjectBuilder guard(&ops);
+    ops.add("timeStamp", VPackValue(now));
+    ops.add("removeIfNotStartedBy", VPackValue(deadline));
+    ops.add("rebootId", VPackValue(rebootId.value()));
+    ops.add("moveShard", job.slice());
+  }
 }

--- a/arangod/Agency/MoveShard.h
+++ b/arangod/Agency/MoveShard.h
@@ -34,13 +34,8 @@ struct MoveShard : public Job {
             std::string const& jobId, std::string const& creator,
             std::string const& database, std::string const& collection,
             std::string const& shard, std::string const& from,
-            std::string const& to, bool isLeader, bool remainsFollower);
-
-  MoveShard(Node const& snapshot, AgentInterface* agent,
-            std::string const& jobId, std::string const& creator,
-            std::string const& database, std::string const& collection,
-            std::string const& shard, std::string const& from,
-            std::string const& to, bool isLeader);
+            std::string const& to, bool isLeader, bool remainsFollower = false,
+            bool tryUndo = false);
 
   MoveShard(Node const& snapshot, AgentInterface* agent, JOB_STATUS status,
             std::string const& jobId);
@@ -65,6 +60,7 @@ struct MoveShard : public Job {
   bool _isLeader;
   bool _remainsFollower;
   bool _toServerIsFollower;
+  bool _tryUndo{false};
 
   MoveShard& withParent(std::string parentId) {
     _parentJobId = std::move(parentId);
@@ -83,6 +79,7 @@ struct MoveShard : public Job {
   void addMoveShardFromServerUnLock(Builder& ops) const;
   void addMoveShardToServerCanUnLock(Builder& ops) const;
   void addMoveShardFromServerCanUnLock(Builder& ops) const;
+  void addUndoMoveShard(Builder& ops, Builder const& job) const;
 
   bool moveShardFinish(bool unlock, bool success, std::string const& msg);
   bool checkLeaderFollowerCurrent(

--- a/arangod/Agency/ResignLeadership.cpp
+++ b/arangod/Agency/ResignLeadership.cpp
@@ -45,10 +45,12 @@ ResignLeadership::ResignLeadership(Node const& snapshot, AgentInterface* agent,
   std::string path = pos[status] + _jobId + "/";
   auto tmp_server = _snapshot.hasAsString(path + "server");
   auto tmp_creator = _snapshot.hasAsString(path + "creator");
+  auto tmp_undoMoves = _snapshot.hasAsBool(path + "undoMoves");
 
   if (tmp_server && tmp_creator) {
     _server = tmp_server.value();
     _creator = tmp_creator.value();
+    _undoMoves = tmp_undoMoves.value_or(true);
   } else {
     std::stringstream err;
     err << "Failed to find job " << _jobId << " in agency.";
@@ -167,6 +169,7 @@ bool ResignLeadership::create(std::shared_ptr<VPackBuilder> envelope) {
       _jb->add("server", VPackValue(_server));
       _jb->add("jobId", VPackValue(_jobId));
       _jb->add("creator", VPackValue(_creator));
+      _jb->add("undoMoves", VPackValue(_undoMoves));
       _jb->add("timeCreated",
                VPackValue(timepointToString(std::chrono::system_clock::now())));
     }
@@ -403,7 +406,7 @@ bool ResignLeadership::scheduleMoveShards(std::shared_ptr<Builder>& trx) {
 
           MoveShard(_snapshot, _agent, _jobId + "-" + std::to_string(sub++),
                     _jobId, database.first, collptr.first, shard.first, _server,
-                    toServer, isLeader, true)
+                    toServer, isLeader, /*remainsFollower*/ true, _undoMoves)
               .withParent(_jobId)
               .create(trx);
 

--- a/arangod/Agency/ResignLeadership.h
+++ b/arangod/Agency/ResignLeadership.h
@@ -52,6 +52,7 @@ struct ResignLeadership : public Job {
   bool scheduleMoveShards(std::shared_ptr<Builder>& trx);
 
   std::string _server;
+  bool _undoMoves{true};
 };
 }  // namespace consensus
 }  // namespace arangodb

--- a/arangod/Agency/Supervision.cpp
+++ b/arangod/Agency/Supervision.cpp
@@ -2991,7 +2991,7 @@ void Supervision::checkUndoLeaderChangeActions() {
     auto path = basics::StringUtils::joinT("/", "Plan/Collections", database,
                                            collection, "shards", shard);
     auto servers = snapshot().hasAsArray(path);
-    if (not servers) {
+    if (!servers) {
       return false;
     }
     TRI_ASSERT(servers->isArray() && servers->length() > 0);
@@ -3009,7 +3009,7 @@ void Supervision::checkUndoLeaderChangeActions() {
     auto path = basics::StringUtils::joinT("/", "Current/Collections", database,
                                            collection, shard, "servers");
     auto servers = snapshot().hasAsArray(path);
-    if (not servers) {
+    if (!servers) {
       return false;
     }
     TRI_ASSERT(servers->isArray() && servers->length() > 0);
@@ -3082,7 +3082,7 @@ void Supervision::checkUndoLeaderChangeActions() {
       };
 
   auto undos = snapshot().hasAsChildren("Target/ReturnLeadership");
-  if (not undos) {
+  if (!undos) {
     return;
   }
 

--- a/arangod/Agency/Supervision.cpp
+++ b/arangod/Agency/Supervision.cpp
@@ -34,6 +34,7 @@
 #include "Agency/FailedServer.h"
 #include "Agency/Job.h"
 #include "Agency/JobContext.h"
+#include "Agency/MoveShard.h"
 #include "Agency/RemoveFollower.h"
 #include "Agency/Store.h"
 #include "AgencyPaths.h"
@@ -1750,6 +1751,10 @@ bool Supervision::handleJobs() {
       << "Begin checkBrokenAnalyzers";
   checkBrokenAnalyzers();
 
+  LOG_TOPIC("2cd7b", TRACE, Logger::SUPERVISION)
+      << "Begin checkUndoLeaderChangeActions";
+  checkUndoLeaderChangeActions();
+
   LOG_TOPIC("00aab", TRACE, Logger::SUPERVISION) << "Begin workJobs";
   workJobs();
 
@@ -2977,4 +2982,187 @@ Node const& Supervision::snapshot() const {
                     : _spearhead.nodePtr();
   }
   return *_snapshot;
+}
+
+void Supervision::checkUndoLeaderChangeActions() {
+  auto const isServerInPlan =
+      [&](std::string_view database, std::string_view collection,
+          std::string_view shard, std::string_view server) -> bool {
+    auto path = basics::StringUtils::joinT("/", "Plan/Collections", database,
+                                           collection, "shards", shard);
+    auto servers = snapshot().hasAsArray(path);
+    if (not servers) {
+      return false;
+    }
+    TRI_ASSERT(servers->isArray() && servers->length() > 0);
+    for (size_t i = 0; i < servers->length(); ++i) {
+      if (server == servers->at(i).stringView()) {
+        return true;
+      }
+    }
+    return false;
+  };
+
+  auto const isServerInSync =
+      [&](std::string_view database, std::string_view collection,
+          std::string_view shard, std::string_view server) -> bool {
+    auto path = basics::StringUtils::joinT("/", "Current/Collections", database,
+                                           collection, shard, "servers");
+    auto servers = snapshot().hasAsArray(path);
+    if (not servers) {
+      return false;
+    }
+    TRI_ASSERT(servers->isArray() && servers->length() > 0);
+    for (size_t i = 1; i < servers->length(); ++i) {
+      if (server == servers->at(i).stringView()) {
+        return true;
+      }
+    }
+    return false;
+  };
+
+  auto const checkDeletion = [&](std::string const& shard,
+                                 std::shared_ptr<Node> entry) -> bool {
+    std::string now(timepointToString(std::chrono::system_clock::now()));
+    auto deadline = entry->hasAsString("removeIfNotStartedBy");
+    auto started = entry->hasAsString("started");
+    if (deadline) {
+      if (!started && now > deadline.value()) {
+        return true;
+      }
+    }
+    if (started) {
+      auto jobId = entry->hasAsString("jobId");
+      if (jobId) {
+        auto inTodo = _snapshot->hasAsNode(toDoPrefix + jobId.value());
+        auto inPending = _snapshot->hasAsNode(pendingPrefix + jobId.value());
+        if (!inTodo && !inPending) {
+          return true;
+        }
+      } else {
+        return true;
+        // This should not happen, since if started is there, we have a
+        // jobId.
+      }
+    }
+    auto jobOpt = entry->hasAsNode("moveShard");
+    if (!jobOpt) {
+      return true;
+    }
+    Node const& job(jobOpt.value());
+    auto database = job.hasAsString("database");
+    auto collection = job.hasAsString("collection");
+    auto server = job.hasAsString("fromServer");
+    if (!server) {
+      return true;
+    } else {
+      if (!isServerInPlan(database.value(), collection.value(), shard,
+                          server.value())) {
+        return true;
+      }
+    }
+    return false;
+  };
+
+  auto const reclaimShard =
+      [&](std::shared_ptr<VPackBuilder> const& trx, std::string const& database,
+          std::string const& collection, std::string const& shard,
+          std::string const& newLeader, std::string const& oldLeader) {
+        uint64_t jobId = _jobId++;
+        MoveShard(*_snapshot, _agent, std::to_string(jobId), "supervision",
+                  database, collection, shard, newLeader, oldLeader,
+                  /*isLeader*/ true, /*remainsFollower*/ true,
+                  /*tryUndo*/ false)
+            .create(trx);
+
+        std::string now(timepointToString(std::chrono::system_clock::now()));
+        std::string path = returnLeadershipPrefix + std::string(shard) + "/";
+        trx->add(path + "started", VPackValue(now));
+        trx->add(path + "jobId", VPackValue(std::to_string(jobId)));
+      };
+
+  auto undos = snapshot().hasAsChildren("Target/ReturnLeadership");
+  if (not undos) {
+    return;
+  }
+
+  // Collect a transaction:
+  auto trx = std::make_shared<VPackBuilder>();
+  {
+    VPackArrayBuilder guard(trx.get());
+    VPackObjectBuilder guard2(trx.get());
+
+    for (auto const& [shard, entry] : undos->get()) {
+      // First check some conditions under which we simply get rid of the
+      // entry:
+      //  - deadline exceeded (and not yet started)
+      //  - dependent MoveShard gone (and started)
+      //  - fromServer no longer in Plan
+      if (checkDeletion(shard, entry)) {
+        // Let's remove the entry:
+        trx->add(VPackValue(returnLeadershipPrefix + shard));
+        {
+          VPackObjectBuilder guard3(trx.get());
+          trx->add("op", VPackValue("delete"));
+        }
+        continue;
+      }
+
+      // Now the job is still valid, let's see if it fires. Note that we
+      // do not get here, if the job is not found!
+      auto jobOpt = entry->hasAsNode("moveShard");
+      TRI_ASSERT(jobOpt);
+      Node const& job = jobOpt.value();
+
+      // We need to check if:
+      //  - it is not yet started
+      //  - the fromServer is GOOD
+      //  - it is in sync for the shard (and all distributeShardsLike shards)
+      //  - its current rebootId is larger than the stored one
+      auto started = entry->hasAsString("started");
+      if (started) {
+        continue;
+      }
+
+      auto database = job.hasAsString("database");
+      auto collection = job.hasAsString("collection");
+      auto fromServer = job.hasAsString("fromServer");
+      auto toServer = job.hasAsString("toServer");
+      TRI_ASSERT(fromServer && toServer && database && collection);
+
+      // get server health
+      if (serverHealth(fromServer.value()) != HEALTH_STATUS_GOOD) {
+        continue;
+      }
+
+      if (!isServerInSync(database.value(), collection.value(), shard,
+                          fromServer.value())) {
+        continue;
+      }
+
+      // get current reboot id
+      auto rebootId = snapshot().hasAsUInt(basics::StringUtils::concatT(
+          curServersKnown, fromServer.value(), "/", StaticStrings::RebootId));
+      if (!rebootId) {
+        continue;
+      }
+
+      // check if reboot id is bigger than the stored one
+      auto storedRebootId = entry->hasAsUInt("rebootId");
+      if (!storedRebootId || storedRebootId.value() < rebootId.value()) {
+        reclaimShard(trx, database.value(), collection.value(), shard,
+                     toServer.value(), fromServer.value());
+      }
+    }
+  }
+
+  // And finally write out the transaction:
+  if (trx->slice()[0].length() > 0) {
+    write_ret_t res = singleWriteTransaction(_agent, *trx, false);
+
+    if (!res.accepted || (res.indices.size() == 1 && res.indices[0] == 0)) {
+      LOG_TOPIC("fad4b", INFO, Logger::SUPERVISION)
+          << "Failed to modify returnLeadership jobs: " << trx->toJson();
+    }
+  }
 }

--- a/arangod/Agency/Supervision.h
+++ b/arangod/Agency/Supervision.h
@@ -170,6 +170,9 @@ class Supervision : public arangodb::Thread {
   /// @brief Upgrade agency to supervision overhaul jobs
   void upgradeHealthRecords(VPackBuilder&);
 
+  /// @brief Check undo-leader-change-actions
+  void checkUndoLeaderChangeActions();
+
   /// @brief Check for orphaned index creations, which have been successfully
   /// built
   void readyOrphanedIndexCreations();
@@ -206,20 +209,8 @@ class Supervision : public arangodb::Thread {
   void enforceReplication();
 
  private:
-  /// @brief Move shard from one db server to other db server
-  bool moveShard(std::string const& from, std::string const& to);
-
-  /// @brief Move shard from one db server to other db server
-  bool replicateShard(std::string const& to);
-
-  /// @brief Move shard from one db server to other db server
-  bool removeShard(std::string const& from);
-
   /// @brief Check machines in agency
   std::vector<check_t> check(std::string const&);
-
-  // @brief Check shards in agency
-  std::vector<check_t> checkShards();
 
   /// @brief Cleanup old Supervision jobs
   void cleanupFinishedAndFailedJobs();

--- a/arangod/RestHandler/RestAdminClusterHandler.cpp
+++ b/arangod/RestHandler/RestAdminClusterHandler.cpp
@@ -640,6 +640,7 @@ RestAdminClusterHandler::MoveShardContext::fromVelocyPack(VPackSlice slice) {
     auto fromServer = slice.get("fromServer");
     auto toServer = slice.get("toServer");
     auto remainsFollower = slice.get("remainsFollower");
+    auto tryUndo = slice.get("tryUndo");
 
     bool valid = collection.isString() && shard.isString() &&
                  fromServer.isString() && toServer.isString();
@@ -650,7 +651,8 @@ RestAdminClusterHandler::MoveShardContext::fromVelocyPack(VPackSlice slice) {
       return std::make_unique<MoveShardContext>(
           std::move(databaseStr), collection.copyString(), shard.copyString(),
           fromServer.copyString(), toServer.copyString(), std::string{},
-          remainsFollower.isNone() || remainsFollower.isTrue());
+          remainsFollower.isNone() || remainsFollower.isTrue(),
+          tryUndo.isTrue());
     }
   }
 
@@ -781,6 +783,7 @@ RestAdminClusterHandler::FutureVoid RestAdminClusterHandler::createMoveShard(
                    builder.add("remainsFollower",
                                isLeader ? VPackValue(ctx->remainsFollower)
                                         : VPackValue(false));
+                   builder.add("tryUndo", VPackValue(ctx->tryUndo));
                    builder.add("creator",
                                VPackValue(ServerState::instance()->getId()));
                    builder.add("timeCreated",
@@ -1154,7 +1157,7 @@ RestStatus RestAdminClusterHandler::handleSingleServerJob(
     VPackSlice server = body.get("server");
     if (server.isString()) {
       std::string serverId = resolveServerNameID(server.copyString());
-      return handleCreateSingleServerJob(job, serverId);
+      return handleCreateSingleServerJob(job, serverId, body);
     }
   }
 
@@ -1164,7 +1167,7 @@ RestStatus RestAdminClusterHandler::handleSingleServerJob(
 }
 
 RestStatus RestAdminClusterHandler::handleCreateSingleServerJob(
-    std::string const& job, std::string const& serverId) {
+    std::string const& job, std::string const& serverId, VPackSlice body) {
   std::string jobId = std::to_string(
       server().getFeature<ClusterFeature>().clusterInfo().uniqid());
   auto jobToDoPath =
@@ -1177,6 +1180,11 @@ RestStatus RestAdminClusterHandler::handleCreateSingleServerJob(
     builder.add("server", VPackValue(serverId));
     builder.add("jobId", VPackValue(jobId));
     builder.add("creator", VPackValue(ServerState::instance()->getId()));
+    if (job == "resignLeadership") {
+      if (body.isObject() && body.hasKey("undoMoves")) {
+        builder.add("undoMoves", VPackValue(body.get("undoMoves").isTrue()));
+      }
+    }
     builder.add(
         "timeCreated",
         VPackValue(timepointToString(std::chrono::system_clock::now())));

--- a/arangod/RestHandler/RestAdminClusterHandler.h
+++ b/arangod/RestHandler/RestAdminClusterHandler.h
@@ -105,17 +105,20 @@ class RestAdminClusterHandler : public RestVocbaseBaseHandler {
     std::string toServer;
     std::string collectionID;
     bool remainsFollower;
+    bool tryUndo;
 
     MoveShardContext(std::string database, std::string collection,
                      std::string shard, std::string from, std::string to,
-                     std::string collectionID, bool remainsFollower)
+                     std::string collectionID, bool remainsFollower,
+                     bool tryUndo = false)
         : database(std::move(database)),
           collection(std::move(collection)),
           shard(std::move(shard)),
           fromServer(std::move(from)),
           toServer(std::move(to)),
           collectionID(std::move(collectionID)),
-          remainsFollower(true) {}
+          remainsFollower(remainsFollower),
+          tryUndo(tryUndo) {}
 
     static std::unique_ptr<MoveShardContext> fromVelocyPack(
         arangodb::velocypack::Slice slice);
@@ -125,7 +128,8 @@ class RestAdminClusterHandler : public RestVocbaseBaseHandler {
 
   RestStatus handleSingleServerJob(std::string const& job);
   RestStatus handleCreateSingleServerJob(std::string const& job,
-                                         std::string const& server);
+                                         std::string const& server,
+                                         VPackSlice body);
 
   typedef std::chrono::steady_clock clock;
   typedef futures::Future<futures::Unit> FutureVoid;

--- a/tests/Agency/MoveShardTest.cpp
+++ b/tests/Agency/MoveShardTest.cpp
@@ -112,7 +112,7 @@ Node createRootNode() {
 }
 
 VPackBuilder createJob(std::string const& collection, std::string const& from,
-                       std::string const& to) {
+                       std::string const& to, bool tryUndo = false) {
   VPackBuilder builder;
   {
     VPackObjectBuilder b(&builder);
@@ -125,6 +125,7 @@ VPackBuilder createJob(std::string const& collection, std::string const& from,
     builder.add("fromServer", VPackValue(from));
     builder.add("toServer", VPackValue(to));
     builder.add("isLeader", VPackValue(from == SHARD_LEADER));
+    builder.add("tryUndo", VPackValue(tryUndo));
   }
   return builder;
 }
@@ -903,6 +904,132 @@ TEST_F(MoveShardTest,
   Verify(Method(mockAgent, write));
 }
 
+TEST_F(
+    MoveShardTest,
+    the_job_should_be_moved_to_pending_when_everything_is_ok_undo_set_to_false) {
+  std::function<std::unique_ptr<VPackBuilder>(velocypack::Slice,
+                                              std::string const&)>
+      createTestStructure = [&](velocypack::Slice s, std::string const& path) {
+        auto builder = std::make_unique<velocypack::Builder>();
+        if (s.isObject()) {
+          builder->add(VPackValue(VPackValueType::Object));
+          for (auto it : VPackObjectIterator(s)) {
+            auto childBuilder =
+                createTestStructure(it.value, path + "/" + it.key.copyString());
+            if (childBuilder) {
+              builder->add(it.key.copyString(), childBuilder->slice());
+            }
+          }
+
+          if (path == "/arango/Target/ToDo") {
+            builder->add(
+                jobId,
+                createJob(COLLECTION, SHARD_LEADER, FREE_SERVER, true).slice());
+          }
+          builder->close();
+        } else {
+          builder->add(s);
+        }
+        return builder;
+      };
+
+  Mock<AgentInterface> mockAgent;
+  When(Method(mockAgent, write))
+      .AlwaysDo([&](query_t const& q,
+                    consensus::AgentInterface::WriteMode w) -> write_ret_t {
+        std::string sourceKey = "/arango/Target/ToDo/1";
+        EXPECT_EQ(std::string(q->slice().typeName()), "array");
+        EXPECT_EQ(q->slice().length(), 1);
+        EXPECT_EQ(std::string(q->slice()[0].typeName()), "array");
+        EXPECT_EQ(q->slice()[0].length(), 2);
+        EXPECT_EQ(std::string(q->slice()[0][0].typeName()), "object");
+        EXPECT_EQ(std::string(q->slice()[0][1].typeName()), "object");
+
+        auto writes = q->slice()[0][0];
+        EXPECT_EQ(std::string(writes.get(sourceKey).typeName()), "object");
+        EXPECT_TRUE(std::string(writes.get(sourceKey).get("op").typeName()) ==
+                    "string");
+        EXPECT_EQ(writes.get(sourceKey).get("op").copyString(), "delete");
+        EXPECT_TRUE(
+            writes.get("/arango/Supervision/Shards/" + SHARD).copyString() ==
+            "1");
+        EXPECT_TRUE(writes.get("/arango/Supervision/DBServers/" + FREE_SERVER)
+                        .get("op")
+                        .isEqualString("read-lock"));
+        EXPECT_TRUE(writes.get("/arango/Supervision/DBServers/" + FREE_SERVER)
+                        .get("by")
+                        .isEqualString("1"));
+        EXPECT_TRUE(writes.get("/arango/Plan/Version").get("op").copyString() ==
+                    "increment");
+        EXPECT_TRUE(
+            std::string(writes.get("/arango/Target/Pending/1").typeName()) ==
+            "object");
+        EXPECT_TRUE(std::string(writes.get("/arango/Target/Pending/1")
+                                    .get("timeStarted")
+                                    .typeName()) == "string");
+        EXPECT_TRUE(
+            writes.get("/arango/Target/Pending/1").get("tryUndo").isFalse());
+        EXPECT_TRUE(writes
+                        .get("/arango/Plan/Collections/" + DATABASE + "/" +
+                             COLLECTION + "/shards/" + SHARD)
+                        .length() == 3);  // leader, oldFollower, newLeader
+        EXPECT_TRUE(writes
+                        .get("/arango/Plan/Collections/" + DATABASE + "/" +
+                             COLLECTION + "/shards/" + SHARD)[0]
+                        .copyString() == SHARD_LEADER);
+
+        // order not really relevant ... assume it might appear anyway
+        auto followers = writes.get("/arango/Plan/Collections/" + DATABASE +
+                                    "/" + COLLECTION + "/shards/" + SHARD);
+        bool found = false;
+        for (auto const& server : VPackArrayIterator(followers)) {
+          if (server.copyString() == FREE_SERVER) {
+            found = true;
+          }
+        }
+        EXPECT_TRUE(found);
+
+        auto preconditions = q->slice()[0][1];
+        EXPECT_TRUE(preconditions.get("/arango/Target/CleanedServers")
+                        .get("old")
+                        .toJson() == "[]");
+        EXPECT_TRUE(preconditions.get("/arango/Target/FailedServers")
+                        .get("old")
+                        .toJson() == "{}");
+        EXPECT_TRUE(
+            preconditions
+                .get("/arango/Supervision/Health/" + FREE_SERVER + "/Status")
+                .get("old")
+                .copyString() == "GOOD");
+        EXPECT_TRUE(
+            preconditions.get("/arango/Supervision/DBServers/" + FREE_SERVER)
+                .get("can-read-lock")
+                .isEqualString("1"));
+        EXPECT_TRUE(preconditions.get("/arango/Supervision/Shards/" + SHARD)
+                        .get("oldEmpty")
+                        .getBool() == true);
+        EXPECT_TRUE(preconditions
+                        .get("/arango/Plan/Collections/" + DATABASE + "/" +
+                             COLLECTION + "/shards/" + SHARD)
+                        .get("old")
+                        .toJson() ==
+                    "[\"" + SHARD_LEADER + "\",\"" + SHARD_FOLLOWER1 + "\"]");
+
+        return fakeWriteResult;
+      });
+  When(Method(mockAgent, waitFor)).AlwaysReturn();
+
+  AgentInterface& agent = mockAgent.get();
+
+  auto builder = createTestStructure(baseStructure.toBuilder().slice(), "");
+  ASSERT_TRUE(builder);
+  Node agency = createAgencyFromBuilder(*builder);
+
+  auto moveShard = MoveShard(agency, &agent, TODO, jobId);
+  moveShard.start(aborts);
+  Verify(Method(mockAgent, write));
+}
+
 TEST_F(MoveShardTest, moving_from_a_follower_should_be_possible) {
   std::function<std::unique_ptr<VPackBuilder>(VPackSlice const&,
                                               std::string const&)>
@@ -1454,6 +1581,209 @@ TEST_F(MoveShardTest, if_the_job_is_done_it_should_properly_finish_itself) {
                              COLLECTION + "/shards/" + SHARD)
                         .get("old")
                         .length() == 3);
+
+        return fakeWriteResult;
+      });
+  AgentInterface& agent = mockAgent.get();
+
+  auto moveShard = MoveShard(agency, &agent, PENDING, jobId);
+  moveShard.run(aborts);
+  Verify(Method(mockAgent, write));
+}
+
+TEST_F(MoveShardTest,
+       if_the_job_is_done_it_should_properly_finish_itself_leader_change) {
+  std::function<std::unique_ptr<VPackBuilder>(velocypack::Slice,
+                                              std::string const&)>
+      createTestStructure = [&](velocypack::Slice s, std::string const& path) {
+        auto builder = std::make_unique<velocypack::Builder>();
+        if (s.isObject()) {
+          builder->add(VPackValue(VPackValueType::Object));
+          for (auto it : VPackObjectIterator(s)) {
+            auto childBuilder =
+                createTestStructure(it.value, path + "/" + it.key.copyString());
+            if (childBuilder) {
+              builder->add(it.key.copyString(), childBuilder->slice());
+            }
+          }
+
+          if (path == "/arango/Target/Pending") {
+            VPackBuilder pendingJob;
+            {
+              VPackObjectBuilder b(&pendingJob);
+              auto plainJob =
+                  createJob(COLLECTION, SHARD_LEADER, SHARD_FOLLOWER1);
+              for (auto it : VPackObjectIterator(plainJob.slice())) {
+                pendingJob.add(it.key.copyString(), it.value);
+              }
+              pendingJob.add("timeCreated",
+                             VPackValue(timepointToString(
+                                 std::chrono::system_clock::now())));
+            }
+            builder->add(jobId, pendingJob.slice());
+          }
+          builder->close();
+        } else {
+          if (path == "/arango/Current/Collections/" + DATABASE + "/" +
+                          COLLECTION + "/" + SHARD + "/servers") {
+            builder->add(VPackValue(VPackValueType::Array));
+            builder->add(VPackValue(SHARD_FOLLOWER1));
+            builder->add(VPackValue(SHARD_LEADER));
+            builder->close();
+          } else if (path == "/arango/Plan/Collections/" + DATABASE + "/" +
+                                 COLLECTION + "/shards/" + SHARD) {
+            builder->add(VPackValue(VPackValueType::Array));
+            builder->add(VPackValue(SHARD_FOLLOWER1));
+            builder->add(VPackValue(SHARD_LEADER));
+            builder->close();
+          } else {
+            builder->add(s);
+          }
+        }
+        return builder;
+      };
+
+  auto builder = createTestStructure(baseStructure.toBuilder().slice(), "");
+  Node agency = createAgencyFromBuilder(*builder);
+
+  Mock<AgentInterface> mockAgent;
+  When(Method(mockAgent, waitFor)).AlwaysReturn();
+  When(Method(mockAgent, write))
+      .Do([&](query_t const& q,
+              consensus::AgentInterface::WriteMode w) -> write_ret_t {
+        auto writes = q->slice()[0][0];
+        EXPECT_TRUE(
+            writes.get("/arango/Target/Pending/1").get("op").copyString() ==
+            "delete");
+        EXPECT_TRUE(
+            std::string(writes.get("/arango/Target/Finished/1").typeName()) ==
+            "object");
+        EXPECT_TRUE(writes.get("/arango/Supervision/Shards/" + SHARD)
+                        .get("op")
+                        .copyString() == "delete");
+        EXPECT_TRUE(writes.get("/arango/Supervision/DBServers/" + SHARD_LEADER)
+                        .get("op")
+                        .isEqualString("read-unlock"));
+        EXPECT_TRUE(
+            writes.get("/arango/Supervision/DBServers/" + SHARD_FOLLOWER1)
+                .get("op")
+                .isEqualString("read-unlock"));
+        VPackSlice undo =
+            writes.get("/arango/Target/ReturnLeadership/" + SHARD);
+        EXPECT_TRUE(undo.isNone());
+
+        auto preconditions = q->slice()[0][1];
+        EXPECT_TRUE(preconditions
+                        .get("/arango/Plan/Collections/" + DATABASE + "/" +
+                             COLLECTION + "/shards/" + SHARD)
+                        .get("old")
+                        .length() == 2);
+
+        return fakeWriteResult;
+      });
+  AgentInterface& agent = mockAgent.get();
+
+  auto moveShard = MoveShard(agency, &agent, PENDING, jobId);
+  moveShard.run(aborts);
+  Verify(Method(mockAgent, write));
+}
+
+TEST_F(
+    MoveShardTest,
+    if_the_job_is_done_it_should_properly_finish_itself_leader_change_with_undo) {
+  std::function<std::unique_ptr<VPackBuilder>(velocypack::Slice,
+                                              std::string const&)>
+      createTestStructure = [&](velocypack::Slice s, std::string const& path) {
+        auto builder = std::make_unique<velocypack::Builder>();
+        if (s.isObject()) {
+          builder->add(VPackValue(VPackValueType::Object));
+          for (auto it : VPackObjectIterator(s)) {
+            auto childBuilder =
+                createTestStructure(it.value, path + "/" + it.key.copyString());
+            if (childBuilder) {
+              builder->add(it.key.copyString(), childBuilder->slice());
+            }
+          }
+
+          if (path == "/arango/Target/Pending") {
+            VPackBuilder pendingJob;
+            {
+              VPackObjectBuilder b(&pendingJob);
+              auto plainJob =
+                  createJob(COLLECTION, SHARD_LEADER, SHARD_FOLLOWER1, true);
+              for (auto it : VPackObjectIterator(plainJob.slice())) {
+                pendingJob.add(it.key.copyString(), it.value);
+              }
+              pendingJob.add("timeCreated",
+                             VPackValue(timepointToString(
+                                 std::chrono::system_clock::now())));
+            }
+            builder->add(jobId, pendingJob.slice());
+          }
+          if (path == "/arango/Current/ServersKnown") {
+            VPackObjectBuilder guard(builder.get(), SHARD_LEADER);
+            builder->add("rebootId", VPackValue(17));
+          }
+          builder->close();
+        } else {
+          if (path == "/arango/Current/Collections/" + DATABASE + "/" +
+                          COLLECTION + "/" + SHARD + "/servers") {
+            builder->add(VPackValue(VPackValueType::Array));
+            builder->add(VPackValue(SHARD_FOLLOWER1));
+            builder->add(VPackValue(SHARD_LEADER));
+            builder->close();
+          } else if (path == "/arango/Plan/Collections/" + DATABASE + "/" +
+                                 COLLECTION + "/shards/" + SHARD) {
+            builder->add(VPackValue(VPackValueType::Array));
+            builder->add(VPackValue(SHARD_FOLLOWER1));
+            builder->add(VPackValue(SHARD_LEADER));
+            builder->close();
+          } else {
+            builder->add(s);
+          }
+        }
+        return builder;
+      };
+
+  auto builder = createTestStructure(baseStructure.toBuilder().slice(), "");
+  Node agency = createAgencyFromBuilder(*builder);
+
+  Mock<AgentInterface> mockAgent;
+  When(Method(mockAgent, waitFor)).AlwaysReturn();
+  When(Method(mockAgent, write))
+      .Do([&](query_t const& q,
+              consensus::AgentInterface::WriteMode w) -> write_ret_t {
+        auto writes = q->slice()[0][0];
+        EXPECT_TRUE(
+            writes.get("/arango/Target/Pending/1").get("op").copyString() ==
+            "delete");
+        EXPECT_TRUE(
+            std::string(writes.get("/arango/Target/Finished/1").typeName()) ==
+            "object");
+        EXPECT_TRUE(writes.get("/arango/Supervision/Shards/" + SHARD)
+                        .get("op")
+                        .copyString() == "delete");
+        EXPECT_TRUE(writes.get("/arango/Supervision/DBServers/" + SHARD_LEADER)
+                        .get("op")
+                        .isEqualString("read-unlock"));
+        EXPECT_TRUE(
+            writes.get("/arango/Supervision/DBServers/" + SHARD_FOLLOWER1)
+                .get("op")
+                .isEqualString("read-unlock"));
+        VPackSlice undo =
+            writes.get("/arango/Target/ReturnLeadership/" + SHARD);
+        VPackSlice guck = undo.get("rebootId");
+        VPackSlice move = undo.get("moveShard");
+        EXPECT_TRUE(guck.isInteger());
+        EXPECT_TRUE(guck.getNumber<int64_t>() == 17);
+        EXPECT_TRUE(move.get("shard").isEqualString(SHARD));
+
+        auto preconditions = q->slice()[0][1];
+        EXPECT_TRUE(preconditions
+                        .get("/arango/Plan/Collections/" + DATABASE + "/" +
+                             COLLECTION + "/shards/" + SHARD)
+                        .get("old")
+                        .length() == 2);
 
         return fakeWriteResult;
       });

--- a/tests/Agency/MoveShardTest.json
+++ b/tests/Agency/MoveShardTest.json
@@ -13,7 +13,8 @@ R"=(
             }
           }
         }
-      }
+      },
+      "ServersKnown": {}
     },
     "Plan": {
       "Collections": {

--- a/tests/js/server/resilience/move/moving-shards-cluster.js
+++ b/tests/js/server/resilience/move/moving-shards-cluster.js
@@ -39,6 +39,93 @@ const queryAgencyJob = require("@arangodb/testutils/cluster-test-helper").queryA
 const deriveTestSuite = require('@arangodb/test-helper').deriveTestSuite;
 const errors = internal.errors;
 const request = require('@arangodb/request');
+const serverHelper = require("@arangodb/test-helper");
+
+const waitFor = function (checkFn, maxTries = 240, onErrorCallback) {
+  let count = 0;
+  let result = null;
+  while (count < maxTries) {
+    result = checkFn();
+    if (result === true || result === undefined) {
+      return result;
+    }
+    if (!(result instanceof Error)) {
+      throw Error("expected error");
+    }
+    count += 1;
+    if (count % 10 === 0) {
+      console.log(result);
+    }
+    wait(0.5); // 240 * .5s = 2 minutes
+  }
+  if (onErrorCallback !== undefined) {
+    onErrorCallback(result);
+  } else {
+    throw result;
+  }
+};
+
+const getServerProcessID = function (serverId) {
+  // Now look for instanceManager:
+  let pos = _.findIndex(global.instanceManager.arangods,
+      x => x.id === serverId);
+  return global.instanceManager.arangods[pos].pid;
+};
+
+const stopServerImpl = function (serverId) {
+  console.log(`suspending server ${serverId}`);
+  let result = require('internal').suspendExternal(getServerProcessID(serverId));
+  if (!result) {
+    throw Error("Failed to suspend server");
+  }
+};
+
+const continueServerImpl = function (serverId) {
+  console.log(`continuing server ${serverId}`);
+  let result = require('internal').continueExternal(getServerProcessID(serverId));
+  if (!result) {
+    throw Error("Failed to continue server");
+  }
+};
+
+const readAgencyValueAt = function (key) {
+  const response = serverHelper.agency.get(key);
+  const path = ['arango', ...key.split('/')];
+  let result = response;
+  for (const p of path) {
+    if (result === undefined) {
+      return undefined;
+    }
+    result = result[p];
+  }
+  return result;
+};
+
+const getServerHealth = function (serverId) {
+  return readAgencyValueAt(`Supervision/Health/${serverId}/Status`);
+};
+
+const checkServerHealth = function (serverId, value) {
+  return function () {
+    if (value === getServerHealth(serverId)) {
+      return true;
+    }
+    return Error(`${serverId} is not ${value}`);
+  };
+};
+
+const serverHealthy = (serverId) => checkServerHealth(serverId, "GOOD");
+const serverFailed = (serverId) => checkServerHealth(serverId, "FAILED");
+
+const continueServerWaitOk = function (serverId) {
+  continueServerImpl(serverId);
+  waitFor(serverHealthy(serverId));
+};
+
+const stopServerWaitFailed = function (serverId) {
+  stopServerImpl(serverId);
+  waitFor(serverFailed(serverId));
+};
 
 // in the `useData` case, use this many documents:
 const numDocuments = 1000;
@@ -284,6 +371,29 @@ function MovingShardsSuite ({useData}) {
     return true;
   }
 
+  function findLeaderShardsForServer(id) {
+    let result = [];
+    for (var i = 0; i <  c.length ; ++i) {
+      global.ArangoClusterInfo.flush();
+      var servers = findCollectionServers("_system", c[i].name());
+      if (servers.indexOf(id) === 0 && servers.length !== 1) {
+        result.push(c[i].name());
+      }
+    }
+    return result;
+  }
+
+  function waitForShardLeader(id, expectedShards) {
+    waitFor(function () {
+      const shards = findLeaderShardsForServer(id);
+      if (!_.isEqual(shards, expectedShards)) {
+        return Error(`expected shards to be ${expectedShards}, but found ${shards}`);
+      }
+      return true;
+    });
+    return true;
+  }
+
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief test whether or not a server is clean
 ////////////////////////////////////////////////////////////////////////////////
@@ -410,13 +520,13 @@ function MovingShardsSuite ({useData}) {
 /// @brief request a dbserver to resign:
 ////////////////////////////////////////////////////////////////////////////////
 
-  function resignLeadership(id) {
+  function resignLeadership(id, undoMoves = false) {
     var coordEndpoint =
         global.ArangoClusterInfo.getServerEndpoint("Coordinator0001");
     var request = require("@arangodb/request");
     var endpointToURL = require("@arangodb/cluster").endpointToURL;
     var url = endpointToURL(coordEndpoint);
-    var body = {"server": id};
+    var body = {"server": id, undoMoves};
     var result;
     try {
       result = request({ method: "POST",
@@ -908,9 +1018,40 @@ function MovingShardsSuite ({useData}) {
     testResignLeadership : function() {
       assertTrue(waitForSynchronousReplication("_system"));
       var servers = findCollectionServers("_system", c[0].name());
-      var toResign = servers[1];
+      var toResign = servers[0];
       assertTrue(resignLeadership(toResign));
       assertTrue(testServerNoLeader(toResign));
+      assertTrue(waitForSupervision());
+      checkCollectionContents();
+    },
+
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief resign leadership for a dbserver and wait for restore
+////////////////////////////////////////////////////////////////////////////////
+
+    testResignLeadershipWithUndo: function () {
+      assertTrue(waitForSynchronousReplication("_system"));
+      var servers = findCollectionServers("_system", c[0].name());
+      var toResign = servers[0];
+      const shards = findLeaderShardsForServer(toResign);
+      assertTrue(resignLeadership(toResign, true));
+      assertTrue(testServerNoLeader(toResign));
+      assertTrue(waitForSupervision());
+
+      checkCollectionContents();
+      // now suspend that server
+      stopServerWaitFailed(toResign);
+
+      // Wait until FailedServer job is executed, then the RebootId is
+      // increased, which would also happen in a proper reboot scenario.
+      assertTrue(waitForSupervision());
+
+      // restart the server
+      continueServerWaitOk(toResign);
+
+      // now wait for the server to become leader again for shards
+      assertTrue(waitForShardLeader(toResign, shards));
       assertTrue(waitForSupervision());
       checkCollectionContents();
     },

--- a/tests/js/server/resilience/move/moving-shards-cluster.js
+++ b/tests/js/server/resilience/move/moving-shards-cluster.js
@@ -39,7 +39,6 @@ const queryAgencyJob = require("@arangodb/testutils/cluster-test-helper").queryA
 const deriveTestSuite = require('@arangodb/test-helper').deriveTestSuite;
 const errors = internal.errors;
 const request = require('@arangodb/request');
-const serverHelper = require("@arangodb/test-helper");
 
 const waitFor = function (checkFn, maxTries = 240, onErrorCallback) {
   let count = 0;

--- a/tests/js/server/resilience/move/moving-shards-cluster.js
+++ b/tests/js/server/resilience/move/moving-shards-cluster.js
@@ -183,7 +183,7 @@ function delaySupervisionFailoverActions(value) {
     arangod => arangod.role === "agent").map(
     arangod => arangod.url);
   for (let a of agents) {
-    res = request({url: a + "/_api/agency/config",
+    const res = request({url: a + "/_api/agency/config",
                    method: "PUT",
                    body: JSON.stringify(
                      {delayAddFollower: value, delayFailedFollower: value})});

--- a/tests/js/server/resilience/move/moving-shards-cluster.js
+++ b/tests/js/server/resilience/move/moving-shards-cluster.js
@@ -67,9 +67,9 @@ const waitFor = function (checkFn, maxTries = 240, onErrorCallback) {
 
 const getServerProcessID = function (serverId) {
   // Now look for instanceManager:
-  let pos = _.findIndex(global.instanceManager.arangods,
+  let pos = _.findIndex(global.instanceInfo.arangods,
       x => x.id === serverId);
-  return global.instanceManager.arangods[pos].pid;
+  return global.instanceInfo.arangods[pos].pid;
 };
 
 const stopServerImpl = function (serverId) {
@@ -89,7 +89,7 @@ const continueServerImpl = function (serverId) {
 };
 
 const readAgencyValueAt = function (key) {
-  const response = serverHelper.agency.get(key);
+  const response = ArangoAgency.get(key);
   const path = ['arango', ...key.split('/')];
   let result = response;
   for (const p of path) {


### PR DESCRIPTION
### Scope & Purpose
The purpose of this PR is https://arangodb.atlassian.net/browse/BTS-1104. The design document is here:
https://github.com/arangodb/documents/pull/122

1. The `resignLeadership` job will schedule its `MoveShard` jobs with a `tryUndo: true` attribute.
2. This will lead to the effect that the `MoveShard` job (for leader change) is undone once the old leader has been restarted.
3. This works by putting an entry in `/Target/ReturnLeadership` which the `Supervision` observes.

For detailed rules see the design document.

- [x] :pizza: New feature

### Checklist

- [x] Tests
  - [x] C++ **Unit tests**
  - [x] **integration tests**
- [*] :book: CHANGELOG entry made
- [*] Backports
  - [*] Backport for 3.9: This is it.

#### Related Information

- [*] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/BTS-1104
- [*] Design document: https://github.com/arangodb/documents/pull/122
- [*] Devel PR: https://github.com/arangodb/arangodb/pull/17624



