### PR TITLE
small code improvements for agency code

### DIFF
--- a/arangod/Agency/AddFollower.cpp
+++ b/arangod/Agency/AddFollower.cpp
@@ -230,7 +230,7 @@ bool AddFollower::start(bool&) {
   // Remove those that are not in state "GOOD":
   auto it = available.begin();
   while (it != available.end()) {
-    if (checkServerHealth(_snapshot, *it) != "GOOD") {
+    if (checkServerHealth(_snapshot, *it) != Supervision::HEALTH_STATUS_GOOD) {
       it = available.erase(it);
     } else {
       ++it;
@@ -355,7 +355,7 @@ bool AddFollower::start(bool&) {
           });
       addPreconditionShardNotBlocked(trx, _shard);
       for (auto const& srv : chosen) {
-        addPreconditionServerHealth(trx, srv, "GOOD");
+        addPreconditionServerHealth(trx, srv, Supervision::HEALTH_STATUS_GOOD);
       }
     }  // precondition done
   }    // array for transaction done

--- a/arangod/Agency/FailedFollower.cpp
+++ b/arangod/Agency/FailedFollower.cpp
@@ -164,7 +164,7 @@ bool FailedFollower::start(bool& aborts) {
   bool found = false;
   if (planned.isArray()) {
     for (VPackSlice s : VPackArrayIterator(planned)) {
-      if (s.isString() && _from == s.copyString()) {
+      if (s.isString() && _from == s.stringView()) {
         found = true;
         break;
       }
@@ -198,7 +198,7 @@ bool FailedFollower::start(bool& aborts) {
     if (s.isString()) {
       std::string id = s.copyString();
       if (failoverCands.find(id) == failoverCands.end()) {
-        excludes.push_back(s.copyString());
+        excludes.push_back(std::move(id));
       }
     }
   }
@@ -274,7 +274,7 @@ bool FailedFollower::start(bool& aborts) {
                   VPackValue(timepointToString(system_clock::now())));
           job.add("toServer", VPackValue(_to));  // toServer
           for (auto const& obj : VPackObjectIterator(todo.slice()[0])) {
-            job.add(obj.key.copyString(), obj.value);
+            job.add(obj.key.stringView(), obj.value);
           }
         }
         addRemoveJobFromSomewhere(job, "ToDo", _jobId);
@@ -294,7 +294,7 @@ bool FailedFollower::start(bool& aborts) {
         job.add(VPackValue(healthPrefix + _from + "/Status"));
         {
           VPackObjectBuilder stillExists(&job);
-          job.add("old", VPackValue("FAILED"));
+          job.add("old", VPackValue(Supervision::HEALTH_STATUS_FAILED));
         }
         // Plan still as we see it:
         addPreconditionUnchanged(job, planPath, planned);
@@ -317,7 +317,7 @@ bool FailedFollower::start(bool& aborts) {
         // shard not blocked
         addPreconditionShardNotBlocked(job, _shard);
         // toServer in good condition
-        addPreconditionServerHealth(job, _to, "GOOD");
+        addPreconditionServerHealth(job, _to, Supervision::HEALTH_STATUS_GOOD);
       }
     }
   }
@@ -359,13 +359,15 @@ bool FailedFollower::start(bool& aborts) {
 
   auto slice = result.get(std::vector<std::string>(
       {agencyPrefix, "Supervision", "Health", _from, "Status"}));
-  if (slice.isString() && slice.copyString() != "FAILED") {
+  if (slice.isString() &&
+      slice.stringView() != Supervision::HEALTH_STATUS_FAILED) {
     finish("", _shard, false, "Server " + _from + " no longer failing.");
   }
 
   slice = result.get(std::vector<std::string>(
       {agencyPrefix, "Supervision", "Health", _to, "Status"}));
-  if (!slice.isString() || slice.copyString() != "GOOD") {
+  if (!slice.isString() ||
+      slice.stringView() != Supervision::HEALTH_STATUS_GOOD) {
     LOG_TOPIC("4785b", INFO, Logger::SUPERVISION)
         << "Destination server " << _to << " is no longer in good condition";
   }

--- a/arangod/Agency/FailedLeader.cpp
+++ b/arangod/Agency/FailedLeader.cpp
@@ -107,7 +107,7 @@ void FailedLeader::rollback() {
         VPackArrayBuilder r(&rb);
         for (auto const i : VPackArrayIterator(planned)) {
           TRI_ASSERT(i.isString());
-          auto istr = i.copyString();
+          auto istr = i.stringView();
           if (istr == _from) {
             rb.add(VPackValue(_to));
           } else if (istr == _to) {
@@ -252,7 +252,7 @@ bool FailedLeader::start(bool& aborts) {
     // should never happen as well, but if it happens, this situation will
     // repair itself by diverging replicationFactor.
     if (s != _from && s != _to && !s.empty() && s[0] != '_') {
-      planv.push_back(s);
+      planv.push_back(std::move(s));
     }
   }
 
@@ -265,7 +265,7 @@ bool FailedLeader::start(bool& aborts) {
     if (s.isString()) {
       std::string id = s.copyString();
       if (failoverCands.find(id) == failoverCands.end()) {
-        excludes.push_back(s.copyString());
+        excludes.push_back(std::move(id));
       }
     }
   }
@@ -300,7 +300,7 @@ bool FailedLeader::start(bool& aborts) {
                       VPackValue(timepointToString(system_clock::now())));
           pending.add("toServer", VPackValue(_to));  // toServer
           for (auto const& obj : VPackObjectIterator(todo.slice()[0])) {
-            pending.add(obj.key.copyString(), obj.value);
+            pending.add(obj.key.stringView(), obj.value);
           }
         }
         addRemoveJobFromSomewhere(pending, "ToDo", _jobId);
@@ -314,7 +314,7 @@ bool FailedLeader::start(bool& aborts) {
           // others to remove.
           for (auto const& i : VPackArrayIterator(current)) {
             std::string s = i.copyString();
-            if (s.size() > 0 && s[0] == '_') {
+            if (s.starts_with('_')) {
               s = s.substr(1);
             }
             // We need to make sure to only pick servers from the plan as
@@ -350,9 +350,11 @@ bool FailedLeader::start(bool& aborts) {
       {
         VPackObjectBuilder preconditions(&pending);
         // Failed condition persists
-        addPreconditionServerHealth(pending, _from, "FAILED");
+        addPreconditionServerHealth(pending, _from,
+                                    Supervision::HEALTH_STATUS_FAILED);
         // Destination server still in good condition
-        addPreconditionServerHealth(pending, _to, "GOOD");
+        addPreconditionServerHealth(pending, _to,
+                                    Supervision::HEALTH_STATUS_GOOD);
         // Server list in plan still as before
         addPreconditionUnchanged(pending, planPath, planned);
         // Check that Current/servers and failoverCandidates are still as
@@ -420,7 +422,8 @@ bool FailedLeader::start(bool& aborts) {
     // Still failing _from?
     auto slice = result.get(std::vector<std::string>(
         {agencyPrefix, "Supervision", "Health", _from, "Status"}));
-    if (slice.isString() && slice.copyString() == "GOOD") {
+    if (slice.isString() &&
+        slice.stringView() == Supervision::HEALTH_STATUS_GOOD) {
       finish("", _shard, false, "Server " + _from + " no longer failing.");
       return false;
     }
@@ -428,7 +431,8 @@ bool FailedLeader::start(bool& aborts) {
     // Still healthy _to?
     slice = result.get(std::vector<std::string>(
         {agencyPrefix, "Supervision", "Health", _to, "Status"}));
-    if (slice.isString() && slice.copyString() != "GOOD") {
+    if (slice.isString() &&
+        slice.stringView() != Supervision::HEALTH_STATUS_GOOD) {
       LOG_TOPIC("7e2ef", INFO, Logger::SUPERVISION)
           << "Will not failover from " << _from << " to " << _to
           << " as target server is no longer in good condition. Will retry.";
@@ -484,7 +488,8 @@ JOB_STATUS FailedLeader::status() {
   }
 
   std::string toServerHealth = checkServerHealth(_snapshot, _to);
-  if (toServerHealth == "FAILED" || toServerHealth == "UNCLEAR") {
+  if (toServerHealth == Supervision::HEALTH_STATUS_FAILED ||
+      toServerHealth == Supervision::HEALTH_STATUS_UNCLEAR) {
     finish("", _shard, false, "_to server not health");
     return FAILED;
   }

--- a/arangod/Agency/FailedServer.cpp
+++ b/arangod/Agency/FailedServer.cpp
@@ -83,7 +83,7 @@ bool FailedServer::start(bool& aborts) {
 
   // Fail job, if Health back to not FAILED
   auto status = _snapshot.hasAsString(healthPrefix + _server + "/Status");
-  if (status && status.value() != "FAILED") {
+  if (status && status.value() != Supervision::HEALTH_STATUS_FAILED) {
     std::stringstream reason;
     reason << "Server " << _server
            << " is no longer failed. Not starting FailedServer job";
@@ -277,7 +277,8 @@ bool FailedServer::start(bool& aborts) {
       // Check that toServer not blocked
       addPreconditionServerNotBlocked(*transactions, _server);
       // Status should still be FAILED
-      addPreconditionServerHealth(*transactions, _server, "FAILED");
+      addPreconditionServerHealth(*transactions, _server,
+                                  Supervision::HEALTH_STATUS_FAILED);
     }  // <--------- Preconditions
   }
 
@@ -341,7 +342,8 @@ bool FailedServer::create(std::shared_ptr<VPackBuilder> envelope) {
     {
       VPackObjectBuilder health(_jb.get());
       // Status should still be BAD
-      addPreconditionServerHealth(*_jb, _server, "BAD");
+      addPreconditionServerHealth(*_jb, _server,
+                                  Supervision::HEALTH_STATUS_BAD);
       // Target/FailedServers does not already include _server
       _jb->add(VPackValue(failedServersPrefix + "/" + _server));
       {

--- a/arangod/Agency/Job.cpp
+++ b/arangod/Agency/Job.cpp
@@ -404,7 +404,7 @@ std::string Job::randomIdleAvailableServer(
       }
 
       std::string const status = (*srv.second).hasAsString("Status").value();
-      if (status == "GOOD") {
+      if (status == Supervision::HEALTH_STATUS_GOOD) {
         good.push_back(srv.first);
       }
     }
@@ -445,8 +445,8 @@ size_t Job::countGoodOrBadServersInList(Node const& snap,
         // serverName not a string? Then don't count
         std::string serverStr = serverName.copyString();
         // Ignore a potential _ prefix, which can occur on leader resign:
-        if (serverStr.size() > 0 && serverStr[0] == '_') {
-          serverStr.erase(0, 1);  // remove trailing _
+        if (serverStr.starts_with('_')) {
+          serverStr.erase(0, 1);  // remove leading _
         }
         // Now look up this server:
         auto it = healthData.find(serverStr);
@@ -456,7 +456,8 @@ size_t Job::countGoodOrBadServersInList(Node const& snap,
           // Check its status:
 
           if (auto status = healthNode->hasAsString("Status");
-              status && (status.value() == "GOOD" || status.value() == "BAD")) {
+              status && (status.value() == Supervision::HEALTH_STATUS_GOOD ||
+                         status.value() == Supervision::HEALTH_STATUS_BAD)) {
             ++count;
             // check is server is maintenance mode, if so, consider as good
           } else if (maintenanceSet.has_value() &&
@@ -487,7 +488,8 @@ size_t Job::countGoodOrBadServersInList(
         std::shared_ptr<Node> healthNode = it->second;
         // Check its status:
         if (auto status = healthNode->hasAsString("Status");
-            status && (status.value() == "GOOD" || status.value() == "BAD")) {
+            status && (status.value() == Supervision::HEALTH_STATUS_GOOD ||
+                       status.value() == Supervision::HEALTH_STATUS_BAD)) {
           ++count;
         }
       }
@@ -661,7 +663,8 @@ Job::findNonblockedCommonHealthyInSyncFollower(  // Which is in "GOOD" health
   std::unordered_map<std::string, bool> good;
 
   for (auto const& i : snap.hasAsChildren(healthPrefix).value().get()) {
-    good[i.first] = ((*i.second).hasAsString("Status").value() == "GOOD");
+    good[i.first] = ((*i.second).hasAsString("Status").value() ==
+                     Supervision::HEALTH_STATUS_GOOD);
   }
 
   std::unordered_map<std::string, size_t> currentServers;
@@ -861,13 +864,10 @@ void Job::doForAllShards(
                        std::string& curPath)>
         worker) {
   for (auto const& collShard : shards) {
-    std::string shard = collShard.shard;
-    std::string collection = collShard.collection;
-
-    std::string planPath =
-        planColPrefix + database + "/" + collection + "/shards/" + shard;
-    std::string curPath =
-        curColPrefix + database + "/" + collection + "/" + shard + "/servers";
+    std::string planPath = planColPrefix + database + "/" +
+                           collShard.collection + "/shards/" + collShard.shard;
+    std::string curPath = curColPrefix + database + "/" + collShard.collection +
+                          "/" + collShard.shard + "/servers";
 
     Slice plan = snapshot.hasAsSlice(planPath).value();
     Slice current = snapshot.hasAsSlice(curPath).value_or(Slice::noneSlice());
@@ -1035,7 +1035,7 @@ std::string Job::checkServerHealth(Node const& snapshot,
   auto status = snapshot.hasAsString(healthPrefix + server + "/Status");
 
   if (!status) {
-    return "UNCLEAR";
+    return std::string{Supervision::HEALTH_STATUS_UNCLEAR};
   }
   return status.value();
 }
@@ -1194,7 +1194,8 @@ std::string Job::findOtherHealthyParticipant(Node const& snap,
   }
   std::unordered_map<std::string, bool> good;
   for (const auto& i : snap.hasAsChildren(healthPrefix).value().get()) {
-    good[i.first] = ((*i.second).hasAsString("Status").value() == "GOOD");
+    good[i.first] = ((*i.second).hasAsString("Status").value() ==
+                     Supervision::HEALTH_STATUS_GOOD);
   }
 
   for (const auto& [id, participantData] : target->participants) {

--- a/arangod/Agency/JobContext.cpp
+++ b/arangod/Agency/JobContext.cpp
@@ -36,11 +36,10 @@
 
 using namespace arangodb::consensus;
 
-JobContext::JobContext(JOB_STATUS status, std::string id, Node const& snapshot,
-                       AgentInterface* agent)
+JobContext::JobContext(JOB_STATUS status, std::string const& id,
+                       Node const& snapshot, AgentInterface* agent)
     : _job(nullptr) {
-  std::string path = pos[status] + id;
-  auto typePair = snapshot.hasAsString(path + "/type");
+  auto typePair = snapshot.hasAsString(pos[status] + id + "/type");
   std::string type;
 
   if (typePair) {

--- a/arangod/Agency/JobContext.h
+++ b/arangod/Agency/JobContext.h
@@ -36,7 +36,7 @@ namespace consensus {
 class JobContext {
  public:
   /// @brief Contextualize arbitrary Job
-  JobContext(JOB_STATUS status, std::string id, Node const& snapshot,
+  JobContext(JOB_STATUS status, std::string const& id, Node const& snapshot,
              AgentInterface* agent);
 
   /// @brief Create job

--- a/arangod/Agency/MoveShard.cpp
+++ b/arangod/Agency/MoveShard.cpp
@@ -295,8 +295,8 @@ bool MoveShard::start(bool&) {
 
   // Check that the toServer is in state "GOOD":
   std::string health = checkServerHealth(_snapshot, _to);
-  if (health != "GOOD") {
-    if (health == "BAD") {
+  if (health != Supervision::HEALTH_STATUS_GOOD) {
+    if (health == Supervision::HEALTH_STATUS_BAD) {
       LOG_TOPIC("de055", DEBUG, Logger::SUPERVISION)
           << "server " << _to << " is currently " << health
           << ", not starting MoveShard job " << _jobId;
@@ -579,7 +579,8 @@ bool MoveShard::start(bool&) {
       addPreconditionShardNotBlocked(pending, _shard);
       addMoveShardToServerCanLock(pending);
       addMoveShardFromServerCanLock(pending);
-      addPreconditionServerHealth(pending, _to, "GOOD");
+      addPreconditionServerHealth(pending, _to,
+                                  Supervision::HEALTH_STATUS_GOOD);
       addPreconditionUnchanged(pending, failedServersPrefix, failedServers);
       addPreconditionUnchanged(pending, cleanedPrefix, cleanedServers);
     }  // precondition done
@@ -675,7 +676,7 @@ bool MoveShard::startReplication2() {
       addPreconditionShardNotBlocked(trx, _shard);
       addMoveShardToServerCanLock(trx);
       addMoveShardFromServerCanLock(trx);
-      addPreconditionServerHealth(trx, _to, "GOOD");
+      addPreconditionServerHealth(trx, _to, Supervision::HEALTH_STATUS_GOOD);
 
       {
         VPackObjectBuilder ob(&trx, targetPath + "/version");

--- a/arangod/Agency/Store.h
+++ b/arangod/Agency/Store.h
@@ -24,11 +24,16 @@
 #pragma once
 
 #include "AgentInterface.h"
+#include "Agency/Node.h"
 #include "Basics/ConditionVariable.h"
 #include "Basics/Mutex.h"
 #include "RestServer/arangod.h"
-#include "Node.h"
+
+#include <iostream>
 #include <map>
+#include <string>
+#include <string_view>
+#include <unordered_map>
 
 namespace arangodb {
 namespace consensus {
@@ -158,12 +163,12 @@ class Store {
 
   /// @brief Split strings by forward slashes, omitting empty strings,
   /// and ignoring multiple subsequent forward slashes
-  static std::vector<std::string> split(std::string const& str);
+  static std::vector<std::string> split(std::string_view str);
 
   using AgencyTriggerCallback =
       std::function<void(std::string_view path, VPackSlice trx)>;
 
-  void registerPrefixTrigger(std::string prefix, AgencyTriggerCallback);
+  void registerPrefixTrigger(std::string const& prefix, AgencyTriggerCallback);
 
 #if !defined(MAKE_NOTIFY_OBSERVERS_PUBLIC)
  private:

--- a/arangod/Agency/Supervision.cpp
+++ b/arangod/Agency/Supervision.cpp
@@ -23,10 +23,6 @@
 
 #include "Supervision.h"
 
-#include <Basics/StringUtils.h>
-#include <Basics/overload.h>
-#include <thread>
-
 #include "Agency/ActiveFailoverJob.h"
 #include "Agency/AddFollower.h"
 #include "Agency/Agent.h"
@@ -42,6 +38,8 @@
 #include "Basics/ConditionLocker.h"
 #include "Basics/MutexLocker.h"
 #include "Basics/StaticStrings.h"
+#include "Basics/StringUtils.h"
+#include "Basics/overload.h"
 #include "Cluster/ClusterHelpers.h"
 #include "Cluster/ServerState.h"
 #include "Metrics/CounterBuilder.h"
@@ -278,7 +276,7 @@ void Supervision::upgradeZero(Builder& builder) {
           VPackObjectBuilder oo(&builder);
           if (fails.length() > 0) {
             for (VPackSlice fail : VPackArrayIterator(fails)) {
-              builder.add(VPackValue(fail.copyString()));
+              builder.add(VPackValue(fail.stringView()));
               { VPackArrayBuilder ooo(&builder); }
             }
           }
@@ -532,7 +530,7 @@ void handleOnStatus(
                            delayFailedFollower, failedLeaderAddsFollower);
   } else if (ClusterHelpers::isCoordinatorName(serverID)) {
     handleOnStatusCoordinator(agent, snapshot, persisted, transisted, serverID);
-  } else if (serverID.compare(0, 4, "SNGL") == 0) {
+  } else if (serverID.starts_with("SNGL")) {
     handleOnStatusSingle(agent, snapshot, persisted, transisted, serverID,
                          jobId, envelope);
   } else {
@@ -559,7 +557,7 @@ std::vector<check_t> Supervision::check(std::string const& type) {
          ClusterHelpers::isDBServerName(machine.first)) ||
         (type == "Coordinators" &&
          ClusterHelpers::isCoordinatorName(machine.first)) ||
-        (type == "Singles" && machine.first.compare(0, 4, "SNGL") == 0)) {
+        (type == "Singles" && machine.first.starts_with("SNGL"))) {
       // Put only those on list which are no longer planned:
       if (machinesPlanned.find(machine.first) == machinesPlanned.end()) {
         todelete.push_back(machine.first);
@@ -569,7 +567,7 @@ std::vector<check_t> Supervision::check(std::string const& type) {
 
   if (!todelete.empty()) {
     velocypack::Builder builder;
-    removeTransactionBuilder(builder, todelete);
+    buildRemoveTransaction(builder, todelete);
     _agent->write(builder.slice());
   }
 
@@ -786,7 +784,6 @@ std::vector<check_t> Supervision::check(std::string const& type) {
       Builder tReport;
       {
         VPackArrayBuilder transaction(&tReport);  // Transist Transaction
-        std::shared_ptr<VPackBuilder> envelope;
         {
           VPackObjectBuilder operation(&tReport);  // Operation
           tReport.add(
@@ -816,7 +813,7 @@ std::vector<check_t> Supervision::check(std::string const& type) {
                          envelope->slice()[0].isObject());
               for (VPackObjectIterator::ObjectPair i :
                    VPackObjectIterator(envelope->slice()[0])) {
-                pReport.add(i.key.copyString(), i.value);
+                pReport.add(i.key.stringView(), i.value);
               }
             }
           }  // Operation
@@ -883,14 +880,14 @@ bool Supervision::earlyBird() const {
 
   // every db server in plan accounted for in transient store?
   for (auto const& server : VPackObjectIterator(dbservers)) {
-    auto serverId = server.key.copyString();
+    auto serverId = server.key.stringView();
     if (!serverStates.hasKey(serverId)) {
       return false;
     }
   }
   // every db server in plan accounted for in transient store?
   for (auto const& server : VPackObjectIterator(coordinators)) {
-    auto serverId = server.key.copyString();
+    auto serverId = server.key.stringView();
     if (!serverStates.hasKey(serverId)) {
       return false;
     }
@@ -1921,14 +1918,13 @@ void arangodb::consensus::cleanupHotbackupTransferJobsFunctional(
     for (auto const& pp : dbservers->get()) {
       auto const& status = pp.second->hasAsString("Status");
       if (status) {
-        if (status->compare("COMPLETED") != 0 &&
-            status->compare("FAILED") != 0) {
+        if (status.value() != "COMPLETED" && status.value() != "FAILED") {
           // If we get here, we might be looking at an old leftover which
           // appears to be ongoing, or at a new style, properly ongoing
           // We ignore non-completedness of old crud and only consider
           // new jobs with a rebootId as incomplete:
           auto const& rebootId = pp.second->hasAsUInt(StaticStrings::RebootId);
-          if (status.value().compare("NEW") == 0 || rebootId) {
+          if (status.value() == "NEW" || rebootId) {
             completed = false;
           }
         }
@@ -2022,9 +2018,8 @@ void arangodb::consensus::failBrokenHotbackupTransferJobsFunctional(
           // Should not happen, just be cautious
           continue;
         }
-        if (status.value().compare("COMPLETED") == 0 ||
-            status.value().compare("FAILED") == 0 ||
-            status.value().compare("CANCELLED") == 0) {
+        if (status.value() == "COMPLETED" || status.value() == "FAILED" ||
+            status.value() == "CANCELLED") {
           // Nothing to do
           continue;
         }
@@ -2154,8 +2149,7 @@ void Supervision::workJobs() {
   bool doneFailedJob = false;
   while (it != todos.end()) {
     auto const& jobNode = *(it->second);
-    if (jobNode.hasAsString("type").value().compare(0, FAILED.length(),
-                                                    FAILED) == 0) {
+    if (jobNode.hasAsString("type").value().starts_with(FAILED)) {
       if (selectRandom && RandomGenerator::interval(static_cast<uint64_t>(
                               todos.size())) > maximalJobsPerRound) {
         LOG_TOPIC("675fe", TRACE, Logger::SUPERVISION) << "Skipped ToDo Job";
@@ -2186,8 +2180,7 @@ void Supervision::workJobs() {
         continue;
       }
       auto const& jobNode = *todoEnt.second;
-      if (jobNode.hasAsString("type").value().compare(0, FAILED.length(),
-                                                      FAILED) != 0) {
+      if (!jobNode.hasAsString("type").value().starts_with(FAILED)) {
         LOG_TOPIC("aa667", TRACE, Logger::SUPERVISION)
             << "Begin JobContext::run()";
         JobContext(TODO, jobNode.hasAsString("jobId").value(), snapshot(),
@@ -3408,7 +3401,7 @@ Node const& Supervision::snapshot() const {
   return *_snapshot;
 }
 
-void Supervision::removeTransactionBuilder(
+void Supervision::buildRemoveTransaction(
     velocypack::Builder& del, std::vector<std::string> const& todelete) {
   VPackArrayBuilder trxs(&del);
   {
@@ -3474,17 +3467,17 @@ void Supervision::checkUndoLeaderChangeActions() {
   };
 
   auto const checkDeletion = [&](std::string const& shard,
-                                 std::shared_ptr<Node> entry) -> bool {
+                                 Node const& entry) -> bool {
     std::string now(timepointToString(std::chrono::system_clock::now()));
-    auto deadline = entry->hasAsString("removeIfNotStartedBy");
-    auto started = entry->hasAsString("started");
+    auto deadline = entry.hasAsString("removeIfNotStartedBy");
+    auto started = entry.hasAsString("started");
     if (deadline) {
       if (!started && now > deadline.value()) {
         return true;
       }
     }
     if (started) {
-      auto jobId = entry->hasAsString("jobId");
+      auto jobId = entry.hasAsString("jobId");
       if (jobId) {
         auto inTodo = _snapshot->hasAsNode(toDoPrefix + jobId.value());
         auto inPending = _snapshot->hasAsNode(pendingPrefix + jobId.value());
@@ -3497,7 +3490,7 @@ void Supervision::checkUndoLeaderChangeActions() {
         // jobId.
       }
     }
-    auto jobOpt = entry->hasAsNode("moveShard");
+    auto jobOpt = entry.hasAsNode("moveShard");
     if (!jobOpt) {
       return true;
     }
@@ -3558,7 +3551,8 @@ void Supervision::checkUndoLeaderChangeActions() {
       //  - deadline exceeded (and not yet started)
       //  - dependent MoveShard gone (and started)
       //  - fromServer no longer in Plan
-      if (checkDeletion(shard, entry)) {
+      TRI_ASSERT(entry != nullptr);
+      if (checkDeletion(shard, *entry)) {
         // Let's remove the entry:
         trx->add(VPackValue(returnLeadershipPrefix + shard));
         {

--- a/arangod/Agency/Supervision.h
+++ b/arangod/Agency/Supervision.h
@@ -116,12 +116,15 @@ class Supervision : public arangodb::Thread {
    * @param  del       Agency transaction builder
    * @param  todelete  List of servers to be removed
    */
-  static void removeTransactionBuilder(
-      velocypack::Builder& del, std::vector<std::string> const& todelete);
+  static void buildRemoveTransaction(velocypack::Builder& del,
+                                     std::vector<std::string> const& todelete);
 
   static constexpr std::string_view HEALTH_STATUS_GOOD = "GOOD";
   static constexpr std::string_view HEALTH_STATUS_BAD = "BAD";
   static constexpr std::string_view HEALTH_STATUS_FAILED = "FAILED";
+  // should never be stored in the agency. only used internally to return an
+  // unclear health status
+  static constexpr std::string_view HEALTH_STATUS_UNCLEAR = "UNCLEAR";
 
   static std::string agencyPrefix() { return _agencyPrefix; }
 

--- a/tests/Agency/SupervisionTest.cpp
+++ b/tests/Agency/SupervisionTest.cpp
@@ -43,7 +43,7 @@ std::vector<std::string> servers{"XXX-XXX-XXX", "XXX-XXX-XXY"};
 TEST(SupervisionTest, checking_for_the_delete_transaction_0_servers) {
   std::vector<std::string> todelete;
   velocypack::Builder builder;
-  Supervision::removeTransactionBuilder(builder, todelete);
+  Supervision::buildRemoveTransaction(builder, todelete);
   auto slice = builder.slice();
 
   ASSERT_TRUE(slice.isArray());
@@ -57,7 +57,7 @@ TEST(SupervisionTest, checking_for_the_delete_transaction_0_servers) {
 TEST(SupervisionTest, checking_for_the_delete_transaction_1_server) {
   std::vector<std::string> todelete{servers[0]};
   velocypack::Builder builder;
-  Supervision::removeTransactionBuilder(builder, todelete);
+  Supervision::buildRemoveTransaction(builder, todelete);
   auto slice = builder.slice();
 
   ASSERT_TRUE(slice.isArray());
@@ -79,7 +79,7 @@ TEST(SupervisionTest, checking_for_the_delete_transaction_1_server) {
 TEST(SupervisionTest, checking_for_the_delete_transaction_2_servers) {
   std::vector<std::string> todelete = servers;
   velocypack::Builder builder;
-  Supervision::removeTransactionBuilder(builder, todelete);
+  Supervision::buildRemoveTransaction(builder, todelete);
   auto slice = builder.slice();
 
   ASSERT_TRUE(slice.isArray());


### PR DESCRIPTION
### Scope & Purpose

Small code improvements for agency code
- use symbols Supervision::HEALTH_STATUS_XXX instead of strings
  "GOOD", "BAD", "FAILED" to indicate health status
- use std::string_views in more cases, to avoid creation of temporary
  std::strings (e.g. in conjuction with velocypack::Slice::copyString())
- rename Supervision::removeTransactionBuilder() to
  Supervision::buildRemoveTransaction() to better indicate what the
  function does
- avoid a few copies of std::shared_ptrs and std::strings

The PR does not intend to change the observable behavior in any way.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: -
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 