### PR TITLE
fix wrong version numbers in `introducedIn` of metrics

### DIFF
--- a/Documentation/Metrics/arangodb_replication2_replicated_log_append_entries_rtt.yaml
+++ b/Documentation/Metrics/arangodb_replication2_replicated_log_append_entries_rtt.yaml
@@ -1,5 +1,5 @@
 name: arangodb_replication2_replicated_log_append_entries_rtt
-introducedIn: "3.9.0"
+introducedIn: "3.11.0"
 help: |
   Histogram of the RTT of appendEntries requests in microseconds.
 unit: us

--- a/Documentation/Metrics/arangodb_replication2_replicated_log_creation_total.yaml
+++ b/Documentation/Metrics/arangodb_replication2_replicated_log_creation_total.yaml
@@ -1,5 +1,5 @@
 name: arangodb_replication2_replicated_log_creation_total
-introducedIn: "3.9.0"
+introducedIn: "3.11.0"
 help: |
   Number of replicated log instances created on this server since its start.
 unit: number

--- a/Documentation/Metrics/arangodb_replication2_replicated_log_deletion_total.yaml
+++ b/Documentation/Metrics/arangodb_replication2_replicated_log_deletion_total.yaml
@@ -1,5 +1,5 @@
 name: arangodb_replication2_replicated_log_deletion_total
-introducedIn: "3.9.0"
+introducedIn: "3.11.0"
 help: |
   Number of replicated log instances deleted on this server since its start.
 unit: number

--- a/Documentation/Metrics/arangodb_replication2_replicated_log_follower_append_entries_rt.yaml
+++ b/Documentation/Metrics/arangodb_replication2_replicated_log_follower_append_entries_rt.yaml
@@ -1,5 +1,5 @@
 name: arangodb_replication2_replicated_log_follower_append_entries_rt
-introducedIn: "3.9.0"
+introducedIn: "3.11.0"
 help: |
   Histogram of the duration of appendEntries calls in microseconds.
 unit: us

--- a/Documentation/Metrics/arangodb_replication2_replicated_log_follower_number.yaml
+++ b/Documentation/Metrics/arangodb_replication2_replicated_log_follower_number.yaml
@@ -1,5 +1,5 @@
 name: arangodb_replication2_replicated_log_follower_number
-introducedIn: "3.9.0"
+introducedIn: "3.11.0"
 help: |
   Current number of followers of replicated logs.
 unit: number

--- a/Documentation/Metrics/arangodb_replication2_replicated_log_inactive_number.yaml
+++ b/Documentation/Metrics/arangodb_replication2_replicated_log_inactive_number.yaml
@@ -1,5 +1,5 @@
 name: arangodb_replication2_replicated_log_inactive_number
-introducedIn: "3.9.0"
+introducedIn: "3.11.0"
 help: |
   Current number of inactive replicated logs.
 unit: number

--- a/Documentation/Metrics/arangodb_replication2_replicated_log_inserts_bytes.yaml
+++ b/Documentation/Metrics/arangodb_replication2_replicated_log_inserts_bytes.yaml
@@ -1,5 +1,5 @@
 name: arangodb_replication2_replicated_log_inserts_bytes
-introducedIn: "3.9.0"
+introducedIn: "3.11.0"
 help: |
   Number of bytes inserted into replicated logs.
 unit: bytes

--- a/Documentation/Metrics/arangodb_replication2_replicated_log_inserts_rtt.yaml
+++ b/Documentation/Metrics/arangodb_replication2_replicated_log_inserts_rtt.yaml
@@ -1,5 +1,5 @@
 name: arangodb_replication2_replicated_log_inserts_rtt
-introducedIn: "3.9.0"
+introducedIn: "3.11.0"
 help: |
   Round-trip time of inserts into replicated logs in microseconds.
 unit: us

--- a/Documentation/Metrics/arangodb_replication2_replicated_log_leader_number.yaml
+++ b/Documentation/Metrics/arangodb_replication2_replicated_log_leader_number.yaml
@@ -1,5 +1,5 @@
 name: arangodb_replication2_replicated_log_leader_number
-introducedIn: "3.9.0"
+introducedIn: "3.11.0"
 help: |
   Current number of replicated log leaders.
 unit: number

--- a/Documentation/Metrics/arangodb_replication2_replicated_log_leader_took_over_total.yaml
+++ b/Documentation/Metrics/arangodb_replication2_replicated_log_leader_took_over_total.yaml
@@ -1,5 +1,5 @@
 name: arangodb_replication2_replicated_log_leader_took_over_total
-introducedIn: "3.9.0"
+introducedIn: "3.11.0"
 help: |
   Number of leader takeovers.
 unit: number

--- a/Documentation/Metrics/arangodb_replication2_replicated_log_number.yaml
+++ b/Documentation/Metrics/arangodb_replication2_replicated_log_number.yaml
@@ -1,5 +1,5 @@
 name: arangodb_replication2_replicated_log_number
-introducedIn: "3.9.0"
+introducedIn: "3.11.0"
 help: |
   Number of replicated logs.
 unit: number

--- a/Documentation/Metrics/arangodb_replication2_replicated_log_number_accepted_entries_total.yaml
+++ b/Documentation/Metrics/arangodb_replication2_replicated_log_number_accepted_entries_total.yaml
@@ -1,5 +1,5 @@
 name: arangodb_replication2_replicated_log_number_accepted_entries_total
-introducedIn: "3.10.0"
+introducedIn: "3.11.0"
 help: |
   Number of accepted (not yet committed) log entries.
 unit: number

--- a/Documentation/Metrics/arangodb_replication2_replicated_log_number_committed_entries_total.yaml
+++ b/Documentation/Metrics/arangodb_replication2_replicated_log_number_committed_entries_total.yaml
@@ -1,5 +1,5 @@
 name: arangodb_replication2_replicated_log_number_committed_entries_total
-introducedIn: "3.10.0"
+introducedIn: "3.11.0"
 help: |
   Number of committed log entries.
 unit: number

--- a/Documentation/Metrics/arangodb_replication2_replicated_log_number_compacted_entries_total.yaml
+++ b/Documentation/Metrics/arangodb_replication2_replicated_log_number_compacted_entries_total.yaml
@@ -1,5 +1,5 @@
 name: arangodb_replication2_replicated_log_number_compacted_entries_total
-introducedIn: "3.10.0"
+introducedIn: "3.11.0"
 help: |
   Number of compacted log entries.
 unit: number

--- a/Documentation/Metrics/arangodb_replication2_replicated_log_number_meta_entries_total.yaml
+++ b/Documentation/Metrics/arangodb_replication2_replicated_log_number_meta_entries_total.yaml
@@ -1,5 +1,5 @@
 name: arangodb_replication2_replicated_log_number_meta_entries_total
-introducedIn: "3.10.0"
+introducedIn: "3.11.0"
 help: |
   Number of meta log entries.
 unit: number

--- a/Documentation/Metrics/arangodb_replication2_replicated_log_started_following_total.yaml
+++ b/Documentation/Metrics/arangodb_replication2_replicated_log_started_following_total.yaml
@@ -1,5 +1,5 @@
 name: arangodb_replication2_replicated_log_started_following_total
-introducedIn: "3.9.0"
+introducedIn: "3.11.0"
 help: |
   Number of times started following a replicated log.
 unit: number

--- a/Documentation/Metrics/arangodb_replication2_replicated_state_acquire_snapshot_errors_total.yaml
+++ b/Documentation/Metrics/arangodb_replication2_replicated_state_acquire_snapshot_errors_total.yaml
@@ -1,5 +1,5 @@
 name: arangodb_replication2_replicated_state_acquire_snapshot_errors_total
-introducedIn: "3.10.0"
+introducedIn: "3.11.0"
 help: |
   Number of errors during an acquire snapshot operation.
 unit: number

--- a/Documentation/Metrics/arangodb_replication2_replicated_state_applied_entries_total.yaml
+++ b/Documentation/Metrics/arangodb_replication2_replicated_state_applied_entries_total.yaml
@@ -1,5 +1,5 @@
 name: arangodb_replication2_replicated_state_applied_entries_total
-introducedIn: "3.10.0"
+introducedIn: "3.11.0"
 help: |
   Number of log entries applied to the internal state.
 unit: number

--- a/Documentation/Metrics/arangodb_replication2_replicated_state_apply_entries_errors_total.yaml
+++ b/Documentation/Metrics/arangodb_replication2_replicated_state_apply_entries_errors_total.yaml
@@ -1,5 +1,5 @@
 name: arangodb_replication2_replicated_state_apply_entries_errors_total
-introducedIn: "3.10.0"
+introducedIn: "3.11.0"
 help: |
   Number of errors during an apply entries operation.
 unit: number

--- a/Documentation/Metrics/arangodb_replication2_replicated_state_follower_acquire_snapshot_rt.yaml
+++ b/Documentation/Metrics/arangodb_replication2_replicated_state_follower_acquire_snapshot_rt.yaml
@@ -1,5 +1,5 @@
 name: arangodb_replication2_replicated_state_follower_acquire_snapshot_rt
-introducedIn: "3.10.0"
+introducedIn: "3.11.0"
 help: |
   Histogram of the duration of acquireSnapshot calls in microseconds.
 unit: us

--- a/Documentation/Metrics/arangodb_replication2_replicated_state_follower_apply_entries_rt.yaml
+++ b/Documentation/Metrics/arangodb_replication2_replicated_state_follower_apply_entries_rt.yaml
@@ -1,5 +1,5 @@
 name: arangodb_replication2_replicated_state_follower_apply_entries_rt
-introducedIn: "3.10.0"
+introducedIn: "3.11.0"
 help: |
   Histogram of the duration of applyEntries calls in microseconds.
 unit: us

--- a/Documentation/Metrics/arangodb_replication2_replicated_state_follower_number.yaml
+++ b/Documentation/Metrics/arangodb_replication2_replicated_state_follower_number.yaml
@@ -1,5 +1,5 @@
 name: arangodb_replication2_replicated_state_follower_number
-introducedIn: "3.10.0"
+introducedIn: "3.11.0"
 help: |
   Number of follower replicated states.
 unit: number

--- a/Documentation/Metrics/arangodb_replication2_replicated_state_follower_waiting_for_leader_number.yaml
+++ b/Documentation/Metrics/arangodb_replication2_replicated_state_follower_waiting_for_leader_number.yaml
@@ -1,5 +1,5 @@
 name: arangodb_replication2_replicated_state_follower_waiting_for_leader_number
-introducedIn: "3.10.0"
+introducedIn: "3.11.0"
 help: |
   Number of followers waiting for the leader to acknowledge the current term.
 unit: number

--- a/Documentation/Metrics/arangodb_replication2_replicated_state_follower_waiting_for_snapshot_number.yaml
+++ b/Documentation/Metrics/arangodb_replication2_replicated_state_follower_waiting_for_snapshot_number.yaml
@@ -1,5 +1,5 @@
 name: arangodb_replication2_replicated_state_follower_waiting_for_snapshot_number
-introducedIn: "3.10.0"
+introducedIn: "3.11.0"
 help: |
   Number of followers waiting for a snapshot transfer to complete.
 unit: number

--- a/Documentation/Metrics/arangodb_replication2_replicated_state_leader_number.yaml
+++ b/Documentation/Metrics/arangodb_replication2_replicated_state_leader_number.yaml
@@ -1,5 +1,5 @@
 name: arangodb_replication2_replicated_state_leader_number
-introducedIn: "3.10.0"
+introducedIn: "3.11.0"
 help: |
   Number of leader replicated states.
 unit: number

--- a/Documentation/Metrics/arangodb_replication2_replicated_state_leader_recover_entries_rt.yaml
+++ b/Documentation/Metrics/arangodb_replication2_replicated_state_leader_recover_entries_rt.yaml
@@ -1,5 +1,5 @@
 name: arangodb_replication2_replicated_state_leader_recover_entries_rt
-introducedIn: "3.10.0"
+introducedIn: "3.11.0"
 help: |
   Histogram of the duration of recoverEntries calls in microseconds.
 unit: us

--- a/Documentation/Metrics/arangodb_replication2_replicated_state_leader_waiting_for_recovery_number.yaml
+++ b/Documentation/Metrics/arangodb_replication2_replicated_state_leader_waiting_for_recovery_number.yaml
@@ -1,5 +1,5 @@
 name: arangodb_replication2_replicated_state_leader_waiting_for_recovery_number
-introducedIn: "3.10.0"
+introducedIn: "3.11.0"
 help: |
   Number of leaders waiting for recovery to be complete.
 unit: number

--- a/Documentation/Metrics/arangodb_replication2_replicated_state_number.yaml
+++ b/Documentation/Metrics/arangodb_replication2_replicated_state_number.yaml
@@ -1,5 +1,5 @@
 name: arangodb_replication2_replicated_state_number
-introducedIn: "3.10.0"
+introducedIn: "3.11.0"
 help: |
   Number of replicated states.
 unit: number

--- a/Documentation/Metrics/arangodb_replication2_replicated_state_processed_entries_total.yaml
+++ b/Documentation/Metrics/arangodb_replication2_replicated_state_processed_entries_total.yaml
@@ -1,5 +1,5 @@
 name: arangodb_replication2_replicated_state_processed_entries_total
-introducedIn: "3.10.0"
+introducedIn: "3.11.0"
 help: |
   Number of log entries processed by the follower.
 unit: number


### PR DESCRIPTION
### Scope & Purpose

Fix wrong version numbers in `introducedIn` attribute of replication2 metrics.
All these metrics will appear in 3.11, not in previous versions.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: -
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 