### PR TITLE
testing: split the long running server_parameters testsuite into buckets for better parallelism.

### DIFF
--- a/js/client/modules/@arangodb/testsuites/server_permissions.js
+++ b/js/client/modules/@arangodb/testsuites/server_permissions.js
@@ -254,13 +254,15 @@ class permissionsRunner extends tu.runLocalInArangoshRunner {
 }
 
 function server_permissions(options) {
-  return new permissionsRunner(options, "server_permissions").run(
-    tu.scanTestPaths(testPaths.server_permissions, options));
+  let testCases = tu.scanTestPaths(testPaths.server_permissions, options);
+  testCases = tu.splitBuckets(options, testCases);
+  return new permissionsRunner(options, "server_permissions").run(testCases);
 }
 
 function server_parameters(options) {
-  return new permissionsRunner(options, "server_parameters").run(
-    tu.scanTestPaths(testPaths.server_parameters, options));
+  let testCases = tu.scanTestPaths(testPaths.server_parameters, options);
+  testCases = tu.splitBuckets(options, testCases);
+  return new permissionsRunner(options, "server_parameters").run(testCases);
 }
 
 function server_secrets(options) {

--- a/tests/test-definitions.txt
+++ b/tests/test-definitions.txt
@@ -86,7 +86,7 @@ replication2_client cluster
 replication2_server cluster buckets=3 -- --dumpAgencyOnError true
 
 resilience_analyzers priority=500 cluster -- --dumpAgencyOnError true
-resilience_failover priority=750 cluster -- --dumpAgencyOnError true
+resilience_failover priority=1200 cluster -- --dumpAgencyOnError true
 resilience_move priority=600 cluster -- --dumpAgencyOnError true
 resilience_sharddist cluster -- --dumpAgencyOnError true
 

--- a/tests/test-definitions.txt
+++ b/tests/test-definitions.txt
@@ -108,7 +108,7 @@ hot_backup !windows -- --dumpAgencyOnError true
 
 # frequent restarts impose more threats to the SUT, increase parallelity.
 server_parameters priority=1000 parallelity=2 single -- --dumpAgencyOnError true
-server_parameters priority=1000 parallelity=5 cluster -- --dumpAgencyOnError true
+server_parameters priority=1000 parallelity=5 buckets=6 cluster -- --dumpAgencyOnError true
 server_permissions priority=1000 parallelity=5 -- --dumpAgencyOnError true
 server_secrets priority=500 -- --dumpAgencyOnError true
 


### PR DESCRIPTION
### Scope & Purpose

Improve parallelism by bucketing test

