### PR TITLE
BTS-1141

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,12 @@
 v3.10.2 (XXXX-XX-XX)
 --------------------
 
+* BTS-1141: Changed the default value of startup option 
+  `--rocksdb.enforce-block-cache-size-limit` from `true` to `false`. 
+  This change prevents RocksDB from going into read-only mode when an internal
+  operation tries to insert some value into the block cache, but can't do so
+  because the block cache's capacity limit is reached.
+
 * Add missing metrics for user traffic: Histograms:
     `arangodb_client_user_connection_statistics_bytes_received`
     `arangodb_client_user_connection_statistics_bytes_sent`

--- a/arangod/RocksDBEngine/RocksDBOptionFeature.cpp
+++ b/arangod/RocksDBEngine/RocksDBOptionFeature.cpp
@@ -186,7 +186,7 @@ RocksDBOptionFeature::RocksDBOptionFeature(Server& server)
       _reserveTableReaderMemory(
           rocksDBTableOptionsDefaults.reserve_table_reader_memory),
       _recycleLogFileNum(rocksDBDefaults.recycle_log_file_num),
-      _enforceBlockCacheSizeLimit(true),
+      _enforceBlockCacheSizeLimit(false),
       _cacheIndexAndFilterBlocks(true),
       _cacheIndexAndFilterBlocksWithHighPriority(
           rocksDBTableOptionsDefaults


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/17747

* BTS-1141: Changed the default value of startup option `--rocksdb.enforce-block-cache-size-limit` from `true` to `false`. This change prevents RocksDB from going into read-only mode when an internal operation tries to insert some value into the block cache, but can't do so because the block cache's capacity limit is reached.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [x] Backports
  - [x] Backport for 3.10: this PR
  - [ ] Backport for 3.9: not needed
  - [ ] Backport for 3.8: not needed

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 