### PR TITLE
if shell-general-graph-creation-cluster.js is ran with coverage instrumented binaries, this test will not finish any time soon

### DIFF
--- a/tests/js/server/shell/shell-general-graph-creation-cluster.js
+++ b/tests/js/server/shell/shell-general-graph-creation-cluster.js
@@ -1,5 +1,5 @@
 /*jshint globalstrict:false, strict:false */
-/*global assertEqual, assertTrue, assertFalse, fail */
+/*global print, assertEqual, assertTrue, assertFalse, fail */
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief test the general-graph class
@@ -72,6 +72,10 @@ function GeneralGraphClusterCreationSuite() {
     },
 
     testCreateMoreShardsThanAllowed : function () {
+      if (internal.ccoverage) {
+        print("Skipping testCreateMoreShardsThanAllowed in coverage tests");
+        return;
+      }
       let max = internal.maxNumberOfShards;
       try {
         graph._create(gn, edgeDef, null, { numberOfShards: max + 1 });

--- a/tests/js/server/shell/shell-general-graph-creation-cluster.js
+++ b/tests/js/server/shell/shell-general-graph-creation-cluster.js
@@ -66,19 +66,17 @@ function GeneralGraphClusterCreationSuite() {
     
     testCreateAsManyShardsAsAllowed : function () {
       let max = internal.maxNumberOfShards;
-      let myGraph = graph._create(gn, edgeDef, null, { numberOfShards: max });
+      let myGraph = graph._create(gn, edgeDef, null, { numberOfShards: max, replicationFactor: 1 });
       let properties = db._graphs.document(gn);
+      assertEqual(1, properties.replicationFactor);
+      assertEqual(1, properties.minReplicationFactor);
       assertEqual(max, properties.numberOfShards);
     },
 
     testCreateMoreShardsThanAllowed : function () {
-      if (internal.ccoverage) {
-        print("Skipping testCreateMoreShardsThanAllowed in coverage tests");
-        return;
-      }
       let max = internal.maxNumberOfShards;
       try {
-        graph._create(gn, edgeDef, null, { numberOfShards: max + 1 });
+        graph._create(gn, edgeDef, null, { numberOfShards: max + 1, replicationFactor: 1 });
         fail();
       } catch (err) {
         assertEqual(ERRORS.ERROR_CLUSTER_TOO_MANY_SHARDS.code, err.errorNum);
@@ -90,7 +88,7 @@ function GeneralGraphClusterCreationSuite() {
       db._createEdgeCollection(en);
       let max = internal.maxNumberOfShards;
       try {
-        graph._create(gn, edgeDef, null, { numberOfShards: max + 1 });
+        graph._create(gn, edgeDef, null, { numberOfShards: max + 1, replicationFactor: 1 });
         fail();
       } catch (err) {
         assertEqual(ERRORS.ERROR_CLUSTER_TOO_MANY_SHARDS.code, err.errorNum);

--- a/tests/js/server/shell/shell-general-graph-creation-cluster.js
+++ b/tests/js/server/shell/shell-general-graph-creation-cluster.js
@@ -1,5 +1,5 @@
 /*jshint globalstrict:false, strict:false */
-/*global print, assertEqual, assertTrue, assertFalse, fail */
+/*global assertEqual, assertTrue, assertFalse, fail */
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief test the general-graph class


### PR DESCRIPTION
### Scope & Purpose

creating the maximum number of available shards with the preconfigured number of replications is quiet resource intense. 
Disable replication for this test, since it primarily wants to check whether the limit is respected.