### PR TITLE
very small improvements for telemetrics

### DIFF
--- a/arangod/Utils/SupportInfoBuilder.cpp
+++ b/arangod/Utils/SupportInfoBuilder.cpp
@@ -36,6 +36,7 @@
 #include "Cluster/ServerState.h"
 #include "GeneralServer/AuthenticationFeature.h"
 #include "Indexes/Index.h"
+#include "Logger/LogMacros.h"
 #include "Metrics/MetricsFeature.h"
 #include "Network/Methods.h"
 #include "Network/NetworkFeature.h"
@@ -60,7 +61,7 @@
 #include <velocypack/Builder.h>
 #include <absl/strings/str_replace.h>
 
-#include "Logger/LogMacros.h"
+#include <array>
 
 using namespace arangodb;
 using namespace arangodb::rest;
@@ -662,14 +663,13 @@ void SupportInfoBuilder::buildDbServerDataStoredInfo(
 
           if (collsAlreadyVisited.find(planId) == collsAlreadyVisited.end()) {
             auto collType = coll->type();
-            if (collType == TRI_COL_TYPE_DOCUMENT) {
-              numDocColls++;
-              result.add("type", VPackValue("document"));
-            } else if (collType == TRI_COL_TYPE_EDGE) {
+            if (collType == TRI_COL_TYPE_EDGE) {
               result.add("type", VPackValue("edge"));
               numEdgeColls++;
             } else {
-              result.add("type", VPackValue("unknown"));
+              TRI_ASSERT(collType == TRI_COL_TYPE_DOCUMENT);
+              result.add("type", VPackValue("document"));
+              numDocColls++;
             }
             if (coll->isSmart()) {
               numSmartColls++;
@@ -688,7 +688,7 @@ void SupportInfoBuilder::buildDbServerDataStoredInfo(
 
             auto flags = Index::makeFlags(Index::Serialize::Estimates,
                                           Index::Serialize::Figures);
-            std::vector<std::string_view> idxTypes = {
+            constexpr std::array<std::string_view, 12> idxTypes = {
                 "edge",     "geo",        "hash",      "fulltext",
                 "inverted", "persistent", "iresearch", "skiplist",
                 "ttl",      "zkd",        "primary",   "unknown"};
@@ -731,6 +731,9 @@ void SupportInfoBuilder::buildDbServerDataStoredInfo(
 
               auto idxType = it.get("type").stringView();
               if (idxType == "geo1" || idxType == "geo2") {
+                // older deployments can have indexes of type "geo1"
+                // and "geo2". these are old names for "geo" indexes with
+                // specific setting. simply rename them to "geo" here.
                 idxType = "geo";
               }
               result.add("type", VPackValue(idxType));

--- a/lib/SimpleHttpClient/GeneralClientConnection.cpp
+++ b/lib/SimpleHttpClient/GeneralClientConnection.cpp
@@ -41,6 +41,7 @@
 
 #include "ApplicationFeatures/ApplicationServer.h"
 #include "ApplicationFeatures/CommunicationFeaturePhase.h"
+#include "Basics/Exceptions.h"
 #include "Basics/StringBuffer.h"
 #include "Basics/debugging.h"
 #include "Basics/error.h"
@@ -136,7 +137,9 @@ GeneralClientConnection* GeneralClientConnection::factory(
                                    connectTimeout, numRetries, sslProtocol);
   }
 
-  return nullptr;
+  TRI_ASSERT(false);
+  THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_INTERNAL,
+                                 "invalid encryption type for connection");
 }
 
 GeneralClientConnection* GeneralClientConnection::factory(


### PR DESCRIPTION
### Scope & Purpose

A few very small improvements:
* `GeneralClientConnection::factory()` will always return a connection object now, or throw an exception in case an invalid encryption type was used. The latter should never happen in practice. However, the caller of the function can now be sure that the function will either return a new connection object, or throw. It can never return a nullptr anymore, so callers don't need to check for that.
* remove "unknown" collections from telemetrics, because they don't exist. Collections are either document collections or edge collections.
* avoid the creation of an std::vector in an inner loop, and simply use a constexpr std::array instead. This is more efficient.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: -
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 