### PR TITLE
[CINFRA] Remove getCommittedLog finally.

### DIFF
--- a/arangod/Replication2/ReplicatedLog/Components/FollowerCommitManager.cpp
+++ b/arangod/Replication2/ReplicatedLog/Components/FollowerCommitManager.cpp
@@ -26,6 +26,7 @@
 #include "Replication2/ReplicatedLog/Components/IStorageManager.h"
 #include "Logger/LogContextKeys.h"
 #include "Replication2/Exceptions/ParticipantResignedException.h"
+#include "Replication2/ReplicatedLog/TermIndexMapping.h"
 
 using namespace arangodb::replication2::replicated_log::comp;
 
@@ -33,21 +34,22 @@ auto FollowerCommitManager::updateCommitIndex(LogIndex index) noexcept
     -> DeferredAction {
   struct ResolveContext {
     WaitForResult result;
-    InMemoryLog log;
     WaitForQueue queue;
   };
 
   auto ctx = std::make_unique<ResolveContext>();
   auto guard = guardedData.getLockedGuard();
-  ctx->log = guard->storage.getCommittedLog();
 
   LOG_CTX("d2083", TRACE, loggerContext)
       << "received update commit index to " << index
       << " old commit index = " << guard->commitIndex
       << " old resolve index = " << guard->resolveIndex;
 
+  auto localSpearhead =
+      guard->storage.getTermIndexMapping().getLastIndex().value_or(
+          TermIndexPair{});
   guard->commitIndex = std::max(guard->commitIndex, index);
-  auto newResolveIndex = std::min(guard->commitIndex, ctx->log.getLastIndex());
+  auto newResolveIndex = std::min(guard->commitIndex, localSpearhead.index);
 
   if (newResolveIndex > guard->resolveIndex) {
     LOG_CTX("71a8f", TRACE, loggerContext)
@@ -67,7 +69,7 @@ auto FollowerCommitManager::updateCommitIndex(LogIndex index) noexcept
     for (auto& it : ctx->queue) {
       if (!it.second.isFulfilled()) {
         // This only throws if promise was fulfilled earlier.
-        it.second.setValue(std::make_pair(ctx->result, ctx->log));
+        it.second.setValue(ctx->result);
       }
     }
   });
@@ -86,21 +88,6 @@ FollowerCommitManager::FollowerCommitManager(IStorageManager& storage,
 
 auto FollowerCommitManager::waitFor(LogIndex index) noexcept
     -> ILogParticipant::WaitForFuture {
-  return waitForBoth(index).thenValue([](auto&& pair) { return pair.first; });
-}
-
-auto FollowerCommitManager::waitForIterator(LogIndex index) noexcept
-    -> ILogParticipant::WaitForIteratorFuture {
-  return waitForBoth(index).thenValue(
-      [index](auto&& pair) -> std::unique_ptr<LogRangeIterator> {
-        auto commitIndex = pair.first.currentCommitIndex;
-        auto& log = pair.second;
-        return log.getIteratorRange(index, commitIndex + 1);
-      });
-}
-
-auto FollowerCommitManager::waitForBoth(LogIndex index) noexcept
-    -> futures::Future<std::pair<WaitForResult, InMemoryLog>> {
   auto guard = guardedData.getLockedGuard();
 
   if (guard->isResigned) {
@@ -112,12 +99,26 @@ auto FollowerCommitManager::waitForBoth(LogIndex index) noexcept
 
   if (index <= guard->resolveIndex) {
     // resolve immediately
-    auto result = WaitForResult(guard->commitIndex, nullptr);
-    auto log = guard->storage.getCommittedLog();
-    return std::make_pair(result, log);
+    return WaitForResult(guard->commitIndex, nullptr);
   }
 
   return guard->waitQueue.emplace(index, ResolvePromise{})->second.getFuture();
+}
+
+auto FollowerCommitManager::waitForIterator(LogIndex index) noexcept
+    -> ILogParticipant::WaitForIteratorFuture {
+  return waitFor(index).thenValue(
+      [index,
+       weak = weak_from_this()](auto&&) -> std::unique_ptr<LogRangeIterator> {
+        if (auto self = weak.lock(); self) {
+          auto guard = self->guardedData.getLockedGuard();
+          return guard->storage.getCommittedLogIterator(
+              LogRange{index, guard->resolveIndex + 1});
+        }
+
+        THROW_ARANGO_EXCEPTION(
+            TRI_ERROR_REPLICATION_REPLICATED_LOG_FOLLOWER_RESIGNED);
+      });
 }
 
 void FollowerCommitManager::resign() noexcept {

--- a/arangod/Replication2/ReplicatedLog/Components/FollowerCommitManager.h
+++ b/arangod/Replication2/ReplicatedLog/Components/FollowerCommitManager.h
@@ -32,7 +32,9 @@ inline namespace comp {
 
 struct IStorageManager;
 
-struct FollowerCommitManager : IFollowerCommitManager {
+struct FollowerCommitManager
+    : IFollowerCommitManager,
+      std::enable_shared_from_this<FollowerCommitManager> {
   explicit FollowerCommitManager(IStorageManager&, IStateHandleManager&,
                                  LoggerContext const& loggerContext);
   auto updateCommitIndex(LogIndex index) noexcept -> DeferredAction override;
@@ -46,12 +48,9 @@ struct FollowerCommitManager : IFollowerCommitManager {
   void resign() noexcept;
 
  private:
-  using ResolveType = std::pair<WaitForResult, InMemoryLog>;
-  using ResolveFuture = futures::Future<ResolveType>;
-  using ResolvePromise = futures::Promise<ResolveType>;
+  using ResolvePromise = futures::Promise<WaitForResult>;
+  using ResolveFuture = futures::Future<WaitForResult>;
   using WaitForQueue = std::multimap<LogIndex, ResolvePromise>;
-
-  auto waitForBoth(LogIndex) noexcept -> ResolveFuture;
 
   struct GuardedData {
     explicit GuardedData(IStorageManager&, IStateHandleManager&);

--- a/arangod/Replication2/ReplicatedLog/Components/IStorageManager.h
+++ b/arangod/Replication2/ReplicatedLog/Components/IStorageManager.h
@@ -74,7 +74,6 @@ struct IStorageManager {
   virtual auto transaction() -> std::unique_ptr<IStorageTransaction> = 0;
   [[nodiscard]] virtual auto getTermIndexMapping() const
       -> TermIndexMapping = 0;
-  [[nodiscard]] virtual auto getCommittedLog() const -> InMemoryLog = 0;
   [[nodiscard]] virtual auto getCommittedLogIterator(
       std::optional<LogRange> range = std::nullopt) const
       -> std::unique_ptr<TypedLogRangeIterator<LogEntryView>> = 0;

--- a/arangod/Replication2/ReplicatedLog/Components/StorageManager.cpp
+++ b/arangod/Replication2/ReplicatedLog/Components/StorageManager.cpp
@@ -338,16 +338,14 @@ auto StorageManager::getPeristedLogIterator(std::optional<LogRange> bounds)
         : _range(range), _disk(std::move(disk)) {}
 
     auto next() -> std::optional<PersistingLogEntry> override {
-      while (true) {
-        auto entry = _disk->next();
-        if (not entry) {
-          return std::nullopt;
-        }
-        if (not _range.contains(entry->logIndex())) {
-          return std::nullopt;  // end of range
-        }
-        return entry;
+      auto entry = _disk->next();
+      if (not entry) {
+        return std::nullopt;
       }
+      if (not _range.contains(entry->logIndex())) {
+        return std::nullopt;  // end of range
+      }
+      return entry;
     }
 
     LogRange _range;

--- a/arangod/Replication2/ReplicatedLog/Components/StorageManager.h
+++ b/arangod/Replication2/ReplicatedLog/Components/StorageManager.h
@@ -42,10 +42,11 @@ struct StorageManager : IStorageManager,
                           LoggerContext const& loggerContext);
   auto resign() noexcept -> std::unique_ptr<IStorageEngineMethods>;
   auto transaction() -> std::unique_ptr<IStorageTransaction> override;
-  auto getCommittedLog() const -> InMemoryLog override;
   auto getCommittedLogIterator(std::optional<LogRange> range) const
       -> std::unique_ptr<LogRangeIterator> override;
   auto getPeristedLogIterator(LogIndex first) const
+      -> std::unique_ptr<PersistedLogIterator>;
+  auto getPeristedLogIterator(std::optional<LogRange> range) const
       -> std::unique_ptr<PersistedLogIterator>;
   auto getTermIndexMapping() const -> TermIndexMapping override;
   auto beginMetaInfoTrx() -> std::unique_ptr<IStateInfoTransaction> override;

--- a/tests/Replication2/ReplicatedLog/Components/CompactionManagerTest.cpp
+++ b/tests/Replication2/ReplicatedLog/Components/CompactionManagerTest.cpp
@@ -55,7 +55,6 @@ struct StorageTransactionMock : IStorageTransaction {
 struct StorageManagerMock : IStorageManager {
   MOCK_METHOD(std::unique_ptr<IStorageTransaction>, transaction, (),
               (override));
-  MOCK_METHOD(InMemoryLog, getCommittedLog, (), (const, override));
   MOCK_METHOD(std::unique_ptr<TypedLogRangeIterator<LogEntryView>>,
               getCommittedLogIterator, (std::optional<LogRange>),
               (const, override));

--- a/tests/Replication2/ReplicatedLog/Components/SnapshotManagerTest.cpp
+++ b/tests/Replication2/ReplicatedLog/Components/SnapshotManagerTest.cpp
@@ -67,7 +67,6 @@ struct StateInfoTransactionMock : IStateInfoTransaction {
 struct StorageManagerMock : IStorageManager {
   MOCK_METHOD(std::unique_ptr<IStorageTransaction>, transaction, (),
               (override));
-  MOCK_METHOD(InMemoryLog, getCommittedLog, (), (const, override));
   MOCK_METHOD(std::unique_ptr<TypedLogRangeIterator<LogEntryView>>,
               getCommittedLogIterator, (std::optional<LogRange>),
               (const, override));


### PR DESCRIPTION
### Scope & Purpose
Finaly step of evicting log entries from memory is to remove the function `getCommittedLog`. After that, it is no longer possible to get a _global_ view of the entire log at once, but instead the only option is to receive a log iterator. 

This iterator can be served from disk easily. 