### PR TITLE
pimp testfailures.txt in fatal abort situation

### DIFF
--- a/js/client/modules/@arangodb/testutils/result-processing.js
+++ b/js/client/modules/@arangodb/testutils/result-processing.js
@@ -992,7 +992,7 @@ function writeDefaultReports(options, testSuites) {
   }
   fs.write(fs.join(options.testOutputDirectory, testFailureText),
            "Incomplete testrun with these testsuites: '" + testSuites +
-           "'\nand these options: " + JSON.stringify(options) + "\n");
+           "'\nand these options: " + JSON.stringify(options, null, 2) + "\n");
 
 }
 


### PR DESCRIPTION
### Scope & Purpose

instead of
```

=== dump_encrypted ===
Incomplete testrun with these testsuites: 'dump_encrypted'
and these options: {"testOutput":"/work/ArangoDB/testrun/report/dump_encrypted","dumpAgencyOnError":true,"coreCheck":true,"disableMonitor":true,"writeXmlReport":true,"skipNondeterministic":true,"skipTimeCritical":true,"buildType":"RelWithDebInfo","minPort":13700,"maxPort":13799,"skipGrey":true,"onlyGrey":false,"testOutputDirectory":"/work/ArangoDB/testrun/report/dump_encrypted/","agencySize":3,"agencyWaitForSync":false,"agencySupervision":true,"build":"","cleanup":true,"cluster":false,"concurrency":3,"configDir":"etc/testing","coordinators":1,"coreDirectory":"/var/tmp","coreGen":true,"dbServers":2,"duration":10,"encryptionAtRest":false,"extraArgs":{},"extremeVerbosity":false,"force":true,"forceJson":false,"getSockStat":false,"arangosearch":true,"loopEternal":false,"loopSleepSec":1,"loopSleepWhen":1,"memprof":false,"onlyNightly":false,"password":"","protocol":"tcp","replication":false,"rr":false,"exceptionFilter":null,"exceptionCount":1,"sanitizer":false,"activefailover":false,"singles":1,"setInterruptable":true,"sniff":false,"sniffAgency":true,"sniffDBServers":true,"skipLogAnalysis":true,"maxLogFileSize":512000,"skipMemoryIntense":false,"skipNightly":true,"oneTestTimeout":900,"isSan":false,"useReconnect":true,"username":"root","valgrind":false,"valgrindFileBase":"","valgrindArgs":{},"valgrindHosts":false,"verbose":false,"noStartStopLogs":false,"vst":false,"http2":false,"walFlushTimeout":30000,"testFailureText":"testfailures.txt","crashAnalysisText":"testfailures.txt","disableClusterMonitor":true,"sleepBeforeStart":0,"sleepBeforeShutdown":0,"failed":false}
```
we shall now see pretty printed json.