### PR TITLE
clang-format.ps1: Fix for call operator change in pwsh 7.3.0

### DIFF
--- a/scripts/clang-format.ps1
+++ b/scripts/clang-format.ps1
@@ -16,7 +16,7 @@ if (![bool]$git_for_windows.InstallPath) {
 
 # Using bash.exe because git-bash.exe would open a new window
 $git_bash = Join-Path ($git_for_windows).InstallPath 'bin' 'bash.exe'
-$files = ''
+$files = $null
 if ($args.length -gt 0) {
     $files = $args.Replace('\', '/')
 }


### PR DESCRIPTION
Unbreaks the PowerShell wrapper script. Starting with pwsh v7.3.0, the call operator seems to forward a variable with an empty string as such, causing the `clang-format.sh` script not to find any files (unless explicitly specified).