### PR TITLE
[GORDO-1557] Improve some pregel algorithms code

### DIFF
--- a/arangod/Pregel/AlgoRegistry.cpp
+++ b/arangod/Pregel/AlgoRegistry.cpp
@@ -91,6 +91,47 @@ IAlgorithm* AlgoRegistry::createAlgorithm(std::string const& algorithm,
   }
   return nullptr;
 }
+auto AlgoRegistry::createAlgorithmNew(std::string const& algorithm,
+                                      VPackSlice userParams)
+    -> std::optional<std::unique_ptr<IAlgorithm>> {
+  if (algorithm == "sssp") {
+    return std::make_unique<algos::SSSPAlgorithm>(userParams);
+  } else if (algorithm == "pagerank") {
+    return std::make_unique<algos::PageRank>(userParams);
+  } else if (algorithm == "recoveringpagerank") {
+    return std::make_unique<algos::RecoveringPageRank>(userParams);
+  } else if (algorithm == "shortestpath") {
+    return std::make_unique<algos::ShortestPathAlgorithm>(userParams);
+  } else if (algorithm == "linerank") {
+    return std::make_unique<algos::LineRank>(userParams);
+  } else if (algorithm == "effectivecloseness") {
+    return std::make_unique<algos::EffectiveCloseness>(userParams);
+  } else if (algorithm == "connectedcomponents") {
+    return std::make_unique<algos::ConnectedComponents>(userParams);
+  } else if (algorithm == "scc") {
+    return std::make_unique<algos::SCC>(userParams);
+  } else if (algorithm == "hits") {
+    return std::make_unique<algos::HITS>(userParams);
+  } else if (algorithm == "hitskleinberg") {
+    return std::make_unique<algos::HITSKleinberg>(userParams);
+  } else if (algorithm == "labelpropagation") {
+    return std::make_unique<algos::LabelPropagation>(userParams);
+  } else if (algorithm == "slpa") {
+    return std::make_unique<algos::SLPA>(userParams);
+  } else if (algorithm == "dmid") {
+    return std::make_unique<algos::DMID>(userParams);
+  } else if (algorithm == "wcc") {
+    return std::make_unique<algos::WCC>(userParams);
+  } else if (algorithm == "colorpropagation") {
+    return std::make_unique<algos::ColorPropagation>(userParams);
+  }
+#if defined(ARANGODB_ENABLE_MAINTAINER_MODE)
+  else if (algorithm == "readwrite") {
+    return std::make_unique<algos::ReadWrite>(userParams);
+  }
+#endif
+  return std::nullopt;
+}
 
 template<typename V, typename E, typename M>
 std::shared_ptr<IWorker> AlgoRegistry::createWorker(

--- a/arangod/Pregel/AlgoRegistry.h
+++ b/arangod/Pregel/AlgoRegistry.h
@@ -41,6 +41,9 @@ struct AlgoRegistry {
   static std::shared_ptr<IWorker> createWorker(TRI_vocbase_t& vocbase,
                                                CreateWorker const& parameters,
                                                PregelFeature& feature);
+  static auto createAlgorithmNew(std::string const& algorithm,
+                                 VPackSlice userParams)
+      -> std::optional<std::unique_ptr<IAlgorithm>>;
 
  private:
   template<typename V, typename E, typename M>

--- a/arangod/Pregel/Algorithm.h
+++ b/arangod/Pregel/Algorithm.h
@@ -61,15 +61,7 @@ struct IAlgorithm {
     return nullptr;
   }
 
-  // ============= Configure runtime parameters ============
-
-  [[nodiscard]] std::string const& name() const { return _name; }
-
- protected:
-  explicit IAlgorithm(std::string name) : _name(std::move(name)) {}
-
- private:
-  std::string _name;
+  [[nodiscard]] virtual auto name() const -> std::string_view = 0;
 };
 
 // specify serialization, whatever
@@ -120,9 +112,6 @@ struct Algorithm : IAlgorithm {
       return msgsPerSec > 250.0 ? (uint32_t)msgsPerSec : 250;
     }
   }
-
- protected:
-  Algorithm(std::string const& name) : IAlgorithm(name) {}
 };
 
 template<typename V, typename E, typename M>
@@ -130,8 +119,7 @@ class SimpleAlgorithm : public Algorithm<V, E, M> {
  protected:
   std::string _sourceField, _resultField;
 
-  SimpleAlgorithm(std::string const& name, VPackSlice userParams)
-      : Algorithm<V, E, M>(name) {
+  SimpleAlgorithm(VPackSlice userParams) {
     arangodb::velocypack::Slice field = userParams.get("sourceField");
     _sourceField = field.isString() ? field.copyString() : "value";
     field = userParams.get("resultField");

--- a/arangod/Pregel/Algorithm.h
+++ b/arangod/Pregel/Algorithm.h
@@ -56,10 +56,15 @@ struct IAlgorithm {
     return nullptr;
   }
 
-  [[nodiscard]] virtual MasterContext* masterContext(
-      arangodb::velocypack::Slice userParams) const {
-    return nullptr;
-  }
+  [[nodiscard]] virtual auto masterContext(
+      std::unique_ptr<AggregatorHandler> aggregators,
+      arangodb::velocypack::Slice userParams) const -> MasterContext* = 0;
+
+  [[nodiscard]] virtual auto masterContextUnique(
+      uint64_t vertexCount, uint64_t edgeCount,
+      std::unique_ptr<AggregatorHandler> aggregators,
+      arangodb::velocypack::Slice userParams) const
+      -> std::unique_ptr<MasterContext> = 0;
 
   [[nodiscard]] virtual auto name() const -> std::string_view = 0;
 };

--- a/arangod/Pregel/Algos/ColorPropagation/ColorPropagation.cpp
+++ b/arangod/Pregel/Algos/ColorPropagation/ColorPropagation.cpp
@@ -24,12 +24,14 @@
 #include "ColorPropagation.h"
 #include <atomic>
 #include <climits>
+#include <memory>
 #include <utility>
 #include "Cluster/ClusterInfo.h"
 #include "Cluster/ServerState.h"
 #include "Pregel/Aggregator.h"
 #include "Pregel/Algorithm.h"
 #include "Pregel/IncomingCache.h"
+#include "Pregel/MasterContext.h"
 
 using namespace arangodb;
 using namespace arangodb::pregel;
@@ -99,6 +101,25 @@ ColorPropagation::createComputation(
 
 WorkerContext* ColorPropagation::workerContext(VPackSlice userParams) const {
   return new ColorPropagationWorkerContext(_maxGss, _numColors);
+}
+
+struct ColorPropagationMasterContext : public MasterContext {
+  ColorPropagationMasterContext(uint64_t vertexCount, uint64_t edgeCount,
+                                std::unique_ptr<AggregatorHandler> aggregators)
+      : MasterContext(vertexCount, edgeCount, std::move(aggregators)){};
+};
+[[nodiscard]] auto ColorPropagation::masterContext(
+    std::unique_ptr<AggregatorHandler> aggregators,
+    arangodb::velocypack::Slice userParams) const -> MasterContext* {
+  return new ColorPropagationMasterContext(0, 0, std::move(aggregators));
+}
+[[nodiscard]] auto ColorPropagation::masterContextUnique(
+    uint64_t vertexCount, uint64_t edgeCount,
+    std::unique_ptr<AggregatorHandler> aggregators,
+    arangodb::velocypack::Slice userParams) const
+    -> std::unique_ptr<MasterContext> {
+  return std::make_unique<ColorPropagationMasterContext>(
+      vertexCount, edgeCount, std::move(aggregators));
 }
 
 ColorPropagationWorkerContext::ColorPropagationWorkerContext(uint64_t maxGss,

--- a/arangod/Pregel/Algos/ColorPropagation/ColorPropagation.h
+++ b/arangod/Pregel/Algos/ColorPropagation/ColorPropagation.h
@@ -97,6 +97,12 @@ namespace arangodb::pregel::algos {
  *    - send the new colors to all successors outside our own collection.
  */
 
+struct ColorPropagationType {
+  using Vertex = ColorPropagationValue;
+  using Edge = int8_t;
+  using Message = ColorPropagationMessageValue;
+};
+
 struct ColorPropagation : public Algorithm<ColorPropagationValue, int8_t,
                                            ColorPropagationMessageValue> {
  public:

--- a/arangod/Pregel/Algos/ColorPropagation/ColorPropagation.h
+++ b/arangod/Pregel/Algos/ColorPropagation/ColorPropagation.h
@@ -131,6 +131,15 @@ struct ColorPropagation : public Algorithm<ColorPropagationValue, int8_t,
   [[nodiscard]] WorkerContext* workerContext(
       VPackSlice userParams) const override;
 
+  [[nodiscard]] auto masterContext(
+      std::unique_ptr<AggregatorHandler> aggregators,
+      arangodb::velocypack::Slice userParams) const -> MasterContext* override;
+  [[nodiscard]] auto masterContextUnique(
+      uint64_t vertexCount, uint64_t edgeCount,
+      std::unique_ptr<AggregatorHandler> aggregators,
+      arangodb::velocypack::Slice userParams) const
+      -> std::unique_ptr<MasterContext> override;
+
   [[nodiscard]] IAggregator* aggregator(std::string const& name) const override;
 
  private:

--- a/arangod/Pregel/Algos/ColorPropagation/ColorPropagation.h
+++ b/arangod/Pregel/Algos/ColorPropagation/ColorPropagation.h
@@ -107,13 +107,15 @@ struct ColorPropagation : public Algorithm<ColorPropagationValue, int8_t,
                                            ColorPropagationMessageValue> {
  public:
   explicit ColorPropagation(VPackSlice userParams)
-      : Algorithm<ColorPropagationValue, int8_t, ColorPropagationMessageValue>(
-            "colorpropagation"),
-        _numColors{getNumColors(userParams)},
+      : _numColors{getNumColors(userParams)},
         _inputColorsFieldName(getInputColorsFieldName(userParams)),
         _outputColorsFieldName(getOutputColorsFieldName(userParams)),
         _equivalenceClassFieldName(getEquivalenceClassFieldName(userParams)),
         _maxGss{getMaxGss(userParams)} {}
+
+  [[nodiscard]] auto name() const -> std::string_view override {
+    return "colorpropagation";
+  };
 
   [[nodiscard]] GraphFormat<ColorPropagationValue, int8_t>* inputFormat()
       const override;

--- a/arangod/Pregel/Algos/ConnectedComponents/ConnectedComponents.h
+++ b/arangod/Pregel/Algos/ConnectedComponents/ConnectedComponents.h
@@ -60,5 +60,14 @@ struct ConnectedComponents
       std::shared_ptr<WorkerConfig const>) const override;
   VertexCompensation<uint64_t, uint8_t, uint64_t>* createCompensation(
       std::shared_ptr<WorkerConfig const>) const override;
+
+  [[nodiscard]] auto masterContext(
+      std::unique_ptr<AggregatorHandler> aggregators,
+      arangodb::velocypack::Slice userParams) const -> MasterContext* override;
+  [[nodiscard]] auto masterContextUnique(
+      uint64_t vertexCount, uint64_t edgeCount,
+      std::unique_ptr<AggregatorHandler> aggregators,
+      arangodb::velocypack::Slice userParams) const
+      -> std::unique_ptr<MasterContext> override;
 };
 }  // namespace arangodb::pregel::algos

--- a/arangod/Pregel/Algos/ConnectedComponents/ConnectedComponents.h
+++ b/arangod/Pregel/Algos/ConnectedComponents/ConnectedComponents.h
@@ -42,7 +42,11 @@ struct ConnectedComponents
     : public SimpleAlgorithm<uint64_t, uint8_t, uint64_t> {
  public:
   explicit ConnectedComponents(VPackSlice userParams)
-      : SimpleAlgorithm("connectedcomponents", userParams) {}
+      : SimpleAlgorithm(userParams) {}
+
+  [[nodiscard]] auto name() const -> std::string_view override {
+    return "connectedcomponents";
+  };
 
   GraphFormat<uint64_t, uint8_t>* inputFormat() const override;
 

--- a/arangod/Pregel/Algos/ConnectedComponents/ConnectedComponents.h
+++ b/arangod/Pregel/Algos/ConnectedComponents/ConnectedComponents.h
@@ -27,6 +27,12 @@
 
 namespace arangodb::pregel::algos {
 
+struct ConnectedComponentsType {
+  using Vertex = uint64_t;
+  using Edge = uint8_t;
+  using Message = uint64_t;
+};
+
 /// The idea behind the algorithm is very simple: propagate the smallest
 /// vertex id along the edges to all vertices of a connected component. The
 /// number of supersteps necessary is equal to the length of the maximum

--- a/arangod/Pregel/Algos/DMID/DMID.cpp
+++ b/arangod/Pregel/Algos/DMID/DMID.cpp
@@ -663,7 +663,10 @@ GraphFormat<DMIDValue, float>* DMID::inputFormat() const {
 }
 
 struct DMIDMasterContext : public MasterContext {
-  DMIDMasterContext() {}  // TODO use _threshold
+  DMIDMasterContext(uint64_t vertexCount, uint64_t edgeCount,
+                    std::unique_ptr<AggregatorHandler> aggregators)
+      : MasterContext(vertexCount, edgeCount, std::move(aggregators)) {
+  }  // TODO use _threshold
 
   void preGlobalSuperstep() override {
     /**
@@ -781,8 +784,18 @@ struct DMIDMasterContext : public MasterContext {
   }
 };
 
-MasterContext* DMID::masterContext(VPackSlice userParams) const {
-  return new DMIDMasterContext();
+[[nodiscard]] auto DMID::masterContext(
+    std::unique_ptr<AggregatorHandler> aggregators,
+    arangodb::velocypack::Slice userParams) const -> MasterContext* {
+  return new DMIDMasterContext(0, 0, std::move(aggregators));
+}
+[[nodiscard]] auto DMID::masterContextUnique(
+    uint64_t vertexCount, uint64_t edgeCount,
+    std::unique_ptr<AggregatorHandler> aggregators,
+    arangodb::velocypack::Slice userParams) const
+    -> std::unique_ptr<MasterContext> {
+  return std::make_unique<DMIDMasterContext>(vertexCount, edgeCount,
+                                             std::move(aggregators));
 }
 
 IAggregator* DMID::aggregator(std::string const& name) const {

--- a/arangod/Pregel/Algos/DMID/DMID.h
+++ b/arangod/Pregel/Algos/DMID/DMID.h
@@ -44,13 +44,17 @@ struct DMID : public SimpleAlgorithm<DMIDValue, float, DMIDMessage> {
 
  public:
   explicit DMID(VPackSlice userParams)
-      : SimpleAlgorithm<DMIDValue, float, DMIDMessage>("DMID", userParams) {
+      : SimpleAlgorithm<DMIDValue, float, DMIDMessage>(userParams) {
     arangodb::velocypack::Slice val = userParams.get("maxCommunities");
     if (val.isInteger()) {
       _maxCommunities = (unsigned)std::min(
           (uint64_t)32, std::max(val.getUInt(), (uint64_t)0));
     }
   }
+
+  [[nodiscard]] auto name() const -> std::string_view override {
+    return "DMID";
+  };
 
   GraphFormat<DMIDValue, float>* inputFormat() const override;
   MessageFormat<DMIDMessage>* messageFormat() const override;

--- a/arangod/Pregel/Algos/DMID/DMID.h
+++ b/arangod/Pregel/Algos/DMID/DMID.h
@@ -62,7 +62,14 @@ struct DMID : public SimpleAlgorithm<DMIDValue, float, DMIDMessage> {
   VertexComputation<DMIDValue, float, DMIDMessage>* createComputation(
       std::shared_ptr<WorkerConfig const>) const override;
 
-  MasterContext* masterContext(VPackSlice userParams) const override;
+  [[nodiscard]] auto masterContext(
+      std::unique_ptr<AggregatorHandler> aggregators,
+      arangodb::velocypack::Slice userParams) const -> MasterContext* override;
+  [[nodiscard]] auto masterContextUnique(
+      uint64_t vertexCount, uint64_t edgeCount,
+      std::unique_ptr<AggregatorHandler> aggregators,
+      arangodb::velocypack::Slice userParams) const
+      -> std::unique_ptr<MasterContext> override;
 
   IAggregator* aggregator(std::string const& name) const override;
 };

--- a/arangod/Pregel/Algos/DMID/DMID.h
+++ b/arangod/Pregel/Algos/DMID/DMID.h
@@ -32,6 +32,13 @@ namespace pregel {
 namespace algos {
 
 /// https://github.com/Rofti/DMID
+
+struct DMIDType {
+  using Vertex = DMIDValue;
+  using Edge = float;
+  using Message = DMIDMessage;
+};
+
 struct DMID : public SimpleAlgorithm<DMIDValue, float, DMIDMessage> {
   unsigned _maxCommunities = 1;
 

--- a/arangod/Pregel/Algos/EffectiveCloseness/EffectiveCloseness.cpp
+++ b/arangod/Pregel/Algos/EffectiveCloseness/EffectiveCloseness.cpp
@@ -22,6 +22,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #include "EffectiveCloseness.h"
+#include <memory>
 #include "Pregel/Aggregator.h"
 #include "Pregel/Algorithm.h"
 #include "Pregel/Algos/EffectiveCloseness/HLLCounterFormat.h"
@@ -126,4 +127,24 @@ struct ECGraphFormat : public GraphFormat<ECValue, int8_t> {
 
 GraphFormat<ECValue, int8_t>* EffectiveCloseness::inputFormat() const {
   return new ECGraphFormat(_resultField);
+}
+
+struct EffectiveClosenessMasterContext : public MasterContext {
+  EffectiveClosenessMasterContext(
+      uint64_t vertexCount, uint64_t edgeCount,
+      std::unique_ptr<AggregatorHandler> aggregators)
+      : MasterContext(vertexCount, edgeCount, std::move(aggregators)){};
+};
+[[nodiscard]] auto EffectiveCloseness::masterContext(
+    std::unique_ptr<AggregatorHandler> aggregators,
+    arangodb::velocypack::Slice userParams) const -> MasterContext* {
+  return new EffectiveClosenessMasterContext(0, 0, std::move(aggregators));
+}
+[[nodiscard]] auto EffectiveCloseness::masterContextUnique(
+    uint64_t vertexCount, uint64_t edgeCount,
+    std::unique_ptr<AggregatorHandler> aggregators,
+    arangodb::velocypack::Slice userParams) const
+    -> std::unique_ptr<MasterContext> {
+  return std::make_unique<EffectiveClosenessMasterContext>(
+      vertexCount, edgeCount, std::move(aggregators));
 }

--- a/arangod/Pregel/Algos/EffectiveCloseness/EffectiveCloseness.h
+++ b/arangod/Pregel/Algos/EffectiveCloseness/EffectiveCloseness.h
@@ -31,6 +31,12 @@ namespace arangodb {
 namespace pregel {
 namespace algos {
 
+struct EffectiveClosenessType {
+  using Vertex = ECValue;
+  using Edge = int8_t;
+  using Message = HLLCounter;
+};
+
 /// Effective Closeness
 struct EffectiveCloseness
     : public SimpleAlgorithm<ECValue, int8_t, HLLCounter> {

--- a/arangod/Pregel/Algos/EffectiveCloseness/EffectiveCloseness.h
+++ b/arangod/Pregel/Algos/EffectiveCloseness/EffectiveCloseness.h
@@ -53,6 +53,15 @@ struct EffectiveCloseness
 
   VertexComputation<ECValue, int8_t, HLLCounter>* createComputation(
       std::shared_ptr<WorkerConfig const>) const override;
+
+  [[nodiscard]] auto masterContext(
+      std::unique_ptr<AggregatorHandler> aggregators,
+      arangodb::velocypack::Slice userParams) const -> MasterContext* override;
+  [[nodiscard]] auto masterContextUnique(
+      uint64_t vertexCount, uint64_t edgeCount,
+      std::unique_ptr<AggregatorHandler> aggregators,
+      arangodb::velocypack::Slice userParams) const
+      -> std::unique_ptr<MasterContext> override;
 };
 }  // namespace algos
 }  // namespace pregel

--- a/arangod/Pregel/Algos/EffectiveCloseness/EffectiveCloseness.h
+++ b/arangod/Pregel/Algos/EffectiveCloseness/EffectiveCloseness.h
@@ -41,8 +41,11 @@ struct EffectiveClosenessType {
 struct EffectiveCloseness
     : public SimpleAlgorithm<ECValue, int8_t, HLLCounter> {
   explicit EffectiveCloseness(VPackSlice params)
-      : SimpleAlgorithm<ECValue, int8_t, HLLCounter>("effectivecloseness",
-                                                     params) {}
+      : SimpleAlgorithm<ECValue, int8_t, HLLCounter>(params) {}
+
+  [[nodiscard]] auto name() const -> std::string_view override {
+    return "effectivecloseness";
+  };
 
   GraphFormat<ECValue, int8_t>* inputFormat() const override;
   MessageFormat<HLLCounter>* messageFormat() const override;

--- a/arangod/Pregel/Algos/HITS/HITS.cpp
+++ b/arangod/Pregel/Algos/HITS/HITS.cpp
@@ -137,7 +137,12 @@ struct HITSMasterContext : public MasterContext {
   // and could be unified, but
   // (1) we are going to refactor it anyway
   // (2) this would introduce common code for different algorithms
-  HITSMasterContext(VPackSlice userParams) : authNorm(0), hubNorm(0) {
+  HITSMasterContext(uint64_t vertexCount, uint64_t edgeCount,
+                    std::unique_ptr<AggregatorHandler> aggregators,
+                    VPackSlice userParams)
+      : MasterContext(vertexCount, edgeCount, std::move(aggregators)),
+        authNorm(0),
+        hubNorm(0) {
     if (userParams.hasKey(Utils::threshold)) {
       if (!userParams.get(Utils::threshold).isNumber()) {
         THROW_ARANGO_EXCEPTION_MESSAGE(
@@ -164,8 +169,18 @@ struct HITSMasterContext : public MasterContext {
   }
 };
 
-MasterContext* HITS::masterContext(VPackSlice userParams) const {
-  return new HITSMasterContext(userParams);
+[[nodiscard]] auto HITS::masterContext(
+    std::unique_ptr<AggregatorHandler> aggregators,
+    arangodb::velocypack::Slice userParams) const -> MasterContext* {
+  return new HITSMasterContext(0, 0, std::move(aggregators), userParams);
+}
+[[nodiscard]] auto HITS::masterContextUnique(
+    uint64_t vertexCount, uint64_t edgeCount,
+    std::unique_ptr<AggregatorHandler> aggregators,
+    arangodb::velocypack::Slice userParams) const
+    -> std::unique_ptr<MasterContext> {
+  return std::make_unique<HITSMasterContext>(
+      vertexCount, edgeCount, std::move(aggregators), userParams);
 }
 
 IAggregator* HITS::aggregator(std::string const& name) const {

--- a/arangod/Pregel/Algos/HITS/HITS.h
+++ b/arangod/Pregel/Algos/HITS/HITS.h
@@ -44,6 +44,12 @@ namespace arangodb::pregel::algos {
 /// color as you.
 ///    All nodes visited belongs to the SCC identified by the root color.
 
+struct HITSType {
+  using Vertex = HITSValue;
+  using Edge = int8_t;
+  using Message = SenderMessage<double>;
+};
+
 struct HITS : public SimpleAlgorithm<HITSValue, int8_t, SenderMessage<double>> {
  public:
   explicit HITS(VPackSlice userParams)

--- a/arangod/Pregel/Algos/HITS/HITS.h
+++ b/arangod/Pregel/Algos/HITS/HITS.h
@@ -70,8 +70,14 @@ struct HITS : public SimpleAlgorithm<HITSValue, int8_t, SenderMessage<double>> {
 
   [[nodiscard]] WorkerContext* workerContext(
       VPackSlice userParams) const override;
-  [[nodiscard]] MasterContext* masterContext(
-      VPackSlice userParams) const override;
+  [[nodiscard]] auto masterContext(
+      std::unique_ptr<AggregatorHandler> aggregators,
+      arangodb::velocypack::Slice userParams) const -> MasterContext* override;
+  [[nodiscard]] auto masterContextUnique(
+      uint64_t vertexCount, uint64_t edgeCount,
+      std::unique_ptr<AggregatorHandler> aggregators,
+      arangodb::velocypack::Slice userParams) const
+      -> std::unique_ptr<MasterContext> override;
 
   [[nodiscard]] IAggregator* aggregator(std::string const& name) const override;
 };

--- a/arangod/Pregel/Algos/HITS/HITS.h
+++ b/arangod/Pregel/Algos/HITS/HITS.h
@@ -53,8 +53,11 @@ struct HITSType {
 struct HITS : public SimpleAlgorithm<HITSValue, int8_t, SenderMessage<double>> {
  public:
   explicit HITS(VPackSlice userParams)
-      : SimpleAlgorithm<HITSValue, int8_t, SenderMessage<double>>("hits",
-                                                                  userParams) {}
+      : SimpleAlgorithm<HITSValue, int8_t, SenderMessage<double>>(userParams) {}
+
+  [[nodiscard]] auto name() const -> std::string_view override {
+    return "hits";
+  };
 
   [[nodiscard]] GraphFormat<HITSValue, int8_t>* inputFormat() const override;
   [[nodiscard]] MessageFormat<SenderMessage<double>>* messageFormat()

--- a/arangod/Pregel/Algos/HITSKleinberg/HITSKleinberg.cpp
+++ b/arangod/Pregel/Algos/HITSKleinberg/HITSKleinberg.cpp
@@ -316,8 +316,11 @@ WorkerContext* HITSKleinberg::workerContext(VPackSlice userParams) const {
 struct HITSKleinbergMasterContext : public MasterContext {
   double const threshold;
 
-  explicit HITSKleinbergMasterContext(VPackSlice userParams)
-      : threshold(getThreshold(userParams)) {}
+  explicit HITSKleinbergMasterContext(
+      uint64_t vertexCount, uint64_t edgeCount,
+      std::unique_ptr<AggregatorHandler> aggregators, VPackSlice userParams)
+      : MasterContext(vertexCount, edgeCount, std::move(aggregators)),
+        threshold(getThreshold(userParams)) {}
 
   bool postGlobalSuperstep() override {
     double const authMaxDiff =
@@ -333,8 +336,19 @@ struct HITSKleinbergMasterContext : public MasterContext {
   }
 };
 
-MasterContext* HITSKleinberg::masterContext(VPackSlice userParams) const {
-  return new HITSKleinbergMasterContext(userParams);
+[[nodiscard]] auto HITSKleinberg::masterContext(
+    std::unique_ptr<AggregatorHandler> aggregators,
+    arangodb::velocypack::Slice userParams) const -> MasterContext* {
+  return new HITSKleinbergMasterContext(0, 0, std::move(aggregators),
+                                        userParams);
+}
+[[nodiscard]] auto HITSKleinberg::masterContextUnique(
+    uint64_t vertexCount, uint64_t edgeCount,
+    std::unique_ptr<AggregatorHandler> aggregators,
+    arangodb::velocypack::Slice userParams) const
+    -> std::unique_ptr<MasterContext> {
+  return std::make_unique<HITSKleinbergMasterContext>(
+      vertexCount, edgeCount, std::move(aggregators), userParams);
 }
 
 IAggregator* HITSKleinberg::aggregator(std::string const& name) const {

--- a/arangod/Pregel/Algos/HITSKleinberg/HITSKleinberg.h
+++ b/arangod/Pregel/Algos/HITSKleinberg/HITSKleinberg.h
@@ -46,7 +46,7 @@ struct HITSKleinberg : public SimpleAlgorithm<HITSKleinbergValue, int8_t,
  public:
   HITSKleinberg(VPackSlice userParams)
       : SimpleAlgorithm<HITSKleinbergValue, int8_t, SenderMessage<double>>(
-            "HITSKleinberg", userParams) {
+            userParams) {
     if (userParams.hasKey(Utils::maxNumIterations)) {
       numIterations = userParams.get(Utils::maxNumIterations).getInt();
     }
@@ -54,6 +54,10 @@ struct HITSKleinberg : public SimpleAlgorithm<HITSKleinbergValue, int8_t,
       maxGSS = userParams.get(Utils::maxGSS).getInt();
     }
   }
+
+  [[nodiscard]] auto name() const -> std::string_view override {
+    return "HITSKleinberg";
+  };
 
   [[nodiscard]] GraphFormat<HITSKleinbergValue, int8_t>* inputFormat()
       const override;

--- a/arangod/Pregel/Algos/HITSKleinberg/HITSKleinberg.h
+++ b/arangod/Pregel/Algos/HITSKleinberg/HITSKleinberg.h
@@ -35,6 +35,12 @@
 
 namespace arangodb::pregel::algos {
 
+struct HITSKleinbergType {
+  using Vertex = HITSKleinbergValue;
+  using Edge = int8_t;
+  using Message = SenderMessage<double>;
+};
+
 struct HITSKleinberg : public SimpleAlgorithm<HITSKleinbergValue, int8_t,
                                               SenderMessage<double>> {
  public:

--- a/arangod/Pregel/Algos/HITSKleinberg/HITSKleinberg.h
+++ b/arangod/Pregel/Algos/HITSKleinberg/HITSKleinberg.h
@@ -71,8 +71,15 @@ struct HITSKleinberg : public SimpleAlgorithm<HITSKleinbergValue, int8_t,
 
   [[nodiscard]] WorkerContext* workerContext(
       VPackSlice userParams) const override;
-  [[nodiscard]] MasterContext* masterContext(
-      VPackSlice userParams) const override;
+
+  [[nodiscard]] auto masterContext(
+      std::unique_ptr<AggregatorHandler> aggregators,
+      arangodb::velocypack::Slice userParams) const -> MasterContext* override;
+  [[nodiscard]] auto masterContextUnique(
+      uint64_t vertexCount, uint64_t edgeCount,
+      std::unique_ptr<AggregatorHandler> aggregators,
+      arangodb::velocypack::Slice userParams) const
+      -> std::unique_ptr<MasterContext> override;
 
   [[nodiscard]] IAggregator* aggregator(std::string const& name) const override;
 

--- a/arangod/Pregel/Algos/LabelPropagation/LabelPropagation.cpp
+++ b/arangod/Pregel/Algos/LabelPropagation/LabelPropagation.cpp
@@ -136,3 +136,22 @@ struct LPGraphFormat : public GraphFormat<LPValue, int8_t> {
 GraphFormat<LPValue, int8_t>* LabelPropagation::inputFormat() const {
   return new LPGraphFormat(_resultField);
 }
+
+struct LabelPropagationMasterContext : public MasterContext {
+  LabelPropagationMasterContext(uint64_t vertexCount, uint64_t edgeCount,
+                                std::unique_ptr<AggregatorHandler> aggregators)
+      : MasterContext(vertexCount, edgeCount, std::move(aggregators)){};
+};
+[[nodiscard]] auto LabelPropagation::masterContext(
+    std::unique_ptr<AggregatorHandler> aggregators,
+    arangodb::velocypack::Slice userParams) const -> MasterContext* {
+  return new LabelPropagationMasterContext(0, 0, std::move(aggregators));
+}
+[[nodiscard]] auto LabelPropagation::masterContextUnique(
+    uint64_t vertexCount, uint64_t edgeCount,
+    std::unique_ptr<AggregatorHandler> aggregators,
+    arangodb::velocypack::Slice userParams) const
+    -> std::unique_ptr<MasterContext> {
+  return std::make_unique<LabelPropagationMasterContext>(
+      vertexCount, edgeCount, std::move(aggregators));
+}

--- a/arangod/Pregel/Algos/LabelPropagation/LabelPropagation.h
+++ b/arangod/Pregel/Algos/LabelPropagation/LabelPropagation.h
@@ -46,8 +46,11 @@ struct LabelPropagationType {
 struct LabelPropagation : public SimpleAlgorithm<LPValue, int8_t, uint64_t> {
  public:
   explicit LabelPropagation(VPackSlice userParams)
-      : SimpleAlgorithm<LPValue, int8_t, uint64_t>("labelpropagation",
-                                                   userParams) {}
+      : SimpleAlgorithm<LPValue, int8_t, uint64_t>(userParams) {}
+
+  [[nodiscard]] auto name() const -> std::string_view override {
+    return "labelpropagation";
+  };
 
   GraphFormat<LPValue, int8_t>* inputFormat() const override;
   MessageFormat<uint64_t>* messageFormat() const override {

--- a/arangod/Pregel/Algos/LabelPropagation/LabelPropagation.h
+++ b/arangod/Pregel/Algos/LabelPropagation/LabelPropagation.h
@@ -36,6 +36,13 @@ namespace arangodb::pregel::algos {
 /// most frequently. Tries to avoid osscilation, usually won't converge so
 /// specify a
 /// maximum superstep number.
+
+struct LabelPropagationType {
+  using Vertex = LPValue;
+  using Edge = int8_t;
+  using Message = uint64_t;
+};
+
 struct LabelPropagation : public SimpleAlgorithm<LPValue, int8_t, uint64_t> {
  public:
   explicit LabelPropagation(VPackSlice userParams)

--- a/arangod/Pregel/Algos/LabelPropagation/LabelPropagation.h
+++ b/arangod/Pregel/Algos/LabelPropagation/LabelPropagation.h
@@ -59,5 +59,14 @@ struct LabelPropagation : public SimpleAlgorithm<LPValue, int8_t, uint64_t> {
 
   VertexComputation<LPValue, int8_t, uint64_t>* createComputation(
       std::shared_ptr<WorkerConfig const>) const override;
+
+  [[nodiscard]] auto masterContext(
+      std::unique_ptr<AggregatorHandler> aggregators,
+      arangodb::velocypack::Slice userParams) const -> MasterContext* override;
+  [[nodiscard]] auto masterContextUnique(
+      uint64_t vertexCount, uint64_t edgeCount,
+      std::unique_ptr<AggregatorHandler> aggregators,
+      arangodb::velocypack::Slice userParams) const
+      -> std::unique_ptr<MasterContext> override;
 };
 }  // namespace arangodb::pregel::algos

--- a/arangod/Pregel/Algos/LineRank/LineRank.cpp
+++ b/arangod/Pregel/Algos/LineRank/LineRank.cpp
@@ -40,7 +40,7 @@ static const float RESTART_PROB = 0.15f;
 static const float EPS = 0.0000001f;
 
 LineRank::LineRank(arangodb::velocypack::Slice params)
-    : SimpleAlgorithm("linerank", params) {}
+    : SimpleAlgorithm(params) {}
 
 struct LRMasterContext : MasterContext {
   bool _stopNext = false;

--- a/arangod/Pregel/Algos/LineRank/LineRank.h
+++ b/arangod/Pregel/Algos/LineRank/LineRank.h
@@ -68,6 +68,12 @@ namespace arangodb::pregel::algos {
  * each other.
  */
 
+struct LineRankType {
+  using Vertex = float;
+  using Edge = float;
+  using Message = float;
+};
+
 struct LineRank : public SimpleAlgorithm<float, float, float> {
  public:
   explicit LineRank(arangodb::velocypack::Slice params);

--- a/arangod/Pregel/Algos/LineRank/LineRank.h
+++ b/arangod/Pregel/Algos/LineRank/LineRank.h
@@ -94,7 +94,15 @@ struct LineRank : public SimpleAlgorithm<float, float, float> {
   }
 
   WorkerContext* workerContext(velocypack::Slice params) const override;
-  MasterContext* masterContext(velocypack::Slice) const override;
+
+  [[nodiscard]] auto masterContext(
+      std::unique_ptr<AggregatorHandler> aggregators,
+      arangodb::velocypack::Slice userParams) const -> MasterContext* override;
+  [[nodiscard]] auto masterContextUnique(
+      uint64_t vertexCount, uint64_t edgeCount,
+      std::unique_ptr<AggregatorHandler> aggregators,
+      arangodb::velocypack::Slice userParams) const
+      -> std::unique_ptr<MasterContext> override;
 
   VertexComputation<float, float, float>* createComputation(
       std::shared_ptr<WorkerConfig const>) const override;

--- a/arangod/Pregel/Algos/LineRank/LineRank.h
+++ b/arangod/Pregel/Algos/LineRank/LineRank.h
@@ -78,6 +78,10 @@ struct LineRank : public SimpleAlgorithm<float, float, float> {
  public:
   explicit LineRank(arangodb::velocypack::Slice params);
 
+  [[nodiscard]] auto name() const -> std::string_view override {
+    return "linerank";
+  };
+
   GraphFormat<float, float>* inputFormat() const override {
     return new VertexGraphFormat<float, float>(_resultField, 0);
   }

--- a/arangod/Pregel/Algos/PageRank/PageRank.cpp
+++ b/arangod/Pregel/Algos/PageRank/PageRank.cpp
@@ -52,8 +52,7 @@ struct PRWorkerContext : public WorkerContext {
 };
 
 PageRank::PageRank(VPackSlice const& params)
-    : SimpleAlgorithm("pagerank", params),
-      _useSource(params.hasKey("sourceField")) {}
+    : SimpleAlgorithm(params), _useSource(params.hasKey("sourceField")) {}
 
 /// will use a seed value for pagerank if available
 struct SeededPRGraphFormat final : public NumberGraphFormat<float, float> {

--- a/arangod/Pregel/Algos/PageRank/PageRank.h
+++ b/arangod/Pregel/Algos/PageRank/PageRank.h
@@ -38,6 +38,10 @@ struct PageRankType {
 struct PageRank : public SimpleAlgorithm<float, float, float> {
   explicit PageRank(arangodb::velocypack::Slice const& params);
 
+  [[nodiscard]] auto name() const -> std::string_view override {
+    return "pagerank";
+  };
+
   GraphFormat<float, float>* inputFormat() const override;
 
   MessageFormat<float>* messageFormat() const override {

--- a/arangod/Pregel/Algos/PageRank/PageRank.h
+++ b/arangod/Pregel/Algos/PageRank/PageRank.h
@@ -57,7 +57,14 @@ struct PageRank : public SimpleAlgorithm<float, float, float> {
 
   WorkerContext* workerContext(VPackSlice userParams) const override;
 
-  MasterContext* masterContext(VPackSlice userParams) const override;
+  [[nodiscard]] auto masterContext(
+      std::unique_ptr<AggregatorHandler> aggregators,
+      arangodb::velocypack::Slice userParams) const -> MasterContext* override;
+  [[nodiscard]] auto masterContextUnique(
+      uint64_t vertexCount, uint64_t edgeCount,
+      std::unique_ptr<AggregatorHandler> aggregators,
+      arangodb::velocypack::Slice userParams) const
+      -> std::unique_ptr<MasterContext> override;
 
   IAggregator* aggregator(std::string const& name) const override;
 

--- a/arangod/Pregel/Algos/PageRank/PageRank.h
+++ b/arangod/Pregel/Algos/PageRank/PageRank.h
@@ -28,6 +28,12 @@
 
 namespace arangodb::pregel::algos {
 
+struct PageRankType {
+  using Vertex = float;
+  using Edge = float;
+  using Message = float;
+};
+
 /// PageRank
 struct PageRank : public SimpleAlgorithm<float, float, float> {
   explicit PageRank(arangodb::velocypack::Slice const& params);

--- a/arangod/Pregel/Algos/ReadWrite/ReadWrite.cpp
+++ b/arangod/Pregel/Algos/ReadWrite/ReadWrite.cpp
@@ -42,7 +42,7 @@ struct ReadWriteWorkerContext : public WorkerContext {
 };
 
 ReadWrite::ReadWrite(VPackSlice const& userParams)
-    : SimpleAlgorithm("readwrite", userParams) {}
+    : SimpleAlgorithm(userParams) {}
 
 struct ReadWriteGraphFormat final : public GraphFormat<V, E> {
   ReadWriteGraphFormat(std::string sourceFieldName, std::string resultFieldName)

--- a/arangod/Pregel/Algos/ReadWrite/ReadWrite.cpp
+++ b/arangod/Pregel/Algos/ReadWrite/ReadWrite.cpp
@@ -107,7 +107,10 @@ WorkerContext* ReadWrite::workerContext(VPackSlice userParams) const {
 
 struct ReadWriteMasterContext : public MasterContext {
   size_t maxGss;
-  explicit ReadWriteMasterContext(VPackSlice userParams) {
+  explicit ReadWriteMasterContext(
+      uint64_t vertexCount, uint64_t edgeCount,
+      std::unique_ptr<AggregatorHandler> aggregators, VPackSlice userParams)
+      : MasterContext(vertexCount, edgeCount, std::move(aggregators)) {
     auto value = userParams.get(Utils::maxGSS);
     if (not value.isNone()) {
       maxGss = value.getInt();
@@ -117,8 +120,18 @@ struct ReadWriteMasterContext : public MasterContext {
   bool postGlobalSuperstep() override { return globalSuperstep() <= maxGss; };
 };
 
-MasterContext* ReadWrite::masterContext(VPackSlice userParams) const {
-  return new ReadWriteMasterContext(userParams);
+[[nodiscard]] auto ReadWrite::masterContext(
+    std::unique_ptr<AggregatorHandler> aggregators,
+    arangodb::velocypack::Slice userParams) const -> MasterContext* {
+  return new ReadWriteMasterContext(0, 0, std::move(aggregators), userParams);
+}
+[[nodiscard]] auto ReadWrite::masterContextUnique(
+    uint64_t vertexCount, uint64_t edgeCount,
+    std::unique_ptr<AggregatorHandler> aggregators,
+    arangodb::velocypack::Slice userParams) const
+    -> std::unique_ptr<MasterContext> {
+  return std::make_unique<ReadWriteMasterContext>(
+      vertexCount, edgeCount, std::move(aggregators), userParams);
 }
 
 IAggregator* ReadWrite::aggregator(std::string const& name) const {

--- a/arangod/Pregel/Algos/ReadWrite/ReadWrite.h
+++ b/arangod/Pregel/Algos/ReadWrite/ReadWrite.h
@@ -28,6 +28,12 @@
 
 namespace arangodb::pregel::algos {
 
+struct ReadWriteType {
+  using Vertex = float;
+  using Edge = uint8_t;
+  using Message = float;
+};
+
 using V = float;  // need to simulate MaxAggregator
 using E = uint8_t;
 

--- a/arangod/Pregel/Algos/ReadWrite/ReadWrite.h
+++ b/arangod/Pregel/Algos/ReadWrite/ReadWrite.h
@@ -60,8 +60,14 @@ struct ReadWrite : public SimpleAlgorithm<V, E, V> {
   [[nodiscard]] WorkerContext* workerContext(
       VPackSlice userParams) const override;
 
-  [[nodiscard]] MasterContext* masterContext(
-      VPackSlice userParams) const override;
+  [[nodiscard]] auto masterContext(
+      std::unique_ptr<AggregatorHandler> aggregators,
+      arangodb::velocypack::Slice userParams) const -> MasterContext* override;
+  [[nodiscard]] auto masterContextUnique(
+      uint64_t vertexCount, uint64_t edgeCount,
+      std::unique_ptr<AggregatorHandler> aggregators,
+      arangodb::velocypack::Slice userParams) const
+      -> std::unique_ptr<MasterContext> override;
 
   [[nodiscard]] IAggregator* aggregator(std::string const& name) const override;
 };

--- a/arangod/Pregel/Algos/ReadWrite/ReadWrite.h
+++ b/arangod/Pregel/Algos/ReadWrite/ReadWrite.h
@@ -40,6 +40,10 @@ using E = uint8_t;
 struct ReadWrite : public SimpleAlgorithm<V, E, V> {
   explicit ReadWrite(arangodb::velocypack::Slice const& params);
 
+  [[nodiscard]] auto name() const -> std::string_view override {
+    return "readwrite";
+  };
+
   [[nodiscard]] GraphFormat<V, E>* inputFormat() const override;
 
   [[nodiscard]] MessageFormat<V>* messageFormat() const override {

--- a/arangod/Pregel/Algos/RecoveringPageRank/RecoveringPageRank.cpp
+++ b/arangod/Pregel/Algos/RecoveringPageRank/RecoveringPageRank.cpp
@@ -116,7 +116,10 @@ VertexCompensation<float, float, float>* RecoveringPageRank::createCompensation(
 struct RPRMasterContext : public MasterContext {
   float _threshold;
 
-  explicit RPRMasterContext(VPackSlice params) {
+  explicit RPRMasterContext(uint64_t vertexCount, uint64_t edgeCount,
+                            std::unique_ptr<AggregatorHandler> aggregators,
+                            VPackSlice params)
+      : MasterContext(vertexCount, edgeCount, std::move(aggregators)) {
     VPackSlice t = params.get("convergenceThreshold");
     _threshold = t.isNumber() ? t.getNumber<float>() : EPS;
   };
@@ -157,6 +160,16 @@ struct RPRMasterContext : public MasterContext {
   }
 };
 
-MasterContext* RecoveringPageRank::masterContext(VPackSlice userParams) const {
-  return new RPRMasterContext(userParams);
+[[nodiscard]] auto RecoveringPageRank::masterContext(
+    std::unique_ptr<AggregatorHandler> aggregators,
+    arangodb::velocypack::Slice userParams) const -> MasterContext* {
+  return new RPRMasterContext(0, 0, std::move(aggregators), userParams);
+}
+[[nodiscard]] auto RecoveringPageRank::masterContextUnique(
+    uint64_t vertexCount, uint64_t edgeCount,
+    std::unique_ptr<AggregatorHandler> aggregators,
+    arangodb::velocypack::Slice userParams) const
+    -> std::unique_ptr<MasterContext> {
+  return std::make_unique<RPRMasterContext>(vertexCount, edgeCount,
+                                            std::move(aggregators), userParams);
 }

--- a/arangod/Pregel/Algos/RecoveringPageRank/RecoveringPageRank.h
+++ b/arangod/Pregel/Algos/RecoveringPageRank/RecoveringPageRank.h
@@ -30,6 +30,12 @@ namespace arangodb {
 namespace pregel {
 namespace algos {
 
+struct RecoveringPageRankType {
+  using Vertex = float;
+  using Edge = float;
+  using Message = float;
+};
+
 /// PageRank
 struct RecoveringPageRank : public SimpleAlgorithm<float, float, float> {
   explicit RecoveringPageRank(arangodb::velocypack::Slice params)

--- a/arangod/Pregel/Algos/RecoveringPageRank/RecoveringPageRank.h
+++ b/arangod/Pregel/Algos/RecoveringPageRank/RecoveringPageRank.h
@@ -39,7 +39,11 @@ struct RecoveringPageRankType {
 /// PageRank
 struct RecoveringPageRank : public SimpleAlgorithm<float, float, float> {
   explicit RecoveringPageRank(arangodb::velocypack::Slice params)
-      : SimpleAlgorithm("pagerank", params) {}
+      : SimpleAlgorithm(params) {}
+
+  [[nodiscard]] auto name() const -> std::string_view override {
+    return "pagerank";
+  };
 
   MasterContext* masterContext(VPackSlice userParams) const override;
 

--- a/arangod/Pregel/Algos/RecoveringPageRank/RecoveringPageRank.h
+++ b/arangod/Pregel/Algos/RecoveringPageRank/RecoveringPageRank.h
@@ -45,7 +45,14 @@ struct RecoveringPageRank : public SimpleAlgorithm<float, float, float> {
     return "pagerank";
   };
 
-  MasterContext* masterContext(VPackSlice userParams) const override;
+  [[nodiscard]] auto masterContext(
+      std::unique_ptr<AggregatorHandler> aggregators,
+      arangodb::velocypack::Slice userParams) const -> MasterContext* override;
+  [[nodiscard]] auto masterContextUnique(
+      uint64_t vertexCount, uint64_t edgeCount,
+      std::unique_ptr<AggregatorHandler> aggregators,
+      arangodb::velocypack::Slice userParams) const
+      -> std::unique_ptr<MasterContext> override;
 
   GraphFormat<float, float>* inputFormat() const override {
     return new VertexGraphFormat<float, float>(_resultField, 0);

--- a/arangod/Pregel/Algos/SCC/SCC.cpp
+++ b/arangod/Pregel/Algos/SCC/SCC.cpp
@@ -24,6 +24,7 @@
 #include "SCC.h"
 #include <atomic>
 #include <climits>
+#include <memory>
 #include <utility>
 #include "Cluster/ClusterInfo.h"
 #include "Cluster/ServerState.h"
@@ -190,7 +191,10 @@ GraphFormat<SCCValue, int8_t>* SCC::inputFormat() const {
 }
 
 struct SCCMasterContext : public MasterContext {
-  SCCMasterContext() = default;  // TODO use _threshold
+  SCCMasterContext(uint64_t vertexCount, uint64_t edgeCount,
+                   std::unique_ptr<AggregatorHandler> aggregators)
+      : MasterContext(vertexCount, edgeCount, std::move(aggregators)){};
+
   void preGlobalSuperstep() override {
     if (globalSuperstep() == 0) {
       aggregate<uint32_t>(kPhase, SCCPhase::TRANSPOSE);
@@ -236,8 +240,18 @@ struct SCCMasterContext : public MasterContext {
   };
 };
 
-MasterContext* SCC::masterContext(VPackSlice userParams) const {
-  return new SCCMasterContext();
+[[nodiscard]] auto SCC::masterContext(
+    std::unique_ptr<AggregatorHandler> aggregators,
+    arangodb::velocypack::Slice userParams) const -> MasterContext* {
+  return new SCCMasterContext(0, 0, std::move(aggregators));
+}
+[[nodiscard]] auto SCC::masterContextUnique(
+    uint64_t vertexCount, uint64_t edgeCount,
+    std::unique_ptr<AggregatorHandler> aggregators,
+    arangodb::velocypack::Slice userParams) const
+    -> std::unique_ptr<MasterContext> {
+  return std::make_unique<SCCMasterContext>(vertexCount, edgeCount,
+                                            std::move(aggregators));
 }
 
 IAggregator* SCC::aggregator(std::string const& name) const {

--- a/arangod/Pregel/Algos/SCC/SCC.h
+++ b/arangod/Pregel/Algos/SCC/SCC.h
@@ -93,6 +93,12 @@ namespace arangodb::pregel::algos {
  * (3) Propagate also a color backwards (as suggested in the paper).
  */
 
+struct SCCType {
+  using Vertex = SCCValue;
+  using Edge = int8_t;
+  using Message = SenderMessage<uint64_t>;
+};
+
 struct SCC : public SimpleAlgorithm<SCCValue, int8_t, SenderMessage<uint64_t>> {
  public:
   explicit SCC(VPackSlice userParams)

--- a/arangod/Pregel/Algos/SCC/SCC.h
+++ b/arangod/Pregel/Algos/SCC/SCC.h
@@ -118,8 +118,14 @@ struct SCC : public SimpleAlgorithm<SCCValue, int8_t, SenderMessage<uint64_t>> {
   VertexComputation<SCCValue, int8_t, SenderMessage<uint64_t>>*
       createComputation(std::shared_ptr<WorkerConfig const>) const override;
 
-  [[nodiscard]] MasterContext* masterContext(
-      VPackSlice userParams) const override;
+  [[nodiscard]] auto masterContext(
+      std::unique_ptr<AggregatorHandler> aggregators,
+      arangodb::velocypack::Slice userParams) const -> MasterContext* override;
+  [[nodiscard]] auto masterContextUnique(
+      uint64_t vertexCount, uint64_t edgeCount,
+      std::unique_ptr<AggregatorHandler> aggregators,
+      arangodb::velocypack::Slice userParams) const
+      -> std::unique_ptr<MasterContext> override;
 
   [[nodiscard]] IAggregator* aggregator(std::string const& name) const override;
 };

--- a/arangod/Pregel/Algos/SCC/SCC.h
+++ b/arangod/Pregel/Algos/SCC/SCC.h
@@ -102,8 +102,12 @@ struct SCCType {
 struct SCC : public SimpleAlgorithm<SCCValue, int8_t, SenderMessage<uint64_t>> {
  public:
   explicit SCC(VPackSlice userParams)
-      : SimpleAlgorithm<SCCValue, int8_t, SenderMessage<uint64_t>>(
-            "scc", userParams) {}
+      : SimpleAlgorithm<SCCValue, int8_t, SenderMessage<uint64_t>>(userParams) {
+  }
+
+  [[nodiscard]] auto name() const -> std::string_view override {
+    return "scc";
+  };
 
   [[nodiscard]] GraphFormat<SCCValue, int8_t>* inputFormat() const override;
   [[nodiscard]] MessageFormat<SenderMessage<uint64_t>>* messageFormat()

--- a/arangod/Pregel/Algos/SLPA/SLPA.cpp
+++ b/arangod/Pregel/Algos/SLPA/SLPA.cpp
@@ -205,3 +205,22 @@ GraphFormat<SLPAValue, int8_t>* SLPA::inputFormat() const {
 WorkerContext* SLPA::workerContext(velocypack::Slice userParams) const {
   return new SLPAWorkerContext();
 }
+
+struct SLPAMasterContext : public MasterContext {
+  SLPAMasterContext(uint64_t vertexCount, uint64_t edgeCount,
+                    std::unique_ptr<AggregatorHandler> aggregators)
+      : MasterContext(vertexCount, edgeCount, std::move(aggregators)){};
+};
+[[nodiscard]] auto SLPA::masterContext(
+    std::unique_ptr<AggregatorHandler> aggregators,
+    arangodb::velocypack::Slice userParams) const -> MasterContext* {
+  return new SLPAMasterContext(0, 0, std::move(aggregators));
+}
+[[nodiscard]] auto SLPA::masterContextUnique(
+    uint64_t vertexCount, uint64_t edgeCount,
+    std::unique_ptr<AggregatorHandler> aggregators,
+    arangodb::velocypack::Slice userParams) const
+    -> std::unique_ptr<MasterContext> {
+  return std::make_unique<SLPAMasterContext>(vertexCount, edgeCount,
+                                             std::move(aggregators));
+}

--- a/arangod/Pregel/Algos/SLPA/SLPA.h
+++ b/arangod/Pregel/Algos/SLPA/SLPA.h
@@ -126,5 +126,14 @@ struct SLPA : public SimpleAlgorithm<SLPAValue, int8_t, uint64_t> {
   VertexComputation<SLPAValue, int8_t, uint64_t>* createComputation(
       std::shared_ptr<WorkerConfig const>) const override;
   WorkerContext* workerContext(velocypack::Slice userParams) const override;
+
+  [[nodiscard]] auto masterContext(
+      std::unique_ptr<AggregatorHandler> aggregators,
+      arangodb::velocypack::Slice userParams) const -> MasterContext* override;
+  [[nodiscard]] auto masterContextUnique(
+      uint64_t vertexCount, uint64_t edgeCount,
+      std::unique_ptr<AggregatorHandler> aggregators,
+      arangodb::velocypack::Slice userParams) const
+      -> std::unique_ptr<MasterContext> override;
 };
 }  // namespace arangodb::pregel::algos

--- a/arangod/Pregel/Algos/SLPA/SLPA.h
+++ b/arangod/Pregel/Algos/SLPA/SLPA.h
@@ -89,6 +89,13 @@ namespace arangodb::pregel::algos {
  * this accumulated sum reaches r (the randomly generated number), choose the
  * current ID and send it.
  */
+
+struct SLPAType {
+  using Vertex = SLPAValue;
+  using Edge = int8_t;
+  using Message = uint64_t;
+};
+
 struct SLPA : public SimpleAlgorithm<SLPAValue, int8_t, uint64_t> {
   double _threshold = 0.15;
   unsigned _maxCommunities = 1;

--- a/arangod/Pregel/Algos/SLPA/SLPA.h
+++ b/arangod/Pregel/Algos/SLPA/SLPA.h
@@ -102,7 +102,7 @@ struct SLPA : public SimpleAlgorithm<SLPAValue, int8_t, uint64_t> {
 
  public:
   explicit SLPA(VPackSlice userParams)
-      : SimpleAlgorithm<SLPAValue, int8_t, uint64_t>("slpa", userParams) {
+      : SimpleAlgorithm<SLPAValue, int8_t, uint64_t>(userParams) {
     arangodb::velocypack::Slice val = userParams.get("threshold");
     if (val.isNumber()) {
       _threshold = std::min(1.0, std::max(val.getDouble(), 0.0));
@@ -113,6 +113,10 @@ struct SLPA : public SimpleAlgorithm<SLPAValue, int8_t, uint64_t> {
           (uint64_t)32, std::max(val.getUInt(), (uint64_t)0));
     }
   }
+
+  [[nodiscard]] auto name() const -> std::string_view override {
+    return "slpa";
+  };
 
   GraphFormat<SLPAValue, int8_t>* inputFormat() const override;
   MessageFormat<uint64_t>* messageFormat() const override {

--- a/arangod/Pregel/Algos/SSSP/SSSP.cpp
+++ b/arangod/Pregel/Algos/SSSP/SSSP.cpp
@@ -53,6 +53,23 @@ struct SSSPComputation : public VertexComputation<int64_t, int64_t, int64_t> {
   }
 };
 
+SSSPAlgorithm::SSSPAlgorithm(VPackSlice userParams) {
+  if (!userParams.isObject() || !userParams.hasKey("source")) {
+    THROW_ARANGO_EXCEPTION_MESSAGE(
+        TRI_ERROR_BAD_PARAMETER, "You need to specify the source document id");
+  }
+  _sourceDocumentId = userParams.get("source").copyString();
+
+  VPackSlice slice = userParams.get("resultField");
+  if (slice.isString()) {
+    _resultField = slice.copyString();
+  } else {
+    VPackSlice slice = userParams.get("_resultField");
+    if (slice.isString()) {
+      _resultField = slice.copyString();
+    }
+  }
+}
 uint32_t SSSPAlgorithm::messageBatchSize(
     std::shared_ptr<WorkerConfig const> config,
     MessageStats const& stats) const {

--- a/arangod/Pregel/Algos/SSSP/SSSP.cpp
+++ b/arangod/Pregel/Algos/SSSP/SSSP.cpp
@@ -25,6 +25,7 @@
 #include "Pregel/Algorithm.h"
 #include "Pregel/GraphStore/GraphStore.h"
 #include "Pregel/IncomingCache.h"
+#include "Pregel/MasterContext.h"
 #include "Pregel/VertexComputation.h"
 
 using namespace arangodb;
@@ -122,4 +123,23 @@ VertexCompensation<int64_t, int64_t, int64_t>*
 SSSPAlgorithm::createCompensation(
     std::shared_ptr<WorkerConfig const> config) const {
   return new SSSPCompensation();
+}
+
+struct SSSPMasterContext : public MasterContext {
+  SSSPMasterContext(uint64_t vertexCount, uint64_t edgeCount,
+                    std::unique_ptr<AggregatorHandler> aggregators)
+      : MasterContext(vertexCount, edgeCount, std::move(aggregators)){};
+};
+[[nodiscard]] auto SSSPAlgorithm::masterContext(
+    std::unique_ptr<AggregatorHandler> aggregators,
+    arangodb::velocypack::Slice userParams) const -> MasterContext* {
+  return new SSSPMasterContext(0, 0, std::move(aggregators));
+}
+[[nodiscard]] auto SSSPAlgorithm::masterContextUnique(
+    uint64_t vertexCount, uint64_t edgeCount,
+    std::unique_ptr<AggregatorHandler> aggregators,
+    arangodb::velocypack::Slice userParams) const
+    -> std::unique_ptr<MasterContext> {
+  return std::make_unique<SSSPMasterContext>(vertexCount, edgeCount,
+                                             std::move(aggregators));
 }

--- a/arangod/Pregel/Algos/SSSP/SSSP.h
+++ b/arangod/Pregel/Algos/SSSP/SSSP.h
@@ -66,6 +66,15 @@ class SSSPAlgorithm : public Algorithm<int64_t, int64_t, int64_t> {
 
   uint32_t messageBatchSize(std::shared_ptr<WorkerConfig const> config,
                             MessageStats const& stats) const override;
+
+  [[nodiscard]] auto masterContext(
+      std::unique_ptr<AggregatorHandler> aggregators,
+      arangodb::velocypack::Slice userParams) const -> MasterContext* override;
+  [[nodiscard]] auto masterContextUnique(
+      uint64_t vertexCount, uint64_t edgeCount,
+      std::unique_ptr<AggregatorHandler> aggregators,
+      arangodb::velocypack::Slice userParams) const
+      -> std::unique_ptr<MasterContext> override;
 };
 }  // namespace algos
 }  // namespace pregel

--- a/arangod/Pregel/Algos/SSSP/SSSP.h
+++ b/arangod/Pregel/Algos/SSSP/SSSP.h
@@ -43,24 +43,11 @@ class SSSPAlgorithm : public Algorithm<int64_t, int64_t, int64_t> {
   std::string _sourceDocumentId, _resultField = "result";
 
  public:
-  explicit SSSPAlgorithm(VPackSlice userParams) : Algorithm("sssp") {
-    if (!userParams.isObject() || !userParams.hasKey("source")) {
-      THROW_ARANGO_EXCEPTION_MESSAGE(
-          TRI_ERROR_BAD_PARAMETER,
-          "You need to specify the source document id");
-    }
-    _sourceDocumentId = userParams.get("source").copyString();
+  explicit SSSPAlgorithm(VPackSlice userParams);
 
-    VPackSlice slice = userParams.get("resultField");
-    if (slice.isString()) {
-      _resultField = slice.copyString();
-    } else {
-      VPackSlice slice = userParams.get("_resultField");
-      if (slice.isString()) {
-        _resultField = slice.copyString();
-      }
-    }
-  }
+  [[nodiscard]] auto name() const -> std::string_view override {
+    return "sssp";
+  };
 
   GraphFormat<int64_t, int64_t>* inputFormat() const override;
 

--- a/arangod/Pregel/Algos/SSSP/SSSP.h
+++ b/arangod/Pregel/Algos/SSSP/SSSP.h
@@ -23,11 +23,18 @@
 
 #pragma once
 
+#include <cstdint>
 #include "Pregel/Algorithm.h"
 
 namespace arangodb {
 namespace pregel {
 namespace algos {
+
+struct SSSPType {
+  using Vertex = int64_t;
+  using Edge = int64_t;
+  using Message = int64_t;
+};
 
 /// Single Source Shortest Path. Uses integer attribute 'value', the source
 /// should have

--- a/arangod/Pregel/Algos/ShortestPath/ShortestPath.cpp
+++ b/arangod/Pregel/Algos/ShortestPath/ShortestPath.cpp
@@ -93,8 +93,7 @@ struct arangodb::pregel::algos::SPGraphFormat
   }
 };
 
-ShortestPathAlgorithm::ShortestPathAlgorithm(VPackSlice userParams)
-    : Algorithm("ShortestPath") {
+ShortestPathAlgorithm::ShortestPathAlgorithm(VPackSlice userParams) {
   VPackSlice val1 = userParams.get("source");
   VPackSlice val2 = userParams.get("target");
   if (val1.isNone() || val2.isNone()) {

--- a/arangod/Pregel/Algos/ShortestPath/ShortestPath.cpp
+++ b/arangod/Pregel/Algos/ShortestPath/ShortestPath.cpp
@@ -22,8 +22,10 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #include "Pregel/Algos/ShortestPath/ShortestPath.h"
+#include "Aql/ExecutionBlockImpl.tpp"
 #include "Pregel/Aggregator.h"
 #include "Pregel/Algorithm.h"
+#include "Pregel/MasterContext.h"
 #include "Pregel/GraphStore/GraphStore.h"
 #include "Pregel/IncomingCache.h"
 #include "Pregel/VertexComputation.h"
@@ -124,4 +126,23 @@ IAggregator* ShortestPathAlgorithm::aggregator(std::string const& name) const {
     return new MinAggregator<int64_t>(INT64_MAX, true);
   }
   return nullptr;
+}
+
+struct ShortestPathMasterContext : public MasterContext {
+  ShortestPathMasterContext(uint64_t vertexCount, uint64_t edgeCount,
+                            std::unique_ptr<AggregatorHandler> aggregators)
+      : MasterContext(vertexCount, edgeCount, std::move(aggregators)){};
+};
+[[nodiscard]] auto ShortestPathAlgorithm::masterContext(
+    std::unique_ptr<AggregatorHandler> aggregators,
+    arangodb::velocypack::Slice userParams) const -> MasterContext* {
+  return new ShortestPathMasterContext(0, 0, std::move(aggregators));
+}
+[[nodiscard]] auto ShortestPathAlgorithm::masterContextUnique(
+    uint64_t vertexCount, uint64_t edgeCount,
+    std::unique_ptr<AggregatorHandler> aggregators,
+    arangodb::velocypack::Slice userParams) const
+    -> std::unique_ptr<MasterContext> {
+  return std::make_unique<ShortestPathMasterContext>(vertexCount, edgeCount,
+                                                     std::move(aggregators));
 }

--- a/arangod/Pregel/Algos/ShortestPath/ShortestPath.h
+++ b/arangod/Pregel/Algos/ShortestPath/ShortestPath.h
@@ -44,6 +44,10 @@ struct ShortestPathAlgorithm : public Algorithm<int64_t, int64_t, int64_t> {
  public:
   explicit ShortestPathAlgorithm(VPackSlice userParams);
 
+  [[nodiscard]] auto name() const -> std::string_view override {
+    return "ShortestPath";
+  };
+
   GraphFormat<int64_t, int64_t>* inputFormat() const override;
   MessageFormat<int64_t>* messageFormat() const override {
     return new IntegerMessageFormat<int64_t>();

--- a/arangod/Pregel/Algos/ShortestPath/ShortestPath.h
+++ b/arangod/Pregel/Algos/ShortestPath/ShortestPath.h
@@ -61,5 +61,14 @@ struct ShortestPathAlgorithm : public Algorithm<int64_t, int64_t, int64_t> {
       std::shared_ptr<WorkerConfig const> config) const override;
   IAggregator* aggregator(std::string const& name) const override;
   std::set<std::string> initialActiveSet() override;
+
+  [[nodiscard]] auto masterContext(
+      std::unique_ptr<AggregatorHandler> aggregators,
+      arangodb::velocypack::Slice userParams) const -> MasterContext* override;
+  [[nodiscard]] auto masterContextUnique(
+      uint64_t vertexCount, uint64_t edgeCount,
+      std::unique_ptr<AggregatorHandler> aggregators,
+      arangodb::velocypack::Slice userParams) const
+      -> std::unique_ptr<MasterContext> override;
 };
 }  // namespace arangodb::pregel::algos

--- a/arangod/Pregel/Algos/ShortestPath/ShortestPath.h
+++ b/arangod/Pregel/Algos/ShortestPath/ShortestPath.h
@@ -27,6 +27,12 @@
 
 namespace arangodb::pregel::algos {
 
+struct ShortestPathType {
+  using Vertex = int64_t;
+  using Edge = int64_t;
+  using Message = int64_t;
+};
+
 struct SPGraphFormat;
 
 /// Single Source Shortest Path. Uses integer attribute 'value', the source

--- a/arangod/Pregel/Algos/WCC/WCC.h
+++ b/arangod/Pregel/Algos/WCC/WCC.h
@@ -44,7 +44,11 @@ struct WCCType {
 struct WCC
     : public SimpleAlgorithm<WCCValue, uint64_t, SenderMessage<uint64_t>> {
  public:
-  explicit WCC(VPackSlice userParams) : SimpleAlgorithm("wcc", userParams) {}
+  explicit WCC(VPackSlice userParams) : SimpleAlgorithm(userParams) {}
+
+  [[nodiscard]] auto name() const -> std::string_view override {
+    return "wcc";
+  };
 
   GraphFormat<WCCValue, uint64_t>* inputFormat() const override;
 

--- a/arangod/Pregel/Algos/WCC/WCC.h
+++ b/arangod/Pregel/Algos/WCC/WCC.h
@@ -60,5 +60,14 @@ struct WCC
   }
   VertexComputation<WCCValue, uint64_t, SenderMessage<uint64_t>>*
       createComputation(std::shared_ptr<WorkerConfig const>) const override;
+
+  [[nodiscard]] auto masterContext(
+      std::unique_ptr<AggregatorHandler> aggregators,
+      arangodb::velocypack::Slice userParams) const -> MasterContext* override;
+  [[nodiscard]] auto masterContextUnique(
+      uint64_t vertexCount, uint64_t edgeCount,
+      std::unique_ptr<AggregatorHandler> aggregators,
+      arangodb::velocypack::Slice userParams) const
+      -> std::unique_ptr<MasterContext> override;
 };
 }  // namespace arangodb::pregel::algos

--- a/arangod/Pregel/Algos/WCC/WCC.h
+++ b/arangod/Pregel/Algos/WCC/WCC.h
@@ -29,10 +29,18 @@
 #include "Pregel/SenderMessageFormat.h"
 
 namespace arangodb::pregel::algos {
+
 /// The idea behind the algorithm is very simple: propagate the smallest
 /// vertex id along the edges to all vertices of a connected component. The
 /// number of supersteps necessary is equal to the length of the maximum
 /// diameter of all components + 1
+
+struct WCCType {
+  using Vertex = WCCValue;
+  using Edge = uint64_t;
+  using Message = SenderMessage<uint64_t>;
+};
+
 struct WCC
     : public SimpleAlgorithm<WCCValue, uint64_t, SenderMessage<uint64_t>> {
  public:

--- a/arangod/Pregel/Conductor/Conductor.cpp
+++ b/arangod/Pregel/Conductor/Conductor.cpp
@@ -469,7 +469,7 @@ ErrorCode Conductor::_initializeWorkers() {
 
     auto createWorker =
         CreateWorker{.executionNumber = _specifications.executionNumber,
-                     .algorithm = _algorithm->name(),
+                     .algorithm = std::string{_algorithm->name()},
                      .userParameters = _specifications.userParameters,
                      .coordinatorId = coordinatorId,
                      .useMemoryMaps = _specifications.useMemoryMaps,

--- a/arangod/Pregel/Conductor/Conductor.cpp
+++ b/arangod/Pregel/Conductor/Conductor.cpp
@@ -29,6 +29,7 @@
 
 #include "Inspection/VPackWithErrorT.h"
 #include "Logger/LogMacros.h"
+#include "Pregel/AggregatorHandler.h"
 #include "Pregel/AlgoRegistry.h"
 #include "Pregel/Algorithm.h"
 #include "Pregel/Conductor/Messages.h"
@@ -84,9 +85,9 @@ Conductor::Conductor(ExecutionSpecifications const& specifications,
     THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_BAD_PARAMETER,
                                    "Algorithm not found");
   }
-  _masterContext.reset(
-      _algorithm->masterContext(specifications.userParameters.slice()));
-  _aggregators = std::make_unique<AggregatorHandler>(_algorithm.get());
+  _masterContext.reset(_algorithm->masterContext(
+      std::make_unique<AggregatorHandler>(_algorithm.get()),
+      specifications.userParameters.slice()));
 
   _feature.metrics()->pregelConductorsNumber->fetch_add(1);
 
@@ -135,7 +136,7 @@ bool Conductor::_startGlobalStep() {
   _callbackMutex.assertLockedByCurrentThread();
 
   /// collect the aggregators
-  _aggregators->resetValues();
+  _masterContext->_aggregators->resetValues();
   _statistics.resetActiveCount();
   _totalVerticesCount = 0;  // might change during execution
   _totalEdgesCount = 0;
@@ -168,7 +169,8 @@ bool Conductor::_startGlobalStep() {
                   "Cannot deserialize GlobalSuperStepPrepared message: {}",
                   prepared.error().error()));
         }
-        _aggregators->aggregateValues(prepared.get().aggregators.slice());
+        _masterContext->_aggregators->aggregateValues(
+            prepared.get().aggregators.slice());
         _statistics.accumulateActiveCounts(prepared.get().sender,
                                            prepared.get().activeCount);
         _totalVerticesCount += prepared.get().vertexCount;
@@ -229,7 +231,7 @@ bool Conductor::_startGlobalStep() {
   VPackBuilder agg;
   {
     VPackObjectBuilder ob(&agg);
-    _aggregators->serializeValues(agg);
+    _masterContext->_aggregators->serializeValues(agg);
   }
   auto runGss =
       RunGlobalSuperStep{.executionNumber = _specifications.executionNumber,
@@ -302,7 +304,6 @@ void Conductor::finishedWorkerStartup(GraphLoaded const& graphLoaded) {
     _masterContext->_globalSuperstep = 0;
     _masterContext->_vertexCount = _totalVerticesCount;
     _masterContext->_edgeCount = _totalEdgesCount;
-    _masterContext->_aggregators = _aggregators.get();
     _masterContext->preApplication();
   }
 
@@ -593,7 +594,7 @@ void Conductor::finishedWorkerFinalize(Finished const& data) {
   debugOut.add("stats", VPackValue(VPackValueType::Object));
   _statistics.serializeValues(debugOut);
   debugOut.close();
-  _aggregators->serializeValues(debugOut);
+  _masterContext->_aggregators->serializeValues(debugOut);
   debugOut.close();
 
   LOG_PREGEL("063b5", INFO)
@@ -726,7 +727,7 @@ void Conductor::toVelocyPack(VPackBuilder& result) const {
       result.add(VPackValue(gssTime.elapsedSeconds().count()));
     }
   }
-  _aggregators->serializeValues(result);
+  _masterContext->_aggregators->serializeValues(result);
   _statistics.serializeValues(result);
   if (_state != ExecutionState::RUNNING || ExecutionState::LOADING) {
     result.add("vertexCount", VPackValue(_totalVerticesCount));

--- a/arangod/Pregel/Conductor/Conductor.h
+++ b/arangod/Pregel/Conductor/Conductor.h
@@ -71,7 +71,6 @@ class Conductor : public std::enable_shared_from_this<Conductor> {
   const DatabaseGuard _vocbaseGuard;
   ExecutionSpecifications _specifications;
 
-  std::unique_ptr<AggregatorHandler> _aggregators;
   std::unique_ptr<MasterContext> _masterContext;
   std::unique_ptr<IAlgorithm> _algorithm;
 

--- a/arangod/Pregel/MasterContext.h
+++ b/arangod/Pregel/MasterContext.h
@@ -35,14 +35,17 @@ class Conductor;
 class MasterContext {
   friend class Conductor;
 
+ public:
   uint64_t _globalSuperstep = 0;
   uint64_t _vertexCount = 0;
   uint64_t _edgeCount = 0;
-  // Should cause the master to tell everyone to enter the next phase
-  AggregatorHandler* _aggregators = nullptr;
+  std::unique_ptr<AggregatorHandler> _aggregators = nullptr;
 
- public:
-  MasterContext() {}
+  MasterContext(uint64_t vertexCount, uint64_t edgeCount,
+                std::unique_ptr<AggregatorHandler> aggregators)
+      : _vertexCount{vertexCount},
+        _edgeCount{edgeCount},
+        _aggregators{std::move(aggregators)} {}
   virtual ~MasterContext() = default;
 
   inline uint64_t globalSuperstep() const { return _globalSuperstep; }


### PR DESCRIPTION

- Defines Vertex-, Edge- and Message type in a common struct in each algorithm. More refactoring will be done here in another ticket: see https://arangodb.atlassian.net/browse/GORDO-1568.
- Makes IAlgorithm abstract and implements name function in each algorithm
- Adds a MasterContext to each algorithm (before, only some algorithms had a master context). The aggregates, that were previously owned by the Conductor, are now owned by the MasterContext, such that we don't have duplication of variables here. (other variables are also duplicated, both master context and conductor have them - vertexCount, edgeCount and gss - but I will not fix that here but for our actors).
- The algorithm can now also create a unique ptr to MasterContext - opposed to a raw pointer - this is not used yet but will be used in our Conductor actor
- Adds a function to AlgoRegistry that creates pregel algorithms using unique ptr instead of raw ptr - also this is not used yet but will be used in our Conductor actor