### PR TITLE
Partial fix for PRESUPP-539

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,13 @@
 devel
 -----
 
+* Partial fix for PRESUPP-539: account for memory used during AQL condition
+  transformation to disjunctive normal form (DNF). This transformation can use
+  a lot of memory for complex filter conditions, which was previously not
+  accounted for. Now if the transformation uses a lot of memory and hits the
+  configured query memory limit, the query will rather be aborted than overuse
+  memory.
+
 * Improve memory usage of in-memory edge index cache if most of the edges in an
   index refer to a single or mostly the same collection.
   Previously the full edge ids, consisting of the the referred-to collection

--- a/arangod/Aql/Ast.cpp
+++ b/arangod/Aql/Ast.cpp
@@ -21,9 +21,6 @@
 /// @author Jan Steemann
 ////////////////////////////////////////////////////////////////////////////////
 
-#include <velocypack/Iterator.h>
-#include <velocypack/Slice.h>
-
 #include "Ast.h"
 
 #include "ApplicationFeatures/ApplicationServer.h"
@@ -60,6 +57,9 @@
 #include "V8Server/V8DealerFeature.h"
 
 #include <absl/strings/str_cat.h>
+
+#include <velocypack/Iterator.h>
+#include <velocypack/Slice.h>
 
 using namespace arangodb;
 using namespace arangodb::aql;
@@ -2994,7 +2994,7 @@ AstNode* Ast::shallowCopyForModify(AstNode const* node) {
   // copy payload...
   copyPayload(node, copy);
 
-  // recursively add subnodes
+  // add subnodes, non-recursively
   size_t const n = node->numMembers();
   copy->members.reserve(n);
   for (size_t i = 0; i < n; ++i) {
@@ -4377,7 +4377,7 @@ void Ast::addWriteCollection(AstNode const* node, bool isExclusiveAccess) {
   _writeCollections.emplace_back(node, isExclusiveAccess);
 }
 
-bool Ast::functionsMayAccessDocuments() const {
+bool Ast::functionsMayAccessDocuments() const noexcept {
   return _functionsMayAccessDocuments;
 }
 

--- a/arangod/Aql/Ast.h
+++ b/arangod/Aql/Ast.h
@@ -108,9 +108,11 @@ class Ast {
   static constexpr uint64_t maxExpressionNesting = 500;
 
   /// @brief return the query
-  QueryContext& query() const { return _query; }
+  QueryContext const& query() const noexcept { return _query; }
+  QueryContext& query() noexcept { return _query; }
 
-  AstResources& resources() { return _resources; }
+  AstResources const& resources() const noexcept { return _resources; }
+  AstResources& resources() noexcept { return _resources; }
 
   /// @brief return the variable generator
   VariableGenerator* variables();
@@ -138,7 +140,7 @@ class Ast {
   void addWriteCollection(AstNode const* node, bool isExclusiveAccess);
 
   /// @brief whether or not function calls may access collection documents
-  bool functionsMayAccessDocuments() const;
+  bool functionsMayAccessDocuments() const noexcept;
 
   /// @brief whether or not the query contains a traversal
   bool containsTraversal() const noexcept;


### PR DESCRIPTION
### Scope & Purpose

Partial fix for https://arangodb.atlassian.net/browse/PRESUPP-539

* Partial fix for PRESUPP-539: account for memory used during AQL condition transformation to disjunctive normal form (DNF). This transformation can use a lot of memory for complex filter conditions, which was previously not accounted for. Now if the transformation uses a lot of memory and hits the configured query memory limit, the query will rather be aborted than overuse memory.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: -
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [x] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/PRESUPP-539
- [ ] Design document: 