### PR TITLE
fix misleading message

### DIFF
--- a/js/apps/system/_admin/aardvark/APP/frontend/js/views/settingsView.js
+++ b/js/apps/system/_admin/aardvark/APP/frontend/js/views/settingsView.js
@@ -260,13 +260,20 @@
             } else {
               var wfs = data.waitForSync;
               if (data.replicationFactor && frontendConfig.isCluster) {
-                if (data.replicationFactor === 'satellite' || data.distributeShardsLike !== undefined) {
+                var msg = null;
+                if (data.replicationFactor === 'satellite') {
+                  msg = 'This collection is a SatelliteCollection.';
+                } else if (data.distributeShardsLike !== undefined) {
+                  msg = 'This collection uses \'distributeShardsLike\'.';
+                }
+
+                if (msg !== null) {
                   tableContent.push(
                     window.modalView.createReadOnlyEntry(
                       'change-replication-factor',
                       'Replication factor',
                       data.replicationFactor,
-                      'This collection is a SatelliteCollection. The replicationFactor is not changeable.',
+                      msg + ' The replication factor is not changeable.',
                       '',
                       true
                     )
@@ -276,7 +283,7 @@
                       'change-write-concern',
                       'Write concern',
                       JSON.stringify(data.writeConcern),
-                      'This collection is a SatelliteCollection. The write concern is not changeable.',
+                      msg + ' The write concern is not changeable.',
                       '',
                       true
                     )


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/18185

The UI reported 'this collection is a SatelliteCollection. the replication factor cannot be changed' in case the collection is actually a satellite collection (correct) **and** in case the collection has its distributeShardsLike attribute set (incorrect).
Now the two different cases produce two separate messages.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.10: this PR
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 