### PR TITLE
SEARCH-433 make field name check earlier + test

### DIFF
--- a/arangod/IResearch/IResearchFilterFactory.cpp
+++ b/arangod/IResearch/IResearchFilterFactory.cpp
@@ -1401,12 +1401,6 @@ Result fromArrayComparison(irs::boolean_filter*& filter,
 
   auto const& ctx = filterCtx.query;
 
-  std::string fieldName{ctx.namePrefix};
-  if (!nameFromAttributeAccess(fieldName, *attributeNode, ctx,
-                               filter != nullptr)) {
-    return error::failedToGenerateName("fromArrayComparison", 1);
-  }
-
   if (aql::NODE_TYPE_ARRAY == valueNode->type) {
     if (!attributeNode->isDeterministic()) {
       // not supported by IResearch, but could be handled by ArangoDB
@@ -1504,6 +1498,12 @@ Result fromArrayComparison(irs::boolean_filter*& filter,
       !checkAttributeAccess(attributeNode, *ctx.ref, !ctx.isSearchQuery) ||
       findReference(*valueNode, *ctx.ref)) {
     return fromExpression(filter, filterCtx, node);
+  }
+
+  std::string fieldName{ctx.namePrefix};
+  if (!nameFromAttributeAccess(fieldName, *attributeNode, ctx,
+                               filter != nullptr)) {
+    return error::failedToGenerateName("fromArrayComparison", 1);
   }
 
   if (!filter) {


### PR DESCRIPTION
### Scope & Purpose

For IN and Array IN operators attribute name check was moved earlier. So it is not skipped during optimization phase

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [x] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [x] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.10: *(Please link PR)*


