### PR TITLE
[CINFRA] Fix spurious test failure

### DIFF
--- a/tests/Replication2/ReplicatedState/DocumentStateMachineTest.cpp
+++ b/tests/Replication2/ReplicatedState/DocumentStateMachineTest.cpp
@@ -997,12 +997,16 @@ TEST_F(DocumentStateMachineTest,
         std::in_place,
         SnapshotConfig{.snapshotId = SnapshotId{1}, .shards = shardMap}};
   });
+  auto emptyPayload = velocypack::SharedSlice(std::shared_ptr<uint8_t const>(
+      velocypack::Slice::emptyArraySliceData,
+      [](auto) { /* don't delete the pointer */ }));
   ON_CALL(*leaderInterfaceMock, nextSnapshotBatch)
       .WillByDefault([&](SnapshotId id) {
         return futures::Future<ResultT<SnapshotBatch>>{
-            std::in_place,
-            SnapshotBatch{
-                .snapshotId = id, .shardId = shardId, .hasMore = true}};
+            std::in_place, SnapshotBatch{.snapshotId = id,
+                                         .shardId = shardId,
+                                         .hasMore = true,
+                                         .payload = emptyPayload}};
       });
 
   std::thread t([follower]() {


### PR DESCRIPTION
### Scope & Purpose

Fix spurious test failures like

```
[ RUN      ] DocumentStateMachineTest.follower_resigning_while_acquiring_snapshot_concurrently
terminate called after throwing an instance of 'arangodb::velocypack::Exception'
  what():  Expecting type Array or Object
```

