### PR TITLE
Improve Filter optimizations on Traversals in AQL

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 v3.10.4 (XXXX-XX-XX)
 --------------------
 
+* Improved optimization of functions to be covered by Traversals. Now more 
+  functions should be optimized into the traversal, and some that are not valid 
+  should not be optimized anymore. Fixes #16589.
+
 * BTS-1193: Fix for schema update. When removing a field and then inserting a
   new field into the schema, previously, both old and new schema would be
   merged, meaning it would maintain the old field and add the new one.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,8 +1,8 @@
 v3.10.4 (XXXX-XX-XX)
 --------------------
 
-* Improved optimization of functions to be covered by Traversals. Now more 
-  functions should be optimized into the traversal, and some that are not valid 
+* Improved optimization of functions to be covered by Traversals. Now more
+  functions should be optimized into the traversal, and some that are not valid
   should not be optimized anymore. Fixes #16589.
 
 * BTS-1193: Fix for schema update. When removing a field and then inserting a

--- a/arangod/Aql/AstNode.cpp
+++ b/arangod/Aql/AstNode.cpp
@@ -1616,6 +1616,15 @@ bool AstNode::willUseV8() const {
   return false;
 }
 
+/// @brief whether or not a node's filter condition can be used inside a
+/// TraversalNode
+bool AstNode::canBeUsedInFilter(bool isOneShard) const {
+  if (willUseV8() || !canRunOnDBServer(isOneShard) || !isDeterministic()) {
+    return false;
+  }
+  return true;
+}
+
 /// @brief whether or not a node has a constant value
 bool AstNode::isConstant() const {
   if (hasFlag(DETERMINED_CONSTANT)) {

--- a/arangod/Aql/AstNode.h
+++ b/arangod/Aql/AstNode.h
@@ -411,6 +411,10 @@ struct AstNode {
   /// this may also set the FLAG_V8 flag for the node
   bool willUseV8() const;
 
+  /// @brief whether or not a node's filter condition can be used inside a
+  /// TraversalNode
+  bool canBeUsedInFilter(bool isOneShard) const;
+
   /// @brief whether or not a node is a simple comparison operator
   bool isSimpleComparisonOperator() const;
 

--- a/arangod/Aql/Condition.cpp
+++ b/arangod/Aql/Condition.cpp
@@ -933,6 +933,24 @@ AstNode* Condition::removeIndexCondition(ExecutionPlan const* plan,
                                          Index const* index) {
   TRI_ASSERT(index != nullptr);
 
+  return removeCondition(plan, variable, condition, index, false);
+}
+
+/// @brief remove filter conditions already covered by the traversal
+AstNode* Condition::removeTraversalCondition(ExecutionPlan const* plan,
+                                             Variable const* variable,
+                                             AstNode* other,
+                                             bool isPathCondition) {
+  return removeCondition(plan, variable, other, nullptr,
+                         /*isFromTraverser*/ isPathCondition);
+}
+
+AstNode* Condition::removeCondition(ExecutionPlan const* plan,
+                                    Variable const* variable,
+                                    AstNode const* condition,
+                                    Index const* index, bool isFromTraverser) {
+  TRI_ASSERT(!isFromTraverser || index == nullptr);
+
   if (_root == nullptr || condition == nullptr) {
     return _root;
   }
@@ -956,7 +974,7 @@ AstNode* Condition::removeIndexCondition(ExecutionPlan const* plan,
 
   ::arangodb::containers::HashSet<size_t> toRemove;
   collectOverlappingMembers(plan, variable, andNode, conditionAndNode, toRemove,
-                            index, false);
+                            index, isFromTraverser);
 
   if (toRemove.empty()) {
     return _root;
@@ -965,56 +983,6 @@ AstNode* Condition::removeIndexCondition(ExecutionPlan const* plan,
   // build a new AST condition
   AstNode* newNode = nullptr;
 
-  for (size_t i = 0; i < n; ++i) {
-    if (toRemove.find(i) == toRemove.end()) {
-      auto what = andNode->getMemberUnchecked(i);
-
-      if (newNode == nullptr) {
-        // the only node so far
-        newNode = what;
-      } else {
-        // AND-combine with existing node
-        newNode = _ast->createNodeBinaryOperator(NODE_TYPE_OPERATOR_BINARY_AND,
-                                                 newNode, what);
-      }
-    }
-  }
-
-  return newNode;
-}
-
-/// @brief remove filter conditions already covered by the traversal
-AstNode* Condition::removeTraversalCondition(ExecutionPlan const* plan,
-                                             Variable const* variable,
-                                             AstNode* other) {
-  if (_root == nullptr || other == nullptr) {
-    return _root;
-  }
-  TRI_ASSERT(_root != nullptr);
-  TRI_ASSERT(_root->type == NODE_TYPE_OPERATOR_NARY_OR);
-
-  TRI_ASSERT(other != nullptr);
-  TRI_ASSERT(other->type == NODE_TYPE_OPERATOR_NARY_OR);
-  if (other->numMembers() != 1 && _root->numMembers() != 1) {
-    return _root;
-  }
-
-  auto andNode = _root->getMemberUnchecked(0);
-  TRI_ASSERT(andNode->type == NODE_TYPE_OPERATOR_NARY_AND);
-  auto otherAndNode = other->getMemberUnchecked(0);
-  TRI_ASSERT(otherAndNode->type == NODE_TYPE_OPERATOR_NARY_AND);
-  size_t const n = andNode->numMembers();
-
-  ::arangodb::containers::HashSet<size_t> toRemove;
-  collectOverlappingMembers(plan, variable, andNode, otherAndNode, toRemove,
-                            nullptr, true);
-
-  if (toRemove.empty()) {
-    return _root;
-  }
-
-  // build a new AST condition
-  AstNode* newNode = nullptr;
   for (size_t i = 0; i < n; ++i) {
     if (toRemove.find(i) == toRemove.end()) {
       auto what = andNode->getMemberUnchecked(i);

--- a/arangod/Aql/Condition.h
+++ b/arangod/Aql/Condition.h
@@ -178,7 +178,7 @@ class Condition {
 
   /// @brief removes condition parts from another
   AstNode* removeTraversalCondition(ExecutionPlan const*, Variable const*,
-                                    AstNode*);
+                                    AstNode*, bool isPathCondition);
 
   /// @brief remove (now) invalid variables from the condition
   bool removeInvalidVariables(VarSet const&);
@@ -201,6 +201,12 @@ class Condition {
   getNonNullAttributes(Variable const*) const;
 
  private:
+  /// @brief internal worker function for removeIndexCondition and
+  /// removeTraversalCondition
+  AstNode* removeCondition(ExecutionPlan const* plan, Variable const* variable,
+                           AstNode const* condition, Index const* index,
+                           bool isFromTraverser);
+
   /// @brief optimize the condition expression tree
   void optimize(ExecutionPlan*, bool multivalued);
 

--- a/arangod/Aql/ExecutionPlan.cpp
+++ b/arangod/Aql/ExecutionPlan.cpp
@@ -1361,6 +1361,15 @@ ExecutionNode* ExecutionPlan::fromNodeTraversal(ExecutionNode* previous,
         absl::StrCat("Invalid PRUNE expression: ", errorReason));
   }
 
+  if (pruneExpression != nullptr && !pruneExpression->canBeUsedInPrune(
+                                        _ast->query().vocbase().isOneShard())) {
+    // PRUNE is designed to be executed inside a DBServer. Therefore, we need a
+    // check here and abort in cases which are just not allowed, e.g. execution
+    // of user defined JavaScript method or V8 based methods.
+    THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_QUERY_PARSE,
+                                   "Invalid PRUNE expression");
+  }
+
   auto options =
       createTraversalOptions(getAst(), direction, node->getMember(4));
 

--- a/arangod/Aql/Expression.cpp
+++ b/arangod/Aql/Expression.cpp
@@ -1921,6 +1921,13 @@ bool Expression::canBeUsedInPrune(bool isOneShard, std::string& errorReason) {
   return true;
 }
 
+bool Expression::canBeUsedInPrune(bool isOneShard) {
+  if (willUseV8() || !canRunOnDBServer(isOneShard)) {
+    return false;
+  }
+  return true;
+}
+
 std::unique_ptr<Expression> Expression::clone(Ast* ast, bool deepCopy) {
   // We do not need to copy the _ast, since it is managed by the
   // query object and the memory management of the ASTs

--- a/arangod/Aql/Expression.h
+++ b/arangod/Aql/Expression.h
@@ -99,6 +99,9 @@ class Expression {
   /// @brief whether or not the expression can be used inside a PRUNE statement
   bool canBeUsedInPrune(bool isOneShard, std::string& errorReason);
 
+  /// @brief whether or not the expression can be used inside a PRUNE statement
+  bool canBeUsedInPrune(bool isOneShard);
+
   /// @brief clone the expression, needed to clone execution plans
   std::unique_ptr<Expression> clone(Ast* ast, bool deepCopy = false);
 

--- a/arangod/Aql/GraphNode.cpp
+++ b/arangod/Aql/GraphNode.cpp
@@ -176,6 +176,7 @@ GraphNode::GraphNode(ExecutionPlan* plan, ExecutionNodeId id,
       _vocbase(vocbase),
       _vertexOutVariable(nullptr),
       _edgeOutVariable(nullptr),
+      _optimizedOutVariables({}),
       _graphObj(nullptr),
       _tmpObjVariable(_plan->getAst()->variables()->createTemporaryVariable()),
       _tmpObjVarNode(_plan->getAst()->createNodeReference(_tmpObjVariable)),
@@ -361,6 +362,7 @@ GraphNode::GraphNode(ExecutionPlan* plan,
       _vocbase(&(plan->getAst()->query().vocbase())),
       _vertexOutVariable(nullptr),
       _edgeOutVariable(nullptr),
+      _optimizedOutVariables({}),
       _graphObj(nullptr),
       _tmpObjVariable(nullptr),
       _tmpObjVarNode(nullptr),
@@ -485,6 +487,15 @@ GraphNode::GraphNode(ExecutionPlan* plan,
         Variable::varFromVPack(plan->getAst(), base, "edgeOutVariable");
   }
 
+  VPackSlice optimizedOutVariables = base.get("optimizedOutVariables");
+  if (optimizedOutVariables.isArray()) {
+    for (auto const& var : VPackArrayIterator(optimizedOutVariables)) {
+      if (var.isNumber()) {
+        _optimizedOutVariables.emplace(var.getNumber<VariableId>());
+      }
+    }
+  }
+
   // Temporary Filter Objects
   TRI_ASSERT(base.hasKey("tmpObjVariable"));
   _tmpObjVariable =
@@ -529,6 +540,7 @@ GraphNode::GraphNode(ExecutionPlan* plan, ExecutionNodeId id,
       _vocbase(vocbase),
       _vertexOutVariable(nullptr),
       _edgeOutVariable(nullptr),
+      _optimizedOutVariables({}),
       _graphObj(graph),
       _tmpObjVariable(_plan->getAst()->variables()->createTemporaryVariable()),
       _tmpObjVarNode(_plan->getAst()->createNodeReference(_tmpObjVariable)),
@@ -574,6 +586,7 @@ GraphNode::GraphNode(ExecutionPlan& plan, GraphNode const& other,
       _vocbase(other._vocbase),
       _vertexOutVariable(nullptr),
       _edgeOutVariable(nullptr),
+      _optimizedOutVariables(other._optimizedOutVariables),
       _graphObj(other.graph()),
       _tmpObjVariable(_plan->getAst()->variables()->createTemporaryVariable()),
       _tmpObjVarNode(_plan->getAst()->createNodeReference(_tmpObjVariable)),
@@ -688,6 +701,14 @@ void GraphNode::doToVelocyPack(VPackBuilder& nodes, unsigned flags) const {
     edgeOutVariable()->toVelocyPack(nodes);
   }
 
+  nodes.add(VPackValue("optimizedOutVariables"));
+  {
+    VPackArrayBuilder guard(&nodes);
+    for (auto const& var : _optimizedOutVariables) {
+      nodes.add(VPackValue(var));
+    }
+  }
+
   // Flags
   nodes.add(StaticStrings::IsSmart, VPackValue(_isSmart));
   nodes.add(StaticStrings::IsDisjoint, VPackValue(_isDisjoint));
@@ -718,6 +739,9 @@ void GraphNode::graphCloneHelper(ExecutionPlan&, GraphNode& clone, bool) const {
   clone._isSmart = _isSmart;
   clone._isDisjoint = _isDisjoint;
   clone._enabledClusterOneShardRule = _enabledClusterOneShardRule;
+
+  // Optimized Out Variables
+  clone._optimizedOutVariables = _optimizedOutVariables;
 }
 
 CostEstimate GraphNode::estimateCost() const {
@@ -987,7 +1011,14 @@ bool GraphNode::isVertexOutVariableUsedLater() const {
 }
 
 void GraphNode::setVertexOutput(Variable const* outVar) {
+  if (outVar == nullptr) {
+    markUnusedConditionVariable(_vertexOutVariable);
+  }
   _vertexOutVariable = outVar;
+}
+
+void GraphNode::markUnusedConditionVariable(Variable const* var) {
+  _optimizedOutVariables.emplace(var->id);
 }
 
 Variable const* GraphNode::edgeOutVariable() const { return _edgeOutVariable; }
@@ -997,6 +1028,9 @@ bool GraphNode::isEdgeOutVariableUsedLater() const {
 }
 
 void GraphNode::setEdgeOutput(Variable const* outVar) {
+  if (outVar == nullptr) {
+    markUnusedConditionVariable(_edgeOutVariable);
+  }
   _edgeOutVariable = outVar;
 }
 

--- a/arangod/Aql/GraphNode.h
+++ b/arangod/Aql/GraphNode.h
@@ -135,6 +135,8 @@ class GraphNode : public ExecutionNode {
   /// @brief checks if the vertex out variable is used
   bool isVertexOutVariableUsedLater() const;
 
+  void markUnusedConditionVariable(Variable const* var);
+
   /// @brief set the vertex out variable
   void setVertexOutput(Variable const* outVar);
 
@@ -251,6 +253,9 @@ class GraphNode : public ExecutionNode {
 
   /// @brief vertex output variable
   Variable const* _edgeOutVariable;
+
+  /// @brief variables that got optimized out
+  VarIdSet _optimizedOutVariables;
 
   /// @brief our graph...
   graph::Graph const* _graphObj;

--- a/arangod/Aql/OptimizerRules.cpp
+++ b/arangod/Aql/OptimizerRules.cpp
@@ -6471,37 +6471,56 @@ void arangodb::aql::removeFiltersCoveredByTraversal(
         auto traversalCondition = traversalNode->condition();
 
         if (traversalCondition != nullptr && !traversalCondition->isEmpty()) {
-          /*auto const& indexesUsed = traversalNode->get
-          //indexNode->getIndexes();
-
-          if (indexesUsed.size() == 1) {*/
-          // single index. this is something that we can handle
-          Variable const* outVariable = traversalNode->pathOutVariable();
           VarSet varsUsedByCondition;
           Ast::getReferencedVariables(condition.root(), varsUsedByCondition);
-          if (outVariable != nullptr && varsUsedByCondition.find(outVariable) !=
-                                            varsUsedByCondition.end()) {
+
+          auto remover = [&](Variable const* outVariable,
+                             bool isPathCondition) -> bool {
+            if (outVariable == nullptr) {
+              return false;
+            }
+            if (varsUsedByCondition.find(outVariable) ==
+                varsUsedByCondition.end()) {
+              return false;
+            }
+
             auto newNode = condition.removeTraversalCondition(
-                plan.get(), outVariable, traversalCondition->root());
+                plan.get(), outVariable, traversalCondition->root(),
+                isPathCondition);
             if (newNode == nullptr) {
               // no condition left...
               // FILTER node can be completely removed
               toUnlink.emplace(node);
               // note: we must leave the calculation node intact, in case it
               // is still used by other nodes in the plan
-              modified = true;
-              handled = true;
+              return true;
             } else if (newNode != condition.root()) {
               // some condition is left, but it is a different one than
               // the one from the FILTER node
               auto expr = std::make_unique<Expression>(plan->getAst(), newNode);
-              CalculationNode* cn = new CalculationNode(
+              auto* cn = plan->createNode<CalculationNode>(
                   plan.get(), plan->nextId(), std::move(expr),
                   calculationNode->outVariable());
-              plan->registerNode(cn);
               plan->replaceNode(setter, cn);
+              return true;
+            }
+
+            return false;
+          };
+
+          std::array<std::pair<Variable const*, bool>, 3> vars = {
+              std::make_pair(traversalNode->pathOutVariable(),
+                             /*isPathCondition*/ true),
+              std::make_pair(traversalNode->vertexOutVariable(),
+                             /*isPathCondition*/ false),
+              std::make_pair(traversalNode->edgeOutVariable(),
+                             /*isPathCondition*/ false)};
+
+          for (auto [v, isPathCondition] : vars) {
+            if (remover(v, isPathCondition)) {
               modified = true;
               handled = true;
+              break;
             }
           }
         }

--- a/arangod/Aql/PruneExpressionEvaluator.cpp
+++ b/arangod/Aql/PruneExpressionEvaluator.cpp
@@ -25,7 +25,9 @@
 
 #include "Aql/AqlValue.h"
 #include "Aql/Expression.h"
+#include "Cluster/ServerState.h"
 #include "Transaction/Methods.h"
+#include "VocBase/vocbase.h"
 
 using namespace arangodb;
 using namespace arangodb::aql;
@@ -37,7 +39,11 @@ PruneExpressionEvaluator::PruneExpressionEvaluator(
     size_t pathVarIdx, Expression* expr)
     : _pruneExpression(expr),
       _ctx(trx, query, cache, std::move(vars), std::move(regs), vertexVarIdx,
-           edgeVarIdx, pathVarIdx) {}
+           edgeVarIdx, pathVarIdx) {
+  TRI_ASSERT(_pruneExpression == nullptr ||
+             !ServerState::instance()->isRunningInCluster() ||
+             _pruneExpression->canRunOnDBServer(_ctx.vocbase().isOneShard()));
+}
 
 PruneExpressionEvaluator::~PruneExpressionEvaluator() = default;
 

--- a/arangod/Aql/TraversalNode.cpp
+++ b/arangod/Aql/TraversalNode.cpp
@@ -321,6 +321,9 @@ Variable const* TraversalNode::pathOutVariable() const {
 
 /// @brief set the path out variable
 void TraversalNode::setPathOutput(Variable const* outVar) {
+  if (outVar == nullptr) {
+    markUnusedConditionVariable(_pathOutVariable);
+  }
   _pathOutVariable = outVar;
 }
 
@@ -365,16 +368,18 @@ void TraversalNode::replaceVariables(
 /// @brief getVariablesUsedHere
 void TraversalNode::getVariablesUsedHere(VarSet& result) const {
   for (auto const& condVar : _conditionVariables) {
-    if (condVar != getTemporaryVariable()) {
+    if (condVar != pathOutVariable() && condVar != getTemporaryVariable()) {
       result.emplace(condVar);
     }
   }
+
   for (auto const& pruneVar : _pruneVariables) {
     if (pruneVar != vertexOutVariable() && pruneVar != edgeOutVariable() &&
         pruneVar != pathOutVariable()) {
       result.emplace(pruneVar);
     }
   }
+
   if (usesInVariable()) {
     result.emplace(_inVariable);
   }
@@ -1097,6 +1102,10 @@ void TraversalNode::traversalCloneHelper(ExecutionPlan& plan, TraversalNode& c,
                                     it.second->clone(_plan->getAst()));
   }
 
+  if (_condition) {
+    c.setCondition(_condition->clone());
+  }
+
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   c.checkConditionsDefined();
 #endif
@@ -1220,7 +1229,8 @@ void TraversalNode::setCondition(
          oneVar->id != _vertexOutVariable->id) &&
         (_edgeOutVariable == nullptr || oneVar->id != _edgeOutVariable->id) &&
         (_pathOutVariable == nullptr || oneVar->id != _pathOutVariable->id) &&
-        (_inVariable == nullptr || oneVar->id != _inVariable->id)) {
+        (_inVariable == nullptr || oneVar->id != _inVariable->id) &&
+        (!_optimizedOutVariables.contains(oneVar->id))) {
       _conditionVariables.emplace(oneVar);
     }
   }
@@ -1272,6 +1282,10 @@ void TraversalNode::registerGlobalCondition(bool isConditionOnEdge,
 void TraversalNode::registerPostFilterCondition(AstNode const* condition) {
   // We cannot modify the postFilterExpression after it was build
   TRI_ASSERT(_postFilterExpression == nullptr);
+  TRI_ASSERT(condition != nullptr);
+  TRI_ASSERT(!condition->willUseV8());
+  TRI_ASSERT(!ServerState::instance()->isRunningInCluster() ||
+             condition->canRunOnDBServer(vocbase()->isOneShard()));
   _postFilterConditions.emplace_back(condition);
   Ast::getReferencedVariables(condition, _postFilterVariables);
 }

--- a/arangod/Aql/types.h
+++ b/arangod/Aql/types.h
@@ -90,6 +90,7 @@ using AqlCollectionMap = std::map<std::string, aql::Collection*, std::less<>>;
 struct Variable;
 // Note: #include <Containers/HashSet.h> to use the following types
 using VarSet = containers::HashSet<Variable const*>;
+using VarIdSet = containers::HashSet<VariableId>;
 using VarSetStack = std::vector<VarSet>;
 using RegIdSet = containers::HashSet<RegisterId>;
 using RegIdSetStack = std::vector<RegIdSet>;

--- a/js/common/modules/@arangodb/aql/explainer.js
+++ b/js/common/modules/@arangodb/aql/explainer.js
@@ -642,10 +642,10 @@ function printTraversalDetails(traversals) {
     }
     // else do not add a cell in 4
     if (node.hasOwnProperty('ConditionStr')) {
-      outTable.addCell(5, 'FILTER ' + node.ConditionStr);
+      outTable.addCell(5, keyword('FILTER ') + node.ConditionStr);
     }
     if (node.hasOwnProperty('PruneConditionStr')) {
-      outTable.addCell(5, 'PRUNE ' + node.PruneConditionStr);
+      outTable.addCell(5, keyword('PRUNE ') + node.PruneConditionStr);
     }
   });
   outTable.print(stringBuilder);
@@ -2321,11 +2321,15 @@ function debug(query, bindVars, options) {
     input.options = {};
   }
   input.options.explainRegisters = true;
+  let dbProperties = db._properties();
+  delete dbProperties.id;
+  delete dbProperties.isSystem;
+  delete dbProperties.path;
 
   let result = {
     engine: db._engine(),
     version: db._version(true),
-    database: db._name(),
+    database: dbProperties,
     query: input,
     queryCache: require('@arangodb/aql/cache').properties(),
     collections: {},

--- a/js/server/modules/@arangodb/testutils/aql-graph-traversal-generic-tests.js
+++ b/js/server/modules/@arangodb/testutils/aql-graph-traversal-generic-tests.js
@@ -1,5 +1,5 @@
 /*jshint globalstrict:true, strict:true, esnext: true */
-/*global print, fail */
+/*global print, fail, AQL_EXPLAIN */
 
 "use strict";
 
@@ -35,6 +35,7 @@ const {aql, errors} = require("@arangodb");
 const protoGraphs = require('@arangodb/testutils/aql-graph-traversal-generic-graphs').protoGraphs;
 const _ = require("lodash");
 const {getCompactStatsNodes, TraversalBlock} = require("@arangodb/testutils/aql-profiler-test-helper");
+const {findExecutionNodes} = require("@arangodb/aql-helper");
 const isCluster = require("internal").isCluster();
 
 /*
@@ -2960,6 +2961,117 @@ function testSmallCircleKShortestPathEnabledWeightCheckWithMultipleLimitsGen(tes
 
     checkResIsValidKShortestPathListWeights(allowedPaths, actualPath, limit);
   });
+}
+
+function testSmallCircleFilterOptimization(testGraph) {
+  // Which Graph is used here does not matter, enough to test with one of the graphs
+  // we picked the smallCircle graph at random
+  assertTrue(testGraph.name().startsWith(protoGraphs.smallCircle.name()));
+
+  const optimizableConditions = [
+    `v.color == "blue"`,
+    `"blue" == e.color`,
+    `p.edges[1].color == "blue"`,
+    `"blue" == p.vertices[1].color`,
+    `p.edges[*].color ALL == "blue"`,
+    `p.vertices[*].color ALL == "blue"`
+  ];
+
+  // Optimize a single condition
+  const filtersToTest = optimizableConditions.map(f => `FILTER ${f}`);
+  // More complex test.
+  for (let first = 0; first < optimizableConditions.length; ++first) {
+    for (let second = first + 1; second < optimizableConditions.length; ++second) {
+      // Optimize two filter nodes, and erase the filter nodes
+      filtersToTest.push(`FILTER ${optimizableConditions[first]} FILTER ${optimizableConditions[second]}`);
+    }
+  }
+
+  for (const filterCondition of filtersToTest) {
+    const query = `
+      FOR v,e,p IN 1..3 OUTBOUND "${testGraph.vertex('A')}" GRAPH "${testGraph.name()}"
+        ${filterCondition}
+        return v
+    `;
+    const plan = AQL_EXPLAIN(query, {});
+
+
+    assertEqual(findExecutionNodes(plan, "FilterNode").length, 0, query + " Still has FilterNode");
+
+    const traversals = findExecutionNodes(plan, "TraversalNode");
+    assertEqual(traversals.length, 1, query + " Somehow we have removed the Traversal");
+    const travNode = traversals[0];
+    assertTrue(travNode.hasOwnProperty("condition"));
+  }
+
+  // Non optimizable filters
+  const nonOptimizableFilters = [
+    `DOCUMENT(v.docId).color == "blue"`,
+    `DOCUMENT(e.docId).color == "blue"`,
+    /* ASSSERT has side-effects on false so it should not be optimized */
+    `ASSERT(v.color == "blue", "Color is not blue")`,
+    `DATE_YEAR(p.vertices[1].timestamp) == DATE_YEAR(DATE_ADD(p.vertices[0].timestamp, 1, "y"))`,
+    `DATE_YEAR(p.vertices[1].timestamp) == DATE_YEAR(DATE_ADD(DOCUMENT("${testGraph.vertex('A')}").timestamp, 1, "y"))`
+  ];
+
+  /* Note: this set has a chance to be optimized, we cannot reliably detect methods yet
+  * therefore the FILTER node will stay in place, but the Methods is already moved into the Traversal
+  */
+  const optimizedButFilterIsKept = [
+    `DATE_MONTH(v.timestamp) == 11`,
+    `25 == DATE_DAY(e.timestamp)`,
+    `DATE_YEAR(p.vertices[1].timestamp) == DATE_YEAR(DATE_ADD(0, 100, "y"))`,
+  ];
+
+  // This is a pair of FilterCondition and LeftOver non-optimized condition.
+  // The FILTER node needs to stay, and needs to cover the non-optimized condition
+  const nonOptFiltersToTest = nonOptimizableFilters.map(f => [`FILTER ${f}`, `${f}`, false]);
+
+  for (const c of optimizedButFilterIsKept.map(f => [`FILTER ${f}`, `${f}`, true])) {
+    nonOptFiltersToTest.push(c);
+  }
+
+  // NOTE: we only detect one of the two AND branches to be covered.
+  // Actually both are covered, our optimizer does not detect this yet.
+  // NOTE: We only iterate up to 2 as the following all cover Path only conditions which are optimized
+  for (let first = 0; first < 2; ++first) {
+    for (let second = first + 1; second < optimizableConditions.length; ++second) {
+      nonOptFiltersToTest.push([`FILTER ${optimizableConditions[first]} && ${optimizableConditions[second]}`, `${optimizableConditions[first]}`, true]);
+    }
+  }
+
+  // More complex test.
+  for (let first = 0; first < nonOptimizableFilters.length; ++first) {
+    for (let second = 0; second < optimizableConditions.length; ++second) {
+      // Add two filter nodes, one can be optimized, one note. The optimizable one should be erased.
+      nonOptFiltersToTest.push([`FILTER ${nonOptimizableFilters[first]} FILTER ${optimizableConditions[second]}`, `${nonOptimizableFilters[first]}`, true]);
+      // Put it into one big condition, where parts can be optimized, parts not
+      nonOptFiltersToTest.push([`FILTER ${nonOptimizableFilters[first]} && ${optimizableConditions[second]}`, `${nonOptimizableFilters[first]}`, true]);
+    }
+  }
+
+  for (const [filterCondition, _, somethingOptimizedInTraversal] of nonOptFiltersToTest) {
+    const query = `
+      FOR v,e,p IN 1..3 OUTBOUND "${testGraph.vertex('A')}" GRAPH "${testGraph.name()}"
+        ${filterCondition}
+        return v
+    `;
+    const plan = AQL_EXPLAIN(query, {});
+
+    const filters = findExecutionNodes(plan, "FilterNode");
+
+    assertEqual(filters.length, 1, query + " Optimized out the FilterNode");
+    const filterCalc = findExecutionNodes(plan, "CalculationNode").find(n => n.id === filters[0].dependencies[0]);
+    assertNotEqual(filterCalc, undefined);
+
+    // TODO it would be nice to analyse that calculation matches the leftOver condition
+    // but this would require to reverse-implement node structure.
+    const traversals = findExecutionNodes(plan, "TraversalNode");
+    assertEqual(traversals.length, 1, query + " Somehow we have removed the Traversal");
+    const travNode = traversals[0];
+    assertEqual(travNode.hasOwnProperty("condition"), somethingOptimizedInTraversal, JSON.stringify(travNode.condition));
+  }
+
 }
 
 function testCompleteGraphDfsUniqueVerticesPathD1(testGraph) {
@@ -6464,7 +6576,8 @@ const testsByGraph = {
     testSmallCircleKShortestPathWithMultipleLimitsWT,
     testSmallCircleKShortestPathEnabledWeightCheckWithMultipleLimits,
     testSmallCircleKShortestPathEnabledWeightCheckIndexedWithMultipleLimits,
-    testSmallCircleKShortestPathEnabledWeightCheckWithMultipleLimitsWT
+    testSmallCircleKShortestPathEnabledWeightCheckWithMultipleLimitsWT,
+    testSmallCircleFilterOptimization
   },
   completeGraph: {
     testCompleteGraphDfsUniqueVerticesPathD1,

--- a/tests/js/server/aql/aql-graph-traverser-complexFiltering.js
+++ b/tests/js/server/aql/aql-graph-traverser-complexFiltering.js
@@ -494,7 +494,9 @@ function complexFilteringSuite() {
           assertEqual(node["inVariable"]["name"], "pruneCondition");
         }
       });
-      assertTrue(foundExtraLet);
+
+      // We cannot find an extra LET, as the PruneCondition can be optimized into the Traversal and be transformed into a local
+      assertFalse(foundExtraLet);
     },
 
     testStorePruneConditionVertexInVariableExplainLogicalOrWithOptions: function () {
@@ -517,7 +519,9 @@ function complexFilteringSuite() {
           assertEqual(node["options"]["order"], "bfs");
         }
       });
-      assertTrue(foundExtraLet);
+
+      // We cannot find an extra LET, as the PruneCondition can be optimized into the Traversal and be transformed into a local
+      assertFalse(foundExtraLet);
     },
 
     testStorePruneConditionEdgeInVariableExplain: function () {
@@ -537,7 +541,9 @@ function complexFilteringSuite() {
           assertEqual(node["inVariable"]["name"], "pruneCondition");
         }
       });
-      assertTrue(foundExtraLet);
+
+      // We cannot find an extra LET, as the PruneCondition can be optimized into the Traversal and be transformed into a local
+      assertFalse(foundExtraLet);
     },
 
     testStorePruneConditionEdgeInVariableExplainWithOptions: function () {
@@ -560,7 +566,9 @@ function complexFilteringSuite() {
           assertEqual(node["options"]["order"], "bfs");
         }
       });
-      assertTrue(foundExtraLet);
+
+      // We cannot find an extra LET, as the PruneCondition can be optimized into the Traversal and be transformed into a local
+      assertFalse(foundExtraLet);
     },
 
     testStorePruneConditionPathInVariableExplain: function () {

--- a/tests/js/server/aql/aql-optimizer-rule-optimize-traversals-spec.js
+++ b/tests/js/server/aql/aql-optimizer-rule-optimize-traversals-spec.js
@@ -165,9 +165,6 @@ describe('Rule optimize-traversals', () => {
       FILTER p.edges[p.edges.length - 1].theFalse == false
       RETURN {v:v,e:e,p:p}`,
       `FOR v, e, p IN 2 OUTBOUND 'circles/A' GRAPH '${graphName}'
-      FILTER CONCAT(p.edges[0]._key, '') == " + edgeKey + " SORT v._key
-      RETURN {v:v,e:e,p:p}`,
-      `FOR v, e, p IN 2 OUTBOUND 'circles/A' GRAPH '${graphName}'
       FILTER NOOPT(CONCAT(p.edges[0]._key, '')) == " + edgeKey + " SORT v._key
       RETURN {v:v,e:e,p:p}`,
       `FOR snippet IN ['a', 'b']
@@ -203,7 +200,10 @@ describe('Rule optimize-traversals', () => {
       LET test = CONCAT(snippet, 'ar')
       FOR v, e, p IN 1..5 OUTBOUND 'circles/A' GRAPH '${graphName}'
       FILTER p.edges[1].label == test 
-      RETURN {v,e,p}`
+      RETURN {v,e,p}`,
+      `FOR v, e, p IN 2 OUTBOUND 'circles/A' GRAPH '${graphName}'
+      FILTER CONCAT(p.edges[0]._key, '') == " + edgeKey + " SORT v._key
+      RETURN {v:v,e:e,p:p}`
     ];
     queries.forEach(function (query) {
       const result = AQL_EXPLAIN(query, { }, paramEnabled);


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/16622 
Enterprise companion PR: https://github.com/arangodb/enterprise/pull/1206

Note: Includes additional fix for (#17291)
Note: also includes unrelated change (backport of https://github.com/arangodb/arangodb/pull/18088)

PR for some traversal optimizations. The PR includes the following changes regarding traversal filter conditions:

**Less post-filtering for vertex or edge filters**
Vertex or edge filters that were pulled into the traversal were previously not removed as post filters. 
That means the filter condition for vertex or edge filters was evaluated inside the traversal and _additionally_ as a post filter. This is unnecessarily expensive.
This PR fixes that, at least for simple filter conditions. Conditions such as `FILTER v.attribute == ...` will be detected and removed as post-filters. More complex filter conditions will not be detected, especially if the filter conditions invoke function calls (e.g. `FILTER LOWER(v.attribute) == ...`) or if there are FILTER conditions on multiple traversal output variables (e.g. `FILTER v.attribute == e.attribute`).

**Moving more path filters into the traversal**
Previously, path filter conditions were only moved into the traversal if they did not contain any AQL function call. This restriction has now been lifted, so that generally all deterministic AQL functions can be used in path filters as well. In cluster, the used AQL functions additionally have to be executable on DB servers in order to qualify.
AQL user-defined functions (UDFs) still cannot be used in path filters.

**Prevent moving of unsafe vertex or edge filters into the traversal**
Previously any vertex or edge filter condition qualified to be moved into the traversal. This is not safe if the condition is executed on DB servers. For example, on DB servers it is not possible to execute JavaScript user-defined functions, or some other AQL functions that only work on coordinators.
With this PR, vertex and edge filter conditions are first checked for these criteria before they are moved into the traversal. Unsafe conditions are not moved into the traversal.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [x] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [x] Backports
  - [x] Backport for 3.10: this PR
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -

#### Related Information

- [ ] Docs PR: 
- [x] Enterprise PR: https://github.com/arangodb/enterprise/pull/1206
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 