### PR TITLE
fix single-to-single replication with authentication

### DIFF
--- a/arangod/Replication/DatabaseInitialSyncer.cpp
+++ b/arangod/Replication/DatabaseInitialSyncer.cpp
@@ -159,7 +159,7 @@ arangodb::Result fetchRevisions(
     arangodb::DatabaseInitialSyncer::Configuration& config,
     arangodb::Syncer::SyncerState& state,
     arangodb::LogicalCollection& collection, std::string const& leader,
-    bool encodeAsHLC, std::vector<arangodb::RevisionId>& toFetch,
+    bool encodeAsHLC, std::vector<arangodb::RevisionId> const& toFetch,
     arangodb::ReplicationMetricsFeature::InitialSyncStats& stats) {
   using arangodb::PhysicalCollection;
   using arangodb::RestReplicationHandler;
@@ -187,7 +187,21 @@ arangodb::Result fetchRevisions(
   std::string path = arangodb::replutils::ReplicationUrl + "/" +
                      RestReplicationHandler::Revisions + "/" +
                      RestReplicationHandler::Documents;
-  auto headers = arangodb::replutils::createHeaders();
+
+  arangodb::network::Headers headers;
+  if (arangodb::ServerState::instance()->isSingleServer() &&
+      config.applier._jwt.empty()) {
+    // if we are the single-server replication and there is no JWT
+    // present, inject the username/password credentials into the
+    // requests.
+    // this is not state-of-the-art, but fixes a problem in single
+    // server replication when the leader uses authentication with
+    // username/password
+    headers.emplace(arangodb::StaticStrings::Authorization,
+                    "Basic " + arangodb::basics::StringUtils::encodeBase64(
+                                   config.applier._username + ":" +
+                                   config.applier._password));
+  }
 
   config.progress.set("fetching documents by revision for collection '" +
                       collection.name() + "' from " + path);
@@ -287,7 +301,7 @@ arangodb::Result fetchRevisions(
       auto buffer = requestBuilder.steal();
       auto f = arangodb::network::sendRequestRetry(
           pool, config.leader.endpoint, arangodb::fuerte::RestVerb::Put, path,
-          std::move(*buffer), reqOptions);
+          std::move(*buffer), reqOptions, headers);
       futures.emplace_back(std::move(f));
       shoppingLists.emplace_back(std::move(shoppingList));
       ++stats.numDocsRequests;
@@ -443,7 +457,7 @@ arangodb::Result fetchRevisions(
         auto buffer = requestBuilder.steal();
         auto f = arangodb::network::sendRequestRetry(
             pool, config.leader.endpoint, arangodb::fuerte::RestVerb::Put, path,
-            std::move(*buffer), reqOptions);
+            std::move(*buffer), reqOptions, headers);
         futures.emplace_back(std::move(f));
         shoppingLists.emplace_back(std::move(newList));
         ++stats.numDocsRequests;

--- a/js/client/modules/@arangodb/testsuites/replication.js
+++ b/js/client/modules/@arangodb/testsuites/replication.js
@@ -157,8 +157,6 @@ function replicationFuzz (options) {
 
 function replicationRandom (options) {
   let testCases = tu.scanTestPaths(testPaths.replication_random, options);
-
-
   return new replicationRunner(options, 'replication_random').run(testCases);
 }
 
@@ -178,7 +176,6 @@ function replicationAql (options) {
 var _replicationOngoing = function(path) {
   this.func = function replicationOngoing (options) {
     let testCases = tu.scanTestPaths(testPaths[path], options);
-
     return new replicationRunner(options, path).run(testCases);
   };
 };
@@ -197,7 +194,7 @@ function replicationStatic (options) {
 
   return new replicationRunner(
     options,
-    'master_static',
+    'leader_static',
     {
       'server.authentication': 'true'
     }, true).run(testCases);
@@ -211,7 +208,7 @@ function replicationSync (options) {
   let testCases = tu.scanTestPaths(testPaths.replication_sync, options);
   testCases = tu.splitBuckets(options, testCases);
 
-  return new replicationRunner(options, 'replication_sync').run(testCases);
+  return new replicationRunner(options, 'replication_sync', {"server.authentication": "true"}).run(testCases);
 }
 
 exports.setup = function (testFns, opts, fnDocs, optionsDoc, allTestPaths) {

--- a/tests/js/server/replication/sync/replication-sync-malarkey.inc
+++ b/tests/js/server/replication/sync/replication-sync-malarkey.inc
@@ -162,7 +162,9 @@ function BaseTestConfig () {
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
         verbose: true,
-        incremental: true
+        incremental: true,
+        username: "root",
+        password: "",
       });
       
       connectToLeader();
@@ -181,7 +183,9 @@ function BaseTestConfig () {
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
         verbose: true,
-        incremental: true
+        incremental: true,
+        username: "root",
+        password: "",
       });
 
       c = db._collection(cn);
@@ -199,6 +203,8 @@ function BaseTestConfig () {
 
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
+        username: "root",
+        password: "",
       });
 
       let docs = [];
@@ -220,7 +226,9 @@ function BaseTestConfig () {
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
         verbose: true,
-        incremental: true
+        incremental: true,
+        username: "root",
+        password: "",
       });
 
       db._flushCache();
@@ -236,6 +244,8 @@ function BaseTestConfig () {
 
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
+        username: "root",
+        password: "",
       });
 
       let docs = [];
@@ -257,7 +267,9 @@ function BaseTestConfig () {
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
         verbose: true,
-        incremental: true
+        incremental: true,
+        username: "root",
+        password: "",
       });
 
       db._flushCache();
@@ -273,6 +285,8 @@ function BaseTestConfig () {
 
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
+        username: "root",
+        password: "",
       });
 
       let docs = [];
@@ -294,7 +308,9 @@ function BaseTestConfig () {
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
         verbose: true,
-        incremental: true
+        incremental: true,
+        username: "root",
+        password: "",
       });
 
       db._flushCache();
@@ -310,6 +326,8 @@ function BaseTestConfig () {
 
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
+        username: "root",
+        password: "",
       });
 
       let docs = [];
@@ -331,7 +349,9 @@ function BaseTestConfig () {
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
         verbose: true,
-        incremental: true
+        incremental: true,
+        username: "root",
+        password: "",
       });
 
       db._flushCache();
@@ -347,6 +367,8 @@ function BaseTestConfig () {
 
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
+        username: "root",
+        password: "",
       });
       // insert 1 document, so that the incremental sync gets triggered
       c.insert({ _key: "testi" });
@@ -374,7 +396,9 @@ function BaseTestConfig () {
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
         verbose: true,
-        incremental: true
+        incremental: true,
+        username: "root",
+        password: "",
       });
 
       db._flushCache();
@@ -390,6 +414,8 @@ function BaseTestConfig () {
 
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
+        username: "root",
+        password: "",
       });
       // insert documents with evil keys
       let docs = [];
@@ -422,7 +448,9 @@ function BaseTestConfig () {
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
         verbose: true,
-        incremental: true
+        incremental: true,
+        username: "root",
+        password: "",
       });
 
       db._flushCache();
@@ -438,6 +466,8 @@ function BaseTestConfig () {
 
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
+        username: "root",
+        password: "",
       });
 
       connectToLeader();
@@ -460,7 +490,9 @@ function BaseTestConfig () {
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
         verbose: true,
-        incremental: true
+        incremental: true,
+        username: "root",
+        password: "",
       });
 
       db._flushCache();
@@ -476,6 +508,8 @@ function BaseTestConfig () {
 
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
+        username: "root",
+        password: "",
       });
 
       connectToLeader();
@@ -500,7 +534,9 @@ function BaseTestConfig () {
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
         verbose: true,
-        incremental: true
+        incremental: true,
+        username: "root",
+        password: "",
       });
 
       db._flushCache();
@@ -520,6 +556,8 @@ function BaseTestConfig () {
 
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
+        username: "root",
+        password: "",
       });
 
       connectToLeader();
@@ -542,7 +580,9 @@ function BaseTestConfig () {
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
         verbose: true,
-        incremental: true
+        incremental: true,
+        username: "root",
+        password: "",
       });
 
       db._flushCache();
@@ -570,7 +610,9 @@ function BaseTestConfig () {
       connectToFollower();
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
-        verbose: true
+        verbose: true,
+        username: "root",
+        password: "",
       });
       db._flushCache();
       c = db._collection(cn);
@@ -580,7 +622,9 @@ function BaseTestConfig () {
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
         verbose: true,
-        incremental: true
+        incremental: true,
+        username: "root",
+        password: "",
       });
 
       db._flushCache();
@@ -606,7 +650,9 @@ function BaseTestConfig () {
       connectToFollower();
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
-        verbose: true
+        verbose: true,
+        username: "root",
+        password: "",
       });
       db._flushCache();
       c = db._collection(cn);
@@ -616,7 +662,9 @@ function BaseTestConfig () {
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
         verbose: true,
-        incremental: true
+        incremental: true,
+        username: "root",
+        password: "",
       });
 
       db._flushCache();
@@ -643,7 +691,9 @@ function BaseTestConfig () {
       connectToFollower();
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
-        verbose: true
+        verbose: true,
+        username: "root",
+        password: "",
       });
       db._flushCache();
       c = db._collection(cn);
@@ -662,7 +712,9 @@ function BaseTestConfig () {
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
         verbose: true,
-        incremental: true
+        incremental: true,
+        username: "root",
+        password: "",
       });
 
       db._flushCache();
@@ -748,7 +800,9 @@ function BaseTestConfig () {
       connectToFollower();
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
-        verbose: true
+        verbose: true,
+        username: "root",
+        password: "",
       });
       db._flushCache();
       c = db._collection(cn);
@@ -758,7 +812,9 @@ function BaseTestConfig () {
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
         verbose: true,
-        incremental: true
+        incremental: true,
+        username: "root",
+        password: "",
       });
 
       db._flushCache();
@@ -836,7 +892,9 @@ function BaseTestConfig () {
       connectToFollower();
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
-        verbose: true
+        verbose: true,
+        username: "root",
+        password: "",
       });
       db._flushCache();
       c = db._collection(cn);
@@ -860,7 +918,9 @@ function BaseTestConfig () {
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
         verbose: true,
-        incremental: true
+        incremental: true,
+        username: "root",
+        password: "",
       });
 
       db._flushCache();
@@ -880,7 +940,9 @@ function BaseTestConfig () {
       connectToFollower();
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
-        verbose: true
+        verbose: true,
+        username: "root",
+        password: "",
       });
       db._flushCache();
       c = db._collection(cn);
@@ -902,7 +964,9 @@ function BaseTestConfig () {
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
         verbose: true,
-        incremental: true
+        incremental: true,
+        username: "root",
+        password: "",
       });
 
       db._flushCache();
@@ -921,7 +985,9 @@ function BaseTestConfig () {
       connectToFollower();
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
-        verbose: true
+        verbose: true,
+        username: "root",
+        password: "",
       });
       db._flushCache();
       c = db._collection(cn);
@@ -940,7 +1006,9 @@ function BaseTestConfig () {
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
         verbose: true,
-        incremental: true
+        incremental: true,
+        username: "root",
+        password: "",
       });
 
       db._flushCache();
@@ -959,7 +1027,9 @@ function BaseTestConfig () {
       connectToFollower();
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
-        verbose: true
+        verbose: true,
+        username: "root",
+        password: "",
       });
       db._flushCache();
       c = db._collection(cn);
@@ -982,7 +1052,9 @@ function BaseTestConfig () {
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
         verbose: true,
-        incremental: true
+        incremental: true,
+        username: "root",
+        password: "",
       });
 
       db._flushCache();
@@ -1001,7 +1073,9 @@ function BaseTestConfig () {
       connectToFollower();
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
-        verbose: true
+        verbose: true,
+        username: "root",
+        password: "",
       });
       db._flushCache();
       c = db._collection(cn);
@@ -1024,7 +1098,9 @@ function BaseTestConfig () {
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
         verbose: true,
-        incremental: true
+        incremental: true,
+        username: "root",
+        password: "",
       });
 
       db._flushCache();
@@ -1044,7 +1120,9 @@ function BaseTestConfig () {
       connectToFollower();
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
-        verbose: true
+        verbose: true,
+        username: "root",
+        password: "",
       });
       db._flushCache();
       c = db._collection(cn);
@@ -1065,7 +1143,9 @@ function BaseTestConfig () {
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
         verbose: true,
-        incremental: true
+        incremental: true,
+        username: "root",
+        password: "",
       });
 
       db._flushCache();
@@ -1090,7 +1170,9 @@ function BaseTestConfig () {
       connectToFollower();
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
-        verbose: true
+        verbose: true,
+        username: "root",
+        password: "",
       });
       db._flushCache();
       c = db._collection(cn);
@@ -1111,7 +1193,9 @@ function BaseTestConfig () {
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
         verbose: true,
-        incremental: true
+        incremental: true,
+        username: "root",
+        password: "",
       });
 
       db._flushCache();
@@ -1136,7 +1220,9 @@ function BaseTestConfig () {
       connectToFollower();
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
-        verbose: true
+        verbose: true,
+        username: "root",
+        password: "",
       });
       db._flushCache();
       c = db._collection(cn);
@@ -1157,7 +1243,9 @@ function BaseTestConfig () {
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
         verbose: true,
-        incremental: true
+        incremental: true,
+        username: "root",
+        password: "",
       });
 
       db._flushCache();
@@ -1176,7 +1264,9 @@ function BaseTestConfig () {
       connectToFollower();
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
-        verbose: true
+        verbose: true,
+        username: "root",
+        password: "",
       });
       db._flushCache();
       c = db._collection(cn);
@@ -1197,7 +1287,9 @@ function BaseTestConfig () {
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
         verbose: true,
-        incremental: true
+        incremental: true,
+        username: "root",
+        password: "",
       });
 
       db._flushCache();
@@ -1216,7 +1308,9 @@ function BaseTestConfig () {
       connectToFollower();
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
-        verbose: true
+        verbose: true,
+        username: "root",
+        password: "",
       });
       db._flushCache();
       c = db._collection(cn);
@@ -1239,7 +1333,9 @@ function BaseTestConfig () {
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
         verbose: true,
-        incremental: true
+        incremental: true,
+        username: "root",
+        password: "",
       });
 
       db._flushCache();
@@ -1264,7 +1360,9 @@ function BaseTestConfig () {
       connectToFollower();
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
-        verbose: true
+        verbose: true,
+        username: "root",
+        password: "",
       });
       db._flushCache();
       c = db._collection(cn);
@@ -1287,7 +1385,9 @@ function BaseTestConfig () {
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
         verbose: true,
-        incremental: true
+        incremental: true,
+        username: "root",
+        password: "",
       });
 
       db._flushCache();
@@ -1310,7 +1410,9 @@ function BaseTestConfig () {
       connectToFollower();
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
-        verbose: true
+        verbose: true,
+        username: "root",
+        password: "",
       });
       db._flushCache();
       c = db._collection(cn);
@@ -1333,7 +1435,9 @@ function BaseTestConfig () {
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
         verbose: true,
-        incremental: true
+        incremental: true,
+        username: "root",
+        password: "",
       });
 
       db._flushCache();

--- a/tests/js/server/replication/sync/replication-sync.js
+++ b/tests/js/server/replication/sync/replication-sync.js
@@ -79,7 +79,9 @@ const compare = function (leaderFunc, followerInitFunc, followerCompareFunc, inc
     endpoint: leaderEndpoint,
     verbose: true,
     includeSystem: true,
-    incremental
+    incremental,
+    username: "root",
+    password: "",
   });
 
   db._flushCache();
@@ -134,7 +136,10 @@ function BaseTestConfig () {
           //  already create the collection on the follower
           replication.syncCollection(cn, {
             endpoint: leaderEndpoint,
-            incremental: false
+            incremental: false,
+            username: "root",
+            password: "",
+
           });
           // collection present on follower now
           var c = db._collection(cn);
@@ -196,7 +201,9 @@ function BaseTestConfig () {
             //  already create the collection on the follower
             replication.syncCollection(cn, {
               endpoint: leaderEndpoint,
-              incremental: false
+              incremental: false,
+              username: "root",
+              password: "",
             });
 
             // collection present on follower now
@@ -431,7 +438,9 @@ function BaseTestConfig () {
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
         verbose: true,
-        incremental: true
+        incremental: true,
+        username: "root",
+        password: "",
       });
 
       assertEqual(st.count, collectionCount(cn));
@@ -488,7 +497,9 @@ function BaseTestConfig () {
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
         verbose: true,
-        incremental: true
+        incremental: true,
+        username: "root",
+        password: "",
       });
 
       assertEqual(st.count, collectionCount(cn));
@@ -561,7 +572,9 @@ function BaseTestConfig () {
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
         verbose: true,
-        incremental: true
+        incremental: true,
+        username: "root",
+        password: "",
       });
 
       assertEqual(st.count, collectionCount(cn));
@@ -626,7 +639,9 @@ function BaseTestConfig () {
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
         verbose: true,
-        incremental: true
+        incremental: true,
+        username: "root",
+        password: "",
       });
 
       assertEqual(st.count, collectionCount(cn));
@@ -711,7 +726,9 @@ function BaseTestConfig () {
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
         verbose: true,
-        incremental: true
+        incremental: true,
+        username: "root",
+        password: "",
       });
 
       assertEqual(st.count, collectionCount(cn));
@@ -804,7 +821,9 @@ function BaseTestConfig () {
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
         verbose: true,
-        incremental: true
+        incremental: true,
+        username: "root",
+        password: "",
       });
 
       assertEqual(st.count, collectionCount(cn));
@@ -835,7 +854,9 @@ function BaseTestConfig () {
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
         verbose: true,
-        incremental: true
+        incremental: true,
+        username: "root",
+        password: "",
       });
      
       // add a lot more data on the leader
@@ -864,7 +885,9 @@ function BaseTestConfig () {
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
         verbose: true,
-        incremental: true
+        incremental: true,
+        username: "root",
+        password: "",
       });
 
       db._flushCache();
@@ -906,7 +929,9 @@ function BaseTestConfig () {
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
         verbose: true,
-        incremental: true
+        incremental: true,
+        username: "root",
+        password: "",
       });
      
       // update documents on the leader
@@ -927,7 +952,9 @@ function BaseTestConfig () {
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
         verbose: true,
-        incremental: true
+        incremental: true,
+        username: "root",
+        password: "",
       });
 
       db._flushCache();
@@ -969,7 +996,9 @@ function BaseTestConfig () {
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
         verbose: true,
-        incremental: true
+        incremental: true,
+        username: "root",
+        password: "",
       });
      
       // remove half the documents on the leader
@@ -990,7 +1019,9 @@ function BaseTestConfig () {
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
         verbose: true,
-        incremental: true
+        incremental: true,
+        username: "root",
+        password: "",
       });
 
       db._flushCache();
@@ -1100,7 +1131,9 @@ function BaseTestConfig () {
           //  already create the collection on the follower
           replication.syncCollection(cn, {
             endpoint: leaderEndpoint,
-            incremental: false
+            incremental: false,
+            username: "root",
+            password: "",
           });
           let c = db._collection(cn);
           c.truncate({ compact: false }); // but empty it
@@ -1159,7 +1192,7 @@ function BaseTestConfig () {
       connectToFollower();
       internal.wait(0.1, false);
       //  sync on follower
-      replication.sync({ endpoint: leaderEndpoint });
+      replication.sync({ endpoint: leaderEndpoint, username: "root", password: "" });
 
       db._flushCache();
       {
@@ -1192,7 +1225,7 @@ function BaseTestConfig () {
       db._flushCache();
       connectToFollower();
 
-      replication.sync({ endpoint: leaderEndpoint });
+      replication.sync({ endpoint: leaderEndpoint, username: "root", password: "" });
 
       // check replicated analyzer
       {
@@ -1243,7 +1276,7 @@ function BaseTestConfig () {
       connectToFollower();
       internal.wait(0.1, false);
       //  sync on follower
-      replication.sync({ endpoint: leaderEndpoint });
+      replication.sync({ endpoint: leaderEndpoint, username: "root", password: "" });
 
       db._flushCache();
 
@@ -1296,7 +1329,7 @@ function BaseTestConfig () {
       connectToFollower();
       internal.wait(0.1, false);
       //  sync on follower
-      replication.sync({ endpoint: leaderEndpoint });
+      replication.sync({ endpoint: leaderEndpoint, username: "root", password: "" });
 
       db._flushCache();
       {
@@ -1330,7 +1363,7 @@ function BaseTestConfig () {
       connectToFollower();
       internal.wait(0.1, false);
       //  sync on follower
-      replication.sync({ endpoint: leaderEndpoint });
+      replication.sync({ endpoint: leaderEndpoint, username: "root", password: "" });
 
       db._flushCache();
       {
@@ -1363,7 +1396,7 @@ function BaseTestConfig () {
       db._flushCache();
       connectToFollower();
 
-      replication.sync({ endpoint: leaderEndpoint });
+      replication.sync({ endpoint: leaderEndpoint, username: "root", password: "" });
 
       {
         let view = db._view(cn + 'View');
@@ -1405,7 +1438,9 @@ function BaseTestConfig () {
           //  already create the collection on the follower
           replication.syncCollection(cn, {
             endpoint: leaderEndpoint,
-            incremental: false
+            incremental: false,
+            username: "root",
+            password: "",
           });
           var c = db._collection(cn);
           c.truncate({ compact: false }); // but empty it
@@ -1467,7 +1502,9 @@ function BaseTestConfig () {
           //  already create the collection on the follower
           replication.syncCollection(cn, {
             endpoint: leaderEndpoint,
-            incremental: false
+            incremental: false,
+            username: "root",
+            password: "",
           });
           var c = db._collection(cn);
           c.truncate(); // but empty it
@@ -1589,7 +1626,9 @@ function BaseTestConfig () {
           //  already create the collection on the follower
           replication.syncCollection(cn, {
             endpoint: leaderEndpoint,
-            incremental: false
+            incremental: false,
+            username: "root",
+            password: "",
           });
           var c = db._collection(cn);
           c.truncate(); // but empty it
@@ -1627,7 +1666,9 @@ function BaseTestConfig () {
           //  already create the collection on the follower
           replication.syncCollection(cn, {
             endpoint: leaderEndpoint,
-            incremental: false
+            incremental: false,
+            username: "root",
+            password: "",
           });
           var c = db._collection(cn);
           c.truncate(); // but empty it
@@ -1659,7 +1700,9 @@ function BaseTestConfig () {
           //  already create the collection on the follower
           replication.syncCollection(cn, {
             endpoint: leaderEndpoint,
-            incremental: false
+            incremental: false,
+            username: "root",
+            password: "",
           });
           let c = db._collection(cn);
           c.truncate(); // but empty it
@@ -1698,7 +1741,9 @@ function BaseTestConfig () {
           //  already create the collection on the follower
           replication.syncCollection(cn, {
             endpoint: leaderEndpoint,
-            incremental: false
+            incremental: false,
+            username: "root",
+            password: "",
           });
           let c = db._collection(cn);
           c.truncate(); // but empty it
@@ -1743,7 +1788,9 @@ function BaseTestConfig () {
           //  already create the collection on the follower
           replication.syncCollection(cn, {
             endpoint: leaderEndpoint,
-            incremental: false
+            incremental: false,
+            username: "root",
+            password: "",
           });
           var c = db._collection(cn);
           c.truncate(); // but empty it
@@ -1787,7 +1834,9 @@ function BaseTestConfig () {
           //  already create the collection on the follower
           replication.syncCollection(cn, {
             endpoint: leaderEndpoint,
-            incremental: false
+            incremental: false,
+            username: "root",
+            password: "",
           });
           var c = db._collection(cn);
           c.truncate(); // but empty it
@@ -1831,7 +1880,9 @@ function BaseTestConfig () {
           //  already create the collection on the follower
           replication.syncCollection(cn, {
             endpoint: leaderEndpoint,
-            incremental: false
+            incremental: false,
+            username: "root",
+            password: "",
           });
           let c = db._collection(cn);
           c.truncate(); // but empty it
@@ -1875,7 +1926,9 @@ function BaseTestConfig () {
           //  already create the collection on the follower
           replication.syncCollection(cn, {
             endpoint: leaderEndpoint,
-            incremental: false
+            incremental: false,
+            username: "root",
+            password: "",
           });
           let c = db._collection(cn);
           c.truncate(); // but empty it
@@ -1922,7 +1975,9 @@ function BaseTestConfig () {
           //  already create the collection on the follower
           replication.syncCollection(cn, {
             endpoint: leaderEndpoint,
-            incremental: false
+            incremental: false,
+            username: "root",
+            password: "",
           });
           let c = db._collection(cn);
           c.truncate({ compact: false }); // but empty it
@@ -1973,7 +2028,9 @@ function BaseTestConfig () {
           //  already create the collection on the follower
           replication.syncCollection(cn, {
             endpoint: leaderEndpoint,
-            incremental: false
+            incremental: false,
+            username: "root",
+            password: "",
           });
           let c = db._collection(cn);
           c.truncate({ compact: false }); // but empty it
@@ -2023,7 +2080,9 @@ function BaseTestConfig () {
           //  already create the collection on the follower
           replication.syncCollection(cn, {
             endpoint: leaderEndpoint,
-            incremental: false
+            incremental: false,
+            username: "root",
+            password: "",
           });
           let c = db._collection(cn);
           c.truncate({ compact: false }); // but empty it
@@ -2072,7 +2131,9 @@ function BaseTestConfig () {
           //  already create the collection on the follower
           replication.syncCollection(cn, {
             endpoint: leaderEndpoint,
-            incremental: false
+            incremental: false,
+            username: "root",
+            password: "",
           });
           let c = db._collection(cn);
           c.truncate({ compact: false }); // but empty it
@@ -2123,7 +2184,9 @@ function BaseTestConfig () {
           //  already create the collection on the follower
           replication.syncCollection(cn, {
             endpoint: leaderEndpoint,
-            incremental: false
+            incremental: false,
+            username: "root",
+            password: "",
           });
           let c = db._collection(cn);
           c.truncate({ compact: false }); // but empty it
@@ -2175,7 +2238,9 @@ function BaseTestConfig () {
           //  already create the collection on the follower
           replication.syncCollection(cn, {
             endpoint: leaderEndpoint,
-            incremental: false
+            incremental: false,
+            username: "root",
+            password: "",
           });
           let c = db._collection(cn);
           c.truncate({ compact: false }); // but empty it
@@ -2240,7 +2305,7 @@ function ReplicationSuite () {
         analyzers.remove('smartCustom');
       } catch (e) { }
       db._flushCache();
-      db._users.toArray().forEach(user => {
+      userManager.all().forEach(user => {
         if (user.user !== "root") {
           userManager.remove(user.user);
         }
@@ -2263,7 +2328,7 @@ function ReplicationSuite () {
         analyzers.remove('smartCustom');
       } catch (e) { }
       db._flushCache();
-      db._users.toArray().forEach(user => {
+      userManager.all().forEach(user => {
         if (user.user !== "root") {
           userManager.remove(user.user);
         }
@@ -2309,7 +2374,7 @@ function ReplicationOtherDBSuiteBase (dbName) {
       } catch (e) {
       }
       db._flushCache();
-      db._users.toArray().forEach(user => {
+      userManager.all().forEach(user => {
         if (user.user !== "root") {
           userManager.remove(user.user);
         }
@@ -2321,7 +2386,7 @@ function ReplicationOtherDBSuiteBase (dbName) {
       } catch (e) {
       }
       db._flushCache();
-      db._users.toArray().forEach(user => {
+      userManager.all().forEach(user => {
         if (user.user !== "root") {
           userManager.remove(user.user);
         }
@@ -2367,7 +2432,7 @@ function ReplicationIncrementalKeyConflict () {
       connectToLeader();
       db._drop(cn);
       db._flushCache();
-      db._users.toArray().forEach(user => {
+      userManager.all().forEach(user => {
         if (user.user !== "root") {
           userManager.remove(user.user);
         }
@@ -2376,7 +2441,7 @@ function ReplicationIncrementalKeyConflict () {
       connectToFollower();
       db._drop(cn);
       db._flushCache();
-      db._users.toArray().forEach(user => {
+      userManager.all().forEach(user => {
         if (user.user !== "root") {
           userManager.remove(user.user);
         }
@@ -2407,7 +2472,9 @@ function ReplicationIncrementalKeyConflict () {
       connectToFollower();
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
-        verbose: true
+        verbose: true,
+        username: "root",
+        password: "",
       });
       db._flushCache();
       c = db._collection(cn);
@@ -2438,7 +2505,9 @@ function ReplicationIncrementalKeyConflict () {
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
         verbose: true,
-        incremental: true
+        incremental: true,
+        username: "root",
+        password: "",
       });
 
       db._flushCache();
@@ -2472,7 +2541,9 @@ function ReplicationIncrementalKeyConflict () {
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
         verbose: true,
-        incremental: true
+        incremental: true,
+        username: "root",
+        password: "",
       });
 
       db._flushCache();
@@ -2495,7 +2566,9 @@ function ReplicationIncrementalKeyConflict () {
       connectToFollower();
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
-        verbose: true
+        verbose: true,
+        username: "root",
+        password: "",
       });
       db._flushCache();
       c = db._collection(cn);
@@ -2532,7 +2605,9 @@ function ReplicationIncrementalKeyConflict () {
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
         verbose: true,
-        incremental: true
+        incremental: true,
+        username: "root",
+        password: "",
       });
 
       db._flushCache();
@@ -2556,7 +2631,9 @@ function ReplicationIncrementalKeyConflict () {
       connectToFollower();
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
-        verbose: true
+        verbose: true,
+        username: "root",
+        password: "",
       });
       db._flushCache();
       c = db._collection(cn);
@@ -2580,7 +2657,9 @@ function ReplicationIncrementalKeyConflict () {
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
         verbose: true,
-        incremental: true
+        incremental: true,
+        username: "root",
+        password: "",
       });
 
       db._flushCache();
@@ -2612,7 +2691,9 @@ function ReplicationIncrementalKeyConflict () {
       connectToFollower();
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
-        verbose: true
+        verbose: true,
+        username: "root",
+        password: "",
       });
       db._flushCache();
       c = db._collection(cn);
@@ -2654,7 +2735,9 @@ function ReplicationIncrementalKeyConflict () {
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
         verbose: true,
-        incremental: true
+        incremental: true,
+        username: "root",
+        password: "",
       });
 
       db._flushCache();
@@ -2686,7 +2769,7 @@ function ReplicationNonIncrementalKeyConflict () {
       connectToLeader();
       db._drop(cn);
       db._flushCache();
-      db._users.toArray().forEach(user => {
+      userManager.all().forEach(user => {
         if (user.user !== "root") {
           userManager.remove(user.user);
         }
@@ -2695,7 +2778,7 @@ function ReplicationNonIncrementalKeyConflict () {
       connectToFollower();
       db._drop(cn);
       db._flushCache();
-      db._users.toArray().forEach(user => {
+      userManager.all().forEach(user => {
         if (user.user !== "root") {
           userManager.remove(user.user);
         }
@@ -2726,7 +2809,9 @@ function ReplicationNonIncrementalKeyConflict () {
       connectToFollower();
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
-        verbose: true
+        verbose: true,
+        username: "root",
+        password: "",
       });
       db._flushCache();
       c = db._collection(cn);
@@ -2758,7 +2843,9 @@ function ReplicationNonIncrementalKeyConflict () {
         endpoint: leaderEndpoint,
         verbose: true,
         incremental: false,
-        skipCreateDrop: true
+        skipCreateDrop: true,
+        username: "root",
+        password: "",
       });
 
       db._flushCache();
@@ -2792,7 +2879,9 @@ function ReplicationNonIncrementalKeyConflict () {
       connectToFollower();
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
-        verbose: true
+        verbose: true,
+        username: "root",
+        password: "",
       });
       db._flushCache();
       c = db._collection(cn);
@@ -2835,7 +2924,9 @@ function ReplicationNonIncrementalKeyConflict () {
         endpoint: leaderEndpoint,
         verbose: true,
         incremental: false,
-        skipCreateDrop: true
+        skipCreateDrop: true,
+        username: "root",
+        password: "",
       });
 
       db._flushCache();


### PR DESCRIPTION
### Scope & Purpose

single-to-single replication that used HTTP authentication to authenticate requests on the leader could be broken if the collections on the leader were created with 3.8 or later, and thus used the Merkle tree protocol to exchange different document revisions. the revisions API was extended with a document prefetching capability about a year ago, and this prefetching capability uses the NetworkFeature to send the requests out to the leader. The NetworkFeature does not support HTTP authentication however, so on a leader that used HTTP authentication, the requests were rejected with HTTP 401 or HTTP 403, and replication failed.
when using JWTs, everything worked fine, but the single-to-single replication also support HTTP authentication with different credentials per database.

`replication_sync` tests were adjusted to use HTTP authentication.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.10: -
  - [x] Backport for 3.9: https://github.com/arangodb/arangodb/pull/18418
  - [ ] Backport for 3.8: not affected

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 