### PR TITLE
fix issues with deferred database creation

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,21 @@
+v3.9.11 (XXXX-XX-XX)
+--------------------
+
+* Fix issues with deferred database creation
+
+  When a database has made it into the Plan part of the agency with some
+  settings, e.g. `replicationFactor` that would violate the current
+  settings for databases (e.g. `--cluster.min-replication-factor` and
+  `--cluster.max-replication-factor`), and then a new DB server is added,
+  it will try to create the database locally with the settings from the
+  Plan.
+  As these settings however violate the min/max replication factor values,
+  the database is not created on the new DB server and an error is written
+  into Current instead.
+  This can cause follow-up errors and the PlanSyncer complaining about
+  missing databases for analyzers etc.
+
+
 v3.9.10 (2023-03-16)
 --------------------
 

--- a/arangod/Cluster/ClusterInfo.cpp
+++ b/arangod/Cluster/ClusterInfo.cpp
@@ -1014,6 +1014,13 @@ void ClusterInfo::loadPlan() {
 
         // create a local database object...
         arangodb::CreateDatabaseInfo info(_server, ExecContext::current());
+        // validation of the database creation parameters should have happened
+        // already when we get here. whenever we get here, we have a database
+        // in the plan with whatever settings.
+        // we should not make the validation fail here, because that can lead
+        // to all sorts of problems later on if _new_ servers join the cluster
+        // that validate _existing_ databases. this must not fail.
+        info.strictValidation(false);
         Result res = info.load(dbSlice, VPackSlice::emptyArraySlice());
 
         if (res.fail()) {

--- a/arangod/Cluster/Maintenance.cpp
+++ b/arangod/Cluster/Maintenance.cpp
@@ -1468,7 +1468,7 @@ arangodb::Result arangodb::maintenance::reportInCurrent(
       }
 
       // UpdateCurrentForCollections (Current/Collections/Collection)
-      if (curcolls.isObject()) {
+      if (curcolls.isObject() && ldb.isObject()) {
         for (auto const& collection : VPackObjectIterator(curcolls)) {
           auto const colName = collection.key.copyString();
 
@@ -1483,8 +1483,6 @@ arangodb::Result arangodb::maintenance::reportInCurrent(
             // Shard in current and has servers
             auto servers = shard.value.get(SERVERS);
             auto const shName = shard.key.copyString();
-
-            TRI_ASSERT(ldb.isObject());
 
             if (servers.isArray() && servers.length() > 0  // servers in current
                 && servers[0].stringRef() == serverId      // we are leading

--- a/arangod/VocBase/Methods/Databases.cpp
+++ b/arangod/VocBase/Methods/Databases.cpp
@@ -338,6 +338,16 @@ arangodb::Result Databases::create(
   }
 
   CreateDatabaseInfo createInfo(server, exec);
+  if (ServerState::instance()->isDBServer()) {
+    // if we are on a DB server, we are likely called by the maintenance,
+    // and validation of database creation should have happened on the
+    // coordinator already.
+    // we should not make the validation fail on the DB server only,
+    // because that can lead to all sorts of problems later on if _new_
+    // DB servers are added and that validate _existing_ database
+    // differently.
+    createInfo.strictValidation(false);
+  }
   arangodb::Result res = createInfo.load(dbName, options, users);
 
   if (!res.ok()) {

--- a/arangod/VocBase/Methods/Databases.cpp
+++ b/arangod/VocBase/Methods/Databases.cpp
@@ -344,7 +344,7 @@ arangodb::Result Databases::create(
     // coordinator already.
     // we should not make the validation fail on the DB server only,
     // because that can lead to all sorts of problems later on if _new_
-    // DB servers are added and that validate _existing_ database
+    // DB servers are added that validate _existing_ databases
     // differently.
     createInfo.strictValidation(false);
   }

--- a/arangod/VocBase/VocbaseInfo.cpp
+++ b/arangod/VocBase/VocbaseInfo.cpp
@@ -48,6 +48,12 @@ ShardingPrototype CreateDatabaseInfo::shardingPrototype() const {
   return _shardingPrototype;
 }
 
+uint64_t CreateDatabaseInfo::getId() const {
+  TRI_ASSERT(_valid);
+  TRI_ASSERT(_validId || !_strictValidation);
+  return _id;
+}
+
 void CreateDatabaseInfo::shardingPrototype(ShardingPrototype type) {
   _shardingPrototype = type;
 }

--- a/arangod/VocBase/VocbaseInfo.h
+++ b/arangod/VocBase/VocbaseInfo.h
@@ -39,9 +39,6 @@ namespace application_features {
 class ApplicationServer;
 }
 
-// TODO do we need to add some sort of coordinator?
-// builder.add("coordinator", VPackValue(ServerState::instance()->getId()));
-
 struct DBUser {
   DBUser() = default;
   DBUser(DBUser const&) =
@@ -93,11 +90,7 @@ class CreateDatabaseInfo {
 
   application_features::ApplicationServer& server() const;
 
-  uint64_t getId() const {
-    TRI_ASSERT(_valid);
-    TRI_ASSERT(_validId);
-    return _id;
-  }
+  uint64_t getId() const;
 
   void strictValidation(bool value) noexcept { _strictValidation = value; }
 

--- a/tests/js/client/server_parameters/database-invalid-replication-factor-cluster.js
+++ b/tests/js/client/server_parameters/database-invalid-replication-factor-cluster.js
@@ -1,0 +1,121 @@
+/*jshint globalstrict:false, strict:true */
+/*global getOptions, assertEqual, assertTrue, assertFalse, fail */
+
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2010-2016 triagens GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is triAGENS GmbH, Cologne, Germany
+///
+/// @author Jan Steemann
+/// @author Copyright 2023, triAGENS GmbH, Cologne, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+if (getOptions === true) {
+  return {
+    'cluster.min-replication-factor': '2',
+    'cluster.max-replication-factor': '3',
+    'cluster.default-replication-factor': '2',
+  };
+}
+
+const jsunity = require("jsunity");
+const wait = require("internal").sleep;
+const errors = require("internal").errors;
+const helper = require("@arangodb/test-helper");
+const db = require("@arangodb").db;
+
+function InvalidReplicationFactorTestSuite () {
+  'use strict';
+
+  const name = "someTestDatabase";
+  
+  return {
+    tearDown : function () {
+      try {
+        db._dropDatabase(name);
+      } catch (err) {
+      }
+    },
+    
+    testCreateDatabaseWithInvalidReplicationFactor : function () {
+      try {
+        db._createDatabase(name, { replicationFactor: 1 });
+        fail();
+      } catch (err) {
+        assertEqual(errors.ERROR_BAD_PARAMETER.code, err.errorNum);
+      }
+    },
+
+    testStoreDatabaseInPlanWithInvalidReplicationFactor : function () {
+      // inject a database with replicationFactor 1 into the Plan,
+      // bypassing the database creation API, which would validate the
+      // replication factor
+      const data = {
+        "writeConcern": 1,
+        "sharding": "single",
+        "replicationFactor": 1,
+        "name": name,
+        "isSystem": false,
+        "id": "3457693543845" // just assume this ID is not used otherwise
+      };
+      const key = "Plan/Databases/" + name;
+      helper.agency.set(key, data);
+      helper.agency.increaseVersion("Plan/Version");
+
+      let res = helper.agency.get(key).arango.Plan.Databases[name];
+      assertEqual(res, data);
+   
+      const dbServers = helper.getEndpointsByType("dbserver").length;
+
+      let keys, current;
+      let tries = 0;
+
+      while (++tries < 50) {
+        let res = helper.agency.get("Current/Databases").arango.Current.Databases;
+        if (!res.hasOwnProperty(name)) {
+          wait(0.5);
+          continue;
+        } 
+
+        current = res[name];
+        keys = Object.keys(current);
+        if (keys.length < dbServers) {
+          // not all DB servers reported in Current
+          wait(0.5);
+          continue;
+        }
+
+        break;
+      }
+
+      // all DB servers must have picked up the database and successfully
+      // report it to Current, despite the replicationFactor that isnt'r right.
+      keys.forEach((k) => {
+        assertFalse(current[k].error);
+        assertEqual(0, current[k].errorNum);
+        assertEqual("", current[k].errorMessage);
+        assertEqual(name, current[k].name);
+      });
+    },
+
+  };
+}
+
+
+jsunity.run(InvalidReplicationFactorTestSuite);
+
+return jsunity.done();


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/18431

When a database has made it into the Plan part of the agency with some settings, e.g. `replicationFactor` that would violate the current settings for databases (e.g. `--cluster.min-replication-factor` and `--cluster.max-replication-factor`), and then a new DB server is added, it will try to create the database locally with the settings from the Plan.
As these settings however violate the min/max replication factor values, the database is not created on the new DB server and an error is written into Current instead.
This can cause follow-up errors and the PlanSyncer complaining about missing databases for analyzers etc.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.10: https://github.com/arangodb/arangodb/pull/18432
  - [x] Backport for 3.9: this PR
  - [ ] Backport for 3.8: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 