### PR TITLE
[GORDO-1582] Cancel pregel run

### DIFF
--- a/arangod/Pregel/Actor/include/Actor/ActorList.h
+++ b/arangod/Pregel/Actor/include/Actor/ActorList.h
@@ -48,6 +48,11 @@ struct ActorList {
   ActorList(ActorMap map) : actors{std::move(map)} {}
   ActorList() = default;
 
+  auto contains(ActorID id) const -> bool {
+    return actors.doUnderLock(
+        [id](ActorMap const& map) -> bool { return map.contains(id); });
+  }
+
   auto find(ActorID id) const -> std::optional<std::shared_ptr<ActorBase>> {
     return actors.doUnderLock(
         [id](ActorMap const& map) -> std::optional<std::shared_ptr<ActorBase>> {

--- a/arangod/Pregel/Actor/include/Actor/Runtime.h
+++ b/arangod/Pregel/Actor/include/Actor/Runtime.h
@@ -83,6 +83,8 @@ struct Runtime
 
   auto getActorIDs() -> std::vector<ActorID> { return actors.allIDs(); }
 
+  auto contains(ActorID id) const -> bool { return actors.contains(id); }
+
   template<typename ActorConfig>
   auto getActorStateByID(ActorID id) const
       -> std::optional<typename ActorConfig::State> {

--- a/arangod/Pregel/Conductor/ExecutionStates/AQLResultsAvailableState.h
+++ b/arangod/Pregel/Conductor/ExecutionStates/AQLResultsAvailableState.h
@@ -39,6 +39,7 @@ struct AQLResultsAvailable : ExecutionState {
   AQLResultsAvailable(ConductorState& conductor);
   auto name() const -> std::string override { return "done"; }
   auto aqlResultsAvailable() const -> bool override { return true; }
+  auto canBeCanceled() const -> bool override { return false; }
   auto messages()
       -> std::unordered_map<actor::ActorPID,
                             worker::message::WorkerMessages> override;

--- a/arangod/Pregel/Conductor/ExecutionStates/CanceledState.cpp
+++ b/arangod/Pregel/Conductor/ExecutionStates/CanceledState.cpp
@@ -61,7 +61,9 @@ auto Canceled::receive(actor::ActorPID sender,
     -> std::optional<std::unique_ptr<ExecutionState>> {
   if (not conductor.workers.contains(sender) or
       not std::holds_alternative<message::CleanupFinished>(message)) {
-    return std::make_unique<FatalError>(conductor);
+    // can receive all kinds of messages initiated from other states
+    // ignore them and just continue if it is CleanupFinished message
+    return std::nullopt;
   }
   conductor.workers.erase(sender);
   if (conductor.workers.empty()) {

--- a/arangod/Pregel/Conductor/ExecutionStates/CanceledState.h
+++ b/arangod/Pregel/Conductor/ExecutionStates/CanceledState.h
@@ -32,6 +32,7 @@ struct Canceled : ExecutionState {
   Canceled(ConductorState& conductor);
   ~Canceled() {}
   auto name() const -> std::string override { return "canceled"; };
+  auto canBeCanceled() const -> bool override { return false; }
   auto messages()
       -> std::unordered_map<actor::ActorPID,
                             worker::message::WorkerMessages> override;

--- a/arangod/Pregel/Conductor/ExecutionStates/DoneState.h
+++ b/arangod/Pregel/Conductor/ExecutionStates/DoneState.h
@@ -31,6 +31,7 @@ struct ConductorState;
 struct Done : ExecutionState {
   Done(ConductorState& conductor);
   auto name() const -> std::string override { return "done"; }
+  auto canBeCanceled() const -> bool override { return false; }
   auto messages()
       -> std::unordered_map<actor::ActorPID,
                             worker::message::WorkerMessages> override;

--- a/arangod/Pregel/Conductor/ExecutionStates/FatalErrorState.h
+++ b/arangod/Pregel/Conductor/ExecutionStates/FatalErrorState.h
@@ -32,6 +32,7 @@ struct FatalError : ExecutionState {
   FatalError(ConductorState& conductor);
   ~FatalError() = default;
   auto name() const -> std::string override { return "fatal error"; };
+  auto canBeCanceled() const -> bool override { return false; }
   auto messages()
       -> std::unordered_map<actor::ActorPID,
                             worker::message::WorkerMessages> override;

--- a/arangod/Pregel/Conductor/ExecutionStates/State.h
+++ b/arangod/Pregel/Conductor/ExecutionStates/State.h
@@ -44,6 +44,7 @@ struct ExecutionState {
                        conductor::message::ConductorMessages message)
       -> std::optional<std::unique_ptr<ExecutionState>> = 0;
   virtual auto aqlResultsAvailable() const -> bool { return false; }
+  virtual auto canBeCanceled() const -> bool { return true; }
   virtual ~ExecutionState() = default;
 };
 

--- a/arangod/Pregel/Conductor/Handler.h
+++ b/arangod/Pregel/Conductor/Handler.h
@@ -54,10 +54,11 @@ struct ConductorHandler : actor::HandlerBase<Runtime, ConductorState> {
     for (auto& [server, message] : messages) {
       this->dispatch(
           this->state->spawnActor,
-          pregel::message::SpawnMessages{
-              pregel::message::SpawnWorker{.destinationServer = server,
-                                           .conductor = this->self,
-                                           .message = message}});
+          pregel::message::SpawnMessages{pregel::message::SpawnWorker{
+              .destinationServer = server,
+              .conductor = this->self,
+              .resultActorOnCoordinator = this->state->resultActor,
+              .message = message}});
     }
     return std::move(this->state);
   }

--- a/arangod/Pregel/Conductor/Messages.h
+++ b/arangod/Pregel/Conductor/Messages.h
@@ -145,14 +145,20 @@ auto inspect(Inspector& f, CleanupFinished& x) {
   return f.object(x).fields();
 }
 
+struct Cancel {};
+template<typename Inspector>
+auto inspect(Inspector& f, Cancel& x) {
+  return f.object(x).fields();
+}
+
 struct ConductorMessages
     : std::variant<ConductorStart, ResultT<WorkerCreated>, ResultT<GraphLoaded>,
                    ResultT<GlobalSuperStepFinished>, ResultT<Stored>,
-                   ResultCreated, StatusUpdate, CleanupFinished> {
+                   ResultCreated, StatusUpdate, CleanupFinished, Cancel> {
   using std::variant<ConductorStart, ResultT<WorkerCreated>,
                      ResultT<GraphLoaded>, ResultT<GlobalSuperStepFinished>,
                      ResultT<Stored>, ResultCreated, StatusUpdate,
-                     CleanupFinished>::variant;
+                     CleanupFinished, Cancel>::variant;
 };
 template<typename Inspector>
 auto inspect(Inspector& f, ConductorMessages& x) {
@@ -165,7 +171,8 @@ auto inspect(Inspector& f, ConductorMessages& x) {
       arangodb::inspection::type<ResultT<Stored>>("Stored"),
       arangodb::inspection::type<ResultCreated>("ResultCreated"),
       arangodb::inspection::type<StatusUpdate>("StatusUpdate"),
-      arangodb::inspection::type<CleanupFinished>("CleanupFinished"));
+      arangodb::inspection::type<CleanupFinished>("CleanupFinished"),
+      arangodb::inspection::type<Cancel>("Cancel"));
 }
 
 }  // namespace conductor::message

--- a/arangod/Pregel/PregelFeature.h
+++ b/arangod/Pregel/PregelFeature.h
@@ -129,6 +129,8 @@ class PregelFeature final : public ArangodFeature {
 
   auto metrics() -> std::shared_ptr<PregelMetrics> { return _metrics; }
 
+  auto cancel(ExecutionNumber executionNumber) -> Result;
+
  private:
   void scheduleGarbageCollection();
 
@@ -164,9 +166,9 @@ class PregelFeature final : public ArangodFeature {
   std::shared_ptr<actor::Runtime<PregelScheduler, ArangoExternalDispatcher>>
       _actorRuntime;
 
-  std::unordered_map<ExecutionNumber, actor::ActorPID> _resultActors;
-
-  Guarded<std::unordered_map<ExecutionNumber, actor::ActorPID>> _statusActors;
+  std::unordered_map<ExecutionNumber, actor::ActorPID> _resultActor;
+  // conductor actor is only used on the coordinator
+  std::unordered_map<ExecutionNumber, actor::ActorPID> _conductorActor;
 };
 
 }  // namespace arangodb::pregel

--- a/arangod/Pregel/PregelFeature.h
+++ b/arangod/Pregel/PregelFeature.h
@@ -166,9 +166,9 @@ class PregelFeature final : public ArangodFeature {
   std::shared_ptr<actor::Runtime<PregelScheduler, ArangoExternalDispatcher>>
       _actorRuntime;
 
-  std::unordered_map<ExecutionNumber, actor::ActorPID> _resultActor;
+  Guarded<std::unordered_map<ExecutionNumber, actor::ActorPID>> _resultActor;
   // conductor actor is only used on the coordinator
-  std::unordered_map<ExecutionNumber, actor::ActorPID> _conductorActor;
+  Guarded<std::unordered_map<ExecutionNumber, actor::ActorPID>> _conductorActor;
 };
 
 }  // namespace arangodb::pregel

--- a/arangod/Pregel/PregelFeature.h
+++ b/arangod/Pregel/PregelFeature.h
@@ -169,6 +169,7 @@ class PregelFeature final : public ArangodFeature {
   Guarded<std::unordered_map<ExecutionNumber, actor::ActorPID>> _resultActor;
   // conductor actor is only used on the coordinator
   Guarded<std::unordered_map<ExecutionNumber, actor::ActorPID>> _conductorActor;
+  Guarded<std::unordered_map<ExecutionNumber, actor::ActorPID>> _statusActors;
 };
 
 }  // namespace arangodb::pregel

--- a/arangod/Pregel/REST/RestPregelHandler.cpp
+++ b/arangod/Pregel/REST/RestPregelHandler.cpp
@@ -106,8 +106,11 @@ RestStatus RestPregelHandler::execute() {
             actor::ActorPID{.server = ServerState::instance()->getId(),
                             .database = _vocbase.name(),
                             .id = resultActorID};
-        _pregel._resultActor.emplace(spawnWorkerMsg.message.executionNumber,
-                                     resultActorPID);
+        _pregel._resultActor.doUnderLock(
+            [&spawnWorkerMsg, &resultActorPID](auto& actors) {
+              actors.emplace(spawnWorkerMsg.message.executionNumber,
+                             resultActorPID);
+            });
         _pregel._actorRuntime->dispatch<message::ResultMessages>(
             resultActorPID, spawnWorkerMsg.resultActorOnCoordinator,
             message::OtherResultActorStarted{});

--- a/arangod/Pregel/REST/RestPregelHandler.cpp
+++ b/arangod/Pregel/REST/RestPregelHandler.cpp
@@ -32,6 +32,7 @@
 #include "Inspection/VPackWithErrorT.h"
 #include "Logger/LogMacros.h"
 #include "Pregel/PregelFeature.h"
+#include "Pregel/ResultMessages.h"
 #include "Pregel/SpawnActor.h"
 #include "Pregel/Utils.h"
 #include "Pregel/ResultActor.h"
@@ -95,6 +96,8 @@ RestStatus RestPregelHandler::execute() {
                                     inspection::json(spawnMessage.get())));
           return RestStatus::DONE;
         }
+        auto spawnWorkerMsg =
+            std::get<message::SpawnWorker>(spawnMessage.get());
 
         auto resultActorID = _pregel._actorRuntime->spawn<ResultActor>(
             _vocbase.name(), std::make_unique<ResultState>(),
@@ -103,10 +106,11 @@ RestStatus RestPregelHandler::execute() {
             actor::ActorPID{.server = ServerState::instance()->getId(),
                             .database = _vocbase.name(),
                             .id = resultActorID};
-        _pregel._resultActors.emplace(
-            std::get<message::SpawnWorker>(spawnMessage.get())
-                .message.executionNumber,
-            resultActorPID);
+        _pregel._resultActor.emplace(spawnWorkerMsg.message.executionNumber,
+                                     resultActorPID);
+        _pregel._actorRuntime->dispatch<message::ResultMessages>(
+            resultActorPID, spawnWorkerMsg.resultActorOnCoordinator,
+            message::OtherResultActorStarted{});
 
         _pregel._actorRuntime->spawn<SpawnActor>(
             _vocbase.name(),

--- a/arangod/Pregel/ResultMessages.h
+++ b/arangod/Pregel/ResultMessages.h
@@ -35,6 +35,12 @@ auto inspect(Inspector& f, ResultStart& x) {
   return f.object(x).fields();
 }
 
+struct OtherResultActorStarted {};
+template<typename Inspector>
+auto inspect(Inspector& f, OtherResultActorStarted& x) {
+  return f.object(x).fields();
+}
+
 struct SaveResults {
   ResultT<PregelResults> results = {PregelResults{}};
 };
@@ -54,16 +60,27 @@ auto inspect(Inspector& f, AddResults& x) {
       f.field("receivedAllResults", x.receivedAllResults));
 }
 
-struct ResultMessages : std::variant<ResultStart, SaveResults, AddResults> {
-  using std::variant<ResultStart, SaveResults, AddResults>::variant;
+struct ResultCleanup {};
+template<typename Inspector>
+auto inspect(Inspector& f, ResultCleanup& x) {
+  return f.object(x).fields();
+}
+
+struct ResultMessages : std::variant<ResultStart, OtherResultActorStarted,
+                                     SaveResults, AddResults, ResultCleanup> {
+  using std::variant<ResultStart, OtherResultActorStarted, SaveResults,
+                     AddResults, ResultCleanup>::variant;
 };
 
 template<typename Inspector>
 auto inspect(Inspector& f, ResultMessages& x) {
   return f.variant(x).unqualified().alternatives(
       arangodb::inspection::type<ResultStart>("Start"),
+      arangodb::inspection::type<OtherResultActorStarted>(
+          "OtherResultActorStarted"),
       arangodb::inspection::type<SaveResults>("SaveResults"),
-      arangodb::inspection::type<AddResults>("AddResults"));
+      arangodb::inspection::type<AddResults>("AddResults"),
+      arangodb::inspection::type<ResultCleanup>("Cleanup"));
 }
 
 }  // namespace arangodb::pregel::message

--- a/arangod/Pregel/SpawnMessages.h
+++ b/arangod/Pregel/SpawnMessages.h
@@ -38,13 +38,16 @@ auto inspect(Inspector& f, SpawnStart& x) {
 struct SpawnWorker {
   actor::ServerID destinationServer;
   actor::ActorPID conductor;
+  actor::ActorPID resultActorOnCoordinator;
   worker::message::CreateWorker message;
 };
 template<typename Inspector>
 auto inspect(Inspector& f, SpawnWorker& x) {
-  return f.object(x).fields(f.field("destinationServer", x.destinationServer),
-                            f.field("conductor", x.conductor),
-                            f.field("message", x.message));
+  return f.object(x).fields(
+      f.field("destinationServer", x.destinationServer),
+      f.field("conductor", x.conductor),
+      f.field("resultActorOnCoordinator", x.resultActorOnCoordinator),
+      f.field("message", x.message));
 }
 
 struct SpawnCleanup {};

--- a/arangod/V8Server/v8-pregel.cpp
+++ b/arangod/V8Server/v8-pregel.cpp
@@ -220,12 +220,12 @@ static void JS_PregelCancel(v8::FunctionCallbackInfo<v8::Value> const& args) {
 
   auto executionNum = arangodb::pregel::ExecutionNumber{
       TRI_ObjectToUInt64(isolate, args[0], true)};
-  auto c = pregel.conductor(executionNum);
-  if (!c) {
-    TRI_V8_THROW_EXCEPTION_MESSAGE(TRI_ERROR_CURSOR_NOT_FOUND,
-                                   "Execution number is invalid");
+
+  auto canceled = pregel.cancel(executionNum);
+  if (canceled.fail()) {
+    TRI_V8_THROW_EXCEPTION_MESSAGE(canceled.errorNumber(),
+                                   canceled.errorMessage());
   }
-  c->cancel();
 
   TRI_V8_RETURN_UNDEFINED();
   TRI_V8_TRY_CATCH_END


### PR DESCRIPTION
With this PR you are able to cancel a pregel run. This does two things:
1. If pregel is still running: Cancel the run and cleanup the conductor (setting it to finished such that actor garbage collection can remove it). For that we now have now another map of execution number to conductor pid inside the pregel feature, such that we can find the conductor for the corresponding execution number.
2. Independent of pregel running or already finished: Cleanup all result actors (on conductor and workers). For this to work, the result actor on the coordinator has to know the actor pids of the result actors on the dbservers: In the RestPregelHandler this pid is send to the result actor on the coordinator after a result actor is created on the dbserver.

This PR adds the contains function to the actor runtime which checks if the runtime contains an actor with a given actor pid. This is needed because the map of execution number to conductor pid in the feature is not necessarily up-to-date: A conductor finishes itself after the pregel run finished and is then garbage collected, but this cannot be communicated to the feature. Therefore we always have to check if a conductor in this map still exists in the runtime.