### PR TITLE
testing: only enable the process monitoring in maintainer mode 

### DIFF
--- a/client-tools/Shell/ProcessMonitoringFeature.cpp
+++ b/client-tools/Shell/ProcessMonitoringFeature.cpp
@@ -96,8 +96,12 @@ ProcessMonitoringFeature::~ProcessMonitoringFeature() = default;
 
 void ProcessMonitoringFeature::validateOptions(
     std::shared_ptr<options::ProgramOptions> /*options*/) {
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   _enabled =
       server().getFeature<V8SecurityFeature>().isAllowedToControlProcesses();
+#else
+  _enabled =
+#endif
 }
 
 void ProcessMonitoringFeature::start() {


### PR DESCRIPTION
### Scope & Purpose

disable process monitoring thread in production arangosh'es.