### PR TITLE
[CINFRA-645] acquireSnapshot could be called concurrently

### DIFF
--- a/arangod/Replication2/StateMachines/Document/DocumentFollowerState.cpp
+++ b/arangod/Replication2/StateMachines/Document/DocumentFollowerState.cpp
@@ -243,7 +243,12 @@ auto DocumentFollowerState::handleSnapshotTransfer(
           return self->populateLocalShard(docs);
         });
         if (insertRes.fail()) {
-          return insertRes;
+          LOG_CTX("d8b8a", ERR, self->loggerContext)
+              << "Failed to populate local shard: " << insertRes;
+          return leader->finishSnapshot(snapshotRes->snapshotId);
+          // TODO return result and maybe the leader clear the failed snapshot
+          // itself
+          // return insertRes;
         }
 
         if (snapshotRes->hasMore) {

--- a/arangod/Replication2/StateMachines/Document/DocumentFollowerState.h
+++ b/arangod/Replication2/StateMachines/Document/DocumentFollowerState.h
@@ -82,7 +82,6 @@ struct DocumentFollowerState
   Guarded<GuardedData, basics::UnshackledMutex> _guardedData;
   ActiveTransactionsQueue _activeTransactions;
   std::atomic<std::uint64_t> _snapshotsCount;
-  std::mutex _shardRewriteMutex;
 };
 
 }  // namespace arangodb::replication2::replicated_state::document

--- a/arangod/Replication2/StateMachines/Document/DocumentFollowerState.h
+++ b/arangod/Replication2/StateMachines/Document/DocumentFollowerState.h
@@ -64,24 +64,24 @@ struct DocumentFollowerState
   auto populateLocalShard(velocypack::SharedSlice slice) -> Result;
   auto handleSnapshotTransfer(
       std::shared_ptr<IDocumentStateLeaderInterface> leader,
-      LogIndex waitForIndex, std::uint64_t snapshotsCount,
+      LogIndex waitForIndex, std::uint64_t snapshotVersion,
       futures::Future<ResultT<SnapshotBatch>>&& snapshotFuture) noexcept
       -> futures::Future<Result>;
 
  private:
   struct GuardedData {
     explicit GuardedData(std::unique_ptr<DocumentCore> core)
-        : core(std::move(core)){};
+        : core(std::move(core)), currentSnapshotVersion{0} {};
     [[nodiscard]] bool didResign() const noexcept { return core == nullptr; }
 
     std::unique_ptr<DocumentCore> core;
+    std::uint64_t currentSnapshotVersion;
   };
 
   std::shared_ptr<IDocumentStateNetworkHandler> _networkHandler;
   std::unique_ptr<IDocumentStateTransactionHandler> _transactionHandler;
   Guarded<GuardedData, basics::UnshackledMutex> _guardedData;
   ActiveTransactionsQueue _activeTransactions;
-  std::atomic<std::uint64_t> _snapshotsCount;
 };
 
 }  // namespace arangodb::replication2::replicated_state::document

--- a/arangod/Replication2/StateMachines/Document/DocumentFollowerState.h
+++ b/arangod/Replication2/StateMachines/Document/DocumentFollowerState.h
@@ -64,7 +64,7 @@ struct DocumentFollowerState
   auto populateLocalShard(velocypack::SharedSlice slice) -> Result;
   auto handleSnapshotTransfer(
       std::shared_ptr<IDocumentStateLeaderInterface> leader,
-      LogIndex waitForIndex,
+      LogIndex waitForIndex, std::uint64_t snapshotsCount,
       futures::Future<ResultT<SnapshotBatch>>&& snapshotFuture) noexcept
       -> futures::Future<Result>;
 
@@ -81,6 +81,8 @@ struct DocumentFollowerState
   std::unique_ptr<IDocumentStateTransactionHandler> _transactionHandler;
   Guarded<GuardedData, basics::UnshackledMutex> _guardedData;
   ActiveTransactionsQueue _activeTransactions;
+  std::atomic<std::uint64_t> _snapshotsCount;
+  std::mutex _shardRewriteMutex;
 };
 
 }  // namespace arangodb::replication2::replicated_state::document

--- a/tests/Replication2/ReplicatedState/DocumentStateMachineTest.cpp
+++ b/tests/Replication2/ReplicatedState/DocumentStateMachineTest.cpp
@@ -668,9 +668,10 @@ TEST_F(DocumentStateMachineTest,
 
   std::thread t([follower]() {
     auto res = follower->acquireSnapshot("participantId", LogIndex{1});
-    EXPECT_TRUE(res.isReady() && res.get().fail() &&
-                res.get().errorNumber() ==
-                    TRI_ERROR_REPLICATION_REPLICATED_LOG_FOLLOWER_RESIGNED);
+    EXPECT_TRUE(res.isReady());
+    EXPECT_TRUE(res.get().fail());
+    EXPECT_TRUE(res.get().errorNumber() ==
+                TRI_ERROR_REPLICATION_REPLICATED_LOG_FOLLOWER_RESIGNED);
   });
 
   acquireSnapshotCalled.wait(false);


### PR DESCRIPTION
### Scope & Purpose

The user may remove and add the server again. The leader might do a compaction which the follower won't notice if the process is stopped. From the follower's perspective, the leader compacted something without waiting for itself. Hence, a new snapshot is required. This can happen so quick, that one snapshot transfer is not yet completed before another one is requested.
Before we start transferring the snapshot, we truncate the shard. In case an older snapshot transfer is still ongoing, we make sure that it's not going to apply transactions anymore.
As a remark, currently there's no way to abort a snapshot on the leader, except sending a `finish` request. This would be changed later on, but for now it does suffice.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

