### PR TITLE
improve user message for end users

### DIFF
--- a/arangod/RestHandler/RestTransactionHandler.cpp
+++ b/arangod/RestHandler/RestTransactionHandler.cpp
@@ -155,8 +155,11 @@ void RestTransactionHandler::executeBegin() {
 
   if (found) {
     if (!ServerState::isDBServer(role)) {
-      generateError(rest::ResponseCode::BAD, TRI_ERROR_NOT_IMPLEMENTED,
-                    "Not supported on this server type");
+      // it is not expected that the user sends a transaction ID to begin
+      // a transaction
+      generateError(
+          rest::ResponseCode::BAD, TRI_ERROR_BAD_PARAMETER,
+          "unexpected transaction ID received in begin transaction request");
       return;
     }
     // figure out the transaction ID
@@ -180,8 +183,9 @@ void RestTransactionHandler::executeBegin() {
   } else {
     if (!ServerState::isCoordinator(role) &&
         !ServerState::isSingleServer(role)) {
-      generateError(rest::ResponseCode::BAD, TRI_ERROR_NOT_IMPLEMENTED,
-                    "Not supported on this server type");
+      generateError(
+          rest::ResponseCode::BAD, TRI_ERROR_BAD_PARAMETER,
+          "missing transaction ID in internal transaction begin request");
       return;
     }
 


### PR DESCRIPTION
### Scope & Purpose

~willify~ improve an error message when a transaction ID is sent in a request to begin a transaction.
Sending a transaction ID is unexpected, and previously produced a "Not supported on this server type" error message.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: -
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 