### PR TITLE
testing: enable rocksdb logging

### DIFF
--- a/js/client/modules/@arangodb/testsuites/endpoints.js
+++ b/js/client/modules/@arangodb/testsuites/endpoints.js
@@ -71,8 +71,9 @@ class endpointRunner extends tu.runInArangoshRunner {
     this.instance = new inst.instance(this.options,
                                       inst.instanceRole.single,
                                       {
-                                        'log.level': 'startup=trace',
-                                        'log.force-direct': 'true'
+                                        'log.level': ['startup=trace', 'rocksdb=trace'],
+                                        'log.force-direct': 'true',
+                                        'rocksdb.debug-logging': 'true',
                                       },
                                       {}, 'tcp', this.dummyDir, '',
                                       new inst.agencyConfig(this.options, null));


### PR DESCRIPTION
### Scope & Purpose

we found out startup may be slow inside of rocksdb, drill further down.