### PR TITLE
Change request lane for active failover catchup requests

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,11 @@
 devel
 -----
 
+* Change the request lane for replication catchup requests that leaders in
+  active failover receive from their followers from medium to high. This
+  will give catchup requests from followers highest priority, so that the
+  leader will preferrably execute them compared to regular requests.
+
 * Web UI [FE-48]: Additional fix to the previously introduced license
   information usability improvement. In case the server is being started with
   the additional parameter `--server.harden`, the previous fix did not handle

--- a/arangod/GeneralServer/RestHandler.h
+++ b/arangod/GeneralServer/RestHandler.h
@@ -88,9 +88,12 @@ class RestHandler : public std::enable_shared_from_this<RestHandler> {
     return std::move(_response);
   }
 
-  ArangodServer& server() { return _server; }
+  ArangodServer& server() noexcept { return _server; }
+  ArangodServer const& server() const noexcept { return _server; }
 
-  RequestStatistics::Item const& statistics() { return _statistics; }
+  RequestStatistics::Item const& statistics() const noexcept {
+    return _statistics;
+  }
   RequestStatistics::Item&& stealStatistics();
   void setStatistics(RequestStatistics::Item&& stat);
 

--- a/arangod/RestHandler/RestWalAccessHandler.cpp
+++ b/arangod/RestHandler/RestWalAccessHandler.cpp
@@ -99,7 +99,15 @@ RequestLane RestWalAccessHandler::lane() const {
         return RequestLane::SERVER_REPLICATION_CATCHUP;
       }
     }
+  } else if (server()
+                 .getFeature<ReplicationFeature>()
+                 .isActiveFailoverEnabled()) {
+    // prioritize catch-up requests by active failover followers over other
+    // requests, so that followers have a better chance of catching up with the
+    // leader
+    return RequestLane::SERVER_REPLICATION_CATCHUP;
   }
+
   return RequestLane::SERVER_REPLICATION;
 }
 


### PR DESCRIPTION
### Scope & Purpose

Change the request lane for replication catchup requests that leaders in active failover receive from their followers from medium to high. This will give catchup requests from followers highest priority, so that the leader will preferrably execute them compared to regular requests.
The change will likely not help a lot, because catchup requests have been on the medium request lane before already, which already has higher priority than the lanes that normal write operations run on.

Potentially slightly helps https://arangodb.atlassian.net/browse/ES-1398.

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.10: https://github.com/arangodb/arangodb/pull/17928
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [x] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/ES-1398
- [ ] Design document: 