### PR TITLE
[GORDO-1549] Execute one gss in worker

### DIFF
--- a/arangod/Pregel/Conductor/ExecutionStates/CollectionLookup.h
+++ b/arangod/Pregel/Conductor/ExecutionStates/CollectionLookup.h
@@ -24,8 +24,10 @@
 
 #include <string>
 #include <map>
+#include <unordered_map>
+#include <vector>
 
-#include "Cluster/ClusterTypes.h"
+#include "Pregel/DatabaseTypes.h"
 
 namespace arangodb::pregel::conductor {
 

--- a/arangod/Pregel/Conductor/ExecutionStates/CreateWorkersState.cpp
+++ b/arangod/Pregel/Conductor/ExecutionStates/CreateWorkersState.cpp
@@ -1,18 +1,49 @@
 #include "CreateWorkersState.h"
 
+#include "Pregel/Conductor/ExecutionStates/CollectionLookup.h"
 #include "Pregel/Conductor/ExecutionStates/LoadingState.h"
 #include "Pregel/Conductor/ExecutionStates/FatalErrorState.h"
 
 using namespace arangodb;
+using namespace arangodb::pregel;
 using namespace arangodb::pregel::conductor;
 
 CreateWorkers::CreateWorkers(ConductorState& conductor) : conductor{conductor} {
   conductor.timing.total.start();
 }
 
+auto workerSpecification(
+    std::unique_ptr<CollectionLookup> const& collectionLookup,
+    ExecutionSpecifications const& specifications)
+    -> std::unordered_map<ServerID, worker::message::CreateWorker> {
+  auto createWorkers =
+      std::unordered_map<ServerID, worker::message::CreateWorker>{};
+  for (auto const& [server, vertexShards] :
+       collectionLookup->getServerMapVertices()) {
+    auto edgeShards = collectionLookup->getServerMapEdges().at(server);
+    createWorkers.emplace(
+        server,
+        worker::message::CreateWorker{
+            .executionNumber = specifications.executionNumber,
+            .algorithm = std::string{specifications.algorithm},
+            .userParameters = specifications.userParameters,
+            .coordinatorId = "",
+            .useMemoryMaps = specifications.useMemoryMaps,
+            .parallelism = specifications.parallelism,
+            .edgeCollectionRestrictions =
+                specifications.edgeCollectionRestrictions,
+            .vertexShards = std::move(vertexShards),
+            .edgeShards = std::move(edgeShards),
+            .collectionPlanIds = collectionLookup->getCollectionPlanIdMapAll(),
+            .allShards = collectionLookup->getAllShards()});
+  }
+  return createWorkers;
+}
+
 auto CreateWorkers::messagesToServers()
     -> std::unordered_map<ServerID, worker::message::CreateWorker> {
-  auto workerSpecifications = _workerSpecifications();
+  auto workerSpecifications =
+      workerSpecification(conductor.lookupInfo, conductor.specifications);
 
   auto servers = std::vector<ServerID>{};
   for (auto const& [server, _] : workerSpecifications) {
@@ -36,38 +67,32 @@ auto CreateWorkers::receive(actor::ActorPID sender,
     return std::make_unique<FatalError>(conductor);
   }
   conductor.workers.emplace(sender);
+
+  _updateResponsibleActorPerShard(sender);
+
   respondedServers.emplace(sender.server);
   responseCount++;
 
   if (responseCount == sentServers.size() and respondedServers == sentServers) {
-    return std::make_unique<Loading>(conductor);
+    return std::make_unique<Loading>(conductor, std::move(actorForShard));
   }
   return std::nullopt;
 };
 
-auto CreateWorkers::_workerSpecifications() const
-    -> std::unordered_map<ServerID, worker::message::CreateWorker> {
-  auto createWorkers =
-      std::unordered_map<ServerID, worker::message::CreateWorker>{};
-  for (auto const& [server, vertexShards] :
-       conductor.lookupInfo->getServerMapVertices()) {
-    auto edgeShards = conductor.lookupInfo->getServerMapEdges().at(server);
-    createWorkers.emplace(
-        server,
-        worker::message::CreateWorker{
-            .executionNumber = conductor.specifications.executionNumber,
-            .algorithm = std::string{conductor.specifications.algorithm},
-            .userParameters = conductor.specifications.userParameters,
-            .coordinatorId = "",
-            .useMemoryMaps = conductor.specifications.useMemoryMaps,
-            .parallelism = conductor.specifications.parallelism,
-            .edgeCollectionRestrictions =
-                conductor.specifications.edgeCollectionRestrictions,
-            .vertexShards = std::move(vertexShards),
-            .edgeShards = std::move(edgeShards),
-            .collectionPlanIds =
-                conductor.lookupInfo->getCollectionPlanIdMapAll(),
-            .allShards = conductor.lookupInfo->getAllShards()});
+auto CreateWorkers::_updateResponsibleActorPerShard(actor::ActorPID actor)
+    -> void {
+  auto vertexCollectionsOnSenderServer =
+      conductor.lookupInfo->getServerMapVertices()[actor.server];
+  auto edgeCollectionsOnSenderServer =
+      conductor.lookupInfo->getServerMapEdges()[actor.server];
+  for (auto const& [_, shards] : vertexCollectionsOnSenderServer) {
+    for (auto const& shard : shards) {
+      actorForShard.emplace(shard, actor);
+    }
   }
-  return createWorkers;
+  for (auto const& [_, shards] : edgeCollectionsOnSenderServer) {
+    for (auto const& shard : shards) {
+      actorForShard.emplace(shard, actor);
+    }
+  }
 }

--- a/arangod/Pregel/Conductor/ExecutionStates/CreateWorkersState.h
+++ b/arangod/Pregel/Conductor/ExecutionStates/CreateWorkersState.h
@@ -24,6 +24,7 @@
 
 #include <set>
 #include <unordered_map>
+#include "Actor/ActorPID.h"
 #include "Pregel/Conductor/State.h"
 
 namespace arangodb::pregel::conductor {
@@ -60,11 +61,13 @@ struct CreateWorkers : ExecutionState {
       -> std::optional<std::unique_ptr<ExecutionState>> override;
 
   ConductorState& conductor;
+  std::unordered_map<ShardID, actor::ActorPID> actorForShard;
   std::set<ServerID> sentServers;
   std::set<ServerID> respondedServers;
   uint64_t responseCount = 0;
-  auto _workerSpecifications() const
-      -> std::unordered_map<ServerID, worker::message::CreateWorker>;
+
+ private:
+  auto _updateResponsibleActorPerShard(actor::ActorPID actor) -> void;
 };
 
 }  // namespace arangodb::pregel::conductor

--- a/arangod/Pregel/Conductor/ExecutionStates/LoadingState.cpp
+++ b/arangod/Pregel/Conductor/ExecutionStates/LoadingState.cpp
@@ -4,7 +4,9 @@
 
 using namespace arangodb::pregel::conductor;
 
-Loading::Loading(ConductorState& conductor) : conductor{conductor} {
+Loading::Loading(ConductorState& conductor,
+                 std::unordered_map<ShardID, actor::ActorPID> actorForShard)
+    : conductor{conductor}, actorForShard{std::move(actorForShard)} {
   conductor.timing.loading.start();
   // TODO GORDO-1510
   // _feature.metrics()->pregelConductorsLoadingNumber->fetch_add(1);
@@ -20,7 +22,8 @@ auto Loading::messages()
   auto messages =
       std::unordered_map<actor::ActorPID, worker::message::WorkerMessages>{};
   for (auto const& worker : conductor.workers) {
-    messages.emplace(worker, worker::message::LoadGraph{});
+    messages.emplace(worker, worker::message::LoadGraph{
+                                 .responsibleActorPerShard = actorForShard});
   }
   return messages;
 };

--- a/arangod/Pregel/Conductor/ExecutionStates/LoadingState.h
+++ b/arangod/Pregel/Conductor/ExecutionStates/LoadingState.h
@@ -33,7 +33,8 @@ namespace arangodb::pregel::conductor {
 struct ConductorState;
 
 struct Loading : ExecutionState {
-  Loading(ConductorState& conductor);
+  Loading(ConductorState& conductor,
+          std::unordered_map<ShardID, actor::ActorPID> actorForShard);
   ~Loading();
   auto name() const -> std::string override { return "loading"; };
   auto messages()
@@ -43,6 +44,7 @@ struct Loading : ExecutionState {
       -> std::optional<std::unique_ptr<ExecutionState>> override;
 
   ConductorState& conductor;
+  std::unordered_map<ShardID, actor::ActorPID> actorForShard;
   std::unordered_set<actor::ActorPID> respondedWorkers;
   uint64_t totalVerticesCount = 0;
   uint64_t totalEdgesCount = 0;

--- a/arangod/Pregel/Conductor/Handler.h
+++ b/arangod/Pregel/Conductor/Handler.h
@@ -87,6 +87,22 @@ struct ConductorHandler : actor::HandlerBase<Runtime, ConductorState> {
     return std::move(this->state);
   }
 
+  auto operator()(ResultT<message::GlobalSuperStepFinished> message)
+      -> std::unique_ptr<ConductorState> {
+    LOG_TOPIC("543aa", INFO, Logger::PREGEL) << fmt::format(
+        "Conductor Actor: Global super step finished on worker {}",
+        this->sender);
+    return std::move(this->state);
+  }
+
+  auto operator()(message::StatusUpdate message)
+      -> std::unique_ptr<ConductorState> {
+    LOG_TOPIC("f89db", INFO, Logger::PREGEL) << fmt::format(
+        "Conductor Actor: Received status update from worker {}: {}",
+        this->sender, inspection::json(message));
+    return std::move(this->state);
+  }
+
   auto operator()(message::ResultCreated msg)
       -> std::unique_ptr<ConductorState> {
     LOG_TOPIC("e1791", INFO, Logger::PREGEL) << fmt::format(

--- a/arangod/Pregel/Conductor/Messages.h
+++ b/arangod/Pregel/Conductor/Messages.h
@@ -30,6 +30,7 @@
 #include "Inspection/Format.h"
 #include "Inspection/Types.h"
 #include "Pregel/ExecutionNumber.h"
+#include "Pregel/Statistics.h"
 #include "Pregel/Status/Status.h"
 #include "Pregel/Utils.h"
 #include "Pregel/Worker/Messages.h"
@@ -62,10 +63,35 @@ auto inspect(Inspector& f, GraphLoaded& x) {
       f.field("vertexCount", x.vertexCount), f.field("edgeCount", x.edgeCount));
 }
 
-struct GlobalSuperStepFinished {};
+struct GlobalSuperStepFinished {
+  GlobalSuperStepFinished() noexcept = default;
+  GlobalSuperStepFinished(
+      MessageStats messageStats,
+      std::unordered_map<actor::ActorPID, uint64_t> sendCountPerActor,
+      uint64_t activeCount, uint64_t vertexCount, uint64_t edgeCount,
+      VPackBuilder aggregators)
+      : messageStats{std::move(messageStats)},
+        sendCountPerActor{std::move(sendCountPerActor)},
+        activeCount{activeCount},
+        vertexCount{vertexCount},
+        edgeCount{edgeCount},
+        aggregators{std::move(aggregators)} {};
+  MessageStats messageStats;
+  std::unordered_map<actor::ActorPID, uint64_t> sendCountPerActor;
+  uint64_t activeCount;
+  uint64_t vertexCount;
+  uint64_t edgeCount;
+  VPackBuilder aggregators;
+};
 template<typename Inspector>
 auto inspect(Inspector& f, GlobalSuperStepFinished& x) {
-  return f.object(x).fields();
+  return f.object(x).fields(
+      f.field("messageStats", x.messageStats),
+      // f.field("sentCounts", x.sendCountPerActor), // make inspection worker
+      // with self-defined hashtable
+      f.field("activeCount", x.activeCount),
+      f.field("vertexCount", x.vertexCount), f.field("edgeCount", x.edgeCount),
+      f.field("aggregators", x.aggregators));
 }
 
 struct ResultCreated {
@@ -169,4 +195,8 @@ struct fmt::formatter<arangodb::pregel::PrepareGlobalSuperStep>
     : arangodb::inspection::inspection_formatter {};
 template<>
 struct fmt::formatter<arangodb::pregel::RunGlobalSuperStep>
+    : arangodb::inspection::inspection_formatter {};
+template<>
+struct fmt::formatter<
+    arangodb::pregel::conductor::message::GlobalSuperStepFinished>
     : arangodb::inspection::inspection_formatter {};

--- a/arangod/Pregel/Conductor/Messages.h
+++ b/arangod/Pregel/Conductor/Messages.h
@@ -24,6 +24,7 @@
 
 #include <map>
 
+#include "Actor/ActorPID.h"
 #include "Basics/ResultT.h"
 #include "Cluster/ClusterTypes.h"
 #include "Inspection/Format.h"

--- a/arangod/Pregel/DatabaseTypes.h
+++ b/arangod/Pregel/DatabaseTypes.h
@@ -28,3 +28,4 @@
 // for this ClusterInfo should be broken into several files
 using ShardID = std::string;
 using CollectionID = std::string;
+using ServerID = std::string;

--- a/arangod/Pregel/OutgoingCache.cpp
+++ b/arangod/Pregel/OutgoingCache.cpp
@@ -76,13 +76,8 @@ void ArrayOutCache<M>::appendMessage(PregelShard shard,
                                      std::string_view const& key,
                                      M const& data) {
   if (this->_config->isLocalVertexShard(shard)) {
-    if (this->_sendToNextGSS) {  // I use the global cache, we need locking
-      this->_localCacheNextGSS->storeMessage(shard, key, data);
-      this->_sendCountNextGSS++;
-    } else {  // the local cache is always thread local
-      this->_localCache->storeMessageNoLock(shard, key, data);
-      this->_sendCount++;
-    }
+    this->_localCache->storeMessageNoLock(shard, key, data);
+    this->_sendCount++;
   } else {
     _shardMap[shard][std::string(key)].push_back(data);
     if (++(this->_containedMessages) >= this->_batchSize) {
@@ -121,9 +116,6 @@ void ArrayOutCache<M>::flushMessages() {
   // LOG_TOPIC("7af7f", INFO, Logger::PREGEL) << "Beginning to send messages to
   // other machines";
   uint64_t gss = this->_config->globalSuperstep();
-  if (this->_sendToNextGSS) {
-    gss += 1;
-  }
   auto& server = this->_config->vocbase()->server();
   auto const& nf = server.template getFeature<arangodb::NetworkFeature>();
   network::ConnectionPool* pool = nf.pool();
@@ -156,11 +148,7 @@ void ArrayOutCache<M>::flushMessages() {
         fuerte::RestVerb::Post, this->_baseUrl + Utils::messagesPath,
         std::move(buffer), reqOpts));
 
-    if (this->_sendToNextGSS) {
-      this->_sendCountNextGSS += shardMessageCount;
-    } else {
-      this->_sendCount += shardMessageCount;
-    }
+    this->_sendCount += shardMessageCount;
   }
 
   futures::collectAll(responses).wait();
@@ -192,13 +180,8 @@ void CombiningOutCache<M>::appendMessage(PregelShard shard,
                                          std::string_view const& key,
                                          M const& data) {
   if (this->_config->isLocalVertexShard(shard)) {
-    if (this->_sendToNextGSS) {
-      this->_localCacheNextGSS->storeMessage(shard, key, data);
-      this->_sendCountNextGSS++;
-    } else {
-      this->_localCache->storeMessageNoLock(shard, key, data);
-      this->_sendCount++;
-    }
+    this->_localCache->storeMessageNoLock(shard, key, data);
+    this->_sendCount++;
   } else {
     std::unordered_map<std::string_view, M>& vertexMap = _shardMap[shard];
     auto it = vertexMap.find(key);
@@ -209,7 +192,6 @@ void CombiningOutCache<M>::appendMessage(PregelShard shard,
       vertexMap.try_emplace(key, data);
 
       if (++(this->_containedMessages) >= this->_batchSize) {
-        // LOG_TOPIC("23bc7", INFO, Logger::PREGEL) << "Hit buffer limit";
         flushMessages();
       }
     }
@@ -272,16 +254,171 @@ void CombiningOutCache<M>::flushMessages() {
         fuerte::RestVerb::Post, this->_baseUrl + Utils::messagesPath,
         std::move(buffer), reqOpts));
 
-    if (this->_sendToNextGSS) {
-      this->_sendCountNextGSS += vertexMessageMap.size();
-    } else {
-      this->_sendCount += vertexMessageMap.size();
-    }
+    this->_sendCount += vertexMessageMap.size();
   }
 
   futures::collectAll(responses).wait();
 
   _removeContainedMessages();
+}
+
+// ================= ArrayOutActorCache ==================
+
+template<typename M>
+void ArrayOutActorCache<M>::_removeContainedMessages() {
+  for (auto& pair : _shardMap) {
+    pair.second.clear();
+  }
+  this->_containedMessages = 0;
+}
+
+template<typename M>
+void ArrayOutActorCache<M>::appendMessage(PregelShard shard,
+                                          std::string_view const& key,
+                                          M const& data) {
+  _sendCountPerActor[_responsibleActorPerShard
+                         [this->_config->globalShardIDs()[shard.value]]]++;
+  if (this->_config->isLocalVertexShard(shard)) {
+    this->_localCache->storeMessageNoLock(shard, key, data);
+    this->_sendCount++;
+  } else {
+    _shardMap[shard][std::string(key)].push_back(data);
+    if (++(this->_containedMessages) >= this->_batchSize) {
+      flushMessages();
+    }
+  }
+}
+template<typename M>
+auto ArrayOutActorCache<M>::messagesToVPack(
+    std::unordered_map<std::string, std::vector<M>> const& messagesForVertices)
+    -> std::tuple<size_t, VPackBuilder> {
+  VPackBuilder messagesVPack;
+  size_t messageCount = 0;
+  {
+    VPackArrayBuilder ab(&messagesVPack);
+    for (auto const& [vertex, messages] : messagesForVertices) {
+      messagesVPack.add(VPackValue(vertex));  // key
+      {
+        VPackArrayBuilder ab2(&messagesVPack);
+        for (M const& message : messages) {
+          this->_format->addValue(messagesVPack, message);
+          messageCount++;
+        }
+      }
+    }
+  }
+  return {messageCount, messagesVPack};
+}
+
+template<typename M>
+void ArrayOutActorCache<M>::flushMessages() {
+  if (this->_containedMessages == 0) {
+    return;
+  }
+
+  uint64_t gss = this->_config->globalSuperstep();
+
+  for (auto const& [shard, vertexMessageMap] : _shardMap) {
+    if (vertexMessageMap.size() == 0) {
+      continue;
+    }
+
+    auto [shardMessageCount, messages] = messagesToVPack(vertexMessageMap);
+    auto pregelMessage = worker::message::PregelMessage{
+        .executionNumber = this->_config->executionNumber(),
+        .gss = gss,
+        .shard = shard,
+        .messages = messages};
+    auto actor =
+        _responsibleActorPerShard[this->_config->globalShardIDs()[shard.value]];
+    _dispatch(actor, pregelMessage);
+
+    this->_sendCount += shardMessageCount;
+  }
+  this->_removeContainedMessages();
+}
+
+// ================= CombiningOutActorCache ==================
+
+template<typename M>
+CombiningOutActorCache<M>::~CombiningOutActorCache() = default;
+
+template<typename M>
+void CombiningOutActorCache<M>::_removeContainedMessages() {
+  for (auto& pair : _shardMap) {
+    pair.second.clear();
+  }
+  this->_containedMessages = 0;
+}
+
+template<typename M>
+void CombiningOutActorCache<M>::appendMessage(PregelShard shard,
+                                              std::string_view const& key,
+                                              M const& data) {
+  if (this->_config->isLocalVertexShard(shard)) {
+    _sendCountPerActor[_responsibleActorPerShard
+                           [this->_config->globalShardIDs()[shard.value]]]++;
+    this->_localCache->storeMessageNoLock(shard, key, data);
+    this->_sendCount++;
+  } else {
+    std::unordered_map<std::string_view, M>& vertexMap = _shardMap[shard];
+    auto it = vertexMap.find(key);
+    if (it != vertexMap.end()) {  // more than one message
+      auto& ref = (*it).second;   // will be modified by combine(...)
+      _combiner->combine(ref, data);
+    } else {  // first message for this vertex
+      _sendCountPerActor[_responsibleActorPerShard
+                             [this->_config->globalShardIDs()[shard.value]]]++;
+      vertexMap.try_emplace(key, data);
+
+      if (++(this->_containedMessages) >= this->_batchSize) {
+        flushMessages();
+      }
+    }
+  }
+}
+
+template<typename M>
+auto CombiningOutActorCache<M>::messagesToVPack(
+    std::unordered_map<std::string_view, M> const& messagesForVertices)
+    -> VPackBuilder {
+  VPackBuilder messagesVPack;
+  {
+    VPackArrayBuilder ab(&messagesVPack);
+    for (auto const& [vertex, message] : messagesForVertices) {
+      messagesVPack.add(VPackValuePair(vertex.data(), vertex.size(),
+                                       VPackValueType::String));  // key
+      this->_format->addValue(messagesVPack, message);            // value
+    }
+  }
+  return messagesVPack;
+}
+
+template<typename M>
+void CombiningOutActorCache<M>::flushMessages() {
+  if (this->_containedMessages == 0) {
+    return;
+  }
+
+  uint64_t gss = this->_config->globalSuperstep();
+
+  for (auto const& [shard, vertexMessageMap] : _shardMap) {
+    if (vertexMessageMap.size() == 0) {
+      continue;
+    }
+
+    auto pregelMessage = worker::message::PregelMessage{
+        .executionNumber = this->_config->executionNumber(),
+        .gss = gss,
+        .shard = shard,
+        .messages = messagesToVPack(vertexMessageMap)};
+    auto actor =
+        _responsibleActorPerShard[this->_config->globalShardIDs()[shard.value]];
+    _dispatch(actor, pregelMessage);
+
+    this->_sendCount += vertexMessageMap.size();
+  }
+  this->_removeContainedMessages();
 }
 
 // template types to create
@@ -297,25 +434,46 @@ template class arangodb::pregel::CombiningOutCache<int64_t>;
 template class arangodb::pregel::CombiningOutCache<uint64_t>;
 template class arangodb::pregel::CombiningOutCache<float>;
 template class arangodb::pregel::CombiningOutCache<double>;
+template class arangodb::pregel::ArrayOutActorCache<int64_t>;
+template class arangodb::pregel::ArrayOutActorCache<uint64_t>;
+template class arangodb::pregel::ArrayOutActorCache<float>;
+template class arangodb::pregel::ArrayOutActorCache<double>;
+template class arangodb::pregel::CombiningOutActorCache<int64_t>;
+template class arangodb::pregel::CombiningOutActorCache<uint64_t>;
+template class arangodb::pregel::CombiningOutActorCache<float>;
+template class arangodb::pregel::CombiningOutActorCache<double>;
 
 // algo specific
 template class arangodb::pregel::OutCache<SenderMessage<uint64_t>>;
 template class arangodb::pregel::ArrayOutCache<SenderMessage<uint64_t>>;
 template class arangodb::pregel::CombiningOutCache<SenderMessage<uint64_t>>;
+template class arangodb::pregel::ArrayOutActorCache<SenderMessage<uint64_t>>;
+template class arangodb::pregel::CombiningOutActorCache<
+    SenderMessage<uint64_t>>;
 
 template class arangodb::pregel::OutCache<SenderMessage<double>>;
 template class arangodb::pregel::ArrayOutCache<SenderMessage<double>>;
 template class arangodb::pregel::CombiningOutCache<SenderMessage<double>>;
+template class arangodb::pregel::ArrayOutActorCache<SenderMessage<double>>;
+template class arangodb::pregel::CombiningOutActorCache<SenderMessage<double>>;
 
 template class arangodb::pregel::OutCache<DMIDMessage>;
 template class arangodb::pregel::ArrayOutCache<DMIDMessage>;
 template class arangodb::pregel::CombiningOutCache<DMIDMessage>;
+template class arangodb::pregel::ArrayOutActorCache<DMIDMessage>;
+template class arangodb::pregel::CombiningOutActorCache<DMIDMessage>;
 
 template class arangodb::pregel::OutCache<HLLCounter>;
 template class arangodb::pregel::ArrayOutCache<HLLCounter>;
 template class arangodb::pregel::CombiningOutCache<HLLCounter>;
+template class arangodb::pregel::ArrayOutActorCache<HLLCounter>;
+template class arangodb::pregel::CombiningOutActorCache<HLLCounter>;
 
 template class arangodb::pregel::OutCache<ColorPropagationMessageValue>;
 template class arangodb::pregel::ArrayOutCache<ColorPropagationMessageValue>;
 template class arangodb::pregel::CombiningOutCache<
+    ColorPropagationMessageValue>;
+template class arangodb::pregel::ArrayOutActorCache<
+    ColorPropagationMessageValue>;
+template class arangodb::pregel::CombiningOutActorCache<
     ColorPropagationMessageValue>;

--- a/arangod/Pregel/OutgoingCache.h
+++ b/arangod/Pregel/OutgoingCache.h
@@ -23,8 +23,10 @@
 
 #pragma once
 
+#include "Actor/ActorPID.h"
 #include "Basics/Common.h"
 #include "Cluster/ClusterInfo.h"
+#include "Pregel/Worker/Messages.h"
 #include "VocBase/voc-types.h"
 
 #include "Pregel/GraphStore/GraphStore.h"
@@ -59,13 +61,12 @@ class OutCache {
   InCache<M>* _localCacheNextGSS = nullptr;
   std::string _baseUrl;
   uint32_t _batchSize = 1000;
-  bool _sendToNextGSS = false;
 
   /// @brief current number of vertices stored
   size_t _containedMessages = 0;
   size_t _sendCount = 0;
-  size_t _sendCountNextGSS = 0;
   virtual void _removeContainedMessages() = 0;
+  virtual auto _clearSendCountPerActor() -> void{};
 
  public:
   OutCache(std::shared_ptr<WorkerConfig const> state,
@@ -73,29 +74,29 @@ class OutCache {
   virtual ~OutCache() = default;
 
   size_t sendCount() const { return _sendCount; }
-  size_t sendCountNextGSS() const { return _sendCountNextGSS; }
   uint32_t batchSize() const { return _batchSize; }
   void setBatchSize(uint32_t bs) { _batchSize = bs; }
   inline void setLocalCache(InCache<M>* cache) { _localCache = cache; }
-  inline void setLocalCacheNextGSS(InCache<M>* cache) {
-    _localCacheNextGSS = cache;
-  }
-
-  void sendToNextGSS(bool np) {
-    if (np != _sendToNextGSS) {
-      flushMessages();
-      _sendToNextGSS = np;
-    }
-  }
 
   void clear() {
     _sendCount = 0;
-    _sendCountNextGSS = 0;
     _removeContainedMessages();
+    _clearSendCountPerActor();
   }
+
+  virtual void setDispatch(
+      std::function<void(actor::ActorPID receiver,
+                         worker::message::PregelMessage message)>
+          dispatch){};
+  virtual void setResponsibleActorPerShard(
+      std::unordered_map<ShardID, actor::ActorPID> _responsibleActorPerShard){};
   virtual void appendMessage(PregelShard shard, std::string_view const& key,
                              M const& data) = 0;
   virtual void flushMessages() = 0;
+  virtual auto sendCountPerActor() const
+      -> std::unordered_map<actor::ActorPID, uint64_t> {
+    return {};
+  }
 };
 
 template<typename M>
@@ -104,8 +105,12 @@ class ArrayOutCache : public OutCache<M> {
   std::unordered_map<PregelShard,
                      std::unordered_map<std::string, std::vector<M>>>
       _shardMap;
+  std::unordered_map<ShardID, uint64_t> _sendCountPerShard;
 
   void _removeContainedMessages() override;
+  auto messagesToVPack(std::unordered_map<std::string, std::vector<M>> const&
+                           messagesForVertices)
+      -> std::tuple<size_t, VPackBuilder>;
 
  public:
   ArrayOutCache(std::shared_ptr<WorkerConfig const> state,
@@ -115,9 +120,6 @@ class ArrayOutCache : public OutCache<M> {
 
   void appendMessage(PregelShard shard, std::string_view const& key,
                      M const& data) override;
-  auto messagesToVPack(std::unordered_map<std::string, std::vector<M>> const&
-                           messagesForVertices)
-      -> std::tuple<size_t, VPackBuilder>;
   void flushMessages() override;
 };
 
@@ -128,7 +130,12 @@ class CombiningOutCache : public OutCache<M> {
   /// @brief two stage map: shard -> vertice -> message
   std::unordered_map<PregelShard, std::unordered_map<std::string_view, M>>
       _shardMap;
+  std::unordered_map<ShardID, uint64_t> _sendCountPerShard;
+
   void _removeContainedMessages() override;
+  auto messagesToVPack(
+      std::unordered_map<std::string_view, M> const& messagesForVertices)
+      -> VPackBuilder;
 
  public:
   CombiningOutCache(std::shared_ptr<WorkerConfig const> state,
@@ -138,10 +145,101 @@ class CombiningOutCache : public OutCache<M> {
 
   void appendMessage(PregelShard shard, std::string_view const& key,
                      M const& data) override;
+  void flushMessages() override;
+};
+
+template<typename M>
+class ArrayOutActorCache : public OutCache<M> {
+  std::unordered_map<ShardID, actor::ActorPID> _responsibleActorPerShard;
+  std::function<void(actor::ActorPID receiver,
+                     worker::message::PregelMessage message)>
+      _dispatch;
+
+  /// @brief two stage map: shard -> vertice -> message
+  std::unordered_map<PregelShard,
+                     std::unordered_map<std::string, std::vector<M>>>
+      _shardMap;
+  std::unordered_map<actor::ActorPID, uint64_t> _sendCountPerActor;
+
+  void _removeContainedMessages() override;
+
+  auto _clearSendCountPerActor() -> void override {
+    _sendCountPerActor.clear();
+  }
+  auto messagesToVPack(std::unordered_map<std::string, std::vector<M>> const&
+                           messagesForVertices)
+      -> std::tuple<size_t, VPackBuilder>;
+
+ public:
+  ArrayOutActorCache(std::shared_ptr<WorkerConfig const> state,
+                     MessageFormat<M> const* format)
+      : OutCache<M>{std::move(state), format} {};
+  ~ArrayOutActorCache() = default;
+
+  void setDispatch(std::function<void(actor::ActorPID receiver,
+                                      worker::message::PregelMessage message)>
+                       dispatch) override {
+    _dispatch = std::move(dispatch);
+  }
+  void setResponsibleActorPerShard(std::unordered_map<ShardID, actor::ActorPID>
+                                       responsibleActorPerShard) override {
+    _responsibleActorPerShard = std::move(responsibleActorPerShard);
+  }
+  void appendMessage(PregelShard shard, std::string_view const& key,
+                     M const& data) override;
+  void flushMessages() override;
+  auto sendCountPerActor() const
+      -> std::unordered_map<actor::ActorPID, uint64_t> override {
+    return _sendCountPerActor;
+  }
+};
+
+template<typename M>
+class CombiningOutActorCache : public OutCache<M> {
+  MessageCombiner<M> const* _combiner;
+  std::unordered_map<ShardID, actor::ActorPID> _responsibleActorPerShard;
+  std::function<void(actor::ActorPID receiver,
+                     worker::message::PregelMessage message)>
+      _dispatch;
+
+  /// @brief two stage map: shard -> vertice -> message
+  std::unordered_map<PregelShard, std::unordered_map<std::string_view, M>>
+      _shardMap;
+  std::unordered_map<actor::ActorPID, uint64_t> _sendCountPerActor;
+
+  void _removeContainedMessages() override;
+
+  auto _clearSendCountPerActor() -> void override {
+    _sendCountPerActor.clear();
+  }
   auto messagesToVPack(
       std::unordered_map<std::string_view, M> const& messagesForVertices)
       -> VPackBuilder;
+
+ public:
+  CombiningOutActorCache(std::shared_ptr<WorkerConfig const> state,
+                         MessageFormat<M> const* format,
+                         MessageCombiner<M> const* combiner)
+      : OutCache<M>(state, format), _combiner(combiner){};
+  ~CombiningOutActorCache();
+
+  void setDispatch(std::function<void(actor::ActorPID receiver,
+                                      worker::message::PregelMessage message)>
+                       dispatch) override {
+    _dispatch = std::move(dispatch);
+  }
+  void setResponsibleActorPerShard(std::unordered_map<ShardID, actor::ActorPID>
+                                       responsibleActorPerShard) override {
+    _responsibleActorPerShard = std::move(responsibleActorPerShard);
+  }
+  void appendMessage(PregelShard shard, std::string_view const& key,
+                     M const& data) override;
   void flushMessages() override;
+  auto sendCountPerActor() const
+      -> std::unordered_map<actor::ActorPID, uint64_t> override {
+    return _sendCountPerActor;
+  }
 };
+
 }  // namespace pregel
 }  // namespace arangodb

--- a/arangod/Pregel/Statistics.h
+++ b/arangod/Pregel/Statistics.h
@@ -68,7 +68,7 @@ struct MessageStats {
     b.add(Utils::receivedCountKey, VPackValue(receivedCount));
   }
 
-  void resetTracking() {
+  void reset() {
     sendCount = 0;
     receivedCount = 0;
     superstepRuntimeSecs = 0;

--- a/arangod/Pregel/VertexComputation.h
+++ b/arangod/Pregel/VertexComputation.h
@@ -43,6 +43,7 @@ template<typename V, typename E, typename M>
 class VertexContext {
   friend class Worker<V, E, M>;
 
+ public:
   uint64_t _gss = 0;
   uint64_t _lss = 0;
   WorkerContext* _context = nullptr;
@@ -51,7 +52,6 @@ class VertexContext {
   AggregatorHandler* _writeAggregators = nullptr;
   Vertex<V, E>* _vertexEntry = nullptr;
 
- public:
   virtual ~VertexContext() = default;
 
   template<typename T>
@@ -117,9 +117,10 @@ class VertexContext {
 template<typename V, typename E, typename M>
 class VertexComputation : public VertexContext<V, E, M> {
   friend class Worker<V, E, M>;
-  OutCache<M>* _cache = nullptr;
 
  public:
+  OutCache<M>* _cache = nullptr;
+
   virtual ~VertexComputation() = default;
 
   void sendMessage(Edge<E> const& edge, M const& data) {

--- a/arangod/Pregel/Worker/Handler.h
+++ b/arangod/Pregel/Worker/Handler.h
@@ -44,10 +44,13 @@ struct WorkerHandler : actor::HandlerBase<Runtime, WorkerState<V, E, M>> {
     return std::move(this->state);
   }
 
-  auto operator()(message::LoadGraph start)
+  auto operator()(message::LoadGraph msg)
       -> std::unique_ptr<WorkerState<V, E, M>> {
     LOG_TOPIC("cd69c", INFO, Logger::PREGEL)
         << fmt::format("Worker Actor {} is loading", this->self);
+
+    this->state->responsibleActorPerShard = msg.responsibleActorPerShard;
+
     std::function<void()> statusUpdateCallback =
         [/*self = shared_from_this(),*/ this] {
           // TODO

--- a/arangod/Pregel/Worker/Messages.h
+++ b/arangod/Pregel/Worker/Messages.h
@@ -23,10 +23,10 @@
 #pragma once
 
 #include "Actor/ActorPID.h"
-#include "Cluster/ClusterTypes.h"
 #include "Inspection/Format.h"
 #include "Inspection/Types.h"
 #include "Pregel/CollectionSpecifications.h"
+#include "Pregel/DatabaseTypes.h"
 #include "Pregel/ExecutionNumber.h"
 #include "Pregel/GraphStore/Graph.h"
 #include "Pregel/PregelOptions.h"
@@ -73,10 +73,13 @@ auto inspect(Inspector& f, WorkerStart& x) {
   return f.object(x).fields();
 }
 
-struct LoadGraph {};
+struct LoadGraph {
+  std::unordered_map<ShardID, actor::ActorPID> responsibleActorPerShard;
+};
 template<typename Inspector>
 auto inspect(Inspector& f, LoadGraph& x) {
-  return f.object(x).fields();
+  return f.object(x).fields(
+      f.field("responsibleActorPerShard", x.responsibleActorPerShard));
 }
 
 struct RunGlobalSuperStep {

--- a/arangod/Pregel/Worker/State.h
+++ b/arangod/Pregel/Worker/State.h
@@ -96,6 +96,7 @@ struct WorkerState {
   }
 
   std::shared_ptr<WorkerConfig> config;
+  std::unordered_map<ShardID, actor::ActorPID> responsibleActorPerShard;
 
   // only needed in computing state
   std::unique_ptr<WorkerContext> workerContext;

--- a/arangod/Pregel/Worker/Worker.cpp
+++ b/arangod/Pregel/Worker/Worker.cpp
@@ -475,7 +475,7 @@ void Worker<V, E, M>::_finishedProcessing() {
   uint64_t tn = _config->parallelism();
   uint64_t s = _messageStats.sendCount / tn / 2UL;
   _messageBatchSize = s > 1000 ? (uint32_t)s : 1000;
-  _messageStats.resetTracking();
+  _messageStats.reset();
   LOG_PREGEL("13dbf", DEBUG) << "Message batch size: " << _messageBatchSize;
 }
 

--- a/arangod/Pregel/Worker/WorkerConfig.h
+++ b/arangod/Pregel/Worker/WorkerConfig.h
@@ -137,10 +137,11 @@ class WorkerConfig : std::enable_shared_from_this<WorkerConfig> {
   // convert an arangodb document id to a pregel id
   VertexID documentIdToPregel(std::string_view documentID) const;
 
- private:
-  ExecutionNumber _executionNumber{};
   uint64_t _globalSuperstep = 0;
   uint64_t _localSuperstep = 0;
+
+ private:
+  ExecutionNumber _executionNumber{};
 
   std::string _coordinatorId;
   TRI_vocbase_t* _vocbase;

--- a/arangod/Pregel/WorkerContext.h
+++ b/arangod/Pregel/WorkerContext.h
@@ -35,11 +35,17 @@ class WorkerContext {
   template<typename V, typename E, typename M>
   friend class Worker;
 
-  uint64_t _vertexCount = 0, _edgeCount = 0;
-  std::unique_ptr<AggregatorHandler> _readAggregators;
-  std::unique_ptr<AggregatorHandler> _writeAggregators;
+ public:
+  WorkerContext(std::unique_ptr<AggregatorHandler> readAggregators,
+                std::unique_ptr<AggregatorHandler> writeAggregators)
+      : _readAggregators{std::move(readAggregators)},
+        _writeAggregators{std::move(writeAggregators)} {};
+  virtual ~WorkerContext() = default;
 
- protected:
+  inline uint64_t vertexCount() const { return _vertexCount; }
+
+  inline uint64_t edgeCount() const { return _edgeCount; }
+
   template<typename T>
   inline void aggregate(std::string const& name, T const& value) {
     T const* ptr = &value;
@@ -55,16 +61,9 @@ class WorkerContext {
   virtual void preGlobalSuperstep(uint64_t gss) {}
   virtual void postGlobalSuperstep(uint64_t gss) {}
 
- public:
-  WorkerContext(std::unique_ptr<AggregatorHandler> readAggregators,
-                std::unique_ptr<AggregatorHandler> writeAggregators)
-      : _readAggregators{std::move(readAggregators)},
-        _writeAggregators{std::move(writeAggregators)} {};
-  virtual ~WorkerContext() = default;
-
-  inline uint64_t vertexCount() const { return _vertexCount; }
-
-  inline uint64_t edgeCount() const { return _edgeCount; }
+  uint64_t _vertexCount = 0, _edgeCount = 0;
+  std::unique_ptr<AggregatorHandler> _readAggregators;
+  std::unique_ptr<AggregatorHandler> _writeAggregators;
 };
 }  // namespace pregel
 }  // namespace arangodb


### PR DESCRIPTION
This PR adds code in the worker actor to execute one gss - so everything between getting the message RunGlobalSuperStep from the conductor and sending GlobalSuperStepFinished message back to the conductor.

Additionally, some preparation is needed for this to work: The conductor CreateWorkers execution state now keeps track of which worker actors are responsible for which shards, gives this information to the Loading execution state which sends this information to all workers. This information is needed inside each worker because workers send messages around to other workers and in the actor framework they have to know to which actor they should send these messages to.

This PR also adds two actor-specific OutCaches: ArrayOutActorCache (for sending arrays of messages) and CombiningOutActorCache (for combining messages before sending them). These two Caches now send messages to specific actors instead of sending plain REST messages as the old OutCaches. 
When we have more time, we need to refactor the In- and OutCaches, they are very messy.