### PR TITLE
[GORDO-1559] Add REST pregel option to run pregel with actors

### DIFF
--- a/arangod/Pregel/PregelOptions.h
+++ b/arangod/Pregel/PregelOptions.h
@@ -95,6 +95,9 @@ struct PregelOptions {
   std::string algorithm;
   VPackBuilder userParameters;
   GraphSource graphSource;
+  // A switch between running pregel with or without actors
+  // Can be deleted if we finished refactoring to use only actors
+  bool useActors = false;
 };
 
 struct TTL {

--- a/arangod/Pregel/REST/RestOptions.cpp
+++ b/arangod/Pregel/REST/RestOptions.cpp
@@ -33,14 +33,16 @@ auto RestOptions::options() -> PregelOptions {
         .algorithm = x.options.algorithm,
         .userParameters = x.options.userParameters,
         .graphSource = {{GraphName{.graph = x.graph}},
-                        {x.options.edgeCollectionRestrictions}}};
+                        {x.options.edgeCollectionRestrictions}},
+        .useActors = x.options.useActors};
   }
   auto x = std::get<pregel::RestCollectionSettings>(*this);
   return PregelOptions{
       .algorithm = x.options.algorithm,
       .userParameters = x.options.userParameters,
-      .graphSource = {
-          {GraphCollectionNames{.vertexCollections = x.vertexCollections,
-                                .edgeCollections = x.edgeCollections}},
-          {x.options.edgeCollectionRestrictions}}};
+      .graphSource = {{GraphCollectionNames{
+                          .vertexCollections = x.vertexCollections,
+                          .edgeCollections = x.edgeCollections}},
+                      {x.options.edgeCollectionRestrictions}},
+      .useActors = x.options.useActors};
 }

--- a/arangod/Pregel/REST/RestOptions.h
+++ b/arangod/Pregel/REST/RestOptions.h
@@ -36,6 +36,9 @@ struct RestGeneralOptions {
   VPackBuilder userParameters;
   std::unordered_map<std::string, std::vector<std::string>>
       edgeCollectionRestrictions;
+  // A switch between running pregel with or without actors
+  // Can be deleted if we finished refactoring to use only actors
+  bool useActors;
 };
 template<typename Inspector>
 auto inspect(Inspector& f, RestGeneralOptions& x) {
@@ -45,7 +48,8 @@ auto inspect(Inspector& f, RestGeneralOptions& x) {
           .fallback(VPackSlice::emptyObjectSlice()),
       f.field("edgeCollectionRestrictions", x.edgeCollectionRestrictions)
           .fallback(
-              std::unordered_map<std::string, std::vector<std::string>>{}));
+              std::unordered_map<std::string, std::vector<std::string>>{}),
+      f.field("actors", x.useActors).fallback(false));
 }
 
 struct RestCollectionSettings {


### PR DESCRIPTION
With this PR, pregel runs either as it was before without actors (the default) or with actors. In a REST call you can add `"actors":true` to run with actors, e.g.:
```
curl -X POST http://localhost:8529/_api/control_pregel -u root: -d '{"algorithm" : "wcc", "graphName" : "generatedGraph", "actors":true}'
```