### PR TITLE
[testing] make sure tests cleanup their instances directories and temporary files

### DIFF
--- a/js/client/modules/@arangodb/testsuites/dump.js
+++ b/js/client/modules/@arangodb/testsuites/dump.js
@@ -115,10 +115,11 @@ class DumpRestoreHelper extends tu.runInArangoshRunner {
     let doCleanup = this.options.cleanup && (this.results.failed === 0) && cleanup;
     if (doCleanup) {
       if (this.im1 != null) {
-        this.im1.destructor();
+        print('santoeuh')
+        this.im1.destructor(this.results.failed === 0);
       }
       if (this.im2 != null) {
-        this.im2.destructor();
+        this.im2.destructor(this.results.failed === 0);
       }
       [this.keyDir,
        this.otherKeyDir,
@@ -314,7 +315,7 @@ class DumpRestoreHelper extends tu.runInArangoshRunner {
     }
     print(CYAN + 'Shutting down...' + RESET);
     this.results['shutdown'] = this.instanceManager.shutdownInstance();
-    this.instanceManager.destructor(this.results.failed === 0);
+    this.instanceManager.destructor(false);
     print(CYAN + 'done.' + RESET);
 
     print();

--- a/js/client/modules/@arangodb/testsuites/dump.js
+++ b/js/client/modules/@arangodb/testsuites/dump.js
@@ -305,7 +305,7 @@ class DumpRestoreHelper extends tu.runInArangoshRunner {
   }
 
   extractResults() {
-    if (this.fn !== undefined) {
+    if (this.fn !== undefined && fs.exists(this.fn)) {
       fs.remove(this.fn);
     }
     if (this.instanceManager === null) {

--- a/js/client/modules/@arangodb/testsuites/dump.js
+++ b/js/client/modules/@arangodb/testsuites/dump.js
@@ -120,8 +120,15 @@ class DumpRestoreHelper extends tu.runInArangoshRunner {
       return this.results;
     }
     print(CYAN + 'Shutting down...' + RESET);
+    if (this.im1.detectShouldBeRunning()) {
+      this.im1.reconnect();
+    }
     this.results['shutdown'] = this.im1.shutdownInstance();
+
     if (this.im2 !== null) {
+      if (this.im2.detectShouldBeRunning()) {
+        this.im2.reconnect();
+      }
       this.results['shutdown'] &= this.im2.shutdownInstance();
     }
     print(CYAN + 'done.' + RESET);
@@ -267,8 +274,6 @@ class DumpRestoreHelper extends tu.runInArangoshRunner {
     if (this.restartServer) {
       print(CYAN + 'Shutting down...' + RESET);
       let rootDir = fs.join(fs.getTempPath(), '2');
-      this.results['shutdown'] = this.instanceManager.shutdownInstance();
-      this.instanceManager.destructor(false); // must not cleanup!
       print(CYAN + 'done.' + RESET);
       this.which = this.which + "_2";
       this.instanceManager = this.im2 = new im.instanceManager('tcp', this.secondRunOptions, this.serverOptions, this.which, rootDir);

--- a/js/client/modules/@arangodb/testsuites/dump.js
+++ b/js/client/modules/@arangodb/testsuites/dump.js
@@ -228,7 +228,8 @@ class DumpRestoreHelper extends tu.runInArangoshRunner {
   }
 
   startFirstInstance() {
-    this.instanceManager = this.im1 = new im.instanceManager('tcp', this.firstRunOptions, this.serverOptions, this.which);
+    let rootDir = fs.join(fs.getTempPath(), '1');
+    this.instanceManager = this.im1 = new im.instanceManager('tcp', this.firstRunOptions, this.serverOptions, this.which, rootDir);
     this.instanceManager.prepareInstance();
     this.instanceManager.launchTcpDump("");
     if (!this.instanceManager.launchInstance()) {
@@ -252,11 +253,12 @@ class DumpRestoreHelper extends tu.runInArangoshRunner {
   restartInstance() {
     if (this.restartServer) {
       print(CYAN + 'Shutting down...' + RESET);
+      let rootDir = fs.join(fs.getTempPath(), '2');
       this.results['shutdown'] = this.instanceManager.shutdownInstance();
       this.instanceManager.destructor(false); // must not cleanup!
       print(CYAN + 'done.' + RESET);
       this.which = this.which + "_2";
-      this.instanceManager = this.im2 = new im.instanceManager('tcp', this.secondRunOptions, this.serverOptions, this.which);
+      this.instanceManager = this.im2 = new im.instanceManager('tcp', this.secondRunOptions, this.serverOptions, this.which, rootDir);
       this.instanceManager.prepareInstance();
       this.instanceManager.launchTcpDump("");
       if (!this.instanceManager.launchInstance()) {

--- a/js/client/modules/@arangodb/testsuites/dump.js
+++ b/js/client/modules/@arangodb/testsuites/dump.js
@@ -114,7 +114,7 @@ class DumpRestoreHelper extends tu.runInArangoshRunner {
   destructor(cleanup) {
     let doCleanup = this.options.cleanup && (this.results.failed === 0) && cleanup;
     if (doCleanup) {
-      if (this.im1 != null) {
+      if (this.im1 !== null) {
         this.im1.destructor(this.results.failed === 0);
       }
       if (this.im2 != null) {

--- a/js/client/modules/@arangodb/testsuites/dump.js
+++ b/js/client/modules/@arangodb/testsuites/dump.js
@@ -105,6 +105,8 @@ class DumpRestoreHelper extends tu.runInArangoshRunner {
     this.restoreOldConfig = false;
     this.afterServerStart = afterServerStart;
     this.instanceManager = null;
+    this.im1 = null;
+    this.im2 = null;
     this.keyDir = null;
     this.otherKeyDir = null;
   }
@@ -112,6 +114,12 @@ class DumpRestoreHelper extends tu.runInArangoshRunner {
   destructor(cleanup) {
     let doCleanup = this.options.cleanup && (this.results.failed === 0) && cleanup;
     if (doCleanup) {
+      if (this.im1 != null) {
+        this.im1.destructor();
+      }
+      if (this.im2 != null) {
+        this.im2.destructor();
+      }
       [this.keyDir,
        this.otherKeyDir,
        this.dumpConfig.getOutputDirectory()].forEach(dir => {
@@ -220,7 +228,7 @@ class DumpRestoreHelper extends tu.runInArangoshRunner {
   }
 
   startFirstInstance() {
-    this.instanceManager = new im.instanceManager('tcp', this.firstRunOptions, this.serverOptions, this.which);
+    this.instanceManager = this.im1 = new im.instanceManager('tcp', this.firstRunOptions, this.serverOptions, this.which);
     this.instanceManager.prepareInstance();
     this.instanceManager.launchTcpDump("");
     if (!this.instanceManager.launchInstance()) {
@@ -248,7 +256,7 @@ class DumpRestoreHelper extends tu.runInArangoshRunner {
       this.instanceManager.destructor(false); // must not cleanup!
       print(CYAN + 'done.' + RESET);
       this.which = this.which + "_2";
-      this.instanceManager = new im.instanceManager('tcp', this.secondRunOptions, this.serverOptions, this.which);
+      this.instanceManager = this.im2 = new im.instanceManager('tcp', this.secondRunOptions, this.serverOptions, this.which);
       this.instanceManager.prepareInstance();
       this.instanceManager.launchTcpDump("");
       if (!this.instanceManager.launchInstance()) {

--- a/js/client/modules/@arangodb/testsuites/dump.js
+++ b/js/client/modules/@arangodb/testsuites/dump.js
@@ -117,7 +117,7 @@ class DumpRestoreHelper extends tu.runInArangoshRunner {
       if (this.im1 !== null) {
         this.im1.destructor(this.results.failed === 0);
       }
-      if (this.im2 != null) {
+      if (this.im2 !== null) {
         this.im2.destructor(this.results.failed === 0);
       }
       [this.keyDir,

--- a/js/client/modules/@arangodb/testsuites/dump.js
+++ b/js/client/modules/@arangodb/testsuites/dump.js
@@ -115,7 +115,6 @@ class DumpRestoreHelper extends tu.runInArangoshRunner {
     let doCleanup = this.options.cleanup && (this.results.failed === 0) && cleanup;
     if (doCleanup) {
       if (this.im1 != null) {
-        print('santoeuh')
         this.im1.destructor(this.results.failed === 0);
       }
       if (this.im2 != null) {

--- a/js/client/modules/@arangodb/testsuites/dump.js
+++ b/js/client/modules/@arangodb/testsuites/dump.js
@@ -966,6 +966,7 @@ function hotBackup (options) {
 
   const helper = new DumpRestoreHelper(options, options, addArgs, {}, options, options, which, function(){});
   if (!helper.startFirstInstance()) {
+      helper.destructor(false);
     return helper.extractResults();
   }
 
@@ -991,6 +992,7 @@ function hotBackup (options) {
       !helper.restoreHotBackup() ||
       !helper.runTests(dumpCheck, 'UnitTestsDumpDst')||
       !helper.tearDown(tearDownFile)) {
+      helper.destructor(true);
     return helper.extractResults();
   }
 
@@ -1000,6 +1002,7 @@ function hotBackup (options) {
     const oldTestFile = tu.makePathUnix(fs.join(testPaths[which][0], tstFiles.dumpCheckGraph));
     if (!helper.restoreOld(restoreDir) ||
         !helper.testRestoreOld(oldTestFile)) {
+      helper.destructor(true);
       return helper.extractResults();
     }
   }
@@ -1012,6 +1015,7 @@ function hotBackup (options) {
         !helper.testFoxxAppsBundle(foxxTestFile, 'UnitTestsDumpFoxxAppsBundle') ||
         !helper.restoreFoxxAppsBundle('UnitTestsDumpFoxxBundleApps') ||
         !helper.testFoxxAppsBundle(foxxTestFile, 'UnitTestsDumpFoxxBundleApps')) {
+      helper.destructor(true);
       return helper.extractResults();
     }
   }
@@ -1019,6 +1023,7 @@ function hotBackup (options) {
   if (options.cleanup) {
     fs.removeDirectoryRecursive(keyDir, true);
   }
+  helper.destructor(true);
   return helper.extractResults();
 }
 

--- a/js/client/modules/@arangodb/testsuites/dump.js
+++ b/js/client/modules/@arangodb/testsuites/dump.js
@@ -112,6 +112,19 @@ class DumpRestoreHelper extends tu.runInArangoshRunner {
   }
 
   destructor(cleanup) {
+    if (this.fn !== undefined && fs.exists(this.fn)) {
+      fs.remove(this.fn);
+    }
+    if (this.instanceManager === null) {
+      print(RED + 'no instance running. Nothing to stop!' + RESET);
+      return this.results;
+    }
+    print(CYAN + 'Shutting down...' + RESET);
+    this.results['shutdown'] = this.im1.shutdownInstance();
+    if (this.im2 !== null) {
+      this.results['shutdown'] &= this.im2.shutdownInstance();
+    }
+    print(CYAN + 'done.' + RESET);
     let doCleanup = this.options.cleanup && (this.results.failed === 0) && cleanup;
     if (doCleanup) {
       if (this.im1 !== null) {
@@ -307,18 +320,6 @@ class DumpRestoreHelper extends tu.runInArangoshRunner {
   }
 
   extractResults() {
-    if (this.fn !== undefined && fs.exists(this.fn)) {
-      fs.remove(this.fn);
-    }
-    if (this.instanceManager === null) {
-      print(RED + 'no instance running. Nothing to stop!' + RESET);
-      return this.results;
-    }
-    print(CYAN + 'Shutting down...' + RESET);
-    this.results['shutdown'] = this.instanceManager.shutdownInstance();
-    this.instanceManager.destructor(false);
-    print(CYAN + 'done.' + RESET);
-
     print();
     return this.results;
   }

--- a/js/client/modules/@arangodb/testsuites/export.js
+++ b/js/client/modules/@arangodb/testsuites/export.js
@@ -61,6 +61,8 @@ class exportRunner extends tu.runInArangoshRunner {
   shutdown (results) {
     print(CYAN + 'Shutting down...' + RESET);
     results['shutdown'] = this.instanceManager.shutdownInstance(false);
+    results.status = results.failed === 0 && results['shutdown'];
+    this.instanceManager.destructor(results.status);
     print(CYAN + 'done.' + RESET);
     print();
     return results;

--- a/js/client/modules/@arangodb/testsuites/server_permissions.js
+++ b/js/client/modules/@arangodb/testsuites/server_permissions.js
@@ -65,12 +65,14 @@ class permissionsRunner extends tu.runLocalInArangoshRunner {
     this.info = "runInDriverTest";
   }
   run(testList) {
+    let tmpDir = fs.getTempPath();
     let beforeStart = time();
     this.continueTesting = true;
     this.testList = testList;
     let testrunStart = time();
     this.results = {
       shutdown: true,
+      status: true,
       startupTime: testrunStart - beforeStart
     };
     let serverDead = false;
@@ -144,6 +146,7 @@ class permissionsRunner extends tu.runLocalInArangoshRunner {
               shutdown: shutdownStatus
             };
             this.results['shutdown'] = this.results['shutdown'] && shutdownStatus;
+            this.results.status = false;
             return this.results;
           }
           if (this.instanceManager.shutdownInstance(forceTerminate)) {                                            // stop
@@ -248,6 +251,9 @@ class permissionsRunner extends tu.runLocalInArangoshRunner {
           print('Skipped ' + te + ' because of ' + filtered.filter);
         }
       }
+    }
+    if (this.results.status && this.options.cleanup) {
+      fs.removeDirectoryRecursive(tmpDir, true);
     }
     return this.results;
   }

--- a/js/client/modules/@arangodb/testutils/instance-manager.js
+++ b/js/client/modules/@arangodb/testutils/instance-manager.js
@@ -772,7 +772,7 @@ class instanceManager {
 
   detectShouldBeRunning() {
     let ret = true;
-    this.arangods.forEach(arangod => { ret = ret && arangod.pid !== null} );
+    this.arangods.forEach(arangod => { ret = ret && arangod.pid !== null; } );
     return ret;
   }
 

--- a/js/client/modules/@arangodb/testutils/instance-manager.js
+++ b/js/client/modules/@arangodb/testutils/instance-manager.js
@@ -770,6 +770,12 @@ class instanceManager {
     }
   }
 
+  detectShouldBeRunning() {
+    let ret = true;
+    this.arangods.forEach(arangod => { ret = ret && arangod.pid !== null} );
+    return ret;
+  }
+
   // //////////////////////////////////////////////////////////////////////////////
   // / @brief shuts down an instance
   // //////////////////////////////////////////////////////////////////////////////

--- a/js/client/modules/@arangodb/testutils/instance.js
+++ b/js/client/modules/@arangodb/testutils/instance.js
@@ -528,6 +528,12 @@ class instance {
   // //////////////////////////////////////////////////////////////////////////////
 
   readAssertLogLines (expectAsserts) {
+    if (!fs.exists(this.logFile)) {
+      if (fs.exists(this.rootDir)) {
+        print(`readAssertLogLines: Logfile ${this.logFile} already gone.`);
+      }
+      return;
+    }
     let size = fs.size(this.logFile);
     if (this.options.maxLogFileSize !== 0 && size > this.options.maxLogFileSize) {
       // File bigger 500k? this needs to be a bug in the tests.

--- a/js/client/modules/@arangodb/testutils/instance.js
+++ b/js/client/modules/@arangodb/testutils/instance.js
@@ -520,7 +520,9 @@ class instance {
     if (this.options.extremeVerbosity) {
       print(CYAN + "cleaning up " + this.name + " 's Directory: " + this.rootDir + RESET);
     }
-    fs.removeDirectoryRecursive(this.rootDir, true);
+    if (fs.exists(this.rootDir)) {
+      fs.removeDirectoryRecursive(this.rootDir, true);
+    }
   }
 
   // //////////////////////////////////////////////////////////////////////////////

--- a/tests/js/client/shell/shell-dump-integration.js
+++ b/tests/js/client/shell/shell-dump-integration.js
@@ -346,41 +346,32 @@ function dumpIntegrationSuite() {
 
     testDumpForCollectionWithSchema: function () {
       let path = fs.getTempFile();
-      try {
-        let args = ['--collection', cn + "WithSchema", '--compress-output', 'false'];
-        let tree = runDump(path, args, 0);
-        checkEncryption(tree, path, "none");
-        checkStructureFile(tree, path, true, cn + "WithSchema");
-        checkDataFile(tree, path, false, false, false, cn + "WithSchema");
-      } finally {
-        fs.removeDirectoryRecursive(path, true);
-      }
+      let args = ['--collection', cn + "WithSchema", '--compress-output', 'false'];
+      let tree = runDump(path, args, 0);
+      checkEncryption(tree, path, "none");
+      checkStructureFile(tree, path, true, cn + "WithSchema");
+      checkDataFile(tree, path, false, false, false, cn + "WithSchema");
+      fs.removeDirectoryRecursive(path, true);
     },
 
     testDumpForCollectionWithComputedValuesUncompressed: function () {
       let path = fs.getTempFile();
-      try {
-        let args = ['--collection', cn + "ComputedValues", '--compress-output', 'false'];
-        let tree = runDump(path, args, 0);
-        checkEncryption(tree, path, "none");
-        checkStructureFile(tree, path, true, cn + "ComputedValues");
-        checkDataFileForCollectionWithComputedValues(tree, path, false, false, true, cn + "ComputedValues");
-      } finally {
-        fs.removeDirectoryRecursive(path, true);
-      }
+      let args = ['--collection', cn + "ComputedValues", '--compress-output', 'false'];
+      let tree = runDump(path, args, 0);
+      checkEncryption(tree, path, "none");
+      checkStructureFile(tree, path, true, cn + "ComputedValues");
+      checkDataFileForCollectionWithComputedValues(tree, path, false, false, true, cn + "ComputedValues");
+      fs.removeDirectoryRecursive(path, true);
     },
 
     testDumpForCollectionWithComputedValuesCompressed: function () {
       let path = fs.getTempFile();
-      try {
-        let args = ['--collection', cn + "ComputedValues", '--compress-output', 'true'];
-        let tree = runDump(path, args, 0);
-        checkEncryption(tree, path, "none");
-        checkStructureFile(tree, path, true, cn + "ComputedValues");
-        checkDataFileForCollectionWithComputedValues(tree, path, true, false, true, cn + "ComputedValues");
-      } finally {
-        fs.removeDirectoryRecursive(path, true);
-      }
+      let args = ['--collection', cn + "ComputedValues", '--compress-output', 'true'];
+      let tree = runDump(path, args, 0);
+      checkEncryption(tree, path, "none");
+      checkStructureFile(tree, path, true, cn + "ComputedValues");
+      checkDataFileForCollectionWithComputedValues(tree, path, true, false, true, cn + "ComputedValues");
+      fs.removeDirectoryRecursive(path, true);
     },
 
     testDumpOnlyOneShard: function () {
@@ -395,17 +386,14 @@ function dumpIntegrationSuite() {
       let shards = Object.keys(shardCounts);
 
       assertEqual(3, shards.length);
-      try {
-        let args = ['--collection', cn, '--dump-data', 'true', '--compress-output', 'false', '--shard', shards[0]];
-        let tree = runDump(path, args, 0);
+      let args = ['--collection', cn, '--dump-data', 'true', '--compress-output', 'false', '--shard', shards[0]];
+      let tree = runDump(path, args, 0);
 
-        const prefix = cn + "_" + require("@arangodb/crypto").md5(cn);
-        let file = fs.join(path, prefix + '.data.json');
-        let data = fs.readFileSync(file).toString();
-        assertEqual(shardCounts[shards[0]] + 1, data.split('\n').length);
-      } finally {
-        fs.removeDirectoryRecursive(path, true);
-      }
+      const prefix = cn + "_" + require("@arangodb/crypto").md5(cn);
+      let file = fs.join(path, prefix + '.data.json');
+      let data = fs.readFileSync(file).toString();
+      assertEqual(shardCounts[shards[0]] + 1, data.split('\n').length);
+      fs.removeDirectoryRecursive(path, true);
     },
 
     testDumpOnlyTwoShards: function () {
@@ -420,152 +408,133 @@ function dumpIntegrationSuite() {
       let shards = Object.keys(shardCounts);
 
       assertEqual(3, shards.length);
-      try {
-        let args = ['--collection', cn, '--dump-data', 'true', '--compress-output', 'false', '--shard', shards[0], '--shard', shards[1]];
-        let tree = runDump(path, args, 0);
+      let args = ['--collection', cn, '--dump-data', 'true', '--compress-output', 'false', '--shard', shards[0], '--shard', shards[1]];
+      let tree = runDump(path, args, 0);
 
-        const prefix = cn + "_" + require("@arangodb/crypto").md5(cn);
-        let file = fs.join(path, prefix + '.data.json');
-        let data = fs.readFileSync(file).toString();
-        assertEqual(shardCounts[shards[0]] + shardCounts[shards[1]] + 1, data.split('\n').length);
-      } finally {
-        fs.removeDirectoryRecursive(path, true);
-      }
+      const prefix = cn + "_" + require("@arangodb/crypto").md5(cn);
+      let file = fs.join(path, prefix + '.data.json');
+      let data = fs.readFileSync(file).toString();
+      assertEqual(shardCounts[shards[0]] + shardCounts[shards[1]] + 1, data.split('\n').length);
+      fs.removeDirectoryRecursive(path, true);
     },
 
     testDumpAutoIncrementKeyGenerator: function () {
 
       let path = fs.getTempFile();
-      try {
-        let args = ['--collection', cn + 'AutoIncrement', '--dump-data', 'false'];
-        let tree = runDump(path, args, 0);
-        checkStructureFile(tree, path, true, cn + 'AutoIncrement');
-        let structure = structureFile(path, cn + 'AutoIncrement');
-        let data = JSON.parse(fs.readFileSync(fs.join(path, structure)).toString());
-        assertEqual("autoincrement", data.parameters.keyOptions.type);
-        let c = db._collection(cn + 'AutoIncrement');
-        assertEqual(1000, c.count());
-        let p = c.properties();
-        let lastValue = p.keyOptions.lastValue;
-        if (!isCluster) {
-          assertTrue(lastValue > 0, lastValue);
-        }
-        assertEqual(lastValue, data.parameters.keyOptions.lastValue);
-      } finally {
-        fs.removeDirectoryRecursive(path, true);
+      let args = ['--collection', cn + 'AutoIncrement', '--dump-data', 'false'];
+      let tree = runDump(path, args, 0);
+      checkStructureFile(tree, path, true, cn + 'AutoIncrement');
+      let structure = structureFile(path, cn + 'AutoIncrement');
+      let data = JSON.parse(fs.readFileSync(fs.join(path, structure)).toString());
+      assertEqual("autoincrement", data.parameters.keyOptions.type);
+      let c = db._collection(cn + 'AutoIncrement');
+      assertEqual(1000, c.count());
+      let p = c.properties();
+      let lastValue = p.keyOptions.lastValue;
+      if (!isCluster) {
+        assertTrue(lastValue > 0, lastValue);
       }
+      assertEqual(lastValue, data.parameters.keyOptions.lastValue);
+      fs.removeDirectoryRecursive(path, true);
     },
 
     testDumpPaddedKeyGenerator: function () {
       let path = fs.getTempFile();
-      try {
-        let args = ['--collection', cn + 'Padded', '--dump-data', 'false'];
-        let tree = runDump(path, args, 0);
-        checkStructureFile(tree, path, true, cn + 'Padded');
-        let structure = structureFile(path, cn + 'Padded');
-        let data = JSON.parse(fs.readFileSync(fs.join(path, structure)).toString());
-        assertEqual("padded", data.parameters.keyOptions.type);
-        let c = db._collection(cn + 'Padded');
-        assertEqual(1000, c.count());
-        let p = c.properties();
-        let lastValue = p.keyOptions.lastValue;
-        assertTrue(lastValue > 0, lastValue);
-        assertEqual(lastValue, data.parameters.keyOptions.lastValue);
-
-      } finally {
-        fs.removeDirectoryRecursive(path, true);
-      }
+      let args = ['--collection', cn + 'Padded', '--dump-data', 'false'];
+      let tree = runDump(path, args, 0);
+      checkStructureFile(tree, path, true, cn + 'Padded');
+      let structure = structureFile(path, cn + 'Padded');
+      let data = JSON.parse(fs.readFileSync(fs.join(path, structure)).toString());
+      assertEqual("padded", data.parameters.keyOptions.type);
+      let c = db._collection(cn + 'Padded');
+      assertEqual(1000, c.count());
+      let p = c.properties();
+      let lastValue = p.keyOptions.lastValue;
+      assertTrue(lastValue > 0, lastValue);
+      assertEqual(lastValue, data.parameters.keyOptions.lastValue);
+      fs.removeDirectoryRecursive(path, true);
     },
 
     testDumpSingleDatabase: function () {
       dbs.forEach((name) => {
         let path = fs.getTempFile();
         db._useDatabase(name);
-        try {
-          let args = ['--overwrite', 'true'];
-          let tree = runDump(path, args, 0);
-          checkDumpJsonFile(name, path, db._id());
-          checkCollections(tree, path);
-        } finally {
-          fs.removeDirectoryRecursive(path, true);
-        }
+        let args = ['--overwrite', 'true'];
+        let tree = runDump(path, args, 0);
+        checkDumpJsonFile(name, path, db._id());
+        checkCollections(tree, path);
+        fs.removeDirectoryRecursive(path, true);
       });
     },
 
     testDumpAllDatabases: function () {
       let path = fs.getTempFile();
-      try {
-        let args = ['--all-databases', 'true'];
-        let tree = runDump(path, args, 0);
-        db._useDatabase("maçã");
-        assertEqual(-1, tree.indexOf("maçã"));
-        assertNotEqual(-1, tree.indexOf(db._id()));
-        checkDumpJsonFile("maçã", fs.join(path, db._id()), db._id());
-        checkCollections(tree, path, db._id());
-        db._useDatabase("_system");
-        assertNotEqual(-1, tree.indexOf("_system"));
-        assertEqual(-1, tree.indexOf(db._id()));
-        checkDumpJsonFile("_system", fs.join(path, db._name()), db._id());
-        checkCollections(tree, path, db._name());
-        db._useDatabase("testName");
-        assertNotEqual(-1, tree.indexOf("testName"));
-        assertEqual(-1, tree.indexOf(db._id()));
-        checkDumpJsonFile("testName", fs.join(path, db._name()), db._id());
-        checkCollections(tree, path, db._name());
-        db._useDatabase("😀");
-        assertEqual(-1, tree.indexOf("😀"));
-        assertNotEqual(-1, tree.indexOf(db._id()));
-        checkDumpJsonFile("😀", fs.join(path, db._id()), db._id());
-        checkCollections(tree, path, db._id());
-        db._useDatabase("ﻚﻠﺑ ﻞﻄﻴﻓ");
-        assertEqual(-1, tree.indexOf("ﻚﻠﺑ ﻞﻄﻴﻓ"));
-        assertNotEqual(-1, tree.indexOf(db._id()));
-        checkDumpJsonFile("ﻚﻠﺑ ﻞﻄﻴﻓ", fs.join(path, db._id()), db._id());
-        checkCollections(tree, path, db._id());
-      } finally {
-        fs.removeDirectoryRecursive(path, true);
-      }
+      let args = ['--all-databases', 'true'];
+      let tree = runDump(path, args, 0);
+      db._useDatabase("maçã");
+      assertEqual(-1, tree.indexOf("maçã"));
+      assertNotEqual(-1, tree.indexOf(db._id()));
+      checkDumpJsonFile("maçã", fs.join(path, db._id()), db._id());
+      checkCollections(tree, path, db._id());
+      db._useDatabase("_system");
+      assertNotEqual(-1, tree.indexOf("_system"));
+      assertEqual(-1, tree.indexOf(db._id()));
+      checkDumpJsonFile("_system", fs.join(path, db._name()), db._id());
+      checkCollections(tree, path, db._name());
+      db._useDatabase("testName");
+      assertNotEqual(-1, tree.indexOf("testName"));
+      assertEqual(-1, tree.indexOf(db._id()));
+      checkDumpJsonFile("testName", fs.join(path, db._name()), db._id());
+      checkCollections(tree, path, db._name());
+      db._useDatabase("😀");
+      assertEqual(-1, tree.indexOf("😀"));
+      assertNotEqual(-1, tree.indexOf(db._id()));
+      checkDumpJsonFile("😀", fs.join(path, db._id()), db._id());
+      checkCollections(tree, path, db._id());
+      db._useDatabase("ﻚﻠﺑ ﻞﻄﻴﻓ");
+      assertEqual(-1, tree.indexOf("ﻚﻠﺑ ﻞﻄﻴﻓ"));
+      assertNotEqual(-1, tree.indexOf(db._id()));
+      checkDumpJsonFile("ﻚﻠﺑ ﻞﻄﻴﻓ", fs.join(path, db._id()), db._id());
+      checkCollections(tree, path, db._id());
+      fs.removeDirectoryRecursive(path, true);
     },
 
     testDumpAllDatabasesWithOverwrite: function () {
       let path = fs.getTempFile();
-      try {
-        let args = ['--all-databases', 'true'];
-        runDump(path, args, 0);
+      let args = ['--all-databases', 'true'];
+      runDump(path, args, 0);
 
-        // run the dump a second time, to overwrite all data in the target directory
-        args.push('--overwrite');
-        args.push('true');
+      // run the dump a second time, to overwrite all data in the target directory
+      args.push('--overwrite');
+      args.push('true');
 
-        let tree = runDump(path, args, 0);
-        db._useDatabase("maçã");
-        assertEqual(-1, tree.indexOf("maçã"));
-        assertNotEqual(-1, tree.indexOf(db._id()));
-        checkDumpJsonFile("maçã", fs.join(path, db._id()), db._id());
-        checkCollections(tree, path, db._id());
-        db._useDatabase("_system");
-        assertNotEqual(-1, tree.indexOf("_system"));
-        assertEqual(-1, tree.indexOf(db._id()));
-        checkDumpJsonFile("_system", fs.join(path, db._name()), db._id());
-        checkCollections(tree, path, db._name());
-        db._useDatabase("testName");
-        assertNotEqual(-1, tree.indexOf("testName"));
-        assertEqual(-1, tree.indexOf(db._id()));
-        checkDumpJsonFile("testName", fs.join(path, db._name()), db._id());
-        checkCollections(tree, path, db._name());
-        db._useDatabase("😀");
-        assertEqual(-1, tree.indexOf("😀"));
-        assertNotEqual(-1, tree.indexOf(db._id()));
-        checkDumpJsonFile("😀", fs.join(path, db._id()), db._id());
-        checkCollections(tree, path, db._id());
-        db._useDatabase("ﻚﻠﺑ ﻞﻄﻴﻓ");
-        assertEqual(-1, tree.indexOf("ﻚﻠﺑ ﻞﻄﻴﻓ"));
-        assertNotEqual(-1, tree.indexOf(db._id()));
-        checkDumpJsonFile("ﻚﻠﺑ ﻞﻄﻴﻓ", fs.join(path, db._id()), db._id());
-        checkCollections(tree, path, db._id());
-      } finally {
-        fs.removeDirectoryRecursive(path, true);
-      }
+      let tree = runDump(path, args, 0);
+      db._useDatabase("maçã");
+      assertEqual(-1, tree.indexOf("maçã"));
+      assertNotEqual(-1, tree.indexOf(db._id()));
+      checkDumpJsonFile("maçã", fs.join(path, db._id()), db._id());
+      checkCollections(tree, path, db._id());
+      db._useDatabase("_system");
+      assertNotEqual(-1, tree.indexOf("_system"));
+      assertEqual(-1, tree.indexOf(db._id()));
+      checkDumpJsonFile("_system", fs.join(path, db._name()), db._id());
+      checkCollections(tree, path, db._name());
+      db._useDatabase("testName");
+      assertNotEqual(-1, tree.indexOf("testName"));
+      assertEqual(-1, tree.indexOf(db._id()));
+      checkDumpJsonFile("testName", fs.join(path, db._name()), db._id());
+      checkCollections(tree, path, db._name());
+      db._useDatabase("😀");
+      assertEqual(-1, tree.indexOf("😀"));
+      assertNotEqual(-1, tree.indexOf(db._id()));
+      checkDumpJsonFile("😀", fs.join(path, db._id()), db._id());
+      checkCollections(tree, path, db._id());
+      db._useDatabase("ﻚﻠﺑ ﻞﻄﻴﻓ");
+      assertEqual(-1, tree.indexOf("ﻚﻠﺑ ﻞﻄﻴﻓ"));
+      assertNotEqual(-1, tree.indexOf(db._id()));
+      checkDumpJsonFile("ﻚﻠﺑ ﻞﻄﻴﻓ", fs.join(path, db._id()), db._id());
+      checkCollections(tree, path, db._id());
+      fs.removeDirectoryRecursive(path, true);
     },
 
     testDumpCompressedEncryptedWithEnvelope: function () {
@@ -575,18 +544,15 @@ function dumpIntegrationSuite() {
 
       let keyfile = fs.getTempFile();
       let path = fs.getTempFile();
-      try {
-        // 32 bytes of garbage
-        fs.writeFileSync(keyfile, "01234567890123456789012345678901");
+      // 32 bytes of garbage
+      fs.writeFileSync(keyfile, "01234567890123456789012345678901");
 
-        let args = ['--compress-output', 'true', '--envelope', 'true', '--encryption.keyfile', keyfile, '--collection', cn];
-        let tree = runDump(path, args, 0);
-        checkEncryption(tree, path, "aes-256-ctr");
-        checkStructureFile(tree, path, false, cn);
-        checkDataFile(tree, path, false, true, false, cn);
-      } finally {
-        fs.removeDirectoryRecursive(path, true);
-      }
+      let args = ['--compress-output', 'true', '--envelope', 'true', '--encryption.keyfile', keyfile, '--collection', cn];
+      let tree = runDump(path, args, 0);
+      checkEncryption(tree, path, "aes-256-ctr");
+      checkStructureFile(tree, path, false, cn);
+      checkDataFile(tree, path, false, true, false, cn);
+      fs.removeDirectoryRecursive(path, true);
     },
 
     testDumpCompressedEncryptedNoEnvelope: function () {
@@ -596,58 +562,49 @@ function dumpIntegrationSuite() {
 
       let keyfile = fs.getTempFile();
       let path = fs.getTempFile();
-      try {
-        // 32 bytes of garbage
-        fs.writeFileSync(keyfile, "01234567890123456789012345678901");
+      // 32 bytes of garbage
+      fs.writeFileSync(keyfile, "01234567890123456789012345678901");
 
-        let args = ['--compress-output', 'true', '--envelope', 'false', '--encryption.keyfile', keyfile, '--collection', cn];
-        let tree = runDump(path, args, 0);
-        checkEncryption(tree, path, "aes-256-ctr");
-        checkStructureFile(tree, path, false, cn);
-        checkDataFile(tree, path, false, false, false, cn);
-      } finally {
-        fs.removeDirectoryRecursive(path, true);
-      }
+      let args = ['--compress-output', 'true', '--envelope', 'false', '--encryption.keyfile', keyfile, '--collection', cn];
+      let tree = runDump(path, args, 0);
+      checkEncryption(tree, path, "aes-256-ctr");
+      checkStructureFile(tree, path, false, cn);
+      checkDataFile(tree, path, false, false, false, cn);
+      fs.removeDirectoryRecursive(path, true);
     },
 
     testDumpOverwriteUncompressedWithEnvelope: function () {
       let path = fs.getTempFile();
-      try {
-        let args = ['--compress-output', 'false', '--envelope', 'true', '--collection', cn];
-        let tree = runDump(path, args, 0);
-        checkEncryption(tree, path, "none");
-        checkStructureFile(tree, path, true, cn);
-        checkDataFile(tree, path, false, true, true, cn);
+      let args = ['--compress-output', 'false', '--envelope', 'true', '--collection', cn];
+      let tree = runDump(path, args, 0);
+      checkEncryption(tree, path, "none");
+      checkStructureFile(tree, path, true, cn);
+      checkDataFile(tree, path, false, true, true, cn);
 
-        // second dump, which overwrites
-        args = ['--compress-output', 'false', '--envelope', 'true', '--overwrite', 'true', '--collection', cn];
-        tree = runDump(path, args, 0);
-        checkEncryption(tree, path, "none");
-        checkStructureFile(tree, path, true, cn);
-        checkDataFile(tree, path, false, true, true, cn);
-      } finally {
-        fs.removeDirectoryRecursive(path, true);
-      }
+      // second dump, which overwrites
+      args = ['--compress-output', 'false', '--envelope', 'true', '--overwrite', 'true', '--collection', cn];
+      tree = runDump(path, args, 0);
+      checkEncryption(tree, path, "none");
+      checkStructureFile(tree, path, true, cn);
+      checkDataFile(tree, path, false, true, true, cn);
+      fs.removeDirectoryRecursive(path, true);
     },
 
     testDumpOverwriteUncompressedNoEnvelope: function () {
       let path = fs.getTempFile();
-      try {
-        let args = ['--compress-output', 'false', '--envelope', 'true', '--collection', cn];
-        let tree = runDump(path, args, 0);
-        checkEncryption(tree, path, "none");
-        checkStructureFile(tree, path, true, cn);
-        checkDataFile(tree, path, false, true, true, cn);
+      let args = ['--compress-output', 'false', '--envelope', 'true', '--collection', cn];
+      let tree = runDump(path, args, 0);
+      checkEncryption(tree, path, "none");
+      checkStructureFile(tree, path, true, cn);
+      checkDataFile(tree, path, false, true, true, cn);
 
-        // second dump, which overwrites
-        args = ['--compress-output', 'false', '--envelope', 'false', '--overwrite', 'true', '--collection', cn];
-        tree = runDump(path, args, 0);
-        checkEncryption(tree, path, "none");
-        checkStructureFile(tree, path, true, cn);
-        checkDataFile(tree, path, false, false, true, cn);
-      } finally {
-        fs.removeDirectoryRecursive(path, true);
-      }
+      // second dump, which overwrites
+      args = ['--compress-output', 'false', '--envelope', 'false', '--overwrite', 'true', '--collection', cn];
+      tree = runDump(path, args, 0);
+      checkEncryption(tree, path, "none");
+      checkStructureFile(tree, path, true, cn);
+      checkDataFile(tree, path, false, false, true, cn);
+      fs.removeDirectoryRecursive(path, true);
     },
 
     testDumpCompressedEncrypted: function () {
@@ -657,73 +614,61 @@ function dumpIntegrationSuite() {
 
       let keyfile = fs.getTempFile();
       let path = fs.getTempFile();
-      try {
-        // 32 bytes of garbage
-        fs.writeFileSync(keyfile, "01234567890123456789012345678901");
+      // 32 bytes of garbage
+      fs.writeFileSync(keyfile, "01234567890123456789012345678901");
 
-        let args = ['--compress-output', 'true', '--encryption.keyfile', keyfile, '--collection', cn];
-        let tree = runDump(path, args, 0);
-        checkEncryption(tree, path, "aes-256-ctr");
-        checkStructureFile(tree, path, false, cn);
-        checkDataFile(tree, path, false, true, false, cn);
-      } finally {
-        fs.removeDirectoryRecursive(path, true);
-      }
+      let args = ['--compress-output', 'true', '--encryption.keyfile', keyfile, '--collection', cn];
+      let tree = runDump(path, args, 0);
+      checkEncryption(tree, path, "aes-256-ctr");
+      checkStructureFile(tree, path, false, cn);
+      checkDataFile(tree, path, false, true, false, cn);
+      fs.removeDirectoryRecursive(path, true);
     },
 
     testDumpOverwriteDisabled: function () {
       let path = fs.getTempFile();
-      try {
-        let args = ['--collection', cn];
-        let tree = runDump(path, args, 0);
-        checkEncryption(tree, path, "none");
+      let args = ['--collection', cn];
+      let tree = runDump(path, args, 0);
+      checkEncryption(tree, path, "none");
 
-        // second dump, without overwrite
-        // this is expected to have an exit code of 1
-        runDump(path, args, 1 /*exit code*/);
-      } finally {
-        fs.removeDirectoryRecursive(path, true);
-      }
+      // second dump, without overwrite
+      // this is expected to have an exit code of 1
+      runDump(path, args, 1 /*exit code*/);
+      fs.removeDirectoryRecursive(path, true);
     },
 
     testDumpOverwriteCompressed: function () {
       let path = fs.getTempFile();
-      try {
-        let args = ['--compress-output', 'true', '--collection', cn];
-        let tree = runDump(path, args, 0);
-        checkEncryption(tree, path, "none");
-        checkStructureFile(tree, path, true, cn);
-        checkDataFile(tree, path, true, false, true, cn);
+      let args = ['--compress-output', 'true', '--collection', cn];
+      let tree = runDump(path, args, 0);
+      checkEncryption(tree, path, "none");
+      checkStructureFile(tree, path, true, cn);
+      checkDataFile(tree, path, true, false, true, cn);
 
-        // second dump, which overwrites
-        args = ['--compress-output', 'true', '--overwrite', 'true', '--collection', cn];
-        tree = runDump(path, args, 0);
-        checkEncryption(tree, path, "none");
-        checkStructureFile(tree, path, true, cn);
-        checkDataFile(tree, path, true, false, true, cn);
-      } finally {
-        fs.removeDirectoryRecursive(path, true);
-      }
+      // second dump, which overwrites
+      args = ['--compress-output', 'true', '--overwrite', 'true', '--collection', cn];
+      tree = runDump(path, args, 0);
+      checkEncryption(tree, path, "none");
+      checkStructureFile(tree, path, true, cn);
+      checkDataFile(tree, path, true, false, true, cn);
+      fs.removeDirectoryRecursive(path, true);
     },
 
     testDumpOverwriteUncompressed: function () {
       let path = fs.getTempFile();
-      try {
-        let args = ['--compress-output', 'false', '--collection', cn];
-        let tree = runDump(path, args, 0);
-        checkEncryption(tree, path, "none");
-        checkStructureFile(tree, path, true, cn);
-        checkDataFile(tree, path, false, false, true, cn);
+      let args = ['--compress-output', 'false', '--collection', cn];
+      let tree = runDump(path, args, 0);
+      checkEncryption(tree, path, "none");
+      checkStructureFile(tree, path, true, cn);
+      checkDataFile(tree, path, false, false, true, cn);
 
-        // second dump, which overwrites
-        args = ['--compress-output', 'false', '--overwrite', 'true', '--collection', cn];
-        tree = runDump(path, args, 0);
-        checkEncryption(tree, path, "none");
-        checkStructureFile(tree, path, true, cn);
-        checkDataFile(tree, path, false, false, true, cn);
-      } finally {
-        fs.removeDirectoryRecursive(path, true);
-      }
+      // second dump, which overwrites
+      args = ['--compress-output', 'false', '--overwrite', 'true', '--collection', cn];
+      tree = runDump(path, args, 0);
+      checkEncryption(tree, path, "none");
+      checkStructureFile(tree, path, true, cn);
+      checkDataFile(tree, path, false, false, true, cn);
+      fs.removeDirectoryRecursive(path, true);
     },
 
     testDumpOverwriteEncrypted: function () {
@@ -733,25 +678,22 @@ function dumpIntegrationSuite() {
 
       let keyfile = fs.getTempFile();
       let path = fs.getTempFile();
-      try {
-        // 32 bytes of garbage
-        fs.writeFileSync(keyfile, "01234567890123456789012345678901");
+      // 32 bytes of garbage
+      fs.writeFileSync(keyfile, "01234567890123456789012345678901");
 
-        let args = ['--compress-output', 'false', '--encryption.keyfile', keyfile, '--collection', cn];
-        let tree = runDump(path, args, 0);
-        checkEncryption(tree, path, "aes-256-ctr");
-        checkStructureFile(tree, path, false, cn);
-        checkDataFile(tree, path, false, true, false, cn);
+      let args = ['--compress-output', 'false', '--encryption.keyfile', keyfile, '--collection', cn];
+      let tree = runDump(path, args, 0);
+      checkEncryption(tree, path, "aes-256-ctr");
+      checkStructureFile(tree, path, false, cn);
+      checkDataFile(tree, path, false, true, false, cn);
 
-        // second dump, which overwrites
-        args = ['--compress-output', 'false', '--encryption.keyfile', keyfile, '--overwrite', 'true', '--collection', cn];
-        tree = runDump(path, args, 0);
-        checkEncryption(tree, path, "aes-256-ctr");
-        checkStructureFile(tree, path, false, cn);
-        checkDataFile(tree, path, false, true, false, cn);
-      } finally {
-        fs.removeDirectoryRecursive(path, true);
-      }
+      // second dump, which overwrites
+      args = ['--compress-output', 'false', '--encryption.keyfile', keyfile, '--overwrite', 'true', '--collection', cn];
+      tree = runDump(path, args, 0);
+      checkEncryption(tree, path, "aes-256-ctr");
+      checkStructureFile(tree, path, false, cn);
+      checkDataFile(tree, path, false, true, false, cn);
+      fs.removeDirectoryRecursive(path, true);
     },
 
     testDumpOverwriteCompressedWithEncrypted: function () {
@@ -761,80 +703,65 @@ function dumpIntegrationSuite() {
 
       let keyfile = fs.getTempFile();
       let path = fs.getTempFile();
-      try {
-        // 32 bytes of garbage
-        fs.writeFileSync(keyfile, "01234567890123456789012345678901");
+      // 32 bytes of garbage
+      fs.writeFileSync(keyfile, "01234567890123456789012345678901");
 
-        let args = ['--compress-output', 'true', '--collection', cn];
-        let tree = runDump(path, args, 0);
-        checkEncryption(tree, path, "none");
-        checkStructureFile(tree, path, true, cn);
-        checkDataFile(tree, path, true, false, true, cn);
+      let args = ['--compress-output', 'true', '--collection', cn];
+      let tree = runDump(path, args, 0);
+      checkEncryption(tree, path, "none");
+      checkStructureFile(tree, path, true, cn);
+      checkDataFile(tree, path, true, false, true, cn);
 
-        // second dump, which overwrites
-        // this is expected to have an exit code of 1
-        args = ['--compress-output', 'false', '--encryption.keyfile', keyfile, '--overwrite', 'true', '--collection', cn];
-        runDump(path, args, 1 /*exit code*/);
-      } finally {
-        fs.removeDirectoryRecursive(path, true);
-      }
+      // second dump, which overwrites
+      // this is expected to have an exit code of 1
+      args = ['--compress-output', 'false', '--encryption.keyfile', keyfile, '--overwrite', 'true', '--collection', cn];
+      runDump(path, args, 1 /*exit code*/);
+      fs.removeDirectoryRecursive(path, true);
     },
 
     testDumpOverwriteOtherCompressed: function () {
       let path = fs.getTempFile();
-      try {
-        let args = ['--compress-output', 'true', '--collection', cn];
-        let tree = runDump(path, args, 0);
-        checkEncryption(tree, path, "none");
-        checkStructureFile(tree, path, true, cn);
-        checkDataFile(tree, path, true, false, true, cn);
+      let args = ['--compress-output', 'true', '--collection', cn];
+      let tree = runDump(path, args, 0);
+      checkEncryption(tree, path, "none");
+      checkStructureFile(tree, path, true, cn);
+      checkDataFile(tree, path, true, false, true, cn);
 
-        // second dump, which overwrites
-        args = ['--compress-output', 'true', '--overwrite', 'true', '--collection', cn + "Other"];
-        tree = runDump(path, args, 0);
-        checkEncryption(tree, path, "none");
-        checkStructureFile(tree, path, true, cn);
-        checkDataFile(tree, path, true, false, true, cn);
-        checkStructureFile(tree, path, true, cn + "Other");
-        checkDataFile(tree, path, true, false, true, cn + "Other");
-      } finally {
-        fs.removeDirectoryRecursive(path, true);
-      }
+      // second dump, which overwrites
+      args = ['--compress-output', 'true', '--overwrite', 'true', '--collection', cn + "Other"];
+      tree = runDump(path, args, 0);
+      checkEncryption(tree, path, "none");
+      checkStructureFile(tree, path, true, cn);
+      checkDataFile(tree, path, true, false, true, cn);
+      checkStructureFile(tree, path, true, cn + "Other");
+      checkDataFile(tree, path, true, false, true, cn + "Other");
+      fs.removeDirectoryRecursive(path, true);
     },
 
     testDumpJustOneInvalidCollection: function () {
       let path = fs.getTempFile();
-      try {
-        let args = ['--collection', 'foobarbaz'];
-        let tree = runDump(path, args, 1);
-        checkEncryption(tree, path, "none");
-      } finally {
-        fs.removeDirectoryRecursive(path, true);
-      }
+      let args = ['--collection', 'foobarbaz'];
+      let tree = runDump(path, args, 1);
+      checkEncryption(tree, path, "none");
+      fs.removeDirectoryRecursive(path, true);
     },
 
     testDumpJustInvalidCollections: function () {
       let path = fs.getTempFile();
-      try {
-        let args = ['--collection', 'foobarbaz', '--collection', 'knarzknarzknarz'];
-        let tree = runDump(path, args, 1);
-        checkEncryption(tree, path, "none");
-      } finally {
-        fs.removeDirectoryRecursive(path, true);
-      }
+      let args = ['--collection', 'foobarbaz', '--collection', 'knarzknarzknarz'];
+      let tree = runDump(path, args, 1);
+      checkEncryption(tree, path, "none");
+      fs.removeDirectoryRecursive(path, true);
     },
 
     testDumpOneValidCollection: function () {
       let path = fs.getTempFile();
-      try {
-        let args = ['--compress-output', 'true', '--collection', cn, '--collection', 'knarzknarzknarz'];
-        let tree = runDump(path, args, 0);
-        checkEncryption(tree, path, "none");
-        checkStructureFile(tree, path, true, cn);
-        checkDataFile(tree, path, true, false, true, cn);
-      } finally {
-        fs.removeDirectoryRecursive(path, true);
-      }
+      let args = ['--compress-output', 'true', '--collection', cn, '--collection', 'knarzknarzknarz'];
+      let tree = runDump(path, args, 0);
+      checkEncryption(tree, path, "none");
+      checkStructureFile(tree, path, true, cn);
+      checkDataFile(tree, path, true, false, true, cn);
+      fs.removeDirectoryRecursive(path, true);
     },
   };
 }

--- a/tests/js/client/shell/shell-dump-integration.js
+++ b/tests/js/client/shell/shell-dump-integration.js
@@ -84,19 +84,14 @@ function dumpIntegrationSuite() {
     args.push(arango.connectedUser());
   };
 
-  let runDump = function (path, args, rc) {
-    try {
-      fs.removeDirectory(path);
-    } catch (err) {
-    }
-
+  let runDump = function (path, args, expectRc) {
     args.push('--output-directory');
     args.push(path);
     addConnectionArgs(args);
 
     let actualRc = internal.executeExternalAndWait(arangodump, args);
     assertTrue(actualRc.hasOwnProperty("exit"));
-    assertEqual(rc, actualRc.exit);
+    assertEqual(expectRc, actualRc.exit);
     return fs.listTree(path);
   };
 
@@ -358,10 +353,7 @@ function dumpIntegrationSuite() {
         checkStructureFile(tree, path, true, cn + "WithSchema");
         checkDataFile(tree, path, false, false, false, cn + "WithSchema");
       } finally {
-        try {
-          fs.removeDirectory(path);
-        } catch (err) {
-        }
+        fs.removeDirectoryRecursive(path, true);
       }
     },
 
@@ -374,10 +366,7 @@ function dumpIntegrationSuite() {
         checkStructureFile(tree, path, true, cn + "ComputedValues");
         checkDataFileForCollectionWithComputedValues(tree, path, false, false, true, cn + "ComputedValues");
       } finally {
-        try {
-          fs.removeDirectory(path);
-        } catch (err) {
-        }
+        fs.removeDirectoryRecursive(path, true);
       }
     },
 
@@ -390,10 +379,7 @@ function dumpIntegrationSuite() {
         checkStructureFile(tree, path, true, cn + "ComputedValues");
         checkDataFileForCollectionWithComputedValues(tree, path, true, false, true, cn + "ComputedValues");
       } finally {
-        try {
-          fs.removeDirectory(path);
-        } catch (err) {
-        }
+        fs.removeDirectoryRecursive(path, true);
       }
     },
 
@@ -418,10 +404,7 @@ function dumpIntegrationSuite() {
         let data = fs.readFileSync(file).toString();
         assertEqual(shardCounts[shards[0]] + 1, data.split('\n').length);
       } finally {
-        try {
-          fs.removeDirectory(path);
-        } catch (err) {
-        }
+        fs.removeDirectoryRecursive(path, true);
       }
     },
 
@@ -446,10 +429,7 @@ function dumpIntegrationSuite() {
         let data = fs.readFileSync(file).toString();
         assertEqual(shardCounts[shards[0]] + shardCounts[shards[1]] + 1, data.split('\n').length);
       } finally {
-        try {
-          fs.removeDirectory(path);
-        } catch (err) {
-        }
+        fs.removeDirectoryRecursive(path, true);
       }
     },
 
@@ -472,10 +452,7 @@ function dumpIntegrationSuite() {
         }
         assertEqual(lastValue, data.parameters.keyOptions.lastValue);
       } finally {
-        try {
-          fs.removeDirectory(path);
-        } catch (err) {
-        }
+        fs.removeDirectoryRecursive(path, true);
       }
     },
 
@@ -496,10 +473,7 @@ function dumpIntegrationSuite() {
         assertEqual(lastValue, data.parameters.keyOptions.lastValue);
 
       } finally {
-        try {
-          fs.removeDirectory(path);
-        } catch (err) {
-        }
+        fs.removeDirectoryRecursive(path, true);
       }
     },
 
@@ -513,10 +487,7 @@ function dumpIntegrationSuite() {
           checkDumpJsonFile(name, path, db._id());
           checkCollections(tree, path);
         } finally {
-          try {
-            fs.removeDirectory(path);
-          } catch (err) {
-          }
+          fs.removeDirectoryRecursive(path, true);
         }
       });
     },
@@ -552,11 +523,7 @@ function dumpIntegrationSuite() {
         checkDumpJsonFile("ﻚﻠﺑ ﻞﻄﻴﻓ", fs.join(path, db._id()), db._id());
         checkCollections(tree, path, db._id());
       } finally {
-        try {
-          fs.removeDirectory(path);
-          db._useDatabase("_system");
-        } catch (err) {
-        }
+        fs.removeDirectoryRecursive(path, true);
       }
     },
 
@@ -597,11 +564,7 @@ function dumpIntegrationSuite() {
         checkDumpJsonFile("ﻚﻠﺑ ﻞﻄﻴﻓ", fs.join(path, db._id()), db._id());
         checkCollections(tree, path, db._id());
       } finally {
-        try {
-          fs.removeDirectory(path);
-          db._useDatabase("_system");
-        } catch (err) {
-        }
+        fs.removeDirectoryRecursive(path, true);
       }
     },
 
@@ -622,10 +585,7 @@ function dumpIntegrationSuite() {
         checkStructureFile(tree, path, false, cn);
         checkDataFile(tree, path, false, true, false, cn);
       } finally {
-        try {
-          fs.removeDirectory(path);
-        } catch (err) {
-        }
+        fs.removeDirectoryRecursive(path, true);
       }
     },
 
@@ -646,10 +606,7 @@ function dumpIntegrationSuite() {
         checkStructureFile(tree, path, false, cn);
         checkDataFile(tree, path, false, false, false, cn);
       } finally {
-        try {
-          fs.removeDirectory(path);
-        } catch (err) {
-        }
+        fs.removeDirectoryRecursive(path, true);
       }
     },
 
@@ -669,10 +626,7 @@ function dumpIntegrationSuite() {
         checkStructureFile(tree, path, true, cn);
         checkDataFile(tree, path, false, true, true, cn);
       } finally {
-        try {
-          fs.removeDirectory(path);
-        } catch (err) {
-        }
+        fs.removeDirectoryRecursive(path, true);
       }
     },
 
@@ -692,10 +646,7 @@ function dumpIntegrationSuite() {
         checkStructureFile(tree, path, true, cn);
         checkDataFile(tree, path, false, false, true, cn);
       } finally {
-        try {
-          fs.removeDirectory(path);
-        } catch (err) {
-        }
+        fs.removeDirectoryRecursive(path, true);
       }
     },
 
@@ -716,10 +667,7 @@ function dumpIntegrationSuite() {
         checkStructureFile(tree, path, false, cn);
         checkDataFile(tree, path, false, true, false, cn);
       } finally {
-        try {
-          fs.removeDirectory(path);
-        } catch (err) {
-        }
+        fs.removeDirectoryRecursive(path, true);
       }
     },
 
@@ -734,10 +682,7 @@ function dumpIntegrationSuite() {
         // this is expected to have an exit code of 1
         runDump(path, args, 1 /*exit code*/);
       } finally {
-        try {
-          fs.removeDirectory(path);
-        } catch (err) {
-        }
+        fs.removeDirectoryRecursive(path, true);
       }
     },
 
@@ -757,10 +702,7 @@ function dumpIntegrationSuite() {
         checkStructureFile(tree, path, true, cn);
         checkDataFile(tree, path, true, false, true, cn);
       } finally {
-        try {
-          fs.removeDirectory(path);
-        } catch (err) {
-        }
+        fs.removeDirectoryRecursive(path, true);
       }
     },
 
@@ -780,10 +722,7 @@ function dumpIntegrationSuite() {
         checkStructureFile(tree, path, true, cn);
         checkDataFile(tree, path, false, false, true, cn);
       } finally {
-        try {
-          fs.removeDirectory(path);
-        } catch (err) {
-        }
+        fs.removeDirectoryRecursive(path, true);
       }
     },
 
@@ -811,10 +750,7 @@ function dumpIntegrationSuite() {
         checkStructureFile(tree, path, false, cn);
         checkDataFile(tree, path, false, true, false, cn);
       } finally {
-        try {
-          fs.removeDirectory(path);
-        } catch (err) {
-        }
+        fs.removeDirectoryRecursive(path, true);
       }
     },
 
@@ -840,10 +776,7 @@ function dumpIntegrationSuite() {
         args = ['--compress-output', 'false', '--encryption.keyfile', keyfile, '--overwrite', 'true', '--collection', cn];
         runDump(path, args, 1 /*exit code*/);
       } finally {
-        try {
-          fs.removeDirectory(path);
-        } catch (err) {
-        }
+        fs.removeDirectoryRecursive(path, true);
       }
     },
 
@@ -865,10 +798,7 @@ function dumpIntegrationSuite() {
         checkStructureFile(tree, path, true, cn + "Other");
         checkDataFile(tree, path, true, false, true, cn + "Other");
       } finally {
-        try {
-          fs.removeDirectory(path);
-        } catch (err) {
-        }
+        fs.removeDirectoryRecursive(path, true);
       }
     },
 
@@ -879,10 +809,7 @@ function dumpIntegrationSuite() {
         let tree = runDump(path, args, 1);
         checkEncryption(tree, path, "none");
       } finally {
-        try {
-          fs.removeDirectory(path);
-        } catch (err) {
-        }
+        fs.removeDirectoryRecursive(path, true);
       }
     },
 
@@ -893,10 +820,7 @@ function dumpIntegrationSuite() {
         let tree = runDump(path, args, 1);
         checkEncryption(tree, path, "none");
       } finally {
-        try {
-          fs.removeDirectory(path);
-        } catch (err) {
-        }
+        fs.removeDirectoryRecursive(path, true);
       }
     },
 
@@ -909,10 +833,7 @@ function dumpIntegrationSuite() {
         checkStructureFile(tree, path, true, cn);
         checkDataFile(tree, path, true, false, true, cn);
       } finally {
-        try {
-          fs.removeDirectory(path);
-        } catch (err) {
-        }
+        fs.removeDirectoryRecursive(path, true);
       }
     },
   };

--- a/tests/js/client/shell/shell-restore-integration.js
+++ b/tests/js/client/shell/shell-restore-integration.js
@@ -181,10 +181,7 @@ function restoreIntegrationSuite() {
           lastValue = newLastValue;
         }
       } finally {
-        try {
-          fs.removeDirectory(path);
-        } catch (err) {
-        }
+        fs.removeDirectoryRecursive(path, true);
       }
     },
 
@@ -221,10 +218,7 @@ function restoreIntegrationSuite() {
           lastValue = newLastValue;
         }
       } finally {
-        try {
-          fs.removeDirectory(path);
-        } catch (err) {
-        }
+        fs.removeDirectoryRecursive(path, true);
       }
     },
 
@@ -267,10 +261,7 @@ function restoreIntegrationSuite() {
         const schema = colProperties.schema;
         assertEqual(schema, validatorJson);
       } finally {
-        try {
-          fs.removeDirectory(path);
-        } catch (err) {
-        }
+        fs.removeDirectoryRecursive(path, true);
       }
     },
 
@@ -309,10 +300,7 @@ function restoreIntegrationSuite() {
           assertTrue(doc.overwrite);
         }
       } finally {
-        try {
-          fs.removeDirectory(path);
-        } catch (err) {
-        }
+        fs.removeDirectoryRecursive(path, true);
       }
     },
 
@@ -366,10 +354,7 @@ function restoreIntegrationSuite() {
           assertFalse(doc.hasOwnProperty('overwrite'));
         }
       } finally {
-        try {
-          fs.removeDirectory(path);
-        } catch (err) {
-        }
+        fs.removeDirectoryRecursive(path, true);
       }
     },
 
@@ -428,10 +413,7 @@ function restoreIntegrationSuite() {
           assertEqual(doc.value4, doc.value2 + " " + doc.value1);
         }
       } finally {
-        try {
-          fs.removeDirectory(path);
-        } catch (err) {
-        }
+        fs.removeDirectoryRecursive(path, true);
       }
     },
 
@@ -469,10 +451,7 @@ function restoreIntegrationSuite() {
           assertEqual(i, doc.value);
         }
       } finally {
-        try {
-          fs.removeDirectory(path);
-        } catch (err) {
-        }
+        fs.removeDirectoryRecursive(path, true);
       }
     },
 
@@ -554,10 +533,7 @@ function restoreIntegrationSuite() {
           assertEqual(i, doc.value);
         }
       } finally {
-        try {
-          fs.removeDirectory(path);
-        } catch (err) {
-        }
+        fs.removeDirectoryRecursive(path, true);
       }
     },
 
@@ -735,10 +711,7 @@ function restoreIntegrationSuite() {
           assertEqual(i, doc.value);
         }
       } finally {
-        try {
-          fs.removeDirectory(path);
-        } catch (err) {
-        }
+        fs.removeDirectoryRecursive(path, true);
       }
     },
 
@@ -775,10 +748,7 @@ function restoreIntegrationSuite() {
           assertEqual(i, doc.value);
         }
       } finally {
-        try {
-          fs.removeDirectory(path);
-        } catch (err) {
-        }
+        fs.removeDirectoryRecursive(path, true);
       }
     },
 
@@ -804,10 +774,7 @@ function restoreIntegrationSuite() {
         assertTrue(props.hasOwnProperty("syncByRevision"));
         assertTrue(props.syncByRevision);
       } finally {
-        try {
-          fs.removeDirectory(path);
-        } catch (err) {
-        }
+        fs.removeDirectoryRecursive(path, true);
       }
     },
 
@@ -834,10 +801,7 @@ function restoreIntegrationSuite() {
         assertTrue(props.hasOwnProperty("syncByRevision"));
         assertFalse(props.syncByRevision);
       } finally {
-        try {
-          fs.removeDirectory(path);
-        } catch (err) {
-        }
+        fs.removeDirectoryRecursive(path, true);
       }
     },
 
@@ -864,10 +828,7 @@ function restoreIntegrationSuite() {
         assertTrue(props.hasOwnProperty("syncByRevision"));
         assertTrue(props.syncByRevision);
       } finally {
-        try {
-          fs.removeDirectory(path);
-        } catch (err) {
-        }
+        fs.removeDirectoryRecursive(path, true);
       }
     },
 
@@ -893,10 +854,7 @@ function restoreIntegrationSuite() {
         let c = db._collection(cn);
         assertNotEqual("123456789012", c.properties().globallyUniqueId);
       } finally {
-        try {
-          fs.removeDirectory(path);
-        } catch (err) {
-        }
+        fs.removeDirectoryRecursive(path, true);
       }
     },
 
@@ -944,10 +902,7 @@ function restoreIntegrationSuite() {
         let result = db._query("FOR doc IN " + cn + " FILTER doc.value == 42 RETURN doc").toArray();
         assertEqual(100, result.length);
       } finally {
-        try {
-          fs.removeDirectory(path);
-        } catch (err) {
-        }
+        fs.removeDirectoryRecursive(path, true);
       }
     },
 
@@ -981,10 +936,7 @@ function restoreIntegrationSuite() {
         assertEqual(["loc"], indexes[1].fields);
         assertFalse(indexes[1].geoJson);
       } finally {
-        try {
-          fs.removeDirectory(path);
-        } catch (err) {
-        }
+        fs.removeDirectoryRecursive(path, true);
       }
     },
 
@@ -1018,10 +970,7 @@ function restoreIntegrationSuite() {
         assertEqual(["a", "b"], indexes[1].fields);
         assertFalse(indexes[1].geoJson);
       } finally {
-        try {
-          fs.removeDirectory(path);
-        } catch (err) {
-        }
+        fs.removeDirectoryRecursive(path, true);
       }
     },
 
@@ -1055,10 +1004,7 @@ function restoreIntegrationSuite() {
         assertEqual(["text"], indexes[1].fields);
         assertEqual(indexes[1].minLength, 1);
       } finally {
-        try {
-          fs.removeDirectory(path);
-        } catch (err) {
-        }
+        fs.removeDirectoryRecursive(path, true);
       }
     },
 
@@ -1104,10 +1050,7 @@ function restoreIntegrationSuite() {
         let result = db._query("FOR doc IN " + cn + " FILTER doc.value == 42 RETURN doc").toArray();
         assertEqual(100, result.length);
       } finally {
-        try {
-          fs.removeDirectory(path);
-        } catch (err) {
-        }
+        fs.removeDirectoryRecursive(path, true);
       }
     },
 
@@ -1163,10 +1106,7 @@ function restoreIntegrationSuite() {
         let result = db._query("FOR doc IN " + cn + " FILTER doc.value == 42 RETURN doc").toArray();
         assertEqual(100, result.length);
       } finally {
-        try {
-          fs.removeDirectory(path);
-        } catch (err) {
-        }
+        fs.removeDirectoryRecursive(path, true);
       }
     },
 
@@ -1206,10 +1146,7 @@ function restoreIntegrationSuite() {
           assertEqual("test" + i, c.document("test" + i)._key);
         }
       } finally {
-        try {
-          fs.removeDirectory(path);
-        } catch (err) {
-        }
+        fs.removeDirectoryRecursive(path, true);
       }
     },
 
@@ -1256,10 +1193,7 @@ function restoreIntegrationSuite() {
           assertEqual("test" + i, outEdges[0]._key);
         }
       } finally {
-        try {
-          fs.removeDirectory(path);
-        } catch (err) {
-        }
+        fs.removeDirectoryRecursive(path, true);
       }
     },
 
@@ -1346,10 +1280,7 @@ function restoreIntegrationSuite() {
         assertTrue(props.hasOwnProperty("syncByRevision"));
         assertTrue(props.syncByRevision);
       } finally {
-        try {
-          fs.removeDirectory(path);
-        } catch (err) {
-        }
+        fs.removeDirectoryRecursive(path, true);
       }
     },
 
@@ -1376,10 +1307,7 @@ function restoreIntegrationSuite() {
         assertTrue(props.hasOwnProperty("syncByRevision"));
         assertTrue(props.syncByRevision);
       } finally {
-        try {
-          fs.removeDirectory(path);
-        } catch (err) {
-        }
+        fs.removeDirectoryRecursive(path, true);
       }
     },
 
@@ -1407,10 +1335,7 @@ function restoreIntegrationSuite() {
         assertTrue(props.hasOwnProperty("syncByRevision"));
         assertFalse(props.syncByRevision);
       } finally {
-        try {
-          fs.removeDirectory(path);
-        } catch (err) {
-        }
+        fs.removeDirectoryRecursive(path, true);
       }
     },
   };


### PR DESCRIPTION
### Scope & Purpose

- dump tests would not cleanup their work data on success in all cases, fix this.
- export tests would not clean up their database directories
- server_permissions tests would not clean up temporary files created along with the tests
- `shell-dump-integration.js` & `shell-restore-integration.js` would not clean up
 