### PR TITLE
small cleanup w.r.t. HeartbeatThread

### DIFF
--- a/arangod/Cluster/ActionBase.cpp
+++ b/arangod/Cluster/ActionBase.cpp
@@ -27,7 +27,6 @@
 #include "ApplicationFeatures/ApplicationServer.h"
 #include "Basics/TimeString.h"
 #include "Cluster/ClusterFeature.h"
-#include "Cluster/HeartbeatThread.h"
 #include "Cluster/MaintenanceFeature.h"
 #include "Logger/LogMacros.h"
 #include "Logger/Logger.h"
@@ -96,8 +95,8 @@ bool ActionBase::matches(std::unordered_set<std::string> const& labels) const {
   return true;
 }
 
-bool ActionBase::fastTrack() const {
-  return _labels.find(FAST_TRACK) != _labels.end();
+bool ActionBase::fastTrack() const noexcept {
+  return _labels.contains(FAST_TRACK);
 }
 
 /// @brief execution finished successfully or failed ... and race timer expired

--- a/arangod/Cluster/ActionBase.h
+++ b/arangod/Cluster/ActionBase.h
@@ -75,15 +75,15 @@ class ActionBase {
   virtual bool done() const;
 
   /// @brief waiting for a worker to grab it and go!
-  bool runnable() const { return READY == _state; }
+  bool runnable() const noexcept { return READY == _state; }
 
   /// @brief did initialization have issues?
-  bool ok() const { return FAILED != _state; }
+  bool ok() const noexcept { return FAILED != _state; }
 
   /// @brief adjust state of object, assumes WRITE lock on _actionRegistryLock
-  ActionState state() const { return _state; }
+  ActionState state() const noexcept { return _state; }
 
-  bool fastTrack() const;
+  bool fastTrack() const noexcept;
 
   void notify();
 

--- a/arangod/Cluster/HeartbeatThread.cpp
+++ b/arangod/Cluster/HeartbeatThread.cpp
@@ -71,8 +71,6 @@ using namespace arangodb;
 using namespace arangodb::application_features;
 using namespace arangodb::rest;
 
-std::atomic<bool> HeartbeatThread::HasRunOnce(false);
-
 namespace arangodb {
 
 class HeartbeatBackgroundJobThread : public Thread {
@@ -224,6 +222,7 @@ HeartbeatThread::HeartbeatThread(Server& server,
       _lastSuccessfulVersion(0),
       _currentPlanVersion(0),
       _ready(false),
+      _hasRunOnce(false),
       _currentVersions(0, 0),
       _desiredVersions(std::make_shared<AgencyVersions>(0, 0)),
       _backgroundJobsPosted(0),
@@ -1401,14 +1400,14 @@ bool HeartbeatThread::handlePlanChangeCoordinator(uint64_t currentPlanVersion) {
               << "creating local database '" << dbName
               << "' failed: " << res.errorMessage();
         } else {
-          HasRunOnce.store(true, std::memory_order_release);
+          _hasRunOnce.store(true, std::memory_order_release);
         }
       } else {
         if (vocbase->isSystem()) {
           // workaround: _system collection already exists now on every
-          // coordinator setting HasRunOnce lets coordinator startup continue
+          // coordinator setting _hasRunOnce lets coordinator startup continue
           TRI_ASSERT(vocbase->id() == 1);
-          HasRunOnce.store(true, std::memory_order_release);
+          _hasRunOnce.store(true, std::memory_order_release);
         }
       }
     }

--- a/arangod/Cluster/MaintenanceRestHandler.cpp
+++ b/arangod/Cluster/MaintenanceRestHandler.cpp
@@ -29,7 +29,6 @@
 #include "Basics/conversions.h"
 #include "Cluster/ClusterFeature.h"
 #include "Cluster/DBServerAgencySync.h"
-#include "Cluster/HeartbeatThread.h"
 #include "Cluster/MaintenanceFeature.h"
 #include "Logger/LogMacros.h"
 #include "Logger/Logger.h"

--- a/arangod/Cluster/RestClusterHandler.cpp
+++ b/arangod/Cluster/RestClusterHandler.cpp
@@ -229,7 +229,7 @@ void RestClusterHandler::handleCommandEndpoints() {
       }
     }
 
-    // master always in front
+    // leader always in front
     endpoints.insert(endpoints.begin(), leaderId);
 
   } else {


### PR DESCRIPTION
### Scope & Purpose

Small cleanup w.r.t. HeartbeatThread
- removed a few unnecessary includes of HeartbeatThread.h
- turned a static variable in HeartbeatThread.cpp into an instance variable

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: -
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 