### PR TITLE
[CINFRA-672] Use explicit shards for replicated operations.

### DIFF
--- a/arangod/Replication2/StateMachines/Document/DocumentLeaderState.h
+++ b/arangod/Replication2/StateMachines/Document/DocumentLeaderState.h
@@ -54,7 +54,8 @@ struct DocumentLeaderState
 
   auto replicateOperation(velocypack::SharedSlice payload,
                           OperationType operation, TransactionId transactionId,
-                          ReplicationOptions opts) -> futures::Future<LogIndex>;
+                          ShardID shard, ReplicationOptions opts)
+      -> futures::Future<LogIndex>;
 
   std::size_t getActiveTransactionsCount() const noexcept {
     return _activeTransactions.getLockedGuard()->size();

--- a/arangod/RocksDBEngine/ReplicatedRocksDBTransactionCollection.cpp
+++ b/arangod/RocksDBEngine/ReplicatedRocksDBTransactionCollection.cpp
@@ -235,7 +235,7 @@ ReplicatedRocksDBTransactionCollection::performIntermediateCommitIfRequired() {
     try {
       return leader
           ->replicateOperation(velocypack::SharedSlice{}, operation,
-                               _transaction->id(), options)
+                               _transaction->id(), collectionName(), options)
           .thenValue([state = _transaction->shared_from_this(),
                       this](auto&& res) -> Result {
             return _rocksMethods->triggerIntermediateCommit();

--- a/arangod/Transaction/Methods.cpp
+++ b/arangod/Transaction/Methods.cpp
@@ -2635,7 +2635,7 @@ Future<OperationResult> transaction::Methods::truncateLocal(
       leaderState->replicateOperation(
           body.sharedSlice(),
           replication2::replicated_state::document::OperationType::kTruncate,
-          state()->id(),
+          state()->id(), trxColl->collectionName(),
           replication2::replicated_state::document::ReplicationOptions{});
     } catch (basics::Exception const& e) {
       return OperationResult(Result{e.code(), e.what()}, options);
@@ -3131,7 +3131,7 @@ Future<Result> Methods::replicateOperations(
           replicationData.sharedSlice(),
           replication2::replicated_state::document::fromDocumentOperation(
               operation),
-          state()->id(),
+          state()->id(), rtc.collectionName(),
           replication2::replicated_state::document::ReplicationOptions{});
     } catch (basics::Exception const& e) {
       return Result{e.code(), e.what()};


### PR DESCRIPTION
### Scope & Purpose
Use explicit shards for replicated operations. 