### PR TITLE
Allow database server start with invalid repl factor settings

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,12 @@
 v3.9.7 (XXXX-XX-XX)
 -------------------
 
+* Allow cluster database servers to start even when there are existing databases
+  that would violate the settings `--cluster.min-replication-factor` or
+  `--cluster.max-replication-factor`.
+  This allows upgrading from older versions in which the replication factor
+  validation for databases was not yet present.
+
 * Use intermediate commits in old shard synchronization protocol. This avoids
   overly large RocksDB transactions when syncing large shards, which is a remedy
   for OOM kills during restarts.

--- a/arangod/Cluster/HeartbeatThread.cpp
+++ b/arangod/Cluster/HeartbeatThread.cpp
@@ -1372,13 +1372,18 @@ bool HeartbeatThread::handlePlanChangeCoordinator(uint64_t currentPlanVersion) {
         continue;
       }
 
-      arangodb::CreateDatabaseInfo info(_server, ExecContext::current());
       TRI_ASSERT(options.value.get("name").isString());
+      CreateDatabaseInfo info(_server, ExecContext::current());
+      // set strict validation for database options to false.
+      // we don't want the heartbeat thread to fail here in case some
+      // invalid settings are present
+      info.strictValidation(false);
       // when loading we allow system database names
       auto infoResult = info.load(options.value, VPackSlice::emptyArraySlice());
       if (infoResult.fail()) {
         LOG_TOPIC("3fa12", ERR, Logger::HEARTBEAT)
-            << "In agency database plan" << infoResult.errorMessage();
+            << "in agency database plan for database " << options.value.toJson()
+            << ": " << infoResult.errorMessage();
         TRI_ASSERT(false);
       }
 

--- a/arangod/RestHandler/RestAdminServerHandler.cpp
+++ b/arangod/RestHandler/RestAdminServerHandler.cpp
@@ -251,7 +251,8 @@ void RestAdminServerHandler::handleMode() {
 }
 
 void RestAdminServerHandler::handleDatabaseDefaults() {
-  auto defaults = getVocbaseOptions(server(), VPackSlice::emptyObjectSlice());
+  auto defaults = getVocbaseOptions(server(), VPackSlice::emptyObjectSlice(),
+                                    /*strictValidation*/ false);
   VPackBuilder builder;
 
   builder.openObject();

--- a/arangod/VocBase/VocbaseInfo.h
+++ b/arangod/VocBase/VocbaseInfo.h
@@ -99,11 +99,13 @@ class CreateDatabaseInfo {
     return _id;
   }
 
-  bool valid() const { return _valid; }
+  void strictValidation(bool value) noexcept { _strictValidation = value; }
 
-  bool validId() const { return _validId; }
+  bool valid() const noexcept { return _valid; }
 
-  // shold be created with vaild id
+  bool validId() const noexcept { return _validId; }
+
+  // shold be created with valid id
   void setId(uint64_t id) {
     _id = id;
     _validId = true;
@@ -123,10 +125,12 @@ class CreateDatabaseInfo {
     TRI_ASSERT(_valid);
     return _writeConcern;
   }
+
   std::string const& sharding() const {
     TRI_ASSERT(_valid);
     return _sharding;
   }
+
   void sharding(std::string const& sharding) { _sharding = sharding; }
 
   ShardingPrototype shardingPrototype() const;
@@ -151,19 +155,19 @@ class CreateDatabaseInfo {
   std::uint32_t _writeConcern = 1;
   ShardingPrototype _shardingPrototype = ShardingPrototype::Undefined;
 
+  bool _strictValidation = true;
   bool _validId = false;
-  bool _valid =
-      false;  // required because TRI_ASSERT needs variable in Release mode.
+  bool _valid = false;
 };
 
 struct VocbaseOptions {
-  std::string sharding = "";
+  std::string sharding;
   std::uint32_t replicationFactor = 1;
   std::uint32_t writeConcern = 1;
 };
 
 VocbaseOptions getVocbaseOptions(application_features::ApplicationServer&,
-                                 velocypack::Slice const&);
+                                 velocypack::Slice, bool strictValidation);
 
 void addClusterOptions(VPackBuilder& builder, std::string const& sharding,
                        std::uint32_t replicationFactor,


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/17883

Allow database server start in cluster even in case there are existing databases that would violate the settings `--cluster.min-replication-factor` or `--cluster.max-replication-factor`. This allows upgrading from older versions in which the replication factor validation for databases was not yet present.
A more thorough validation for replication factor settings for databases was added in 3.10.2, which is appropriate when creating new databases. However, the more strict validation added in 3.10.2 prevents servers with improper replication factor settings in existing databases from starting. The same validation was added in 3.9.7, but it wasn't released yet.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [x] Backports
  - [x] Backport for 3.10: https://github.com/arangodb/arangodb/pull/17880
  - [x] Backport for 3.9: this PR
  - [ ] Backport for 3.8: not necessary

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [x] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/OASIS-24944
- [ ] Design document: 

[OASIS-24944]: https://arangodb.atlassian.net/browse/OASIS-24944?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ