### PR TITLE
[GORDO-1549] Finish gss and decide how to continue in conductor

### DIFF
--- a/arangod/Pregel/Algorithm.h
+++ b/arangod/Pregel/Algorithm.h
@@ -116,7 +116,7 @@ struct Algorithm : IAlgorithm {
   }
   virtual std::set<std::string> initialActiveSet() { return {}; }
 
-  [[nodiscard]] virtual uint32_t messageBatchSize(
+  [[deprecated]] [[nodiscard]] virtual uint32_t messageBatchSize(
       std::shared_ptr<WorkerConfig const> config,
       MessageStats const& stats) const {
     if (config->localSuperstep() == 0) {

--- a/arangod/Pregel/Conductor/ExecutionStates/ComputingState.cpp
+++ b/arangod/Pregel/Conductor/ExecutionStates/ComputingState.cpp
@@ -1,22 +1,33 @@
 #include "ComputingState.h"
+#include "Pregel/Conductor/ExecutionStates/FatalErrorState.h"
+#include "Pregel/Conductor/ExecutionStates/ProduceAQLResultsState.h"
+#include "Pregel/Conductor/ExecutionStates/StoringState.h"
+#include "velocypack/Iterator.h"
 
 using namespace arangodb::pregel::conductor;
 
-Computing::Computing(ConductorState& conductor,
-                     std::unique_ptr<MasterContext> masterContext)
-    : conductor{conductor}, masterContext{std::move(masterContext)} {
-  // TODO somewhere call masterContext->preApplication();
-  conductor.timing.computation.start();
+Computing::Computing(
+    ConductorState& conductor, std::unique_ptr<MasterContext> masterContext,
+    std::unordered_map<actor::ActorPID, uint64_t> sendCountPerActor)
+    : conductor{conductor},
+      masterContext{std::move(masterContext)},
+      sendCountPerActor{std::move(sendCountPerActor)} {
   // TODO GORDO-1510
   // _feature.metrics()->pregelConductorsRunningNumber->fetch_add(1);
-  // TODO start gss timing
-  // TODO conductor.mastercontext->preGlobalSuperstep()
+  conductor.timing.gss.emplace_back(Duration{
+      ._start = std::chrono::steady_clock::now(), ._finish = std::nullopt});
 }
 
 Computing::~Computing() {}
 
 auto Computing::messages()
     -> std::unordered_map<actor::ActorPID, worker::message::WorkerMessages> {
+  if (masterContext->_globalSuperstep == 0) {
+    conductor.timing.computation.start();
+    masterContext->preApplication();
+  }
+  masterContext->preGlobalSuperstep();
+
   VPackBuilder aggregators;
   {
     VPackObjectBuilder ob(&aggregators);
@@ -25,20 +36,74 @@ auto Computing::messages()
   auto out =
       std::unordered_map<actor::ActorPID, worker::message::WorkerMessages>();
   for (auto const& worker : conductor.workers) {
-    out.emplace(worker,
-                worker::message::RunGlobalSuperStep{
-                    .gss = masterContext->_globalSuperstep,
-                    .vertexCount = masterContext->_vertexCount,
-                    .edgeCount = masterContext->_edgeCount,
-                    .sendCount = sendCountPerServer.contains(worker.server)
-                                     ? sendCountPerServer.at(worker.server)
-                                     : 0,
-                    .aggregators = aggregators});
+    out.emplace(worker, worker::message::RunGlobalSuperStep{
+                            .gss = masterContext->_globalSuperstep,
+                            .vertexCount = masterContext->_vertexCount,
+                            .edgeCount = masterContext->_edgeCount,
+                            .sendCount = sendCountPerActor.contains(worker)
+                                             ? sendCountPerActor.at(worker)
+                                             : 0,
+                            .aggregators = aggregators});
   }
   return out;
 }
 auto Computing::receive(actor::ActorPID sender,
                         message::ConductorMessages message)
     -> std::optional<std::unique_ptr<ExecutionState>> {
+  if (not conductor.workers.contains(sender) or
+      not std::holds_alternative<ResultT<message::GlobalSuperStepFinished>>(
+          message)) {
+    return std::make_unique<FatalError>(conductor);
+  }
+  auto gssFinished =
+      std::get<ResultT<message::GlobalSuperStepFinished>>(message);
+  if (not gssFinished.ok()) {
+    return std::make_unique<FatalError>(conductor);
+  }
+  respondedWorkers.emplace(sender);
+  messageAccumulation.add(gssFinished.get());
+
+  if (respondedWorkers == conductor.workers) {
+    masterContext->_vertexCount = messageAccumulation.vertexCount;
+    masterContext->_edgeCount = messageAccumulation.edgeCount;
+    masterContext->_aggregators->resetValues();
+    for (auto aggregator :
+         VPackArrayIterator(messageAccumulation.aggregators.slice())) {
+      masterContext->_aggregators->aggregateValues(aggregator);
+    }
+
+    auto postGss = _postGlobalSuperStep();
+
+    if (postGss.finished) {
+      conductor.timing.gss.back().finish();
+      masterContext->postApplication();
+      conductor.timing.computation.finish();
+      // TODO GORDO-1510
+      // conductor._feature.metrics()->pregelConductorsRunningNumber->fetch_sub(1);
+      if (conductor.specifications.storeResults) {
+        return std::make_unique<Storing>(conductor);
+      }
+      return std::make_unique<ProduceAQLResults>(conductor);
+    }
+
+    conductor.timing.gss.back().finish();
+    masterContext->_globalSuperstep++;
+    return std::make_unique<Computing>(
+        conductor, std::move(masterContext),
+        std::move(messageAccumulation.sendCountPerActor));
+  }
+
   return std::nullopt;
 };
+
+auto Computing::_postGlobalSuperStep() -> PostGlobalSuperStepResult {
+  // workers are done if all messages were processed and no active vertices
+  // are left to process
+  bool done = messageAccumulation.activeCount == 0 &&
+              messageAccumulation.messageStats.allMessagesProcessed();
+  auto proceed = masterContext->postGlobalSuperstep();
+  return PostGlobalSuperStepResult{
+      .finished = !proceed || done ||
+                  masterContext->_globalSuperstep >=
+                      conductor.specifications.maxSuperstep};
+}

--- a/arangod/Pregel/Conductor/ExecutionStates/LoadingState.cpp
+++ b/arangod/Pregel/Conductor/ExecutionStates/LoadingState.cpp
@@ -46,12 +46,14 @@ auto Loading::receive(actor::ActorPID sender,
   totalEdgesCount += workerCreated.get().edgeCount;
 
   if (respondedWorkers == conductor.workers) {
+    auto masterContext = conductor.algorithm->masterContextUnique(
+        totalVerticesCount, totalEdgesCount,
+        std::make_unique<AggregatorHandler>(conductor.algorithm.get()),
+        conductor.specifications.userParameters.slice());
+
     return std::make_unique<Computing>(
-        conductor,
-        conductor.algorithm->masterContextUnique(
-            totalVerticesCount, totalEdgesCount,
-            std::make_unique<AggregatorHandler>(conductor.algorithm.get()),
-            conductor.specifications.userParameters.slice()));
+        conductor, std::move(masterContext),
+        std::unordered_map<actor::ActorPID, uint64_t>{});
   }
 
   return std::nullopt;

--- a/arangod/Pregel/Conductor/ExecutionStates/StoringState.h
+++ b/arangod/Pregel/Conductor/ExecutionStates/StoringState.h
@@ -1,7 +1,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 /// DISCLAIMER
 ///
-/// Copyright 2014-2022 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2014-2023 ArangoDB GmbH, Cologne, Germany
 /// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,14 +18,13 @@
 ///
 /// Copyright holder is ArangoDB GmbH, Cologne, Germany
 ///
-/// @author Julia Volmer
+/// @author Heiko Kernbach
 ////////////////////////////////////////////////////////////////////////////////
 #pragma once
 
 #include <unordered_map>
 #include "Pregel/Conductor/Messages.h"
 #include "Pregel/Conductor/State.h"
-#include "Pregel/MasterContext.h"
 #include "Pregel/Worker/Messages.h"
 #include "State.h"
 
@@ -33,28 +32,20 @@ namespace arangodb::pregel::conductor {
 
 struct ConductorState;
 
-struct Computing : ExecutionState {
-  Computing(ConductorState& conductor,
-            std::unique_ptr<MasterContext> masterContext,
-            std::unordered_map<actor::ActorPID, uint64_t> sendCountPerActor);
-  ~Computing();
-  auto name() const -> std::string override { return "computing"; };
+struct Storing : ExecutionState {
+  Storing(ConductorState& conductor) : conductor{conductor} {}
+  ~Storing() {}
+  auto name() const -> std::string override { return "storing"; };
   auto messages()
       -> std::unordered_map<actor::ActorPID,
-                            worker::message::WorkerMessages> override;
+                            worker::message::WorkerMessages> override {
+    return {};
+  }
   auto receive(actor::ActorPID sender, message::ConductorMessages message)
-      -> std::optional<std::unique_ptr<ExecutionState>> override;
-  struct PostGlobalSuperStepResult {
-    bool finished;
+      -> std::optional<std::unique_ptr<ExecutionState>> override {
+    return std::nullopt;
   };
-  auto _postGlobalSuperStep() -> PostGlobalSuperStepResult;
-
   ConductorState& conductor;
-  std::unique_ptr<MasterContext> masterContext;
-  std::unordered_map<actor::ActorPID, uint64_t> sendCountPerActor;
-
-  std::unordered_set<actor::ActorPID> respondedWorkers;
-  message::GlobalSuperStepFinished messageAccumulation;
 };
 
 }  // namespace arangodb::pregel::conductor

--- a/arangod/Pregel/Conductor/Handler.h
+++ b/arangod/Pregel/Conductor/Handler.h
@@ -92,6 +92,12 @@ struct ConductorHandler : actor::HandlerBase<Runtime, ConductorState> {
     LOG_TOPIC("543aa", INFO, Logger::PREGEL) << fmt::format(
         "Conductor Actor: Global super step finished on worker {}",
         this->sender);
+    auto newExecutionState =
+        this->state->executionState->receive(this->sender, std::move(message));
+    if (newExecutionState.has_value()) {
+      changeState(std::move(newExecutionState.value()));
+      sendMessages();
+    }
     return std::move(this->state);
   }
 

--- a/arangod/Pregel/MasterContext.h
+++ b/arangod/Pregel/MasterContext.h
@@ -102,6 +102,8 @@ class MasterContext {
   /// @return true to continue the computation
   virtual bool postGlobalSuperstep() { return true; }
 
+  virtual void postApplication() {}
+
   virtual void serializeValues(VPackBuilder& b) {}
 
   /// should indicate if compensation is supposed to start by returning true


### PR DESCRIPTION
In the Computing conductor state: After all workers send a GlobalSuperStepFinshed message to the conductor, the Computing state decides how to continue:
- Start next super step by creating a new Computation state or
- Finish computation and change into Storing state (if pregel results should be stored in database) or
- Finish computation and change into ProduceAqlResults state (if pregel results should *not* be stored in database). 