### PR TITLE
[CINFRA] Create/DropShard vs resign mutex

### DIFF
--- a/arangod/Replication2/StateMachines/Document/DocumentLeaderState.cpp
+++ b/arangod/Replication2/StateMachines/Document/DocumentLeaderState.cpp
@@ -271,18 +271,27 @@ auto DocumentLeaderState::allSnapshotsStatus() -> ResultT<AllSnapshotsStatus> {
 auto DocumentLeaderState::createShard(ShardID shard, CollectionID collectionId,
                                       velocypack::SharedSlice properties)
     -> futures::Future<Result> {
-  DocumentLogEntry entry;
-  entry.operation = OperationType::kCreateShard;
-  entry.shardId = shard;
-  entry.data = properties;
-  entry.collectionId = collectionId;
+  auto fut = _guardedData.doUnderLock([&](auto& data) {
+    if (data.didResign()) {
+      THROW_ARANGO_EXCEPTION(
+          TRI_ERROR_REPLICATION_REPLICATED_LOG_LEADER_RESIGNED);
+    }
 
-  // TODO actually we have to block this log entry from release until the
-  // collection is actually created
-  auto const& stream = getStream();
-  auto idx = stream->insert(entry);
+    DocumentLogEntry entry;
+    entry.operation = OperationType::kCreateShard;
+    entry.shardId = shard;
+    entry.data = properties;
+    entry.collectionId = collectionId;
 
-  return stream->waitFor(idx).thenValue(
+    // TODO actually we have to block this log entry from release until the
+    // collection is actually created
+    auto const& stream = getStream();
+    auto idx = stream->insert(entry);
+
+    return stream->waitFor(idx);
+  });
+
+  return std::move(fut).thenValue(
       [self = shared_from_this(), shard = std::move(shard),
        collectionId = std::move(collectionId),
        properties = std::move(properties)](auto&&) mutable {
@@ -298,16 +307,24 @@ auto DocumentLeaderState::createShard(ShardID shard, CollectionID collectionId,
 
 auto DocumentLeaderState::dropShard(ShardID shard, CollectionID collectionId)
     -> futures::Future<Result> {
-  DocumentLogEntry entry;
-  entry.operation = OperationType::kDropShard;
-  entry.shardId = shard;
-  entry.collectionId = collectionId;
+  auto fut = _guardedData.doUnderLock([&](auto& data) {
+    if (data.didResign()) {
+      THROW_ARANGO_EXCEPTION(
+          TRI_ERROR_REPLICATION_REPLICATED_LOG_LEADER_RESIGNED);
+    }
+    DocumentLogEntry entry;
+    entry.operation = OperationType::kDropShard;
+    entry.shardId = shard;
+    entry.collectionId = collectionId;
 
-  // TODO actually we have to block this log entry from release until the
-  // collection is actually created
-  auto const& stream = getStream();
-  auto idx = stream->insert(entry);
-  return stream->waitFor(idx).thenValue(
+    // TODO actually we have to block this log entry from release until the
+    // collection is actually created
+    auto const& stream = getStream();
+    auto idx = stream->insert(entry);
+    return stream->waitFor(idx);
+  });
+
+  return std::move(fut).thenValue(
       [self = shared_from_this(), shard = std::move(shard),
        collectionId = std::move(collectionId)](auto&&) mutable {
         return self->_guardedData.doUnderLock([&](auto& data) -> Result {


### PR DESCRIPTION
### Scope & Purpose
The `createShard` and `dropShard` functions accessed the stream without acquiring the mutex first and thus could access the stream even after resign was called.