### PR TITLE
[CINFRA-699] Call acquireSnapshot after becomeFollower

### DIFF
--- a/arangod/Replication2/ReplicatedLog/Components/LogFollower.cpp
+++ b/arangod/Replication2/ReplicatedLog/Components/LogFollower.cpp
@@ -111,6 +111,8 @@ FollowerManager::FollowerManager(
   metrics->replicatedLogFollowerNumber->operator++();
   auto provider = std::make_unique<MethodsProvider>(*this);
   stateHandle->becomeFollower(std::move(provider));
+  // Follower state manager is there, now get a snapshot if we need one.
+  snapshot->acquireSnapshotIfNecessary();
 }
 
 FollowerManager::~FollowerManager() {

--- a/arangod/Replication2/ReplicatedLog/Components/SnapshotManager.cpp
+++ b/arangod/Replication2/ReplicatedLog/Components/SnapshotManager.cpp
@@ -101,9 +101,7 @@ SnapshotManager::SnapshotManager(
       termInfo(std::move(termInfo)),
       loggerContext(
           loggerContext.with<logContextKeyLogComponent>("snapshot-man")),
-      guardedData(storage, stateHandle) {
-  acquireSnapshotIfNecessary();
-}
+      guardedData(storage, stateHandle) {}
 
 void SnapshotManager::acquireSnapshotIfNecessary() {
   auto guard = guardedData.getLockedGuard();

--- a/arangod/Replication2/ReplicatedLog/Components/SnapshotManager.cpp
+++ b/arangod/Replication2/ReplicatedLog/Components/SnapshotManager.cpp
@@ -102,14 +102,18 @@ SnapshotManager::SnapshotManager(
       loggerContext(
           loggerContext.with<logContextKeyLogComponent>("snapshot-man")),
       guardedData(storage, stateHandle) {
+  acquireSnapshotIfNecessary();
+}
+
+void SnapshotManager::acquireSnapshotIfNecessary() {
   auto guard = guardedData.getLockedGuard();
-  if (this->termInfo->leader.has_value() and
-      guard->state == SnapshotState::MISSING) {
+  if (termInfo->leader.has_value() and guard->state == SnapshotState::MISSING) {
     auto version = ++guard->lastSnapshotVersion;
+    auto& stateHandle = guard->stateHandle;
     guard.unlock();
     LOG_CTX("5426a", INFO, loggerContext)
         << "detected missing snapshot - acquire new one";
-    stateHandle.acquireSnapshot(*this->termInfo->leader, version);
+    stateHandle.acquireSnapshot(*termInfo->leader, version);
   }
 }
 

--- a/arangod/Replication2/ReplicatedLog/Components/SnapshotManager.h
+++ b/arangod/Replication2/ReplicatedLog/Components/SnapshotManager.h
@@ -42,11 +42,12 @@ struct SnapshotManager : ISnapshotManager {
       std::shared_ptr<FollowerTermInformation const> termInfo,
       std::shared_ptr<ILeaderCommunicator> leaderComm,
       LoggerContext const& loggerContext);
-  // should be called once after construction
-  void acquireSnapshotIfNecessary();
 
   auto invalidateSnapshotState() -> Result override;
   auto checkSnapshotState() noexcept -> SnapshotState override;
+
+  // should be called once after construction
+  void acquireSnapshotIfNecessary();
 
   auto setSnapshotStateAvailable(MessageId msgId, std::uint64_t version)
       -> Result;

--- a/arangod/Replication2/ReplicatedLog/Components/SnapshotManager.h
+++ b/arangod/Replication2/ReplicatedLog/Components/SnapshotManager.h
@@ -42,6 +42,9 @@ struct SnapshotManager : ISnapshotManager {
       std::shared_ptr<FollowerTermInformation const> termInfo,
       std::shared_ptr<ILeaderCommunicator> leaderComm,
       LoggerContext const& loggerContext);
+  // should be called once after construction
+  void acquireSnapshotIfNecessary();
+
   auto invalidateSnapshotState() -> Result override;
   auto checkSnapshotState() noexcept -> SnapshotState override;
 

--- a/tests/Replication2/ReplicatedLog/Components/SnapshotManagerTest.cpp
+++ b/tests/Replication2/ReplicatedLog/Components/SnapshotManagerTest.cpp
@@ -128,8 +128,9 @@ TEST_F(SnapshotManagerTest, create_with_invalid_snapshot) {
     return state;
   });
 
-  EXPECT_CALL(stateHandleManagerMock, acquireSnapshot("LEADER", 1));
   auto snapMan = constructSnapshotManager();
+  EXPECT_CALL(stateHandleManagerMock, acquireSnapshot("LEADER", 1));
+  snapMan->acquireSnapshotIfNecessary();
 }
 
 TEST_F(SnapshotManagerTest, invalidate_snapshot) {


### PR DESCRIPTION
### Scope & Purpose

The LogFollower calls becomeFollower() on the state handle in its constructor. But the snapshot manager is constructed before that, which in turn called acquireSnapshot() on that state handle. However, the acquireSnapshot call must be delegated to the FollowerStateManager, which is constructed only during becomeFollower. This PR fixes that order.