### PR TITLE
Install GDB in testing dockers

### DIFF
--- a/.circleci/base_config.yml
+++ b/.circleci/base_config.yml
@@ -150,7 +150,11 @@ jobs:
           command: ulimit -c unlimited
       - run:
           name: Install dependencies
-          command: pip install psutil py7zr && sudo apt update && sudo apt install 7zip
+          command: |
+            pip install psutil py7zr
+            sudo apt update
+            sudo apt install 7zip
+            sudo apt install gdb
       - run:
           name: Run << parameters.suiteName >> tests
           command: |


### PR DESCRIPTION
### Scope & Purpose

Install GDB in the docker runners for tests to be able to pull stack traces.
