### PR TITLE
[CINFRA-718] Snapshot mutex

### DIFF
--- a/arangod/Replication2/StateMachines/Document/DocumentStateSnapshot.h
+++ b/arangod/Replication2/StateMachines/Document/DocumentStateSnapshot.h
@@ -35,7 +35,7 @@
 #include <memory>
 #include <optional>
 #include <variant>
-#include <shared_mutex>
+#include <mutex>
 
 namespace arangodb::replication2::replicated_state::document {
 struct ICollectionReader;
@@ -318,6 +318,6 @@ class Snapshot {
   SnapshotConfig _config;
   SnapshotState _state;
   SnapshotStatistics _statistics;
-  std::shared_mutex _shardsMutex;
+  mutable std::mutex _mutex;
 };
 }  // namespace arangodb::replication2::replicated_state::document


### PR DESCRIPTION
### Scope & Purpose

A crash was detected during chaos testing. We believe it to be due to incorrect usage of the mutex in the Snapshot class.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification