### PR TITLE
fix issues reported by cppcheck

### DIFF
--- a/arangod/Aql/DocumentProducingNode.cpp
+++ b/arangod/Aql/DocumentProducingNode.cpp
@@ -63,7 +63,8 @@ DocumentProducingNode::DocumentProducingNode(ExecutionPlan* plan,
   if (!p.isNone()) {
     Ast* ast = plan->getAst();
     // new AstNode is memory-managed by the Ast
-    setFilter(std::make_unique<Expression>(ast, ast->createNode(p)));
+    DocumentProducingNode::setFilter(
+        std::make_unique<Expression>(ast, ast->createNode(p)));
   }
 
   _count = arangodb::basics::VelocyPackHelper::getBooleanValue(slice, "count",

--- a/arangod/Aql/ShadowAqlItemRow.cpp
+++ b/arangod/Aql/ShadowAqlItemRow.cpp
@@ -33,6 +33,7 @@ using namespace arangodb::aql;
 ShadowAqlItemRow::ShadowAqlItemRow(SharedAqlItemBlockPtr block,
                                    size_t baseIndex)
     : _block(std::move(block)), _baseIndex(baseIndex) {
+  // cppcheck-suppress ignoredReturnValue
   TRI_ASSERT(isInitialized());
   TRI_ASSERT(_baseIndex < _block->numRows());
   TRI_ASSERT(_block->isShadowRow(_baseIndex));
@@ -54,6 +55,7 @@ bool ShadowAqlItemRow::internalBlockIs(SharedAqlItemBlockPtr const& other,
 #endif
 
 AqlValue const& ShadowAqlItemRow::getValue(RegisterId registerId) const {
+  // cppcheck-suppress ignoredReturnValue
   TRI_ASSERT(isInitialized());
   TRI_ASSERT(registerId.isRegularRegister());
   TRI_ASSERT(registerId < getNumRegisters());
@@ -61,6 +63,7 @@ AqlValue const& ShadowAqlItemRow::getValue(RegisterId registerId) const {
 }
 
 AqlValue ShadowAqlItemRow::stealAndEraseValue(RegisterId registerId) {
+  // cppcheck-suppress ignoredReturnValue
   TRI_ASSERT(isInitialized());
   TRI_ASSERT(registerId < getNumRegisters());
   // caller needs to take immediate ownership.
@@ -68,11 +71,13 @@ AqlValue ShadowAqlItemRow::stealAndEraseValue(RegisterId registerId) {
 }
 
 size_t ShadowAqlItemRow::getShadowDepthValue() const {
+  // cppcheck-suppress ignoredReturnValue
   TRI_ASSERT(isInitialized());
   return block().getShadowRowDepth(_baseIndex);
 }
 
 uint64_t ShadowAqlItemRow::getDepth() const {
+  // cppcheck-suppress ignoredReturnValue
   TRI_ASSERT(isInitialized());
   return static_cast<uint64_t>(block().getShadowRowDepth(_baseIndex));
 }

--- a/lib/Basics/ErrorT.h
+++ b/lib/Basics/ErrorT.h
@@ -69,6 +69,7 @@ struct ErrorT {
   [[nodiscard]] auto operator*() & -> T& { return get(); }
   [[nodiscard]] auto operator*() const& -> T const& { return get(); }
 
+  // cppcheck-suppress returnStdMoveLocal
   [[nodiscard]] auto operator*() && -> T&& { return std::move(get()); }
 
  private:

--- a/lib/Basics/SourceLocation.h
+++ b/lib/Basics/SourceLocation.h
@@ -30,18 +30,19 @@ namespace arangodb::basics {
 // Poor-man's replacement for std::source_location, until we get C++20.
 struct SourceLocation {
  private:
-  const char* _file_name;
+  char const* _fileName;
   int _line;
 
  public:
   SourceLocation() = delete;
-  constexpr SourceLocation(decltype(_file_name) file,
+  // cppcheck-suppress unknownMacro
+  constexpr SourceLocation(decltype(_fileName) file,
                            decltype(_line) line) noexcept
-      : _file_name(file), _line(line) {}
+      : _fileName(file), _line(line) {}
 
   [[nodiscard]] constexpr auto file_name() const noexcept
-      -> decltype(_file_name) {
-    return _file_name;
+      -> decltype(_fileName) {
+    return _fileName;
   }
   [[nodiscard]] constexpr auto line() const noexcept -> decltype(_line) {
     return _line;


### PR DESCRIPTION
### Scope & Purpose

Fix the following issues reported by cppcheck:

```
<results version="2">
  <cppcheck version="2.8"/>
  <errors>
    <error id="virtualCallInConstructor" severity="style" msg="Virtual function 'setFilter' is called from constructor 'DocumentProducingNode(ExecutionPlan*plan,arangodb::velocypack::Slice slice)' at line 66. Dynamic binding is not used." verbose="Virtual function 'setFilter' is called from constructor 'DocumentProducingNode(ExecutionPlan*plan,arangodb::velocypack::Slice slice)' at line 66. Dynamic binding is not used." file0="arangod/Aql/DocumentProducingNode.cpp">
      <location file="./work/ArangoDB/arangod/Aql/DocumentProducingNode.h" line="71" column="16" info="setFilter is a virtual function"/>
      <location file="./work/ArangoDB/arangod/Aql/DocumentProducingNode.cpp" line="66" column="5" info="Calling setFilter"/>
    </error>
    <error id="ignoredReturnValue" severity="warning" msg="Return value of function isInitialized() is not used." verbose="Return value of function isInitialized() is not used." cwe="252" file0="arangod/Aql/ShadowAqlItemRow.cpp">
      <location file="./work/ArangoDB/arangod/Aql/ShadowAqlItemRow.cpp" line="36" column="3"/>
    </error>
    <error id="ignoredReturnValue" severity="warning" msg="Return value of function isInitialized() is not used." verbose="Return value of function isInitialized() is not used." cwe="252" file0="arangod/Aql/ShadowAqlItemRow.cpp">
      <location file="./work/ArangoDB/arangod/Aql/ShadowAqlItemRow.cpp" line="57" column="3"/>
    </error>
    <error id="ignoredReturnValue" severity="warning" msg="Return value of function isInitialized() is not used." verbose="Return value of function isInitialized() is not used." cwe="252" file0="arangod/Aql/ShadowAqlItemRow.cpp">
    </error>
    <error id="ignoredReturnValue" severity="warning" msg="Return value of function isInitialized() is not used." verbose="Return value of function isInitialized() is not used." cwe="252" file0="arangod/Aql/ShadowAqlItemRow.cpp">
      <location file="./work/ArangoDB/arangod/Aql/ShadowAqlItemRow.cpp" line="71" column="3"/>
    </error>
    <error id="ignoredReturnValue" severity="warning" msg="Return value of function isInitialized() is not used." verbose="Return value of function isInitialized() is not used." cwe="252" file0="arangod/Aql/ShadowAqlItemRow.cpp">
      <location file="./work/ArangoDB/arangod/Aql/ShadowAqlItemRow.cpp" line="76" column="3"/>
    </error>
    <error id="returnStdMoveLocal" severity="performance" msg="Using std::move for returning object by-value from function will affect copy elision optimization. More: https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rf-return-move-local" verbose="Using std::move for returning object by-value from function will affect copy elision optimization. More: https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rf-return-move-local" file0="arangod/Pregel/ExecutionNumber.cpp">
      <location file="./work/ArangoDB/lib/Basics/ErrorT.h" line="72" column="66"/>
    </error>
    <error id="unknownMacro" severity="error" msg="There is an unknown macro here somewhere. Configuration is required. If decltype is a macro then please configure it." verbose="There is an unknown macro here somewhere. Configuration is required. If decltype is a macro then please configure it." file0="lib/Basics/SourceLocation.h">
      <location file="./work/ArangoDB/lib/Basics/SourceLocation.h" line="38" column="28"/>
    </error>
  </errors>
</results>
````

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: -
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 