### PR TITLE
Coverage Presets, Small fix for CMakeLists.txt to work with clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -206,6 +206,7 @@ endif ()
 option(USE_COVERAGE "enable gcov code coverage" OFF)
 if (USE_COVERAGE)
   add_compile_options(-fno-stack-protector -fprofile-arcs -ftest-coverage)
+  add_link_options(--coverage)
   add_definitions("-DUSE_COVERAGE=1")
 endif ()
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -162,6 +162,16 @@
       "name": "enterprise-developer-asan-ubsan",
       "inherits": [ "asan-ubsan", "enterprise-developer" ],
       "displayName": "Build ArangoDB Enterprise Edition (ASAN and UBSAN Build)"
+    },
+    {
+      "name": "community-developer-coverage",
+      "inherits": [ "gcov", "community-developer" ],
+      "displayName": "Build ArangoDB Community Edition (Coverage Build)"
+    },
+    {
+      "name": "enterprise-developer-coverage",
+      "inherits": [ "gcov", "enterprise-developer" ],
+      "displayName": "Build ArangoDB Enterprise Edition (Coverage Build)"
     }
   ],
   "buildPresets": [
@@ -204,6 +214,14 @@
     {
       "name": "enterprise-developer-asan-ubsan",
       "configurePreset": "enterprise-developer-asan-ubsan"
+    },
+    {
+      "name": "community-developer-coverage",
+      "configurePreset": "community-developer-coverage"
+    },
+    {
+      "name": "enterprise-developer-coverage",
+      "configurePreset": "enterprise-developer-coverage"
     }
   ],
   "testPresets": [


### PR DESCRIPTION
### Scope & Purpose

* Add CMake presets to build with coverage
* Fix `CMakeLists.txt` to work when using clang.