### PR TITLE
[CINFRA] Replace Participant Race with Agency Cache

### DIFF
--- a/arangod/Agency/AsyncAgencyComm.cpp
+++ b/arangod/Agency/AsyncAgencyComm.cpp
@@ -434,8 +434,8 @@ namespace arangodb {
 
 futures::Future<consensus::index_t> AsyncAgencyComm::getCurrentCommitIndex()
     const {
-  auto future = sendWithFailover(fuerte::RestVerb::Get, "_api/agency/config",
-                                 120s, RequestType::CUSTOM, {});
+  auto future = sendWithFailover(fuerte::RestVerb::Get, "/_api/agency/config",
+                                 120s, RequestType::READ, {});
   return std::move(future).thenValue([](AsyncAgencyCommResult&& response) {
     if (auto result = response.asResult(); result.fail()) {
       THROW_ARANGO_EXCEPTION(result);

--- a/arangod/Agency/AsyncAgencyComm.cpp
+++ b/arangod/Agency/AsyncAgencyComm.cpp
@@ -432,6 +432,20 @@ arangodb::AsyncAgencyComm::FutureResult agencyAsyncSend(
 
 namespace arangodb {
 
+futures::Future<consensus::index_t> AsyncAgencyComm::getCurrentCommitIndex()
+    const {
+  auto future = sendWithFailover(fuerte::RestVerb::Get, "_api/agency/config",
+                                 120s, RequestType::CUSTOM, {});
+  return std::move(future).thenValue([](AsyncAgencyCommResult&& response) {
+    if (auto result = response.asResult(); result.fail()) {
+      THROW_ARANGO_EXCEPTION(result);
+    }
+
+    auto slice = response.slice();
+    return slice.get("commitIndex").extract<consensus::index_t>();
+  });
+}
+
 AsyncAgencyComm::FutureResult AsyncAgencyComm::sendWithFailover(
     arangodb::fuerte::RestVerb method, std::string const& url,
     network::Timeout timeout, RequestType type, uint64_t index) const {

--- a/arangod/Agency/AsyncAgencyComm.h
+++ b/arangod/Agency/AsyncAgencyComm.h
@@ -40,6 +40,7 @@
 #include "Futures/Future.h"
 #include "Network/Methods.h"
 #include "Network/Utils.h"
+#include "AgencyCommon.h"
 
 namespace arangodb {
 
@@ -200,6 +201,9 @@ class AsyncAgencyComm final {
       std::optional<network::Timeout> timeout = {}) const;
   [[nodiscard]] FutureResult poll(network::Timeout timeout,
                                   uint64_t index) const;
+
+  [[nodiscard]] futures::Future<consensus::index_t> getCurrentCommitIndex()
+      const;
 
   template<typename T>
   [[nodiscard]] FutureResult setValue(

--- a/arangod/Cluster/AgencyCache.cpp
+++ b/arangod/Cluster/AgencyCache.cpp
@@ -163,6 +163,12 @@ futures::Future<arangodb::Result> AgencyCache::waitFor(index_t index) {
       ->second.getFuture();
 }
 
+futures::Future<Result> AgencyCache::waitForLatestCommitIndex() {
+  AsyncAgencyComm ac;
+  return ac.getCurrentCommitIndex().thenValue(
+      [this](consensus::index_t idx) { return this->waitFor(idx); });
+}
+
 index_t AgencyCache::index() const {
   std::shared_lock g(_storeLock);
   return _commitIndex;

--- a/arangod/Cluster/AgencyCache.h
+++ b/arangod/Cluster/AgencyCache.h
@@ -117,6 +117,10 @@ class AgencyCache final : public ServerThread<ArangodServer> {
   /// @brief Wait to be notified, when a Raft index has arrived.
   [[nodiscard]] futures::Future<Result> waitFor(consensus::index_t index);
 
+  /// @brief Queries the agency for the latest commit index and waits for the
+  /// local cache to reach this index.
+  [[nodiscard]] futures::Future<Result> waitForLatestCommitIndex();
+
   /// @brief Cache has these path? AgencyCommHelper::path is prepended
   bool has(std::string const& path) const;
 

--- a/arangod/Replication2/AgencyMethods.cpp
+++ b/arangod/Replication2/AgencyMethods.cpp
@@ -289,6 +289,10 @@ auto methods::replaceReplicatedStateParticipant(
                 return std::move(precs).isEqual(*path->leader(),
                                                 *currentLeader);
               })
+        .cond(not currentLeader.has_value(),
+              [&](auto&& precs) {
+                return std::move(precs).isEmpty(*path->leader());
+              })
         .end()
         .done();
   }

--- a/arangod/RestHandler/RestLogHandler.cpp
+++ b/arangod/RestHandler/RestLogHandler.cpp
@@ -106,6 +106,10 @@ RestStatus RestLogHandler::handlePostRequest(
     namespace paths = ::arangodb::cluster::paths;
     auto& agencyCache =
         _vocbase.server().getFeature<ClusterFeature>().agencyCache();
+    if (auto result = agencyCache.waitForLatestCommitIndex().get();
+        result.fail()) {
+      THROW_ARANGO_EXCEPTION(result);
+    }
     auto path = paths::aliases::target()
                     ->replicatedLogs()
                     ->database(_vocbase.name())


### PR DESCRIPTION
### Scope & Purpose
I did two things in this PR:
1. I added `waitForLastCommitIndex()` to the agency cache. The function calls the agency and looks for the current commit index. Then it waits for this index to be visible in the local cache. Doing that ensures, that writes that were performed on a different coordinator before a call to `waitForLastCommitIndex` are visible locally.
2. To implement the above function I added `getCurrentCommitIndex` to the AsyncAgencyComm.
3. The replace-participant call, that failed due to a wrong cache, is not patched. See below for more details, why the test failed.
4. I added a precondition, that was missing and allowed the write, although something else was already present in the agency. Just having this precondition, wouldn't have fixed the test. Instead it would have failed with precondition-failed.




#### Details ####
This is a caching issue. The test does the following: it creates a replicated log, without an explicit leader set. Then it sets the leader explicitly to the current leader. After that it replaces the leader with another server.
The test now asserts, that the explicitly set leader is replaced with the new server, that the new server becomes the leader and that the old leader is removed.
However, in this run, the coordinator agency cache did not see that the leader was explicitly set, because the cache did not reflect the first write. Hence it did not generate a transaction that replaces the explicitly set leader.