### PR TITLE
use std::string::starts_with

### DIFF
--- a/arangod/Aql/ExecutionEngine.cpp
+++ b/arangod/Aql/ExecutionEngine.cpp
@@ -564,7 +564,7 @@ struct DistributedQueryInstanciator final
           _query.vocbase().server().getFeature<ClusterFeature>().clusterInfo();
       engine->rebootTrackers().reserve(srvrQryId.size());
       for (auto const& [server, queryId, rebootId] : srvrQryId) {
-        TRI_ASSERT(server.substr(0, 7) != "server:");
+        TRI_ASSERT(!server.starts_with("server:"));
         std::string comment = std::string("AQL query from coordinator ") +
                               ServerState::instance()->getId();
 

--- a/arangod/Aql/Query.cpp
+++ b/arangod/Aql/Query.cpp
@@ -1591,7 +1591,7 @@ futures::Future<Result> finishDBServerParts(Query& query, ErrorCode errorCode) {
   TRI_ASSERT(ss != nullptr);
 
   for (auto const& [server, queryId, rebootId] : serverQueryIds) {
-    TRI_ASSERT(server.substr(0, 7) != "server:");
+    TRI_ASSERT(!server.starts_with("server:"));
 
     auto f =
         network::sendRequest(pool, "server:" + server, fuerte::RestVerb::Delete,

--- a/arangod/Cluster/ClusterTrxMethods.cpp
+++ b/arangod/Cluster/ClusterTrxMethods.cpp
@@ -144,7 +144,7 @@ Future<network::Response> beginTransactionRequest(TransactionState& state,
   TransactionId tid = state.id().child();
   TRI_ASSERT(!tid.isLegacyTransactionId());
 
-  TRI_ASSERT(server.substr(0, 7) != "server:");
+  TRI_ASSERT(!server.starts_with("server:"));
 
   double const lockTimeout = state.options().lockTimeout;
 
@@ -273,7 +273,7 @@ Future<Result> commitAbortTransaction(arangodb::TransactionState* state,
   std::vector<Future<network::Response>> requests;
   requests.reserve(state->knownServers().size());
   for (std::string const& server : state->knownServers()) {
-    TRI_ASSERT(server.substr(0, 7) != "server:");
+    TRI_ASSERT(!server.starts_with("server:"));
     requests.emplace_back(network::sendRequestRetry(
         pool, "server:" + server, verb, path, VPackBuffer<uint8_t>(), reqOpts));
   }
@@ -572,7 +572,7 @@ void addAQLTransactionHeader(transaction::Methods const& trx,
     return;
   }
 
-  TRI_ASSERT(server.substr(0, 7) != "server:");
+  TRI_ASSERT(!server.starts_with("server:"));
 
   std::string value = std::to_string(state.id().child().id());
   bool const addBegin = !state.knowsServer(server);

--- a/arangod/Cluster/TakeoverShardLeadership.cpp
+++ b/arangod/Cluster/TakeoverShardLeadership.cpp
@@ -55,17 +55,18 @@
 #include <velocypack/Iterator.h>
 #include <velocypack/Slice.h>
 
+#include <string_view>
+
 using namespace arangodb;
 using namespace arangodb::application_features;
 using namespace arangodb::maintenance;
 using namespace arangodb::methods;
 
 namespace {
-static std::string serverPrefix("server:");
+constexpr std::string_view serverPrefix("server:");
 
 std::string stripServerPrefix(std::string const& destination) {
-  TRI_ASSERT(destination.size() >= serverPrefix.size() &&
-             destination.substr(0, serverPrefix.size()) == serverPrefix);
+  TRI_ASSERT(destination.starts_with(serverPrefix));
   return destination.substr(serverPrefix.size());
 }
 }  // namespace


### PR DESCRIPTION
### Scope & Purpose

Simplify some assertion code that uses substr() and compare() for string prefix checking.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: -
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 