### PR TITLE
[FE-48] only admin see license info PART2

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,11 @@
 devel
 -----
 
+* Web UI [FE-48]: Additional fix to the previously introduced license
+  information usability improvement. In case the server is being started with
+  the additional parameter `--server.harden`, the previous fix did not handle
+  that specific edge case.
+
 * Use more compact and efficient representation for arrays and objects during
   AQL AST serialization and deserialization. This can help to reduce the size
   of messages exchanged between coordinator and database servers during query

--- a/js/apps/system/_admin/aardvark/APP/frontend/js/views/navigationView.js
+++ b/js/apps/system/_admin/aardvark/APP/frontend/js/views/navigationView.js
@@ -142,10 +142,9 @@
           } else {
             self.showLicenseError();
           }
-        },
-        error: function () {
-          self.showLicenseError();
         }
+        // intentionally no error handling: non-root users may not be allowed to fetch license information, but in that case we do not want to show an error
+        // Additional note: This is required if "--server.harden true" is being set.
       });
     },
 


### PR DESCRIPTION
### Scope & Purpose

In addition to the original PR #15776 , we also must disable error notifications for the actual licence call itself - if parameter: `--server.harden true` is being set. Otherwise the attempted effect (original pr) does not take into account.

Original scope (part1): 

> Non-root users has no access to the api endpoint "/_admin/time" which we use to calculate and display license info below the navigation bar and therefore returns a 403 error. Meaning those users got the info "Error: Failed to fetch license information" all the time what is bad user experience. As this license information is just an information for the user we removed error handling at fetching the license information to not show errors in the Web UI. In this specific case we improve the user experience in not showing errors.

- [x] :hankey: Bugfix

### Checklist

- [x] Tests
  - [x] **manually tested**
- [x] :book: CHANGELOG entry made
- [x] Backports
  - [ ] Backport for 3.10: *(Please link PR)*
  - [ ] Backport for 3.9: *(Please link PR)*
  - [x] Backport for 3.8: not required since original fix does not include 3.8

#### Related Information

- [x] Jira ticket: https://arangodb.atlassian.net/browse/FE-48
- [x] GitHub ticket: https://github.com/arangodb/arangodb/pull/15776 
