### PR TITLE
testing: SKIPPED testcase should now indicate the full error

### DIFF
--- a/js/client/modules/@arangodb/testutils/result-processing.js
+++ b/js/client/modules/@arangodb/testutils/result-processing.js
@@ -279,10 +279,15 @@ function saveToJunitXML(options, results) {
       if (testSuite.hasOwnProperty('total')) {
         total = testSuite.total;
       }
-
+      let msg = "";
+      let errors = 0;
+      if (!testSuite.status && testSuite.hasOwnProperty('message')) {
+        msg = testSuite.message;
+        errors = 1;
+      }
       state.xml.elem('testsuite', {
-        errors: 0,
-        failures: testSuite.failed,
+        errors: errors,
+        failures: msg,
         tests: total,
         name: state.xmlName,
         // time is in seconds


### PR DESCRIPTION
### Scope & Purpose

If the testsuite run aborts on crash or timeout, the generated XML would not reflect this error.

