### PR TITLE
improve usefulness of debug messages

### DIFF
--- a/arangod/Replication/ReplicationClients.cpp
+++ b/arangod/Replication/ReplicationClients.cpp
@@ -231,23 +231,21 @@ void ReplicationClientsProgressTracker::garbageCollect(double thresholdStamp) {
     _feature->clientsMetric().fetch_sub(removed);
   }
 
-#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   LOG_TOPIC("239fb", DEBUG, Logger::REPLICATION)
       << "replication progress tracker has " << _clients.size()
       << " clients left";
 
-  if (!_clients.empty()) {
-    for (auto const& it : _clients) {
-      ReplicationClientProgress const& value = it.second;
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+  for (auto const& it : _clients) {
+    ReplicationClientProgress const& value = it.second;
 
-      LOG_TOPIC("81d72", TRACE, Logger::REPLICATION)
-          << "replication progress tracker entry: "
-          << "server: " << value.clientId.id()
-          << ", syncer: " << value.syncerId.toString()
-          << ", lastServed: " << value.lastServedTick
-          << ", lastSeen: " << value.lastSeenStamp
-          << ", expire: " << value.expireStamp;
-    }
+    LOG_TOPIC("81d72", TRACE, Logger::REPLICATION)
+        << "replication progress tracker entry: "
+        << "server: " << value.clientId.id()
+        << ", syncer: " << value.syncerId.toString()
+        << ", lastServed: " << value.lastServedTick
+        << ", lastSeen: " << value.lastSeenStamp
+        << ", expire: " << value.expireStamp;
   }
 #endif
 }

--- a/arangod/RocksDBEngine/RocksDBMetaCollection.cpp
+++ b/arangod/RocksDBEngine/RocksDBMetaCollection.cpp
@@ -1208,7 +1208,7 @@ void RocksDBMetaCollection::bufferUpdates(
   }
 
   LOG_TOPIC("bafcf", TRACE, Logger::ENGINES)
-      << "buffering " << inserts.size() << "inserts and " << removals.size()
+      << "buffering " << inserts.size() << " inserts and " << removals.size()
       << " removals "
       << "for collection " << _logicalCollection.name();
 


### PR DESCRIPTION
### Scope & Purpose

Improve usefulness of a replication debug message, which previously was only available in maintainer builds.
Also add a missing space character to another debug message.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: -
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 