### PR TITLE
Make inspection formatter independent of exceptions

### DIFF
--- a/lib/Inspection/Format.h
+++ b/lib/Inspection/Format.h
@@ -27,8 +27,8 @@
 #include <fmt/format.h>
 
 #include "Inspection/VPackSaveInspector.h"
+#include "Inspection/VPackWithErrorT.h"
 #include "Inspection/detail/traits.h"
-#include <Inspection/VPack.h>
 
 template<>
 struct fmt::formatter<VPackSlice> {
@@ -77,8 +77,16 @@ struct inspection_formatter : fmt::formatter<VPackSlice> {
            typename Inspector = VPackSaveInspector<NoContext>>
   requires detail::HasInspectOverload<T, Inspector>::value auto format(
       const T& value, FormatContext& ctx) const -> decltype(ctx.out()) {
-    auto sharedSlice = arangodb::velocypack::serialize(value);
-    return fmt::formatter<VPackSlice>::format(sharedSlice.slice(), ctx);
+    auto sharedSlice = inspection::serializeWithErrorT(value);
+    if (not sharedSlice.ok()) {
+      VPackBuilder error;
+      {
+        VPackObjectBuilder ob(&error);
+        error.add("error", VPackValue(sharedSlice.error().error()));
+      }
+      return fmt::formatter<VPackSlice>::format(error.slice(), ctx);
+    }
+    return fmt::formatter<VPackSlice>::format(sharedSlice.get().slice(), ctx);
   }
 };
 }  // namespace arangodb::inspection

--- a/tests/Basics/InspectionTest.cpp
+++ b/tests/Basics/InspectionTest.cpp
@@ -563,7 +563,13 @@ auto inspect(Inspector& f, MyStringEnum& x) {
   return f.enumeration(x).values(MyStringEnum::kValue1, "value1",  //
                                  MyStringEnum::kValue2, "value2");
 }
+}  // namespace
 
+template<>
+struct fmt::formatter<MyStringEnum>
+    : arangodb::inspection::inspection_formatter {};
+
+namespace {
 enum class MyIntEnum {
   kValue1,
   kValue2,
@@ -2671,6 +2677,12 @@ TEST_F(VPackInspectionTest, formatter) {
   EXPECT_EQ(pretty,
             "My name is {\n  \"i\" : 42,\n  \"d\" : 123.456,\n  \"b\" : "
             "true,\n  \"s\" : \"cheese\"\n}");
+}
+
+TEST_F(VPackInspectionTest, formatter_prints_serialization_error) {
+  MyStringEnum val = static_cast<MyStringEnum>(42);
+  auto def = fmt::format("{}", val);
+  ASSERT_EQ(def, R"({"error":"Unknown enum value 42"})");
 }
 
 TEST_F(VPackInspectionTest, deserialize) {


### PR DESCRIPTION
The inspection formatter uses now serializeWithErrorT instead of serialize in formatter. This comes handy if you want to use the formatter, but don't want to link to the full arango that includes exceptions.
