### PR TITLE
Fix some undefined behaviour in some maintainer mode code (#14891)

### DIFF
--- a/arangod/Agency/AsyncAgencyComm.cpp
+++ b/arangod/Agency/AsyncAgencyComm.cpp
@@ -524,10 +524,10 @@ void AsyncAgencyCommManager::reportError(std::string const& endpoint) {
       << "reportError(" << endpoint << "), endpoints = " << _endpoints;
   if (endpoint == _endpoints.front()) {
     _endpoints.pop_front();
+    _endpoints.push_back(endpoint);
     LOG_TOPIC("aac43", DEBUG, Logger::AGENCYCOMM)
         << "Error using endpoint " << endpoint << ", switching to "
         << _endpoints.front();
-    _endpoints.push_back(endpoint);
   }
 }
 


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/14891

This is a trivial bug fix for a corner case.

If in maintainer mode, or if the log topic AgencyComm is set to DEBUG
or TRACE mode, and all agents are gone, then the first element of
an empty deque is dereferenced. With STL debugging on this leads to
a crash.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: already included in 3.10
  - [x] Backport for 3.9: this PR
  - [x] Backport for 3.8: https://github.com/arangodb/arangodb/pull/18372

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 