### PR TITLE
Delete duplicate compile-warnings options

### DIFF
--- a/arangod/Agency/CMakeLists.txt
+++ b/arangod/Agency/CMakeLists.txt
@@ -39,6 +39,3 @@ target_link_libraries(arango_agency
 target_include_directories(arango_agency PRIVATE
   "${PROJECT_SOURCE_DIR}/arangod"
   "${PROJECT_SOURCE_DIR}/${ENTERPRISE_INCLUDE_DIR}")
-
-target_compile_options(arango_agency PRIVATE
-	${CMAKE_DEPRECATE_OPTIONS})

--- a/arangod/Aql/CMakeLists.txt
+++ b/arangod/Aql/CMakeLists.txt
@@ -187,9 +187,6 @@ target_include_directories(arango_aql PRIVATE
   "${PROJECT_SOURCE_DIR}/arangod"
   "${PROJECT_SOURCE_DIR}/${ENTERPRISE_INCLUDE_DIR}")
 
-target_compile_options(arango_aql PRIVATE
-	${CMAKE_DEPRECATE_OPTIONS})
-
 ################################################################################
 ## BISON/FLEX
 ################################################################################

--- a/arangod/CMakeLists.txt
+++ b/arangod/CMakeLists.txt
@@ -2,19 +2,6 @@
 ## define variables
 ################################################################################
 
-# TODO move CMAKE_DEPRECATE_OPTIONS to presets
-if (USE_FAIL_ON_WARNINGS)
-  if (MSVC)
-    list(APPEND ${CMAKE_DEPRECATE_OPTIONS} /WX /D_WINSOCK_DEPRECATED_NO_WARNINGS)
-    if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang") # clang-cl.exe
-      # There's a warning about /MP being unused if compiling only a single file
-      list(APPEND ${CMAKE_DEPRECATE_OPTIONS} -Wno-unused-command-line-argument)
-    endif()
-  else ()
-    list(APPEND ${CMAKE_DEPRECATE_OPTIONS} -Werror -Wno-error=deprecated-declarations)
-  endif ()
-endif ()
-
 add_compile_warnings_flags()
 
 ################################################################################
@@ -55,8 +42,6 @@ target_include_directories(${BIN_ARANGOD} PRIVATE
   "${PROJECT_SOURCE_DIR}/arangod"
   "${PROJECT_SOURCE_DIR}/${ENTERPRISE_INCLUDE_DIR}")
 
-target_compile_options(${BIN_ARANGOD} PRIVATE
-	${CMAKE_DEPRECATE_OPTIONS})
 target_compile_features(${BIN_ARANGOD} PRIVATE cxx_constexpr)
 
 ################################################################################

--- a/arangod/Cache/CMakeLists.txt
+++ b/arangod/Cache/CMakeLists.txt
@@ -25,6 +25,3 @@ target_link_libraries(arango_cache
 target_include_directories(arango_cache PRIVATE
   "${PROJECT_SOURCE_DIR}/arangod"
   "${PROJECT_SOURCE_DIR}/${ENTERPRISE_INCLUDE_DIR}")
-
-target_compile_options(arango_cache PRIVATE
-	${CMAKE_DEPRECATE_OPTIONS})

--- a/arangod/Cluster/CMakeLists.txt
+++ b/arangod/Cluster/CMakeLists.txt
@@ -10,6 +10,3 @@ target_link_libraries(arango_cluster_methods
 target_include_directories(arango_cluster_methods PRIVATE
   "${PROJECT_SOURCE_DIR}/arangod"
   "${PROJECT_SOURCE_DIR}/${ENTERPRISE_INCLUDE_DIR}")
-
-target_compile_options(arango_cluster_methods PRIVATE
-	${CMAKE_DEPRECATE_OPTIONS})

--- a/arangod/ClusterEngine/CMakeLists.txt
+++ b/arangod/ClusterEngine/CMakeLists.txt
@@ -25,6 +25,3 @@ target_include_directories(arango_cluster_engine PUBLIC
 target_include_directories(arango_cluster_engine PRIVATE
   "${PROJECT_SOURCE_DIR}/arangod"
   "${PROJECT_SOURCE_DIR}/${ENTERPRISE_INCLUDE_DIR}")
-
-target_compile_options(arango_cluster_engine PRIVATE
-	${CMAKE_DEPRECATE_OPTIONS})

--- a/arangod/Graph/CMakeLists.txt
+++ b/arangod/Graph/CMakeLists.txt
@@ -35,9 +35,6 @@ target_include_directories(arango_graph PRIVATE
   "${PROJECT_SOURCE_DIR}/arangod"
   "${PROJECT_SOURCE_DIR}/${ENTERPRISE_INCLUDE_DIR}")
 
-target_compile_options(arango_graph PRIVATE
-	${CMAKE_DEPRECATE_OPTIONS})
-
 add_subdirectory(Cache)
 add_subdirectory(Cursors)
 add_subdirectory(Enumerators)

--- a/arangod/IResearch/CMakeLists.txt
+++ b/arangod/IResearch/CMakeLists.txt
@@ -105,5 +105,3 @@ target_include_directories(arango_iresearch PRIVATE
 
 target_compile_definitions(arango_iresearch
   PUBLIC "$<$<CONFIG:Debug>:IRESEARCH_DEBUG=1>")
-target_compile_options(arango_iresearch PRIVATE
-	${CMAKE_DEPRECATE_OPTIONS})

--- a/arangod/Indexes/CMakeLists.txt
+++ b/arangod/Indexes/CMakeLists.txt
@@ -23,6 +23,3 @@ target_include_directories(arango_indexes
 target_include_directories(arango_indexes PRIVATE
   "${PROJECT_SOURCE_DIR}/arangod"
   "${PROJECT_SOURCE_DIR}/${ENTERPRISE_INCLUDE_DIR}")
-
-target_compile_options(arango_indexes PRIVATE
-	${CMAKE_DEPRECATE_OPTIONS})

--- a/arangod/Metrics/CMakeLists.txt
+++ b/arangod/Metrics/CMakeLists.txt
@@ -16,6 +16,3 @@ target_link_libraries(arango_metrics
 target_include_directories(arango_metrics PRIVATE
   "${PROJECT_SOURCE_DIR}/arangod"
   "${PROJECT_SOURCE_DIR}/${ENTERPRISE_INCLUDE_DIR}")
-
-target_compile_options(arango_metrics PRIVATE
-	${CMAKE_DEPRECATE_OPTIONS})

--- a/arangod/Network/CMakeLists.txt
+++ b/arangod/Network/CMakeLists.txt
@@ -17,6 +17,3 @@ target_link_libraries(arango_network
 target_include_directories(arango_network PRIVATE
   "${PROJECT_SOURCE_DIR}/arangod"
   "${PROJECT_SOURCE_DIR}/${ENTERPRISE_INCLUDE_DIR}")
-
-target_compile_options(arango_network PRIVATE
-	${CMAKE_DEPRECATE_OPTIONS})

--- a/arangod/Pregel/CMakeLists.txt
+++ b/arangod/Pregel/CMakeLists.txt
@@ -27,5 +27,4 @@ target_include_directories(arango_pregel PRIVATE
   "${PROJECT_SOURCE_DIR}/arangod"
   "${PROJECT_SOURCE_DIR}/${ENTERPRISE_INCLUDE_DIR}")
 
-add_subdirectory(REST)
 add_subdirectory(Algos)

--- a/arangod/Pregel/CMakeLists.txt
+++ b/arangod/Pregel/CMakeLists.txt
@@ -27,7 +27,5 @@ target_include_directories(arango_pregel PRIVATE
   "${PROJECT_SOURCE_DIR}/arangod"
   "${PROJECT_SOURCE_DIR}/${ENTERPRISE_INCLUDE_DIR}")
 
-target_compile_options(arango_pregel PRIVATE
-	${CMAKE_DEPRECATE_OPTIONS})
-
+add_subdirectory(REST)
 add_subdirectory(Algos)

--- a/arangod/Replication/CMakeLists.txt
+++ b/arangod/Replication/CMakeLists.txt
@@ -25,6 +25,3 @@ target_link_libraries(arango_replication
 target_include_directories(arango_replication PRIVATE
   "${PROJECT_SOURCE_DIR}/arangod"
   "${PROJECT_SOURCE_DIR}/${ENTERPRISE_INCLUDE_DIR}")
-
-target_compile_options(arango_replication PRIVATE
-	${CMAKE_DEPRECATE_OPTIONS})

--- a/arangod/Replication2/CMakeLists.txt
+++ b/arangod/Replication2/CMakeLists.txt
@@ -20,9 +20,6 @@ target_include_directories(arango_replication2 PRIVATE
   "${PROJECT_SOURCE_DIR}/arangod"
   "${PROJECT_SOURCE_DIR}/${ENTERPRISE_INCLUDE_DIR}")
 
-target_compile_options(arango_replication2 PRIVATE
-	${CMAKE_DEPRECATE_OPTIONS})
-
 add_subdirectory(Exceptions)
 add_subdirectory(ReplicatedLog)
 add_subdirectory(ReplicatedState)

--- a/arangod/RestHandler/CMakeLists.txt
+++ b/arangod/RestHandler/CMakeLists.txt
@@ -10,6 +10,3 @@ target_link_libraries(arango_common_rest_handler
 target_include_directories(arango_common_rest_handler PRIVATE
   "${PROJECT_SOURCE_DIR}/arangod"
   "${PROJECT_SOURCE_DIR}/${ENTERPRISE_INCLUDE_DIR}")
-
-target_compile_options(arango_common_rest_handler PRIVATE
-	${CMAKE_DEPRECATE_OPTIONS})

--- a/arangod/RocksDBEngine/CMakeLists.txt
+++ b/arangod/RocksDBEngine/CMakeLists.txt
@@ -121,8 +121,5 @@ target_include_directories(arango_rocksdb PRIVATE
   "${PROJECT_SOURCE_DIR}/arangod"
   "${PROJECT_SOURCE_DIR}/${ENTERPRISE_INCLUDE_DIR}")
 
-target_compile_options(arango_rocksdb PRIVATE
-	${CMAKE_DEPRECATE_OPTIONS})
-
 add_subdirectory(Listeners)
 add_subdirectory(Methods)

--- a/arangod/StorageEngine/CMakeLists.txt
+++ b/arangod/StorageEngine/CMakeLists.txt
@@ -4,8 +4,6 @@ target_link_libraries(arango_health arango)
 target_include_directories(arango_health PRIVATE
   "${PROJECT_SOURCE_DIR}/arangod"
   "${PROJECT_SOURCE_DIR}/${ENTERPRISE_INCLUDE_DIR}")
-target_compile_options(arango_health PRIVATE
-	${CMAKE_DEPRECATE_OPTIONS})
 
 add_library(arango_storage_engine STATIC
   EngineSelectorFeature.cpp
@@ -24,8 +22,6 @@ target_link_libraries(arango_storage_engine
 target_include_directories(arango_storage_engine PRIVATE
   "${PROJECT_SOURCE_DIR}/arangod"
   "${PROJECT_SOURCE_DIR}/${ENTERPRISE_INCLUDE_DIR}")
-target_compile_options(arango_storage_engine PRIVATE
-	${CMAKE_DEPRECATE_OPTIONS})
 
 # arango_storage_engine uses arango_rocksdb.
 # In turn, arango_storage_engine_common provides something for both.
@@ -39,5 +35,3 @@ target_link_libraries(arango_storage_engine_common
 target_include_directories(arango_storage_engine_common PRIVATE
   "${PROJECT_SOURCE_DIR}/arangod"
   "${PROJECT_SOURCE_DIR}/${ENTERPRISE_INCLUDE_DIR}")
-target_compile_options(arango_storage_engine_common PRIVATE
-	${CMAKE_DEPRECATE_OPTIONS})

--- a/arangod/Utils/CMakeLists.txt
+++ b/arangod/Utils/CMakeLists.txt
@@ -17,6 +17,3 @@ target_link_libraries(arango_utils
 target_include_directories(arango_utils PRIVATE
   "${PROJECT_SOURCE_DIR}/arangod"
   "${PROJECT_SOURCE_DIR}/${ENTERPRISE_INCLUDE_DIR}")
-
-target_compile_options(arango_utils PRIVATE
-	${CMAKE_DEPRECATE_OPTIONS})

--- a/arangod/V8Server/CMakeLists.txt
+++ b/arangod/V8Server/CMakeLists.txt
@@ -37,6 +37,3 @@ target_link_libraries(arango_v8server
 target_include_directories(arango_v8server PRIVATE
   "${PROJECT_SOURCE_DIR}/arangod"
   "${PROJECT_SOURCE_DIR}/${ENTERPRISE_INCLUDE_DIR}")
-
-target_compile_options(arango_v8server PRIVATE
-	${CMAKE_DEPRECATE_OPTIONS})

--- a/arangod/VocBase/CMakeLists.txt
+++ b/arangod/VocBase/CMakeLists.txt
@@ -29,9 +29,6 @@ target_include_directories(arango_vocbase PRIVATE
   "${PROJECT_SOURCE_DIR}/arangod"
   "${PROJECT_SOURCE_DIR}/${ENTERPRISE_INCLUDE_DIR}")
 
-target_compile_options(arango_vocbase PRIVATE
-	${CMAKE_DEPRECATE_OPTIONS})
-
 add_subdirectory(Identifiers)
 add_subdirectory(Methods)
 add_subdirectory(Properties)

--- a/arangod/arangoserver.cmake
+++ b/arangod/arangoserver.cmake
@@ -224,7 +224,4 @@ target_include_directories(arangoserver PRIVATE
   "${PROJECT_SOURCE_DIR}/arangod"
   "${PROJECT_SOURCE_DIR}/${ENTERPRISE_INCLUDE_DIR}")
 
-target_compile_options(arangoserver PRIVATE
-	${CMAKE_DEPRECATE_OPTIONS})
-
 add_dependencies(arangoserver tzdata)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -340,20 +340,6 @@ target_include_directories(arangodbtests PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}/Mocks/
 )
 
-
-if(MSVC AND USE_FAIL_ON_WARNINGS)
-  target_compile_options(arangodbtests PRIVATE /WX /D_WINSOCK_DEPRECATED_NO_WARNINGS)
-  if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang") # clang-cl.exe
-    # There's a warning about /MP being unused if compiling only a single file
-    target_compile_options(arangodbtests PRIVATE -Wno-unused-command-line-argument)
-  endif()
-endif()
-
-if (DARWIN AND USE_FAIL_ON_WARNINGS)
-  # Missing Braces is broken in older CLangs - disable them here.
-  target_compile_options(arangodbtests PRIVATE -Werror -Wno-error=deprecated-declarations -Wno-missing-braces)
-endif()
-
 # add these includes as system includes because otherwise
 # the compiler will emit warnings for fakeit.hpp
 target_include_directories(arangodbtests SYSTEM PRIVATE


### PR DESCRIPTION
Deletes duplicate compile-warnings options: Options are already added via add_compile_warnings_flags function.
