### PR TITLE
Fix OASIS-24962

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,19 @@
+v3.9.8 (XXXX-XX-XX)
+-------------------
+
+* Fix coordinator segfault in AQL queries in which the query is invoked from
+  within a JavaScript context (e.g. from Foxx or from the server's console
+  mode) **and** the query has multiple coordinator snippets of which except
+  the outermost one invokes a JavaScript function.
+  Instead of crashing, coordinators will now respond with the exception 
+  "no v8 context available to enter for current transaction context".
+  For AQL queries that called one of the AQL functions `CALL` or `APPLY` with
+  a fixed function name, e.g. `APPLY('CONCAT', ...)`, it is now also assumed
+  correctly that no JavaScript is needed, except if the fixed function name
+  is the name of a user-defined function.
+  This fixes an issue described in OASIS-24962.
+
+
 v3.9.7 (2023-01-10)
 -------------------
 

--- a/arangod/Aql/AstNode.cpp
+++ b/arangod/Aql/AstNode.cpp
@@ -1703,15 +1703,19 @@ bool AstNode::willUseV8() const {
 
     if (func->name == "CALL" || func->name == "APPLY") {
       // CALL and APPLY can call arbitrary other functions...
-      if (numMembers() > 0 && getMemberUnchecked(0)->isStringValue()) {
-        auto s = getMemberUnchecked(0)->getStringRef();
-        if (s.find(':') != std::string::npos) {
+      if (numMembers() > 0 && getMemberUnchecked(0)->isArray() &&
+          getMemberUnchecked(0)->numMembers() > 0 &&
+          getMemberUnchecked(0)->getMemberUnchecked(0)->isStringValue()) {
+        if (auto s =
+                getMemberUnchecked(0)->getMemberUnchecked(0)->getStringRef();
+            s.find(':') != std::string::npos) {
           // a user-defined function.
           // this will use V8
           setFlag(DETERMINED_V8, VALUE_V8);
           return true;
         }
-        // fallthrough intentional
+        // fallthrough intentional. additionally inspect the function call
+        // parameters for CALL/APPLY
       } else {
         // we are unsure about what function will be called by
         // CALL and APPLY. We cannot rule out user-defined functions,
@@ -1722,6 +1726,7 @@ bool AstNode::willUseV8() const {
     }
   }
 
+  // inspect all subnodes
   size_t const n = numMembers();
 
   for (size_t i = 0; i < n; ++i) {

--- a/arangod/Aql/ExecutionNode.cpp
+++ b/arangod/Aql/ExecutionNode.cpp
@@ -1947,7 +1947,7 @@ void CalculationNode::doToVelocyPack(VPackBuilder& nodes,
                 nodes.add(
                     "cacheable",
                     VPackValue(func->hasFlag(Function::Flags::Cacheable)));
-                nodes.add("usesV8", VPackValue(func->hasV8Implementation()));
+                nodes.add("usesV8", VPackValue(node->willUseV8()));
                 // deprecated
                 nodes.add("canRunOnDBServer",
                           VPackValue(func->hasFlag(

--- a/arangod/Aql/Expression.cpp
+++ b/arangod/Aql/Expression.cpp
@@ -971,7 +971,23 @@ AqlValue Expression::executeSimpleExpressionFCallJS(AstNode const* node,
     ISOLATE;
     TRI_ASSERT(isolate != nullptr);
     TRI_V8_CURRENT_GLOBALS_AND_SCOPE;
-    auto context = TRI_IGETC;
+
+    std::string jsName;
+    if (node->type == NODE_TYPE_FCALL_USER) {
+      jsName = "FCALL_USER";
+    } else {
+      auto func = static_cast<Function*>(node->getData());
+      TRI_ASSERT(func != nullptr);
+      TRI_ASSERT(func->hasV8Implementation());
+      jsName = "AQL_" + func->name;
+    }
+
+    if (v8g == nullptr) {
+      THROW_ARANGO_EXCEPTION_MESSAGE(
+          TRI_ERROR_INTERNAL,
+          std::string("no V8 context available when executing call to ") +
+              jsName);
+    }
 
     VPackOptions const& options = _expressionContext->trx().vpackOptions();
 
@@ -980,14 +996,13 @@ AqlValue Expression::executeSimpleExpressionFCallJS(AstNode const* node,
     auto sg =
         arangodb::scopeGuard([&]() noexcept { v8g->_expressionContext = old; });
 
-    std::string jsName;
     size_t const n = member->numMembers();
     size_t callArgs = (node->type == NODE_TYPE_FCALL_USER ? 2 : n);
     auto args = std::make_unique<v8::Handle<v8::Value>[]>(callArgs);
 
     if (node->type == NODE_TYPE_FCALL_USER) {
       // a call to a user-defined function
-      jsName = "FCALL_USER";
+      auto context = TRI_IGETC;
       v8::Handle<v8::Array> params =
           v8::Array::New(isolate, static_cast<int>(n));
 
@@ -1013,7 +1028,6 @@ AqlValue Expression::executeSimpleExpressionFCallJS(AstNode const* node,
       auto func = static_cast<Function*>(node->getData());
       TRI_ASSERT(func != nullptr);
       TRI_ASSERT(func->hasV8Implementation());
-      jsName = "AQL_" + func->name;
 
       for (size_t i = 0; i < n; ++i) {
         auto arg = member->getMemberUnchecked(i);

--- a/arangod/Transaction/V8Context.cpp
+++ b/arangod/Transaction/V8Context.cpp
@@ -27,9 +27,9 @@
 #include "Transaction/StandaloneContext.h"
 #include "Utils/CollectionNameResolver.h"
 #include "V8Server/V8DealerFeature.h"
+#include "V8/v8-globals.h"
 
 #include <v8.h>
-#include "V8/v8-globals.h"
 
 using namespace arangodb;
 
@@ -93,6 +93,11 @@ transaction::V8Context::acquireState(transaction::Options const& options,
 void transaction::V8Context::enterV8Context() {
   // registerTransaction
   auto v8g = getV8State();
+  if (v8g == nullptr) {
+    THROW_ARANGO_EXCEPTION_MESSAGE(
+        TRI_ERROR_INTERNAL,
+        "no v8 context available to enter for current transaction context");
+  }
   TRI_ASSERT(v8g != nullptr);
 
   TRI_ASSERT(_currentTransaction != nullptr);

--- a/tests/js/common/aql/aql-view-arangosearch-cluster.inc
+++ b/tests/js/common/aql/aql-view-arangosearch-cluster.inc
@@ -269,7 +269,7 @@
 
       testV8FunctionInSearch: function () {
         try {
-          db._query("FOR doc IN CompoundView SEARCH doc.a == 'foo' && APPLY('LOWER', 'abc') == 'ABC' OPTIONS { waitForSync: true } RETURN doc");
+          db._query("FOR doc IN CompoundView SEARCH doc.a == 'foo' && V8('abc') == 'ABC' OPTIONS { waitForSync: true } RETURN doc");
           fail();
         } catch (e) {
           assertEqual(ERRORS.ERROR_NOT_IMPLEMENTED.code, e.errorNum);

--- a/tests/js/common/aql/aql-view-arangosearch-noncluster.js
+++ b/tests/js/common/aql/aql-view-arangosearch-noncluster.js
@@ -235,7 +235,7 @@ function iResearchAqlTestSuite () {
 
     testV8FunctionInSearch: function () {
       try {
-        db._query("FOR doc IN CompoundView SEARCH doc.a == 'foo' && APPLY('LOWER', 'abc') == 'ABC' OPTIONS { waitForSync: true } RETURN doc");
+        db._query("FOR doc IN CompoundView SEARCH doc.a == 'foo' && V8('abc') == 'ABC' OPTIONS { waitForSync: true } RETURN doc");
         fail();
       } catch (e) {
         assertEqual(ERRORS.ERROR_NOT_IMPLEMENTED.code, e.errorNum);

--- a/tests/js/server/aql/aql-multiple-snippets-javascript-cluster.js
+++ b/tests/js/server/aql/aql-multiple-snippets-javascript-cluster.js
@@ -1,0 +1,138 @@
+/*jshint globalstrict:false, strict:false, maxlen: 400 */
+/*global fail, assertEqual, assertMatch, AQL_EXECUTE, AQL_EXPLAIN */
+
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2010-2012 triagens GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is triAGENS GmbH, Cologne, Germany
+///
+/// @author Jan Steemann
+/// @author Copyright 2012, triAGENS GmbH, Cologne, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+const jsunity = require("jsunity");
+const arangodb = require("@arangodb");
+const db = arangodb.db;
+const errors = require("internal").errors;
+
+function MultipleSnippetsInCoordinatorSuite () {
+  'use strict';
+  const cn = "UnitTestsSnippets";
+  
+  return {
+    setUpAll: function () {
+      db._drop(cn);
+      db._create(cn, { numberOfShards: 3 });
+    },
+
+    tearDownAll: function () {
+      db._drop(cn);
+    },
+
+    // tests an issue reported via OASIS-24962:
+    // when a query is started from within some JavaScript environment
+    // (e.g. console mode or Foxx) and has multiple coordinator snippets,
+    // only the outermost coordinator snippet can make use of the
+    // JavaScript V8 context. The other generated coordinator snippets
+    // will believe that they also have access to the JavaScript V8
+    // context of the other snippet, but in fact they don't. The problem
+    // exists because the Query object is shared among coordinator
+    // snippets. Once this is fixed properly, this test should stop
+    // failing.
+    testMultipleCoordinatorSnippetsJavaScriptProblem: function () {
+      const query = `
+LET x = NOOPT(V8(['a', 'b', 'c']))
+LET q1 = (LET values = V8(x) FOR doc IN @@cn RETURN doc._key IN values)
+LET q2 = (LET values = V8(x) FOR doc IN @@cn RETURN doc._key IN values)
+RETURN MERGE({}, q1, q2)
+`;
+      
+      // verify that we actually have multiple coordinator snippets
+      let nodes = AQL_EXPLAIN(query, { "@cn": cn }).plan.nodes.map((n) => n.type);
+      const expected = [ "SingletonNode", "CalculationNode", "CalculationNode", "SubqueryStartNode", "ScatterNode", "RemoteNode", "IndexNode", "CalculationNode", "RemoteNode", "GatherNode", "SubqueryEndNode", "SubqueryStartNode", "ScatterNode", "RemoteNode", "IndexNode", "CalculationNode", "RemoteNode", "GatherNode", "SubqueryEndNode", "CalculationNode", "ReturnNode" ];
+      assertEqual(expected, nodes);
+
+      let remotes = 0;
+      nodes.forEach((n) => { if (n === 'RemoteNode') { remotes++; } });
+      assertEqual(4, remotes);
+
+      try {
+        // query execution must fail because we have multiple coordinator
+        // snippets that will use JavaScript, but only one of them actually has
+        // a JavaScript context attached
+        AQL_EXECUTE(query, { "@cn": cn });
+        fail();
+      } catch (err) {
+        assertMatch(/no v8 context available to enter for current transaction context/, err.errorMessage);
+        assertEqual(errors.ERROR_INTERNAL.code, err.errorNum);
+      }
+    },
+    
+    testMultipleCoordinatorSnippetsNoJavaScriptNeededExceptForOutermostSnippet: function () {
+      const query = `
+LET x = NOOPT(['a', 'b', 'c'])
+LET q1 = (LET values = NOOPT(x) FOR doc IN @@cn RETURN doc._key IN values)
+LET q2 = (LET values = NOOPT(x) FOR doc IN @@cn RETURN doc._key IN values)
+RETURN V8(APPEND(q1, q2))
+`;
+      
+      // verify that we actually have multiple coordinator snippets
+      let nodes = AQL_EXPLAIN(query, { "@cn": cn }).plan.nodes.map((n) => n.type);
+      const expected = [ "SingletonNode", "CalculationNode", "SubqueryStartNode", "CalculationNode", "ScatterNode", "RemoteNode", "IndexNode", "CalculationNode", "RemoteNode", "GatherNode", "SubqueryEndNode", "SubqueryStartNode", "CalculationNode", "ScatterNode", "RemoteNode", "IndexNode", "CalculationNode", "RemoteNode", "GatherNode", "SubqueryEndNode", "CalculationNode", "ReturnNode" ];
+
+      let remotes = 0;
+      nodes.forEach((n) => { if (n === 'RemoteNode') { remotes++; } });
+      assertEqual(4, remotes);
+
+      // query execution for this query should work because only the outermost
+      // snippet requires JavaScript
+      let result = AQL_EXECUTE(query, { "@cn": cn }).json;
+      // results don't matter. all that counts is that we don't run into an error
+      // during query execution
+      assertEqual([[]], result);
+    },
+    
+    testMultipleCoordinatorSnippetsNoJavaScriptNeeded: function () {
+      const query = `
+LET x = NOOPT(['a', 'b', 'c'])
+LET q1 = (LET values = NOOPT(x) FOR doc IN @@cn RETURN doc._key IN values)
+LET q2 = (LET values = NOOPT(x) FOR doc IN @@cn RETURN doc._key IN values)
+RETURN APPEND(q1, q2)
+`;
+      
+      // verify that we actually have multiple coordinator snippets
+      let nodes = AQL_EXPLAIN(query, { "@cn": cn }).plan.nodes.map((n) => n.type);
+      const expected = [ "SingletonNode", "CalculationNode", "SubqueryStartNode", "CalculationNode", "ScatterNode", "RemoteNode", "IndexNode", "CalculationNode", "RemoteNode", "GatherNode", "SubqueryEndNode", "SubqueryStartNode", "CalculationNode", "ScatterNode", "RemoteNode", "IndexNode", "CalculationNode", "RemoteNode", "GatherNode", "SubqueryEndNode", "CalculationNode", "ReturnNode" ];
+
+      let remotes = 0;
+      nodes.forEach((n) => { if (n === 'RemoteNode') { remotes++; } });
+      assertEqual(4, remotes);
+
+      // query execution for this query should work because only the outermost
+      // snippet requires JavaScript
+      let result = AQL_EXECUTE(query, { "@cn": cn }).json;
+      // results don't matter. all that counts is that we don't run into an error
+      // during query execution
+      assertEqual([[]], result);
+    },
+  
+  };
+}
+ 
+jsunity.run(MultipleSnippetsInCoordinatorSuite);
+
+return jsunity.done();


### PR DESCRIPTION
### Scope & Purpose


Backport of https://github.com/arangodb/arangodb/pull/17954

Fix coordinator segfault in AQL queries in which the query is invoked from within a JavaScript context (e.g. from Foxx or from the server's console mode) **and** the query has multiple coordinator snippets of which except the outermost one invokes a JavaScript function. 
Instead of crashing, coordinators will now respond with the exception "no v8 context available to enter for current transaction context". 

For AQL queries that called one of the AQL functions `CALL` or `APPLY` with a fixed function name, e.g. `APPLY('CONCAT', ...)`, it is now also assumed correctly that no JavaScript is needed if the fixed function name refers to a built-in function, and if the function call parameters also don't require the usage of JavaScript.

A follow-up PR will fix that multiple coordinator snippets refer to the same `Query` instance and share information about the query's V8 context invocation.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [x] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.10: https://github.com/arangodb/arangodb/pull/17953
  - [x] Backport for 3.9: this PR
  - [x] Backport for 3.8: 

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [x] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/OASIS-24962
- [ ] Design document: 

