### PR TITLE
Bug fix/3.10 smartedges race condition

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,12 @@
 v3.10.4 (XXXX-XX-XX)
 --------------------
 
+* Fixed EE: Concurrent batch insert/update CRUD operations into
+  SmartEdgeCollections on conflicting edge keys could get the smart edge caching
+  out-of-sync, which would yield different results for OUTBOUND/INBOUND search
+  over edges. This is now fixed, however there is now a slightly higher chance
+  to get a CONFLICT response back on those queries.
+
 * Return peak memory usage and execution time as part of query explain result.
   This helps finding queries that use a lot of memory to build the execution
   plan.
@@ -27,13 +33,6 @@ v3.10.4 (XXXX-XX-XX)
 * BTS-1193: Fix for schema update. When removing a field and then inserting a
   new field into the schema, previously, both old and new schema would be
   merged, meaning it would maintain the old field and add the new one.
-
-* Fixed EE: Concurrent batch insert/update CRUD operations into
-  SmartEdgeCollections on conflicting edge keys could get the
-  smart edge caching out-of-sync, which would yield different results
-  for OUTBOUND/INBOUND search over edges. This is now fixed, however there
-  is now a slightly higher chance to get a CONFLICT response back on those
-  queries.
 
 * Fixed issue #18053: Computed Values become null when Schema is modified.
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -19,6 +19,13 @@ v3.10.4 (XXXX-XX-XX)
   new field into the schema, previously, both old and new schema would be
   merged, meaning it would maintain the old field and add the new one.
 
+* Fixed EE: Concurrent batch insert/update CRUD operations into
+  SmartEgeCollections on conflicting edge keys, could get the
+  smart edge caching out-of-sync, which would yield different results
+  for OUTBOUND/INBOUND search over edges. This is now fixed, however there
+  is now a slightly higher chance to get a CONFLICT response back on those
+  queries.
+
 * Fixed issue #18053: Computed Values become null when Schema is modified.
 
 * Set the cache_oblivious option of jemalloc to `false` by default. This helps

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -20,7 +20,7 @@ v3.10.4 (XXXX-XX-XX)
   merged, meaning it would maintain the old field and add the new one.
 
 * Fixed EE: Concurrent batch insert/update CRUD operations into
-  SmartEgeCollections on conflicting edge keys, could get the
+  SmartEdgeCollections on conflicting edge keys could get the
   smart edge caching out-of-sync, which would yield different results
   for OUTBOUND/INBOUND search over edges. This is now fixed, however there
   is now a slightly higher chance to get a CONFLICT response back on those

--- a/arangod/ClusterEngine/ClusterTransactionState.cpp
+++ b/arangod/ClusterEngine/ClusterTransactionState.cpp
@@ -40,8 +40,8 @@
 #include "Transaction/Manager.h"
 #include "Transaction/ManagerFeature.h"
 #include "Transaction/Methods.h"
-#include "VocBase/LogicalCollection.h"
 #include "Utils/CollectionNameResolver.h"
+#include "VocBase/LogicalCollection.h"
 
 using namespace arangodb;
 

--- a/arangod/RestHandler/RestDocumentHandler.cpp
+++ b/arangod/RestHandler/RestDocumentHandler.cpp
@@ -109,9 +109,11 @@ RestStatus RestDocumentHandler::execute() {
   auto const type = _request->requestType();
 #ifdef ARANGODB_ENABLE_FAILURE_TESTS
   std::vector<std::string> const& suffixes = _request->decodedSuffixes();
-  TRI_IF_FAILURE("failOnCRUDAPI" + suffixes[0]) {
-    generateError(GeneralResponse::responseCode(TRI_ERROR_DEBUG),
-                  TRI_ERROR_DEBUG, "Intentional test error");
+  if (!suffixes.empty()) {
+    TRI_IF_FAILURE("failOnCRUDAPI" + suffixes[0]) {
+      generateError(GeneralResponse::responseCode(TRI_ERROR_DEBUG),
+                    TRI_ERROR_DEBUG, "Intentional test error");
+    }
   }
 #endif
   // execute one of the CRUD methods

--- a/arangod/RestHandler/RestDocumentHandler.cpp
+++ b/arangod/RestHandler/RestDocumentHandler.cpp
@@ -107,7 +107,13 @@ RequestLane RestDocumentHandler::lane() const {
 RestStatus RestDocumentHandler::execute() {
   // extract the sub-request type
   auto const type = _request->requestType();
-
+#ifdef ARANGODB_ENABLE_FAILURE_TESTS
+  std::vector<std::string> const& suffixes = _request->decodedSuffixes();
+  TRI_IF_FAILURE("failOnCRUDAPI" + suffixes[0]) {
+    generateError(GeneralResponse::responseCode(TRI_ERROR_DEBUG),
+                  TRI_ERROR_DEBUG, "Intentional test error");
+  }
+#endif
   // execute one of the CRUD methods
   switch (type) {
     case rest::RequestType::DELETE_REQ:

--- a/arangod/RestHandler/RestDocumentHandler.cpp
+++ b/arangod/RestHandler/RestDocumentHandler.cpp
@@ -801,8 +801,6 @@ RestStatus RestDocumentHandler::removeDocument() {
             "' with the required access mode.");
   }
 
-  bool const isMultiple = search.isArray();
-
   return waitForFuture(
       _activeTrx->removeAsync(cname, search, opOptions)
           .thenValue([=, this,

--- a/arangod/RestHandler/RestDocumentHandler.cpp
+++ b/arangod/RestHandler/RestDocumentHandler.cpp
@@ -249,17 +249,18 @@ RestStatus RestDocumentHandler::insertDocument() {
   _activeTrx = createTransaction(cname, AccessMode::Type::WRITE, opOptions);
   bool const isMultiple = body.isArray();
 
-  if (!isMultiple && !opOptions.isOverwriteModeUpdateReplace()) {
-    _activeTrx->addHint(transaction::Hints::Hint::SINGLE_OPERATION);
-  }
-
   {
     // HACK for SmartEdgeCollections to trigger a coordinator wide lock, and no local lock
     CollectionNameResolver resolver{_vocbase};
     auto col = resolver.getCollection(cname);
-    TRI_ASSERT(col != nullptr) << "YOLO collection";
+    ADB_PROD_ASSERT(col != nullptr) << "Get collection API should have thrown.";
     if (col->isSmartEdgeCollection()) {
       _activeTrx->addHint(transaction::Hints::Hint::GLOBAL_MANAGED);
+    } else {
+      if (!isMultiple && !opOptions.isOverwriteModeUpdateReplace()) {
+        _activeTrx->addHint(transaction::Hints::Hint::SINGLE_OPERATION);
+      }
+
     }
   }
 

--- a/arangod/RestHandler/RestDocumentHandler.h
+++ b/arangod/RestHandler/RestDocumentHandler.h
@@ -72,6 +72,9 @@ class RestDocumentHandler : public RestVocbaseBaseHandler {
   RestStatus removeDocument();
 
  private:
+  void addTransactionHints(std::string const& collectionName, bool isMultiple,
+                           bool isOverwritingInsert);
+
   std::unique_ptr<transaction::Methods> _activeTrx;
 };
 }  // namespace arangodb

--- a/arangod/Transaction/Methods.cpp
+++ b/arangod/Transaction/Methods.cpp
@@ -1298,7 +1298,7 @@ Future<OperationResult> transaction::Methods::insertLocal(
   auto workForOneDocument = [&](VPackSlice value, bool isArray) -> Result {
     newDocumentBuilder->clear();
 #ifdef ARANGODB_ENABLE_FAILURE_TESTS
-    TRI_IF_FAILURE("failOnCRUDAction" + _collection.name()) {
+    TRI_IF_FAILURE("failOnCRUDAction" + collectionName) {
       return {TRI_ERROR_DEBUG, "Intentional test error"};
     }
 #endif
@@ -1736,7 +1736,7 @@ Future<OperationResult> transaction::Methods::modifyLocal(
     previousDocumentBuilder->clear();
 
 #ifdef ARANGODB_ENABLE_FAILURE_TESTS
-    TRI_IF_FAILURE("failOnCRUDAction" + _collection.name()) {
+    TRI_IF_FAILURE("failOnCRUDAction" + collectionName) {
       return {TRI_ERROR_DEBUG, "Intentional test error"};
     }
 #endif
@@ -2096,7 +2096,7 @@ Future<OperationResult> transaction::Methods::removeLocal(
   auto workForOneDocument = [&](VPackSlice value, bool isArray) -> Result {
     std::string_view key;
 #ifdef ARANGODB_ENABLE_FAILURE_TESTS
-    TRI_IF_FAILURE("failOnCRUDAction" + _collection.name()) {
+    TRI_IF_FAILURE("failOnCRUDAction" + collectionName) {
       return {TRI_ERROR_DEBUG, "Intentional test error"};
     }
 #endif

--- a/arangod/Transaction/Methods.cpp
+++ b/arangod/Transaction/Methods.cpp
@@ -1297,6 +1297,11 @@ Future<OperationResult> transaction::Methods::insertLocal(
 
   auto workForOneDocument = [&](VPackSlice value, bool isArray) -> Result {
     newDocumentBuilder->clear();
+#ifdef ARANGODB_ENABLE_FAILURE_TESTS
+     TRI_IF_FAILURE("failOnCRUDAction" + _collection.name()) {
+       return {TRI_ERROR_DEBUG, "Intentional test error"};
+     }
+ #endif
 
     if (!value.isObject()) {
       return {TRI_ERROR_ARANGO_DOCUMENT_TYPE_INVALID};
@@ -1730,6 +1735,12 @@ Future<OperationResult> transaction::Methods::modifyLocal(
     newDocumentBuilder->clear();
     previousDocumentBuilder->clear();
 
+#ifdef ARANGODB_ENABLE_FAILURE_TESTS
+    TRI_IF_FAILURE("failOnCRUDAction" + _collection.name()) {
+      return {TRI_ERROR_DEBUG, "Intentional test error"};
+    }
+ #endif
+
     if (!newValue.isObject()) {
       return {TRI_ERROR_ARANGO_DOCUMENT_TYPE_INVALID};
     }
@@ -2084,6 +2095,11 @@ Future<OperationResult> transaction::Methods::removeLocal(
 
   auto workForOneDocument = [&](VPackSlice value, bool isArray) -> Result {
     std::string_view key;
+#ifdef ARANGODB_ENABLE_FAILURE_TESTS
+    TRI_IF_FAILURE("failOnCRUDAction" + _collection.name()) {
+      return {TRI_ERROR_DEBUG, "Intentional test error"};
+    }
+#endif 
 
     if (value.isString()) {
       key = value.stringView();

--- a/arangod/Transaction/Methods.cpp
+++ b/arangod/Transaction/Methods.cpp
@@ -1298,10 +1298,10 @@ Future<OperationResult> transaction::Methods::insertLocal(
   auto workForOneDocument = [&](VPackSlice value, bool isArray) -> Result {
     newDocumentBuilder->clear();
 #ifdef ARANGODB_ENABLE_FAILURE_TESTS
-     TRI_IF_FAILURE("failOnCRUDAction" + _collection.name()) {
-       return {TRI_ERROR_DEBUG, "Intentional test error"};
-     }
- #endif
+    TRI_IF_FAILURE("failOnCRUDAction" + _collection.name()) {
+      return {TRI_ERROR_DEBUG, "Intentional test error"};
+    }
+#endif
 
     if (!value.isObject()) {
       return {TRI_ERROR_ARANGO_DOCUMENT_TYPE_INVALID};
@@ -1739,7 +1739,7 @@ Future<OperationResult> transaction::Methods::modifyLocal(
     TRI_IF_FAILURE("failOnCRUDAction" + _collection.name()) {
       return {TRI_ERROR_DEBUG, "Intentional test error"};
     }
- #endif
+#endif
 
     if (!newValue.isObject()) {
       return {TRI_ERROR_ARANGO_DOCUMENT_TYPE_INVALID};
@@ -2099,7 +2099,7 @@ Future<OperationResult> transaction::Methods::removeLocal(
     TRI_IF_FAILURE("failOnCRUDAction" + _collection.name()) {
       return {TRI_ERROR_DEBUG, "Intentional test error"};
     }
-#endif 
+#endif
 
     if (value.isString()) {
       key = value.stringView();

--- a/arangod/V8Server/v8-collection.cpp
+++ b/arangod/V8Server/v8-collection.cpp
@@ -744,7 +744,7 @@ static void RemoveVocbaseCol(v8::FunctionCallbackInfo<v8::Value> const& args) {
           std::shared_ptr<transaction::Context>(), &transactionContext),
       collectionName, AccessMode::Type::WRITE);
 
-  ::addTransactionHints(*col, trx, !args[0]->IsArray(), false);
+  ::addTransactionHints(*col, trx, args[0]->IsArray(), false);
 
   Result res = trx.begin();
   if (!res.ok()) {

--- a/arangod/V8Server/v8-collection.cpp
+++ b/arangod/V8Server/v8-collection.cpp
@@ -95,6 +95,23 @@ std::shared_ptr<arangodb::LogicalCollection> GetCollectionFromArgument(
   return vocbase.lookupCollection(TRI_ObjectToString(isolate, val));
 }
 
+void addTransactionHints(arangodb::LogicalCollection& col,
+                         arangodb::SingleCollectionTransaction& trx,
+                         bool isMultiple, bool isOverwritingInsert) {
+  if (arangodb::ServerState::instance()->isCoordinator()) {
+    if (col.isSmartEdgeCollection()) {
+      // Smart Edge Collections hit multiple shards with dependent requests,
+      // they have to be globally managed.
+      trx.addHint(arangodb::transaction::Hints::Hint::GLOBAL_MANAGED);
+      return;
+    }
+  }
+  // For non multiple operations we can optimize to use SingleOperations.
+  if (!isMultiple && !isOverwritingInsert) {
+    trx.addHint(arangodb::transaction::Hints::Hint::SINGLE_OPERATION);
+  }
+}
+
 }  // namespace
 
 using namespace arangodb;
@@ -727,9 +744,7 @@ static void RemoveVocbaseCol(v8::FunctionCallbackInfo<v8::Value> const& args) {
           std::shared_ptr<transaction::Context>(), &transactionContext),
       collectionName, AccessMode::Type::WRITE);
 
-  if (!args[0]->IsArray()) {
-    trx.addHint(transaction::Hints::Hint::SINGLE_OPERATION);
-  }
+  ::addTransactionHints(*col, trx, !args[0]->IsArray(), false);
 
   Result res = trx.begin();
   if (!res.ok()) {
@@ -821,7 +836,7 @@ static void RemoveVocbase(v8::FunctionCallbackInfo<v8::Value> const& args) {
       std::shared_ptr<transaction::Context>(
           std::shared_ptr<transaction::Context>(), &transactionContext),
       collectionName, AccessMode::Type::WRITE);
-  trx.addHint(transaction::Hints::Hint::SINGLE_OPERATION);
+  ::addTransactionHints(*collection, trx, false, false);
 
   Result res = trx.begin();
 
@@ -1540,9 +1555,7 @@ static void ModifyVocbaseCol(TRI_voc_document_operation_e operation,
           std::shared_ptr<transaction::Context>(), &transactionContext),
       collectionName, AccessMode::Type::WRITE);
 
-  if (!args[0]->IsArray()) {
-    trx.addHint(transaction::Hints::Hint::SINGLE_OPERATION);
-  }
+  addTransactionHints(*col, trx, args[0]->IsArray(), false);
 
   Result res = trx.begin();
 
@@ -1663,7 +1676,7 @@ static void ModifyVocbase(TRI_voc_document_operation_e operation,
       std::shared_ptr<transaction::Context>(
           std::shared_ptr<transaction::Context>(), &transactionContext),
       collectionName, AccessMode::Type::WRITE);
-  trx.addHint(transaction::Hints::Hint::SINGLE_OPERATION);
+  addTransactionHints(*collection, trx, false, false);
 
   Result res = trx.begin();
   if (!res.ok()) {
@@ -2181,9 +2194,8 @@ static void InsertVocbaseCol(v8::Isolate* isolate,
           std::shared_ptr<transaction::Context>(), &transactionContext),
       *collection, AccessMode::Type::WRITE);
 
-  if (!payloadIsArray && !options.isOverwriteModeUpdateReplace()) {
-    trx.addHint(transaction::Hints::Hint::SINGLE_OPERATION);
-  }
+  addTransactionHints(*collection, trx, payloadIsArray,
+                      options.isOverwriteModeUpdateReplace());
 
   Result res = trx.begin();
 


### PR DESCRIPTION
### Scope & Purpose

*FIXED: Concurrent batch insert/update CRUD operations into
  SmartEdgeCollections on conflicting edge keys could get the
  smart edge caching out-of-sync, which would yield different results
  for OUTBOUND/INBOUND search over edges. This is now fixed, however there
  is now a slightly higher chance to get a CONFLICT response back on those
  queries.*

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [x] Tests
  - [x] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: *(Please link PR)*
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR: https://github.com/arangodb/enterprise/pull/1208
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

