### PR TITLE
Auto-flushing of WAL and column family data

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,22 @@
 v3.10.5 (XXXX-XX-XX)
 --------------------
 
+* Auto-flush RocksDB WAL files and in-memory column family data if the number
+  of live WAL files exceeds a certain threshold. This is to make sure that
+  WAL files are moved to the archive when there are a lot of live WAL files
+  present (e.g. after a restart; in this case RocksDB does not count any
+  previously existing WAL files when calculating the size of WAL files and 
+  comparing it `max_total_wal_size`.
+  The feature can be configured via the following startup options:
+  - `--rocksdb.auto-flush-min-live-wal-files`: minimum number of live WAL
+    files that triggers an auto-flush. Defaults to `10`.
+  - `--rocksdb.auto-flush-check-interval`: interval (in seconds) in which
+    auto-flushes are executed. Defaults to `3600`.
+  Note that an auto-flush is only executed if the number of live WAL files 
+  exceeds the configured threshold and the last auto-flush is longer ago than
+  the configured auto-flush check interval. That way too frequent auto-flushes
+  can be avoided.
+
 * Added the following metrics for WAL file tracking:
   - `rocksdb_live_wal_files`: number of alive WAL files (not archived)
   - `rocksdb_wal_released_tick_flush`: lower bound sequence number from which

--- a/arangod/ClusterEngine/ClusterEngine.h
+++ b/arangod/ClusterEngine/ClusterEngine.h
@@ -161,7 +161,8 @@ class ClusterEngine final : public StorageEngine {
     return std::vector<std::string>();
   }
 
-  Result flushWal(bool waitForSync, bool waitForCollector) override {
+  Result flushWal(bool /*waitForSync*/ = false,
+                  bool /*flushColumnFamilies*/ = false) override {
     return {};
   }
 

--- a/arangod/RocksDBEngine/RocksDBBackgroundThread.cpp
+++ b/arangod/RocksDBEngine/RocksDBBackgroundThread.cpp
@@ -192,6 +192,13 @@ void RocksDBBackgroundThread::run() {
           << ", earliest seq needed: " << earliestSeqNeeded
           << ", min tick for replication: " << minTickForReplication;
 
+      try {
+        _engine.flushOpenFilesIfRequired();
+      } catch (...) {
+        // whatever happens here, we don't want it to block/skip any of
+        // the following operations
+      }
+
       bool canPrune =
           TRI_microtime() >= startTime + _engine.pruneWaitTimeInitial();
       TRI_IF_FAILURE("BuilderIndex::purgeWal") { canPrune = true; }

--- a/arangod/RocksDBEngine/RocksDBEngine.h
+++ b/arangod/RocksDBEngine/RocksDBEngine.h
@@ -24,6 +24,7 @@
 
 #pragma once
 
+#include <chrono>
 #include <deque>
 #include <map>
 #include <memory>
@@ -163,6 +164,7 @@ class RocksDBEngine final : public StorageEngine {
   void stop() override;
   void unprepare() override;
 
+  void flushOpenFilesIfRequired();
   HealthData healthCheck() override;
 
   std::unique_ptr<transaction::Manager> createTransactionManager(
@@ -246,7 +248,8 @@ class RocksDBEngine final : public StorageEngine {
   /// The function parameter name are a remainder from MMFiles times, when
   /// they made more sense. This can be refactored at any point, so that
   /// flushing column families becomes a separate API.
-  Result flushWal(bool waitForSync, bool waitForCollector) override;
+  Result flushWal(bool waitForSync = false,
+                  bool flushColumnFamilies = false) override;
   void waitForEstimatorSync(std::chrono::milliseconds maxWaitTime) override;
 
   virtual std::unique_ptr<TRI_vocbase_t> openDatabase(
@@ -668,6 +671,14 @@ class RocksDBEngine final : public StorageEngine {
 #ifdef ARANGODB_USE_GOOGLE_TESTS
   uint64_t _recoveryStartSequence = 0;
 #endif
+
+  // last point in time when an auto-flush happened
+  std::chrono::steady_clock::time_point _autoFlushLastExecuted;
+  // interval (in s) in which auto-flushing is tried
+  double _autoFlushCheckInterval;
+  // minimum number of live WAL files that need to be present to trigger
+  // an auto-flush
+  uint64_t _autoFlushMinWalFiles;
 
   metrics::Gauge<uint64_t>& _metricsWalReleasedTickFlush;
   metrics::Gauge<uint64_t>& _metricsWalSequenceLowerBound;

--- a/arangod/RocksDBEngine/RocksDBRestWalHandler.cpp
+++ b/arangod/RocksDBEngine/RocksDBRestWalHandler.cpp
@@ -117,16 +117,16 @@ void RocksDBRestWalHandler::flush() {
 
     value = slice.get("waitForCollector");
     if (value.isString()) {
-      waitForCollector = basics::StringUtils::boolean(value.copyString());
+      flushColumnFamilies = basics::StringUtils::boolean(value.copyString());
     } else if (value.isBoolean()) {
-      waitForCollector = value.getBoolean();
+      flushColumnFamilies = value.getBoolean();
     }
   }
 
   auto res = TRI_ERROR_NO_ERROR;
   if (ServerState::instance()->isCoordinator()) {
     auto& feature = server().getFeature<ClusterFeature>();
-    res = flushWalOnAllDBServers(feature, waitForSync, waitForCollector);
+    res = flushWalOnAllDBServers(feature, waitForSync, flushColumnFamilies);
   } else {
     server().getFeature<EngineSelectorFeature>().engine().flushWal(
         waitForSync, flushColumnFamilies);


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/18299

* Auto-flush RocksDB WAL files and in-memory column family data if the number of live WAL files exceeds a certain threshold. This is to make sure that WAL files are moved to the archive when there are a lot of live WAL files present (e.g. after a restart; in this case RocksDB does not count any previously existing WAL files when calculating the size of WAL files and comparing it `max_total_wal_size`. The feature can be configured via the following startup options:
  - `--rocksdb.auto-flush-min-live-wal-files`: minimum number of live WAL files that triggers an auto-flush. Defaults to `10`.
  - `--rocksdb.auto-flush-check-interval`: interval (in seconds) in which auto-flushes are executed. Defaults to `3600`. Note that an auto-flush is only executed if the number of live WAL files exceeds the configured threshold and the last auto-flush is longer ago than the configured auto-flush check interval. That way too frequent auto-flushes can be avoided.

This fixes a problem that existing WAL files are not counted by RocksDB after startup, and their size is not accounted for and compared against `max_total_wal_size`. This may prevent WAL files from being moved to the archive quickly.

- [x] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.10: this PR
  - [x] Backport for 3.9: https://github.com/arangodb/arangodb/pull/18304
  - [ ] Backport for 3.8: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 