### PR TITLE
[CINFRA-657] Return a successful result such that we don't crash

### DIFF
--- a/arangod/Replication2/StateMachines/Document/DocumentFollowerState.cpp
+++ b/arangod/Replication2/StateMachines/Document/DocumentFollowerState.cpp
@@ -90,6 +90,11 @@ auto DocumentFollowerState::applyEntries(
 
         if (self->_transactionHandler == nullptr) {
           // TODO this is a temporary fix, see CINFRA-588
+          LOG_CTX("cfd76", ERR, self->loggerContext) << fmt::format(
+              "Transaction handler is missing from "
+              "DocumentFollowerState {}! This happens if the vocbase cannot be "
+              "found during DocumentState construction.",
+              self->shardId);
           return Result{};
         }
 
@@ -157,6 +162,11 @@ auto DocumentFollowerState::forceLocalTransaction(OperationType opType,
     -> Result {
   if (_transactionHandler == nullptr) {
     // TODO this is a temporary fix, see CINFRA-588
+    LOG_CTX("cfd76", ERR, loggerContext) << fmt::format(
+        "Transaction handler is missing from "
+        "DocumentFollowerState {}! This happens if the vocbase cannot be found "
+        "during DocumentState construction.",
+        shardId);
     return Result{};
   }
   auto trxId = TransactionId::createFollower();

--- a/arangod/Replication2/StateMachines/Document/DocumentFollowerState.cpp
+++ b/arangod/Replication2/StateMachines/Document/DocumentFollowerState.cpp
@@ -89,14 +89,8 @@ auto DocumentFollowerState::applyEntries(
         }
 
         if (self->_transactionHandler == nullptr) {
-          return Result{
-              TRI_ERROR_ARANGO_DATABASE_NOT_FOUND,
-              fmt::format(
-                  "Transaction handler is missing from "
-                  "DocumentFollowerState during applyEntries "
-                  "{}! This happens if the vocbase cannot be found during "
-                  "DocumentState construction.",
-                  to_string(data.core->getGid()))};
+          // TODO this is a temporary fix, see CINFRA-588
+          return Result{};
         }
 
         return basics::catchToResultT([&]() -> std::optional<LogIndex> {
@@ -161,6 +155,10 @@ auto DocumentFollowerState::applyEntries(
 auto DocumentFollowerState::forceLocalTransaction(OperationType opType,
                                                   velocypack::SharedSlice slice)
     -> Result {
+  if (_transactionHandler == nullptr) {
+    // TODO this is a temporary fix, see CINFRA-588
+    return Result{};
+  }
   auto trxId = TransactionId::createFollower();
   auto doc =
       DocumentLogEntry{std::string(shardId), opType, std::move(slice), trxId};

--- a/arangod/Replication2/StateMachines/Document/DocumentFollowerState.cpp
+++ b/arangod/Replication2/StateMachines/Document/DocumentFollowerState.cpp
@@ -162,7 +162,7 @@ auto DocumentFollowerState::forceLocalTransaction(OperationType opType,
     -> Result {
   if (_transactionHandler == nullptr) {
     // TODO this is a temporary fix, see CINFRA-588
-    LOG_CTX("cfd76", ERR, loggerContext) << fmt::format(
+    LOG_CTX("27c2b", ERR, loggerContext) << fmt::format(
         "Transaction handler is missing from "
         "DocumentFollowerState {}! This happens if the vocbase cannot be found "
         "during DocumentState construction.",

--- a/arangod/Replication2/StateMachines/Document/DocumentLeaderState.cpp
+++ b/arangod/Replication2/StateMachines/Document/DocumentLeaderState.cpp
@@ -94,13 +94,7 @@ auto DocumentLeaderState::recoverEntries(std::unique_ptr<EntryIterator> ptr)
         self->_handlersFactory->createTransactionHandler(self->gid);
     if (transactionHandler == nullptr) {
       // TODO this is a temporary fix, see CINFRA-588
-      return Result{
-          TRI_ERROR_ARANGO_DATABASE_NOT_FOUND,
-          fmt::format("Transaction handler is missing from DocumentLeaderState "
-                      "during recoverEntries "
-                      "{}! This happens if the vocbase cannot be found during "
-                      "DocumentState construction.",
-                      to_string(self->gid))};
+      return Result{};
     }
 
     while (auto entry = ptr->next()) {

--- a/arangod/Replication2/StateMachines/Document/DocumentLeaderState.cpp
+++ b/arangod/Replication2/StateMachines/Document/DocumentLeaderState.cpp
@@ -94,7 +94,7 @@ auto DocumentLeaderState::recoverEntries(std::unique_ptr<EntryIterator> ptr)
         self->_handlersFactory->createTransactionHandler(self->gid);
     if (transactionHandler == nullptr) {
       // TODO this is a temporary fix, see CINFRA-588
-      LOG_CTX("cfd76", ERR, self->loggerContext) << fmt::format(
+      LOG_CTX("8cd17", ERR, self->loggerContext) << fmt::format(
           "Transaction handler is missing from "
           "DocumentLeaderState {}! This happens if the vocbase cannot be "
           "found during DocumentState construction.",

--- a/arangod/Replication2/StateMachines/Document/DocumentLeaderState.cpp
+++ b/arangod/Replication2/StateMachines/Document/DocumentLeaderState.cpp
@@ -94,6 +94,11 @@ auto DocumentLeaderState::recoverEntries(std::unique_ptr<EntryIterator> ptr)
         self->_handlersFactory->createTransactionHandler(self->gid);
     if (transactionHandler == nullptr) {
       // TODO this is a temporary fix, see CINFRA-588
+      LOG_CTX("cfd76", ERR, self->loggerContext) << fmt::format(
+          "Transaction handler is missing from "
+          "DocumentLeaderState {}! This happens if the vocbase cannot be "
+          "found during DocumentState construction.",
+          self->shardId);
       return Result{};
     }
 


### PR DESCRIPTION
### Scope & Purpose

Returning a failed result triggers an assertion further down the line, which causes the server to crash. This happens when the `vocbase` is not found during the construction of the replicated state, therefore some important members cannot be initialized. We know about the issue and it's being fixed in [CINFRA-588](https://arangodb.atlassian.net/browse/CINFRA-588) and [CINFRA-649](https://arangodb.atlassian.net/browse/CINFRA-649), but for now let's not crash in devel.

We still use logging to report the problem.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

[CINFRA-588]: https://arangodb.atlassian.net/browse/CINFRA-588?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CINFRA-649]: https://arangodb.atlassian.net/browse/CINFRA-649?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ