### PR TITLE
validate `replicationFactor` when creating new databases

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,12 @@
 v3.10.2 (XXXX-XX-XX)
 --------------------
 
+* Disallow creating new databases with a `replicationFactor` value set to
+  a value lower than `--cluster.min-replication-factor` or higher than
+  `--cluster.max-replication-factor`. Previously the `replicationFactor`
+  settings for new databases were not bounds-checked, only for new
+  collections.
+
 * Add missing metrics for user traffic: Histograms:
     `arangodb_client_user_connection_statistics_bytes_received`
     `arangodb_client_user_connection_statistics_bytes_sent`

--- a/arangod/VocBase/VocbaseInfo.cpp
+++ b/arangod/VocBase/VocbaseInfo.cpp
@@ -63,8 +63,7 @@ Result CreateDatabaseInfo::load(std::string const& name, uint64_t id) {
   return checkOptions();
 }
 
-Result CreateDatabaseInfo::load(VPackSlice const& options,
-                                VPackSlice const& users) {
+Result CreateDatabaseInfo::load(VPackSlice options, VPackSlice users) {
   Result res = extractOptions(options, true /*getId*/, true /*getUser*/);
   if (!res.ok()) {
     return res;
@@ -82,9 +81,8 @@ Result CreateDatabaseInfo::load(VPackSlice const& options,
   return checkOptions();
 }
 
-Result CreateDatabaseInfo::load(std::string const& name,
-                                VPackSlice const& options,
-                                VPackSlice const& users) {
+Result CreateDatabaseInfo::load(std::string const& name, VPackSlice options,
+                                VPackSlice users) {
   _name = methods::Databases::normalizeName(name);
 
   Result res = extractOptions(options, true /*getId*/, false /*getName*/);
@@ -105,8 +103,7 @@ Result CreateDatabaseInfo::load(std::string const& name,
 }
 
 Result CreateDatabaseInfo::load(std::string const& name, uint64_t id,
-                                VPackSlice const& options,
-                                VPackSlice const& users) {
+                                VPackSlice options, VPackSlice users) {
   _name = methods::Databases::normalizeName(name);
   _id = id;
 
@@ -163,7 +160,7 @@ void CreateDatabaseInfo::UsersToVelocyPack(VPackBuilder& builder) const {
 
 ArangodServer& CreateDatabaseInfo::server() const { return _server; }
 
-Result CreateDatabaseInfo::extractUsers(VPackSlice const& users) {
+Result CreateDatabaseInfo::extractUsers(VPackSlice users) {
   if (users.isNone() || users.isNull()) {
     return Result();
   } else if (!users.isArray()) {
@@ -172,7 +169,7 @@ Result CreateDatabaseInfo::extractUsers(VPackSlice const& users) {
     return Result(TRI_ERROR_HTTP_BAD_PARAMETER, "invalid users slice");
   }
 
-  for (VPackSlice const& user : VPackArrayIterator(users)) {
+  for (VPackSlice user : VPackArrayIterator(users)) {
     if (!user.isObject()) {
       events::CreateDatabase(_name, Result(TRI_ERROR_HTTP_BAD_PARAMETER),
                              _context);
@@ -197,8 +194,7 @@ Result CreateDatabaseInfo::extractUsers(VPackSlice const& users) {
     }
 
     std::string password;
-    if (user.hasKey("passwd")) {
-      VPackSlice passwd = user.get("passwd");
+    if (VPackSlice passwd = user.get("passwd"); !passwd.isNone()) {
       if (!passwd.isString()) {
         events::CreateDatabase(_name, Result(TRI_ERROR_HTTP_BAD_PARAMETER),
                                _context);
@@ -208,14 +204,12 @@ Result CreateDatabaseInfo::extractUsers(VPackSlice const& users) {
     }
 
     bool active = true;
-    VPackSlice act = user.get("active");
-    if (act.isBool()) {
+    if (VPackSlice act = user.get("active"); act.isBool()) {
       active = act.getBool();
     }
 
     std::shared_ptr<VPackBuilder> extraBuilder;
-    VPackSlice extra = user.get("extra");
-    if (extra.isObject()) {
+    if (VPackSlice extra = user.get("extra"); extra.isObject()) {
       extraBuilder = std::make_shared<VPackBuilder>();
       extraBuilder->add(extra);
     }
@@ -230,10 +224,10 @@ Result CreateDatabaseInfo::extractUsers(VPackSlice const& users) {
   return Result();
 }
 
-Result CreateDatabaseInfo::extractOptions(VPackSlice const& options,
-                                          bool extractId, bool extractName) {
+Result CreateDatabaseInfo::extractOptions(VPackSlice options, bool extractId,
+                                          bool extractName) {
   if (options.isNone() || options.isNull()) {
-    return Result();
+    options = VPackSlice::emptyObjectSlice();
   }
   if (!options.isObject()) {
     events::CreateDatabase(_name, Result(TRI_ERROR_HTTP_BAD_PARAMETER),
@@ -310,8 +304,7 @@ VocbaseOptions getVocbaseOptions(ArangodServer& server, VPackSlice options) {
 
   {
     auto shardingSlice = options.get(StaticStrings::Sharding);
-    if (shardingSlice.isString() &&
-        shardingSlice.compareString("single") == 0) {
+    if (shardingSlice.isString() && shardingSlice.stringView() == "single") {
       vocbaseOptions.sharding = shardingSlice.copyString();
     }
   }
@@ -321,7 +314,7 @@ VocbaseOptions getVocbaseOptions(ArangodServer& server, VPackSlice options) {
     VPackSlice replicationSlice = options.get(StaticStrings::ReplicationFactor);
     bool isSatellite =
         (replicationSlice.isString() &&
-         replicationSlice.compareString(StaticStrings::Satellite) == 0);
+         replicationSlice.stringView() == StaticStrings::Satellite);
     bool isNumber = replicationSlice.isNumber();
     isSatellite = isSatellite || (isNumber && replicationSlice.getUInt() == 0);
     if (!isSatellite && !isNumber) {
@@ -338,6 +331,29 @@ VocbaseOptions getVocbaseOptions(ArangodServer& server, VPackSlice options) {
       vocbaseOptions.replicationFactor =
           replicationSlice
               .getNumber<decltype(vocbaseOptions.replicationFactor)>();
+      if (haveCluster) {
+        uint32_t const minReplicationFactor =
+            server.getFeature<ClusterFeature>().minReplicationFactor();
+        uint32_t const maxReplicationFactor =
+            server.getFeature<ClusterFeature>().maxReplicationFactor();
+        // make sure the replicationFactor value is between the configured min
+        // and max values
+        if (vocbaseOptions.replicationFactor > maxReplicationFactor &&
+            maxReplicationFactor > 0) {
+          THROW_ARANGO_EXCEPTION_MESSAGE(
+              TRI_ERROR_BAD_PARAMETER,
+              std::string("replicationFactor must not be higher than "
+                          "maximum allowed replicationFactor (") +
+                  std::to_string(maxReplicationFactor) + ")");
+        } else if (vocbaseOptions.replicationFactor < minReplicationFactor &&
+                   minReplicationFactor > 0) {
+          THROW_ARANGO_EXCEPTION_MESSAGE(
+              TRI_ERROR_BAD_PARAMETER,
+              std::string("replicationFactor must not be lower than "
+                          "minimum allowed replicationFactor (") +
+                  std::to_string(minReplicationFactor) + ")");
+        }
+      }
     }
 #ifndef USE_ENTERPRISE
     if (vocbaseOptions.replicationFactor == 0) {

--- a/arangod/VocBase/VocbaseInfo.h
+++ b/arangod/VocBase/VocbaseInfo.h
@@ -23,13 +23,14 @@
 
 #pragma once
 
-#include <velocypack/Builder.h>
-#include <velocypack/Slice.h>
 #include "Basics/Result.h"
 #include "Basics/debugging.h"
 #include "RestServer/arangod.h"
 #include "Utils/OperationOptions.h"
 #include "VocBase/voc-types.h"
+
+#include <velocypack/Builder.h>
+#include <velocypack/Slice.h>
 
 struct TRI_vocbase_t;
 
@@ -78,13 +79,13 @@ class CreateDatabaseInfo {
   CreateDatabaseInfo(ArangodServer&, ExecContext const&);
   Result load(std::string const& name, uint64_t id);
 
-  Result load(std::string const& name, VPackSlice const& options,
-              VPackSlice const& users = VPackSlice::emptyArraySlice());
+  Result load(std::string const& name, VPackSlice options,
+              VPackSlice users = VPackSlice::emptyArraySlice());
 
-  Result load(std::string const& name, uint64_t id, VPackSlice const& options,
-              VPackSlice const& users);
+  Result load(std::string const& name, uint64_t id, VPackSlice options,
+              VPackSlice users);
 
-  Result load(VPackSlice const& options, VPackSlice const& users);
+  Result load(VPackSlice options, VPackSlice users);
 
   void toVelocyPack(VPackBuilder& builder, bool withUsers = false) const;
   void UsersToVelocyPack(VPackBuilder& builder) const;
@@ -131,8 +132,8 @@ class CreateDatabaseInfo {
   void shardingPrototype(ShardingPrototype type);
 
  private:
-  Result extractUsers(VPackSlice const& users);
-  Result extractOptions(VPackSlice const& options, bool extactId = true,
+  Result extractUsers(VPackSlice users);
+  Result extractOptions(VPackSlice options, bool extactId = true,
                         bool extractName = true);
   Result checkOptions();
 


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/17728.

Validate `replicationFactor` when creating new databases.

* Disallow creating new databases with a `replicationFactor` value set to a value lower than `--cluster.min-replication-factor` or higher than `--cluster.max-replication-factor`. Previously the `replicationFactor` settings for new databases were not bounds-checked, only for new collections.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [x] Backports
  - [x] Backport for 3.10: this PR
  - [x] Backport for 3.9: https://github.com/arangodb/arangodb/pull/17730
  - [ ] Backport for 3.8: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

