### PR TITLE
[CINFRA] Added more metrics to the log leader.

### DIFF
--- a/Documentation/Metrics/arangodb_replication2_replicated_log_append_entries_num_entries.yaml
+++ b/Documentation/Metrics/arangodb_replication2_replicated_log_append_entries_num_entries.yaml
@@ -1,0 +1,15 @@
+name: arangodb_replication2_replicated_log_append_entries_num_entries
+introducedIn: "3.11.0"
+help: |
+  Histogram of the number of entries in an append-entries message.
+unit: number
+type: histogram
+category: Replication
+complexity: medium
+exposedBy:
+  - dbserver
+description: |
+  The leader of a replicated log replicates the log entries by sending
+  append-entries requests to its followers.
+  This is a histogram keeping track of the number of log entries in those
+  requests.

--- a/Documentation/Metrics/arangodb_replication2_replicated_log_append_entries_size.yaml
+++ b/Documentation/Metrics/arangodb_replication2_replicated_log_append_entries_size.yaml
@@ -1,0 +1,14 @@
+name: arangodb_replication2_replicated_log_append_entries_size
+introducedIn: "3.11.0"
+help: |
+  Histogram of the size of append-entries message.
+unit: bytes
+type: histogram
+category: Replication
+complexity: medium
+exposedBy:
+  - dbserver
+description: |
+  The leader of a replicated log replicates the log entries by sending
+  append-entries requests to its followers.
+  This is a histogram keeping track of the size of those messages.

--- a/Documentation/Metrics/arangodb_replication2_replicated_log_follower_entry_drop_count.yaml
+++ b/Documentation/Metrics/arangodb_replication2_replicated_log_follower_entry_drop_count.yaml
@@ -1,0 +1,16 @@
+name: arangodb_replication2_replicated_log_follower_entry_drop_count
+introducedIn: "3.11.0"
+help: |
+  Counter of how many entries have been dropped by a follower during an
+  append-entries request.
+unit: number
+type: counter
+category: Replication
+complexity: medium
+exposedBy:
+  - dbserver
+description: |
+  The leader of a replicated log replicates the log entries by sending
+  append-entries requests to its followers.
+  Sometimes followers have to drop existing log entries before appending the
+  new log entries. This usually happens after a failover or leader change.

--- a/Documentation/Metrics/arangodb_replication2_replicated_log_leader_append_entries_error_count.yaml
+++ b/Documentation/Metrics/arangodb_replication2_replicated_log_leader_append_entries_error_count.yaml
@@ -1,0 +1,15 @@
+name: arangodb_replication2_replicated_log_leader_append_entries_error_count
+introducedIn: "3.11.0"
+help: |
+  Counter of failed append-entries messages.
+unit: number
+type: counter
+category: Replication
+complexity: medium
+exposedBy:
+  - dbserver
+description: |
+  The leader of a replicated log replicates the log entries by sending
+  append-entries requests to its followers.
+  This metric counts the amount of true failures, i.e. does not account
+  for expected protocol errors that are handled gracefully.

--- a/arangod/Replication2/ReplicatedLog/Components/StorageManager.cpp
+++ b/arangod/Replication2/ReplicatedLog/Components/StorageManager.cpp
@@ -98,9 +98,8 @@ struct comp::StorageManagerTransaction : IStorageTransaction {
         std::move(mapping),
         [slice = std::move(slice), iter = std::move(iter)](
             StorageManager::IStorageEngineMethods& methods) mutable noexcept {
-          return methods.insert(std::move(iter), {}).thenValue([](auto&& res) {
-            return res.result();
-          });
+          return methods.insert(std::move(iter), {.waitForSync = true})
+              .thenValue([](auto&& res) { return res.result(); });
         });
   }
 

--- a/arangod/Replication2/ReplicatedLog/LogLeader.cpp
+++ b/arangod/Replication2/ReplicatedLog/LogLeader.cpp
@@ -900,6 +900,10 @@ auto replicated_log::LogLeader::GuardedLeaderData::createAppendEntriesRequest(
       }
     }
     req.entries = std::move(transientEntries).persistent();
+
+    _self._logMetrics->replicatedLogAppendEntriesNumEntries->count(
+        req.entries.size());
+    _self._logMetrics->replicatedLogAppendEntriesSize->count(sizeCounter);
   }
 
   auto isEmptyAppendEntries = req.entries.empty();
@@ -1000,6 +1004,8 @@ auto replicated_log::LogLeader::GuardedLeaderData::handleAppendEntriesResponse(
                 << to_string(response.reason.error)
                 << " message id = " << messageId;
             ++follower.numErrorsSinceLastAnswer;
+            _self._logMetrics->replicatedLogLeaderAppendEntriesErrorCount
+                ->count();
         }
       }
     } else {
@@ -1011,6 +1017,7 @@ auto replicated_log::LogLeader::GuardedLeaderData::handleAppendEntriesResponse(
     }
   } else if (res.hasException()) {
     ++follower.numErrorsSinceLastAnswer;
+    _self._logMetrics->replicatedLogLeaderAppendEntriesErrorCount->count();
     follower.lastErrorReason = {
         AppendEntriesErrorReason::ErrorType::kCommunicationError};
     try {

--- a/arangod/Replication2/ReplicatedLog/ReplicatedLogMetrics.h
+++ b/arangod/Replication2/ReplicatedLog/ReplicatedLogMetrics.h
@@ -49,6 +49,12 @@ struct ReplicatedLogMetrics {
   metrics::Histogram<metrics::LogScale<std::uint64_t>>*
       replicatedLogInsertsBytes;
   metrics::Histogram<metrics::LogScale<std::uint64_t>>* replicatedLogInsertsRtt;
+  metrics::Histogram<metrics::LogScale<std::uint64_t>>*
+      replicatedLogAppendEntriesNumEntries;
+  metrics::Histogram<metrics::LogScale<std::uint64_t>>*
+      replicatedLogAppendEntriesSize;
+  metrics::Counter* replicatedLogFollowerEntryDropCount;
+  metrics::Counter* replicatedLogLeaderAppendEntriesErrorCount;
 
   metrics::Counter* replicatedLogNumberAcceptedEntries;
   metrics::Counter* replicatedLogNumberCommittedEntries;

--- a/arangod/Replication2/ReplicatedLog/ReplicatedLogMetrics.tpp
+++ b/arangod/Replication2/ReplicatedLog/ReplicatedLogMetrics.tpp
@@ -100,6 +100,19 @@ ReplicatedLogMetricsIndirect<mock>::ReplicatedLogMetricsIndirect(
   leaderNumInMemoryBytes =
       createMetric<arangodb_replication2_leader_in_memory_bytes>(
           metricsFeature);
+
+  replicatedLogAppendEntriesNumEntries = createMetric<
+      arangodb_replication2_replicated_log_append_entries_num_entries>(
+      metricsFeature);
+  replicatedLogAppendEntriesSize =
+      createMetric<arangodb_replication2_replicated_log_append_entries_size>(
+          metricsFeature);
+  replicatedLogFollowerEntryDropCount = createMetric<
+      arangodb_replication2_replicated_log_follower_entry_drop_count>(
+      metricsFeature);
+  replicatedLogLeaderAppendEntriesErrorCount = createMetric<
+      arangodb_replication2_replicated_log_leader_append_entries_error_count>(
+      metricsFeature);
 }
 
 }  // namespace arangodb::replication2::replicated_log

--- a/arangod/Replication2/ReplicatedLog/ReplicatedLogMetricsDeclarations.h
+++ b/arangod/Replication2/ReplicatedLog/ReplicatedLogMetricsDeclarations.h
@@ -48,6 +48,20 @@ struct InsertBytesScale {
   }
 };
 
+struct AppendEntriesNumEntriesScale {
+  using scale_t = metrics::LogScale<std::uint64_t>;
+  static scale_t scale() {
+    return {scale_t::kSupplySmallestBucket, 2, 0, 1, 16};
+  }
+};
+
+struct AppendEntriesSizeScale {
+  using scale_t = metrics::LogScale<std::uint64_t>;
+  static scale_t scale() {
+    return {scale_t::kSupplySmallestBucket, 2, 0, 64, 18};
+  }
+};
+
 DECLARE_GAUGE(arangodb_replication2_replicated_log_number, std::uint64_t,
               "Number of replicated logs on this arangodb instance");
 
@@ -98,6 +112,21 @@ DECLARE_HISTOGRAM(arangodb_replication2_replicated_log_inserts_bytes,
 DECLARE_HISTOGRAM(
     arangodb_replication2_replicated_log_inserts_rtt, AppendEntriesRttScale,
     "Histogram of round-trip times of replicated log inserts [us]");
+
+DECLARE_HISTOGRAM(
+    arangodb_replication2_replicated_log_append_entries_num_entries,
+    AppendEntriesNumEntriesScale,
+    "Histogram of number of log entries per append-entries request");
+DECLARE_HISTOGRAM(arangodb_replication2_replicated_log_append_entries_size,
+                  AppendEntriesSizeScale,
+                  "Histogram of size of append-entries requests");
+DECLARE_COUNTER(
+    arangodb_replication2_replicated_log_follower_entry_drop_count,
+    "Number of log entries dropped by a follower before appending the log");
+
+DECLARE_COUNTER(
+    arangodb_replication2_replicated_log_leader_append_entries_error_count,
+    "Number of failed append-entries requests");
 
 DECLARE_COUNTER(
     arangodb_replication2_replicated_log_number_accepted_entries_total,


### PR DESCRIPTION
### Scope & Purpose
This PR adds four new metrics:
1. Histogram of number of log entries per append-entries request
2. Histogram of append-entries request sizes
3. Number of log entries dropped by a follower before appending the log
4. Number of failed append-entries requests (only counting true errors, not NoPrevLogMatch)