### PR TITLE
Remove superflous OPENSSL version guards

### DIFF
--- a/arangod/GeneralServer/AcceptorTcp.cpp
+++ b/arangod/GeneralServer/AcceptorTcp.cpp
@@ -191,9 +191,7 @@ bool tls_h2_negotiated(SSL* ssl) {
   const unsigned char* next_proto = nullptr;
   unsigned int next_proto_len = 0;
 
-#if OPENSSL_VERSION_NUMBER >= 0x10002000L
   SSL_get0_alpn_selected(ssl, &next_proto, &next_proto_len);
-#endif  // OPENSSL_VERSION_NUMBER >= 0x10002000L
 
   // allowed value is "h2"
   // http://www.iana.org/assignments/tls-extensiontype-values/tls-extensiontype-values.xhtml

--- a/arangod/GeneralServer/SslServerFeature.cpp
+++ b/arangod/GeneralServer/SslServerFeature.cpp
@@ -401,7 +401,6 @@ asio_ns::ssl::context SslServerFeature::createSslContextInternal(
       }
     }
 
-#if OPENSSL_VERSION_NUMBER >= 0x0090800fL
     if (!_ecdhCurve.empty()) {
       int sslEcdhNid = OBJ_sn2nid(_ecdhCurve.c_str());
 
@@ -431,7 +430,6 @@ asio_ns::ssl::context SslServerFeature::createSslContextInternal(
       EC_KEY_free(ecdhKey);
       SSL_CTX_set_options(nativeContext, SSL_OP_SINGLE_ECDH_USE);
     }
-#endif
 
     // set ssl context
     int res = SSL_CTX_set_session_id_context(

--- a/arangod/RocksDBEngine/RocksDBChecksumEnv.cpp
+++ b/arangod/RocksDBEngine/RocksDBChecksumEnv.cpp
@@ -35,13 +35,7 @@
 
 namespace arangodb::checksum {
 
-ChecksumCalculator::ChecksumCalculator()
-    :
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L
-      _context(EVP_MD_CTX_new()) {
-#else
-      _context(EVP_MD_CTX_create()) {
-#endif
+ChecksumCalculator::ChecksumCalculator() : _context(EVP_MD_CTX_new()) {
   if (_context == nullptr) {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_OUT_OF_MEMORY);
   }

--- a/lib/SimpleHttpClient/SslClientConnection.cpp
+++ b/lib/SimpleHttpClient/SslClientConnection.cpp
@@ -245,30 +245,16 @@ void SslClientConnection::init(uint64_t sslProtocol) {
       break;
 
     case TLS_V1:
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L
       meth = TLS_client_method();
-#else
-      meth = TLSv1_method();
-#endif
       break;
 
     case TLS_V12:
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L
       meth = TLS_client_method();
-#else
-      meth = TLSv1_2_method();
-#endif
       break;
 
-      // TLS 1.3, only supported from OpenSSL 1.1.1 onwards
-
-      // openssl version number format is
-      // MNNFFPPS: major minor fix patch status
-#if OPENSSL_VERSION_NUMBER >= 0x10101000L
     case TLS_V13:
       meth = TLS_client_method();
       break;
-#endif
 
     case TLS_GENERIC:
       meth = TLS_client_method();
@@ -276,17 +262,12 @@ void SslClientConnection::init(uint64_t sslProtocol) {
 
     case SSL_UNKNOWN:
     default:
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L
       // The actual protocol version used will be negotiated to the highest
       // version mutually supported by the client and the server. The supported
       // protocols are SSLv3, TLSv1, TLSv1.1 and TLSv1.2. Applications should
       // use these methods, and avoid the version-specific methods described
       // below.
       meth = TLS_method();
-#else
-      // default to TLS 1.2
-      meth = TLSv1_2_method();
-#endif
       break;
   }
 
@@ -342,9 +323,7 @@ bool SslClientConnection::connectSocket() {
   switch (SslProtocol(_sslProtocol)) {
     case TLS_V1:
     case TLS_V12:
-#if OPENSSL_VERSION_NUMBER >= 0x10101000L
     case TLS_V13:
-#endif
     case TLS_GENERIC:
     default:
       SSL_set_tlsext_host_name(_ssl, _endpoint->host().c_str());

--- a/lib/Ssl/ssl-helper.cpp
+++ b/lib/Ssl/ssl-helper.cpp
@@ -78,14 +78,9 @@ asio_ns::ssl::context arangodb::sslContext(SslProtocol protocol,
       meth = asio_ns::ssl::context::method::tlsv12_server;
       break;
 
-#if OPENSSL_VERSION_NUMBER >= 0x10101000L
     case TLS_V13:
-      // TLS 1.3, only supported from OpenSSL 1.1.1 onwards
-      // openssl version number format is
-      // MNNFFPPS: major minor fix patch status
       meth = asio_ns::ssl::context::method::tlsv13_server;
       break;
-#endif
 
     case TLS_GENERIC:
       meth = asio_ns::ssl::context::method::tls_server;
@@ -123,9 +118,6 @@ asio_ns::ssl::context arangodb::sslContext(SslProtocol protocol,
     THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_BAD_PARAMETER,
                                    "unable to read key from keyfile");
   }
-#if (OPENSSL_VERSION_NUMBER < 0x00905100L)
-  sslctx.set_verify_depth(1);
-#endif
 
   return sslctx;
 }
@@ -151,10 +143,8 @@ std::string arangodb::protocolName(SslProtocol protocol) {
     case TLS_V12:
       return "TLSv12";
 
-#if OPENSSL_VERSION_NUMBER >= 0x10101000L
     case TLS_V13:
       return "TLSv13";
-#endif
 
     case TLS_GENERIC:
       return "TLS";
@@ -167,31 +157,17 @@ std::string arangodb::protocolName(SslProtocol protocol) {
 std::unordered_set<uint64_t> arangodb::availableSslProtocols() {
   // openssl version number format is
   // MNNFFPPS: major minor fix patch status
-#if OPENSSL_VERSION_NUMBER >= 0x10101000L
   // TLS 1.3, only support from OpenSSL 1.1.1 onwards
   return std::unordered_set<uint64_t>{
       SslProtocol::SSL_V2,  // unsupported!
       SslProtocol::SSL_V23, SslProtocol::SSL_V3,  SslProtocol::TLS_V1,
       SslProtocol::TLS_V12, SslProtocol::TLS_V13, SslProtocol::TLS_GENERIC};
-#else
-  // no support for TLS 1.3
-  return std::unordered_set<uint64_t>{
-      SslProtocol::SSL_V2,  // unsupported!
-      SslProtocol::SSL_V23, SslProtocol::SSL_V3,     SslProtocol::TLS_V1,
-      SslProtocol::TLS_V12, SslProtocol::TLS_GENERIC};
-#endif
 }
 
 std::string arangodb::availableSslProtocolsDescription() {
-#if OPENSSL_VERSION_NUMBER >= 0x10101000L
   return "The SSL protocol (1 = SSLv2 (unsupported), 2 = SSLv2 or SSLv3 "
          "(negotiated), 3 = SSLv3, 4 = TLSv1, 5 = TLSv1.2, 6 = TLSv1.3, "
          "9 = generic TLS (negotiated))";
-#else
-  return "The SSL protocol (1 = SSLv2 (unsupported), 2 = SSLv2 or SSLv3 "
-         "(negotiated), 3 = SSLv3, 4 = TLSv1, 5 = TLSv1.2, "
-         "9 = generic TLS (negotiated))";
-#endif
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/lib/Ssl/ssl-helper.h
+++ b/lib/Ssl/ssl-helper.h
@@ -49,19 +49,13 @@ enum SslProtocol {
   SSL_V3 = 3,
   TLS_V1 = 4,
   TLS_V12 = 5,
-#if OPENSSL_VERSION_NUMBER >= 0x10101000L
   TLS_V13 = 6,
-#endif
   TLS_GENERIC = 9,
 
   SSL_LAST
 };
 
-#if (OPENSSL_VERSION_NUMBER < 0x00999999L)
-#define SSL_CONST /* */
-#else
 #define SSL_CONST const
-#endif
 
 /// @brief returns a set with all available SSL protocols
 std::unordered_set<uint64_t> availableSslProtocols();


### PR DESCRIPTION
### Scope & Purpose

These guards checked whether OpenSSL was version < OpenSSL 1.1.1, which are not supported anymore and should hence always evaluate to `false` anyway.