### PR TITLE
The snapshotHandler might not be initialized

### DIFF
--- a/arangod/Replication2/StateMachines/Document/DocumentStateHandlersFactory.cpp
+++ b/arangod/Replication2/StateMachines/Document/DocumentStateHandlersFactory.cpp
@@ -62,12 +62,9 @@ auto DocumentStateHandlersFactory::createSnapshotHandler(
     -> std::unique_ptr<IDocumentStateSnapshotHandler> {
   auto* vocbase = _databaseFeature.lookupDatabase(gid.database);
   if (vocbase == nullptr) {
-    // TODO this is a temporary fix, see CINFRA-588
-    /*
-    THROW_ARANGO_EXCEPTION_MESSAGE(
-        TRI_ERROR_ARANGO_DATABASE_NOT_FOUND,
-        fmt::format("database {} not found", gid.database));
-     */
+    LOG_TOPIC("52f26", ERR, Logger::REPLICATION2)
+        << "database " << gid.database
+        << " not found during creation of snapshot handler";
     return nullptr;
   }
   return std::make_unique<DocumentStateSnapshotHandler>(


### PR DESCRIPTION
### Scope & Purpose

The problem was triggered in the following scenario:
A replicated state is created at the beginning of a JS test. One follower is stopped and we wait until the server is FAILED. The test continues and finished, but in the `tearDown` the server is brought back up. Immediately, the suite proceeds with `tearDownAll` and drops the database. At this point, the replicated state is still there and the follower is initialized again. During initialization, we use `lookupDatabase` to get a pointer to the vocbase, in order to create the `snapshotHandler`. If the database is being dropped, but we're still in the constructor of the follower, we won't be able to initialize the `snapshotHandler`. Eventually, when we'll get to `resign`, we'll try to access the `snapshotHandler` and crash.
This PR handler this case gracefully.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
