### PR TITLE
disable jemalloc cache_oblivious behavior

### DIFF
--- a/3rdParty/jemalloc/CMakeLists.txt
+++ b/3rdParty/jemalloc/CMakeLists.txt
@@ -28,7 +28,7 @@ if (LINUX OR DARWIN)
   else ()
     set(JEMALLOC_CC_TMP "${CMAKE_C_COMPILER}")
     set(JEMALLOC_CXX_TMP "${CMAKE_CXX_COMPILER}")
-    set(JEMALLOC_CONFIG "background_thread:true")
+    set(JEMALLOC_CONFIG "background_thread:true,cache_oblivious:false")
   endif ()
 
   if (USE_JEMALLOC_PROF)

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 v3.10.4 (XXXX-XX-XX)
 --------------------
 
+* Set the cache_oblivious option of jemalloc to `false` by default. This helps
+  to save 4096 bytes of RAM for every allocation which is at least 16384 bytes
+  large. This is particularly beneficial for the RocksDB buffer cache.
+
 * Activate RDB_CoveringIterator and use it for some geo index queries.
   This speeds up and simplifies geo queries with geo index which do not use
   GEO_DISTANCE.


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/17870

Set the cache_oblivious option of jemalloc to `false` by default. This helps to save 4096 bytes of RAM for every allocation which is at least 16384 bytes large. This is particularly beneficial for the RocksDB buffer cache.

After we have added configurability for jemalloc's cache_oblivious option to 3.10.3 with a previous PR, this PR now disables the cache_oblivious option. This should help to save memory for allocations of size 16kb.

Note: we need to check performance results for this PR, because it can have an effect on allocator performance.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [x] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [x] Backports
  - [x] Backport for 3.10: this PR
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 