### PR TITLE
[CINFRA] Remove InMemoryLogs from StorageManager

### DIFF
--- a/arangod/Replication2/ReplicatedLog/Components/AppendEntriesManager.cpp
+++ b/arangod/Replication2/ReplicatedLog/Components/AppendEntriesManager.cpp
@@ -90,7 +90,8 @@ auto AppendEntriesManager::appendEntries(AppendEntriesRequest request)
 
   {
     auto store = guard->storage.transaction();
-    if (store->getInMemoryLog().getLastIndex() != request.prevLogEntry.index) {
+    if (store->getLogBounds().to.saturatedDecrement() !=
+        request.prevLogEntry.index) {
       auto startRemoveIndex = request.prevLogEntry.index + 1;
       LOG_CTX("9272b", DEBUG, lctx)
           << "log does not append cleanly, removing starting at "

--- a/arangod/Replication2/ReplicatedLog/Components/IStorageManager.h
+++ b/arangod/Replication2/ReplicatedLog/Components/IStorageManager.h
@@ -51,7 +51,6 @@ inline namespace comp {
 
 struct IStorageTransaction {
   virtual ~IStorageTransaction() = default;
-  [[nodiscard]] virtual auto getInMemoryLog() const noexcept -> InMemoryLog = 0;
   [[nodiscard]] virtual auto getLogBounds() const noexcept -> LogRange = 0;
   virtual auto removeFront(LogIndex stop) noexcept
       -> futures::Future<Result> = 0;

--- a/arangod/Replication2/ReplicatedLog/Components/StorageManager.h
+++ b/arangod/Replication2/ReplicatedLog/Components/StorageManager.h
@@ -65,22 +65,18 @@ struct StorageManager : IStorageManager,
 
   struct StorageRequest {
     std::unique_ptr<StorageOperation> operation;
-    InMemoryLog logResult;
     TermIndexMapping mappingResult;
     futures::Promise<Result> promise;
 
     ~StorageRequest();
     StorageRequest(StorageRequest&&) noexcept = default;
     explicit StorageRequest(std::unique_ptr<StorageOperation> op,
-                            InMemoryLog logResult,
                             TermIndexMapping mappingResult);
   };
 
   struct GuardedData {
     explicit GuardedData(std::unique_ptr<IStorageEngineMethods> methods);
 
-    // TODO remove InMemoryLogs
-    InMemoryLog onDiskLog, spearheadLog;
     TermIndexMapping onDiskMapping, spearheadMapping;
     std::unique_ptr<IStorageEngineMethods> methods;
     std::deque<StorageRequest> queue;
@@ -91,13 +87,11 @@ struct StorageManager : IStorageManager,
   using GuardType = Guarded<GuardedData>::mutex_guard_type;
   LoggerContext const loggerContext;
 
-  auto scheduleOperation(GuardType&&, InMemoryLog result,
-                         TermIndexMapping mapResult,
+  auto scheduleOperation(GuardType&&, TermIndexMapping mapResult,
                          std::unique_ptr<StorageOperation>)
       -> futures::Future<Result>;
   template<typename F>
-  auto scheduleOperationLambda(GuardType&&, InMemoryLog result,
-                               TermIndexMapping mapResult, F&&)
+  auto scheduleOperationLambda(GuardType&&, TermIndexMapping mapResult, F&&)
       -> futures::Future<Result>;
   void triggerQueueWorker(GuardType) noexcept;
 };

--- a/arangod/Replication2/ReplicatedLog/TermIndexMapping.cpp
+++ b/arangod/Replication2/ReplicatedLog/TermIndexMapping.cpp
@@ -142,3 +142,17 @@ void TermIndexMapping::append(TermIndexMapping const& other) noexcept {
     insert(range, term);
   }
 }
+
+auto TermIndexMapping::getIndexRange() const noexcept -> LogRange {
+  if (_mapping.empty()) {
+    return LogRange{};
+  } else {
+    auto from = _mapping.begin()->second.from;
+    auto to = _mapping.rbegin()->second.to;
+    return LogRange{from, to};
+  }
+}
+
+auto TermIndexMapping::empty() const noexcept -> bool {
+  return _mapping.empty();
+}

--- a/arangod/Replication2/ReplicatedLog/TermIndexMapping.h
+++ b/arangod/Replication2/ReplicatedLog/TermIndexMapping.h
@@ -38,9 +38,11 @@ struct TermIndexMapping {
   auto getFirstIndexOfTerm(LogTerm term) const noexcept
       -> std::optional<LogIndex>;
   auto getTermRange(LogTerm) const noexcept -> std::optional<LogRange>;
+  auto getIndexRange() const noexcept -> LogRange;
   auto getTermOfIndex(LogIndex) const noexcept -> std::optional<LogTerm>;
   auto getLastIndex() const noexcept -> std::optional<TermIndexPair>;
   auto getFirstIndex() const noexcept -> std::optional<TermIndexPair>;
+  auto empty() const noexcept -> bool;
 
   void removeFront(LogIndex stop) noexcept;
   void removeBack(LogIndex start) noexcept;

--- a/tests/Replication2/ReplicatedLog/Components/CompactionManagerTest.cpp
+++ b/tests/Replication2/ReplicatedLog/Components/CompactionManagerTest.cpp
@@ -42,7 +42,6 @@ namespace {
 struct StorageManagerMock;
 
 struct StorageTransactionMock : IStorageTransaction {
-  MOCK_METHOD(InMemoryLog, getInMemoryLog, (), (const, noexcept, override));
   MOCK_METHOD(LogRange, getLogBounds, (), (const, noexcept, override));
   MOCK_METHOD(futures::Future<Result>, removeFront, (LogIndex),
               (noexcept, override));

--- a/tests/Replication2/ReplicatedLog/Components/SnapshotManagerTest.cpp
+++ b/tests/Replication2/ReplicatedLog/Components/SnapshotManagerTest.cpp
@@ -50,7 +50,6 @@ namespace {
 struct StorageManagerMock;
 
 struct StorageTransactionMock : IStorageTransaction {
-  MOCK_METHOD(InMemoryLog, getInMemoryLog, (), (const, noexcept, override));
   MOCK_METHOD(LogRange, getLogBounds, (), (const, noexcept, override));
   MOCK_METHOD(futures::Future<Result>, removeFront, (LogIndex),
               (noexcept, override));


### PR DESCRIPTION
### Scope & Purpose

Remove all InMemoryLogs from StorageManager. On the leader on the uncommitted and not locally persisted log entries reside in memory. On the follower, only those not yet persisted.