### PR TITLE
Disable "maybe-uninitialized" warnings as errors for GCC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -925,7 +925,7 @@ else () # NOT MSVC
   if (CMAKE_COMPILER_IS_GNUCC)
     message(STATUS "Compiler type GNU: ${CMAKE_CXX_COMPILER}")
     set(BASE_FLAGS "-Wall -Wextra -Wno-unused-parameter -Wno-deprecated-declarations ${BASE_FLAGS}")
-    set(EXTRA_CXX_FLAGS "-Wsuggest-override -Wnon-virtual-dtor")
+    set(EXTRA_CXX_FLAGS "-Wsuggest-override -Wnon-virtual-dtor -Wno-error=maybe-uninitialized")
     if (CMAKE_CXX_COMPILER_VERSION VERSION_EQUAL "11.1.0")
       set(EXTRA_CXX_FLAGS "${EXTRA_CXX_FLAGS} -Wno-error=nonnull")
     endif()


### PR DESCRIPTION
### Scope & Purpose

Disable `maybe-uninitialized` warnings as errors on GCC. The warning stays enabled, but it's no longer a build error.
This is changed because we've seen too many false positives over the last years.

- [X] :building_construction: Build change

