### PR TITLE
[PREG-226] Use structs for conductor messages

### DIFF
--- a/arangod/Pregel/AlgoRegistry.cpp
+++ b/arangod/Pregel/AlgoRegistry.cpp
@@ -95,13 +95,13 @@ IAlgorithm* AlgoRegistry::createAlgorithm(
 }
 
 template<typename V, typename E, typename M>
-/*static*/ std::shared_ptr<IWorker> AlgoRegistry::createWorker(
+std::shared_ptr<IWorker> AlgoRegistry::createWorker(
     TRI_vocbase_t& vocbase, Algorithm<V, E, M>* algo,
     CreateWorker const& parameters, PregelFeature& feature) {
   return std::make_shared<Worker<V, E, M>>(vocbase, algo, parameters, feature);
 }
 
-/*static*/ std::shared_ptr<IWorker> AlgoRegistry::createWorker(
+std::shared_ptr<IWorker> AlgoRegistry::createWorker(
     TRI_vocbase_t& vocbase, CreateWorker const& parameters,
     PregelFeature& feature) {
   VPackSlice userParams = parameters.userParameters.slice();

--- a/arangod/Pregel/AlgoRegistry.cpp
+++ b/arangod/Pregel/AlgoRegistry.cpp
@@ -22,6 +22,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #include "ApplicationFeatures/ApplicationServer.h"
+#include "Pregel/Conductor/Messages.h"
 #include "VocBase/vocbase.h"
 #include "Pregel/AlgoRegistry.h"
 #include "Pregel/Algos/ConnectedComponents.h"
@@ -95,82 +96,76 @@ IAlgorithm* AlgoRegistry::createAlgorithm(
 
 template<typename V, typename E, typename M>
 /*static*/ std::shared_ptr<IWorker> AlgoRegistry::createWorker(
-    TRI_vocbase_t& vocbase, Algorithm<V, E, M>* algo, VPackSlice body,
-    PregelFeature& feature) {
-  return std::make_shared<Worker<V, E, M>>(vocbase, algo, body, feature);
+    TRI_vocbase_t& vocbase, Algorithm<V, E, M>* algo,
+    CreateWorker const& parameters, PregelFeature& feature) {
+  return std::make_shared<Worker<V, E, M>>(vocbase, algo, parameters, feature);
 }
 
 /*static*/ std::shared_ptr<IWorker> AlgoRegistry::createWorker(
-    TRI_vocbase_t& vocbase, VPackSlice body, PregelFeature& feature) {
-  VPackSlice algoSlice = body.get(Utils::algorithmKey);
-
-  if (!algoSlice.isString()) {
-    THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_BAD_PARAMETER,
-                                   "Supplied bad parameters to worker");
-  }
-
-  VPackSlice userParams = body.get(Utils::userParametersKey);
-  std::string algorithm = algoSlice.copyString();
+    TRI_vocbase_t& vocbase, CreateWorker const& parameters,
+    PregelFeature& feature) {
+  VPackSlice userParams = parameters.userParameters.slice();
+  std::string algorithm = parameters.algorithm;
   std::transform(algorithm.begin(), algorithm.end(), algorithm.begin(),
                  ::tolower);
 
   auto& server = vocbase.server();
   if (algorithm == "sssp") {
     return createWorker(vocbase, new algos::SSSPAlgorithm(server, userParams),
-                        body, feature);
+                        parameters, feature);
   } else if (algorithm == "pagerank") {
-    return createWorker(vocbase, new algos::PageRank(server, userParams), body,
-                        feature);
+    return createWorker(vocbase, new algos::PageRank(server, userParams),
+                        parameters, feature);
   } else if (algorithm == "recoveringpagerank") {
     return createWorker(vocbase,
-                        new algos::RecoveringPageRank(server, userParams), body,
-                        feature);
+                        new algos::RecoveringPageRank(server, userParams),
+                        parameters, feature);
   } else if (algorithm == "shortestpath") {
     return createWorker(vocbase,
                         new algos::ShortestPathAlgorithm(server, userParams),
-                        body, feature);
+                        parameters, feature);
   } else if (algorithm == "linerank") {
-    return createWorker(vocbase, new algos::LineRank(server, userParams), body,
-                        feature);
+    return createWorker(vocbase, new algos::LineRank(server, userParams),
+                        parameters, feature);
   } else if (algorithm == "effectivecloseness") {
     return createWorker(vocbase,
-                        new algos::EffectiveCloseness(server, userParams), body,
-                        feature);
+                        new algos::EffectiveCloseness(server, userParams),
+                        parameters, feature);
   } else if (algorithm == "connectedcomponents") {
     return createWorker(vocbase,
                         new algos::ConnectedComponents(server, userParams),
-                        body, feature);
+                        parameters, feature);
   } else if (algorithm == "scc") {
-    return createWorker(vocbase, new algos::SCC(server, userParams), body,
+    return createWorker(vocbase, new algos::SCC(server, userParams), parameters,
                         feature);
   } else if (algorithm == "hits") {
-    return createWorker(vocbase, new algos::HITS(server, userParams), body,
-                        feature);
+    return createWorker(vocbase, new algos::HITS(server, userParams),
+                        parameters, feature);
   } else if (algorithm == "hitskleinberg") {
     return createWorker(vocbase, new algos::HITSKleinberg(server, userParams),
-                        body, feature);
+                        parameters, feature);
   } else if (algorithm == "labelpropagation") {
     return createWorker(vocbase,
-                        new algos::LabelPropagation(server, userParams), body,
-                        feature);
+                        new algos::LabelPropagation(server, userParams),
+                        parameters, feature);
   } else if (algorithm == "slpa") {
-    return createWorker(vocbase, new algos::SLPA(server, userParams), body,
-                        feature);
+    return createWorker(vocbase, new algos::SLPA(server, userParams),
+                        parameters, feature);
   } else if (algorithm == "dmid") {
-    return createWorker(vocbase, new algos::DMID(server, userParams), body,
-                        feature);
+    return createWorker(vocbase, new algos::DMID(server, userParams),
+                        parameters, feature);
   } else if (algorithm == "wcc") {
-    return createWorker(vocbase, new algos::WCC(server, userParams), body,
+    return createWorker(vocbase, new algos::WCC(server, userParams), parameters,
                         feature);
   } else if (algorithm == "colorpropagation") {
     return createWorker(vocbase,
-                        new algos::ColorPropagation(server, userParams), body,
-                        feature);
+                        new algos::ColorPropagation(server, userParams),
+                        parameters, feature);
   }
 #if defined(ARANGODB_ENABLE_MAINTAINER_MODE)
   else if (algorithm == "readwrite") {
-    return createWorker(vocbase, new algos::ReadWrite(server, userParams), body,
-                        feature);
+    return createWorker(vocbase, new algos::ReadWrite(server, userParams),
+                        parameters, feature);
   }
 #endif
   THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_BAD_PARAMETER,

--- a/arangod/Pregel/AlgoRegistry.h
+++ b/arangod/Pregel/AlgoRegistry.h
@@ -25,6 +25,7 @@
 
 #include <string>
 #include "Pregel/Algorithm.h"
+#include "Pregel/Conductor/Messages.h"
 #include "Pregel/Worker/Worker.h"
 
 struct TRI_vocbase_t;
@@ -39,14 +40,14 @@ struct AlgoRegistry {
       application_features::ApplicationServer& server,
       std::string const& algorithm, VPackSlice userParams);
   static std::shared_ptr<IWorker> createWorker(TRI_vocbase_t& vocbase,
-                                               VPackSlice body,
+                                               CreateWorker const& parameters,
                                                PregelFeature& feature);
 
  private:
   template<typename V, typename E, typename M>
   static std::shared_ptr<IWorker> createWorker(TRI_vocbase_t& vocbase,
                                                Algorithm<V, E, M>* algo,
-                                               VPackSlice body,
+                                               CreateWorker const& parameters,
                                                PregelFeature& feature);
 };
 

--- a/arangod/Pregel/Conductor/Conductor.cpp
+++ b/arangod/Pregel/Conductor/Conductor.cpp
@@ -486,7 +486,6 @@ ErrorCode Conductor::_initializeWorkers(std::string const& suffix,
 
   std::string const path = Utils::baseUrl(Utils::workerPrefix) + suffix;
 
-  // int64_t vertexCount = 0, edgeCount = 0;
   std::unordered_map<CollectionID, std::string> collectionPlanIdMap;
   std::map<ServerID, std::map<CollectionID, std::vector<ShardID>>> vertexMap,
       edgeMap;

--- a/arangod/Pregel/Conductor/Conductor.h
+++ b/arangod/Pregel/Conductor/Conductor.h
@@ -37,6 +37,7 @@
 #include "Pregel/Status/ExecutionStatus.h"
 
 #include <chrono>
+#include <set>
 
 namespace arangodb {
 namespace pregel {

--- a/arangod/Pregel/Conductor/Messages.h
+++ b/arangod/Pregel/Conductor/Messages.h
@@ -74,19 +74,20 @@ auto inspect(Inspector& f, PrepareGlobalSuperStep& x) {
 }
 
 struct RunGlobalSuperStep {
+  ExecutionNumber executionNumber;
   uint64_t gss;
   uint64_t vertexCount;
   uint64_t edgeCount;
-  uint64_t sendCount;
   VPackBuilder aggregators;
 };
 
 template<typename Inspector>
 auto inspect(Inspector& f, RunGlobalSuperStep& x) {
   return f.object(x).fields(
+      f.field(Utils::executionNumberKey, x.executionNumber),
       f.field(Utils::globalSuperstepKey, x.gss),
       f.field("vertexCount", x.vertexCount), f.field("edgeCount", x.edgeCount),
-      f.field("sendCount", x.sendCount), f.field("aggregators", x.aggregators));
+      f.field("aggregators", x.aggregators));
 }
 
 struct Store {};
@@ -114,4 +115,7 @@ auto inspect(Inspector& f, CollectPregelResults& x) {
 
 template<>
 struct fmt::formatter<arangodb::pregel::PrepareGlobalSuperStep>
+    : arangodb::inspection::inspection_formatter {};
+template<>
+struct fmt::formatter<arangodb::pregel::RunGlobalSuperStep>
     : arangodb::inspection::inspection_formatter {};

--- a/arangod/Pregel/Conductor/Messages.h
+++ b/arangod/Pregel/Conductor/Messages.h
@@ -90,16 +90,16 @@ auto inspect(Inspector& f, RunGlobalSuperStep& x) {
       f.field("aggregators", x.aggregators));
 }
 
-struct Store {};
+// TODO split into Store and Cleanup
+struct FinalizeExecution {
+  ExecutionNumber executionNumber;
+  bool store;
+};
 template<typename Inspector>
-auto inspect(Inspector& f, Store& x) {
-  return f.object(x).fields();
-}
-
-struct Cleanup {};
-template<typename Inspector>
-auto inspect(Inspector& f, Cleanup& x) {
-  return f.object(x).fields();
+auto inspect(Inspector& f, FinalizeExecution& x) {
+  return f.object(x).fields(
+      f.field(Utils::executionNumberKey, x.executionNumber),
+      f.field("store", x.store));
 }
 
 struct CollectPregelResults {

--- a/arangod/Pregel/Conductor/Messages.h
+++ b/arangod/Pregel/Conductor/Messages.h
@@ -24,6 +24,7 @@
 
 #include <map>
 
+#include "Inspection/Format.h"
 #include "Pregel/ExecutionNumber.h"
 #include "Pregel/Utils.h"
 
@@ -59,16 +60,17 @@ auto inspect(Inspector& f, CreateWorker& x) {
 }
 
 struct PrepareGlobalSuperStep {
+  ExecutionNumber executionNumber;
   uint64_t gss;
   uint64_t vertexCount;
   uint64_t edgeCount;
 };
-
 template<typename Inspector>
 auto inspect(Inspector& f, PrepareGlobalSuperStep& x) {
-  return f.object(x).fields(f.field(Utils::globalSuperstepKey, x.gss),
-                            f.field("vertexCount", x.vertexCount),
-                            f.field("edgeCount", x.edgeCount));
+  return f.object(x).fields(
+      f.field(Utils::executionNumberKey, x.executionNumber),
+      f.field(Utils::globalSuperstepKey, x.gss),
+      f.field("vertexCount", x.vertexCount), f.field("edgeCount", x.edgeCount));
 }
 
 struct RunGlobalSuperStep {
@@ -109,3 +111,7 @@ auto inspect(Inspector& f, CollectPregelResults& x) {
 }
 
 }  // namespace arangodb::pregel
+
+template<>
+struct fmt::formatter<arangodb::pregel::PrepareGlobalSuperStep>
+    : arangodb::inspection::inspection_formatter {};

--- a/arangod/Pregel/Conductor/Messages.h
+++ b/arangod/Pregel/Conductor/Messages.h
@@ -1,0 +1,111 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2022 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Julia Volmer
+////////////////////////////////////////////////////////////////////////////////
+#pragma once
+
+#include <map>
+
+#include "Pregel/ExecutionNumber.h"
+#include "Pregel/Utils.h"
+
+namespace arangodb::pregel {
+
+// TODO split LoadGraph off CreateWorker
+struct CreateWorker {
+  ExecutionNumber executionNumber;
+  std::string algorithm;
+  VPackBuilder userParameters;
+  std::string coordinatorId;
+  bool useMemoryMaps;
+  std::unordered_map<CollectionID, std::vector<ShardID>>
+      edgeCollectionRestrictions;
+  std::map<CollectionID, std::vector<ShardID>> vertexShards;
+  std::map<CollectionID, std::vector<ShardID>> edgeShards;
+  std::unordered_map<CollectionID, std::string> collectionPlanIds;
+  std::vector<ShardID> allShards;
+};
+template<typename Inspector>
+auto inspect(Inspector& f, CreateWorker& x) {
+  return f.object(x).fields(
+      f.field(Utils::executionNumberKey, x.executionNumber),
+      f.field("algorithm", x.algorithm),
+      f.field("userParameters", x.userParameters),
+      f.field("coordinatorId", x.coordinatorId),
+      f.field("useMemoryMaps", x.useMemoryMaps),
+      f.field("edgeCollectionRestrictions", x.edgeCollectionRestrictions),
+      f.field("vertexShards", x.vertexShards),
+      f.field("edgeShards", x.edgeShards),
+      f.field("collectionPlanIds", x.collectionPlanIds),
+      f.field("allShards", x.allShards));
+}
+
+struct PrepareGlobalSuperStep {
+  uint64_t gss;
+  uint64_t vertexCount;
+  uint64_t edgeCount;
+};
+
+template<typename Inspector>
+auto inspect(Inspector& f, PrepareGlobalSuperStep& x) {
+  return f.object(x).fields(f.field(Utils::globalSuperstepKey, x.gss),
+                            f.field("vertexCount", x.vertexCount),
+                            f.field("edgeCount", x.edgeCount));
+}
+
+struct RunGlobalSuperStep {
+  uint64_t gss;
+  uint64_t vertexCount;
+  uint64_t edgeCount;
+  uint64_t sendCount;
+  VPackBuilder aggregators;
+};
+
+template<typename Inspector>
+auto inspect(Inspector& f, RunGlobalSuperStep& x) {
+  return f.object(x).fields(
+      f.field(Utils::globalSuperstepKey, x.gss),
+      f.field("vertexCount", x.vertexCount), f.field("edgeCount", x.edgeCount),
+      f.field("sendCount", x.sendCount), f.field("aggregators", x.aggregators));
+}
+
+struct Store {};
+template<typename Inspector>
+auto inspect(Inspector& f, Store& x) {
+  return f.object(x).fields();
+}
+
+struct Cleanup {};
+template<typename Inspector>
+auto inspect(Inspector& f, Cleanup& x) {
+  return f.object(x).fields();
+}
+
+struct CollectPregelResults {
+  bool withId;
+};
+
+template<typename Inspector>
+auto inspect(Inspector& f, CollectPregelResults& x) {
+  return f.object(x).fields(f.field("withId", x.withId).fallback(false));
+}
+
+}  // namespace arangodb::pregel

--- a/arangod/Pregel/Conductor/Messages.h
+++ b/arangod/Pregel/Conductor/Messages.h
@@ -103,12 +103,14 @@ auto inspect(Inspector& f, FinalizeExecution& x) {
 }
 
 struct CollectPregelResults {
+  ExecutionNumber executionNumber;
   bool withId;
 };
-
 template<typename Inspector>
 auto inspect(Inspector& f, CollectPregelResults& x) {
-  return f.object(x).fields(f.field("withId", x.withId).fallback(false));
+  return f.object(x).fields(
+      f.field(Utils::executionNumberKey, x.executionNumber),
+      f.field("withId", x.withId).fallback(false));
 }
 
 }  // namespace arangodb::pregel

--- a/arangod/Pregel/PregelFeature.cpp
+++ b/arangod/Pregel/PregelFeature.cpp
@@ -830,7 +830,13 @@ void PregelFeature::handleWorkerRequest(TRI_vocbase_t& vocbase,
     }
     w->prepareGlobalStep(message.get(), outBuilder);
   } else if (path == Utils::startGSSPath) {
-    w->startGlobalStep(body);
+    auto message = inspection::deserializeWithErrorT<RunGlobalSuperStep>(
+        velocypack::SharedSlice({}, body));
+    if (!message.ok()) {
+      THROW_ARANGO_EXCEPTION_MESSAGE(
+          TRI_ERROR_INTERNAL, "Cannot deserialize RunGlobalSuperStep message");
+    }
+    w->startGlobalStep(message.get());
   } else if (path == Utils::messagesPath) {
     w->receivedMessages(body);
   } else if (path == Utils::cancelGSSPath) {

--- a/arangod/Pregel/PregelFeature.cpp
+++ b/arangod/Pregel/PregelFeature.cpp
@@ -839,8 +839,6 @@ void PregelFeature::handleWorkerRequest(TRI_vocbase_t& vocbase,
     w->startGlobalStep(message.get());
   } else if (path == Utils::messagesPath) {
     w->receivedMessages(body);
-  } else if (path == Utils::cancelGSSPath) {
-    w->cancelGlobalStep(body);
   } else if (path == Utils::finalizeExecutionPath) {
     w->finalizeExecution(body, [this, exeNum]() { cleanupWorker(exeNum); });
   } else if (path == Utils::aqlResultsPath) {

--- a/arangod/Pregel/PregelFeature.cpp
+++ b/arangod/Pregel/PregelFeature.cpp
@@ -849,12 +849,14 @@ void PregelFeature::handleWorkerRequest(TRI_vocbase_t& vocbase,
     w->finalizeExecution(message.get(),
                          [this, exeNum]() { cleanupWorker(exeNum); });
   } else if (path == Utils::aqlResultsPath) {
-    bool withId = false;
-    if (body.isObject()) {
-      VPackSlice slice = body.get("withId");
-      withId = slice.isBoolean() && slice.getBool();
+    auto message = inspection::deserializeWithErrorT<CollectPregelResults>(
+        velocypack::SharedSlice({}, body));
+    if (!message.ok()) {
+      THROW_ARANGO_EXCEPTION_MESSAGE(
+          TRI_ERROR_INTERNAL,
+          "Cannot deserialize CollectPregelResults message");
     }
-    w->aqlResult(outBuilder, withId);
+    w->aqlResult(outBuilder, message.get().withId);
   }
 }
 

--- a/arangod/Pregel/PregelFeature.cpp
+++ b/arangod/Pregel/PregelFeature.cpp
@@ -821,7 +821,14 @@ void PregelFeature::handleWorkerRequest(TRI_vocbase_t& vocbase,
   }
 
   if (path == Utils::prepareGSSPath) {
-    w->prepareGlobalStep(body, outBuilder);
+    auto message = inspection::deserializeWithErrorT<PrepareGlobalSuperStep>(
+        velocypack::SharedSlice({}, body));
+    if (!message.ok()) {
+      THROW_ARANGO_EXCEPTION_MESSAGE(
+          TRI_ERROR_INTERNAL,
+          "Cannot deserialize PrepareGlobalSuperStep message");
+    }
+    w->prepareGlobalStep(message.get(), outBuilder);
   } else if (path == Utils::startGSSPath) {
     w->startGlobalStep(body);
   } else if (path == Utils::messagesPath) {

--- a/arangod/Pregel/PregelFeature.cpp
+++ b/arangod/Pregel/PregelFeature.cpp
@@ -39,6 +39,7 @@
 #include "Cluster/ClusterInfo.h"
 #include "Cluster/ServerState.h"
 #include "GeneralServer/AuthenticationFeature.h"
+#include "Graph/GraphManager.h"
 #include "Inspection/VPackWithErrorT.h"
 #include "Metrics/CounterBuilder.h"
 #include "Metrics/GaugeBuilder.h"

--- a/arangod/Pregel/Utils.cpp
+++ b/arangod/Pregel/Utils.cpp
@@ -45,7 +45,6 @@ std::string const Utils::startGSSPath = "startGSS";
 std::string const Utils::finishedWorkerStepPath = "finishedStep";
 std::string const Utils::finishedWorkerFinalizationPath =
     "finishedFinalization";
-std::string const Utils::cancelGSSPath = "cancelGSS";
 std::string const Utils::messagesPath = "messages";
 std::string const Utils::finalizeExecutionPath = "finalizeExecution";
 std::string const Utils::storeCheckpointPath = "storeCheckpoint";

--- a/arangod/Pregel/Utils.cpp
+++ b/arangod/Pregel/Utils.cpp
@@ -26,6 +26,7 @@
 #include "Cluster/ClusterInfo.h"
 #include "Cluster/ServerState.h"
 #include "Logger/LogMacros.h"
+#include "Pregel/Worker/WorkerConfig.h"
 #include "VocBase/LogicalCollection.h"
 #include "VocBase/vocbase.h"
 

--- a/arangod/Pregel/Utils.h
+++ b/arangod/Pregel/Utils.h
@@ -28,14 +28,13 @@
 #include "Basics/Common.h"
 #include "Cluster/ClusterInfo.h"
 
-#include "Pregel/ExecutionNumber.h"
-#include "Pregel/Worker/WorkerConfig.h"
-
 struct TRI_vocbase_t;
 
 namespace arangodb {
 class LogicalCollection;
 namespace pregel {
+
+class WorkerConfig;
 
 class Utils {
   Utils() = delete;

--- a/arangod/Pregel/Utils.h
+++ b/arangod/Pregel/Utils.h
@@ -53,7 +53,6 @@ class Utils {
   static std::string const startGSSPath;
   static std::string const finishedWorkerStepPath;
   static std::string const finishedWorkerFinalizationPath;
-  static std::string const cancelGSSPath;
   static std::string const messagesPath;
   static std::string const finalizeExecutionPath;
   static std::string const storeCheckpointPath;

--- a/arangod/Pregel/Worker/Worker.cpp
+++ b/arangod/Pregel/Worker/Worker.cpp
@@ -1,3 +1,4 @@
+#include "Pregel/Conductor/Messages.h"
 ////////////////////////////////////////////////////////////////////////////////
 /// DISCLAIMER
 ///
@@ -67,18 +68,16 @@ using namespace arangodb::pregel;
 
 template<typename V, typename E, typename M>
 Worker<V, E, M>::Worker(TRI_vocbase_t& vocbase, Algorithm<V, E, M>* algo,
-                        VPackSlice initConfig, PregelFeature& feature)
+                        CreateWorker const& parameters, PregelFeature& feature)
     : _feature(feature),
       _state(WorkerState::IDLE),
       _config(&vocbase),
       _algorithm(algo) {
-  _config.updateConfig(_feature, initConfig);
+  _config.updateConfig(_feature, parameters);
 
   MUTEX_LOCKER(guard, _commandMutex);
 
-  VPackSlice userParams = initConfig.get(Utils::userParametersKey);
-
-  _workerContext.reset(algo->workerContext(userParams));
+  _workerContext.reset(algo->workerContext(parameters.userParameters.slice()));
   _messageFormat.reset(algo->messageFormat());
   _messageCombiner.reset(algo->messageCombiner());
   _conductorAggregators = std::make_unique<AggregatorHandler>(algo);

--- a/arangod/Pregel/Worker/Worker.h
+++ b/arangod/Pregel/Worker/Worker.h
@@ -30,6 +30,7 @@
 #include "Basics/ReadWriteLock.h"
 #include "Pregel/AggregatorHandler.h"
 #include "Pregel/Algorithm.h"
+#include "Pregel/Conductor/Messages.h"
 #include "Pregel/Statistics.h"
 #include "Pregel/Status/Status.h"
 #include "Pregel/Worker/WorkerConfig.h"
@@ -143,7 +144,7 @@ class Worker : public IWorker {
 
  public:
   Worker(TRI_vocbase_t& vocbase, Algorithm<V, E, M>* algorithm,
-         VPackSlice params, PregelFeature& feature);
+         CreateWorker const& params, PregelFeature& feature);
   ~Worker();
 
   // ====== called by rest handler =====

--- a/arangod/Pregel/Worker/Worker.h
+++ b/arangod/Pregel/Worker/Worker.h
@@ -51,7 +51,7 @@ class IWorker : public std::enable_shared_from_this<IWorker> {
  public:
   virtual ~IWorker() = default;
   virtual void setupWorker() = 0;
-  virtual void prepareGlobalStep(VPackSlice const& data,
+  virtual void prepareGlobalStep(PrepareGlobalSuperStep const& data,
                                  VPackBuilder& result) = 0;
   virtual void startGlobalStep(
       VPackSlice const& data) = 0;  // called by coordinator
@@ -149,7 +149,8 @@ class Worker : public IWorker {
 
   // ====== called by rest handler =====
   void setupWorker() override;
-  void prepareGlobalStep(VPackSlice const& data, VPackBuilder& result) override;
+  void prepareGlobalStep(PrepareGlobalSuperStep const& data,
+                         VPackBuilder& result) override;
   void startGlobalStep(VPackSlice const& data) override;
   void cancelGlobalStep(VPackSlice const& data) override;
   void receivedMessages(VPackSlice const& data) override;

--- a/arangod/Pregel/Worker/Worker.h
+++ b/arangod/Pregel/Worker/Worker.h
@@ -54,7 +54,7 @@ class IWorker : public std::enable_shared_from_this<IWorker> {
   virtual void prepareGlobalStep(PrepareGlobalSuperStep const& data,
                                  VPackBuilder& result) = 0;
   virtual void startGlobalStep(
-      VPackSlice const& data) = 0;  // called by coordinator
+      RunGlobalSuperStep const& data) = 0;  // called by coordinator
   virtual void cancelGlobalStep(
       VPackSlice const& data) = 0;  // called by coordinator
   virtual void receivedMessages(VPackSlice const& data) = 0;
@@ -151,7 +151,7 @@ class Worker : public IWorker {
   void setupWorker() override;
   void prepareGlobalStep(PrepareGlobalSuperStep const& data,
                          VPackBuilder& result) override;
-  void startGlobalStep(VPackSlice const& data) override;
+  void startGlobalStep(RunGlobalSuperStep const& data) override;
   void cancelGlobalStep(VPackSlice const& data) override;
   void receivedMessages(VPackSlice const& data) override;
   void finalizeExecution(VPackSlice const& data,

--- a/arangod/Pregel/Worker/Worker.h
+++ b/arangod/Pregel/Worker/Worker.h
@@ -58,7 +58,7 @@ class IWorker : public std::enable_shared_from_this<IWorker> {
   virtual void cancelGlobalStep(
       VPackSlice const& data) = 0;  // called by coordinator
   virtual void receivedMessages(VPackSlice const& data) = 0;
-  virtual void finalizeExecution(VPackSlice const& data,
+  virtual void finalizeExecution(FinalizeExecution const& data,
                                  std::function<void()> cb) = 0;
   virtual void aqlResult(VPackBuilder&, bool withId) const = 0;
 };
@@ -154,7 +154,7 @@ class Worker : public IWorker {
   void startGlobalStep(RunGlobalSuperStep const& data) override;
   void cancelGlobalStep(VPackSlice const& data) override;
   void receivedMessages(VPackSlice const& data) override;
-  void finalizeExecution(VPackSlice const& data,
+  void finalizeExecution(FinalizeExecution const& data,
                          std::function<void()> cb) override;
 
   void aqlResult(VPackBuilder&, bool withId) const override;

--- a/arangod/Pregel/Worker/WorkerConfig.h
+++ b/arangod/Pregel/Worker/WorkerConfig.h
@@ -30,6 +30,7 @@
 #include "Basics/Common.h"
 #include "Cluster/ClusterInfo.h"
 
+#include "Pregel/Conductor/Messages.h"
 #include "Pregel/ExecutionNumber.h"
 #include "Pregel/Graph.h"
 
@@ -50,7 +51,7 @@ class WorkerConfig {
 
  public:
   explicit WorkerConfig(TRI_vocbase_t* vocbase);
-  void updateConfig(PregelFeature& feature, VPackSlice updated);
+  void updateConfig(PregelFeature& feature, CreateWorker const& updated);
 
   // get effective parallelism from Pregel feature and params
   static size_t parallelism(PregelFeature& feature, VPackSlice params);


### PR DESCRIPTION
Use structs instead of plain velocypack for messages sent from conductor to workers. A simliar PR for messages from workers to conductor will follow.

This is a preparation step for using a proper messaging framework for Pregel.