### PR TITLE
allow parallel access to the shards of smart edge collections in AQL

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,7 @@
 v3.9.7 (XXXX-XX-XX)
 -------------------
 
-* Allow parallel access to the shards of smart edge collections in AQL via 
+* Allow parallel access to the shards of smart edge collections in AQL via
   parallel GatherNodes.
 
 * Added a configuration option (for the agency):

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 v3.9.7 (XXXX-XX-XX)
 -------------------
 
+* Allow parallel access to the shards of smart edge collections in AQL via 
+  parallel GatherNodes.
+
 * Added a configuration option (for the agency):
     --agency.supervision-failed-leader-adds-follower
   with a default of `true` (behavior as before). If set to `false`, a

--- a/arangod/Aql/ClusterNodes.cpp
+++ b/arangod/Aql/ClusterNodes.cpp
@@ -567,10 +567,9 @@ GatherNode::Parallelism GatherNode::evaluateParallelism(
   // single-sharded collections don't require any parallelism. collections with
   // more than one shard are eligible for later parallelization (the Undefined
   // allows this)
-  return (((collection.isSmart() && collection.type() == TRI_COL_TYPE_EDGE) ||
-           (collection.numberOfShards() <= 1 && !collection.isSatellite()))
-              ? Parallelism::Serial
-              : Parallelism::Undefined);
+  return (collection.numberOfShards() == 1 || collection.isSatellite())
+             ? Parallelism::Serial
+             : Parallelism::Undefined;
 }
 
 void GatherNode::replaceVariables(


### PR DESCRIPTION
### Scope & Purpose

Late backport of https://github.com/arangodb/arangodb/pull/16371

Allow parallel access to the shards of smart edge collections in AQL via parallel GatherNodes.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [x] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [x] Backports
  - [x] Backport for 3.10: https://github.com/arangodb/arangodb/pull/16371
  - [x] Backport for 3.9: this PR
  - [ ] Backport for 3.8: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 