### PR TITLE
[GORDO-1509] Use actor framework in pregel

### DIFF
--- a/arangod/Pregel/Actor/include/Actor/ActorPID.h
+++ b/arangod/Pregel/Actor/include/Actor/ActorPID.h
@@ -69,11 +69,14 @@ using DatabaseName = std::string;
 
 struct ActorPID {
   ServerID server;
+  DatabaseName database;
   ActorID id;
 };
 template<typename Inspector>
 auto inspect(Inspector& f, ActorPID& x) {
-  return f.object(x).fields(f.field("server", x.server), f.field("id", x.id));
+  return f.object(x).fields(f.field("server", x.server),
+                            f.field("database", x.database),
+                            f.field("id", x.id));
 }
 
 }  // namespace arangodb::pregel::actor

--- a/arangod/Pregel/Actor/include/Actor/HandlerBase.h
+++ b/arangod/Pregel/Actor/include/Actor/HandlerBase.h
@@ -45,7 +45,8 @@ struct HandlerBase {
   template<typename ActorConfig>
   auto spawn(typename ActorConfig::State initialState,
              typename ActorConfig::Message initialMessage) -> ActorID {
-    return runtime->template spawn<ActorConfig>(initialState, initialMessage);
+    return runtime->template spawn<ActorConfig>(self.database, initialState,
+                                                initialMessage);
   }
 
   auto finish() -> void { runtime->finish(self); }

--- a/arangod/Pregel/Actor/include/Actor/Message.h
+++ b/arangod/Pregel/Actor/include/Actor/Message.h
@@ -68,24 +68,23 @@ auto inspect(Inspector& f, ActorNotFound& x) {
   return f.object(x).fields(f.field("actor", x.actor));
 }
 
-struct ServerNotFound {
-  ServerID server;
+struct NetworkError {
+  std::string message;
 };
 template<typename Inspector>
-auto inspect(Inspector& f, ServerNotFound& x) {
-  return f.object(x).fields(f.field("server", x.server));
+auto inspect(Inspector& f, NetworkError& x) {
+  return f.object(x).fields(f.field("server", x.message));
 }
 
-struct ActorError
-    : std::variant<UnknownMessage, ActorNotFound, ServerNotFound> {
-  using std::variant<UnknownMessage, ActorNotFound, ServerNotFound>::variant;
+struct ActorError : std::variant<UnknownMessage, ActorNotFound, NetworkError> {
+  using std::variant<UnknownMessage, ActorNotFound, NetworkError>::variant;
 };
 template<typename Inspector>
 auto inspect(Inspector& f, ActorError& x) {
   return f.variant(x).unqualified().alternatives(
       arangodb::inspection::type<UnknownMessage>("UnknownMessage"),
       arangodb::inspection::type<ActorNotFound>("ActorNotFound"),
-      arangodb::inspection::type<ServerNotFound>("ServerNotFound"));
+      arangodb::inspection::type<NetworkError>("NetworkError"));
 }
 
 template<typename T, typename U>
@@ -120,5 +119,5 @@ template<>
 struct fmt::formatter<arangodb::pregel::actor::ActorNotFound>
     : arangodb::inspection::inspection_formatter {};
 template<>
-struct fmt::formatter<arangodb::pregel::actor::ServerNotFound>
+struct fmt::formatter<arangodb::pregel::actor::NetworkError>
     : arangodb::inspection::inspection_formatter {};

--- a/arangod/Pregel/ArangoExternalDispatcher.h
+++ b/arangod/Pregel/ArangoExternalDispatcher.h
@@ -1,0 +1,100 @@
+#pragma once
+
+#include "Actor/ActorPID.h"
+#include "Actor/Message.h"
+#include "Inspection/VPackWithErrorT.h"
+#include "Logger/LogMacros.h"
+#include "Network/ConnectionPool.h"
+#include "Network/Methods.h"
+
+namespace arangodb::pregel {
+
+struct NetworkMessage {
+  actor::ActorPID sender;
+  actor::ActorPID receiver;
+  VPackBuilder payload;
+};
+template<typename Inspector>
+auto inspect(Inspector& f, NetworkMessage& x) {
+  return f.object(x).fields(f.field("sender", x.sender),
+                            f.field("receiver", x.receiver),
+                            f.field("payload", x.payload));
+}
+
+struct ArangoExternalDispatcher {
+  static auto errorHandling(arangodb::network::Response const& message)
+      -> arangodb::ResultT<VPackSlice> {
+    if (message.fail()) {
+      return {arangodb::Result{
+          TRI_ERROR_INTERNAL,
+          fmt::format("REST request failed: {}",
+                      arangodb::fuerte::to_string(message.error))}};
+    }
+    if (message.statusCode() >= 400) {
+      return {arangodb::Result{
+          TRI_ERROR_FAILED,
+          fmt::format("REST request returned an error code {}: {}",
+                      message.statusCode(), message.slice().toJson())}};
+    }
+    return message.slice();
+  }
+
+  ArangoExternalDispatcher(std::string url,
+                           network::ConnectionPool* connectionPool)
+      : connectionPool(connectionPool), baseURL{std::move(url)} {}
+
+  auto send(actor::ActorPID sender, actor::ActorPID receiver,
+            arangodb::velocypack::SharedSlice msg) -> network::FutureRes {
+    auto networkMessage =
+        NetworkMessage{.sender = sender,
+                       .receiver = receiver,
+                       .payload = velocypack::Builder(msg.slice())};
+    auto serialized = inspection::serializeWithErrorT(networkMessage);
+    if (not serialized.ok()) {
+      fmt::print(stderr, "Error serializing ActorNotFound");
+      std::abort();
+    }
+    auto builder = velocypack::Builder(serialized.get().slice());
+    return network::sendRequestRetry(
+        this->connectionPool,
+        // TODO: what about "shard:"?
+        std::string{"server:"} + receiver.server, fuerte::RestVerb::Post,
+        baseURL, builder.bufferRef(),
+        network::RequestOptions{.database = receiver.database,
+                                .timeout = timeout});
+  }
+
+  auto operator()(actor::ActorPID sender, actor::ActorPID receiver,
+                  arangodb::velocypack::SharedSlice msg) -> void {
+    send(sender, receiver, msg)
+        .thenValue([sender, receiver, this](auto&& result) -> void {
+          auto out = errorHandling(result);
+          if (out.fail()) {
+            auto error = actor::ActorError{actor::NetworkError{
+                .message = (std::string)out.errorMessage()}};
+            auto payload = inspection::serializeWithErrorT(error);
+            if (!payload.ok()) {
+              fmt::print("Error serializing NetworkError");
+              std::abort();
+            }
+            send(receiver, sender, payload.get())
+                .thenValue([](auto&& result) -> void {
+                  // if sending the error does also not work, we just print the
+                  // error
+                  auto out = errorHandling(result);
+                  if (out.fail()) {
+                    LOG_DEVEL
+                        << fmt::format("Error in network communication: {}",
+                                       out.errorMessage());
+                  }
+                });
+          }
+        });
+  }
+
+  network::ConnectionPool* connectionPool;
+  std::string baseURL;
+  network::Timeout timeout{5.0 * 60};
+};
+
+}  // namespace arangodb::pregel

--- a/arangod/Pregel/ArangoExternalDispatcher.h
+++ b/arangod/Pregel/ArangoExternalDispatcher.h
@@ -72,13 +72,14 @@ struct ArangoExternalDispatcher {
     auto serialized = inspection::serializeWithErrorT(networkMessage);
     ADB_PROD_ASSERT(serialized.ok());
     auto builder = velocypack::Builder(serialized.get().slice());
-    return network::sendRequestRetry(
-        this->connectionPool,
-        // TODO: what about "shard:"?
-        std::string{"server:"} + receiver.server, fuerte::RestVerb::Post,
-        baseURL, builder.bufferRef(),
-        network::RequestOptions{.database = receiver.database,
-                                .timeout = timeout});
+    auto options = network::RequestOptions{};
+    options.database = receiver.database;
+    options.timeout = timeout;
+    return network::sendRequestRetry(this->connectionPool,
+                                     // TODO: what about "shard:"?
+                                     std::string{"server:"} + receiver.server,
+                                     fuerte::RestVerb::Post, baseURL,
+                                     builder.bufferRef(), options);
   }
 
   static auto errorHandling(arangodb::network::Response const& message)

--- a/arangod/Pregel/CMakeLists.txt
+++ b/arangod/Pregel/CMakeLists.txt
@@ -13,6 +13,7 @@ target_link_libraries(arango_pregel
   arango
   arango_agency
   boost_boost
+  arango_actor
   boost_system)
 
 target_include_directories(arango_pregel PRIVATE

--- a/arangod/Pregel/Conductor/Actor.h
+++ b/arangod/Pregel/Conductor/Actor.h
@@ -1,0 +1,93 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2022 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Julia Volmer
+////////////////////////////////////////////////////////////////////////////////
+#pragma once
+
+#include <memory>
+#include "Actor/HandlerBase.h"
+#include "Pregel/Worker/Actor.h"
+#include "Pregel/Conductor/Messages.h"
+#include "Logger/LogMacros.h"
+#include "fmt/core.h"
+
+namespace arangodb::pregel {
+
+struct ConductorState {};
+template<typename Inspector>
+auto inspect(Inspector& f, ConductorState& x) {
+  return f.object(x).fields();
+}
+
+template<typename Runtime>
+struct ConductorHandler : actor::HandlerBase<Runtime, ConductorState> {
+  auto operator()(ConductorStart start) -> std::unique_ptr<ConductorState> {
+    LOG_DEVEL << fmt::format("Conductor Actor {} started", this->self);
+    // TODO call State::initializeWorkers in here
+    // and then spawn actors from here
+    return std::move(this->state);
+  }
+
+  auto operator()(WorkerCreated start) -> std::unique_ptr<ConductorState> {
+    LOG_DEVEL << "Conductor Actor: Worker was created";
+    return std::move(this->state);
+  }
+
+  auto operator()(actor::UnknownMessage unknown)
+      -> std::unique_ptr<ConductorState> {
+    LOG_DEVEL << fmt::format(
+        "Conductor Actor: Error - sent unknown message to {}",
+        unknown.receiver);
+    return std::move(this->state);
+  }
+
+  auto operator()(actor::ActorNotFound notFound)
+      -> std::unique_ptr<ConductorState> {
+    LOG_DEVEL << fmt::format(
+        "Conductor Actor: Error - recieving actor {} not found",
+        notFound.actor);
+    return std::move(this->state);
+  }
+
+  auto operator()(actor::NetworkError notFound)
+      -> std::unique_ptr<ConductorState> {
+    LOG_DEVEL << fmt::format("Conductor Actor: Error - network error {}",
+                             notFound.message);
+    return std::move(this->state);
+  }
+
+  auto operator()(auto&& rest) -> std::unique_ptr<ConductorState> {
+    LOG_DEVEL << "Conductor Actor: Got unhandled message";
+    return std::move(this->state);
+  }
+};
+
+struct ConductorActor {
+  using State = ConductorState;
+  using Message = ConductorMessages;
+  template<typename Runtime>
+  using Handler = ConductorHandler<Runtime>;
+  static constexpr auto typeName() -> std::string_view {
+    return "Conductor Actor";
+  }
+};
+
+}  // namespace arangodb::pregel

--- a/arangod/Pregel/Conductor/Actor.h
+++ b/arangod/Pregel/Conductor/Actor.h
@@ -26,7 +26,6 @@
 #include "Actor/HandlerBase.h"
 #include "Pregel/Worker/Actor.h"
 #include "Pregel/Conductor/Messages.h"
-#include "Logger/LogMacros.h"
 #include "fmt/core.h"
 
 namespace arangodb::pregel {
@@ -40,42 +39,45 @@ auto inspect(Inspector& f, ConductorState& x) {
 template<typename Runtime>
 struct ConductorHandler : actor::HandlerBase<Runtime, ConductorState> {
   auto operator()(ConductorStart start) -> std::unique_ptr<ConductorState> {
-    LOG_DEVEL << fmt::format("Conductor Actor {} started", this->self);
+    LOG_TOPIC("56db0", INFO, Logger::PREGEL)
+        << fmt::format("Conductor Actor {} started", this->self);
     // TODO call State::initializeWorkers in here
     // and then spawn actors from here
     return std::move(this->state);
   }
 
   auto operator()(WorkerCreated start) -> std::unique_ptr<ConductorState> {
-    LOG_DEVEL << "Conductor Actor: Worker was created";
+    LOG_TOPIC("17915", INFO, Logger::PREGEL)
+        << "Conductor Actor: Worker was created";
     return std::move(this->state);
   }
 
   auto operator()(actor::UnknownMessage unknown)
       -> std::unique_ptr<ConductorState> {
-    LOG_DEVEL << fmt::format(
-        "Conductor Actor: Error - sent unknown message to {}",
-        unknown.receiver);
+    LOG_TOPIC("d1791", INFO, Logger::PREGEL)
+        << fmt::format("Conductor Actor: Error - sent unknown message to {}",
+                       unknown.receiver);
     return std::move(this->state);
   }
 
   auto operator()(actor::ActorNotFound notFound)
       -> std::unique_ptr<ConductorState> {
-    LOG_DEVEL << fmt::format(
-        "Conductor Actor: Error - recieving actor {} not found",
-        notFound.actor);
+    LOG_TOPIC("ea585", INFO, Logger::PREGEL)
+        << fmt::format("Conductor Actor: Error - recieving actor {} not found",
+                       notFound.actor);
     return std::move(this->state);
   }
 
   auto operator()(actor::NetworkError notFound)
       -> std::unique_ptr<ConductorState> {
-    LOG_DEVEL << fmt::format("Conductor Actor: Error - network error {}",
-                             notFound.message);
+    LOG_TOPIC("866d8", INFO, Logger::PREGEL) << fmt::format(
+        "Conductor Actor: Error - network error {}", notFound.message);
     return std::move(this->state);
   }
 
   auto operator()(auto&& rest) -> std::unique_ptr<ConductorState> {
-    LOG_DEVEL << "Conductor Actor: Got unhandled message";
+    LOG_TOPIC("7ae0f", INFO, Logger::PREGEL)
+        << "Conductor Actor: Got unhandled message";
     return std::move(this->state);
   }
 };

--- a/arangod/Pregel/Conductor/Actor.h
+++ b/arangod/Pregel/Conductor/Actor.h
@@ -63,7 +63,7 @@ struct ConductorHandler : actor::HandlerBase<Runtime, ConductorState> {
   auto operator()(actor::ActorNotFound notFound)
       -> std::unique_ptr<ConductorState> {
     LOG_TOPIC("ea585", INFO, Logger::PREGEL)
-        << fmt::format("Conductor Actor: Error - recieving actor {} not found",
+        << fmt::format("Conductor Actor: Error - receiving actor {} not found",
                        notFound.actor);
     return std::move(this->state);
   }

--- a/arangod/Pregel/Conductor/Messages.h
+++ b/arangod/Pregel/Conductor/Messages.h
@@ -25,10 +25,31 @@
 #include <map>
 
 #include "Inspection/Format.h"
+#include "Inspection/Types.h"
 #include "Pregel/ExecutionNumber.h"
 #include "Pregel/Utils.h"
 
 namespace arangodb::pregel {
+
+struct ConductorStart {};
+template<typename Inspector>
+auto inspect(Inspector& f, ConductorStart& x) {
+  return f.object(x).fields();
+}
+struct WorkerCreated {};
+template<typename Inspector>
+auto inspect(Inspector& f, WorkerCreated& x) {
+  return f.object(x).fields();
+}
+struct ConductorMessages : std::variant<ConductorStart, WorkerCreated> {
+  using std::variant<ConductorStart, WorkerCreated>::variant;
+};
+template<typename Inspector>
+auto inspect(Inspector& f, ConductorMessages& x) {
+  return f.variant(x).unqualified().alternatives(
+      arangodb::inspection::type<ConductorStart>("Start"),
+      arangodb::inspection::type<WorkerCreated>("WorkerCreated"));
+}
 
 // TODO split LoadGraph off CreateWorker
 struct CreateWorker {

--- a/arangod/Pregel/PregelFeature.cpp
+++ b/arangod/Pregel/PregelFeature.cpp
@@ -600,13 +600,12 @@ void PregelFeature::start() {
 
   // TODO needs to go here for now because server feature has not startd in
   // pregel feature constructor
-  _actorRuntime =
-      std::make_shared<actor::Runtime<MockScheduler, ArangoExternalDispatcher>>(
-          ServerState::instance()->getId(), "PregelFeature",
-          std::make_shared<MockScheduler>(),
-          std::make_shared<ArangoExternalDispatcher>(
-              "/_api/pregel/actor",
-              server().getFeature<NetworkFeature>().pool()));
+  _actorRuntime = std::make_shared<
+      actor::Runtime<PregelScheduler, ArangoExternalDispatcher>>(
+      ServerState::instance()->getId(), "PregelFeature",
+      std::make_shared<PregelScheduler>(),
+      std::make_shared<ArangoExternalDispatcher>(
+          "/_api/pregel/actor", server().getFeature<NetworkFeature>().pool()));
 }
 
 void PregelFeature::beginShutdown() {

--- a/arangod/Pregel/PregelFeature.cpp
+++ b/arangod/Pregel/PregelFeature.cpp
@@ -605,7 +605,8 @@ void PregelFeature::start() {
       ServerState::instance()->getId(), "PregelFeature",
       std::make_shared<PregelScheduler>(),
       std::make_shared<ArangoExternalDispatcher>(
-          "/_api/pregel/actor", server().getFeature<NetworkFeature>().pool()));
+          "/_api/pregel/actor", server().getFeature<NetworkFeature>().pool(),
+          network::Timeout{5.0 * 60}));
 }
 
 void PregelFeature::beginShutdown() {

--- a/arangod/Pregel/PregelFeature.cpp
+++ b/arangod/Pregel/PregelFeature.cpp
@@ -301,11 +301,7 @@ ResultT<ExecutionNumber> PregelFeature::startExecution(TRI_vocbase_t& vocbase,
 void PregelFeature::spawnActor(actor::ServerID server, actor::ActorPID sender,
                                SpawnMessages msg) {
   if (server == _actorRuntime->myServerID) {
-    std::visit(overloaded{[this, sender](auto&& arg) {
-                 _actorRuntime->spawn<SpawnActor>(sender.database, SpawnState{},
-                                                  arg);
-               }},
-               msg);
+    _actorRuntime->spawn<SpawnActor>(sender.database, SpawnState{}, msg);
   } else {
     _actorRuntime->dispatch(
         sender,

--- a/arangod/Pregel/PregelFeature.h
+++ b/arangod/Pregel/PregelFeature.h
@@ -34,9 +34,12 @@
 #include <velocypack/Builder.h>
 #include <velocypack/Slice.h>
 
+#include "Pregel/ArangoExternalDispatcher.h"
+#include "Actor/Runtime.h"
 #include "Basics/Common.h"
 #include "Basics/Mutex.h"
 #include "Pregel/ExecutionNumber.h"
+#include "Pregel/SpawnMessages.h"
 #include "Pregel/PregelOptions.h"
 #include "ProgramOptions/ProgramOptions.h"
 #include "RestServer/arangod.h"
@@ -46,6 +49,10 @@
 struct TRI_vocbase_t;
 
 namespace arangodb::pregel {
+
+struct MockScheduler {
+  auto operator()(auto fn) { fn(); };
+};
 
 class Conductor;
 class IWorker;
@@ -107,6 +114,9 @@ class PregelFeature final : public ArangodFeature {
 
   auto metrics() -> std::shared_ptr<PregelMetrics> { return _metrics; }
 
+  void spawnActor(actor::ServerID server, actor::ActorPID sender,
+                  SpawnMessages msg);
+
  private:
   void scheduleGarbageCollection();
 
@@ -148,6 +158,10 @@ class PregelFeature final : public ArangodFeature {
   std::atomic<bool> _softShutdownOngoing;
 
   std::shared_ptr<PregelMetrics> _metrics;
+
+ public:
+  std::shared_ptr<actor::Runtime<MockScheduler, ArangoExternalDispatcher>>
+      _actorRuntime;
 };
 
 }  // namespace arangodb::pregel

--- a/arangod/Pregel/SpawnActor.h
+++ b/arangod/Pregel/SpawnActor.h
@@ -1,0 +1,96 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2022 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Julia Volmer
+////////////////////////////////////////////////////////////////////////////////
+#pragma once
+
+#include <memory>
+#include "Actor/ActorPID.h"
+#include "Actor/HandlerBase.h"
+#include "Pregel/Conductor/Actor.h"
+#include "Pregel/Worker/Actor.h"
+#include "Pregel/SpawnMessages.h"
+#include "Logger/LogMacros.h"
+#include "fmt/core.h"
+
+namespace arangodb::pregel {
+
+struct SpawnState {};
+template<typename Inspector>
+auto inspect(Inspector& f, SpawnState& x) {
+  return f.object(x).fields();
+}
+
+template<typename Runtime>
+struct SpawnHandler : actor::HandlerBase<Runtime, SpawnState> {
+  auto operator()(SpawnStart start) -> std::unique_ptr<SpawnState> {
+    LOG_DEVEL << fmt::format("Spawn Actor {} started", this->self);
+    return std::move(this->state);
+  }
+
+  auto operator()(SpawnConductor msg) -> std::unique_ptr<SpawnState> {
+    LOG_DEVEL << "Spawn Actor: Spawn conductor actor";
+    this->template spawn<ConductorActor>(ConductorState{}, ConductorStart{});
+    return std::move(this->state);
+  }
+
+  auto operator()(SpawnWorker msg) -> std::unique_ptr<SpawnState> {
+    LOG_DEVEL << "Spawn Actor: Spawn worker actor";
+    this->template spawn<WorkerActor>(
+        WorkerState{}, WorkerStart{});  //.conductor = msg.conductor});
+    return std::move(this->state);
+  }
+
+  auto operator()(actor::UnknownMessage unknown)
+      -> std::unique_ptr<SpawnState> {
+    LOG_DEVEL << fmt::format("Spawn Actor: Error - sent unknown message to {}",
+                             unknown.receiver);
+    return std::move(this->state);
+  }
+
+  auto operator()(actor::ActorNotFound notFound)
+      -> std::unique_ptr<SpawnState> {
+    LOG_DEVEL << fmt::format(
+        "Spawn Actor: Error - recieving actor {} not found", notFound.actor);
+    return std::move(this->state);
+  }
+
+  auto operator()(actor::NetworkError notFound) -> std::unique_ptr<SpawnState> {
+    LOG_DEVEL << fmt::format("Spawn Actor: Error - network error {}",
+                             notFound.message);
+    return std::move(this->state);
+  }
+
+  auto operator()(auto&& rest) -> std::unique_ptr<SpawnState> {
+    LOG_DEVEL << "Spawn Actor: Got unhandled message";
+    return std::move(this->state);
+  }
+};
+
+struct SpawnActor {
+  using State = SpawnState;
+  using Message = SpawnMessages;
+  template<typename Runtime>
+  using Handler = SpawnHandler<Runtime>;
+  static constexpr auto typeName() -> std::string_view { return "Spawn Actor"; }
+};
+
+}  // namespace arangodb::pregel

--- a/arangod/Pregel/SpawnActor.h
+++ b/arangod/Pregel/SpawnActor.h
@@ -28,7 +28,6 @@
 #include "Pregel/Conductor/Actor.h"
 #include "Pregel/Worker/Actor.h"
 #include "Pregel/SpawnMessages.h"
-#include "Logger/LogMacros.h"
 #include "fmt/core.h"
 
 namespace arangodb::pregel {
@@ -42,18 +41,21 @@ auto inspect(Inspector& f, SpawnState& x) {
 template<typename Runtime>
 struct SpawnHandler : actor::HandlerBase<Runtime, SpawnState> {
   auto operator()(SpawnStart start) -> std::unique_ptr<SpawnState> {
-    LOG_DEVEL << fmt::format("Spawn Actor {} started", this->self);
+    LOG_TOPIC("4a414", INFO, Logger::PREGEL)
+        << fmt::format("Spawn Actor {} started", this->self);
     return std::move(this->state);
   }
 
   auto operator()(SpawnConductor msg) -> std::unique_ptr<SpawnState> {
-    LOG_DEVEL << "Spawn Actor: Spawn conductor actor";
+    LOG_TOPIC("ed212", INFO, Logger::PREGEL)
+        << "Spawn Actor: Spawn conductor actor";
     this->template spawn<ConductorActor>(ConductorState{}, ConductorStart{});
     return std::move(this->state);
   }
 
   auto operator()(SpawnWorker msg) -> std::unique_ptr<SpawnState> {
-    LOG_DEVEL << "Spawn Actor: Spawn worker actor";
+    LOG_TOPIC("2452c", INFO, Logger::PREGEL)
+        << "Spawn Actor: Spawn worker actor";
     this->template spawn<WorkerActor>(
         WorkerState{}, WorkerStart{});  //.conductor = msg.conductor});
     return std::move(this->state);
@@ -61,26 +63,27 @@ struct SpawnHandler : actor::HandlerBase<Runtime, SpawnState> {
 
   auto operator()(actor::UnknownMessage unknown)
       -> std::unique_ptr<SpawnState> {
-    LOG_DEVEL << fmt::format("Spawn Actor: Error - sent unknown message to {}",
-                             unknown.receiver);
+    LOG_TOPIC("7b602", INFO, Logger::PREGEL) << fmt::format(
+        "Spawn Actor: Error - sent unknown message to {}", unknown.receiver);
     return std::move(this->state);
   }
 
   auto operator()(actor::ActorNotFound notFound)
       -> std::unique_ptr<SpawnState> {
-    LOG_DEVEL << fmt::format(
+    LOG_TOPIC("03156", INFO, Logger::PREGEL) << fmt::format(
         "Spawn Actor: Error - recieving actor {} not found", notFound.actor);
     return std::move(this->state);
   }
 
   auto operator()(actor::NetworkError notFound) -> std::unique_ptr<SpawnState> {
-    LOG_DEVEL << fmt::format("Spawn Actor: Error - network error {}",
-                             notFound.message);
+    LOG_TOPIC("a87b3", INFO, Logger::PREGEL) << fmt::format(
+        "Spawn Actor: Error - network error {}", notFound.message);
     return std::move(this->state);
   }
 
   auto operator()(auto&& rest) -> std::unique_ptr<SpawnState> {
-    LOG_DEVEL << "Spawn Actor: Got unhandled message";
+    LOG_TOPIC("89d72", INFO, Logger::PREGEL)
+        << "Spawn Actor: Got unhandled message";
     return std::move(this->state);
   }
 };

--- a/arangod/Pregel/SpawnActor.h
+++ b/arangod/Pregel/SpawnActor.h
@@ -71,7 +71,7 @@ struct SpawnHandler : actor::HandlerBase<Runtime, SpawnState> {
   auto operator()(actor::ActorNotFound notFound)
       -> std::unique_ptr<SpawnState> {
     LOG_TOPIC("03156", INFO, Logger::PREGEL) << fmt::format(
-        "Spawn Actor: Error - recieving actor {} not found", notFound.actor);
+        "Spawn Actor: Error - receiving actor {} not found", notFound.actor);
     return std::move(this->state);
   }
 

--- a/arangod/Pregel/SpawnMessages.h
+++ b/arangod/Pregel/SpawnMessages.h
@@ -1,0 +1,59 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2022 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Julia Volmer
+////////////////////////////////////////////////////////////////////////////////
+#pragma once
+
+#include <variant>
+#include "Actor/ActorPID.h"
+#include "Inspection/Types.h"
+
+namespace arangodb::pregel {
+
+struct SpawnStart {};
+template<typename Inspector>
+auto inspect(Inspector& f, SpawnStart& x) {
+  return f.object(x).fields();
+}
+struct SpawnConductor {};
+template<typename Inspector>
+auto inspect(Inspector& f, SpawnConductor& x) {
+  return f.object(x).fields();
+}
+struct SpawnWorker {
+  // actor::ActorPID conductor;
+};
+template<typename Inspector>
+auto inspect(Inspector& f, SpawnWorker& x) {
+  return f.object(x).fields();  // f.field("conductor", x.conductor));
+}
+struct SpawnMessages : std::variant<SpawnStart, SpawnConductor, SpawnWorker> {
+  using std::variant<SpawnStart, SpawnConductor, SpawnWorker>::variant;
+};
+template<typename Inspector>
+auto inspect(Inspector& f, SpawnMessages& x) {
+  return f.variant(x).unqualified().alternatives(
+      arangodb::inspection::type<SpawnStart>("Start"),
+      arangodb::inspection::type<SpawnConductor>("SpawnConductor"),
+      arangodb::inspection::type<SpawnWorker>("SpawnWorker"));
+}
+
+}  // namespace arangodb::pregel

--- a/arangod/Pregel/Worker/Actor.h
+++ b/arangod/Pregel/Worker/Actor.h
@@ -27,7 +27,6 @@
 #include "Actor/HandlerBase.h"
 #include "Pregel/Worker/Messages.h"
 #include "Pregel/Conductor/Messages.h"
-#include "Logger/LogMacros.h"
 #include "fmt/core.h"
 
 namespace arangodb::pregel {
@@ -43,7 +42,8 @@ auto inspect(Inspector& f, WorkerState& x) {
 template<typename Runtime>
 struct WorkerHandler : actor::HandlerBase<Runtime, WorkerState> {
   auto operator()(WorkerStart start) -> std::unique_ptr<WorkerState> {
-    LOG_DEVEL << fmt::format("Worker Actor {} started", this->self);
+    LOG_TOPIC("cd696", INFO, Logger::PREGEL)
+        << fmt::format("Worker Actor {} started", this->self);
     // TODO when we get a message with a conductor PID
     // this->state->conductor = start.conductor;
     // this->template dispatch<ConductorMessages>(this->state->conductor,
@@ -53,28 +53,29 @@ struct WorkerHandler : actor::HandlerBase<Runtime, WorkerState> {
 
   auto operator()(actor::UnknownMessage unknown)
       -> std::unique_ptr<WorkerState> {
-    LOG_DEVEL << fmt::format("Worker Actor: Error - sent unknown message to {}",
-                             unknown.receiver);
+    LOG_TOPIC("7ee4d", INFO, Logger::PREGEL) << fmt::format(
+        "Worker Actor: Error - sent unknown message to {}", unknown.receiver);
     return std::move(this->state);
   }
 
   auto operator()(actor::ActorNotFound notFound)
       -> std::unique_ptr<WorkerState> {
-    LOG_DEVEL << fmt::format(
+    LOG_TOPIC("2d647", INFO, Logger::PREGEL) << fmt::format(
         "Worker Actor: Error - recieving actor {} not found", notFound.actor);
     return std::move(this->state);
   }
 
   auto operator()(actor::NetworkError notFound)
       -> std::unique_ptr<WorkerState> {
-    LOG_DEVEL << fmt::format("Worker Actor: Error - network error {}",
-                             notFound.message);
+    LOG_TOPIC("7915", INFO, Logger::PREGEL) << fmt::format(
+        "Worker Actor: Error - network error {}", notFound.message);
     return std::move(this->state);
   }
 
   auto operator()(auto&& rest) -> std::unique_ptr<WorkerState> {
-    LOG_DEVEL << "Worker Actor: Got unhandled message";
-    LOG_DEVEL << fmt::format("{}", rest);
+    LOG_TOPIC("8b81a", INFO, Logger::PREGEL)
+        << "Worker Actor: Got unhandled message";
+    LOG_TOPIC("f5bac", INFO, Logger::PREGEL) << fmt::format("{}", rest);
     return std::move(this->state);
   }
 };

--- a/arangod/Pregel/Worker/Actor.h
+++ b/arangod/Pregel/Worker/Actor.h
@@ -1,0 +1,89 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2022 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Julia Volmer
+////////////////////////////////////////////////////////////////////////////////
+#pragma once
+
+#include <memory>
+#include "Actor/ActorPID.h"
+#include "Actor/HandlerBase.h"
+#include "Pregel/Worker/Messages.h"
+#include "Pregel/Conductor/Messages.h"
+#include "Logger/LogMacros.h"
+#include "fmt/core.h"
+
+namespace arangodb::pregel {
+
+struct WorkerState {
+  actor::ActorPID conductor;
+};
+template<typename Inspector>
+auto inspect(Inspector& f, WorkerState& x) {
+  return f.object(x).fields(f.field("conductor", x.conductor));
+}
+
+template<typename Runtime>
+struct WorkerHandler : actor::HandlerBase<Runtime, WorkerState> {
+  auto operator()(WorkerStart start) -> std::unique_ptr<WorkerState> {
+    LOG_DEVEL << fmt::format("Worker Actor {} started", this->self);
+    // TODO when we get a message with a conductor PID
+    // this->state->conductor = start.conductor;
+    // this->template dispatch<ConductorMessages>(this->state->conductor,
+    //                                            WorkerCreated{});
+    return std::move(this->state);
+  }
+
+  auto operator()(actor::UnknownMessage unknown)
+      -> std::unique_ptr<WorkerState> {
+    LOG_DEVEL << fmt::format("Worker Actor: Error - sent unknown message to {}",
+                             unknown.receiver);
+    return std::move(this->state);
+  }
+
+  auto operator()(actor::ActorNotFound notFound)
+      -> std::unique_ptr<WorkerState> {
+    LOG_DEVEL << fmt::format(
+        "Worker Actor: Error - recieving actor {} not found", notFound.actor);
+    return std::move(this->state);
+  }
+
+  auto operator()(actor::NetworkError notFound)
+      -> std::unique_ptr<WorkerState> {
+    LOG_DEVEL << fmt::format("Worker Actor: Error - network error {}",
+                             notFound.message);
+    return std::move(this->state);
+  }
+
+  auto operator()(auto&& rest) -> std::unique_ptr<WorkerState> {
+    LOG_DEVEL << "Worker Actor: Got unhandled message";
+    LOG_DEVEL << fmt::format("{}", rest);
+    return std::move(this->state);
+  }
+};
+
+struct WorkerActor {
+  using State = WorkerState;
+  using Message = WorkerMessages;
+  template<typename Runtime>
+  using Handler = WorkerHandler<Runtime>;
+  static constexpr auto typeName() -> std::string_view { return "WorkerActor"; }
+};
+}  // namespace arangodb::pregel

--- a/arangod/Pregel/Worker/Actor.h
+++ b/arangod/Pregel/Worker/Actor.h
@@ -67,7 +67,7 @@ struct WorkerHandler : actor::HandlerBase<Runtime, WorkerState> {
 
   auto operator()(actor::NetworkError notFound)
       -> std::unique_ptr<WorkerState> {
-    LOG_TOPIC("7915", INFO, Logger::PREGEL) << fmt::format(
+    LOG_TOPIC("1c3d9", INFO, Logger::PREGEL) << fmt::format(
         "Worker Actor: Error - network error {}", notFound.message);
     return std::move(this->state);
   }

--- a/arangod/Pregel/Worker/Actor.h
+++ b/arangod/Pregel/Worker/Actor.h
@@ -61,7 +61,7 @@ struct WorkerHandler : actor::HandlerBase<Runtime, WorkerState> {
   auto operator()(actor::ActorNotFound notFound)
       -> std::unique_ptr<WorkerState> {
     LOG_TOPIC("2d647", INFO, Logger::PREGEL) << fmt::format(
-        "Worker Actor: Error - recieving actor {} not found", notFound.actor);
+        "Worker Actor: Error - receiving actor {} not found", notFound.actor);
     return std::move(this->state);
   }
 

--- a/arangod/Pregel/Worker/Messages.h
+++ b/arangod/Pregel/Worker/Messages.h
@@ -24,12 +24,30 @@
 
 #include "Cluster/ClusterTypes.h"
 #include "Inspection/Format.h"
+#include "Inspection/Types.h"
 #include "Pregel/ExecutionNumber.h"
 #include "Pregel/GraphStore/Graph.h"
 #include "Pregel/Statistics.h"
 #include "Pregel/Status/Status.h"
 
 namespace arangodb::pregel {
+
+struct WorkerStart {
+  // arangodb::pregel::actor::ActorPID conductor;
+};
+template<typename Inspector>
+auto inspect(Inspector& f, WorkerStart& x) {
+  return f.object(x).fields();  // f.field("conductor", x.conductor));
+}
+
+struct WorkerMessages : std::variant<WorkerStart> {
+  using std::variant<WorkerStart>::variant;
+};
+template<typename Inspector>
+auto inspect(Inspector& f, WorkerMessages& x) {
+  return f.variant(x).unqualified().alternatives(
+      arangodb::inspection::type<WorkerStart>("Start"));
+}
 
 struct GraphLoaded {
   ExecutionNumber executionNumber;

--- a/tests/Pregel/Actor/ActorTest.cpp
+++ b/tests/Pregel/Actor/ActorTest.cpp
@@ -79,11 +79,11 @@ TEST(ActorTest, formats_actor) {
   auto runtime =
       std::make_shared<ActorTestRuntime>("A", "myID", scheduler, dispatcher);
   auto actor = std::make_shared<Actor<ActorTestRuntime, TrivialActor>>(
-      ActorPID{.server = "A", .id = {1}}, runtime,
+      ActorPID{.server = "A", .database = "database", .id = {1}}, runtime,
       std::make_unique<TrivialState>());
   ASSERT_EQ(
       fmt::format("{}", *actor),
-      R"({"pid":{"server":"A","id":1},"state":{"state":"","called":0},"batchsize":16})");
+      R"({"pid":{"server":"A","database":"database","id":1},"state":{"state":"","called":0},"batchsize":16})");
 }
 
 TEST(ActorTest, changes_its_state_after_processing_a_message) {
@@ -92,12 +92,13 @@ TEST(ActorTest, changes_its_state_after_processing_a_message) {
   auto runtime =
       std::make_shared<ActorTestRuntime>("A", "myID", scheduler, dispatcher);
   auto actor = std::make_shared<Actor<ActorTestRuntime, TrivialActor>>(
-      ActorPID{.server = "A", .id = {1}}, runtime,
+      ActorPID{.server = "A", .database = "database", .id = {1}}, runtime,
       std::make_unique<TrivialState>());
   ASSERT_EQ(actor->getState(), (TrivialState{.state = "", .called = 0}));
 
   auto message = MessagePayload<TrivialMessages>(TrivialMessage{"Hello"});
-  actor->process(ActorPID{.server = "A", .id = {5}}, message);
+  actor->process(ActorPID{.server = "A", .database = "database", .id = {5}},
+                 message);
   ASSERT_EQ(actor->getState(), (TrivialState{.state = "Hello", .called = 1}));
 }
 
@@ -107,12 +108,12 @@ TEST(ActorTest, changes_its_state_after_processing_a_velocypack_message) {
   auto runtime =
       std::make_shared<ActorTestRuntime>("A", "myID", scheduler, dispatcher);
   auto actor = std::make_shared<Actor<ActorTestRuntime, TrivialActor>>(
-      ActorPID{.server = "A", .id = {1}}, runtime,
+      ActorPID{.server = "A", .database = "database", .id = {1}}, runtime,
       std::make_unique<TrivialState>());
   ASSERT_EQ(actor->getState(), (TrivialState{.state = "", .called = 0}));
 
   auto message = TrivialMessages{TrivialMessage{"Hello"}};
-  actor->process(ActorPID{.server = "A", .id = {5}},
+  actor->process(ActorPID{.server = "A", .database = "database", .id = {5}},
                  arangodb::inspection::serializeWithErrorT(message).get());
 
   ASSERT_EQ(actor->getState(), (TrivialState{.state = "Hello", .called = 1}));
@@ -124,7 +125,7 @@ TEST(ActorTest, sets_itself_to_finish) {
   auto runtime =
       std::make_shared<ActorTestRuntime>("A", "myID", scheduler, dispatcher);
   auto actor = std::make_shared<Actor<ActorTestRuntime, TrivialActor>>(
-      ActorPID{.server = "A", .id = {1}}, runtime,
+      ActorPID{.server = "A", .database = "database", .id = {1}}, runtime,
       std::make_unique<TrivialState>());
   ASSERT_FALSE(actor->isFinishedAndIdle());
 
@@ -139,13 +140,13 @@ TYPED_TEST(ActorTest, does_not_work_on_new_messages_after_actor_finished) {
       "A", "myID", this->scheduler, dispatcher);
   auto actor = std::make_shared<
       Actor<Runtime<TypeParam, EmptyExternalDispatcher>, TrivialActor>>(
-      ActorPID{.server = "A", .id = {1}}, runtime,
+      ActorPID{.server = "A", .database = "database", .id = {1}}, runtime,
       std::make_unique<TrivialState>());
   actor->finish();
 
   // send message to actor
   auto message = TrivialMessages{TrivialMessage{"Hello"}};
-  actor->process(ActorPID{.server = "A", .id = {5}},
+  actor->process(ActorPID{.server = "A", .database = "database", .id = {5}},
                  arangodb::inspection::serializeWithErrorT(message).get());
 
   this->scheduler->stop();
@@ -153,33 +154,31 @@ TYPED_TEST(ActorTest, does_not_work_on_new_messages_after_actor_finished) {
   ASSERT_EQ(actor->getState(), (TrivialState{}));
 }
 
-// TYPED_TEST(ActorTest,
-// finished_actor_works_on_all_remaining_messages_in_queue) {
-//   auto dispatcher = std::make_shared<EmptyExternalDispatcher>();
-//   auto runtime = std::make_shared<Runtime<TypeParam,
-//   EmptyExternalDispatcher>>(
-//       "A", "myID", this->scheduler, dispatcher);
-//   auto actor = std::make_shared<
-//       Actor<Runtime<TypeParam, EmptyExternalDispatcher>, TrivialActor>>(
-//       ActorPID{.server = "A", .id = {1}}, runtime,
-//       std::make_unique<TrivialState>());
+TYPED_TEST(ActorTest, finished_actor_works_on_all_remaining_messages_in_queue) {
+  auto dispatcher = std::make_shared<EmptyExternalDispatcher>();
+  auto runtime = std::make_shared<Runtime<TypeParam, EmptyExternalDispatcher>>(
+      "A", "myID", this->scheduler, dispatcher);
+  auto actor = std::make_shared<
+      Actor<Runtime<TypeParam, EmptyExternalDispatcher>, TrivialActor>>(
+      ActorPID{.server = "A", .database = "database", .id = {1}}, runtime,
+      std::make_unique<TrivialState>());
 
-//   // send a lot of messages to actor
-//   auto message = TrivialMessages{TrivialMessage{"A"}};
-//   size_t sent_message_count = 1000;
-//   for (size_t i = 0; i < sent_message_count; i++) {
-//     actor->process(ActorPID{.server = "A", .id = {5}},
-//                    arangodb::inspection::serializeWithErrorT(message).get());
-//   }
+  // send a lot of messages to actor
+  auto message = TrivialMessages{TrivialMessage{"A"}};
+  size_t sent_message_count = 1000;
+  for (size_t i = 0; i < sent_message_count; i++) {
+    actor->process(ActorPID{.server = "A", .database = "database", .id = {5}},
+                   arangodb::inspection::serializeWithErrorT(message).get());
+  }
 
-//   // finish actor possibly before actor worked on all messages
-//   actor->finish();
+  // finish actor possibly before actor worked on all messages
+  actor->finish();
 
-//   // wait for actor to work off all messages
-//   while (not actor->isIdle()) {
-//   }
-//   this->scheduler->stop();
-//   ASSERT_EQ(actor->getState(),
-//             (TrivialState{.state = std::string(sent_message_count, 'A'),
-//                           .called = sent_message_count}));
-// }
+  // wait for actor to work off all messages
+  while (not actor->isIdle()) {
+  }
+  this->scheduler->stop();
+  ASSERT_EQ(actor->getState(),
+            (TrivialState{.state = std::string(sent_message_count, 'A'),
+                          .called = sent_message_count}));
+}

--- a/tests/Pregel/Actor/ActorTest.cpp
+++ b/tests/Pregel/Actor/ActorTest.cpp
@@ -154,31 +154,34 @@ TYPED_TEST(ActorTest, does_not_work_on_new_messages_after_actor_finished) {
   ASSERT_EQ(actor->getState(), (TrivialState{}));
 }
 
-TYPED_TEST(ActorTest, finished_actor_works_on_all_remaining_messages_in_queue) {
-  auto dispatcher = std::make_shared<EmptyExternalDispatcher>();
-  auto runtime = std::make_shared<Runtime<TypeParam, EmptyExternalDispatcher>>(
-      "A", "myID", this->scheduler, dispatcher);
-  auto actor = std::make_shared<
-      Actor<Runtime<TypeParam, EmptyExternalDispatcher>, TrivialActor>>(
-      ActorPID{.server = "A", .database = "database", .id = {1}}, runtime,
-      std::make_unique<TrivialState>());
+// TYPED_TEST(ActorTest,
+// finished_actor_works_on_all_remaining_messages_in_queue) {
+//   auto dispatcher = std::make_shared<EmptyExternalDispatcher>();
+//   auto runtime = std::make_shared<Runtime<TypeParam,
+//   EmptyExternalDispatcher>>(
+//       "A", "myID", this->scheduler, dispatcher);
+//   auto actor = std::make_shared<
+//       Actor<Runtime<TypeParam, EmptyExternalDispatcher>, TrivialActor>>(
+//       ActorPID{.server = "A", .database = "database", .id = {1}}, runtime,
+//       std::make_unique<TrivialState>());
 
-  // send a lot of messages to actor
-  auto message = TrivialMessages{TrivialMessage{"A"}};
-  size_t sent_message_count = 1000;
-  for (size_t i = 0; i < sent_message_count; i++) {
-    actor->process(ActorPID{.server = "A", .database = "database", .id = {5}},
-                   arangodb::inspection::serializeWithErrorT(message).get());
-  }
+//   // send a lot of messages to actor
+//   auto message = TrivialMessages{TrivialMessage{"A"}};
+//   size_t sent_message_count = 1000;
+//   for (size_t i = 0; i < sent_message_count; i++) {
+//     actor->process(ActorPID{.server = "A", .database = "database", .id =
+//     {5}},
+//                    arangodb::inspection::serializeWithErrorT(message).get());
+//   }
 
-  // finish actor possibly before actor worked on all messages
-  actor->finish();
+//   // finish actor possibly before actor worked on all messages
+//   actor->finish();
 
-  // wait for actor to work off all messages
-  while (not actor->isIdle()) {
-  }
-  this->scheduler->stop();
-  ASSERT_EQ(actor->getState(),
-            (TrivialState{.state = std::string(sent_message_count, 'A'),
-                          .called = sent_message_count}));
-}
+//   // wait for actor to work off all messages
+//   while (not actor->isIdle()) {
+//   }
+//   this->scheduler->stop();
+//   ASSERT_EQ(actor->getState(),
+//             (TrivialState{.state = std::string(sent_message_count, 'A'),
+//                           .called = sent_message_count}));
+// }

--- a/tests/Pregel/Actor/Actors/TrivialActor.h
+++ b/tests/Pregel/Actor/Actors/TrivialActor.h
@@ -97,10 +97,9 @@ struct TrivialHandler : HandlerBase<Runtime, TrivialState> {
     return std::move(this->state);
   }
 
-  auto operator()(ServerNotFound notFound) -> std::unique_ptr<TrivialState> {
+  auto operator()(NetworkError notFound) -> std::unique_ptr<TrivialState> {
     this->state->called++;
-    this->state->state =
-        fmt::format("receiving server {} not found", notFound.server);
+    this->state->state = fmt::format("network error: {}", notFound.message);
     return std::move(this->state);
   }
 

--- a/tests/Pregel/Actor/MultiRuntimeTest.cpp
+++ b/tests/Pregel/Actor/MultiRuntimeTest.cpp
@@ -54,7 +54,8 @@ struct MockExternalDispatcher {
     if (receiving_runtime != std::end(runtimes)) {
       receiving_runtime->second->receive(sender, receiver, msg);
     } else {
-      auto error = ActorError{ServerNotFound{.server = receiver.server}};
+      auto error = ActorError{NetworkError{
+          .message = fmt::format("Cannot find server {}", receiver.server)}};
       auto payload = inspection::serializeWithErrorT(error);
       if (payload.ok()) {
         runtimes[sender.server]->dispatch(receiver, sender, payload.get());
@@ -98,9 +99,9 @@ TYPED_TEST(ActorMultiRuntimeTest, sends_message_to_actor_in_another_runtime) {
           sending_server, "RuntimeTest-sending", this->scheduler, dispatcher));
   auto sending_actor_id =
       runtimes[sending_server]->template spawn<TrivialActor>(
-          TrivialState{.state = "foo"}, TrivialStart{});
-  auto sending_actor =
-      ActorPID{.server = sending_server, .id = sending_actor_id};
+          "database", TrivialState{.state = "foo"}, TrivialStart{});
+  auto sending_actor = ActorPID{
+      .server = sending_server, .database = "database", .id = sending_actor_id};
 
   // Receiving Runtime
   auto receiving_server = ServerID{"B"};
@@ -110,7 +111,7 @@ TYPED_TEST(ActorMultiRuntimeTest, sends_message_to_actor_in_another_runtime) {
                        this->scheduler, dispatcher));
   auto receiving_actor_id =
       runtimes[receiving_server]->template spawn<TrivialActor>(
-          TrivialState{.state = "foo"}, TrivialStart{});
+          "database", TrivialState{.state = "foo"}, TrivialStart{});
   auto receiving_actor =
       ActorPID{.server = receiving_server, .id = receiving_actor_id};
 
@@ -167,9 +168,9 @@ TYPED_TEST(
           sending_server, "RuntimeTest-sending", this->scheduler, dispatcher));
   auto sending_actor_id =
       runtimes[sending_server]->template spawn<TrivialActor>(
-          TrivialState{.state = "foo"}, TrivialStart{});
-  auto sending_actor =
-      ActorPID{.server = sending_server, .id = sending_actor_id};
+          "database", TrivialState{.state = "foo"}, TrivialStart{});
+  auto sending_actor = ActorPID{
+      .server = sending_server, .database = "database", .id = sending_actor_id};
 
   // Receiving Runtime
   auto receiving_server = ServerID{"B"};
@@ -179,9 +180,10 @@ TYPED_TEST(
                        this->scheduler, dispatcher));
   auto receiving_actor_id =
       runtimes[receiving_server]->template spawn<TrivialActor>(
-          TrivialState{.state = "foo"}, TrivialStart{});
-  auto receiving_actor =
-      ActorPID{.server = receiving_server, .id = receiving_actor_id};
+          "database", TrivialState{.state = "foo"}, TrivialStart{});
+  auto receiving_actor = ActorPID{.server = receiving_server,
+                                  .database = "database",
+                                  .id = receiving_actor_id};
 
   // send
   runtimes[sending_server]->dispatch(sending_actor, receiving_actor,
@@ -226,9 +228,9 @@ TYPED_TEST(
           sending_server, "RuntimeTest-sending", this->scheduler, dispatcher));
   auto sending_actor_id =
       runtimes[sending_server]->template spawn<TrivialActor>(
-          TrivialState{.state = "foo"}, TrivialStart{});
-  auto sending_actor =
-      ActorPID{.server = sending_server, .id = sending_actor_id};
+          "database", TrivialState{.state = "foo"}, TrivialStart{});
+  auto sending_actor = ActorPID{
+      .server = sending_server, .database = "database", .id = sending_actor_id};
 
   // Receiving Runtime
   auto receiving_server = ServerID{"B"};
@@ -238,7 +240,8 @@ TYPED_TEST(
                        this->scheduler, dispatcher));
 
   // send
-  auto unknown_actor = ActorPID{.server = receiving_server, .id = {999}};
+  auto unknown_actor =
+      ActorPID{.server = receiving_server, .database = "database", .id = {999}};
   runtimes[sending_server]->dispatch(
       sending_actor, unknown_actor,
       TrivialActor::Message{TrivialMessage("baz")});
@@ -259,7 +262,7 @@ TYPED_TEST(
 
 TYPED_TEST(
     ActorMultiRuntimeTest,
-    actor_receives_actor_not_found_message_after_trying_to_send_message_to_non_existent_server) {
+    actor_receives_network_error_message_after_trying_to_send_message_to_non_existent_server) {
   std::unordered_map<ServerID,
                      std::shared_ptr<typename TestFixture::MockRuntime>>
       runtimes;
@@ -274,25 +277,26 @@ TYPED_TEST(
           sending_server, "RuntimeTest-sending", this->scheduler, dispatcher));
   auto sending_actor_id =
       runtimes[sending_server]->template spawn<TrivialActor>(
-          TrivialState{.state = "foo"}, TrivialStart{});
-  auto sending_actor =
-      ActorPID{.server = sending_server, .id = sending_actor_id};
+          "database", TrivialState{.state = "foo"}, TrivialStart{});
+  auto sending_actor = ActorPID{
+      .server = sending_server, .database = "database", .id = sending_actor_id};
 
   // send
   auto unknown_server = ServerID{"B"};
   runtimes[sending_server]->dispatch(
-      sending_actor, ActorPID{.server = unknown_server, .id = {999}},
+      sending_actor,
+      ActorPID{.server = unknown_server, .database = "database", .id = {999}},
       TrivialActor::Message{TrivialMessage("baz")});
 
   this->scheduler->stop();
-  // sending actor received a server-not-known message error
-  // after it messaged to non-existing server
-  ASSERT_EQ(
-      runtimes[sending_server]->template getActorStateByID<TrivialActor>(
-          sending_actor_id),
-      (TrivialActor::State{
-          .state = fmt::format("receiving server {} not found", unknown_server),
-          .called = 2}));
+  // sending actor received a network error message after it messaged
+  // to non-existing server
+  ASSERT_EQ(runtimes[sending_server]->template getActorStateByID<TrivialActor>(
+                sending_actor_id),
+            (TrivialActor::State{
+                .state = fmt::format("network error: Cannot find server {}",
+                                     unknown_server),
+                .called = 2}));
   for (auto& [_, runtime] : runtimes) {
     runtime->softShutdown();
   }
@@ -313,7 +317,7 @@ TYPED_TEST(ActorMultiRuntimeTest, ping_pong_game) {
       std::make_shared<typename TestFixture::MockRuntime>(
           pong_server, "RuntimeTest-A", this->scheduler, dispatcher));
   auto pong_actor = runtimes[pong_server]->template spawn<pong_actor::Actor>(
-      pong_actor::PongState{}, pong_actor::Start{});
+      "database", pong_actor::PongState{}, pong_actor::Start{});
 
   // Ping Runtime
   auto ping_server = ServerID{"B"};
@@ -322,9 +326,10 @@ TYPED_TEST(ActorMultiRuntimeTest, ping_pong_game) {
       std::make_shared<typename TestFixture::MockRuntime>(
           ping_server, "RuntimeTest-B", this->scheduler, dispatcher));
   auto ping_actor = runtimes[ping_server]->template spawn<ping_actor::Actor>(
-      ping_actor::PingState{},
-      ping_actor::Start{.pongActor =
-                            ActorPID{.server = pong_server, .id = pong_actor}});
+      "database", ping_actor::PingState{},
+      ping_actor::Start{.pongActor = ActorPID{.server = pong_server,
+                                              .database = "database",
+                                              .id = pong_actor}});
 
   this->scheduler->stop();
   // pong actor was called twice

--- a/tests/Pregel/Actor/MultiRuntimeTest.cpp
+++ b/tests/Pregel/Actor/MultiRuntimeTest.cpp
@@ -112,8 +112,9 @@ TYPED_TEST(ActorMultiRuntimeTest, sends_message_to_actor_in_another_runtime) {
   auto receiving_actor_id =
       runtimes[receiving_server]->template spawn<TrivialActor>(
           "database", TrivialState{.state = "foo"}, TrivialStart{});
-  auto receiving_actor =
-      ActorPID{.server = receiving_server, .id = receiving_actor_id};
+  auto receiving_actor = ActorPID{.server = receiving_server,
+                                  .database = "database",
+                                  .id = receiving_actor_id};
 
   // send
   runtimes[sending_server]->dispatch(

--- a/tests/Pregel/Actor/RuntimeTest.cpp
+++ b/tests/Pregel/Actor/RuntimeTest.cpp
@@ -298,9 +298,12 @@ TYPED_TEST(ActorRuntimeTest, garbage_collects_finished_actor) {
   auto finishing_actor = runtime->template spawn<FinishingActor>(
       "database", FinishingState{}, FinishingStart{});
 
-  runtime->dispatch(ActorPID{.server = serverID, .id = finishing_actor},
-                    ActorPID{.server = serverID, .id = finishing_actor},
-                    FinishingActor::Message{FinishingFinish{}});
+  runtime->dispatch(
+      ActorPID{
+          .server = serverID, .database = "database", .id = finishing_actor},
+      ActorPID{
+          .server = serverID, .database = "database", .id = finishing_actor},
+      FinishingActor::Message{FinishingFinish{}});
   // wait for actor to work off all messages
   while (not runtime->areAllActorsIdle()) {
   }
@@ -329,13 +332,20 @@ TYPED_TEST(ActorRuntimeTest, garbage_collects_all_finished_actors) {
   runtime->template spawn<FinishingActor>("database", FinishingState{},
                                           FinishingStart{});
 
-  runtime->dispatch(ActorPID{.server = serverID, .id = actor_to_be_finished},
-                    ActorPID{.server = serverID, .id = actor_to_be_finished},
+  runtime->dispatch(ActorPID{.server = serverID,
+                             .database = "database",
+                             .id = actor_to_be_finished},
+                    ActorPID{.server = serverID,
+                             .database = "database",
+                             .id = actor_to_be_finished},
                     FinishingActor::Message{FinishingFinish{}});
-  runtime->dispatch(
-      ActorPID{.server = serverID, .id = another_actor_to_be_finished},
-      ActorPID{.server = serverID, .id = another_actor_to_be_finished},
-      FinishingActor::Message{FinishingFinish{}});
+  runtime->dispatch(ActorPID{.server = serverID,
+                             .database = "database",
+                             .id = another_actor_to_be_finished},
+                    ActorPID{.server = serverID,
+                             .database = "database",
+                             .id = another_actor_to_be_finished},
+                    FinishingActor::Message{FinishingFinish{}});
   // wait for actor to work off all messages
   while (not runtime->areAllActorsIdle()) {
   }

--- a/tests/Pregel/Actor/RuntimeTest.cpp
+++ b/tests/Pregel/Actor/RuntimeTest.cpp
@@ -69,12 +69,12 @@ TYPED_TEST(ActorRuntimeTest, formats_runtime_and_actor_state) {
   auto runtime = std::make_shared<Runtime<TypeParam, EmptyExternalDispatcher>>(
       ServerID{"PRMR-1234"}, "RuntimeTest", this->scheduler, dispatcher);
   auto actorID = runtime->template spawn<pong_actor::Actor>(
-      pong_actor::PongState{}, pong_actor::Start{});
+      "database", pong_actor::PongState{}, pong_actor::Start{});
 
   this->scheduler->stop();
   ASSERT_EQ(
       fmt::format("{}", *runtime),
-      R"({"myServerID":"PRMR-1234","runtimeID":"RuntimeTest","uniqueActorIDCounter":1,"actors":[{"id":0,"type":"PongActor"}]})");
+      R"({"myServerID":"PRMR-1234","runtimeID":"RuntimeTest","uniqueActorIDCounter":2,"actors":[{"id":1,"type":"PongActor"}]})");
   auto actor =
       runtime->template getActorStateByID<pong_actor::Actor>(actorID).value();
   ASSERT_EQ(fmt::format("{}", actor), R"({"called":1})");
@@ -86,12 +86,12 @@ TYPED_TEST(ActorRuntimeTest, serializes_an_actor_including_its_actor_state) {
   auto runtime = std::make_shared<Runtime<TypeParam, EmptyExternalDispatcher>>(
       ServerID{"PRMR-1234"}, "RuntimeTest", this->scheduler, dispatcher);
   auto actor = runtime->template spawn<TrivialActor>(
-      TrivialState{.state = "foo"}, TrivialStart());
+      "database", TrivialState{.state = "foo"}, TrivialStart());
 
   this->scheduler->stop();
   using namespace arangodb::velocypack;
   auto expected =
-      R"({"pid":{"server":"PRMR-1234","id":0},"state":{"state":"foo","called":1},"batchsize":16})"_vpack;
+      R"({"pid":{"server":"PRMR-1234","database":"database","id":1},"state":{"state":"foo","called":1},"batchsize":16})"_vpack;
   ASSERT_EQ(runtime->getSerializedActorByID(actor)->toJson(),
             expected.toJson());
   runtime->softShutdown();
@@ -103,7 +103,7 @@ TYPED_TEST(ActorRuntimeTest, spawns_actor) {
       "PRMR-1234", "RuntimeTest", this->scheduler, dispatcher);
 
   auto actor = runtime->template spawn<TrivialActor>(
-      TrivialState{.state = "foo"}, TrivialStart());
+      "database", TrivialState{.state = "foo"}, TrivialStart());
 
   this->scheduler->stop();
   auto state = runtime->template getActorStateByID<TrivialActor>(actor);
@@ -117,7 +117,7 @@ TYPED_TEST(ActorRuntimeTest, sends_initial_message_when_spawning_actor) {
       "PRMR-1234", "RuntimeTest", this->scheduler, dispatcher);
 
   auto actor = runtime->template spawn<TrivialActor>(
-      TrivialState{.state = "foo"}, TrivialMessage("bar"));
+      "database", TrivialState{.state = "foo"}, TrivialMessage("bar"));
 
   this->scheduler->stop();
   auto state = runtime->template getActorStateByID<TrivialActor>(actor);
@@ -133,9 +133,9 @@ TYPED_TEST(ActorRuntimeTest, gives_all_existing_actor_ids) {
   ASSERT_TRUE(runtime->getActorIDs().empty());
 
   auto actor_foo = runtime->template spawn<TrivialActor>(
-      TrivialState{.state = "foo"}, TrivialStart());
+      "database", TrivialState{.state = "foo"}, TrivialStart());
   auto actor_bar = runtime->template spawn<TrivialActor>(
-      TrivialState{.state = "bar"}, TrivialStart());
+      "database", TrivialState{.state = "bar"}, TrivialStart());
 
   this->scheduler->stop();
   auto allActorIDs = runtime->getActorIDs();
@@ -151,11 +151,12 @@ TYPED_TEST(ActorRuntimeTest, sends_message_to_an_actor) {
   auto runtime = std::make_shared<Runtime<TypeParam, EmptyExternalDispatcher>>(
       "PRMR-1234", "RuntimeTest", this->scheduler, dispatcher);
   auto actor = runtime->template spawn<TrivialActor>(
-      TrivialState{.state = "foo"}, TrivialStart{});
+      "database", TrivialState{.state = "foo"}, TrivialStart{});
 
-  runtime->dispatch(ActorPID{.server = "PRMR-1234", .id = actor},
-                    ActorPID{.server = "PRMR-1234", .id = actor},
-                    TrivialActor::Message{TrivialMessage("baz")});
+  runtime->dispatch(
+      ActorPID{.server = "PRMR-1234", .database = "database", .id = actor},
+      ActorPID{.server = "PRMR-1234", .database = "database", .id = actor},
+      TrivialActor::Message{TrivialMessage("baz")});
 
   this->scheduler->stop();
   auto state = runtime->template getActorStateByID<TrivialActor>(actor);
@@ -183,8 +184,9 @@ TYPED_TEST(
   auto runtime = std::make_shared<Runtime<TypeParam, EmptyExternalDispatcher>>(
       "PRMR-1234", "RuntimeTest", this->scheduler, dispatcher);
   auto actor_id = runtime->template spawn<TrivialActor>(
-      TrivialState{.state = "foo"}, TrivialStart{});
-  auto actor = ActorPID{.server = "PRMR-1234", .id = actor_id};
+      "database", TrivialState{.state = "foo"}, TrivialStart{});
+  auto actor =
+      ActorPID{.server = "PRMR-1234", .database = "database", .id = actor_id};
 
   runtime->dispatch(actor, actor, SomeMessages{SomeMessage{}});
 
@@ -203,10 +205,12 @@ TYPED_TEST(
   auto runtime = std::make_shared<Runtime<TypeParam, EmptyExternalDispatcher>>(
       "PRMR-1234", "RuntimeTest", this->scheduler, dispatcher);
   auto actor_id = runtime->template spawn<TrivialActor>(
-      TrivialState{.state = "foo"}, TrivialStart{});
-  auto actor = ActorPID{.server = "PRMR-1234", .id = actor_id};
+      "database", TrivialState{.state = "foo"}, TrivialStart{});
+  auto actor =
+      ActorPID{.server = "PRMR-1234", .database = "database", .id = actor_id};
 
-  auto unknown_actor = ActorPID{.server = "PRMR-1234", .id = {999}};
+  auto unknown_actor =
+      ActorPID{.server = "PRMR-1234", .database = "database", .id = {999}};
   runtime->dispatch(actor, unknown_actor,
                     TrivialActor::Message{TrivialMessage{"baz"}});
 
@@ -225,11 +229,12 @@ TYPED_TEST(ActorRuntimeTest, ping_pong_game) {
       serverID, "RuntimeTest", this->scheduler, dispatcher);
 
   auto pong_actor = runtime->template spawn<pong_actor::Actor>(
-      pong_actor::PongState{}, pong_actor::Start{});
+      "database", pong_actor::PongState{}, pong_actor::Start{});
   auto ping_actor = runtime->template spawn<ping_actor::Actor>(
-      ping_actor::PingState{},
-      ping_actor::Start{.pongActor =
-                            ActorPID{.server = serverID, .id = pong_actor}});
+      "database", ping_actor::PingState{},
+      ping_actor::Start{.pongActor = ActorPID{.server = serverID,
+                                              .database = "database",
+                                              .id = pong_actor}});
 
   this->scheduler->stop();
   auto ping_actor_state =
@@ -248,12 +253,13 @@ TYPED_TEST(ActorRuntimeTest, spawn_game) {
   auto runtime = std::make_shared<Runtime<TypeParam, EmptyExternalDispatcher>>(
       serverID, "RuntimeTest", this->scheduler, dispatcher);
 
-  auto spawn_actor =
-      runtime->template spawn<SpawnActor>(SpawnState{}, SpawnStartMessage{});
+  auto spawn_actor = runtime->template spawn<SpawnActor>(
+      "database", SpawnState{}, SpawnStartMessage{});
 
-  runtime->dispatch(ActorPID{.server = serverID, .id = spawn_actor},
-                    ActorPID{.server = serverID, .id = spawn_actor},
-                    SpawnActor::Message{SpawnMessage{"baz"}});
+  runtime->dispatch(
+      ActorPID{.server = serverID, .database = "database", .id = spawn_actor},
+      ActorPID{.server = serverID, .database = "database", .id = spawn_actor},
+      SpawnActor::Message{SpawnMessage{"baz"}});
 
   this->scheduler->stop();
   ASSERT_EQ(runtime->getActorIDs().size(), 2);
@@ -269,11 +275,14 @@ TYPED_TEST(ActorRuntimeTest, finishes_actor_when_actor_says_so) {
       serverID, "RuntimeTest", this->scheduler, dispatcher);
 
   auto finishing_actor = runtime->template spawn<FinishingActor>(
-      FinishingState{}, FinishingStart{});
+      "database", FinishingState{}, FinishingStart{});
 
-  runtime->dispatch(ActorPID{.server = serverID, .id = finishing_actor},
-                    ActorPID{.server = serverID, .id = finishing_actor},
-                    FinishingActor::Message{FinishingFinish{}});
+  runtime->dispatch(
+      ActorPID{
+          .server = serverID, .database = "database", .id = finishing_actor},
+      ActorPID{
+          .server = serverID, .database = "database", .id = finishing_actor},
+      FinishingActor::Message{FinishingFinish{}});
 
   this->scheduler->stop();
   ASSERT_TRUE(
@@ -287,7 +296,7 @@ TYPED_TEST(ActorRuntimeTest, garbage_collects_finished_actor) {
   auto runtime = std::make_shared<Runtime<TypeParam, EmptyExternalDispatcher>>(
       serverID, "RuntimeTest", this->scheduler, dispatcher);
   auto finishing_actor = runtime->template spawn<FinishingActor>(
-      FinishingState{}, FinishingStart{});
+      "database", FinishingState{}, FinishingStart{});
 
   runtime->dispatch(ActorPID{.server = serverID, .id = finishing_actor},
                     ActorPID{.server = serverID, .id = finishing_actor},
@@ -310,12 +319,15 @@ TYPED_TEST(ActorRuntimeTest, garbage_collects_all_finished_actors) {
       serverID, "RuntimeTest", this->scheduler, dispatcher);
 
   auto actor_to_be_finished = runtime->template spawn<FinishingActor>(
-      FinishingState{}, FinishingStart{});
-  runtime->template spawn<FinishingActor>(FinishingState{}, FinishingStart{});
-  runtime->template spawn<FinishingActor>(FinishingState{}, FinishingStart{});
+      "database", FinishingState{}, FinishingStart{});
+  runtime->template spawn<FinishingActor>("database", FinishingState{},
+                                          FinishingStart{});
+  runtime->template spawn<FinishingActor>("database", FinishingState{},
+                                          FinishingStart{});
   auto another_actor_to_be_finished = runtime->template spawn<FinishingActor>(
-      FinishingState{}, FinishingStart{});
-  runtime->template spawn<FinishingActor>(FinishingState{}, FinishingStart{});
+      "database", FinishingState{}, FinishingStart{});
+  runtime->template spawn<FinishingActor>("database", FinishingState{},
+                                          FinishingStart{});
 
   runtime->dispatch(ActorPID{.server = serverID, .id = actor_to_be_finished},
                     ActorPID{.server = serverID, .id = actor_to_be_finished},
@@ -346,11 +358,16 @@ TYPED_TEST(ActorRuntimeTest,
   auto dispatcher = std::make_shared<EmptyExternalDispatcher>();
   auto runtime = std::make_shared<Runtime<TypeParam, EmptyExternalDispatcher>>(
       serverID, "RuntimeTest", this->scheduler, dispatcher);
-  runtime->template spawn<TrivialActor>(TrivialState{}, TrivialStart{});
-  runtime->template spawn<TrivialActor>(TrivialState{}, TrivialStart{});
-  runtime->template spawn<TrivialActor>(TrivialState{}, TrivialStart{});
-  runtime->template spawn<TrivialActor>(TrivialState{}, TrivialStart{});
-  runtime->template spawn<TrivialActor>(TrivialState{}, TrivialStart{});
+  runtime->template spawn<TrivialActor>("database", TrivialState{},
+                                        TrivialStart{});
+  runtime->template spawn<TrivialActor>("database", TrivialState{},
+                                        TrivialStart{});
+  runtime->template spawn<TrivialActor>("database", TrivialState{},
+                                        TrivialStart{});
+  runtime->template spawn<TrivialActor>("database", TrivialState{},
+                                        TrivialStart{});
+  runtime->template spawn<TrivialActor>("database", TrivialState{},
+                                        TrivialStart{});
   ASSERT_EQ(runtime->actors.size(), 5);
   // wait for actor to work off all messages
   while (not runtime->areAllActorsIdle()) {
@@ -371,16 +388,26 @@ TEST(ActorRuntimeTest, sends_messages_between_lots_of_actors) {
   size_t actor_count = 128;
 
   for (size_t i = 0; i < actor_count; i++) {
-    runtime->template spawn<TrivialActor>(TrivialState{}, TrivialStart{});
+    runtime->template spawn<TrivialActor>("database", TrivialState{},
+                                          TrivialStart{});
   }
 
   // send from actor i to actor i+1 a message with content i
-  for (size_t i = 0; i < actor_count; i++) {
+  for (size_t i = 1; i < actor_count; i++) {
     runtime->dispatch(
-        ActorPID{.server = serverID, .id = ActorID{(i + 1) % actor_count}},
-        ActorPID{.server = serverID, .id = ActorID{i}},
+        ActorPID{.server = serverID,
+                 .database = "database",
+                 .id = ActorID{(i + 1) % actor_count}},
+        ActorPID{.server = serverID, .database = "database", .id = ActorID{i}},
         TrivialActor::Message{TrivialMessage{std::to_string(i)}});
   }
+  // send from actor actor_count to actor 1 (jump over special actor id 0)
+  runtime->dispatch(
+      ActorPID{.server = serverID, .database = "database", .id = ActorID{1}},
+      ActorPID{.server = serverID,
+               .database = "database",
+               .id = ActorID{actor_count}},
+      TrivialActor::Message{TrivialMessage{std::to_string(actor_count)}});
 
   // wait for actor to work off all messages
   while (not runtime->areAllActorsIdle()) {
@@ -388,9 +415,12 @@ TEST(ActorRuntimeTest, sends_messages_between_lots_of_actors) {
 
   scheduler->stop();
   ASSERT_EQ(runtime->actors.size(), actor_count);
-  for (size_t i = 0; i < actor_count; i++) {
+  for (size_t i = 1; i < actor_count; i++) {
     ASSERT_EQ(runtime->template getActorStateByID<TrivialActor>(ActorID{i}),
               (TrivialState{.state = std::to_string(i), .called = 2}));
   }
+  ASSERT_EQ(
+      runtime->template getActorStateByID<TrivialActor>(ActorID{actor_count}),
+      (TrivialState{.state = std::to_string(actor_count), .called = 2}));
   runtime->softShutdown();
 }


### PR DESCRIPTION
Uses actor framework in pregel:
When the pregel run now starts, a conductor actor is started. As soon as the involved DBServers are known, one worker actor is started on each of these servers. The conductor and worker actors are currently very simple. Code from the worker and conductor will be moved into these actors in following PRs.

For that to work, this PR:
- Adds an external dispatcher for arangodb and handles messages from this external dispatcher in the RestPregelHandler.
- To send REST messages, we need the specific database we are working on. Therefore, the database is now part of the ActorPID.
- To spawn an actor on another server, we start a spawn actor on each involved server. Because of the database addition to our ActorPID, the spawn server needs to be specific per database, therefore this actor can only be started once a pregel run started and the database is known.
Per REST this SpawnActor is created on the other server by sending a spawn message to this other server with the special Actor ID 0: The PregelRestHandler recognizes this special message by its ActorID 0 and spawns a SpawnActor.