### PR TITLE
we must not remove the temporary directory itself for subsequently ran testuite

### DIFF
--- a/js/client/modules/@arangodb/testsuites/server_permissions.js
+++ b/js/client/modules/@arangodb/testsuites/server_permissions.js
@@ -254,7 +254,9 @@ class permissionsRunner extends tu.runLocalInArangoshRunner {
       }
     }
     if (this.results.status && this.options.cleanup) {
-      fs.removeDirectoryRecursive(tmpDir, true);
+      fs.list(tmpDir).forEach(file => {
+        fs.removeDirectoryRecursive(fs.join(tmpDir, file), true);
+      });
     }
     return this.results;
   }


### PR DESCRIPTION
### Scope & Purpose

in https://github.com/arangodb/arangodb/pull/18079 we introduced proper cleanup of files. 
however, if testing.js launches two testsuites, we must not remove the directory by itself, just its subdirectories, 
else the second suite will fail to launch tests.

- [x] :hankey: Bugfix
