### PR TITLE
[CINFRA-647] Make the Stream throw an exception after resign

### DIFF
--- a/arangod/Replication2/ReplicatedState/ReplicatedState.tpp
+++ b/arangod/Replication2/ReplicatedState/ReplicatedState.tpp
@@ -274,8 +274,9 @@ template<typename S, template<typename> typename Interface,
          ValidStreamLogMethods ILogMethodsT>
 auto StreamProxy<S, Interface, ILogMethodsT>::waitFor(LogIndex index)
     -> futures::Future<WaitForResult> {
-  // TODO As far as I can tell right now, we can get rid of this:
-  //      Delete this, also in streams::Stream.
+  // TODO We might want to remove waitFor here, in favor of updateCommitIndex.
+  //      It's currently used by DocumentLeaderState::replicateOperation.
+  //      If this is removed, delete it also in streams::Stream.
   return _logMethods->waitFor(index).thenValue(
       [](auto const&) { return WaitForResult(); });
 }

--- a/arangod/Replication2/ReplicatedState/ReplicatedState.tpp
+++ b/arangod/Replication2/ReplicatedState/ReplicatedState.tpp
@@ -321,6 +321,9 @@ auto StreamProxy<S, Interface, ILogMethodsT>::release(LogIndex index) -> void {
       }
     })();
 
+    // The DocumentFollowerState does not synchronize calls to `release()` with
+    // resigning (see https://github.com/arangodb/arangodb/pull/17850).
+    // It relies on this method to throw an exception in that case.
     throw replicated_log::ParticipantResignedException(errorCode, ADB_HERE);
   }
 }


### PR DESCRIPTION
### Scope & Purpose

Since #17850, the DocumentFollowerState no longer synchronizes resigning with calling release on the stream. But calls to release on a resigned stream caused a nullptr-deref. This PR changes that, so it throws an exception instead.

- [X] :hankey: Bugfix

#### Related Information

- [X] Jira ticket: https://arangodb.atlassian.net/browse/CINFRA-647


