### PR TITLE
[testing]: lean jsunity callstack

### DIFF
--- a/js/common/modules/jsunity/jsunity.js
+++ b/js/common/modules/jsunity/jsunity.js
@@ -11,16 +11,24 @@
  */
 var counter; // crying
 function reduceStack(errstack) {
+  const maxLines = 5;
   let ret = '';
-  let printLine = true;
-  String(errstack).split('\n').forEach(line => {
-    if ((line.search('RunTest') >= 0) ||
-        (line.search('Object.run') >= 0)){
-      printLine = false;
+  let numPrinted = 0;
+  let last;
+  let lines = String(errstack).split('\n').filter(
+    line => line.trim() !== '').filter(
+      line => !line.match(/(jsunity\.js|unknown source|RunTest|Object\.run|<anonymous>|run.*Runner\.run)/));
+  lines.forEach((line, index) => {
+    if (numPrinted++ >= maxLines && index !== lines.length - 1) {
+      // don't print more than x lines, but always print last line
+      return;
     }
-    if (printLine && line.search('jsunity.js') === -1) {
-      ret += line + '\n';
+    if (last === line) {
+      // don't print duplicate lines
+      return;
     }
+    last = line;
+    ret += line + '\n';
   });
   return ret;
 }

--- a/js/common/modules/jsunity/jsunity.js
+++ b/js/common/modules/jsunity/jsunity.js
@@ -20,11 +20,13 @@ function reduceStack(errstack) {
       line => !line.match(/(jsunity\.js|unknown source|RunTest|Object\.run|<anonymous>|run.*Runner\.run)/));
   lines.forEach((line, index) => {
     if (numPrinted++ >= maxLines && index !== lines.length - 1) {
+      ret += '.';
       // don't print more than x lines, but always print last line
       return;
     }
     if (last === line) {
       // don't print duplicate lines
+      ret += '.';
       return;
     }
     last = line;

--- a/js/common/modules/jsunity/jsunity.js
+++ b/js/common/modules/jsunity/jsunity.js
@@ -10,6 +10,20 @@
  * http://www.opensource.org/licenses/mit-license.php
  */
 var counter; // crying
+function reduceStack(errstack) {
+  let ret = '';
+  let printLine = true;
+  String(errstack).split('\n').forEach(line => {
+    if ((line.search('RunTest') >= 0) ||
+        (line.search('Object.run') >= 0)){
+      printLine = false;
+    }
+    if (printLine && line.search('jsunity.js') === -1) {
+      ret += line + '\n';
+    }
+  });
+  return ret;
+}
 var jsUnity = exports.jsUnity = (function () {
   function fmt(str) {
     var internal = require("internal");
@@ -62,7 +76,7 @@ var jsUnity = exports.jsUnity = (function () {
       var err = new Error();
 
       throw fmt("?: (?) does not raise an exception or not a function\n(?)",
-                message || "assertException", fn, err.stack);
+                message || "assertException", fn, reduceStack(err.stack));
     },
 
     assertTrue: function (actual, message) {
@@ -70,7 +84,7 @@ var jsUnity = exports.jsUnity = (function () {
       if (! actual) {
         var err = new Error();
         throw fmt("?: (?) does not evaluate to true\n(?)",
-                  message || "assertTrue", actual, err.stack);
+                  message || "assertTrue", actual, reduceStack(err.stack));
       }
     },
 
@@ -79,7 +93,7 @@ var jsUnity = exports.jsUnity = (function () {
       if (actual) {
         var err = new Error();
         throw fmt("?: (?) does not evaluate to false\n(?)",
-                  message || "assertFalse", actual, err.stack);
+                  message || "assertFalse", actual, reduceStack(err.stack));
       }
     },
 
@@ -89,7 +103,7 @@ var jsUnity = exports.jsUnity = (function () {
         var err = new Error();
         throw fmt("?: (?) is not identical to (?)\n(?)",
                   message || "assertIdentical", actual,
-                  expected, err.stack);
+                  expected, reduceStack(err.stack));
       }
     },
 
@@ -98,7 +112,7 @@ var jsUnity = exports.jsUnity = (function () {
       if (expected === actual) {
         var err = new Error();
         throw fmt("?: (?) is identical to (?)\n(?)",
-                  message || "assertNotIdentical", actual, expected, err.stack);
+                  message || "assertNotIdentical", actual, expected, reduceStack(err.stack));
       }
     },
 
@@ -107,7 +121,7 @@ var jsUnity = exports.jsUnity = (function () {
       if (hash(expected) !== hash(actual)) {
         var err = new Error();
         throw fmt("?: (?) is not equal to (?)\n(?)",
-                  message || "assertEqual", actual, expected, err.stack);
+                  message || "assertEqual", actual, expected, reduceStack(err.stack));
       }
     },
 
@@ -116,7 +130,7 @@ var jsUnity = exports.jsUnity = (function () {
       if (hash(expected) === hash(actual)) {
         var err = new Error();
         throw fmt("?: (?) is equal to (?)\n(?)",
-                  message || "assertNotEqual", actual, expected, err.stack);
+                  message || "assertNotEqual", actual, expected, reduceStack(err.stack));
       }
     },
 
@@ -125,7 +139,7 @@ var jsUnity = exports.jsUnity = (function () {
       if (! re.test(actual)) {
         var err = new Error();
         throw fmt("?: (?) does not match (?)\n(?)",
-                  message || "assertMatch", actual, re, err.stack);
+                  message || "assertMatch", actual, re, reduceStack(err.stack));
       }
     },
 
@@ -134,7 +148,7 @@ var jsUnity = exports.jsUnity = (function () {
       if (re.test(actual)) {
         var err = new Error();
         throw fmt("?: (?) matches (?)\n(?)",
-                  message || "assertNotMatch", actual, re, err.stack);
+                  message || "assertNotMatch", actual, re, reduceStack(err.stack));
       }
     },
 
@@ -143,7 +157,7 @@ var jsUnity = exports.jsUnity = (function () {
       if (typeof actual !== typ) {
         var err = new Error();
         throw fmt("?: (?) is not of type (?)\n(?)",
-                  message || "assertTypeOf", actual, typ, err.stack);
+                  message || "assertTypeOf", actual, typ, reduceStack(err.stack));
       }
     },
 
@@ -152,7 +166,7 @@ var jsUnity = exports.jsUnity = (function () {
       if (typeof actual === typ) {
         var err = new Error();
         throw fmt("?: (?) is of type (?)\n(?)",
-                  message || "assertNotTypeOf", actual, typ, err.stack);
+                  message || "assertNotTypeOf", actual, typ, reduceStack(err.stack));
       }
     },
 
@@ -161,7 +175,7 @@ var jsUnity = exports.jsUnity = (function () {
       if (!(actual instanceof cls)) {
         var err = new Error();
         throw fmt("?: (?) is not an instance of (?)\n(?)",
-                  message || "assertInstanceOf", actual, cls, err.stack);
+                  message || "assertInstanceOf", actual, cls, reduceStack(err.stack));
       }
     },
 
@@ -170,7 +184,7 @@ var jsUnity = exports.jsUnity = (function () {
       if (actual instanceof cls) {
         var err = new Error();
         throw fmt("?: (?) is an instance of (?)\n(?)",
-                  message || "assertNotInstanceOf", actual, cls, err.stack);
+                  message || "assertNotInstanceOf", actual, cls, reduceStack(err.stack));
       }
     },
 
@@ -179,7 +193,7 @@ var jsUnity = exports.jsUnity = (function () {
       if (actual !== null) {
         var err = new Error();
         throw fmt("?: (?) is not null\n(?)",
-                  message || "assertNull", actual, err.stack);
+                  message || "assertNull", actual, reduceStack(err.stack));
       }
     },
 
@@ -188,7 +202,7 @@ var jsUnity = exports.jsUnity = (function () {
       if (actual === null) {
         var err = new Error();
         throw fmt("?: (?) is null\n(?)",
-                  message || "assertNotNull", actual, err.stack);
+                  message || "assertNotNull", actual, reduceStack(err.stack));
       }
     },
 
@@ -197,7 +211,7 @@ var jsUnity = exports.jsUnity = (function () {
       if (actual !== undefined) {
         var err = new Error();
         throw fmt("?: (?) is not undefined\n(?)",
-                  message || "assertUndefined", actual, err.stack);
+                  message || "assertUndefined", actual, reduceStack(err.stack));
       }
     },
 
@@ -206,7 +220,7 @@ var jsUnity = exports.jsUnity = (function () {
       if (actual === undefined) {
         var err = new Error();
         throw fmt("?: (?) is undefined\n(?)",
-                  message || "assertNotUndefined", actual, err.stack);
+                  message || "assertNotUndefined", actual, reduceStack(err.stack));
       }
     },
 
@@ -215,7 +229,7 @@ var jsUnity = exports.jsUnity = (function () {
       if (!isNaN(actual)) {
         var err = new Error();
         throw fmt("?: (?) is not NaN\n(?)",
-                  message || "assertNaN", actual, err.stack);
+                  message || "assertNaN", actual, reduceStack(err.stack));
       }
     },
 
@@ -224,7 +238,7 @@ var jsUnity = exports.jsUnity = (function () {
       if (isNaN(actual)) {
         var err = new Error();
         throw fmt("?: (?) is NaN\n(?)",
-                  message || "assertNotNaN", actual, err.stack);
+                  message || "assertNotNaN", actual, reduceStack(err.stack));
       }
     },
 
@@ -521,7 +535,7 @@ var jsUnity = exports.jsUnity = (function () {
           runSuite = false;
           if (setUpAllError.stack !== undefined) {
             this.results.fail(0, suite.suiteName,
-                              setUpAllError + " - " + String(setUpAllError.stack) + 
+                              setUpAllError + " - " + reduceStack(setUpAllError.stack) + 
                               " - setUpAll failed");
           }
         }
@@ -582,19 +596,19 @@ var jsUnity = exports.jsUnity = (function () {
                 if (!didSetUp) {
                   this.results.endSetUp(suite.scope, test.name);
                   didSetUp = true;
-                  messages.push(String(e.stack) + " - setUp failed");
+                  messages.push(reduceStack(e.stack) + " - setUp failed");
                   skipTest = true;
                   continue;
                 }
                 if (!didTest && !skipTest) {
                   didTest = true;
-                  messages.push(String(e.stack) + " - test failed");
+                  messages.push(reduceStack(e.stack) + " - test failed");
                   continue;
                 }
                 if (!didTearDown) {
                   this.results.endTeardown(suite.scope, test.name);
                   didTearDown = true;
-                  messages.push(String(e.stack) + " - tearDown failed");
+                  messages.push(reduceStack(e.stack) + " - tearDown failed");
                   continue;
                 }
               }
@@ -609,7 +623,7 @@ var jsUnity = exports.jsUnity = (function () {
         } catch (tearDownAllError) {
           if (tearDownAllError.stack !== undefined) {
             this.results.fail(0, suite.suiteName,
-                              tearDownAllError + " - " + String(tearDownAllError.stack) + 
+                              tearDownAllError + " - " + reduceStack(tearDownAllError.stack) + 
                               " - tearDownAll failed");
           }
         }


### PR DESCRIPTION
### Scope & Purpose

So far we will output the full javascript stacktrace with test-errors. 
most of this callstack contains references to boilerplate code we usually aren't interested in.
This PR: 
 - will filter out any line containing `jsunity.js` - hence the function doing the assert itself, and any other from jsunity
 - all lines in stackframes above `RunTest` (our main integration point to jsunity) 
 - all lines in stackframes above `Object.run` (the integration point to the individual jsunity test cases, may be in the stack above `RunTest`)

So, from:
```

    [FAILED]  enterprise/tests/js/common/aql/aql-arangosearch-views-nested-search.js

      "testSubNested" failed: Error: at assertion #9: assertEqual: (6) is not equal to (3)
(Error
    at assertEqual (/work/ArangoDB/js/common/modules/jsunity/jsunity.js:108:19)
    at Object.setUp (enterprise/tests/js/common/aql/aql-arangosearch-views-nested-search.js:117:9)
    at /work/ArangoDB/js/common/modules/jsunity/jsunity.js:483:16
    at Object.run (/work/ArangoDB/js/common/modules/jsunity/jsunity.js:545:21)
    at Object.Run [as run] (/work/ArangoDB/js/common/modules/jsunity.js:299:24)
    at enterprise/tests/js/common/aql/aql-arangosearch-views-nested-search.js:309:9
    at enterprise/tests/js/common/aql/aql-arangosearch-views-nested-search.js:312:3
    at RunTest (/work/ArangoDB/js/common/modules/jsunity.js:418:12)
    at source (eval at <anonymous> (unknown source), <anonymous>:3:8))
    at Object.run (/work/ArangoDB/js/common/modules/jsunity/jsunity.js:575:23)
    at Object.Run [as run] (/work/ArangoDB/js/common/modules/jsunity.js:299:24)
    at enterprise/tests/js/common/aql/aql-arangosearch-views-nested-search.js:309:9
    at enterprise/tests/js/common/aql/aql-arangosearch-views-nested-search.js:312:3
    at RunTest (/work/ArangoDB/js/common/modules/jsunity.js:418:12)
    at source (eval at <anonymous> (unknown source), <anonymous>:3:8) - setUp failed
```
we will keep:
```

    [FAILED]  enterprise/tests/js/common/aql/aql-arangosearch-views-nested-search.js

      "testSubNested" failed: Error: at assertion #9: assertEqual: (6) is not equal to (3)
(Error
    at Object.setUp (enterprise/tests/js/common/aql/aql-arangosearch-views-nested-search.js:117:9)
```
