### PR TITLE
Return service unavailable if state is unavailable.

### DIFF
--- a/arangod/VocBase/LogicalCollection.cpp
+++ b/arangod/VocBase/LogicalCollection.cpp
@@ -1299,9 +1299,10 @@ auto LogicalCollection::getDocumentStateLeader() -> std::shared_ptr<
     // TODO get more information if available (e.g. is the leader resigned or in
     //      recovery?)
     throwUnavailable(ADB_HERE,
-                     "Replicated state {} is not available as leader, accessed "
-                     "from {}/{}.",
-                     *_replicatedStateId, vocbase().name(), name());
+                     "Shard {}/{}/{} is not available as leader, associated "
+                     "replicated log is {}",
+                     vocbase().name(), planId().id(), name(),
+                     *_replicatedStateId);
   }
 
   return leader;

--- a/lib/Rest/GeneralResponse.cpp
+++ b/lib/Rest/GeneralResponse.cpp
@@ -451,6 +451,7 @@ rest::ResponseCode GeneralResponse::responseCode(ErrorCode code) {
     case static_cast<int>(TRI_ERROR_STARTING_UP):
     case static_cast<int>(TRI_ERROR_CLUSTER_CONNECTION_LOST):
     case static_cast<int>(TRI_ERROR_REPLICATION_REPLICATED_LOG_LEADER_RESIGNED):
+    case static_cast<int>(TRI_ERROR_REPLICATION_REPLICATED_STATE_NOT_AVAILABLE):
       return ResponseCode::SERVICE_UNAVAILABLE;
 
     case static_cast<int>(TRI_ERROR_HTTP_NOT_IMPLEMENTED):


### PR DESCRIPTION
### Scope & Purpose
Previously when a replicated state was not yet available the server would return an internal server error. However, usually this is just a temporary condition, so 503 is more applicable.