### PR TITLE
abort long-running commands if db/collection is dropped

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,11 @@
+v3.10.6 (XXXX-XX-XX)
+--------------------
+
+* Make long-running operations such as foreground or background index creation
+  or index warmup abort early in case the underlying collection or database
+  gets dropped.
+
+
 v3.10.5 (XXXX-XX-XX)
 --------------------
 

--- a/arangod/RocksDBEngine/RocksDBEdgeIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBEdgeIndex.cpp
@@ -790,9 +790,19 @@ void RocksDBEdgeIndex::warmupInternal(transaction::Methods* trx,
   size_t n = 0;
   for (it->Seek(lower); it->Valid(); it->Next()) {
     ++n;
-    if (n % 1024 == 0 && collection().vocbase().server().isStopping()) {
-      // periodically check for server shutdown
-      return;
+    if (n % 1024 == 0) {
+      if (collection().vocbase().server().isStopping()) {
+        // periodically check for server shutdown
+        THROW_ARANGO_EXCEPTION(TRI_ERROR_SHUTTING_DOWN);
+      }
+      if (collection().vocbase().isDropped()) {
+        // database was dropped
+        THROW_ARANGO_EXCEPTION(TRI_ERROR_ARANGO_DATABASE_NOT_FOUND);
+      }
+      if (collection().deleted()) {
+        // collection was dropped
+        THROW_ARANGO_EXCEPTION(TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND);
+      }
     }
 
     rocksdb::Slice key = it->key();

--- a/arangod/RocksDBEngine/RocksDBIndexCacheRefillFeature.cpp
+++ b/arangod/RocksDBEngine/RocksDBIndexCacheRefillFeature.cpp
@@ -318,10 +318,16 @@ void RocksDBIndexCacheRefillFeature::scheduleIndexRefillTasks() {
               res = {TRI_ERROR_INTERNAL, ex.what()};
             }
             if (res.fail()) {
-              LOG_TOPIC("91c13", WARN, Logger::ENGINES)
-                  << "unable to warmup index '" << task.iid.id() << "' in "
-                  << task.database << "/" << task.collection << ": "
-                  << res.errorMessage();
+              // check error. it is somewhat expected that a collection or
+              // database is not found anymore in case someone has dropped it
+              if (!res.is(TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND) &&
+                  !res.is(TRI_ERROR_ARANGO_DATABASE_NOT_FOUND)) {
+                // an unexpected error
+                LOG_TOPIC("91c13", WARN, Logger::ENGINES)
+                    << "unable to warmup index '" << task.iid.id() << "' in "
+                    << task.database << "/" << task.collection << ": "
+                    << res.errorMessage();
+              }
             } else {
               ++_totalFullIndexRefills;
             }

--- a/arangod/RocksDBEngine/RocksDBMetaCollection.cpp
+++ b/arangod/RocksDBEngine/RocksDBMetaCollection.cpp
@@ -226,9 +226,19 @@ uint64_t RocksDBMetaCollection::recalculateCounts() {
     TRI_ASSERT(it->key().compare(upper) < 0);
     ++count;
 
-    if (count % 4096 == 0 && server.isStopping()) {
-      // check for server shutdown
-      THROW_ARANGO_EXCEPTION(TRI_ERROR_SHUTTING_DOWN);
+    if (count % 4096 == 0) {
+      if (server.isStopping()) {
+        // server shutdown
+        THROW_ARANGO_EXCEPTION(TRI_ERROR_SHUTTING_DOWN);
+      }
+      if (_logicalCollection.vocbase().isDropped()) {
+        // database dropped
+        THROW_ARANGO_EXCEPTION(TRI_ERROR_ARANGO_DATABASE_NOT_FOUND);
+      }
+      if (_logicalCollection.deleted()) {
+        // collection dropped
+        THROW_ARANGO_EXCEPTION(TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND);
+      }
     }
   }
 
@@ -814,7 +824,16 @@ RocksDBMetaCollection::buildTreeFromIterator(
       revisions.clear();
 
       if (_logicalCollection.vocbase().server().isStopping()) {
+        // server shutdown
         THROW_ARANGO_EXCEPTION(TRI_ERROR_SHUTTING_DOWN);
+      }
+      if (_logicalCollection.vocbase().isDropped()) {
+        // database dropped
+        THROW_ARANGO_EXCEPTION(TRI_ERROR_ARANGO_DATABASE_NOT_FOUND);
+      }
+      if (_logicalCollection.deleted()) {
+        // collection dropped
+        THROW_ARANGO_EXCEPTION(TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND);
       }
     }
     it.next();
@@ -1045,7 +1064,16 @@ void RocksDBMetaCollection::rebuildRevisionTree(
       revisions.clear();
 
       if (_logicalCollection.vocbase().server().isStopping()) {
+        // server shutdown
         THROW_ARANGO_EXCEPTION(TRI_ERROR_SHUTTING_DOWN);
+      }
+      if (_logicalCollection.vocbase().isDropped()) {
+        // database dropped
+        THROW_ARANGO_EXCEPTION(TRI_ERROR_ARANGO_DATABASE_NOT_FOUND);
+      }
+      if (_logicalCollection.deleted()) {
+        // collection dropped
+        THROW_ARANGO_EXCEPTION(TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND);
       }
     }
   }
@@ -1169,7 +1197,16 @@ uint64_t RocksDBMetaCollection::placeRevisionTreeBlocker(
     }
 
     if (_logicalCollection.vocbase().server().isStopping()) {
+      // server shutdown
       THROW_ARANGO_EXCEPTION(TRI_ERROR_SHUTTING_DOWN);
+    }
+    if (_logicalCollection.vocbase().isDropped()) {
+      // database dropped
+      THROW_ARANGO_EXCEPTION(TRI_ERROR_ARANGO_DATABASE_NOT_FOUND);
+    }
+    if (_logicalCollection.deleted()) {
+      // collection dropped
+      THROW_ARANGO_EXCEPTION(TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND);
     }
 
     std::this_thread::yield();

--- a/arangod/VocBase/Methods/Collections.cpp
+++ b/arangod/VocBase/Methods/Collections.cpp
@@ -1154,6 +1154,11 @@ futures::Future<Result> Collections::warmup(TRI_vocbase_t& vocbase,
   auto idxs = coll.getIndexes();
   for (auto const& idx : idxs) {
     if (idx->canWarmup()) {
+      TRI_IF_FAILURE("warmup::executeDirectly") {
+        // when this failure point is set, execute the warmup directly
+        idx->warmup();
+        continue;
+      }
       engine.scheduleFullIndexRefill(vocbase.name(), coll.name(), idx->id());
     }
   }

--- a/tests/js/client/shell/abort-long-running-operations-noncluster.js
+++ b/tests/js/client/shell/abort-long-running-operations-noncluster.js
@@ -1,0 +1,224 @@
+/*jshint globalstrict:false, strict:false */
+/*global assertEqual, fail */
+
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2010-2012 triagens GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is triAGENS GmbH, Cologne, Germany
+///
+/// @author Jan Steemann
+/// @author Copyright 2018, triAGENS GmbH, Cologne, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+const jsunity = require("jsunity");
+const arangodb = require("@arangodb");
+const db = arangodb.db;
+const tasks = require("@arangodb/tasks");
+const internal = require("internal");
+const { deriveTestSuite } = require('@arangodb/test-helper');
+const ERRORS = arangodb.errors;
+  
+const cn = "UnitTestsCollection";
+  
+let setupCollection = (type) => {
+  let c;
+  if (type === 'edge') {
+    c = db._createEdgeCollection(cn);
+  } else {
+    c = db._create(cn);
+  }
+  let docs = [];
+  for (let i = 0; i < 5000; ++i) {
+    docs.push({ value1: i, value2: "test" + i, _from: "v/test" + i, _to: "v/test" + i });
+  }
+  for (let i = 0; i < 350000; i += docs.length) {
+    c.insert(docs);
+  }
+  return c;
+};
+  
+let shutdownTask = (task) => {
+  while (true) {
+    try {
+      tasks.get(task);
+      require("internal").wait(0.25, false);
+    } catch (err) {
+      // "task not found" means the task is finished
+      break;
+    }
+  }
+};
+
+function BaseTestConfig (dropCb, expectedError) {
+  return {
+    testIndexCreationAborts : function () {
+      let c = setupCollection('document');
+      let task = dropCb();
+
+      try {
+        c.ensureIndex({ type: "persistent", fields: ["value1", "value2"] });
+        fail();
+      } catch (err) {
+        // unfortunately it is possible that this fails because of unexpected
+        // scheduling. the whole test is time-based and assumes reasonable
+        // scheduling, which probably isn't guaranteed on some CI servers.
+        assertEqual(expectedError, err.errorNum);
+      }
+
+      shutdownTask(task);
+    },
+    
+    testIndexCreationInBackgroundAborts : function () {
+      let c = setupCollection('document');
+      let task = dropCb();
+
+      try {
+        c.ensureIndex({ type: "persistent", fields: ["value1", "value2"], inBackground: true });
+        fail();
+      } catch (err) {
+        // unfortunately it is possible that this fails because of unexpected
+        // scheduling. the whole test is time-based and assumes reasonable
+        // scheduling, which probably isn't guaranteed on some CI servers.
+        assertEqual(expectedError, err.errorNum);
+      }
+
+      shutdownTask(task);
+    },
+    
+    testWarmupAborts : function () {
+      if (!internal.debugCanUseFailAt()) {
+        return;
+      }
+
+      internal.debugSetFailAt("warmup::executeDirectly");
+      
+      let c = setupCollection('edge');
+      let task = dropCb();
+
+      try {
+        c.loadIndexesIntoMemory();
+        fail();
+      } catch (err) {
+        // unfortunately it is possible that this fails because of unexpected
+        // scheduling. the whole test is time-based and assumes reasonable
+        // scheduling, which probably isn't guaranteed on some CI servers.
+        assertEqual(expectedError, err.errorNum);
+      }
+
+      shutdownTask(task);
+    },
+
+  };
+}
+
+function AbortLongRunningOperationsWhenCollectionIsDroppedSuite() {
+  'use strict';
+
+  let dropCb = () => {
+    let task = tasks.register({
+      command: function() {
+        let db = require("internal").db;
+        let cn = "UnitTestsCollection";
+        db[cn].insert({ _key: "runner1", _from: "v/test1", _to: "v/test2" });
+
+        while (!db[cn].exists("runner2")) {
+          require("internal").sleep(0.02);
+        }
+
+        require("internal").sleep(0.02);
+        db._drop(cn);
+      },
+    });
+
+    while (!db[cn].exists("runner1")) {
+      require("internal").sleep(0.02);
+    }
+    db[cn].insert({ _key: "runner2", _from: "v/test1", _to: "v/test2" });
+    return task;
+  };
+
+  let suite = {
+    tearDown: function () {
+      internal.debugClearFailAt();
+      db._drop(cn);
+    }
+  };
+
+  deriveTestSuite(BaseTestConfig(dropCb, ERRORS.ERROR_ARANGO_DATA_SOURCE_NOT_FOUND.code), suite, '_collection');
+  return suite;
+}
+
+function AbortLongRunningOperationsWhenDatabaseIsDroppedSuite() {
+  'use strict';
+
+  let dropCb = () => {
+    let old = db._name();
+    db._useDatabase('_system');
+    try {
+      let task = tasks.register({
+        command: function(params) {
+          let db = require("internal").db;
+          db._useDatabase(params.old);
+          let cn = "UnitTestsCollection";
+          db[cn].insert({ _key: "runner1", _from: "v/test1", _to: "v/test2" });
+
+          while (!db[cn].exists("runner2")) {
+            require("internal").sleep(0.02);
+          }
+
+          require("internal").sleep(0.02);
+          db._useDatabase('_system');
+          db._dropDatabase(cn);
+        },
+        params: { old },
+        isSystem: true,
+      });
+
+      db._useDatabase(old);
+      while (!db[cn].exists("runner1")) {
+        require("internal").sleep(0.02);
+      }
+      db[cn].insert({ _key: "runner2", _from: "v/test1", _to: "v/test2" });
+      return task;
+    } finally {
+      db._useDatabase(old);
+    }
+  };
+
+  let suite = {
+    setUp: function () {
+      db._createDatabase(cn);
+      db._useDatabase(cn);
+    },
+    tearDown: function () {
+      internal.debugClearFailAt();
+      db._useDatabase('_system');
+      try {
+        db._dropDatabase(cn);
+      } catch (err) {
+        // in most cases the DB will already have been deleted
+      }
+    }
+  };
+
+  deriveTestSuite(BaseTestConfig(dropCb, ERRORS.ERROR_ARANGO_DATABASE_NOT_FOUND.code), suite, '_database');
+  return suite;
+}
+
+jsunity.run(AbortLongRunningOperationsWhenCollectionIsDroppedSuite);
+jsunity.run(AbortLongRunningOperationsWhenDatabaseIsDroppedSuite);
+return jsunity.done();


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/18294

Enterprise companion PR: https://github.com/arangodb/enterprise/pull/1228

Abort the following potentially long-running commands prematurely if the underlying collection or database is dropped:
* ensureIndex
* warmup
* recalculateCounts
* rebuildRevisionTree

- [x] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.10: this PR
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -

#### Related Information

- [ ] Docs PR: 
- [x] Enterprise PR: https://github.com/arangodb/enterprise/pull/1228
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 