### PR TITLE
[GORDO-1518] Fix memory leak in tests

### DIFF
--- a/tests/Pregel/Actor/MPSCQueueTest.cpp
+++ b/tests/Pregel/Actor/MPSCQueueTest.cpp
@@ -117,11 +117,10 @@ TEST(ActorMPSCQueue, threads_push_stuff_comes_out) {
     while (true) {
       auto rcv = queue.pop();
       if (rcv != nullptr) {
-        auto msg = rcv.release();
-        receivedIds[msg->threadId][msg->messageId] = true;
+        receivedIds[rcv->threadId][rcv->messageId] = true;
         counter++;
 
-        ASSERT_LT(msg->threadId, numberThreads);
+        ASSERT_LT(rcv->threadId, numberThreads);
         ASSERT_LE(counter, numberThreads * numberMessages);
 
         if (counter == numberThreads * numberMessages) {

--- a/tests/Pregel/Actor/MultiRuntimeTest.cpp
+++ b/tests/Pregel/Actor/MultiRuntimeTest.cpp
@@ -132,6 +132,9 @@ TYPED_TEST(ActorMultiRuntimeTest, sends_message_to_actor_in_another_runtime) {
           receiving_actor_id);
   ASSERT_EQ(receiving_actor_state,
             (TrivialActor::State{.state = "foobaz", .called = 2}));
+  for (auto& [_, runtime] : runtimes) {
+    runtime->softShutdown();
+  }
 }
 
 struct SomeMessage {};
@@ -201,6 +204,9 @@ TYPED_TEST(
       (TrivialActor::State{
           .state = fmt::format("sent unknown message to {}", receiving_actor),
           .called = 2}));
+  for (auto& [_, runtime] : runtimes) {
+    runtime->softShutdown();
+  }
 }
 
 TYPED_TEST(
@@ -246,6 +252,9 @@ TYPED_TEST(
       (TrivialActor::State{
           .state = fmt::format("receiving actor {} not found", unknown_actor),
           .called = 2}));
+  for (auto& [_, runtime] : runtimes) {
+    runtime->softShutdown();
+  }
 }
 
 TYPED_TEST(
@@ -284,6 +293,9 @@ TYPED_TEST(
       (TrivialActor::State{
           .state = fmt::format("receiving server {} not found", unknown_server),
           .called = 2}));
+  for (auto& [_, runtime] : runtimes) {
+    runtime->softShutdown();
+  }
 }
 
 TYPED_TEST(ActorMultiRuntimeTest, ping_pong_game) {
@@ -326,4 +338,7 @@ TYPED_TEST(ActorMultiRuntimeTest, ping_pong_game) {
           ping_actor);
   ASSERT_EQ(ping_actor_state,
             (ping_actor::PingState{.called = 2, .message = "hello world"}));
+  for (auto& [_, runtime] : runtimes) {
+    runtime->softShutdown();
+  }
 }


### PR DESCRIPTION
### Scope & Purpose

ASAN/UBSAN detected a load of memory leaks, all caused by not shutting down the runtimes for actors. 

This patch fixes the immediate problem; We will look at better solutions for shutting down runtimes gracefully.

To verify this locally I used the following commands

```
# cmake --preset community-developer-asan-ubsan
# cmake --build --preset community-developer-asan-ubsan --target arangodbtests_actor
# build-presets/bin/arangodbtests_actor
```
