### PR TITLE
[CINFRA-656] CreateCollection on Leader Maintenance

### DIFF
--- a/arangod/Cluster/ClusterInfo.cpp
+++ b/arangod/Cluster/ClusterInfo.cpp
@@ -1733,9 +1733,13 @@ void ClusterInfo::loadPlan() {
   }
 
   decltype(_replicatedLogs) newReplicatedLogs;
+  decltype(_collectionGroups) newCollectionGroups;
   for (auto& dbs : newStuffByDatabase) {
     for (auto& it : dbs.second->replicatedLogs) {
       newReplicatedLogs.emplace(it.first, it.second);
+    }
+    for (auto& it : dbs.second->collectionGroups) {
+      newCollectionGroups.emplace(it.first, it.second);
     }
   }
 
@@ -1795,6 +1799,7 @@ void ClusterInfo::loadPlan() {
 
   _newStuffByDatabase.swap(newStuffByDatabase);
   _replicatedLogs.swap(newReplicatedLogs);
+  _collectionGroups.swap(newCollectionGroups);
 
   if (planValid) {
     _planProt.isValid = true;
@@ -6647,6 +6652,17 @@ auto ClusterInfo::getReplicatedLogsParticipants(std::string_view database) const
   }
 
   return replicatedLogs;
+}
+
+auto ClusterInfo::getCollectionGroupById(
+    replication2::agency::CollectionGroupId id)
+    -> std::shared_ptr<
+        replication2::agency::CollectionGroupPlanSpecification const> {
+  READ_LOCKER(readLocker, _planProt.lock);
+  if (auto iter = _collectionGroups.find(id); iter != _collectionGroups.end()) {
+    return iter->second;
+  }
+  return nullptr;
 }
 
 auto ClusterInfo::getReplicatedLogLeader(replication2::LogId id) const

--- a/arangod/Cluster/ClusterInfo.h
+++ b/arangod/Cluster/ClusterInfo.h
@@ -854,6 +854,10 @@ class ClusterInfo final {
       -> ResultT<
           std::unordered_map<replication2::LogId, std::vector<std::string>>>;
 
+  auto getCollectionGroupById(replication2::agency::CollectionGroupId)
+      -> std::shared_ptr<
+          replication2::agency::CollectionGroupPlanSpecification const>;
+
   /**
    * @brief Lock agency's hot backup with TTL 60 seconds
    *
@@ -1163,7 +1167,10 @@ class ClusterInfo final {
 
   using CollectionGroupMap = containers::FlatHashMap<
       replication2::agency::CollectionGroupId,
-      std::shared_ptr<replication2::agency::CollectionGroup const>>;
+      std::shared_ptr<
+          replication2::agency::CollectionGroupPlanSpecification const>>;
+  // note: protected by _planProt
+  CollectionGroupMap _collectionGroups;
 
   //////////////////////////////////////////////////////////////////////////////
   /// @brief uniqid sequence

--- a/arangod/Cluster/CreateCollection.cpp
+++ b/arangod/Cluster/CreateCollection.cpp
@@ -28,6 +28,7 @@
 #include "Basics/StaticStrings.h"
 #include "Basics/VelocyPackHelper.h"
 #include "Cluster/ClusterFeature.h"
+#include "Cluster/ClusterInfo.h"
 #include "Cluster/FollowerInfo.h"
 #include "Cluster/MaintenanceFeature.h"
 #include "Logger/LogMacros.h"
@@ -127,13 +128,33 @@ bool CreateCollection::first() {
     if (vocbase.replicationVersion() == replication::Version::TWO &&
         from == "maintenance") {
       // special case for replication 2 on the leader
-      LOG_DEVEL << shard << " " << collection << " " << properties().toJson();
       // TODO use collection group instead
       auto logId = LogicalCollection::shardIdToStateId(shard);
       if (auto gid = props.get("groupId"); gid.isNumber()) {
         logId = replication2::LogId{gid.getUInt()};
+        // Now look up the collection group
+        auto& ci = _feature.server().getFeature<ClusterFeature>().clusterInfo();
+        auto group = ci.getCollectionGroupById(
+            replication2::agency::CollectionGroupId{logId.id()});
+        if (group == nullptr) {
+          return false;  // retry later
+        }
+        // now find the index of the shard in the collection group
+        auto shardsR2 = props.get("shardsR2");
+        ADB_PROD_ASSERT(shardsR2.isArray());
+        bool found = false;
+        std::size_t index = 0;
+        for (auto x : VPackArrayIterator(shardsR2)) {
+          if (x.isEqualString(shard)) {
+            found = true;
+            break;
+          }
+          ++index;
+        }
+        ADB_PROD_ASSERT(found);
+        ADB_PROD_ASSERT(index < group->shardSheaves.size());
+        logId = group->shardSheaves[index].replicatedLog;
       }
-      LOG_DEVEL << "using replicated log " << logId;
       auto state = vocbase.getReplicatedStateById(logId);
       if (state.ok()) {
         auto leaderState = std::dynamic_pointer_cast<
@@ -143,11 +164,7 @@ bool CreateCollection::first() {
           leaderState->createShard(
               shard, collection,
               velocypack::SharedSlice(_description.properties()->bufferRef()));
-        } else {
-          LOG_DEVEL << "leader state not yet ready " << logId;
         }
-      } else {
-        LOG_DEVEL << "replicated log " << logId << " not yet ready";
       }
 
       return false;

--- a/arangod/Cluster/CreateCollection.h
+++ b/arangod/Cluster/CreateCollection.h
@@ -26,6 +26,7 @@
 
 #include "ActionBase.h"
 #include "ActionDescription.h"
+#include "VocBase/vocbase.h"
 
 #include <chrono>
 
@@ -45,6 +46,9 @@ class CreateCollection : public ActionBase, public ShardDefinition {
  private:
   bool _doNotIncrement =
       false;  // indicate that `setState` shall not increment the version
+  bool createReplication2Shard(CollectionID const& collection,
+                               ShardID const& shard, VPackSlice props,
+                               TRI_vocbase_t& vocbase) const;
 };
 
 }  // namespace maintenance

--- a/arangod/Cluster/Maintenance.cpp
+++ b/arangod/Cluster/Maintenance.cpp
@@ -407,8 +407,11 @@ static void handlePlanShard(
     }
   } else {  // Create the collection, if not a previous error stops us
     if (!errors.shards.contains(dbname + "/" + colname + "/" + shname)) {
-      if (replicationVersion != replication::Version::TWO) {
-        // Skip for replication 2 databases
+      if (replicationVersion != replication::Version::TWO || shouldBeLeading) {
+        LOG_DEVEL_IF(replicationVersion == replication::Version::TWO)
+            << "maintenance detected new shard " << dbname << "/" << colname
+            << "/" << shname;
+        // Skip for replication 2 databases on followers
         auto props = createProps(cprops);  // Only once might need often!
         description = std::make_shared<ActionDescription>(
             std::map<std::string, std::string>{
@@ -417,6 +420,7 @@ static void handlePlanShard(
                 {SHARD, shname},
                 {DATABASE, dbname},
                 {SERVER_ID, serverId},
+                {"from", "maintenance"},  // TODO clean up
                 {THE_LEADER, CreateLeaderString(leaderId, shouldBeLeading)}},
             shouldBeLeading ? LEADER_PRIORITY : FOLLOWER_PRIORITY, true,
             std::move(props));

--- a/arangod/Cluster/Maintenance.cpp
+++ b/arangod/Cluster/Maintenance.cpp
@@ -417,7 +417,9 @@ static void handlePlanShard(
                 {SHARD, shname},
                 {DATABASE, dbname},
                 {SERVER_ID, serverId},
-                {"from", "maintenance"},  // TODO clean up
+                {"from", "maintenance"},  // ugly hack - leader uses maintenance
+                                          // action as well. Used to distinguish
+                                          // between callers.
                 {THE_LEADER, CreateLeaderString(leaderId, shouldBeLeading)}},
             shouldBeLeading ? LEADER_PRIORITY : FOLLOWER_PRIORITY, true,
             std::move(props));

--- a/arangod/Cluster/Maintenance.cpp
+++ b/arangod/Cluster/Maintenance.cpp
@@ -408,9 +408,6 @@ static void handlePlanShard(
   } else {  // Create the collection, if not a previous error stops us
     if (!errors.shards.contains(dbname + "/" + colname + "/" + shname)) {
       if (replicationVersion != replication::Version::TWO || shouldBeLeading) {
-        LOG_DEVEL_IF(replicationVersion == replication::Version::TWO)
-            << "maintenance detected new shard " << dbname << "/" << colname
-            << "/" << shname;
         // Skip for replication 2 databases on followers
         auto props = createProps(cprops);  // Only once might need often!
         description = std::make_shared<ActionDescription>(

--- a/arangod/Replication2/StateMachines/Document/DocumentCore.cpp
+++ b/arangod/Replication2/StateMachines/Document/DocumentCore.cpp
@@ -45,20 +45,13 @@ DocumentCore::DocumentCore(
   auto collectionProperties =
       _agencyHandler->getCollectionPlan(_params.collectionId);
 
+  // TODO this is currently still required. once the snapshot transfer contains
+  //  a list of shards that exist for this log, we can remove this.
   _shardId = _params.shardId;
-  // auto shardResult = _shardHandler->createLocalShard(
-  //    _shardId, _params.collectionId, collectionProperties);
-  // TRI_ASSERT(shardResult.ok()) << "Shard creation failed for replicated state
-  // "
-  //                             << _gid << ": " << shardResult;
-
-  // auto commResult = _agencyHandler->reportShardInCurrent(
-  //    _params.collectionId, _shardId, collectionProperties);
-
-  // TODO see CINFRA-651
-  // TRI_ASSERT(true || commResult.ok())
-  //    << "Failed to report shard in current for replicated state " << _gid
-  //    << ": " << commResult;
+  auto shardResult = _shardHandler->createLocalShard(
+      _shardId, _params.collectionId, collectionProperties);
+  TRI_ASSERT(shardResult.ok()) << "Shard creation failed for replicated state"
+                               << _gid << ": " << shardResult;
 
   LOG_CTX("b7e0d", TRACE, this->loggerContext)
       << "Created shard " << _shardId << " for replicated state " << _gid;

--- a/arangod/Replication2/StateMachines/Document/DocumentCore.cpp
+++ b/arangod/Replication2/StateMachines/Document/DocumentCore.cpp
@@ -46,18 +46,19 @@ DocumentCore::DocumentCore(
       _agencyHandler->getCollectionPlan(_params.collectionId);
 
   _shardId = _params.shardId;
-  auto shardResult = _shardHandler->createLocalShard(
-      _shardId, _params.collectionId, collectionProperties);
-  TRI_ASSERT(shardResult.ok()) << "Shard creation failed for replicated state "
-                               << _gid << ": " << shardResult;
+  // auto shardResult = _shardHandler->createLocalShard(
+  //    _shardId, _params.collectionId, collectionProperties);
+  // TRI_ASSERT(shardResult.ok()) << "Shard creation failed for replicated state
+  // "
+  //                             << _gid << ": " << shardResult;
 
-  auto commResult = _agencyHandler->reportShardInCurrent(
-      _params.collectionId, _shardId, collectionProperties);
+  // auto commResult = _agencyHandler->reportShardInCurrent(
+  //    _params.collectionId, _shardId, collectionProperties);
 
   // TODO see CINFRA-651
-  TRI_ASSERT(true || commResult.ok())
-      << "Failed to report shard in current for replicated state " << _gid
-      << ": " << commResult;
+  // TRI_ASSERT(true || commResult.ok())
+  //    << "Failed to report shard in current for replicated state " << _gid
+  //    << ": " << commResult;
 
   LOG_CTX("b7e0d", TRACE, this->loggerContext)
       << "Created shard " << _shardId << " for replicated state " << _gid;

--- a/arangod/Replication2/StateMachines/Document/DocumentLeaderState.cpp
+++ b/arangod/Replication2/StateMachines/Document/DocumentLeaderState.cpp
@@ -28,6 +28,7 @@
 #include "Replication2/StateMachines/Document/DocumentStateMachine.h"
 #include "Replication2/StateMachines/Document/DocumentStateHandlersFactory.h"
 #include "Replication2/StateMachines/Document/DocumentStateTransactionHandler.h"
+#include "Replication2/StateMachines/Document/DocumentStateShardHandler.h"
 #include "Transaction/Manager.h"
 
 #include <Futures/Future.h>
@@ -46,6 +47,7 @@ DocumentLeaderState::DocumentLeaderState(
       _handlersFactory(std::move(handlersFactory)),
       _snapshotHandler(
           _handlersFactory->createSnapshotHandler(core->getVocbase(), gid)),
+      _shardHandler(_handlersFactory->createShardHandler(gid)),
       _guardedData(std::move(core)),
       _transactionManager(transactionManager),
       _isResigning(false) {
@@ -119,10 +121,11 @@ auto DocumentLeaderState::recoverEntries(std::unique_ptr<EntryIterator> ptr)
       }
     }
 
-    auto doc = DocumentLogEntry{"",  // this affects all shards
+    auto doc = DocumentLogEntry{{},  // this affects all shards
                                 OperationType::kAbortAllOngoingTrx,
                                 {},
-                                TransactionId{0}};
+                                TransactionId{0},
+                                {}};
     auto stream = self->getStream();
     stream->insert(doc);
 
@@ -169,8 +172,11 @@ auto DocumentLeaderState::replicateOperation(velocypack::SharedSlice payload,
   }
 
   auto const& stream = getStream();
-  auto entry = DocumentLogEntry{shard, operation, std::move(payload),
-                                transactionId.asFollowerTransactionId()};
+  auto entry = DocumentLogEntry{shard,
+                                operation,
+                                std::move(payload),
+                                transactionId.asFollowerTransactionId(),
+                                {}};
 
   // Insert and emplace must happen atomically
   auto idx = _activeTransactions.doUnderLock([&](auto& activeTransactions) {
@@ -232,6 +238,41 @@ auto DocumentLeaderState::allSnapshotsStatus() -> ResultT<AllSnapshotsStatus> {
                 "Could not get snapshot statuses of {}, state resigned.",
                 to_string(gid))};
       });
+}
+
+auto DocumentLeaderState::createShard(ShardID shard, CollectionID collectionId,
+                                      velocypack::SharedSlice properties)
+    -> futures::Future<Result> {
+  DocumentLogEntry entry;
+  entry.operation = OperationType::kCreateShard;
+  entry.shardId = shard;
+  entry.data = properties;
+  entry.collectionId = collectionId;
+
+  LOG_DEVEL << "creating shard in document leader state " << collectionId << "/"
+            << shard;
+
+  // TODO actually we have to block this log entry from release until the
+  // collection is actually created
+  auto const& stream = getStream();
+  auto idx = stream->insert(entry);
+
+  return stream->waitFor(idx).thenValue([=, self = shared_from_this()](auto&&) {
+    LOG_DEVEL << "shard creation replicated, actually create that shard "
+              << collectionId << "/" << shard;
+
+    auto guard = self->_shardHandler.getLockedGuard();
+    // TODO remove this unnecessary copy when api is better
+    auto propertiesCopy = std::make_shared<VPackBuilder>();
+    propertiesCopy->add(properties.slice());
+
+    auto result =
+        guard->get()->createLocalShard(shard, collectionId, propertiesCopy);
+    // TODO update internal shard map
+    LOG_DEVEL << "shard creation result " << collectionId << "/" << shard
+              << ": " << result;
+    return result;
+  });
 }
 
 template<class ResultType, class GetFunc, class ProcessFunc>

--- a/arangod/Replication2/StateMachines/Document/DocumentLeaderState.cpp
+++ b/arangod/Replication2/StateMachines/Document/DocumentLeaderState.cpp
@@ -249,18 +249,12 @@ auto DocumentLeaderState::createShard(ShardID shard, CollectionID collectionId,
   entry.data = properties;
   entry.collectionId = collectionId;
 
-  LOG_DEVEL << "creating shard in document leader state " << collectionId << "/"
-            << shard;
-
   // TODO actually we have to block this log entry from release until the
   // collection is actually created
   auto const& stream = getStream();
   auto idx = stream->insert(entry);
 
   return stream->waitFor(idx).thenValue([=, self = shared_from_this()](auto&&) {
-    LOG_DEVEL << "shard creation replicated, actually create that shard "
-              << collectionId << "/" << shard;
-
     auto guard = self->_shardHandler.getLockedGuard();
     // TODO remove this unnecessary copy when api is better
     auto propertiesCopy = std::make_shared<VPackBuilder>();
@@ -269,8 +263,6 @@ auto DocumentLeaderState::createShard(ShardID shard, CollectionID collectionId,
     auto result =
         guard->get()->createLocalShard(shard, collectionId, propertiesCopy);
     // TODO update internal shard map
-    LOG_DEVEL << "shard creation result " << collectionId << "/" << shard
-              << ": " << result;
     return result;
   });
 }

--- a/arangod/Replication2/StateMachines/Document/DocumentLeaderState.h
+++ b/arangod/Replication2/StateMachines/Document/DocumentLeaderState.h
@@ -57,6 +57,12 @@ struct DocumentLeaderState
                           ShardID shard, ReplicationOptions opts)
       -> futures::Future<LogIndex>;
 
+  auto createShard(ShardID shard, CollectionID collectionId,
+                   velocypack::SharedSlice properties)
+      -> futures::Future<Result>;
+  auto dropShard(ShardID shard) -> futures::Future<Result>;
+  auto modifyShard(ShardID shard) -> futures::Future<Result>;
+
   std::size_t getActiveTransactionsCount() const noexcept {
     return _activeTransactions.getLockedGuard()->size();
   }
@@ -90,6 +96,8 @@ struct DocumentLeaderState
   Guarded<std::unique_ptr<IDocumentStateSnapshotHandler>,
           basics::UnshackledMutex>
       _snapshotHandler;
+  Guarded<std::shared_ptr<IDocumentStateShardHandler>, basics::UnshackledMutex>
+      _shardHandler;
   Guarded<GuardedData, basics::UnshackledMutex> _guardedData;
   Guarded<ActiveTransactionsQueue, std::mutex> _activeTransactions;
   transaction::IManager& _transactionManager;

--- a/arangod/Replication2/StateMachines/Document/DocumentLogEntry.h
+++ b/arangod/Replication2/StateMachines/Document/DocumentLogEntry.h
@@ -75,11 +75,13 @@ struct DocumentLogEntry {
   OperationType operation;
   velocypack::SharedSlice data;
   TransactionId tid;
+  std::string collectionId;  // only set for create/drop/modifyCollection
 
   template<class Inspector>
   inline friend auto inspect(Inspector& f, DocumentLogEntry& p) {
     return f.object(p).fields(
-        f.field("shardId", p.shardId), f.field("operation", p.operation),
+        f.field("shardId", p.shardId), f.field("collectionId", p.collectionId),
+        f.field("operation", p.operation),
         f.field("data", p.data).fallback(velocypack::SharedSlice{}),
         f.field("tid", p.tid));
   }


### PR DESCRIPTION
### Scope & Purpose
The purpose of this PR is to create a shard on the leader document state via the maintenance. The shard creation is then replicated and only then the shard is actually created. Followers will create the shard if they apply the corresponding log entry.

There will be two follow up PRs. Once for deleting a shard and another one for changing the collection properties of a shard.