### PR TITLE
Fixing missing version increment.

### DIFF
--- a/arangod/Replication2/Supervision/CollectionGroupSupervision.cpp
+++ b/arangod/Replication2/Supervision/CollectionGroupSupervision.cpp
@@ -542,6 +542,9 @@ struct TransactionBuilder {
                        "/arango/Target/ReplicatedLogs/", database, "/",
                        action.logId, "/participants/", action.participant),
                    VPackSlice::emptyObjectSlice())
+              .inc(basics::StringUtils::concatT(
+                  "/arango/Target/ReplicatedLogs/", database, "/", action.logId,
+                  "/version"))
               .end();
   }
 
@@ -550,6 +553,9 @@ struct TransactionBuilder {
               .remove(basics::StringUtils::concatT(
                   "/arango/Target/ReplicatedLogs/", database, "/", action.logId,
                   "/participants/", action.participant))
+              .inc(basics::StringUtils::concatT(
+                  "/arango/Target/ReplicatedLogs/", database, "/", action.logId,
+                  "/version"))
               .end();
   }
 

--- a/arangod/Replication2/Supervision/CollectionGroupSupervision.h
+++ b/arangod/Replication2/Supervision/CollectionGroupSupervision.h
@@ -115,7 +115,7 @@ auto checkCollectionGroup(DatabaseID const& database,
 
 auto executeCheckCollectionGroup(
     DatabaseID const& database, std::string const& logIdString,
-    CollectionGroup const& log,
+    CollectionGroup const& group,
     replicated_log::ParticipantsHealth const& health, UniqueIdProvider& uniqid,
     arangodb::agency::envelope envelope) noexcept -> arangodb::agency::envelope;
 


### PR DESCRIPTION
### Scope & Purpose
During a code review, we found that `version` of a replicated log in target was not incremented by the collection group supervision when it modified the target. This could lead to a _converged_ state, although the replicated log did not actually converge, yet.