### PR TITLE
ES-1366: suppress "stream truncated" warnings

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 v3.8.9 (XXXX-XX-XX)
 -------------------
 
+* Don't log Boost ASIO warnings such as `asio IO error: 'stream truncated'`
+  when a peer closes an SSL/TLS connection without performing a proper
+  connection shutdown.
+
 * Add missing metrics for user traffic: Histograms:
     `arangodb_client_user_connection_statistics_bytes_received`
     `arangodb_client_user_connection_statistics_bytes_sent`

--- a/arangod/GeneralServer/GeneralCommTask.cpp
+++ b/arangod/GeneralServer/GeneralCommTask.cpp
@@ -62,7 +62,11 @@ void GeneralCommTask<T>::stop() {
 template <SocketType T>
 void GeneralCommTask<T>::close(asio_ns::error_code const& ec) {
   _stopped.store(true, std::memory_order_release);
-  if (ec && ec != asio_ns::error::misc_errors::eof) {
+  if (ec && 
+      (ec != asio_ns::error::misc_errors::eof && ec != asio_ns::ssl::error::stream_truncated)) {
+    // stream_truncated will occur when a peer closes an SSL/TLS connection
+    // without performing a proper connection shutdown. unfortunately that
+    // can happen at any time, and we have no control over it.
     LOG_TOPIC("2b6b3", WARN, arangodb::Logger::REQUESTS)
     << "asio IO error: '" << ec.message() << "'";
   }


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/17739

Fixes https://arangodb.atlassian.net/browse/ES-1366

* Don't log Boost ASIO warnings such as `asio IO error: 'stream truncated'` when a peer closes an SSL/TLS connection without performing a proper connection shutdown.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [x] Backports
  - [x] Backport for 3.10: https://github.com/arangodb/arangodb/pull/17740
  - [x] Backport for 3.9: https://github.com/arangodb/arangodb/pull/17741
  - [x] Backport for 3.8: this PR

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [x] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/ES-1366
- [ ] Design document: 