### PR TITLE
refill index caches with multiple threads

### DIFF
--- a/Documentation/Metrics/rocksdb_cache_auto_refill_dropped_total.yaml
+++ b/Documentation/Metrics/rocksdb_cache_auto_refill_dropped_total.yaml
@@ -26,8 +26,11 @@ description: |
   affect correctness.
 troubleshoot: |
   If this metric keeps increasing, it indicates that the index refill background 
-  thread can't keep up with the incoming data modification requests. 
-  In this case, consider increasing the background thread's queueing capacity via
-  the `--rocksdb.auto-refill-index-cache-queue-capacity` startup option.
-  Increasing the capacity helps to handle bursts of request, but does not help
-  if the background thread is overwhelmed by a continuous high load.
+  threads can't keep up with the incoming data modification requests. 
+  In this case, consider increasing the background threads' queueing capacity via
+  the `--rocksdb.auto-refill-index-cache-queue-capacity` startup option, or the
+  number of background threads via the `--rocksdb.auto-refill-background-threads`
+  startup options.
+  Increasing the capacity or number of threads helps to handle bursts of requests, 
+  but does not help if the background threads are overwhelmed by a continuous high
+  load.

--- a/Documentation/Metrics/rocksdb_cache_auto_refill_foreground_total.yaml
+++ b/Documentation/Metrics/rocksdb_cache_auto_refill_foreground_total.yaml
@@ -1,0 +1,33 @@
+name: rocksdb_cache_auto_refill_foreground_total
+introducedIn: "3.10.3"
+help: |
+  Total number of entries in automatic in-memory index cache refilling that were
+  processed in foreground.
+unit: number
+type: counter
+category: RocksDB
+complexity: advanced
+exposedBy:
+  - coordinator
+  - dbserver
+  - agent
+  - single
+description: |
+  This metric shows the total number of entries for no automatic background 
+  refilling happened in the in-memory index caches.
+  This counter increases only for insert, update, replace, and remove operations
+  affecting edge indexes and cache-enabled persistent indexes and with requested
+  automatic refilling, if no refill operation could be queued due to capacity 
+  constraints and the system is configured to handle the refilling in foreground
+  instead.
+troubleshoot: |
+  If this metric keeps increasing, it indicates that the index refill background 
+  threads can't keep up with the incoming data modification requests. This is not
+  necessarily a problem, because index cache refilling is still happening, but as
+  part of the foreground data modification operations.
+  If cache refilling happens in foreground, this may slow down data modification
+  operations. In case this is undesired, and caches should rather be refilled in
+  background, consider increasing the background threads' queueing capacity via
+  the `--rocksdb.auto-refill-index-cache-queue-capacity` startup option, or the
+  number of background threads via the `--rocksdb.auto-refill-background-threads`
+  startup options.

--- a/Documentation/Metrics/rocksdb_cache_auto_refill_queued_total.yaml
+++ b/Documentation/Metrics/rocksdb_cache_auto_refill_queued_total.yaml
@@ -1,0 +1,17 @@
+name: rocksdb_cache_auto_refill_queued_total
+introducedIn: "3.9.7"
+help: |
+  Total number of cache entries queued for automatical refilling.
+unit: number
+type: counter
+category: RocksDB
+complexity: advanced
+exposedBy:
+  - coordinator
+  - dbserver
+  - agent
+  - single
+description: |
+  This metric shows the total number of in-memory cache entries that we queued
+  for automatic refilling. 
+  On Agents and Coordinators, the values reported by this metric are always zero.

--- a/arangod/RestHandler/RestDocumentHandler.cpp
+++ b/arangod/RestHandler/RestDocumentHandler.cpp
@@ -31,6 +31,7 @@
 #include "Cluster/ClusterInfo.h"
 #include "Cluster/ServerState.h"
 #include "Random/RandomGenerator.h"
+#include "RocksDBEngine/RocksDBIndexCacheRefillFeature.h"
 #include "StorageEngine/TransactionState.h"
 #include "Transaction/Helpers.h"
 #include "Transaction/Hints.h"
@@ -45,24 +46,6 @@
 using namespace arangodb;
 using namespace arangodb::basics;
 using namespace arangodb::rest;
-
-namespace {
-RefillIndexCaches readFillIndexCachesValue(GeneralRequest const& request) {
-  RefillIndexCaches refillIndexCaches = RefillIndexCaches::kDefault;
-
-  bool found = false;
-  // this attribute can have 3 values: default, true and false. only
-  // pick it up when it is set to true or false
-  std::string const& value =
-      request.value(StaticStrings::RefillIndexCachesString, found);
-  if (found) {
-    refillIndexCaches = StringUtils::boolean(value)
-                            ? RefillIndexCaches::kRefill
-                            : RefillIndexCaches::kDontRefill;
-  }
-  return refillIndexCaches;
-}
-}  // namespace
 
 RestDocumentHandler::RestDocumentHandler(
     application_features::ApplicationServer& server, GeneralRequest* request,
@@ -199,6 +182,8 @@ RestStatus RestDocumentHandler::insertDocument() {
   }
 
   arangodb::OperationOptions opOptions(_context);
+  extractStringParameter(StaticStrings::IsSynchronousReplicationString,
+                         opOptions.isSynchronousReplicationFrom);
   opOptions.isRestore =
       _request->parsedValue(StaticStrings::IsRestoreString, false);
   opOptions.waitForSync =
@@ -208,7 +193,7 @@ RestStatus RestDocumentHandler::insertDocument() {
   opOptions.returnNew =
       _request->parsedValue(StaticStrings::ReturnNewString, false);
   opOptions.silent = _request->parsedValue(StaticStrings::SilentString, false);
-  opOptions.refillIndexCaches = ::readFillIndexCachesValue(*_request);
+  handleFillIndexCachesValue(opOptions);
 
   if (_request->parsedValue(StaticStrings::Overwrite, false)) {
     // the default behavior if just "overwrite" is set
@@ -234,8 +219,6 @@ RestStatus RestDocumentHandler::insertDocument() {
   opOptions.returnOld =
       _request->parsedValue(StaticStrings::ReturnOldString, false) &&
       opOptions.isOverwriteModeUpdateReplace();
-  extractStringParameter(StaticStrings::IsSynchronousReplicationString,
-                         opOptions.isSynchronousReplicationFrom);
 
   TRI_IF_FAILURE("delayed_synchronous_replication_request_processing") {
     if (!opOptions.isSynchronousReplicationFrom.empty()) {
@@ -517,6 +500,8 @@ RestStatus RestDocumentHandler::modifyDocument(bool isPatch) {
     return RestStatus::DONE;
   }
 
+  extractStringParameter(StaticStrings::IsSynchronousReplicationString,
+                         opOptions.isSynchronousReplicationFrom);
   opOptions.isRestore =
       _request->parsedValue(StaticStrings::IsRestoreString, false);
   opOptions.ignoreRevs =
@@ -530,9 +515,7 @@ RestStatus RestDocumentHandler::modifyDocument(bool isPatch) {
   opOptions.returnOld =
       _request->parsedValue(StaticStrings::ReturnOldString, false);
   opOptions.silent = _request->parsedValue(StaticStrings::SilentString, false);
-  opOptions.refillIndexCaches = ::readFillIndexCachesValue(*_request);
-  extractStringParameter(StaticStrings::IsSynchronousReplicationString,
-                         opOptions.isSynchronousReplicationFrom);
+  handleFillIndexCachesValue(opOptions);
 
   TRI_IF_FAILURE("delayed_synchronous_replication_request_processing") {
     if (!opOptions.isSynchronousReplicationFrom.empty()) {
@@ -693,6 +676,8 @@ RestStatus RestDocumentHandler::removeDocument() {
   }
 
   OperationOptions opOptions(_context);
+  extractStringParameter(StaticStrings::IsSynchronousReplicationString,
+                         opOptions.isSynchronousReplicationFrom);
   opOptions.returnOld =
       _request->parsedValue(StaticStrings::ReturnOldString, false);
   opOptions.ignoreRevs =
@@ -700,9 +685,7 @@ RestStatus RestDocumentHandler::removeDocument() {
   opOptions.waitForSync =
       _request->parsedValue(StaticStrings::WaitForSyncString, false);
   opOptions.silent = _request->parsedValue(StaticStrings::SilentString, false);
-  opOptions.refillIndexCaches = ::readFillIndexCachesValue(*_request);
-  extractStringParameter(StaticStrings::IsSynchronousReplicationString,
-                         opOptions.isSynchronousReplicationFrom);
+  handleFillIndexCachesValue(opOptions);
 
   TRI_IF_FAILURE("delayed_synchronous_replication_request_processing") {
     if (!opOptions.isSynchronousReplicationFrom.empty()) {
@@ -865,4 +848,29 @@ RestStatus RestDocumentHandler::readManyDocuments() {
                       _activeTrx->transactionContextPtr()->getVPackOptions());
                 });
           }));
+}
+
+void RestDocumentHandler::handleFillIndexCachesValue(
+    OperationOptions& options) {
+  RefillIndexCaches ric = RefillIndexCaches::kDefault;
+
+  if (!options.isSynchronousReplicationFrom.empty() &&
+      !_vocbase.server()
+           .getFeature<RocksDBIndexCacheRefillFeature>()
+           .autoRefillOnFollowers()) {
+    // do not refill caches on followers if this is intentionally turned off
+    ric = RefillIndexCaches::kDontRefill;
+  } else {
+    bool found = false;
+    std::string const& value =
+        _request->value(StaticStrings::RefillIndexCachesString, found);
+    if (found) {
+      // this attribute can have 3 values: default, true and false. only
+      // pick it up when it is set to true or false
+      ric = StringUtils::boolean(value) ? RefillIndexCaches::kRefill
+                                        : RefillIndexCaches::kDontRefill;
+    }
+  }
+
+  options.refillIndexCaches = ric;
 }

--- a/arangod/RestHandler/RestDocumentHandler.h
+++ b/arangod/RestHandler/RestDocumentHandler.h
@@ -27,6 +27,8 @@
 #include "RestHandler/RestVocbaseBaseHandler.h"
 
 namespace arangodb {
+struct OperationOptions;
+
 namespace transaction {
 class Methods;
 }
@@ -71,6 +73,8 @@ class RestDocumentHandler : public RestVocbaseBaseHandler {
 
   // removes a document
   RestStatus removeDocument();
+
+  void handleFillIndexCachesValue(OperationOptions& options);
 
  private:
   std::unique_ptr<transaction::Methods> _activeTrx;

--- a/arangod/RocksDBEngine/RocksDBEdgeIndex.h
+++ b/arangod/RocksDBEngine/RocksDBEdgeIndex.h
@@ -112,7 +112,7 @@ class RocksDBEdgeIndex final : public RocksDBIndex {
                 OperationOptions const& options) override;
 
   void refillCache(transaction::Methods& trx,
-                   std::vector<std::string> const& keys) override;
+                   containers::FlatHashSet<std::string> const& keys) override;
 
  private:
   /// @brief create the iterator

--- a/arangod/RocksDBEngine/RocksDBIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBIndex.cpp
@@ -330,8 +330,9 @@ Result RocksDBIndex::update(transaction::Methods& trx, RocksDBMethods* mthd,
   return insert(trx, mthd, newDocumentId, newDoc, options, performChecks);
 }
 
-void RocksDBIndex::refillCache(transaction::Methods& trx,
-                               std::vector<std::string> const& /*keys*/) {}
+void RocksDBIndex::refillCache(
+    transaction::Methods& trx,
+    containers::FlatHashSet<std::string> const& /*keys*/) {}
 
 /// @brief return the memory usage of the index
 size_t RocksDBIndex::memory() const {

--- a/arangod/RocksDBEngine/RocksDBIndex.h
+++ b/arangod/RocksDBEngine/RocksDBIndex.h
@@ -27,6 +27,7 @@
 
 #include "Basics/AttributeNameParser.h"
 #include "Basics/Common.h"
+#include "Containers/FlatHashSet.h"
 #include "Indexes/Index.h"
 #include "RocksDBEngine/RocksDBCuckooIndexEstimator.h"
 #include "RocksDBEngine/RocksDBKeyBounds.h"
@@ -133,7 +134,7 @@ class RocksDBIndex : public Index {
                         OperationOptions const& options, bool performChecks);
 
   virtual void refillCache(transaction::Methods& trx,
-                           std::vector<std::string> const& keys);
+                           containers::FlatHashSet<std::string> const& keys);
 
   rocksdb::ColumnFamilyHandle* columnFamily() const { return _cf; }
 

--- a/arangod/RocksDBEngine/RocksDBIndexCacheRefillFeature.cpp
+++ b/arangod/RocksDBEngine/RocksDBIndexCacheRefillFeature.cpp
@@ -350,10 +350,7 @@ void RocksDBIndexCacheRefillFeature::waitForCatchup() {
 
 void RocksDBIndexCacheRefillFeature::stopThreads() {
   for (auto& t : _backgroundThreads) {
-    t->beginShutdown();
-    while (t->isRunning()) {
-      std::this_thread::yield();
-    }
+    t->shutdown();
   }
 }
 

--- a/arangod/RocksDBEngine/RocksDBIndexCacheRefillFeature.cpp
+++ b/arangod/RocksDBEngine/RocksDBIndexCacheRefillFeature.cpp
@@ -68,13 +68,15 @@ uint64_t defaultConcurrentIndexFillTasks() {
 
 DECLARE_COUNTER(rocksdb_cache_full_index_refills_total,
                 "Total number of completed full index cache refills");
-DECLARE_COUNTER(rocksdb_cache_auto_refill_loaded_total,
-                "Total number of auto-refilled in-memory cache items");
+DECLARE_COUNTER(rocksdb_cache_auto_refill_queued_total,
+                "Total number of cache items queued for auto-refilling");
 DECLARE_COUNTER(rocksdb_cache_auto_refill_dropped_total,
                 "Total number of dropped items for in-memory cache refilling");
 DECLARE_COUNTER(rocksdb_cache_auto_refill_foreground_total,
                 "Total number of items processed in foreground for in-memory "
                 "cache refilling");
+DECLARE_COUNTER(rocksdb_cache_auto_refill_loaded_total,
+                "Total number of cache items auto-refilled");
 
 RocksDBIndexCacheRefillFeature::RocksDBIndexCacheRefillFeature(
     application_features::ApplicationServer& server)
@@ -91,11 +93,13 @@ RocksDBIndexCacheRefillFeature::RocksDBIndexCacheRefillFeature(
       _totalFullIndexRefills(server.getFeature<MetricsFeature>().add(
           rocksdb_cache_full_index_refills_total{})),
       _totalNumQueued(server.getFeature<MetricsFeature>().add(
-          rocksdb_cache_auto_refill_loaded_total{})),
+          rocksdb_cache_auto_refill_queued_total{})),
       _totalNumDropped(server.getFeature<MetricsFeature>().add(
           rocksdb_cache_auto_refill_dropped_total{})),
       _totalNumForeground(server.getFeature<MetricsFeature>().add(
           rocksdb_cache_auto_refill_foreground_total{})),
+      _totalNumLoaded(server.getFeature<MetricsFeature>().add(
+          rocksdb_cache_auto_refill_loaded_total{})),
       _currentlyRunningIndexFillTasks(0) {
   setOptional(true);
   // we want to be late in the startup sequence
@@ -258,6 +262,11 @@ void RocksDBIndexCacheRefillFeature::increaseTotalNumForeground(
   _totalNumForeground += value;
 }
 
+void RocksDBIndexCacheRefillFeature::increaseTotalNumLoaded(
+    uint64_t value) noexcept {
+  _totalNumLoaded += value;
+}
+
 void RocksDBIndexCacheRefillFeature::stop() { stopThreads(); }
 
 bool RocksDBIndexCacheRefillFeature::autoRefill() const noexcept {
@@ -283,7 +292,7 @@ bool RocksDBIndexCacheRefillFeature::fillOnStartup() const noexcept {
 
 bool RocksDBIndexCacheRefillFeature::trackRefill(
     std::shared_ptr<LogicalCollection> const& collection, IndexId iid,
-    containers::FlatHashSet<std::string> keys) {
+    containers::FlatHashSet<std::string>& keys) {
   if (_backgroundThreads.empty()) {
     return false;
   }
@@ -304,7 +313,7 @@ bool RocksDBIndexCacheRefillFeature::trackRefill(
     size_t i = idx % _numBackgroundThreads;
     TRI_ASSERT(i < _backgroundThreads.size());
     auto& t = _backgroundThreads[i];
-    bool result = t->trackRefill(collection, iid, std::move(keys));
+    bool result = t->trackRefill(collection, iid, keys);
     if (result) {
       return true;
     }

--- a/arangod/RocksDBEngine/RocksDBIndexCacheRefillFeature.cpp
+++ b/arangod/RocksDBEngine/RocksDBIndexCacheRefillFeature.cpp
@@ -45,6 +45,8 @@
 #include "VocBase/Methods/Collections.h"
 #include "VocBase/Methods/Databases.h"
 
+#include <thread>
+
 using namespace arangodb;
 
 namespace {
@@ -114,6 +116,7 @@ RocksDBIndexCacheRefillFeature::RocksDBIndexCacheRefillFeature(
 
 RocksDBIndexCacheRefillFeature::~RocksDBIndexCacheRefillFeature() {
   stopThreads();
+  removeThreads();
 }
 
 void RocksDBIndexCacheRefillFeature::collectOptions(
@@ -269,6 +272,8 @@ void RocksDBIndexCacheRefillFeature::increaseTotalNumLoaded(
 
 void RocksDBIndexCacheRefillFeature::stop() { stopThreads(); }
 
+void RocksDBIndexCacheRefillFeature::unprepare() { removeThreads(); }
+
 bool RocksDBIndexCacheRefillFeature::autoRefill() const noexcept {
   return _autoRefill;
 }
@@ -293,7 +298,7 @@ bool RocksDBIndexCacheRefillFeature::fillOnStartup() const noexcept {
 bool RocksDBIndexCacheRefillFeature::trackRefill(
     std::shared_ptr<LogicalCollection> const& collection, IndexId iid,
     containers::FlatHashSet<std::string>& keys) {
-  if (_backgroundThreads.empty()) {
+  if (_backgroundThreads.empty() || server().isStopping()) {
     return false;
   }
   TRI_ASSERT(_numBackgroundThreads > 0);
@@ -345,8 +350,18 @@ void RocksDBIndexCacheRefillFeature::waitForCatchup() {
 
 void RocksDBIndexCacheRefillFeature::stopThreads() {
   for (auto& t : _backgroundThreads) {
+    t->beginShutdown();
+    while (t->isRunning()) {
+      std::this_thread::yield();
+    }
+  }
+}
+
+void RocksDBIndexCacheRefillFeature::removeThreads() {
+  for (auto& t : _backgroundThreads) {
     t.reset();
   }
+  _backgroundThreads.clear();
 }
 
 void RocksDBIndexCacheRefillFeature::buildStartupIndexRefillTasks() {

--- a/arangod/RocksDBEngine/RocksDBIndexCacheRefillFeature.h
+++ b/arangod/RocksDBEngine/RocksDBIndexCacheRefillFeature.h
@@ -59,7 +59,7 @@ class RocksDBIndexCacheRefillFeature final
   // track the refill of the specified keys. returns true if the keys
   // were taken, false otherwise
   bool trackRefill(std::shared_ptr<LogicalCollection> const& collection,
-                   IndexId iid, containers::FlatHashSet<std::string> keys);
+                   IndexId iid, containers::FlatHashSet<std::string>& keys);
 
   // schedule the refill of the full index
   void scheduleFullIndexRefill(std::string const& database,
@@ -86,6 +86,7 @@ class RocksDBIndexCacheRefillFeature final
   void increaseTotalNumQueued(uint64_t value) noexcept;
   void increaseTotalNumDropped(uint64_t value) noexcept;
   void increaseTotalNumForeground(uint64_t value) noexcept;
+  void increaseTotalNumLoaded(uint64_t value) noexcept;
 
  private:
   void stopThreads();
@@ -152,6 +153,9 @@ class RocksDBIndexCacheRefillFeature final
 
   // total number of items processed in foreground (because of queue full)
   Counter& _totalNumForeground;
+
+  // total number of items reloaded
+  Counter& _totalNumLoaded;
 
   // protects _indexFillTasks and _currentlyRunningIndexFillTasks
   std::mutex _indexFillTasksMutex;

--- a/arangod/RocksDBEngine/RocksDBIndexCacheRefillFeature.h
+++ b/arangod/RocksDBEngine/RocksDBIndexCacheRefillFeature.h
@@ -55,6 +55,7 @@ class RocksDBIndexCacheRefillFeature final
   void beginShutdown() override;
   void start() override;
   void stop() override;
+  void unprepare() override;
 
   // track the refill of the specified keys. returns true if the keys
   // were taken, false otherwise
@@ -90,6 +91,7 @@ class RocksDBIndexCacheRefillFeature final
 
  private:
   void stopThreads();
+  void removeThreads();
 
   // build the initial data in _indexFillTasks
   void buildStartupIndexRefillTasks();

--- a/arangod/RocksDBEngine/RocksDBIndexCacheRefillThread.cpp
+++ b/arangod/RocksDBEngine/RocksDBIndexCacheRefillThread.cpp
@@ -146,6 +146,11 @@ void RocksDBIndexCacheRefillThread::refill(TRI_vocbase_t& vocbase,
 
   // loop over all the indexes in the given collection
   for (auto const& it : data) {
+    if (isStopping()) {
+      // we are in shutdown, abort quickly
+      return;
+    }
+
     auto idx = trx.documentCollection()->lookupIndex(it.first);
     if (idx == nullptr) {
       // index doesn't exist anymore

--- a/arangod/RocksDBEngine/RocksDBIndexCacheRefillThread.cpp
+++ b/arangod/RocksDBEngine/RocksDBIndexCacheRefillThread.cpp
@@ -63,7 +63,7 @@ void RocksDBIndexCacheRefillThread::beginShutdown() {
 
 bool RocksDBIndexCacheRefillThread::trackRefill(
     std::shared_ptr<LogicalCollection> const& collection, IndexId iid,
-    containers::FlatHashSet<std::string> keys) {
+    containers::FlatHashSet<std::string>& keys) {
   size_t const n = keys.size();
 
   if (n == 0) {
@@ -108,6 +108,7 @@ bool RocksDBIndexCacheRefillThread::trackRefill(
   _condition.signal();
   // increase metric
   _refillFeature.increaseTotalNumQueued(n);
+  keys.clear();
 
   return true;
 }
@@ -151,6 +152,7 @@ void RocksDBIndexCacheRefillThread::refill(TRI_vocbase_t& vocbase,
       continue;
     }
     static_cast<RocksDBIndex*>(idx.get())->refillCache(trx, it.second);
+    _refillFeature.increaseTotalNumLoaded(it.second.size());
   }
 }
 

--- a/arangod/RocksDBEngine/RocksDBIndexCacheRefillThread.h
+++ b/arangod/RocksDBEngine/RocksDBIndexCacheRefillThread.h
@@ -55,7 +55,7 @@ class RocksDBIndexCacheRefillThread final : public Thread {
   void beginShutdown() override;
 
   bool trackRefill(std::shared_ptr<LogicalCollection> const& collection,
-                   IndexId iid, containers::FlatHashSet<std::string> keys);
+                   IndexId iid, containers::FlatHashSet<std::string>& keys);
 
   void waitForCatchup();
 

--- a/arangod/RocksDBEngine/RocksDBTransactionCollection.cpp
+++ b/arangod/RocksDBEngine/RocksDBTransactionCollection.cpp
@@ -312,7 +312,7 @@ void RocksDBTransactionCollection::handleIndexCacheRefills() {
   for (auto& it : _trackedCacheRefills) {
     TRI_ASSERT(!it.second.empty());
 
-    if (refiller.trackRefill(_collection, it.first, std::move(it.second))) {
+    if (refiller.trackRefill(_collection, it.first, it.second)) {
       it.second.clear();
     } else if (!refiller.refillInForegroundIfQueueFull()) {
       // background thread could not take over. but we are configured to not
@@ -343,6 +343,8 @@ void RocksDBTransactionCollection::handleIndexCacheRefills() {
           }
           static_cast<RocksDBIndex*>(idx.get())->refillCache(trx, it.second);
           refiller.increaseTotalNumForeground(it.second.size());
+          refiller.increaseTotalNumLoaded(it.second.size());
+          it.second.clear();
         }
       }
     } catch (std::exception const& ex) {

--- a/arangod/RocksDBEngine/RocksDBTransactionCollection.h
+++ b/arangod/RocksDBEngine/RocksDBTransactionCollection.h
@@ -25,6 +25,7 @@
 
 #include "Basics/Common.h"
 #include "Containers/FlatHashMap.h"
+#include "Containers/FlatHashSet.h"
 #include "StorageEngine/TransactionCollection.h"
 #include "VocBase/AccessMode.h"
 #include "VocBase/Identifiers/IndexId.h"
@@ -167,7 +168,7 @@ class RocksDBTransactionCollection final : public TransactionCollection {
   ///        Will be applied to the inserter on commit and not applied on abort
   IndexOperationsMap _trackedIndexOperations;
 
-  containers::FlatHashMap<IndexId, std::vector<std::string>>
+  containers::FlatHashMap<IndexId, containers::FlatHashSet<std::string>>
       _trackedCacheRefills;
 
   bool _usageLocked;

--- a/arangod/Transaction/Methods.cpp
+++ b/arangod/Transaction/Methods.cpp
@@ -2611,10 +2611,11 @@ Future<Result> Methods::replicateOperations(
 
   // path and requestType are different for insert/remove/modify.
 
+  // path and requestType are different for insert/remove/modify.
+
   network::RequestOptions reqOpts;
   reqOpts.database = vocbase().name();
   reqOpts.param(StaticStrings::IsRestoreString, "true");
-
   if (options.refillIndexCaches != RefillIndexCaches::kDefault) {
     // this attribute can have 3 values: default, true and false. only
     // expose it when it is not set to "default"


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/17823

This PR adds optional multi-threaded refilling of index caches.
It adds the following new startup options for index cache refilling:
* `--rocksdb.auto-refill-background-threads`: the number of background threads for in-memory index cache refill operations.
* `--rocksdb.auto-refill-in-foreground-if-queue-full`: whether to automatically (re-)fill the in-memory index caches in foreground if background thread queues are full. If this is set to `false`, any refill operations are dropped in case the maximum queue capacity is reached in all background threads. If set to `true`, the refill operations will be carried out in foreground as part of the data modification operation (insert/update/replace/remove), which may slow them down. The default value is `false`.
* `--rocksdb.auto-refill-index-caches-on-followers`: whether to automatically (re-)fill the in-memory index caches on followers as well. Defaults to `true` and can be turned off to save index cache memory on followers.

This PR also adds the followings metrics
* `rocksdb_cache_auto_refill_foreground_total`: this metric contains the total number of entries in automatic in-memory index cache refilling that were processed in foreground. This metric will be increased only if `--rocksdb.auto-refill-in-foreground-if-queue-full` is `true` and all background threads have reached their capacity limits.
* `rocksdb_cache_auto_refill_queued_total`: total number of index entries queued for automatic refilling by background threads. This metric will not be increased if no background thread has capacity for queueing.

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [x] Backports
  - [x] Backport for 3.10: TO DO
  - [x] Backport for 3.9: this PR
  - [ ] Backport for 3.8: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 