### PR TITLE
BTS-1272: correct counting of connections in pool

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,12 @@
 v3.8.9 (XXXX-XX-XX)
 -------------------
 
+* BTS-1272: Fixed metric `arangodb_connection_pool_connections_current`. In
+  some cases where multiple connections to a server are canceled the metric
+  could miss-count, as for now it only counted individually closed connections.
+  The wrong counted situations are: other server crashes, restore of a HotBackup,
+  rotation of JWT secret.
+
 * Updated arangosync to v2.15.0.
 
 * Fixed a bug in the API used by `arangorestore`: On restore, a new _rev value

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,11 +1,11 @@
 v3.8.9 (XXXX-XX-XX)
 -------------------
 
-* BTS-1272: Fixed metric `arangodb_connection_pool_connections_current`. In
-  some cases where multiple connections to a server are canceled the metric
-  could miss-count, as for now it only counted individually closed connections.
-  The wrong counted situations are: other server crashes, restore of a HotBackup,
-  rotation of JWT secret.
+* BTS-1272: Fixed metric `arangodb_connection_pool_connections_current`. In some
+  cases where multiple connections to a server are canceled the metric could
+  miss-count, as for now it only counted individually closed connections.
+  The wrong counted situations are: other server crashes, restore of a
+  HotBackup, rotation of JWT secret.
 
 * Updated arangosync to v2.15.0.
 

--- a/arangod/Network/ConnectionPool.cpp
+++ b/arangod/Network/ConnectionPool.cpp
@@ -96,11 +96,16 @@ network::ConnectionPtr ConnectionPool::leaseConnection(std::string const& endpoi
 /// @brief drain all connections
 void ConnectionPool::drainConnections() {
   WRITE_LOCKER(guard, _lock);
+  size_t n = 0;
   for (auto& pair : _connections) {
     Bucket& buck = *(pair.second);
     std::lock_guard<std::mutex> lock(buck.mutex);
+    n += buck.list.size();
     buck.list.clear();
   }
+  // We drop everything.
+  TRI_ASSERT(_totalConnectionsInPool.load() == n);
+  _totalConnectionsInPool -= n;
   _connections.clear();
 }
 
@@ -182,6 +187,10 @@ size_t ConnectionPool::cancelConnections(std::string const& endpoint) {
       }
     }
     _connections.erase(it);
+    // We just erased `n` connections on the bucket.
+    // Let's count it.
+    TRI_ASSERT(_totalConnectionsInPool.load() >= n);
+    _totalConnectionsInPool -= n;
     return n;
   }
   return 0;

--- a/arangod/Network/ConnectionPool.h
+++ b/arangod/Network/ConnectionPool.h
@@ -102,6 +102,10 @@ class ConnectionPool final {
   size_t numOpenConnections() const;
 
   Config const& config() const;
+  
+  uint64_t totalConnectionsInPool() const {
+    return _totalConnectionsInPool.load();
+  }
 
  protected:
 

--- a/tests/Network/ConnectionPoolTest.cpp
+++ b/tests/Network/ConnectionPoolTest.cpp
@@ -36,430 +36,619 @@ using namespace arangodb::network;
 namespace {
 
 void doNothing(fuerte::Error, std::unique_ptr<fuerte::Request> req,
-              std::unique_ptr<fuerte::Response> res) {
+               std::unique_ptr<fuerte::Response> res) {
   std::this_thread::sleep_for(std::chrono::milliseconds(10));
 };
-}
+}  // namespace
 
 namespace arangodb {
 namespace tests {
 
-struct NetworkConnectionPoolTest
-    : public ::testing::Test {
-  NetworkConnectionPoolTest() : server(false) {
-    server.startFeatures();
-  }
+struct NetworkConnectionPoolTest : public ::testing::Test {
+  NetworkConnectionPoolTest() : server(false) { server.startFeatures(); }
+
  protected:
+  MetricsFeature& metrics() { return server.getFeature<MetricsFeature>(); }
+
   tests::mocks::MockMetricsServer server;
 };
 
 TEST_F(NetworkConnectionPoolTest, acquire_endpoint) {
-  ConnectionPool::Config config(server.getFeature<MetricsFeature>());
+  ConnectionPool::Config config(metrics());
   config.numIOThreads = 1;
   config.maxOpenConnections = 3;
-  config.idleConnectionMilli = 10; // extra small for testing
+  config.idleConnectionMilli = 10;  // extra small for testing
   config.verifyHosts = false;
   config.protocol = fuerte::ProtocolType::Http;
-  
   ConnectionPool pool(config);
   std::this_thread::sleep_for(std::chrono::seconds(1));
-  
+
   bool isFromPool;
   auto conn = pool.leaseConnection("tcp://example.org:80", isFromPool);
   ASSERT_EQ(pool.numOpenConnections(), 1);
-  auto req = fuerte::createRequest(fuerte::RestVerb::Get, fuerte::ContentType::Unset);
+  EXPECT_EQ(pool.totalConnectionsInPool(), 1ull);
+  auto req =
+      fuerte::createRequest(fuerte::RestVerb::Get, fuerte::ContentType::Unset);
   auto res = conn->sendRequest(std::move(req));
   ASSERT_EQ(res->statusCode(), fuerte::StatusOK);
   ASSERT_TRUE(res->payloadSize() > 0);
 }
 
 TEST_F(NetworkConnectionPoolTest, acquire_multiple_endpoint) {
-  ConnectionPool::Config config(server.getFeature<MetricsFeature>());
+  ConnectionPool::Config config(metrics());
   config.numIOThreads = 1;
   config.maxOpenConnections = 3;
-  config.idleConnectionMilli = 10; // extra small for testing
+  config.idleConnectionMilli = 10;  // extra small for testing
   config.verifyHosts = false;
   config.protocol = fuerte::ProtocolType::Http;
-  
+
   ConnectionPool pool(config);
   std::this_thread::sleep_for(std::chrono::seconds(1));
-  
+
   bool isFromPool;
   auto conn1 = pool.leaseConnection("tcp://example.org:80", isFromPool);
-  
-  conn1->sendRequest(fuerte::createRequest(fuerte::RestVerb::Get,
-                                           fuerte::ContentType::Unset), doNothing);
-  
+
+  conn1->sendRequest(
+      fuerte::createRequest(fuerte::RestVerb::Get, fuerte::ContentType::Unset),
+      doNothing);
+
   auto conn2 = pool.leaseConnection("tcp://example.org:80", isFromPool);
-  
+
   ASSERT_NE(conn1.get(), conn2.get());
   ASSERT_EQ(pool.numOpenConnections(), 2);
-  
+  EXPECT_EQ(pool.totalConnectionsInPool(), 2ull);
+
   auto conn3 = pool.leaseConnection("tcp://example.com:80", isFromPool);
   ASSERT_NE(conn1.get(), conn3.get());
-  
+
   ASSERT_EQ(pool.numOpenConnections(), 3);
+  EXPECT_EQ(pool.totalConnectionsInPool(), 3ull);
 }
 
 TEST_F(NetworkConnectionPoolTest, release_multiple_endpoints_one) {
   ConnectionPool::Config config(server.getFeature<MetricsFeature>());
   config.numIOThreads = 1;
   config.maxOpenConnections = 3;
-  config.idleConnectionMilli = 5; // extra small for testing
+  config.idleConnectionMilli = 5;  // extra small for testing
   config.verifyHosts = false;
   config.protocol = fuerte::ProtocolType::Http;
-  
+
   ConnectionPool pool(config);
 
   {
     bool isFromPool;
     auto conn1 = pool.leaseConnection("tcp://example.org:80", isFromPool);
     ASSERT_EQ(pool.numOpenConnections(), 1);
+    EXPECT_EQ(pool.totalConnectionsInPool(), 1ull);
     conn1->sendRequest(fuerte::createRequest(fuerte::RestVerb::Get,
-                                             fuerte::ContentType::Unset), doNothing);
-    
+                                             fuerte::ContentType::Unset),
+                       doNothing);
+
     auto conn2 = pool.leaseConnection("tcp://example.com:80", isFromPool);
     ASSERT_NE(conn1.get(), conn2.get());
     ASSERT_EQ(pool.numOpenConnections(), 2);
+    EXPECT_EQ(pool.totalConnectionsInPool(), 2ull);
   }
   ASSERT_EQ(pool.numOpenConnections(), 2);
-  
+  EXPECT_EQ(pool.totalConnectionsInPool(), 2ull);
+
   std::this_thread::sleep_for(std::chrono::milliseconds(15));
   pool.pruneConnections();
-  
-  ASSERT_EQ(pool.numOpenConnections(), 1); // keep one busy connection
+
+  ASSERT_EQ(pool.numOpenConnections(), 1);  // keep one busy connection
+  EXPECT_EQ(pool.totalConnectionsInPool(), 1ull);
 }
 
 TEST_F(NetworkConnectionPoolTest, release_multiple_endpoints_two) {
-  ConnectionPool::Config config(server.getFeature<MetricsFeature>());
+  ConnectionPool::Config config(metrics());
   config.numIOThreads = 1;
   config.maxOpenConnections = 3;
-  config.idleConnectionMilli = 10; // extra small for testing
+  config.idleConnectionMilli = 10;  // extra small for testing
   config.verifyHosts = false;
   config.protocol = fuerte::ProtocolType::Http;
-  
+
   ConnectionPool pool(config);
   std::this_thread::sleep_for(std::chrono::seconds(1));
-  
+
   bool isFromPool;
   {
     auto conn1 = pool.leaseConnection("tcp://example.org:80", isFromPool);
     ASSERT_EQ(pool.numOpenConnections(), 1);
+    EXPECT_EQ(pool.totalConnectionsInPool(), 1ull);
     conn1->sendRequest(fuerte::createRequest(fuerte::RestVerb::Get,
-                                             fuerte::ContentType::Unset), doNothing);
-    
+                                             fuerte::ContentType::Unset),
+                       doNothing);
+
     auto conn2 = pool.leaseConnection("tcp://example.com:80", isFromPool);
     ASSERT_NE(conn1.get(), conn2.get());
     ASSERT_EQ(pool.numOpenConnections(), 2);
+    EXPECT_EQ(pool.totalConnectionsInPool(), 2ull);
   }
   ASSERT_EQ(pool.numOpenConnections(), 2);
-  
+  EXPECT_EQ(pool.totalConnectionsInPool(), 2ull);
+
   std::this_thread::sleep_for(std::chrono::milliseconds(21));
   // this will only expire conn2 (conn1 is still in use)
   pool.pruneConnections();
   ASSERT_EQ(pool.numOpenConnections(), 1);
+  EXPECT_EQ(pool.totalConnectionsInPool(), 1ull);
 
   pool.drainConnections();
-  
-  {
 
+  // Drain needs to erase all connections
+  ASSERT_EQ(pool.numOpenConnections(), 0);
+  EXPECT_EQ(pool.totalConnectionsInPool(), 0ull);
+  {
     auto conn1 = pool.leaseConnection("tcp://example.org:80", isFromPool);
     ASSERT_EQ(pool.numOpenConnections(), 1);
-    
+    EXPECT_EQ(pool.totalConnectionsInPool(), 1ull);
+
     auto conn2 = pool.leaseConnection("tcp://example.com:80", isFromPool);
     ASSERT_NE(conn1.get(), conn2.get());
     ASSERT_EQ(pool.numOpenConnections(), 2);
+    EXPECT_EQ(pool.totalConnectionsInPool(), 2ull);
   }
   ASSERT_EQ(pool.numOpenConnections(), 2);
-  
+  EXPECT_EQ(pool.totalConnectionsInPool(), 2ull);
+
   std::this_thread::sleep_for(std::chrono::milliseconds(21));
   pool.pruneConnections();
   ASSERT_EQ(pool.numOpenConnections(), 0);
+  EXPECT_EQ(pool.totalConnectionsInPool(), 0ull);
 
   pool.drainConnections();
-  
+  EXPECT_EQ(pool.totalConnectionsInPool(), 0ull);
+
   {
     auto conn1 = pool.leaseConnection("tcp://example.org:80", isFromPool);
     ASSERT_EQ(pool.numOpenConnections(), 1);
+    EXPECT_EQ(pool.totalConnectionsInPool(), 1ull);
     conn1->sendRequest(fuerte::createRequest(fuerte::RestVerb::Get,
-                                             fuerte::ContentType::Unset), doNothing);
-    
+                                             fuerte::ContentType::Unset),
+                       doNothing);
+
     auto conn2 = pool.leaseConnection("tcp://example.com:80", isFromPool);
     ASSERT_NE(conn1.get(), conn2.get());
     ASSERT_EQ(pool.numOpenConnections(), 2);
-    
+    EXPECT_EQ(pool.totalConnectionsInPool(), 2ull);
+
     conn2->sendRequest(fuerte::createRequest(fuerte::RestVerb::Get,
-                                             fuerte::ContentType::Unset), doNothing);
+                                             fuerte::ContentType::Unset),
+                       doNothing);
   }
   ASSERT_EQ(pool.numOpenConnections(), 2);
-  
+  EXPECT_EQ(pool.totalConnectionsInPool(), 2ull);
+
   std::this_thread::sleep_for(std::chrono::milliseconds(21));
   pool.pruneConnections();
   ASSERT_EQ(pool.numOpenConnections(), 2);
-  
+  EXPECT_EQ(pool.totalConnectionsInPool(), 2ull);
+
   pool.drainConnections();
+  ASSERT_EQ(pool.numOpenConnections(), 0);
+  EXPECT_EQ(pool.totalConnectionsInPool(), 0ull);
 }
 
 TEST_F(NetworkConnectionPoolTest, checking_min_and_max_connections) {
-  ConnectionPool::Config config(server.getFeature<MetricsFeature>());
+  ConnectionPool::Config config(metrics());
   config.numIOThreads = 1;
   config.maxOpenConnections = 2;
-  config.idleConnectionMilli = 10; // extra small for testing
+  config.idleConnectionMilli = 10;  // extra small for testing
   config.verifyHosts = false;
   config.protocol = fuerte::ProtocolType::Http;
-  
+
   ConnectionPool pool(config);
   std::this_thread::sleep_for(std::chrono::seconds(1));
-  
+
   bool isFromPool;
   {
     auto conn1 = pool.leaseConnection("tcp://example.org:80", isFromPool);
     ASSERT_EQ(pool.numOpenConnections(), 1);
-    
+    EXPECT_EQ(pool.totalConnectionsInPool(), 1ull);
+
     conn1->sendRequest(fuerte::createRequest(fuerte::RestVerb::Get,
-                                             fuerte::ContentType::Unset), doNothing);
-   
+                                             fuerte::ContentType::Unset),
+                       doNothing);
+
     auto conn2 = pool.leaseConnection("tcp://example.org:80", isFromPool);
     ASSERT_NE(conn1.get(), conn2.get());
     ASSERT_EQ(pool.numOpenConnections(), 2);
-    
+    EXPECT_EQ(pool.totalConnectionsInPool(), 2ull);
+
     conn2->sendRequest(fuerte::createRequest(fuerte::RestVerb::Get,
-                                             fuerte::ContentType::Unset), doNothing);
-    
+                                             fuerte::ContentType::Unset),
+                       doNothing);
+
     auto conn3 = pool.leaseConnection("tcp://example.org:80", isFromPool);
     ASSERT_NE(conn1.get(), conn3.get());
     ASSERT_NE(conn1.get(), conn2.get());
     ASSERT_EQ(pool.numOpenConnections(), 3);
+    EXPECT_EQ(pool.totalConnectionsInPool(), 3ull);
   }
   ASSERT_EQ(pool.numOpenConnections(), 3);
-  
+  EXPECT_EQ(pool.totalConnectionsInPool(), 3ull);
+
   // 21ms > 2 * 10ms
   std::this_thread::sleep_for(std::chrono::milliseconds(21));
 
   // this will only expire conn3 (conn1 and conn2 are still in use)
   pool.pruneConnections();
   ASSERT_EQ(pool.numOpenConnections(), 2);
+  EXPECT_EQ(pool.totalConnectionsInPool(), 2ull);
 
   pool.drainConnections();
-  
+  ASSERT_EQ(pool.numOpenConnections(), 0);
+  EXPECT_EQ(pool.totalConnectionsInPool(), 0ull);
+
   {
     auto conn1 = pool.leaseConnection("tcp://example.org:80", isFromPool);
     ASSERT_EQ(pool.numOpenConnections(), 1);
-    
+    EXPECT_EQ(pool.totalConnectionsInPool(), 1ull);
+
     conn1->sendRequest(fuerte::createRequest(fuerte::RestVerb::Get,
-                                             fuerte::ContentType::Unset), doNothing);
-   
+                                             fuerte::ContentType::Unset),
+                       doNothing);
+
     auto conn2 = pool.leaseConnection("tcp://example.org:80", isFromPool);
     ASSERT_NE(conn1.get(), conn2.get());
     ASSERT_EQ(pool.numOpenConnections(), 2);
-    
+    EXPECT_EQ(pool.totalConnectionsInPool(), 2ull);
+
     conn2->sendRequest(fuerte::createRequest(fuerte::RestVerb::Get,
-                                             fuerte::ContentType::Unset), doNothing);
-    
+                                             fuerte::ContentType::Unset),
+                       doNothing);
+
     auto conn3 = pool.leaseConnection("tcp://example.org:80", isFromPool);
     ASSERT_NE(conn1.get(), conn3.get());
     ASSERT_NE(conn1.get(), conn2.get());
     ASSERT_EQ(pool.numOpenConnections(), 3);
-    
+    EXPECT_EQ(pool.totalConnectionsInPool(), 3ull);
+
     conn3->sendRequest(fuerte::createRequest(fuerte::RestVerb::Get,
-                                             fuerte::ContentType::Unset), doNothing);
+                                             fuerte::ContentType::Unset),
+                       doNothing);
   }
   ASSERT_EQ(pool.numOpenConnections(), 3);
-  
+  EXPECT_EQ(pool.totalConnectionsInPool(), 3ull);
+
   // 21ms > 2 * 10ms
   std::this_thread::sleep_for(std::chrono::milliseconds(21));
 
   pool.pruneConnections();
   ASSERT_EQ(pool.numOpenConnections(), 3);
+  EXPECT_EQ(pool.totalConnectionsInPool(), 3ull);
 
   pool.drainConnections();
+  ASSERT_EQ(pool.numOpenConnections(), 0);
+  EXPECT_EQ(pool.totalConnectionsInPool(), 0ull);
 }
 
 TEST_F(NetworkConnectionPoolTest, checking_expiration) {
   ConnectionPool::Config config(server.getFeature<MetricsFeature>());
   config.numIOThreads = 1;
   config.maxOpenConnections = 2;
-  config.idleConnectionMilli = 10; // extra small for testing
+  config.idleConnectionMilli = 10;  // extra small for testing
   config.verifyHosts = false;
   config.protocol = fuerte::ProtocolType::Http;
-  
+
   ConnectionPool pool(config);
   std::this_thread::sleep_for(std::chrono::seconds(1));
-  
+
   bool isFromPool;
   {
     auto conn1 = pool.leaseConnection("tcp://example.org:80", isFromPool);
     ASSERT_EQ(pool.numOpenConnections(), 1);
+    EXPECT_EQ(pool.totalConnectionsInPool(), 1ull);
   }
   ASSERT_EQ(pool.numOpenConnections(), 1);
-  
+  EXPECT_EQ(pool.totalConnectionsInPool(), 1ull);
+
   // 21ms > 2 * 10ms
   std::this_thread::sleep_for(std::chrono::milliseconds(21));
 
   // expires the connection
   pool.pruneConnections();
   ASSERT_EQ(pool.numOpenConnections(), 0);
-  
+  EXPECT_EQ(pool.totalConnectionsInPool(), 0ull);
+
   pool.drainConnections();
-  
+  ASSERT_EQ(pool.numOpenConnections(), 0);
+  EXPECT_EQ(pool.totalConnectionsInPool(), 0ull);
+
   {
     auto conn1 = pool.leaseConnection("tcp://example.org:80", isFromPool);
     ASSERT_EQ(pool.numOpenConnections(), 1);
-    
+    EXPECT_EQ(pool.totalConnectionsInPool(), 1ull);
+
     auto conn2 = pool.leaseConnection("tcp://example.org:80", isFromPool);
     ASSERT_EQ(pool.numOpenConnections(), 2);
+    EXPECT_EQ(pool.totalConnectionsInPool(), 2ull);
   }
   ASSERT_EQ(pool.numOpenConnections(), 2);
-  
+  EXPECT_EQ(pool.totalConnectionsInPool(), 2ull);
+
   // 21ms > 2 * 10ms
   std::this_thread::sleep_for(std::chrono::milliseconds(21));
 
   // expires the connections
   pool.pruneConnections();
   ASSERT_EQ(pool.numOpenConnections(), 0);
+  EXPECT_EQ(pool.totalConnectionsInPool(), 0ull);
 
   pool.drainConnections();
-  
+  EXPECT_EQ(pool.totalConnectionsInPool(), 0ull);
+
   {
     auto conn1 = pool.leaseConnection("tcp://example.org:80", isFromPool);
     ASSERT_EQ(pool.numOpenConnections(), 1);
-    
+    EXPECT_EQ(pool.totalConnectionsInPool(), 1ull);
+
     auto conn2 = pool.leaseConnection("tcp://example.org:80", isFromPool);
     ASSERT_EQ(pool.numOpenConnections(), 2);
-    
+    EXPECT_EQ(pool.totalConnectionsInPool(), 2ull);
+
     auto conn3 = pool.leaseConnection("tcp://example.org:80", isFromPool);
     ASSERT_EQ(pool.numOpenConnections(), 3);
+    EXPECT_EQ(pool.totalConnectionsInPool(), 3ull);
   }
   ASSERT_EQ(pool.numOpenConnections(), 3);
-  
+  EXPECT_EQ(pool.totalConnectionsInPool(), 3ull);
+
   // 21ms > 2 * 10ms
   std::this_thread::sleep_for(std::chrono::milliseconds(21));
 
   // expires the connections
   pool.pruneConnections();
   ASSERT_EQ(pool.numOpenConnections(), 0);
-  
+  EXPECT_EQ(pool.totalConnectionsInPool(), 0ull);
+
   pool.drainConnections();
+  EXPECT_EQ(pool.totalConnectionsInPool(), 0ull);
 }
 
 TEST_F(NetworkConnectionPoolTest, checking_expiration_multiple_endpints) {
   ConnectionPool::Config config(server.getFeature<MetricsFeature>());
   config.numIOThreads = 1;
   config.maxOpenConnections = 2;
-  config.idleConnectionMilli = 10; // extra small for testing
+  config.idleConnectionMilli = 10;  // extra small for testing
   config.verifyHosts = false;
   config.protocol = fuerte::ProtocolType::Http;
-  
+
   ConnectionPool pool(config);
   std::this_thread::sleep_for(std::chrono::seconds(1));
-  
+
   bool isFromPool;
   {
     auto conn1 = pool.leaseConnection("tcp://example.org:80", isFromPool);
     ASSERT_EQ(pool.numOpenConnections(), 1);
-    
+    EXPECT_EQ(pool.totalConnectionsInPool(), 1ull);
+
     auto conn2 = pool.leaseConnection("tcp://example.org:80", isFromPool);
     ASSERT_EQ(pool.numOpenConnections(), 2);
+    EXPECT_EQ(pool.totalConnectionsInPool(), 2ull);
   }
   ASSERT_EQ(pool.numOpenConnections(), 2);
-  
+  EXPECT_EQ(pool.totalConnectionsInPool(), 2ull);
+
   // 21ms > 2 * 10ms
   std::this_thread::sleep_for(std::chrono::milliseconds(21));
 
   // expires the connection(s)
   pool.pruneConnections();
   ASSERT_EQ(pool.numOpenConnections(), 0);
+  EXPECT_EQ(pool.totalConnectionsInPool(), 0ull);
 
   pool.drainConnections();
-  
+  ASSERT_EQ(pool.numOpenConnections(), 0);
+  EXPECT_EQ(pool.totalConnectionsInPool(), 0ull);
+
   {
     auto conn1 = pool.leaseConnection("tcp://example.org:80", isFromPool);
     ASSERT_EQ(pool.numOpenConnections(), 1);
-    
+    EXPECT_EQ(pool.totalConnectionsInPool(), 1ull);
+
     auto conn2 = pool.leaseConnection("tcp://example.com:80", isFromPool);
     ASSERT_EQ(pool.numOpenConnections(), 2);
+    EXPECT_EQ(pool.totalConnectionsInPool(), 2ull);
   }
   ASSERT_EQ(pool.numOpenConnections(), 2);
-  
+  EXPECT_EQ(pool.totalConnectionsInPool(), 2ull);
+
   // 21ms > 2 * 10ms
   std::this_thread::sleep_for(std::chrono::milliseconds(21));
 
   // expires the connection
   pool.pruneConnections();
   ASSERT_EQ(pool.numOpenConnections(), 0);
+  EXPECT_EQ(pool.totalConnectionsInPool(), 0ull);
 
   pool.drainConnections();
-  
+  ASSERT_EQ(pool.numOpenConnections(), 0);
+  EXPECT_EQ(pool.totalConnectionsInPool(), 0ull);
+
   {
     auto conn1 = pool.leaseConnection("tcp://example.org:80", isFromPool);
     ASSERT_EQ(pool.numOpenConnections(), 1);
-    
+    EXPECT_EQ(pool.totalConnectionsInPool(), 1ull);
+
     auto conn2 = pool.leaseConnection("tcp://example.org:80", isFromPool);
     ASSERT_EQ(pool.numOpenConnections(), 2);
-    
+    EXPECT_EQ(pool.totalConnectionsInPool(), 2ull);
+
     auto conn3 = pool.leaseConnection("tcp://example.com:80", isFromPool);
     ASSERT_EQ(pool.numOpenConnections(), 3);
+    EXPECT_EQ(pool.totalConnectionsInPool(), 3ull);
   }
   ASSERT_EQ(pool.numOpenConnections(), 3);
-  
+  EXPECT_EQ(pool.totalConnectionsInPool(), 3ull);
+
   // 21ms > 2 * 10ms
   std::this_thread::sleep_for(std::chrono::milliseconds(21));
 
   // expires the connections
   pool.pruneConnections();
   ASSERT_EQ(pool.numOpenConnections(), 0);
-  
+  EXPECT_EQ(pool.totalConnectionsInPool(), 0ull);
+
   pool.drainConnections();
-  
+  ASSERT_EQ(pool.numOpenConnections(), 0);
+  EXPECT_EQ(pool.totalConnectionsInPool(), 0ull);
+
   {
     auto conn1 = pool.leaseConnection("tcp://example.org:80", isFromPool);
     ASSERT_EQ(pool.numOpenConnections(), 1);
-    
+    EXPECT_EQ(pool.totalConnectionsInPool(), 1ull);
+
     auto conn2 = pool.leaseConnection("tcp://example.org:80", isFromPool);
     ASSERT_EQ(pool.numOpenConnections(), 2);
-    
+    EXPECT_EQ(pool.totalConnectionsInPool(), 2ull);
+
     auto conn3 = pool.leaseConnection("tcp://example.org:80", isFromPool);
     ASSERT_EQ(pool.numOpenConnections(), 3);
-  }  
+    EXPECT_EQ(pool.totalConnectionsInPool(), 3ull);
+  }
   {
-    
     auto conn4 = pool.leaseConnection("tcp://example.com:80", isFromPool);
     ASSERT_EQ(pool.numOpenConnections(), 4);
-    
+    EXPECT_EQ(pool.totalConnectionsInPool(), 4ull);
+
     auto conn5 = pool.leaseConnection("tcp://example.com:80", isFromPool);
     ASSERT_EQ(pool.numOpenConnections(), 5);
-    
+    EXPECT_EQ(pool.totalConnectionsInPool(), 5ull);
+
     // 21ms > 2 * 10ms
     std::this_thread::sleep_for(std::chrono::milliseconds(21));
 
     // expires the connections
     pool.pruneConnections();
     ASSERT_EQ(pool.numOpenConnections(), 2);
+    EXPECT_EQ(pool.totalConnectionsInPool(), 2ull);
   }
-  
+
   pool.drainConnections();
-  
+  ASSERT_EQ(pool.numOpenConnections(), 0);
+  EXPECT_EQ(pool.totalConnectionsInPool(), 0ull);
+
   {
     auto conn1 = pool.leaseConnection("tcp://example.org:80", isFromPool);
     ASSERT_EQ(pool.numOpenConnections(), 1);
-    
+    EXPECT_EQ(pool.totalConnectionsInPool(), 1ull);
+
     auto conn2 = pool.leaseConnection("tcp://example.com:80", isFromPool);
     ASSERT_EQ(pool.numOpenConnections(), 2);
-    
+    EXPECT_EQ(pool.totalConnectionsInPool(), 2ull);
+
     auto conn3 = pool.leaseConnection("tcp://example.net:80", isFromPool);
     ASSERT_EQ(pool.numOpenConnections(), 3);
+    EXPECT_EQ(pool.totalConnectionsInPool(), 3ull);
   }
   ASSERT_EQ(pool.numOpenConnections(), 3);
-  
+  EXPECT_EQ(pool.totalConnectionsInPool(), 3ull);
+
   // 21ms > 2 * 10ms
   std::this_thread::sleep_for(std::chrono::milliseconds(21));
 
   // expires the connections
   pool.pruneConnections();
   ASSERT_EQ(pool.numOpenConnections(), 0);
-  
+  EXPECT_EQ(pool.totalConnectionsInPool(), 0ull);
+
   pool.drainConnections();
+  ASSERT_EQ(pool.numOpenConnections(), 0);
+  EXPECT_EQ(pool.totalConnectionsInPool(), 0ull);
 }
 
+TEST_F(NetworkConnectionPoolTest, test_cancel_endpoint_all) {
+  ConnectionPool::Config config(metrics());
+  config.numIOThreads = 1;
+  config.maxOpenConnections = 2;
+  config.idleConnectionMilli = 10;  // extra small for testing
+  config.verifyHosts = false;
+  config.protocol = fuerte::ProtocolType::Http;
+
+  ConnectionPool pool(config);
+
+  bool isFromPool;
+  {
+    auto conn1 = pool.leaseConnection("tcp://example.org:80", isFromPool);
+    EXPECT_FALSE(isFromPool);
+    EXPECT_EQ(pool.numOpenConnections(), 1);
+    EXPECT_EQ(pool.totalConnectionsInPool(), 1ull);
+
+    auto conn2 = pool.leaseConnection("tcp://example.org:80", isFromPool);
+    EXPECT_FALSE(isFromPool);
+    EXPECT_EQ(pool.numOpenConnections(), 2);
+    EXPECT_EQ(pool.totalConnectionsInPool(), 2ull);
+
+    auto conn3 = pool.leaseConnection("tcp://example.org:80", isFromPool);
+    EXPECT_FALSE(isFromPool);
+    EXPECT_EQ(pool.numOpenConnections(), 3);
+    EXPECT_EQ(pool.totalConnectionsInPool(), 3ull);
+  }
+  EXPECT_EQ(pool.numOpenConnections(), 3);
+  EXPECT_EQ(pool.totalConnectionsInPool(), 3ull);
+
+  // cancel all connections
+  pool.cancelConnections("tcp://example.org:80");
+  EXPECT_EQ(pool.numOpenConnections(), 0);
+  EXPECT_EQ(pool.totalConnectionsInPool(), 0ull);
 }
+
+TEST_F(NetworkConnectionPoolTest, test_cancel_endpoint_some) {
+  std::string endpointA = "tcp://example.org:80";
+  std::string endpointB = "tcp://example.org:800";
+  ConnectionPool::Config config(metrics());
+  config.numIOThreads = 1;
+  config.maxOpenConnections = 2;
+  config.idleConnectionMilli = 10;  // extra small for testing
+  config.verifyHosts = false;
+  config.protocol = fuerte::ProtocolType::Http;
+
+  ConnectionPool pool(config);
+
+  bool isFromPool;
+  {
+    auto conn1 = pool.leaseConnection(endpointA, isFromPool);
+    EXPECT_FALSE(isFromPool);
+    EXPECT_EQ(pool.numOpenConnections(), 1);
+    EXPECT_EQ(pool.totalConnectionsInPool(), 1ull);
+
+    auto conn2 = pool.leaseConnection(endpointB, isFromPool);
+    EXPECT_FALSE(isFromPool);
+    EXPECT_EQ(pool.numOpenConnections(), 2);
+    EXPECT_EQ(pool.totalConnectionsInPool(), 2ull);
+
+    auto conn3 = pool.leaseConnection(endpointA, isFromPool);
+    EXPECT_FALSE(isFromPool);
+    EXPECT_EQ(pool.numOpenConnections(), 3);
+    EXPECT_EQ(pool.totalConnectionsInPool(), 3ull);
+
+    auto conn4 = pool.leaseConnection(endpointB, isFromPool);
+    EXPECT_FALSE(isFromPool);
+    EXPECT_EQ(pool.numOpenConnections(), 4);
+    EXPECT_EQ(pool.totalConnectionsInPool(), 4ull);
+
+    auto conn5 = pool.leaseConnection(endpointA, isFromPool);
+    EXPECT_FALSE(isFromPool);
+    EXPECT_EQ(pool.numOpenConnections(), 5);
+    EXPECT_EQ(pool.totalConnectionsInPool(), 5ull);
+  }
+  // 3 from A, 2 from B
+  EXPECT_EQ(pool.numOpenConnections(), 5);
+  EXPECT_EQ(pool.totalConnectionsInPool(), 5ull);
+
+  // cancel all connections from endpointA
+  pool.cancelConnections(endpointA);
+  // The connections to endpointB stay intact
+  EXPECT_EQ(pool.numOpenConnections(), 2);
+  EXPECT_EQ(pool.totalConnectionsInPool(), 2ull);
+
+  // cancel all connections from endpointB
+  pool.cancelConnections(endpointB);
+  // No connections left
+  EXPECT_EQ(pool.numOpenConnections(), 0);
+  EXPECT_EQ(pool.totalConnectionsInPool(), 0ull);
 }
+
+}  // namespace tests
+}  // namespace arangodb


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/18394

The metric for the number of connections in the pool (arangodb_connection_pool_connections_current) was not counted down properly in case all connections to a specific endpoint (IP address + port) were canceled. Cancelation happens when another DB server or coordinator, identified by its IP address + port, is identified as “failed”. That happens, for example, a few seconds after a process crash or after a process is being OOM-killed by the OOM killer.

In this cases, the connections to the failed server were correctly closed, but the metric for the number of connections in the pool was not counted down at all. So even though the connections were effectively gone, due to the wrong metric values returned, it may have seemed that connections were leaked.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [x] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.10: https://github.com/arangodb/arangodb/pull/18410
  - [x] Backport for 3.9: https://github.com/arangodb/arangodb/pull/18411
  - [x] Backport for 3.8: this PR

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 