### PR TITLE
[PREGEL] Provide test binary for Pregel

### DIFF
--- a/arangod/Pregel/CommonFormats.h
+++ b/arangod/Pregel/CommonFormats.h
@@ -34,6 +34,8 @@
 #include "Pregel/MessageFormat.h"
 #include "Pregel/VertexComputation.h"
 
+#include "Inspection/VPack.h"
+
 namespace arangodb::pregel {
 
 // Speaker-listerner Label propagation

--- a/arangod/Pregel/ExecutionNumber.h
+++ b/arangod/Pregel/ExecutionNumber.h
@@ -22,7 +22,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #pragma once
-#include <Inspection/VPack.h>
+#include <Inspection/VPackWithErrorT.h>
 
 #include <ostream>
 #include <fmt/core.h>

--- a/arangod/Pregel/Status/ConductorStatus.h
+++ b/arangod/Pregel/Status/ConductorStatus.h
@@ -40,7 +40,7 @@
 //       First step: split ClusterTypes.h into sensible bits
 //       Second step: only include the type aliases here
 namespace arangodb {
-typedef std::string ServerID;         // ID of a server
+typedef std::string ServerID;  // ID of a server
 }
 
 namespace arangodb::pregel {

--- a/arangod/Pregel/Status/ConductorStatus.h
+++ b/arangod/Pregel/Status/ConductorStatus.h
@@ -28,13 +28,15 @@
 #include <numeric>
 #include <string>
 
-#include <Inspection/VPack.h>
+#include <Inspection/VPackWithErrorT.h>
 #include <Inspection/Transformers.h>
-
-#include <Cluster/ClusterTypes.h>
 
 #include <Pregel/Common.h>
 #include <Pregel/Status/Status.h>
+
+namespace arangodb {
+typedef std::string ServerID;         // ID of a server
+}
 
 namespace arangodb::pregel {
 

--- a/arangod/Pregel/Status/ConductorStatus.h
+++ b/arangod/Pregel/Status/ConductorStatus.h
@@ -34,6 +34,11 @@
 #include <Pregel/Common.h>
 #include <Pregel/Status/Status.h>
 
+// TODO: This is a hack to not have to include ClusterTypes.h
+//       which in turn pulls in Result.h which requires building
+//       of voc-errors.
+//       First step: split ClusterTypes.h into sensible bits
+//       Second step: only include the type aliases here
 namespace arangodb {
 typedef std::string ServerID;         // ID of a server
 }

--- a/arangod/Pregel/Status/ExecutionStatus.h
+++ b/arangod/Pregel/Status/ExecutionStatus.h
@@ -25,7 +25,9 @@
 #include <string>
 #include <chrono>
 
-#include <Inspection/VPack.h>
+#include <Inspection/VPackWithErrorT.h>
+#include <CrashHandler/CrashHandler.h>
+#include <Assertions/ProdAssert.h>
 
 namespace arangodb::pregel {
 

--- a/arangod/Pregel/Status/Status.h
+++ b/arangod/Pregel/Status/Status.h
@@ -29,7 +29,7 @@
 #include <optional>
 #include <string>
 
-#include <Inspection/VPack.h>
+#include <Inspection/VPackWithErrorT.h>
 #include <Inspection/Transformers.h>
 
 #include <Pregel/Common.h>

--- a/lib/Assertions/ProdAssert.h
+++ b/lib/Assertions/ProdAssert.h
@@ -39,6 +39,8 @@
 
 #include "AssertionConditionalLogger.h"
 
+#include "Basics/system-compiler.h"
+
 // Always evaluates expr, even if the assertion does not fail
 #define ADB_PROD_ASSERT(expr) /*GCOVR_EXCL_LINE*/                          \
   ::arangodb::debug::AssertionConditionalLogger{                           \

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -18,6 +18,7 @@ add_subdirectory(Zkd)
 add_subdirectory(Graph)
 add_subdirectory(Replication2)
 add_subdirectory(Futures)
+add_subdirectory(Pregel)
 
 # ----------------------------------------
 # Link directories
@@ -233,9 +234,7 @@ set(ARANGODB_TESTS_SOURCES
   Network/ConnectionPoolTest.cpp
   Network/MethodsTest.cpp
   Network/UtilsTest.cpp
-  Pregel/DurationTest.cpp
   Pregel/typedbuffer.cpp
-  Pregel/StatusTest.cpp
   ProgramOptions/InifileParserTest.cpp
   ProgramOptions/ParametersTest.cpp
   Replication/ReplicationClientsProgressTrackerTest.cpp
@@ -312,6 +311,7 @@ target_link_libraries(arangodbtests
   arango_tests_graph
   arango_tests_futures
   arango_tests_zkd
+  arango_tests_pregel
   arango_agency
   arango_cluster_engine
   arango_rocksdb

--- a/tests/Pregel/CMakeLists.txt
+++ b/tests/Pregel/CMakeLists.txt
@@ -5,17 +5,25 @@ add_library(arango_tests_pregel OBJECT
   DurationTest.cpp
   StatusTest.cpp)
 
+target_include_directories(arango_tests_pregel
+  PRIVATE
+  ${PROJECT_SOURCE_DIR}/arangod
+  ${PROJECT_SOURCE_DIR}/lib)
+
 target_link_libraries(arango_tests_pregel
-    arango_tests_basics
-    velocypack
-    fmt)
+  gtest
+  date_interface
+  velocypack
+  fmt)
 
 add_executable(arangodbtests_pregel
   EXCLUDE_FROM_ALL)
 
 target_link_libraries(arangodbtests_pregel
     gtest_main
-    arango_tests_pregel)
+    arango_tests_pregel
+    arango_crashhandler_light
+    arango_assertions)
 
 add_test(NAME pregel
          COMMAND arangodbtests_pregel)

--- a/tests/Pregel/CMakeLists.txt
+++ b/tests/Pregel/CMakeLists.txt
@@ -11,6 +11,7 @@ target_include_directories(arango_tests_pregel
   ${PROJECT_SOURCE_DIR}/lib)
 
 target_link_libraries(arango_tests_pregel
+  PRIVATE
   gtest
   date_interface
   velocypack

--- a/tests/Pregel/CMakeLists.txt
+++ b/tests/Pregel/CMakeLists.txt
@@ -1,0 +1,21 @@
+# note that typedbuffer.cpp is excluded intentionally
+# since it seems to have a big dependency footprint;
+# we intent to remove the TypedBuffer construct soon
+add_library(arango_tests_pregel OBJECT
+  DurationTest.cpp
+  StatusTest.cpp)
+
+target_link_libraries(arango_tests_pregel
+    arango_tests_basics
+    velocypack
+    fmt)
+
+add_executable(arangodbtests_pregel
+  EXCLUDE_FROM_ALL)
+
+target_link_libraries(arangodbtests_pregel
+    gtest_main
+    arango_tests_pregel)
+
+add_test(NAME pregel
+         COMMAND arangodbtests_pregel)


### PR DESCRIPTION
### Scope & Purpose

Adds `CMakeLists.txt` for `tests/Pregel`, which adds a test executable `arangodbtests_pregel` and a test case `pregel`;

Note that `typedbuffer.cpp` is not included in this test-binary intentionally because of its large dependency footprint and the fact that we plan to remove that class. It is still tested by `arangodbtests`.