### PR TITLE
Make sure testresults are also copied when test fails

### DIFF
--- a/.circleci/base_config.yml
+++ b/.circleci/base_config.yml
@@ -161,6 +161,9 @@ jobs:
               --cluster << parameters.cluster >> \
               --extraArgs " << parameters.extraArgs >>" \
               --definition tests/test-definitions.txt
+      - run:
+          name: Copy test results
+          command: |
             mkdir test-results
             find testrun -iname *xml -exec cp "{}" --target-directory=./test-results \;
       - store_artifacts:


### PR DESCRIPTION
### Scope & Purpose

Before this change, because of how the shell is configured in a CircleCI step, a non-zero exit code from the test runner would lead to test-result XMLs not being uploaded.
