### PR TITLE
properly decrease _jobsSubmitted if we can't submit to q

### DIFF
--- a/arangod/Scheduler/SupervisedScheduler.cpp
+++ b/arangod/Scheduler/SupervisedScheduler.cpp
@@ -324,6 +324,9 @@ bool SupervisedScheduler::queueItem(RequestLane lane,
     if (bounded) {
       queue.numCountedItems.fetch_sub(1, std::memory_order_relaxed);
     }
+    [[maybe_unused]] uint64_t oldSubmitted =
+        _jobsSubmitted.fetch_sub(1, std::memory_order_relaxed);
+    TRI_ASSERT(oldSubmitted > 0);
     throw;
   }
   std::ignore = work.release();  // queue now has ownership for the WorkItemBase


### PR DESCRIPTION
### Scope & Purpose

Properly count down the value of `_jobsSubmitted` in case adding to the scheduler's queue failed and threw an exception.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: -
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 