### PR TITLE
[CINFRA-717] Avoid double leader switch

### DIFF
--- a/arangod/RestHandler/RestReplicationHandler.cpp
+++ b/arangod/RestHandler/RestReplicationHandler.cpp
@@ -3611,8 +3611,13 @@ Result RestReplicationHandler::createBlockingTransaction(
     TRI_ASSERT(access == AccessMode::Type::EXCLUSIVE);
     exc.push_back(col.name());
   }
-
-  TRI_ASSERT(isLockHeld(id).is(TRI_ERROR_HTTP_NOT_FOUND));
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+  {
+    auto const lockHeld = isLockHeld(id);
+    TRI_ASSERT(lockHeld.is(TRI_ERROR_HTTP_NOT_FOUND))
+        << "Unexpected error code " << lockHeld;
+  }
+#endif
 
   transaction::Options opts;
   opts.lockTimeout = ttl;  // not sure if appropriate ?

--- a/tests/Replication2/Helper/ModelChecker/AgencyState.h
+++ b/tests/Replication2/Helper/ModelChecker/AgencyState.h
@@ -48,11 +48,10 @@ struct AgencyState {
 
   friend auto operator<<(std::ostream& os, AgencyState const& state)
       -> std::ostream& {
-    // return os;
     auto const print = [&](auto const& x) {
       VPackBuilder builder;
       velocypack::serialize(builder, x);
-      os << builder.toString() << std::endl;
+      os << builder.toJson() << std::endl;
     };
 
     if (state.replicatedLog) {

--- a/tests/Replication2/Helper/ModelChecker/AgencyTransition.cpp
+++ b/tests/Replication2/Helper/ModelChecker/AgencyTransition.cpp
@@ -186,6 +186,9 @@ void ReplaceServerTargetLog::apply(AgencyState& agency) const {
   auto& target = agency.replicatedLog->target;
   target.participants.erase(oldServer);
   target.participants[newServer];
+  if (target.leader == oldServer) {
+    target.leader = newServer;
+  }
   target.version.emplace(target.version.value_or(0) + 1);
 }
 

--- a/tests/Replication2/Helper/ModelChecker/Predicates.h
+++ b/tests/Replication2/Helper/ModelChecker/Predicates.h
@@ -106,7 +106,7 @@ static inline auto isParticipantCurrent(
   });
 }
 
-static inline auto serverIsLeader(std::string_view id) {
+static inline auto anyServerIsLeader(std::unordered_set<std::string_view> ids) {
   return MC_BOOL_PRED(global, {
     AgencyState const& state = global.state;
     if (state.replicatedLog && state.replicatedLog->plan &&
@@ -114,11 +114,15 @@ static inline auto serverIsLeader(std::string_view id) {
       auto const& term = *state.replicatedLog->plan->currentTerm;
       if (term.leader) {
         auto const& leader = *term.leader;
-        return leader.serverId == id;
+        return ids.contains(leader.serverId);
       }
     }
     return false;
   });
+}
+
+static inline auto serverIsLeader(std::string_view id) {
+  return anyServerIsLeader({id});
 }
 
 static inline auto

--- a/tests/Replication2/ModelChecker/ModelChecker.h
+++ b/tests/Replication2/ModelChecker/ModelChecker.h
@@ -160,8 +160,8 @@ struct DFSEnumerator {
   friend auto operator<<(std::ostream& os, PathVectorType const& path)
       -> std::ostream& {
     for (auto const& [v, t] : path) {
-      os << "{" << v->state << "}" << std::endl
-         << " -[" << t << "]-> " << std::endl;
+      os << "{" << v->state << "}\n"
+         << " -[" << t << "]-> \n";
     }
     return os;
   }
@@ -292,15 +292,17 @@ struct DFSEnumerator {
             result.stats.eliminatedStates += 1;
           }
           auto checkResult = step->observer.check(step->state);
+          constexpr auto maxDepth = 40;
           if (isPrune(checkResult)) {
             continue;
           } else if (isError(checkResult)) {
             result.failed.emplace(checkResult.asError(), step,
                                   buildPathVector());
             return result;
-          } else if (v->depth > 40) {
-            result.failed.emplace(CheckError("path to long"), step,
-                                  buildPathVector());
+          } else if (v->depth > maxDepth) {
+            result.failed.emplace(
+                CheckError(fmt::format("path too long (>{})", maxDepth)), step,
+                buildPathVector());
             return result;
           }
           if (step->isActive()) {
@@ -389,8 +391,8 @@ struct RandomEnumerator {
   friend auto operator<<(std::ostream& os, PathVectorType const& path)
       -> std::ostream& {
     for (auto const& [v, t] : path) {
-      os << "{" << v->state << "}"
-         << " -[" << t << "]-> ";
+      os << "{" << v->state << "}\n"
+         << " -[" << t << "]-> \n";
     }
     return os;
   }

--- a/tests/Replication2/ModelChecker/Predicates.h
+++ b/tests/Replication2/ModelChecker/Predicates.h
@@ -254,7 +254,7 @@ struct Str {
 template<Str File, std::size_t Line>
 struct FileLineType {
   static auto annotate(std::string_view message) -> std::string {
-    return fmt::format("{}:{}:{}", File.buffer, Line, message);
+    return fmt::format("{}:{}: {}", File.buffer, Line, message);
   }
 };
 }  // namespace detail

--- a/tests/Replication2/ReplicatedLog/Supervision/SupervisionSimulationTest.cpp
+++ b/tests/Replication2/ReplicatedLog/Supervision/SupervisionSimulationTest.cpp
@@ -697,6 +697,7 @@ TEST_F(ReplicatedLogSupervisionSimulationTest,
       MC_EVENTUALLY_ALWAYS(mcpreds::isLeaderHealth()),
       MC_ALWAYS(mcpreds::leaderHasSnapshot()),
       MC_ALWAYS(mcpreds::anyServerIsLeader({"A", "D"})),
+      MC_EVENTUALLY_ALWAYS(mcpreds::serverIsLeader("D")),
       MC_EVENTUALLY_ALWAYS(mcpreds::isParticipantNotPlanned("A"))};
   using Engine = model_checker::ActorEngine<model_checker::DFSEnumerator,
                                             AgencyState, AgencyTransition>;

--- a/tests/Replication2/ReplicatedLog/Supervision/SupervisionSimulationTest.cpp
+++ b/tests/Replication2/ReplicatedLog/Supervision/SupervisionSimulationTest.cpp
@@ -653,3 +653,58 @@ TEST_F(ReplicatedLogSupervisionSimulationTest,
   EXPECT_FALSE(result.failed) << *result.failed;
   std::cout << result.stats << std::endl;
 }
+
+TEST_F(ReplicatedLogSupervisionSimulationTest,
+       check_log_replace_target_leader) {
+  AgencyLogBuilder log;
+  log.setTargetConfig(LogTargetConfig(2, 2, true))
+      .setId(logId)
+      .setTargetParticipant("A", defaultFlags)
+      .setTargetParticipant("B", defaultFlags)
+      .setTargetParticipant("C", defaultFlags);
+
+  log.setPlanParticipant("A", defaultFlags)
+      .setPlanParticipant("B", defaultFlags)
+      .setPlanParticipant("C", defaultFlags);
+  log.setTargetLeader("A");
+  log.setPlanLeader("A");
+  log.establishLeadership();
+  log.acknowledgeTerm("A").acknowledgeTerm("B").acknowledgeTerm("C");
+  log.allSnapshotsTrue();
+
+  replicated_log::ParticipantsHealth health;
+  health._health.emplace(
+      "A", replicated_log::ParticipantHealth{.rebootId = RebootId(0),
+                                             .notIsFailed = true});
+  health._health.emplace(
+      "B", replicated_log::ParticipantHealth{.rebootId = RebootId(0),
+                                             .notIsFailed = true});
+  health._health.emplace(
+      "C", replicated_log::ParticipantHealth{.rebootId = RebootId(0),
+                                             .notIsFailed = true});
+  health._health.emplace(
+      "D", replicated_log::ParticipantHealth{.rebootId = RebootId(0),
+                                             .notIsFailed = true});
+
+  auto initState = makeAgencyState(log.get(), std::move(health));
+
+  auto driver = model_checker::ActorDriver{
+      SupervisionActor{}, ReplaceSpecificLogServerActor{"A", "D"},
+      DBServerActor{"A"}, DBServerActor{"B"},
+      DBServerActor{"C"}, DBServerActor{"D"}};
+
+  auto allTests = model_checker::combined{
+      MC_EVENTUALLY_ALWAYS(mcpreds::isLeaderHealth()),
+      MC_ALWAYS(mcpreds::leaderHasSnapshot()),
+      MC_ALWAYS(mcpreds::anyServerIsLeader({"A", "D"})),
+      MC_EVENTUALLY_ALWAYS(mcpreds::isParticipantNotPlanned("A"))};
+  using Engine = model_checker::ActorEngine<model_checker::DFSEnumerator,
+                                            AgencyState, AgencyTransition>;
+  //
+  // using Engine = model_checker::ActorEngine<model_checker::RandomEnumerator,
+  //                                          AgencyState, AgencyTransition>;
+
+  auto result = Engine::run(driver, allTests, initState);
+  EXPECT_FALSE(result.failed) << *result.failed;
+  std::cout << result.stats << std::endl;
+}


### PR DESCRIPTION
### Scope & Purpose

When the existing leader in a replicated log is replaced by a dbserver that's not a participant yet, it usually comes to two leader switches. This is because the previous leader is also removed as a participant from the log. So while the new server is not yet ready to become a leader (it hasn't fetched all necessary data yet), the old one is already removed and thus replaced by some of the other participants first, only to be replaced shortly after by the intended one.

While the current behavior is correct - it does not loose data, and it arrives at the targeted configuration - the first leader switch is undesirable, at least because it has an avoidable service interruption. It's also a small avoidable amount of work for the cluster.

- [X] :pizza: New feature
- [X] :fire: Performance improvement

### Checklist

- [X] Tests
  - [X] C++ **Unit tests**
  - [x] **integration tests**

#### Related Information

- [X] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/CINFRA-717

