### PR TITLE
[GORDO-1598] Send status updates from worker

### DIFF
--- a/arangod/Pregel/Conductor/Handler.h
+++ b/arangod/Pregel/Conductor/Handler.h
@@ -59,6 +59,7 @@ struct ConductorHandler : actor::HandlerBase<Runtime, ConductorState> {
               .destinationServer = server,
               .conductor = this->self,
               .resultActorOnCoordinator = this->state->resultActor,
+              .statusActor = this->state->statusActor,
               .ttl = this->state->specifications.ttl,
               .message = message}});
     }

--- a/arangod/Pregel/GraphStore/GraphStorer.cpp
+++ b/arangod/Pregel/GraphStore/GraphStorer.cpp
@@ -38,27 +38,15 @@
 #include "Pregel/StatusMessages.h"
 #include "Pregel/Worker/WorkerConfig.h"
 
+#include "ApplicationFeatures/ApplicationServer.h"
+#include "Basics/overload.h"
 #include "Logger/LogMacros.h"
-
 #include "Scheduler/SchedulerFeature.h"
 #include "Transaction/StandaloneContext.h"
 #include "Utils/OperationOptions.h"
 #include "Utils/OperationResult.h"
 #include "Utils/SingleCollectionTransaction.h"
 #include "VocBase/vocbase.h"
-
-#include "ApplicationFeatures/ApplicationServer.h"
-
-namespace {
-// helper type for the visitor
-template<class... Ts>
-struct overloaded : Ts... {
-  using Ts::operator()...;
-};
-// explicit deduction guide (not needed as of C++20)
-template<class... Ts>
-overloaded(Ts...) -> overloaded<Ts...>;
-}  // namespace
 
 #define LOG_PREGEL(logId, level)          \
   LOG_TOPIC(logId, level, Logger::PREGEL) \
@@ -158,28 +146,28 @@ auto GraphStorer<V, E>::store(std::shared_ptr<Quiver<V, E>> quiver) -> void {
     builder.close();
     ++numDocs;
     if (numDocs % Utils::batchOfVerticesStoredBeforeUpdatingStatus == 0) {
-      std::visit(overloaded{[&](ActorStoringUpdate const& update) {
-                              update.fn(message::GraphStoringUpdate{
-                                  .verticesStored = 0  // TODO
-                              });
-                            },
-                            [](OldStoringUpdate const& update) {
-                              SchedulerFeature::SCHEDULER->queue(
-                                  RequestLane::INTERNAL_LOW, update.fn);
-                            }},
+      std::visit(overload{[&](ActorStoringUpdate const& update) {
+                            update.fn(message::GraphStoringUpdate{
+                                .verticesStored = 0  // TODO
+                            });
+                          },
+                          [](OldStoringUpdate const& update) {
+                            SchedulerFeature::SCHEDULER->queue(
+                                RequestLane::INTERNAL_LOW, update.fn);
+                          }},
                  updateCallback);
     }
   }
 
-  std::visit(overloaded{[&](ActorStoringUpdate const& update) {
-                          update.fn(message::GraphStoringUpdate{
-                              .verticesStored = 0  // TODO
-                          });
-                        },
-                        [](OldStoringUpdate const& update) {
-                          SchedulerFeature::SCHEDULER->queue(
-                              RequestLane::INTERNAL_LOW, update.fn);
-                        }},
+  std::visit(overload{[&](ActorStoringUpdate const& update) {
+                        update.fn(message::GraphStoringUpdate{
+                            .verticesStored = 0  // TODO
+                        });
+                      },
+                      [](OldStoringUpdate const& update) {
+                        SchedulerFeature::SCHEDULER->queue(
+                            RequestLane::INTERNAL_LOW, update.fn);
+                      }},
              updateCallback);
 
   // commit the remainders in our buffer

--- a/arangod/Pregel/SpawnActor.h
+++ b/arangod/Pregel/SpawnActor.h
@@ -86,7 +86,7 @@ struct SpawnHandler : actor::HandlerBase<Runtime, SpawnState> {
             msg.conductor, msg.message, algorithm->messageFormatUnique(),
             algorithm->messageCombinerUnique(), std::move(algorithm),
             this->state->vocbaseGuard.database(), this->self,
-            this->state->resultActor),
+            this->state->resultActor, msg.statusActor),
         worker::message::WorkerStart{});
   }
 

--- a/arangod/Pregel/SpawnMessages.h
+++ b/arangod/Pregel/SpawnMessages.h
@@ -39,6 +39,7 @@ struct SpawnWorker {
   actor::ServerID destinationServer;
   actor::ActorPID conductor;
   actor::ActorPID resultActorOnCoordinator;
+  actor::ActorPID statusActor;
   TTL ttl;
   worker::message::CreateWorker message;
 };
@@ -46,7 +47,7 @@ template<typename Inspector>
 auto inspect(Inspector& f, SpawnWorker& x) {
   return f.object(x).fields(
       f.field("destinationServer", x.destinationServer),
-      f.field("conductor", x.conductor),
+      f.field("conductor", x.conductor), f.field("statusActor", x.statusActor),
       f.field("resultActorOnCoordinator", x.resultActorOnCoordinator),
       f.field("ttl", x.ttl), f.field("message", x.message));
 }

--- a/arangod/Pregel/Statistics.h
+++ b/arangod/Pregel/Statistics.h
@@ -36,31 +36,16 @@ namespace pregel {
 struct MessageStats {
   size_t sendCount = 0;
   size_t receivedCount = 0;
+  size_t memoryBytesUsedForMessages = 0;
   double superstepRuntimeSecs = 0;
 
   MessageStats() = default;
-  explicit MessageStats(VPackSlice statValues) { accumulate(statValues); }
   MessageStats(size_t s, size_t r) : sendCount(s), receivedCount(r) {}
 
   void accumulate(MessageStats const& other) {
     sendCount += other.sendCount;
     receivedCount += other.receivedCount;
     superstepRuntimeSecs += other.superstepRuntimeSecs;
-  }
-
-  void accumulate(VPackSlice statValues) {
-    VPackSlice p = statValues.get(Utils::sendCountKey);
-    if (p.isInteger()) {
-      sendCount += p.getUInt();
-    }
-    p = statValues.get(Utils::receivedCountKey);
-    if (p.isInteger()) {
-      receivedCount += p.getUInt();
-    }
-    // p = statValues.get(Utils::superstepRuntimeKey);
-    // if (p.isNumber()) {
-    //  superstepRuntimeSecs += p.getNumber<double>();
-    //}
   }
 
   void serializeValues(VPackBuilder& b) const {
@@ -97,13 +82,6 @@ struct StatsManager {
 
   void accumulateActiveCounts(std::string const& sender, uint64_t active) {
     _activeStats[sender] += active;
-  }
-
-  void accumulateMessageStats(VPackSlice data) {
-    VPackSlice sender = data.get(Utils::senderKey);
-    if (sender.isString()) {
-      _serverStats[sender.copyString()].accumulate(data);
-    }
   }
 
   void accumulateMessageStats(std::string const& sender,

--- a/arangod/Pregel/StatusMessages.h
+++ b/arangod/Pregel/StatusMessages.h
@@ -80,6 +80,14 @@ auto inspect(Inspector& f, GraphLoadingUpdate& x) {
                             f.field("memoryBytesUsed", x.memoryBytesUsed));
 }
 
+struct GraphStoringUpdate {
+  uint64_t verticesStored;
+};
+template<typename Inspector>
+auto inspect(Inspector& f, GraphStoringUpdate& x) {
+  return f.object(x).fields(f.field("verticesStored", x.verticesStored));
+}
+
 struct GlobalSuperStepUpdate {
   std::uint64_t gss;
   std::uint64_t verticesProcessed = 0;
@@ -97,10 +105,10 @@ auto inspect(Inspector& f, GlobalSuperStepUpdate& x) {
 }
 
 struct StatusMessages
-    : std::variant<StatusStart, LoadingStarted, GraphLoadingUpdate,
-                   GlobalSuperStepUpdate> {
-  using std::variant<StatusStart, LoadingStarted, GraphLoadingUpdate,
-                     GlobalSuperStepUpdate>::variant;
+    : std::variant<StatusStart, GraphLoadingUpdate, GlobalSuperStepUpdate,
+                   GraphStoringUpdate> {
+  using std::variant<StatusStart, GraphLoadingUpdate, GlobalSuperStepUpdate,
+                     GraphStoringUpdate>::variant;
 };
 template<typename Inspector>
 auto inspect(Inspector& f, StatusMessages& x) {
@@ -109,7 +117,8 @@ auto inspect(Inspector& f, StatusMessages& x) {
       arangodb::inspection::type<LoadingStarted>("LoadingStarted"),
       arangodb::inspection::type<GraphLoadingUpdate>("GraphLoadingUpdate"),
       arangodb::inspection::type<GlobalSuperStepUpdate>(
-          "GlobalSuperStepUpdate"));
+          "GlobalSuperStepUpdate"),
+      arangodb::inspection::type<GraphStoringUpdate>("GraphStoringUpdate"));
 }
 
 }  // namespace arangodb::pregel::message

--- a/arangod/Pregel/StatusMessages.h
+++ b/arangod/Pregel/StatusMessages.h
@@ -105,10 +105,10 @@ auto inspect(Inspector& f, GlobalSuperStepUpdate& x) {
 }
 
 struct StatusMessages
-    : std::variant<StatusStart, GraphLoadingUpdate, GlobalSuperStepUpdate,
-                   GraphStoringUpdate> {
-  using std::variant<StatusStart, GraphLoadingUpdate, GlobalSuperStepUpdate,
-                     GraphStoringUpdate>::variant;
+    : std::variant<StatusStart, LoadingStarted, GraphLoadingUpdate,
+                   GlobalSuperStepUpdate, GraphStoringUpdate> {
+  using std::variant<StatusStart, LoadingStarted, GraphLoadingUpdate,
+                     GlobalSuperStepUpdate, GraphStoringUpdate>::variant;
 };
 template<typename Inspector>
 auto inspect(Inspector& f, StatusMessages& x) {

--- a/arangod/Pregel/StatusMessages.h
+++ b/arangod/Pregel/StatusMessages.h
@@ -80,16 +80,36 @@ auto inspect(Inspector& f, GraphLoadingUpdate& x) {
                             f.field("memoryBytesUsed", x.memoryBytesUsed));
 }
 
+struct GlobalSuperStepUpdate {
+  std::uint64_t gss;
+  std::uint64_t verticesProcessed = 0;
+  std::uint64_t messagesSent = 0;
+  std::uint64_t messagesReceived = 0;
+  std::uint64_t memoryBytesUsedForMessages = 0;
+};
+template<typename Inspector>
+auto inspect(Inspector& f, GlobalSuperStepUpdate& x) {
+  return f.object(x).fields(
+      f.field("gss", x.gss), f.field("verticesProcessed", x.verticesProcessed),
+      f.field("messagesSent", x.messagesSent),
+      f.field("messagesReceived", x.messagesReceived),
+      f.field("memoryBytesUsedForMessages", x.memoryBytesUsedForMessages));
+}
+
 struct StatusMessages
-    : std::variant<StatusStart, LoadingStarted, GraphLoadingUpdate> {
-  using std::variant<StatusStart, LoadingStarted, GraphLoadingUpdate>::variant;
+    : std::variant<StatusStart, LoadingStarted, GraphLoadingUpdate,
+                   GlobalSuperStepUpdate> {
+  using std::variant<StatusStart, LoadingStarted, GraphLoadingUpdate,
+                     GlobalSuperStepUpdate>::variant;
 };
 template<typename Inspector>
 auto inspect(Inspector& f, StatusMessages& x) {
   return f.variant(x).unqualified().alternatives(
       arangodb::inspection::type<StatusStart>("Start"),
       arangodb::inspection::type<LoadingStarted>("LoadingStarted"),
-      arangodb::inspection::type<GraphLoadingUpdate>("GraphLoadingUpdate"));
+      arangodb::inspection::type<GraphLoadingUpdate>("GraphLoadingUpdate"),
+      arangodb::inspection::type<GlobalSuperStepUpdate>(
+          "GlobalSuperStepUpdate"));
 }
 
 }  // namespace arangodb::pregel::message

--- a/arangod/Pregel/StatusMessages.h
+++ b/arangod/Pregel/StatusMessages.h
@@ -68,14 +68,28 @@ auto inspect(Inspector& f, LoadingStarted& x) {
   return f.object(x).fields(f.field("state", x.state), f.field("time", x.time));
 }
 
-struct StatusMessages : std::variant<StatusStart, LoadingStarted> {
-  using std::variant<StatusStart, LoadingStarted>::variant;
+struct GraphLoadingUpdate {
+  std::uint64_t verticesLoaded;
+  std::uint64_t edgesLoaded;
+  std::uint64_t memoryBytesUsed;
+};
+template<typename Inspector>
+auto inspect(Inspector& f, GraphLoadingUpdate& x) {
+  return f.object(x).fields(f.field("verticesLoaded", x.verticesLoaded),
+                            f.field("edgesLoaded", x.edgesLoaded),
+                            f.field("memoryBytesUsed", x.memoryBytesUsed));
+}
+
+struct StatusMessages
+    : std::variant<StatusStart, LoadingStarted, GraphLoadingUpdate> {
+  using std::variant<StatusStart, LoadingStarted, GraphLoadingUpdate>::variant;
 };
 template<typename Inspector>
 auto inspect(Inspector& f, StatusMessages& x) {
   return f.variant(x).unqualified().alternatives(
       arangodb::inspection::type<StatusStart>("Start"),
-      arangodb::inspection::type<LoadingStarted>("LoadingStarted"));
+      arangodb::inspection::type<LoadingStarted>("LoadingStarted"),
+      arangodb::inspection::type<GraphLoadingUpdate>("GraphLoadingUpdate"));
 }
 
 }  // namespace arangodb::pregel::message

--- a/arangod/Pregel/Worker/State.h
+++ b/arangod/Pregel/Worker/State.h
@@ -79,21 +79,6 @@ struct WorkerState {
     }
   }
 
-  auto observeStatus() -> Status const {
-    auto currentGss = currentGssObservables.observe();
-    auto fullGssStatus = allGssStatus;
-
-    if (!currentGss.isDefault()) {
-      fullGssStatus.gss.emplace_back(currentGss);
-    }
-    return Status{
-        .graphStoreStatus =
-            GraphStoreStatus{},  // TODO GORDO-1546 graphStore->status(),
-        .allGssStatus = fullGssStatus.gss.size() > 0
-                            ? std::optional{fullGssStatus}
-                            : std::nullopt};
-  }
-
   std::shared_ptr<WorkerConfig> config;
 
   // only needed in computing state
@@ -111,7 +96,7 @@ struct WorkerState {
   std::unique_ptr<OutCache<M>> outCache = nullptr;
   uint32_t messageBatchSize = 500;
 
-  actor::ActorPID conductor;
+  const actor::ActorPID conductor;
   std::unique_ptr<Algorithm<V, E, M>> algorithm;
   const DatabaseGuard vocbaseGuard;
   const actor::ActorPID spawnActor;
@@ -119,8 +104,6 @@ struct WorkerState {
   const actor::ActorPID statusActor;
   std::shared_ptr<Quiver<V, E>> quiver = std::make_unique<Quiver<V, E>>();
   MessageStats messageStats;
-  GssObservables currentGssObservables;
-  AllGssStatus allGssStatus;
 };
 template<typename V, typename E, typename M, typename Inspector>
 auto inspect(Inspector& f, WorkerState<V, E, M>& x) {

--- a/arangod/Pregel/Worker/State.h
+++ b/arangod/Pregel/Worker/State.h
@@ -46,7 +46,7 @@ struct WorkerState {
               std::unique_ptr<MessageCombiner<M>> newMessageCombiner,
               std::unique_ptr<Algorithm<V, E, M>> algorithm,
               TRI_vocbase_t& vocbase, actor::ActorPID spawnActor,
-              actor::ActorPID resultActor)
+              actor::ActorPID resultActor, actor::ActorPID statusActor)
       : config{std::make_shared<WorkerConfig>(&vocbase)},
         workerContext{std::move(workerContext)},
         messageFormat{std::move(newMessageFormat)},
@@ -55,7 +55,8 @@ struct WorkerState {
         algorithm{std::move(algorithm)},
         vocbaseGuard{vocbase},
         spawnActor(spawnActor),
-        resultActor(resultActor) {
+        resultActor(resultActor),
+        statusActor(statusActor) {
     config->updateConfig(specifications);
 
     if (messageCombiner) {
@@ -115,6 +116,7 @@ struct WorkerState {
   const DatabaseGuard vocbaseGuard;
   const actor::ActorPID spawnActor;
   const actor::ActorPID resultActor;
+  const actor::ActorPID statusActor;
   std::shared_ptr<Quiver<V, E>> quiver = std::make_unique<Quiver<V, E>>();
   MessageStats messageStats;
   GssObservables currentGssObservables;

--- a/arangod/Pregel/Worker/Worker.cpp
+++ b/arangod/Pregel/Worker/Worker.cpp
@@ -526,9 +526,9 @@ void Worker<V, E, M>::finalizeExecution(FinalizeExecution const& msg,
          statusUpdateCallback = std::move(_makeStatusCallback()),
          cleanup = std::move(cleanup)] {
           try {
-            auto storer = GraphStorer<V, E>(_config, _algorithm->inputFormat(),
-                                            _config->globalShardIDs(),
-                                            std::move(statusUpdateCallback));
+            auto storer = GraphStorer<V, E>(
+                _config, _algorithm->inputFormat(), _config->globalShardIDs(),
+                OldStoringUpdate{.fn = std::move(statusUpdateCallback)});
             _feature.metrics()->pregelWorkersStoringNumber->fetch_add(1);
             storer.store(_quiver);
           } catch (std::exception const& ex) {

--- a/arangod/Pregel/Worker/Worker.cpp
+++ b/arangod/Pregel/Worker/Worker.cpp
@@ -188,25 +188,26 @@ void Worker<V, E, M>::setupWorker() {
       "Worker for execution number {} is loading", _config->executionNumber());
   _feature.metrics()->pregelWorkersLoadingNumber->fetch_add(1);
   Scheduler* scheduler = SchedulerFeature::SCHEDULER;
-  scheduler->queue(
-      RequestLane::INTERNAL_LOW,
-      [this, self = shared_from_this(),
-       statusUpdateCallback = std::move(_makeStatusCallback()),
-       finishedCallback = std::move(finishedCallback)] {
-        try {
-          auto loader = GraphLoader<V, E>(_config, _algorithm->inputFormat(),
-                                          statusUpdateCallback);
-          _quiver = loader.load();
-        } catch (std::exception const& ex) {
-          LOG_PREGEL("a47c4", WARN)
-              << "caught exception in loadShards: " << ex.what();
-          throw;
-        } catch (...) {
-          LOG_PREGEL("e932d", WARN) << "caught unknown exception in loadShards";
-          throw;
-        }
-        finishedCallback();
-      });
+  scheduler->queue(RequestLane::INTERNAL_LOW,
+                   [this, self = shared_from_this(),
+                    statusUpdateCallback = std::move(_makeStatusCallback()),
+                    finishedCallback = std::move(finishedCallback)] {
+                     try {
+                       auto loader = GraphLoader<V, E>(
+                           _config, _algorithm->inputFormat(),
+                           OldLoadingUpdate{.fn = statusUpdateCallback});
+                       _quiver = loader.load();
+                     } catch (std::exception const& ex) {
+                       LOG_PREGEL("a47c4", WARN)
+                           << "caught exception in loadShards: " << ex.what();
+                       throw;
+                     } catch (...) {
+                       LOG_PREGEL("e932d", WARN)
+                           << "caught unknown exception in loadShards";
+                       throw;
+                     }
+                     finishedCallback();
+                   });
 }
 
 template<typename V, typename E, typename M>


### PR DESCRIPTION
Sends status updates from the worker actor to the status actor. There are 3 different message types for the different phases loading, computing (one message per global superstep) and storing.
The loading and storing messages are sent from the GraphLoader and GraphStorer, I adapted them a bit such you can now either give it an old status update callback (such that these two still work with the old pregel) or a callback to call the actor-dispatch function. (After we delete the old pregel without actors, we should think about how to not need to use a callback here.)
The status actor updates the status of each worker separately and aggregates the status of the workers to get a total value on all the variables.