### PR TITLE
[CINFRA-612] Handle shard creation errors

### DIFF
--- a/arangod/Replication2/StateMachines/Document/DocumentStateAgencyHandler.h
+++ b/arangod/Replication2/StateMachines/Document/DocumentStateAgencyHandler.h
@@ -39,7 +39,7 @@ namespace arangodb::replication2::replicated_state::document {
 struct IDocumentStateAgencyHandler {
   virtual ~IDocumentStateAgencyHandler() = default;
   virtual auto getCollectionPlan(std::string const& collectionId)
-      -> std::shared_ptr<velocypack::Builder> = 0;
+      -> ResultT<std::shared_ptr<velocypack::Builder>> = 0;
   virtual auto reportShardInCurrent(
       std::string const& collectionId, std::string const& shardId,
       std::shared_ptr<velocypack::Builder> const& properties) -> Result = 0;
@@ -51,7 +51,7 @@ class DocumentStateAgencyHandler : public IDocumentStateAgencyHandler {
                                       ArangodServer& server,
                                       AgencyCache& agencyCache);
   auto getCollectionPlan(std::string const& collectionId)
-      -> std::shared_ptr<velocypack::Builder> override;
+      -> ResultT<std::shared_ptr<velocypack::Builder>> override;
   auto reportShardInCurrent(
       std::string const& collectionId, std::string const& shardId,
       std::shared_ptr<velocypack::Builder> const& properties)

--- a/tests/Replication2/ReplicatedState/DocumentStateMachineTest.cpp
+++ b/tests/Replication2/ReplicatedState/DocumentStateMachineTest.cpp
@@ -113,7 +113,7 @@ struct MockDocumentStateTransactionHandler : IDocumentStateTransactionHandler {
 };
 
 struct MockDocumentStateAgencyHandler : IDocumentStateAgencyHandler {
-  MOCK_METHOD(std::shared_ptr<velocypack::Builder>, getCollectionPlan,
+  MOCK_METHOD(ResultT<std::shared_ptr<velocypack::Builder>>, getCollectionPlan,
               (std::string const&), (override));
   MOCK_METHOD(Result, reportShardInCurrent,
               (std::string const&, std::string const&,


### PR DESCRIPTION
### Scope & Purpose

When a collection is created, we start creating the corresponding replicated state, which in turn starts creating the core. The core is responsible for creating the shard, but for that, it needs to look up the collection properties in the agency. There is a slight race in there, because the collection could get removed, before the core gets to look up the properties, in which case it will find nothing.
Currently we crash the server with an error message. This PR makes `getCollectionPlan` return a `ResultT`. The `DocumentCore` checks the value and throws and exception in case something went wrong. This would get caught by `UpdateReplicatedStateAction`.

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

