### PR TITLE
Revert "fix races in in-memory cache system (#18243) (#18265)"

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 v3.10.6 (XXXX-XX-XX)
 --------------------
 
+* Fix potential thread starvation in in-memory edge cache.
+
 * SEARCH-300: Fixed a rare case when arangosearch data folders might be left on
   disk after database is dropped.
   

--- a/arangod/Cache/Cache.cpp
+++ b/arangod/Cache/Cache.cpp
@@ -32,6 +32,7 @@
 
 #include "Basics/SpinLocker.h"
 #include "Basics/SpinUnlocker.h"
+#include "Basics/cpu-relax.h"
 #include "Basics/voc-errors.h"
 #include "Cache/CachedValue.h"
 #include "Cache/Common.h"
@@ -52,7 +53,8 @@ Cache::Cache(Manager* manager, std::uint64_t id, Metadata&& metadata,
              std::shared_ptr<Table> table, bool enableWindowedStats,
              std::function<Table::BucketClearer(Metadata*)> bucketClearer,
              std::size_t slotsPerBucket)
-    : _shutdown(false),
+    : _taskLock(),
+      _shutdown(false),
       _enableWindowedStats(enableWindowedStats),
       _findHits(),
       _findMisses(),
@@ -327,8 +329,6 @@ std::shared_ptr<Table> Cache::table() const {
 }
 
 void Cache::shutdown() {
-  SpinLocker shutdownGuard(SpinLocker::Mode::Write, _shutdownLock);
-
   SpinLocker taskGuard(SpinLocker::Mode::Write, _taskLock);
   auto handle = shared_from_this();  // hold onto self-reference to prevent
                                      // pre-mature shared_ptr destruction
@@ -343,10 +343,7 @@ void Cache::shutdown() {
       }
 
       SpinUnlocker taskUnguard(SpinUnlocker::Mode::Write, _taskLock);
-      SpinUnlocker shutdownUnguard(SpinUnlocker::Mode::Write, _shutdownLock);
-
-      // sleep a bit without holding the locks
-      std::this_thread::sleep_for(std::chrono::microseconds(20));
+      std::this_thread::sleep_for(std::chrono::microseconds(10));
     }
 
     std::shared_ptr<cache::Table> table = this->table();
@@ -378,6 +375,15 @@ bool Cache::canResize() noexcept {
 
   SpinLocker metaGuard(SpinLocker::Mode::Read, _metadata.lock());
   return !(_metadata.isResizing() || _metadata.isMigrating());
+}
+
+bool Cache::canMigrate() noexcept {
+  if (ADB_UNLIKELY(isShutdown())) {
+    return false;
+  }
+
+  SpinLocker metaGuard(SpinLocker::Mode::Read, _metadata.lock());
+  return !_metadata.isMigrating();
 }
 
 /// TODO Improve freeing algorithm
@@ -425,12 +431,6 @@ bool Cache::freeMemory() {
 
 bool Cache::migrate(std::shared_ptr<Table> newTable) {
   if (ADB_UNLIKELY(isShutdown())) {
-    // unmarking migrating flag
-    SpinLocker metaGuard(SpinLocker::Mode::Write, _metadata.lock());
-
-    TRI_ASSERT(_metadata.isMigrating());
-    _metadata.toggleMigrating();
-    TRI_ASSERT(!_metadata.isMigrating());
     return false;
   }
 
@@ -464,9 +464,7 @@ bool Cache::migrate(std::shared_ptr<Table> newTable) {
   {
     SpinLocker metaGuard(SpinLocker::Mode::Write, _metadata.lock());
     _metadata.changeTable(newTable->memoryUsage());
-    TRI_ASSERT(_metadata.isMigrating());
     _metadata.toggleMigrating();
-    TRI_ASSERT(!_metadata.isMigrating());
   }
 
   // clear out old table and release it

--- a/arangod/Cache/Cache.h
+++ b/arangod/Cache/Cache.h
@@ -81,8 +81,6 @@ class Cache : public std::enable_shared_from_this<Cache> {
 
   static constexpr std::uint64_t triesGuarantee =
       std::numeric_limits<std::uint64_t>::max();
-  static constexpr std::uint64_t triesFast = 200;
-  static constexpr std::uint64_t triesSlow = 10000;
 
   // primary functionality; documented in derived classes
   virtual Finding find(void const* key, std::uint32_t keySize) = 0;
@@ -154,7 +152,7 @@ class Cache : public std::enable_shared_from_this<Cache> {
   //////////////////////////////////////////////////////////////////////////////
   /// @brief Check whether the cache has begun the process of shutting down.
   //////////////////////////////////////////////////////////////////////////////
-  bool isShutdown() const noexcept { return _shutdown.load(); }
+  inline bool isShutdown() const noexcept { return _shutdown.load(); }
 
   // helper struct that takes care of inserting into the cache during
   // object construction. The insertion is not guaranteed to work. To
@@ -199,32 +197,8 @@ class Cache : public std::enable_shared_from_this<Cache> {
   };
 
  protected:
-  // shutdown cache and let its memory be reclaimed
-  static void destroy(std::shared_ptr<Cache> const& cache);
-
-  void requestGrow();
-  void requestMigrate(std::uint32_t requestedLogSize = 0);
-
-  static void freeValue(CachedValue* value) noexcept;
-  bool reclaimMemory(std::uint64_t size) noexcept;
-
-  void recordStat(Stat stat);
-
-  bool reportInsert(bool hadEviction);
-
-  // management
-  Metadata& metadata();
-  std::shared_ptr<Table> table() const;
-  void shutdown();
-  [[nodiscard]] bool canResize() noexcept;
-  bool freeMemory();
-  bool migrate(std::shared_ptr<Table> newTable);
-
-  virtual std::uint64_t freeMemoryFrom(std::uint32_t hash) = 0;
-  virtual void migrateBucket(void* sourcePtr,
-                             std::unique_ptr<Table::Subtable> targets,
-                             Table& newTable) = 0;
-
+  static constexpr std::uint64_t triesFast = 200;
+  static constexpr std::uint64_t triesSlow = 10000;
   static constexpr std::uint64_t findStatsCapacity = 16384;
 
   basics::ReadWriteSpinLock _taskLock;
@@ -251,13 +225,6 @@ class Cache : public std::enable_shared_from_this<Cache> {
   // manage eviction rate
   basics::SharedCounter<64> _insertsTotal;
   basics::SharedCounter<64> _insertEvictions;
-
-  // times to wait until requesting is allowed again
-  std::atomic<Manager::time_point::rep> _migrateRequestTime;
-  std::atomic<Manager::time_point::rep> _resizeRequestTime;
-
-  basics::ReadWriteSpinLock _shutdownLock;
-
   static constexpr std::uint64_t _evictionMask =
       4095;  // check roughly every 4096 insertions
   static constexpr double _evictionRateThreshold =
@@ -265,10 +232,42 @@ class Cache : public std::enable_shared_from_this<Cache> {
              // evictions in past 4096
              // inserts, migrate
 
+  // times to wait until requesting is allowed again
+  std::atomic<Manager::time_point::rep> _migrateRequestTime;
+  std::atomic<Manager::time_point::rep> _resizeRequestTime;
+
   // friend class manager and tasks
   friend class FreeMemoryTask;
   friend class Manager;
   friend class MigrateTask;
+
+ protected:
+  // shutdown cache and let its memory be reclaimed
+  static void destroy(std::shared_ptr<Cache> const& cache);
+
+  void requestGrow();
+  void requestMigrate(std::uint32_t requestedLogSize = 0);
+
+  static void freeValue(CachedValue* value) noexcept;
+  bool reclaimMemory(std::uint64_t size) noexcept;
+
+  void recordStat(Stat stat);
+
+  bool reportInsert(bool hadEviction);
+
+  // management
+  Metadata& metadata();
+  std::shared_ptr<Table> table() const;
+  void shutdown();
+  [[nodiscard]] bool canResize() noexcept;
+  [[nodiscard]] bool canMigrate() noexcept;
+  bool freeMemory();
+  bool migrate(std::shared_ptr<Table> newTable);
+
+  virtual std::uint64_t freeMemoryFrom(std::uint32_t hash) = 0;
+  virtual void migrateBucket(void* sourcePtr,
+                             std::unique_ptr<Table::Subtable> targets,
+                             Table& newTable) = 0;
 };
 
 }  // end namespace arangodb::cache

--- a/arangod/Cache/Manager.h
+++ b/arangod/Cache/Manager.h
@@ -249,6 +249,7 @@ class Manager {
   // task management
   enum TaskEnvironment { none, rebalancing, resizing };
   PostFn _schedulerPost;
+  std::uint64_t _resizeAttempt;
   std::atomic<std::uint64_t> _outstandingTasks;
   std::atomic<std::uint64_t> _rebalancingTasks;
   std::atomic<std::uint64_t> _resizingTasks;
@@ -292,7 +293,7 @@ class Manager {
 
   // coordinate state with task lifecycles
   void prepareTask(TaskEnvironment environment);
-  void unprepareTask(TaskEnvironment environment) noexcept;
+  void unprepareTask(TaskEnvironment environment);
 
   // periodically run to rebalance allocations globally
   ErrorCode rebalance(bool onlyCalculate = false);

--- a/arangod/Cache/ManagerTasks.cpp
+++ b/arangod/Cache/ManagerTasks.cpp
@@ -21,8 +21,7 @@
 /// @author Dan Larkin-York
 ////////////////////////////////////////////////////////////////////////////////
 
-#include "ManagerTasks.h"
-
+#include "Cache/ManagerTasks.h"
 #include "Basics/SpinLocker.h"
 #include "Cache/Cache.h"
 #include "Cache/Manager.h"
@@ -38,15 +37,13 @@ FreeMemoryTask::~FreeMemoryTask() = default;
 
 bool FreeMemoryTask::dispatch() {
   _manager.prepareTask(_environment);
-
   try {
     if (_manager.post([self = shared_from_this()]() -> void { self->run(); })) {
-      // intentionally don't unprepare task
       return true;
     }
     _manager.unprepareTask(_environment);
     return false;
-  } catch (...) {
+  } catch (std::exception const&) {
     _manager.unprepareTask(_environment);
     throw;
   }
@@ -56,31 +53,20 @@ void FreeMemoryTask::run() {
   try {
     using basics::SpinLocker;
 
-    {
+    bool ran = _cache->freeMemory();
+
+    if (ran) {
+      std::uint64_t reclaimed = 0;
       SpinLocker guard(SpinLocker::Mode::Write, _manager._lock);
-
-      // note: FreeMemoryTask must not run concurrently with the
-      // cache's own shutdown to avoid data inconsistency
-      SpinLocker taskGuard(SpinLocker::Mode::Read, _cache->_shutdownLock);
-
-      bool ran = _cache->freeMemory();
-
-      if (ran) {
-        std::uint64_t reclaimed = 0;
-        Metadata& metadata = _cache->metadata();
-        {
-          SpinLocker metaGuard(SpinLocker::Mode::Write, metadata.lock());
-          TRI_ASSERT(metaGuard.isLocked());
-          reclaimed = metadata.hardUsageLimit - metadata.softUsageLimit;
-          metadata.adjustLimits(metadata.softUsageLimit,
-                                metadata.softUsageLimit);
-          metadata.toggleResizing();
-        }
-        TRI_ASSERT(_manager._globalAllocation >=
-                   reclaimed + _manager._fixedAllocation);
-        _manager._globalAllocation -= reclaimed;
-        TRI_ASSERT(_manager._globalAllocation >= _manager._fixedAllocation);
+      Metadata& metadata = _cache->metadata();
+      {
+        SpinLocker metaGuard(SpinLocker::Mode::Write, metadata.lock());
+        TRI_ASSERT(metaGuard.isLocked());
+        reclaimed = metadata.hardUsageLimit - metadata.softUsageLimit;
+        metadata.adjustLimits(metadata.softUsageLimit, metadata.softUsageLimit);
+        metadata.toggleResizing();
       }
+      _manager._globalAllocation -= reclaimed;
     }
 
     _manager.unprepareTask(_environment);
@@ -103,15 +89,13 @@ MigrateTask::~MigrateTask() = default;
 
 bool MigrateTask::dispatch() {
   _manager.prepareTask(_environment);
-
   try {
     if (_manager.post([self = shared_from_this()]() -> void { self->run(); })) {
-      // intentionally don't unprepare task
       return true;
     }
     _manager.unprepareTask(_environment);
     return false;
-  } catch (...) {
+  } catch (std::exception const&) {
     _manager.unprepareTask(_environment);
     throw;
   }
@@ -121,18 +105,18 @@ void MigrateTask::run() {
   try {
     using basics::SpinLocker;
 
-    {
-      // note: MigrateTask must not run concurrently with the
-      // cache's own shutdown to avoid data inconsistency
-      SpinLocker taskGuard(SpinLocker::Mode::Read, _cache->_shutdownLock);
+    // do the actual migration
+    bool ran = _cache->migrate(_table);
 
-      // do the actual migration
-      bool ran = _cache->migrate(_table);
-
-      if (!ran) {
-        _manager.reclaimTable(std::move(_table), false);
-        TRI_ASSERT(_table == nullptr);
+    if (!ran) {
+      Metadata& metadata = _cache->metadata();
+      {
+        SpinLocker metaGuard(SpinLocker::Mode::Write, metadata.lock());
+        TRI_ASSERT(metaGuard.isLocked());
+        metadata.toggleMigrating();
       }
+      _manager.reclaimTable(std::move(_table), false);
+      TRI_ASSERT(_table == nullptr);
     }
 
     _manager.unprepareTask(_environment);

--- a/arangod/Cache/ManagerTasks.h
+++ b/arangod/Cache/ManagerTasks.h
@@ -36,6 +36,11 @@ namespace arangodb {
 namespace cache {
 
 class FreeMemoryTask : public std::enable_shared_from_this<FreeMemoryTask> {
+ private:
+  Manager::TaskEnvironment _environment;
+  Manager& _manager;
+  std::shared_ptr<Cache> _cache;
+
  public:
   FreeMemoryTask() = delete;
   FreeMemoryTask(FreeMemoryTask const&) = delete;
@@ -49,13 +54,15 @@ class FreeMemoryTask : public std::enable_shared_from_this<FreeMemoryTask> {
 
  private:
   void run();
-
-  Manager::TaskEnvironment _environment;
-  Manager& _manager;
-  std::shared_ptr<Cache> _cache;
 };
 
 class MigrateTask : public std::enable_shared_from_this<MigrateTask> {
+ private:
+  Manager::TaskEnvironment _environment;
+  Manager& _manager;
+  std::shared_ptr<Cache> _cache;
+  std::shared_ptr<Table> _table;
+
  public:
   MigrateTask() = delete;
   MigrateTask(MigrateTask const&) = delete;
@@ -69,11 +76,6 @@ class MigrateTask : public std::enable_shared_from_this<MigrateTask> {
 
  private:
   void run();
-
-  Manager::TaskEnvironment _environment;
-  Manager& _manager;
-  std::shared_ptr<Cache> _cache;
-  std::shared_ptr<Table> _table;
 };
 
 };  // end namespace cache

--- a/arangod/Cache/Metadata.cpp
+++ b/arangod/Cache/Metadata.cpp
@@ -26,8 +26,11 @@
 #include "Basics/debugging.h"
 #include "Cache/Cache.h"
 #include "Cache/Manager.h"
+#include "Logger/LogMacros.h"
 
 #include <algorithm>
+#include <atomic>
+#include <cstdint>
 
 namespace arangodb::cache {
 
@@ -40,10 +43,11 @@ Metadata::Metadata() noexcept
       usage(0),
       softUsageLimit(0),
       hardUsageLimit(0),
+      _lock(),
       _migrating(false),
       _resizing(false) {}
 
-Metadata::Metadata(std::uint64_t usageLimit, std::uint64_t fixed,
+Metadata::Metadata(uint64_t usageLimit, std::uint64_t fixed,
                    std::uint64_t table, std::uint64_t max) noexcept
     : fixedSize(fixed),
       tableSize(table),
@@ -53,6 +57,7 @@ Metadata::Metadata(std::uint64_t usageLimit, std::uint64_t fixed,
       usage(0),
       softUsageLimit(usageLimit),
       hardUsageLimit(usageLimit),
+      _lock(),
       _migrating(false),
       _resizing(false) {
   TRI_ASSERT(allocatedSize <= maxSize);

--- a/arangod/Cache/Table.cpp
+++ b/arangod/Cache/Table.cpp
@@ -79,7 +79,7 @@ Table::Subtable::Subtable(std::shared_ptr<Table> source, GenericBucket* buckets,
       _shift(shift) {}
 
 void* Table::Subtable::fetchBucket(std::uint32_t hash) noexcept {
-  return &_buckets[(hash & _mask) >> _shift];
+  return &(_buckets[(hash & _mask) >> _shift]);
 }
 
 std::vector<Table::BucketLocker> Table::Subtable::lockAllBuckets() {
@@ -220,8 +220,6 @@ std::uint32_t Table::logSize() const noexcept { return _logSize; }
 
 Table::BucketLocker Table::fetchAndLockBucket(std::uint32_t hash,
                                               std::uint64_t maxTries) {
-  std::uint32_t index = (hash & _mask) >> _shift;
-
   BucketLocker bucketGuard;
 
   SpinLocker guard(SpinLocker::Mode::Read, _lock,
@@ -229,7 +227,8 @@ Table::BucketLocker Table::fetchAndLockBucket(std::uint32_t hash,
 
   if (guard.isLocked()) {
     if (!_disabled) {
-      bucketGuard = BucketLocker(&_buckets[index], this, maxTries);
+      bucketGuard =
+          BucketLocker(&(_buckets[(hash & _mask) >> _shift]), this, maxTries);
       if (bucketGuard.isLocked()) {
         if (bucketGuard.bucket<GenericBucket>().isMigrated()) {
           bucketGuard.release();
@@ -258,7 +257,7 @@ void* Table::primaryBucket(uint64_t index) noexcept {
   if (!isEnabled()) {
     return nullptr;
   }
-  return &_buckets[index];
+  return &(_buckets[index]);
 }
 
 std::unique_ptr<Table::Subtable> Table::auxiliaryBuckets(std::uint32_t index) {
@@ -277,13 +276,13 @@ std::unique_ptr<Table::Subtable> Table::auxiliaryBuckets(std::uint32_t index) {
     TRI_ASSERT(_auxiliary.get() != nullptr);
     if (_logSize > _auxiliary->_logSize) {
       std::uint32_t diff = _logSize - _auxiliary->_logSize;
-      base = &_auxiliary->_buckets[index >> diff];
+      base = &(_auxiliary->_buckets[index >> diff]);
       size = 1;
       mask = 0;
       shift = 0;
     } else {
       std::uint32_t diff = _auxiliary->_logSize - _logSize;
-      base = &_auxiliary->_buckets[index << diff];
+      base = &(_auxiliary->_buckets[index << diff]);
       size = static_cast<std::uint64_t>(1) << diff;
       mask = (static_cast<std::uint32_t>(size - 1) << _auxiliary->_shift);
       shift = _auxiliary->_shift;

--- a/arangod/Cache/Table.h
+++ b/arangod/Cache/Table.h
@@ -30,7 +30,6 @@
 #include <cstdint>
 #include <limits>
 #include <memory>
-#include <vector>
 
 namespace arangodb::cache {
 


### PR DESCRIPTION
### Scope & Purpose

This reverts commit 05c2154505a1a330169317c9b4e7ddde7495d633.
This change had unintended side effects.
Reverting the commit may bring back assertion failures in the in-memory cache in maintainer mode during Jenkins test runs.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.10: this PR
  - [x] Backport for 3.9: https://github.com/arangodb/arangodb/pull/18476
  - [ ] Backport for 3.8: not affected

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 