### PR TITLE
simplify structs in process-utils

### DIFF
--- a/lib/Basics/process-utils.cpp
+++ b/lib/Basics/process-utils.cpp
@@ -170,17 +170,8 @@ ExternalId::ExternalId()
 }
 #endif
 
-ExternalProcess::ExternalProcess()
-    : _numberArguments(0),
-      _arguments(nullptr),
-#ifdef _WIN32
-      _process(nullptr),
-#endif
-      _status(TRI_EXT_NOT_STARTED),
-      _exitStatus(0) {
-}
-
 ExternalProcess::~ExternalProcess() {
+  TRI_ASSERT(_numberArguments == 0 || _arguments != nullptr);
   for (size_t i = 0; i < _numberArguments; i++) {
     if (_arguments[i] != nullptr) {
       TRI_Free(_arguments[i]);
@@ -207,9 +198,6 @@ ExternalProcess::~ExternalProcess() {
   }
 #endif
 }
-
-ExternalProcessStatus::ExternalProcessStatus()
-    : _status(TRI_EXT_NOT_STARTED), _exitStatus(0), _errorMessage() {}
 
 ExternalProcess* TRI_LookupSpawnedProcess(TRI_pid_t pid) {
   {
@@ -1063,7 +1051,6 @@ ExternalProcessStatus TRI_CheckExternalProcess(ExternalId pid, bool wait,
                                                uint32_t timeout) {
   ExternalProcessStatus status;
   status._status = TRI_EXT_NOT_FOUND;
-  status._exitStatus = 0;
 
   auto external = TRI_LookupSpawnedProcess(pid._pid);
 
@@ -1071,7 +1058,6 @@ ExternalProcessStatus TRI_CheckExternalProcess(ExternalId pid, bool wait,
     status._errorMessage =
         std::string("the pid you're looking for is not in our list: ") +
         arangodb::basics::StringUtils::itoa(static_cast<int64_t>(pid._pid));
-    status._status = TRI_EXT_NOT_FOUND;
     LOG_TOPIC("f5f99", WARN, arangodb::Logger::FIXME)
         << "checkExternal: pid not found: " << pid._pid;
 

--- a/lib/Basics/process-utils.h
+++ b/lib/Basics/process-utils.h
@@ -100,18 +100,21 @@ struct ExternalId {
 
 struct ExternalProcess : public ExternalId {
   std::string _executable;
-  size_t _numberArguments;
-  char** _arguments;
+  size_t _numberArguments = 0;
+  char** _arguments = nullptr;
 
 #ifdef _WIN32
-  HANDLE _process;
+  HANDLE _process = nullptr;
 #endif
 
-  TRI_external_status_e _status;
-  int64_t _exitStatus;
+  TRI_external_status_e _status = TRI_EXT_NOT_STARTED;
+  int64_t _exitStatus = 0;
 
+  ExternalProcess(ExternalProcess const& other) = delete;
+  ExternalProcess& operator=(ExternalProcess const& other) = delete;
+
+  ExternalProcess() = default;
   ~ExternalProcess();
-  ExternalProcess();
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -125,11 +128,9 @@ extern std::vector<ExternalProcess*> ExternalProcesses;
 ////////////////////////////////////////////////////////////////////////////////
 
 struct ExternalProcessStatus {
-  TRI_external_status_e _status;
-  int64_t _exitStatus;
+  TRI_external_status_e _status = TRI_EXT_NOT_STARTED;
+  int64_t _exitStatus = 0;
   std::string _errorMessage;
-
-  ExternalProcessStatus();
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -144,7 +145,7 @@ uint64_t TRI_MicrosecondsTv(struct timeval* tv);
 /// @brief returns information about the current process
 ////////////////////////////////////////////////////////////////////////////////
 
-ProcessInfo TRI_ProcessInfoSelf(void);
+ProcessInfo TRI_ProcessInfoSelf();
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief returns information about the process

--- a/lib/V8/v8-utils.cpp
+++ b/lib/V8/v8-utils.cpp
@@ -4737,7 +4737,7 @@ static void JS_StatusExternal(v8::FunctionCallbackInfo<v8::Value> const& args) {
                                static_cast<int32_t>(external._exitStatus)))
         .FromMaybe(false);
   }
-  if (external._errorMessage.length() > 0) {
+  if (!external._errorMessage.empty()) {
     result
         ->Set(context, TRI_V8_STD_STRING(isolate, StaticStrings::ErrorMessage),
               TRI_V8_STD_STRING(isolate, external._errorMessage))


### PR DESCRIPTION
### Scope & Purpose

Simplify some structs in process-utils, and disallow copying of a struct that doesn't support it

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: -
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 