### PR TITLE
Fix arangorestore API to create _rev on shard leader [BTS-1232].

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,8 +4,8 @@ v3.8.9 (XXXX-XX-XX)
 * Fixed a bug in the API used by `arangorestore`: On restore, a new _rev value
   is generated for each imported document to avoid clashes with previously
   present data. This must be created on the shard leader rather than the
-  coordinator. The bug happened, when two coordinators were creating
-  the same _rev value for two different documents concurrently.
+  coordinator. The bug happened, when two coordinators were creating the same
+  _rev value for two different documents concurrently.
 
 * Updated ArangoDB Starter to 0.15.7.
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,12 @@
 v3.8.9 (XXXX-XX-XX)
 -------------------
 
+* Fixed a bug in the API used by `arangorestore`: On restore, a new _rev value
+  is generated for each imported document to avoid clashes with previously
+  present data. This must be created on the shard leader rather than the
+  coordinator. The bug happened, when two coordinators were creating
+  the same _rev value for two different documents concurrently.
+
 * Updated ArangoDB Starter to 0.15.7.
 
 * Updated OpenSSL to 1.1.1t and OpenLDAP to 2.6.4.

--- a/arangod/RestHandler/RestReplicationHandler.cpp
+++ b/arangod/RestHandler/RestReplicationHandler.cpp
@@ -1531,11 +1531,14 @@ Result RestReplicationHandler::parseBatch(transaction::Methods& trx,
             // prevent checking for _rev twice in the same document
             checkRev = false;
 
-            char ridBuffer[arangodb::basics::maxUInt64StringSize];
-            RevisionId newRid = physical->newRevisionId();
-            
-            documentsToInsert.add(it.key);
-            documentsToInsert.add(newRid.toValuePair(ridBuffer));
+            // We simply get rid of the `_rev` attribute here on the
+            // coordinator. We need to create a new value but it has to be
+            // unique in the shard, therefore the shard leader must create the
+            // value. If multiple coordinators would create a timestamp based
+            // _rev value concurrently, we could get a duplicate, which would
+            // lead to a clash on the actual shard leader and can lead to
+            // RocksDB conflicts or even data corruption between primary index
+            // and data in the documents column family.
           } else {
             // copy key/value verbatim
             documentsToInsert.add(it.key);


### PR DESCRIPTION
### Scope & Purpose

This is about https://arangodb.atlassian.net/browse/BTS-1232 .

Short description: 

arangorestore uses the (undocumented) API /_api/replication/restore-data
implemented in the RestReplicationHandler. Since ArangoDB 3.8, we
create new _rev values during the restore operation. Unfortunately,
this creation of _rev values was done on the coordinator(s) and since
these are hybrid logical clock (HLC) values, it can happen that the
generated _rev values on two different coordinators are the same for
two different documents. This will clash on the leader of the OneShard
database, since there, the newly generated _rev values are used as
internal document IDs, which directly translate into a RocksDB key in
the DocumentsColumnFamily. This leads to a collision and this manifests
itself as a lock timeout, since two different RocksDB transactions try
to touch the same key. However, even if no lock timeout would have
happened, the consequences would have been dire: Namely, there would
have been a corruption between primary index and data in the Documents
column family. We would have had two primary index entries pointing to
the same document.

- [*] :hankey: Bugfix

### Checklist

- [*] :book: CHANGELOG entry made
- [*] Backports
  - [*] Backport for 3.8: This is it.

#### Related Information

- [*] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/BTS-1232
- [*] Original PR: https://github.com/arangodb/arangodb/pull/18187



