### PR TITLE
Make agency watertight against illegal agents with new UUIDs BTS-1185

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 v3.10.3 (XXXX-XX-XX)
 --------------------
 
+* Prevent agency configuration confusion by an agent which comes back without
+  its data directory and thus without its UUID.
+
 * Change the request lane for replication catchup requests that leaders in
   active failover receive from their followers from medium to high. This will
   give catchup requests from followers highest priority, so that the leader will

--- a/arangod/Agency/AgentConfiguration.cpp
+++ b/arangod/Agency/AgentConfiguration.cpp
@@ -413,6 +413,10 @@ query_t config_t::poolToBuilder() const {
 
 bool config_t::updateEndpoint(std::string const& id, std::string const& ep) {
   WRITE_LOCKER(readLocker, _lock);
+  auto it = _pool.find(id);
+  if (it == _pool.end() && _pool.size() == _agencySize) {
+    return false;
+  }
   if (_pool[id] != ep) {
     _pool[id] = ep;
     ++_version;

--- a/arangod/Agency/State.cpp
+++ b/arangod/Agency/State.cpp
@@ -1048,6 +1048,15 @@ bool State::loadOrPersistConfiguration() {
           << "Merging configuration " << conf.toJson();
       _agent->mergeConfiguration(conf);
 
+      auto pool = _agent->config().pool();
+      auto it = pool.find(_agent->config().id());
+      if (it == pool.end()) {
+        LOG_TOPIC("6acd3", FATAL, Logger::AGENCY)
+            << "Ended up with a pool of agents which does not include "
+               "ourselves, configuration: "
+            << _agent->config().toBuilder()->slice().toJson();
+        FATAL_ERROR_EXIT();
+      }
     } catch (std::exception const& e) {
       LOG_TOPIC("6acd2", FATAL, Logger::AGENCY)
           << "Failed to merge persisted configuration into runtime "


### PR DESCRIPTION
This tries to address https://arangodb.atlassian.net/browse/BTS-1185

There is currently a problem with an agent which might have lost its
data directory and thus has forgotten its UUID. It then tries to join
the agency with a new UUID. There are situations in which this can
confuse the agency configuration.

### Scope & Purpose

- [*] :hankey: Bugfix

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [*] :book: CHANGELOG entry made
- [*] Backports
  - [*] Backport for 3.10: This is it.

#### Related Information

- [*] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/BTS-1185
- [*] Devel PR: https://github.com/arangodb/arangodb/pull/17919


