### PR TITLE
[PREGEL] Use struct for pregel constants

### DIFF
--- a/arangod/Pregel/Conductor/Conductor.cpp
+++ b/arangod/Pregel/Conductor/Conductor.cpp
@@ -99,10 +99,7 @@ Conductor::Conductor(PregelConstants const& constants, TRI_vocbase_t& vocbase,
   _feature.metrics()->pregelConductorsNumber->fetch_add(1);
 
   LOG_PREGEL("00f5f", INFO) << fmt::format(
-      "Starting pregel in database {} with parallelism {} and constants {}",
-      vocbase.name(),
-      WorkerConfig::parallelism(_feature, constants.userParameters.slice()),
-      constants);
+      "Starting pregel in database {} with {}", vocbase.name(), constants);
 }
 
 Conductor::~Conductor() {
@@ -752,10 +749,7 @@ void Conductor::toVelocyPack(VPackBuilder& result) const {
     result.add("vertexCount", VPackValue(_totalVerticesCount));
     result.add("edgeCount", VPackValue(_totalEdgesCount));
   }
-  VPackSlice p = _constants.userParameters.slice().get(Utils::parallelismKey);
-  if (!p.isNone()) {
-    result.add("parallelism", p);
-  }
+  result.add("parallelism", VPackValue(_constants.parallelism));
   if (_masterContext) {
     VPackObjectBuilder ob(&result, "masterContext");
     _masterContext->serializeValues(result);

--- a/arangod/Pregel/Conductor/Conductor.cpp
+++ b/arangod/Pregel/Conductor/Conductor.cpp
@@ -79,14 +79,14 @@ using namespace arangodb::basics;
 const char* arangodb::pregel::ExecutionStateNames[9] = {
     "none", "loading", "running", "storing", "done", "canceled", "fatal error"};
 
-Conductor::Conductor(ExecutionSpecifications const& specifications, TRI_vocbase_t& vocbase,
-                     PregelFeature& feature)
+Conductor::Conductor(ExecutionSpecifications const& specifications,
+                     TRI_vocbase_t& vocbase, PregelFeature& feature)
     : _feature(feature),
       _vocbaseGuard(vocbase),
       _specifications(specifications),
-      _algorithm(
-          AlgoRegistry::createAlgorithm(vocbase.server(), specifications.algorithm,
-                                        specifications.userParameters.slice())),
+      _algorithm(AlgoRegistry::createAlgorithm(
+          vocbase.server(), specifications.algorithm,
+          specifications.userParameters.slice())),
       _created(std::chrono::system_clock::now()) {
   if (!_algorithm) {
     THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_BAD_PARAMETER,
@@ -475,17 +475,18 @@ ErrorCode Conductor::_initializeWorkers() {
   for (auto const& [server, vertexShardMap] : vertexMap) {
     auto const& edgeShardMap = edgeMap[server];
 
-    auto createWorker = CreateWorker{
-        .executionNumber = _specifications.executionNumber,
-        .algorithm = _algorithm->name(),
-        .userParameters = _specifications.userParameters,
-        .coordinatorId = coordinatorId,
-        .useMemoryMaps = _specifications.useMemoryMaps,
-        .edgeCollectionRestrictions = _specifications.edgeCollectionRestrictions,
-        .vertexShards = vertexShardMap,
-        .edgeShards = edgeShardMap,
-        .collectionPlanIds = collectionPlanIdMap,
-        .allShards = shardList};
+    auto createWorker =
+        CreateWorker{.executionNumber = _specifications.executionNumber,
+                     .algorithm = _algorithm->name(),
+                     .userParameters = _specifications.userParameters,
+                     .coordinatorId = coordinatorId,
+                     .useMemoryMaps = _specifications.useMemoryMaps,
+                     .edgeCollectionRestrictions =
+                         _specifications.edgeCollectionRestrictions,
+                     .vertexShards = vertexShardMap,
+                     .edgeShards = edgeShardMap,
+                     .collectionPlanIds = collectionPlanIdMap,
+                     .allShards = shardList};
 
     // TODO should be done inside conductor actor (this whole function will be
     // moved into the conductor actor state)

--- a/arangod/Pregel/Conductor/Conductor.h
+++ b/arangod/Pregel/Conductor/Conductor.h
@@ -127,8 +127,7 @@ class Conductor : public std::enable_shared_from_this<Conductor> {
   ConductorStatus _status;
 
   bool _startGlobalStep();
-  ErrorCode _initializeWorkers(std::string const& suffix,
-                               VPackSlice additional);
+  ErrorCode _initializeWorkers();
   ErrorCode _finalizeWorkers();
   ErrorCode _sendToAllDBServers(std::string const& path,
                                 VPackBuilder const& message);

--- a/arangod/Pregel/Conductor/Conductor.h
+++ b/arangod/Pregel/Conductor/Conductor.h
@@ -70,7 +70,7 @@ class Conductor : public std::enable_shared_from_this<Conductor> {
 
   PregelFeature& _feature;
   const DatabaseGuard _vocbaseGuard;
-  PregelConstants _constants;
+  ExecutionSpecifications _specifications;
 
   std::unique_ptr<AggregatorHandler> _aggregators;
   std::unique_ptr<MasterContext> _masterContext;
@@ -118,7 +118,7 @@ class Conductor : public std::enable_shared_from_this<Conductor> {
   void finishedWorkerFinalize(Finished const& data);
 
  public:
-  Conductor(PregelConstants const& constants, TRI_vocbase_t& vocbase,
+  Conductor(ExecutionSpecifications const& specifications, TRI_vocbase_t& vocbase,
             PregelFeature& feature);
 
   ~Conductor();
@@ -130,7 +130,7 @@ class Conductor : public std::enable_shared_from_this<Conductor> {
 
   bool canBeGarbageCollected() const;
 
-  ExecutionNumber executionNumber() const { return _constants.executionNumber; }
+  ExecutionNumber executionNumber() const { return _specifications.executionNumber; }
 
  private:
   void cancelNoLock();

--- a/arangod/Pregel/Conductor/Conductor.h
+++ b/arangod/Pregel/Conductor/Conductor.h
@@ -118,8 +118,8 @@ class Conductor : public std::enable_shared_from_this<Conductor> {
   void finishedWorkerFinalize(Finished const& data);
 
  public:
-  Conductor(ExecutionSpecifications const& specifications, TRI_vocbase_t& vocbase,
-            PregelFeature& feature);
+  Conductor(ExecutionSpecifications const& specifications,
+            TRI_vocbase_t& vocbase, PregelFeature& feature);
 
   ~Conductor();
 
@@ -130,7 +130,9 @@ class Conductor : public std::enable_shared_from_this<Conductor> {
 
   bool canBeGarbageCollected() const;
 
-  ExecutionNumber executionNumber() const { return _specifications.executionNumber; }
+  ExecutionNumber executionNumber() const {
+    return _specifications.executionNumber;
+  }
 
  private:
   void cancelNoLock();

--- a/arangod/Pregel/PregelFeature.cpp
+++ b/arangod/Pregel/PregelFeature.cpp
@@ -345,7 +345,7 @@ ResultT<ExecutionNumber> PregelFeature::startExecution(TRI_vocbase_t& vocbase,
 
   auto en = createExecutionNumber();
 
-  auto pregelConstants = PregelConstants{
+  auto executionSpecifications = ExecutionSpecifications{
       .executionNumber = en,
       .algorithm = options.algorithm,
       .vertexCollections = vertexCollections,
@@ -359,7 +359,7 @@ ResultT<ExecutionNumber> PregelFeature::startExecution(TRI_vocbase_t& vocbase,
       .userParameters = options.userParameters};
 
   // TODO needs to be part of the conductor state
-  auto c = std::make_shared<pregel::Conductor>(pregelConstants, vocbase, *this);
+  auto c = std::make_shared<pregel::Conductor>(executionSpecifications, vocbase, *this);
   addConductor(std::move(c), en);
   TRI_ASSERT(conductor(en));
   conductor(en)->start();

--- a/arangod/Pregel/PregelFeature.cpp
+++ b/arangod/Pregel/PregelFeature.cpp
@@ -359,7 +359,8 @@ ResultT<ExecutionNumber> PregelFeature::startExecution(TRI_vocbase_t& vocbase,
       .userParameters = options.userParameters};
 
   // TODO needs to be part of the conductor state
-  auto c = std::make_shared<pregel::Conductor>(executionSpecifications, vocbase, *this);
+  auto c = std::make_shared<pregel::Conductor>(executionSpecifications, vocbase,
+                                               *this);
   addConductor(std::move(c), en);
   TRI_ASSERT(conductor(en));
   conductor(en)->start();

--- a/arangod/Pregel/PregelFeature.h
+++ b/arangod/Pregel/PregelFeature.h
@@ -114,6 +114,8 @@ class PregelFeature final : public ArangodFeature {
   size_t defaultParallelism() const noexcept;
   size_t minParallelism() const noexcept;
   size_t maxParallelism() const noexcept;
+  size_t parallelism(VPackSlice params) const noexcept;
+
   std::string tempPath() const;
   bool useMemoryMaps() const noexcept;
 

--- a/arangod/Pregel/PregelOptions.h
+++ b/arangod/Pregel/PregelOptions.h
@@ -136,6 +136,7 @@ struct PregelConstants {
   bool useMemoryMaps;
   bool storeResults;
   TTL ttl;
+  size_t parallelism;
   VPackBuilder const& userParameters;
 };
 template<typename Inspector>
@@ -149,6 +150,7 @@ auto inspect(Inspector& f, PregelConstants& x) {
       f.field("maxSuperstep", x.maxSuperstep),
       f.field("useMemoryMaps", x.useMemoryMaps),
       f.field("storeResults", x.storeResults), f.field("ttl", x.ttl),
+      f.field("parallelism", x.parallelism),
       f.field("userParamters", x.userParameters));
 }
 

--- a/arangod/Pregel/PregelOptions.h
+++ b/arangod/Pregel/PregelOptions.h
@@ -114,7 +114,7 @@ auto inspect(Inspector& f, TTL& x) {
   }
 }
 
-struct PregelConstants {
+struct ExecutionSpecifications {
   ExecutionNumber executionNumber;
   std::string const& algorithm;
   std::vector<CollectionID> const& vertexCollections;
@@ -140,7 +140,7 @@ struct PregelConstants {
   VPackBuilder const& userParameters;
 };
 template<typename Inspector>
-auto inspect(Inspector& f, PregelConstants& x) {
+auto inspect(Inspector& f, ExecutionSpecifications& x) {
   return f.object(x).fields(
       f.field("executionNumber", x.executionNumber),
       f.field("algorithm", x.algorithm),
@@ -157,5 +157,5 @@ auto inspect(Inspector& f, PregelConstants& x) {
 }  // namespace arangodb::pregel
 
 template<>
-struct fmt::formatter<arangodb::pregel::PregelConstants>
+struct fmt::formatter<arangodb::pregel::ExecutionSpecifications>
     : arangodb::inspection::inspection_formatter {};

--- a/arangod/Pregel/Worker/WorkerConfig.cpp
+++ b/arangod/Pregel/Worker/WorkerConfig.cpp
@@ -49,8 +49,7 @@ void WorkerConfig::updateConfig(PregelFeature& feature,
   VPackSlice userParams = params.userParameters.slice();
   _globalShardIDs = params.allShards;
 
-  // parallelism
-  _parallelism = WorkerConfig::parallelism(feature, userParams);
+  _parallelism = feature.parallelism(userParams);
 
   // list of all shards, equal on all workers. Used to avoid storing strings of
   // shard names
@@ -86,22 +85,6 @@ void WorkerConfig::updateConfig(PregelFeature& feature,
   }
 
   _edgeCollectionRestrictions = params.edgeCollectionRestrictions;
-}
-
-size_t WorkerConfig::parallelism(PregelFeature& feature, VPackSlice params) {
-  // start off with default parallelism
-  size_t parallelism = feature.defaultParallelism();
-  if (params.isObject()) {
-    // then update parallelism value from user config
-    if (VPackSlice parallel = params.get(Utils::parallelismKey);
-        parallel.isInteger()) {
-      // limit parallelism to configured bounds
-      parallelism =
-          std::clamp(parallel.getNumber<size_t>(), feature.minParallelism(),
-                     feature.maxParallelism());
-    }
-  }
-  return parallelism;
 }
 
 std::vector<ShardID> const& WorkerConfig::edgeCollectionRestrictions(

--- a/arangod/Pregel/Worker/WorkerConfig.h
+++ b/arangod/Pregel/Worker/WorkerConfig.h
@@ -53,9 +53,6 @@ class WorkerConfig {
   explicit WorkerConfig(TRI_vocbase_t* vocbase);
   void updateConfig(PregelFeature& feature, CreateWorker const& updated);
 
-  // get effective parallelism from Pregel feature and params
-  static size_t parallelism(PregelFeature& feature, VPackSlice params);
-
   ExecutionNumber executionNumber() const { return _executionNumber; }
 
   inline uint64_t globalSuperstep() const { return _globalSuperstep; }

--- a/tests/js/common/shell/shell-pregel-multicollection-edgecol.js
+++ b/tests/js/common/shell/shell-pregel-multicollection-edgecol.js
@@ -217,7 +217,7 @@ function multiCollectionTestSuite() {
 
       assertEqual(stats.vertexCount, numComponents * n, stats);
       assertEqual(stats.edgeCount, numComponents * (m + n), stats);
-      assertFalse(stats.hasOwnProperty("parallelism"));
+      assertTrue(stats.hasOwnProperty("parallelism"));
 
       let allUniquePregelResults = new Set();
       for (let j = 0; j < cn; ++j) {


### PR DESCRIPTION
Combines all constant values of a pregel run in one struct to tidy up the conductor. For this, all theses constant value during a pregel run are specified in the feature, just before the conductor is created.

Additionally, I did some small cleanups like
- deleted redundant function input to Conductor::initializeWorkers
- deleted unused method Conductor::ensureUniqueResponse(VPackSlice)
