### PR TITLE
[PREGEL] Make pregel js tests more stable

### DIFF
--- a/js/common/modules/@arangodb/graph/pregel-test-helpers.js
+++ b/js/common/modules/@arangodb/graph/pregel-test-helpers.js
@@ -80,11 +80,11 @@ const uniquePregelResults = function(documentCursor) {
   let myset = new Set();
   while (documentCursor.hasNext()) {
     const doc = documentCursor.next();
-    assertTrue(doc.result != undefined, "Found no pregel result in document " + doc);
+    assertTrue(doc.result !== undefined, "Found no pregel result in document " + doc);
     myset.add(doc.result);
   }
   return myset;
-}
+};
 
 /**
  * Assert that expected and actual are of the same type and that they are equal up to the tolerance epsilon.

--- a/js/common/modules/@arangodb/graph/pregel-test-helpers.js
+++ b/js/common/modules/@arangodb/graph/pregel-test-helpers.js
@@ -76,6 +76,16 @@ const waitUntilRunFinishedSuccessfully = function (pid, maxWaitSeconds = 120, sl
   return status;
 };
 
+const uniquePregelResults = function(documentCursor) {
+  let myset = new Set();
+  while (documentCursor.hasNext()) {
+    const doc = documentCursor.next();
+    assertTrue(doc.result != undefined, "Found no pregel result in document " + doc);
+    myset.add(doc.result);
+  }
+  return myset;
+}
+
 /**
  * Assert that expected and actual are of the same type and that they are equal up to the tolerance epsilon.
  * @param expected the expected value, a number
@@ -1740,3 +1750,4 @@ exports.runFinished = runFinished;
 exports.runCanceled = runCanceled;
 exports.runFinishedSuccessfully = runFinishedSuccessfully;
 exports.waitUntilRunFinishedSuccessfully = waitUntilRunFinishedSuccessfully;
+exports.uniquePregelResults = uniquePregelResults;

--- a/js/common/modules/@arangodb/graph/pregel-test-helpers.js
+++ b/js/common/modules/@arangodb/graph/pregel-test-helpers.js
@@ -62,11 +62,11 @@ const waitUntilRunFinishedSuccessfully = function (pid, maxWaitSeconds = 120, sl
   do {
     internal.sleep(0.2);
     status = pregel.status(pid);
-    if (wakeupsLeft-- == 0) {
+    if (wakeupsLeft-- === 0) {
       assertTrue(false, "timeout in pregel execution");
       return;
     }
-  } while (!runFinished(status))
+  } while (!runFinished(status));
 
   if (runFinishedUnsuccessfully(status)) {
     assertTrue(false, "Pregel run finished unsuccessfully in state " + status.state);

--- a/js/common/modules/@arangodb/graph/pregel-test-helpers.js
+++ b/js/common/modules/@arangodb/graph/pregel-test-helpers.js
@@ -51,6 +51,31 @@ const Graph = graphGeneration.Graph;
 
 const epsilon = 0.00001;
 
+const runFinishedSuccessfully = (stats) => stats.state === "done";
+const runFinishedUnsuccessfully = (stats) => stats.state === "canceled" || stats.state === "fatal error";
+const runFinished = (stats) => runFinishedSuccessfully(stats) || runFinishedUnsuccessfully(stats);
+const runCanceled = (stats) => stats.state === "canceled";
+
+const waitUntilRunFinishedSuccessfully = function (pid, maxWaitSeconds = 120, sleepIntervalSeconds = 0.2) {
+  let wakeupsLeft = maxWaitSeconds / sleepIntervalSeconds;
+  var status;
+  do {
+    internal.sleep(0.2);
+    status = pregel.status(pid);
+    if (wakeupsLeft-- == 0) {
+      assertTrue(false, "timeout in pregel execution");
+      return;
+    }
+  } while (!runFinished(status))
+
+  if (runFinishedUnsuccessfully(status)) {
+    assertTrue(false, "Pregel run finished unsuccessfully in state " + status.state);
+    return;
+  }
+
+  return status;
+};
+
 /**
  * Assert that expected and actual are of the same type and that they are equal up to the tolerance epsilon.
  * @param expected the expected value, a number
@@ -77,34 +102,21 @@ const assertAlmostEquals = function (expected, actual, epsilon, msg, expectedDes
     }
 };
 
-const runPregelInstance = function (algName, graphName, parameters, query, maxWaitTimeSecs = 120) {
-    const pid = pregel.start(algName, graphName, parameters);
-    const sleepIntervalSecs = 0.2;
-    let wakeupsLeft = maxWaitTimeSecs / sleepIntervalSecs;
-    while (pregel.status(pid).state !== "done" && wakeupsLeft > 0) {
-        wakeupsLeft--;
-        internal.sleep(0.2);
-    }
-    const statusState = pregel.status(pid).state;
-    assertEqual(statusState, "done", `Pregel Job did never succeed. Status: ${statusState}`);
-    return db._query(query).toArray();
-};
-
 const dampingFactor = 0.85;
-
 
 const testPageRankOnGraph = function (vertices, edges, seeded = false) {
     db[vColl].save(vertices);
     db[eColl].save(edges);
-    const query = `
-                  FOR v in ${vColl}
-                  RETURN {"_key": v._key, "value": v.pagerank}  
-              `;
     let parameters = {maxGSS: 100, resultField: "pagerank"};
     if (seeded) {
         parameters.sourceField = "input";
     }
-    const result = runPregelInstance("pagerank", graphName, parameters, query);
+    const pid = pregel.start("pagerank", graphName, parameters);
+	  waitUntilRunFinishedSuccessfully(pid);
+    const result = db._query(`
+                  FOR v in ${vColl}
+                  RETURN {"_key": v._key, "value": v.pagerank}  
+                `).toArray();
 
     const graph = new Graph(vertices, edges);
     for (const v of result) {
@@ -130,15 +142,15 @@ const testPageRankOnGraph = function (vertices, edges, seeded = false) {
 const testHITSKleinbergOnGraph = function (vertices, edges) {
     db[vColl].save(vertices);
     db[eColl].save(edges);
-    const query = `
-                  FOR v in ${vColl}
-                  RETURN {"_key": v._key, "value": {hits_hub: v.hits_hub, hits_auth: v.hits_auth}}  
-              `;
     const numberIterations = 50;
 
     let parameters = {resultField: "hits", maxNumIterations: numberIterations};
-    let algName = "hitskleinberg";
-    const result = runPregelInstance(algName, graphName, parameters, query);
+    const pid = pregel.start("hitskleinberg", graphName, parameters);
+    waitUntilRunFinishedSuccessfully(pid);
+    const result = db._query(`
+                  FOR v in ${vColl}
+                  RETURN {"_key": v._key, "value": {hits_hub: v.hits_hub, hits_auth: v.hits_auth}}  
+              `).toArray();
 
     const hits = new HITS();
     const graph = new Graph(vertices, edges);
@@ -177,16 +189,16 @@ const testHITSKleinbergOnGraph = function (vertices, edges) {
 const testHITSKleinbergThresholdOnGraph = function (vertices, edges) {
     db[vColl].save(vertices);
     db[eColl].save(edges);
-    const query = `
-                  FOR v in ${vColl}
-                  RETURN {"_key": v._key, "value": {hits_hub: v.hits_hub, hits_auth: v.hits_auth}}  
-              `;
     const numberIterations = 50;
     const threshold = 200.0; // must be less than 1000.0, the value added in HITSKleinberg in reportFakeDifference()
 
     let parameters = {resultField: "hits", maxNumIterations: numberIterations, threshold: threshold};
-    let algName = "hitskleinberg";
-    const result = runPregelInstance(algName, graphName, parameters, query);
+    const pid = pregel.start("hitskleinberg", graphName, parameters);
+    waitUntilRunFinishedSuccessfully(pid);
+    const result = db._query(`
+                  FOR v in ${vColl}
+                  RETURN {"_key": v._key, "value": {hits_hub: v.hits_hub, hits_auth: v.hits_auth}}  
+                `).toArray();
 
     const hits = new HITS();
     const graph = new Graph(vertices, edges);
@@ -230,13 +242,14 @@ const pregelRunSmallInstanceGetComponents = function (algName, graphName, parame
     assertTrue(parameters.hasOwnProperty("resultField"),
         `Malformed test: the parameter "parameters" of pregelRunSmallInstanceGetComponents 
         must have an attribute "resultField"`);
-    const query = `
+    const pid = pregel.start(algName, graphName, parameters);
+    waitUntilRunFinishedSuccessfully(pid);
+    return db._query(`
         FOR v IN ${vColl}
           COLLECT ${parameters.resultField} = v.result WITH COUNT INTO size
           SORT size DESC
           RETURN {${parameters.resultField}, size}
-      `;
-    return runPregelInstance(algName, graphName, parameters, query);
+        `).toArray();
 };
 
 const makeSetUp = function (smart, smartAttribute, numberOfShards) {
@@ -294,11 +307,12 @@ const testSubgraphs = function (algName, graphName, parameters, expectedSizes) {
     });
     if (parameters.hasOwnProperty("test") && parameters.test) {
         delete parameters.test;
-        const query = `
-        FOR v in ${vColl}
-        RETURN {"vertex": v._key, "result": v.result}
-    `;
-        runPregelInstance(algName, graphName, parameters, query);
+        const pid = pregel.start(algName, graphName, parameters);
+        waitUntilRunFinishedSuccessfully(pid);
+        db._query(`
+          FOR v in ${vColl}
+          RETURN {"vertex": v._key, "result": v.result}
+        `).toArray();
         return;
     }
     const computedComponents = pregelRunSmallInstanceGetComponents(algName, graphName, parameters);
@@ -1035,12 +1049,14 @@ function makeLabelPropagationTestSuite(isSmart, smartAttribute, numberOfShards) 
                 const {vertices, edges} = graphGenerator(verticesEdgesGenerator(vColl, "v")).makeDirectedCycle(length);
                 db[vColl].save(vertices);
                 db[eColl].save(edges);
-                const query = `
+
+                const pid = pregel.start("labelpropagation", graphName, {maxGSS: 100, resultField: "community"});
+                waitUntilRunFinishedSuccessfully(pid);
+                const result = db._query(`
                   FOR v in ${vColl}
                   RETURN {"_key": v._key, "community": v.community}  
-              `;
-                const result = runPregelInstance("labelpropagation", graphName,
-                    {maxGSS: 100, resultField: "community"}, query);
+                `).toArray();
+
                 assertEqual(result.length, length);
                 for (const value of result) {
                     assertEqual(value.community, result[0].community);
@@ -1056,14 +1072,15 @@ function makeLabelPropagationTestSuite(isSmart, smartAttribute, numberOfShards) 
                 db[vColl].save(verticesEdges.vertices);
                 db[eColl].save(verticesEdges.edges);
 
-                const query = `
+                const pid = pregel.start("labelpropagation", graphName, {maxGSS: 100, resultField: "community"});
+                waitUntilRunFinishedSuccessfully(pid);
+                const result = db._query(`
                   FOR v in ${vColl}
                   COLLECT community = v.community WITH COUNT INTO size
                   SORT size DESC
                   RETURN {community, size}
-              `;
-                const result = runPregelInstance("labelpropagation", graphName,
-                    {maxGSS: 100, resultField: "community"}, query);
+                `).toArray();
+
                 assertEqual(result.length, 2);
                 assertEqual(result[0].size, length);
                 assertEqual(result[1].size, length);
@@ -1080,19 +1097,20 @@ function makeLabelPropagationTestSuite(isSmart, smartAttribute, numberOfShards) 
 
                 db[eColl].save(makeEdgeBetweenVertices(vColl, 0, "v0", 0, "v1"));
 
-                const query = `
+                const pid = pregel.start("labelpropagation", graphName, {maxGSS: 100, resultField: "community"});
+                waitUntilRunFinishedSuccessfully(pid);
+                const result = db._query(`
                   FOR v in ${vColl}
                   COLLECT community = v.community WITH COUNT INTO size
                   SORT size DESC
                   RETURN {community, size}
-              `;
+                `).toArray();
+
                 // expected (depending on the "random" distribution of initial ids) that
                 //  - all vertices are in one community:
                 //      if the least initial value of vertices in the component with label v0,
                 //      is less than the least initial value of vertices in the component with label v1,
                 //  - or two communities otherwise.
-                const result = runPregelInstance("labelpropagation", graphName,
-                    {maxGSS: 100, resultField: "community"}, query);
                 assertTrue(result.length === 1 || result.length === 2, `Expected 1 or 2, obtained ${result}`);
                 if (result.length === 1) {
                     assertEqual(result[0].size, 2 * size);
@@ -1480,12 +1498,14 @@ function makeSSSPTestSuite(isSmart, smartAttribute, numberOfShards) {
 
         db[vColl].save(vertices);
         db[eColl].save(edges);
-        const query = `
+        let parameters = {source: `${vColl}/${source}`, resultField: "distance"};
+        const pid = pregel.start("sssp", graphName, parameters);
+        waitUntilRunFinishedSuccessfully(pid);
+        const result = db._query(`
                   FOR v in ${vColl}
                   RETURN {"_key": v._key, "result": v.distance}  
-              `;
-        let parameters = {source: `${vColl}/${source}`, resultField: "distance"};
-        const result = runPregelInstance("sssp", graphName, parameters, query);
+                `).toArray();
+
         const graph = new Graph(vertices, edges);
         // assign to each vertex.value infinity
         // (This is what Pregel, in fact, returns if a vertex is not reachable.
@@ -1712,8 +1732,11 @@ exports.makePagerankTestSuite = makePagerankTestSuite;
 exports.makeSeededPagerankTestSuite = makeSeededPagerankTestSuite;
 exports.makeSSSPTestSuite = makeSSSPTestSuite;
 exports.makeHITSTestSuite = makeHITSTestSuite;
-exports.runPregelInstance = runPregelInstance;
 exports.epsilon = epsilon;
 exports.makeSetUp = makeSetUp;
 exports.makeTearDown = makeTearDown;
 exports.assertAlmostEquals = assertAlmostEquals;
+exports.runFinished = runFinished;
+exports.runCanceled = runCanceled;
+exports.runFinishedSuccessfully = runFinishedSuccessfully;
+exports.waitUntilRunFinishedSuccessfully = waitUntilRunFinishedSuccessfully;

--- a/tests/js/client/load-balancing/load-balancing-pregel-auth-cluster.js
+++ b/tests/js/client/load-balancing/load-balancing-pregel-auth-cluster.js
@@ -35,6 +35,7 @@ const url = require('url');
 const userModule = require("@arangodb/users");
 const _ = require("lodash");
 const getCoordinatorEndpoints = require('@arangodb/test-helper').getCoordinatorEndpoints;
+let pregelTestHelpers = require("@arangodb/graph/pregel-test-helpers");
 
 const servers = getCoordinatorEndpoints();
 

--- a/tests/js/client/load-balancing/load-balancing-pregel-noauth-cluster.js
+++ b/tests/js/client/load-balancing/load-balancing-pregel-noauth-cluster.js
@@ -138,7 +138,6 @@ function PregelSuite () {
 
         assertFalse(result === undefined || result === {});
         assertEqual(result.status, 200);
-        assertTrue(result.body.state === 'loading' || result.body.state === 'running' || result.body.state === 'done');
       });
 
       require('internal').wait(5.0, false);
@@ -176,7 +175,6 @@ function PregelSuite () {
 
       assertFalse(result === undefined || result === {});
       assertEqual(result.status, 200);
-      assertTrue(result.body.state === "loading" || result.body.state === "running");
 
       require('internal').wait(5.0, false);
 
@@ -210,7 +208,6 @@ function PregelSuite () {
 
       assertFalse(result === undefined || result === {});
       assertEqual(result.status, 200);
-      assertTrue(result.body.state === "loading" || result.body.state === "running");
 
       require('internal').wait(5.0, false);
 

--- a/tests/js/common/shell/shell-pregel-basics-example.js
+++ b/tests/js/common/shell/shell-pregel-basics-example.js
@@ -36,6 +36,7 @@ var internal = require("internal");
 var console = require("console");
 var EPS = 0.0001;
 let pregel = require("@arangodb/pregel");
+let pregelTestHelpers = require("@arangodb/graph/pregel-test-helpers");
 
 const graphName = "UnitTest_pregel";
 const vColl = "UnitTest_pregel_v", eColl = "UnitTest_pregel_e";
@@ -43,40 +44,30 @@ const vColl = "UnitTest_pregel_v", eColl = "UnitTest_pregel_e";
 function testAlgo(a, p) {
   let pid = pregel.start(a, graphName, p);
   assertTrue(typeof pid === "string");
-  let i = 10000;
-  do {
-    internal.sleep(0.2);
-    let stats = pregel.status(pid);
-    if (stats.state !== "loading" && stats.state !== "running" && stats.state !== "storing") {
-      assertEqual(stats.vertexCount, 11, stats);
-      assertEqual(stats.edgeCount, 17, stats);
-      let attrs = ["totalRuntime", "startupTime", "computationTime"];
-      if (p.store && stats.hasOwnProperty('storageTime')) {
-        assertEqual("number", typeof stats.storageTime);
-        assertTrue(stats.storageTime >= 0.0, stats);
-      }
-      attrs.forEach((k) => {
-        assertTrue(stats.hasOwnProperty(k), { p, stats });
-        assertEqual("number", typeof stats[k]);
-        assertTrue(stats[k] >= 0.0, stats);
-      });
+  const stats = pregelTestHelpers.waitUntilRunFinishedSuccessfully(pid);
 
-      db[vColl].all().toArray()
-        .forEach(function (d) {
-          if (d[a] && d[a] !== -1) {
-            var diff = Math.abs(d[a] - d.result);
-            if (diff > EPS) {
-              console.log("Error on " + JSON.stringify(d));
-              assertTrue(false);// peng
-            }
-          }
-        });
-      break;
-    }
-  } while (i-- >= 0);
-  if (i === 0) {
-    assertTrue(false, "timeout in pregel execution");
+  assertEqual(stats.vertexCount, 11, stats);
+  assertEqual(stats.edgeCount, 17, stats);
+  let attrs = ["totalRuntime", "startupTime", "computationTime"];
+  if (p.store && stats.hasOwnProperty('storageTime')) {
+    assertEqual("number", typeof stats.storageTime);
+    assertTrue(stats.storageTime >= 0.0, stats);
   }
+  attrs.forEach((k) => {
+    assertTrue(stats.hasOwnProperty(k), { p, stats });
+    assertEqual("number", typeof stats[k]);
+    assertTrue(stats[k] >= 0.0, stats);
+  });
+
+  db[vColl].all().toArray()
+    .forEach(function (d) {
+      if (d[a] && d[a] !== -1) {
+        var diff = Math.abs(d[a] - d.result);
+        if (diff > EPS) {
+          assertTrue(false, "Error on " + JSON.stringify(d));
+        }
+      }
+    });
 }
 
 function basicTestSuite() {
@@ -173,116 +164,84 @@ function basicTestSuite() {
     // test the PREGEL_RESULT AQL function
     test_AQL_pregel_result_contains_pregel_results_when_they_are_not_stored_in_the_database: function () {
       var pid = pregel.start("pagerank", graphName, { threshold: EPS / 10, store: false });
-      var i = 10000;
-      do {
-        internal.sleep(0.2);
-        var stats = pregel.status(pid);
-        if (stats.state !== "loading" && stats.state !== "running" && stats.state !== "storing") {
-          assertEqual(stats.vertexCount, 11, stats);
-          assertEqual(stats.edgeCount, 17, stats);
+      const stats = pregelTestHelpers.waitUntilRunFinishedSuccessfully(pid);
 
-          // pregel results are not written to the database
+      assertEqual(stats.vertexCount, 11, stats);
+      assertEqual(stats.edgeCount, 17, stats);
 
-          let vertices = db._collection(vColl);
-          vertices.all().toArray().forEach(d => assertTrue(!d.result));
+      // pregel results are not written to the database
 
-          // pregel results can be queried with PREGEL_RESULT in AQL
+      let vertices = db._collection(vColl);
+      vertices.all().toArray().forEach(d => assertTrue(!d.result));
 
-          let array = db._query("RETURN PREGEL_RESULT(@id)", { "id": pid }).toArray();
-          assertEqual(array.length, 1);
-          let results = array[0];
-          assertEqual(results.length, 11);
+      // pregel results can be queried with PREGEL_RESULT in AQL
 
-          results.forEach(function (d) {
-            let v = vertices.document(d._key);
-            assertTrue(v !== null);
-            assertTrue(Math.abs(v.pagerank - d.result) < EPS);
-          });
+      let array = db._query("RETURN PREGEL_RESULT(@id)", { "id": pid }).toArray();
+      assertEqual(array.length, 1);
+      let results = array[0];
+      assertEqual(results.length, 11);
 
-          // PREGEL_RESULT(<handle>, true) additionally returns vertex _id for each result
+      results.forEach(function (d) {
+        let v = vertices.document(d._key);
+        assertTrue(v !== null);
+        assertTrue(Math.abs(v.pagerank - d.result) < EPS);
+      });
 
-          array = db._query("RETURN PREGEL_RESULT(@id, true)", { "id": pid }).toArray();
-          assertEqual(array.length, 1);
-          results = array[0];
-          assertEqual(results.length, 11);
+      // PREGEL_RESULT(<handle>, true) additionally returns vertex _id for each result
 
-          results.forEach(function (d) {
-            let v = vertices.document(d._key);
-            assertTrue(v !== null);
-            assertTrue(Math.abs(v.pagerank - d.result) < EPS);
+      array = db._query("RETURN PREGEL_RESULT(@id, true)", { "id": pid }).toArray();
+      assertEqual(array.length, 1);
+      results = array[0];
+      assertEqual(results.length, 11);
 
-            let v2 = db._document(d._id);
-            assertEqual(v, v2);
-          });
+      results.forEach(function (d) {
+        let v = vertices.document(d._key);
+        assertTrue(v !== null);
+        assertTrue(Math.abs(v.pagerank - d.result) < EPS);
 
-          // after cancelling the pregel run, PREGEL_RESULT is empty
+        let v2 = db._document(d._id);
+        assertEqual(v, v2);
+      });
 
-          pregel.cancel(pid);
-          internal.sleep(5.0);
+      // after cancelling the pregel run, PREGEL_RESULT is empty
 
-          array = db._query("RETURN PREGEL_RESULT(@id)", { "id": pid }).toArray();
-          assertEqual(array.length, 1);
-          results = array[0];
-          assertEqual(results.length, 0);
+      pregel.cancel(pid);
+      internal.sleep(5.0);
 
-          break;
-        }
-      } while (i-- >= 0);
-      if (i === 0) {
-        assertTrue(false, "timeout in pregel execution");
-      }
+      array = db._query("RETURN PREGEL_RESULT(@id)", { "id": pid }).toArray();
+      assertEqual(array.length, 1);
+      results = array[0];
+      assertEqual(results.length, 0);
     },
 
     test_AQL_pregel_result_is_empty_after_ttl_expires: function () {
 			// set ttl to one second
       var pid = pregel.start("pagerank", graphName, { threshold: EPS / 10, store: false, ttl: 1 });
-      var i = 10000;
-      do {
-        internal.sleep(0.2);
-        var stats = pregel.status(pid);
-        if (stats.state === "done") {
-          assertEqual(stats.vertexCount, 11, stats);
-          assertEqual(stats.edgeCount, 17, stats);
+      const stats = pregelTestHelpers.waitUntilRunFinishedSuccessfully(pid);
+      assertEqual(stats.vertexCount, 11, stats);
+      assertEqual(stats.edgeCount, 17, stats);
 
-          // garbage collection runs every 20s, therefore we should wait at least that long plus the ttl given
-          internal.sleep(25);
-          let array = db._query("RETURN PREGEL_RESULT(@id)", { "id": pid }).toArray();
-          assertEqual(array.length, 1);
-          let results = array[0];
-          assertEqual(results.length, 0);
-
-          break;
-        }
-      } while (i-- >= 0);
-      if (i === 0) {
-        assertTrue(false, "timeout in pregel execution");
-      }
+      // garbage collection runs every 20s, therefore we should wait at least that long plus the ttl given
+      internal.sleep(25);
+      let array = db._query("RETURN PREGEL_RESULT(@id)", { "id": pid }).toArray();
+      assertEqual(array.length, 1);
+      let results = array[0];
+      assertEqual(results.length, 0);
     },
 
     test_AQL_pregel_result_is_empty_when_pregel_results_are_stored_in_database: function () {
       var pid = pregel.start("pagerank", graphName, { threshold: EPS / 10, store: true });
-      var i = 10000;
-      do {
-        internal.sleep(0.2);
-        var stats = pregel.status(pid);
-        if (stats.state === "done") {
-          assertEqual(stats.vertexCount, 11, stats);
-          assertEqual(stats.edgeCount, 17, stats);
+      const stats = pregelTestHelpers.waitUntilRunFinishedSuccessfully(pid);
+      assertEqual(stats.vertexCount, 11, stats);
+      assertEqual(stats.edgeCount, 17, stats);
 
-          let vertices = db._collection(vColl);
-          vertices.all().toArray().forEach(d => assertTrue(Math.abs(d.pagerank - d.result) < EPS));
+      let vertices = db._collection(vColl);
+      vertices.all().toArray().forEach(d => assertTrue(Math.abs(d.pagerank - d.result) < EPS));
 
-          let array = db._query("RETURN PREGEL_RESULT(@id)", { "id": pid }).toArray();
-          assertEqual(array.length, 1);
-          let results = array[0];
-          assertEqual(results.length, 0);
-
-          break;
-        }
-      } while (i-- >= 0);
-      if (i === 0) {
-        assertTrue(false, "timeout in pregel execution");
-      }
+      let array = db._query("RETURN PREGEL_RESULT(@id)", { "id": pid }).toArray();
+      assertEqual(array.length, 1);
+      let results = array[0];
+      assertEqual(results.length, 0);
     }
   };
 };
@@ -310,24 +269,14 @@ function exampleTestSuite() {
     },
 
     testSocial: function () {
-      var key = pregel.start("effectivecloseness", {
+      var pid = pregel.start("effectivecloseness", {
         vertexCollections: ['female', 'male'], 
         edgeCollections: ['relation'],
       }, { resultField: "closeness" });
-      assertTrue(typeof key === "string");
-      var i = 10000;
-      do {
-        internal.sleep(0.2);
-        var stats = pregel.status(key);
-        if (stats.state !== "loading" && stats.state !== "running" && stats.state !== "storing") {
-          assertEqual(stats.vertexCount, 4, stats);
-          assertEqual(stats.edgeCount, 4, stats);
-          break;
-        }
-      } while (i-- >= 0);
-      if (i === 0) {
-        assertTrue(false, "timeout in pregel execution");
-      }
+      assertTrue(typeof pid === "string");
+      const stats = pregelTestHelpers.waitUntilRunFinishedSuccessfully(pid);
+      assertEqual(stats.vertexCount, 4, stats);
+      assertEqual(stats.edgeCount, 4, stats);
     }
   };
 };

--- a/tests/js/common/shell/shell-pregel-components.js
+++ b/tests/js/common/shell/shell-pregel-components.js
@@ -200,29 +200,20 @@ function componentsTestSuite() {
 
         testWCC: function () {
             var pid = pregel.start("wcc", graphName, {resultField: "result", store: true});
-            var i = 10000;
-            do {
-                internal.sleep(0.2);
-                let stats = pregel.status(pid);
-                if (stats.state !== "loading" && stats.state !== "running" && stats.state !== "storing") {
-                    assertEqual(stats.vertexCount, numComponents * n, stats);
-                    assertEqual(stats.edgeCount, numComponents * (m + n), stats);
+            const stats = pregelTestHelpers.waitUntilRunFinishedSuccessfully(pid);
 
-                    let c = db[vColl].all();
-                    let mySet = new Set();
-                    while (c.hasNext()) {
-                        let doc = c.next();
-                        assertTrue(doc.result !== undefined, doc);
-                        mySet.add(doc.result);
-                    }
-                    assertEqual(mySet.size, numComponents);
+            assertEqual(stats.vertexCount, numComponents * n, stats);
+            assertEqual(stats.edgeCount, numComponents * (m + n), stats);
 
-                    break;
-                }
-            } while (i-- >= 0);
-            if (i === 0) {
-                assertTrue(false, "timeout in WCC execution");
+            let c = db[vColl].all();
+            let mySet = new Set();
+            while (c.hasNext()) {
+                let doc = c.next();
+                assertTrue(doc.result !== undefined, doc);
+                mySet.add(doc.result);
             }
+            assertEqual(mySet.size, numComponents);
+
         },
 
         testWCC2: function () {
@@ -233,20 +224,10 @@ function componentsTestSuite() {
             }
 
             // weakly connected components algorithm
-            var handle = pregel.start('wcc', problematicGraphName, {
+            var pid = pregel.start('wcc', problematicGraphName, {
                 maxGSS: 250, resultField: 'component'
             });
-
-            while (true) {
-                var status = pregel.status(handle);
-                if (status.state !== 'loading' && status.state !== 'running' && status.state !== 'storing') {
-                    console.log(status);
-                    break;
-                } else {
-                    console.log('Waiting for Pregel result...');
-                    internal.sleep(1);
-                }
-            }
+            pregelTestHelpers.waitUntilRunFinishedSuccessfully(pid, 120, 0.2);
 
             const counts = db._query(
                 `FOR vert IN @@v
@@ -311,15 +292,7 @@ function wccRegressionTestSuite() {
             db[eColl].save(edges);
 
             const pid = pregel.start("wcc", graphName, {resultField: "result", store: true});
-            const maxWaitTimeSecs = 120;
-            const sleepIntervalSecs = 0.2;
-            let wakeupsLeft = maxWaitTimeSecs / sleepIntervalSecs;
-            while (pregel.status(pid).state !== "done" && wakeupsLeft > 0) {
-                wakeupsLeft--;
-                internal.sleep(0.2);
-            }
-            const status = pregel.status(pid);
-            assertEqual(status.state, "done", "Pregel Job did never succeed.");
+            pregelTestHelpers.waitUntilRunFinishedSuccessfully(pid);
 
             // Now test the result.
             // We expect two components
@@ -381,15 +354,7 @@ function wccRegressionTestSuite() {
             db[eColl].save(edges);
 
             const pid = pregel.start("wcc", graphName, {resultField: "result", store: true});
-            const maxWaitTimeSecs = 120;
-            const sleepIntervalSecs = 0.2;
-            let wakeupsLeft = maxWaitTimeSecs / sleepIntervalSecs;
-            while (pregel.status(pid).state !== "done" && wakeupsLeft > 0) {
-                wakeupsLeft--;
-                internal.sleep(0.2);
-            }
-            const status = pregel.status(pid);
-            assertEqual(status.state, "done", "Pregel Job did never succeed.");
+            pregelTestHelpers.waitUntilRunFinishedSuccessfully(pid);
 
             // Now test the result.
             // We expect two components

--- a/tests/js/common/shell/shell-pregel-components.js
+++ b/tests/js/common/shell/shell-pregel-components.js
@@ -206,13 +206,8 @@ function componentsTestSuite() {
             assertEqual(stats.edgeCount, numComponents * (m + n), stats);
 
             let c = db[vColl].all();
-            let mySet = new Set();
-            while (c.hasNext()) {
-                let doc = c.next();
-                assertTrue(doc.result !== undefined, doc);
-                mySet.add(doc.result);
-            }
-            assertEqual(mySet.size, numComponents);
+            const uniquePregelResults = pregelTestHelpers.uniquePregelResults(c);
+            assertEqual(uniquePregelResults.size, numComponents);
 
         },
 

--- a/tests/js/common/shell/shell-pregel-multicollection-edgecol.js
+++ b/tests/js/common/shell/shell-pregel-multicollection-edgecol.js
@@ -219,17 +219,14 @@ function multiCollectionTestSuite() {
       assertEqual(stats.edgeCount, numComponents * (m + n), stats);
       assertFalse(stats.hasOwnProperty("parallelism"));
 
-      let mySet = new Set();
+      let allUniquePregelResults = new Set();
       for (let j = 0; j < cn; ++j) {
         let c = db[`${vColl}_${j}`].all();
-        while (c.hasNext()) {
-          let doc = c.next();
-          assertTrue(doc.result !== undefined, doc);
-          mySet.add(doc.result);
-        }
+        const pregelResults = pregelTestHelpers.uniquePregelResults(c);
+        allUniquePregelResults = new Set([...allUniquePregelResults, ...pregelResults]);
       }
 
-      assertEqual(mySet.size, numComponents);
+      assertEqual(allUniquePregelResults.size, numComponents);
 
     },
     
@@ -244,17 +241,13 @@ function multiCollectionTestSuite() {
         assertTrue(stats.hasOwnProperty("parallelism"));
         assertEqual(parallelism, stats.parallelism);
 
-        let mySet = new Set();
+        let allUniquePregelResults = new Set();
         for (let j = 0; j < cn; ++j) {
           let c = db[`${vColl}_${j}`].all();
-          while (c.hasNext()) {
-            let doc = c.next();
-            assertTrue(doc.result !== undefined, doc);
-            mySet.add(doc.result);
-          }
+          const pregelResults = pregelTestHelpers.uniquePregelResults(c);
+          allUniquePregelResults = new Set([...allUniquePregelResults, ...pregelResults]);
         }
-
-        assertEqual(mySet.size, numComponents);
+        assertEqual(allUniquePregelResults.size, numComponents);
       });
     },
     
@@ -269,17 +262,13 @@ function multiCollectionTestSuite() {
         assertTrue(stats.hasOwnProperty("parallelism"), stats);
         assertEqual(parallelism, stats.parallelism, stats);
 
-        let mySet = new Set();
+        let allUniquePregelResults = new Set();
         for (let j = 0; j < cn; ++j) {
           let c = db[`${vColl}_${j}`].all();
-          while (c.hasNext()) {
-            let doc = c.next();
-            assertTrue(doc.result !== undefined, doc);
-            mySet.add(doc.result);
-          }
+          const pregelResults = pregelTestHelpers.uniquePregelResults(c);
+          allUniquePregelResults = new Set([...allUniquePregelResults, ...pregelResults]);
         }
-
-        assertEqual(mySet.size, numComponents);
+        assertEqual(allUniquePregelResults.size, numComponents);
       });
     },
 

--- a/tests/js/common/shell/shell-pregel-random.js
+++ b/tests/js/common/shell/shell-pregel-random.js
@@ -232,6 +232,7 @@ function randomTestSuite() {
 
     test_garbage_collects_all_jobs: function () {
       let allNewRuns = [];
+
       for (let i = 0; i < 5; ++i) {
         let pid = pregel.start("hits", graphName, { threshold: 0.0000001, resultField: "score", store: false, ttl: 5 });
 				allNewRuns.push(pid);

--- a/tests/js/common/shell/shell-pregel-random.js
+++ b/tests/js/common/shell/shell-pregel-random.js
@@ -231,7 +231,7 @@ function randomTestSuite() {
     },
 
     test_garbage_collects_all_jobs: function () {
-			let allNewRuns = [];
+      let allNewRuns = [];
       for (let i = 0; i < 5; ++i) {
         let pid = pregel.start("hits", graphName, { threshold: 0.0000001, resultField: "score", store: false, ttl: 5 });
 				allNewRuns.push(pid);

--- a/tests/js/common/shell/shell-pregel-random.js
+++ b/tests/js/common/shell/shell-pregel-random.js
@@ -239,7 +239,7 @@ function randomTestSuite() {
       // helper function
       const unique = function (value, index, self) {
         return self.indexOf(value) === index;
-      }
+      };
       // wait for garbage collection
       let i = 1000;
       let runningPregelIDs = [];
@@ -253,11 +253,11 @@ function randomTestSuite() {
           assertEqual("_system", mostRecentStatsForPID.database);
           assertEqual("hits", mostRecentStatsForPID.algorithm);
         });
-        if (i-- == 0) {
+        if (i-- === 0) {
           assertTrue(false, "timeout in pregel execution: not everything was garbage collected");
           return;
 				}
-      } while (runningPregelIDs.length > 0)
+      } while (runningPregelIDs.length > 0);
     },
 
   };

--- a/tests/js/common/shell/shell-pregel-random.js
+++ b/tests/js/common/shell/shell-pregel-random.js
@@ -36,6 +36,7 @@ var internal = require("internal");
 var console = require("console");
 var EPS = 0.0001;
 let pregel = require("@arangodb/pregel");
+let pregelTestHelpers = require("@arangodb/graph/pregel-test-helpers");
 
 const graphName = "UnitTest_pregel";
 const vColl = "UnitTest_pregel_v", eColl = "UnitTest_pregel_e";
@@ -46,28 +47,14 @@ function randomTestSuite() {
   const n = 20000; // vertices
   const m = 300000; // edges
   
-  let checkStatus = function(key) {
-    let i = 10000;
-    do {
-      internal.sleep(0.2);
-      let stats = pregel.status(key);
-      if (stats.state !== "loading" && stats.state !== "running" && stats.state !== 'storing') {
-        break;
-      }
-    } while (i-- >= 0);
-    if (i === 0) {
-      assertTrue(false, "timeout in pregel execution");
-    }
-  };
-  
-  let checkCancel = function(key) {
-    checkStatus(key);
-    pregel.cancel(key);
+  let checkCancel = function(pid) {
+    pregelTestHelpers.waitUntilRunFinishedSuccessfully(pid);
+    pregel.cancel(pid);
     let i = 10000;
     do {
       try {
-        let stats = pregel.status(key);
-        if (stats.state === "canceled") {
+        let stats = pregel.status(pid);
+        if (pregelTestHelpers.runCanceled(pid)) {
           break;
         }
       } catch (err) {
@@ -157,19 +144,10 @@ function randomTestSuite() {
 
     testPageRankRandom: function () {
       var pid = pregel.start("pagerank", graphName, { threshold: 0.0000001, resultField: "result", store: true });
-      var i = 10000;
-      do {
-        internal.sleep(0.2);
-        var stats = pregel.status(pid);
-        if (stats.state !== "loading" && stats.state !== "running" && stats.state !== "storing") {
-          assertEqual(stats.vertexCount, n, stats);
-          assertEqual(stats.edgeCount, m * 2, stats);
-          break;
-        }
-      } while (i-- >= 0);
-      if (i === 0) {
-        assertTrue(false, "timeout in pregel execution");
-      }
+      const stats = pregelTestHelpers.waitUntilRunFinishedSuccessfully(pid);
+
+      assertEqual(stats.vertexCount, n, stats);
+      assertEqual(stats.edgeCount, m * 2, stats);
     },
 
     testPageRankRandomMMap: function () {
@@ -178,19 +156,10 @@ function randomTestSuite() {
         store: true, useMemoryMaps: true
       };
       var pid = pregel.start("pagerank", graphName, opts);
-      var i = 10000;
-      do {
-        internal.sleep(0.2);
-        var stats = pregel.status(pid);
-        if (stats.state !== "loading" && stats.state !== "running" && stats.state !== "storing") {
-          assertEqual(stats.vertexCount, n, stats);
-          assertEqual(stats.edgeCount, m * 2, stats);
-          break;
-        }
-      } while (i-- >= 0);
-      if (i === 0) {
-        assertTrue(false, "timeout in pregel execution");
-      }
+      const stats = pregelTestHelpers.waitUntilRunFinishedSuccessfully(pid);
+
+      assertEqual(stats.vertexCount, n, stats);
+      assertEqual(stats.edgeCount, m * 2, stats);
     },
 
     testHITS: function () {
@@ -199,31 +168,22 @@ function randomTestSuite() {
         store: true
       };
       var pid = pregel.start("hits", graphName, opts);
-      var i = 10000;
-      do {
-        internal.sleep(0.2);
-        var stats = pregel.status(pid);
-        if (stats.state !== "loading" && stats.state !== "running" && stats.state !== "storing") {
-          assertEqual(stats.vertexCount, n, stats);
-          assertEqual(stats.edgeCount, m * 2, stats);
-          break;
-        }
-      } while (i-- >= 0);
-      if (i === 0) {
-        assertTrue(false, "timeout in pregel execution");
-      }
+      const stats = pregelTestHelpers.waitUntilRunFinishedSuccessfully(pid);
+
+      assertEqual(stats.vertexCount, n, stats);
+      assertEqual(stats.edgeCount, m * 2, stats);
     },
 
     testStatusWithNumericId: function () {
-      let key = pregel.start("hits", graphName, { threshold: 0.0000001, resultField: "score", store: true });
-      assertTrue(typeof key === "string");
-      checkStatus(Number(key));
+      let pid = pregel.start("hits", graphName, { threshold: 0.0000001, resultField: "score", store: true });
+      assertTrue(typeof pid === "string");
+      pregelTestHelpers.waitUntilRunFinishedSuccessfully(pid);
     },
     
     testStatusWithStringId: function () {
-      let key = pregel.start("hits", graphName, { threshold: 0.0000001, resultField: "score", store: true });
-      assertTrue(typeof key === "string");
-      checkStatus(key);
+      let pid = pregel.start("hits", graphName, { threshold: 0.0000001, resultField: "score", store: true });
+      assertTrue(typeof pid === "string");
+      pregelTestHelpers.waitUntilRunFinishedSuccessfully(pid);
     },
     
     testCancelWithNumericId: function () {
@@ -239,37 +199,29 @@ function randomTestSuite() {
     },
     
     testGarbageCollectionForJob: function () {
-      let key = pregel.start("hits", graphName, { threshold: 0.0000001, resultField: "score", store: false, ttl: 15 });
-      assertTrue(typeof key === "string");
+      let pid = pregel.start("hits", graphName, { threshold: 0.0000001, resultField: "score", store: false, ttl: 15 });
+      assertTrue(typeof pid === "string");
           
-      let stats = pregel.status(key);
+      let stats = pregel.status(pid);
       assertTrue(stats.hasOwnProperty('id'));
-      assertEqual(stats.id, key);
+      assertEqual(stats.id, pid);
       assertEqual("_system", stats.database);
       assertEqual("hits", stats.algorithm);
       assertTrue(stats.hasOwnProperty('created'));
       assertTrue(stats.hasOwnProperty('ttl'));
       assertEqual(15, stats.ttl);
 
-      let i = 1000;
-      do {
-        stats = pregel.status(key);
-        if (stats.state === "done") {
-          break;
-        }
-        internal.sleep(0.2);
-      } while (i-- >= 0);
+      stats = pregelTestHelpers.waitUntilRunFinishedSuccessfully(pid);
       assertEqual("done", stats.state);
       assertTrue(stats.hasOwnProperty('expires'));
       assertTrue(stats.expires > stats.created);
-      assertTrue(i > 0, "timeout in pregel execution");
 
       // wait for garbage collection
-      i = 1000;
+      let i = 1000;
       do {
         try {
           stats = pregel.status(key);
-          assertEqual("done", stats.state);
+          assertEqual(pregelTestHelpers.runFinishedSuccessfully(stats), stats.state);
         } catch (err) {
           // fine.
           break;

--- a/tests/js/common/shell/shell-pregel-start-cluster.js
+++ b/tests/js/common/shell/shell-pregel-start-cluster.js
@@ -145,8 +145,7 @@ function basicTestSuite() {
         if (d[a] && d[a] !== -1) {
           var diff = Math.abs(d[a] - d.result);
           if (diff > EPS) {
-            console.log("Error on " + JSON.stringify(d));
-            assertTrue(false);// peng
+            assertTrue(false, "Error on " + JSON.stringify(d));
           }
         }
       });

--- a/tests/js/common/shell/shell-pregel-start-cluster.js
+++ b/tests/js/common/shell/shell-pregel-start-cluster.js
@@ -34,6 +34,7 @@ var db = require("@arangodb").db;
 var internal = require("internal");
 let pregel = require("@arangodb/pregel");
 var graph_module = require("@arangodb/general-graph");
+let pregelTestHelpers = require("@arangodb/graph/pregel-test-helpers");
 
 var EPS = 0.0001;
 
@@ -61,7 +62,7 @@ function shardKeysTestSuite() {
     tearDown: function () {
 
       if(pid !== 0) {
-        while(pregel.status(pid).state === 'loading' || pregel.status(pid).state === 'running') {
+        while(!pregelTestHelpers.runFinished(pregel.status(pid))) {
           internal.sleep(0.1);
         }
         pregel.cancel(pid); // delete contents
@@ -134,30 +135,21 @@ function basicTestSuite() {
   function testAlgo(a, p) {
     p.shardKeyAttribute = shardKey;
     var pid = pregel.start(a, graphName, p);
-    var i = 10000;
-    do {
-      internal.wait(0.2);
-      var stats = pregel.status(pid);
-      if (stats.state !== "loading" && stats.state !== "running" && stats.state !== "storing") {
-        assertEqual(stats.vertexCount, 11, stats);
-        assertEqual(stats.edgeCount, 17, stats);
+    const stats = pregelTestHelpers.waitUntilRunFinishedSuccessfully(pid);
+
+    assertEqual(stats.vertexCount, 11, stats);
+    assertEqual(stats.edgeCount, 17, stats);
   
-        db[vColl].all().toArray()
-          .forEach(function (d) {
-            if (d[a] && d[a] !== -1) {
-              var diff = Math.abs(d[a] - d.result);
-              if (diff > EPS) {
-                console.log("Error on " + JSON.stringify(d));
-                assertTrue(false);// peng
-              }
-            }
-          });
-        break;
-      }
-    } while (i-- >= 0);
-    if (i === 0) {
-      assertTrue(false, "timeout in pregel execution");
-    }
+    db[vColl].all().toArray()
+      .forEach(function (d) {
+        if (d[a] && d[a] !== -1) {
+          var diff = Math.abs(d[a] - d.result);
+          if (diff > EPS) {
+            console.log("Error on " + JSON.stringify(d));
+            assertTrue(false);// peng
+          }
+        }
+      });
   }
 
   return {
@@ -251,60 +243,50 @@ function basicTestSuite() {
 
     // test the PREGEL_RESULT AQL function
     testPageRankAQLResult: function () {
-      var pid = pregel.start("pagerank", graphName, { shardKeyAttribute: shardKey, threshold: EPS / 10, store: false });
-      var i = 10000;
-      do {
-        internal.wait(0.2);
-        var stats = pregel.status(pid);
-        if (stats.state !== "loading" && stats.state !== "running" && stats.state !== "storing") {
-          assertEqual(stats.vertexCount, 11, stats);
-          assertEqual(stats.edgeCount, 17, stats);
+      const pid = pregel.start("pagerank", graphName, { shardKeyAttribute: shardKey, threshold: EPS / 10, store: false });
+      const stats = pregelTestHelpers.waitUntilRunFinishedSuccessfully(pid);
 
-          let vertices = db._collection(vColl);
-          // no result was written to the default result field
-          vertices.all().toArray().forEach(d => assertTrue(!d.result));
+      assertEqual(stats.vertexCount, 11, stats);
+      assertEqual(stats.edgeCount, 17, stats);
 
-          let array = db._query("RETURN PREGEL_RESULT(@id)", { "id": pid }).toArray();
-          assertEqual(array.length, 1);
-          let results = array[0];
-          assertEqual(results.length, 11);
+      let vertices = db._collection(vColl);
+      // no result was written to the default result field
+      vertices.all().toArray().forEach(d => assertTrue(!d.result));
 
-          // verify results
-          results.forEach(function (d) {
-            let v = vertices.document(d._key);
-            assertTrue(v !== null);
-            assertTrue(Math.abs(v.pagerank - d.result) < EPS);
-          });
+      let array = db._query("RETURN PREGEL_RESULT(@id)", { "id": pid }).toArray();
+      assertEqual(array.length, 1);
+      let results = array[0];
+      assertEqual(results.length, 11);
 
-          array = db._query("RETURN PREGEL_RESULT(@id, true)", { "id": pid }).toArray();
-          assertEqual(array.length, 1);
-          results = array[0];
-          assertEqual(results.length, 11);
+      // verify results
+      results.forEach(function (d) {
+        let v = vertices.document(d._key);
+        assertTrue(v !== null);
+        assertTrue(Math.abs(v.pagerank - d.result) < EPS);
+      });
 
-          // verify results
-          results.forEach(function (d) {
-            let v = vertices.document(d._key);
-            assertTrue(v !== null);
-            assertTrue(Math.abs(v.pagerank - d.result) < EPS);
+      array = db._query("RETURN PREGEL_RESULT(@id, true)", { "id": pid }).toArray();
+      assertEqual(array.length, 1);
+      results = array[0];
+      assertEqual(results.length, 11);
 
-            let v2 = db._document(d._id);
-            assertEqual(v, v2);
-          });
+      // verify results
+      results.forEach(function (d) {
+        let v = vertices.document(d._key);
+        assertTrue(v !== null);
+        assertTrue(Math.abs(v.pagerank - d.result) < EPS);
 
-          pregel.cancel(pid); // delete contents
-          internal.wait(5.0);
+        let v2 = db._document(d._id);
+        assertEqual(v, v2);
+      });
 
-          array = db._query("RETURN PREGEL_RESULT(@id)", { "id": pid }).toArray();
-          assertEqual(array.length, 1);
-          results = array[0];
-          assertEqual(results.length, 0);
+      pregel.cancel(pid); // delete contents
+      internal.wait(5.0);
 
-          break;
-        }
-      } while (i-- >= 0);
-      if (i === 0) {
-        assertTrue(false, "timeout in pregel execution");
-      }
+      array = db._query("RETURN PREGEL_RESULT(@id)", { "id": pid }).toArray();
+      assertEqual(array.length, 1);
+      results = array[0];
+      assertEqual(results.length, 0);
     }
   };
 };


### PR DESCRIPTION
Use a function everywhere where a test waits for pregel to finsh successfully. This makes sure that all tests check against the correct pregel status and give helpful error message if the pregel run did not finish successfully.