### PR TITLE
BTS-163: no network::Response::slice() noexcept

### DIFF
--- a/arangod/Network/Methods.h
+++ b/arangod/Network/Methods.h
@@ -82,18 +82,18 @@ struct Response {
   [[nodiscard]] std::unique_ptr<arangodb::fuerte::Response>
   stealResponse() noexcept;
 
-  [[nodiscard]] bool ok() const {
+  [[nodiscard]] bool ok() const noexcept {
     return fuerte::Error::NoError == this->error;
   }
 
-  [[nodiscard]] bool fail() const { return !ok(); }
+  [[nodiscard]] bool fail() const noexcept { return !ok(); }
 
   // returns a slice of the payload if there was no error
-  [[nodiscard]] velocypack::Slice slice() const;
+  [[nodiscard]] velocypack::Slice slice() const noexcept;
 
   [[nodiscard]] std::size_t payloadSize() const noexcept;
 
-  fuerte::StatusCode statusCode() const;
+  fuerte::StatusCode statusCode() const noexcept;
 
   /// @brief Build a Result that contains
   ///   - no error if everything went well, otherwise


### PR DESCRIPTION
### Scope & Purpose

BTS-163: arangodb::network::sendRequest is potentially used in an unsafe fashion

Make `network::Request::slice()` noexcept. The BTS ticket in question is more than 2 years old, and in practice we haven't seen any problems with potential exceptions originating from the `slice()` method. However, make it formally noexcept now and handle any potential exceptions internally.

https://arangodb.atlassian.net/browse/BTS-163

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: -
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [x] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/BTS-163
- [ ] Design document: 