### PR TITLE
[CINFRA-696] Fix crashes in AppendEntriesManager on store errors or resign race

### DIFF
--- a/arangod/Replication2/ReplicatedLog/Components/AppendEntriesManager.h
+++ b/arangod/Replication2/ReplicatedLog/Components/AppendEntriesManager.h
@@ -60,6 +60,8 @@ struct AppendEntriesManager
 
   auto getLastReceivedMessageId() const noexcept -> MessageId;
 
+  auto resign() && noexcept -> void override;
+
   struct GuardedData {
     GuardedData(IStorageManager& storage, ISnapshotManager& snapshot,
                 ICompactionManager& compaction, IFollowerCommitManager& commit);
@@ -67,7 +69,9 @@ struct AppendEntriesManager
                          FollowerTermInformation const&,
                          LoggerContext const& lctx)
         -> std::optional<AppendEntriesResult>;
+    auto resign() && noexcept -> void;
 
+    bool resigned = false;
     ExclusiveBool requestInFlight;
     AppendEntriesMessageIdAcceptor messageIdAcceptor;
 

--- a/arangod/Replication2/ReplicatedLog/Components/IAppendEntriesManager.h
+++ b/arangod/Replication2/ReplicatedLog/Components/IAppendEntriesManager.h
@@ -36,6 +36,7 @@ struct IAppendEntriesManager {
   virtual ~IAppendEntriesManager() = default;
   virtual auto appendEntries(AppendEntriesRequest request)
       -> futures::Future<AppendEntriesResult> = 0;
+  virtual auto resign() && noexcept -> void = 0;
 };
 
 }  // namespace comp

--- a/arangod/Replication2/ReplicatedLog/Components/LogFollower.cpp
+++ b/arangod/Replication2/ReplicatedLog/Components/LogFollower.cpp
@@ -166,7 +166,10 @@ auto FollowerManager::resign()
   auto handle = stateHandle->resign();
   // 2. resign the storage manager to receive the storage engine methods
   auto methods = storage->resign();
-  // 3. abort all wait for promises.
+  // 3. resign append entries manager, so append entries requests in flight
+  // don't try to access other managers after this
+  std::move((*appendEntriesManager)).resign();
+  // 4. abort all wait for promises.
   commit->resign();
   return std::make_tuple(std::move(methods), std::move(handle),
                          DeferredAction{});

--- a/tests/Replication2/ReplicatedLog/LogFollower/AppendEntriesTest.cpp
+++ b/tests/Replication2/ReplicatedLog/LogFollower/AppendEntriesTest.cpp
@@ -372,6 +372,7 @@ TEST_F(AppendEntriesFollowerTest, resigned_follower) {
     request.leaderId = "leader";
     request.leaderTerm = LogTerm{2};
     request.prevLogEntry = TermIndexPair{LogTerm{1}, LogIndex{99}};
-    EXPECT_ANY_THROW({ std::ignore = follower->appendEntries(request).get(); });
+    EXPECT_THROW({ std::ignore = follower->appendEntries(request).get(); },
+                 ParticipantResignedException);
   }
 }


### PR DESCRIPTION
### Scope & Purpose

During work on tests in https://github.com/arangodb/arangodb/pull/18215, two bugs manifested in the follower component AppendEntriesManager.

1) If one of the `store` operations `removeBack` or `appendEntries` returned an error, the `guard` variable was accessed before it was locked again, resulting in a nullptr-deref.
2) Additionally in the same situation, if the follower already resigned, the snapshot manager was accessed - however, this is a (possible) use-after-free, as the managers might be destroyed after resign.

- [X] :hankey: Bugfix

