### PR TITLE
Added metric for observing the number of replication clients

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 v3.10.5 (XXXX-XX-XX)
 --------------------
 
+* Added metric `arangodb_replication_clients` showing the number of currently
+  active/connected replication clients for a server.
+
 * Improve memory usage of in-memory edge index cache if most of the edges in an
   index refer to a single or mostly the same collection.
   Previously the full edge ids, consisting of the the referred-to collection

--- a/Documentation/Metrics/arangodb_replication_clients.yaml
+++ b/Documentation/Metrics/arangodb_replication_clients.yaml
@@ -1,0 +1,15 @@
+name: arangodb_replication_clients
+introducedIn: "3.10.5"
+help: |
+  Number of currently connected/active replication clients.
+unit: number
+type: gauge
+category: Replication
+complexity: medium
+exposedBy:
+  - single
+  - dbserver
+description: |
+  This metric contains the number of currently active/connected replication clients
+  that have started or are currently receiving data from this server for replication
+  purposes.

--- a/arangod/Replication/ReplicationClients.h
+++ b/arangod/Replication/ReplicationClients.h
@@ -26,6 +26,7 @@
 #include "Basics/Common.h"
 #include "Basics/ReadWriteLock.h"
 #include "Basics/debugging.h"
+#include "Replication/ReplicationFeature.h"
 #include "Replication/SyncerId.h"
 #include "VocBase/Identifiers/ServerId.h"
 
@@ -67,7 +68,8 @@ struct ReplicationClientProgress {
 /// for a particular database
 class ReplicationClientsProgressTracker {
  public:
-  ReplicationClientsProgressTracker() = default;
+  explicit ReplicationClientsProgressTracker(ReplicationFeature& rf);
+
 #ifndef ARANGODB_ENABLE_MAINTAINER_MODE
   ~ReplicationClientsProgressTracker() = default;
 #else
@@ -189,6 +191,8 @@ class ReplicationClientsProgressTracker {
   }
 
  private:
+  ReplicationFeature& _feature;
+
   mutable basics::ReadWriteLock _lock;
 
   /// @brief mapping from (SyncerId | ClientServerId) -> progress

--- a/arangod/Replication/ReplicationClients.h
+++ b/arangod/Replication/ReplicationClients.h
@@ -26,11 +26,12 @@
 #include "Basics/Common.h"
 #include "Basics/ReadWriteLock.h"
 #include "Basics/debugging.h"
-#include "Replication/ReplicationFeature.h"
 #include "Replication/SyncerId.h"
 #include "VocBase/Identifiers/ServerId.h"
 
 namespace arangodb {
+class ReplicationFeature;
+
 namespace velocypack {
 class Builder;
 }
@@ -68,7 +69,8 @@ struct ReplicationClientProgress {
 /// for a particular database
 class ReplicationClientsProgressTracker {
  public:
-  explicit ReplicationClientsProgressTracker(ReplicationFeature& rf);
+  // note: rf is a nullptr in unit tests
+  explicit ReplicationClientsProgressTracker(ReplicationFeature* rf);
 
 #ifndef ARANGODB_ENABLE_MAINTAINER_MODE
   ~ReplicationClientsProgressTracker() = default;
@@ -191,7 +193,8 @@ class ReplicationClientsProgressTracker {
   }
 
  private:
-  ReplicationFeature& _feature;
+  // pointer to replication feature. this is a nullptr during unit tests
+  ReplicationFeature* _feature;
 
   mutable basics::ReadWriteLock _lock;
 

--- a/arangod/Replication/ReplicationFeature.h
+++ b/arangod/Replication/ReplicationFeature.h
@@ -24,7 +24,7 @@
 #pragma once
 
 #include "Cluster/ServerState.h"
-#include "Metrics/Counter.h"
+#include "Metrics/Fwd.h"
 #include "RestServer/arangod.h"
 #include "SimpleHttpClient/ConnectionCache.h"
 
@@ -100,7 +100,7 @@ class ReplicationFeature final : public ArangodFeature {
   /// must only be called after a successful call to trackTailingstart
   void trackTailingEnd() noexcept;
 
-  void trackInventoryRequest() { ++_inventoryRequests; }
+  void trackInventoryRequest() noexcept;
 
   /// @brief set the x-arango-endpoint header
   void setEndpointHeader(GeneralResponse*, arangodb::ServerState::Mode);
@@ -111,6 +111,9 @@ class ReplicationFeature final : public ArangodFeature {
   /// @brief get max document num for quick call to _api/replication/keys to get
   /// actual keys or only doc count
   uint64_t quickKeysLimit() const { return _quickKeysLimit; }
+
+  /// @brief return a reference to the "number of clients" metric
+  metrics::Gauge<uint64_t>& clientsMetric() { return _clients; }
 
  private:
   /// @brief connection timeout for replication requests
@@ -150,6 +153,9 @@ class ReplicationFeature final : public ArangodFeature {
   uint64_t _quickKeysLimit;
 
   metrics::Counter& _inventoryRequests;
+
+  /// @brief number of currently active clients
+  metrics::Gauge<uint64_t>& _clients;
 };
 
 }  // namespace arangodb

--- a/arangod/RocksDBEngine/RocksDBEngine.cpp
+++ b/arangod/RocksDBEngine/RocksDBEngine.cpp
@@ -2293,9 +2293,10 @@ void RocksDBEngine::determinePrunableWalFiles(TRI_voc_tick_t minTickExternal) {
                                 : std::numeric_limits<TRI_voc_tick_t>::max(),
                minTickExternal);
 
-  LOG_TOPIC("4673c", TRACE, Logger::ENGINES)
+  LOG_TOPIC("4673c", DEBUG, Logger::ENGINES)
       << "determining prunable WAL files, minTickToKeep: " << minTickToKeep
-      << ", minTickExternal: " << minTickExternal;
+      << ", minTickExternal: " << minTickExternal
+      << ", releasedTick: " << _releasedTick;
 
   // Retrieve the sorted list of all wal files with earliest file first
   rocksdb::VectorLogPtr files;

--- a/arangod/RocksDBEngine/RocksDBMetadata.cpp
+++ b/arangod/RocksDBEngine/RocksDBMetadata.cpp
@@ -392,6 +392,17 @@ Result RocksDBMetadata::serializeMeta(rocksdb::WriteBatch& batch,
     return res;
   }
 
+  struct Stats {
+    rocksdb::SequenceNumber originalAppliedSeq = 0;
+    rocksdb::SequenceNumber maxCommitSeq = 0;
+    rocksdb::SequenceNumber appliedSeqAfterRevisionTree = 0;
+    bool didWork = false;
+  };
+
+  Stats stats;
+  // store original applied seq
+  stats.originalAppliedSeq = appliedSeq;
+
   auto& engine = coll.vocbase()
                      .server()
                      .getFeature<EngineSelectorFeature>()
@@ -399,6 +410,8 @@ Result RocksDBMetadata::serializeMeta(rocksdb::WriteBatch& batch,
   std::string const context = coll.vocbase().name() + "/" + coll.name();
 
   rocksdb::SequenceNumber const maxCommitSeq = committableSeq(appliedSeq);
+  // store committable seq
+  stats.maxCommitSeq = maxCommitSeq;
   TRI_ASSERT(maxCommitSeq <= appliedSeq);
 
 #ifdef ARANGODB_ENABLE_FAILURE_TESTS
@@ -419,6 +432,7 @@ Result RocksDBMetadata::serializeMeta(rocksdb::WriteBatch& batch,
   }
 
   bool didWork = applyAdjustments(maxCommitSeq);
+  stats.didWork = didWork;
   appliedSeq = maxCommitSeq;
 
   RocksDBKey key;
@@ -521,21 +535,36 @@ Result RocksDBMetadata::serializeMeta(rocksdb::WriteBatch& batch,
     }
   }
 
-  if (!coll.useSyncByRevision()) {
-    return Result{};
+  TRI_ASSERT(res.ok());
+
+  if (coll.useSyncByRevision()) {
+    // Step 4. Take care of revision tree, either serialize or persist
+    // it, or at least check if we can move forward the seq number when
+    // it was last serialized (in case there have been no writes to the
+    // collection for some time). In either case, the resulting sequence
+    // number is incorporated into the minimum calculation for lastSync
+    // (via `appliedSeq`), such that recovery only has to look at the WAL
+    // from this sequence number on to be able to recover the tree from
+    // its last persisted state.
+    res = rcoll->takeCareOfRevisionTreePersistence(coll, engine, batch, cf,
+                                                   maxCommitSeq, force, context,
+                                                   output, appliedSeq);
+
+    stats.appliedSeqAfterRevisionTree = appliedSeq;
   }
 
-  // Step 4. Take care of revision tree, either serialize or persist
-  // it, or at least check if we can move forward the seq number when
-  // it was last serialized (in case there have been no writes to the
-  // collection for some time). In either case, the resulting sequence
-  // number is incorporated into the minimum calculation for lastSync
-  // (via `appliedSeq`), such that recovery only has to look at the WAL
-  // from this sequence number on to be able to recover the tree from
-  // its last persisted state.
-  return rcoll->takeCareOfRevisionTreePersistence(coll, engine, batch, cf,
-                                                  maxCommitSeq, force, context,
-                                                  output, appliedSeq);
+  if (stats.didWork || stats.originalAppliedSeq != appliedSeq) {
+    // only log if there is something noteworthy
+    LOG_TOPIC("ec667", DEBUG, Logger::ENGINES)
+        << "serializeMeta for '" << coll.vocbase().name() << "/" << coll.name()
+        << "': original applied seq: " << stats.originalAppliedSeq
+        << ", max commit seq: " << maxCommitSeq
+        << ", applied seq after revision trees: "
+        << stats.appliedSeqAfterRevisionTree
+        << ", didWork: " << (didWork ? "yes" : "no");
+  }
+
+  return res;
 }
 
 /// @brief deserialize collection metadata, only called on startup

--- a/arangod/RocksDBEngine/RocksDBSettingsManager.cpp
+++ b/arangod/RocksDBEngine/RocksDBSettingsManager.cpp
@@ -176,11 +176,15 @@ ResultT<bool> RocksDBSettingsManager::sync(bool force) {
       // Collections which are marked as isAStub are not allowed to have
       // physicalCollections. Therefore, we cannot continue serializing in that
       // case.
-      if (!coll || coll->isAStub()) {
+      if (!coll) {
         continue;
       }
       auto sg2 = arangodb::scopeGuard(
           [&]() noexcept { vocbase->releaseCollection(coll.get()); });
+
+      if (coll->isAStub()) {
+        continue;
+      }
 
       LOG_TOPIC("afb17", TRACE, Logger::ENGINES)
           << "syncing metadata for collection '" << coll->name() << "'";

--- a/arangod/RocksDBEngine/RocksDBSettingsManager.cpp
+++ b/arangod/RocksDBEngine/RocksDBSettingsManager.cpp
@@ -187,7 +187,8 @@ ResultT<bool> RocksDBSettingsManager::sync(bool force) {
       }
 
       LOG_TOPIC("afb17", TRACE, Logger::ENGINES)
-          << "syncing metadata for collection '" << coll->name() << "'";
+          << "syncing metadata for collection '" << vocbase->name() << "/"
+          << coll->name() << "', maxSeqNr: " << maxSeqNr;
 
       // clear our scratch buffers for this round
       _scratch.clear();
@@ -210,9 +211,23 @@ ResultT<bool> RocksDBSettingsManager::sync(bool force) {
 
       if (res.fail()) {
         LOG_TOPIC("afa17", WARN, Logger::ENGINES)
-            << "could not sync metadata for collection '" << coll->name()
-            << "'";
+            << "could not sync metadata for collection '" << vocbase->name()
+            << "/" << coll->name() << "'";
         return res;
+      }
+
+      // always log in TRACE mode
+      LOG_TOPIC("1d419", TRACE, Logger::ENGINES)
+          << "synced metadata for collection '" << vocbase->name() << "/"
+          << coll->name() << "', maxSeqNr: " << maxSeqNr
+          << ", minSeqNr: " << minSeqNr << ", appliedSeq: " << appliedSeq;
+
+      if (appliedSeq < minSeqNr) {
+        // in DEBUG mode only log _relevant_ information
+        LOG_TOPIC("31dc8", DEBUG, Logger::ENGINES)
+            << "synced metadata for collection '" << vocbase->name() << "/"
+            << coll->name() << "', maxSeqNr: " << maxSeqNr
+            << ", minSeqNr: " << minSeqNr << ", appliedSeq: " << appliedSeq;
       }
 
       minSeqNr = std::min(minSeqNr, appliedSeq);

--- a/arangod/VocBase/vocbase.cpp
+++ b/arangod/VocBase/vocbase.cpp
@@ -1585,9 +1585,15 @@ TRI_vocbase_t::TRI_vocbase_t(TRI_vocbase_type_e type,
   }
   _cursorRepository = std::make_unique<arangodb::CursorRepository>(*this);
 
-  auto& rf = _info.server().getFeature<ReplicationFeature>();
-  _replicationClients =
-      std::make_unique<arangodb::ReplicationClientsProgressTracker>(&rf);
+  if (_info.server().hasFeature<ReplicationFeature>()) {
+    auto& rf = _info.server().getFeature<ReplicationFeature>();
+    _replicationClients =
+        std::make_unique<arangodb::ReplicationClientsProgressTracker>(&rf);
+  } else {
+    // during unit testing, there is no ReplicationFeature available
+    _replicationClients =
+        std::make_unique<arangodb::ReplicationClientsProgressTracker>(nullptr);
+  }
 
   // init collections
   _collections.reserve(32);

--- a/arangod/VocBase/vocbase.cpp
+++ b/arangod/VocBase/vocbase.cpp
@@ -70,6 +70,7 @@
 #include "Replication/ReplicationClients.h"
 #include "Metrics/Counter.h"
 #include "Metrics/Gauge.h"
+#include "Replication/ReplicationFeature.h"
 #include "RestServer/DatabaseFeature.h"
 #include "RestServer/QueryRegistryFeature.h"
 #include "Scheduler/SchedulerFeature.h"
@@ -1583,9 +1584,10 @@ TRI_vocbase_t::TRI_vocbase_t(TRI_vocbase_type_e type,
     _queries = std::make_unique<arangodb::aql::QueryList>(feature);
   }
   _cursorRepository = std::make_unique<arangodb::CursorRepository>(*this);
+
+  auto& rf = _info.server().getFeature<ReplicationFeature>();
   _replicationClients =
-      std::make_unique<arangodb::ReplicationClientsProgressTracker>(
-          _info.server().getFeature<ReplicationFeature>());
+      std::make_unique<arangodb::ReplicationClientsProgressTracker>(&rf);
 
   // init collections
   _collections.reserve(32);

--- a/arangod/VocBase/vocbase.cpp
+++ b/arangod/VocBase/vocbase.cpp
@@ -1584,7 +1584,8 @@ TRI_vocbase_t::TRI_vocbase_t(TRI_vocbase_type_e type,
   }
   _cursorRepository = std::make_unique<arangodb::CursorRepository>(*this);
   _replicationClients =
-      std::make_unique<arangodb::ReplicationClientsProgressTracker>();
+      std::make_unique<arangodb::ReplicationClientsProgressTracker>(
+          _info.server().getFeature<ReplicationFeature>());
 
   // init collections
   _collections.reserve(32);

--- a/tests/Replication/ReplicationClientsProgressTrackerTest.cpp
+++ b/tests/Replication/ReplicationClientsProgressTrackerTest.cpp
@@ -28,6 +28,7 @@
 
 #include "Logger/LogMacros.h"
 #include "Replication/ReplicationClients.h"
+#include "Replication/ReplicationFeature.h"
 #include "Replication/SyncerId.h"
 #include "VocBase/Identifiers/ServerId.h"
 
@@ -42,7 +43,7 @@ namespace replication {
 class ReplicationClientsProgressTrackerTest_SingleClient
     : public ::testing::TestWithParam<std::pair<SyncerId, ServerId>> {
  protected:
-  ReplicationClientsProgressTracker testee{};
+  ReplicationClientsProgressTracker testee{nullptr};
   SyncerId syncerId{};
   ServerId clientId{};
 
@@ -260,7 +261,7 @@ INSTANTIATE_TEST_CASE_P(ReplicationClientsProgressTrackerTest_SingleClient,
 class ReplicationClientsProgressTrackerTest_MultiClient
     : public ::testing::Test {
  protected:
-  ReplicationClientsProgressTracker testee{};
+  ReplicationClientsProgressTracker testee{nullptr};
 
   double const ttl = 7200;
 


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/18223

Better diagnostics for tracking WAL lower bound values.

* Added log messages for per-database replication lower bound-influencing values
* Added log messages for per-collection/shard lower bound-influencing values
* Added metric `arangodb_replication_clients` showing the number of currently active/connected replication clients for a server.

The additional log messages will only appear when log topic `ENGINES` is set to `DEBUG` or lower.
Manually tested in cluster and single server.

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.10: this PR
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 