### PR TITLE
Cleanup Member Names in ClusterInfo

### DIFF
--- a/arangod/Cluster/ClusterInfo.h
+++ b/arangod/Cluster/ClusterInfo.h
@@ -1083,7 +1083,7 @@ class ClusterInfo final {
       _shards;  // from Plan/Collections/
                 // (may later come from Current/Collections/ )
   // planned shard => servers map
-  containers::FlatHashMap<ShardID, std::vector<ServerID>> _shardServers;
+  containers::FlatHashMap<ShardID, std::vector<ServerID>> _shardsToPlanServers;
   // planned shard ID => collection name
   containers::FlatHashMap<ShardID, CollectionID> _shardToName;
 
@@ -1138,7 +1138,7 @@ class ClusterInfo final {
   // The Current state:
   AllCollectionsCurrent _currentCollections;  // from Current/Collections/
   containers::FlatHashMap<ShardID, std::shared_ptr<std::vector<ServerID>>>
-      _shardIds;  // from Current/Collections/
+      _shardsToCurrentServers;  // from Current/Collections/
 
   struct NewStuffByDatabase;
   containers::FlatHashMap<DatabaseID, std::shared_ptr<NewStuffByDatabase>>


### PR DESCRIPTION
### Scope & Purpose

Enterprise PR:  https://github.com/arangodb/enterprise/pull/1245

Rename `_shardIds` to `_shardsToCurrentServers`, `_shardServers` to `_shardsToPlanServers`. The reason is that I would like to change something in `loadPlan` and the current naming is just to confusing for me. Additionally I want to split the renaming and the actual change in separate PRs.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification
