### PR TITLE
[CINFRA] Prototype State Flaky Test

### DIFF
--- a/tests/js/common/shell/shell-prototype-state-cluster.js
+++ b/tests/js/common/shell/shell-prototype-state-cluster.js
@@ -121,7 +121,7 @@ function PrototypeStateTestSuite() {
 
     testReadFromServer: function () {
       const state = db._createPrototypeState({config});
-      let idx = state.write({"A": "1", "B": "2", "C": "3", "D": "4"}, {waitForCommit: false});
+      let idx = state.write({"A": "1", "B": "2", "C": "3", "D": "4"}, {waitForCommit: true});
 
       const status = db._replicatedLog(state.id()).status();
       const follower = _.sample(_.without(Object.keys(status.participants), status.leaderId));


### PR DESCRIPTION
### Scope & Purpose

This tests is based on dirty reads and therefore it has been seen failing sometimes. To decrease the chance of that happening, I am instructing the state to wait for the entries to be committed before returning from the write call.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification