### PR TITLE
Resign replicated logs when a database is dropped.

### DIFF
--- a/arangod/RestServer/DatabaseFeature.cpp
+++ b/arangod/RestServer/DatabaseFeature.cpp
@@ -471,6 +471,7 @@ void DatabaseFeature::beginShutdown() {
 
     // throw away all open cursors in order to speed up shutdown
     vocbase->cursorRepository()->garbageCollect(true);
+    vocbase->shutdownReplicatedLogs();
   }
 }
 
@@ -878,7 +879,7 @@ ErrorCode DatabaseFeature::dropDatabase(std::string_view name,
           .getFeature<arangodb::iresearch::IResearchAnalyzerFeature>()
           .invalidate(*vocbase);
     }
-
+    vocbase->shutdownReplicatedLogs();
     auto queryRegistry = QueryRegistryFeature::registry();
     if (queryRegistry != nullptr) {
       queryRegistry->destroy(vocbase->name());

--- a/arangod/VocBase/vocbase.cpp
+++ b/arangod/VocBase/vocbase.cpp
@@ -146,8 +146,9 @@ struct arangodb::VocBaseLogManager {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_NOT_IMPLEMENTED);
   }
 
-  auto resignAll() {
+  auto resignAll() noexcept {
     auto guard = _guardedData.getLockedGuard();
+    guard->resignAllWasCalled = true;
     for (auto&& [id, val] : guard->statesAndLogs) {
       auto&& log = val.log;
       auto core = std::move(*log).resign();
@@ -316,8 +317,8 @@ struct arangodb::VocBaseLogManager {
       arangodb::replication2::replicated_log::ReplicatedLogConnection
           connection;
     };
-    absl::flat_hash_map<arangodb::replication2::LogId, StateAndLog>
-        statesAndLogs;
+    std::map<arangodb::replication2::LogId, StateAndLog> statesAndLogs;
+    bool resignAllWasCalled{false};
 
     void registerRebootTracker(
         replication2::LogId id,
@@ -352,7 +353,9 @@ struct arangodb::VocBaseLogManager {
       // TODO Make this atomic without crashing on errors if possible
       using namespace arangodb::replication2;
       using namespace arangodb::replication2::replicated_state;
-
+      if (resignAllWasCalled) {
+        return {TRI_ERROR_SHUTTING_DOWN};
+      }
       if (auto iter = statesAndLogs.find(id); iter != std::end(statesAndLogs)) {
         return {TRI_ERROR_ARANGO_DUPLICATE_IDENTIFIER};
       }
@@ -2164,6 +2167,10 @@ void TRI_SanitizeObject(VPackSlice slice, VPackBuilder& builder) {
 }
 
 using namespace arangodb::replication2;
+
+void TRI_vocbase_t::shutdownReplicatedLogs() noexcept {
+  _logManager->resignAll();
+}
 
 auto TRI_vocbase_t::updateReplicatedState(
     LogId id, agency::LogPlanTermSpecification const& term,

--- a/arangod/VocBase/vocbase.h
+++ b/arangod/VocBase/vocbase.h
@@ -215,6 +215,8 @@ struct TRI_vocbase_t {
   auto getReplicatedLogFollowerById(arangodb::replication2::LogId id)
       -> std::shared_ptr<arangodb::replication2::replicated_log::LogFollower>;
 
+  void shutdownReplicatedLogs() noexcept;
+
   [[nodiscard]] auto getDatabaseConfiguration()
       -> arangodb::DatabaseConfiguration;
 


### PR DESCRIPTION
### Scope & Purpose
This PR fixes a shutdown hanger. The reason for the hanger was, that on a dropped database, replicated logs are not immediately resigned. This could cause the maintenance feature to wait for an action to finish, this action in turn waits for a replicated log to replicated some log entries. Since all other servers are already down, this is essentially a dead lock.