### PR TITLE
DOC-312 | Inverted indexes and `arangosearch` Views accept an array of strings for `storedValues`

### DIFF
--- a/Documentation/DocuBlocks/Rest/Indexes/post_api_index_inverted.md
+++ b/Documentation/DocuBlocks/Rest/Indexes/post_api_index_inverted.md
@@ -175,10 +175,22 @@ the same tokens occur repeatedly, to emphasize these documents less.
 Default: `false`
 
 @RESTBODYPARAM{storedValues,array,optional,post_api_index_inverted_storedvalues}
-The optional `storedValues` attribute can contain an array of paths to additional 
-attributes to store in the index. These additional attributes cannot be used for
-index lookups or for sorting, but they can be used for projections. This allows an
-index to fully cover more queries and avoid extra document lookups.
+The optional `storedValues` attribute can contain an array of objects with paths
+to additional attributes to store in the index. These additional attributes
+cannot be used for index lookups or for sorting, but they can be used for
+projections. This allows an index to fully cover more queries and avoid extra
+document lookups.
+
+You may use the following shorthand notations on index creation instead of
+an array of objects. The default compression and cache settings are used in
+this case:
+
+- An array of string, like `["attr1", "attr2"]`, to place each attribute into
+  a separate column of the index (introduced in v3.10.3).
+
+- An array of arrays of strings, like `[["attr1", "attr2"]]`, to place the
+  attributes into a single column of the index, or `[["attr1"], ["attr2"]]`
+  to place each attribute into a separate column.
 
 @RESTSTRUCT{fields,post_api_index_inverted_storedvalues,array,required,string}
 A list of attribute paths. The `.` character denotes sub-attributes.

--- a/Documentation/DocuBlocks/Rest/Indexes/post_api_index_inverted.md
+++ b/Documentation/DocuBlocks/Rest/Indexes/post_api_index_inverted.md
@@ -190,7 +190,16 @@ this case:
 
 - An array of arrays of strings, like `[["attr1", "attr2"]]`, to place the
   attributes into a single column of the index, or `[["attr1"], ["attr2"]]`
-  to place each attribute into a separate column.
+  to place each attribute into a separate column. You can also mix it with the
+  the full form:
+  
+  ```json
+  [
+    ["attr1"],
+    ["attr2", "attr3"],
+    { "fields": ["attr4", "attr5"], "cache": true }
+  ]
+  ```
 
 @RESTSTRUCT{fields,post_api_index_inverted_storedvalues,array,required,string}
 A list of attribute paths. The `.` character denotes sub-attributes.

--- a/Documentation/DocuBlocks/Rest/Indexes/post_api_index_inverted.md
+++ b/Documentation/DocuBlocks/Rest/Indexes/post_api_index_inverted.md
@@ -185,7 +185,7 @@ You may use the following shorthand notations on index creation instead of
 an array of objects. The default compression and cache settings are used in
 this case:
 
-- An array of string, like `["attr1", "attr2"]`, to place each attribute into
+- An array of strings, like `["attr1", "attr2"]`, to place each attribute into
   a separate column of the index (introduced in v3.10.3).
 
 - An array of arrays of strings, like `[["attr1", "attr2"]]`, to place the

--- a/Documentation/DocuBlocks/Rest/Views/post_api_view_arangosearch.md
+++ b/Documentation/DocuBlocks/Rest/Views/post_api_view_arangosearch.md
@@ -88,6 +88,17 @@ Each object is expected in the following form:
   `--arangosearch.columns-cache-limit` startup option
   to control the memory consumption of this cache.
 
+  You may use the following shorthand notations on View creation instead of
+  an array of objects as described above. The default compression and cache
+  settings are used in this case:
+
+  - An array of string, like `["attr1", "attr2"]`, to place each attribute into
+    a separate column of the index (introduced in v3.10.3).
+
+  - An array of arrays of strings, like `[["attr1", "attr2"]]`, to place the
+    attributes into a single column of the index, or `[["attr1"], ["attr2"]]`
+    to place each attribute into a separate column.
+
 The `storedValues` option is not to be confused with the `storeValues` option,
 which allows to store meta data about attribute values in the View index.
 

--- a/Documentation/DocuBlocks/Rest/Views/post_api_view_arangosearch.md
+++ b/Documentation/DocuBlocks/Rest/Views/post_api_view_arangosearch.md
@@ -92,7 +92,7 @@ Each object is expected in the following form:
   an array of objects as described above. The default compression and cache
   settings are used in this case:
 
-  - An array of string, like `["attr1", "attr2"]`, to place each attribute into
+  - An array of strings, like `["attr1", "attr2"]`, to place each attribute into
     a separate column of the index (introduced in v3.10.3).
 
   - An array of arrays of strings, like `[["attr1", "attr2"]]`, to place the

--- a/Documentation/DocuBlocks/Rest/Views/post_api_view_arangosearch.md
+++ b/Documentation/DocuBlocks/Rest/Views/post_api_view_arangosearch.md
@@ -97,7 +97,16 @@ Each object is expected in the following form:
 
   - An array of arrays of strings, like `[["attr1", "attr2"]]`, to place the
     attributes into a single column of the index, or `[["attr1"], ["attr2"]]`
-    to place each attribute into a separate column.
+    to place each attribute into a separate column. You can also mix it with the
+  the full form:
+  
+  ```json
+  [
+    ["attr1"],
+    ["attr2", "attr3"],
+    { "fields": ["attr4", "attr5"], "cache": true }
+  ]
+  ```
 
 The `storedValues` option is not to be confused with the `storeValues` option,
 which allows to store meta data about attribute values in the View index.


### PR DESCRIPTION
See https://github.com/arangodb/docs/pull/1238