### PR TITLE
allow usage of suffix `b` in startup option values

### DIFF
--- a/lib/ProgramOptions/UnitsHelper.cpp
+++ b/lib/ProgramOptions/UnitsHelper.cpp
@@ -34,7 +34,9 @@ std::pair<std::string_view, uint64_t> extractSuffix(std::string_view value) {
   constexpr uint64_t oneKiB = 1'024;
   constexpr uint64_t oneKB = 1'000;
 
-  constexpr std::array<std::pair<std::string_view, uint64_t>, 28> units = {{
+  // note: longer strings must come first in this array!
+  constexpr std::array<std::pair<std::string_view, uint64_t>, 30> units = {{
+      // three letter units
       {std::string_view{"kib"}, oneKiB},
       {std::string_view{"KiB"}, oneKiB},
       {std::string_view{"KIB"}, oneKiB},
@@ -47,6 +49,7 @@ std::pair<std::string_view, uint64_t> extractSuffix(std::string_view value) {
       {std::string_view{"tib"}, oneKiB * oneKiB * oneKiB * oneKiB},
       {std::string_view{"TiB"}, oneKiB * oneKiB * oneKiB * oneKiB},
       {std::string_view{"TIB"}, oneKiB * oneKiB * oneKiB * oneKiB},
+      // two letter units
       {std::string_view{"kb"}, oneKB},
       {std::string_view{"KB"}, oneKB},
       {std::string_view{"mb"}, oneKB * oneKB},
@@ -55,6 +58,7 @@ std::pair<std::string_view, uint64_t> extractSuffix(std::string_view value) {
       {std::string_view{"GB"}, oneKB * oneKB * oneKB},
       {std::string_view{"tb"}, oneKB * oneKB * oneKB * oneKB},
       {std::string_view{"TB"}, oneKB * oneKB * oneKB * oneKB},
+      // single letter units
       {std::string_view{"k"}, oneKB},
       {std::string_view{"K"}, oneKB},
       {std::string_view{"m"}, oneKB * oneKB},
@@ -63,6 +67,8 @@ std::pair<std::string_view, uint64_t> extractSuffix(std::string_view value) {
       {std::string_view{"G"}, oneKB * oneKB * oneKB},
       {std::string_view{"t"}, oneKB * oneKB * oneKB * oneKB},
       {std::string_view{"T"}, oneKB * oneKB * oneKB * oneKB},
+      {std::string_view{"b"}, 1},
+      {std::string_view{"B"}, 1},
   }};
 
   // handle unit suffixes

--- a/tests/ProgramOptions/ParametersTest.cpp
+++ b/tests/ProgramOptions/ParametersTest.cpp
@@ -130,6 +130,18 @@ TEST(ParametersTest, toNumberComments) {
 }
 
 TEST(ParametersTest, toNumberUnits) {
+  ASSERT_EQ(int64_t(0), arangodb::options::toNumber<int64_t>("0b"));
+  ASSERT_EQ(int64_t(1), arangodb::options::toNumber<int64_t>("1b"));
+  ASSERT_EQ(int64_t(100), arangodb::options::toNumber<int64_t>("100b"));
+  ASSERT_EQ(int64_t(1000000), arangodb::options::toNumber<int64_t>("1000000b"));
+  ASSERT_EQ(int64_t(1234567890),
+            arangodb::options::toNumber<int64_t>("1234567890b"));
+  ASSERT_EQ(int64_t(0), arangodb::options::toNumber<int64_t>("0B"));
+  ASSERT_EQ(int64_t(1), arangodb::options::toNumber<int64_t>("1B"));
+  ASSERT_EQ(int64_t(100), arangodb::options::toNumber<int64_t>("100B"));
+  ASSERT_EQ(int64_t(6684888386),
+            arangodb::options::toNumber<int64_t>("6684888386B"));
+
   ASSERT_EQ(int64_t(0), arangodb::options::toNumber<int64_t>("0k"));
   ASSERT_EQ(int64_t(0), arangodb::options::toNumber<int64_t>("0kb"));
   ASSERT_EQ(int64_t(0), arangodb::options::toNumber<int64_t>("0KB"));


### PR DESCRIPTION
### Scope & Purpose

we previously allowed kb, mb, gb, tb, but not b.
now it is possible to specify things with a unit of bytes as well, e.g. `--rocksdb.block-cache-size=1073741824b`.

docs PR: https://github.com/arangodb/docs/pull/1253

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: -
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -

#### Related Information

- [x] Docs PR: https://github.com/arangodb/docs/pull/1253
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 