### PR TITLE
add startup option to configure number of bloom bits

### DIFF
--- a/arangod/RocksDBEngine/RocksDBOptionFeature.cpp
+++ b/arangod/RocksDBEngine/RocksDBOptionFeature.cpp
@@ -231,6 +231,7 @@ RocksDBOptionFeature::RocksDBOptionFeature(Server& server)
       _targetFileSizeMultiplier(rocksDBDefaults.target_file_size_multiplier),
       _blockCacheSize(::defaultBlockCacheSize()),
       _blockCacheShardBits(-1),
+      _bloomBitsPerKey(10.0),
       _tableBlockSize(std::max(
           rocksDBTableOptionsDefaults.block_size,
           static_cast<decltype(rocksDBTableOptionsDefaults.block_size)>(16 *
@@ -920,6 +921,19 @@ the overall size of the block cache.)");
           arangodb::options::Flags::OnDBServer,
           arangodb::options::Flags::OnSingle));
 
+  options
+      ->addOption(
+          "--rocksdb.bloom-filter-bits-per-key",
+          "The average number of bits to use per key in a Bloom filter.",
+          new DoubleParameter(&_bloomBitsPerKey),
+          arangodb::options::makeFlags(
+              arangodb::options::Flags::Uncommon,
+              arangodb::options::Flags::DefaultNoComponents,
+              arangodb::options::Flags::OnAgent,
+              arangodb::options::Flags::OnDBServer,
+              arangodb::options::Flags::OnSingle))
+      .setIntroducedIn(31003);
+
   options->addOption(
       "--rocksdb.compaction-read-ahead-size",
       "If non-zero, bigger reads are performed when doing compaction. If you "
@@ -1355,6 +1369,7 @@ void RocksDBOptionFeature::start() {
       << ", periodic_compaction_ttl: " << _periodicCompactionTtl
       << ", checksum: " << _checksumType
       << ", format_version: " << _formatVersion
+      << ", bloom_bits_per_key: " << _bloomBitsPerKey
       << ", enable_index_compression: " << std::boolalpha
       << _enableIndexCompression
       << ", prepopulate_block_cache: " << std::boolalpha
@@ -1582,7 +1597,8 @@ rocksdb::BlockBasedTableOptions RocksDBOptionFeature::doGetTableOptions()
   result.pin_top_level_index_and_filter = _pinTopLevelIndexAndFilter;
 
   result.block_size = _tableBlockSize;
-  result.filter_policy.reset(rocksdb::NewBloomFilterPolicy(10, true));
+  result.filter_policy.reset(
+      rocksdb::NewBloomFilterPolicy(_bloomBitsPerKey, true));
   result.enable_index_compression = _enableIndexCompression;
   result.format_version = _formatVersion;
   result.prepopulate_block_cache =

--- a/arangod/RocksDBEngine/RocksDBOptionFeature.h
+++ b/arangod/RocksDBEngine/RocksDBOptionFeature.h
@@ -104,6 +104,7 @@ class RocksDBOptionFeature final : public ArangodFeature,
   uint64_t _targetFileSizeMultiplier;
   uint64_t _blockCacheSize;
   int64_t _blockCacheShardBits;
+  double _bloomBitsPerKey;
   uint64_t _tableBlockSize;
   uint64_t _compactionReadaheadSize;
   int64_t _level0CompactionTrigger;


### PR DESCRIPTION
### Scope & Purpose

Added startup option to configure the number of bloom bits per key. The default value is 10, which is downwards-compatible to the previously hard-coded value.

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.10: https://github.com/arangodb/arangodb/pull/17892
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 