### PR TITLE
fix single-to-single replication with authentication

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,17 @@
+v3.9.11 (XXXX-XX-XX)
+--------------------
+
+* Fixed single-to-single replication that used HTTP authentication to 
+  authenticate requests on the leader. This could be broken if the collections
+  on the leader were created with 3.8 or later, and thus used the Merkle tree
+  protocol to exchange different document revisions. 
+  When using HTTP authentication, the prefetching code for document revisions
+  did not pass on the authentication credentials, so the leader could reject
+  requests with HTTP 401 or HTTP 403, and replication failed.
+  Replication in the cluster and replication using JWT authentication were not
+  affected.
+
+
 v3.9.10 (2023-03-16)
 --------------------
 

--- a/arangod/Replication/DatabaseInitialSyncer.cpp
+++ b/arangod/Replication/DatabaseInitialSyncer.cpp
@@ -140,7 +140,7 @@ arangodb::Result fetchRevisions(
     arangodb::DatabaseInitialSyncer::Configuration& config,
     arangodb::Syncer::SyncerState& state,
     arangodb::LogicalCollection& collection, std::string const& leader,
-    bool encodeAsHLC, std::vector<arangodb::RevisionId>& toFetch,
+    bool encodeAsHLC, std::vector<arangodb::RevisionId> const& toFetch,
     arangodb::ReplicationMetricsFeature::InitialSyncStats& stats) {
   using arangodb::PhysicalCollection;
   using arangodb::RestReplicationHandler;
@@ -170,7 +170,21 @@ arangodb::Result fetchRevisions(
   std::string path = arangodb::replutils::ReplicationUrl + "/" +
                      RestReplicationHandler::Revisions + "/" +
                      RestReplicationHandler::Documents;
-  auto headers = arangodb::replutils::createHeaders();
+
+  arangodb::network::Headers headers;
+  if (arangodb::ServerState::instance()->isSingleServer() &&
+      config.applier._jwt.empty()) {
+    // if we are the single-server replication and there is no JWT
+    // present, inject the username/password credentials into the
+    // requests.
+    // this is not state-of-the-art, but fixes a problem in single
+    // server replication when the leader uses authentication with
+    // username/password
+    headers.emplace(arangodb::StaticStrings::Authorization,
+                    "Basic " + arangodb::basics::StringUtils::encodeBase64(
+                                   config.applier._username + ":" +
+                                   config.applier._password));
+  }
 
   config.progress.set("fetching documents by revision for collection '" +
                       collection.name() + "' from " + path);
@@ -246,7 +260,7 @@ arangodb::Result fetchRevisions(
       auto buffer = requestBuilder.steal();
       auto f = arangodb::network::sendRequestRetry(
           pool, config.leader.endpoint, arangodb::fuerte::RestVerb::Put, path,
-          std::move(*buffer), reqOptions);
+          std::move(*buffer), reqOptions, headers);
       futures.emplace_back(std::move(f));
       shoppingLists.emplace_back(std::move(shoppingList));
       ++stats.numDocsRequests;
@@ -399,7 +413,7 @@ arangodb::Result fetchRevisions(
         auto buffer = requestBuilder.steal();
         auto f = arangodb::network::sendRequestRetry(
             pool, config.leader.endpoint, arangodb::fuerte::RestVerb::Put, path,
-            std::move(*buffer), reqOptions);
+            std::move(*buffer), reqOptions, headers);
         futures.emplace_back(std::move(f));
         shoppingLists.emplace_back(std::move(newList));
         ++stats.numDocsRequests;

--- a/js/client/modules/@arangodb/testsuites/replication.js
+++ b/js/client/modules/@arangodb/testsuites/replication.js
@@ -624,7 +624,7 @@ function replicationSync (options) {
     }
   };
 
-  return tu.performTests(options, testCases, 'replication_sync', tu.runInArangosh, {}, startStopHandlers);
+  return tu.performTests(options, testCases, 'replication_sync', tu.runInArangosh, {"server.authentication": "true"}, startStopHandlers);
 }
 
 exports.setup = function (testFns, defaultFns, opts, fnDocs, optionsDoc, allTestPaths) {

--- a/tests/js/server/replication/sync/replication-sync-malarkey.js
+++ b/tests/js/server/replication/sync/replication-sync-malarkey.js
@@ -162,7 +162,9 @@ function BaseTestConfig () {
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
         verbose: true,
-        incremental: true
+        incremental: true,
+        username: "root",
+        password: "",
       });
       
       connectToLeader();
@@ -181,7 +183,9 @@ function BaseTestConfig () {
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
         verbose: true,
-        incremental: true
+        incremental: true,
+        username: "root",
+        password: "",
       });
 
       c = db._collection(cn);
@@ -199,6 +203,8 @@ function BaseTestConfig () {
 
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
+        username: "root",
+        password: "",
       });
 
       let docs = [];
@@ -220,7 +226,9 @@ function BaseTestConfig () {
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
         verbose: true,
-        incremental: true
+        incremental: true,
+        username: "root",
+        password: "",
       });
 
       db._flushCache();
@@ -236,6 +244,8 @@ function BaseTestConfig () {
 
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
+        username: "root",
+        password: "",
       });
 
       let docs = [];
@@ -257,7 +267,9 @@ function BaseTestConfig () {
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
         verbose: true,
-        incremental: true
+        incremental: true,
+        username: "root",
+        password: "",
       });
 
       db._flushCache();
@@ -273,6 +285,8 @@ function BaseTestConfig () {
 
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
+        username: "root",
+        password: "",
       });
 
       let docs = [];
@@ -294,7 +308,9 @@ function BaseTestConfig () {
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
         verbose: true,
-        incremental: true
+        incremental: true,
+        username: "root",
+        password: "",
       });
 
       db._flushCache();
@@ -310,6 +326,8 @@ function BaseTestConfig () {
 
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
+        username: "root",
+        password: "",
       });
 
       let docs = [];
@@ -331,7 +349,9 @@ function BaseTestConfig () {
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
         verbose: true,
-        incremental: true
+        incremental: true,
+        username: "root",
+        password: "",
       });
 
       db._flushCache();
@@ -347,6 +367,8 @@ function BaseTestConfig () {
 
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
+        username: "root",
+        password: "",
       });
       // insert 1 document, so that the incremental sync gets triggered
       c.insert({ _key: "testi" });
@@ -374,7 +396,9 @@ function BaseTestConfig () {
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
         verbose: true,
-        incremental: true
+        incremental: true,
+        username: "root",
+        password: "",
       });
 
       db._flushCache();
@@ -390,6 +414,8 @@ function BaseTestConfig () {
 
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
+        username: "root",
+        password: "",
       });
       // insert documents with evil keys
       let docs = [];
@@ -422,7 +448,9 @@ function BaseTestConfig () {
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
         verbose: true,
-        incremental: true
+        incremental: true,
+        username: "root",
+        password: "",
       });
 
       db._flushCache();
@@ -438,6 +466,8 @@ function BaseTestConfig () {
 
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
+        username: "root",
+        password: "",
       });
 
       connectToLeader();
@@ -460,7 +490,9 @@ function BaseTestConfig () {
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
         verbose: true,
-        incremental: true
+        incremental: true,
+        username: "root",
+        password: "",
       });
 
       db._flushCache();
@@ -476,6 +508,8 @@ function BaseTestConfig () {
 
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
+        username: "root",
+        password: "",
       });
 
       connectToLeader();
@@ -500,7 +534,9 @@ function BaseTestConfig () {
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
         verbose: true,
-        incremental: true
+        incremental: true,
+        username: "root",
+        password: "",
       });
 
       db._flushCache();
@@ -520,6 +556,8 @@ function BaseTestConfig () {
 
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
+        username: "root",
+        password: "",
       });
 
       connectToLeader();
@@ -542,7 +580,9 @@ function BaseTestConfig () {
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
         verbose: true,
-        incremental: true
+        incremental: true,
+        username: "root",
+        password: "",
       });
 
       db._flushCache();
@@ -570,7 +610,9 @@ function BaseTestConfig () {
       connectToFollower();
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
-        verbose: true
+        verbose: true,
+        username: "root",
+        password: "",
       });
       db._flushCache();
       c = db._collection(cn);
@@ -580,7 +622,9 @@ function BaseTestConfig () {
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
         verbose: true,
-        incremental: true
+        incremental: true,
+        username: "root",
+        password: "",
       });
 
       db._flushCache();
@@ -606,7 +650,9 @@ function BaseTestConfig () {
       connectToFollower();
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
-        verbose: true
+        verbose: true,
+        username: "root",
+        password: "",
       });
       db._flushCache();
       c = db._collection(cn);
@@ -616,7 +662,9 @@ function BaseTestConfig () {
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
         verbose: true,
-        incremental: true
+        incremental: true,
+        username: "root",
+        password: "",
       });
 
       db._flushCache();
@@ -643,7 +691,9 @@ function BaseTestConfig () {
       connectToFollower();
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
-        verbose: true
+        verbose: true,
+        username: "root",
+        password: "",
       });
       db._flushCache();
       c = db._collection(cn);
@@ -662,7 +712,9 @@ function BaseTestConfig () {
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
         verbose: true,
-        incremental: true
+        incremental: true,
+        username: "root",
+        password: "",
       });
 
       db._flushCache();
@@ -748,7 +800,9 @@ function BaseTestConfig () {
       connectToFollower();
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
-        verbose: true
+        verbose: true,
+        username: "root",
+        password: "",
       });
       db._flushCache();
       c = db._collection(cn);
@@ -758,7 +812,9 @@ function BaseTestConfig () {
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
         verbose: true,
-        incremental: true
+        incremental: true,
+        username: "root",
+        password: "",
       });
 
       db._flushCache();
@@ -836,7 +892,9 @@ function BaseTestConfig () {
       connectToFollower();
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
-        verbose: true
+        verbose: true,
+        username: "root",
+        password: "",
       });
       db._flushCache();
       c = db._collection(cn);
@@ -860,7 +918,9 @@ function BaseTestConfig () {
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
         verbose: true,
-        incremental: true
+        incremental: true,
+        username: "root",
+        password: "",
       });
 
       db._flushCache();
@@ -880,7 +940,9 @@ function BaseTestConfig () {
       connectToFollower();
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
-        verbose: true
+        verbose: true,
+        username: "root",
+        password: "",
       });
       db._flushCache();
       c = db._collection(cn);
@@ -902,7 +964,9 @@ function BaseTestConfig () {
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
         verbose: true,
-        incremental: true
+        incremental: true,
+        username: "root",
+        password: "",
       });
 
       db._flushCache();
@@ -921,7 +985,9 @@ function BaseTestConfig () {
       connectToFollower();
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
-        verbose: true
+        verbose: true,
+        username: "root",
+        password: "",
       });
       db._flushCache();
       c = db._collection(cn);
@@ -940,7 +1006,9 @@ function BaseTestConfig () {
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
         verbose: true,
-        incremental: true
+        incremental: true,
+        username: "root",
+        password: "",
       });
 
       db._flushCache();
@@ -959,7 +1027,9 @@ function BaseTestConfig () {
       connectToFollower();
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
-        verbose: true
+        verbose: true,
+        username: "root",
+        password: "",
       });
       db._flushCache();
       c = db._collection(cn);
@@ -982,7 +1052,9 @@ function BaseTestConfig () {
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
         verbose: true,
-        incremental: true
+        incremental: true,
+        username: "root",
+        password: "",
       });
 
       db._flushCache();
@@ -1001,7 +1073,9 @@ function BaseTestConfig () {
       connectToFollower();
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
-        verbose: true
+        verbose: true,
+        username: "root",
+        password: "",
       });
       db._flushCache();
       c = db._collection(cn);
@@ -1024,7 +1098,9 @@ function BaseTestConfig () {
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
         verbose: true,
-        incremental: true
+        incremental: true,
+        username: "root",
+        password: "",
       });
 
       db._flushCache();
@@ -1044,7 +1120,9 @@ function BaseTestConfig () {
       connectToFollower();
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
-        verbose: true
+        verbose: true,
+        username: "root",
+        password: "",
       });
       db._flushCache();
       c = db._collection(cn);
@@ -1065,7 +1143,9 @@ function BaseTestConfig () {
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
         verbose: true,
-        incremental: true
+        incremental: true,
+        username: "root",
+        password: "",
       });
 
       db._flushCache();
@@ -1090,7 +1170,9 @@ function BaseTestConfig () {
       connectToFollower();
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
-        verbose: true
+        verbose: true,
+        username: "root",
+        password: "",
       });
       db._flushCache();
       c = db._collection(cn);
@@ -1111,7 +1193,9 @@ function BaseTestConfig () {
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
         verbose: true,
-        incremental: true
+        incremental: true,
+        username: "root",
+        password: "",
       });
 
       db._flushCache();
@@ -1136,7 +1220,9 @@ function BaseTestConfig () {
       connectToFollower();
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
-        verbose: true
+        verbose: true,
+        username: "root",
+        password: "",
       });
       db._flushCache();
       c = db._collection(cn);
@@ -1157,7 +1243,9 @@ function BaseTestConfig () {
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
         verbose: true,
-        incremental: true
+        incremental: true,
+        username: "root",
+        password: "",
       });
 
       db._flushCache();
@@ -1176,7 +1264,9 @@ function BaseTestConfig () {
       connectToFollower();
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
-        verbose: true
+        verbose: true,
+        username: "root",
+        password: "",
       });
       db._flushCache();
       c = db._collection(cn);
@@ -1197,7 +1287,9 @@ function BaseTestConfig () {
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
         verbose: true,
-        incremental: true
+        incremental: true,
+        username: "root",
+        password: "",
       });
 
       db._flushCache();
@@ -1216,7 +1308,9 @@ function BaseTestConfig () {
       connectToFollower();
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
-        verbose: true
+        verbose: true,
+        username: "root",
+        password: "",
       });
       db._flushCache();
       c = db._collection(cn);
@@ -1239,7 +1333,9 @@ function BaseTestConfig () {
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
         verbose: true,
-        incremental: true
+        incremental: true,
+        username: "root",
+        password: "",
       });
 
       db._flushCache();
@@ -1264,7 +1360,9 @@ function BaseTestConfig () {
       connectToFollower();
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
-        verbose: true
+        verbose: true,
+        username: "root",
+        password: "",
       });
       db._flushCache();
       c = db._collection(cn);
@@ -1287,7 +1385,9 @@ function BaseTestConfig () {
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
         verbose: true,
-        incremental: true
+        incremental: true,
+        username: "root",
+        password: "",
       });
 
       db._flushCache();
@@ -1310,7 +1410,9 @@ function BaseTestConfig () {
       connectToFollower();
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
-        verbose: true
+        verbose: true,
+        username: "root",
+        password: "",
       });
       db._flushCache();
       c = db._collection(cn);
@@ -1333,7 +1435,9 @@ function BaseTestConfig () {
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
         verbose: true,
-        incremental: true
+        incremental: true,
+        username: "root",
+        password: "",
       });
 
       db._flushCache();

--- a/tests/js/server/replication/sync/replication-sync.js
+++ b/tests/js/server/replication/sync/replication-sync.js
@@ -78,7 +78,9 @@ const compare = function (leaderFunc, followerInitFunc, followerCompareFunc, inc
     endpoint: leaderEndpoint,
     verbose: true,
     includeSystem: true,
-    incremental
+    incremental,
+    username: "root",
+    password: "",
   });
 
   db._flushCache();
@@ -133,7 +135,10 @@ function BaseTestConfig () {
           //  already create the collection on the follower
           replication.syncCollection(cn, {
             endpoint: leaderEndpoint,
-            incremental: false
+            incremental: false,
+            username: "root",
+            password: "",
+
           });
           // collection present on follower now
           var c = db._collection(cn);
@@ -195,7 +200,9 @@ function BaseTestConfig () {
             //  already create the collection on the follower
             replication.syncCollection(cn, {
               endpoint: leaderEndpoint,
-              incremental: false
+              incremental: false,
+              username: "root",
+              password: "",
             });
 
             // collection present on follower now
@@ -430,7 +437,9 @@ function BaseTestConfig () {
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
         verbose: true,
-        incremental: true
+        incremental: true,
+        username: "root",
+        password: "",
       });
 
       assertEqual(st.count, collectionCount(cn));
@@ -487,7 +496,9 @@ function BaseTestConfig () {
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
         verbose: true,
-        incremental: true
+        incremental: true,
+        username: "root",
+        password: "",
       });
 
       assertEqual(st.count, collectionCount(cn));
@@ -560,7 +571,9 @@ function BaseTestConfig () {
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
         verbose: true,
-        incremental: true
+        incremental: true,
+        username: "root",
+        password: "",
       });
 
       assertEqual(st.count, collectionCount(cn));
@@ -625,7 +638,9 @@ function BaseTestConfig () {
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
         verbose: true,
-        incremental: true
+        incremental: true,
+        username: "root",
+        password: "",
       });
 
       assertEqual(st.count, collectionCount(cn));
@@ -710,7 +725,9 @@ function BaseTestConfig () {
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
         verbose: true,
-        incremental: true
+        incremental: true,
+        username: "root",
+        password: "",
       });
 
       assertEqual(st.count, collectionCount(cn));
@@ -803,7 +820,9 @@ function BaseTestConfig () {
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
         verbose: true,
-        incremental: true
+        incremental: true,
+        username: "root",
+        password: "",
       });
 
       assertEqual(st.count, collectionCount(cn));
@@ -905,7 +924,9 @@ function BaseTestConfig () {
           //  already create the collection on the follower
           replication.syncCollection(cn, {
             endpoint: leaderEndpoint,
-            incremental: false
+            incremental: false,
+            username: "root",
+            password: "",
           });
           let c = db._collection(cn);
           c.truncate({ compact: false }); // but empty it
@@ -964,7 +985,7 @@ function BaseTestConfig () {
       connectToFollower();
       internal.wait(0.1, false);
       //  sync on follower
-      replication.sync({ endpoint: leaderEndpoint });
+      replication.sync({ endpoint: leaderEndpoint, username: "root", password: "" });
 
       db._flushCache();
       {
@@ -995,7 +1016,7 @@ function BaseTestConfig () {
       db._flushCache();
       connectToFollower();
 
-      replication.sync({ endpoint: leaderEndpoint });
+      replication.sync({ endpoint: leaderEndpoint, username: "root", password: "" });
 
       // check replicated analyzer
       {
@@ -1044,7 +1065,7 @@ function BaseTestConfig () {
       connectToFollower();
       internal.wait(0.1, false);
       //  sync on follower
-      replication.sync({ endpoint: leaderEndpoint });
+      replication.sync({ endpoint: leaderEndpoint, username: "root", password: "" });
 
       db._flushCache();
 
@@ -1100,7 +1121,9 @@ function BaseTestConfig () {
           //  already create the collection on the follower
           replication.syncCollection(cn, {
             endpoint: leaderEndpoint,
-            incremental: false
+            incremental: false,
+            username: "root",
+            password: "",
           });
           var c = db._collection(cn);
           c.truncate({ compact: false }); // but empty it
@@ -1162,7 +1185,9 @@ function BaseTestConfig () {
           //  already create the collection on the follower
           replication.syncCollection(cn, {
             endpoint: leaderEndpoint,
-            incremental: false
+            incremental: false,
+            username: "root",
+            password: "",
           });
           var c = db._collection(cn);
           c.truncate(); // but empty it
@@ -1284,7 +1309,9 @@ function BaseTestConfig () {
           //  already create the collection on the follower
           replication.syncCollection(cn, {
             endpoint: leaderEndpoint,
-            incremental: false
+            incremental: false,
+            username: "root",
+            password: "",
           });
           var c = db._collection(cn);
           c.truncate(); // but empty it
@@ -1322,7 +1349,9 @@ function BaseTestConfig () {
           //  already create the collection on the follower
           replication.syncCollection(cn, {
             endpoint: leaderEndpoint,
-            incremental: false
+            incremental: false,
+            username: "root",
+            password: "",
           });
           var c = db._collection(cn);
           c.truncate(); // but empty it
@@ -1354,7 +1383,9 @@ function BaseTestConfig () {
           //  already create the collection on the follower
           replication.syncCollection(cn, {
             endpoint: leaderEndpoint,
-            incremental: false
+            incremental: false,
+            username: "root",
+            password: "",
           });
           let c = db._collection(cn);
           c.truncate(); // but empty it
@@ -1393,7 +1424,9 @@ function BaseTestConfig () {
           //  already create the collection on the follower
           replication.syncCollection(cn, {
             endpoint: leaderEndpoint,
-            incremental: false
+            incremental: false,
+            username: "root",
+            password: "",
           });
           let c = db._collection(cn);
           c.truncate(); // but empty it
@@ -1438,7 +1471,9 @@ function BaseTestConfig () {
           //  already create the collection on the follower
           replication.syncCollection(cn, {
             endpoint: leaderEndpoint,
-            incremental: false
+            incremental: false,
+            username: "root",
+            password: "",
           });
           var c = db._collection(cn);
           c.truncate(); // but empty it
@@ -1482,7 +1517,9 @@ function BaseTestConfig () {
           //  already create the collection on the follower
           replication.syncCollection(cn, {
             endpoint: leaderEndpoint,
-            incremental: false
+            incremental: false,
+            username: "root",
+            password: "",
           });
           var c = db._collection(cn);
           c.truncate(); // but empty it
@@ -1526,7 +1563,9 @@ function BaseTestConfig () {
           //  already create the collection on the follower
           replication.syncCollection(cn, {
             endpoint: leaderEndpoint,
-            incremental: false
+            incremental: false,
+            username: "root",
+            password: "",
           });
           let c = db._collection(cn);
           c.truncate(); // but empty it
@@ -1570,7 +1609,9 @@ function BaseTestConfig () {
           //  already create the collection on the follower
           replication.syncCollection(cn, {
             endpoint: leaderEndpoint,
-            incremental: false
+            incremental: false,
+            username: "root",
+            password: "",
           });
           let c = db._collection(cn);
           c.truncate(); // but empty it
@@ -1617,7 +1658,9 @@ function BaseTestConfig () {
           //  already create the collection on the follower
           replication.syncCollection(cn, {
             endpoint: leaderEndpoint,
-            incremental: false
+            incremental: false,
+            username: "root",
+            password: "",
           });
           let c = db._collection(cn);
           c.truncate({ compact: false }); // but empty it
@@ -1668,7 +1711,9 @@ function BaseTestConfig () {
           //  already create the collection on the follower
           replication.syncCollection(cn, {
             endpoint: leaderEndpoint,
-            incremental: false
+            incremental: false,
+            username: "root",
+            password: "",
           });
           let c = db._collection(cn);
           c.truncate({ compact: false }); // but empty it
@@ -1718,7 +1763,9 @@ function BaseTestConfig () {
           //  already create the collection on the follower
           replication.syncCollection(cn, {
             endpoint: leaderEndpoint,
-            incremental: false
+            incremental: false,
+            username: "root",
+            password: "",
           });
           let c = db._collection(cn);
           c.truncate({ compact: false }); // but empty it
@@ -1767,7 +1814,9 @@ function BaseTestConfig () {
           //  already create the collection on the follower
           replication.syncCollection(cn, {
             endpoint: leaderEndpoint,
-            incremental: false
+            incremental: false,
+            username: "root",
+            password: "",
           });
           let c = db._collection(cn);
           c.truncate({ compact: false }); // but empty it
@@ -1818,7 +1867,9 @@ function BaseTestConfig () {
           //  already create the collection on the follower
           replication.syncCollection(cn, {
             endpoint: leaderEndpoint,
-            incremental: false
+            incremental: false,
+            username: "root",
+            password: "",
           });
           let c = db._collection(cn);
           c.truncate({ compact: false }); // but empty it
@@ -1870,7 +1921,9 @@ function BaseTestConfig () {
           //  already create the collection on the follower
           replication.syncCollection(cn, {
             endpoint: leaderEndpoint,
-            incremental: false
+            incremental: false,
+            username: "root",
+            password: "",
           });
           let c = db._collection(cn);
           c.truncate({ compact: false }); // but empty it
@@ -2074,7 +2127,9 @@ function ReplicationIncrementalKeyConflict () {
       connectToFollower();
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
-        verbose: true
+        verbose: true,
+        username: "root",
+        password: "",
       });
       db._flushCache();
       c = db._collection(cn);
@@ -2105,7 +2160,9 @@ function ReplicationIncrementalKeyConflict () {
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
         verbose: true,
-        incremental: true
+        incremental: true,
+        username: "root",
+        password: "",
       });
 
       db._flushCache();
@@ -2139,7 +2196,9 @@ function ReplicationIncrementalKeyConflict () {
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
         verbose: true,
-        incremental: true
+        incremental: true,
+        username: "root",
+        password: "",
       });
 
       db._flushCache();
@@ -2162,7 +2221,9 @@ function ReplicationIncrementalKeyConflict () {
       connectToFollower();
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
-        verbose: true
+        verbose: true,
+        username: "root",
+        password: "",
       });
       db._flushCache();
       c = db._collection(cn);
@@ -2199,7 +2260,9 @@ function ReplicationIncrementalKeyConflict () {
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
         verbose: true,
-        incremental: true
+        incremental: true,
+        username: "root",
+        password: "",
       });
 
       db._flushCache();
@@ -2223,7 +2286,9 @@ function ReplicationIncrementalKeyConflict () {
       connectToFollower();
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
-        verbose: true
+        verbose: true,
+        username: "root",
+        password: "",
       });
       db._flushCache();
       c = db._collection(cn);
@@ -2247,7 +2312,9 @@ function ReplicationIncrementalKeyConflict () {
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
         verbose: true,
-        incremental: true
+        incremental: true,
+        username: "root",
+        password: "",
       });
 
       db._flushCache();
@@ -2279,7 +2346,9 @@ function ReplicationIncrementalKeyConflict () {
       connectToFollower();
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
-        verbose: true
+        verbose: true,
+        username: "root",
+        password: "",
       });
       db._flushCache();
       c = db._collection(cn);
@@ -2321,7 +2390,9 @@ function ReplicationIncrementalKeyConflict () {
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
         verbose: true,
-        incremental: true
+        incremental: true,
+        username: "root",
+        password: "",
       });
 
       db._flushCache();
@@ -2381,7 +2452,9 @@ function ReplicationNonIncrementalKeyConflict () {
       connectToFollower();
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
-        verbose: true
+        verbose: true,
+        username: "root",
+        password: "",
       });
       db._flushCache();
       c = db._collection(cn);
@@ -2413,7 +2486,9 @@ function ReplicationNonIncrementalKeyConflict () {
         endpoint: leaderEndpoint,
         verbose: true,
         incremental: false,
-        skipCreateDrop: true
+        skipCreateDrop: true,
+        username: "root",
+        password: "",
       });
 
       db._flushCache();
@@ -2447,7 +2522,9 @@ function ReplicationNonIncrementalKeyConflict () {
       connectToFollower();
       replication.syncCollection(cn, {
         endpoint: leaderEndpoint,
-        verbose: true
+        verbose: true,
+        username: "root",
+        password: "",
       });
       db._flushCache();
       c = db._collection(cn);
@@ -2490,7 +2567,9 @@ function ReplicationNonIncrementalKeyConflict () {
         endpoint: leaderEndpoint,
         verbose: true,
         incremental: false,
-        skipCreateDrop: true
+        skipCreateDrop: true,
+        username: "root",
+        password: "",
       });
 
       db._flushCache();


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/18416

single-to-single replication that used HTTP authentication to authenticate requests on the leader could be broken if the collections on the leader were created with 3.8 or later, and thus used the Merkle tree protocol to exchange different document revisions. the revisions API was extended with a document prefetching capability about a year ago, and this prefetching capability uses the NetworkFeature to send the requests out to the leader. The NetworkFeature does not support HTTP authentication however, so on a leader that used HTTP authentication, the requests were rejected with HTTP 401 or HTTP 403, and replication failed.
when using JWTs, everything worked fine, but the single-to-single replication also support HTTP authentication with different credentials per database.

`replication_sync` tests were adjusted to use HTTP authentication.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.10: https://github.com/arangodb/arangodb/pull/18417
  - [x] Backport for 3.9: this PR
  - [ ] Backport for 3.8: not affected

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 