### PR TITLE
Add missing sccache links

### DIFF
--- a/scripts/build/arangodb-build.Dockerfile
+++ b/scripts/build/arangodb-build.Dockerfile
@@ -12,4 +12,9 @@ RUN [ "/tools/install-openssl.sh", "1.1.1", "t" ]
 ENV OPENSSL_ROOT_DIR=/opt/openssl-1.1.1
 RUN apk --no-cache del perl
 
+RUN ln /usr/bin/sccache /usr/local/bin/gcc && \
+    ln /usr/bin/sccache /usr/local/bin/g++ && \
+    ln /usr/bin/sccache /usr/local/bin/clang-14 && \
+    ln /usr/bin/sccache /usr/local/bin/clang++-14
+
 CMD [ "sh" ]


### PR DESCRIPTION
### Scope & Purpose

Somehow the sccache links in the build container got lost - this PR fixes that.
Note - no build is needed for this PR. The container is already built and pushed and used in current CircleCI builds.

- [x] :hankey: Bugfix
