### PR TITLE
Fix OASIS-24962

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,17 +1,6 @@
 devel
 -----
 
-* Prevent agency configuration confusion by an agent which comes back without
-  its data directory and thus without its UUID.
-
-* APM-592: In batched query results, when executing requests for `/_api/cursor`, 
-  there might be a connection error and the user might not be able to retrieve
-  the latest batch from the cursor. For that, a query option flag `allowRetry` was
-  added. When set to `true`, if the latest batch response object wasn't
-  successfully received, the user can send a retry request to receive it with 
-  a POST request to `/_api/cursor/<cursorId>/<batchId>`. Only the latest batch
-  is cached, meaning former batches cannot be retrieved again later.
-
 * Fix coordinator segfault in AQL queries in which the query is invoked from
   within a JavaScript context (e.g. from Foxx or from the server's console
   mode) **and** the query has multiple coordinator snippets of which except
@@ -23,6 +12,17 @@ devel
   correctly that no JavaScript is needed, except if the fixed function name
   is the name of a user-defined function.
   This fixes an issue described in OASIS-24962.
+
+* Prevent agency configuration confusion by an agent which comes back without
+  its data directory and thus without its UUID.
+
+* APM-592: In batched query results, when executing requests for `/_api/cursor`, 
+  there might be a connection error and the user might not be able to retrieve
+  the latest batch from the cursor. For that, a query option flag `allowRetry` was
+  added. When set to `true`, if the latest batch response object wasn't
+  successfully received, the user can send a retry request to receive it with 
+  a POST request to `/_api/cursor/<cursorId>/<batchId>`. Only the latest batch
+  is cached, meaning former batches cannot be retrieved again later.
 
 * Change the request lane for replication catchup requests that leaders in
   active failover receive from their followers from medium to high. This

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,6 +12,18 @@ devel
   a POST request to `/_api/cursor/<cursorId>/<batchId>`. Only the latest batch
   is cached, meaning former batches cannot be retrieved again later.
 
+* Fix coordinator segfault in AQL queries in which the query is invoked from
+  within a JavaScript context (e.g. from Foxx or from the server's console
+  mode) **and** the query has multiple coordinator snippets of which except
+  the outermost one invokes a JavaScript function.
+  Instead of crashing, coordinators will now respond with the exception 
+  "no v8 context available to enter for current transaction context".
+  For AQL queries that called one of the AQL functions `CALL` or `APPLY` with
+  a fixed function name, e.g. `APPLY('CONCAT', ...)`, it is now also assumed
+  correctly that no JavaScript is needed, except if the fixed function name
+  is the name of a user-defined function.
+  This fixes an issue described in OASIS-24962.
+
 * Change the request lane for replication catchup requests that leaders in
   active failover receive from their followers from medium to high. This
   will give catchup requests from followers highest priority, so that the

--- a/arangod/Aql/Ast.h
+++ b/arangod/Aql/Ast.h
@@ -605,10 +605,11 @@ class Ast {
   static void traverseReadOnly(AstNode const*,
                                std::function<void(AstNode const*)> const&);
 
- private:
   /// @brief normalize a function name
-  std::pair<std::string, bool> normalizeFunctionName(std::string_view name);
+  static std::pair<std::string, bool> normalizeFunctionName(
+      std::string_view name);
 
+ private:
   /// @brief create a node of the specified type
   AstNode* createNode(AstNodeType);
 

--- a/arangod/Aql/AstNode.cpp
+++ b/arangod/Aql/AstNode.cpp
@@ -1637,6 +1637,7 @@ bool AstNode::willUseV8() const {
       if (numMembers() > 0 && getMemberUnchecked(0)->isArray() &&
           getMemberUnchecked(0)->numMembers() > 0 &&
           getMemberUnchecked(0)->getMemberUnchecked(0)->isStringValue()) {
+        // calling a function with a fixed name (known an query compile time)
         if (auto s =
                 getMemberUnchecked(0)->getMemberUnchecked(0)->getStringView();
             s.find(':') != std::string::npos) {
@@ -1644,6 +1645,18 @@ bool AstNode::willUseV8() const {
           // this will use V8
           setFlag(DETERMINED_V8, VALUE_V8);
           return true;
+        } else {
+          // a built-in function (or some invalid function name)
+          auto [normalized, isBuiltIn] = Ast::normalizeFunctionName(s);
+          // note: normalizeFunctionName always returns an upper-case name.
+          // we must hard-code the function name here, because we can't lookup
+          // the definition for the function s without having access to the
+          // AqlFunctionsFeature, which is not present here.
+          if (normalized == "V8") {
+            // the V8() function itself... obviously uses V8
+            setFlag(DETERMINED_V8, VALUE_V8);
+            return true;
+          }
         }
         // fallthrough intentional. additionally inspect the function call
         // parameters for CALL/APPLY

--- a/arangod/Aql/AstNode.cpp
+++ b/arangod/Aql/AstNode.cpp
@@ -1634,15 +1634,19 @@ bool AstNode::willUseV8() const {
 
     if (func->name == "CALL" || func->name == "APPLY") {
       // CALL and APPLY can call arbitrary other functions...
-      if (numMembers() > 0 && getMemberUnchecked(0)->isStringValue()) {
-        auto s = getMemberUnchecked(0)->getStringView();
-        if (s.find(':') != std::string::npos) {
+      if (numMembers() > 0 && getMemberUnchecked(0)->isArray() &&
+          getMemberUnchecked(0)->numMembers() > 0 &&
+          getMemberUnchecked(0)->getMemberUnchecked(0)->isStringValue()) {
+        if (auto s =
+                getMemberUnchecked(0)->getMemberUnchecked(0)->getStringView();
+            s.find(':') != std::string::npos) {
           // a user-defined function.
           // this will use V8
           setFlag(DETERMINED_V8, VALUE_V8);
           return true;
         }
-        // fallthrough intentional
+        // fallthrough intentional. additionally inspect the function call
+        // parameters for CALL/APPLY
       } else {
         // we are unsure about what function will be called by
         // CALL and APPLY. We cannot rule out user-defined functions,
@@ -1653,6 +1657,7 @@ bool AstNode::willUseV8() const {
     }
   }
 
+  // inspect all subnodes
   size_t const n = numMembers();
 
   for (size_t i = 0; i < n; ++i) {

--- a/arangod/Aql/ExecutionNode.cpp
+++ b/arangod/Aql/ExecutionNode.cpp
@@ -2065,7 +2065,7 @@ void CalculationNode::doToVelocyPack(velocypack::Builder& nodes,
                 nodes.add(
                     "cacheable",
                     VPackValue(func->hasFlag(Function::Flags::Cacheable)));
-                nodes.add("usesV8", VPackValue(func->hasV8Implementation()));
+                nodes.add("usesV8", VPackValue(node->willUseV8()));
                 // deprecated
                 nodes.add("canRunOnDBServer",
                           VPackValue(func->hasFlag(

--- a/arangod/Aql/Expression.cpp
+++ b/arangod/Aql/Expression.cpp
@@ -978,8 +978,9 @@ AqlValue Expression::executeSimpleExpressionFCallJS(ExpressionContext& ctx,
     if (v8g == nullptr) {
       THROW_ARANGO_EXCEPTION_MESSAGE(
           TRI_ERROR_INTERNAL,
-          absl::StrCat("no V8 context available when executing call to ",
-                       jsName));
+          absl::StrCat(
+              "no V8 context available when executing call to function ",
+              jsName));
     }
 
     VPackOptions const& options = ctx.trx().vpackOptions();

--- a/arangod/Aql/Expression.cpp
+++ b/arangod/Aql/Expression.cpp
@@ -964,7 +964,23 @@ AqlValue Expression::executeSimpleExpressionFCallJS(ExpressionContext& ctx,
     ISOLATE;
     TRI_ASSERT(isolate != nullptr);
     TRI_V8_CURRENT_GLOBALS_AND_SCOPE;
-    auto context = TRI_IGETC;
+
+    std::string jsName;
+    if (node->type == NODE_TYPE_FCALL_USER) {
+      jsName = "FCALL_USER";
+    } else {
+      auto func = static_cast<Function*>(node->getData());
+      TRI_ASSERT(func != nullptr);
+      TRI_ASSERT(func->hasV8Implementation());
+      jsName = "AQL_" + func->name;
+    }
+
+    if (v8g == nullptr) {
+      THROW_ARANGO_EXCEPTION_MESSAGE(
+          TRI_ERROR_INTERNAL,
+          absl::StrCat("no V8 context available when executing call to ",
+                       jsName));
+    }
 
     VPackOptions const& options = ctx.trx().vpackOptions();
 
@@ -973,14 +989,13 @@ AqlValue Expression::executeSimpleExpressionFCallJS(ExpressionContext& ctx,
     auto sg =
         arangodb::scopeGuard([&]() noexcept { v8g->_expressionContext = old; });
 
-    std::string jsName;
     size_t const n = member->numMembers();
     size_t callArgs = (node->type == NODE_TYPE_FCALL_USER ? 2 : n);
     auto args = std::make_unique<v8::Handle<v8::Value>[]>(callArgs);
 
     if (node->type == NODE_TYPE_FCALL_USER) {
       // a call to a user-defined function
-      jsName = "FCALL_USER";
+      auto context = TRI_IGETC;
       v8::Handle<v8::Array> params =
           v8::Array::New(isolate, static_cast<int>(n));
 
@@ -1006,7 +1021,6 @@ AqlValue Expression::executeSimpleExpressionFCallJS(ExpressionContext& ctx,
       auto func = static_cast<Function*>(node->getData());
       TRI_ASSERT(func != nullptr);
       TRI_ASSERT(func->hasV8Implementation());
-      jsName = "AQL_" + func->name;
 
       for (size_t i = 0; i < n; ++i) {
         auto arg = member->getMemberUnchecked(i);

--- a/arangod/Aql/Function.cpp
+++ b/arangod/Aql/Function.cpp
@@ -73,7 +73,9 @@ Function::Function(std::string const& name, char const* arguments,
 
   // only the V8 function does not have a C++ implementation.
   // don't ever change this!
-  TRI_ASSERT(hasCxxImplementation() || name == "V8" || name == "CUSTOMSCORER")
+  // note: CUSTOMSCORER and INVALID are only used by unit tests
+  TRI_ASSERT(hasCxxImplementation() || name == "V8" || name == "CUSTOMSCORER" ||
+             name == "INVALID")
       << "unexpected AQL function without C++ implementation: " << name;
 }
 

--- a/arangod/Aql/Function.cpp
+++ b/arangod/Aql/Function.cpp
@@ -73,7 +73,8 @@ Function::Function(std::string const& name, char const* arguments,
 
   // only the V8 function does not have a C++ implementation.
   // don't ever change this!
-  TRI_ASSERT(hasCxxImplementation() || name == "V8");
+  TRI_ASSERT(hasCxxImplementation() || name == "V8" || name == "CUSTOMSCORER")
+      << "unexpected AQL function without C++ implementation: " << name;
 }
 
 #ifdef ARANGODB_USE_GOOGLE_TESTS

--- a/arangod/Aql/Function.cpp
+++ b/arangod/Aql/Function.cpp
@@ -70,6 +70,10 @@ Function::Function(std::string const& name, char const* arguments,
   // functions that read documents are not usable in analyzers.
   TRI_ASSERT(!hasFlag(Flags::CanReadDocuments) ||
              !hasFlag(Flags::CanUseInAnalyzer));
+
+  // only the V8 function does not have a C++ implementation.
+  // don't ever change this!
+  TRI_ASSERT(hasCxxImplementation() || name == "V8");
 }
 
 #ifdef ARANGODB_USE_GOOGLE_TESTS

--- a/arangod/Aql/Functions.cpp
+++ b/arangod/Aql/Functions.cpp
@@ -89,6 +89,8 @@
 #include "utils/ngram_match_utils.hpp"
 #include "utils/utf8_utils.hpp"
 
+#include <absl/strings/str_cat.h>
+
 #include <boost/uuid/uuid.hpp>
 #include <boost/uuid/uuid_generators.hpp>
 #include <boost/uuid/uuid_io.hpp>
@@ -1136,6 +1138,12 @@ AqlValue callApplyBackend(ExpressionContext* expressionContext,
   // JavaScript function (this includes user-defined functions)
   {
     ISOLATE;
+    if (isolate == nullptr) {
+      THROW_ARANGO_EXCEPTION_MESSAGE(
+          TRI_ERROR_INTERNAL,
+          absl::StrCat(
+              "no V8 context available when executing call to function ", AFN));
+    }
     TRI_V8_CURRENT_GLOBALS_AND_SCOPE;
     auto context = TRI_IGETC;
 

--- a/arangod/Transaction/V8Context.cpp
+++ b/arangod/Transaction/V8Context.cpp
@@ -28,9 +28,9 @@
 #include "Transaction/StandaloneContext.h"
 #include "Utils/CollectionNameResolver.h"
 #include "V8Server/V8DealerFeature.h"
+#include "V8/v8-globals.h"
 
 #include <v8.h>
-#include "V8/v8-globals.h"
 
 using namespace arangodb;
 
@@ -94,6 +94,11 @@ transaction::V8Context::acquireState(transaction::Options const& options,
 void transaction::V8Context::enterV8Context() {
   // registerTransaction
   auto v8g = getV8State();
+  if (v8g == nullptr) {
+    THROW_ARANGO_EXCEPTION_MESSAGE(
+        TRI_ERROR_INTERNAL,
+        "no v8 context available to enter for current transaction context");
+  }
   TRI_ASSERT(v8g != nullptr);
 
   TRI_ASSERT(_currentTransaction != nullptr);

--- a/tests/js/common/aql/aql-view-arangosearch-cluster.inc
+++ b/tests/js/common/aql/aql-view-arangosearch-cluster.inc
@@ -278,7 +278,7 @@
 
       testV8FunctionInSearch: function () {
         try {
-          db._query("FOR doc IN CompoundView SEARCH doc.a == 'foo' && APPLY('LOWER', 'abc') == 'ABC' OPTIONS { waitForSync: true } RETURN doc");
+          db._query("FOR doc IN CompoundView SEARCH doc.a == 'foo' && V8('abc') == 'ABC' OPTIONS { waitForSync: true } RETURN doc");
           fail();
         } catch (e) {
           assertEqual(ERRORS.ERROR_NOT_IMPLEMENTED.code, e.errorNum);

--- a/tests/js/common/aql/aql-view-arangosearch-common-noncluster.inc
+++ b/tests/js/common/aql/aql-view-arangosearch-common-noncluster.inc
@@ -127,7 +127,7 @@ return function (args) {
 
     testV8FunctionInSearch: function () {
       try {
-        db._query("FOR doc IN CompoundView SEARCH doc.a == 'foo' && APPLY('LOWER', 'abc') == 'ABC' OPTIONS { waitForSync: true } RETURN doc");
+        db._query("FOR doc IN CompoundView SEARCH doc.a == 'foo' && V8('abc') == 'ABC' OPTIONS { waitForSync: true } RETURN doc");
         fail();
       } catch (e) {
         assertEqual(ERRORS.ERROR_NOT_IMPLEMENTED.code, e.errorNum);

--- a/tests/js/server/aql/aql-multiple-snippets-javascript-cluster.js
+++ b/tests/js/server/aql/aql-multiple-snippets-javascript-cluster.js
@@ -1,0 +1,138 @@
+/*jshint globalstrict:false, strict:false, maxlen: 400 */
+/*global fail, assertEqual, assertMatch, AQL_EXECUTE, AQL_EXPLAIN */
+
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2010-2012 triagens GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is triAGENS GmbH, Cologne, Germany
+///
+/// @author Jan Steemann
+/// @author Copyright 2012, triAGENS GmbH, Cologne, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+const jsunity = require("jsunity");
+const arangodb = require("@arangodb");
+const db = arangodb.db;
+const errors = require("internal").errors;
+
+function MultipleSnippetsInCoordinatorSuite () {
+  'use strict';
+  const cn = "UnitTestsSnippets";
+  
+  return {
+    setUpAll: function () {
+      db._drop(cn);
+      db._create(cn, { numberOfShards: 3 });
+    },
+
+    tearDownAll: function () {
+      db._drop(cn);
+    },
+
+    // tests an issue reported via OASIS-24962:
+    // when a query is started from within some JavaScript environment
+    // (e.g. console mode or Foxx) and has multiple coordinator snippets,
+    // only the outermost coordinator snippet can make use of the
+    // JavaScript V8 context. The other generated coordinator snippets
+    // will believe that they also have access to the JavaScript V8
+    // context of the other snippet, but in fact they don't. The problem
+    // exists because the Query object is shared among coordinator
+    // snippets. Once this is fixed properly, this test should stop
+    // failing.
+    testMultipleCoordinatorSnippetsJavaScriptProblem: function () {
+      const query = `
+LET x = NOOPT(V8(['a', 'b', 'c']))
+LET q1 = (LET values = V8(x) FOR doc IN @@cn RETURN doc._key IN values)
+LET q2 = (LET values = V8(x) FOR doc IN @@cn RETURN doc._key IN values)
+RETURN MERGE({}, q1, q2)
+`;
+      
+      // verify that we actually have multiple coordinator snippets
+      let nodes = AQL_EXPLAIN(query, { "@cn": cn }).plan.nodes.map((n) => n.type);
+      const expected = [ "SingletonNode", "CalculationNode", "CalculationNode", "SubqueryStartNode", "ScatterNode", "RemoteNode", "IndexNode", "CalculationNode", "RemoteNode", "GatherNode", "SubqueryEndNode", "SubqueryStartNode", "ScatterNode", "RemoteNode", "IndexNode", "CalculationNode", "RemoteNode", "GatherNode", "SubqueryEndNode", "CalculationNode", "ReturnNode" ];
+      assertEqual(expected, nodes);
+
+      let remotes = 0;
+      nodes.forEach((n) => { if (n === 'RemoteNode') { remotes++; } });
+      assertEqual(4, remotes);
+
+      try {
+        // query execution must fail because we have multiple coordinator
+        // snippets that will use JavaScript, but only one of them actually has
+        // a JavaScript context attached
+        AQL_EXECUTE(query, { "@cn": cn });
+        fail();
+      } catch (err) {
+        assertMatch(/no v8 context available to enter for current transaction context/, err.errorMessage);
+        assertEqual(errors.ERROR_INTERNAL.code, err.errorNum);
+      }
+    },
+    
+    testMultipleCoordinatorSnippetsNoJavaScriptNeededExceptForOutermostSnippet: function () {
+      const query = `
+LET x = NOOPT(['a', 'b', 'c'])
+LET q1 = (LET values = NOOPT(x) FOR doc IN @@cn RETURN doc._key IN values)
+LET q2 = (LET values = NOOPT(x) FOR doc IN @@cn RETURN doc._key IN values)
+RETURN V8(APPEND(q1, q2))
+`;
+      
+      // verify that we actually have multiple coordinator snippets
+      let nodes = AQL_EXPLAIN(query, { "@cn": cn }).plan.nodes.map((n) => n.type);
+      const expected = [ "SingletonNode", "CalculationNode", "SubqueryStartNode", "CalculationNode", "ScatterNode", "RemoteNode", "IndexNode", "CalculationNode", "RemoteNode", "GatherNode", "SubqueryEndNode", "SubqueryStartNode", "CalculationNode", "ScatterNode", "RemoteNode", "IndexNode", "CalculationNode", "RemoteNode", "GatherNode", "SubqueryEndNode", "CalculationNode", "ReturnNode" ];
+
+      let remotes = 0;
+      nodes.forEach((n) => { if (n === 'RemoteNode') { remotes++; } });
+      assertEqual(4, remotes);
+
+      // query execution for this query should work because only the outermost
+      // snippet requires JavaScript
+      let result = AQL_EXECUTE(query, { "@cn": cn }).json;
+      // results don't matter. all that counts is that we don't run into an error
+      // during query execution
+      assertEqual([[]], result);
+    },
+    
+    testMultipleCoordinatorSnippetsNoJavaScriptNeeded: function () {
+      const query = `
+LET x = NOOPT(['a', 'b', 'c'])
+LET q1 = (LET values = NOOPT(x) FOR doc IN @@cn RETURN doc._key IN values)
+LET q2 = (LET values = NOOPT(x) FOR doc IN @@cn RETURN doc._key IN values)
+RETURN APPEND(q1, q2)
+`;
+      
+      // verify that we actually have multiple coordinator snippets
+      let nodes = AQL_EXPLAIN(query, { "@cn": cn }).plan.nodes.map((n) => n.type);
+      const expected = [ "SingletonNode", "CalculationNode", "SubqueryStartNode", "CalculationNode", "ScatterNode", "RemoteNode", "IndexNode", "CalculationNode", "RemoteNode", "GatherNode", "SubqueryEndNode", "SubqueryStartNode", "CalculationNode", "ScatterNode", "RemoteNode", "IndexNode", "CalculationNode", "RemoteNode", "GatherNode", "SubqueryEndNode", "CalculationNode", "ReturnNode" ];
+
+      let remotes = 0;
+      nodes.forEach((n) => { if (n === 'RemoteNode') { remotes++; } });
+      assertEqual(4, remotes);
+
+      // query execution for this query should work because only the outermost
+      // snippet requires JavaScript
+      let result = AQL_EXECUTE(query, { "@cn": cn }).json;
+      // results don't matter. all that counts is that we don't run into an error
+      // during query execution
+      assertEqual([[]], result);
+    },
+  
+  };
+}
+ 
+jsunity.run(MultipleSnippetsInCoordinatorSuite);
+
+return jsunity.done();


### PR DESCRIPTION
### Scope & Purpose

Fix coordinator segfault in AQL queries in which the query is invoked from within a JavaScript context (e.g. from Foxx or from the server's console mode) **and** the query has multiple coordinator snippets of which except the outermost one invokes a JavaScript function. 
Instead of crashing, coordinators will now respond with the exception "no v8 context available to enter for current transaction context". 

For AQL queries that called one of the AQL functions `CALL` or `APPLY` with a fixed function name, e.g. `APPLY('CONCAT', ...)`, it is now also assumed correctly that no JavaScript is needed if the fixed function name refers to a built-in function, and if the function call parameters also don't require the usage of JavaScript.

A follow-up PR will fix that multiple coordinator snippets refer to the same `Query` instance and share information about the query's V8 context invocation.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [x] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.10: https://github.com/arangodb/arangodb/pull/17953
  - [x] Backport for 3.9: https://github.com/arangodb/arangodb/pull/17955
  - [x] Backport for 3.8: https://github.com/arangodb/arangodb/pull/17956

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [x] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/OASIS-24962
- [ ] Design document: 