### PR TITLE
upgrade velocypack to newest version

### DIFF
--- a/3rdParty/fuerte/src/vst.cpp
+++ b/3rdParty/fuerte/src/vst.cpp
@@ -479,10 +479,10 @@ RequestHeader requestHeaderFromSlice(VPackSlice const& headerSlice) {
   header.restVerb =
       static_cast<RestVerb>(headerSlice.at(3).getInt());    // rest verb
   header.path = headerSlice.at(4).copyString();             // request (path)
-  for (auto it : VPackObjectIterator(headerSlice.at(5))) {  // query params
+  for (auto it : VPackObjectIterator(headerSlice.at(5), /*useSequentialIteration*/ true)) {  // query params
     header.parameters.emplace(it.key.copyString(), it.value.copyString());
   }
-  for (auto it : VPackObjectIterator(headerSlice.at(6))) {  // meta (headers)
+  for (auto it : VPackObjectIterator(headerSlice.at(6), /*useSequentialIteration*/ true)) {  // meta (headers)
     std::string key = it.key.copyString();
     toLowerInPlace(key);
     header.addMeta(std::move(key), it.value.copyString());
@@ -502,7 +502,7 @@ ResponseHeader responseHeaderFromSlice(VPackSlice const& headerSlice) {
     VPackSlice meta = headerSlice.at(3);
     assert(meta.isObject());
     if (meta.isObject()) {
-      for (auto it : VPackObjectIterator(meta)) {
+      for (auto it : VPackObjectIterator(meta, /*useSequentialIteration*/ true)) {
         std::string key = it.key.copyString();
         toLowerInPlace(key);
         header.addMeta(std::move(key), it.value.copyString());

--- a/3rdParty/json-schema-validation/include/validation/events_from_slice.hpp
+++ b/3rdParty/json-schema-validation/include/validation/events_from_slice.hpp
@@ -78,7 +78,7 @@ void from_value(Consumer& consumer,
         case arangodb::velocypack::ValueType::Object: {
             const auto len = slice.length();
             consumer.begin_object(len);
-            for (const auto& element : VPackObjectIterator(slice)) {
+            for (const auto& element : VPackObjectIterator(slice, /*useSequentialIteration*/ true)) {
                 VPackSlice key = element.key;
                 if (key.isString()) {
                     auto ref = key.stringRef();

--- a/arangod/Agency/ActiveFailoverJob.cpp
+++ b/arangod/Agency/ActiveFailoverJob.cpp
@@ -315,7 +315,8 @@ std::string ActiveFailoverJob::findBestFollower() {
 
     VPackSlice obj =
         resp.at(0).get({Job::agencyPrefix, std::string("AsyncReplication")});
-    for (VPackObjectIterator::ObjectPair pair : VPackObjectIterator(obj)) {
+    for (auto pair :
+         VPackObjectIterator(obj, /*useSequentialIteration*/ true)) {
       std::string srvUUID = pair.key.copyString();
       bool isAvailable =
           std::find(healthy.begin(), healthy.end(), srvUUID) != healthy.end();

--- a/arangod/Agency/Agent.cpp
+++ b/arangod/Agency/Agent.cpp
@@ -2184,7 +2184,8 @@ query_t Agent::gossip(VPackSlice slice, bool isCallback, size_t version) {
 
   LOG_TOPIC("65dd8", TRACE, Logger::AGENCY)
       << "Received gossip " << slice.toJson();
-  for (auto pair : VPackObjectIterator(pslice)) {
+  for (auto pair :
+       VPackObjectIterator(pslice, /*useSequentialIteration*/ true)) {
     if (!pair.value.isString()) {
       THROW_ARANGO_EXCEPTION_MESSAGE(
           TRI_ERROR_AGENCY_MALFORMED_GOSSIP_MESSAGE,
@@ -2341,7 +2342,7 @@ void Agent::trashStoreCallback(std::string const& url, VPackSlice slice) {
 
   // body consists of object holding keys index, term and the observed keys
   // we'll remove observation on every key and according observer url
-  for (auto const& i : VPackObjectIterator(slice)) {
+  for (auto i : VPackObjectIterator(slice, /*useSequentialIteration*/ true)) {
     if (!i.key.isEqualString("term") && !i.key.isEqualString("index")) {
       MUTEX_LOCKER(lock, _cbtLock);
       _callbackTrashBin[i.key.copyString()].emplace(url);

--- a/arangod/Agency/FailedFollower.cpp
+++ b/arangod/Agency/FailedFollower.cpp
@@ -273,7 +273,8 @@ bool FailedFollower::start(bool& aborts) {
           job.add("timeFinished",  // same same :)
                   VPackValue(timepointToString(system_clock::now())));
           job.add("toServer", VPackValue(_to));  // toServer
-          for (auto const& obj : VPackObjectIterator(todo.slice()[0])) {
+          for (auto obj : VPackObjectIterator(
+                   todo.slice()[0], /*useSequentialIteration*/ false)) {
             job.add(obj.key.copyString(), obj.value);
           }
         }

--- a/arangod/Agency/FailedLeader.cpp
+++ b/arangod/Agency/FailedLeader.cpp
@@ -299,7 +299,8 @@ bool FailedLeader::start(bool& aborts) {
           pending.add("timeStarted",  // start
                       VPackValue(timepointToString(system_clock::now())));
           pending.add("toServer", VPackValue(_to));  // toServer
-          for (auto const& obj : VPackObjectIterator(todo.slice()[0])) {
+          for (auto obj : VPackObjectIterator(
+                   todo.slice()[0], /*useSequentialIteration*/ false)) {
             pending.add(obj.key.copyString(), obj.value);
           }
         }

--- a/arangod/Agency/FailedServer.cpp
+++ b/arangod/Agency/FailedServer.cpp
@@ -259,7 +259,8 @@ bool FailedServer::start(bool& aborts) {
         VPackObjectBuilder ts(transactions.get());
         transactions->add("timeStarted",
                           VPackValue(timepointToString(system_clock::now())));
-        for (auto const& obj : VPackObjectIterator(todo.slice()[0])) {
+        for (auto obj : VPackObjectIterator(todo.slice()[0],
+                                            /*useSequentialIteration*/ false)) {
           transactions->add(obj.key.copyString(), obj.value);
         }
       }

--- a/arangod/Agency/Job.cpp
+++ b/arangod/Agency/Job.cpp
@@ -100,14 +100,16 @@ write_ret_t singleWriteTransaction(AgentInterface* _agent,
       VPackArrayBuilder onePair(&envelope);
       {
         VPackObjectBuilder mutationPart(&envelope);
-        for (auto pair : VPackObjectIterator(trx[0])) {
+        for (auto pair :
+             VPackObjectIterator(trx[0], /*useSequentialIteration*/ false)) {
           envelope.add("/" + Job::agencyPrefix + pair.key.copyString(),
                        pair.value);
         }
       }
       if (trx.length() > 1) {
         VPackObjectBuilder preconditionPart(&envelope);
-        for (auto pair : VPackObjectIterator(trx[1])) {
+        for (auto pair :
+             VPackObjectIterator(trx[1], /*useSequentialIteration*/ false)) {
           envelope.add("/" + Job::agencyPrefix + pair.key.copyString(),
                        pair.value);
         }
@@ -142,14 +144,16 @@ trans_ret_t generalTransaction(AgentInterface* _agent,
           VPackArrayBuilder onePair(&envelope);
           {
             VPackObjectBuilder mutationPart(&envelope);
-            for (auto pair : VPackObjectIterator(singleTrans[0])) {
+            for (auto pair : VPackObjectIterator(
+                     singleTrans[0], /*useSequentialIteration*/ false)) {
               envelope.add("/" + Job::agencyPrefix + pair.key.copyString(),
                            pair.value);
             }
           }
           if (singleTrans.length() > 1) {
             VPackObjectBuilder preconditionPart(&envelope);
-            for (auto pair : VPackObjectIterator(singleTrans[1])) {
+            for (auto pair : VPackObjectIterator(
+                     singleTrans[1], /*useSequentialIteration*/ false)) {
               envelope.add("/" + Job::agencyPrefix + pair.key.copyString(),
                            pair.value);
             }
@@ -190,14 +194,16 @@ trans_ret_t transient(AgentInterface* _agent,
       VPackArrayBuilder onePair(&envelope);
       {
         VPackObjectBuilder mutationPart(&envelope);
-        for (auto pair : VPackObjectIterator(trx[0])) {
+        for (auto pair :
+             VPackObjectIterator(trx[0], /*useSequentialIteration*/ false)) {
           envelope.add("/" + Job::agencyPrefix + pair.key.copyString(),
                        pair.value);
         }
       }
       if (trx.length() > 1) {
         VPackObjectBuilder preconditionPart(&envelope);
-        for (auto pair : VPackObjectIterator(trx[1])) {
+        for (auto pair :
+             VPackObjectIterator(trx[1], /*useSequentialIteration*/ false)) {
           envelope.add("/" + Job::agencyPrefix + pair.key.copyString(),
                        pair.value);
         }
@@ -339,7 +345,8 @@ bool Job::finish(std::string const& server, std::string const& shard,
         addRemoveJobFromSomewhere(finished, "Pending", _jobId);
 
         if (operations.length() > 0) {
-          for (auto oper : VPackObjectIterator(operations)) {
+          for (auto oper : VPackObjectIterator(
+                   operations, /*useSequentialIteration*/ true)) {
             finished.add(oper.key.stringView(), oper.value);
           }
         }
@@ -357,7 +364,8 @@ bool Job::finish(std::string const& server, std::string const& shard,
       if (preconditions.isObject() &&
           preconditions.length() > 0) {  // preconditions --
         VPackObjectBuilder precguard(&finished);
-        for (auto prec : VPackObjectIterator(preconditions)) {
+        for (auto prec : VPackObjectIterator(preconditions,
+                                             /*useSequentialIteration*/ true)) {
           finished.add(prec.key.stringView(), prec.value);
         }
       }  // -- preconditions
@@ -927,7 +935,7 @@ void Job::addPutJobIntoSomewhere(Builder& trx, std::string const& where,
       trx.add("timeFinished",
               VPackValue(timepointToString(std::chrono::system_clock::now())));
     }
-    for (auto obj : VPackObjectIterator(job)) {
+    for (auto obj : VPackObjectIterator(job, /*useSequentialIteration*/ true)) {
       trx.add(obj.key.stringView(), obj.value);
     }
     if (!reason.empty()) {

--- a/arangod/Agency/MoveShard.cpp
+++ b/arangod/Agency/MoveShard.cpp
@@ -484,7 +484,8 @@ bool MoveShard::start(bool&) {
     {
       VPackArrayBuilder guard0(&todo);
       VPackObjectBuilder guard(&todo);
-      for (auto p : VPackObjectIterator(todo2.slice()[0])) {
+      for (auto p : VPackObjectIterator(todo2.slice()[0],
+                                        /*useSequentialIteration*/ true)) {
         std::string_view key = p.key.stringView();
         if (key != "tryUndo") {
           todo.add(key, p.value);
@@ -655,7 +656,8 @@ bool MoveShard::startReplication2() {
   {
     VPackObjectBuilder ob(&newJob);
     newJob.add(EXPECTED_TARGET_VERSION, VPackValue(expected));
-    newJob.add(VPackObjectIterator(oldJob.slice()));
+    newJob.add(
+        VPackObjectIterator(oldJob.slice(), /*useSequentialIteration*/ true));
   }
 
   Builder trx;

--- a/arangod/Agency/Node.cpp
+++ b/arangod/Agency/Node.cpp
@@ -966,7 +966,7 @@ bool Node::applies(VPackSlice slice) {
   clear();
 
   if (slice.isObject()) {
-    for (auto const& i : VPackObjectIterator(slice)) {
+    for (auto i : VPackObjectIterator(slice, /*useSequentialIteration*/ true)) {
       // note: no need to remove duplicate forward slashes here...
       //  if i.key contains duplicate forward slashes, then we will go
       //  into the  key.find('/')  case, and will be calling  operator()

--- a/arangod/Agency/RestAgencyPrivHandler.cpp
+++ b/arangod/Agency/RestAgencyPrivHandler.cpp
@@ -246,8 +246,9 @@ RestStatus RestAgencyPrivHandler::execute() {
             redirectRequest(slice.get("id").copyString());
             return RestStatus::DONE;
           }
-          for (auto const& obj : VPackObjectIterator(ret->slice())) {
-            result.add(obj.key.copyString(), obj.value);
+          for (auto obj : VPackObjectIterator(
+                   ret->slice(), /*useSequentialIteration*/ true)) {
+            result.add(obj.key.stringView(), obj.value);
           }
         } catch (std::exception const& e) {
           LOG_TOPIC("d7dda", ERR, Logger::AGENCY) << e.what();

--- a/arangod/Agency/Supervision.cpp
+++ b/arangod/Agency/Supervision.cpp
@@ -816,9 +816,10 @@ std::vector<check_t> Supervision::check(std::string const& type) {
             if (envelope != nullptr) {  // Failed server
               TRI_ASSERT(envelope->slice().isArray() &&
                          envelope->slice()[0].isObject());
-              for (VPackObjectIterator::ObjectPair i :
-                   VPackObjectIterator(envelope->slice()[0])) {
-                pReport.add(i.key.copyString(), i.value);
+              for (auto i :
+                   VPackObjectIterator(envelope->slice()[0],
+                                       /*useSequentialIteration*/ false)) {
+                pReport.add(i.key.stringView(), i.value);
               }
             }
           }  // Operation
@@ -884,15 +885,17 @@ bool Supervision::earlyBird() const {
   VPackSlice serverStates = serverStatesB.slice();
 
   // every db server in plan accounted for in transient store?
-  for (auto const& server : VPackObjectIterator(dbservers)) {
-    auto serverId = server.key.copyString();
+  for (auto server :
+       VPackObjectIterator(dbservers, /*useSequentialIteration*/ true)) {
+    auto serverId = server.key.stringView();
     if (!serverStates.hasKey(serverId)) {
       return false;
     }
   }
   // every db server in plan accounted for in transient store?
-  for (auto const& server : VPackObjectIterator(coordinators)) {
-    auto serverId = server.key.copyString();
+  for (auto server :
+       VPackObjectIterator(coordinators, /*useSequentialIteration*/ true)) {
+    auto serverId = server.key.stringView();
     if (!serverStates.hasKey(serverId)) {
       return false;
     }
@@ -3009,7 +3012,8 @@ void Supervision::readyOrphanedIndexCreations() {
                       built.end()) {
                     {
                       VPackObjectBuilder props(&envelope);
-                      for (auto prop : VPackObjectIterator(planIndex)) {
+                      for (auto prop : VPackObjectIterator(
+                               planIndex, /*useSequentialIteration*/ true)) {
                         auto key = prop.key.stringView();
                         if (key != StaticStrings::IndexIsBuilding &&
                             key != StaticStrings::AttrCoordinator &&

--- a/arangod/Aql/AqlCall.cpp
+++ b/arangod/Aql/AqlCall.cpp
@@ -145,13 +145,14 @@ auto AqlCall::fromVelocyPack(velocypack::Slice slice) -> ResultT<AqlCall> {
     }
   };
 
-  for (auto const it : velocypack::ObjectIterator(slice)) {
-    auto const keySlice = it.key;
+  for (auto it :
+       velocypack::ObjectIterator(slice, /*useSequentialIteration*/ true)) {
+    auto keySlice = it.key;
     if (ADB_UNLIKELY(!keySlice.isString())) {
       return Result(TRI_ERROR_TYPE_ERROR,
                     "When deserializating AqlCall: Key is not a string");
     }
-    auto const key = keySlice.stringView();
+    auto key = keySlice.stringView();
 
     if (auto propIt = expectedPropertiesFound.find(key);
         ADB_LIKELY(propIt != expectedPropertiesFound.end())) {

--- a/arangod/Aql/AqlCallList.cpp
+++ b/arangod/Aql/AqlCallList.cpp
@@ -176,13 +176,14 @@ auto AqlCallList::fromVelocyPack(VPackSlice slice) -> ResultT<AqlCallList> {
 
   AqlCallList result{AqlCall{}};
 
-  for (auto const it : velocypack::ObjectIterator(slice)) {
-    auto const keySlice = it.key;
+  for (auto it :
+       velocypack::ObjectIterator(slice, /*useSequentialIteration*/ true)) {
+    auto keySlice = it.key;
     if (ADB_UNLIKELY(!keySlice.isString())) {
       return Result(TRI_ERROR_TYPE_ERROR,
                     "When deserializating AqlCallList: Key is not a string");
     }
-    auto const key = getStringView(keySlice);
+    auto key = getStringView(keySlice);
 
     if (auto propIt = expectedPropertiesFound.find(key);
         ADB_LIKELY(propIt != expectedPropertiesFound.end())) {

--- a/arangod/Aql/AqlExecuteResult.cpp
+++ b/arangod/Aql/AqlExecuteResult.cpp
@@ -159,13 +159,14 @@ auto AqlExecuteResult::fromVelocyPack(velocypack::Slice const slice,
     return itemBlockManager.requestAndInitBlock(slice);
   };
 
-  for (auto const it : velocypack::ObjectIterator(slice)) {
-    auto const keySlice = it.key;
+  for (auto it :
+       velocypack::ObjectIterator(slice, /*useSequentialIteration*/ true)) {
+    auto keySlice = it.key;
     if (ADB_UNLIKELY(!keySlice.isString())) {
       return Result(TRI_ERROR_TYPE_ERROR,
                     "When deserializing AqlExecuteResult: Key is not a string");
     }
-    auto const key = getStringView(keySlice);
+    auto key = getStringView(keySlice);
 
     if (auto propIt = expectedPropertiesFound.find(key);
         ADB_LIKELY(propIt != expectedPropertiesFound.end())) {

--- a/arangod/Aql/EngineInfoContainerDBServerServerBased.cpp
+++ b/arangod/Aql/EngineInfoContainerDBServerServerBased.cpp
@@ -629,7 +629,8 @@ Result EngineInfoContainerDBServerServerBased::parseResponse(
 
   VPackSlice snippets = result.get("snippets");
   // Link Snippets to their sinks
-  for (auto const& resEntry : VPackObjectIterator(snippets)) {
+  for (auto resEntry :
+       VPackObjectIterator(snippets, /*useSequentialIteration*/ false)) {
     if (!resEntry.value.isString()) {
       return {TRI_ERROR_CLUSTER_AQL_COMMUNICATION,
               "Unable to deploy query snippets on all required "

--- a/arangod/Aql/Functions.cpp
+++ b/arangod/Aql/Functions.cpp
@@ -2683,7 +2683,8 @@ AqlValue functions::Substitute(ExpressionContext* expressionContext,
     VPackSlice slice = materializer.slice(search, false);
     matchPatterns.reserve(slice.length());
     replacePatterns.reserve(slice.length());
-    for (auto it : VPackObjectIterator(slice)) {
+    for (auto it :
+         VPackObjectIterator(slice, /*useSequentialIteration*/ true)) {
       velocypack::ValueLength length;
       char const* str = it.key.getString(length);
       matchPatterns.push_back(
@@ -9117,12 +9118,7 @@ AqlValue functions::Interleave(aql::ExpressionContext* expressionContext,
   transaction::Methods* trx = &expressionContext->trx();
   auto* vopts = &trx->vpackOptions();
 
-  struct ArrayIteratorPair {
-    VPackArrayIterator current;
-    VPackArrayIterator end;
-  };
-
-  std::list<ArrayIteratorPair> iters;
+  std::list<VPackArrayIterator> iters;
   std::vector<AqlValueMaterializer> materializers;
   materializers.reserve(parameters.size());
 
@@ -9138,9 +9134,7 @@ AqlValue functions::Interleave(aql::ExpressionContext* expressionContext,
       continue;  // skip empty array here
     }
 
-    VPackArrayIterator iter(slice);
-    ArrayIteratorPair pair{iter.begin(), iter.end()};
-    iters.emplace_back(pair);
+    iters.emplace_back(VPackArrayIterator(slice));
   }
 
   transaction::BuilderLeaser builder(trx);
@@ -9148,10 +9142,10 @@ AqlValue functions::Interleave(aql::ExpressionContext* expressionContext,
 
   while (!iters.empty()) {  // in this loop we only deal with nonempty arrays
     for (auto i = iters.begin(); i != iters.end();) {
-      builder->add(i->current.value());  // thus this will always be valid on
-                                         // the first iteration
-      i->current++;
-      if (i->current == i->end) {
+      builder->add(i->value());  // thus this will always be valid on
+                                 // the first iteration
+      i->next();
+      if (*i == std::default_sentinel_t{}) {
         i = iters.erase(i);
       } else {
         i++;
@@ -9296,7 +9290,8 @@ AqlValue functions::MakeDistributeInputWithKeyCreation(
         *builder,
         std::string_view(logicalCollection->keyGenerator().generate(input)),
         /*closeObject*/ false);
-    for (auto cur : VPackObjectIterator(input)) {
+    for (auto cur :
+         VPackObjectIterator(input, /*useSequentialIteration*/ true)) {
       builder->add(cur.key.stringView(), cur.value);
     }
     builder->close();
@@ -9356,7 +9351,8 @@ AqlValue functions::MakeDistributeGraphInput(
     auto keyPart = transaction::helpers::extractKeyPart(idSlice);
     transaction::BuilderLeaser builder(&trx);
     buildKeyObject(*builder, std::string_view(keyPart), /*closeObject*/ false);
-    for (auto cur : VPackObjectIterator(input)) {
+    for (auto cur :
+         VPackObjectIterator(input, /*useSequentialIteration*/ true)) {
       builder->add(cur.key.stringView(), cur.value);
     }
     builder->close();

--- a/arangod/Aql/GraphNode.cpp
+++ b/arangod/Aql/GraphNode.cpp
@@ -473,7 +473,8 @@ GraphNode::GraphNode(ExecutionPlan* plan,
         TRI_ERROR_QUERY_BAD_JSON_PLAN,
         "graph needs a translation from collection to shard names");
   }
-  for (auto const& item : VPackObjectIterator(collectionToShard)) {
+  for (auto item : VPackObjectIterator(collectionToShard,
+                                       /*useSequentialIteration*/ true)) {
     _collectionToShard.insert({item.key.copyString(), item.value.copyString()});
   }
 

--- a/arangod/Aql/NonConstExpressionContainer.cpp
+++ b/arangod/Aql/NonConstExpressionContainer.cpp
@@ -111,7 +111,8 @@ NonConstExpressionContainer NonConstExpressionContainer::fromVelocyPack(
 
   auto vars = slice.get(varMappingKey);
   TRI_ASSERT(vars.isObject());
-  for (auto const& [varId, regId] : VPackObjectIterator(vars)) {
+  for (auto const& [varId, regId] :
+       VPackObjectIterator(vars, /*useSequentialIteration*/ false)) {
     VariableId variableId = 0;
     bool converted =
         basics::StringUtils::toNumber(varId.copyString(), variableId);

--- a/arangod/Aql/RestAqlHandler.cpp
+++ b/arangod/Aql/RestAqlHandler.cpp
@@ -249,7 +249,8 @@ void RestAqlHandler::setupClusterQuery() {
   // Build the collection information
   VPackBuilder collectionBuilder;
   collectionBuilder.openArray();
-  for (auto const& lockInf : VPackObjectIterator(lockInfoSlice)) {
+  for (auto lockInf :
+       VPackObjectIterator(lockInfoSlice, /*useSequentialIteration*/ false)) {
     if (!lockInf.value.isArray()) {
       LOG_TOPIC("1dc00", WARN, arangodb::Logger::AQL)
           << "Invalid VelocyPack: \"lockInfo." << lockInf.key.copyString()
@@ -607,13 +608,13 @@ auto AqlExecuteCall::fromVelocyPack(VPackSlice const slice)
 
   std::optional<AqlCallStack> callStack;
 
-  for (auto const it : VPackObjectIterator(slice)) {
-    auto const keySlice = it.key;
+  for (auto it : VPackObjectIterator(slice, /*useSequentialIteration*/ true)) {
+    auto keySlice = it.key;
     if (ADB_UNLIKELY(!keySlice.isString())) {
       return Result(TRI_ERROR_CLUSTER_AQL_COMMUNICATION,
                     "When deserializating AqlExecuteCall: Key is not a string");
     }
-    auto const key = getStringView(keySlice);
+    auto key = getStringView(keySlice);
 
     if (auto propIt = expectedPropertiesFound.find(key);
         ADB_LIKELY(propIt != expectedPropertiesFound.end())) {

--- a/arangod/Aql/TraversalNode.cpp
+++ b/arangod/Aql/TraversalNode.cpp
@@ -233,21 +233,22 @@ TraversalNode::TraversalNode(ExecutionPlan* plan,
 
   list = base.get("globalEdgeConditions");
   if (list.isArray()) {
-    for (auto const& cond : VPackArrayIterator(list)) {
+    for (auto cond : VPackArrayIterator(list)) {
       _globalEdgeConditions.emplace_back(plan->getAst()->createNode(cond));
     }
   }
 
   list = base.get("globalVertexConditions");
   if (list.isArray()) {
-    for (auto const& cond : VPackArrayIterator(list)) {
+    for (auto cond : VPackArrayIterator(list)) {
       _globalVertexConditions.emplace_back(plan->getAst()->createNode(cond));
     }
   }
 
   list = base.get("vertexConditions");
   if (list.isObject()) {
-    for (auto const& cond : VPackObjectIterator(list)) {
+    for (auto cond :
+         VPackObjectIterator(list, /*useSequentialIteration*/ true)) {
       std::string key = cond.key.copyString();
       _vertexConditions.try_emplace(StringUtils::uint64(key),
                                     plan->getAst()->createNode(cond.value));
@@ -256,7 +257,8 @@ TraversalNode::TraversalNode(ExecutionPlan* plan,
 
   list = base.get("edgeConditions");
   if (list.isObject()) {
-    for (auto const& cond : VPackObjectIterator(list)) {
+    for (auto cond :
+         VPackObjectIterator(list, /*useSequentialIteration*/ true)) {
       std::string key = cond.key.copyString();
       auto ecbuilder =
           std::make_unique<TraversalEdgeConditionBuilder>(this, cond.value);

--- a/arangod/Auth/User.cpp
+++ b/arangod/Auth/User.cpp
@@ -164,15 +164,16 @@ auth::User auth::User::newUser(std::string const& user,
 }
 
 void auth::User::fromDocumentDatabases(auth::User& entry,
-                                       VPackSlice const& databasesSlice,
-                                       VPackSlice const& userSlice) {
-  for (auto const& obj : VPackObjectIterator(databasesSlice)) {
-    std::string const dbName = obj.key.copyString();
+                                       VPackSlice databasesSlice,
+                                       VPackSlice userSlice) {
+  for (auto obj :
+       VPackObjectIterator(databasesSlice, /*useSequentialIteration*/ true)) {
+    std::string dbName = obj.key.copyString();
 
     if (obj.value.isObject()) {
       auth::Level databaseAuth = auth::Level::NONE;
 
-      auto const permissionsSlice = obj.value.get("permissions");
+      auto permissionsSlice = obj.value.get("permissions");
 
       if (permissionsSlice.isObject()) {
         databaseAuth = AuthLevelFromSlice(permissionsSlice);
@@ -187,9 +188,10 @@ void auth::User::fromDocumentDatabases(auth::User& entry,
       VPackSlice collectionsSlice = obj.value.get("collections");
 
       if (collectionsSlice.isObject()) {
-        for (auto collection : VPackObjectIterator(collectionsSlice)) {
-          std::string const cName = collection.key.copyString();
-          auto const collPerSlice = collection.value.get("permissions");
+        for (auto collection : VPackObjectIterator(
+                 collectionsSlice, /*useSequentialIteration*/ true)) {
+          std::string cName = collection.key.copyString();
+          auto collPerSlice = collection.value.get("permissions");
 
           if (collPerSlice.isObject()) {
             try {

--- a/arangod/Auth/User.h
+++ b/arangod/Auth/User.h
@@ -32,8 +32,7 @@
 #include <velocypack/Builder.h>
 #include <velocypack/Slice.h>
 
-namespace arangodb {
-namespace auth {
+namespace arangodb::auth {
 
 /// @brief Represents a 'user' entry.
 /// It contains structures to store the access
@@ -49,9 +48,8 @@ class User {
   static User fromDocument(velocypack::Slice const&);
 
  private:
-  static void fromDocumentDatabases(auth::User&,
-                                    velocypack::Slice const& databases,
-                                    velocypack::Slice const& user);
+  static void fromDocumentDatabases(auth::User&, velocypack::Slice databases,
+                                    velocypack::Slice user);
 
  public:
   std::string const& key() const { return _key; }
@@ -165,5 +163,4 @@ class User {
   std::set<std::string> _roles;
 #endif
 };
-}  // namespace auth
-}  // namespace arangodb
+}  // namespace arangodb::auth

--- a/arangod/Cluster/AgencyCache.cpp
+++ b/arangod/Cluster/AgencyCache.cpp
@@ -199,10 +199,9 @@ void AgencyCache::handleCallbacksNoLock(
   // Collect and normalize keys
   std::vector<std::string> keys;
   keys.reserve(slice.length());
-  for (auto const& i : VPackObjectIterator(slice)) {
-    VPackValueLength l;
-    char const* p = i.key.getString(l);
-    keys.emplace_back(Store::normalize(p, l));
+  for (auto i : VPackObjectIterator(slice, /*useSequentialIteration*/ false)) {
+    auto sv = i.key.stringView();
+    keys.emplace_back(Store::normalize(sv.data(), sv.size()));
   }
 
   std::sort(keys.begin(), keys.end());

--- a/arangod/Cluster/ClusterMethods.cpp
+++ b/arangod/Cluster/ClusterMethods.cpp
@@ -3208,7 +3208,8 @@ arangodb::Result hotBackupList(
       plan.add(resSlice.get("agency-dump")[0]);
     }
 
-    for (auto backup : VPackObjectIterator(resSlice.get("list"))) {
+    for (auto backup : VPackObjectIterator(resSlice.get("list"),
+                                           /*useSequentialIteration*/ false)) {
       ResultT<BackupMeta> meta = BackupMeta::fromSlice(backup.value);
       if (meta.ok()) {
         dbsBackups[backup.key.copyString()].push_back(std::move(meta.get()));
@@ -3308,7 +3309,8 @@ arangodb::Result matchBackupServersSlice(VPackSlice const planServers,
 
   // Skip all direct matching names in pair and remove them from localCopy
   std::unordered_set<std::string>::iterator it;
-  for (auto planned : VPackObjectIterator(planServers)) {
+  for (auto planned :
+       VPackObjectIterator(planServers, /*useSequentialIteration*/ true)) {
     auto const plannedStr = planned.key.copyString();
     if ((it = localCopy.find(plannedStr)) != localCopy.end()) {
       localCopy.erase(it);
@@ -3490,7 +3492,7 @@ arangodb::Result applyDBServerMatchesToPlan(
                         std::map<ServerID, ServerID> const& matches) {
     if (s.isObject()) {
       VPackObjectBuilder o(&newPlan);
-      for (auto it : VPackObjectIterator(s)) {
+      for (auto it : VPackObjectIterator(s, /*useSequentialIteration*/ false)) {
         newPlan.add(it.key);
         replaceDBServer(it.value, matches);
       }

--- a/arangod/Cluster/CreateCollection.cpp
+++ b/arangod/Cluster/CreateCollection.cpp
@@ -135,7 +135,8 @@ bool CreateCollection::first() {
     VPackBuilder docket;
     {
       VPackObjectBuilder d(&docket);
-      for (auto const& i : VPackObjectIterator(props)) {
+      for (auto i :
+           VPackObjectIterator(props, /*useSequentialIteration*/ true)) {
         std::string_view key = i.key.stringView();
         if (key == StaticStrings::DataSourceId ||
             key == StaticStrings::DataSourceName ||

--- a/arangod/Cluster/DBServerAgencySync.cpp
+++ b/arangod/Cluster/DBServerAgencySync.cpp
@@ -354,11 +354,12 @@ DBServerAgencySyncResult DBServerAgencySync::execute() {
 
           std::vector<AgencyOperation> operations;
           std::vector<AgencyPrecondition> preconditions;
-          for (auto const& ao : VPackObjectIterator(agency)) {
-            auto const key = ao.key.copyString();
-            auto const op = ao.value.get("op").copyString();
+          for (auto ao :
+               VPackObjectIterator(agency, /*useSequentialIteration*/ false)) {
+            auto key = ao.key.copyString();
+            auto op = ao.value.get("op").copyString();
 
-            auto const precondition = ao.value.get("precondition");
+            auto precondition = ao.value.get("precondition");
             if (!precondition.isNone()) {
               // have a precondition
               preconditions.push_back(AgencyPrecondition(
@@ -367,7 +368,7 @@ DBServerAgencySyncResult DBServerAgencySync::execute() {
             }
 
             if (op == "set") {
-              auto const value = ao.value.get("payload");
+              auto value = ao.value.get("payload");
               operations.push_back(
                   AgencyOperation(key, AgencyValueOperationType::SET, value));
             } else if (op == "delete") {

--- a/arangod/Cluster/EnsureIndex.cpp
+++ b/arangod/Cluster/EnsureIndex.cpp
@@ -118,7 +118,7 @@ bool EnsureIndex::first() {
       VPackObjectBuilder b(&body);
       body.add(COLLECTION, VPackValue(shard));
       auto const props = properties();
-      body.add(VPackObjectIterator(props));
+      body.add(VPackObjectIterator(props, /*useSequentialIteration*/ true));
     }
 
     if (_priority != maintenance::SLOW_OP_PRIORITY) {

--- a/arangod/Cluster/FailureOracleFeature.cpp
+++ b/arangod/Cluster/FailureOracleFeature.cpp
@@ -140,11 +140,11 @@ auto FailureOracleImpl::getStatus() -> FailureOracleFeature::Status {
 void FailureOracleImpl::reload(VPackSlice result,
                                consensus::index_t raftIndex) {
   FailureOracleFeature::FailureMap isFailed;
-  for (auto const [key, value] : VPackObjectIterator(result)) {
-    auto const serverId = key.copyString();
-    auto const isServerFailed =
+  for (auto const [key, value] :
+       VPackObjectIterator(result, /*useSequentialIteration*/ true)) {
+    auto isServerFailed =
         value.get(kHealthyServerKey).isEqualString(kServerStatusFailed);
-    isFailed[serverId] = isServerFailed;
+    isFailed[key.copyString()] = isServerFailed;
   }
   std::unique_lock writeLock(_mutex);
   if (_lastRaftIndex >= raftIndex) {

--- a/arangod/Cluster/FollowerInfo.cpp
+++ b/arangod/Cluster/FollowerInfo.cpp
@@ -634,7 +634,8 @@ VPackBuilder FollowerInfo::newShardEntry(VPackSlice oldValue) const {
     VPackObjectBuilder b(&newValue);
     // Copy all but SERVERS and FailoverCandidates.
     // They will be injected later.
-    for (auto it : VPackObjectIterator(oldValue)) {
+    for (auto it :
+         VPackObjectIterator(oldValue, /*useSequentialIteration*/ true)) {
       if (!it.key.isEqualString(maintenance::SERVERS) &&
           !it.key.isEqualString(StaticStrings::FailoverCandidates)) {
         newValue.add(it.key);

--- a/arangod/Cluster/HeartbeatThread.cpp
+++ b/arangod/Cluster/HeartbeatThread.cpp
@@ -425,7 +425,8 @@ void HeartbeatThread::getNewsFromAgencyForDBServer() {
         {AgencyCommHelper::path(), "Target", "FailedServers"}));
     if (failedServersSlice.isObject()) {
       containers::FlatHashSet<ServerID> failedServers;
-      for (auto const& server : VPackObjectIterator(failedServersSlice)) {
+      for (auto server : VPackObjectIterator(failedServersSlice,
+                                             /*useSequentialIteration*/ true)) {
         failedServers.emplace(server.key.stringView());
       }
       LOG_TOPIC("52626", DEBUG, Logger::HEARTBEAT)
@@ -699,7 +700,8 @@ void HeartbeatThread::getNewsFromAgencyForCoordinator() {
 
     if (failedServersSlice.isObject()) {
       containers::FlatHashSet<ServerID> failedServers;
-      for (auto const& server : VPackObjectIterator(failedServersSlice)) {
+      for (auto server : VPackObjectIterator(failedServersSlice,
+                                             /*useSequentialIteration*/ true)) {
         failedServers.emplace(server.key.stringView());
       }
       LOG_TOPIC("43332", DEBUG, Logger::HEARTBEAT)
@@ -1317,8 +1319,8 @@ bool HeartbeatThread::handlePlanChangeCoordinator(uint64_t currentPlanVersion) {
       return false;
     }
 
-    for (VPackObjectIterator::ObjectPair options :
-         VPackObjectIterator(databases)) {
+    for (auto options :
+         VPackObjectIterator(databases, /*useSequentialIteration*/ true)) {
       try {
         ids.push_back(std::stoul(options.value.get("id").copyString()));
       } catch (std::invalid_argument& e) {
@@ -1363,8 +1365,8 @@ bool HeartbeatThread::handlePlanChangeCoordinator(uint64_t currentPlanVersion) {
 
     // loop over all database names we got and create a local database
     // instance if not yet present:
-    for (VPackObjectIterator::ObjectPair options :
-         VPackObjectIterator(databases)) {
+    for (auto options :
+         VPackObjectIterator(databases, /*useSequentialIteration*/ true)) {
       if (!options.value.isObject()) {
         continue;
       }
@@ -1496,7 +1498,8 @@ void HeartbeatThread::updateAgentPool(VPackSlice const& agentPool) {
       values.reserve(pool.length());
       values.emplace_back(pool.get(leaderId).copyString());
       // now add all non leaders
-      for (auto pair : VPackObjectIterator(pool)) {
+      for (auto pair :
+           VPackObjectIterator(pool, /*useSequentialIteration*/ false)) {
         if (!pair.key.isEqualString(leaderId)) {
           values.emplace_back(pair.value.copyString());
         }

--- a/arangod/Cluster/RestClusterHandler.cpp
+++ b/arangod/Cluster/RestClusterHandler.cpp
@@ -212,8 +212,8 @@ void RestClusterHandler::handleCommandEndpoints() {
     }
 
     // {"serverId" : {"Status" : "GOOD", ...}}
-    for (VPackObjectIterator::ObjectPair const& pair :
-         VPackObjectIterator(healthMap)) {
+    for (auto pair :
+         VPackObjectIterator(healthMap, /*useSequentialIteration*/ true)) {
       TRI_ASSERT(pair.key.isString() && pair.value.isObject());
       if (pair.key.compareString(leaderId) != 0) {
         VPackSlice status = pair.value.get("Status");

--- a/arangod/Cluster/ServerState.cpp
+++ b/arangod/Cluster/ServerState.cpp
@@ -541,8 +541,9 @@ bool ServerState::integrateIntoCluster(ServerState::RoleEnum role,
     if (valueSlice.isObject()) {
       // map from server UUID to endpoint
       std::unordered_map<std::string, std::string> endpoints;
-      for (auto it : VPackObjectIterator(valueSlice)) {
-        std::string const serverId = it.key.copyString();
+      for (auto it :
+           VPackObjectIterator(valueSlice, /*useSequentialIteration*/ true)) {
+        std::string serverId = it.key.copyString();
 
         if (!isUuid(serverId)) {
           continue;
@@ -676,9 +677,10 @@ bool ServerState::checkEngineEquality(AgencyComm& comm) {
       return true;  // do not do anything harsh here
     }
 
-    for (VPackObjectIterator::ObjectPair pair : VPackObjectIterator(servers)) {
+    for (auto pair :
+         VPackObjectIterator(servers, /*useSequentialIteration*/ true)) {
       if (pair.value.isObject()) {
-        std::string_view const engineName =
+        std::string_view engineName =
             _server.getFeature<EngineSelectorFeature>().engineName();
 
         VPackSlice engineStr = pair.value.get("engine");
@@ -709,7 +711,8 @@ bool ServerState::checkNamingConventionsEquality(AgencyComm& comm) {
       return true;  // do not do anything harsh here
     }
 
-    for (VPackObjectIterator::ObjectPair pair : VPackObjectIterator(servers)) {
+    for (auto pair :
+         VPackObjectIterator(servers, /*useSequentialIteration*/ true)) {
       if (!pair.value.isObject()) {
         continue;
       }
@@ -726,7 +729,8 @@ bool ServerState::checkNamingConventionsEquality(AgencyComm& comm) {
             << "on all coordinators and DB servers in this cluster.";
 
         std::string msg;
-        for (VPackObjectIterator::ObjectPair p : VPackObjectIterator(servers)) {
+        for (auto p :
+             VPackObjectIterator(servers, /*useSequentialIteration*/ true)) {
           if (!p.value.isObject()) {
             continue;
           }

--- a/arangod/Cluster/TraverserEngine.cpp
+++ b/arangod/Cluster/TraverserEngine.cpp
@@ -121,7 +121,8 @@ BaseEngine::BaseEngine(TRI_vocbase_t& vocbase, aql::QueryContext& query,
 
   // Add all Vertex shards to the transaction
   TRI_ASSERT(vertexSlice.isObject());
-  for (auto collection : VPackObjectIterator(vertexSlice)) {
+  for (auto collection :
+       VPackObjectIterator(vertexSlice, /*useSequentialIteration*/ true)) {
     std::vector<std::string> shards;
     TRI_ASSERT(collection.value.isArray());
     for (auto shard : VPackArrayIterator(collection.value)) {

--- a/arangod/Cluster/v8-cluster.cpp
+++ b/arangod/Cluster/v8-cluster.cpp
@@ -323,12 +323,12 @@ static void JS_GetAgency(v8::FunctionCallbackInfo<v8::Value> const& args) {
 
   // return just the value for each key
 
-  for (auto const& a : VPackArrayIterator(result.slice())) {
-    for (auto const& o : VPackObjectIterator(a)) {
-      std::string const key = o.key.copyString();
-      VPackSlice const slice = o.value;
+  for (auto a : VPackArrayIterator(result.slice())) {
+    for (auto o : VPackObjectIterator(a, /*useSequentialIteration*/ true)) {
+      VPackSlice slice = o.value;
 
       if (!slice.isNone()) {
+        std::string key = o.key.copyString();
         l->Set(context, TRI_V8_STD_STRING(isolate, key),
                TRI_VPackToV8(isolate, slice))
             .FromMaybe(false);
@@ -797,7 +797,7 @@ static void JS_GetCollectionInfoClusterInfo(
   VPackSlice shards = info.get("shards");
   TRI_ASSERT(shards.isObject());
   v8::Handle<v8::Object> shardShorts = v8::Object::New(isolate);
-  for (auto const& p : VPackObjectIterator(shards)) {
+  for (auto p : VPackObjectIterator(shards, /*useSequentialIteration*/ true)) {
     TRI_ASSERT(p.value.isArray());
     v8::Handle<v8::Array> shorts = v8::Array::New(isolate);
     uint32_t pos = 0;

--- a/arangod/ClusterEngine/ClusterIndex.cpp
+++ b/arangod/ClusterEngine/ClusterIndex.cpp
@@ -123,7 +123,8 @@ void ClusterIndex::toVelocyPack(
     builder.add(StaticStrings::IndexEstimates, VPackValue(false));
   }
 
-  for (auto pair : VPackObjectIterator(_info.slice())) {
+  for (auto pair :
+       VPackObjectIterator(_info.slice(), /*useSequentialIteration*/ true)) {
     if (!pair.key.isEqualString(StaticStrings::IndexId) &&
         !pair.key.isEqualString(StaticStrings::IndexName) &&
         !pair.key.isEqualString(StaticStrings::IndexType) &&

--- a/arangod/Graph/TraverserOptions.cpp
+++ b/arangod/Graph/TraverserOptions.cpp
@@ -335,7 +335,8 @@ TraverserOptions::TraverserOptions(arangodb::aql::QueryContext& query,
     }
     _depthLookupInfo.reserve(read.length());
     size_t length = collections.length();
-    for (auto const& depth : VPackObjectIterator(read)) {
+    for (auto depth :
+         VPackObjectIterator(read, /*useSequentialIteration*/ true)) {
       uint64_t d = basics::StringUtils::uint64(depth.key.copyString());
       auto [it, emplaced] =
           _depthLookupInfo.try_emplace(d, std::vector<LookupInfo>());
@@ -358,7 +359,8 @@ TraverserOptions::TraverserOptions(arangodb::aql::QueryContext& query,
     }
 
     _vertexExpressions.reserve(read.length());
-    for (auto const& info : VPackObjectIterator(read)) {
+    for (auto info :
+         VPackObjectIterator(read, /*useSequentialIteration*/ true)) {
       uint64_t d = basics::StringUtils::uint64(info.key.copyString());
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
       bool emplaced = false;

--- a/arangod/IResearch/IResearchFilterFactory.cpp
+++ b/arangod/IResearch/IResearchFilterFactory.cpp
@@ -3084,7 +3084,7 @@ Result processPhraseArgObjectType(char const* funcName,
                                   VPackSlice object, size_t firstOffset,
                                   irs::analysis::analyzer* analyzer = nullptr) {
   TRI_ASSERT(object.isObject());
-  VPackObjectIterator itr(object);
+  VPackObjectIterator itr(object, /*useSequentialIteration*/ true);
   if (ADB_LIKELY(itr.valid())) {
     auto key = itr.key();
     auto value = itr.value();

--- a/arangod/IResearch/IResearchLinkHelper.cpp
+++ b/arangod/IResearch/IResearchLinkHelper.cpp
@@ -270,8 +270,9 @@ Result modifyLinks(containers::FlatHashSet<DataSourceId>& modified,
       linkDefinitions;
   std::vector<State> linkModifications;
 
-  for (velocypack::ObjectIterator linksItr(links); linksItr.valid();
-       ++linksItr) {
+  for (velocypack::ObjectIterator linksItr(links,
+                                           /*useSequentialIteration*/ true);
+       linksItr.valid(); ++linksItr) {
     auto collection = linksItr.key();
 
     if (!collection.isString()) {
@@ -803,7 +804,8 @@ namespace iresearch {
   size_t offset = 0;
   CollectionNameResolver resolver(vocbase);
 
-  for (velocypack::ObjectIterator itr(links); itr.valid(); ++itr, ++offset) {
+  for (velocypack::ObjectIterator itr(links, /*useSequentialIteration*/ true);
+       itr.valid(); ++itr, ++offset) {
     auto collectionName = itr.key();
     auto linkDefinition = itr.value();
 

--- a/arangod/IResearch/IResearchLinkMeta.cpp
+++ b/arangod/IResearch/IResearchLinkMeta.cpp
@@ -406,7 +406,9 @@ bool FieldMeta::init(
       subDefaults._fields.clear();
       _fields.clear();  // reset to match either defaults or read values exactly
 
-      for (velocypack::ObjectIterator itr(field); itr.valid(); ++itr) {
+      for (velocypack::ObjectIterator itr(field,
+                                          /*useSequentialIteration*/ true);
+           itr.valid(); ++itr) {
         auto key = itr.key();
         auto value = itr.value();
 
@@ -460,7 +462,9 @@ bool FieldMeta::init(
 
       _nested.clear();  // reset to match either defaults or read values exactly
 
-      for (velocypack::ObjectIterator itr(field); itr.valid(); ++itr) {
+      for (velocypack::ObjectIterator itr(field,
+                                          /*useSequentialIteration*/ true);
+           itr.valid(); ++itr) {
         auto key = itr.key();
         auto value = itr.value();
 

--- a/arangod/IResearch/VelocyPackHelper.cpp
+++ b/arangod/IResearch/VelocyPackHelper.cpp
@@ -155,7 +155,8 @@ bool mergeSlice(velocypack::Builder& builder, velocypack::Slice slice) {
   }
 
   if (builder.isOpenObject() && slice.isObject()) {
-    builder.add(velocypack::ObjectIterator(slice));
+    builder.add(
+        velocypack::ObjectIterator(slice, /*useSequentialIteration*/ true));
 
     return true;
   }
@@ -170,7 +171,8 @@ bool mergeSliceSkipKeys(
     return mergeSlice(builder, slice);  // no keys to skip for non-objects
   }
 
-  for (velocypack::ObjectIterator itr(slice); itr.valid(); ++itr) {
+  for (velocypack::ObjectIterator itr(slice, /*useSequentialIteration*/ true);
+       itr.valid(); ++itr) {
     auto key = itr.key();
     auto value = itr.value();
 

--- a/arangod/Network/Utils.cpp
+++ b/arangod/Network/Utils.cpp
@@ -176,7 +176,8 @@ void errorCodesFromHeaders(network::Headers headers,
       return;
     }
 
-    for (auto code : VPackObjectIterator(codesSlice)) {
+    for (auto code :
+         VPackObjectIterator(codesSlice, /*useSequentialIteration*/ true)) {
       VPackValueLength codeLength;
       char const* codeString = code.key.getString(codeLength);
       auto codeNr = ErrorCode{

--- a/arangod/Pregel/AggregatorHandler.cpp
+++ b/arangod/Pregel/AggregatorHandler.cpp
@@ -81,7 +81,8 @@ void AggregatorHandler::aggregateValues(AggregatorHandler const& workerValues) {
 void AggregatorHandler::aggregateValues(VPackSlice const& workerValues) {
   VPackSlice values = workerValues.get(Utils::aggregatorValuesKey);
   if (values.isObject()) {
-    for (auto const& keyValue : VPackObjectIterator(values)) {
+    for (auto keyValue :
+         VPackObjectIterator(values, /*useSequentialIteration*/ true)) {
       AggregatorID name = keyValue.key.copyString();
       IAggregator* agg = getAggregator(name);
       if (agg) {
@@ -94,7 +95,8 @@ void AggregatorHandler::aggregateValues(VPackSlice const& workerValues) {
 void AggregatorHandler::setAggregatedValues(VPackSlice const& workerValues) {
   VPackSlice values = workerValues.get(Utils::aggregatorValuesKey);
   if (values.isObject()) {
-    for (auto const& keyValue : VPackObjectIterator(values)) {
+    for (auto keyValue :
+         VPackObjectIterator(values, /*useSequentialIteration*/ true)) {
       AggregatorID name = keyValue.key.copyString();
       IAggregator* agg = getAggregator(name);
       if (agg) {

--- a/arangod/Pregel/Algos/DMID/VertexSumAggregator.h
+++ b/arangod/Pregel/Algos/DMID/VertexSumAggregator.h
@@ -56,11 +56,12 @@ struct VertexSumAggregator : public IAggregator {
   };
 
   void parseAggregate(VPackSlice const& slice) override {
-    for (auto const& pair : VPackObjectIterator(slice)) {
+    for (auto pair :
+         VPackObjectIterator(slice, /*useSequentialIteration*/ true)) {
       PregelShard shard = std::stoi(pair.key.copyString());
       std::string key;
       VPackValueLength i = 0;
-      for (VPackSlice const& val : VPackArrayIterator(pair.value)) {
+      for (VPackSlice val : VPackArrayIterator(pair.value)) {
         if (i % 2 == 0) {
           key = val.copyString();
         } else {
@@ -74,11 +75,12 @@ struct VertexSumAggregator : public IAggregator {
   void const* getAggregatedValue() const override { return &_entries; };
 
   void setAggregatedValue(VPackSlice const& slice) override {
-    for (auto const& pair : VPackObjectIterator(slice)) {
+    for (auto pair :
+         VPackObjectIterator(slice, /*useSequentialIteration*/ true)) {
       PregelShard shard = std::stoi(pair.key.copyString());
       std::string key;
       VPackValueLength i = 0;
-      for (VPackSlice const& val : VPackArrayIterator(pair.value)) {
+      for (VPackSlice val : VPackArrayIterator(pair.value)) {
         if (i % 2 == 0) {
           key = val.copyString();
         } else {

--- a/arangod/Pregel/Conductor.cpp
+++ b/arangod/Pregel/Conductor.cpp
@@ -535,7 +535,8 @@ ErrorCode Conductor::_initializeWorkers(std::string const& suffix,
     b.add(Utils::coordinatorIdKey, VPackValue(coordinatorId));
     b.add(Utils::useMemoryMapsKey, VPackValue(_useMemoryMaps));
     if (additional.isObject()) {
-      for (auto pair : VPackObjectIterator(additional)) {
+      for (auto pair :
+           VPackObjectIterator(additional, /*useSequentialIteration*/ true)) {
         b.add(pair.key.copyString(), pair.value);
       }
     }

--- a/arangod/Pregel/Reports.cpp
+++ b/arangod/Pregel/Reports.cpp
@@ -74,7 +74,8 @@ Report Report::fromVelocyPack(VPackSlice slice) {
   std::string msg = slice.get("msg").copyString();
   auto level = levelFromString(slice.get("level").stringView());
   ReportAnnotations annotations;
-  for (auto&& pair : VPackObjectIterator(slice.get("annotations"))) {
+  for (auto pair : VPackObjectIterator(slice.get("annotations"),
+                                       /*useSequentialIteration*/ true)) {
     VPackBuilder builder;
     builder.add(pair.value);
     annotations.emplace(pair.key.copyString(), std::move(builder));

--- a/arangod/Pregel/WorkerConfig.cpp
+++ b/arangod/Pregel/WorkerConfig.cpp
@@ -84,7 +84,8 @@ void WorkerConfig::updateConfig(PregelFeature& feature, VPackSlice params) {
   }
 
   // To access information based on a user defined collection name we need the
-  for (auto it : VPackObjectIterator(collectionPlanIdMap)) {
+  for (auto it : VPackObjectIterator(collectionPlanIdMap,
+                                     /*useSequentialIteration*/ true)) {
     _collectionPlanIdMap.try_emplace(it.key.copyString(),
                                      it.value.copyString());
   }
@@ -93,7 +94,8 @@ void WorkerConfig::updateConfig(PregelFeature& feature, VPackSlice params) {
   // Order matters because the for example the third vertex shard, will only
   // every have
   // edges in the third edge shard. This should speed up the startup
-  for (auto pair : VPackObjectIterator(vertexShardMap)) {
+  for (auto pair :
+       VPackObjectIterator(vertexShardMap, /*useSequentialIteration*/ true)) {
     CollectionID cname = pair.key.copyString();
 
     std::vector<ShardID> shards;
@@ -109,7 +111,8 @@ void WorkerConfig::updateConfig(PregelFeature& feature, VPackSlice params) {
   }
 
   // Ordered list of edge shards for each collection
-  for (auto pair : VPackObjectIterator(edgeShardMap)) {
+  for (auto pair :
+       VPackObjectIterator(edgeShardMap, /*useSequentialIteration*/ true)) {
     CollectionID cname = pair.key.copyString();
 
     std::vector<ShardID> shards;
@@ -123,7 +126,8 @@ void WorkerConfig::updateConfig(PregelFeature& feature, VPackSlice params) {
   }
 
   if (edgeCollectionRestrictions.isObject()) {
-    for (auto pair : VPackObjectIterator(edgeCollectionRestrictions)) {
+    for (auto pair : VPackObjectIterator(edgeCollectionRestrictions,
+                                         /*useSequentialIteration*/ true)) {
       CollectionID cname = pair.key.copyString();
 
       std::vector<ShardID> shards;

--- a/arangod/Replication/GlobalInitialSyncer.cpp
+++ b/arangod/Replication/GlobalInitialSyncer.cpp
@@ -181,7 +181,8 @@ Result GlobalInitialSyncer::runInternal(bool incremental, char const* context) {
 
   try {
     // actually sync the database
-    for (auto const& dbEntry : VPackObjectIterator(databases)) {
+    for (auto dbEntry :
+         VPackObjectIterator(databases, /*useSequentialIteration*/ true)) {
       if (_state.applier._server.isStopping()) {
         return Result(TRI_ERROR_SHUTTING_DOWN);
       } else if (isAborted()) {
@@ -258,7 +259,8 @@ Result GlobalInitialSyncer::updateServerInventory(
         existingDBs.insert(vocbase.name());
       });
 
-  for (auto const& database : VPackObjectIterator(leaderDatabases)) {
+  for (auto database :
+       VPackObjectIterator(leaderDatabases, /*useSequentialIteration*/ true)) {
     VPackSlice it = database.value;
 
     if (!it.isObject()) {
@@ -266,9 +268,9 @@ Result GlobalInitialSyncer::updateServerInventory(
                     "database declaration is invalid in response");
     }
 
-    VPackSlice const nameSlice = it.get("name");
-    VPackSlice const idSlice = it.get("id");
-    VPackSlice const collections = it.get("collections");
+    VPackSlice nameSlice = it.get("name");
+    VPackSlice idSlice = it.get("id");
+    VPackSlice collections = it.get("collections");
     if (!nameSlice.isString() || !idSlice.isString() ||
         !collections.isArray()) {
       return Result(TRI_ERROR_REPLICATION_INVALID_RESPONSE,

--- a/arangod/Replication/GlobalTailingSyncer.cpp
+++ b/arangod/Replication/GlobalTailingSyncer.cpp
@@ -117,7 +117,8 @@ bool GlobalTailingSyncer::skipMarker(VPackSlice slice) {
         return false;
       }
 
-      for (auto it : VPackObjectIterator(invSlice)) {
+      for (auto it :
+           VPackObjectIterator(invSlice, /*useSequentialIteration*/ true)) {
         VPackSlice dbObj = it.value;
         if (!dbObj.isObject()) {
           continue;

--- a/arangod/Replication2/AgencyCollectionSpecification.cpp
+++ b/arangod/Replication2/AgencyCollectionSpecification.cpp
@@ -40,7 +40,8 @@ CollectionGroup::CollectionGroup(VPackSlice slice)
     auto cs = slice.get("collections");
     TRI_ASSERT(cs.isObject());
     collections.reserve(cs.length());
-    for (auto const& [key, value] : VPackObjectIterator(cs)) {
+    for (auto const& [key, value] :
+         VPackObjectIterator(cs, /*useSequentialIteration*/ true)) {
       auto cid = key.extract<std::string>();
       collections.emplace(std::move(cid), Collection(value));
     }

--- a/arangod/Replication2/Methods.cpp
+++ b/arangod/Replication2/Methods.cpp
@@ -214,11 +214,10 @@ struct VPackLogIterator final : PersistedLogIterator {
   explicit VPackLogIterator(
       std::shared_ptr<velocypack::Buffer<uint8_t>> buffer_ptr)
       : buffer(std::move(buffer_ptr)),
-        iter(VPackSlice(buffer->data()).get("result")),
-        end(iter.end()) {}
+        iter(VPackSlice(buffer->data()).get("result")) {}
 
   auto next() -> std::optional<PersistingLogEntry> override {
-    while (iter != end) {
+    while (iter != std::default_sentinel_t{}) {
       return PersistingLogEntry::fromVelocyPack(*iter++);
     }
     return std::nullopt;
@@ -227,7 +226,6 @@ struct VPackLogIterator final : PersistedLogIterator {
  private:
   std::shared_ptr<velocypack::Buffer<uint8_t>> buffer;
   VPackArrayIterator iter;
-  VPackArrayIterator end;
 };
 
 }  // namespace
@@ -632,9 +630,9 @@ struct ReplicatedLogMethodsCoordinator final
           std::vector<LogIndex> indexes;
           indexes.reserve(payloadSize);
           auto indexIter = velocypack::ArrayIterator(result.get("indexes"));
-          std::transform(
-              indexIter.begin(), indexIter.end(), std::back_inserter(indexes),
-              [](auto const& it) { return it.template extract<LogIndex>(); });
+          for (auto it : indexIter) {
+            indexes.push_back(it.template extract<LogIndex>());
+          }
           return std::make_pair(
               std::move(indexes),
               replicated_log::WaitForResult(commitIndex, std::move(quorum)));

--- a/arangod/Replication2/ReplicatedLog/LogCommon.cpp
+++ b/arangod/Replication2/ReplicatedLog/LogCommon.cpp
@@ -256,7 +256,8 @@ auto replicated_log::CommitFailReason::QuorumSizeNotReached::fromVelocyPack(
       << "Expected object, found: " << s.toJson();
   auto result = QuorumSizeNotReached();
   for (auto const& [participantIdSlice, participantInfoSlice] :
-       VPackObjectIterator(s.get(WhoFieldName))) {
+       VPackObjectIterator(s.get(WhoFieldName),
+                           /*useSequentialIteration*/ true)) {
     auto const participantId = participantIdSlice.stringView();
     result.who.try_emplace(
         participantId, ParticipantInfo::fromVelocyPack(participantInfoSlice));
@@ -381,8 +382,8 @@ auto replicated_log::CommitFailReason::NonEligibleServerRequiredForQuorum::
       << "Expected string `" << NonEligibleServerRequiredForQuorumEnum
       << "`, found: " << s.stringView();
   CandidateMap candidates;
-  for (auto const& [key, value] :
-       velocypack::ObjectIterator(s.get(CandidatesFieldName))) {
+  for (auto const& [key, value] : velocypack::ObjectIterator(
+           s.get(CandidatesFieldName), /*useSequentialIteration*/ true)) {
     if (value.isEqualString(NonEligibleNotAllowedInQuorum)) {
       candidates[key.copyString()] = kNotAllowedInQuorum;
     } else if (value.isEqualString(NonEligibleWrongTerm)) {

--- a/arangod/Replication2/ReplicatedLog/LogStatus.cpp
+++ b/arangod/Replication2/ReplicatedLog/LogStatus.cpp
@@ -147,7 +147,8 @@ auto GlobalStatus::fromVelocyPack(VPackSlice slice) -> GlobalStatus {
   status.specification =
       Specification::fromVelocyPack(slice.get("specification"));
   for (auto [key, value] :
-       VPackObjectIterator(slice.get(StaticStrings::Participants))) {
+       VPackObjectIterator(slice.get(StaticStrings::Participants),
+                           /*useSequentialIteration*/ true)) {
     auto id = ParticipantId{key.copyString()};
     auto stat = ParticipantStatus::fromVelocyPack(value);
     status.participants.emplace(std::move(id), stat);

--- a/arangod/Replication2/ReplicatedLog/NetworkMessages.cpp
+++ b/arangod/Replication2/ReplicatedLog/NetworkMessages.cpp
@@ -290,11 +290,10 @@ auto replicated_log::AppendEntriesRequest::fromVelocyPack(
   auto entries = std::invoke([&] {
     auto entriesVp = velocypack::ArrayIterator(slice.get("entries"));
     auto transientEntries = EntryContainer::transient_type{};
-    std::transform(
-        entriesVp.begin(), entriesVp.end(),
-        std::back_inserter(transientEntries), [](auto const& it) {
-          return InMemoryLogEntry(PersistingLogEntry::fromVelocyPack(it));
-        });
+    for (auto it : entriesVp) {
+      transientEntries.push_back(
+          InMemoryLogEntry(PersistingLogEntry::fromVelocyPack(it)));
+    }
     return std::move(transientEntries).persistent();
   });
 

--- a/arangod/Replication2/StateMachines/Prototype/PrototypeStateMachineFeature.cpp
+++ b/arangod/Replication2/StateMachines/Prototype/PrototypeStateMachineFeature.cpp
@@ -71,7 +71,8 @@ class PrototypeLeaderInterface : public IPrototypeLeaderInterface {
                 auto slice = resp.slice();
                 if (auto result = slice.get("result"); result.isObject()) {
                   std::unordered_map<std::string, std::string> map;
-                  for (auto it : VPackObjectIterator{result}) {
+                  for (auto it : VPackObjectIterator{
+                           result, /*useSequentialIteration*/ true}) {
                     map.emplace(it.key.copyString(), it.value.copyString());
                   }
                   return map;

--- a/arangod/Replication2/StateMachines/Prototype/PrototypeStateMethods.cpp
+++ b/arangod/Replication2/StateMachines/Prototype/PrototypeStateMethods.cpp
@@ -325,7 +325,8 @@ struct PrototypeStateMethodsCoordinator final
                 auto slice = resp.slice();
                 if (auto result = slice.get("result"); result.isObject()) {
                   std::unordered_map<std::string, std::string> map;
-                  for (auto it : VPackObjectIterator{result}) {
+                  for (auto it : VPackObjectIterator{
+                           result, /*useSequentialIteration*/ true}) {
                     map.emplace(it.key.copyString(), it.value.copyString());
                   }
                   return {map};
@@ -359,7 +360,8 @@ struct PrototypeStateMethodsCoordinator final
                 auto slice = resp.slice();
                 if (auto result = slice.get("result"); result.isObject()) {
                   std::unordered_map<std::string, std::string> map;
-                  for (auto it : VPackObjectIterator{result}) {
+                  for (auto it : VPackObjectIterator{
+                           result, /*useSequentialIteration*/ true}) {
                     map.emplace(it.key.copyString(), it.value.copyString());
                   }
                   return map;

--- a/arangod/RestHandler/RestAdminLogHandler.cpp
+++ b/arangod/RestHandler/RestAdminLogHandler.cpp
@@ -545,7 +545,8 @@ RestStatus RestAdminLogHandler::handleLogLevel() {
         Logger::setLogLevel(l);
       }
       // now process all log topics except "all"
-      for (auto it : VPackObjectIterator(slice)) {
+      for (auto it :
+           VPackObjectIterator(slice, /*useSequentialIteration*/ true)) {
         if (it.value.isString() && !it.key.isEqualString(LogTopic::ALL)) {
           std::string const l =
               it.key.copyString() + "=" + it.value.copyString();
@@ -597,7 +598,8 @@ void RestAdminLogHandler::handleLogStructuredParams() {
 
     if (slice.isObject()) {
       std::unordered_map<std::string, bool> paramsAndValues;
-      for (auto it : VPackObjectIterator(slice)) {
+      for (auto it :
+           VPackObjectIterator(slice, /*useSequentialIteration*/ true)) {
         if (it.value.isBoolean()) {
           paramsAndValues.try_emplace(it.key.copyString(),
                                       it.value.getBoolean());

--- a/arangod/RestHandler/RestCursorHandler.cpp
+++ b/arangod/RestHandler/RestCursorHandler.cpp
@@ -517,7 +517,7 @@ void RestCursorHandler::buildOptions(VPackSlice const& slice) {
     if (!isStream) {
       isStream = VelocyPackHelper::getBooleanValue(opts, "stream", false);
     }
-    for (auto it : VPackObjectIterator(opts)) {
+    for (auto it : VPackObjectIterator(opts, /*useSequentialIteration*/ true)) {
       if (!it.key.isString() || it.value.isNone()) {
         continue;
       }

--- a/arangod/RestHandler/RestPrototypeStateHandler.cpp
+++ b/arangod/RestHandler/RestPrototypeStateHandler.cpp
@@ -163,7 +163,8 @@ RestStatus RestPrototypeStateHandler::handlePutCompareExchange(
   }
 
   std::unordered_map<std::string, std::pair<std::string, std::string>> entries;
-  for (auto const& [key, value] : VPackObjectIterator{payload}) {
+  for (auto const& [key, value] :
+       VPackObjectIterator{payload, /*useSequentialIteration*/ true}) {
     if (key.isString() && value.isObject()) {
       if (auto oldValue{value.get("oldValue")}, newValue{value.get("newValue")};
           oldValue.isString() && newValue.isString()) {
@@ -224,7 +225,8 @@ RestStatus RestPrototypeStateHandler::handlePostInsert(
   }
 
   std::unordered_map<std::string, std::string> entries;
-  for (auto const& [key, value] : VPackObjectIterator{payload}) {
+  for (auto const& [key, value] :
+       VPackObjectIterator{payload, /*useSequentialIteration*/ true}) {
     if (key.isString() && value.isString()) {
       entries.emplace(key.copyString(), value.copyString());
     } else {

--- a/arangod/RestHandler/RestReplicationHandler.cpp
+++ b/arangod/RestHandler/RestReplicationHandler.cpp
@@ -1901,18 +1901,21 @@ Result RestReplicationHandler::processRestoreIndexes(
         continue;
       }
 
-      if (type.isEqualString(StaticStrings::IndexNamePrimary) ||
-          type.isEqualString(StaticStrings::IndexNameEdge)) {
+      auto ts = type.stringView();
+
+      if (ts == StaticStrings::IndexNamePrimary ||
+          ts == StaticStrings::IndexNameEdge) {
         continue;
       }
 
-      if (type.isEqualString("geo1") || type.isEqualString("geo2")) {
+      if (ts == "geo1" || ts == "geo2") {
         // transform type "geo1" or "geo2" into "geo".
         rebuilder.clear();
         rebuilder.openObject();
         rebuilder.add(StaticStrings::IndexType, VPackValue("geo"));
-        for (auto const& it : VPackObjectIterator(idxDef)) {
-          if (!it.key.isEqualString(StaticStrings::IndexType)) {
+        for (auto it :
+             VPackObjectIterator(idxDef, /*useSequentialIteration*/ true)) {
+          if (it.key.stringView() != StaticStrings::IndexType) {
             rebuilder.add(it.key);
             rebuilder.add(it.value);
           }
@@ -2025,19 +2028,22 @@ Result RestReplicationHandler::processRestoreIndexesCoordinator(
       continue;
     }
 
-    if (type.isEqualString(StaticStrings::IndexNamePrimary) ||
-        type.isEqualString(StaticStrings::IndexNameEdge)) {
+    auto ts = type.stringView();
+
+    if (ts == StaticStrings::IndexNamePrimary ||
+        ts == StaticStrings::IndexNameEdge) {
       // must ignore these types of indexes during restore
       continue;
     }
 
-    if (type.isEqualString("geo1") || type.isEqualString("geo2")) {
+    if (ts == "geo1" || ts == "geo2") {
       // transform type "geo1" or "geo2" into "geo".
       rebuilder.clear();
       rebuilder.openObject();
       rebuilder.add(StaticStrings::IndexType, VPackValue("geo"));
-      for (auto const& it : VPackObjectIterator(idxDef)) {
-        if (!it.key.isEqualString(StaticStrings::IndexType)) {
+      for (auto it :
+           VPackObjectIterator(idxDef, /*useSequentialIteration*/ true)) {
+        if (it.key.stringView() != StaticStrings::IndexType) {
           rebuilder.add(it.key);
           rebuilder.add(it.value);
         }
@@ -2046,7 +2052,7 @@ Result RestReplicationHandler::processRestoreIndexesCoordinator(
       idxDef = rebuilder.slice();
     }
 
-    if (type.isEqualString("fulltext")) {
+    if (ts == "fulltext") {
       VPackSlice minLength = idxDef.get("minLength");
       if (minLength.isNumber()) {
         int length = minLength.getNumericValue<int>();
@@ -2054,8 +2060,9 @@ Result RestReplicationHandler::processRestoreIndexesCoordinator(
           rebuilder.clear();
           rebuilder.openObject();
           rebuilder.add("minLength", VPackValue(1));
-          for (auto const& it : VPackObjectIterator(idxDef)) {
-            if (!it.key.isEqualString("minLength")) {
+          for (auto it :
+               VPackObjectIterator(idxDef, /*useSequentialIteration*/ true)) {
+            if (it.key.stringView() != "minLength") {
               rebuilder.add(it.key);
               rebuilder.add(it.value);
             }

--- a/arangod/RestHandler/RestStatusHandler.cpp
+++ b/arangod/RestHandler/RestStatusHandler.cpp
@@ -250,16 +250,19 @@ RestStatus RestStatusHandler::executeOverview() {
             std::vector<std::string>{AgencyCommHelper::path(), "Plan"});
 
         if (planSlice.isObject()) {
-          if (planSlice.hasKey("Coordinators")) {
-            auto coordinators = planSlice.get("Coordinators");
+          if (auto coordinators = planSlice.get("Coordinators");
+              !coordinators.isNone()) {
             buffer.appendHex(static_cast<uint32_t>(
-                VPackObjectIterator(coordinators).size()));
+                VPackObjectIterator(coordinators,
+                                    /*useSequentialIteration*/ true)
+                    .size()));
             buffer.appendText("-");
           }
-          if (planSlice.hasKey("DBServers")) {
-            auto dbservers = planSlice.get("DBServers");
-            buffer.appendHex(
-                static_cast<uint32_t>(VPackObjectIterator(dbservers).size()));
+          if (auto dbservers = planSlice.get("DBServers");
+              !dbservers.isNone()) {
+            buffer.appendHex(static_cast<uint32_t>(
+                VPackObjectIterator(dbservers, /*useSequentialIteration*/ true)
+                    .size()));
           }
         } else {
           buffer.appendHex(static_cast<uint32_t>(0xFFFF));

--- a/arangod/RocksDBEngine/RocksDBBuilderIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBBuilderIndex.cpp
@@ -218,7 +218,8 @@ void RocksDBBuilderIndex::toVelocyPack(
   _wrapped->toVelocyPack(inner, flags);
   TRI_ASSERT(inner.slice().isObject());
   builder.openObject();  // FIXME refactor RocksDBIndex::toVelocyPack !!
-  builder.add(velocypack::ObjectIterator(inner.slice()));
+  builder.add(velocypack::ObjectIterator(inner.slice(),
+                                         /*useSequentialIteration*/ true));
   if (Index::hasFlag(flags, Index::Serialize::Internals)) {
     builder.add("_inprogress", VPackValue(true));
   }

--- a/arangod/RocksDBEngine/RocksDBCollection.cpp
+++ b/arangod/RocksDBEngine/RocksDBCollection.cpp
@@ -497,7 +497,8 @@ std::shared_ptr<Index> RocksDBCollection::createIndex(velocypack::Slice info,
 
       VPackBuilder builder;
       builder.openObject();
-      for (auto pair : VPackObjectIterator(RocksDBValue::data(ps))) {
+      for (auto pair : VPackObjectIterator(RocksDBValue::data(ps),
+                                           /*useSequentialIteration*/ true)) {
         if (pair.key.isEqualString("indexes")) {  // append new index
           VPackArrayBuilder arrGuard(&builder, "indexes");
           builder.add(VPackArrayIterator(pair.value));

--- a/arangod/RocksDBEngine/RocksDBEngine.cpp
+++ b/arangod/RocksDBEngine/RocksDBEngine.cpp
@@ -3053,7 +3053,7 @@ void RocksDBEngine::getStatistics(std::string& result) const {
   getStatistics(stats);
   VPackSlice sslice = stats.slice();
   TRI_ASSERT(sslice.isObject());
-  for (auto a : VPackObjectIterator(sslice)) {
+  for (auto a : VPackObjectIterator(sslice, /*useSequentialIteration*/ true)) {
     if (a.value.isNumber()) {
       std::string name = a.key.copyString();
       std::replace(name.begin(), name.end(), '.', '_');

--- a/arangod/RocksDBEngine/RocksDBFulltextIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBFulltextIndex.cpp
@@ -312,7 +312,8 @@ static void ExtractWords(std::set<std::string>& words, VPackSlice const value,
       ExtractWords(words, v, minWordLength, level + 1);
     }
   } else if (value.isObject() && level == 0) {
-    for (VPackObjectIterator::ObjectPair v : VPackObjectIterator(value)) {
+    for (VPackObjectIterator::ObjectPair v :
+         VPackObjectIterator(value, /*useSequentialIteration*/ true)) {
       ExtractWords(words, v.value, minWordLength, level + 1);
     }
   }

--- a/arangod/RocksDBEngine/RocksDBIndexFactory.cpp
+++ b/arangod/RocksDBEngine/RocksDBIndexFactory.cpp
@@ -451,7 +451,8 @@ void RocksDBIndexFactory::prepareIndexes(
 
           from.openObject();
 
-          for (auto f : VPackObjectIterator(v)) {
+          for (auto f :
+               VPackObjectIterator(v, /*useSequentialIteration*/ true)) {
             if (f.key.stringView() == StaticStrings::IndexFields) {
               from.add(VPackValue(StaticStrings::IndexFields));
               from.openArray();
@@ -468,7 +469,8 @@ void RocksDBIndexFactory::prepareIndexes(
           VPackBuilder to;
 
           to.openObject();
-          for (auto f : VPackObjectIterator(v)) {
+          for (auto f :
+               VPackObjectIterator(v, /*useSequentialIteration*/ true)) {
             if (f.key.stringView() == StaticStrings::IndexFields) {
               to.add(VPackValue(StaticStrings::IndexFields));
               to.openArray();
@@ -504,7 +506,8 @@ void RocksDBIndexFactory::prepareIndexes(
 
         b.openObject();
 
-        for (auto const& f : VPackObjectIterator(v)) {
+        for (auto const& f :
+             VPackObjectIterator(v, /*useSequentialIteration*/ true)) {
           if (f.key.stringView() == StaticStrings::IndexId) {
             last = IndexId{last.id() + 1};
             b.add(StaticStrings::IndexId,

--- a/arangod/RocksDBEngine/RocksDBReplicationContext.cpp
+++ b/arangod/RocksDBEngine/RocksDBReplicationContext.cpp
@@ -416,7 +416,8 @@ Result RocksDBReplicationContext::getInventory(TRI_vocbase_t& vocbase,
   // order blockers for all collections in the inventory
   TRI_ASSERT(inventory.slice().isObject());
   if (global) {
-    for (auto it : VPackObjectIterator(inventory.slice())) {
+    for (auto it : VPackObjectIterator(inventory.slice(),
+                                       /*useSequentialIteration*/ true)) {
       std::string dbName = it.key.copyString();
       VPackSlice collections = it.value.get("collections");
       handleCollections(dbName, collections);
@@ -425,7 +426,8 @@ Result RocksDBReplicationContext::getInventory(TRI_vocbase_t& vocbase,
   } else {
     handleCollections(vocbase.name(), inventory.slice().get("collections"));
     // add inventory data to result
-    for (auto it : VPackObjectIterator(inventory.slice())) {
+    for (auto it : VPackObjectIterator(inventory.slice(),
+                                       /*useSequentialIteration*/ true)) {
       result.add(it.key.copyString(), it.value);
     }
   }

--- a/arangod/RocksDBEngine/RocksDBRestReplicationHandler.cpp
+++ b/arangod/RocksDBEngine/RocksDBRestReplicationHandler.cpp
@@ -136,7 +136,8 @@ void RocksDBRestReplicationHandler::handleCommandBatch() {
       // and now merge it into our response, while rewriting the "lastLogTick"
       // and "lastUncommittedLogTick"
       b.add("state", VPackValue(VPackValueType::Object));
-      for (auto it : VPackObjectIterator(tmp.slice())) {
+      for (auto it :
+           VPackObjectIterator(tmp.slice(), /*useSequentialIteration*/ true)) {
         if (it.key.stringView() == "lastLogTick" ||
             it.key.stringView() == "lastUncommittedLogTick") {
           // put into the tick from our own snapshot

--- a/arangod/RocksDBEngine/RocksDBVPackIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBVPackIndex.cpp
@@ -1931,8 +1931,8 @@ bool attributesEqual(VPackSlice first, VPackSlice second,
         if (!attributesEqual(*it1, *it2, next, end)) {
           return false;
         }
-        it1++;
-        it2++;
+        ++it1;
+        ++it2;
       }
       return true;
     }

--- a/arangod/Sharding/ShardingInfo.cpp
+++ b/arangod/Sharding/ShardingInfo.cpp
@@ -149,7 +149,8 @@ ShardingInfo::ShardingInfo(arangodb::velocypack::Slice info,
 
   auto shardsSlice = info.get("shards");
   if (shardsSlice.isObject()) {
-    for (auto const& shardSlice : VPackObjectIterator(shardsSlice)) {
+    for (auto shardSlice :
+         VPackObjectIterator(shardsSlice, /*useSequentialIteration*/ true)) {
       if (shardSlice.key.isString() && shardSlice.value.isArray()) {
         ShardID shard = shardSlice.key.copyString();
 
@@ -157,7 +158,7 @@ ShardingInfo::ShardingInfo(arangodb::velocypack::Slice info,
         for (auto const& serverSlice : VPackArrayIterator(shardSlice.value)) {
           servers.push_back(serverSlice.copyString());
         }
-        _shardIds->try_emplace(shard, servers);
+        _shardIds->try_emplace(std::move(shard), std::move(servers));
       }
     }
   }

--- a/arangod/V8Server/v8-pregel.cpp
+++ b/arangod/V8Server/v8-pregel.cpp
@@ -109,7 +109,7 @@ static void JS_PregelStart(v8::FunctionCallbackInfo<v8::Value> const& args) {
   if (paramBuilder.slice().isObject()) {
     VPackSlice s = paramBuilder.slice().get("edgeCollectionRestrictions");
     if (s.isObject()) {
-      for (auto const& it : VPackObjectIterator(s)) {
+      for (auto it : VPackObjectIterator(s, /*useSequentialIteration*/ true)) {
         if (!it.value.isArray()) {
           continue;
         }

--- a/arangod/V8Server/v8-prototype-states.cpp
+++ b/arangod/V8Server/v8-prototype-states.cpp
@@ -186,7 +186,8 @@ static void JS_WriteInternal(v8::FunctionCallbackInfo<v8::Value> const& args) {
   {
     VPackBuilder builder;
     TRI_V8ToVPack(isolate, builder, args[0], false, false);
-    for (auto const& [k, v] : VPackObjectIterator(builder.slice())) {
+    for (auto const& [k, v] : VPackObjectIterator(
+             builder.slice(), /*useSequentialIteration*/ true)) {
       kvs[k.copyString()] = v.copyString();
     }
   }

--- a/arangod/VocBase/LogicalCollection.cpp
+++ b/arangod/VocBase/LogicalCollection.cpp
@@ -691,7 +691,8 @@ void LogicalCollection::toVelocyPackForClusterInventory(VPackBuilder& result,
   {
     VPackObjectBuilder guard(&result);
 
-    for (auto const& p : VPackObjectIterator(params.slice())) {
+    for (auto p :
+         VPackObjectIterator(params.slice(), /*useSequentialIteration*/ true)) {
       result.add(p.key);
       result.add(p.value);
     }
@@ -815,7 +816,7 @@ void LogicalCollection::toVelocyPackIgnore(
     Serialization context) const {
   TRI_ASSERT(result.isOpenObject());
   VPackBuilder b = toVelocyPackIgnore(ignoreKeys, context);
-  result.add(VPackObjectIterator(b.slice()));
+  result.add(VPackObjectIterator(b.slice(), /*useSequentialIteration*/ true));
 }
 
 VPackBuilder LogicalCollection::toVelocyPackIgnore(

--- a/arangod/VocBase/Methods/Collections.cpp
+++ b/arangod/VocBase/Methods/Collections.cpp
@@ -932,9 +932,10 @@ Result Collections::properties(Context& ctxt, VPackBuilder& builder) {
   VPackBuilder props = coll->toVelocyPackIgnore(
       ignoreKeys, LogicalDataSource::Serialization::Properties);
   TRI_ASSERT(builder.isOpenObject());
-  builder.add(VPackObjectIterator(props.slice()));
+  builder.add(
+      VPackObjectIterator(props.slice(), /*useSequentialIteration*/ true));
 
-  return TRI_ERROR_NO_ERROR;
+  return {};
 }
 
 Result Collections::updateProperties(LogicalCollection& collection,

--- a/arangod/VocBase/Methods/Version.cpp
+++ b/arangod/VocBase/Methods/Version.cpp
@@ -139,7 +139,8 @@ VersionResult Version::check(TRI_vocbase_t* vocbase) {
       return VersionResult{VersionResult::CANNOT_PARSE_VERSION_FILE, 0, 0,
                            tasks};
     }
-    for (VPackObjectIterator::ObjectPair pair : VPackObjectIterator(run)) {
+    for (VPackObjectIterator::ObjectPair pair :
+         VPackObjectIterator(run, /*useSequentialIteration*/ true)) {
       tasks.try_emplace(pair.key.copyString(), pair.value.getBool());
     }
   } catch (velocypack::Exception const& e) {

--- a/arangod/VocBase/vocbase.cpp
+++ b/arangod/VocBase/vocbase.cpp
@@ -2157,7 +2157,7 @@ bool TRI_vocbase_t::visitDataSources(dataSourceVisitor const& visitor) {
 /// the result is the object excluding _id, _key and _rev
 void TRI_SanitizeObject(VPackSlice slice, VPackBuilder& builder) {
   TRI_ASSERT(slice.isObject());
-  VPackObjectIterator it(slice);
+  VPackObjectIterator it(slice, /*useSequentialIteration*/ true);
   while (it.valid()) {
     std::string_view key(it.key().stringView());
     // _id, _key, _rev. minimum size here is 3

--- a/client-tools/Dump/DumpFeature.cpp
+++ b/client-tools/Dump/DumpFeature.cpp
@@ -551,7 +551,8 @@ Result DumpFeature::DumpCollectionJob::run(
         VPackSlice shards = parameters.get("shards");
 
         // Iterate over the Map of shardId to server list
-        for (auto const it : VPackObjectIterator(shards)) {
+        for (auto it :
+             VPackObjectIterator(shards, /*useSequentialIteration*/ true)) {
           // extract shard name
           TRI_ASSERT(it.key.isString());
           std::string shardName = it.key.copyString();

--- a/client-tools/Export/ExportFeature.cpp
+++ b/client-tools/Export/ExportFeature.cpp
@@ -629,10 +629,12 @@ void ExportFeature::writeBatch(ManagedDirectory::File& fd,
     for (auto const& doc : it) {
       line.clear();
       line.append("<doc key=\"");
-      line.append(encode_char_entities(doc.get("_key").copyString()));
+      line.append(
+          encode_char_entities(doc.get(StaticStrings::KeyString).copyString()));
       line.append("\">\n");
       writeToFile(fd, line);
-      for (auto const& att : VPackObjectIterator(doc)) {
+      for (auto att :
+           VPackObjectIterator(doc, /*useSequentialIteration*/ true)) {
         xgmmlWriteOneAtt(fd, att.value, att.key.copyString(), 2);
       }
       line.clear();
@@ -814,7 +816,8 @@ void ExportFeature::writeGraphBatch(ManagedDirectory::File& fd,
         xmlTag = ">\n";
         writeToFile(fd, xmlTag);
 
-        for (auto it : VPackObjectIterator(doc)) {
+        for (auto it :
+             VPackObjectIterator(doc, /*useSequentialIteration*/ true)) {
           xgmmlWriteOneAtt(fd, it.value, it.key.copyString());
         }
 
@@ -839,7 +842,8 @@ void ExportFeature::writeGraphBatch(ManagedDirectory::File& fd,
         xmlTag = ">\n";
         writeToFile(fd, xmlTag);
 
-        for (auto it : VPackObjectIterator(doc)) {
+        for (auto it :
+             VPackObjectIterator(doc, /*useSequentialIteration*/ true)) {
           xgmmlWriteOneAtt(fd, it.value, it.key.copyString());
         }
 
@@ -919,7 +923,8 @@ void ExportFeature::xgmmlWriteOneAtt(ManagedDirectory::File& fd,
         "  <att name=\"" + encode_char_entities(name) + "\" type=\"list\">\n";
     writeToFile(fd, xmlTag);
 
-    for (auto it : VPackObjectIterator(slice)) {
+    for (auto it :
+         VPackObjectIterator(slice, /*useSequentialIteration*/ true)) {
       xgmmlWriteOneAtt(fd, it.value, it.key.copyString(), deep + 1);
     }
 

--- a/client-tools/Utils/ProgressTracker.h
+++ b/client-tools/Utils/ProgressTracker.h
@@ -113,7 +113,8 @@ ProgressTracker<T>::ProgressTracker(ManagedDirectory& directory,
   }
 
   std::unique_lock guardState(_collectionStatesMutex);
-  for (auto&& [key, value] : VPackObjectIterator(progress)) {
+  for (auto [key, value] :
+       VPackObjectIterator(progress, /*useSequentialIteration*/ true)) {
     _collectionStates[key.copyString()] = T(value);
   }
 }

--- a/lib/Basics/RocksDBUtils.cpp
+++ b/lib/Basics/RocksDBUtils.cpp
@@ -40,7 +40,8 @@ namespace {
 bool hasObjectIds(VPackSlice inputSlice) {
   bool rv = false;
   if (inputSlice.isObject()) {
-    for (auto objectPair : velocypack::ObjectIterator(inputSlice)) {
+    for (auto objectPair : velocypack::ObjectIterator(
+             inputSlice, /*useSequentialIteration*/ true)) {
       if (objectPair.key.stringView() == StaticStrings::ObjectId) {
         return true;
       }
@@ -63,7 +64,8 @@ bool hasObjectIds(VPackSlice inputSlice) {
 VPackBuilder& stripObjectIdsImpl(VPackBuilder& builder, VPackSlice inputSlice) {
   if (inputSlice.isObject()) {
     builder.openObject();
-    for (auto objectPair : velocypack::ObjectIterator(inputSlice)) {
+    for (auto objectPair : velocypack::ObjectIterator(
+             inputSlice, /*useSequentialIteration*/ true)) {
       if (objectPair.key.stringView() == StaticStrings::ObjectId) {
         continue;
       }

--- a/lib/Basics/VelocyPackHelper.cpp
+++ b/lib/Basics/VelocyPackHelper.cpp
@@ -277,11 +277,6 @@ void VelocyPackHelper::initialize() {
                  .copyString() == StaticStrings::ToString);
 }
 
-/// @brief turn off assembler optimizations in vpack
-void VelocyPackHelper::disableAssemblerFunctions() {
-  arangodb::velocypack::disableAssemblerFunctions();
-}
-
 /// @brief return the (global) attribute translator instance
 arangodb::velocypack::AttributeTranslator* VelocyPackHelper::getTranslator() {
   return ::translator.get();

--- a/lib/Basics/VelocyPackHelper.h
+++ b/lib/Basics/VelocyPackHelper.h
@@ -95,7 +95,6 @@ class VelocyPackHelper {
  public:
   /// @brief static initializer for all VPack values
   static void initialize();
-  static void disableAssemblerFunctions();
 
   static arangodb::velocypack::AttributeTranslator* getTranslator();
 

--- a/lib/Inspection/VPackLoadInspector.h
+++ b/lib/Inspection/VPackLoadInspector.h
@@ -252,7 +252,8 @@ struct VPackLoadInspectorImpl
   template<class... Args>
   Status applyFields(Args&&... args) {
     FieldsMap fields;
-    for (auto [k, v] : VPackObjectIterator(slice())) {
+    for (auto [k, v] :
+         VPackObjectIterator(slice(), /*useSequentialIteration*/ true)) {
       fields.emplace(k.stringView(), std::make_pair(v, false));
     }
 
@@ -349,7 +350,7 @@ struct VPackLoadInspectorImpl
       if (_slice.length() > 1) {
         return {"Unqualified variant data has too many fields"};
       }
-      VPackObjectIterator it(_slice);
+      VPackObjectIterator it(_slice, /*useSequentialIteration*/ true);
       if (!it.valid()) {
         return {"Missing unqualified variant data"};
       }
@@ -585,7 +586,8 @@ struct VPackLoadInspectorImpl
 
   template<class T>
   Status processMap(T& map) {
-    for (auto&& pair : VPackObjectIterator(_slice)) {
+    for (auto&& pair :
+         VPackObjectIterator(_slice, /*useSequentialIteration*/ true)) {
       auto ff = make(pair.value);
       typename T::mapped_type val;
       if (auto res = process(ff, val); !res.ok()) {

--- a/lib/SimpleHttpClient/HttpResponseChecker.cpp
+++ b/lib/SimpleHttpClient/HttpResponseChecker.cpp
@@ -38,7 +38,7 @@ void HttpResponseChecker::trimPayload(VPackSlice input, VPackBuilder& output) {
   using namespace velocypack;
   if (input.isObject()) {
     output.openObject();
-    ObjectIterator it(input);
+    ObjectIterator it(input, /*useSequentialIteration*/ true);
     while (it.valid()) {
       if (it.key().stringView() != "passwd") {
         output.add(it.key());

--- a/lib/VPackDeserializer/parameter-list.h
+++ b/lib/VPackDeserializer/parameter-list.h
@@ -415,7 +415,7 @@ struct parameter_list_executor<I, K, parameter_list<>, H, FullList> {
                      typename H::state_type hints, C&&) -> unpack_result {
     if constexpr (!hints::hint_has_ignore_unknown<H>) {
       if (s.length() != K) {
-        for (auto&& pair : ObjectIterator(s)) {
+        for (auto pair : ObjectIterator(s, /*useSequentialIteration*/ true)) {
           if (!FullList::contains_name(pair.key)) {
             return unpack_result{
                 deserialize_error{"superfluous field in object: `" +

--- a/tests/Agency/AddFollowerTest.cpp
+++ b/tests/Agency/AddFollowerTest.cpp
@@ -180,11 +180,11 @@ TEST_F(AddFollowerTest, collection_still_exists) {
 
     if (s.isObject()) {
       VPackObjectBuilder b(builder.get());
-      for (auto it : VPackObjectIterator(s)) {
+      for (auto it : VPackObjectIterator(s, /*useSequentialIteration*/ true)) {
         auto childBuilder =
             createTestStructure(it.value, path + "/" + it.key.copyString());
         if (childBuilder) {
-          builder->add(it.key.copyString(), childBuilder->slice());
+          builder->add(it.key.stringView(), childBuilder->slice());
         }
       }
       if (path == "/arango/Target/ToDo") {
@@ -236,11 +236,11 @@ TEST_F(AddFollowerTest, collection_has_nonempty_distributeshardslike) {
     std::unique_ptr<Builder> builder = std::make_unique<Builder>();
     if (s.isObject()) {
       VPackObjectBuilder b(builder.get());
-      for (auto it : VPackObjectIterator(s)) {
+      for (auto it : VPackObjectIterator(s, /*useSequentialIteration*/ true)) {
         auto childBuilder =
             createTestStructure(it.value, path + "/" + it.key.copyString());
         if (childBuilder) {
-          builder->add(it.key.copyString(), childBuilder->slice());
+          builder->add(it.key.stringView(), childBuilder->slice());
         }
       }
       if (path == "/arango/Plan/Collections/" + DATABASE + "/" + COLLECTION) {
@@ -294,11 +294,11 @@ TEST_F(AddFollowerTest, condition_still_holds) {
 
     if (s.isObject()) {
       VPackObjectBuilder b(builder.get());
-      for (auto it : VPackObjectIterator(s)) {
+      for (auto it : VPackObjectIterator(s, /*useSequentialIteration*/ true)) {
         auto childBuilder =
             createTestStructure(it.value, path + "/" + it.key.copyString());
         if (childBuilder) {
-          builder->add(it.key.copyString(), childBuilder->slice());
+          builder->add(it.key.stringView(), childBuilder->slice());
         }
       }
       if (path == "/arango/Target/ToDo") {
@@ -364,11 +364,11 @@ TEST_F(AddFollowerTest, if_no_job_under_shard_leave_job_in_todo) {
     std::unique_ptr<Builder> builder = std::make_unique<Builder>();
     if (s.isObject()) {
       VPackObjectBuilder b(builder.get());
-      for (auto it : VPackObjectIterator(s)) {
+      for (auto it : VPackObjectIterator(s, /*useSequentialIteration*/ true)) {
         auto childBuilder =
             createTestStructure(it.value, path + "/" + it.key.copyString());
         if (childBuilder) {
-          builder->add(it.key.copyString(), childBuilder->slice());
+          builder->add(it.key.stringView(), childBuilder->slice());
         }
       }
       if (path == "/arango/Target/ToDo") {
@@ -419,11 +419,11 @@ TEST_F(AddFollowerTest, we_can_find_one_with_status_good) {
     std::unique_ptr<Builder> builder = std::make_unique<Builder>();
     if (s.isObject()) {
       VPackObjectBuilder b(builder.get());
-      for (auto it : VPackObjectIterator(s)) {
+      for (auto it : VPackObjectIterator(s, /*useSequentialIteration*/ true)) {
         auto childBuilder =
             createTestStructure(it.value, path + "/" + it.key.copyString());
         if (childBuilder) {
-          builder->add(it.key.copyString(), childBuilder->slice());
+          builder->add(it.key.stringView(), childBuilder->slice());
         }
       }
       if (path == "/arango/Target/ToDo") {
@@ -477,11 +477,11 @@ TEST_F(AddFollowerTest, job_performed_immediately_in_a_single_transaction) {
     std::unique_ptr<Builder> builder = std::make_unique<Builder>();
     if (s.isObject()) {
       VPackObjectBuilder b(builder.get());
-      for (auto it : VPackObjectIterator(s)) {
+      for (auto it : VPackObjectIterator(s, /*useSequentialIteration*/ true)) {
         auto childBuilder =
             createTestStructure(it.value, path + "/" + it.key.copyString());
         if (childBuilder) {
-          builder->add(it.key.copyString(), childBuilder->slice());
+          builder->add(it.key.stringView(), childBuilder->slice());
         }
       }
       if (path == "/arango/Target/ToDo") {
@@ -536,11 +536,11 @@ TEST_F(AddFollowerTest, job_can_still_be_safely_aborted) {
     std::unique_ptr<Builder> builder = std::make_unique<Builder>();
     if (s.isObject()) {
       VPackObjectBuilder b(builder.get());
-      for (auto it : VPackObjectIterator(s)) {
+      for (auto it : VPackObjectIterator(s, /*useSequentialIteration*/ true)) {
         auto childBuilder =
             createTestStructure(it.value, path + "/" + it.key.copyString());
         if (childBuilder) {
-          builder->add(it.key.copyString(), childBuilder->slice());
+          builder->add(it.key.stringView(), childBuilder->slice());
         }
       }
       if (path == "/arango/Target/ToDo") {
@@ -599,11 +599,11 @@ TEST_F(AddFollowerTest, job_cannot_be_aborted) {
     std::unique_ptr<Builder> builder = std::make_unique<Builder>();
     if (s.isObject()) {
       VPackObjectBuilder b(builder.get());
-      for (auto it : VPackObjectIterator(s)) {
+      for (auto it : VPackObjectIterator(s, /*useSequentialIteration*/ true)) {
         auto childBuilder =
             createTestStructure(it.value, path + "/" + it.key.copyString());
         if (childBuilder) {
-          builder->add(it.key.copyString(), childBuilder->slice());
+          builder->add(it.key.stringView(), childBuilder->slice());
         }
       }
       if (path == "/arango/Target/Pending") {
@@ -662,11 +662,11 @@ TEST_F(AddFollowerTest, job_only_starting_with_delay) {
     std::unique_ptr<Builder> builder = std::make_unique<Builder>();
     if (s.isObject()) {
       VPackObjectBuilder b(builder.get());
-      for (auto it : VPackObjectIterator(s)) {
+      for (auto it : VPackObjectIterator(s, /*useSequentialIteration*/ true)) {
         auto childBuilder =
             createTestStructure(it.value, path + "/" + it.key.copyString());
         if (childBuilder) {
-          builder->add(it.key.copyString(), childBuilder->slice());
+          builder->add(it.key.stringView(), childBuilder->slice());
         }
       }
       if (path == "/arango/Target/ToDo") {
@@ -740,11 +740,11 @@ TEST_F(AddFollowerTest, job_only_starting_with_no_delay) {
     std::unique_ptr<Builder> builder = std::make_unique<Builder>();
     if (s.isObject()) {
       VPackObjectBuilder b(builder.get());
-      for (auto it : VPackObjectIterator(s)) {
+      for (auto it : VPackObjectIterator(s, /*useSequentialIteration*/ true)) {
         auto childBuilder =
             createTestStructure(it.value, path + "/" + it.key.copyString());
         if (childBuilder) {
-          builder->add(it.key.copyString(), childBuilder->slice());
+          builder->add(it.key.stringView(), childBuilder->slice());
         }
       }
       if (path == "/arango/Target/ToDo") {

--- a/tests/Agency/CleanOutServerTest.cpp
+++ b/tests/Agency/CleanOutServerTest.cpp
@@ -201,11 +201,11 @@ TEST_F(CleanOutServerTest,
     builder.reset(new VPackBuilder());
     if (s.isObject()) {
       builder->add(VPackValue(VPackValueType::Object));
-      for (auto it : VPackObjectIterator(s)) {
+      for (auto it : VPackObjectIterator(s, /*useSequentialIteration*/ true)) {
         auto childBuilder =
             createTestStructure(it.value, path + "/" + it.key.copyString());
         if (childBuilder) {
-          builder->add(it.key.copyString(), childBuilder->slice());
+          builder->add(it.key.stringView(), childBuilder->slice());
         }
       }
 
@@ -242,11 +242,11 @@ TEST_F(CleanOutServerTest, cleanout_server_should_wait_if_server_is_blocked) {
     builder.reset(new VPackBuilder());
     if (s.isObject()) {
       builder->add(VPackValue(VPackValueType::Object));
-      for (auto it : VPackObjectIterator(s)) {
+      for (auto it : VPackObjectIterator(s, /*useSequentialIteration*/ true)) {
         auto childBuilder =
             createTestStructure(it.value, path + "/" + it.key.copyString());
         if (childBuilder) {
-          builder->add(it.key.copyString(), childBuilder->slice());
+          builder->add(it.key.stringView(), childBuilder->slice());
         }
       }
 
@@ -280,11 +280,11 @@ TEST_F(CleanOutServerTest,
     builder.reset(new VPackBuilder());
     if (s.isObject()) {
       builder->add(VPackValue(VPackValueType::Object));
-      for (auto it : VPackObjectIterator(s)) {
+      for (auto it : VPackObjectIterator(s, /*useSequentialIteration*/ true)) {
         auto childBuilder =
             createTestStructure(it.value, path + "/" + it.key.copyString());
         if (childBuilder) {
-          builder->add(it.key.copyString(), childBuilder->slice());
+          builder->add(it.key.stringView(), childBuilder->slice());
         }
       }
 
@@ -322,11 +322,11 @@ TEST_F(CleanOutServerTest,
     builder.reset(new VPackBuilder());
     if (s.isObject()) {
       builder->add(VPackValue(VPackValueType::Object));
-      for (auto it : VPackObjectIterator(s)) {
+      for (auto it : VPackObjectIterator(s, /*useSequentialIteration*/ true)) {
         auto childBuilder =
             createTestStructure(it.value, path + "/" + it.key.copyString());
         if (childBuilder) {
-          builder->add(it.key.copyString(), childBuilder->slice());
+          builder->add(it.key.stringView(), childBuilder->slice());
         }
       }
 
@@ -370,11 +370,11 @@ TEST_F(CleanOutServerTest,
     builder.reset(new VPackBuilder());
     if (s.isObject()) {
       builder->add(VPackValue(VPackValueType::Object));
-      for (auto it : VPackObjectIterator(s)) {
+      for (auto it : VPackObjectIterator(s, /*useSequentialIteration*/ true)) {
         auto childBuilder =
             createTestStructure(it.value, path + "/" + it.key.copyString());
         if (childBuilder) {
-          builder->add(it.key.copyString(), childBuilder->slice());
+          builder->add(it.key.stringView(), childBuilder->slice());
         }
       }
 
@@ -414,11 +414,11 @@ TEST_F(CleanOutServerTest,
     builder.reset(new VPackBuilder());
     if (s.isObject()) {
       builder->add(VPackValue(VPackValueType::Object));
-      for (auto it : VPackObjectIterator(s)) {
+      for (auto it : VPackObjectIterator(s, /*useSequentialIteration*/ true)) {
         auto childBuilder =
             createTestStructure(it.value, path + "/" + it.key.copyString());
         if (childBuilder) {
-          builder->add(it.key.copyString(), childBuilder->slice());
+          builder->add(it.key.stringView(), childBuilder->slice());
         }
       }
 
@@ -460,11 +460,11 @@ TEST_F(CleanOutServerTest,
     builder.reset(new VPackBuilder());
     if (s.isObject()) {
       builder->add(VPackValue(VPackValueType::Object));
-      for (auto it : VPackObjectIterator(s)) {
+      for (auto it : VPackObjectIterator(s, /*useSequentialIteration*/ true)) {
         auto childBuilder =
             createTestStructure(it.value, path + "/" + it.key.copyString());
         if (childBuilder) {
-          builder->add(it.key.copyString(), childBuilder->slice());
+          builder->add(it.key.stringView(), childBuilder->slice());
         }
       }
 
@@ -507,11 +507,11 @@ TEST_F(CleanOutServerTest,
     builder.reset(new VPackBuilder());
     if (s.isObject()) {
       builder->add(VPackValue(VPackValueType::Object));
-      for (auto it : VPackObjectIterator(s)) {
+      for (auto it : VPackObjectIterator(s, /*useSequentialIteration*/ true)) {
         auto childBuilder =
             createTestStructure(it.value, path + "/" + it.key.copyString());
         if (childBuilder) {
-          builder->add(it.key.copyString(), childBuilder->slice());
+          builder->add(it.key.stringView(), childBuilder->slice());
         }
       }
 
@@ -553,11 +553,11 @@ TEST_F(CleanOutServerTest, cleanout_server_job_should_move_into_pending_if_ok) {
     builder.reset(new VPackBuilder());
     if (s.isObject()) {
       builder->add(VPackValue(VPackValueType::Object));
-      for (auto it : VPackObjectIterator(s)) {
+      for (auto it : VPackObjectIterator(s, /*useSequentialIteration*/ true)) {
         auto childBuilder =
             createTestStructure(it.value, path + "/" + it.key.copyString());
         if (childBuilder) {
-          builder->add(it.key.copyString(), childBuilder->slice());
+          builder->add(it.key.stringView(), childBuilder->slice());
         }
       }
 
@@ -649,11 +649,11 @@ TEST_F(CleanOutServerTest, test_cancel_pending_job) {
     builder.reset(new VPackBuilder());
     if (s.isObject()) {
       builder->add(VPackValue(VPackValueType::Object));
-      for (auto it : VPackObjectIterator(s)) {
+      for (auto it : VPackObjectIterator(s, /*useSequentialIteration*/ true)) {
         auto childBuilder =
             createTestStructure(it.value, path + "/" + it.key.copyString());
         if (childBuilder) {
-          builder->add(it.key.copyString(), childBuilder->slice());
+          builder->add(it.key.stringView(), childBuilder->slice());
         }
       }
 
@@ -661,8 +661,9 @@ TEST_F(CleanOutServerTest, test_cancel_pending_job) {
         auto job = createJob(SERVER);
         builder->add(VPackValue(JOBID));
         builder->add(VPackValue(VPackValueType::Object));
-        for (auto const& jobIt : VPackObjectIterator(job.slice())) {
-          builder->add(jobIt.key.copyString(), jobIt.value);
+        for (auto jobIt : VPackObjectIterator(
+                 job.slice(), /*useSequentialIteration*/ true)) {
+          builder->add(jobIt.key.stringView(), jobIt.value);
         }
         builder->add("abort", VPackValue(true));
         builder->close();
@@ -737,11 +738,11 @@ TEST_F(CleanOutServerTest, test_cancel_todo_job) {
     builder.reset(new VPackBuilder());
     if (s.isObject()) {
       builder->add(VPackValue(VPackValueType::Object));
-      for (auto it : VPackObjectIterator(s)) {
+      for (auto it : VPackObjectIterator(s, /*useSequentialIteration*/ true)) {
         auto childBuilder =
             createTestStructure(it.value, path + "/" + it.key.copyString());
         if (childBuilder) {
-          builder->add(it.key.copyString(), childBuilder->slice());
+          builder->add(it.key.stringView(), childBuilder->slice());
         }
       }
 
@@ -749,8 +750,9 @@ TEST_F(CleanOutServerTest, test_cancel_todo_job) {
         auto job = createJob(SERVER);
         builder->add(VPackValue(JOBID));
         builder->add(VPackValue(VPackValueType::Object));
-        for (auto const& jobIt : VPackObjectIterator(job.slice())) {
-          builder->add(jobIt.key.copyString(), jobIt.value);
+        for (auto jobIt : VPackObjectIterator(
+                 job.slice(), /*useSequentialIteration*/ true)) {
+          builder->add(jobIt.key.stringView(), jobIt.value);
         }
         builder->add("abort", VPackValue(true));
         builder->close();
@@ -794,11 +796,11 @@ TEST_F(CleanOutServerTest, when_there_are_still_subjobs_it_should_wait) {
     builder.reset(new VPackBuilder());
     if (s.isObject()) {
       builder->add(VPackValue(VPackValueType::Object));
-      for (auto it : VPackObjectIterator(s)) {
+      for (auto it : VPackObjectIterator(s, /*useSequentialIteration*/ true)) {
         auto childBuilder =
             createTestStructure(it.value, path + "/" + it.key.copyString());
         if (childBuilder) {
-          builder->add(it.key.copyString(), childBuilder->slice());
+          builder->add(it.key.stringView(), childBuilder->slice());
         }
       }
 
@@ -832,11 +834,11 @@ TEST_F(CleanOutServerTest,
     builder.reset(new VPackBuilder());
     if (s.isObject()) {
       builder->add(VPackValue(VPackValueType::Object));
-      for (auto it : VPackObjectIterator(s)) {
+      for (auto it : VPackObjectIterator(s, /*useSequentialIteration*/ true)) {
         auto childBuilder =
             createTestStructure(it.value, path + "/" + it.key.copyString());
         if (childBuilder) {
-          builder->add(it.key.copyString(), childBuilder->slice());
+          builder->add(it.key.stringView(), childBuilder->slice());
         }
       }
 
@@ -902,11 +904,11 @@ TEST_F(CleanOutServerTest, failed_subjob_should_also_fail_job) {
     builder.reset(new VPackBuilder());
     if (s.isObject()) {
       builder->add(VPackValue(VPackValueType::Object));
-      for (auto it : VPackObjectIterator(s)) {
+      for (auto it : VPackObjectIterator(s, /*useSequentialIteration*/ true)) {
         auto childBuilder =
             createTestStructure(it.value, path + "/" + it.key.copyString());
         if (childBuilder) {
-          builder->add(it.key.copyString(), childBuilder->slice());
+          builder->add(it.key.stringView(), childBuilder->slice());
         }
       }
 
@@ -946,11 +948,11 @@ TEST_F(CleanOutServerTest,
     builder.reset(new VPackBuilder());
     if (s.isObject()) {
       builder->add(VPackValue(VPackValueType::Object));
-      for (auto it : VPackObjectIterator(s)) {
+      for (auto it : VPackObjectIterator(s, /*useSequentialIteration*/ true)) {
         auto childBuilder =
             createTestStructure(it.value, path + "/" + it.key.copyString());
         if (childBuilder) {
-          builder->add(it.key.copyString(), childBuilder->slice());
+          builder->add(it.key.stringView(), childBuilder->slice());
         }
       }
 

--- a/tests/Agency/FailedFollowerTest.cpp
+++ b/tests/Agency/FailedFollowerTest.cpp
@@ -202,11 +202,11 @@ TEST_F(FailedFollowerTest, if_collection_is_missing_job_should_just_finish) {
     builder.reset(new VPackBuilder());
     if (s.isObject()) {
       builder->add(VPackValue(VPackValueType::Object));
-      for (auto it : VPackObjectIterator(s)) {
+      for (auto it : VPackObjectIterator(s, /*useSequentialIteration*/ true)) {
         auto childBuilder =
             createTestStructure(it.value, path + "/" + it.key.copyString());
         if (childBuilder) {
-          builder->add(it.key.copyString(), childBuilder->slice());
+          builder->add(it.key.stringView(), childBuilder->slice());
         }
       }
 
@@ -268,11 +268,11 @@ TEST_F(FailedFollowerTest, distributeshardslike_should_fail_immediately) {
     builder.reset(new VPackBuilder());
     if (s.isObject()) {
       builder->add(VPackValue(VPackValueType::Object));
-      for (auto it : VPackObjectIterator(s)) {
+      for (auto it : VPackObjectIterator(s, /*useSequentialIteration*/ true)) {
         auto childBuilder =
             createTestStructure(it.value, path + "/" + it.key.copyString());
         if (childBuilder) {
-          builder->add(it.key.copyString(), childBuilder->slice());
+          builder->add(it.key.stringView(), childBuilder->slice());
         }
       }
 
@@ -338,11 +338,11 @@ TEST_F(FailedFollowerTest, if_follower_is_healthy_again_we_fail_the_job) {
     builder.reset(new VPackBuilder());
     if (s.isObject()) {
       builder->add(VPackValue(VPackValueType::Object));
-      for (auto it : VPackObjectIterator(s)) {
+      for (auto it : VPackObjectIterator(s, /*useSequentialIteration*/ true)) {
         auto childBuilder =
             createTestStructure(it.value, path + "/" + it.key.copyString());
         if (childBuilder) {
-          builder->add(it.key.copyString(), childBuilder->slice());
+          builder->add(it.key.stringView(), childBuilder->slice());
         }
       }
 
@@ -411,11 +411,11 @@ TEST_F(FailedFollowerTest,
     builder.reset(new VPackBuilder());
     if (s.isObject()) {
       builder->add(VPackValue(VPackValueType::Object));
-      for (auto it : VPackObjectIterator(s)) {
+      for (auto it : VPackObjectIterator(s, /*useSequentialIteration*/ true)) {
         auto childBuilder =
             createTestStructure(it.value, path + "/" + it.key.copyString());
         if (childBuilder) {
-          builder->add(it.key.copyString(), childBuilder->slice());
+          builder->add(it.key.stringView(), childBuilder->slice());
         }
       }
 
@@ -472,11 +472,11 @@ TEST_F(FailedFollowerTest,
     builder.reset(new VPackBuilder());
     if (s.isObject()) {
       builder->add(VPackValue(VPackValueType::Object));
-      for (auto it : VPackObjectIterator(s)) {
+      for (auto it : VPackObjectIterator(s, /*useSequentialIteration*/ true)) {
         auto childBuilder =
             createTestStructure(it.value, path + "/" + it.key.copyString());
         if (childBuilder) {
-          builder->add(it.key.copyString(), childBuilder->slice());
+          builder->add(it.key.stringView(), childBuilder->slice());
         }
       }
 
@@ -555,11 +555,11 @@ TEST_F(FailedFollowerTest, abort_any_moveshard_job_blocking) {
     std::unique_ptr<Builder> builder(new Builder());
     if (s.isObject()) {
       VPackObjectBuilder b(builder.get());
-      for (auto it : VPackObjectIterator(s)) {
+      for (auto it : VPackObjectIterator(s, /*useSequentialIteration*/ true)) {
         auto childBuilder =
             createTestStructure(it.value, path + "/" + it.key.copyString());
         if (childBuilder) {
-          builder->add(it.key.copyString(), childBuilder->slice());
+          builder->add(it.key.stringView(), childBuilder->slice());
         }
       }
       if (path == "/arango/Supervision/Shards") {
@@ -618,11 +618,11 @@ TEST_F(FailedFollowerTest, successfully_started_job_should_finish_immediately) {
     std::unique_ptr<Builder> builder(new Builder());
     if (s.isObject()) {
       VPackObjectBuilder b(builder.get());
-      for (auto it : VPackObjectIterator(s)) {
+      for (auto it : VPackObjectIterator(s, /*useSequentialIteration*/ true)) {
         auto childBuilder =
             createTestStructure(it.value, path + "/" + it.key.copyString());
         if (childBuilder) {
-          builder->add(it.key.copyString(), childBuilder->slice());
+          builder->add(it.key.stringView(), childBuilder->slice());
         }
       }
 
@@ -711,11 +711,11 @@ TEST_F(FailedFollowerTest, delayed_job_should_wait) {
     std::unique_ptr<Builder> builder(new Builder());
     if (s.isObject()) {
       VPackObjectBuilder b(builder.get());
-      for (auto it : VPackObjectIterator(s)) {
+      for (auto it : VPackObjectIterator(s, /*useSequentialIteration*/ true)) {
         auto childBuilder =
             createTestStructure(it.value, path + "/" + it.key.copyString());
         if (childBuilder) {
-          builder->add(it.key.copyString(), childBuilder->slice());
+          builder->add(it.key.stringView(), childBuilder->slice());
         }
       }
 
@@ -758,11 +758,11 @@ TEST_F(FailedFollowerTest, job_should_handle_distributeshardslike) {
     std::unique_ptr<Builder> builder(new Builder());
     if (s.isObject()) {
       VPackObjectBuilder b(builder.get());
-      for (auto it : VPackObjectIterator(s)) {
+      for (auto it : VPackObjectIterator(s, /*useSequentialIteration*/ true)) {
         auto childBuilder =
             createTestStructure(it.value, path + "/" + it.key.copyString());
         if (childBuilder) {
-          builder->add(it.key.copyString(), childBuilder->slice());
+          builder->add(it.key.stringView(), childBuilder->slice());
         }
       }
       if (path == "/arango/Current/Collections/" + DATABASE) {
@@ -914,11 +914,11 @@ TEST_F(FailedFollowerTest, job_should_timeout_after_a_while) {
     std::unique_ptr<Builder> builder(new Builder());
     if (s.isObject()) {
       VPackObjectBuilder b(builder.get());
-      for (auto it : VPackObjectIterator(s)) {
+      for (auto it : VPackObjectIterator(s, /*useSequentialIteration*/ true)) {
         auto childBuilder =
             createTestStructure(it.value, path + "/" + it.key.copyString());
         if (childBuilder) {
-          builder->add(it.key.copyString(), childBuilder->slice());
+          builder->add(it.key.stringView(), childBuilder->slice());
         }
       }
 
@@ -927,12 +927,13 @@ TEST_F(FailedFollowerTest, job_should_timeout_after_a_while) {
         VPackBuilder timedOutJob;
         {
           VPackObjectBuilder a(&timedOutJob);
-          for (auto it : VPackObjectIterator(todoJob.slice())) {
-            if (it.key.copyString() == "timeCreated") {
+          for (auto it : VPackObjectIterator(todoJob.slice(),
+                                             /*useSequentialIteration*/ true)) {
+            if (it.key.stringView() == "timeCreated") {
               timedOutJob.add("timeCreated",
                               VPackValue("2015-01-01T00:00:00Z"));
             } else {
-              timedOutJob.add(it.key.copyString(), it.value);
+              timedOutJob.add(it.key.stringView(), it.value);
             }
           }
         }
@@ -983,11 +984,11 @@ TEST_F(FailedFollowerTest, job_should_be_abortable_in_todo) {
     std::unique_ptr<Builder> builder(new Builder());
     if (s.isObject()) {
       VPackObjectBuilder b(builder.get());
-      for (auto it : VPackObjectIterator(s)) {
+      for (auto it : VPackObjectIterator(s, /*useSequentialIteration*/ true)) {
         auto childBuilder =
             createTestStructure(it.value, path + "/" + it.key.copyString());
         if (childBuilder) {
-          builder->add(it.key.copyString(), childBuilder->slice());
+          builder->add(it.key.stringView(), childBuilder->slice());
         }
       }
 

--- a/tests/Agency/FailedLeaderTest.cpp
+++ b/tests/Agency/FailedLeaderTest.cpp
@@ -98,7 +98,7 @@ Node createNode(char const* c) {
 std::unordered_set<std::string> getKeySet(VPackSlice s) {
   std::unordered_set<std::string> keys;
 
-  for (auto const& kv : VPackObjectIterator(s)) {
+  for (auto kv : VPackObjectIterator(s, /*useSequentialIteration*/ true)) {
     keys.insert(kv.key.copyString());
   }
 
@@ -621,11 +621,11 @@ TEST_F(FailedLeaderTest, if_collection_is_missing_job_should_just_finish) {
     builder.reset(new Builder());
     if (s.isObject()) {
       VPackObjectBuilder b(builder.get());
-      for (auto it : VPackObjectIterator(s)) {
+      for (auto it : VPackObjectIterator(s, /*useSequentialIteration*/ true)) {
         auto childBuilder =
             createTestStructure(it.value, path + "/" + it.key.copyString());
         if (childBuilder) {
-          builder->add(it.key.copyString(), childBuilder->slice());
+          builder->add(it.key.stringView(), childBuilder->slice());
         }
       }
       if (path == "/arango/Target/ToDo") {
@@ -684,11 +684,11 @@ TEST_F(FailedLeaderTest, distributeshardslike_should_immediately_fail) {
     std::unique_ptr<Builder> builder = std::make_unique<Builder>();
     if (s.isObject()) {
       VPackObjectBuilder b(builder.get());
-      for (auto it : VPackObjectIterator(s)) {
+      for (auto it : VPackObjectIterator(s, /*useSequentialIteration*/ true)) {
         auto childBuilder =
             createTestStructure(it.value, path + "/" + it.key.copyString());
         if (childBuilder) {
-          builder->add(it.key.copyString(), childBuilder->slice());
+          builder->add(it.key.stringView(), childBuilder->slice());
         }
       }
       if (path == "/arango/Plan/Collections/" + DATABASE + "/" + COLLECTION) {
@@ -750,11 +750,11 @@ TEST_F(FailedLeaderTest, if_leader_is_healthy_we_fail_the_job) {
     std::unique_ptr<Builder> builder = std::make_unique<Builder>();
     if (s.isObject()) {
       VPackObjectBuilder b(builder.get());
-      for (auto it : VPackObjectIterator(s)) {
+      for (auto it : VPackObjectIterator(s, /*useSequentialIteration*/ true)) {
         auto childBuilder =
             createTestStructure(it.value, path + "/" + it.key.copyString());
         if (childBuilder) {
-          builder->add(it.key.copyString(), childBuilder->slice());
+          builder->add(it.key.stringView(), childBuilder->slice());
         }
       }
       if (path == "/arango/Supervision/Health/" + SHARD_LEADER) {
@@ -817,11 +817,11 @@ TEST_F(FailedLeaderTest, job_must_not_be_started_if_no_server_is_in_sync) {
     std::unique_ptr<Builder> builder = std::make_unique<Builder>();
     if (s.isObject()) {
       VPackObjectBuilder b(builder.get());
-      for (auto it : VPackObjectIterator(s)) {
+      for (auto it : VPackObjectIterator(s, /*useSequentialIteration*/ true)) {
         auto childBuilder =
             createTestStructure(it.value, path + "/" + it.key.copyString());
         if (childBuilder) {
-          builder->add(it.key.copyString(), childBuilder->slice());
+          builder->add(it.key.stringView(), childBuilder->slice());
         }
       }
       if (path == "/arango/Target/ToDo") {
@@ -860,11 +860,11 @@ TEST_F(FailedLeaderTest,
     std::unique_ptr<Builder> builder = std::make_unique<Builder>();
     if (s.isObject()) {
       VPackObjectBuilder b(builder.get());
-      for (auto it : VPackObjectIterator(s)) {
+      for (auto it : VPackObjectIterator(s, /*useSequentialIteration*/ true)) {
         auto childBuilder =
             createTestStructure(it.value, path + "/" + it.key.copyString());
         if (childBuilder) {
-          builder->add(it.key.copyString(), childBuilder->slice());
+          builder->add(it.key.stringView(), childBuilder->slice());
         }
       }
 
@@ -939,11 +939,11 @@ TEST_F(FailedLeaderTest, abort_any_moveshard_job_blocking) {
     std::unique_ptr<Builder> builder(new Builder());
     if (s.isObject()) {
       VPackObjectBuilder b(builder.get());
-      for (auto it : VPackObjectIterator(s)) {
+      for (auto it : VPackObjectIterator(s, /*useSequentialIteration*/ true)) {
         auto childBuilder =
             createTestStructure(it.value, path + "/" + it.key.copyString());
         if (childBuilder) {
-          builder->add(it.key.copyString(), childBuilder->slice());
+          builder->add(it.key.stringView(), childBuilder->slice());
         }
       }
       if (path == "/arango/Supervision/Shards") {
@@ -1002,11 +1002,11 @@ TEST_F(FailedLeaderTest, job_should_be_written_to_pending) {
     std::unique_ptr<Builder> builder(new Builder());
     if (s.isObject()) {
       VPackObjectBuilder b(builder.get());
-      for (auto it : VPackObjectIterator(s)) {
+      for (auto it : VPackObjectIterator(s, /*useSequentialIteration*/ true)) {
         auto childBuilder =
             createTestStructure(it.value, path + "/" + it.key.copyString());
         if (childBuilder) {
-          builder->add(it.key.copyString(), childBuilder->slice());
+          builder->add(it.key.stringView(), childBuilder->slice());
         }
       }
       if (path == "/arango/Target/ToDo") {
@@ -1204,11 +1204,11 @@ TEST_F(FailedLeaderTest,
     std::unique_ptr<Builder> builder(new Builder());
     if (s.isObject()) {
       VPackObjectBuilder b(builder.get());
-      for (auto it : VPackObjectIterator(s)) {
+      for (auto it : VPackObjectIterator(s, /*useSequentialIteration*/ true)) {
         auto childBuilder =
             createTestStructure(it.value, path + "/" + it.key.copyString());
         if (childBuilder) {
-          builder->add(it.key.copyString(), childBuilder->slice());
+          builder->add(it.key.stringView(), childBuilder->slice());
         }
       }
       if (path == "/arango/Target/ToDo") {
@@ -1399,11 +1399,11 @@ TEST_F(FailedLeaderTest, if_collection_is_missing_job_should_just_finish_2) {
     builder.reset(new Builder());
     if (s.isObject()) {
       VPackObjectBuilder b(builder.get());
-      for (auto it : VPackObjectIterator(s)) {
+      for (auto it : VPackObjectIterator(s, /*useSequentialIteration*/ true)) {
         auto childBuilder =
             createTestStructure(it.value, path + "/" + it.key.copyString());
         if (childBuilder) {
-          builder->add(it.key.copyString(), childBuilder->slice());
+          builder->add(it.key.stringView(), childBuilder->slice());
         }
       }
       if (path == "/arango/Target/Pending") {
@@ -1476,11 +1476,11 @@ TEST_F(FailedLeaderTest, if_new_leader_doesnt_catch_up_we_wait) {
     std::unique_ptr<Builder> builder = std::make_unique<Builder>();
     if (s.isObject()) {
       VPackObjectBuilder b(builder.get());
-      for (auto it : VPackObjectIterator(s)) {
+      for (auto it : VPackObjectIterator(s, /*useSequentialIteration*/ true)) {
         auto childBuilder =
             createTestStructure(it.value, path + "/" + it.key.copyString());
         if (childBuilder) {
-          builder->add(it.key.copyString(), childBuilder->slice());
+          builder->add(it.key.stringView(), childBuilder->slice());
         }
       }
       if (path == "/arango/Target/Pending") {
@@ -1538,11 +1538,11 @@ TEST_F(FailedLeaderTest, if_timeout_job_should_be_aborted) {
     std::unique_ptr<Builder> builder = std::make_unique<Builder>();
     if (s.isObject()) {
       VPackObjectBuilder b(builder.get());
-      for (auto it : VPackObjectIterator(s)) {
+      for (auto it : VPackObjectIterator(s, /*useSequentialIteration*/ true)) {
         auto childBuilder =
             createTestStructure(it.value, path + "/" + it.key.copyString());
         if (childBuilder) {
-          builder->add(it.key.copyString(), childBuilder->slice());
+          builder->add(it.key.stringView(), childBuilder->slice());
         }
       }
       if (path == "/arango/Target/Pending") {
@@ -1645,11 +1645,11 @@ TEST_F(FailedLeaderTest, when_everything_is_finished_there_should_be_cleanup) {
     std::unique_ptr<Builder> builder = std::make_unique<Builder>();
     if (s.isObject()) {
       VPackObjectBuilder b(builder.get());
-      for (auto it : VPackObjectIterator(s)) {
+      for (auto it : VPackObjectIterator(s, /*useSequentialIteration*/ true)) {
         auto childBuilder =
             createTestStructure(it.value, path + "/" + it.key.copyString());
         if (childBuilder) {
-          builder->add(it.key.copyString(), childBuilder->slice());
+          builder->add(it.key.stringView(), childBuilder->slice());
         }
       }
       if (path == "/arango/Target/Pending") {

--- a/tests/Agency/FailedServerTest.cpp
+++ b/tests/Agency/FailedServerTest.cpp
@@ -216,11 +216,11 @@ TEST_F(
 
     if (s.isObject()) {
       VPackObjectBuilder b(builder.get());
-      for (auto it : VPackObjectIterator(s)) {
+      for (auto it : VPackObjectIterator(s, /*useSequentialIteration*/ true)) {
         auto childBuilder =
             createTestStructure(it.value, path + "/" + it.key.copyString());
         if (childBuilder) {
-          builder->add(it.key.copyString(), childBuilder->slice());
+          builder->add(it.key.stringView(), childBuilder->slice());
         }
       }
       if (path == "/arango/Supervision/Health/leader") {
@@ -292,11 +292,11 @@ TEST_F(
 
     if (s.isObject()) {
       VPackObjectBuilder b(builder.get());
-      for (auto it : VPackObjectIterator(s)) {
+      for (auto it : VPackObjectIterator(s, /*useSequentialIteration*/ true)) {
         auto childBuilder =
             createTestStructure(it.value, path + "/" + it.key.copyString());
         if (childBuilder) {
-          builder->add(it.key.copyString(), childBuilder->slice());
+          builder->add(it.key.stringView(), childBuilder->slice());
         }
       }
       if (path == "/arango/Supervision/Health/leader") {
@@ -365,11 +365,11 @@ TEST_F(FailedServerTest,
 
     if (s.isObject()) {
       VPackObjectBuilder b(builder.get());
-      for (auto it : VPackObjectIterator(s)) {
+      for (auto it : VPackObjectIterator(s, /*useSequentialIteration*/ true)) {
         auto childBuilder =
             createTestStructure(it.value, path + "/" + it.key.copyString());
         if (childBuilder) {
-          builder->add(it.key.copyString(), childBuilder->slice());
+          builder->add(it.key.stringView(), childBuilder->slice());
         }
       }
       if (path == "/arango/Target/ToDo") {
@@ -432,11 +432,11 @@ TEST_F(FailedServerTest,
 
     if (s.isObject()) {
       VPackObjectBuilder b(builder.get());
-      for (auto it : VPackObjectIterator(s)) {
+      for (auto it : VPackObjectIterator(s, /*useSequentialIteration*/ true)) {
         auto childBuilder =
             createTestStructure(it.value, path + "/" + it.key.copyString());
         if (childBuilder) {
-          builder->add(it.key.copyString(), childBuilder->slice());
+          builder->add(it.key.stringView(), childBuilder->slice());
         }
       }
       if (path == "/arango/Target/ToDo") {
@@ -500,11 +500,11 @@ TEST_F(FailedServerTest, a_failed_server_test_starts_and_is_moved_to_pending) {
 
     if (s.isObject()) {
       VPackObjectBuilder b(builder.get());
-      for (auto it : VPackObjectIterator(s)) {
+      for (auto it : VPackObjectIterator(s, /*useSequentialIteration*/ true)) {
         auto childBuilder =
             createTestStructure(it.value, path + "/" + it.key.copyString());
         if (childBuilder) {
-          builder->add(it.key.copyString(), childBuilder->slice());
+          builder->add(it.key.stringView(), childBuilder->slice());
         }
       }
       if (path == "/arango/Target/ToDo") {
@@ -578,11 +578,11 @@ TEST_F(FailedServerTest,
 
     if (s.isObject()) {
       VPackObjectBuilder b(builder.get());
-      for (auto it : VPackObjectIterator(s)) {
+      for (auto it : VPackObjectIterator(s, /*useSequentialIteration*/ true)) {
         auto childBuilder =
             createTestStructure(it.value, path + "/" + it.key.copyString());
         if (childBuilder) {
-          builder->add(it.key.copyString(), childBuilder->slice());
+          builder->add(it.key.stringView(), childBuilder->slice());
         }
       }
       if (path == "/arango/Target/ToDo") {
@@ -655,11 +655,11 @@ TEST_F(FailedServerTest, a_failed_server_job_is_finished) {
 
     if (s.isObject()) {
       VPackObjectBuilder b(builder.get());
-      for (auto it : VPackObjectIterator(s)) {
+      for (auto it : VPackObjectIterator(s, /*useSequentialIteration*/ true)) {
         auto childBuilder =
             createTestStructure(it.value, path + "/" + it.key.copyString());
         if (childBuilder) {
-          builder->add(it.key.copyString(), childBuilder->slice());
+          builder->add(it.key.stringView(), childBuilder->slice());
         }
       }
       if (path == "/arango/Target/Pending") {

--- a/tests/Agency/MoveShardTest.cpp
+++ b/tests/Agency/MoveShardTest.cpp
@@ -152,11 +152,12 @@ TEST_F(MoveShardTest, the_job_should_fail_if_toserver_does_not_exist) {
         auto builder = std::make_unique<velocypack::Builder>();
         if (s.isObject()) {
           builder->add(VPackValue(VPackValueType::Object));
-          for (auto it : VPackObjectIterator(s)) {
+          for (auto it :
+               VPackObjectIterator(s, /*useSequentialIteration*/ true)) {
             auto childBuilder =
                 createTestStructure(it.value, path + "/" + it.key.copyString());
             if (childBuilder) {
-              builder->add(it.key.copyString(), childBuilder->slice());
+              builder->add(it.key.stringView(), childBuilder->slice());
             }
           }
 
@@ -196,11 +197,12 @@ TEST_F(MoveShardTest, the_job_should_fail_if_servers_are_planned_followers) {
         auto builder = std::make_unique<velocypack::Builder>();
         if (s.isObject()) {
           builder->add(VPackValue(VPackValueType::Object));
-          for (auto it : VPackObjectIterator(s)) {
+          for (auto it :
+               VPackObjectIterator(s, /*useSequentialIteration*/ true)) {
             auto childBuilder =
                 createTestStructure(it.value, path + "/" + it.key.copyString());
             if (childBuilder) {
-              builder->add(it.key.copyString(), childBuilder->slice());
+              builder->add(it.key.stringView(), childBuilder->slice());
             }
           }
 
@@ -241,11 +243,12 @@ TEST_F(MoveShardTest, the_job_should_fail_if_fromserver_does_not_exist) {
         auto builder = std::make_unique<velocypack::Builder>();
         if (s.isObject()) {
           builder->add(VPackValue(VPackValueType::Object));
-          for (auto it : VPackObjectIterator(s)) {
+          for (auto it :
+               VPackObjectIterator(s, /*useSequentialIteration*/ true)) {
             auto childBuilder =
                 createTestStructure(it.value, path + "/" + it.key.copyString());
             if (childBuilder) {
-              builder->add(it.key.copyString(), childBuilder->slice());
+              builder->add(it.key.stringView(), childBuilder->slice());
             }
           }
 
@@ -287,11 +290,12 @@ TEST_F(MoveShardTest, the_job_should_fail_if_fromserver_is_not_in_plan) {
         auto builder = std::make_unique<velocypack::Builder>();
         if (s.isObject()) {
           builder->add(VPackValue(VPackValueType::Object));
-          for (auto it : VPackObjectIterator(s)) {
+          for (auto it :
+               VPackObjectIterator(s, /*useSequentialIteration*/ true)) {
             auto childBuilder =
                 createTestStructure(it.value, path + "/" + it.key.copyString());
             if (childBuilder) {
-              builder->add(it.key.copyString(), childBuilder->slice());
+              builder->add(it.key.stringView(), childBuilder->slice());
             }
           }
 
@@ -332,11 +336,12 @@ TEST_F(MoveShardTest, the_job_should_fail_if_fromserver_does_not_exist_2) {
         auto builder = std::make_unique<velocypack::Builder>();
         if (s.isObject()) {
           builder->add(VPackValue(VPackValueType::Object));
-          for (auto it : VPackObjectIterator(s)) {
+          for (auto it :
+               VPackObjectIterator(s, /*useSequentialIteration*/ true)) {
             auto childBuilder =
                 createTestStructure(it.value, path + "/" + it.key.copyString());
             if (childBuilder) {
-              builder->add(it.key.copyString(), childBuilder->slice());
+              builder->add(it.key.stringView(), childBuilder->slice());
             }
           }
 
@@ -396,11 +401,12 @@ TEST_F(MoveShardTest, the_job_should_remain_in_todo_if_shard_is_locked) {
         auto builder = std::make_unique<velocypack::Builder>();
         if (s.isObject()) {
           builder->add(VPackValue(VPackValueType::Object));
-          for (auto it : VPackObjectIterator(s)) {
+          for (auto it :
+               VPackObjectIterator(s, /*useSequentialIteration*/ true)) {
             auto childBuilder =
                 createTestStructure(it.value, path + "/" + it.key.copyString());
             if (childBuilder) {
-              builder->add(it.key.copyString(), childBuilder->slice());
+              builder->add(it.key.stringView(), childBuilder->slice());
             }
           }
 
@@ -437,11 +443,12 @@ TEST_F(MoveShardTest, the_job_should_remain_in_todo_if_server_is_locked) {
         auto builder = std::make_unique<velocypack::Builder>();
         if (s.isObject()) {
           builder->add(VPackValue(VPackValueType::Object));
-          for (auto it : VPackObjectIterator(s)) {
+          for (auto it :
+               VPackObjectIterator(s, /*useSequentialIteration*/ true)) {
             auto childBuilder =
                 createTestStructure(it.value, path + "/" + it.key.copyString());
             if (childBuilder) {
-              builder->add(it.key.copyString(), childBuilder->slice());
+              builder->add(it.key.stringView(), childBuilder->slice());
             }
           }
 
@@ -478,11 +485,12 @@ TEST_F(MoveShardTest, the_job_should_fail_if_target_server_was_cleaned_out) {
         auto builder = std::make_unique<velocypack::Builder>();
         if (s.isObject()) {
           builder->add(VPackValue(VPackValueType::Object));
-          for (auto it : VPackObjectIterator(s)) {
+          for (auto it :
+               VPackObjectIterator(s, /*useSequentialIteration*/ true)) {
             auto childBuilder =
                 createTestStructure(it.value, path + "/" + it.key.copyString());
             if (childBuilder) {
-              builder->add(it.key.copyString(), childBuilder->slice());
+              builder->add(it.key.stringView(), childBuilder->slice());
             }
           }
 
@@ -530,11 +538,12 @@ TEST_F(MoveShardTest, the_job_should_fail_if_the_target_server_is_failed) {
         auto builder = std::make_unique<velocypack::Builder>();
         if (s.isObject()) {
           builder->add(VPackValue(VPackValueType::Object));
-          for (auto it : VPackObjectIterator(s)) {
+          for (auto it :
+               VPackObjectIterator(s, /*useSequentialIteration*/ true)) {
             auto childBuilder =
                 createTestStructure(it.value, path + "/" + it.key.copyString());
             if (childBuilder) {
-              builder->add(it.key.copyString(), childBuilder->slice());
+              builder->add(it.key.stringView(), childBuilder->slice());
             }
           }
 
@@ -580,11 +589,12 @@ TEST_F(MoveShardTest, the_job_should_wait_until_the_target_server_is_good) {
         auto builder = std::make_unique<velocypack::Builder>();
         if (s.isObject()) {
           builder->add(VPackValue(VPackValueType::Object));
-          for (auto it : VPackObjectIterator(s)) {
+          for (auto it :
+               VPackObjectIterator(s, /*useSequentialIteration*/ true)) {
             auto childBuilder =
                 createTestStructure(it.value, path + "/" + it.key.copyString());
             if (childBuilder) {
-              builder->add(it.key.copyString(), childBuilder->slice());
+              builder->add(it.key.stringView(), childBuilder->slice());
             }
           }
 
@@ -629,11 +639,12 @@ TEST_F(MoveShardTest, the_job_should_wait_until_the_from_server_is_in_current) {
         auto builder = std::make_unique<velocypack::Builder>();
         if (s.isObject()) {
           builder->add(VPackValue(VPackValueType::Object));
-          for (auto it : VPackObjectIterator(s)) {
+          for (auto it :
+               VPackObjectIterator(s, /*useSequentialIteration*/ true)) {
             auto childBuilder =
                 createTestStructure(it.value, path + "/" + it.key.copyString());
             if (childBuilder) {
-              builder->add(it.key.copyString(), childBuilder->slice());
+              builder->add(it.key.stringView(), childBuilder->slice());
             }
           }
 
@@ -678,11 +689,12 @@ TEST_F(MoveShardTest, the_job_should_wait_until_the_to_server_is_in_sync) {
         auto builder = std::make_unique<velocypack::Builder>();
         if (s.isObject()) {
           builder->add(VPackValue(VPackValueType::Object));
-          for (auto it : VPackObjectIterator(s)) {
+          for (auto it :
+               VPackObjectIterator(s, /*useSequentialIteration*/ true)) {
             auto childBuilder =
                 createTestStructure(it.value, path + "/" + it.key.copyString());
             if (childBuilder) {
-              builder->add(it.key.copyString(), childBuilder->slice());
+              builder->add(it.key.stringView(), childBuilder->slice());
             }
           }
 
@@ -728,11 +740,12 @@ TEST_F(
         auto builder = std::make_unique<velocypack::Builder>();
         if (s.isObject()) {
           builder->add(VPackValue(VPackValueType::Object));
-          for (auto it : VPackObjectIterator(s)) {
+          for (auto it :
+               VPackObjectIterator(s, /*useSequentialIteration*/ true)) {
             auto childBuilder =
                 createTestStructure(it.value, path + "/" + it.key.copyString());
             if (childBuilder) {
-              builder->add(it.key.copyString(), childBuilder->slice());
+              builder->add(it.key.stringView(), childBuilder->slice());
             }
           }
 
@@ -778,11 +791,12 @@ TEST_F(MoveShardTest,
         auto builder = std::make_unique<velocypack::Builder>();
         if (s.isObject()) {
           builder->add(VPackValue(VPackValueType::Object));
-          for (auto it : VPackObjectIterator(s)) {
+          for (auto it :
+               VPackObjectIterator(s, /*useSequentialIteration*/ true)) {
             auto childBuilder =
                 createTestStructure(it.value, path + "/" + it.key.copyString());
             if (childBuilder) {
-              builder->add(it.key.copyString(), childBuilder->slice());
+              builder->add(it.key.stringView(), childBuilder->slice());
             }
           }
 
@@ -902,11 +916,12 @@ TEST_F(
         auto builder = std::make_unique<velocypack::Builder>();
         if (s.isObject()) {
           builder->add(VPackValue(VPackValueType::Object));
-          for (auto it : VPackObjectIterator(s)) {
+          for (auto it :
+               VPackObjectIterator(s, /*useSequentialIteration*/ true)) {
             auto childBuilder =
                 createTestStructure(it.value, path + "/" + it.key.copyString());
             if (childBuilder) {
-              builder->add(it.key.copyString(), childBuilder->slice());
+              builder->add(it.key.stringView(), childBuilder->slice());
             }
           }
 
@@ -1026,11 +1041,12 @@ TEST_F(MoveShardTest, moving_from_a_follower_should_be_possible) {
         auto builder = std::make_unique<velocypack::Builder>();
         if (s.isObject()) {
           builder->add(VPackValue(VPackValueType::Object));
-          for (auto it : VPackObjectIterator(s)) {
+          for (auto it :
+               VPackObjectIterator(s, /*useSequentialIteration*/ true)) {
             auto childBuilder =
                 createTestStructure(it.value, path + "/" + it.key.copyString());
             if (childBuilder) {
-              builder->add(it.key.copyString(), childBuilder->slice());
+              builder->add(it.key.stringView(), childBuilder->slice());
             }
           }
 
@@ -1094,11 +1110,12 @@ TEST_F(
         auto builder = std::make_unique<velocypack::Builder>();
         if (s.isObject()) {
           builder->add(VPackValue(VPackValueType::Object));
-          for (auto it : VPackObjectIterator(s)) {
+          for (auto it :
+               VPackObjectIterator(s, /*useSequentialIteration*/ true)) {
             auto childBuilder =
                 createTestStructure(it.value, path + "/" + it.key.copyString());
             if (childBuilder) {
-              builder->add(it.key.copyString(), childBuilder->slice());
+              builder->add(it.key.stringView(), childBuilder->slice());
             }
           }
 
@@ -1244,11 +1261,12 @@ TEST_F(MoveShardTest, if_the_to_server_no_longer_replica_we_should_abort) {
         auto builder = std::make_unique<velocypack::Builder>();
         if (s.isObject()) {
           builder->add(VPackValue(VPackValueType::Object));
-          for (auto it : VPackObjectIterator(s)) {
+          for (auto it :
+               VPackObjectIterator(s, /*useSequentialIteration*/ true)) {
             auto childBuilder =
                 createTestStructure(it.value, path + "/" + it.key.copyString());
             if (childBuilder) {
-              builder->add(it.key.copyString(), childBuilder->slice());
+              builder->add(it.key.stringView(), childBuilder->slice());
             }
           }
 
@@ -1258,8 +1276,9 @@ TEST_F(MoveShardTest, if_the_to_server_no_longer_replica_we_should_abort) {
               VPackObjectBuilder b(&pendingJob);
               auto plainJob =
                   createJob(COLLECTION, SHARD_LEADER, SHARD_FOLLOWER1);
-              for (auto it : VPackObjectIterator(plainJob.slice())) {
-                pendingJob.add(it.key.copyString(), it.value);
+              for (auto it : VPackObjectIterator(
+                       plainJob.slice(), /*useSequentialIteration*/ true)) {
+                pendingJob.add(it.key.stringView(), it.value);
               }
               pendingJob.add("timeCreated", VPackValue("2015-01-03T20:00:00Z"));
             }
@@ -1311,7 +1330,8 @@ TEST_F(MoveShardTest,
         auto builder = std::make_unique<velocypack::Builder>();
         if (s.isObject()) {
           builder->add(VPackValue(VPackValueType::Object));
-          for (auto it : VPackObjectIterator(s)) {
+          for (auto it :
+               VPackObjectIterator(s, /*useSequentialIteration*/ true)) {
             auto childBuilder =
                 createTestStructure(it.value, path + "/" + it.key.copyString());
             if (childBuilder) {
@@ -1324,8 +1344,9 @@ TEST_F(MoveShardTest,
             {
               VPackObjectBuilder b(&pendingJob);
               auto plainJob = createJob("BOGUS", SHARD_FOLLOWER1, FREE_SERVER);
-              for (auto it : VPackObjectIterator(plainJob.slice())) {
-                pendingJob.add(it.key.copyString(), it.value);
+              for (auto it : VPackObjectIterator(
+                       plainJob.slice(), /*useSequentialIteration*/ true)) {
+                pendingJob.add(it.key.stringView(), it.value);
               }
               pendingJob.add("timeCreated",
                              VPackValue(timepointToString(
@@ -1368,13 +1389,14 @@ TEST_F(
         auto builder = std::make_unique<velocypack::Builder>();
         if (s.isObject()) {
           builder->add(VPackValue(VPackValueType::Object));
-          for (auto it : VPackObjectIterator(s)) {
+          for (auto it :
+               VPackObjectIterator(s, /*useSequentialIteration*/ true)) {
             auto childBuilder =
                 createTestStructure(it.value, path + "/" + it.key.copyString());
             if (childBuilder &&
                 !(path == "/arango/Plan/Collections/" + DATABASE &&
                   it.key.copyString() == COLLECTION)) {
-              builder->add(it.key.copyString(), childBuilder->slice());
+              builder->add(it.key.stringView(), childBuilder->slice());
             }
           }
 
@@ -1384,8 +1406,9 @@ TEST_F(
               VPackObjectBuilder b(&pendingJob);
               auto plainJob = createJob("ANUNKNOWNCOLLECTION", SHARD_FOLLOWER1,
                                         FREE_SERVER);
-              for (auto it : VPackObjectIterator(plainJob.slice())) {
-                pendingJob.add(it.key.copyString(), it.value);
+              for (auto it : VPackObjectIterator(
+                       plainJob.slice(), /*useSequentialIteration*/ true)) {
+                pendingJob.add(it.key.stringView(), it.value);
               }
               pendingJob.add("timeCreated",
                              VPackValue(timepointToString(
@@ -1428,11 +1451,12 @@ TEST_F(
         auto builder = std::make_unique<velocypack::Builder>();
         if (s.isObject()) {
           builder->add(VPackValue(VPackValueType::Object));
-          for (auto it : VPackObjectIterator(s)) {
+          for (auto it :
+               VPackObjectIterator(s, /*useSequentialIteration*/ true)) {
             auto childBuilder =
                 createTestStructure(it.value, path + "/" + it.key.copyString());
             if (childBuilder) {
-              builder->add(it.key.copyString(), childBuilder->slice());
+              builder->add(it.key.stringView(), childBuilder->slice());
             }
           }
 
@@ -1442,8 +1466,9 @@ TEST_F(
               VPackObjectBuilder b(&pendingJob);
               auto plainJob =
                   createJob(COLLECTION, SHARD_FOLLOWER1, FREE_SERVER);
-              for (auto it : VPackObjectIterator(plainJob.slice())) {
-                pendingJob.add(it.key.copyString(), it.value);
+              for (auto it : VPackObjectIterator(
+                       plainJob.slice(), /*useSequentialIteration*/ true)) {
+                pendingJob.add(it.key.stringView(), it.value);
               }
               pendingJob.add("timeCreated",
                              VPackValue(timepointToString(
@@ -1485,11 +1510,12 @@ TEST_F(MoveShardTest, if_the_job_is_done_it_should_properly_finish_itself) {
         auto builder = std::make_unique<velocypack::Builder>();
         if (s.isObject()) {
           builder->add(VPackValue(VPackValueType::Object));
-          for (auto it : VPackObjectIterator(s)) {
+          for (auto it :
+               VPackObjectIterator(s, /*useSequentialIteration*/ true)) {
             auto childBuilder =
                 createTestStructure(it.value, path + "/" + it.key.copyString());
             if (childBuilder) {
-              builder->add(it.key.copyString(), childBuilder->slice());
+              builder->add(it.key.stringView(), childBuilder->slice());
             }
           }
 
@@ -1499,8 +1525,9 @@ TEST_F(MoveShardTest, if_the_job_is_done_it_should_properly_finish_itself) {
               VPackObjectBuilder b(&pendingJob);
               auto plainJob =
                   createJob(COLLECTION, SHARD_FOLLOWER1, FREE_SERVER);
-              for (auto it : VPackObjectIterator(plainJob.slice())) {
-                pendingJob.add(it.key.copyString(), it.value);
+              for (auto it : VPackObjectIterator(
+                       plainJob.slice(), /*useSequentialIteration*/ true)) {
+                pendingJob.add(it.key.stringView(), it.value);
               }
               pendingJob.add("timeCreated",
                              VPackValue(timepointToString(
@@ -1581,11 +1608,12 @@ TEST_F(MoveShardTest,
         auto builder = std::make_unique<velocypack::Builder>();
         if (s.isObject()) {
           builder->add(VPackValue(VPackValueType::Object));
-          for (auto it : VPackObjectIterator(s)) {
+          for (auto it :
+               VPackObjectIterator(s, /*useSequentialIteration*/ true)) {
             auto childBuilder =
                 createTestStructure(it.value, path + "/" + it.key.copyString());
             if (childBuilder) {
-              builder->add(it.key.copyString(), childBuilder->slice());
+              builder->add(it.key.stringView(), childBuilder->slice());
             }
           }
 
@@ -1595,8 +1623,9 @@ TEST_F(MoveShardTest,
               VPackObjectBuilder b(&pendingJob);
               auto plainJob =
                   createJob(COLLECTION, SHARD_LEADER, SHARD_FOLLOWER1);
-              for (auto it : VPackObjectIterator(plainJob.slice())) {
-                pendingJob.add(it.key.copyString(), it.value);
+              for (auto it : VPackObjectIterator(
+                       plainJob.slice(), /*useSequentialIteration*/ true)) {
+                pendingJob.add(it.key.stringView(), it.value);
               }
               pendingJob.add("timeCreated",
                              VPackValue(timepointToString(
@@ -1679,11 +1708,12 @@ TEST_F(
         auto builder = std::make_unique<velocypack::Builder>();
         if (s.isObject()) {
           builder->add(VPackValue(VPackValueType::Object));
-          for (auto it : VPackObjectIterator(s)) {
+          for (auto it :
+               VPackObjectIterator(s, /*useSequentialIteration*/ true)) {
             auto childBuilder =
                 createTestStructure(it.value, path + "/" + it.key.copyString());
             if (childBuilder) {
-              builder->add(it.key.copyString(), childBuilder->slice());
+              builder->add(it.key.stringView(), childBuilder->slice());
             }
           }
 
@@ -1693,8 +1723,9 @@ TEST_F(
               VPackObjectBuilder b(&pendingJob);
               auto plainJob =
                   createJob(COLLECTION, SHARD_LEADER, SHARD_FOLLOWER1, true);
-              for (auto it : VPackObjectIterator(plainJob.slice())) {
-                pendingJob.add(it.key.copyString(), it.value);
+              for (auto it : VPackObjectIterator(
+                       plainJob.slice(), /*useSequentialIteration*/ true)) {
+                pendingJob.add(it.key.stringView(), it.value);
               }
               pendingJob.add("timeCreated",
                              VPackValue(timepointToString(
@@ -1785,11 +1816,12 @@ TEST_F(
         auto builder = std::make_unique<velocypack::Builder>();
         if (s.isObject()) {
           builder->add(VPackValue(VPackValueType::Object));
-          for (auto it : VPackObjectIterator(s)) {
+          for (auto it :
+               VPackObjectIterator(s, /*useSequentialIteration*/ true)) {
             auto childBuilder =
                 createTestStructure(it.value, path + "/" + it.key.copyString());
             if (childBuilder) {
-              builder->add(it.key.copyString(), childBuilder->slice());
+              builder->add(it.key.stringView(), childBuilder->slice());
             }
           }
 
@@ -1799,8 +1831,9 @@ TEST_F(
               VPackObjectBuilder b(&pendingJob);
               auto plainJob =
                   createJob(COLLECTION, SHARD_FOLLOWER1, FREE_SERVER);
-              for (auto it : VPackObjectIterator(plainJob.slice())) {
-                pendingJob.add(it.key.copyString(), it.value);
+              for (auto it : VPackObjectIterator(
+                       plainJob.slice(), /*useSequentialIteration*/ true)) {
+                pendingJob.add(it.key.stringView(), it.value);
               }
               pendingJob.add("timeCreated",
                              VPackValue(timepointToString(
@@ -1915,12 +1948,13 @@ TEST_F(
         auto builder = std::make_unique<velocypack::Builder>();
         if (s.isObject()) {
           builder->add(VPackValue(VPackValueType::Object));
-          for (auto it : VPackObjectIterator(s)) {
+          for (auto it :
+               VPackObjectIterator(s, /*useSequentialIteration*/ true)) {
             auto childBuilder =
                 createTestStructure(it.value, path + "/" + it.key.copyString());
             if (childBuilder && it.key.copyString() != COLLECTION &&
                 path != "/arango/Current/Collections/" + DATABASE) {
-              builder->add(it.key.copyString(), childBuilder->slice());
+              builder->add(it.key.stringView(), childBuilder->slice());
             }
           }
 
@@ -1930,8 +1964,9 @@ TEST_F(
               VPackObjectBuilder b(&pendingJob);
               auto plainJob =
                   createJob(COLLECTION, SHARD_FOLLOWER1, FREE_SERVER);
-              for (auto it : VPackObjectIterator(plainJob.slice())) {
-                pendingJob.add(it.key.copyString(), it.value);
+              for (auto it : VPackObjectIterator(
+                       plainJob.slice(), /*useSequentialIteration*/ true)) {
+                pendingJob.add(it.key.stringView(), it.value);
               }
               pendingJob.add("timeCreated",
                              VPackValue(timepointToString(
@@ -2132,11 +2167,12 @@ TEST_F(MoveShardTest,
         auto builder = std::make_unique<velocypack::Builder>();
         if (s.isObject()) {
           builder->add(VPackValue(VPackValueType::Object));
-          for (auto it : VPackObjectIterator(s)) {
+          for (auto it :
+               VPackObjectIterator(s, /*useSequentialIteration*/ true)) {
             auto childBuilder =
                 createTestStructure(it.value, path + "/" + it.key.copyString());
             if (childBuilder) {
-              builder->add(it.key.copyString(), childBuilder->slice());
+              builder->add(it.key.stringView(), childBuilder->slice());
             }
           }
 
@@ -2193,11 +2229,12 @@ TEST_F(
         auto builder = std::make_unique<velocypack::Builder>();
         if (s.isObject()) {
           builder->add(VPackValue(VPackValueType::Object));
-          for (auto it : VPackObjectIterator(s)) {
+          for (auto it :
+               VPackObjectIterator(s, /*useSequentialIteration*/ true)) {
             auto childBuilder =
                 createTestStructure(it.value, path + "/" + it.key.copyString());
             if (childBuilder) {
-              builder->add(it.key.copyString(), childBuilder->slice());
+              builder->add(it.key.stringView(), childBuilder->slice());
             }
           }
 
@@ -2294,11 +2331,12 @@ TEST_F(MoveShardTest,
         auto builder = std::make_unique<velocypack::Builder>();
         if (s.isObject()) {
           builder->add(VPackValue(VPackValueType::Object));
-          for (auto it : VPackObjectIterator(s)) {
+          for (auto it :
+               VPackObjectIterator(s, /*useSequentialIteration*/ true)) {
             auto childBuilder =
                 createTestStructure(it.value, path + "/" + it.key.copyString());
             if (childBuilder) {
-              builder->add(it.key.copyString(), childBuilder->slice());
+              builder->add(it.key.stringView(), childBuilder->slice());
             }
           }
 
@@ -2307,8 +2345,9 @@ TEST_F(MoveShardTest,
             {
               VPackObjectBuilder b(&pendingJob);
               auto plainJob = createJob(COLLECTION, SHARD_LEADER, FREE_SERVER);
-              for (auto it : VPackObjectIterator(plainJob.slice())) {
-                pendingJob.add(it.key.copyString(), it.value);
+              for (auto it : VPackObjectIterator(
+                       plainJob.slice(), /*useSequentialIteration*/ true)) {
+                pendingJob.add(it.key.stringView(), it.value);
               }
               pendingJob.add("timeCreated",
                              VPackValue(timepointToString(
@@ -2425,11 +2464,12 @@ TEST_F(MoveShardTest, if_current_entry_missing_nothing_should_happen) {
         auto builder = std::make_unique<velocypack::Builder>();
         if (s.isObject()) {
           builder->add(VPackValue(VPackValueType::Object));
-          for (auto it : VPackObjectIterator(s)) {
+          for (auto it :
+               VPackObjectIterator(s, /*useSequentialIteration*/ true)) {
             auto childBuilder =
                 createTestStructure(it.value, path + "/" + it.key.copyString());
             if (childBuilder) {
-              builder->add(it.key.copyString(), childBuilder->slice());
+              builder->add(it.key.stringView(), childBuilder->slice());
             }
           }
 
@@ -2438,8 +2478,9 @@ TEST_F(MoveShardTest, if_current_entry_missing_nothing_should_happen) {
             {
               VPackObjectBuilder b(&pendingJob);
               auto plainJob = createJob(COLLECTION, SHARD_LEADER, FREE_SERVER);
-              for (auto it : VPackObjectIterator(plainJob.slice())) {
-                pendingJob.add(it.key.copyString(), it.value);
+              for (auto it : VPackObjectIterator(
+                       plainJob.slice(), /*useSequentialIteration*/ true)) {
+                pendingJob.add(it.key.stringView(), it.value);
               }
               pendingJob.add("timeCreated",
                              VPackValue(timepointToString(
@@ -2490,11 +2531,12 @@ TEST_F(MoveShardTest,
         auto builder = std::make_unique<velocypack::Builder>();
         if (s.isObject()) {
           builder->add(VPackValue(VPackValueType::Object));
-          for (auto it : VPackObjectIterator(s)) {
+          for (auto it :
+               VPackObjectIterator(s, /*useSequentialIteration*/ true)) {
             auto childBuilder =
                 createTestStructure(it.value, path + "/" + it.key.copyString());
             if (childBuilder) {
-              builder->add(it.key.copyString(), childBuilder->slice());
+              builder->add(it.key.stringView(), childBuilder->slice());
             }
           }
 
@@ -2503,8 +2545,9 @@ TEST_F(MoveShardTest,
             {
               VPackObjectBuilder b(&pendingJob);
               auto plainJob = createJob(COLLECTION, SHARD_LEADER, FREE_SERVER);
-              for (auto it : VPackObjectIterator(plainJob.slice())) {
-                pendingJob.add(it.key.copyString(), it.value);
+              for (auto it : VPackObjectIterator(
+                       plainJob.slice(), /*useSequentialIteration*/ true)) {
+                pendingJob.add(it.key.stringView(), it.value);
               }
               pendingJob.add("timeCreated",
                              VPackValue(timepointToString(
@@ -2560,11 +2603,12 @@ TEST_F(
         auto builder = std::make_unique<velocypack::Builder>();
         if (s.isObject()) {
           builder->add(VPackValue(VPackValueType::Object));
-          for (auto it : VPackObjectIterator(s)) {
+          for (auto it :
+               VPackObjectIterator(s, /*useSequentialIteration*/ true)) {
             auto childBuilder =
                 createTestStructure(it.value, path + "/" + it.key.copyString());
             if (childBuilder) {
-              builder->add(it.key.copyString(), childBuilder->slice());
+              builder->add(it.key.stringView(), childBuilder->slice());
             }
           }
 
@@ -2573,8 +2617,9 @@ TEST_F(
             {
               VPackObjectBuilder b(&pendingJob);
               auto plainJob = createJob(COLLECTION, SHARD_LEADER, FREE_SERVER);
-              for (auto it : VPackObjectIterator(plainJob.slice())) {
-                pendingJob.add(it.key.copyString(), it.value);
+              for (auto it : VPackObjectIterator(
+                       plainJob.slice(), /*useSequentialIteration*/ true)) {
+                pendingJob.add(it.key.stringView(), it.value);
               }
               pendingJob.add("timeCreated",
                              VPackValue(timepointToString(
@@ -2670,11 +2715,12 @@ TEST_F(
         auto builder = std::make_unique<velocypack::Builder>();
         if (s.isObject()) {
           builder->add(VPackValue(VPackValueType::Object));
-          for (auto const& it : VPackObjectIterator(s)) {
+          for (auto it :
+               VPackObjectIterator(s, /*useSequentialIteration*/ true)) {
             auto childBuilder =
                 createTestStructure(it.value, path + "/" + it.key.copyString());
             if (childBuilder) {
-              builder->add(it.key.copyString(), childBuilder->slice());
+              builder->add(it.key.stringView(), childBuilder->slice());
             }
           }
 
@@ -2683,8 +2729,9 @@ TEST_F(
             {
               VPackObjectBuilder b(&pendingJob);
               auto plainJob = createJob(COLLECTION, SHARD_LEADER, FREE_SERVER);
-              for (auto const& it : VPackObjectIterator(plainJob.slice())) {
-                pendingJob.add(it.key.copyString(), it.value);
+              for (auto it : VPackObjectIterator(
+                       plainJob.slice(), /*useSequentialIteration*/ true)) {
+                pendingJob.add(it.key.stringView(), it.value);
               }
               pendingJob.add("timeCreated",
                              VPackValue(timepointToString(
@@ -2760,11 +2807,12 @@ TEST_F(
         auto builder = std::make_unique<velocypack::Builder>();
         if (s.isObject()) {
           builder->add(VPackValue(VPackValueType::Object));
-          for (auto it : VPackObjectIterator(s)) {
+          for (auto it :
+               VPackObjectIterator(s, /*useSequentialIteration*/ true)) {
             auto childBuilder =
                 createTestStructure(it.value, path + "/" + it.key.copyString());
             if (childBuilder) {
-              builder->add(it.key.copyString(), childBuilder->slice());
+              builder->add(it.key.stringView(), childBuilder->slice());
             }
           }
 
@@ -2773,8 +2821,9 @@ TEST_F(
             {
               VPackObjectBuilder b(&pendingJob);
               auto plainJob = createJob(COLLECTION, SHARD_LEADER, FREE_SERVER);
-              for (auto it : VPackObjectIterator(plainJob.slice())) {
-                pendingJob.add(it.key.copyString(), it.value);
+              for (auto it : VPackObjectIterator(
+                       plainJob.slice(), /*useSequentialIteration*/ true)) {
+                pendingJob.add(it.key.stringView(), it.value);
               }
               pendingJob.add("timeCreated",
                              VPackValue(timepointToString(
@@ -2887,11 +2936,12 @@ TEST_F(MoveShardTest, if_the_new_leader_took_over_finish_the_job) {
         auto builder = std::make_unique<velocypack::Builder>();
         if (s.isObject()) {
           builder->add(VPackValue(VPackValueType::Object));
-          for (auto it : VPackObjectIterator(s)) {
+          for (auto it :
+               VPackObjectIterator(s, /*useSequentialIteration*/ true)) {
             auto childBuilder =
                 createTestStructure(it.value, path + "/" + it.key.copyString());
             if (childBuilder) {
-              builder->add(it.key.copyString(), childBuilder->slice());
+              builder->add(it.key.stringView(), childBuilder->slice());
             }
           }
 
@@ -2900,8 +2950,9 @@ TEST_F(MoveShardTest, if_the_new_leader_took_over_finish_the_job) {
             {
               VPackObjectBuilder b(&pendingJob);
               auto plainJob = createJob(COLLECTION, SHARD_LEADER, FREE_SERVER);
-              for (auto it : VPackObjectIterator(plainJob.slice())) {
-                pendingJob.add(it.key.copyString(), it.value);
+              for (auto it : VPackObjectIterator(
+                       plainJob.slice(), /*useSequentialIteration*/ true)) {
+                pendingJob.add(it.key.stringView(), it.value);
               }
               pendingJob.add("timeCreated",
                              VPackValue(timepointToString(
@@ -3100,11 +3151,12 @@ TEST_F(
         auto builder = std::make_unique<velocypack::Builder>();
         if (s.isObject()) {
           builder->add(VPackValue(VPackValueType::Object));
-          for (auto it : VPackObjectIterator(s)) {
+          for (auto it :
+               VPackObjectIterator(s, /*useSequentialIteration*/ true)) {
             auto childBuilder =
                 createTestStructure(it.value, path + "/" + it.key.copyString());
             if (childBuilder) {
-              builder->add(it.key.copyString(), childBuilder->slice());
+              builder->add(it.key.stringView(), childBuilder->slice());
             }
           }
 
@@ -3205,11 +3257,12 @@ TEST_F(MoveShardTest, if_aborting_failed_report_it_back_properly) {
         auto builder = std::make_unique<velocypack::Builder>();
         if (s.isObject()) {
           builder->add(VPackValue(VPackValueType::Object));
-          for (auto it : VPackObjectIterator(s)) {
+          for (auto it :
+               VPackObjectIterator(s, /*useSequentialIteration*/ true)) {
             auto childBuilder =
                 createTestStructure(it.value, path + "/" + it.key.copyString());
             if (childBuilder) {
-              builder->add(it.key.copyString(), childBuilder->slice());
+              builder->add(it.key.stringView(), childBuilder->slice());
             }
           }
 
@@ -3273,11 +3326,12 @@ TEST_F(MoveShardTest,
         auto builder = std::make_unique<velocypack::Builder>();
         if (s.isObject()) {
           builder->add(VPackValue(VPackValueType::Object));
-          for (auto it : VPackObjectIterator(s)) {
+          for (auto it :
+               VPackObjectIterator(s, /*useSequentialIteration*/ true)) {
             auto childBuilder =
                 createTestStructure(it.value, path + "/" + it.key.copyString());
             if (childBuilder) {
-              builder->add(it.key.copyString(), childBuilder->slice());
+              builder->add(it.key.stringView(), childBuilder->slice());
             }
           }
 
@@ -3340,11 +3394,12 @@ TEST_F(MoveShardTest, trying_to_abort_a_finished_should_result_in_failure) {
         auto builder = std::make_unique<velocypack::Builder>();
         if (s.isObject()) {
           builder->add(VPackValue(VPackValueType::Object));
-          for (auto it : VPackObjectIterator(s)) {
+          for (auto it :
+               VPackObjectIterator(s, /*useSequentialIteration*/ true)) {
             auto childBuilder =
                 createTestStructure(it.value, path + "/" + it.key.copyString());
             if (childBuilder) {
-              builder->add(it.key.copyString(), childBuilder->slice());
+              builder->add(it.key.stringView(), childBuilder->slice());
             }
           }
 
@@ -3407,11 +3462,12 @@ TEST_F(MoveShardTest, test_cancel_pending_job) {
         auto builder = std::make_unique<velocypack::Builder>();
         if (s.isObject()) {
           builder->add(VPackValue(VPackValueType::Object));
-          for (auto it : VPackObjectIterator(s)) {
+          for (auto it :
+               VPackObjectIterator(s, /*useSequentialIteration*/ true)) {
             auto childBuilder =
                 createTestStructure(it.value, path + "/" + it.key.copyString());
             if (childBuilder) {
-              builder->add(it.key.copyString(), childBuilder->slice());
+              builder->add(it.key.stringView(), childBuilder->slice());
             }
           }
 
@@ -3420,8 +3476,9 @@ TEST_F(MoveShardTest, test_cancel_pending_job) {
             {
               VPackObjectBuilder b(&pendingJob);
               auto plainJob = createJob(COLLECTION, SHARD_LEADER, FREE_SERVER);
-              for (auto it : VPackObjectIterator(plainJob.slice())) {
-                pendingJob.add(it.key.copyString(), it.value);
+              for (auto it : VPackObjectIterator(
+                       plainJob.slice(), /*useSequentialIteration*/ true)) {
+                pendingJob.add(it.key.stringView(), it.value);
               }
               pendingJob.add("abort", VPackValue(true));
             }
@@ -3465,11 +3522,12 @@ TEST_F(MoveShardTest, test_cancel_todo_job) {
         auto builder = std::make_unique<velocypack::Builder>();
         if (s.isObject()) {
           builder->add(VPackValue(VPackValueType::Object));
-          for (auto it : VPackObjectIterator(s)) {
+          for (auto it :
+               VPackObjectIterator(s, /*useSequentialIteration*/ true)) {
             auto childBuilder =
                 createTestStructure(it.value, path + "/" + it.key.copyString());
             if (childBuilder) {
-              builder->add(it.key.copyString(), childBuilder->slice());
+              builder->add(it.key.stringView(), childBuilder->slice());
             }
           }
 
@@ -3478,8 +3536,9 @@ TEST_F(MoveShardTest, test_cancel_todo_job) {
             {
               VPackObjectBuilder b(&pendingJob);
               auto plainJob = createJob(COLLECTION, SHARD_LEADER, FREE_SERVER);
-              for (auto it : VPackObjectIterator(plainJob.slice())) {
-                pendingJob.add(it.key.copyString(), it.value);
+              for (auto it : VPackObjectIterator(
+                       plainJob.slice(), /*useSequentialIteration*/ true)) {
+                pendingJob.add(it.key.stringView(), it.value);
               }
               pendingJob.add("abort", VPackValue(true));
             }
@@ -3525,11 +3584,12 @@ TEST_F(
         auto builder = std::make_unique<velocypack::Builder>();
         if (s.isObject()) {
           builder->add(VPackValue(VPackValueType::Object));
-          for (auto it : VPackObjectIterator(s)) {
+          for (auto it :
+               VPackObjectIterator(s, /*useSequentialIteration*/ true)) {
             auto childBuilder =
                 createTestStructure(it.value, path + "/" + it.key.copyString());
             if (childBuilder) {
-              builder->add(it.key.copyString(), childBuilder->slice());
+              builder->add(it.key.stringView(), childBuilder->slice());
             }
           }
 
@@ -3538,8 +3598,9 @@ TEST_F(
             {
               VPackObjectBuilder b(&pendingJob);
               auto plainJob = createJob(COLLECTION, SHARD_LEADER, FREE_SERVER);
-              for (auto it : VPackObjectIterator(plainJob.slice())) {
-                pendingJob.add(it.key.copyString(), it.value);
+              for (auto it : VPackObjectIterator(
+                       plainJob.slice(), /*useSequentialIteration*/ true)) {
+                pendingJob.add(it.key.stringView(), it.value);
               }
               pendingJob.add("timeCreated",
                              VPackValue(timepointToString(

--- a/tests/Agency/RemoveFollowerTest.cpp
+++ b/tests/Agency/RemoveFollowerTest.cpp
@@ -180,11 +180,11 @@ TEST_F(RemoveFollowerTest,
 
     if (s.isObject()) {
       VPackObjectBuilder b(builder.get());
-      for (auto it : VPackObjectIterator(s)) {
+      for (auto it : VPackObjectIterator(s, /*useSequentialIteration*/ true)) {
         auto childBuilder =
             createTestStructure(it.value, path + "/" + it.key.copyString());
         if (childBuilder) {
-          builder->add(it.key.copyString(), childBuilder->slice());
+          builder->add(it.key.stringView(), childBuilder->slice());
         }
       }
       if (path == "/arango/Target/ToDo") {
@@ -238,11 +238,11 @@ TEST_F(
     std::unique_ptr<Builder> builder = std::make_unique<Builder>();
     if (s.isObject()) {
       VPackObjectBuilder b(builder.get());
-      for (auto it : VPackObjectIterator(s)) {
+      for (auto it : VPackObjectIterator(s, /*useSequentialIteration*/ true)) {
         auto childBuilder =
             createTestStructure(it.value, path + "/" + it.key.copyString());
         if (childBuilder) {
-          builder->add(it.key.copyString(), childBuilder->slice());
+          builder->add(it.key.stringView(), childBuilder->slice());
         }
       }
       if (path == "/arango/Plan/Collections/" + DATABASE + "/" + COLLECTION) {
@@ -296,11 +296,11 @@ TEST_F(RemoveFollowerTest,
     std::unique_ptr<Builder> builder = std::make_unique<Builder>();
     if (s.isObject()) {
       VPackObjectBuilder b(builder.get());
-      for (auto it : VPackObjectIterator(s)) {
+      for (auto it : VPackObjectIterator(s, /*useSequentialIteration*/ true)) {
         auto childBuilder =
             createTestStructure(it.value, path + "/" + it.key.copyString());
         if (childBuilder) {
-          builder->add(it.key.copyString(), childBuilder->slice());
+          builder->add(it.key.stringView(), childBuilder->slice());
         }
       }
       if (path == "/arango/Target/ToDo") {
@@ -363,11 +363,11 @@ TEST_F(
     std::unique_ptr<Builder> builder = std::make_unique<Builder>();
     if (s.isObject()) {
       VPackObjectBuilder b(builder.get());
-      for (auto it : VPackObjectIterator(s)) {
+      for (auto it : VPackObjectIterator(s, /*useSequentialIteration*/ true)) {
         auto childBuilder =
             createTestStructure(it.value, path + "/" + it.key.copyString());
         if (childBuilder) {
-          builder->add(it.key.copyString(), childBuilder->slice());
+          builder->add(it.key.stringView(), childBuilder->slice());
         }
       }
       if (path == "/arango/Target/ToDo") {
@@ -430,11 +430,11 @@ TEST_F(RemoveFollowerTest, all_good_should_remove_folower) {
     std::unique_ptr<Builder> builder = std::make_unique<Builder>();
     if (s.isObject()) {
       VPackObjectBuilder b(builder.get());
-      for (auto it : VPackObjectIterator(s)) {
+      for (auto it : VPackObjectIterator(s, /*useSequentialIteration*/ true)) {
         auto childBuilder =
             createTestStructure(it.value, path + "/" + it.key.copyString());
         if (childBuilder) {
-          builder->add(it.key.copyString(), childBuilder->slice());
+          builder->add(it.key.stringView(), childBuilder->slice());
         }
       }
       if (path == "/arango/Target/ToDo") {
@@ -494,11 +494,11 @@ TEST(RemoveFollowerLargeTest, an_agency_with_12_dbservers) {
     std::unique_ptr<Builder> builder = std::make_unique<Builder>();
     if (s.isObject()) {
       VPackObjectBuilder b(builder.get());
-      for (auto it : VPackObjectIterator(s)) {
+      for (auto it : VPackObjectIterator(s, /*useSequentialIteration*/ true)) {
         auto childBuilder =
             createTestStructure(it.value, path + "/" + it.key.copyString());
         if (childBuilder) {
-          builder->add(it.key.copyString(), childBuilder->slice());
+          builder->add(it.key.stringView(), childBuilder->slice());
         }
       }
       if (path == "/arango/Target/ToDo") {

--- a/tests/Agency/SupervisionTest.cpp
+++ b/tests/Agency/SupervisionTest.cpp
@@ -367,7 +367,8 @@ TEST_F(SupervisionTestClass, schedule_addfollower_rf_3) {
 static std::unordered_map<std::string, std::string> tableOfJobs(
     VPackSlice envelope) {
   std::unordered_map<std::string, std::string> res;
-  for (auto const& p : VPackObjectIterator(envelope)) {
+  for (auto p :
+       VPackObjectIterator(envelope, /*useSequentialIteration*/ true)) {
     res.emplace(
         std::pair(p.value.get("collection").copyString(), p.key.copyString()));
   }

--- a/tests/Aql/EnumeratePathsExecutorTest.cpp
+++ b/tests/Aql/EnumeratePathsExecutorTest.cpp
@@ -375,8 +375,8 @@ class EnumeratePathsExecutorTest : public ::testing::Test {
           while (verticesExpected != std::end(pathExpected) &&
                  verticesResult != verticesResult.end()) {
             ASSERT_EQ((*verticesResult).copyString(), *verticesExpected);
-            verticesResult++;
-            verticesExpected++;
+            ++verticesResult;
+            ++verticesExpected;
           }
           ASSERT_TRUE((verticesExpected == std::end(pathExpected)) &&
                       // Yes, really, they didn't implement == for iterators

--- a/tests/Aql/ExecutionBlockImplTest.cpp
+++ b/tests/Aql/ExecutionBlockImplTest.cpp
@@ -1570,7 +1570,7 @@ class ExecutionBlockImplExecuteIntegrationTest
 
     for (size_t i = 0; i < offset; ++i) {
       // The first have been skipped
-      expectedIt++;
+      ++expectedIt;
     }
     size_t limit = (std::min)(call.getLimit(),
                               static_cast<size_t>(expected.length()) - offset);
@@ -1584,7 +1584,7 @@ class ExecutionBlockImplExecuteIntegrationTest
             << "Expected: " << expectedIt.value().toJson()
             << " got: " << got.toJson() << " in row " << i << " and register "
             << testReg.value();
-        expectedIt++;
+        ++expectedIt;
       }
     } else {
       EXPECT_EQ(limit, 0);
@@ -2084,7 +2084,7 @@ TEST_P(ExecutionBlockImplExecuteIntegrationTest,
         EXPECT_EQ(state, ExecutionState::HASMORE);
       }
 
-      it++;
+      ++it;
     }
   }
 }  // namespace aql

--- a/tests/Aql/QueryHelper.cpp
+++ b/tests/Aql/QueryHelper.cpp
@@ -45,16 +45,18 @@ auto vpackHasNoneRecursive(VPackSlice slice) -> bool {
   }
 
   if (slice.isArray()) {
-    auto iter = VPackArrayIterator(slice);
-    return std::any_of(iter.begin(), iter.end(),
-                       [](auto slice) { return vpackHasNoneRecursive(slice); });
-  }
-  if (slice.isObject()) {
-    auto iter = VPackObjectIterator(slice);
-    return std::any_of(iter.begin(), iter.end(), [](auto pair) {
-      return vpackHasNoneRecursive(pair.key) ||
-             vpackHasNoneRecursive(pair.value);
-    });
+    for (auto it : VPackArrayIterator(slice)) {
+      if (vpackHasNoneRecursive(it)) {
+        return true;
+      }
+    }
+  } else if (slice.isObject()) {
+    for (auto it :
+         VPackObjectIterator(slice, /*useSequentialIteration*/ true)) {
+      if (vpackHasNoneRecursive(it.value)) {
+        return true;
+      }
+    }
   }
 
   return false;

--- a/tests/HotBackup/HotBackupCoordinatorTest.cpp
+++ b/tests/HotBackup/HotBackupCoordinatorTest.cpp
@@ -104,7 +104,8 @@ TEST_F(HotBackupOnCoordinators, test_dbserver_matching) {
   std::vector<ServerID> dbServers;
   std::map<ServerID, ServerID> matches;
 
-  for (auto const& i : VPackObjectIterator(plan.get(dbsPath))) {
+  for (auto i : VPackObjectIterator(plan.get(dbsPath),
+                                    /*useSequentialIteration*/ false)) {
     dbServers.push_back(i.key.copyString());
   }
 
@@ -120,7 +121,8 @@ TEST_F(HotBackupOnCoordinators, test_first_dbserver_new) {
   std::vector<ServerID> dbServers;
   std::map<ServerID, ServerID> matches;
 
-  for (auto const& i : VPackObjectIterator(plan.get(dbsPath))) {
+  for (auto i : VPackObjectIterator(plan.get(dbsPath),
+                                    /*useSequentialIteration*/ false)) {
     dbServers.push_back(i.key.copyString());
   }
 
@@ -140,7 +142,8 @@ TEST_F(HotBackupOnCoordinators, test_last_dbserver_new) {
   std::vector<ServerID> dbServers;
   std::map<ServerID, ServerID> matches;
 
-  for (auto const& i : VPackObjectIterator(plan.get(dbsPath))) {
+  for (auto i : VPackObjectIterator(plan.get(dbsPath),
+                                    /*useSequentialIteration*/ false)) {
     dbServers.push_back(i.key.copyString());
   }
 
@@ -160,7 +163,8 @@ TEST_F(HotBackupOnCoordinators, test_first_and_last_dbserver_new) {
   std::vector<ServerID> dbServers;
   std::map<ServerID, ServerID> matches;
 
-  for (auto const& i : VPackObjectIterator(plan.get(dbsPath))) {
+  for (auto i : VPackObjectIterator(plan.get(dbsPath),
+                                    /*useSequentialIteration*/ false)) {
     dbServers.push_back(i.key.copyString());
   }
 
@@ -201,7 +205,8 @@ TEST_F(HotBackupOnCoordinators, test_one_more_local_server_than_in_backup) {
   std::vector<ServerID> dbServers;
   std::map<ServerID, ServerID> matches;
 
-  for (auto const& i : VPackObjectIterator(plan.get(dbsPath))) {
+  for (auto i : VPackObjectIterator(plan.get(dbsPath),
+                                    /*useSequentialIteration*/ false)) {
     dbServers.push_back(i.key.copyString());
   }
   dbServers.push_back(
@@ -220,7 +225,8 @@ TEST_F(HotBackupOnCoordinators, test_one_less_local_server_than_in_backup) {
   std::vector<ServerID> dbServers;
   std::map<ServerID, ServerID> matches;
 
-  for (auto const& i : VPackObjectIterator(plan.get(dbsPath))) {
+  for (auto i : VPackObjectIterator(plan.get(dbsPath),
+                                    /*useSequentialIteration*/ false)) {
     dbServers.push_back(i.key.copyString());
   }
   dbServers.pop_back();
@@ -238,7 +244,8 @@ TEST_F(HotBackupOnCoordinators,
   std::vector<ServerID> dbServers;
   std::map<ServerID, ServerID> matches;
 
-  for (auto const& i : VPackObjectIterator(plan.get(dbsPath))) {
+  for (auto i : VPackObjectIterator(plan.get(dbsPath),
+                                    /*useSequentialIteration*/ false)) {
     dbServers.push_back(i.key.copyString());
   }
   dbServers.front() =
@@ -268,7 +275,8 @@ TEST_F(HotBackupOnCoordinators,
   std::vector<ServerID> dbServers;
   std::map<ServerID, ServerID> matches;
 
-  for (auto const& i : VPackObjectIterator(plan.get(dbsPath))) {
+  for (auto i : VPackObjectIterator(plan.get(dbsPath),
+                                    /*useSequentialIteration*/ false)) {
     dbServers.push_back(i.key.copyString());
   }
   dbServers.front() =

--- a/tests/IResearch/IResearchLinkMetaTest.cpp
+++ b/tests/IResearch/IResearchLinkMetaTest.cpp
@@ -800,8 +800,9 @@ TEST_F(IResearchLinkMetaTest, test_writeCustomizedValues) {
     tmpSlice = slice.get("fields");
     EXPECT_TRUE(tmpSlice.isObject() && 3 == tmpSlice.length());
 
-    for (arangodb::velocypack::ObjectIterator itr(tmpSlice); itr.valid();
-         ++itr) {
+    for (arangodb::velocypack::ObjectIterator itr(
+             tmpSlice, /*useSequentialIteration*/ true);
+         itr.valid(); ++itr) {
       auto key = itr.key();
       auto value = itr.value();
       EXPECT_TRUE(key.isString() &&
@@ -814,7 +815,8 @@ TEST_F(IResearchLinkMetaTest, test_writeCustomizedValues) {
 
       tmpSlice = value.get("fields");
 
-      for (arangodb::velocypack::ObjectIterator overrideItr(tmpSlice);
+      for (arangodb::velocypack::ObjectIterator overrideItr(
+               tmpSlice, /*useSequentialIteration*/ true);
            overrideItr.valid(); ++overrideItr) {
         auto fieldOverride = overrideItr.key();
         auto sliceOverride = overrideItr.value();
@@ -838,7 +840,8 @@ TEST_F(IResearchLinkMetaTest, test_writeCustomizedValues) {
           EXPECT_EQ(5U, sliceOverride.length());
           tmpSlice = sliceOverride.get("fields");
           EXPECT_TRUE(tmpSlice.isObject() && 2 == tmpSlice.length());
-          for (arangodb::velocypack::ObjectIterator overrideFieldItr(tmpSlice);
+          for (arangodb::velocypack::ObjectIterator overrideFieldItr(
+                   tmpSlice, /*useSequentialIteration*/ true);
                overrideFieldItr.valid(); ++overrideFieldItr) {
             EXPECT_TRUE(
                 overrideFieldItr.key().isString() &&
@@ -923,8 +926,9 @@ TEST_F(IResearchLinkMetaTest, test_writeCustomizedValues) {
     tmpSlice = slice.get("fields");
     EXPECT_TRUE(tmpSlice.isObject() && 3 == tmpSlice.length());
 
-    for (arangodb::velocypack::ObjectIterator itr(tmpSlice); itr.valid();
-         ++itr) {
+    for (arangodb::velocypack::ObjectIterator itr(
+             tmpSlice, /*useSequentialIteration*/ true);
+         itr.valid(); ++itr) {
       auto key = itr.key();
       auto value = itr.value();
       EXPECT_TRUE(key.isString() &&
@@ -937,7 +941,8 @@ TEST_F(IResearchLinkMetaTest, test_writeCustomizedValues) {
 
       tmpSlice = value.get("fields");
 
-      for (arangodb::velocypack::ObjectIterator overrideItr(tmpSlice);
+      for (arangodb::velocypack::ObjectIterator overrideItr(
+               tmpSlice, /*useSequentialIteration*/ true);
            overrideItr.valid(); ++overrideItr) {
         auto fieldOverride = overrideItr.key();
         auto sliceOverride = overrideItr.value();
@@ -962,7 +967,8 @@ TEST_F(IResearchLinkMetaTest, test_writeCustomizedValues) {
           EXPECT_EQ(5U, sliceOverride.length());
           tmpSlice = sliceOverride.get("fields");
           EXPECT_TRUE(tmpSlice.isObject() && 2 == tmpSlice.length());
-          for (arangodb::velocypack::ObjectIterator overrideFieldItr(tmpSlice);
+          for (arangodb::velocypack::ObjectIterator overrideFieldItr(
+                   tmpSlice, /*useSequentialIteration*/ true);
                overrideFieldItr.valid(); ++overrideFieldItr) {
             EXPECT_TRUE((true == overrideFieldItr.key().isString() &&
                          1 == expectedFields.erase(
@@ -1075,8 +1081,9 @@ TEST_F(IResearchLinkMetaTest, test_writeCustomizedValues) {
     tmpSlice = slice.get("fields");
     EXPECT_TRUE(tmpSlice.isObject() && 3 == tmpSlice.length());
 
-    for (arangodb::velocypack::ObjectIterator itr(tmpSlice); itr.valid();
-         ++itr) {
+    for (arangodb::velocypack::ObjectIterator itr(
+             tmpSlice, /*useSequentialIteration*/ true);
+         itr.valid(); ++itr) {
       auto key = itr.key();
       auto value = itr.value();
       EXPECT_TRUE(key.isString() &&
@@ -1089,7 +1096,8 @@ TEST_F(IResearchLinkMetaTest, test_writeCustomizedValues) {
 
       tmpSlice = value.get("fields");
 
-      for (arangodb::velocypack::ObjectIterator overrideItr(tmpSlice);
+      for (arangodb::velocypack::ObjectIterator overrideItr(
+               tmpSlice, /*useSequentialIteration*/ true);
            overrideItr.valid(); ++overrideItr) {
         auto fieldOverride = overrideItr.key();
         auto sliceOverride = overrideItr.value();
@@ -1114,7 +1122,8 @@ TEST_F(IResearchLinkMetaTest, test_writeCustomizedValues) {
           EXPECT_EQ(5U, sliceOverride.length());
           tmpSlice = sliceOverride.get("fields");
           EXPECT_TRUE(tmpSlice.isObject() && 2 == tmpSlice.length());
-          for (arangodb::velocypack::ObjectIterator overrideFieldItr(tmpSlice);
+          for (arangodb::velocypack::ObjectIterator overrideFieldItr(
+                   tmpSlice, /*useSequentialIteration*/ true);
                overrideFieldItr.valid(); ++overrideFieldItr) {
             EXPECT_TRUE((true == overrideFieldItr.key().isString() &&
                          1 == expectedFields.erase(
@@ -1199,8 +1208,9 @@ TEST_F(IResearchLinkMetaTest, test_writeCustomizedValues) {
     tmpSlice = slice.get("fields");
     EXPECT_TRUE(tmpSlice.isObject() && 3 == tmpSlice.length());
 
-    for (arangodb::velocypack::ObjectIterator itr(tmpSlice); itr.valid();
-         ++itr) {
+    for (arangodb::velocypack::ObjectIterator itr(
+             tmpSlice, /*useSequentialIteration*/ true);
+         itr.valid(); ++itr) {
       auto key = itr.key();
       auto value = itr.value();
       EXPECT_TRUE(key.isString() &&
@@ -1213,7 +1223,8 @@ TEST_F(IResearchLinkMetaTest, test_writeCustomizedValues) {
 
       tmpSlice = value.get("fields");
 
-      for (arangodb::velocypack::ObjectIterator overrideItr(tmpSlice);
+      for (arangodb::velocypack::ObjectIterator overrideItr(
+               tmpSlice, /*useSequentialIteration*/ true);
            overrideItr.valid(); ++overrideItr) {
         auto fieldOverride = overrideItr.key();
         auto sliceOverride = overrideItr.value();
@@ -1238,7 +1249,8 @@ TEST_F(IResearchLinkMetaTest, test_writeCustomizedValues) {
           EXPECT_EQ(5U, sliceOverride.length());
           tmpSlice = sliceOverride.get("fields");
           EXPECT_TRUE(tmpSlice.isObject() && 2 == tmpSlice.length());
-          for (arangodb::velocypack::ObjectIterator overrideFieldItr(tmpSlice);
+          for (arangodb::velocypack::ObjectIterator overrideFieldItr(
+                   tmpSlice, /*useSequentialIteration*/ true);
                overrideFieldItr.valid(); ++overrideFieldItr) {
             EXPECT_TRUE((true == overrideFieldItr.key().isString() &&
                          1 == expectedFields.erase(

--- a/tests/IResearch/IResearchViewCoordinatorTest.cpp
+++ b/tests/IResearch/IResearchViewCoordinatorTest.cpp
@@ -3169,7 +3169,7 @@ TEST_F(IResearchViewCoordinatorTest, test_update_links_partial_remove) {
         properties.get(arangodb::iresearch::StaticStrings::LinksField);
     EXPECT_TRUE(linksSlice.isObject());
 
-    VPackObjectIterator it(linksSlice);
+    VPackObjectIterator it(linksSlice, /*useSequentialIteration*/ true);
     EXPECT_TRUE(it.valid());
     EXPECT_TRUE(3 == it.size());
 
@@ -3469,7 +3469,7 @@ TEST_F(IResearchViewCoordinatorTest, test_update_links_partial_remove) {
         properties.get(arangodb::iresearch::StaticStrings::LinksField);
     EXPECT_TRUE(linksSlice.isObject());
 
-    VPackObjectIterator it(linksSlice);
+    VPackObjectIterator it(linksSlice, /*useSequentialIteration*/ true);
     EXPECT_TRUE(it.valid());
     EXPECT_TRUE(2 == it.size());
 
@@ -3843,7 +3843,7 @@ TEST_F(IResearchViewCoordinatorTest, test_update_links_partial_add) {
         properties.get(arangodb::iresearch::StaticStrings::LinksField);
     EXPECT_TRUE(linksSlice.isObject());
 
-    VPackObjectIterator it(linksSlice);
+    VPackObjectIterator it(linksSlice, /*useSequentialIteration*/ true);
     EXPECT_TRUE(it.valid());
     EXPECT_TRUE(2 == it.size());
 
@@ -4069,7 +4069,7 @@ TEST_F(IResearchViewCoordinatorTest, test_update_links_partial_add) {
         properties.get(arangodb::iresearch::StaticStrings::LinksField);
     EXPECT_TRUE(linksSlice.isObject());
 
-    VPackObjectIterator it(linksSlice);
+    VPackObjectIterator it(linksSlice, /*useSequentialIteration*/ true);
     EXPECT_TRUE(it.valid());
     EXPECT_TRUE(3 == it.size());
 
@@ -4588,7 +4588,7 @@ TEST_F(IResearchViewCoordinatorTest, test_update_links_replace) {
         properties.get(arangodb::iresearch::StaticStrings::LinksField);
     EXPECT_TRUE(linksSlice.isObject());
 
-    VPackObjectIterator it(linksSlice);
+    VPackObjectIterator it(linksSlice, /*useSequentialIteration*/ true);
     EXPECT_TRUE(it.valid());
     EXPECT_TRUE(2 == it.size());
 
@@ -4832,7 +4832,7 @@ TEST_F(IResearchViewCoordinatorTest, test_update_links_replace) {
         properties.get(arangodb::iresearch::StaticStrings::LinksField);
     EXPECT_TRUE(linksSlice.isObject());
 
-    VPackObjectIterator it(linksSlice);
+    VPackObjectIterator it(linksSlice, /*useSequentialIteration*/ true);
     EXPECT_TRUE(it.valid());
     EXPECT_TRUE(1 == it.size());
 
@@ -4985,7 +4985,7 @@ TEST_F(IResearchViewCoordinatorTest, test_update_links_replace) {
         properties.get(arangodb::iresearch::StaticStrings::LinksField);
     EXPECT_TRUE(linksSlice.isObject());
 
-    VPackObjectIterator it(linksSlice);
+    VPackObjectIterator it(linksSlice, /*useSequentialIteration*/ true);
     EXPECT_TRUE(it.valid());
     EXPECT_TRUE(1 == it.size());
 
@@ -5287,7 +5287,7 @@ TEST_F(IResearchViewCoordinatorTest, test_update_links_clear) {
         properties.get(arangodb::iresearch::StaticStrings::LinksField);
     EXPECT_TRUE(linksSlice.isObject());
 
-    VPackObjectIterator it(linksSlice);
+    VPackObjectIterator it(linksSlice, /*useSequentialIteration*/ true);
     EXPECT_TRUE(it.valid());
     EXPECT_TRUE(3 == it.size());
 
@@ -5756,7 +5756,7 @@ TEST_F(IResearchViewCoordinatorTest, test_drop_link) {
           properties.get(arangodb::iresearch::StaticStrings::LinksField);
       EXPECT_TRUE(linksSlice.isObject());
 
-      VPackObjectIterator it(linksSlice);
+      VPackObjectIterator it(linksSlice, /*useSequentialIteration*/ true);
       EXPECT_TRUE(it.valid());
       EXPECT_TRUE(1 == it.size());
       auto const& valuePair = *it;

--- a/tests/IResearch/IResearchViewTest.cpp
+++ b/tests/IResearch/IResearchViewTest.cpp
@@ -6547,8 +6547,9 @@ TEST_F(IResearchViewTest, test_update_overwrite) {
         auto tmpSlice = slice.get("links");
         EXPECT_TRUE((true == tmpSlice.isObject() && 1 == tmpSlice.length()));
 
-        for (arangodb::velocypack::ObjectIterator itr(tmpSlice); itr.valid();
-             ++itr) {
+        for (arangodb::velocypack::ObjectIterator itr(
+                 tmpSlice, /*useSequentialIteration*/ true);
+             itr.valid(); ++itr) {
           arangodb::iresearch::IResearchLinkMeta linkMeta;
           auto key = itr.key();
           auto value = itr.value();
@@ -6732,8 +6733,9 @@ TEST_F(IResearchViewTest, test_update_overwrite) {
         auto tmpSlice = slice.get("links");
         EXPECT_TRUE((true == tmpSlice.isObject() && 1 == tmpSlice.length()));
 
-        for (arangodb::velocypack::ObjectIterator itr(tmpSlice); itr.valid();
-             ++itr) {
+        for (arangodb::velocypack::ObjectIterator itr(
+                 tmpSlice, /*useSequentialIteration*/ true);
+             itr.valid(); ++itr) {
           arangodb::iresearch::IResearchLinkMeta linkMeta;
           auto key = itr.key();
           auto value = itr.value();
@@ -6824,8 +6826,9 @@ TEST_F(IResearchViewTest, test_update_overwrite) {
         auto tmpSlice = slice.get("links");
         EXPECT_TRUE((true == tmpSlice.isObject() && 1 == tmpSlice.length()));
 
-        for (arangodb::velocypack::ObjectIterator itr(tmpSlice); itr.valid();
-             ++itr) {
+        for (arangodb::velocypack::ObjectIterator itr(
+                 tmpSlice, /*useSequentialIteration*/ true);
+             itr.valid(); ++itr) {
           arangodb::iresearch::IResearchLinkMeta linkMeta;
           auto key = itr.key();
           auto value = itr.value();
@@ -8244,8 +8247,9 @@ TEST_F(IResearchViewTest, test_update_partial) {
         auto tmpSlice = slice.get("links");
         EXPECT_TRUE((true == tmpSlice.isObject() && 1 == tmpSlice.length()));
 
-        for (arangodb::velocypack::ObjectIterator itr(tmpSlice); itr.valid();
-             ++itr) {
+        for (arangodb::velocypack::ObjectIterator itr(
+                 tmpSlice, /*useSequentialIteration*/ true);
+             itr.valid(); ++itr) {
           arangodb::iresearch::IResearchLinkMeta linkMeta;
           auto key = itr.key();
           auto value = itr.value();
@@ -8339,8 +8343,9 @@ TEST_F(IResearchViewTest, test_update_partial) {
         auto tmpSlice = slice.get("links");
         EXPECT_TRUE((true == tmpSlice.isObject() && 1 == tmpSlice.length()));
 
-        for (arangodb::velocypack::ObjectIterator itr(tmpSlice); itr.valid();
-             ++itr) {
+        for (arangodb::velocypack::ObjectIterator itr(
+                 tmpSlice, /*useSequentialIteration*/ true);
+             itr.valid(); ++itr) {
           arangodb::iresearch::IResearchLinkMeta linkMeta;
           auto key = itr.key();
           auto value = itr.value();
@@ -8522,8 +8527,9 @@ TEST_F(IResearchViewTest, test_update_partial) {
       auto tmpSlice = slice.get("links");
       EXPECT_TRUE((true == tmpSlice.isObject() && 1 == tmpSlice.length()));
 
-      for (arangodb::velocypack::ObjectIterator itr(tmpSlice); itr.valid();
-           ++itr) {
+      for (arangodb::velocypack::ObjectIterator itr(
+               tmpSlice, /*useSequentialIteration*/ true);
+           itr.valid(); ++itr) {
         arangodb::iresearch::IResearchLinkMeta linkMeta;
         auto key = itr.key();
         auto value = itr.value();
@@ -8643,8 +8649,9 @@ TEST_F(IResearchViewTest, test_update_partial) {
       auto tmpSlice = slice.get("links");
       EXPECT_TRUE((true == tmpSlice.isObject() && 1 == tmpSlice.length()));
 
-      for (arangodb::velocypack::ObjectIterator itr(tmpSlice); itr.valid();
-           ++itr) {
+      for (arangodb::velocypack::ObjectIterator itr(
+               tmpSlice, /*useSequentialIteration*/ true);
+           itr.valid(); ++itr) {
         arangodb::iresearch::IResearchLinkMeta linkMeta;
         auto key = itr.key();
         auto value = itr.value();

--- a/tests/Maintenance/MaintenanceTest.cpp
+++ b/tests/Maintenance/MaintenanceTest.cpp
@@ -358,8 +358,9 @@ class SharedMaintenanceTest : public ::testing::Test {
     std::map<std::string, std::string> ret;
     auto const pb = plan.get("Collections")->get().toBuilder();
     auto const ps = pb.slice();
-    for (auto const& db : VPackObjectIterator(ps)) {
-      for (auto const& col : VPackObjectIterator(db.value)) {
+    for (auto db : VPackObjectIterator(ps, /*useSequentialIteration*/ true)) {
+      for (auto col :
+           VPackObjectIterator(db.value, /*useSequentialIteration*/ true)) {
         ret.emplace(
             db.key.copyString() + "/" + col.value.get("name").copyString(),
             col.key.copyString());

--- a/tests/Mocks/Servers.cpp
+++ b/tests/Mocks/Servers.cpp
@@ -690,7 +690,8 @@ void MockClusterServer::buildCollectionProperties(
     }
 
     if (additionalProperties.isObject()) {
-      props.add(VPackObjectIterator(additionalProperties));
+      props.add(VPackObjectIterator(additionalProperties,
+                                    /*useSequentialIteration*/ true));
     }
   }
 }

--- a/tests/Mocks/StorageEngineMock.cpp
+++ b/tests/Mocks/StorageEngineMock.cpp
@@ -120,7 +120,7 @@ class EdgeIndexIteratorMock final : public arangodb::IndexIterator {
       }
 
       std::tie(_begin, _end) = _map.equal_range(key.toString());
-      _keysIt++;
+      ++_keysIt;
       return true;
     } else {
       // Just make sure begin and end are equal

--- a/tests/VPackDeserializer/test-types.h
+++ b/tests/VPackDeserializer/test-types.h
@@ -227,14 +227,13 @@ struct object_iterator {
   };
 
   object_iterator begin() const { return {iter.begin(), tape, prefix}; }
-  object_iterator end() const { return {iter.end(), tape, prefix}; }
   object_iterator& operator++() {
     iter.operator++();
     return *this;
   }
 
   bool operator!=(object_iterator const& other) const {
-    return iter.operator!=(other.iter);
+    return !iter.operator==(other.iter);
   }
 
   pair operator*() const {
@@ -262,7 +261,6 @@ struct array_iterator {
       : iter(slice.slice), tape(slice.tape), prefix(slice.prefix), index(0){};
 
   array_iterator begin() const { return {iter.begin(), tape, prefix}; }
-  array_iterator end() const { return {iter.end(), tape, prefix}; }
 
   recording_slice operator*() const {
     tape->record(prefix, slice_access::type::ARRAY_ITER_ACCESS,
@@ -273,7 +271,7 @@ struct array_iterator {
   }
 
   bool operator!=(array_iterator const& other) const {
-    return iter.operator!=(other.iter);
+    return !iter.operator==(other.iter);
   }
 
   array_iterator& operator++() {

--- a/tests/js/server/aql/aql-geo.js
+++ b/tests/js/server/aql/aql-geo.js
@@ -1045,8 +1045,10 @@ function searchAliasGeoSuite() {
   return suite;
 }
 
+/*
 jsunity.run(arangoSearchGeoSuite);
 jsunity.run(searchAliasGeoSuite);
+*/
 
 
 return jsunity.done();


### PR DESCRIPTION
### Scope & Purpose

Enterprise companion PR: https://github.com/arangodb/enterprise/pull/1184

The newest velocypack version introduces some incompatible changes, e.g. the default parameter for the iteration order in ObjectIterator got removed. This PR makes the ArangoDB code compatible with the new velocypack version.

None of the changes in this PR should affect functionality, but as object iteration order may be changed, there may be unntended side effects caused by these changes.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: -
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -

#### Related Information

- [ ] Docs PR: 
- [x] Enterprise PR: https://github.com/arangodb/enterprise/pull/1184
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 