### PR TITLE
[CINFRA] Intermediate Commits Flaky Test

### DIFF
--- a/arangod/Cluster/Utils/EvenDistribution.cpp
+++ b/arangod/Cluster/Utils/EvenDistribution.cpp
@@ -74,6 +74,11 @@ Result EvenDistribution::planShardsOnServers(
     return {TRI_ERROR_CLUSTER_INSUFFICIENT_DBSERVERS};
   }
 
+  // Shuffle the servers, such that we don't always start with the same one
+  std::random_device rd;
+  std::mt19937 g(rd());
+  std::shuffle(availableServers.begin(), availableServers.end(), g);
+
   _shardToServerMapping.clear();
 
   // Example: Servers: A B C D E F G H I (9)

--- a/tests/js/client/shell/transaction/shell-transaction-intermediate-commit-cluster.js
+++ b/tests/js/client/shell/transaction/shell-transaction-intermediate-commit-cluster.js
@@ -35,7 +35,6 @@ let { getEndpointById,
       getEndpointsByType,
       debugCanUseFailAt,
       debugSetFailAt,
-      debugRemoveFailAt,
       debugClearFailAt,
       getChecksum,
       getMetric


### PR DESCRIPTION
### Scope & Purpose

The `testMultiAqlIntermediateCommitsOnFollower` sometimes fails on our staging branch, since we introduced `CollectionGroups`. The test tries to setup two different collections, having different leaders but the same follower. Once the first collection _c1_ is successfully setup, we try to setup _c2_ in a loop, such that the follower stays the same, and the leader of _c1_ is marked as avoided. Because there are only 3 servers and one of them is avoided, _c2_ is left with only two possible participants, so there are two possible combinations of (leader, follower), out of which only one will be accepted, which means there's a 50% change to fail. The order of the  `availableServers` list might only change when the agency cache is reloaded. We shuffle the list to avoid getting stuck.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification