### PR TITLE
suppress a useless error message

### DIFF
--- a/client-tools/Shell/ClientFeature.cpp
+++ b/client-tools/Shell/ClientFeature.cpp
@@ -121,10 +121,14 @@ void ClientFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
         "server endpoint, otherwise http+tcp:// or unix://";
   }
 
-  options->addOption(
+  auto& opt = options->addOption(
       "--server.endpoint", endpointHelp,
       new VectorParameter<StringParameter>(&_endpoints),
       arangodb::options::makeFlags(Flags::FlushOnFirst, Flags::Default));
+  if (isArangosh) {
+    opt.setLongDescription(R"(You can use `--server.endpoint none` to start
+arangosh with an active connection.)");
+  }
 
   options->addOption("--server.password",
                      "The password to use when connecting. If not specified "

--- a/client-tools/Shell/ClientFeature.cpp
+++ b/client-tools/Shell/ClientFeature.cpp
@@ -384,8 +384,10 @@ std::unique_ptr<httpclient::SimpleHttpClient> ClientFeature::createHttpClient(
   std::unique_ptr<Endpoint> endpoint(Endpoint::clientFactory(definition));
 
   if (endpoint.get() == nullptr) {
-    LOG_TOPIC("2fac8", ERR, arangodb::Logger::FIXME)
-        << "invalid value for --server.endpoint ('" << definition << "')";
+    if (definition != "none") {
+      LOG_TOPIC("2fac8", ERR, arangodb::Logger::FIXME)
+          << "invalid value for --server.endpoint ('" << definition << "')";
+    }
     THROW_ARANGO_EXCEPTION(TRI_ERROR_BAD_PARAMETER);
   }
 

--- a/client-tools/Shell/ClientFeature.cpp
+++ b/client-tools/Shell/ClientFeature.cpp
@@ -127,7 +127,7 @@ void ClientFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
       arangodb::options::makeFlags(Flags::FlushOnFirst, Flags::Default));
   if (isArangosh) {
     opt.setLongDescription(R"(You can use `--server.endpoint none` to start
-arangosh with an active connection.)");
+arangosh without connecting to a server.)");
   }
 
   options->addOption("--server.password",


### PR DESCRIPTION
### Scope & Purpose

when starting arangosh with `--server.endpoint none`, the user explicitly asks for no endpoint to connect to.
previously doing so caused an error message when starting the shell: `invalid value for --server.endpoint (none)`.
the message is now suppressed, because it is not relevant.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: -
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 