### PR TITLE
improve query plan serialization time

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,22 @@
 devel
 -----
 
+* Added new stage "instantiating executors" to the query profiling output.
+  The time spent in "instantiating executors" is the time needed to create
+  the query executors from the final query execution time. In cluster mode,
+  this stage also includes the time needed for physically distributing the 
+  query snippets to the participating database servers.
+  Previously, the time spent for instantiating executors and the physical
+  distribution was contained in the "optimizing plan" stage, which was
+  misleading.
+
+* Remove constant values for query variables from query plan serialization 
+  in cases they were not needed. Previously, constant values of query variables
+  were always serialized for all occurrences of a variable in a query plan.
+  If the constant values were large, this contributed to higher serialization
+  and thus query setup times. Now the constant values are only serialized
+  for relevant parts of query execution plans.
+
 * BTS-199: remove check for environment variable `GLIBCXX_FORCE_NEW` from 
   server start, and remove setting this variable from startup scripts. 
   The reason is that the environment variable only controls the behavior of

--- a/arangod/Aql/Ast.cpp
+++ b/arangod/Aql/Ast.cpp
@@ -1346,10 +1346,7 @@ AstNode* Ast::createNodeValueInt(int64_t value) {
   AstNode* node = createNode(NODE_TYPE_VALUE);
   node->setValueType(VALUE_TYPE_INT);
   node->setIntValue(value);
-  node->setFlag(DETERMINED_CONSTANT, VALUE_CONSTANT);
-  node->setFlag(DETERMINED_SIMPLE, VALUE_SIMPLE);
-  node->setFlag(DETERMINED_RUNONDBSERVER, VALUE_RUNONDBSERVER);
-
+  node->setConstantFlags();
   return node;
 }
 
@@ -1367,10 +1364,7 @@ AstNode* Ast::createNodeValueDouble(double value) {
   AstNode* node = createNode(NODE_TYPE_VALUE);
   node->setValueType(VALUE_TYPE_DOUBLE);
   node->setDoubleValue(value);
-  node->setFlag(DETERMINED_CONSTANT, VALUE_CONSTANT);
-  node->setFlag(DETERMINED_SIMPLE, VALUE_SIMPLE);
-  node->setFlag(DETERMINED_RUNONDBSERVER, VALUE_RUNONDBSERVER);
-
+  node->setConstantFlags();
   return node;
 }
 
@@ -1403,10 +1397,7 @@ AstNode* Ast::createNodeValueString(char const* value, size_t length) {
   AstNode* node = createNode(NODE_TYPE_VALUE);
   node->setValueType(VALUE_TYPE_STRING);
   node->setStringValue(value, length);
-  node->setFlag(DETERMINED_CONSTANT, VALUE_CONSTANT);
-  node->setFlag(DETERMINED_SIMPLE, VALUE_SIMPLE);
-  node->setFlag(DETERMINED_RUNONDBSERVER, VALUE_RUNONDBSERVER);
-
+  node->setConstantFlags();
   return node;
 }
 
@@ -3966,7 +3957,7 @@ AstNode* Ast::optimizeObject(AstNode* node) {
 /// sure then that string values are valid through the query lifetime.
 AstNode* Ast::nodeFromVPack(VPackSlice slice, bool copyStringValues) {
   if (slice.isBoolean()) {
-    return createNodeValueBool(slice.getBoolean());
+    return createNodeValueBool(slice.isTrue());
   }
 
   if (slice.isNumber()) {
@@ -4008,16 +3999,12 @@ AstNode* Ast::nodeFromVPack(VPackSlice slice, bool copyStringValues) {
       it.next();
     }
 
-    node->setFlag(DETERMINED_CONSTANT, VALUE_CONSTANT);
-    node->setFlag(DETERMINED_SIMPLE, VALUE_SIMPLE);
-    node->setFlag(DETERMINED_RUNONDBSERVER, VALUE_RUNONDBSERVER);
-
+    node->setConstantFlags();
     return node;
   }
 
   if (slice.isObject()) {
     VPackObjectIterator it(slice, true);
-
     auto node = createNodeObject();
     node->members.reserve(static_cast<size_t>(it.size()));
 
@@ -4037,10 +4024,7 @@ AstNode* Ast::nodeFromVPack(VPackSlice slice, bool copyStringValues) {
       it.next();
     }
 
-    node->setFlag(DETERMINED_CONSTANT, VALUE_CONSTANT);
-    node->setFlag(DETERMINED_SIMPLE, VALUE_SIMPLE);
-    node->setFlag(DETERMINED_RUNONDBSERVER, VALUE_RUNONDBSERVER);
-
+    node->setConstantFlags();
     return node;
   }
 
@@ -4369,6 +4353,7 @@ AstNode* Ast::endSubQuery() {
 }
 
 bool Ast::isInSubQuery() const { return (_queries.size() > 1); }
+
 std::unordered_set<std::string> Ast::bindParameters() const {
   return std::unordered_set<std::string>(_bindParameters);
 }

--- a/arangod/Aql/AstNode.h
+++ b/arangod/Aql/AstNode.h
@@ -297,15 +297,11 @@ struct AstNode {
   static void validateValueType(int type);
 
   /// @brief fetch a node's type from VPack
-  static AstNodeType getNodeTypeFromVPack(
-      arangodb::velocypack::Slice const& slice);
+  static AstNodeType getNodeTypeFromVPack(arangodb::velocypack::Slice slice);
 
-  /**
-   * @brief Helper class to check if this node can be represented as VelocyPack
-   * If this method returns FALSE a call to "toVelocyPackValue" will yield
-   * no change in the handed in builder.
-   * On TRUE it is guaranteed that the handed in Builder was modified.
-   */
+  void setConstantFlags() noexcept;
+
+  /// @brief function to check if this node can be represented as VelocyPack.
   bool valueHasVelocyPackRepresentation() const;
 
   /// @brief build a VelocyPack representation of the node value

--- a/arangod/Aql/EngineInfoContainerDBServerServerBased.cpp
+++ b/arangod/Aql/EngineInfoContainerDBServerServerBased.cpp
@@ -192,8 +192,9 @@ EngineInfoContainerDBServerServerBased::buildSetupRequest(
     network::RequestOptions const& options) const {
   TRI_ASSERT(!server.starts_with("server:"));
 
-  VPackBuffer<uint8_t> buffer(infoSlice.byteSize());
-  buffer.append(infoSlice.begin(), infoSlice.byteSize());
+  auto byteSize = infoSlice.byteSize();
+  VPackBuffer<uint8_t> buffer(byteSize);
+  buffer.append(infoSlice.begin(), byteSize);
 
   // add the transaction ID header
   network::Headers headers;

--- a/arangod/Aql/Functions.cpp
+++ b/arangod/Aql/Functions.cpp
@@ -9539,7 +9539,7 @@ AqlValue DistanceImpl(aql::ExpressionContext* expressionContext,
                       F&& distanceFunc) {
   auto calculateDistance = [distanceFunc = std::forward<F>(distanceFunc),
                             expressionContext,
-                            &node](const VPackSlice lhs, const VPackSlice rhs) {
+                            &node](VPackSlice lhs, VPackSlice rhs) {
     TRI_ASSERT(lhs.isArray());
     TRI_ASSERT(rhs.isArray());
     auto lhsLength = lhs.length();

--- a/arangod/Aql/Query.cpp
+++ b/arangod/Aql/Query.cpp
@@ -347,6 +347,8 @@ void Query::prepareQuery(SerializationFormat format) {
       }
     }
 
+    enterState(QueryExecutionState::ValueType::PHYSICAL_INSTANTIATION);
+
     // simon: assumption is _queryString is empty for DBServer snippets
     bool const planRegisters = !_queryString.empty();
     ExecutionEngine::instantiateFromPlan(*this, *plan, planRegisters, format);

--- a/arangod/Aql/QueryExecutionState.cpp
+++ b/arangod/Aql/QueryExecutionState.cpp
@@ -31,16 +31,17 @@ using namespace arangodb::aql;
 
 /// @brief names of query phases / states
 static std::string const StateNames[] = {
-    "initializing",         // INITIALIZATION
-    "parsing",              // PARSING
-    "optimizing ast",       // AST_OPTIMIZATION
-    "loading collections",  // LOADING_COLLECTIONS
-    "instantiating plan",   // PLAN_INSTANTIATION
-    "optimizing plan",      // PLAN_OPTIMIZATION
-    "executing",            // EXECUTION
-    "finalizing",           // FINALIZATION
-    "finished",             // FINISHED
-    "killed",               // KILLED
+    "initializing",             // INITIALIZATION
+    "parsing",                  // PARSING
+    "optimizing ast",           // AST_OPTIMIZATION
+    "loading collections",      // LOADING_COLLECTIONS
+    "instantiating plan",       // PLAN_INSTANTIATION
+    "optimizing plan",          // PLAN_OPTIMIZATION
+    "instantiating executors",  // PHYSICAL_INSTANTIATION
+    "executing",                // EXECUTION
+    "finalizing",               // FINALIZATION
+    "finished",                 // FINISHED
+    "killed",                   // KILLED
 
     "invalid"  // INVALID
 };

--- a/arangod/Aql/QueryExecutionState.h
+++ b/arangod/Aql/QueryExecutionState.h
@@ -28,9 +28,7 @@
 #include <iosfwd>
 #include <string>
 
-namespace arangodb {
-namespace aql {
-namespace QueryExecutionState {
+namespace arangodb::aql::QueryExecutionState {
 
 /// @brief execution states
 enum class ValueType {
@@ -40,6 +38,7 @@ enum class ValueType {
   LOADING_COLLECTIONS,
   PLAN_INSTANTIATION,
   PLAN_OPTIMIZATION,
+  PHYSICAL_INSTANTIATION,
   EXECUTION,
   FINALIZATION,
   FINISHED,
@@ -52,9 +51,7 @@ size_t toNumber(QueryExecutionState::ValueType value);
 std::string const& toString(QueryExecutionState::ValueType state);
 std::string toStringWithPrefix(QueryExecutionState::ValueType state);
 
-}  // namespace QueryExecutionState
-}  // namespace aql
-}  // namespace arangodb
+}  // namespace arangodb::aql::QueryExecutionState
 
 std::ostream& operator<<(std::ostream&,
                          arangodb::aql::QueryExecutionState::ValueType);

--- a/arangod/Aql/QueryProfile.h
+++ b/arangod/Aql/QueryProfile.h
@@ -78,7 +78,7 @@ static_assert(
     static_cast<int>(QueryExecutionState::ValueType::INITIALIZATION) == 0,
     "unexpected min QueryExecutionState enum value");
 static_assert(static_cast<int>(QueryExecutionState::ValueType::INVALID_STATE) <
-                  11,
+                  12,
               "unexpected max QueryExecutionState enum value");
 
 }  // namespace aql

--- a/arangod/Aql/TraversalNode.cpp
+++ b/arangod/Aql/TraversalNode.cpp
@@ -513,7 +513,7 @@ void TraversalNode::doToVelocyPack(VPackBuilder& nodes, unsigned flags) const {
       nodes.add(VPackValue("variables"));
       VPackArrayBuilder postFilterVariablesGuard(&nodes);
       for (auto const& var : _postFilterVariables) {
-        var->toVelocyPack(nodes);
+        var->toVelocyPack(nodes, Variable::WithConstantValue{});
       }
     }
   }

--- a/arangod/Aql/TraverserEngineShardLists.cpp
+++ b/arangod/Aql/TraverserEngineShardLists.cpp
@@ -120,7 +120,7 @@ void TraverserEngineShardLists::serializeIntoBuilder(
       infoBuilder.add(VPackValue("variables"));
       infoBuilder.openArray();
       for (auto v : vars) {
-        v->toVelocyPack(infoBuilder);
+        v->toVelocyPack(infoBuilder, Variable::WithConstantValue{});
       }
       infoBuilder.close();
     }

--- a/arangod/Aql/VariableGenerator.cpp
+++ b/arangod/Aql/VariableGenerator.cpp
@@ -153,7 +153,7 @@ std::string VariableGenerator::nextName() {
 void VariableGenerator::toVelocyPack(VPackBuilder& builder) const {
   VPackArrayBuilder guard(&builder);
   for (auto const& it : _variables) {
-    it.second->toVelocyPack(builder);
+    it.second->toVelocyPack(builder, Variable::WithConstantValue{});
   }
 }
 

--- a/js/apps/system/_admin/aardvark/APP/frontend/js/views/queryView.js
+++ b/js/apps/system/_admin/aardvark/APP/frontend/js/views/queryView.js
@@ -2393,7 +2393,7 @@
           var profileWidth = 590;
 
           var legend = [
-            'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H'
+            'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I'
           ];
 
           var colors = [
@@ -2403,6 +2403,7 @@
             'rgb(93, 165, 218)',
             'rgb(250, 164, 58)',
             'rgb(64, 74, 83)',
+            'rgb(110, 112, 57)',
             'rgb(96, 189, 104)',
             'rgb(221, 224, 114)'
           ];
@@ -2412,8 +2413,9 @@
             'query parsing',
             'abstract syntax tree optimizations',
             'loading collections',
-            'instanciation of initial execution plan',
+            'instantiation of initial execution plan',
             'execution plan optimization and permutation',
+            'instantiation of query executors (incl. distribution)',
             'query execution',
             'query finalization'
           ];

--- a/js/common/modules/@arangodb/aql/explainer.js
+++ b/js/common/modules/@arangodb/aql/explainer.js
@@ -2625,8 +2625,8 @@ function explainQuerysRegisters(plan) {
    *     type: string,
    *     unusedRegsStack: Array<number[]>,
    *     varInfoList: Array<{VariableId: number, RegisterId: number, depth: number}>,
-   *     varsSetHere: Array<{id: number, name: string, isDataFromCollection: boolean}>,
-   *     varsUsedHere: Array<{id: number, name: string, isDataFromCollection: boolean}>,
+   *     varsSetHere: Array<{id: number, name: string, isFullDocumentFromCollection: boolean}>,
+   *     varsUsedHere: Array<{id: number, name: string, isFullDocumentFromCollection: boolean}>,
    *   }
    * }
    */

--- a/js/server/modules/@arangodb/testutils/aql-profiler-test-helper.js
+++ b/js/server/modules/@arangodb/testutils/aql-profiler-test-helper.js
@@ -319,6 +319,7 @@ function assertIsProfileProfileObject (profile) {
     'loading collections',
     'instantiating plan',
     'optimizing plan',
+    'instantiating executors',
     'executing',
     'finalizing',
   ]);
@@ -388,7 +389,7 @@ function assertIsProfilePlanObject (plan) {
     expect(variable).to.include.all.keys([
       'id',
       'name',
-      'isDataFromCollection',
+      'isFullDocumentFromCollection',
     ]);
 
     expect(variable.id).to.be.a('number');


### PR DESCRIPTION
### Scope & Purpose

Improve query plan serialization time

* Added new stage "instantiating executors" to the query profiling output. The time spent in "instantiating executors" is the time needed to create the query executors from the final query execution time. In cluster mode, this stage also includes the time needed for physically distributing the query snippets to the participating database servers. Previously, the time spent for instantiating executors and the physical distribution was contained in the "optimizing plan" stage, which was misleading.

* Remove constant values for query variables from query plan serialization in cases they were not needed. Previously, constant values of query variables were always serialized for all occurrences of a variable in a query plan. If the constant values were large, this contributed to higher serialization and thus query setup times. Now the constant values are only serialized for relevant parts of query execution plans.

The relevant change in this PR that has the largest effect on performance is that the `toVelocyPack(...)` method of `aql::Variable` now doesn't include constant values anymore. There is new overload of that method that will also include constant values, but it has to be called explicitly. This is now done only in a few dedicated places. All other places that call `toVelocyPack(...)` will call the method that doesn't serialize the constant values.
The rest of this PR contains a bit of cleanup, which is not relevant for the performance improvement.

- [x] :hankey: Bugfix
- [x] :pizza: New feature
- [x] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: https://github.com/arangodb/arangodb/pull/17900
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 