### PR TITLE
Make ArangoDB compile with clang-15

### DIFF
--- a/arangod/Agency/RemoveFollower.cpp
+++ b/arangod/Agency/RemoveFollower.cpp
@@ -230,11 +230,8 @@ bool RemoveFollower::start(bool&) {
                  });
 
   size_t inSyncCount = 0;
-  size_t notGoodCount = 0;
   for (auto const& pair : overview) {
-    if (pair.second == -1) {
-      ++notGoodCount;
-    } else if (static_cast<size_t>(pair.second) >= shardsLikeMe.size()) {
+    if (static_cast<size_t>(pair.second) >= shardsLikeMe.size()) {
       ++inSyncCount;
     }
   }

--- a/arangod/Agency/Supervision.cpp
+++ b/arangod/Agency/Supervision.cpp
@@ -3347,8 +3347,6 @@ bool Supervision::start(Agent* agent) {
   return start();
 }
 
-static std::string const syncLatest = "/Sync/LatestID";
-
 void Supervision::getUniqueIds() {
   _lock.assertLockedByCurrentThread();
 

--- a/arangod/Aql/CMakeLists.txt
+++ b/arangod/Aql/CMakeLists.txt
@@ -216,3 +216,5 @@ endif ()
 if (CMAKE_COMPILER_IS_GNUCC)
   set_source_files_properties(tokens.cpp PROPERTIES COMPILE_FLAGS -Wno-sign-compare)
 endif ()
+
+set_source_files_properties(grammar.cpp PROPERTIES COMPILE_FLAGS -Wno-unused-but-set-variable)

--- a/arangod/Cluster/AutoRebalance.cpp
+++ b/arangod/Cluster/AutoRebalance.cpp
@@ -513,10 +513,7 @@ int AutoRebalanceProblem::optimize(bool considerLeaderChanges,
 
   ShardImbalance shardImb = computeShardImbalance();
   LeaderImbalance leaderImb = computeLeaderImbalance();
-  size_t count = 0;
   for (auto& moves : moveGroups) {
-    ++count;
-
     for (auto& job : moves) {
       job.shardImbAfter = shardImb;    // copy
       job.leaderImbAfter = leaderImb;  // copy

--- a/arangod/Pregel/Algos/RecoveringPageRank.cpp
+++ b/arangod/Pregel/Algos/RecoveringPageRank.cpp
@@ -37,7 +37,6 @@ static float EPS = 0.00001f;
 static std::string const kConvergence = "convergence";
 static std::string const kStep = "step";
 static std::string const kRank = "rank";
-static std::string const kFailedCount = "failedCount";
 static std::string const kNonFailedCount = "nonfailedCount";
 static std::string const kScale = "scale";
 

--- a/arangod/RestHandler/RestReplicationHandler.cpp
+++ b/arangod/RestHandler/RestReplicationHandler.cpp
@@ -92,7 +92,6 @@ using Helper = arangodb::basics::VelocyPackHelper;
 
 namespace {
 std::string const dataString("data");
-std::string const keyString("key");
 std::string const typeString("type");
 }  // namespace
 

--- a/lib/Zip/zip.cpp
+++ b/lib/Zip/zip.cpp
@@ -1460,10 +1460,6 @@ extern int ZEXPORT zipWriteInFileInZip(zipFile file, const void* buf,
       if ((zi->ci.method == Z_DEFLATED) && (!zi->ci.raw)) {
         uLong uTotalOutBefore = zi->ci.stream.total_out;
         err = deflate(&zi->ci.stream, Z_NO_FLUSH);
-        if (uTotalOutBefore > zi->ci.stream.total_out) {
-          int bBreak = 0;
-          bBreak++;
-        }
 
         zi->ci.pos_in_buffered_data +=
             (uInt)(zi->ci.stream.total_out - uTotalOutBefore);


### PR DESCRIPTION
### Scope & Purpose

Make ArangoDB compile with clang-15. clang-15 now errors on unused but set variables. I removed all of them.
These changes are necessary for me, because otherwise there is no compiler available on arch linux that compiles arangodb. gcc-12.2.1 does not work because of known template errors.

There is one small catch: The automatically generated code in `grammar.cpp` declares a variable `Aqlnerrs` which we do not use. Thus I disabled the warning for that file.