### PR TITLE
reduce dependency on StringBuffer

### DIFF
--- a/lib/Basics/VelocyPackHelper.cpp
+++ b/lib/Basics/VelocyPackHelper.cpp
@@ -51,7 +51,6 @@
 #include "Basics/NumberUtils.h"
 #include "Basics/ScopeGuard.h"
 #include "Basics/StaticStrings.h"
-#include "Basics/StringBuffer.h"
 #include "Basics/StringUtils.h"
 #include "Basics/Utf8Helper.h"
 #include "Basics/error.h"

--- a/lib/Rest/GeneralRequest.cpp
+++ b/lib/Rest/GeneralRequest.cpp
@@ -24,8 +24,6 @@
 
 #include "GeneralRequest.h"
 
-#include "Basics/StaticStrings.h"
-#include "Basics/StringBuffer.h"
 #include "Basics/StringUtils.h"
 #include "Basics/VelocyPackHelper.h"
 #include "Basics/debugging.h"
@@ -36,6 +34,11 @@
 
 using namespace arangodb;
 using namespace arangodb::basics;
+
+namespace {
+// intentionally empty
+std::string const empty{};
+}  // namespace
 
 std::string_view GeneralRequest::translateMethod(RequestType method) {
   switch (method) {
@@ -99,13 +102,6 @@ rest::RequestType GeneralRequest::translateMethod(std::string_view method) {
     return ::translateMethodHelper(std::string_view(methodString));
   }
   return ret;
-}
-
-void GeneralRequest::appendMethod(RequestType method, StringBuffer* buffer) {
-  // append RequestType as string value to given String buffer
-  auto meth = translateMethod(method);
-  buffer->appendText(meth.data(), meth.size());
-  buffer->appendChar(' ');
 }
 
 rest::RequestType GeneralRequest::findRequestType(char const* ptr,
@@ -198,7 +194,7 @@ std::string const& GeneralRequest::header(std::string const& key,
   auto it = _headers.find(key);
   if (it == _headers.end()) {
     found = false;
-    return StaticStrings::Empty;
+    return ::empty;
   }
 
   found = true;
@@ -222,7 +218,7 @@ std::string const& GeneralRequest::value(std::string const& key,
   }
 
   found = false;
-  return StaticStrings::Empty;
+  return ::empty;
 }
 
 std::string const& GeneralRequest::value(std::string const& key) const {

--- a/lib/Rest/GeneralRequest.h
+++ b/lib/Rest/GeneralRequest.h
@@ -45,14 +45,6 @@
 
 namespace arangodb {
 class RequestContext;
-namespace velocypack {
-class Builder;
-struct Options;
-}  // namespace velocypack
-
-namespace basics {
-class StringBuffer;
-}
 
 using rest::ContentType;
 using rest::EncodingType;
@@ -70,9 +62,6 @@ class GeneralRequest {
 
   // translate "HTTP method string" into RequestType enum value
   static RequestType translateMethod(std::string_view method);
-
-  // append RequestType as string value to given String buffer
-  static void appendMethod(RequestType, arangodb::basics::StringBuffer*);
 
  protected:
   static RequestType findRequestType(char const*, size_t const);

--- a/lib/Rest/VstResponse.h
+++ b/lib/Rest/VstResponse.h
@@ -23,10 +23,17 @@
 
 #pragma once
 
-#include "Basics/StringBuffer.h"
 #include "Rest/GeneralResponse.h"
 
+#include <cstdint>
+
+#include <velocypack/Buffer.h>
+
 namespace arangodb {
+namespace velocypack {
+struct Options;
+class Slice;
+}  // namespace velocypack
 
 class VstResponse : public GeneralResponse {
  public:
@@ -34,16 +41,15 @@ class VstResponse : public GeneralResponse {
 
   bool isResponseEmpty() const override { return _payload.empty(); }
 
-  virtual arangodb::Endpoint::TransportType transportType() override {
-    return arangodb::Endpoint::TransportType::VST;
-  };
+  virtual Endpoint::TransportType transportType() override {
+    return Endpoint::TransportType::VST;
+  }
 
   void reset(ResponseCode code) override final;
-  void addPayload(velocypack::Slice slice,
-                  arangodb::velocypack::Options const* = nullptr,
+  void addPayload(velocypack::Slice slice, velocypack::Options const* = nullptr,
                   bool resolveExternals = true) override;
   void addPayload(velocypack::Buffer<uint8_t>&&,
-                  arangodb::velocypack::Options const* = nullptr,
+                  velocypack::Options const* = nullptr,
                   bool resolveExternals = true) override;
   void addRawPayload(std::string_view payload) override;
 

--- a/lib/SimpleHttpClient/SimpleHttpClient.cpp
+++ b/lib/SimpleHttpClient/SimpleHttpClient.cpp
@@ -23,10 +23,12 @@
 /// @author Simon Grätzer
 ////////////////////////////////////////////////////////////////////////////////
 
-#include <stddef.h>
 #include <chrono>
+#include <cstddef>
 #include <cstdint>
 #include <exception>
+#include <string>
+#include <string_view>
 #include <thread>
 #include <utility>
 
@@ -558,7 +560,9 @@ void SimpleHttpClient::setRequest(
   _writeBuffer.clear();
 
   // append method
-  GeneralRequest::appendMethod(method, &_writeBuffer);
+  std::string_view mth = GeneralRequest::translateMethod(method);
+  _writeBuffer.appendText(mth.data(), mth.size());
+  _writeBuffer.appendChar(' ');
 
   // append location
   std::string const* l = &location;

--- a/tests/IResearch/RestHandlerMock.h
+++ b/tests/IResearch/RestHandlerMock.h
@@ -27,10 +27,13 @@
 #include "Rest/GeneralRequest.h"
 #include "Rest/GeneralResponse.h"
 
-struct TRI_vocbase_t;  // forward declaration
+#include <velocypack/Builder.h>
+#include <velocypack/Slice.h>
+
+struct TRI_vocbase_t;
 
 namespace arangodb {
-class VocbaseContext;  // forward declaration
+class VocbaseContext;
 }
 
 struct GeneralRequestMock : public arangodb::GeneralRequest {


### PR DESCRIPTION
### Scope & Purpose

Reduce dependency on `StringBuffer` where it is not actually needed.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: -
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 