### PR TITLE
[GORDO-1552] Implement conductor canceled state

### DIFF
--- a/arangod/Pregel/Conductor/ExecutionStates/AQLResultsAvailableState.h
+++ b/arangod/Pregel/Conductor/ExecutionStates/AQLResultsAvailableState.h
@@ -36,19 +36,16 @@ struct ConductorState;
   PregelFeature::getResults returns these results.
  */
 struct AQLResultsAvailable : ExecutionState {
-  AQLResultsAvailable() = default;
+  AQLResultsAvailable(ConductorState& conductor);
   auto name() const -> std::string override { return "done"; }
+  auto aqlResultsAvailable() const -> bool override { return true; }
   auto messages()
       -> std::unordered_map<actor::ActorPID,
-                            worker::message::WorkerMessages> override {
-    return {};
-  }
+                            worker::message::WorkerMessages> override;
   auto receive(actor::ActorPID sender, message::ConductorMessages message)
-      -> std::optional<std::unique_ptr<ExecutionState>> override {
-    return std::nullopt;
-  }
+      -> std::optional<std::unique_ptr<ExecutionState>> override;
 
-  auto aqlResultsAvailable() const -> bool override { return true; }
+  ConductorState& conductor;
 };
 
 }  // namespace arangodb::pregel::conductor

--- a/arangod/Pregel/Conductor/ExecutionStates/CMakeLists.txt
+++ b/arangod/Pregel/Conductor/ExecutionStates/CMakeLists.txt
@@ -4,4 +4,7 @@ target_sources(arango_pregel_with_actors PRIVATE
   ComputingState.cpp
   StoringState.cpp
   ProduceAQLResultsState.cpp
-  CanceledState.cpp)
+	AQLResultsAvailableState.cpp
+  DoneState.cpp
+  CanceledState.cpp
+  FatalErrorState.cpp)

--- a/arangod/Pregel/Conductor/ExecutionStates/CMakeLists.txt
+++ b/arangod/Pregel/Conductor/ExecutionStates/CMakeLists.txt
@@ -3,4 +3,5 @@ target_sources(arango_pregel_with_actors PRIVATE
   LoadingState.cpp
   ComputingState.cpp
   StoringState.cpp
-  ProduceAQLResultsState.cpp)
+  ProduceAQLResultsState.cpp
+  CanceledState.cpp)

--- a/arangod/Pregel/Conductor/ExecutionStates/CanceledState.cpp
+++ b/arangod/Pregel/Conductor/ExecutionStates/CanceledState.cpp
@@ -1,0 +1,71 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2023 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Julia Volmer
+////////////////////////////////////////////////////////////////////////////////
+
+#include "CanceledState.h"
+#include "Pregel/Conductor/ExecutionStates/CleanedUpState.h"
+#include "Pregel/Conductor/ExecutionStates/FatalErrorState.h"
+
+using namespace arangodb::pregel::conductor;
+
+Canceled::Canceled(ConductorState& conductor) : conductor{conductor} {
+  if (conductor.timing.loading.hasStarted() and
+      not conductor.timing.loading.hasFinished()) {
+    conductor.timing.loading.finish();
+  }
+  if (conductor.timing.computation.hasStarted() and
+      not conductor.timing.computation.hasFinished()) {
+    conductor.timing.computation.finish();
+  }
+  if (conductor.timing.storing.hasStarted() and
+      not conductor.timing.storing.hasFinished()) {
+    conductor.timing.storing.finish();
+  }
+  if (conductor.timing.total.hasStarted() and
+      not conductor.timing.total.hasFinished()) {
+    conductor.timing.total.finish();
+  }
+}
+
+auto Canceled::messages()
+    -> std::unordered_map<actor::ActorPID, worker::message::WorkerMessages> {
+  auto messages =
+      std::unordered_map<actor::ActorPID, worker::message::WorkerMessages>{};
+  for (auto const& worker : conductor.workers) {
+    messages.emplace(worker, worker::message::Cleanup{});
+  }
+  return messages;
+}
+
+auto Canceled::receive(actor::ActorPID sender,
+                       message::ConductorMessages message)
+    -> std::optional<std::unique_ptr<ExecutionState>> {
+  if (not conductor.workers.contains(sender) or
+      not std::holds_alternative<message::CleanupFinished>(message)) {
+    return std::make_unique<FatalError>(conductor);
+  }
+  conductor.workers.erase(sender);
+  if (conductor.workers.empty()) {
+    return std::make_unique<CleanedUp>();
+  }
+  return std::nullopt;
+};

--- a/arangod/Pregel/Conductor/ExecutionStates/CanceledState.h
+++ b/arangod/Pregel/Conductor/ExecutionStates/CanceledState.h
@@ -1,0 +1,44 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2023 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Julia Volmer
+////////////////////////////////////////////////////////////////////////////////
+#pragma once
+
+#include "Pregel/Conductor/State.h"
+
+namespace arangodb::pregel::conductor {
+
+struct ConductorState;
+
+struct Canceled : ExecutionState {
+  Canceled(ConductorState& conductor);
+  ~Canceled() {}
+  auto name() const -> std::string override { return "canceled"; };
+  auto messages()
+      -> std::unordered_map<actor::ActorPID,
+                            worker::message::WorkerMessages> override;
+  auto receive(actor::ActorPID sender, message::ConductorMessages message)
+      -> std::optional<std::unique_ptr<ExecutionState>> override;
+
+  ConductorState& conductor;
+};
+
+}  // namespace arangodb::pregel::conductor

--- a/arangod/Pregel/Conductor/ExecutionStates/CleanedUpState.h
+++ b/arangod/Pregel/Conductor/ExecutionStates/CleanedUpState.h
@@ -1,0 +1,45 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2023 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Heiko Kernbach
+////////////////////////////////////////////////////////////////////////////////
+#pragma once
+
+#include "Pregel/Conductor/ExecutionStates/State.h"
+
+namespace arangodb::pregel::conductor {
+
+struct ConductorState;
+
+struct CleanedUp : ExecutionState {
+  CleanedUp() = default;
+  auto name() const -> std::string override { return "cleaned up"; }
+  auto messages()
+      -> std::unordered_map<actor::ActorPID,
+                            worker::message::WorkerMessages> override {
+    return {};
+  }
+  auto receive(actor::ActorPID sender, message::ConductorMessages message)
+      -> std::optional<std::unique_ptr<ExecutionState>> override {
+    return std::nullopt;
+  }
+};
+
+}  // namespace arangodb::pregel::conductor

--- a/arangod/Pregel/Conductor/ExecutionStates/DoneState.cpp
+++ b/arangod/Pregel/Conductor/ExecutionStates/DoneState.cpp
@@ -18,33 +18,37 @@
 ///
 /// Copyright holder is ArangoDB GmbH, Cologne, Germany
 ///
-/// @author Heiko Kernbach
+/// @author Julia Volmer
 ////////////////////////////////////////////////////////////////////////////////
 
-#include "ProduceAQLResultsState.h"
-
+#include "DoneState.h"
+#include "Pregel/Conductor/ExecutionStates/CleanedUpState.h"
 #include "Pregel/Conductor/ExecutionStates/FatalErrorState.h"
 #include "Pregel/Conductor/State.h"
-#include "Pregel/Conductor/ExecutionStates/AQLResultsAvailableState.h"
 
-using namespace arangodb::pregel::actor;
 using namespace arangodb::pregel::conductor;
 
-ProduceAQLResults::ProduceAQLResults(ConductorState& conductor)
-    : conductor{conductor} {}
+Done::Done(ConductorState& conductor) : conductor{conductor} {}
 
-auto ProduceAQLResults::receive(actor::ActorPID sender,
-                                message::ConductorMessages message)
+auto Done::messages()
+    -> std::unordered_map<actor::ActorPID, worker::message::WorkerMessages> {
+  auto messages =
+      std::unordered_map<actor::ActorPID, worker::message::WorkerMessages>{};
+  for (auto const& worker : conductor.workers) {
+    messages.emplace(worker, worker::message::Cleanup{});
+  }
+  return messages;
+}
+
+auto Done::receive(actor::ActorPID sender, message::ConductorMessages message)
     -> std::optional<std::unique_ptr<ExecutionState>> {
-  if (not std::holds_alternative<message::ResultCreated>(message)) {
+  if (not conductor.workers.contains(sender) or
+      not std::holds_alternative<message::CleanupFinished>(message)) {
     return std::make_unique<FatalError>(conductor);
   }
-  responseCount++;
-  respondedWorkers.emplace(sender);
-
-  if (responseCount == conductor.workers.size() and
-      respondedWorkers == conductor.workers) {
-    return std::make_unique<AQLResultsAvailable>(conductor);
+  conductor.workers.erase(sender);
+  if (conductor.workers.empty()) {
+    return std::make_unique<CleanedUp>();
   }
   return std::nullopt;
-}
+};

--- a/arangod/Pregel/Conductor/ExecutionStates/DoneState.h
+++ b/arangod/Pregel/Conductor/ExecutionStates/DoneState.h
@@ -29,17 +29,15 @@ namespace arangodb::pregel::conductor {
 struct ConductorState;
 
 struct Done : ExecutionState {
-  Done() = default;
+  Done(ConductorState& conductor);
   auto name() const -> std::string override { return "done"; }
   auto messages()
       -> std::unordered_map<actor::ActorPID,
-                            worker::message::WorkerMessages> override {
-    return {};
-  }
+                            worker::message::WorkerMessages> override;
   auto receive(actor::ActorPID sender, message::ConductorMessages message)
-      -> std::optional<std::unique_ptr<ExecutionState>> override {
-    return std::nullopt;
-  }
+      -> std::optional<std::unique_ptr<ExecutionState>> override;
+
+  ConductorState& conductor;
 };
 
 }  // namespace arangodb::pregel::conductor

--- a/arangod/Pregel/Conductor/ExecutionStates/FatalErrorState.cpp
+++ b/arangod/Pregel/Conductor/ExecutionStates/FatalErrorState.cpp
@@ -1,0 +1,71 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2023 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Julia Volmer
+////////////////////////////////////////////////////////////////////////////////
+
+#include "FatalErrorState.h"
+#include "Pregel/Conductor/ExecutionStates/CleanedUpState.h"
+#include "Pregel/Conductor/State.h"
+
+using namespace arangodb::pregel::conductor;
+
+FatalError::FatalError(ConductorState& conductor) : conductor{conductor} {
+  if (conductor.timing.loading.hasStarted() and
+      not conductor.timing.loading.hasFinished()) {
+    conductor.timing.loading.finish();
+  }
+  if (conductor.timing.computation.hasStarted() and
+      not conductor.timing.computation.hasFinished()) {
+    conductor.timing.computation.finish();
+  }
+  if (conductor.timing.storing.hasStarted() and
+      not conductor.timing.storing.hasFinished()) {
+    conductor.timing.storing.finish();
+  }
+  if (conductor.timing.total.hasStarted() and
+      not conductor.timing.total.hasFinished()) {
+    conductor.timing.total.finish();
+  }
+}
+
+auto FatalError::messages()
+    -> std::unordered_map<actor::ActorPID, worker::message::WorkerMessages> {
+  auto messages =
+      std::unordered_map<actor::ActorPID, worker::message::WorkerMessages>{};
+  for (auto const& worker : conductor.workers) {
+    messages.emplace(worker, worker::message::Cleanup{});
+  }
+  return messages;
+}
+
+auto FatalError::receive(actor::ActorPID sender,
+                         message::ConductorMessages message)
+    -> std::optional<std::unique_ptr<ExecutionState>> {
+  if (not conductor.workers.contains(sender) or
+      not std::holds_alternative<message::CleanupFinished>(message)) {
+    return std::nullopt;
+  }
+  conductor.workers.erase(sender);
+  if (conductor.workers.empty()) {
+    return std::make_unique<CleanedUp>();
+  }
+  return std::nullopt;
+};

--- a/arangod/Pregel/Conductor/ExecutionStates/FatalErrorState.h
+++ b/arangod/Pregel/Conductor/ExecutionStates/FatalErrorState.h
@@ -22,31 +22,22 @@
 ////////////////////////////////////////////////////////////////////////////////
 #pragma once
 
-#include <unordered_map>
-#include "Pregel/Conductor/Messages.h"
-#include "Pregel/Conductor/State.h"
-#include "Pregel/Worker/Messages.h"
-#include "State.h"
+#include "Pregel/Conductor/ExecutionStates/State.h"
 
 namespace arangodb::pregel::conductor {
 
 struct ConductorState;
 
 struct FatalError : ExecutionState {
-  FatalError(ConductorState& conductor) : conductor{conductor} {
-    conductor.timing.total.finish();
-  }
-  ~FatalError() {}
+  FatalError(ConductorState& conductor);
+  ~FatalError() = default;
   auto name() const -> std::string override { return "fatal error"; };
   auto messages()
       -> std::unordered_map<actor::ActorPID,
-                            worker::message::WorkerMessages> override {
-    return {};
-  }
+                            worker::message::WorkerMessages> override;
   auto receive(actor::ActorPID sender, message::ConductorMessages message)
-      -> std::optional<std::unique_ptr<ExecutionState>> override {
-    return std::nullopt;
-  };
+      -> std::optional<std::unique_ptr<ExecutionState>> override;
+
   ConductorState& conductor;
 };
 

--- a/arangod/Pregel/Conductor/ExecutionStates/StoringState.cpp
+++ b/arangod/Pregel/Conductor/ExecutionStates/StoringState.cpp
@@ -63,7 +63,7 @@ auto Storing::receive(actor::ActorPID sender,
   respondedWorkers.emplace(sender);
 
   if (respondedWorkers == conductor.workers) {
-    return std::make_unique<Done>();
+    return std::make_unique<Done>(conductor);
   }
 
   return std::nullopt;

--- a/arangod/Pregel/Conductor/Handler.h
+++ b/arangod/Pregel/Conductor/Handler.h
@@ -117,6 +117,7 @@ struct ConductorHandler : actor::HandlerBase<Runtime, ConductorState> {
         this->state->executionState->receive(this->sender, std::move(msg));
     if (newExecutionState.has_value()) {
       changeState(std::move(newExecutionState.value()));
+      sendMessages();
     }
     return std::move(this->state);
   }

--- a/arangod/Pregel/Conductor/Handler.h
+++ b/arangod/Pregel/Conductor/Handler.h
@@ -140,6 +140,19 @@ struct ConductorHandler : actor::HandlerBase<Runtime, ConductorState> {
     return std::move(this->state);
   }
 
+  auto operator()(message::CleanupFinished start)
+      -> std::unique_ptr<ConductorState> {
+    LOG_TOPIC("02da1", INFO, Logger::PREGEL) << fmt::format(
+        "Conductor Actor: Worker {} is cleaned up", this->sender);
+    auto newExecutionState =
+        this->state->executionState->receive(this->sender, std::move(start));
+    if (newExecutionState.has_value()) {
+      changeState(std::move(newExecutionState.value()));
+      this->finish();
+    }
+    return std::move(this->state);
+  }
+
   auto operator()(actor::message::UnknownMessage unknown)
       -> std::unique_ptr<ConductorState> {
     LOG_TOPIC("d1791", INFO, Logger::PREGEL)

--- a/arangod/Pregel/Conductor/Handler.h
+++ b/arangod/Pregel/Conductor/Handler.h
@@ -149,6 +149,8 @@ struct ConductorHandler : actor::HandlerBase<Runtime, ConductorState> {
     if (newExecutionState.has_value()) {
       changeState(std::move(newExecutionState.value()));
       this->finish();
+      this->template dispatch<pregel::message::SpawnMessages>(
+          this->state->spawnActor, pregel::message::SpawnCleanup{});
     }
     return std::move(this->state);
   }

--- a/arangod/Pregel/Conductor/Messages.h
+++ b/arangod/Pregel/Conductor/Messages.h
@@ -138,13 +138,21 @@ auto inspect(Inspector& f, StatusUpdate& x) {
       f.field(Utils::executionNumberKey, x.executionNumber),
       f.field("status", x.status));
 }
+
+struct CleanupFinished {};
+template<typename Inspector>
+auto inspect(Inspector& f, CleanupFinished& x) {
+  return f.object(x).fields();
+}
+
 struct ConductorMessages
     : std::variant<ConductorStart, ResultT<WorkerCreated>, ResultT<GraphLoaded>,
                    ResultT<GlobalSuperStepFinished>, ResultT<Stored>,
-                   ResultCreated, StatusUpdate> {
+                   ResultCreated, StatusUpdate, CleanupFinished> {
   using std::variant<ConductorStart, ResultT<WorkerCreated>,
                      ResultT<GraphLoaded>, ResultT<GlobalSuperStepFinished>,
-                     ResultT<Stored>, ResultCreated, StatusUpdate>::variant;
+                     ResultT<Stored>, ResultCreated, StatusUpdate,
+                     CleanupFinished>::variant;
 };
 template<typename Inspector>
 auto inspect(Inspector& f, ConductorMessages& x) {
@@ -156,7 +164,8 @@ auto inspect(Inspector& f, ConductorMessages& x) {
           "GlobalSuperStepFinished"),
       arangodb::inspection::type<ResultT<Stored>>("Stored"),
       arangodb::inspection::type<ResultCreated>("ResultCreated"),
-      arangodb::inspection::type<StatusUpdate>("StatusUpdate"));
+      arangodb::inspection::type<StatusUpdate>("StatusUpdate"),
+      arangodb::inspection::type<CleanupFinished>("CleanupFinished"));
 }
 
 }  // namespace conductor::message

--- a/arangod/Pregel/ResultMessages.h
+++ b/arangod/Pregel/ResultMessages.h
@@ -38,7 +38,6 @@ auto inspect(Inspector& f, ResultStart& x) {
 struct SaveResults {
   ResultT<PregelResults> results = {PregelResults{}};
 };
-
 template<typename Inspector>
 auto inspect(Inspector& f, SaveResults& x) {
   return f.object(x).fields(f.field("results", x.results));
@@ -48,7 +47,6 @@ struct AddResults {
   ResultT<PregelResults> results = {PregelResults{}};
   bool receivedAllResults{false};
 };
-
 template<typename Inspector>
 auto inspect(Inspector& f, AddResults& x) {
   return f.object(x).fields(

--- a/arangod/Pregel/SpawnActor.h
+++ b/arangod/Pregel/SpawnActor.h
@@ -85,7 +85,8 @@ struct SpawnHandler : actor::HandlerBase<Runtime, SpawnState> {
                 msg.message.userParameters.slice()),
             msg.conductor, msg.message, algorithm->messageFormatUnique(),
             algorithm->messageCombinerUnique(), std::move(algorithm),
-            this->state->vocbaseGuard.database(), this->state->resultActor),
+            this->state->vocbaseGuard.database(), this->self,
+            this->state->resultActor),
         worker::message::WorkerStart{});
   }
 
@@ -195,6 +196,11 @@ struct SpawnHandler : actor::HandlerBase<Runtime, SpawnState> {
                                      .id = {0}},
                      message::SpawnMessages{msg});
     }
+    return std::move(this->state);
+  }
+
+  auto operator()(message::SpawnCleanup msg) -> std::unique_ptr<SpawnState> {
+    this->finish();
     return std::move(this->state);
   }
 

--- a/arangod/Pregel/SpawnMessages.h
+++ b/arangod/Pregel/SpawnMessages.h
@@ -34,6 +34,7 @@ template<typename Inspector>
 auto inspect(Inspector& f, SpawnStart& x) {
   return f.object(x).fields();
 }
+
 struct SpawnWorker {
   actor::ServerID destinationServer;
   actor::ActorPID conductor;
@@ -45,14 +46,22 @@ auto inspect(Inspector& f, SpawnWorker& x) {
                             f.field("conductor", x.conductor),
                             f.field("message", x.message));
 }
-struct SpawnMessages : std::variant<SpawnStart, SpawnWorker> {
-  using std::variant<SpawnStart, SpawnWorker>::variant;
+
+struct SpawnCleanup {};
+template<typename Inspector>
+auto inspect(Inspector& f, SpawnCleanup& x) {
+  return f.object(x).fields();
+}
+
+struct SpawnMessages : std::variant<SpawnStart, SpawnWorker, SpawnCleanup> {
+  using std::variant<SpawnStart, SpawnWorker, SpawnCleanup>::variant;
 };
 template<typename Inspector>
 auto inspect(Inspector& f, SpawnMessages& x) {
   return f.variant(x).unqualified().alternatives(
       arangodb::inspection::type<SpawnStart>("Start"),
-      arangodb::inspection::type<SpawnWorker>("SpawnWorker"));
+      arangodb::inspection::type<SpawnWorker>("SpawnWorker"),
+      arangodb::inspection::type<SpawnCleanup>("SpawnCleanup"));
 }
 
 }  // namespace arangodb::pregel::message

--- a/arangod/Pregel/Worker/Handler.h
+++ b/arangod/Pregel/Worker/Handler.h
@@ -31,6 +31,7 @@
 #include "Pregel/Worker/State.h"
 #include "Pregel/Conductor/Messages.h"
 #include "Pregel/ResultMessages.h"
+#include "Pregel/SpawnMessages.h"
 
 namespace arangodb::pregel::worker {
 
@@ -434,6 +435,8 @@ struct WorkerHandler : actor::HandlerBase<Runtime, WorkerState<V, E, M>> {
 
     this->finish();
 
+    this->template dispatch<pregel::message::SpawnMessages>(
+        this->state->spawnActor, pregel::message::SpawnCleanup{});
     this->template dispatch<pregel::conductor::message::ConductorMessages>(
         this->state->conductor, pregel::conductor::message::CleanupFinished{});
 

--- a/arangod/Pregel/Worker/Handler.h
+++ b/arangod/Pregel/Worker/Handler.h
@@ -427,6 +427,19 @@ struct WorkerHandler : actor::HandlerBase<Runtime, WorkerState<V, E, M>> {
     return std::move(this->state);
   }
 
+  auto operator()(message::Cleanup msg)
+      -> std::unique_ptr<WorkerState<V, E, M>> {
+    LOG_TOPIC("664f5", INFO, Logger::PREGEL)
+        << fmt::format("Worker Actor {} is cleaned", this->self);
+
+    this->finish();
+
+    this->template dispatch<pregel::conductor::message::ConductorMessages>(
+        this->state->conductor, pregel::conductor::message::CleanupFinished{});
+
+    return std::move(this->state);
+  }
+
   auto operator()(actor::message::UnknownMessage unknown)
       -> std::unique_ptr<WorkerState<V, E, M>> {
     LOG_TOPIC("7ee4d", INFO, Logger::PREGEL) << fmt::format(

--- a/arangod/Pregel/Worker/Messages.h
+++ b/arangod/Pregel/Worker/Messages.h
@@ -97,20 +97,6 @@ auto inspect(Inspector& f, RunGlobalSuperStep& x) {
       f.field("aggregators", x.aggregators));
 }
 
-struct Store {};
-template<typename Inspector>
-auto inspect(Inspector& f, Store& x) {
-  return f.object(x).fields();
-}
-
-struct ProduceResults {
-  bool withID;
-};
-template<typename Inspector>
-auto inspect(Inspector& f, ProduceResults& x) {
-  return f.object(x).fields(f.field("withID", x.withID));
-}
-
 struct PregelMessage {
   ExecutionNumber executionNumber;
   uint64_t gss;
@@ -125,11 +111,31 @@ auto inspect(Inspector& f, PregelMessage& x) {
       f.field("messages", x.messages));
 }
 
+struct Store {};
+template<typename Inspector>
+auto inspect(Inspector& f, Store& x) {
+  return f.object(x).fields();
+}
+
+struct ProduceResults {
+  bool withID;
+};
+template<typename Inspector>
+auto inspect(Inspector& f, ProduceResults& x) {
+  return f.object(x).fields(f.field("withID", x.withID));
+}
+
+struct Cleanup {};
+template<typename Inspector>
+auto inspect(Inspector& f, Cleanup& x) {
+  return f.object(x).fields();
+}
+
 struct WorkerMessages
     : std::variant<WorkerStart, CreateWorker, LoadGraph, RunGlobalSuperStep,
-                   Store, PregelMessage, ProduceResults> {
+                   PregelMessage, Store, ProduceResults, Cleanup> {
   using std::variant<WorkerStart, CreateWorker, LoadGraph, RunGlobalSuperStep,
-                     Store, PregelMessage, ProduceResults>::variant;
+                     PregelMessage, Store, ProduceResults, Cleanup>::variant;
 };
 template<typename Inspector>
 auto inspect(Inspector& f, WorkerMessages& x) {
@@ -140,7 +146,8 @@ auto inspect(Inspector& f, WorkerMessages& x) {
       arangodb::inspection::type<RunGlobalSuperStep>("RunGlobalSuperStep"),
       arangodb::inspection::type<PregelMessage>("PregelMessage"),
       arangodb::inspection::type<Store>("Store"),
-      arangodb::inspection::type<ProduceResults>("ProduceResults"));
+      arangodb::inspection::type<ProduceResults>("ProduceResults"),
+      arangodb::inspection::type<Cleanup>("Cleanup"));
 }
 
 }  // namespace worker::message

--- a/arangod/Pregel/Worker/State.h
+++ b/arangod/Pregel/Worker/State.h
@@ -44,7 +44,8 @@ struct WorkerState {
               std::unique_ptr<MessageFormat<M>> messageFormat,
               std::unique_ptr<MessageCombiner<M>> messageCombiner,
               std::unique_ptr<Algorithm<V, E, M>> algorithm,
-              TRI_vocbase_t& vocbase, actor::ActorPID resultActor)
+              TRI_vocbase_t& vocbase, actor::ActorPID spawnActor,
+              actor::ActorPID resultActor)
       : config{std::make_shared<WorkerConfig>(&vocbase)},
         workerContext{std::move(workerContext)},
         messageFormat{std::move(messageFormat)},
@@ -52,6 +53,7 @@ struct WorkerState {
         conductor{std::move(conductor)},
         algorithm{std::move(algorithm)},
         vocbaseGuard{vocbase},
+        spawnActor(spawnActor),
         resultActor(resultActor) {
     config->updateConfig(specifications);
 
@@ -110,6 +112,7 @@ struct WorkerState {
   actor::ActorPID conductor;
   std::unique_ptr<Algorithm<V, E, M>> algorithm;
   const DatabaseGuard vocbaseGuard;
+  const actor::ActorPID spawnActor;
   const actor::ActorPID resultActor;
   // TODO GOROD-1546 add graph store when it is not dependent any more on
   // feature: std::unique_ptr<GraphStore> graphStore;


### PR DESCRIPTION
Adds cancel state that cleans up worker and spawn actors (meaning they are set to finished, such that garbage collection can delete them).

I changed all other final states (Done, FatalError and AQLResultsAvailable) do the same cleanup.

When the cleanup is finished in all these states, the conductor changes its execution state to Finished state, which cleans up the conductor.