### PR TITLE
fix inefficient temporary string creation for log messages

### DIFF
--- a/arangod/Agency/ActiveFailoverJob.cpp
+++ b/arangod/Agency/ActiveFailoverJob.cpp
@@ -69,7 +69,7 @@ void ActiveFailoverJob::run(bool& aborts) { runHelper(_server, "", aborts); }
 
 bool ActiveFailoverJob::create(std::shared_ptr<VPackBuilder> envelope) {
   LOG_TOPIC("3f7ab", DEBUG, Logger::SUPERVISION)
-      << "Todo: Handle failover for leader " + _server;
+      << "Todo: Handle failover for leader " << _server;
 
   bool selfCreate = (envelope == nullptr);  // Do we create ourselves?
 
@@ -139,7 +139,7 @@ bool ActiveFailoverJob::create(std::shared_ptr<VPackBuilder> envelope) {
   _status = NOTFOUND;
 
   LOG_TOPIC("3e5b0", INFO, Logger::SUPERVISION)
-      << "Failed to insert job " + _jobId;
+      << "Failed to insert job " << _jobId;
   return false;
 }
 
@@ -182,8 +182,8 @@ bool ActiveFailoverJob::start(bool&) {
         _snapshot.get(toDoPrefix + _jobId).value().get().toBuilder(todo);
       } catch (std::exception const&) {
         LOG_TOPIC("26fec", INFO, Logger::SUPERVISION)
-            << "Failed to get key " + toDoPrefix + _jobId +
-                   " from agency snapshot";
+            << "Failed to get key " << toDoPrefix << _jobId
+            << " from agency snapshot";
         return false;
       }
     } else {
@@ -241,7 +241,7 @@ bool ActiveFailoverJob::start(bool&) {
   }
 
   LOG_TOPIC("bcf05", INFO, Logger::SUPERVISION)
-      << "Precondition failed for ActiveFailoverJob " + _jobId;
+      << "Precondition failed for ActiveFailoverJob " << _jobId;
   return false;
 }
 

--- a/arangod/Agency/AddFollower.cpp
+++ b/arangod/Agency/AddFollower.cpp
@@ -131,7 +131,7 @@ bool AddFollower::create(std::shared_ptr<VPackBuilder> envelope) {
   _status = NOTFOUND;
 
   LOG_TOPIC("02cef", INFO, Logger::SUPERVISION)
-      << "Failed to insert job " + _jobId;
+      << "Failed to insert job " << _jobId;
   return false;
 }
 
@@ -289,8 +289,8 @@ bool AddFollower::start(bool&) {
         // Just in case, this is never going to happen, since we will only
         // call the start() method if the job is already in ToDo.
         LOG_TOPIC("24c50", INFO, Logger::SUPERVISION)
-            << "Failed to get key " + toDoPrefix + _jobId +
-                   " from agency snapshot";
+            << "Failed to get key " << toDoPrefix << _jobId
+            << " from agency snapshot";
         return false;
       }
     } else {
@@ -372,7 +372,7 @@ bool AddFollower::start(bool&) {
   }
 
   LOG_TOPIC("63ba4", INFO, Logger::SUPERVISION)
-      << "Start precondition failed for AddFollower " + _jobId;
+      << "Start precondition failed for AddFollower " << _jobId;
   return false;
 }
 

--- a/arangod/Agency/CleanOutServer.cpp
+++ b/arangod/Agency/CleanOutServer.cpp
@@ -152,7 +152,7 @@ JOB_STATUS CleanOutServer::status() {
 
 bool CleanOutServer::create(std::shared_ptr<VPackBuilder> envelope) {
   LOG_TOPIC("8a94c", DEBUG, Logger::SUPERVISION)
-      << "Todo: Clean out server " + _server + " for shrinkage";
+      << "Todo: Clean out server " << _server << " for shrinkage";
 
   bool selfCreate = (envelope == nullptr);  // Do we create ourselves?
 
@@ -194,7 +194,7 @@ bool CleanOutServer::create(std::shared_ptr<VPackBuilder> envelope) {
   _status = NOTFOUND;
 
   LOG_TOPIC("525fa", INFO, Logger::SUPERVISION)
-      << "Failed to insert job " + _jobId;
+      << "Failed to insert job " << _jobId;
   return false;
 }
 
@@ -299,8 +299,8 @@ bool CleanOutServer::start(bool& aborts) {
         // Just in case, this is never going to happen, since we will only
         // call the start() method if the job is already in ToDo.
         LOG_TOPIC("1e9a9", INFO, Logger::SUPERVISION)
-            << "Failed to get key " + toDoPrefix + _jobId +
-                   " from agency snapshot";
+            << "Failed to get key " << toDoPrefix << _jobId
+            << " from agency snapshot";
         return false;
       }
     } else {
@@ -361,13 +361,13 @@ bool CleanOutServer::start(bool& aborts) {
 
   if (res.accepted && res.indices.size() == 1 && res.indices[0]) {
     LOG_TOPIC("e341c", DEBUG, Logger::SUPERVISION)
-        << "Pending: Clean out server " + _server;
+        << "Pending: Clean out server " << _server;
 
     return true;
   }
 
   LOG_TOPIC("3a348", INFO, Logger::SUPERVISION)
-      << "Precondition failed for starting CleanOutServer job " + _jobId;
+      << "Precondition failed for starting CleanOutServer job " << _jobId;
 
   return false;
 }

--- a/arangod/Agency/FailedFollower.cpp
+++ b/arangod/Agency/FailedFollower.cpp
@@ -93,7 +93,7 @@ void FailedFollower::run(bool& aborts) { runHelper("", _shard, aborts); }
 bool FailedFollower::create(std::shared_ptr<VPackBuilder> envelope) {
   using namespace std::chrono;
   LOG_TOPIC("b0a34", INFO, Logger::SUPERVISION)
-      << "Create failedFollower for " + _shard + " from " + _from;
+      << "Create failedFollower for " << _shard << " from " << _from;
 
   _created = system_clock::now();
 
@@ -220,7 +220,8 @@ bool FailedFollower::start(bool& aborts) {
   }
 
   LOG_TOPIC("80b9d", INFO, Logger::SUPERVISION)
-      << "Start failedFollower for " + _shard + " from " + _from + " to " + _to;
+      << "Start failedFollower for " << _shard << " from " << _from << " to "
+      << _to;
 
   // Copy todo to pending
   Builder todo;
@@ -232,8 +233,8 @@ bool FailedFollower::start(bool& aborts) {
         jobIdNode->get().toBuilder(todo);
       } else {
         LOG_TOPIC("4571c", INFO, Logger::SUPERVISION)
-            << "Failed to get key " + toDoPrefix + _jobId +
-                   " from agency snapshot";
+            << "Failed to get key " << toDoPrefix << _jobId
+            << " from agency snapshot";
         return false;
       }
     } else {
@@ -383,7 +384,7 @@ bool FailedFollower::start(bool& aborts) {
   if (!slice.isNone()) {
     LOG_TOPIC("ad849", INFO, Logger::SUPERVISION)
         << "Destination " << _to << " is now blocked by job "
-        << slice.copyString();
+        << slice.stringView();
   }
 
   slice = result.get(std::vector<std::string>(
@@ -391,7 +392,7 @@ bool FailedFollower::start(bool& aborts) {
   if (!slice.isNone()) {
     LOG_TOPIC("57da4", INFO, Logger::SUPERVISION)
         << "Shard " << _shard << " is now blocked by job "
-        << slice.copyString();
+        << slice.stringView();
   }
 
   return false;

--- a/arangod/Agency/FailedLeader.cpp
+++ b/arangod/Agency/FailedLeader.cpp
@@ -148,7 +148,7 @@ void FailedLeader::rollback() {
 bool FailedLeader::create(std::shared_ptr<VPackBuilder> b) {
   using namespace std::chrono;
   LOG_TOPIC("46046", INFO, Logger::SUPERVISION)
-      << "Create failedLeader for " + _shard + " from " + _from;
+      << "Create failedLeader for " << _shard << " from " << _from;
 
   if (b == nullptr) {
     _jb = std::make_shared<Builder>();
@@ -208,7 +208,8 @@ bool FailedLeader::start(bool& aborts) {
   }
 
   LOG_TOPIC("0ced0", INFO, Logger::SUPERVISION)
-      << "Start failedLeader for " + _shard + " from " + _from + " to " + _to;
+      << "Start failedLeader for " << _shard << " from " << _from << " to "
+      << _to;
 
   using namespace std::chrono;
 
@@ -232,8 +233,8 @@ bool FailedLeader::start(bool& aborts) {
         jobIdNode->get().toBuilder(todo);
       } else {
         LOG_TOPIC("96395", INFO, Logger::SUPERVISION)
-            << "Failed to get key " + toDoPrefix + _jobId +
-                   " from agency snapshot";
+            << "Failed to get key " << toDoPrefix << _jobId
+            << " from agency snapshot";
         return false;
       }
     } else {
@@ -515,7 +516,7 @@ JOB_STATUS FailedLeader::status() {
         !basics::VelocyPackHelper::equal(plan_slice.value()[0],
                                          cur_slice.value()[0], false)) {
       LOG_TOPIC("0d8ca", DEBUG, Logger::SUPERVISION)
-          << "FailedLeader waiting for " << sub + "/" + shard;
+          << "FailedLeader waiting for " << sub << "/" << shard;
       break;
     }
     done = true;
@@ -524,8 +525,8 @@ JOB_STATUS FailedLeader::status() {
   if (done) {
     if (finish("", shard)) {
       LOG_TOPIC("1ead6", INFO, Logger::SUPERVISION)
-          << "Finished failedLeader for " + _shard + " from " + _from + " to " +
-                 _to;
+          << "Finished failedLeader for " << _shard << " from " << _from
+          << " to " << _to;
       return FINISHED;
     }
   }

--- a/arangod/Agency/FailedServer.cpp
+++ b/arangod/Agency/FailedServer.cpp
@@ -150,8 +150,8 @@ bool FailedServer::start(bool& aborts) {
         toDoJob.value().get().toBuilder(todo);
       } else {
         LOG_TOPIC("729c3", INFO, Logger::SUPERVISION)
-            << "Failed to get key " + toDoPrefix + _jobId +
-                   " from agency snapshot";
+            << "Failed to get key " << toDoPrefix << _jobId
+            << " from agency snapshot";
         return false;
       }
     } else {
@@ -292,14 +292,14 @@ bool FailedServer::start(bool& aborts) {
   }
 
   LOG_TOPIC("a3459", INFO, Logger::SUPERVISION)
-      << "Precondition failed for starting FailedServer " + _jobId;
+      << "Precondition failed for starting FailedServer " << _jobId;
 
   return false;
 }
 
 bool FailedServer::create(std::shared_ptr<VPackBuilder> envelope) {
   LOG_TOPIC("352fa", DEBUG, Logger::SUPERVISION)
-      << "Todo: Handle failover for db server " + _server;
+      << "Todo: Handle failover for db server " << _server;
 
   using namespace std::chrono;
   bool selfCreate = (envelope == nullptr);  // Do we create ourselves?
@@ -362,7 +362,7 @@ bool FailedServer::create(std::shared_ptr<VPackBuilder> envelope) {
     write_ret_t res = singleWriteTransaction(_agent, *_jb, false);
     if (!res.accepted || res.indices.size() != 1 || res.indices[0] == 0) {
       LOG_TOPIC("70ce1", INFO, Logger::SUPERVISION)
-          << "Failed to insert job " + _jobId;
+          << "Failed to insert job " << _jobId;
       return false;
     }
   }

--- a/arangod/Agency/MoveShard.cpp
+++ b/arangod/Agency/MoveShard.cpp
@@ -121,7 +121,7 @@ void MoveShard::run(bool& aborts) { runHelper(_to, _shard, aborts); }
 
 bool MoveShard::create(std::shared_ptr<VPackBuilder> envelope) {
   LOG_TOPIC("02579", DEBUG, Logger::SUPERVISION)
-      << "Todo: Move shard " + _shard + " from " + _from + " to " << _to;
+      << "Todo: Move shard " << _shard << " from " << _from << " to " << _to;
 
   bool selfCreate = (envelope == nullptr);  // Do we create ourselves?
 
@@ -193,7 +193,7 @@ bool MoveShard::create(std::shared_ptr<VPackBuilder> envelope) {
   _status = NOTFOUND;
 
   LOG_TOPIC("cb317", INFO, Logger::SUPERVISION)
-      << "Failed to insert job " + _jobId;
+      << "Failed to insert job " << _jobId;
   return false;
 }
 
@@ -456,8 +456,8 @@ bool MoveShard::start(bool&) {
         // Just in case, this is never going to happen, since we will only
         // call the start() method if the job is already in ToDo.
         LOG_TOPIC("2482a", INFO, Logger::SUPERVISION)
-            << "Failed to get key " + toDoPrefix + _jobId +
-                   " from agency snapshot";
+            << "Failed to get key " << toDoPrefix << _jobId
+            << " from agency snapshot";
         return false;
       }
     } else {
@@ -591,12 +591,13 @@ bool MoveShard::start(bool&) {
 
   if (res.accepted && res.indices.size() == 1 && res.indices[0]) {
     LOG_TOPIC("45120", DEBUG, Logger::SUPERVISION)
-        << "Pending: Move shard " + _shard + " from " + _from + " to " + _to;
+        << "Pending: Move shard " << _shard << " from " << _from << " to "
+        << _to;
     return true;
   }
 
   LOG_TOPIC("0a925", DEBUG, Logger::SUPERVISION)
-      << "Start precondition failed for MoveShard job " + _jobId;
+      << "Start precondition failed for MoveShard job " << _jobId;
   return false;
 }
 
@@ -693,12 +694,13 @@ bool MoveShard::startReplication2() {
 
   if (res.accepted && res.indices.size() == 1 && res.indices[0]) {
     LOG_TOPIC("4512d", DEBUG, Logger::SUPERVISION)
-        << "Pending: Move shard " + _shard + " from " + _from + " to " + _to;
+        << "Pending: Move shard " << _shard << " from " << _from << " to "
+        << _to;
     return true;
   }
 
   LOG_TOPIC("0a92d", DEBUG, Logger::SUPERVISION)
-      << "Start precondition failed for MoveShard job " + _jobId;
+      << "Start precondition failed for MoveShard job " << _jobId;
   return false;
 }
 
@@ -784,12 +786,13 @@ JOB_STATUS MoveShard::pendingReplication2() {
 
   if (res.accepted && res.indices.size() == 1 && res.indices[0]) {
     LOG_TOPIC("f8c21", DEBUG, Logger::SUPERVISION)
-        << "Pending: Move shard " + _shard + " from " + _from + " to " + _to;
+        << "Pending: Move shard " << _shard << " from " << _from << " to "
+        << _to;
     return FINISHED;
   }
 
   LOG_TOPIC("521eb", DEBUG, Logger::SUPERVISION)
-      << "Precondition failed for MoveShard job " + _jobId;
+      << "Precondition failed for MoveShard job " << _jobId;
   return PENDING;
 }
 
@@ -1130,12 +1133,13 @@ JOB_STATUS MoveShard::pendingLeader() {
 
   if (res.accepted && res.indices.size() == 1 && res.indices[0]) {
     LOG_TOPIC("ffc21", DEBUG, Logger::SUPERVISION)
-        << "Pending: Move shard " + _shard + " from " + _from + " to " + _to;
+        << "Pending: Move shard " << _shard << " from " << _from << " to "
+        << _to;
     return (finishedAfterTransaction ? FINISHED : PENDING);
   }
 
   LOG_TOPIC("52feb", DEBUG, Logger::SUPERVISION)
-      << "Precondition failed for MoveShard job " + _jobId;
+      << "Precondition failed for MoveShard job " << _jobId;
   return PENDING;
 }
 

--- a/arangod/Agency/RemoveFollower.cpp
+++ b/arangod/Agency/RemoveFollower.cpp
@@ -124,7 +124,7 @@ bool RemoveFollower::create(std::shared_ptr<VPackBuilder> envelope) {
   _status = NOTFOUND;
 
   LOG_TOPIC("83bf8", INFO, Logger::SUPERVISION)
-      << "Failed to insert job " + _jobId;
+      << "Failed to insert job " << _jobId;
   return false;
 }
 
@@ -372,8 +372,8 @@ bool RemoveFollower::start(bool&) {
         // Just in case, this is never going to happen, since we will only
         // call the start() method if the job is already in ToDo.
         LOG_TOPIC("4fac6", INFO, Logger::SUPERVISION)
-            << "Failed to get key " + toDoPrefix + _jobId +
-                   " from agency snapshot";
+            << "Failed to get key " << toDoPrefix << _jobId
+            << " from agency snapshot";
         return false;
       }
     } else {
@@ -441,7 +441,7 @@ bool RemoveFollower::start(bool&) {
   }
 
   LOG_TOPIC("f2df8", INFO, Logger::SUPERVISION)
-      << "Start precondition failed for RemoveFollower Job " + _jobId;
+      << "Start precondition failed for RemoveFollower Job " << _jobId;
   return false;
 }
 

--- a/arangod/Agency/ResignLeadership.cpp
+++ b/arangod/Agency/ResignLeadership.cpp
@@ -152,7 +152,7 @@ JOB_STATUS ResignLeadership::status() {
 
 bool ResignLeadership::create(std::shared_ptr<VPackBuilder> envelope) {
   LOG_TOPIC("dead7", DEBUG, Logger::SUPERVISION)
-      << "Todo: Resign leadership server " + _server;
+      << "Todo: Resign leadership server " << _server;
 
   bool selfCreate = (envelope == nullptr);  // Do we create ourselves?
 
@@ -195,7 +195,7 @@ bool ResignLeadership::create(std::shared_ptr<VPackBuilder> envelope) {
   _status = NOTFOUND;
 
   LOG_TOPIC("dead8", INFO, Logger::SUPERVISION)
-      << "Failed to insert job " + _jobId;
+      << "Failed to insert job " << _jobId;
   return false;
 }
 
@@ -296,8 +296,8 @@ bool ResignLeadership::start(bool& aborts) {
         // Just in case, this is never going to happen, since we will only
         // call the start() method if the job is already in ToDo.
         LOG_TOPIC("deadb", INFO, Logger::SUPERVISION)
-            << "Failed to get key " + toDoPrefix + _jobId +
-                   " from agency snapshot";
+            << "Failed to get key " << toDoPrefix << _jobId
+            << " from agency snapshot";
         return false;
       }
     } else {
@@ -355,13 +355,13 @@ bool ResignLeadership::start(bool& aborts) {
 
   if (res.accepted && res.indices.size() == 1 && res.indices[0]) {
     LOG_TOPIC("deadd", DEBUG, Logger::SUPERVISION)
-        << "Pending: Clean out server " + _server;
+        << "Pending: Clean out server " << _server;
 
     return true;
   }
 
   LOG_TOPIC("deade", INFO, Logger::SUPERVISION)
-      << "Precondition failed for starting ResignLeadership job " + _jobId;
+      << "Precondition failed for starting ResignLeadership job " << _jobId;
 
   return false;
 }

--- a/arangod/Agency/Supervision.cpp
+++ b/arangod/Agency/Supervision.cpp
@@ -1460,7 +1460,7 @@ std::unordered_map<ServerID, std::string> deletionCandidates(
         }
       } catch (std::exception const& e) {
         LOG_TOPIC("21a9e", DEBUG, Logger::SUPERVISION)
-            << "Failing to analyse " << serverId << " as deletion candidate "
+            << "Failing to analyze " << serverId << " as deletion candidate "
             << e.what();
       }
 

--- a/arangod/Cluster/DropCollection.cpp
+++ b/arangod/Cluster/DropCollection.cpp
@@ -80,7 +80,7 @@ bool DropCollection::first() {
       if (found.ok()) {
         TRI_ASSERT(coll);
         LOG_TOPIC("03e2f", DEBUG, Logger::MAINTENANCE)
-            << "Dropping local collection " + shard;
+            << "Dropping local collection " << shard;
         result(Collections::drop(*coll, false));
 
         // it is safe here to clear our replication failure statistics even

--- a/arangod/Cluster/DropIndex.cpp
+++ b/arangod/Cluster/DropIndex.cpp
@@ -96,7 +96,7 @@ bool DropIndex::first() {
     }
 
     LOG_TOPIC("837c5", DEBUG, Logger::MAINTENANCE)
-        << "Dropping local index " + shard + "/" + id;
+        << "Dropping local index " << shard << "/" << id;
     result(Indexes::drop(col.get(), index.slice()));
 
   } catch (std::exception const& e) {

--- a/arangod/Cluster/EnsureIndex.cpp
+++ b/arangod/Cluster/EnsureIndex.cpp
@@ -106,8 +106,8 @@ bool EnsureIndex::first() {
     auto col = vocbase->lookupCollection(shard);
     if (col == nullptr) {
       std::stringstream error;
-      error << "failed to lookup local collection " << shard
-            << " in database " + database;
+      error << "failed to lookup local collection " << shard << " in database "
+            << database;
       LOG_TOPIC("12767", ERR, Logger::MAINTENANCE)
           << "EnsureIndex: " << error.str();
       result(TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND, error.str());

--- a/arangod/Cluster/ResignShardLeadership.cpp
+++ b/arangod/Cluster/ResignShardLeadership.cpp
@@ -101,7 +101,7 @@ bool ResignShardLeadership::first() {
     if (col == nullptr) {
       std::stringstream error;
       error << "Failed to lookup local collection " << collection
-            << " in database " + database;
+            << " in database " << database;
       LOG_TOPIC("e06ca", ERR, Logger::MAINTENANCE)
           << "ResignLeadership: " << error.str();
       result(TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND, error.str());

--- a/arangod/Cluster/TakeoverShardLeadership.cpp
+++ b/arangod/Cluster/TakeoverShardLeadership.cpp
@@ -273,7 +273,7 @@ bool TakeoverShardLeadership::first() {
     } else {
       std::stringstream error;
       error << "TakeoverShardLeadership: failed to lookup local collection "
-            << shard << "in database " + database;
+            << shard << "in database " << database;
       LOG_TOPIC("65342", ERR, Logger::MAINTENANCE) << error.str();
       res = actionError(TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND, error.str());
       result(res);

--- a/arangod/Cluster/UpdateCollection.cpp
+++ b/arangod/Cluster/UpdateCollection.cpp
@@ -95,7 +95,7 @@ bool UpdateCollection::first() {
     if (found.ok()) {
       TRI_ASSERT(coll);
       LOG_TOPIC("60543", DEBUG, Logger::MAINTENANCE)
-          << "Updating local collection " + shard;
+          << "Updating local collection " << shard;
 
       // If someone (the Supervision most likely) has thrown
       // out a follower from the plan, then the leader
@@ -130,8 +130,8 @@ bool UpdateCollection::first() {
 
     } else {
       std::stringstream error;
-      error << "failed to lookup local collection " << shard
-            << "in database " + database;
+      error << "failed to lookup local collection " << shard << "in database "
+            << database;
       LOG_TOPIC("620fb", ERR, Logger::MAINTENANCE) << error.str();
       res = actionError(TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND, error.str());
       result(res);

--- a/arangod/Replication/TailingSyncer.cpp
+++ b/arangod/Replication/TailingSyncer.cpp
@@ -1834,9 +1834,8 @@ void TailingSyncer::fetchLeaderLog(
     } else {
       // success!
       LOG_TOPIC("a4822", DEBUG, Logger::REPLICATION)
-          << "fetching leader log from tick " + StringUtils::itoa(fetchTick) +
-                 " took "
-          << time << " s";
+          << "fetching leader log from tick " << fetchTick << " took " << time
+          << " s";
       sharedStatus->gotResponse(std::move(response), time);
     }
   } catch (basics::Exception const& ex) {


### PR DESCRIPTION
### Scope & Purpose

Fix inefficient creation of temporary string objects for use with the logger.
Instead of
```
LOG_TOPIC(...) << a + b + c 
```
now use
```
LOG_TOPIC(...) << a << b << c
```
if a, b and c are strings.

None of the adjusted places is performance-critical.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: -
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 