### PR TITLE
fix unstable test

### DIFF
--- a/tests/js/client/server_parameters/auto-refill-index-caches-on-modify-noncluster-off.js
+++ b/tests/js/client/server_parameters/auto-refill-index-caches-on-modify-noncluster-off.js
@@ -143,6 +143,8 @@ function AutoRefillIndexCachesEdge() {
     
     testUpdateEdgeDefault: function() {
       db._query(`FOR i IN 0..${n - 1} INSERT {_from: CONCAT('v/test', i), _to: CONCAT('v/test', (i % 25))} INTO ${cn}`);
+      waitForMetrics();
+
       const oldValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
       db._query(`FOR doc IN ${cn} UPDATE doc WITH {value: doc.value + 1} INTO ${cn}`);
       const newValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
@@ -155,6 +157,8 @@ function AutoRefillIndexCachesEdge() {
     
     testUpdateEdgeDisabled: function() {
       db._query(`FOR i IN 0..${n - 1} INSERT {_from: CONCAT('v/test', i), _to: CONCAT('v/test', (i % 25))} INTO ${cn}`);
+      waitForMetrics();
+
       const oldValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
       db._query(`FOR doc IN ${cn} UPDATE doc WITH {value: doc.value + 1} INTO ${cn} OPTIONS { refillIndexCaches: false }`);
       const newValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
@@ -167,6 +171,8 @@ function AutoRefillIndexCachesEdge() {
     
     testUpdateEdgeEnabled: function() {
       db._query(`FOR i IN 0..${n - 1} INSERT {_from: CONCAT('v/test', i), _to: CONCAT('v/test', (i % 25))} INTO ${cn}`);
+      waitForMetrics();
+
       const oldValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
       db._query(`FOR doc IN ${cn} UPDATE doc WITH {value: doc.value + 1} INTO ${cn} OPTIONS { refillIndexCaches: true }`);
       const newValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
@@ -178,6 +184,8 @@ function AutoRefillIndexCachesEdge() {
     
     testReplaceEdgeDefault: function() {
       db._query(`FOR i IN 0..${n - 1} INSERT {_from: CONCAT('v/test', i), _to: CONCAT('v/test', (i % 25))} INTO ${cn}`);
+      waitForMetrics();
+
       const oldValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
       db._query(`FOR doc IN ${cn} REPLACE doc WITH {_from: doc._from, _to: doc._to, value: doc.value + 1} INTO ${cn}`);
       const newValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
@@ -190,6 +198,8 @@ function AutoRefillIndexCachesEdge() {
     
     testReplaceEdgeDisabled: function() {
       db._query(`FOR i IN 0..${n - 1} INSERT {_from: CONCAT('v/test', i), _to: CONCAT('v/test', (i % 25))} INTO ${cn}`);
+      waitForMetrics();
+
       const oldValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
       db._query(`FOR doc IN ${cn} REPLACE doc WITH {_from: doc._from, _to: doc._to, value: doc.value + 1} INTO ${cn} OPTIONS { refillIndexCaches: false }`);
       const newValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
@@ -202,6 +212,8 @@ function AutoRefillIndexCachesEdge() {
     
     testReplaceEdgeEnabled: function() {
       db._query(`FOR i IN 0..${n - 1} INSERT {_from: CONCAT('v/test', i), _to: CONCAT('v/test', (i % 25))} INTO ${cn}`);
+      waitForMetrics();
+
       const oldValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
       db._query(`FOR doc IN ${cn} REPLACE doc WITH {_from: doc._from, _to: doc._to, value: doc.value + 1} INTO ${cn} OPTIONS { refillIndexCaches: true }`);
       const newValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
@@ -213,6 +225,8 @@ function AutoRefillIndexCachesEdge() {
     
     testRemoveEdgeDefault: function() {
       db._query(`FOR i IN 0..${n - 1} INSERT {_key: CONCAT('test', i), _from: CONCAT('v/test', i), _to: CONCAT('v/test', (i % 25))} INTO ${cn}`);
+      waitForMetrics();
+
       const oldValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
       db._query(`FOR i IN 0..${n / 2 - 1} REMOVE CONCAT('test', i) INTO ${cn}`);
       const newValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
@@ -225,6 +239,8 @@ function AutoRefillIndexCachesEdge() {
     
     testRemoveEdgeDisabled: function() {
       db._query(`FOR i IN 0..${n - 1} INSERT {_key: CONCAT('test', i), _from: CONCAT('v/test', i), _to: CONCAT('v/test', (i % 25))} INTO ${cn}`);
+      waitForMetrics();
+
       const oldValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
       db._query(`FOR i IN 0..${n / 2 - 1} REMOVE CONCAT('test', i) INTO ${cn} OPTIONS { refillIndexCaches: false }`);
       const newValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
@@ -237,6 +253,8 @@ function AutoRefillIndexCachesEdge() {
     
     testRemoveEdgeEnabled: function() {
       db._query(`FOR i IN 0..${n - 1} INSERT {_key: CONCAT('test', i), _from: CONCAT('v/test', i), _to: CONCAT('v/test', (i % 25))} INTO ${cn}`);
+      waitForMetrics();
+
       const oldValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
       db._query(`FOR i IN 0..${n / 2 - 1} REMOVE CONCAT('test', i) INTO ${cn} OPTIONS { refillIndexCaches: true }`);
       const newValue = getMetric("rocksdb_cache_auto_refill_loaded_total");

--- a/tests/js/client/server_parameters/auto-refill-index-caches-on-modify-noncluster-off.js
+++ b/tests/js/client/server_parameters/auto-refill-index-caches-on-modify-noncluster-off.js
@@ -37,7 +37,6 @@ if (getOptions === true) {
 const db = require('@arangodb').db;
 const jsunity = require('jsunity');
 const getMetric = require('@arangodb/test-helper').getMetricSingle;
-const time = require('internal').time;
 
 const cn = 'UnitTestsCollection';
 const n = 5000;
@@ -45,6 +44,31 @@ const n = 5000;
 const waitForPendingRefills = () => {
   // wait for pending refill operations to have finished, using an informal API
   arango.POST('/_api/index/sync-caches', {});
+};
+  
+const runWithRetry = (cb) => {
+  let tries = 0;
+  while (true) {
+    try {
+      cb();
+      // return upon first successful execution of the callback function
+      return;
+    } catch (err) {
+      // if it fails, check how many failures we got. fail only if we failed
+      // 3 times in a row
+      if (tries++ === 3) {
+        throw err;
+      }
+      // attempt failed. this can happen because inserting data into
+      // the cache can fail under the following circumstances:
+      // - cache global budget exceeded
+      // - cache hash table migration in progress
+
+      // start over...
+      db[cn].truncate();
+      require("internal").sleep(2);
+    }
+  }
 };
 
 function AutoRefillIndexCachesEdge() {
@@ -146,12 +170,14 @@ function AutoRefillIndexCachesEdge() {
     },
     
     testInsertEdgeEnabled: function() {
-      const oldValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
-      db._query(`FOR i IN 0..${n - 1} INSERT {_from: CONCAT('v/test', i), _to: CONCAT('v/test', (i % 25))} INTO ${cn} OPTIONS { refillIndexCaches: true }`);
-      const newValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
+      runWithRetry(() => {
+        const oldValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
+        db._query(`FOR i IN 0..${n - 1} INSERT {_from: CONCAT('v/test', i), _to: CONCAT('v/test', (i % 25))} INTO ${cn} OPTIONS { refillIndexCaches: true }`);
+        const newValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
 
-      assertTrue(newValue - oldValue >= n, { oldValue, newValue });
-      runCheck(true);
+        assertTrue(newValue - oldValue >= n, { oldValue, newValue });
+        runCheck(true);
+      });
     },
     
     testUpdateEdgeDefault: function() {
@@ -181,14 +207,16 @@ function AutoRefillIndexCachesEdge() {
     },
     
     testUpdateEdgeEnabled: function() {
-      insertInitialEdges();
+      runWithRetry(() => {
+        insertInitialEdges();
 
-      const oldValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
-      db._query(`FOR doc IN ${cn} UPDATE doc WITH {value: doc.value + 1} INTO ${cn} OPTIONS { refillIndexCaches: true }`);
-      const newValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
+        const oldValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
+        db._query(`FOR doc IN ${cn} UPDATE doc WITH {value: doc.value + 1} INTO ${cn} OPTIONS { refillIndexCaches: true }`);
+        const newValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
 
-      assertTrue(newValue - oldValue >= n, { oldValue, newValue });
-      runCheck(true);
+        assertTrue(newValue - oldValue >= n, { oldValue, newValue });
+        runCheck(true);
+      });
     },
     
     testReplaceEdgeDefault: function() {
@@ -218,14 +246,16 @@ function AutoRefillIndexCachesEdge() {
     },
     
     testReplaceEdgeEnabled: function() {
-      insertInitialEdges();
+      runWithRetry(() => {
+        insertInitialEdges();
 
-      const oldValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
-      db._query(`FOR doc IN ${cn} REPLACE doc WITH {_from: doc._from, _to: doc._to, value: doc.value + 1} INTO ${cn} OPTIONS { refillIndexCaches: true }`);
-      const newValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
+        const oldValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
+        db._query(`FOR doc IN ${cn} REPLACE doc WITH {_from: doc._from, _to: doc._to, value: doc.value + 1} INTO ${cn} OPTIONS { refillIndexCaches: true }`);
+        const newValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
 
-      assertTrue(newValue - oldValue >= n, { oldValue, newValue });
-      runCheck(true);
+        assertTrue(newValue - oldValue >= n, { oldValue, newValue });
+        runCheck(true);
+      });
     },
     
     testRemoveEdgeDefault: function() {
@@ -255,14 +285,16 @@ function AutoRefillIndexCachesEdge() {
     },
     
     testRemoveEdgeEnabled: function() {
-      insertInitialEdges();
+      runWithRetry(() => {
+        insertInitialEdges();
 
-      const oldValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
-      db._query(`FOR i IN 0..${n / 2 - 1} REMOVE CONCAT('test', i) INTO ${cn} OPTIONS { refillIndexCaches: true }`);
-      const newValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
+        const oldValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
+        db._query(`FOR i IN 0..${n / 2 - 1} REMOVE CONCAT('test', i) INTO ${cn} OPTIONS { refillIndexCaches: true }`);
+        const newValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
 
-      assertTrue(newValue - oldValue >= n / 2, { oldValue, newValue });
-      runRemoveCheck(true);
+        assertTrue(newValue - oldValue >= n / 2, { oldValue, newValue });
+        runRemoveCheck(true);
+      });
     },
     
   };

--- a/tests/js/client/server_parameters/auto-refill-index-caches-on-modify-noncluster-on.js
+++ b/tests/js/client/server_parameters/auto-refill-index-caches-on-modify-noncluster-on.js
@@ -128,8 +128,10 @@ function AutoRefillIndexCachesEdge() {
       runCheck(false);
     },
     
-    testUpdateEdgeEabled: function() {
+    testUpdateEdgeEnabled: function() {
       db._query(`FOR i IN 0..${n - 1} INSERT {_from: CONCAT('v/test', i), _to: CONCAT('v/test', (i % 25))} INTO ${cn}`);
+      waitForMetrics();
+
       const oldValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
       db._query(`FOR doc IN ${cn} UPDATE doc WITH {value: doc.value + 1} INTO ${cn}`);
       const newValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
@@ -141,6 +143,8 @@ function AutoRefillIndexCachesEdge() {
     
     testUpdateEdgeDisbled: function() {
       db._query(`FOR i IN 0..${n - 1} INSERT {_from: CONCAT('v/test', i), _to: CONCAT('v/test', (i % 25))} INTO ${cn}`);
+      waitForMetrics();
+
       const oldValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
       db._query(`FOR doc IN ${cn} UPDATE doc WITH {value: doc.value + 1} INTO ${cn} OPTIONS { refillIndexCaches: false }`);
       const newValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
@@ -153,6 +157,8 @@ function AutoRefillIndexCachesEdge() {
     
     testReplaceEdgeEnabled: function() {
       db._query(`FOR i IN 0..${n - 1} INSERT {_from: CONCAT('v/test', i), _to: CONCAT('v/test', (i % 25))} INTO ${cn}`);
+      waitForMetrics();
+
       const oldValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
       db._query(`FOR doc IN ${cn} REPLACE doc WITH {_from: doc._from, _to: doc._to, value: doc.value + 1} INTO ${cn}`);
       const newValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
@@ -164,6 +170,8 @@ function AutoRefillIndexCachesEdge() {
     
     testReplaceEdgeDisabled: function() {
       db._query(`FOR i IN 0..${n - 1} INSERT {_from: CONCAT('v/test', i), _to: CONCAT('v/test', (i % 25))} INTO ${cn}`);
+      waitForMetrics();
+
       const oldValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
       db._query(`FOR doc IN ${cn} REPLACE doc WITH {_from: doc._from, _to: doc._to, value: doc.value + 1} INTO ${cn} OPTIONS { refillIndexCaches: false }`);
       const newValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
@@ -176,6 +184,8 @@ function AutoRefillIndexCachesEdge() {
     
     testRemoveEdgeEnabled: function() {
       db._query(`FOR i IN 0..${n - 1} INSERT {_key: CONCAT('test', i), _from: CONCAT('v/test', i), _to: CONCAT('v/test', (i % 25))} INTO ${cn}`);
+      waitForMetrics();
+
       const oldValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
       db._query(`FOR i IN 0..${n / 2 - 1} REMOVE CONCAT('test', i) INTO ${cn}`);
       const newValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
@@ -187,6 +197,8 @@ function AutoRefillIndexCachesEdge() {
     
     testRemoveEdgeDisabled: function() {
       db._query(`FOR i IN 0..${n - 1} INSERT {_key: CONCAT('test', i), _from: CONCAT('v/test', i), _to: CONCAT('v/test', (i % 25))} INTO ${cn}`);
+      waitForMetrics();
+
       const oldValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
       db._query(`FOR i IN 0..${n / 2 - 1} REMOVE CONCAT('test', i) INTO ${cn} OPTIONS { refillIndexCaches: false }`);
       const newValue = getMetric("rocksdb_cache_auto_refill_loaded_total");


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/17932

Attempt to fix the following unstable integration test:
```
=== server_parameters ===
* Test "server_parameters" [FAILED]  tests/js/client/server_parameters/auto-refill-index-caches-on-modify-noncluster-on.js

      "testUpdateEdgeDisbled" failed: Error: at assertion #5003: {
  "writesExecuted" : 0, "writesIgnored" : 0, "scannedFull" : 0, "scannedIndex" : 5000, "cursorsCreated" : 1, "cursorsRearmed" : 4999, "cacheHits" : 1147, "cacheMisses" : 3853, "filtered" : 0, "httpRequests" : 0, "executionTime" : 0.02600592700036941, "peakMemoryUsage" : 98304 }: (1147) is not equal to (0)
(Error
    at assertEqual (/work/ArangoDB/js/common/modules/jsunity/jsunity.js:108:19)
    at runCheck (tests/js/client/server_parameters/auto-refill-index-caches-on-modify-noncluster-on.js:64:7)
    at Object.testUpdateEdgeDisbled (tests/js/client/server_parameters/auto-refill-index-caches-on-modify-noncluster-on.js:151:7)
    at Object.run (/work/ArangoDB/js/common/modules/jsunity/jsunity.js:552:27)
```

Test-only bugfix. Intentionally no CHANGELOG entry written for it.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.10: this PR
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 