### PR TITLE
[PREGEL bugfix] Move log before return

### DIFF
--- a/arangod/Pregel/Worker/Handler.h
+++ b/arangod/Pregel/Worker/Handler.h
@@ -87,12 +87,12 @@ struct WorkerHandler : actor::HandlerBase<Runtime, WorkerState<V, E, M>> {
                                   std::move(statusUpdateCallback));
         this->state->quiver = loader.load();
 
+        LOG_TOPIC("5206c", WARN, Logger::PREGEL)
+            << fmt::format("Worker {} has finished loading.", this->self);
         return {conductor::message::GraphLoaded{
             .executionNumber = this->state->config->executionNumber(),
             .vertexCount = this->state->quiver->numberOfVertices(),
             .edgeCount = this->state->quiver->numberOfEdges()}};
-        LOG_TOPIC("5206c", WARN, Logger::PREGEL)
-            << fmt::format("Worker {} has finished loading.", this->self);
       } catch (std::exception const& ex) {
         return Result{
             TRI_ERROR_INTERNAL,


### PR DESCRIPTION
Moves a log statement before a return statement, which resulted in spurious errors.