### PR TITLE
fix races in in-memory cache system

### DIFF
--- a/arangod/Cache/Cache.cpp
+++ b/arangod/Cache/Cache.cpp
@@ -32,7 +32,6 @@
 
 #include "Basics/SpinLocker.h"
 #include "Basics/SpinUnlocker.h"
-#include "Basics/cpu-relax.h"
 #include "Basics/voc-errors.h"
 #include "Cache/CachedValue.h"
 #include "Cache/Common.h"
@@ -53,8 +52,7 @@ Cache::Cache(Manager* manager, std::uint64_t id, Metadata&& metadata,
              std::shared_ptr<Table> table, bool enableWindowedStats,
              std::function<Table::BucketClearer(Metadata*)> bucketClearer,
              std::size_t slotsPerBucket)
-    : _taskLock(),
-      _shutdown(false),
+    : _shutdown(false),
       _enableWindowedStats(enableWindowedStats),
       _findHits(),
       _findMisses(),
@@ -329,6 +327,8 @@ std::shared_ptr<Table> Cache::table() const {
 }
 
 void Cache::shutdown() {
+  SpinLocker shutdownGuard(SpinLocker::Mode::Write, _shutdownLock);
+
   SpinLocker taskGuard(SpinLocker::Mode::Write, _taskLock);
   auto handle = shared_from_this();  // hold onto self-reference to prevent
                                      // pre-mature shared_ptr destruction
@@ -343,7 +343,7 @@ void Cache::shutdown() {
       }
 
       SpinUnlocker taskUnguard(SpinUnlocker::Mode::Write, _taskLock);
-      std::this_thread::sleep_for(std::chrono::microseconds(10));
+      std::this_thread::sleep_for(std::chrono::microseconds(20));
     }
 
     std::shared_ptr<cache::Table> table = this->table();
@@ -375,15 +375,6 @@ bool Cache::canResize() noexcept {
 
   SpinLocker metaGuard(SpinLocker::Mode::Read, _metadata.lock());
   return !(_metadata.isResizing() || _metadata.isMigrating());
-}
-
-bool Cache::canMigrate() noexcept {
-  if (ADB_UNLIKELY(isShutdown())) {
-    return false;
-  }
-
-  SpinLocker metaGuard(SpinLocker::Mode::Read, _metadata.lock());
-  return !_metadata.isMigrating();
 }
 
 /// TODO Improve freeing algorithm
@@ -431,6 +422,12 @@ bool Cache::freeMemory() {
 
 bool Cache::migrate(std::shared_ptr<Table> newTable) {
   if (ADB_UNLIKELY(isShutdown())) {
+    // unmarking migrating flag
+    SpinLocker metaGuard(SpinLocker::Mode::Write, _metadata.lock());
+
+    TRI_ASSERT(_metadata.isMigrating());
+    _metadata.toggleMigrating();
+    TRI_ASSERT(!_metadata.isMigrating());
     return false;
   }
 
@@ -464,7 +461,9 @@ bool Cache::migrate(std::shared_ptr<Table> newTable) {
   {
     SpinLocker metaGuard(SpinLocker::Mode::Write, _metadata.lock());
     _metadata.changeTable(newTable->memoryUsage());
+    TRI_ASSERT(_metadata.isMigrating());
     _metadata.toggleMigrating();
+    TRI_ASSERT(!_metadata.isMigrating());
   }
 
   // clear out old table and release it

--- a/arangod/Cache/Manager.cpp
+++ b/arangod/Cache/Manager.cpp
@@ -94,7 +94,6 @@ Manager::Manager(SharedPRNGFeature& sharedPRNG, PostFn schedulerPost,
       _spareTables(0),
       _transactions(),
       _schedulerPost(std::move(schedulerPost)),
-      _resizeAttempt(0),
       _outstandingTasks(0),
       _rebalancingTasks(0),
       _resizingTasks(0),
@@ -120,6 +119,14 @@ Manager::~Manager() {
   } catch (...) {
     // no exceptions allowed here
   }
+
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+  SpinLocker guard(SpinLocker::Mode::Read, _lock);
+  TRI_ASSERT(_globalAllocation == _fixedAllocation)
+      << "globalAllocation: " << _globalAllocation
+      << ", fixedAllocation: " << _fixedAllocation
+      << ", outstandingTasks: " << _outstandingTasks;
+#endif
 }
 
 template<typename Hasher>
@@ -196,6 +203,12 @@ void Manager::shutdown() {
     if (!_shuttingDown) {
       _shuttingDown = true;
     }
+
+    while (globalProcessRunning()) {
+      // wait for rebalancer and migration tasks to complete
+      std::this_thread::yield();
+    }
+
     while (!_caches.empty()) {
       std::shared_ptr<Cache> cache = _caches.begin()->second;
       SpinUnlocker unguard(SpinUnlocker::Mode::Write, _lock);
@@ -251,6 +264,7 @@ std::uint64_t Manager::globalLimit() const noexcept {
 
 std::uint64_t Manager::globalAllocation() const noexcept {
   SpinLocker guard(SpinLocker::Mode::Read, _lock);
+  TRI_ASSERT(_globalAllocation >= _fixedAllocation);
   return _globalAllocation;
 }
 
@@ -318,7 +332,11 @@ void Manager::endTransaction(Transaction* tx) noexcept {
   _transactions.end(tx);
 }
 
-bool Manager::post(std::function<void()> fn) { return _schedulerPost(fn); }
+bool Manager::post(std::function<void()> fn) {
+  // lock already acquired by caller
+  TRI_ASSERT(_lock.isLockedWrite());
+  return _schedulerPost(std::move(fn));
+}
 
 std::tuple<bool, Metadata, std::shared_ptr<Table>> Manager::registerCache(
     std::uint64_t fixedSize, std::uint64_t maxSize) {
@@ -338,11 +356,14 @@ std::tuple<bool, Metadata, std::shared_ptr<Table>> Manager::registerCache(
   }
 
   if (ok) {
-    metadata =
-        Metadata(Cache::kMinSize, fixedSize, table->memoryUsage(), maxSize);
-    ok = increaseAllowed(metadata.allocatedSize - table->memoryUsage(), true);
+    std::uint64_t memoryUsage = table->memoryUsage();
+    metadata = Metadata(Cache::kMinSize, fixedSize, memoryUsage, maxSize);
+    TRI_ASSERT(metadata.allocatedSize >= memoryUsage);
+    ok = increaseAllowed(metadata.allocatedSize - memoryUsage, true);
     if (ok) {
-      _globalAllocation += (metadata.allocatedSize - table->memoryUsage());
+      TRI_ASSERT(_globalAllocation + (metadata.allocatedSize - memoryUsage) >=
+                 _fixedAllocation);
+      _globalAllocation += (metadata.allocatedSize - memoryUsage);
       TRI_ASSERT(_globalAllocation >= _fixedAllocation);
     }
   }
@@ -366,6 +387,7 @@ void Manager::unregisterCache(std::uint64_t id) {
   Metadata& metadata = cache->metadata();
   {
     SpinLocker metaGuard(SpinLocker::Mode::Read, metadata.lock());
+    TRI_ASSERT(_globalAllocation >= metadata.allocatedSize + _fixedAllocation);
     _globalAllocation -= metadata.allocatedSize;
     TRI_ASSERT(_globalAllocation >= _fixedAllocation);
   }
@@ -502,14 +524,17 @@ bool Manager::globalProcessRunning() const noexcept {
 }
 
 void Manager::prepareTask(Manager::TaskEnvironment environment) {
-  _outstandingTasks++;
+  // lock already acquired by caller
+  TRI_ASSERT(_lock.isLockedWrite());
+
+  ++_outstandingTasks;
   switch (environment) {
     case TaskEnvironment::rebalancing: {
-      _rebalancingTasks++;
+      ++_rebalancingTasks;
       break;
     }
     case TaskEnvironment::resizing: {
-      _resizingTasks++;
+      ++_resizingTasks;
       break;
     }
     case TaskEnvironment::none:
@@ -519,10 +544,11 @@ void Manager::prepareTask(Manager::TaskEnvironment environment) {
   }
 }
 
-void Manager::unprepareTask(Manager::TaskEnvironment environment) {
+void Manager::unprepareTask(Manager::TaskEnvironment environment) noexcept {
   switch (environment) {
     case TaskEnvironment::rebalancing: {
-      if ((--_rebalancingTasks) == 0) {
+      TRI_ASSERT(_rebalancingTasks > 0);
+      if (--_rebalancingTasks == 0) {
         SpinLocker guard(SpinLocker::Mode::Write, _lock);
         _rebalancing = false;
         _rebalanceCompleted = std::chrono::steady_clock::now();
@@ -530,7 +556,8 @@ void Manager::unprepareTask(Manager::TaskEnvironment environment) {
       break;
     }
     case TaskEnvironment::resizing: {
-      if ((--_resizingTasks) == 0) {
+      TRI_ASSERT(_resizingTasks > 0);
+      if (--_resizingTasks == 0) {
         SpinLocker guard(SpinLocker::Mode::Write, _lock);
         _resizing = false;
       }
@@ -542,7 +569,7 @@ void Manager::unprepareTask(Manager::TaskEnvironment environment) {
     }
   }
 
-  _outstandingTasks--;
+  --_outstandingTasks;
 }
 
 /// TODO Improve rebalancing algorithm
@@ -621,7 +648,7 @@ ErrorCode Manager::rebalance(bool onlyCalculate) {
 
 void Manager::shrinkOvergrownCaches(Manager::TaskEnvironment environment) {
   TRI_ASSERT(_lock.isLockedWrite());
-  for (auto it : _caches) {
+  for (auto& it : _caches) {
     std::shared_ptr<Cache>& cache = it.second;
     // skip this cache if it is already resizing or shutdown!
     if (!cache->canResize()) {
@@ -640,6 +667,7 @@ void Manager::shrinkOvergrownCaches(Manager::TaskEnvironment environment) {
 
 void Manager::freeUnusedTables() {
   TRI_ASSERT(_lock.isLockedWrite());
+
   constexpr std::size_t tableEntries =
       std::tuple_size<decltype(_tables)>::value;
 
@@ -647,11 +675,15 @@ void Manager::freeUnusedTables() {
     while (!_tables[i].empty()) {
       auto& table = _tables[i].top();
       std::uint64_t memoryUsage = table->memoryUsage();
+      TRI_ASSERT(_globalAllocation >= memoryUsage + _fixedAllocation);
       _globalAllocation -= memoryUsage;
-
       TRI_ASSERT(_globalAllocation >= _fixedAllocation);
+
+      TRI_ASSERT(_spareTableAllocation >= memoryUsage);
       _spareTableAllocation -= memoryUsage;
+
       TRI_ASSERT(_spareTables > 0);
+
       --_spareTables;
       _tables[i].pop();
     }
@@ -677,6 +709,7 @@ void Manager::resizeCache(Manager::TaskEnvironment environment,
                           std::uint64_t newLimit) {
   TRI_ASSERT(_lock.isLockedWrite());
   TRI_ASSERT(metaGuard.isLocked());
+  TRI_ASSERT(cache != nullptr);
   Metadata& metadata = cache->metadata();
 
   if (metadata.usage <= newLimit) {
@@ -684,10 +717,13 @@ void Manager::resizeCache(Manager::TaskEnvironment environment,
     bool success = metadata.adjustLimits(newLimit, newLimit);
     TRI_ASSERT(success);
     metaGuard.release();
-    _globalAllocation -= oldLimit;
-    _globalAllocation += newLimit;
 
-    TRI_ASSERT(_globalAllocation >= _fixedAllocation);
+    if (newLimit != oldLimit) {
+      TRI_ASSERT(_globalAllocation + newLimit - oldLimit >= _fixedAllocation);
+      _globalAllocation -= oldLimit;
+      _globalAllocation += newLimit;
+      TRI_ASSERT(_globalAllocation >= _fixedAllocation);
+    }
     return;
   }
 
@@ -697,11 +733,18 @@ void Manager::resizeCache(Manager::TaskEnvironment environment,
   metadata.toggleResizing();
   metaGuard.release();
 
-  auto task = std::make_shared<FreeMemoryTask>(environment, *this,
-                                               cache->shared_from_this());
-  bool dispatched = task->dispatch();
+  bool dispatched = false;
+  if (!cache->isShutdown()) {
+    try {
+      auto task = std::make_shared<FreeMemoryTask>(environment, *this,
+                                                   cache->shared_from_this());
+      dispatched = task->dispatch();
+    } catch (...) {
+      dispatched = false;
+    }
+  }
+
   if (!dispatched) {
-    // TODO: decide what to do if we don't have an io_service
     SpinLocker altMetaGuard(SpinLocker::Mode::Write, metadata.lock());
     metadata.toggleResizing();
   }
@@ -712,26 +755,31 @@ void Manager::migrateCache(Manager::TaskEnvironment environment,
                            std::shared_ptr<Table> table) {
   TRI_ASSERT(_lock.isLockedWrite());
   TRI_ASSERT(metaGuard.isLocked());
+  TRI_ASSERT(cache != nullptr);
   Metadata& metadata = cache->metadata();
 
   TRI_ASSERT(!metadata.isMigrating());
   metadata.toggleMigrating();
+  TRI_ASSERT(metadata.isMigrating());
   metaGuard.release();
 
-  bool dispatched;
-  try {
-    auto task = std::make_shared<MigrateTask>(environment, *this,
-                                              cache->shared_from_this(), table);
-    dispatched = task->dispatch();
-  } catch (...) {
-    dispatched = false;
+  bool dispatched = false;
+  if (!cache->isShutdown()) {
+    try {
+      auto task = std::make_shared<MigrateTask>(
+          environment, *this, cache->shared_from_this(), table);
+      dispatched = task->dispatch();
+    } catch (...) {
+      dispatched = false;
+    }
   }
 
   if (!dispatched) {
-    // TODO: decide what to do if we don't have an io_service
     SpinLocker altMetaGuard(SpinLocker::Mode::Write, metadata.lock());
     reclaimTable(std::move(table), true);
+    TRI_ASSERT(metadata.isMigrating());
     metadata.toggleMigrating();
+    TRI_ASSERT(!metadata.isMigrating());
   }
 }
 
@@ -792,6 +840,7 @@ void Manager::reclaimTable(std::shared_ptr<Table>&& table, bool internal) {
       ++_spareTables;
       TRI_ASSERT(_spareTables <= kMaxSpareTablesTotal);
     } else {
+      TRI_ASSERT(_globalAllocation >= memoryUsage + _fixedAllocation);
       _globalAllocation -= memoryUsage;
       TRI_ASSERT(_globalAllocation >= _fixedAllocation);
     }

--- a/arangod/Cache/Manager.h
+++ b/arangod/Cache/Manager.h
@@ -249,7 +249,6 @@ class Manager {
   // task management
   enum TaskEnvironment { none, rebalancing, resizing };
   PostFn _schedulerPost;
-  std::uint64_t _resizeAttempt;
   std::atomic<std::uint64_t> _outstandingTasks;
   std::atomic<std::uint64_t> _rebalancingTasks;
   std::atomic<std::uint64_t> _resizingTasks;
@@ -293,7 +292,7 @@ class Manager {
 
   // coordinate state with task lifecycles
   void prepareTask(TaskEnvironment environment);
-  void unprepareTask(TaskEnvironment environment);
+  void unprepareTask(TaskEnvironment environment) noexcept;
 
   // periodically run to rebalance allocations globally
   ErrorCode rebalance(bool onlyCalculate = false);

--- a/arangod/Cache/ManagerTasks.h
+++ b/arangod/Cache/ManagerTasks.h
@@ -36,11 +36,6 @@ namespace arangodb {
 namespace cache {
 
 class FreeMemoryTask : public std::enable_shared_from_this<FreeMemoryTask> {
- private:
-  Manager::TaskEnvironment _environment;
-  Manager& _manager;
-  std::shared_ptr<Cache> _cache;
-
  public:
   FreeMemoryTask() = delete;
   FreeMemoryTask(FreeMemoryTask const&) = delete;
@@ -54,15 +49,13 @@ class FreeMemoryTask : public std::enable_shared_from_this<FreeMemoryTask> {
 
  private:
   void run();
-};
 
-class MigrateTask : public std::enable_shared_from_this<MigrateTask> {
- private:
   Manager::TaskEnvironment _environment;
   Manager& _manager;
   std::shared_ptr<Cache> _cache;
-  std::shared_ptr<Table> _table;
+};
 
+class MigrateTask : public std::enable_shared_from_this<MigrateTask> {
  public:
   MigrateTask() = delete;
   MigrateTask(MigrateTask const&) = delete;
@@ -76,6 +69,11 @@ class MigrateTask : public std::enable_shared_from_this<MigrateTask> {
 
  private:
   void run();
+
+  Manager::TaskEnvironment _environment;
+  Manager& _manager;
+  std::shared_ptr<Cache> _cache;
+  std::shared_ptr<Table> _table;
 };
 
 };  // end namespace cache

--- a/arangod/Cache/Metadata.cpp
+++ b/arangod/Cache/Metadata.cpp
@@ -26,11 +26,8 @@
 #include "Basics/debugging.h"
 #include "Cache/Cache.h"
 #include "Cache/Manager.h"
-#include "Logger/LogMacros.h"
 
 #include <algorithm>
-#include <atomic>
-#include <cstdint>
 
 namespace arangodb::cache {
 
@@ -43,11 +40,10 @@ Metadata::Metadata() noexcept
       usage(0),
       softUsageLimit(0),
       hardUsageLimit(0),
-      _lock(),
       _migrating(false),
       _resizing(false) {}
 
-Metadata::Metadata(uint64_t usageLimit, std::uint64_t fixed,
+Metadata::Metadata(std::uint64_t usageLimit, std::uint64_t fixed,
                    std::uint64_t table, std::uint64_t max) noexcept
     : fixedSize(fixed),
       tableSize(table),
@@ -57,7 +53,6 @@ Metadata::Metadata(uint64_t usageLimit, std::uint64_t fixed,
       usage(0),
       softUsageLimit(usageLimit),
       hardUsageLimit(usageLimit),
-      _lock(),
       _migrating(false),
       _resizing(false) {
   TRI_ASSERT(allocatedSize <= maxSize);


### PR DESCRIPTION
### Scope & Purpose

Partially address https://arangodb.atlassian.net/browse/BTS-1255:

Fix shutdown races (shutdown of a cache could overlap with spawned FreeMemory and Migrate tasks for the same cache, leading to assertion failures because the amount of allocated memory went below zero). This fixes errors we have seen in cache unit tests in devel recently, although the race conditions have been for longer.
In order to prevent the races, a new per-cache `_shutdownLock` is introduced, which is acquired in exclusive mode by the shutdown, and acquired in shared mode while FreeMemory or Migrate tasks execute. That way the shutdown is mutually exclusive with a cache's task execution.
Note: the `shutdown()` function of a cache will be called only when the cache manager is being shut down (shutdown of the entire cache subsystem) or when the cache manager's static `destroyCache(cache)` function is called for a particular cache. The latter happens during index destructors (for indexes with in-memory caches), after `truncate()` calls (when the caches can be wiped and recreated) and after `unload()` calls.

Also added more assertions for verifying some of the cache subsystem's memory usage invariants.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: -
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

