### PR TITLE
attempt to fix unstable test

### DIFF
--- a/tests/js/common/shell/shell-collection-noncluster.js
+++ b/tests/js/common/shell/shell-collection-noncluster.js
@@ -180,8 +180,7 @@ function CollectionSuite () {
       try {
         c.rename(cn1);
         fail();
-      }
-      catch (err2) {
+      } catch (err2) {
         assertEqual(ERRORS.ERROR_FORBIDDEN.code, err2.errorNum);
       }
 
@@ -190,70 +189,91 @@ function CollectionSuite () {
     },
 
     testEdgeCacheBehavior : function() {
-      var cn = "UnitLoadBehavior123";
-      db._drop(cn);
-      var c = db._createEdgeCollection(cn);
-      try {
-        c.load();
-        for (let i = 0; i < 10000; i++) {
-          c.insert({_from:"c/v"+ (i / 100), _to:"c/v" + i});
-          c.insert({_to:"c/v"+ (i / 100), _from:"c/v" + i});
-        }
-
-        // check if edge cache is present
-        var idxs = c.getIndexes(true);
-        assertEqual("edge", idxs[1].type, idxs);
-
-        var initial = [];
-        idxs.forEach(function(idx) {
-          if (idx.figures.cacheInUse) {
-            initial.push(idx.figures);
-          } else {
-            initial.push(-1);
-          }
-        });
-
-        c.loadIndexesIntoMemory();
-
-        // checking if edge cache grew
-        idxs = c.getIndexes(true);
-        idxs.forEach(function(idx, i) {
-          if (idx.figures.cacheInUse) {
-            assertTrue(idx.figures.cacheSize >= initial[i].cacheSize, idx);
-            assertEqual(idx.figures.cacheLifeTimeHitRate, 0, idx);
-            initial[i] = idx.figures;
-          }
-        });
-
-        for (let i = 0; i < 10000; i++) {
-          c.outEdges("c/v" + (i / 100));
-          c.inEdges("c/v" + (i / 100));
-        }
-        idxs = c.getIndexes(true);
-        // cache was filled with same queries, hit rate must now increase
-        idxs.forEach(function(idx, i) {
-          if (idx.figures.cacheInUse) {
-            let diff = Math.abs(initial[i].cacheSize - idx.figures.cacheSize);
-            assertTrue(diff <= Math.pow(2, 23), { diff, initial: initial[i], figures: idx.figures });
-            // this assumption is simply not safe
-            //assertTrue(idx.figures.cacheLifeTimeHitRate > 15, idx);
-            initial[i] = idx.figures;
-          }
-        });
-        for (let i = 0; i < 10000; i++) {
-          c.outEdges("c/v" + (i / 100));
-          c.inEdges("c/v" + (i / 100));
-        }
-        idxs = c.getIndexes(true);
-        // cache was filled with same queries, hit rate must be higher
-        idxs.forEach(function(idx, i) {
-          if (idx.figures.cacheInUse) {
-            assertTrue(Math.abs(initial[i].cacheSize - idx.figures.cacheSize) < 1024);
-            assertTrue(idx.figures.cacheLifeTimeHitRate > initial[i].cacheLifeTimeHitRate, idx, { idx, initial });
-          }
-        });
-      } finally {
+      const cn = "UnitLoadBehavior123";
+        
+      let tries = 0;
+      // allow ourselves to make up to 3 attempts for this test.
+      // this is necessary because the edge cache is not 100%
+      // deterministic (cache grow requests are executed asynchronously
+      // and thus depend on timing)
+      while (++tries <= 3) {
         db._drop(cn);
+        let c = db._createEdgeCollection(cn);
+        try {
+          let docs = [];
+          for (let i = 0; i < 10000; i++) {
+            docs.push({_from: "c/v"+ (i / 100), _to: "c/v" + i});
+            docs.push({_to: "c/v"+ (i / 100), _from: "c/v" + i});
+            if (docs.length === 1000) {
+              c.insert(docs);
+              docs = [];
+            }
+          }
+
+          // check if edge cache is present
+          let idxs = c.getIndexes(true);
+          assertEqual("edge", idxs[1].type, idxs);
+
+          let initial = [];
+          idxs.forEach(function(idx) {
+            if (idx.figures.cacheInUse) {
+              initial.push(idx.figures);
+            } else {
+              initial.push(-1);
+            }
+          });
+
+          c.loadIndexesIntoMemory();
+          // loading is async - wait a bit for the caches to be populated
+          internal.wait(3);
+
+          // checking if edge cache grew
+          idxs = c.getIndexes(true);
+          idxs.forEach(function(idx, i) {
+            if (idx.figures.cacheInUse) {
+              assertTrue(idx.figures.cacheSize >= initial[i].cacheSize, idx);
+              assertEqual(idx.figures.cacheLifeTimeHitRate, 0, idx);
+              initial[i] = idx.figures;
+            }
+          });
+
+          for (let i = 0; i < 10000; i++) {
+            c.outEdges("c/v" + (i / 100));
+            c.inEdges("c/v" + (i / 100));
+          }
+          idxs = c.getIndexes(true);
+          // cache was filled with same queries, hit rate must now increase
+          idxs.forEach(function(idx, i) {
+            if (idx.figures.cacheInUse) {
+              let diff = Math.abs(initial[i].cacheSize - idx.figures.cacheSize);
+              assertTrue(diff <= Math.pow(2, 23), { diff, initial: initial[i], figures: idx.figures });
+              // this assumption is simply not safe
+              //assertTrue(idx.figures.cacheLifeTimeHitRate > 15, idx);
+              initial[i] = idx.figures;
+            }
+          });
+          for (let i = 0; i < 10000; i++) {
+            c.outEdges("c/v" + (i / 100));
+            c.inEdges("c/v" + (i / 100));
+          }
+          idxs = c.getIndexes(true);
+          // cache was filled with same queries, hit rate must be higher
+          idxs.forEach(function(idx, i) {
+            if (idx.figures.cacheInUse) {
+              assertTrue(Math.abs(initial[i].cacheSize - idx.figures.cacheSize) < 1024);
+              assertTrue(idx.figures.cacheLifeTimeHitRate > initial[i].cacheLifeTimeHitRate, { idx, initial });
+            }
+          });
+          // success. exit while loop
+          break;
+        } catch (err) {
+          // ignore errors in round 1 and 2
+          if (tries === 3) {
+            throw err;
+          }
+        } finally {
+          db._drop(cn);
+        }
       }
     }
   };


### PR DESCRIPTION
### Scope & Purpose

Attempt to fix an unstable test.
The edge cache behavior depends on timing (loading is done asynchronously, and cache grow requests are also executed asynchronously). Thus run the test up to 3 times, and only let it fail in run 3.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: -
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 