### PR TITLE
[CINFRA-726] Expose snapshot status as part of the leader status.

### DIFF
--- a/arangod/Cluster/Maintenance.cpp
+++ b/arangod/Cluster/Maintenance.cpp
@@ -1179,7 +1179,8 @@ static std::tuple<VPackBuilder, bool, bool> assembleLocalCollectionInfo(
     DatabaseFeature& df, VPackSlice const& info, VPackSlice const& planServers,
     std::string const& database, std::string const& shard,
     std::string const& ourselves, MaintenanceFeature::errors_t const& allErrors,
-    replication::Version replicationVersion) {
+    replication::Version replicationVersion,
+    ReplicatedLogStatusMapByDatabase const& localLogs) {
   VPackBuilder ret;
 
   try {
@@ -1258,13 +1259,51 @@ static std::tuple<VPackBuilder, bool, bool> assembleLocalCollectionInfo(
         shardInSync = planServers.length() == numFollowers + 1;
         shardReplicated = numFollowers > 0;
       } else {
-        // Copy over PLAN values for replication 2 databases
-        ret.add(VPackValue(maintenance::SERVERS));
-        ret.add(planServers);
-        ret.add(VPackValue(StaticStrings::FailoverCandidates));
-        ret.add(planServers);
-        shardInSync = true;
-        shardReplicated = true;
+        auto const* status =
+            [&]() -> replication2::maintenance::LogStatus const* {
+          if (auto logs = localLogs.find(database); logs != localLogs.end()) {
+            auto logId = collection->replicatedStateId();
+            if (auto log = logs->second.find(logId);
+                log != logs->second.end()) {
+              if (log->second.status.role ==
+                  arangodb::replication2::replicated_log::ParticipantRole::
+                      kLeader) {
+                return &log->second;
+              }
+            }
+          }
+          return nullptr;
+        }();
+
+        if (status) {
+          ret.add(VPackValue(maintenance::SERVERS));
+          {
+            VPackArrayBuilder ar(&ret);
+            ret.add(VPackValue(ourselves));
+            for (auto const& p : status->status.followersWithSnapshot) {
+              ret.add(VPackValue(p));
+            }
+          }
+          ret.add(VPackValue(StaticStrings::FailoverCandidates));
+          {
+            VPackArrayBuilder ar(&ret);
+            ret.add(VPackValue(ourselves));
+            for (auto const& p : status->status.followersWithSnapshot) {
+              ret.add(VPackValue(p));
+            }
+          }
+          shardInSync =
+              status->status.followersWithSnapshot.size() + 1 ==
+              status->status.activeParticipantsConfig->participants.size();
+          shardReplicated = !status->status.followersWithSnapshot.empty();
+        } else {
+          ret.add(VPackValue(maintenance::SERVERS));
+          ret.add(VPackSlice::emptyArraySlice());
+          ret.add(VPackValue(StaticStrings::FailoverCandidates));
+          ret.add(VPackSlice::emptyArraySlice());
+          shardInSync = false;
+          shardReplicated = false;
+        }
       }
     }
     return {ret, shardInSync, shardReplicated};
@@ -1717,7 +1756,7 @@ arangodb::Result arangodb::maintenance::reportInCurrent(
             auto const [localCollectionInfo, shardInSync, shardReplicated] =
                 assembleLocalCollectionInfo(
                     df, shSlice, shardMap.slice().get(shName), dbName, shName,
-                    serverId, allErrors, replicationVersion);
+                    serverId, allErrors, replicationVersion, localLogs);
             // Collection no longer exists
             TRI_ASSERT(!localCollectionInfo.slice().isNone());
             if (localCollectionInfo.slice().isEmptyObject() ||

--- a/arangod/Replication2/ReplicatedLog/LogLeader.cpp
+++ b/arangod/Replication2/ReplicatedLog/LogLeader.cpp
@@ -563,7 +563,7 @@ auto replicated_log::LogLeader::getQuickStatus() const -> QuickLogStatus {
   std::vector<ParticipantId> followersWithSnapshot;
   followersWithSnapshot.reserve(guard->_follower.size());
   for (auto const& [pid, follower] : guard->_follower) {
-    if (follower->snapshotAvailable) {
+    if (pid != _id && follower->snapshotAvailable) {
       followersWithSnapshot.emplace_back(pid);
     }
   }

--- a/arangod/Replication2/ReplicatedLog/LogLeader.cpp
+++ b/arangod/Replication2/ReplicatedLog/LogLeader.cpp
@@ -504,7 +504,7 @@ auto replicated_log::LogLeader::getStatus() const -> LogStatus {
           FollowerStatistics{
               LogStatistics{f->lastAckedIndex, f->lastAckedCommitIndex},
               f->lastErrorReason, lastRequestLatencyMS, state,
-              f->nextPrevLogIndex});
+              f->nextPrevLogIndex, f->snapshotAvailable});
     }
 
     status.commitLagMS = leaderData.calculateCommitLag();
@@ -560,6 +560,13 @@ auto replicated_log::LogLeader::getQuickStatus() const -> QuickLogStatus {
   if (guard->calculateCommitLag() > std::chrono::seconds{20}) {
     commitFailReason = guard->_lastCommitFailReason;
   }
+  std::vector<ParticipantId> followersWithSnapshot;
+  followersWithSnapshot.reserve(guard->_follower.size());
+  for (auto const& [pid, follower] : guard->_follower) {
+    if (follower->snapshotAvailable) {
+      followersWithSnapshot.emplace_back(pid);
+    }
+  }
   return QuickLogStatus{
       .role = ParticipantRole::kLeader,
       .localState = localState,
@@ -569,7 +576,8 @@ auto replicated_log::LogLeader::getQuickStatus() const -> QuickLogStatus {
       .snapshotAvailable = true,
       .commitFailReason = commitFailReason,
       .activeParticipantsConfig = guard->activeParticipantsConfig,
-      .committedParticipantsConfig = guard->committedParticipantsConfig};
+      .committedParticipantsConfig = guard->committedParticipantsConfig,
+      .followersWithSnapshot = std::move(followersWithSnapshot)};
 }
 
 auto replicated_log::LogLeader::insert(LogPayload payload, bool waitForSync)

--- a/arangod/Replication2/ReplicatedLog/LogStatus.h
+++ b/arangod/Replication2/ReplicatedLog/LogStatus.h
@@ -59,6 +59,8 @@ struct QuickLogStatus {
   std::shared_ptr<agency::ParticipantsConfig const>
       committedParticipantsConfig{};
 
+  std::vector<ParticipantId> followersWithSnapshot{};
+
   [[nodiscard]] auto getCurrentTerm() const noexcept -> std::optional<LogTerm>;
   [[nodiscard]] auto getLocalStatistics() const noexcept
       -> std::optional<LogStatistics>;
@@ -91,6 +93,7 @@ auto inspect(Inspector& f, QuickLogStatus& x) {
       f.field("leadershipEstablished", x.leadershipEstablished),
       f.field("snapshotAvailable", x.snapshotAvailable),
       f.field("commitFailReason", x.commitFailReason),
+      f.field("followersWithSnapshot", x.followersWithSnapshot),
       f.field("activeParticipantsConfig", activeParticipantsConfig),
       f.field("committedParticipantsConfig", committedParticipantsConfig));
   if constexpr (Inspector::isLoading) {
@@ -107,6 +110,7 @@ struct FollowerStatistics : LogStatistics {
   std::chrono::duration<double, std::milli> lastRequestLatencyMS;
   FollowerState internalState;
   LogIndex nextPrevLogIndex;
+  bool snapshotAvailable{false};
 
   friend auto operator==(FollowerStatistics const& left,
                          FollowerStatistics const& right) noexcept
@@ -123,6 +127,7 @@ auto inspect(Inspector& f, FollowerStatistics& x) {
       f.field(StaticStrings::ReleaseIndex, x.releaseIndex),
       f.field("nextPrevLogIndex", x.nextPrevLogIndex),
       f.field("lastErrorReason", x.lastErrorReason),
+      f.field("snapshotAvailable", x.snapshotAvailable),
       f.field("lastRequestLatencyMS", x.lastRequestLatencyMS)
           .transformWith(inspection::DurationTransformer<
                          std::chrono::duration<double, std::milli>>{}),


### PR DESCRIPTION
### Scope & Purpose
The goal of this PR is to fix the display of servers in the webui for a given shard. We only want to report those servers in current that actually have received a snapshot from the leader (or already have one).