### PR TITLE
Auto-flushing of WAL and column family data

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,22 @@
 devel
 -----
 
+* Auto-flush RocksDB WAL files and in-memory column family data if the number
+  of live WAL files exceeds a certain threshold. This is to make sure that
+  WAL files are moved to the archive when there are a lot of live WAL files
+  present (e.g. after a restart; in this case RocksDB does not count any
+  previously existing WAL files when calculating the size of WAL files and 
+  comparing it `max_total_wal_size`.
+  The feature can be configured via the following startup options:
+  - `--rocksdb.auto-flush-min-live-wal-files`: minimum number of live WAL
+    files that triggers an auto-flush. Defaults to `10`.
+  - `--rocksdb.auto-flush-check-interval`: interval (in seconds) in which
+    auto-flushes are executed. Defaults to `3600`.
+  Note that an auto-flush is only executed if the number of live WAL files 
+  exceeds the configured threshold and the last auto-flush is longer ago than
+  the configured auto-flush check interval. That way too frequent auto-flushes
+  can be avoided.
+
 * Updated arangosync to v2.16.0-preview-1.
 
 * Added the following metrics for WAL file tracking:

--- a/arangod/ClusterEngine/ClusterEngine.h
+++ b/arangod/ClusterEngine/ClusterEngine.h
@@ -153,7 +153,8 @@ class ClusterEngine final : public StorageEngine {
     return std::vector<std::string>();
   }
 
-  Result flushWal(bool waitForSync, bool flushColumnFamilies) override {
+  Result flushWal(bool /*waitForSync*/ = false,
+                  bool /*flushColumnFamilies*/ = false) override {
     return {};
   }
 

--- a/arangod/RocksDBEngine/RocksDBBackgroundThread.cpp
+++ b/arangod/RocksDBEngine/RocksDBBackgroundThread.cpp
@@ -193,6 +193,13 @@ void RocksDBBackgroundThread::run() {
           << ", earliest seq needed: " << earliestSeqNeeded
           << ", min tick for replication: " << minTickForReplication;
 
+      try {
+        _engine.flushOpenFilesIfRequired();
+      } catch (...) {
+        // whatever happens here, we don't want it to block/skip any of
+        // the following operations
+      }
+
       bool canPrune =
           TRI_microtime() >= startTime + _engine.pruneWaitTimeInitial();
       TRI_IF_FAILURE("BuilderIndex::purgeWal") { canPrune = true; }

--- a/arangod/RocksDBEngine/RocksDBEngine.cpp
+++ b/arangod/RocksDBEngine/RocksDBEngine.cpp
@@ -254,6 +254,8 @@ RocksDBEngine::RocksDBEngine(Server& server,
       _dbExisted(false),
       _runningRebuilds(0),
       _runningCompactions(0),
+      _autoFlushCheckInterval(60.0 * 60.0),
+      _autoFlushMinWalFiles(10),
       _metricsWalReleasedTickFlush(
           server.getFeature<metrics::MetricsFeature>().add(
               rocksdb_wal_released_tick_flush{})),
@@ -342,6 +344,30 @@ void RocksDBEngine::shutdownRocksDBInstance() noexcept {
 
   delete _db;
   _db = nullptr;
+}
+
+void RocksDBEngine::flushOpenFilesIfRequired() {
+  if (_metricsLiveWalFiles.load() < _autoFlushMinWalFiles) {
+    return;
+  }
+
+  auto now = std::chrono::steady_clock::now();
+  if (_autoFlushLastExecuted.time_since_epoch().count() == 0 ||
+      (now - _autoFlushLastExecuted) >=
+          std::chrono::duration<double>(_autoFlushCheckInterval)) {
+    LOG_TOPIC("9bf16", INFO, Logger::ENGINES)
+        << "auto flushing RocksDB wal and column families because number of "
+           "live WAL files is "
+        << _metricsLiveWalFiles.load();
+    Result res = flushWal(/*waitForSync*/ true, /*flushColumnFamilies*/ true);
+    if (res.fail()) {
+      LOG_TOPIC("e936c", WARN, Logger::ENGINES)
+          << "unable to flush RocksDB wal: " << res.errorMessage();
+    }
+    // set _autoFlushLastExecuted regardless of whether flushing has worked or
+    // not. we don't want to put too much stress onto the db
+    _autoFlushLastExecuted = now;
+  }
 }
 
 // inherited from ApplicationFeature
@@ -691,6 +717,30 @@ there are followers attached that may want to read the archive. In case the
 option is set and a leader deletes files from the archive that followers want to
 read, this aborts the replication on the followers. Followers can restart the
 replication doing a resync, however.)");
+
+  options
+      ->addOption("--rocksdb.auto-flush-min-live-wal-files",
+                  "The minimum number of live WAL files that triggers an "
+                  "auto-flush of WAL "
+                  "and column family data.",
+                  new UInt64Parameter(&_autoFlushMinWalFiles),
+                  arangodb::options::makeFlags(
+                      arangodb::options::Flags::DefaultNoComponents,
+                      arangodb::options::Flags::OnDBServer,
+                      arangodb::options::Flags::OnSingle))
+      .setIntroducedIn(31005);
+
+  options
+      ->addOption(
+          "--rocksdb.auto-flush-check-interval",
+          "The interval (in seconds) in which auto-flushes of WAL and column "
+          "family data is executed.",
+          new DoubleParameter(&_autoFlushCheckInterval),
+          arangodb::options::makeFlags(
+              arangodb::options::Flags::DefaultNoComponents,
+              arangodb::options::Flags::OnDBServer,
+              arangodb::options::Flags::OnSingle))
+      .setIntroducedIn(31005);
 
 #ifdef USE_ENTERPRISE
   collectEnterpriseOptions(options);

--- a/arangod/RocksDBEngine/RocksDBRestWalHandler.cpp
+++ b/arangod/RocksDBEngine/RocksDBRestWalHandler.cpp
@@ -101,8 +101,9 @@ void RocksDBRestWalHandler::flush() {
     return;
   }
 
-  bool waitForSync = false;
-  bool flushColumnFamilies = false;
+  bool waitForSync =
+      _request->parsedValue(StaticStrings::WaitForSyncString, false);
+  bool flushColumnFamilies = _request->parsedValue("waitForCollector", false);
 
   if (slice.isObject()) {
     // got a request body
@@ -119,12 +120,6 @@ void RocksDBRestWalHandler::flush() {
     } else if (value.isBoolean()) {
       flushColumnFamilies = value.getBoolean();
     }
-  } else {
-    // no request body
-    waitForSync =
-        _request->parsedValue(StaticStrings::WaitForSyncString, waitForSync);
-    flushColumnFamilies =
-        _request->parsedValue("waitForCollector", flushColumnFamilies);
   }
 
   Result res;
@@ -132,9 +127,8 @@ void RocksDBRestWalHandler::flush() {
     auto& feature = server().getFeature<ClusterFeature>();
     res = flushWalOnAllDBServers(feature, waitForSync, flushColumnFamilies);
   } else {
-    if (waitForSync) {
-      server().getFeature<EngineSelectorFeature>().engine().flushWal();
-    }
+    server().getFeature<EngineSelectorFeature>().engine().flushWal(
+        waitForSync, flushColumnFamilies);
   }
 
   if (res.fail()) {


### PR DESCRIPTION
### Scope & Purpose

* Auto-flush RocksDB WAL files and in-memory column family data if the number of live WAL files exceeds a certain threshold. This is to make sure that WAL files are moved to the archive when there are a lot of live WAL files present (e.g. after a restart; in this case RocksDB does not count any previously existing WAL files when calculating the size of WAL files and comparing it `max_total_wal_size`. The feature can be configured via the following startup options:
  - `--rocksdb.auto-flush-min-live-wal-files`: minimum number of live WAL files that triggers an auto-flush. Defaults to `10`.
  - `--rocksdb.auto-flush-check-interval`: interval (in seconds) in which auto-flushes are executed. Defaults to `3600`. Note that an auto-flush is only executed if the number of live WAL files exceeds the configured threshold and the last auto-flush is longer ago than the configured auto-flush check interval. That way too frequent auto-flushes can be avoided.

This fixes a problem that existing WAL files are not counted by RocksDB after startup, and their size is not accounted for and compared against `max_total_wal_size`. This may prevent WAL files from being moved to the archive quickly.

- [x] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: *(Please link PR)*
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 