### PR TITLE
one more place where we need to deregister the PID from the monitor.

### DIFF
--- a/js/client/modules/@arangodb/testutils/instance.js
+++ b/js/client/modules/@arangodb/testutils/instance.js
@@ -884,16 +884,15 @@ class instance {
     }
   }
   killWithCoreDump (message) {
-    internal.removePidFromMonitor(this.pid);
+    if (this.options.enableAliveMonitor) {
+      internal.removePidFromMonitor(this.pid);
+    }
     this.getInstanceProcessStatus();
     this.serverCrashedLocal = true;
     if (this.pid === null) {
       print(`${RED}${Date()} instance already gone? ${this.name} ${JSON.stringify(this.exitStatus)}${RESET}`);
       this.analyzeServerCrash(`instance ${this.name} during force terminate server already dead? ${JSON.stringify(this.exitStatus)}`);
     } else {
-      if (this.options.enableAliveMonitor) {
-        internal.removePidFromMonitor(this.pid);
-      }
       print(`${RED}${Date()} attempting to generate crashdump of: ${this.name} ${JSON.stringify(this.exitStatus)}${RESET}`);
       crashUtils.generateCrashDump(pu.ARANGOD_BIN, this, this.options, message);
     }

--- a/js/client/modules/@arangodb/testutils/instance.js
+++ b/js/client/modules/@arangodb/testutils/instance.js
@@ -884,6 +884,7 @@ class instance {
     }
   }
   killWithCoreDump (message) {
+    internal.removePidFromMonitor(this.pid);
     this.getInstanceProcessStatus();
     this.serverCrashedLocal = true;
     if (this.pid === null) {


### PR DESCRIPTION
### Scope & Purpose

If we intend to crash the server, we need to deregister its PID from the monitor. 