### PR TITLE
add more transparency for WAL file deletions

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,12 +5,12 @@ v3.9.10 (XXXX-XX-XX)
   - `rocksdb_live_wal_files`: number of alive WAL files (not archived)
   - `rocksdb_wal_released_tick_flush`: lower bound sequence number from which
     onwards WAL files will be kept (i.e. not deleted from the archive) because
-    of external flushing needs. Candidates for these are arangosearch links
-    and background index creation.
+    of external flushing needs. Candidates for these are arangosearch links and
+    background index creation.
   - `rocksdb_wal_released_tick_replication`: lower bound sequence number from
     which onwards WAL files will be kept because they may be needed by the
     replication.
-  - `arangodb_flush_subscriptions`: number of currently active flush 
+  - `arangodb_flush_subscriptions`: number of currently active flush
     subscriptions.
 
 * Added startup option `--rocksdb.auto-refill-index-caches-on-followers` to

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,18 @@
 v3.9.10 (XXXX-XX-XX)
 --------------------
 
+* Added the following metrics for WAL file tracking:
+  - `rocksdb_live_wal_files`: number of alive WAL files (not archived)
+  - `rocksdb_wal_released_tick_flush`: lower bound sequence number from which
+    onwards WAL files will be kept (i.e. not deleted from the archive) because
+    of external flushing needs. Candidates for these are arangosearch links
+    and background index creation.
+  - `rocksdb_wal_released_tick_replication`: lower bound sequence number from
+    which onwards WAL files will be kept because they may be needed by the
+    replication.
+  - `arangodb_flush_subscriptions`: number of currently active flush 
+    subscriptions.
+
 * Added startup option `--rocksdb.auto-refill-index-caches-on-followers` to
   control whether automatic refilling of in-memory caches should happen on
   followers or just leaders. The default value is `true`, i.e. refilling happens

--- a/Documentation/Metrics/arangodb_flush_subscriptions.yaml
+++ b/Documentation/Metrics/arangodb_flush_subscriptions.yaml
@@ -1,0 +1,16 @@
+name: arangodb_flush_subscriptions
+introducedIn: "3.9.10"
+help: |
+  Number of currently active flush subscriptions.
+unit: number
+type: gauge
+category: RocksDB
+complexity: advanced
+exposedBy:
+  - dbserver
+  - agent
+  - single
+description: |
+  This metric exposes the number of currently active flush subscriptions.
+  Flush subscriptions can be created by arangosearch links and by background
+  index creation.

--- a/Documentation/Metrics/rocksdb_live_wal_files.yaml
+++ b/Documentation/Metrics/rocksdb_live_wal_files.yaml
@@ -1,0 +1,16 @@
+name: rocksdb_live_wal_files
+introducedIn: "3.9.10"
+help: |
+  Number of live RocksDB WAL files.
+unit: number
+type: gauge
+category: RocksDB
+complexity: medium
+exposedBy:
+  - dbserver
+  - agent
+  - single
+description: |
+  This metric exhibits the total number of live RocksDB WAL files. These are
+  WAL files that cannot be garbage-collected until they are moved over to the
+  archive.

--- a/Documentation/Metrics/rocksdb_wal_released_tick_flush.yaml
+++ b/Documentation/Metrics/rocksdb_wal_released_tick_flush.yaml
@@ -1,0 +1,21 @@
+name: rocksdb_wal_released_tick_flush
+introducedIn: "3.9.10"
+help: |
+  Lower bound sequence number from which WAL files need to be kept because
+  of external flushing needs.
+unit: number
+type: gauge
+category: RocksDB
+complexity: advanced
+exposedBy:
+  - dbserver
+  - agent
+  - single
+description: |
+  This metric exposes the RocksDB WAL sequence number from which onwards 
+  WAL files have to kept because the WAL data could be used by external
+  flushing needs. WAL files with sequence numbers higher than this value
+  will not be garbage-collected.
+  The candidates that can keep WAL files from being garbage-collected are
+  arangosearch links or inverted indexes that are still syncing data,
+  and background index creation.

--- a/Documentation/Metrics/rocksdb_wal_released_tick_flush.yaml
+++ b/Documentation/Metrics/rocksdb_wal_released_tick_flush.yaml
@@ -13,7 +13,7 @@ exposedBy:
   - single
 description: |
   This metric exposes the RocksDB WAL sequence number from which onwards 
-  WAL files have to kept because the WAL data could be used by external
+  WAL files have to be kept because the WAL data could be used by external
   flushing needs. WAL files with sequence numbers higher than this value
   will not be garbage-collected.
   The candidates that can keep WAL files from being garbage-collected are

--- a/Documentation/Metrics/rocksdb_wal_released_tick_replication.yaml
+++ b/Documentation/Metrics/rocksdb_wal_released_tick_replication.yaml
@@ -1,0 +1,19 @@
+name: rocksdb_wal_released_tick_replication
+introducedIn: "3.9.10"
+help: |
+  Lower bound sequence number from which WAL files need to be kept because
+  of replication.
+unit: number
+type: gauge
+category: RocksDB
+complexity: advanced
+exposedBy:
+  - dbserver
+  - agent
+  - single
+description: |
+  This metric exposes the RocksDB WAL sequence number from which onwards 
+  WAL files have to kept in the archive because the WAL data could be used
+  by the replication.
+  WAL files with sequence numbers higher than this value will not be 
+  garbage-collected.

--- a/arangod/RestServer/FlushFeature.h
+++ b/arangod/RestServer/FlushFeature.h
@@ -25,11 +25,13 @@
 #pragma once
 
 #include "ApplicationFeatures/ApplicationFeature.h"
+#include "RestServer/Metrics.h"
 #include "VocBase/voc-types.h"
 
 #include <cstdint>
 #include <memory>
 #include <mutex>
+#include <string>
 #include <tuple>
 #include <vector>
 
@@ -45,6 +47,7 @@ namespace arangodb {
 struct FlushSubscription {
   virtual ~FlushSubscription() = default;
   virtual TRI_voc_tick_t tick() const = 0;
+  virtual std::string const& name() const = 0;
 };
 
 class FlushFeature final : public application_features::ApplicationFeature {
@@ -63,7 +66,6 @@ class FlushFeature final : public application_features::ApplicationFeature {
   void registerFlushSubscription(
       std::shared_ptr<FlushSubscription> const& subscription);
 
-  arangodb::Result releaseUnusedTicks(size_t& count, TRI_voc_tick_t& tick);
   /// returns number of active flush subscriptions removed, the number of stale
   /// flush scriptions removed, and the tick value up to which the storage
   /// engine could release ticks. if no active or stale flush subscriptions were
@@ -76,6 +78,8 @@ class FlushFeature final : public application_features::ApplicationFeature {
   std::mutex _flushSubscriptionsMutex;
   std::vector<std::weak_ptr<FlushSubscription>> _flushSubscriptions;
   bool _stopped;
+
+  Gauge<uint64_t>& _metricsFlushSubscriptions;
 };
 
 }  // namespace arangodb

--- a/arangod/RocksDBEngine/RocksDBBackgroundThread.cpp
+++ b/arangod/RocksDBEngine/RocksDBBackgroundThread.cpp
@@ -28,19 +28,28 @@
 #include "Replication/ReplicationClients.h"
 #include "RestServer/DatabaseFeature.h"
 #include "RestServer/FlushFeature.h"
+#include "RestServer/MetricsFeature.h"
 #include "RocksDBEngine/RocksDBCommon.h"
 #include "RocksDBEngine/RocksDBEngine.h"
 #include "RocksDBEngine/RocksDBReplicationManager.h"
 #include "RocksDBEngine/RocksDBSettingsManager.h"
 #include "Utils/CursorRepository.h"
 
+#include <atomic>
+
 using namespace arangodb;
 
-RocksDBBackgroundThread::RocksDBBackgroundThread(RocksDBEngine& eng,
+DECLARE_GAUGE(rocksdb_wal_released_tick_replication, uint64_t,
+              "Released tick for RocksDB WAL deletion (replication-induced)");
+
+RocksDBBackgroundThread::RocksDBBackgroundThread(RocksDBEngine& engine,
                                                  double interval)
-    : Thread(eng.server(), "RocksDBThread"),
-      _engine(eng),
-      _interval(interval) {}
+    : Thread(engine.server(), "RocksDBThread"),
+      _engine(engine),
+      _interval(interval),
+      _metricsWalReleasedTickReplication(
+          engine.server().getFeature<arangodb::MetricsFeature>().add(
+              rocksdb_wal_released_tick_replication{})) {}
 
 RocksDBBackgroundThread::~RocksDBBackgroundThread() { shutdown(); }
 
@@ -141,22 +150,45 @@ void RocksDBBackgroundThread::run() {
         }
       }
 
-      uint64_t minTick = _engine.db()->GetLatestSequenceNumber();
-      auto cmTick = _engine.settingsManager()->earliestSeqNeeded();
+      uint64_t const latestSeqNo = _engine.db()->GetLatestSequenceNumber();
+      auto const earliestSeqNeeded =
+          _engine.settingsManager()->earliestSeqNeeded();
 
-      if (cmTick < minTick) {
-        minTick = cmTick;
+      uint64_t minTick = latestSeqNo;
+
+      if (earliestSeqNeeded < minTick) {
+        minTick = earliestSeqNeeded;
       }
 
+      uint64_t minTickForReplication = latestSeqNo;
       if (_engine.server().hasFeature<DatabaseFeature>()) {
         _engine.server().getFeature<DatabaseFeature>().enumerateDatabases(
-            [&minTick](TRI_vocbase_t& vocbase) -> void {
+            [&minTickForReplication, minTick](TRI_vocbase_t& vocbase) -> void {
               // lowestServedValue will return the lowest of the lastServedTick
               // values stored, or UINT64_MAX if no clients are registered
-              minTick = std::min(
-                  minTick, vocbase.replicationClients().lowestServedValue());
+              TRI_voc_tick_t lowestServedValue =
+                  vocbase.replicationClients().lowestServedValue();
+
+              if (lowestServedValue != UINT64_MAX) {
+                // only log noteworthy things
+                LOG_TOPIC("e979f", DEBUG, Logger::ENGINES)
+                    << "lowest served tick for database '" << vocbase.name()
+                    << "': " << lowestServedValue << ", minTick: " << minTick
+                    << ", minTickForReplication: " << minTickForReplication;
+              }
+
+              minTickForReplication =
+                  std::min(minTickForReplication, lowestServedValue);
             });
+
+        minTick = std::min(minTick, minTickForReplication);
       }
+      _metricsWalReleasedTickReplication.operator=(minTickForReplication);
+
+      LOG_TOPIC("cfe65", DEBUG, Logger::ENGINES)
+          << "latest seq number: " << latestSeqNo
+          << ", earliest seq needed: " << earliestSeqNeeded
+          << ", min tick for replication: " << minTickForReplication;
 
       bool canPrune =
           TRI_microtime() >= startTime + _engine.pruneWaitTimeInitial();

--- a/arangod/RocksDBEngine/RocksDBBackgroundThread.h
+++ b/arangod/RocksDBEngine/RocksDBBackgroundThread.h
@@ -26,6 +26,7 @@
 #include "Basics/Common.h"
 #include "Basics/ConditionVariable.h"
 #include "Basics/Thread.h"
+#include "RestServer/Metrics.h"
 
 namespace arangodb {
 
@@ -33,21 +34,6 @@ class RocksDBEngine;
 
 class RocksDBBackgroundThread final : public Thread {
  public:
-  //////////////////////////////////////////////////////////////////////////////
-  /// @brief engine pointer
-  //////////////////////////////////////////////////////////////////////////////
-  RocksDBEngine& _engine;
-
-  //////////////////////////////////////////////////////////////////////////////
-  /// @brief interval in which we will run
-  //////////////////////////////////////////////////////////////////////////////
-  double const _interval;
-
-  //////////////////////////////////////////////////////////////////////////////
-  /// @brief condition variable for heartbeat
-  //////////////////////////////////////////////////////////////////////////////
-  arangodb::basics::ConditionVariable _condition;
-
   RocksDBBackgroundThread(RocksDBEngine& eng, double interval);
   ~RocksDBBackgroundThread();
 
@@ -55,5 +41,17 @@ class RocksDBBackgroundThread final : public Thread {
 
  protected:
   void run() override;
+
+ private:
+  /// @brief engine pointer
+  RocksDBEngine& _engine;
+
+  /// @brief interval in which we will run
+  double const _interval;
+
+  /// @brief condition variable for heartbeat
+  arangodb::basics::ConditionVariable _condition;
+
+  Gauge<uint64_t>& _metricsWalReleasedTickReplication;
 };
 }  // namespace arangodb

--- a/arangod/RocksDBEngine/RocksDBEngine.cpp
+++ b/arangod/RocksDBEngine/RocksDBEngine.cpp
@@ -121,10 +121,14 @@ using namespace arangodb::options;
 
 namespace arangodb {
 
+DECLARE_GAUGE(rocksdb_wal_released_tick_flush, uint64_t,
+              "Released tick for RocksDB WAL deletion (flush-induced)");
 DECLARE_GAUGE(rocksdb_wal_sequence, uint64_t, "Current RocksDB WAL sequence");
 DECLARE_GAUGE(
     rocksdb_wal_sequence_lower_bound, uint64_t,
     "RocksDB WAL sequence number until which background thread has caught up");
+DECLARE_GAUGE(rocksdb_live_wal_files, uint64_t,
+              "Number of live RocksDB WAL files");
 DECLARE_GAUGE(rocksdb_archived_wal_files, uint64_t,
               "Number of archived RocksDB WAL files");
 DECLARE_GAUGE(rocksdb_prunable_wal_files, uint64_t,
@@ -234,9 +238,14 @@ RocksDBEngine::RocksDBEngine(application_features::ApplicationServer& server)
       _dbExisted(false),
       _runningRebuilds(0),
       _runningCompactions(0),
+      _metricsWalReleasedTickFlush(
+          server.getFeature<arangodb::MetricsFeature>().add(
+              rocksdb_wal_released_tick_flush{})),
       _metricsWalSequenceLowerBound(
           server.getFeature<arangodb::MetricsFeature>().add(
               rocksdb_wal_sequence_lower_bound{})),
+      _metricsLiveWalFiles(server.getFeature<arangodb::MetricsFeature>().add(
+          rocksdb_live_wal_files{})),
       _metricsArchivedWalFiles(
           server.getFeature<arangodb::MetricsFeature>().add(
               rocksdb_archived_wal_files{})),
@@ -2429,19 +2438,20 @@ void RocksDBEngine::determineWalFilesInitial() {
     return;
   }
 
+  size_t liveFiles = 0;
   size_t archivedFiles = 0;
   for (size_t current = 0; current < files.size(); current++) {
     auto const& f = files[current].get();
 
-    if (f->Type() != rocksdb::WalFileType::kArchivedLogFile) {
-      // we are only interested in files of the archive
-      continue;
+    if (f->Type() == rocksdb::WalFileType::kArchivedLogFile) {
+      ++archivedFiles;
+    } else if (f->Type() == rocksdb::WalFileType::kAliveLogFile) {
+      ++liveFiles;
     }
-
-    ++archivedFiles;
   }
   _metricsWalSequenceLowerBound.operator=(
       _settingsManager->earliestSeqNeeded());
+  _metricsLiveWalFiles.operator=(liveFiles);
   _metricsArchivedWalFiles.operator=(archivedFiles);
 }
 
@@ -2452,9 +2462,21 @@ void RocksDBEngine::determinePrunableWalFiles(TRI_voc_tick_t minTickExternal) {
                                 : std::numeric_limits<TRI_voc_tick_t>::max(),
                minTickExternal);
 
+  uint64_t minLogNumberToKeep = 0;
+  try {
+    std::string v;
+    if (_db->GetProperty(rocksdb::DB::Properties::kMinLogNumberToKeep, &v)) {
+      minLogNumberToKeep = static_cast<uint64_t>(basics::StringUtils::int64(v));
+    }
+  } catch (...) {
+    // do not fail if fetching the property fails
+  }
+
   LOG_TOPIC("4673c", TRACE, Logger::ENGINES)
       << "determining prunable WAL files, minTickToKeep: " << minTickToKeep
-      << ", minTickExternal: " << minTickExternal;
+      << ", minTickExternal: " << minTickExternal
+      << ", releasedTick: " << _releasedTick
+      << ", minLogNumberToKeep: " << minLogNumberToKeep;
 
   // Retrieve the sorted list of all wal files with earliest file first
   rocksdb::VectorLogPtr files;
@@ -2465,13 +2487,23 @@ void RocksDBEngine::determinePrunableWalFiles(TRI_voc_tick_t minTickExternal) {
     return;
   }
 
+  size_t liveFiles = 0;
   size_t archivedFiles = 0;
   uint64_t totalArchiveSize = 0;
   for (size_t current = 0; current < files.size(); current++) {
     auto const& f = files[current].get();
 
+    if (f->Type() == rocksdb::WalFileType::kAliveLogFile) {
+      ++liveFiles;
+      LOG_TOPIC("dc472", TRACE, Logger::ENGINES)
+          << "live WAL file #" << current << "/" << files.size()
+          << ", filename: '" << f->PathName()
+          << "', start sequence: " << f->StartSequence();
+      continue;
+    }
+
     if (f->Type() != rocksdb::WalFileType::kArchivedLogFile) {
-      // we are only interested in files of the archive
+      // we are mostly interested in files of the archive
       continue;
     }
 
@@ -2489,27 +2521,50 @@ void RocksDBEngine::determinePrunableWalFiles(TRI_voc_tick_t minTickExternal) {
     // following, we need to take its start tick into account as well, because
     // the following file's start tick can be assumed to be the end tick of the
     // current file!
+    bool eligibleStep1 = false;
+    bool eligibleStep2 = false;
     if (f->StartSequence() < minTickToKeep && current < files.size() - 1) {
+      eligibleStep1 = true;
       auto const& n = files[current + 1].get();
       if (n->StartSequence() < minTickToKeep) {
         // this file will be removed because it does not contain any data we
         // still need
-        auto const [it, emplaced] = _prunableWalFiles.try_emplace(
-            f->PathName(), TRI_microtime() + _pruneWaitTime);
+        eligibleStep2 = true;
+
+        double stamp = TRI_microtime() + _pruneWaitTime;
+        auto const [it, emplaced] =
+            _prunableWalFiles.try_emplace(f->PathName(), stamp);
+
         if (emplaced) {
           LOG_TOPIC("9f7a4", DEBUG, Logger::ENGINES)
               << "RocksDB WAL file '" << f->PathName()
               << "' with start sequence " << f->StartSequence()
+              << ", expire stamp " << stamp
               << " added to prunable list because it is not needed anymore";
           TRI_ASSERT(it != _prunableWalFiles.end());
+        } else {
+          LOG_TOPIC("d2c9e", TRACE, Logger::ENGINES)
+              << "unable to add WAL file #" << current << "/" << files.size()
+              << ", filename: '" << f->PathName()
+              << "', start sequence: " << f->StartSequence()
+              << " to list of prunable WAL files. file already present in list "
+                 "with expire stamp "
+              << it->second;
         }
       }
     }
+
+    LOG_TOPIC("ec350", TRACE, Logger::ENGINES)
+        << "inspected WAL file #" << current << "/" << files.size()
+        << ", filename: '" << f->PathName()
+        << "', start sequence: " << f->StartSequence()
+        << ", eligible step1: " << eligibleStep1
+        << ", step2: " << eligibleStep2;
   }
 
-  LOG_TOPIC("01e20", TRACE, Logger::ENGINES)
-      << "found " << files.size() << " WAL file(s), with " << archivedFiles
-      << " files in the archive, "
+  LOG_TOPIC("01e20", DEBUG, Logger::ENGINES)
+      << "found " << files.size() << " WAL file(s), with " << liveFiles
+      << " live file(s) and " << archivedFiles << " file(s) in the archive, "
       << "number of prunable files: " << _prunableWalFiles.size();
 
   if (_maxWalArchiveSizeLimit > 0 &&
@@ -2573,6 +2628,7 @@ void RocksDBEngine::determinePrunableWalFiles(TRI_voc_tick_t minTickExternal) {
 
   _metricsWalSequenceLowerBound.operator=(
       _settingsManager->earliestSeqNeeded());
+  _metricsLiveWalFiles.operator=(liveFiles);
   _metricsArchivedWalFiles.operator=(archivedFiles);
   _metricsPrunableWalFiles.operator=(_prunableWalFiles.size());
   _metricsWalPruningActive.operator=(1);
@@ -2610,9 +2666,15 @@ void RocksDBEngine::pruneWalFiles() {
       // but only if there are no other threads currently inside the WAL tailing
       // section
       deleteFile = purgeEnabler.canPurge();
+      LOG_TOPIC("817bc", TRACE, Logger::ENGINES)
+          << "pruneWalFiles checking overflowed file '" << (*it).first
+          << "', canPurge: " << deleteFile;
     } else if ((*it).second < TRI_microtime()) {
       // file has expired, and it is always safe to delete it
       deleteFile = true;
+      LOG_TOPIC("e7674", TRACE, Logger::ENGINES)
+          << "pruneWalFiles checking expired file '" << (*it).first
+          << "', canPurge: " << deleteFile;
     }
 
     if (deleteFile) {
@@ -2625,6 +2687,9 @@ void RocksDBEngine::pruneWalFiles() {
         // otherwise RocksDB may complain about non-existing files and log a big
         // error message
         s = _db->DeleteFile((*it).first);
+        LOG_TOPIC("5b1ae", DEBUG, Logger::ENGINES)
+            << "calling RocksDB DeleteFile for WAL file '" << (*it).first
+            << "'. status: " << rocksutils::convertStatus(s).errorMessage();
       } else {
         LOG_TOPIC("c2cc9", DEBUG, Logger::ENGINES)
             << "to-be-deleted RocksDB WAL file '" << (*it).first
@@ -3439,8 +3504,13 @@ TRI_voc_tick_t RocksDBEngine::releasedTick() const {
 
 void RocksDBEngine::releaseTick(TRI_voc_tick_t tick) {
   WRITE_LOCKER(lock, _walFileLock);
+
   if (tick > _releasedTick) {
     _releasedTick = tick;
+    lock.unlock();
+
+    // update metric for released tick
+    _metricsWalReleasedTickFlush.operator=(tick);
   }
 }
 

--- a/arangod/RocksDBEngine/RocksDBEngine.h
+++ b/arangod/RocksDBEngine/RocksDBEngine.h
@@ -35,6 +35,7 @@
 #include "Basics/Common.h"
 #include "Basics/Mutex.h"
 #include "Basics/ReadWriteLock.h"
+#include "RestServer/Metrics.h"
 #include "RocksDBEngine/RocksDBKeyBounds.h"
 #include "RocksDBEngine/RocksDBTypes.h"
 #include "StorageEngine/StorageEngine.h"
@@ -667,7 +668,9 @@ class RocksDBEngine final : public StorageEngine {
   uint64_t _recoveryStartSequence = 0;
 #endif
 
+  Gauge<uint64_t>& _metricsWalReleasedTickFlush;
   Gauge<uint64_t>& _metricsWalSequenceLowerBound;
+  Gauge<uint64_t>& _metricsLiveWalFiles;
   Gauge<uint64_t>& _metricsArchivedWalFiles;
   Gauge<uint64_t>& _metricsPrunableWalFiles;
   Gauge<uint64_t>& _metricsWalPruningActive;

--- a/tests/RestServer/FlushFeature-test.cpp
+++ b/tests/RestServer/FlushFeature-test.cpp
@@ -124,10 +124,13 @@ class FlushFeatureTest
 // -----------------------------------------------------------------------------
 
 TEST_F(FlushFeatureTest, test_subscription_retention) {
-  struct TestFlushSubscripion : arangodb::FlushSubscription {
+  struct TestFlushSubscription : arangodb::FlushSubscription {
+    TestFlushSubscription() : _name("test") {}
     TRI_voc_tick_t tick() const noexcept override { return _tick; }
+    std::string const& name() const override { return _name; }
 
     TRI_voc_tick_t _tick{};
+    std::string const _name;
   };
 
   auto& dbFeature = server.getFeature<arangodb::DatabaseFeature>();
@@ -139,7 +142,8 @@ TEST_F(FlushFeatureTest, test_subscription_retention) {
   feature.prepare();
 
   {
-    auto subscription = std::make_shared<TestFlushSubscripion>();
+    auto subscription = std::make_shared<TestFlushSubscription>();
+    ASSERT_EQ("test", subscription->name());
     feature.registerFlushSubscription(subscription);
 
     auto const subscriptionTick = engine.currentTick();


### PR DESCRIPTION
### Scope & Purpose

Backport of most of https://github.com/arangodb/arangodb/pull/18269

Adds more log messages for log topic `engines` in DEBUG and TRACE mode to see what's going on w.r.t. to pruning obsolete WAL files. 

Adds the following new metrics for tracking WAL files:
- `rocksdb_live_wal_files`: number of alive WAL files (not archived)
- `rocksdb_wal_released_tick_flush`: lower bound sequence number from which
  onwards WAL files will be kept (i.e. not deleted from the archive) because
  of external flushing needs. Candidates for these are arangosearch links
  and background index creation.
- `rocksdb_wal_released_tick_replication`: lower bound sequence number from
  which onwards WAL files will be kept because they may be needed by the
  replication.
- `arangodb_flush_subscriptions`: number of currently active flush
   subscriptions.

Gives names to FlushSubscriptions, so that if a FlushSubscription is blocking WAL file deletion, it can be figured out by turning on TRACE logging for the "flush" log topic.

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.10: https://github.com/arangodb/arangodb/pull/18291
  - [x] Backport for 3.9: this PR
  - [ ] Backport for 3.8: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 