### PR TITLE
Allow database server start with invalid repl factor settings

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,9 +1,9 @@
 v3.10.3 (XXXX-XX-XX)
 --------------------
 
-* Allow database server start in cluster even in case there are existing
-  databases that would violate the settings `--cluster.min-replication-factor`
-  or `--cluster.max-replication-factor`.
+* Allow cluster database servers to start even when there are existing databases
+  that would violate the settings `--cluster.min-replication-factor` or
+  `--cluster.max-replication-factor`.
   This allows upgrading from older versions in which the replication factor
   validation for databases was not yet present.
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,12 @@
 v3.10.3 (XXXX-XX-XX)
 --------------------
 
+* Allow database server start in cluster even in case there are existing
+  databases that would violate the settings `--cluster.min-replication-factor`
+  or `--cluster.max-replication-factor`.
+  This allows upgrading from older versions in which the replication factor
+  validation for databases was not yet present.
+
 * Improve performance of RocksDB's transaction lock manager by using different
   container types for the locked keys maps.
   This can improve performance of write-heavy operations that are not I/O-bound

--- a/arangod/Cluster/HeartbeatThread.cpp
+++ b/arangod/Cluster/HeartbeatThread.cpp
@@ -1380,13 +1380,18 @@ bool HeartbeatThread::handlePlanChangeCoordinator(uint64_t currentPlanVersion) {
         continue;
       }
 
-      arangodb::CreateDatabaseInfo info(server(), ExecContext::current());
       TRI_ASSERT(options.value.get("name").isString());
+      CreateDatabaseInfo info(server(), ExecContext::current());
+      // set strict validation for database options to false.
+      // we don't want the heartbeat thread to fail here in case some
+      // invalid settings are present
+      info.strictValidation(false);
       // when loading we allow system database names
       auto infoResult = info.load(options.value, VPackSlice::emptyArraySlice());
       if (infoResult.fail()) {
         LOG_TOPIC("3fa12", ERR, Logger::HEARTBEAT)
-            << "In agency database plan" << infoResult.errorMessage();
+            << "in agency database plan for database " << options.value.toJson()
+            << ": " << infoResult.errorMessage();
         TRI_ASSERT(false);
       }
 

--- a/arangod/RestHandler/RestAdminServerHandler.cpp
+++ b/arangod/RestHandler/RestAdminServerHandler.cpp
@@ -252,7 +252,8 @@ void RestAdminServerHandler::handleMode() {
 }
 
 void RestAdminServerHandler::handleDatabaseDefaults() {
-  auto defaults = getVocbaseOptions(server(), VPackSlice::emptyObjectSlice());
+  auto defaults = getVocbaseOptions(server(), VPackSlice::emptyObjectSlice(),
+                                    /*strictValidation*/ false);
   VPackBuilder builder;
 
   builder.openObject();

--- a/arangod/RestServer/DatabaseFeature.cpp
+++ b/arangod/RestServer/DatabaseFeature.cpp
@@ -1539,13 +1539,19 @@ ErrorCode DatabaseFeature::iterateDatabases(VPackSlice const& databases) {
       // open the database and scan collections in it
 
       // try to open this database
-      arangodb::CreateDatabaseInfo info(server(), ExecContext::current());
+      CreateDatabaseInfo info(server(), ExecContext::current());
+      // set strict validation for database options to false.
+      // we don't want the server start to fail here in case some
+      // invalid settings are present
+      info.strictValidation(false);
       auto res = info.load(it, VPackSlice::emptyArraySlice());
+
       if (res.fail()) {
+        std::string errorMsg;
         if (res.is(TRI_ERROR_ARANGO_DATABASE_NAME_INVALID)) {
+          errorMsg.append(res.errorMessage());
           // special case: if we find an invalid database name during startup,
           // we will give the user some hint how to fix it
-          std::string errorMsg(res.errorMessage());
           errorMsg.append(": '").append(databaseName).append("'");
           // check if the name would be allowed when using extended names
           if (DatabaseNameValidator::isAllowedName(
@@ -1557,9 +1563,14 @@ ErrorCode DatabaseFeature::iterateDatabases(VPackSlice const& databases) {
                 "be enabled via the startup option "
                 "`--database.extended-names-databases true`");
           }
-          res.reset(TRI_ERROR_ARANGO_DATABASE_NAME_INVALID,
-                    std::move(errorMsg));
+        } else {
+          errorMsg.append("when opening database '")
+              .append(databaseName)
+              .append("': ");
+          errorMsg.append(res.errorMessage());
         }
+
+        res.reset(res.errorNumber(), std::move(errorMsg));
         THROW_ARANGO_EXCEPTION(res);
       }
 

--- a/arangod/VocBase/VocbaseInfo.cpp
+++ b/arangod/VocBase/VocbaseInfo.cpp
@@ -67,11 +67,9 @@ Result CreateDatabaseInfo::load(std::string const& name, uint64_t id) {
 
 Result CreateDatabaseInfo::load(VPackSlice options, VPackSlice users) {
   Result res = extractOptions(options, true /*getId*/, true /*getUser*/);
-  if (!res.ok()) {
-    return res;
+  if (res.ok()) {
+    res = extractUsers(users);
   }
-
-  res = extractUsers(users);
   if (!res.ok()) {
     return res;
   }
@@ -88,11 +86,9 @@ Result CreateDatabaseInfo::load(std::string const& name, VPackSlice options,
   _name = methods::Databases::normalizeName(name);
 
   Result res = extractOptions(options, true /*getId*/, false /*getName*/);
-  if (!res.ok()) {
-    return res;
+  if (res.ok()) {
+    res = extractUsers(users);
   }
-
-  res = extractUsers(users);
   if (!res.ok()) {
     return res;
   }
@@ -110,11 +106,9 @@ Result CreateDatabaseInfo::load(std::string const& name, uint64_t id,
   _id = id;
 
   Result res = extractOptions(options, false /*getId*/, false /*getUser*/);
-  if (!res.ok()) {
-    return res;
+  if (res.ok()) {
+    res = extractUsers(users);
   }
-
-  res = extractUsers(users);
   if (!res.ok()) {
     return res;
   }
@@ -237,37 +231,45 @@ Result CreateDatabaseInfo::extractOptions(VPackSlice options, bool extractId,
     return Result(TRI_ERROR_HTTP_BAD_PARAMETER, "invalid options slice");
   }
 
-  auto vocopts = getVocbaseOptions(_server, options);
-  _replicationFactor = vocopts.replicationFactor;
-  _writeConcern = vocopts.writeConcern;
-  _sharding = vocopts.sharding;
+  try {
+    auto vocopts = getVocbaseOptions(_server, options, _strictValidation);
+    _replicationFactor = vocopts.replicationFactor;
+    _writeConcern = vocopts.writeConcern;
+    _sharding = vocopts.sharding;
 
-  if (extractName) {
-    auto nameSlice = options.get(StaticStrings::DatabaseName);
-    if (!nameSlice.isString()) {
-      return Result(TRI_ERROR_ARANGO_DOCUMENT_KEY_BAD, "no valid id given");
+    if (extractName) {
+      auto nameSlice = options.get(StaticStrings::DatabaseName);
+      if (!nameSlice.isString()) {
+        return Result(TRI_ERROR_ARANGO_DOCUMENT_KEY_BAD, "no valid id given");
+      }
+      _name = methods::Databases::normalizeName(nameSlice.copyString());
     }
-    _name = methods::Databases::normalizeName(nameSlice.copyString());
-  }
-  if (extractId) {
-    auto idSlice = options.get(StaticStrings::DatabaseId);
-    if (idSlice.isString()) {
-      // improve once it works
-      // look for some nice internal helper this has proably been done before
-      auto idStr = idSlice.copyString();
-      _id = basics::StringUtils::uint64(idSlice.stringView().data(),
-                                        idSlice.stringView().size());
+    if (extractId) {
+      auto idSlice = options.get(StaticStrings::DatabaseId);
+      if (idSlice.isString()) {
+        // improve once it works
+        // look for some nice internal helper this has proably been done before
+        auto idStr = idSlice.copyString();
+        _id = basics::StringUtils::uint64(idSlice.stringView().data(),
+                                          idSlice.stringView().size());
 
-    } else if (idSlice.isUInt()) {
-      _id = idSlice.getUInt();
-    } else if (idSlice.isNone()) {
-      // do nothing - can be set later - this sucks
-    } else {
-      return Result(TRI_ERROR_ARANGO_DOCUMENT_KEY_BAD, "no valid id given");
+      } else if (idSlice.isUInt()) {
+        _id = idSlice.getUInt();
+      } else if (idSlice.isNone()) {
+        // do nothing - can be set later - this sucks
+      } else {
+        return Result(TRI_ERROR_ARANGO_DOCUMENT_KEY_BAD, "no valid id given");
+      }
     }
-  }
 
-  return checkOptions();
+    return checkOptions();
+  } catch (basics::Exception const& ex) {
+    return Result(ex.code(), ex.what());
+  } catch (std::exception const& ex) {
+    return Result(TRI_ERROR_INTERNAL, ex.what());
+  } catch (...) {
+    return Result(TRI_ERROR_INTERNAL, "an unknown error occurred");
+  }
 }
 
 Result CreateDatabaseInfo::checkOptions() {
@@ -286,7 +288,8 @@ Result CreateDatabaseInfo::checkOptions() {
   return res;
 }
 
-VocbaseOptions getVocbaseOptions(ArangodServer& server, VPackSlice options) {
+VocbaseOptions getVocbaseOptions(ArangodServer& server, VPackSlice options,
+                                 bool strictValidation) {
   TRI_ASSERT(options.isObject());
   // Invalid options will be silently ignored. Default values will be used
   // instead.
@@ -333,7 +336,7 @@ VocbaseOptions getVocbaseOptions(ArangodServer& server, VPackSlice options) {
       vocbaseOptions.replicationFactor =
           replicationSlice
               .getNumber<decltype(vocbaseOptions.replicationFactor)>();
-      if (haveCluster) {
+      if (haveCluster && strictValidation) {
         auto const minReplicationFactor =
             server.getFeature<ClusterFeature>().minReplicationFactor();
         auto const maxReplicationFactor =

--- a/arangod/VocBase/VocbaseInfo.h
+++ b/arangod/VocBase/VocbaseInfo.h
@@ -98,11 +98,13 @@ class CreateDatabaseInfo {
     return _id;
   }
 
-  bool valid() const { return _valid; }
+  void strictValidation(bool value) noexcept { _strictValidation = value; }
 
-  bool validId() const { return _validId; }
+  bool valid() const noexcept { return _valid; }
 
-  // shold be created with vaild id
+  bool validId() const noexcept { return _validId; }
+
+  // shold be created with valid id
   void setId(uint64_t id) {
     _id = id;
     _validId = true;
@@ -122,10 +124,12 @@ class CreateDatabaseInfo {
     TRI_ASSERT(_valid);
     return _writeConcern;
   }
+
   std::string const& sharding() const {
     TRI_ASSERT(_valid);
     return _sharding;
   }
+
   void sharding(std::string const& sharding) { _sharding = sharding; }
 
   ShardingPrototype shardingPrototype() const;
@@ -150,18 +154,19 @@ class CreateDatabaseInfo {
   std::uint32_t _writeConcern = 1;
   ShardingPrototype _shardingPrototype = ShardingPrototype::Undefined;
 
+  bool _strictValidation = true;
   bool _validId = false;
-  bool _valid =
-      false;  // required because TRI_ASSERT needs variable in Release mode.
+  bool _valid = false;
 };
 
 struct VocbaseOptions {
-  std::string sharding = "";
+  std::string sharding;
   std::uint32_t replicationFactor = 1;
   std::uint32_t writeConcern = 1;
 };
 
-VocbaseOptions getVocbaseOptions(ArangodServer&, velocypack::Slice);
+VocbaseOptions getVocbaseOptions(ArangodServer&, velocypack::Slice,
+                                 bool strictValidation);
 
 void addClusterOptions(VPackBuilder& builder, std::string const& sharding,
                        std::uint32_t replicationFactor,


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/17883

Allow database server start in cluster even in case there are existing databases that would violate the settings `--cluster.min-replication-factor` or `--cluster.max-replication-factor`. This allows upgrading from older versions in which the replication factor validation for databases was not yet present.
A more thorough validation for replication factor settings for databases was added in 3.10.2, which is appropriate when creating new databases. However, the more strict validation added in 3.10.2 prevents servers with improper replication factor settings in existing databases from starting.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [x] Backports
  - [x] Backport for 3.10: this PR
  - [x] Backport for 3.9: https://github.com/arangodb/arangodb/pull/17884
  - [ ] Backport for 3.8: not necessary

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [x] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/OASIS-24944
- [ ] Design document: 


[OASIS-24944]: https://arangodb.atlassian.net/browse/OASIS-24944?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ