### PR TITLE
SEARCH-279 Fix consistency during update operations

### DIFF
--- a/arangod/IResearch/IResearchDataStore.h
+++ b/arangod/IResearch/IResearchDataStore.h
@@ -66,17 +66,13 @@ struct IResearchTrxState final : public TransactionState::Cookie {
   LinkLock _linkLock;  // should be first field to destroy last
   irs::IndexWriter::Transaction _ctx;
   PrimaryKeyFilterContainer _removals;  // list of document removals
-  bool _wasCommit = false;
 
   IResearchTrxState(LinkLock&& linkLock, irs::IndexWriter& writer) noexcept
       : _linkLock{std::move(linkLock)}, _ctx{writer.GetBatch()} {}
 
   ~IResearchTrxState() final {
-    if (!_wasCommit) {
-      _removals.clear();
-      _ctx.Reset();
-    }
-    TRI_ASSERT(_removals.empty());
+    _removals.clear();
+    _ctx.Abort();
   }
 
   void remove(LocalDocumentId value, bool nested) {

--- a/tests/js/client/chaos/test-chaos-load-common.inc
+++ b/tests/js/client/chaos/test-chaos-load-common.inc
@@ -133,14 +133,7 @@ const checkViewConsistency = (cn, isSearchAlias, isMaterialize) => {
     } else {
       result = runQuery("FOR d IN " + vn + " OPTIONS {waitForSync: true} COLLECT WITH COUNT INTO length RETURN length")[0];
     }
-    if (expected !== result) {
-      if (expected + 1 !== result) {
-        assertEqual(expected, result);
-      } else {
-        // TODO(MBkkt) Fix it
-        print("ArangoSearch inconsistent with RocksDB");
-      }
-    }
+    assertEqual(expected, result);
   };
 
   vn = viewName(cn + "_view", isSearchAlias);


### PR DESCRIPTION
### Scope & Purpose

1. Fix consistency during update operations
2. Allow us to remove double commit hack for recovery (which can produce small segments and additional work)
3. A lot of small fixes in IndexWriter see https://github.com/iresearch-toolkit/iresearch/pull/484
4. Wait ongoing transaction without spin-sleep-lock.
5. Introduce Abort for IndexWriter::Transaction

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: *(Please link PR)*
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

