### PR TITLE
[PREG-226] Use structs for worker messages

### DIFF
--- a/arangod/Aql/Functions.cpp
+++ b/arangod/Aql/Functions.cpp
@@ -8811,12 +8811,10 @@ AqlValue functions::PregelResult(ExpressionContext* expressionContext,
       return AqlValue(AqlValueHintEmptyArray());
     }
     auto results = worker->aqlResult(withId);
-    auto response = inspection::serializeWithErrorT(results);
-    if (!response.ok()) {
-      registerWarning(expressionContext, AFN, TRI_ERROR_INTERNAL);
-      return AqlValue(AqlValueHintEmptyArray());
+    {
+      VPackArrayBuilder ab(&builder);
+      builder.add(VPackArrayIterator(results.results.slice()));
     }
-    builder.add(response.get().slice());
   }
 
   if (builder.isEmpty()) {

--- a/arangod/Aql/Functions.cpp
+++ b/arangod/Aql/Functions.cpp
@@ -8810,7 +8810,13 @@ AqlValue functions::PregelResult(ExpressionContext* expressionContext,
       registerWarning(expressionContext, AFN, TRI_ERROR_HTTP_NOT_FOUND);
       return AqlValue(AqlValueHintEmptyArray());
     }
-    worker->aqlResult(builder, withId);
+    auto results = worker->aqlResult(withId);
+    auto response = inspection::serializeWithErrorT(results);
+    if (!response.ok()) {
+      registerWarning(expressionContext, AFN, TRI_ERROR_INTERNAL);
+      return AqlValue(AqlValueHintEmptyArray());
+    }
+    builder.add(response.get().slice());
   }
 
   if (builder.isEmpty()) {

--- a/arangod/Pregel/Conductor/Conductor.cpp
+++ b/arangod/Pregel/Conductor/Conductor.cpp
@@ -205,7 +205,9 @@ bool Conductor::_startGlobalStep() {
   auto serialized = inspection::serializeWithErrorT(prepareGss);
   if (!serialized.ok()) {
     THROW_ARANGO_EXCEPTION_MESSAGE(
-        TRI_ERROR_INTERNAL, "Cannot serialize PrepareGlobalSuperStep message");
+        TRI_ERROR_INTERNAL,
+        fmt::format("Cannot serialize PrepareGlobalSuperStep message: {}",
+                    serialized.error().error()));
   }
 
   // we are explicitly expecting an response containing the aggregated
@@ -219,7 +221,9 @@ bool Conductor::_startGlobalStep() {
         if (!prepared.ok()) {
           THROW_ARANGO_EXCEPTION_MESSAGE(
               TRI_ERROR_INTERNAL,
-              "Cannot deserialize GlobalSuperStepPrepared message");
+              fmt::format(
+                  "Cannot deserialize GlobalSuperStepPrepared message: {}",
+                  prepared.error().error()));
         }
         _aggregators->aggregateValues(prepared.get().aggregators.slice());
         _statistics.accumulateActiveCounts(prepared.get().sender,
@@ -297,8 +301,10 @@ bool Conductor::_startGlobalStep() {
   // start vertex level operations, does not get a response
   auto serializedRun = inspection::serializeWithErrorT(runGss);
   if (!serializedRun.ok()) {
-    THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_INTERNAL,
-                                   "Cannot serialize RunGlobalSuperStep");
+    THROW_ARANGO_EXCEPTION_MESSAGE(
+        TRI_ERROR_INTERNAL,
+        fmt::format("Cannot serialize RunGlobalSuperStep: {}",
+                    serializedRun.error().error()));
   }
   auto startRes = _sendToAllDBServers(
       Utils::startGSSPath,
@@ -715,7 +721,9 @@ void Conductor::collectAQLResults(VPackBuilder& outBuilder, bool withId) {
   auto serialized = inspection::serializeWithErrorT(collectResults);
   if (!serialized.ok()) {
     THROW_ARANGO_EXCEPTION_MESSAGE(
-        TRI_ERROR_FAILED, "Cannot serialize CollectPregelResults message");
+        TRI_ERROR_FAILED,
+        fmt::format("Cannot serialize CollectPregelResults message: {}",
+                    serialized.error().error()));
   }
   // merge results from DBServers
   outBuilder.openArray();
@@ -726,7 +734,9 @@ void Conductor::collectAQLResults(VPackBuilder& outBuilder, bool withId) {
             velocypack::SharedSlice({}, payload));
         if (!results.ok()) {
           THROW_ARANGO_EXCEPTION_MESSAGE(
-              TRI_ERROR_FAILED, "Cannot deserialize PregelResults message");
+              TRI_ERROR_FAILED,
+              fmt::format("Cannot deserialize PregelResults message: {}",
+                          results.error().error()));
         }
         outBuilder.add(VPackArrayIterator(results.get().results.slice()));
       });

--- a/arangod/Pregel/Conductor/Conductor.cpp
+++ b/arangod/Pregel/Conductor/Conductor.cpp
@@ -621,14 +621,13 @@ ErrorCode Conductor::_finalizeWorkers() {
                              VPackBuilder(serialized.get().slice()));
 }
 
-void Conductor::finishedWorkerFinalize(VPackSlice data) {
+void Conductor::finishedWorkerFinalize(Finished const& data) {
   MUTEX_LOCKER(guard, _callbackMutex);
 
-  ServerID sender = data.get(Utils::senderKey).copyString();
-  LOG_PREGEL("60f0c", WARN)
-      << fmt::format("finishedWorkerFinalize, got response from {}.", sender);
+  LOG_PREGEL("60f0c", WARN) << fmt::format(
+      "finishedWorkerFinalize, got response from {}.", data.sender);
 
-  _ensureUniqueResponse(data);
+  _ensureUniqueResponse(data.sender);
 
   if (_respondedServers.size() != _dbServers.size()) {
     return;

--- a/arangod/Pregel/Conductor/Conductor.cpp
+++ b/arangod/Pregel/Conductor/Conductor.cpp
@@ -323,7 +323,7 @@ void Conductor::workerStatusUpdate(StatusUpdated&& update) {
   // TODO: for these updates we do not care about uniqueness of responses
   // _ensureUniqueResponse(data);
 
-  LOG_PREGEL("76632", DEBUG) << fmt::format("Update received {}", update);
+  LOG_PREGEL("76632", TRACE) << fmt::format("Update received {}", update);
 
   _status.updateWorkerStatus(update.sender, std::move(update.status));
 }

--- a/arangod/Pregel/Conductor/Conductor.h
+++ b/arangod/Pregel/Conductor/Conductor.h
@@ -138,7 +138,7 @@ class Conductor : public std::enable_shared_from_this<Conductor> {
   void _ensureUniqueResponse(std::string const& sender);
 
   // === REST callbacks ===
-  void workerStatusUpdate(VPackSlice const& data);
+  void workerStatusUpdate(StatusUpdated&& data);
   void finishedWorkerStartup(GraphLoaded const& data);
   VPackBuilder finishedWorkerStep(VPackSlice const& data);
   void finishedWorkerFinalize(VPackSlice data);

--- a/arangod/Pregel/Conductor/Conductor.h
+++ b/arangod/Pregel/Conductor/Conductor.h
@@ -28,6 +28,7 @@
 #include "Basics/Mutex.h"
 #include "Basics/system-functions.h"
 #include "Cluster/ClusterInfo.h"
+#include "Pregel/Worker/Messages.h"
 #include "Scheduler/Scheduler.h"
 #include "Utils/DatabaseGuard.h"
 
@@ -134,10 +135,11 @@ class Conductor : public std::enable_shared_from_this<Conductor> {
                                 VPackBuilder const& message,
                                 std::function<void(VPackSlice)> handle);
   void _ensureUniqueResponse(VPackSlice body);
+  void _ensureUniqueResponse(std::string const& sender);
 
   // === REST callbacks ===
   void workerStatusUpdate(VPackSlice const& data);
-  void finishedWorkerStartup(VPackSlice const& data);
+  void finishedWorkerStartup(GraphLoaded const& data);
   VPackBuilder finishedWorkerStep(VPackSlice const& data);
   void finishedWorkerFinalize(VPackSlice data);
 

--- a/arangod/Pregel/Conductor/Conductor.h
+++ b/arangod/Pregel/Conductor/Conductor.h
@@ -142,7 +142,7 @@ class Conductor : public std::enable_shared_from_this<Conductor> {
   void workerStatusUpdate(StatusUpdated&& data);
   void finishedWorkerStartup(GraphLoaded const& data);
   void finishedWorkerStep(GlobalSuperStepFinished const& data);
-  void finishedWorkerFinalize(VPackSlice data);
+  void finishedWorkerFinalize(Finished const& data);
 
   std::vector<ShardID> getShardIds(ShardID const& collection) const;
 

--- a/arangod/Pregel/Conductor/Conductor.h
+++ b/arangod/Pregel/Conductor/Conductor.h
@@ -1,3 +1,4 @@
+#include "Pregel/Worker/Messages.h"
 ////////////////////////////////////////////////////////////////////////////////
 /// DISCLAIMER
 ///
@@ -140,7 +141,7 @@ class Conductor : public std::enable_shared_from_this<Conductor> {
   // === REST callbacks ===
   void workerStatusUpdate(StatusUpdated&& data);
   void finishedWorkerStartup(GraphLoaded const& data);
-  VPackBuilder finishedWorkerStep(VPackSlice const& data);
+  void finishedWorkerStep(GlobalSuperStepFinished const& data);
   void finishedWorkerFinalize(VPackSlice data);
 
   std::vector<ShardID> getShardIds(ShardID const& collection) const;

--- a/arangod/Pregel/IncomingCache.cpp
+++ b/arangod/Pregel/IncomingCache.cpp
@@ -24,6 +24,7 @@
 #include "IncomingCache.h"
 #include "Pregel/CommonFormats.h"
 #include "Pregel/Utils.h"
+#include "Pregel/Worker/Messages.h"
 #include "Pregel/Worker/WorkerConfig.h"
 
 #include "Basics/MutexLocker.h"
@@ -43,18 +44,13 @@ InCache<M>::InCache(MessageFormat<M> const* format)
     : _containedMessageCount(0), _format(format) {}
 
 template<typename M>
-void InCache<M>::parseMessages(VPackSlice const& incomingData) {
+void InCache<M>::parseMessages(PregelMessage const& message) {
   // every packet contains one shard
-  VPackSlice shardSlice = incomingData.get(Utils::shardIdKey);
-  VPackSlice messages = incomingData.get(Utils::messagesKey);
-
-  // temporary variables
   VPackValueLength i = 0;
   std::string_view key;
-  PregelShard shard = (PregelShard)shardSlice.getUInt();
-  std::lock_guard<std::mutex> guard(this->_bucketLocker[shard]);
+  std::lock_guard<std::mutex> guard(this->_bucketLocker[message.shard]);
 
-  for (VPackSlice current : VPackArrayIterator(messages)) {
+  for (VPackSlice current : VPackArrayIterator(message.messages.slice())) {
     if (i % 2 == 0) {  // TODO support multiple recipients
       key = current.stringView();
     } else {
@@ -64,14 +60,14 @@ void InCache<M>::parseMessages(VPackSlice const& incomingData) {
         for (VPackSlice val : VPackArrayIterator(current)) {
           M newValue;
           _format->unwrapValue(val, newValue);
-          _set(shard, key, newValue);
+          _set(message.shard, key, newValue);
           c++;
         }
         this->_containedMessageCount += c;
       } else {
         M newValue;
         _format->unwrapValue(current, newValue);
-        _set(shard, key, newValue);
+        _set(message.shard, key, newValue);
         this->_containedMessageCount++;
       }
     }

--- a/arangod/Pregel/IncomingCache.h
+++ b/arangod/Pregel/IncomingCache.h
@@ -35,6 +35,7 @@
 #include "Pregel/Iterators.h"
 #include "Pregel/MessageCombiner.h"
 #include "Pregel/MessageFormat.h"
+#include "Pregel/Worker/Messages.h"
 
 namespace arangodb {
 namespace pregel {
@@ -63,7 +64,7 @@ class InCache {
   MessageFormat<M> const* format() const { return _format; }
   uint64_t containedMessageCount() const { return _containedMessageCount; }
 
-  void parseMessages(VPackSlice const& messages);
+  void parseMessages(PregelMessage const& messages);
 
   /// @brief Store a single message.
   /// Only ever call when you are sure this is a thread local store

--- a/arangod/Pregel/OutgoingCache.cpp
+++ b/arangod/Pregel/OutgoingCache.cpp
@@ -22,9 +22,12 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #include "Pregel/OutgoingCache.h"
+#include "Basics/voc-errors.h"
+#include "Inspection/VPackWithErrorT.h"
 #include "Pregel/CommonFormats.h"
 #include "Pregel/IncomingCache.h"
 #include "Pregel/Utils.h"
+#include "Pregel/Worker/Messages.h"
 #include "Pregel/Worker/WorkerConfig.h"
 
 #include "ApplicationFeatures/ApplicationServer.h"
@@ -80,6 +83,27 @@ void ArrayOutCache<M>::appendMessage(PregelShard shard,
     }
   }
 }
+template<typename M>
+auto ArrayOutCache<M>::messagesToVPack(
+    std::unordered_map<std::string, std::vector<M>> const& messagesForVertices)
+    -> std::tuple<size_t, VPackBuilder> {
+  VPackBuilder messagesVPack;
+  size_t messageCount = 0;
+  {
+    VPackArrayBuilder ab(&messagesVPack);
+    for (auto const& [vertex, messages] : messagesForVertices) {
+      messagesVPack.add(VPackValue(vertex));  // key
+      {
+        VPackArrayBuilder ab2(&messagesVPack);
+        for (M const& message : messages) {
+          this->_format->addValue(messagesVPack, message);
+          messageCount++;
+        }
+      }
+    }
+  }
+  return {messageCount, messagesVPack};
+}
 
 template<typename M>
 void ArrayOutCache<M>::flushMessages() {
@@ -93,57 +117,43 @@ void ArrayOutCache<M>::flushMessages() {
   if (this->_sendToNextGSS) {
     gss += 1;
   }
-  VPackOptions options = VPackOptions::Defaults;
-  options.buildUnindexedArrays = true;
-  options.buildUnindexedObjects = true;
-
   auto& server = this->_config->vocbase()->server();
   auto const& nf = server.template getFeature<arangodb::NetworkFeature>();
   network::ConnectionPool* pool = nf.pool();
-
   network::RequestOptions reqOpts;
   reqOpts.database = this->_config->database();
   reqOpts.skipScheduler = true;
 
   std::vector<futures::Future<network::Response>> responses;
-  for (auto const& it : _shardMap) {
-    PregelShard shard = it.first;
-    std::unordered_map<std::string, std::vector<M>> const& vertexMessageMap =
-        it.second;
+  for (auto const& [shard, vertexMessageMap] : _shardMap) {
     if (vertexMessageMap.size() == 0) {
       continue;
     }
 
-    VPackBuffer<uint8_t> buffer;
-    VPackBuilder data(buffer, &options);
-    data.openObject();
-    data.add(Utils::senderKey, VPackValue(ServerState::instance()->getId()));
-    data.add(Utils::executionNumberKey,
-             VPackValue(this->_config->executionNumber().value));
-    data.add(Utils::globalSuperstepKey, VPackValue(gss));
-    data.add(Utils::shardIdKey, VPackValue(shard));
-    data.add(Utils::messagesKey, VPackValue(VPackValueType::Array, true));
-    for (auto const& vertexMessagePair : vertexMessageMap) {
-      data.add(VPackValue(vertexMessagePair.first));      // key
-      data.add(VPackValue(VPackValueType::Array, true));  // message array
-      for (M const& val : vertexMessagePair.second) {
-        this->_format->addValue(data, val);
-        if (this->_sendToNextGSS) {
-          this->_sendCountNextGSS++;
-        } else {
-          this->_sendCount++;
-        }
-      }
-      data.close();
+    auto [shardMessageCount, messages] = messagesToVPack(vertexMessageMap);
+    auto pregelMessage =
+        PregelMessage{.executionNumber = this->_config->executionNumber(),
+                      .gss = gss,
+                      .shard = shard,
+                      .messages = messages};
+    auto serialized = inspection::serializeWithErrorT(pregelMessage);
+    if (!serialized.ok()) {
+      THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_INTERNAL,
+                                     "Cannot serialize PregelMessage");
     }
-    data.close();
-    data.close();
-    // add a request
-    ShardID const& shardId = this->_config->globalShardIDs()[shard];
-
+    VPackBuffer<uint8_t> buffer;
+    buffer.append(serialized.get().slice().begin(),
+                  serialized.get().slice().byteSize());
     responses.emplace_back(network::sendRequest(
-        pool, "shard:" + shardId, fuerte::RestVerb::Post,
-        this->_baseUrl + Utils::messagesPath, std::move(buffer), reqOpts));
+        pool, "shard:" + this->_config->globalShardIDs()[shard],
+        fuerte::RestVerb::Post, this->_baseUrl + Utils::messagesPath,
+        std::move(buffer), reqOpts));
+
+    if (this->_sendToNextGSS) {
+      this->_sendCountNextGSS += shardMessageCount;
+    } else {
+      this->_sendCount += shardMessageCount;
+    }
   }
 
   futures::collectAll(responses).wait();
@@ -200,62 +210,66 @@ void CombiningOutCache<M>::appendMessage(PregelShard shard,
 }
 
 template<typename M>
+auto CombiningOutCache<M>::messagesToVPack(
+    std::unordered_map<std::string_view, M> const& messagesForVertices)
+    -> VPackBuilder {
+  VPackBuilder messagesVPack;
+  {
+    VPackArrayBuilder ab(&messagesVPack);
+    for (auto const& [vertex, message] : messagesForVertices) {
+      messagesVPack.add(VPackValuePair(vertex.data(), vertex.size(),
+                                       VPackValueType::String));  // key
+      this->_format->addValue(messagesVPack, message);            // value
+    }
+  }
+  return messagesVPack;
+}
+
+template<typename M>
 void CombiningOutCache<M>::flushMessages() {
   if (this->_containedMessages == 0) {
     return;
   }
 
   uint64_t gss = this->_config->globalSuperstep();
-  VPackOptions options = VPackOptions::Defaults;
-  options.buildUnindexedArrays = true;
-  options.buildUnindexedObjects = true;
 
   auto& server = this->_config->vocbase()->server();
   auto const& nf = server.template getFeature<arangodb::NetworkFeature>();
   network::ConnectionPool* pool = nf.pool();
+  network::RequestOptions reqOpts;
+  reqOpts.database = this->_config->database();
+  reqOpts.timeout = network::Timeout(180);
+  reqOpts.skipScheduler = true;
 
   std::vector<futures::Future<network::Response>> responses;
-  for (auto const& it : _shardMap) {
-    PregelShard shard = it.first;
-    std::unordered_map<std::string_view, M> const& vertexMessageMap = it.second;
+  for (auto const& [shard, vertexMessageMap] : _shardMap) {
     if (vertexMessageMap.size() == 0) {
       continue;
     }
 
-    VPackBuffer<uint8_t> buffer;
-    VPackBuilder data(buffer, &options);
-    data.openObject();
-    data.add(Utils::senderKey, VPackValue(ServerState::instance()->getId()));
-    data.add(Utils::executionNumberKey,
-             VPackValue(this->_config->executionNumber().value));
-    data.add(Utils::globalSuperstepKey, VPackValue(gss));
-    data.add(Utils::shardIdKey, VPackValue(shard));
-    data.add(Utils::messagesKey, VPackValue(VPackValueType::Array, true));
-    for (auto const& vertexMessagePair : vertexMessageMap) {
-      data.add(VPackValuePair(vertexMessagePair.first.data(),
-                              vertexMessagePair.first.size(),
-                              VPackValueType::String));         // key
-      this->_format->addValue(data, vertexMessagePair.second);  // value
-
-      if (this->_sendToNextGSS) {
-        this->_sendCountNextGSS++;
-      } else {
-        this->_sendCount++;
-      }
+    auto pregelMessage =
+        PregelMessage{.executionNumber = this->_config->executionNumber(),
+                      .gss = gss,
+                      .shard = shard,
+                      .messages = messagesToVPack(vertexMessageMap)};
+    auto serialized = inspection::serializeWithErrorT(pregelMessage);
+    if (!serialized.ok()) {
+      THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_INTERNAL,
+                                     "Cannot serialize PregelMessage");
     }
-    data.close();
-    data.close();
-    // add a request
-    ShardID const& shardId = this->_config->globalShardIDs()[shard];
-
-    network::RequestOptions reqOpts;
-    reqOpts.database = this->_config->database();
-    reqOpts.timeout = network::Timeout(180);
-    reqOpts.skipScheduler = true;
-
+    VPackBuffer<uint8_t> buffer;
+    buffer.append(serialized.get().slice().begin(),
+                  serialized.get().slice().byteSize());
     responses.emplace_back(network::sendRequest(
-        pool, "shard:" + shardId, fuerte::RestVerb::Post,
-        this->_baseUrl + Utils::messagesPath, std::move(buffer), reqOpts));
+        pool, "shard:" + this->_config->globalShardIDs()[shard],
+        fuerte::RestVerb::Post, this->_baseUrl + Utils::messagesPath,
+        std::move(buffer), reqOpts));
+
+    if (this->_sendToNextGSS) {
+      this->_sendCountNextGSS += vertexMessageMap.size();
+    } else {
+      this->_sendCount += vertexMessageMap.size();
+    }
   }
 
   futures::collectAll(responses).wait();

--- a/arangod/Pregel/OutgoingCache.h
+++ b/arangod/Pregel/OutgoingCache.h
@@ -113,6 +113,9 @@ class ArrayOutCache : public OutCache<M> {
 
   void appendMessage(PregelShard shard, std::string_view const& key,
                      M const& data) override;
+  auto messagesToVPack(std::unordered_map<std::string, std::vector<M>> const&
+                           messagesForVertices)
+      -> std::tuple<size_t, VPackBuilder>;
   void flushMessages() override;
 };
 
@@ -132,6 +135,9 @@ class CombiningOutCache : public OutCache<M> {
 
   void appendMessage(PregelShard shard, std::string_view const& key,
                      M const& data) override;
+  auto messagesToVPack(
+      std::unordered_map<std::string_view, M> const& messagesForVertices)
+      -> VPackBuilder;
   void flushMessages() override;
 };
 }  // namespace pregel

--- a/arangod/Pregel/PregelFeature.cpp
+++ b/arangod/Pregel/PregelFeature.cpp
@@ -829,7 +829,14 @@ void PregelFeature::handleWorkerRequest(TRI_vocbase_t& vocbase,
           TRI_ERROR_INTERNAL,
           "Cannot deserialize PrepareGlobalSuperStep message");
     }
-    w->prepareGlobalStep(message.get(), outBuilder);
+    auto prepared = w->prepareGlobalStep(message.get());
+    auto response = inspection::serializeWithErrorT(prepared);
+    if (!response.ok()) {
+      THROW_ARANGO_EXCEPTION_MESSAGE(
+          TRI_ERROR_INTERNAL,
+          "Cannot serialize GlobalSuperStepPrepared message");
+    }
+    outBuilder.add(response.get().slice());
   } else if (path == Utils::startGSSPath) {
     auto message = inspection::deserializeWithErrorT<RunGlobalSuperStep>(
         velocypack::SharedSlice({}, body));

--- a/arangod/Pregel/PregelFeature.cpp
+++ b/arangod/Pregel/PregelFeature.cpp
@@ -784,7 +784,13 @@ void PregelFeature::handleConductorRequest(TRI_vocbase_t& vocbase,
     }
     co->finishedWorkerStep(message.get());
   } else if (path == Utils::finishedWorkerFinalizationPath) {
-    co->finishedWorkerFinalize(body);
+    auto message = inspection::deserializeWithErrorT<Finished>(
+        velocypack::SharedSlice({}, body));
+    if (!message.ok()) {
+      THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_INTERNAL,
+                                     "Cannot deserialize Finished message");
+    }
+    co->finishedWorkerFinalize(message.get());
   }
 }
 

--- a/arangod/Pregel/PregelFeature.cpp
+++ b/arangod/Pregel/PregelFeature.cpp
@@ -763,15 +763,19 @@ void PregelFeature::handleConductorRequest(TRI_vocbase_t& vocbase,
         velocypack::SharedSlice({}, body));
     if (!message.ok()) {
       THROW_ARANGO_EXCEPTION_MESSAGE(
-          TRI_ERROR_INTERNAL, "Cannot deserialize StatusUpdated message");
+          TRI_ERROR_INTERNAL,
+          fmt::format("Cannot deserialize StatusUpdated message: {}",
+                      message.error().error()));
     }
     co->workerStatusUpdate(std::move(message.get()));
   } else if (path == Utils::finishedStartupPath) {
     auto message = inspection::deserializeWithErrorT<GraphLoaded>(
         velocypack::SharedSlice({}, body));
     if (!message.ok()) {
-      THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_INTERNAL,
-                                     "Cannot deserialize GraphLoaded message");
+      THROW_ARANGO_EXCEPTION_MESSAGE(
+          TRI_ERROR_INTERNAL,
+          fmt::format("Cannot deserialize GraphLoaded message: {}",
+                      message.error().error()));
     }
     co->finishedWorkerStartup(message.get());
   } else if (path == Utils::finishedWorkerStepPath) {
@@ -780,15 +784,18 @@ void PregelFeature::handleConductorRequest(TRI_vocbase_t& vocbase,
     if (!message.ok()) {
       THROW_ARANGO_EXCEPTION_MESSAGE(
           TRI_ERROR_INTERNAL,
-          "Cannot deserialize GlobalSuperStepFinished message");
+          fmt::format("Cannot deserialize GlobalSuperStepFinished message: {}",
+                      message.error().error()));
     }
     co->finishedWorkerStep(message.get());
   } else if (path == Utils::finishedWorkerFinalizationPath) {
     auto message = inspection::deserializeWithErrorT<Finished>(
         velocypack::SharedSlice({}, body));
     if (!message.ok()) {
-      THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_INTERNAL,
-                                     "Cannot deserialize Finished message");
+      THROW_ARANGO_EXCEPTION_MESSAGE(
+          TRI_ERROR_INTERNAL,
+          fmt::format("Cannot deserialize Finished message: {}",
+                      message.error().error()));
     }
     co->finishedWorkerFinalize(message.get());
   }
@@ -823,8 +830,10 @@ void PregelFeature::handleWorkerRequest(TRI_vocbase_t& vocbase,
     auto createWorker = inspection::deserializeWithErrorT<CreateWorker>(
         velocypack::SharedSlice({}, body));
     if (!createWorker.ok()) {
-      THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_INTERNAL,
-                                     "Cannot deserialize CreateWorker message");
+      THROW_ARANGO_EXCEPTION_MESSAGE(
+          TRI_ERROR_INTERNAL,
+          fmt::format("Cannot deserialize CreateWorker message: {}",
+                      createWorker.error().error()));
     }
 
     addWorker(AlgoRegistry::createWorker(vocbase, createWorker.get(), *this),
@@ -853,14 +862,16 @@ void PregelFeature::handleWorkerRequest(TRI_vocbase_t& vocbase,
     if (!message.ok()) {
       THROW_ARANGO_EXCEPTION_MESSAGE(
           TRI_ERROR_INTERNAL,
-          "Cannot deserialize PrepareGlobalSuperStep message");
+          fmt::format("Cannot deserialize PrepareGlobalSuperStep message: {}",
+                      message.error().error()));
     }
     auto prepared = w->prepareGlobalStep(message.get());
     auto response = inspection::serializeWithErrorT(prepared);
     if (!response.ok()) {
       THROW_ARANGO_EXCEPTION_MESSAGE(
           TRI_ERROR_INTERNAL,
-          "Cannot serialize GlobalSuperStepPrepared message");
+          fmt::format("Cannot serialize GlobalSuperStepPrepared message: {}",
+                      message.error().error()));
     }
     outBuilder.add(response.get().slice());
   } else if (path == Utils::startGSSPath) {
@@ -868,7 +879,9 @@ void PregelFeature::handleWorkerRequest(TRI_vocbase_t& vocbase,
         velocypack::SharedSlice({}, body));
     if (!message.ok()) {
       THROW_ARANGO_EXCEPTION_MESSAGE(
-          TRI_ERROR_INTERNAL, "Cannot deserialize RunGlobalSuperStep message");
+          TRI_ERROR_INTERNAL,
+          fmt::format("Cannot deserialize RunGlobalSuperStep message: {}",
+                      message.error().error()));
     }
     w->startGlobalStep(message.get());
   } else if (path == Utils::messagesPath) {
@@ -876,7 +889,9 @@ void PregelFeature::handleWorkerRequest(TRI_vocbase_t& vocbase,
         velocypack::SharedSlice({}, body));
     if (!message.ok()) {
       THROW_ARANGO_EXCEPTION_MESSAGE(
-          TRI_ERROR_INTERNAL, "Cannot deserialize PregelMessage message");
+          TRI_ERROR_INTERNAL,
+          fmt::format("Cannot deserialize PregelMessage message: {}",
+                      message.error().error()));
     }
     w->receivedMessages(message.get());
   } else if (path == Utils::finalizeExecutionPath) {
@@ -884,7 +899,9 @@ void PregelFeature::handleWorkerRequest(TRI_vocbase_t& vocbase,
         velocypack::SharedSlice({}, body));
     if (!message.ok()) {
       THROW_ARANGO_EXCEPTION_MESSAGE(
-          TRI_ERROR_INTERNAL, "Cannot deserialize FinalizeExecution message");
+          TRI_ERROR_INTERNAL,
+          fmt::format("Cannot deserialize FinalizeExecution message: {}",
+                      message.error().error()));
     }
     w->finalizeExecution(message.get(),
                          [this, exeNum]() { cleanupWorker(exeNum); });
@@ -894,13 +911,16 @@ void PregelFeature::handleWorkerRequest(TRI_vocbase_t& vocbase,
     if (!message.ok()) {
       THROW_ARANGO_EXCEPTION_MESSAGE(
           TRI_ERROR_INTERNAL,
-          "Cannot deserialize CollectPregelResults message");
+          fmt::format("Cannot deserialize CollectPregelResults message: {}",
+                      message.error().error()));
     }
     auto results = w->aqlResult(message.get().withId);
     auto response = inspection::serializeWithErrorT(results);
     if (!response.ok()) {
-      THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_INTERNAL,
-                                     "Cannot serialize PregelResults message");
+      THROW_ARANGO_EXCEPTION_MESSAGE(
+          TRI_ERROR_INTERNAL,
+          fmt::format("Cannot serialize PregelResults message: {}",
+                      response.error().error()));
     }
     outBuilder.add(response.get().slice());
   }

--- a/arangod/Pregel/PregelFeature.cpp
+++ b/arangod/Pregel/PregelFeature.cpp
@@ -890,7 +890,13 @@ void PregelFeature::handleWorkerRequest(TRI_vocbase_t& vocbase,
           TRI_ERROR_INTERNAL,
           "Cannot deserialize CollectPregelResults message");
     }
-    w->aqlResult(outBuilder, message.get().withId);
+    auto results = w->aqlResult(message.get().withId);
+    auto response = inspection::serializeWithErrorT(results);
+    if (!response.ok()) {
+      THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_INTERNAL,
+                                     "Cannot serialize PregelResults message");
+    }
+    outBuilder.add(response.get().slice());
   }
 }
 

--- a/arangod/Pregel/PregelFeature.cpp
+++ b/arangod/Pregel/PregelFeature.cpp
@@ -758,7 +758,13 @@ void PregelFeature::handleConductorRequest(TRI_vocbase_t& vocbase,
   }
 
   if (path == Utils::statusUpdatePath) {
-    co->workerStatusUpdate(body);
+    auto message = inspection::deserializeWithErrorT<StatusUpdated>(
+        velocypack::SharedSlice({}, body));
+    if (!message.ok()) {
+      THROW_ARANGO_EXCEPTION_MESSAGE(
+          TRI_ERROR_INTERNAL, "Cannot deserialize StatusUpdated message");
+    }
+    co->workerStatusUpdate(std::move(message.get()));
   } else if (path == Utils::finishedStartupPath) {
     auto message = inspection::deserializeWithErrorT<GraphLoaded>(
         velocypack::SharedSlice({}, body));

--- a/arangod/Pregel/PregelFeature.cpp
+++ b/arangod/Pregel/PregelFeature.cpp
@@ -760,7 +760,13 @@ void PregelFeature::handleConductorRequest(TRI_vocbase_t& vocbase,
   if (path == Utils::statusUpdatePath) {
     co->workerStatusUpdate(body);
   } else if (path == Utils::finishedStartupPath) {
-    co->finishedWorkerStartup(body);
+    auto message = inspection::deserializeWithErrorT<GraphLoaded>(
+        velocypack::SharedSlice({}, body));
+    if (!message.ok()) {
+      THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_INTERNAL,
+                                     "Cannot deserialize GraphLoaded message");
+    }
+    co->finishedWorkerStartup(message.get());
   } else if (path == Utils::finishedWorkerStepPath) {
     outBuilder = co->finishedWorkerStep(body);
   } else if (path == Utils::finishedWorkerFinalizationPath) {

--- a/arangod/Pregel/PregelFeature.cpp
+++ b/arangod/Pregel/PregelFeature.cpp
@@ -872,7 +872,13 @@ void PregelFeature::handleWorkerRequest(TRI_vocbase_t& vocbase,
     }
     w->startGlobalStep(message.get());
   } else if (path == Utils::messagesPath) {
-    w->receivedMessages(body);
+    auto message = inspection::deserializeWithErrorT<PregelMessage>(
+        velocypack::SharedSlice({}, body));
+    if (!message.ok()) {
+      THROW_ARANGO_EXCEPTION_MESSAGE(
+          TRI_ERROR_INTERNAL, "Cannot deserialize PregelMessage message");
+    }
+    w->receivedMessages(message.get());
   } else if (path == Utils::finalizeExecutionPath) {
     auto message = inspection::deserializeWithErrorT<FinalizeExecution>(
         velocypack::SharedSlice({}, body));

--- a/arangod/Pregel/Statistics.h
+++ b/arangod/Pregel/Statistics.h
@@ -75,6 +75,13 @@ struct MessageStats {
 
   bool allMessagesProcessed() { return sendCount == receivedCount; }
 };
+template<typename Inspector>
+auto inspect(Inspector& f, MessageStats& x) {
+  return f.object(x).fields(
+      f.field("sendCount", x.sendCount),
+      f.field("receivedCount", x.receivedCount),
+      f.field("superstepRuntimeInSeconds", x.superstepRuntimeSecs));
+}
 
 struct StatsManager {
   void accumulateActiveCounts(VPackSlice data) {
@@ -96,6 +103,11 @@ struct StatsManager {
     if (sender.isString()) {
       _serverStats[sender.copyString()].accumulate(data);
     }
+  }
+
+  void accumulateMessageStats(std::string const& sender,
+                              MessageStats const& stats) {
+    _serverStats[sender].accumulate(stats);
   }
 
   void serializeValues(VPackBuilder& b) const {

--- a/arangod/Pregel/Statistics.h
+++ b/arangod/Pregel/Statistics.h
@@ -87,6 +87,10 @@ struct StatsManager {
     }
   }
 
+  void accumulateActiveCounts(std::string const& sender, uint64_t active) {
+    _activeStats[sender] += active;
+  }
+
   void accumulateMessageStats(VPackSlice data) {
     VPackSlice sender = data.get(Utils::senderKey);
     if (sender.isString()) {

--- a/arangod/Pregel/Worker/Messages.h
+++ b/arangod/Pregel/Worker/Messages.h
@@ -1,0 +1,115 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2022 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Julia Volmer
+////////////////////////////////////////////////////////////////////////////////
+#pragma once
+
+#include "Cluster/ClusterTypes.h"
+#include "Pregel/ExecutionNumber.h"
+#include "Pregel/Graph.h"
+#include "Pregel/Statistics.h"
+#include "Pregel/Status/Status.h"
+
+namespace arangodb::pregel {
+
+struct GlobalSuperStepPrepared {
+  ExecutionNumber executionNumber;
+  std::string sender;
+  uint64_t activeCount;
+  uint64_t vertexCount;
+  uint64_t edgeCount;
+  VPackBuilder aggregators;
+};
+template<typename Inspector>
+auto inspect(Inspector& f, GlobalSuperStepPrepared& x) {
+  return f.object(x).fields(
+      f.field(Utils::executionNumberKey, x.executionNumber),
+      f.field("sender", x.sender), f.field("activeCount", x.activeCount),
+      f.field("vertexCount", x.vertexCount), f.field("edgeCount", x.edgeCount),
+      f.field("aggregators", x.aggregators));
+}
+
+struct GlobalSuperStepFinished {
+  MessageStats messageStats;
+  std::unordered_map<ShardID, uint64_t> sendCountPerShard;
+  uint64_t activeCount;
+  uint64_t vertexCount;
+  uint64_t edgeCount;
+  VPackBuilder aggregators;
+};
+
+template<typename Inspector>
+auto inspect(Inspector& f, GlobalSuperStepFinished& x) {
+  return f.object(x).fields(f.field("messageStats", x.messageStats),
+                            f.field("sentCounts", x.sendCountPerShard),
+                            f.field("activeCount", x.activeCount),
+                            f.field("vertexCount", x.vertexCount),
+                            f.field("edgeCount", x.edgeCount),
+                            f.field("aggregators", x.aggregators));
+}
+
+struct Stored {};
+template<typename Inspector>
+auto inspect(Inspector& f, Stored& x) {
+  return f.object(x).fields();
+}
+
+struct CleanupFinished {};
+template<typename Inspector>
+auto inspect(Inspector& f, CleanupFinished& x) {
+  return f.object(x).fields();
+}
+
+struct StatusUpdated {
+  std::string senderId;
+  Status status;
+};
+
+template<typename Inspector>
+auto inspect(Inspector& f, StatusUpdated& x) {
+  return f.object(x).fields(f.field(Utils::senderKey, x.senderId),
+                            f.field("status", x.status));
+}
+
+struct PregelResults {
+  VPackBuilder results;
+};
+template<typename Inspector>
+auto inspect(Inspector& f, PregelResults& x) {
+  return f.object(x).fields(f.field("results", x.results));
+}
+
+struct PregelMessage {
+  std::string senderId;
+  uint64_t gss;
+  PregelShard shard;
+  VPackBuilder messages;
+};
+
+template<typename Inspector>
+auto inspect(Inspector& f, PregelMessage& x) {
+  return f.object(x).fields(f.field(Utils::senderKey, x.senderId),
+                            f.field(Utils::globalSuperstepKey, x.gss),
+                            f.field("shard", x.shard),
+                            f.field("messages", x.messages));
+}
+
+}  // namespace arangodb::pregel

--- a/arangod/Pregel/Worker/Messages.h
+++ b/arangod/Pregel/Worker/Messages.h
@@ -30,6 +30,21 @@
 
 namespace arangodb::pregel {
 
+struct GraphLoaded {
+  ExecutionNumber executionNumber;
+  std::string sender;
+  uint64_t vertexCount;
+  uint64_t edgeCount;
+};
+
+template<typename Inspector>
+auto inspect(Inspector& f, GraphLoaded& x) {
+  return f.object(x).fields(
+      f.field(Utils::executionNumberKey, x.executionNumber),
+      f.field("sender", x.sender), f.field("vertexCount", x.vertexCount),
+      f.field("edgeCount", x.edgeCount));
+}
+
 struct GlobalSuperStepPrepared {
   ExecutionNumber executionNumber;
   std::string sender;

--- a/arangod/Pregel/Worker/Messages.h
+++ b/arangod/Pregel/Worker/Messages.h
@@ -23,6 +23,7 @@
 #pragma once
 
 #include "Cluster/ClusterTypes.h"
+#include "Inspection/Format.h"
 #include "Pregel/ExecutionNumber.h"
 #include "Pregel/Graph.h"
 #include "Pregel/Statistics.h"
@@ -94,14 +95,15 @@ auto inspect(Inspector& f, CleanupFinished& x) {
 }
 
 struct StatusUpdated {
-  std::string senderId;
+  ExecutionNumber executionNumber;
+  std::string sender;
   Status status;
 };
-
 template<typename Inspector>
 auto inspect(Inspector& f, StatusUpdated& x) {
-  return f.object(x).fields(f.field(Utils::senderKey, x.senderId),
-                            f.field("status", x.status));
+  return f.object(x).fields(
+      f.field(Utils::executionNumberKey, x.executionNumber),
+      f.field("sender", x.sender), f.field("status", x.status));
 }
 
 struct PregelResults {
@@ -128,3 +130,7 @@ auto inspect(Inspector& f, PregelMessage& x) {
 }
 
 }  // namespace arangodb::pregel
+
+template<>
+struct fmt::formatter<arangodb::pregel::StatusUpdated>
+    : arangodb::inspection::inspection_formatter {};

--- a/arangod/Pregel/Worker/Messages.h
+++ b/arangod/Pregel/Worker/Messages.h
@@ -110,7 +110,7 @@ auto inspect(Inspector& f, PregelResults& x) {
 }
 
 struct PregelMessage {
-  std::string senderId;
+  ExecutionNumber executionNumber;
   uint64_t gss;
   PregelShard shard;
   VPackBuilder messages;
@@ -118,10 +118,10 @@ struct PregelMessage {
 
 template<typename Inspector>
 auto inspect(Inspector& f, PregelMessage& x) {
-  return f.object(x).fields(f.field(Utils::senderKey, x.senderId),
-                            f.field(Utils::globalSuperstepKey, x.gss),
-                            f.field("shard", x.shard),
-                            f.field("messages", x.messages));
+  return f.object(x).fields(
+      f.field(Utils::executionNumberKey, x.executionNumber),
+      f.field(Utils::globalSuperstepKey, x.gss), f.field("shard", x.shard),
+      f.field("messages", x.messages));
 }
 
 }  // namespace arangodb::pregel

--- a/arangod/Pregel/Worker/Messages.h
+++ b/arangod/Pregel/Worker/Messages.h
@@ -64,22 +64,18 @@ auto inspect(Inspector& f, GlobalSuperStepPrepared& x) {
 }
 
 struct GlobalSuperStepFinished {
+  ExecutionNumber executionNumber;
+  std::string sender;
+  uint64_t gss;
   MessageStats messageStats;
-  std::unordered_map<ShardID, uint64_t> sendCountPerShard;
-  uint64_t activeCount;
-  uint64_t vertexCount;
-  uint64_t edgeCount;
-  VPackBuilder aggregators;
 };
 
 template<typename Inspector>
 auto inspect(Inspector& f, GlobalSuperStepFinished& x) {
-  return f.object(x).fields(f.field("messageStats", x.messageStats),
-                            f.field("sentCounts", x.sendCountPerShard),
-                            f.field("activeCount", x.activeCount),
-                            f.field("vertexCount", x.vertexCount),
-                            f.field("edgeCount", x.edgeCount),
-                            f.field("aggregators", x.aggregators));
+  return f.object(x).fields(
+      f.field(Utils::executionNumberKey, x.executionNumber),
+      f.field("sender", x.sender), f.field("gss", x.gss),
+      f.field("messageStats", x.messageStats));
 }
 
 struct Stored {};
@@ -133,4 +129,7 @@ auto inspect(Inspector& f, PregelMessage& x) {
 
 template<>
 struct fmt::formatter<arangodb::pregel::StatusUpdated>
+    : arangodb::inspection::inspection_formatter {};
+template<>
+struct fmt::formatter<arangodb::pregel::GlobalSuperStepFinished>
     : arangodb::inspection::inspection_formatter {};

--- a/arangod/Pregel/Worker/Messages.h
+++ b/arangod/Pregel/Worker/Messages.h
@@ -78,16 +78,15 @@ auto inspect(Inspector& f, GlobalSuperStepFinished& x) {
       f.field("messageStats", x.messageStats));
 }
 
-struct Stored {};
+struct Finished {
+  ExecutionNumber executionNumber;
+  std::string sender;
+};
 template<typename Inspector>
-auto inspect(Inspector& f, Stored& x) {
-  return f.object(x).fields();
-}
-
-struct CleanupFinished {};
-template<typename Inspector>
-auto inspect(Inspector& f, CleanupFinished& x) {
-  return f.object(x).fields();
+auto inspect(Inspector& f, Finished& x) {
+  return f.object(x).fields(
+      f.field(Utils::executionNumberKey, x.executionNumber),
+      f.field("sender", x.sender));
 }
 
 struct StatusUpdated {

--- a/arangod/Pregel/Worker/Worker.cpp
+++ b/arangod/Pregel/Worker/Worker.cpp
@@ -160,8 +160,10 @@ void Worker<V, E, M>::setupWorker() {
                     .edgeCount = _graphStore->localEdgeCount()};
     auto serialized = inspection::serializeWithErrorT(graphLoaded);
     if (!serialized.ok()) {
-      THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_FAILED,
-                                     "Cannot serialize GraphLoaded message");
+      THROW_ARANGO_EXCEPTION_MESSAGE(
+          TRI_ERROR_FAILED,
+          fmt::format("Cannot serialize GraphLoaded message: {}",
+                      serialized.error().error()));
     }
     _callConductor(Utils::finishedStartupPath,
                    VPackBuilder(serialized.get().slice()));
@@ -493,7 +495,9 @@ void Worker<V, E, M>::_finishedProcessing() {
   auto serialized = inspection::serializeWithErrorT(gssFinished);
   if (!serialized.ok()) {
     THROW_ARANGO_EXCEPTION_MESSAGE(
-        TRI_ERROR_INTERNAL, "Cannot serialize GlobalSuperStepFinished message");
+        TRI_ERROR_INTERNAL,
+        fmt::format("Cannot serialize GlobalSuperStepFinished message: {}",
+                    serialized.error().error()));
   }
   _callConductor(Utils::finishedWorkerStepPath,
                  VPackBuilder(serialized.get().slice()));
@@ -527,8 +531,10 @@ void Worker<V, E, M>::finalizeExecution(FinalizeExecution const& msg,
                              .sender = ServerState::instance()->getId()};
     auto serialized = inspection::serializeWithErrorT(finished);
     if (!serialized.ok()) {
-      THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_INTERNAL,
-                                     "Cannot serialize Finished message");
+      THROW_ARANGO_EXCEPTION_MESSAGE(
+          TRI_ERROR_INTERNAL,
+          fmt::format("Cannot serialize Finished message: {}",
+                      serialized.error().error()));
     }
     _callConductor(Utils::finishedWorkerFinalizationPath,
                    VPackBuilder(serialized.get().slice()));
@@ -648,8 +654,10 @@ auto Worker<V, E, M>::_makeStatusCallback() -> std::function<void()> {
                                 .status = _observeStatus()};
     auto serialized = inspection::serializeWithErrorT(update);
     if (!serialized.ok()) {
-      THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_FAILED,
-                                     "Cannot serialize StatusUpdated message");
+      THROW_ARANGO_EXCEPTION_MESSAGE(
+          TRI_ERROR_FAILED,
+          fmt::format("Cannot serialize StatusUpdated message: {}",
+                      serialized.error().error()));
     }
     _callConductor(Utils::statusUpdatePath,
                    VPackBuilder(serialized.get().slice()));

--- a/arangod/Pregel/Worker/Worker.cpp
+++ b/arangod/Pregel/Worker/Worker.cpp
@@ -256,10 +256,8 @@ GlobalSuperStepPrepared Worker<V, E, M>::prepareGlobalStep(
 }
 
 template<typename V, typename E, typename M>
-void Worker<V, E, M>::receivedMessages(VPackSlice const& data) {
-  VPackSlice gssSlice = data.get(Utils::globalSuperstepKey);
-  uint64_t gss = gssSlice.getUInt();
-  if (gss == _config._globalSuperstep) {
+void Worker<V, E, M>::receivedMessages(PregelMessage const& data) {
+  if (data.gss == _config._globalSuperstep) {
     {  // make sure the pointer is not changed while
       // parsing messages
       MY_READ_LOCKER(guard, _cacheRWLock);
@@ -269,8 +267,8 @@ void Worker<V, E, M>::receivedMessages(VPackSlice const& data) {
 
   } else {
     // Trigger the processing of vertices
-    LOG_PREGEL("ecd34", ERR)
-        << "Expected: " << _config._globalSuperstep << "Got: " << gss;
+    LOG_PREGEL("ecd34", ERR) << fmt::format("Expected: {}, Got: {}",
+                                            _config._globalSuperstep, data.gss);
     THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_BAD_PARAMETER,
                                    "Superstep out of sync");
   }

--- a/arangod/Pregel/Worker/Worker.h
+++ b/arangod/Pregel/Worker/Worker.h
@@ -58,7 +58,7 @@ class IWorker : public std::enable_shared_from_this<IWorker> {
       RunGlobalSuperStep const& data) = 0;  // called by coordinator
   virtual void cancelGlobalStep(
       VPackSlice const& data) = 0;  // called by coordinator
-  virtual void receivedMessages(VPackSlice const& data) = 0;
+  virtual void receivedMessages(PregelMessage const& data) = 0;
   virtual void finalizeExecution(FinalizeExecution const& data,
                                  std::function<void()> cb) = 0;
   virtual auto aqlResult(bool withId) const -> PregelResults = 0;
@@ -154,7 +154,7 @@ class Worker : public IWorker {
       PrepareGlobalSuperStep const& data) override;
   void startGlobalStep(RunGlobalSuperStep const& data) override;
   void cancelGlobalStep(VPackSlice const& data) override;
-  void receivedMessages(VPackSlice const& data) override;
+  void receivedMessages(PregelMessage const& data) override;
   void finalizeExecution(FinalizeExecution const& data,
                          std::function<void()> cb) override;
 

--- a/arangod/Pregel/Worker/Worker.h
+++ b/arangod/Pregel/Worker/Worker.h
@@ -61,7 +61,7 @@ class IWorker : public std::enable_shared_from_this<IWorker> {
   virtual void receivedMessages(VPackSlice const& data) = 0;
   virtual void finalizeExecution(FinalizeExecution const& data,
                                  std::function<void()> cb) = 0;
-  virtual void aqlResult(VPackBuilder&, bool withId) const = 0;
+  virtual auto aqlResult(bool withId) const -> PregelResults = 0;
 };
 
 template<typename V, typename E>
@@ -158,7 +158,7 @@ class Worker : public IWorker {
   void finalizeExecution(FinalizeExecution const& data,
                          std::function<void()> cb) override;
 
-  void aqlResult(VPackBuilder&, bool withId) const override;
+  auto aqlResult(bool withId) const -> PregelResults override;
 };
 
 }  // namespace arangodb::pregel

--- a/arangod/Pregel/Worker/Worker.h
+++ b/arangod/Pregel/Worker/Worker.h
@@ -33,6 +33,7 @@
 #include "Pregel/Conductor/Messages.h"
 #include "Pregel/Statistics.h"
 #include "Pregel/Status/Status.h"
+#include "Pregel/Worker/Messages.h"
 #include "Pregel/Worker/WorkerConfig.h"
 #include "Pregel/WorkerContext.h"
 #include "Scheduler/Scheduler.h"
@@ -51,8 +52,8 @@ class IWorker : public std::enable_shared_from_this<IWorker> {
  public:
   virtual ~IWorker() = default;
   virtual void setupWorker() = 0;
-  virtual void prepareGlobalStep(PrepareGlobalSuperStep const& data,
-                                 VPackBuilder& result) = 0;
+  virtual GlobalSuperStepPrepared prepareGlobalStep(
+      PrepareGlobalSuperStep const& data) = 0;
   virtual void startGlobalStep(
       RunGlobalSuperStep const& data) = 0;  // called by coordinator
   virtual void cancelGlobalStep(
@@ -149,8 +150,8 @@ class Worker : public IWorker {
 
   // ====== called by rest handler =====
   void setupWorker() override;
-  void prepareGlobalStep(PrepareGlobalSuperStep const& data,
-                         VPackBuilder& result) override;
+  GlobalSuperStepPrepared prepareGlobalStep(
+      PrepareGlobalSuperStep const& data) override;
   void startGlobalStep(RunGlobalSuperStep const& data) override;
   void cancelGlobalStep(VPackSlice const& data) override;
   void receivedMessages(VPackSlice const& data) override;


### PR DESCRIPTION
Use structs instead of plain velocypack for messages sent from worker to conductor.

This is a preparation step for using a proper messaging framework for Pregel.
