### PR TITLE
[CINFRA] QuickFix for deadlock

### DIFF
--- a/arangod/Replication2/StateMachines/Document/DocumentFollowerState.cpp
+++ b/arangod/Replication2/StateMachines/Document/DocumentFollowerState.cpp
@@ -81,6 +81,10 @@ auto DocumentFollowerState::acquireSnapshot(ParticipantId const& destination,
           return Result{TRI_ERROR_REPLICATION_REPLICATED_LOG_FOLLOWER_RESIGNED};
         }
 
+        auto result = data.core->getTransactionHandler()->applyEntry(
+            ReplicatedOperation::buildAbortAllOngoingTrxOperation());
+        ADB_PROD_ASSERT(result.ok()) << result;
+
         auto const& shardHandler = data.core->getShardHandler();
         if (auto dropAllRes = shardHandler->dropAllShards();
             dropAllRes.fail()) {

--- a/tests/Replication2/ReplicatedState/DocumentStateMachineTest.cpp
+++ b/tests/Replication2/ReplicatedState/DocumentStateMachineTest.cpp
@@ -942,7 +942,7 @@ TEST_F(DocumentStateMachineTest,
   // 1 Insert and 1 Commit due to the first batch
   EXPECT_CALL(*transactionHandlerMock,
               applyEntry(Matcher<ReplicatedOperation>(_)))
-      .Times(3);
+      .Times(4);
   EXPECT_CALL(*leaderInterfaceMock, startSnapshot()).Times(1);
   EXPECT_CALL(*leaderInterfaceMock, nextSnapshotBatch(SnapshotId{1})).Times(1);
   EXPECT_CALL(*leaderInterfaceMock, finishSnapshot(SnapshotId{1})).Times(1);


### PR DESCRIPTION
### Scope & Purpose
On a former leader, there could still be some transactions open. If a snapshot transfer is required, the open transactions prevent dropping the shards.

This is a quick fix for this. In future the transaction handler should be stored in the Leader/Follower and not in the core, since transactions are explicitly not shared between terms.