### PR TITLE
[CINFRA] State Creation Speedup

### DIFF
--- a/arangod/Replication2/ReplicatedLog/ILogInterfaces.h
+++ b/arangod/Replication2/ReplicatedLog/ILogInterfaces.h
@@ -116,6 +116,7 @@ struct ILogLeader : ILogParticipant {
       std::shared_ptr<agency::ParticipantsConfig const> const& config)
       -> LogIndex = 0;
   virtual auto ping(std::optional<std::string> message) -> LogIndex = 0;
+  virtual auto waitForLeadership() -> WaitForFuture = 0;
 };
 
 }  // namespace arangodb::replication2::replicated_log

--- a/arangod/Replication2/ReplicatedLog/LogLeader.h
+++ b/arangod/Replication2/ReplicatedLog/LogLeader.h
@@ -154,7 +154,7 @@ class LogLeader : public std::enable_shared_from_this<LogLeader>,
   // entry within its term has been committed.
   [[nodiscard]] auto isLeadershipEstablished() const noexcept -> bool;
 
-  auto waitForLeadership() -> WaitForFuture;
+  auto waitForLeadership() -> WaitForFuture override;
   auto ping(std::optional<std::string> message) -> LogIndex override;
 
   // This function returns the current commit index. Do NOT poll this function,

--- a/js/common/modules/@arangodb/testutils/replicated-logs-helper.js
+++ b/js/common/modules/@arangodb/testutils/replicated-logs-helper.js
@@ -35,6 +35,8 @@ const helper = require('@arangodb/test-helper-common');
 const serverHelper = require('@arangodb/test-helper');
 
 const waitFor = function (checkFn, maxTries = 240, onErrorCallback) {
+  const waitTimes = [0.1, 0.1, 0.2, 0.2, 0.2, 0.3, 0.5];
+  const getWaitTime = (count) => waitTimes[Math.min(waitTimes.length-1, count)];
   let count = 0;
   let result = null;
   while (count < maxTries) {
@@ -49,7 +51,7 @@ const waitFor = function (checkFn, maxTries = 240, onErrorCallback) {
     if (count % 10 === 0) {
       console.log(result);
     }
-    wait(0.5); // 240 * .5s = 2 minutes
+    wait(getWaitTime(count));
   }
   if (onErrorCallback !== undefined) {
     onErrorCallback(result);

--- a/tests/Replication2/ReplicatedLog/ReplicatedLogConnectTest.cpp
+++ b/tests/Replication2/ReplicatedLog/ReplicatedLogConnectTest.cpp
@@ -155,6 +155,9 @@ struct FakeLogLeader : replicated_log::ILogLeader {
   auto waitForIterator(LogIndex index) -> WaitForIteratorFuture override {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_NOT_IMPLEMENTED);
   }
+  auto waitForLeadership() -> WaitForFuture override {
+    return {replicated_log::WaitForResult{}};
+  }
   auto copyInMemoryLog() const -> replicated_log::InMemoryLog override {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_NOT_IMPLEMENTED);
   }


### PR DESCRIPTION
### Scope & Purpose
Collection and Database creation was slow with replication 2. The reason for this was, that changes in replicated states were not reported to the agency asap. This was, because the database was not marked as dirty. This PR changes that. Once a leader is established, the database is marked as dirt, which triggers a maintenance run, which then reports the changes to the agency. Similar code was already in place for updates.

Additionally I changes the times in `waitFor` for testing. Usually replicated states react faster than .5s. I was able (at least on my machine) to push the test run time for `replication2-supervision-replicated-log-target-cluster.js` from 2.5 minutes to 1.5 minutes. Most of the time was spend in waitFor, waiting for the system to converge (which it already did).