### PR TITLE
[CINFRA-654] Introduce shard operations on follower

### DIFF
--- a/arangod/Replication2/StateMachines/Document/DocumentCore.cpp
+++ b/arangod/Replication2/StateMachines/Document/DocumentCore.cpp
@@ -65,6 +65,10 @@ auto DocumentCore::getShardId() -> std::string_view { return _shardId; }
 
 auto DocumentCore::getGid() -> GlobalLogIdentifier { return _gid; }
 
+auto DocumentCore::getCollectionId() -> std::string const& {
+  return _params.collectionId;
+}
+
 void DocumentCore::drop() {
   auto result = _shardHandler->dropLocalShard(_params.collectionId);
   if (result.fail()) {

--- a/arangod/Replication2/StateMachines/Document/DocumentCore.cpp
+++ b/arangod/Replication2/StateMachines/Document/DocumentCore.cpp
@@ -43,11 +43,11 @@ DocumentCore::DocumentCore(
   auto collectionProperties =
       _agencyHandler->getCollectionPlan(_params.collectionId);
 
-  auto shardResult = _shardHandler->createLocalShard(_params.collectionId,
-                                                     collectionProperties);
+  _shardId = fmt::format("s{}", _gid.id);
+  auto shardResult = _shardHandler->createLocalShard(
+      _shardId, _params.collectionId, collectionProperties);
   TRI_ASSERT(shardResult.ok()) << "Shard creation failed for replicated state "
-                               << _gid << ": " << shardResult.result();
-  _shardId = shardResult.get();
+                               << _gid << ": " << shardResult;
 
   auto commResult = _agencyHandler->reportShardInCurrent(
       _params.collectionId, _shardId, collectionProperties);
@@ -61,7 +61,7 @@ DocumentCore::DocumentCore(
       << "Created shard " << _shardId << " for replicated state " << _gid;
 }
 
-auto DocumentCore::getShardId() -> std::string_view { return _shardId; }
+auto DocumentCore::getShardId() -> ShardID const& { return _shardId; }
 
 auto DocumentCore::getGid() -> GlobalLogIdentifier { return _gid; }
 
@@ -70,7 +70,7 @@ auto DocumentCore::getCollectionId() -> std::string const& {
 }
 
 void DocumentCore::drop() {
-  auto result = _shardHandler->dropLocalShard(_params.collectionId);
+  auto result = _shardHandler->dropLocalShard(_shardId, _params.collectionId);
   if (result.fail()) {
     LOG_CTX("b7f0d", FATAL, this->loggerContext)
         << "Failed to drop shard " << _shardId << " for replicated state "

--- a/arangod/Replication2/StateMachines/Document/DocumentCore.h
+++ b/arangod/Replication2/StateMachines/Document/DocumentCore.h
@@ -42,7 +42,7 @@ struct DocumentCore {
 
   LoggerContext const loggerContext;
 
-  auto getShardId() -> std::string_view;
+  auto getShardId() -> ShardID const&;
   auto getGid() -> GlobalLogIdentifier;
   auto getCollectionId() -> std::string const&;
 

--- a/arangod/Replication2/StateMachines/Document/DocumentCore.h
+++ b/arangod/Replication2/StateMachines/Document/DocumentCore.h
@@ -44,6 +44,7 @@ struct DocumentCore {
 
   auto getShardId() -> std::string_view;
   auto getGid() -> GlobalLogIdentifier;
+  auto getCollectionId() -> std::string const&;
 
   void drop();
 

--- a/arangod/Replication2/StateMachines/Document/DocumentFollowerState.cpp
+++ b/arangod/Replication2/StateMachines/Document/DocumentFollowerState.cpp
@@ -111,12 +111,12 @@ auto DocumentFollowerState::applyEntries(
                   std::make_shared<velocypack::Builder>(doc.data.slice());
               auto const& collectionId = data.core->getCollectionId();
               auto res = self->_shardHandler->createLocalShard(
-                  collectionId, collectionProperties);
+                  self->shardId, collectionId, collectionProperties);
               if (res.fail()) {
                 LOG_CTX("d82d4", FATAL, self->loggerContext)
                     << "Failed to create shard " << self->shardId
                     << " of collection " << self->shardId
-                    << " with error: " << res.result();
+                    << " with error: " << res;
                 FATAL_ERROR_EXIT();
               }
               LOG_CTX("d82d5", TRACE, self->loggerContext)
@@ -124,7 +124,8 @@ auto DocumentFollowerState::applyEntries(
                   << " of collection " << collectionId;
             } else if (doc.operation == OperationType::kDropShard) {
               auto const& collectionId = data.core->getCollectionId();
-              auto res = self->_shardHandler->dropLocalShard(collectionId);
+              auto res = self->_shardHandler->dropLocalShard(self->shardId,
+                                                             collectionId);
               if (res.fail()) {
                 LOG_CTX("d82d4", FATAL, self->loggerContext)
                     << "Failed to drop shard " << self->shardId

--- a/arangod/Replication2/StateMachines/Document/DocumentFollowerState.cpp
+++ b/arangod/Replication2/StateMachines/Document/DocumentFollowerState.cpp
@@ -127,19 +127,19 @@ auto DocumentFollowerState::applyEntries(
               auto res = self->_shardHandler->dropLocalShard(self->shardId,
                                                              collectionId);
               if (res.fail()) {
-                LOG_CTX("d82d4", FATAL, self->loggerContext)
+                LOG_CTX("8c7a0", FATAL, self->loggerContext)
                     << "Failed to drop shard " << self->shardId
                     << " of collection " << collectionId
                     << " with error: " << res;
                 FATAL_ERROR_EXIT();
               }
-              LOG_CTX("d82d5", TRACE, self->loggerContext)
+              LOG_CTX("cdc44", TRACE, self->loggerContext)
                   << "Dropped local shard " << self->shardId
                   << " of collection " << collectionId;
             } else {
               auto res = self->_transactionHandler->applyEntry(doc);
               if (res.fail()) {
-                LOG_CTX("d82d4", FATAL, self->loggerContext)
+                LOG_CTX("1b08f", FATAL, self->loggerContext)
                     << "Failed to apply entry " << entry->first
                     << " to local shard " << self->shardId
                     << " with error: " << res;

--- a/arangod/Replication2/StateMachines/Document/DocumentFollowerState.cpp
+++ b/arangod/Replication2/StateMachines/Document/DocumentFollowerState.cpp
@@ -25,6 +25,7 @@
 
 #include "Replication2/StateMachines/Document/DocumentStateHandlersFactory.h"
 #include "Replication2/StateMachines/Document/DocumentStateNetworkHandler.h"
+#include "Replication2/StateMachines/Document/DocumentStateShardHandler.h"
 #include "Replication2/StateMachines/Document/DocumentStateTransactionHandler.h"
 
 #include <Basics/application-exit.h>
@@ -41,6 +42,7 @@ DocumentFollowerState::DocumentFollowerState(
       loggerContext(core->loggerContext.with<logContextKeyStateComponent>(
           "FollowerState")),
       _networkHandler(handlersFactory->createNetworkHandler(core->getGid())),
+      _shardHandler(handlersFactory->createShardHandler(core->getGid())),
       _transactionHandler(
           handlersFactory->createTransactionHandler(core->getGid())),
       _guardedData(std::move(core)) {}
@@ -104,26 +106,57 @@ auto DocumentFollowerState::applyEntries(
 
           while (auto entry = ptr->next()) {
             auto doc = entry->second;
-            auto res = self->_transactionHandler->applyEntry(doc);
-            if (res.fail()) {
-              LOG_CTX("d82d4", FATAL, self->loggerContext)
-                  << "Failed to apply entry " << entry->first
-                  << " to local shard " << self->shardId
-                  << " with error: " << res;
-              FATAL_ERROR_EXIT();
-            }
-
-            if (doc.operation == OperationType::kAbortAllOngoingTrx) {
-              self->_activeTransactions.clear();
-              releaseIndex =
-                  self->_activeTransactions.getReleaseIndex(entry->first);
-            } else if (doc.operation == OperationType::kCommit ||
-                       doc.operation == OperationType::kAbort) {
-              self->_activeTransactions.erase(doc.tid);
-              releaseIndex =
-                  self->_activeTransactions.getReleaseIndex(entry->first);
+            if (doc.operation == OperationType::kCreateShard) {
+              auto collectionProperties =
+                  std::make_shared<velocypack::Builder>(doc.data.slice());
+              auto const& collectionId = data.core->getCollectionId();
+              auto res = self->_shardHandler->createLocalShard(
+                  collectionId, collectionProperties);
+              if (res.fail()) {
+                LOG_CTX("d82d4", FATAL, self->loggerContext)
+                    << "Failed to create shard " << self->shardId
+                    << " of collection " << self->shardId
+                    << " with error: " << res.result();
+                FATAL_ERROR_EXIT();
+              }
+              LOG_CTX("d82d5", TRACE, self->loggerContext)
+                  << "Created local shard " << self->shardId
+                  << " of collection " << collectionId;
+            } else if (doc.operation == OperationType::kDropShard) {
+              auto const& collectionId = data.core->getCollectionId();
+              auto res = self->_shardHandler->dropLocalShard(collectionId);
+              if (res.fail()) {
+                LOG_CTX("d82d4", FATAL, self->loggerContext)
+                    << "Failed to drop shard " << self->shardId
+                    << " of collection " << collectionId
+                    << " with error: " << res;
+                FATAL_ERROR_EXIT();
+              }
+              LOG_CTX("d82d5", TRACE, self->loggerContext)
+                  << "Dropped local shard " << self->shardId
+                  << " of collection " << collectionId;
             } else {
-              self->_activeTransactions.emplace(doc.tid, entry->first);
+              auto res = self->_transactionHandler->applyEntry(doc);
+              if (res.fail()) {
+                LOG_CTX("d82d4", FATAL, self->loggerContext)
+                    << "Failed to apply entry " << entry->first
+                    << " to local shard " << self->shardId
+                    << " with error: " << res;
+                FATAL_ERROR_EXIT();
+              }
+
+              if (doc.operation == OperationType::kAbortAllOngoingTrx) {
+                self->_activeTransactions.clear();
+                releaseIndex =
+                    self->_activeTransactions.getReleaseIndex(entry->first);
+              } else if (doc.operation == OperationType::kCommit ||
+                         doc.operation == OperationType::kAbort) {
+                self->_activeTransactions.erase(doc.tid);
+                releaseIndex =
+                    self->_activeTransactions.getReleaseIndex(entry->first);
+              } else {
+                self->_activeTransactions.emplace(doc.tid, entry->first);
+              }
             }
           }
 

--- a/arangod/Replication2/StateMachines/Document/DocumentFollowerState.h
+++ b/arangod/Replication2/StateMachines/Document/DocumentFollowerState.h
@@ -78,6 +78,7 @@ struct DocumentFollowerState
   };
 
   std::shared_ptr<IDocumentStateNetworkHandler> _networkHandler;
+  std::shared_ptr<IDocumentStateShardHandler> _shardHandler;
   std::unique_ptr<IDocumentStateTransactionHandler> _transactionHandler;
   Guarded<GuardedData, basics::UnshackledMutex> _guardedData;
   ActiveTransactionsQueue _activeTransactions;

--- a/arangod/Replication2/StateMachines/Document/DocumentFollowerState.h
+++ b/arangod/Replication2/StateMachines/Document/DocumentFollowerState.h
@@ -45,7 +45,7 @@ struct DocumentFollowerState
       std::shared_ptr<IDocumentStateHandlersFactory> const& handlersFactory);
   ~DocumentFollowerState() override;
 
-  ShardID const shardId;
+  ShardID const shardId;  // TODO we have to get rid of this member
   LoggerContext const loggerContext;
 
   // unprotected for gtests. TODO think about whether there's a better way

--- a/arangod/Replication2/StateMachines/Document/DocumentLeaderState.cpp
+++ b/arangod/Replication2/StateMachines/Document/DocumentLeaderState.cpp
@@ -105,6 +105,14 @@ auto DocumentLeaderState::recoverEntries(std::unique_ptr<EntryIterator> ptr)
 
     while (auto entry = ptr->next()) {
       auto doc = entry->second;
+      if (doc.operation == OperationType::kCreateShard ||
+          doc.operation == OperationType::kDropShard) {
+        // TODO
+        // If the maintenance sees that shards are missing, it is going to
+        // create them on the leader.
+        // Perhaps we should check that they're already created.
+        continue;
+      }
       auto res = transactionHandler->applyEntry(doc);
       if (res.fail()) {
         return res;

--- a/arangod/Replication2/StateMachines/Document/DocumentLeaderState.cpp
+++ b/arangod/Replication2/StateMachines/Document/DocumentLeaderState.cpp
@@ -159,8 +159,6 @@ auto DocumentLeaderState::replicateOperation(velocypack::SharedSlice payload,
                         // returning a dummy index
   }
 
-  // TODO there is a race here, what happens if the leader resigns after this
-  // point? (CINFRA-613)
   auto const& stream = getStream();
   auto entry =
       DocumentLogEntry{std::string(shardId), operation, std::move(payload),

--- a/arangod/Replication2/StateMachines/Document/DocumentLogEntry.h
+++ b/arangod/Replication2/StateMachines/Document/DocumentLogEntry.h
@@ -46,6 +46,8 @@ enum class OperationType {
   kAbort,
   kAbortAllOngoingTrx,
   kIntermediateCommit,
+  kCreateShard,
+  kDropShard
 };
 
 template<class Inspector>
@@ -59,7 +61,9 @@ auto inspect(Inspector& f, OperationType& p) {
       OperationType::kCommit, "Commit",                          //
       OperationType::kAbort, "Abort",                            //
       OperationType::kAbortAllOngoingTrx, "AbortAllOngoingTrx",  //
-      OperationType::kIntermediateCommit, "IntermediateCommit"   //
+      OperationType::kIntermediateCommit, "IntermediateCommit",  //
+      OperationType::kCreateShard, "CreateShard",                //
+      OperationType::kDropShard, "DropShard"                     //
   );
 }
 

--- a/arangod/Replication2/StateMachines/Document/DocumentStateShardHandler.h
+++ b/arangod/Replication2/StateMachines/Document/DocumentStateShardHandler.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include "Basics/ResultT.h"
+#include "Cluster/ClusterTypes.h"
 #include "Replication2/ReplicatedLog/LogCommon.h"
 
 #include <velocypack/Builder.h>
@@ -38,21 +39,21 @@ namespace arangodb::replication2::replicated_state::document {
 struct IDocumentStateShardHandler {
   virtual ~IDocumentStateShardHandler() = default;
   virtual auto createLocalShard(
-      std::string const& collectionId,
-      std::shared_ptr<velocypack::Builder> const& properties)
-      -> ResultT<std::string> = 0;
-  virtual auto dropLocalShard(std::string const& collectionId) -> Result = 0;
+      ShardID const& shardId, std::string const& collectionId,
+      std::shared_ptr<velocypack::Builder> const& properties) -> Result = 0;
+  virtual auto dropLocalShard(ShardID const& shardId,
+                              std::string const& collectionId) -> Result = 0;
 };
 
 class DocumentStateShardHandler : public IDocumentStateShardHandler {
  public:
   explicit DocumentStateShardHandler(GlobalLogIdentifier gid,
                                      MaintenanceFeature& maintenanceFeature);
-  static auto stateIdToShardId(LogId logId) -> std::string;
-  auto createLocalShard(std::string const& collectionId,
+  auto createLocalShard(ShardID const& shardId, std::string const& collectionId,
                         std::shared_ptr<velocypack::Builder> const& properties)
-      -> ResultT<std::string> override;
-  auto dropLocalShard(const std::string& collectionId) -> Result override;
+      -> Result override;
+  auto dropLocalShard(ShardID const& shardId, const std::string& collectionId)
+      -> Result override;
 
  private:
   GlobalLogIdentifier _gid;

--- a/tests/Replication2/Mocks/DocumentStateMocks.h
+++ b/tests/Replication2/Mocks/DocumentStateMocks.h
@@ -35,6 +35,7 @@
 #include "Replication2/StateMachines/Document/DocumentStateTransaction.h"
 #include "Replication2/StateMachines/Document/DocumentStateTransactionHandler.h"
 
+#include "Cluster/ClusterTypes.h"
 #include "Transaction/Manager.h"
 #include "Utils/DatabaseGuard.h"
 
@@ -205,10 +206,12 @@ struct MockDocumentStateAgencyHandler
 
 struct MockDocumentStateShardHandler
     : replicated_state::document::IDocumentStateShardHandler {
-  MOCK_METHOD(ResultT<std::string>, createLocalShard,
-              (std::string const&, std::shared_ptr<velocypack::Builder> const&),
+  MOCK_METHOD(Result, createLocalShard,
+              (ShardID const&, std::string const&,
+               std::shared_ptr<velocypack::Builder> const&),
               (override));
-  MOCK_METHOD(Result, dropLocalShard, (std::string const&), (override));
+  MOCK_METHOD(Result, dropLocalShard, (ShardID const&, std::string const&),
+              (override));
 };
 
 struct MockDocumentStateSnapshotHandler
@@ -341,7 +344,7 @@ struct MockProducerStream
 struct DocumentLogEntryIterator
     : TypedLogRangeIterator<streams::StreamEntryView<
           replicated_state::document::DocumentLogEntry>> {
-  DocumentLogEntryIterator(
+  explicit DocumentLogEntryIterator(
       std::vector<replicated_state::document::DocumentLogEntry> entries);
 
   auto next() -> std::optional<streams::StreamEntryView<

--- a/tests/Replication2/ReplicatedState/DocumentStateMachineTest.cpp
+++ b/tests/Replication2/ReplicatedState/DocumentStateMachineTest.cpp
@@ -130,6 +130,8 @@ struct DocumentStateMachineTest : testing::Test {
           ON_CALL(*shardHandlerMock, createLocalShard)
               .WillByDefault(Return(ResultT<std::string>::success(
                   DocumentStateShardHandler::stateIdToShardId(gid.id))));
+          ON_CALL(*shardHandlerMock, dropLocalShard(collectionId))
+              .WillByDefault(Return(Result{}));
           return shardHandlerMock;
         });
 
@@ -819,6 +821,58 @@ TEST_F(DocumentStateMachineTest,
   });
   EXPECT_CALL(*transactionHandlerMock, applyEntry(_)).Times(7);
   follower->applyEntries(std::move(entryIterator));
+}
+
+TEST_F(DocumentStateMachineTest,
+       follower_applyEntries_creates_and_drops_shard) {
+  using namespace testing;
+
+  auto factory = DocumentFactory(handlersFactoryMock, transactionManagerMock);
+  auto follower = std::make_shared<DocumentFollowerStateWrapper>(
+      factory.constructCore(globalId, coreParams), handlersFactoryMock);
+
+  auto stream = std::make_shared<MockProducerStream>();
+  follower->setStream(stream);
+  EXPECT_CALL(*stream, release).Times(0);
+
+  std::vector<DocumentLogEntry> entries;
+  addEntry(entries, OperationType::kCreateShard, TransactionId{0});
+  auto entryIterator = std::make_unique<DocumentLogEntryIterator>(entries);
+  EXPECT_CALL(*shardHandlerMock, createLocalShard(collectionId, _)).Times(1);
+  follower->applyEntries(std::move(entryIterator));
+
+  entries.clear();
+  addEntry(entries, OperationType::kDropShard, TransactionId{0});
+  entryIterator = std::make_unique<DocumentLogEntryIterator>(entries);
+  EXPECT_CALL(*shardHandlerMock, dropLocalShard(collectionId)).Times(1);
+  follower->applyEntries(std::move(entryIterator));
+
+  Mock::VerifyAndClearExpectations(stream.get());
+}
+
+TEST_F(DocumentStateMachineTest,
+       follower_dies_if_shard_creation_or_deletion_fails) {
+  using namespace testing;
+
+  auto factory = DocumentFactory(handlersFactoryMock, transactionManagerMock);
+  auto follower = std::make_shared<DocumentFollowerStateWrapper>(
+      factory.constructCore(globalId, coreParams), handlersFactoryMock);
+  auto stream = std::make_shared<MockProducerStream>();
+  follower->setStream(stream);
+
+  std::vector<DocumentLogEntry> entries;
+  addEntry(entries, OperationType::kCreateShard, TransactionId{0});
+  auto entryIterator = std::make_unique<DocumentLogEntryIterator>(entries);
+  ON_CALL(*shardHandlerMock, createLocalShard(collectionId, _))
+      .WillByDefault(Return(Result(TRI_ERROR_WAS_ERLAUBE)));
+  ASSERT_DEATH_CORE_FREE(follower->applyEntries(std::move(entryIterator)), "");
+
+  entries.clear();
+  addEntry(entries, OperationType::kDropShard, TransactionId{0});
+  entryIterator = std::make_unique<DocumentLogEntryIterator>(entries);
+  ON_CALL(*shardHandlerMock, dropLocalShard(collectionId))
+      .WillByDefault(Return(Result(TRI_ERROR_WAS_ERLAUBE)));
+  ASSERT_DEATH_CORE_FREE(follower->applyEntries(std::move(entryIterator)), "");
 }
 
 TEST_F(DocumentStateMachineTest, leader_manipulates_snapshot_successfully) {


### PR DESCRIPTION
### Scope & Purpose

**Context**
The plan is to get rid of the `agencyHandler` from the `DocumentCore`. The maintenance will create the shard on the leader, which in turn will instruct the followers to do the same.

**In this PR**
We are introducing two new operations: `CreateShard` and `DropShard`. We make sure to handle them during `applyEntries` on the follower and `recoverEntries` on the leader.

The `DocumentStateShardHandler` no longer uses the `shardId` of the core, but expects to get one as parameter.

Shard operations are not currently issued by the leader, so in reality the follower is not going to see these in the log.

[CINFRA-653](https://arangodb.atlassian.net/browse/CINFRA-654) is also handled here.

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [x] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: *(Please link PR)*
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*

[CINFRA-653]: https://arangodb.atlassian.net/browse/CINFRA-653?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ