### PR TITLE
FailedLeader does not add follower - BTS-1162

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,15 @@
+v3.9.7 (XXXX-XX-XX)
+-------------------
+
+* Added a configuration option (for the agency):
+    --agency.supervision-failed-leader-adds-follower
+  with a default of `true` (behaviour as before). If set to `false`,
+  a `FailedLeader` job does not automatically configure a new shard
+  follower, thereby preventing unnecessary network traffic, CPU and IO load
+  for the case that the server comes back quickly. If the server is
+  permanently failed, an `AddFollower` job will be created anyway eventually.
+
+
 v3.9.6 (2022-12-06)
 -------------------
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,7 +3,7 @@ v3.9.7 (XXXX-XX-XX)
 
 * Added a configuration option (for the agency):
     --agency.supervision-failed-leader-adds-follower
-  with a default of `true` (behaviour as before). If set to `false`,
+  with a default of `true` (behavior as before). If set to `false`,
   a `FailedLeader` job does not automatically configure a new shard
   follower, thereby preventing unnecessary network traffic, CPU and IO load
   for the case that the server comes back quickly. If the server is

--- a/arangod/Agency/AgencyFeature.cpp
+++ b/arangod/Agency/AgencyFeature.cpp
@@ -69,6 +69,7 @@ AgencyFeature::AgencyFeature(application_features::ApplicationServer& server)
       _supervisionOkThreshold(5.0),
       _supervisionDelayAddFollower(0),
       _supervisionDelayFailedFollower(0),
+      _failedLeaderAddsFollower(true),
       _cmdLineTimings(false) {
   setOptional(true);
   startsAfter<FoxxFeaturePhase>();
@@ -176,6 +177,17 @@ void AgencyFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
                       arangodb::options::Flags::DefaultNoComponents,
                       arangodb::options::Flags::OnAgent))
       .setIntroducedIn(30906)
+      .setIntroducedIn(31002);
+
+  options
+      ->addOption("--agency.supervision-failed-leader-adds-follower",
+                  "Flag indicating whether or not the FailedLeader job adds a "
+                  "new follower.",
+                  new BooleanParameter(&_failedLeaderAddsFollower),
+                  arangodb::options::makeFlags(
+                      arangodb::options::Flags::DefaultNoComponents,
+                      arangodb::options::Flags::OnAgent))
+      .setIntroducedIn(30907)
       .setIntroducedIn(31002);
 
   options->addOption(
@@ -393,7 +405,8 @@ void AgencyFeature::prepare() {
           _supervisionTouched, _waitForSync, _supervisionFrequency,
           _compactionStepSize, _compactionKeepSize, _supervisionGracePeriod,
           _supervisionOkThreshold, _supervisionDelayAddFollower,
-          _supervisionDelayFailedFollower, _cmdLineTimings, _maxAppendSize)));
+          _supervisionDelayFailedFollower, _failedLeaderAddsFollower,
+          _cmdLineTimings, _maxAppendSize)));
 }
 
 void AgencyFeature::start() {

--- a/arangod/Agency/AgencyFeature.h
+++ b/arangod/Agency/AgencyFeature.h
@@ -65,6 +65,7 @@ class AgencyFeature : public application_features::ApplicationFeature {
   double _supervisionOkThreshold;
   uint64_t _supervisionDelayAddFollower;
   uint64_t _supervisionDelayFailedFollower;
+  bool _failedLeaderAddsFollower;
   std::string _agencyMyAddress;
   std::vector<std::string> _agencyEndpoints;
   bool _cmdLineTimings;

--- a/arangod/Agency/Agent.cpp
+++ b/arangod/Agency/Agent.cpp
@@ -2506,6 +2506,14 @@ void Agent::updateSomeConfigValues(VPackSlice data) {
     _config.setSupervisionDelayFailedFollower(u);
     _supervision.setDelayFailedFollower(u);
   }
+  slice = data.get("failedLeaderAddsFollower");
+  if (slice.isBool()) {
+    bool b = slice.getBool();
+    LOG_TOPIC("12345", DEBUG, Logger::SUPERVISION)
+        << "Updating failedLeaderAddsFollower to " << b;
+    _config.setSupervisionDelayFailedFollower(b);
+    _supervision->setFailedLeaderAddsFollower(b);
+  }
 }
 
 std::vector<log_t> Agent::logs(index_t begin, index_t end) const {

--- a/arangod/Agency/Agent.cpp
+++ b/arangod/Agency/Agent.cpp
@@ -2512,7 +2512,7 @@ void Agent::updateSomeConfigValues(VPackSlice data) {
     LOG_TOPIC("12345", DEBUG, Logger::SUPERVISION)
         << "Updating failedLeaderAddsFollower to " << b;
     _config.setSupervisionDelayFailedFollower(b);
-    _supervision->setFailedLeaderAddsFollower(b);
+    _supervision.setFailedLeaderAddsFollower(b);
   }
 }
 

--- a/arangod/Agency/Agent.cpp
+++ b/arangod/Agency/Agent.cpp
@@ -2511,7 +2511,7 @@ void Agent::updateSomeConfigValues(VPackSlice data) {
     bool b = slice.getBool();
     LOG_TOPIC("12345", DEBUG, Logger::SUPERVISION)
         << "Updating failedLeaderAddsFollower to " << b;
-    _config.setSupervisionDelayFailedFollower(b);
+    _config.setSupervisionFailedLeaderAddsFollower(b);
     _supervision.setFailedLeaderAddsFollower(b);
   }
 }

--- a/arangod/Agency/AgentConfiguration.cpp
+++ b/arangod/Agency/AgentConfiguration.cpp
@@ -53,6 +53,8 @@ std::string const config_t::supervisionDelayAddFollowerStr =
     "supervision delay add follower job time";
 std::string const config_t::supervisionDelayFailedFollowerStr =
     "supervision delay failed follower job time";
+std::string const config_t::supervisionFailedLeaderAddsFollowerStr =
+    "supervision FailedLeader job adds a new follower";
 std::string const config_t::compactionStepSizeStr = "compaction step size";
 std::string const config_t::compactionKeepSizeStr = "compaction keep size";
 std::string const config_t::defaultEndpointStr = "tcp://localhost:8529";
@@ -86,7 +88,7 @@ config_t::config_t(std::string const& rid, size_t as, size_t ps, double minp,
                    double maxp, std::string const& e,
                    std::vector<std::string> const& g, bool s, bool st, bool w,
                    double f, uint64_t c, uint64_t k, double p, double o,
-                   uint64_t q, uint64_t r, bool t, size_t a)
+                   uint64_t q, uint64_t r, bool t2, bool t, size_t a)
     : _recoveryId(rid),
       _agencySize(as),
       _poolSize(ps),
@@ -105,6 +107,7 @@ config_t::config_t(std::string const& rid, size_t as, size_t ps, double minp,
       _supervisionOkThreshold(o),
       _supervisionDelayAddFollower(q),
       _supervisionDelayFailedFollower(r),
+      _supervisionFailedLeaderAddsFollower(t2),
       _cmdLineTimings(t),
       _version(0),
       _startup("origin"),
@@ -140,6 +143,8 @@ config_t& config_t::operator=(config_t const& other) {
   _supervisionOkThreshold = other._supervisionOkThreshold;
   _supervisionDelayAddFollower = other._supervisionDelayAddFollower;
   _supervisionDelayFailedFollower = other._supervisionDelayFailedFollower;
+  _supervisionFailedLeaderAddsFollower =
+      other._supervisionFailedLeaderAddsFollower;
   _cmdLineTimings = other._cmdLineTimings;
   _version = other._version;
   _startup = other._startup;
@@ -171,6 +176,8 @@ config_t& config_t::operator=(config_t&& other) {
   _supervisionDelayAddFollower = std::move(other._supervisionDelayAddFollower);
   _supervisionDelayFailedFollower =
       std::move(other._supervisionDelayFailedFollower);
+  _supervisionFailedLeaderAddsFollower =
+      std::move(other._supervisionFailedLeaderAddsFollower);
   _cmdLineTimings = std::move(other._cmdLineTimings);
   _version = std::move(other._version);
   _startup = std::move(other._startup);
@@ -206,6 +213,11 @@ uint64_t config_t::supervisionDelayAddFollower() const {
 uint64_t config_t::supervisionDelayFailedFollower() const {
   READ_LOCKER(readLocker, _lock);
   return _supervisionDelayFailedFollower;
+}
+
+bool config_t::supervisionFailedLeaderAddsFollower() const {
+  READ_LOCKER(readLocker, _lock);
+  return _supervisionFailedLeaderAddsFollower;
 }
 
 double config_t::minPing() const {
@@ -498,6 +510,8 @@ void config_t::toBuilder(VPackBuilder& builder) const {
                 VPackValue(_supervisionDelayAddFollower));
     builder.add(supervisionDelayFailedFollowerStr,
                 VPackValue(_supervisionDelayFailedFollower));
+    builder.add(supervisionFailedLeaderAddsFollowerStr,
+                VPackValue(_supervisionFailedLeaderAddsFollower));
     builder.add(versionStr, VPackValue(_version));
     builder.add(startupStr, VPackValue(_startup));
   }
@@ -769,6 +783,10 @@ void config_t::updateConfiguration(VPackSlice const& other) {
   if (other.hasKey(supervisionDelayFailedFollowerStr)) {
     _supervisionDelayFailedFollower =
         other.get(supervisionDelayFailedFollowerStr).getNumber<uint64_t>();
+  }
+  if (other.hasKey(supervisionFailedLeaderAddsFollowerStr)) {
+    _supervisionFailedLeaderAddsFollower =
+        other.get(supervisionFailedLeaderAddsFollowerStr).getBoolean();
   }
   if (other.hasKey(compactionStepSizeStr)) {
     _compactionStepSize =

--- a/arangod/Agency/AgentConfiguration.h
+++ b/arangod/Agency/AgentConfiguration.h
@@ -25,6 +25,7 @@
 
 #include "Agency/AgencyCommon.h"
 #include "Basics/ReadWriteLock.h"
+#include "Basics/WriteLocker.h"
 
 #include <velocypack/Iterator.h>
 #include <velocypack/velocypack-aliases.h>
@@ -252,23 +253,32 @@ struct config_t {
   bool supervisionFailedLeaderAddsFollower() const;
 
   /// @brief set Supervision grace period
-  void setSupervisionGracePeriod(double d) { _supervisionGracePeriod = d; }
+  void setSupervisionGracePeriod(double d) {
+    WRITE_LOCKER(writeLocker, _lock);
+    _supervisionGracePeriod = d;
+  }
 
   /// @brief set Supervision ok threshold
-  void setSupervisionOkThreshold(double d) { _supervisionOkThreshold = d; }
+  void setSupervisionOkThreshold(double d) {
+    WRITE_LOCKER(writeLocker, _lock);
+    _supervisionOkThreshold = d;
+  }
 
   /// @brief set Supervision delay add follower
   void setSupervisionDelayAddFollower(uint64_t d) {
+    WRITE_LOCKER(writeLocker, _lock);
     _supervisionDelayAddFollower = d;
   }
 
   /// @brief set Supervision delay failed follower
   void setSupervisionDelayFailedFollower(uint64_t d) {
+    WRITE_LOCKER(writeLocker, _lock);
     _supervisionDelayFailedFollower = d;
   }
 
   /// @brief set Supervision FailedLeader adds follower flag
   void setSupervisionFailedLeaderAddsFollower(bool f) {
+    WRITE_LOCKER(writeLocker, _lock);
     _supervisionFailedLeaderAddsFollower = f;
   }
 

--- a/arangod/Agency/AgentConfiguration.h
+++ b/arangod/Agency/AgentConfiguration.h
@@ -58,6 +58,7 @@ struct config_t {
   double _supervisionOkThreshold;
   uint64_t _supervisionDelayAddFollower;
   uint64_t _supervisionDelayFailedFollower;
+  bool _supervisionFailedLeaderAddsFollower;
   bool _cmdLineTimings;
   size_t _version;
   std::string _startup;
@@ -84,6 +85,7 @@ struct config_t {
   static std::string const supervisionOkThresholdStr;
   static std::string const supervisionDelayAddFollowerStr;
   static std::string const supervisionDelayFailedFollowerStr;
+  static std::string const supervisionFailedLeaderAddsFollowerStr;
   static std::string const compactionStepSizeStr;
   static std::string const compactionKeepSizeStr;
   static std::string const defaultEndpointStr;
@@ -99,7 +101,7 @@ struct config_t {
   config_t(std::string const& rid, size_t as, size_t ps, double minp,
            double maxp, std::string const& e, std::vector<std::string> const& g,
            bool s, bool st, bool w, double f, uint64_t c, uint64_t k, double p,
-           double o, uint64_t q, uint64_t r, bool t, size_t a);
+           double o, uint64_t q, uint64_t r, bool t2, bool t, size_t a);
 
   /// @brief copy constructor
   config_t(config_t const&);
@@ -246,6 +248,9 @@ struct config_t {
   /// @brief Supervision delay failed follower
   uint64_t supervisionDelayFailedFollower() const;
 
+  /// @brief Supervision delay failed follower
+  bool supervisionFailedLeaderAddsFollower() const;
+
   /// @brief set Supervision grace period
   void setSupervisionGracePeriod(double d) { _supervisionGracePeriod = d; }
 
@@ -260,6 +265,11 @@ struct config_t {
   /// @brief set Supervision delay failed follower
   void setSupervisionDelayFailedFollower(uint64_t d) {
     _supervisionDelayFailedFollower = d;
+  }
+
+  /// @brief set Supervision FailedLeader adds follower flag
+  void setSupervisionFailedLeaderAddsFollower(bool f) {
+    _supervisionFailedLeaderAddsFollower = f;
   }
 
   /// @brief

--- a/arangod/Agency/FailedLeader.cpp
+++ b/arangod/Agency/FailedLeader.cpp
@@ -37,12 +37,14 @@ FailedLeader::FailedLeader(Node const& snapshot, AgentInterface* agent,
                            std::string const& jobId, std::string const& creator,
                            std::string const& database,
                            std::string const& collection,
-                           std::string const& shard, std::string const& from)
+                           std::string const& shard, std::string const& from,
+                           bool addsFollower)
     : Job(NOTFOUND, snapshot, agent, jobId, creator),
       _database(database),
       _collection(collection),
       _shard(shard),
-      _from(from) {}
+      _from(from),
+      _addsFollower(addsFollower) {}
 
 FailedLeader::FailedLeader(Node const& snapshot, AgentInterface* agent,
                            JOB_STATUS status, std::string const& jobId)
@@ -52,11 +54,15 @@ FailedLeader::FailedLeader(Node const& snapshot, AgentInterface* agent,
   auto tmp_database = _snapshot.hasAsString(path + "database");
   auto tmp_collection = _snapshot.hasAsString(path + "collection");
   auto tmp_from = _snapshot.hasAsString(path + "fromServer");
+  auto tmp_addsFollower = _snapshot.hasAsBool(path + "addsFollower");
 
   // set only if already started (test to prevent warning)
   if (_snapshot.has(path + "toServer")) {
     auto tmp_to = _snapshot.hasAsString(path + "toServer");
     _to = tmp_to.value();
+  }
+  if (tmp_addsFollower) {
+    _addsFollower = tmp_addsFollower.value();
   }
 
   auto tmp_shard = _snapshot.hasAsString(path + "shard");
@@ -161,6 +167,7 @@ bool FailedLeader::create(std::shared_ptr<VPackBuilder> b) {
     _jb->add("fromServer", VPackValue(_from));
     _jb->add("jobId", VPackValue(_jobId));
     _jb->add("timeCreated", VPackValue(timepointToString(system_clock::now())));
+    _jb->add("addsFollower", VPackValue(_addsFollower));
   }
 
   if (b == nullptr) {
@@ -265,9 +272,11 @@ bool FailedLeader::start(bool& aborts) {
   }
 
   // Additional follower, if applicable
-  auto additionalFollower = randomIdleAvailableServer(_snapshot, excludes);
-  if (!additionalFollower.empty()) {
-    planv.push_back(additionalFollower);
+  if (_addsFollower) {
+    auto additionalFollower = randomIdleAvailableServer(_snapshot, excludes);
+    if (!additionalFollower.empty()) {
+      planv.push_back(additionalFollower);
+    }
   }
 
   // Transactions

--- a/arangod/Agency/FailedLeader.h
+++ b/arangod/Agency/FailedLeader.h
@@ -36,7 +36,8 @@ struct FailedLeader : public Job {
                std::string const& database = std::string(),
                std::string const& collection = std::string(),
                std::string const& shard = std::string(),
-               std::string const& from = std::string());
+               std::string const& from = std::string(),
+               bool addsFollower = true);
 
   FailedLeader(Node const& snapshot, AgentInterface* agent, JOB_STATUS status,
                std::string const& jobId);
@@ -56,6 +57,7 @@ struct FailedLeader : public Job {
   std::string _from;
   std::string _to;
   std::chrono::time_point<std::chrono::system_clock> _created;
+  bool _addsFollower{true};
 };
 }  // namespace consensus
 }  // namespace arangodb

--- a/arangod/Agency/FailedServer.cpp
+++ b/arangod/Agency/FailedServer.cpp
@@ -35,10 +35,12 @@ using namespace arangodb::consensus;
 FailedServer::FailedServer(Node const& snapshot, AgentInterface* agent,
                            std::string const& jobId, std::string const& creator,
                            std::string const& server,
-                           std::string const& notBefore)
+                           std::string const& notBefore,
+                           bool failedLeaderAddsFollower)
     : Job(NOTFOUND, snapshot, agent, jobId, creator),
       _server(server),
-      _notBefore(notBefore) {}
+      _notBefore(notBefore),
+      _failedLeaderAddsFollower(failedLeaderAddsFollower) {}
 
 FailedServer::FailedServer(Node const& snapshot, AgentInterface* agent,
                            JOB_STATUS status, std::string const& jobId)
@@ -50,6 +52,11 @@ FailedServer::FailedServer(Node const& snapshot, AgentInterface* agent,
   auto tmp_notBefore = _snapshot.hasAsString(path + "notBefore");
   if (tmp_notBefore) {
     _notBefore = tmp_notBefore.value();
+  }
+  auto tmp_failedLeaderAddsFollower =
+      _snapshot.hasAsBool(path + "failedLeaderAddsFollower");
+  if (tmp_failedLeaderAddsFollower) {
+    _failedLeaderAddsFollower = tmp_failedLeaderAddsFollower.value();
   }
 
   if (tmp_server && tmp_creator) {
@@ -218,7 +225,7 @@ bool FailedServer::start(bool& aborts) {
                     FailedLeader(_snapshot, _agent,
                                  _jobId + "-" + std::to_string(sub++), _jobId,
                                  database.first, collptr.first, shard.first,
-                                 _server)
+                                 _server, _failedLeaderAddsFollower)
                         .create(transactions);
                   } else {
                     if (!isSatellite) {
@@ -317,6 +324,8 @@ bool FailedServer::create(std::shared_ptr<VPackBuilder> envelope) {
         if (!_notBefore.empty()) {
           _jb->add("notBefore", VPackValue(_notBefore));
         }
+        _jb->add("failedLeaderAddsFollower",
+                 VPackValue(_failedLeaderAddsFollower));
       }
       // FailedServers entry []
       _jb->add(VPackValue(failedServersPrefix + "/" + _server));

--- a/arangod/Agency/FailedServer.h
+++ b/arangod/Agency/FailedServer.h
@@ -34,7 +34,8 @@ struct FailedServer : public Job {
                std::string const& jobId,
                std::string const& creator = std::string(),
                std::string const& failed = std::string(),
-               std::string const& notBefore = std::string());
+               std::string const& notBefore = std::string(),
+               bool failedLeaderAddsFollower = true);
 
   FailedServer(Node const& snapshot, AgentInterface* agent, JOB_STATUS status,
                std::string const& jobId);
@@ -49,6 +50,7 @@ struct FailedServer : public Job {
 
   std::string _server;
   std::string _notBefore;  // for handing on to the FailedFollower jobs
+  bool _failedLeaderAddsFollower{true};
 };
 }  // namespace consensus
 }  // namespace arangodb

--- a/arangod/Agency/Supervision.h
+++ b/arangod/Agency/Supervision.h
@@ -252,6 +252,10 @@ class Supervision : public arangodb::Thread {
 
   void setDelayFailedFollower(uint64_t d) noexcept { _delayFailedFollower = d; }
 
+  void setFailedLeaderAddsFollower(bool b) noexcept {
+    _failedLeaderAddsFollower = b;
+  }
+
  private:
   /**
    * @brief Report status of supervision in agency
@@ -294,6 +298,7 @@ class Supervision : public arangodb::Thread {
   double _okThreshold;
   uint64_t _delayAddFollower;
   uint64_t _delayFailedFollower;
+  bool _failedLeaderAddsFollower;
   uint64_t _jobId;
   uint64_t _jobIdMax;
   uint64_t _lastUpdateIndex;

--- a/tests/Agency/FailedLeaderTest.cpp
+++ b/tests/Agency/FailedLeaderTest.cpp
@@ -1188,8 +1188,6 @@ TEST_F(FailedLeaderTest, job_should_be_written_to_pending) {
       .AlwaysReturn(AgentInterface::raft_commit_t::OK);
   AgentInterface& agent = mockAgent.get();
 
-  // new server will randomly be selected...so seed the random number generator
-  srand(1);
   auto failedLeader = FailedLeader(agency.getOrCreate("arango"), &agent,
                                    JOB_STATUS::TODO, jobId);
   failedLeader.start(aborts);
@@ -1382,8 +1380,6 @@ TEST_F(FailedLeaderTest,
       .AlwaysReturn(AgentInterface::raft_commit_t::OK);
   AgentInterface& agent = mockAgent.get();
 
-  // new server will randomly be selected...so seed the random number generator
-  srand(1);
   auto failedLeader = FailedLeader(agency.getOrCreate("arango"), &agent,
                                    JOB_STATUS::TODO, jobId);
   failedLeader.start(aborts);
@@ -1759,8 +1755,6 @@ TEST_F(FailedLeaderTest,
       .AlwaysReturn(AgentInterface::raft_commit_t::OK);
   AgentInterface& agent = mockAgent.get();
 
-  // new server will randomly be selected...so seed the random number generator
-  srand(1);
   auto failedLeader = FailedLeader(agency.getOrCreate("arango"), &agent,
                                    JOB_STATUS::TODO, jobId);
   failedLeader.start(aborts);
@@ -1790,8 +1784,6 @@ TEST_F(FailedLeaderTest,
       .AlwaysReturn(AgentInterface::raft_commit_t::OK);
   AgentInterface& agent = mockAgent.get();
 
-  // new server will randomly be selected...so seed the random number generator
-  srand(1);
   auto failedLeader = FailedLeader(agency.getOrCreate("arango"), &agent,
                                    JOB_STATUS::TODO, jobId);
   failedLeader.start(aborts);
@@ -1824,8 +1816,6 @@ TEST_F(
       .AlwaysReturn(AgentInterface::raft_commit_t::OK);
   AgentInterface& agent = mockAgent.get();
 
-  // new server will randomly be selected...so seed the random number generator
-  srand(1);
   auto failedLeader = FailedLeader(agency.getOrCreate("arango"), &agent,
                                    JOB_STATUS::TODO, jobId);
   failedLeader.start(aborts);
@@ -1858,8 +1848,6 @@ TEST_F(
       .AlwaysReturn(AgentInterface::raft_commit_t::OK);
   AgentInterface& agent = mockAgent.get();
 
-  // new server will randomly be selected...so seed the random number generator
-  srand(1);
   auto failedLeader = FailedLeader(agency.getOrCreate("arango"), &agent,
                                    JOB_STATUS::TODO, jobId);
   failedLeader.start(aborts);
@@ -1897,8 +1885,6 @@ TEST_F(FailedLeaderTest, failedleader_must_not_readd_servers_not_in_plan) {
       .AlwaysReturn(AgentInterface::raft_commit_t::OK);
   AgentInterface& agent = mockAgent.get();
 
-  // new server will randomly be selected...so seed the random number generator
-  srand(1);
   auto failedLeader = FailedLeader(agency.getOrCreate("arango"), &agent,
                                    JOB_STATUS::TODO, jobId);
   failedLeader.start(aborts);
@@ -1937,8 +1923,6 @@ TEST_F(FailedLeaderTest, failedleader_must_not_add_a_follower_if_none_exists) {
       .AlwaysReturn(AgentInterface::raft_commit_t::OK);
   AgentInterface& agent = mockAgent.get();
 
-  // new server will randomly be selected...so seed the random number generator
-  srand(1);
   auto failedLeader = FailedLeader(agency.getOrCreate("arango"), &agent,
                                    JOB_STATUS::TODO, jobId);
   failedLeader.start(aborts);
@@ -1997,8 +1981,6 @@ TEST_F(FailedLeaderTest, failedleader_distribute_shard_like_good_case) {
       .AlwaysReturn(AgentInterface::raft_commit_t::OK);
   AgentInterface& agent = mockAgent.get();
 
-  // new server will randomly be selected...so seed the random number generator
-  srand(1);
   auto failedLeader = FailedLeader(agency.getOrCreate("arango"), &agent,
                                    JOB_STATUS::TODO, jobId);
   failedLeader.start(aborts);
@@ -2061,8 +2043,6 @@ TEST_F(
       .AlwaysReturn(AgentInterface::raft_commit_t::OK);
   AgentInterface& agent = mockAgent.get();
 
-  // new server will randomly be selected...so seed the random number generator
-  srand(1);
   auto failedLeader = FailedLeader(agency.getOrCreate("arango"), &agent,
                                    JOB_STATUS::TODO, jobId);
   failedLeader.start(aborts);
@@ -2126,8 +2106,6 @@ TEST_F(
       .AlwaysReturn(AgentInterface::raft_commit_t::OK);
   AgentInterface& agent = mockAgent.get();
 
-  // new server will randomly be selected...so seed the random number generator
-  srand(1);
   auto failedLeader = FailedLeader(agency.getOrCreate("arango"), &agent,
                                    JOB_STATUS::TODO, jobId);
   failedLeader.start(aborts);
@@ -2179,8 +2157,6 @@ TEST_F(
       .AlwaysReturn(AgentInterface::raft_commit_t::OK);
   AgentInterface& agent = mockAgent.get();
 
-  // new server will randomly be selected...so seed the random number generator
-  srand(1);
   auto failedLeader = FailedLeader(agency.getOrCreate("arango"), &agent,
                                    JOB_STATUS::TODO, jobId);
   failedLeader.start(aborts);
@@ -2232,8 +2208,6 @@ TEST_F(
       .AlwaysReturn(AgentInterface::raft_commit_t::OK);
   AgentInterface& agent = mockAgent.get();
 
-  // new server will randomly be selected...so seed the random number generator
-  srand(1);
   auto failedLeader = FailedLeader(agency.getOrCreate("arango"), &agent,
                                    JOB_STATUS::TODO, jobId);
   failedLeader.start(aborts);
@@ -2291,8 +2265,6 @@ TEST_F(FailedLeaderTest,
       .AlwaysReturn(AgentInterface::raft_commit_t::OK);
   AgentInterface& agent = mockAgent.get();
 
-  // new server will randomly be selected...so seed the random number generator
-  srand(1);
   auto failedLeader = FailedLeader(agency.getOrCreate("arango"), &agent,
                                    JOB_STATUS::TODO, jobId);
   failedLeader.start(aborts);
@@ -2340,8 +2312,6 @@ TEST_F(
       .AlwaysReturn(AgentInterface::raft_commit_t::OK);
   AgentInterface& agent = mockAgent.get();
 
-  // new server will randomly be selected...so seed the random number generator
-  srand(1);
   auto failedLeader = FailedLeader(agency.getOrCreate("arango"), &agent,
                                    JOB_STATUS::TODO, jobId);
   failedLeader.start(aborts);
@@ -2389,8 +2359,6 @@ TEST_F(
       .AlwaysReturn(AgentInterface::raft_commit_t::OK);
   AgentInterface& agent = mockAgent.get();
 
-  // new server will randomly be selected...so seed the random number generator
-  srand(1);
   auto failedLeader = FailedLeader(agency.getOrCreate("arango"), &agent,
                                    JOB_STATUS::TODO, jobId);
   failedLeader.start(aborts);
@@ -2450,8 +2418,6 @@ TEST_F(FailedLeaderTest,
       .AlwaysReturn(AgentInterface::raft_commit_t::OK);
   AgentInterface& agent = mockAgent.get();
 
-  // new server will randomly be selected...so seed the random number generator
-  srand(1);
   auto failedLeader = FailedLeader(agency.getOrCreate("arango"), &agent,
                                    JOB_STATUS::TODO, jobId);
   failedLeader.start(aborts);
@@ -2513,8 +2479,6 @@ TEST_F(
       .AlwaysReturn(AgentInterface::raft_commit_t::OK);
   AgentInterface& agent = mockAgent.get();
 
-  // new server will randomly be selected...so seed the random number generator
-  srand(1);
   auto failedLeader = FailedLeader(agency.getOrCreate("arango"), &agent,
                                    JOB_STATUS::TODO, jobId);
   failedLeader.start(aborts);
@@ -2576,8 +2540,6 @@ TEST_F(
       .AlwaysReturn(AgentInterface::raft_commit_t::OK);
   AgentInterface& agent = mockAgent.get();
 
-  // new server will randomly be selected...so seed the random number generator
-  srand(1);
   auto failedLeader = FailedLeader(agency.getOrCreate("arango"), &agent,
                                    JOB_STATUS::TODO, jobId);
   failedLeader.start(aborts);
@@ -2628,8 +2590,6 @@ TEST_F(
       .AlwaysReturn(AgentInterface::raft_commit_t::OK);
   AgentInterface& agent = mockAgent.get();
 
-  // new server will randomly be selected...so seed the random number generator
-  srand(1);
   auto failedLeader = FailedLeader(agency.getOrCreate("arango"), &agent,
                                    JOB_STATUS::TODO, jobId);
   failedLeader.start(aborts);
@@ -2680,8 +2640,6 @@ TEST_F(
       .AlwaysReturn(AgentInterface::raft_commit_t::OK);
   AgentInterface& agent = mockAgent.get();
 
-  // new server will randomly be selected...so seed the random number generator
-  srand(1);
   auto failedLeader = FailedLeader(agency.getOrCreate("arango"), &agent,
                                    JOB_STATUS::TODO, jobId);
   failedLeader.start(aborts);
@@ -2744,8 +2702,6 @@ TEST_F(FailedLeaderTest,
       .AlwaysReturn(AgentInterface::raft_commit_t::OK);
   AgentInterface& agent = mockAgent.get();
 
-  // new server will randomly be selected...so seed the random number generator
-  srand(1);
   auto failedLeader = FailedLeader(agency.getOrCreate("arango"), &agent,
                                    JOB_STATUS::TODO, jobId);
   failedLeader.start(aborts);
@@ -2808,8 +2764,6 @@ TEST_F(
       .AlwaysReturn(AgentInterface::raft_commit_t::OK);
   AgentInterface& agent = mockAgent.get();
 
-  // new server will randomly be selected...so seed the random number generator
-  srand(1);
   auto failedLeader = FailedLeader(agency.getOrCreate("arango"), &agent,
                                    JOB_STATUS::TODO, jobId);
   failedLeader.start(aborts);
@@ -2873,8 +2827,6 @@ TEST_F(
       .AlwaysReturn(AgentInterface::raft_commit_t::OK);
   AgentInterface& agent = mockAgent.get();
 
-  // new server will randomly be selected...so seed the random number generator
-  srand(1);
   auto failedLeader = FailedLeader(agency.getOrCreate("arango"), &agent,
                                    JOB_STATUS::TODO, jobId);
   failedLeader.start(aborts);
@@ -2938,8 +2890,6 @@ TEST_F(
       .AlwaysReturn(AgentInterface::raft_commit_t::OK);
   AgentInterface& agent = mockAgent.get();
 
-  // new server will randomly be selected...so seed the random number generator
-  srand(1);
   auto failedLeader = FailedLeader(agency.getOrCreate("arango"), &agent,
                                    JOB_STATUS::TODO, jobId);
   failedLeader.start(aborts);

--- a/tests/Agency/FailedLeaderTest.cpp
+++ b/tests/Agency/FailedLeaderTest.cpp
@@ -110,7 +110,15 @@ Node createRootNode() { return createNode(agency); }
 char const* todo = R"=({
   "creator":"1", "type":"failedLeader", "database":"database",
   "collection":"collection", "shard":"s99", "fromServer":"leader",
-  "jobId":"1", "timeCreated":"2017-01-01 00:00:00"
+  "jobId":"1", "timeCreated":"2017-01-01 00:00:00",
+  "addsFollower": true
+  })=";
+
+char const* todo2 = R"=({
+  "creator":"1", "type":"failedLeader", "database":"database",
+  "collection":"collection", "shard":"s99", "fromServer":"leader",
+  "jobId":"1", "timeCreated":"2017-01-01 00:00:00",
+  "addsFollower": false
   })=";
 
 typedef std::function<std::unique_ptr<Builder>(Slice const&,
@@ -534,6 +542,7 @@ TEST_F(FailedLeaderTest, creating_a_job_should_create_a_job_in_todo) {
         EXPECT_EQ(job.get("fromServer").copyString(), SHARD_LEADER);
         EXPECT_EQ(std::string(job.get("jobId").typeName()), "string");
         EXPECT_EQ(std::string(job.get("timeCreated").typeName()), "string");
+        EXPECT_TRUE(job.get("addsFollower").isTrue());
 
         return fakeWriteResult;
       });
@@ -541,8 +550,58 @@ TEST_F(FailedLeaderTest, creating_a_job_should_create_a_job_in_todo) {
       .AlwaysReturn(AgentInterface::raft_commit_t::OK);
   AgentInterface& agent = mockAgent.get();
 
-  auto failedLeader = FailedLeader(baseStructure, &agent, jobId, "unittest",
-                                   DATABASE, COLLECTION, SHARD, SHARD_LEADER);
+  auto failedLeader =
+      FailedLeader(baseStructure, &agent, jobId, "unittest", DATABASE,
+                   COLLECTION, SHARD, SHARD_LEADER, true);
+  failedLeader.create();
+}
+
+TEST_F(FailedLeaderTest,
+       creating_a_job_should_create_a_job_in_todo_no_leader_adds_follower) {
+  Mock<AgentInterface> mockAgent;
+
+  std::string jobId = "1";
+  When(Method(mockAgent, write))
+      .AlwaysDo([&](query_t const& q,
+                    consensus::AgentInterface::WriteMode w) -> write_ret_t {
+        auto expectedJobKey = "/arango/Target/ToDo/" + jobId;
+        EXPECT_EQ(std::string(q->slice().typeName()), "array");
+        EXPECT_EQ(q->slice().length(), 1);
+        EXPECT_EQ(std::string(q->slice()[0].typeName()), "array");
+        EXPECT_EQ(q->slice()[0].length(),
+                  1);  // we always simply override! no preconditions...
+        EXPECT_EQ(std::string(q->slice()[0][0].typeName()), "object");
+        EXPECT_EQ(q->slice()[0][0].length(),
+                  1);  // should ONLY do an entry in todo
+        EXPECT_TRUE(
+            std::string(q->slice()[0][0].get(expectedJobKey).typeName()) ==
+            "object");
+
+        auto job = q->slice()[0][0].get(expectedJobKey);
+        EXPECT_EQ(std::string(job.get("creator").typeName()), "string");
+        EXPECT_EQ(std::string(job.get("type").typeName()), "string");
+        EXPECT_EQ(job.get("type").copyString(), "failedLeader");
+        EXPECT_EQ(std::string(job.get("database").typeName()), "string");
+        EXPECT_EQ(job.get("database").copyString(), DATABASE);
+        EXPECT_EQ(std::string(job.get("collection").typeName()), "string");
+        EXPECT_EQ(job.get("collection").copyString(), COLLECTION);
+        EXPECT_EQ(std::string(job.get("shard").typeName()), "string");
+        EXPECT_EQ(job.get("shard").copyString(), SHARD);
+        EXPECT_EQ(std::string(job.get("fromServer").typeName()), "string");
+        EXPECT_EQ(job.get("fromServer").copyString(), SHARD_LEADER);
+        EXPECT_EQ(std::string(job.get("jobId").typeName()), "string");
+        EXPECT_EQ(std::string(job.get("timeCreated").typeName()), "string");
+        EXPECT_TRUE(job.get("addsFollower").isFalse());
+
+        return fakeWriteResult;
+      });
+  When(Method(mockAgent, waitFor))
+      .AlwaysReturn(AgentInterface::raft_commit_t::OK);
+  AgentInterface& agent = mockAgent.get();
+
+  auto failedLeader =
+      FailedLeader(baseStructure, &agent, jobId, "unittest", DATABASE,
+                   COLLECTION, SHARD, SHARD_LEADER, false);
   failedLeader.create();
 }
 
@@ -1136,6 +1195,200 @@ TEST_F(FailedLeaderTest, job_should_be_written_to_pending) {
   failedLeader.start(aborts);
 }
 
+TEST_F(FailedLeaderTest,
+       job_should_be_written_to_pending_no_additional_follower) {
+  std::string jobId = "1";
+
+  TestStructureType createTestStructure = [&](Slice const& s,
+                                              std::string const& path) {
+    std::unique_ptr<Builder> builder(new Builder());
+    if (s.isObject()) {
+      VPackObjectBuilder b(builder.get());
+      for (auto it : VPackObjectIterator(s)) {
+        auto childBuilder =
+            createTestStructure(it.value, path + "/" + it.key.copyString());
+        if (childBuilder) {
+          builder->add(it.key.copyString(), childBuilder->slice());
+        }
+      }
+      if (path == "/arango/Target/ToDo") {
+        builder->add("1", createBuilder(todo2).slice());
+      }
+    } else {
+      if (path == "/arango/Current/Collections/" + DATABASE + "/" + COLLECTION +
+                      "/" + SHARD + "/servers") {
+        VPackArrayBuilder a(builder.get());
+        builder->add(VPackValue(SHARD_LEADER));
+        builder->add(VPackValue(SHARD_FOLLOWER2));
+      } else {
+        builder->add(s);
+      }
+    }
+    return builder;
+  };
+  auto builder = createTestStructure(baseStructure.toBuilder().slice(), "");
+  ASSERT_TRUE(builder);
+  Node agency = createNodeFromBuilder(*builder);
+
+  Mock<AgentInterface> mockAgent;
+  When(Method(mockAgent, transact))
+      .AlwaysDo([&](query_t const& q) -> trans_ret_t {
+        EXPECT_EQ(std::string(q->slice().typeName()), "array");
+        EXPECT_EQ(q->slice().length(), 1);
+        EXPECT_EQ(std::string(q->slice()[0].typeName()), "array");
+        EXPECT_EQ(q->slice()[0].length(), 2);  // preconditions!
+        EXPECT_EQ(std::string(q->slice()[0][0].typeName()), "object");
+        EXPECT_EQ(std::string(q->slice()[0][1].typeName()), "object");
+
+        auto writes = q->slice()[0][0];
+        EXPECT_TRUE(
+            std::string(writes.get("/arango/Target/ToDo/1").typeName()) ==
+            "object");
+        EXPECT_TRUE(
+            std::string(
+                writes.get("/arango/Target/ToDo/1").get("op").typeName()) ==
+            "string");
+        EXPECT_TRUE(
+            writes.get("/arango/Target/ToDo/1").get("op").copyString() ==
+            "delete");
+        EXPECT_TRUE(
+            std::string(writes.get("/arango/Target/ToDo/1").typeName()) ==
+            "object");
+        EXPECT_TRUE(
+            std::string(writes.get("/arango/Target/Pending/1").typeName()) ==
+            "object");
+
+        auto job = writes.get("/arango/Target/Pending/1");
+        EXPECT_EQ(std::string(job.get("toServer").typeName()), "string");
+        EXPECT_EQ(job.get("toServer").copyString(), SHARD_FOLLOWER2);
+        EXPECT_EQ(std::string(job.get("timeStarted").typeName()), "string");
+
+        EXPECT_TRUE(
+            std::string(writes
+                            .get("/arango/Plan/Collections/" + DATABASE + "/" +
+                                 COLLECTION + "/shards/" + SHARD)
+                            .typeName()) == "array");
+        EXPECT_TRUE(writes
+                        .get("/arango/Plan/Collections/" + DATABASE + "/" +
+                             COLLECTION + "/shards/" + SHARD)
+                        .length() == 3);
+        EXPECT_TRUE(
+            std::string(writes
+                            .get("/arango/Plan/Collections/" + DATABASE + "/" +
+                                 COLLECTION + "/shards/" + SHARD)[0]
+                            .typeName()) == "string");
+        EXPECT_TRUE(
+            std::string(writes
+                            .get("/arango/Plan/Collections/" + DATABASE + "/" +
+                                 COLLECTION + "/shards/" + SHARD)[1]
+                            .typeName()) == "string");
+        EXPECT_TRUE(
+            std::string(writes
+                            .get("/arango/Plan/Collections/" + DATABASE + "/" +
+                                 COLLECTION + "/shards/" + SHARD)[2]
+                            .typeName()) == "string");
+        EXPECT_TRUE(writes
+                        .get("/arango/Plan/Collections/" + DATABASE + "/" +
+                             COLLECTION + "/shards/" + SHARD)[0]
+                        .copyString() == SHARD_FOLLOWER2);
+        EXPECT_TRUE(writes
+                        .get("/arango/Plan/Collections/" + DATABASE + "/" +
+                             COLLECTION + "/shards/" + SHARD)[1]
+                        .copyString() == SHARD_LEADER);
+        EXPECT_TRUE(writes
+                        .get("/arango/Plan/Collections/" + DATABASE + "/" +
+                             COLLECTION + "/shards/" + SHARD)[2]
+                        .copyString() == SHARD_FOLLOWER1);
+
+        auto preconditions = q->slice()[0][1];
+        EXPECT_TRUE(
+            std::string(preconditions.get("/arango/Supervision/Shards/" + SHARD)
+                            .typeName()) == "object");
+        EXPECT_TRUE(
+            std::string(preconditions.get("/arango/Supervision/Shards/" + SHARD)
+                            .get("oldEmpty")
+                            .typeName()) == "bool");
+        EXPECT_TRUE(preconditions.get("/arango/Supervision/Shards/" + SHARD)
+                        .get("oldEmpty")
+                        .getBool() == true);
+        EXPECT_TRUE(
+            preconditions
+                .get("/arango/Supervision/Health/" + SHARD_LEADER + "/Status")
+                .get("old")
+                .copyString() == "FAILED");
+        EXPECT_TRUE(preconditions
+                        .get("/arango/Supervision/Health/" + SHARD_FOLLOWER2 +
+                             "/Status")
+                        .get("old")
+                        .copyString() == "GOOD");
+
+        EXPECT_TRUE(
+            std::string(preconditions
+                            .get("/arango/Plan/Collections/" + DATABASE + "/" +
+                                 COLLECTION + "/shards/" + SHARD)
+                            .typeName()) == "object");
+        EXPECT_TRUE(
+            std::string(preconditions
+                            .get("/arango/Plan/Collections/" + DATABASE + "/" +
+                                 COLLECTION + "/shards/" + SHARD)
+                            .get("old")
+                            .typeName()) == "array");
+        EXPECT_TRUE(preconditions
+                        .get("/arango/Plan/Collections/" + DATABASE + "/" +
+                             COLLECTION + "/shards/" + SHARD)
+                        .get("old")
+                        .length() == 3);
+        EXPECT_TRUE(
+            std::string(preconditions
+                            .get("/arango/Plan/Collections/" + DATABASE + "/" +
+                                 COLLECTION + "/shards/" + SHARD)
+                            .get("old")[0]
+                            .typeName()) == "string");
+        EXPECT_TRUE(
+            std::string(preconditions
+                            .get("/arango/Plan/Collections/" + DATABASE + "/" +
+                                 COLLECTION + "/shards/" + SHARD)
+                            .get("old")[1]
+                            .typeName()) == "string");
+        EXPECT_TRUE(
+            std::string(preconditions
+                            .get("/arango/Plan/Collections/" + DATABASE + "/" +
+                                 COLLECTION + "/shards/" + SHARD)
+                            .get("old")[2]
+                            .typeName()) == "string");
+        EXPECT_TRUE(preconditions
+                        .get("/arango/Plan/Collections/" + DATABASE + "/" +
+                             COLLECTION + "/shards/" + SHARD)
+                        .get("old")[0]
+                        .copyString() == SHARD_LEADER);
+        EXPECT_TRUE(preconditions
+                        .get("/arango/Plan/Collections/" + DATABASE + "/" +
+                             COLLECTION + "/shards/" + SHARD)
+                        .get("old")[1]
+                        .copyString() == SHARD_FOLLOWER1);
+        EXPECT_TRUE(preconditions
+                        .get("/arango/Plan/Collections/" + DATABASE + "/" +
+                             COLLECTION + "/shards/" + SHARD)
+                        .get("old")[2]
+                        .copyString() == SHARD_FOLLOWER2);
+
+        auto result = std::make_shared<Builder>();
+        result->openArray();
+        result->add(VPackValue((uint64_t)1));
+        result->close();
+        return trans_ret_t(true, "1", 1, 0, result);
+      });
+  When(Method(mockAgent, waitFor))
+      .AlwaysReturn(AgentInterface::raft_commit_t::OK);
+  AgentInterface& agent = mockAgent.get();
+
+  // new server will randomly be selected...so seed the random number generator
+  srand(1);
+  auto failedLeader = FailedLeader(agency.getOrCreate("arango"), &agent,
+                                   JOB_STATUS::TODO, jobId);
+  failedLeader.start(aborts);
+}
+
 TEST_F(FailedLeaderTest, if_collection_is_missing_job_should_just_finish_2) {
   std::string jobId = "1";
 
@@ -1416,6 +1669,7 @@ TEST_F(FailedLeaderTest, when_everything_is_finished_there_should_be_cleanup) {
           jobBuilder.add(
               "timeCreated",
               VPackValue(timepointToString(std::chrono::system_clock::now())));
+          jobBuilder.add("addsFollower", VPackValue(true));
         }
         builder->add("1", jobBuilder.slice());
       }
@@ -2499,7 +2753,7 @@ TEST_F(FailedLeaderTest,
 
 TEST_F(
     FailedLeaderTest,
-    failedleader_distribute_shards_like_resigned_leader_all_repoted_in_current) {
+    failedleader_distribute_shards_like_resigned_leader_all_reported_in_current) {
   std::string jobId = "1";
 
   std::string col1 = "shardLike1";
@@ -2563,7 +2817,7 @@ TEST_F(
 
 TEST_F(
     FailedLeaderTest,
-    failedleader_distribute_shards_like_resigned_leader_leader_repoted_in_current) {
+    failedleader_distribute_shards_like_resigned_leader_leader_reported_in_current) {
   std::string jobId = "1";
 
   std::string col1 = "shardLike1";
@@ -2628,7 +2882,7 @@ TEST_F(
 
 TEST_F(
     FailedLeaderTest,
-    failedleader_distribute_shards_like_resigned_leader_follower_repoted_in_current) {
+    failedleader_distribute_shards_like_resigned_leader_follower_reported_in_current) {
   std::string jobId = "1";
 
   std::string col1 = "shardLike1";

--- a/tests/Agency/FailedServerTest.cpp
+++ b/tests/Agency/FailedServerTest.cpp
@@ -150,6 +150,7 @@ TEST_F(FailedServerTest, creating_a_job_should_create_a_job_in_todo) {
         EXPECT_EQ(typeName(job.get("jobId")), "string");
         EXPECT_EQ(typeName(job.get("timeCreated")), "string");
         EXPECT_EQ(typeName(job.get("notBefore")), "string");
+        EXPECT_TRUE(job.get("failedLeaderAddsFollower").isTrue());
 
         return fakeWriteResult;
       });
@@ -158,7 +159,47 @@ TEST_F(FailedServerTest, creating_a_job_should_create_a_job_in_todo) {
   auto& agent = mockAgent.get();
   auto builder = agency.toBuilder();
   FailedServer(agency.getOrCreate(PREFIX), &agent, jobId, "unittest",
-               SHARD_LEADER, "2022-01-01T00:00:00Z")
+               SHARD_LEADER, "2022-01-01T00:00:00Z", true)
+      .create();
+  Verify(Method(mockAgent, write));
+}
+
+TEST_F(FailedServerTest,
+       creating_a_job_should_create_a_job_in_todo_failed_leader_no_followers) {
+  Mock<AgentInterface> mockAgent;
+
+  std::string jobId = "1";
+  When(Method(mockAgent, write))
+      .AlwaysDo([&](query_t const& q,
+                    consensus::AgentInterface::WriteMode w) -> write_ret_t {
+        auto expectedJobKey = PREFIX + toDoPrefix + jobId;
+        EXPECT_EQ(typeName(q->slice()), "array");
+        EXPECT_EQ(q->slice().length(), 1);
+        EXPECT_EQ(typeName(q->slice()[0]), "array");
+        EXPECT_EQ(q->slice()[0].length(), 2);
+        EXPECT_EQ(typeName(q->slice()[0][0]), "object");
+        EXPECT_EQ(q->slice()[0][0].length(), 2);
+        EXPECT_EQ(typeName(q->slice()[0][0].get(expectedJobKey)), "object");
+
+        auto job = q->slice()[0][0].get(expectedJobKey);
+        EXPECT_EQ(typeName(job.get("creator")), "string");
+        EXPECT_EQ(typeName(job.get("type")), "string");
+        EXPECT_EQ(job.get("type").copyString(), "failedServer");
+        EXPECT_EQ(typeName(job.get("server")), "string");
+        EXPECT_EQ(job.get("server").copyString(), SHARD_LEADER);
+        EXPECT_EQ(typeName(job.get("jobId")), "string");
+        EXPECT_EQ(typeName(job.get("timeCreated")), "string");
+        EXPECT_EQ(typeName(job.get("notBefore")), "string");
+        EXPECT_TRUE(job.get("failedLeaderAddsFollower").isFalse());
+
+        return fakeWriteResult;
+      });
+  When(Method(mockAgent, waitFor))
+      .AlwaysReturn(AgentInterface::raft_commit_t::OK);
+  auto& agent = mockAgent.get();
+  auto builder = agency.toBuilder();
+  FailedServer(agency.getOrCreate(PREFIX), &agent, jobId, "unittest",
+               SHARD_LEADER, "2022-01-01T00:00:00Z", false)
       .create();
   Verify(Method(mockAgent, write));
 }
@@ -402,15 +443,16 @@ TEST_F(FailedServerTest,
       if (path == "/arango/Target/ToDo") {
         char const* todo =
             R"=({"creator":"unittest","jobId":"1","server":"leader",
-               "timeCreated":"2017-04-10T11:40:09Z","type":"failedServer"})=";
+               "timeCreated":"2017-04-10T11:40:09Z","type":"failedServer",
+               "failedLeaderAddsFollower":true})=";
         builder->add(jobId, createBuilder(todo).slice());
       }
     } else {
       if (path == "/arango/Supervision/Health/leader/Status") {
-        builder->add("/arango/Supervision/Health/leader/Status",
-                     VPackValue("FAILED"));
+        builder->add(VPackValue("FAILED"));
+      } else {
+        builder->add(s);
       }
-      builder->add(s);
     }
 
     return builder;
@@ -427,8 +469,7 @@ TEST_F(FailedServerTest,
         EXPECT_EQ(typeName(q->slice()), "array");
         EXPECT_EQ(q->slice().length(), 1);
         EXPECT_EQ(typeName(q->slice()[0]), "array");
-        // we always simply override! no preconditions...
-        EXPECT_EQ(q->slice()[0].length(), 1);
+        EXPECT_EQ(q->slice()[0].length(), 2);
         EXPECT_EQ(typeName(q->slice()[0][0]), "object");
 
         auto writes = q->slice()[0][0];
@@ -438,7 +479,8 @@ TEST_F(FailedServerTest,
         EXPECT_TRUE(
             writes.get("/arango/Target/ToDo/1").get("op").copyString() ==
             "delete");
-        EXPECT_EQ(typeName(writes.get("/arango/Target/Pending/1")), "object");
+        auto job = writes.get("/arango/Target/Pending/1");
+        EXPECT_EQ(typeName(job), "object");
         return fakeWriteResult;
       });
 
@@ -447,6 +489,233 @@ TEST_F(FailedServerTest,
   auto& agent = mockAgent.get();
   FailedServer(agency.getOrCreate("arango"), &agent, JOB_STATUS::TODO, jobId)
       .start(aborts);
+
+  Verify(Method(mockAgent, write));
+}
+
+TEST_F(FailedServerTest, a_failed_server_test_starts_and_is_moved_to_pending) {
+  TestStructureType createTestStructure = [&](Slice const& s,
+                                              std::string const& path) {
+    std::unique_ptr<Builder> builder;
+    builder = std::make_unique<Builder>();
+
+    if (s.isObject()) {
+      VPackObjectBuilder b(builder.get());
+      for (auto it : VPackObjectIterator(s)) {
+        auto childBuilder =
+            createTestStructure(it.value, path + "/" + it.key.copyString());
+        if (childBuilder) {
+          builder->add(it.key.copyString(), childBuilder->slice());
+        }
+      }
+      if (path == "/arango/Target/ToDo") {
+        char const* todo =
+            R"=({"creator":"unittest","jobId":"1","server":"leader",
+               "timeCreated":"2017-04-10T11:40:09Z","type":"failedServer",
+               "failedLeaderAddsFollower":true})=";
+        builder->add(jobId, createBuilder(todo).slice());
+      }
+    } else {
+      if (path == "/arango/Supervision/Health/leader/Status") {
+        builder->add(VPackValue("FAILED"));
+      } else if (path == "/arango/Supervision/Health/follower1/Status") {
+        builder->add(VPackValue("GOOD"));
+      } else {
+        builder->add(s);
+      }
+    }
+
+    return builder;
+  };
+
+  auto builder = createTestStructure(agency.toBuilder().slice(), "");
+  ASSERT_TRUE(builder);
+  Node agency = createNodeFromBuilder(*builder);
+
+  Mock<AgentInterface> mockAgent;
+  When(Method(mockAgent, write))
+      .AlwaysDo([&](query_t const& q,
+                    consensus::AgentInterface::WriteMode w) -> write_ret_t {
+        EXPECT_EQ(typeName(q->slice()), "array");
+        EXPECT_EQ(q->slice().length(), 1);
+        EXPECT_EQ(typeName(q->slice()[0]), "array");
+        EXPECT_EQ(q->slice()[0].length(), 2);  // with precondition
+        EXPECT_EQ(typeName(q->slice()[0][0]), "object");
+        EXPECT_EQ(typeName(q->slice()[0][1]), "object");
+        velocypack::Slice writes = q->slice()[0][0];
+        EXPECT_EQ(typeName(writes.get("/arango/Target/ToDo/1")), "object");
+        EXPECT_TRUE(typeName(writes.get("/arango/Target/ToDo/1").get("op")) ==
+                    "string");
+        EXPECT_TRUE(
+            writes.get("/arango/Target/ToDo/1").get("op").copyString() ==
+            "delete");
+        auto job = writes.get("/arango/Target/Pending/1");
+        EXPECT_EQ(typeName(job), "object");
+        EXPECT_TRUE(job.get("failedLeaderAddsFollower").isTrue());
+        auto newJob = writes.get("/arango/Target/ToDo/1-0");
+        EXPECT_EQ(typeName(newJob), "object");
+        auto type = newJob.get("type");
+        EXPECT_EQ(typeName(type), "string");
+        EXPECT_EQ(type.copyString(), std::string("failedLeader"));
+        EXPECT_TRUE(newJob.get("addsFollower").isTrue());
+        return fakeWriteResult;
+      });
+
+  When(Method(mockAgent, waitFor))
+      .AlwaysReturn(AgentInterface::raft_commit_t::OK);
+  auto& agent = mockAgent.get();
+  FailedServer(agency.getOrCreate("arango"), &agent, JOB_STATUS::TODO, jobId)
+      .start(aborts);
+
+  Verify(Method(mockAgent, write));
+}
+
+TEST_F(FailedServerTest,
+       a_failed_server_test_starts_and_is_moved_to_pending_no_followers) {
+  TestStructureType createTestStructure = [&](Slice const& s,
+                                              std::string const& path) {
+    std::unique_ptr<Builder> builder;
+    builder = std::make_unique<Builder>();
+
+    if (s.isObject()) {
+      VPackObjectBuilder b(builder.get());
+      for (auto it : VPackObjectIterator(s)) {
+        auto childBuilder =
+            createTestStructure(it.value, path + "/" + it.key.copyString());
+        if (childBuilder) {
+          builder->add(it.key.copyString(), childBuilder->slice());
+        }
+      }
+      if (path == "/arango/Target/ToDo") {
+        char const* todo =
+            R"=({"creator":"unittest","jobId":"1","server":"leader",
+               "timeCreated":"2017-04-10T11:40:09Z","type":"failedServer",
+               "failedLeaderAddsFollower":false})=";
+        builder->add(jobId, createBuilder(todo).slice());
+      }
+    } else {
+      if (path == "/arango/Supervision/Health/leader/Status") {
+        builder->add(VPackValue("FAILED"));
+      } else if (path == "/arango/Supervision/Health/follower1/Status") {
+        builder->add(VPackValue("GOOD"));
+      } else {
+        builder->add(s);
+      }
+    }
+
+    return builder;
+  };
+
+  auto builder = createTestStructure(agency.toBuilder().slice(), "");
+  ASSERT_TRUE(builder);
+  Node agency = createNodeFromBuilder(*builder);
+
+  Mock<AgentInterface> mockAgent;
+  When(Method(mockAgent, write))
+      .AlwaysDo([&](query_t const& q,
+                    consensus::AgentInterface::WriteMode w) -> write_ret_t {
+        EXPECT_EQ(typeName(q->slice()), "array");
+        EXPECT_EQ(q->slice().length(), 1);
+        EXPECT_EQ(typeName(q->slice()[0]), "array");
+        EXPECT_EQ(q->slice()[0].length(), 2);  // with precondition
+        EXPECT_EQ(typeName(q->slice()[0][0]), "object");
+        EXPECT_EQ(typeName(q->slice()[0][1]), "object");
+        velocypack::Slice writes = q->slice()[0][0];
+        EXPECT_EQ(typeName(writes.get("/arango/Target/ToDo/1")), "object");
+        EXPECT_TRUE(typeName(writes.get("/arango/Target/ToDo/1").get("op")) ==
+                    "string");
+        EXPECT_TRUE(
+            writes.get("/arango/Target/ToDo/1").get("op").copyString() ==
+            "delete");
+        auto job = writes.get("/arango/Target/Pending/1");
+        EXPECT_EQ(typeName(job), "object");
+        EXPECT_TRUE(job.get("failedLeaderAddsFollower").isFalse());
+        auto newJob = writes.get("/arango/Target/ToDo/1-0");
+        EXPECT_EQ(typeName(newJob), "object");
+        auto type = newJob.get("type");
+        EXPECT_EQ(typeName(type), "string");
+        EXPECT_EQ(type.copyString(), std::string("failedLeader"));
+        EXPECT_TRUE(newJob.get("addsFollower").isFalse());
+        return fakeWriteResult;
+      });
+
+  When(Method(mockAgent, waitFor))
+      .AlwaysReturn(AgentInterface::raft_commit_t::OK);
+  auto& agent = mockAgent.get();
+  FailedServer(agency.getOrCreate("arango"), &agent, JOB_STATUS::TODO, jobId)
+      .start(aborts);
+
+  Verify(Method(mockAgent, write));
+}
+
+TEST_F(FailedServerTest, a_failed_server_job_is_finished) {
+  TestStructureType createTestStructure = [&](Slice const& s,
+                                              std::string const& path) {
+    std::unique_ptr<Builder> builder;
+    builder = std::make_unique<Builder>();
+
+    if (s.isObject()) {
+      VPackObjectBuilder b(builder.get());
+      for (auto it : VPackObjectIterator(s)) {
+        auto childBuilder =
+            createTestStructure(it.value, path + "/" + it.key.copyString());
+        if (childBuilder) {
+          builder->add(it.key.copyString(), childBuilder->slice());
+        }
+      }
+      if (path == "/arango/Target/Pending") {
+        char const* pending =
+            R"=({"creator":"unittest","jobId":"1","server":"leader",
+               "timeCreated":"2017-04-10T11:40:09Z","type":"failedServer",
+               "timeStarted":"2017-04-10T11:40:10Z",
+               "failedLeaderAddsFollower":true})=";
+        builder->add(jobId, createBuilder(pending).slice());
+      }
+    } else {
+      if (path == "/arango/Supervision/Health/leader/Status") {
+        builder->add(VPackValue("FAILED"));
+      } else if (path == "/arango/Supervision/Health/follower1/Status") {
+        builder->add(VPackValue("GOOD"));
+      } else {
+        builder->add(s);
+      }
+    }
+
+    return builder;
+  };
+
+  auto builder = createTestStructure(agency.toBuilder().slice(), "");
+  ASSERT_TRUE(builder);
+  Node agency = createNodeFromBuilder(*builder);
+
+  Mock<AgentInterface> mockAgent;
+  When(Method(mockAgent, write))
+      .AlwaysDo([&](query_t const& q,
+                    consensus::AgentInterface::WriteMode w) -> write_ret_t {
+        EXPECT_EQ(typeName(q->slice()), "array");
+        EXPECT_EQ(q->slice().length(), 1);
+        EXPECT_EQ(typeName(q->slice()[0]), "array");
+        EXPECT_EQ(q->slice()[0].length(), 1);  // with precondition
+        EXPECT_EQ(typeName(q->slice()[0][0]), "object");
+        velocypack::Slice writes = q->slice()[0][0];
+        EXPECT_EQ(typeName(writes.get("/arango/Target/Pending/1")), "object");
+        EXPECT_TRUE(
+            typeName(writes.get("/arango/Target/Pending/1").get("op")) ==
+            "string");
+        EXPECT_TRUE(
+            writes.get("/arango/Target/Pending/1").get("op").copyString() ==
+            "delete");
+        auto job = writes.get("/arango/Target/Finished/1");
+        EXPECT_EQ(typeName(job), "object");
+        EXPECT_TRUE(job.get("failedLeaderAddsFollower").isTrue());
+        return fakeWriteResult;
+      });
+
+  When(Method(mockAgent, waitFor))
+      .AlwaysReturn(AgentInterface::raft_commit_t::OK);
+  auto& agent = mockAgent.get();
+  FailedServer(agency.getOrCreate("arango"), &agent, JOB_STATUS::PENDING, jobId)
+      .status();
 
   Verify(Method(mockAgent, write));
 }

--- a/tests/Agency/FailedServerTest.json
+++ b/tests/Agency/FailedServerTest.json
@@ -17,9 +17,17 @@ R"=(
       }
     },
     "Plan": {
+      "Databases": {
+        "database": {
+          "name": "database",
+          "id": "1",
+          "replicationVersion": 1
+        }
+      },
       "Collections": {
         "database": {
           "collection": {
+            "replicationFactor": 3,
             "shards": {
               "shard": [
                 "leader",


### PR DESCRIPTION
### Scope & Purpose

We found that a FailedLeader job automatically deploys a new follower.
This is probably not desirable. An AddFollower will do the work later
anyway. Therefore this proposes to make the new follower configurable.

- [*] :hankey: Bugfix
- [*] :pizza: New feature

### Checklist

- [*] Tests
  - [*] C++ **Unit tests**
- [*] :book: CHANGELOG entry made
- [*] Backports
  - [*] Backport for 3.9: This is it

#### Related Information

- [*] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/BTS-1162
- [*] Design document: https://github.com/arangodb/documents/pull/123
- [*] Original PR for devel: https://github.com/arangodb/arangodb/pull/17785



