### PR TITLE
[PREGEL] Add actor framework

### DIFF
--- a/arangod/Pregel/Actor/CMakeLists.txt
+++ b/arangod/Pregel/Actor/CMakeLists.txt
@@ -1,3 +1,8 @@
 add_library(arango_actor INTERFACE)
 target_include_directories(arango_actor INTERFACE include/)
 target_link_libraries(arango_actor INTERFACE arango_crashhandler velocypack fmt)
+
+add_library(arango_actor_standalone INTERFACE)
+target_include_directories(arango_actor_standalone INTERFACE include/)
+target_link_libraries(arango_actor_standalone INTERFACE velocypack fmt)
+target_compile_definitions(arango_actor_standalone INTERFACE STANDALONE)

--- a/arangod/Pregel/Actor/CMakeLists.txt
+++ b/arangod/Pregel/Actor/CMakeLists.txt
@@ -1,3 +1,3 @@
 add_library(arango_actor INTERFACE)
 target_include_directories(arango_actor INTERFACE include/)
-target_link_libraries(arango_actor INTERFACE velocypack fmt)
+target_link_libraries(arango_actor INTERFACE arango_crashhandler velocypack fmt)

--- a/arangod/Pregel/Actor/CMakeLists.txt
+++ b/arangod/Pregel/Actor/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_library(arango_actor INTERFACE)
+target_include_directories(arango_actor INTERFACE include/)
+target_link_libraries(arango_actor INTERFACE velocypack fmt)

--- a/arangod/Pregel/Actor/README.md
+++ b/arangod/Pregel/Actor/README.md
@@ -1,0 +1,60 @@
+# Actor framework
+
+This actor frameworks implements the actor model. An actor model describes several units of computation (the actors) that run concurrently and possibly distributed. Actors only interact via messages and don't share any resources. Actors have a state which can be modified only via received messages. In this implementation, an actor has a message queue where receiving messages are buffered. Inside the actor, everything runs non-concurrently: An actor takes a message from the queue, then processes it, then takes the next message from the queue and processes that and so on. This makes the processing inside the actor much less error-prone.
+Additionally, the framework abstracts the message sending away, which is especially useful in a distributed system: An actor sends a message to another actor, regardless wether this other actor lives on the same or a different server. The user does not need to know how to send a message and wether the receiver lives on the same or another server, this is done by the framework.
+
+## Usage
+
+On each server, there should exist one running actor runtime. This runtime keeps track of all actors running on this server and is responsible for spawning new actors and communication between actors (also across servers).
+
+To create your own custom actor you need to define
+
+- an actor state,
+- message types the actor can receive (combined inside a variant)
+- a handler that defines what happens when a specific message type arrives. 
+
+Have a look at example actors used in the tests: TrivialActor.cpp, SpawnActor.cpp or PingPongActor.cpp.
+
+### Receiving a message
+Received messages are processed in the handler. Here - as a result of a received message - the actor's state can be changed, new actors can be spawned and messages can be send to other actors. Actors are typesafe, meaning they can only receive messages of their specified message types and some predefined error message types.
+
+### Starting actors
+When spawning an actor, a specific state and a start message have to be given. Then the runtime spawns an actor in the specific state and directly sends the start message to it.
+
+### Identifying actors
+Actors are identified via their PID, which consists of a server ID and an actor ID on that server. The handler can only send messages to other actors if it knows the receiving actor's PID. This PID can e.g. come from a received message or it is part of the actor's state.
+
+### Finishing actors
+When an actor is not needed any more, it can be finished. Then, the actor does not receive any new messages but finishes processing all messages in its queue. After that, garbage collection can then delete this actor from the runtime..
+
+### Error handling
+Errors can occur when messages are send, e.g. the receiving actor of a message cannot be found: Then an error message is sent back to the sending actor. The actor handler can either define the behaviors for individual error types or define a catch-all for all message types it does not define a handle for. The error types are defined in Message.h; the following errors can currently occur:
+
+- UnknownMessage: The actor tried to send a message to another actor which does not recognize the sent message type,
+- ActorNotFound: The receiving actor cannot be found on the receiving server or
+- ServerNotFound: The receiving server cannot be found.
+
+## Our implementation
+
+### Actor
+
+An actor receives messages (serialized or non-serialized) via the process method, tries to convert the message into its own message type or an error-message and - if successful - pushes this message to its queue. If the actor is idle (meaning the actor does not work off messages on the queue or has not scheduled any such work), this schedules a work cycle. In this work cycle, batchsize messages from the queue are processed sequentially. If the queue is still not empty afterward, the actor schedules a new work cycle. 
+
+The scheduler is customizable, in ArangoDB we will use the ArangoDB scheduler. We use a lock-free multi-producer-single-consumer message queue (defined in MPSCQueue.h) such that we will not get any troubles when using the ArangoDB scheduler. The message queue queues messages of type MessageOrError which is a variant of the actor-specific messages and pre-defined errors. This way, the actor can receive messages and errors.
+
+### Runtime
+
+An actor runtime is running on each server and has a list of all actors running on this server - all having the same ActorBase interface. This runtime is responsible for
+
+- spawning new actors,
+- sending a message to another actor (which can be an actor on the same server - meaning inside the same runtime or on another server), and
+- distributing messages coming from another server to the receiving actor in this runtime.
+
+The runtime decides whether a message is sent locally (because the receiving actor runs on the same server) or externally (because the receiving actor runs on another server). If a message is sent to an actor on another server, the message is serialized to velocypack and an external dispatcher sends the serialized message. The external dispatcher is customizable: A very basic example of an external dispatcher is given in MultiRuntimeTest.cpp, for ArangoDB we have to write one that sends the message via our REST interface.
+
+The runtime can garbage collect all actors which were set to finished and have processed their remaining message queue. 
+
+### HandlerBase
+
+The HandlerBase provides method calls of the runtime (spawning a new actor and dispatching a message to another actor) to a custom actor handler. This way, the custom handler needs to inherit from HandlerBase to spawn and dispatch without having a handle on the runtime itself. Additionally, the handler base provides the current actor state, the actor's own PID and the sender PID of the message it processes.
+

--- a/arangod/Pregel/Actor/include/Actor/Actor.h
+++ b/arangod/Pregel/Actor/include/Actor/Actor.h
@@ -212,11 +212,6 @@ struct Actor : ActorBase, std::enable_shared_from_this<Actor<Runtime, Config>> {
     ActorPID sender;
     std::unique_ptr<MessageOrError<typename Config::Message>> payload;
   };
-  template<typename Inspector>
-  auto inspect(Inspector& f, InternalMessage& x) {
-    return f.object(x).fiels(f.field("sender", x.sender),
-                             f.field("payload", x.payload));
-  }
 
   auto pushToQueueAndKick(std::unique_ptr<InternalMessage> msg) -> void {
     // don't add new messages when actor is finished

--- a/arangod/Pregel/Actor/include/Actor/Actor.h
+++ b/arangod/Pregel/Actor/include/Actor/Actor.h
@@ -220,6 +220,7 @@ struct Actor : ActorBase, std::enable_shared_from_this<Actor<Runtime, Config>> {
   std::atomic<bool> finished{false};
   arangodb::pregel::mpscqueue::MPSCQueue<InternalMessage> inbox;
   std::shared_ptr<Runtime> runtime;
+  // tunable parameter: maximal number of processed messages per work() call
   std::size_t batchSize{16};
 
  public:

--- a/arangod/Pregel/Actor/include/Actor/Actor.h
+++ b/arangod/Pregel/Actor/include/Actor/Actor.h
@@ -1,0 +1,223 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2022 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Markus Pfeiffer
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include <Inspection/VPackWithErrorT.h>
+#include <memory>
+#include <iostream>
+#include <string_view>
+#include <type_traits>
+
+#include "ActorBase.h"
+#include "HandlerBase.h"
+#include "Message.h"
+#include "MPSCQueue.h"
+
+namespace arangodb::pregel::actor {
+
+namespace {
+template<typename Runtime, typename A>
+concept IncludesAllActorRelevantTypes =
+    std::is_class<typename A::State>::value &&
+    std::is_class<typename A::template Handler<Runtime>>::value &&
+    std::is_class<typename A::Message>::value;
+template<typename A>
+concept IncludesName = requires() {
+  { A::typeName() } -> std::convertible_to<std::string_view>;
+};
+template<typename Runtime, typename A>
+concept HandlerInheritsFromBaseHandler =
+    std::is_base_of < HandlerBase<Runtime, typename A::State>,
+typename A::template Handler<Runtime> > ::value;
+template<typename Runtime, typename A>
+concept MessageIsVariant = requires(ActorPID pid,
+                                    std::shared_ptr<Runtime> runtime,
+                                    typename A::State state,
+                                    typename A::Message message) {
+  {std::visit(
+      typename A::template Handler<Runtime>{
+          {pid, pid, std::move(std::make_unique<typename A::State>(state)),
+           runtime}},
+      message)};
+};
+template<typename A>
+concept IsInspectable = requires(typename A::Message message,
+                                 typename A::State state) {
+  {fmt::format("{}", message)};
+  {fmt::format("{}", state)};
+};
+};  // namespace
+template<typename Runtime, typename A>
+concept Actorable = IncludesAllActorRelevantTypes<Runtime, A> &&
+    IncludesName<A> && HandlerInheritsFromBaseHandler<Runtime, A> &&
+    MessageIsVariant<Runtime, A> && IsInspectable<A>;
+
+template<typename Runtime, typename Config>
+requires Actorable<Runtime, Config>
+struct Actor : ActorBase {
+  Actor(ActorPID pid, std::shared_ptr<Runtime> runtime,
+        std::unique_ptr<typename Config::State> initialState)
+      : pid(pid), runtime(runtime), state(std::move(initialState)) {}
+
+  Actor(ActorPID pid, std::shared_ptr<Runtime> runtime,
+        std::unique_ptr<typename Config::State> initialState,
+        std::size_t batchSize)
+      : pid(pid),
+        runtime(runtime),
+        state(std::move(initialState)),
+        batchSize(batchSize) {}
+
+  ~Actor() = default;
+
+  auto typeName() -> std::string_view override { return Config::typeName(); };
+
+  void process(ActorPID sender,
+               std::unique_ptr<MessagePayloadBase> msg) override {
+    auto* ptr = msg.release();
+    if (auto* m = dynamic_cast<MessagePayload<typename Config::Message>*>(ptr);
+        m != nullptr) {
+      push(sender, std::move(m->payload));
+      delete m;
+    } else if (auto* n = dynamic_cast<MessagePayload<ActorError>*>(ptr);
+               n != nullptr) {
+      push(sender, std::move(n->payload));
+      delete n;
+    } else {
+      runtime->dispatch(
+          pid, sender,
+          ActorError{UnknownMessage{.sender = sender, .receiver = pid}});
+      delete ptr;
+    }
+    kick();
+  }
+
+  void process(ActorPID sender, velocypack::SharedSlice msg) override {
+    if (auto m =
+            inspection::deserializeWithErrorT<typename Config::Message>(msg);
+        m.ok()) {
+      push(sender, std::move(m.get()));
+    } else if (auto n = inspection::deserializeWithErrorT<ActorError>(msg);
+               n.ok()) {
+      push(sender, std::move(n.get()));
+    } else {
+      auto error =
+          ActorError{UnknownMessage{.sender = sender, .receiver = pid}};
+      auto payload = inspection::serializeWithErrorT(error);
+      if (payload.ok()) {
+        runtime->dispatch(pid, sender, payload.get());
+      } else {
+        fmt::print("Error serializing UnknownMessage");
+        std::abort();
+      }
+    }
+    kick();
+  }
+
+  auto serialize() -> velocypack::SharedSlice override {
+    auto res = inspection::serializeWithErrorT(*this);
+    if (not res.ok()) {
+      std::abort();
+    }
+    return res.get();
+  }
+
+ private:
+  void push(ActorPID sender, typename Config::Message&& msg) {
+    inbox.push(std::make_unique<InternalMessage>(
+        sender,
+        std::make_unique<MessageOrError<typename Config::Message>>(msg)));
+  }
+  void push(ActorPID sender, ActorError&& msg) {
+    inbox.push(std::make_unique<InternalMessage>(
+        sender,
+        std::make_unique<MessageOrError<typename Config::Message>>(msg)));
+  }
+
+  void kick() {
+    // Make sure that *someone* works here
+    (*runtime->scheduler)([this]() { this->work(); });
+  }
+
+  void work() {
+    auto was_false = false;
+    if (busy.compare_exchange_strong(was_false, true)) {
+      auto i = batchSize;
+
+      while (auto msg = inbox.pop()) {
+        state = std::visit(
+            typename Config::template Handler<Runtime>{
+                {pid, msg->sender, std::move(state), runtime}},
+            msg->payload->item);
+        i--;
+        if (i == 0) {
+          break;
+        }
+      }
+      busy.store(false);
+
+      if (!inbox.empty()) {
+        kick();
+      }
+    }
+  }
+
+  struct InternalMessage
+      : arangodb::pregel::mpscqueue::MPSCQueue<InternalMessage>::Node {
+    InternalMessage(
+        ActorPID sender,
+        std::unique_ptr<MessageOrError<typename Config::Message>>&& payload)
+        : sender(sender), payload(std::move(payload)) {}
+    ActorPID sender;
+    std::unique_ptr<MessageOrError<typename Config::Message>> payload;
+  };
+  template<typename Inspector>
+  auto inspect(Inspector& f, InternalMessage& x) {
+    return f.object(x).fiels(f.field("sender", x.sender),
+                             f.field("payload", x.payload));
+  }
+
+ public:
+  ActorPID pid;
+  std::atomic<bool> busy;
+  arangodb::pregel::mpscqueue::MPSCQueue<InternalMessage> inbox;
+  std::shared_ptr<Runtime> runtime;
+  std::unique_ptr<typename Config::State> state;
+  std::size_t batchSize{16};
+};
+
+// TODO make queue inspectable
+template<typename Runtime, typename Config, typename Inspector>
+requires Actorable<Runtime, Config>
+auto inspect(Inspector& f, Actor<Runtime, Config>& x) {
+  return f.object(x).fields(f.field("pid", x.pid), f.field("state", x.state),
+                            f.field("batchsize", x.batchSize));
+}
+
+}  // namespace arangodb::pregel::actor
+
+template<typename Runtime, typename Config>
+requires arangodb::pregel::actor::Actorable<Runtime, Config>
+struct fmt::formatter<arangodb::pregel::actor::Actor<Runtime, Config>>
+    : arangodb::inspection::inspection_formatter {
+};

--- a/arangod/Pregel/Actor/include/Actor/Actor.h
+++ b/arangod/Pregel/Actor/include/Actor/Actor.h
@@ -23,7 +23,6 @@
 
 #pragma once
 
-#include <Inspection/VPackWithErrorT.h>
 #include <memory>
 #include <string_view>
 #include <type_traits>
@@ -116,12 +115,8 @@ struct Actor : ActorBase, std::enable_shared_from_this<Actor<Runtime, Config>> {
       auto error =
           ActorError{UnknownMessage{.sender = sender, .receiver = pid}};
       auto payload = inspection::serializeWithErrorT(error);
-      if (payload.ok()) {
-        runtime->dispatch(pid, sender, payload.get());
-      } else {
-        fmt::print("Error serializing UnknownMessage");
-        std::abort();
-      }
+      ADB_PROD_ASSERT(payload.ok());
+      runtime->dispatch(pid, sender, payload.get());
     }
   }
 
@@ -132,9 +127,7 @@ struct Actor : ActorBase, std::enable_shared_from_this<Actor<Runtime, Config>> {
 
   auto serialize() -> velocypack::SharedSlice override {
     auto res = inspection::serializeWithErrorT(*this);
-    if (not res.ok()) {
-      std::abort();
-    }
+    ADB_PROD_ASSERT(res.ok());
     return res.get();
   }
 

--- a/arangod/Pregel/Actor/include/Actor/Actor.h
+++ b/arangod/Pregel/Actor/include/Actor/Actor.h
@@ -224,8 +224,8 @@ struct Actor : ActorBase, std::enable_shared_from_this<Actor<Runtime, Config>> {
     // only push work to scheduler if actor is idle (meaning no work is waiting
     // on the scheduler and no work is currently processed in work())
     // and set idle to false
-    auto isIdle = true;
-    if (idle.compare_exchange_strong(isIdle, false)) {
+    auto isIdle = idle.load();
+    if (isIdle and idle.compare_exchange_strong(isIdle, false)) {
       kick();
     }
   }

--- a/arangod/Pregel/Actor/include/Actor/ActorBase.h
+++ b/arangod/Pregel/Actor/include/Actor/ActorBase.h
@@ -1,0 +1,67 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2022 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Markus Pfeiffer
+/// @author Julia Volmer
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "ActorPID.h"
+#include "Message.h"
+
+namespace arangodb::pregel::actor {
+
+struct ActorBase {
+  virtual ~ActorBase() = default;
+  virtual auto process(ActorPID sender,
+                       std::unique_ptr<MessagePayloadBase> payload) -> void = 0;
+  virtual auto process(ActorPID sender, velocypack::SharedSlice msg)
+      -> void = 0;
+  virtual auto typeName() -> std::string_view = 0;
+  virtual auto serialize() -> velocypack::SharedSlice = 0;
+};
+
+namespace {
+struct ActorInfo {
+  ActorID id;
+  std::string_view type;
+};
+template<typename Inspector>
+auto inspect(Inspector& f, ActorInfo& x) {
+  return f.object(x).fields(f.embedFields(x.id), f.field("type", x.type));
+}
+}  // namespace
+
+struct ActorMap : std::unordered_map<ActorID, std::unique_ptr<ActorBase>> {};
+template<typename Inspector>
+auto inspect(Inspector& f, ActorMap& x) {
+  if constexpr (Inspector::isLoading) {
+    return inspection::Status{};
+  } else {
+    auto actorInfos = std::vector<ActorInfo>{};
+    for (auto const& [id, actor] : x) {
+      actorInfos.emplace_back(ActorInfo{.id = id, .type = actor->typeName()});
+    }
+    return f.apply(actorInfos);
+  }
+}
+
+};  // namespace arangodb::pregel::actor

--- a/arangod/Pregel/Actor/include/Actor/ActorBase.h
+++ b/arangod/Pregel/Actor/include/Actor/ActorBase.h
@@ -38,6 +38,7 @@ struct ActorBase {
   virtual auto serialize() -> velocypack::SharedSlice = 0;
   virtual auto finish() -> void = 0;
   virtual auto finishedAndIdle() -> bool = 0;
+  virtual auto isIdle() -> bool = 0;
 };
 
 }  // namespace arangodb::pregel::actor

--- a/arangod/Pregel/Actor/include/Actor/ActorBase.h
+++ b/arangod/Pregel/Actor/include/Actor/ActorBase.h
@@ -24,8 +24,8 @@
 
 #pragma once
 
-#include "ActorPID.h"
-#include "Message.h"
+#include "Actor/ActorPID.h"
+#include "Actor/Message.h"
 
 namespace arangodb::pregel::actor {
 
@@ -37,31 +37,8 @@ struct ActorBase {
       -> void = 0;
   virtual auto typeName() -> std::string_view = 0;
   virtual auto serialize() -> velocypack::SharedSlice = 0;
+  virtual auto finish() -> void = 0;
+  virtual auto finishedAndNotBusy() -> bool = 0;
 };
 
-namespace {
-struct ActorInfo {
-  ActorID id;
-  std::string_view type;
-};
-template<typename Inspector>
-auto inspect(Inspector& f, ActorInfo& x) {
-  return f.object(x).fields(f.embedFields(x.id), f.field("type", x.type));
-}
-}  // namespace
-
-struct ActorMap : std::unordered_map<ActorID, std::unique_ptr<ActorBase>> {};
-template<typename Inspector>
-auto inspect(Inspector& f, ActorMap& x) {
-  if constexpr (Inspector::isLoading) {
-    return inspection::Status{};
-  } else {
-    auto actorInfos = std::vector<ActorInfo>{};
-    for (auto const& [id, actor] : x) {
-      actorInfos.emplace_back(ActorInfo{.id = id, .type = actor->typeName()});
-    }
-    return f.apply(actorInfos);
-  }
-}
-
-};  // namespace arangodb::pregel::actor
+}  // namespace arangodb::pregel::actor

--- a/arangod/Pregel/Actor/include/Actor/ActorBase.h
+++ b/arangod/Pregel/Actor/include/Actor/ActorBase.h
@@ -31,8 +31,7 @@ namespace arangodb::pregel::actor {
 
 struct ActorBase {
   virtual ~ActorBase() = default;
-  virtual auto process(ActorPID sender,
-                       std::unique_ptr<MessagePayloadBase> payload) -> void = 0;
+  virtual auto process(ActorPID sender, MessagePayloadBase& msg) -> void = 0;
   virtual auto process(ActorPID sender, velocypack::SharedSlice msg)
       -> void = 0;
   virtual auto typeName() -> std::string_view = 0;

--- a/arangod/Pregel/Actor/include/Actor/ActorBase.h
+++ b/arangod/Pregel/Actor/include/Actor/ActorBase.h
@@ -38,7 +38,7 @@ struct ActorBase {
   virtual auto typeName() -> std::string_view = 0;
   virtual auto serialize() -> velocypack::SharedSlice = 0;
   virtual auto finish() -> void = 0;
-  virtual auto finishedAndNotBusy() -> bool = 0;
+  virtual auto finishedAndIdle() -> bool = 0;
 };
 
 }  // namespace arangodb::pregel::actor

--- a/arangod/Pregel/Actor/include/Actor/ActorList.h
+++ b/arangod/Pregel/Actor/include/Actor/ActorList.h
@@ -1,0 +1,133 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2022 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Markus Pfeiffer
+/// @author Julia Volmer
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "Actor/ActorBase.h"
+#include "Actor/ActorPID.h"
+#include "Basics/Guarded.h"
+
+namespace arangodb::pregel::actor {
+
+struct ActorList {
+  struct ActorMap : std::unordered_map<ActorID, std::shared_ptr<ActorBase>> {};
+
+  ActorList(ActorMap map) : actors{std::move(map)} {}
+  ActorList() = default;
+
+  auto find(ActorID id) -> std::optional<std::shared_ptr<ActorBase>> {
+    return actors.doUnderLock(
+        [id](ActorMap& map)
+            -> std::optional<
+                std::reference_wrapper<std::shared_ptr<ActorBase>>> {
+          auto a = map.find(id);
+          if (a == std::end(map)) {
+            return std::nullopt;
+          }
+          auto& [_, actor] = *a;
+          return actor;
+        });
+  }
+
+  auto add(ActorID id, std::shared_ptr<ActorBase> actor) -> void {
+    actors.doUnderLock([id, actor = std::move(actor)](ActorMap& map) {
+      map.emplace(id, std::move(actor));
+    });
+  }
+
+  auto remove(ActorID id) -> void {
+    auto actor = find(id);
+    if (actor.has_value()) {
+      actors.doUnderLock([id](ActorMap& map) { map.erase(id); });
+    }
+  }
+
+  auto removeIf(
+      std::function<bool(std::shared_ptr<ActorBase> const&)> deletable)
+      -> void {
+    actors.doUnderLock([deletable = std::move(deletable)](ActorMap& map) {
+      std::erase_if(map, [deletable = std::move(deletable)](const auto& item) {
+        auto& [_, actor] = item;
+        return deletable(actor);
+      });
+    });
+  }
+
+  auto apply(std::function<void(std::shared_ptr<ActorBase>&)> fn) -> void {
+    actors.doUnderLock([fn = std::move(fn)](ActorMap& map) {
+      for (auto&& [id, actor] : map) {
+        fn(actor);
+      }
+    });
+  }
+
+  auto allIDs() const -> std::vector<ActorID> {
+    return actors.doUnderLock([](ActorMap const& map) {
+      auto res = std::vector<ActorID>{};
+      for (auto& [id, _] : map) {
+        res.push_back(id);
+      }
+      return res;
+    });
+  }
+
+  auto size() const -> size_t {
+    return actors.doUnderLock([](ActorMap const& map) { return map.size(); });
+  }
+
+  Guarded<ActorMap> actors;
+
+  struct ActorInfo {
+    ActorID id;
+    std::string_view type;
+  };
+};
+template<typename Inspector>
+auto inspect(Inspector& f, ActorList::ActorInfo& x) {
+  return f.object(x).fields(f.embedFields(x.id), f.field("type", x.type));
+}
+template<typename Inspector>
+auto inspect(Inspector& f, ActorList::ActorMap& x) {
+  if constexpr (Inspector::isLoading) {
+    return inspection::Status{};
+  } else {
+    auto actorInfos = std::vector<ActorList::ActorInfo>{};
+    for (auto const& [id, actor] : x) {
+      actorInfos.emplace_back(
+          ActorList::ActorInfo{.id = id, .type = actor->typeName()});
+    }
+    return f.apply(actorInfos);
+  }
+}
+template<typename Inspector>
+auto inspect(Inspector& f, ActorList& x) {
+  if constexpr (Inspector::isLoading) {
+    return inspection::Status{};
+  } else {
+    return x.actors.doUnderLock(
+        [&f](ActorList::ActorMap const& map) { return f.apply(map); });
+  }
+}
+
+};  // namespace arangodb::pregel::actor

--- a/arangod/Pregel/Actor/include/Actor/ActorList.h
+++ b/arangod/Pregel/Actor/include/Actor/ActorList.h
@@ -43,11 +43,9 @@ struct ActorList {
   ActorList(ActorMap map) : actors{std::move(map)} {}
   ActorList() = default;
 
-  auto find(ActorID id) -> std::optional<std::shared_ptr<ActorBase>> {
+  auto find(ActorID id) const -> std::optional<std::shared_ptr<ActorBase>> {
     return actors.doUnderLock(
-        [id](ActorMap& map)
-            -> std::optional<
-                std::reference_wrapper<std::shared_ptr<ActorBase>>> {
+        [id](ActorMap const& map) -> std::optional<std::shared_ptr<ActorBase>> {
           auto a = map.find(id);
           if (a == std::end(map)) {
             return std::nullopt;
@@ -63,10 +61,7 @@ struct ActorList {
   }
 
   auto remove(ActorID id) -> void {
-    auto actor = find(id);
-    if (actor.has_value()) {
-      actors.doUnderLock([id](ActorMap& map) { map.erase(id); });
-    }
+    actors.doUnderLock([id](ActorMap& map) { map.erase(id); });
   }
 
   auto removeIf(

--- a/arangod/Pregel/Actor/include/Actor/ActorList.h
+++ b/arangod/Pregel/Actor/include/Actor/ActorList.h
@@ -83,6 +83,17 @@ struct ActorList {
     });
   }
 
+  auto checkAll(std::function<bool(std::shared_ptr<ActorBase> const&)> fn) const
+      -> bool {
+    return actors.doUnderLock([&fn](ActorMap const& map) {
+      bool result = true;
+      for (auto const& [id, actor] : map) {
+        result = result and fn(actor);
+      }
+      return result;
+    });
+  }
+
   auto allIDs() const -> std::vector<ActorID> {
     return actors.doUnderLock([](ActorMap const& map) {
       auto res = std::vector<ActorID>{};

--- a/arangod/Pregel/Actor/include/Actor/ActorPID.h
+++ b/arangod/Pregel/Actor/include/Actor/ActorPID.h
@@ -1,0 +1,77 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2022 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Julia Volmer
+/// @author Markus Pfeiffer
+////////////////////////////////////////////////////////////////////////////////
+#pragma once
+
+#include <cstddef>
+#include <string>
+#include "Inspection/Format.h"
+
+namespace arangodb::pregel::actor {
+struct ActorID {
+  size_t id;
+
+  auto operator<=>(ActorID const& other) const = default;
+};
+template<typename Inspector>
+auto inspect(Inspector& f, ActorID& x) {
+  return f.object(x).fields(f.field("id", x.id));
+}
+
+}  // namespace arangodb::pregel::actor
+
+template<>
+struct fmt::formatter<arangodb::pregel::actor::ActorID>
+    : arangodb::inspection::inspection_formatter {};
+
+namespace std {
+template<>
+struct hash<arangodb::pregel::actor::ActorID> {
+  size_t operator()(arangodb::pregel::actor::ActorID const& x) const noexcept {
+    return std::hash<size_t>()(x.id);
+  };
+};
+}  // namespace std
+
+namespace arangodb::pregel::actor {
+
+// TODO: at some point this needs to be ArangoDB's ServerID or compatible
+using ServerID = std::string;
+using DatabaseName = std::string;
+
+struct ActorPID {
+  ServerID server;
+  ActorID id;
+  DatabaseName databaseName;
+};
+template<typename Inspector>
+auto inspect(Inspector& f, ActorPID& x) {
+  return f.object(x).fields(f.field("server", x.server), f.embedFields(x.id),
+                            f.field("databaseName", x.databaseName));
+}
+
+}  // namespace arangodb::pregel::actor
+
+template<>
+struct fmt::formatter<arangodb::pregel::actor::ActorPID>
+    : arangodb::inspection::inspection_formatter {};

--- a/arangod/Pregel/Actor/include/Actor/ActorPID.h
+++ b/arangod/Pregel/Actor/include/Actor/ActorPID.h
@@ -62,12 +62,10 @@ using DatabaseName = std::string;
 struct ActorPID {
   ServerID server;
   ActorID id;
-  DatabaseName databaseName;
 };
 template<typename Inspector>
 auto inspect(Inspector& f, ActorPID& x) {
-  return f.object(x).fields(f.field("server", x.server), f.embedFields(x.id),
-                            f.field("databaseName", x.databaseName));
+  return f.object(x).fields(f.field("server", x.server), f.embedFields(x.id));
 }
 
 }  // namespace arangodb::pregel::actor

--- a/arangod/Pregel/Actor/include/Actor/ActorPID.h
+++ b/arangod/Pregel/Actor/include/Actor/ActorPID.h
@@ -33,11 +33,19 @@ struct ActorID {
 
   auto operator<=>(ActorID const& other) const = default;
 };
-template<typename Inspector>
+template<class Inspector>
 auto inspect(Inspector& f, ActorID& x) {
-  return f.object(x).fields(f.field("id", x.id));
+  if constexpr (Inspector::isLoading) {
+    auto v = size_t{0};
+    auto res = f.apply(v);
+    if (res.ok()) {
+      x = ActorID{.id = v};
+    }
+    return res;
+  } else {
+    return f.apply(x.id);
+  }
 }
-
 }  // namespace arangodb::pregel::actor
 
 template<>
@@ -65,7 +73,7 @@ struct ActorPID {
 };
 template<typename Inspector>
 auto inspect(Inspector& f, ActorPID& x) {
-  return f.object(x).fields(f.field("server", x.server), f.embedFields(x.id));
+  return f.object(x).fields(f.field("server", x.server), f.field("id", x.id));
 }
 
 }  // namespace arangodb::pregel::actor

--- a/arangod/Pregel/Actor/include/Actor/ActorPID.h
+++ b/arangod/Pregel/Actor/include/Actor/ActorPID.h
@@ -33,7 +33,7 @@ struct ActorID {
 
   auto operator<=>(ActorID const& other) const = default;
 };
-template<class Inspector>
+template<typename Inspector>
 auto inspect(Inspector& f, ActorID& x) {
   if constexpr (Inspector::isLoading) {
     auto v = size_t{0};

--- a/arangod/Pregel/Actor/include/Actor/Assert.h
+++ b/arangod/Pregel/Actor/include/Actor/Assert.h
@@ -1,4 +1,4 @@
-////////////////////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////////////
 /// DISCLAIMER
 ///
 /// Copyright 2014-2022 ArangoDB GmbH, Cologne, Germany
@@ -19,26 +19,17 @@
 /// Copyright holder is ArangoDB GmbH, Cologne, Germany
 ///
 /// @author Markus Pfeiffer
-/// @author Julia Volmer
 ////////////////////////////////////////////////////////////////////////////////
 
 #pragma once
 
-#include "Actor/ActorPID.h"
-#include "Actor/Message.h"
-
-namespace arangodb::pregel::actor {
-
-struct ActorBase {
-  virtual ~ActorBase() = default;
-  virtual auto process(ActorPID sender, MessagePayloadBase& msg) -> void = 0;
-  virtual auto process(ActorPID sender, velocypack::SharedSlice msg)
-      -> void = 0;
-  virtual auto typeName() -> std::string_view = 0;
-  virtual auto serialize() -> velocypack::SharedSlice = 0;
-  virtual auto finish() -> void = 0;
-  virtual auto isFinishedAndIdle() -> bool = 0;
-  virtual auto isIdle() -> bool = 0;
-};
-
-}  // namespace arangodb::pregel::actor
+#ifdef STANDALONE
+#define ACTOR_ASSERT(expr) \
+  if (not expr) {          \
+    std::abort();          \
+  }
+#else
+#include "CrashHandler/CrashHandler.h"
+#include "Assertions/ProdAssert.h"
+#define ACTOR_ASSERT(expr) ADB_PROD_ASSERT(expr);
+#endif

--- a/arangod/Pregel/Actor/include/Actor/HandlerBase.h
+++ b/arangod/Pregel/Actor/include/Actor/HandlerBase.h
@@ -50,6 +50,7 @@ struct HandlerBase {
 
   auto finish() -> void { runtime->finish(self); }
 
+ protected:
   ActorPID self;
   ActorPID sender;
   std::unique_ptr<State> state;

--- a/arangod/Pregel/Actor/include/Actor/HandlerBase.h
+++ b/arangod/Pregel/Actor/include/Actor/HandlerBase.h
@@ -48,6 +48,8 @@ struct HandlerBase {
     return runtime->template spawn<ActorConfig>(initialState, initialMessage);
   }
 
+  auto finish() -> void { runtime->finish(self); }
+
   ActorPID self;
   ActorPID sender;
   std::unique_ptr<State> state;

--- a/arangod/Pregel/Actor/include/Actor/HandlerBase.h
+++ b/arangod/Pregel/Actor/include/Actor/HandlerBase.h
@@ -1,0 +1,59 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2022 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Markus Pfeiffer
+/// @author Julia Volmer
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "Inspection/VPackWithErrorT.h"
+
+#include "Message.h"
+#include "ActorPID.h"
+
+namespace arangodb::pregel::actor {
+
+template<typename Runtime, typename State>
+struct HandlerBase {
+  HandlerBase(ActorPID self, ActorPID sender, std::unique_ptr<State> state,
+              std::shared_ptr<Runtime> runtime)
+      : self(self), sender(sender), state{std::move(state)}, runtime(runtime){};
+
+  template<typename ActorMessage>
+  auto dispatch(ActorPID receiver, ActorMessage message) -> void {
+    runtime->dispatch(self, receiver, message);
+  }
+
+  template<typename ActorConfig>
+  auto spawn(typename ActorConfig::State initialState,
+             typename ActorConfig::Message initialMessage) -> ActorID {
+    return runtime->template spawn<ActorConfig>(initialState, initialMessage);
+  }
+
+  ActorPID self;
+  ActorPID sender;
+  std::unique_ptr<State> state;
+
+ private:
+  std::shared_ptr<Runtime> runtime;
+};
+
+}  // namespace arangodb::pregel::actor

--- a/arangod/Pregel/Actor/include/Actor/MPSCQueue.h
+++ b/arangod/Pregel/Actor/include/Actor/MPSCQueue.h
@@ -41,24 +41,24 @@ struct MPSCQueue {
     std::atomic<Node*> next{nullptr};
   };
 
-  MPSCQueue() : stub{}, head(&stub), tail(&stub) {}
+  MPSCQueue() noexcept : stub{}, head(&stub), tail(&stub) {}
   MPSCQueue(MPSCQueue const&) = delete;
   MPSCQueue(MPSCQueue&&) = delete;
   MPSCQueue& operator=(MPSCQueue const&) = delete;
   MPSCQueue& operator=(MPSCQueue&&) = delete;
 
-  auto push_internal(Node* value) -> void {
+  auto push_internal(Node* value) noexcept -> void {
     value->next.store(nullptr);
     auto prev = head.exchange(value);
     prev->next.store(value);
   }
 
-  auto push(std::unique_ptr<T> value) -> void {
+  auto push(std::unique_ptr<T> value) noexcept -> void {
     auto ptr = value.release();
     push_internal(ptr);
   }
 
-  auto empty() -> bool {
+  auto empty() noexcept -> bool {
     // We read first tail and then head, because
     auto currentTail = tail.load();
     auto currentHead = head.load();
@@ -66,7 +66,7 @@ struct MPSCQueue {
     return currentHead == currentTail;
   }
 
-  [[nodiscard]] auto pop() -> std::unique_ptr<T> {
+  [[nodiscard]] auto pop() noexcept -> std::unique_ptr<T> {
     auto current = tail.load();
     auto next = current->next.load();
 
@@ -121,7 +121,7 @@ struct MPSCQueue {
     return nullptr;
   }
 
-  auto flush() -> void {
+  auto flush() noexcept -> void {
     auto node = pop();
     while (node != nullptr) {
       auto ptr = node.release();
@@ -130,7 +130,7 @@ struct MPSCQueue {
     }
   }
 
-  ~MPSCQueue() { flush(); }
+  ~MPSCQueue() noexcept { flush(); }
 
  private:
   Node stub{};

--- a/arangod/Pregel/Actor/include/Actor/MPSCQueue.h
+++ b/arangod/Pregel/Actor/include/Actor/MPSCQueue.h
@@ -1,0 +1,130 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2022 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Markus Pfeiffer
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include <memory>
+#include <atomic>
+
+// This lock-free multi-producer-single-consumer-queue is inspired by the
+// code published at
+//
+// https://www.1024cores.net/home/lock-free-algorithms/queues/intrusive-mpsc-node-based-queue
+//
+// under a Apache-2.0 license.
+namespace arangodb::pregel::mpscqueue {
+
+template<typename T>
+struct MPSCQueue {
+  struct Node {
+    virtual ~Node() = default;
+    std::atomic<Node*> next{nullptr};
+  };
+
+  MPSCQueue() : stub{}, head(&stub), tail(&stub) {}
+  MPSCQueue(MPSCQueue const&) = delete;
+  MPSCQueue(MPSCQueue&&) = delete;
+  MPSCQueue& operator=(MPSCQueue const&) = delete;
+  MPSCQueue& operator=(MPSCQueue&&) = delete;
+
+  auto push_internal(Node *value) -> void {
+    value->next.store(nullptr);
+    auto prev = head.exchange(value);
+    prev->next.store(value);
+  }
+
+  auto push(std::unique_ptr<T> value) -> void {
+    auto ptr = value.release();
+    push_internal(ptr);
+  }
+
+  auto empty() -> bool {
+    // We read first tail and then head, because
+    auto currentTail = tail.load();
+    auto currentHead = head.load();
+
+    return currentHead == currentTail;
+  }
+
+  [[nodiscard]] auto pop() -> std::unique_ptr<T> {
+    auto current = tail.load();
+    auto next = current->next.load();
+
+    if (current == &stub) {
+      // stub->next == nullptr means the queue
+      // currently does not contain reachable
+      // elements
+      if (nullptr == next) {
+        return nullptr;
+      }
+      // otherwise just move on past stub.
+      tail.store(next);
+      current = next;
+      next = next->next.load();
+    }
+
+    // not reached the current head yet.
+    if (next != nullptr) {
+      //  move tail
+      tail.store(next);
+      // don't leak a pointer into the queue
+      current->next.store(nullptr);
+      return std::unique_ptr<T>(static_cast<T*>(current));
+    }
+
+    // we are now at the end of the
+    // *visible* linear list;
+    auto currenth = head.load();
+    if (current != currenth) {
+      return nullptr;
+    }
+
+    // we are in the situation where we popped
+    // everything up to the last element (which
+    // head points at!)
+    // Since someone else could still be trying
+    // to add stuff to us, we add the stub so
+    // they can
+    push_internal(&stub);
+
+    // might be stub. or anything else. but
+    // we don't care, we just move on
+    next = current->next.load();
+
+    if (next != nullptr) {
+      tail.store(next);
+      // do not leak pointer into queue
+      current->next.store(nullptr);
+      return std::unique_ptr<T>(static_cast<T*>(current));
+    }
+
+    return nullptr;
+  }
+
+private:
+  Node stub{};
+  std::atomic<Node*> head;
+  std::atomic<Node*> tail;
+};
+
+}  // namespace arangodb::pregel::mpscqueue

--- a/arangod/Pregel/Actor/include/Actor/Message.h
+++ b/arangod/Pregel/Actor/include/Actor/Message.h
@@ -104,10 +104,12 @@ template<typename... Args0, typename... Args1>
 struct concatenator<std::variant<Args0...>, std::variant<Args1...>> {
   std::variant<Args0..., Args1...> item;
   concatenator(std::variant<Args0...> a) {
-    std::visit(overloaded{[this](auto&& arg) { this->item = arg; }}, a);
+    std::visit(overloaded{[this](auto&& arg) { this->item = std::move(arg); }},
+               std::move(a));
   }
   concatenator(std::variant<Args1...> b) {
-    std::visit(overloaded{[this](auto&& arg) { this->item = arg; }}, b);
+    std::visit(overloaded{[this](auto&& arg) { this->item = std::move(arg); }},
+               std::move(b));
   }
 };
 

--- a/arangod/Pregel/Actor/include/Actor/Message.h
+++ b/arangod/Pregel/Actor/include/Actor/Message.h
@@ -124,3 +124,9 @@ struct fmt::formatter<arangodb::pregel::actor::MessagePayload<Payload>>
 template<>
 struct fmt::formatter<arangodb::pregel::actor::UnknownMessage>
     : arangodb::inspection::inspection_formatter {};
+template<>
+struct fmt::formatter<arangodb::pregel::actor::ActorNotFound>
+    : arangodb::inspection::inspection_formatter {};
+template<>
+struct fmt::formatter<arangodb::pregel::actor::ServerNotFound>
+    : arangodb::inspection::inspection_formatter {};

--- a/arangod/Pregel/Actor/include/Actor/Message.h
+++ b/arangod/Pregel/Actor/include/Actor/Message.h
@@ -32,16 +32,6 @@
 #include "ActorPID.h"
 #include "MPSCQueue.h"
 
-namespace {
-// helper type for the visitor
-template<class... Ts>
-struct overloaded : Ts... {
-  using Ts::operator()...;
-};
-template<class... Ts>
-overloaded(Ts...) -> overloaded<Ts...>;
-}  // namespace
-
 namespace arangodb::pregel::actor {
 
 struct MessagePayloadBase {
@@ -104,11 +94,11 @@ template<typename... Args0, typename... Args1>
 struct concatenator<std::variant<Args0...>, std::variant<Args1...>> {
   std::variant<Args0..., Args1...> item;
   concatenator(std::variant<Args0...> a) {
-    std::visit(overloaded{[this](auto&& arg) { this->item = std::move(arg); }},
+    std::visit([this](auto&& arg) { this->item = std::move(arg); },
                std::move(a));
   }
   concatenator(std::variant<Args1...> b) {
-    std::visit(overloaded{[this](auto&& arg) { this->item = std::move(arg); }},
+    std::visit([this](auto&& arg) { this->item = std::move(arg); },
                std::move(b));
   }
 };

--- a/arangod/Pregel/Actor/include/Actor/Message.h
+++ b/arangod/Pregel/Actor/include/Actor/Message.h
@@ -1,0 +1,126 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2022 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Julia Volmer
+/// @author Markus Pfeiffer
+////////////////////////////////////////////////////////////////////////////////
+#pragma once
+
+#include <Inspection/VPackWithErrorT.h>
+#include <memory>
+#include <variant>
+
+#include <velocypack/Builder.h>
+
+#include "ActorPID.h"
+#include "MPSCQueue.h"
+
+namespace {
+// helper type for the visitor
+template<class... Ts>
+struct overloaded : Ts... {
+  using Ts::operator()...;
+};
+template<class... Ts>
+overloaded(Ts...) -> overloaded<Ts...>;
+}  // namespace
+
+namespace arangodb::pregel::actor {
+
+struct MessagePayloadBase {
+  virtual ~MessagePayloadBase() = default;
+};
+
+template<typename Payload>
+struct MessagePayload : MessagePayloadBase {
+  template<typename... Args>
+  MessagePayload(Args&&... args) : payload(std::forward<Args>(args)...) {}
+
+  Payload payload;
+};
+template<typename Payload, typename Inspector>
+auto inspect(Inspector& f, MessagePayload<Payload>& x) {
+  return f.object(x).fields(f.field("payload", x.payload));
+}
+
+struct UnknownMessage {
+  ActorPID sender;
+  ActorPID receiver;
+};
+template<typename Inspector>
+auto inspect(Inspector& f, UnknownMessage& x) {
+  return f.object(x).fields(f.field("sender", x.sender),
+                            f.field("receiver", x.receiver));
+}
+
+struct ActorNotFound {
+  ActorPID actor;
+};
+template<typename Inspector>
+auto inspect(Inspector& f, ActorNotFound& x) {
+  return f.object(x).fields(f.field("actor", x.actor));
+}
+
+struct ServerNotFound {
+  ServerID server;
+};
+template<typename Inspector>
+auto inspect(Inspector& f, ServerNotFound& x) {
+  return f.object(x).fields(f.field("server", x.server));
+}
+
+struct ActorError
+    : std::variant<UnknownMessage, ActorNotFound, ServerNotFound> {
+  using std::variant<UnknownMessage, ActorNotFound, ServerNotFound>::variant;
+};
+template<typename Inspector>
+auto inspect(Inspector& f, ActorError& x) {
+  return f.variant(x).unqualified().alternatives(
+      arangodb::inspection::type<UnknownMessage>("UnknownMessage"),
+      arangodb::inspection::type<ActorNotFound>("ActorNotFound"),
+      arangodb::inspection::type<ServerNotFound>("ServerNotFound"));
+}
+
+template<typename T, typename U>
+struct concatenator;
+template<typename... Args0, typename... Args1>
+struct concatenator<std::variant<Args0...>, std::variant<Args1...>> {
+  std::variant<Args0..., Args1...> item;
+  concatenator(std::variant<Args0...> a) {
+    std::visit(overloaded{[this](auto&& arg) { this->item = arg; }}, a);
+  }
+  concatenator(std::variant<Args1...> b) {
+    std::visit(overloaded{[this](auto&& arg) { this->item = arg; }}, b);
+  }
+};
+
+template<typename T>
+struct MessageOrError : concatenator<typename T::variant, ActorError::variant> {
+  using concatenator<typename T::variant, ActorError::variant>::concatenator;
+};
+
+}  // namespace arangodb::pregel::actor
+
+template<typename Payload>
+struct fmt::formatter<arangodb::pregel::actor::MessagePayload<Payload>>
+    : arangodb::inspection::inspection_formatter {};
+template<>
+struct fmt::formatter<arangodb::pregel::actor::UnknownMessage>
+    : arangodb::inspection::inspection_formatter {};

--- a/arangod/Pregel/Actor/include/Actor/Runtime.h
+++ b/arangod/Pregel/Actor/include/Actor/Runtime.h
@@ -130,10 +130,9 @@ struct Runtime
     }
   }
 
-  // TODO call this function regularly
-  auto garbageCollect() {
-    actors.removeIf([](std::shared_ptr<ActorBase> const& actor) -> bool {
-      return actor->isFinishedAndIdle();
+  auto areAllActorsIdle() -> bool {
+    return actors.checkAll([](std::shared_ptr<ActorBase> const& actor) {
+      return actor->isIdle();
     });
   }
 
@@ -144,9 +143,10 @@ struct Runtime
     }
   }
 
-  auto areAllActorsIdle() -> bool {
-    return actors.checkAll([](std::shared_ptr<ActorBase> const& actor) {
-      return actor->isIdle();
+  // TODO call this function regularly
+  auto garbageCollect() {
+    actors.removeIf([](std::shared_ptr<ActorBase> const& actor) -> bool {
+      return actor->isFinishedAndIdle();
     });
   }
 

--- a/arangod/Pregel/Actor/include/Actor/Runtime.h
+++ b/arangod/Pregel/Actor/include/Actor/Runtime.h
@@ -1,0 +1,206 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2022 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Julia Volmer
+/// @author Markus Pfeiffer
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include <optional>
+#include <string>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "Actor.h"
+
+namespace arangodb::pregel::actor {
+
+template<typename S>
+concept CallableOnFunction = requires(S s) {
+  {s([]() {})};
+};
+template<typename D>
+concept VPackDispatchable = requires(D d, ActorPID pid,
+                                     arangodb::velocypack::SharedSlice msg) {
+  {d(pid, pid, msg)};
+};
+
+template<CallableOnFunction Scheduler, VPackDispatchable ExternalDispatcher>
+struct Runtime
+    : std::enable_shared_from_this<Runtime<Scheduler, ExternalDispatcher>> {
+  Runtime() = delete;
+  Runtime(Runtime const&) = delete;
+  Runtime(Runtime&&) = delete;
+  Runtime(ServerID myServerID, std::string runtimeID,
+          std::shared_ptr<Scheduler> scheduler,
+          std::shared_ptr<ExternalDispatcher> externalDispatcher)
+      : myServerID(myServerID),
+        runtimeID(runtimeID),
+        scheduler(scheduler),
+        externalDispatcher(externalDispatcher) {}
+
+  template<typename ActorConfig>
+  auto spawn(typename ActorConfig::State initialState,
+             typename ActorConfig::Message initialMessage) -> ActorID {
+    auto newId = ActorID{uniqueActorIDCounter++};
+
+    auto address = ActorPID{.server = myServerID, .id = newId};
+
+    auto newActor = std::make_unique<Actor<Runtime, ActorConfig>>(
+        address, this->shared_from_this(),
+        std::make_unique<typename ActorConfig::State>(initialState));
+    actors.emplace(newId, std::move(newActor));
+
+    // Send initial message to newly created actor
+    dispatch(address, address, initialMessage);
+
+    return newId;
+  }
+
+  auto shutdown() -> void {
+    // TODO
+  }
+
+  auto getActorIDs() -> std::vector<ActorID> {
+    auto res = std::vector<ActorID>{};
+
+    for (auto& [id, _] : actors) {
+      res.push_back(id);
+    }
+
+    return res;
+  }
+
+  template<typename ActorConfig>
+  auto getActorStateByID(ActorID id)
+      -> std::optional<typename ActorConfig::State> {
+    auto actorBase = findActorLocally(id);
+    if (actorBase.has_value()) {
+      auto* actor =
+          dynamic_cast<Actor<Runtime, ActorConfig>*>(actorBase->get().get());
+      if (actor != nullptr && actor->state != nullptr) {
+        return *actor->state;
+      }
+    }
+    return std::nullopt;
+  }
+
+  auto getSerializedActorByID(ActorID id)
+      -> std::optional<velocypack::SharedSlice> {
+    auto actor = findActorLocally(id);
+    if (actor.has_value()) {
+      if (actor != nullptr) {
+        return actor->serialize();
+      }
+    }
+    return std::nullopt;
+  }
+
+  auto receive(ActorPID sender, ActorPID receiver, velocypack::SharedSlice msg)
+      -> void {
+    auto actor = findActorLocally(receiver.id);
+    if (actor.has_value()) {
+      actor->get()->process(sender, msg);
+    } else {
+      auto error = ActorError{ActorNotFound{.actor = receiver}};
+      auto payload = inspection::serializeWithErrorT(error);
+      if (payload.ok()) {
+        dispatch(receiver, sender, payload.get());
+      } else {
+        fmt::print("Error serializing ActorNotFound");
+        std::abort();
+      }
+    }
+  }
+
+  template<typename ActorMessage>
+  auto dispatch(ActorPID sender, ActorPID receiver, ActorMessage const& message)
+      -> void {
+    if (receiver.server == sender.server) {
+      dispatchLocally(sender, receiver, message);
+    } else {
+      dispatchExternally(sender, receiver, message);
+    }
+  }
+
+  ServerID myServerID;
+  std::string const runtimeID;
+
+  std::shared_ptr<Scheduler> scheduler;
+  std::shared_ptr<ExternalDispatcher> externalDispatcher;
+
+  std::atomic<size_t> uniqueActorIDCounter{0};
+
+  ActorMap actors;
+
+ private:
+  template<typename ActorMessage>
+  auto dispatchLocally(ActorPID sender, ActorPID receiver,
+                       ActorMessage const& message) -> void {
+    auto actor = findActorLocally(receiver.id);
+    if (actor.has_value()) {
+      actor->get()->process(
+          sender,
+          std::make_unique<MessagePayload<ActorMessage>>(std::move(message)));
+    } else {
+      dispatch(receiver, sender, ActorError{ActorNotFound{.actor = receiver}});
+    }
+  }
+
+  template<typename ActorMessage>
+  auto dispatchExternally(ActorPID sender, ActorPID receiver,
+                          ActorMessage const& message) -> void {
+    auto payload = inspection::serializeWithErrorT(message);
+    if (payload.ok()) {
+      (*externalDispatcher)(sender, receiver, payload.get());
+    } else {
+      fmt::print("Error serializing message");
+      std::abort();
+    }
+  }
+
+  auto findActorLocally(ActorID receiver)
+      -> std::optional<std::reference_wrapper<ActorMap::mapped_type>> {
+    auto a = actors.find(receiver);
+    if (a == std::end(actors)) {
+      return std::nullopt;
+    }
+    auto& [_, actor] = *a;
+    return actor;
+  }
+};
+template<CallableOnFunction Scheduler, VPackDispatchable ExternalDispatcher,
+         typename Inspector>
+auto inspect(Inspector& f, Runtime<Scheduler, ExternalDispatcher>& x) {
+  return f.object(x).fields(
+      f.field("myServerID", x.myServerID), f.field("runtimeID", x.runtimeID),
+      f.field("uniqueActorIDCounter", x.uniqueActorIDCounter.load()),
+      f.field("actors", x.actors));
+}
+
+};  // namespace arangodb::pregel::actor
+
+template<arangodb::pregel::actor::CallableOnFunction Scheduler,
+         arangodb::pregel::actor::VPackDispatchable ExternalDispatcher>
+struct fmt::formatter<
+    arangodb::pregel::actor::Runtime<Scheduler, ExternalDispatcher>>
+    : arangodb::inspection::inspection_formatter {};

--- a/arangod/Pregel/Actor/include/Actor/Runtime.h
+++ b/arangod/Pregel/Actor/include/Actor/Runtime.h
@@ -135,7 +135,7 @@ struct Runtime
   // TODO call this function regularly
   auto garbageCollect() {
     actors.removeIf([](std::shared_ptr<ActorBase> const& actor) -> bool {
-      return actor->finishedAndNotBusy();
+      return actor->finishedAndIdle();
     });
   }
 

--- a/arangod/Pregel/Actor/include/Actor/Runtime.h
+++ b/arangod/Pregel/Actor/include/Actor/Runtime.h
@@ -145,6 +145,12 @@ struct Runtime
     }
   }
 
+  auto areAllActorsIdle() -> bool {
+    return actors.checkAll([](std::shared_ptr<ActorBase> const& actor) {
+      return actor->isIdle();
+    });
+  }
+
   auto softShutdown() -> void {
     actors.apply(
         [](std::shared_ptr<ActorBase> const& actor) { actor->finish(); });

--- a/arangod/Pregel/Actor/include/Actor/Runtime.h
+++ b/arangod/Pregel/Actor/include/Actor/Runtime.h
@@ -81,7 +81,7 @@ struct Runtime
   auto getActorIDs() -> std::vector<ActorID> { return actors.allIDs(); }
 
   template<typename ActorConfig>
-  auto getActorStateByID(ActorID id)
+  auto getActorStateByID(ActorID id) const
       -> std::optional<typename ActorConfig::State> {
     auto actorBase = actors.find(id);
     if (actorBase.has_value()) {
@@ -94,7 +94,7 @@ struct Runtime
     return std::nullopt;
   }
 
-  auto getSerializedActorByID(ActorID id)
+  auto getSerializedActorByID(ActorID id) const
       -> std::optional<velocypack::SharedSlice> {
     auto actor = actors.find(id);
     if (actor.has_value()) {
@@ -167,10 +167,11 @@ struct Runtime
   auto dispatchLocally(ActorPID sender, ActorPID receiver,
                        ActorMessage const& message) -> void {
     auto actor = actors.find(receiver.id);
+    auto payload = MessagePayload<ActorMessage>(std::move(message));
     if (actor.has_value()) {
       actor->get()->process(
           sender,
-          std::make_unique<MessagePayload<ActorMessage>>(std::move(message)));
+          payload);
     } else {
       dispatch(receiver, sender, ActorError{ActorNotFound{.actor = receiver}});
     }

--- a/arangod/Pregel/CMakeLists.txt
+++ b/arangod/Pregel/CMakeLists.txt
@@ -19,6 +19,7 @@ target_include_directories(arango_pregel PRIVATE
   "${PROJECT_SOURCE_DIR}/arangod"
   "${PROJECT_SOURCE_DIR}/${ENTERPRISE_INCLUDE_DIR}")
 
+add_subdirectory(Actor)
 add_subdirectory(Algos)
 add_subdirectory(Conductor)
 add_subdirectory(REST)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -18,7 +18,6 @@ add_subdirectory(Zkd)
 add_subdirectory(Graph)
 add_subdirectory(Replication2)
 add_subdirectory(Futures)
-add_subdirectory(Pregel)
 
 # ----------------------------------------
 # Link directories
@@ -318,6 +317,7 @@ target_link_libraries(arangodbtests
   arango_tests_futures
   arango_tests_zkd
   arango_tests_pregel
+  arango_tests_actor
   arango_agency
   arango_cluster_engine
   arango_rocksdb
@@ -375,4 +375,5 @@ foreach(ELEMENT ${IRESEARCH_LIB_RESOURCES})
   endif()
 endforeach()
 
+add_subdirectory(Pregel)
 add_subdirectory(sepp)

--- a/tests/Pregel/Actor/ActorListTest.cpp
+++ b/tests/Pregel/Actor/ActorListTest.cpp
@@ -41,7 +41,7 @@ struct ActorBaseMock : ActorBase {
     return arangodb::velocypack::SharedSlice();
   };
   auto finish() -> void override { finished = true; };
-  auto finishedAndNotBusy() -> bool override { return finished; };
+  auto finishedAndIdle() -> bool override { return finished; };
 
   std::string type;
   bool finished = false;
@@ -154,8 +154,8 @@ TEST(ActorListTest, applies_function_to_each_actor) {
 
   list.apply(
       [](std::shared_ptr<ActorBase>& actor) -> void { actor->finish(); });
-  ASSERT_TRUE(list.find(ActorID{1}).value()->finishedAndNotBusy());
-  ASSERT_TRUE(list.find(ActorID{2}).value()->finishedAndNotBusy());
-  ASSERT_TRUE(list.find(ActorID{3}).value()->finishedAndNotBusy());
-  ASSERT_TRUE(list.find(ActorID{4}).value()->finishedAndNotBusy());
+  ASSERT_TRUE(list.find(ActorID{1}).value()->finishedAndIdle());
+  ASSERT_TRUE(list.find(ActorID{2}).value()->finishedAndIdle());
+  ASSERT_TRUE(list.find(ActorID{3}).value()->finishedAndIdle());
+  ASSERT_TRUE(list.find(ActorID{4}).value()->finishedAndIdle());
 }

--- a/tests/Pregel/Actor/ActorListTest.cpp
+++ b/tests/Pregel/Actor/ActorListTest.cpp
@@ -32,8 +32,7 @@ struct ActorBaseMock : ActorBase {
   ActorBaseMock(std::string type) : type{std::move(type)} {};
   ActorBaseMock() = default;
   ~ActorBaseMock() = default;
-  auto process(ActorPID sender, std::unique_ptr<MessagePayloadBase> payload)
-      -> void override{};
+  auto process(ActorPID sender, MessagePayloadBase& msg) -> void override{};
   auto process(ActorPID sender, arangodb::velocypack::SharedSlice msg)
       -> void override{};
   auto typeName() -> std::string_view override { return type; };
@@ -89,6 +88,14 @@ TEST(ActorListTest, removes_actor_by_id_from_list) {
 
   list.remove(ActorID{1});
   ASSERT_EQ(list.size(), 0);
+}
+
+TEST(ActorListTest, ignores_removal_of_non_existing_actor) {
+  auto list = ActorList({{{ActorID{1}, std::make_shared<ActorBaseMock>()}}});
+  ASSERT_EQ(list.size(), 1);
+
+  list.remove(ActorID{2});
+  ASSERT_EQ(list.size(), 1);
 }
 
 TEST(ActorListTest, removes_actor_in_use_without_destroying_it) {

--- a/tests/Pregel/Actor/ActorListTest.cpp
+++ b/tests/Pregel/Actor/ActorListTest.cpp
@@ -1,0 +1,161 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2020 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Julia Volmer
+/// @author Markus Pfeiffer
+////////////////////////////////////////////////////////////////////////////////
+
+#include <gtest/gtest.h>
+#include "Actor/ActorBase.h"
+#include "Actor/ActorList.h"
+
+using namespace arangodb::pregel::actor;
+
+struct ActorBaseMock : ActorBase {
+  ActorBaseMock(std::string type) : type{std::move(type)} {};
+  ActorBaseMock() = default;
+  ~ActorBaseMock() = default;
+  auto process(ActorPID sender, std::unique_ptr<MessagePayloadBase> payload)
+      -> void override{};
+  auto process(ActorPID sender, arangodb::velocypack::SharedSlice msg)
+      -> void override{};
+  auto typeName() -> std::string_view override { return type; };
+  auto serialize() -> arangodb::velocypack::SharedSlice override {
+    return arangodb::velocypack::SharedSlice();
+  };
+  auto finish() -> void override { finished = true; };
+  auto finishedAndNotBusy() -> bool override { return finished; };
+
+  std::string type;
+  bool finished = false;
+};
+
+TEST(ActorListTest, finds_actor_by_actor_id_in_list) {
+  auto list =
+      ActorList({{{ActorID{1}, std::make_shared<ActorBaseMock>("some")},
+                  {ActorID{2}, std::make_shared<ActorBaseMock>("search")},
+                  {ActorID{3}, std::make_shared<ActorBaseMock>("some")},
+                  {ActorID{4}, std::make_shared<ActorBaseMock>("some")}}});
+  auto foundActor = list.find(ActorID{2});
+  ASSERT_EQ(foundActor.value()->typeName(), "search");
+}
+
+TEST(ActorListTest, gives_nothing_when_searching_for_unknown_actor_id) {
+  auto list = ActorList({{{ActorID{1}, std::make_shared<ActorBaseMock>()},
+                          {ActorID{2}, std::make_shared<ActorBaseMock>()},
+                          {ActorID{3}, std::make_shared<ActorBaseMock>()},
+                          {ActorID{4}, std::make_shared<ActorBaseMock>()}}});
+  auto foundActor = list.find(ActorID{10});
+  ASSERT_EQ(foundActor, std::nullopt);
+}
+
+TEST(ActorListTest, adds_actor_to_list) {
+  auto list = ActorList{};
+  ASSERT_EQ(list.size(), 0);
+
+  list.add(ActorID{1}, std::make_shared<ActorBaseMock>());
+  ASSERT_EQ(list.size(), 1);
+}
+
+TEST(ActorListTest, neglects_added_actors_with_already_existing_actor_id) {
+  auto list =
+      ActorList({{{ActorID{1}, std::make_shared<ActorBaseMock>("existing")}}});
+
+  list.add(ActorID{1}, std::make_shared<ActorBaseMock>("added"));
+  ASSERT_EQ(list.size(), 1);
+  ASSERT_EQ(list.find(ActorID{1}).value()->typeName(), "existing");
+}
+
+TEST(ActorListTest, removes_actor_by_id_from_list) {
+  auto list = ActorList({{{ActorID{1}, std::make_shared<ActorBaseMock>()}}});
+  ASSERT_EQ(list.size(), 1);
+
+  list.remove(ActorID{1});
+  ASSERT_EQ(list.size(), 0);
+}
+
+TEST(ActorListTest, removes_actor_in_use_without_destroying_it) {
+  auto list = ActorList({{{ActorID{1}, std::make_shared<ActorBaseMock>()}}});
+  ASSERT_EQ(list.size(), 1);
+
+  auto actorInUse = list.find(ActorID{1});
+  list.remove(ActorID{1});
+  ASSERT_EQ(list.size(), 0);
+  ASSERT_EQ(actorInUse->use_count(), 1);
+}
+
+TEST(ActorListTest, gives_all_actor_ids_in_list) {
+  auto list = ActorList({{{ActorID{1}, std::make_shared<ActorBaseMock>()},
+                          {ActorID{5}, std::make_shared<ActorBaseMock>()},
+                          {ActorID{3}, std::make_shared<ActorBaseMock>()},
+                          {ActorID{10}, std::make_shared<ActorBaseMock>()}}});
+  auto ids = list.allIDs();
+  ASSERT_EQ(ids.size(), 4);
+  sort(ids.begin(), ids.end());
+  ASSERT_EQ(ids, (std::vector<ActorID>{ActorID{1}, ActorID{3}, ActorID{5},
+                                       ActorID{10}}));
+}
+
+TEST(ActorListTest, removes_actors_by_precondition_from_list) {
+  auto list = ActorList(
+      {{{ActorID{1}, std::make_shared<ActorBaseMock>("deletable")},
+        {ActorID{2}, std::make_shared<ActorBaseMock>("non-deletable")},
+        {ActorID{3}, std::make_shared<ActorBaseMock>("deletable")},
+        {ActorID{4}, std::make_shared<ActorBaseMock>("deletable")}}});
+  ASSERT_EQ(list.size(), 4);
+
+  list.removeIf([](std::shared_ptr<ActorBase> const& actor) -> bool {
+    return actor->typeName() == "deletable";
+  });
+  ASSERT_EQ(list.size(), 1);
+  ASSERT_EQ(list.allIDs(), std::vector<ActorID>{ActorID{2}});
+}
+
+TEST(ActorListTest,
+     removes_actors_by_precondition_without_destroying_actors_in_use) {
+  auto list = ActorList(
+      {{{ActorID{1}, std::make_shared<ActorBaseMock>("deletable")},
+        {ActorID{2}, std::make_shared<ActorBaseMock>("non-deletable")},
+        {ActorID{3}, std::make_shared<ActorBaseMock>("deletable")},
+        {ActorID{4}, std::make_shared<ActorBaseMock>("deletable")}}});
+  ASSERT_EQ(list.size(), 4);
+
+  auto actorInUse = list.find(ActorID{1});
+  list.removeIf([](std::shared_ptr<ActorBase> const& actor) -> bool {
+    return actor->typeName() == "deletable";
+  });
+  ASSERT_EQ(list.size(), 1);
+  ASSERT_EQ(list.allIDs(), std::vector<ActorID>{ActorID{2}});
+  ASSERT_EQ(actorInUse->use_count(), 1);
+}
+
+TEST(ActorListTest, applies_function_to_each_actor) {
+  auto list = ActorList({{{ActorID{1}, std::make_shared<ActorBaseMock>()},
+                          {ActorID{2}, std::make_shared<ActorBaseMock>()},
+                          {ActorID{3}, std::make_shared<ActorBaseMock>()},
+                          {ActorID{4}, std::make_shared<ActorBaseMock>()}}});
+
+  list.apply(
+      [](std::shared_ptr<ActorBase>& actor) -> void { actor->finish(); });
+  ASSERT_TRUE(list.find(ActorID{1}).value()->finishedAndNotBusy());
+  ASSERT_TRUE(list.find(ActorID{2}).value()->finishedAndNotBusy());
+  ASSERT_TRUE(list.find(ActorID{3}).value()->finishedAndNotBusy());
+  ASSERT_TRUE(list.find(ActorID{4}).value()->finishedAndNotBusy());
+}

--- a/tests/Pregel/Actor/ActorListTest.cpp
+++ b/tests/Pregel/Actor/ActorListTest.cpp
@@ -41,6 +41,7 @@ struct ActorBaseMock : ActorBase {
   };
   auto finish() -> void override { finished = true; };
   auto finishedAndIdle() -> bool override { return finished; };
+  auto isIdle() -> bool override { return true; };
 
   std::string type;
   bool finished = false;
@@ -165,4 +166,33 @@ TEST(ActorListTest, applies_function_to_each_actor) {
   ASSERT_TRUE(list.find(ActorID{2}).value()->finishedAndIdle());
   ASSERT_TRUE(list.find(ActorID{3}).value()->finishedAndIdle());
   ASSERT_TRUE(list.find(ActorID{4}).value()->finishedAndIdle());
+}
+
+TEST(ActorListTest,
+     unsucessfully_checks_condition_not_fulfilled_by_all_actors) {
+  auto list =
+      ActorList({{{ActorID{1}, std::make_shared<ActorBaseMock>("true")},
+                  {ActorID{2}, std::make_shared<ActorBaseMock>("true")},
+                  {ActorID{3}, std::make_shared<ActorBaseMock>("false")},
+                  {ActorID{4}, std::make_shared<ActorBaseMock>("false")}}});
+
+  auto check = list.checkAll([](std::shared_ptr<ActorBase> const& actor) {
+    return actor->typeName() == "true";
+  });
+
+  ASSERT_FALSE(check);
+}
+
+TEST(ActorListTest, sucessfully_checks_condition_fulfilled_by_all_actors) {
+  auto list =
+      ActorList({{{ActorID{1}, std::make_shared<ActorBaseMock>("true")},
+                  {ActorID{2}, std::make_shared<ActorBaseMock>("true")},
+                  {ActorID{3}, std::make_shared<ActorBaseMock>("true")},
+                  {ActorID{4}, std::make_shared<ActorBaseMock>("true")}}});
+
+  auto check = list.checkAll([](std::shared_ptr<ActorBase> const& actor) {
+    return actor->typeName() == "true";
+  });
+
+  ASSERT_TRUE(check);
 }

--- a/tests/Pregel/Actor/ActorListTest.cpp
+++ b/tests/Pregel/Actor/ActorListTest.cpp
@@ -40,7 +40,7 @@ struct ActorBaseMock : ActorBase {
     return arangodb::velocypack::SharedSlice();
   };
   auto finish() -> void override { finished = true; };
-  auto finishedAndIdle() -> bool override { return finished; };
+  auto isFinishedAndIdle() -> bool override { return finished; };
   auto isIdle() -> bool override { return true; };
 
   std::string type;
@@ -162,10 +162,10 @@ TEST(ActorListTest, applies_function_to_each_actor) {
 
   list.apply(
       [](std::shared_ptr<ActorBase>& actor) -> void { actor->finish(); });
-  ASSERT_TRUE(list.find(ActorID{1}).value()->finishedAndIdle());
-  ASSERT_TRUE(list.find(ActorID{2}).value()->finishedAndIdle());
-  ASSERT_TRUE(list.find(ActorID{3}).value()->finishedAndIdle());
-  ASSERT_TRUE(list.find(ActorID{4}).value()->finishedAndIdle());
+  ASSERT_TRUE(list.find(ActorID{1}).value()->isFinishedAndIdle());
+  ASSERT_TRUE(list.find(ActorID{2}).value()->isFinishedAndIdle());
+  ASSERT_TRUE(list.find(ActorID{3}).value()->isFinishedAndIdle());
+  ASSERT_TRUE(list.find(ActorID{4}).value()->isFinishedAndIdle());
 }
 
 TEST(ActorListTest,

--- a/tests/Pregel/Actor/ActorTest.cpp
+++ b/tests/Pregel/Actor/ActorTest.cpp
@@ -79,9 +79,9 @@ TEST(ActorTest, changes_its_state_after_processing_a_message) {
       std::make_unique<TrivialState>());
   ASSERT_EQ(*actor->state, (TrivialState{.state = "", .called = 0}));
 
-  auto message = std::make_unique<MessagePayload<TrivialMessages>>(
+  auto message = MessagePayload<TrivialMessages>(
       TrivialMessage{"Hello"});
-  actor->process(ActorPID{.server = "A", .id = {5}}, std::move(message));
+  actor->process(ActorPID{.server = "A", .id = {5}}, message);
   ASSERT_EQ(*actor->state, (TrivialState{.state = "Hello", .called = 1}));
 }
 

--- a/tests/Pregel/Actor/ActorTest.cpp
+++ b/tests/Pregel/Actor/ActorTest.cpp
@@ -109,10 +109,10 @@ TEST(ActorTest, sets_itself_to_finish) {
   auto actor = std::make_shared<Actor<ActorTestRuntime, TrivialActor>>(
       ActorPID{.server = "A", .id = {1}}, runtime,
       std::make_unique<TrivialState>());
-  ASSERT_FALSE(actor->finishedAndNotBusy());
+  ASSERT_FALSE(actor->finishedAndIdle());
 
   actor->finish();
-  ASSERT_TRUE(actor->finishedAndNotBusy());
+  ASSERT_TRUE(actor->finishedAndIdle());
 }
 
 TEST(ActorTest, does_not_work_on_new_messages_after_actor_finished) {

--- a/tests/Pregel/Actor/ActorTest.cpp
+++ b/tests/Pregel/Actor/ActorTest.cpp
@@ -1,0 +1,100 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2020 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Markus Pfeiffer
+////////////////////////////////////////////////////////////////////////////////
+
+#include "gtest/gtest.h"
+
+#include "Actor/Message.h"
+#include "Actor/Runtime.h"
+#include "Actor/Actor.h"
+#include "Actor/ActorPID.h"
+#include "Actors/TrivialActor.h"
+
+#include "fmt/core.h"
+#include <Inspection/VPackWithErrorT.h>
+
+using namespace arangodb::pregel::actor;
+using namespace arangodb::pregel::actor::test;
+
+struct MockScheduler {
+  auto operator()(auto fn) { fn(); }
+};
+struct EmptyExternalDispatcher {
+  auto operator()(ActorPID sender, ActorPID receiver,
+                  arangodb::velocypack::SharedSlice msg) -> void {}
+};
+using ActorTestRuntime = Runtime<MockScheduler, EmptyExternalDispatcher>;
+
+TEST(ActorTest, has_a_type_name) {
+  auto scheduler = std::make_shared<MockScheduler>();
+  auto dispatcher = std::make_shared<EmptyExternalDispatcher>();
+  auto runtime =
+      std::make_shared<ActorTestRuntime>("A", "myID", scheduler, dispatcher);
+  auto actor = Actor<ActorTestRuntime, TrivialActor>(
+      ActorPID{}, runtime, std::make_unique<TrivialState>());
+  ASSERT_EQ(actor.typeName(), "TrivialActor");
+}
+
+TEST(ActorTest, formats_actor) {
+  auto scheduler = std::make_shared<MockScheduler>();
+  auto dispatcher = std::make_shared<EmptyExternalDispatcher>();
+  auto runtime =
+      std::make_shared<ActorTestRuntime>("A", "myID", scheduler, dispatcher);
+  auto actor = Actor<ActorTestRuntime, TrivialActor>(
+      ActorPID{.server = "A", .id = {1}, .databaseName = ""}, runtime,
+      std::make_unique<TrivialState>());
+  ASSERT_EQ(
+      fmt::format("{}", actor),
+      R"({"pid":{"server":"A","id":1,"databaseName":""},"state":{"state":"","called":0},"batchsize":16})");
+}
+
+TEST(ActorTest, changes_its_state_after_processing_a_message) {
+  auto scheduler = std::make_shared<MockScheduler>();
+  auto dispatcher = std::make_shared<EmptyExternalDispatcher>();
+  auto runtime =
+      std::make_shared<ActorTestRuntime>("A", "myID", scheduler, dispatcher);
+  auto actor = Actor<ActorTestRuntime, TrivialActor>(
+      ActorPID{.server = "A", .id = {1}, .databaseName = ""}, runtime,
+      std::make_unique<TrivialState>());
+  ASSERT_EQ(*actor.state, (TrivialState{.state = "", .called = 0}));
+
+  auto message = std::make_unique<MessagePayload<TrivialMessages>>(
+      TrivialMessage{"Hello"});
+  actor.process(ActorPID{.server = "A", .id = {5}}, std::move(message));
+  ASSERT_EQ(*actor.state, (TrivialState{.state = "Hello", .called = 1}));
+}
+
+TEST(ActorTest, changes_its_state_after_processing_a_velocypack_message) {
+  auto scheduler = std::make_shared<MockScheduler>();
+  auto dispatcher = std::make_shared<EmptyExternalDispatcher>();
+  auto runtime =
+      std::make_shared<ActorTestRuntime>("A", "myID", scheduler, dispatcher);
+  auto actor = Actor<ActorTestRuntime, TrivialActor>(
+      ActorPID{.server = "A", .id = {1}, .databaseName = ""}, runtime,
+      std::make_unique<TrivialState>());
+  ASSERT_EQ(*actor.state, (TrivialState{.state = "", .called = 0}));
+
+  auto message = TrivialMessages{TrivialMessage{"Hello"}};
+  actor.process(ActorPID{.server = "A", .id = {5}},
+                arangodb::inspection::serializeWithErrorT(message).get());
+  ASSERT_EQ(*actor.state, (TrivialState{.state = "Hello", .called = 1}));
+}

--- a/tests/Pregel/Actor/ActorTest.cpp
+++ b/tests/Pregel/Actor/ActorTest.cpp
@@ -21,23 +21,27 @@
 /// @author Markus Pfeiffer
 ////////////////////////////////////////////////////////////////////////////////
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
+#include <memory>
+#include "fmt/core.h"
+#include "velocypack/SharedSlice.h"
+#include "Inspection/VPackWithErrorT.h"
 
 #include "Actor/Message.h"
+#include "Actor/MPSCQueue.h"
 #include "Actor/Runtime.h"
 #include "Actor/Actor.h"
 #include "Actor/ActorPID.h"
-#include "Actors/TrivialActor.h"
 
-#include "fmt/core.h"
-#include "velocypack/SharedSlice.h"
-#include <Inspection/VPackWithErrorT.h>
-#include <memory>
+#include "Actors/TrivialActor.h"
+#include "ThreadPoolScheduler.h"
 
 using namespace arangodb::pregel::actor;
 using namespace arangodb::pregel::actor::test;
 
 struct MockScheduler {
+  auto start(size_t number_of_threads) -> void{};
+  auto stop() -> void{};
   auto operator()(auto fn) { fn(); }
 };
 struct EmptyExternalDispatcher {
@@ -45,6 +49,19 @@ struct EmptyExternalDispatcher {
                   arangodb::velocypack::SharedSlice msg) -> void {}
 };
 using ActorTestRuntime = Runtime<MockScheduler, EmptyExternalDispatcher>;
+
+template<typename T>
+class ActorTest : public testing::Test {
+ public:
+  ActorTest() : scheduler{std::make_shared<T>()} {
+    scheduler->start(number_of_threads);
+  }
+
+  std::shared_ptr<T> scheduler;
+  size_t number_of_threads = 5;
+};
+using SchedulerTypes = ::testing::Types<MockScheduler, ThreadPoolScheduler>;
+TYPED_TEST_SUITE(ActorTest, SchedulerTypes);
 
 TEST(ActorTest, has_a_type_name) {
   auto scheduler = std::make_shared<MockScheduler>();
@@ -79,8 +96,7 @@ TEST(ActorTest, changes_its_state_after_processing_a_message) {
       std::make_unique<TrivialState>());
   ASSERT_EQ(*actor->state, (TrivialState{.state = "", .called = 0}));
 
-  auto message = MessagePayload<TrivialMessages>(
-      TrivialMessage{"Hello"});
+  auto message = MessagePayload<TrivialMessages>(TrivialMessage{"Hello"});
   actor->process(ActorPID{.server = "A", .id = {5}}, message);
   ASSERT_EQ(*actor->state, (TrivialState{.state = "Hello", .called = 1}));
 }
@@ -98,6 +114,7 @@ TEST(ActorTest, changes_its_state_after_processing_a_velocypack_message) {
   auto message = TrivialMessages{TrivialMessage{"Hello"}};
   actor->process(ActorPID{.server = "A", .id = {5}},
                  arangodb::inspection::serializeWithErrorT(message).get());
+
   ASSERT_EQ(*actor->state, (TrivialState{.state = "Hello", .called = 1}));
 }
 
@@ -112,21 +129,55 @@ TEST(ActorTest, sets_itself_to_finish) {
   ASSERT_FALSE(actor->finishedAndIdle());
 
   actor->finish();
+
   ASSERT_TRUE(actor->finishedAndIdle());
 }
 
-TEST(ActorTest, does_not_work_on_new_messages_after_actor_finished) {
-  auto scheduler = std::make_shared<MockScheduler>();
+TYPED_TEST(ActorTest, does_not_work_on_new_messages_after_actor_finished) {
   auto dispatcher = std::make_shared<EmptyExternalDispatcher>();
-  auto runtime =
-      std::make_shared<ActorTestRuntime>("A", "myID", scheduler, dispatcher);
-  auto actor = std::make_shared<Actor<ActorTestRuntime, TrivialActor>>(
+  auto runtime = std::make_shared<Runtime<TypeParam, EmptyExternalDispatcher>>(
+      "A", "myID", this->scheduler, dispatcher);
+  auto actor = std::make_shared<
+      Actor<Runtime<TypeParam, EmptyExternalDispatcher>, TrivialActor>>(
       ActorPID{.server = "A", .id = {1}}, runtime,
       std::make_unique<TrivialState>());
   actor->finish();
 
+  // send message to actor
   auto message = TrivialMessages{TrivialMessage{"Hello"}};
   actor->process(ActorPID{.server = "A", .id = {5}},
                  arangodb::inspection::serializeWithErrorT(message).get());
+
+  this->scheduler->stop();
+  // actor did not receive message
   ASSERT_EQ(*actor->state, (TrivialState{}));
+}
+
+TYPED_TEST(ActorTest, finished_actor_works_on_all_remaining_messages_in_queue) {
+  auto dispatcher = std::make_shared<EmptyExternalDispatcher>();
+  auto runtime = std::make_shared<Runtime<TypeParam, EmptyExternalDispatcher>>(
+      "A", "myID", this->scheduler, dispatcher);
+  auto actor = std::make_shared<
+      Actor<Runtime<TypeParam, EmptyExternalDispatcher>, TrivialActor>>(
+      ActorPID{.server = "A", .id = {1}}, runtime,
+      std::make_unique<TrivialState>());
+
+  // send a lot of messages to actor
+  auto message = TrivialMessages{TrivialMessage{"A"}};
+  size_t sent_message_count = 1000;
+  for (size_t i = 0; i < sent_message_count; i++) {
+    actor->process(ActorPID{.server = "A", .id = {5}},
+                   arangodb::inspection::serializeWithErrorT(message).get());
+  }
+
+  // finish actor possibly before actor worked on all messages
+  actor->finish();
+
+  // wait for actor to work off all messages
+  while (not actor->isIdle()) {
+  }
+  this->scheduler->stop();
+  ASSERT_EQ(*actor->state,
+            (TrivialState{.state = std::string(sent_message_count, 'A'),
+                          .called = sent_message_count}));
 }

--- a/tests/Pregel/Actor/ActorTest.cpp
+++ b/tests/Pregel/Actor/ActorTest.cpp
@@ -60,11 +60,11 @@ TEST(ActorTest, formats_actor) {
   auto runtime =
       std::make_shared<ActorTestRuntime>("A", "myID", scheduler, dispatcher);
   auto actor = Actor<ActorTestRuntime, TrivialActor>(
-      ActorPID{.server = "A", .id = {1}, .databaseName = ""}, runtime,
+      ActorPID{.server = "A", .id = {1}}, runtime,
       std::make_unique<TrivialState>());
   ASSERT_EQ(
       fmt::format("{}", actor),
-      R"({"pid":{"server":"A","id":1,"databaseName":""},"state":{"state":"","called":0},"batchsize":16})");
+      R"({"pid":{"server":"A","id":1},"state":{"state":"","called":0},"batchsize":16})");
 }
 
 TEST(ActorTest, changes_its_state_after_processing_a_message) {
@@ -73,7 +73,7 @@ TEST(ActorTest, changes_its_state_after_processing_a_message) {
   auto runtime =
       std::make_shared<ActorTestRuntime>("A", "myID", scheduler, dispatcher);
   auto actor = Actor<ActorTestRuntime, TrivialActor>(
-      ActorPID{.server = "A", .id = {1}, .databaseName = ""}, runtime,
+      ActorPID{.server = "A", .id = {1}}, runtime,
       std::make_unique<TrivialState>());
   ASSERT_EQ(*actor.state, (TrivialState{.state = "", .called = 0}));
 
@@ -89,7 +89,7 @@ TEST(ActorTest, changes_its_state_after_processing_a_velocypack_message) {
   auto runtime =
       std::make_shared<ActorTestRuntime>("A", "myID", scheduler, dispatcher);
   auto actor = Actor<ActorTestRuntime, TrivialActor>(
-      ActorPID{.server = "A", .id = {1}, .databaseName = ""}, runtime,
+      ActorPID{.server = "A", .id = {1}}, runtime,
       std::make_unique<TrivialState>());
   ASSERT_EQ(*actor.state, (TrivialState{.state = "", .called = 0}));
 

--- a/tests/Pregel/Actor/Actors/FinishingActor.h
+++ b/tests/Pregel/Actor/Actors/FinishingActor.h
@@ -1,0 +1,103 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2020 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Markus Pfeiffer
+////////////////////////////////////////////////////////////////////////////////
+#pragma once
+
+#include <chrono>
+#include <string_view>
+#include <thread>
+#include <string>
+#include <memory>
+#include <variant>
+
+#include "Inspection/InspectorBase.h"
+#include "Actor/Actor.h"
+#include "TrivialActor.h"
+
+namespace arangodb::pregel::actor::test {
+
+struct FinishingState {
+  bool operator==(const FinishingState&) const = default;
+};
+template<typename Inspector>
+auto inspect(Inspector& f, FinishingState& x) {
+  return f.object(x).fields();
+}
+
+struct FinishingStart {};
+template<typename Inspector>
+auto inspect(Inspector& f, FinishingStart& x) {
+  return f.object(x).fields();
+}
+
+struct FinishingFinish {
+  bool finish;
+};
+template<typename Inspector>
+auto inspect(Inspector& f, FinishingFinish& x) {
+  return f.object(x).fields(f.field("finish", x.finish));
+}
+
+struct FinishingMessages : std::variant<FinishingStart, FinishingFinish> {
+  using std::variant<FinishingStart, FinishingFinish>::variant;
+};
+template<typename Inspector>
+auto inspect(Inspector& f, FinishingMessages& x) {
+  return f.variant(x).unqualified().alternatives(
+      arangodb::inspection::type<FinishingStart>("start"),
+      arangodb::inspection::type<FinishingFinish>("finish"));
+}
+
+template<typename Runtime>
+struct FinishingHandler : HandlerBase<Runtime, FinishingState> {
+  auto operator()(FinishingStart msg) -> std::unique_ptr<FinishingState> {
+    return std::move(this->state);
+  }
+
+  auto operator()(FinishingFinish msg) -> std::unique_ptr<FinishingState> {
+    this->finish();
+    return std::move(this->state);
+  }
+
+  auto operator()(auto&& rest) -> std::unique_ptr<FinishingState> {
+    fmt::print(stderr, "Finishing actor: handles rest\n");
+    return std::move(this->state);
+  }
+};
+
+struct FinishingActor {
+  using State = FinishingState;
+  using Message = FinishingMessages;
+  template<typename Runtime>
+  using Handler = FinishingHandler<Runtime>;
+  static constexpr auto typeName() -> std::string_view {
+    return "FinishingActor";
+  };
+};
+}  // namespace arangodb::pregel::actor::test
+
+template<>
+struct fmt::formatter<arangodb::pregel::actor::test::FinishingState>
+    : arangodb::inspection::inspection_formatter {};
+template<>
+struct fmt::formatter<arangodb::pregel::actor::test::FinishingMessages>
+    : arangodb::inspection::inspection_formatter {};

--- a/tests/Pregel/Actor/Actors/PingPongActors.h
+++ b/tests/Pregel/Actor/Actors/PingPongActors.h
@@ -1,0 +1,191 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2020 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Julia Volmer
+/// @author Markus Pfeiffer
+////////////////////////////////////////////////////////////////////////////////
+
+#include <chrono>
+#include <thread>
+#include <string>
+#include <memory>
+#include <variant>
+
+#include "Actor/ActorPID.h"
+#include "Actor/HandlerBase.h"
+#include "Inspection/InspectorBase.h"
+
+namespace arangodb::pregel::actor::test {
+
+namespace pong_actor {
+
+struct Start {};
+template<typename Inspector>
+auto inspect(Inspector& f, Start& x) {
+  return f.object(x).fields();
+}
+
+struct Ping {
+  std::string text;
+};
+
+template<typename Inspector>
+auto inspect(Inspector& f, Ping& x) {
+  return f.object(x).fields(f.field("text", x.text));
+}
+
+struct PongMessage : std::variant<Start, Ping> {
+  using std::variant<Start, Ping>::variant;
+};
+
+template<typename Inspector>
+auto inspect(Inspector& f, PongMessage& x) {
+  return f.variant(x).unqualified().alternatives(
+      arangodb::inspection::type<Start>("start"),
+      arangodb::inspection::type<Ping>("ping"));
+}
+
+}  // namespace pong_actor
+
+namespace ping_actor {
+
+struct PingState {
+  std::size_t called;
+  std::string message;
+  bool operator==(const PingState&) const = default;
+};
+template<typename Inspector>
+auto inspect(Inspector& f, PingState& x) {
+  return f.object(x).fields(f.field("called", x.called),
+                            f.field("message", x.message));
+}
+
+struct Start {
+  ActorPID pongActor;
+};
+template<typename Inspector>
+auto inspect(Inspector& f, Start& x) {
+  return f.object(x).fields(f.field("pongActor", x.pongActor));
+}
+
+struct Pong {
+  std::string text;
+};
+template<typename Inspector>
+auto inspect(Inspector& f, Pong& x) {
+  return f.object(x).fields(f.field("text", x.text));
+}
+
+struct PingMessage : std::variant<Start, Pong> {
+  using std::variant<Start, Pong>::variant;
+};
+template<typename Inspector>
+auto inspect(Inspector& f, PingMessage& x) {
+  return f.variant(x).unqualified().alternatives(
+      arangodb::inspection::type<Start>("start"),
+      arangodb::inspection::type<Pong>("pong"));
+}
+
+template<typename Runtime>
+struct PingHandler : HandlerBase<Runtime, PingState> {
+  auto operator()(Start msg) -> std::unique_ptr<PingState> {
+    this->template dispatch<pong_actor::PongMessage>(
+        msg.pongActor, pong_actor::Ping{.text = "hello world"});
+    this->state->called++;
+    return std::move(this->state);
+  }
+
+  auto operator()(Pong msg) -> std::unique_ptr<PingState> {
+    this->state->called++;
+    this->state->message = msg.text;
+    return std::move(this->state);
+  }
+
+  auto operator()(auto&& rest) -> std::unique_ptr<PingState> {
+    fmt::print(stderr, "PingActor: handles rest\n");
+    return std::move(this->state);
+  }
+};
+
+struct Actor {
+  using State = PingState;
+  template<typename Runtime>
+  using Handler = PingHandler<Runtime>;
+  using Message = PingMessage;
+  static constexpr auto typeName() -> std::string_view { return "PingActor"; };
+};
+
+}  // namespace ping_actor
+
+namespace pong_actor {
+
+struct PongState {
+  std::size_t called;
+  bool operator==(const PongState&) const = default;
+};
+template<typename Inspector>
+auto inspect(Inspector& f, PongState& x) {
+  return f.object(x).fields(f.field("called", x.called));
+}
+
+template<typename Runtime>
+struct PongHandler : HandlerBase<Runtime, PongState> {
+  auto operator()(Start msg) -> std::unique_ptr<PongState> {
+    this->state->called++;
+    return std::move(this->state);
+  }
+
+  auto operator()(Ping msg) -> std::unique_ptr<PongState> {
+    this->template dispatch<ping_actor::Actor::Message>(
+        this->sender, ping_actor::Pong{.text = msg.text});
+    this->state->called++;
+    return std::move(this->state);
+  }
+
+  auto operator()(auto&& rest) -> std::unique_ptr<PongState> {
+    fmt::print(stderr, "PongActor: handles rest\n");
+    return std::move(this->state);
+  }
+};
+
+struct Actor {
+  using State = PongState;
+  template<typename Runtime>
+  using Handler = PongHandler<Runtime>;
+  using Message = PongMessage;
+  static constexpr auto typeName() -> std::string_view { return "PongActor"; };
+};
+
+}  // namespace pong_actor
+
+}  // namespace arangodb::pregel::actor::test
+
+template<>
+struct fmt::formatter<arangodb::pregel::actor::test::pong_actor::PongMessage>
+    : arangodb::inspection::inspection_formatter {};
+template<>
+struct fmt::formatter<arangodb::pregel::actor::test::ping_actor::PingState>
+    : arangodb::inspection::inspection_formatter {};
+template<>
+struct fmt::formatter<arangodb::pregel::actor::test::ping_actor::PingMessage>
+    : arangodb::inspection::inspection_formatter {};
+template<>
+struct fmt::formatter<arangodb::pregel::actor::test::pong_actor::PongState>
+    : arangodb::inspection::inspection_formatter {};

--- a/tests/Pregel/Actor/Actors/SpawnActor.h
+++ b/tests/Pregel/Actor/Actors/SpawnActor.h
@@ -1,0 +1,109 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2020 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Markus Pfeiffer
+////////////////////////////////////////////////////////////////////////////////
+#pragma once
+
+#include <chrono>
+#include <string_view>
+#include <thread>
+#include <string>
+#include <memory>
+#include <variant>
+
+#include "Inspection/InspectorBase.h"
+#include "Actor/Actor.h"
+#include "TrivialActor.h"
+
+namespace arangodb::pregel::actor::test {
+
+struct SpawnState {
+  std::size_t called{};
+  std::string state;
+  bool operator==(const SpawnState&) const = default;
+};
+template<typename Inspector>
+auto inspect(Inspector& f, SpawnState& x) {
+  return f.object(x).fields(f.field("called", x.called),
+                            f.field("state", x.state));
+}
+
+struct SpawnStartMessage {};
+template<typename Inspector>
+auto inspect(Inspector& f, SpawnStartMessage& x) {
+  return f.object(x).fields();
+}
+
+struct SpawnMessage {
+  SpawnMessage() = default;
+  SpawnMessage(std::string message) : message(std::move(message)) {}
+  std::string message;
+};
+template<typename Inspector>
+auto inspect(Inspector& f, SpawnMessage& x) {
+  return f.object(x).fields(f.field("message", x.message));
+}
+
+struct SpawnActorMessage : std::variant<SpawnStartMessage, SpawnMessage> {
+  using std::variant<SpawnStartMessage, SpawnMessage>::variant;
+};
+template<typename Inspector>
+auto inspect(Inspector& f, SpawnActorMessage& x) {
+  return f.variant(x).unqualified().alternatives(
+      arangodb::inspection::type<SpawnStartMessage>("start"),
+      arangodb::inspection::type<SpawnMessage>("spawn"));
+}
+
+template<typename Runtime>
+struct SpawnHandler : HandlerBase<Runtime, SpawnState> {
+  auto operator()(SpawnStartMessage msg) -> std::unique_ptr<SpawnState> {
+    this->state->called++;
+    return std::move(this->state);
+  }
+
+  auto operator()(SpawnMessage msg) -> std::unique_ptr<SpawnState> {
+    this->template spawn<TrivialActor>(TrivialState{}, TrivialStart{});
+    this->state->called++;
+    this->state->state += msg.message;
+    return std::move(this->state);
+  }
+
+  auto operator()(auto&& rest) -> std::unique_ptr<SpawnState> {
+    fmt::print(stderr, "Spawn actor: handles rest\n");
+    return std::move(this->state);
+  }
+};
+
+struct SpawnActor {
+  using State = SpawnState;
+  using Message = SpawnActorMessage;
+  template<typename Runtime>
+  using Handler = SpawnHandler<Runtime>;
+  static constexpr auto typeName() -> std::string_view { return "SpawnActor"; };
+};
+}  // namespace arangodb::pregel::actor::test
+
+template<>
+struct fmt::formatter<arangodb::pregel::actor::test::SpawnState>
+    : arangodb::inspection::inspection_formatter {};
+template<>
+struct fmt::formatter<arangodb::pregel::actor::test::SpawnMessage>
+    : arangodb::inspection::inspection_formatter {};

--- a/tests/Pregel/Actor/Actors/TrivialActor.h
+++ b/tests/Pregel/Actor/Actors/TrivialActor.h
@@ -93,14 +93,14 @@ struct TrivialHandler : HandlerBase<Runtime, TrivialState> {
   auto operator()(ActorNotFound notFound) -> std::unique_ptr<TrivialState> {
     this->state->called++;
     this->state->state =
-        fmt::format("recieving actor {} not found", notFound.actor);
+        fmt::format("receiving actor {} not found", notFound.actor);
     return std::move(this->state);
   }
 
   auto operator()(ServerNotFound notFound) -> std::unique_ptr<TrivialState> {
     this->state->called++;
     this->state->state =
-        fmt::format("recieving server {} not found", notFound.server);
+        fmt::format("receiving server {} not found", notFound.server);
     return std::move(this->state);
   }
 

--- a/tests/Pregel/Actor/Actors/TrivialActor.h
+++ b/tests/Pregel/Actor/Actors/TrivialActor.h
@@ -1,0 +1,129 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2020 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Markus Pfeiffer
+////////////////////////////////////////////////////////////////////////////////
+#pragma once
+
+#include <chrono>
+#include <string_view>
+#include <thread>
+#include <string>
+#include <memory>
+#include <variant>
+
+#include "Actor/Actor.h"
+
+namespace arangodb::pregel::actor::test {
+
+struct TrivialState {
+  std::string state;
+  std::size_t called{};
+  bool operator==(const TrivialState&) const = default;
+};
+template<typename Inspector>
+auto inspect(Inspector& f, TrivialState& x) {
+  return f.object(x).fields(f.field("state", x.state),
+                            f.field("called", x.called));
+}
+
+struct TrivialStart {};
+template<typename Inspector>
+auto inspect(Inspector& f, TrivialStart& x) {
+  return f.object(x).fields();
+}
+
+struct TrivialMessage {
+  TrivialMessage() = default;
+  TrivialMessage(std::string value) : store(std::move(value)) {}
+  std::string store;
+};
+template<typename Inspector>
+auto inspect(Inspector& f, TrivialMessage& x) {
+  return f.object(x).fields(f.field("store", x.store));
+}
+
+struct TrivialMessages : std::variant<TrivialStart, TrivialMessage> {
+  using std::variant<TrivialStart, TrivialMessage>::variant;
+};
+template<typename Inspector>
+auto inspect(Inspector& f, TrivialMessages& x) {
+  return f.variant(x).unqualified().alternatives(
+      arangodb::inspection::type<TrivialStart>("msg0"),
+      arangodb::inspection::type<TrivialMessage>("msg1"));
+}
+
+template<typename Runtime>
+struct TrivialHandler : HandlerBase<Runtime, TrivialState> {
+  auto operator()(TrivialStart msg) -> std::unique_ptr<TrivialState> {
+    this->state->called++;
+    return std::move(this->state);
+  }
+
+  auto operator()(TrivialMessage msg) -> std::unique_ptr<TrivialState> {
+    this->state->called++;
+    this->state->state += msg.store;
+    return std::move(this->state);
+  }
+
+  auto operator()(UnknownMessage unknown) -> std::unique_ptr<TrivialState> {
+    this->state->called++;
+    this->state->state =
+        fmt::format("sent unknown message to {}", unknown.receiver);
+    return std::move(this->state);
+  }
+
+  auto operator()(ActorNotFound notFound) -> std::unique_ptr<TrivialState> {
+    this->state->called++;
+    this->state->state =
+        fmt::format("recieving actor {} not found", notFound.actor);
+    return std::move(this->state);
+  }
+
+  auto operator()(ServerNotFound notFound) -> std::unique_ptr<TrivialState> {
+    this->state->called++;
+    this->state->state =
+        fmt::format("recieving server {} not found", notFound.server);
+    return std::move(this->state);
+  }
+
+  auto operator()(auto&& rest) -> std::unique_ptr<TrivialState> {
+    fmt::print(stderr, "TrivialActor: handles rest\n");
+    return std::move(this->state);
+  }
+};
+
+struct TrivialActor {
+  using State = TrivialState;
+  using Message = TrivialMessages;
+  template<typename Runtime>
+  using Handler = TrivialHandler<Runtime>;
+  static constexpr auto typeName() -> std::string_view {
+    return "TrivialActor";
+  };
+};
+}  // namespace arangodb::pregel::actor::test
+
+template<>
+struct fmt::formatter<arangodb::pregel::actor::test::TrivialState>
+    : arangodb::inspection::inspection_formatter {};
+template<>
+struct fmt::formatter<arangodb::pregel::actor::test::TrivialMessages>
+    : arangodb::inspection::inspection_formatter {};

--- a/tests/Pregel/Actor/CMakeLists.txt
+++ b/tests/Pregel/Actor/CMakeLists.txt
@@ -1,0 +1,19 @@
+add_library(arango_tests_actor OBJECT
+  ActorTest.cpp
+  RuntimeTest.cpp
+  MultiRuntimeTest.cpp
+  MPSCQueueTest.cpp)
+target_include_directories(arango_tests_actor PRIVATE
+  ${PROJECT_SOURCE_DIR}/lib)
+target_link_libraries(arango_tests_actor PRIVATE
+  arango_actor
+  gtest)
+
+add_executable(arangodbtests_actor EXCLUDE_FROM_ALL)
+target_link_libraries(arangodbtests_actor
+  arango_tests_actor
+  gtest_main)
+
+add_test(
+  NAME actor
+  COMMAND arangodbtests_actor)

--- a/tests/Pregel/Actor/CMakeLists.txt
+++ b/tests/Pregel/Actor/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_library(arango_tests_actor OBJECT
+  ActorListTest.cpp
   ActorTest.cpp
   RuntimeTest.cpp
   MultiRuntimeTest.cpp
@@ -7,7 +8,8 @@ target_include_directories(arango_tests_actor PRIVATE
   ${PROJECT_SOURCE_DIR}/lib)
 target_link_libraries(arango_tests_actor PRIVATE
   arango_actor
-  gtest)
+  gtest
+  velocypack_utils)
 
 add_executable(arangodbtests_actor EXCLUDE_FROM_ALL)
 target_link_libraries(arangodbtests_actor

--- a/tests/Pregel/Actor/CMakeLists.txt
+++ b/tests/Pregel/Actor/CMakeLists.txt
@@ -7,7 +7,7 @@ add_library(arango_tests_actor OBJECT
 target_include_directories(arango_tests_actor PRIVATE
   ${PROJECT_SOURCE_DIR}/lib)
 target_link_libraries(arango_tests_actor PRIVATE
-  arango_actor
+  arango_actor_standalone
   gtest
   velocypack_utils)
 

--- a/tests/Pregel/Actor/MPSCQueueTest.cpp
+++ b/tests/Pregel/Actor/MPSCQueueTest.cpp
@@ -137,3 +137,17 @@ TEST(ActorMPSCQueue, threads_push_stuff_comes_out) {
                             [](auto x) { return x; }));
   }
 }
+
+TEST(ActorMPSCQueue, flushes_all_messages) {
+  auto queue = MPSCQueue<MPSCStringMessage>();
+  ASSERT_TRUE(queue.empty());
+
+  queue.push(std::make_unique<MPSCStringMessage>("aon"));
+  queue.push(std::make_unique<MPSCStringMessage>("dha"));
+  queue.push(std::make_unique<MPSCStringMessage>("tri"));
+  ASSERT_FALSE(queue.empty());
+
+  queue.flush();
+
+  ASSERT_TRUE(queue.empty());
+}

--- a/tests/Pregel/Actor/MPSCQueueTest.cpp
+++ b/tests/Pregel/Actor/MPSCQueueTest.cpp
@@ -1,0 +1,139 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2020 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Markus Pfeiffer
+////////////////////////////////////////////////////////////////////////////////
+
+#include <chrono>
+#include <thread>
+#include <string>
+
+#include "gtest/gtest.h"
+
+#include "Actor/MPSCQueue.h"
+#include "Basics/ThreadGuard.h"
+
+#include "fmt/core.h"
+
+using namespace arangodb;
+using namespace arangodb::pregel::mpscqueue;
+
+struct MPSCStringMessage : MPSCQueue<MPSCStringMessage>::Node {
+  MPSCStringMessage(std::string content) : content(std::move(content)) {}
+  std::string content;
+};
+
+// this test just pushes and pops some messages to see whether the
+// queue works properly in the absence of
+// concurrency.
+TEST(ActorMPSCQueue, gives_back_stuff_pushed) {
+  auto queue = MPSCQueue<MPSCStringMessage>();
+
+  queue.push(std::make_unique<MPSCStringMessage>("aon"));
+  queue.push(std::make_unique<MPSCStringMessage>("dha"));
+  queue.push(std::make_unique<MPSCStringMessage>("tri"));
+
+  ASSERT_EQ("aon", queue.pop()->content);
+  ASSERT_EQ("dha", queue.pop()->content);
+  ASSERT_EQ("tri", queue.pop()->content);
+
+  // here the queue should be empty
+  ASSERT_EQ(nullptr, queue.pop());
+
+  queue.push(std::make_unique<MPSCStringMessage>("ceithir"));
+  queue.push(std::make_unique<MPSCStringMessage>("dannsa"));
+
+  ASSERT_EQ("ceithir", queue.pop()->content);
+  ASSERT_EQ("dannsa", queue.pop()->content);
+
+  // empty again!
+  ASSERT_EQ(nullptr, queue.pop());
+
+  queue.push(std::make_unique<MPSCStringMessage>("coig"));
+
+  ASSERT_EQ("coig", queue.pop()->content);
+
+  // not empty
+  queue.push(std::make_unique<MPSCStringMessage>("sia"));
+  ASSERT_EQ("sia", queue.pop()->content);
+
+  ASSERT_EQ(nullptr, queue.pop());
+}
+
+struct MPSCThreadMessage : MPSCQueue<MPSCThreadMessage>::Node {
+  MPSCThreadMessage(size_t threadId, size_t messageId)
+      : threadId(threadId), messageId(messageId) {}
+  size_t threadId{};
+  size_t messageId{};
+};
+
+// This test starts a number of system threads that push
+// Apart from checking that this process doesn't crash
+// messages onto the message queue, and an additional
+// thread that keeps reading messages from the queue;
+//
+// the test checks that every message id from every thread
+// has been read in the consumer.
+TEST(ActorMPSCQueue, threads_push_stuff_comes_out) {
+  constexpr auto numberThreads = size_t{125};
+  constexpr auto numberMessages = size_t{10000};
+
+  auto queue = MPSCQueue<MPSCThreadMessage>();
+  auto threads = ThreadGuard();
+
+  for (auto threadId = size_t{0}; threadId < numberThreads; ++threadId) {
+    threads.emplace([&queue, threadId]() {
+      for (size_t msgN = 0; msgN < numberMessages; ++msgN) {
+        queue.push(std::make_unique<MPSCThreadMessage>(threadId, msgN));
+      }
+    });
+  }
+
+  auto receivedIds = std::vector<std::vector<bool>>(numberThreads);
+  for (auto& thread : receivedIds) {
+    thread = std::vector<bool>(numberMessages);
+  }
+
+  threads.emplace([&queue, &receivedIds, numberThreads]() {
+    auto counter = size_t{0};
+
+    while (true) {
+      auto rcv = queue.pop();
+      if (rcv != nullptr) {
+        auto msg = rcv.release();
+        receivedIds[msg->threadId][msg->messageId] = true;
+        counter++;
+
+        ASSERT_LT(msg->threadId, numberThreads);
+        ASSERT_LE(counter, numberThreads * numberMessages);
+
+        if (counter == numberThreads * numberMessages) {
+          break;
+        }
+      }
+    }
+  });
+  threads.joinAll();
+
+  for (auto& thread : receivedIds) {
+    ASSERT_TRUE(std::all_of(std::begin(thread), std::end(thread),
+                            [](auto x) { return x; }));
+  }
+}

--- a/tests/Pregel/Actor/MultiRuntimeTest.cpp
+++ b/tests/Pregel/Actor/MultiRuntimeTest.cpp
@@ -83,8 +83,8 @@ TEST(ActorMultiRuntimeTest, sends_message_to_actor_in_another_runtime) {
                                        scheduler, dispatcher));
   auto sending_actor_id = runtimes[sending_server]->spawn<TrivialActor>(
       TrivialState{.state = "foo"}, TrivialStart{});
-  auto sending_actor = ActorPID{
-      .server = sending_server, .id = sending_actor_id, .databaseName = ""};
+  auto sending_actor =
+      ActorPID{.server = sending_server, .id = sending_actor_id};
 
   // Receiving Runtime
   auto recieving_server = ServerID{"B"};
@@ -94,8 +94,8 @@ TEST(ActorMultiRuntimeTest, sends_message_to_actor_in_another_runtime) {
                                     scheduler, dispatcher));
   auto recieving_actor_id = runtimes[recieving_server]->spawn<TrivialActor>(
       TrivialState{.state = "foo"}, TrivialStart{});
-  auto recieving_actor = ActorPID{
-      .server = recieving_server, .id = recieving_actor_id, .databaseName = ""};
+  auto recieving_actor =
+      ActorPID{.server = recieving_server, .id = recieving_actor_id};
 
   // send
   runtimes[sending_server]->dispatch(
@@ -143,8 +143,8 @@ TEST(ActorMultiRuntimeTest,
                                        scheduler, dispatcher));
   auto sending_actor_id = runtimes[sending_server]->spawn<TrivialActor>(
       TrivialState{.state = "foo"}, TrivialStart{});
-  auto sending_actor = ActorPID{
-      .server = sending_server, .id = sending_actor_id, .databaseName = ""};
+  auto sending_actor =
+      ActorPID{.server = sending_server, .id = sending_actor_id};
 
   // Receiving Runtime
   auto recieving_server = ServerID{"B"};
@@ -154,8 +154,8 @@ TEST(ActorMultiRuntimeTest,
                                     scheduler, dispatcher));
   auto recieving_actor_id = runtimes[recieving_server]->spawn<TrivialActor>(
       TrivialState{.state = "foo"}, TrivialStart{});
-  auto recieving_actor = ActorPID{
-      .server = recieving_server, .id = recieving_actor_id, .databaseName = ""};
+  auto recieving_actor =
+      ActorPID{.server = recieving_server, .id = recieving_actor_id};
 
   // send
   runtimes[sending_server]->dispatch(sending_actor, recieving_actor,
@@ -194,8 +194,8 @@ TEST(
                                        scheduler, dispatcher));
   auto sending_actor_id = runtimes[sending_server]->spawn<TrivialActor>(
       TrivialState{.state = "foo"}, TrivialStart{});
-  auto sending_actor = ActorPID{
-      .server = sending_server, .id = sending_actor_id, .databaseName = ""};
+  auto sending_actor =
+      ActorPID{.server = sending_server, .id = sending_actor_id};
 
   // Receiving Runtime
   auto recieving_server = ServerID{"B"};
@@ -205,8 +205,7 @@ TEST(
                                     scheduler, dispatcher));
 
   // send
-  auto unknown_actor =
-      ActorPID{.server = recieving_server, .id = {999}, .databaseName = ""};
+  auto unknown_actor = ActorPID{.server = recieving_server, .id = {999}};
   runtimes[sending_server]->dispatch(
       sending_actor, unknown_actor,
       TrivialActor::Message{TrivialMessage("baz")});
@@ -236,14 +235,13 @@ TEST(
                                        scheduler, dispatcher));
   auto sending_actor_id = runtimes[sending_server]->spawn<TrivialActor>(
       TrivialState{.state = "foo"}, TrivialStart{});
-  auto sending_actor = ActorPID{
-      .server = sending_server, .id = sending_actor_id, .databaseName = ""};
+  auto sending_actor =
+      ActorPID{.server = sending_server, .id = sending_actor_id};
 
   // send
   auto unknown_server = ServerID{"B"};
   runtimes[sending_server]->dispatch(
-      sending_actor,
-      ActorPID{.server = unknown_server, .id = {999}, .databaseName = ""},
+      sending_actor, ActorPID{.server = unknown_server, .id = {999}},
       TrivialActor::Message{TrivialMessage("baz")});
 
   // sending actor received a server not known message error after it messaged
@@ -278,9 +276,8 @@ TEST(ActorMultiRuntimeTest, ping_pong_game) {
                                                  scheduler, dispatcher));
   auto ping_actor = runtimes[ping_server]->spawn<ping_actor::Actor>(
       ping_actor::PingState{},
-      ping_actor::Start{.pongActor = ActorPID{.server = pong_server,
-                                              .id = pong_actor,
-                                              .databaseName = ""}});
+      ping_actor::Start{.pongActor =
+                            ActorPID{.server = pong_server, .id = pong_actor}});
 
   // pong actor was called twice
   auto pong_actor_state =

--- a/tests/Pregel/Actor/MultiRuntimeTest.cpp
+++ b/tests/Pregel/Actor/MultiRuntimeTest.cpp
@@ -50,7 +50,6 @@ struct MockExternalDispatcher {
       : runtimes(runtimes) {}
   auto operator()(ActorPID sender, ActorPID receiver,
                   arangodb::velocypack::SharedSlice msg) -> void {
-    // a timeout error would go here
     auto receiving_runtime = runtimes.find(receiver.server);
     if (receiving_runtime != std::end(runtimes)) {
       receiving_runtime->second->receive(sender, receiver, msg);
@@ -79,7 +78,7 @@ class ActorMultiRuntimeTest : public testing::Test {
   };
 
   std::shared_ptr<T> scheduler;
-  size_t number_of_threads = 5;
+  size_t number_of_threads = 128;
 };
 using SchedulerTypes = ::testing::Types<MockScheduler, ThreadPoolScheduler>;
 TYPED_TEST_SUITE(ActorMultiRuntimeTest, SchedulerTypes);

--- a/tests/Pregel/Actor/MultiRuntimeTest.cpp
+++ b/tests/Pregel/Actor/MultiRuntimeTest.cpp
@@ -87,19 +87,19 @@ TEST(ActorMultiRuntimeTest, sends_message_to_actor_in_another_runtime) {
       ActorPID{.server = sending_server, .id = sending_actor_id};
 
   // Receiving Runtime
-  auto recieving_server = ServerID{"B"};
+  auto receiving_server = ServerID{"B"};
   runtimes.emplace(
-      recieving_server,
-      std::make_shared<MockRuntime>(recieving_server, "RuntimeTest-receiving",
+      receiving_server,
+      std::make_shared<MockRuntime>(receiving_server, "RuntimeTest-receiving",
                                     scheduler, dispatcher));
-  auto recieving_actor_id = runtimes[recieving_server]->spawn<TrivialActor>(
+  auto receiving_actor_id = runtimes[receiving_server]->spawn<TrivialActor>(
       TrivialState{.state = "foo"}, TrivialStart{});
-  auto recieving_actor =
-      ActorPID{.server = recieving_server, .id = recieving_actor_id};
+  auto receiving_actor =
+      ActorPID{.server = receiving_server, .id = receiving_actor_id};
 
   // send
   runtimes[sending_server]->dispatch(
-      sending_actor, recieving_actor,
+      sending_actor, receiving_actor,
       TrivialActor::Message{TrivialMessage("baz")});
 
   // sending actor state did not change
@@ -109,10 +109,10 @@ TEST(ActorMultiRuntimeTest, sends_message_to_actor_in_another_runtime) {
   ASSERT_EQ(sending_actor_state,
             (TrivialActor::State{.state = "foo", .called = 1}));
   // receiving actor state changed
-  auto recieving_actor_state =
-      runtimes[recieving_server]->getActorStateByID<TrivialActor>(
-          recieving_actor_id);
-  ASSERT_EQ(recieving_actor_state,
+  auto receiving_actor_state =
+      runtimes[receiving_server]->getActorStateByID<TrivialActor>(
+          receiving_actor_id);
+  ASSERT_EQ(receiving_actor_state,
             (TrivialActor::State{.state = "foobaz", .called = 2}));
 }
 
@@ -147,25 +147,25 @@ TEST(ActorMultiRuntimeTest,
       ActorPID{.server = sending_server, .id = sending_actor_id};
 
   // Receiving Runtime
-  auto recieving_server = ServerID{"B"};
+  auto receiving_server = ServerID{"B"};
   runtimes.emplace(
-      recieving_server,
-      std::make_shared<MockRuntime>(recieving_server, "RuntimeTest-receiving",
+      receiving_server,
+      std::make_shared<MockRuntime>(receiving_server, "RuntimeTest-receiving",
                                     scheduler, dispatcher));
-  auto recieving_actor_id = runtimes[recieving_server]->spawn<TrivialActor>(
+  auto receiving_actor_id = runtimes[receiving_server]->spawn<TrivialActor>(
       TrivialState{.state = "foo"}, TrivialStart{});
-  auto recieving_actor =
-      ActorPID{.server = recieving_server, .id = recieving_actor_id};
+  auto receiving_actor =
+      ActorPID{.server = receiving_server, .id = receiving_actor_id};
 
   // send
-  runtimes[sending_server]->dispatch(sending_actor, recieving_actor,
+  runtimes[sending_server]->dispatch(sending_actor, receiving_actor,
                                      SomeMessages{SomeMessage{}});
 
-  // recieving actor state was called once
-  auto recieving_actor_state =
-      runtimes[recieving_server]->getActorStateByID<TrivialActor>(
-          recieving_actor_id);
-  ASSERT_EQ(recieving_actor_state,
+  // receiving actor state was called once
+  auto receiving_actor_state =
+      runtimes[receiving_server]->getActorStateByID<TrivialActor>(
+          receiving_actor_id);
+  ASSERT_EQ(receiving_actor_state,
             (TrivialActor::State{.state = "foo", .called = 1}));
   // sending actor received an unknown message error after it sent wrong
   // message type
@@ -175,7 +175,7 @@ TEST(ActorMultiRuntimeTest,
   ASSERT_EQ(
       sending_actor_state,
       (TrivialActor::State{
-          .state = fmt::format("sent unknown message to {}", recieving_actor),
+          .state = fmt::format("sent unknown message to {}", receiving_actor),
           .called = 2}));
 }
 
@@ -198,14 +198,14 @@ TEST(
       ActorPID{.server = sending_server, .id = sending_actor_id};
 
   // Receiving Runtime
-  auto recieving_server = ServerID{"B"};
+  auto receiving_server = ServerID{"B"};
   runtimes.emplace(
-      recieving_server,
-      std::make_shared<MockRuntime>(recieving_server, "RuntimeTest-receiving",
+      receiving_server,
+      std::make_shared<MockRuntime>(receiving_server, "RuntimeTest-receiving",
                                     scheduler, dispatcher));
 
   // send
-  auto unknown_actor = ActorPID{.server = recieving_server, .id = {999}};
+  auto unknown_actor = ActorPID{.server = receiving_server, .id = {999}};
   runtimes[sending_server]->dispatch(
       sending_actor, unknown_actor,
       TrivialActor::Message{TrivialMessage("baz")});
@@ -216,7 +216,7 @@ TEST(
       runtimes[sending_server]->getActorStateByID<TrivialActor>(
           sending_actor_id),
       (TrivialActor::State{
-          .state = fmt::format("recieving actor {} not found", unknown_actor),
+          .state = fmt::format("receiving actor {} not found", unknown_actor),
           .called = 2}));
 }
 
@@ -250,7 +250,7 @@ TEST(
       runtimes[sending_server]->getActorStateByID<TrivialActor>(
           sending_actor_id),
       (TrivialActor::State{
-          .state = fmt::format("recieving server {} not found", unknown_server),
+          .state = fmt::format("receiving server {} not found", unknown_server),
           .called = 2}));
 }
 

--- a/tests/Pregel/Actor/MultiRuntimeTest.cpp
+++ b/tests/Pregel/Actor/MultiRuntimeTest.cpp
@@ -1,0 +1,294 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2020 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Julia Volmer
+/// @author Markus Pfeiffer
+////////////////////////////////////////////////////////////////////////////////
+
+#include <gtest/gtest.h>
+#include <unordered_set>
+
+#include "Actor/ActorPID.h"
+#include "Actor/Runtime.h"
+
+#include "Actors/TrivialActor.h"
+#include "Actors/PingPongActors.h"
+
+using namespace arangodb;
+
+using namespace arangodb::pregel::actor;
+using namespace arangodb::pregel::actor::test;
+
+struct MockScheduler {
+  auto operator()(auto fn) { fn(); }
+};
+
+template<typename Runtime>
+struct MockExternalDispatcher {
+  MockExternalDispatcher(
+      std::unordered_map<ServerID, std::shared_ptr<Runtime>>& runtimes)
+      : runtimes(runtimes) {}
+  auto operator()(ActorPID sender, ActorPID receiver,
+                  arangodb::velocypack::SharedSlice msg) -> void {
+    // a timeout error would go here
+    auto receiving_runtime = runtimes.find(receiver.server);
+    if (receiving_runtime != std::end(runtimes)) {
+      receiving_runtime->second->receive(sender, receiver, msg);
+    } else {
+      auto error = ActorError{ServerNotFound{.server = receiver.server}};
+      auto payload = inspection::serializeWithErrorT(error);
+      if (payload.ok()) {
+        runtimes[sender.server]->dispatch(receiver, sender, payload.get());
+      } else {
+        fmt::print("Error serializing ActorNotFound");
+        std::abort();
+      }
+    }
+  }
+  std::unordered_map<ServerID, std::shared_ptr<Runtime>>& runtimes;
+};
+
+struct MockRuntime
+    : Runtime<MockScheduler, MockExternalDispatcher<MockRuntime>> {
+  using Runtime<MockScheduler, MockExternalDispatcher<MockRuntime>>::Runtime;
+};
+
+TEST(ActorMultiRuntimeTest, sends_message_to_actor_in_another_runtime) {
+  std::unordered_map<ServerID, std::shared_ptr<MockRuntime>> runtimes;
+  auto scheduler = std::make_shared<MockScheduler>();
+  auto dispatcher =
+      std::make_shared<MockExternalDispatcher<MockRuntime>>(runtimes);
+
+  // Sending Runtime
+  auto sending_server = ServerID{"A"};
+  runtimes.emplace(sending_server, std::make_shared<MockRuntime>(
+                                       sending_server, "RuntimeTest-sending",
+                                       scheduler, dispatcher));
+  auto sending_actor_id = runtimes[sending_server]->spawn<TrivialActor>(
+      TrivialState{.state = "foo"}, TrivialStart{});
+  auto sending_actor = ActorPID{
+      .server = sending_server, .id = sending_actor_id, .databaseName = ""};
+
+  // Receiving Runtime
+  auto recieving_server = ServerID{"B"};
+  runtimes.emplace(
+      recieving_server,
+      std::make_shared<MockRuntime>(recieving_server, "RuntimeTest-receiving",
+                                    scheduler, dispatcher));
+  auto recieving_actor_id = runtimes[recieving_server]->spawn<TrivialActor>(
+      TrivialState{.state = "foo"}, TrivialStart{});
+  auto recieving_actor = ActorPID{
+      .server = recieving_server, .id = recieving_actor_id, .databaseName = ""};
+
+  // send
+  runtimes[sending_server]->dispatch(
+      sending_actor, recieving_actor,
+      TrivialActor::Message{TrivialMessage("baz")});
+
+  // sending actor state did not change
+  auto sending_actor_state =
+      runtimes[sending_server]->getActorStateByID<TrivialActor>(
+          sending_actor_id);
+  ASSERT_EQ(sending_actor_state,
+            (TrivialActor::State{.state = "foo", .called = 1}));
+  // receiving actor state changed
+  auto recieving_actor_state =
+      runtimes[recieving_server]->getActorStateByID<TrivialActor>(
+          recieving_actor_id);
+  ASSERT_EQ(recieving_actor_state,
+            (TrivialActor::State{.state = "foobaz", .called = 2}));
+}
+
+struct SomeMessage {};
+template<typename Inspector>
+auto inspect(Inspector& f, SomeMessage& x) {
+  return f.object(x).fields();
+}
+struct SomeMessages : std::variant<SomeMessage> {
+  using std::variant<SomeMessage>::variant;
+};
+template<typename Inspector>
+auto inspect(Inspector& f, SomeMessages& x) {
+  return f.variant(x).unqualified().alternatives(
+      arangodb::inspection::type<SomeMessage>("someMessage"));
+}
+TEST(ActorMultiRuntimeTest,
+     actor_receiving_wrong_message_type_sends_back_unknown_error_message) {
+  std::unordered_map<ServerID, std::shared_ptr<MockRuntime>> runtimes;
+  auto scheduler = std::make_shared<MockScheduler>();
+  auto dispatcher =
+      std::make_shared<MockExternalDispatcher<MockRuntime>>(runtimes);
+
+  // Sending Runtime
+  auto sending_server = ServerID{"A"};
+  runtimes.emplace(sending_server, std::make_shared<MockRuntime>(
+                                       sending_server, "RuntimeTest-sending",
+                                       scheduler, dispatcher));
+  auto sending_actor_id = runtimes[sending_server]->spawn<TrivialActor>(
+      TrivialState{.state = "foo"}, TrivialStart{});
+  auto sending_actor = ActorPID{
+      .server = sending_server, .id = sending_actor_id, .databaseName = ""};
+
+  // Receiving Runtime
+  auto recieving_server = ServerID{"B"};
+  runtimes.emplace(
+      recieving_server,
+      std::make_shared<MockRuntime>(recieving_server, "RuntimeTest-receiving",
+                                    scheduler, dispatcher));
+  auto recieving_actor_id = runtimes[recieving_server]->spawn<TrivialActor>(
+      TrivialState{.state = "foo"}, TrivialStart{});
+  auto recieving_actor = ActorPID{
+      .server = recieving_server, .id = recieving_actor_id, .databaseName = ""};
+
+  // send
+  runtimes[sending_server]->dispatch(sending_actor, recieving_actor,
+                                     SomeMessages{SomeMessage{}});
+
+  // recieving actor state was called once
+  auto recieving_actor_state =
+      runtimes[recieving_server]->getActorStateByID<TrivialActor>(
+          recieving_actor_id);
+  ASSERT_EQ(recieving_actor_state,
+            (TrivialActor::State{.state = "foo", .called = 1}));
+  // sending actor received an unknown message error after it sent wrong
+  // message type
+  auto sending_actor_state =
+      runtimes[sending_server]->getActorStateByID<TrivialActor>(
+          sending_actor_id);
+  ASSERT_EQ(
+      sending_actor_state,
+      (TrivialActor::State{
+          .state = fmt::format("sent unknown message to {}", recieving_actor),
+          .called = 2}));
+}
+
+TEST(
+    ActorMultiRuntimeTest,
+    actor_receives_actor_not_found_message_after_trying_to_send_message_to_non_existent_actor) {
+  std::unordered_map<ServerID, std::shared_ptr<MockRuntime>> runtimes;
+  auto scheduler = std::make_shared<MockScheduler>();
+  auto dispatcher =
+      std::make_shared<MockExternalDispatcher<MockRuntime>>(runtimes);
+
+  // Sending Runtime
+  auto sending_server = ServerID{"A"};
+  runtimes.emplace(sending_server, std::make_shared<MockRuntime>(
+                                       sending_server, "RuntimeTest-sending",
+                                       scheduler, dispatcher));
+  auto sending_actor_id = runtimes[sending_server]->spawn<TrivialActor>(
+      TrivialState{.state = "foo"}, TrivialStart{});
+  auto sending_actor = ActorPID{
+      .server = sending_server, .id = sending_actor_id, .databaseName = ""};
+
+  // Receiving Runtime
+  auto recieving_server = ServerID{"B"};
+  runtimes.emplace(
+      recieving_server,
+      std::make_shared<MockRuntime>(recieving_server, "RuntimeTest-receiving",
+                                    scheduler, dispatcher));
+
+  // send
+  auto unknown_actor =
+      ActorPID{.server = recieving_server, .id = {999}, .databaseName = ""};
+  runtimes[sending_server]->dispatch(
+      sending_actor, unknown_actor,
+      TrivialActor::Message{TrivialMessage("baz")});
+
+  // sending actor received an actor not known message error after it messaged
+  // to non-existing actor on other runtime
+  ASSERT_EQ(
+      runtimes[sending_server]->getActorStateByID<TrivialActor>(
+          sending_actor_id),
+      (TrivialActor::State{
+          .state = fmt::format("recieving actor {} not found", unknown_actor),
+          .called = 2}));
+}
+
+TEST(
+    ActorMultiRuntimeTest,
+    actor_receives_actor_not_found_message_after_trying_to_send_message_to_non_existent_server) {
+  std::unordered_map<ServerID, std::shared_ptr<MockRuntime>> runtimes;
+  auto scheduler = std::make_shared<MockScheduler>();
+  auto dispatcher =
+      std::make_shared<MockExternalDispatcher<MockRuntime>>(runtimes);
+
+  // Sending Runtime
+  auto sending_server = ServerID{"A"};
+  runtimes.emplace(sending_server, std::make_shared<MockRuntime>(
+                                       sending_server, "RuntimeTest-sending",
+                                       scheduler, dispatcher));
+  auto sending_actor_id = runtimes[sending_server]->spawn<TrivialActor>(
+      TrivialState{.state = "foo"}, TrivialStart{});
+  auto sending_actor = ActorPID{
+      .server = sending_server, .id = sending_actor_id, .databaseName = ""};
+
+  // send
+  auto unknown_server = ServerID{"B"};
+  runtimes[sending_server]->dispatch(
+      sending_actor,
+      ActorPID{.server = unknown_server, .id = {999}, .databaseName = ""},
+      TrivialActor::Message{TrivialMessage("baz")});
+
+  // sending actor received a server not known message error after it messaged
+  // to non-existing server
+  ASSERT_EQ(
+      runtimes[sending_server]->getActorStateByID<TrivialActor>(
+          sending_actor_id),
+      (TrivialActor::State{
+          .state = fmt::format("recieving server {} not found", unknown_server),
+          .called = 2}));
+}
+
+TEST(ActorMultiRuntimeTest, ping_pong_game) {
+  std::unordered_map<ServerID, std::shared_ptr<MockRuntime>> runtimes;
+
+  auto scheduler = std::make_shared<MockScheduler>();
+  auto dispatcher =
+      std::make_shared<MockExternalDispatcher<MockRuntime>>(runtimes);
+
+  // Pong Runtime
+  auto pong_server = ServerID{"A"};
+  runtimes.emplace(pong_server,
+                   std::make_shared<MockRuntime>(pong_server, "RuntimeTest-A",
+                                                 scheduler, dispatcher));
+  auto pong_actor = runtimes[pong_server]->spawn<pong_actor::Actor>(
+      pong_actor::PongState{}, pong_actor::Start{});
+
+  // Ping Runtime
+  auto ping_server = ServerID{"B"};
+  runtimes.emplace(ping_server,
+                   std::make_shared<MockRuntime>(ping_server, "RuntimeTest-B",
+                                                 scheduler, dispatcher));
+  auto ping_actor = runtimes[ping_server]->spawn<ping_actor::Actor>(
+      ping_actor::PingState{},
+      ping_actor::Start{.pongActor = ActorPID{.server = pong_server,
+                                              .id = pong_actor,
+                                              .databaseName = ""}});
+
+  // pong actor was called twice
+  auto pong_actor_state =
+      runtimes[pong_server]->getActorStateByID<pong_actor::Actor>(pong_actor);
+  ASSERT_EQ(pong_actor_state, (pong_actor::PongState{.called = 2}));
+  // ping actor received message from pong
+  auto ping_actor_state =
+      runtimes[ping_server]->getActorStateByID<ping_actor::Actor>(ping_actor);
+  ASSERT_EQ(ping_actor_state,
+            (ping_actor::PingState{.called = 2, .message = "hello world"}));
+}

--- a/tests/Pregel/Actor/RuntimeTest.cpp
+++ b/tests/Pregel/Actor/RuntimeTest.cpp
@@ -24,22 +24,25 @@
 
 #include <gtest/gtest.h>
 #include <unordered_set>
+#include "fmt/format.h"
+#include "velocypack/SharedSlice.h"
+#include "VelocypackUtils/VelocyPackStringLiteral.h"
 
 #include "Actor/ActorPID.h"
 #include "Actor/Runtime.h"
+
 #include "Actors/FinishingActor.h"
 #include "Actors/SpawnActor.h"
 #include "Actors/TrivialActor.h"
 #include "Actors/PingPongActors.h"
-
-#include "fmt/format.h"
-#include "velocypack/SharedSlice.h"
-#include "VelocypackUtils/VelocyPackStringLiteral.h"
+#include "ThreadPoolScheduler.h"
 
 using namespace arangodb::pregel::actor;
 using namespace arangodb::pregel::actor::test;
 
 struct MockScheduler {
+  auto start(size_t number_of_threads) -> void{};
+  auto stop() -> void{};
   auto operator()(auto fn) { fn(); }
 };
 
@@ -48,30 +51,43 @@ struct EmptyExternalDispatcher {
                   arangodb::velocypack::SharedSlice msg) -> void {}
 };
 
-using MockRuntime = Runtime<MockScheduler, EmptyExternalDispatcher>;
+template<typename T>
+class ActorRuntimeTest : public testing::Test {
+ public:
+  ActorRuntimeTest() : scheduler{std::make_shared<T>()} {
+    scheduler->start(number_of_threads);
+  }
 
-TEST(ActorRuntimeTest, formats_runtime_and_actor_state) {
-  auto scheduler = std::make_shared<MockScheduler>();
+  std::shared_ptr<T> scheduler;
+  size_t number_of_threads = 5;
+};
+using SchedulerTypes = ::testing::Types<MockScheduler, ThreadPoolScheduler>;
+TYPED_TEST_SUITE(ActorRuntimeTest, SchedulerTypes);
+
+TYPED_TEST(ActorRuntimeTest, formats_runtime_and_actor_state) {
   auto dispatcher = std::make_shared<EmptyExternalDispatcher>();
-  auto runtime = std::make_shared<MockRuntime>(
-      ServerID{"PRMR-1234"}, "RuntimeTest", scheduler, dispatcher);
-  auto actorID = runtime->spawn<pong_actor::Actor>(pong_actor::PongState{},
-                                                   pong_actor::Start{});
+  auto runtime = std::make_shared<Runtime<TypeParam, EmptyExternalDispatcher>>(
+      ServerID{"PRMR-1234"}, "RuntimeTest", this->scheduler, dispatcher);
+  auto actorID = runtime->template spawn<pong_actor::Actor>(
+      pong_actor::PongState{}, pong_actor::Start{});
+
+  this->scheduler->stop();
   ASSERT_EQ(
       fmt::format("{}", *runtime),
       R"({"myServerID":"PRMR-1234","runtimeID":"RuntimeTest","uniqueActorIDCounter":1,"actors":[{"id":0,"type":"PongActor"}]})");
-  auto actor = runtime->getActorStateByID<pong_actor::Actor>(actorID).value();
+  auto actor =
+      runtime->template getActorStateByID<pong_actor::Actor>(actorID).value();
   ASSERT_EQ(fmt::format("{}", actor), R"({"called":1})");
 }
 
-TEST(ActorRuntimeTest, serializes_an_actor_including_its_actor_state) {
-  auto scheduler = std::make_shared<MockScheduler>();
+TYPED_TEST(ActorRuntimeTest, serializes_an_actor_including_its_actor_state) {
   auto dispatcher = std::make_shared<EmptyExternalDispatcher>();
-  auto runtime = std::make_shared<MockRuntime>(
-      ServerID{"PRMR-1234"}, "RuntimeTest", scheduler, dispatcher);
-  auto actor = runtime->spawn<TrivialActor>(TrivialState{.state = "foo"},
-                                            TrivialStart());
+  auto runtime = std::make_shared<Runtime<TypeParam, EmptyExternalDispatcher>>(
+      ServerID{"PRMR-1234"}, "RuntimeTest", this->scheduler, dispatcher);
+  auto actor = runtime->template spawn<TrivialActor>(
+      TrivialState{.state = "foo"}, TrivialStart());
 
+  this->scheduler->stop();
   using namespace arangodb::velocypack;
   auto expected =
       R"({"pid":{"server":"PRMR-1234","id":0},"state":{"state":"foo","called":1},"batchsize":16})"_vpack;
@@ -79,45 +95,45 @@ TEST(ActorRuntimeTest, serializes_an_actor_including_its_actor_state) {
             expected.toJson());
 }
 
-TEST(ActorRuntimeTest, spawns_actor) {
-  auto scheduler = std::make_shared<MockScheduler>();
+TYPED_TEST(ActorRuntimeTest, spawns_actor) {
   auto dispatcher = std::make_shared<EmptyExternalDispatcher>();
-  auto runtime = std::make_shared<MockRuntime>("PRMR-1234", "RuntimeTest",
-                                               scheduler, dispatcher);
+  auto runtime = std::make_shared<Runtime<TypeParam, EmptyExternalDispatcher>>(
+      "PRMR-1234", "RuntimeTest", this->scheduler, dispatcher);
 
-  auto actor = runtime->spawn<TrivialActor>(TrivialState{.state = "foo"},
-                                            TrivialStart());
+  auto actor = runtime->template spawn<TrivialActor>(
+      TrivialState{.state = "foo"}, TrivialStart());
 
-  auto state = runtime->getActorStateByID<TrivialActor>(actor);
+  this->scheduler->stop();
+  auto state = runtime->template getActorStateByID<TrivialActor>(actor);
   ASSERT_EQ(state, (TrivialState{.state = "foo", .called = 1}));
 }
 
-TEST(ActorRuntimeTest, sends_initial_message_when_spawning_actor) {
-  auto scheduler = std::make_shared<MockScheduler>();
+TYPED_TEST(ActorRuntimeTest, sends_initial_message_when_spawning_actor) {
   auto dispatcher = std::make_shared<EmptyExternalDispatcher>();
-  auto runtime = std::make_shared<MockRuntime>("PRMR-1234", "RuntimeTest",
-                                               scheduler, dispatcher);
+  auto runtime = std::make_shared<Runtime<TypeParam, EmptyExternalDispatcher>>(
+      "PRMR-1234", "RuntimeTest", this->scheduler, dispatcher);
 
-  auto actor = runtime->spawn<TrivialActor>(TrivialState{.state = "foo"},
-                                            TrivialMessage("bar"));
+  auto actor = runtime->template spawn<TrivialActor>(
+      TrivialState{.state = "foo"}, TrivialMessage("bar"));
 
-  auto state = runtime->getActorStateByID<TrivialActor>(actor);
+  this->scheduler->stop();
+  auto state = runtime->template getActorStateByID<TrivialActor>(actor);
   ASSERT_EQ(state, (TrivialState{.state = "foobar", .called = 1}));
 }
 
-TEST(ActorRuntimeTest, gives_all_existing_actor_ids) {
-  auto scheduler = std::make_shared<MockScheduler>();
+TYPED_TEST(ActorRuntimeTest, gives_all_existing_actor_ids) {
   auto dispatcher = std::make_shared<EmptyExternalDispatcher>();
-  auto runtime = std::make_shared<MockRuntime>("PRMR-1234", "RuntimeTest",
-                                               scheduler, dispatcher);
+  auto runtime = std::make_shared<Runtime<TypeParam, EmptyExternalDispatcher>>(
+      "PRMR-1234", "RuntimeTest", this->scheduler, dispatcher);
 
   ASSERT_TRUE(runtime->getActorIDs().empty());
 
-  auto actor_foo = runtime->spawn<TrivialActor>(TrivialState{.state = "foo"},
-                                                TrivialStart());
-  auto actor_bar = runtime->spawn<TrivialActor>(TrivialState{.state = "bar"},
-                                                TrivialStart());
+  auto actor_foo = runtime->template spawn<TrivialActor>(
+      TrivialState{.state = "foo"}, TrivialStart());
+  auto actor_bar = runtime->template spawn<TrivialActor>(
+      TrivialState{.state = "bar"}, TrivialStart());
 
+  this->scheduler->stop();
   auto allActorIDs = runtime->getActorIDs();
   ASSERT_EQ(allActorIDs.size(), 2);
   ASSERT_EQ(
@@ -125,19 +141,19 @@ TEST(ActorRuntimeTest, gives_all_existing_actor_ids) {
       (std::unordered_set<ActorID>{actor_foo, actor_bar}));
 }
 
-TEST(ActorRuntimeTest, sends_message_to_an_actor) {
-  auto scheduler = std::make_shared<MockScheduler>();
+TYPED_TEST(ActorRuntimeTest, sends_message_to_an_actor) {
   auto dispatcher = std::make_shared<EmptyExternalDispatcher>();
-  auto runtime = std::make_shared<MockRuntime>("PRMR-1234", "RuntimeTest",
-                                               scheduler, dispatcher);
-  auto actor = runtime->spawn<TrivialActor>(TrivialState{.state = "foo"},
-                                            TrivialStart{});
+  auto runtime = std::make_shared<Runtime<TypeParam, EmptyExternalDispatcher>>(
+      "PRMR-1234", "RuntimeTest", this->scheduler, dispatcher);
+  auto actor = runtime->template spawn<TrivialActor>(
+      TrivialState{.state = "foo"}, TrivialStart{});
 
   runtime->dispatch(ActorPID{.server = "PRMR-1234", .id = actor},
                     ActorPID{.server = "PRMR-1234", .id = actor},
                     TrivialActor::Message{TrivialMessage("baz")});
 
-  auto state = runtime->getActorStateByID<TrivialActor>(actor);
+  this->scheduler->stop();
+  auto state = runtime->template getActorStateByID<TrivialActor>(actor);
   ASSERT_EQ(state, (TrivialState{.state = "foobaz", .called = 2}));
 }
 
@@ -154,137 +170,137 @@ auto inspect(Inspector& f, SomeMessages& x) {
   return f.variant(x).unqualified().alternatives(
       arangodb::inspection::type<SomeMessage>("someMessage"));
 }
-TEST(ActorRuntimeTest,
-     actor_receiving_wrong_message_type_sends_back_unknown_error_message) {
-  auto scheduler = std::make_shared<MockScheduler>();
+TYPED_TEST(
+    ActorRuntimeTest,
+    actor_receiving_wrong_message_type_sends_back_unknown_error_message) {
   auto dispatcher = std::make_shared<EmptyExternalDispatcher>();
-  auto runtime = std::make_shared<MockRuntime>("PRMR-1234", "RuntimeTest",
-                                               scheduler, dispatcher);
-  auto actor_id = runtime->spawn<TrivialActor>(TrivialState{.state = "foo"},
-                                               TrivialStart{});
+  auto runtime = std::make_shared<Runtime<TypeParam, EmptyExternalDispatcher>>(
+      "PRMR-1234", "RuntimeTest", this->scheduler, dispatcher);
+  auto actor_id = runtime->template spawn<TrivialActor>(
+      TrivialState{.state = "foo"}, TrivialStart{});
   auto actor = ActorPID{.server = "PRMR-1234", .id = actor_id};
 
   runtime->dispatch(actor, actor, SomeMessages{SomeMessage{}});
 
+  this->scheduler->stop();
   ASSERT_EQ(
-      runtime->getActorStateByID<TrivialActor>(actor_id),
+      runtime->template getActorStateByID<TrivialActor>(actor_id),
       (TrivialState{.state = fmt::format("sent unknown message to {}", actor),
                     .called = 2}));
 }
 
-TEST(
+TYPED_TEST(
     ActorRuntimeTest,
     actor_receives_actor_not_found_message_after_trying_to_send_message_to_non_existent_actor) {
-  auto scheduler = std::make_shared<MockScheduler>();
   auto dispatcher = std::make_shared<EmptyExternalDispatcher>();
-  auto runtime = std::make_shared<MockRuntime>("PRMR-1234", "RuntimeTest",
-                                               scheduler, dispatcher);
-  auto actor_id = runtime->spawn<TrivialActor>(TrivialState{.state = "foo"},
-                                               TrivialStart{});
+  auto runtime = std::make_shared<Runtime<TypeParam, EmptyExternalDispatcher>>(
+      "PRMR-1234", "RuntimeTest", this->scheduler, dispatcher);
+  auto actor_id = runtime->template spawn<TrivialActor>(
+      TrivialState{.state = "foo"}, TrivialStart{});
   auto actor = ActorPID{.server = "PRMR-1234", .id = actor_id};
 
   auto unknown_actor = ActorPID{.server = "PRMR-1234", .id = {999}};
   runtime->dispatch(actor, unknown_actor,
                     TrivialActor::Message{TrivialMessage{"baz"}});
 
-  ASSERT_EQ(runtime->getActorStateByID<TrivialActor>(actor_id),
+  this->scheduler->stop();
+  ASSERT_EQ(runtime->template getActorStateByID<TrivialActor>(actor_id),
             (TrivialState{.state = fmt::format("receiving actor {} not found",
                                                unknown_actor),
                           .called = 2}));
 }
 
-TEST(ActorRuntimeTest, ping_pong_game) {
+TYPED_TEST(ActorRuntimeTest, ping_pong_game) {
   auto serverID = ServerID{"PRMR-1234"};
-  auto scheduler = std::make_shared<MockScheduler>();
   auto dispatcher = std::make_shared<EmptyExternalDispatcher>();
-  auto runtime = std::make_shared<MockRuntime>(serverID, "RuntimeTest",
-                                               scheduler, dispatcher);
+  auto runtime = std::make_shared<Runtime<TypeParam, EmptyExternalDispatcher>>(
+      serverID, "RuntimeTest", this->scheduler, dispatcher);
 
-  auto pong_actor = runtime->spawn<pong_actor::Actor>(pong_actor::PongState{},
-                                                      pong_actor::Start{});
-  auto ping_actor = runtime->spawn<ping_actor::Actor>(
+  auto pong_actor = runtime->template spawn<pong_actor::Actor>(
+      pong_actor::PongState{}, pong_actor::Start{});
+  auto ping_actor = runtime->template spawn<ping_actor::Actor>(
       ping_actor::PingState{},
       ping_actor::Start{.pongActor =
                             ActorPID{.server = serverID, .id = pong_actor}});
 
+  this->scheduler->stop();
   auto ping_actor_state =
-      runtime->getActorStateByID<ping_actor::Actor>(ping_actor);
+      runtime->template getActorStateByID<ping_actor::Actor>(ping_actor);
   ASSERT_EQ(ping_actor_state,
             (ping_actor::PingState{.called = 2, .message = "hello world"}));
   auto pong_actor_state =
-      runtime->getActorStateByID<pong_actor::Actor>(pong_actor);
+      runtime->template getActorStateByID<pong_actor::Actor>(pong_actor);
   ASSERT_EQ(pong_actor_state, (pong_actor::PongState{.called = 2}));
 }
 
-TEST(ActorRuntimeTest, spawn_game) {
+TYPED_TEST(ActorRuntimeTest, spawn_game) {
   auto serverID = ServerID{"PRMR-1234"};
-  auto scheduler = std::make_shared<MockScheduler>();
   auto dispatcher = std::make_shared<EmptyExternalDispatcher>();
-  auto runtime = std::make_shared<MockRuntime>(serverID, "RuntimeTest",
-                                               scheduler, dispatcher);
+  auto runtime = std::make_shared<Runtime<TypeParam, EmptyExternalDispatcher>>(
+      serverID, "RuntimeTest", this->scheduler, dispatcher);
 
   auto spawn_actor =
-      runtime->spawn<SpawnActor>(SpawnState{}, SpawnStartMessage{});
+      runtime->template spawn<SpawnActor>(SpawnState{}, SpawnStartMessage{});
 
   runtime->dispatch(ActorPID{.server = serverID, .id = spawn_actor},
                     ActorPID{.server = serverID, .id = spawn_actor},
                     SpawnActor::Message{SpawnMessage{"baz"}});
 
+  this->scheduler->stop();
   ASSERT_EQ(runtime->getActorIDs().size(), 2);
-  ASSERT_EQ(runtime->getActorStateByID<SpawnActor>(spawn_actor),
+  ASSERT_EQ(runtime->template getActorStateByID<SpawnActor>(spawn_actor),
             (SpawnState{.called = 2, .state = "baz"}));
 }
 
-TEST(ActorRuntimeTest, finishes_actor_when_actor_says_so) {
+TYPED_TEST(ActorRuntimeTest, finishes_actor_when_actor_says_so) {
   auto serverID = ServerID{"PRMR-1234"};
-  auto scheduler = std::make_shared<MockScheduler>();
   auto dispatcher = std::make_shared<EmptyExternalDispatcher>();
-  auto runtime = std::make_shared<MockRuntime>(serverID, "RuntimeTest",
-                                               scheduler, dispatcher);
+  auto runtime = std::make_shared<Runtime<TypeParam, EmptyExternalDispatcher>>(
+      serverID, "RuntimeTest", this->scheduler, dispatcher);
 
-  auto finishing_actor =
-      runtime->spawn<FinishingActor>(FinishingState{}, FinishingStart{});
+  auto finishing_actor = runtime->template spawn<FinishingActor>(
+      FinishingState{}, FinishingStart{});
 
   runtime->dispatch(ActorPID{.server = serverID, .id = finishing_actor},
                     ActorPID{.server = serverID, .id = finishing_actor},
                     FinishingActor::Message{FinishingFinish{}});
 
+  this->scheduler->stop();
   ASSERT_TRUE(runtime->actors.find(finishing_actor)->get()->finishedAndIdle());
 }
 
-TEST(ActorRuntimeTest, garbage_collects_finished_actor) {
+TYPED_TEST(ActorRuntimeTest, garbage_collects_finished_actor) {
   auto serverID = ServerID{"PRMR-1234"};
-  auto scheduler = std::make_shared<MockScheduler>();
   auto dispatcher = std::make_shared<EmptyExternalDispatcher>();
-  auto runtime = std::make_shared<MockRuntime>(serverID, "RuntimeTest",
-                                               scheduler, dispatcher);
+  auto runtime = std::make_shared<Runtime<TypeParam, EmptyExternalDispatcher>>(
+      serverID, "RuntimeTest", this->scheduler, dispatcher);
 
-  auto finishing_actor =
-      runtime->spawn<FinishingActor>(FinishingState{}, FinishingStart{});
+  auto finishing_actor = runtime->template spawn<FinishingActor>(
+      FinishingState{}, FinishingStart{});
 
   runtime->dispatch(ActorPID{.server = serverID, .id = finishing_actor},
                     ActorPID{.server = serverID, .id = finishing_actor},
                     FinishingActor::Message{FinishingFinish{}});
 
+  this->scheduler->stop();
   runtime->garbageCollect();
 
   ASSERT_EQ(runtime->actors.size(), 0);
 }
 
-TEST(ActorRuntimeTest, garbage_collects_all_finished_actors) {
+TYPED_TEST(ActorRuntimeTest, garbage_collects_all_finished_actors) {
   auto serverID = ServerID{"PRMR-1234"};
-  auto scheduler = std::make_shared<MockScheduler>();
   auto dispatcher = std::make_shared<EmptyExternalDispatcher>();
-  auto runtime = std::make_shared<MockRuntime>(serverID, "RuntimeTest",
-                                               scheduler, dispatcher);
+  auto runtime = std::make_shared<Runtime<TypeParam, EmptyExternalDispatcher>>(
+      serverID, "RuntimeTest", this->scheduler, dispatcher);
 
-  auto actor_to_be_finished =
-      runtime->spawn<FinishingActor>(FinishingState{}, FinishingStart{});
-  runtime->spawn<FinishingActor>(FinishingState{}, FinishingStart{});
-  runtime->spawn<FinishingActor>(FinishingState{}, FinishingStart{});
-  auto another_actor_to_be_finished =
-      runtime->spawn<FinishingActor>(FinishingState{}, FinishingStart{});
-  runtime->spawn<FinishingActor>(FinishingState{}, FinishingStart{});
+  auto actor_to_be_finished = runtime->template spawn<FinishingActor>(
+      FinishingState{}, FinishingStart{});
+  runtime->template spawn<FinishingActor>(FinishingState{}, FinishingStart{});
+  runtime->template spawn<FinishingActor>(FinishingState{}, FinishingStart{});
+  auto another_actor_to_be_finished = runtime->template spawn<FinishingActor>(
+      FinishingState{}, FinishingStart{});
+  runtime->template spawn<FinishingActor>(FinishingState{}, FinishingStart{});
 
   runtime->dispatch(ActorPID{.server = serverID, .id = actor_to_be_finished},
                     ActorPID{.server = serverID, .id = actor_to_be_finished},
@@ -294,6 +310,7 @@ TEST(ActorRuntimeTest, garbage_collects_all_finished_actors) {
       ActorPID{.server = serverID, .id = another_actor_to_be_finished},
       FinishingActor::Message{FinishingFinish{}});
 
+  this->scheduler->stop();
   runtime->garbageCollect();
 
   ASSERT_EQ(runtime->actors.size(), 3);
@@ -304,20 +321,21 @@ TEST(ActorRuntimeTest, garbage_collects_all_finished_actors) {
   ASSERT_FALSE(actor_ids.contains(another_actor_to_be_finished));
 }
 
-TEST(ActorRuntimeTest,
-     finishes_and_garbage_collects_all_actors_when_shutting_down) {
+TYPED_TEST(ActorRuntimeTest,
+           finishes_and_garbage_collects_all_actors_when_shutting_down) {
   auto serverID = ServerID{"PRMR-1234"};
-  auto scheduler = std::make_shared<MockScheduler>();
   auto dispatcher = std::make_shared<EmptyExternalDispatcher>();
-  auto runtime = std::make_shared<MockRuntime>(serverID, "RuntimeTest",
-                                               scheduler, dispatcher);
-  runtime->spawn<TrivialActor>(TrivialState{}, TrivialStart{});
-  runtime->spawn<TrivialActor>(TrivialState{}, TrivialStart{});
-  runtime->spawn<TrivialActor>(TrivialState{}, TrivialStart{});
-  runtime->spawn<TrivialActor>(TrivialState{}, TrivialStart{});
-  runtime->spawn<TrivialActor>(TrivialState{}, TrivialStart{});
+  auto runtime = std::make_shared<Runtime<TypeParam, EmptyExternalDispatcher>>(
+      serverID, "RuntimeTest", this->scheduler, dispatcher);
+  runtime->template spawn<TrivialActor>(TrivialState{}, TrivialStart{});
+  runtime->template spawn<TrivialActor>(TrivialState{}, TrivialStart{});
+  runtime->template spawn<TrivialActor>(TrivialState{}, TrivialStart{});
+  runtime->template spawn<TrivialActor>(TrivialState{}, TrivialStart{});
+  runtime->template spawn<TrivialActor>(TrivialState{}, TrivialStart{});
   ASSERT_EQ(runtime->actors.size(), 5);
 
+  this->scheduler->stop();
   runtime->softShutdown();
+
   ASSERT_EQ(runtime->actors.size(), 0);
 }

--- a/tests/Pregel/Actor/RuntimeTest.cpp
+++ b/tests/Pregel/Actor/RuntimeTest.cpp
@@ -188,7 +188,7 @@ TEST(
                     TrivialActor::Message{TrivialMessage{"baz"}});
 
   ASSERT_EQ(runtime->getActorStateByID<TrivialActor>(actor_id),
-            (TrivialState{.state = fmt::format("recieving actor {} not found",
+            (TrivialState{.state = fmt::format("receiving actor {} not found",
                                                unknown_actor),
                           .called = 2}));
 }

--- a/tests/Pregel/Actor/RuntimeTest.cpp
+++ b/tests/Pregel/Actor/RuntimeTest.cpp
@@ -42,11 +42,6 @@ using namespace arangodb::pregel::actor::test;
 struct MockScheduler {
   auto operator()(auto fn) { fn(); }
 };
-// struct NonTrivialScheduler {
-//   NonTrivialScheduler() {}
-//   auto operator()(auto fn) { threads.emplace(fn); }
-//   ThreadGuard threads;
-// };
 
 struct EmptyExternalDispatcher {
   auto operator()(ActorPID sender, ActorPID receiver,

--- a/tests/Pregel/Actor/RuntimeTest.cpp
+++ b/tests/Pregel/Actor/RuntimeTest.cpp
@@ -254,8 +254,7 @@ TEST(ActorRuntimeTest, finishes_actor_when_actor_says_so) {
                     ActorPID{.server = serverID, .id = finishing_actor},
                     FinishingActor::Message{FinishingFinish{}});
 
-  ASSERT_TRUE(
-      runtime->actors.find(finishing_actor)->get()->finishedAndNotBusy());
+  ASSERT_TRUE(runtime->actors.find(finishing_actor)->get()->finishedAndIdle());
 }
 
 TEST(ActorRuntimeTest, garbage_collects_finished_actor) {

--- a/tests/Pregel/Actor/RuntimeTest.cpp
+++ b/tests/Pregel/Actor/RuntimeTest.cpp
@@ -121,10 +121,9 @@ TEST(ActorRuntimeTest, sends_message_to_an_actor) {
   auto actor = runtime->spawn<TrivialActor>(TrivialState{.state = "foo"},
                                             TrivialStart{});
 
-  runtime->dispatch(
-      ActorPID{.server = "PRMR-1234", .id = actor, .databaseName = ""},
-      ActorPID{.server = "PRMR-1234", .id = actor, .databaseName = ""},
-      TrivialActor::Message{TrivialMessage("baz")});
+  runtime->dispatch(ActorPID{.server = "PRMR-1234", .id = actor},
+                    ActorPID{.server = "PRMR-1234", .id = actor},
+                    TrivialActor::Message{TrivialMessage("baz")});
 
   auto state = runtime->getActorStateByID<TrivialActor>(actor);
   ASSERT_EQ(state, (TrivialState{.state = "foobaz", .called = 2}));
@@ -151,8 +150,7 @@ TEST(ActorRuntimeTest,
                                                scheduler, dispatcher);
   auto actor_id = runtime->spawn<TrivialActor>(TrivialState{.state = "foo"},
                                                TrivialStart{});
-  auto actor =
-      ActorPID{.server = "PRMR-1234", .id = actor_id, .databaseName = ""};
+  auto actor = ActorPID{.server = "PRMR-1234", .id = actor_id};
 
   runtime->dispatch(actor, actor, SomeMessages{SomeMessage{}});
 
@@ -171,11 +169,9 @@ TEST(
                                                scheduler, dispatcher);
   auto actor_id = runtime->spawn<TrivialActor>(TrivialState{.state = "foo"},
                                                TrivialStart{});
-  auto actor =
-      ActorPID{.server = "PRMR-1234", .id = actor_id, .databaseName = ""};
+  auto actor = ActorPID{.server = "PRMR-1234", .id = actor_id};
 
-  auto unknown_actor =
-      ActorPID{.server = "PRMR-1234", .id = {999}, .databaseName = ""};
+  auto unknown_actor = ActorPID{.server = "PRMR-1234", .id = {999}};
   runtime->dispatch(actor, unknown_actor,
                     TrivialActor::Message{TrivialMessage{"baz"}});
 
@@ -196,9 +192,8 @@ TEST(ActorRuntimeTest, ping_pong_game) {
                                                       pong_actor::Start{});
   auto ping_actor = runtime->spawn<ping_actor::Actor>(
       ping_actor::PingState{},
-      ping_actor::Start{.pongActor = ActorPID{.server = serverID,
-                                              .id = pong_actor,
-                                              .databaseName = ""}});
+      ping_actor::Start{.pongActor =
+                            ActorPID{.server = serverID, .id = pong_actor}});
 
   auto ping_actor_state =
       runtime->getActorStateByID<ping_actor::Actor>(ping_actor);
@@ -219,10 +214,9 @@ TEST(ActorRuntimeTest, spawn_game) {
   auto spawn_actor =
       runtime->spawn<SpawnActor>(SpawnState{}, SpawnStartMessage{});
 
-  runtime->dispatch(
-      ActorPID{.server = serverID, .id = spawn_actor, .databaseName = ""},
-      ActorPID{.server = serverID, .id = spawn_actor, .databaseName = ""},
-      SpawnActor::Message{SpawnMessage{"baz"}});
+  runtime->dispatch(ActorPID{.server = serverID, .id = spawn_actor},
+                    ActorPID{.server = serverID, .id = spawn_actor},
+                    SpawnActor::Message{SpawnMessage{"baz"}});
 
   ASSERT_EQ(runtime->getActorIDs().size(), 2);
   ASSERT_EQ(runtime->getActorStateByID<SpawnActor>(spawn_actor),

--- a/tests/Pregel/Actor/RuntimeTest.cpp
+++ b/tests/Pregel/Actor/RuntimeTest.cpp
@@ -1,0 +1,230 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2020 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Julia Volmer
+/// @author Markus Pfeiffer
+////////////////////////////////////////////////////////////////////////////////
+
+#include <gtest/gtest.h>
+#include <unordered_set>
+
+#include "Actor/ActorPID.h"
+#include "Actor/Runtime.h"
+#include "Actors/SpawnActor.h"
+#include "Actors/TrivialActor.h"
+#include "Actors/PingPongActors.h"
+
+#include "fmt/format.h"
+#include "velocypack/SharedSlice.h"
+
+using namespace arangodb::pregel::actor;
+using namespace arangodb::pregel::actor::test;
+
+struct MockScheduler {
+  auto operator()(auto fn) { fn(); }
+};
+// struct NonTrivialScheduler {
+//   NonTrivialScheduler() {}
+//   auto operator()(auto fn) { threads.emplace(fn); }
+//   ThreadGuard threads;
+// };
+
+struct EmptyExternalDispatcher {
+  auto operator()(ActorPID sender, ActorPID receiver,
+                  arangodb::velocypack::SharedSlice msg) -> void {}
+};
+
+using MockRuntime = Runtime<MockScheduler, EmptyExternalDispatcher>;
+
+TEST(ActorRuntimeTest, formats_runtime_and_actor_state) {
+  auto scheduler = std::make_shared<MockScheduler>();
+  auto dispatcher = std::make_shared<EmptyExternalDispatcher>();
+  auto runtime = std::make_shared<MockRuntime>(
+      ServerID{"PRMR-1234"}, "RuntimeTest", scheduler, dispatcher);
+  auto actorID = runtime->spawn<pong_actor::Actor>(pong_actor::PongState{},
+                                                   pong_actor::Start{});
+  ASSERT_EQ(
+      fmt::format("{}", *runtime),
+      R"({"myServerID":"PRMR-1234","runtimeID":"RuntimeTest","uniqueActorIDCounter":1,"actors":[{"id":0,"type":"PongActor"}]})");
+  auto actor = runtime->getActorStateByID<pong_actor::Actor>(actorID).value();
+  ASSERT_EQ(fmt::format("{}", actor), R"({"called":1})");
+}
+
+TEST(ActorRuntimeTest, spawns_actor) {
+  auto scheduler = std::make_shared<MockScheduler>();
+  auto dispatcher = std::make_shared<EmptyExternalDispatcher>();
+  auto runtime = std::make_shared<MockRuntime>("PRMR-1234", "RuntimeTest",
+                                               scheduler, dispatcher);
+
+  auto actor = runtime->spawn<TrivialActor>(TrivialState{.state = "foo"},
+                                            TrivialStart());
+
+  auto state = runtime->getActorStateByID<TrivialActor>(actor);
+  ASSERT_EQ(state, (TrivialState{.state = "foo", .called = 1}));
+}
+
+TEST(ActorRuntimeTest, sends_initial_message_when_spawning_actor) {
+  auto scheduler = std::make_shared<MockScheduler>();
+  auto dispatcher = std::make_shared<EmptyExternalDispatcher>();
+  auto runtime = std::make_shared<MockRuntime>("PRMR-1234", "RuntimeTest",
+                                               scheduler, dispatcher);
+
+  auto actor = runtime->spawn<TrivialActor>(TrivialState{.state = "foo"},
+                                            TrivialMessage("bar"));
+
+  auto state = runtime->getActorStateByID<TrivialActor>(actor);
+  ASSERT_EQ(state, (TrivialState{.state = "foobar", .called = 1}));
+}
+
+TEST(ActorRuntimeTest, gives_all_existing_actor_ids) {
+  auto scheduler = std::make_shared<MockScheduler>();
+  auto dispatcher = std::make_shared<EmptyExternalDispatcher>();
+  auto runtime = std::make_shared<MockRuntime>("PRMR-1234", "RuntimeTest",
+                                               scheduler, dispatcher);
+
+  ASSERT_TRUE(runtime->getActorIDs().empty());
+
+  auto actor_foo = runtime->spawn<TrivialActor>(TrivialState{.state = "foo"},
+                                                TrivialStart());
+  auto actor_bar = runtime->spawn<TrivialActor>(TrivialState{.state = "bar"},
+                                                TrivialStart());
+
+  auto allActorIDs = runtime->getActorIDs();
+  ASSERT_EQ(allActorIDs.size(), 2);
+  ASSERT_EQ(
+      (std::unordered_set<ActorID>(allActorIDs.begin(), allActorIDs.end())),
+      (std::unordered_set<ActorID>{actor_foo, actor_bar}));
+}
+
+TEST(ActorRuntimeTest, sends_message_to_an_actor) {
+  auto scheduler = std::make_shared<MockScheduler>();
+  auto dispatcher = std::make_shared<EmptyExternalDispatcher>();
+  auto runtime = std::make_shared<MockRuntime>("PRMR-1234", "RuntimeTest",
+                                               scheduler, dispatcher);
+  auto actor = runtime->spawn<TrivialActor>(TrivialState{.state = "foo"},
+                                            TrivialStart{});
+
+  runtime->dispatch(
+      ActorPID{.server = "PRMR-1234", .id = actor, .databaseName = ""},
+      ActorPID{.server = "PRMR-1234", .id = actor, .databaseName = ""},
+      TrivialActor::Message{TrivialMessage("baz")});
+
+  auto state = runtime->getActorStateByID<TrivialActor>(actor);
+  ASSERT_EQ(state, (TrivialState{.state = "foobaz", .called = 2}));
+}
+
+struct SomeMessage {};
+template<typename Inspector>
+auto inspect(Inspector& f, SomeMessage& x) {
+  return f.object(x).fields();
+}
+struct SomeMessages : std::variant<SomeMessage> {
+  using std::variant<SomeMessage>::variant;
+};
+template<typename Inspector>
+auto inspect(Inspector& f, SomeMessages& x) {
+  return f.variant(x).unqualified().alternatives(
+      arangodb::inspection::type<SomeMessage>("someMessage"));
+}
+TEST(ActorRuntimeTest,
+     actor_receiving_wrong_message_type_sends_back_unknown_error_message) {
+  auto scheduler = std::make_shared<MockScheduler>();
+  auto dispatcher = std::make_shared<EmptyExternalDispatcher>();
+  auto runtime = std::make_shared<MockRuntime>("PRMR-1234", "RuntimeTest",
+                                               scheduler, dispatcher);
+  auto actor_id = runtime->spawn<TrivialActor>(TrivialState{.state = "foo"},
+                                               TrivialStart{});
+  auto actor =
+      ActorPID{.server = "PRMR-1234", .id = actor_id, .databaseName = ""};
+
+  runtime->dispatch(actor, actor, SomeMessages{SomeMessage{}});
+
+  ASSERT_EQ(
+      runtime->getActorStateByID<TrivialActor>(actor_id),
+      (TrivialState{.state = fmt::format("sent unknown message to {}", actor),
+                    .called = 2}));
+}
+
+TEST(
+    ActorRuntimeTest,
+    actor_receives_actor_not_found_message_after_trying_to_send_message_to_non_existent_actor) {
+  auto scheduler = std::make_shared<MockScheduler>();
+  auto dispatcher = std::make_shared<EmptyExternalDispatcher>();
+  auto runtime = std::make_shared<MockRuntime>("PRMR-1234", "RuntimeTest",
+                                               scheduler, dispatcher);
+  auto actor_id = runtime->spawn<TrivialActor>(TrivialState{.state = "foo"},
+                                               TrivialStart{});
+  auto actor =
+      ActorPID{.server = "PRMR-1234", .id = actor_id, .databaseName = ""};
+
+  auto unknown_actor =
+      ActorPID{.server = "PRMR-1234", .id = {999}, .databaseName = ""};
+  runtime->dispatch(actor, unknown_actor,
+                    TrivialActor::Message{TrivialMessage{"baz"}});
+
+  ASSERT_EQ(runtime->getActorStateByID<TrivialActor>(actor_id),
+            (TrivialState{.state = fmt::format("recieving actor {} not found",
+                                               unknown_actor),
+                          .called = 2}));
+}
+
+TEST(ActorRuntimeTest, ping_pong_game) {
+  auto serverID = ServerID{"PRMR-1234"};
+  auto scheduler = std::make_shared<MockScheduler>();
+  auto dispatcher = std::make_shared<EmptyExternalDispatcher>();
+  auto runtime = std::make_shared<MockRuntime>(serverID, "RuntimeTest",
+                                               scheduler, dispatcher);
+
+  auto pong_actor = runtime->spawn<pong_actor::Actor>(pong_actor::PongState{},
+                                                      pong_actor::Start{});
+  auto ping_actor = runtime->spawn<ping_actor::Actor>(
+      ping_actor::PingState{},
+      ping_actor::Start{.pongActor = ActorPID{.server = serverID,
+                                              .id = pong_actor,
+                                              .databaseName = ""}});
+
+  auto ping_actor_state =
+      runtime->getActorStateByID<ping_actor::Actor>(ping_actor);
+  ASSERT_EQ(ping_actor_state,
+            (ping_actor::PingState{.called = 2, .message = "hello world"}));
+  auto pong_actor_state =
+      runtime->getActorStateByID<pong_actor::Actor>(pong_actor);
+  ASSERT_EQ(pong_actor_state, (pong_actor::PongState{.called = 2}));
+}
+
+TEST(ActorRuntimeTest, spawn_game) {
+  auto serverID = ServerID{"PRMR-1234"};
+  auto scheduler = std::make_shared<MockScheduler>();
+  auto dispatcher = std::make_shared<EmptyExternalDispatcher>();
+  auto runtime = std::make_shared<MockRuntime>(serverID, "RuntimeTest",
+                                               scheduler, dispatcher);
+
+  auto spawn_actor =
+      runtime->spawn<SpawnActor>(SpawnState{}, SpawnStartMessage{});
+
+  runtime->dispatch(
+      ActorPID{.server = serverID, .id = spawn_actor, .databaseName = ""},
+      ActorPID{.server = serverID, .id = spawn_actor, .databaseName = ""},
+      SpawnActor::Message{SpawnMessage{"baz"}});
+
+  ASSERT_EQ(runtime->getActorIDs().size(), 2);
+  ASSERT_EQ(runtime->getActorStateByID<SpawnActor>(spawn_actor),
+            (SpawnState{.called = 2, .state = "baz"}));
+}

--- a/tests/Pregel/Actor/ThreadPoolScheduler.h
+++ b/tests/Pregel/Actor/ThreadPoolScheduler.h
@@ -1,0 +1,84 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2020 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Julia Volmer
+////////////////////////////////////////////////////////////////////////////////
+
+#include <condition_variable>
+#include <mutex>
+#include <queue>
+#include <vector>
+#include <thread>
+#include <functional>
+
+struct ThreadPoolScheduler {
+ private:
+  std::vector<std::thread> threads;
+  std::queue<std::function<void()>> jobs;
+  std::mutex queue_mutex;
+  std::condition_variable mutex_condition;
+  bool should_terminate = false;
+
+  auto loop() -> void {
+    while (true) {
+      std::function<void()> job;
+      {
+        std::unique_lock lock(queue_mutex);
+        mutex_condition.wait(
+            lock, [this] { return !jobs.empty() || should_terminate; });
+        // all jobs need to be completed before thread ends loop execution
+        if (should_terminate && jobs.empty()) {
+          return;
+        }
+        job = std::move(jobs.front());
+        jobs.pop();
+      }
+      job();
+    }
+  }
+
+ public:
+  auto start(size_t number_of_threads) -> void {
+    threads.resize(number_of_threads);
+    for (size_t i = 0; i < number_of_threads; i++) {
+      threads[i] = std::thread([this]() { loop(); });
+    }
+  }
+
+  auto stop() -> void {
+    {
+      std::unique_lock lock(queue_mutex);
+      should_terminate = true;
+    }
+    mutex_condition.notify_all();
+    for (auto& active_thread : threads) {
+      active_thread.join();
+    }
+    threads.clear();
+  }
+
+  auto operator()(std::function<void()> job) -> void {
+    {
+      std::unique_lock lock(queue_mutex);
+      jobs.push(job);
+    }
+    mutex_condition.notify_one();
+  }
+};

--- a/tests/Pregel/CMakeLists.txt
+++ b/tests/Pregel/CMakeLists.txt
@@ -29,3 +29,5 @@ target_link_libraries(arangodbtests_pregel
 
 add_test(NAME pregel
          COMMAND arangodbtests_pregel)
+
+add_subdirectory(Actor)


### PR DESCRIPTION
Adds a self-written actor framework that implements the actor model.
This framework will be used for messaging in Pregel and will simplify the Pregel code. Several PRs will follow in which this framework will be used inside Pregel. In the long run it can be beneficial to use the C++ Actor Framework instead of our own implementation because it is much more powerful, but for the first usage we did not want to pull a full framework into ArangoDB.

The idea of the actor model is that you have several units of computation (the actors) that run concurrently and possibly distributed. Actors only interact via messages. In our implementation, an actor has a message queue where receiving messages are buffered. Inside the actor everything runs non-concurrently: An actor takes a message from the queue, then processes it, then takes the next message from the queue and processes that and so on. This makes the processing inside the actor much less error-prone. Additionally, the framework does the sending of messages for you (also between different servers), such that your code using the framework does not need to handle that.

## Usage
One actor runtime runs on each server. This runtime has a map of all actors running on this server and is responsible for spawning new actors and communication between actors (also across servers).

To create your own custom actor you need to define
- an actor state,
- message types the actor can receive (combined inside a variant) and 
- a handler that defines what happens when a specific message type arrives. 
Have a look at example actors we used in the tests: TrivialActor.cpp, SpawnActor.cpp or PingPongActor.cpp.

Inside the handler, the actor's state can be changed, new actors can be spawned and messages can be send to other actors. Actors are typesafe, meaning they can only receive messages of their specified message types (and some predefined error message types).

When spawning an actor, a specific state and a start message have to be given. Then the runtime spawns an actor in the specific state and directly sends the start message to it.

Actors are identified via their PID, which consists of a server ID and an actor ID on that server. The handler can only send messages to other actors if it knows the receiving actor's PID. This PID can e.g. come from a received message or it is part of the actor's state.

Errors can happen when messages are send: If an error happens during sending - e.g. the receiving actor cannot be found - an error message is sent back to the sending actor. The handler can define the behavior of the custom actor if a specific error type arrives or define a catch-all for all message types it does not define a handle for. The error types are defined in Message.h; the following errors can currently occur: 
- UnknownMessage if the actor tried to send a message to another actor which does not recognize the sent message type, 
- ActorNotFound if the receiving actor cannot be found on the receiving server or
- ServerNotFound if the receiving server cannot be found


## Our implementation
### Actor
An actor receives messages (serialized or non-serialized) via the _process_ method, tries to convert the message into its own message type or an error-message and - if successful - pushes this message to its queue. This starts a work cycle that is moved to the scheduler. In this work cycle, _batchsize_ messages from the queue are processed sequentially. The scheduler is customizable, in ArangoDB we will use the ArangoDB scheduler. We use a lock-free multi-producer-single-consumer message queue (defined in MPSCQueue.h) such that we will not get any troubles when using the ArangoDB scheduler. The message queue queues messages of type MessageOrError which is a variant of the actor-specific messages and pre-defined errors. This way, the actor can receive messages and errors.

### Runtime
An actor runtime is running on each server and knows all actors running on this server - all having the same ActorBase interface. This runtime is responsible for
- spawning new actors
- sending a message to another actor (which can be an actor on the same server - meaning inside the same runtime) or on another server, and
- distributing messages coming from another server to the receiving actor in this runtime.
The runtime decides whether a message is sent locally - because the receiving actor is on the same server - or sent externally to an actor on another server. 
If a message is sent to an actor on another server, the message is serialized to velocypack and an external dispatcher sends the serialized message. The external dispatcher is customizable: A very basic example of an external dispatcher is given in MultiRuntimeTest.cpp, for ArangoDB we have to write one that sends the message via our REST interface.

### HandlerBase
The HandlerBase provides method calls of the runtime (spawning a new actor and dispatching a message to another actor) to a custom actor handler. This way the custom handler needs to inherit from HandlerBase to spawn and dispatch without having a handle on the runtime itself. Additionally, it provides the current actor state, the actor's own PID and the sender PID of the message it processes.

## TODO
We still need to implement the cleanup of actors inside the runtime, e.g. when shutting down the runtime.
