### PR TITLE
improve query plan serialization time

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,13 @@
 v3.10.3 (XXXX-XX-XX)
 --------------------
 
+* Remove constant values for query variables from query plan serialization
+  in cases they were not needed. Previously, constant values of query variables
+  were always serialized for all occurrences of a variable in a query plan.
+  If the constant values were large, this contributed to higher serialization
+  and thus query setup times. Now the constant values are only serialized
+  for relevant parts of query execution plans.
+
 * Improve performance of RocksDB's transaction lock manager by using different
   container types for the locked keys maps.
   This can improve performance of write-heavy operations that are not I/O-bound

--- a/arangod/Aql/TraversalNode.cpp
+++ b/arangod/Aql/TraversalNode.cpp
@@ -508,7 +508,7 @@ void TraversalNode::doToVelocyPack(VPackBuilder& nodes, unsigned flags) const {
       nodes.add(VPackValue("variables"));
       VPackArrayBuilder postFilterVariablesGuard(&nodes);
       for (auto const& var : _postFilterVariables) {
-        var->toVelocyPack(nodes);
+        var->toVelocyPack(nodes, Variable::WithConstantValue{});
       }
     }
   }

--- a/arangod/Aql/TraverserEngineShardLists.cpp
+++ b/arangod/Aql/TraverserEngineShardLists.cpp
@@ -119,7 +119,7 @@ void TraverserEngineShardLists::serializeIntoBuilder(
       infoBuilder.add(VPackValue("variables"));
       infoBuilder.openArray();
       for (auto v : vars) {
-        v->toVelocyPack(infoBuilder);
+        v->toVelocyPack(infoBuilder, Variable::WithConstantValue{});
       }
       infoBuilder.close();
     }

--- a/arangod/Aql/Variable.cpp
+++ b/arangod/Aql/Variable.cpp
@@ -27,8 +27,10 @@
 #include "Basics/VelocyPackHelper.h"
 #include "Basics/debugging.h"
 
+#include <velocypack/Builder.h>
 #include <velocypack/Slice.h>
 
+using namespace arangodb;
 using namespace arangodb::aql;
 
 /// @brief create the variable
@@ -38,22 +40,19 @@ Variable::Variable(std::string name, VariableId id,
       name(std::move(name)),
       isFullDocumentFromCollection(isFullDocumentFromCollection) {}
 
-Variable::Variable(arangodb::velocypack::Slice const& slice)
-    : id(arangodb::basics::VelocyPackHelper::checkAndGetNumericValue<
-          VariableId>(slice, "id")),
-      name(arangodb::basics::VelocyPackHelper::checkAndGetStringValue(slice,
-                                                                      "name")),
-      isFullDocumentFromCollection(
-          arangodb::basics::VelocyPackHelper::getBooleanValue(
-              slice, "isFullDocumentFromCollection", false)),
+Variable::Variable(velocypack::Slice slice)
+    : id(basics::VelocyPackHelper::checkAndGetNumericValue<VariableId>(slice,
+                                                                       "id")),
+      name(basics::VelocyPackHelper::checkAndGetStringValue(slice, "name")),
+      isFullDocumentFromCollection(basics::VelocyPackHelper::getBooleanValue(
+          slice, "isFullDocumentFromCollection", false)),
       _constantValue(slice.get("constantValue")) {
   if (!isFullDocumentFromCollection) {
     // "isDataFromCollection" used to be the old attribute name, used
     // before 3.10. for downwards-compatibility we also check the old attribute
     // here. this can be removed after 3.10.
-    isFullDocumentFromCollection |=
-        arangodb::basics::VelocyPackHelper::getBooleanValue(
-            slice, "isDataFromCollection", false);
+    isFullDocumentFromCollection |= basics::VelocyPackHelper::getBooleanValue(
+        slice, "isDataFromCollection", false);
   }
 }
 
@@ -64,29 +63,30 @@ Variable* Variable::clone() const {
   return new Variable(name, id, isFullDocumentFromCollection);
 }
 
-bool Variable::isUserDefined() const {
+bool Variable::isUserDefined() const noexcept {
   TRI_ASSERT(!name.empty());
   char const c = name[0];
   // variables starting with a number are not user-defined
   return (c < '0' || c > '9');
 }
 
-bool Variable::needsRegister() const {
+bool Variable::needsRegister() const noexcept {
   TRI_ASSERT(!name.empty());
   // variables starting with a number are not user-defined
   return isUserDefined() || name.back() != '_';
 }
 
 /// @brief return a VelocyPack representation of the variable
-void Variable::toVelocyPack(VPackBuilder& builder) const {
+void Variable::toVelocyPack(velocypack::Builder& builder) const {
   VPackObjectBuilder b(&builder);
-  builder.add("id", VPackValue(id));
-  builder.add("name", VPackValue(name));
-  builder.add("isFullDocumentFromCollection",
-              VPackValue(isFullDocumentFromCollection));
-  // "isDataFromCollection" was the attribute name used before 3.10 and can be
-  // removed after 3.10.
-  builder.add("isDataFromCollection", VPackValue(isFullDocumentFromCollection));
+  toVelocyPackCommon(builder);
+}
+
+/// @brief return a VelocyPack representation of the variable
+void Variable::toVelocyPack(velocypack::Builder& builder,
+                            Variable::WithConstantValue /*tag*/) const {
+  VPackObjectBuilder b(&builder);
+  toVelocyPackCommon(builder);
 
   if (type() == Variable::Type::Const) {
     builder.add(VPackValue("constantValue"));
@@ -95,26 +95,34 @@ void Variable::toVelocyPack(VPackBuilder& builder) const {
   }
 }
 
+void Variable::toVelocyPackCommon(velocypack::Builder& builder) const {
+  builder.add("id", VPackValue(id));
+  builder.add("name", VPackValue(name));
+  // "isDataFromCollection" was the attribute name used before 3.10 and can be
+  // removed after 3.10.
+  builder.add("isDataFromCollection", VPackValue(isFullDocumentFromCollection));
+  builder.add("isFullDocumentFromCollection",
+              VPackValue(isFullDocumentFromCollection));
+}
+
 /// @brief replace a variable by another
 Variable const* Variable::replace(
     Variable const* variable,
     std::unordered_map<VariableId, Variable const*> const& replacements) {
   while (variable != nullptr) {
     auto it = replacements.find(variable->id);
-    if (it != replacements.end()) {
-      variable = (*it).second;
-    } else {
+    if (it == replacements.end()) {
       break;
     }
+    variable = (*it).second;
   }
 
   return variable;
 }
 
 /// @brief factory for (optional) variables from VPack
-Variable* Variable::varFromVPack(Ast* ast,
-                                 arangodb::velocypack::Slice const& base,
-                                 char const* variableName, bool optional) {
+Variable* Variable::varFromVPack(Ast* ast, velocypack::Slice base,
+                                 std::string_view variableName, bool optional) {
   VPackSlice variable = base.get(variableName);
 
   if (variable.isNone()) {
@@ -125,12 +133,12 @@ Variable* Variable::varFromVPack(Ast* ast,
     std::string msg;
     msg +=
         "mandatory variable \"" + std::string(variableName) + "\" not found.";
-    THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_INTERNAL, msg);
+    THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_INTERNAL, std::move(msg));
   }
   return ast->variables()->createVariable(variable);
 }
 
-bool Variable::isEqualTo(Variable const& other) const {
+bool Variable::isEqualTo(Variable const& other) const noexcept {
   return (id == other.id) && (name == other.name);
 }
 

--- a/arangod/Aql/VariableGenerator.cpp
+++ b/arangod/Aql/VariableGenerator.cpp
@@ -153,7 +153,7 @@ std::string VariableGenerator::nextName() {
 void VariableGenerator::toVelocyPack(VPackBuilder& builder) const {
   VPackArrayBuilder guard(&builder);
   for (auto const& it : _variables) {
-    it.second->toVelocyPack(builder);
+    it.second->toVelocyPack(builder, Variable::WithConstantValue{});
   }
 }
 


### PR DESCRIPTION
### Scope & Purpose

Partial backport of https://github.com/arangodb/arangodb/pull/17897



Remove constant values for query variables from query plan serialization in cases they were not needed. Previously, constant values of query variables were always serialized for all occurrences of a variable in a query plan. If the constant values were large, this contributed to higher serialization and thus query setup times. Now the constant values are only serialized for relevant parts of query execution plans.

The relevant change in this PR that has the largest effect on performance is that the toVelocyPack(...) method of aql::Variable now doesn't include constant values anymore. There is new overload of that method that will also include constant values, but it has to be called explicitly. This is now done only in a few dedicated places. All other places that call toVelocyPack(...) will call the method that doesn't serialize the constant values.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [x] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [x] Backports
  - [x] Backport for 3.10: this PR
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

