### PR TITLE
disable full chaos run on windows for the nightlies until s.b. wants to work on it

### DIFF
--- a/tests/test-definitions.txt
+++ b/tests/test-definitions.txt
@@ -154,7 +154,7 @@ ldapsecondldap !windows single full ldap priority=2000 -- --ldapHost $LDAPHOST -
 
 # Full Cluster Tests
 authentication full cluster priority=500 buckets=3 -- --dumpAgencyOnError true
-chaos full cluster priority=9600 -- --dumpAgencyOnError true --skipNightly false
+chaos !windows full cluster priority=9600 -- --dumpAgencyOnError true --skipNightly false
 client_resilience full cluster priority=500 -- --dumpAgencyOnError true
 resilience_failover_failure full cluster priority=500 -- --dumpAgencyOnError true
 resilience_failover_view full cluster priority=500 -- --dumpAgencyOnError true


### PR DESCRIPTION
### Scope & Purpose
We have these errors atm, and will work on them later:
```

=== chaos ===
* Test "chaos"
    [FAILED]  tests\js\client\chaos\test-module-chaos-load-cluster-nightly.js__no_IntermediateCommits_no_FailurePoints_no_Delays_no_StreamingTransactions_with_Truncate_with_VaryingOverwriteMode

      "testWorkInParallel_no_IntermediateCommits_no_FailurePoints_no_Delays_no_StreamingTransactions_with_Truncate_with_VaryingOverwriteMode" failed: Error: at assertion #28: assertEqual: (600) is not equal to (599)
(Error
    at assertEqual (d:\win05-colo2\oskar\work\ArangoDB\js\common\modules\jsunity\jsunity.js:108:19)
    at checkView (d:\win05-colo2\oskar\work\ArangoDB\tests\js\client\chaos\test-chaos-load-common.inc:136:5)
    at checkViewConsistency (d:\win05-colo2\oskar\work\ArangoDB\tests\js\client\chaos\test-chaos-load-common.inc:140:3)
    at Object.testWorkInParallel (d:\win05-colo2\oskar\work\ArangoDB\tests\js\client\chaos\test-chaos-load-common.inc:510:9)
    at Object.run (d:\win05-colo2\oskar\work\ArangoDB\js\common\modules\jsunity\jsunity.js:552:27)
    at Object.Run [as run] (d:\win05-colo2\oskar\work\ArangoDB\js\common\modules\jsunity.js:299:24)
    at Object.run (d:\win05-colo2\oskar\work\ArangoDB\tests\js\client\chaos\test-chaos-load-common.inc:557:11)
    at tests\js\client\chaos\test-module-chaos-load-cluster-nightly.js:1:265
    at tests\js\client\chaos\test-module-chaos-load-cluster-nightly.js:1:297
    at RunTest (d:\win05-colo2\oskar\work\ArangoDB\js\common\modules\jsunity.js:418:12))
    at Object.run (d:\win05-colo2\oskar\work\ArangoDB\js\common\modules\jsunity\jsunity.js:575:23)
    at Object.Run [as run] (d:\win05-colo2\oskar\work\ArangoDB\js\common\modules\jsunity.js:299:24)
    at Object.run (d:\win05-colo2\oskar\work\ArangoDB\tests\js\client\chaos\test-chaos-load-common.inc:557:11)
    at tests\js\client\chaos\test-module-chaos-load-cluster-nightly.js:1:265
    at tests\js\client\chaos\test-module-chaos-load-cluster-nightly.js:1:297
    at RunTest (d:\win05-colo2\oskar\work\ArangoDB\js\common\modules\jsunity.js:418:12)
    at testFunc (eval at runOneTest (d:\win05-colo2\oskar\work\ArangoDB\js\client\modules\@arangodb\testutils\test-utils.js:501:7), <anonymous>:4:8)
    at chaosRunner.runOneTest (d:\win05-colo2\oskar\work\ArangoDB\js\client\modules\@arangodb\testutils\test-utils.js:515:20)
    at chaosRunner.run (d:\win05-colo2\oskar\work\ArangoDB\js\client\modules\@arangodb\testutils\testrunner.js:523:28)
    at Object.chaos (d:\win05-colo2\oskar\work\ArangoDB\js\client\modules\@arangodb\testsuites\chaos.js:94:48) - test failed

    [FAILED]  tests\js\client\chaos\test-module-chaos-load-cluster-nightly.js__with_IntermediateCommits_no_FailurePoints_no_Delays_no_StreamingTransactions_with_Truncate_with_VaryingOverwriteMode

      "testWorkInParallel_with_IntermediateCommits_no_FailurePoints_no_Delays_no_StreamingTransactions_with_Truncate_with_VaryingOverwriteMode" failed: Error: at assertion #28: assertEqual: (6895) is not equal to (6894)
(Error
    at assertEqual (d:\win05-colo2\oskar\work\ArangoDB\js\common\modules\jsunity\jsunity.js:108:19)
    at checkView (d:\win05-colo2\oskar\work\ArangoDB\tests\js\client\chaos\test-chaos-load-common.inc:136:5)
    at checkViewConsistency (d:\win05-colo2\oskar\work\ArangoDB\tests\js\client\chaos\test-chaos-load-common.inc:140:3)
    at Object.testWorkInParallel (d:\win05-colo2\oskar\work\ArangoDB\tests\js\client\chaos\test-chaos-load-common.inc:510:9)
    at Object.run (d:\win05-colo2\oskar\work\ArangoDB\js\common\modules\jsunity\jsunity.js:552:27)
    at Object.Run [as run] (d:\win05-colo2\oskar\work\ArangoDB\js\common\modules\jsunity.js:299:24)
    at Object.run (d:\win05-colo2\oskar\work\ArangoDB\tests\js\client\chaos\test-chaos-load-common.inc:557:11)
    at tests\js\client\chaos\test-module-chaos-load-cluster-nightly.js:1:265
    at tests\js\client\chaos\test-module-chaos-load-cluster-nightly.js:1:297
    at RunTest (d:\win05-colo2\oskar\work\ArangoDB\js\common\modules\jsunity.js:418:12))
    at Object.run (d:\win05-colo2\oskar\work\ArangoDB\js\common\modules\jsunity\jsunity.js:575:23)
    at Object.Run [as run] (d:\win05-colo2\oskar\work\ArangoDB\js\common\modules\jsunity.js:299:24)
    at Object.run (d:\win05-colo2\oskar\work\ArangoDB\tests\js\client\chaos\test-chaos-load-common.inc:557:11)
    at tests\js\client\chaos\test-module-chaos-load-cluster-nightly.js:1:265
    at tests\js\client\chaos\test-module-chaos-load-cluster-nightly.js:1:297
    at RunTest (d:\win05-colo2\oskar\work\ArangoDB\js\common\modules\jsunity.js:418:12)
    at testFunc (eval at runOneTest (d:\win05-colo2\oskar\work\ArangoDB\js\client\modules\@arangodb\testutils\test-utils.js:501:7), <anonymous>:4:8)
    at chaosRunner.runOneTest (d:\win05-colo2\oskar\work\ArangoDB\js\client\modules\@arangodb\testutils\test-utils.js:515:20)
    at chaosRunner.run (d:\win05-colo2\oskar\work\ArangoDB\js\client\modules\@arangodb\testutils\testrunner.js:523:28)
    at Object.chaos (d:\win05-colo2\oskar\work\ArangoDB\js\client\modules\@arangodb\testsuites\chaos.js:94:48) - test failed

    [FAILED]  tests\js\client\chaos\test-module-chaos-load-cluster.js__with_IntermediateCommits_with_FailurePoints_with_Delays_with_StreamingTransactions_with_Truncate_with_VaryingOverwriteMode

      "test" failed: server unavailable for testing. undefined
```