### PR TITLE
[testing]: it seems ARM tends to be slower on shutdown; lets give it some more time

### DIFF
--- a/js/client/modules/@arangodb/testsuites/endpoints.js
+++ b/js/client/modules/@arangodb/testsuites/endpoints.js
@@ -333,7 +333,7 @@ class endpointRunner extends tu.runInArangoshRunner {
       let message = "";
       try {
         obj.instance.shutDownOneInstance({nonAgenciesCount: 1}, false, 30);
-        obj.instance.waitForInstanceShutdown(10);
+        obj.instance.waitForInstanceShutdown(20);
       } catch (ex) {
         shutdown = false;
         message = ex.message;


### PR DESCRIPTION
### Scope & Purpose

we had ARM testruns where subsequent launches would overlap with old runs. give it more time.
