### PR TITLE
Make cache_oblivious configurable via env for jemalloc

### DIFF
--- a/3rdParty/jemalloc/v5.3.0/src/jemalloc.c
+++ b/3rdParty/jemalloc/v5.3.0/src/jemalloc.c
@@ -1220,6 +1220,7 @@ malloc_conf_init_helper(sc_data_t *sc_data, unsigned bin_shard_sizes[SC_NBINS],
 
 			CONF_HANDLE_BOOL(opt_abort, "abort")
 			CONF_HANDLE_BOOL(opt_abort_conf, "abort_conf")
+			CONF_HANDLE_BOOL(opt_cache_oblivious, "cache_oblivious")
 			CONF_HANDLE_BOOL(opt_trust_madvise, "trust_madvise")
 			if (strncmp("metadata_thp", k, klen) == 0) {
 				int m;

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,11 @@
 v3.10.3 (XXXX-XX-XX)
 --------------------
 
+* Make the cache_oblivious option of jemalloc configurable from the
+  environment. This helps to save 4096 bytes of RAM for every allocation
+  which is at least 16384 bytes large. This is particularly beneficial
+  for the RocksDB buffer cache.
+
 * Improve performance of RocksDB's transaction lock manager by using different
   container types for the locked keys maps.
   This can improve performance of write-heavy operations that are not I/O-bound


### PR DESCRIPTION
This "fixes" an option of jemalloc which can safe considerable amounts
of memory without impacting performance (according to our measurements).
In this PR, we add configurability of this option from the environment
(forgotten in jemalloc).

- Make `cache_oblivious` configurable for jemalloc from ENV.

This option does the following:

If set to true (old default), jemalloc allocates for every allocation
of 16384 or more bytes one additional page (4k) to change the base
address that it is not divisible by 4096. This could potentially make
sense since it helps the CPU caches, in the case that lots of accesses
to the beginning of such blocks happen (because of the limited
associativity) of the CPU caches.

However, on the flip side, it "wastes" 4K for every allocation. Since
the RocksDB buffer cache does most of its allocations for 16384 bytes,
this is 25% additional RAM usage, which hurts.

Setting the option to `false` helps to not do this optimization. So far,
our measurements suggest that this does not have a bad influence on
performance. I guess that the RocksDB buffer cache does not access the
beginning of allocated blocks more frequently than other places.

This is the backport to 3.10, but we keep the default at `true`.

### Scope & Purpose

- [*] :hankey: Bugfix
- [*] :fire: Performance improvement

### Checklist

- [*] :book: CHANGELOG entry made
- [*] Backports
  - [*] Backport for 3.10: This is it.

### Related information

Original PR: https://github.com/arangodb/arangodb/pull/17870

