### PR TITLE
Improve efficiency of array/object serialization in query plans

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,12 @@ devel
   setup, and also reduce the time needed for parsing these messages. This 
   especially helps when there are large bind parameter values that are arrays
   or objects.
+  The more efficient format is used also inside an AQL query's "explain" and 
+  "profile" methods, and thus any callers that process the return values of
+  explain and profile operations may now receive the new format. All callers
+  inside the ArangoDB code have been adjusted, but any external callers that
+  process the JSON response values of AQL query explain or profile operations
+  may need to be adjusted to handle the new format.
 
 * Added new stage "instantiating executors" to the query profiling output.
   The time spent in "instantiating executors" is the time needed to create

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,13 @@
 devel
 -----
 
+* Use more compact and efficient representation for arrays and objects during
+  AQL AST serialization and deserialization. This can help to reduce the size
+  of messages exchanged between coordinator and database servers during query
+  setup, and also reduce the time needed for parsing these messages. This 
+  especially helps when there are large bind parameter values that are arrays
+  or objects.
+
 * BTS-199: remove check for environment variable `GLIBCXX_FORCE_NEW` from 
   server start, and remove setting this variable from startup scripts. 
   The reason is that the environment variable only controls the behavior of

--- a/arangod/Aql/AqlCallList.cpp
+++ b/arangod/Aql/AqlCallList.cpp
@@ -24,29 +24,23 @@
 #include "AqlCallList.h"
 
 #include "Basics/StaticStrings.h"
+#include "Basics/debugging.h"
 #include "Basics/voc-errors.h"
 #include "Containers/Enumerate.h"
 #include "Logger/LogMacros.h"
 #include "Logger/Logger.h"
 
 #include <velocypack/Builder.h>
-#include <velocypack/Collection.h>
+#include <velocypack/Iterator.h>
 #include <velocypack/Slice.h>
 
+#include <algorithm>
+#include <array>
 #include <iostream>
-#include <map>
 #include <string_view>
 
 using namespace arangodb;
 using namespace arangodb::aql;
-
-namespace {
-// hack for MSVC
-auto getStringView(VPackSlice slice) -> std::string_view {
-  std::string_view ref = slice.stringView();
-  return std::string_view(ref.data(), ref.size());
-}
-}  // namespace
 
 AqlCallList::AqlCallList(AqlCall const& call) : _specificCalls{call} {
   // We can never create a new CallList with existing skipCounter
@@ -66,7 +60,7 @@ AqlCallList::AqlCallList(AqlCall const& specificCall,
   if (!_specificCalls.empty()) {
     // We only implemented for a single given call.
     TRI_ASSERT(_specificCalls.size() == 1);
-    auto res = _specificCalls.back();
+    auto res = std::move(_specificCalls.back());
     _specificCalls.pop_back();
     return res;
   }
@@ -121,9 +115,13 @@ auto AqlCallList::fromVelocyPack(VPackSlice slice) -> ResultT<AqlCallList> {
                       slice.typeName());
   }
 
-  auto expectedPropertiesFound = std::map<std::string_view, bool>{};
-  expectedPropertiesFound.emplace(StaticStrings::AqlCallListSpecific, false);
-  expectedPropertiesFound.emplace(StaticStrings::AqlCallListDefault, false);
+  // we only have 2 different keys to check. using an std::map requires
+  // dynamic memory allocation and would be wasteful. instead, use a simple
+  // std::array here to get rid of any allocations
+  auto expectedPropertiesFound =
+      std::array<std::pair<std::string_view, bool>, 2>{
+          {{StaticStrings::AqlCallListSpecific, false},
+           {StaticStrings::AqlCallListDefault, false}}};
 
   auto const readSpecific =
       [](velocypack::Slice slice) -> ResultT<std::vector<AqlCall>> {
@@ -137,7 +135,7 @@ auto AqlCallList::fromVelocyPack(VPackSlice slice) -> ResultT<AqlCallList> {
     }
     std::vector<AqlCall> res;
     res.reserve(slice.length());
-    for (VPackSlice const c : VPackArrayIterator(slice)) {
+    for (VPackSlice c : VPackArrayIterator(slice)) {
       auto maybeAqlCall = AqlCall::fromVelocyPack(c);
       if (ADB_UNLIKELY(maybeAqlCall.fail())) {
         auto message = std::string{"When deserializing AqlCallList: entry "};
@@ -146,14 +144,17 @@ auto AqlCallList::fromVelocyPack(VPackSlice slice) -> ResultT<AqlCallList> {
         message += maybeAqlCall.errorMessage();
         return Result(TRI_ERROR_TYPE_ERROR, std::move(message));
       }
-      res.emplace_back(maybeAqlCall.get());
+      res.emplace_back(std::move(maybeAqlCall.get()));
     }
     return res;
   };
 
   auto const readDefault =
       [](velocypack::Slice slice) -> ResultT<std::optional<AqlCall>> {
-    if (ADB_UNLIKELY(!slice.isObject() && !slice.isNull())) {
+    if (slice.isNull()) {
+      return {std::nullopt};
+    }
+    if (ADB_UNLIKELY(!slice.isObject())) {
       auto message =
           std::string{"When deserializating AqlCallList: When reading " +
                       StaticStrings::AqlCallListDefault +
@@ -161,9 +162,6 @@ auto AqlCallList::fromVelocyPack(VPackSlice slice) -> ResultT<AqlCallList> {
                       "Unexpected type "};
       message += slice.typeName();
       return Result(TRI_ERROR_TYPE_ERROR, std::move(message));
-    }
-    if (slice.isNull()) {
-      return {std::nullopt};
     }
     auto maybeAqlCall = AqlCall::fromVelocyPack(slice);
     if (ADB_UNLIKELY(maybeAqlCall.fail())) {
@@ -177,16 +175,15 @@ auto AqlCallList::fromVelocyPack(VPackSlice slice) -> ResultT<AqlCallList> {
   AqlCallList result{AqlCall{}};
 
   for (auto const it : velocypack::ObjectIterator(slice)) {
-    auto const keySlice = it.key;
-    if (ADB_UNLIKELY(!keySlice.isString())) {
-      return Result(TRI_ERROR_TYPE_ERROR,
-                    "When deserializating AqlCallList: Key is not a string");
-    }
-    auto const key = getStringView(keySlice);
+    auto key = it.key.stringView();
 
-    if (auto propIt = expectedPropertiesFound.find(key);
+    if (auto propIt = std::find_if(
+            expectedPropertiesFound.begin(), expectedPropertiesFound.end(),
+            [&key](auto const& epf) { return epf.first == key; });
         ADB_LIKELY(propIt != expectedPropertiesFound.end())) {
       if (ADB_UNLIKELY(propIt->second)) {
+        // should never happen
+        TRI_ASSERT(false);
         return Result(
             TRI_ERROR_TYPE_ERROR,
             "When deserializating AqlCallList: Encountered duplicate key");

--- a/arangod/Aql/AqlCallList.cpp
+++ b/arangod/Aql/AqlCallList.cpp
@@ -181,6 +181,7 @@ auto AqlCallList::fromVelocyPack(VPackSlice slice) -> ResultT<AqlCallList> {
             expectedPropertiesFound.begin(), expectedPropertiesFound.end(),
             [&key](auto const& epf) { return epf.first == key; });
         ADB_LIKELY(propIt != expectedPropertiesFound.end())) {
+      TRI_ASSERT(!propIt->second);
       propIt->second = true;
     }
 

--- a/arangod/Aql/AqlCallList.cpp
+++ b/arangod/Aql/AqlCallList.cpp
@@ -181,13 +181,6 @@ auto AqlCallList::fromVelocyPack(VPackSlice slice) -> ResultT<AqlCallList> {
             expectedPropertiesFound.begin(), expectedPropertiesFound.end(),
             [&key](auto const& epf) { return epf.first == key; });
         ADB_LIKELY(propIt != expectedPropertiesFound.end())) {
-      if (ADB_UNLIKELY(propIt->second)) {
-        // should never happen
-        TRI_ASSERT(false);
-        return Result(
-            TRI_ERROR_TYPE_ERROR,
-            "When deserializating AqlCallList: Encountered duplicate key");
-      }
       propIt->second = true;
     }
 

--- a/arangod/Aql/Ast.cpp
+++ b/arangod/Aql/Ast.cpp
@@ -382,10 +382,8 @@ void Ast::clearMost() noexcept { _resources.clearMost(); }
 
 /// @brief convert the AST into VelocyPack
 void Ast::toVelocyPack(VPackBuilder& builder, bool verbose) const {
-  {
-    VPackArrayBuilder guard(&builder);
-    _root->toVelocyPack(builder, verbose);
-  }
+  VPackArrayBuilder guard(&builder);
+  _root->toVelocyPack(builder, verbose);
 }
 
 /// @brief add an operation to the AST

--- a/arangod/Aql/Ast.cpp
+++ b/arangod/Aql/Ast.cpp
@@ -3420,7 +3420,7 @@ AstNode* Ast::optimizeBinaryOperatorRelational(
   bool const lhsIsConst = lhs->isConstant();
 
   if (!lhsIsConst) {
-    if (rhs->numMembers() >= AstNode::SortNumberThreshold &&
+    if (rhs->numMembers() >= AstNode::kSortNumberThreshold &&
         rhs->type == NODE_TYPE_ARRAY &&
         (node->type == NODE_TYPE_OPERATOR_BINARY_IN ||
          node->type == NODE_TYPE_OPERATOR_BINARY_NIN)) {

--- a/arangod/Aql/AstNode.cpp
+++ b/arangod/Aql/AstNode.cpp
@@ -44,7 +44,6 @@
 #include <iostream>
 #endif
 
-#include <frozen/string.h>
 #include <frozen/unordered_map.h>
 
 #include <velocypack/Builder.h>

--- a/arangod/Aql/AstNode.cpp
+++ b/arangod/Aql/AstNode.cpp
@@ -834,14 +834,14 @@ void AstNode::sort() {
     // attribute accesses
     std::sort(members.begin(), members.end(),
               [](AstNode const* lhs, AstNode const* rhs) {
-                return (compareAstNodes<false>(lhs, rhs, true) < 0);
+                return compareAstNodes<false>(lhs, rhs, true) < 0;
               });
   } else {
     // slower compare function that needs to resolve attribute
     // accesses
     std::sort(members.begin(), members.end(),
               [](AstNode const* lhs, AstNode const* rhs) {
-                return (compareAstNodes<true>(lhs, rhs, true) < 0);
+                return compareAstNodes<true>(lhs, rhs, true) < 0;
               });
   }
 

--- a/arangod/Aql/AstNode.cpp
+++ b/arangod/Aql/AstNode.cpp
@@ -1093,7 +1093,7 @@ void AstNode::toVelocyPack(VPackBuilder& builder, bool verbose) const {
     // this is a hack to serialize (potentially large) arrays and objects
     // in a more compact way.
     // instead of serializing every array/object member with their "typeID",
-    // "vType", "vTypeID" etc. attributes, we simply store the array/object
+    // "vTypeID" etc. attributes, we simply store the array/object
     // data in plain JSON.
     // when unserializing the data back, we have to check if there is a "raw"
     // attribute, and if it exists, we have to use a special decoder for the
@@ -1111,7 +1111,12 @@ void AstNode::toVelocyPack(VPackBuilder& builder, bool verbose) const {
     toVelocyPackValue(builder);
 
     if (verbose) {
-      builder.add("vType", VPackValue(getValueTypeString()));
+      // it is not necessary to serialize the type name for the value type,
+      // because there is not code that ever reads it back.
+      // not serializing it helps to save a bit of overhead:
+      //   builder.add("vType", VPackValue(getValueTypeString()));
+      // we need to serialize the value type ID though, because that is
+      // later read back
       builder.add("vTypeID", VPackValue(static_cast<int>(value.type)));
     }
   }

--- a/arangod/Aql/AstNode.cpp
+++ b/arangod/Aql/AstNode.cpp
@@ -1087,7 +1087,8 @@ void AstNode::toVelocyPack(VPackBuilder& builder, bool verbose) const {
     builder.add("sorted", VPackValue(hasFlag(VALUE_SORTED)));
   }
 
-  if ((type == NODE_TYPE_ARRAY || type == NODE_TYPE_OBJECT) && isConstant()) {
+  if (verbose && (type == NODE_TYPE_ARRAY || type == NODE_TYPE_OBJECT) &&
+      isConstant() && valueHasVelocyPackRepresentation()) {
     // this is a hack to serialize (potentially large) arrays and objects
     // in a more compact way.
     // instead of serializing every array/object member with their "typeID",

--- a/arangod/Aql/AstNode.h
+++ b/arangod/Aql/AstNode.h
@@ -278,10 +278,10 @@ struct AstNode {
   void sort();
 
   /// @brief return the type name of a node
-  std::string const& getTypeString() const;
+  std::string_view getTypeString() const;
 
   /// @brief return the value type name of a node
-  std::string const& getValueTypeString() const;
+  std::string_view getValueTypeString() const;
 
   /// @brief stringify the AstNode
   static std::string toString(AstNode const*);
@@ -597,7 +597,7 @@ struct AstNode {
 };
 
 template<bool resolveAttributeAccess = true>
-int CompareAstNodes(AstNode const* lhs, AstNode const* rhs, bool compareUtf8);
+int compareAstNodes(AstNode const* lhs, AstNode const* rhs, bool compareUtf8);
 
 struct AstNodeValueHash {
   size_t operator()(AstNode const* value) const noexcept;

--- a/arangod/Aql/AstNode.h
+++ b/arangod/Aql/AstNode.h
@@ -30,7 +30,6 @@
 #include <memory>
 #include <string>
 #include <string_view>
-#include <unordered_map>
 #include <vector>
 
 namespace arangodb {
@@ -231,9 +230,10 @@ static_assert(NODE_TYPE_ARRAY < NODE_TYPE_OBJECT, "incorrect node types order");
 struct AstNode {
   friend class Ast;
 
-  static std::unordered_map<int, std::string const> const Operators;
-  static std::unordered_map<int, std::string const> const TypeNames;
-  static std::unordered_map<int, std::string const> const ValueTypeNames;
+  /// @brief array values with at least this number of members that
+  /// are in IN or NOT IN lookups will be sorted, so that we can use
+  /// a binary sort to do lookups
+  static constexpr size_t kSortNumberThreshold = 8;
 
   /// @brief create the node
   explicit AstNode(AstNodeType);
@@ -246,9 +246,6 @@ struct AstNode {
 
   /// @brief destroy the node
   ~AstNode();
-
- public:
-  static constexpr size_t SortNumberThreshold = 8;
 
   /// @brief return the string value of a node, as an std::string
   std::string getString() const;

--- a/arangod/Aql/Condition.cpp
+++ b/arangod/Aql/Condition.cpp
@@ -342,7 +342,7 @@ bool ConditionPart::isCoveredBy(ConditionPart const& other,
   if (!isExpanded && !other.isExpanded &&
       other.operatorType == NODE_TYPE_OPERATOR_BINARY_IN &&
       other.valueNode->isConstant() && isReversed) {
-    if (CompareAstNodes(other.valueNode, valueNode, false) == 0) {
+    if (compareAstNodes(other.valueNode, valueNode, false) == 0) {
       return true;
     }
   }
@@ -376,7 +376,7 @@ bool ConditionPart::isCoveredBy(ConditionPart const& other,
             auto w = other.valueNode->getMemberUnchecked(j);
 
             ConditionPartCompareResult res =
-                ResultsTable[CompareAstNodes(v, w, true) + 1][0][0];
+                ResultsTable[compareAstNodes(v, w, true) + 1][0][0];
 
             if (res != CompareResult::OTHER_CONTAINED_IN_SELF &&
                 res != CompareResult::CONVERT_EQUAL &&
@@ -412,7 +412,7 @@ bool ConditionPart::isCoveredBy(ConditionPart const& other,
       operatorType == NODE_TYPE_OPERATOR_BINARY_IN &&
       other.operatorType == NODE_TYPE_OPERATOR_BINARY_IN &&
       other.valueNode->isConstant()) {
-    return CompareAstNodes(other.valueNode, valueNode, false) == 0;
+    return compareAstNodes(other.valueNode, valueNode, false) == 0;
   }
 
   bool a = operatorNode->isArrayComparisonOperator();
@@ -437,13 +437,13 @@ bool ConditionPart::isCoveredBy(ConditionPart const& other,
         operatorType == NODE_TYPE_OPERATOR_BINARY_ARRAY_IN &&
         other.operatorType == NODE_TYPE_OPERATOR_BINARY_ARRAY_IN &&
         other.valueNode->isConstant()) {
-      return CompareAstNodes(other.valueNode, valueNode, false) == 0;
+      return compareAstNodes(other.valueNode, valueNode, false) == 0;
     }
   }
 
   // Results are -1, 0, 1, move to 0, 1, 2 for the lookup:
   ConditionPartCompareResult res =
-      ResultsTable[CompareAstNodes(other.valueNode, valueNode, true) + 1]
+      ResultsTable[compareAstNodes(other.valueNode, valueNode, true) + 1]
                   [other.whichCompareOperation()][whichCompareOperation()];
 
   if (res == CompareResult::OTHER_CONTAINED_IN_SELF ||
@@ -1152,7 +1152,7 @@ void Condition::deduplicateJunctionNode(AstNode* unlockedNode) {
             }
             if (current.whichCompareOperation() ==
                     other.whichCompareOperation() &&
-                CompareAstNodes(current.valueNode, other.valueNode, true) ==
+                compareAstNodes(current.valueNode, other.valueNode, true) ==
                     0) {  // duplicate comparison detected - remove it
               TRI_ASSERT(!positions.empty());
               TRI_ASSERT(j < positions.size());
@@ -1396,7 +1396,7 @@ void Condition::optimize(ExecutionPlan* plan, bool multivalued) {
                 for (size_t k = 0; k < values->numMembers(); ++k) {
                   auto value = values->getMemberUnchecked(k);
                   ConditionPartCompareResult res =
-                      ResultsTable[CompareAstNodes(value, other.valueNode,
+                      ResultsTable[compareAstNodes(value, other.valueNode,
                                                    true) +
                                    1][0 /*NODE_TYPE_OPERATOR_BINARY_EQ*/]
                                   [other.whichCompareOperation()];
@@ -1429,7 +1429,7 @@ void Condition::optimize(ExecutionPlan* plan, bool multivalued) {
 
             // Results are -1, 0, 1, move to 0, 1, 2 for the lookup:
             ConditionPartCompareResult res =
-                resultsTable[CompareAstNodes(current.valueNode, other.valueNode,
+                resultsTable[compareAstNodes(current.valueNode, other.valueNode,
                                              true) +
                              1][current.whichCompareOperation()]
                             [other.whichCompareOperation()];

--- a/arangod/Aql/ExecutionPlan.cpp
+++ b/arangod/Aql/ExecutionPlan.cpp
@@ -1319,7 +1319,7 @@ ExecutionNode* ExecutionPlan::fromNodeTraversal(ExecutionNode* previous,
     for (size_t i = 0; i < n; ++i) {
       auto member = start->getMember(i);
       if (member->type == NODE_TYPE_OBJECT_ELEMENT &&
-          member->getString() == StaticStrings::IdString) {
+          member->getStringView() == StaticStrings::IdString) {
         start = member->getMember(0);
         break;
       }
@@ -1397,7 +1397,7 @@ AstNode const* ExecutionPlan::parseTraversalVertexNode(ExecutionNode*& previous,
     for (size_t i = 0; i < n; ++i) {
       auto member = vertex->getMember(i);
       if (member->type == NODE_TYPE_OBJECT_ELEMENT &&
-          member->getString() == StaticStrings::IdString) {
+          member->getStringView() == StaticStrings::IdString) {
         vertex = member->getMember(0);
         break;
       }

--- a/arangod/Aql/Expression.cpp
+++ b/arangod/Aql/Expression.cpp
@@ -209,7 +209,7 @@ bool Expression::findInArray(AqlValue const& left, AqlValue const& right,
 
   size_t const n = right.length();
 
-  if (n >= AstNode::SortNumberThreshold &&
+  if (n >= AstNode::kSortNumberThreshold &&
       (node->getMember(1)->isSorted() ||
        ((node->type == NODE_TYPE_OPERATOR_BINARY_IN ||
          node->type == NODE_TYPE_OPERATOR_BINARY_NIN) &&

--- a/arangod/Aql/Expression.cpp
+++ b/arangod/Aql/Expression.cpp
@@ -49,6 +49,8 @@
 #include "V8/v8-globals.h"
 #include "V8/v8-vpack.h"
 
+#include <absl/strings/str_cat.h>
+
 #include <velocypack/Buffer.h>
 #include <velocypack/Builder.h>
 #include <velocypack/Iterator.h>
@@ -462,10 +464,10 @@ AqlValue Expression::executeSimpleExpression(ExpressionContext& ctx,
       return executeSimpleExpressionNaryAndOr(ctx, node, mustDestroy);
     case NODE_TYPE_COLLECTION:
     case NODE_TYPE_VIEW:
-      THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_NOT_IMPLEMENTED,
-                                     std::string("node type '") +
-                                         node->getTypeString() +
-                                         "' is not supported in expressions");
+      THROW_ARANGO_EXCEPTION_MESSAGE(
+          TRI_ERROR_NOT_IMPLEMENTED,
+          absl::StrCat("node type '", node->getTypeString(),
+                       "' is not supported in expressions"));
 
     default:
       std::string msg("unhandled type '");

--- a/arangod/Aql/OptimizerRules.cpp
+++ b/arangod/Aql/OptimizerRules.cpp
@@ -1164,7 +1164,8 @@ void arangodb::aql::sortInValuesRule(Optimizer* opt,
     }
 
     if (rhs->type == NODE_TYPE_ARRAY) {
-      if (rhs->numMembers() < AstNode::SortNumberThreshold || rhs->isSorted()) {
+      if (rhs->numMembers() < AstNode::kSortNumberThreshold ||
+          rhs->isSorted()) {
         // number of values is below threshold or array is already sorted
         continue;
       }
@@ -1223,7 +1224,7 @@ void arangodb::aql::sortInValuesRule(Optimizer* opt,
       }
 
       if (testNode->type == NODE_TYPE_ARRAY &&
-          testNode->numMembers() < AstNode::SortNumberThreshold) {
+          testNode->numMembers() < AstNode::kSortNumberThreshold) {
         // number of values is below threshold
         continue;
       }
@@ -1259,7 +1260,7 @@ void arangodb::aql::sortInValuesRule(Optimizer* opt,
       // estimate items in subquery
       CostEstimate estimate = sub->getSubquery()->getCost();
 
-      if (estimate.estimatedNrItems < AstNode::SortNumberThreshold) {
+      if (estimate.estimatedNrItems < AstNode::kSortNumberThreshold) {
         continue;
       }
 

--- a/arangod/Aql/OptimizerUtils.cpp
+++ b/arangod/Aql/OptimizerUtils.cpp
@@ -249,7 +249,7 @@ bool sortOrs(aql::Ast* ast, aql::AstNode* root, aql::Variable const* variable,
 
         if (ll != nullptr && lr != nullptr) {
           // both lower bounds are set
-          res = CompareAstNodes(ll, lr, true);
+          res = compareAstNodes(ll, lr, true);
 
           if (res != 0) {
             return res < 0;

--- a/arangod/Aql/SortingGatherExecutor.cpp
+++ b/arangod/Aql/SortingGatherExecutor.cpp
@@ -356,14 +356,14 @@ auto SortingGatherExecutor::produceRows(typename Fetcher::DataRange& input,
     -> std::tuple<ExecutorState, Stats, AqlCallSet> {
   if (!_initialized) {
     // First initialize
-    auto const callSet = initialize(input, output.getClientCall());
+    auto callSet = initialize(input, output.getClientCall());
     if (!callSet.empty()) {
       return {ExecutorState::HASMORE, NoStats{}, std::move(callSet)};
     }
   }
 
   {
-    auto const callSet = requiresMoreInput(input, output.getClientCall());
+    auto callSet = requiresMoreInput(input, output.getClientCall());
     if (!callSet.empty()) {
       return {ExecutorState::HASMORE, NoStats{}, std::move(callSet)};
     }
@@ -381,7 +381,7 @@ auto SortingGatherExecutor::produceRows(typename Fetcher::DataRange& input,
       output.advanceRow();
     }
 
-    auto const callSet = requiresMoreInput(input, output.getClientCall());
+    auto callSet = requiresMoreInput(input, output.getClientCall());
     if (!callSet.empty()) {
       return {ExecutorState::HASMORE, NoStats{}, std::move(callSet)};
     }
@@ -405,14 +405,14 @@ auto SortingGatherExecutor::skipRowsRange(typename Fetcher::DataRange& input,
     -> std::tuple<ExecutorState, Stats, size_t, AqlCallSet> {
   if (!_initialized) {
     // First initialize
-    auto const callSet = initialize(input, call);
+    auto callSet = initialize(input, call);
     if (!callSet.empty()) {
       return {ExecutorState::HASMORE, NoStats{}, 0, std::move(callSet)};
     }
   }
 
   {
-    auto const callSet = requiresMoreInput(input, call);
+    auto callSet = requiresMoreInput(input, call);
     if (!callSet.empty()) {
       return {ExecutorState::HASMORE, NoStats{}, 0, std::move(callSet)};
     }
@@ -432,7 +432,7 @@ auto SortingGatherExecutor::skipRowsRange(typename Fetcher::DataRange& input,
     if (row) {
       call.didSkip(1);
     }
-    auto const callSet = requiresMoreInput(input, call);
+    auto callSet = requiresMoreInput(input, call);
     if (!callSet.empty()) {
       return {ExecutorState::HASMORE, NoStats{}, call.getSkipCount(),
               std::move(callSet)};

--- a/arangod/Aql/SortingGatherExecutor.cpp
+++ b/arangod/Aql/SortingGatherExecutor.cpp
@@ -358,14 +358,14 @@ auto SortingGatherExecutor::produceRows(typename Fetcher::DataRange& input,
     // First initialize
     auto const callSet = initialize(input, output.getClientCall());
     if (!callSet.empty()) {
-      return {ExecutorState::HASMORE, NoStats{}, callSet};
+      return {ExecutorState::HASMORE, NoStats{}, std::move(callSet)};
     }
   }
 
   {
     auto const callSet = requiresMoreInput(input, output.getClientCall());
     if (!callSet.empty()) {
-      return {ExecutorState::HASMORE, NoStats{}, callSet};
+      return {ExecutorState::HASMORE, NoStats{}, std::move(callSet)};
     }
   }
 
@@ -383,7 +383,7 @@ auto SortingGatherExecutor::produceRows(typename Fetcher::DataRange& input,
 
     auto const callSet = requiresMoreInput(input, output.getClientCall());
     if (!callSet.empty()) {
-      return {ExecutorState::HASMORE, NoStats{}, callSet};
+      return {ExecutorState::HASMORE, NoStats{}, std::move(callSet)};
     }
   }
 
@@ -407,14 +407,14 @@ auto SortingGatherExecutor::skipRowsRange(typename Fetcher::DataRange& input,
     // First initialize
     auto const callSet = initialize(input, call);
     if (!callSet.empty()) {
-      return {ExecutorState::HASMORE, NoStats{}, 0, callSet};
+      return {ExecutorState::HASMORE, NoStats{}, 0, std::move(callSet)};
     }
   }
 
   {
     auto const callSet = requiresMoreInput(input, call);
     if (!callSet.empty()) {
-      return {ExecutorState::HASMORE, NoStats{}, 0, callSet};
+      return {ExecutorState::HASMORE, NoStats{}, 0, std::move(callSet)};
     }
   }
 
@@ -434,7 +434,8 @@ auto SortingGatherExecutor::skipRowsRange(typename Fetcher::DataRange& input,
     }
     auto const callSet = requiresMoreInput(input, call);
     if (!callSet.empty()) {
-      return {ExecutorState::HASMORE, NoStats{}, call.getSkipCount(), callSet};
+      return {ExecutorState::HASMORE, NoStats{}, call.getSkipCount(),
+              std::move(callSet)};
     }
   }
 
@@ -476,7 +477,7 @@ auto SortingGatherExecutor::skipRowsRange(typename Fetcher::DataRange& input,
 
   TRI_ASSERT(!input.isDone() || callSet.empty());
 
-  return {input.state(), NoStats{}, call.getSkipCount(), callSet};
+  return {input.state(), NoStats{}, call.getSkipCount(), std::move(callSet)};
 }
 
 bool SortingGatherExecutor::constrainedSort() const noexcept {

--- a/arangod/IResearch/AqlHelper.cpp
+++ b/arangod/IResearch/AqlHelper.cpp
@@ -145,7 +145,7 @@ bool equalTo(aql::AstNode const* lhs, aql::AstNode const* rhs) {
     }
 
     case aql::NODE_TYPE_VALUE: {
-      return 0 == aql::CompareAstNodes(lhs, rhs, true);
+      return 0 == aql::compareAstNodes(lhs, rhs, true);
     }
 
     case aql::NODE_TYPE_OBJECT_ELEMENT: {
@@ -190,7 +190,7 @@ size_t hash(aql::AstNode const* node, size_t hash /*= 0*/) noexcept {
   // hash node type
   auto const& typeString = node->getTypeString();
 
-  hash = fasthash64(static_cast<const void*>(typeString.c_str()),
+  hash = fasthash64(static_cast<const void*>(typeString.data()),
                     typeString.size(), hash);
 
   // hash node members

--- a/arangod/IResearch/AqlHelper.h
+++ b/arangod/IResearch/AqlHelper.h
@@ -464,20 +464,6 @@ struct NormalizedCmpNode {
 };
 
 ////////////////////////////////////////////////////////////////////////////////
-/// @returns pointer to type name for the specified value if it's present in
-///          TypeMap, nullptr otherwise
-////////////////////////////////////////////////////////////////////////////////
-inline std::string const* getNodeTypeName(aql::AstNodeType type) noexcept {
-  auto const it = aql::AstNode::TypeNames.find(type);
-
-  if (aql::AstNode::TypeNames.end() == it) {
-    return nullptr;
-  }
-
-  return &it->second;
-}
-
-////////////////////////////////////////////////////////////////////////////////
 /// @returns pointer to 'idx'th member of type 'expectedType', or nullptr
 ////////////////////////////////////////////////////////////////////////////////
 inline aql::AstNode const* getNode(aql::AstNode const& node, size_t idx,

--- a/arangod/IResearch/IResearchFilterFactory.cpp
+++ b/arangod/IResearch/IResearchFilterFactory.cpp
@@ -1033,7 +1033,7 @@ Result fromRange(irs::boolean_filter* filter, FilterContext const& filterCtx,
   TRI_ASSERT(aql::NODE_TYPE_RANGE == node.type);
 
   if (node.numMembers() != 2) {
-    auto rv = error::malformedNode(node.type);
+    auto rv = error::malformedNode(node);
     return rv.reset(
         TRI_ERROR_BAD_PARAMETER,
         absl::StrCat("wrong number of arguments in range expression: ",
@@ -1382,7 +1382,7 @@ Result fromArrayComparison(irs::boolean_filter*& filter,
              aql::NODE_TYPE_OPERATOR_BINARY_ARRAY_IN == node.type ||
              aql::NODE_TYPE_OPERATOR_BINARY_ARRAY_NIN == node.type);
   if (node.numMembers() != 3) {
-    auto rv = error::malformedNode(node.type);
+    auto rv = error::malformedNode(node);
     return rv.reset(rv.errorNumber(),
                     absl::StrCat("error in Array comparison operator: ",
                                  rv.errorMessage()));
@@ -1702,7 +1702,7 @@ Result fromIn(irs::boolean_filter* filter, FilterContext const& filterCtx,
              aql::NODE_TYPE_OPERATOR_BINARY_NIN == node.type);
 
   if (node.numMembers() != 2) {
-    auto rv = error::malformedNode(node.type);
+    auto rv = error::malformedNode(node);
     return rv.reset(rv.errorNumber(),
                     absl::StrCat("error in from In", rv.errorMessage()));
   }
@@ -1838,7 +1838,7 @@ Result fromNegation(irs::boolean_filter* filter, FilterContext const& filterCtx,
   TRI_ASSERT(aql::NODE_TYPE_OPERATOR_UNARY_NOT == node.type);
 
   if (node.numMembers() != 1) {
-    auto rv = error::malformedNode(node.type);
+    auto rv = error::malformedNode(node);
     return rv.reset(rv.errorNumber(),
                     absl::StrCat("Bad node in negation", rv.errorMessage()));
   }
@@ -1882,7 +1882,7 @@ bool rangeFromBinaryAnd(irs::boolean_filter* filter,
              aql::NODE_TYPE_OPERATOR_NARY_AND == node.type);
 
   if (node.numMembers() != 2) {
-    logMalformedNode(node.type);
+    logMalformedNode(node);
     return false;  // wrong number of members
   }
 
@@ -3864,7 +3864,7 @@ Result fromFCallUser(irs::boolean_filter* filter,
   TRI_ASSERT(aql::NODE_TYPE_FCALL_USER == node.type);
 
   if (node.numMembers() != 1) {
-    return error::malformedNode(node.type);
+    return error::malformedNode(node);
   }
 
   auto const* args = getNode(node, 0, aql::NODE_TYPE_ARRAY);
@@ -3924,7 +3924,7 @@ Result fromFCall(irs::boolean_filter* filter, FilterContext const& filterCtx,
   auto const* fn = static_cast<aql::Function*>(node.getData());
 
   if (!fn || node.numMembers() != 1) {
-    return error::malformedNode(node.type);
+    return error::malformedNode(node);
   }
 
   if (!isFilter(*fn)) {
@@ -3954,7 +3954,7 @@ Result fromFilter(irs::boolean_filter* filter, FilterContext const& filterCtx,
   TRI_ASSERT(aql::NODE_TYPE_FILTER == node.type);
 
   if (node.numMembers() != 1) {
-    auto rv = error::malformedNode(node.type);
+    auto rv = error::malformedNode(node);
     return rv.reset(
         rv.errorNumber(),
         absl::StrCat("wrong number of parameters: ", rv.errorMessage()));

--- a/arangod/IResearch/IResearchFilterFactoryCommon.h
+++ b/arangod/IResearch/IResearchFilterFactoryCommon.h
@@ -234,13 +234,10 @@ inline Result failedToGenerateName(char const* funcName, size_t i) {
                        i, "'")};
 }
 
-inline Result malformedNode(aql::AstNodeType type) {
-  auto const* typeName = getNodeTypeName(type);
-  return {
-      TRI_ERROR_BAD_PARAMETER,
-      absl::StrCat(
-          "Can't process malformed AstNode of type '",
-          (typeName ? absl::AlphaNum{*typeName} : absl::AlphaNum{type}), "'")};
+inline Result malformedNode(aql::AstNode const& node) {
+  return {TRI_ERROR_BAD_PARAMETER,
+          absl::StrCat("Can't process malformed AstNode of type '",
+                       node.getTypeString(), "'")};
 }
 
 }  // namespace error

--- a/arangod/RocksDBEngine/RocksDBPrimaryIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBPrimaryIndex.cpp
@@ -64,6 +64,8 @@
 #include "Enterprise/VocBase/VirtualClusterSmartEdgeCollection.h"
 #endif
 
+#include <absl/strings/str_cat.h>
+
 #include <rocksdb/iterator.h>
 #include <rocksdb/utilities/transaction.h>
 
@@ -988,8 +990,8 @@ std::unique_ptr<IndexIterator> RocksDBPrimaryIndex::iteratorForCondition(
       // keep lower bound
     } else {
       THROW_ARANGO_EXCEPTION_MESSAGE(
-          TRI_ERROR_INTERNAL, std::string("unhandled type for valNode: ") +
-                                  aap.value->getTypeString());
+          TRI_ERROR_INTERNAL, absl::StrCat("unhandled type for valNode: ",
+                                           aap.value->getTypeString()));
     }
 
     // strip collection name prefix from comparison value

--- a/js/common/modules/@arangodb/aql/explainer.js
+++ b/js/common/modules/@arangodb/aql/explainer.js
@@ -919,6 +919,37 @@ function processQuery(query, explain, planIndex) {
     return (node) => variableName(node);
   };
 
+  var buildRaw = function (node) {
+    if (Array.isArray(node)) {
+      // array
+      if (node.length > maxMembersToPrint) {
+        // print only the first few values from the array
+        return '[ ' + node.slice(0, maxMembersToPrint).map(buildRaw).join(', ') + ', ... ]';
+      }
+      return '[ ' + node.subNodes.map(buildRaw).join(', ') + ' ]';
+    } else if (typeof node === 'object' && node !== null) {
+      // object
+      let keys = Object.keys(node);
+      let r = '{';
+      keys.slice(0, maxMembersToPrint).forEach((k, i) => {
+        if (i === 0) {
+          r += ' ';
+        } else {
+          r += ', ';
+        }
+        r += value(JSON.stringify(k)) + ' : ' + buildRaw(node[k]);
+      });
+      if (keys.length > maxMembersToPrint) {
+        r += ', ...';
+      }
+      r += ' }';
+      return r;
+    }
+
+    // anything else
+    return value(JSON.stringify(node));
+  };
+
   var buildExpression = function (node) {
     var binaryOperator = function (node, name) {
       if (name.match(/^[a-zA-Z]+$/)) {
@@ -970,6 +1001,9 @@ function processQuery(query, explain, planIndex) {
       case 'value':
         return value(JSON.stringify(node.value));
       case 'object':
+        if (node.hasOwnProperty('raw')) {
+          return buildRaw(node.raw);
+        }
         if (node.hasOwnProperty('subNodes')) {
           if (node.subNodes.length > maxMembersToPrint) {
             // print only the first few values from the object
@@ -983,6 +1017,9 @@ function processQuery(query, explain, planIndex) {
       case 'calculated object element':
         return '[ ' + buildExpression(node.subNodes[0]) + ' ] : ' + buildExpression(node.subNodes[1]);
       case 'array':
+        if (node.hasOwnProperty('raw')) {
+          return buildRaw(node.raw);
+        }
         if (node.hasOwnProperty('subNodes')) {
           if (node.subNodes.length > maxMembersToPrint) {
             // print only the first few values from the array

--- a/js/common/modules/@arangodb/aql/explainer.js
+++ b/js/common/modules/@arangodb/aql/explainer.js
@@ -926,7 +926,7 @@ function processQuery(query, explain, planIndex) {
         // print only the first few values from the array
         return '[ ' + node.slice(0, maxMembersToPrint).map(buildRaw).join(', ') + ', ... ]';
       }
-      return '[ ' + node.subNodes.map(buildRaw).join(', ') + ' ]';
+      return '[ ' + node.map(buildRaw).join(', ') + ' ]';
     } else if (typeof node === 'object' && node !== null) {
       // object
       let keys = Object.keys(node);

--- a/js/server/modules/@arangodb/aql-helper.js
+++ b/js/server/modules/@arangodb/aql-helper.js
@@ -393,6 +393,36 @@ function removeCost (obj) {
   }
 }
 
+function unpackRawExpression (node, transform = false) {
+  if (node.type === 'array') {
+    if (node.hasOwnProperty('raw')) {
+      node.subNodes = [];
+      node.raw.forEach((n) => {
+        node.subNodes.push(unpackRawExpression(n, true));
+      });
+      delete node.raw;
+    } else {
+      node.subNodes.map((s) => unpackRawExpression(s, false));
+    }
+  } else if (node.type === 'object') {
+    if (node.hasOwnProperty('raw')) {
+      node.subNodes = [];
+      let keys = Object.keys(node.raw);
+      keys.forEach((k) => {
+        node.subNodes.push({ type: "object element", name: k, subNodes: [unpackRawExpression(node.raw[k], true)] });
+      });
+      delete node.raw;
+    } else {
+      node.subNodes.map((s) => unpackRawExpression(s, false));
+    }
+  } else if (node.hasOwnProperty('subNodes') && node.subNodes.length) {
+    node.subNodes.map((s) => unpackRawExpression(s, false));
+  } else if (transform) {
+    return { type: 'value', value: node };
+  }
+  return node;
+}
+
 function sanitizeStats (stats) {
   // remove these members from the stats because they don't matter
   // for the comparisons
@@ -429,4 +459,5 @@ exports.removeAlwaysOnClusterRules = removeAlwaysOnClusterRules;
 exports.removeClusterNodes = removeClusterNodes;
 exports.removeClusterNodesFromPlan = removeClusterNodesFromPlan;
 exports.removeCost = removeCost;
+exports.unpackRawExpression = unpackRawExpression;
 exports.sanitizeStats = sanitizeStats;

--- a/tests/Aql/AstNodeTest.cpp
+++ b/tests/Aql/AstNodeTest.cpp
@@ -1,0 +1,871 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2022 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Jan Steemann
+////////////////////////////////////////////////////////////////////////////////
+
+#include "Aql/Ast.h"
+#include "Aql/AstNode.h"
+#include "Aql/Query.h"
+#include "Logger/LogMacros.h"
+#include "Mocks/Servers.h"
+
+#include "gtest/gtest.h"
+
+#include <functional>
+
+#include <velocypack/Builder.h>
+#include <velocypack/Slice.h>
+
+using namespace arangodb;
+using namespace arangodb::aql;
+
+namespace {
+
+class AstNodeTest : public ::testing::Test {
+ public:
+  AstNodeTest()
+      : _server{}, _query{_server.createFakeQuery()}, _ast{_query->ast()} {}
+
+  void toVelocyPackHelper(
+      std::function<void(AstNode const*)> const& validateAst, bool verbose) {
+    AstNode* root = _ast->nodeFromVPack(_builder.slice(), true);
+    EXPECT_NE(root, nullptr);
+
+    validateAst(root);
+
+    _builder.clear();
+    root->toVelocyPack(_builder, verbose);
+  }
+
+ protected:
+  tests::mocks::MockAqlServer _server;
+  std::shared_ptr<Query> _query;
+  Ast* _ast;
+
+  VPackBuilder _builder;
+};
+
+TEST_F(AstNodeTest, toVelocyPackNull) {
+  // handle verbose and non-verbose cases in one go
+  bool values[] = {true, false};
+  for (bool verbose : values) {
+    _builder.clear();
+    _builder.add(VPackValue(VPackValueType::Null));
+
+    auto validate = [](AstNode const* root) {
+      EXPECT_EQ(NODE_TYPE_VALUE, root->type);
+      EXPECT_TRUE(root->isNullValue());
+    };
+
+    // convert Builder contents to AstNode and call toVelocyPack
+    // on the root AstNode
+    toVelocyPackHelper([&validate](AstNode const* root) { validate(root); },
+                       verbose);
+
+    // validate the resulting VelocyPack
+    VPackSlice s = _builder.slice();
+
+    EXPECT_TRUE(s.isObject());
+    EXPECT_EQ("value", s.get("type").stringView());
+    EXPECT_TRUE(s.get("value").isNull());
+
+    EXPECT_TRUE(s.get("raw").isNone());
+
+    if (verbose) {
+      // create an AstNode from the VelocyPack containing the raw
+      // serialized values. this tests whether we can read back the
+      // compact serialization format for values
+      AstNode* root = _ast->createNode(s);
+      validate(root);
+    }
+  }
+}
+
+TEST_F(AstNodeTest, toVelocyPackNumber) {
+  // handle verbose and non-verbose cases in one go
+  bool values[] = {true, false};
+  for (bool verbose : values) {
+    _builder.clear();
+    _builder.add(VPackValue(123));
+
+    auto validate = [](AstNode const* root) {
+      EXPECT_EQ(NODE_TYPE_VALUE, root->type);
+      EXPECT_TRUE(root->isIntValue());
+      EXPECT_EQ(123, root->getIntValue());
+    };
+
+    // convert Builder contents to AstNode and call toVelocyPack
+    // on the root AstNode
+    toVelocyPackHelper([&validate](AstNode const* root) { validate(root); },
+                       verbose);
+
+    // validate the resulting VelocyPack
+    VPackSlice s = _builder.slice();
+
+    EXPECT_TRUE(s.isObject());
+    EXPECT_EQ("value", s.get("type").stringView());
+    EXPECT_EQ(123, s.get("value").getUInt());
+
+    EXPECT_TRUE(s.get("raw").isNone());
+
+    if (verbose) {
+      // create an AstNode from the VelocyPack containing the raw
+      // serialized values. this tests whether we can read back the
+      // compact serialization format for values
+      AstNode* root = _ast->createNode(s);
+      validate(root);
+    }
+  }
+}
+
+TEST_F(AstNodeTest, toVelocyPackString) {
+  // handle verbose and non-verbose cases in one go
+  bool values[] = {true, false};
+  for (bool verbose : values) {
+    _builder.clear();
+    _builder.add(VPackValue("foobarbaz"));
+
+    auto validate = [](AstNode const* root) {
+      EXPECT_EQ(NODE_TYPE_VALUE, root->type);
+      EXPECT_TRUE(root->isStringValue());
+      EXPECT_EQ("foobarbaz", root->getStringView());
+    };
+
+    // convert Builder contents to AstNode and call toVelocyPack
+    // on the root AstNode
+    toVelocyPackHelper([&validate](AstNode const* root) { validate(root); },
+                       verbose);
+
+    // validate the resulting VelocyPack
+    VPackSlice s = _builder.slice();
+
+    EXPECT_TRUE(s.isObject());
+    EXPECT_EQ("value", s.get("type").stringView());
+    EXPECT_EQ("foobarbaz", s.get("value").stringView());
+
+    EXPECT_TRUE(s.get("raw").isNone());
+
+    if (verbose) {
+      // create an AstNode from the VelocyPack containing the raw
+      // serialized values. this tests whether we can read back the
+      // compact serialization format for values
+      AstNode* root = _ast->createNode(s);
+      validate(root);
+    }
+  }
+}
+
+TEST_F(AstNodeTest, toVelocyPackArrayNonVerbose) {
+  _builder.openArray();
+  _builder.add(VPackValue(1));
+  _builder.add(VPackValue(2));
+  _builder.add(VPackValue("foo"));
+  _builder.close();
+
+  auto validate = [](AstNode const* root) {
+    EXPECT_EQ(NODE_TYPE_ARRAY, root->type);
+    EXPECT_EQ(3, root->numMembers());
+    EXPECT_EQ(NODE_TYPE_VALUE, root->getMember(0)->type);
+    EXPECT_EQ(1, root->getMember(0)->getIntValue());
+    EXPECT_EQ(NODE_TYPE_VALUE, root->getMember(1)->type);
+    EXPECT_EQ(2, root->getMember(1)->getIntValue());
+    EXPECT_EQ(NODE_TYPE_VALUE, root->getMember(2)->type);
+    EXPECT_EQ("foo", root->getMember(2)->getStringView());
+  };
+
+  // convert Builder contents to AstNode and call toVelocyPack
+  // on the root AstNode
+  toVelocyPackHelper([&validate](AstNode const* root) { validate(root); },
+                     /*verbose*/ false);
+
+  // validate the resulting VelocyPack
+  VPackSlice s = _builder.slice();
+
+  EXPECT_TRUE(s.isObject());
+  EXPECT_EQ("array", s.get("type").stringView());
+  EXPECT_TRUE(s.get("subNodes").isArray());
+  EXPECT_EQ(3, s.get("subNodes").length());
+
+  EXPECT_TRUE(s.get("raw").isNone());
+
+  EXPECT_EQ("value", s.get("subNodes").at(0).get("type").stringView());
+  EXPECT_EQ(1, s.get("subNodes").at(0).get("value").getUInt());
+  EXPECT_EQ("value", s.get("subNodes").at(1).get("type").stringView());
+  EXPECT_EQ(2, s.get("subNodes").at(1).get("value").getUInt());
+  EXPECT_EQ("value", s.get("subNodes").at(2).get("type").stringView());
+  EXPECT_EQ("foo", s.get("subNodes").at(2).get("value").stringView());
+}
+
+TEST_F(AstNodeTest, toVelocyPackArrayVerbose) {
+  _builder.openArray();
+  _builder.add(VPackValue(1));
+  _builder.add(VPackValue(2));
+  _builder.add(VPackValue("foo"));
+  _builder.close();
+
+  auto validate = [](AstNode const* root) {
+    EXPECT_EQ(NODE_TYPE_ARRAY, root->type);
+    EXPECT_EQ(3, root->numMembers());
+    EXPECT_EQ(NODE_TYPE_VALUE, root->getMember(0)->type);
+    EXPECT_EQ(1, root->getMember(0)->getIntValue());
+    EXPECT_EQ(NODE_TYPE_VALUE, root->getMember(1)->type);
+    EXPECT_EQ(2, root->getMember(1)->getIntValue());
+    EXPECT_EQ(NODE_TYPE_VALUE, root->getMember(2)->type);
+    EXPECT_EQ("foo", root->getMember(2)->getStringView());
+  };
+
+  // convert Builder contents to AstNode and call toVelocyPack
+  // on the root AstNode
+  toVelocyPackHelper([&validate](AstNode const* root) { validate(root); },
+                     /*verbose*/ true);
+
+  // validate the resulting VelocyPack
+  VPackSlice s = _builder.slice();
+
+  EXPECT_TRUE(s.isObject());
+  EXPECT_EQ("array", s.get("type").stringView());
+  EXPECT_TRUE(s.get("raw").isArray());
+  EXPECT_EQ(3, s.get("raw").length());
+
+  EXPECT_TRUE(s.get("subNodes").isNone());
+
+  EXPECT_EQ(1, s.get("raw").at(0).getUInt());
+  EXPECT_EQ(2, s.get("raw").at(1).getUInt());
+  EXPECT_EQ("foo", s.get("raw").at(2).stringView());
+
+  // create an AstNode from the VelocyPack containing the raw
+  // serialized values. this tests whether we can read back the
+  // compact serialization format for values
+  AstNode* root = _ast->createNode(s);
+  validate(root);
+}
+
+TEST_F(AstNodeTest, toVelocyPackNestedArrayNonVerbose) {
+  _builder.openArray();
+  _builder.add(VPackValue(1));
+  _builder.add(VPackValue(2));
+  _builder.openArray();
+  _builder.add(VPackValue("foo"));
+  _builder.add(VPackValue("bar"));
+  _builder.close();
+  _builder.close();
+
+  auto validate = [](AstNode const* root) {
+    EXPECT_EQ(NODE_TYPE_ARRAY, root->type);
+    EXPECT_EQ(3, root->numMembers());
+    EXPECT_EQ(NODE_TYPE_VALUE, root->getMember(0)->type);
+    EXPECT_EQ(1, root->getMember(0)->getIntValue());
+    EXPECT_EQ(NODE_TYPE_VALUE, root->getMember(1)->type);
+    EXPECT_EQ(2, root->getMember(1)->getIntValue());
+    EXPECT_EQ(NODE_TYPE_ARRAY, root->getMember(2)->type);
+    EXPECT_EQ(NODE_TYPE_VALUE, root->getMember(2)->getMember(0)->type);
+    EXPECT_EQ("foo", root->getMember(2)->getMember(0)->getStringView());
+    EXPECT_EQ(NODE_TYPE_VALUE, root->getMember(2)->getMember(1)->type);
+    EXPECT_EQ("bar", root->getMember(2)->getMember(1)->getStringView());
+  };
+
+  // convert Builder contents to AstNode and call toVelocyPack
+  // on the root AstNode
+  toVelocyPackHelper([&validate](AstNode const* root) { validate(root); },
+                     /*verbose*/ false);
+
+  // validate the resulting VelocyPack
+  VPackSlice s = _builder.slice();
+
+  EXPECT_TRUE(s.isObject());
+  EXPECT_EQ("array", s.get("type").stringView());
+  EXPECT_TRUE(s.get("subNodes").isArray());
+  EXPECT_EQ(3, s.get("subNodes").length());
+
+  EXPECT_TRUE(s.get("raw").isNone());
+
+  EXPECT_EQ("value", s.get("subNodes").at(0).get("type").stringView());
+  EXPECT_EQ(1, s.get("subNodes").at(0).get("value").getUInt());
+  EXPECT_EQ("value", s.get("subNodes").at(1).get("type").stringView());
+  EXPECT_EQ(2, s.get("subNodes").at(1).get("value").getUInt());
+
+  EXPECT_EQ("array", s.get("subNodes").at(2).get("type").stringView());
+  EXPECT_TRUE(s.get("subNodes").at(2).get("subNodes").isArray());
+  EXPECT_EQ(2, s.get("subNodes").at(2).get("subNodes").length());
+  EXPECT_EQ(
+      "value",
+      s.get("subNodes").at(2).get("subNodes").at(0).get("type").stringView());
+  EXPECT_EQ(
+      "foo",
+      s.get("subNodes").at(2).get("subNodes").at(0).get("value").stringView());
+  EXPECT_EQ(
+      "value",
+      s.get("subNodes").at(2).get("subNodes").at(1).get("type").stringView());
+  EXPECT_EQ(
+      "bar",
+      s.get("subNodes").at(2).get("subNodes").at(1).get("value").stringView());
+}
+
+TEST_F(AstNodeTest, toVelocyPackNestedArrayVerbose) {
+  _builder.openArray();
+  _builder.add(VPackValue(1));
+  _builder.add(VPackValue(2));
+  _builder.openArray();
+  _builder.add(VPackValue("foo"));
+  _builder.add(VPackValue("bar"));
+  _builder.close();
+  _builder.close();
+
+  auto validate = [](AstNode const* root) {
+    EXPECT_EQ(NODE_TYPE_ARRAY, root->type);
+    EXPECT_EQ(3, root->numMembers());
+    EXPECT_EQ(NODE_TYPE_VALUE, root->getMember(0)->type);
+    EXPECT_EQ(1, root->getMember(0)->getIntValue());
+    EXPECT_EQ(NODE_TYPE_VALUE, root->getMember(1)->type);
+    EXPECT_EQ(2, root->getMember(1)->getIntValue());
+    EXPECT_EQ(NODE_TYPE_ARRAY, root->getMember(2)->type);
+    EXPECT_EQ(NODE_TYPE_VALUE, root->getMember(2)->getMember(0)->type);
+    EXPECT_EQ("foo", root->getMember(2)->getMember(0)->getStringView());
+    EXPECT_EQ(NODE_TYPE_VALUE, root->getMember(2)->getMember(1)->type);
+    EXPECT_EQ("bar", root->getMember(2)->getMember(1)->getStringView());
+  };
+
+  // convert Builder contents to AstNode and call toVelocyPack
+  // on the root AstNode
+  toVelocyPackHelper([&validate](AstNode const* root) { validate(root); },
+                     /*verbose*/ true);
+
+  // validate the resulting VelocyPack
+  VPackSlice s = _builder.slice();
+
+  EXPECT_TRUE(s.isObject());
+  EXPECT_EQ("array", s.get("type").stringView());
+  EXPECT_TRUE(s.get("raw").isArray());
+  EXPECT_EQ(3, s.get("raw").length());
+
+  EXPECT_TRUE(s.get("subNodes").isNone());
+
+  EXPECT_EQ(1, s.get("raw").at(0).getUInt());
+  EXPECT_EQ(2, s.get("raw").at(1).getUInt());
+
+  EXPECT_TRUE(s.get("raw").at(2).isArray());
+  EXPECT_EQ(2, s.get("raw").at(2).length());
+  EXPECT_EQ("foo", s.get("raw").at(2).at(0).stringView());
+  EXPECT_EQ("bar", s.get("raw").at(2).at(1).stringView());
+
+  // create an AstNode from the VelocyPack containing the raw
+  // serialized values. this tests whether we can read back the
+  // compact serialization format for values
+  AstNode* root = _ast->createNode(s);
+  validate(root);
+}
+
+TEST_F(AstNodeTest, toVelocyPackObjectNonVerbose) {
+  _builder.openObject();
+  _builder.add("foo", VPackValue(1));
+  _builder.add("bar", VPackValue(2));
+  _builder.add("baz", VPackValue("foo"));
+  _builder.close();
+
+  auto validate = [](AstNode const* root) {
+    EXPECT_EQ(NODE_TYPE_OBJECT, root->type);
+    EXPECT_EQ(3, root->numMembers());
+    EXPECT_EQ(NODE_TYPE_OBJECT_ELEMENT, root->getMember(0)->type);
+    EXPECT_EQ(NODE_TYPE_VALUE, root->getMember(0)->getMember(0)->type);
+    EXPECT_EQ("foo", root->getMember(0)->getStringView());
+    EXPECT_EQ(1, root->getMember(0)->getMember(0)->getIntValue());
+    EXPECT_EQ(NODE_TYPE_OBJECT_ELEMENT, root->getMember(1)->type);
+    EXPECT_EQ(NODE_TYPE_VALUE, root->getMember(1)->getMember(0)->type);
+    EXPECT_EQ("bar", root->getMember(1)->getStringView());
+    EXPECT_EQ(2, root->getMember(1)->getMember(0)->getIntValue());
+    EXPECT_EQ(NODE_TYPE_OBJECT_ELEMENT, root->getMember(2)->type);
+    EXPECT_EQ(NODE_TYPE_VALUE, root->getMember(2)->getMember(0)->type);
+    EXPECT_EQ("foo", root->getMember(2)->getMember(0)->getStringView());
+    EXPECT_EQ("baz", root->getMember(2)->getStringView());
+  };
+
+  // convert Builder contents to AstNode and call toVelocyPack
+  // on the root AstNode
+  toVelocyPackHelper([&validate](AstNode const* root) { validate(root); },
+                     /*verbose*/ false);
+
+  // validate the resulting VelocyPack
+  VPackSlice s = _builder.slice();
+
+  EXPECT_TRUE(s.isObject());
+  EXPECT_EQ("object", s.get("type").stringView());
+  EXPECT_TRUE(s.get("subNodes").isArray());
+  EXPECT_EQ(3, s.get("subNodes").length());
+
+  EXPECT_TRUE(s.get("raw").isNone());
+
+  EXPECT_EQ("object element", s.get("subNodes").at(0).get("type").stringView());
+  EXPECT_EQ("foo", s.get("subNodes").at(0).get("name").stringView());
+  EXPECT_EQ(
+      "value",
+      s.get("subNodes").at(0).get("subNodes").at(0).get("type").stringView());
+  EXPECT_EQ(
+      1, s.get("subNodes").at(0).get("subNodes").at(0).get("value").getUInt());
+  EXPECT_EQ("object element", s.get("subNodes").at(1).get("type").stringView());
+  EXPECT_EQ("bar", s.get("subNodes").at(1).get("name").stringView());
+  EXPECT_EQ(
+      "value",
+      s.get("subNodes").at(1).get("subNodes").at(0).get("type").stringView());
+  EXPECT_EQ(
+      2, s.get("subNodes").at(1).get("subNodes").at(0).get("value").getUInt());
+  EXPECT_EQ("object element", s.get("subNodes").at(2).get("type").stringView());
+  EXPECT_EQ("baz", s.get("subNodes").at(2).get("name").stringView());
+  EXPECT_EQ(
+      "value",
+      s.get("subNodes").at(2).get("subNodes").at(0).get("type").stringView());
+  EXPECT_EQ(
+      "foo",
+      s.get("subNodes").at(2).get("subNodes").at(0).get("value").stringView());
+}
+
+TEST_F(AstNodeTest, toVelocyPackObjectVerbose) {
+  _builder.openObject();
+  _builder.add("foo", VPackValue(1));
+  _builder.add("bar", VPackValue(2));
+  _builder.add("baz", VPackValue("foo"));
+  _builder.close();
+
+  auto validate = [](AstNode const* root) {
+    EXPECT_EQ(NODE_TYPE_OBJECT, root->type);
+    EXPECT_EQ(3, root->numMembers());
+    EXPECT_EQ(NODE_TYPE_OBJECT_ELEMENT, root->getMember(0)->type);
+    EXPECT_EQ(NODE_TYPE_VALUE, root->getMember(0)->getMember(0)->type);
+    EXPECT_EQ("foo", root->getMember(0)->getStringView());
+    EXPECT_EQ(1, root->getMember(0)->getMember(0)->getIntValue());
+    EXPECT_EQ(NODE_TYPE_OBJECT_ELEMENT, root->getMember(1)->type);
+    EXPECT_EQ(NODE_TYPE_VALUE, root->getMember(1)->getMember(0)->type);
+    EXPECT_EQ("bar", root->getMember(1)->getStringView());
+    EXPECT_EQ(2, root->getMember(1)->getMember(0)->getIntValue());
+    EXPECT_EQ(NODE_TYPE_OBJECT_ELEMENT, root->getMember(2)->type);
+    EXPECT_EQ(NODE_TYPE_VALUE, root->getMember(2)->getMember(0)->type);
+    EXPECT_EQ("foo", root->getMember(2)->getMember(0)->getStringView());
+    EXPECT_EQ("baz", root->getMember(2)->getStringView());
+  };
+
+  // convert Builder contents to AstNode and call toVelocyPack
+  // on the root AstNode
+  toVelocyPackHelper([&validate](AstNode const* root) { validate(root); },
+                     /*verbose*/ true);
+
+  // validate the resulting VelocyPack
+  VPackSlice s = _builder.slice();
+
+  EXPECT_TRUE(s.isObject());
+  EXPECT_EQ("object", s.get("type").stringView());
+  EXPECT_TRUE(s.get("raw").isObject());
+  EXPECT_EQ(3, s.get("raw").length());
+
+  EXPECT_TRUE(s.get("subNodes").isNone());
+
+  EXPECT_EQ(1, s.get("raw").get("foo").getUInt());
+  EXPECT_EQ(2, s.get("raw").get("bar").getUInt());
+  EXPECT_EQ("foo", s.get("raw").get("baz").stringView());
+
+  // create an AstNode from the VelocyPack containing the raw
+  // serialized values. this tests whether we can read back the
+  // compact serialization format for values
+  AstNode* root = _ast->createNode(s);
+  validate(root);
+}
+
+TEST_F(AstNodeTest, toVelocyPackNestedObjectNonVerbose) {
+  _builder.openObject();
+  _builder.add("foo", VPackValue(1));
+  _builder.add("bar", VPackValue(2));
+  _builder.add("baz", VPackValue(VPackValueType::Object));
+  _builder.add("qux", VPackValue(true));
+  _builder.add("quetzal", VPackValue(VPackValueType::Object));
+  _builder.add("bark", VPackValue(VPackValueType::Array));
+  _builder.add(VPackValue(666));
+  _builder.close();
+  _builder.close();
+  _builder.close();
+  _builder.close();
+
+  auto validate = [](AstNode const* root) {
+    EXPECT_EQ(NODE_TYPE_OBJECT, root->type);
+    EXPECT_EQ(3, root->numMembers());
+    EXPECT_EQ(NODE_TYPE_OBJECT_ELEMENT, root->getMember(0)->type);
+    EXPECT_EQ(NODE_TYPE_VALUE, root->getMember(0)->getMember(0)->type);
+    EXPECT_EQ("foo", root->getMember(0)->getStringView());
+    EXPECT_EQ(1, root->getMember(0)->getMember(0)->getIntValue());
+    EXPECT_EQ(NODE_TYPE_OBJECT_ELEMENT, root->getMember(1)->type);
+    EXPECT_EQ(NODE_TYPE_VALUE, root->getMember(1)->getMember(0)->type);
+    EXPECT_EQ("bar", root->getMember(1)->getStringView());
+    EXPECT_EQ(2, root->getMember(1)->getMember(0)->getIntValue());
+    EXPECT_EQ(NODE_TYPE_OBJECT_ELEMENT, root->getMember(2)->type);
+    EXPECT_EQ(NODE_TYPE_OBJECT, root->getMember(2)->getMember(0)->type);
+    EXPECT_EQ("baz", root->getMember(2)->getStringView());
+    EXPECT_EQ(NODE_TYPE_OBJECT, root->getMember(2)->getMember(0)->type);
+    EXPECT_EQ(NODE_TYPE_OBJECT_ELEMENT,
+              root->getMember(2)->getMember(0)->getMember(0)->type);
+    EXPECT_EQ("qux",
+              root->getMember(2)->getMember(0)->getMember(0)->getStringView());
+    EXPECT_EQ(
+        NODE_TYPE_VALUE,
+        root->getMember(2)->getMember(0)->getMember(0)->getMember(0)->type);
+    EXPECT_TRUE(root->getMember(2)
+                    ->getMember(0)
+                    ->getMember(0)
+                    ->getMember(0)
+                    ->isBoolValue());
+    EXPECT_EQ(NODE_TYPE_OBJECT_ELEMENT,
+              root->getMember(2)->getMember(0)->getMember(1)->type);
+    EXPECT_EQ("quetzal",
+              root->getMember(2)->getMember(0)->getMember(1)->getStringView());
+    EXPECT_EQ(
+        NODE_TYPE_OBJECT,
+        root->getMember(2)->getMember(0)->getMember(1)->getMember(0)->type);
+    EXPECT_EQ(NODE_TYPE_OBJECT_ELEMENT, root->getMember(2)
+                                            ->getMember(0)
+                                            ->getMember(1)
+                                            ->getMember(0)
+                                            ->getMember(0)
+                                            ->type);
+    EXPECT_EQ("bark", root->getMember(2)
+                          ->getMember(0)
+                          ->getMember(1)
+                          ->getMember(0)
+                          ->getMember(0)
+                          ->getStringView());
+
+    EXPECT_EQ(NODE_TYPE_ARRAY, root->getMember(2)
+                                   ->getMember(0)
+                                   ->getMember(1)
+                                   ->getMember(0)
+                                   ->getMember(0)
+                                   ->getMember(0)
+                                   ->type);
+
+    EXPECT_EQ(NODE_TYPE_VALUE, root->getMember(2)
+                                   ->getMember(0)
+                                   ->getMember(1)
+                                   ->getMember(0)
+                                   ->getMember(0)
+                                   ->getMember(0)
+                                   ->getMember(0)
+                                   ->type);
+
+    EXPECT_EQ(666, root->getMember(2)
+                       ->getMember(0)
+                       ->getMember(1)
+                       ->getMember(0)
+                       ->getMember(0)
+                       ->getMember(0)
+                       ->getMember(0)
+                       ->getIntValue());
+  };
+
+  // convert Builder contents to AstNode and call toVelocyPack
+  // on the root AstNode
+  toVelocyPackHelper([&validate](AstNode const* root) { validate(root); },
+                     /*verbose*/ false);
+
+  // validate the resulting VelocyPack
+  VPackSlice s = _builder.slice();
+
+  EXPECT_TRUE(s.isObject());
+  EXPECT_EQ("object", s.get("type").stringView());
+  EXPECT_TRUE(s.get("subNodes").isArray());
+  EXPECT_EQ(3, s.get("subNodes").length());
+
+  EXPECT_TRUE(s.get("raw").isNone());
+
+  EXPECT_EQ("object element", s.get("subNodes").at(0).get("type").stringView());
+  EXPECT_EQ("foo", s.get("subNodes").at(0).get("name").stringView());
+  EXPECT_EQ(
+      "value",
+      s.get("subNodes").at(0).get("subNodes").at(0).get("type").stringView());
+  EXPECT_EQ(
+      1, s.get("subNodes").at(0).get("subNodes").at(0).get("value").getUInt());
+  EXPECT_EQ("object element", s.get("subNodes").at(1).get("type").stringView());
+  EXPECT_EQ("bar", s.get("subNodes").at(1).get("name").stringView());
+  EXPECT_EQ(
+      "value",
+      s.get("subNodes").at(1).get("subNodes").at(0).get("type").stringView());
+  EXPECT_EQ(
+      2, s.get("subNodes").at(1).get("subNodes").at(0).get("value").getUInt());
+  EXPECT_EQ("object element", s.get("subNodes").at(2).get("type").stringView());
+  EXPECT_EQ("baz", s.get("subNodes").at(2).get("name").stringView());
+  EXPECT_EQ(
+      "object",
+      s.get("subNodes").at(2).get("subNodes").at(0).get("type").stringView());
+  EXPECT_EQ("object element", s.get("subNodes")
+                                  .at(2)
+                                  .get("subNodes")
+                                  .at(0)
+                                  .get("subNodes")
+                                  .at(0)
+                                  .get("type")
+                                  .stringView());
+  EXPECT_EQ("qux", s.get("subNodes")
+                       .at(2)
+                       .get("subNodes")
+                       .at(0)
+                       .get("subNodes")
+                       .at(0)
+                       .get("name")
+                       .stringView());
+  EXPECT_EQ("value", s.get("subNodes")
+                         .at(2)
+                         .get("subNodes")
+                         .at(0)
+                         .get("subNodes")
+                         .at(0)
+                         .get("subNodes")
+                         .at(0)
+                         .get("type")
+                         .stringView());
+  EXPECT_EQ(true, s.get("subNodes")
+                      .at(2)
+                      .get("subNodes")
+                      .at(0)
+                      .get("subNodes")
+                      .at(0)
+                      .get("subNodes")
+                      .at(0)
+                      .get("value")
+                      .getBoolean());
+
+  EXPECT_EQ("object element", s.get("subNodes")
+                                  .at(2)
+                                  .get("subNodes")
+                                  .at(0)
+                                  .get("subNodes")
+                                  .at(1)
+                                  .get("type")
+                                  .stringView());
+  EXPECT_EQ("quetzal", s.get("subNodes")
+                           .at(2)
+                           .get("subNodes")
+                           .at(0)
+                           .get("subNodes")
+                           .at(1)
+                           .get("name")
+                           .stringView());
+  EXPECT_EQ("object", s.get("subNodes")
+                          .at(2)
+                          .get("subNodes")
+                          .at(0)
+                          .get("subNodes")
+                          .at(1)
+                          .get("subNodes")
+                          .at(0)
+                          .get("type")
+                          .stringView());
+
+  EXPECT_EQ("object element", s.get("subNodes")
+                                  .at(2)
+                                  .get("subNodes")
+                                  .at(0)
+                                  .get("subNodes")
+                                  .at(1)
+                                  .get("subNodes")
+                                  .at(0)
+                                  .get("subNodes")
+                                  .at(0)
+                                  .get("type")
+                                  .stringView());
+  EXPECT_EQ("bark", s.get("subNodes")
+                        .at(2)
+                        .get("subNodes")
+                        .at(0)
+                        .get("subNodes")
+                        .at(1)
+                        .get("subNodes")
+                        .at(0)
+                        .get("subNodes")
+                        .at(0)
+                        .get("name")
+                        .stringView());
+
+  EXPECT_EQ("array", s.get("subNodes")
+                         .at(2)
+                         .get("subNodes")
+                         .at(0)
+                         .get("subNodes")
+                         .at(1)
+                         .get("subNodes")
+                         .at(0)
+                         .get("subNodes")
+                         .at(0)
+                         .get("subNodes")
+                         .at(0)
+                         .get("type")
+                         .stringView());
+
+  EXPECT_EQ("value", s.get("subNodes")
+                         .at(2)
+                         .get("subNodes")
+                         .at(0)
+                         .get("subNodes")
+                         .at(1)
+                         .get("subNodes")
+                         .at(0)
+                         .get("subNodes")
+                         .at(0)
+                         .get("subNodes")
+                         .at(0)
+                         .get("subNodes")
+                         .at(0)
+                         .get("type")
+                         .stringView());
+
+  EXPECT_EQ(666, s.get("subNodes")
+                     .at(2)
+                     .get("subNodes")
+                     .at(0)
+                     .get("subNodes")
+                     .at(1)
+                     .get("subNodes")
+                     .at(0)
+                     .get("subNodes")
+                     .at(0)
+                     .get("subNodes")
+                     .at(0)
+                     .get("subNodes")
+                     .at(0)
+                     .get("value")
+                     .getUInt());
+}
+
+TEST_F(AstNodeTest, toVelocyPackNestedObjectVerbose) {
+  _builder.openObject();
+  _builder.add("foo", VPackValue(1));
+  _builder.add("bar", VPackValue(2));
+  _builder.add("baz", VPackValue(VPackValueType::Object));
+  _builder.add("qux", VPackValue(true));
+  _builder.add("quetzal", VPackValue(VPackValueType::Object));
+  _builder.add("bark", VPackValue(VPackValueType::Array));
+  _builder.add(VPackValue(666));
+  _builder.close();
+  _builder.close();
+  _builder.close();
+  _builder.close();
+
+  auto validate = [](AstNode const* root) {
+    EXPECT_EQ(NODE_TYPE_OBJECT, root->type);
+    EXPECT_EQ(3, root->numMembers());
+    EXPECT_EQ(NODE_TYPE_OBJECT_ELEMENT, root->getMember(0)->type);
+    EXPECT_EQ(NODE_TYPE_VALUE, root->getMember(0)->getMember(0)->type);
+    EXPECT_EQ("foo", root->getMember(0)->getStringView());
+    EXPECT_EQ(1, root->getMember(0)->getMember(0)->getIntValue());
+    EXPECT_EQ(NODE_TYPE_OBJECT_ELEMENT, root->getMember(1)->type);
+    EXPECT_EQ(NODE_TYPE_VALUE, root->getMember(1)->getMember(0)->type);
+    EXPECT_EQ("bar", root->getMember(1)->getStringView());
+    EXPECT_EQ(2, root->getMember(1)->getMember(0)->getIntValue());
+    EXPECT_EQ(NODE_TYPE_OBJECT_ELEMENT, root->getMember(2)->type);
+    EXPECT_EQ(NODE_TYPE_OBJECT, root->getMember(2)->getMember(0)->type);
+    EXPECT_EQ("baz", root->getMember(2)->getStringView());
+    EXPECT_EQ(NODE_TYPE_OBJECT, root->getMember(2)->getMember(0)->type);
+    EXPECT_EQ(NODE_TYPE_OBJECT_ELEMENT,
+              root->getMember(2)->getMember(0)->getMember(0)->type);
+    EXPECT_EQ("qux",
+              root->getMember(2)->getMember(0)->getMember(0)->getStringView());
+    EXPECT_EQ(
+        NODE_TYPE_VALUE,
+        root->getMember(2)->getMember(0)->getMember(0)->getMember(0)->type);
+    EXPECT_TRUE(root->getMember(2)
+                    ->getMember(0)
+                    ->getMember(0)
+                    ->getMember(0)
+                    ->isBoolValue());
+    EXPECT_EQ(NODE_TYPE_OBJECT_ELEMENT,
+              root->getMember(2)->getMember(0)->getMember(1)->type);
+    EXPECT_EQ("quetzal",
+              root->getMember(2)->getMember(0)->getMember(1)->getStringView());
+    EXPECT_EQ(
+        NODE_TYPE_OBJECT,
+        root->getMember(2)->getMember(0)->getMember(1)->getMember(0)->type);
+    EXPECT_EQ(NODE_TYPE_OBJECT_ELEMENT, root->getMember(2)
+                                            ->getMember(0)
+                                            ->getMember(1)
+                                            ->getMember(0)
+                                            ->getMember(0)
+                                            ->type);
+    EXPECT_EQ("bark", root->getMember(2)
+                          ->getMember(0)
+                          ->getMember(1)
+                          ->getMember(0)
+                          ->getMember(0)
+                          ->getStringView());
+
+    EXPECT_EQ(NODE_TYPE_ARRAY, root->getMember(2)
+                                   ->getMember(0)
+                                   ->getMember(1)
+                                   ->getMember(0)
+                                   ->getMember(0)
+                                   ->getMember(0)
+                                   ->type);
+
+    EXPECT_EQ(NODE_TYPE_VALUE, root->getMember(2)
+                                   ->getMember(0)
+                                   ->getMember(1)
+                                   ->getMember(0)
+                                   ->getMember(0)
+                                   ->getMember(0)
+                                   ->getMember(0)
+                                   ->type);
+
+    EXPECT_EQ(666, root->getMember(2)
+                       ->getMember(0)
+                       ->getMember(1)
+                       ->getMember(0)
+                       ->getMember(0)
+                       ->getMember(0)
+                       ->getMember(0)
+                       ->getIntValue());
+  };
+
+  // convert Builder contents to AstNode and call toVelocyPack
+  // on the root AstNode
+  toVelocyPackHelper([&validate](AstNode const* root) { validate(root); },
+                     /*verbose*/ true);
+
+  // validate the resulting VelocyPack
+  VPackSlice s = _builder.slice();
+
+  EXPECT_TRUE(s.isObject());
+  EXPECT_EQ("object", s.get("type").stringView());
+  EXPECT_TRUE(s.get("raw").isObject());
+  EXPECT_EQ(3, s.get("raw").length());
+
+  EXPECT_TRUE(s.get("subNodes").isNone());
+
+  EXPECT_EQ(1, s.get("raw").get("foo").getUInt());
+  EXPECT_EQ(2, s.get("raw").get("bar").getUInt());
+  EXPECT_TRUE(s.get("raw").get("baz").isObject());
+  EXPECT_TRUE(s.get("raw").get("baz").get("subNodes").isNone());
+  EXPECT_TRUE(s.get("raw").get("baz").get("qux").isTrue());
+  EXPECT_TRUE(s.get("raw").get("baz").get("quetzal").isObject());
+  EXPECT_TRUE(s.get("raw").get("baz").get("quetzal").get("subNodes").isNone());
+  EXPECT_TRUE(s.get("raw").get("baz").get("quetzal").get("bark").isArray());
+  EXPECT_EQ(666,
+            s.get("raw").get("baz").get("quetzal").get("bark").at(0).getUInt());
+
+  // create an AstNode from the VelocyPack containing the raw
+  // serialized values. this tests whether we can read back the
+  // compact serialization format for values
+  AstNode* root = _ast->createNode(s);
+  validate(root);
+}
+
+}  // namespace

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -86,6 +86,7 @@ set(ARANGODB_TESTS_SOURCES
   Aql/AqlItemRowTest.cpp
   Aql/AqlShadowRowTest.cpp
   Aql/AqlValueMemoryLayoutTest.cpp
+  Aql/AstNodeTest.cpp
   Aql/AstResourcesTest.cpp
   Aql/AttributeNamePathTest.cpp
   Aql/BitFunctionsTest.cpp

--- a/tests/js/server/aql/aql-optimizer-condition.js
+++ b/tests/js/server/aql/aql-optimizer-condition.js
@@ -28,17 +28,14 @@
 /// @author Copyright 2012, triAGENS GmbH, Cologne, Germany
 ////////////////////////////////////////////////////////////////////////////////
 
-var jsunity = require("jsunity");
-var db = require("@arangodb").db;
-
-////////////////////////////////////////////////////////////////////////////////
-/// @brief test suite
-////////////////////////////////////////////////////////////////////////////////
+const jsunity = require("jsunity");
+const db = require("@arangodb").db;
+const helper = require("@arangodb/aql-helper");
 
 function optimizerConditionsTestSuite () {
   const opt = { optimizer: { rules: ["-move-filters-into-enumerate"] } };
 
-  var c;
+  let c;
 
   return {
     setUpAll : function () {
@@ -224,8 +221,8 @@ function optimizerConditionsTestSuite () {
       var expression = calcNode.expression;
       assertEqual("logical and", expression.type);
       assertEqual(2, expression.subNodes.length);
-     
-      var left = expression.subNodes[0];
+    
+      var left = helper.unpackRawExpression(expression.subNodes[0]);
 
       assertEqual("logical and", left.type);
       assertEqual(2, left.subNodes.length);
@@ -245,7 +242,7 @@ function optimizerConditionsTestSuite () {
       assertEqual("value", left.subNodes[1].subNodes[1].subNodes[1].type);
       assertEqual("b", left.subNodes[1].subNodes[1].subNodes[1].value);
 
-      var right = expression.subNodes[1];
+      var right = helper.unpackRawExpression(expression.subNodes[1]);
      
       assertEqual("compare in", right.type);
       assertEqual("attribute access", right.subNodes[0].type);
@@ -257,7 +254,7 @@ function optimizerConditionsTestSuite () {
 
   };
 }
+
 jsunity.run(optimizerConditionsTestSuite);
 
 return jsunity.done();
-

--- a/tests/js/server/aql/aql-optimizer-geoindex.js
+++ b/tests/js/server/aql/aql-optimizer-geoindex.js
@@ -29,19 +29,15 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 const expect = require('chai').expect;
-var internal = require("internal");
-var jsunity = require("jsunity");
-var helper = require("@arangodb/aql-helper");
-var isEqual = helper.isEqual;
-var findExecutionNodes = helper.findExecutionNodes;
-var findReferencedNodes = helper.findReferencedNodes;
-var getQueryMultiplePlansAndExecutions = helper.getQueryMultiplePlansAndExecutions;
-var removeAlwaysOnClusterRules = helper.removeAlwaysOnClusterRules;
-var db = require('internal').db;
-
-////////////////////////////////////////////////////////////////////////////////
-/// @brief test suite
-////////////////////////////////////////////////////////////////////////////////
+const internal = require("internal");
+const jsunity = require("jsunity");
+const helper = require("@arangodb/aql-helper");
+const isEqual = helper.isEqual;
+const findExecutionNodes = helper.findExecutionNodes;
+const findReferencedNodes = helper.findReferencedNodes;
+const getQueryMultiplePlansAndExecutions = helper.getQueryMultiplePlansAndExecutions;
+const removeAlwaysOnClusterRules = helper.removeAlwaysOnClusterRules;
+const db = require('internal').db;
 
 function legacyOptimizerRuleTestSuite() {
   // quickly disable tests here
@@ -467,7 +463,7 @@ function optimizerRuleTestSuite() {
         
         assertFalse(n.sorted);
         assertEqual("d" + (i + 1), n.outVariable.name);
-        let cond = n.condition.subNodes[0];
+        let cond = helper.unpackRawExpression(n.condition.subNodes[0]);
         assertEqual("n-ary and", cond.type);
         assertEqual(1, cond.subNodes.length);
         cond = cond.subNodes[0];


### PR DESCRIPTION
### Scope & Purpose

Follow-up PR to https://github.com/arangodb/arangodb/pull/17897

* Use more compact and efficient representation for arrays and objects during AQL AST serialization and deserialization. This can help to reduce the size of messages exchanged between coordinator and database servers during query setup, and also reduce the time needed for parsing these messages. This especially helps when there are large bind parameter values that are arrays or objects.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [x] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: -
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 