### PR TITLE
fix duplicate cache stats reporting

### DIFF
--- a/arangod/Cache/TransactionalCache.cpp
+++ b/arangod/Cache/TransactionalCache.cpp
@@ -63,7 +63,6 @@ Finding TransactionalCache<Hasher>::find(void const* key,
       recordStat(Stat::findMiss);
       result.reportError(TRI_ERROR_ARANGO_DOCUMENT_NOT_FOUND);
     }
-    recordStat(result.found() ? Stat::findHit : Stat::findMiss);
   }
   return result;
 }


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/17857

Fix duplicate reporting of find hits/misses in transactional cache

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [x] Backports
  - [x] Backport for 3.10: this PR
  - [x] Backport for 3.9: https://github.com/arangodb/arangodb/pull/17859
  - [ ] Backport for 3.8: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

