### PR TITLE
Changed test path for config files from relative to testing

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 devel
 -----
 
+* Changed path were test scripts locate configuration files from `etc/relative`
+  to `etc/testing`. These paths contain files such as `arangosh.conf` and 
+  `arangod.conf`. 
+
 * Auto-flush RocksDB WAL files and in-memory column family data if the number
   of live WAL files exceeds a certain threshold. This is to make sure that
   WAL files are moved to the archive when there are a lot of live WAL files

--- a/etc/testing/arangosh.conf
+++ b/etc/testing/arangosh.conf
@@ -1,6 +1,18 @@
+[console]
+pretty-print = true
+
+[server]
+authentication = false
+# username = root
+# password =
+
 [log]
 file = -
 
 [javascript]
+startup-directory = ./js
 allow-external-process-control = true
 allow-port-testing = true
+
+[javascript:enterprise]
+module-directory = ./enterprise/js

--- a/scripts/test/site_config.py
+++ b/scripts/test/site_config.py
@@ -200,7 +200,7 @@ class SiteConfig:
  - {socket_count} number of currently active tcp sockets
 {san_gcov_msg}"""
         )
-        self.cfgdir = base_source_dir / "etc" / "relative"
+        self.cfgdir = base_source_dir / "etc" / "testing"
         self.bin_dir = bin_dir
         self.base_path = base_source_dir
         self.test_data_dir = base_source_dir

--- a/scripts/unittest
+++ b/scripts/unittest
@@ -92,7 +92,7 @@ fi
 (
   cd "${EXEC_PATH}"
   exec $NUMA $ARANGOSH \
-       -c etc${PS}relative${PS}arangosh.conf \
+       -c etc${PS}testing${PS}arangosh.conf \
        --log.level warning \
        --server.endpoint none \
        --javascript.allow-external-process-control true \

--- a/scripts/unittest.ps1
+++ b/scripts/unittest.ps1
@@ -38,7 +38,7 @@ if ($null -eq $env:ARANGOSH) {
 }
 
 $arguments = @(
-  "-c etc/relative/arangosh.conf",
+  "-c etc/testing/arangosh.conf",
   "--log.level warning",
   "--server.endpoint none",
   "--javascript.execute js/client/modules/@arangodb/unittest.js"


### PR DESCRIPTION
### Scope & Purpose

Changed path were test scripts locate configuration files from `etc/relative` to `etc/testing`. These paths contain files such as `arangosh.conf` and `arangod.conf`. 
No extra tests were created. There's a PR related to this change in oskar
https://github.com/arangodb/oskar/pull/499.


- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports Obs.: might add


