### PR TITLE
Bug fix/allow oneshard with matching distributeshardslike

### DIFF
--- a/client-tools/Shell/TelemetricsHandler.cpp
+++ b/client-tools/Shell/TelemetricsHandler.cpp
@@ -55,7 +55,15 @@ std::string const kTelemetricsGatheringUrl =
 namespace arangodb {
 TelemetricsHandler::TelemetricsHandler(ArangoshServer& server,
                                        bool sendToEndpoint)
-    : _server(server), _sendToEndpoint(sendToEndpoint) {}
+    :
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+      _server(server),
+      _sendToEndpoint(sendToEndpoint) {
+}
+#else
+      _server(server) {
+}
+#endif
 
 TelemetricsHandler::~TelemetricsHandler() {
   if (_telemetricsThread.joinable()) {

--- a/client-tools/Shell/TelemetricsHandler.h
+++ b/client-tools/Shell/TelemetricsHandler.h
@@ -81,7 +81,9 @@ class TelemetricsHandler {
   velocypack::Builder _telemetricsFetchedInfo;
 
   std::thread _telemetricsThread;
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   bool const _sendToEndpoint;
+#endif
 };
 
 }  // namespace arangodb


### PR DESCRIPTION
### Scope & Purpose

*This PR enables an exception for OneShard databases to be allowed to create collections with exactly matching distributeShardsLike. This is required by arangosync*

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [x] Tests
  - [x] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: On Purpose no changelog entry written as this this a bug-fix for non-released feature.
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: *(Please link PR)*
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

