### PR TITLE
[GORDO-1549] Start computing state

### DIFF
--- a/arangod/Pregel/AlgoRegistry.cpp
+++ b/arangod/Pregel/AlgoRegistry.cpp
@@ -136,12 +136,12 @@ auto AlgoRegistry::createAlgorithmNew(std::string const& algorithm,
 template<typename V, typename E, typename M>
 std::shared_ptr<IWorker> AlgoRegistry::createWorker(
     TRI_vocbase_t& vocbase, Algorithm<V, E, M>* algo,
-    CreateWorker const& parameters, PregelFeature& feature) {
+    worker::message::CreateWorker const& parameters, PregelFeature& feature) {
   return std::make_shared<Worker<V, E, M>>(vocbase, algo, parameters, feature);
 }
 
 std::shared_ptr<IWorker> AlgoRegistry::createWorker(
-    TRI_vocbase_t& vocbase, CreateWorker const& parameters,
+    TRI_vocbase_t& vocbase, worker::message::CreateWorker const& parameters,
     PregelFeature& feature) {
   VPackSlice userParams = parameters.userParameters.slice();
   std::string algorithm = parameters.algorithm;

--- a/arangod/Pregel/AlgoRegistry.h
+++ b/arangod/Pregel/AlgoRegistry.h
@@ -38,19 +38,18 @@ class PregelFeature;
 struct AlgoRegistry {
   static IAlgorithm* createAlgorithm(std::string const& algorithm,
                                      VPackSlice userParams);
-  static std::shared_ptr<IWorker> createWorker(TRI_vocbase_t& vocbase,
-                                               CreateWorker const& parameters,
-                                               PregelFeature& feature);
+  static std::shared_ptr<IWorker> createWorker(
+      TRI_vocbase_t& vocbase, worker::message::CreateWorker const& parameters,
+      PregelFeature& feature);
   static auto createAlgorithmNew(std::string const& algorithm,
                                  VPackSlice userParams)
       -> std::optional<std::unique_ptr<IAlgorithm>>;
 
  private:
   template<typename V, typename E, typename M>
-  static std::shared_ptr<IWorker> createWorker(TRI_vocbase_t& vocbase,
-                                               Algorithm<V, E, M>* algo,
-                                               CreateWorker const& parameters,
-                                               PregelFeature& feature);
+  static std::shared_ptr<IWorker> createWorker(
+      TRI_vocbase_t& vocbase, Algorithm<V, E, M>* algo,
+      worker::message::CreateWorker const& parameters, PregelFeature& feature);
 };
 
 }  // namespace pregel

--- a/arangod/Pregel/Algorithm.h
+++ b/arangod/Pregel/Algorithm.h
@@ -69,10 +69,6 @@ struct IAlgorithm {
       std::unique_ptr<AggregatorHandler> readAggregators,
       std::unique_ptr<AggregatorHandler> writeAggregators,
       velocypack::Slice userParams) const -> WorkerContext* = 0;
-  [[nodiscard]] virtual auto workerContextUnique(
-      std::unique_ptr<AggregatorHandler> readAggregators,
-      std::unique_ptr<AggregatorHandler> writeAggregators,
-      velocypack::Slice userParams) const -> std::unique_ptr<WorkerContext> = 0;
 
   [[nodiscard]] virtual auto name() const -> std::string_view = 0;
 };
@@ -97,6 +93,10 @@ struct Algorithm : IAlgorithm {
       VertexCompensation<vertex_type, edge_type, message_type>;
 
  public:
+  [[nodiscard]] virtual auto workerContextUnique(
+      std::unique_ptr<AggregatorHandler> readAggregators,
+      std::unique_ptr<AggregatorHandler> writeAggregators,
+      velocypack::Slice userParams) const -> std::unique_ptr<WorkerContext> = 0;
   virtual std::shared_ptr<graph_format const> inputFormat() const = 0;
   [[deprecated]] virtual message_format* messageFormat() const = 0;
   [[nodiscard]] virtual auto messageFormatUnique() const

--- a/arangod/Pregel/Conductor/Conductor.cpp
+++ b/arangod/Pregel/Conductor/Conductor.cpp
@@ -470,18 +470,19 @@ ErrorCode Conductor::_initializeWorkers() {
   for (auto const& [server, vertexShardMap] : vertexMap) {
     auto const& edgeShardMap = edgeMap[server];
 
-    auto createWorker =
-        CreateWorker{.executionNumber = _specifications.executionNumber,
-                     .algorithm = std::string{_algorithm->name()},
-                     .userParameters = _specifications.userParameters,
-                     .coordinatorId = coordinatorId,
-                     .useMemoryMaps = _specifications.useMemoryMaps,
-                     .edgeCollectionRestrictions =
-                         _specifications.edgeCollectionRestrictions,
-                     .vertexShards = vertexShardMap,
-                     .edgeShards = edgeShardMap,
-                     .collectionPlanIds = collectionPlanIdMap,
-                     .allShards = shardList};
+    auto createWorker = worker::message::CreateWorker{
+        .executionNumber = _specifications.executionNumber,
+        .algorithm = std::string{_algorithm->name()},
+        .userParameters = _specifications.userParameters,
+        .coordinatorId = coordinatorId,
+        .useMemoryMaps = _specifications.useMemoryMaps,
+        .parallelism = _specifications.parallelism,
+        .edgeCollectionRestrictions =
+            _specifications.edgeCollectionRestrictions,
+        .vertexShards = vertexShardMap,
+        .edgeShards = edgeShardMap,
+        .collectionPlanIds = collectionPlanIdMap,
+        .allShards = shardList};
 
     // hack for single server
     if (ServerState::instance()->getRole() == ServerState::ROLE_SINGLE) {

--- a/arangod/Pregel/Conductor/ExecutionStates/AQLResultsAvailableState.h
+++ b/arangod/Pregel/Conductor/ExecutionStates/AQLResultsAvailableState.h
@@ -38,8 +38,10 @@ struct ConductorState;
 struct AQLResultsAvailable : ExecutionState {
   AQLResultsAvailable() = default;
   auto name() const -> std::string override { return "done"; }
-  auto message() -> worker::message::WorkerMessages override {
-    return worker::message::WorkerMessages{};
+  auto messages()
+      -> std::unordered_map<actor::ActorPID,
+                            worker::message::WorkerMessages> override {
+    return {};
   }
   auto receive(actor::ActorPID sender, message::ConductorMessages message)
       -> std::optional<std::unique_ptr<ExecutionState>> override {

--- a/arangod/Pregel/Conductor/ExecutionStates/ComputingState.cpp
+++ b/arangod/Pregel/Conductor/ExecutionStates/ComputingState.cpp
@@ -6,13 +6,37 @@ Computing::Computing(ConductorState& conductor,
                      std::unique_ptr<MasterContext> masterContext)
     : conductor{conductor}, masterContext{std::move(masterContext)} {
   // TODO somewhere call masterContext->preApplication();
+  conductor.timing.computation.start();
+  // TODO GORDO-1510
+  // _feature.metrics()->pregelConductorsRunningNumber->fetch_add(1);
+  // TODO start gss timing
+  // TODO conductor.mastercontext->preGlobalSuperstep()
 }
 
 Computing::~Computing() {}
 
-auto Computing::message() -> worker::message::WorkerMessages {
-  return worker::message::WorkerMessages{};
-};
+auto Computing::messages()
+    -> std::unordered_map<actor::ActorPID, worker::message::WorkerMessages> {
+  VPackBuilder aggregators;
+  {
+    VPackObjectBuilder ob(&aggregators);
+    masterContext->_aggregators->serializeValues(aggregators);
+  }
+  auto out =
+      std::unordered_map<actor::ActorPID, worker::message::WorkerMessages>();
+  for (auto const& worker : conductor.workers) {
+    out.emplace(worker,
+                worker::message::RunGlobalSuperStep{
+                    .gss = masterContext->_globalSuperstep,
+                    .vertexCount = masterContext->_vertexCount,
+                    .edgeCount = masterContext->_edgeCount,
+                    .sendCount = sendCountPerServer.contains(worker.server)
+                                     ? sendCountPerServer.at(worker.server)
+                                     : 0,
+                    .aggregators = aggregators});
+  }
+  return out;
+}
 auto Computing::receive(actor::ActorPID sender,
                         message::ConductorMessages message)
     -> std::optional<std::unique_ptr<ExecutionState>> {

--- a/arangod/Pregel/Conductor/ExecutionStates/ComputingState.h
+++ b/arangod/Pregel/Conductor/ExecutionStates/ComputingState.h
@@ -33,18 +33,20 @@ namespace arangodb::pregel::conductor {
 
 struct ConductorState;
 
-// TODO implement in GORDO-1548
 struct Computing : ExecutionState {
   Computing(ConductorState& conductor,
             std::unique_ptr<MasterContext> masterContext);
   ~Computing();
   auto name() const -> std::string override { return "computing"; };
-  auto message() -> worker::message::WorkerMessages override;
+  auto messages()
+      -> std::unordered_map<actor::ActorPID,
+                            worker::message::WorkerMessages> override;
   auto receive(actor::ActorPID sender, message::ConductorMessages message)
       -> std::optional<std::unique_ptr<ExecutionState>> override;
 
   ConductorState& conductor;
   std::unique_ptr<MasterContext> masterContext;
+  std::unordered_map<ServerID, uint64_t> sendCountPerServer;
 };
 
 }  // namespace arangodb::pregel::conductor

--- a/arangod/Pregel/Conductor/ExecutionStates/CreateWorkersState.cpp
+++ b/arangod/Pregel/Conductor/ExecutionStates/CreateWorkersState.cpp
@@ -10,7 +10,7 @@ CreateWorkers::CreateWorkers(ConductorState& conductor) : conductor{conductor} {
   conductor.timing.total.start();
 }
 
-auto CreateWorkers::messages()
+auto CreateWorkers::messagesToServers()
     -> std::unordered_map<ServerID, worker::message::CreateNewWorker> {
   auto workerSpecifications = _workerSpecifications();
 

--- a/arangod/Pregel/Conductor/ExecutionStates/CreateWorkersState.cpp
+++ b/arangod/Pregel/Conductor/ExecutionStates/CreateWorkersState.cpp
@@ -11,7 +11,7 @@ CreateWorkers::CreateWorkers(ConductorState& conductor) : conductor{conductor} {
 }
 
 auto CreateWorkers::messagesToServers()
-    -> std::unordered_map<ServerID, worker::message::CreateNewWorker> {
+    -> std::unordered_map<ServerID, worker::message::CreateWorker> {
   auto workerSpecifications = _workerSpecifications();
 
   auto servers = std::vector<ServerID>{};
@@ -46,21 +46,28 @@ auto CreateWorkers::receive(actor::ActorPID sender,
 };
 
 auto CreateWorkers::_workerSpecifications() const
-    -> std::unordered_map<ServerID, worker::message::CreateNewWorker> {
+    -> std::unordered_map<ServerID, worker::message::CreateWorker> {
   auto createWorkers =
-      std::unordered_map<ServerID, worker::message::CreateNewWorker>{};
+      std::unordered_map<ServerID, worker::message::CreateWorker>{};
   for (auto const& [server, vertexShards] :
        conductor.lookupInfo->getServerMapVertices()) {
     auto edgeShards = conductor.lookupInfo->getServerMapEdges().at(server);
     createWorkers.emplace(
-        server, worker::message::CreateNewWorker{
-                    .executionSpecifications = conductor.specifications,
-                    .collectionSpecifications = CollectionSpecifications{
-                        .vertexShards = std::move(vertexShards),
-                        .edgeShards = std::move(edgeShards),
-                        .collectionPlanIds =
-                            conductor.lookupInfo->getCollectionPlanIdMapAll(),
-                        .allShards = conductor.lookupInfo->getAllShards()}});
+        server,
+        worker::message::CreateWorker{
+            .executionNumber = conductor.specifications.executionNumber,
+            .algorithm = std::string{conductor.specifications.algorithm},
+            .userParameters = conductor.specifications.userParameters,
+            .coordinatorId = "",
+            .useMemoryMaps = conductor.specifications.useMemoryMaps,
+            .parallelism = conductor.specifications.parallelism,
+            .edgeCollectionRestrictions =
+                conductor.specifications.edgeCollectionRestrictions,
+            .vertexShards = std::move(vertexShards),
+            .edgeShards = std::move(edgeShards),
+            .collectionPlanIds =
+                conductor.lookupInfo->getCollectionPlanIdMapAll(),
+            .allShards = conductor.lookupInfo->getAllShards()});
   }
   return createWorkers;
 }

--- a/arangod/Pregel/Conductor/ExecutionStates/CreateWorkersState.h
+++ b/arangod/Pregel/Conductor/ExecutionStates/CreateWorkersState.h
@@ -50,7 +50,7 @@ struct CreateWorkers : ExecutionState {
     interface.
    */
   auto messagesToServers()
-      -> std::unordered_map<ServerID, worker::message::CreateNewWorker>;
+      -> std::unordered_map<ServerID, worker::message::CreateWorker>;
   auto messages()
       -> std::unordered_map<actor::ActorPID,
                             worker::message::WorkerMessages> override {
@@ -64,7 +64,7 @@ struct CreateWorkers : ExecutionState {
   std::set<ServerID> respondedServers;
   uint64_t responseCount = 0;
   auto _workerSpecifications() const
-      -> std::unordered_map<ServerID, worker::message::CreateNewWorker>;
+      -> std::unordered_map<ServerID, worker::message::CreateWorker>;
 };
 
 }  // namespace arangodb::pregel::conductor

--- a/arangod/Pregel/Conductor/ExecutionStates/CreateWorkersState.h
+++ b/arangod/Pregel/Conductor/ExecutionStates/CreateWorkersState.h
@@ -49,11 +49,13 @@ struct CreateWorkers : ExecutionState {
     function that needs to be used instead of the message function of the state
     interface.
    */
-  auto messages()
+  auto messagesToServers()
       -> std::unordered_map<ServerID, worker::message::CreateNewWorker>;
-  auto message() -> worker::message::WorkerMessages override {
-    return worker::message::WorkerMessages{};
-  };
+  auto messages()
+      -> std::unordered_map<actor::ActorPID,
+                            worker::message::WorkerMessages> override {
+    return {};
+  }
   auto receive(actor::ActorPID sender, message::ConductorMessages message)
       -> std::optional<std::unique_ptr<ExecutionState>> override;
 

--- a/arangod/Pregel/Conductor/ExecutionStates/DoneState.h
+++ b/arangod/Pregel/Conductor/ExecutionStates/DoneState.h
@@ -31,8 +31,10 @@ struct ConductorState;
 struct Done : ExecutionState {
   Done() = default;
   auto name() const -> std::string override { return "done"; }
-  auto message() -> worker::message::WorkerMessages override {
-    return worker::message::WorkerMessages{};
+  auto messages()
+      -> std::unordered_map<actor::ActorPID,
+                            worker::message::WorkerMessages> override {
+    return {};
   }
   auto receive(actor::ActorPID sender, message::ConductorMessages message)
       -> std::optional<std::unique_ptr<ExecutionState>> override {

--- a/arangod/Pregel/Conductor/ExecutionStates/FatalErrorState.h
+++ b/arangod/Pregel/Conductor/ExecutionStates/FatalErrorState.h
@@ -38,9 +38,11 @@ struct FatalError : ExecutionState {
   }
   ~FatalError() {}
   auto name() const -> std::string override { return "fatal error"; };
-  auto message() -> worker::message::WorkerMessages override {
-    return worker::message::WorkerMessages{};
-  };
+  auto messages()
+      -> std::unordered_map<actor::ActorPID,
+                            worker::message::WorkerMessages> override {
+    return {};
+  }
   auto receive(actor::ActorPID sender, message::ConductorMessages message)
       -> std::optional<std::unique_ptr<ExecutionState>> override {
     return std::nullopt;

--- a/arangod/Pregel/Conductor/ExecutionStates/InitialState.h
+++ b/arangod/Pregel/Conductor/ExecutionStates/InitialState.h
@@ -37,9 +37,11 @@ struct ConductorState;
 struct Initial : ExecutionState {
   Initial() = default;
   auto name() const -> std::string override { return "initial"; };
-  auto message() -> worker::message::WorkerMessages override {
-    return worker::message::WorkerMessages{};
-  };
+  auto messages()
+      -> std::unordered_map<actor::ActorPID,
+                            worker::message::WorkerMessages> override {
+    return {};
+  }
   auto receive(actor::ActorPID sender, message::ConductorMessages message)
       -> std::optional<std::unique_ptr<ExecutionState>> override {
     return std::nullopt;

--- a/arangod/Pregel/Conductor/ExecutionStates/LoadingState.cpp
+++ b/arangod/Pregel/Conductor/ExecutionStates/LoadingState.cpp
@@ -14,9 +14,17 @@ Loading::~Loading() {
   // TODO GORDO-1510
   // conductor._feature.metrics()->pregelConductorsLoadingNumber->fetch_sub(1);
 }
-auto Loading::message() -> worker::message::WorkerMessages {
-  return worker::message::LoadGraph{};
+
+auto Loading::messages()
+    -> std::unordered_map<actor::ActorPID, worker::message::WorkerMessages> {
+  auto messages =
+      std::unordered_map<actor::ActorPID, worker::message::WorkerMessages>{};
+  for (auto const& worker : conductor.workers) {
+    messages.emplace(worker, worker::message::LoadGraph{});
+  }
+  return messages;
 };
+
 auto Loading::receive(actor::ActorPID sender,
                       message::ConductorMessages message)
     -> std::optional<std::unique_ptr<ExecutionState>> {

--- a/arangod/Pregel/Conductor/ExecutionStates/LoadingState.h
+++ b/arangod/Pregel/Conductor/ExecutionStates/LoadingState.h
@@ -36,7 +36,9 @@ struct Loading : ExecutionState {
   Loading(ConductorState& conductor);
   ~Loading();
   auto name() const -> std::string override { return "loading"; };
-  auto message() -> worker::message::WorkerMessages override;
+  auto messages()
+      -> std::unordered_map<actor::ActorPID,
+                            worker::message::WorkerMessages> override;
   auto receive(actor::ActorPID sender, message::ConductorMessages message)
       -> std::optional<std::unique_ptr<ExecutionState>> override;
 

--- a/arangod/Pregel/Conductor/ExecutionStates/ProduceAQLResultsState.h
+++ b/arangod/Pregel/Conductor/ExecutionStates/ProduceAQLResultsState.h
@@ -42,9 +42,11 @@ struct ProduceAQLResults : ExecutionState {
   // Discussable Note: To prevent API state change we're using "storing" as the
   // defined name here. Better: Use the real name of that state.
   auto name() const -> std::string override { return "storing"; };
-  auto message() -> worker::message::WorkerMessages override {
-    return worker::message::WorkerMessages{};
-  };
+  auto messages()
+      -> std::unordered_map<actor::ActorPID,
+                            worker::message::WorkerMessages> override {
+    return {};
+  }
   auto receive(actor::ActorPID sender, message::ConductorMessages message)
       -> std::optional<std::unique_ptr<ExecutionState>> override;
 

--- a/arangod/Pregel/Conductor/ExecutionStates/State.h
+++ b/arangod/Pregel/Conductor/ExecutionStates/State.h
@@ -37,7 +37,9 @@ namespace arangodb::pregel::conductor {
 
 struct ExecutionState {
   virtual auto name() const -> std::string = 0;
-  virtual auto message() -> worker::message::WorkerMessages = 0;
+  virtual auto messages()
+      -> std::unordered_map<actor::ActorPID,
+                            worker::message::WorkerMessages> = 0;
   virtual auto receive(actor::ActorPID sender,
                        conductor::message::ConductorMessages message)
       -> std::optional<std::unique_ptr<ExecutionState>> = 0;

--- a/arangod/Pregel/Conductor/Handler.h
+++ b/arangod/Pregel/Conductor/Handler.h
@@ -43,13 +43,13 @@ struct ConductorHandler : actor::HandlerBase<Runtime, ConductorState> {
     this->state->executionState = std::make_unique<CreateWorkers>(*this->state);
     /*
        CreateWorkers is a special state because it creates the workers instead
-       of just sending messages to them. Therefore we cannot use the message fct
-       of the ExecutionState but need to call the special messages function
-       which is specific to the CreateWorkers state only
+       of just sending messages to them. Therefore we cannot use the messages
+       fct of the ExecutionState but need to call the special messagesToServers
+       function which is specific to the CreateWorkers state only
     */
     auto createWorkers =
         static_cast<CreateWorkers*>(this->state->executionState.get());
-    auto messages = createWorkers->messages();
+    auto messages = createWorkers->messagesToServers();
     for (auto& [server, message] : messages) {
       this->dispatch(
           this->state->spawnActor,
@@ -69,7 +69,7 @@ struct ConductorHandler : actor::HandlerBase<Runtime, ConductorState> {
         this->state->executionState->receive(this->sender, std::move(start));
     if (newExecutionState.has_value()) {
       changeState(std::move(newExecutionState.value()));
-      sendMessageToWorkers();
+      sendMessages();
     }
     return std::move(this->state);
   }
@@ -82,7 +82,7 @@ struct ConductorHandler : actor::HandlerBase<Runtime, ConductorState> {
         this->state->executionState->receive(this->sender, std::move(start));
     if (newExecutionState.has_value()) {
       changeState(std::move(newExecutionState.value()));
-      sendMessageToWorkers();
+      sendMessages();
     }
     return std::move(this->state);
   }
@@ -142,9 +142,9 @@ struct ConductorHandler : actor::HandlerBase<Runtime, ConductorState> {
                        this->state->executionState->name());
   }
 
-  auto sendMessageToWorkers() -> void {
-    auto message = this->state->executionState->message();
-    for (auto& worker : this->state->workers) {
+  auto sendMessages() -> void {
+    auto messages = this->state->executionState->messages();
+    for (auto const& [worker, message] : messages) {
       this->dispatch(worker, message);
     }
   }

--- a/arangod/Pregel/Conductor/Messages.h
+++ b/arangod/Pregel/Conductor/Messages.h
@@ -42,11 +42,13 @@ template<typename Inspector>
 auto inspect(Inspector& f, ConductorStart& x) {
   return f.object(x).fields();
 }
+
 struct WorkerCreated {};
 template<typename Inspector>
 auto inspect(Inspector& f, WorkerCreated& x) {
   return f.object(x).fields();
 }
+
 struct GraphLoaded {
   ExecutionNumber executionNumber;
   uint64_t vertexCount;
@@ -58,15 +60,11 @@ auto inspect(Inspector& f, GraphLoaded& x) {
       f.field(Utils::executionNumberKey, x.executionNumber),
       f.field("vertexCount", x.vertexCount), f.field("edgeCount", x.edgeCount));
 }
-struct StatusUpdate {
-  ExecutionNumber executionNumber;
-  Status status;
-};
+
+struct GlobalSuperStepFinished {};
 template<typename Inspector>
-auto inspect(Inspector& f, StatusUpdate& x) {
-  return f.object(x).fields(
-      f.field(Utils::executionNumberKey, x.executionNumber),
-      f.field("status", x.status));
+auto inspect(Inspector& f, GlobalSuperStepFinished& x) {
+  return f.object(x).fields();
 }
 
 struct ResultCreated {
@@ -77,12 +75,23 @@ auto inspect(Inspector& f, ResultCreated& x) {
   return f.object(x).fields(f.field("results", x.results));
 }
 
+struct StatusUpdate {
+  ExecutionNumber executionNumber;
+  Status status;
+};
+template<typename Inspector>
+auto inspect(Inspector& f, StatusUpdate& x) {
+  return f.object(x).fields(
+      f.field(Utils::executionNumberKey, x.executionNumber),
+      f.field("status", x.status));
+}
 struct ConductorMessages
     : std::variant<ConductorStart, ResultT<WorkerCreated>, ResultT<GraphLoaded>,
-                   StatusUpdate, ResultCreated> {
+                   ResultT<GlobalSuperStepFinished>, ResultCreated,
+                   StatusUpdate> {
   using std::variant<ConductorStart, ResultT<WorkerCreated>,
-                     ResultT<GraphLoaded>, StatusUpdate,
-                     ResultCreated>::variant;
+                     ResultT<GraphLoaded>, ResultT<GlobalSuperStepFinished>,
+                     ResultCreated, StatusUpdate>::variant;
 };
 template<typename Inspector>
 auto inspect(Inspector& f, ConductorMessages& x) {
@@ -90,6 +99,8 @@ auto inspect(Inspector& f, ConductorMessages& x) {
       arangodb::inspection::type<ConductorStart>("Start"),
       arangodb::inspection::type<ResultT<WorkerCreated>>("WorkerCreated"),
       arangodb::inspection::type<ResultT<GraphLoaded>>("GraphLoaded"),
+      arangodb::inspection::type<ResultT<GlobalSuperStepFinished>>(
+          "GlobalSuperStepFinished"),
       arangodb::inspection::type<ResultCreated>("ResultCreated"),
       arangodb::inspection::type<StatusUpdate>("StatusUpdate"));
 }

--- a/arangod/Pregel/Conductor/Messages.h
+++ b/arangod/Pregel/Conductor/Messages.h
@@ -96,35 +96,6 @@ auto inspect(Inspector& f, ConductorMessages& x) {
 
 }  // namespace conductor::message
 
-// TODO split LoadGraph off CreateWorker
-struct CreateWorker {
-  ExecutionNumber executionNumber;
-  std::string algorithm;
-  VPackBuilder userParameters;
-  std::string coordinatorId;
-  bool useMemoryMaps;
-  std::unordered_map<CollectionID, std::vector<ShardID>>
-      edgeCollectionRestrictions;
-  std::map<CollectionID, std::vector<ShardID>> vertexShards;
-  std::map<CollectionID, std::vector<ShardID>> edgeShards;
-  std::unordered_map<CollectionID, std::string> collectionPlanIds;
-  std::vector<ShardID> allShards;
-};
-template<typename Inspector>
-auto inspect(Inspector& f, CreateWorker& x) {
-  return f.object(x).fields(
-      f.field(Utils::executionNumberKey, x.executionNumber),
-      f.field("algorithm", x.algorithm),
-      f.field("userParameters", x.userParameters),
-      f.field("coordinatorId", x.coordinatorId),
-      f.field("useMemoryMaps", x.useMemoryMaps),
-      f.field("edgeCollectionRestrictions", x.edgeCollectionRestrictions),
-      f.field("vertexShards", x.vertexShards),
-      f.field("edgeShards", x.edgeShards),
-      f.field("collectionPlanIds", x.collectionPlanIds),
-      f.field("allShards", x.allShards));
-}
-
 struct PrepareGlobalSuperStep {
   ExecutionNumber executionNumber;
   uint64_t gss;

--- a/arangod/Pregel/IncomingCache.cpp
+++ b/arangod/Pregel/IncomingCache.cpp
@@ -49,7 +49,7 @@ InCache<M>::InCache(MessageFormat<M> const* format)
     : _containedMessageCount(0), _format(format) {}
 
 template<typename M>
-void InCache<M>::parseMessages(PregelMessage const& message) {
+void InCache<M>::parseMessages(worker::message::PregelMessage const& message) {
   // every packet contains one shard
   VPackValueLength i = 0;
   std::string_view key;

--- a/arangod/Pregel/IncomingCache.h
+++ b/arangod/Pregel/IncomingCache.h
@@ -64,7 +64,7 @@ class InCache {
   MessageFormat<M> const* format() const { return _format; }
   uint64_t containedMessageCount() const { return _containedMessageCount; }
 
-  void parseMessages(PregelMessage const& messages);
+  void parseMessages(worker::message::PregelMessage const& messages);
 
   /// @brief Store a single message.
   /// Only ever call when you are sure this is a thread local store

--- a/arangod/Pregel/OutgoingCache.cpp
+++ b/arangod/Pregel/OutgoingCache.cpp
@@ -138,11 +138,11 @@ void ArrayOutCache<M>::flushMessages() {
     }
 
     auto [shardMessageCount, messages] = messagesToVPack(vertexMessageMap);
-    auto pregelMessage =
-        PregelMessage{.executionNumber = this->_config->executionNumber(),
-                      .gss = gss,
-                      .shard = shard,
-                      .messages = messages};
+    auto pregelMessage = worker::message::PregelMessage{
+        .executionNumber = this->_config->executionNumber(),
+        .gss = gss,
+        .shard = shard,
+        .messages = messages};
     auto serialized = inspection::serializeWithErrorT(pregelMessage);
     if (!serialized.ok()) {
       THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_INTERNAL,
@@ -254,11 +254,11 @@ void CombiningOutCache<M>::flushMessages() {
       continue;
     }
 
-    auto pregelMessage =
-        PregelMessage{.executionNumber = this->_config->executionNumber(),
-                      .gss = gss,
-                      .shard = shard,
-                      .messages = messagesToVPack(vertexMessageMap)};
+    auto pregelMessage = worker::message::PregelMessage{
+        .executionNumber = this->_config->executionNumber(),
+        .gss = gss,
+        .shard = shard,
+        .messages = messagesToVPack(vertexMessageMap)};
     auto serialized = inspection::serializeWithErrorT(pregelMessage);
     if (!serialized.ok()) {
       THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_INTERNAL,

--- a/arangod/Pregel/PregelFeature.cpp
+++ b/arangod/Pregel/PregelFeature.cpp
@@ -1051,8 +1051,9 @@ void PregelFeature::handleWorkerRequest(TRI_vocbase_t& vocbase,
     }
     w->startGlobalStep(message.get());
   } else if (path == Utils::messagesPath) {
-    auto message = inspection::deserializeWithErrorT<PregelMessage>(
-        velocypack::SharedSlice({}, body));
+    auto message =
+        inspection::deserializeWithErrorT<worker::message::PregelMessage>(
+            velocypack::SharedSlice({}, body));
     if (!message.ok()) {
       THROW_ARANGO_EXCEPTION_MESSAGE(
           TRI_ERROR_INTERNAL,

--- a/arangod/Pregel/PregelFeature.cpp
+++ b/arangod/Pregel/PregelFeature.cpp
@@ -992,8 +992,9 @@ void PregelFeature::handleWorkerRequest(TRI_vocbase_t& vocbase,
           TRI_ERROR_INTERNAL,
           "Worker with this execution number already exists.");
     }
-    auto createWorker = inspection::deserializeWithErrorT<CreateWorker>(
-        velocypack::SharedSlice({}, body));
+    auto createWorker =
+        inspection::deserializeWithErrorT<worker::message::CreateWorker>(
+            velocypack::SharedSlice({}, body));
     if (!createWorker.ok()) {
       THROW_ARANGO_EXCEPTION_MESSAGE(
           TRI_ERROR_INTERNAL,

--- a/arangod/Pregel/REST/RestPregelHandler.cpp
+++ b/arangod/Pregel/REST/RestPregelHandler.cpp
@@ -105,7 +105,7 @@ RestStatus RestPregelHandler::execute() {
                             .id = resultActorID};
         _pregel._resultActor.emplace(
             std::get<message::SpawnWorker>(spawnMessage.get())
-                .message.executionSpecifications.executionNumber,
+                .message.executionNumber,
             resultActorPID);
 
         _pregel._actorRuntime->spawn<SpawnActor>(

--- a/arangod/Pregel/SpawnActor.h
+++ b/arangod/Pregel/SpawnActor.h
@@ -25,6 +25,7 @@
 #include <memory>
 #include "Actor/ActorPID.h"
 #include "Actor/HandlerBase.h"
+#include "Pregel/AggregatorHandler.h"
 #include "Pregel/Worker/Actor.h"
 #include "Pregel/SpawnMessages.h"
 #include "Pregel/Worker/Messages.h"
@@ -78,16 +79,19 @@ struct SpawnHandler : actor::HandlerBase<Runtime, SpawnState> {
                    message::SpawnWorker msg) -> void {
     this->template spawn<worker::WorkerActor<V, E, M>>(
         std::make_unique<worker::WorkerState<V, E, M>>(
-            msg.conductor, msg.message.executionSpecifications,
-            msg.message.collectionSpecifications, std::move(algorithm),
+            algorithm->workerContextUnique(
+                std::make_unique<AggregatorHandler>(algorithm.get()),
+                std::make_unique<AggregatorHandler>(algorithm.get()),
+                msg.message.userParameters.slice()),
+            msg.conductor, msg.message, algorithm->messageFormatUnique(),
+            algorithm->messageCombinerUnique(), std::move(algorithm),
             this->state->vocbaseGuard.database(), this->state->resultActor),
         worker::message::WorkerStart{});
   }
 
   auto spawnWorker(message::SpawnWorker msg) -> void {
-    VPackSlice userParams =
-        msg.message.executionSpecifications.userParameters.slice();
-    std::string algorithm = msg.message.executionSpecifications.algorithm;
+    VPackSlice userParams = msg.message.userParameters.slice();
+    std::string algorithm = msg.message.algorithm;
 
     if (algorithm == "sssp") {
       spawnWorker<algos::SSSPType::Vertex, algos::SSSPType::Edge,

--- a/arangod/Pregel/SpawnMessages.h
+++ b/arangod/Pregel/SpawnMessages.h
@@ -37,7 +37,7 @@ auto inspect(Inspector& f, SpawnStart& x) {
 struct SpawnWorker {
   actor::ServerID destinationServer;
   actor::ActorPID conductor;
-  worker::message::CreateNewWorker message;
+  worker::message::CreateWorker message;
 };
 template<typename Inspector>
 auto inspect(Inspector& f, SpawnWorker& x) {

--- a/arangod/Pregel/Worker/Handler.h
+++ b/arangod/Pregel/Worker/Handler.h
@@ -54,8 +54,7 @@ struct WorkerHandler : actor::HandlerBase<Runtime, WorkerState<V, E, M>> {
           this->template dispatch<conductor::message::ConductorMessages>(
               this->state->conductor,
               conductor::message::StatusUpdate{
-                  .executionNumber =
-                      this->state->executionSpecifications.executionNumber,
+                  .executionNumber = this->state->config->executionNumber(),
                   .status = this->state->observeStatus()});
         };
 
@@ -70,8 +69,7 @@ struct WorkerHandler : actor::HandlerBase<Runtime, WorkerState<V, E, M>> {
         // this->state->graphStore->loadShards(&_config, statusUpdateCallback,
         // []() {});
         return {conductor::message::GraphLoaded{
-            .executionNumber =
-                this->state->executionSpecifications.executionNumber,
+            .executionNumber = this->state->config->executionNumber(),
             .vertexCount = 0,  // TODO GORDO-1546
                                // this->state->graphStore->localVertexCount(),
             .edgeCount = 0,    // TODO GORDO-1546

--- a/arangod/Pregel/Worker/Handler.h
+++ b/arangod/Pregel/Worker/Handler.h
@@ -95,6 +95,16 @@ struct WorkerHandler : actor::HandlerBase<Runtime, WorkerState<V, E, M>> {
     return std::move(this->state);
   }
 
+  auto operator()(message::RunGlobalSuperStep message)
+      -> std::unique_ptr<WorkerState<V, E, M>> {
+    LOG_TOPIC("0f658", INFO, Logger::PREGEL)
+        << fmt::format("Worker Actor {} is computing", this->self);
+    // prepare
+    // process vertices in threads
+    // finish
+    return std::move(this->state);
+  }
+
   auto operator()(message::ProduceResults msg)
       -> std::unique_ptr<WorkerState<V, E, M>> {
     std::string tmp;

--- a/arangod/Pregel/Worker/Handler.h
+++ b/arangod/Pregel/Worker/Handler.h
@@ -66,7 +66,7 @@ struct WorkerHandler : actor::HandlerBase<Runtime, WorkerState<V, E, M>> {
       try {
         // TODO GORDO-1546
         // add graph store to state
-        // this->state->graphStore->loadShards(&_config, statusUpdateCallback,
+        // this->state->graphStore->loadShards(_config, statusUpdateCallback,
         // []() {});
         return {conductor::message::GraphLoaded{
             .executionNumber = this->state->config->executionNumber(),
@@ -93,6 +93,8 @@ struct WorkerHandler : actor::HandlerBase<Runtime, WorkerState<V, E, M>> {
     return std::move(this->state);
   }
 
+  // ----- computing -----
+
   auto operator()(message::RunGlobalSuperStep message)
       -> std::unique_ptr<WorkerState<V, E, M>> {
     LOG_TOPIC("0f658", INFO, Logger::PREGEL)
@@ -102,6 +104,38 @@ struct WorkerHandler : actor::HandlerBase<Runtime, WorkerState<V, E, M>> {
     // finish
     return std::move(this->state);
   }
+
+  auto operator()(message::PregelMessage message)
+      -> std::unique_ptr<WorkerState<V, E, M>> {
+    LOG_TOPIC("80709", INFO, Logger::PREGEL) << fmt::format(
+        "Worker Actor {} received message {}", this->self, message);
+    if (message.gss != this->state->config->globalSuperstep() &&
+        message.gss != this->state->config->globalSuperstep() + 1) {
+      LOG_TOPIC("da39a", ERR, Logger::PREGEL)
+          << "Expected: " << this->state->config->globalSuperstep()
+          << " Got: " << message.gss;
+      this->template dispatch<conductor::message::ConductorMessages>(
+          this->state->conductor,
+          ResultT<conductor::message::GlobalSuperStepFinished>::error(
+              TRI_ERROR_BAD_PARAMETER, "Superstep out of sync"));
+    }
+    // queue message if read and write cache are not swapped yet, otherwise you
+    // will loose this message
+    if (message.gss == this->state->config->globalSuperstep() + 1 ||
+        // if config->gss == 0 and _computationStarted == false: read and write
+        // cache are not swapped yet, config->gss is currently 0 only due to its
+        // initialization
+        (this->state->config->globalSuperstep() == 0 &&
+         !this->state->computationStarted)) {
+      this->state->messagesForNextGss.push_back(message);
+    } else {
+      this->state->writeCache->parseMessages(message);
+    }
+
+    return std::move(this->state);
+  }
+
+  // ------ end computing ----
 
   auto operator()(message::ProduceResults msg)
       -> std::unique_ptr<WorkerState<V, E, M>> {

--- a/arangod/Pregel/Worker/Messages.h
+++ b/arangod/Pregel/Worker/Messages.h
@@ -60,6 +60,21 @@ auto inspect(Inspector& f, LoadGraph& x) {
   return f.object(x).fields();
 }
 
+struct RunGlobalSuperStep {
+  uint64_t gss;
+  uint64_t vertexCount;
+  uint64_t edgeCount;
+  uint64_t sendCount;
+  VPackBuilder aggregators;
+};
+template<typename Inspector>
+auto inspect(Inspector& f, RunGlobalSuperStep& x) {
+  return f.object(x).fields(
+      f.field("globalSuperStep", x.gss), f.field("vertexCount", x.vertexCount),
+      f.field("edgeCount", x.edgeCount), f.field("sendCount", x.sendCount),
+      f.field("aggregators", x.aggregators));
+}
+
 struct ProduceResults {
   bool withID;
 };
@@ -68,10 +83,10 @@ auto inspect(Inspector& f, ProduceResults& x) {
   return f.object(x).fields(f.field("withID", x.withID));
 }
 
-struct WorkerMessages
-    : std::variant<WorkerStart, CreateNewWorker, LoadGraph, ProduceResults> {
+struct WorkerMessages : std::variant<WorkerStart, CreateNewWorker, LoadGraph,
+                                     RunGlobalSuperStep, ProduceResults> {
   using std::variant<WorkerStart, CreateNewWorker, LoadGraph,
-                     ProduceResults>::variant;
+                     RunGlobalSuperStep, ProduceResults>::variant;
 };
 
 template<typename Inspector>
@@ -80,6 +95,7 @@ auto inspect(Inspector& f, WorkerMessages& x) {
       arangodb::inspection::type<WorkerStart>("Start"),
       arangodb::inspection::type<CreateNewWorker>("CreateWorker"),
       arangodb::inspection::type<LoadGraph>("LoadGraph"),
+      arangodb::inspection::type<RunGlobalSuperStep>("RunGlobalSuperStep"),
       arangodb::inspection::type<ProduceResults>("ProduceResults"));
 }
 
@@ -194,6 +210,9 @@ struct fmt::formatter<arangodb::pregel::worker::message::CreateNewWorker>
     : arangodb::inspection::inspection_formatter {};
 template<>
 struct fmt::formatter<arangodb::pregel::worker::message::LoadGraph>
+    : arangodb::inspection::inspection_formatter {};
+template<>
+struct fmt::formatter<arangodb::pregel::worker::message::RunGlobalSuperStep>
     : arangodb::inspection::inspection_formatter {};
 template<>
 struct fmt::formatter<arangodb::pregel::worker::message::WorkerMessages>

--- a/arangod/Pregel/Worker/State.h
+++ b/arangod/Pregel/Worker/State.h
@@ -24,9 +24,12 @@
 
 #include "Actor/ActorPID.h"
 #include "Pregel/Algorithm.h"
-#include "Basics/Guarded.h"
 #include "Pregel/CollectionSpecifications.h"
+#include "Pregel/IncomingCache.h"
+#include "Pregel/OutgoingCache.h"
 #include "Pregel/PregelOptions.h"
+#include "Pregel/Worker/Messages.h"
+#include "Pregel/WorkerContext.h"
 #include "Utils/DatabaseGuard.h"
 #include "VocBase/vocbase.h"
 #include "Pregel/Status/Status.h"
@@ -35,17 +38,46 @@ namespace arangodb::pregel::worker {
 
 template<typename V, typename E, typename M>
 struct WorkerState {
-  WorkerState(actor::ActorPID conductor,
-              ExecutionSpecifications executionSpecifications,
-              CollectionSpecifications collectionSpecifications,
+  WorkerState(std::unique_ptr<WorkerContext> workerContext,
+              actor::ActorPID conductor,
+              worker::message::CreateWorker specifications,
+              std::unique_ptr<MessageFormat<M>> messageFormat,
+              std::unique_ptr<MessageCombiner<M>> messageCombiner,
               std::unique_ptr<Algorithm<V, E, M>> algorithm,
               TRI_vocbase_t& vocbase, actor::ActorPID resultActor)
-      : conductor{std::move(conductor)},
-        executionSpecifications{std::move(executionSpecifications)},
-        collectionSpecifications{std::move(collectionSpecifications)},
+      : config{std::make_shared<WorkerConfig>(&vocbase)},
+        workerContext{std::move(workerContext)},
+        messageFormat{std::move(messageFormat)},
+        messageCombiner{std::move(messageCombiner)},
+        conductor{std::move(conductor)},
         algorithm{std::move(algorithm)},
         vocbaseGuard{vocbase},
-        resultActor(resultActor){};
+        resultActor(resultActor) {
+    config->updateConfig(specifications);
+
+    if (messageCombiner) {
+      readCache.reset(new CombiningInCache<M>(config, messageFormat.get(),
+                                              messageCombiner.get()));
+      writeCache.reset(new CombiningInCache<M>(config, messageFormat.get(),
+                                               messageCombiner.get()));
+      for (size_t i = 0; i < config->parallelism(); i++) {
+        auto incoming = std::make_unique<CombiningInCache<M>>(
+            nullptr, messageFormat.get(), messageCombiner.get());
+        inCaches.push_back(std::move(incoming));
+        outCaches.push_back(new CombiningOutCache<M>(
+            config, messageFormat.get(), messageCombiner.get()));
+      }
+    } else {
+      readCache.reset(new ArrayInCache<M>(config, messageFormat.get()));
+      writeCache.reset(new ArrayInCache<M>(config, messageFormat.get()));
+      for (size_t i = 0; i < config->parallelism(); i++) {
+        auto incoming =
+            std::make_unique<ArrayInCache<M>>(nullptr, messageFormat.get());
+        inCaches.push_back(std::move(incoming));
+        outCaches.push_back(new ArrayOutCache<M>(config, messageFormat.get()));
+      }
+    }
+  }
 
   auto observeStatus() -> Status const {
     auto currentGss = currentGssObservables.observe();
@@ -62,9 +94,19 @@ struct WorkerState {
                             : std::nullopt};
   }
 
+  std::shared_ptr<WorkerConfig> config;
+
+  // only needed in computing state
+  std::unique_ptr<WorkerContext> workerContext;
+  std::vector<PregelMessage> messagesForNextGss;
+  std::unique_ptr<MessageFormat<M>> messageFormat;
+  std::unique_ptr<MessageCombiner<M>> messageCombiner;
+  std::unique_ptr<InCache<M>> readCache = nullptr;
+  std::unique_ptr<InCache<M>> writeCache = nullptr;
+  std::vector<std::unique_ptr<InCache<M>>> inCaches;
+  std::vector<std::unique_ptr<OutCache<M>>> outCaches;
+
   actor::ActorPID conductor;
-  const ExecutionSpecifications executionSpecifications;
-  const CollectionSpecifications collectionSpecifications;
   std::unique_ptr<Algorithm<V, E, M>> algorithm;
   const DatabaseGuard vocbaseGuard;
   const actor::ActorPID resultActor;
@@ -75,11 +117,8 @@ struct WorkerState {
 };
 template<typename V, typename E, typename M, typename Inspector>
 auto inspect(Inspector& f, WorkerState<V, E, M>& x) {
-  return f.object(x).fields(
-      f.field("conductor", x.conductor),
-      f.field("executionSpecifications", x.executionSpecifications),
-      f.field("collectionSpecifications", x.collectionSpecifications),
-      f.field("algorithm", x.algorithm->name()));
+  return f.object(x).fields(f.field("conductor", x.conductor),
+                            f.field("algorithm", x.algorithm->name()));
 }
 
 }  // namespace arangodb::pregel::worker

--- a/arangod/Pregel/Worker/State.h
+++ b/arangod/Pregel/Worker/State.h
@@ -64,7 +64,7 @@ struct WorkerState {
         auto incoming = std::make_unique<CombiningInCache<M>>(
             nullptr, messageFormat.get(), messageCombiner.get());
         inCaches.push_back(std::move(incoming));
-        outCaches.push_back(new CombiningOutCache<M>(
+        outCaches.push_back(std::make_unique<CombiningOutCache<M>>(
             config, messageFormat.get(), messageCombiner.get()));
       }
     } else {
@@ -74,7 +74,8 @@ struct WorkerState {
         auto incoming =
             std::make_unique<ArrayInCache<M>>(nullptr, messageFormat.get());
         inCaches.push_back(std::move(incoming));
-        outCaches.push_back(new ArrayOutCache<M>(config, messageFormat.get()));
+        outCaches.push_back(
+            std::make_unique<ArrayOutCache<M>>(config, messageFormat.get()));
       }
     }
   }
@@ -98,7 +99,11 @@ struct WorkerState {
 
   // only needed in computing state
   std::unique_ptr<WorkerContext> workerContext;
-  std::vector<PregelMessage> messagesForNextGss;
+  std::vector<worker::message::PregelMessage> messagesForNextGss;
+  // distinguishes config.globalSuperStep being initialized to 0 and
+  // config.globalSuperStep being explicitely set to 0 when the first superstep
+  // starts: needed to process incoming messages in its dedicated gss
+  bool computationStarted = false;
   std::unique_ptr<MessageFormat<M>> messageFormat;
   std::unique_ptr<MessageCombiner<M>> messageCombiner;
   std::unique_ptr<InCache<M>> readCache = nullptr;

--- a/arangod/Pregel/Worker/Worker.cpp
+++ b/arangod/Pregel/Worker/Worker.cpp
@@ -80,12 +80,13 @@ using namespace arangodb::pregel;
 
 template<typename V, typename E, typename M>
 Worker<V, E, M>::Worker(TRI_vocbase_t& vocbase, Algorithm<V, E, M>* algo,
-                        CreateWorker const& parameters, PregelFeature& feature)
+                        worker::message::CreateWorker const& parameters,
+                        PregelFeature& feature)
     : _feature(feature),
       _state(WorkerState::IDLE),
       _config(std::make_shared<WorkerConfig>(&vocbase)),
       _algorithm(algo) {
-  _config->updateConfig(_feature, parameters);
+  _config->updateConfig(parameters);
 
   MUTEX_LOCKER(guard, _commandMutex);
 

--- a/arangod/Pregel/Worker/Worker.cpp
+++ b/arangod/Pregel/Worker/Worker.cpp
@@ -265,7 +265,8 @@ GlobalSuperStepPrepared Worker<V, E, M>::prepareGlobalStep(
 }
 
 template<typename V, typename E, typename M>
-void Worker<V, E, M>::receivedMessages(PregelMessage const& data) {
+void Worker<V, E, M>::receivedMessages(
+    worker::message::PregelMessage const& data) {
   if (data.gss == _config->_globalSuperstep) {
     {  // make sure the pointer is not changed while
       // parsing messages

--- a/arangod/Pregel/Worker/Worker.h
+++ b/arangod/Pregel/Worker/Worker.h
@@ -141,7 +141,7 @@ class Worker : public IWorker {
 
  public:
   Worker(TRI_vocbase_t& vocbase, Algorithm<V, E, M>* algorithm,
-         CreateWorker const& params, PregelFeature& feature);
+         worker::message::CreateWorker const& params, PregelFeature& feature);
   ~Worker();
 
   // ====== called by rest handler =====

--- a/arangod/Pregel/Worker/Worker.h
+++ b/arangod/Pregel/Worker/Worker.h
@@ -59,7 +59,7 @@ class IWorker : public std::enable_shared_from_this<IWorker> {
       RunGlobalSuperStep const& data) = 0;  // called by coordinator
   virtual void cancelGlobalStep(
       VPackSlice const& data) = 0;  // called by coordinator
-  virtual void receivedMessages(PregelMessage const& data) = 0;
+  virtual void receivedMessages(worker::message::PregelMessage const& data) = 0;
   virtual void finalizeExecution(FinalizeExecution const& data,
                                  std::function<void()> cb) = 0;
   virtual auto aqlResult(bool withId) const -> PregelResults = 0;
@@ -150,7 +150,7 @@ class Worker : public IWorker {
       PrepareGlobalSuperStep const& data) override;
   void startGlobalStep(RunGlobalSuperStep const& data) override;
   void cancelGlobalStep(VPackSlice const& data) override;
-  void receivedMessages(PregelMessage const& data) override;
+  void receivedMessages(worker::message::PregelMessage const& data) override;
   void finalizeExecution(FinalizeExecution const& data,
                          std::function<void()> cb) override;
 

--- a/arangod/Pregel/Worker/WorkerConfig.cpp
+++ b/arangod/Pregel/Worker/WorkerConfig.cpp
@@ -42,15 +42,13 @@ WorkerConfig::WorkerConfig(TRI_vocbase_t* vocbase) : _vocbase(vocbase) {}
 
 std::string const& WorkerConfig::database() const { return _vocbase->name(); }
 
-void WorkerConfig::updateConfig(PregelFeature& feature,
-                                CreateWorker const& params) {
+void WorkerConfig::updateConfig(worker::message::CreateWorker const& params) {
   _executionNumber = params.executionNumber;
   _coordinatorId = params.coordinatorId;
   _useMemoryMaps = params.useMemoryMaps;
-  VPackSlice userParams = params.userParameters.slice();
   _globalShardIDs = params.allShards;
 
-  _parallelism = feature.parallelism(userParams);
+  _parallelism = params.parallelism;
 
   // list of all shards, equal on all workers. Used to avoid storing strings of
   // shard names

--- a/arangod/Pregel/Worker/WorkerConfig.h
+++ b/arangod/Pregel/Worker/WorkerConfig.h
@@ -31,7 +31,7 @@
 #include "Basics/Common.h"
 #include "Basics/StaticStrings.h"
 
-#include "Pregel/Conductor/Messages.h"
+#include "Pregel/Worker/Messages.h"
 #include "Pregel/DatabaseTypes.h"
 #include "Pregel/ExecutionNumber.h"
 #include "Pregel/GraphStore/Graph.h"
@@ -53,7 +53,7 @@ class WorkerConfig : std::enable_shared_from_this<WorkerConfig> {
 
  public:
   explicit WorkerConfig(TRI_vocbase_t* vocbase);
-  void updateConfig(PregelFeature& feature, CreateWorker const& updated);
+  void updateConfig(worker::message::CreateWorker const& updated);
 
   ExecutionNumber executionNumber() const { return _executionNumber; }
 

--- a/tests/Pregel/ConductorStateTest.cpp
+++ b/tests/Pregel/ConductorStateTest.cpp
@@ -93,13 +93,6 @@ struct AlgorithmFake : IAlgorithm {
       arangodb::velocypack::Slice userParams) const -> WorkerContext* override {
     return nullptr;
   }
-  [[nodiscard]] auto workerContextUnique(
-      std::unique_ptr<AggregatorHandler> readAggregators,
-      std::unique_ptr<AggregatorHandler> writeAggregators,
-      arangodb::velocypack::Slice userParams) const
-      -> std::unique_ptr<WorkerContext> override {
-    return nullptr;
-  }
   [[nodiscard]] auto name() const -> std::string_view override {
     return "fake";
   };

--- a/tests/Pregel/ConductorStateTest.cpp
+++ b/tests/Pregel/ConductorStateTest.cpp
@@ -129,7 +129,7 @@ TEST(CreateWorkersStateTest, creates_as_many_messages_as_required_servers) {
         std::make_unique<AlgorithmFake>(), ExecutionSpecifications(),
         std::make_unique<LookupInfoMock>(servers), fakeActorPID, fakeActorPID);
     auto createWorkersState = CreateWorkers(cState);
-    auto msgs = createWorkersState.messages();
+    auto msgs = createWorkersState.messagesToServers();
     ASSERT_EQ(msgs.size(), servers.size());
 
     for (auto const& serverName : servers) {
@@ -147,7 +147,7 @@ TEST(CreateWorkersStateTest, creates_worker_pids_from_received_messages) {
       std::make_unique<AlgorithmFake>(), ExecutionSpecifications(),
       std::make_unique<LookupInfoMock>(servers), fakeActorPID, fakeActorPID);
   auto createWorkers = CreateWorkers(cState);
-  auto msgs = createWorkers.messages();
+  auto msgs = createWorkers.messagesToServers();
 
   auto created = arangodb::ResultT<message::WorkerCreated>();
   ASSERT_TRUE(created.ok());
@@ -180,7 +180,7 @@ TEST(CreateWorkersStateTest,
       std::make_unique<AlgorithmFake>(), ExecutionSpecifications(),
       std::make_unique<LookupInfoMock>(servers), fakeActorPID, fakeActorPID);
   auto createWorkers = CreateWorkers(cState);
-  auto msgs = createWorkers.messages();
+  auto msgs = createWorkers.messagesToServers();
   ASSERT_EQ(msgs.size(), servers.size());
 
   {
@@ -216,7 +216,7 @@ TEST(CreateWorkersStateTest, receive_invalid_message_type) {
       std::make_unique<AlgorithmFake>(), ExecutionSpecifications(),
       std::make_unique<LookupInfoMock>(servers), fakeActorPID, fakeActorPID);
   auto createWorkers = CreateWorkers(cState);
-  auto msgs = createWorkers.messages();
+  auto msgs = createWorkers.messagesToServers();
 
   {
     actor::ActorPID actorPid{
@@ -236,7 +236,7 @@ TEST(CreateWorkersStateTest, receive_valid_message_from_unknown_server) {
       std::make_unique<AlgorithmFake>(), ExecutionSpecifications(),
       std::make_unique<LookupInfoMock>(servers), fakeActorPID, fakeActorPID);
   auto createWorkers = CreateWorkers(cState);
-  auto msgs = createWorkers.messages();
+  auto msgs = createWorkers.messagesToServers();
 
   {
     actor::ActorPID unknownActorPid{
@@ -256,7 +256,7 @@ TEST(CreateWorkersStateTest, receive_valid_error_message) {
       std::make_unique<AlgorithmFake>(), ExecutionSpecifications(),
       std::make_unique<LookupInfoMock>(servers), fakeActorPID, fakeActorPID);
   auto createWorkers = CreateWorkers(cState);
-  auto msgs = createWorkers.messages();
+  auto msgs = createWorkers.messagesToServers();
 
   {
     actor::ActorPID unknownActorPid{


### PR DESCRIPTION
This PR partly implements the conductor computing state:
1. The conductor sends a `RunGlobalSuperStep` message to each worker
2. The worker gets this message but does not do anything yet with it (this will be done in the next PR).
3. The worker is able to receive `PregelMessage`s that are sent during the computation from other workers. The worker adds such a message either to its write cache (if the worker has the same global super step as the message) or to the `messagesForNextGss` buffer (if the message is for the next gss). (The case gss=0 is a bit weird: Before the computation starts, gss is initialized to zero, but the first gss is also 0, therefore some checking is done for this).

Some other changes I did during that:
- I changed the worker state to be closer to the old worker. Much can be improved here, but this makes right now the refactoring more easy, the worker state can the be refactored afterwards when the pregel runs successfully with actors.
- I slightly changed the execution state interface: The messages function does now return a map of messages that should be send to a specified actor. This makes the interface more flexible: Especially in this computing state, not all worker actors get the same message.