### PR TITLE
Enable some cluster tests

### DIFF
--- a/tests/js/client/shell/multi/shell-inventory-cluster.js
+++ b/tests/js/client/shell/multi/shell-inventory-cluster.js
@@ -1,5 +1,5 @@
 /*jshint globalstrict:false, strict:false, maxlen : 4000 */
-/* global arango, assertTrue, assertFalse, assertEqual, assertNotEqual */
+/* global arango, assertTrue, assertFalse, assertEqual, assertNotEqual, _ */
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief tests for inventory
@@ -221,23 +221,45 @@ function clusterInventorySuite () {
       db._createView("UnitTestsDumpViewEmpty", "arangosearch", {});
 
       let view = db._createView("UnitTestsDumpView", "arangosearch", {});
-      view.properties({
-        cleanupIntervalStep: 456,
-        consolidationPolicy: {
-          threshold: 0.3,
-          type: "bytes_accum"
-        },
-        commitIntervalMsec: 12345,
-        consolidationIntervalMsec: 0,
-        links: {
-          "UnitTestsDumpEmpty" : {
-            includeAllFields: true,
-            fields: {
-              text: { analyzers: [ "text_en", analyzer.name ], "fields": { "value": { "nested": { "nested_1": {"nested": {"nested_2": {}}}}}} }
+      let viewMeta = {};
+      if (isEnterprise) {
+        viewMeta = {
+          cleanupIntervalStep: 456,
+          consolidationPolicy: {
+            threshold: 0.3,
+            type: "bytes_accum"
+          },
+          commitIntervalMsec: 12345,
+          consolidationIntervalMsec: 0,
+          links: {
+            "UnitTestsDumpEmpty" : {
+              includeAllFields: true,
+              fields: {
+                text: { analyzers: [ "text_en", analyzer.name ], "fields": { "value": { "nested": { "nested_1": {"nested": {"nested_2": {}}}}}} }
+              }
             }
           }
-        }
-      });
+        };
+      } else {
+        viewMeta = {
+          cleanupIntervalStep: 456,
+          consolidationPolicy: {
+            threshold: 0.3,
+            type: "bytes_accum"
+          },
+          commitIntervalMsec: 12345,
+          consolidationIntervalMsec: 0,
+          links: {
+            "UnitTestsDumpEmpty" : {
+              includeAllFields: true,
+              fields: {
+                text: { analyzers: [ "text_en", analyzer.name ], "fields": { "value": {}}}
+              }
+            }
+          }
+        };
+      }
+      view.properties(viewMeta);
       
       c = db._create("UnitTestsDumpSearchAliasCollection");
       let idx = c.ensureIndex({ type: "inverted", fields: [{ name: "value", analyzer: analyzer.name }] });
@@ -384,10 +406,18 @@ function clusterInventorySuite () {
       assertEqual(1, Object.keys(link.fields).length);
       assertEqual("text", Object.keys(link.fields)[0]);
       let field = link.fields["text"];
-      assertEqual(1, Object.keys(field).length);
+      assertEqual(2, Object.keys(field).length);
       assertEqual("analyzers", Object.keys(field)[0]);
       assertTrue(Array.isArray(field.analyzers));
       assertEqual(["custom", "text_en"], field.analyzers.sort());
+
+      assertEqual("fields", Object.keys(field)[1]);
+      assertTrue(typeof field.fields === 'object');
+      if (isEnterprise) {
+        assertTrue(_.isEqual(field.fields.value.nested.nested_1.nested.nested_2, {}));
+      } else {
+        assertTrue(_.isEqual(field.fields.value, {}));
+      }
 
       assertTrue(Array.isArray(link.analyzerDefinitions));
       assertEqual(3, link.analyzerDefinitions.length);

--- a/tests/test-definitions.txt
+++ b/tests/test-definitions.txt
@@ -92,6 +92,10 @@ resilience_sharddist cluster -- --dumpAgencyOnError true
 
 recovery_cluster priority=2000 cluster buckets=8
 
+#shell_client_multi priority=1500 cluster suffix=http2 -- --http2 true
+shell_client_multi priority=1500 cluster suffix=http
+#shell_client_multi priority=2500 cluster suffix=vst -- --vst true
+
 # different number of buckets in cluster
 shell_server_aql priority=1000 cluster buckets=16 -- --dumpAgencyOnError true
 shell_client priority=500 cluster buckets=5 -- --dumpAgencyOnError true

--- a/tests/test-definitions.txt
+++ b/tests/test-definitions.txt
@@ -92,9 +92,9 @@ resilience_sharddist cluster -- --dumpAgencyOnError true
 
 recovery_cluster priority=2000 cluster buckets=8
 
-#shell_client_multi priority=1500 cluster suffix=http2 -- --http2 true
+shell_client_multi priority=1500 cluster suffix=http2 -- --http2 true
 shell_client_multi priority=1500 cluster suffix=http
-#shell_client_multi priority=2500 cluster suffix=vst -- --vst true
+shell_client_multi priority=2500 cluster suffix=vst -- --vst true
 
 # different number of buckets in cluster
 shell_server_aql priority=1000 cluster buckets=16 -- --dumpAgencyOnError true


### PR DESCRIPTION
### Scope & Purpose

Some tests for cluster are not being executed since https://github.com/arangodb/arangodb/pull/17724.
This PR enable them.

But there is an open question: should we enable http2 and vst for testing them?

- [X] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [X] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [X] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: *(Please link PR)*
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

