### PR TITLE
BTS-1272: correct counting of connections in pool

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,11 +1,11 @@
 v3.10.6 (XXXX-XX-XX)
 --------------------
 
-* BTS-1272: Fixed metric `arangodb_connection_pool_connections_current`. In
-  some cases where multiple connections to a server are canceled the metric
-  could miss-count, as for now it only counted individually closed connections.
-  The wrong counted situations are: other server crashes, restore of a HotBackup,
-  rotation of JWT secret.
+* BTS-1272: Fixed metric `arangodb_connection_pool_connections_current`. In some
+  cases where multiple connections to a server are canceled the metric could
+  miss-count, as for now it only counted individually closed connections.
+  The wrong counted situations are: other server crashes, restore of a
+  HotBackup, rotation of JWT secret.
 
 
 v3.10.5 (2023-03-16)

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,13 @@
+v3.10.6 (XXXX-XX-XX)
+--------------------
+
+* BTS-1272: Fixed metric `arangodb_connection_pool_connections_current`. In
+  some cases where multiple connections to a server are canceled the metric
+  could miss-count, as for now it only counted individually closed connections.
+  The wrong counted situations are: other server crashes, restore of a HotBackup,
+  rotation of JWT secret.
+
+
 v3.10.5 (2023-03-16)
 --------------------
 

--- a/tests/Network/ConnectionPoolTest.cpp
+++ b/tests/Network/ConnectionPoolTest.cpp
@@ -30,6 +30,8 @@
 
 #include "Mocks/Servers.h"
 
+#include "Metrics/Gauge.h"
+
 using namespace arangodb;
 using namespace arangodb::network;
 
@@ -48,23 +50,36 @@ struct NetworkConnectionPoolTest : public ::testing::Test {
   NetworkConnectionPoolTest() : server(false) { server.startFeatures(); }
 
  protected:
+  metrics::MetricsFeature& metrics() {
+    return server.getFeature<metrics::MetricsFeature>();
+  }
+
+  uint64_t extractCurrentMetric() {
+    auto m = metrics().get(currentConnectionsMetric);
+    TRI_ASSERT(m != nullptr) << "Metric not registered";
+    auto gauge = dynamic_cast<metrics::Gauge<uint64_t>*>(m);
+    return gauge->load();
+  }
   tests::mocks::MockMetricsServer server;
+
+  static constexpr metrics::MetricKeyView currentConnectionsMetric{
+      "arangodb_connection_pool_connections_current", "pool=\"\""};
 };
 
 TEST_F(NetworkConnectionPoolTest, acquire_endpoint) {
-  ConnectionPool::Config config(server.getFeature<metrics::MetricsFeature>());
+  ConnectionPool::Config config(metrics());
   config.numIOThreads = 1;
   config.maxOpenConnections = 3;
   config.idleConnectionMilli = 10;  // extra small for testing
   config.verifyHosts = false;
   config.protocol = fuerte::ProtocolType::Http;
-
   ConnectionPool pool(config);
   std::this_thread::sleep_for(std::chrono::seconds(1));
 
   bool isFromPool;
   auto conn = pool.leaseConnection("tcp://example.org:80", isFromPool);
   ASSERT_EQ(pool.numOpenConnections(), 1);
+  EXPECT_EQ(extractCurrentMetric(), 1ull);
   auto req =
       fuerte::createRequest(fuerte::RestVerb::Get, fuerte::ContentType::Unset);
   auto res = conn->sendRequest(std::move(req));
@@ -73,7 +88,7 @@ TEST_F(NetworkConnectionPoolTest, acquire_endpoint) {
 }
 
 TEST_F(NetworkConnectionPoolTest, acquire_multiple_endpoint) {
-  ConnectionPool::Config config(server.getFeature<metrics::MetricsFeature>());
+  ConnectionPool::Config config(metrics());
   config.numIOThreads = 1;
   config.maxOpenConnections = 3;
   config.idleConnectionMilli = 10;  // extra small for testing
@@ -94,11 +109,13 @@ TEST_F(NetworkConnectionPoolTest, acquire_multiple_endpoint) {
 
   ASSERT_NE(conn1.get(), conn2.get());
   ASSERT_EQ(pool.numOpenConnections(), 2);
+  EXPECT_EQ(extractCurrentMetric(), 2ull);
 
   auto conn3 = pool.leaseConnection("tcp://example.com:80", isFromPool);
   ASSERT_NE(conn1.get(), conn3.get());
 
   ASSERT_EQ(pool.numOpenConnections(), 3);
+  EXPECT_EQ(extractCurrentMetric(), 3ull);
 }
 
 TEST_F(NetworkConnectionPoolTest, release_multiple_endpoints_one) {
@@ -115,6 +132,7 @@ TEST_F(NetworkConnectionPoolTest, release_multiple_endpoints_one) {
     bool isFromPool;
     auto conn1 = pool.leaseConnection("tcp://example.org:80", isFromPool);
     ASSERT_EQ(pool.numOpenConnections(), 1);
+    EXPECT_EQ(extractCurrentMetric(), 1ull);
     conn1->sendRequest(fuerte::createRequest(fuerte::RestVerb::Get,
                                              fuerte::ContentType::Unset),
                        doNothing);
@@ -122,17 +140,20 @@ TEST_F(NetworkConnectionPoolTest, release_multiple_endpoints_one) {
     auto conn2 = pool.leaseConnection("tcp://example.com:80", isFromPool);
     ASSERT_NE(conn1.get(), conn2.get());
     ASSERT_EQ(pool.numOpenConnections(), 2);
+    EXPECT_EQ(extractCurrentMetric(), 2ull);
   }
   ASSERT_EQ(pool.numOpenConnections(), 2);
+  EXPECT_EQ(extractCurrentMetric(), 2ull);
 
   std::this_thread::sleep_for(std::chrono::milliseconds(15));
   pool.pruneConnections();
 
   ASSERT_EQ(pool.numOpenConnections(), 1);  // keep one busy connection
+  EXPECT_EQ(extractCurrentMetric(), 1ull);
 }
 
 TEST_F(NetworkConnectionPoolTest, release_multiple_endpoints_two) {
-  ConnectionPool::Config config(server.getFeature<metrics::MetricsFeature>());
+  ConnectionPool::Config config(metrics());
   config.numIOThreads = 1;
   config.maxOpenConnections = 3;
   config.idleConnectionMilli = 10;  // extra small for testing
@@ -146,6 +167,7 @@ TEST_F(NetworkConnectionPoolTest, release_multiple_endpoints_two) {
   {
     auto conn1 = pool.leaseConnection("tcp://example.org:80", isFromPool);
     ASSERT_EQ(pool.numOpenConnections(), 1);
+    EXPECT_EQ(extractCurrentMetric(), 1ull);
     conn1->sendRequest(fuerte::createRequest(fuerte::RestVerb::Get,
                                              fuerte::ContentType::Unset),
                        doNothing);
@@ -153,35 +175,47 @@ TEST_F(NetworkConnectionPoolTest, release_multiple_endpoints_two) {
     auto conn2 = pool.leaseConnection("tcp://example.com:80", isFromPool);
     ASSERT_NE(conn1.get(), conn2.get());
     ASSERT_EQ(pool.numOpenConnections(), 2);
+    EXPECT_EQ(extractCurrentMetric(), 2ull);
   }
   ASSERT_EQ(pool.numOpenConnections(), 2);
+  EXPECT_EQ(extractCurrentMetric(), 2ull);
 
   std::this_thread::sleep_for(std::chrono::milliseconds(21));
   // this will only expire conn2 (conn1 is still in use)
   pool.pruneConnections();
   ASSERT_EQ(pool.numOpenConnections(), 1);
+  EXPECT_EQ(extractCurrentMetric(), 1ull);
 
   pool.drainConnections();
 
+  // Drain needs to erase all connections
+  ASSERT_EQ(pool.numOpenConnections(), 0);
+  EXPECT_EQ(extractCurrentMetric(), 0ull);
   {
     auto conn1 = pool.leaseConnection("tcp://example.org:80", isFromPool);
     ASSERT_EQ(pool.numOpenConnections(), 1);
+    EXPECT_EQ(extractCurrentMetric(), 1ull);
 
     auto conn2 = pool.leaseConnection("tcp://example.com:80", isFromPool);
     ASSERT_NE(conn1.get(), conn2.get());
     ASSERT_EQ(pool.numOpenConnections(), 2);
+    EXPECT_EQ(extractCurrentMetric(), 2ull);
   }
   ASSERT_EQ(pool.numOpenConnections(), 2);
+  EXPECT_EQ(extractCurrentMetric(), 2ull);
 
   std::this_thread::sleep_for(std::chrono::milliseconds(21));
   pool.pruneConnections();
   ASSERT_EQ(pool.numOpenConnections(), 0);
+  EXPECT_EQ(extractCurrentMetric(), 0ull);
 
   pool.drainConnections();
+  EXPECT_EQ(extractCurrentMetric(), 0ull);
 
   {
     auto conn1 = pool.leaseConnection("tcp://example.org:80", isFromPool);
     ASSERT_EQ(pool.numOpenConnections(), 1);
+    EXPECT_EQ(extractCurrentMetric(), 1ull);
     conn1->sendRequest(fuerte::createRequest(fuerte::RestVerb::Get,
                                              fuerte::ContentType::Unset),
                        doNothing);
@@ -189,22 +223,27 @@ TEST_F(NetworkConnectionPoolTest, release_multiple_endpoints_two) {
     auto conn2 = pool.leaseConnection("tcp://example.com:80", isFromPool);
     ASSERT_NE(conn1.get(), conn2.get());
     ASSERT_EQ(pool.numOpenConnections(), 2);
+    EXPECT_EQ(extractCurrentMetric(), 2ull);
 
     conn2->sendRequest(fuerte::createRequest(fuerte::RestVerb::Get,
                                              fuerte::ContentType::Unset),
                        doNothing);
   }
   ASSERT_EQ(pool.numOpenConnections(), 2);
+  EXPECT_EQ(extractCurrentMetric(), 2ull);
 
   std::this_thread::sleep_for(std::chrono::milliseconds(21));
   pool.pruneConnections();
   ASSERT_EQ(pool.numOpenConnections(), 2);
+  EXPECT_EQ(extractCurrentMetric(), 2ull);
 
   pool.drainConnections();
+  ASSERT_EQ(pool.numOpenConnections(), 0);
+  EXPECT_EQ(extractCurrentMetric(), 0ull);
 }
 
 TEST_F(NetworkConnectionPoolTest, checking_min_and_max_connections) {
-  ConnectionPool::Config config(server.getFeature<metrics::MetricsFeature>());
+  ConnectionPool::Config config(metrics());
   config.numIOThreads = 1;
   config.maxOpenConnections = 2;
   config.idleConnectionMilli = 10;  // extra small for testing
@@ -218,6 +257,7 @@ TEST_F(NetworkConnectionPoolTest, checking_min_and_max_connections) {
   {
     auto conn1 = pool.leaseConnection("tcp://example.org:80", isFromPool);
     ASSERT_EQ(pool.numOpenConnections(), 1);
+    EXPECT_EQ(extractCurrentMetric(), 1ull);
 
     conn1->sendRequest(fuerte::createRequest(fuerte::RestVerb::Get,
                                              fuerte::ContentType::Unset),
@@ -226,6 +266,7 @@ TEST_F(NetworkConnectionPoolTest, checking_min_and_max_connections) {
     auto conn2 = pool.leaseConnection("tcp://example.org:80", isFromPool);
     ASSERT_NE(conn1.get(), conn2.get());
     ASSERT_EQ(pool.numOpenConnections(), 2);
+    EXPECT_EQ(extractCurrentMetric(), 2ull);
 
     conn2->sendRequest(fuerte::createRequest(fuerte::RestVerb::Get,
                                              fuerte::ContentType::Unset),
@@ -235,8 +276,10 @@ TEST_F(NetworkConnectionPoolTest, checking_min_and_max_connections) {
     ASSERT_NE(conn1.get(), conn3.get());
     ASSERT_NE(conn1.get(), conn2.get());
     ASSERT_EQ(pool.numOpenConnections(), 3);
+    EXPECT_EQ(extractCurrentMetric(), 3ull);
   }
   ASSERT_EQ(pool.numOpenConnections(), 3);
+  EXPECT_EQ(extractCurrentMetric(), 3ull);
 
   // 21ms > 2 * 10ms
   std::this_thread::sleep_for(std::chrono::milliseconds(21));
@@ -244,12 +287,16 @@ TEST_F(NetworkConnectionPoolTest, checking_min_and_max_connections) {
   // this will only expire conn3 (conn1 and conn2 are still in use)
   pool.pruneConnections();
   ASSERT_EQ(pool.numOpenConnections(), 2);
+  EXPECT_EQ(extractCurrentMetric(), 2ull);
 
   pool.drainConnections();
+  ASSERT_EQ(pool.numOpenConnections(), 0);
+  EXPECT_EQ(extractCurrentMetric(), 0ull);
 
   {
     auto conn1 = pool.leaseConnection("tcp://example.org:80", isFromPool);
     ASSERT_EQ(pool.numOpenConnections(), 1);
+    EXPECT_EQ(extractCurrentMetric(), 1ull);
 
     conn1->sendRequest(fuerte::createRequest(fuerte::RestVerb::Get,
                                              fuerte::ContentType::Unset),
@@ -258,6 +305,7 @@ TEST_F(NetworkConnectionPoolTest, checking_min_and_max_connections) {
     auto conn2 = pool.leaseConnection("tcp://example.org:80", isFromPool);
     ASSERT_NE(conn1.get(), conn2.get());
     ASSERT_EQ(pool.numOpenConnections(), 2);
+    EXPECT_EQ(extractCurrentMetric(), 2ull);
 
     conn2->sendRequest(fuerte::createRequest(fuerte::RestVerb::Get,
                                              fuerte::ContentType::Unset),
@@ -267,20 +315,25 @@ TEST_F(NetworkConnectionPoolTest, checking_min_and_max_connections) {
     ASSERT_NE(conn1.get(), conn3.get());
     ASSERT_NE(conn1.get(), conn2.get());
     ASSERT_EQ(pool.numOpenConnections(), 3);
+    EXPECT_EQ(extractCurrentMetric(), 3ull);
 
     conn3->sendRequest(fuerte::createRequest(fuerte::RestVerb::Get,
                                              fuerte::ContentType::Unset),
                        doNothing);
   }
   ASSERT_EQ(pool.numOpenConnections(), 3);
+  EXPECT_EQ(extractCurrentMetric(), 3ull);
 
   // 21ms > 2 * 10ms
   std::this_thread::sleep_for(std::chrono::milliseconds(21));
 
   pool.pruneConnections();
   ASSERT_EQ(pool.numOpenConnections(), 3);
+  EXPECT_EQ(extractCurrentMetric(), 3ull);
 
   pool.drainConnections();
+  ASSERT_EQ(pool.numOpenConnections(), 0);
+  EXPECT_EQ(extractCurrentMetric(), 0ull);
 }
 
 TEST_F(NetworkConnectionPoolTest, checking_expiration) {
@@ -298,8 +351,10 @@ TEST_F(NetworkConnectionPoolTest, checking_expiration) {
   {
     auto conn1 = pool.leaseConnection("tcp://example.org:80", isFromPool);
     ASSERT_EQ(pool.numOpenConnections(), 1);
+    EXPECT_EQ(extractCurrentMetric(), 1ull);
   }
   ASSERT_EQ(pool.numOpenConnections(), 1);
+  EXPECT_EQ(extractCurrentMetric(), 1ull);
 
   // 21ms > 2 * 10ms
   std::this_thread::sleep_for(std::chrono::milliseconds(21));
@@ -307,17 +362,23 @@ TEST_F(NetworkConnectionPoolTest, checking_expiration) {
   // expires the connection
   pool.pruneConnections();
   ASSERT_EQ(pool.numOpenConnections(), 0);
+  EXPECT_EQ(extractCurrentMetric(), 0ull);
 
   pool.drainConnections();
+  ASSERT_EQ(pool.numOpenConnections(), 0);
+  EXPECT_EQ(extractCurrentMetric(), 0ull);
 
   {
     auto conn1 = pool.leaseConnection("tcp://example.org:80", isFromPool);
     ASSERT_EQ(pool.numOpenConnections(), 1);
+    EXPECT_EQ(extractCurrentMetric(), 1ull);
 
     auto conn2 = pool.leaseConnection("tcp://example.org:80", isFromPool);
     ASSERT_EQ(pool.numOpenConnections(), 2);
+    EXPECT_EQ(extractCurrentMetric(), 2ull);
   }
   ASSERT_EQ(pool.numOpenConnections(), 2);
+  EXPECT_EQ(extractCurrentMetric(), 2ull);
 
   // 21ms > 2 * 10ms
   std::this_thread::sleep_for(std::chrono::milliseconds(21));
@@ -325,20 +386,26 @@ TEST_F(NetworkConnectionPoolTest, checking_expiration) {
   // expires the connections
   pool.pruneConnections();
   ASSERT_EQ(pool.numOpenConnections(), 0);
+  EXPECT_EQ(extractCurrentMetric(), 0ull);
 
   pool.drainConnections();
+  EXPECT_EQ(extractCurrentMetric(), 0ull);
 
   {
     auto conn1 = pool.leaseConnection("tcp://example.org:80", isFromPool);
     ASSERT_EQ(pool.numOpenConnections(), 1);
+    EXPECT_EQ(extractCurrentMetric(), 1ull);
 
     auto conn2 = pool.leaseConnection("tcp://example.org:80", isFromPool);
     ASSERT_EQ(pool.numOpenConnections(), 2);
+    EXPECT_EQ(extractCurrentMetric(), 2ull);
 
     auto conn3 = pool.leaseConnection("tcp://example.org:80", isFromPool);
     ASSERT_EQ(pool.numOpenConnections(), 3);
+    EXPECT_EQ(extractCurrentMetric(), 3ull);
   }
   ASSERT_EQ(pool.numOpenConnections(), 3);
+  EXPECT_EQ(extractCurrentMetric(), 3ull);
 
   // 21ms > 2 * 10ms
   std::this_thread::sleep_for(std::chrono::milliseconds(21));
@@ -346,8 +413,10 @@ TEST_F(NetworkConnectionPoolTest, checking_expiration) {
   // expires the connections
   pool.pruneConnections();
   ASSERT_EQ(pool.numOpenConnections(), 0);
+  EXPECT_EQ(extractCurrentMetric(), 0ull);
 
   pool.drainConnections();
+  EXPECT_EQ(extractCurrentMetric(), 0ull);
 }
 
 TEST_F(NetworkConnectionPoolTest, checking_expiration_multiple_endpints) {
@@ -365,11 +434,14 @@ TEST_F(NetworkConnectionPoolTest, checking_expiration_multiple_endpints) {
   {
     auto conn1 = pool.leaseConnection("tcp://example.org:80", isFromPool);
     ASSERT_EQ(pool.numOpenConnections(), 1);
+    EXPECT_EQ(extractCurrentMetric(), 1ull);
 
     auto conn2 = pool.leaseConnection("tcp://example.org:80", isFromPool);
     ASSERT_EQ(pool.numOpenConnections(), 2);
+    EXPECT_EQ(extractCurrentMetric(), 2ull);
   }
   ASSERT_EQ(pool.numOpenConnections(), 2);
+  EXPECT_EQ(extractCurrentMetric(), 2ull);
 
   // 21ms > 2 * 10ms
   std::this_thread::sleep_for(std::chrono::milliseconds(21));
@@ -377,17 +449,23 @@ TEST_F(NetworkConnectionPoolTest, checking_expiration_multiple_endpints) {
   // expires the connection(s)
   pool.pruneConnections();
   ASSERT_EQ(pool.numOpenConnections(), 0);
+  EXPECT_EQ(extractCurrentMetric(), 0ull);
 
   pool.drainConnections();
+  ASSERT_EQ(pool.numOpenConnections(), 0);
+  EXPECT_EQ(extractCurrentMetric(), 0ull);
 
   {
     auto conn1 = pool.leaseConnection("tcp://example.org:80", isFromPool);
     ASSERT_EQ(pool.numOpenConnections(), 1);
+    EXPECT_EQ(extractCurrentMetric(), 1ull);
 
     auto conn2 = pool.leaseConnection("tcp://example.com:80", isFromPool);
     ASSERT_EQ(pool.numOpenConnections(), 2);
+    EXPECT_EQ(extractCurrentMetric(), 2ull);
   }
   ASSERT_EQ(pool.numOpenConnections(), 2);
+  EXPECT_EQ(extractCurrentMetric(), 2ull);
 
   // 21ms > 2 * 10ms
   std::this_thread::sleep_for(std::chrono::milliseconds(21));
@@ -395,20 +473,27 @@ TEST_F(NetworkConnectionPoolTest, checking_expiration_multiple_endpints) {
   // expires the connection
   pool.pruneConnections();
   ASSERT_EQ(pool.numOpenConnections(), 0);
+  EXPECT_EQ(extractCurrentMetric(), 0ull);
 
   pool.drainConnections();
+  ASSERT_EQ(pool.numOpenConnections(), 0);
+  EXPECT_EQ(extractCurrentMetric(), 0ull);
 
   {
     auto conn1 = pool.leaseConnection("tcp://example.org:80", isFromPool);
     ASSERT_EQ(pool.numOpenConnections(), 1);
+    EXPECT_EQ(extractCurrentMetric(), 1ull);
 
     auto conn2 = pool.leaseConnection("tcp://example.org:80", isFromPool);
     ASSERT_EQ(pool.numOpenConnections(), 2);
+    EXPECT_EQ(extractCurrentMetric(), 2ull);
 
     auto conn3 = pool.leaseConnection("tcp://example.com:80", isFromPool);
     ASSERT_EQ(pool.numOpenConnections(), 3);
+    EXPECT_EQ(extractCurrentMetric(), 3ull);
   }
   ASSERT_EQ(pool.numOpenConnections(), 3);
+  EXPECT_EQ(extractCurrentMetric(), 3ull);
 
   // 21ms > 2 * 10ms
   std::this_thread::sleep_for(std::chrono::milliseconds(21));
@@ -416,25 +501,33 @@ TEST_F(NetworkConnectionPoolTest, checking_expiration_multiple_endpints) {
   // expires the connections
   pool.pruneConnections();
   ASSERT_EQ(pool.numOpenConnections(), 0);
+  EXPECT_EQ(extractCurrentMetric(), 0ull);
 
   pool.drainConnections();
+  ASSERT_EQ(pool.numOpenConnections(), 0);
+  EXPECT_EQ(extractCurrentMetric(), 0ull);
 
   {
     auto conn1 = pool.leaseConnection("tcp://example.org:80", isFromPool);
     ASSERT_EQ(pool.numOpenConnections(), 1);
+    EXPECT_EQ(extractCurrentMetric(), 1ull);
 
     auto conn2 = pool.leaseConnection("tcp://example.org:80", isFromPool);
     ASSERT_EQ(pool.numOpenConnections(), 2);
+    EXPECT_EQ(extractCurrentMetric(), 2ull);
 
     auto conn3 = pool.leaseConnection("tcp://example.org:80", isFromPool);
     ASSERT_EQ(pool.numOpenConnections(), 3);
+    EXPECT_EQ(extractCurrentMetric(), 3ull);
   }
   {
     auto conn4 = pool.leaseConnection("tcp://example.com:80", isFromPool);
     ASSERT_EQ(pool.numOpenConnections(), 4);
+    EXPECT_EQ(extractCurrentMetric(), 4ull);
 
     auto conn5 = pool.leaseConnection("tcp://example.com:80", isFromPool);
     ASSERT_EQ(pool.numOpenConnections(), 5);
+    EXPECT_EQ(extractCurrentMetric(), 5ull);
 
     // 21ms > 2 * 10ms
     std::this_thread::sleep_for(std::chrono::milliseconds(21));
@@ -442,21 +535,28 @@ TEST_F(NetworkConnectionPoolTest, checking_expiration_multiple_endpints) {
     // expires the connections
     pool.pruneConnections();
     ASSERT_EQ(pool.numOpenConnections(), 2);
+    EXPECT_EQ(extractCurrentMetric(), 2ull);
   }
 
   pool.drainConnections();
+  ASSERT_EQ(pool.numOpenConnections(), 0);
+  EXPECT_EQ(extractCurrentMetric(), 0ull);
 
   {
     auto conn1 = pool.leaseConnection("tcp://example.org:80", isFromPool);
     ASSERT_EQ(pool.numOpenConnections(), 1);
+    EXPECT_EQ(extractCurrentMetric(), 1ull);
 
     auto conn2 = pool.leaseConnection("tcp://example.com:80", isFromPool);
     ASSERT_EQ(pool.numOpenConnections(), 2);
+    EXPECT_EQ(extractCurrentMetric(), 2ull);
 
     auto conn3 = pool.leaseConnection("tcp://example.net:80", isFromPool);
     ASSERT_EQ(pool.numOpenConnections(), 3);
+    EXPECT_EQ(extractCurrentMetric(), 3ull);
   }
   ASSERT_EQ(pool.numOpenConnections(), 3);
+  EXPECT_EQ(extractCurrentMetric(), 3ull);
 
   // 21ms > 2 * 10ms
   std::this_thread::sleep_for(std::chrono::milliseconds(21));
@@ -464,8 +564,103 @@ TEST_F(NetworkConnectionPoolTest, checking_expiration_multiple_endpints) {
   // expires the connections
   pool.pruneConnections();
   ASSERT_EQ(pool.numOpenConnections(), 0);
+  EXPECT_EQ(extractCurrentMetric(), 0ull);
 
   pool.drainConnections();
+  ASSERT_EQ(pool.numOpenConnections(), 0);
+  EXPECT_EQ(extractCurrentMetric(), 0ull);
+}
+
+TEST_F(NetworkConnectionPoolTest, test_cancel_endpoint_all) {
+  ConnectionPool::Config config(server.getFeature<metrics::MetricsFeature>());
+  config.numIOThreads = 1;
+  config.maxOpenConnections = 2;
+  config.idleConnectionMilli = 10;  // extra small for testing
+  config.verifyHosts = false;
+  config.protocol = fuerte::ProtocolType::Http;
+
+  ConnectionPool pool(config);
+
+  bool isFromPool;
+  {
+    auto conn1 = pool.leaseConnection("tcp://example.org:80", isFromPool);
+    EXPECT_FALSE(isFromPool);
+    EXPECT_EQ(pool.numOpenConnections(), 1);
+    EXPECT_EQ(extractCurrentMetric(), 1ull);
+
+    auto conn2 = pool.leaseConnection("tcp://example.org:80", isFromPool);
+    EXPECT_FALSE(isFromPool);
+    EXPECT_EQ(pool.numOpenConnections(), 2);
+    EXPECT_EQ(extractCurrentMetric(), 2ull);
+
+    auto conn3 = pool.leaseConnection("tcp://example.org:80", isFromPool);
+    EXPECT_FALSE(isFromPool);
+    EXPECT_EQ(pool.numOpenConnections(), 3);
+    EXPECT_EQ(extractCurrentMetric(), 3ull);
+  }
+  EXPECT_EQ(pool.numOpenConnections(), 3);
+  EXPECT_EQ(extractCurrentMetric(), 3ull);
+
+  // cancel all connections
+  pool.cancelConnections("tcp://example.org:80");
+  EXPECT_EQ(pool.numOpenConnections(), 0);
+  EXPECT_EQ(extractCurrentMetric(), 0ull);
+}
+
+TEST_F(NetworkConnectionPoolTest, test_cancel_endpoint_some) {
+  std::string endpointA = "tcp://example.org:80";
+  std::string endpointB = "tcp://example.org:800";
+  ConnectionPool::Config config(server.getFeature<metrics::MetricsFeature>());
+  config.numIOThreads = 1;
+  config.maxOpenConnections = 2;
+  config.idleConnectionMilli = 10;  // extra small for testing
+  config.verifyHosts = false;
+  config.protocol = fuerte::ProtocolType::Http;
+
+  ConnectionPool pool(config);
+
+  bool isFromPool;
+  {
+    auto conn1 = pool.leaseConnection(endpointA, isFromPool);
+    EXPECT_FALSE(isFromPool);
+    EXPECT_EQ(pool.numOpenConnections(), 1);
+    EXPECT_EQ(extractCurrentMetric(), 1ull);
+
+    auto conn2 = pool.leaseConnection(endpointB, isFromPool);
+    EXPECT_FALSE(isFromPool);
+    EXPECT_EQ(pool.numOpenConnections(), 2);
+    EXPECT_EQ(extractCurrentMetric(), 2ull);
+
+    auto conn3 = pool.leaseConnection(endpointA, isFromPool);
+    EXPECT_FALSE(isFromPool);
+    EXPECT_EQ(pool.numOpenConnections(), 3);
+    EXPECT_EQ(extractCurrentMetric(), 3ull);
+
+    auto conn4 = pool.leaseConnection(endpointB, isFromPool);
+    EXPECT_FALSE(isFromPool);
+    EXPECT_EQ(pool.numOpenConnections(), 4);
+    EXPECT_EQ(extractCurrentMetric(), 4ull);
+
+    auto conn5 = pool.leaseConnection(endpointA, isFromPool);
+    EXPECT_FALSE(isFromPool);
+    EXPECT_EQ(pool.numOpenConnections(), 5);
+    EXPECT_EQ(extractCurrentMetric(), 5ull);
+  }
+  // 3 from A, 2 from B
+  EXPECT_EQ(pool.numOpenConnections(), 5);
+  EXPECT_EQ(extractCurrentMetric(), 5ull);
+
+  // cancel all connections from endpointA
+  pool.cancelConnections(endpointA);
+  // The connections to endpointB stay intact
+  EXPECT_EQ(pool.numOpenConnections(), 2);
+  EXPECT_EQ(extractCurrentMetric(), 2ull);
+
+  // cancel all connections from endpointB
+  pool.cancelConnections(endpointB);
+  // No connections left
+  EXPECT_EQ(pool.numOpenConnections(), 0);
+  EXPECT_EQ(extractCurrentMetric(), 0ull);
 }
 
 }  // namespace tests


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/18394

The metric for the number of connections in the pool (arangodb_connection_pool_connections_current) was not counted down properly in case all connections to a specific endpoint (IP address + port) were canceled. Cancelation happens when another DB server or coordinator, identified by its IP address + port, is identified as “failed”. That happens, for example, a few seconds after a process crash or after a process is being OOM-killed by the OOM killer.

In this cases, the connections to the failed server were correctly closed, but the metric for the number of connections in the pool was not counted down at all. So even though the connections were effectively gone, due to the wrong metric values returned, it may have seemed that connections were leaked.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [x] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.10: this PR
  - [x] Backport for 3.9: https://github.com/arangodb/arangodb/pull/18411
  - [x] Backport for 3.8: https://github.com/arangodb/arangodb/pull/18412

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 