### PR TITLE
[cmake] Ignore user presets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ p/
 !core.h
 TAGS
 
+CMakeUserPresets.json
 CPackConfig.cmake
 CPackSourceConfig.cmake
 CTestTestfile.cmake

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -279,8 +279,6 @@ set(ARANGODB_TESTS_SOURCES
   VocBase/VersionTest.cpp
   VocBase/VocbaseTest.cpp
   VPackDeserializer/BasicTests.cpp
-  Zkd/Conversion.cpp
-  Zkd/Library.cpp
   Cluster/ShardAutoRebalancerTest.cpp)
 
 if (LINUX)
@@ -313,6 +311,7 @@ target_link_libraries(arangodbtests
   arango_tests_replication2
   arango_tests_graph
   arango_tests_futures
+  arango_tests_zkd
   arango_agency
   arango_cluster_engine
   arango_rocksdb

--- a/tests/Futures/CMakeLists.txt
+++ b/tests/Futures/CMakeLists.txt
@@ -2,20 +2,18 @@ add_library(arango_tests_futures OBJECT
   FutureTest.cpp
   PromiseTest.cpp
   TryTest.cpp)
-
 target_link_libraries(arango_tests_futures
+  PRIVATE
     arango_futures
     gtest
     velocypack
     fmt)
 
-add_executable(arangodbtests_futures
-  EXCLUDE_FROM_ALL)
-
+add_executable(arangodbtests_futures EXCLUDE_FROM_ALL)
 target_link_libraries(arangodbtests_futures
-    arango_crashhandler_light
-    gtest_main
-    arango_tests_futures)
+  arango_crashhandler_light
+  gtest_main
+  arango_tests_futures)
 
 add_test(NAME futures
          COMMAND arangodbtests_futures)

--- a/tests/Zkd/CMakeLists.txt
+++ b/tests/Zkd/CMakeLists.txt
@@ -1,14 +1,18 @@
-add_executable(arangodbtests_zkd EXCLUDE_FROM_ALL
+add_library(arango_tests_zkd OBJECT
   Conversion.cpp
-  Library.cpp
-  main.cpp)
+  Library.cpp)
+target_link_libraries(arango_tests_zkd
+	PRIVATE
+    arango_rocksdb
+    gtest)	
+target_include_directories(arango_tests_zkd
+  PRIVATE
+    ${PROJECT_SOURCE_DIR}/arangod)
 
+add_executable(arangodbtests_zkd EXCLUDE_FROM_ALL)
 target_link_libraries(arangodbtests_zkd
-  arango_rocksdb
-  gtest)
-
-target_include_directories(arangodbtests_zkd PRIVATE
-  ${PROJECT_SOURCE_DIR}/arangod)
+  arango_tests_zkd
+  gtest_main)
 
 add_test(NAME zkd
          COMMAND arangodbtests_zkd)

--- a/tests/Zkd/CMakeLists.txt
+++ b/tests/Zkd/CMakeLists.txt
@@ -2,7 +2,7 @@ add_library(arango_tests_zkd OBJECT
   Conversion.cpp
   Library.cpp)
 target_link_libraries(arango_tests_zkd
-	PRIVATE
+  PRIVATE
     arango_rocksdb
     gtest)	
 target_include_directories(arango_tests_zkd


### PR DESCRIPTION
Adds cmake user presets file to gitignore - Each user should be able to define his/her own presets.

Links zkd tests library into arangodbtests instead of adding test files manually to arangodbtests.