### PR TITLE
[CINFRA-721] Getting Transaction Handler out of the Core

### DIFF
--- a/arangod/Replication2/StateMachines/Document/DocumentCore.cpp
+++ b/arangod/Replication2/StateMachines/Document/DocumentCore.cpp
@@ -40,17 +40,9 @@ DocumentCore::DocumentCore(
       loggerContext(std::move(loggerContext)),
       _vocbase(vocbase),
       _params(std::move(coreParameters)),
-      _shardHandler(handlersFactory->createShardHandler(vocbase, this->gid)),
-      _transactionHandler(handlersFactory->createTransactionHandler(
-          _vocbase, this->gid, _shardHandler)) {}
+      _shardHandler(handlersFactory->createShardHandler(vocbase, this->gid)) {}
 
 void DocumentCore::drop() {
-  if (auto res = _transactionHandler->applyEntry(
-          ReplicatedOperation::buildAbortAllOngoingTrxOperation());
-      res.fail()) {
-    LOG_CTX("f3b3c", ERR, loggerContext)
-        << "Failed to abort all ongoing transactions: " << res;
-  }
   if (auto res = _shardHandler->dropAllShards(); res.fail()) {
     LOG_CTX("f3b3d", ERR, loggerContext)
         << "Failed to drop all shards: " << res;
@@ -58,11 +50,6 @@ void DocumentCore::drop() {
 }
 
 auto DocumentCore::getVocbase() -> TRI_vocbase_t& { return _vocbase; }
-
-auto DocumentCore::getTransactionHandler()
-    -> std::shared_ptr<IDocumentStateTransactionHandler> {
-  return _transactionHandler;
-}
 
 auto DocumentCore::getShardHandler()
     -> std::shared_ptr<IDocumentStateShardHandler> {

--- a/arangod/Replication2/StateMachines/Document/DocumentCore.h
+++ b/arangod/Replication2/StateMachines/Document/DocumentCore.h
@@ -47,14 +47,11 @@ struct DocumentCore {
 
   auto getVocbase() -> TRI_vocbase_t&;
   void drop();
-  auto getTransactionHandler()
-      -> std::shared_ptr<IDocumentStateTransactionHandler>;
   auto getShardHandler() -> std::shared_ptr<IDocumentStateShardHandler>;
 
  private:
   TRI_vocbase_t& _vocbase;
   DocumentCoreParameters _params;
   std::shared_ptr<IDocumentStateShardHandler> _shardHandler;
-  std::shared_ptr<IDocumentStateTransactionHandler> _transactionHandler;
 };
 }  // namespace arangodb::replication2::replicated_state::document

--- a/arangod/Replication2/StateMachines/Document/DocumentFollowerState.cpp
+++ b/arangod/Replication2/StateMachines/Document/DocumentFollowerState.cpp
@@ -36,13 +36,21 @@
 
 using namespace arangodb::replication2::replicated_state::document;
 
+DocumentFollowerState::GuardedData::GuardedData(
+    std::unique_ptr<DocumentCore> core,
+    std::shared_ptr<IDocumentStateHandlersFactory> const& handlersFactory)
+    : core(std::move(core)), currentSnapshotVersion{0} {
+  transactionHandler = handlersFactory->createTransactionHandler(
+      this->core->getVocbase(), this->core->gid, this->core->getShardHandler());
+}
+
 DocumentFollowerState::DocumentFollowerState(
     std::unique_ptr<DocumentCore> core,
     std::shared_ptr<IDocumentStateHandlersFactory> const& handlersFactory)
     : loggerContext(core->loggerContext.with<logContextKeyStateComponent>(
           "FollowerState")),
       _networkHandler(handlersFactory->createNetworkHandler(core->gid)),
-      _guardedData(std::move(core)) {}
+      _guardedData(std::move(core), handlersFactory) {}
 
 DocumentFollowerState::~DocumentFollowerState() = default;
 
@@ -52,6 +60,11 @@ auto DocumentFollowerState::resign() && noexcept
     if (data.didResign()) {
       THROW_ARANGO_EXCEPTION(TRI_ERROR_CLUSTER_NOT_FOLLOWER);
     }
+
+    auto abortAllRes = data.transactionHandler->applyEntry(
+        ReplicatedOperation::buildAbortAllOngoingTrxOperation());
+    ADB_PROD_ASSERT(abortAllRes.ok()) << abortAllRes;
+
     return std::move(data.core);
   });
 }
@@ -80,6 +93,10 @@ auto DocumentFollowerState::acquireSnapshot(ParticipantId const& destination,
         if (data.didResign()) {
           return Result{TRI_ERROR_REPLICATION_REPLICATED_LOG_FOLLOWER_RESIGNED};
         }
+
+        auto abortAllRes = data.transactionHandler->applyEntry(
+            ReplicatedOperation::buildAbortAllOngoingTrxOperation());
+        ADB_PROD_ASSERT(abortAllRes.ok()) << abortAllRes;
 
         auto const& shardHandler = data.core->getShardHandler();
         if (auto dropAllRes = shardHandler->dropAllShards();
@@ -273,8 +290,6 @@ auto DocumentFollowerState::handleSnapshotTransfer(
                         "new one was started!"};
               }
 
-              auto transactionHandler = data.core->getTransactionHandler();
-
               std::stringstream ss;
               for (auto const& [shardId, _] : shards) {
                 ss << shardId << " ";
@@ -285,7 +300,7 @@ auto DocumentFollowerState::handleSnapshotTransfer(
                   << ss.str();
 
               for (auto const& [shardId, properties] : shards) {
-                auto res = transactionHandler->applyEntry(
+                auto res = data.transactionHandler->applyEntry(
                     ReplicatedOperation::buildCreateShardOperation(
                         shardId, properties.collection, properties.properties));
                 if (res.fail()) {
@@ -409,7 +424,7 @@ auto DocumentFollowerState::handleSnapshotTransfer(
                 << " bytes into shard " << *snapshotRes->shardId;
             if (auto localShardRes = self->populateLocalShard(
                     *snapshotRes->shardId, snapshotRes->payload,
-                    data.core->getTransactionHandler());
+                    data.transactionHandler);
                 localShardRes.fail()) {
               reportingFailure = true;
               return localShardRes;
@@ -448,7 +463,6 @@ auto DocumentFollowerState::handleSnapshotTransfer(
 auto DocumentFollowerState::GuardedData::applyEntry(
     ModifiesUserTransaction auto const& op, LogIndex index)
     -> ResultT<std::optional<LogIndex>> {
-  auto const& transactionHandler = core->getTransactionHandler();
   if (auto validationRes = transactionHandler->validate(op);
       validationRes.is(TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND)) {
     //  Even though a shard was dropped before acquiring the
@@ -480,7 +494,6 @@ auto DocumentFollowerState::GuardedData::applyEntry(
         << " because it is not active";
     return ResultT<std::optional<LogIndex>>{std::nullopt};
   }
-  auto const& transactionHandler = core->getTransactionHandler();
   if (auto res = transactionHandler->applyEntry(op); res.fail()) {
     return res;
   }
@@ -502,7 +515,6 @@ auto DocumentFollowerState::GuardedData::applyEntry(
     return ResultT<std::optional<LogIndex>>{std::nullopt};
   }
 
-  auto const& transactionHandler = core->getTransactionHandler();
   if (auto res = transactionHandler->applyEntry(op); res.fail()) {
     return res;
   }
@@ -516,7 +528,6 @@ auto DocumentFollowerState::GuardedData::applyEntry(
 auto DocumentFollowerState::GuardedData::applyEntry(
     ReplicatedOperation::AbortAllOngoingTrx const& op, LogIndex index)
     -> ResultT<std::optional<LogIndex>> {
-  auto const& transactionHandler = core->getTransactionHandler();
   if (auto res = transactionHandler->applyEntry(op); res.fail()) {
     return res;
   }
@@ -530,7 +541,6 @@ auto DocumentFollowerState::GuardedData::applyEntry(
     ReplicatedOperation::DropShard const& op, LogIndex index)
     -> ResultT<std::optional<LogIndex>> {
   // We first have to abort all transactions for this shard.
-  auto const& transactionHandler = core->getTransactionHandler();
   for (auto const& tid :
        transactionHandler->getTransactionsForShard(op.shard)) {
     auto abortRes = transactionHandler->applyEntry(
@@ -557,7 +567,6 @@ auto DocumentFollowerState::GuardedData::applyEntry(
 auto DocumentFollowerState::GuardedData::applyEntry(
     ReplicatedOperation::CreateShard const& op, LogIndex index)
     -> ResultT<std::optional<LogIndex>> {
-  auto const& transactionHandler = core->getTransactionHandler();
   if (auto res = transactionHandler->applyEntry(op); res.fail()) {
     return res;
   }

--- a/arangod/Replication2/StateMachines/Document/DocumentFollowerState.cpp
+++ b/arangod/Replication2/StateMachines/Document/DocumentFollowerState.cpp
@@ -130,7 +130,8 @@ auto DocumentFollowerState::acquireSnapshot(ParticipantId const& destination,
 
         LOG_CTX("b4fcb", DEBUG, self->loggerContext)
             << "Snapshot " << *snapshotTransferResult.snapshotId
-            << " data transfer completed, sending finish request";
+            << " data transfer over, will send finish request: "
+            << snapshotTransferResult.res;
 
         return leader->finishSnapshot(*snapshotTransferResult.snapshotId)
             .thenValue([snapshotTransferResult](auto&& res) {

--- a/arangod/Replication2/StateMachines/Document/DocumentLeaderState.h
+++ b/arangod/Replication2/StateMachines/Document/DocumentLeaderState.h
@@ -40,6 +40,7 @@ struct IManager;
 
 namespace arangodb::replication2::replicated_state::document {
 
+struct IDocumentStateTransactionHandler;
 struct IDocumentStateSnapshotHandler;
 
 struct DocumentLeaderState
@@ -90,11 +91,13 @@ struct DocumentLeaderState
 
  private:
   struct GuardedData {
-    explicit GuardedData(std::unique_ptr<DocumentCore> core)
-        : core(std::move(core)){};
+    explicit GuardedData(
+        std::unique_ptr<DocumentCore> core,
+        std::shared_ptr<IDocumentStateHandlersFactory> const& handlersFactory);
     [[nodiscard]] bool didResign() const noexcept { return core == nullptr; }
 
     std::unique_ptr<DocumentCore> core;
+    std::shared_ptr<IDocumentStateTransactionHandler> transactionHandler;
   };
 
   template<class ResultType, class GetFunc, class ProcessFunc>

--- a/tests/Replication2/ReplicatedState/DocumentStateMachineTest.cpp
+++ b/tests/Replication2/ReplicatedState/DocumentStateMachineTest.cpp
@@ -254,6 +254,12 @@ TEST_F(DocumentStateMachineTest,
        shard_is_dropped_and_transactions_aborted_during_cleanup) {
   using namespace testing;
 
+  // For simplicity, no shards for this snapshot.
+  ON_CALL(*leaderInterfaceMock, startSnapshot).WillByDefault([&]() {
+    return futures::Future<ResultT<SnapshotConfig>>{
+        std::in_place, SnapshotConfig{SnapshotId{1}, {}}};
+  });
+
   auto transactionHandlerMock = handlersFactoryMock->makeRealTransactionHandler(
       globalId, shardHandlerMock);
   ON_CALL(*handlersFactoryMock, createTransactionHandler(_, _, _))
@@ -267,8 +273,15 @@ TEST_F(DocumentStateMachineTest,
   auto follower = std::make_shared<DocumentFollowerStateWrapper>(
       factory.constructCore(vocbaseMock, globalId, coreParams),
       handlersFactoryMock);
+
+  // transaction should be aborted before the snapshot is acquired
+  EXPECT_CALL(
+      *transactionHandlerMock,
+      applyEntry(ReplicatedOperation::buildAbortAllOngoingTrxOperation()))
+      .Times(1);
   auto res = follower->acquireSnapshot("participantId", LogIndex{1});
   EXPECT_TRUE(res.isReady() && res.get().ok());
+  Mock::VerifyAndClearExpectations(transactionHandlerMock.get());
 
   EXPECT_CALL(
       *transactionHandlerMock,
@@ -937,12 +950,13 @@ TEST_F(DocumentStateMachineTest,
             transactionHandlerMock);
       });
 
+  // The first call to applyEntry should be AbortAllOngoingTrx
   // 3 transactions are expected to be applied
   // 1 CreateShard due to the snapshot transfer
   // 1 Insert and 1 Commit due to the first batch
   EXPECT_CALL(*transactionHandlerMock,
               applyEntry(Matcher<ReplicatedOperation>(_)))
-      .Times(3);
+      .Times(4);
   EXPECT_CALL(*leaderInterfaceMock, startSnapshot()).Times(1);
   EXPECT_CALL(*leaderInterfaceMock, nextSnapshotBatch(SnapshotId{1})).Times(1);
   EXPECT_CALL(*leaderInterfaceMock, finishSnapshot(SnapshotId{1})).Times(1);
@@ -1503,6 +1517,15 @@ TEST_F(DocumentStateMachineTest,
        leader_resign_should_abort_active_transactions) {
   using namespace testing;
 
+  auto transactionHandlerMock = handlersFactoryMock->makeRealTransactionHandler(
+      globalId, shardHandlerMock);
+  ON_CALL(*handlersFactoryMock, createTransactionHandler(_, _, _))
+      .WillByDefault([&](TRI_vocbase_t&, GlobalLogIdentifier const&,
+                         std::shared_ptr<IDocumentStateShardHandler> const&) {
+        return std::make_unique<NiceMock<MockDocumentStateTransactionHandler>>(
+            transactionHandlerMock);
+      });
+
   DocumentFactory factory =
       DocumentFactory(handlersFactoryMock, transactionManagerMock);
 
@@ -1555,8 +1578,16 @@ TEST_F(DocumentStateMachineTest,
   EXPECT_CALL(transactionManagerMock,
               abortManagedTrx(TransactionId{13}, globalId.database))
       .Times(1);
+
+  // resigning should abort all ongoing transactions
+  EXPECT_CALL(
+      *transactionHandlerMock,
+      applyEntry(ReplicatedOperation::buildAbortAllOngoingTrxOperation()))
+      .Times(1);
+
   std::ignore = std::move(*leaderState).resign();
   Mock::VerifyAndClearExpectations(&transactionManagerMock);
+  Mock::VerifyAndClearExpectations(transactionHandlerMock.get());
 }
 
 TEST_F(DocumentStateMachineTest,

--- a/tests/js/server/replication2/replication2-replicated-state-document-store.js
+++ b/tests/js/server/replication2/replication2-replicated-state-document-store.js
@@ -786,7 +786,6 @@ const replicatedStateSnapshotTransferSuite = function () {
 
       result = dh.allSnapshotsStatus(leaderUrl, database, logId);
       lh.checkRequestResult(result);
-      internal.print(result.json.result);
       assertEqual(Object.keys(result.json.result.snapshots).length, 0);
     }
   };


### PR DESCRIPTION
### Scope & Purpose

Transaction information should not be persisted between terms. There is no need for the `DocumentStateTransactionHandler` to reside inside the `DocumentCore`.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification
