### PR TITLE
[CINFRA] No snapshot on first start

### DIFF
--- a/arangod/VocBase/vocbase.cpp
+++ b/arangod/VocBase/vocbase.cpp
@@ -381,7 +381,8 @@ struct arangodb::VocBaseLogManager {
 
         auto metadata = PersistedStateInfo{
             .stateId = id,
-            .snapshot = {.status = replicated_state::SnapshotStatus::kCompleted,
+            .snapshot = {.status =
+                             replicated_state::SnapshotStatus::kUninitialized,
                          .timestamp = {},
                          .error = {}},
             .generation = {},


### PR DESCRIPTION
### Scope & Purpose
New servers added to a replicated log assume they have a snapshot. This ok, because they will never be elected as leader. However, the supervision might use this information and takes the wrong decision. 

So instead for optimizing for the initial case, we should allow the supervision to make use of this snapshot available flag by not setting it to true on default.

But there is a **problem**: The leader can't establish leadership unless it can form a quorum. The leader can't form a quorum unless the followers have a snapshot. The replicated state leader is not exposed unless leadership is established. Hence the followers can't acquire a snapshot. This could be problem in general and not only during startup.