### PR TITLE
flush instanceInfo after a test suite is done

### DIFF
--- a/js/client/modules/@arangodb/test-helper.js
+++ b/js/client/modules/@arangodb/test-helper.js
@@ -190,10 +190,14 @@ exports.getChecksum = function (endpoint, name) {
 exports.getRawMetric = function (endpoint, tags) {
   const primaryEndpoint = arango.getEndpoint();
   try {
-    reconnectRetry(endpoint, db._name(), "root", "");
+    if (endpoint !== primaryEndpoint) {
+      reconnectRetry(endpoint, db._name(), "root", "");
+    }
     return arango.GET_RAW('/_admin/metrics' + tags);
   } finally {
-    reconnectRetry(primaryEndpoint, db._name(), "root", "");
+    if (endpoint !== primaryEndpoint) {
+      reconnectRetry(primaryEndpoint, db._name(), "root", "");
+    }
   }
 };
 

--- a/js/client/modules/@arangodb/testutils/testing.js
+++ b/js/client/modules/@arangodb/testutils/testing.js
@@ -33,7 +33,7 @@ const pu = require('@arangodb/testutils/process-utils');
 const rp = require('@arangodb/testutils/result-processing');
 const cu = require('@arangodb/testutils/crash-utils');
 const tu = require('@arangodb/testutils/test-utils');
-const versionHas = require("@arangodb/test-helper").versionHas;
+const {versionHas, flushInstanceInfo} = require("@arangodb/test-helper");
 const internal = require('internal');
 const platform = internal.platform;
 
@@ -513,6 +513,9 @@ function iterateTests(cases, options) {
   }
   // running all tests
   for (let n = 0; n < caselist.length; ++n) {
+    // required, because each different test suite may operate with a different set of servers!
+    flushInstanceInfo();
+
     const currentTest = caselist[n];
     var localOptions = _.cloneDeep(options);
     if (localOptions.failed) {


### PR DESCRIPTION
### Scope & Purpose

flush instanceInfo after a test suite is done
because otherwise tests may refer to outdated instanceInfo if suites start different sets of servers

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: -
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 