### PR TITLE
Add missing deleteLog code for tests.

### DIFF
--- a/tests/js/server/replication2/replication2-regression.js
+++ b/tests/js/server/replication2/replication2-regression.js
@@ -243,6 +243,7 @@ const replicatedLogRegressionSuite = function () {
         target.config.writeConcern = 2;
       });
       waitFor(preds.replicatedLogLeaderEstablished(database, logId, undefined, servers));
+      replicatedLogDeleteTarget(database, logId);
     },
 
     testWriteConcernBiggerThanReplicationFactor: function () {
@@ -279,9 +280,8 @@ const replicatedLogRegressionSuite = function () {
       });
 
       waitFor(preds.replicatedLogTargetVersion(database, logId, lastVersion));
+      replicatedLogDeleteTarget(database, logId);
     },
-
-
   };
 };
 


### PR DESCRIPTION
### Scope & Purpose
Two tests did not drop the replicated logs they created.