### PR TITLE
BTS-1193 backport for 3.9

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 v3.9.8 (2023-01-23)
 -------------------
 
+* BTS-1193: Fix for schema update. When removing a field and then inserting a
+  new field into the schema, previously, both old and new schema would be
+  merged, meaning it would maintain the old field and add the new one.
+
 * Log information about follower state/apply progress in supervision job that
   organizes failover in active failover mode.
 

--- a/arangod/Cluster/ClusterInfo.cpp
+++ b/arangod/Cluster/ClusterInfo.cpp
@@ -3679,8 +3679,8 @@ Result ClusterInfo::setCollectionPropertiesCoordinator(
   info->getPhysical()->getPropertiesVPack(temp);
   temp.close();
 
-  VPackBuilder builder = VPackCollection::merge(collection, temp.slice(), true);
-
+  VPackBuilder builder =
+      VPackCollection::merge(collection, temp.slice(), false);
   AgencyOperation setColl(
       "Plan/Collections/" + databaseName + "/" + collectionID,
       AgencyValueOperationType::SET, builder.slice());

--- a/tests/js/client/shell/shell-dump-integration.js
+++ b/tests/js/client/shell/shell-dump-integration.js
@@ -34,14 +34,38 @@ let pu = require('@arangodb/testutils/process-utils');
 let db = arangodb.db;
 let isCluster = require("internal").isCluster();
 let dbs = ["_system", "maçã", "😀", "ﻚﻠﺑ ﻞﻄﻴﻓ", "testName"];
+const validatorJson = {
+  "message": "",
+  "level": "new",
+  "type": "json",
+  "rule": {
+    "additionalProperties": true,
+    "properties": {
+      "value1": {
+        "type": "integer"
+      },
+      "value2": {
+        "type": "string"
+      },
+      "name": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "value1",
+      "value2"
+    ],
+    "type": "object"
+  }
+};
 
-function checkDumpJsonFile (dbName, path, id) {
+function checkDumpJsonFile(dbName, path, id) {
   let data = JSON.parse(fs.readFileSync(fs.join(path, "dump.json")).toString());
   assertEqual(dbName, data.properties.name);
   assertEqual(id, data.properties.id);
 }
 
-function dumpIntegrationSuite () {
+function dumpIntegrationSuite() {
   'use strict';
   const cn = 'UnitTestsDump';
   // detect the path of arangodump. quite hacky, but works
@@ -49,11 +73,11 @@ function dumpIntegrationSuite () {
 
   assertTrue(fs.isFile(arangodump), "arangodump not found!");
 
-  let addConnectionArgs = function(args) {
+  let addConnectionArgs = function (args) {
     let endpoint = arango.getEndpoint().replace(/\+vpp/, '').replace(/^http:/, 'tcp:').replace(/^https:/, 'ssl:').replace(/^vst:/, 'tcp:').replace(/^h2:/, 'tcp:');
     args.push('--server.endpoint');
     args.push(endpoint);
-    if(args.indexOf("--all-databases") === -1) {
+    if (args.indexOf("--all-databases") === -1) {
       args.push('--server.database');
       args.push(arango.getDatabaseName());
     }
@@ -61,10 +85,11 @@ function dumpIntegrationSuite () {
     args.push(arango.connectedUser());
   };
 
-  let runDump = function(path, args, rc) {
+  let runDump = function (path, args, rc) {
     try {
       fs.removeDirectory(path);
-    } catch (err) {}
+    } catch (err) {
+    }
 
     args.push('--output-directory');
     args.push(path);
@@ -76,13 +101,13 @@ function dumpIntegrationSuite () {
     return fs.listTree(path);
   };
 
-  let checkEncryption = function(tree, path, expected) {
+  let checkEncryption = function (tree, path, expected) {
     assertNotEqual(-1, tree.indexOf("ENCRYPTION"));
     let data = fs.readFileSync(fs.join(path, "ENCRYPTION")).toString();
     assertEqual(expected, data);
   };
 
-  let structureFile = function(path, cn) {
+  let structureFile = function (path, cn) {
     const prefix = cn + "_" + require("@arangodb/crypto").md5(cn);
     let structure = prefix + ".structure.json";
     if (!fs.isFile(fs.join(path, structure))) {
@@ -91,14 +116,14 @@ function dumpIntegrationSuite () {
     }
     return structure;
   };
-  
-  let checkStructureFile = function(tree, path, readable, cn, subdir="") {
+
+  let checkStructureFile = function (tree, path, readable, cn, subdir = "") {
     let structurePath = path;
-    if(subdir !== "") {
+    if (subdir !== "") {
       structurePath = fs.join(path, subdir);
     }
     let structure = structureFile(structurePath, cn);
-    if(subdir !== "") {
+    if (subdir !== "") {
       structure = fs.join(subdir, structure);
     }
     assertTrue(fs.isFile(fs.join(path, structure)), structure);
@@ -107,6 +132,11 @@ function dumpIntegrationSuite () {
     if (readable) {
       let data = JSON.parse(fs.readFileSync(fs.join(path, structure)).toString());
       assertEqual(cn, data.parameters.name);
+      if (cn.endsWith("WithSchema")) {
+        assertTrue(data.parameters.hasOwnProperty("schema"));
+        const schema = data.parameters.schema;
+        assertEqual(schema, validatorJson);
+      }
     } else {
       try {
         // cannot read encrypted file
@@ -119,20 +149,20 @@ function dumpIntegrationSuite () {
     }
   };
 
-  let checkCollections = function (tree, path, subdir="") {
+  let checkCollections = function (tree, path, subdir = "") {
     db._collections().forEach((collectionObj) => {
       const collectionName = collectionObj.name();
-      if(!collectionName.startsWith("_")) {
+      if (!collectionName.startsWith("_")) {
         checkStructureFile(tree, path, true, collectionName, subdir);
       }
     });
   };
 
-  let checkDataFile = function(tree, path, compressed, envelopes, readable, cn) {
+  let checkDataFile = function (tree, path, compressed, envelopes, readable, cn) {
     const prefix = cn + "_" + require("@arangodb/crypto").md5(cn);
-    let checkData = function(data, envelopes) {
+    let checkData = function (data, envelopes) {
       assertEqual(1000, data.length);
-      data.forEach(function(line) {
+      data.forEach(function (line) {
         line = JSON.parse(line);
         if (envelopes) {
           assertEqual(2300, line.type);
@@ -153,13 +183,13 @@ function dumpIntegrationSuite () {
 
       assertNotEqual(-1, tree.indexOf(prefix + ".data.json.gz"));
       assertEqual(-1, tree.indexOf(prefix + ".data.json"));
-      
+
       let data = fs.readGzip(fs.join(path, prefix + ".data.json.gz")).toString().trim().split('\n');
       checkData(data, envelopes);
     } else {
       assertEqual(-1, tree.indexOf(prefix + ".data.json.gz"));
       assertNotEqual(-1, tree.indexOf(prefix + ".data.json"));
-      
+
       if (readable) {
         let data = fs.readFileSync(fs.join(path, prefix + ".data.json")).toString().trim().split('\n');
         checkData(data, envelopes);
@@ -179,61 +209,83 @@ function dumpIntegrationSuite () {
   return {
 
     setUpAll: function () {
-      
-      
+
+
       dbs.forEach((name) => {
-        if(name !== "_system") {
+        if (name !== "_system") {
           db._useDatabase("_system");
           db._createDatabase(name);
         }
         db._useDatabase(name);
         db._drop(cn);
-        let c = db._create(cn, { numberOfShards: 3 });
+        let c = db._create(cn, {numberOfShards: 3});
         let docs = [];
         for (let i = 0; i < 1000; ++i) {
-          docs.push({ _key: "test" + i });
+          docs.push({_key: "test" + i});
         }
         c.insert(docs);
-        
+
         db._drop(cn + "Other");
-        c = db._create(cn + "Other", { numberOfShards: 3 });
+        c = db._create(cn + "Other", {numberOfShards: 3});
         c.insert(docs);
-        
+
         db._drop(cn + "Padded");
-        c = db._create(cn + "Padded", { keyOptions: { type: "padded" }, numberOfShards: 3 });
+        c = db._create(cn + "Padded", {keyOptions: {type: "padded"}, numberOfShards: 3});
         docs = [];
         for (let i = 0; i < 1000; ++i) {
           docs.push({});
         }
         c.insert(docs);
-        
+
         db._drop(cn + "AutoIncrement");
         if (!isCluster) {
-          c = db._create(cn + "AutoIncrement", { keyOptions: { type: "autoincrement" }, numberOfShards: 3 });
+          c = db._create(cn + "AutoIncrement", {keyOptions: {type: "autoincrement"}, numberOfShards: 3});
           docs = [];
           for (let i = 0; i < 1000; ++i) {
             docs.push({});
           }
           c.insert(docs);
         }
-
+        c = db._create(cn + "WithSchema", {schema: validatorJson, numberOfShards: 3});
+        docs = [];
+        for (let i = 0; i < 1000; ++i) {
+          docs.push({value1: i, value2: "abc"});
+        }
+        c.insert(docs);
       });
     },
 
     tearDownAll: function () {
       db._useDatabase("_system");
       dbs.forEach((name) => {
-        if(name === "_system") {
+        if (name === "_system") {
           db._drop(cn);
           db._drop(cn + "Other");
           db._drop(cn + "Padded");
           db._drop(cn + "AutoIncrement");
+          db._drop(cn + "WithSchema");
         } else {
           db._dropDatabase(name);
         }
       });
     },
-    
+
+    testDumpForCollectionWithSchema: function () {
+      let path = fs.getTempFile();
+      try {
+        let args = ['--collection', cn + "WithSchema", '--compress-output', 'false'];
+        let tree = runDump(path, args, 0);
+        checkEncryption(tree, path, "none");
+        checkStructureFile(tree, path, true, cn + "WithSchema");
+        checkDataFile(tree, path, false, false, false, cn + "WithSchema");
+      } finally {
+        try {
+          fs.removeDirectory(path);
+        } catch (err) {
+        }
+      }
+    },
+
     testDumpOnlyOneShard: function () {
       if (!isCluster) {
         return;
@@ -248,8 +300,8 @@ function dumpIntegrationSuite () {
       assertEqual(3, shards.length);
       try {
         let args = ['--collection', cn, '--dump-data', 'true', '--compress-output', 'false', '--shard', shards[0]];
-        let tree = runDump(path, args, 0); 
-   
+        let tree = runDump(path, args, 0);
+
         const prefix = cn + "_" + require("@arangodb/crypto").md5(cn);
         let file = fs.join(path, prefix + '.data.json');
         let data = fs.readFileSync(file).toString();
@@ -257,10 +309,11 @@ function dumpIntegrationSuite () {
       } finally {
         try {
           fs.removeDirectory(path);
-        } catch (err) {}
+        } catch (err) {
+        }
       }
     },
-    
+
     testDumpOnlyTwoShards: function () {
       if (!isCluster) {
         return;
@@ -275,8 +328,8 @@ function dumpIntegrationSuite () {
       assertEqual(3, shards.length);
       try {
         let args = ['--collection', cn, '--dump-data', 'true', '--compress-output', 'false', '--shard', shards[0], '--shard', shards[1]];
-        let tree = runDump(path, args, 0); 
-   
+        let tree = runDump(path, args, 0);
+
         const prefix = cn + "_" + require("@arangodb/crypto").md5(cn);
         let file = fs.join(path, prefix + '.data.json');
         let data = fs.readFileSync(file).toString();
@@ -284,10 +337,11 @@ function dumpIntegrationSuite () {
       } finally {
         try {
           fs.removeDirectory(path);
-        } catch (err) {}
+        } catch (err) {
+        }
       }
     },
-   
+
     testDumpAutoIncrementKeyGenerator: function () {
       if (isCluster) {
         // autoincrement key generator is not supported in cluster
@@ -297,7 +351,7 @@ function dumpIntegrationSuite () {
       let path = fs.getTempFile();
       try {
         let args = ['--collection', cn + 'AutoIncrement', '--dump-data', 'false'];
-        let tree = runDump(path, args, 0); 
+        let tree = runDump(path, args, 0);
         checkStructureFile(tree, path, true, cn + 'AutoIncrement');
         let structure = structureFile(path, cn + 'AutoIncrement');
         let data = JSON.parse(fs.readFileSync(fs.join(path, structure)).toString());
@@ -312,15 +366,16 @@ function dumpIntegrationSuite () {
       } finally {
         try {
           fs.removeDirectory(path);
-        } catch (err) {}
+        } catch (err) {
+        }
       }
     },
-    
+
     testDumpPaddedKeyGenerator: function () {
       let path = fs.getTempFile();
       try {
         let args = ['--collection', cn + 'Padded', '--dump-data', 'false'];
-        let tree = runDump(path, args, 0); 
+        let tree = runDump(path, args, 0);
         checkStructureFile(tree, path, true, cn + 'Padded');
         let structure = structureFile(path, cn + 'Padded');
         let data = JSON.parse(fs.readFileSync(fs.join(path, structure)).toString());
@@ -335,10 +390,11 @@ function dumpIntegrationSuite () {
       } finally {
         try {
           fs.removeDirectory(path);
-        } catch (err) {}
+        } catch (err) {
+        }
       }
     },
-    
+
     testDumpSingleDatabase: function () {
       dbs.forEach((name) => {
         let path = fs.getTempFile();
@@ -351,7 +407,8 @@ function dumpIntegrationSuite () {
         } finally {
           try {
             fs.removeDirectory(path);
-          } catch (err) {}
+          } catch (err) {
+          }
         }
       });
     },
@@ -363,43 +420,44 @@ function dumpIntegrationSuite () {
         let tree = runDump(path, args, 0);
         db._useDatabase("maçã");
         assertEqual(-1, tree.indexOf("maçã"));
-        assertNotEqual(-1, tree.indexOf(db._id())); 
+        assertNotEqual(-1, tree.indexOf(db._id()));
         checkDumpJsonFile("maçã", fs.join(path, db._id()), db._id());
         checkCollections(tree, path, db._id());
         db._useDatabase("_system");
         assertNotEqual(-1, tree.indexOf("_system"));
-        assertEqual(-1, tree.indexOf(db._id())); 
+        assertEqual(-1, tree.indexOf(db._id()));
         checkDumpJsonFile("_system", fs.join(path, db._name()), db._id());
         checkCollections(tree, path, db._name());
         db._useDatabase("testName");
         assertNotEqual(-1, tree.indexOf("testName"));
-        assertEqual(-1, tree.indexOf(db._id())); 
+        assertEqual(-1, tree.indexOf(db._id()));
         checkDumpJsonFile("testName", fs.join(path, db._name()), db._id());
         checkCollections(tree, path, db._name());
         db._useDatabase("😀");
-        assertEqual(-1, tree.indexOf("😀")); 
+        assertEqual(-1, tree.indexOf("😀"));
         assertNotEqual(-1, tree.indexOf(db._id()));
         checkDumpJsonFile("😀", fs.join(path, db._id()), db._id());
         checkCollections(tree, path, db._id());
         db._useDatabase("ﻚﻠﺑ ﻞﻄﻴﻓ");
         assertEqual(-1, tree.indexOf("ﻚﻠﺑ ﻞﻄﻴﻓ"));
         assertNotEqual(-1, tree.indexOf(db._id()));
-        checkDumpJsonFile("ﻚﻠﺑ ﻞﻄﻴﻓ", fs.join(path, db._id()), db._id()); 
+        checkDumpJsonFile("ﻚﻠﺑ ﻞﻄﻴﻓ", fs.join(path, db._id()), db._id());
         checkCollections(tree, path, db._id());
       } finally {
         try {
           fs.removeDirectory(path);
           db._useDatabase("_system");
-        } catch (err) {}
+        } catch (err) {
+        }
       }
     },
-    
+
     testDumpAllDatabasesWithOverwrite: function () {
       let path = fs.getTempFile();
       try {
         let args = ['--all-databases', 'true'];
         runDump(path, args, 0);
-        
+
         // run the dump a second time, to overwrite all data in the target directory
         args.push('--overwrite');
         args.push('true');
@@ -407,34 +465,35 @@ function dumpIntegrationSuite () {
         let tree = runDump(path, args, 0);
         db._useDatabase("maçã");
         assertEqual(-1, tree.indexOf("maçã"));
-        assertNotEqual(-1, tree.indexOf(db._id())); 
+        assertNotEqual(-1, tree.indexOf(db._id()));
         checkDumpJsonFile("maçã", fs.join(path, db._id()), db._id());
         checkCollections(tree, path, db._id());
         db._useDatabase("_system");
         assertNotEqual(-1, tree.indexOf("_system"));
-        assertEqual(-1, tree.indexOf(db._id())); 
+        assertEqual(-1, tree.indexOf(db._id()));
         checkDumpJsonFile("_system", fs.join(path, db._name()), db._id());
         checkCollections(tree, path, db._name());
         db._useDatabase("testName");
         assertNotEqual(-1, tree.indexOf("testName"));
-        assertEqual(-1, tree.indexOf(db._id())); 
+        assertEqual(-1, tree.indexOf(db._id()));
         checkDumpJsonFile("testName", fs.join(path, db._name()), db._id());
         checkCollections(tree, path, db._name());
         db._useDatabase("😀");
-        assertEqual(-1, tree.indexOf("😀")); 
+        assertEqual(-1, tree.indexOf("😀"));
         assertNotEqual(-1, tree.indexOf(db._id()));
         checkDumpJsonFile("😀", fs.join(path, db._id()), db._id());
         checkCollections(tree, path, db._id());
         db._useDatabase("ﻚﻠﺑ ﻞﻄﻴﻓ");
         assertEqual(-1, tree.indexOf("ﻚﻠﺑ ﻞﻄﻴﻓ"));
         assertNotEqual(-1, tree.indexOf(db._id()));
-        checkDumpJsonFile("ﻚﻠﺑ ﻞﻄﻴﻓ", fs.join(path, db._id()), db._id()); 
+        checkDumpJsonFile("ﻚﻠﺑ ﻞﻄﻴﻓ", fs.join(path, db._id()), db._id());
         checkCollections(tree, path, db._id());
       } finally {
         try {
           fs.removeDirectory(path);
           db._useDatabase("_system");
-        } catch (err) {}
+        } catch (err) {
+        }
       }
     },
 
@@ -450,17 +509,18 @@ function dumpIntegrationSuite () {
         fs.writeFileSync(keyfile, "01234567890123456789012345678901");
 
         let args = ['--compress-output', 'true', '--envelope', 'true', '--encryption.keyfile', keyfile, '--collection', cn];
-        let tree = runDump(path, args, 0); 
+        let tree = runDump(path, args, 0);
         checkEncryption(tree, path, "aes-256-ctr");
         checkStructureFile(tree, path, false, cn);
         checkDataFile(tree, path, false, true, false, cn);
       } finally {
         try {
           fs.removeDirectory(path);
-        } catch (err) {}
+        } catch (err) {
+        }
       }
     },
-    
+
     testDumpCompressedEncryptedNoEnvelope: function () {
       if (!require("internal").isEnterprise()) {
         return;
@@ -473,61 +533,64 @@ function dumpIntegrationSuite () {
         fs.writeFileSync(keyfile, "01234567890123456789012345678901");
 
         let args = ['--compress-output', 'true', '--envelope', 'false', '--encryption.keyfile', keyfile, '--collection', cn];
-        let tree = runDump(path, args, 0); 
+        let tree = runDump(path, args, 0);
         checkEncryption(tree, path, "aes-256-ctr");
         checkStructureFile(tree, path, false, cn);
         checkDataFile(tree, path, false, false, false, cn);
       } finally {
         try {
           fs.removeDirectory(path);
-        } catch (err) {}
+        } catch (err) {
+        }
       }
     },
-    
+
     testDumpOverwriteUncompressedWithEnvelope: function () {
       let path = fs.getTempFile();
       try {
         let args = ['--compress-output', 'false', '--envelope', 'true', '--collection', cn];
-        let tree = runDump(path, args, 0); 
+        let tree = runDump(path, args, 0);
         checkEncryption(tree, path, "none");
         checkStructureFile(tree, path, true, cn);
         checkDataFile(tree, path, false, true, true, cn);
-        
+
         // second dump, which overwrites
         args = ['--compress-output', 'false', '--envelope', 'true', '--overwrite', 'true', '--collection', cn];
-        tree = runDump(path, args, 0); 
+        tree = runDump(path, args, 0);
         checkEncryption(tree, path, "none");
         checkStructureFile(tree, path, true, cn);
         checkDataFile(tree, path, false, true, true, cn);
       } finally {
         try {
           fs.removeDirectory(path);
-        } catch (err) {}
+        } catch (err) {
+        }
       }
     },
-    
+
     testDumpOverwriteUncompressedNoEnvelope: function () {
       let path = fs.getTempFile();
       try {
         let args = ['--compress-output', 'false', '--envelope', 'true', '--collection', cn];
-        let tree = runDump(path, args, 0); 
+        let tree = runDump(path, args, 0);
         checkEncryption(tree, path, "none");
         checkStructureFile(tree, path, true, cn);
         checkDataFile(tree, path, false, true, true, cn);
-        
+
         // second dump, which overwrites
         args = ['--compress-output', 'false', '--envelope', 'false', '--overwrite', 'true', '--collection', cn];
-        tree = runDump(path, args, 0); 
+        tree = runDump(path, args, 0);
         checkEncryption(tree, path, "none");
         checkStructureFile(tree, path, true, cn);
         checkDataFile(tree, path, false, false, true, cn);
       } finally {
         try {
           fs.removeDirectory(path);
-        } catch (err) {}
+        } catch (err) {
+        }
       }
     },
-    
+
     testDumpCompressedEncrypted: function () {
       if (!require("internal").isEnterprise()) {
         return;
@@ -540,31 +603,33 @@ function dumpIntegrationSuite () {
         fs.writeFileSync(keyfile, "01234567890123456789012345678901");
 
         let args = ['--compress-output', 'true', '--encryption.keyfile', keyfile, '--collection', cn];
-        let tree = runDump(path, args, 0); 
+        let tree = runDump(path, args, 0);
         checkEncryption(tree, path, "aes-256-ctr");
         checkStructureFile(tree, path, false, cn);
         checkDataFile(tree, path, false, true, false, cn);
       } finally {
         try {
           fs.removeDirectory(path);
-        } catch (err) {}
+        } catch (err) {
+        }
       }
     },
-    
+
     testDumpOverwriteDisabled: function () {
       let path = fs.getTempFile();
       try {
         let args = ['--collection', cn];
-        let tree = runDump(path, args, 0); 
+        let tree = runDump(path, args, 0);
         checkEncryption(tree, path, "none");
-       
+
         // second dump, without overwrite
         // this is expected to have an exit code of 1
         runDump(path, args, 1 /*exit code*/);
       } finally {
         try {
           fs.removeDirectory(path);
-        } catch (err) {}
+        } catch (err) {
+        }
       }
     },
 
@@ -572,46 +637,48 @@ function dumpIntegrationSuite () {
       let path = fs.getTempFile();
       try {
         let args = ['--compress-output', 'true', '--collection', cn];
-        let tree = runDump(path, args, 0); 
+        let tree = runDump(path, args, 0);
         checkEncryption(tree, path, "none");
         checkStructureFile(tree, path, true, cn);
         checkDataFile(tree, path, true, false, true, cn);
-        
+
         // second dump, which overwrites
         args = ['--compress-output', 'true', '--overwrite', 'true', '--collection', cn];
-        tree = runDump(path, args, 0); 
+        tree = runDump(path, args, 0);
         checkEncryption(tree, path, "none");
         checkStructureFile(tree, path, true, cn);
         checkDataFile(tree, path, true, false, true, cn);
       } finally {
         try {
           fs.removeDirectory(path);
-        } catch (err) {}
+        } catch (err) {
+        }
       }
     },
-    
+
     testDumpOverwriteUncompressed: function () {
       let path = fs.getTempFile();
       try {
         let args = ['--compress-output', 'false', '--collection', cn];
-        let tree = runDump(path, args, 0); 
+        let tree = runDump(path, args, 0);
         checkEncryption(tree, path, "none");
         checkStructureFile(tree, path, true, cn);
         checkDataFile(tree, path, false, false, true, cn);
-        
+
         // second dump, which overwrites
         args = ['--compress-output', 'false', '--overwrite', 'true', '--collection', cn];
-        tree = runDump(path, args, 0); 
+        tree = runDump(path, args, 0);
         checkEncryption(tree, path, "none");
         checkStructureFile(tree, path, true, cn);
         checkDataFile(tree, path, false, false, true, cn);
       } finally {
         try {
           fs.removeDirectory(path);
-        } catch (err) {}
+        } catch (err) {
+        }
       }
     },
-    
+
     testDumpOverwriteEncrypted: function () {
       if (!require("internal").isEnterprise()) {
         return;
@@ -624,24 +691,25 @@ function dumpIntegrationSuite () {
         fs.writeFileSync(keyfile, "01234567890123456789012345678901");
 
         let args = ['--compress-output', 'false', '--encryption.keyfile', keyfile, '--collection', cn];
-        let tree = runDump(path, args, 0); 
+        let tree = runDump(path, args, 0);
         checkEncryption(tree, path, "aes-256-ctr");
         checkStructureFile(tree, path, false, cn);
         checkDataFile(tree, path, false, true, false, cn);
 
         // second dump, which overwrites
         args = ['--compress-output', 'false', '--encryption.keyfile', keyfile, '--overwrite', 'true', '--collection', cn];
-        tree = runDump(path, args, 0); 
+        tree = runDump(path, args, 0);
         checkEncryption(tree, path, "aes-256-ctr");
         checkStructureFile(tree, path, false, cn);
         checkDataFile(tree, path, false, true, false, cn);
       } finally {
         try {
           fs.removeDirectory(path);
-        } catch (err) {}
+        } catch (err) {
+        }
       }
     },
-    
+
     testDumpOverwriteCompressedWithEncrypted: function () {
       if (!require("internal").isEnterprise()) {
         return;
@@ -654,11 +722,11 @@ function dumpIntegrationSuite () {
         fs.writeFileSync(keyfile, "01234567890123456789012345678901");
 
         let args = ['--compress-output', 'true', '--collection', cn];
-        let tree = runDump(path, args, 0); 
+        let tree = runDump(path, args, 0);
         checkEncryption(tree, path, "none");
         checkStructureFile(tree, path, true, cn);
         checkDataFile(tree, path, true, false, true, cn);
-        
+
         // second dump, which overwrites
         // this is expected to have an exit code of 1
         args = ['--compress-output', 'false', '--encryption.keyfile', keyfile, '--overwrite', 'true', '--collection', cn];
@@ -666,22 +734,23 @@ function dumpIntegrationSuite () {
       } finally {
         try {
           fs.removeDirectory(path);
-        } catch (err) {}
+        } catch (err) {
+        }
       }
     },
-    
+
     testDumpOverwriteOtherCompressed: function () {
       let path = fs.getTempFile();
       try {
         let args = ['--compress-output', 'true', '--collection', cn];
-        let tree = runDump(path, args, 0); 
+        let tree = runDump(path, args, 0);
         checkEncryption(tree, path, "none");
         checkStructureFile(tree, path, true, cn);
         checkDataFile(tree, path, true, false, true, cn);
-        
+
         // second dump, which overwrites
         args = ['--compress-output', 'true', '--overwrite', 'true', '--collection', cn + "Other"];
-        tree = runDump(path, args, 0); 
+        tree = runDump(path, args, 0);
         checkEncryption(tree, path, "none");
         checkStructureFile(tree, path, true, cn);
         checkDataFile(tree, path, true, false, true, cn);
@@ -690,10 +759,11 @@ function dumpIntegrationSuite () {
       } finally {
         try {
           fs.removeDirectory(path);
-        } catch (err) {}
+        } catch (err) {
+        }
       }
     },
-    
+
     testDumpJustOneInvalidCollection: function () {
       let path = fs.getTempFile();
       try {
@@ -703,35 +773,38 @@ function dumpIntegrationSuite () {
       } finally {
         try {
           fs.removeDirectory(path);
-        } catch (err) {}
+        } catch (err) {
+        }
       }
     },
-    
+
     testDumpJustInvalidCollections: function () {
       let path = fs.getTempFile();
       try {
         let args = ['--collection', 'foobarbaz', '--collection', 'knarzknarzknarz'];
-        let tree = runDump(path, args, 1); 
+        let tree = runDump(path, args, 1);
         checkEncryption(tree, path, "none");
       } finally {
         try {
           fs.removeDirectory(path);
-        } catch (err) {}
+        } catch (err) {
+        }
       }
     },
-    
+
     testDumpOneValidCollection: function () {
       let path = fs.getTempFile();
       try {
         let args = ['--compress-output', 'true', '--collection', cn, '--collection', 'knarzknarzknarz'];
-        let tree = runDump(path, args, 0); 
+        let tree = runDump(path, args, 0);
         checkEncryption(tree, path, "none");
         checkStructureFile(tree, path, true, cn);
         checkDataFile(tree, path, true, false, true, cn);
       } finally {
         try {
           fs.removeDirectory(path);
-        } catch (err) {}
+        } catch (err) {
+        }
       }
     },
   };

--- a/tests/js/client/shell/shell-restore-integration.js
+++ b/tests/js/client/shell/shell-restore-integration.js
@@ -34,9 +34,41 @@ const fs = require('fs');
 const pu = require('@arangodb/testutils/process-utils');
 const db = arangodb.db;
 const isCluster = require("internal").isCluster();
-const dbs = [{"name": "maçã", "id": "9999994", "isUnicode": true}, {"name": "cachorro", "id": "9999995", "isUnicode": false}, {"name": "testName", "id": "9999996", "isUnicode": false}, {"name": "😀", "id": "9999997", "isUnicode": true}, {"name": "かわいい犬", "id": "9999998"}, {"name": "ﻚﻠﺑ ﻞﻄﻴﻓ", "id": "9999999", "isUnicode": true}];
+const dbs = [{"name": "maçã", "id": "9999994", "isUnicode": true}, {
+  "name": "cachorro",
+  "id": "9999995",
+  "isUnicode": false
+}, {"name": "testName", "id": "9999996", "isUnicode": false}, {
+  "name": "😀",
+  "id": "9999997",
+  "isUnicode": true
+}, {"name": "かわいい犬", "id": "9999998"}, {"name": "ﻚﻠﺑ ﻞﻄﻴﻓ", "id": "9999999", "isUnicode": true}];
+const validatorJson = {
+  "message": "",
+  "level": "new",
+  "type": "json",
+  "rule": {
+    "additionalProperties": true,
+    "properties": {
+      "value1": {
+        "type": "integer"
+      },
+      "value2": {
+        "type": "string"
+      },
+      "name": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "value1",
+      "value2"
+    ],
+    "type": "object"
+  }
+};
 
-function createCollectionFiles (path, cn) {
+function createCollectionFiles(path, cn) {
   let fn = fs.join(path, cn + ".structure.json");
   fs.write(fn, JSON.stringify({
     indexes: [],
@@ -49,7 +81,7 @@ function createCollectionFiles (path, cn) {
 
   let data = [];
   for (let i = 0; i < 1000; ++i) {
-    data.push({ type: 2300, data: { _key: "test" + i, value: i} });
+    data.push({type: 2300, data: {_key: "test" + i, value: i}});
   }
 
   fn = fs.join(path, cn + ".data.json");
@@ -57,7 +89,7 @@ function createCollectionFiles (path, cn) {
   return data;
 }
 
-function createDumpJsonFile (path, databaseName, id) {  
+function createDumpJsonFile(path, databaseName, id) {
   let fn = fs.join(path, "dump.json");
   fs.write(fn, JSON.stringify({
     database: databaseName,
@@ -68,7 +100,7 @@ function createDumpJsonFile (path, databaseName, id) {
   }));
 }
 
-function restoreIntegrationSuite () {
+function restoreIntegrationSuite() {
   'use strict';
   const cn = 'UnitTestsRestore';
   // detect the path of arangorestore. quite hacky, but works
@@ -76,11 +108,11 @@ function restoreIntegrationSuite () {
 
   assertTrue(fs.isFile(arangorestore), "arangorestore not found!");
 
-  let addConnectionArgs = function(args) {
+  let addConnectionArgs = function (args) {
     let endpoint = arango.getEndpoint().replace(/\+vpp/, '').replace(/^http:/, 'tcp:').replace(/^https:/, 'ssl:').replace(/^vst:/, 'tcp:').replace(/^h2:/, 'tcp:');
     args.push('--server.endpoint');
     args.push(endpoint);
-    if(args.indexOf("--all-databases") === -1 && args.indexOf("--server.database") === -1) {
+    if (args.indexOf("--all-databases") === -1 && args.indexOf("--server.database") === -1) {
       args.push('--server.database');
       args.push(arango.getDatabaseName());
     }
@@ -88,7 +120,7 @@ function restoreIntegrationSuite () {
     args.push(arango.connectedUser());
   };
 
-  let runRestore = function(path, args, rc) {
+  let runRestore = function (path, args, rc) {
     args.push('--input-directory');
     args.push(path);
     addConnectionArgs(args);
@@ -107,12 +139,12 @@ function restoreIntegrationSuite () {
     tearDown: function () {
       db._drop(cn);
       db._databases().forEach((database) => {
-        if(database !== "_system") {
+        if (database !== "_system") {
           db._dropDatabase(database);
         }
       });
     },
-    
+
     testRestoreAutoIncrementKeyGenerator: function () {
       if (isCluster) {
         // auto-increment key-generator not supported on cluster
@@ -130,12 +162,12 @@ function restoreIntegrationSuite () {
             name: cn,
             numberOfShards: 3,
             type: 2,
-            keyOptions: { type: "autoincrement", lastValue: 12345, increment: 3, offset: 19 }
+            keyOptions: {type: "autoincrement", lastValue: 12345, increment: 3, offset: 19}
           }
         }));
 
         let args = ['--collection', cn, '--import-data', 'false'];
-        runRestore(path, args, 0); 
+        runRestore(path, args, 0);
 
         let c = db._collection(cn);
         let p = c.properties();
@@ -155,10 +187,11 @@ function restoreIntegrationSuite () {
       } finally {
         try {
           fs.removeDirectory(path);
-        } catch (err) {}
+        } catch (err) {
+        }
       }
     },
-    
+
     testRestorePaddedKeyGenerator: function () {
       let path = fs.getTempFile();
       try {
@@ -171,12 +204,12 @@ function restoreIntegrationSuite () {
             name: cn,
             numberOfShards: 3,
             type: 2,
-            keyOptions: { type: "padded", lastValue: 12345 }
+            keyOptions: {type: "padded", lastValue: 12345}
           }
         }));
 
         let args = ['--collection', cn, '--import-data', 'false'];
-        runRestore(path, args, 0); 
+        runRestore(path, args, 0);
 
         let c = db._collection(cn);
         let p = c.properties();
@@ -194,10 +227,57 @@ function restoreIntegrationSuite () {
       } finally {
         try {
           fs.removeDirectory(path);
-        } catch (err) {}
+        } catch (err) {
+        }
       }
     },
-    
+
+    testRestoreWithSchema: function () {
+      let path = fs.getTempFile();
+      try {
+        fs.makeDirectory(path);
+        let fn = fs.join(path, cn + ".structure.json");
+
+        fs.write(fn, JSON.stringify({
+          indexes: [],
+          parameters: {
+            name: cn,
+            schema: validatorJson,
+            numberOfShards: 3,
+            type: 2
+          }
+        }));
+
+        let data = [];
+        for (let i = 0; i < 1000; ++i) {
+          data.push({type: 2300, data: {_key: "test" + i, value1: i, value2: "abc"}});
+        }
+
+        fn = fs.join(path, cn + ".data.json");
+        fs.write(fn, data.map((d) => JSON.stringify(d)).join('\n'));
+
+        let args = ['--collection', cn, '--import-data', 'true'];
+        runRestore(path, args, 0);
+
+        let c = db._collection(cn);
+        assertEqual(data.length, c.count());
+        for (let i = 0; i < data.length; ++i) {
+          let doc = c.document("test" + i);
+          assertEqual(doc.value1, i);
+          assertEqual(doc.value2, "abc");
+        }
+        const colProperties = db[cn].properties();
+        assertTrue(colProperties.hasOwnProperty("schema"));
+        const schema = colProperties.schema;
+        assertEqual(schema, validatorJson);
+      } finally {
+        try {
+          fs.removeDirectory(path);
+        } catch (err) {
+        }
+      }
+    },
+
     testRestoreWithRepeatedDocuments: function () {
       let path = fs.getTempFile();
       try {
@@ -216,14 +296,14 @@ function restoreIntegrationSuite () {
         let data = [];
         for (let i = 0; i < 1000; ++i) {
           // will generate keys such as test0, test0, test1, test1 etc.
-          data.push({ type: 2300, data: { _key: "test" + Math.floor(i / 2), value: i, overwrite: (i % 2 === 1) } });
+          data.push({type: 2300, data: {_key: "test" + Math.floor(i / 2), value: i, overwrite: (i % 2 === 1)}});
         }
 
         fn = fs.join(path, cn + ".data.json");
         fs.write(fn, data.map((d) => JSON.stringify(d)).join('\n'));
-        
+
         let args = ['--collection', cn, '--import-data', 'true'];
-        runRestore(path, args, 0); 
+        runRestore(path, args, 0);
 
         let c = db._collection(cn);
         assertEqual(data.length / 2, c.count());
@@ -235,10 +315,11 @@ function restoreIntegrationSuite () {
       } finally {
         try {
           fs.removeDirectory(path);
-        } catch (err) {}
+        } catch (err) {
+        }
       }
     },
-    
+
     testRestoreInsertRemove: function () {
       let path = fs.getTempFile();
       try {
@@ -256,20 +337,20 @@ function restoreIntegrationSuite () {
 
         let data = [];
         for (let i = 0; i < 10; ++i) {
-          data.push({ type: 2300, data: { _key: "test" + i, value: i, old: true } });
+          data.push({type: 2300, data: {_key: "test" + i, value: i, old: true}});
         }
         for (let i = 0; i < 6; ++i) {
-          data.push({ type: 2302, key: "test" + i });
+          data.push({type: 2302, key: "test" + i});
         }
         for (let i = 4; i < 7; ++i) {
-          data.push({ type: 2300, data: { _key: "test" + i, value: i * 2, overwrite: true } });
+          data.push({type: 2300, data: {_key: "test" + i, value: i * 2, overwrite: true}});
         }
 
         fn = fs.join(path, cn + ".data.json");
         fs.write(fn, data.map((d) => JSON.stringify(d)).join('\n'));
-        
+
         let args = ['--collection', cn, '--import-data', 'true', '--overwrite', 'true'];
-        runRestore(path, args, 0); 
+        runRestore(path, args, 0);
 
         let c = db._collection(cn), count = c.count();
         assertEqual(6, count);
@@ -287,14 +368,15 @@ function restoreIntegrationSuite () {
           assertEqual(i, doc.value);
           assertTrue(doc.old);
           assertFalse(doc.hasOwnProperty('overwrite'));
-        }  
+        }
       } finally {
         try {
           fs.removeDirectory(path);
-        } catch (err) {}
+        } catch (err) {
+        }
       }
     },
-    
+
     testRestoreWithLineBreaksInData: function () {
       let path = fs.getTempFile();
       try {
@@ -312,14 +394,14 @@ function restoreIntegrationSuite () {
 
         let data = [];
         for (let i = 0; i < 1000; ++i) {
-          data.push({ type: 2300, data: { _key: "test" + i, value: i } });
+          data.push({type: 2300, data: {_key: "test" + i, value: i}});
         }
 
         fn = fs.join(path, cn + ".data.json");
         fs.write(fn, data.map((d) => '\n' + JSON.stringify(d)).join('\n\n'));
-        
+
         let args = ['--collection', cn, '--import-data', 'true'];
-        runRestore(path, args, 0); 
+        runRestore(path, args, 0);
 
         let c = db._collection(cn);
         assertEqual(data.length, c.count());
@@ -330,10 +412,11 @@ function restoreIntegrationSuite () {
       } finally {
         try {
           fs.removeDirectory(path);
-        } catch (err) {}
+        } catch (err) {
+        }
       }
     },
-    
+
     testRestoreWithEnvelopesWithDumpJsonFile: function () {
       let path = fs.getTempFile();
       try {
@@ -351,19 +434,19 @@ function restoreIntegrationSuite () {
 
         let data = [];
         for (let i = 0; i < 5000; ++i) {
-          data.push({ type: 2300, data: { _key: "test" + i, value: i } });
+          data.push({type: 2300, data: {_key: "test" + i, value: i}});
         }
 
         fn = fs.join(path, cn + ".data.json");
         fs.write(fn, data.map((d) => JSON.stringify(d)).join('\n'));
-        
+
         fn = fs.join(path, "dump.json");
         fs.write(fn, JSON.stringify({
           useEnvelopes: true
         }));
-        
+
         let args = ['--collection', cn, '--import-data', 'true'];
-        runRestore(path, args, 0); 
+        runRestore(path, args, 0);
 
         let c = db._collection(cn);
         assertEqual(data.length, c.count());
@@ -374,10 +457,11 @@ function restoreIntegrationSuite () {
       } finally {
         try {
           fs.removeDirectory(path);
-        } catch (err) {}
+        } catch (err) {
+        }
       }
     },
-    
+
     testRestoreWithEnvelopesNoDumpJsonFile: function () {
       let path = fs.getTempFile();
       try {
@@ -395,14 +479,14 @@ function restoreIntegrationSuite () {
 
         let data = [];
         for (let i = 0; i < 5000; ++i) {
-          data.push({ type: 2300, data: { _key: "test" + i, value: i } });
+          data.push({type: 2300, data: {_key: "test" + i, value: i}});
         }
 
         fn = fs.join(path, cn + ".data.json");
         fs.write(fn, data.map((d) => JSON.stringify(d)).join('\n'));
-        
+
         let args = ['--collection', cn, '--import-data', 'true'];
-        runRestore(path, args, 0); 
+        runRestore(path, args, 0);
 
         let c = db._collection(cn);
         assertEqual(data.length, c.count());
@@ -413,7 +497,8 @@ function restoreIntegrationSuite () {
       } finally {
         try {
           fs.removeDirectory(path);
-        } catch (err) {}
+        } catch (err) {
+        }
       }
     },
 
@@ -424,19 +509,19 @@ function restoreIntegrationSuite () {
       try {
         let subdir = "";
         dbs.forEach((database) => {
-          if(database["isUnicode"]) {
+          if (database["isUnicode"]) {
             subdir = database["id"];
           } else {
             subdir = database["name"];
           }
           let dbPath = fs.join(path, subdir);
           fs.makeDirectory(dbPath);
-          createDumpJsonFile(dbPath, database["name"], database["id"]);  
+          createDumpJsonFile(dbPath, database["name"], database["id"]);
         });
         runRestore(path, args, 0);
         dbs.forEach((database) => {
           db._useDatabase(database["name"]);
-          if(database["isUnicode"]) {
+          if (database["isUnicode"]) {
             subdir = database["id"];
           } else {
             subdir = database["name"];
@@ -458,23 +543,23 @@ function restoreIntegrationSuite () {
       try {
         let subdir = "";
         dbs.forEach((database, index) => {
-          if(database["isUnicode"]) {
+          if (database["isUnicode"]) {
             subdir = database["id"];
           } else {
             subdir = database["name"];
           }
           let dbPath = fs.join(path, subdir);
           fs.makeDirectory(dbPath);
-          if(index % 2 === 0) {
+          if (index % 2 === 0) {
             db._createDatabase(database["name"]);
           }
-          createDumpJsonFile(dbPath, database["name"], database["id"]);  
+          createDumpJsonFile(dbPath, database["name"], database["id"]);
         });
         assertTrue(db._databases().length > 2);
         runRestore(path, args, 0);
         dbs.forEach((database) => {
           db._useDatabase(database["name"]);
-          if(database["isUnicode"]) {
+          if (database["isUnicode"]) {
             subdir = database["id"];
           } else {
             subdir = database["name"];
@@ -495,14 +580,14 @@ function restoreIntegrationSuite () {
       try {
         let subdir = "";
         dbs.forEach((database) => {
-          if(database["isUnicode"]) {
+          if (database["isUnicode"]) {
             subdir = database["id"];
           } else {
             subdir = database["name"];
           }
           let dbPath = fs.join(path, subdir);
           fs.makeDirectory(dbPath);
-          createDumpJsonFile(dbPath, database["name"], database["id"]);  
+          createDumpJsonFile(dbPath, database["name"], database["id"]);
           let data = createCollectionFiles(dbPath, cn);
           let args = ['--collection', cn, '--import-data', 'true', '--create-database', 'true', '--server.database', database["name"]];
           runRestore(dbPath, args, 0);
@@ -512,41 +597,41 @@ function restoreIntegrationSuite () {
           for (let i = 0; i < data.length; ++i) {
             let doc = c.document("test" + i);
             assertEqual(i, doc.value);
-          } 
+          }
         });
       } finally {
         db._useDatabase("_system");
         fs.removeDirectoryRecursive(path, true);
       }
-    }, 
-    
+    },
+
     testRestoreCollectionWithAllDatabasesUnicode: function () {
       let path = fs.getTempFile();
       fs.makeDirectory(path);
       try {
         let subdir = "";
         dbs.forEach((database) => {
-          if(database["isUnicode"]) {
+          if (database["isUnicode"]) {
             subdir = database["id"];
           } else {
             subdir = database["name"];
           }
           let dbPath = fs.join(path, subdir);
           fs.makeDirectory(dbPath);
-          createDumpJsonFile(dbPath, database["name"], database["id"]);  
+          createDumpJsonFile(dbPath, database["name"], database["id"]);
           createCollectionFiles(dbPath, cn);
         });
         let args = ['--collection', cn, '--import-data', 'true', '--create-database', 'true', '--all-databases', 'true'];
         runRestore(path, args, 0);
-        dbs.forEach((database) => { 
+        dbs.forEach((database) => {
           db._useDatabase(database["name"]);
           let c = db._collection(cn);
           assertEqual(1000, c.count());
           for (let i = 0; i < 1000; ++i) {
             let doc = c.document("test" + i);
             assertEqual(i, doc.value);
-          } 
-        });  
+          }
+        });
       } finally {
         db._useDatabase("_system");
         fs.removeDirectoryRecursive(path, true);
@@ -570,19 +655,19 @@ function restoreIntegrationSuite () {
 
         let data = [];
         for (let i = 0; i < 5000; ++i) {
-          data.push({ _key: "test" + i, value: i });
+          data.push({_key: "test" + i, value: i});
         }
 
         fn = fs.join(path, cn + ".data.json");
         fs.write(fn, data.map((d) => JSON.stringify(d)).join('\n'));
-        
+
         fn = fs.join(path, "dump.json");
         fs.write(fn, JSON.stringify({
           useEnvelopes: false
         }));
-        
+
         let args = ['--collection', cn, '--import-data', 'true'];
-        runRestore(path, args, 0); 
+        runRestore(path, args, 0);
 
         let c = db._collection(cn);
         assertEqual(data.length, c.count());
@@ -593,10 +678,11 @@ function restoreIntegrationSuite () {
       } finally {
         try {
           fs.removeDirectory(path);
-        } catch (err) {}
+        } catch (err) {
+        }
       }
     },
-    
+
     testRestoreWithoutEnvelopesNoDumpJsonFile: function () {
       let path = fs.getTempFile();
       try {
@@ -614,14 +700,14 @@ function restoreIntegrationSuite () {
 
         let data = [];
         for (let i = 0; i < 5000; ++i) {
-          data.push({ _key: "test" + i, value: i });
+          data.push({_key: "test" + i, value: i});
         }
 
         fn = fs.join(path, cn + ".data.json");
         fs.write(fn, data.map((d) => JSON.stringify(d)).join('\n'));
-        
+
         let args = ['--collection', cn, '--import-data', 'true'];
-        runRestore(path, args, 0); 
+        runRestore(path, args, 0);
 
         let c = db._collection(cn);
         assertEqual(data.length, c.count());
@@ -632,10 +718,11 @@ function restoreIntegrationSuite () {
       } finally {
         try {
           fs.removeDirectory(path);
-        } catch (err) {}
+        } catch (err) {
+        }
       }
     },
-    
+
     testRestoreNumericGloballyUniqueId: function () {
       let path = fs.getTempFile();
       try {
@@ -653,17 +740,18 @@ function restoreIntegrationSuite () {
         }));
 
         let args = ['--collection', cn, '--import-data', 'false'];
-        runRestore(path, args, 0); 
+        runRestore(path, args, 0);
 
         let c = db._collection(cn);
         assertNotEqual("123456789012", c.properties().globallyUniqueId);
       } finally {
         try {
           fs.removeDirectory(path);
-        } catch (err) {}
+        } catch (err) {
+        }
       }
     },
-    
+
     testRestoreIndexesOldFormat: function () {
       let path = fs.getTempFile();
       try {
@@ -674,9 +762,9 @@ function restoreIntegrationSuite () {
           indexes: [],
           parameters: {
             indexes: [
-              { id: "0", fields: ["_key"], type: "primary", unique: true },
-              { id: "95", fields: ["loc"], type: "geo", geoJson: false },
-              { id: "295", fields: ["value"], type: "skiplist", sparse: true },
+              {id: "0", fields: ["_key"], type: "primary", unique: true},
+              {id: "95", fields: ["loc"], type: "geo", geoJson: false},
+              {id: "295", fields: ["value"], type: "skiplist", sparse: true},
             ],
             name: cn,
             numberOfShards: 3,
@@ -685,7 +773,7 @@ function restoreIntegrationSuite () {
         }));
 
         let args = ['--collection', cn, '--import-data', 'false'];
-        runRestore(path, args, 0); 
+        runRestore(path, args, 0);
 
         let c = db._collection(cn);
         let indexes = c.indexes();
@@ -700,7 +788,7 @@ function restoreIntegrationSuite () {
 
         // test if the indexes work
         for (let i = 0; i < 100; ++i) {
-          c.insert({ _key: "test" + i, value: 42 });
+          c.insert({_key: "test" + i, value: 42});
         }
         for (let i = 0; i < 100; ++i) {
           assertEqual("test" + i, c.document("test" + i)._key);
@@ -710,10 +798,11 @@ function restoreIntegrationSuite () {
       } finally {
         try {
           fs.removeDirectory(path);
-        } catch (err) {}
+        } catch (err) {
+        }
       }
     },
-    
+
     testRestoreIndexesOldFormatGeo1: function () {
       let path = fs.getTempFile();
       try {
@@ -724,7 +813,7 @@ function restoreIntegrationSuite () {
           indexes: [],
           parameters: {
             indexes: [
-              { id: "95", fields: ["loc"], type: "geo1", geoJson: false },
+              {id: "95", fields: ["loc"], type: "geo1", geoJson: false},
             ],
             name: cn,
             numberOfShards: 3,
@@ -733,7 +822,7 @@ function restoreIntegrationSuite () {
         }));
 
         let args = ['--collection', cn, '--import-data', 'false'];
-        runRestore(path, args, 0); 
+        runRestore(path, args, 0);
 
         let c = db._collection(cn);
         let indexes = c.indexes();
@@ -746,10 +835,11 @@ function restoreIntegrationSuite () {
       } finally {
         try {
           fs.removeDirectory(path);
-        } catch (err) {}
+        } catch (err) {
+        }
       }
     },
-    
+
     testRestoreIndexesOldFormatGeo2: function () {
       let path = fs.getTempFile();
       try {
@@ -760,7 +850,7 @@ function restoreIntegrationSuite () {
           indexes: [],
           parameters: {
             indexes: [
-              { id: "95", fields: ["a", "b"], type: "geo2", geoJson: false },
+              {id: "95", fields: ["a", "b"], type: "geo2", geoJson: false},
             ],
             name: cn,
             numberOfShards: 3,
@@ -769,7 +859,7 @@ function restoreIntegrationSuite () {
         }));
 
         let args = ['--collection', cn, '--import-data', 'false'];
-        runRestore(path, args, 0); 
+        runRestore(path, args, 0);
 
         let c = db._collection(cn);
         let indexes = c.indexes();
@@ -782,7 +872,8 @@ function restoreIntegrationSuite () {
       } finally {
         try {
           fs.removeDirectory(path);
-        } catch (err) {}
+        } catch (err) {
+        }
       }
     },
 
@@ -796,7 +887,7 @@ function restoreIntegrationSuite () {
           indexes: [],
           parameters: {
             indexes: [
-              { id: "95", fields: ["text"], type: "fulltext", minLength: 0 },
+              {id: "95", fields: ["text"], type: "fulltext", minLength: 0},
             ],
             name: cn,
             numberOfShards: 3,
@@ -805,7 +896,7 @@ function restoreIntegrationSuite () {
         }));
 
         let args = ['--collection', cn, '--import-data', 'false'];
-        runRestore(path, args, 0); 
+        runRestore(path, args, 0);
 
         let c = db._collection(cn);
         let indexes = c.indexes();
@@ -818,10 +909,11 @@ function restoreIntegrationSuite () {
       } finally {
         try {
           fs.removeDirectory(path);
-        } catch (err) {}
+        } catch (err) {
+        }
       }
     },
-    
+
     testRestoreIndexesNewFormat: function () {
       let path = fs.getTempFile();
       try {
@@ -830,8 +922,8 @@ function restoreIntegrationSuite () {
 
         fs.write(fn, JSON.stringify({
           indexes: [
-            { id: "95", fields: ["loc"], type: "geo", geoJson: false },
-            { id: "295", fields: ["value"], type: "skiplist", sparse: true },
+            {id: "95", fields: ["loc"], type: "geo", geoJson: false},
+            {id: "295", fields: ["value"], type: "skiplist", sparse: true},
           ],
           parameters: {
             name: cn,
@@ -841,7 +933,7 @@ function restoreIntegrationSuite () {
         }));
 
         let args = ['--collection', cn, '--import-data', 'false'];
-        runRestore(path, args, 0); 
+        runRestore(path, args, 0);
 
         let c = db._collection(cn);
         let indexes = c.indexes();
@@ -856,7 +948,7 @@ function restoreIntegrationSuite () {
 
         // test if the indexes work
         for (let i = 0; i < 100; ++i) {
-          c.insert({ _key: "test" + i, value: 42 });
+          c.insert({_key: "test" + i, value: 42});
         }
         for (let i = 0; i < 100; ++i) {
           assertEqual("test" + i, c.document("test" + i)._key);
@@ -866,7 +958,8 @@ function restoreIntegrationSuite () {
       } finally {
         try {
           fs.removeDirectory(path);
-        } catch (err) {}
+        } catch (err) {
+        }
       }
     },
 
@@ -880,9 +973,9 @@ function restoreIntegrationSuite () {
           indexes: [],
           parameters: {
             indexes: [
-              { id: "0", fields: ["_key"], type: "primary", unique: true },
-              { id: "1", fields: ["_from", "_to"], type: "edge" },
-              { id: "95", fields: ["value"], type: "hash" },
+              {id: "0", fields: ["_key"], type: "primary", unique: true},
+              {id: "1", fields: ["_from", "_to"], type: "edge"},
+              {id: "95", fields: ["value"], type: "hash"},
             ],
             name: cn,
             numberOfShards: 3,
@@ -891,7 +984,7 @@ function restoreIntegrationSuite () {
         }));
 
         let args = ['--collection', cn, '--import-data', 'false'];
-        runRestore(path, args, 0); 
+        runRestore(path, args, 0);
 
         let c = db._collection(cn);
         let indexes = c.indexes();
@@ -905,7 +998,7 @@ function restoreIntegrationSuite () {
 
         // test if the indexes work
         for (let i = 0; i < 100; ++i) {
-          c.insert({ _key: "test" + i, _from: "v/" + i, _to: "v/" + i, value: 42 });
+          c.insert({_key: "test" + i, _from: "v/" + i, _to: "v/" + i, value: 42});
         }
         for (let i = 0; i < 100; ++i) {
           assertEqual("test" + i, c.document("test" + i)._key);
@@ -914,7 +1007,7 @@ function restoreIntegrationSuite () {
           let inEdges = c.inEdges("v/" + i);
           assertEqual(1, inEdges.length);
           assertEqual("test" + i, inEdges[0]._key);
-          
+
           let outEdges = c.outEdges("v/" + i);
           assertEqual(1, outEdges.length);
           assertEqual("test" + i, outEdges[0]._key);
@@ -924,10 +1017,11 @@ function restoreIntegrationSuite () {
       } finally {
         try {
           fs.removeDirectory(path);
-        } catch (err) {}
+        } catch (err) {
+        }
       }
     },
-    
+
     testRestoreEdgeIndexWrongCollectionType: function () {
       let path = fs.getTempFile();
       try {
@@ -938,8 +1032,8 @@ function restoreIntegrationSuite () {
           indexes: [],
           parameters: {
             indexes: [
-              { id: "0", fields: ["_key"], type: "primary", unique: true },
-              { id: "1", fields: ["_from", "_to"], type: "edge" },
+              {id: "0", fields: ["_key"], type: "primary", unique: true},
+              {id: "1", fields: ["_from", "_to"], type: "edge"},
             ],
             name: cn,
             numberOfShards: 3,
@@ -948,7 +1042,7 @@ function restoreIntegrationSuite () {
         }));
 
         let args = ['--collection', cn, '--import-data', 'false'];
-        runRestore(path, args, 0); 
+        runRestore(path, args, 0);
 
         let c = db._collection(cn);
         let indexes = c.indexes();
@@ -958,7 +1052,7 @@ function restoreIntegrationSuite () {
 
         // test if the index works
         for (let i = 0; i < 100; ++i) {
-          c.insert({ _key: "test" + i });
+          c.insert({_key: "test" + i});
         }
         for (let i = 0; i < 100; ++i) {
           assertEqual("test" + i, c.document("test" + i)._key);
@@ -966,10 +1060,11 @@ function restoreIntegrationSuite () {
       } finally {
         try {
           fs.removeDirectory(path);
-        } catch (err) {}
+        } catch (err) {
+        }
       }
     },
-    
+
     testRestoreEdgeIndexNewFormat: function () {
       let path = fs.getTempFile();
       try {
@@ -986,7 +1081,7 @@ function restoreIntegrationSuite () {
         }));
 
         let args = ['--collection', cn, '--import-data', 'false'];
-        runRestore(path, args, 0); 
+        runRestore(path, args, 0);
 
         let c = db._collection(cn);
         let indexes = c.indexes();
@@ -998,7 +1093,7 @@ function restoreIntegrationSuite () {
 
         // test if the indexes work
         for (let i = 0; i < 100; ++i) {
-          c.insert({ _key: "test" + i, _from: "v/" + i, _to: "v/" + i, value: 42 });
+          c.insert({_key: "test" + i, _from: "v/" + i, _to: "v/" + i, value: 42});
         }
         for (let i = 0; i < 100; ++i) {
           assertEqual("test" + i, c.document("test" + i)._key);
@@ -1007,7 +1102,7 @@ function restoreIntegrationSuite () {
           let inEdges = c.inEdges("v/" + i);
           assertEqual(1, inEdges.length);
           assertEqual("test" + i, inEdges[0]._key);
-          
+
           let outEdges = c.outEdges("v/" + i);
           assertEqual(1, outEdges.length);
           assertEqual("test" + i, outEdges[0]._key);
@@ -1015,7 +1110,8 @@ function restoreIntegrationSuite () {
       } finally {
         try {
           fs.removeDirectory(path);
-        } catch (err) {}
+        } catch (err) {
+        }
       }
     },
 
@@ -1043,7 +1139,9 @@ function restoreIntegrationSuite () {
         {"parameters": {"name": "Tag", "type": 2}},
       ];
       // satisfy the file format requirements by adding indexes
-      collectionsJson.forEach(col => { col.indexes = []; });
+      collectionsJson.forEach(col => {
+        col.indexes = [];
+      });
 
       const path = fs.getTempFile();
       try {
@@ -1077,7 +1175,7 @@ function restoreIntegrationSuite () {
         db._useDatabase("_system");
       }
     },
-    
+
     testRestoreEnableRevisionTreesDefault: function () {
       let path = fs.getTempFile();
       try {
@@ -1093,7 +1191,7 @@ function restoreIntegrationSuite () {
         }));
 
         let args = ['--collection', cn, '--import-data', 'false'];
-        runRestore(path, args, 0); 
+        runRestore(path, args, 0);
 
         let c = db._collection(cn);
         let props = c.properties();
@@ -1102,9 +1200,10 @@ function restoreIntegrationSuite () {
       } finally {
         try {
           fs.removeDirectory(path);
-        } catch (err) {}
+        } catch (err) {
+        }
       }
-    },    
+    },
 
     testRestoreEnableRevisionTreesTrue: function () {
       let path = fs.getTempFile();
@@ -1121,7 +1220,7 @@ function restoreIntegrationSuite () {
         }));
 
         let args = ['--collection', cn, '--import-data', 'false', '--enable-revision-trees', 'true'];
-        runRestore(path, args, 0); 
+        runRestore(path, args, 0);
 
         let c = db._collection(cn);
         let props = c.properties();
@@ -1130,10 +1229,11 @@ function restoreIntegrationSuite () {
       } finally {
         try {
           fs.removeDirectory(path);
-        } catch (err) {}
+        } catch (err) {
+        }
       }
-    },    
-    
+    },
+
     testRestoreEnableRevisionTreesFalse: function () {
       let path = fs.getTempFile();
       try {
@@ -1149,7 +1249,7 @@ function restoreIntegrationSuite () {
         }));
 
         let args = ['--collection', cn, '--import-data', 'false', '--enable-revision-trees', 'false'];
-        runRestore(path, args, 0); 
+        runRestore(path, args, 0);
 
         let c = db._collection(cn);
         let props = c.properties();
@@ -1158,9 +1258,10 @@ function restoreIntegrationSuite () {
       } finally {
         try {
           fs.removeDirectory(path);
-        } catch (err) {}
+        } catch (err) {
+        }
       }
-    },    
+    },
   };
 }
 

--- a/tests/js/common/shell/shell-validation.js
+++ b/tests/js/common/shell/shell-validation.js
@@ -1,5 +1,5 @@
 /*jshint globalstrict:false, strict:false */
-/*global assertEqual, assertTypeOf, assertNotEqual, assertTrue, assertFalse, assertUndefined, assertNotUndefined, fail */
+/*global assertEqual, assertTrue, assertFalse, assertNotNull, assertNotUndefined, fail */
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief test the collection interface
@@ -42,23 +42,24 @@ let sleepInCluster = () => {
   }
 };
 
-const skipOptions = { "skipDocumentValidation": true };
+const skipOptions = {"skipDocumentValidation": true};
 
-function ValidationBasicsSuite () {
+function ValidationBasicsSuite() {
   const testCollectionName = "TestValidationCollection";
   let testCollection;
   let validatorJson;
 
   // Same attribute key, so that updating badDoc with goodDoc will succeed
-  const goodDoc = { "numArray": [1, 2, 3, 4] };
-  const badDoc = { "numArray": "1, 2, 3, 4" };
+  const goodDoc = {"numArray": [1, 2, 3, 4]};
+  const badDoc = {"numArray": "1, 2, 3, 4"};
 
   return {
 
     setUp: () => {
       try {
         db._drop(testCollectionName);
-      } catch (ex) {}
+      } catch (ex) {
+      }
       validatorJson = {
         "level": "strict",
         "type": "json",
@@ -97,7 +98,8 @@ function ValidationBasicsSuite () {
     tearDown: () => {
       try {
         db._drop(testCollectionName);
-      } catch (ex) {}
+      } catch (ex) {
+      }
     },
 
     // properties ////////////////////////////////////////////////////////////////////////////////////////
@@ -115,7 +117,7 @@ function ValidationBasicsSuite () {
       let v = validatorJson;
       v.level = "none";
 
-      testCollection.properties({ "schema": v });
+      testCollection.properties({"schema": v});
 
       const props = testCollection.properties();
       assertEqual(props.schema.rule, v.rule);
@@ -127,7 +129,7 @@ function ValidationBasicsSuite () {
     testPropertiesUpdateNoObject: () => {
       const v = "hund";
       try {
-        testCollection.properties({ "schema": v });
+        testCollection.properties({"schema": v});
         fail();
       } catch (err) {
         assertEqual(ERRORS.ERROR_VALIDATION_BAD_PARAMETER.code, err.errorNum);
@@ -159,7 +161,9 @@ function ValidationBasicsSuite () {
     },
 
     testAQLInsertGood: () => {
-      db._query(`INSERT { "numArray": [1, 2, 3, 4] } INTO ${testCollectionName}`);
+      db._query(`INSERT
+      { "numArray": [1, 2, 3, 4] } INTO
+      ${testCollectionName}`);
       assertEqual(testCollection.count(), 1);
       let doc = testCollection.any();
       assertTrue(Array.isArray(doc.numArray));
@@ -167,7 +171,9 @@ function ValidationBasicsSuite () {
 
     testAQLInsertBad: () => {
       try {
-        db._query(`INSERT { "numArray": "1, 2, 3, 4" } INTO ${testCollectionName}`);
+        db._query(`INSERT
+        { "numArray": "1, 2, 3, 4" } INTO
+        ${testCollectionName}`);
         fail();
       } catch (err) {
         assertEqual(ERRORS.ERROR_VALIDATION_FAILED.code, err.errorNum);
@@ -175,7 +181,15 @@ function ValidationBasicsSuite () {
     },
 
     testAQLInsertBadSkip: () => {
-      db._query(`INSERT { "numArray": "1, 2, 3, 4" } INTO ${testCollectionName} OPTIONS { "skipDocumentValidation": true }`);
+      db._query(`INSERT
+      { "numArray": "1, 2, 3, 4" } INTO
+      ${testCollectionName}
+      OPTIONS
+      {
+      "skipDocumentValidation"
+      :
+      true
+      }`);
       assertEqual(testCollection.count(), 1);
       let doc = testCollection.any();
       assertFalse(Array.isArray(doc.numArray));
@@ -306,7 +320,7 @@ function ValidationBasicsSuite () {
     // levels ////////////////////////////////////////////////////////////////////////////////////////////
     testLevelNone: () => {
       validatorJson.level = "none";
-      testCollection.properties({ "schema": validatorJson });
+      testCollection.properties({"schema": validatorJson});
       sleepInCluster();
       assertEqual(testCollection.properties().schema.level, validatorJson.level);
       testCollection.insert(badDoc);
@@ -314,7 +328,7 @@ function ValidationBasicsSuite () {
 
     testLevelNew: () => {
       validatorJson.level = "new";
-      testCollection.properties({ "schema": validatorJson });
+      testCollection.properties({"schema": validatorJson});
       sleepInCluster();
       assertEqual(testCollection.properties().schema.level, validatorJson.level);
 
@@ -331,7 +345,7 @@ function ValidationBasicsSuite () {
 
     testLevelModerateInsert: () => {
       validatorJson.level = "moderate";
-      testCollection.properties({ "schema": validatorJson });
+      testCollection.properties({"schema": validatorJson});
       sleepInCluster();
       assertEqual(testCollection.properties().schema.level, validatorJson.level);
 
@@ -346,7 +360,7 @@ function ValidationBasicsSuite () {
 
     testLevelModerateModifyBadToGood: () => {
       validatorJson.level = "moderate";
-      testCollection.properties({ "schema": validatorJson });
+      testCollection.properties({"schema": validatorJson});
       sleepInCluster();
       assertEqual(testCollection.properties().schema.level, validatorJson.level);
 
@@ -361,7 +375,7 @@ function ValidationBasicsSuite () {
 
     testLevelModerateModifyBadWithBad: () => {
       validatorJson.level = "moderate";
-      testCollection.properties({ "schema": validatorJson });
+      testCollection.properties({"schema": validatorJson});
       sleepInCluster();
       assertEqual(testCollection.properties().schema.level, validatorJson.level);
 
@@ -385,7 +399,7 @@ function ValidationBasicsSuite () {
 
     testLevelModerateUpdateGoodToBad: () => {
       validatorJson.level = "moderate";
-      testCollection.properties({ "schema": validatorJson });
+      testCollection.properties({"schema": validatorJson});
       sleepInCluster();
       assertEqual(testCollection.properties().schema.level, validatorJson.level);
 
@@ -409,7 +423,7 @@ function ValidationBasicsSuite () {
 
     testLevelModerateReplaceGoodToBad: () => {
       validatorJson.level = "moderate";
-      testCollection.properties({ "schema": validatorJson });
+      testCollection.properties({"schema": validatorJson});
       sleepInCluster();
       assertEqual(testCollection.properties().schema.level, validatorJson.level);
 
@@ -432,7 +446,7 @@ function ValidationBasicsSuite () {
 
     testLevelStict: () => {
       validatorJson.level = "strict";
-      testCollection.properties({ "schema": validatorJson });
+      testCollection.properties({"schema": validatorJson});
       sleepInCluster();
       assertEqual(testCollection.properties().schema.level, validatorJson.level);
 
@@ -483,7 +497,7 @@ function ValidationBasicsSuite () {
       } catch (err) {
         assertEqual(ERRORS.ERROR_VALIDATION_FAILED.code, err.errorNum);
       }
-      testCollection.properties({ "schema": { } });
+      testCollection.properties({"schema": {}});
       sleepInCluster();
       assertEqual(testCollection.properties().schema, null);
       testCollection.insert(badDoc);
@@ -497,7 +511,7 @@ function ValidationBasicsSuite () {
       } catch (err) {
         assertEqual(ERRORS.ERROR_VALIDATION_FAILED.code, err.errorNum);
       }
-      testCollection.properties({ "schema": null });
+      testCollection.properties({"schema": null});
       sleepInCluster();
       assertEqual(testCollection.properties().schema, null);
       testCollection.insert(badDoc);
@@ -507,7 +521,7 @@ function ValidationBasicsSuite () {
     // json ////////////////////////////////////////////////////////////////////////////////////////////
     testJson: () => {
       validatorJson.level = "strict";
-      testCollection.properties({ "schema": validatorJson });
+      testCollection.properties({"schema": validatorJson});
       sleepInCluster();
 
       testCollection.insert(goodDoc);
@@ -522,12 +536,12 @@ function ValidationBasicsSuite () {
     testJsonRequire: () => {
       let p = {
         ...validatorJson.rule,
-        required: [ "numArray", "name" ]
+        required: ["numArray", "name"]
       };
       validatorJson.rule = p;
       validatorJson.level = "strict";
 
-      testCollection.properties({ "schema": validatorJson });
+      testCollection.properties({"schema": validatorJson});
       sleepInCluster();
 
       try {
@@ -563,7 +577,7 @@ function ValidationBasicsSuite () {
     // AQL ////////////////////////////////////////////////////////////////////////////////////////////
     testAQLSchemaGet: () => {
       validatorJson.level = "strict";
-      testCollection.properties({ "schema": validatorJson });
+      testCollection.properties({"schema": validatorJson});
       sleepInCluster();
 
       // get regular schema
@@ -583,7 +597,7 @@ function ValidationBasicsSuite () {
 
     testAQLSchemaGetNull: () => {
       // no validation available must return `null`
-      testCollection.properties({ schema: {} });
+      testCollection.properties({schema: {}});
       let res = db._query(`
         RETURN SCHEMA_GET("${testCollectionName}")
       `).toArray();
@@ -592,7 +606,7 @@ function ValidationBasicsSuite () {
 
     testAqlSchemaValidate: () => {
       // unset schema
-      testCollection.properties({ schema: {} });
+      testCollection.properties({schema: {}});
       sleepInCluster();
 
       let res;
@@ -610,7 +624,7 @@ function ValidationBasicsSuite () {
           }
         )
       `).toArray();
-      assertEqual([ null ], res);
+      assertEqual([null], res);
 
       // doc is not an object
       res = db._query(`
@@ -626,7 +640,7 @@ function ValidationBasicsSuite () {
           }
         )
       `).toArray();
-      assertEqual([ null ], res);
+      assertEqual([null], res);
 
       // doc is not an object
       res = db._query(`
@@ -642,7 +656,7 @@ function ValidationBasicsSuite () {
           }
         )
       `).toArray();
-      assertEqual([ null ], res);
+      assertEqual([null], res);
 
       // doc does not match schema
       res = db._query(`
@@ -708,7 +722,115 @@ function ValidationBasicsSuite () {
   }; // return
 } // END - ValidationBasicsSuite
 
-function ValidationEdgeSuite () {
+
+function UpdateSchemaCoverageSuite() {
+  const testCollectionName = "TestCollection";
+  let testCollection = null;
+  const validatorJson = {
+    "message": "",
+    "level": "new",
+    "type": "json",
+    "rule": {
+      "additionalProperties": true,
+      "properties": {
+        "created": {
+          "type": "integer"
+        },
+        "creator": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "created",
+        "creator"
+      ],
+      "type": "object"
+    }
+  };
+
+  const validatorJson2 = {
+    "message": "",
+    "level": "new",
+    "type": "json",
+    "rule": {
+      "additionalProperties": true,
+      "properties": {
+        "created": {
+          "type": "integer"
+        },
+        "creator": {
+          "type": "string"
+        },
+        "dog": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "created"
+      ],
+      "type": "object"
+    }
+  };
+
+
+  return {
+
+    setUp: () => {
+      try {
+        db._drop(testCollectionName);
+      } catch (ex) {
+      }
+      testCollection = db._create(testCollectionName, {
+        schema: validatorJson,
+        replicationFactor: 3,
+        numberOfShards: 5
+      });
+    },
+
+    tearDown: () => {
+      try {
+        db._drop(testCollectionName);
+      } catch (ex) {
+      }
+    },
+
+    testPropertiesRemoveAttributeAfterDocInsertion: () => {
+      assertNotNull(testCollection);
+      const newDoc = {"created": 123, "creator": "Julia"};
+      testCollection.insert(newDoc);
+      delete validatorJson.rule.properties.name;
+      assertFalse(validatorJson.rule.hasOwnProperty("name"));
+      const schema = testCollection.properties({"schema": validatorJson}).schema;
+      assertEqual(schema.message, validatorJson.message);
+      assertEqual(schema.level, validatorJson.level);
+      assertEqual(schema.type, validatorJson.type);
+      assertEqual(schema.rule, validatorJson.rule);
+    },
+    testPropertiesRemoveAndInsertAttributes: () => {
+      assertNotNull(testCollection);
+      const schema = testCollection.properties({"schema": validatorJson2}).schema;
+      assertEqual(schema.message, validatorJson2.message);
+      assertEqual(schema.level, validatorJson2.level);
+      assertEqual(schema.type, validatorJson2.type);
+      assertEqual(schema.rule, validatorJson2.rule);
+    },
+    testPropertiesRemove2AttributesAndInsert: () => {
+      assertNotNull(testCollection);
+      delete validatorJson2.rule.properties.creator;
+      assertFalse(validatorJson.rule.hasOwnProperty("creator"));
+      const schema = testCollection.properties({"schema": validatorJson2}).schema;
+      assertEqual(schema.message, validatorJson2.message);
+      assertEqual(schema.level, validatorJson2.level);
+      assertEqual(schema.type, validatorJson2.type);
+      assertEqual(schema.rule, validatorJson2.rule);
+    },
+  };
+} // END - UpdateSchemaCoverageSuite
+
+function ValidationEdgeSuite() {
   const testCollectionName = "TestValidationEdgeCollection";
   let testCollection;
   let validatorJson;
@@ -731,7 +853,8 @@ function ValidationEdgeSuite () {
     setUp: () => {
       try {
         db._drop(testCollectionName);
-      } catch (ex) {}
+      } catch (ex) {
+      }
       validatorJson = {
         "level": "strict",
         "rule": {
@@ -754,7 +877,8 @@ function ValidationEdgeSuite () {
     tearDown: () => {
       try {
         db._drop(testCollectionName);
-      } catch (ex) {}
+      } catch (ex) {
+      }
     },
 
     // insert ////////////////////////////////////////////////////////////////////////////////////////
@@ -778,13 +902,17 @@ function ValidationEdgeSuite () {
     },
 
     testAQLInsertEdgeGood: () => {
-      db._query(`INSERT { "_from": "vert/A", "_to": "vert/B", "name": "Helge" } INTO ${testCollectionName}`);
+      db._query(`INSERT
+      { "_from": "vert/A", "_to": "vert/B", "name": "Helge" } INTO
+      ${testCollectionName}`);
       assertEqual(testCollection.count(), 1);
     },
 
     testAQLInsertEdgeBad: () => {
       try {
-        db._query(`INSERT { "_from": "vert/A", "_to": "vert/B", "additional": true } INTO ${testCollectionName}`);
+        db._query(`INSERT
+        { "_from": "vert/A", "_to": "vert/B", "additional": true } INTO
+        ${testCollectionName}`);
         fail();
       } catch (err) {
         assertEqual(ERRORS.ERROR_VALIDATION_FAILED.code, err.errorNum);
@@ -792,7 +920,15 @@ function ValidationEdgeSuite () {
     },
 
     testAQLInsertEdgeBadSkip: () => {
-      db._query(`INSERT { "_from": "vert/A", "_to": "vert/B", "additional": true } INTO ${testCollectionName} OPTIONS { "skipDocumentValidation": true }`);
+      db._query(`INSERT
+      { "_from": "vert/A", "_to": "vert/B", "additional": true } INTO
+      ${testCollectionName}
+      OPTIONS
+      {
+      "skipDocumentValidation"
+      :
+      true
+      }`);
       assertEqual(testCollection.count(), 1);
     },
 
@@ -922,5 +1058,6 @@ function ValidationEdgeSuite () {
 
 jsunity.run(ValidationBasicsSuite);
 jsunity.run(ValidationEdgeSuite);
+jsunity.run(UpdateSchemaCoverageSuite);
 
 return jsunity.done();


### PR DESCRIPTION
Backport for https://github.com/arangodb/arangodb/pull/18014.
PR related to https://arangodb.atlassian.net/browse/BTS-1193.
Fix for schema update. When removing a field and then inserting a new field into the schema, previously, both old and new schema would be merged, meaning it would maintain the old field and add the new one.