### PR TITLE
Make resilience tests stable again [BTS-1235].

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 devel
 -----
 
+* Stabilized resilience tests. The assumption that an AQL query can run
+  without error directly after a leader has been stopped, is wrong.
+
 * Auto-flush RocksDB WAL files and in-memory column family data if the number
   of live WAL files exceeds a certain threshold. This is to make sure that
   WAL files are moved to the archive when there are a lot of live WAL files

--- a/arangod/Aql/EngineInfoContainerDBServerServerBased.cpp
+++ b/arangod/Aql/EngineInfoContainerDBServerServerBased.cpp
@@ -241,6 +241,14 @@ EngineInfoContainerDBServerServerBased::buildSetupRequest(
     return result;
   };
 
+  if (_query.vocbase()
+          .server()
+          .getFeature<ClusterFeature>()
+          .clusterInfo()
+          .isFailedServer(server)) {
+    return Result{TRI_ERROR_CLUSTER_CONNECTION_LOST};
+  }
+
   return network::sendRequestRetry(
              pool, "server:" + server, fuerte::RestVerb::Post,
              "/_api/aql/setup", std::move(buffer), options, std::move(headers))

--- a/arangod/Cluster/ClusterInfo.cpp
+++ b/arangod/Cluster/ClusterInfo.cpp
@@ -6462,6 +6462,11 @@ void ClusterInfo::setFailedServers(
   _failedServers = std::move(failedServers);
 }
 
+bool ClusterInfo::isFailedServer(ServerID const& id) const noexcept {
+  std::lock_guard lock{_failedServersMutex};
+  return _failedServers.contains(id);
+}
+
 #ifdef ARANGODB_USE_GOOGLE_TESTS
 void ClusterInfo::setServers(
     containers::FlatHashMap<ServerID, std::string> servers) {

--- a/arangod/Cluster/ClusterInfo.h
+++ b/arangod/Cluster/ClusterInfo.h
@@ -783,6 +783,8 @@ class ClusterInfo final {
 
   void setFailedServers(containers::FlatHashSet<ServerID> failedServers);
 
+  bool isFailedServer(ServerID const& id) const noexcept;
+
 #ifdef ARANGODB_USE_GOOGLE_TESTS
   void setServers(containers::FlatHashMap<ServerID, std::string> servers);
 

--- a/tests/js/server/resilience/failover-view/resilience-synchronous-repl-with-arangosearch-view-cluster.js
+++ b/tests/js/server/resilience/failover-view/resilience-synchronous-repl-with-arangosearch-view-cluster.js
@@ -396,7 +396,18 @@ function SynchronousReplicationWithViewSuite () {
     }
 
     if (healing.place === 12) { healFailure(healing); }
-    if (failure.place === 13) { makeFailure(failure); }
+    if (failure.place === 13) {
+      makeFailure(failure);
+      // Note that it is not guaranteed that an AQL query runs without an
+      // error, directly after the leader of a collection which occurs in
+      // the query is stopped. It is entirely possible that the coordinator
+      // still picks the failed server, so we have to wait for the failover
+      // to happen. The easiest way to achieve this is to read a document,
+      // which can retry until the failover has happened:
+      if (!failure.follower) {
+        doc = c.document(id._key);
+      }
+    }
 
     // AQL:
     var q = db._query(`FOR x IN @@cn

--- a/tests/js/server/resilience/failover/resilience-synchronous-repl-cluster.inc
+++ b/tests/js/server/resilience/failover/resilience-synchronous-repl-cluster.inc
@@ -287,7 +287,18 @@
       assertEqual(107, docs[1].Hallox);
 
       if (healing.place === 12) { healFailure(healing); }
-      if (failure.place === 13) { makeFailure(failure); }
+      if (failure.place === 13) {
+        makeFailure(failure);
+        // Note that it is not guaranteed that an AQL query runs without an
+        // error, directly after the leader of a collection which occurs in
+        // the query is stopped. It is entirely possible that the coordinator
+        // still picks the failed server, so we have to wait for the failover
+        // to happen. The easiest way to achieve this is to read a document,
+        // which can retry until the failover has happened:
+        if (!failure.follower) {
+          doc = c.document(id._key);
+        }
+      }
 
       // AQL:
       var q = db._query(`FOR x IN @@cn


### PR DESCRIPTION
### Scope & Purpose

This is about https://arangodb.atlassian.net/browse/BTS-1235

An investigation has shown the following: It is not safe to assume that
running an AQL query directly after a leader of a collection has been
stopped (before the failover has happened). In many cases this works, 
because the query optimizer has to query collection counts or
selectivity estimates before running the query and these can be retried
until the failover has happened. But if these values are cached on the
coordinator, the query directly proceeds to run on the supposed leader
of the collections in question. And if this leader is failed but no
failover has happened yet, the query will run into an error.

The fix in this PR acknowledges this fact of life and adjusts the
resilience tests accordingly, making them more stable.

The PR also includes a change that makes the AQL query setup not
send query setup requests to obviously failed DB servers. This change
is intentionally not included in this PR's backports.

- [*] :hankey: Bugfix

### Checklist

- [*] Tests
  - [*] **integration tests**
- [*] :book: CHANGELOG entry made
- [*] Backports
  - [*] Backport for 3.10: https://github.com/arangodb/arangodb/pull/18334
  - [*] Backport for 3.9: https://github.com/arangodb/arangodb/pull/18335

#### Related Information

- [*] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/BTS-1235

