### PR TITLE
[CINFRA-724] Prevent flag flapping

### DIFF
--- a/arangod/Replication2/ReplicatedLog/Supervision.cpp
+++ b/arangod/Replication2/ReplicatedLog/Supervision.cpp
@@ -505,16 +505,16 @@ auto checkLeaderSetInTarget(SupervisionContext& ctx, Log const& log,
         }
       }
 
+      if (!planLeaderConfig.allowedAsLeader) {
+        ctx.reportStatus<LogCurrentSupervision::TargetLeaderExcluded>();
+        return;
+      }
+
       if (planLeaderConfig.forced != true) {
         auto desiredFlags = planLeaderConfig;
         desiredFlags.forced = true;
         ctx.createAction<UpdateParticipantFlagsAction>(*target.leader,
                                                        desiredFlags);
-        return;
-      }
-
-      if (!planLeaderConfig.allowedAsLeader) {
-        ctx.reportStatus<LogCurrentSupervision::TargetLeaderExcluded>();
         return;
       }
 

--- a/arangod/Replication2/ReplicatedLog/SupervisionContext.h
+++ b/arangod/Replication2/ReplicatedLog/SupervisionContext.h
@@ -48,7 +48,10 @@ struct SupervisionContext {
 
   template<typename StatusType, typename... Args>
   void reportStatus(Args&&... args) {
-    if (_isErrorReportingEnabled) {
+    // Silently ignore reports if there's already an action, because an existing
+    // action prevents doing something (i.e. creating an action) anyway.
+    if (_isErrorReportingEnabled and
+        std::holds_alternative<EmptyAction>(_action)) {
       _reports.emplace_back(StatusType{std::forward<Args>(args)...});
     }
   }

--- a/js/common/modules/@arangodb/testutils/replicated-logs-helper.js
+++ b/js/common/modules/@arangodb/testutils/replicated-logs-helper.js
@@ -565,10 +565,14 @@ const testHelperFunctions = function (database, databaseOptions = {}) {
   };
 };
 
-const getSupervisionActionTypes = function (database, logId) {
+const getSupervisionActions = function (database, logId) {
   const {current} = readReplicatedLogAgency(database, logId);
   // filter out all empty actions
-  const actions = _.filter(current.actions, (a) => a.desc.type !== "EmptyAction");
+  return _.filter(current.actions, (a) => a.desc.type !== "EmptyAction");
+};
+
+const getSupervisionActionTypes = function (database, logId) {
+  const actions = getSupervisionActions(database, logId);
   return _.map(actions, (a) => a.desc.type);
 };
 
@@ -711,6 +715,7 @@ exports.getServerHealth = getServerHealth;
 exports.getServerRebootId = getServerRebootId;
 exports.getServerUrl = getServerUrl;
 exports.getSupervisionActionTypes = getSupervisionActionTypes;
+exports.getSupervisionActions = getSupervisionActions;
 exports.nextUniqueLogId = nextUniqueLogId;
 exports.readAgencyValueAt = readAgencyValueAt;
 exports.readReplicatedLogAgency = readReplicatedLogAgency;


### PR DESCRIPTION
### Scope & Purpose

When a server was selected as leader in the target, but also had the flag `allowedAsLeader: false`, the Supervision still set `forced: true` as a first step for the leader change. This is then immediately reverted, assuming its target config has `forced: false`. This flaps back and forth endlessly as long as the target configuration stays unchanged.

- [X] :hankey: Bugfix

### Checklist

- [X] Tests
  - [X] **integration tests**
