### PR TITLE
remove future versions from startup option help

### DIFF
--- a/arangod/Agency/AgencyFeature.cpp
+++ b/arangod/Agency/AgencyFeature.cpp
@@ -165,8 +165,7 @@ void AgencyFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
                   arangodb::options::makeFlags(
                       arangodb::options::Flags::DefaultNoComponents,
                       arangodb::options::Flags::OnAgent))
-      .setIntroducedIn(30906)
-      .setIntroducedIn(31002);
+      .setIntroducedIn(30906);
 
   options
       ->addOption("--agency.supervision-delay-failed-follower",
@@ -176,8 +175,7 @@ void AgencyFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
                   arangodb::options::makeFlags(
                       arangodb::options::Flags::DefaultNoComponents,
                       arangodb::options::Flags::OnAgent))
-      .setIntroducedIn(30906)
-      .setIntroducedIn(31002);
+      .setIntroducedIn(30906);
 
   options
       ->addOption("--agency.supervision-failed-leader-adds-follower",
@@ -187,8 +185,7 @@ void AgencyFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
                   arangodb::options::makeFlags(
                       arangodb::options::Flags::DefaultNoComponents,
                       arangodb::options::Flags::OnAgent))
-      .setIntroducedIn(30907)
-      .setIntroducedIn(31002);
+      .setIntroducedIn(30907);
 
   options->addOption(
       "--agency.compaction-step-size",

--- a/arangod/RestServer/QueryRegistryFeature.cpp
+++ b/arangod/RestServer/QueryRegistryFeature.cpp
@@ -414,9 +414,7 @@ void QueryRegistryFeature::collectOptions(
                       arangodb::options::Flags::OnAgent,
                       arangodb::options::Flags::OnCoordinator,
                       arangodb::options::Flags::OnSingle))
-      .setIntroducedIn(30905)
-      .setIntroducedIn(31002)
-      .setIntroducedIn(31100);
+      .setIntroducedIn(30905);
 
   options
       ->addOption("--query.log-memory-usage-threshold",
@@ -428,9 +426,7 @@ void QueryRegistryFeature::collectOptions(
                       arangodb::options::Flags::OnAgent,
                       arangodb::options::Flags::OnCoordinator,
                       arangodb::options::Flags::OnSingle))
-      .setIntroducedIn(30905)
-      .setIntroducedIn(31002)
-      .setIntroducedIn(31100);
+      .setIntroducedIn(30905);
 
   options
       ->addOption("--query.log-failed", "log failed AQL queries",
@@ -440,9 +436,7 @@ void QueryRegistryFeature::collectOptions(
                       arangodb::options::Flags::OnAgent,
                       arangodb::options::Flags::OnCoordinator,
                       arangodb::options::Flags::OnSingle))
-      .setIntroducedIn(30905)
-      .setIntroducedIn(31002)
-      .setIntroducedIn(31100);
+      .setIntroducedIn(30905);
 }
 
 void QueryRegistryFeature::validateOptions(

--- a/arangod/RocksDBEngine/RocksDBIndexCacheRefillFeature.cpp
+++ b/arangod/RocksDBEngine/RocksDBIndexCacheRefillFeature.cpp
@@ -97,8 +97,7 @@ void RocksDBIndexCacheRefillFeature::collectOptions(
                       options::Flags::DefaultNoComponents,
                       options::Flags::OnDBServer, options::Flags::OnSingle,
                       options::Flags::Hidden, options::Flags::Experimental))
-      .setIntroducedIn(30906)
-      .setIntroducedIn(31002);
+      .setIntroducedIn(30906);
 
   options
       ->addOption("--rocksdb.auto-refill-index-caches-on-modify",
@@ -110,8 +109,7 @@ void RocksDBIndexCacheRefillFeature::collectOptions(
                       options::Flags::DefaultNoComponents,
                       options::Flags::OnDBServer, options::Flags::OnSingle,
                       options::Flags::Hidden, options::Flags::Experimental))
-      .setIntroducedIn(30906)
-      .setIntroducedIn(31002);
+      .setIntroducedIn(30906);
 
   options
       ->addOption(
@@ -123,8 +121,7 @@ void RocksDBIndexCacheRefillFeature::collectOptions(
                              options::Flags::OnDBServer,
                              options::Flags::OnSingle, options::Flags::Hidden,
                              options::Flags::Experimental))
-      .setIntroducedIn(30906)
-      .setIntroducedIn(31002);
+      .setIntroducedIn(30906);
 
   options
       ->addOption("--rocksdb.max-concurrent-index-fill-tasks",
@@ -135,8 +132,7 @@ void RocksDBIndexCacheRefillFeature::collectOptions(
                       options::Flags::DefaultNoComponents,
                       options::Flags::OnDBServer, options::Flags::OnSingle,
                       options::Flags::Hidden, options::Flags::Experimental))
-      .setIntroducedIn(30906)
-      .setIntroducedIn(31002);
+      .setIntroducedIn(30906);
 }
 
 void RocksDBIndexCacheRefillFeature::validateOptions(


### PR DESCRIPTION
### Scope & Purpose

According to @Simran-B , future versions should be mentioned in "setIntroducedIn" of earlier versions.
The rule is also written down here: https://github.com/arangodb/arangodb/blob/devel/CONTRIBUTING.md#adding-startup-options

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: -
  - [x] Backport for 3.9: this PR
  - [ ] Backport for 3.8: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 