### PR TITLE
[GORDO-1548] Be able to use master context on every algorithm

### DIFF
--- a/arangod/Pregel/AlgoRegistry.cpp
+++ b/arangod/Pregel/AlgoRegistry.cpp
@@ -93,6 +93,48 @@ IAlgorithm* AlgoRegistry::createAlgorithm(
   }
   return nullptr;
 }
+auto AlgoRegistry::createAlgorithmNew(
+    application_features::ApplicationServer& server,
+    std::string const& algorithm, VPackSlice userParams)
+    -> std::optional<std::unique_ptr<IAlgorithm>> {
+  if (algorithm == "sssp") {
+    return std::make_unique<algos::SSSPAlgorithm>(server, userParams);
+  } else if (algorithm == "pagerank") {
+    return std::make_unique<algos::PageRank>(server, userParams);
+  } else if (algorithm == "recoveringpagerank") {
+    return std::make_unique<algos::RecoveringPageRank>(server, userParams);
+  } else if (algorithm == "shortestpath") {
+    return std::make_unique<algos::ShortestPathAlgorithm>(server, userParams);
+  } else if (algorithm == "linerank") {
+    return std::make_unique<algos::LineRank>(server, userParams);
+  } else if (algorithm == "effectivecloseness") {
+    return std::make_unique<algos::EffectiveCloseness>(server, userParams);
+  } else if (algorithm == "connectedcomponents") {
+    return std::make_unique<algos::ConnectedComponents>(server, userParams);
+  } else if (algorithm == "scc") {
+    return std::make_unique<algos::SCC>(server, userParams);
+  } else if (algorithm == "hits") {
+    return std::make_unique<algos::HITS>(server, userParams);
+  } else if (algorithm == "hitskleinberg") {
+    return std::make_unique<algos::HITSKleinberg>(server, userParams);
+  } else if (algorithm == "labelpropagation") {
+    return std::make_unique<algos::LabelPropagation>(server, userParams);
+  } else if (algorithm == "slpa") {
+    return std::make_unique<algos::SLPA>(server, userParams);
+  } else if (algorithm == "dmid") {
+    return std::make_unique<algos::DMID>(server, userParams);
+  } else if (algorithm == "wcc") {
+    return std::make_unique<algos::WCC>(server, userParams);
+  } else if (algorithm == "colorpropagation") {
+    return std::make_unique<algos::ColorPropagation>(server, userParams);
+  }
+#if defined(ARANGODB_ENABLE_MAINTAINER_MODE)
+  else if (algorithm == "readwrite") {
+    return std::make_unique<algos::ReadWrite>(server, userParams);
+  }
+#endif
+  return std::nullopt;
+}
 
 template<typename V, typename E, typename M>
 std::shared_ptr<IWorker> AlgoRegistry::createWorker(

--- a/arangod/Pregel/AlgoRegistry.h
+++ b/arangod/Pregel/AlgoRegistry.h
@@ -42,6 +42,10 @@ struct AlgoRegistry {
   static std::shared_ptr<IWorker> createWorker(TRI_vocbase_t& vocbase,
                                                CreateWorker const& parameters,
                                                PregelFeature& feature);
+  static auto createAlgorithmNew(
+      application_features::ApplicationServer& server,
+      std::string const& algorithm, VPackSlice userParams)
+      -> std::optional<std::unique_ptr<IAlgorithm>>;
 
  private:
   template<typename V, typename E, typename M>

--- a/arangod/Pregel/Algorithm.h
+++ b/arangod/Pregel/Algorithm.h
@@ -63,6 +63,11 @@ struct IAlgorithm {
       arangodb::velocypack::Slice userParams) const {
     return nullptr;
   }
+  [[nodiscard]] virtual auto masterContextUnique(
+      uint64_t vertexCount, uint64_t edgeCount,
+      std::unique_ptr<AggregatorHandler> aggregators,
+      arangodb::velocypack::Slice userParams) const
+      -> std::unique_ptr<MasterContext> = 0;
 
   // ============= Configure runtime parameters ============
 

--- a/arangod/Pregel/Algos/ColorPropagation/ColorPropagation.cpp
+++ b/arangod/Pregel/Algos/ColorPropagation/ColorPropagation.cpp
@@ -192,8 +192,8 @@ bool ColorPropagationGraphFormat::buildVertexDocument(
 GraphFormat<ColorPropagationValue, int8_t>* ColorPropagation::inputFormat()
     const {
   return new ColorPropagationGraphFormat(
-      _server, _inputColorsFieldName, _outputColorsFieldName,
-      _equivalenceClassFieldName, _numColors);
+      _inputColorsFieldName, _outputColorsFieldName, _equivalenceClassFieldName,
+      _numColors);
 }
 
 IAggregator* ColorPropagation::aggregator(std::string const& name) const {

--- a/arangod/Pregel/Algos/ColorPropagation/ColorPropagation.h
+++ b/arangod/Pregel/Algos/ColorPropagation/ColorPropagation.h
@@ -123,6 +123,11 @@ struct ColorPropagation : public Algorithm<ColorPropagationValue, int8_t,
 
   [[nodiscard]] WorkerContext* workerContext(
       VPackSlice userParams) const override;
+  [[nodiscard]] auto masterContextUnique(
+      uint64_t vertexCount, uint64_t edgeCount,
+      std::unique_ptr<AggregatorHandler> aggregators,
+      arangodb::velocypack::Slice userParams) const
+      -> std::unique_ptr<MasterContext> override;
 
   [[nodiscard]] IAggregator* aggregator(std::string const& name) const override;
 

--- a/arangod/Pregel/Algos/ColorPropagation/ColorPropagation.h
+++ b/arangod/Pregel/Algos/ColorPropagation/ColorPropagation.h
@@ -207,11 +207,11 @@ struct ColorPropagationGraphFormat
   const std::string equivalenceClassFieldName;
   const uint16_t numColors;
 
-  explicit ColorPropagationGraphFormat(
-      application_features::ApplicationServer& server,
-      std::string inputColorsFieldName, std::string outputColorsFieldName,
-      std::string equivalenceClassFieldName, uint16_t numColors)
-      : GraphFormat<ColorPropagationValue, int8_t>(server),
+  explicit ColorPropagationGraphFormat(std::string inputColorsFieldName,
+                                       std::string outputColorsFieldName,
+                                       std::string equivalenceClassFieldName,
+                                       uint16_t numColors)
+      : GraphFormat<ColorPropagationValue, int8_t>(),
         inputColorsFieldName(std::move(inputColorsFieldName)),
         outputColorsFieldName(outputColorsFieldName),
         equivalenceClassFieldName(std::move(equivalenceClassFieldName)),

--- a/arangod/Pregel/Algos/ConnectedComponents/ConnectedComponents.cpp
+++ b/arangod/Pregel/Algos/ConnectedComponents/ConnectedComponents.cpp
@@ -25,6 +25,7 @@
 #include "Cluster/ClusterInfo.h"
 #include "Cluster/ServerState.h"
 #include "Pregel/Algorithm.h"
+#include "Pregel/MasterContext.h"
 #include "Pregel/Worker/GraphStore.h"
 #include "Pregel/IncomingCache.h"
 #include "Pregel/VertexComputation.h"
@@ -94,4 +95,19 @@ GraphFormat<uint64_t, uint8_t>* ConnectedComponents::inputFormat() const {
 VertexCompensation<uint64_t, uint8_t, uint64_t>*
 ConnectedComponents::createCompensation(WorkerConfig const* config) const {
   return new MyCompensation();
+}
+
+struct ConnectedComponentsMasterContext : public MasterContext {
+  ConnectedComponentsMasterContext(
+      uint64_t vertexCount, uint64_t edgeCount,
+      std::unique_ptr<AggregatorHandler> aggregators)
+      : MasterContext(vertexCount, edgeCount, std::move(aggregators)){};
+};
+[[nodiscard]] auto ConnectedComponents::masterContextUnique(
+    uint64_t vertexCount, uint64_t edgeCount,
+    std::unique_ptr<AggregatorHandler> aggregators,
+    arangodb::velocypack::Slice userParams) const
+    -> std::unique_ptr<MasterContext> {
+  return std::make_unique<ConnectedComponentsMasterContext>(
+      vertexCount, edgeCount, std::move(aggregators));
 }

--- a/arangod/Pregel/Algos/ConnectedComponents/ConnectedComponents.cpp
+++ b/arangod/Pregel/Algos/ConnectedComponents/ConnectedComponents.cpp
@@ -57,10 +57,8 @@ struct MyComputation : public VertexComputation<uint64_t, uint8_t, uint64_t> {
 };
 
 struct MyGraphFormat final : public VertexGraphFormat<uint64_t, uint8_t> {
-  explicit MyGraphFormat(application_features::ApplicationServer& server,
-                         std::string const& result)
-      : VertexGraphFormat<uint64_t, uint8_t>(server, result, /*vertexNull*/ 0) {
-  }
+  explicit MyGraphFormat(std::string const& result)
+      : VertexGraphFormat<uint64_t, uint8_t>(result, /*vertexNull*/ 0) {}
 
   void copyVertexData(arangodb::velocypack::Options const&,
                       std::string const& /*documentId*/,
@@ -90,7 +88,7 @@ ConnectedComponents::createComputation(WorkerConfig const* config) const {
 }
 
 GraphFormat<uint64_t, uint8_t>* ConnectedComponents::inputFormat() const {
-  return new MyGraphFormat(_server, _resultField);
+  return new MyGraphFormat(_resultField);
 }
 
 VertexCompensation<uint64_t, uint8_t, uint64_t>*

--- a/arangod/Pregel/Algos/ConnectedComponents/ConnectedComponents.h
+++ b/arangod/Pregel/Algos/ConnectedComponents/ConnectedComponents.h
@@ -51,5 +51,11 @@ struct ConnectedComponents
       WorkerConfig const*) const override;
   VertexCompensation<uint64_t, uint8_t, uint64_t>* createCompensation(
       WorkerConfig const*) const override;
+
+  [[nodiscard]] auto masterContextUnique(
+      uint64_t vertexCount, uint64_t edgeCount,
+      std::unique_ptr<AggregatorHandler> aggregators,
+      arangodb::velocypack::Slice userParams) const
+      -> std::unique_ptr<MasterContext> override;
 };
 }  // namespace arangodb::pregel::algos

--- a/arangod/Pregel/Algos/DMID/DMID.cpp
+++ b/arangod/Pregel/Algos/DMID/DMID.cpp
@@ -599,9 +599,8 @@ struct DMIDGraphFormat : public GraphFormat<DMIDValue, float> {
   const std::string _resultField;
   unsigned _maxCommunities;
 
-  explicit DMIDGraphFormat(application_features::ApplicationServer& server,
-                           std::string const& result, unsigned mc)
-      : GraphFormat<DMIDValue, float>(server),
+  explicit DMIDGraphFormat(std::string const& result, unsigned mc)
+      : GraphFormat<DMIDValue, float>(),
         _resultField(result),
         _maxCommunities(mc) {}
 
@@ -664,7 +663,7 @@ struct DMIDGraphFormat : public GraphFormat<DMIDValue, float> {
 };
 
 GraphFormat<DMIDValue, float>* DMID::inputFormat() const {
-  return new DMIDGraphFormat(_server, _resultField, _maxCommunities);
+  return new DMIDGraphFormat(_resultField, _maxCommunities);
 }
 
 struct DMIDMasterContext : public MasterContext {

--- a/arangod/Pregel/Algos/DMID/DMID.cpp
+++ b/arangod/Pregel/Algos/DMID/DMID.cpp
@@ -667,7 +667,11 @@ GraphFormat<DMIDValue, float>* DMID::inputFormat() const {
 }
 
 struct DMIDMasterContext : public MasterContext {
-  DMIDMasterContext() {}  // TODO use _threshold
+  DMIDMasterContext(uint64_t vertexCount, uint64_t edgeCount,
+                    std::unique_ptr<AggregatorHandler> aggregators)
+      : MasterContext(vertexCount, edgeCount, std::move(aggregators)) {
+  }  // TODO use _threshold
+  DMIDMasterContext() = default;
 
   void preGlobalSuperstep() override {
     /**
@@ -787,6 +791,14 @@ struct DMIDMasterContext : public MasterContext {
 
 MasterContext* DMID::masterContext(VPackSlice userParams) const {
   return new DMIDMasterContext();
+}
+[[nodiscard]] auto DMID::masterContextUnique(
+    uint64_t vertexCount, uint64_t edgeCount,
+    std::unique_ptr<AggregatorHandler> aggregators,
+    arangodb::velocypack::Slice userParams) const
+    -> std::unique_ptr<MasterContext> {
+  return std::make_unique<DMIDMasterContext>(vertexCount, edgeCount,
+                                             std::move(aggregators));
 }
 
 IAggregator* DMID::aggregator(std::string const& name) const {

--- a/arangod/Pregel/Algos/DMID/DMID.h
+++ b/arangod/Pregel/Algos/DMID/DMID.h
@@ -55,6 +55,12 @@ struct DMID : public SimpleAlgorithm<DMIDValue, float, DMIDMessage> {
 
   MasterContext* masterContext(VPackSlice userParams) const override;
 
+  [[nodiscard]] auto masterContextUnique(
+      uint64_t vertexCount, uint64_t edgeCount,
+      std::unique_ptr<AggregatorHandler> aggregators,
+      arangodb::velocypack::Slice userParams) const
+      -> std::unique_ptr<MasterContext> override;
+
   IAggregator* aggregator(std::string const& name) const override;
 };
 }  // namespace algos

--- a/arangod/Pregel/Algos/EffectiveCloseness/EffectiveCloseness.cpp
+++ b/arangod/Pregel/Algos/EffectiveCloseness/EffectiveCloseness.cpp
@@ -91,9 +91,8 @@ EffectiveCloseness::createComputation(WorkerConfig const*) const {
 struct ECGraphFormat : public GraphFormat<ECValue, int8_t> {
   const std::string _resultField;
 
-  explicit ECGraphFormat(application_features::ApplicationServer& server,
-                         std::string const& result)
-      : GraphFormat<ECValue, int8_t>(server), _resultField(result) {}
+  explicit ECGraphFormat(std::string const& result)
+      : GraphFormat<ECValue, int8_t>(), _resultField(result) {}
 
   size_t estimatedEdgeSize() const override { return 0; }
 
@@ -125,5 +124,5 @@ struct ECGraphFormat : public GraphFormat<ECValue, int8_t> {
 };
 
 GraphFormat<ECValue, int8_t>* EffectiveCloseness::inputFormat() const {
-  return new ECGraphFormat(_server, _resultField);
+  return new ECGraphFormat(_resultField);
 }

--- a/arangod/Pregel/Algos/EffectiveCloseness/EffectiveCloseness.cpp
+++ b/arangod/Pregel/Algos/EffectiveCloseness/EffectiveCloseness.cpp
@@ -22,6 +22,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #include "EffectiveCloseness.h"
+#include <memory>
 #include "Pregel/Aggregator.h"
 #include "Pregel/Algorithm.h"
 #include "Pregel/Algos/EffectiveCloseness/HLLCounterFormat.h"
@@ -125,4 +126,19 @@ struct ECGraphFormat : public GraphFormat<ECValue, int8_t> {
 
 GraphFormat<ECValue, int8_t>* EffectiveCloseness::inputFormat() const {
   return new ECGraphFormat(_resultField);
+}
+
+struct EffectiveClosenessMasterContext : public MasterContext {
+  EffectiveClosenessMasterContext(
+      uint64_t vertexCount, uint64_t edgeCount,
+      std::unique_ptr<AggregatorHandler> aggregators)
+      : MasterContext(vertexCount, edgeCount, std::move(aggregators)){};
+};
+[[nodiscard]] auto EffectiveCloseness::masterContextUnique(
+    uint64_t vertexCount, uint64_t edgeCount,
+    std::unique_ptr<AggregatorHandler> aggregators,
+    arangodb::velocypack::Slice userParams) const
+    -> std::unique_ptr<MasterContext> {
+  return std::make_unique<EffectiveClosenessMasterContext>(
+      vertexCount, edgeCount, std::move(aggregators));
 }

--- a/arangod/Pregel/Algos/EffectiveCloseness/EffectiveCloseness.h
+++ b/arangod/Pregel/Algos/EffectiveCloseness/EffectiveCloseness.h
@@ -45,6 +45,12 @@ struct EffectiveCloseness
 
   VertexComputation<ECValue, int8_t, HLLCounter>* createComputation(
       WorkerConfig const*) const override;
+
+  [[nodiscard]] auto masterContextUnique(
+      uint64_t vertexCount, uint64_t edgeCount,
+      std::unique_ptr<AggregatorHandler> aggregators,
+      arangodb::velocypack::Slice userParams) const
+      -> std::unique_ptr<MasterContext> override;
 };
 }  // namespace algos
 }  // namespace pregel

--- a/arangod/Pregel/Algos/HITS/HITS.cpp
+++ b/arangod/Pregel/Algos/HITS/HITS.cpp
@@ -105,9 +105,8 @@ HITS::createComputation(WorkerConfig const* config) const {
 struct HITSGraphFormat : public GraphFormat<HITSValue, int8_t> {
   const std::string _resultField;
 
-  explicit HITSGraphFormat(application_features::ApplicationServer& server,
-                           std::string const& result)
-      : GraphFormat<HITSValue, int8_t>(server), _resultField(result) {}
+  explicit HITSGraphFormat(std::string const& result)
+      : GraphFormat<HITSValue, int8_t>(), _resultField(result) {}
 
   size_t estimatedEdgeSize() const override { return 0; }
 
@@ -126,7 +125,7 @@ struct HITSGraphFormat : public GraphFormat<HITSValue, int8_t> {
 };
 
 GraphFormat<HITSValue, int8_t>* HITS::inputFormat() const {
-  return new HITSGraphFormat(_server, _resultField);
+  return new HITSGraphFormat(_resultField);
 }
 
 WorkerContext* HITS::workerContext(VPackSlice userParams) const {

--- a/arangod/Pregel/Algos/HITS/HITS.h
+++ b/arangod/Pregel/Algos/HITS/HITS.h
@@ -64,6 +64,11 @@ struct HITS : public SimpleAlgorithm<HITSValue, int8_t, SenderMessage<double>> {
       VPackSlice userParams) const override;
   [[nodiscard]] MasterContext* masterContext(
       VPackSlice userParams) const override;
+  [[nodiscard]] auto masterContextUnique(
+      uint64_t vertexCount, uint64_t edgeCount,
+      std::unique_ptr<AggregatorHandler> aggregators,
+      arangodb::velocypack::Slice userParams) const
+      -> std::unique_ptr<MasterContext> override;
 
   [[nodiscard]] IAggregator* aggregator(std::string const& name) const override;
 };

--- a/arangod/Pregel/Algos/HITSKleinberg/HITSKleinberg.cpp
+++ b/arangod/Pregel/Algos/HITSKleinberg/HITSKleinberg.cpp
@@ -317,6 +317,11 @@ struct HITSKleinbergMasterContext : public MasterContext {
 
   explicit HITSKleinbergMasterContext(VPackSlice userParams)
       : threshold(getThreshold(userParams)) {}
+  explicit HITSKleinbergMasterContext(
+      uint64_t vertexCount, uint64_t edgeCount,
+      std::unique_ptr<AggregatorHandler> aggregators, VPackSlice userParams)
+      : MasterContext(vertexCount, edgeCount, std::move(aggregators)),
+        threshold(getThreshold(userParams)) {}
 
   bool postGlobalSuperstep() override {
     double const authMaxDiff =
@@ -334,6 +339,14 @@ struct HITSKleinbergMasterContext : public MasterContext {
 
 MasterContext* HITSKleinberg::masterContext(VPackSlice userParams) const {
   return new HITSKleinbergMasterContext(userParams);
+}
+[[nodiscard]] auto HITSKleinberg::masterContextUnique(
+    uint64_t vertexCount, uint64_t edgeCount,
+    std::unique_ptr<AggregatorHandler> aggregators,
+    arangodb::velocypack::Slice userParams) const
+    -> std::unique_ptr<MasterContext> {
+  return std::make_unique<HITSKleinbergMasterContext>(
+      vertexCount, edgeCount, std::move(aggregators), userParams);
 }
 
 IAggregator* HITSKleinberg::aggregator(std::string const& name) const {

--- a/arangod/Pregel/Algos/HITSKleinberg/HITSKleinberg.cpp
+++ b/arangod/Pregel/Algos/HITSKleinberg/HITSKleinberg.cpp
@@ -284,10 +284,8 @@ HITSKleinberg::createComputation(WorkerConfig const* config) const {
 struct HITSKleinbergGraphFormat : public GraphFormat<VertexType, int8_t> {
   std::string const _resultField;
 
-  explicit HITSKleinbergGraphFormat(
-      application_features::ApplicationServer& server, std::string result)
-      : GraphFormat<VertexType, int8_t>(server),
-        _resultField(std::move(result)) {}
+  explicit HITSKleinbergGraphFormat(std::string result)
+      : GraphFormat<VertexType, int8_t>(), _resultField(std::move(result)) {}
 
   [[nodiscard]] size_t estimatedEdgeSize() const override { return 0; }
 
@@ -306,7 +304,7 @@ struct HITSKleinbergGraphFormat : public GraphFormat<VertexType, int8_t> {
 };
 
 GraphFormat<VertexType, int8_t>* HITSKleinberg::inputFormat() const {
-  return new HITSKleinbergGraphFormat(_server, _resultField);
+  return new HITSKleinbergGraphFormat(_resultField);
 }
 
 WorkerContext* HITSKleinberg::workerContext(VPackSlice userParams) const {

--- a/arangod/Pregel/Algos/HITSKleinberg/HITSKleinberg.h
+++ b/arangod/Pregel/Algos/HITSKleinberg/HITSKleinberg.h
@@ -64,6 +64,11 @@ struct HITSKleinberg : public SimpleAlgorithm<HITSKleinbergValue, int8_t,
       VPackSlice userParams) const override;
   [[nodiscard]] MasterContext* masterContext(
       VPackSlice userParams) const override;
+  [[nodiscard]] auto masterContextUnique(
+      uint64_t vertexCount, uint64_t edgeCount,
+      std::unique_ptr<AggregatorHandler> aggregators,
+      arangodb::velocypack::Slice userParams) const
+      -> std::unique_ptr<MasterContext> override;
 
   [[nodiscard]] IAggregator* aggregator(std::string const& name) const override;
 

--- a/arangod/Pregel/Algos/LabelPropagation/LabelPropagation.cpp
+++ b/arangod/Pregel/Algos/LabelPropagation/LabelPropagation.cpp
@@ -112,9 +112,8 @@ LabelPropagation::createComputation(WorkerConfig const* config) const {
 struct LPGraphFormat : public GraphFormat<LPValue, int8_t> {
   std::string _resultField;
 
-  explicit LPGraphFormat(application_features::ApplicationServer& server,
-                         std::string const& result)
-      : GraphFormat<LPValue, int8_t>(server), _resultField(result) {}
+  explicit LPGraphFormat(std::string const& result)
+      : GraphFormat<LPValue, int8_t>(), _resultField(result) {}
 
   size_t estimatedVertexSize() const override { return sizeof(LPValue); }
   size_t estimatedEdgeSize() const override { return 0; }
@@ -135,5 +134,5 @@ struct LPGraphFormat : public GraphFormat<LPValue, int8_t> {
 };
 
 GraphFormat<LPValue, int8_t>* LabelPropagation::inputFormat() const {
-  return new LPGraphFormat(_server, _resultField);
+  return new LPGraphFormat(_resultField);
 }

--- a/arangod/Pregel/Algos/LabelPropagation/LabelPropagation.cpp
+++ b/arangod/Pregel/Algos/LabelPropagation/LabelPropagation.cpp
@@ -23,6 +23,7 @@
 
 #include "LabelPropagation.h"
 #include <cmath>
+#include <memory>
 #include "Cluster/ClusterInfo.h"
 #include "Cluster/ServerState.h"
 #include "Pregel/Aggregator.h"
@@ -135,4 +136,18 @@ struct LPGraphFormat : public GraphFormat<LPValue, int8_t> {
 
 GraphFormat<LPValue, int8_t>* LabelPropagation::inputFormat() const {
   return new LPGraphFormat(_resultField);
+}
+
+struct LabelPropagationMasterContext : public MasterContext {
+  LabelPropagationMasterContext(uint64_t vertexCount, uint64_t edgeCount,
+                                std::unique_ptr<AggregatorHandler> aggregators)
+      : MasterContext(vertexCount, edgeCount, std::move(aggregators)){};
+};
+[[nodiscard]] auto LabelPropagation::masterContextUnique(
+    uint64_t vertexCount, uint64_t edgeCount,
+    std::unique_ptr<AggregatorHandler> aggregators,
+    arangodb::velocypack::Slice userParams) const
+    -> std::unique_ptr<MasterContext> {
+  return std::make_unique<LabelPropagationMasterContext>(
+      vertexCount, edgeCount, std::move(aggregators));
 }

--- a/arangod/Pregel/Algos/LabelPropagation/LabelPropagation.h
+++ b/arangod/Pregel/Algos/LabelPropagation/LabelPropagation.h
@@ -50,5 +50,11 @@ struct LabelPropagation : public SimpleAlgorithm<LPValue, int8_t, uint64_t> {
 
   VertexComputation<LPValue, int8_t, uint64_t>* createComputation(
       WorkerConfig const*) const override;
+
+  [[nodiscard]] auto masterContextUnique(
+      uint64_t vertexCount, uint64_t edgeCount,
+      std::unique_ptr<AggregatorHandler> aggregators,
+      arangodb::velocypack::Slice userParams) const
+      -> std::unique_ptr<MasterContext> override;
 };
 }  // namespace arangodb::pregel::algos

--- a/arangod/Pregel/Algos/LineRank/LineRank.cpp
+++ b/arangod/Pregel/Algos/LineRank/LineRank.cpp
@@ -47,6 +47,10 @@ LineRank::LineRank(application_features::ApplicationServer& server,
 }
 
 struct LRMasterContext : MasterContext {
+  LRMasterContext(uint64_t vertexCount, uint64_t edgeCount,
+                  std::unique_ptr<AggregatorHandler> aggregators)
+      : MasterContext(vertexCount, edgeCount, std::move(aggregators)){};
+  LRMasterContext() = default;
   bool _stopNext = false;
   bool postGlobalSuperstep() override {
     float const* diff = getAggregatedValue<float>(kDiff);
@@ -120,6 +124,14 @@ WorkerContext* LineRank::workerContext(VPackSlice params) const {
 
 MasterContext* LineRank::masterContext(VPackSlice params) const {
   return new LRMasterContext();
+}
+[[nodiscard]] auto LineRank::masterContextUnique(
+    uint64_t vertexCount, uint64_t edgeCount,
+    std::unique_ptr<AggregatorHandler> aggregators,
+    arangodb::velocypack::Slice userParams) const
+    -> std::unique_ptr<MasterContext> {
+  return std::make_unique<LRMasterContext>(vertexCount, edgeCount,
+                                           std::move(aggregators));
 }
 
 IAggregator* LineRank::aggregator(std::string const& name) const {

--- a/arangod/Pregel/Algos/LineRank/LineRank.h
+++ b/arangod/Pregel/Algos/LineRank/LineRank.h
@@ -86,6 +86,11 @@ struct LineRank : public SimpleAlgorithm<float, float, float> {
 
   WorkerContext* workerContext(velocypack::Slice params) const override;
   MasterContext* masterContext(velocypack::Slice) const override;
+  [[nodiscard]] auto masterContextUnique(
+      uint64_t vertexCount, uint64_t edgeCount,
+      std::unique_ptr<AggregatorHandler> aggregators,
+      arangodb::velocypack::Slice userParams) const
+      -> std::unique_ptr<MasterContext> override;
 
   VertexComputation<float, float, float>* createComputation(
       WorkerConfig const*) const override;

--- a/arangod/Pregel/Algos/LineRank/LineRank.h
+++ b/arangod/Pregel/Algos/LineRank/LineRank.h
@@ -74,7 +74,7 @@ struct LineRank : public SimpleAlgorithm<float, float, float> {
                     arangodb::velocypack::Slice params);
 
   GraphFormat<float, float>* inputFormat() const override {
-    return new VertexGraphFormat<float, float>(_server, _resultField, 0);
+    return new VertexGraphFormat<float, float>(_resultField, 0);
   }
   MessageFormat<float>* messageFormat() const override {
     return new NumberMessageFormat<float>();

--- a/arangod/Pregel/Algos/PageRank/PageRank.cpp
+++ b/arangod/Pregel/Algos/PageRank/PageRank.cpp
@@ -58,17 +58,16 @@ PageRank::PageRank(application_features::ApplicationServer& server,
 
 /// will use a seed value for pagerank if available
 struct SeededPRGraphFormat final : public NumberGraphFormat<float, float> {
-  SeededPRGraphFormat(application_features::ApplicationServer& server,
-                      std::string const& source, std::string const& result,
+  SeededPRGraphFormat(std::string const& source, std::string const& result,
                       float vertexNull)
-      : NumberGraphFormat(server, source, result, vertexNull, 0.0f) {}
+      : NumberGraphFormat(source, result, vertexNull, 0.0f) {}
 };
 
 GraphFormat<float, float>* PageRank::inputFormat() const {
   if (_useSource && !_sourceField.empty()) {
-    return new SeededPRGraphFormat(_server, _sourceField, _resultField, -1.0);
+    return new SeededPRGraphFormat(_sourceField, _resultField, -1.0);
   } else {
-    return new VertexGraphFormat<float, float>(_server, _resultField, -1.0);
+    return new VertexGraphFormat<float, float>(_resultField, -1.0);
   }
 }
 

--- a/arangod/Pregel/Algos/PageRank/PageRank.cpp
+++ b/arangod/Pregel/Algos/PageRank/PageRank.cpp
@@ -112,6 +112,13 @@ WorkerContext* PageRank::workerContext(VPackSlice userParams) const {
 
 struct PRMasterContext : public MasterContext {
   float _threshold = EPS;
+  explicit PRMasterContext(uint64_t vertexCount, uint64_t edgeCount,
+                           std::unique_ptr<AggregatorHandler> aggregators,
+                           VPackSlice params)
+      : MasterContext(vertexCount, edgeCount, std::move(aggregators)) {
+    VPackSlice t = params.get("threshold");
+    _threshold = t.isNumber() ? t.getNumber<float>() : EPS;
+  }
   explicit PRMasterContext(VPackSlice params) {
     VPackSlice t = params.get("threshold");
     _threshold = t.isNumber() ? t.getNumber<float>() : EPS;
@@ -130,6 +137,14 @@ struct PRMasterContext : public MasterContext {
 
 MasterContext* PageRank::masterContext(VPackSlice userParams) const {
   return new PRMasterContext(userParams);
+}
+[[nodiscard]] auto PageRank::masterContextUnique(
+    uint64_t vertexCount, uint64_t edgeCount,
+    std::unique_ptr<AggregatorHandler> aggregators,
+    arangodb::velocypack::Slice userParams) const
+    -> std::unique_ptr<MasterContext> {
+  return std::make_unique<PRMasterContext>(vertexCount, edgeCount,
+                                           std::move(aggregators), userParams);
 }
 
 IAggregator* PageRank::aggregator(std::string const& name) const {

--- a/arangod/Pregel/Algos/PageRank/PageRank.h
+++ b/arangod/Pregel/Algos/PageRank/PageRank.h
@@ -49,6 +49,11 @@ struct PageRank : public SimpleAlgorithm<float, float, float> {
   WorkerContext* workerContext(VPackSlice userParams) const override;
 
   MasterContext* masterContext(VPackSlice userParams) const override;
+  [[nodiscard]] auto masterContextUnique(
+      uint64_t vertexCount, uint64_t edgeCount,
+      std::unique_ptr<AggregatorHandler> aggregators,
+      arangodb::velocypack::Slice userParams) const
+      -> std::unique_ptr<MasterContext> override;
 
   IAggregator* aggregator(std::string const& name) const override;
 

--- a/arangod/Pregel/Algos/ReadWrite/ReadWrite.cpp
+++ b/arangod/Pregel/Algos/ReadWrite/ReadWrite.cpp
@@ -46,9 +46,8 @@ ReadWrite::ReadWrite(application_features::ApplicationServer& server,
     : SimpleAlgorithm(server, "readwrite", userParams) {}
 
 struct ReadWriteGraphFormat final : public GraphFormat<V, E> {
-  ReadWriteGraphFormat(application_features::ApplicationServer& server,
-                       std::string sourceFieldName, std::string resultFieldName)
-      : GraphFormat(server),
+  ReadWriteGraphFormat(std::string sourceFieldName, std::string resultFieldName)
+      : GraphFormat(),
         sourceFieldName{std::move(sourceFieldName)},
         resultFieldName{std::move(resultFieldName)} {}
   std::string const sourceFieldName;
@@ -82,7 +81,7 @@ struct ReadWriteGraphFormat final : public GraphFormat<V, E> {
 };
 
 GraphFormat<V, E>* ReadWrite::inputFormat() const {
-  return new ReadWriteGraphFormat(_server, _sourceField, _resultField);
+  return new ReadWriteGraphFormat(_sourceField, _resultField);
 }
 
 struct ReadWriteComputation : public VertexComputation<V, E, V> {

--- a/arangod/Pregel/Algos/ReadWrite/ReadWrite.h
+++ b/arangod/Pregel/Algos/ReadWrite/ReadWrite.h
@@ -53,6 +53,11 @@ struct ReadWrite : public SimpleAlgorithm<V, E, V> {
 
   [[nodiscard]] MasterContext* masterContext(
       VPackSlice userParams) const override;
+  [[nodiscard]] auto masterContextUnique(
+      uint64_t vertexCount, uint64_t edgeCount,
+      std::unique_ptr<AggregatorHandler> aggregators,
+      arangodb::velocypack::Slice userParams) const
+      -> std::unique_ptr<MasterContext> override;
 
   [[nodiscard]] IAggregator* aggregator(std::string const& name) const override;
 };

--- a/arangod/Pregel/Algos/RecoveringPageRank/RecoveringPageRank.cpp
+++ b/arangod/Pregel/Algos/RecoveringPageRank/RecoveringPageRank.cpp
@@ -120,6 +120,13 @@ struct RPRMasterContext : public MasterContext {
     VPackSlice t = params.get("convergenceThreshold");
     _threshold = t.isNumber() ? t.getNumber<float>() : EPS;
   };
+  explicit RPRMasterContext(uint64_t vertexCount, uint64_t edgeCount,
+                            std::unique_ptr<AggregatorHandler> aggregators,
+                            VPackSlice params)
+      : MasterContext(vertexCount, edgeCount, std::move(aggregators)) {
+    VPackSlice t = params.get("convergenceThreshold");
+    _threshold = t.isNumber() ? t.getNumber<float>() : EPS;
+  };
 
   int32_t recoveryStep = 0;
   float totalRank = 0;
@@ -159,4 +166,12 @@ struct RPRMasterContext : public MasterContext {
 
 MasterContext* RecoveringPageRank::masterContext(VPackSlice userParams) const {
   return new RPRMasterContext(userParams);
+}
+[[nodiscard]] auto RecoveringPageRank::masterContextUnique(
+    uint64_t vertexCount, uint64_t edgeCount,
+    std::unique_ptr<AggregatorHandler> aggregators,
+    arangodb::velocypack::Slice userParams) const
+    -> std::unique_ptr<MasterContext> {
+  return std::make_unique<RPRMasterContext>(vertexCount, edgeCount,
+                                            std::move(aggregators), userParams);
 }

--- a/arangod/Pregel/Algos/RecoveringPageRank/RecoveringPageRank.h
+++ b/arangod/Pregel/Algos/RecoveringPageRank/RecoveringPageRank.h
@@ -39,7 +39,7 @@ struct RecoveringPageRank : public SimpleAlgorithm<float, float, float> {
   MasterContext* masterContext(VPackSlice userParams) const override;
 
   GraphFormat<float, float>* inputFormat() const override {
-    return new VertexGraphFormat<float, float>(_server, _resultField, 0);
+    return new VertexGraphFormat<float, float>(_resultField, 0);
   }
 
   MessageFormat<float>* messageFormat() const override {

--- a/arangod/Pregel/Algos/RecoveringPageRank/RecoveringPageRank.h
+++ b/arangod/Pregel/Algos/RecoveringPageRank/RecoveringPageRank.h
@@ -37,6 +37,11 @@ struct RecoveringPageRank : public SimpleAlgorithm<float, float, float> {
       : SimpleAlgorithm(server, "pagerank", params) {}
 
   MasterContext* masterContext(VPackSlice userParams) const override;
+  [[nodiscard]] auto masterContextUnique(
+      uint64_t vertexCount, uint64_t edgeCount,
+      std::unique_ptr<AggregatorHandler> aggregators,
+      arangodb::velocypack::Slice userParams) const
+      -> std::unique_ptr<MasterContext> override;
 
   GraphFormat<float, float>* inputFormat() const override {
     return new VertexGraphFormat<float, float>(_resultField, 0);

--- a/arangod/Pregel/Algos/SCC/SCC.cpp
+++ b/arangod/Pregel/Algos/SCC/SCC.cpp
@@ -24,6 +24,7 @@
 #include "SCC.h"
 #include <atomic>
 #include <climits>
+#include <memory>
 #include <utility>
 #include "Cluster/ClusterInfo.h"
 #include "Cluster/ServerState.h"
@@ -191,6 +192,10 @@ GraphFormat<SCCValue, int8_t>* SCC::inputFormat() const {
 
 struct SCCMasterContext : public MasterContext {
   SCCMasterContext() = default;  // TODO use _threshold
+  SCCMasterContext(uint64_t vertexCount, uint64_t edgeCount,
+                   std::unique_ptr<AggregatorHandler> aggregators)
+      : MasterContext(vertexCount, edgeCount, std::move(aggregators)){};
+
   void preGlobalSuperstep() override {
     if (globalSuperstep() == 0) {
       aggregate<uint32_t>(kPhase, SCCPhase::TRANSPOSE);
@@ -238,6 +243,14 @@ struct SCCMasterContext : public MasterContext {
 
 MasterContext* SCC::masterContext(VPackSlice userParams) const {
   return new SCCMasterContext();
+}
+[[nodiscard]] auto SCC::masterContextUnique(
+    uint64_t vertexCount, uint64_t edgeCount,
+    std::unique_ptr<AggregatorHandler> aggregators,
+    arangodb::velocypack::Slice userParams) const
+    -> std::unique_ptr<MasterContext> {
+  return std::make_unique<SCCMasterContext>(vertexCount, edgeCount,
+                                            std::move(aggregators));
 }
 
 IAggregator* SCC::aggregator(std::string const& name) const {

--- a/arangod/Pregel/Algos/SCC/SCC.cpp
+++ b/arangod/Pregel/Algos/SCC/SCC.cpp
@@ -160,10 +160,8 @@ namespace {
 struct SCCGraphFormat : public GraphFormat<SCCValue, int8_t> {
   const std::string _resultField;
 
-  explicit SCCGraphFormat(application_features::ApplicationServer& server,
-                          std::string result)
-      : GraphFormat<SCCValue, int8_t>(server),
-        _resultField(std::move(result)) {}
+  explicit SCCGraphFormat(std::string result)
+      : GraphFormat<SCCValue, int8_t>(), _resultField(std::move(result)) {}
 
   [[nodiscard]] size_t estimatedEdgeSize() const override { return 0; }
 
@@ -188,7 +186,7 @@ struct SCCGraphFormat : public GraphFormat<SCCValue, int8_t> {
 }  // namespace
 
 GraphFormat<SCCValue, int8_t>* SCC::inputFormat() const {
-  return new SCCGraphFormat(_server, _resultField);
+  return new SCCGraphFormat(_resultField);
 }
 
 struct SCCMasterContext : public MasterContext {

--- a/arangod/Pregel/Algos/SCC/SCC.h
+++ b/arangod/Pregel/Algos/SCC/SCC.h
@@ -111,6 +111,11 @@ struct SCC : public SimpleAlgorithm<SCCValue, int8_t, SenderMessage<uint64_t>> {
 
   [[nodiscard]] MasterContext* masterContext(
       VPackSlice userParams) const override;
+  [[nodiscard]] auto masterContextUnique(
+      uint64_t vertexCount, uint64_t edgeCount,
+      std::unique_ptr<AggregatorHandler> aggregators,
+      arangodb::velocypack::Slice userParams) const
+      -> std::unique_ptr<MasterContext> override;
 
   [[nodiscard]] IAggregator* aggregator(std::string const& name) const override;
 };

--- a/arangod/Pregel/Algos/SLPA/SLPA.cpp
+++ b/arangod/Pregel/Algos/SLPA/SLPA.cpp
@@ -138,9 +138,8 @@ struct SLPAGraphFormat : public GraphFormat<SLPAValue, int8_t> {
   double threshold;
   unsigned maxCommunities;
 
-  explicit SLPAGraphFormat(application_features::ApplicationServer& server,
-                           std::string const& result, double thr, unsigned mc)
-      : GraphFormat<SLPAValue, int8_t>(server),
+  explicit SLPAGraphFormat(std::string const& result, double thr, unsigned mc)
+      : GraphFormat<SLPAValue, int8_t>(),
         resField(result),
         threshold(thr),
         maxCommunities(mc) {}
@@ -200,8 +199,7 @@ struct SLPAGraphFormat : public GraphFormat<SLPAValue, int8_t> {
 };
 
 GraphFormat<SLPAValue, int8_t>* SLPA::inputFormat() const {
-  return new SLPAGraphFormat(_server, _resultField, _threshold,
-                             _maxCommunities);
+  return new SLPAGraphFormat(_resultField, _threshold, _maxCommunities);
 }
 
 WorkerContext* SLPA::workerContext(velocypack::Slice userParams) const {

--- a/arangod/Pregel/Algos/SLPA/SLPA.cpp
+++ b/arangod/Pregel/Algos/SLPA/SLPA.cpp
@@ -205,3 +205,17 @@ GraphFormat<SLPAValue, int8_t>* SLPA::inputFormat() const {
 WorkerContext* SLPA::workerContext(velocypack::Slice userParams) const {
   return new SLPAWorkerContext();
 }
+
+struct SLPAMasterContext : public MasterContext {
+  SLPAMasterContext(uint64_t vertexCount, uint64_t edgeCount,
+                    std::unique_ptr<AggregatorHandler> aggregators)
+      : MasterContext(vertexCount, edgeCount, std::move(aggregators)){};
+};
+[[nodiscard]] auto SLPA::masterContextUnique(
+    uint64_t vertexCount, uint64_t edgeCount,
+    std::unique_ptr<AggregatorHandler> aggregators,
+    arangodb::velocypack::Slice userParams) const
+    -> std::unique_ptr<MasterContext> {
+  return std::make_unique<SLPAMasterContext>(vertexCount, edgeCount,
+                                             std::move(aggregators));
+}

--- a/arangod/Pregel/Algos/SLPA/SLPA.h
+++ b/arangod/Pregel/Algos/SLPA/SLPA.h
@@ -117,5 +117,11 @@ struct SLPA : public SimpleAlgorithm<SLPAValue, int8_t, uint64_t> {
   VertexComputation<SLPAValue, int8_t, uint64_t>* createComputation(
       WorkerConfig const*) const override;
   WorkerContext* workerContext(velocypack::Slice userParams) const override;
+
+  [[nodiscard]] auto masterContextUnique(
+      uint64_t vertexCount, uint64_t edgeCount,
+      std::unique_ptr<AggregatorHandler> aggregators,
+      arangodb::velocypack::Slice userParams) const
+      -> std::unique_ptr<MasterContext> override;
 };
 }  // namespace arangodb::pregel::algos

--- a/arangod/Pregel/Algos/SSSP/SSSP.cpp
+++ b/arangod/Pregel/Algos/SSSP/SSSP.cpp
@@ -25,6 +25,7 @@
 #include "Pregel/Algorithm.h"
 #include "Pregel/Worker/GraphStore.h"
 #include "Pregel/IncomingCache.h"
+#include "Pregel/MasterContext.h"
 #include "Pregel/VertexComputation.h"
 
 using namespace arangodb;
@@ -106,4 +107,18 @@ struct SSSPCompensation : public VertexCompensation<int64_t, int64_t, int64_t> {
 VertexCompensation<int64_t, int64_t, int64_t>*
 SSSPAlgorithm::createCompensation(WorkerConfig const* config) const {
   return new SSSPCompensation();
+}
+
+struct SSSPMasterContext : public MasterContext {
+  SSSPMasterContext(uint64_t vertexCount, uint64_t edgeCount,
+                    std::unique_ptr<AggregatorHandler> aggregators)
+      : MasterContext(vertexCount, edgeCount, std::move(aggregators)){};
+};
+[[nodiscard]] auto SSSPAlgorithm::masterContextUnique(
+    uint64_t vertexCount, uint64_t edgeCount,
+    std::unique_ptr<AggregatorHandler> aggregators,
+    arangodb::velocypack::Slice userParams) const
+    -> std::unique_ptr<MasterContext> {
+  return std::make_unique<SSSPMasterContext>(vertexCount, edgeCount,
+                                             std::move(aggregators));
 }

--- a/arangod/Pregel/Algos/SSSP/SSSP.cpp
+++ b/arangod/Pregel/Algos/SSSP/SSSP.cpp
@@ -77,8 +77,7 @@ struct SSSPGraphFormat : public InitGraphFormat<int64_t, int64_t> {
  public:
   SSSPGraphFormat(application_features::ApplicationServer& server,
                   std::string const& source, std::string const& result)
-      : InitGraphFormat<int64_t, int64_t>(server, result, 0, 1),
-        _sourceDocId(source) {}
+      : InitGraphFormat<int64_t, int64_t>(result, 0, 1), _sourceDocId(source) {}
 
   void copyVertexData(arangodb::velocypack::Options const&,
                       std::string const& documentId,

--- a/arangod/Pregel/Algos/SSSP/SSSP.h
+++ b/arangod/Pregel/Algos/SSSP/SSSP.h
@@ -74,6 +74,12 @@ class SSSPAlgorithm : public Algorithm<int64_t, int64_t, int64_t> {
 
   uint32_t messageBatchSize(WorkerConfig const& config,
                             MessageStats const& stats) const override;
+
+  [[nodiscard]] auto masterContextUnique(
+      uint64_t vertexCount, uint64_t edgeCount,
+      std::unique_ptr<AggregatorHandler> aggregators,
+      arangodb::velocypack::Slice userParams) const
+      -> std::unique_ptr<MasterContext> override;
 };
 }  // namespace algos
 }  // namespace pregel

--- a/arangod/Pregel/Algos/ShortestPath/ShortestPath.cpp
+++ b/arangod/Pregel/Algos/ShortestPath/ShortestPath.cpp
@@ -22,8 +22,10 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #include "Pregel/Algos/ShortestPath/ShortestPath.h"
+#include "Aql/ExecutionBlockImpl.tpp"
 #include "Pregel/Aggregator.h"
 #include "Pregel/Algorithm.h"
+#include "Pregel/MasterContext.h"
 #include "Pregel/Worker/GraphStore.h"
 #include "Pregel/IncomingCache.h"
 #include "Pregel/VertexComputation.h"
@@ -127,4 +129,18 @@ IAggregator* ShortestPathAlgorithm::aggregator(std::string const& name) const {
     return new MinAggregator<int64_t>(INT64_MAX, true);
   }
   return nullptr;
+}
+
+struct ShortestPathMasterContext : public MasterContext {
+  ShortestPathMasterContext(uint64_t vertexCount, uint64_t edgeCount,
+                            std::unique_ptr<AggregatorHandler> aggregators)
+      : MasterContext(vertexCount, edgeCount, std::move(aggregators)){};
+};
+[[nodiscard]] auto ShortestPathAlgorithm::masterContextUnique(
+    uint64_t vertexCount, uint64_t edgeCount,
+    std::unique_ptr<AggregatorHandler> aggregators,
+    arangodb::velocypack::Slice userParams) const
+    -> std::unique_ptr<MasterContext> {
+  return std::make_unique<ShortestPathMasterContext>(vertexCount, edgeCount,
+                                                     std::move(aggregators));
 }

--- a/arangod/Pregel/Algos/ShortestPath/ShortestPath.cpp
+++ b/arangod/Pregel/Algos/ShortestPath/ShortestPath.cpp
@@ -81,9 +81,8 @@ struct arangodb::pregel::algos::SPGraphFormat
   std::string _sourceDocId, _targetDocId;
 
  public:
-  SPGraphFormat(application_features::ApplicationServer& server,
-                std::string const& source, std::string const& target)
-      : InitGraphFormat<int64_t, int64_t>(server, "length", 0, 1),
+  SPGraphFormat(std::string const& source, std::string const& target)
+      : InitGraphFormat<int64_t, int64_t>("length", 0, 1),
         _sourceDocId(source),
         _targetDocId(target) {}
 
@@ -114,7 +113,7 @@ std::set<std::string> ShortestPathAlgorithm::initialActiveSet() {
 }
 
 GraphFormat<int64_t, int64_t>* ShortestPathAlgorithm::inputFormat() const {
-  return new SPGraphFormat(_server, _source, _target);
+  return new SPGraphFormat(_source, _target);
 }
 
 VertexComputation<int64_t, int64_t, int64_t>*

--- a/arangod/Pregel/Algos/ShortestPath/ShortestPath.h
+++ b/arangod/Pregel/Algos/ShortestPath/ShortestPath.h
@@ -52,5 +52,11 @@ struct ShortestPathAlgorithm : public Algorithm<int64_t, int64_t, int64_t> {
       WorkerConfig const* config) const override;
   IAggregator* aggregator(std::string const& name) const override;
   std::set<std::string> initialActiveSet() override;
+
+  [[nodiscard]] auto masterContextUnique(
+      uint64_t vertexCount, uint64_t edgeCount,
+      std::unique_ptr<AggregatorHandler> aggregators,
+      arangodb::velocypack::Slice userParams) const
+      -> std::unique_ptr<MasterContext> override;
 };
 }  // namespace arangodb::pregel::algos

--- a/arangod/Pregel/Algos/WCC/WCC.cpp
+++ b/arangod/Pregel/Algos/WCC/WCC.cpp
@@ -134,9 +134,8 @@ struct WCCComputation
 };
 
 struct WCCGraphFormat final : public GraphFormat<WCCValue, uint64_t> {
-  explicit WCCGraphFormat(application_features::ApplicationServer& server,
-                          std::string const& result)
-      : GraphFormat<WCCValue, uint64_t>(server), _resultField(result) {}
+  explicit WCCGraphFormat(std::string const& result)
+      : GraphFormat<WCCValue, uint64_t>(), _resultField(result) {}
 
   std::string const _resultField;
 
@@ -175,5 +174,5 @@ WCC::createComputation(WorkerConfig const* config) const {
 }
 
 GraphFormat<WCCValue, uint64_t>* WCC::inputFormat() const {
-  return new ::WCCGraphFormat(_server, _resultField);
+  return new ::WCCGraphFormat(_resultField);
 }

--- a/arangod/Pregel/Algos/WCC/WCC.cpp
+++ b/arangod/Pregel/Algos/WCC/WCC.cpp
@@ -26,6 +26,7 @@
 #include "Cluster/ClusterInfo.h"
 #include "Cluster/ServerState.h"
 #include "Pregel/Algorithm.h"
+#include "Pregel/MasterContext.h"
 #include "Pregel/Worker/GraphStore.h"
 #include "Pregel/IncomingCache.h"
 #include "Pregel/VertexComputation.h"
@@ -175,4 +176,18 @@ WCC::createComputation(WorkerConfig const* config) const {
 
 GraphFormat<WCCValue, uint64_t>* WCC::inputFormat() const {
   return new ::WCCGraphFormat(_resultField);
+}
+
+struct WCCMasterContext : public MasterContext {
+  WCCMasterContext(uint64_t vertexCount, uint64_t edgeCount,
+                   std::unique_ptr<AggregatorHandler> aggregators)
+      : MasterContext(vertexCount, edgeCount, std::move(aggregators)){};
+};
+[[nodiscard]] auto WCC::masterContextUnique(
+    uint64_t vertexCount, uint64_t edgeCount,
+    std::unique_ptr<AggregatorHandler> aggregators,
+    arangodb::velocypack::Slice userParams) const
+    -> std::unique_ptr<MasterContext> {
+  return std::make_unique<WCCMasterContext>(vertexCount, edgeCount,
+                                            std::move(aggregators));
 }

--- a/arangod/Pregel/Algos/WCC/WCC.h
+++ b/arangod/Pregel/Algos/WCC/WCC.h
@@ -50,5 +50,11 @@ struct WCC
   }
   VertexComputation<WCCValue, uint64_t, SenderMessage<uint64_t>>*
   createComputation(WorkerConfig const*) const override;
+
+  [[nodiscard]] auto masterContextUnique(
+      uint64_t vertexCount, uint64_t edgeCount,
+      std::unique_ptr<AggregatorHandler> aggregators,
+      arangodb::velocypack::Slice userParams) const
+      -> std::unique_ptr<MasterContext> override;
 };
 }  // namespace arangodb::pregel::algos

--- a/arangod/Pregel/Conductor/ExecutionStates/CreateWorkers.cpp
+++ b/arangod/Pregel/Conductor/ExecutionStates/CreateWorkers.cpp
@@ -51,8 +51,8 @@ auto CreateWorkers::_workerSpecifications() const
   auto createWorkers =
       std::unordered_map<ServerID, worker::message::CreateNewWorker>{};
   for (auto const& [server, vertexShards] :
-       conductor._lookupInfo->getServerMapVertices()) {
-    auto edgeShards = conductor._lookupInfo->getServerMapEdges().at(server);
+       conductor.lookupInfo->getServerMapVertices()) {
+    auto edgeShards = conductor.lookupInfo->getServerMapEdges().at(server);
     createWorkers.emplace(
         server, worker::message::CreateNewWorker{
                     .executionSpecifications = conductor.specifications,
@@ -60,8 +60,8 @@ auto CreateWorkers::_workerSpecifications() const
                         .vertexShards = std::move(vertexShards),
                         .edgeShards = std::move(edgeShards),
                         .collectionPlanIds =
-                            conductor._lookupInfo->getCollectionPlanIdMapAll(),
-                        .allShards = conductor._lookupInfo->getAllShards()}});
+                            conductor.lookupInfo->getCollectionPlanIdMapAll(),
+                        .allShards = conductor.lookupInfo->getAllShards()}});
   }
   return createWorkers;
 }

--- a/arangod/Pregel/Conductor/ExecutionStates/CreateWorkers.cpp
+++ b/arangod/Pregel/Conductor/ExecutionStates/CreateWorkers.cpp
@@ -11,7 +11,7 @@ using namespace arangodb;
 using namespace arangodb::pregel::conductor;
 
 CreateWorkers::CreateWorkers(ConductorState& conductor) : conductor{conductor} {
-  conductor._timing.total.start();
+  conductor.timing.total.start();
 }
 
 auto CreateWorkers::messages()
@@ -23,7 +23,7 @@ auto CreateWorkers::messages()
     servers.emplace_back(server);
     sentServers.emplace(server);
   }
-  conductor._status = ConductorStatus::forWorkers(servers);
+  conductor.status = ConductorStatus::forWorkers(servers);
 
   return workerSpecifications;
 }
@@ -41,7 +41,7 @@ auto CreateWorkers::receive(actor::ActorPID sender,
     // TODO return error state (GORDO-1553)
     return std::nullopt;
   }
-  conductor._workers.emplace_back(sender);
+  conductor.workers.emplace_back(sender);
   respondedServers.emplace(sender.server);
   responseCount++;
 
@@ -107,13 +107,13 @@ auto CreateWorkers::_workerSpecifications() const
   std::vector<ShardID> shardList;
 
   for (CollectionID const& collectionID :
-       conductor._specifications.vertexCollections) {
-    resolveInfo(&(conductor._vocbaseGuard.database()), collectionID,
+       conductor.specifications.vertexCollections) {
+    resolveInfo(&(conductor.vocbaseGuard.database()), collectionID,
                 collectionPlanIdMap, vertexMap, shardList);
   }
   for (CollectionID const& collectionID :
-       conductor._specifications.edgeCollections) {
-    resolveInfo(&(conductor._vocbaseGuard.database()), collectionID,
+       conductor.specifications.edgeCollections) {
+    resolveInfo(&(conductor.vocbaseGuard.database()), collectionID,
                 collectionPlanIdMap, edgeMap, shardList);
   }
 
@@ -123,7 +123,7 @@ auto CreateWorkers::_workerSpecifications() const
     auto const& edgeShards = edgeMap[server];
     createWorkers.emplace(
         server, worker::message::CreateNewWorker{
-                    .executionSpecifications = conductor._specifications,
+                    .executionSpecifications = conductor.specifications,
                     .collectionSpecifications = CollectionSpecifications{
                         .vertexShards = std::move(vertexShards),
                         .edgeShards = std::move(edgeShards),

--- a/arangod/Pregel/Conductor/ExecutionStates/LoadingState.h
+++ b/arangod/Pregel/Conductor/ExecutionStates/LoadingState.h
@@ -35,12 +35,12 @@ struct ConductorState;
 // TODO implement in GORDO-1548
 struct Loading : ExecutionState {
   Loading(ConductorState& conductor) : conductor{conductor} {
-    conductor._timing.loading.start();
+    conductor.timing.loading.start();
     // TODO GORDO-1510
     // _feature.metrics()->pregelConductorsLoadingNumber->fetch_add(1);
   }
   ~Loading() {
-    conductor._timing.loading.finish();
+    conductor.timing.loading.finish();
     // TODO GORDO-1510
     // conductor._feature.metrics()->pregelConductorsLoadingNumber->fetch_sub(1);
   }

--- a/arangod/Pregel/Conductor/Handler.h
+++ b/arangod/Pregel/Conductor/Handler.h
@@ -39,7 +39,9 @@ struct ConductorHandler : actor::HandlerBase<Runtime, ConductorState> {
   void spawnActorOnServer(actor::ServerID server,
                           pregel::message::SpawnMessages msg) {
     if (server == this->self.server) {
-      this->template spawn<SpawnActor>(std::make_unique<SpawnState>(), msg);
+      this->template spawn<SpawnActor>(
+          std::make_unique<SpawnState>(this->state->_vocbaseGuard.database()),
+          msg);
     } else {
       this->dispatch(
           actor::ActorPID{

--- a/arangod/Pregel/Conductor/State.h
+++ b/arangod/Pregel/Conductor/State.h
@@ -35,27 +35,27 @@ namespace arangodb::pregel::conductor {
 
 struct ConductorState {
   ConductorState(ExecutionSpecifications specifications, TRI_vocbase_t& vocbase)
-      : _specifications{std::move(specifications)}, _vocbaseGuard{vocbase} {}
+      : specifications{std::move(specifications)}, vocbaseGuard{vocbase} {}
 
-  ExecutionTimings _timing;
-  uint64_t _globalSuperstep = 0;
-  std::unique_ptr<ExecutionState> _executionState = std::make_unique<Initial>();
+  ExecutionTimings timing;
+  uint64_t globalSuperstep = 0;
+  std::unique_ptr<ExecutionState> executionState = std::make_unique<Initial>();
   // TODO how to update metrics in feature (needed for 'loading' and subsequent
   // states)
-  ConductorStatus _status;
-  std::vector<actor::ActorPID> _workers;
-  const ExecutionSpecifications _specifications;
-  const DatabaseGuard _vocbaseGuard;
+  ConductorStatus status;
+  std::vector<actor::ActorPID> workers;
+  const ExecutionSpecifications specifications;
+  const DatabaseGuard vocbaseGuard;
 };
 
 template<typename Inspector>
 auto inspect(Inspector& f, ConductorState& x) {
-  return f.object(x).fields(
-      f.field("timing", x._timing),
-      f.field("globalSuperstep", x._globalSuperstep),
-      f.field("executionState", x._executionState->name()),
-      f.field("status", x._status), f.field("workers", x._workers),
-      f.field("specifications", x._specifications));
+  return f.object(x).fields(f.field("timing", x.timing),
+                            f.field("globalSuperstep", x.globalSuperstep),
+                            f.field("executionState", x.executionState->name()),
+                            f.field("status", x.status),
+                            f.field("workers", x.workers),
+                            f.field("specifications", x.specifications));
 }
 
 }  // namespace arangodb::pregel::conductor

--- a/arangod/Pregel/GraphFormat.h
+++ b/arangod/Pregel/GraphFormat.h
@@ -33,16 +33,11 @@
 #include "Pregel/GraphStore/Graph.h"
 
 struct TRI_vocbase_t;
-namespace arangodb {
-namespace application_features {
-class ApplicationServer;
-}
-namespace pregel {
+namespace arangodb::pregel {
 
 template<typename V, typename E>
 struct GraphFormat {
-  explicit GraphFormat(application_features::ApplicationServer& server)
-      : _server(server) {}
+  explicit GraphFormat() = default;
   virtual ~GraphFormat() = default;
 
   virtual size_t estimatedVertexSize() const { return sizeof(V); }
@@ -61,9 +56,6 @@ struct GraphFormat {
 
   virtual bool buildVertexDocument(arangodb::velocypack::Builder& b,
                                    V const* targetPtr) const = 0;
-
- private:
-  application_features::ApplicationServer& _server;
 };
 
 template<typename V, typename E>
@@ -77,10 +69,9 @@ class NumberGraphFormat : public GraphFormat<V, E> {
   const E _eDefault;
 
  public:
-  NumberGraphFormat(application_features::ApplicationServer& server,
-                    std::string const& source, std::string const& result,
+  NumberGraphFormat(std::string const& source, std::string const& result,
                     V vertexNull, E edgeNull)
-      : GraphFormat<V, E>(server),
+      : GraphFormat<V, E>(),
         _sourceField(source),
         _resultField(result),
         _vDefault(vertexNull),
@@ -132,9 +123,8 @@ class InitGraphFormat : public GraphFormat<V, E> {
   const E _eDefault;
 
  public:
-  InitGraphFormat(application_features::ApplicationServer& server,
-                  std::string const& result, V vertexNull, E edgeNull)
-      : GraphFormat<V, E>(server),
+  InitGraphFormat(std::string const& result, V vertexNull, E edgeNull)
+      : GraphFormat<V, E>(),
         _resultField(result),
         _vDefault(vertexNull),
         _eDefault(edgeNull) {}
@@ -167,11 +157,8 @@ class VertexGraphFormat : public GraphFormat<V, E> {
   const V _vDefault;
 
  public:
-  VertexGraphFormat(application_features::ApplicationServer& server,
-                    std::string const& result, V vertexNull)
-      : GraphFormat<V, E>(server),
-        _resultField(result),
-        _vDefault(vertexNull) {}
+  VertexGraphFormat(std::string const& result, V vertexNull)
+      : GraphFormat<V, E>(), _resultField(result), _vDefault(vertexNull) {}
 
   size_t estimatedVertexSize() const override { return sizeof(V); }
   virtual size_t estimatedEdgeSize() const override { return 0; }
@@ -189,5 +176,4 @@ class VertexGraphFormat : public GraphFormat<V, E> {
     return true;
   }
 };
-}  // namespace pregel
-}  // namespace arangodb
+}  // namespace arangodb::pregel

--- a/arangod/Pregel/MasterContext.h
+++ b/arangod/Pregel/MasterContext.h
@@ -40,9 +40,15 @@ class MasterContext {
   uint64_t _edgeCount = 0;
   // Should cause the master to tell everyone to enter the next phase
   AggregatorHandler* _aggregators = nullptr;
+  std::unique_ptr<AggregatorHandler> _aggregatorsUnique = nullptr;
 
  public:
-  MasterContext() {}
+  MasterContext(uint64_t vertexCount, uint64_t edgeCount,
+                std::unique_ptr<AggregatorHandler> aggregators)
+      : _vertexCount{vertexCount},
+        _edgeCount{edgeCount},
+        _aggregatorsUnique{std::move(aggregators)} {}
+  MasterContext() = default;
   virtual ~MasterContext() = default;
 
   inline uint64_t globalSuperstep() const { return _globalSuperstep; }

--- a/arangod/Pregel/PregelFeature.cpp
+++ b/arangod/Pregel/PregelFeature.cpp
@@ -335,12 +335,15 @@ ResultT<ExecutionNumber> PregelFeature::startExecution(TRI_vocbase_t& vocbase,
   auto ttl = TTL{.duration = std::chrono::seconds(
                      basics::VelocyPackHelper::getNumericValue(
                          options.userParameters.slice(), "ttl", 600))};
+  auto algorithm = std::move(options.algorithm);
+  std::transform(algorithm.begin(), algorithm.end(), algorithm.begin(),
+                 ::tolower);
 
   auto en = createExecutionNumber();
 
   auto executionSpecifications = ExecutionSpecifications{
       .executionNumber = en,
-      .algorithm = std::move(options.algorithm),
+      .algorithm = std::move(algorithm),
       .vertexCollections = std::move(vertexCollections),
       .edgeCollections = std::move(edgeColls),
       .edgeCollectionRestrictions =

--- a/arangod/Pregel/REST/RestPregelHandler.cpp
+++ b/arangod/Pregel/REST/RestPregelHandler.cpp
@@ -75,7 +75,7 @@ RestStatus RestPregelHandler::execute() {
       }
       if (msg.get().receiver.id == actor::ActorID{0}) {
         _pregel._actorRuntime->spawn<SpawnActor>(
-            _vocbase.name(), std::make_unique<SpawnState>(),
+            _vocbase.name(), std::make_unique<SpawnState>(_vocbase),
             velocypack::SharedSlice({}, msg.get().payload.slice()));
         generateResult(rest::ResponseCode::OK, VPackBuilder().slice());
         return RestStatus::DONE;

--- a/arangod/Pregel/SpawnActor.h
+++ b/arangod/Pregel/SpawnActor.h
@@ -27,11 +27,37 @@
 #include "Actor/HandlerBase.h"
 #include "Pregel/Worker/Actor.h"
 #include "Pregel/SpawnMessages.h"
+#include "Pregel/Worker/Messages.h"
+#include "Pregel/Worker/State.h"
+#include "VocBase/vocbase.h"
 #include "fmt/core.h"
+
+#include "Pregel/Algos/ColorPropagation/ColorPropagation.h"
+#include "Pregel/Algos/ConnectedComponents/ConnectedComponents.h"
+#include "Pregel/Algos/DMID/DMID.h"
+#include "Pregel/Algos/EffectiveCloseness/EffectiveCloseness.h"
+#include "Pregel/Algos/HITS/HITS.h"
+#include "Pregel/Algos/HITSKleinberg/HITSKleinberg.h"
+#include "Pregel/Algos/LabelPropagation/LabelPropagation.h"
+#include "Pregel/Algos/LineRank/LineRank.h"
+#include "Pregel/Algos/PageRank/PageRank.h"
+#include "Pregel/Algos/RecoveringPageRank/RecoveringPageRank.h"
+#include "Pregel/Algos/SCC/SCC.h"
+#include "Pregel/Algos/ShortestPath/ShortestPath.h"
+#include "Pregel/Algos/SLPA/SLPA.h"
+#include "Pregel/Algos/SSSP/SSSP.h"
+#include "Pregel/Algos/WCC/WCC.h"
+#include "Pregel/Utils.h"
+#if defined(ARANGODB_ENABLE_MAINTAINER_MODE)
+#include "Pregel/Algos/ReadWrite/ReadWrite.h"
+#endif
 
 namespace arangodb::pregel {
 
-struct SpawnState {};
+struct SpawnState {
+  SpawnState(TRI_vocbase_t& vocbase) : vocbaseGuard{vocbase} {}
+  const DatabaseGuard vocbaseGuard;
+};
 template<typename Inspector>
 auto inspect(Inspector& f, SpawnState& x) {
   return f.object(x).fields();
@@ -45,14 +71,75 @@ struct SpawnHandler : actor::HandlerBase<Runtime, SpawnState> {
     return std::move(this->state);
   }
 
+  template<typename V, typename E, typename M>
+  auto spawnWorker(Algorithm<V, E, M>* algorithm, message::SpawnWorker msg)
+      -> void {
+    this->template spawn<worker::WorkerActor<V, E, M>>(
+        std::make_unique<worker::WorkerState<V, E, M>>(
+            msg.conductor, msg.message.executionSpecifications,
+            msg.message.collectionSpecifications, algorithm,
+            this->state->vocbaseGuard.database()),
+        worker::message::WorkerStart{});
+  }
+
+  auto spawnWorker(message::SpawnWorker msg) -> void {
+    VPackSlice userParams =
+        msg.message.executionSpecifications.userParameters.slice();
+    std::string algorithm = msg.message.executionSpecifications.algorithm;
+
+    auto& server = this->state->vocbaseGuard.database().server();
+    if (algorithm == "sssp") {
+      spawnWorker(new algos::SSSPAlgorithm(server, userParams), std::move(msg));
+    } else if (algorithm == "pagerank") {
+      spawnWorker(new algos::PageRank(server, userParams), std::move(msg));
+    } else if (algorithm == "recoveringpagerank") {
+      spawnWorker(new algos::RecoveringPageRank(server, userParams),
+                  std::move(msg));
+    } else if (algorithm == "shortestpath") {
+      spawnWorker(new algos::ShortestPathAlgorithm(server, userParams),
+                  std::move(msg));
+    } else if (algorithm == "linerank") {
+      spawnWorker(new algos::LineRank(server, userParams), std::move(msg));
+    } else if (algorithm == "effectivecloseness") {
+      spawnWorker(new algos::EffectiveCloseness(server, userParams),
+                  std::move(msg));
+    } else if (algorithm == "connectedcomponents") {
+      spawnWorker(new algos::ConnectedComponents(server, userParams),
+                  std::move(msg));
+    } else if (algorithm == "scc") {
+      spawnWorker(new algos::SCC(server, userParams), std::move(msg));
+    } else if (algorithm == "hits") {
+      spawnWorker(new algos::HITS(server, userParams), std::move(msg));
+    } else if (algorithm == "hitskleinberg") {
+      spawnWorker(new algos::HITSKleinberg(server, userParams), std::move(msg));
+    } else if (algorithm == "labelpropagation") {
+      spawnWorker(new algos::LabelPropagation(server, userParams),
+                  std::move(msg));
+    } else if (algorithm == "slpa") {
+      spawnWorker(new algos::SLPA(server, userParams), std::move(msg));
+    } else if (algorithm == "dmid") {
+      spawnWorker(new algos::DMID(server, userParams), std::move(msg));
+    } else if (algorithm == "wcc") {
+      spawnWorker(new algos::WCC(server, userParams), std::move(msg));
+    } else if (algorithm == "colorpropagation") {
+      spawnWorker(new algos::ColorPropagation(server, userParams),
+                  std::move(msg));
+    }
+#if defined(ARANGODB_ENABLE_MAINTAINER_MODE)
+    else if (algorithm == "readwrite") {
+      spawnWorker(new algos::ReadWrite(server, userParams), std::move(msg));
+    } else {
+#endif
+      this->template dispatch<conductor::message::ConductorMessages>(
+          msg.conductor, ResultT<conductor::message::WorkerCreated>::error(
+                             TRI_ERROR_BAD_PARAMETER, "Unsupported algorithm"));
+    }
+  }
+
   auto operator()(message::SpawnWorker msg) -> std::unique_ptr<SpawnState> {
     LOG_TOPIC("2452c", INFO, Logger::PREGEL)
         << "Spawn Actor: Spawn worker actor";
-    this->template spawn<worker::WorkerActor>(
-        std::make_unique<worker::WorkerState>(
-            msg.conductor, msg.message.executionSpecifications,
-            msg.message.collectionSpecifications),
-        worker::message::WorkerStart{});
+    spawnWorker(std::move(msg));
     return std::move(this->state);
   }
 

--- a/arangod/Pregel/Worker/Actor.h
+++ b/arangod/Pregel/Worker/Actor.h
@@ -28,11 +28,12 @@
 
 namespace arangodb::pregel::worker {
 
+template<typename V, typename E, typename M>
 struct WorkerActor {
-  using State = WorkerState;
+  using State = WorkerState<V, E, M>;
   using Message = message::WorkerMessages;
   template<typename Runtime>
-  using Handler = WorkerHandler<Runtime>;
+  using Handler = WorkerHandler<V, E, M, Runtime>;
   static constexpr auto typeName() -> std::string_view { return "WorkerActor"; }
 };
 

--- a/arangod/Pregel/Worker/State.h
+++ b/arangod/Pregel/Worker/State.h
@@ -23,32 +23,42 @@
 #pragma once
 
 #include "Actor/ActorPID.h"
+#include "Pregel/Algorithm.h"
 #include "Pregel/CollectionSpecifications.h"
 #include "Pregel/PregelOptions.h"
+#include "Utils/DatabaseGuard.h"
+#include "VocBase/vocbase.h"
 
 namespace arangodb::pregel::worker {
 
+template<typename V, typename E, typename M>
 struct WorkerState {
   WorkerState(actor::ActorPID conductor,
               ExecutionSpecifications executionSpecifications,
-              CollectionSpecifications collectionSpecifications)
+              CollectionSpecifications collectionSpecifications,
+              Algorithm<V, E, M>* algorithm, TRI_vocbase_t& vocbase)
       : conductor{std::move(conductor)},
         executionSpecifications{std::move(executionSpecifications)},
-        collectionSpecifications{std::move(collectionSpecifications)} {};
+        collectionSpecifications{std::move(collectionSpecifications)},
+        algorithm{algorithm},
+        vocbaseGuard{vocbase} {};
   actor::ActorPID conductor;
   const ExecutionSpecifications executionSpecifications;
   const CollectionSpecifications collectionSpecifications;
+  std::unique_ptr<Algorithm<V, E, M>> algorithm;
+  const DatabaseGuard vocbaseGuard;
 };
-template<typename Inspector>
-auto inspect(Inspector& f, WorkerState& x) {
+template<typename V, typename E, typename M, typename Inspector>
+auto inspect(Inspector& f, WorkerState<V, E, M>& x) {
   return f.object(x).fields(
       f.field("conductor", x.conductor),
       f.field("executionSpecifications", x.executionSpecifications),
-      f.field("collectionSpecifications", x.collectionSpecifications));
+      f.field("collectionSpecifications", x.collectionSpecifications),
+      f.field("algorithm", x.algorithm->name()));
 }
 
 }  // namespace arangodb::pregel::worker
 
-template<>
-struct fmt::formatter<arangodb::pregel::worker::WorkerState>
+template<typename V, typename E, typename M>
+struct fmt::formatter<arangodb::pregel::worker::WorkerState<V, E, M>>
     : arangodb::inspection::inspection_formatter {};

--- a/tests/Pregel/ConductorStateTest.cpp
+++ b/tests/Pregel/ConductorStateTest.cpp
@@ -74,7 +74,7 @@ TEST(ConductorStateTest,
   std::vector<std::string> emptyServers{};
   auto cState = ConductorState(ExecutionSpecifications(),
                                std::make_unique<LookupInfoMock>(emptyServers));
-  ASSERT_EQ(cState._executionState->name(), "initial");
+  ASSERT_EQ(cState.executionState->name(), "initial");
 }
 
 TEST(CreateWorkersStateTest, creates_as_many_messages_as_required_servers) {
@@ -116,7 +116,7 @@ TEST(CreateWorkersStateTest, creates_worker_pids_from_received_messages) {
         created);
   }
 
-  ASSERT_EQ(cState._workers.size(), servers.size());
+  ASSERT_EQ(cState.workers.size(), servers.size());
   // for (auto const& serverID : servers) {
   //  TODO check also if proper PIDs are inserted here
   //   enable as soon as _workers ar a std::set instead of a std::vector


### PR DESCRIPTION
This PR makes it possible to create a MasterContext for every Algorithm running in Pregel.
Before, only some algorithms used the MasterContext, the others used member variables in the Conductor (e.g. `_totalVerticesCount`, _`totalEdgesCount` or `_aggregators`) to keep track of the status of the computation. The MasterContext keeps also track of these variables, therefore it makes sense to unify the algorithms and use MasterContext for all algorithms.