### PR TITLE
Error hanlding if no DBServers are available for CollectionCreation

### DIFF
--- a/arangod/Cluster/Utils/EvenDistribution.cpp
+++ b/arangod/Cluster/Utils/EvenDistribution.cpp
@@ -44,7 +44,8 @@ Result EvenDistribution::planShardsOnServers(
     std::unordered_set<ServerID>& serversPlanned) {
   // Caller needs to ensure we have something to place shards on
   if (availableServers.empty()) {
-    return  {TRI_ERROR_CLUSTER_INSUFFICIENT_DBSERVERS, "Do not have a single server to make responsible for shards"};
+    return {TRI_ERROR_CLUSTER_INSUFFICIENT_DBSERVERS,
+            "Do not have a single server to make responsible for shards"};
   }
 
   if (_enforceReplicationFactor &&

--- a/arangod/Cluster/Utils/EvenDistribution.cpp
+++ b/arangod/Cluster/Utils/EvenDistribution.cpp
@@ -43,7 +43,9 @@ Result EvenDistribution::planShardsOnServers(
     std::vector<ServerID> availableServers,
     std::unordered_set<ServerID>& serversPlanned) {
   // Caller needs to ensure we have something to place shards on
-  ADB_PROD_ASSERT(!availableServers.empty());
+  if (availableServers.empty()) {
+    return  {TRI_ERROR_CLUSTER_INSUFFICIENT_DBSERVERS, "Do not have a single server to make responsible for shards"};
+  }
 
   if (_enforceReplicationFactor &&
       availableServers.size() < _replicationFactor) {

--- a/arangod/Replication2/Supervision/CollectionGroupSupervision.cpp
+++ b/arangod/Replication2/Supervision/CollectionGroupSupervision.cpp
@@ -67,7 +67,8 @@ auto getHealthyParticipants(replicated_log::ParticipantsHealth const& health)
 
 auto computeEvenDistributionForServers(
     std::size_t numberOfShards, std::size_t replicationFactor,
-    replicated_log::ParticipantsHealth const& health) -> ResultT<EvenDistribution> {
+    replicated_log::ParticipantsHealth const& health)
+    -> ResultT<EvenDistribution> {
   auto servers = getHealthyParticipants(health);
   {
     // TODO reuse random device?


### PR DESCRIPTION
### Scope & Purpose

*Fix _system database _system collections in Replication 2*
*Actually added error handling in case no servers are available when creating a Collection*

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: *(Please link PR)*
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

