### PR TITLE
fix races in in-memory cache system

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 v3.9.10 (XXXX-XX-XX)
 --------------------
 
+* Fix potential memory under-accounting on cache shutdown for in-memory caches
+  for edge indexes.
+
 * Added startup option `--rocksdb.auto-refill-index-caches-on-followers` to
   control whether automatic refilling of in-memory caches should happen on
   followers or just leaders. The default value is `true`, i.e. refilling happens

--- a/arangod/Cache/Cache.cpp
+++ b/arangod/Cache/Cache.cpp
@@ -59,8 +59,7 @@ Cache::Cache(ConstructionGuard guard, Manager* manager, std::uint64_t id,
              bool enableWindowedStats,
              std::function<Table::BucketClearer(Metadata*)> bucketClearer,
              std::size_t slotsPerBucket)
-    : _taskLock(),
-      _shutdown(false),
+    : _shutdown(false),
       _enableWindowedStats(enableWindowedStats),
       _findStats(nullptr),
       _findHits(),
@@ -354,6 +353,8 @@ std::shared_ptr<Table> Cache::table() const {
 }
 
 void Cache::shutdown() {
+  SpinLocker shutdownGuard(SpinLocker::Mode::Write, _shutdownLock);
+
   SpinLocker taskGuard(SpinLocker::Mode::Write, _taskLock);
   auto handle = shared_from_this();  // hold onto self-reference to prevent
                                      // pre-mature shared_ptr destruction
@@ -368,7 +369,10 @@ void Cache::shutdown() {
       }
 
       SpinUnlocker taskUnguard(SpinUnlocker::Mode::Write, _taskLock);
-      std::this_thread::sleep_for(std::chrono::microseconds(10));
+      SpinUnlocker shutdownUnguard(SpinUnlocker::Mode::Write, _shutdownLock);
+
+      // sleep a bit without holding the locks
+      std::this_thread::sleep_for(std::chrono::microseconds(20));
     }
 
     std::shared_ptr<cache::Table> table = this->table();
@@ -400,15 +404,6 @@ bool Cache::canResize() {
 
   SpinLocker metaGuard(SpinLocker::Mode::Read, _metadata.lock());
   return !(_metadata.isResizing() || _metadata.isMigrating());
-}
-
-bool Cache::canMigrate() {
-  if (isShutdown()) {
-    return false;
-  }
-
-  SpinLocker metaGuard(SpinLocker::Mode::Read, _metadata.lock());
-  return !_metadata.isMigrating();
 }
 
 /// TODO Improve freeing algorithm
@@ -455,7 +450,13 @@ bool Cache::freeMemory() {
 }
 
 bool Cache::migrate(std::shared_ptr<Table> newTable) {
-  if (isShutdown()) {
+  if (ADB_UNLIKELY(isShutdown())) {
+    // unmarking migrating flag
+    SpinLocker metaGuard(SpinLocker::Mode::Write, _metadata.lock());
+
+    TRI_ASSERT(_metadata.isMigrating());
+    _metadata.toggleMigrating();
+    TRI_ASSERT(!_metadata.isMigrating());
     return false;
   }
 
@@ -491,7 +492,9 @@ bool Cache::migrate(std::shared_ptr<Table> newTable) {
   {
     SpinLocker metaGuard(SpinLocker::Mode::Write, _metadata.lock());
     _metadata.changeTable(table->memoryUsage());
+    TRI_ASSERT(_metadata.isMigrating());
     _metadata.toggleMigrating();
+    TRI_ASSERT(!_metadata.isMigrating());
   }
 
   return true;

--- a/arangod/Cache/Manager.h
+++ b/arangod/Cache/Manager.h
@@ -223,7 +223,6 @@ class Manager {
   // task management
   enum TaskEnvironment { none, rebalancing, resizing };
   PostFn _schedulerPost;
-  std::uint64_t _resizeAttempt;
   std::atomic<std::uint64_t> _outstandingTasks;
   std::atomic<std::uint64_t> _rebalancingTasks;
   std::atomic<std::uint64_t> _resizingTasks;
@@ -265,7 +264,7 @@ class Manager {
 
   // coordinate state with task lifecycles
   void prepareTask(TaskEnvironment environment);
-  void unprepareTask(TaskEnvironment environment);
+  void unprepareTask(TaskEnvironment environment) noexcept;
 
   // periodically run to rebalance allocations globally
   ErrorCode rebalance(bool onlyCalculate = false);

--- a/arangod/Cache/ManagerTasks.cpp
+++ b/arangod/Cache/ManagerTasks.cpp
@@ -21,7 +21,8 @@
 /// @author Dan Larkin-York
 ////////////////////////////////////////////////////////////////////////////////
 
-#include "Cache/ManagerTasks.h"
+#include "ManagerTasks.h"
+
 #include "Basics/SpinLocker.h"
 #include "Cache/Cache.h"
 #include "Cache/Manager.h"
@@ -37,13 +38,15 @@ FreeMemoryTask::~FreeMemoryTask() = default;
 
 bool FreeMemoryTask::dispatch() {
   _manager.prepareTask(_environment);
+
   try {
     if (_manager.post([self = shared_from_this()]() -> void { self->run(); })) {
+      // intentionally don't unprepare task
       return true;
     }
     _manager.unprepareTask(_environment);
     return false;
-  } catch (std::exception const&) {
+  } catch (...) {
     _manager.unprepareTask(_environment);
     throw;
   }
@@ -53,20 +56,31 @@ void FreeMemoryTask::run() {
   try {
     using basics::SpinLocker;
 
-    bool ran = _cache->freeMemory();
-
-    if (ran) {
-      std::uint64_t reclaimed = 0;
+    {
       SpinLocker guard(SpinLocker::Mode::Write, _manager._lock);
-      Metadata& metadata = _cache->metadata();
-      {
-        SpinLocker metaGuard(SpinLocker::Mode::Write, metadata.lock());
-        TRI_ASSERT(metaGuard.isLocked());
-        reclaimed = metadata.hardUsageLimit - metadata.softUsageLimit;
-        metadata.adjustLimits(metadata.softUsageLimit, metadata.softUsageLimit);
-        metadata.toggleResizing();
+
+      // note: FreeMemoryTask must not run concurrently with the
+      // cache's own shutdown to avoid data inconsistency
+      SpinLocker taskGuard(SpinLocker::Mode::Read, _cache->_shutdownLock);
+
+      bool ran = _cache->freeMemory();
+
+      if (ran) {
+        std::uint64_t reclaimed = 0;
+        Metadata& metadata = _cache->metadata();
+        {
+          SpinLocker metaGuard(SpinLocker::Mode::Write, metadata.lock());
+          TRI_ASSERT(metaGuard.isLocked());
+          reclaimed = metadata.hardUsageLimit - metadata.softUsageLimit;
+          metadata.adjustLimits(metadata.softUsageLimit,
+                                metadata.softUsageLimit);
+          metadata.toggleResizing();
+        }
+        TRI_ASSERT(_manager._globalAllocation >=
+                   reclaimed + _manager._fixedAllocation);
+        _manager._globalAllocation -= reclaimed;
+        TRI_ASSERT(_manager._globalAllocation >= _manager._fixedAllocation);
       }
-      _manager._globalAllocation -= reclaimed;
     }
 
     _manager.unprepareTask(_environment);
@@ -89,13 +103,15 @@ MigrateTask::~MigrateTask() = default;
 
 bool MigrateTask::dispatch() {
   _manager.prepareTask(_environment);
+
   try {
     if (_manager.post([self = shared_from_this()]() -> void { self->run(); })) {
+      // intentionally don't unprepare task
       return true;
     }
     _manager.unprepareTask(_environment);
     return false;
-  } catch (std::exception const&) {
+  } catch (...) {
     _manager.unprepareTask(_environment);
     throw;
   }
@@ -105,17 +121,18 @@ void MigrateTask::run() {
   try {
     using basics::SpinLocker;
 
-    // do the actual migration
-    bool ran = _cache->migrate(_table);
+    {
+      // note: MigrateTask must not run concurrently with the
+      // cache's own shutdown to avoid data inconsistency
+      SpinLocker taskGuard(SpinLocker::Mode::Read, _cache->_shutdownLock);
 
-    if (!ran) {
-      Metadata& metadata = _cache->metadata();
-      {
-        SpinLocker metaGuard(SpinLocker::Mode::Write, metadata.lock());
-        TRI_ASSERT(metaGuard.isLocked());
-        metadata.toggleMigrating();
+      // do the actual migration
+      bool ran = _cache->migrate(_table);
+
+      if (!ran) {
+        _manager.reclaimTable(std::move(_table), false);
+        TRI_ASSERT(_table == nullptr);
       }
-      _manager.reclaimTable(_table, false);
     }
 
     _manager.unprepareTask(_environment);

--- a/arangod/Cache/ManagerTasks.h
+++ b/arangod/Cache/ManagerTasks.h
@@ -36,11 +36,6 @@ namespace arangodb {
 namespace cache {
 
 class FreeMemoryTask : public std::enable_shared_from_this<FreeMemoryTask> {
- private:
-  Manager::TaskEnvironment _environment;
-  Manager& _manager;
-  std::shared_ptr<Cache> _cache;
-
  public:
   FreeMemoryTask() = delete;
   FreeMemoryTask(FreeMemoryTask const&) = delete;
@@ -54,15 +49,13 @@ class FreeMemoryTask : public std::enable_shared_from_this<FreeMemoryTask> {
 
  private:
   void run();
-};
 
-class MigrateTask : public std::enable_shared_from_this<MigrateTask> {
- private:
   Manager::TaskEnvironment _environment;
   Manager& _manager;
   std::shared_ptr<Cache> _cache;
-  std::shared_ptr<Table> _table;
+};
 
+class MigrateTask : public std::enable_shared_from_this<MigrateTask> {
  public:
   MigrateTask() = delete;
   MigrateTask(MigrateTask const&) = delete;
@@ -76,6 +69,11 @@ class MigrateTask : public std::enable_shared_from_this<MigrateTask> {
 
  private:
   void run();
+
+  Manager::TaskEnvironment _environment;
+  Manager& _manager;
+  std::shared_ptr<Cache> _cache;
+  std::shared_ptr<Table> _table;
 };
 
 };  // end namespace cache

--- a/arangod/Cache/Metadata.cpp
+++ b/arangod/Cache/Metadata.cpp
@@ -26,11 +26,8 @@
 #include "Basics/debugging.h"
 #include "Cache/Cache.h"
 #include "Cache/Manager.h"
-#include "Logger/LogMacros.h"
 
 #include <algorithm>
-#include <atomic>
-#include <cstdint>
 
 namespace arangodb::cache {
 
@@ -47,7 +44,7 @@ Metadata::Metadata()
       _migrating(false),
       _resizing(false) {}
 
-Metadata::Metadata(uint64_t usageLimit, std::uint64_t fixed,
+Metadata::Metadata(std::uint64_t usageLimit, std::uint64_t fixed,
                    std::uint64_t table, std::uint64_t max)
     : fixedSize(fixed),
       tableSize(table),
@@ -57,7 +54,6 @@ Metadata::Metadata(uint64_t usageLimit, std::uint64_t fixed,
       usage(0),
       softUsageLimit(usageLimit),
       hardUsageLimit(usageLimit),
-      _lock(),
       _migrating(false),
       _resizing(false) {
   TRI_ASSERT(allocatedSize <= maxSize);

--- a/arangod/Cache/Table.cpp
+++ b/arangod/Cache/Table.cpp
@@ -82,7 +82,7 @@ Table::Subtable::Subtable(std::shared_ptr<Table> source, GenericBucket* buckets,
       _shift(shift) {}
 
 void* Table::Subtable::fetchBucket(std::uint32_t hash) noexcept {
-  return &(_buckets[(hash & _mask) >> _shift]);
+  return &_buckets[(hash & _mask) >> _shift];
 }
 
 std::vector<Table::BucketLocker> Table::Subtable::lockAllBuckets() {
@@ -227,14 +227,16 @@ std::uint32_t Table::logSize() const { return _logSize; }
 
 Table::BucketLocker Table::fetchAndLockBucket(std::uint32_t hash,
                                               std::uint64_t maxTries) {
+  std::uint32_t index = (hash & _mask) >> _shift;
+
+  BucketLocker bucketGuard;
+
   SpinLocker guard(SpinLocker::Mode::Read, _lock,
                    static_cast<std::size_t>(maxTries));
-  BucketLocker bucketGuard;
 
   if (guard.isLocked()) {
     if (!_disabled) {
-      bucketGuard =
-          BucketLocker(&(_buckets[(hash & _mask) >> _shift]), this, maxTries);
+      bucketGuard = BucketLocker(&_buckets[index], this, maxTries);
       if (bucketGuard.isLocked()) {
         if (bucketGuard.bucket<GenericBucket>().isMigrated()) {
           bucketGuard.release();
@@ -269,7 +271,7 @@ void* Table::primaryBucket(uint64_t index) {
   if (!isEnabled()) {
     return nullptr;
   }
-  return &(_buckets[index]);
+  return &_buckets[index];
 }
 
 std::unique_ptr<Table::Subtable> Table::auxiliaryBuckets(std::uint32_t index) {
@@ -288,13 +290,13 @@ std::unique_ptr<Table::Subtable> Table::auxiliaryBuckets(std::uint32_t index) {
     TRI_ASSERT(_auxiliary.get() != nullptr);
     if (_logSize > _auxiliary->_logSize) {
       std::uint32_t diff = _logSize - _auxiliary->_logSize;
-      base = &(_auxiliary->_buckets[index >> diff]);
+      base = &_auxiliary->_buckets[index >> diff];
       size = 1;
       mask = 0;
       shift = 0;
     } else {
       std::uint32_t diff = _auxiliary->_logSize - _logSize;
-      base = &(_auxiliary->_buckets[index << diff]);
+      base = &_auxiliary->_buckets[index << diff];
       size = static_cast<std::uint64_t>(1) << diff;
       mask = (static_cast<std::uint32_t>(size - 1) << _auxiliary->_shift);
       shift = _auxiliary->_shift;

--- a/arangod/Cache/Table.h
+++ b/arangod/Cache/Table.h
@@ -30,6 +30,7 @@
 #include <cstdint>
 #include <limits>
 #include <memory>
+#include <vector>
 
 namespace arangodb {
 namespace cache {


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/18243

Partially address https://arangodb.atlassian.net/browse/BTS-1255:

Fix shutdown races (shutdown of a cache could overlap with spawned FreeMemory and Migrate tasks for the same cache, leading to assertion failures because the amount of allocated memory went below zero). This fixes errors we have seen in cache unit tests in devel recently, although the race conditions have been for longer.
In order to prevent the races, a new per-cache `_shutdownLock` is introduced, which is acquired in exclusive mode by the shutdown, and acquired in shared mode while FreeMemory or Migrate tasks execute. That way the shutdown is mutually exclusive with a cache's task execution.
Note: the `shutdown()` function of a cache will be called only when the cache manager is being shut down (shutdown of the entire cache subsystem) or when the cache manager's static `destroyCache(cache)` function is called for a particular cache. The latter happens during index destructors (for indexes with in-memory caches), after `truncate()` calls (when the caches can be wiped and recreated) and after `unload()` calls.

Also added more assertions for verifying some of the cache subsystem's memory usage invariants.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.10: https://github.com/arangodb/arangodb/pull/18265
  - [x] Backport for 3.9: this PR
  - [ ] Backport for 3.8: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 