### PR TITLE
BTS-1249: Add startup option `--foxx.enable`.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,17 @@
 devel
 -----
 
+* BTS-1249: Add startup option `--foxx.enable`.
+  This startup option determines whether access to user-defined Foxx services
+  is possible for the instance. It defaults to `true`.
+  If the option is set to `false`, access to Foxx services is forbidden and
+  will be responded with an HTTP 403 Forbidden error. Access to ArangoDB's
+  built-in web interface, which is also a Foxx service, is still possible even
+  with the option set to `false`.
+  When setting the option to `false`, access to the management APIs for Foxx
+  services will also be disabled. This is the same as manually setting the
+  option `--foxx.api false`.
+
 * Updated arangosync to v2.15.0-preview-1.
 
 * The internal Graph code is completely converted to the new graph engine.

--- a/arangod/GeneralServer/CommTask.cpp
+++ b/arangod/GeneralServer/CommTask.cpp
@@ -49,6 +49,9 @@
 #include "Utils/Events.h"
 #include "VocBase/ticks.h"
 #include "VocBase/vocbase.h"
+#include "V8Server/FoxxFeature.h"
+
+#include <string_view>
 
 using namespace arangodb;
 using namespace arangodb::basics;
@@ -56,9 +59,11 @@ using namespace arangodb::rest;
 
 namespace {
 // some static URL path prefixes
-std::string const AdminAardvark("/_admin/aardvark/");
-std::string const ApiUser("/_api/user/");
-std::string const Open("/_open/");
+constexpr std::string_view pathPrefixApi("/_api/");
+constexpr std::string_view pathPrefixApiUser("/_api/user/");
+constexpr std::string_view pathPrefixAdmin("/_admin/");
+constexpr std::string_view pathPrefixAdminAardvark("/_admin/aardvark/");
+constexpr std::string_view pathPrefixOpen("/_open/");
 
 VocbasePtr lookupDatabaseFromRequest(ArangodServer& server,
                                      GeneralRequest& req) {
@@ -256,7 +261,7 @@ CommTask::Flow CommTask::prepareExecution(
     }
       [[fallthrough]];
     case ServerState::Mode::TRYAGAIN: {
-      // the following paths are allowed on followers
+      // the following paths are allowed on followers in active failover
       if (!path.starts_with("/_admin/shutdown") &&
           !path.starts_with("/_admin/cluster/health") &&
           !path.starts_with("/_admin/cluster/maintenance") &&
@@ -335,6 +340,20 @@ CommTask::Flow CommTask::prepareExecution(
                       TRI_ERROR_FORBIDDEN,
                       "not authorized to execute this request");
     return Flow::Abort;
+  }
+
+  if (ServerState::instance()->isSingleServerOrCoordinator()) {
+    auto& ff = _server.server().getFeature<FoxxFeature>();
+    if (!ff.foxxEnabled() &&
+        !(path == "/" || path.starts_with(::pathPrefixAdmin) ||
+          path.starts_with(::pathPrefixApi) ||
+          path.starts_with(::pathPrefixOpen))) {
+      sendErrorResponse(rest::ResponseCode::FORBIDDEN,
+                        req.contentTypeResponse(), req.messageId(),
+                        TRI_ERROR_FORBIDDEN,
+                        "access to Foxx apps is turned off on this instance");
+      return Flow::Abort;
+    }
   }
 
   // Step 5: Update global HLC timestamp from authenticated requests
@@ -826,8 +845,8 @@ CommTask::Flow CommTask::canAccessPath(auth::TokenCache::Entry const& token,
     if (result == Flow::Abort) {
       std::string const& username = req.user();
 
-      if (path == "/" || path.starts_with(Open) ||
-          path.starts_with(AdminAardvark) ||
+      if (path == "/" || path.starts_with(::pathPrefixOpen) ||
+          path.starts_with(::pathPrefixAdminAardvark) ||
           path == "/_admin/server/availability") {
         // mop: these paths are always callable...they will be able to check
         // req.user when it could be validated
@@ -838,12 +857,13 @@ CommTask::Flow CommTask::canAccessPath(auth::TokenCache::Entry const& token,
         result = Flow::Continue;
         // vc->forceReadOnly();
       } else if (req.requestType() == RequestType::POST && !username.empty() &&
-                 path.starts_with(ApiUser + username + '/')) {
+                 path.starts_with(std::string{::pathPrefixApiUser} + username +
+                                  '/')) {
         // simon: unauthorized users should be able to call
         // `/_api/users/<name>` to check their passwords
         result = Flow::Continue;
         vc->forceReadOnly();
-      } else if (userAuthenticated && path.starts_with(ApiUser)) {
+      } else if (userAuthenticated && path.starts_with(::pathPrefixApiUser)) {
         result = Flow::Continue;
       }
     }

--- a/arangod/GeneralServer/ServerSecurityFeature.cpp
+++ b/arangod/GeneralServer/ServerSecurityFeature.cpp
@@ -85,19 +85,23 @@ void ServerSecurityFeature::collectOptions(
       .setIntroducedIn(30805);
 }
 
-bool ServerSecurityFeature::isFoxxApiDisabled() const {
+void ServerSecurityFeature::disableFoxxApi() noexcept {
+  _enableFoxxApi = false;
+}
+
+bool ServerSecurityFeature::isFoxxApiDisabled() const noexcept {
   return !_enableFoxxApi;
 }
 
-bool ServerSecurityFeature::isFoxxStoreDisabled() const {
+bool ServerSecurityFeature::isFoxxStoreDisabled() const noexcept {
   return !_enableFoxxStore || !_enableFoxxApi;
 }
 
-bool ServerSecurityFeature::isRestApiHardened() const {
+bool ServerSecurityFeature::isRestApiHardened() const noexcept {
   return _hardenedRestApi;
 }
 
-bool ServerSecurityFeature::canAccessHardenedApi() const {
+bool ServerSecurityFeature::canAccessHardenedApi() const noexcept {
   bool allowAccess = !isRestApiHardened();
 
   if (!allowAccess) {
@@ -111,6 +115,6 @@ bool ServerSecurityFeature::canAccessHardenedApi() const {
   return allowAccess;
 }
 
-bool ServerSecurityFeature::foxxAllowInstallFromRemote() const {
+bool ServerSecurityFeature::foxxAllowInstallFromRemote() const noexcept {
   return _foxxAllowInstallFromRemote;
 }

--- a/arangod/GeneralServer/ServerSecurityFeature.h
+++ b/arangod/GeneralServer/ServerSecurityFeature.h
@@ -35,11 +35,14 @@ class ServerSecurityFeature final : public ArangodFeature {
 
   void collectOptions(std::shared_ptr<options::ProgramOptions>) override final;
 
-  bool isRestApiHardened() const;
-  bool isFoxxApiDisabled() const;
-  bool isFoxxStoreDisabled() const;
-  bool canAccessHardenedApi() const;
-  bool foxxAllowInstallFromRemote() const;
+  // disable Foxx API. must only be called during server startup
+  void disableFoxxApi() noexcept;
+
+  bool isRestApiHardened() const noexcept;
+  bool isFoxxApiDisabled() const noexcept;
+  bool isFoxxStoreDisabled() const noexcept;
+  bool canAccessHardenedApi() const noexcept;
+  bool foxxAllowInstallFromRemote() const noexcept;
 
  private:
   bool _enableFoxxApi;

--- a/arangod/Utils/ExecContext.cpp
+++ b/arangod/Utils/ExecContext.cpp
@@ -139,18 +139,19 @@ auth::Level ExecContext::collectionAuthLevel(std::string const& dbname,
     return auth::Level::RW;
   }
 
-  if (coll.size() >= 5 && coll[0] == '_') {
-    // _users, _queues, _frontend
-
+  if (coll.starts_with('_')) {
     // handle fixed permissions here outside auth module.
     // TODO: move this block above, such that it takes effect
     //       when authentication is disabled
     if (dbname == StaticStrings::SystemDatabase &&
         coll == StaticStrings::UsersCollection) {
+      // _users (only present in _system database)
       return auth::Level::NONE;
     } else if (coll == StaticStrings::QueuesCollection) {
+      // _queues
       return auth::Level::RO;
     } else if (coll == StaticStrings::FrontendCollection) {
+      // _frontend
       return auth::Level::RW;
     }  // intentional fall through
   }

--- a/arangod/Utils/ExecContext.h
+++ b/arangod/Utils/ExecContext.h
@@ -71,21 +71,21 @@ class ExecContext : public RequestContext {
 
   /// @brief an internal user is none / ro / rw for all collections / dbs
   /// mainly used to override further permission resolution
-  inline bool isInternal() const { return _type == Type::Internal; }
+  bool isInternal() const noexcept { return _type == Type::Internal; }
 
   /// @brief any internal operation is a superuser.
-  bool isSuperuser() const {
+  bool isSuperuser() const noexcept {
     return isInternal() && _systemDbAuthLevel == auth::Level::RW &&
            _databaseAuthLevel == auth::Level::RW;
   }
 
   /// @brief is this an internal read-only user
-  bool isReadOnly() const {
+  bool isReadOnly() const noexcept {
     return isInternal() && _systemDbAuthLevel == auth::Level::RO;
   }
 
   /// @brief is allowed to manage users, create databases, ...
-  bool isAdminUser() const { return _isAdminUser; }
+  bool isAdminUser() const noexcept { return _isAdminUser; }
 
   /// @brief tells you if this execution was canceled
   virtual bool isCanceled() const { return false; }
@@ -95,15 +95,15 @@ class ExecContext : public RequestContext {
 
   // std::string const& database() const { return _database; }
   /// @brief authentication level on _system. Always RW for superuser
-  auth::Level systemAuthLevel() const { return _systemDbAuthLevel; }
+  auth::Level systemAuthLevel() const noexcept { return _systemDbAuthLevel; }
 
   /// @brief Authentication level on database selected in the current
   ///        request scope. Should almost always contain something,
   ///        if this thread originated in v8 or from HTTP / VST
-  auth::Level databaseAuthLevel() const { return _databaseAuthLevel; }
+  auth::Level databaseAuthLevel() const noexcept { return _databaseAuthLevel; }
 
   /// @brief returns true if auth level is above or equal `requested`
-  bool canUseDatabase(auth::Level requested) const {
+  bool canUseDatabase(auth::Level requested) const noexcept {
     return requested <= _databaseAuthLevel;
   }
 

--- a/arangod/V8Server/FoxxFeature.cpp
+++ b/arangod/V8Server/FoxxFeature.cpp
@@ -25,11 +25,10 @@
 
 #include "Agency/AgencyComm.h"
 #include "ApplicationFeatures/ApplicationServer.h"
+#include "GeneralServer/ServerSecurityFeature.h"
 #include "Logger/LogMacros.h"
 #include "ProgramOptions/Parameters.h"
 #include "ProgramOptions/ProgramOptions.h"
-
-#include <shared_mutex>
 
 using namespace arangodb::application_features;
 using namespace arangodb::options;
@@ -40,9 +39,10 @@ FoxxFeature::FoxxFeature(Server& server)
     : ArangodFeature{server, *this},
       _queueVersion(0),
       _localQueueInserts(0),
-      _pollInterval(1.0),
-      _enabled(true),
-      _startupWaitForSelfHeal(false) {
+      _queuesPollInterval(1.0),
+      _queuesEnabled(true),
+      _startupWaitForSelfHeal(false),
+      _foxxEnabled(true) {
   setOptional(true);
   startsAfter<application_features::ServerFeaturePhase>();
 }
@@ -56,7 +56,7 @@ void FoxxFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
 
   options
       ->addOption("--foxx.queues", "Enable or disable Foxx queues.",
-                  new BooleanParameter(&_enabled),
+                  new BooleanParameter(&_queuesEnabled),
                   arangodb::options::makeFlags(
                       arangodb::options::Flags::DefaultNoComponents,
                       arangodb::options::Flags::OnCoordinator,
@@ -70,7 +70,7 @@ being processed, which may reduce CPU load a bit.)");
   options
       ->addOption("--foxx.queues-poll-interval",
                   "The poll interval for the Foxx queue manager (in seconds)",
-                  new DoubleParameter(&_pollInterval),
+                  new DoubleParameter(&_queuesPollInterval),
                   arangodb::options::makeFlags(
                       arangodb::options::Flags::DefaultNoComponents,
                       arangodb::options::Flags::OnCoordinator,
@@ -117,18 +117,56 @@ Active Failover mode, all Foxx apps are available from the very beginning.
 
 **Note**: ArangoDB 3.8 changes the default value to `false` for this option.
 In previous versions, this option had a default value of `true`.)");
+
+  options
+      ->addOption("--foxx.enable", "Enable Foxx.",
+                  new BooleanParameter(&_foxxEnabled),
+                  arangodb::options::makeFlags(
+                      arangodb::options::Flags::DefaultNoComponents,
+                      arangodb::options::Flags::OnCoordinator,
+                      arangodb::options::Flags::OnSingle))
+      .setIntroducedIn(31005)
+      .setLongDescription(R"(If set to `false`, access to any custom Foxx 
+services in the deployment will be forbidden. Access to ArangoDB's built-in
+web interface will still be possible though.
+
+**Note**: when setting this option to `false`, the management API for Foxx
+services will automatically be disabled as well. This is the same as manually
+setting the startup option `--foxx.api false`.)");
 }
 
 void FoxxFeature::validateOptions(std::shared_ptr<ProgramOptions> options) {
   // use a minimum for the interval
-  if (_pollInterval < 0.1) {
-    _pollInterval = 0.1;
+  if (_queuesPollInterval < 0.1) {
+    _queuesPollInterval = 0.1;
   }
 }
 
-bool FoxxFeature::startupWaitForSelfHeal() const {
+void FoxxFeature::prepare() {
+  if (!_foxxEnabled) {
+    auto& ssf = server().getFeature<ServerSecurityFeature>();
+    if (!ssf.isFoxxApiDisabled()) {
+      ssf.disableFoxxApi();
+      LOG_TOPIC("a19bd", WARN, Logger::FIXME)
+          << "automatically disabling management APIs for Foxx, as access to "
+             "Foxx apps is "
+             "also turned off";
+    }
+  }
+}
+
+double FoxxFeature::pollInterval() const noexcept {
+  if (!_queuesEnabled) {
+    return -1.0;
+  }
+  return _queuesPollInterval;
+}
+
+bool FoxxFeature::startupWaitForSelfHeal() const noexcept {
   return _startupWaitForSelfHeal;
 }
+
+bool FoxxFeature::foxxEnabled() const noexcept { return _foxxEnabled; }
 
 uint64_t FoxxFeature::queueVersion() const noexcept {
   std::shared_lock lock(_queueLock);

--- a/arangod/V8Server/FoxxFeature.h
+++ b/arangod/V8Server/FoxxFeature.h
@@ -37,17 +37,15 @@ class FoxxFeature final : public ArangodFeature {
 
   void collectOptions(std::shared_ptr<options::ProgramOptions>) override final;
   void validateOptions(std::shared_ptr<options::ProgramOptions>) override final;
+  void prepare() override final;
 
   // return poll interval for foxx queues. returns a negative number if
   // foxx queues are turned off
-  double pollInterval() const {
-    if (!_enabled) {
-      return -1.0;
-    }
-    return _pollInterval;
-  }
+  double pollInterval() const noexcept;
 
-  bool startupWaitForSelfHeal() const;
+  bool startupWaitForSelfHeal() const noexcept;
+
+  bool foxxEnabled() const noexcept;
 
   // store the locally applied version of the queue. this method will make sure
   // we will not go below any version that we have already seen.
@@ -75,9 +73,10 @@ class FoxxFeature final : public ArangodFeature {
   uint64_t _queueVersion;
   uint64_t _localQueueInserts;
 
-  double _pollInterval;
-  bool _enabled;
+  double _queuesPollInterval;
+  bool _queuesEnabled;
   bool _startupWaitForSelfHeal;
+  bool _foxxEnabled;
 };
 
 }  // namespace arangodb

--- a/tests/js/client/server_parameters/foxx-enable-false.js
+++ b/tests/js/client/server_parameters/foxx-enable-false.js
@@ -1,0 +1,105 @@
+/*jshint globalstrict:false, strict:false */
+/* global getOptions, assertEqual, assertTrue, assertFalse, arango */
+
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2010-2012 triagens GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB Inc, Cologne, Germany
+///
+/// @author Jan Steemann
+/// @author Copyright 2021, ArangoDB Inc, Cologne, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+if (getOptions === true) {
+  return {
+    'foxx.enable': 'false',
+  };
+}
+const jsunity = require('jsunity');
+
+function testSuite() {
+  const mount = "/test123";
+
+  return {
+    testAccessAPIs: function() {
+      const urls = [
+        [ "/", 301 ],
+        [ "/_admin/log", 200 ],
+        [ "/_admin/log/level", 200 ],
+        [ "/_admin/version", 200 ],
+        [ "/_api/collection", 200 ],
+        [ "/_api/version", 200 ],
+      ];
+      urls.forEach((data) => {
+        const [url, code] = data;
+        let res = arango.GET_RAW(url);
+        assertEqual(code, res.code, { res, url });
+        assertFalse(res.error, { res, url });
+      });
+    },
+
+    testAccessWebInterface: function() {
+      const urls = [
+        [ "/", 301 ],
+        [ "/_admin/aardvark", 307 ],
+        [ "/_admin/aardvark/", 307 ],
+        [ "/_admin/aardvark/index.html", 200 ],
+      ];
+      urls.forEach((data) => {
+        const [url, code] = data;
+        let res = arango.GET_RAW(url);
+        assertEqual(code, res.code, { res, url });
+        assertFalse(res.error, { res, url });
+      });
+    },
+    
+    testAccessNonExistingFoxxApps: function() {
+      const urls = [
+        [ "/this/foxx/does-not-exist", 403 ],
+        [ "/this/foxx/does-not-exist/", 403 ],
+        [ "/foxx/does-not-exist", 403 ],
+        [ "/foxx/does-not-exist/", 403 ],
+        [ "/does-not-exist", 403 ],
+        [ "/does-not-exist/", 403 ],
+      ];
+      urls.forEach((data) => {
+        const [url, code] = data;
+        let res = arango.GET_RAW(url);
+        assertEqual(code, res.code, { res, url });
+        assertTrue(res.error, { res, url });
+      });
+    },
+
+    testInstallAndAccessFoxxApp: function() {
+      const url = "https://github.com/arangodb-foxx/demo-itzpapalotl/archive/refs/heads/master.zip";
+
+      // try installing the app, but it should fail
+      let res = arango.PUT_RAW(`/_admin/aardvark/foxxes/url?mount=${mount}`, { url });
+      assertTrue(res.error, { res, url });
+      assertEqual(403, res.code, { res, url });
+
+      // access Foxx app
+      res = arango.GET_RAW(mount);
+      assertEqual(403, res.code, { res, url });
+      assertTrue(res.error, { res, url });
+    },
+
+  };
+}
+
+jsunity.run(testSuite);
+return jsunity.done();

--- a/tests/js/client/server_parameters/foxx-enable-true.js
+++ b/tests/js/client/server_parameters/foxx-enable-true.js
@@ -1,0 +1,116 @@
+/*jshint globalstrict:false, strict:false */
+/* global getOptions, assertEqual, assertTrue, assertFalse, arango */
+
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2010-2012 triagens GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB Inc, Cologne, Germany
+///
+/// @author Jan Steemann
+/// @author Copyright 2021, ArangoDB Inc, Cologne, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+if (getOptions === true) {
+  return {
+    'foxx.enable': 'true',
+  };
+}
+const jsunity = require('jsunity');
+const FoxxManager = require('@arangodb/foxx/manager');
+
+function testSuite() {
+  const mount = "/test123";
+
+  return {
+    testAccessAPIs: function() {
+      const urls = [
+        [ "/", 301 ],
+        [ "/_admin/log", 200 ],
+        [ "/_admin/log/level", 200 ],
+        [ "/_admin/version", 200 ],
+        [ "/_api/collection", 200 ],
+        [ "/_api/version", 200 ],
+      ];
+      urls.forEach((data) => {
+        const [url, code] = data;
+        let res = arango.GET_RAW(url);
+        assertEqual(code, res.code, { res, url });
+        assertFalse(res.error, { res, url });
+      });
+    },
+
+    testAccessWebInterface: function() {
+      const urls = [
+        [ "/", 301 ],
+        [ "/_admin/aardvark", 307 ],
+        [ "/_admin/aardvark/", 307 ],
+        [ "/_admin/aardvark/index.html", 200 ],
+      ];
+      urls.forEach((data) => {
+        const [url, code] = data;
+        let res = arango.GET_RAW(url);
+        assertEqual(code, res.code, { res, url });
+        assertFalse(res.error, { res, url });
+      });
+    },
+    
+    testAccessNonExistingFoxxApps: function() {
+      const urls = [
+        [ "/this/foxx/does-not-exist", 404 ],
+        [ "/this/foxx/does-not-exist/", 404 ],
+        [ "/foxx/does-not-exist", 404 ],
+        [ "/foxx/does-not-exist/", 404 ],
+        [ "/does-not-exist", 404 ],
+        [ "/does-not-exist/", 404 ],
+      ];
+      urls.forEach((data) => {
+        const [url, code] = data;
+        let res = arango.GET_RAW(url);
+        assertEqual(code, res.code, { res, url });
+        assertTrue(res.error, { res, url });
+      });
+    },
+
+    testInstallAndAccessFoxxApp: function() {
+      const url = "https://github.com/arangodb-foxx/demo-itzpapalotl/archive/refs/heads/master.zip";
+
+      try {
+        // install app first
+        let res = arango.PUT(`/_admin/aardvark/foxxes/url?mount=${mount}`, { url });
+        assertFalse(res.error, { res, url });
+
+        // access Foxx app
+        res = arango.GET_RAW(mount);
+        assertEqual(307, res.code, { res, url });
+        assertFalse(res.error, { res, url });
+        
+        res = arango.GET_RAW(mount + "/index");
+        assertEqual(200, res.code, { res, url });
+        assertFalse(res.error, { res, url });
+
+      } finally {
+        try {
+          FoxxManager.uninstall(mount);
+        } catch (err) {}
+      }
+    },
+
+  };
+}
+
+jsunity.run(testSuite);
+return jsunity.done();


### PR DESCRIPTION
### Scope & Purpose

Implement https://arangodb.atlassian.net/browse/BTS-1249

* BTS-1249: Add startup option `--foxx.enable`. This startup option determines whether access to user-defined Foxx services is possible for the instance. It defaults to `true`. If the option is set to `false`, access to Foxx services is forbidden and will be responded with an HTTP 403 Forbidden error. Access to ArangoDB's built-in web interface, which is also a Foxx service, is still possible even with the option set to `false`. When setting the option to `false`, access to the management APIs for Foxx services will also be disabled. This is the same as manually setting the option `--foxx.api false`.

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [x] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.10: https://github.com/arangodb/arangodb/pull/18203
  - [ ] Backport for 3.9: 
  - [ ] Backport for 3.8: 

#### Related Information

- [x] Docs PR: https://github.com/arangodb/docs/pull/1291
- [ ] Enterprise PR:
- [x] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/BTS-1249
- [ ] Design document: 