### PR TITLE
added server options for arangosearch cache in RTA

### DIFF
--- a/js/client/modules/@arangodb/testsuites/rta_makedata.js
+++ b/js/client/modules/@arangodb/testsuites/rta_makedata.js
@@ -80,6 +80,7 @@ function makeDataWrapper (options) {
     constructor(options, testname, ...optionalArgs) {
       super(options, testname, ...optionalArgs);
       this.info = "runRtaInArangosh";
+      this.serverOptions["arangosearch.columns-cache-limit"] = "5000";
     }
     filter(te, filtered) {
       return true;


### PR DESCRIPTION
### Scope & Purpose

We should enable arangosearch cache by specifying the parameter `--arangosearch.columns-cache-limit <N>` in RTA script in main repository.

- [ ] :hankey: Bugfix
- [X] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [X] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [X] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: *(Please link PR)*
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

