### PR TITLE
[WIP] Crash instead of ignoring errors

### DIFF
--- a/lib/V8/v8-utils.cpp
+++ b/lib/V8/v8-utils.cpp
@@ -5633,9 +5633,19 @@ void TRI_CreateErrorObject(v8::Isolate* isolate, ErrorCode errorNumber,
     } else {
       CreateErrorObject(isolate, errorNumber, message);
     }
+  } catch (std::exception const& ex) {
+    // we cannot do anything about this here, but no C++ exception must
+    // escape the C++ bindings called by V8
+    ADB_PROD_CRASH()
+        << "Exception thrown while creating V8 error. Exception is: ```"
+        << ex.what() << "'''. Error to be created was: " << errorNumber << " "
+        << message;
   } catch (...) {
     // we cannot do anything about this here, but no C++ exception must
     // escape the C++ bindings called by V8
+    ADB_PROD_CRASH() << "Unknown exception thrown while creating V8 error. "
+                        "Error to be created was: "
+                     << errorNumber << " " << message;
   }
 }
 


### PR DESCRIPTION
### Scope & Purpose

Subject to discussion. I'd prefer crashing instead of UB if an error occurred but can't be set. There are more places to change, so this PR is incomplete; also, it needs to be discussed. So this is currently a placeholder and a reminder for myself.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: *(Please link PR)*
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

