### PR TITLE
[CINFRA-715] Supervision Deadlock Snapshot Missing

### DIFF
--- a/arangod/Replication2/StateMachines/Document/DocumentStateNetworkHandler.cpp
+++ b/arangod/Replication2/StateMachines/Document/DocumentStateNetworkHandler.cpp
@@ -79,10 +79,12 @@ auto DocumentStateLeaderInterface::finishSnapshot(SnapshotId id)
                               opts)
       .thenValue([self = shared_from_this(), id = id](
                      network::Response&& resp) -> futures::Future<Result> {
+        // Only retry on network error
         if (resp.fail()) {
           LOG_TOPIC("2e771", ERR, Logger::REPLICATION2)
               << "Failed to finish snapshot " << id << " on "
-              << self->_participantId << ", retrying in 5 seconds";
+              << self->_participantId << ": " << resp.combinedResult()
+              << " - retrying in 5 seconds";
           std::this_thread::sleep_for(std::chrono::seconds(5));
           return self->finishSnapshot(id);
         } else if (!fuerte::statusIsSuccess(resp.statusCode())) {

--- a/arangod/Replication2/StateMachines/Document/DocumentStateShardHandler.cpp
+++ b/arangod/Replication2/StateMachines/Document/DocumentStateShardHandler.cpp
@@ -106,6 +106,7 @@ auto DocumentStateShardHandler::dropAllShards() -> Result {
                                 res.errorMessage())};
     }
   }
+  _shardMap.shards.clear();
   return {};
 }
 


### PR DESCRIPTION
### Scope & Purpose

In some cases the supervision excluded a server from the quorum. If not all snapshots are available, this could create a deadlock.

Therefore we only consider excluding a server from the quorum, when after the exclusion there is still enough participants with a snapshot.
Additionally, if the flag `allowedInQuorum=false` is already in place, we undo it, _unless_ it was specified by the user in Target.