### PR TITLE
[CINFRA] LogicalCollection Shard store replicated state id

### DIFF
--- a/arangod/Cluster/CreateCollection.cpp
+++ b/arangod/Cluster/CreateCollection.cpp
@@ -162,6 +162,12 @@ bool CreateCollection::first() {
         }
         docket.add(key, i.value);
       }
+      if (_description.has(maintenance::REPLICATED_LOG_ID)) {
+        auto logId = replication2::LogId::fromString(
+            _description.get(maintenance::REPLICATED_LOG_ID));
+        TRI_ASSERT(logId.has_value());
+        docket.add("replicatedStateId", VPackValue(*logId));
+      }
       docket.add("planId", VPackValue(collection));
     }
 
@@ -181,15 +187,6 @@ bool CreateCollection::first() {
         col->followers()->takeOverLeadership(noFollowers, nullptr);
       } else {
         col->followers()->setTheLeader(LEADER_NOT_YET_KNOWN);
-      }
-
-      if (_description.has(maintenance::REPLICATED_LOG_ID)) {
-        auto logId = replication2::LogId::fromString(
-            _description.get(maintenance::REPLICATED_LOG_ID));
-        TRI_ASSERT(logId.has_value());
-        col->setDocumentStateId(logId.value());
-      } else {
-        col->setDocumentStateId(col->shardIdToStateId(shard));
       }
     }
 

--- a/arangod/VocBase/LogicalCollection.cpp
+++ b/arangod/VocBase/LogicalCollection.cpp
@@ -231,6 +231,10 @@ LogicalCollection::LogicalCollection(TRI_vocbase_t& vocbase, VPackSlice info,
   if (replicationVersion() == replication::Version::TWO &&
       info.hasKey("groupId")) {
     _groupId = info.get("groupId").getNumericValue<uint64_t>();
+    if (auto stateId = info.get("replicatedStateId"); stateId.isNumber()) {
+      _replicatedStateId =
+          info.get("replicatedStateId").extract<replication2::LogId>();
+    }
   }
 }
 
@@ -798,6 +802,9 @@ Result LogicalCollection::appendVPack(velocypack::Builder& build,
   if (replicationVersion() == replication::Version::TWO &&
       _groupId.has_value()) {
     build.add("groupId", VPackValue(_groupId.value()));
+    if (_replicatedStateId) {
+      build.add("replicatedStateId", VPackValue(*_replicatedStateId));
+    }
   }
   // We leave the object open
   return {};

--- a/tests/js/client/restart/test-restart-replication2-database.js
+++ b/tests/js/client/restart/test-restart-replication2-database.js
@@ -139,6 +139,8 @@ function testSuite () {
       disableMaintenanceMode();
 
       compareAllDocuments(col, expectedKeys);
+      // Insert another document to check if the collection is writable (it should)
+      col.insert({_key: "another-document"});
     },
   };
 }


### PR DESCRIPTION
### Scope & Purpose
This PR does two things:
1. it stores the replicated state id as part of the persisted information of a shard. During restart this information is loaded, if available.
2. The maintenance now passes the replicated state id directly during collection construction and does not set if after the fact.