### PR TITLE
Port #18044 directly to devel

### DIFF
--- a/js/common/modules/@arangodb/testutils/replicated-logs-helper.js
+++ b/js/common/modules/@arangodb/testutils/replicated-logs-helper.js
@@ -467,8 +467,12 @@ const testHelperFunctions = function (database, databaseOptions = {}) {
   };
 
   const stopServerWait = function (serverId) {
-    stopServer(serverId);
-    waitFor(lpreds.serverFailed(serverId));
+    stopServersWait([serverId]);
+  };
+
+  const stopServersWait = function (serverIds) {
+    serverIds.forEach(stopServer);
+    serverIds.forEach(serverId => waitFor(lpreds.serverFailed(serverId)));
   };
 
   const continueServer = function (serverId) {
@@ -480,14 +484,16 @@ const testHelperFunctions = function (database, databaseOptions = {}) {
   };
 
   const continueServerWait = function (serverId) {
-    continueServer(serverId);
-    waitFor(lpreds.serverHealthy(serverId));
+    continueServersWait([serverId]);
+  };
+
+  const continueServersWait = function (serverIds) {
+    serverIds.forEach(continueServer);
+    serverIds.forEach(serverId => waitFor(lpreds.serverHealthy(serverId)));
   };
 
   const resumeAll = function () {
-    Object.keys(stoppedServers).forEach(function (key) {
-      continueServerWait(key);
-    });
+    continueServersWait(Object.keys(stoppedServers));
     stoppedServers = {};
   };
 
@@ -536,8 +542,10 @@ const testHelperFunctions = function (database, databaseOptions = {}) {
   return {
     stopServer,
     stopServerWait,
+    stopServersWait,
     continueServer,
     continueServerWait,
+    continueServersWait,
     resumeAll,
     setUpAll,
     tearDownAll,

--- a/tests/js/client/shell/transaction/replication2_recovery/shell-transaction-replication2-recovery.js
+++ b/tests/js/client/shell/transaction/replication2_recovery/shell-transaction-replication2-recovery.js
@@ -1,5 +1,4 @@
 /* jshint globalstrict:false, strict:false, maxlen: 200 */
-/* global print */
 
 // //////////////////////////////////////////////////////////////////////////////
 // / @brief ArangoTransaction sTests
@@ -37,12 +36,14 @@ const _ = require('lodash');
 const db = arangodb.db;
 const helper = require('@arangodb/test-helper');
 const internal = require('internal');
+const print = internal.print;
 const replicatedStateHelper = require('@arangodb/testutils/replicated-state-helper');
 const replicatedLogsHelper = require('@arangodb/testutils/replicated-logs-helper');
 const replicatedLogsPredicates = require('@arangodb/testutils/replicated-logs-predicates');
 const replicatedStatePredicates = require('@arangodb/testutils/replicated-state-predicates');
 const replicatedLogsHttpHelper = require('@arangodb/testutils/replicated-logs-http-helper');
 const request = require('@arangodb/request');
+const console = require('console');
 
 /**
  * TODO this function is here temporarily and is will be removed once we have a better solution.
@@ -92,8 +93,17 @@ function transactionReplication2Recovery() {
   let shardId = null;
   let logId = null;
 
-  const { setUpAll, tearDownAll, stopServerWait, continueServerWait, setUpAnd, tearDownAnd } =
-    replicatedLogsHelper.testHelperFunctions(dbn, { replicationVersion: "2" });
+  const {
+    setUpAll,
+    tearDownAll,
+    stopServerWait,
+    stopServersWait,
+    continueServerWait,
+    continueServersWait,
+    setUpAnd,
+    tearDownAnd,
+  } =
+    replicatedLogsHelper.testHelperFunctions(dbn, {replicationVersion: '2'});
 
   return {
     setUpAll,
@@ -346,9 +356,7 @@ function transactionReplication2Recovery() {
       });
 
       // Stop all servers except for the leader.
-      for (const serverId of allOtherServers) {
-        stopServerWait(serverId);
-      }
+      stopServersWait(allOtherServers);
 
       let tc = trx.collection(c.name());
       tc.insert({_key: 'test1', value: 1});
@@ -363,18 +371,22 @@ function transactionReplication2Recovery() {
         "test1", false));
 
       // Resume enough participants to reach write concern.
-      for (let cnt = 0; cnt < WC - 1; ++cnt) {
-        continueServerWait(followers[cnt]);
-      }
+      continueServersWait(followers.slice(0, WC - 1));
 
       // Expect the transaction to be committed
       replicatedLogsHelper.waitFor(replicatedStatePredicates.localKeyStatus(leaderServer, dbn, shardId,
         "test1", true, 1));
-      for (let cnt = 0; cnt < WC - 1; ++cnt) {
-        let server = replicatedLogsHelper.getServerUrl(followers[cnt]);
-        replicatedLogsHelper.waitFor(replicatedStatePredicates.localKeyStatus(server, dbn, shardId,
-          "test1", true, 1));
-      }
+      // TODO Uncomment this, after https://arangodb.atlassian.net/browse/CINFRA-668 is addressed.
+      //      Currently, this can occasionally fail, if the replicated state is recreated (due to the change in
+      //      RebootId) *after* the replicated log on the follower is completely up-to-date (including commit index),
+      //      but *before* the latest entries have been applied to the replicated state.
+      //      Because then, the leader has no reason to send new append entries requests, while the follower's log
+      //      still has a freshly initialized commit index of 0.
+      // for (let cnt = 0; cnt < WC - 1; ++cnt) {
+      //   let server = replicatedLogsHelper.getServerUrl(followers[cnt]);
+      //   replicatedLogsHelper.waitFor(replicatedStatePredicates.localKeyStatus(server, dbn, shardId,
+      //     "test1", true, 1));
+      // }
     },
   };
 }


### PR DESCRIPTION
In order to get rid of the spurious failures of `testCannotReachWriteConcernDuringTransaction` in Jenkins more quickly, get this relevant part of #18044 directly to devel.