### PR TITLE
increase timeout even more, add missing forced shutdown if we still fail

### DIFF
--- a/js/client/modules/@arangodb/testsuites/endpoints.js
+++ b/js/client/modules/@arangodb/testsuites/endpoints.js
@@ -333,8 +333,10 @@ class endpointRunner extends tu.runInArangoshRunner {
       let message = "";
       try {
         obj.instance.shutDownOneInstance({nonAgenciesCount: 1}, false, 30);
-        obj.instance.waitForInstanceShutdown(20);
+        obj.instance.waitForInstanceShutdown(30);
       } catch (ex) {
+        print(`${RED}${Date()} Server did not shut down on time: ${ex.message}${RESET}`);
+        obj.instance.shutdownArangod(true);
         shutdown = false;
         message = ex.message;
       }

--- a/js/client/modules/@arangodb/testsuites/endpoints.js
+++ b/js/client/modules/@arangodb/testsuites/endpoints.js
@@ -279,7 +279,7 @@ class endpointRunner extends tu.runInArangoshRunner {
       }
       sleep(2);
       try {
-        obj.instance.checkArangoConnection(20);
+        obj.instance.checkArangoConnection(30);
       } catch (ex) {
         print(RED + Date() + ' Server did not become available on time' + RESET);
         obj.instance.shutdownArangod(true);


### PR DESCRIPTION
### Scope & Purpose

ARM seems to need even more than 20s to shutdown arangod.
- increase timeout to 30s
- if we still fail, force shutdown so we see where its hanging about.

- [x] :hankey: Bugfix
