### PR TITLE
extract GlobalContextMethods from V8Context.h header

### DIFF
--- a/arangod/Auth/UserManager.cpp
+++ b/arangod/Auth/UserManager.cpp
@@ -30,6 +30,7 @@
 #include "Aql/QueryString.h"
 #include "Auth/Handler.h"
 #include "Basics/ReadLocker.h"
+#include "Basics/StaticStrings.h"
 #include "Basics/StringUtils.h"
 #include "Basics/VelocyPackHelper.h"
 #include "Basics/WriteLocker.h"

--- a/arangod/RestHandler/RestAdminRoutingHandler.cpp
+++ b/arangod/RestHandler/RestAdminRoutingHandler.cpp
@@ -58,7 +58,7 @@ RestStatus RestAdminRoutingHandler::execute() {
 
 void RestAdminRoutingHandler::reloadRouting() {
   if (!server().getFeature<V8DealerFeature>().addGlobalContextMethod(
-          "reloadRouting")) {
+          GlobalContextMethods::MethodType::kReloadRouting)) {
     generateError(rest::ResponseCode::SERVER_ERROR, TRI_ERROR_INTERNAL,
                   "invalid action definition");
     return;

--- a/arangod/V8Server/CMakeLists.txt
+++ b/arangod/V8Server/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_library(arango_v8server STATIC
   FoxxFeature.cpp
+  GlobalContextMethods.cpp
   V8Context.cpp
   V8DealerFeature.cpp
   v8-actions.cpp

--- a/arangod/V8Server/GlobalContextMethods.cpp
+++ b/arangod/V8Server/GlobalContextMethods.cpp
@@ -1,0 +1,48 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2023 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Dr. Frank Celler
+////////////////////////////////////////////////////////////////////////////////
+
+#include "GlobalContextMethods.h"
+
+using namespace arangodb;
+
+std::string_view GlobalContextMethods::name(
+    GlobalContextMethods::MethodType type) noexcept {
+  switch (type) {
+    case MethodType::kReloadRouting:
+      return "reloadRouting";
+    case MethodType::kReloadAql:
+      return "reloadAql";
+  }
+  return "unknown";
+}
+
+std::string_view GlobalContextMethods::code(
+    GlobalContextMethods::MethodType type) noexcept {
+  switch (type) {
+    case MethodType::kReloadRouting:
+      return "require(\"@arangodb/actions\").reloadRouting();";
+    case MethodType::kReloadAql:
+      return "try { require(\"@arangodb/aql\").reload(); } catch (err) {}";
+  }
+  return "";
+}

--- a/arangod/V8Server/GlobalContextMethods.h
+++ b/arangod/V8Server/GlobalContextMethods.h
@@ -1,0 +1,41 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2023 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Dr. Frank Celler
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include <string_view>
+
+namespace arangodb {
+class GlobalContextMethods {
+ public:
+  enum class MethodType {
+    kReloadRouting,
+    kReloadAql,
+  };
+
+  static std::string_view name(MethodType type) noexcept;
+
+  static std::string_view code(MethodType type) noexcept;
+};
+
+}  // namespace arangodb

--- a/arangod/V8Server/V8Context.h
+++ b/arangod/V8Server/V8Context.h
@@ -25,91 +25,46 @@
 
 #include "Basics/Common.h"
 
-#include <v8.h>
-
 #include "Basics/Mutex.h"
-#include "Basics/StaticStrings.h"
+#include "V8Server/GlobalContextMethods.h"
 
 #include <atomic>
+#include <string_view>
+
+#include <v8.h>
 
 namespace arangodb {
-class GlobalContextMethods {
- public:
-  enum class MethodType {
-    UNKNOWN = 0,
-    RELOAD_ROUTING,
-    RELOAD_AQL,
-  };
-
- public:
-  static MethodType type(std::string const& type) {
-    if (type == "reloadRouting") {
-      return MethodType::RELOAD_ROUTING;
-    }
-    if (type == "reloadAql") {
-      return MethodType::RELOAD_AQL;
-    }
-
-    return MethodType::UNKNOWN;
-  }
-
-  static std::string const name(MethodType type) {
-    switch (type) {
-      case MethodType::RELOAD_ROUTING:
-        return "reloadRouting";
-      case MethodType::RELOAD_AQL:
-        return "reloadAql";
-      case MethodType::UNKNOWN:
-      default:
-        return "unknown";
-    }
-  }
-
-  static std::string const& code(MethodType type) {
-    switch (type) {
-      case MethodType::RELOAD_ROUTING:
-        return CodeReloadRouting;
-      case MethodType::RELOAD_AQL:
-        return CodeReloadAql;
-      case MethodType::UNKNOWN:
-      default:
-        return StaticStrings::Empty;
-    }
-  }
-
- public:
-  static std::string const CodeReloadRouting;
-  static std::string const CodeReloadAql;
-};
-
 class V8Context {
  public:
   V8Context(size_t id, v8::Isolate* isolate);
 
-  size_t id() const { return _id; }
-  bool isDefault() const { return _id == 0; }
+  size_t id() const noexcept { return _id; }
+  bool isDefault() const noexcept { return _id == 0; }
   void assertLocked() const;
   double age() const;
   void lockAndEnter();
   void unlockAndExit();
-  uint64_t invocations() const {
+  uint64_t invocations() const noexcept {
     return _invocations.load(std::memory_order_relaxed);
   }
   double acquired() const noexcept { return _acquired; }
-  char const* description() const noexcept { return _description; }
+  std::string_view description() const noexcept { return _description; }
   bool shouldBeRemoved(double maxAge, uint64_t maxInvocations) const;
   bool hasGlobalMethodsQueued();
   void setCleaned(double stamp);
 
   // sets acquisition description (char const* must stay valid forever) and
   // acquisition timestamp
-  void setDescription(char const* description, double acquired) noexcept {
+  void setDescription(std::string_view description, double acquired) noexcept {
     _description = description;
     _acquired = acquired;
   }
   void clearDescription() noexcept { _description = "none"; }
 
- public:
+  void addGlobalContextMethod(GlobalContextMethods::MethodType type);
+  void handleGlobalContextMethods();
+  void handleCancellationCleanup();
+
   v8::Persistent<v8::Context> _context;
   v8::Isolate* const _isolate;
   double _lastGcStamp;
@@ -122,18 +77,13 @@ class V8Context {
   v8::Locker* _locker;
   /// @brief description of what the context is doing. pointer must be valid
   /// through the entire program lifetime
-  char const* _description;
+  std::string_view _description;
   /// @brief timestamp of when the context was last entered
   double _acquired;
   double const _creationStamp;
 
   Mutex _globalMethodsLock;
   std::vector<GlobalContextMethods::MethodType> _globalMethods;
-
- public:
-  bool addGlobalContextMethod(std::string const&);
-  void handleGlobalContextMethods();
-  void handleCancellationCleanup();
 };
 
 class V8ContextEntryGuard {

--- a/arangod/V8Server/V8DealerFeature.cpp
+++ b/arangod/V8Server/V8DealerFeature.cpp
@@ -36,6 +36,7 @@
 #include "Basics/ConditionLocker.h"
 #include "Basics/FileUtils.h"
 #include "Basics/ScopeGuard.h"
+#include "Basics/StaticStrings.h"
 #include "Basics/StringUtils.h"
 #include "Basics/Thread.h"
 #include "Basics/application-exit.h"
@@ -81,6 +82,7 @@
 #ifdef USE_ENTERPRISE
 #include "Enterprise/Encryption/EncryptionFeature.h"
 #endif
+
 using namespace arangodb;
 using namespace arangodb::application_features;
 using namespace arangodb::basics;
@@ -795,16 +797,15 @@ void V8DealerFeature::unprepare() {
   _gcThread.reset();
 }
 
-bool V8DealerFeature::addGlobalContextMethod(std::string const& method) {
+bool V8DealerFeature::addGlobalContextMethod(
+    GlobalContextMethods::MethodType type) {
   bool result = true;
 
   CONDITION_LOCKER(guard, _contextCondition);
 
   for (auto& context : _contexts) {
     try {
-      if (!context->addGlobalContextMethod(method)) {
-        result = false;
-      }
+      context->addGlobalContextMethod(type);
     } catch (...) {
       result = false;
     }

--- a/arangod/V8Server/V8DealerFeature.h
+++ b/arangod/V8Server/V8DealerFeature.h
@@ -24,7 +24,10 @@
 #pragma once
 
 #include <atomic>
+#include <string>
+#include <string_view>
 #include <unordered_set>
+#include <vector>
 
 #include "ApplicationFeatures/CommunicationFeaturePhase.h"
 #include "Basics/ConditionVariable.h"
@@ -32,6 +35,7 @@
 #include "RestServer/arangod.h"
 #include "Utils/DatabaseGuard.h"
 #include "V8/JSLoader.h"
+#include "V8Server/GlobalContextMethods.h"
 
 #include <velocypack/Builder.h>
 #include <velocypack/Slice.h>
@@ -110,7 +114,7 @@ class V8DealerFeature final : public ArangodFeature {
   bool allowJavaScriptUdfs() const noexcept { return _allowJavaScriptUdfs; }
   bool allowJavaScriptTasks() const noexcept { return _allowJavaScriptTasks; }
 
-  bool addGlobalContextMethod(std::string const&);
+  bool addGlobalContextMethod(GlobalContextMethods::MethodType type);
   void collectGarbage();
 
   /// @brief loads a JavaScript file in all contexts, only called at startup.
@@ -132,9 +136,9 @@ class V8DealerFeature final : public ArangodFeature {
     }
   }
 
-  uint64_t maximumContexts() const { return _nrMaxContexts; }
+  uint64_t maximumContexts() const noexcept { return _nrMaxContexts; }
 
-  void setMaximumContexts(size_t nr) { _nrMaxContexts = nr; }
+  void setMaximumContexts(size_t nr) noexcept { _nrMaxContexts = nr; }
 
   Statistics getCurrentContextNumbers();
   std::vector<DetailedContextStatistics> getCurrentContextDetails();

--- a/arangod/V8Server/v8-actions.cpp
+++ b/arangod/V8Server/v8-actions.cpp
@@ -55,6 +55,7 @@
 #include "V8/v8-utils.h"
 #include "V8/v8-vpack.h"
 #include "V8Server/FoxxFeature.h"
+#include "V8Server/GlobalContextMethods.h"
 #include "V8Server/V8Context.h"
 #include "V8Server/V8DealerFeature.h"
 #include "V8Server/v8-vocbase.h"
@@ -1266,36 +1267,18 @@ static void JS_DefineAction(v8::FunctionCallbackInfo<v8::Value> const& args) {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// @brief eventually executes a function in all contexts
-///
-/// @FUN{internal.executeGlobalContextFunction(@FA{function-definition})}
+/// @brief reload routing defintions in all contexts
 ////////////////////////////////////////////////////////////////////////////////
 
-static void JS_ExecuteGlobalContextFunction(
-    v8::FunctionCallbackInfo<v8::Value> const& args) {
+static void JS_ReloadRouting(v8::FunctionCallbackInfo<v8::Value> const& args) {
   TRI_V8_TRY_CATCH_BEGIN(isolate);
   v8::HandleScope scope(isolate);
 
-  if (args.Length() != 1) {
-    TRI_V8_THROW_EXCEPTION_USAGE(
-        "executeGlobalContextFunction(<function-type>)");
-  }
-
-  // extract the action name
-  v8::String::Utf8Value utf8def(isolate, args[0]);
-
-  if (*utf8def == nullptr) {
-    TRI_V8_THROW_TYPE_ERROR("<definition> must be a UTF-8 function definition");
-  }
-
-  std::string const def = std::string(*utf8def, utf8def.length());
-
   TRI_GET_SERVER_GLOBALS(ArangodServer);
-  // and pass it to the V8 contexts
   if (!v8g->server().getFeature<V8DealerFeature>().addGlobalContextMethod(
-          def)) {
+          GlobalContextMethods::MethodType::kReloadRouting)) {
     TRI_V8_THROW_EXCEPTION_MESSAGE(TRI_ERROR_INTERNAL,
-                                   "invalid action definition");
+                                   "unable to reload routing");
   }
 
   TRI_V8_RETURN_UNDEFINED();
@@ -1603,9 +1586,8 @@ void TRI_InitV8Actions(v8::Isolate* isolate) {
       isolate, TRI_V8_ASCII_STRING(isolate, "SYS_DEFINE_ACTION"),
       JS_DefineAction);
   TRI_AddGlobalFunctionVocbase(
-      isolate,
-      TRI_V8_ASCII_STRING(isolate, "SYS_EXECUTE_GLOBAL_CONTEXT_FUNCTION"),
-      JS_ExecuteGlobalContextFunction, true);
+      isolate, TRI_V8_ASCII_STRING(isolate, "SYS_RELOAD_ROUTING"),
+      JS_ReloadRouting, true);
   TRI_AddGlobalFunctionVocbase(
       isolate, TRI_V8_ASCII_STRING(isolate, "SYS_GET_CURRENT_REQUEST"),
       JS_GetCurrentRequest);

--- a/arangod/VocBase/Methods/AqlUserFunctions.cpp
+++ b/arangod/VocBase/Methods/AqlUserFunctions.cpp
@@ -40,6 +40,7 @@
 #include "V8/JavaScriptSecurityContext.h"
 #include "V8/v8-globals.h"
 #include "V8/v8-utils.h"
+#include "V8Server/V8Context.h"
 #include "V8Server/V8DealerFeature.h"
 
 #include <v8.h>
@@ -71,8 +72,8 @@ void reloadAqlUserFunctions(ArangodServer& server) {
   if (server.hasFeature<V8DealerFeature>() &&
       server.isEnabled<V8DealerFeature>() &&
       server.getFeature<V8DealerFeature>().isEnabled()) {
-    std::string const def("reloadAql");
-    server.getFeature<V8DealerFeature>().addGlobalContextMethod(def);
+    server.getFeature<V8DealerFeature>().addGlobalContextMethod(
+        GlobalContextMethods::MethodType::kReloadAql);
   }
 }
 

--- a/arangod/VocBase/Methods/AqlUserFunctions.h
+++ b/arangod/VocBase/Methods/AqlUserFunctions.h
@@ -25,12 +25,12 @@
 
 #include "Basics/Result.h"
 
+#include <string>
+
 struct TRI_vocbase_t;
 
 namespace arangodb {
-
 namespace velocypack {
-
 class Builder;
 class Slice;
 

--- a/arangod/VocBase/Methods/Databases.h
+++ b/arangod/VocBase/Methods/Databases.h
@@ -45,23 +45,20 @@ struct Databases {
 
   static std::vector<std::string> list(ArangodServer& server,
                                        std::string const& user = "");
-  static arangodb::Result info(TRI_vocbase_t* vocbase, VPackBuilder& result);
-  static arangodb::Result create(ArangodServer& server,
-                                 ExecContext const& context,
-                                 std::string const& dbName,
-                                 VPackSlice const& users,
-                                 VPackSlice const& options);
-  static arangodb::Result drop(ExecContext const& context,
-                               TRI_vocbase_t* systemVocbase,
-                               std::string const& dbName);
+  static Result info(TRI_vocbase_t* vocbase, VPackBuilder& result);
+  static Result create(ArangodServer& server, ExecContext const& context,
+                       std::string const& dbName, VPackSlice const& users,
+                       VPackSlice const& options);
+  static Result drop(ExecContext const& context, TRI_vocbase_t* systemVocbase,
+                     std::string const& dbName);
 
  private:
   /// @brief will retry for at most <timeout> seconds
-  static arangodb::Result grantCurrentUser(CreateDatabaseInfo const& info,
-                                           int64_t timeout);
+  static Result grantCurrentUser(CreateDatabaseInfo const& info,
+                                 int64_t timeout);
 
-  static arangodb::Result createCoordinator(CreateDatabaseInfo const& info);
-  static arangodb::Result createOther(CreateDatabaseInfo const& info);
+  static Result createCoordinator(CreateDatabaseInfo const& info);
+  static Result createOther(CreateDatabaseInfo const& info);
 };
 }  // namespace methods
 }  // namespace arangodb

--- a/js/server/modules/@arangodb/foxx/manager.js
+++ b/js/server/modules/@arangodb/foxx/manager.js
@@ -387,7 +387,7 @@ function commitLocalState (replace) {
 // Change propagation
 
 function reloadRouting () {
-  global.SYS_EXECUTE_GLOBAL_CONTEXT_FUNCTION('reloadRouting');
+  global.SYS_RELOAD_ROUTING();
   actions.reloadRouting();
 }
 

--- a/lib/V8/JavaScriptSecurityContext.cpp
+++ b/lib/V8/JavaScriptSecurityContext.cpp
@@ -26,7 +26,7 @@
 using namespace arangodb;
 
 /// @brief return the context type as a string
-char const* JavaScriptSecurityContext::typeName() const {
+std::string_view JavaScriptSecurityContext::typeName() const noexcept {
   switch (_type) {
     case Type::Restricted:
       return "restricted";
@@ -39,70 +39,71 @@ char const* JavaScriptSecurityContext::typeName() const {
     case Type::Task:
       return "task";
     case Type::RestAction:
-      return "rest action";
+      return "REST action";
     case Type::RestAdminScriptAction:
-      return "rest admin script action";
+      return "REST admin script action";
   }
   // should not happen
   return "unknown";
 }
 
-void JavaScriptSecurityContext::reset() { _canUseDatabase = false; }
+void JavaScriptSecurityContext::reset() noexcept { _canUseDatabase = false; }
 
-bool JavaScriptSecurityContext::canDefineHttpAction() const {
+bool JavaScriptSecurityContext::canDefineHttpAction() const noexcept {
   return _type == Type::Internal;
 }
 
-bool JavaScriptSecurityContext::canReadFs() const {
+bool JavaScriptSecurityContext::canReadFs() const noexcept {
   return _type == Type::Internal;
 }
 
-bool JavaScriptSecurityContext::canWriteFs() const {
+bool JavaScriptSecurityContext::canWriteFs() const noexcept {
   return _type == Type::Internal;
 }
 
-bool JavaScriptSecurityContext::canControlProcesses() const {
+bool JavaScriptSecurityContext::canControlProcesses() const noexcept {
   return _type == Type::Internal || _type == Type::AdminScript ||
          _type == Type::RestAdminScriptAction;
 }
 
 /*static*/ JavaScriptSecurityContext
-JavaScriptSecurityContext::createRestrictedContext() {
+JavaScriptSecurityContext::createRestrictedContext() noexcept {
   JavaScriptSecurityContext context(Type::Restricted);
   context._canUseDatabase = false;
   return context;
 }
 
 /*static*/ JavaScriptSecurityContext
-JavaScriptSecurityContext::createInternalContext() {
+JavaScriptSecurityContext::createInternalContext() noexcept {
   JavaScriptSecurityContext context(Type::Internal);
   context._canUseDatabase = true;
   return context;
 }
 
 /*static*/ JavaScriptSecurityContext
-JavaScriptSecurityContext::createAdminScriptContext() {
+JavaScriptSecurityContext::createAdminScriptContext() noexcept {
   JavaScriptSecurityContext context(Type::AdminScript);
   context._canUseDatabase = true;
   return context;
 }
 
 /*static*/ JavaScriptSecurityContext
-JavaScriptSecurityContext::createQueryContext() {
+JavaScriptSecurityContext::createQueryContext() noexcept {
   JavaScriptSecurityContext context(Type::Query);
   context._canUseDatabase = false;
   return context;
 }
 
 /*static*/ JavaScriptSecurityContext
-JavaScriptSecurityContext::createTaskContext(bool allowUseDatabase) {
+JavaScriptSecurityContext::createTaskContext(bool allowUseDatabase) noexcept {
   JavaScriptSecurityContext context(Type::Task);
   context._canUseDatabase = allowUseDatabase;
   return context;
 }
 
 /*static*/ JavaScriptSecurityContext
-JavaScriptSecurityContext::createRestActionContext(bool allowUseDatabase) {
+JavaScriptSecurityContext::createRestActionContext(
+    bool allowUseDatabase) noexcept {
   JavaScriptSecurityContext context(Type::RestAction);
   context._canUseDatabase = allowUseDatabase;
   return context;
@@ -110,7 +111,7 @@ JavaScriptSecurityContext::createRestActionContext(bool allowUseDatabase) {
 
 /*static*/ JavaScriptSecurityContext
 JavaScriptSecurityContext::createRestAdminScriptActionContext(
-    bool allowUseDatabase) {
+    bool allowUseDatabase) noexcept {
   JavaScriptSecurityContext context(Type::RestAdminScriptAction);
   context._canUseDatabase = allowUseDatabase;
   return context;

--- a/lib/V8/JavaScriptSecurityContext.h
+++ b/lib/V8/JavaScriptSecurityContext.h
@@ -23,7 +23,7 @@
 
 #pragma once
 
-#include "Basics/Common.h"
+#include <string_view>
 
 namespace arangodb {
 
@@ -39,71 +39,72 @@ class JavaScriptSecurityContext {
     RestAdminScriptAction
   };
 
-  explicit JavaScriptSecurityContext(Type type) : _type(type) {}
+  explicit JavaScriptSecurityContext(Type type) noexcept : _type(type) {}
 
   ~JavaScriptSecurityContext() = default;
 
   /// @brief return the context type as a string
-  char const* typeName() const;
+  std::string_view typeName() const noexcept;
 
   /// @brief resets context to most restrictive settings
-  void reset();
+  void reset() noexcept;
 
   /// @brief whether or not the context is an internal context
-  bool isInternal() const { return _type == Type::Internal; }
+  bool isInternal() const noexcept { return _type == Type::Internal; }
 
   /// @brief whether or not the context is an admin script
-  bool isAdminScript() const { return _type == Type::AdminScript; }
+  bool isAdminScript() const noexcept { return _type == Type::AdminScript; }
 
   /// @brief whether or not the context is an admin script
-  bool isRestAdminScript() const {
+  bool isRestAdminScript() const noexcept {
     return _type == Type::RestAdminScriptAction;
   }
 
   /// @brief whether or not db._useDatabase(...) is allowed
-  bool canUseDatabase() const { return _canUseDatabase; }
+  bool canUseDatabase() const noexcept { return _canUseDatabase; }
 
   /// @brief whether fs read is allowed
-  bool canReadFs() const;
+  bool canReadFs() const noexcept;
 
   /// @brief whether fs read is allowed
-  bool canWriteFs() const;
+  bool canWriteFs() const noexcept;
 
   /// @brief whether or not actions.defineAction(...) is allowed, which will
   /// add REST endpoints
   /// currently only internal operations are allowed to do this
-  bool canDefineHttpAction() const;
+  bool canDefineHttpAction() const noexcept;
 
   /// @brief whether or not execution or state-modification of external
   /// binaries is allowed.
-  bool canControlProcesses() const;
+  bool canControlProcesses() const noexcept;
 
   /// @brief create a security context that is most restricted
-  static JavaScriptSecurityContext createRestrictedContext();
+  static JavaScriptSecurityContext createRestrictedContext() noexcept;
 
   /// @brief create a security context for arangodb-internal
   /// operations, with non-restrictive settings
-  static JavaScriptSecurityContext createInternalContext();
+  static JavaScriptSecurityContext createInternalContext() noexcept;
 
   /// @brief create a security context for admin script operations,
   /// invoked by `--javascript.execute` or when running in --console mode
-  static JavaScriptSecurityContext createAdminScriptContext();
+  static JavaScriptSecurityContext createAdminScriptContext() noexcept;
 
   /// @brief create a security context for AQL queries,
   /// with restrictive settings
-  static JavaScriptSecurityContext createQueryContext();
+  static JavaScriptSecurityContext createQueryContext() noexcept;
 
   /// @brief create a security context for tasks actions
-  static JavaScriptSecurityContext createTaskContext(bool allowUseDatabase);
+  static JavaScriptSecurityContext createTaskContext(
+      bool allowUseDatabase) noexcept;
 
   /// @brief create a security context for REST actions
   static JavaScriptSecurityContext createRestActionContext(
-      bool allowUseDatabase);
+      bool allowUseDatabase) noexcept;
 
   /// @brief create a security context for admin script operations running
   /// via POST /_admin/execute
   static JavaScriptSecurityContext createRestAdminScriptActionContext(
-      bool allowUseDatabase);
+      bool allowUseDatabase) noexcept;
 
  private:
   Type _type;


### PR DESCRIPTION
### Scope & Purpose

extract GlobalContextMethods from V8Context.h header and move it to a file of its own.
also simplify the implementation and do not allow using arbitrary GlobalContextMethods, but just the defined ones.
additionally add a few `noexcept` declarations and move a few functions from .h to .cpp files.
finally, move away from `char const*` and `std::string` in a few places and replace with `std::string_view`.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: -
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 