### PR TITLE
Forward correct logger context to Follower Manager.

### DIFF
--- a/arangod/Replication2/ReplicatedLog/Components/FollowerCommitManager.cpp
+++ b/arangod/Replication2/ReplicatedLog/Components/FollowerCommitManager.cpp
@@ -50,7 +50,7 @@ auto FollowerCommitManager::updateCommitIndex(LogIndex index) noexcept
   auto newResolveIndex = std::min(guard->commitIndex, ctx->log.getLastIndex());
 
   if (newResolveIndex > guard->resolveIndex) {
-    LOG_CTX("71a8f", DEBUG, loggerContext)
+    LOG_CTX("71a8f", TRACE, loggerContext)
         << "resolving commit index up to " << newResolveIndex;
     guard->resolveIndex = newResolveIndex;
     guard->stateHandle.updateCommitIndex(guard->resolveIndex);

--- a/arangod/Replication2/ReplicatedLog/Components/LogFollower.cpp
+++ b/arangod/Replication2/ReplicatedLog/Components/LogFollower.cpp
@@ -104,8 +104,8 @@ FollowerManager::FollowerManager(
     std::shared_ptr<FollowerTermInformation const> termInfo,
     std::shared_ptr<ReplicatedLogGlobalSettings const> options,
     std::shared_ptr<ReplicatedLogMetrics> metrics,
-    std::shared_ptr<ILeaderCommunicator> leaderComm)
-    : loggerContext(deriveLoggerContext(*termInfo)),
+    std::shared_ptr<ILeaderCommunicator> leaderComm, LoggerContext logContext)
+    : loggerContext(deriveLoggerContext(*termInfo, logContext)),
       options(options),
       metrics(metrics),
       storage(
@@ -313,10 +313,10 @@ LogFollowerImpl::LogFollowerImpl(
     std::shared_ptr<const FollowerTermInformation> termInfo,
     std::shared_ptr<const ReplicatedLogGlobalSettings> options,
     std::shared_ptr<ReplicatedLogMetrics> metrics,
-    std::shared_ptr<ILeaderCommunicator> leaderComm)
+    std::shared_ptr<ILeaderCommunicator> leaderComm, LoggerContext logContext)
     : myself(std::move(myself)),
       guarded(std::move(methods), std::move(stateHandlePtr),
               std::move(termInfo), std::move(options), std::move(metrics),
-              std::move(leaderComm)) {}
+              std::move(leaderComm), logContext) {}
 
 }  // namespace arangodb::replication2::replicated_log

--- a/arangod/Replication2/ReplicatedLog/Components/LogFollower.h
+++ b/arangod/Replication2/ReplicatedLog/Components/LogFollower.h
@@ -65,7 +65,7 @@ struct FollowerManager {
       std::shared_ptr<FollowerTermInformation const> termInfo,
       std::shared_ptr<ReplicatedLogGlobalSettings const> options,
       std::shared_ptr<ReplicatedLogMetrics> metrics,
-      std::shared_ptr<ILeaderCommunicator>);
+      std::shared_ptr<ILeaderCommunicator>, LoggerContext logContext);
   ~FollowerManager();
   auto getStatus() const -> LogStatus;
   auto getQuickStatus() const -> QuickLogStatus;
@@ -101,7 +101,8 @@ struct LogFollowerImpl : ILogFollower {
       std::shared_ptr<FollowerTermInformation const> termInfo,
       std::shared_ptr<ReplicatedLogGlobalSettings const> options,
       std::shared_ptr<ReplicatedLogMetrics> metrics,
-      std::shared_ptr<ILeaderCommunicator> leaderComm);
+      std::shared_ptr<ILeaderCommunicator> leaderComm,
+      LoggerContext logContext);
 
   auto getStatus() const -> LogStatus override;
 

--- a/arangod/Replication2/ReplicatedLog/ReplicatedLog.cpp
+++ b/arangod/Replication2/ReplicatedLog/ReplicatedLog.cpp
@@ -322,7 +322,8 @@ auto DefaultParticipantsFactory::constructFollower(
 
   return std::make_shared<LogFollowerImpl>(
       info.myself, std::move(methods), std::move(context.stateHandle), info2,
-      std::move(context.options), std::move(context.metrics), leaderComm);
+      std::move(context.options), std::move(context.metrics), leaderComm,
+      context.loggerContext);
 }
 
 auto DefaultParticipantsFactory::constructLeader(

--- a/tests/Replication2/ReplicatedLog/LogFollower/AppendEntriesTest.cpp
+++ b/tests/Replication2/ReplicatedLog/LogFollower/AppendEntriesTest.cpp
@@ -84,7 +84,7 @@ struct AppendEntriesFollowerTest : ::testing::Test {
     return std::make_shared<FollowerManager>(
         storage.getMethods(),
         std::unique_ptr<ReplicatedStateHandleMock>(stateHandle), termInfo,
-        options, metrics, nullptr);
+        options, metrics, nullptr, LoggerContext{Logger::REPLICATION2});
   }
 };
 


### PR DESCRIPTION
### Scope & Purpose
The Follower Manager used a default constructed LoggerContext, which is missing crutial information. Now it inherits the logger context from the replicated log.