### PR TITLE
[testing] compress agency dumps

### DIFF
--- a/js/client/modules/@arangodb/testutils/instance-manager.js
+++ b/js/client/modules/@arangodb/testutils/instance-manager.js
@@ -528,6 +528,21 @@ class instanceManager {
   // / @brief dump the state of the agency to disk. if we still can get one.
   // //////////////////////////////////////////////////////////////////////////////
   dumpAgency() {
+    const dumpdir = fs.join(this.options.testOutputDirectory, 'agencydump');
+    const zipfn = fs.join(this.options.testOutputDirectory, 'agencydump.zip');
+    if (fs.exists(dumpdir)) {
+      if (fs.isFile(zipfn)) {
+        fs.remove(zipfn);
+      };
+      fs.list(dumpdir).forEach(file => {
+        const fn = fs.join(dumpdir, file);
+        if (fs.isFile(fn)) {
+          fs.remove(fn);
+        }
+      });
+    } else {
+      fs.makeDirectory(dumpdir);
+    }
     this.arangods.forEach((arangod) => {
       if (arangod.isAgent()) {
         if (!arangod.checkArangoAlive()) {
@@ -542,6 +557,18 @@ class instanceManager {
         }
       }
     });
+    let zipfiles = [];
+    fs.list(dumpdir).forEach(file => {
+      const fn = fs.join(dumpdir, file);
+      if (fs.isFile(fn)) {
+        zipfiles.push(file);
+      }
+    });
+    fs.zipFile(zipfn, dumpdir, zipfiles);
+    zipfiles.forEach(file => {
+      fs.remove(fs.join(dumpdir, file));
+    });
+    fs.removeDirectory(dumpdir);
   }
 
   checkUptime () {

--- a/js/client/modules/@arangodb/testutils/instance.js
+++ b/js/client/modules/@arangodb/testutils/instance.js
@@ -861,7 +861,7 @@ class instance {
     let agencyReply = this.getAgent(path, method);
     if (agencyReply.code === 200) {
       let agencyValue = JSON.parse(agencyReply.body);
-      fs.write(fs.join(this.options.testOutputDirectory, fn + '_' + this.pid + ".json"), JSON.stringify(agencyValue, null, 2));
+      fs.write(fs.join(this.options.testOutputDirectory, 'agencydump', fn + '_' + this.pid + ".json"), JSON.stringify(agencyValue, null, 2));
     } else {
       print(agencyReply);
     }

--- a/js/client/modules/@arangodb/testutils/instance.js
+++ b/js/client/modules/@arangodb/testutils/instance.js
@@ -856,12 +856,12 @@ class instance {
     return download(this.url + path, method === 'POST' ? '[["/"]]' : '', opts);
   }
 
-  dumpAgent(path, method, fn) {
+  dumpAgent(path, method, fn, dumpdir) {
     print('--------------------------------- '+ fn + ' -----------------------------------------------');
     let agencyReply = this.getAgent(path, method);
     if (agencyReply.code === 200) {
       let agencyValue = JSON.parse(agencyReply.body);
-      fs.write(fs.join(this.options.testOutputDirectory, 'agencydump', fn + '_' + this.pid + ".json"), JSON.stringify(agencyValue, null, 2));
+      fs.write(fs.join(dumpdir, fn + '_' + this.pid + ".json"), JSON.stringify(agencyValue, null, 2));
     } else {
       print(agencyReply);
     }


### PR DESCRIPTION
### Scope & Purpose
since CI allways dumps the agency and zip is cheaper and distributed than the final 7z, zip them right after getting them.
7z takes ~5 minutes on a successfull run, hopefully this improves that. 