### PR TITLE
Allow usage of projections in more cases

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,12 @@
 v3.10.4 (XXXX-XX-XX)
 --------------------
 
+* Allow usage of document projections and traversal projections in slightly
+  more cases, specifically when the document's or traversal's output
+  variables were used in subqueries. Previously the usage of the document or
+  traversal output variables in subqueries could lead to projections being 
+  disabled.
+
 * BTS-1193: Fix for schema update. When removing a field and then inserting a
   new field into the schema, previously, both old and new schema would be
   merged, meaning it would maintain the old field and add the new one.

--- a/arangod/Aql/OptimizerUtils.cpp
+++ b/arangod/Aql/OptimizerUtils.cpp
@@ -1046,6 +1046,15 @@ bool findProjections(ExecutionNode* n, Variable const* v,
           return false;
         }
       }
+    } else if (current->getType() == EN::SUBQUERY) {
+      auto sub = ExecutionNode::castTo<SubqueryNode*>(current);
+      ExecutionNode* top = sub->getSubquery();
+      while (top->hasDependency()) {
+        top = top->getFirstDependency();
+      }
+      if (!findProjections(top, v, expectedAttribute, false, attributes)) {
+        return false;
+      }
     } else {
       // all other node types mandate a check
       doRegularCheck = true;

--- a/tests/js/server/aql/aql-subquery.js
+++ b/tests/js/server/aql/aql-subquery.js
@@ -433,8 +433,8 @@ function ahuacatlSubqueryTestSuite () {
           const cursor = db._query(query);
           const actual = cursor.toArray();
           const {scannedFull, scannedIndex, filtered, httpRequests} = cursor.getExtra().stats;
-          assertEqual(scannedFull, 2000);
-          assertEqual(scannedIndex, 40000);
+          assertEqual(scannedFull, 0);
+          assertEqual(scannedIndex, 42000);
           assertEqual(filtered, 0);
           if (isCoordinator) {
             assertTrue(httpRequests <= 4003 * dbServers + 1, httpRequests);

--- a/tests/js/server/aql/aql-traversal-projections.js
+++ b/tests/js/server/aql/aql-traversal-projections.js
@@ -135,6 +135,16 @@ function projectionsTestSuite () {
         [`FOR v, e, p IN 1..2 OUTBOUND 'v/test0' ${cn} RETURN [v.one, p.vertices[0].two, e.three, p.edges[1].four]`, ["one", "two"], ["_from", "_to", "three", "four"], true, true, true],
         [`FOR v, e, p IN 1..2 OUTBOUND 'v/test0' ${cn} RETURN [v.one, p.vertices[-1].one.two, e.three, p.edges[-11].three.four]`, ["one"], ["_from", "_to", "three"], true, true, true],
         [`FOR v, e, p IN 1..2 OUTBOUND 'v/test0' ${cn} RETURN [p.vertices[-1].one.two, p.edges[-11].three.four]`, [["one", "two"]], ["_from", "_to", ["three", "four"]], true, true, true],
+        
+        /* Test for subqueries */
+        [`FOR v, e, p IN 1..2 OUTBOUND 'v/test0' ${cn} LET sub = (FOR i IN 1..10 RETURN v.testi) RETURN sub`, ["testi"], ["_from", "_to"], true, false, false],
+        [`FOR v, e, p IN 1..2 OUTBOUND 'v/test0' ${cn} LET sub = (FOR i IN 1..10 FILTER v.testi == i RETURN v.testi) RETURN sub`, ["testi"], ["_from", "_to"], true, false, false],
+        [`FOR v, e, p IN 1..2 OUTBOUND 'v/test0' ${cn} LET sub = (FOR i IN 1..10 RETURN v.testi1) RETURN [sub, v.testi2]`, ["testi1", "testi2"], ["_from", "_to"], true, false, false],
+        [`FOR v, e, p IN 1..2 OUTBOUND 'v/test0' ${cn} LET sub = (FOR i IN 1..10 FILTER v.testi1 == i RETURN v.testi1) RETURN [sub, v.testi2]`, ["testi1", "testi2"], ["_from", "_to"], true, false, false],
+        [`FOR v, e, p IN 1..2 OUTBOUND 'v/test0' ${cn} LET sub = (FOR i IN 1..10 RETURN e.testi) RETURN sub`, [], ["_from", "_to", "testi"], false, false, false],
+        [`FOR v, e, p IN 1..2 OUTBOUND 'v/test0' ${cn} LET sub = (FOR i IN 1..10 FILTER e.testi == i RETURN e.testi) RETURN sub`, [], ["_from", "_to", "testi"], false, false, false],
+        [`FOR v, e, p IN 1..2 OUTBOUND 'v/test0' ${cn} LET sub = (FOR i IN 1..10 RETURN e.testi1) RETURN [sub, e.testi2]`, [], ["_from", "_to", "testi1", "testi2"], false, false, false],
+        [`FOR v, e, p IN 1..2 OUTBOUND 'v/test0' ${cn} LET sub = (FOR i IN 1..10 FILTER e.testi1 == i RETURN e.testi1) RETURN [sub, e.testi2]`, [], ["_from", "_to", "testi1", "testi2"], false, false, false],
 
         /* Test for PRUNE */
         [`FOR v, e, p IN 1..2 OUTBOUND 'v/test0' ${cn} PRUNE v.c == "foo" RETURN e`, ["c"], [], true, false, false],


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/18090

Allow usage of projections in more cases

* Allow usage of document projections and traversal projections in slightly more cases, specifically when the document's or traversal's output variables were used in subqueries. Previously the usage of the document or traversal output variables in subqueries could lead to projections being disabled.

- [x] :hankey: Bugfix
- [x] :pizza: New feature
- [x] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [x] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.10: this PR
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 