### PR TITLE
[CINFRA] Use plan-, not current-, leader

### DIFF
--- a/arangod/Replication2/ReplicatedLog/Supervision.cpp
+++ b/arangod/Replication2/ReplicatedLog/Supervision.cpp
@@ -421,7 +421,7 @@ auto checkLeaderRemovedFromTargetParticipants(SupervisionContext& ctx,
     }
 
     auto const acceptableLeaderSet = getParticipantsAcceptableAsLeaders(
-        current.leader->serverId, committedParticipants, current.localState);
+        leader.serverId, committedParticipants, current.localState);
 
     // If there's a new target, we don't want to switch to another server than
     // that to avoid switching the leader too often. Note that this doesn't
@@ -449,7 +449,7 @@ auto checkLeaderRemovedFromTargetParticipants(SupervisionContext& ctx,
     for (auto const& participant : acceptableLeaderSet) {
       // both assertions are guaranteed by getParticipantsAcceptableAsLeaders()
       TRI_ASSERT(committedParticipants.contains(participant));
-      TRI_ASSERT(participant != current.leader->serverId);
+      TRI_ASSERT(participant != leader.serverId);
       auto const& flags = committedParticipants.at(participant);
 
       if (flags.forced) {


### PR DESCRIPTION
### Scope & Purpose

If the leader of a replicated log is no longer part of the target participants, it's replaced with another leader by the Supervision. The logic for that lives in `checkLeaderRemovedFromTargetParticipants`. The current leader is excluded from the list of possible targets; however, the planned leader is the correct entity to compare with.

This is a minor change; the current implementation might lead to some quirky behavior when observing the Supervision, possibly delaying the desired outcome, but I don't see any way it could be harmful.
