### PR TITLE
remove redundant calls to `db._dropDatabase(...)`

### DIFF
--- a/tests/js/server/replication/aql/replication-aql.js
+++ b/tests/js/server/replication/aql/replication-aql.js
@@ -176,10 +176,6 @@ function ReplicationSuite() {
     tearDownAll: function() {
       connectToLeader();
       db._useDatabase("_system");
-
-      db._dropDatabase(cn);
-      connectToFollower();
-      db._useDatabase("_system");
       db._dropDatabase(cn);
     },
     

--- a/tests/js/server/replication/random/replication-random.js
+++ b/tests/js/server/replication/random/replication-random.js
@@ -185,11 +185,6 @@ function ReplicationSuite() {
       connectToLeader();
       db._useDatabase("_system");
       db._dropDatabase(cn);
-      connectToFollower();
-      db._useDatabase("_system");
-      replication.applier.stop();
-      replication.applier.forget();
-      db._dropDatabase(cn);
     },
     
     testRandomTransactions: function() {


### PR DESCRIPTION
### Scope & Purpose

After some recent change w.r.t. to how `tearDown` / `tearDownAll` report their errors, the two test suites modified by this PR started failing.
This PR adjusts these tests' tearDown functions so that the previously veiled errors are not happening anymore.
Test-only bugfix.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: -
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 