### PR TITLE
the 'all' testsuite has been unused since we have oskar, delete it.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -789,10 +789,6 @@ Controlling the place where the test-data is stored:
 Note that the `arangodbtests` executable is not compiled and shipped for
 production releases (`-DUSE_GOOGLE_TESTS=off`).
 
-Run all tests:
-
-    scripts/unittest all
-
 `scripts/unittest` is only a wrapper for the most part, the backend
 functionality lives in `js/client/modules/@arangodb/` (`testing.js`,
 `process-utils.js`, `test-utils.js`). The actual testsuites are located in the
@@ -802,7 +798,6 @@ functionality lives in `js/client/modules/@arangodb/` (`testing.js`,
 
 The first parameter chooses the facility to execute. Available choices include:
 
-- **all**: This target is utilized by most of the Jenkins builds invoking unit tests (calls multiple)
 - **single_client**: (see [Running a single unittest suite](#running-a-single-unittest-suite))
 - **single_server**: (see [Running a single unittest suite](#running-a-single-unittest-suite))
 

--- a/js/client/modules/@arangodb/testsuites/agency-restart.js
+++ b/js/client/modules/@arangodb/testsuites/agency-restart.js
@@ -200,7 +200,7 @@ function agencyRestart (options) {
   return results;
 }
 
-exports.setup = function (testFns, defaultFns, opts, fnDocs, optionsDoc, allTestPaths) {
+exports.setup = function (testFns, opts, fnDocs, optionsDoc, allTestPaths) {
   Object.assign(allTestPaths, testPaths);
   testFns['agency-restart'] = agencyRestart;
   for (var attrname in functionsDocumentation) { fnDocs[attrname] = functionsDocumentation[attrname]; }

--- a/js/client/modules/@arangodb/testsuites/agency.js
+++ b/js/client/modules/@arangodb/testsuites/agency.js
@@ -58,10 +58,10 @@ function agency (options) {
   return results;
 }
 
-exports.setup = function (testFns, defaultFns, opts, fnDocs, optionsDoc, allTestPaths) {
+exports.setup = function (testFns, opts, fnDocs, optionsDoc, allTestPaths) {
   Object.assign(allTestPaths, testPaths);
   testFns['agency'] = agency;
-  defaultFns.push('agency');
+
   for (var attrname in functionsDocumentation) { fnDocs[attrname] = functionsDocumentation[attrname]; }
   for (var i = 0; i < optionsDocumentation.length; i++) { optionsDoc.push(optionsDocumentation[i]); }
 };

--- a/js/client/modules/@arangodb/testsuites/aql.js
+++ b/js/client/modules/@arangodb/testsuites/aql.js
@@ -388,7 +388,7 @@ function shellClientReplication2Recovery(options) {
   return rc;
 }
 
-exports.setup = function (testFns, defaultFns, opts, fnDocs, optionsDoc, allTestPaths) {
+exports.setup = function (testFns, opts, fnDocs, optionsDoc, allTestPaths) {
   Object.assign(allTestPaths, testPaths);
   testFns['shell_v8'] = shellV8;
   testFns['shell_server_v8'] = shellV8Server;
@@ -403,19 +403,6 @@ exports.setup = function (testFns, defaultFns, opts, fnDocs, optionsDoc, allTest
   testFns['shell_client_transaction'] = shellClientTransaction;
   testFns['shell_client_replication2_recovery'] = shellClientReplication2Recovery;
   testFns['shell_client_traffic'] = shellClientTraffic;
-
-  defaultFns.push('shell_v8');
-  defaultFns.push('shell_server_v8');
-  defaultFns.push('shell_api');
-  defaultFns.push('shell_api_multi');
-  defaultFns.push('shell_client');
-  defaultFns.push('shell_client_multi');
-  defaultFns.push('shell_server');
-  defaultFns.push('shell_client_aql');
-  defaultFns.push('shell_server_aql');
-  defaultFns.push('shell_client_transaction');
-  defaultFns.push('shell_client_replication2_recovery');
-  defaultFns.push('shell_client_traffic');
 
   opts['skipAql'] = false;
   opts['skipRanges'] = true;

--- a/js/client/modules/@arangodb/testsuites/arangobench.js
+++ b/js/client/modules/@arangodb/testsuites/arangobench.js
@@ -337,11 +337,9 @@ function arangobench (options) {
   return results;
 }
 
-exports.setup = function (testFns, defaultFns, opts, fnDocs, optionsDoc, allTestPaths) {
+exports.setup = function (testFns, opts, fnDocs, optionsDoc, allTestPaths) {
   Object.assign(allTestPaths, testPaths);
   testFns['arangobench'] = arangobench;
-
-  defaultFns.push('arangobench');
 
   opts['skipArangoBench'] = false;
   opts['skipArangoBenchNonConnKeepAlive'] = true;

--- a/js/client/modules/@arangodb/testsuites/arangosh.js
+++ b/js/client/modules/@arangodb/testsuites/arangosh.js
@@ -389,10 +389,9 @@ function arangosh (options) {
   return ret;
 }
 
-exports.setup = function (testFns, defaultFns, opts, fnDocs, optionsDoc, allTestPaths) {
+exports.setup = function (testFns, opts, fnDocs, optionsDoc, allTestPaths) {
   Object.assign(allTestPaths, testPaths);
   testFns['arangosh'] = arangosh;
-  defaultFns.push('arangosh');
   opts['skipShebang'] = false;
 
   for (var attrname in functionsDocumentation) { fnDocs[attrname] = functionsDocumentation[attrname]; }

--- a/js/client/modules/@arangodb/testsuites/audit.js
+++ b/js/client/modules/@arangodb/testsuites/audit.js
@@ -98,7 +98,7 @@ function auditLog(onServer) {
   };
 }
 
-exports.setup = function (testFns, defaultFns, opts, fnDocs, optionsDoc, allTestPaths) {
+exports.setup = function (testFns, opts, fnDocs, optionsDoc, allTestPaths) {
   Object.assign(allTestPaths, testPaths);
   testFns['audit_server'] = auditLog(true);
   testFns['audit_client'] = auditLog(false);

--- a/js/client/modules/@arangodb/testsuites/authentication.js
+++ b/js/client/modules/@arangodb/testsuites/authentication.js
@@ -266,17 +266,13 @@ function authenticationParameters (options) {
   return results;
 }
 
-exports.setup = function (testFns, defaultFns, opts, fnDocs, optionsDoc, allTestPaths) {
+exports.setup = function (testFns, opts, fnDocs, optionsDoc, allTestPaths) {
   Object.assign(allTestPaths, testPaths);
   testFns['authentication'] = authenticationClient;
   testFns['authentication_server'] = authenticationServer;
   testFns['authentication_parameters'] = authenticationParameters;
 
   opts['skipAuthentication'] = false;
-
-  defaultFns.push('authentication');
-  defaultFns.push('authentication_server');
-  defaultFns.push('authentication_parameters');
 
   for (var attrname in functionsDocumentation) { fnDocs[attrname] = functionsDocumentation[attrname]; }
   for (var i = 0; i < optionsDocumentation.length; i++) { optionsDoc.push(optionsDocumentation[i]); }

--- a/js/client/modules/@arangodb/testsuites/backup.js
+++ b/js/client/modules/@arangodb/testsuites/backup.js
@@ -284,17 +284,12 @@ const BackupAuthNoSysTests = (options) => {
                                 testPaths.BackupAuthNoSysTests);
 };
 
-exports.setup = function (testFns, defaultFns, opts, fnDocs, optionsDoc, allTestPaths) {
+exports.setup = function (testFns, opts, fnDocs, optionsDoc, allTestPaths) {
   Object.assign(allTestPaths, testPaths);
   testFns['BackupNoAuthSysTests'] = BackupNoAuthSysTests;
   testFns['BackupNoAuthNoSysTests'] = BackupNoAuthNoSysTests;
   testFns['BackupAuthSysTests'] = BackupAuthSysTests;
   testFns['BackupAuthNoSysTests'] = BackupAuthNoSysTests;
-
-  defaultFns.push('BackupNoAuthSysTests');
-  defaultFns.push('BackupNoAuthNoSysTests');
-  defaultFns.push('BackupAuthSysTests');
-  defaultFns.push('BackupAuthNoSysTests');
 
   for (var attrname in functionsDocumentation) { fnDocs[attrname] = functionsDocumentation[attrname]; }
   for (var i = 0; i < optionsDocumentation.length; i++) { optionsDoc.push(optionsDocumentation[i]); }

--- a/js/client/modules/@arangodb/testsuites/chaos.js
+++ b/js/client/modules/@arangodb/testsuites/chaos.js
@@ -94,13 +94,9 @@ function chaos (options) {
   return new chaosRunner(options, 'chaos', {}).run(testCases);
 }
 
-exports.setup = function (testFns, defaultFns, opts, fnDocs, optionsDoc, allTestPaths) {
+exports.setup = function (testFns, opts, fnDocs, optionsDoc, allTestPaths) {
   Object.assign(allTestPaths, testPaths);
   testFns['chaos'] = chaos;
-  
-  // intentionally not turned on by default, as the suite may take a lot of time
-  // defaultFns.push('chaos');
-
   for (var attrname in functionsDocumentation) { fnDocs[attrname] = functionsDocumentation[attrname]; }
   for (var i = 0; i < optionsDocumentation.length; i++) { optionsDoc.push(optionsDocumentation[i]); }
 };

--- a/js/client/modules/@arangodb/testsuites/communication.js
+++ b/js/client/modules/@arangodb/testsuites/communication.js
@@ -57,13 +57,10 @@ function communicationSsl (options) {
   return new tu.runLocalInArangoshRunner(opts, 'communication-ssl', {}).run(testCases);
 }
 
-exports.setup = function (testFns, defaultFns, opts, fnDocs, optionsDoc, allTestPaths) {
+exports.setup = function (testFns, opts, fnDocs, optionsDoc, allTestPaths) {
   Object.assign(allTestPaths, testPaths);
   testFns['communication'] = communication;
   testFns['communication_ssl'] = communicationSsl;
-  
-  // intentionally not turned on by default, as the suite may take a lot of time
-  // defaultFns.push('communication');
 
   for (var attrname in functionsDocumentation) { fnDocs[attrname] = functionsDocumentation[attrname]; }
   for (var i = 0; i < optionsDocumentation.length; i++) { optionsDoc.push(optionsDocumentation[i]); }

--- a/js/client/modules/@arangodb/testsuites/config.js
+++ b/js/client/modules/@arangodb/testsuites/config.js
@@ -170,10 +170,10 @@ function config (options) {
   return results;
 }
 
-exports.setup = function (testFns, defaultFns, opts, fnDocs, optionsDoc, allTestPaths) {
+exports.setup = function (testFns, opts, fnDocs, optionsDoc, allTestPaths) {
   Object.assign(allTestPaths, testPaths);
   testFns['config'] = config;
-  defaultFns.push('config');
+
   for (var attrname in functionsDocumentation) { fnDocs[attrname] = functionsDocumentation[attrname]; }
   for (var i = 0; i < optionsDocumentation.length; i++) { optionsDoc.push(optionsDocumentation[i]); }
 };

--- a/js/client/modules/@arangodb/testsuites/drivers.js
+++ b/js/client/modules/@arangodb/testsuites/drivers.js
@@ -167,7 +167,7 @@ function driver (options) {
 }
 
 
-exports.setup = function (testFns, defaultFns, opts, fnDocs, optionsDoc, allTestPaths) {
+exports.setup = function (testFns, opts, fnDocs, optionsDoc, allTestPaths) {
   Object.assign(allTestPaths, testPaths);
   opts.driverScript = 'run_tests.sh';
   opts.driverScriptInterpreter = '/bin/bash';

--- a/js/client/modules/@arangodb/testsuites/dump.js
+++ b/js/client/modules/@arangodb/testsuites/dump.js
@@ -1006,41 +1006,20 @@ function hotBackup (options) {
   return helper.extractResults();
 }
 
-exports.setup = function (testFns, defaultFns, opts, fnDocs, optionsDoc, allTestPaths) {
+exports.setup = function (testFns, opts, fnDocs, optionsDoc, allTestPaths) {
   Object.assign(allTestPaths, testPaths);
 
   testFns['dump'] = dump;
-  defaultFns.push('dump');
-
   testFns['dump_mixed_cluster_single'] = dumpMixedClusterSingle;
-  defaultFns.push('dump_mixed_cluster_single');
-
   testFns['dump_mixed_single_cluster'] = dumpMixedSingleCluster;
-  defaultFns.push('dump_mixed_single_cluster');
-
   testFns['dump_authentication'] = dumpAuthentication;
-  defaultFns.push('dump_authentication');
-  
   testFns['dump_jwt'] = dumpJwt;
-  defaultFns.push('dump_jwt');
-
   testFns['dump_encrypted'] = dumpEncrypted;
-  defaultFns.push('dump_encrypted');
-
   testFns['dump_maskings'] = dumpMaskings;
-  defaultFns.push('dump_maskings');
-
   testFns['dump_multiple'] = dumpMultiple;
-  defaultFns.push('dump_multiple');
-
   testFns['dump_no_envelope'] = dumpNoEnvelope;
-  defaultFns.push('dump_no_envelope');
-
   testFns['dump_with_crashes'] = dumpWithCrashes;
-  defaultFns.push('dump_with_crashes');
-
   testFns['hot_backup'] = hotBackup;
-  defaultFns.push('hot_backup');
 
   for (var attrname in functionsDocumentation) { fnDocs[attrname] = functionsDocumentation[attrname]; }
   for (var i = 0; i < optionsDocumentation.length; i++) { optionsDoc.push(optionsDocumentation[i]); }

--- a/js/client/modules/@arangodb/testsuites/endpoints.js
+++ b/js/client/modules/@arangodb/testsuites/endpoints.js
@@ -346,7 +346,7 @@ function endpoints (options) {
   print(CYAN + 'Endpoints tests...' + RESET);
   return new endpointRunner(options, "endpoints").run();
 }
-exports.setup = function (testFns, defaultFns, opts, fnDocs, optionsDoc, allTestPaths) {
+exports.setup = function (testFns, opts, fnDocs, optionsDoc, allTestPaths) {
   Object.assign(allTestPaths, testPaths);
   testFns['endpoints'] = endpoints;
 
@@ -355,8 +355,6 @@ exports.setup = function (testFns, defaultFns, opts, fnDocs, optionsDoc, allTest
   opts['skipEndpointsIpv4'] = false;
   opts['skipEndpointsSSL'] = false;
   opts['skipEndpointsUnix'] = (platform.substr(0, 3) === 'win');
-
-  defaultFns.push('endpoints');
 
   for (var attrname in functionsDocumentation) { fnDocs[attrname] = functionsDocumentation[attrname]; }
   for (var i = 0; i < optionsDocumentation.length; i++) { optionsDoc.push(optionsDocumentation[i]); }

--- a/js/client/modules/@arangodb/testsuites/export.js
+++ b/js/client/modules/@arangodb/testsuites/export.js
@@ -704,10 +704,10 @@ class exportRunner extends tu.runInArangoshRunner {
 function exportTest (options) {
   return new exportRunner(options, "export").run();
 }
-exports.setup = function (testFns, defaultFns, opts, fnDocs, optionsDoc, allTestPaths) {
+exports.setup = function (testFns, opts, fnDocs, optionsDoc, allTestPaths) {
   Object.assign(allTestPaths, testPaths);
   testFns['export'] = exportTest;
-  defaultFns.push('export');
+
   for (var attrname in functionsDocumentation) { fnDocs[attrname] = functionsDocumentation[attrname]; }
   for (var i = 0; i < optionsDocumentation.length; i++) { optionsDoc.push(optionsDocumentation[i]); }
 };

--- a/js/client/modules/@arangodb/testsuites/fail.js
+++ b/js/client/modules/@arangodb/testsuites/fail.js
@@ -147,7 +147,7 @@ function success (options) {
   };
 }
 
-exports.setup = function (testFns, defaultFns, opts, fnDocs, optionsDoc, allTestPaths) {
+exports.setup = function (testFns, opts, fnDocs, optionsDoc, allTestPaths) {
   Object.assign(allTestPaths, testPaths);
   testFns['fail'] = fail;
   testFns['fail2'] = fail2;

--- a/js/client/modules/@arangodb/testsuites/foxxmanager.js
+++ b/js/client/modules/@arangodb/testsuites/foxxmanager.js
@@ -78,7 +78,7 @@ function foxxManager (options) {
 
   return results;
 }
-exports.setup = function (testFns, defaultFns, opts, fnDocs, optionsDoc, allTestPaths) {
+exports.setup = function (testFns, opts, fnDocs, optionsDoc, allTestPaths) {
   Object.assign(allTestPaths, testPaths);
   testFns['foxx_manager'] = foxxManager;
   for (var attrname in functionsDocumentation) { fnDocs[attrname] = functionsDocumentation[attrname]; }

--- a/js/client/modules/@arangodb/testsuites/fuerte.js
+++ b/js/client/modules/@arangodb/testsuites/fuerte.js
@@ -158,13 +158,11 @@ function gtestRunner(options) {
   return results;
 }
 
-exports.setup = function (testFns, defaultFns, opts, fnDocs, optionsDoc, allTestPaths) {
+exports.setup = function (testFns, opts, fnDocs, optionsDoc, allTestPaths) {
   Object.assign(allTestPaths, testPaths);
   testFns['fuerte'] = gtestRunner;
 
   opts['skipFuerte'] = false;
-
-  defaultFns.push('fuerte');
 
   for (var attrname in functionsDocumentation) { fnDocs[attrname] = functionsDocumentation[attrname]; }
   for (var i = 0; i < optionsDocumentation.length; i++) { optionsDoc.push(optionsDocumentation[i]); }

--- a/js/client/modules/@arangodb/testsuites/fuzzer.js
+++ b/js/client/modules/@arangodb/testsuites/fuzzer.js
@@ -60,11 +60,9 @@ function shellFuzzer(options) {
   return rc;
 }
 
-exports.setup = function (testFns, defaultFns, opts, fnDocs, optionsDoc, allTestPaths) {
+exports.setup = function (testFns, opts, fnDocs, optionsDoc, allTestPaths) {
   Object.assign(allTestPaths, testPaths);
   testFns['shell_fuzzer'] = shellFuzzer;
-
-  defaultFns.push('shell_fuzzer');
 
   for (var attrname in functionsDocumentation) {
     fnDocs[attrname] = functionsDocumentation[attrname];

--- a/js/client/modules/@arangodb/testsuites/go.js
+++ b/js/client/modules/@arangodb/testsuites/go.js
@@ -223,7 +223,7 @@ function goDriver (options) {
 }
 
 
-exports.setup = function (testFns, defaultFns, opts, fnDocs, optionsDoc, allTestPaths) {
+exports.setup = function (testFns, opts, fnDocs, optionsDoc, allTestPaths) {
   Object.assign(allTestPaths, testPaths);
   testFns['go_driver'] = goDriver;
   for (var attrname in functionsDocumentation) { fnDocs[attrname] = functionsDocumentation[attrname]; }

--- a/js/client/modules/@arangodb/testsuites/gtest.js
+++ b/js/client/modules/@arangodb/testsuites/gtest.js
@@ -151,7 +151,7 @@ function gtestRunner (testname, options) {
   return results;
 }
 
-exports.setup = function (testFns, defaultFns, opts, fnDocs, optionsDoc, allTestPaths) {
+exports.setup = function (testFns, opts, fnDocs, optionsDoc, allTestPaths) {
   Object.assign(allTestPaths, testPaths);
 
   const tests = [ 'arangodbtests_zkd' ];
@@ -162,9 +162,6 @@ exports.setup = function (testFns, defaultFns, opts, fnDocs, optionsDoc, allTest
   testFns['gtest'] = x => gtestRunner('arangodbtests', x);
 
   opts['skipGtest'] = false;
-
-  defaultFns.push('gtest');
-
   testFns['gtest_replication2'] = x => gtestRunner('arangodbtests_replication2', x);
 
   for (var attrname in functionsDocumentation) { fnDocs[attrname] = functionsDocumentation[attrname]; }

--- a/js/client/modules/@arangodb/testsuites/importing.js
+++ b/js/client/modules/@arangodb/testsuites/importing.js
@@ -511,10 +511,10 @@ class importRunner extends tu.runInArangoshRunner {
 function importing (options) {
   return new importRunner(options, "importing").run();
 }
-exports.setup = function (testFns, defaultFns, opts, fnDocs, optionsDoc, allTestPaths) {
+exports.setup = function (testFns, opts, fnDocs, optionsDoc, allTestPaths) {
   Object.assign(allTestPaths, testPaths);
   testFns['importing'] = importing;
-  defaultFns.push('importing');
+
   for (var attrname in functionsDocumentation) { fnDocs[attrname] = functionsDocumentation[attrname]; }
   for (var i = 0; i < optionsDocumentation.length; i++) { optionsDoc.push(optionsDocumentation[i]); }
 };

--- a/js/client/modules/@arangodb/testsuites/java.js
+++ b/js/client/modules/@arangodb/testsuites/java.js
@@ -247,7 +247,7 @@ function javaDriver (options) {
 }
 
 
-exports.setup = function (testFns, defaultFns, opts, fnDocs, optionsDoc, allTestPaths) {
+exports.setup = function (testFns, opts, fnDocs, optionsDoc, allTestPaths) {
   Object.assign(allTestPaths, testPaths);
   testFns['java_driver'] = javaDriver;
   for (var attrname in functionsDocumentation) { fnDocs[attrname] = functionsDocumentation[attrname]; }

--- a/js/client/modules/@arangodb/testsuites/js.js
+++ b/js/client/modules/@arangodb/testsuites/js.js
@@ -173,7 +173,7 @@ function jsDriver (options) {
 }
 
 
-exports.setup = function (testFns, defaultFns, opts, fnDocs, optionsDoc, allTestPaths) {
+exports.setup = function (testFns, opts, fnDocs, optionsDoc, allTestPaths) {
   Object.assign(allTestPaths, testPaths);
   testFns['js_driver'] = jsDriver;
   for (var attrname in functionsDocumentation) { fnDocs[attrname] = functionsDocumentation[attrname]; }

--- a/js/client/modules/@arangodb/testsuites/ldap.js
+++ b/js/client/modules/@arangodb/testsuites/ldap.js
@@ -479,7 +479,7 @@ function authenticationLdapSecondLdap(options) {
   return new ldapTestRunner(options, 'ldap', conf).run(testCases);
 }
 
-exports.setup = function(testFns, defaultFns, opts, fnDocs, optionsDoc, allTestPaths) {
+exports.setup = function(testFns, opts, fnDocs, optionsDoc, allTestPaths) {
   Object.assign(allTestPaths, testPaths);
   // just a convenience wrapper for the regular tests
   testFns['ldap'] = ['ldaprole', 'ldapsearch', 'ldapsearchplaceholder', 'ldaprolesimple', 'ldapsearchsimple'];

--- a/js/client/modules/@arangodb/testsuites/license.js
+++ b/js/client/modules/@arangodb/testsuites/license.js
@@ -52,7 +52,7 @@ const testPaths = {
 // / @brief Shared conf
 // //////////////////////////////////////////////////////////////////////////////
 
-exports.setup = function(testFns, defaultFns, opts, fnDocs, optionsDoc, allTestPaths) {
+exports.setup = function(testFns, opts, fnDocs, optionsDoc, allTestPaths) {
   Object.assign(allTestPaths, testPaths);
   // just a convenience wrapper for the regular tests
   testFns['license'] = ['license-api'];

--- a/js/client/modules/@arangodb/testsuites/loadBalancing.js
+++ b/js/client/modules/@arangodb/testsuites/loadBalancing.js
@@ -112,14 +112,12 @@ function loadBalancingAuthClient (options) {
   return rc;
 }
 
-exports.setup = function (testFns, defaultFns, opts, fnDocs, optionsDoc, allTestPaths) {
+exports.setup = function (testFns, opts, fnDocs, optionsDoc, allTestPaths) {
   Object.assign(allTestPaths, testPaths);
   testFns['load_balancing'] = loadBalancingClient;
   testFns['load_balancing_auth'] = loadBalancingAuthClient;
 
   opts['skipLoadBalancing'] = false;
-
-  defaultFns.push('load_balancing');
 
   for (var attrname in functionsDocumentation) { fnDocs[attrname] = functionsDocumentation[attrname]; }
   for (var i = 0; i < optionsDocumentation.length; i++) { optionsDoc.push(optionsDocumentation[i]); }

--- a/js/client/modules/@arangodb/testsuites/paths_server.js
+++ b/js/client/modules/@arangodb/testsuites/paths_server.js
@@ -60,7 +60,7 @@ function paths_server(options) {
   return rc;
 }
 
-exports.setup = function (testFns, defaultFns, opts, fnDocs, optionsDoc, allTestPaths) {
+exports.setup = function (testFns, opts, fnDocs, optionsDoc, allTestPaths) {
   Object.assign(allTestPaths, testPaths);
   testFns['paths_server'] = paths_server;
   for (var attrname in functionsDocumentation) { fnDocs[attrname] = functionsDocumentation[attrname]; }

--- a/js/client/modules/@arangodb/testsuites/permissions_client.js
+++ b/js/client/modules/@arangodb/testsuites/permissions_client.js
@@ -114,10 +114,10 @@ class permissionsRunner extends tu.runInArangoshRunner {
 function permissions(options) {
   return new permissionsRunner(options, "permissions").run();
 }
-exports.setup = function (testFns, defaultFns, opts, fnDocs, optionsDoc, allTestPaths) {
+exports.setup = function (testFns, opts, fnDocs, optionsDoc, allTestPaths) {
   Object.assign(allTestPaths, testPaths);
   testFns['permissions'] = permissions;
-  defaultFns.push('permissions');
+
   opts['skipShebang'] = false;
 
   for (var attrname in functionsDocumentation) { fnDocs[attrname] = functionsDocumentation[attrname]; }

--- a/js/client/modules/@arangodb/testsuites/php.js
+++ b/js/client/modules/@arangodb/testsuites/php.js
@@ -165,7 +165,7 @@ function phpDriver (options) {
 }
 
 
-exports.setup = function (testFns, defaultFns, opts, fnDocs, optionsDoc, allTestPaths) {
+exports.setup = function (testFns, opts, fnDocs, optionsDoc, allTestPaths) {
   opts['phpkeepalive'] = true;
   Object.assign(allTestPaths, testPaths);
   testFns['php_driver'] = phpDriver;

--- a/js/client/modules/@arangodb/testsuites/queryCacheAuthorization.js
+++ b/js/client/modules/@arangodb/testsuites/queryCacheAuthorization.js
@@ -159,7 +159,7 @@ function queryCacheAuthorization (options) {
   return results;
 }
 
-exports.setup = function (testFns, defaultFns, opts, fnDocs, optionsDoc, allTestPaths) {
+exports.setup = function (testFns, opts, fnDocs, optionsDoc, allTestPaths) {
   Object.assign(allTestPaths, testPaths);
   testFns['queryCacheAuthorization'] = queryCacheAuthorization;
 

--- a/js/client/modules/@arangodb/testsuites/readOnly.js
+++ b/js/client/modules/@arangodb/testsuites/readOnly.js
@@ -228,11 +228,10 @@ function readOnly (options) {
   return results;
 }
 
-exports.setup = function (testFns, defaultFns, opts, fnDocs, optionsDoc, allTestPaths) {
+exports.setup = function (testFns, opts, fnDocs, optionsDoc, allTestPaths) {
   Object.assign(allTestPaths, testPaths);
   testFns['readOnly'] = readOnly;
-  defaultFns.push('readOnly');
-  
+
   for (var attrname in functionsDocumentation) { fnDocs[attrname] = functionsDocumentation[attrname]; }
   for (var i = 0; i < optionsDocumentation.length; i++) { optionsDoc.push(optionsDocumentation[i]); }
 };

--- a/js/client/modules/@arangodb/testsuites/recovery.js
+++ b/js/client/modules/@arangodb/testsuites/recovery.js
@@ -322,7 +322,7 @@ function recovery (options) {
   return results;
 }
 
-exports.setup = function (testFns, defaultFns, opts, fnDocs, optionsDoc, allTestPaths) {
+exports.setup = function (testFns, opts, fnDocs, optionsDoc, allTestPaths) {
   Object.assign(allTestPaths, testPaths);
   testFns['recovery'] = recovery;
   for (var attrname in functionsDocumentation) { fnDocs[attrname] = functionsDocumentation[attrname]; }

--- a/js/client/modules/@arangodb/testsuites/recovery_cluster.js
+++ b/js/client/modules/@arangodb/testsuites/recovery_cluster.js
@@ -370,7 +370,7 @@ function recovery (options) {
   return results;
 }
 
-exports.setup = function (testFns, defaultFns, opts, fnDocs, optionsDoc, allTestPaths) {
+exports.setup = function (testFns, opts, fnDocs, optionsDoc, allTestPaths) {
   Object.assign(allTestPaths, testPaths);
   testFns['recovery_cluster'] = recovery;
   for (var attrname in functionsDocumentation) { fnDocs[attrname] = functionsDocumentation[attrname]; }

--- a/js/client/modules/@arangodb/testsuites/replication.js
+++ b/js/client/modules/@arangodb/testsuites/replication.js
@@ -214,7 +214,7 @@ function replicationSync (options) {
   return new replicationRunner(options, 'replication_sync').run(testCases);
 }
 
-exports.setup = function (testFns, defaultFns, opts, fnDocs, optionsDoc, allTestPaths) {
+exports.setup = function (testFns, opts, fnDocs, optionsDoc, allTestPaths) {
   Object.assign(allTestPaths, testPaths);
   testFns['shell_replication'] = shellReplication;
   testFns['replication_aql'] = replicationAql;

--- a/js/client/modules/@arangodb/testsuites/replication2.js
+++ b/js/client/modules/@arangodb/testsuites/replication2.js
@@ -72,15 +72,14 @@ function replication2Server(options) {
 }
 
 
-exports.setup = function (testFns, defaultFns, opts, fnDocs, optionsDoc, allTestPaths) {
+exports.setup = function (testFns, opts, fnDocs, optionsDoc, allTestPaths) {
   Object.assign(allTestPaths, testPaths);
   testFns.replication2_client = replication2Client;
   testFns.replication2_server = replication2Server;
   for (const [key, value] of Object.entries(functionsDocumentation)) {
     fnDocs[key] = value;
   }
-  defaultFns.push('replication2_client');
-  defaultFns.push('replication2_server');
+
   for (let i = 0; i < optionsDocumentation.length; i++) {
     optionsDoc.push(optionsDocumentation[i]);
   }

--- a/js/client/modules/@arangodb/testsuites/resilience.js
+++ b/js/client/modules/@arangodb/testsuites/resilience.js
@@ -148,7 +148,7 @@ function activeFailover (options) {
   return rc;
 }
 
-exports.setup = function (testFns, defaultFns, opts, fnDocs, optionsDoc, allTestPaths) {
+exports.setup = function (testFns, opts, fnDocs, optionsDoc, allTestPaths) {
   Object.assign(allTestPaths, testPaths);
   testFns['resilience_move'] = resilienceMove;
   testFns['resilience_move_view'] = resilienceMoveView;

--- a/js/client/modules/@arangodb/testsuites/restart.js
+++ b/js/client/modules/@arangodb/testsuites/restart.js
@@ -85,7 +85,7 @@ function restart (options) {
   return rc;
 }
 
-exports.setup = function (testFns, defaultFns, opts, fnDocs, optionsDoc, allTestPaths) {
+exports.setup = function (testFns, opts, fnDocs, optionsDoc, allTestPaths) {
   Object.assign(allTestPaths, testPaths);
   testFns['restart'] = restart;
   for (var attrname in functionsDocumentation) { fnDocs[attrname] = functionsDocumentation[attrname]; }

--- a/js/client/modules/@arangodb/testsuites/rta_makedata.js
+++ b/js/client/modules/@arangodb/testsuites/rta_makedata.js
@@ -158,7 +158,7 @@ function makeDataWrapper (options) {
 }
 
 
-exports.setup = function (testFns, defaultFns, opts, fnDocs, optionsDoc, allTestPaths) {
+exports.setup = function (testFns, opts, fnDocs, optionsDoc, allTestPaths) {
   Object.assign(allTestPaths, testPaths);
   testFns['rta_makedata'] = makeDataWrapper;
   opts['rtasource'] = fs.makeAbsolute(fs.join('.', '..','release-test-automation'));

--- a/js/client/modules/@arangodb/testsuites/server_permissions.js
+++ b/js/client/modules/@arangodb/testsuites/server_permissions.js
@@ -311,7 +311,7 @@ function server_secrets(options) {
   return rc;
 }
 
-exports.setup = function (testFns, defaultFns, opts, fnDocs, optionsDoc, allTestPaths) {
+exports.setup = function (testFns, opts, fnDocs, optionsDoc, allTestPaths) {
   Object.assign(allTestPaths, testPaths);
   testFns['server_permissions'] = server_permissions;
   testFns['server_parameters'] = server_parameters;

--- a/js/client/modules/@arangodb/testsuites/upgrade.js
+++ b/js/client/modules/@arangodb/testsuites/upgrade.js
@@ -95,10 +95,10 @@ function upgrade (options) {
   return result;
 }
 
-exports.setup = function (testFns, defaultFns, opts, fnDocs, optionsDoc, allTestPaths) {
+exports.setup = function (testFns, opts, fnDocs, optionsDoc, allTestPaths) {
   Object.assign(allTestPaths, testPaths);
   testFns['upgrade'] = upgrade;
-  defaultFns.push('upgrade');
+
   for (var attrname in functionsDocumentation) { fnDocs[attrname] = functionsDocumentation[attrname]; }
   for (var i = 0; i < optionsDocumentation.length; i++) { optionsDoc.push(optionsDocumentation[i]); }
 };

--- a/js/client/modules/@arangodb/testsuites/version.js
+++ b/js/client/modules/@arangodb/testsuites/version.js
@@ -85,9 +85,9 @@ function version(options) {
   return results;
 }
 
-exports.setup = function (testFns, defaultFns, opts, fnDocs, optionsDoc, allTestPaths) {
+exports.setup = function (testFns, opts, fnDocs, optionsDoc, allTestPaths) {
   Object.assign(allTestPaths, testPaths);
   testFns['version'] = version;
-  defaultFns.push('version');
+
   for (var attrname in functionsDocumentation) { fnDocs[attrname] = functionsDocumentation[attrname]; }
 };

--- a/js/client/modules/@arangodb/testsuites/wal.js
+++ b/js/client/modules/@arangodb/testsuites/wal.js
@@ -66,11 +66,9 @@ function walCleanup (options) {
   return rc;
 }
 
-exports.setup = function (testFns, defaultFns, opts, fnDocs, optionsDoc, allTestPaths) {
+exports.setup = function (testFns, opts, fnDocs, optionsDoc, allTestPaths) {
   Object.assign(allTestPaths, testPaths);
   testFns['wal_cleanup'] = walCleanup;
-
-  defaultFns.push('wal_cleanup');
 
   for (var attrname in functionsDocumentation) { fnDocs[attrname] = functionsDocumentation[attrname]; }
 };

--- a/js/client/modules/@arangodb/testutils/testing.js
+++ b/js/client/modules/@arangodb/testutils/testing.js
@@ -44,7 +44,6 @@ const RESET = internal.COLORS.COLOR_RESET;
 const YELLOW = internal.COLORS.COLOR_YELLOW;
 
 let functionsDocumentation = {
-  'all': 'run all tests (marked with [x])',
   'find': 'searches all testcases, and eventually filters them by `--test`, ' +
     'will dump testcases associated to testsuites.',
   'auto': 'uses find; if the testsuite for the testcase is located, ' +
@@ -273,15 +272,7 @@ function printUsage () {
         oneFunctionDocumentation = '';
       }
 
-      let checkAll;
-
-      if (allTests.indexOf(i) !== -1) {
-        checkAll = '[x]';
-      } else {
-        checkAll = '   ';
-      }
-
-      print('    ' + checkAll + ' ' + i + ' ' + oneFunctionDocumentation);
+      print(`     ${i} ${oneFunctionDocumentation}`);
     }
   }
 
@@ -434,7 +425,6 @@ function loadTestSuites () {
   for (let j = 0; j < testSuites.length; j++) {
     try {
       require('@arangodb/testsuites/' + testSuites[j]).setup(testFuncs,
-                                                             allTests,
                                                              optionsDefaults,
                                                              functionsDocumentation,
                                                              optionsDocumentation,
@@ -444,7 +434,7 @@ function loadTestSuites () {
       throw x;
     }
   }
-  testFuncs['all'] = allTests;
+  allTests = Object.keys(testFuncs);
   testFuncs['find'] = findTest;
   testFuncs['auto'] = autoTest;
 }


### PR DESCRIPTION
### Scope & Purpose

Remove the `all` testsuite and its construction mechanisms, its not used anymore for several years now.

- [x] :hammer: Refactoring/simplification
