### PR TITLE
[GORDO-1549] Make worker context own aggregators

### DIFF
--- a/arangod/Pregel/Algorithm.h
+++ b/arangod/Pregel/Algorithm.h
@@ -59,7 +59,6 @@ struct IAlgorithm {
   [[nodiscard]] virtual auto masterContext(
       std::unique_ptr<AggregatorHandler> aggregators,
       arangodb::velocypack::Slice userParams) const -> MasterContext* = 0;
-
   [[nodiscard]] virtual auto masterContextUnique(
       uint64_t vertexCount, uint64_t edgeCount,
       std::unique_ptr<AggregatorHandler> aggregators,
@@ -67,9 +66,13 @@ struct IAlgorithm {
       -> std::unique_ptr<MasterContext> = 0;
 
   [[nodiscard]] virtual auto workerContext(
-      std::unique_ptr<AggregatorHandler> conductorAggregators,
-      std::unique_ptr<AggregatorHandler> workerAggregators,
+      std::unique_ptr<AggregatorHandler> readAggregators,
+      std::unique_ptr<AggregatorHandler> writeAggregators,
       velocypack::Slice userParams) const -> WorkerContext* = 0;
+  [[nodiscard]] virtual auto workerContextUnique(
+      std::unique_ptr<AggregatorHandler> readAggregators,
+      std::unique_ptr<AggregatorHandler> writeAggregators,
+      velocypack::Slice userParams) const -> std::unique_ptr<WorkerContext> = 0;
 
   [[nodiscard]] virtual auto name() const -> std::string_view = 0;
 };

--- a/arangod/Pregel/Algorithm.h
+++ b/arangod/Pregel/Algorithm.h
@@ -56,7 +56,7 @@ struct IAlgorithm {
     return nullptr;
   }
 
-  [[nodiscard]] virtual auto masterContext(
+  [[deprecated]] [[nodiscard]] virtual auto masterContext(
       std::unique_ptr<AggregatorHandler> aggregators,
       arangodb::velocypack::Slice userParams) const -> MasterContext* = 0;
   [[nodiscard]] virtual auto masterContextUnique(
@@ -65,7 +65,7 @@ struct IAlgorithm {
       arangodb::velocypack::Slice userParams) const
       -> std::unique_ptr<MasterContext> = 0;
 
-  [[nodiscard]] virtual auto workerContext(
+  [[deprecated]] [[nodiscard]] virtual auto workerContext(
       std::unique_ptr<AggregatorHandler> readAggregators,
       std::unique_ptr<AggregatorHandler> writeAggregators,
       velocypack::Slice userParams) const -> WorkerContext* = 0;
@@ -98,8 +98,16 @@ struct Algorithm : IAlgorithm {
 
  public:
   virtual std::shared_ptr<graph_format const> inputFormat() const = 0;
-  virtual message_format* messageFormat() const = 0;
-  virtual message_combiner* messageCombiner() const { return nullptr; }
+  [[deprecated]] virtual message_format* messageFormat() const = 0;
+  [[nodiscard]] virtual auto messageFormatUnique() const
+      -> std::unique_ptr<message_format> = 0;
+  [[deprecated]] virtual message_combiner* messageCombiner() const {
+    return nullptr;
+  }
+  [[nodiscard]] virtual auto messageCombinerUnique() const
+      -> std::unique_ptr<message_combiner> {
+    return nullptr;
+  }
   virtual vertex_computation* createComputation(
       std::shared_ptr<WorkerConfig const>) const = 0;
   virtual vertex_compensation* createCompensation(

--- a/arangod/Pregel/Algorithm.h
+++ b/arangod/Pregel/Algorithm.h
@@ -66,6 +66,11 @@ struct IAlgorithm {
       arangodb::velocypack::Slice userParams) const
       -> std::unique_ptr<MasterContext> = 0;
 
+  [[nodiscard]] virtual auto workerContext(
+      std::unique_ptr<AggregatorHandler> conductorAggregators,
+      std::unique_ptr<AggregatorHandler> workerAggregators,
+      velocypack::Slice userParams) const -> WorkerContext* = 0;
+
   [[nodiscard]] virtual auto name() const -> std::string_view = 0;
 };
 
@@ -89,10 +94,6 @@ struct Algorithm : IAlgorithm {
       VertexCompensation<vertex_type, edge_type, message_type>;
 
  public:
-  [[nodiscard]] virtual WorkerContext* workerContext(
-      velocypack::Slice userParams) const {
-    return new WorkerContext();
-  }
   virtual std::shared_ptr<graph_format const> inputFormat() const = 0;
   virtual message_format* messageFormat() const = 0;
   virtual message_combiner* messageCombiner() const { return nullptr; }

--- a/arangod/Pregel/Algos/ColorPropagation/ColorPropagation.cpp
+++ b/arangod/Pregel/Algos/ColorPropagation/ColorPropagation.cpp
@@ -99,8 +99,13 @@ ColorPropagation::createComputation(
   return new ColorPropagationComputation();
 }
 
-WorkerContext* ColorPropagation::workerContext(VPackSlice userParams) const {
-  return new ColorPropagationWorkerContext(_maxGss, _numColors);
+[[nodiscard]] auto ColorPropagation::workerContext(
+    std::unique_ptr<AggregatorHandler> readAggregators,
+    std::unique_ptr<AggregatorHandler> writeAggregators,
+    velocypack::Slice userParams) const -> WorkerContext* {
+  return new ColorPropagationWorkerContext(std::move(readAggregators),
+                                           std::move(writeAggregators), _maxGss,
+                                           _numColors);
 }
 
 struct ColorPropagationMasterContext : public MasterContext {
@@ -122,9 +127,13 @@ struct ColorPropagationMasterContext : public MasterContext {
       vertexCount, edgeCount, std::move(aggregators));
 }
 
-ColorPropagationWorkerContext::ColorPropagationWorkerContext(uint64_t maxGss,
-                                                             uint16_t numColors)
-    : numColors{numColors}, maxGss{maxGss} {}
+ColorPropagationWorkerContext::ColorPropagationWorkerContext(
+    std::unique_ptr<AggregatorHandler> readAggregators,
+    std::unique_ptr<AggregatorHandler> writeAggregators, uint64_t maxGss,
+    uint16_t numColors)
+    : WorkerContext(std::move(readAggregators), std::move(writeAggregators)),
+      numColors{numColors},
+      maxGss{maxGss} {}
 
 CollectionIdType getEquivalenceClass(
     VPackSlice vertexDocument, std::string_view equivalenceClassFieldName) {

--- a/arangod/Pregel/Algos/ColorPropagation/ColorPropagation.cpp
+++ b/arangod/Pregel/Algos/ColorPropagation/ColorPropagation.cpp
@@ -107,6 +107,14 @@ ColorPropagation::createComputation(
                                            std::move(writeAggregators), _maxGss,
                                            _numColors);
 }
+[[nodiscard]] auto ColorPropagation::workerContextUnique(
+    std::unique_ptr<AggregatorHandler> readAggregators,
+    std::unique_ptr<AggregatorHandler> writeAggregators,
+    velocypack::Slice userParams) const -> std::unique_ptr<WorkerContext> {
+  return std::make_unique<ColorPropagationWorkerContext>(
+      std::move(readAggregators), std::move(writeAggregators), _maxGss,
+      _numColors);
+}
 
 struct ColorPropagationMasterContext : public MasterContext {
   ColorPropagationMasterContext(uint64_t vertexCount, uint64_t edgeCount,

--- a/arangod/Pregel/Algos/ColorPropagation/ColorPropagation.h
+++ b/arangod/Pregel/Algos/ColorPropagation/ColorPropagation.h
@@ -134,6 +134,11 @@ struct ColorPropagation : public Algorithm<ColorPropagationValue, int8_t,
       std::unique_ptr<AggregatorHandler> readAggregators,
       std::unique_ptr<AggregatorHandler> writeAggregators,
       velocypack::Slice userParams) const -> WorkerContext* override;
+  [[nodiscard]] auto workerContextUnique(
+      std::unique_ptr<AggregatorHandler> readAggregators,
+      std::unique_ptr<AggregatorHandler> writeAggregators,
+      velocypack::Slice userParams) const
+      -> std::unique_ptr<WorkerContext> override;
 
   [[nodiscard]] auto masterContext(
       std::unique_ptr<AggregatorHandler> aggregators,

--- a/arangod/Pregel/Algos/ColorPropagation/ColorPropagation.h
+++ b/arangod/Pregel/Algos/ColorPropagation/ColorPropagation.h
@@ -125,6 +125,10 @@ struct ColorPropagation : public Algorithm<ColorPropagationValue, int8_t,
       const override {
     return new ColorPropagationValueMessageFormat();
   }
+  [[nodiscard]] auto messageFormatUnique() const
+      -> std::unique_ptr<message_format> override {
+    return std::make_unique<ColorPropagationValueMessageFormat>();
+  }
 
   VertexComputation<ColorPropagationValue, int8_t,
                     ColorPropagationMessageValue>*

--- a/arangod/Pregel/Algos/ColorPropagation/ColorPropagation.h
+++ b/arangod/Pregel/Algos/ColorPropagation/ColorPropagation.h
@@ -23,6 +23,7 @@
 
 #pragma once
 
+#include "Pregel/AggregatorHandler.h"
 #include "Pregel/Algorithm.h"
 #include "Pregel/VertexComputation.h"
 #include "Pregel/Algos/ColorPropagation/ColorPropagationValue.h"
@@ -129,8 +130,10 @@ struct ColorPropagation : public Algorithm<ColorPropagationValue, int8_t,
                     ColorPropagationMessageValue>*
       createComputation(std::shared_ptr<WorkerConfig const>) const override;
 
-  [[nodiscard]] WorkerContext* workerContext(
-      VPackSlice userParams) const override;
+  [[nodiscard]] auto workerContext(
+      std::unique_ptr<AggregatorHandler> readAggregators,
+      std::unique_ptr<AggregatorHandler> writeAggregators,
+      velocypack::Slice userParams) const -> WorkerContext* override;
 
   [[nodiscard]] auto masterContext(
       std::unique_ptr<AggregatorHandler> aggregators,
@@ -201,7 +204,10 @@ struct ColorPropagation : public Algorithm<ColorPropagationValue, int8_t,
 enum class State { SendInitialColors, PropagateColors };
 
 struct ColorPropagationWorkerContext : public WorkerContext {
-  ColorPropagationWorkerContext(uint64_t maxGss, uint16_t numColors);
+  ColorPropagationWorkerContext(
+      std::unique_ptr<AggregatorHandler> readAggregators,
+      std::unique_ptr<AggregatorHandler> writeAggregators, uint64_t maxGss,
+      uint16_t numColors);
   void postGlobalSuperstep(uint64_t gss) override;
 
   State state = State::SendInitialColors;

--- a/arangod/Pregel/Algos/ConnectedComponents/ConnectedComponents.cpp
+++ b/arangod/Pregel/Algos/ConnectedComponents/ConnectedComponents.cpp
@@ -28,6 +28,7 @@
 #include "Pregel/GraphStore/GraphStore.h"
 #include "Pregel/IncomingCache.h"
 #include "Pregel/VertexComputation.h"
+#include "Pregel/WorkerContext.h"
 
 using namespace arangodb;
 using namespace arangodb::pregel;
@@ -98,6 +99,21 @@ VertexCompensation<uint64_t, uint8_t, uint64_t>*
 ConnectedComponents::createCompensation(
     std::shared_ptr<WorkerConfig const> config) const {
   return new MyCompensation();
+}
+
+struct ConnectedComponentsWorkerContext : public WorkerContext {
+  ConnectedComponentsWorkerContext(
+      std::unique_ptr<AggregatorHandler> readAggregators,
+      std::unique_ptr<AggregatorHandler> writeAggregators)
+      : WorkerContext(std::move(readAggregators),
+                      std::move(writeAggregators)){};
+};
+[[nodiscard]] auto ConnectedComponents::workerContext(
+    std::unique_ptr<AggregatorHandler> readAggregators,
+    std::unique_ptr<AggregatorHandler> writeAggregators,
+    velocypack::Slice userParams) const -> WorkerContext* {
+  return new ConnectedComponentsWorkerContext(std::move(readAggregators),
+                                              std::move(writeAggregators));
 }
 
 struct ConnectedComponentsMasterContext : public MasterContext {

--- a/arangod/Pregel/Algos/ConnectedComponents/ConnectedComponents.cpp
+++ b/arangod/Pregel/Algos/ConnectedComponents/ConnectedComponents.cpp
@@ -115,6 +115,13 @@ struct ConnectedComponentsWorkerContext : public WorkerContext {
   return new ConnectedComponentsWorkerContext(std::move(readAggregators),
                                               std::move(writeAggregators));
 }
+[[nodiscard]] auto ConnectedComponents::workerContextUnique(
+    std::unique_ptr<AggregatorHandler> readAggregators,
+    std::unique_ptr<AggregatorHandler> writeAggregators,
+    velocypack::Slice userParams) const -> std::unique_ptr<WorkerContext> {
+  return std::make_unique<ConnectedComponentsWorkerContext>(
+      std::move(readAggregators), std::move(writeAggregators));
+}
 
 struct ConnectedComponentsMasterContext : public MasterContext {
   ConnectedComponentsMasterContext(

--- a/arangod/Pregel/Algos/ConnectedComponents/ConnectedComponents.h
+++ b/arangod/Pregel/Algos/ConnectedComponents/ConnectedComponents.h
@@ -66,6 +66,11 @@ struct ConnectedComponents
       std::unique_ptr<AggregatorHandler> readAggregators,
       std::unique_ptr<AggregatorHandler> writeAggregators,
       velocypack::Slice userParams) const -> WorkerContext* override;
+  [[nodiscard]] auto workerContextUnique(
+      std::unique_ptr<AggregatorHandler> readAggregators,
+      std::unique_ptr<AggregatorHandler> writeAggregators,
+      velocypack::Slice userParams) const
+      -> std::unique_ptr<WorkerContext> override;
 
   [[nodiscard]] auto masterContext(
       std::unique_ptr<AggregatorHandler> aggregators,

--- a/arangod/Pregel/Algos/ConnectedComponents/ConnectedComponents.h
+++ b/arangod/Pregel/Algos/ConnectedComponents/ConnectedComponents.h
@@ -54,8 +54,16 @@ struct ConnectedComponents
   MessageFormat<uint64_t>* messageFormat() const override {
     return new IntegerMessageFormat<uint64_t>();
   }
+  [[nodiscard]] auto messageFormatUnique() const
+      -> std::unique_ptr<message_format> override {
+    return std::make_unique<IntegerMessageFormat<uint64_t>>();
+  }
   MessageCombiner<uint64_t>* messageCombiner() const override {
     return new MinCombiner<uint64_t>();
+  }
+  [[nodiscard]] auto messageCombinerUnique() const
+      -> std::unique_ptr<message_combiner> override {
+    return std::make_unique<MinCombiner<uint64_t>>();
   }
   VertexComputation<uint64_t, uint8_t, uint64_t>* createComputation(
       std::shared_ptr<WorkerConfig const>) const override;

--- a/arangod/Pregel/Algos/ConnectedComponents/ConnectedComponents.h
+++ b/arangod/Pregel/Algos/ConnectedComponents/ConnectedComponents.h
@@ -62,6 +62,11 @@ struct ConnectedComponents
   VertexCompensation<uint64_t, uint8_t, uint64_t>* createCompensation(
       std::shared_ptr<WorkerConfig const>) const override;
 
+  [[nodiscard]] auto workerContext(
+      std::unique_ptr<AggregatorHandler> readAggregators,
+      std::unique_ptr<AggregatorHandler> writeAggregators,
+      velocypack::Slice userParams) const -> WorkerContext* override;
+
   [[nodiscard]] auto masterContext(
       std::unique_ptr<AggregatorHandler> aggregators,
       arangodb::velocypack::Slice userParams) const -> MasterContext* override;

--- a/arangod/Pregel/Algos/DMID/DMID.cpp
+++ b/arangod/Pregel/Algos/DMID/DMID.cpp
@@ -675,6 +675,13 @@ struct DMIDWorkerContext : public WorkerContext {
   return new DMIDWorkerContext(std::move(readAggregators),
                                std::move(writeAggregators));
 }
+[[nodiscard]] auto DMID::workerContextUnique(
+    std::unique_ptr<AggregatorHandler> readAggregators,
+    std::unique_ptr<AggregatorHandler> writeAggregators,
+    velocypack::Slice userParams) const -> std::unique_ptr<WorkerContext> {
+  return std::make_unique<DMIDWorkerContext>(std::move(readAggregators),
+                                             std::move(writeAggregators));
+}
 
 struct DMIDMasterContext : public MasterContext {
   DMIDMasterContext(uint64_t vertexCount, uint64_t edgeCount,

--- a/arangod/Pregel/Algos/DMID/DMID.cpp
+++ b/arangod/Pregel/Algos/DMID/DMID.cpp
@@ -662,6 +662,20 @@ std::shared_ptr<GraphFormat<DMIDValue, float> const> DMID::inputFormat() const {
   return std::make_shared<DMIDGraphFormat>(_resultField, _maxCommunities);
 }
 
+struct DMIDWorkerContext : public WorkerContext {
+  DMIDWorkerContext(std::unique_ptr<AggregatorHandler> readAggregators,
+                    std::unique_ptr<AggregatorHandler> writeAggregators)
+      : WorkerContext(std::move(readAggregators),
+                      std::move(writeAggregators)){};
+};
+[[nodiscard]] auto DMID::workerContext(
+    std::unique_ptr<AggregatorHandler> readAggregators,
+    std::unique_ptr<AggregatorHandler> writeAggregators,
+    velocypack::Slice userParams) const -> WorkerContext* {
+  return new DMIDWorkerContext(std::move(readAggregators),
+                               std::move(writeAggregators));
+}
+
 struct DMIDMasterContext : public MasterContext {
   DMIDMasterContext(uint64_t vertexCount, uint64_t edgeCount,
                     std::unique_ptr<AggregatorHandler> aggregators)

--- a/arangod/Pregel/Algos/DMID/DMID.cpp
+++ b/arangod/Pregel/Algos/DMID/DMID.cpp
@@ -846,3 +846,7 @@ IAggregator* DMID::aggregator(std::string const& name) const {
 MessageFormat<DMIDMessage>* DMID::messageFormat() const {
   return new DMIDMessageFormat();
 }
+[[nodiscard]] auto DMID::messageFormatUnique() const
+    -> std::unique_ptr<message_format> {
+  return std::make_unique<DMIDMessageFormat>();
+}

--- a/arangod/Pregel/Algos/DMID/DMID.h
+++ b/arangod/Pregel/Algos/DMID/DMID.h
@@ -59,6 +59,8 @@ struct DMID : public SimpleAlgorithm<DMIDValue, float, DMIDMessage> {
   std::shared_ptr<GraphFormat<DMIDValue, float> const> inputFormat()
       const override;
   MessageFormat<DMIDMessage>* messageFormat() const override;
+  [[nodiscard]] auto messageFormatUnique() const
+      -> std::unique_ptr<message_format> override;
 
   VertexComputation<DMIDValue, float, DMIDMessage>* createComputation(
       std::shared_ptr<WorkerConfig const>) const override;

--- a/arangod/Pregel/Algos/DMID/DMID.h
+++ b/arangod/Pregel/Algos/DMID/DMID.h
@@ -67,6 +67,11 @@ struct DMID : public SimpleAlgorithm<DMIDValue, float, DMIDMessage> {
       std::unique_ptr<AggregatorHandler> readAggregators,
       std::unique_ptr<AggregatorHandler> writeAggregators,
       velocypack::Slice userParams) const -> WorkerContext* override;
+  [[nodiscard]] auto workerContextUnique(
+      std::unique_ptr<AggregatorHandler> readAggregators,
+      std::unique_ptr<AggregatorHandler> writeAggregators,
+      velocypack::Slice userParams) const
+      -> std::unique_ptr<WorkerContext> override;
 
   [[nodiscard]] auto masterContext(
       std::unique_ptr<AggregatorHandler> aggregators,

--- a/arangod/Pregel/Algos/DMID/DMID.h
+++ b/arangod/Pregel/Algos/DMID/DMID.h
@@ -63,6 +63,11 @@ struct DMID : public SimpleAlgorithm<DMIDValue, float, DMIDMessage> {
   VertexComputation<DMIDValue, float, DMIDMessage>* createComputation(
       std::shared_ptr<WorkerConfig const>) const override;
 
+  [[nodiscard]] auto workerContext(
+      std::unique_ptr<AggregatorHandler> readAggregators,
+      std::unique_ptr<AggregatorHandler> writeAggregators,
+      velocypack::Slice userParams) const -> WorkerContext* override;
+
   [[nodiscard]] auto masterContext(
       std::unique_ptr<AggregatorHandler> aggregators,
       arangodb::velocypack::Slice userParams) const -> MasterContext* override;

--- a/arangod/Pregel/Algos/EffectiveCloseness/EffectiveCloseness.cpp
+++ b/arangod/Pregel/Algos/EffectiveCloseness/EffectiveCloseness.cpp
@@ -38,9 +38,17 @@ using namespace arangodb::pregel::algos;
 MessageFormat<HLLCounter>* EffectiveCloseness::messageFormat() const {
   return new HLLCounterFormat();
 }
+[[nodiscard]] auto EffectiveCloseness::messageFormatUnique() const
+    -> std::unique_ptr<message_format> {
+  return std::make_unique<HLLCounterFormat>();
+}
 
 MessageCombiner<HLLCounter>* EffectiveCloseness::messageCombiner() const {
   return new HLLCounterCombiner();
+}
+[[nodiscard]] auto EffectiveCloseness::messageCombinerUnique() const
+    -> std::unique_ptr<message_combiner> {
+  return std::make_unique<HLLCounterCombiner>();
 }
 
 struct ECComputation : public VertexComputation<ECValue, int8_t, HLLCounter> {

--- a/arangod/Pregel/Algos/EffectiveCloseness/EffectiveCloseness.cpp
+++ b/arangod/Pregel/Algos/EffectiveCloseness/EffectiveCloseness.cpp
@@ -130,6 +130,21 @@ EffectiveCloseness::inputFormat() const {
   return std::make_shared<ECGraphFormat>(_resultField);
 }
 
+struct EffectiveClosenessWorkerContext : public WorkerContext {
+  EffectiveClosenessWorkerContext(
+      std::unique_ptr<AggregatorHandler> readAggregators,
+      std::unique_ptr<AggregatorHandler> writeAggregators)
+      : WorkerContext(std::move(readAggregators),
+                      std::move(writeAggregators)){};
+};
+[[nodiscard]] auto EffectiveCloseness::workerContext(
+    std::unique_ptr<AggregatorHandler> readAggregators,
+    std::unique_ptr<AggregatorHandler> writeAggregators,
+    velocypack::Slice userParams) const -> WorkerContext* {
+  return new EffectiveClosenessWorkerContext(std::move(readAggregators),
+                                             std::move(writeAggregators));
+}
+
 struct EffectiveClosenessMasterContext : public MasterContext {
   EffectiveClosenessMasterContext(
       uint64_t vertexCount, uint64_t edgeCount,

--- a/arangod/Pregel/Algos/EffectiveCloseness/EffectiveCloseness.cpp
+++ b/arangod/Pregel/Algos/EffectiveCloseness/EffectiveCloseness.cpp
@@ -144,6 +144,13 @@ struct EffectiveClosenessWorkerContext : public WorkerContext {
   return new EffectiveClosenessWorkerContext(std::move(readAggregators),
                                              std::move(writeAggregators));
 }
+[[nodiscard]] auto EffectiveCloseness::workerContextUnique(
+    std::unique_ptr<AggregatorHandler> readAggregators,
+    std::unique_ptr<AggregatorHandler> writeAggregators,
+    velocypack::Slice userParams) const -> std::unique_ptr<WorkerContext> {
+  return std::make_unique<EffectiveClosenessWorkerContext>(
+      std::move(readAggregators), std::move(writeAggregators));
+}
 
 struct EffectiveClosenessMasterContext : public MasterContext {
   EffectiveClosenessMasterContext(

--- a/arangod/Pregel/Algos/EffectiveCloseness/EffectiveCloseness.h
+++ b/arangod/Pregel/Algos/EffectiveCloseness/EffectiveCloseness.h
@@ -55,6 +55,11 @@ struct EffectiveCloseness
   VertexComputation<ECValue, int8_t, HLLCounter>* createComputation(
       std::shared_ptr<WorkerConfig const>) const override;
 
+  [[nodiscard]] auto workerContext(
+      std::unique_ptr<AggregatorHandler> readAggregators,
+      std::unique_ptr<AggregatorHandler> writeAggregators,
+      velocypack::Slice userParams) const -> WorkerContext* override;
+
   [[nodiscard]] auto masterContext(
       std::unique_ptr<AggregatorHandler> aggregators,
       arangodb::velocypack::Slice userParams) const -> MasterContext* override;

--- a/arangod/Pregel/Algos/EffectiveCloseness/EffectiveCloseness.h
+++ b/arangod/Pregel/Algos/EffectiveCloseness/EffectiveCloseness.h
@@ -59,6 +59,11 @@ struct EffectiveCloseness
       std::unique_ptr<AggregatorHandler> readAggregators,
       std::unique_ptr<AggregatorHandler> writeAggregators,
       velocypack::Slice userParams) const -> WorkerContext* override;
+  [[nodiscard]] auto workerContextUnique(
+      std::unique_ptr<AggregatorHandler> readAggregators,
+      std::unique_ptr<AggregatorHandler> writeAggregators,
+      velocypack::Slice userParams) const
+      -> std::unique_ptr<WorkerContext> override;
 
   [[nodiscard]] auto masterContext(
       std::unique_ptr<AggregatorHandler> aggregators,

--- a/arangod/Pregel/Algos/EffectiveCloseness/EffectiveCloseness.h
+++ b/arangod/Pregel/Algos/EffectiveCloseness/EffectiveCloseness.h
@@ -50,7 +50,11 @@ struct EffectiveCloseness
   std::shared_ptr<GraphFormat<ECValue, int8_t> const> inputFormat()
       const override;
   MessageFormat<HLLCounter>* messageFormat() const override;
+  [[nodiscard]] auto messageFormatUnique() const
+      -> std::unique_ptr<message_format> override;
   MessageCombiner<HLLCounter>* messageCombiner() const override;
+  [[nodiscard]] auto messageCombinerUnique() const
+      -> std::unique_ptr<message_combiner> override;
 
   VertexComputation<ECValue, int8_t, HLLCounter>* createComputation(
       std::shared_ptr<WorkerConfig const>) const override;

--- a/arangod/Pregel/Algos/HITS/HITS.cpp
+++ b/arangod/Pregel/Algos/HITS/HITS.cpp
@@ -140,6 +140,13 @@ std::shared_ptr<GraphFormat<HITSValue, int8_t> const> HITS::inputFormat()
   return new HITSWorkerContext(std::move(readAggregators),
                                std::move(writeAggregators));
 }
+[[nodiscard]] auto HITS::workerContextUnique(
+    std::unique_ptr<AggregatorHandler> readAggregators,
+    std::unique_ptr<AggregatorHandler> writeAggregators,
+    velocypack::Slice userParams) const -> std::unique_ptr<WorkerContext> {
+  return std::make_unique<HITSWorkerContext>(std::move(readAggregators),
+                                             std::move(writeAggregators));
+}
 
 struct HITSMasterContext : public MasterContext {
   // note: this is identical to getThreshold() in HITSKleinberg.cpp

--- a/arangod/Pregel/Algos/HITS/HITS.cpp
+++ b/arangod/Pregel/Algos/HITS/HITS.cpp
@@ -29,6 +29,7 @@
 #include "Pregel/IncomingCache.h"
 #include "Pregel/MasterContext.h"
 #include "Pregel/VertexComputation.h"
+#include "Pregel/WorkerContext.h"
 
 using namespace arangodb;
 using namespace arangodb::pregel;
@@ -38,7 +39,10 @@ static std::string const kAuthNorm = "auth";
 static std::string const kHubNorm = "hub";
 
 struct HITSWorkerContext : public WorkerContext {
-  HITSWorkerContext() {}
+  HITSWorkerContext(std::unique_ptr<AggregatorHandler> readAggregators,
+                    std::unique_ptr<AggregatorHandler> writeAggregators)
+      : WorkerContext(std::move(readAggregators), std::move(writeAggregators)) {
+  }
 
   double authNormRoot = 0;
   double hubNormRoot = 0;
@@ -129,8 +133,12 @@ std::shared_ptr<GraphFormat<HITSValue, int8_t> const> HITS::inputFormat()
   return std::make_shared<HITSGraphFormat>(_resultField);
 }
 
-WorkerContext* HITS::workerContext(VPackSlice userParams) const {
-  return new HITSWorkerContext();
+[[nodiscard]] auto HITS::workerContext(
+    std::unique_ptr<AggregatorHandler> readAggregators,
+    std::unique_ptr<AggregatorHandler> writeAggregators,
+    velocypack::Slice userParams) const -> WorkerContext* {
+  return new HITSWorkerContext(std::move(readAggregators),
+                               std::move(writeAggregators));
 }
 
 struct HITSMasterContext : public MasterContext {

--- a/arangod/Pregel/Algos/HITS/HITS.h
+++ b/arangod/Pregel/Algos/HITS/HITS.h
@@ -69,8 +69,11 @@ struct HITS : public SimpleAlgorithm<HITSValue, int8_t, SenderMessage<double>> {
   VertexComputation<HITSValue, int8_t, SenderMessage<double>>*
       createComputation(std::shared_ptr<WorkerConfig const>) const override;
 
-  [[nodiscard]] WorkerContext* workerContext(
-      VPackSlice userParams) const override;
+  [[nodiscard]] auto workerContext(
+      std::unique_ptr<AggregatorHandler> readAggregators,
+      std::unique_ptr<AggregatorHandler> writeAggregators,
+      velocypack::Slice userParams) const -> WorkerContext* override;
+
   [[nodiscard]] auto masterContext(
       std::unique_ptr<AggregatorHandler> aggregators,
       arangodb::velocypack::Slice userParams) const -> MasterContext* override;

--- a/arangod/Pregel/Algos/HITS/HITS.h
+++ b/arangod/Pregel/Algos/HITS/HITS.h
@@ -65,6 +65,10 @@ struct HITS : public SimpleAlgorithm<HITSValue, int8_t, SenderMessage<double>> {
       const override {
     return new SenderMessageFormat<double>();
   }
+  [[nodiscard]] auto messageFormatUnique() const
+      -> std::unique_ptr<message_format> override {
+    return std::make_unique<SenderMessageFormat<double>>();
+  }
 
   VertexComputation<HITSValue, int8_t, SenderMessage<double>>*
       createComputation(std::shared_ptr<WorkerConfig const>) const override;

--- a/arangod/Pregel/Algos/HITS/HITS.h
+++ b/arangod/Pregel/Algos/HITS/HITS.h
@@ -73,6 +73,11 @@ struct HITS : public SimpleAlgorithm<HITSValue, int8_t, SenderMessage<double>> {
       std::unique_ptr<AggregatorHandler> readAggregators,
       std::unique_ptr<AggregatorHandler> writeAggregators,
       velocypack::Slice userParams) const -> WorkerContext* override;
+  [[nodiscard]] auto workerContextUnique(
+      std::unique_ptr<AggregatorHandler> readAggregators,
+      std::unique_ptr<AggregatorHandler> writeAggregators,
+      velocypack::Slice userParams) const
+      -> std::unique_ptr<WorkerContext> override;
 
   [[nodiscard]] auto masterContext(
       std::unique_ptr<AggregatorHandler> aggregators,

--- a/arangod/Pregel/Algos/HITSKleinberg/HITSKleinberg.cpp
+++ b/arangod/Pregel/Algos/HITSKleinberg/HITSKleinberg.cpp
@@ -73,9 +73,13 @@ enum class State {
 };
 
 struct HITSKleinbergWorkerContext : public WorkerContext {
-  HITSKleinbergWorkerContext(size_t maxGSS, size_t numIterations,
-                             double threshold)
-      : numIterations(numIterations), threshold(threshold){};
+  HITSKleinbergWorkerContext(
+      std::unique_ptr<AggregatorHandler> readAggregators,
+      std::unique_ptr<AggregatorHandler> writeAggregators, size_t maxGSS,
+      size_t numIterations, double threshold)
+      : WorkerContext(std::move(readAggregators), std::move(writeAggregators)),
+        numIterations(numIterations),
+        threshold(threshold){};
 
   double authDivisor = 0;
   double hubDivisor = 0;
@@ -309,9 +313,14 @@ HITSKleinberg::inputFormat() const {
   return std::make_shared<HITSKleinbergGraphFormat>(_resultField);
 }
 
-WorkerContext* HITSKleinberg::workerContext(VPackSlice userParams) const {
+[[nodiscard]] auto HITSKleinberg::workerContext(
+    std::unique_ptr<AggregatorHandler> readAggregators,
+    std::unique_ptr<AggregatorHandler> writeAggregators,
+    velocypack::Slice userParams) const -> WorkerContext* {
   double const threshold = getThreshold(userParams);
-  return new HITSKleinbergWorkerContext(maxGSS, numIterations, threshold);
+  return new HITSKleinbergWorkerContext(std::move(readAggregators),
+                                        std::move(writeAggregators), maxGSS,
+                                        numIterations, threshold);
 }
 
 struct HITSKleinbergMasterContext : public MasterContext {

--- a/arangod/Pregel/Algos/HITSKleinberg/HITSKleinberg.cpp
+++ b/arangod/Pregel/Algos/HITSKleinberg/HITSKleinberg.cpp
@@ -322,6 +322,15 @@ HITSKleinberg::inputFormat() const {
                                         std::move(writeAggregators), maxGSS,
                                         numIterations, threshold);
 }
+[[nodiscard]] auto HITSKleinberg::workerContextUnique(
+    std::unique_ptr<AggregatorHandler> readAggregators,
+    std::unique_ptr<AggregatorHandler> writeAggregators,
+    velocypack::Slice userParams) const -> std::unique_ptr<WorkerContext> {
+  double const threshold = getThreshold(userParams);
+  return std::make_unique<HITSKleinbergWorkerContext>(
+      std::move(readAggregators), std::move(writeAggregators), maxGSS,
+      numIterations, threshold);
+}
 
 struct HITSKleinbergMasterContext : public MasterContext {
   double const threshold;

--- a/arangod/Pregel/Algos/HITSKleinberg/HITSKleinberg.h
+++ b/arangod/Pregel/Algos/HITSKleinberg/HITSKleinberg.h
@@ -69,8 +69,10 @@ struct HITSKleinberg : public SimpleAlgorithm<HITSKleinbergValue, int8_t,
   VertexComputation<HITSKleinbergValue, int8_t, SenderMessage<double>>*
       createComputation(std::shared_ptr<WorkerConfig const>) const override;
 
-  [[nodiscard]] WorkerContext* workerContext(
-      VPackSlice userParams) const override;
+  [[nodiscard]] auto workerContext(
+      std::unique_ptr<AggregatorHandler> readAggregators,
+      std::unique_ptr<AggregatorHandler> writeAggregators,
+      velocypack::Slice userParams) const -> WorkerContext* override;
 
   [[nodiscard]] auto masterContext(
       std::unique_ptr<AggregatorHandler> aggregators,

--- a/arangod/Pregel/Algos/HITSKleinberg/HITSKleinberg.h
+++ b/arangod/Pregel/Algos/HITSKleinberg/HITSKleinberg.h
@@ -65,6 +65,10 @@ struct HITSKleinberg : public SimpleAlgorithm<HITSKleinbergValue, int8_t,
       const override {
     return new SenderMessageFormat<double>();
   }
+  [[nodiscard]] auto messageFormatUnique() const
+      -> std::unique_ptr<message_format> override {
+    return std::make_unique<SenderMessageFormat<double>>();
+  }
 
   VertexComputation<HITSKleinbergValue, int8_t, SenderMessage<double>>*
       createComputation(std::shared_ptr<WorkerConfig const>) const override;

--- a/arangod/Pregel/Algos/HITSKleinberg/HITSKleinberg.h
+++ b/arangod/Pregel/Algos/HITSKleinberg/HITSKleinberg.h
@@ -73,6 +73,11 @@ struct HITSKleinberg : public SimpleAlgorithm<HITSKleinbergValue, int8_t,
       std::unique_ptr<AggregatorHandler> readAggregators,
       std::unique_ptr<AggregatorHandler> writeAggregators,
       velocypack::Slice userParams) const -> WorkerContext* override;
+  [[nodiscard]] auto workerContextUnique(
+      std::unique_ptr<AggregatorHandler> readAggregators,
+      std::unique_ptr<AggregatorHandler> writeAggregators,
+      velocypack::Slice userParams) const
+      -> std::unique_ptr<WorkerContext> override;
 
   [[nodiscard]] auto masterContext(
       std::unique_ptr<AggregatorHandler> aggregators,

--- a/arangod/Pregel/Algos/LabelPropagation/LabelPropagation.cpp
+++ b/arangod/Pregel/Algos/LabelPropagation/LabelPropagation.cpp
@@ -152,6 +152,13 @@ struct LabelPropagationWorkerContext : public WorkerContext {
   return new LabelPropagationWorkerContext(std::move(readAggregators),
                                            std::move(writeAggregators));
 }
+[[nodiscard]] auto LabelPropagation::workerContextUnique(
+    std::unique_ptr<AggregatorHandler> readAggregators,
+    std::unique_ptr<AggregatorHandler> writeAggregators,
+    velocypack::Slice userParams) const -> std::unique_ptr<WorkerContext> {
+  return std::make_unique<LabelPropagationWorkerContext>(
+      std::move(readAggregators), std::move(writeAggregators));
+}
 
 struct LabelPropagationMasterContext : public MasterContext {
   LabelPropagationMasterContext(uint64_t vertexCount, uint64_t edgeCount,

--- a/arangod/Pregel/Algos/LabelPropagation/LabelPropagation.cpp
+++ b/arangod/Pregel/Algos/LabelPropagation/LabelPropagation.cpp
@@ -138,6 +138,21 @@ LabelPropagation::inputFormat() const {
   return std::make_shared<LPGraphFormat>(_resultField);
 }
 
+struct LabelPropagationWorkerContext : public WorkerContext {
+  LabelPropagationWorkerContext(
+      std::unique_ptr<AggregatorHandler> readAggregators,
+      std::unique_ptr<AggregatorHandler> writeAggregators)
+      : WorkerContext(std::move(readAggregators),
+                      std::move(writeAggregators)){};
+};
+[[nodiscard]] auto LabelPropagation::workerContext(
+    std::unique_ptr<AggregatorHandler> readAggregators,
+    std::unique_ptr<AggregatorHandler> writeAggregators,
+    velocypack::Slice userParams) const -> WorkerContext* {
+  return new LabelPropagationWorkerContext(std::move(readAggregators),
+                                           std::move(writeAggregators));
+}
+
 struct LabelPropagationMasterContext : public MasterContext {
   LabelPropagationMasterContext(uint64_t vertexCount, uint64_t edgeCount,
                                 std::unique_ptr<AggregatorHandler> aggregators)

--- a/arangod/Pregel/Algos/LabelPropagation/LabelPropagation.h
+++ b/arangod/Pregel/Algos/LabelPropagation/LabelPropagation.h
@@ -57,6 +57,10 @@ struct LabelPropagation : public SimpleAlgorithm<LPValue, int8_t, uint64_t> {
   MessageFormat<uint64_t>* messageFormat() const override {
     return new NumberMessageFormat<uint64_t>();
   }
+  [[nodiscard]] auto messageFormatUnique() const
+      -> std::unique_ptr<message_format> override {
+    return std::make_unique<NumberMessageFormat<uint64_t>>();
+  }
 
   VertexComputation<LPValue, int8_t, uint64_t>* createComputation(
       std::shared_ptr<WorkerConfig const>) const override;

--- a/arangod/Pregel/Algos/LabelPropagation/LabelPropagation.h
+++ b/arangod/Pregel/Algos/LabelPropagation/LabelPropagation.h
@@ -61,6 +61,11 @@ struct LabelPropagation : public SimpleAlgorithm<LPValue, int8_t, uint64_t> {
   VertexComputation<LPValue, int8_t, uint64_t>* createComputation(
       std::shared_ptr<WorkerConfig const>) const override;
 
+  [[nodiscard]] auto workerContext(
+      std::unique_ptr<AggregatorHandler> readAggregators,
+      std::unique_ptr<AggregatorHandler> writeAggregators,
+      velocypack::Slice userParams) const -> WorkerContext* override;
+
   [[nodiscard]] auto masterContext(
       std::unique_ptr<AggregatorHandler> aggregators,
       arangodb::velocypack::Slice userParams) const -> MasterContext* override;

--- a/arangod/Pregel/Algos/LabelPropagation/LabelPropagation.h
+++ b/arangod/Pregel/Algos/LabelPropagation/LabelPropagation.h
@@ -65,6 +65,11 @@ struct LabelPropagation : public SimpleAlgorithm<LPValue, int8_t, uint64_t> {
       std::unique_ptr<AggregatorHandler> readAggregators,
       std::unique_ptr<AggregatorHandler> writeAggregators,
       velocypack::Slice userParams) const -> WorkerContext* override;
+  [[nodiscard]] auto workerContextUnique(
+      std::unique_ptr<AggregatorHandler> readAggregators,
+      std::unique_ptr<AggregatorHandler> writeAggregators,
+      velocypack::Slice userParams) const
+      -> std::unique_ptr<WorkerContext> override;
 
   [[nodiscard]] auto masterContext(
       std::unique_ptr<AggregatorHandler> aggregators,

--- a/arangod/Pregel/Algos/LineRank/LineRank.cpp
+++ b/arangod/Pregel/Algos/LineRank/LineRank.cpp
@@ -124,6 +124,13 @@ VertexComputation<float, float, float>* LineRank::createComputation(
   return new LRWorkerContext(std::move(readAggregators),
                              std::move(writeAggregators));
 }
+[[nodiscard]] auto LineRank::workerContextUnique(
+    std::unique_ptr<AggregatorHandler> readAggregators,
+    std::unique_ptr<AggregatorHandler> writeAggregators,
+    velocypack::Slice userParams) const -> std::unique_ptr<WorkerContext> {
+  return std::make_unique<LRWorkerContext>(std::move(readAggregators),
+                                           std::move(writeAggregators));
+}
 
 [[nodiscard]] auto LineRank::masterContext(
     std::unique_ptr<AggregatorHandler> aggregators,

--- a/arangod/Pregel/Algos/LineRank/LineRank.cpp
+++ b/arangod/Pregel/Algos/LineRank/LineRank.cpp
@@ -64,6 +64,10 @@ struct LRMasterContext : MasterContext {
 
 /// do not recalculate startAtNodeProb in every compute call
 struct LRWorkerContext : WorkerContext {
+  LRWorkerContext(std::unique_ptr<AggregatorHandler> readAggregators,
+                  std::unique_ptr<AggregatorHandler> writeAggregators)
+      : WorkerContext(std::move(readAggregators),
+                      std::move(writeAggregators)){};
   float startAtNodeProb = 0;
 
   void preApplication() override { startAtNodeProb = 1.0f / edgeCount(); };
@@ -113,8 +117,12 @@ VertexComputation<float, float, float>* LineRank::createComputation(
   return new LRComputation();
 }
 
-WorkerContext* LineRank::workerContext(VPackSlice params) const {
-  return new LRWorkerContext();
+[[nodiscard]] auto LineRank::workerContext(
+    std::unique_ptr<AggregatorHandler> readAggregators,
+    std::unique_ptr<AggregatorHandler> writeAggregators,
+    velocypack::Slice userParams) const -> WorkerContext* {
+  return new LRWorkerContext(std::move(readAggregators),
+                             std::move(writeAggregators));
 }
 
 [[nodiscard]] auto LineRank::masterContext(

--- a/arangod/Pregel/Algos/LineRank/LineRank.h
+++ b/arangod/Pregel/Algos/LineRank/LineRank.h
@@ -99,6 +99,11 @@ struct LineRank : public SimpleAlgorithm<float, float, float> {
       std::unique_ptr<AggregatorHandler> readAggregators,
       std::unique_ptr<AggregatorHandler> writeAggregators,
       velocypack::Slice userParams) const -> WorkerContext* override;
+  [[nodiscard]] auto workerContextUnique(
+      std::unique_ptr<AggregatorHandler> readAggregators,
+      std::unique_ptr<AggregatorHandler> writeAggregators,
+      velocypack::Slice userParams) const
+      -> std::unique_ptr<WorkerContext> override;
 
   [[nodiscard]] auto masterContext(
       std::unique_ptr<AggregatorHandler> aggregators,

--- a/arangod/Pregel/Algos/LineRank/LineRank.h
+++ b/arangod/Pregel/Algos/LineRank/LineRank.h
@@ -90,9 +90,17 @@ struct LineRank : public SimpleAlgorithm<float, float, float> {
   MessageFormat<float>* messageFormat() const override {
     return new NumberMessageFormat<float>();
   }
+  [[nodiscard]] auto messageFormatUnique() const
+      -> std::unique_ptr<message_format> override {
+    return std::make_unique<NumberMessageFormat<float>>();
+  }
 
   MessageCombiner<float>* messageCombiner() const override {
     return new SumCombiner<float>();
+  }
+  [[nodiscard]] auto messageCombinerUnique() const
+      -> std::unique_ptr<message_combiner> override {
+    return std::make_unique<SumCombiner<float>>();
   }
 
   [[nodiscard]] auto workerContext(

--- a/arangod/Pregel/Algos/LineRank/LineRank.h
+++ b/arangod/Pregel/Algos/LineRank/LineRank.h
@@ -95,7 +95,10 @@ struct LineRank : public SimpleAlgorithm<float, float, float> {
     return new SumCombiner<float>();
   }
 
-  WorkerContext* workerContext(velocypack::Slice params) const override;
+  [[nodiscard]] auto workerContext(
+      std::unique_ptr<AggregatorHandler> readAggregators,
+      std::unique_ptr<AggregatorHandler> writeAggregators,
+      velocypack::Slice userParams) const -> WorkerContext* override;
 
   [[nodiscard]] auto masterContext(
       std::unique_ptr<AggregatorHandler> aggregators,

--- a/arangod/Pregel/Algos/PageRank/PageRank.cpp
+++ b/arangod/Pregel/Algos/PageRank/PageRank.cpp
@@ -116,6 +116,13 @@ VertexComputation<float, float, float>* PageRank::createComputation(
   return new PRWorkerContext(std::move(readAggregators),
                              std::move(writeAggregators));
 }
+[[nodiscard]] auto PageRank::workerContextUnique(
+    std::unique_ptr<AggregatorHandler> readAggregators,
+    std::unique_ptr<AggregatorHandler> writeAggregators,
+    velocypack::Slice userParams) const -> std::unique_ptr<WorkerContext> {
+  return std::make_unique<PRWorkerContext>(std::move(readAggregators),
+                                           std::move(writeAggregators));
+}
 
 struct PRMasterContext : public MasterContext {
   float _threshold = EPS;

--- a/arangod/Pregel/Algos/PageRank/PageRank.cpp
+++ b/arangod/Pregel/Algos/PageRank/PageRank.cpp
@@ -37,7 +37,10 @@ static float EPS = 0.00001f;
 static std::string const kConvergence = "convergence";
 
 struct PRWorkerContext : public WorkerContext {
-  PRWorkerContext() {}
+  PRWorkerContext(std::unique_ptr<AggregatorHandler> readAggregators,
+                  std::unique_ptr<AggregatorHandler> writeAggregators)
+      : WorkerContext(std::move(readAggregators),
+                      std::move(writeAggregators)){};
 
   float commonProb = 0;
   void preGlobalSuperstep(uint64_t gss) override {
@@ -106,8 +109,12 @@ VertexComputation<float, float, float>* PageRank::createComputation(
   return new PRComputation();
 }
 
-WorkerContext* PageRank::workerContext(VPackSlice userParams) const {
-  return new PRWorkerContext();
+[[nodiscard]] auto PageRank::workerContext(
+    std::unique_ptr<AggregatorHandler> readAggregators,
+    std::unique_ptr<AggregatorHandler> writeAggregators,
+    velocypack::Slice userParams) const -> WorkerContext* {
+  return new PRWorkerContext(std::move(readAggregators),
+                             std::move(writeAggregators));
 }
 
 struct PRMasterContext : public MasterContext {

--- a/arangod/Pregel/Algos/PageRank/PageRank.h
+++ b/arangod/Pregel/Algos/PageRank/PageRank.h
@@ -59,6 +59,11 @@ struct PageRank : public SimpleAlgorithm<float, float, float> {
       std::unique_ptr<AggregatorHandler> readAggregators,
       std::unique_ptr<AggregatorHandler> writeAggregators,
       velocypack::Slice userParams) const -> WorkerContext* override;
+  [[nodiscard]] auto workerContextUnique(
+      std::unique_ptr<AggregatorHandler> readAggregators,
+      std::unique_ptr<AggregatorHandler> writeAggregators,
+      velocypack::Slice userParams) const
+      -> std::unique_ptr<WorkerContext> override;
 
   [[nodiscard]] auto masterContext(
       std::unique_ptr<AggregatorHandler> aggregators,

--- a/arangod/Pregel/Algos/PageRank/PageRank.h
+++ b/arangod/Pregel/Algos/PageRank/PageRank.h
@@ -55,7 +55,10 @@ struct PageRank : public SimpleAlgorithm<float, float, float> {
   VertexComputation<float, float, float>* createComputation(
       std::shared_ptr<WorkerConfig const>) const override;
 
-  WorkerContext* workerContext(VPackSlice userParams) const override;
+  [[nodiscard]] auto workerContext(
+      std::unique_ptr<AggregatorHandler> readAggregators,
+      std::unique_ptr<AggregatorHandler> writeAggregators,
+      velocypack::Slice userParams) const -> WorkerContext* override;
 
   [[nodiscard]] auto masterContext(
       std::unique_ptr<AggregatorHandler> aggregators,

--- a/arangod/Pregel/Algos/PageRank/PageRank.h
+++ b/arangod/Pregel/Algos/PageRank/PageRank.h
@@ -47,9 +47,17 @@ struct PageRank : public SimpleAlgorithm<float, float, float> {
   MessageFormat<float>* messageFormat() const override {
     return new NumberMessageFormat<float>();
   }
+  [[nodiscard]] auto messageFormatUnique() const
+      -> std::unique_ptr<message_format> override {
+    return std::make_unique<NumberMessageFormat<float>>();
+  }
 
   MessageCombiner<float>* messageCombiner() const override {
     return new SumCombiner<float>();
+  }
+  [[nodiscard]] auto messageCombinerUnique() const
+      -> std::unique_ptr<message_combiner> override {
+    return std::make_unique<SumCombiner<float>>();
   }
 
   VertexComputation<float, float, float>* createComputation(

--- a/arangod/Pregel/Algos/ReadWrite/ReadWrite.cpp
+++ b/arangod/Pregel/Algos/ReadWrite/ReadWrite.cpp
@@ -38,7 +38,10 @@ using namespace arangodb::pregel::algos;
 static std::string const simulatedAggregatorName = "simulatedAggregator";
 
 struct ReadWriteWorkerContext : public WorkerContext {
-  ReadWriteWorkerContext() = default;
+  ReadWriteWorkerContext(std::unique_ptr<AggregatorHandler> readAggregators,
+                         std::unique_ptr<AggregatorHandler> writeAggregators)
+      : WorkerContext(std::move(readAggregators),
+                      std::move(writeAggregators)){};
 };
 
 ReadWrite::ReadWrite(VPackSlice const& userParams)
@@ -102,8 +105,12 @@ VertexComputation<V, E, V>* ReadWrite::createComputation(
   return new ReadWriteComputation();
 }
 
-WorkerContext* ReadWrite::workerContext(VPackSlice userParams) const {
-  return new ReadWriteWorkerContext();
+[[nodiscard]] auto ReadWrite::workerContext(
+    std::unique_ptr<AggregatorHandler> readAggregators,
+    std::unique_ptr<AggregatorHandler> writeAggregators,
+    velocypack::Slice userParams) const -> WorkerContext* {
+  return new ReadWriteWorkerContext(std::move(readAggregators),
+                                    std::move(writeAggregators));
 }
 
 struct ReadWriteMasterContext : public MasterContext {

--- a/arangod/Pregel/Algos/ReadWrite/ReadWrite.cpp
+++ b/arangod/Pregel/Algos/ReadWrite/ReadWrite.cpp
@@ -112,6 +112,13 @@ VertexComputation<V, E, V>* ReadWrite::createComputation(
   return new ReadWriteWorkerContext(std::move(readAggregators),
                                     std::move(writeAggregators));
 }
+[[nodiscard]] auto ReadWrite::workerContextUnique(
+    std::unique_ptr<AggregatorHandler> readAggregators,
+    std::unique_ptr<AggregatorHandler> writeAggregators,
+    velocypack::Slice userParams) const -> std::unique_ptr<WorkerContext> {
+  return std::make_unique<ReadWriteWorkerContext>(std::move(readAggregators),
+                                                  std::move(writeAggregators));
+}
 
 struct ReadWriteMasterContext : public MasterContext {
   size_t maxGss;

--- a/arangod/Pregel/Algos/ReadWrite/ReadWrite.h
+++ b/arangod/Pregel/Algos/ReadWrite/ReadWrite.h
@@ -62,6 +62,11 @@ struct ReadWrite : public SimpleAlgorithm<V, E, V> {
       std::unique_ptr<AggregatorHandler> readAggregators,
       std::unique_ptr<AggregatorHandler> writeAggregators,
       velocypack::Slice userParams) const -> WorkerContext* override;
+  [[nodiscard]] auto workerContextUnique(
+      std::unique_ptr<AggregatorHandler> readAggregators,
+      std::unique_ptr<AggregatorHandler> writeAggregators,
+      velocypack::Slice userParams) const
+      -> std::unique_ptr<WorkerContext> override;
 
   [[nodiscard]] auto masterContext(
       std::unique_ptr<AggregatorHandler> aggregators,

--- a/arangod/Pregel/Algos/ReadWrite/ReadWrite.h
+++ b/arangod/Pregel/Algos/ReadWrite/ReadWrite.h
@@ -50,9 +50,17 @@ struct ReadWrite : public SimpleAlgorithm<V, E, V> {
   [[nodiscard]] MessageFormat<V>* messageFormat() const override {
     return new NumberMessageFormat<V>();
   }
+  [[nodiscard]] auto messageFormatUnique() const
+      -> std::unique_ptr<message_format> override {
+    return std::make_unique<NumberMessageFormat<V>>();
+  }
 
   [[nodiscard]] MessageCombiner<V>* messageCombiner() const override {
     return new SumCombiner<V>();
+  }
+  [[nodiscard]] auto messageCombinerUnique() const
+      -> std::unique_ptr<message_combiner> override {
+    return std::make_unique<SumCombiner<V>>();
   }
 
   VertexComputation<V, E, V>* createComputation(

--- a/arangod/Pregel/Algos/ReadWrite/ReadWrite.h
+++ b/arangod/Pregel/Algos/ReadWrite/ReadWrite.h
@@ -58,8 +58,10 @@ struct ReadWrite : public SimpleAlgorithm<V, E, V> {
   VertexComputation<V, E, V>* createComputation(
       std::shared_ptr<WorkerConfig const>) const override;
 
-  [[nodiscard]] WorkerContext* workerContext(
-      VPackSlice userParams) const override;
+  [[nodiscard]] auto workerContext(
+      std::unique_ptr<AggregatorHandler> readAggregators,
+      std::unique_ptr<AggregatorHandler> writeAggregators,
+      velocypack::Slice userParams) const -> WorkerContext* override;
 
   [[nodiscard]] auto masterContext(
       std::unique_ptr<AggregatorHandler> aggregators,

--- a/arangod/Pregel/Algos/RecoveringPageRank/RecoveringPageRank.cpp
+++ b/arangod/Pregel/Algos/RecoveringPageRank/RecoveringPageRank.cpp
@@ -126,6 +126,13 @@ struct RPRWorkerContext : public WorkerContext {
   return new RPRWorkerContext(std::move(readAggregators),
                               std::move(writeAggregators));
 }
+[[nodiscard]] auto RecoveringPageRank::workerContextUnique(
+    std::unique_ptr<AggregatorHandler> readAggregators,
+    std::unique_ptr<AggregatorHandler> writeAggregators,
+    velocypack::Slice userParams) const -> std::unique_ptr<WorkerContext> {
+  return std::make_unique<RPRWorkerContext>(std::move(readAggregators),
+                                            std::move(writeAggregators));
+}
 
 struct RPRMasterContext : public MasterContext {
   float _threshold;

--- a/arangod/Pregel/Algos/RecoveringPageRank/RecoveringPageRank.cpp
+++ b/arangod/Pregel/Algos/RecoveringPageRank/RecoveringPageRank.cpp
@@ -113,6 +113,20 @@ VertexCompensation<float, float, float>* RecoveringPageRank::createCompensation(
   return new RPRCompensation();
 }
 
+struct RPRWorkerContext : public WorkerContext {
+  RPRWorkerContext(std::unique_ptr<AggregatorHandler> readAggregators,
+                   std::unique_ptr<AggregatorHandler> writeAggregators)
+      : WorkerContext(std::move(readAggregators),
+                      std::move(writeAggregators)){};
+};
+[[nodiscard]] auto RecoveringPageRank::workerContext(
+    std::unique_ptr<AggregatorHandler> readAggregators,
+    std::unique_ptr<AggregatorHandler> writeAggregators,
+    velocypack::Slice userParams) const -> WorkerContext* {
+  return new RPRWorkerContext(std::move(readAggregators),
+                              std::move(writeAggregators));
+}
+
 struct RPRMasterContext : public MasterContext {
   float _threshold;
 

--- a/arangod/Pregel/Algos/RecoveringPageRank/RecoveringPageRank.h
+++ b/arangod/Pregel/Algos/RecoveringPageRank/RecoveringPageRank.h
@@ -73,9 +73,17 @@ struct RecoveringPageRank : public SimpleAlgorithm<float, float, float> {
   MessageFormat<float>* messageFormat() const override {
     return new NumberMessageFormat<float>();
   }
+  [[nodiscard]] auto messageFormatUnique() const
+      -> std::unique_ptr<message_format> override {
+    return std::make_unique<NumberMessageFormat<float>>();
+  }
 
   MessageCombiner<float>* messageCombiner() const override {
     return new SumCombiner<float>();
+  }
+  [[nodiscard]] auto messageCombinerUnique() const
+      -> std::unique_ptr<message_combiner> override {
+    return std::make_unique<SumCombiner<float>>();
   }
 
   VertexComputation<float, float, float>* createComputation(

--- a/arangod/Pregel/Algos/RecoveringPageRank/RecoveringPageRank.h
+++ b/arangod/Pregel/Algos/RecoveringPageRank/RecoveringPageRank.h
@@ -49,6 +49,11 @@ struct RecoveringPageRank : public SimpleAlgorithm<float, float, float> {
       std::unique_ptr<AggregatorHandler> readAggregators,
       std::unique_ptr<AggregatorHandler> writeAggregators,
       velocypack::Slice userParams) const -> WorkerContext* override;
+  [[nodiscard]] auto workerContextUnique(
+      std::unique_ptr<AggregatorHandler> readAggregators,
+      std::unique_ptr<AggregatorHandler> writeAggregators,
+      velocypack::Slice userParams) const
+      -> std::unique_ptr<WorkerContext> override;
 
   [[nodiscard]] auto masterContext(
       std::unique_ptr<AggregatorHandler> aggregators,

--- a/arangod/Pregel/Algos/RecoveringPageRank/RecoveringPageRank.h
+++ b/arangod/Pregel/Algos/RecoveringPageRank/RecoveringPageRank.h
@@ -45,6 +45,11 @@ struct RecoveringPageRank : public SimpleAlgorithm<float, float, float> {
     return "pagerank";
   };
 
+  [[nodiscard]] auto workerContext(
+      std::unique_ptr<AggregatorHandler> readAggregators,
+      std::unique_ptr<AggregatorHandler> writeAggregators,
+      velocypack::Slice userParams) const -> WorkerContext* override;
+
   [[nodiscard]] auto masterContext(
       std::unique_ptr<AggregatorHandler> aggregators,
       arangodb::velocypack::Slice userParams) const -> MasterContext* override;

--- a/arangod/Pregel/Algos/SCC/SCC.cpp
+++ b/arangod/Pregel/Algos/SCC/SCC.cpp
@@ -203,6 +203,13 @@ struct SCCWorkerContext : public WorkerContext {
   return new SCCWorkerContext(std::move(readAggregators),
                               std::move(writeAggregators));
 }
+[[nodiscard]] auto SCC::workerContextUnique(
+    std::unique_ptr<AggregatorHandler> readAggregators,
+    std::unique_ptr<AggregatorHandler> writeAggregators,
+    velocypack::Slice userParams) const -> std::unique_ptr<WorkerContext> {
+  return std::make_unique<SCCWorkerContext>(std::move(readAggregators),
+                                            std::move(writeAggregators));
+}
 
 struct SCCMasterContext : public MasterContext {
   SCCMasterContext(uint64_t vertexCount, uint64_t edgeCount,

--- a/arangod/Pregel/Algos/SCC/SCC.cpp
+++ b/arangod/Pregel/Algos/SCC/SCC.cpp
@@ -190,6 +190,20 @@ std::shared_ptr<GraphFormat<SCCValue, int8_t> const> SCC::inputFormat() const {
   return std::make_shared<SCCGraphFormat>(_resultField);
 }
 
+struct SCCWorkerContext : public WorkerContext {
+  SCCWorkerContext(std::unique_ptr<AggregatorHandler> readAggregators,
+                   std::unique_ptr<AggregatorHandler> writeAggregators)
+      : WorkerContext(std::move(readAggregators),
+                      std::move(writeAggregators)){};
+};
+[[nodiscard]] auto SCC::workerContext(
+    std::unique_ptr<AggregatorHandler> readAggregators,
+    std::unique_ptr<AggregatorHandler> writeAggregators,
+    velocypack::Slice userParams) const -> WorkerContext* {
+  return new SCCWorkerContext(std::move(readAggregators),
+                              std::move(writeAggregators));
+}
+
 struct SCCMasterContext : public MasterContext {
   SCCMasterContext(uint64_t vertexCount, uint64_t edgeCount,
                    std::unique_ptr<AggregatorHandler> aggregators)

--- a/arangod/Pregel/Algos/SCC/SCC.h
+++ b/arangod/Pregel/Algos/SCC/SCC.h
@@ -115,6 +115,10 @@ struct SCC : public SimpleAlgorithm<SCCValue, int8_t, SenderMessage<uint64_t>> {
       const override {
     return new SenderMessageFormat<uint64_t>();
   }
+  [[nodiscard]] auto messageFormatUnique() const
+      -> std::unique_ptr<message_format> override {
+    return std::make_unique<SenderMessageFormat<uint64_t>>();
+  }
 
   VertexComputation<SCCValue, int8_t, SenderMessage<uint64_t>>*
       createComputation(std::shared_ptr<WorkerConfig const>) const override;

--- a/arangod/Pregel/Algos/SCC/SCC.h
+++ b/arangod/Pregel/Algos/SCC/SCC.h
@@ -119,6 +119,11 @@ struct SCC : public SimpleAlgorithm<SCCValue, int8_t, SenderMessage<uint64_t>> {
   VertexComputation<SCCValue, int8_t, SenderMessage<uint64_t>>*
       createComputation(std::shared_ptr<WorkerConfig const>) const override;
 
+  [[nodiscard]] auto workerContext(
+      std::unique_ptr<AggregatorHandler> readAggregators,
+      std::unique_ptr<AggregatorHandler> writeAggregators,
+      velocypack::Slice userParams) const -> WorkerContext* override;
+
   [[nodiscard]] auto masterContext(
       std::unique_ptr<AggregatorHandler> aggregators,
       arangodb::velocypack::Slice userParams) const -> MasterContext* override;

--- a/arangod/Pregel/Algos/SCC/SCC.h
+++ b/arangod/Pregel/Algos/SCC/SCC.h
@@ -123,6 +123,11 @@ struct SCC : public SimpleAlgorithm<SCCValue, int8_t, SenderMessage<uint64_t>> {
       std::unique_ptr<AggregatorHandler> readAggregators,
       std::unique_ptr<AggregatorHandler> writeAggregators,
       velocypack::Slice userParams) const -> WorkerContext* override;
+  [[nodiscard]] auto workerContextUnique(
+      std::unique_ptr<AggregatorHandler> readAggregators,
+      std::unique_ptr<AggregatorHandler> writeAggregators,
+      velocypack::Slice userParams) const
+      -> std::unique_ptr<WorkerContext> override;
 
   [[nodiscard]] auto masterContext(
       std::unique_ptr<AggregatorHandler> aggregators,

--- a/arangod/Pregel/Algos/SLPA/SLPA.cpp
+++ b/arangod/Pregel/Algos/SLPA/SLPA.cpp
@@ -40,6 +40,10 @@ using namespace arangodb::pregel;
 using namespace arangodb::pregel::algos;
 
 struct SLPAWorkerContext : public WorkerContext {
+  SLPAWorkerContext(std::unique_ptr<AggregatorHandler> readAggregators,
+                    std::unique_ptr<AggregatorHandler> writeAggregators)
+      : WorkerContext(std::move(readAggregators),
+                      std::move(writeAggregators)){};
   uint32_t mod = 1;
   void preGlobalSuperstep(uint64_t gss) override {
     // lets switch the order randomly, but ensure equal listenting time
@@ -205,8 +209,12 @@ std::shared_ptr<GraphFormat<SLPAValue, int8_t> const> SLPA::inputFormat()
                                            _maxCommunities);
 }
 
-WorkerContext* SLPA::workerContext(velocypack::Slice userParams) const {
-  return new SLPAWorkerContext();
+[[nodiscard]] auto SLPA::workerContext(
+    std::unique_ptr<AggregatorHandler> readAggregators,
+    std::unique_ptr<AggregatorHandler> writeAggregators,
+    velocypack::Slice userParams) const -> WorkerContext* {
+  return new SLPAWorkerContext(std::move(readAggregators),
+                               std::move(writeAggregators));
 }
 
 struct SLPAMasterContext : public MasterContext {

--- a/arangod/Pregel/Algos/SLPA/SLPA.cpp
+++ b/arangod/Pregel/Algos/SLPA/SLPA.cpp
@@ -216,6 +216,13 @@ std::shared_ptr<GraphFormat<SLPAValue, int8_t> const> SLPA::inputFormat()
   return new SLPAWorkerContext(std::move(readAggregators),
                                std::move(writeAggregators));
 }
+[[nodiscard]] auto SLPA::workerContextUnique(
+    std::unique_ptr<AggregatorHandler> readAggregators,
+    std::unique_ptr<AggregatorHandler> writeAggregators,
+    velocypack::Slice userParams) const -> std::unique_ptr<WorkerContext> {
+  return std::make_unique<SLPAWorkerContext>(std::move(readAggregators),
+                                             std::move(writeAggregators));
+}
 
 struct SLPAMasterContext : public MasterContext {
   SLPAMasterContext(uint64_t vertexCount, uint64_t edgeCount,

--- a/arangod/Pregel/Algos/SLPA/SLPA.h
+++ b/arangod/Pregel/Algos/SLPA/SLPA.h
@@ -126,7 +126,11 @@ struct SLPA : public SimpleAlgorithm<SLPAValue, int8_t, uint64_t> {
 
   VertexComputation<SLPAValue, int8_t, uint64_t>* createComputation(
       std::shared_ptr<WorkerConfig const>) const override;
-  WorkerContext* workerContext(velocypack::Slice userParams) const override;
+
+  [[nodiscard]] auto workerContext(
+      std::unique_ptr<AggregatorHandler> readAggregators,
+      std::unique_ptr<AggregatorHandler> writeAggregators,
+      velocypack::Slice userParams) const -> WorkerContext* override;
 
   [[nodiscard]] auto masterContext(
       std::unique_ptr<AggregatorHandler> aggregators,

--- a/arangod/Pregel/Algos/SLPA/SLPA.h
+++ b/arangod/Pregel/Algos/SLPA/SLPA.h
@@ -123,6 +123,10 @@ struct SLPA : public SimpleAlgorithm<SLPAValue, int8_t, uint64_t> {
   MessageFormat<uint64_t>* messageFormat() const override {
     return new NumberMessageFormat<uint64_t>();
   }
+  [[nodiscard]] auto messageFormatUnique() const
+      -> std::unique_ptr<message_format> override {
+    return std::make_unique<NumberMessageFormat<uint64_t>>();
+  }
 
   VertexComputation<SLPAValue, int8_t, uint64_t>* createComputation(
       std::shared_ptr<WorkerConfig const>) const override;

--- a/arangod/Pregel/Algos/SLPA/SLPA.h
+++ b/arangod/Pregel/Algos/SLPA/SLPA.h
@@ -131,6 +131,11 @@ struct SLPA : public SimpleAlgorithm<SLPAValue, int8_t, uint64_t> {
       std::unique_ptr<AggregatorHandler> readAggregators,
       std::unique_ptr<AggregatorHandler> writeAggregators,
       velocypack::Slice userParams) const -> WorkerContext* override;
+  [[nodiscard]] auto workerContextUnique(
+      std::unique_ptr<AggregatorHandler> readAggregators,
+      std::unique_ptr<AggregatorHandler> writeAggregators,
+      velocypack::Slice userParams) const
+      -> std::unique_ptr<WorkerContext> override;
 
   [[nodiscard]] auto masterContext(
       std::unique_ptr<AggregatorHandler> aggregators,

--- a/arangod/Pregel/Algos/SSSP/SSSP.cpp
+++ b/arangod/Pregel/Algos/SSSP/SSSP.cpp
@@ -126,6 +126,20 @@ SSSPAlgorithm::createCompensation(
   return new SSSPCompensation();
 }
 
+struct SSSPWorkerContext : public WorkerContext {
+  SSSPWorkerContext(std::unique_ptr<AggregatorHandler> readAggregators,
+                    std::unique_ptr<AggregatorHandler> writeAggregators)
+      : WorkerContext(std::move(readAggregators),
+                      std::move(writeAggregators)){};
+};
+[[nodiscard]] auto SSSPAlgorithm::workerContext(
+    std::unique_ptr<AggregatorHandler> readAggregators,
+    std::unique_ptr<AggregatorHandler> writeAggregators,
+    velocypack::Slice userParams) const -> WorkerContext* {
+  return new SSSPWorkerContext(std::move(readAggregators),
+                               std::move(writeAggregators));
+}
+
 struct SSSPMasterContext : public MasterContext {
   SSSPMasterContext(uint64_t vertexCount, uint64_t edgeCount,
                     std::unique_ptr<AggregatorHandler> aggregators)

--- a/arangod/Pregel/Algos/SSSP/SSSP.cpp
+++ b/arangod/Pregel/Algos/SSSP/SSSP.cpp
@@ -139,6 +139,13 @@ struct SSSPWorkerContext : public WorkerContext {
   return new SSSPWorkerContext(std::move(readAggregators),
                                std::move(writeAggregators));
 }
+[[nodiscard]] auto SSSPAlgorithm::workerContextUnique(
+    std::unique_ptr<AggregatorHandler> readAggregators,
+    std::unique_ptr<AggregatorHandler> writeAggregators,
+    velocypack::Slice userParams) const -> std::unique_ptr<WorkerContext> {
+  return std::make_unique<SSSPWorkerContext>(std::move(readAggregators),
+                                             std::move(writeAggregators));
+}
 
 struct SSSPMasterContext : public MasterContext {
   SSSPMasterContext(uint64_t vertexCount, uint64_t edgeCount,

--- a/arangod/Pregel/Algos/SSSP/SSSP.h
+++ b/arangod/Pregel/Algos/SSSP/SSSP.h
@@ -68,6 +68,11 @@ class SSSPAlgorithm : public Algorithm<int64_t, int64_t, int64_t> {
   uint32_t messageBatchSize(std::shared_ptr<WorkerConfig const> config,
                             MessageStats const& stats) const override;
 
+  [[nodiscard]] auto workerContext(
+      std::unique_ptr<AggregatorHandler> readAggregators,
+      std::unique_ptr<AggregatorHandler> writeAggregators,
+      velocypack::Slice userParams) const -> WorkerContext* override;
+
   [[nodiscard]] auto masterContext(
       std::unique_ptr<AggregatorHandler> aggregators,
       arangodb::velocypack::Slice userParams) const -> MasterContext* override;

--- a/arangod/Pregel/Algos/SSSP/SSSP.h
+++ b/arangod/Pregel/Algos/SSSP/SSSP.h
@@ -72,6 +72,11 @@ class SSSPAlgorithm : public Algorithm<int64_t, int64_t, int64_t> {
       std::unique_ptr<AggregatorHandler> readAggregators,
       std::unique_ptr<AggregatorHandler> writeAggregators,
       velocypack::Slice userParams) const -> WorkerContext* override;
+  [[nodiscard]] auto workerContextUnique(
+      std::unique_ptr<AggregatorHandler> readAggregators,
+      std::unique_ptr<AggregatorHandler> writeAggregators,
+      velocypack::Slice userParams) const
+      -> std::unique_ptr<WorkerContext> override;
 
   [[nodiscard]] auto masterContext(
       std::unique_ptr<AggregatorHandler> aggregators,

--- a/arangod/Pregel/Algos/SSSP/SSSP.h
+++ b/arangod/Pregel/Algos/SSSP/SSSP.h
@@ -55,9 +55,17 @@ class SSSPAlgorithm : public Algorithm<int64_t, int64_t, int64_t> {
   MessageFormat<int64_t>* messageFormat() const override {
     return new IntegerMessageFormat<int64_t>();
   }
+  [[nodiscard]] auto messageFormatUnique() const
+      -> std::unique_ptr<message_format> override {
+    return std::make_unique<IntegerMessageFormat<int64_t>>();
+  }
 
   MessageCombiner<int64_t>* messageCombiner() const override {
     return new MinCombiner<int64_t>();
+  }
+  [[nodiscard]] auto messageCombinerUnique() const
+      -> std::unique_ptr<message_combiner> override {
+    return std::make_unique<MinCombiner<int64_t>>();
   }
 
   VertexComputation<int64_t, int64_t, int64_t>* createComputation(

--- a/arangod/Pregel/Algos/ShortestPath/ShortestPath.cpp
+++ b/arangod/Pregel/Algos/ShortestPath/ShortestPath.cpp
@@ -142,6 +142,13 @@ struct ShortestPathWorkerContext : public WorkerContext {
   return new ShortestPathWorkerContext(std::move(readAggregators),
                                        std::move(writeAggregators));
 }
+[[nodiscard]] auto ShortestPathAlgorithm::workerContextUnique(
+    std::unique_ptr<AggregatorHandler> readAggregators,
+    std::unique_ptr<AggregatorHandler> writeAggregators,
+    velocypack::Slice userParams) const -> std::unique_ptr<WorkerContext> {
+  return std::make_unique<ShortestPathWorkerContext>(
+      std::move(readAggregators), std::move(writeAggregators));
+}
 
 struct ShortestPathMasterContext : public MasterContext {
   ShortestPathMasterContext(uint64_t vertexCount, uint64_t edgeCount,

--- a/arangod/Pregel/Algos/ShortestPath/ShortestPath.cpp
+++ b/arangod/Pregel/Algos/ShortestPath/ShortestPath.cpp
@@ -129,6 +129,20 @@ IAggregator* ShortestPathAlgorithm::aggregator(std::string const& name) const {
   return nullptr;
 }
 
+struct ShortestPathWorkerContext : public WorkerContext {
+  ShortestPathWorkerContext(std::unique_ptr<AggregatorHandler> readAggregators,
+                            std::unique_ptr<AggregatorHandler> writeAggregators)
+      : WorkerContext(std::move(readAggregators),
+                      std::move(writeAggregators)){};
+};
+[[nodiscard]] auto ShortestPathAlgorithm::workerContext(
+    std::unique_ptr<AggregatorHandler> readAggregators,
+    std::unique_ptr<AggregatorHandler> writeAggregators,
+    velocypack::Slice userParams) const -> WorkerContext* {
+  return new ShortestPathWorkerContext(std::move(readAggregators),
+                                       std::move(writeAggregators));
+}
+
 struct ShortestPathMasterContext : public MasterContext {
   ShortestPathMasterContext(uint64_t vertexCount, uint64_t edgeCount,
                             std::unique_ptr<AggregatorHandler> aggregators)

--- a/arangod/Pregel/Algos/ShortestPath/ShortestPath.h
+++ b/arangod/Pregel/Algos/ShortestPath/ShortestPath.h
@@ -63,6 +63,11 @@ struct ShortestPathAlgorithm : public Algorithm<int64_t, int64_t, int64_t> {
   IAggregator* aggregator(std::string const& name) const override;
   std::set<std::string> initialActiveSet() override;
 
+  [[nodiscard]] auto workerContext(
+      std::unique_ptr<AggregatorHandler> readAggregators,
+      std::unique_ptr<AggregatorHandler> writeAggregators,
+      velocypack::Slice userParams) const -> WorkerContext* override;
+
   [[nodiscard]] auto masterContext(
       std::unique_ptr<AggregatorHandler> aggregators,
       arangodb::velocypack::Slice userParams) const -> MasterContext* override;

--- a/arangod/Pregel/Algos/ShortestPath/ShortestPath.h
+++ b/arangod/Pregel/Algos/ShortestPath/ShortestPath.h
@@ -67,6 +67,11 @@ struct ShortestPathAlgorithm : public Algorithm<int64_t, int64_t, int64_t> {
       std::unique_ptr<AggregatorHandler> readAggregators,
       std::unique_ptr<AggregatorHandler> writeAggregators,
       velocypack::Slice userParams) const -> WorkerContext* override;
+  [[nodiscard]] auto workerContextUnique(
+      std::unique_ptr<AggregatorHandler> readAggregators,
+      std::unique_ptr<AggregatorHandler> writeAggregators,
+      velocypack::Slice userParams) const
+      -> std::unique_ptr<WorkerContext> override;
 
   [[nodiscard]] auto masterContext(
       std::unique_ptr<AggregatorHandler> aggregators,

--- a/arangod/Pregel/Algos/ShortestPath/ShortestPath.h
+++ b/arangod/Pregel/Algos/ShortestPath/ShortestPath.h
@@ -53,9 +53,17 @@ struct ShortestPathAlgorithm : public Algorithm<int64_t, int64_t, int64_t> {
   MessageFormat<int64_t>* messageFormat() const override {
     return new IntegerMessageFormat<int64_t>();
   }
+  [[nodiscard]] auto messageFormatUnique() const
+      -> std::unique_ptr<message_format> override {
+    return std::make_unique<IntegerMessageFormat<int64_t>>();
+  }
 
   MessageCombiner<int64_t>* messageCombiner() const override {
     return new MinCombiner<int64_t>();
+  }
+  [[nodiscard]] auto messageCombinerUnique() const
+      -> std::unique_ptr<message_combiner> override {
+    return std::make_unique<MinCombiner<int64_t>>();
   }
 
   VertexComputation<int64_t, int64_t, int64_t>* createComputation(

--- a/arangod/Pregel/Algos/WCC/WCC.cpp
+++ b/arangod/Pregel/Algos/WCC/WCC.cpp
@@ -191,6 +191,13 @@ struct WCCWorkerContext : public WorkerContext {
   return new WCCWorkerContext(std::move(readAggregators),
                               std::move(writeAggregators));
 }
+[[nodiscard]] auto WCC::workerContextUnique(
+    std::unique_ptr<AggregatorHandler> readAggregators,
+    std::unique_ptr<AggregatorHandler> writeAggregators,
+    velocypack::Slice userParams) const -> std::unique_ptr<WorkerContext> {
+  return std::make_unique<WCCWorkerContext>(std::move(readAggregators),
+                                            std::move(writeAggregators));
+}
 
 struct WCCMasterContext : public MasterContext {
   WCCMasterContext(uint64_t vertexCount, uint64_t edgeCount,

--- a/arangod/Pregel/Algos/WCC/WCC.cpp
+++ b/arangod/Pregel/Algos/WCC/WCC.cpp
@@ -178,6 +178,20 @@ std::shared_ptr<GraphFormat<WCCValue, uint64_t> const> WCC::inputFormat()
   return std::make_shared<::WCCGraphFormat>(_resultField);
 }
 
+struct WCCWorkerContext : public WorkerContext {
+  WCCWorkerContext(std::unique_ptr<AggregatorHandler> readAggregators,
+                   std::unique_ptr<AggregatorHandler> writeAggregators)
+      : WorkerContext(std::move(readAggregators),
+                      std::move(writeAggregators)){};
+};
+[[nodiscard]] auto WCC::workerContext(
+    std::unique_ptr<AggregatorHandler> readAggregators,
+    std::unique_ptr<AggregatorHandler> writeAggregators,
+    velocypack::Slice userParams) const -> WorkerContext* {
+  return new WCCWorkerContext(std::move(readAggregators),
+                              std::move(writeAggregators));
+}
+
 struct WCCMasterContext : public MasterContext {
   WCCMasterContext(uint64_t vertexCount, uint64_t edgeCount,
                    std::unique_ptr<AggregatorHandler> aggregators)

--- a/arangod/Pregel/Algos/WCC/WCC.h
+++ b/arangod/Pregel/Algos/WCC/WCC.h
@@ -62,6 +62,11 @@ struct WCC
   VertexComputation<WCCValue, uint64_t, SenderMessage<uint64_t>>*
       createComputation(std::shared_ptr<WorkerConfig const>) const override;
 
+  [[nodiscard]] auto workerContext(
+      std::unique_ptr<AggregatorHandler> readAggregators,
+      std::unique_ptr<AggregatorHandler> writeAggregators,
+      velocypack::Slice userParams) const -> WorkerContext* override;
+
   [[nodiscard]] auto masterContext(
       std::unique_ptr<AggregatorHandler> aggregators,
       arangodb::velocypack::Slice userParams) const -> MasterContext* override;

--- a/arangod/Pregel/Algos/WCC/WCC.h
+++ b/arangod/Pregel/Algos/WCC/WCC.h
@@ -56,9 +56,11 @@ struct WCC
   MessageFormat<SenderMessage<uint64_t>>* messageFormat() const override {
     return new SenderMessageFormat<uint64_t>();
   }
-  MessageCombiner<SenderMessage<uint64_t>>* messageCombiner() const override {
-    return nullptr;
+  [[nodiscard]] auto messageFormatUnique() const
+      -> std::unique_ptr<message_format> override {
+    return std::make_unique<SenderMessageFormat<uint64_t>>();
   }
+
   VertexComputation<WCCValue, uint64_t, SenderMessage<uint64_t>>*
       createComputation(std::shared_ptr<WorkerConfig const>) const override;
 

--- a/arangod/Pregel/Algos/WCC/WCC.h
+++ b/arangod/Pregel/Algos/WCC/WCC.h
@@ -66,6 +66,11 @@ struct WCC
       std::unique_ptr<AggregatorHandler> readAggregators,
       std::unique_ptr<AggregatorHandler> writeAggregators,
       velocypack::Slice userParams) const -> WorkerContext* override;
+  [[nodiscard]] auto workerContextUnique(
+      std::unique_ptr<AggregatorHandler> readAggregators,
+      std::unique_ptr<AggregatorHandler> writeAggregators,
+      velocypack::Slice userParams) const
+      -> std::unique_ptr<WorkerContext> override;
 
   [[nodiscard]] auto masterContext(
       std::unique_ptr<AggregatorHandler> aggregators,

--- a/arangod/Pregel/MasterContext.h
+++ b/arangod/Pregel/MasterContext.h
@@ -39,7 +39,7 @@ class MasterContext {
   uint64_t _globalSuperstep = 0;
   uint64_t _vertexCount = 0;
   uint64_t _edgeCount = 0;
-  std::unique_ptr<AggregatorHandler> _aggregators = nullptr;
+  std::unique_ptr<AggregatorHandler> _aggregators;
 
   MasterContext(uint64_t vertexCount, uint64_t edgeCount,
                 std::unique_ptr<AggregatorHandler> aggregators)

--- a/arangod/Pregel/Worker/Worker.h
+++ b/arangod/Pregel/Worker/Worker.h
@@ -104,8 +104,6 @@ class Worker : public IWorker {
   // locks swapping
   mutable arangodb::basics::ReadWriteLock _cacheRWLock;
 
-  std::unique_ptr<AggregatorHandler> _conductorAggregators;
-  std::unique_ptr<AggregatorHandler> _workerAggregators;
   std::unique_ptr<GraphStore<V, E>> _graphStore;
   std::unique_ptr<MessageFormat<M>> _messageFormat;
   std::unique_ptr<MessageCombiner<M>> _messageCombiner;

--- a/arangod/Pregel/WorkerContext.h
+++ b/arangod/Pregel/WorkerContext.h
@@ -35,9 +35,9 @@ class WorkerContext {
   template<typename V, typename E, typename M>
   friend class Worker;
 
-  uint64_t _vertexCount, _edgeCount;
-  AggregatorHandler* _readAggregators;
-  AggregatorHandler* _writeAggregators;
+  uint64_t _vertexCount = 0, _edgeCount = 0;
+  std::unique_ptr<AggregatorHandler> _readAggregators;
+  std::unique_ptr<AggregatorHandler> _writeAggregators;
 
  protected:
   template<typename T>
@@ -56,11 +56,10 @@ class WorkerContext {
   virtual void postGlobalSuperstep(uint64_t gss) {}
 
  public:
-  WorkerContext()
-      : _vertexCount(0),
-        _edgeCount(0),
-        _readAggregators(nullptr),
-        _writeAggregators(nullptr) {}
+  WorkerContext(std::unique_ptr<AggregatorHandler> readAggregators,
+                std::unique_ptr<AggregatorHandler> writeAggregators)
+      : _readAggregators{std::move(readAggregators)},
+        _writeAggregators{std::move(writeAggregators)} {};
   virtual ~WorkerContext() = default;
 
   inline uint64_t vertexCount() const { return _vertexCount; }

--- a/tests/Pregel/ConductorStateTest.cpp
+++ b/tests/Pregel/ConductorStateTest.cpp
@@ -87,6 +87,19 @@ struct AlgorithmFake : IAlgorithm {
       -> std::unique_ptr<MasterContext> override {
     return nullptr;
   }
+  [[nodiscard]] auto workerContext(
+      std::unique_ptr<AggregatorHandler> readAggregators,
+      std::unique_ptr<AggregatorHandler> writeAggregators,
+      arangodb::velocypack::Slice userParams) const -> WorkerContext* override {
+    return nullptr;
+  }
+  [[nodiscard]] auto workerContextUnique(
+      std::unique_ptr<AggregatorHandler> readAggregators,
+      std::unique_ptr<AggregatorHandler> writeAggregators,
+      arangodb::velocypack::Slice userParams) const
+      -> std::unique_ptr<WorkerContext> override {
+    return nullptr;
+  }
   [[nodiscard]] auto name() const -> std::string_view override {
     return "fake";
   };


### PR DESCRIPTION
This PR is similar to some things done in https://github.com/arangodb/arangodb/pull/18277:
-Adds a WorkerContext to each algorithm (before, only some algorithms had a worker context). The aggregates, that were previously owned by the Worker, are now owned by the WorkerContext, such that we don't have duplication of variables here.
-The algorithm can now also create a unique ptr to WorkerContext - opposed to a raw pointer - this is not used yet but will be used in our Worker actor