### PR TITLE
BTS-1272: correct counting of connections in pool

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,13 @@
+v3.9.11 (XXXX-XX-XX)
+--------------------
+
+* BTS-1272: Fixed metric `arangodb_connection_pool_connections_current`. In
+  some cases where multiple connections to a server are canceled the metric
+  could miss-count, as for now it only counted individually closed connections.
+  The wrong counted situations are: other server crashes, restore of a HotBackup,
+  rotation of JWT secret.
+
+
 v3.9.10 (2023-03-16)
 --------------------
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,11 +1,11 @@
 v3.9.11 (XXXX-XX-XX)
 --------------------
 
-* BTS-1272: Fixed metric `arangodb_connection_pool_connections_current`. In
-  some cases where multiple connections to a server are canceled the metric
-  could miss-count, as for now it only counted individually closed connections.
-  The wrong counted situations are: other server crashes, restore of a HotBackup,
-  rotation of JWT secret.
+* BTS-1272: Fixed metric `arangodb_connection_pool_connections_current`. In some
+  cases where multiple connections to a server are canceled the metric could
+  miss-count, as for now it only counted individually closed connections.
+  The wrong counted situations are: other server crashes, restore of a
+  HotBackup, rotation of JWT secret.
 
 
 v3.9.10 (2023-03-16)

--- a/arangod/Network/ConnectionPool.cpp
+++ b/arangod/Network/ConnectionPool.cpp
@@ -96,11 +96,16 @@ network::ConnectionPtr ConnectionPool::leaseConnection(
 /// @brief drain all connections
 void ConnectionPool::drainConnections() {
   WRITE_LOCKER(guard, _lock);
+  size_t n = 0;
   for (auto& pair : _connections) {
     Bucket& buck = *(pair.second);
     std::lock_guard<std::mutex> lock(buck.mutex);
+    n += buck.list.size();
     buck.list.clear();
   }
+  // We drop everything.
+  TRI_ASSERT(_totalConnectionsInPool.load() == n);
+  _totalConnectionsInPool -= n;
   _connections.clear();
 }
 
@@ -182,6 +187,10 @@ size_t ConnectionPool::cancelConnections(std::string const& endpoint) {
       }
     }
     _connections.erase(it);
+    // We just erased `n` connections on the bucket.
+    // Let's count it.
+    TRI_ASSERT(_totalConnectionsInPool.load() >= n);
+    _totalConnectionsInPool -= n;
     return n;
   }
   return 0;

--- a/arangod/Network/ConnectionPool.h
+++ b/arangod/Network/ConnectionPool.h
@@ -102,6 +102,10 @@ class ConnectionPool final {
 
   Config const& config() const;
 
+  uint64_t totalConnectionsInPool() const {
+    return _totalConnectionsInPool.load();
+  }
+
  protected:
   struct Context {
     Context(std::shared_ptr<fuerte::Connection>,


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/18394

The metric for the number of connections in the pool (arangodb_connection_pool_connections_current) was not counted down properly in case all connections to a specific endpoint (IP address + port) were canceled. Cancelation happens when another DB server or coordinator, identified by its IP address + port, is identified as “failed”. That happens, for example, a few seconds after a process crash or after a process is being OOM-killed by the OOM killer.

In this cases, the connections to the failed server were correctly closed, but the metric for the number of connections in the pool was not counted down at all. So even though the connections were effectively gone, due to the wrong metric values returned, it may have seemed that connections were leaked.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [x] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.10: https://github.com/arangodb/arangodb/pull/18410
  - [x] Backport for 3.9: this PR
  - [x] Backport for 3.8: https://github.com/arangodb/arangodb/pull/18412

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 