### PR TITLE
Slick GEO tests to just create each set of data *once* at the beginning in individual collections / views

### DIFF
--- a/tests/js/server/aql/aql-geo.inc
+++ b/tests/js/server/aql/aql-geo.inc
@@ -486,7 +486,8 @@
         Object.keys(withView).forEach(key => { withView[key].drop(); });
         Object.keys(noIndex).forEach(key => { noIndex[key].drop(); });
         Object.keys(withIndex).forEach(key => { withIndex[key].drop(); });
-        Object.keys(testAnalyzers).forEach(key => { analyzers.remove(testAnalyzers[key].name()); });
+        Object.keys(testAnalyzers).forEach(key => {
+          analyzers.remove(testAnalyzers[key].name(), true); });
       },
 
       ////////////////////////////////////////////////////////////////////////////////

--- a/tests/js/server/aql/aql-geo.inc
+++ b/tests/js/server/aql/aql-geo.inc
@@ -483,17 +483,10 @@
 
       tearDownAll: function () {
         Object.keys(plainView).forEach(key => { plainView[key].drop(); });
+        Object.keys(withView).forEach(key => { withView[key].drop(); });
         Object.keys(noIndex).forEach(key => { noIndex[key].drop(); });
         Object.keys(withIndex).forEach(key => { withIndex[key].drop(); });
-        Object.keys(withView).forEach(key => { withView[key].drop(); });
-        //Object.keys(testAnalyzers).forEach(key => { testAnalyzers[key].drop(); });
-      },
-
-      ////////////////////////////////////////////////////////////////////////////////
-      /// @brief tear down
-      ////////////////////////////////////////////////////////////////////////////////
-
-      tearDown: function () {
+        Object.keys(testAnalyzers).forEach(key => { analyzers.remove(testAnalyzers[key].name()); });
       },
 
       ////////////////////////////////////////////////////////////////////////////////

--- a/tests/js/server/aql/aql-geo.inc
+++ b/tests/js/server/aql/aql-geo.inc
@@ -47,7 +47,7 @@
       return {
         type: "Polygon",
         coordinates: [[[lon[0], lat[0]], [lon[1], lat[0]],
-          [lon[1], lat[1]], [lon[0], lat[1]], [lon[0], lat[0]]]]
+                       [lon[1], lat[1]], [lon[0], lat[1]], [lon[0], lat[0]]]]
       };
     }
 
@@ -56,7 +56,7 @@
       return {
         type: "Polygon",
         coordinates: [[[lon[0], lat[0]], [lon[0], lat[1]],
-          [lon[1], lat[1]], [lon[1], lat[0]], [lon[0], lat[0]]]]
+                       [lon[1], lat[1]], [lon[1], lat[0]], [lon[0], lat[0]]]]
       };
     }
 
@@ -69,123 +69,123 @@
     let withView;
     let view;
 
-  let keyCounter = 0;
+    let keyCounter = 0;
 
-  function waitForArangoSearch() {
-    let res = getQueryResults(
-      `FOR d IN ${viewName} OPTIONS { waitForSync:true } LIMIT 1 RETURN 1`);
-  }
-
-  function insertAll(x) {
-    for (let i = 0; i < x.length; ++i) {
-      x[i]._key = "K" + (++keyCounter);
+    function waitForArangoSearch() {
+      let res = getQueryResults(
+        `FOR d IN ${viewName} OPTIONS { waitForSync:true } LIMIT 1 RETURN 1`);
     }
-    noIndex.insert(x);
-    withIndex.insert(x);
-    withView.insert(x);
-  }
 
-  function truncateAll(x) {
-    noIndex.truncate();
-    withIndex.truncate();
-    withView.truncate();
-  }
-
-  function compareKeyLists(namea, a, nameb, b) {
-    let good = true;
-    let msg = "";
-    if (a.length !== b.length) {
-      good = false;
-      msg += "Different number of results " + namea + " (" + a.length +
-             ") and " + nameb + " (" + b.length + ").\n";
+    function insertAll(name, x) {
+      for (let i = 0; i < x.length; ++i) {
+        x[i]._key = "K" + (++keyCounter);
+      }
+      noIndex.insert(x);
+      withIndex.insert(x);
+      withView.insert(x);
     }
-    let i = 0;
-    let j = 0;
-    let count = 0;
-    while (i < a.length && j < b.length) {
-      if (a[i] < b[j]) {
+
+    function truncateAll(x) {
+      noIndex.truncate();
+      withIndex.truncate();
+      withView.truncate();
+    }
+
+    function compareKeyLists(namea, a, nameb, b) {
+      let good = true;
+      let msg = "";
+      if (a.length !== b.length) {
+        good = false;
+        msg += "Different number of results " + namea + " (" + a.length +
+          ") and " + nameb + " (" + b.length + ").\n";
+      }
+      let i = 0;
+      let j = 0;
+      let count = 0;
+      while (i < a.length && j < b.length) {
+        if (a[i] < b[j]) {
+          good = false;
+          msg += "Found key " + a[i] + " in '" + namea + "' but not in '"
+            + nameb + "'\n";
+          ++i;
+        } else if (a[i] > b[j]) {
+          good = false;
+          msg += "Found key " + b[j] + " in '" + nameb + "' but not in '"
+            + namea + "'\n";
+          ++j;
+        } else {
+          ++i;
+          ++j;
+        }
+        if (++count >= 10) {
+          return {good, msg};
+        }
+      }
+      while (i < a.length) {
         good = false;
         msg += "Found key " + a[i] + " in '" + namea + "' but not in '"
-               + nameb + "'\n";
+          + nameb + "'\n";
         ++i;
-      } else if (a[i] > b[j]) {
+        if (++count >= 10) {
+          return {good, msg};
+        }
+      }
+      while (j < b.length) {
         good = false;
         msg += "Found key " + b[j] + " in '" + nameb + "' but not in '"
-               + namea + "'\n";
+          + namea + "'\n";
         ++j;
-      } else {
-        ++i;
-        ++j;
+        if (++count >= 10) {
+          return {good, msg};
+        }
       }
-      if (++count >= 10) {
-        return {good, msg};
+      return {good, msg};
+    }
+
+    function compare(query, queryView) {
+      let fullScanQuery = `FOR d IN @@coll ${query} RETURN d._key`;
+      let viewQuery = `FOR d IN ${viewName} ${queryView} RETURN d._key`;
+      let invertedIndexQuery = `FOR d IN ${collWithIndex} OPTIONS {indexHint: "inverted", forceIndexHint: true, waitForSync: true} ${query} RETURN d._key`;
+
+      let resFullScanNoIndexes = getQueryResults(fullScanQuery, {"@coll": collWithoutIndex}).sort();
+      let resFullScanWithIndexes = getQueryResults(fullScanQuery, {"@coll": collWithIndex}).sort();
+      let resView = getQueryResults(viewQuery, {}).sort();
+      let resInvertedIndex = getQueryResults(invertedIndexQuery, {}).sort();
+
+      let cmpResFullScanWithIndexes = compareKeyLists("without index", resFullScanNoIndexes, "with index", resFullScanWithIndexes);
+      let cmpResView = compareKeyLists("without index", resFullScanNoIndexes, "with view", resView);
+      let cmpResInvertedIndex = compareKeyLists("without index", resFullScanNoIndexes, "with inverted index", resInvertedIndex);
+
+      // PLEASE UNCOMMENT LINES BELOW AFTER FIXING https://arangodb.atlassian.net/browse/BTS-1184
+
+      /*
+        let explanation = db._createStatement(invertedIndexQuery).explain().plan;
+        let utilizedIndexes = explanation.nodes.filter(node => node.type === 'IndexNode')[0].indexes;
+        assertEqual(utilizedIndexes.length, 1);
+        assertEqual(utilizedIndexes[0].name, "inverted");
+      */
+
+      if (!cmpResFullScanWithIndexes.good || !cmpResView.good || !cmpResInvertedIndex.good) {
+        print("Query for collections:", fullScanQuery);
+        print("Query for views:", viewQuery);
+        print("Query for collections with Inverted Index:", invertedIndexQuery);
+
+        print("Without index:", resFullScanNoIndexes.length);
+        print("With index:", resFullScanWithIndexes.length);
+        print("With view:", resView.length);
+        print("With Inverted Index:", resInvertedIndex.length);
+
+        print("Errors with index: ", cmpResFullScanWithIndexes.msg);
+        print("Errors with view: ", cmpResView.msg);
+        print("Errors with Inverted Index: ", cmpResInvertedIndex.msg);
       }
-    }
-    while (i < a.length) {
-      good = false;
-      msg += "Found key " + a[i] + " in '" + namea + "' but not in '"
-             + nameb + "'\n";
-      ++i;
-      if (++count >= 10) {
-        return {good, msg};
+
+      if (disableViewTests) {
+        cmpResView.good = true;   // fake goodness
+        cmpResInvertedIndex.good = true;   // fake goodness
       }
+      return {cmpResFullScanWithIndexes, cmpResView, cmpResInvertedIndex};
     }
-    while (j < b.length) {
-      good = false;
-      msg += "Found key " + b[j] + " in '" + nameb + "' but not in '"
-             + namea + "'\n";
-      ++j;
-      if (++count >= 10) {
-        return {good, msg};
-      }
-    }
-    return {good, msg};
-  }
-
-  function compare(query, queryView) {
-    let fullScanQuery = `FOR d IN @@coll ${query} RETURN d._key`;
-    let viewQuery = `FOR d IN ${viewName} ${queryView} RETURN d._key`;
-    let invertedIndexQuery = `FOR d IN ${collWithIndex} OPTIONS {indexHint: "inverted", forceIndexHint: true, waitForSync: true} ${query} RETURN d._key`;
-
-    let resFullScanNoIndexes = getQueryResults(fullScanQuery, {"@coll": collWithoutIndex}).sort();
-    let resFullScanWithIndexes = getQueryResults(fullScanQuery, {"@coll": collWithIndex}).sort();
-    let resView = getQueryResults(viewQuery, {}).sort();
-    let resInvertedIndex = getQueryResults(invertedIndexQuery, {}).sort();
-
-    let cmpResFullScanWithIndexes = compareKeyLists("without index", resFullScanNoIndexes, "with index", resFullScanWithIndexes);
-    let cmpResView = compareKeyLists("without index", resFullScanNoIndexes, "with view", resView);
-    let cmpResInvertedIndex = compareKeyLists("without index", resFullScanNoIndexes, "with inverted index", resInvertedIndex);
-
-    // PLEASE UNCOMMENT LINES BELOW AFTER FIXING https://arangodb.atlassian.net/browse/BTS-1184
-
-    /*
-    let explanation = db._createStatement(invertedIndexQuery).explain().plan;
-    let utilizedIndexes = explanation.nodes.filter(node => node.type === 'IndexNode')[0].indexes;
-    assertEqual(utilizedIndexes.length, 1);
-    assertEqual(utilizedIndexes[0].name, "inverted");
-    */
-
-    if (!cmpResFullScanWithIndexes.good || !cmpResView.good || !cmpResInvertedIndex.good) {
-      print("Query for collections:", fullScanQuery);
-      print("Query for views:", viewQuery);
-      print("Query for collections with Inverted Index:", invertedIndexQuery);
-
-      print("Without index:", resFullScanNoIndexes.length);
-      print("With index:", resFullScanWithIndexes.length);
-      print("With view:", resView.length);
-      print("With Inverted Index:", resInvertedIndex.length);
-
-      print("Errors with index: ", cmpResFullScanWithIndexes.msg);
-      print("Errors with view: ", cmpResView.msg);
-      print("Errors with Inverted Index: ", cmpResInvertedIndex.msg);
-    }
-
-    if (disableViewTests) {
-      cmpResView.good = true;   // fake goodness
-      cmpResInvertedIndex.good = true;   // fake goodness
-    }
-    return {cmpResFullScanWithIndexes, cmpResView, cmpResInvertedIndex};
-  }
 
     function createOnePolygon() {
       insertAll([{geo: { type: "Point", coordinates: [50, 50] } }]);
@@ -195,9 +195,9 @@
       // Centroid will be at approx. [7,10]
       insertAll([
         {geo:{type:"Polygon",
-         coordinates:[[[0,0],[10,10],[0,20],[9,10],[0,0]]]}},
+              coordinates:[[[0,0],[10,10],[0,20],[9,10],[0,0]]]}},
         {geo:{type:"Polygon",
-         coordinates:[[[0,0],[10,10],[0,20],[0,19],[9,10],[0,1],[0,0]]]}}
+              coordinates:[[[0,0],[10,10],[0,20],[0,19],[9,10],[0,1],[0,0]]]}}
       ]);
       waitForArangoSearch();
     }
@@ -220,20 +220,20 @@
         let points = [];
         for (let y = 0; y < 100; ++y) {
           points.push({ geo: { type: "Point",
-              coordinates: [lat + x/1000, long + y/1000] } });
+                               coordinates: [lat + x/1000, long + y/1000] } });
         }
         insertAll(points);
       }
       insertAll([{ geo: { "type": "Polygon", "coordinates": [
         [[ 37.614323, 55.705898 ],
-          [ 37.615825, 55.705898 ],
-          [ 37.615825, 55.70652  ],
-          [ 37.614323, 55.70652  ],
-          [ 37.614323, 55.705898 ]]
+         [ 37.615825, 55.705898 ],
+         [ 37.615825, 55.70652  ],
+         [ 37.614323, 55.70652  ],
+         [ 37.614323, 55.705898 ]]
       ]}}]);
       insertAll([{ geo: {"type": "LineString", "coordinates": [
         [ 6.537, 50.332 ], [ 6.537, 50.376 ]]
-      }}]);
+                        }}]);
       insertAll([{ geo: { "type": "MultiLineString", "coordinates": [
         [[ 6.537, 50.332 ], [ 6.537, 50.376 ]],
         [[ 6.621, 50.332 ], [ 6.621, 50.376 ]]
@@ -257,7 +257,7 @@
       waitForArangoSearch();
     }
     function createNearGrid() {
-    let l = [];
+      let l = [];
       for (let lat = 9; lat <= 21; lat += 0.1) {
         for (let lon = 9; lon <= 21; lon += 0.1) {
           l.push({geo:{type:"Point", coordinates:[lon, lat]}});
@@ -271,8 +271,8 @@
         insertAll(l);
       }
       waitForArangoSearch();
-  }
-  function createNarrowGrid() {
+    }
+    function createNarrowGrid() {
       let l = [];
       for (let size = 0.0001; size <= 10; size *= 10) {
         for (let lon = 14.8; lon <= 15.2; lon += 0.04) {
@@ -280,8 +280,8 @@
             geo: {
               type: "Polygon",
               coordinates: [[[lon - size, 10 - size], [lon + size, 10 - size],
-                [lon + size, 10 + size], [lon - size, 10 + size],
-                [lon - size, 10 - size]]]
+                             [lon + size, 10 + size], [lon - size, 10 + size],
+                             [lon - size, 10 - size]]]
             },
             centroid: {type: "Point", coordinates: [lon, 10]}
           });
@@ -295,8 +295,8 @@
         insertAll(l);
       }
       waitForArangoSearch();
-  }
-  function createNearSlidingObject() {
+    }
+    function createNearSlidingObject() {
       let l = [];
       for (let size = 1; size <= 11; size += 1) {
         for (let lon = 11; lon <= 30; lon += 0.1) {
@@ -304,8 +304,8 @@
             geo: {
               type: "Polygon",
               coordinates: [[[lon - size, 10 - size], [lon + size, 10 - size],
-                [lon + size, 10 + size], [lon - size, 10 + size],
-                [lon - size, 10 - size]]]
+                             [lon + size, 10 + size], [lon - size, 10 + size],
+                             [lon - size, 10 - size]]]
             },
             centroid: {type: "Point", coordinates: [lon, 10]}
           });
@@ -318,8 +318,8 @@
       if (l.length > 0) {
         insertAll(l);
       }
-    waitForArangoSearch();
-  }
+      waitForArangoSearch();
+    }
     function createLargeGrid() {
       let l = [];
       for (let lat = 45; lat <= 55; lat += 1) {
@@ -380,604 +380,604 @@
       if (l.length > 0) {
         insertAll(l);
       }
-    waitForArangoSearch();
-  }
-  return {
+      waitForArangoSearch();
+    }
+    return {
 
-////////////////////////////////////////////////////////////////////////////////
-/// @brief set up all
-////////////////////////////////////////////////////////////////////////////////
+      ////////////////////////////////////////////////////////////////////////////////
+      /// @brief set up all
+      ////////////////////////////////////////////////////////////////////////////////
 
-    setUpAll: function () {
-      db._dropView(viewName);
-      db._drop(collWithoutIndex);
-      db._drop(collWithIndex);
-      db._drop(collWithView);
+      setUpAll: function () {
+        db._dropView(viewName);
+        db._drop(collWithoutIndex);
+        db._drop(collWithIndex);
+        db._drop(collWithView);
 
-      noIndex = db._create(collWithoutIndex);
-      withIndex = db._create(collWithIndex);
-      withIndex.ensureIndex({type: "geo", geoJson: true, fields: ["geo"]});
-      withView = db._create(collWithView);
-      let analyzers = require("@arangodb/analyzers");
-      analyzers.save("geo_json", analyzerType, analyzerDefinition, ["frequency", "norm", "position"]);
+        noIndex = db._create(collWithoutIndex);
+        withIndex = db._create(collWithIndex);
+        withIndex.ensureIndex({type: "geo", geoJson: true, fields: ["geo"]});
+        withView = db._create(collWithView);
+        let analyzers = require("@arangodb/analyzers");
+        analyzers.save("geo_json", analyzerType, analyzerDefinition, ["frequency", "norm", "position"]);
 
-      withIndex.save({ name_1: "name", "value": [{ "nested_1": [{ "nested_2": "foo123"}]}]});
-      withView.save({ name_1: "name", "value": [{ "nested_1": [{ "nested_2": "foo123"}]}]});
+        withIndex.save({ name_1: "name", "value": [{ "nested_1": [{ "nested_2": "foo123"}]}]});
+        withView.save({ name_1: "name", "value": [{ "nested_1": [{ "nested_2": "foo123"}]}]});
 
-      // ensure inverted indexes for each collections
+        // ensure inverted indexes for each collections
 
-      let commonInvertedIndexMeta = {};
-      if (isEnterprise) {
-        commonInvertedIndexMeta = {type: "inverted", name: "inverted", includeAllFields: true, fields:[
-          {"name": "value", "nested": [{"name": "nested_1", "nested": [{"name": "nested_2"}]}]},
-          "name_1",
-          {"name": "geo", "analyzer": "geo_json"}
-        ]};
-      } else {
-        commonInvertedIndexMeta = {type: "inverted", name: "inverted", includeAllFields: true, fields:[
-          {"name": "value[*]"},
-          "name_1",
-          {"name": "geo", "analyzer": "geo_json"}
-        ]};
-      }
-      withView.ensureIndex(commonInvertedIndexMeta);
-      withIndex.ensureIndex(commonInvertedIndexMeta);
-
-      if (isSearchAlias) {
-        let indexMeta = {};
+        let commonInvertedIndexMeta = {};
         if (isEnterprise) {
-          indexMeta = {type: "inverted", fields: [
-            {name: "geo", analyzer: "geo_json"},
-            {"name": "value", "nested": [{"name": "nested_1", "nested": [{"name": "nested_2"}]}]}]
-          };
+          commonInvertedIndexMeta = {type: "inverted", name: "inverted", includeAllFields: true, fields:[
+            {"name": "value", "nested": [{"name": "nested_1", "nested": [{"name": "nested_2"}]}]},
+            "name_1",
+            {"name": "geo", "analyzer": "geo_json"}
+          ]};
         } else {
-          indexMeta = {type: "inverted", fields: [
-            {name: "geo", analyzer: "geo_json"},
-            {"name": "value[*]"}]
-          };
+          commonInvertedIndexMeta = {type: "inverted", name: "inverted", includeAllFields: true, fields:[
+            {"name": "value[*]"},
+            "name_1",
+            {"name": "geo", "analyzer": "geo_json"}
+          ]};
         }
-        let i = db.UnitTestsGeoWithView.ensureIndex(indexMeta);
-        view = db._createView(viewName, "search-alias", {
-          indexes: [{collection: "UnitTestsGeoWithView", index: i.name}]
-        });
-      } else {
-        let meta = {};
-        if (isEnterprise) {
-          meta = {
-            links: {
-              UnitTestsGeoWithView: {
-                fields: {geo: {analyzers: ["geo_json"]}, "value": { "nested": { "nested_1": {"nested": {"nested_2": {}}}}}}
-              }
-            }
-          };
+        withView.ensureIndex(commonInvertedIndexMeta);
+        withIndex.ensureIndex(commonInvertedIndexMeta);
+
+        if (isSearchAlias) {
+          let indexMeta = {};
+          if (isEnterprise) {
+            indexMeta = {type: "inverted", fields: [
+              {name: "geo", analyzer: "geo_json"},
+              {"name": "value", "nested": [{"name": "nested_1", "nested": [{"name": "nested_2"}]}]}]
+                        };
+          } else {
+            indexMeta = {type: "inverted", fields: [
+              {name: "geo", analyzer: "geo_json"},
+              {"name": "value[*]"}]
+                        };
+          }
+          let i = db.UnitTestsGeoWithView.ensureIndex(indexMeta);
+          view = db._createView(viewName, "search-alias", {
+            indexes: [{collection: "UnitTestsGeoWithView", index: i.name}]
+          });
         } else {
-          meta = {
-            links: {
-              UnitTestsGeoWithView: {
-                fields: {geo: {analyzers: ["geo_json"]}}
+          let meta = {};
+          if (isEnterprise) {
+            meta = {
+              links: {
+                UnitTestsGeoWithView: {
+                  fields: {geo: {analyzers: ["geo_json"]}, "value": { "nested": { "nested_1": {"nested": {"nested_2": {}}}}}}
+                }
               }
-            }
-          };
+            };
+          } else {
+            meta = {
+              links: {
+                UnitTestsGeoWithView: {
+                  fields: {geo: {analyzers: ["geo_json"]}}
+                }
+              }
+            };
+          }
+          view = db._createView(viewName, "arangosearch", meta);
         }
-        view = db._createView(viewName, "arangosearch", meta);
-      }
-    },
+      },
 
-////////////////////////////////////////////////////////////////////////////////
-/// @brief tear down all
-////////////////////////////////////////////////////////////////////////////////
+      ////////////////////////////////////////////////////////////////////////////////
+      /// @brief tear down all
+      ////////////////////////////////////////////////////////////////////////////////
 
-    tearDownAll: function () {
-      db._dropView(viewName);
-      db._drop(collWithoutIndex);
-      db._drop(collWithIndex);
-      db._drop(collWithView);
-      let analyzers = require("@arangodb/analyzers");
-      analyzers.remove("geo_json");
-    },
+      tearDownAll: function () {
+        db._dropView(viewName);
+        db._drop(collWithoutIndex);
+        db._drop(collWithIndex);
+        db._drop(collWithView);
+        let analyzers = require("@arangodb/analyzers");
+        analyzers.remove("geo_json");
+      },
 
-////////////////////////////////////////////////////////////////////////////////
-/// @brief tear down
-////////////////////////////////////////////////////////////////////////////////
+      ////////////////////////////////////////////////////////////////////////////////
+      /// @brief tear down
+      ////////////////////////////////////////////////////////////////////////////////
 
-    tearDown: function () {
-      truncateAll();
-    },
+      tearDown: function () {
+        truncateAll();
+      },
 
-////////////////////////////////////////////////////////////////////////////////
-/// @brief test single point
-////////////////////////////////////////////////////////////////////////////////
+      ////////////////////////////////////////////////////////////////////////////////
+      /// @brief test single point
+      ////////////////////////////////////////////////////////////////////////////////
 
-    testSetup : function () {
-      createOnePolygon();
-      let c = compare(
-        `FILTER GEO_DISTANCE([50, 50], d.geo) < 5000`,
-        `SEARCH ANALYZER(GEO_DISTANCE([50, 50], d.geo) < 5000, "geo_json")`
-      );
-      assertTrue(c.cmpResFullScanWithIndexes.good && c.cmpResView.good && c.cmpResInvertedIndex.good, c.cmpResFullScanWithIndexes.msg + c.cmpResView.msg + c.cmpResInvertedIndex.msg);
-    },
-
-////////////////////////////////////////////////////////////////////////////////
-/// @brief test point near centroid of polygon
-////////////////////////////////////////////////////////////////////////////////
-
-    testPointNearCentroidOfPolygon : function () {
-      createThreePolygons();
-      let c = compare(
-        `FILTER GEO_DISTANCE([15, 15], d.geo) <= 5000`,
-        `SEARCH ANALYZER(GEO_DISTANCE([15, 15], d.geo) <= 5000, "geo_json")`
-      );
-      assertTrue(c.cmpResFullScanWithIndexes.good && c.cmpResView.good && c.cmpResInvertedIndex.good, c.cmpResFullScanWithIndexes.msg + c.cmpResView.msg + c.cmpResInvertedIndex.msg);
-    },
-
-////////////////////////////////////////////////////////////////////////////////
-/// @brief test near query with grid of points, upper bound
-////////////////////////////////////////////////////////////////////////////////
-
-    testNearGrid : function () {
-      createNearGrid();
-      let c = compare(
-        `FILTER GEO_DISTANCE([15, 15], d.geo) <= 666666`,
-        `SEARCH ANALYZER(GEO_DISTANCE([15, 15], d.geo) <= 666666, "geo_json")`
-      );
-      assertTrue(c.cmpResFullScanWithIndexes.good && c.cmpResView.good && c.cmpResInvertedIndex.good, c.cmpResFullScanWithIndexes.msg + c.cmpResView.msg + c.cmpResInvertedIndex.msg);
-    },
-
-////////////////////////////////////////////////////////////////////////////////
-/// @brief test near query with grid of points, upper and lower bound
-////////////////////////////////////////////////////////////////////////////////
-
-    testNearGridRingArea : function () {
-      createNearGrid();
-      let c = compare(
-        `FILTER GEO_DISTANCE([15, 15], d.geo) <= 666666 &&
-                GEO_DISTANCE([15, 15], d.geo) >= 300000`,
-        `SEARCH ANALYZER(GEO_DISTANCE([15, 15], d.geo) <= 666666 &&
-                         GEO_DISTANCE([15, 15], d.geo) >= 300000, "geo_json")`
-      );
-      assertTrue(c.cmpResFullScanWithIndexes.good && c.cmpResView.good && c.cmpResInvertedIndex.good, c.cmpResFullScanWithIndexes.msg + c.cmpResView.msg + c.cmpResInvertedIndex.msg);
-    },
-
-////////////////////////////////////////////////////////////////////////////////
-/// @brief test near query with grid of points, only lower bound
-////////////////////////////////////////////////////////////////////////////////
-
-    testNearGridOuterArea : function () {
-      createNearGrid();
-      let c = compare(
-        `FILTER GEO_DISTANCE([15, 15], d.geo) >= 300000`,
-        `SEARCH ANALYZER(GEO_DISTANCE([15, 15], d.geo) >= 300000, "geo_json")`
-      );
-      assertTrue(c.cmpResFullScanWithIndexes.good && c.cmpResView.good && c.cmpResInvertedIndex.good, c.cmpResFullScanWithIndexes.msg + c.cmpResView.msg + c.cmpResInvertedIndex.msg);
-    },
-
-////////////////////////////////////////////////////////////////////////////////
-/// @brief test near query with grid of points, upper bound, descending
-////////////////////////////////////////////////////////////////////////////////
-
-    testNearGridDescending : function () {
-      createNearGrid();
-      let c = compare(
-        `FILTER GEO_DISTANCE([15, 15], d.geo) <= 666666
-         SORT GEO_DISTANCE([15, 15], d.geo) DESC`,
-        `SEARCH ANALYZER(GEO_DISTANCE([15, 15], d.geo) <= 666666, "geo_json")
-         SORT GEO_DISTANCE([15, 15], d.geo) DESC`
-      );
-      assertTrue(c.cmpResFullScanWithIndexes.good && c.cmpResView.good && c.cmpResInvertedIndex.good, c.cmpResFullScanWithIndexes.msg + c.cmpResView.msg + c.cmpResInvertedIndex.msg);
-    },
-
-////////////////////////////////////////////////////////////////////////////////
-/// @brief test near query with grid of points, upper and lower bound, desc
-////////////////////////////////////////////////////////////////////////////////
-
-    testNearGridRingAreaDescending : function () {
-      createNearGrid();
-      let c = compare(
-        `FILTER GEO_DISTANCE([15, 15], d.geo) <= 666666 &&
-                GEO_DISTANCE([15, 15], d.geo) >= 300000
-         SORT GEO_DISTANCE([15, 15], d.geo) DESC`,
-        `SEARCH ANALYZER(GEO_DISTANCE([15, 15], d.geo) <= 666666 &&
-                         GEO_DISTANCE([15, 15], d.geo) >= 300000, "geo_json")
-         SORT GEO_DISTANCE([15, 15], d.geo) DESC`
-      );
-      assertTrue(c.cmpResFullScanWithIndexes.good && c.cmpResView.good && c.cmpResInvertedIndex.good, c.cmpResFullScanWithIndexes.msg + c.cmpResView.msg + c.cmpResInvertedIndex.msg);
-    },
-
-////////////////////////////////////////////////////////////////////////////////
-/// @brief test near query with grid of points, only lower bound, descending
-////////////////////////////////////////////////////////////////////////////////
-
-    testNearGridOuterAreaDescending : function () {
-      createNearGrid();
-      let c = compare(
-        `FILTER GEO_DISTANCE([15, 15], d.geo) >= 300000`,
-        `SEARCH ANALYZER(GEO_DISTANCE([15, 15], d.geo) >= 300000, "geo_json")`
-      );
-      assertTrue(c.cmpResFullScanWithIndexes.good && c.cmpResView.good && c.cmpResInvertedIndex.good, c.cmpResFullScanWithIndexes.msg + c.cmpResView.msg + c.cmpResInvertedIndex.msg);
-    },
-
-////////////////////////////////////////////////////////////////////////////////
-/// @brief test near query with objects of different sizes
-////////////////////////////////////////////////////////////////////////////////
-
-    testNearObjectsSizes : function () {
-      createNarrowGrid();
-      let c = compare(
-        `FILTER GEO_DISTANCE([10, 10], d.geo) <= 555974`,
-        `SEARCH ANALYZER(GEO_DISTANCE([10, 10], d.geo) <= 555974, "geo_json")`
-      );
-      assertTrue(c.cmpResFullScanWithIndexes.good && c.cmpResView.good && c.cmpResInvertedIndex.good, c.cmpResFullScanWithIndexes.msg + c.cmpResView.msg + c.cmpResInvertedIndex.msg);
-    },
-
-////////////////////////////////////////////////////////////////////////////////
-/// @brief test near query with large objects different distance
-////////////////////////////////////////////////////////////////////////////////
-
-    testNearSlidingLargeObject : function () {
-      createNearSlidingObject();
-      let c = compare(
-        `FILTER GEO_DISTANCE([10, 10], d.geo) <= 555974`,
-        `SEARCH ANALYZER(GEO_DISTANCE([10, 10], d.geo) <= 555974, "geo_json")`
-      );
-      assertTrue(c.cmpResFullScanWithIndexes.good && c.cmpResView.good && c.cmpResInvertedIndex.good, c.cmpResFullScanWithIndexes.msg + c.cmpResView.msg + c.cmpResInvertedIndex.msg);
-    },
-
-////////////////////////////////////////////////////////////////////////////////
-/// @brief test near query with large non-convex object whose centroid
-/// is not contained in the object.
-////////////////////////////////////////////////////////////////////////////////
-
-    testNearNonConvexObject : function () {
-      createTwoPolygons
-      for (let dist = 1000; dist <= 100000; dist += 100) {
-        //print("Distance", dist);
+      testSetup : function () {
+        createOnePolygon();
         let c = compare(
-          `FILTER GEO_DISTANCE([4.7874, 10.0735], d.geo) <= ${dist}`,
-          `SEARCH ANALYZER(GEO_DISTANCE([4.7874, 10.0735], d.geo) <= ${dist}, "geo_json")`
+          `FILTER GEO_DISTANCE([50, 50], d.geo) < 5000`,
+          `SEARCH ANALYZER(GEO_DISTANCE([50, 50], d.geo) < 5000, "geo_json")`
         );
         assertTrue(c.cmpResFullScanWithIndexes.good && c.cmpResView.good && c.cmpResInvertedIndex.good, c.cmpResFullScanWithIndexes.msg + c.cmpResView.msg + c.cmpResInvertedIndex.msg);
-      }
-    },
+      },
 
-////////////////////////////////////////////////////////////////////////////////
-/// @brief test contains query with a polygon, move polygon over grip
-////////////////////////////////////////////////////////////////////////////////
+      ////////////////////////////////////////////////////////////////////////////////
+      /// @brief test point near centroid of polygon
+      ////////////////////////////////////////////////////////////////////////////////
 
-    testContainsWithSmallPoly : function () {
-      createNearGrid();
-      let d = 0.001;
-      for (let lat = 9; lat <= 11; lat += 0.4) {
-        for (let lon = 9; lon <= 11; lon += 0.4) {
-          let p = {type:"Polygon", coordinates:[[[lon-d, lat-d],
-            [lon+d, lat-d], [lon+d, lat+d], [lon-d, lat+d], [lon-d, lat-d]]]};
-          //print("Polygon:", JSON.stringify(p));
+      testPointNearCentroidOfPolygon : function () {
+        createThreePolygons();
+        let c = compare(
+          `FILTER GEO_DISTANCE([15, 15], d.geo) <= 5000`,
+          `SEARCH ANALYZER(GEO_DISTANCE([15, 15], d.geo) <= 5000, "geo_json")`
+        );
+        assertTrue(c.cmpResFullScanWithIndexes.good && c.cmpResView.good && c.cmpResInvertedIndex.good, c.cmpResFullScanWithIndexes.msg + c.cmpResView.msg + c.cmpResInvertedIndex.msg);
+      },
+
+      ////////////////////////////////////////////////////////////////////////////////
+      /// @brief test near query with grid of points, upper bound
+      ////////////////////////////////////////////////////////////////////////////////
+
+      testNearGrid : function () {
+        createNearGrid();
+        let c = compare(
+          `FILTER GEO_DISTANCE([15, 15], d.geo) <= 666666`,
+          `SEARCH ANALYZER(GEO_DISTANCE([15, 15], d.geo) <= 666666, "geo_json")`
+        );
+        assertTrue(c.cmpResFullScanWithIndexes.good && c.cmpResView.good && c.cmpResInvertedIndex.good, c.cmpResFullScanWithIndexes.msg + c.cmpResView.msg + c.cmpResInvertedIndex.msg);
+      },
+
+      ////////////////////////////////////////////////////////////////////////////////
+      /// @brief test near query with grid of points, upper and lower bound
+      ////////////////////////////////////////////////////////////////////////////////
+
+      testNearGridRingArea : function () {
+        createNearGrid();
+        let c = compare(
+          `FILTER GEO_DISTANCE([15, 15], d.geo) <= 666666 &&
+                GEO_DISTANCE([15, 15], d.geo) >= 300000`,
+          `SEARCH ANALYZER(GEO_DISTANCE([15, 15], d.geo) <= 666666 &&
+                         GEO_DISTANCE([15, 15], d.geo) >= 300000, "geo_json")`
+        );
+        assertTrue(c.cmpResFullScanWithIndexes.good && c.cmpResView.good && c.cmpResInvertedIndex.good, c.cmpResFullScanWithIndexes.msg + c.cmpResView.msg + c.cmpResInvertedIndex.msg);
+      },
+
+      ////////////////////////////////////////////////////////////////////////////////
+      /// @brief test near query with grid of points, only lower bound
+      ////////////////////////////////////////////////////////////////////////////////
+
+      testNearGridOuterArea : function () {
+        createNearGrid();
+        let c = compare(
+          `FILTER GEO_DISTANCE([15, 15], d.geo) >= 300000`,
+          `SEARCH ANALYZER(GEO_DISTANCE([15, 15], d.geo) >= 300000, "geo_json")`
+        );
+        assertTrue(c.cmpResFullScanWithIndexes.good && c.cmpResView.good && c.cmpResInvertedIndex.good, c.cmpResFullScanWithIndexes.msg + c.cmpResView.msg + c.cmpResInvertedIndex.msg);
+      },
+
+      ////////////////////////////////////////////////////////////////////////////////
+      /// @brief test near query with grid of points, upper bound, descending
+      ////////////////////////////////////////////////////////////////////////////////
+
+      testNearGridDescending : function () {
+        createNearGrid();
+        let c = compare(
+          `FILTER GEO_DISTANCE([15, 15], d.geo) <= 666666
+         SORT GEO_DISTANCE([15, 15], d.geo) DESC`,
+          `SEARCH ANALYZER(GEO_DISTANCE([15, 15], d.geo) <= 666666, "geo_json")
+         SORT GEO_DISTANCE([15, 15], d.geo) DESC`
+        );
+        assertTrue(c.cmpResFullScanWithIndexes.good && c.cmpResView.good && c.cmpResInvertedIndex.good, c.cmpResFullScanWithIndexes.msg + c.cmpResView.msg + c.cmpResInvertedIndex.msg);
+      },
+
+      ////////////////////////////////////////////////////////////////////////////////
+      /// @brief test near query with grid of points, upper and lower bound, desc
+      ////////////////////////////////////////////////////////////////////////////////
+
+      testNearGridRingAreaDescending : function () {
+        createNearGrid();
+        let c = compare(
+          `FILTER GEO_DISTANCE([15, 15], d.geo) <= 666666 &&
+                GEO_DISTANCE([15, 15], d.geo) >= 300000
+         SORT GEO_DISTANCE([15, 15], d.geo) DESC`,
+          `SEARCH ANALYZER(GEO_DISTANCE([15, 15], d.geo) <= 666666 &&
+                         GEO_DISTANCE([15, 15], d.geo) >= 300000, "geo_json")
+         SORT GEO_DISTANCE([15, 15], d.geo) DESC`
+        );
+        assertTrue(c.cmpResFullScanWithIndexes.good && c.cmpResView.good && c.cmpResInvertedIndex.good, c.cmpResFullScanWithIndexes.msg + c.cmpResView.msg + c.cmpResInvertedIndex.msg);
+      },
+
+      ////////////////////////////////////////////////////////////////////////////////
+      /// @brief test near query with grid of points, only lower bound, descending
+      ////////////////////////////////////////////////////////////////////////////////
+
+      testNearGridOuterAreaDescending : function () {
+        createNearGrid();
+        let c = compare(
+          `FILTER GEO_DISTANCE([15, 15], d.geo) >= 300000`,
+          `SEARCH ANALYZER(GEO_DISTANCE([15, 15], d.geo) >= 300000, "geo_json")`
+        );
+        assertTrue(c.cmpResFullScanWithIndexes.good && c.cmpResView.good && c.cmpResInvertedIndex.good, c.cmpResFullScanWithIndexes.msg + c.cmpResView.msg + c.cmpResInvertedIndex.msg);
+      },
+
+      ////////////////////////////////////////////////////////////////////////////////
+      /// @brief test near query with objects of different sizes
+      ////////////////////////////////////////////////////////////////////////////////
+
+      testNearObjectsSizes : function () {
+        createNarrowGrid();
+        let c = compare(
+          `FILTER GEO_DISTANCE([10, 10], d.geo) <= 555974`,
+          `SEARCH ANALYZER(GEO_DISTANCE([10, 10], d.geo) <= 555974, "geo_json")`
+        );
+        assertTrue(c.cmpResFullScanWithIndexes.good && c.cmpResView.good && c.cmpResInvertedIndex.good, c.cmpResFullScanWithIndexes.msg + c.cmpResView.msg + c.cmpResInvertedIndex.msg);
+      },
+
+      ////////////////////////////////////////////////////////////////////////////////
+      /// @brief test near query with large objects different distance
+      ////////////////////////////////////////////////////////////////////////////////
+
+      testNearSlidingLargeObject : function () {
+        createNearSlidingObject();
+        let c = compare(
+          `FILTER GEO_DISTANCE([10, 10], d.geo) <= 555974`,
+          `SEARCH ANALYZER(GEO_DISTANCE([10, 10], d.geo) <= 555974, "geo_json")`
+        );
+        assertTrue(c.cmpResFullScanWithIndexes.good && c.cmpResView.good && c.cmpResInvertedIndex.good, c.cmpResFullScanWithIndexes.msg + c.cmpResView.msg + c.cmpResInvertedIndex.msg);
+      },
+
+      ////////////////////////////////////////////////////////////////////////////////
+      /// @brief test near query with large non-convex object whose centroid
+      /// is not contained in the object.
+      ////////////////////////////////////////////////////////////////////////////////
+
+      testNearNonConvexObject : function () {
+        createTwoPolygons
+        for (let dist = 1000; dist <= 100000; dist += 100) {
+          //print("Distance", dist);
+          let c = compare(
+            `FILTER GEO_DISTANCE([4.7874, 10.0735], d.geo) <= ${dist}`,
+            `SEARCH ANALYZER(GEO_DISTANCE([4.7874, 10.0735], d.geo) <= ${dist}, "geo_json")`
+          );
+          assertTrue(c.cmpResFullScanWithIndexes.good && c.cmpResView.good && c.cmpResInvertedIndex.good, c.cmpResFullScanWithIndexes.msg + c.cmpResView.msg + c.cmpResInvertedIndex.msg);
+        }
+      },
+
+      ////////////////////////////////////////////////////////////////////////////////
+      /// @brief test contains query with a polygon, move polygon over grip
+      ////////////////////////////////////////////////////////////////////////////////
+
+      testContainsWithSmallPoly : function () {
+        createNearGrid();
+        let d = 0.001;
+        for (let lat = 9; lat <= 11; lat += 0.4) {
+          for (let lon = 9; lon <= 11; lon += 0.4) {
+            let p = {type:"Polygon", coordinates:[[[lon-d, lat-d],
+                                                   [lon+d, lat-d], [lon+d, lat+d], [lon-d, lat+d], [lon-d, lat-d]]]};
+            //print("Polygon:", JSON.stringify(p));
+            let c = compare(
+              `FILTER GEO_CONTAINS(${JSON.stringify(p)}, d.geo)`,
+              `SEARCH ANALYZER(GEO_CONTAINS(${JSON.stringify(p)}, d.geo), "geo_json")`
+            );
+            assertTrue(c.cmpResFullScanWithIndexes.good && c.cmpResView.good && c.cmpResInvertedIndex.good, c.cmpResFullScanWithIndexes.msg + c.cmpResView.msg + c.cmpResInvertedIndex.msg);
+          }
+        }
+      },
+
+      ////////////////////////////////////////////////////////////////////////////////
+      /// @brief test contains query with a large polygon and a point grid
+      ////////////////////////////////////////////////////////////////////////////////
+
+      testContainsGrid : function () {
+        createNearGrid();
+        for (let d = 1; d <= 5; d += 1) {
+          let p = {
+            type: "Polygon", coordinates: [[[15 - d, 15], [15, 15 - d], [15 + d, 15],
+                                            [15, 15 + d], [15 - d, 15]]]
+          };
+          //print("d=", d, JSON.stringify(p));
+          let c = compare(
+            `FILTER GEO_CONTAINS(${JSON.stringify(p)}, d.geo)`,
+            `SEARCH ANALYZER(GEO_CONTAINS(${JSON.stringify(p)}, d.geo), "geo_json")`
+          );
+          if (!isInt) {
+            assertTrue(c.cmpResFullScanWithIndexes.good && c.cmpResView.good && c.cmpResInvertedIndex.good, c.cmpResFullScanWithIndexes.msg + c.cmpResView.msg + c.cmpResInvertedIndex.msg);
+          }
+        }
+      },
+
+      ////////////////////////////////////////////////////////////////////////////////
+      /// @brief test contains query with a complement of a large polygon and a 
+      /// point grid
+      ////////////////////////////////////////////////////////////////////////////////
+
+      testContainsGridComplement : function () {
+        createNearGrid();
+        for (let d = 1; d <= 5; d += 1) {
+          let p = {
+            type: "Polygon", coordinates: [[[15 - d, 15], [15, 15 + d], [15 + d, 15],
+                                            [15, 15 - d], [15 - d, 15]]]
+          };
+          //print("d=", d, JSON.stringify(p));
+          let c = compare(
+            `FILTER GEO_CONTAINS(${JSON.stringify(p)}, d.geo)`,
+            `SEARCH ANALYZER(GEO_CONTAINS(${JSON.stringify(p)}, d.geo), "geo_json")`
+          );
+          if (!isInt) {
+            assertTrue(c.cmpResFullScanWithIndexes.good && c.cmpResView.good && c.cmpResInvertedIndex.good, c.cmpResFullScanWithIndexes.msg + c.cmpResView.msg + c.cmpResInvertedIndex.msg);
+          }
+        }
+      },
+
+      ////////////////////////////////////////////////////////////////////////////////
+      /// @brief test intersects query with a polygon, move polygon over grip
+      ////////////////////////////////////////////////////////////////////////////////
+
+      testIntersectsWithSmallPoly : function () {
+        createNearGrid();
+        let d = 0.001;
+        for (let lat = 9; lat <= 11; lat += 0.4) {
+          for (let lon = 9; lon <= 11; lon += 0.4) {
+            let p = {type:"Polygon", coordinates:[[[lon-d, lat-d],
+                                                   [lon+d, lat-d], [lon+d, lat+d], [lon-d, lat+d], [lon-d, lat-d]]]};
+            //print("Polygon:", JSON.stringify(p));
+            let c = compare(
+              `FILTER GEO_INTERSECTS(${JSON.stringify(p)}, d.geo)`,
+              `SEARCH ANALYZER(GEO_INTERSECTS(${JSON.stringify(p)}, d.geo), "geo_json")`
+            );
+            assertTrue(c.cmpResFullScanWithIndexes.good && c.cmpResView.good && c.cmpResInvertedIndex.good, c.cmpResFullScanWithIndexes.msg + c.cmpResView.msg + c.cmpResInvertedIndex.msg);
+          }
+        }
+      },
+
+      ////////////////////////////////////////////////////////////////////////////////
+      /// @brief test intersects query with a large polygon and a point grid
+      ////////////////////////////////////////////////////////////////////////////////
+
+      testIntersectsGrid : function () {
+        createNearGrid();
+        for (let d = 1; d <= 5; d += 1) {
+          let p = {
+            type: "Polygon", coordinates: [[[15 - d, 15], [15, 15 - d], [15 + d, 15],
+                                            [15, 15 + d], [15 - d, 15]]]
+          };
+          //print("d=", d, JSON.stringify(p));
+          let c = compare(
+            `FILTER GEO_INTERSECTS(${JSON.stringify(p)}, d.geo)`,
+            `SEARCH ANALYZER(GEO_INTERSECTS(${JSON.stringify(p)}, d.geo), "geo_json")`
+          );
+          if (!isInt) {
+            assertTrue(c.cmpResFullScanWithIndexes.good && c.cmpResView.good && c.cmpResInvertedIndex.good, c.cmpResFullScanWithIndexes.msg + c.cmpResView.msg + c.cmpResInvertedIndex.msg);
+          }
+        }
+      },
+
+      ////////////////////////////////////////////////////////////////////////////////
+      /// @brief test intersects query with a complement of a large polygon and a 
+      /// point grid
+      ////////////////////////////////////////////////////////////////////////////////
+
+      testIntersectsGridComplement : function () {
+        createNearGrid();
+        for (let d = 1; d <= 5; d += 1) {
+          let p = {
+            type: "Polygon", coordinates: [[[15 - d, 15], [15, 15 + d], [15 + d, 15],
+                                            [15, 15 - d], [15 - d, 15]]]
+          };
+          //print("d=", d, JSON.stringify(p));
+          let c = compare(
+            `FILTER GEO_INTERSECTS(${JSON.stringify(p)}, d.geo)`,
+            `SEARCH ANALYZER(GEO_INTERSECTS(${JSON.stringify(p)}, d.geo), "geo_json")`
+          );
+          if (!isInt) {
+            assertTrue(c.cmpResFullScanWithIndexes.good && c.cmpResView.good && c.cmpResInvertedIndex.good, c.cmpResFullScanWithIndexes.msg + c.cmpResView.msg + c.cmpResInvertedIndex.msg);
+          }
+        }
+      },
+
+      ////////////////////////////////////////////////////////////////////////////////
+      /// @brief test intersects query with large non-convex object whose centroid
+      /// is not contained in the object.
+      ////////////////////////////////////////////////////////////////////////////////
+
+      testIntersectsNonConvexObject : function () {
+        createTwoPolygons();
+        let smallPoly = {type:"Polygon",
+                         coordinates:[[[4.7873, 10.0734], [4.7875, 10.0734], [4.7875, 10.0736],
+                                       [4.7873, 10.0736], [4.7873, 10.0734]]]};
+        let c = compare(
+          `FILTER GEO_INTERSECTS(${JSON.stringify(smallPoly)}, d.geo)`,
+          `SEARCH ANALYZER(GEO_INTERSECTS(${JSON.stringify(smallPoly)}, d.geo), "geo_json")`
+        );
+        assertTrue(c.cmpResFullScanWithIndexes.good && c.cmpResView.good && c.cmpResInvertedIndex.good, c.cmpResFullScanWithIndexes.msg + c.cmpResView.msg + c.cmpResInvertedIndex.msg);
+      },
+
+      ////////////////////////////////////////////////////////////////////////////////
+      /// @brief test some areas which are more than half of the earth
+      ////////////////////////////////////////////////////////////////////////////////
+
+      testMoreThanHalf1Grid: function () {
+        createLargeGrid();
+        let polys = [
+          makePolyInside([-85, 95], [-80, 50]),
+          makePolyOutside([-85, 95], [-80, 50]),
+          makePolyInside([-85, 85], [-80, 50]),
+          makePolyOutside([-85, 85], [-80, 50]),
+          makePolyInside([-85, 95], [-80, 40]),
+          makePolyOutside([-85, 95], [-80, 40]),
+          makePolyInside([-85, 85], [-80, 40]),
+          makePolyOutside([-85, 85], [-80, 40]),
+          makePolyInside([-85, 105], [-80, 60]),
+          makePolyOutside([-85, 105], [-80, 60]),
+          makePolyInside([170, -10], [-80, 60]),
+          makePolyOutside([170, -10], [-80, 60]),
+          makePolyInside([170, -10], [-80, 50]),
+          makePolyOutside([170, -10], [-80, 50]),
+        ];
+        for (let p of polys) {
+          let c = compare(
+            `FILTER GEO_CONTAINS(${JSON.stringify(p)}, d.geo)`,
+            `SEARCH ANALYZER(GEO_CONTAINS(${JSON.stringify(p)}, d.geo), "geo_json")`
+          );
+          if (!isInt) {
+            assertTrue(c.cmpResFullScanWithIndexes.good && c.cmpResView.good && c.cmpResInvertedIndex.good, c.cmpResFullScanWithIndexes.msg + c.cmpResView.msg + c.cmpResInvertedIndex.msg);
+          }
+        }
+      },
+
+      ////////////////////////////////////////////////////////////////////////////////
+      /// @brief test some areas which are more than half of the earth, around
+      /// date wrap
+      ////////////////////////////////////////////////////////////////////////////////
+
+      testMoreThanHalf2 : function () {
+        createSuperLargeGrid();
+        let polys = [
+          makePolyInside([-85, 95], [-80, 50]),
+          makePolyOutside([-85, 95], [-80, 50]),
+          makePolyInside([-85, 85], [-80, 50]),
+          makePolyOutside([-85, 85], [-80, 50]),
+          makePolyInside([-85, 95], [-80, 40]),
+          makePolyOutside([-85, 95], [-80, 40]),
+          makePolyInside([-85, 85], [-80, 40]),
+          makePolyOutside([-85, 85], [-80, 40]),
+          makePolyInside([-85, 105], [-80, 60]),
+          makePolyOutside([-85, 105], [-80, 60]),
+          makePolyInside([170, -10], [-80, 60]),
+          makePolyOutside([170, -10], [-80, 60]),
+          makePolyInside([170, -10], [-80, 50]),
+          makePolyOutside([170, -10], [-80, 50]),
+        ];
+        for (let p of polys) {
           let c = compare(
             `FILTER GEO_CONTAINS(${JSON.stringify(p)}, d.geo)`,
             `SEARCH ANALYZER(GEO_CONTAINS(${JSON.stringify(p)}, d.geo), "geo_json")`
           );
           assertTrue(c.cmpResFullScanWithIndexes.good && c.cmpResView.good && c.cmpResInvertedIndex.good, c.cmpResFullScanWithIndexes.msg + c.cmpResView.msg + c.cmpResInvertedIndex.msg);
         }
-      }
-    },
+      },
 
-////////////////////////////////////////////////////////////////////////////////
-/// @brief test contains query with a large polygon and a point grid
-////////////////////////////////////////////////////////////////////////////////
+      ////////////////////////////////////////////////////////////////////////////////
+      /// @brief test some areas which are more than half of the earth, around
+      /// north pole
+      ////////////////////////////////////////////////////////////////////////////////
 
-    testContainsGrid : function () {
-      createNearGrid();
-      for (let d = 1; d <= 5; d += 1) {
-        let p = {
-          type: "Polygon", coordinates: [[[15 - d, 15], [15, 15 - d], [15 + d, 15],
-            [15, 15 + d], [15 - d, 15]]]
-        };
-        //print("d=", d, JSON.stringify(p));
-        let c = compare(
-          `FILTER GEO_CONTAINS(${JSON.stringify(p)}, d.geo)`,
-          `SEARCH ANALYZER(GEO_CONTAINS(${JSON.stringify(p)}, d.geo), "geo_json")`
-        );
-        if (!isInt) {
-          assertTrue(c.cmpResFullScanWithIndexes.good && c.cmpResView.good && c.cmpResInvertedIndex.good, c.cmpResFullScanWithIndexes.msg + c.cmpResView.msg + c.cmpResInvertedIndex.msg);
-        }
-      }
-    },
-
-////////////////////////////////////////////////////////////////////////////////
-/// @brief test contains query with a complement of a large polygon and a 
-/// point grid
-////////////////////////////////////////////////////////////////////////////////
-
-    testContainsGridComplement : function () {
-      createNearGrid();
-      for (let d = 1; d <= 5; d += 1) {
-        let p = {
-          type: "Polygon", coordinates: [[[15 - d, 15], [15, 15 + d], [15 + d, 15],
-            [15, 15 - d], [15 - d, 15]]]
-        };
-        //print("d=", d, JSON.stringify(p));
-        let c = compare(
-          `FILTER GEO_CONTAINS(${JSON.stringify(p)}, d.geo)`,
-          `SEARCH ANALYZER(GEO_CONTAINS(${JSON.stringify(p)}, d.geo), "geo_json")`
-        );
-        if (!isInt) {
-          assertTrue(c.cmpResFullScanWithIndexes.good && c.cmpResView.good && c.cmpResInvertedIndex.good, c.cmpResFullScanWithIndexes.msg + c.cmpResView.msg + c.cmpResInvertedIndex.msg);
-        }
-      }
-    },
-
-////////////////////////////////////////////////////////////////////////////////
-/// @brief test intersects query with a polygon, move polygon over grip
-////////////////////////////////////////////////////////////////////////////////
-
-    testIntersectsWithSmallPoly : function () {
-      createNearGrid();
-      let d = 0.001;
-      for (let lat = 9; lat <= 11; lat += 0.4) {
-        for (let lon = 9; lon <= 11; lon += 0.4) {
-          let p = {type:"Polygon", coordinates:[[[lon-d, lat-d],
-            [lon+d, lat-d], [lon+d, lat+d], [lon-d, lat+d], [lon-d, lat-d]]]};
-          //print("Polygon:", JSON.stringify(p));
+      testMoreThanHalf3 : function () {
+        createBiggestGrid();
+        let polys = [
+          makePolyInside([-85, 95], [-80, 87]),
+          makePolyOutside([-85, 95], [-80, 87]),
+          makePolyInside([-85, 85], [-80, 87]),
+          makePolyOutside([-85, 85], [-80, 87]),
+          makePolyInside([-85, 95], [-80, 80]),
+          makePolyOutside([-85, 95], [-80, 80]),
+          makePolyInside([-85, 85], [-80, 80]),
+          makePolyOutside([-85, 85], [-80, 80]),
+          makePolyInside([-85, 105], [-80, 89]),
+          makePolyOutside([-85, 105], [-80, 89]),
+          makePolyInside([170, -10], [-80, 89]),
+          makePolyOutside([170, -10], [-80, 89]),
+          makePolyInside([170, -10], [-80, 87]),
+          makePolyOutside([170, -10], [-80, 87]),
+        ];
+        for (let p of polys) {
           let c = compare(
-            `FILTER GEO_INTERSECTS(${JSON.stringify(p)}, d.geo)`,
-            `SEARCH ANALYZER(GEO_INTERSECTS(${JSON.stringify(p)}, d.geo), "geo_json")`
+            `FILTER GEO_CONTAINS(${JSON.stringify(p)}, d.geo)`,
+            `SEARCH ANALYZER(GEO_CONTAINS(${JSON.stringify(p)}, d.geo), "geo_json")`
           );
           assertTrue(c.cmpResFullScanWithIndexes.good && c.cmpResView.good && c.cmpResInvertedIndex.good, c.cmpResFullScanWithIndexes.msg + c.cmpResView.msg + c.cmpResInvertedIndex.msg);
         }
-      }
-    },
+      },
 
-////////////////////////////////////////////////////////////////////////////////
-/// @brief test intersects query with a large polygon and a point grid
-////////////////////////////////////////////////////////////////////////////////
+      ////////////////////////////////////////////////////////////////////////////////
+      /// @brief further non-convex cases
+      ////////////////////////////////////////////////////////////////////////////////
 
-    testIntersectsGrid : function () {
-      createNearGrid();
-      for (let d = 1; d <= 5; d += 1) {
-        let p = {
-          type: "Polygon", coordinates: [[[15 - d, 15], [15, 15 - d], [15 + d, 15],
-            [15, 15 + d], [15 - d, 15]]]
+      testMoreNonConvex : function () {
+        createSomePolygons();
+        let multiLineString = {
+          "type": "MultiLineString",
+          "coordinates": [[[6.537, 50.332], [6.537, 50.376]],
+                          [[6.621, 50.332], [6.621, 50.376]]]
         };
-        //print("d=", d, JSON.stringify(p));
         let c = compare(
-          `FILTER GEO_INTERSECTS(${JSON.stringify(p)}, d.geo)`,
-          `SEARCH ANALYZER(GEO_INTERSECTS(${JSON.stringify(p)}, d.geo), "geo_json")`
-        );
-        if (!isInt) {
-          assertTrue(c.cmpResFullScanWithIndexes.good && c.cmpResView.good && c.cmpResInvertedIndex.good, c.cmpResFullScanWithIndexes.msg + c.cmpResView.msg + c.cmpResInvertedIndex.msg);
-        }
-      }
-    },
-
-////////////////////////////////////////////////////////////////////////////////
-/// @brief test intersects query with a complement of a large polygon and a 
-/// point grid
-////////////////////////////////////////////////////////////////////////////////
-
-    testIntersectsGridComplement : function () {
-      createNearGrid();
-      for (let d = 1; d <= 5; d += 1) {
-        let p = {
-          type: "Polygon", coordinates: [[[15 - d, 15], [15, 15 + d], [15 + d, 15],
-            [15, 15 - d], [15 - d, 15]]]
-        };
-        //print("d=", d, JSON.stringify(p));
-        let c = compare(
-          `FILTER GEO_INTERSECTS(${JSON.stringify(p)}, d.geo)`,
-          `SEARCH ANALYZER(GEO_INTERSECTS(${JSON.stringify(p)}, d.geo), "geo_json")`
-        );
-        if (!isInt) {
-          assertTrue(c.cmpResFullScanWithIndexes.good && c.cmpResView.good && c.cmpResInvertedIndex.good, c.cmpResFullScanWithIndexes.msg + c.cmpResView.msg + c.cmpResInvertedIndex.msg);
-        }
-      }
-    },
-
-////////////////////////////////////////////////////////////////////////////////
-/// @brief test intersects query with large non-convex object whose centroid
-/// is not contained in the object.
-////////////////////////////////////////////////////////////////////////////////
-
-    testIntersectsNonConvexObject : function () {
-      createTwoPolygons();
-      let smallPoly = {type:"Polygon",
-        coordinates:[[[4.7873, 10.0734], [4.7875, 10.0734], [4.7875, 10.0736],
-                      [4.7873, 10.0736], [4.7873, 10.0734]]]};
-      let c = compare(
-        `FILTER GEO_INTERSECTS(${JSON.stringify(smallPoly)}, d.geo)`,
-        `SEARCH ANALYZER(GEO_INTERSECTS(${JSON.stringify(smallPoly)}, d.geo), "geo_json")`
-      );
-      assertTrue(c.cmpResFullScanWithIndexes.good && c.cmpResView.good && c.cmpResInvertedIndex.good, c.cmpResFullScanWithIndexes.msg + c.cmpResView.msg + c.cmpResInvertedIndex.msg);
-    },
-
-////////////////////////////////////////////////////////////////////////////////
-/// @brief test some areas which are more than half of the earth
-////////////////////////////////////////////////////////////////////////////////
-
-    testMoreThanHalf1Grid: function () {
-      createLargeGrid();
-      let polys = [
-        makePolyInside([-85, 95], [-80, 50]),
-        makePolyOutside([-85, 95], [-80, 50]),
-        makePolyInside([-85, 85], [-80, 50]),
-        makePolyOutside([-85, 85], [-80, 50]),
-        makePolyInside([-85, 95], [-80, 40]),
-        makePolyOutside([-85, 95], [-80, 40]),
-        makePolyInside([-85, 85], [-80, 40]),
-        makePolyOutside([-85, 85], [-80, 40]),
-        makePolyInside([-85, 105], [-80, 60]),
-        makePolyOutside([-85, 105], [-80, 60]),
-        makePolyInside([170, -10], [-80, 60]),
-        makePolyOutside([170, -10], [-80, 60]),
-        makePolyInside([170, -10], [-80, 50]),
-        makePolyOutside([170, -10], [-80, 50]),
-      ];
-      for (let p of polys) {
-        let c = compare(
-          `FILTER GEO_CONTAINS(${JSON.stringify(p)}, d.geo)`,
-          `SEARCH ANALYZER(GEO_CONTAINS(${JSON.stringify(p)}, d.geo), "geo_json")`
-        );
-        if (!isInt) {
-          assertTrue(c.cmpResFullScanWithIndexes.good && c.cmpResView.good && c.cmpResInvertedIndex.good, c.cmpResFullScanWithIndexes.msg + c.cmpResView.msg + c.cmpResInvertedIndex.msg);
-        }
-      }
-    },
-
-////////////////////////////////////////////////////////////////////////////////
-/// @brief test some areas which are more than half of the earth, around
-/// date wrap
-////////////////////////////////////////////////////////////////////////////////
-
-    testMoreThanHalf2 : function () {
-      createSuperLargeGrid();
-      let polys = [
-        makePolyInside([-85, 95], [-80, 50]),
-        makePolyOutside([-85, 95], [-80, 50]),
-        makePolyInside([-85, 85], [-80, 50]),
-        makePolyOutside([-85, 85], [-80, 50]),
-        makePolyInside([-85, 95], [-80, 40]),
-        makePolyOutside([-85, 95], [-80, 40]),
-        makePolyInside([-85, 85], [-80, 40]),
-        makePolyOutside([-85, 85], [-80, 40]),
-        makePolyInside([-85, 105], [-80, 60]),
-        makePolyOutside([-85, 105], [-80, 60]),
-        makePolyInside([170, -10], [-80, 60]),
-        makePolyOutside([170, -10], [-80, 60]),
-        makePolyInside([170, -10], [-80, 50]),
-        makePolyOutside([170, -10], [-80, 50]),
-      ];
-      for (let p of polys) {
-        let c = compare(
-          `FILTER GEO_CONTAINS(${JSON.stringify(p)}, d.geo)`,
-          `SEARCH ANALYZER(GEO_CONTAINS(${JSON.stringify(p)}, d.geo), "geo_json")`
+          `FILTER GEO_DISTANCE(${JSON.stringify(multiLineString)}, d.geo) < 100`,
+          `SEARCH ANALYZER(GEO_DISTANCE(${JSON.stringify(multiLineString)}, d.geo) < 100, "geo_json")`
         );
         assertTrue(c.cmpResFullScanWithIndexes.good && c.cmpResView.good && c.cmpResInvertedIndex.good, c.cmpResFullScanWithIndexes.msg + c.cmpResView.msg + c.cmpResInvertedIndex.msg);
-      }
-    },
-
-////////////////////////////////////////////////////////////////////////////////
-/// @brief test some areas which are more than half of the earth, around
-/// north pole
-////////////////////////////////////////////////////////////////////////////////
-
-    testMoreThanHalf3 : function () {
-      createBiggestGrid();
-      let polys = [
-        makePolyInside([-85, 95], [-80, 87]),
-        makePolyOutside([-85, 95], [-80, 87]),
-        makePolyInside([-85, 85], [-80, 87]),
-        makePolyOutside([-85, 85], [-80, 87]),
-        makePolyInside([-85, 95], [-80, 80]),
-        makePolyOutside([-85, 95], [-80, 80]),
-        makePolyInside([-85, 85], [-80, 80]),
-        makePolyOutside([-85, 85], [-80, 80]),
-        makePolyInside([-85, 105], [-80, 89]),
-        makePolyOutside([-85, 105], [-80, 89]),
-        makePolyInside([170, -10], [-80, 89]),
-        makePolyOutside([170, -10], [-80, 89]),
-        makePolyInside([170, -10], [-80, 87]),
-        makePolyOutside([170, -10], [-80, 87]),
-      ];
-      for (let p of polys) {
-        let c = compare(
-          `FILTER GEO_CONTAINS(${JSON.stringify(p)}, d.geo)`,
-          `SEARCH ANALYZER(GEO_CONTAINS(${JSON.stringify(p)}, d.geo), "geo_json")`
+        multiLineString = {
+          "type": "MultiLineString",
+          "coordinates": [ [[ 37.614323, 55.705898 ], [ 37.615825, 55.705898 ]],
+                           [[ 37.614323, 55.70652 ], [ 37.615825, 55.70652 ]] ] };
+        c = compare(
+          `FILTER GEO_DISTANCE(${JSON.stringify(multiLineString)}, d.geo) < 100`,
+          `SEARCH ANALYZER(GEO_DISTANCE(${JSON.stringify(multiLineString)}, d.geo) < 100, "geo_json")`
         );
         assertTrue(c.cmpResFullScanWithIndexes.good && c.cmpResView.good && c.cmpResInvertedIndex.good, c.cmpResFullScanWithIndexes.msg + c.cmpResView.msg + c.cmpResInvertedIndex.msg);
-      }
-    },
+        let multiPoint = {
+          type: "MultiPoint",
+          coordinates: [ [ 6.537, 50.332 ], [ 6.537, 50.376 ],
+                         [ 6.621, 50.332 ], [ 6.621, 50.376 ] ] };
+        c = compare(
+          `FILTER GEO_DISTANCE(${JSON.stringify(multiPoint)}, d.geo) < 100`,
+          `SEARCH ANALYZER(GEO_DISTANCE(${JSON.stringify(multiPoint)}, d.geo) < 100, "geo_json")`
+        );
+        assertTrue(c.cmpResFullScanWithIndexes.good && c.cmpResView.good && c.cmpResInvertedIndex.good, c.cmpResFullScanWithIndexes.msg + c.cmpResView.msg + c.cmpResInvertedIndex.msg);
+        multiPoint = {
+          type: "MultiPoint",
+          "coordinates": [ [ 37.614323, 55.705898 ], [ 37.615825, 55.705898 ],
+                           [ 37.614323, 55.70652 ], [ 37.615825, 55.70652 ] ] };
+        c = compare(
+          `FILTER GEO_DISTANCE(${JSON.stringify(multiPoint)}, d.geo) < 100`,
+          `SEARCH ANALYZER(GEO_DISTANCE(${JSON.stringify(multiPoint)}, d.geo) < 100, "geo_json")`
+        );
+        assertTrue(c.cmpResFullScanWithIndexes.good && c.cmpResView.good && c.cmpResInvertedIndex.good, c.cmpResFullScanWithIndexes.msg + c.cmpResView.msg + c.cmpResInvertedIndex.msg);
+      },
 
-////////////////////////////////////////////////////////////////////////////////
-/// @brief further non-convex cases
-////////////////////////////////////////////////////////////////////////////////
+      ////////////////////////////////////////////////////////////////////////////////
+      /// @brief further non-convex cases, GEO_IN_RANGE
+      ////////////////////////////////////////////////////////////////////////////////
 
-    testMoreNonConvex : function () {
-      createSomePolygons();
-      let multiLineString = {
-        "type": "MultiLineString",
-        "coordinates": [[[6.537, 50.332], [6.537, 50.376]],
-          [[6.621, 50.332], [6.621, 50.376]]]
-      };
-      let c = compare(
-        `FILTER GEO_DISTANCE(${JSON.stringify(multiLineString)}, d.geo) < 100`,
-        `SEARCH ANALYZER(GEO_DISTANCE(${JSON.stringify(multiLineString)}, d.geo) < 100, "geo_json")`
-      );
-      assertTrue(c.cmpResFullScanWithIndexes.good && c.cmpResView.good && c.cmpResInvertedIndex.good, c.cmpResFullScanWithIndexes.msg + c.cmpResView.msg + c.cmpResInvertedIndex.msg);
-      multiLineString = {
-        "type": "MultiLineString",
-        "coordinates": [ [[ 37.614323, 55.705898 ], [ 37.615825, 55.705898 ]],
-                         [[ 37.614323, 55.70652 ], [ 37.615825, 55.70652 ]] ] };
-      c = compare(
-        `FILTER GEO_DISTANCE(${JSON.stringify(multiLineString)}, d.geo) < 100`,
-        `SEARCH ANALYZER(GEO_DISTANCE(${JSON.stringify(multiLineString)}, d.geo) < 100, "geo_json")`
-      );
-      assertTrue(c.cmpResFullScanWithIndexes.good && c.cmpResView.good && c.cmpResInvertedIndex.good, c.cmpResFullScanWithIndexes.msg + c.cmpResView.msg + c.cmpResInvertedIndex.msg);
-      let multiPoint = {
-        type: "MultiPoint",
-        coordinates: [ [ 6.537, 50.332 ], [ 6.537, 50.376 ],
-                       [ 6.621, 50.332 ], [ 6.621, 50.376 ] ] };
-      c = compare(
-        `FILTER GEO_DISTANCE(${JSON.stringify(multiPoint)}, d.geo) < 100`,
-        `SEARCH ANALYZER(GEO_DISTANCE(${JSON.stringify(multiPoint)}, d.geo) < 100, "geo_json")`
-      );
-      assertTrue(c.cmpResFullScanWithIndexes.good && c.cmpResView.good && c.cmpResInvertedIndex.good, c.cmpResFullScanWithIndexes.msg + c.cmpResView.msg + c.cmpResInvertedIndex.msg);
-      multiPoint = {
-        type: "MultiPoint",
-        "coordinates": [ [ 37.614323, 55.705898 ], [ 37.615825, 55.705898 ],
-                         [ 37.614323, 55.70652 ], [ 37.615825, 55.70652 ] ] };
-      c = compare(
-        `FILTER GEO_DISTANCE(${JSON.stringify(multiPoint)}, d.geo) < 100`,
-        `SEARCH ANALYZER(GEO_DISTANCE(${JSON.stringify(multiPoint)}, d.geo) < 100, "geo_json")`
-      );
-      assertTrue(c.cmpResFullScanWithIndexes.good && c.cmpResView.good && c.cmpResInvertedIndex.good, c.cmpResFullScanWithIndexes.msg + c.cmpResView.msg + c.cmpResInvertedIndex.msg);
-    },
+      testMoreNonConvexGeoInRange : function () {
+        createSomePolygons();
+        let multiLineString = {
+          "type": "MultiLineString",
+          "coordinates": [ [ [ 6.537, 50.332 ], [ 6.537, 50.376 ] ],
+                           [ [ 6.621, 50.332 ], [ 6.621, 50.376 ] ] ] };
 
-////////////////////////////////////////////////////////////////////////////////
-/// @brief further non-convex cases, GEO_IN_RANGE
-////////////////////////////////////////////////////////////////////////////////
+        let c = compare(
+          `FILTER GEO_IN_RANGE(${JSON.stringify(multiLineString)}, d.geo, 0, 100)`,
+          `SEARCH ANALYZER(GEO_IN_RANGE(${JSON.stringify(multiLineString)}, d.geo, 0, 100), "geo_json")`
+        );
+        assertTrue(c.cmpResFullScanWithIndexes.good && c.cmpResView.good && c.cmpResInvertedIndex.good, c.cmpResFullScanWithIndexes.msg + c.cmpResView.msg + c.cmpResInvertedIndex.msg);
+        multiLineString = {
+          "type": "MultiLineString",
+          "coordinates": [ [[ 37.614323, 55.705898 ], [ 37.615825, 55.705898 ]],
+                           [[ 37.614323, 55.70652 ], [ 37.615825, 55.70652 ]] ] };
 
-    testMoreNonConvexGeoInRange : function () {
-      createSomePolygons();
-      let multiLineString = {
-        "type": "MultiLineString",
-        "coordinates": [ [ [ 6.537, 50.332 ], [ 6.537, 50.376 ] ],
-                         [ [ 6.621, 50.332 ], [ 6.621, 50.376 ] ] ] };
+        c = compare(
+          `FILTER GEO_IN_RANGE(${JSON.stringify(multiLineString)}, d.geo, 0, 100)`,
+          `SEARCH ANALYZER(GEO_IN_RANGE(${JSON.stringify(multiLineString)}, d.geo, 0, 100), "geo_json")`
+        );
+        assertTrue(c.cmpResFullScanWithIndexes.good && c.cmpResView.good && c.cmpResInvertedIndex.good, c.cmpResFullScanWithIndexes.msg + c.cmpResView.msg + c.cmpResInvertedIndex.msg);
+        let multiPoint = {
+          type: "MultiPoint",
+          coordinates: [ [ 6.537, 50.332 ], [ 6.537, 50.376 ],
+                         [ 6.621, 50.332 ], [ 6.621, 50.376 ] ] };
 
-      let c = compare(
-        `FILTER GEO_IN_RANGE(${JSON.stringify(multiLineString)}, d.geo, 0, 100)`,
-        `SEARCH ANALYZER(GEO_IN_RANGE(${JSON.stringify(multiLineString)}, d.geo, 0, 100), "geo_json")`
-      );
-      assertTrue(c.cmpResFullScanWithIndexes.good && c.cmpResView.good && c.cmpResInvertedIndex.good, c.cmpResFullScanWithIndexes.msg + c.cmpResView.msg + c.cmpResInvertedIndex.msg);
-      multiLineString = {
-        "type": "MultiLineString",
-        "coordinates": [ [[ 37.614323, 55.705898 ], [ 37.615825, 55.705898 ]],
-                         [[ 37.614323, 55.70652 ], [ 37.615825, 55.70652 ]] ] };
+        c = compare(
+          `FILTER GEO_IN_RANGE(${JSON.stringify(multiPoint)}, d.geo, 0, 100)`,
+          `SEARCH ANALYZER(GEO_IN_RANGE(${JSON.stringify(multiPoint)}, d.geo, 0, 100), "geo_json")`
+        );
+        assertTrue(c.cmpResFullScanWithIndexes.good && c.cmpResView.good && c.cmpResInvertedIndex.good, c.cmpResFullScanWithIndexes.msg + c.cmpResView.msg + c.cmpResInvertedIndex.msg);
+        multiPoint = {
+          type: "MultiPoint",
+          "coordinates": [ [ 37.614323, 55.705898 ], [ 37.615825, 55.705898 ],
+                           [37.614323, 55.70652], [37.615825, 55.70652]]
+        };
 
-      c = compare(
-        `FILTER GEO_IN_RANGE(${JSON.stringify(multiLineString)}, d.geo, 0, 100)`,
-        `SEARCH ANALYZER(GEO_IN_RANGE(${JSON.stringify(multiLineString)}, d.geo, 0, 100), "geo_json")`
-      );
-      assertTrue(c.cmpResFullScanWithIndexes.good && c.cmpResView.good && c.cmpResInvertedIndex.good, c.cmpResFullScanWithIndexes.msg + c.cmpResView.msg + c.cmpResInvertedIndex.msg);
-      let multiPoint = {
-        type: "MultiPoint",
-        coordinates: [ [ 6.537, 50.332 ], [ 6.537, 50.376 ],
-                       [ 6.621, 50.332 ], [ 6.621, 50.376 ] ] };
-
-      c = compare(
-        `FILTER GEO_IN_RANGE(${JSON.stringify(multiPoint)}, d.geo, 0, 100)`,
-        `SEARCH ANALYZER(GEO_IN_RANGE(${JSON.stringify(multiPoint)}, d.geo, 0, 100), "geo_json")`
-      );
-      assertTrue(c.cmpResFullScanWithIndexes.good && c.cmpResView.good && c.cmpResInvertedIndex.good, c.cmpResFullScanWithIndexes.msg + c.cmpResView.msg + c.cmpResInvertedIndex.msg);
-      multiPoint = {
-        type: "MultiPoint",
-        "coordinates": [ [ 37.614323, 55.705898 ], [ 37.615825, 55.705898 ],
-          [37.614323, 55.70652], [37.615825, 55.70652]]
-      };
-
-      c = compare(
-        `FILTER GEO_IN_RANGE(${JSON.stringify(multiPoint)}, d.geo, 0, 100)`,
-        `SEARCH ANALYZER(GEO_IN_RANGE(${JSON.stringify(multiPoint)}, d.geo, 0, 100), "geo_json")`
-      );
-      assertTrue(c.cmpResFullScanWithIndexes.good && c.cmpResView.good && c.cmpResInvertedIndex.good, c.cmpResFullScanWithIndexes.msg + c.cmpResView.msg + c.cmpResInvertedIndex.msg);
-    },
-  };
+        c = compare(
+          `FILTER GEO_IN_RANGE(${JSON.stringify(multiPoint)}, d.geo, 0, 100)`,
+          `SEARCH ANALYZER(GEO_IN_RANGE(${JSON.stringify(multiPoint)}, d.geo, 0, 100), "geo_json")`
+        );
+        assertTrue(c.cmpResFullScanWithIndexes.good && c.cmpResView.good && c.cmpResInvertedIndex.good, c.cmpResFullScanWithIndexes.msg + c.cmpResView.msg + c.cmpResInvertedIndex.msg);
+      },
+    };
   };
 }());

--- a/tests/js/server/aql/aql-geo.inc
+++ b/tests/js/server/aql/aql-geo.inc
@@ -224,7 +224,7 @@
     function compare(query, queryView) {
       let fullScanQuery = `FOR d IN @@coll ${query} RETURN d._key`;
       let viewQuery = `FOR d IN ${viewName} ${queryView} RETURN d._key`;
-      let invertedIndexQuery = `FOR d IN ${collWithIndex} OPTIONS {indexHint: "inverted", forceIndexHint: true, waitForSync: true} ${query} RETURN d._key`;
+      let invertedIndexQuery = `FOR d IN ${collWithIndex} OPTIONS {indexHint: "inverted", forceIndexHint: true } ${query} RETURN d._key`;
 
       let resFullScanNoIndexes = getQueryResults(fullScanQuery, {"@coll": collWithoutIndex}).sort();
       let resFullScanWithIndexes = getQueryResults(fullScanQuery, {"@coll": collWithIndex}).sort();

--- a/tests/js/server/aql/aql-geo.inc
+++ b/tests/js/server/aql/aql-geo.inc
@@ -51,6 +51,11 @@
     let withView = {};
     let plainView = {};
     let testAnalyzers = {};
+    let defaultAnalyzer = null;
+
+    function createDefaultAnalyzer() {
+      defaultAnalyzer = analyzers.save("geo_json", analyzerType, analyzerDefinition, ["frequency", "norm", "position"]);
+    }
 
     function makePolyInside(lon, lat) {
       // lon and lat are longitude and latitude ranges
@@ -84,7 +89,7 @@
       viewName = plainView[basename].name();
       analyzerName = testAnalyzers[basename].name();
     }
-    function createCollectionSet(basename) {
+    function createCollectionSet(basename, theanalyzer) {
       let collWithoutIndex = "UnitTestsGeoWithoutIndex";
       let collWithIndex = "UnitTestsGeoWithIndex";
       let collWithView = "UnitTestsGeoWithView";
@@ -93,7 +98,7 @@
       withIndex[basename] = db._create(basename + '_' + collWithIndex);
       withIndex[basename].ensureIndex({type: "geo", geoJson: true, fields: ["geo"]});
       withView[basename] = db._create(basename + '_' + collWithView);
-      testAnalyzers[basename] = analyzers.save(basename + "_geo_json", analyzerType, analyzerDefinition, ["frequency", "norm", "position"]);
+      testAnalyzers[basename] = theanalyzer;
 
       withIndex[basename].save({ name_1: "name", "value": [{ "nested_1": [{ "nested_2": "foo123"}]}]});
       withView[basename].save({ name_1: "name", "value": [{ "nested_1": [{ "nested_2": "foo123"}]}]});
@@ -152,9 +157,9 @@
         plainView[basename] = db._createView(basename + '_' + viewName, "arangosearch", meta);
       }
     }
-    function insertAll(name, x) {
+    function insertAll(name, theAnalyzer, x) {
       if (!noIndex.hasOwnProperty(name)) {
-        createCollectionSet(name);
+        createCollectionSet(name, theAnalyzer);
       }
 
       for (let i = 0; i < x.length; ++i) {
@@ -262,11 +267,11 @@
     }
 
     function createOnePolygon() {
-      insertAll('createOnePolygon', [{geo: { type: "Point", coordinates: [50, 50] } }]);
+      insertAll('createOnePolygon', defaultAnalyzer, [{geo: { type: "Point", coordinates: [50, 50] } }]);
     }
     function createTwoPolygons() {
       // Centroid will be at approx. [7,10]
-      insertAll('createTwoPolygons', [
+      insertAll('createTwoPolygons', defaultAnalyzer, [
         {geo:{type:"Polygon",
               coordinates:[[[0,0],[10,10],[0,20],[9,10],[0,0]]]}},
         {geo:{type:"Polygon",
@@ -274,7 +279,7 @@
       ]);
     }
     function createThreePolygons() {
-      insertAll('createThreePolygons', [
+      insertAll('createThreePolygons', defaultAnalyzer, [
         {geo:{type:"Polygon",
               coordinates:[[[10,10],[20,10],[20,20],[10,20],[10,10]]]}},
         {geo:{type:"Polygon",
@@ -294,27 +299,27 @@
           points.push({ geo: { type: "Point",
                                coordinates: [lat + x/1000, long + y/1000] } });
         }
-        insertAll(name, points);
+        insertAll(name, defaultAnalyzer, points);
       }
-      insertAll(name, [{ geo: { "type": "Polygon", "coordinates": [
+      insertAll(name, defaultAnalyzer, [{ geo: { "type": "Polygon", "coordinates": [
         [[ 37.614323, 55.705898 ],
          [ 37.615825, 55.705898 ],
          [ 37.615825, 55.70652  ],
          [ 37.614323, 55.70652  ],
          [ 37.614323, 55.705898 ]]
       ]}}]);
-      insertAll(name, [{ geo: {"type": "LineString", "coordinates": [
+      insertAll(name, defaultAnalyzer, [{ geo: {"type": "LineString", "coordinates": [
         [ 6.537, 50.332 ], [ 6.537, 50.376 ]]
                         }}]);
-      insertAll(name, [{ geo: { "type": "MultiLineString", "coordinates": [
+      insertAll(name, defaultAnalyzer, [{ geo: { "type": "MultiLineString", "coordinates": [
         [[ 6.537, 50.332 ], [ 6.537, 50.376 ]],
         [[ 6.621, 50.332 ], [ 6.621, 50.376 ]]
       ]}}]);
-      insertAll(name, [{ geo: { "type": "MultiPoint", "coordinates": [
+      insertAll(name, defaultAnalyzer, [{ geo: { "type": "MultiPoint", "coordinates": [
         [ 6.537, 50.332 ], [ 6.537, 50.376 ],
         [ 6.621, 50.332 ], [ 6.621, 50.376 ]
       ]}}]);
-      insertAll(name, [{ geo: { "type": "MultiPolygon", "coordinates": [
+      insertAll(name, defaultAnalyzer, [{ geo: { "type": "MultiPolygon", "coordinates": [
         [[[ 37.614323, 55.705898 ],
           [ 37.615825, 55.705898 ],
           [ 37.615825, 55.70652  ],
@@ -334,13 +339,13 @@
         for (let lon = 9; lon <= 21; lon += 0.1) {
           l.push({geo:{type:"Point", coordinates:[lon, lat]}});
           if (l.length % 1000 === 0) {
-            insertAll(name, l);
+            insertAll(name, defaultAnalyzer, l);
             l = [];
           }
         }
       }
       if (l.length > 0) {
-        insertAll(name, l);
+        insertAll(name, defaultAnalyzer, l);
       }
     }
     function createNarrowGrid() {
@@ -358,13 +363,13 @@
             centroid: {type: "Point", coordinates: [lon, 10]}
           });
           if (l.length % 1000 === 0) {
-            insertAll(name, l);
+            insertAll(name, defaultAnalyzer, l);
             l = [];
           }
         }
       }
       if (l.length > 0) {
-        insertAll(name, l);
+        insertAll(name, defaultAnalyzer, l);
       }
     }
     function createNearSlidingObject() {
@@ -382,13 +387,13 @@
             centroid: {type: "Point", coordinates: [lon, 10]}
           });
           if (l.length % 1000 === 0) {
-            insertAll(name, l);
+            insertAll(name, defaultAnalyzer, l);
             l = [];
           }
         }
       }
       if (l.length > 0) {
-        insertAll(name, l);
+        insertAll(name, defaultAnalyzer, l);
       }
     }
     function createLargeGrid() {
@@ -398,13 +403,13 @@
         for (let lon = 90; lon <= 100; lon += 1) {
           l.push({geo: {type: "Point", coordinates: [lon, lat]}});
           if (l.length % 1000 === 0) {
-            insertAll(name, l);
+            insertAll(name, defaultAnalyzer, l);
             l = [];
           }
         }
       }
       if (l.length > 0) {
-        insertAll(name, l);
+        insertAll(name, defaultAnalyzer, l);
       }
     }
     function createSuperLargeGrid() {
@@ -414,20 +419,20 @@
         for (let lon = 175; lon < 180; lon += 1) {
           l.push({geo:{type:"Point", coordinates:[lon, lat]}});
           if (l.length % 1000 === 0) {
-            insertAll(name, l);
+            insertAll(name, defaultAnalyzer, l);
             l = [];
           }
         }
         for (let lon = -179; lon <= -170; lon += 1) {
           l.push({geo:{type:"Point", coordinates:[lon, lat]}});
           if (l.length % 1000 === 0) {
-            insertAll(name, l);
+            insertAll(name, defaultAnalyzer, l);
             l = [];
           }
         }
       }
       if (l.length > 0) {
-        insertAll(name, l);
+        insertAll(name, defaultAnalyzer, l);
       }
     }
     function createBiggestGrid() {
@@ -437,20 +442,20 @@
         for (let lon = 175; lon < 180; lon += 1) {
           l.push({geo:{type:"Point", coordinates:[lon, lat]}});
           if (l.length % 1000 === 0) {
-            insertAll(name, l);
+            insertAll(name, defaultAnalyzer, l);
             l = [];
           }
         }
         for (let lon = -179; lon <= -170; lon += 1) {
           l.push({geo:{type:"Point", coordinates:[lon, lat]}});
           if (l.length % 1000 === 0) {
-            insertAll(name, l);
+            insertAll(name, defaultAnalyzer, l);
             l = [];
           }
         }
       }
       if (l.length > 0) {
-        insertAll(name, l);
+        insertAll(name, defaultAnalyzer, l);
       }
     }
     return {
@@ -464,6 +469,7 @@
         //db._drop(collWithoutIndex);
         //db._drop(collWithIndex);
         //db._drop(collWithView);
+        createDefaultAnalyzer();
         createOnePolygon();
         createTwoPolygons();
         createThreePolygons();
@@ -487,7 +493,10 @@
         Object.keys(noIndex).forEach(key => { noIndex[key].drop(); });
         Object.keys(withIndex).forEach(key => { withIndex[key].drop(); });
         Object.keys(testAnalyzers).forEach(key => {
-          analyzers.remove(testAnalyzers[key].name(), true); });
+          if (testAnalyzers[key].name() !== defaultAnalyzer.name()) {
+            analyzers.remove(testAnalyzers[key].name(), true);
+          }});
+        analyzers.remove(defaultAnalyzer.name(), true);
       },
 
       ////////////////////////////////////////////////////////////////////////////////

--- a/tests/js/server/aql/aql-geo.inc
+++ b/tests/js/server/aql/aql-geo.inc
@@ -41,6 +41,16 @@
   const isEnterprise = require("internal").isEnterprise();
 
   return function (isSearchAlias, analyzerType, analyzerDefinition, isInt = false) {
+    let collWithoutIndex = null;
+    let collWithIndex = null;
+    let collWithView = null;
+    let viewName = null;
+    let analyzerName = null;
+    let noIndex = {};
+    let withIndex = {};
+    let withView = {};
+    let plainView = {};
+    let testAnalyzers = {};
 
     function makePolyInside(lon, lat) {
       // lon and lat are longitude and latitude ranges
@@ -60,15 +70,6 @@
       };
     }
 
-    let collWithoutIndex = null;
-    let collWithIndex = null;
-    let collWithView = null;
-    let viewName = null;
-    let noIndex = [];
-    let withIndex = [];
-    let withView = [];
-    let view = [];
-    let testAnalyzers = [];
 
     let keyCounter = 0;
 
@@ -77,10 +78,11 @@
         `FOR d IN ${viewName} OPTIONS { waitForSync:true } LIMIT 1 RETURN 1`);
     }
     function chooseCollectionSet(basename) {
-      collWithoutIndex = noIndex[basename].name;
-      collWithIndex = withIndex[basename].name;
-      collWithView = withIndex[basename].name;
-      viewName = view[basename].name;
+      collWithoutIndex = noIndex[basename].name();
+      collWithIndex = withIndex[basename].name();
+      collWithView = withIndex[basename].name();
+      viewName = plainView[basename].name();
+      analyzerName = testAnalyzers[basename].name();
     }
     function createCollectionSet(basename) {
       let collWithoutIndex = "UnitTestsGeoWithoutIndex";
@@ -103,13 +105,13 @@
         commonInvertedIndexMeta = {type: "inverted", name: "inverted", includeAllFields: true, fields:[
           {"name": "value", "nested": [{"name": "nested_1", "nested": [{"name": "nested_2"}]}]},
           "name_1",
-          {"name": "geo", "analyzer": testAnalyzers[basename].name}
+          {"name": "geo", "analyzer": testAnalyzers[basename].name()}
         ]};
       } else {
         commonInvertedIndexMeta = {type: "inverted", name: "inverted", includeAllFields: true, fields:[
           {"name": "value[*]"},
           "name_1",
-          {"name": "geo", "analyzer": testAnalyzers[basename].name}
+          {"name": "geo", "analyzer": testAnalyzers[basename].name()}
         ]};
       }
       withView[basename].ensureIndex(commonInvertedIndexMeta);
@@ -119,18 +121,18 @@
         let indexMeta = {};
         if (isEnterprise) {
           indexMeta = {type: "inverted", fields: [
-            {name: "geo", analyzer: testAnalyzers[basename].name},
+            {name: "geo", analyzer: testAnalyzers[basename].name()},
             {"name": "value", "nested": [{"name": "nested_1", "nested": [{"name": "nested_2"}]}]}]
                       };
         } else {
           indexMeta = {type: "inverted", fields: [
-            {name: "geo", analyzer: testAnalyzers[basename].name},
+            {name: "geo", analyzer: testAnalyzers[basename].name()},
             {"name": "value[*]"}]
                       };
         }
         let i = withView[basename].ensureIndex(indexMeta);
-        view = db._createView(basename + '_' + viewName, "search-alias", {
-          indexes: [{collection: withView[basename].name, index: i.name}]
+        plainView[basename] = db._createView(basename + '_' + viewName, "search-alias", {
+          indexes: [{collection: withView[basename].name(), index: i.name}]
         });
       } else {
         let meta = {
@@ -139,20 +141,19 @@
         };
 
         if (isEnterprise) {
-          meta['links'][withView[basename].name] = {
-            fields: {geo: {analyzers: [testAnalyzers[basename].name]}, "value": { "nested": { "nested_1": {"nested": {"nested_2": {}}}}}}
+          meta['links'][withView[basename].name()] = {
+            fields: {geo: {analyzers: [testAnalyzers[basename].name()]}, "value": { "nested": { "nested_1": {"nested": {"nested_2": {}}}}}}
           };
         } else {
-          meta['links'][withView[basename].name] = {
-            fields: {geo: {analyzers: [testAnalyzers[basename].name]}}
+          meta['links'][withView[basename].name()] = {
+            fields: {geo: {analyzers: [testAnalyzers[basename].name()]}}
           };
         }
-        view[basename] = db._createView(basename + '_' + viewName, "arangosearch", meta);
+        plainView[basename] = db._createView(basename + '_' + viewName, "arangosearch", meta);
       }
     }
     function insertAll(name, x) {
       if (!noIndex.hasOwnProperty(name)) {
-        print(name)
         createCollectionSet(name);
       }
 
@@ -262,7 +263,6 @@
 
     function createOnePolygon() {
       insertAll('createOnePolygon', [{geo: { type: "Point", coordinates: [50, 50] } }]);
-      waitForArangoSearch();
     }
     function createTwoPolygons() {
       // Centroid will be at approx. [7,10]
@@ -272,7 +272,6 @@
         {geo:{type:"Polygon",
               coordinates:[[[0,0],[10,10],[0,20],[0,19],[9,10],[0,1],[0,0]]]}}
       ]);
-      waitForArangoSearch();
     }
     function createThreePolygons() {
       insertAll('createThreePolygons', [
@@ -284,7 +283,6 @@
               coordinates:[[[10,10],[20,10],[20,20],[10,20],[10,11.1],
                             [11,11.1],[11,19],[19,19],[19,11],[10,11],[10,10]]]}}
       ]);
-      waitForArangoSearch();
     }
     function createSomePolygons() {
       let name = 'createSomePolygons';
@@ -328,7 +326,6 @@
           [ 37.614, 55.7058 ],
           [ 37.614, 55.7050 ]]]
       ]}}]);
-      waitForArangoSearch();
     }
     function createNearGrid() {
       const name = 'createNearGrid';
@@ -345,7 +342,6 @@
       if (l.length > 0) {
         insertAll(name, l);
       }
-      waitForArangoSearch();
     }
     function createNarrowGrid() {
       const name = 'createNarrowGrid';
@@ -370,7 +366,6 @@
       if (l.length > 0) {
         insertAll(name, l);
       }
-      waitForArangoSearch();
     }
     function createNearSlidingObject() {
       const name = 'createNearSlidingObject';
@@ -395,7 +390,6 @@
       if (l.length > 0) {
         insertAll(name, l);
       }
-      waitForArangoSearch();
     }
     function createLargeGrid() {
       const name = 'createLargeGrid';
@@ -412,7 +406,6 @@
       if (l.length > 0) {
         insertAll(name, l);
       }
-      waitForArangoSearch();
     }
     function createSuperLargeGrid() {
       const name = 'createSuperLargeGrid';
@@ -436,7 +429,6 @@
       if (l.length > 0) {
         insertAll(name, l);
       }
-      waitForArangoSearch();
     }
     function createBiggestGrid() {
       const name = 'createBiggestGrid';
@@ -460,7 +452,6 @@
       if (l.length > 0) {
         insertAll(name, l);
       }
-      waitForArangoSearch();
     }
     return {
 
@@ -483,7 +474,7 @@
         createLargeGrid();
         createSuperLargeGrid();
         createBiggestGrid();
-        view.forEach(oneView => { waitForArangoSearch(viewName.name);});
+        Object.keys(plainView).forEach(key => { waitForArangoSearch(plainView[key].name()); });
       },
 
       ////////////////////////////////////////////////////////////////////////////////
@@ -491,12 +482,11 @@
       ////////////////////////////////////////////////////////////////////////////////
 
       tearDownAll: function () {
-        view.forEach(oneView => { view._drop(); });
-        noIndex.forEach(coll => { coll._drop(); });
-        withIndex.forEach(coll => { coll._drop(); });
-        withView.forEach(coll => { coll._drop(); });
-        let analyzers = require("@arangodb/analyzers");
-        analyzers.remove("geo_json");
+        Object.keys(plainView).forEach(key => { plainView[key].drop(); });
+        Object.keys(noIndex).forEach(key => { noIndex[key].drop(); });
+        Object.keys(withIndex).forEach(key => { withIndex[key].drop(); });
+        Object.keys(withView).forEach(key => { withView[key].drop(); });
+        //Object.keys(testAnalyzers).forEach(key => { testAnalyzers[key].drop(); });
       },
 
       ////////////////////////////////////////////////////////////////////////////////
@@ -514,7 +504,7 @@
         chooseCollectionSet('createOnePolygon');
         let c = compare(
           `FILTER GEO_DISTANCE([50, 50], d.geo) < 5000`,
-          `SEARCH ANALYZER(GEO_DISTANCE([50, 50], d.geo) < 5000, "geo_json")`
+          `SEARCH ANALYZER(GEO_DISTANCE([50, 50], d.geo) < 5000, "${analyzerName}")`
         );
         assertTrue(c.cmpResFullScanWithIndexes.good && c.cmpResView.good && c.cmpResInvertedIndex.good, c.cmpResFullScanWithIndexes.msg + c.cmpResView.msg + c.cmpResInvertedIndex.msg);
       },
@@ -527,7 +517,7 @@
         chooseCollectionSet('createThreePolygons');
         let c = compare(
           `FILTER GEO_DISTANCE([15, 15], d.geo) <= 5000`,
-          `SEARCH ANALYZER(GEO_DISTANCE([15, 15], d.geo) <= 5000, "geo_json")`
+          `SEARCH ANALYZER(GEO_DISTANCE([15, 15], d.geo) <= 5000, "${analyzerName}")`
         );
         assertTrue(c.cmpResFullScanWithIndexes.good && c.cmpResView.good && c.cmpResInvertedIndex.good, c.cmpResFullScanWithIndexes.msg + c.cmpResView.msg + c.cmpResInvertedIndex.msg);
       },
@@ -540,7 +530,7 @@
         chooseCollectionSet('createNearGrid');
         let c = compare(
           `FILTER GEO_DISTANCE([15, 15], d.geo) <= 666666`,
-          `SEARCH ANALYZER(GEO_DISTANCE([15, 15], d.geo) <= 666666, "geo_json")`
+          `SEARCH ANALYZER(GEO_DISTANCE([15, 15], d.geo) <= 666666, "${analyzerName}")`
         );
         assertTrue(c.cmpResFullScanWithIndexes.good && c.cmpResView.good && c.cmpResInvertedIndex.good, c.cmpResFullScanWithIndexes.msg + c.cmpResView.msg + c.cmpResInvertedIndex.msg);
       },
@@ -555,7 +545,7 @@
           `FILTER GEO_DISTANCE([15, 15], d.geo) <= 666666 &&
                 GEO_DISTANCE([15, 15], d.geo) >= 300000`,
           `SEARCH ANALYZER(GEO_DISTANCE([15, 15], d.geo) <= 666666 &&
-                         GEO_DISTANCE([15, 15], d.geo) >= 300000, "geo_json")`
+                         GEO_DISTANCE([15, 15], d.geo) >= 300000, "${analyzerName}")`
         );
         assertTrue(c.cmpResFullScanWithIndexes.good && c.cmpResView.good && c.cmpResInvertedIndex.good, c.cmpResFullScanWithIndexes.msg + c.cmpResView.msg + c.cmpResInvertedIndex.msg);
       },
@@ -568,7 +558,7 @@
         chooseCollectionSet('createNearGrid');
         let c = compare(
           `FILTER GEO_DISTANCE([15, 15], d.geo) >= 300000`,
-          `SEARCH ANALYZER(GEO_DISTANCE([15, 15], d.geo) >= 300000, "geo_json")`
+          `SEARCH ANALYZER(GEO_DISTANCE([15, 15], d.geo) >= 300000, "${analyzerName}")`
         );
         assertTrue(c.cmpResFullScanWithIndexes.good && c.cmpResView.good && c.cmpResInvertedIndex.good, c.cmpResFullScanWithIndexes.msg + c.cmpResView.msg + c.cmpResInvertedIndex.msg);
       },
@@ -582,7 +572,7 @@
         let c = compare(
           `FILTER GEO_DISTANCE([15, 15], d.geo) <= 666666
          SORT GEO_DISTANCE([15, 15], d.geo) DESC`,
-          `SEARCH ANALYZER(GEO_DISTANCE([15, 15], d.geo) <= 666666, "geo_json")
+          `SEARCH ANALYZER(GEO_DISTANCE([15, 15], d.geo) <= 666666, "${analyzerName}")
          SORT GEO_DISTANCE([15, 15], d.geo) DESC`
         );
         assertTrue(c.cmpResFullScanWithIndexes.good && c.cmpResView.good && c.cmpResInvertedIndex.good, c.cmpResFullScanWithIndexes.msg + c.cmpResView.msg + c.cmpResInvertedIndex.msg);
@@ -599,7 +589,7 @@
                 GEO_DISTANCE([15, 15], d.geo) >= 300000
          SORT GEO_DISTANCE([15, 15], d.geo) DESC`,
           `SEARCH ANALYZER(GEO_DISTANCE([15, 15], d.geo) <= 666666 &&
-                         GEO_DISTANCE([15, 15], d.geo) >= 300000, "geo_json")
+                         GEO_DISTANCE([15, 15], d.geo) >= 300000, "${analyzerName}")
          SORT GEO_DISTANCE([15, 15], d.geo) DESC`
         );
         assertTrue(c.cmpResFullScanWithIndexes.good && c.cmpResView.good && c.cmpResInvertedIndex.good, c.cmpResFullScanWithIndexes.msg + c.cmpResView.msg + c.cmpResInvertedIndex.msg);
@@ -613,7 +603,7 @@
         chooseCollectionSet('createNearGrid');
         let c = compare(
           `FILTER GEO_DISTANCE([15, 15], d.geo) >= 300000`,
-          `SEARCH ANALYZER(GEO_DISTANCE([15, 15], d.geo) >= 300000, "geo_json")`
+          `SEARCH ANALYZER(GEO_DISTANCE([15, 15], d.geo) >= 300000, "${analyzerName}")`
         );
         assertTrue(c.cmpResFullScanWithIndexes.good && c.cmpResView.good && c.cmpResInvertedIndex.good, c.cmpResFullScanWithIndexes.msg + c.cmpResView.msg + c.cmpResInvertedIndex.msg);
       },
@@ -626,7 +616,7 @@
         chooseCollectionSet('createNarrowGrid');
         let c = compare(
           `FILTER GEO_DISTANCE([10, 10], d.geo) <= 555974`,
-          `SEARCH ANALYZER(GEO_DISTANCE([10, 10], d.geo) <= 555974, "geo_json")`
+          `SEARCH ANALYZER(GEO_DISTANCE([10, 10], d.geo) <= 555974, "${analyzerName}")`
         );
         assertTrue(c.cmpResFullScanWithIndexes.good && c.cmpResView.good && c.cmpResInvertedIndex.good, c.cmpResFullScanWithIndexes.msg + c.cmpResView.msg + c.cmpResInvertedIndex.msg);
       },
@@ -639,7 +629,7 @@
         chooseCollectionSet('createNearSlidingObject');
         let c = compare(
           `FILTER GEO_DISTANCE([10, 10], d.geo) <= 555974`,
-          `SEARCH ANALYZER(GEO_DISTANCE([10, 10], d.geo) <= 555974, "geo_json")`
+          `SEARCH ANALYZER(GEO_DISTANCE([10, 10], d.geo) <= 555974, "${analyzerName}")`
         );
         assertTrue(c.cmpResFullScanWithIndexes.good && c.cmpResView.good && c.cmpResInvertedIndex.good, c.cmpResFullScanWithIndexes.msg + c.cmpResView.msg + c.cmpResInvertedIndex.msg);
       },
@@ -655,7 +645,7 @@
           //print("Distance", dist);
           let c = compare(
             `FILTER GEO_DISTANCE([4.7874, 10.0735], d.geo) <= ${dist}`,
-            `SEARCH ANALYZER(GEO_DISTANCE([4.7874, 10.0735], d.geo) <= ${dist}, "geo_json")`
+            `SEARCH ANALYZER(GEO_DISTANCE([4.7874, 10.0735], d.geo) <= ${dist}, "${analyzerName}")`
           );
           assertTrue(c.cmpResFullScanWithIndexes.good && c.cmpResView.good && c.cmpResInvertedIndex.good, c.cmpResFullScanWithIndexes.msg + c.cmpResView.msg + c.cmpResInvertedIndex.msg);
         }
@@ -675,7 +665,7 @@
             //print("Polygon:", JSON.stringify(p));
             let c = compare(
               `FILTER GEO_CONTAINS(${JSON.stringify(p)}, d.geo)`,
-              `SEARCH ANALYZER(GEO_CONTAINS(${JSON.stringify(p)}, d.geo), "geo_json")`
+              `SEARCH ANALYZER(GEO_CONTAINS(${JSON.stringify(p)}, d.geo), "${analyzerName}")`
             );
             assertTrue(c.cmpResFullScanWithIndexes.good && c.cmpResView.good && c.cmpResInvertedIndex.good, c.cmpResFullScanWithIndexes.msg + c.cmpResView.msg + c.cmpResInvertedIndex.msg);
           }
@@ -696,7 +686,7 @@
           //print("d=", d, JSON.stringify(p));
           let c = compare(
             `FILTER GEO_CONTAINS(${JSON.stringify(p)}, d.geo)`,
-            `SEARCH ANALYZER(GEO_CONTAINS(${JSON.stringify(p)}, d.geo), "geo_json")`
+            `SEARCH ANALYZER(GEO_CONTAINS(${JSON.stringify(p)}, d.geo), "${analyzerName}")`
           );
           if (!isInt) {
             assertTrue(c.cmpResFullScanWithIndexes.good && c.cmpResView.good && c.cmpResInvertedIndex.good, c.cmpResFullScanWithIndexes.msg + c.cmpResView.msg + c.cmpResInvertedIndex.msg);
@@ -719,7 +709,7 @@
           //print("d=", d, JSON.stringify(p));
           let c = compare(
             `FILTER GEO_CONTAINS(${JSON.stringify(p)}, d.geo)`,
-            `SEARCH ANALYZER(GEO_CONTAINS(${JSON.stringify(p)}, d.geo), "geo_json")`
+            `SEARCH ANALYZER(GEO_CONTAINS(${JSON.stringify(p)}, d.geo), "${analyzerName}")`
           );
           if (!isInt) {
             assertTrue(c.cmpResFullScanWithIndexes.good && c.cmpResView.good && c.cmpResInvertedIndex.good, c.cmpResFullScanWithIndexes.msg + c.cmpResView.msg + c.cmpResInvertedIndex.msg);
@@ -741,7 +731,7 @@
             //print("Polygon:", JSON.stringify(p));
             let c = compare(
               `FILTER GEO_INTERSECTS(${JSON.stringify(p)}, d.geo)`,
-              `SEARCH ANALYZER(GEO_INTERSECTS(${JSON.stringify(p)}, d.geo), "geo_json")`
+              `SEARCH ANALYZER(GEO_INTERSECTS(${JSON.stringify(p)}, d.geo), "${analyzerName}")`
             );
             assertTrue(c.cmpResFullScanWithIndexes.good && c.cmpResView.good && c.cmpResInvertedIndex.good, c.cmpResFullScanWithIndexes.msg + c.cmpResView.msg + c.cmpResInvertedIndex.msg);
           }
@@ -762,7 +752,7 @@
           //print("d=", d, JSON.stringify(p));
           let c = compare(
             `FILTER GEO_INTERSECTS(${JSON.stringify(p)}, d.geo)`,
-            `SEARCH ANALYZER(GEO_INTERSECTS(${JSON.stringify(p)}, d.geo), "geo_json")`
+            `SEARCH ANALYZER(GEO_INTERSECTS(${JSON.stringify(p)}, d.geo), "${analyzerName}")`
           );
           if (!isInt) {
             assertTrue(c.cmpResFullScanWithIndexes.good && c.cmpResView.good && c.cmpResInvertedIndex.good, c.cmpResFullScanWithIndexes.msg + c.cmpResView.msg + c.cmpResInvertedIndex.msg);
@@ -785,7 +775,7 @@
           //print("d=", d, JSON.stringify(p));
           let c = compare(
             `FILTER GEO_INTERSECTS(${JSON.stringify(p)}, d.geo)`,
-            `SEARCH ANALYZER(GEO_INTERSECTS(${JSON.stringify(p)}, d.geo), "geo_json")`
+            `SEARCH ANALYZER(GEO_INTERSECTS(${JSON.stringify(p)}, d.geo), "${analyzerName}")`
           );
           if (!isInt) {
             assertTrue(c.cmpResFullScanWithIndexes.good && c.cmpResView.good && c.cmpResInvertedIndex.good, c.cmpResFullScanWithIndexes.msg + c.cmpResView.msg + c.cmpResInvertedIndex.msg);
@@ -805,7 +795,7 @@
                                        [4.7873, 10.0736], [4.7873, 10.0734]]]};
         let c = compare(
           `FILTER GEO_INTERSECTS(${JSON.stringify(smallPoly)}, d.geo)`,
-          `SEARCH ANALYZER(GEO_INTERSECTS(${JSON.stringify(smallPoly)}, d.geo), "geo_json")`
+          `SEARCH ANALYZER(GEO_INTERSECTS(${JSON.stringify(smallPoly)}, d.geo), "${analyzerName}")`
         );
         assertTrue(c.cmpResFullScanWithIndexes.good && c.cmpResView.good && c.cmpResInvertedIndex.good, c.cmpResFullScanWithIndexes.msg + c.cmpResView.msg + c.cmpResInvertedIndex.msg);
       },
@@ -835,7 +825,7 @@
         for (let p of polys) {
           let c = compare(
             `FILTER GEO_CONTAINS(${JSON.stringify(p)}, d.geo)`,
-            `SEARCH ANALYZER(GEO_CONTAINS(${JSON.stringify(p)}, d.geo), "geo_json")`
+            `SEARCH ANALYZER(GEO_CONTAINS(${JSON.stringify(p)}, d.geo), "${analyzerName}")`
           );
           if (!isInt) {
             assertTrue(c.cmpResFullScanWithIndexes.good && c.cmpResView.good && c.cmpResInvertedIndex.good, c.cmpResFullScanWithIndexes.msg + c.cmpResView.msg + c.cmpResInvertedIndex.msg);
@@ -869,7 +859,7 @@
         for (let p of polys) {
           let c = compare(
             `FILTER GEO_CONTAINS(${JSON.stringify(p)}, d.geo)`,
-            `SEARCH ANALYZER(GEO_CONTAINS(${JSON.stringify(p)}, d.geo), "geo_json")`
+            `SEARCH ANALYZER(GEO_CONTAINS(${JSON.stringify(p)}, d.geo), "${analyzerName}")`
           );
           assertTrue(c.cmpResFullScanWithIndexes.good && c.cmpResView.good && c.cmpResInvertedIndex.good, c.cmpResFullScanWithIndexes.msg + c.cmpResView.msg + c.cmpResInvertedIndex.msg);
         }
@@ -901,7 +891,7 @@
         for (let p of polys) {
           let c = compare(
             `FILTER GEO_CONTAINS(${JSON.stringify(p)}, d.geo)`,
-            `SEARCH ANALYZER(GEO_CONTAINS(${JSON.stringify(p)}, d.geo), "geo_json")`
+            `SEARCH ANALYZER(GEO_CONTAINS(${JSON.stringify(p)}, d.geo), "${analyzerName}")`
           );
           assertTrue(c.cmpResFullScanWithIndexes.good && c.cmpResView.good && c.cmpResInvertedIndex.good, c.cmpResFullScanWithIndexes.msg + c.cmpResView.msg + c.cmpResInvertedIndex.msg);
         }
@@ -920,7 +910,7 @@
         };
         let c = compare(
           `FILTER GEO_DISTANCE(${JSON.stringify(multiLineString)}, d.geo) < 100`,
-          `SEARCH ANALYZER(GEO_DISTANCE(${JSON.stringify(multiLineString)}, d.geo) < 100, "geo_json")`
+          `SEARCH ANALYZER(GEO_DISTANCE(${JSON.stringify(multiLineString)}, d.geo) < 100, "${analyzerName}")`
         );
         assertTrue(c.cmpResFullScanWithIndexes.good && c.cmpResView.good && c.cmpResInvertedIndex.good, c.cmpResFullScanWithIndexes.msg + c.cmpResView.msg + c.cmpResInvertedIndex.msg);
         multiLineString = {
@@ -929,7 +919,7 @@
                            [[ 37.614323, 55.70652 ], [ 37.615825, 55.70652 ]] ] };
         c = compare(
           `FILTER GEO_DISTANCE(${JSON.stringify(multiLineString)}, d.geo) < 100`,
-          `SEARCH ANALYZER(GEO_DISTANCE(${JSON.stringify(multiLineString)}, d.geo) < 100, "geo_json")`
+          `SEARCH ANALYZER(GEO_DISTANCE(${JSON.stringify(multiLineString)}, d.geo) < 100, "${analyzerName}")`
         );
         assertTrue(c.cmpResFullScanWithIndexes.good && c.cmpResView.good && c.cmpResInvertedIndex.good, c.cmpResFullScanWithIndexes.msg + c.cmpResView.msg + c.cmpResInvertedIndex.msg);
         let multiPoint = {
@@ -938,7 +928,7 @@
                          [ 6.621, 50.332 ], [ 6.621, 50.376 ] ] };
         c = compare(
           `FILTER GEO_DISTANCE(${JSON.stringify(multiPoint)}, d.geo) < 100`,
-          `SEARCH ANALYZER(GEO_DISTANCE(${JSON.stringify(multiPoint)}, d.geo) < 100, "geo_json")`
+          `SEARCH ANALYZER(GEO_DISTANCE(${JSON.stringify(multiPoint)}, d.geo) < 100, "${analyzerName}")`
         );
         assertTrue(c.cmpResFullScanWithIndexes.good && c.cmpResView.good && c.cmpResInvertedIndex.good, c.cmpResFullScanWithIndexes.msg + c.cmpResView.msg + c.cmpResInvertedIndex.msg);
         multiPoint = {
@@ -947,7 +937,7 @@
                            [ 37.614323, 55.70652 ], [ 37.615825, 55.70652 ] ] };
         c = compare(
           `FILTER GEO_DISTANCE(${JSON.stringify(multiPoint)}, d.geo) < 100`,
-          `SEARCH ANALYZER(GEO_DISTANCE(${JSON.stringify(multiPoint)}, d.geo) < 100, "geo_json")`
+          `SEARCH ANALYZER(GEO_DISTANCE(${JSON.stringify(multiPoint)}, d.geo) < 100, "${analyzerName}")`
         );
         assertTrue(c.cmpResFullScanWithIndexes.good && c.cmpResView.good && c.cmpResInvertedIndex.good, c.cmpResFullScanWithIndexes.msg + c.cmpResView.msg + c.cmpResInvertedIndex.msg);
       },
@@ -965,7 +955,7 @@
 
         let c = compare(
           `FILTER GEO_IN_RANGE(${JSON.stringify(multiLineString)}, d.geo, 0, 100)`,
-          `SEARCH ANALYZER(GEO_IN_RANGE(${JSON.stringify(multiLineString)}, d.geo, 0, 100), "geo_json")`
+          `SEARCH ANALYZER(GEO_IN_RANGE(${JSON.stringify(multiLineString)}, d.geo, 0, 100), "${analyzerName}")`
         );
         assertTrue(c.cmpResFullScanWithIndexes.good && c.cmpResView.good && c.cmpResInvertedIndex.good, c.cmpResFullScanWithIndexes.msg + c.cmpResView.msg + c.cmpResInvertedIndex.msg);
         multiLineString = {
@@ -975,7 +965,7 @@
 
         c = compare(
           `FILTER GEO_IN_RANGE(${JSON.stringify(multiLineString)}, d.geo, 0, 100)`,
-          `SEARCH ANALYZER(GEO_IN_RANGE(${JSON.stringify(multiLineString)}, d.geo, 0, 100), "geo_json")`
+          `SEARCH ANALYZER(GEO_IN_RANGE(${JSON.stringify(multiLineString)}, d.geo, 0, 100), "${analyzerName}")`
         );
         assertTrue(c.cmpResFullScanWithIndexes.good && c.cmpResView.good && c.cmpResInvertedIndex.good, c.cmpResFullScanWithIndexes.msg + c.cmpResView.msg + c.cmpResInvertedIndex.msg);
         let multiPoint = {
@@ -985,7 +975,7 @@
 
         c = compare(
           `FILTER GEO_IN_RANGE(${JSON.stringify(multiPoint)}, d.geo, 0, 100)`,
-          `SEARCH ANALYZER(GEO_IN_RANGE(${JSON.stringify(multiPoint)}, d.geo, 0, 100), "geo_json")`
+          `SEARCH ANALYZER(GEO_IN_RANGE(${JSON.stringify(multiPoint)}, d.geo, 0, 100), "${analyzerName}")`
         );
         assertTrue(c.cmpResFullScanWithIndexes.good && c.cmpResView.good && c.cmpResInvertedIndex.good, c.cmpResFullScanWithIndexes.msg + c.cmpResView.msg + c.cmpResInvertedIndex.msg);
         multiPoint = {
@@ -996,7 +986,7 @@
 
         c = compare(
           `FILTER GEO_IN_RANGE(${JSON.stringify(multiPoint)}, d.geo, 0, 100)`,
-          `SEARCH ANALYZER(GEO_IN_RANGE(${JSON.stringify(multiPoint)}, d.geo, 0, 100), "geo_json")`
+          `SEARCH ANALYZER(GEO_IN_RANGE(${JSON.stringify(multiPoint)}, d.geo, 0, 100), "${analyzerName}")`
         );
         assertTrue(c.cmpResFullScanWithIndexes.good && c.cmpResView.good && c.cmpResInvertedIndex.good, c.cmpResFullScanWithIndexes.msg + c.cmpResView.msg + c.cmpResInvertedIndex.msg);
       },

--- a/tests/js/server/aql/aql-geo.inc
+++ b/tests/js/server/aql/aql-geo.inc
@@ -30,11 +30,11 @@
 
 (function () {
   const disableViewTests = false;
-
   const jsunity = require("jsunity");
   const db = require("@arangodb").db;
   const errors = require("@arangodb").errors;
   const helper = require("@arangodb/aql-helper");
+  const analyzers = require("@arangodb/analyzers");
   const getQueryResults = helper.getQueryResults;
   const assertQueryError = helper.assertQueryError;
   const deriveTestSuite = require('@arangodb/test-helper').deriveTestSuite;
@@ -60,35 +60,108 @@
       };
     }
 
-    let collWithoutIndex = "UnitTestsGeoWithoutIndex";
-    let collWithIndex = "UnitTestsGeoWithIndex";
-    let collWithView = "UnitTestsGeoWithView";
-    let viewName = "UnitTestsGeoView";
-    let noIndex;
-    let withIndex;
-    let withView;
-    let view;
+    let collWithoutIndex = null;
+    let collWithIndex = null;
+    let collWithView = null;
+    let viewName = null;
+    let noIndex = [];
+    let withIndex = [];
+    let withView = [];
+    let view = [];
+    let testAnalyzers = [];
 
     let keyCounter = 0;
 
-    function waitForArangoSearch() {
+    function waitForArangoSearch(viewName) {
       let res = getQueryResults(
         `FOR d IN ${viewName} OPTIONS { waitForSync:true } LIMIT 1 RETURN 1`);
     }
+    function chooseCollectionSet(basename) {
+      collWithoutIndex = noIndex[basename].name;
+      collWithIndex = withIndex[basename].name;
+      collWithView = withIndex[basename].name;
+      viewName = view[basename].name;
+    }
+    function createCollectionSet(basename) {
+      let collWithoutIndex = "UnitTestsGeoWithoutIndex";
+      let collWithIndex = "UnitTestsGeoWithIndex";
+      let collWithView = "UnitTestsGeoWithView";
+      let viewName = "UnitTestsGeoView";
+      noIndex[basename] = db._create(basename + '_' + collWithoutIndex);
+      withIndex[basename] = db._create(basename + '_' + collWithIndex);
+      withIndex[basename].ensureIndex({type: "geo", geoJson: true, fields: ["geo"]});
+      withView[basename] = db._create(basename + '_' + collWithView);
+      testAnalyzers[basename] = analyzers.save(basename + "_geo_json", analyzerType, analyzerDefinition, ["frequency", "norm", "position"]);
 
+      withIndex[basename].save({ name_1: "name", "value": [{ "nested_1": [{ "nested_2": "foo123"}]}]});
+      withView[basename].save({ name_1: "name", "value": [{ "nested_1": [{ "nested_2": "foo123"}]}]});
+
+      // ensure inverted indexes for each collections
+
+      let commonInvertedIndexMeta = {};
+      if (isEnterprise) {
+        commonInvertedIndexMeta = {type: "inverted", name: "inverted", includeAllFields: true, fields:[
+          {"name": "value", "nested": [{"name": "nested_1", "nested": [{"name": "nested_2"}]}]},
+          "name_1",
+          {"name": "geo", "analyzer": testAnalyzers[basename].name}
+        ]};
+      } else {
+        commonInvertedIndexMeta = {type: "inverted", name: "inverted", includeAllFields: true, fields:[
+          {"name": "value[*]"},
+          "name_1",
+          {"name": "geo", "analyzer": testAnalyzers[basename].name}
+        ]};
+      }
+      withView[basename].ensureIndex(commonInvertedIndexMeta);
+      withIndex[basename].ensureIndex(commonInvertedIndexMeta);
+
+      if (isSearchAlias) {
+        let indexMeta = {};
+        if (isEnterprise) {
+          indexMeta = {type: "inverted", fields: [
+            {name: "geo", analyzer: testAnalyzers[basename].name},
+            {"name": "value", "nested": [{"name": "nested_1", "nested": [{"name": "nested_2"}]}]}]
+                      };
+        } else {
+          indexMeta = {type: "inverted", fields: [
+            {name: "geo", analyzer: testAnalyzers[basename].name},
+            {"name": "value[*]"}]
+                      };
+        }
+        let i = withView[basename].ensureIndex(indexMeta);
+        view = db._createView(basename + '_' + viewName, "search-alias", {
+          indexes: [{collection: withView[basename].name, index: i.name}]
+        });
+      } else {
+        let meta = {
+          links: {
+          }
+        };
+
+        if (isEnterprise) {
+          meta['links'][withView[basename].name] = {
+            fields: {geo: {analyzers: [testAnalyzers[basename].name]}, "value": { "nested": { "nested_1": {"nested": {"nested_2": {}}}}}}
+          };
+        } else {
+          meta['links'][withView[basename].name] = {
+            fields: {geo: {analyzers: [testAnalyzers[basename].name]}}
+          };
+        }
+        view[basename] = db._createView(basename + '_' + viewName, "arangosearch", meta);
+      }
+    }
     function insertAll(name, x) {
+      if (!noIndex.hasOwnProperty(name)) {
+        print(name)
+        createCollectionSet(name);
+      }
+
       for (let i = 0; i < x.length; ++i) {
         x[i]._key = "K" + (++keyCounter);
       }
-      noIndex.insert(x);
-      withIndex.insert(x);
-      withView.insert(x);
-    }
-
-    function truncateAll(x) {
-      noIndex.truncate();
-      withIndex.truncate();
-      withView.truncate();
+      noIndex[name].insert(x);
+      withIndex[name].insert(x);
+      withView[name].insert(x);
     }
 
     function compareKeyLists(namea, a, nameb, b) {
@@ -188,12 +261,12 @@
     }
 
     function createOnePolygon() {
-      insertAll([{geo: { type: "Point", coordinates: [50, 50] } }]);
+      insertAll('createOnePolygon', [{geo: { type: "Point", coordinates: [50, 50] } }]);
       waitForArangoSearch();
     }
     function createTwoPolygons() {
       // Centroid will be at approx. [7,10]
-      insertAll([
+      insertAll('createTwoPolygons', [
         {geo:{type:"Polygon",
               coordinates:[[[0,0],[10,10],[0,20],[9,10],[0,0]]]}},
         {geo:{type:"Polygon",
@@ -202,7 +275,7 @@
       waitForArangoSearch();
     }
     function createThreePolygons() {
-      insertAll([
+      insertAll('createThreePolygons', [
         {geo:{type:"Polygon",
               coordinates:[[[10,10],[20,10],[20,20],[10,20],[10,10]]]}},
         {geo:{type:"Polygon",
@@ -214,6 +287,7 @@
       waitForArangoSearch();
     }
     function createSomePolygons() {
+      let name = 'createSomePolygons';
       let lat = 6.537;
       let long = 50.332;
       for (let x = 0; x < 100; ++x) {
@@ -222,27 +296,27 @@
           points.push({ geo: { type: "Point",
                                coordinates: [lat + x/1000, long + y/1000] } });
         }
-        insertAll(points);
+        insertAll(name, points);
       }
-      insertAll([{ geo: { "type": "Polygon", "coordinates": [
+      insertAll(name, [{ geo: { "type": "Polygon", "coordinates": [
         [[ 37.614323, 55.705898 ],
          [ 37.615825, 55.705898 ],
          [ 37.615825, 55.70652  ],
          [ 37.614323, 55.70652  ],
          [ 37.614323, 55.705898 ]]
       ]}}]);
-      insertAll([{ geo: {"type": "LineString", "coordinates": [
+      insertAll(name, [{ geo: {"type": "LineString", "coordinates": [
         [ 6.537, 50.332 ], [ 6.537, 50.376 ]]
                         }}]);
-      insertAll([{ geo: { "type": "MultiLineString", "coordinates": [
+      insertAll(name, [{ geo: { "type": "MultiLineString", "coordinates": [
         [[ 6.537, 50.332 ], [ 6.537, 50.376 ]],
         [[ 6.621, 50.332 ], [ 6.621, 50.376 ]]
       ]}}]);
-      insertAll([{ geo: { "type": "MultiPoint", "coordinates": [
+      insertAll(name, [{ geo: { "type": "MultiPoint", "coordinates": [
         [ 6.537, 50.332 ], [ 6.537, 50.376 ],
         [ 6.621, 50.332 ], [ 6.621, 50.376 ]
       ]}}]);
-      insertAll([{ geo: { "type": "MultiPolygon", "coordinates": [
+      insertAll(name, [{ geo: { "type": "MultiPolygon", "coordinates": [
         [[[ 37.614323, 55.705898 ],
           [ 37.615825, 55.705898 ],
           [ 37.615825, 55.70652  ],
@@ -257,22 +331,24 @@
       waitForArangoSearch();
     }
     function createNearGrid() {
+      const name = 'createNearGrid';
       let l = [];
       for (let lat = 9; lat <= 21; lat += 0.1) {
         for (let lon = 9; lon <= 21; lon += 0.1) {
           l.push({geo:{type:"Point", coordinates:[lon, lat]}});
           if (l.length % 1000 === 0) {
-            insertAll(l);
+            insertAll(name, l);
             l = [];
           }
         }
       }
       if (l.length > 0) {
-        insertAll(l);
+        insertAll(name, l);
       }
       waitForArangoSearch();
     }
     function createNarrowGrid() {
+      const name = 'createNarrowGrid';
       let l = [];
       for (let size = 0.0001; size <= 10; size *= 10) {
         for (let lon = 14.8; lon <= 15.2; lon += 0.04) {
@@ -286,17 +362,18 @@
             centroid: {type: "Point", coordinates: [lon, 10]}
           });
           if (l.length % 1000 === 0) {
-            insertAll(l);
+            insertAll(name, l);
             l = [];
           }
         }
       }
       if (l.length > 0) {
-        insertAll(l);
+        insertAll(name, l);
       }
       waitForArangoSearch();
     }
     function createNearSlidingObject() {
+      const name = 'createNearSlidingObject';
       let l = [];
       for (let size = 1; size <= 11; size += 1) {
         for (let lon = 11; lon <= 30; lon += 0.1) {
@@ -310,75 +387,78 @@
             centroid: {type: "Point", coordinates: [lon, 10]}
           });
           if (l.length % 1000 === 0) {
-            insertAll(l);
+            insertAll(name, l);
             l = [];
           }
         }
       }
       if (l.length > 0) {
-        insertAll(l);
+        insertAll(name, l);
       }
       waitForArangoSearch();
     }
     function createLargeGrid() {
+      const name = 'createLargeGrid';
       let l = [];
       for (let lat = 45; lat <= 55; lat += 1) {
         for (let lon = 90; lon <= 100; lon += 1) {
           l.push({geo: {type: "Point", coordinates: [lon, lat]}});
           if (l.length % 1000 === 0) {
-            insertAll(l);
+            insertAll(name, l);
             l = [];
           }
         }
       }
       if (l.length > 0) {
-        insertAll(l);
+        insertAll(name, l);
       }
       waitForArangoSearch();
     }
     function createSuperLargeGrid() {
+      const name = 'createSuperLargeGrid';
       let l = [];
       for (let lat = 45; lat <= 55; lat += 1) {
         for (let lon = 175; lon < 180; lon += 1) {
           l.push({geo:{type:"Point", coordinates:[lon, lat]}});
           if (l.length % 1000 === 0) {
-            insertAll(l);
+            insertAll(name, l);
             l = [];
           }
         }
         for (let lon = -179; lon <= -170; lon += 1) {
           l.push({geo:{type:"Point", coordinates:[lon, lat]}});
           if (l.length % 1000 === 0) {
-            insertAll(l);
+            insertAll(name, l);
             l = [];
           }
         }
       }
       if (l.length > 0) {
-        insertAll(l);
+        insertAll(name, l);
       }
       waitForArangoSearch();
     }
     function createBiggestGrid() {
+      const name = 'createBiggestGrid';
       let l = [];
       for (let lat = 85; lat < 90; lat += 1) {
         for (let lon = 175; lon < 180; lon += 1) {
           l.push({geo:{type:"Point", coordinates:[lon, lat]}});
           if (l.length % 1000 === 0) {
-            insertAll(l);
+            insertAll(name, l);
             l = [];
           }
         }
         for (let lon = -179; lon <= -170; lon += 1) {
           l.push({geo:{type:"Point", coordinates:[lon, lat]}});
           if (l.length % 1000 === 0) {
-            insertAll(l);
+            insertAll(name, l);
             l = [];
           }
         }
       }
       if (l.length > 0) {
-        insertAll(l);
+        insertAll(name, l);
       }
       waitForArangoSearch();
     }
@@ -389,78 +469,21 @@
       ////////////////////////////////////////////////////////////////////////////////
 
       setUpAll: function () {
-        db._dropView(viewName);
-        db._drop(collWithoutIndex);
-        db._drop(collWithIndex);
-        db._drop(collWithView);
-
-        noIndex = db._create(collWithoutIndex);
-        withIndex = db._create(collWithIndex);
-        withIndex.ensureIndex({type: "geo", geoJson: true, fields: ["geo"]});
-        withView = db._create(collWithView);
-        let analyzers = require("@arangodb/analyzers");
-        analyzers.save("geo_json", analyzerType, analyzerDefinition, ["frequency", "norm", "position"]);
-
-        withIndex.save({ name_1: "name", "value": [{ "nested_1": [{ "nested_2": "foo123"}]}]});
-        withView.save({ name_1: "name", "value": [{ "nested_1": [{ "nested_2": "foo123"}]}]});
-
-        // ensure inverted indexes for each collections
-
-        let commonInvertedIndexMeta = {};
-        if (isEnterprise) {
-          commonInvertedIndexMeta = {type: "inverted", name: "inverted", includeAllFields: true, fields:[
-            {"name": "value", "nested": [{"name": "nested_1", "nested": [{"name": "nested_2"}]}]},
-            "name_1",
-            {"name": "geo", "analyzer": "geo_json"}
-          ]};
-        } else {
-          commonInvertedIndexMeta = {type: "inverted", name: "inverted", includeAllFields: true, fields:[
-            {"name": "value[*]"},
-            "name_1",
-            {"name": "geo", "analyzer": "geo_json"}
-          ]};
-        }
-        withView.ensureIndex(commonInvertedIndexMeta);
-        withIndex.ensureIndex(commonInvertedIndexMeta);
-
-        if (isSearchAlias) {
-          let indexMeta = {};
-          if (isEnterprise) {
-            indexMeta = {type: "inverted", fields: [
-              {name: "geo", analyzer: "geo_json"},
-              {"name": "value", "nested": [{"name": "nested_1", "nested": [{"name": "nested_2"}]}]}]
-                        };
-          } else {
-            indexMeta = {type: "inverted", fields: [
-              {name: "geo", analyzer: "geo_json"},
-              {"name": "value[*]"}]
-                        };
-          }
-          let i = db.UnitTestsGeoWithView.ensureIndex(indexMeta);
-          view = db._createView(viewName, "search-alias", {
-            indexes: [{collection: "UnitTestsGeoWithView", index: i.name}]
-          });
-        } else {
-          let meta = {};
-          if (isEnterprise) {
-            meta = {
-              links: {
-                UnitTestsGeoWithView: {
-                  fields: {geo: {analyzers: ["geo_json"]}, "value": { "nested": { "nested_1": {"nested": {"nested_2": {}}}}}}
-                }
-              }
-            };
-          } else {
-            meta = {
-              links: {
-                UnitTestsGeoWithView: {
-                  fields: {geo: {analyzers: ["geo_json"]}}
-                }
-              }
-            };
-          }
-          view = db._createView(viewName, "arangosearch", meta);
-        }
+        //db._dropView(viewName);
+        //db._drop(collWithoutIndex);
+        //db._drop(collWithIndex);
+        //db._drop(collWithView);
+        createOnePolygon();
+        createTwoPolygons();
+        createThreePolygons();
+        createSomePolygons();
+        createNearGrid();
+        createNarrowGrid();
+        createNearSlidingObject();
+        createLargeGrid();
+        createSuperLargeGrid();
+        createBiggestGrid();
+        view.forEach(oneView => { waitForArangoSearch(viewName.name);});
       },
 
       ////////////////////////////////////////////////////////////////////////////////
@@ -468,10 +491,10 @@
       ////////////////////////////////////////////////////////////////////////////////
 
       tearDownAll: function () {
-        db._dropView(viewName);
-        db._drop(collWithoutIndex);
-        db._drop(collWithIndex);
-        db._drop(collWithView);
+        view.forEach(oneView => { view._drop(); });
+        noIndex.forEach(coll => { coll._drop(); });
+        withIndex.forEach(coll => { coll._drop(); });
+        withView.forEach(coll => { coll._drop(); });
         let analyzers = require("@arangodb/analyzers");
         analyzers.remove("geo_json");
       },
@@ -481,7 +504,6 @@
       ////////////////////////////////////////////////////////////////////////////////
 
       tearDown: function () {
-        truncateAll();
       },
 
       ////////////////////////////////////////////////////////////////////////////////
@@ -489,7 +511,7 @@
       ////////////////////////////////////////////////////////////////////////////////
 
       testSetup : function () {
-        createOnePolygon();
+        chooseCollectionSet('createOnePolygon');
         let c = compare(
           `FILTER GEO_DISTANCE([50, 50], d.geo) < 5000`,
           `SEARCH ANALYZER(GEO_DISTANCE([50, 50], d.geo) < 5000, "geo_json")`
@@ -502,7 +524,7 @@
       ////////////////////////////////////////////////////////////////////////////////
 
       testPointNearCentroidOfPolygon : function () {
-        createThreePolygons();
+        chooseCollectionSet('createThreePolygons');
         let c = compare(
           `FILTER GEO_DISTANCE([15, 15], d.geo) <= 5000`,
           `SEARCH ANALYZER(GEO_DISTANCE([15, 15], d.geo) <= 5000, "geo_json")`
@@ -515,7 +537,7 @@
       ////////////////////////////////////////////////////////////////////////////////
 
       testNearGrid : function () {
-        createNearGrid();
+        chooseCollectionSet('createNearGrid');
         let c = compare(
           `FILTER GEO_DISTANCE([15, 15], d.geo) <= 666666`,
           `SEARCH ANALYZER(GEO_DISTANCE([15, 15], d.geo) <= 666666, "geo_json")`
@@ -528,7 +550,7 @@
       ////////////////////////////////////////////////////////////////////////////////
 
       testNearGridRingArea : function () {
-        createNearGrid();
+        chooseCollectionSet('createNearGrid');
         let c = compare(
           `FILTER GEO_DISTANCE([15, 15], d.geo) <= 666666 &&
                 GEO_DISTANCE([15, 15], d.geo) >= 300000`,
@@ -543,7 +565,7 @@
       ////////////////////////////////////////////////////////////////////////////////
 
       testNearGridOuterArea : function () {
-        createNearGrid();
+        chooseCollectionSet('createNearGrid');
         let c = compare(
           `FILTER GEO_DISTANCE([15, 15], d.geo) >= 300000`,
           `SEARCH ANALYZER(GEO_DISTANCE([15, 15], d.geo) >= 300000, "geo_json")`
@@ -556,7 +578,7 @@
       ////////////////////////////////////////////////////////////////////////////////
 
       testNearGridDescending : function () {
-        createNearGrid();
+        chooseCollectionSet('createNearGrid');
         let c = compare(
           `FILTER GEO_DISTANCE([15, 15], d.geo) <= 666666
          SORT GEO_DISTANCE([15, 15], d.geo) DESC`,
@@ -571,7 +593,7 @@
       ////////////////////////////////////////////////////////////////////////////////
 
       testNearGridRingAreaDescending : function () {
-        createNearGrid();
+        chooseCollectionSet('createNearGrid');
         let c = compare(
           `FILTER GEO_DISTANCE([15, 15], d.geo) <= 666666 &&
                 GEO_DISTANCE([15, 15], d.geo) >= 300000
@@ -588,7 +610,7 @@
       ////////////////////////////////////////////////////////////////////////////////
 
       testNearGridOuterAreaDescending : function () {
-        createNearGrid();
+        chooseCollectionSet('createNearGrid');
         let c = compare(
           `FILTER GEO_DISTANCE([15, 15], d.geo) >= 300000`,
           `SEARCH ANALYZER(GEO_DISTANCE([15, 15], d.geo) >= 300000, "geo_json")`
@@ -601,7 +623,7 @@
       ////////////////////////////////////////////////////////////////////////////////
 
       testNearObjectsSizes : function () {
-        createNarrowGrid();
+        chooseCollectionSet('createNarrowGrid');
         let c = compare(
           `FILTER GEO_DISTANCE([10, 10], d.geo) <= 555974`,
           `SEARCH ANALYZER(GEO_DISTANCE([10, 10], d.geo) <= 555974, "geo_json")`
@@ -614,7 +636,7 @@
       ////////////////////////////////////////////////////////////////////////////////
 
       testNearSlidingLargeObject : function () {
-        createNearSlidingObject();
+        chooseCollectionSet('createNearSlidingObject');
         let c = compare(
           `FILTER GEO_DISTANCE([10, 10], d.geo) <= 555974`,
           `SEARCH ANALYZER(GEO_DISTANCE([10, 10], d.geo) <= 555974, "geo_json")`
@@ -628,7 +650,7 @@
       ////////////////////////////////////////////////////////////////////////////////
 
       testNearNonConvexObject : function () {
-        createTwoPolygons
+        chooseCollectionSet('createTwoPolygons');
         for (let dist = 1000; dist <= 100000; dist += 100) {
           //print("Distance", dist);
           let c = compare(
@@ -644,7 +666,7 @@
       ////////////////////////////////////////////////////////////////////////////////
 
       testContainsWithSmallPoly : function () {
-        createNearGrid();
+        chooseCollectionSet('createNearGrid');
         let d = 0.001;
         for (let lat = 9; lat <= 11; lat += 0.4) {
           for (let lon = 9; lon <= 11; lon += 0.4) {
@@ -665,7 +687,7 @@
       ////////////////////////////////////////////////////////////////////////////////
 
       testContainsGrid : function () {
-        createNearGrid();
+        chooseCollectionSet('createNearGrid');
         for (let d = 1; d <= 5; d += 1) {
           let p = {
             type: "Polygon", coordinates: [[[15 - d, 15], [15, 15 - d], [15 + d, 15],
@@ -688,7 +710,7 @@
       ////////////////////////////////////////////////////////////////////////////////
 
       testContainsGridComplement : function () {
-        createNearGrid();
+        chooseCollectionSet('createNearGrid');
         for (let d = 1; d <= 5; d += 1) {
           let p = {
             type: "Polygon", coordinates: [[[15 - d, 15], [15, 15 + d], [15 + d, 15],
@@ -710,7 +732,7 @@
       ////////////////////////////////////////////////////////////////////////////////
 
       testIntersectsWithSmallPoly : function () {
-        createNearGrid();
+        chooseCollectionSet('createNearGrid');
         let d = 0.001;
         for (let lat = 9; lat <= 11; lat += 0.4) {
           for (let lon = 9; lon <= 11; lon += 0.4) {
@@ -731,7 +753,7 @@
       ////////////////////////////////////////////////////////////////////////////////
 
       testIntersectsGrid : function () {
-        createNearGrid();
+        chooseCollectionSet('createNearGrid');
         for (let d = 1; d <= 5; d += 1) {
           let p = {
             type: "Polygon", coordinates: [[[15 - d, 15], [15, 15 - d], [15 + d, 15],
@@ -754,7 +776,7 @@
       ////////////////////////////////////////////////////////////////////////////////
 
       testIntersectsGridComplement : function () {
-        createNearGrid();
+        chooseCollectionSet('createNearGrid');
         for (let d = 1; d <= 5; d += 1) {
           let p = {
             type: "Polygon", coordinates: [[[15 - d, 15], [15, 15 + d], [15 + d, 15],
@@ -777,7 +799,7 @@
       ////////////////////////////////////////////////////////////////////////////////
 
       testIntersectsNonConvexObject : function () {
-        createTwoPolygons();
+        chooseCollectionSet('createTwoPolygons');
         let smallPoly = {type:"Polygon",
                          coordinates:[[[4.7873, 10.0734], [4.7875, 10.0734], [4.7875, 10.0736],
                                        [4.7873, 10.0736], [4.7873, 10.0734]]]};
@@ -793,7 +815,7 @@
       ////////////////////////////////////////////////////////////////////////////////
 
       testMoreThanHalf1Grid: function () {
-        createLargeGrid();
+        chooseCollectionSet('createLargeGrid');
         let polys = [
           makePolyInside([-85, 95], [-80, 50]),
           makePolyOutside([-85, 95], [-80, 50]),
@@ -827,7 +849,7 @@
       ////////////////////////////////////////////////////////////////////////////////
 
       testMoreThanHalf2 : function () {
-        createSuperLargeGrid();
+        chooseCollectionSet('createSuperLargeGrid');
         let polys = [
           makePolyInside([-85, 95], [-80, 50]),
           makePolyOutside([-85, 95], [-80, 50]),
@@ -859,7 +881,7 @@
       ////////////////////////////////////////////////////////////////////////////////
 
       testMoreThanHalf3 : function () {
-        createBiggestGrid();
+        chooseCollectionSet('createBiggestGrid');
         let polys = [
           makePolyInside([-85, 95], [-80, 87]),
           makePolyOutside([-85, 95], [-80, 87]),
@@ -890,7 +912,7 @@
       ////////////////////////////////////////////////////////////////////////////////
 
       testMoreNonConvex : function () {
-        createSomePolygons();
+        chooseCollectionSet('createSomePolygons');
         let multiLineString = {
           "type": "MultiLineString",
           "coordinates": [[[6.537, 50.332], [6.537, 50.376]],
@@ -935,7 +957,7 @@
       ////////////////////////////////////////////////////////////////////////////////
 
       testMoreNonConvexGeoInRange : function () {
-        createSomePolygons();
+        chooseCollectionSet('createSomePolygons');
         let multiLineString = {
           "type": "MultiLineString",
           "coordinates": [ [ [ 6.537, 50.332 ], [ 6.537, 50.376 ] ],

--- a/tests/js/server/aql/aql-geo.inc
+++ b/tests/js/server/aql/aql-geo.inc
@@ -187,6 +187,201 @@
     return {cmpResFullScanWithIndexes, cmpResView, cmpResInvertedIndex};
   }
 
+    function createOnePolygon() {
+      insertAll([{geo: { type: "Point", coordinates: [50, 50] } }]);
+      waitForArangoSearch();
+    }
+    function createTwoPolygons() {
+      // Centroid will be at approx. [7,10]
+      insertAll([
+        {geo:{type:"Polygon",
+         coordinates:[[[0,0],[10,10],[0,20],[9,10],[0,0]]]}},
+        {geo:{type:"Polygon",
+         coordinates:[[[0,0],[10,10],[0,20],[0,19],[9,10],[0,1],[0,0]]]}}
+      ]);
+      waitForArangoSearch();
+    }
+    function createThreePolygons() {
+      insertAll([
+        {geo:{type:"Polygon",
+              coordinates:[[[10,10],[20,10],[20,20],[10,20],[10,10]]]}},
+        {geo:{type:"Polygon",
+              coordinates:[[[10,10],[20,10],[30,20],[10,20],[10,10]]]}},
+        {geo:{type:"Polygon",
+              coordinates:[[[10,10],[20,10],[20,20],[10,20],[10,11.1],
+                            [11,11.1],[11,19],[19,19],[19,11],[10,11],[10,10]]]}}
+      ]);
+      waitForArangoSearch();
+    }
+    function createSomePolygons() {
+      let lat = 6.537;
+      let long = 50.332;
+      for (let x = 0; x < 100; ++x) {
+        let points = [];
+        for (let y = 0; y < 100; ++y) {
+          points.push({ geo: { type: "Point",
+              coordinates: [lat + x/1000, long + y/1000] } });
+        }
+        insertAll(points);
+      }
+      insertAll([{ geo: { "type": "Polygon", "coordinates": [
+        [[ 37.614323, 55.705898 ],
+          [ 37.615825, 55.705898 ],
+          [ 37.615825, 55.70652  ],
+          [ 37.614323, 55.70652  ],
+          [ 37.614323, 55.705898 ]]
+      ]}}]);
+      insertAll([{ geo: {"type": "LineString", "coordinates": [
+        [ 6.537, 50.332 ], [ 6.537, 50.376 ]]
+      }}]);
+      insertAll([{ geo: { "type": "MultiLineString", "coordinates": [
+        [[ 6.537, 50.332 ], [ 6.537, 50.376 ]],
+        [[ 6.621, 50.332 ], [ 6.621, 50.376 ]]
+      ]}}]);
+      insertAll([{ geo: { "type": "MultiPoint", "coordinates": [
+        [ 6.537, 50.332 ], [ 6.537, 50.376 ],
+        [ 6.621, 50.332 ], [ 6.621, 50.376 ]
+      ]}}]);
+      insertAll([{ geo: { "type": "MultiPolygon", "coordinates": [
+        [[[ 37.614323, 55.705898 ],
+          [ 37.615825, 55.705898 ],
+          [ 37.615825, 55.70652  ],
+          [ 37.614323, 55.70652  ],
+          [ 37.614323, 55.705898 ]]],
+        [[[ 37.614, 55.7050 ],
+          [ 37.615, 55.7050 ],
+          [ 37.615, 55.7058 ],
+          [ 37.614, 55.7058 ],
+          [ 37.614, 55.7050 ]]]
+      ]}}]);
+      waitForArangoSearch();
+    }
+    function createNearGrid() {
+    let l = [];
+      for (let lat = 9; lat <= 21; lat += 0.1) {
+        for (let lon = 9; lon <= 21; lon += 0.1) {
+          l.push({geo:{type:"Point", coordinates:[lon, lat]}});
+          if (l.length % 1000 === 0) {
+            insertAll(l);
+            l = [];
+          }
+        }
+      }
+      if (l.length > 0) {
+        insertAll(l);
+      }
+      waitForArangoSearch();
+  }
+  function createNarrowGrid() {
+      let l = [];
+      for (let size = 0.0001; size <= 10; size *= 10) {
+        for (let lon = 14.8; lon <= 15.2; lon += 0.04) {
+          l.push({
+            geo: {
+              type: "Polygon",
+              coordinates: [[[lon - size, 10 - size], [lon + size, 10 - size],
+                [lon + size, 10 + size], [lon - size, 10 + size],
+                [lon - size, 10 - size]]]
+            },
+            centroid: {type: "Point", coordinates: [lon, 10]}
+          });
+          if (l.length % 1000 === 0) {
+            insertAll(l);
+            l = [];
+          }
+        }
+      }
+      if (l.length > 0) {
+        insertAll(l);
+      }
+      waitForArangoSearch();
+  }
+  function createNearSlidingObject() {
+      let l = [];
+      for (let size = 1; size <= 11; size += 1) {
+        for (let lon = 11; lon <= 30; lon += 0.1) {
+          l.push({
+            geo: {
+              type: "Polygon",
+              coordinates: [[[lon - size, 10 - size], [lon + size, 10 - size],
+                [lon + size, 10 + size], [lon - size, 10 + size],
+                [lon - size, 10 - size]]]
+            },
+            centroid: {type: "Point", coordinates: [lon, 10]}
+          });
+          if (l.length % 1000 === 0) {
+            insertAll(l);
+            l = [];
+          }
+        }
+      }
+      if (l.length > 0) {
+        insertAll(l);
+      }
+    waitForArangoSearch();
+  }
+    function createLargeGrid() {
+      let l = [];
+      for (let lat = 45; lat <= 55; lat += 1) {
+        for (let lon = 90; lon <= 100; lon += 1) {
+          l.push({geo: {type: "Point", coordinates: [lon, lat]}});
+          if (l.length % 1000 === 0) {
+            insertAll(l);
+            l = [];
+          }
+        }
+      }
+      if (l.length > 0) {
+        insertAll(l);
+      }
+      waitForArangoSearch();
+    }
+    function createSuperLargeGrid() {
+      let l = [];
+      for (let lat = 45; lat <= 55; lat += 1) {
+        for (let lon = 175; lon < 180; lon += 1) {
+          l.push({geo:{type:"Point", coordinates:[lon, lat]}});
+          if (l.length % 1000 === 0) {
+            insertAll(l);
+            l = [];
+          }
+        }
+        for (let lon = -179; lon <= -170; lon += 1) {
+          l.push({geo:{type:"Point", coordinates:[lon, lat]}});
+          if (l.length % 1000 === 0) {
+            insertAll(l);
+            l = [];
+          }
+        }
+      }
+      if (l.length > 0) {
+        insertAll(l);
+      }
+      waitForArangoSearch();
+    }
+    function createBiggestGrid() {
+      let l = [];
+      for (let lat = 85; lat < 90; lat += 1) {
+        for (let lon = 175; lon < 180; lon += 1) {
+          l.push({geo:{type:"Point", coordinates:[lon, lat]}});
+          if (l.length % 1000 === 0) {
+            insertAll(l);
+            l = [];
+          }
+        }
+        for (let lon = -179; lon <= -170; lon += 1) {
+          l.push({geo:{type:"Point", coordinates:[lon, lat]}});
+          if (l.length % 1000 === 0) {
+            insertAll(l);
+            l = [];
+          }
+        }
+      }
+      if (l.length > 0) {
+        insertAll(l);
+      }
+    waitForArangoSearch();
+  }
   return {
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -294,8 +489,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
     testSetup : function () {
-      insertAll([{geo: { type: "Point", coordinates: [50, 50] } }]);
-      waitForArangoSearch();
+      createOnePolygon();
       let c = compare(
         `FILTER GEO_DISTANCE([50, 50], d.geo) < 5000`,
         `SEARCH ANALYZER(GEO_DISTANCE([50, 50], d.geo) < 5000, "geo_json")`
@@ -308,16 +502,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
     testPointNearCentroidOfPolygon : function () {
-      insertAll([
-        {geo:{type:"Polygon",
-              coordinates:[[[10,10],[20,10],[20,20],[10,20],[10,10]]]}},
-        {geo:{type:"Polygon",
-              coordinates:[[[10,10],[20,10],[30,20],[10,20],[10,10]]]}},
-        {geo:{type:"Polygon",
-              coordinates:[[[10,10],[20,10],[20,20],[10,20],[10,11.1],
-                [11,11.1],[11,19],[19,19],[19,11],[10,11],[10,10]]]}}
-      ]);
-      waitForArangoSearch();
+      createThreePolygons();
       let c = compare(
         `FILTER GEO_DISTANCE([15, 15], d.geo) <= 5000`,
         `SEARCH ANALYZER(GEO_DISTANCE([15, 15], d.geo) <= 5000, "geo_json")`
@@ -330,20 +515,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
     testNearGrid : function () {
-      let l = [];
-      for (let lat = 9; lat <= 21; lat += 0.1) {
-        for (let lon = 9; lon <= 21; lon += 0.1) {
-          l.push({geo:{type:"Point", coordinates:[lon, lat]}});
-          if (l.length % 1000 === 0) {
-            insertAll(l);
-            l = [];
-          }
-        }
-      }
-      if (l.length > 0) {
-        insertAll(l);
-      }
-      waitForArangoSearch();
+      createNearGrid();
       let c = compare(
         `FILTER GEO_DISTANCE([15, 15], d.geo) <= 666666`,
         `SEARCH ANALYZER(GEO_DISTANCE([15, 15], d.geo) <= 666666, "geo_json")`
@@ -356,20 +528,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
     testNearGridRingArea : function () {
-      let l = [];
-      for (let lat = 9; lat <= 21; lat += 0.1) {
-        for (let lon = 9; lon <= 21; lon += 0.1) {
-          l.push({geo:{type:"Point", coordinates:[lon, lat]}});
-          if (l.length % 1000 === 0) {
-            insertAll(l);
-            l = [];
-          }
-        }
-      }
-      if (l.length > 0) {
-        insertAll(l);
-      }
-      waitForArangoSearch();
+      createNearGrid();
       let c = compare(
         `FILTER GEO_DISTANCE([15, 15], d.geo) <= 666666 &&
                 GEO_DISTANCE([15, 15], d.geo) >= 300000`,
@@ -384,20 +543,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
     testNearGridOuterArea : function () {
-      let l = [];
-      for (let lat = 9; lat <= 21; lat += 0.1) {
-        for (let lon = 9; lon <= 21; lon += 0.1) {
-          l.push({geo:{type:"Point", coordinates:[lon, lat]}});
-          if (l.length % 1000 === 0) {
-            insertAll(l);
-            l = [];
-          }
-        }
-      }
-      if (l.length > 0) {
-        insertAll(l);
-      }
-      waitForArangoSearch();
+      createNearGrid();
       let c = compare(
         `FILTER GEO_DISTANCE([15, 15], d.geo) >= 300000`,
         `SEARCH ANALYZER(GEO_DISTANCE([15, 15], d.geo) >= 300000, "geo_json")`
@@ -410,20 +556,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
     testNearGridDescending : function () {
-      let l = [];
-      for (let lat = 9; lat <= 21; lat += 0.1) {
-        for (let lon = 9; lon <= 21; lon += 0.1) {
-          l.push({geo:{type:"Point", coordinates:[lon, lat]}});
-          if (l.length % 1000 === 0) {
-            insertAll(l);
-            l = [];
-          }
-        }
-      }
-      if (l.length > 0) {
-        insertAll(l);
-      }
-      waitForArangoSearch();
+      createNearGrid();
       let c = compare(
         `FILTER GEO_DISTANCE([15, 15], d.geo) <= 666666
          SORT GEO_DISTANCE([15, 15], d.geo) DESC`,
@@ -438,20 +571,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
     testNearGridRingAreaDescending : function () {
-      let l = [];
-      for (let lat = 9; lat <= 21; lat += 0.1) {
-        for (let lon = 9; lon <= 21; lon += 0.1) {
-          l.push({geo:{type:"Point", coordinates:[lon, lat]}});
-          if (l.length % 1000 === 0) {
-            insertAll(l);
-            l = [];
-          }
-        }
-      }
-      if (l.length > 0) {
-        insertAll(l);
-      }
-      waitForArangoSearch();
+      createNearGrid();
       let c = compare(
         `FILTER GEO_DISTANCE([15, 15], d.geo) <= 666666 &&
                 GEO_DISTANCE([15, 15], d.geo) >= 300000
@@ -468,20 +588,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
     testNearGridOuterAreaDescending : function () {
-      let l = [];
-      for (let lat = 9; lat <= 21; lat += 0.1) {
-        for (let lon = 9; lon <= 21; lon += 0.1) {
-          l.push({geo:{type:"Point", coordinates:[lon, lat]}});
-          if (l.length % 1000 === 0) {
-            insertAll(l);
-            l = [];
-          }
-        }
-      }
-      if (l.length > 0) {
-        insertAll(l);
-      }
-      waitForArangoSearch();
+      createNearGrid();
       let c = compare(
         `FILTER GEO_DISTANCE([15, 15], d.geo) >= 300000`,
         `SEARCH ANALYZER(GEO_DISTANCE([15, 15], d.geo) >= 300000, "geo_json")`
@@ -494,28 +601,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
     testNearObjectsSizes : function () {
-      let l = [];
-      for (let size = 0.0001; size <= 10; size *= 10) {
-        for (let lon = 14.8; lon <= 15.2; lon += 0.04) {
-          l.push({
-            geo: {
-              type: "Polygon",
-              coordinates: [[[lon - size, 10 - size], [lon + size, 10 - size],
-                [lon + size, 10 + size], [lon - size, 10 + size],
-                [lon - size, 10 - size]]]
-            },
-            centroid: {type: "Point", coordinates: [lon, 10]}
-          });
-          if (l.length % 1000 === 0) {
-            insertAll(l);
-            l = [];
-          }
-        }
-      }
-      if (l.length > 0) {
-        insertAll(l);
-      }
-      waitForArangoSearch();
+      createNarrowGrid();
       let c = compare(
         `FILTER GEO_DISTANCE([10, 10], d.geo) <= 555974`,
         `SEARCH ANALYZER(GEO_DISTANCE([10, 10], d.geo) <= 555974, "geo_json")`
@@ -528,28 +614,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
     testNearSlidingLargeObject : function () {
-      let l = [];
-      for (let size = 1; size <= 11; size += 1) {
-        for (let lon = 11; lon <= 30; lon += 0.1) {
-          l.push({
-            geo: {
-              type: "Polygon",
-              coordinates: [[[lon - size, 10 - size], [lon + size, 10 - size],
-                [lon + size, 10 + size], [lon - size, 10 + size],
-                [lon - size, 10 - size]]]
-            },
-            centroid: {type: "Point", coordinates: [lon, 10]}
-          });
-          if (l.length % 1000 === 0) {
-            insertAll(l);
-            l = [];
-          }
-        }
-      }
-      if (l.length > 0) {
-        insertAll(l);
-      }
-      waitForArangoSearch();
+      createNearSlidingObject();
       let c = compare(
         `FILTER GEO_DISTANCE([10, 10], d.geo) <= 555974`,
         `SEARCH ANALYZER(GEO_DISTANCE([10, 10], d.geo) <= 555974, "geo_json")`
@@ -563,14 +628,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
     testNearNonConvexObject : function () {
-      insertAll([
-        {geo:{type:"Polygon",
-         coordinates:[[[0,0],[10,10],[0,20],[9,10],[0,0]]]}},
-        {geo:{type:"Polygon",
-         coordinates:[[[0,0],[10,10],[0,20],[0,19],[9,10],[0,1],[0,0]]]}}
-      ]);
-      // Centroid will be at approx. [7,10]
-      waitForArangoSearch();
+      createTwoPolygons
       for (let dist = 1000; dist <= 100000; dist += 100) {
         //print("Distance", dist);
         let c = compare(
@@ -586,14 +644,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
     testContainsWithSmallPoly : function () {
-      let l = [];
-      for (let lat = 9; lat <= 11; lat += 0.1) {
-        for (let lon = 9; lon <= 11; lon += 0.1) {
-          l.push({geo:{type:"Point", coordinates:[lon, lat]}});
-        }
-      }
-      insertAll(l);
-      waitForArangoSearch();
+      createNearGrid();
       let d = 0.001;
       for (let lat = 9; lat <= 11; lat += 0.4) {
         for (let lon = 9; lon <= 11; lon += 0.4) {
@@ -614,20 +665,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
     testContainsGrid : function () {
-      let l = [];
-      for (let lat = 9; lat <= 21; lat += 0.1) {
-        for (let lon = 9; lon <= 21; lon += 0.1) {
-          l.push({geo:{type:"Point", coordinates:[lon, lat]}});
-          if (l.length % 1000 === 0) {
-            insertAll(l);
-            l = [];
-          }
-        }
-      }
-      if (l.length > 0) {
-        insertAll(l);
-      }
-      waitForArangoSearch();
+      createNearGrid();
       for (let d = 1; d <= 5; d += 1) {
         let p = {
           type: "Polygon", coordinates: [[[15 - d, 15], [15, 15 - d], [15 + d, 15],
@@ -650,20 +688,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
     testContainsGridComplement : function () {
-      let l = [];
-      for (let lat = 9; lat <= 21; lat += 0.1) {
-        for (let lon = 9; lon <= 21; lon += 0.1) {
-          l.push({geo:{type:"Point", coordinates:[lon, lat]}});
-          if (l.length % 1000 === 0) {
-            insertAll(l);
-            l = [];
-          }
-        }
-      }
-      if (l.length > 0) {
-        insertAll(l);
-      }
-      waitForArangoSearch();
+      createNearGrid();
       for (let d = 1; d <= 5; d += 1) {
         let p = {
           type: "Polygon", coordinates: [[[15 - d, 15], [15, 15 + d], [15 + d, 15],
@@ -685,14 +710,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
     testIntersectsWithSmallPoly : function () {
-      let l = [];
-      for (let lat = 9; lat <= 11; lat += 0.1) {
-        for (let lon = 9; lon <= 11; lon += 0.1) {
-          l.push({geo:{type:"Point", coordinates:[lon, lat]}});
-        }
-      }
-      insertAll(l);
-      waitForArangoSearch();
+      createNearGrid();
       let d = 0.001;
       for (let lat = 9; lat <= 11; lat += 0.4) {
         for (let lon = 9; lon <= 11; lon += 0.4) {
@@ -713,20 +731,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
     testIntersectsGrid : function () {
-      let l = [];
-      for (let lat = 9; lat <= 21; lat += 0.1) {
-        for (let lon = 9; lon <= 21; lon += 0.1) {
-          l.push({geo:{type:"Point", coordinates:[lon, lat]}});
-          if (l.length % 1000 === 0) {
-            insertAll(l);
-            l = [];
-          }
-        }
-      }
-      if (l.length > 0) {
-        insertAll(l);
-      }
-      waitForArangoSearch();
+      createNearGrid();
       for (let d = 1; d <= 5; d += 1) {
         let p = {
           type: "Polygon", coordinates: [[[15 - d, 15], [15, 15 - d], [15 + d, 15],
@@ -749,20 +754,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
     testIntersectsGridComplement : function () {
-      let l = [];
-      for (let lat = 9; lat <= 21; lat += 0.1) {
-        for (let lon = 9; lon <= 21; lon += 0.1) {
-          l.push({geo:{type:"Point", coordinates:[lon, lat]}});
-          if (l.length % 1000 === 0) {
-            insertAll(l);
-            l = [];
-          }
-        }
-      }
-      if (l.length > 0) {
-        insertAll(l);
-      }
-      waitForArangoSearch();
+      createNearGrid();
       for (let d = 1; d <= 5; d += 1) {
         let p = {
           type: "Polygon", coordinates: [[[15 - d, 15], [15, 15 + d], [15 + d, 15],
@@ -785,14 +777,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
     testIntersectsNonConvexObject : function () {
-      insertAll([
-        {geo:{type:"Polygon",
-         coordinates:[[[0,0],[10,10],[0,20],[9,10],[0,0]]]}},
-        {geo:{type:"Polygon",
-         coordinates:[[[0,0],[10,10],[0,20],[0,19],[9,10],[0,1],[0,0]]]}}
-      ]);
-      // Centroid will be at approx. [7,10]
-      waitForArangoSearch();
+      createTwoPolygons();
       let smallPoly = {type:"Polygon",
         coordinates:[[[4.7873, 10.0734], [4.7875, 10.0734], [4.7875, 10.0736],
                       [4.7873, 10.0736], [4.7873, 10.0734]]]};
@@ -808,20 +793,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
     testMoreThanHalf1Grid: function () {
-      let l = [];
-      for (let lat = 45; lat <= 55; lat += 1) {
-        for (let lon = 90; lon <= 100; lon += 1) {
-          l.push({geo: {type: "Point", coordinates: [lon, lat]}});
-          if (l.length % 1000 === 0) {
-            insertAll(l);
-            l = [];
-          }
-        }
-      }
-      if (l.length > 0) {
-        insertAll(l);
-      }
-      waitForArangoSearch();
+      createLargeGrid();
       let polys = [
         makePolyInside([-85, 95], [-80, 50]),
         makePolyOutside([-85, 95], [-80, 50]),
@@ -855,27 +827,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
     testMoreThanHalf2 : function () {
-      let l = [];
-      for (let lat = 45; lat <= 55; lat += 1) {
-        for (let lon = 175; lon < 180; lon += 1) {
-          l.push({geo:{type:"Point", coordinates:[lon, lat]}});
-          if (l.length % 1000 === 0) {
-            insertAll(l);
-            l = [];
-          }
-        }
-        for (let lon = -179; lon <= -170; lon += 1) {
-          l.push({geo:{type:"Point", coordinates:[lon, lat]}});
-          if (l.length % 1000 === 0) {
-            insertAll(l);
-            l = [];
-          }
-        }
-      }
-      if (l.length > 0) {
-        insertAll(l);
-      }
-      waitForArangoSearch();
+      createSuperLargeGrid();
       let polys = [
         makePolyInside([-85, 95], [-80, 50]),
         makePolyOutside([-85, 95], [-80, 50]),
@@ -907,27 +859,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
     testMoreThanHalf3 : function () {
-      let l = [];
-      for (let lat = 85; lat < 90; lat += 1) {
-        for (let lon = 175; lon < 180; lon += 1) {
-          l.push({geo:{type:"Point", coordinates:[lon, lat]}});
-          if (l.length % 1000 === 0) {
-            insertAll(l);
-            l = [];
-          }
-        }
-        for (let lon = -179; lon <= -170; lon += 1) {
-          l.push({geo:{type:"Point", coordinates:[lon, lat]}});
-          if (l.length % 1000 === 0) {
-            insertAll(l);
-            l = [];
-          }
-        }
-      }
-      if (l.length > 0) {
-        insertAll(l);
-      }
-      waitForArangoSearch();
+      createBiggestGrid();
       let polys = [
         makePolyInside([-85, 95], [-80, 87]),
         makePolyOutside([-85, 95], [-80, 87]),
@@ -958,47 +890,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
     testMoreNonConvex : function () {
-      let lat = 6.537;
-      let long = 50.332;
-      for (let x = 0; x < 100; ++x) {
-        let points = [];
-        for (let y = 0; y < 100; ++y) {
-          points.push({ geo: { type: "Point",
-              coordinates: [lat + x/1000, long + y/1000] } });
-        }
-        insertAll(points);
-      }
-      insertAll([{ geo: { "type": "Polygon", "coordinates": [
-        [[ 37.614323, 55.705898 ],
-          [ 37.615825, 55.705898 ],
-          [ 37.615825, 55.70652  ],
-          [ 37.614323, 55.70652  ],
-          [ 37.614323, 55.705898 ]]
-      ]}}]);
-      insertAll([{ geo: {"type": "LineString", "coordinates": [
-        [ 6.537, 50.332 ], [ 6.537, 50.376 ]]
-      }}]);
-      insertAll([{ geo: { "type": "MultiLineString", "coordinates": [
-        [[ 6.537, 50.332 ], [ 6.537, 50.376 ]],
-        [[ 6.621, 50.332 ], [ 6.621, 50.376 ]]
-      ]}}]);
-      insertAll([{ geo: { "type": "MultiPoint", "coordinates": [
-        [ 6.537, 50.332 ], [ 6.537, 50.376 ],
-        [ 6.621, 50.332 ], [ 6.621, 50.376 ]
-      ]}}]);
-      insertAll([{ geo: { "type": "MultiPolygon", "coordinates": [
-        [[[ 37.614323, 55.705898 ],
-          [ 37.615825, 55.705898 ],
-          [ 37.615825, 55.70652  ],
-          [ 37.614323, 55.70652  ],
-          [ 37.614323, 55.705898 ]]],
-        [[[ 37.614, 55.7050 ],
-          [ 37.615, 55.7050 ],
-          [ 37.615, 55.7058 ],
-          [ 37.614, 55.7058 ],
-          [ 37.614, 55.7050 ]]]
-      ]}}]);
-      waitForArangoSearch();
+      createSomePolygons();
       let multiLineString = {
         "type": "MultiLineString",
         "coordinates": [[[6.537, 50.332], [6.537, 50.376]],
@@ -1043,47 +935,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
     testMoreNonConvexGeoInRange : function () {
-      let lat = 6.537;
-      let long = 50.332;
-      for (let x = 0; x < 100; ++x) {
-        let points = [];
-        for (let y = 0; y < 100; ++y) {
-          points.push({ geo: { type: "Point",
-              coordinates: [lat + x/1000, long + y/1000] } });
-        }
-        insertAll(points);
-      }
-      insertAll([{ geo: { "type": "Polygon", "coordinates": [
-        [[ 37.614323, 55.705898 ],
-          [ 37.615825, 55.705898 ],
-          [ 37.615825, 55.70652  ],
-          [ 37.614323, 55.70652  ],
-          [ 37.614323, 55.705898 ]]
-      ]}}]);
-      insertAll([{ geo: {"type": "LineString", "coordinates": [
-        [ 6.537, 50.332 ], [ 6.537, 50.376 ]]
-      }}]);
-      insertAll([{ geo: { "type": "MultiLineString", "coordinates": [
-        [[ 6.537, 50.332 ], [ 6.537, 50.376 ]],
-        [[ 6.621, 50.332 ], [ 6.621, 50.376 ]]
-      ]}}]);
-      insertAll([{ geo: { "type": "MultiPoint", "coordinates": [
-        [ 6.537, 50.332 ], [ 6.537, 50.376 ],
-        [ 6.621, 50.332 ], [ 6.621, 50.376 ]
-      ]}}]);
-      insertAll([{ geo: { "type": "MultiPolygon", "coordinates": [
-        [[[ 37.614323, 55.705898 ],
-          [ 37.615825, 55.705898 ],
-          [ 37.615825, 55.70652  ],
-          [ 37.614323, 55.70652  ],
-          [ 37.614323, 55.705898 ]]],
-        [[[ 37.614, 55.7050 ],
-          [ 37.615, 55.7050 ],
-          [ 37.615, 55.7058 ],
-          [ 37.614, 55.7058 ],
-          [ 37.614, 55.7050 ]]]
-      ]}}]);
-      waitForArangoSearch();
+      createSomePolygons();
       let multiLineString = {
         "type": "MultiLineString",
         "coordinates": [ [ [ 6.537, 50.332 ], [ 6.537, 50.376 ] ],

--- a/tests/js/server/aql/aql-geo.inc
+++ b/tests/js/server/aql/aql-geo.inc
@@ -235,14 +235,10 @@
       let cmpResView = compareKeyLists("without index", resFullScanNoIndexes, "with view", resView);
       let cmpResInvertedIndex = compareKeyLists("without index", resFullScanNoIndexes, "with inverted index", resInvertedIndex);
 
-      // PLEASE UNCOMMENT LINES BELOW AFTER FIXING https://arangodb.atlassian.net/browse/BTS-1184
-
-      /*
-        let explanation = db._createStatement(invertedIndexQuery).explain().plan;
-        let utilizedIndexes = explanation.nodes.filter(node => node.type === 'IndexNode')[0].indexes;
-        assertEqual(utilizedIndexes.length, 1);
-        assertEqual(utilizedIndexes[0].name, "inverted");
-      */
+      let explanation = db._createStatement(invertedIndexQuery).explain().plan;
+      let utilizedIndexes = explanation.nodes.filter(node => node.type === 'IndexNode')[0].indexes;
+      assertEqual(utilizedIndexes.length, 1);
+      assertEqual(utilizedIndexes[0].name, "inverted");
 
       if (!cmpResFullScanWithIndexes.good || !cmpResView.good || !cmpResInvertedIndex.good) {
         print("Query for collections:", fullScanQuery);


### PR DESCRIPTION
### Scope & Purpose

We improve the test performance by 
1) [x] DRY the test case creation
2) [x] use setupAll
3) [x] join the suites to just have one set of these

- [x] :hankey: Bugfix
- [x] :fire: Performance improvement

Same set of binaries, 
`time ./scripts/unittest auto --test aql-geo-3  --cluster true` 
=>  Default:
```
real    2m3.704s
user    3m24.658s
sys     0m14.395s
```
=> this PR:
```
real    0m56.104s
user    0m58.925s
sys     0m5.747s
```