### PR TITLE
Make ServerState::_rebootId atomic

### DIFF
--- a/arangod/Cluster/ClusterTypes.h
+++ b/arangod/Cluster/ClusterTypes.h
@@ -46,7 +46,8 @@ class RebootId {
   using value_type = uint64_t;
 
   explicit constexpr RebootId() noexcept = delete;
-  explicit constexpr RebootId(value_type rebootId) noexcept : _value(rebootId) {}
+  explicit constexpr RebootId(value_type rebootId) noexcept
+      : _value(rebootId) {}
   [[nodiscard]] value_type value() const noexcept { return _value; }
 
   [[nodiscard]] bool initialized() const noexcept { return value() != 0; }

--- a/arangod/Cluster/ClusterTypes.h
+++ b/arangod/Cluster/ClusterTypes.h
@@ -43,9 +43,11 @@ typedef std::string ServerShortName;  // Short name of a server
 
 class RebootId {
  public:
+  using value_type = uint64_t;
+
   explicit constexpr RebootId() noexcept = delete;
-  explicit constexpr RebootId(uint64_t rebootId) noexcept : _value(rebootId) {}
-  [[nodiscard]] uint64_t value() const noexcept { return _value; }
+  explicit constexpr RebootId(value_type rebootId) noexcept : _value(rebootId) {}
+  [[nodiscard]] value_type value() const noexcept { return _value; }
 
   [[nodiscard]] bool initialized() const noexcept { return value() != 0; }
 
@@ -69,13 +71,13 @@ class RebootId {
   }
 
   [[nodiscard]] static constexpr RebootId max() noexcept {
-    return RebootId{std::numeric_limits<decltype(_value)>::max()};
+    return RebootId{std::numeric_limits<value_type>::max()};
   }
 
   std::ostream& print(std::ostream& o) const;
 
  private:
-  uint64_t _value{};
+  value_type _value{};
 };
 
 template<class Inspector>

--- a/arangod/Cluster/ServerState.cpp
+++ b/arangod/Cluster/ServerState.cpp
@@ -1076,13 +1076,14 @@ void ServerState::setShortId(uint32_t id) {
 }
 
 RebootId ServerState::getRebootId() const {
-  TRI_ASSERT(_rebootId.initialized());
-  return _rebootId;
+  auto const rebootId = RebootId(_rebootId.load(std::memory_order_relaxed));
+  TRI_ASSERT(rebootId.initialized());
+  return rebootId;
 }
 
 void ServerState::setRebootId(RebootId const rebootId) {
   TRI_ASSERT(rebootId.initialized());
-  _rebootId = rebootId;
+  _rebootId.store(rebootId.value(), std::memory_order_relaxed);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/arangod/Cluster/ServerState.h
+++ b/arangod/Cluster/ServerState.h
@@ -364,7 +364,7 @@ class ServerState {
   ///
   /// Changes of rebootIds (i.e. server reboots) are noticed in ClusterInfo and
   /// can be used through a notification architecture from there
-  RebootId _rebootId;
+  std::atomic<RebootId::value_type> _rebootId = 0;
 
   /// @brief the server's own endpoint, can be set just once
   std::string _myEndpoint;


### PR DESCRIPTION
### Scope & Purpose

`ServerState::getRebootId()` and `ServerState::setRebootId()` can be called simultaneously, but this was a data race. This makes `ServerState::_rebootId` an atomic to fix this.

`setRebootId()` is called once in the startup phase; here, no race can happen. After that, `setRebootId()` is (only) called when the Supervision marks the server as failed (e.g. due to a network split or SIGSTOP), and the server reconnects without actually having been restarted. This is an unlikely event, and this data race having visible impact seems very unlikely.

- [X] :hankey: Bugfix
