### PR TITLE
remove unused functionality from LoggerStream

### DIFF
--- a/lib/Basics/memory-map-posix.cpp
+++ b/lib/Basics/memory-map-posix.cpp
@@ -39,7 +39,7 @@
 using namespace arangodb;
 
 namespace {
-static std::string flagify(int flags) {
+std::string flagify(int flags) {
   std::string result;
 
   int const remain = flags & (PROT_READ | PROT_WRITE | PROT_EXEC);
@@ -86,9 +86,8 @@ ErrorCode TRI_MMFile(void* memoryAddress, size_t numOfBytesToInitialize,
     TRI_ASSERT(*result != nullptr);
 
     LOG_TOPIC("667d8", DEBUG, Logger::MMAP)
-        << "memory-mapped range "
-        << Logger::RANGE(*result, numOfBytesToInitialize)
-        << ", file-descriptor " << fileDescriptor
+        << "memory-mapped " << numOfBytesToInitialize << " bytes at address "
+        << *result << ", file-descriptor " << fileDescriptor
         << ", flags: " << flagify(flags);
 
     return TRI_ERROR_NO_ERROR;
@@ -103,9 +102,9 @@ ErrorCode TRI_MMFile(void* memoryAddress, size_t numOfBytesToInitialize,
   // preserve errno value while we're logging
   int tmp = errno;
   LOG_TOPIC("b3306", WARN, Logger::MMAP)
-      << "memory-mapping failed for range "
-      << Logger::RANGE(*result, numOfBytesToInitialize) << ", file-descriptor "
-      << fileDescriptor << ", flags: " << flagify(flags);
+      << "memory-mapping failed for range of size " << numOfBytesToInitialize
+      << " at address " << *result << ", file-descriptor " << fileDescriptor
+      << ", flags: " << flagify(flags);
   errno = tmp;
   return TRI_ERROR_SYS_ERROR;
 }
@@ -122,9 +121,9 @@ ErrorCode TRI_UNMMFile(void* memoryAddress, size_t numOfBytesToUnMap,
 
   if (res == 0) {
     LOG_TOPIC("a12c1", DEBUG, Logger::MMAP)
-        << "memory-unmapped range "
-        << Logger::RANGE(memoryAddress, numOfBytesToUnMap)
-        << ", file-descriptor " << fileDescriptor;
+        << "memory-unmapped range of size " << numOfBytesToUnMap
+        << " at address " << memoryAddress << ", file-descriptor "
+        << fileDescriptor;
 
     return TRI_ERROR_NO_ERROR;
   }
@@ -148,8 +147,8 @@ ErrorCode TRI_UNMMFile(void* memoryAddress, size_t numOfBytesToUnMap,
 ErrorCode TRI_MMFileAdvise(void* memoryAddress, size_t numOfBytes, int advice) {
 #ifdef __linux__
   LOG_TOPIC("399d4", TRACE, Logger::MMAP)
-      << "madvise " << advice << " for range "
-      << Logger::RANGE(memoryAddress, numOfBytes);
+      << "madvise " << advice << " for range of size " << numOfBytes
+      << " at address " << memoryAddress;
 
   int res = madvise(memoryAddress, numOfBytes, advice);
 
@@ -159,9 +158,8 @@ ErrorCode TRI_MMFileAdvise(void* memoryAddress, size_t numOfBytes, int advice) {
 
   res = errno;
   LOG_TOPIC("7fffb", ERR, Logger::MMAP)
-      << "madvise " << advice << " for range "
-      << Logger::RANGE(memoryAddress, numOfBytes)
-      << " failed with: " << strerror(res);
+      << "madvise " << advice << " failed for range of size " << numOfBytes
+      << " at address " << memoryAddress << " with " << strerror(res);
   return TRI_ERROR_INTERNAL;
 #else
   return TRI_ERROR_NO_ERROR;

--- a/lib/Basics/memory-map-win32.cpp
+++ b/lib/Basics/memory-map-win32.cpp
@@ -196,9 +196,8 @@ ErrorCode TRI_MMFile(void* memoryAddress, size_t numOfBytesToInitialize,
   }
 
   LOG_TOPIC("048dd", DEBUG, Logger::MMAP)
-      << "memory-mapped range "
-      << Logger::RANGE(*result, numOfBytesToInitialize) << ", file-descriptor "
-      << fileDescriptor;
+      << "memory-mapped " << numOfBytesToInitialize << " bytes at address "
+      << *result << ", file-descriptor " << fileDescriptor;
 
   return TRI_ERROR_NO_ERROR;
 }
@@ -230,9 +229,8 @@ ErrorCode TRI_UNMMFile(void* memoryAddress, size_t numOfBytesToUnMap,
   }
 
   LOG_TOPIC("447d8", DEBUG, Logger::MMAP)
-      << "memory-unmapped range "
-      << Logger::RANGE(memoryAddress, numOfBytesToUnMap) << ", file-descriptor "
-      << fileDescriptor;
+      << "memory-unmapped range of size " << numOfBytesToUnMap << " at address "
+      << memoryAddress << ", file-descriptor " << fileDescriptor;
 
   return TRI_ERROR_NO_ERROR;
 }

--- a/lib/Logger/Logger.h
+++ b/lib/Logger/Logger.h
@@ -212,28 +212,6 @@ class Logger {
     int _precision;
   };
 
-  struct CHARS {
-    CHARS(char const* data, size_t size) noexcept : data(data), size(size) {}
-    char const* data;
-    size_t size;
-  };
-
-  struct BINARY {
-    BINARY(void const* baseAddress, size_t size)
-    noexcept : baseAddress(baseAddress), size(size) {}
-    explicit BINARY(std::string const& data) noexcept
-        : BINARY(data.data(), data.size()) {}
-    void const* baseAddress;
-    size_t size;
-  };
-
-  struct RANGE {
-    RANGE(void const* baseAddress, size_t size)
-    noexcept : baseAddress(baseAddress), size(size) {}
-    void const* baseAddress;
-    size_t size;
-  };
-
   struct LINE {
     explicit LINE(int line) noexcept : _line(line) {}
     int _line;

--- a/lib/Logger/LoggerStream.cpp
+++ b/lib/Logger/LoggerStream.cpp
@@ -56,57 +56,6 @@ LoggerStreamBase& LoggerStreamBase::operator<<(LogTopic const& topic) noexcept {
   return *this;
 }
 
-// print a hex representation of the binary data
-LoggerStreamBase& LoggerStreamBase::operator<<(
-    Logger::BINARY const& binary) noexcept {
-  try {
-    uint8_t const* ptr = static_cast<uint8_t const*>(binary.baseAddress);
-    uint8_t const* end = ptr + binary.size;
-
-    while (ptr < end) {
-      uint8_t n = *ptr;
-
-      uint8_t n1 = n >> 4;
-      uint8_t n2 = n & 0x0F;
-
-      _out << "\\x"
-           << static_cast<char>((n1 < 10) ? ('0' + n1) : ('A' + n1 - 10))
-           << static_cast<char>((n2 < 10) ? ('0' + n2) : ('A' + n2 - 10));
-      ++ptr;
-    }
-  } catch (...) {
-    // ignore any errors here. logging should not have side effects
-  }
-
-  return *this;
-}
-
-// print a character array
-LoggerStreamBase& LoggerStreamBase::operator<<(
-    Logger::CHARS const& data) noexcept {
-  try {
-    _out.write(data.data, data.size);
-  } catch (...) {
-    // ignore any errors here. logging should not have side effects
-  }
-
-  return *this;
-}
-
-LoggerStreamBase& LoggerStreamBase::operator<<(
-    Logger::RANGE const& range) noexcept {
-  try {
-    _out << range.baseAddress << " - "
-         << static_cast<void const*>(
-                static_cast<char const*>(range.baseAddress) + range.size)
-         << " (" << range.size << " bytes)";
-  } catch (...) {
-    // ignore any errors here. logging should not have side effects
-  }
-
-  return *this;
-}
-
 LoggerStreamBase& LoggerStreamBase::operator<<(
     Logger::FIXED const& value) noexcept {
   try {

--- a/lib/Logger/LoggerStream.h
+++ b/lib/Logger/LoggerStream.h
@@ -50,12 +50,6 @@ class LoggerStreamBase {
 
   LoggerStreamBase& operator<<(LogTopic const& topic) noexcept;
 
-  LoggerStreamBase& operator<<(Logger::BINARY const& binary) noexcept;
-
-  LoggerStreamBase& operator<<(Logger::CHARS const& chars) noexcept;
-
-  LoggerStreamBase& operator<<(Logger::RANGE const& range) noexcept;
-
   LoggerStreamBase& operator<<(Logger::FIXED const& duration) noexcept;
 
   LoggerStreamBase& operator<<(Logger::LINE const& line) noexcept;


### PR DESCRIPTION
### Scope & Purpose

Remove unused functionality from Logger/LoggerStream: `Logger::CHARS`, Logger::RANGE` and `Logger::BINARY`.
Adjust a few places that still used it to use something else instead.
This is an internal change that should not have any effect on the user-visible behavior.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: -
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
