### PR TITLE
[BTS-899] _admin/status crash on agents

### DIFF
--- a/arangod/RestHandler/RestStatusHandler.cpp
+++ b/arangod/RestHandler/RestStatusHandler.cpp
@@ -145,11 +145,12 @@ RestStatus RestStatusHandler::executeStandard(ServerSecurityFeature& security) {
 
     if (!isStartup && !serverState->isSingleServer()) {
       result.add("persistedId", VPackValue(serverState->getPersistedId()));
-      if (auto rid = serverState->getRebootId(); rid.initialized()) {
-        result.add("rebootId", VPackValue(rid.value()));
-      }
 
       if (!serverState->isAgent()) {
+        // agents do not initialize the reboot id
+        if (auto rid = serverState->getRebootId(); rid.initialized()) {
+          result.add("rebootId", VPackValue(rid.value()));
+        }
         result.add("address", VPackValue(serverState->getEndpoint()));
         result.add("serverId", VPackValue(serverState->getId()));
 


### PR DESCRIPTION
### Scope & Purpose
[BTS](https://arangodb.atlassian.net/browse/BTS-899)

Do not expose the reboot id on agents, because there is none.