### PR TITLE
Fix potential race when cloning repository in CircleCI

### DIFF
--- a/.circleci/base_config.yml
+++ b/.circleci/base_config.yml
@@ -16,8 +16,10 @@ jobs:
       - run:
           name: Checkout
           command: |
-            git clone --depth 1 https://github.com/arangodb/arangodb.git --branch "$CIRCLE_BRANCH" --shallow-submodules -j 8 .
-            git reset --hard "$CIRCLE_SHA1"
+            git init
+            git remote add origin https://github.com/arangodb/arangodb.git
+            git fetch --depth 1 origin $CIRCLE_SHA1
+            git checkout $CIRCLE_SHA1
       - persist_to_workspace:
           root: .
           paths:
@@ -105,8 +107,14 @@ jobs:
       - run:
           name: Checkout ArangoDB
           command: |
-            git clone --depth 1 https://github.com/arangodb/arangodb.git --branch "$CIRCLE_BRANCH" --recurse-submodules --shallow-submodules -j 8 /root/project
-            git reset --hard "$CIRCLE_SHA1"
+            mkdir /root/project && cd /root/project
+            git init
+            git remote add origin https://github.com/arangodb/arangodb.git
+            git fetch --depth 1 origin $CIRCLE_SHA1
+            git checkout $CIRCLE_SHA1
+            git submodule init
+            git submodule update --recursive --depth 1 --jobs 8
+
       - run:
           name: Checkout Enterprise
           command: |


### PR DESCRIPTION
### Scope & Purpose

The build itself is started for a specific commit, but creating a shallow clone requires a branch name. It can happen that during the time the build is started, but before the clone command is executed, another commit is pushed to the branch. As a result, the branch will point to the new commit. Previously we tried to work around such a situation by resetting to the specified commit, but since we are creating a shallow clone this does not work because that commit is not known.

This PR tries a different approach to fetch only the specific commit.

- [x] :hankey: Bugfix