### PR TITLE
[CINFRA-700] Fix getResponsibleServer by relying on the supervision.

### DIFF
--- a/arangod/Cluster/ClusterInfo.h
+++ b/arangod/Cluster/ClusterInfo.h
@@ -710,12 +710,6 @@ class ClusterInfo final {
   std::shared_ptr<std::vector<ServerID> const> getResponsibleServer(
       std::string_view shardID);
 
-  std::shared_ptr<std::vector<ServerID> const> getResponsibleServerReplication1(
-      std::string_view shardID);
-
-  std::shared_ptr<std::vector<ServerID> const> getResponsibleServerReplication2(
-      std::string_view shardID);
-
   //////////////////////////////////////////////////////////////////////////////
   /// @brief atomically find all servers who are responsible for the given
   /// shards (only the leaders).
@@ -727,14 +721,6 @@ class ClusterInfo final {
 
   containers::FlatHashMap<ShardID, ServerID> getResponsibleServers(
       containers::FlatHashSet<ShardID> const&);
-
-  void getResponsibleServersReplication1(
-      containers::FlatHashSet<ShardID> const& shardIds,
-      containers::FlatHashMap<ShardID, ServerID>& result);
-
-  bool getResponsibleServersReplication2(
-      containers::FlatHashSet<ShardID> const& shardIds,
-      containers::FlatHashMap<ShardID, ServerID>& result);
 
   //////////////////////////////////////////////////////////////////////////////
   /// @brief atomically find all servers who are responsible for the given


### PR DESCRIPTION
### Scope & Purpose
Currently the supervision for collection groups updates the shard map in plan. This shard map is copied by the leader into current. This will always contains the correct server as leader. Thus we can rely on the replication 1 way of looking up the shard.

This is much simpler than the previous code and it is correct! Once we got rid of the old shard map, we have touch this code anyways again.