### PR TITLE
Add replication-version parameter to startLocalCluster.sh

### DIFF
--- a/scripts/cluster-run-common.sh
+++ b/scripts/cluster-run-common.sh
@@ -54,6 +54,7 @@ SRC_DIR="."
 USE_RR="false"
 ENCRYPTION_SECRET=""
 ENABLE_HOTBACKUP="true"
+REPLICATION_VERSION=""
 
 parse_args(){
 while [[ -n "$1" ]]; do
@@ -135,6 +136,10 @@ while [[ -n "$1" ]]; do
       ;;
     --auto-upgrade)
       AUTOUPGRADE=${2}
+      shift
+      ;;
+    -r|--replication-version)
+      REPLICATION_VERSION=${2}
       shift
       ;;
     --rr)

--- a/scripts/startLocalCluster.sh
+++ b/scripts/startLocalCluster.sh
@@ -205,6 +205,11 @@ start() {
         CMD="rr $CMD"
     fi
 
+    REPLICATION_VERSION_PARAM=""
+    if [ -n "$REPLICATION_VERSION" ]; then
+      REPLICATION_VERSION_PARAM="--database.default-replication-version=${REPLICATION_VERSION}"
+    fi
+
     TYPE=$1
     PORT=$2
     mkdir -p cluster/data$PORT
@@ -231,6 +236,7 @@ start() {
       --server.descriptors-minimum 0
       --javascript.allow-admin-execute true
       --http.trusted-origin all
+      $REPLICATION_VERSION_PARAM
 EOM
 
     SERVER_OPTIONS="$SERVER_OPTIONS $SYSTEM_REPLICATION_FACTOR $AUTHENTICATION $SSLKEYFILE $ENCRYPTION"


### PR DESCRIPTION
### Scope & Purpose
Add `-r|--replication-version` parameter to the `startLocalCluster.sh` script. If not set, the default replication version is used.