### PR TITLE
don't try to jslint files in UnitTests

### DIFF
--- a/utils/jslint.sh
+++ b/utils/jslint.sh
@@ -15,7 +15,6 @@ if [ -z "$*" ] ; then
     $(find "${WD}/tests/js/server" -name "*.js" -o -name "*.inc" | grep -v "ranges-combined") \
     $(find "${WD}/tests/js/common" -name "*.js" -o -name "*.inc" | grep -v "test-data") \
     $(find "${WD}/tests/js/client" -name "*.js" -o -name "*.inc") \
-    $(find "${WD}/UnitTests" -name "*.js") \
     \
     $(find "${WD}/js/apps/system/_admin/aardvark/APP/frontend/js/models" -name "*.js") \
     $(find "${WD}/js/apps/system/_admin/aardvark/APP/frontend/js/views" -name "*.js") \


### PR DESCRIPTION
### Scope & Purpose

Adjust jslint script to not search for files in now-nonexisting directory `UnitTests`.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: -
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 