### PR TITLE
[cmake] Get rid of duplicated dependencies in graph and rep2 tests

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -32,7 +32,6 @@ if (WINDOWS)
 endif ()
 
 add_library(arango_tests_basics OBJECT
-  ${CMAKE_CURRENT_SOURCE_DIR}/Aql/VelocyPackHelper.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/Mocks/IResearchLinkMock.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/Mocks/IResearchInvertedIndexMock.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/Mocks/LogLevels.cpp

--- a/tests/Graph/CMakeLists.txt
+++ b/tests/Graph/CMakeLists.txt
@@ -17,6 +17,7 @@ add_library(arango_tests_graph OBJECT
   SingleServerProviderTest.cpp)
 
 target_link_libraries(arango_tests_graph
+  PRIVATE
     arango
     arango_tests_basics
     velocypack
@@ -26,16 +27,14 @@ add_executable(arangodbtests_graph
   EXCLUDE_FROM_ALL)
 
 target_link_libraries(arangodbtests_graph
-    gtest
-    arango_tests_basics
     arango_tests_graph
+    arango_tests_basics
     arango_agency
     arango_cluster_engine
     arango_rocksdb
     arango_v8server
     arangoserver
-    boost_boost
-    fmt)
+    boost_boost)
 
 add_test(NAME graph
          COMMAND arangodbtests_graph)

--- a/tests/Replication2/CMakeLists.txt
+++ b/tests/Replication2/CMakeLists.txt
@@ -88,11 +88,12 @@ target_include_directories(arango_tests_replication2 PUBLIC
     ${PROJECT_SOURCE_DIR}/tests/Mocks/)
 
 target_link_libraries(arango_tests_replication2
+  PRIVATE
+    arango_replication2
     gtest
     gmock
     arango
     arango_futures
-    arango_replication2
     velocypack
     fmt)
 
@@ -106,16 +107,14 @@ else()
 endif()
 
 target_link_libraries(arangodbtests_replication2
-    gtest
-    arango_tests_basics
     arango_tests_replication2
+    arango_tests_basics
     arango_agency
     arango_cluster_engine
     arango_rocksdb
     arango_v8server
     arangoserver
-    boost_boost
-    fmt)
+    boost_boost)
 
 add_test(NAME replication2
          COMMAND arangodbtests_replication2)


### PR DESCRIPTION
Gets rid of duplicated linking in graph and rep2 tests and uses PRIVATE where appropriate.