### PR TITLE
fix failing test, next attempt

### DIFF
--- a/tests/js/client/server_parameters/auto-refill-index-caches-on-modify-noncluster-off.js
+++ b/tests/js/client/server_parameters/auto-refill-index-caches-on-modify-noncluster-off.js
@@ -37,7 +37,6 @@ if (getOptions === true) {
 const db = require('@arangodb').db;
 const jsunity = require('jsunity');
 const getMetric = require('@arangodb/test-helper').getMetricSingle;
-const time = require('internal').time;
 
 const cn = 'UnitTestsCollection';
 const n = 5000;
@@ -45,6 +44,31 @@ const n = 5000;
 const waitForPendingRefills = () => {
   // wait for pending refill operations to have finished, using an informal API
   arango.POST('/_api/index/sync-caches', {});
+};
+  
+const runWithRetry = (cb) => {
+  let tries = 0;
+  while (true) {
+    try {
+      cb();
+      // return upon first successful execution of the callback function
+      return;
+    } catch (err) {
+      // if it fails, check how many failures we got. fail only if we failed
+      // 3 times in a row
+      if (tries++ === 3) {
+        throw err;
+      }
+      // attempt failed. this can happen because inserting data into
+      // the cache can fail under the following circumstances:
+      // - cache global budget exceeded
+      // - cache hash table migration in progress
+
+      // start over...
+      db[cn].truncate();
+      require("internal").sleep(2);
+    }
+  }
 };
 
 function AutoRefillIndexCachesEdge() {
@@ -142,12 +166,14 @@ function AutoRefillIndexCachesEdge() {
     },
     
     testInsertEdgeEnabled: function() {
-      const oldValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
-      db._query(`FOR i IN 0..${n - 1} INSERT {_from: CONCAT('v/test', i), _to: CONCAT('v/test', (i % 25))} INTO ${cn} OPTIONS { refillIndexCaches: true }`);
-      const newValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
+      runWithRetry(() => {
+        const oldValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
+        db._query(`FOR i IN 0..${n - 1} INSERT {_from: CONCAT('v/test', i), _to: CONCAT('v/test', (i % 25))} INTO ${cn} OPTIONS { refillIndexCaches: true }`);
+        const newValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
 
-      assertTrue(newValue - oldValue >= n, { oldValue, newValue });
-      runCheck(true);
+        assertTrue(newValue - oldValue >= n, { oldValue, newValue });
+        runCheck(true);
+      });
     },
     
     testUpdateEdgeDefault: function() {
@@ -177,14 +203,16 @@ function AutoRefillIndexCachesEdge() {
     },
     
     testUpdateEdgeEnabled: function() {
-      insertInitialEdges();
+      runWithRetry(() => {
+        insertInitialEdges();
 
-      const oldValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
-      db._query(`FOR doc IN ${cn} UPDATE doc WITH {value: doc.value + 1} INTO ${cn} OPTIONS { refillIndexCaches: true }`);
-      const newValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
+        const oldValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
+        db._query(`FOR doc IN ${cn} UPDATE doc WITH {value: doc.value + 1} INTO ${cn} OPTIONS { refillIndexCaches: true }`);
+        const newValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
 
-      assertTrue(newValue - oldValue >= n, { oldValue, newValue });
-      runCheck(true);
+        assertTrue(newValue - oldValue >= n, { oldValue, newValue });
+        runCheck(true);
+      });
     },
     
     testReplaceEdgeDefault: function() {
@@ -214,14 +242,16 @@ function AutoRefillIndexCachesEdge() {
     },
     
     testReplaceEdgeEnabled: function() {
-      insertInitialEdges();
+      runWithRetry(() => {
+        insertInitialEdges();
 
-      const oldValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
-      db._query(`FOR doc IN ${cn} REPLACE doc WITH {_from: doc._from, _to: doc._to, value: doc.value + 1} INTO ${cn} OPTIONS { refillIndexCaches: true }`);
-      const newValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
+        const oldValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
+        db._query(`FOR doc IN ${cn} REPLACE doc WITH {_from: doc._from, _to: doc._to, value: doc.value + 1} INTO ${cn} OPTIONS { refillIndexCaches: true }`);
+        const newValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
 
-      assertTrue(newValue - oldValue >= n, { oldValue, newValue });
-      runCheck(true);
+        assertTrue(newValue - oldValue >= n, { oldValue, newValue });
+        runCheck(true);
+      });
     },
     
     testRemoveEdgeDefault: function() {
@@ -251,14 +281,16 @@ function AutoRefillIndexCachesEdge() {
     },
     
     testRemoveEdgeEnabled: function() {
-      insertInitialEdges();
+      runWithRetry(() => {
+        insertInitialEdges();
 
-      const oldValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
-      db._query(`FOR i IN 0..${n / 2 - 1} REMOVE CONCAT('test', i) INTO ${cn} OPTIONS { refillIndexCaches: true }`);
-      const newValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
+        const oldValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
+        db._query(`FOR i IN 0..${n / 2 - 1} REMOVE CONCAT('test', i) INTO ${cn} OPTIONS { refillIndexCaches: true }`);
+        const newValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
 
-      assertTrue(newValue - oldValue >= n / 2, { oldValue, newValue });
-      runRemoveCheck(true);
+        assertTrue(newValue - oldValue >= n / 2, { oldValue, newValue });
+        runRemoveCheck(true);
+      });
     },
     
   };
@@ -327,13 +359,15 @@ function AutoRefillIndexCachesVPack() {
     },
     
     testInsertVPackEnabled: function() {
-      const oldValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
-      db._query(`FOR i IN 0..${n - 1} INSERT {value: i} INTO ${cn} OPTIONS { refillIndexCaches: true }`);
-      const newValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
+      runWithRetry(() => {
+        const oldValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
+        db._query(`FOR i IN 0..${n - 1} INSERT {value: i} INTO ${cn} OPTIONS { refillIndexCaches: true }`);
+        const newValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
 
-      assertTrue(newValue - oldValue >= n, { oldValue, newValue });
-      waitForPendingRefills();
-      runCheck(0, true);
+        assertTrue(newValue - oldValue >= n, { oldValue, newValue });
+        waitForPendingRefills();
+        runCheck(0, true);
+      });
     },
     
     testUpdateVPackDefault: function() {
@@ -363,14 +397,16 @@ function AutoRefillIndexCachesVPack() {
     },
     
     testUpdateVPackEnabled: function() {
-      db._query(`FOR i IN 0..${n - 1} INSERT {value: i} INTO ${cn}`);
-      const oldValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
-      db._query(`FOR doc IN ${cn} UPDATE doc WITH {value: doc.value + 1} INTO ${cn} OPTIONS { refillIndexCaches: true }`);
-      const newValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
+      runWithRetry(() => {
+        db._query(`FOR i IN 0..${n - 1} INSERT {value: i} INTO ${cn}`);
+        const oldValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
+        db._query(`FOR doc IN ${cn} UPDATE doc WITH {value: doc.value + 1} INTO ${cn} OPTIONS { refillIndexCaches: true }`);
+        const newValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
 
-      assertTrue(newValue - oldValue >= n, { oldValue, newValue });
-      waitForPendingRefills();
-      runCheck(1, true);
+        assertTrue(newValue - oldValue >= n, { oldValue, newValue });
+        waitForPendingRefills();
+        runCheck(1, true);
+      });
     },
     
     testReplaceVPackDefault: function() {
@@ -398,14 +434,16 @@ function AutoRefillIndexCachesVPack() {
     },
     
     testReplaceVPackEnabled: function() {
-      db._query(`FOR i IN 0..${n - 1} INSERT {value: i} INTO ${cn}`);
-      const oldValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
-      db._query(`FOR doc IN ${cn} REPLACE doc WITH {value: doc.value + 1} INTO ${cn} OPTIONS { refillIndexCaches: true }`);
-      const newValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
+      runWithRetry(() => {
+        db._query(`FOR i IN 0..${n - 1} INSERT {value: i} INTO ${cn}`);
+        const oldValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
+        db._query(`FOR doc IN ${cn} REPLACE doc WITH {value: doc.value + 1} INTO ${cn} OPTIONS { refillIndexCaches: true }`);
+        const newValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
 
-      assertTrue(newValue - oldValue >= n, { oldValue, newValue });
-      waitForPendingRefills();
-      runCheck(1, true);
+        assertTrue(newValue - oldValue >= n, { oldValue, newValue });
+        waitForPendingRefills();
+        runCheck(1, true);
+      });
     },
     
     testRemoveVPackDefault: function() {
@@ -433,14 +471,16 @@ function AutoRefillIndexCachesVPack() {
     },
     
     testRemoveVPackEnabled: function() {
-      db._query(`FOR i IN 0..${n - 1} INSERT {_key: CONCAT('test', i), value: i} INTO ${cn}`);
-      const oldValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
-      db._query(`FOR i IN 0..${n / 2 - 1} REMOVE CONCAT('test', i) INTO ${cn} OPTIONS { refillIndexCaches: true }`);
-      const newValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
+      runWithRetry(() => {
+        db._query(`FOR i IN 0..${n - 1} INSERT {_key: CONCAT('test', i), value: i} INTO ${cn}`);
+        const oldValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
+        db._query(`FOR i IN 0..${n / 2 - 1} REMOVE CONCAT('test', i) INTO ${cn} OPTIONS { refillIndexCaches: true }`);
+        const newValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
 
-      assertTrue(newValue - oldValue >= n / 2, { oldValue, newValue });
-      waitForPendingRefills();
-      runRemoveCheck(true);
+        assertTrue(newValue - oldValue >= n / 2, { oldValue, newValue });
+        waitForPendingRefills();
+        runRemoveCheck(true);
+      });
     },
 
   };

--- a/tests/js/client/server_parameters/auto-refill-index-caches-on-modify-noncluster-on.js
+++ b/tests/js/client/server_parameters/auto-refill-index-caches-on-modify-noncluster-on.js
@@ -37,7 +37,6 @@ if (getOptions === true) {
 const db = require('@arangodb').db;
 const jsunity = require('jsunity');
 const getMetric = require('@arangodb/test-helper').getMetricSingle;
-const time = require('internal').time;
 
 const cn = 'UnitTestsCollection';
 const n = 5000;
@@ -45,6 +44,31 @@ const n = 5000;
 const waitForPendingRefills = () => {
   // wait for pending refill operations to have finished, using an informal API
   arango.POST('/_api/index/sync-caches', {});
+};
+
+const runWithRetry = (cb) => {
+  let tries = 0;
+  while (true) {
+    try {
+      cb();
+      // return upon first successful execution of the callback function
+      return;
+    } catch (err) {
+      // if it fails, check how many failures we got. fail only if we failed
+      // 3 times in a row
+      if (tries++ === 3) {
+        throw err;
+      }
+      // attempt failed. this can happen because inserting data into
+      // the cache can fail under the following circumstances:
+      // - cache global budget exceeded
+      // - cache hash table migration in progress
+
+      // start over...
+      db[cn].truncate();
+      require("internal").sleep(2);
+    }
+  }
 };
 
 function AutoRefillIndexCachesEdge() {
@@ -120,12 +144,14 @@ function AutoRefillIndexCachesEdge() {
     },
     
     testInsertEdgeEnabled: function() {
-      const oldValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
-      db._query(`FOR i IN 0..${n - 1} INSERT {_from: CONCAT('v/test', i), _to: CONCAT('v/test', (i % 25))} INTO ${cn}`);
-      const newValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
+      runWithRetry(() => {
+        const oldValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
+        db._query(`FOR i IN 0..${n - 1} INSERT {_from: CONCAT('v/test', i), _to: CONCAT('v/test', (i % 25))} INTO ${cn}`);
+        const newValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
 
-      assertTrue(newValue - oldValue >= 2 * n, { oldValue, newValue });
-      runCheck(true);
+        assertTrue(newValue - oldValue >= 2 * n, { oldValue, newValue });
+        runCheck(true);
+      });
     },
     
     testInsertEdgeDisabled: function() {
@@ -140,14 +166,16 @@ function AutoRefillIndexCachesEdge() {
     },
     
     testUpdateEdgeEnabled: function() {
-      insertInitialEdges();
+      runWithRetry(() => {
+        insertInitialEdges();
       
-      const oldValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
-      db._query(`FOR doc IN ${cn} UPDATE doc WITH {value: doc.value + 1} INTO ${cn}`);
-      const newValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
+        const oldValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
+        db._query(`FOR doc IN ${cn} UPDATE doc WITH {value: doc.value + 1} INTO ${cn}`);
+        const newValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
 
-      assertTrue(newValue - oldValue >= 2 * n, { oldValue, newValue });
-      runCheck(true);
+        assertTrue(newValue - oldValue >= 2 * n, { oldValue, newValue });
+        runCheck(true);
+      });
     },
     
     testUpdateEdgeDisbled: function() {
@@ -164,14 +192,16 @@ function AutoRefillIndexCachesEdge() {
     },
     
     testReplaceEdgeEnabled: function() {
-      insertInitialEdges();
+      runWithRetry(() => {
+        insertInitialEdges();
 
-      const oldValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
-      db._query(`FOR doc IN ${cn} REPLACE doc WITH {_from: doc._from, _to: doc._to, value: doc.value + 1} INTO ${cn}`);
-      const newValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
+        const oldValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
+        db._query(`FOR doc IN ${cn} REPLACE doc WITH {_from: doc._from, _to: doc._to, value: doc.value + 1} INTO ${cn}`);
+        const newValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
 
-      assertTrue(newValue - oldValue >= 2 * n, { oldValue, newValue });
-      runCheck(true);
+        assertTrue(newValue - oldValue >= 2 * n, { oldValue, newValue });
+        runCheck(true);
+      });
     },
     
     testReplaceEdgeDisabled: function() {
@@ -188,14 +218,16 @@ function AutoRefillIndexCachesEdge() {
     },
     
     testRemoveEdgeEnabled: function() {
-      insertInitialEdges();
+      runWithRetry(() => {
+        insertInitialEdges();
 
-      const oldValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
-      db._query(`FOR i IN 0..${n / 2 - 1} REMOVE CONCAT('test', i) INTO ${cn}`);
-      const newValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
+        const oldValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
+        db._query(`FOR i IN 0..${n / 2 - 1} REMOVE CONCAT('test', i) INTO ${cn}`);
+        const newValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
 
-      assertTrue(newValue - oldValue >= n / 2, { oldValue, newValue });
-      runRemoveCheck(true);
+        assertTrue(newValue - oldValue >= n / 2, { oldValue, newValue });
+        runRemoveCheck(true);
+      });
     },
     
     testRemoveEdgeDisabled: function() {
@@ -305,12 +337,14 @@ function AutoRefillIndexCachesVPack() {
     testInsertVPackEnabled: function() {
       db[cn].ensureIndex({ type: "persistent", fields: ["value"], cacheEnabled: true });
 
-      const oldValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
-      db._query(`FOR i IN 0..${n - 1} INSERT {value: i} INTO ${cn}`);
-      const newValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
+      runWithRetry(() => {
+        const oldValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
+        db._query(`FOR i IN 0..${n - 1} INSERT {value: i} INTO ${cn}`);
+        const newValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
 
-      assertTrue(newValue - oldValue >= n, { oldValue, newValue });
-      runCheck(0, true);
+        assertTrue(newValue - oldValue >= n, { oldValue, newValue });
+        runCheck(0, true);
+      });
     },
     
     testUpdateVPackNoCache: function() {
@@ -343,14 +377,17 @@ function AutoRefillIndexCachesVPack() {
     
     testUpdateVPackEnabled: function() {
       db[cn].ensureIndex({ type: "persistent", fields: ["value"], cacheEnabled: true });
-      insertInitialDocuments();
+      
+      runWithRetry(() => {
+        insertInitialDocuments();
 
-      const oldValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
-      db._query(`FOR doc IN ${cn} UPDATE doc WITH {value: doc.value + 1} INTO ${cn}`);
-      const newValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
+        const oldValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
+        db._query(`FOR doc IN ${cn} UPDATE doc WITH {value: doc.value + 1} INTO ${cn}`);
+        const newValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
 
-      assertTrue(newValue - oldValue >= n, { oldValue, newValue });
-      runCheck(1, true);
+        assertTrue(newValue - oldValue >= n, { oldValue, newValue });
+        runCheck(1, true);
+      });
     },
     
     testReplaceVPackNoCache: function() {
@@ -383,14 +420,17 @@ function AutoRefillIndexCachesVPack() {
     
     testReplaceVPackEnabled: function() {
       db[cn].ensureIndex({ type: "persistent", fields: ["value"], cacheEnabled: true });
-      insertInitialDocuments();
+      
+      runWithRetry(() => {
+        insertInitialDocuments();
 
-      const oldValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
-      db._query(`FOR doc IN ${cn} REPLACE doc WITH {value: doc.value + 1} INTO ${cn}`);
-      const newValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
+        const oldValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
+        db._query(`FOR doc IN ${cn} REPLACE doc WITH {value: doc.value + 1} INTO ${cn}`);
+        const newValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
 
-      assertTrue(newValue - oldValue >= n, { oldValue, newValue });
-      runCheck(1, true);
+        assertTrue(newValue - oldValue >= n, { oldValue, newValue });
+        runCheck(1, true);
+      });
     },
     
     testRemoveVPackNoCache: function() {
@@ -423,14 +463,17 @@ function AutoRefillIndexCachesVPack() {
     
     testRemoveVPackEnabled: function() {
       db[cn].ensureIndex({ type: "persistent", fields: ["value"], cacheEnabled: true });
-      insertInitialDocuments();
+      
+      runWithRetry(() => {
+        insertInitialDocuments();
 
-      const oldValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
-      db._query(`FOR i IN 0..${n / 2 - 1} REMOVE CONCAT('test', i) INTO ${cn}`);
-      const newValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
+        const oldValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
+        db._query(`FOR i IN 0..${n / 2 - 1} REMOVE CONCAT('test', i) INTO ${cn}`);
+        const newValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
 
-      assertTrue(newValue - oldValue >= n / 2, { oldValue, newValue });
-      runRemoveCheck(true);
+        assertTrue(newValue - oldValue >= n / 2, { oldValue, newValue });
+        runRemoveCheck(true);
+      });
     },
 
   };


### PR DESCRIPTION
### Scope & Purpose

test-only bugfix

the previous version of the tests could sporadically fail if inserting data into the in-memory index caches failed. this is possible, because inserting index entries into the in-memory cache is not guaranteed to work. inserting into the cache will fail if:
- the global memory budget of the cache subsystem is exceeded
- the cache's underlying hash table is in a "migration" phase it is thus rarely possible that the insertion of any index entries into an in-memory cache fails for a certain amount of time. the fix in this PR is to try again in case of failure. up to 3 attempts are made so that the tests do no execute endlessly.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.10: 
  - [ ] Backport for 3.9: not necessary
  - [ ] Backport for 3.8: not necessary

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 