### PR TITLE
[GOROD-1225] Delete fragile test

### DIFF
--- a/tests/js/common/shell/shell-pregel-random.js
+++ b/tests/js/common/shell/shell-pregel-random.js
@@ -230,39 +230,6 @@ function randomTestSuite() {
       assertTrue(i > 0, "timeout in pregel execution");
     },
 
-    test_garbage_collects_all_jobs: function () {
-      let allNewRuns = [];
-
-      for (let i = 0; i < 5; ++i) {
-        let pid = pregel.start("hits", graphName, { threshold: 0.0000001, resultField: "score", store: false, ttl: 5 });
-				allNewRuns.push(pid);
-        assertTrue(typeof pid === "string");
-      }
-
-      // helper function
-      const unique = function (value, index, self) {
-        return self.indexOf(value) === index;
-      };
-      // wait for garbage collection
-      let i = 1000;
-      let runningNewRuns = [];
-      do {
-        internal.sleep(0.2);
-        let allStats = pregel.status();
-        runningNewRuns = allStats.map((job) => job.id).filter((pid) => allNewRuns.includes(pid)).filter(unique);
-        runningNewRuns.forEach((pid) => {
-          const mostRecentStatsForRun = allStats.filter((job) => job.id === pid).pop();
-          assertEqual(5, mostRecentStatsForRun.ttl);
-          assertEqual("_system", mostRecentStatsForRun.database);
-          assertEqual("hits", mostRecentStatsForRun.algorithm);
-        });
-        if (i-- === 0) {
-          assertTrue(false, "timeout in pregel execution: not everything was garbage collected");
-          return;
-				}
-      } while (runningNewRuns.length > 0);
-    },
-
   };
 }
 


### PR DESCRIPTION
This test now failed in Jenkins test coverage run and several times on devel in CircleCI. The test is very fragile because it waits a long time for garbage collection to take place. Very probably, it runs into a shutdown while the test is waiting. The garbage collection is already tested for one pregel run in another test, 