### PR TITLE
Added startup option --javascript.user-defined-functions.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,13 @@
 v3.10.4 (XXXX-XX-XX)
 --------------------
 
+* Added startup option `--javascript.user-defined-functions`. 
+  This option controls whether JavaScript user-defined functions (UDFs) can
+  be used in AQL queries. The option defaults to `true`. The option can be
+  set to `false` to disallow using JavaScript UDFs from inside AQL queries.
+  In that case, a parse error will be thrown when trying to run a query that
+  invokes a UDF.
+
 * Activate RDB_CoveringIterator and use it for some geo index queries.
   This speeds up and simplifies geo queries with geo index which do not use
   GEO_DISTANCE.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,10 +1,10 @@
 v3.10.4 (XXXX-XX-XX)
 --------------------
 
-* Added startup option `--javascript.user-defined-functions`. 
-  This option controls whether JavaScript user-defined functions (UDFs) can
-  be used in AQL queries. The option defaults to `true`. The option can be
-  set to `false` to disallow using JavaScript UDFs from inside AQL queries.
+* Added startup option `--javascript.user-defined-functions`.
+  This option controls whether JavaScript user-defined functions (UDFs) can be
+  used in AQL queries. The option defaults to `true`. The option can be set to
+  `false` to disallow using JavaScript UDFs from inside AQL queries.
   In that case, a parse error will be thrown when trying to run a query that
   invokes a UDF.
 

--- a/arangod/Aql/Ast.cpp
+++ b/arangod/Aql/Ast.cpp
@@ -56,6 +56,7 @@
 #include "Utilities/NameValidator.h"
 #include "VocBase/LogicalCollection.h"
 #include "VocBase/LogicalView.h"
+#include "V8Server/V8DealerFeature.h"
 
 using namespace arangodb;
 using namespace arangodb::aql;
@@ -1891,7 +1892,17 @@ AstNode* Ast::createNodeFunctionCall(std::string_view functionName,
       _functionsMayAccessDocuments = true;
     }
   } else {
-    // user-defined function
+    // user-defined function (UDF)
+    if (!_query.vocbase()
+             .server()
+             .getFeature<V8DealerFeature>()
+             .allowJavaScriptUdfs()) {
+      // usage of user-defined functions is disallowed
+      THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_QUERY_PARSE,
+                                     "usage of AQL user-defined functions "
+                                     "(UDFs) is disallowed via configuration");
+    }
+
     node = createNode(NODE_TYPE_FCALL_USER);
     // register the function name
     char* fname = _resources.registerString(normalized);

--- a/arangod/Aql/Ast.cpp
+++ b/arangod/Aql/Ast.cpp
@@ -1893,7 +1893,8 @@ AstNode* Ast::createNodeFunctionCall(std::string_view functionName,
     }
   } else {
     // user-defined function (UDF)
-    if (!_query.vocbase()
+    if (_query.vocbase().server().hasFeature<V8DealerFeature>() &&
+        !_query.vocbase()
              .server()
              .getFeature<V8DealerFeature>()
              .allowJavaScriptUdfs()) {

--- a/arangod/V8Server/V8DealerFeature.cpp
+++ b/arangod/V8Server/V8DealerFeature.cpp
@@ -125,13 +125,14 @@ V8DealerFeature::V8DealerFeature(Server& server)
       _gcFrequency(60.0),
       _gcInterval(2000),
       _maxContextAge(60.0),
-      _copyInstallation(false),
       _nrMaxContexts(0),
       _nrMinContexts(0),
       _nrInflightContexts(0),
       _maxContextInvocations(0),
+      _copyInstallation(false),
       _allowAdminExecute(false),
       _allowJavaScriptTransactions(true),
+      _allowJavaScriptUdfs(true),
       _allowJavaScriptTasks(true),
       _enableJS(true),
       _nextId(0),
@@ -325,6 +326,17 @@ or teardown commands for execution on the server.)");
                       arangodb::options::Flags::OnCoordinator,
                       arangodb::options::Flags::OnSingle))
       .setIntroducedIn(30800);
+
+  options
+      ->addOption(
+          "--javascript.user-defined-functions",
+          "Enable JavaScript user-defined functions (UDFs) in AQL queries.",
+          new BooleanParameter(&_allowJavaScriptUdfs),
+          arangodb::options::makeFlags(
+              arangodb::options::Flags::DefaultNoComponents,
+              arangodb::options::Flags::OnCoordinator,
+              arangodb::options::Flags::OnSingle))
+      .setIntroducedIn(31100);
 
   options
       ->addOption("--javascript.tasks", "Enable JavaScript tasks.",

--- a/arangod/V8Server/V8DealerFeature.cpp
+++ b/arangod/V8Server/V8DealerFeature.cpp
@@ -336,7 +336,7 @@ or teardown commands for execution on the server.)");
               arangodb::options::Flags::DefaultNoComponents,
               arangodb::options::Flags::OnCoordinator,
               arangodb::options::Flags::OnSingle))
-      .setIntroducedIn(31100);
+      .setIntroducedIn(31004);
 
   options
       ->addOption("--javascript.tasks", "Enable JavaScript tasks.",

--- a/arangod/V8Server/V8DealerFeature.h
+++ b/arangod/V8Server/V8DealerFeature.h
@@ -78,22 +78,35 @@ class V8DealerFeature final : public ArangodFeature {
   std::string _startupDirectory;
   std::string _nodeModulesDirectory;
   std::vector<std::string> _moduleDirectories;
+  // maximum number of contexts to create
+  uint64_t _nrMaxContexts;
+  // minimum number of contexts to keep
+  uint64_t _nrMinContexts;
+  // number of contexts currently in creation
+  uint64_t _nrInflightContexts;
+  // maximum number of V8 context invocations
+  uint64_t _maxContextInvocations;
+
+  // copy JavaScript files into database directory on startup
   bool _copyInstallation;
-  uint64_t _nrMaxContexts;          // maximum number of contexts to create
-  uint64_t _nrMinContexts;          // minimum number of contexts to keep
-  uint64_t _nrInflightContexts;     // number of contexts currently in creation
-  uint64_t _maxContextInvocations;  // maximum number of V8 context invocations
+  // enable /_admin/execute API
   bool _allowAdminExecute;
+  // allow JavaScript transactions?
   bool _allowJavaScriptTransactions;
+  // allow JavaScript user-defined functions?
+  bool _allowJavaScriptUdfs;
+  // allow JavaScript tasks (tasks module)?
   bool _allowJavaScriptTasks;
+  // enable JavaScript globally
   bool _enableJS;
 
  public:
-  bool allowAdminExecute() const { return _allowAdminExecute; }
-  bool allowJavaScriptTransactions() const {
+  bool allowAdminExecute() const noexcept { return _allowAdminExecute; }
+  bool allowJavaScriptTransactions() const noexcept {
     return _allowJavaScriptTransactions;
   }
-  bool allowJavaScriptTasks() const { return _allowJavaScriptTasks; }
+  bool allowJavaScriptUdfs() const noexcept { return _allowJavaScriptUdfs; }
+  bool allowJavaScriptTasks() const noexcept { return _allowJavaScriptTasks; }
 
   bool addGlobalContextMethod(std::string const&);
   void collectGarbage();

--- a/lib/ProgramOptions/ProgramOptions.cpp
+++ b/lib/ProgramOptions/ProgramOptions.cpp
@@ -607,7 +607,8 @@ void ProgramOptions::addPositional(std::string const& value) {
 // adds an option to the list of options
 void ProgramOptions::addOption(Option&& option) {
   checkIfSealed();
-  auto sectionIt = addSection(option.section, "");
+  std::map<std::string, Section>::iterator sectionIt =
+      addSection(option.section, "");
 
   if (!option.shorthand.empty()) {
     if (!_shorthands.try_emplace(option.shorthand, option.fullName()).second) {
@@ -618,11 +619,7 @@ void ProgramOptions::addOption(Option&& option) {
   }
 
   Section& section = (*sectionIt).second;
-  if (!section.options.try_emplace(option.name, std::move(option)).second) {
-    throw std::logic_error(
-        std::string("duplicate option definition for option ") +
-        option.displayName());
-  }
+  section.options.try_emplace(option.name, std::move(option));
 }
 
 // modernize an option name

--- a/lib/ProgramOptions/ProgramOptions.cpp
+++ b/lib/ProgramOptions/ProgramOptions.cpp
@@ -607,8 +607,7 @@ void ProgramOptions::addPositional(std::string const& value) {
 // adds an option to the list of options
 void ProgramOptions::addOption(Option&& option) {
   checkIfSealed();
-  std::map<std::string, Section>::iterator sectionIt =
-      addSection(option.section, "");
+  auto sectionIt = addSection(option.section, "");
 
   if (!option.shorthand.empty()) {
     if (!_shorthands.try_emplace(option.shorthand, option.fullName()).second) {
@@ -619,7 +618,11 @@ void ProgramOptions::addOption(Option&& option) {
   }
 
   Section& section = (*sectionIt).second;
-  section.options.try_emplace(option.name, std::move(option));
+  if (!section.options.try_emplace(option.name, std::move(option)).second) {
+    throw std::logic_error(
+        std::string("duplicate option definition for option ") +
+        option.displayName());
+  }
 }
 
 // modernize an option name

--- a/tests/js/client/server_parameters/javascript-user-defined-functions-off.js
+++ b/tests/js/client/server_parameters/javascript-user-defined-functions-off.js
@@ -1,0 +1,70 @@
+/*jshint globalstrict:false, strict:false */
+/*global assertEqual, getOptions, fail */
+
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2010-2012 triagens GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is triAGENS GmbH, Cologne, Germany
+///
+/// @author Jan Steemann
+/// @author Copyright 2023, triAGENS GmbH, Cologne, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+if (getOptions === true) {
+  return {
+    'javascript.user-defined-functions': 'false',
+  };
+}
+
+const jsunity = require("jsunity");
+const arangodb = require("@arangodb");
+const udf = require("@arangodb/aql/functions");
+const db = arangodb.db;
+const ERRORS = arangodb.errors;
+
+function UserDefinedFunctionsTestSuite () {
+  return {
+
+    setUpAll : function () {
+      udf.register("some::func", function() { return 1; });
+    },
+
+    tearDownAll : function () {
+      udf.unregister("some::func");
+    },
+
+    testUseUDF : function () {
+      try {
+        // invoking a UDF should fail with a parse error
+        db._query("RETURN some::func()");
+        fail();
+      } catch (err) {
+        assertEqual(err.errorNum, ERRORS.ERROR_QUERY_PARSE.code);
+      }
+    },
+
+    testNormalAqlFunction : function () {
+      // invoking normal AQL functions should just work
+      let res = db._query("RETURN MAX([1, 2, 3])");
+      assertEqual([ 3 ], res.toArray());
+    },
+  };
+}
+
+jsunity.run(UserDefinedFunctionsTestSuite);
+
+return jsunity.done();


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/18048

Added startup option `--javascript.user-defined-functions`.

  This option controls whether JavaScript user-defined functions (UDFs) can
  be used in AQL queries. The option defaults to `true`. The option can be
  set to `false` to disallow using JavaScript UDFs from inside AQL queries.
  In that case, a parse error will be thrown when trying to run a query that
  invokes a UDF.

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.10: this PR
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -

#### Related Information

- [x] Docs PR: https://github.com/arangodb/docs/pull/1260
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 