### PR TITLE
[CINFRA] Deadlock 456823

### DIFF
--- a/arangod/Replication2/ReplicatedLog/Components/AppendEntriesManager.cpp
+++ b/arangod/Replication2/ReplicatedLog/Components/AppendEntriesManager.cpp
@@ -143,6 +143,7 @@ auto AppendEntriesManager::appendEntries(AppendEntriesRequest request)
       guard->snapshot.checkSnapshotState() == SnapshotState::AVAILABLE;
   guard.unlock();
   action.fire();
+  requestGuard.reset();
   LOG_CTX("f5ecd", TRACE, lctx) << "append entries successful";
   co_return AppendEntriesResult::withOk(termInfo->term, request.messageId,
                                         hasSnapshot);

--- a/arangod/Replication2/ReplicatedLog/LogLeader.cpp
+++ b/arangod/Replication2/ReplicatedLog/LogLeader.cpp
@@ -750,7 +750,8 @@ auto replicated_log::LogLeader::GuardedLeaderData::updateCommitIndexLeader(
     _stateHandle->leadershipEstablished(std::make_unique<MethodsImpl>(_self));
   }
 
-  // Currently unused
+  // Currently unused, and could deadlock with recoverEntries, because that in
+  // return calls insert
   //_stateHandle->updateCommitIndex(_commitIndex);
 
   try {

--- a/arangod/Replication2/ReplicatedLog/LogLeader.cpp
+++ b/arangod/Replication2/ReplicatedLog/LogLeader.cpp
@@ -750,7 +750,8 @@ auto replicated_log::LogLeader::GuardedLeaderData::updateCommitIndexLeader(
     _stateHandle->leadershipEstablished(std::make_unique<MethodsImpl>(_self));
   }
 
-  _stateHandle->updateCommitIndex(_commitIndex);
+  // Currently unused
+  //_stateHandle->updateCommitIndex(_commitIndex);
 
   try {
     WaitForQueue toBeResolved;

--- a/arangod/Replication2/StateMachines/Document/DocumentFollowerState.cpp
+++ b/arangod/Replication2/StateMachines/Document/DocumentFollowerState.cpp
@@ -120,7 +120,8 @@ auto DocumentFollowerState::acquireSnapshot(ParticipantId const& destination,
             << " data transfer completed, sending finish request";
 
         return leader->finishSnapshot(*snapshotTransferResult.snapshotId)
-            .thenValue([snapshotTransferResult](auto&& res) {
+            .then([snapshotTransferResult](auto&& tryRes) {
+              auto res = basics::catchToResult([&] { return tryRes.get(); });
               if (res.fail()) {
                 LOG_TOPIC("0e168", ERR, Logger::REPLICATION2)
                     << "Failed to finish snapshot "


### PR DESCRIPTION
### Scope & Purpose
1. Sometimes a follower refuses to accept an append entries, because a previous one is still in flight. This is because the `requestGuard` was not reset explicitly at the end of the coroutine. It would then be reset once the coroutine is destroyed and (similar to futures) this can happen whenever the system feels like.
2. `recoverEntries` can deadlock with `updateCommitIndex`. However, `updateCommitIndex` is not used on the leader, therefore I removed the call (for now),
3. If we post the append entries on the scheduler, we have to make sure that the methods are still there. Otherwise we might get a nullptr access.