### PR TITLE
[GORDO-1596] Query pregel actor status

### DIFF
--- a/arangod/Pregel/PregelFeature.h
+++ b/arangod/Pregel/PregelFeature.h
@@ -41,6 +41,7 @@
 #include "Pregel/ExecutionNumber.h"
 #include "Pregel/SpawnMessages.h"
 #include "Pregel/PregelOptions.h"
+#include "Pregel/StatusActor.h"
 #include "ProgramOptions/ProgramOptions.h"
 #include "RestServer/arangod.h"
 #include "Scheduler/Scheduler.h"
@@ -102,6 +103,7 @@ class PregelFeature final : public ArangodFeature {
   void cleanupConductor(ExecutionNumber executionNumber);
   void cleanupWorker(ExecutionNumber executionNumber);
   [[nodiscard]] ResultT<PregelResults> getResults(ExecutionNumber execNr);
+  [[nodiscard]] ResultT<StatusState> getStatus(ExecutionNumber execNr);
 
   void handleConductorRequest(TRI_vocbase_t& vocbase, std::string const& path,
                               VPackSlice const& body,
@@ -162,7 +164,9 @@ class PregelFeature final : public ArangodFeature {
   std::shared_ptr<actor::Runtime<PregelScheduler, ArangoExternalDispatcher>>
       _actorRuntime;
 
-  std::unordered_map<ExecutionNumber, actor::ActorPID> _resultActor;
+  std::unordered_map<ExecutionNumber, actor::ActorPID> _resultActors;
+
+  Guarded<std::unordered_map<ExecutionNumber, actor::ActorPID>> _statusActors;
 };
 
 }  // namespace arangodb::pregel

--- a/arangod/Pregel/REST/RestControlPregelHandler.cpp
+++ b/arangod/Pregel/REST/RestControlPregelHandler.cpp
@@ -34,6 +34,7 @@
 #include "Pregel/PregelFeature.h"
 #include "Pregel/REST/RestOptions.h"
 #include "Pregel/StatusWriter/CollectionStatusWriter.h"
+#include "Pregel/StatusActor.h"
 #include "Transaction/StandaloneContext.h"
 
 #include <velocypack/Builder.h>
@@ -172,8 +173,20 @@ void RestControlPregelHandler::handleGetRequest() {
     auto c = _pregel.conductor(executionNumber);
 
     if (nullptr == c) {
-      generateError(rest::ResponseCode::NOT_FOUND, TRI_ERROR_CURSOR_NOT_FOUND,
-                    "Execution number is invalid");
+      auto status = _pregel.getStatus(executionNumber);
+      if (not status.ok()) {
+        generateError(rest::ResponseCode::NOT_FOUND, status.errorNumber(),
+                      status.errorMessage());
+        return;
+      }
+      auto serializedState = inspection::serializeWithErrorT(status.get());
+      if (!serializedState.ok()) {
+        generateError(rest::ResponseCode::NOT_FOUND, TRI_ERROR_CURSOR_NOT_FOUND,
+                      fmt::format("Cannot serialize status: {}",
+                                  serializedState.error().error()));
+        return;
+      }
+      generateResult(rest::ResponseCode::OK, serializedState.get().slice());
       return;
     }
 

--- a/arangod/Pregel/REST/RestPregelHandler.cpp
+++ b/arangod/Pregel/REST/RestPregelHandler.cpp
@@ -103,7 +103,7 @@ RestStatus RestPregelHandler::execute() {
             actor::ActorPID{.server = ServerState::instance()->getId(),
                             .database = _vocbase.name(),
                             .id = resultActorID};
-        _pregel._resultActor.emplace(
+        _pregel._resultActors.emplace(
             std::get<message::SpawnWorker>(spawnMessage.get())
                 .message.executionNumber,
             resultActorPID);

--- a/arangod/Pregel/StatusActor.h
+++ b/arangod/Pregel/StatusActor.h
@@ -1,0 +1,84 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2022 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Julia Volmer
+////////////////////////////////////////////////////////////////////////////////
+#pragma once
+
+#include "Actor/ActorPID.h"
+#include "Actor/HandlerBase.h"
+#include "Pregel/StatusMessages.h"
+#include "fmt/core.h"
+
+namespace arangodb::pregel {
+
+struct StatusState {};
+template<typename Inspector>
+auto inspect(Inspector& f, StatusState& x) {
+  return f.object(x).fields();
+}
+
+template<typename Runtime>
+struct StatusHandler : actor::HandlerBase<Runtime, StatusState> {
+  auto operator()(message::StatusStart start) -> std::unique_ptr<StatusState> {
+    LOG_TOPIC("ea4f4", INFO, Logger::PREGEL)
+        << fmt::format("Status Actor {} started", this->self);
+    return std::move(this->state);
+  }
+
+  auto operator()(actor::message::UnknownMessage unknown)
+      -> std::unique_ptr<StatusState> {
+    LOG_TOPIC("eb6f2", INFO, Logger::PREGEL) << fmt::format(
+        "Status Actor: Error - sent unknown message to {}", unknown.receiver);
+    return std::move(this->state);
+  }
+
+  auto operator()(actor::message::ActorNotFound notFound)
+      -> std::unique_ptr<StatusState> {
+    LOG_TOPIC("e31f6", INFO, Logger::PREGEL) << fmt::format(
+        "Status Actor: Error - receiving actor {} not found", notFound.actor);
+    return std::move(this->state);
+  }
+
+  auto operator()(actor::message::NetworkError notFound)
+      -> std::unique_ptr<StatusState> {
+    LOG_TOPIC("e87f3", INFO, Logger::PREGEL) << fmt::format(
+        "Status Actor: Error - network error {}", notFound.message);
+    return std::move(this->state);
+  }
+
+  auto operator()(auto&& rest) -> std::unique_ptr<StatusState> {
+    LOG_TOPIC("e9df2", INFO, Logger::PREGEL)
+        << "Status Actor: Got unhandled message";
+    return std::move(this->state);
+  }
+};
+
+struct StatusActor {
+  using State = StatusState;
+  using Message = message::StatusMessages;
+  template<typename Runtime>
+  using Handler = StatusHandler<Runtime>;
+  static constexpr auto typeName() -> std::string_view {
+    return "Status Actor";
+  }
+};
+
+}  // namespace arangodb::pregel

--- a/arangod/Pregel/StatusMessages.h
+++ b/arangod/Pregel/StatusMessages.h
@@ -1,0 +1,46 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2023 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Julia Volmer
+////////////////////////////////////////////////////////////////////////////////
+#pragma once
+
+#include <variant>
+#include "Actor/ActorPID.h"
+#include "Inspection/Types.h"
+
+namespace arangodb::pregel::message {
+
+struct StatusStart {};
+template<typename Inspector>
+auto inspect(Inspector& f, StatusStart& x) {
+  return f.object(x).fields();
+}
+
+struct StatusMessages : std::variant<StatusStart> {
+  using std::variant<StatusStart>::variant;
+};
+template<typename Inspector>
+auto inspect(Inspector& f, StatusMessages& x) {
+  return f.variant(x).unqualified().alternatives(
+      arangodb::inspection::type<StatusStart>("Start"));
+}
+
+}  // namespace arangodb::pregel::message

--- a/arangod/V8Server/v8-pregel.cpp
+++ b/arangod/V8Server/v8-pregel.cpp
@@ -159,11 +159,10 @@ static void JS_PregelStatus(v8::FunctionCallbackInfo<v8::Value> const& args) {
   }
   auto& pregel = vocbase.server().getFeature<arangodb::pregel::PregelFeature>();
 
-  VPackBuilder builder;
-
   // check the arguments
   uint32_t const argLength = args.Length();
   if (argLength == 0) {
+    VPackBuilder builder;
     pregel.toVelocyPack(vocbase, builder, false, true);
     TRI_V8_RETURN(TRI_VPackToV8(isolate, builder.slice()));
     return;
@@ -178,10 +177,25 @@ static void JS_PregelStatus(v8::FunctionCallbackInfo<v8::Value> const& args) {
       TRI_ObjectToUInt64(isolate, args[0], true)};
   auto c = pregel.conductor(executionNum);
   if (!c) {
-    TRI_V8_THROW_EXCEPTION_MESSAGE(TRI_ERROR_CURSOR_NOT_FOUND,
-                                   "Execution number is invalid");
+    auto status = pregel.getStatus(executionNum);
+    if (not status.ok()) {
+      TRI_V8_THROW_EXCEPTION_MESSAGE(status.errorNumber(),
+                                     status.errorMessage());
+      return;
+    }
+    auto serializedState = inspection::serializeWithErrorT(status.get());
+    if (!serializedState.ok()) {
+      TRI_V8_THROW_EXCEPTION_MESSAGE(
+          TRI_ERROR_CURSOR_NOT_FOUND,
+          fmt::format("Cannot serialize status {}",
+                      serializedState.error().error()));
+      return;
+    }
+    TRI_V8_RETURN(TRI_VPackToV8(isolate, serializedState.get().slice()));
+    return;
   }
 
+  VPackBuilder builder;
   c->toVelocyPack(builder);
   TRI_V8_RETURN(TRI_VPackToV8(isolate, builder.slice()));
   TRI_V8_TRY_CATCH_END


### PR DESCRIPTION
Adds a new status actor for every conductor.
If a pregel run ist started using actors, the pregel status is provided by the state this actor.