### PR TITLE
Small improvements for cmake presets

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -61,7 +61,8 @@
       "inherits": "community-developer",
       "displayName": "Build ArangoDB Community Edition (TSAN Build)",
       "cacheVariables": {
-        "CMAKE_CXX_FLAGS": "-fsanitize=thread"
+        "CMAKE_CXX_FLAGS": "-fsanitize=thread",
+        "CMAKE_C_FLAGS": "-fsanitize=thread"
       }
     },
     {
@@ -69,7 +70,8 @@
       "inherits": "enterprise-developer",
       "displayName": "Build ArangoDB Enterprise Edition (TSAN Build)",
       "cacheVariables": {
-        "CMAKE_CXX_FLAGS": "-fsanitize=thread"
+        "CMAKE_CXX_FLAGS": "-fsanitize=thread",
+        "CMAKE_C_FLAGS": "-fsanitize=thread"
       }
     },
     {
@@ -77,7 +79,8 @@
       "inherits": "community-developer",
       "displayName": "Build ArangoDB Community Edition (ASAN and UBSAN Build)",
       "cacheVariables": {
-        "CMAKE_CXX_FLAGS": "-fsanitize=address -fsanitize=leak -fsanitize=undefined -fsanitize=float-divide-by-zero -fsanitize-address-use-after-return=never",
+        "CMAKE_CXX_FLAGS": "-fsanitize=address -fsanitize=leak -fsanitize=undefined -fsanitize=float-divide-by-zero -fsanitize-address-use-after-return=never -fno-sanitize=vptr -fno-sanitize=alignment",
+        "CMAKE_C_FLAGS": "-fsanitize=address -fsanitize=leak -fsanitize=undefined -fsanitize=float-divide-by-zero -fsanitize-address-use-after-return=never -fno-sanitize=alignment",
         "USE_JEMALLOC": "Off"
       }
     },
@@ -86,7 +89,8 @@
       "inherits": "enterprise-developer",
       "displayName": "Build ArangoDB Enterprise Edition (ASAN and UBSAN Build)",
       "cacheVariables": {
-        "CMAKE_CXX_FLAGS": "-fsanitize=address -fsanitize=leak -fsanitize=undefined -fsanitize=float-divide-by-zero -fsanitize-address-use-after-return=never",
+        "CMAKE_CXX_FLAGS": "-fsanitize=address -fsanitize=leak -fsanitize=undefined -fsanitize=float-divide-by-zero -fsanitize-address-use-after-return=never -fno-sanitize=vptr -fno-sanitize=alignment",
+        "CMAKE_C_FLAGS": "-fsanitize=address -fsanitize=leak -fsanitize=undefined -fsanitize=float-divide-by-zero -fsanitize-address-use-after-return=never -fno-sanitize=alignment",
         "USE_JEMALLOC": "Off"
       }
     }

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -77,7 +77,8 @@
       "inherits": "community-developer",
       "displayName": "Build ArangoDB Community Edition (ASAN and UBSAN Build)",
       "cacheVariables": {
-        "CMAKE_CXX_FLAGS": "-fsanitize=address -fsanitize=leak -fsanitize=undefined -fsanitize=float-divide-by-zero -fno-sanitize-address-use-after-scope -fno-sanitize=alignment -fno-var-tracking-assignments -fno-sanitize=vptr"
+        "CMAKE_CXX_FLAGS": "-fsanitize=address -fsanitize=leak -fsanitize=undefined -fsanitize=float-divide-by-zero -fsanitize-address-use-after-return=never",
+        "USE_JEMALLOC": "Off"
       }
     },
     {
@@ -85,7 +86,8 @@
       "inherits": "enterprise-developer",
       "displayName": "Build ArangoDB Enterprise Edition (ASAN and UBSAN Build)",
       "cacheVariables": {
-        "CMAKE_CXX_FLAGS": "-fsanitize=address -fsanitize=leak -fsanitize=undefined -fsanitize=float-divide-by-zero -fno-sanitize-address-use-after-scope -fno-sanitize=alignment -fno-var-tracking-assignments -fno-sanitize=vptr"
+        "CMAKE_CXX_FLAGS": "-fsanitize=address -fsanitize=leak -fsanitize=undefined -fsanitize=float-divide-by-zero -fsanitize-address-use-after-return=never",
+        "USE_JEMALLOC": "Off"
       }
     }
   ],
@@ -115,11 +117,11 @@
       "configurePreset": "enterprise-developer-tsan"
     },
     {
-      "name": "community-developer-asan-uban",
+      "name": "community-developer-asan-ubsan",
       "configurePreset": "community-developer-asan-ubsan"
     },
     {
-      "name": "enterprise-developer-asan",
+      "name": "enterprise-developer-asan-ubsan",
       "configurePreset": "enterprise-developer-asan-ubsan"
     }
   ],


### PR DESCRIPTION
### Scope & Purpose

Small improvements for cmake presets

- turn off jemalloc for ASan/UBSan builds, because no other memory allocator should be used with ASan
- use the same ASan/UBSan options as we currently do in Oskar (they were recently changed there)
- fix "incorrect" preset names

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: -
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 