### PR TITLE
[CINFRA-679] Document State Tracks Multiple Shards

### DIFF
--- a/arangod/Cluster/CreateCollection.cpp
+++ b/arangod/Cluster/CreateCollection.cpp
@@ -273,7 +273,8 @@ bool CreateCollection::createReplication2Shard(CollectionID const& collection,
         replication2::replicated_state::document::DocumentLeaderState>(
         state.get()->getLeader());
     if (leaderState != nullptr) {
-      // TODO we are blocking the maintenance here, but we should not
+      // It is necessary to block here to prevent creation of an additional
+      // action while we are waiting for the shard to be created.
       leaderState
           ->createShard(
               shard, collection,

--- a/arangod/Cluster/CreateCollection.cpp
+++ b/arangod/Cluster/CreateCollection.cpp
@@ -273,9 +273,12 @@ bool CreateCollection::createReplication2Shard(CollectionID const& collection,
         replication2::replicated_state::document::DocumentLeaderState>(
         state.get()->getLeader());
     if (leaderState != nullptr) {
-      leaderState->createShard(
-          shard, collection,
-          velocypack::SharedSlice(_description.properties()->bufferRef()));
+      // TODO we are blocking the maintenance here, but we should not
+      leaderState
+          ->createShard(
+              shard, collection,
+              velocypack::SharedSlice(_description.properties()->bufferRef()))
+          .get();
     }
   }
 

--- a/arangod/Cluster/Maintenance.cpp
+++ b/arangod/Cluster/Maintenance.cpp
@@ -421,8 +421,7 @@ static void handlePlanShard(
                                           // action as well. Used to distinguish
                                           // between callers.
                 {THE_LEADER, CreateLeaderString(leaderId, shouldBeLeading)}},
-            shouldBeLeading ? LEADER_PRIORITY : FOLLOWER_PRIORITY, true,
-            std::move(props));
+            SLOW_OP_PRIORITY, true, std::move(props));
         makeDirty.insert(dbname);
         callNotify = true;
         actions.emplace_back(std::move(description));

--- a/arangod/Replication2/ReplicatedLog/LogCommon.h
+++ b/arangod/Replication2/ReplicatedLog/LogCommon.h
@@ -54,6 +54,7 @@
 #include <velocypack/Slice.h>
 #include <velocypack/Value.h>
 
+#include "Inspection/Format.h"
 #include "Inspection/Status.h"
 #include "Inspection/Types.h"
 #include "Basics/ErrorCode.h"
@@ -589,6 +590,10 @@ struct velocypack::Extractor<replication2::LogId> {
 template<>
 struct fmt::formatter<arangodb::replication2::LogId>
     : fmt::formatter<arangodb::basics::Identifier> {};
+
+template<>
+struct fmt::formatter<arangodb::replication2::GlobalLogIdentifier>
+    : arangodb::inspection::inspection_formatter {};
 
 template<>
 struct std::hash<arangodb::replication2::LogIndex> {

--- a/arangod/Replication2/StateMachines/Document/DocumentCore.cpp
+++ b/arangod/Replication2/StateMachines/Document/DocumentCore.cpp
@@ -53,7 +53,12 @@ DocumentCore::DocumentCore(
   TRI_ASSERT(shardResult.ok()) << "Shard creation failed for replicated state"
                                << _gid << ": " << shardResult;
 
-  _shards.emplace(shardId, std::move(collectionProperties));
+  auto shardProperties = ShardProperties{
+      .shardId = shardId,
+      .collectionId = _params.collectionId,
+      .properties = std::move(collectionProperties),
+  };
+  _shards.emplace(shardId, std::move(shardProperties));
   LOG_CTX("b7e0d", TRACE, this->loggerContext)
       << "Created shard " << shardId << " for replicated state " << _gid;
 }
@@ -64,19 +69,11 @@ auto DocumentCore::getShardId() -> ShardID const& {
 
 auto DocumentCore::getGid() -> GlobalLogIdentifier { return _gid; }
 
-auto DocumentCore::getCollectionId() -> std::string const& {
-  return _params.collectionId;
-}
-
 void DocumentCore::drop() {
-  for (auto const& [shardId, _] : _shards) {
-    auto result = _shardHandler->dropLocalShard(shardId, _params.collectionId);
-    if (result.fail()) {
-      LOG_CTX("b7f0d", FATAL, this->loggerContext)
-          << "Failed to drop shard " << shardId << " for replicated state "
-          << _gid << ": " << result;
-      FATAL_ERROR_EXIT();
-    }
+  if (auto result = dropAllShards(); result.fail()) {
+    LOG_CTX("b7f0d", FATAL, this->loggerContext)
+        << "Failed to drop all shards for replicated state: " << result;
+    FATAL_ERROR_EXIT();
   }
 }
 
@@ -86,8 +83,8 @@ auto DocumentCore::getVocbase() const -> TRI_vocbase_t const& {
   return _vocbase;
 }
 
-auto DocumentCore::addShard(ShardID shardId, CollectionID collectionId,
-                            velocypack::SharedSlice properties) -> Result {
+auto DocumentCore::createShard(ShardID shardId, CollectionID collectionId,
+                               velocypack::SharedSlice properties) -> Result {
   // TODO remove this unnecessary copy when api is better
   auto propertiesCopy = std::make_shared<VPackBuilder>();
   propertiesCopy->add(properties.slice());
@@ -95,7 +92,55 @@ auto DocumentCore::addShard(ShardID shardId, CollectionID collectionId,
   auto result =
       _shardHandler->createLocalShard(shardId, collectionId, propertiesCopy);
   if (result.ok()) {
-    _shards.emplace(std::move(shardId), std::move(propertiesCopy));
+    auto shardProperties =
+        ShardProperties{shardId, collectionId, propertiesCopy};
+    _shards.emplace(std::move(shardId), std::move(shardProperties));
   }
   return result;
+}
+
+auto DocumentCore::dropShard(ShardID shardId, CollectionID collectionId)
+    -> Result {
+  if (!_shards.contains(shardId)) {
+    LOG_CTX("d335b", DEBUG, loggerContext) << fmt::format(
+        "Skipping dropping of shard {}, because it is already dropped.",
+        shardId);
+    return {};
+  }
+  auto result = _shardHandler->dropLocalShard(shardId, collectionId);
+  if (result.ok()) {
+    _shards.erase(shardId);
+  }
+  return result;
+}
+
+auto DocumentCore::dropAllShards() -> Result {
+  for (auto const& [shardId, shardProperties] : _shards) {
+    auto result =
+        _shardHandler->dropLocalShard(shardId, shardProperties.collectionId);
+    if (result.fail()) {
+      return Result{result.errorNumber(),
+                    fmt::format("Failed to drop shard {}: {}", shardId,
+                                result.errorMessage())};
+    }
+    _shards.erase(shardId);
+  }
+  _shards.clear();
+  return {};
+}
+
+auto DocumentCore::ensureShard(ShardID shardId, CollectionID collectionId,
+                               velocypack::SharedSlice properties) -> Result {
+  if (_shards.contains(shardId)) {
+    LOG_CTX("69bf5", DEBUG, loggerContext) << fmt::format(
+        "Skipping creation of shard {}, because it is already created.",
+        shardId);
+    return {};
+  }
+  return createShard(std::move(shardId), std::move(collectionId),
+                     std::move(properties));
+}
+
+auto DocumentCore::isShardAvailable(ShardID const& shardId) -> bool {
+  return _shards.contains(shardId);
 }

--- a/arangod/Replication2/StateMachines/Document/DocumentCore.cpp
+++ b/arangod/Replication2/StateMachines/Document/DocumentCore.cpp
@@ -62,10 +62,6 @@ DocumentCore::DocumentCore(
       << "Created shard " << shardId << " for replicated state " << _gid;
 }
 
-auto DocumentCore::getShardId() -> ShardID const& {
-  return _shards.begin()->first;
-}
-
 auto DocumentCore::getGid() -> GlobalLogIdentifier { return _gid; }
 
 void DocumentCore::drop() {
@@ -141,3 +137,5 @@ auto DocumentCore::ensureShard(ShardID shardId, CollectionID collectionId,
 auto DocumentCore::isShardAvailable(ShardID const& shardId) -> bool {
   return _shards.contains(shardId);
 }
+
+auto DocumentCore::getShardMap() -> ShardMap const& { return _shards; }

--- a/arangod/Replication2/StateMachines/Document/DocumentCore.h
+++ b/arangod/Replication2/StateMachines/Document/DocumentCore.h
@@ -38,6 +38,8 @@ struct IDocumentStateAgencyHandler;
 struct IDocumentStateShardHandler;
 
 struct DocumentCore {
+  using ShardMap = std::unordered_map<ShardID, ShardProperties>;
+
   explicit DocumentCore(
       TRI_vocbase_t& vocbase, GlobalLogIdentifier gid,
       DocumentCoreParameters coreParameters,
@@ -48,7 +50,6 @@ struct DocumentCore {
 
   auto getVocbase() -> TRI_vocbase_t&;
   auto getVocbase() const -> TRI_vocbase_t const&;
-  auto getShardId() -> ShardID const&;
   auto getGid() -> GlobalLogIdentifier;
   auto createShard(ShardID shardId, CollectionID collectionId,
                    velocypack::SharedSlice properties) -> Result;
@@ -58,12 +59,13 @@ struct DocumentCore {
                    velocypack::SharedSlice properties) -> Result;
   auto isShardAvailable(ShardID const& shardId) -> bool;
   void drop();
+  auto getShardMap() -> ShardMap const&;
 
  private:
   TRI_vocbase_t& _vocbase;
   GlobalLogIdentifier _gid;
   DocumentCoreParameters _params;
-  std::unordered_map<ShardID, ShardProperties> _shards;
+  ShardMap _shards;
   std::shared_ptr<IDocumentStateAgencyHandler> _agencyHandler;
   std::shared_ptr<IDocumentStateShardHandler> _shardHandler;
 };

--- a/arangod/Replication2/StateMachines/Document/DocumentCore.h
+++ b/arangod/Replication2/StateMachines/Document/DocumentCore.h
@@ -50,6 +50,8 @@ struct DocumentCore {
   auto getShardId() -> ShardID const&;
   auto getGid() -> GlobalLogIdentifier;
   auto getCollectionId() -> std::string const&;
+  auto addShard(ShardID shardId, CollectionID collectionId,
+                velocypack::SharedSlice properties) -> Result;
 
   void drop();
 
@@ -57,7 +59,7 @@ struct DocumentCore {
   TRI_vocbase_t& _vocbase;
   GlobalLogIdentifier _gid;
   DocumentCoreParameters _params;
-  ShardID _shardId;
+  std::unordered_map<ShardID, std::shared_ptr<velocypack::Builder>> _shards;
   std::shared_ptr<IDocumentStateAgencyHandler> _agencyHandler;
   std::shared_ptr<IDocumentStateShardHandler> _shardHandler;
 };

--- a/arangod/Replication2/StateMachines/Document/DocumentCore.h
+++ b/arangod/Replication2/StateMachines/Document/DocumentCore.h
@@ -25,6 +25,7 @@
 
 #include "Replication2/StateMachines/Document/DocumentLogEntry.h"
 #include "Replication2/StateMachines/Document/DocumentStateMachine.h"
+#include "Replication2/StateMachines/Document/ShardProperties.h"
 
 #include "Replication2/LoggerContext.h"
 #include "Replication2/ReplicatedLog/LogCommon.h"
@@ -49,17 +50,20 @@ struct DocumentCore {
   auto getVocbase() const -> TRI_vocbase_t const&;
   auto getShardId() -> ShardID const&;
   auto getGid() -> GlobalLogIdentifier;
-  auto getCollectionId() -> std::string const&;
-  auto addShard(ShardID shardId, CollectionID collectionId,
-                velocypack::SharedSlice properties) -> Result;
-
+  auto createShard(ShardID shardId, CollectionID collectionId,
+                   velocypack::SharedSlice properties) -> Result;
+  auto dropShard(ShardID shardId, CollectionID collectionId) -> Result;
+  auto dropAllShards() -> Result;
+  auto ensureShard(ShardID shardId, CollectionID collectionId,
+                   velocypack::SharedSlice properties) -> Result;
+  auto isShardAvailable(ShardID const& shardId) -> bool;
   void drop();
 
  private:
   TRI_vocbase_t& _vocbase;
   GlobalLogIdentifier _gid;
   DocumentCoreParameters _params;
-  std::unordered_map<ShardID, std::shared_ptr<velocypack::Builder>> _shards;
+  std::unordered_map<ShardID, ShardProperties> _shards;
   std::shared_ptr<IDocumentStateAgencyHandler> _agencyHandler;
   std::shared_ptr<IDocumentStateShardHandler> _shardHandler;
 };

--- a/arangod/Replication2/StateMachines/Document/DocumentFollowerState.cpp
+++ b/arangod/Replication2/StateMachines/Document/DocumentFollowerState.cpp
@@ -138,7 +138,7 @@ auto DocumentFollowerState::applyEntries(
               // Even though a shard was dropped before acquiring the snapshot,
               // we could still see transactions referring to that shard.
               if (!data.core->isShardAvailable(doc.shardId)) {
-                LOG_CTX("1970d", DEBUG, self->loggerContext)
+                LOG_CTX("1970d", INFO, self->loggerContext)
                     << "Will not apply transaction " << doc.tid << " for shard "
                     << doc.shardId << " because it is not available";
                 continue;

--- a/arangod/Replication2/StateMachines/Document/DocumentFollowerState.cpp
+++ b/arangod/Replication2/StateMachines/Document/DocumentFollowerState.cpp
@@ -66,13 +66,14 @@ auto DocumentFollowerState::acquireSnapshot(ParticipantId const& destination,
         }
 
         auto count = ++data.currentSnapshotVersion;
-        // TODO we're going to drop the shards when then snapshot transfer will
-        // handle multiple shards
-        if (auto truncateRes =
-                self->truncateLocalShard(data.core->getShardId());
-            truncateRes.fail()) {
-          return truncateRes;
+
+        for (auto const& [shardId, _] : data.core->getShardMap()) {
+          auto truncateRes = self->truncateLocalShard(shardId);
+          if (truncateRes.fail()) {
+            return truncateRes;
+          }
         }
+
         /*
         if (auto dropAllRes = data.core->dropAllShards(); dropAllRes.fail()) {
           return dropAllRes;

--- a/arangod/Replication2/StateMachines/Document/DocumentFollowerState.h
+++ b/arangod/Replication2/StateMachines/Document/DocumentFollowerState.h
@@ -45,7 +45,6 @@ struct DocumentFollowerState
       std::shared_ptr<IDocumentStateHandlersFactory> const& handlersFactory);
   ~DocumentFollowerState() override;
 
-  ShardID const shardId;  // TODO we have to get rid of this member
   LoggerContext const loggerContext;
 
   // unprotected for gtests. TODO think about whether there's a better way
@@ -58,10 +57,11 @@ struct DocumentFollowerState
       -> futures::Future<Result> override;
 
  private:
-  auto forceLocalTransaction(OperationType opType,
+  auto forceLocalTransaction(ShardID shardId, OperationType opType,
                              velocypack::SharedSlice slice) -> Result;
-  auto truncateLocalShard() -> Result;
-  auto populateLocalShard(velocypack::SharedSlice slice) -> Result;
+  auto truncateLocalShard(ShardID const& shardId) -> Result;
+  auto populateLocalShard(ShardID shardId, velocypack::SharedSlice slice)
+      -> Result;
   auto handleSnapshotTransfer(
       std::shared_ptr<IDocumentStateLeaderInterface> leader,
       LogIndex waitForIndex, std::uint64_t snapshotVersion,

--- a/arangod/Replication2/StateMachines/Document/DocumentFollowerState.h
+++ b/arangod/Replication2/StateMachines/Document/DocumentFollowerState.h
@@ -79,7 +79,6 @@ struct DocumentFollowerState
   };
 
   std::shared_ptr<IDocumentStateNetworkHandler> _networkHandler;
-  std::shared_ptr<IDocumentStateShardHandler> _shardHandler;
   std::unique_ptr<IDocumentStateTransactionHandler> _transactionHandler;
   Guarded<GuardedData, basics::UnshackledMutex> _guardedData;
   ActiveTransactionsQueue _activeTransactions;

--- a/arangod/Replication2/StateMachines/Document/DocumentLeaderState.cpp
+++ b/arangod/Replication2/StateMachines/Document/DocumentLeaderState.cpp
@@ -117,7 +117,7 @@ auto DocumentLeaderState::recoverEntries(std::unique_ptr<EntryIterator> ptr)
 
       // Note that the shard could've been dropped before doing recovery.
       if (!data.core->isShardAvailable(doc.shardId)) {
-        LOG_CTX("1970d", DEBUG, self->loggerContext)
+        LOG_CTX("bee57", DEBUG, self->loggerContext)
             << "Will not apply transaction " << doc.tid << " for shard "
             << doc.shardId << " because it is not available";
         continue;

--- a/arangod/Replication2/StateMachines/Document/DocumentLeaderState.cpp
+++ b/arangod/Replication2/StateMachines/Document/DocumentLeaderState.cpp
@@ -126,7 +126,7 @@ auto DocumentLeaderState::recoverEntries(std::unique_ptr<EntryIterator> ptr)
       } else {
         // Note that the shard could've been dropped before doing recovery.
         if (!data.core->isShardAvailable(doc.shardId)) {
-          LOG_CTX("bee57", DEBUG, self->loggerContext)
+          LOG_CTX("bee57", INFO, self->loggerContext)
               << "Will not apply transaction " << doc.tid << " for shard "
               << doc.shardId << " because it is not available";
           continue;

--- a/arangod/Replication2/StateMachines/Document/DocumentLeaderState.h
+++ b/arangod/Replication2/StateMachines/Document/DocumentLeaderState.h
@@ -77,7 +77,6 @@ struct DocumentLeaderState
 
   GlobalLogIdentifier const gid;
   LoggerContext const loggerContext;
-  ShardID const shardId;
 
  private:
   struct GuardedData {

--- a/arangod/Replication2/StateMachines/Document/DocumentLeaderState.h
+++ b/arangod/Replication2/StateMachines/Document/DocumentLeaderState.h
@@ -96,8 +96,6 @@ struct DocumentLeaderState
   Guarded<std::unique_ptr<IDocumentStateSnapshotHandler>,
           basics::UnshackledMutex>
       _snapshotHandler;
-  Guarded<std::shared_ptr<IDocumentStateShardHandler>, basics::UnshackledMutex>
-      _shardHandler;
   Guarded<GuardedData, basics::UnshackledMutex> _guardedData;
   Guarded<ActiveTransactionsQueue, std::mutex> _activeTransactions;
   transaction::IManager& _transactionManager;

--- a/arangod/Replication2/StateMachines/Document/DocumentStateMachine.cpp
+++ b/arangod/Replication2/StateMachines/Document/DocumentStateMachine.cpp
@@ -67,7 +67,6 @@ auto DocumentFactory::constructCore(TRI_vocbase_t& vocbase,
       LoggerContext(Logger::REPLICATED_STATE)
           .with<logContextKeyStateImpl>(DocumentState::NAME)
           .with<logContextKeyDatabaseName>(gid.database)
-          .with<logContextKeyCollectionId>(coreParameters.collectionId)
           .with<logContextKeyLogId>(gid.id);
   return std::make_unique<DocumentCore>(
       vocbase, std::move(gid), std::move(coreParameters), _handlersFactory,

--- a/arangod/Replication2/StateMachines/Document/DocumentStateSnapshotHandler.cpp
+++ b/arangod/Replication2/StateMachines/Document/DocumentStateSnapshotHandler.cpp
@@ -31,16 +31,15 @@ DocumentStateSnapshotHandler::DocumentStateSnapshotHandler(
     std::unique_ptr<IDatabaseSnapshotFactory> databaseSnapshotFactory)
     : _databaseSnapshotFactory(std::move(databaseSnapshotFactory)) {}
 
-auto DocumentStateSnapshotHandler::create(std::string_view shardId)
+auto DocumentStateSnapshotHandler::create(std::vector<ShardID> shardIds)
     -> ResultT<std::weak_ptr<Snapshot>> {
   try {
     auto snapshot = _databaseSnapshotFactory->createSnapshot();
 
     auto id = SnapshotId::create();
     auto emplacement = _snapshots.emplace(
-        id, std::make_shared<Snapshot>(
-                id, std::vector<ShardID>{std::string{shardId}},
-                std::move(snapshot)));
+        id, std::make_shared<Snapshot>(id, std::move(shardIds),
+                                       std::move(snapshot)));
     TRI_ASSERT(emplacement.second);
     return ResultT<std::weak_ptr<Snapshot>>::success(emplacement.first->second);
   } catch (basics::Exception const& ex) {

--- a/arangod/Replication2/StateMachines/Document/DocumentStateSnapshotHandler.h
+++ b/arangod/Replication2/StateMachines/Document/DocumentStateSnapshotHandler.h
@@ -40,7 +40,7 @@ struct IDatabaseSnapshotFactory;
  */
 struct IDocumentStateSnapshotHandler {
   virtual ~IDocumentStateSnapshotHandler() = default;
-  virtual auto create(std::string_view shardId)
+  virtual auto create(std::vector<ShardID> shardIds)
       -> ResultT<std::weak_ptr<Snapshot>> = 0;
   virtual auto find(SnapshotId const& id)
       -> ResultT<std::weak_ptr<Snapshot>> = 0;
@@ -55,7 +55,7 @@ class DocumentStateSnapshotHandler : public IDocumentStateSnapshotHandler {
       std::unique_ptr<IDatabaseSnapshotFactory> databaseSnapshotFactory);
 
   // Create a new snapshot
-  auto create(std::string_view shardId)
+  auto create(std::vector<ShardID> shardIds)
       -> ResultT<std::weak_ptr<Snapshot>> override;
 
   // Find a snapshot by id

--- a/arangod/Replication2/StateMachines/Document/ShardProperties.h
+++ b/arangod/Replication2/StateMachines/Document/ShardProperties.h
@@ -29,7 +29,6 @@
 
 namespace arangodb::replication2::replicated_state::document {
 struct ShardProperties {
-  ShardID shardId;
   CollectionID collectionId;
   std::shared_ptr<velocypack::Builder> properties;
 };

--- a/arangod/Replication2/StateMachines/Document/ShardProperties.h
+++ b/arangod/Replication2/StateMachines/Document/ShardProperties.h
@@ -1,0 +1,36 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2023 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Alexandru Petenchea
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "Cluster/ClusterTypes.h"
+
+#include <unordered_map>
+
+namespace arangodb::replication2::replicated_state::document {
+struct ShardProperties {
+  ShardID shardId;
+  CollectionID collectionId;
+  std::shared_ptr<velocypack::Builder> properties;
+};
+}  // namespace arangodb::replication2::replicated_state::document

--- a/tests/Replication2/Mocks/DocumentStateMocks.cpp
+++ b/tests/Replication2/Mocks/DocumentStateMocks.cpp
@@ -53,8 +53,9 @@ MockDocumentStateSnapshotHandler::MockDocumentStateSnapshotHandler(
         real)
     : _real(std::move(real)) {
   ON_CALL(*this, create(testing::_))
-      .WillByDefault(
-          [this](std::string_view shardId) { return _real->create(shardId); });
+      .WillByDefault([this](std::vector<ShardID> shardIds) {
+        return _real->create(std::move(shardIds));
+      });
   ON_CALL(*this, find(testing::_))
       .WillByDefault(
           [this](replicated_state::document::SnapshotId const& snapshotId) {

--- a/tests/Replication2/Mocks/DocumentStateMocks.h
+++ b/tests/Replication2/Mocks/DocumentStateMocks.h
@@ -247,7 +247,7 @@ struct MockDocumentStateSnapshotHandler
           real);
 
   MOCK_METHOD(ResultT<std::weak_ptr<replicated_state::document::Snapshot>>,
-              create, (std::string_view), (override));
+              create, (std::vector<ShardID>), (override));
   MOCK_METHOD(ResultT<std::weak_ptr<replicated_state::document::Snapshot>>,
               find, (replicated_state::document::SnapshotId const&),
               (override));

--- a/tests/Replication2/ReplicatedState/DocumentStateMachineTest.cpp
+++ b/tests/Replication2/ReplicatedState/DocumentStateMachineTest.cpp
@@ -897,9 +897,10 @@ TEST_F(DocumentStateMachineTest,
   follower->setStream(stream);
 
   std::vector<DocumentLogEntry> entries;
-  addShardEntry(entries, OperationType::kCreateShard, shardId, collectionId);
+  addShardEntry(entries, OperationType::kCreateShard, "randomShardId",
+                collectionId);
   auto entryIterator = std::make_unique<DocumentLogEntryIterator>(entries);
-  ON_CALL(*shardHandlerMock, createLocalShard(shardId, collectionId, _))
+  ON_CALL(*shardHandlerMock, createLocalShard("randomShardId", collectionId, _))
       .WillByDefault(Return(Result(TRI_ERROR_WAS_ERLAUBE)));
   ASSERT_DEATH_CORE_FREE(follower->applyEntries(std::move(entryIterator)), "");
 


### PR DESCRIPTION
### Scope & Purpose

We are adding support for multiple shards in `DocumentCore`. Until now, we used to have the `shardId` property for referencing the corresponding shard. This PR replaces that with a map, *ShardId -> ShardProperties*.
Because on the followers we create and drop shards through the use of log entries, we are now in a situation in which, during a replay of the log, a transaction might reference a dropped shard. Or, the follower tries to create an already existing shard. The document state checks for the existence of a shard before applying any transaction.

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**