### PR TITLE
Upload test results even if test fails

### DIFF
--- a/.circleci/base_config.yml
+++ b/.circleci/base_config.yml
@@ -167,6 +167,7 @@ jobs:
               --definition tests/test-definitions.txt
       - run:
           name: Copy test results
+          when: always
           command: |
             mkdir test-results
             find testrun -iname *xml -exec cp "{}" --target-directory=./test-results \;


### PR DESCRIPTION
### Scope & Purpose

CircleCI executes the steps in a test one at a time, but by default skips remaining steps on failure.

The `when` attribute ensures we upload test results (if they are available).