### PR TITLE
[CINFRA] Compaction Manager Deadlock

### DIFF
--- a/arangod/Replication2/ReplicatedLog/Components/CompactionManager.cpp
+++ b/arangod/Replication2/ReplicatedLog/Components/CompactionManager.cpp
@@ -135,8 +135,8 @@ void CompactionManager::triggerAsyncCompaction(
         compaction.range = compactionRange;
         LOG_CTX("28d7d", TRACE, self->loggerContext)
             << "starting compaction on range " << compactionRange;
-        auto f = store->removeFront(index);
         guard.unlock();
+        auto f = store->removeFront(index);
         auto result = co_await asResult(std::move(f));
         auto cresult = CompactResult{.error = std::nullopt,
                                      .stopReason = reason,

--- a/arangod/Replication2/ReplicatedState/ReplicatedState.tpp
+++ b/arangod/Replication2/ReplicatedState/ReplicatedState.tpp
@@ -570,12 +570,8 @@ auto FollowerStateManager<S>::GuardedData::maybeScheduleApplyEntries(
     // Apply at most 1000 entries at once, so we have a smoother progression.
     _applyEntriesIndexInFlight =
         std::min(_commitIndex, _lastAppliedIndex + 1000);
-    // get an iterator for the range [last_applied + 1, commitIndex + 1)
-    auto logIter = _stream->methods()->getCommittedLogIterator(
-        {{_lastAppliedIndex + 1, *_applyEntriesIndexInFlight + 1}});
-    auto deserializedIter = std::make_unique<
-        LazyDeserializingIterator<EntryType const&, Deserializer>>(
-        std::move(logIter));
+    auto range =
+        LogRange{_lastAppliedIndex + 1, *_applyEntriesIndexInFlight + 1};
     auto promise = futures::Promise<Result>();
     auto future = promise.getFuture();
     auto rttGuard = MeasureTimeGuard(*metrics->replicatedStateApplyEntriesRtt);
@@ -583,10 +579,14 @@ auto FollowerStateManager<S>::GuardedData::maybeScheduleApplyEntries(
     // scheduler to avoid blocking the current appendEntries request from
     // returning. By using _applyEntriesIndexInFlight we make sure not to call
     // it multiple time in parallel.
-    scheduler->queue([promise = std::move(promise),
-                      deserializedIter = std::move(deserializedIter),
+    scheduler->queue([promise = std::move(promise), stream = _stream, range,
                       followerState = _followerState,
                       rttGuard = std::move(rttGuard)]() mutable {
+      // get an iterator for the range [last_applied + 1, commitIndex + 1)
+      auto logIter = stream->methods()->getCommittedLogIterator(range);
+      auto deserializedIter = std::make_unique<
+          LazyDeserializingIterator<EntryType const&, Deserializer>>(
+          std::move(logIter));
       followerState->applyEntries(std::move(deserializedIter))
           .thenFinal(
               [promise = std::move(promise),


### PR DESCRIPTION
### Scope & Purpose
1. Fix a deadlock in the compaction manager. 
2. Move the iterator creation into a separate thread. This should reduce the appendEntries roundtrip time.