### PR TITLE
log crash info in tests

### DIFF
--- a/js/client/modules/@arangodb/testutils/instance.js
+++ b/js/client/modules/@arangodb/testutils/instance.js
@@ -371,7 +371,7 @@ class instance {
     if (this.options.verbose) {
       this.args['log.level'] = 'debug';
     } else if (this.options.noStartStopLogs) {
-      let logs = ['all=error'];
+      let logs = ['all=error', 'crash=info'];
       if (this.args['log.level'] !== undefined) {
         if (Array.isArray(this.args['log.level'])) {
           logs = logs.concat(this.args['log.level']);


### PR DESCRIPTION
### Scope & Purpose

By default, crash info and crash stack traces are suppressed during test execution, because for test execution the log verbosity for all log topics is set to `error`.
This PR fixes that by explicitly setting the log verbosity for the `crash` log topic to `info`.
This PR only affects logging during test execution, and thus only has impact on tests.

The change contained in this PR has already been made in devel before.
3.9 and 3.8 do not need this change, because test execution is very verbose in these branches anyway.

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.10: this PR
  - [ ] Backport for 3.9: not necessary
  - [ ] Backport for 3.8: not necessary

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 