### PR TITLE
fix "introduced in" version number for 3.10

### DIFF
--- a/arangod/RocksDBEngine/RocksDBIndexCacheRefillFeature.cpp
+++ b/arangod/RocksDBEngine/RocksDBIndexCacheRefillFeature.cpp
@@ -98,7 +98,7 @@ void RocksDBIndexCacheRefillFeature::collectOptions(
                       options::Flags::OnDBServer, options::Flags::OnSingle,
                       options::Flags::Hidden, options::Flags::Experimental))
       .setIntroducedIn(30906)
-      .setIntroducedIn(31020);
+      .setIntroducedIn(31002);
 
   options
       ->addOption("--rocksdb.auto-refill-index-caches-on-modify",
@@ -111,7 +111,7 @@ void RocksDBIndexCacheRefillFeature::collectOptions(
                       options::Flags::OnDBServer, options::Flags::OnSingle,
                       options::Flags::Hidden, options::Flags::Experimental))
       .setIntroducedIn(30906)
-      .setIntroducedIn(31020);
+      .setIntroducedIn(31002);
 
   options
       ->addOption(
@@ -124,7 +124,7 @@ void RocksDBIndexCacheRefillFeature::collectOptions(
                              options::Flags::OnSingle, options::Flags::Hidden,
                              options::Flags::Experimental))
       .setIntroducedIn(30906)
-      .setIntroducedIn(31020);
+      .setIntroducedIn(31002);
 
   options
       ->addOption("--rocksdb.max-concurrent-index-fill-tasks",
@@ -136,7 +136,7 @@ void RocksDBIndexCacheRefillFeature::collectOptions(
                       options::Flags::OnDBServer, options::Flags::OnSingle,
                       options::Flags::Hidden, options::Flags::Experimental))
       .setIntroducedIn(30906)
-      .setIntroducedIn(31020);
+      .setIntroducedIn(31002);
 }
 
 void RocksDBIndexCacheRefillFeature::validateOptions(


### PR DESCRIPTION
### Scope & Purpose

Fix wrong version number for 3.10 version in "introduced in" description. Found by @neunhoef 

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: fixed in https://github.com/arangodb/arangodb/pull/17696
  - [x] Backport for 3.9: this PR
  - [ ] Backport for 3.8: not needed

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 