### PR TITLE
BTS-1192: fix potential race in sha file creation

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,12 @@
 v3.10.3 (XXXX-XX-XX)
 --------------------
 
+* BTS-1192: fix a potential race during hot backup creation, which could result
+  in error messages such as
+  `{backup} Source file engine_rocksdb/002516.sst does not have a hash file.`
+  during hot backup creation. However, despite the error message being logged,
+  the hot backup was still complete.
+
 * Change the request lane for replication catchup requests that leaders in
   active failover receive from their followers from medium to high. This will
   give catchup requests from followers highest priority, so that the leader will


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/17948

This PR fixes a potential race during hot backup creation, described in https://arangodb.atlassian.net/browse/BTS-1192:

There has been a report about the following error occuring every hour:
```
ERROR [d5f51] {backup} Source file engine_rocksdb/002516.sst does not have a hash file.
```
More details can be found in the BTS ticket.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.10: this PR
  - [x] Backport for 3.9: https://github.com/arangodb/arangodb/pull/17944
  - [ ] Backport for 3.8: not affected

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [x] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/BTS-1192
- [ ] Design document: 