### PR TITLE
Cancel delayed requests when log leader resignes.

### DIFF
--- a/arangod/Replication2/ReplicatedLog/LogLeader.cpp
+++ b/arangod/Replication2/ReplicatedLog/LogLeader.cpp
@@ -145,13 +145,26 @@ auto replicated_log::LogLeader::instantiateFollowers(
 
 namespace {
 auto delayedFuture(std::chrono::steady_clock::duration duration)
-    -> futures::Future<futures::Unit> {
+    -> std::pair<Scheduler::WorkHandle, futures::Future<futures::Unit>> {
   if (SchedulerFeature::SCHEDULER) {
-    return SchedulerFeature::SCHEDULER->delay("r2 appendentries", duration);
+    auto p = futures::Promise<futures::Unit>();
+    auto f = p.getFuture();
+    auto item = SchedulerFeature::SCHEDULER->queueDelayed(
+        "r2 appendentries", RequestLane::DELAYED_FUTURE, duration,
+        [p = std::move(p)](bool cancelled) mutable {
+          if (cancelled) {
+            p.setException(basics::Exception(Result{TRI_ERROR_REQUEST_CANCELED},
+                                             ADB_HERE));
+          } else {
+            p.setValue(futures::Unit{});
+          }
+        });
+
+    return std::make_pair(std::move(item), std::move(f));
   }
 
   // std::this_thread::sleep_for(duration);
-  return futures::Future<futures::Unit>{std::in_place};
+  return std::make_pair(nullptr, futures::Future<futures::Unit>{futures::unit});
 }
 }  // namespace
 
@@ -174,117 +187,120 @@ void replicated_log::LogLeader::handleResolvedPromiseSet(
 void replicated_log::LogLeader::executeAppendEntriesRequests(
     std::vector<std::optional<PreparedAppendEntryRequest>> requests,
     std::shared_ptr<ReplicatedLogMetrics> const& logMetrics) {
-  for (auto& it : requests) {
-    if (it.has_value()) {
-      delayedFuture(it->_executionDelay)
-          .thenFinal([it = std::move(it), logMetrics](auto&&) mutable {
-            auto follower = it->_follower.lock();
-            auto logLeader = it->_parentLog.lock();
-            if (logLeader == nullptr || follower == nullptr) {
-              LOG_TOPIC("de312", TRACE, Logger::REPLICATION2)
-                  << "parent log already gone, not sending any more "
-                     "AppendEntryRequests";
-              return;
-            }
+  for (auto& req : requests) {
+    if (req.has_value()) {
+      auto [item, f] = delayedFuture(req->_executionDelay);
+      if (item != nullptr) {
+        if (auto follower = req->_follower.lock(); !follower) {
+          continue;  // follower was dropped
+        } else {
+          follower->lastRequestHandle = std::move(item);
+        }
+      }
+      std::move(f).thenFinal([req = std::move(req),
+                              logMetrics](auto&&) mutable {
+        auto follower = req->_follower.lock();
+        auto logLeader = req->_parentLog.lock();
+        if (logLeader == nullptr || follower == nullptr) {
+          LOG_TOPIC("de312", TRACE, Logger::REPLICATION2)
+              << "parent log already gone, not sending any more "
+                 "AppendEntryRequests";
+          return;
+        }
 
-            auto [request, lastIndex] =
-                logLeader->_guardedLeaderData.doUnderLock(
-                    [&](auto const& self) {
-                      auto lastAvailableIndex =
-                          self._inMemoryLog.getLastTermIndexPair();
-                      LOG_CTX("71801", TRACE, follower->logContext)
-                          << "last matched index = "
-                          << follower->nextPrevLogIndex
-                          << ", current index = " << lastAvailableIndex
-                          << ", last acked commit index = "
-                          << follower->lastAckedCommitIndex
-                          << ", current commit index = " << self._commitIndex
-                          << ", last acked litk = "
-                          << follower->lastAckedLowestIndexToKeep
-                          << ", current litk = " << self._lowestIndexToKeep;
-                      // We can only get here if there is some new information
-                      // for this follower
-                      TRI_ASSERT(follower->nextPrevLogIndex.index !=
-                                     lastAvailableIndex.index ||
-                                 self._commitIndex !=
-                                     follower->lastAckedCommitIndex ||
-                                 self._lowestIndexToKeep !=
-                                     follower->lastAckedLowestIndexToKeep);
+        auto [request, lastIndex] =
+            logLeader->_guardedLeaderData.doUnderLock([&](auto const& self) {
+              auto lastAvailableIndex =
+                  self._inMemoryLog.getLastTermIndexPair();
+              LOG_CTX("71801", TRACE, follower->logContext)
+                  << "last matched index = " << follower->nextPrevLogIndex
+                  << ", current index = " << lastAvailableIndex
+                  << ", last acked commit index = "
+                  << follower->lastAckedCommitIndex
+                  << ", current commit index = " << self._commitIndex
+                  << ", last acked litk = "
+                  << follower->lastAckedLowestIndexToKeep
+                  << ", current litk = " << self._lowestIndexToKeep;
+              // We can only get here if there is some new information
+              // for this follower
+              TRI_ASSERT(follower->nextPrevLogIndex.index !=
+                             lastAvailableIndex.index ||
+                         self._commitIndex != follower->lastAckedCommitIndex ||
+                         self._lowestIndexToKeep !=
+                             follower->lastAckedLowestIndexToKeep);
 
-                      return self.createAppendEntriesRequest(
-                          *follower, lastAvailableIndex);
+              return self.createAppendEntriesRequest(*follower,
+                                                     lastAvailableIndex);
+            });
+
+        auto messageId = request.messageId;
+        LOG_CTX("1b0ec", TRACE, follower->logContext)
+            << "sending append entries, messageId = " << messageId;
+
+        // We take the start time here again to have a more precise
+        // measurement. (And do not use follower._lastRequestStartTP)
+        // TODO really needed?
+        auto startTime = std::chrono::steady_clock::now();
+        // Capture a weak pointer `parentLog` that will be locked
+        // when the request returns. If the locking is successful
+        // we are still in the same term.
+        follower->_impl->appendEntries(std::move(request))
+            .thenFinal([weakParentLog = req->_parentLog,
+                        followerWeak = req->_follower, lastIndex = lastIndex,
+                        currentCommitIndex = request.leaderCommit,
+                        currentLITK = request.lowestIndexToKeep,
+                        currentTerm = logLeader->_currentTerm,
+                        messageId = messageId, startTime,
+                        logMetrics = logMetrics](
+                           futures::Try<AppendEntriesResult>&& res) noexcept {
+              // This has to remain noexcept, because the code below is not
+              // exception safe
+              auto const endTime = std::chrono::steady_clock::now();
+
+              auto self = weakParentLog.lock();
+              auto follower = followerWeak.lock();
+              if (self != nullptr && follower != nullptr) {
+                using namespace std::chrono_literals;
+                auto const duration = endTime - startTime;
+                self->_logMetrics->replicatedLogAppendEntriesRttUs->count(
+                    duration / 1us);
+                LOG_CTX("8ff44", TRACE, follower->logContext)
+                    << "received append entries response, messageId = "
+                    << messageId;
+                auto [preparedRequests, resolvedPromises] = std::invoke(
+                    [&]() -> std::pair<std::vector<std::optional<
+                                           PreparedAppendEntryRequest>>,
+                                       ResolvedPromiseSet> {
+                      auto guarded = self->acquireMutex();
+                      if (!guarded->_didResign) {
+                        return guarded->handleAppendEntriesResponse(
+                            *follower, lastIndex, currentCommitIndex,
+                            currentLITK, currentTerm, std::move(res),
+                            endTime - startTime, messageId);
+                      } else {
+                        LOG_CTX("da116", DEBUG, follower->logContext)
+                            << "received response from follower but leader "
+                               "already resigned, messageId = "
+                            << messageId;
+                      }
+                      return {};
                     });
 
-            auto messageId = request.messageId;
-            LOG_CTX("1b0ec", TRACE, follower->logContext)
-                << "sending append entries, messageId = " << messageId;
-
-            // We take the start time here again to have a more precise
-            // measurement. (And do not use follower._lastRequestStartTP)
-            // TODO really needed?
-            auto startTime = std::chrono::steady_clock::now();
-            // Capture a weak pointer `parentLog` that will be locked
-            // when the request returns. If the locking is successful
-            // we are still in the same term.
-            follower->_impl->appendEntries(std::move(request))
-                .thenFinal([weakParentLog = it->_parentLog,
-                            followerWeak = it->_follower, lastIndex = lastIndex,
-                            currentCommitIndex = request.leaderCommit,
-                            currentLITK = request.lowestIndexToKeep,
-                            currentTerm = logLeader->_currentTerm,
-                            messageId = messageId, startTime,
-                            logMetrics =
-                                logMetrics](futures::Try<AppendEntriesResult>&&
-                                                res) noexcept {
-                  // This has to remain noexcept, because the code below is not
-                  // exception safe
-                  auto const endTime = std::chrono::steady_clock::now();
-
-                  auto self = weakParentLog.lock();
-                  auto follower = followerWeak.lock();
-                  if (self != nullptr && follower != nullptr) {
-                    using namespace std::chrono_literals;
-                    auto const duration = endTime - startTime;
-                    self->_logMetrics->replicatedLogAppendEntriesRttUs->count(
-                        duration / 1us);
-                    LOG_CTX("8ff44", TRACE, follower->logContext)
-                        << "received append entries response, messageId = "
-                        << messageId;
-                    auto [preparedRequests, resolvedPromises] = std::invoke(
-                        [&]() -> std::pair<std::vector<std::optional<
-                                               PreparedAppendEntryRequest>>,
-                                           ResolvedPromiseSet> {
-                          auto guarded = self->acquireMutex();
-                          if (!guarded->_didResign) {
-                            return guarded->handleAppendEntriesResponse(
-                                *follower, lastIndex, currentCommitIndex,
-                                currentLITK, currentTerm, std::move(res),
-                                endTime - startTime, messageId);
-                          } else {
-                            LOG_CTX("da116", DEBUG, follower->logContext)
-                                << "received response from follower but leader "
-                                   "already resigned, messageId = "
-                                << messageId;
-                          }
-                          return {};
-                        });
-
-                    handleResolvedPromiseSet(std::move(resolvedPromises),
+                handleResolvedPromiseSet(std::move(resolvedPromises),
+                                         logMetrics);
+                executeAppendEntriesRequests(std::move(preparedRequests),
                                              logMetrics);
-                    executeAppendEntriesRequests(std::move(preparedRequests),
-                                                 logMetrics);
-                  } else {
-                    if (follower == nullptr) {
-                      LOG_TOPIC("6f490", DEBUG, Logger::REPLICATION2)
-                          << "follower already gone.";
-                    } else {
-                      LOG_CTX("de300", DEBUG, follower->logContext)
-                          << "parent log already gone, messageId = "
-                          << messageId;
-                    }
-                  }
-                });
-          });
+              } else {
+                if (follower == nullptr) {
+                  LOG_TOPIC("6f490", DEBUG, Logger::REPLICATION2)
+                      << "follower already gone.";
+                } else {
+                  LOG_CTX("de300", DEBUG, follower->logContext)
+                      << "parent log already gone, messageId = " << messageId;
+                }
+              }
+            });
+      });
     }
   }
 }
@@ -408,6 +424,9 @@ auto replicated_log::LogLeader::resign() && -> std::tuple<
       throw ParticipantResignedException(
           TRI_ERROR_REPLICATION_REPLICATED_LOG_LEADER_RESIGNED, ADB_HERE);
     }
+
+    // cancel all delayed scheduler work items
+    leaderData._follower.clear();
 
     // WARNING! This stunt is here to make things exception safe.
     // The move constructor of std::multimap is **not** noexcept.

--- a/arangod/Replication2/ReplicatedLog/LogLeader.h
+++ b/arangod/Replication2/ReplicatedLog/LogLeader.h
@@ -47,6 +47,7 @@
 #include "Replication2/ReplicatedLog/NetworkMessages.h"
 #include "Replication2/ReplicatedLog/WaitForBag.h"
 #include "Replication2/ReplicatedLog/types.h"
+#include "Scheduler/Scheduler.h"
 
 namespace arangodb {
 struct DeferredAction;
@@ -201,6 +202,7 @@ class LogLeader : public std::enable_shared_from_this<LogLeader>,
     std::size_t numErrorsSinceLastAnswer = 0;
     AppendEntriesErrorReason lastErrorReason;
     LoggerContext const logContext;
+    Scheduler::WorkHandle lastRequestHandle;
 
     enum class State {
       IDLE,

--- a/arangod/VocBase/vocbase.cpp
+++ b/arangod/VocBase/vocbase.cpp
@@ -950,13 +950,15 @@ void TRI_vocbase_t::stop() {
   } catch (...) {
     // we are calling this on shutdown, and always want to go on from here
   }
+
+  _logManager->resignStates();
+  _logManager->resignAll();
 }
 
 /// @brief closes a database and all collections
 void TRI_vocbase_t::shutdown() {
   this->stop();
 
-  _logManager->resignStates();
   std::vector<std::shared_ptr<arangodb::LogicalCollection>> collections;
 
   {
@@ -991,7 +993,6 @@ void TRI_vocbase_t::shutdown() {
   }
 
   _collections.clear();
-  _logManager->resignAll();
 }
 
 /// @brief returns names of all known (document) collections


### PR DESCRIPTION
### Scope & Purpose
During server shutdown we detected that some replicated logs did not cancel their delayed work items on the scheduler. This mechanism is used to implement an error back-off.

The `delay` api used does not provide a way to cancel such a future. Therefore, I now use `queueDelay` instead. The work item is then stored in the associated follower info for that follower. This is fine, because there will be at most one request in flight per follower.

During resign, the replicated log leader cancels all delayed work items.

Furthermore, I made sure, that the replicated logs are resigned before the scheduler is stoppped. Thus is moved the `resignAll` from `Vocbase::shutdown` to `Vocbase::stop`.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
