### PR TITLE
[CINFRA-357] NodeLoadInspector

### DIFF
--- a/arangod/Agency/Node.cpp
+++ b/arangod/Agency/Node.cpp
@@ -1119,14 +1119,14 @@ std::vector<std::string> Node::exists(
 }
 
 std::vector<std::string> Node::exists(std::string const& rel) const {
-  return exists(Store::split(rel));
+  return exists(split(rel));
 }
 
 bool Node::has(std::vector<std::string> const& rel) const {
   return exists(rel).size() == rel.size();
 }
 
-bool Node::has(std::string const& rel) const { return has(Store::split(rel)); }
+bool Node::has(std::string const& rel) const { return has(split(rel)); }
 
 std::optional<int64_t> Node::getInt() const noexcept {
   if (type() == NODE || !slice().isNumber<int64_t>()) {

--- a/arangod/Agency/Node.cpp
+++ b/arangod/Agency/Node.cpp
@@ -70,6 +70,46 @@ Node::Node(std::string const& name, Store* store)
 /// @brief Default dtor
 Node::~Node() = default;
 
+/// @brief Split strings by forward slashes, omitting empty strings,
+/// and ignoring multiple subsequent forward slashes
+std::vector<std::string> Node::split(std::string_view str) {
+  std::vector<std::string> result;
+
+  char const* p = str.data();
+  char const* e = str.data() + str.size();
+
+  // strip leading forward slashes
+  while (p != e && *p == '/') {
+    ++p;
+  }
+
+  // strip trailing forward slashes
+  while (p != e && *(e - 1) == '/') {
+    --e;
+  }
+
+  char const* start = nullptr;
+  while (p != e) {
+    if (*p == '/') {
+      if (start != nullptr) {
+        // had already found something
+        result.emplace_back(start, p - start);
+        start = nullptr;
+      }
+    } else {
+      if (start == nullptr) {
+        start = p;
+      }
+    }
+    ++p;
+  }
+  if (start != nullptr) {
+    result.emplace_back(start, p - start);
+  }
+
+  return result;
+}
+
 /// @brief Get slice to value buffer
 Slice Node::slice() const {
   // Some array
@@ -373,14 +413,14 @@ std::optional<std::reference_wrapper<Node const>> Node::get(
 }
 
 /// @brief lh-value at path
-Node& Node::getOrCreate(std::string const& path) {
-  return getOrCreate(Store::split(path));
+Node& Node::getOrCreate(std::string_view path) {
+  return getOrCreate(split(path));
 }
 
 /// @brief rh-value at path
 std::optional<std::reference_wrapper<Node const>> Node::get(
-    std::string const& path) const {
-  return get(Store::split(path));
+    std::string_view path) const {
+  return get(split(path));
 }
 
 // lh-store
@@ -1130,6 +1170,20 @@ bool Node::isString() const {
   return slice().isString();
 }
 
+bool Node::isArray() const {
+  if (type() == NODE) {
+    return false;
+  }
+  return _isArray;
+}
+
+bool Node::isObject() const {
+  if (type() == NODE) {
+    return true;
+  }
+  return false;
+}
+
 bool Node::isUInt() const {
   if (type() == NODE) {
     return false;
@@ -1251,6 +1305,13 @@ std::optional<std::string> Node::getString() const {
     return std::nullopt;
   }
   return slice().copyString();
+}
+
+std::optional<std::string_view> Node::getStringView() const {
+  if (type() == NODE || !slice().isString()) {
+    return std::nullopt;
+  }
+  return slice().stringView();
 }
 
 std::optional<Slice> Node::getArray() const {

--- a/arangod/Agency/Node.h
+++ b/arangod/Agency/Node.h
@@ -145,6 +145,10 @@ class Node final {
   /// @brief Child nodes
   typedef std::unordered_map<std::string, std::shared_ptr<Node>> Children;
 
+  /// @brief Split strings by forward slashes, omitting empty strings,
+  /// and ignoring multiple subsequent forward slashes
+  static std::vector<std::string> split(std::string_view str);
+
   /// @brief Construct with name
   explicit Node(std::string const& name);
 
@@ -278,6 +282,12 @@ class Node final {
   /// @brief Is string
   bool isString() const;
 
+  /// @brief Is array
+  bool isArray() const;
+
+  /// @brief Is object
+  bool isObject() const;
+
   /**
    * @brief Set expiry for this node
    * @param Time point of expiry
@@ -334,14 +344,17 @@ class Node final {
   //  unit tests updated.
   //
   /// @brief Get node specified by path string
-  Node& getOrCreate(std::string const& path);
+  Node& getOrCreate(std::string_view path);
 
   /// @brief Get node specified by path string
   std::optional<std::reference_wrapper<Node const>> get(
-      std::string const& path) const;
+      std::string_view path) const;
 
   /// @brief Get string value (throws if type NODE or if conversion fails)
   std::optional<std::string> getString() const;
+
+  /// @brief Get string value (throws if type NODE or if conversion fails)
+  std::optional<std::string_view> getStringView() const;
 
   /// @brief Get array value
   std::optional<Slice> getArray() const;

--- a/arangod/Agency/NodeDeserialization.h
+++ b/arangod/Agency/NodeDeserialization.h
@@ -1,0 +1,161 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2022 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Manuel Pöter
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "NodeLoadInspector.h"
+
+namespace arangodb::consensus {
+
+namespace detail {
+
+template<class Inspector, class T>
+[[nodiscard]] inspection::Status deserializeWithStatus(Inspector& inspector,
+                                                       T& result) {
+  return inspector.apply(result);
+}
+
+template<class Inspector, class T>
+void deserialize(Inspector& inspector, T& result) {
+  if (auto res = deserializeWithStatus(inspector, result); !res.ok()) {
+    THROW_ARANGO_EXCEPTION_MESSAGE(
+        TRI_ERROR_DESERIALIZE, std::string{"Error while parsing VelocyPack: "} +
+                                   res.error() + "\nPath: " + res.path());
+  }
+}
+
+template<class Inspector, class T>
+void deserialize(Node const& node, T& result,
+                 inspection::ParseOptions options) {
+  Inspector inspector(&node, options);
+  deserialize(inspector, result);
+}
+
+template<class Inspector, class T, class Context>
+void deserialize(Node const& node, T& result, inspection::ParseOptions options,
+                 Context const& context) {
+  Inspector inspector(&node, options, context);
+  deserialize(inspector, result);
+}
+
+template<class Inspector, class T>
+T deserialize(Node const& node, inspection::ParseOptions options) {
+  T result;
+  detail::deserialize<Inspector, T>(node, result, options);
+  return result;
+}
+
+template<class Inspector, class T, class Context>
+T deserialize(Node const& node, inspection::ParseOptions options,
+              Context const& context) {
+  T result;
+  detail::deserialize<Inspector, T>(node, result, options, context);
+  return result;
+}
+
+template<class Inspector, class T>
+[[nodiscard]] inspection::Status deserializeWithStatus(
+    Node const& node, T& result, inspection::ParseOptions options) {
+  Inspector inspector(&node, options);
+  return deserializeWithStatus(inspector, result);
+}
+
+template<class Inspector, class T, class Context>
+[[nodiscard]] inspection::Status deserializeWithStatus(
+    Node const& node, T& result, inspection::ParseOptions options,
+    Context const& context) {
+  Inspector inspector(&node, options, context);
+  return deserializeWithStatus(inspector, result);
+}
+
+}  // namespace detail
+
+template<class T>
+void deserialize(Node const& node, T& result,
+                 inspection::ParseOptions options = {}) {
+  detail::deserialize<inspection::NodeLoadInspector<>>(node, result, options);
+}
+
+template<class T, class Context>
+void deserialize(Node const& node, T& result, inspection::ParseOptions options,
+                 Context const& context) {
+  detail::deserialize<inspection::NodeLoadInspector<Context>>(node, result,
+                                                              options, context);
+}
+
+template<class T>
+[[nodiscard]] inspection::Status deserializeWithStatus(
+    Node const& node, T& result, inspection::ParseOptions options = {}) {
+  return detail::deserializeWithStatus<inspection::NodeLoadInspector<>>(
+      node, result, options);
+}
+
+template<class T, class Context>
+[[nodiscard]] inspection::Status deserializeWithStatus(
+    Node const& node, T& result, inspection::ParseOptions options,
+    Context const& context) {
+  return detail::deserializeWithStatus<inspection::NodeLoadInspector<Context>>(
+      node, result, options, context);
+}
+
+template<class T>
+void deserializeUnsafe(Node const& node, T& result,
+                       inspection::ParseOptions options = {}) {
+  detail::deserialize<inspection::NodeUnsafeLoadInspector<>>(node, result,
+                                                             options);
+}
+
+template<class T, class Context>
+void deserializeUnsafe(Node const& node, T& result,
+                       inspection::ParseOptions options,
+                       Context const& context) {
+  detail::deserialize<inspection::NodeUnsafeLoadInspector<Context>>(
+      node, result, options, context);
+}
+
+template<class T>
+T deserialize(Node const& node, inspection::ParseOptions options = {}) {
+  return detail::deserialize<inspection::NodeLoadInspector<>, T>(node, options);
+}
+
+template<class T, class Context>
+T deserialize(Node const& node, inspection::ParseOptions options,
+              Context const& context) {
+  return detail::deserialize<inspection::NodeLoadInspector<Context>, T>(
+      node, options, context);
+}
+
+template<class T>
+T deserializeUnsafe(Node const& node, inspection::ParseOptions options = {}) {
+  return detail::deserialize<inspection::NodeUnsafeLoadInspector<>, T>(node,
+                                                                       options);
+}
+
+template<class T, class Context>
+T deserializeUnsafe(Node const& node, inspection::ParseOptions options,
+                    Context const& context) {
+  return detail::deserialize<inspection::NodeUnsafeLoadInspector<Context>, T>(
+      node, options, context);
+}
+
+}  // namespace arangodb::consensus

--- a/arangod/Agency/NodeLoadInspector.h
+++ b/arangod/Agency/NodeLoadInspector.h
@@ -193,7 +193,7 @@ struct NodeLoadInspectorImpl
     assert(_node);
     assert(_node->isObject());
     for (auto& [k, v] : _node->children()) {
-      if (auto res = func(k, v.get()); not res.ok()) {
+      if (auto res = func(k, v.get()); !res.ok()) {
         return res;
       }
     }
@@ -204,7 +204,7 @@ struct NodeLoadInspectorImpl
   Status doProcessList(Func&& func) {
     assert(_node->isArray());
     for (auto&& s : VPackArrayIterator(*_node->getArray())) {
-      if (auto res = func(s); not res.ok()) {
+      if (auto res = func(s); !res.ok()) {
         return res;
       }
     }
@@ -237,7 +237,7 @@ struct NodeLoadInspectorImpl
     }
 
     auto node = _node->get(variant.valueField);
-    if (not node.has_value()) {
+    if (!node.has_value()) {
       return {"Variant value field \"" + std::string(variant.valueField) +
               "\" is missing"};
     }
@@ -247,12 +247,12 @@ struct NodeLoadInspectorImpl
 
   Status loadTypeField(std::string_view fieldName, std::string_view& result) {
     auto v = _node->get(fieldName);
-    if (not v.has_value()) {
+    if (!v.has_value()) {
       return {"Variant type field \"" + std::string(fieldName) +
               "\" is missing"};
     }
     auto val = v->get().getStringView();
-    if (not val.has_value()) {
+    if (!val.has_value()) {
       return {"Variant type field \"" + std::string(fieldName) +
               "\" must be a string"};
     }

--- a/arangod/Agency/NodeLoadInspector.h
+++ b/arangod/Agency/NodeLoadInspector.h
@@ -182,8 +182,11 @@ struct NodeLoadInspectorImpl
   }
 
   auto getTypeTag() const noexcept {
-    assert(_node->type() == consensus::LEAF);
-    return _node->slice().type();
+    if (_node->type() == consensus::LEAF) {
+      return _node->slice().type();
+    } else {
+      return velocypack::ValueType::Object;
+    }
   }
 
   template<class Func>
@@ -293,7 +296,7 @@ struct NodeLoadInspectorImpl
   template<std::size_t Idx, std::size_t End, class T>
   [[nodiscard]] Status processTuple(T& data) {
     auto slice = _node->getArray();
-    assert(slice != nullptr);
+    assert(slice.has_value());
     if constexpr (Idx < End) {
       auto ff = make(slice->operator[](Idx));
       if (auto res = process(ff, std::get<Idx>(data)); !res.ok()) {
@@ -307,7 +310,7 @@ struct NodeLoadInspectorImpl
 
   Status checkArrayLength(std::size_t arrayLength) {
     auto slice = _node->getArray();
-    assert(slice != nullptr);
+    assert(slice.has_value());
     if (slice->length() != arrayLength) {
       return {"Expected array of length " + std::to_string(arrayLength)};
     }

--- a/arangod/Agency/Store.cpp
+++ b/arangod/Agency/Store.cpp
@@ -1097,46 +1097,6 @@ std::string Store::normalize(char const* key, size_t length) {
   return normalized;
 }
 
-/// @brief Split strings by forward slashes, omitting empty strings,
-/// and ignoring multiple subsequent forward slashes
-std::vector<std::string> Store::split(std::string_view str) {
-  std::vector<std::string> result;
-
-  char const* p = str.data();
-  char const* e = str.data() + str.size();
-
-  // strip leading forward slashes
-  while (p != e && *p == '/') {
-    ++p;
-  }
-
-  // strip trailing forward slashes
-  while (p != e && *(e - 1) == '/') {
-    --e;
-  }
-
-  char const* start = nullptr;
-  while (p != e) {
-    if (*p == '/') {
-      if (start != nullptr) {
-        // had already found something
-        result.emplace_back(start, p - start);
-        start = nullptr;
-      }
-    } else {
-      if (start == nullptr) {
-        start = p;
-      }
-    }
-    ++p;
-  }
-  if (start != nullptr) {
-    result.emplace_back(start, p - start);
-  }
-
-  return result;
-}
-
 /**
  * @brief Unguarded pointer to a node path in this store.
  *        Caller must enforce locking.

--- a/arangod/Agency/Store.h
+++ b/arangod/Agency/Store.h
@@ -163,7 +163,9 @@ class Store {
 
   /// @brief Split strings by forward slashes, omitting empty strings,
   /// and ignoring multiple subsequent forward slashes
-  static std::vector<std::string> split(std::string_view str);
+  static std::vector<std::string> split(std::string_view str) {
+    return Node::split(str);
+  }
 
   using AgencyTriggerCallback =
       std::function<void(std::string_view path, VPackSlice trx)>;

--- a/arangod/Agency/Supervision.cpp
+++ b/arangod/Agency/Supervision.cpp
@@ -33,6 +33,7 @@
 #include "Agency/JobContext.h"
 #include "Agency/RemoveFollower.h"
 #include "Agency/Store.h"
+#include "Agency/NodeLoadInspector.h"
 #include "AgencyPaths.h"
 #include "ApplicationFeatures/ApplicationServer.h"
 #include "Basics/ConditionLocker.h"
@@ -2668,8 +2669,15 @@ void Supervision::deleteBrokenIndex(AgentInterface* agent,
 namespace {
 template<typename T>
 auto parseSomethingFromNode(Node const& n) -> T {
-  auto builder = n.toBuilder();
-  return velocypack::deserialize<T>(builder.slice());
+  inspection::NodeUnsafeLoadInspector<> i{&n, {}};
+  T result;
+  if (auto status = i.apply(result); !status.ok()) {
+    THROW_ARANGO_EXCEPTION_MESSAGE(
+        TRI_ERROR_INTERNAL,
+        std::string{"Error while reading from Agency node: "} + status.error() +
+            "\nPath: " + status.path());
+  }
+  return result;
 }
 
 template<typename T>

--- a/arangod/Replication2/ReplicatedState/ReplicatedState.tpp
+++ b/arangod/Replication2/ReplicatedState/ReplicatedState.tpp
@@ -893,7 +893,8 @@ ReplicatedState<S>::~ReplicatedState() {
 template<typename S>
 auto ReplicatedState<S>::buildCore(
     std::optional<velocypack::SharedSlice> const& coreParameter) {
-  if constexpr (std::is_void_v<typename S::CoreParameterType>) {
+  using CoreParameterType = typename S::CoreParameterType;
+  if constexpr (std::is_void_v<CoreParameterType>) {
     return factory->constructCore(gid);
   } else {
     if (!coreParameter.has_value()) {
@@ -903,8 +904,16 @@ auto ReplicatedState<S>::buildCore(
                       "ID {}, created in database {}, for {} state",
                       gid.id, gid.database, S::NAME));
     }
-    auto params = velocypack::deserialize<typename S::CoreParameterType>(
-        coreParameter->slice());
+    auto params = CoreParameterType{};
+    try {
+      params =
+          velocypack::deserialize<CoreParameterType>(coreParameter->slice());
+    } catch (std::exception const& ex) {
+      LOG_CTX("63857", ERR, loggerContext)
+          << "failed to deserialize core parameters for replicated state "
+          << gid << ". " << ex.what() << " json = " << coreParameter->toJson();
+      throw;
+    }
     PersistedStateInfo info;
     info.stateId = gid.id;
     info.specification.type = S::NAME;

--- a/lib/Inspection/Access.h
+++ b/lib/Inspection/Access.h
@@ -188,7 +188,7 @@ struct OptionalAccess {
   template<class Inspector>
   [[nodiscard]] static Status apply(Inspector& f, T& val) {
     if constexpr (Inspector::isLoading) {
-      if (f.slice().isNull()) {
+      if (f.isNull()) {
         val.reset();
         return {};
       } else {
@@ -301,10 +301,9 @@ struct Access<std::monostate> : AccessBase<std::monostate> {
   template<class Inspector>
   static auto apply(Inspector& f, std::monostate&) {
     if constexpr (Inspector::isLoading) {
-      if (!f.slice().isEmptyObject()) {
-        return Status{"Expected empty object"};
-      }
-      return Status{};
+      return f.beginObject()                      //
+             | [&]() { return f.applyFields(); }  //
+             | [&]() { return f.endObject(); };
     } else {
       return f.beginObject()  //
              | [&]() { return f.endObject(); };

--- a/lib/Inspection/InspectorBase.h
+++ b/lib/Inspection/InspectorBase.h
@@ -422,7 +422,7 @@ struct InspectorBase : detail::ContextContainer<Context> {
   };
 
   template<const char ErrorMsg[], class Func, class... Args>
-  static Status checkInvariant(Func&& func, Args&&... args) {
+  static Status doCheckInvariant(Func&& func, Args&&... args) {
     using result_t = std::invoke_result_t<Func, Args...>;
     if constexpr (std::is_same_v<result_t, bool>) {
       if (!std::invoke(std::forward<Func>(func), std::forward<Args>(args)...)) {

--- a/lib/Inspection/LoadInspectorBase.h
+++ b/lib/Inspection/LoadInspectorBase.h
@@ -160,7 +160,7 @@ struct LoadInspectorBase : InspectorBase<Derived, Context> {
     });
 
     auto result = parseFields(fields, std::forward<Args>(args)...);
-    if (result.ok() and not _options.ignoreUnknownFields) {
+    if (result.ok() && !_options.ignoreUnknownFields) {
       for (auto& [k, v] : fields) {
         if (!v.second) {
           return {"Found unexpected attribute '" + std::string(k) + "'"};
@@ -232,7 +232,7 @@ struct LoadInspectorBase : InspectorBase<Derived, Context> {
       std::string_view type;
       ValueType data{};
       auto res = this->self().parseVariantInformation(type, data, variant);
-      if (not res.ok()) {
+      if (!res.ok()) {
         return res;
       }
       auto parser = [this, data](auto& v) {
@@ -419,7 +419,7 @@ struct LoadInspectorBase : InspectorBase<Derived, Context> {
     return this->self().doProcessList([&](auto value) -> Status {
       auto ff = this->self().make(value);
       typename T::value_type val;
-      if (auto res = process(ff, val); not res.ok()) {
+      if (auto res = process(ff, val); !res.ok()) {
         return {std::move(res), std::to_string(idx), Status::ArrayTag{}};
       }
       list.push_back(std::move(val));
@@ -433,7 +433,7 @@ struct LoadInspectorBase : InspectorBase<Derived, Context> {
     std::size_t index = 0;
     return this->self().doProcessList([&](auto value) -> Status {
       auto ff = this->self().make(value);
-      if (auto res = process(ff, data[index]); not res.ok()) {
+      if (auto res = process(ff, data[index]); !res.ok()) {
         return {std::move(res), std::to_string(index), Status::ArrayTag{}};
       }
       ++index;

--- a/lib/Inspection/LoadInspectorBase.h
+++ b/lib/Inspection/LoadInspectorBase.h
@@ -1,0 +1,462 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2022 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Manuel Pöter
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <tuple>
+#include <type_traits>
+#include <variant>
+
+#include "Inspection/InspectorBase.h"
+
+namespace arangodb::inspection {
+
+struct ParseOptions {
+  bool ignoreUnknownFields = false;
+  bool ignoreMissingFields = false;
+};
+
+template<class Derived, class ValueType, class Context>
+struct LoadInspectorBase : InspectorBase<Derived, Context> {
+ protected:
+  using Base = InspectorBase<Derived, Context>;
+
+ public:
+  static constexpr bool isLoading = true;
+
+  explicit LoadInspectorBase(ParseOptions options) requires(!Base::hasContext)
+      : _options(options) {}
+
+  explicit LoadInspectorBase(ParseOptions options, Context const& context)
+      : Base(context), _options(options) {}
+
+  template<class T>
+  [[nodiscard]] Status list(T& list) {
+    auto& f = this->self();
+    return f.beginArray()                           //
+           | [&]() { return f.processList(list); }  //
+           | [&]() { return f.endArray(); };        //
+  }
+
+  template<class T>
+  [[nodiscard]] Status map(T& map) {
+    auto& f = this->self();
+    return f.beginObject()                        //
+           | [&]() { return f.processMap(map); }  //
+           | [&]() { return f.endObject(); };     //
+  }
+
+  template<class T>
+  [[nodiscard]] Status tuple(T& data) {
+    constexpr auto arrayLength = std::tuple_size_v<T>;
+    auto& f = this->self();
+    return f.beginArray()                                                     //
+           | [&]() { return f.checkArrayLength(arrayLength); }                //
+           | [&]() { return f.template processTuple<0, arrayLength>(data); }  //
+           | [&]() { return f.endArray(); };                                  //
+  }
+
+  template<class T, size_t N>
+  [[nodiscard]] Status tuple(T (&data)[N]) {
+    auto& f = this->self();
+    return f.beginArray()                             //
+           | [&]() { return f.checkArrayLength(N); }  //
+           | [&]() { return f.processArray(data); }   //
+           | [&]() { return f.endArray(); };          //
+  }
+
+  ParseOptions options() const noexcept { return _options; }
+
+  template<class U>
+  struct ActualFallbackContainer {
+    explicit ActualFallbackContainer(U&& val) : fallbackValue(std::move(val)) {}
+    template<class T>
+    void apply(T& val) const noexcept {
+      if constexpr (std::is_assignable_v<T, U>) {
+        val = fallbackValue;
+      } else {
+        val = T{fallbackValue};
+      }
+    }
+
+   private:
+    U fallbackValue;
+  };
+
+  struct EmptyFallbackContainer {
+    explicit EmptyFallbackContainer(typename Base::Keep&&) {}
+    template<class T>
+    void apply(T&) const noexcept {}
+  };
+
+  template<class U>
+  using FallbackContainer =
+      std::conditional_t<std::is_same_v<U, typename Base::Keep>,
+                         EmptyFallbackContainer, ActualFallbackContainer<U>>;
+
+  template<class Fn>
+  struct FallbackFactoryContainer {
+    explicit FallbackFactoryContainer(Fn&& fn) : factory(std::move(fn)) {}
+    template<class T>
+    void apply(T& val) const noexcept {
+      if constexpr (std::is_assignable_v<T, std::invoke_result_t<Fn>>) {
+        val = std::invoke(factory);
+      } else {
+        val = T{std::invoke(factory)};
+      }
+    }
+
+   private:
+    Fn factory;
+  };
+
+  template<class Invariant>
+  struct InvariantContainer {
+    explicit InvariantContainer(Invariant&& invariant)
+        : invariantFunc(std::move(invariant)) {}
+    Invariant invariantFunc;
+  };
+
+  template<class Invariant, class T>
+  Status objectInvariant(T& object, Invariant&& func, Status result) {
+    if (result.ok()) {
+      result =
+          Base::template doCheckInvariant<detail::ObjectInvariantFailedError>(
+              std::forward<Invariant>(func), object);
+    }
+    return result;
+  }
+
+  template<class... Args>
+  Status applyFields(Args&&... args) {
+    FieldsMap fields;
+    this->self().doProcessObject([&](std::string_view key, ValueType value) {
+      fields.emplace(key, std::make_pair(value, false));
+      return Status::Success{};
+    });
+
+    auto result = parseFields(fields, std::forward<Args>(args)...);
+    if (result.ok() and not _options.ignoreUnknownFields) {
+      for (auto& [k, v] : fields) {
+        if (!v.second) {
+          return {"Found unexpected attribute '" + std::string(k) + "'"};
+        }
+      }
+    }
+    return result;
+  }
+
+  template<class T, class Arg, class... Args>
+  auto processVariant(T& variant, Arg&& arg, Args&&... args) {
+    if constexpr (Arg::isInlineType) {
+      auto type = this->self().getTypeTag();
+      return this->parseVariant(type, variant, std::forward<Arg>(arg),
+                                std::forward<Args>(args)...);
+    } else {
+      return this->parseNonInlineTypes(variant, std::forward<Arg>(arg),
+                                       std::forward<Args>(args)...);
+    }
+  }
+
+ protected:
+  using FieldsMap =
+      std::unordered_map<std::string_view, std::pair<ValueType, bool>>;
+
+  using EmbeddedParam = FieldsMap;
+
+  auto make(ValueType data) {
+    if constexpr (Base::hasContext) {
+      return Derived(data, _options, this->getContext());
+    } else {
+      return Derived(data, _options);
+    }
+  }
+
+  template<class... Args>
+  Status processEmbeddedFields(EmbeddedParam& fields, Args&&... args) {
+    return parseFields(fields, std::forward<Args>(args)...);
+  }
+
+  template<class TypeTag, class Variant, class Arg, class... Args>
+  Status parseVariant(TypeTag type, Variant& variant, Arg&& arg,
+                      Args&&... args) {
+    if constexpr (Arg::isInlineType) {
+      if (this->self().template shouldTryType<typename Arg::Type>(type)) {
+        typename Arg::Type v;
+        auto res = this->apply(v);
+        if (res.ok()) {
+          variant.value = std::move(v);
+          return res;
+        }
+      }
+
+      if constexpr (sizeof...(Args) == 0) {
+        return {"Could not find matching inline type"};
+      } else {
+        return parseVariant(type, variant, std::forward<Args>(args)...);
+      }
+    } else {
+      return parseNonInlineTypes(variant, std::forward<Arg>(arg),
+                                 std::forward<Args>(args)...);
+    }
+  }
+
+  template<class FieldNameFn, class Variant, class... Args>
+  auto doParseNonInlineTypes(FieldNameFn fieldName, Variant& variant,
+                             Args&&... args) {
+    auto loadVariant = [&]() -> Status {
+      std::string_view type;
+      ValueType data{};
+      auto res = this->self().parseVariantInformation(type, data, variant);
+      if (not res.ok()) {
+        return res;
+      }
+      auto parser = [this, data](auto& v) {
+        auto inspector = make(data);
+        return inspector.apply(v);
+      };
+      return parseType(type, parser, fieldName, variant.value,
+                       std::forward<Args>(args)...);
+    };
+    auto& f = this->self();
+    return f.beginObject()                     //
+           | loadVariant                       //
+           | [&]() { return f.endObject(); };  //
+  }
+
+  template<class... Ts, class... Args>
+  auto parseNonInlineTypes(
+      typename Base::template UnqualifiedVariant<Ts...>& variant,
+      Args&&... args) {
+    auto fieldName = [](auto const& arg) { return arg.tag; };
+    return doParseNonInlineTypes(fieldName, variant,
+                                 std::forward<Args>(args)...);
+  }
+
+  template<class... Ts, class... Args>
+  auto parseNonInlineTypes(
+      typename Base::template QualifiedVariant<Ts...>& variant,
+      Args&&... args) {
+    auto fieldName = [&variant](auto const& arg) { return variant.valueField; };
+    return doParseNonInlineTypes(fieldName, variant,
+                                 std::forward<Args>(args)...);
+  }
+
+  template<class... Ts, class... Args>
+  auto parseNonInlineTypes(
+      typename Base::template EmbeddedVariant<Ts...>& variant, Args&&... args) {
+    auto& f = this->self();
+    std::string_view type;
+    auto loadVariant = [&]() -> Status {
+      auto parser = [this, &variant, &f](auto& v) {
+        return f.applyFields(this->ignoreField(variant.typeField),
+                             this->embedFields(v));
+      };
+      return parseType(type, parser, std::monostate{}, variant.value,
+                       std::forward<Args>(args)...);
+    };
+    return f.beginObject()                                               //
+           | [&]() { return f.loadTypeField(variant.typeField, type); }  //
+           | loadVariant                                                 //
+           | [&]() { return f.endObject(); };                            //
+  }
+
+  Status::Success parseFields(FieldsMap&) { return Status::Success{}; }
+
+  template<class Arg>
+  Status parseFields(FieldsMap& fields, Arg&& arg) {
+    return this->self().parseField(fields, std::forward<Arg>(arg));
+  }
+
+  template<class Arg, class... Args>
+  Status parseFields(FieldsMap& fields, Arg&& arg, Args&&... args) {
+    auto& f = this->self();
+    return f.parseField(fields, std::forward<Arg>(arg)) |
+           [&]() { return f.parseFields(fields, std::forward<Args>(args)...); };
+  }
+
+  [[nodiscard]] Status parseField(
+      FieldsMap& fields,
+      std::unique_ptr<detail::EmbeddedFields<Derived>>&& embeddedFields) {
+    return embeddedFields->apply(this->self(), fields)  //
+           | [&]() { return embeddedFields->checkInvariant(); };
+  }
+
+  [[nodiscard]] Status::Success parseField(FieldsMap& fields,
+                                           typename Base::IgnoreField&& field) {
+    if (auto it = fields.find(field.name); it != fields.end()) {
+      assert(!it->second.second &&
+             "field processed twice during inspection. Make sure field names "
+             "are unique!");
+      it->second.second = true;  // mark the field as processed
+    }
+    return {};
+  }
+
+  template<class T>
+  [[nodiscard]] Status parseField(FieldsMap& fields, T&& field) {
+    auto name = Base::getFieldName(field);
+    bool isPresent = false;
+    auto getFieldData = [&]() -> ValueType {
+      if (auto it = fields.find(name); it != fields.end()) {
+        assert(!it->second.second &&
+               "field processed twice during inspection. Make sure field "
+               "names "
+               "are unique!");
+        isPresent = true;
+        it->second.second = true;  // mark the field as processed
+        return it->second.first;
+      }
+      return {};
+    };
+    auto ff = make(getFieldData());
+    auto& value = Base::getFieldValue(field);
+    auto load = [&]() -> Status {
+      using FallbackField = decltype(Base::getFallbackField(field));
+      if constexpr (!std::is_void_v<FallbackField>) {
+        auto applyFallback = [&](auto& val) {
+          Base::getFallbackField(field).apply(val);
+        };
+        if constexpr (!std::is_void_v<decltype(Base::getTransformer(field))>) {
+          return loadTransformedField(ff, name, isPresent, value,
+                                      std::move(applyFallback),
+                                      Base::getTransformer(field));
+        } else {
+          return loadField(ff, name, isPresent, value,
+                           std::move(applyFallback));
+        }
+      } else {
+        if (!isPresent && _options.ignoreMissingFields) {
+          return {};
+        }
+        if constexpr (!std::is_void_v<decltype(Base::getTransformer(field))>) {
+          return loadTransformedField(ff, name, isPresent, value,
+                                      Base::getTransformer(field));
+        } else {
+          return loadField(ff, name, isPresent, value);
+        }
+      }
+    };
+
+    auto res = load()                                            //
+               | [&]() { return this->checkInvariant(field); };  //
+
+    if (!res.ok()) {
+      return {std::move(res), name, Status::AttributeTag{}};
+    }
+    return res;
+  }
+
+  template<class ParseFn, class FieldNameFn, class... Ts, class Arg,
+           class... Args>
+  Status parseType(std::string_view tag, ParseFn parse, FieldNameFn fieldName,
+                   std::variant<Ts...>& result, Arg&& arg, Args&&... args) {
+    static_assert(!Arg::isInlineType,
+                  "All inline types must be listed at the beginning of the "
+                  "alternatives list");
+    if (arg.tag == tag) {
+      typename Arg::Type v;
+      auto res = parse(v);
+      if (res.ok()) {
+        result = v;
+      } else if constexpr (!std::is_same_v<FieldNameFn, std::monostate>) {
+        return {std::move(res), fieldName(arg), Status::AttributeTag{}};
+      }
+      return res;
+    }
+
+    if constexpr (sizeof...(Args) == 0) {
+      return {"Found invalid type: " + std::string(tag)};
+    } else {
+      return parseType(tag, std::forward<ParseFn>(parse),
+                       std::forward<FieldNameFn>(fieldName), result,
+                       std::forward<Args>(args)...);
+    }
+  }
+
+  template<class T>
+  Status processMap(T& map) {
+    return this->self().doProcessObject(
+        [&](std::string_view key, ValueType value) -> Status {
+          auto ff = this->make(value);
+          typename T::mapped_type val;
+          if (auto res = process(ff, val); !res.ok()) {
+            return {std::move(res), "'" + std::string(key) + "'",
+                    Status::ArrayTag{}};
+          }
+          map.emplace(key, std::move(val));
+          return {};
+        });
+  }
+
+  template<class T>
+  Status processList(T& list) {
+    std::size_t idx = 0;
+    return this->self().doProcessList([&](ValueType value) -> Status {
+      auto ff = make(value);
+      typename T::value_type val;
+      if (auto res = process(ff, val); not res.ok()) {
+        return {std::move(res), std::to_string(idx), Status::ArrayTag{}};
+      }
+      list.push_back(std::move(val));
+      ++idx;
+      return {};
+    });
+  }
+
+  template<class T, size_t N>
+  [[nodiscard]] Status processArray(T (&data)[N]) {
+    std::size_t index = 0;
+    return this->self().doProcessList([&](ValueType value) -> Status {
+      auto ff = make(value);
+      if (auto res = process(ff, data[index]); not res.ok()) {
+        return {std::move(res), std::to_string(index), Status::ArrayTag{}};
+      }
+      ++index;
+      return {};
+    });
+  }
+
+  template<class T, class U>
+  Status checkInvariant(typename Base::template InvariantField<T, U>& field) {
+    return Base::template doCheckInvariant<detail::FieldInvariantFailedError>(
+        field.invariantFunc, Base::getFieldValue(field));
+  }
+
+  template<class T>
+  auto checkInvariant(T& field) {
+    if constexpr (!detail::IsRawField<std::remove_cvref_t<T>>::value) {
+      return checkInvariant(field.inner);
+    } else {
+      return Status::Success{};
+    }
+  }
+
+  ParseOptions _options;
+};
+
+}  // namespace arangodb::inspection

--- a/lib/Inspection/LoadInspectorBase.h
+++ b/lib/Inspection/LoadInspectorBase.h
@@ -416,8 +416,8 @@ struct LoadInspectorBase : InspectorBase<Derived, Context> {
   template<class T>
   Status processList(T& list) {
     std::size_t idx = 0;
-    return this->self().doProcessList([&](ValueType value) -> Status {
-      auto ff = make(value);
+    return this->self().doProcessList([&](auto value) -> Status {
+      auto ff = this->self().make(value);
       typename T::value_type val;
       if (auto res = process(ff, val); not res.ok()) {
         return {std::move(res), std::to_string(idx), Status::ArrayTag{}};
@@ -431,8 +431,8 @@ struct LoadInspectorBase : InspectorBase<Derived, Context> {
   template<class T, size_t N>
   [[nodiscard]] Status processArray(T (&data)[N]) {
     std::size_t index = 0;
-    return this->self().doProcessList([&](ValueType value) -> Status {
-      auto ff = make(value);
+    return this->self().doProcessList([&](auto value) -> Status {
+      auto ff = this->self().make(value);
       if (auto res = process(ff, data[index]); not res.ok()) {
         return {std::move(res), std::to_string(index), Status::ArrayTag{}};
       }

--- a/lib/Inspection/Status.h
+++ b/lib/Inspection/Status.h
@@ -54,6 +54,9 @@ struct Status {
     return _error->path;
   }
 
+  template<class, class, class>
+  friend struct InspectorBase;
+
   struct AttributeTag {};
   struct ArrayTag {};
 

--- a/lib/Inspection/VPackLoadInspector.h
+++ b/lib/Inspection/VPackLoadInspector.h
@@ -215,7 +215,7 @@ struct VPackLoadInspectorImpl
       return {"Missing unqualified variant data"};
     }
     auto [t, v] = *it;
-    assert(type.isString());
+    assert(t.isString());
     type = t.stringView();
     data = v;
     return {};

--- a/lib/Inspection/VPackLoadInspector.h
+++ b/lib/Inspection/VPackLoadInspector.h
@@ -37,29 +37,23 @@
 #include <velocypack/Iterator.h>
 #include <velocypack/Slice.h>
 #include <velocypack/Value.h>
+#include <velocypack/ValueType.h>
 
-#include "Inspection/InspectorBase.h"
+#include "Inspection/LoadInspectorBase.h"
 #include "Inspection/Status.h"
 #include "Inspection/detail/traits.h"
-#include "velocypack/ValueType.h"
 
 namespace arangodb::inspection {
 
-struct ParseOptions {
-  bool ignoreUnknownFields = false;
-  bool ignoreMissingFields = false;
-};
-
 template<bool AllowUnsafeTypes, class Context = NoContext>
 struct VPackLoadInspectorImpl
-    : InspectorBase<VPackLoadInspectorImpl<AllowUnsafeTypes, Context>,
-                    Context> {
+    : LoadInspectorBase<VPackLoadInspectorImpl<AllowUnsafeTypes, Context>,
+                        velocypack::Slice, Context> {
  protected:
-  using Base = InspectorBase<VPackLoadInspectorImpl, Context>;
+  using Base =
+      LoadInspectorBase<VPackLoadInspectorImpl, velocypack::Slice, Context>;
 
  public:
-  static constexpr bool isLoading = true;
-
   explicit VPackLoadInspectorImpl(
       velocypack::Builder& builder,
       ParseOptions options = {}) requires(!Base::hasContext)
@@ -71,11 +65,11 @@ struct VPackLoadInspectorImpl
 
   explicit VPackLoadInspectorImpl(
       velocypack::Slice slice, ParseOptions options) requires(!Base::hasContext)
-      : _slice(slice), _options(options) {}
+      : Base(options), _slice(slice) {}
 
   explicit VPackLoadInspectorImpl(velocypack::Slice slice, ParseOptions options,
                                   Context const& context)
-      : Base(context), _slice(slice), _options(options) {}
+      : Base(options, context), _slice(slice) {}
 
   template<class T, class = std::enable_if_t<std::is_integral_v<T>>>
   [[nodiscard]] Status value(T& v) {
@@ -167,131 +161,7 @@ struct VPackLoadInspectorImpl
 
   [[nodiscard]] Status::Success endArray() { return {}; }
 
-  template<class T>
-  [[nodiscard]] Status list(T& list) {
-    return beginArray()                           //
-           | [&]() { return processList(list); }  //
-           | [&]() { return endArray(); };        //
-  }
-
-  template<class T>
-  [[nodiscard]] Status map(T& map) {
-    return beginObject()                        //
-           | [&]() { return processMap(map); }  //
-           | [&]() { return endObject(); };     //
-  }
-
-  template<class T>
-  [[nodiscard]] Status tuple(T& data) {
-    constexpr auto arrayLength = std::tuple_size_v<T>;
-
-    return beginArray()                                            //
-           | [&]() { return checkArrayLength(arrayLength); }       //
-           | [&]() { return processTuple<0, arrayLength>(data); }  //
-           | [&]() { return endArray(); };                         //
-  }
-
-  template<class T, size_t N>
-  [[nodiscard]] Status tuple(T (&data)[N]) {
-    return beginArray()                             //
-           | [&]() { return checkArrayLength(N); }  //
-           | [&]() { return processArray(data); }   //
-           | [&]() { return endArray(); };          //
-  }
-
   velocypack::Slice slice() noexcept { return _slice; }
-
-  ParseOptions options() const noexcept { return _options; }
-
-  template<class U>
-  struct ActualFallbackContainer {
-    explicit ActualFallbackContainer(U&& val) : fallbackValue(std::move(val)) {}
-    template<class T>
-    void apply(T& val) const noexcept {
-      if constexpr (std::is_assignable_v<T, U>) {
-        val = fallbackValue;
-      } else {
-        val = T{fallbackValue};
-      }
-    }
-
-   private:
-    U fallbackValue;
-  };
-
-  struct EmptyFallbackContainer {
-    explicit EmptyFallbackContainer(typename Base::Keep&&) {}
-    template<class T>
-    void apply(T&) const noexcept {}
-  };
-
-  template<class U>
-  using FallbackContainer =
-      std::conditional_t<std::is_same_v<U, typename Base::Keep>,
-                         EmptyFallbackContainer, ActualFallbackContainer<U>>;
-
-  template<class Fn>
-  struct FallbackFactoryContainer {
-    explicit FallbackFactoryContainer(Fn&& fn) : factory(std::move(fn)) {}
-    template<class T>
-    void apply(T& val) const noexcept {
-      if constexpr (std::is_assignable_v<T, std::invoke_result_t<Fn>>) {
-        val = std::invoke(factory);
-      } else {
-        val = T{std::invoke(factory)};
-      }
-    }
-
-   private:
-    Fn factory;
-  };
-
-  template<class Invariant>
-  struct InvariantContainer {
-    explicit InvariantContainer(Invariant&& invariant)
-        : invariantFunc(std::move(invariant)) {}
-    Invariant invariantFunc;
-  };
-
-  template<class... Args>
-  Status applyFields(Args&&... args) {
-    FieldsMap fields;
-    for (auto [k, v] : VPackObjectIterator(slice())) {
-      fields.emplace(k.stringView(), std::make_pair(v, false));
-    }
-
-    auto result = parseFields(fields, std::forward<Args>(args)...);
-    if (result.ok() && !_options.ignoreUnknownFields) {
-      for (auto& [k, v] : fields) {
-        if (!v.second) {
-          return {"Found unexpected attribute '" + std::string(k) + "'"};
-        }
-      }
-    }
-    return result;
-  }
-
-  template<class T, class Arg, class... Args>
-  auto processVariant(T& variant, Arg&& arg, Args&&... args) {
-    if constexpr (Arg::isInlineType) {
-      auto type = _slice.type();
-      return parseVariant(type, variant, std::forward<Arg>(arg),
-                          std::forward<Args>(args)...);
-    } else {
-      return parseNonInlineTypes(variant, std::forward<Arg>(arg),
-                                 std::forward<Args>(args)...);
-    }
-  }
-
-  template<class Invariant, class T>
-  Status objectInvariant(T& object, Invariant&& func, Status result) {
-    if (result.ok()) {
-      result =
-          Base::template checkInvariant<detail::ObjectInvariantFailedError>(
-              std::forward<Invariant>(func), object);
-    }
-    return result;
-  }
 
  private:
   template<class>
@@ -303,119 +173,66 @@ struct VPackLoadInspectorImpl
   template<class, class>
   friend struct detail::EmbeddedFieldInspector;
 
-  using FieldsMap =
-      std::unordered_map<std::string_view, std::pair<velocypack::Slice, bool>>;
+  template<class, class, class>
+  friend struct LoadInspectorBase;
 
-  using EmbeddedParam = FieldsMap;
+  auto getTypeTag() const noexcept { return _slice.type(); }
 
-  template<class... Args>
-  Status processEmbeddedFields(EmbeddedParam& fields, Args&&... args) {
-    return parseFields(fields, std::forward<Args>(args)...);
-  }
-
-  auto make(velocypack::Slice slice) {
-    if constexpr (Base::hasContext) {
-      return VPackLoadInspectorImpl(slice, _options, this->getContext());
-    } else {
-      return VPackLoadInspectorImpl(slice, _options);
+  template<class Func>
+  auto doProcessObject(Func&& func)
+      -> decltype(func(std::string_view(), velocypack::Slice())) {
+    assert(_slice.isObject());
+    for (auto [k, v] : VPackObjectIterator(slice())) {
+      if (auto res = func(k.stringView(), v); not res.ok()) {
+        return res;
+      }
     }
+    return {};
   }
 
-  template<class T, class Arg, class... Args>
-  Status parseVariant(velocypack::ValueType type, T& variant, Arg&& arg,
-                      Args&&... args) {
-    if constexpr (Arg::isInlineType) {
-      if (shouldTryType<typename Arg::Type>(type)) {
-        typename Arg::Type v;
-        auto res = this->apply(v);
-        if (res.ok()) {
-          variant.value = std::move(v);
-          return res;
-        }
+  template<class Func>
+  Status doProcessList(Func&& func) {
+    assert(_slice.isArray());
+    for (auto&& s : VPackArrayIterator(slice())) {
+      if (auto res = func(s); not res.ok()) {
+        return res;
       }
-
-      if constexpr (sizeof...(Args) == 0) {
-        return {"Could not find matching inline type"};
-      } else {
-        return parseVariant(type, variant, std::forward<Args>(args)...);
-      }
-    } else {
-      return parseNonInlineTypes(variant, std::forward<Arg>(arg),
-                                 std::forward<Args>(args)...);
     }
+    return {};
   }
 
-  template<class... Ts, class... Args>
-  auto parseNonInlineTypes(
-      typename Base::template UnqualifiedVariant<Ts...>& variant,
-      Args&&... args) {
-    auto loadVariant = [&]() -> Status {
-      if (_slice.length() > 1) {
-        return {"Unqualified variant data has too many fields"};
-      }
-      VPackObjectIterator it(_slice);
-      if (!it.valid()) {
-        return {"Missing unqualified variant data"};
-      }
-      auto [type, value] = *it;
-      assert(type.isString());
-      auto parser = [this, value = value](auto& v) {
-        auto inspector = make(value);
-        return inspector.apply(v);
-      };
-      auto fieldName = [](auto const& arg) { return arg.tag; };
-      return parseType(type.stringView(), parser, fieldName, variant.value,
-                       std::forward<Args>(args)...);
-    };
-    return beginObject()                     //
-           | loadVariant                     //
-           | [&]() { return endObject(); };  //
+  template<class... Ts>
+  auto parseVariantInformation(
+      std::string_view& type, velocypack::Slice& data,
+      typename Base::template UnqualifiedVariant<Ts...>& variant) -> Status {
+    if (_slice.length() > 1) {
+      return {"Unqualified variant data has too many fields"};
+    }
+    VPackObjectIterator it(_slice);
+    if (!it.valid()) {
+      return {"Missing unqualified variant data"};
+    }
+    auto [t, v] = *it;
+    assert(type.isString());
+    type = t.stringView();
+    data = v;
+    return {};
   }
 
-  template<class... Ts, class... Args>
-  auto parseNonInlineTypes(
-      typename Base::template QualifiedVariant<Ts...>& variant,
-      Args&&... args) {
-    std::string_view type;
-    auto loadVariant = [&]() -> Status {
-      auto value = slice()[variant.valueField];
-      if (value.isNone()) {
-        return {"Variant value field \"" + std::string(variant.valueField) +
-                "\" is missing"};
-      }
+  template<class... Ts>
+  auto parseVariantInformation(
+      std::string_view& type, velocypack::Slice& data,
+      typename Base::template QualifiedVariant<Ts...>& variant) -> Status {
+    if (auto res = loadTypeField(variant.typeField, type); !res.ok()) {
+      return res;
+    }
 
-      auto parser = [this, value](auto& v) {
-        auto inspector = make(value);
-        return inspector.apply(v);
-      };
-      auto fieldName = [&variant](auto const& arg) {
-        return variant.valueField;
-      };
-      return parseType(type, parser, fieldName, variant.value,
-                       std::forward<Args>(args)...);
-    };
-    return beginObject()                                               //
-           | [&]() { return loadTypeField(variant.typeField, type); }  //
-           | loadVariant                                               //
-           | [&]() { return endObject(); };                            //
-  }
-
-  template<class... Ts, class... Args>
-  auto parseNonInlineTypes(
-      typename Base::template EmbeddedVariant<Ts...>& variant, Args&&... args) {
-    std::string_view type;
-    auto loadVariant = [&]() -> Status {
-      auto parser = [this, &variant](auto& v) {
-        return applyFields(this->ignoreField(variant.typeField),
-                           this->embedFields(v));
-      };
-      return parseType(type, parser, std::monostate{}, variant.value,
-                       std::forward<Args>(args)...);
-    };
-    return beginObject()                                               //
-           | [&]() { return loadTypeField(variant.typeField, type); }  //
-           | loadVariant                                               //
-           | [&]() { return endObject(); };                            //
+    data = slice()[variant.valueField];
+    if (data.isNone()) {
+      return {"Variant value field \"" + std::string(variant.valueField) +
+              "\" is missing"};
+    }
+    return {};
   }
 
   Status loadTypeField(std::string_view fieldName, std::string_view& result) {
@@ -430,116 +247,6 @@ struct VPackLoadInspectorImpl
     }
     result = v.stringView();
     return {};
-  }
-
-  Status::Success parseFields(FieldsMap&) { return Status::Success{}; }
-
-  template<class Arg>
-  Status parseFields(FieldsMap& fields, Arg&& arg) {
-    return parseField(fields, std::forward<Arg>(arg));
-  }
-
-  template<class Arg, class... Args>
-  Status parseFields(FieldsMap& fields, Arg&& arg, Args&&... args) {
-    return parseField(fields, std::forward<Arg>(arg)) |
-           [&]() { return parseFields(fields, std::forward<Args>(args)...); };
-  }
-
-  [[nodiscard]] Status parseField(
-      FieldsMap& fields,
-      std::unique_ptr<detail::EmbeddedFields<VPackLoadInspectorImpl>>&&
-          embeddedFields) {
-    return embeddedFields->apply(*this, fields)  //
-           | [&]() { return embeddedFields->checkInvariant(); };
-  }
-
-  [[nodiscard]] Status::Success parseField(FieldsMap& fields,
-                                           typename Base::IgnoreField&& field) {
-    if (auto it = fields.find(field.name); it != fields.end()) {
-      assert(!it->second.second &&
-             "field processed twice during inspection. Make sure field names "
-             "are unique!");
-      it->second.second = true;  // mark the field as processed
-    }
-    return {};
-  }
-
-  template<class T>
-  [[nodiscard]] Status parseField(FieldsMap& fields, T&& field) {
-    auto name = Base::getFieldName(field);
-    velocypack::Slice slice;
-    bool isPresent = false;
-    if (auto it = fields.find(name); it != fields.end()) {
-      assert(!it->second.second &&
-             "field processed twice during inspection. Make sure field names "
-             "are unique!");
-      isPresent = true;
-      slice = it->second.first;
-      it->second.second = true;  // mark the field as processed
-    }
-    auto ff = make(slice);
-    auto& value = Base::getFieldValue(field);
-    auto load = [&]() -> Status {
-      using FallbackField = decltype(Base::getFallbackField(field));
-      if constexpr (!std::is_void_v<FallbackField>) {
-        auto applyFallback = [&](auto& val) {
-          Base::getFallbackField(field).apply(val);
-        };
-        if constexpr (!std::is_void_v<decltype(Base::getTransformer(field))>) {
-          return loadTransformedField(ff, name, isPresent, value,
-                                      std::move(applyFallback),
-                                      Base::getTransformer(field));
-        } else {
-          return loadField(ff, name, isPresent, value,
-                           std::move(applyFallback));
-        }
-      } else {
-        if (!isPresent && _options.ignoreMissingFields) {
-          return {};
-        }
-        if constexpr (!std::is_void_v<decltype(Base::getTransformer(field))>) {
-          return loadTransformedField(ff, name, isPresent, value,
-                                      Base::getTransformer(field));
-        } else {
-          return loadField(ff, name, isPresent, value);
-        }
-      }
-    };
-
-    auto res = load()                                      //
-               | [&]() { return checkInvariant(field); };  //
-
-    if (!res.ok()) {
-      return {std::move(res), name, Status::AttributeTag{}};
-    }
-    return res;
-  }
-
-  template<class ParseFn, class FieldNameFn, class... Ts, class Arg,
-           class... Args>
-  Status parseType(std::string_view tag, ParseFn parse, FieldNameFn fieldName,
-                   std::variant<Ts...>& result, Arg&& arg, Args&&... args) {
-    static_assert(!Arg::isInlineType,
-                  "All inline types must be listed at the beginning of the "
-                  "alternatives list");
-    if (arg.tag == tag) {
-      typename Arg::Type v;
-      auto res = parse(v);
-      if (res.ok()) {
-        result = v;
-      } else if constexpr (!std::is_same_v<FieldNameFn, std::monostate>) {
-        return {std::move(res), fieldName(arg), Status::AttributeTag{}};
-      }
-      return res;
-    }
-
-    if constexpr (sizeof...(Args) == 0) {
-      return {"Found invalid type: " + std::string(tag)};
-    } else {
-      return parseType(tag, std::forward<ParseFn>(parse),
-                       std::forward<FieldNameFn>(fieldName), result,
-                       std::forward<Args>(args)...);
-    }
   }
 
   template<class T>
@@ -572,54 +279,10 @@ struct VPackLoadInspectorImpl
     return true;
   }
 
-  template<class T>
-  Status processList(T& list) {
-    std::size_t idx = 0;
-    for (auto&& s : VPackArrayIterator(_slice)) {
-      auto ff = make(s);
-      typename T::value_type val;
-      if (auto res = process(ff, val); !res.ok()) {
-        return {std::move(res), std::to_string(idx), Status::ArrayTag{}};
-      }
-      list.push_back(std::move(val));
-      ++idx;
-    }
-    return {};
-  }
-
-  template<class T>
-  Status processMap(T& map) {
-    for (auto&& pair : VPackObjectIterator(_slice)) {
-      auto ff = make(pair.value);
-      typename T::mapped_type val;
-      if (auto res = process(ff, val); !res.ok()) {
-        return {std::move(res), "'" + pair.key.copyString() + "'",
-                Status::ArrayTag{}};
-      }
-      map.emplace(pair.key.copyString(), std::move(val));
-    }
-    return {};
-  }
-
-  template<class T, class U>
-  Status checkInvariant(typename Base::template InvariantField<T, U>& field) {
-    return Base::template checkInvariant<detail::FieldInvariantFailedError>(
-        field.invariantFunc, Base::getFieldValue(field));
-  }
-
-  template<class T>
-  auto checkInvariant(T& field) {
-    if constexpr (!detail::IsRawField<std::remove_cvref_t<T>>::value) {
-      return checkInvariant(field.inner);
-    } else {
-      return Status::Success{};
-    }
-  }
-
   template<std::size_t Idx, std::size_t End, class T>
   [[nodiscard]] Status processTuple(T& data) {
     if constexpr (Idx < End) {
-      auto ff = make(_slice[Idx]);
+      auto ff = this->make(_slice[Idx]);
       if (auto res = process(ff, std::get<Idx>(data)); !res.ok()) {
         return {std::move(res), std::to_string(Idx), Status::ArrayTag{}};
       }
@@ -629,20 +292,8 @@ struct VPackLoadInspectorImpl
     }
   }
 
-  template<class T, size_t N>
-  [[nodiscard]] Status processArray(T (&data)[N]) {
-    std::size_t index = 0;
-    for (auto&& v : VPackArrayIterator(_slice)) {
-      auto ff = make(v);
-      if (auto res = process(ff, data[index]); !res.ok()) {
-        return {std::move(res), std::to_string(index), Status::ArrayTag{}};
-      }
-      ++index;
-    }
-    return {};
-  }
-
   Status checkArrayLength(std::size_t arrayLength) {
+    assert(_slice.isArray());
     if (_slice.length() != arrayLength) {
       return {"Expected array of length " + std::to_string(arrayLength)};
     }
@@ -650,7 +301,6 @@ struct VPackLoadInspectorImpl
   }
 
   velocypack::Slice _slice;
-  ParseOptions _options;
 };
 
 template<class Context = NoContext>

--- a/lib/Inspection/ValidateInspector.h
+++ b/lib/Inspection/ValidateInspector.h
@@ -117,7 +117,7 @@ struct ValidateInspector : InspectorBase<ValidateInspector<Context>, Context> {
   Status objectInvariant(T& object, Invariant&& func, Status result) {
     if (result.ok()) {
       result =
-          Base::template checkInvariant<detail::ObjectInvariantFailedError>(
+          Base::template doCheckInvariant<detail::ObjectInvariantFailedError>(
               std::forward<Invariant>(func), object);
     }
     return result;
@@ -177,7 +177,7 @@ struct ValidateInspector : InspectorBase<ValidateInspector<Context>, Context> {
 
   template<class T, class U>
   Status checkInvariant(typename Base::template InvariantField<T, U>& field) {
-    return Base::template checkInvariant<detail::FieldInvariantFailedError>(
+    return Base::template doCheckInvariant<detail::FieldInvariantFailedError>(
         field.invariantFunc, Base::getFieldValue(field));
   }
 

--- a/lib/Inspection/detail/Fields.h
+++ b/lib/Inspection/detail/Fields.h
@@ -288,7 +288,7 @@ struct EmbeddedFieldsWithObjectInvariant : EmbeddedFields<Inspector> {
   }
 
   Status checkInvariant() override {
-    return Inspector::Base::template checkInvariant<
+    return Inspector::Base::template doCheckInvariant<
         detail::ObjectInvariantFailedError>(std::forward<Invariant>(invariant),
                                             object);
   }

--- a/tests/Basics/Inspection/NodeLoadTest.cpp
+++ b/tests/Basics/Inspection/NodeLoadTest.cpp
@@ -1,0 +1,1337 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2022 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Manuel Pöter
+////////////////////////////////////////////////////////////////////////////////
+
+#include <gtest/gtest.h>
+
+#include <velocypack/Builder.h>
+#include <velocypack/Value.h>
+#include <memory>
+
+#include "Agency/NodeDeserialization.h"
+#include "Agency/NodeLoadInspector.h"
+
+#include "InspectionTestHelper.h"
+
+namespace {
+using namespace arangodb;
+using NodeLoadInspector = inspection::NodeLoadInspector<>;
+
+struct NodeLoadInspectorTest : public ::testing::Test {};
+
+template<class T>
+void assign(consensus::Node& node, T value) {
+  velocypack::Builder builder;
+  builder.add(VPackValue(value));
+  node = builder.slice();
+}
+
+consensus::Node& addChild(consensus::Node& node, std::string name) {
+  auto result = std::make_shared<consensus::Node>(name);
+  node.addChild(name, result);
+  return *result;
+}
+
+TEST_F(NodeLoadInspectorTest, load_empty_object) {
+  consensus::Node node{""};
+  NodeLoadInspector inspector{&node};
+
+  auto d = AnEmptyObject{};
+  auto result = inspector.apply(d);
+  ASSERT_TRUE(result.ok());
+}
+
+TEST_F(NodeLoadInspectorTest, load_int) {
+  consensus::Node node{""};
+  assign(node, 42);
+  NodeLoadInspector inspector{&node};
+
+  int x = 0;
+  auto result = inspector.apply(x);
+  EXPECT_TRUE(result.ok());
+  EXPECT_EQ(42, x);
+}
+
+TEST_F(NodeLoadInspectorTest, load_double) {
+  consensus::Node node{""};
+  assign(node, 123.456);
+  NodeLoadInspector inspector{&node};
+
+  double x = 0;
+  auto result = inspector.apply(x);
+  EXPECT_TRUE(result.ok());
+  EXPECT_EQ(123.456, x);
+}
+
+TEST_F(NodeLoadInspectorTest, load_bool) {
+  consensus::Node node{""};
+  assign(node, true);
+  NodeLoadInspector inspector{&node};
+
+  bool x = false;
+  auto result = inspector.apply(x);
+  EXPECT_TRUE(result.ok());
+  EXPECT_EQ(true, x);
+}
+
+TEST_F(NodeLoadInspectorTest, load_string) {
+  consensus::Node node{""};
+  assign(node, "foobar");
+  NodeLoadInspector inspector{&node};
+
+  std::string x;
+  auto result = inspector.apply(x);
+  EXPECT_TRUE(result.ok());
+  EXPECT_EQ("foobar", x);
+}
+
+TEST_F(NodeLoadInspectorTest, load_object) {
+  consensus::Node node{""};
+  assign(addChild(node, "i"), 42);
+  assign(addChild(node, "d"), 123.456);
+  assign(addChild(node, "b"), true);
+  assign(addChild(node, "s"), "foobar");
+  NodeLoadInspector inspector{&node};
+
+  Dummy d;
+  auto result = inspector.apply(d);
+  ASSERT_TRUE(result.ok());
+  EXPECT_EQ(42, d.i);
+  EXPECT_EQ(123.456, d.d);
+  EXPECT_EQ(true, d.b);
+  EXPECT_EQ("foobar", d.s);
+}
+
+TEST_F(NodeLoadInspectorTest, load_nested_object) {
+  consensus::Node parent{""};
+  auto& node = addChild(parent, "dummy");
+  assign(addChild(node, "i"), 42);
+  assign(addChild(node, "d"), 123.456);
+  assign(addChild(node, "b"), true);
+  assign(addChild(node, "s"), "foobar");
+  NodeLoadInspector inspector{&parent};
+
+  Nested n;
+  auto result = inspector.apply(n);
+  ASSERT_TRUE(result.ok());
+  EXPECT_EQ(42, n.dummy.i);
+  EXPECT_EQ(123.456, n.dummy.d);
+  EXPECT_EQ(true, n.dummy.b);
+  EXPECT_EQ("foobar", n.dummy.s);
+}
+
+TEST_F(NodeLoadInspectorTest, load_nested_object_without_nesting) {
+  consensus::Node node{""};
+  assign(addChild(node, "i"), 42);
+  NodeLoadInspector inspector{&node};
+
+  Container c;
+  auto result = inspector.apply(c);
+  ASSERT_TRUE(result.ok());
+  EXPECT_EQ(42, c.i.value);
+}
+
+TEST_F(NodeLoadInspectorTest, load_list) {
+  consensus::Node node{""};
+  {
+    velocypack::Builder builder;
+    builder.openArray();
+    builder.openObject();
+    builder.add("i", VPackValue(1));
+    builder.close();
+    builder.openObject();
+    builder.add("i", VPackValue(2));
+    builder.close();
+    builder.openObject();
+    builder.add("i", VPackValue(3));
+    builder.close();
+    builder.close();
+    addChild(node, "vec") = builder.slice();
+  }
+  {
+    velocypack::Builder builder;
+    builder.openArray();
+    builder.add(VPackValue(4));
+    builder.add(VPackValue(5));
+    builder.close();
+    addChild(node, "list") = builder.slice();
+  }
+  NodeLoadInspector inspector{&node};
+
+  List l;
+  auto result = inspector.apply(l);
+  ASSERT_TRUE(result.ok());
+
+  EXPECT_EQ(3u, l.vec.size());
+  EXPECT_EQ(1, l.vec[0].i.value);
+  EXPECT_EQ(2, l.vec[1].i.value);
+  EXPECT_EQ(3, l.vec[2].i.value);
+  EXPECT_EQ((std::list<int>{4, 5}), l.list);
+}
+
+TEST_F(NodeLoadInspectorTest, load_map) {
+  consensus::Node parent{""};
+  {
+    auto& node = addChild(parent, "map");
+    assign(addChild(addChild(node, "1"), "i"), 1);
+    assign(addChild(addChild(node, "2"), "i"), 2);
+    assign(addChild(addChild(node, "3"), "i"), 3);
+  }
+
+  {
+    auto& node = addChild(parent, "unordered");
+    assign(addChild(node, "4"), 4);
+    assign(addChild(node, "5"), 5);
+  }
+  NodeLoadInspector inspector{&parent};
+
+  Map m;
+  auto result = inspector.apply(m);
+  ASSERT_TRUE(result.ok());
+
+  EXPECT_EQ(
+      (std::map<std::string, Container>{{"1", {1}}, {"2", {2}}, {"3", {3}}}),
+      m.map);
+  EXPECT_EQ((std::unordered_map<std::string, int>{{"4", 4}, {"5", 5}}),
+            m.unordered);
+}
+
+TEST_F(NodeLoadInspectorTest, load_tuples) {
+  consensus::Node node{""};
+
+  {
+    velocypack::Builder builder;
+    builder.openArray();
+    builder.add(VPackValue("foo"));
+    builder.add(VPackValue(42));
+    builder.add(VPackValue(12.34));
+    builder.close();
+    addChild(node, "tuple") = builder.slice();
+  }
+
+  {
+    velocypack::Builder builder;
+    builder.openArray();
+    builder.add(VPackValue(987));
+    builder.add(VPackValue("bar"));
+    builder.close();
+    addChild(node, "pair") = builder.slice();
+  }
+
+  {
+    velocypack::Builder builder;
+    builder.openArray();
+    builder.add(VPackValue("a"));
+    builder.add(VPackValue("b"));
+    builder.close();
+    addChild(node, "array1") = builder.slice();
+  }
+
+  {
+    velocypack::Builder builder;
+    builder.openArray();
+    builder.add(VPackValue(1));
+    builder.add(VPackValue(2));
+    builder.add(VPackValue(3));
+    builder.close();
+    addChild(node, "array2") = builder.slice();
+  }
+
+  NodeLoadInspector inspector{&node};
+
+  Tuple t;
+  auto result = inspector.apply(t);
+  ASSERT_TRUE(result.ok());
+
+  Tuple expected{.tuple = {"foo", 42, 12.34},
+                 .pair = {987, "bar"},
+                 .array1 = {"a", "b"},
+                 .array2 = {1, 2, 3}};
+  EXPECT_EQ(expected.tuple, t.tuple);
+  EXPECT_EQ(expected.pair, t.pair);
+  EXPECT_EQ(expected.array1[0], t.array1[0]);
+  EXPECT_EQ(expected.array1[1], t.array1[1]);
+  EXPECT_EQ(expected.array2, t.array2);
+}
+
+TEST_F(NodeLoadInspectorTest, load_optional) {
+  consensus::Node node{""};
+  assign(addChild(node, "y"), "blubb");
+
+  {
+    velocypack::Builder builder;
+    builder.openArray();
+    builder.add(VPackValue(1));
+    builder.add(VPackValue(velocypack::ValueType::Null));
+    builder.add(VPackValue(3));
+    builder.close();
+    addChild(node, "vec") = builder.slice();
+  }
+
+  {
+    auto& child = addChild(node, "map");
+    assign(addChild(child, "1"), 1);
+    assign(addChild(child, "2"), velocypack::ValueType::Null);
+    assign(addChild(child, "3"), 3);
+  }
+
+  assign(addChild(node, "a"), velocypack::ValueType::Null);
+  NodeLoadInspector inspector{&node};
+
+  Optional o{.a = 1, .b = 2, .x = 42, .y = {}, .vec = {}, .map = {}};
+  auto result = inspector.apply(o);
+  ASSERT_TRUE(result.ok()) << result.error();
+
+  Optional expected{.a = std::nullopt,
+                    .b = 456,
+                    .x = std::nullopt,
+                    .y = "blubb",
+                    .vec = {1, std::nullopt, 3},
+                    .map = {{"1", 1}, {"2", std::nullopt}, {"3", 3}}};
+  EXPECT_EQ(expected.a, o.a);
+  EXPECT_EQ(expected.b, o.b);
+  EXPECT_EQ(expected.x, o.x);
+  EXPECT_EQ(expected.y, o.y);
+  ASSERT_EQ(expected.vec, o.vec);
+  EXPECT_EQ(expected.map, o.map);
+}
+
+TEST_F(NodeLoadInspectorTest, load_optional_pointer) {
+  consensus::Node node{""};
+  {
+    velocypack::Builder builder;
+    builder.openArray();
+    builder.add(VPackValue(1));
+    builder.add(VPackValue(VPackValueType::Null));
+    builder.add(VPackValue(2));
+    builder.close();
+    addChild(node, "vec") = builder.slice();
+  }
+
+  assign(addChild(node, "a"), VPackValueType::Null);
+  assign(addChild(node, "b"), 42);
+
+  {
+    auto& child = addChild(node, "d");
+    assign(addChild(child, "i"), 43);
+  }
+
+  assign(addChild(node, "x"), VPackValueType::Null);
+
+  NodeLoadInspector inspector{&node};
+
+  Pointer p{.a = std::make_shared<int>(0),
+            .b = std::make_shared<int>(0),
+            .c = std::make_unique<int>(0),
+            .d = std::make_unique<Container>(Container{.i = {.value = 0}}),
+            .vec = {},
+            .x = std::make_shared<int>(0),
+            .y = std::make_shared<int>(0)};
+  auto result = inspector.apply(p);
+  ASSERT_TRUE(result.ok()) << result.error() << "; " << result.path();
+
+  EXPECT_EQ(nullptr, p.a);
+  ASSERT_NE(nullptr, p.b);
+  EXPECT_EQ(42, *p.b);
+  EXPECT_EQ(nullptr, p.c);
+  ASSERT_NE(nullptr, p.d);
+  EXPECT_EQ(43, p.d->i.value);
+
+  ASSERT_EQ(3u, p.vec.size());
+  ASSERT_NE(nullptr, p.vec[0]);
+  EXPECT_EQ(1, *p.vec[0]);
+  EXPECT_EQ(nullptr, p.vec[1]);
+  ASSERT_NE(nullptr, p.vec[2]);
+  EXPECT_EQ(2, *p.vec[2]);
+
+  EXPECT_EQ(nullptr, p.x);
+  ASSERT_NE(nullptr, p.y);
+  EXPECT_EQ(456, *p.y);
+}
+
+TEST_F(NodeLoadInspectorTest, error_expecting_int) {
+  consensus::Node node{""};
+  assign(node, "foo");
+  NodeLoadInspector inspector{&node};
+
+  int i{};
+  auto result = inspector.apply(i);
+  ASSERT_FALSE(result.ok());
+  EXPECT_EQ("Expecting type Int", result.error());
+}
+
+TEST_F(NodeLoadInspectorTest, error_expecting_int16) {
+  consensus::Node node{""};
+  assign(node, 123456789);
+  NodeLoadInspector inspector{&node};
+
+  std::int16_t i{};
+  auto result = inspector.apply(i);
+  ASSERT_FALSE(result.ok());
+  EXPECT_EQ("Number out of range", result.error());
+}
+
+TEST_F(NodeLoadInspectorTest, error_expecting_double) {
+  consensus::Node node{""};
+  assign(node, "foo");
+  NodeLoadInspector inspector{&node};
+
+  double d{};
+  auto result = inspector.apply(d);
+  ASSERT_FALSE(result.ok());
+  EXPECT_EQ("Expecting numeric type", result.error());
+}
+
+TEST_F(NodeLoadInspectorTest, error_expecting_bool) {
+  consensus::Node node{""};
+  assign(node, 42);
+  NodeLoadInspector inspector{&node};
+
+  bool b{};
+  auto result = inspector.apply(b);
+  ASSERT_FALSE(result.ok());
+  EXPECT_EQ("Expecting type Bool", result.error());
+}
+
+TEST_F(NodeLoadInspectorTest, error_expecting_string) {
+  consensus::Node node{""};
+  assign(node, 42);
+  NodeLoadInspector inspector{&node};
+
+  std::string s;
+  auto result = inspector.apply(s);
+  ASSERT_FALSE(result.ok());
+  EXPECT_EQ("Expecting type String", result.error());
+}
+
+TEST_F(NodeLoadInspectorTest, error_expecting_array) {
+  consensus::Node node{""};
+  assign(node, 42);
+  NodeLoadInspector inspector{&node};
+
+  std::vector<int> v;
+  auto result = inspector.apply(v);
+  ASSERT_FALSE(result.ok());
+  EXPECT_EQ("Expecting type Array", result.error());
+}
+
+TEST_F(NodeLoadInspectorTest, error_expecting_object) {
+  consensus::Node node{""};
+  assign(node, 42);
+  NodeLoadInspector inspector{&node};
+
+  Dummy d;
+  auto result = inspector.apply(d);
+  ASSERT_FALSE(result.ok());
+  EXPECT_EQ("Expecting type Object", result.error());
+}
+
+TEST_F(NodeLoadInspectorTest, error_expecting_type_on_path) {
+  consensus::Node node{""};
+  assign(addChild(addChild(node, "dummy"), "i"), "foo");
+  NodeLoadInspector inspector{&node};
+
+  Nested n;
+  auto result = inspector.apply(n);
+  ASSERT_FALSE(result.ok());
+  EXPECT_EQ("dummy.i", result.path());
+}
+
+TEST_F(NodeLoadInspectorTest, error_expecting_type_on_path_with_array) {
+  consensus::Node node{""};
+
+  {
+    velocypack::Builder builder;
+    builder.openArray();
+    builder.openObject();
+    builder.add("i", VPackValue(1));
+    builder.close();
+    builder.openObject();
+    builder.add("i", VPackValue(2));
+    builder.close();
+    builder.openObject();
+    builder.add("i", VPackValue("foobar"));
+    builder.close();
+    builder.close();
+    addChild(node, "vec") = builder.slice();
+  }
+  NodeLoadInspector inspector{&node};
+
+  List l;
+  auto result = inspector.apply(l);
+
+  ASSERT_FALSE(result.ok());
+  EXPECT_EQ("vec[2].i", result.path());
+}
+
+TEST_F(NodeLoadInspectorTest, error_expecting_type_on_path_with_map) {
+  consensus::Node node{""};
+  {
+    auto& child = addChild(node, "map");
+    assign(addChild(addChild(child, "1"), "i"), 1);
+    assign(addChild(addChild(child, "2"), "i"), 2);
+    assign(addChild(addChild(child, "3"), "i"), "foobar");
+  }
+
+  NodeLoadInspector inspector{&node};
+
+  Map m;
+  auto result = inspector.apply(m);
+
+  ASSERT_FALSE(result.ok());
+  EXPECT_EQ("map['3'].i", result.path());
+}
+
+TEST_F(NodeLoadInspectorTest, error_missing_field) {
+  consensus::Node node{""};
+  assign(addChild(addChild(node, "dummy"), "s"), "foo");
+  NodeLoadInspector inspector{&node};
+
+  Nested n;
+  auto result = inspector.apply(n);
+  ASSERT_FALSE(result.ok());
+  EXPECT_EQ("Missing required attribute 'i'", result.error());
+  EXPECT_EQ("dummy.i", result.path());
+}
+
+TEST_F(NodeLoadInspectorTest, error_found_unexpected_attribute) {
+  consensus::Node node{""};
+  assign(addChild(node, "i"), 42);
+  assign(addChild(node, "should_not_be_here"), 123);
+  NodeLoadInspector inspector{&node};
+
+  Container c;
+  auto result = inspector.apply(c);
+  ASSERT_FALSE(result.ok());
+  EXPECT_EQ("Found unexpected attribute 'should_not_be_here'", result.error());
+}
+
+TEST_F(NodeLoadInspectorTest, load_object_ignoring_unknown_attributes) {
+  consensus::Node node{""};
+  assign(addChild(node, "i"), 42);
+  assign(addChild(node, "ignore_me"), 123);
+  NodeLoadInspector inspector{&node, {.ignoreUnknownFields = true}};
+
+  Container c;
+  auto result = inspector.apply(c);
+  ASSERT_TRUE(result.ok()) << "Error: " << result.error()
+                           << "\nPath: " << result.path();
+}
+
+TEST_F(NodeLoadInspectorTest, load_object_with_fallbacks) {
+  consensus::Node node{""};
+  NodeLoadInspector inspector{&node};
+
+  Fallback f;
+  Dummy expected = f.d;
+  auto result = inspector.apply(f);
+  ASSERT_TRUE(result.ok());
+  EXPECT_EQ(42, f.i);
+  EXPECT_EQ("foobar", f.s);
+  EXPECT_EQ(expected, f.d);
+  EXPECT_EQ(84, f.dynamic);  // f.i * 2
+}
+
+TEST_F(NodeLoadInspectorTest, load_object_with_fallback_reference) {
+  consensus::Node node{""};
+  assign(addChild(node, "x"), 42);
+  NodeLoadInspector inspector{&node};
+
+  FallbackReference f;
+  auto result = inspector.apply(f);
+  ASSERT_TRUE(result.ok());
+  EXPECT_EQ(42, f.x);
+  EXPECT_EQ(42, f.y);
+}
+
+TEST_F(NodeLoadInspectorTest, load_object_ignoring_missing_fields) {
+  consensus::Node node{""};
+  NodeLoadInspector inspector{&node, {.ignoreMissingFields = true}};
+
+  FallbackReference f{.x = 1, .y = 2};
+  auto result = inspector.apply(f);
+  ASSERT_TRUE(result.ok());
+  EXPECT_EQ(1, f.x);
+  EXPECT_EQ(1, f.y);
+}
+
+TEST_F(NodeLoadInspectorTest, load_object_with_invariant_fulfilled) {
+  consensus::Node node{""};
+  assign(addChild(node, "i"), 42);
+  assign(addChild(node, "s"), "foobar");
+  NodeLoadInspector inspector{&node};
+
+  Invariant i;
+  auto result = inspector.apply(i);
+  ASSERT_TRUE(result.ok());
+  EXPECT_EQ(42, i.i);
+  EXPECT_EQ("foobar", i.s);
+}
+
+TEST_F(NodeLoadInspectorTest, load_object_with_invariant_not_fulfilled) {
+  {
+    consensus::Node node{""};
+    assign(addChild(node, "i"), 0);
+    assign(addChild(node, "s"), "foobar");
+    NodeLoadInspector inspector{&node};
+
+    Invariant i;
+    auto result = inspector.apply(i);
+    ASSERT_FALSE(result.ok());
+    EXPECT_EQ("Field invariant failed", result.error());
+    EXPECT_EQ("i", result.path());
+  }
+
+  {
+    consensus::Node node{""};
+    assign(addChild(node, "i"), 42);
+    assign(addChild(node, "s"), "");
+    NodeLoadInspector inspector{&node};
+
+    Invariant i;
+    auto result = inspector.apply(i);
+    ASSERT_FALSE(result.ok());
+    EXPECT_EQ("Field invariant failed", result.error());
+    EXPECT_EQ("s", result.path());
+  }
+}
+
+TEST_F(NodeLoadInspectorTest, load_object_with_invariant_Result_not_fulfilled) {
+  {
+    consensus::Node node{""};
+    assign(addChild(node, "i"), 0);
+    NodeLoadInspector inspector{&node};
+
+    InvariantWithResult i;
+    auto result = inspector.apply(i);
+    ASSERT_FALSE(result.ok());
+    EXPECT_EQ("Must not be zero", result.error());
+    EXPECT_EQ("i", result.path());
+  }
+
+  {
+    consensus::Node node{""};
+    assign(addChild(node, "i"), 42);
+    assign(addChild(node, "s"), "");
+    NodeLoadInspector inspector{&node};
+
+    Invariant i;
+    auto result = inspector.apply(i);
+    ASSERT_FALSE(result.ok());
+    EXPECT_EQ("Field invariant failed", result.error());
+    EXPECT_EQ("s", result.path());
+  }
+}
+
+TEST_F(NodeLoadInspectorTest, load_object_with_invariant_and_fallback) {
+  consensus::Node node{""};
+  NodeLoadInspector inspector{&node};
+
+  InvariantAndFallback i;
+  auto result = inspector.apply(i);
+  ASSERT_TRUE(result.ok());
+  EXPECT_EQ(42, i.i);
+  EXPECT_EQ("foobar", i.s);
+}
+
+TEST_F(NodeLoadInspectorTest, load_object_with_object_invariant) {
+  consensus::Node node{""};
+  assign(addChild(node, "i"), 42);
+  assign(addChild(node, "s"), "");
+  NodeLoadInspector inspector{&node};
+
+  ObjectInvariant o;
+  auto result = inspector.apply(o);
+  ASSERT_FALSE(result.ok());
+  EXPECT_EQ("Object invariant failed", result.error());
+}
+
+TEST_F(NodeLoadInspectorTest, load_object_with_field_transform) {
+  consensus::Node node{""};
+  assign(addChild(node, "x"), "42");
+  NodeLoadInspector inspector{&node};
+
+  FieldTransform f;
+  auto result = inspector.apply(f);
+  ASSERT_TRUE(result.ok());
+  EXPECT_EQ(42, f.x);
+}
+
+TEST_F(NodeLoadInspectorTest, load_object_with_field_transform_and_fallback) {
+  consensus::Node node{""};
+  assign(addChild(node, "x"), "42");
+  NodeLoadInspector inspector{&node};
+
+  FieldTransformWithFallback f;
+  auto result = inspector.apply(f);
+  ASSERT_TRUE(result.ok());
+  EXPECT_EQ(42, f.x);
+  EXPECT_EQ(2, f.y);
+}
+
+TEST_F(NodeLoadInspectorTest, load_object_with_optional_field_transform) {
+  consensus::Node node{""};
+  assign(addChild(node, "x"), "42");
+  NodeLoadInspector inspector{&node};
+
+  OptionalFieldTransform f{.x = 1, .y = 2, .z = 3};
+  auto result = inspector.apply(f);
+  ASSERT_TRUE(result.ok());
+  EXPECT_EQ(42, *f.x);
+  EXPECT_FALSE(f.y.has_value());
+  EXPECT_EQ(123, *f.z);
+}
+
+TEST_F(NodeLoadInspectorTest, load_type_with_custom_specialization) {
+  consensus::Node node{""};
+  assign(addChild(node, "i"), 42);
+  assign(addChild(node, "s"), "foobar");
+  NodeLoadInspector inspector{&node};
+
+  Specialization s;
+  auto result = inspector.apply(s);
+  ASSERT_TRUE(result.ok());
+  EXPECT_EQ(42, s.i);
+  EXPECT_EQ("foobar", s.s);
+}
+
+TEST_F(NodeLoadInspectorTest, load_type_with_explicitly_ignored_fields) {
+  consensus::Node node{""};
+  assign(addChild(node, "s"), "foobar");
+  assign(addChild(node, "ignore"), "something");
+  NodeLoadInspector inspector{&node};
+
+  ExplicitIgnore e;
+  auto result = inspector.apply(e);
+  ASSERT_TRUE(result.ok());
+}
+
+TEST_F(NodeLoadInspectorTest, load_qualified_variant) {
+  consensus::Node node{""};
+  assign(addChild(node, "a"), "foobar");
+
+  {
+    auto& child = addChild(node, "b");
+    assign(addChild(child, "t"), "int");
+    assign(addChild(child, "v"), 42);
+  }
+
+  {
+    auto& child = addChild(node, "c");
+    assign(addChild(child, "t"), "Struct1");
+    assign(addChild(addChild(child, "v"), "v"), 1);
+  }
+
+  {
+    auto& child = addChild(node, "d");
+    assign(addChild(child, "t"), "Struct2");
+    assign(addChild(addChild(child, "v"), "v"), 2);
+  }
+
+  {
+    auto& child = addChild(node, "e");
+    assign(addChild(child, "t"), "nil");
+    addChild(child, "v");
+  }
+
+  NodeLoadInspector inspector{&node};
+
+  QualifiedVariant v{.a = {std::monostate{}},
+                     .b = {std::monostate{}},
+                     .c = {std::monostate{}},
+                     .d = {std::monostate{}},
+                     .e = {0}};
+  auto result = inspector.apply(v);
+  ASSERT_TRUE(result.ok());
+  EXPECT_EQ("foobar", std::get<std::string>(v.a));
+  EXPECT_EQ(42, std::get<int>(v.b));
+  EXPECT_EQ(1, std::get<Struct1>(v.c).v);
+  EXPECT_EQ(2, std::get<Struct2>(v.d).v);
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(v.e));
+}
+
+TEST_F(NodeLoadInspectorTest,
+       error_unknown_type_tag_when_loading_qualified_variant) {
+  consensus::Node node{""};
+  {
+    auto& child = addChild(node, "a");
+    assign(addChild(child, "t"), "blubb");
+    assign(addChild(child, "v"), "");
+  }
+  NodeLoadInspector inspector{&node};
+
+  QualifiedVariant v;
+  auto result = inspector.apply(v);
+  ASSERT_FALSE(result.ok());
+  EXPECT_EQ("Found invalid type: blubb", result.error());
+  EXPECT_EQ("a", result.path());
+}
+
+TEST_F(NodeLoadInspectorTest,
+       error_expecting_string_when_parsing_qualified_variant_value) {
+  consensus::Node node{""};
+  {
+    auto& child = addChild(node, "a");
+    assign(addChild(child, "t"), "int");
+    assign(addChild(child, "v"), "blubb");
+  }
+  NodeLoadInspector inspector{&node};
+
+  QualifiedVariant v;
+  auto result = inspector.apply(v);
+  ASSERT_FALSE(result.ok());
+  EXPECT_EQ("Expecting type Int", result.error());
+  EXPECT_EQ("a.v", result.path());
+}
+
+TEST_F(NodeLoadInspectorTest,
+       error_missing_tag_when_parsing_qualified_variant) {
+  consensus::Node node{""};
+  {
+    auto& child = addChild(node, "a");
+    assign(addChild(child, "v"), 42);
+  }
+  NodeLoadInspector inspector{&node};
+
+  QualifiedVariant v;
+  auto result = inspector.apply(v);
+  ASSERT_FALSE(result.ok());
+  EXPECT_EQ("Variant type field \"t\" is missing", result.error());
+  EXPECT_EQ("a", result.path());
+}
+
+TEST_F(NodeLoadInspectorTest,
+       error_invalid_tag_type_when_parsing_qualified_variant) {
+  consensus::Node node{""};
+  {
+    auto& child = addChild(node, "a");
+    assign(addChild(child, "t"), 42);
+  }
+  NodeLoadInspector inspector{&node};
+
+  QualifiedVariant v;
+  auto result = inspector.apply(v);
+  ASSERT_FALSE(result.ok());
+  EXPECT_EQ("Variant type field \"t\" must be a string", result.error());
+  EXPECT_EQ("a", result.path());
+}
+
+TEST_F(NodeLoadInspectorTest,
+       error_missing_value_when_parsing_qualified_variant) {
+  consensus::Node node{""};
+  {
+    auto& child = addChild(node, "a");
+    assign(addChild(child, "t"), "int");
+  }
+  NodeLoadInspector inspector{&node};
+
+  QualifiedVariant v;
+  auto result = inspector.apply(v);
+  ASSERT_FALSE(result.ok());
+  EXPECT_EQ("Variant value field \"v\" is missing", result.error());
+  EXPECT_EQ("a", result.path());
+}
+
+TEST_F(NodeLoadInspectorTest, load_unqualified_variant) {
+  consensus::Node node{""};
+  assign(addChild(addChild(node, "a"), "string"), "foobar");
+  assign(addChild(node, "b"), 42);
+  assign(addChild(addChild(addChild(node, "c"), "Struct1"), "v"), 1);
+  assign(addChild(addChild(addChild(node, "d"), "Struct2"), "v"), 2);
+  addChild(addChild(node, "e"), "nil");
+  NodeLoadInspector inspector{&node};
+
+  UnqualifiedVariant v{.a = {std::monostate{}},
+                       .b = {std::monostate{}},
+                       .c = {std::monostate{}},
+                       .d = {std::monostate{}},
+                       .e = {0}};
+  auto result = inspector.apply(v);
+  ASSERT_TRUE(result.ok());
+  EXPECT_EQ("foobar", std::get<std::string>(v.a));
+  EXPECT_EQ(42, std::get<int>(v.b));
+  EXPECT_EQ(1, std::get<Struct1>(v.c).v);
+  EXPECT_EQ(2, std::get<Struct2>(v.d).v);
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(v.e));
+}
+
+TEST_F(NodeLoadInspectorTest,
+       error_unknown_type_tag_when_loading_unqualified_variant) {
+  consensus::Node node{""};
+  assign(addChild(addChild(node, "a"), "blubb"), "");
+  NodeLoadInspector inspector{&node};
+
+  UnqualifiedVariant v;
+  auto result = inspector.apply(v);
+  ASSERT_FALSE(result.ok());
+  EXPECT_EQ("Found invalid type: blubb", result.error());
+  EXPECT_EQ("a", result.path());
+}
+
+TEST_F(NodeLoadInspectorTest,
+       error_expecting_string_when_parsing_unqualified_variant_value) {
+  consensus::Node node{""};
+  assign(addChild(addChild(node, "a"), "string"), 42);
+  NodeLoadInspector inspector{&node};
+
+  UnqualifiedVariant v;
+  auto result = inspector.apply(v);
+  ASSERT_FALSE(result.ok());
+  EXPECT_EQ("Expecting type String", result.error());
+  EXPECT_EQ("a.string", result.path());
+}
+
+TEST_F(NodeLoadInspectorTest,
+       error_missing_data_when_parsing_unqualified_variant) {
+  consensus::Node node{""};
+  addChild(node, "a");
+  NodeLoadInspector inspector{&node};
+
+  UnqualifiedVariant v;
+  auto result = inspector.apply(v);
+  ASSERT_FALSE(result.ok());
+  EXPECT_EQ("Missing unqualified variant data", result.error());
+  EXPECT_EQ("a", result.path());
+}
+
+TEST_F(NodeLoadInspectorTest,
+       error_when_parsing_unqualified_variant_with_more_than_one_field) {
+  consensus::Node node{""};
+  {
+    auto& child = addChild(node, "a");
+    assign(addChild(child, "string"), "foobar");
+    assign(addChild(child, "blubb"), "blubb");
+  }
+  NodeLoadInspector inspector{&node};
+
+  UnqualifiedVariant v;
+  auto result = inspector.apply(v);
+  ASSERT_FALSE(result.ok());
+  EXPECT_EQ("Unqualified variant data has too many fields", result.error());
+  EXPECT_EQ("a", result.path());
+}
+
+TEST_F(NodeLoadInspectorTest, load_inline_variant) {
+  consensus::Node node{""};
+  assign(addChild(node, "a"), "foobar");
+
+  assign(addChild(addChild(node, "b"), "v"), 42);
+
+  {
+    velocypack::Builder builder;
+    builder.openArray();
+    builder.add(VPackValue(1));
+    builder.add(VPackValue(2));
+    builder.add(VPackValue(3));
+    builder.close();
+    addChild(node, "c") = builder.slice();
+  }
+
+  assign(addChild(node, "d"), 123);
+
+  {
+    velocypack::Builder builder;
+    builder.openArray();
+    builder.add(VPackValue("blubb"));
+    builder.add(VPackValue(987));
+    builder.add(VPackValue(true));
+    builder.close();
+    addChild(node, "e") = builder.slice();
+  }
+
+  NodeLoadInspector inspector{&node};
+
+  InlineVariant v{.a = {}, .b = {}, .c = {}, .d{}, .e = {}};
+  auto result = inspector.apply(v);
+  ASSERT_TRUE(result.ok()) << result.error();
+  EXPECT_EQ("foobar", std::get<std::string>(v.a));
+  EXPECT_EQ(42, std::get<Struct1>(v.b).v);
+  EXPECT_EQ(std::vector<int>({1, 2, 3}), std::get<std::vector<int>>(v.c));
+  EXPECT_EQ(123, std::get<TypedInt>(v.d).value);
+  EXPECT_EQ(std::make_tuple("blubb", 987, true),
+            (std::get<std::tuple<std::string, int, bool>>(v.e)));
+}
+
+TEST_F(NodeLoadInspectorTest, error_unknown_type_when_loading_inline_variant) {
+  consensus::Node node{""};
+  addChild(node, "a");
+  NodeLoadInspector inspector{&node};
+
+  InlineVariant v;
+  auto result = inspector.apply(v);
+  ASSERT_FALSE(result.ok());
+  EXPECT_EQ("Could not find matching inline type", result.error());
+  EXPECT_EQ("a", result.path());
+}
+
+TEST_F(NodeLoadInspectorTest, load_embedded_variant) {
+  consensus::Node node{""};
+  {
+    auto& child = addChild(node, "a");
+    assign(addChild(child, "t"), "Struct1");
+    assign(addChild(child, "v"), 1);
+  }
+  {
+    auto& child = addChild(node, "b");
+    assign(addChild(child, "t"), "Struct2");
+    assign(addChild(child, "v"), 2);
+  }
+  {
+    auto& child = addChild(node, "c");
+    assign(addChild(child, "t"), "Struct3");
+    assign(addChild(child, "a"), 1);
+    assign(addChild(child, "b"), 2);
+  }
+  assign(addChild(node, "d"), true);
+  NodeLoadInspector inspector{&node};
+
+  EmbeddedVariant v{.a = {}, .b = {}, .c = {}, .d = {}};
+  auto result = inspector.apply(v);
+  ASSERT_TRUE(result.ok()) << result.error();
+  EXPECT_EQ(1, std::get<Struct1>(v.a).v);
+  EXPECT_EQ(2, std::get<Struct2>(v.b).v);
+  EXPECT_EQ(1, std::get<Struct3>(v.c).a);
+  EXPECT_EQ(2, std::get<Struct3>(v.c).b);
+  EXPECT_EQ(true, std::get<bool>(v.d));
+}
+
+TEST_F(NodeLoadInspectorTest,
+       error_unknown_type_tag_when_loading_embedded_variant) {
+  consensus::Node node{""};
+  {
+    auto& child = addChild(node, "a");
+    assign(addChild(child, "t"), "blubb");
+    assign(addChild(child, "v"), "");
+  }
+  NodeLoadInspector inspector{&node};
+
+  EmbeddedVariant v;
+  auto result = inspector.apply(v);
+  ASSERT_FALSE(result.ok());
+  EXPECT_EQ("Found invalid type: blubb", result.error());
+  EXPECT_EQ("a", result.path());
+}
+
+TEST_F(NodeLoadInspectorTest,
+       error_expecting_int_when_parsing_embedded_variant_value) {
+  consensus::Node node{""};
+  {
+    auto& child = addChild(node, "a");
+    assign(addChild(child, "t"), "Struct1");
+    assign(addChild(child, "v"), "blubb");
+  }
+  NodeLoadInspector inspector{&node};
+
+  EmbeddedVariant v;
+  auto result = inspector.apply(v);
+  ASSERT_FALSE(result.ok());
+  EXPECT_EQ("Expecting type Int", result.error());
+  EXPECT_EQ("a.v", result.path());
+}
+
+TEST_F(NodeLoadInspectorTest, error_missing_tag_when_parsing_embedded_variant) {
+  consensus::Node node{""};
+  assign(addChild(addChild(node, "a"), "v"), 42);
+  NodeLoadInspector inspector{&node};
+
+  EmbeddedVariant v;
+  auto result = inspector.apply(v);
+  ASSERT_FALSE(result.ok());
+  EXPECT_EQ("Variant type field \"t\" is missing", result.error());
+  EXPECT_EQ("a", result.path());
+}
+
+TEST_F(NodeLoadInspectorTest,
+       error_invalid_tag_type_when_parsing_embedded_variant) {
+  consensus::Node node{""};
+  assign(addChild(addChild(node, "a"), "t"), 42);
+  NodeLoadInspector inspector{&node};
+
+  EmbeddedVariant v;
+  auto result = inspector.apply(v);
+  ASSERT_FALSE(result.ok());
+  EXPECT_EQ("Variant type field \"t\" must be a string", result.error());
+  EXPECT_EQ("a", result.path());
+}
+
+TEST_F(NodeLoadInspectorTest,
+       error_missing_value_when_parsing_embedded_variant) {
+  consensus::Node node{""};
+  {
+    auto& child = addChild(node, "a");
+    assign(addChild(child, "t"), "Struct3");
+    assign(addChild(child, "a"), 1);
+  }
+  NodeLoadInspector inspector{&node};
+
+  EmbeddedVariant v;
+  auto result = inspector.apply(v);
+  ASSERT_FALSE(result.ok());
+  EXPECT_EQ("Missing required attribute 'b'", result.error());
+  EXPECT_EQ("a.b", result.path());
+}
+
+TEST_F(NodeLoadInspectorTest, load_type_with_unsafe_fields) {
+  consensus::Node node{""};
+  assign(addChild(node, "view"), "foobar");
+  assign(addChild(node, "slice"), "blubb");
+  assign(addChild(node, "hashed"), "hashedString");
+  arangodb::inspection::NodeUnsafeLoadInspector<> inspector{&node};
+
+  Unsafe u;
+  auto result = inspector.apply(u);
+  ASSERT_TRUE(result.ok());
+  EXPECT_EQ(node.get("view")->get().getStringView().value(), u.view);
+  EXPECT_EQ(node.get("view")->get().getStringView().value().data(),
+            u.view.data());
+  EXPECT_EQ(node.get("slice")->get().slice().start(), u.slice.start());
+  EXPECT_EQ(node.get("hashed")->get().getStringView().value(),
+            u.hashed.stringView());
+  EXPECT_EQ(node.get("hashed")->get().getStringView().value().data(),
+            u.hashed.data());
+}
+
+TEST_F(NodeLoadInspectorTest, load_string_enum) {
+  consensus::Node node{""};
+  MyStringEnum myEnum;
+  {
+    assign(node, "value1");
+    arangodb::inspection::NodeLoadInspector<> inspector{&node};
+    auto result = inspector.apply(myEnum);
+    ASSERT_TRUE(result.ok());
+    EXPECT_EQ(MyStringEnum::kValue1, myEnum);
+  }
+
+  {
+    assign(node, "value2");
+    arangodb::inspection::NodeLoadInspector<> inspector{&node};
+    auto result = inspector.apply(myEnum);
+    ASSERT_TRUE(result.ok());
+    EXPECT_EQ(MyStringEnum::kValue2, myEnum);
+  }
+}
+
+TEST_F(NodeLoadInspectorTest, load_int_enum) {
+  consensus::Node node{""};
+  MyIntEnum myEnum;
+  {
+    assign(node, 1);
+    arangodb::inspection::NodeLoadInspector<> inspector{&node};
+    auto result = inspector.apply(myEnum);
+    ASSERT_TRUE(result.ok());
+    EXPECT_EQ(MyIntEnum::kValue1, myEnum);
+  }
+
+  {
+    assign(node, 2);
+    arangodb::inspection::NodeLoadInspector<> inspector{&node};
+    auto result = inspector.apply(myEnum);
+    ASSERT_TRUE(result.ok());
+    EXPECT_EQ(MyIntEnum::kValue2, myEnum);
+  }
+}
+
+TEST_F(NodeLoadInspectorTest, load_mixed_enum) {
+  consensus::Node node{""};
+  MyMixedEnum myEnum;
+  {
+    assign(node, "value1");
+    arangodb::inspection::NodeLoadInspector<> inspector{&node};
+    auto result = inspector.apply(myEnum);
+    ASSERT_TRUE(result.ok());
+    EXPECT_EQ(MyMixedEnum::kValue1, myEnum);
+  }
+  {
+    assign(node, 1);
+    arangodb::inspection::NodeLoadInspector<> inspector{&node};
+    auto result = inspector.apply(myEnum);
+    ASSERT_TRUE(result.ok());
+    EXPECT_EQ(MyMixedEnum::kValue1, myEnum);
+  }
+  {
+    assign(node, "value2");
+    arangodb::inspection::NodeLoadInspector<> inspector{&node};
+    auto result = inspector.apply(myEnum);
+    ASSERT_TRUE(result.ok());
+    EXPECT_EQ(MyMixedEnum::kValue2, myEnum);
+  }
+  {
+    assign(node, 2);
+    arangodb::inspection::NodeLoadInspector<> inspector{&node};
+    auto result = inspector.apply(myEnum);
+    ASSERT_TRUE(result.ok());
+    EXPECT_EQ(MyMixedEnum::kValue2, myEnum);
+  }
+}
+
+TEST_F(NodeLoadInspectorTest, load_string_enum_returns_error_when_not_string) {
+  consensus::Node node{""};
+  assign(node, 42);
+  arangodb::inspection::NodeLoadInspector<> inspector{&node};
+
+  MyStringEnum myEnum;
+  auto result = inspector.apply(myEnum);
+  EXPECT_FALSE(result.ok());
+  EXPECT_EQ("Expecting type String", result.error());
+}
+
+TEST_F(NodeLoadInspectorTest, load_int_enum_returns_error_when_not_int) {
+  consensus::Node node{""};
+  assign(node, "foobar");
+  arangodb::inspection::NodeLoadInspector<> inspector{&node};
+
+  MyIntEnum myEnum;
+  auto result = inspector.apply(myEnum);
+  EXPECT_FALSE(result.ok());
+  EXPECT_EQ("Expecting type UInt", result.error());
+}
+
+TEST_F(NodeLoadInspectorTest,
+       load_mixed_enum_returns_error_when_not_string_or_int) {
+  consensus::Node node{""};
+  assign(node, false);
+  arangodb::inspection::NodeLoadInspector<> inspector{&node};
+
+  MyMixedEnum myEnum;
+  auto result = inspector.apply(myEnum);
+  EXPECT_FALSE(result.ok());
+  EXPECT_EQ("Expecting type String or Int", result.error());
+}
+
+TEST_F(NodeLoadInspectorTest,
+       load_string_enum_returns_error_when_value_is_unknown) {
+  consensus::Node node{""};
+  assign(node, "unknownValue");
+  arangodb::inspection::NodeLoadInspector<> inspector{&node};
+
+  MyStringEnum myEnum;
+  auto result = inspector.apply(myEnum);
+  EXPECT_FALSE(result.ok());
+  EXPECT_EQ("Unknown enum value unknownValue", result.error());
+}
+
+TEST_F(NodeLoadInspectorTest,
+       load_int_enum_returns_error_when_value_is_unknown) {
+  consensus::Node node{""};
+  assign(node, 42);
+  arangodb::inspection::NodeLoadInspector<> inspector{&node};
+
+  MyIntEnum myEnum;
+  auto result = inspector.apply(myEnum);
+  EXPECT_FALSE(result.ok());
+  EXPECT_EQ("Unknown enum value 42", result.error());
+}
+
+TEST_F(NodeLoadInspectorTest,
+       load_mixed_enum_returns_error_when_value_is_unknown) {
+  {
+    consensus::Node node{""};
+    assign(node, "unknownValue");
+    arangodb::inspection::NodeLoadInspector<> inspector{&node};
+
+    MyMixedEnum myEnum;
+    auto result = inspector.apply(myEnum);
+    EXPECT_FALSE(result.ok());
+    EXPECT_EQ("Unknown enum value unknownValue", result.error());
+  }
+  {
+    consensus::Node node{""};
+    assign(node, 42);
+    arangodb::inspection::NodeLoadInspector<> inspector{&node};
+
+    MyMixedEnum myEnum;
+    auto result = inspector.apply(myEnum);
+    EXPECT_FALSE(result.ok());
+    EXPECT_EQ("Unknown enum value 42", result.error());
+  }
+}
+
+TEST_F(NodeLoadInspectorTest, load_embedded_object) {
+  consensus::Node node{""};
+  assign(addChild(node, "a"), 1);
+  assign(addChild(node, "b"), 2);
+  NodeLoadInspector inspector{&node};
+
+  NestedEmbedding n;
+  auto result = inspector.apply(n);
+  ASSERT_TRUE(result.ok());
+  EXPECT_EQ(1, n.a);
+  EXPECT_EQ(42, n.inner.i);
+  EXPECT_EQ("foobar", n.inner.s);
+  EXPECT_EQ(2, n.b);
+}
+
+TEST_F(NodeLoadInspectorTest,
+       load_embedded_object_with_invariant_not_fulfilled) {
+  consensus::Node node{""};
+  assign(addChild(node, "a"), 1);
+  assign(addChild(node, "b"), 2);
+  assign(addChild(node, "i"), 0);
+  NodeLoadInspector inspector{&node};
+
+  NestedEmbedding n;
+  auto result = inspector.apply(n);
+  ASSERT_FALSE(result.ok());
+  EXPECT_EQ("Field invariant failed", result.error());
+  EXPECT_EQ("i", result.path());
+}
+
+TEST_F(NodeLoadInspectorTest,
+       load_embedded_object_with_object_invariant_not_fulfilled) {
+  consensus::Node node{""};
+  assign(addChild(node, "a"), 1);
+  assign(addChild(node, "b"), 2);
+  assign(addChild(node, "i"), 42);
+  assign(addChild(node, "s"), "");
+  NodeLoadInspector inspector{&node};
+
+  NestedEmbeddingWithObjectInvariant o;
+  auto result = inspector.apply(o);
+  ASSERT_FALSE(result.ok());
+  EXPECT_EQ("Object invariant failed", result.error());
+}
+
+TEST(NodeLoadInspectorContextTest, deserialize_with_context) {
+  struct Context {
+    int defaultInt;
+    int minInt;
+    std::string defaultString;
+  };
+
+  consensus::Node node{""};
+
+  {
+    Context ctxt{.defaultInt = 42, .minInt = 0, .defaultString = "foobar"};
+    auto data = consensus::deserialize<WithContext>(node, {}, ctxt);
+    EXPECT_EQ(42, data.i);
+    EXPECT_EQ("foobar", data.s);
+  }
+
+  {
+    Context ctxt{.defaultInt = -1, .minInt = -2, .defaultString = "blubb"};
+    auto data = consensus::deserialize<WithContext>(node, {}, ctxt);
+    EXPECT_EQ(-1, data.i);
+    EXPECT_EQ("blubb", data.s);
+  }
+}
+
+}  // namespace

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -179,6 +179,7 @@ set(ARANGODB_TESTS_SOURCES
   Basics/GuardedTest.cpp
   Basics/Inspection/InspectionTest.cpp
   Basics/Inspection/JsonPrintTest.cpp
+  Basics/Inspection/NodeLoadTest.cpp
   Basics/Inspection/ValidateTest.cpp
   Basics/Inspection/ValidateTest.cpp
   Basics/Inspection/VPackLoadTest.cpp


### PR DESCRIPTION
### Scope & Purpose

This PR adds a node load inspector that allows to read of data structures from agency nodes.

This is currently a draft because it is based on the changes in #17283. Once that PR is merged I will rebase this branch onto devel.

- [x] :pizza: New feature

### Checklist

- [x] Tests
  - [x] C++ **Unit tests**

