### PR TITLE
Make InCaches independent of WorkerConfig

### DIFF
--- a/arangod/Pregel/IncomingCache.cpp
+++ b/arangod/Pregel/IncomingCache.cpp
@@ -24,7 +24,6 @@
 #include "IncomingCache.h"
 #include "Pregel/Utils.h"
 #include "Pregel/Worker/Messages.h"
-#include "Pregel/Worker/WorkerConfig.h"
 #include "Pregel/SenderMessage.h"
 
 #include "Pregel/Algos/ColorPropagation/ColorPropagationValue.h"
@@ -104,16 +103,13 @@ void InCache<M>::storeMessage(PregelShard shard, std::string_view vertexId,
 // ================== ArrayIncomingCache ==================
 
 template<typename M>
-ArrayInCache<M>::ArrayInCache(std::shared_ptr<WorkerConfig const> config,
+ArrayInCache<M>::ArrayInCache(std::set<PregelShard> localShards,
                               MessageFormat<M> const* format)
-    : InCache<M>(format) {
-  if (config != nullptr) {
-    std::set<PregelShard> const& shardIDs = config->localPregelShardIDs();
-    // one mutex per shard, we will see how this scales
-    for (PregelShard shardID : shardIDs) {
-      this->_bucketLocker[shardID];
-      _shardMap[shardID];
-    }
+    : InCache<M>(format), _localShards(localShards) {
+  // one mutex per shard, we will see how this scales
+  for (PregelShard pregelShard : _localShards) {
+    this->_bucketLocker[pregelShard];
+    _shardMap[pregelShard];
   }
 }
 
@@ -125,14 +121,12 @@ void ArrayInCache<M>::_set(PregelShard shard, std::string_view const& key,
 }
 
 template<typename M>
-void ArrayInCache<M>::mergeCache(std::shared_ptr<WorkerConfig const> config,
-                                 InCache<M> const* otherCache) {
+void ArrayInCache<M>::mergeCache(InCache<M> const* otherCache) {
   ArrayInCache<M>* other = (ArrayInCache<M>*)otherCache;
   this->_containedMessageCount += other->_containedMessageCount;
 
   // ranomize access to buckets, don't wait for the lock
-  std::set<PregelShard> const& shardIDs = config->localPregelShardIDs();
-  std::vector<PregelShard> randomized(shardIDs.begin(), shardIDs.end());
+  std::vector<PregelShard> randomized(_localShards.begin(), _localShards.end());
 
   std::random_device rd;
   std::mt19937 g(rd());
@@ -221,17 +215,14 @@ void ArrayInCache<M>::forEach(
 // ================== CombiningIncomingCache ==================
 
 template<typename M>
-CombiningInCache<M>::CombiningInCache(
-    std::shared_ptr<WorkerConfig const> config, MessageFormat<M> const* format,
-    MessageCombiner<M> const* combiner)
-    : InCache<M>(format), _combiner(combiner) {
-  if (config != nullptr) {
-    std::set<PregelShard> const& shardIDs = config->localPregelShardIDs();
-    // one mutex per shard, we will see how this scales
-    for (PregelShard shardID : shardIDs) {
-      this->_bucketLocker[shardID];
-      _shardMap[shardID];
-    }
+CombiningInCache<M>::CombiningInCache(std::set<PregelShard> localShards,
+                                      MessageFormat<M> const* format,
+                                      MessageCombiner<M> const* combiner)
+    : InCache<M>(format), _combiner(combiner), _localShards(localShards) {
+  // one mutex per shard, we will see how this scales
+  for (PregelShard pregelShard : localShards) {
+    this->_bucketLocker[pregelShard];
+    _shardMap[pregelShard];
   }
 }
 
@@ -249,8 +240,7 @@ void CombiningInCache<M>::_set(PregelShard shard, std::string_view const& key,
 }
 
 template<typename M>
-void CombiningInCache<M>::mergeCache(std::shared_ptr<WorkerConfig const> config,
-                                     InCache<M> const* otherCache) {
+void CombiningInCache<M>::mergeCache(InCache<M> const* otherCache) {
   CombiningInCache<M>* other = (CombiningInCache<M>*)otherCache;
   this->_containedMessageCount += other->_containedMessageCount;
 
@@ -259,8 +249,7 @@ void CombiningInCache<M>::mergeCache(std::shared_ptr<WorkerConfig const> config,
   }
 
   // randomize access to buckets, don't wait for the lock
-  std::set<PregelShard> const& shardIDs = config->localPregelShardIDs();
-  std::vector<PregelShard> randomized(shardIDs.begin(), shardIDs.end());
+  std::vector<PregelShard> randomized(_localShards.begin(), _localShards.end());
   std::random_device rd;
   std::mt19937 g(rd());
   std::shuffle(randomized.begin(), randomized.end(), g);

--- a/arangod/Pregel/IncomingCache.h
+++ b/arangod/Pregel/IncomingCache.h
@@ -26,8 +26,9 @@
 #include <velocypack/Slice.h>
 
 #include <atomic>
-#include <string>
 #include <map>
+#include <set>
+#include <string>
 
 #include "Basics/Common.h"
 
@@ -38,8 +39,6 @@
 
 namespace arangodb {
 namespace pregel {
-
-class WorkerConfig;
 
 /* In the longer run, maybe write optimized implementations for certain use
 cases. For example threaded
@@ -73,8 +72,7 @@ class InCache {
   void storeMessage(PregelShard shard, std::string_view vertexId,
                     M const& data);
 
-  virtual void mergeCache(std::shared_ptr<WorkerConfig const> config,
-                          InCache<M> const* otherCache) = 0;
+  virtual void mergeCache(InCache<M> const* otherCache) = 0;
   /// @brief get messages for vertex id. (Don't use keys from _from or _to
   /// directly, they contain the collection name)
   virtual MessageIterator<M> getMessages(PregelShard shard,
@@ -97,17 +95,17 @@ template<typename M>
 class ArrayInCache : public InCache<M> {
   typedef std::unordered_map<std::string, std::vector<M>> HMap;
   std::map<PregelShard, HMap> _shardMap;
+  std::set<PregelShard> _localShards;
 
  protected:
   void _set(PregelShard shard, std::string_view const& vertexId,
             M const& data) override;
 
  public:
-  ArrayInCache(std::shared_ptr<WorkerConfig const> config,
+  ArrayInCache(std::set<PregelShard> localShards,
                MessageFormat<M> const* format);
 
-  void mergeCache(std::shared_ptr<WorkerConfig const> config,
-                  InCache<M> const* otherCache) override;
+  void mergeCache(InCache<M> const* otherCache) override;
   MessageIterator<M> getMessages(PregelShard shard,
                                  std::string_view const& key) override;
   void clear() override;
@@ -124,20 +122,20 @@ class CombiningInCache : public InCache<M> {
 
   MessageCombiner<M> const* _combiner;
   std::map<PregelShard, HMap> _shardMap;
+  std::set<PregelShard> _localShards;
 
  protected:
   void _set(PregelShard shard, std::string_view const& vertexId,
             M const& data) override;
 
  public:
-  CombiningInCache(std::shared_ptr<WorkerConfig const> config,
+  CombiningInCache(std::set<PregelShard> localShards,
                    MessageFormat<M> const* format,
                    MessageCombiner<M> const* combiner);
 
   MessageCombiner<M> const* combiner() const { return _combiner; }
 
-  void mergeCache(std::shared_ptr<WorkerConfig const> config,
-                  InCache<M> const* otherCache) override;
+  void mergeCache(InCache<M> const* otherCache) override;
   MessageIterator<M> getMessages(PregelShard shard,
                                  std::string_view const& key) override;
   void clear() override;

--- a/arangod/Pregel/Worker/Handler.h
+++ b/arangod/Pregel/Worker/Handler.h
@@ -190,7 +190,7 @@ struct WorkerHandler : actor::HandlerBase<Runtime, WorkerState<V, E, M>> {
 
     outCache->flushMessages();
 
-    this->state->writeCache->mergeCache(this->state->config, inCache);
+    this->state->writeCache->mergeCache(inCache);
     // _feature.metrics()->pregelMessagesSent->count(outCache->sendCount());
 
     MessageStats stats;

--- a/arangod/Pregel/Worker/State.h
+++ b/arangod/Pregel/Worker/State.h
@@ -60,19 +60,22 @@ struct WorkerState {
 
     if (messageCombiner) {
       readCache = std::make_unique<CombiningInCache<M>>(
-          config, messageFormat.get(), messageCombiner.get());
+          config->localPregelShardIDs(), messageFormat.get(),
+          messageCombiner.get());
       writeCache = std::make_unique<CombiningInCache<M>>(
-          config, messageFormat.get(), messageCombiner.get());
+          config->localPregelShardIDs(), messageFormat.get(),
+          messageCombiner.get());
       inCache = std::make_unique<CombiningInCache<M>>(
-          nullptr, messageFormat.get(), messageCombiner.get());
+          std::set<PregelShard>{}, messageFormat.get(), messageCombiner.get());
       outCache = std::make_unique<CombiningOutActorCache<M>>(
           config, messageFormat.get(), messageCombiner.get());
     } else {
-      readCache =
-          std::make_unique<ArrayInCache<M>>(config, messageFormat.get());
-      writeCache =
-          std::make_unique<ArrayInCache<M>>(config, messageFormat.get());
-      inCache = std::make_unique<ArrayInCache<M>>(nullptr, messageFormat.get());
+      readCache = std::make_unique<ArrayInCache<M>>(
+          config->localPregelShardIDs(), messageFormat.get());
+      writeCache = std::make_unique<ArrayInCache<M>>(
+          config->localPregelShardIDs(), messageFormat.get());
+      inCache = std::make_unique<ArrayInCache<M>>(std::set<PregelShard>{},
+                                                  messageFormat.get());
       outCache =
           std::make_unique<ArrayOutActorCache<M>>(config, messageFormat.get());
     }

--- a/arangod/Pregel/Worker/Worker.cpp
+++ b/arangod/Pregel/Worker/Worker.cpp
@@ -133,24 +133,29 @@ template<typename V, typename E, typename M>
 void Worker<V, E, M>::_initializeMessageCaches() {
   const size_t p = _config->parallelism();
   if (_messageCombiner) {
-    _readCache = new CombiningInCache<M>(_config, _messageFormat.get(),
-                                         _messageCombiner.get());
-    _writeCache = new CombiningInCache<M>(_config, _messageFormat.get(),
-                                          _messageCombiner.get());
+    _readCache =
+        new CombiningInCache<M>(_config->localPregelShardIDs(),
+                                _messageFormat.get(), _messageCombiner.get());
+    _writeCache =
+        new CombiningInCache<M>(_config->localPregelShardIDs(),
+                                _messageFormat.get(), _messageCombiner.get());
     for (size_t i = 0; i < p; i++) {
       auto incoming = std::make_unique<CombiningInCache<M>>(
-          nullptr, _messageFormat.get(), _messageCombiner.get());
+          std::set<PregelShard>{}, _messageFormat.get(),
+          _messageCombiner.get());
       _inCaches.push_back(incoming.get());
       _outCaches.push_back(new CombiningOutCache<M>(
           _config, _messageFormat.get(), _messageCombiner.get()));
       incoming.release();
     }
   } else {
-    _readCache = new ArrayInCache<M>(_config, _messageFormat.get());
-    _writeCache = new ArrayInCache<M>(_config, _messageFormat.get());
+    _readCache = new ArrayInCache<M>(_config->localPregelShardIDs(),
+                                     _messageFormat.get());
+    _writeCache = new ArrayInCache<M>(_config->localPregelShardIDs(),
+                                      _messageFormat.get());
     for (size_t i = 0; i < p; i++) {
-      auto incoming =
-          std::make_unique<ArrayInCache<M>>(nullptr, _messageFormat.get());
+      auto incoming = std::make_unique<ArrayInCache<M>>(std::set<PregelShard>{},
+                                                        _messageFormat.get());
       _inCaches.push_back(incoming.get());
       _outCaches.push_back(new ArrayOutCache<M>(_config, _messageFormat.get()));
       incoming.release();
@@ -411,7 +416,7 @@ bool Worker<V, E, M>::_processVertices() {
   }
 
   // merge thread local messages, _writeCache does locking
-  _writeCache->mergeCache(_config, inCache);
+  _writeCache->mergeCache(inCache);
   _feature.metrics()->pregelMessagesSent->count(outCache->sendCount());
 
   MessageStats stats;


### PR DESCRIPTION
### Scope & Purpose

Makes the InCache independent of worker config as it only used the set of pregel shards as a local shard index.
 