### PR TITLE
Add missing include for gcc 11.2 with glibc

### DIFF
--- a/lib/Assertions/ProdAssert.h
+++ b/lib/Assertions/ProdAssert.h
@@ -52,6 +52,8 @@
 
 #include "AssertionLogger.h"
 
+#include "Basics/system-compiler.h"
+
 #define ADB_PROD_ASSERT(expr) /*GCOVR_EXCL_LINE*/                             \
   (ADB_LIKELY(expr))                                                          \
       ? (void)nullptr                                                         \


### PR DESCRIPTION
### Scope & Purpose

I found that I cannot compile devel with maintainer mode switched off on
Ubuntu with gcc 11.2.0 and glibc. It seems an include is missing. This
PR adds the include.

- [*] :hankey: Bugfix

