### PR TITLE
Removed comment from test in BTS-1184 3.10 backport

### DIFF
--- a/tests/js/server/aql/aql-geo.js
+++ b/tests/js/server/aql/aql-geo.js
@@ -155,14 +155,10 @@ function geoSuite(isSearchAlias) {
     let cmpResView = compareKeyLists("without index", resFullScanNoIndexes, "with view", resView);
     let cmpResInvertedIndex = compareKeyLists("without index", resFullScanNoIndexes, "with inverted index", resInvertedIndex);
     
-    // PLEASE UNCOMMENT LINES BELOW AFTER FIXING https://arangodb.atlassian.net/browse/BTS-1184
-    
-    /*
     let explanation = db._createStatement(invertedIndexQuery).explain().plan;
     let utilizedIndexes = explanation.nodes.filter(node => node.type === 'IndexNode')[0].indexes;
     assertEqual(utilizedIndexes.length, 1);
     assertEqual(utilizedIndexes[0].name, "inverted");
-    */
 
     if (!cmpResFullScanWithIndexes.good || !cmpResView.good || !cmpResInvertedIndex.good) {
       print("Query for collections:", fullScanQuery);


### PR DESCRIPTION
### Scope & Purpose

Backport for https://github.com/arangodb/arangodb/pull/18218.
This PR removes a comment from a test after the fix for BTS-1184 in https://github.com/arangodb/arangodb/pull/18086.