### PR TITLE
Silence compiler warning

### DIFF
--- a/tests/Replication2/Helper/ModelChecker/Actors.cpp
+++ b/tests/Replication2/Helper/ModelChecker/Actors.cpp
@@ -383,7 +383,7 @@ auto ModifySoftWCMultipleStepsActor::expand(AgencyState const& s,
   }
 
   std::vector<AgencyTransition> actions;
-  State nextState;
+  State nextState{State::INIT};
   if (i.state == State::INIT) {
     actions = {SetSoftWriteConcernAction(setInvalidWC)};
     nextState = State::SET_TO_INVALID;


### PR DESCRIPTION
### Scope & Purpose

GCC 11.3 will complain about this uninitialized variable.
