### PR TITLE
Make OutCache more independent of worker config

### DIFF
--- a/arangod/Pregel/OutgoingCache.cpp
+++ b/arangod/Pregel/OutgoingCache.cpp
@@ -52,15 +52,14 @@ using namespace arangodb::pregel::algos;
 
 template<typename M>
 OutCache<M>::OutCache(std::shared_ptr<WorkerConfig const> state,
+                      std::set<PregelShard> localShards,
                       MessageFormat<M> const* format)
-    : _config(state),
+    : _config(std::move(state)),
+      _localShards(std::move(localShards)),
       _format(format),
       _baseUrl(Utils::baseUrl(Utils::workerPrefix)) {}
 
 // ================= ArrayOutCache ==================
-
-template<typename M>
-ArrayOutCache<M>::~ArrayOutCache() = default;
 
 template<typename M>
 void ArrayOutCache<M>::_removeContainedMessages() {
@@ -74,7 +73,7 @@ template<typename M>
 void ArrayOutCache<M>::appendMessage(PregelShard shard,
                                      std::string_view const& key,
                                      M const& data) {
-  if (this->_config->isLocalVertexShard(shard)) {
+  if (this->isLocalShard(shard)) {
     this->_localCache->storeMessageNoLock(shard, key, data);
     this->_sendCount++;
   } else {
@@ -156,16 +155,6 @@ void ArrayOutCache<M>::flushMessages() {
 }
 
 // ================= CombiningOutCache ==================
-
-template<typename M>
-CombiningOutCache<M>::CombiningOutCache(
-    std::shared_ptr<WorkerConfig const> state, MessageFormat<M> const* format,
-    MessageCombiner<M> const* combiner)
-    : OutCache<M>(state, format), _combiner(combiner) {}
-
-template<typename M>
-CombiningOutCache<M>::~CombiningOutCache() = default;
-
 template<typename M>
 void CombiningOutCache<M>::_removeContainedMessages() {
   for (auto& pair : _shardMap) {
@@ -178,7 +167,7 @@ template<typename M>
 void CombiningOutCache<M>::appendMessage(PregelShard shard,
                                          std::string_view const& key,
                                          M const& data) {
-  if (this->_config->isLocalVertexShard(shard)) {
+  if (this->isLocalShard(shard)) {
     this->_localCache->storeMessageNoLock(shard, key, data);
     this->_sendCount++;
   } else {
@@ -277,7 +266,7 @@ void ArrayOutActorCache<M>::appendMessage(PregelShard shard,
                                           M const& data) {
   _sendCountPerActor[_responsibleActorPerShard
                          [this->_config->globalShardIDs()[shard.value]]]++;
-  if (this->_config->isLocalVertexShard(shard)) {
+  if (this->isLocalShard(shard)) {
     this->_localCache->storeMessageNoLock(shard, key, data);
     this->_sendCount++;
   } else {
@@ -354,7 +343,7 @@ template<typename M>
 void CombiningOutActorCache<M>::appendMessage(PregelShard shard,
                                               std::string_view const& key,
                                               M const& data) {
-  if (this->_config->isLocalVertexShard(shard)) {
+  if (this->isLocalShard(shard)) {
     _sendCountPerActor[_responsibleActorPerShard
                            [this->_config->globalShardIDs()[shard.value]]]++;
     this->_localCache->storeMessageNoLock(shard, key, data);

--- a/arangod/Pregel/OutgoingCache.cpp
+++ b/arangod/Pregel/OutgoingCache.cpp
@@ -264,8 +264,8 @@ template<typename M>
 void ArrayOutActorCache<M>::appendMessage(PregelShard shard,
                                           std::string_view const& key,
                                           M const& data) {
-  _sendCountPerActor[_responsibleActorPerShard
-                         [this->_config->globalShardIDs()[shard.value]]]++;
+  _sendCountPerActor[_responsibleActorPerShard[this->_config->globalShardID(
+      shard)]]++;
   if (this->isLocalShard(shard)) {
     this->_localCache->storeMessageNoLock(shard, key, data);
     this->_sendCount++;
@@ -317,8 +317,7 @@ void ArrayOutActorCache<M>::flushMessages() {
         .gss = gss,
         .shard = shard,
         .messages = messages};
-    auto actor =
-        _responsibleActorPerShard[this->_config->globalShardIDs()[shard.value]];
+    auto actor = _responsibleActorPerShard[this->_config->globalShardID(shard)];
     _dispatch(actor, pregelMessage);
 
     this->_sendCount += shardMessageCount;
@@ -344,8 +343,8 @@ void CombiningOutActorCache<M>::appendMessage(PregelShard shard,
                                               std::string_view const& key,
                                               M const& data) {
   if (this->isLocalShard(shard)) {
-    _sendCountPerActor[_responsibleActorPerShard
-                           [this->_config->globalShardIDs()[shard.value]]]++;
+    _sendCountPerActor[_responsibleActorPerShard[this->_config->globalShardID(
+        shard)]]++;
     this->_localCache->storeMessageNoLock(shard, key, data);
     this->_sendCount++;
   } else {
@@ -355,8 +354,8 @@ void CombiningOutActorCache<M>::appendMessage(PregelShard shard,
       auto& ref = (*it).second;   // will be modified by combine(...)
       _combiner->combine(ref, data);
     } else {  // first message for this vertex
-      _sendCountPerActor[_responsibleActorPerShard
-                             [this->_config->globalShardIDs()[shard.value]]]++;
+      _sendCountPerActor[_responsibleActorPerShard[this->_config->globalShardID(
+          shard)]]++;
       vertexMap.try_emplace(key, data);
 
       if (++(this->_containedMessages) >= this->_batchSize) {
@@ -400,8 +399,7 @@ void CombiningOutActorCache<M>::flushMessages() {
         .gss = gss,
         .shard = shard,
         .messages = messagesToVPack(vertexMessageMap)};
-    auto actor =
-        _responsibleActorPerShard[this->_config->globalShardIDs()[shard.value]];
+    auto actor = _responsibleActorPerShard[this->_config->globalShardID(shard)];
     _dispatch(actor, pregelMessage);
 
     this->_sendCount += vertexMessageMap.size();

--- a/arangod/Pregel/Worker/State.h
+++ b/arangod/Pregel/Worker/State.h
@@ -72,7 +72,8 @@ struct WorkerState {
       inCache = std::make_unique<CombiningInCache<M>>(
           std::set<PregelShard>{}, messageFormat.get(), messageCombiner.get());
       outCache = std::make_unique<CombiningOutActorCache<M>>(
-          config, messageFormat.get(), messageCombiner.get());
+          config, config->localPregelShardIDs(), messageFormat.get(),
+          messageCombiner.get());
     } else {
       readCache = std::make_unique<ArrayInCache<M>>(
           config->localPregelShardIDs(), messageFormat.get());
@@ -80,8 +81,8 @@ struct WorkerState {
           config->localPregelShardIDs(), messageFormat.get());
       inCache = std::make_unique<ArrayInCache<M>>(std::set<PregelShard>{},
                                                   messageFormat.get());
-      outCache =
-          std::make_unique<ArrayOutActorCache<M>>(config, messageFormat.get());
+      outCache = std::make_unique<ArrayOutActorCache<M>>(
+          config, config->localPregelShardIDs(), messageFormat.get());
     }
   }
 

--- a/arangod/Pregel/Worker/VertexProcessor.cpp
+++ b/arangod/Pregel/Worker/VertexProcessor.cpp
@@ -49,12 +49,13 @@ VertexProcessor<V, E, M>::VertexProcessor(
     localMessageCache = std::make_shared<CombiningInCache<M>>(
         std::set<PregelShard>{}, messageFormat.get(), messageCombiner.get());
     outCache = std::make_shared<CombiningOutCache<M>>(
-        workerConfig, messageFormat.get(), messageCombiner.get());
+        workerConfig, workerConfig->localPregelShardIDs(), messageFormat.get(),
+        messageCombiner.get());
   } else {
     localMessageCache = std::make_shared<ArrayInCache<M>>(
         std::set<PregelShard>{}, messageFormat.get());
-    outCache =
-        std::make_shared<ArrayOutCache<M>>(workerConfig, messageFormat.get());
+    outCache = std::make_shared<ArrayOutCache<M>>(
+        workerConfig, workerConfig->localPregelShardIDs(), messageFormat.get());
   }
 
   outCache->setBatchSize(messageBatchSize);


### PR DESCRIPTION
### Scope & Purpose

Make out caches more independent of worker config. 

The worker config is still needed because caches also take care of sending batches of messages across the network. This should be removed in a later step.