### PR TITLE
wip: improve memory usage of in-memory edge cache

### DIFF
--- a/arangod/RocksDBEngine/RocksDBEdgeIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBEdgeIndex.cpp
@@ -45,7 +45,6 @@
 #include "RocksDBEngine/RocksDBIndexCacheRefillFeature.h"
 #include "RocksDBEngine/RocksDBKey.h"
 #include "RocksDBEngine/RocksDBKeyBounds.h"
-#include "RocksDBEngine/RocksDBSettingsManager.h"
 #include "RocksDBEngine/RocksDBTransactionMethods.h"
 #include "RocksDBEngine/RocksDBTransactionState.h"
 #include "RocksDBEngine/RocksDBTypes.h"
@@ -83,11 +82,11 @@ class RocksDBEdgeIndexLookupIterator final : public IndexIterator {
   // holds both the indexed attribute (_from/_to) and the opposite
   // attribute (_to/_from). Avoids copying the data and is thus
   // just an efficient, non-owning container for the _from/_to values
-  // of a single edge during covering edge index lookups-
+  // of a single edge during covering edge index lookups.
   class EdgeCoveringData final : public IndexIteratorCoveringData {
    public:
     explicit EdgeCoveringData(VPackSlice indexAttribute,
-                              VPackSlice otherAttribute)
+                              VPackSlice otherAttribute) noexcept
         : _indexAttribute(indexAttribute), _otherAttribute(otherAttribute) {}
 
     VPackSlice at(size_t i) const override {
@@ -203,39 +202,50 @@ class RocksDBEdgeIndexLookupIterator final : public IndexIterator {
  private:
   void resetInplaceMemory() { _builder.clear(); }
 
-  /// internal retrieval loop
+  // internal retrieval loop
   template<typename F>
   inline bool nextImplementation(F&& cb, uint64_t limit) {
     TRI_ASSERT(_trx->state()->isRunning());
-#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
-    TRI_ASSERT(limit > 0);  // Someone called with limit == 0. Api broken
-#else
-    // Gracefully return in production code
-    // Nothing bad has happened
+    TRI_ASSERT(limit > 0);
     if (limit == 0) {
+      // gracefully return in production mode. nothing bad has happened
       return false;
     }
-#endif
+
+    std::string* cacheKeyCollection = nullptr;
+    std::string const* cacheValueCollection = nullptr;
 
     while (limit > 0) {
       while (_builderIterator.valid()) {
-        // We still have unreturned edges in out memory.
-        // Just plainly return those.
+        // we still have unreturned edges in out memory. simply return them
         TRI_ASSERT(_builderIterator.value().isNumber());
         LocalDocumentId docId{
             _builderIterator.value().getNumericValue<uint64_t>()};
         _builderIterator.next();
         TRI_ASSERT(_builderIterator.valid());
         // For now we store the complete opposite _from/_to value
-        TRI_ASSERT(_builderIterator.value().isString());
+        VPackSlice fromTo = _builderIterator.value();
+        TRI_ASSERT(fromTo.isString());
 
-        std::forward<F>(cb)(docId, _builderIterator.value());
+        std::string_view v = fromTo.stringView();
+        TRI_ASSERT(!v.empty());
+        if (v.front() == '/') {
+          // prefix-compressed value
+          cacheValueCollection =
+              _index->cachedValueCollection(cacheValueCollection);
+          TRI_ASSERT(cacheValueCollection != nullptr);
+          _idBuilder.clear();
+          // collection name  and  key including forward slash
+          _idBuilder.add(VPackValueString2Parts(*cacheValueCollection, v));
+          fromTo = _idBuilder.slice();
+        }
+        std::forward<F>(cb)(docId, fromTo);
 
         _builderIterator.next();
         limit--;
 
         if (limit == 0) {
-          // Limit reached bail out
+          // Limit reached. bail out
           return true;
         }
       }
@@ -249,52 +259,83 @@ class RocksDBEdgeIndexLookupIterator final : public IndexIterator {
       _lastKey = _keysIterator.value();
       TRI_ASSERT(_lastKey.isString());
       std::string_view fromTo = _lastKey.stringView();
+      std::string_view cacheKey;
 
       bool needRocksLookup = true;
       if (_cache) {
         // Try to read from cache
-        auto finding =
-            _cache->find(fromTo.data(), static_cast<uint32_t>(fromTo.size()));
-        if (finding.found()) {
-          incrCacheHits();
-          needRocksLookup = false;
-          // We got sth. in the cache
-          VPackSlice cachedData(finding.value()->value());
-          TRI_ASSERT(cachedData.isArray());
-          if (cachedData.length() / 2 < limit) {
-            // Directly return it, no need to copy
-            _builderIterator = VPackArrayIterator(cachedData);
-            while (_builderIterator.valid()) {
-              TRI_ASSERT(_builderIterator.value().isNumber());
-              LocalDocumentId docId{
-                  _builderIterator.value().getNumericValue<uint64_t>()};
 
-              _builderIterator.next();
+        // build actual cache lookup key. this is either the value of fromTo,
+        // or a suffix of it in case fromTo starts with the cached collection
+        // name, and an empty string_view if the lookup value is invalid.
+        cacheKey = _index->buildCompressedCacheKey(cacheKeyCollection, fromTo);
+        TRI_ASSERT(cacheKey.empty() || cacheKey == fromTo ||
+                   fromTo.ends_with(cacheKey));
 
-              TRI_ASSERT(_builderIterator.valid());
-              TRI_ASSERT(_builderIterator.value().isString());
-              std::forward<F>(cb)(docId, _builderIterator.value());
+        if (!cacheKey.empty()) {
+          // only look up a key in the cache if the key is syntactially valid.
+          // this is important because we can only tell syntactically valid keys
+          // apart from prefix-compressed keys.
+          auto finding = _cache->find(cacheKey.data(),
+                                      static_cast<uint32_t>(cacheKey.size()));
 
-              _builderIterator.next();
-              limit--;
+          if (finding.found()) {
+            incrCacheHits();
+            needRocksLookup = false;
+            // We got sth. in the cache
+            VPackSlice cachedData(finding.value()->value());
+            TRI_ASSERT(cachedData.isArray());
+            if (cachedData.length() / 2 < limit) {
+              // Directly return it, no need to copy
+              _builderIterator = VPackArrayIterator(cachedData);
+              while (_builderIterator.valid()) {
+                TRI_ASSERT(_builderIterator.value().isNumber());
+                LocalDocumentId docId{
+                    _builderIterator.value().getNumericValue<uint64_t>()};
+
+                _builderIterator.next();
+
+                TRI_ASSERT(_builderIterator.valid());
+                VPackSlice fromTo = _builderIterator.value();
+                TRI_ASSERT(fromTo.isString());
+                std::string_view v = fromTo.stringView();
+                TRI_ASSERT(!v.empty());
+                if (v.front() == '/') {
+                  // prefix-compressed value
+                  cacheValueCollection =
+                      _index->cachedValueCollection(cacheValueCollection);
+                  TRI_ASSERT(cacheValueCollection != nullptr);
+                  _idBuilder.clear();
+                  // collection name  and  key including forward slash
+                  _idBuilder.add(
+                      VPackValueString2Parts(*cacheValueCollection, v));
+                  fromTo = _idBuilder.slice();
+                }
+
+                std::forward<F>(cb)(docId, fromTo);
+
+                _builderIterator.next();
+                limit--;
+              }
+              _builderIterator =
+                  VPackArrayIterator(VPackArrayIterator::Empty{});
+            } else {
+              // We need to copy it.
+              // And then we just get back to beginning of the loop
+              _builder.clear();
+              _builder.add(cachedData);
+              TRI_ASSERT(_builder.slice().isArray());
+              _builderIterator = VPackArrayIterator(_builder.slice());
+              // Do not set limit
             }
-            _builderIterator = VPackArrayIterator(VPackArrayIterator::Empty{});
           } else {
-            // We need to copy it.
-            // And then we just get back to beginning of the loop
-            _builder.clear();
-            _builder.add(cachedData);
-            TRI_ASSERT(_builder.slice().isArray());
-            _builderIterator = VPackArrayIterator(_builder.slice());
-            // Do not set limit
+            incrCacheMisses();
           }
-        } else {
-          incrCacheMisses();
         }
       }  // if (_cache)
 
       if (needRocksLookup) {
-        lookupInRocksDB(fromTo);
+        lookupInRocksDB(fromTo, cacheKey);
       }
 
       _keysIterator.next();
@@ -303,13 +344,11 @@ class RocksDBEdgeIndexLookupIterator final : public IndexIterator {
     return _builderIterator.valid() || _keysIterator.valid();
   }
 
-  void lookupInRocksDB(std::string_view fromTo) {
-    // Bad (slow) case: read from RocksDB
-
+  void lookupInRocksDB(std::string_view fromTo, std::string_view cacheKey) {
+    // slow case: read from RocksDB
     auto* mthds = RocksDBTransactionState::toMethods(_trx, _collection->id());
 
-    // create iterator only on demand, so we save the allocation in case
-    // the reads can be satisfied from the cache
+    std::string* cacheValueCollection = nullptr;
 
     // unfortunately we *must* create a new RocksDB iterator here for each edge
     // lookup. the problem is that if we don't and reuse an existing RocksDB
@@ -354,7 +393,13 @@ class RocksDBEdgeIndexLookupIterator final : public IndexIterator {
       // adding documentId and _from or _to value
       _builder.add(VPackValue(docId.id()));
       std::string_view vertexId = RocksDBValue::vertexId(iterator->value());
-      _builder.add(VPackValue(vertexId));
+
+      // construct a potentially prefix-compressed vertex id from the original
+      // _from/_to value
+      std::string_view cacheValue =
+          _index->buildCompressedCacheValue(cacheValueCollection, vertexId);
+      TRI_ASSERT(!cacheValue.empty() && vertexId.ends_with(cacheValue));
+      _builder.add(VPackValue(cacheValue));
     }
     _builder.close();
 
@@ -362,12 +407,14 @@ class RocksDBEdgeIndexLookupIterator final : public IndexIterator {
     rocksutils::checkIteratorStatus(*iterator);
 
     if (_cache != nullptr) {
-      // TODO Add cache retry on next call
-      // Now we have something in _inplaceMemory.
-      // It may be an empty array or a filled one, never mind, we cache both
+      // key to store value under in the cache. we will use cacheKey is set, and
+      // fromTo otherwise.
+      std::string_view key = cacheKey.empty() ? fromTo : cacheKey;
+      // the value we store in the cache may be an empty array or a non-empty
+      // one. we don't care and cache both.
       cache::Cache::SimpleInserter<EdgeIndexCacheType>{
-          static_cast<EdgeIndexCacheType&>(*_cache), fromTo.data(),
-          static_cast<uint32_t>(fromTo.size()), _builder.slice().start(),
+          static_cast<EdgeIndexCacheType&>(*_cache), key.data(),
+          static_cast<uint32_t>(key.size()), _builder.slice().start(),
           static_cast<uint64_t>(_builder.slice().byteSize())};
     }
     TRI_ASSERT(_builder.slice().isArray());
@@ -381,6 +428,8 @@ class RocksDBEdgeIndexLookupIterator final : public IndexIterator {
   velocypack::ArrayIterator _keysIterator;
 
   RocksDBKeyBounds _bounds;
+  // used to build temporary _from/_to values from compressed values
+  velocypack::Builder _idBuilder;
 
   // the following values are required for correct batch handling
   velocypack::Builder _builder;
@@ -392,7 +441,7 @@ class RocksDBEdgeIndexLookupIterator final : public IndexIterator {
 
 // ============================= Index ====================================
 
-uint64_t RocksDBEdgeIndex::HashForKey(rocksdb::Slice const& key) {
+uint64_t RocksDBEdgeIndex::HashForKey(rocksdb::Slice key) {
   std::hash<std::string_view> hasher{};
   // NOTE: This function needs to use the same hashing on the
   // indexed VPack as the initial inserter does
@@ -437,7 +486,6 @@ RocksDBEdgeIndex::RocksDBEdgeIndex(IndexId iid, LogicalCollection& collection,
                             .server()
                             .getFeature<RocksDBIndexCacheRefillFeature>()
                             .autoRefill()),
-      _estimator(nullptr),
       _coveredFields({{AttributeName(attr, false)},
                       {AttributeName((_isFromIndex ? StaticStrings::ToString
                                                    : StaticStrings::FromString),
@@ -577,8 +625,15 @@ void RocksDBEdgeIndex::refillCache(transaction::Methods& trx,
                                     std::move(keysBuilder), _cache,
                                     ReadOwnWrites::no);
 
+  std::string* cacheKeyCollection = nullptr;
+
   for (auto const& key : keys) {
-    it.lookupInRocksDB(VPackStringRef(key.data(), key.size()));
+    std::string_view fromTo = {key.data(), key.size()};
+    std::string_view cacheKey =
+        buildCompressedCacheKey(cacheKeyCollection, fromTo);
+    TRI_ASSERT(cacheKey.empty() || cacheKey == fromTo ||
+               fromTo.ends_with(cacheKey));
+    it.lookupInRocksDB(fromTo, cacheKey);
   }
 }
 
@@ -586,14 +641,21 @@ void RocksDBEdgeIndex::handleCacheInvalidation(transaction::Methods& trx,
                                                OperationOptions const& options,
                                                std::string_view fromToRef) {
   // always invalidate cache entry for all edges with same _from / _to
-  invalidateCacheEntry(fromToRef);
 
-  if (_cache != nullptr &&
-      ((_forceCacheRefill &&
-        options.refillIndexCaches != RefillIndexCaches::kDontRefill) ||
-       options.refillIndexCaches == RefillIndexCaches::kRefill)) {
-    RocksDBTransactionState::toState(&trx)->trackIndexCacheRefill(
-        _collection.id(), id(), fromToRef);
+  // adjust key for potential prefix compression
+  std::string* cacheKeyCollection = nullptr;
+  std::string_view cacheKey =
+      buildCompressedCacheKey(cacheKeyCollection, fromToRef);
+  if (!cacheKey.empty()) {
+    invalidateCacheEntry(cacheKey);
+
+    if (_cache != nullptr &&
+        ((_forceCacheRefill &&
+          options.refillIndexCaches != RefillIndexCaches::kDontRefill) ||
+         options.refillIndexCaches == RefillIndexCaches::kRefill)) {
+      RocksDBTransactionState::toState(&trx)->trackIndexCacheRefill(
+          _collection.id(), id(), fromToRef);
+    }
   }
 }
 
@@ -683,10 +745,10 @@ Result RocksDBEdgeIndex::warmup() {
 void RocksDBEdgeIndex::warmupInternal(transaction::Methods* trx,
                                       rocksdb::Slice lower,
                                       rocksdb::Slice upper) {
+  cache::Cache* cc = _cache.get();
+  TRI_ASSERT(cc != nullptr);
+
   auto rocksColl = toRocksDBCollection(_collection);
-  bool needsInsert = false;
-  std::string previous;
-  VPackBuilder builder;
 
   // intentional copy of the read options
   auto* mthds = RocksDBTransactionState::toMethods(trx, _collection.id());
@@ -701,15 +763,18 @@ void RocksDBEdgeIndex::warmupInternal(transaction::Methods* trx,
       _engine.db()->NewIterator(options, _cf));
 
   ManagedDocumentResult mdr;
+  bool needsInsert = false;
+  std::string previous;
+  VPackBuilder builder;
+  std::string* cacheKeyCollection = nullptr;
+  std::string_view cacheKey;
 
   size_t n = 0;
-  cache::Cache* cc = _cache.get();
   for (it->Seek(lower); it->Valid(); it->Next()) {
     ++n;
-    if (n % 1024 == 0) {
-      if (collection().vocbase().server().isStopping()) {
-        return;
-      }
+    if (n % 1024 == 0 && collection().vocbase().server().isStopping()) {
+      // periodically check for server shutdown
+      return;
     }
 
     rocksdb::Slice key = it->key();
@@ -718,10 +783,16 @@ void RocksDBEdgeIndex::warmupInternal(transaction::Methods* trx,
       // First call.
       builder.clear();
       previous = v;
+
+      // build cache lookup key (can be prefix-compressed)
+      cacheKey = buildCompressedCacheKey(cacheKeyCollection, previous);
+      // the lookup keys we get from RocksDB *must* be valid
+      TRI_ASSERT(!cacheKey.empty() && previous.ends_with(cacheKey));
+
       bool shouldTry = true;
       while (shouldTry) {
         auto finding =
-            cc->find(previous.data(), static_cast<uint32_t>(previous.size()));
+            cc->find(cacheKey.data(), static_cast<uint32_t>(cacheKey.size()));
         if (finding.found()) {
           shouldTry = false;
           needsInsert = false;
@@ -741,16 +812,21 @@ void RocksDBEdgeIndex::warmupInternal(transaction::Methods* trx,
         builder.close();
 
         cache::Cache::SimpleInserter<EdgeIndexCacheType>{
-            static_cast<EdgeIndexCacheType&>(*cc), previous.data(),
-            static_cast<uint32_t>(previous.size()), builder.slice().start(),
+            static_cast<EdgeIndexCacheType&>(*cc), cacheKey.data(),
+            static_cast<uint32_t>(cacheKey.size()), builder.slice().start(),
             static_cast<uint64_t>(builder.slice().byteSize())};
 
         builder.clear();
       }
       // Need to store
       previous = v;
+      // build cache lookup key (can be prefix-compressed)
+      cacheKey = buildCompressedCacheKey(cacheKeyCollection, previous);
+      // the lookup keys we get from RocksDB *must* be valid
+      TRI_ASSERT(!cacheKey.empty() && previous.ends_with(cacheKey));
+
       auto finding =
-          cc->find(previous.data(), static_cast<uint32_t>(previous.size()));
+          cc->find(cacheKey.data(), static_cast<uint32_t>(cacheKey.size()));
       if (finding.found()) {
         needsInsert = false;
       } else {
@@ -781,11 +857,14 @@ void RocksDBEdgeIndex::warmupInternal(transaction::Methods* trx,
     // We still have something to store
     builder.close();
 
+    TRI_ASSERT(!cacheKey.empty() && previous.ends_with(cacheKey));
+
     cache::Cache::SimpleInserter<EdgeIndexCacheType>{
-        static_cast<EdgeIndexCacheType&>(*cc), previous.data(),
-        static_cast<uint32_t>(previous.size()), builder.slice().start(),
+        static_cast<EdgeIndexCacheType&>(*cc), cacheKey.data(),
+        static_cast<uint32_t>(cacheKey.size()), builder.slice().start(),
         static_cast<uint64_t>(builder.slice().byteSize())};
   }
+
   LOG_TOPIC("99a29", DEBUG, Logger::ENGINES) << "loaded n: " << n;
 }
 
@@ -909,4 +988,89 @@ void RocksDBEdgeIndex::recalculateEstimates() {
     _estimator->insert(hash);
   }
   _estimator->setAppliedSeq(seq);
+}
+
+std::string_view RocksDBEdgeIndex::buildCompressedCacheKey(
+    std::string*& previous, std::string_view value) const {
+  return _cacheKeyCollectionName.buildCompressedValue(previous, value);
+}
+
+std::string_view RocksDBEdgeIndex::buildCompressedCacheValue(
+    std::string*& previous, std::string_view value) const {
+  return _cacheValueCollectionName.buildCompressedValue(previous, value);
+}
+
+std::string const* RocksDBEdgeIndex::cachedValueCollection(
+    std::string const*& previous) const noexcept {
+  if (previous == nullptr) {
+    previous = _cacheValueCollectionName.get();
+  }
+  TRI_ASSERT(previous != nullptr);
+  return previous;
+}
+
+RocksDBEdgeIndex::CachedCollectionName::CachedCollectionName() noexcept
+    : _name(nullptr) {}
+
+RocksDBEdgeIndex::CachedCollectionName::~CachedCollectionName() {
+  delete _name.load(std::memory_order_relaxed);
+}
+
+std::string_view RocksDBEdgeIndex::CachedCollectionName::buildCompressedValue(
+    std::string*& previous, std::string_view value) const {
+  // split lookup value to determine collection name and key parts
+  auto pos = value.find('/');
+
+  if (pos == std::string_view::npos || pos == 0 || pos + 1 == value.size() ||
+      value[pos + 1] == '/') {
+    // totally invalid lookup value
+    value = {};
+  } else if (previous == nullptr) {
+    // no context yet. now try looking up cached collection name
+    previous = _name.load(std::memory_order_relaxed);
+    if (previous == nullptr) {
+      // no cached collection name yet. now try to store the collection name
+      // we determined ourselves. create a string with the collection name on
+      // the heap
+      auto cn = std::make_unique<std::string>(value.data(), pos);
+      // try to store the name. this can race with other threads.
+      // TODO: fix memory order
+      if (_name.compare_exchange_strong(previous, cn.get())) {
+        // we won the race and were able to store our value. now we are owning
+        // the collection name.
+        previous = cn.release();
+      } else {
+        // we lost the race. now we need to fetch the name another thread
+        // stored.
+        // TODO: fix memory order
+        previous = _name.load();
+      }
+    }
+
+    // here we must have a collection name
+    TRI_ASSERT(previous != nullptr);
+
+    // now check if the collection name in the value we got matches the cached
+    // name.
+    TRI_ASSERT(!previous->empty());
+    // must have at least 'c/k'
+    TRI_ASSERT(value.size() > 2);
+    if (*previous == value.substr(0, pos)) {
+      // match. now return the remainder of the value, including the `/` at the
+      // front.
+      value = value.substr(pos);
+      // must have at least '/k'
+      TRI_ASSERT(value.size() > 1);
+      TRI_ASSERT(value.starts_with('/'));
+      // cannot have '//...'
+      TRI_ASSERT(value[1] != '/');
+    }
+  }
+
+  return value;
+}
+
+std::string const* RocksDBEdgeIndex::CachedCollectionName::get()
+    const noexcept {
+  return _name.load(std::memory_order_relaxed);
 }

--- a/arangod/RocksDBEngine/RocksDBEdgeIndex.h
+++ b/arangod/RocksDBEngine/RocksDBEdgeIndex.h
@@ -30,11 +30,15 @@
 #include "Indexes/Index.h"
 #include "Indexes/IndexIterator.h"
 #include "RocksDBEngine/RocksDBIndex.h"
-#include "RocksDBEngine/RocksDBKey.h"
-#include "RocksDBEngine/RocksDBKeyBounds.h"
 #include "VocBase/Identifiers/IndexId.h"
 #include "VocBase/voc-types.h"
 #include "VocBase/vocbase.h"
+
+#include <atomic>
+#include <cstdint>
+#include <string>
+#include <string_view>
+#include <vector>
 
 namespace arangodb {
 class DatabaseFeature;
@@ -44,7 +48,7 @@ class RocksDBEdgeIndex final : public RocksDBIndex {
   friend class RocksDBEdgeIndexLookupIterator;
 
  public:
-  static uint64_t HashForKey(rocksdb::Slice const& key);
+  static uint64_t HashForKey(rocksdb::Slice key);
 
   RocksDBEdgeIndex() = delete;
 
@@ -108,6 +112,49 @@ class RocksDBEdgeIndex final : public RocksDBIndex {
   void refillCache(transaction::Methods& trx,
                    std::vector<std::string> const& keys) override;
 
+  // build a potentially prefix compressed lookup key for cache lookups.
+  // the return value is either
+  // - an empty std::string_view if the lookup value is syntactically
+  //   invalid (syntactially invalid _from/_to value),
+  // - identical to the input lookup value if the collection name in the
+  //   lookup value is not identical to the cached collection name
+  // - a suffix of the original lookup value (starting with the forward
+  //   slash) if the collection name of the lookup value matches the
+  //   cached collection name (e.g. 'someCollection/abc' will be returned
+  //   as just '/abc' if the cached collection name is 'someCollection''.
+  // note: previous is an in/out parameter and can be used to memoize
+  // the result of the collection name lookup between multiple calls of
+  // this function. this is a performance optimization to avoid repeated
+  // atomic lookups of the collection name once it is already known.
+  // note: returns an empty string view for invalid lookup values!
+  std::string_view buildCompressedCacheKey(std::string*& previous,
+                                           std::string_view value) const;
+  std::string_view buildCompressedCacheValue(std::string*& previous,
+                                             std::string_view value) const;
+
+  std::string const* cachedValueCollection(
+      std::string const*& previous) const noexcept;
+
+  class CachedCollectionName {
+   public:
+    CachedCollectionName() noexcept;
+    ~CachedCollectionName();
+
+    // note: previous is an in/out parameter and can be used to memoize
+    // the result of the collection name lookup between multiple calls of
+    // this function. this is a performance optimization to avoid repeated
+    // atomic lookups of the collection name once it is already known.
+    // note: returns an empty string view for invalid lookup values!
+    // TODO: make std::string const
+    std::string_view buildCompressedValue(std::string*& previous,
+                                          std::string_view value) const;
+
+    std::string const* get() const noexcept;
+
+   private:
+    std::atomic<std::string*> mutable _name;
+  };
+
  private:
   std::unique_ptr<IndexIterator> createEqIterator(transaction::Methods*,
                                                   aql::AstNode const*,
@@ -139,8 +186,16 @@ class RocksDBEdgeIndex final : public RocksDBIndex {
 
   // name of direction attribute (i.e. "_from" or "_to")
   std::string const _directionAttr;
+
+  // cached collection name for edge index cache keys
+  CachedCollectionName _cacheKeyCollectionName;
+
+  // cached collection name for edge index cache values
+  CachedCollectionName _cacheValueCollectionName;
+
   // whether or not this is the _from part
   bool const _isFromIndex;
+
   // if true, force a refill of the in-memory cache after each
   // insert/update/replace operation
   bool const _forceCacheRefill;


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/18068

Improve memory usage of in-memory edge cache. This is achieved by compressing the ids of lookup keys and mapped values (i.e. `_from` and `_to` values) in case the collection name in `_from` or `_to` matches the collection name cached by the in-memory index.
That cached collection name is automatically determined by the first operation on the in-memory edge index by the first `_from` / `_to` values used.
For the index on `_from`, the collection name part of the first lookup value will be used as prefix of cache keys, and the collection name part of the first mapped `_to` value will be used a prefix of cached values.
For the index on `_to`, the collection name part of the first lookup value will be used as prefix of cache keys, and the collection name part of the first mapped `_from` value will be used a prefix of cached values.
That means the cached collection names in `_from` and `_to` are independent. 
The compressed `_from` and `_to` values will only be used in memory, but will never be stored as such in RocksDB.

The optimization can help to reduce memory usage of the in-memory edge cache if many edges share the initially used (cached) collection name. It should not help much if many different edge collections are used.
Currently the optimization is enabled automatically and cannot be turned off.
We have to run performance tests to see if the change can actually make performance worse in some case (e.g. many different edge collections). We also have to check how far this change can reduce memory usage of the in-memory edge index.
There is also currently some inefficiency while building back the full `_from` / `_to` value from a compressed key / value, which very likely can be improved with a bit of effort.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [x] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.10: this PR
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 