### PR TITLE
[CINFRA-723] Remove unwanted server if possible

### DIFF
--- a/arangod/Replication2/AgencyCollectionSpecification.h
+++ b/arangod/Replication2/AgencyCollectionSpecification.h
@@ -53,9 +53,9 @@ struct CollectionGroup {
 
   struct Attributes {
     struct MutableAttributes {
-      std::size_t writeConcern;
-      std::size_t replicationFactor;
-      bool waitForSync;
+      std::size_t writeConcern{};
+      std::size_t replicationFactor{};
+      bool waitForSync{};
     };
 
     MutableAttributes mutableAttributes;

--- a/arangod/Replication2/AgencyCollectionSpecification.h
+++ b/arangod/Replication2/AgencyCollectionSpecification.h
@@ -53,9 +53,9 @@ struct CollectionGroup {
 
   struct Attributes {
     struct MutableAttributes {
-      std::size_t writeConcern{};
-      std::size_t replicationFactor{};
-      bool waitForSync{};
+      std::size_t writeConcern;
+      std::size_t replicationFactor;
+      bool waitForSync;
     };
 
     MutableAttributes mutableAttributes;

--- a/tests/Replication2/ReplicatedLog/Supervision/SupervisionTest.cpp
+++ b/tests/Replication2/ReplicatedLog/Supervision/SupervisionTest.cpp
@@ -428,7 +428,7 @@ TEST_F(LogSupervisionTest, test_remove_participant_action_missing_snapshot) {
   checkReplicatedLog(ctx, log, health);
 
   // no action is expected.
-  EXPECT_FALSE(ctx.hasAction());
+  EXPECT_FALSE(ctx.hasAction()) << fmt::format("{}", ctx.getAction());
 }
 
 TEST_F(LogSupervisionTest, test_remove_participant_action_wait_for_committed) {


### PR DESCRIPTION
### Scope & Purpose

Previously, a server that should be removed couldn't be if `softWriteConcern == replicationFactor`.

- [X] :hankey: Bugfix

### Checklist

- [X] Tests
  - [X] **Regression tests**
  - [X] C++ **Unit tests**
