### PR TITLE
upgrade velocypack to latest version

### DIFF
--- a/arangod/RocksDBEngine/RocksDBEdgeIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBEdgeIndex.cpp
@@ -85,9 +85,9 @@ class StringFromParts final : public velocypack::IStringFromParts {
     static_assert(sizeof...(Args) == N);
   }
 
-  std::size_t size() const final { return N; }
+  std::size_t numberOfParts() const final { return N; }
 
-  std::size_t length() const final {
+  std::size_t totalLength() const final {
     size_t length = 0;
     for (size_t index = 0; index != N; ++index) {
       length += _parts[index].length();
@@ -96,7 +96,7 @@ class StringFromParts final : public velocypack::IStringFromParts {
   }
 
   std::string_view operator()(size_t index) const final {
-    TRI_ASSERT(index < size());
+    TRI_ASSERT(index < numberOfParts());
     return _parts[index];
   }
 


### PR DESCRIPTION
### Scope & Purpose

Upgrade to latest version of velocypack, which changes naming in the IStringFromParts interface.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: -
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 