### PR TITLE
[CINFRA] Maintenance TakeoverShardLeadership crash fix

### DIFF
--- a/arangod/Cluster/FollowerInfo.cpp
+++ b/arangod/Cluster/FollowerInfo.cpp
@@ -422,7 +422,10 @@ void FollowerInfo::takeOverLeadership(
           << ", theLeader: " << _theLeader << ", theLeaderTouched; "
           << std::boolalpha << _theLeaderTouched;
 
-      TRI_ASSERT(false);
+      if (_docColl->vocbase().replicationVersion() ==
+          replication::Version::ONE) {
+        TRI_ASSERT(false) << "this should not happen with replication 1";
+      }
     } else {
       // We are a valid failover follower
 


### PR DESCRIPTION
### Scope & Purpose
On replication two it can happen that a server has to take over leadership of a shard even though it is in the failover candidates (because failover candidates can be outdated and are not used for replication 2).