### PR TITLE
[CINFRA-730] Fix lock inversions in the follower

### DIFF
--- a/arangod/Replication2/CMakeLists.txt
+++ b/arangod/Replication2/CMakeLists.txt
@@ -31,6 +31,8 @@ add_library(arango_replication2_pure STATIC
   ReplicatedLog/Algorithms.cpp
   ReplicatedLog/ILogInterfaces.cpp
   ReplicatedLog/TermIndexMapping.cpp
+  ReplicatedLog/Components/MethodsProvider.cpp ReplicatedLog/Components/MethodsProvider.h
+  ReplicatedLog/Components/IMethodsProvider.cpp ReplicatedLog/Components/IMethodsProvider.h
   IScheduler.h)
 
 target_link_libraries(arango_replication2_pure PUBLIC arango_lightweight

--- a/arangod/Replication2/CMakeLists.txt
+++ b/arangod/Replication2/CMakeLists.txt
@@ -25,14 +25,6 @@ target_include_directories(arango_replication2 PRIVATE
 
 add_library(arango_replication2_pure STATIC
   MetricsHelper.cpp
-  ReplicatedState/StateStatus.h
-  ReplicatedState/StateCommon.cpp
-  ReplicatedLog/NetworkMessages.cpp
-  ReplicatedLog/Algorithms.cpp
-  ReplicatedLog/ILogInterfaces.cpp
-  ReplicatedLog/TermIndexMapping.cpp
-  ReplicatedLog/Components/MethodsProvider.cpp ReplicatedLog/Components/MethodsProvider.h
-  ReplicatedLog/Components/IMethodsProvider.cpp ReplicatedLog/Components/IMethodsProvider.h
   IScheduler.h)
 
 target_link_libraries(arango_replication2_pure PUBLIC arango_lightweight

--- a/arangod/Replication2/ReplicatedLog/CMakeLists.txt
+++ b/arangod/Replication2/ReplicatedLog/CMakeLists.txt
@@ -21,20 +21,28 @@ target_sources(arango_replication2_pure PRIVATE
   Supervision.cpp
   SupervisionAction.cpp
 
-  ReplicatedLogMetrics.tpp
   AgencyLogSpecification.cpp
-  Components/LogFollower.cpp
-  Components/LogFollower.h
-  Components/StorageManager.cpp
-  Components/StorageManager.h
-  Components/CompactionManager.cpp
-  Components/CompactionManager.h
-  Components/SnapshotManager.cpp
-  Components/SnapshotManager.h
-  Components/AppendEntriesManager.cpp
-  Components/AppendEntriesManager.h
+  Algorithms.cpp
+  ILogInterfaces.cpp
+  NetworkMessages.cpp
+  ReplicatedLogMetrics.tpp
+  TermIndexMapping.cpp
+  Components/AppendEntriesManager.cpp Components/AppendEntriesManager.h
+  Components/CompactionManager.cpp Components/CompactionManager.h
   Components/ExclusiveBool.h
-  Components/FollowerCommitManager.cpp
-  Components/FollowerCommitManager.h
-  Components/StateHandleManager.cpp
-  Components/StateHandleManager.h)
+  Components/FollowerCommitManager.cpp Components/FollowerCommitManager.h
+  Components/IAppendEntriesManager.h
+  Components/ICompactionManager.h
+  Components/IFollowerCommitManager.h
+  Components/IMessageIdManager.h
+  Components/IMethodsProvider.h
+  Components/ISnapshotManager.h
+  Components/IStateHandleManager.h
+  Components/IStorageManager.h
+  Components/LogFollower.cpp Components/LogFollower.h
+  Components/MessageIdManager.cpp Components/MessageIdManager.h
+  Components/MethodsProvider.cpp Components/MethodsProvider.h
+  Components/SnapshotManager.cpp Components/SnapshotManager.h
+  Components/StateHandleManager.cpp Components/StateHandleManager.h
+  Components/StorageManager.cpp Components/StorageManager.h
+  )

--- a/arangod/Replication2/ReplicatedLog/Components/AppendEntriesManager.h
+++ b/arangod/Replication2/ReplicatedLog/Components/AppendEntriesManager.h
@@ -25,6 +25,7 @@
 #include "Basics/Guarded.h"
 #include "Replication2/ReplicatedLog/Components/ExclusiveBool.h"
 #include "Replication2/ReplicatedLog/Components/IAppendEntriesManager.h"
+#include "Replication2/ReplicatedLog/Components/IMessageIdManager.h"
 #include "Replication2/ReplicatedLog/Components/TermInformation.h"
 #include "IFollowerCommitManager.h"
 #include "Replication2/LoggerContext.h"
@@ -37,14 +38,7 @@ struct IStorageManager;
 struct ISnapshotManager;
 struct ICompactionManager;
 struct IStateHandleManager;
-
-struct AppendEntriesMessageIdAcceptor {
-  auto accept(MessageId) noexcept -> bool;
-  auto get() const noexcept -> MessageId { return lastId; }
-
- private:
-  MessageId lastId{0};
-};
+struct IMessageIdManager;
 
 struct AppendEntriesManager
     : IAppendEntriesManager,
@@ -53,20 +47,20 @@ struct AppendEntriesManager
                        IStorageManager& storage, ISnapshotManager& snapshot,
                        ICompactionManager& compaction,
                        IStateHandleManager& stateHandle,
+                       IMessageIdManager& messageIdManager,
                        std::shared_ptr<ReplicatedLogMetrics> metrics,
                        LoggerContext const& loggerContext);
 
   auto appendEntries(AppendEntriesRequest request)
       -> futures::Future<AppendEntriesResult> override;
 
-  auto getLastReceivedMessageId() const noexcept -> MessageId;
-
   auto resign() && noexcept -> void override;
 
   struct GuardedData {
     GuardedData(IStorageManager& storage, ISnapshotManager& snapshot,
                 ICompactionManager& compaction,
-                IStateHandleManager& stateHandle);
+                IStateHandleManager& stateHandle,
+                IMessageIdManager& messageIdManager);
     auto preflightChecks(AppendEntriesRequest const& request,
                          FollowerTermInformation const&,
                          LoggerContext const& lctx)
@@ -75,12 +69,12 @@ struct AppendEntriesManager
 
     bool resigned = false;
     ExclusiveBool requestInFlight;
-    AppendEntriesMessageIdAcceptor messageIdAcceptor;
 
     IStorageManager& storage;
     ISnapshotManager& snapshot;
     ICompactionManager& compaction;
     IStateHandleManager& stateHandle;
+    IMessageIdManager& messageIdManager;
   };
 
   LoggerContext const loggerContext;

--- a/arangod/Replication2/ReplicatedLog/Components/AppendEntriesManager.h
+++ b/arangod/Replication2/ReplicatedLog/Components/AppendEntriesManager.h
@@ -36,6 +36,7 @@ inline namespace comp {
 struct IStorageManager;
 struct ISnapshotManager;
 struct ICompactionManager;
+struct IStateHandleManager;
 
 struct AppendEntriesMessageIdAcceptor {
   auto accept(MessageId) noexcept -> bool;
@@ -51,7 +52,7 @@ struct AppendEntriesManager
   AppendEntriesManager(std::shared_ptr<FollowerTermInformation const> termInfo,
                        IStorageManager& storage, ISnapshotManager& snapshot,
                        ICompactionManager& compaction,
-                       IFollowerCommitManager& commit,
+                       IStateHandleManager& stateHandle,
                        std::shared_ptr<ReplicatedLogMetrics> metrics,
                        LoggerContext const& loggerContext);
 
@@ -64,7 +65,8 @@ struct AppendEntriesManager
 
   struct GuardedData {
     GuardedData(IStorageManager& storage, ISnapshotManager& snapshot,
-                ICompactionManager& compaction, IFollowerCommitManager& commit);
+                ICompactionManager& compaction,
+                IStateHandleManager& stateHandle);
     auto preflightChecks(AppendEntriesRequest const& request,
                          FollowerTermInformation const&,
                          LoggerContext const& lctx)
@@ -78,7 +80,7 @@ struct AppendEntriesManager
     IStorageManager& storage;
     ISnapshotManager& snapshot;
     ICompactionManager& compaction;
-    IFollowerCommitManager& commit;
+    IStateHandleManager& stateHandle;
   };
 
   LoggerContext const loggerContext;

--- a/arangod/Replication2/ReplicatedLog/Components/FollowerCommitManager.h
+++ b/arangod/Replication2/ReplicatedLog/Components/FollowerCommitManager.h
@@ -40,13 +40,13 @@ struct FollowerCommitManager
       std::enable_shared_from_this<FollowerCommitManager> {
   FollowerCommitManager(IStorageManager&, LoggerContext const& loggerContext,
                         std::shared_ptr<IScheduler> scheduler);
-  auto updateCommitIndex(LogIndex index) noexcept
+  [[nodiscard]] auto updateCommitIndex(LogIndex index) noexcept
       -> std::pair<std::optional<LogIndex>, DeferredAction> override;
-  auto getCommitIndex() const noexcept -> LogIndex override;
+  [[nodiscard]] auto getCommitIndex() const noexcept -> LogIndex override;
 
-  auto waitFor(LogIndex index) noexcept
+  [[nodiscard]] auto waitFor(LogIndex index) noexcept
       -> ILogParticipant::WaitForFuture override;
-  auto waitForIterator(LogIndex index) noexcept
+  [[nodiscard]] auto waitForIterator(LogIndex index) noexcept
       -> ILogParticipant::WaitForIteratorFuture override;
 
   void resign() noexcept;

--- a/arangod/Replication2/ReplicatedLog/Components/FollowerCommitManager.h
+++ b/arangod/Replication2/ReplicatedLog/Components/FollowerCommitManager.h
@@ -38,10 +38,10 @@ struct IStorageManager;
 struct FollowerCommitManager
     : IFollowerCommitManager,
       std::enable_shared_from_this<FollowerCommitManager> {
-  FollowerCommitManager(IStorageManager&, IStateHandleManager&,
-                        LoggerContext const& loggerContext,
+  FollowerCommitManager(IStorageManager&, LoggerContext const& loggerContext,
                         std::shared_ptr<IScheduler> scheduler);
-  auto updateCommitIndex(LogIndex index) noexcept -> DeferredAction override;
+  auto updateCommitIndex(LogIndex index) noexcept
+      -> std::pair<std::optional<LogIndex>, DeferredAction> override;
   auto getCommitIndex() const noexcept -> LogIndex override;
 
   auto waitFor(LogIndex index) noexcept
@@ -57,14 +57,13 @@ struct FollowerCommitManager
   using WaitForQueue = std::multimap<LogIndex, ResolvePromise>;
 
   struct GuardedData {
-    explicit GuardedData(IStorageManager&, IStateHandleManager&);
+    explicit GuardedData(IStorageManager&);
     LogIndex commitIndex{0};
     LogIndex resolveIndex{0};
     WaitForQueue waitQueue;
     bool isResigned{false};
 
     IStorageManager& storage;
-    IStateHandleManager& stateHandle;
   };
 
   Guarded<GuardedData> guardedData;

--- a/arangod/Replication2/ReplicatedLog/Components/IFollowerCommitManager.h
+++ b/arangod/Replication2/ReplicatedLog/Components/IFollowerCommitManager.h
@@ -33,12 +33,12 @@ inline namespace comp {
 
 struct IFollowerCommitManager {
   virtual ~IFollowerCommitManager() = default;
-  virtual auto updateCommitIndex(LogIndex) noexcept
+  [[nodiscard]] virtual auto updateCommitIndex(LogIndex) noexcept
       -> std::pair<std::optional<LogIndex>, DeferredAction> = 0;
-  virtual auto getCommitIndex() const noexcept -> LogIndex = 0;
-  virtual auto waitFor(LogIndex index) noexcept
+  [[nodiscard]] virtual auto getCommitIndex() const noexcept -> LogIndex = 0;
+  [[nodiscard]] virtual auto waitFor(LogIndex index) noexcept
       -> ILogParticipant::WaitForFuture = 0;
-  virtual auto waitForIterator(LogIndex index) noexcept
+  [[nodiscard]] virtual auto waitForIterator(LogIndex index) noexcept
       -> ILogParticipant::WaitForIteratorFuture = 0;
 };
 }  // namespace comp

--- a/arangod/Replication2/ReplicatedLog/Components/IMessageIdManager.h
+++ b/arangod/Replication2/ReplicatedLog/Components/IMessageIdManager.h
@@ -22,37 +22,24 @@
 
 #pragma once
 
-#include "Replication2/ReplicatedLog/Components/IMethodsProvider.h"
-
 namespace arangodb {
 namespace replication2 {
 namespace replicated_log {
 
+struct MessageId;
+
 inline namespace comp {
-struct IFollowerCommitManager;
-struct IStorageManager;
-struct ICompactionManager;
-struct ISnapshotManager;
-struct IMessageIdManager;
+struct IMessageIdManager {
+  virtual ~IMessageIdManager() = default;
 
-struct MethodsProviderManager : IMethodsProvider {
-  MethodsProviderManager(std::shared_ptr<IFollowerCommitManager> commit,
-                         std::shared_ptr<IStorageManager> storage,
-                         std::shared_ptr<ICompactionManager> compaction,
-                         std::shared_ptr<ISnapshotManager> snapshot,
-                         std::shared_ptr<IMessageIdManager> messageIdManager);
-
-  virtual auto getMethods()
-      -> std::unique_ptr<IReplicatedLogFollowerMethods> override;
-
-  std::shared_ptr<IFollowerCommitManager> const commit;
-  std::shared_ptr<IStorageManager> const storage;
-  std::shared_ptr<ICompactionManager> const compaction;
-  std::shared_ptr<ISnapshotManager> const snapshot;
-  std::shared_ptr<IMessageIdManager> const messageIdManager;
+  [[nodiscard]] virtual auto acceptReceivedMessageId(MessageId) noexcept
+      -> bool = 0;
+  [[nodiscard]] virtual auto getLastReceivedMessageId() const noexcept
+      -> MessageId = 0;
 };
 
 }  // namespace comp
+
 }  // namespace replicated_log
 }  // namespace replication2
 }  // namespace arangodb

--- a/arangod/Replication2/ReplicatedLog/Components/IMethodsProvider.cpp
+++ b/arangod/Replication2/ReplicatedLog/Components/IMethodsProvider.cpp
@@ -1,8 +1,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 /// DISCLAIMER
 ///
-/// Copyright 2014-2022 ArangoDB GmbH, Cologne, Germany
-/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+/// Copyright 2023-2023 ArangoDB GmbH, Cologne, Germany
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");
 /// you may not use this file except in compliance with the License.
@@ -18,30 +17,13 @@
 ///
 /// Copyright holder is ArangoDB GmbH, Cologne, Germany
 ///
-/// @author Lars Maier
+/// @author Tobias Gödderz
 ////////////////////////////////////////////////////////////////////////////////
-#pragma once
-#include "Replication2/ReplicatedLog/ILogInterfaces.h"
+
+#include "IMethodsProvider.h"
 
 namespace arangodb {
-struct DeferredAction;
 namespace replication2 {
-struct LogIndex;
-namespace replicated_log {
-
-inline namespace comp {
-
-struct IFollowerCommitManager {
-  virtual ~IFollowerCommitManager() = default;
-  virtual auto updateCommitIndex(LogIndex) noexcept
-      -> std::pair<std::optional<LogIndex>, DeferredAction> = 0;
-  virtual auto getCommitIndex() const noexcept -> LogIndex = 0;
-  virtual auto waitFor(LogIndex index) noexcept
-      -> ILogParticipant::WaitForFuture = 0;
-  virtual auto waitForIterator(LogIndex index) noexcept
-      -> ILogParticipant::WaitForIteratorFuture = 0;
-};
-}  // namespace comp
-}  // namespace replicated_log
+namespace replicated_log {}  // namespace replicated_log
 }  // namespace replication2
 }  // namespace arangodb

--- a/arangod/Replication2/ReplicatedLog/Components/IMethodsProvider.h
+++ b/arangod/Replication2/ReplicatedLog/Components/IMethodsProvider.h
@@ -1,8 +1,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 /// DISCLAIMER
 ///
-/// Copyright 2014-2022 ArangoDB GmbH, Cologne, Germany
-/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+/// Copyright 2023-2023 ArangoDB GmbH, Cologne, Germany
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");
 /// you may not use this file except in compliance with the License.
@@ -18,30 +17,25 @@
 ///
 /// Copyright holder is ArangoDB GmbH, Cologne, Germany
 ///
-/// @author Lars Maier
+/// @author Tobias Gödderz
 ////////////////////////////////////////////////////////////////////////////////
+
 #pragma once
-#include "Replication2/ReplicatedLog/ILogInterfaces.h"
+
+#include <memory>
 
 namespace arangodb {
-struct DeferredAction;
 namespace replication2 {
-struct LogIndex;
 namespace replicated_log {
 
-inline namespace comp {
+struct IReplicatedLogFollowerMethods;
 
-struct IFollowerCommitManager {
-  virtual ~IFollowerCommitManager() = default;
-  virtual auto updateCommitIndex(LogIndex) noexcept
-      -> std::pair<std::optional<LogIndex>, DeferredAction> = 0;
-  virtual auto getCommitIndex() const noexcept -> LogIndex = 0;
-  virtual auto waitFor(LogIndex index) noexcept
-      -> ILogParticipant::WaitForFuture = 0;
-  virtual auto waitForIterator(LogIndex index) noexcept
-      -> ILogParticipant::WaitForIteratorFuture = 0;
+struct IMethodsProvider {
+  virtual ~IMethodsProvider() = default;
+  virtual auto getMethods()
+      -> std::unique_ptr<IReplicatedLogFollowerMethods> = 0;
 };
-}  // namespace comp
+
 }  // namespace replicated_log
 }  // namespace replication2
 }  // namespace arangodb

--- a/arangod/Replication2/ReplicatedLog/Components/ISnapshotManager.h
+++ b/arangod/Replication2/ReplicatedLog/Components/ISnapshotManager.h
@@ -27,14 +27,19 @@ namespace arangodb {
 class Result;
 }
 namespace arangodb::replication2::replicated_log {
+struct MessageId;
 inline namespace comp {
 enum class SnapshotState { MISSING, AVAILABLE };
 auto to_string(SnapshotState) noexcept -> std::string_view;
 
 struct ISnapshotManager {
   virtual ~ISnapshotManager() = default;
-  virtual auto invalidateSnapshotState() -> Result = 0;
-  virtual auto checkSnapshotState() const noexcept -> SnapshotState = 0;
+  [[nodiscard]] virtual auto invalidateSnapshotState() -> Result = 0;
+  [[nodiscard]] virtual auto checkSnapshotState() const noexcept
+      -> SnapshotState = 0;
+  [[nodiscard]] virtual auto setSnapshotStateAvailable(MessageId msgId,
+                                                       std::uint64_t version)
+      -> Result = 0;
 };
 }  // namespace comp
 }  // namespace arangodb::replication2::replicated_log

--- a/arangod/Replication2/ReplicatedLog/Components/IStateHandleManager.h
+++ b/arangod/Replication2/ReplicatedLog/Components/IStateHandleManager.h
@@ -20,9 +20,15 @@
 ///
 /// @author Lars Maier
 ////////////////////////////////////////////////////////////////////////////////
+
 #pragma once
+
 #include <memory>
 #include <string>
+
+namespace arangodb {
+struct DeferredAction;
+}
 
 namespace arangodb::replication2 {
 struct LogIndex;
@@ -33,13 +39,14 @@ struct IReplicatedLogFollowerMethods;
 inline namespace comp {
 struct IStateHandleManager {
   virtual ~IStateHandleManager() = default;
-  virtual void updateCommitIndex(LogIndex) noexcept = 0;
+  virtual auto updateCommitIndex(LogIndex) noexcept -> DeferredAction = 0;
   virtual auto resign() noexcept -> std::unique_ptr<IReplicatedStateHandle> = 0;
   virtual void becomeFollower(
       std::unique_ptr<IReplicatedLogFollowerMethods>) = 0;
   virtual void acquireSnapshot(ParticipantId const& leader,
                                std::uint64_t version) noexcept = 0;
 };
+
 }  // namespace comp
 }  // namespace replicated_log
 }  // namespace arangodb::replication2

--- a/arangod/Replication2/ReplicatedLog/Components/LogFollower.cpp
+++ b/arangod/Replication2/ReplicatedLog/Components/LogFollower.cpp
@@ -33,54 +33,12 @@
 #include "Replication2/ReplicatedLog/Components/FollowerCommitManager.h"
 #include "Replication2/ReplicatedLog/Components/AppendEntriesManager.h"
 #include "Replication2/ReplicatedLog/Components/StateHandleManager.h"
+#include "Replication2/ReplicatedLog/Components/MethodsProvider.h"
 
 using namespace arangodb;
 using namespace arangodb::replication2;
 
 namespace arangodb::replication2::replicated_log {
-
-struct MethodsProvider : IReplicatedLogFollowerMethods {
-  explicit MethodsProvider(FollowerManager& fm) : follower(fm) {}
-  auto releaseIndex(LogIndex index) -> void override {
-    follower.compaction->updateReleaseIndex(index);
-  }
-
-  auto getCommittedLogIterator(std::optional<LogRange> range)
-      -> std::unique_ptr<LogRangeIterator> override {
-    return follower.storage->getCommittedLogIterator(range);
-  }
-
-  auto waitFor(LogIndex index) -> ILogParticipant::WaitForFuture override {
-    return follower.commit->waitFor(index);
-  }
-
-  auto waitForIterator(LogIndex index)
-      -> ILogParticipant::WaitForIteratorFuture override {
-    return follower.commit->waitForIterator(index);
-  }
-
-  auto snapshotCompleted(std::uint64_t version) -> Result override {
-    return follower.snapshot->setSnapshotStateAvailable(
-        follower.appendEntriesManager->getLastReceivedMessageId(), version);
-  }
-
-  [[nodiscard]] auto leaderConnectionEstablished() const -> bool override {
-    // Having a commit index means we've got at least one append entries request
-    // which was also applied *successfully*.
-    // Note that this is pessimistic, in the sense that it actually waits for an
-    // append entries request that was sent after leadership was established,
-    // which we don't necessarily need.
-    return follower.commit->getCommitIndex() > LogIndex{0};
-  }
-
-  auto checkSnapshotState() const noexcept
-      -> replicated_log::SnapshotState override {
-    return follower.snapshot->checkSnapshotState();
-  }
-
- private:
-  FollowerManager& follower;
-};
 
 namespace {
 
@@ -95,7 +53,7 @@ auto deriveLoggerContext(FollowerTermInformation const& info,
 }  // namespace
 
 FollowerManager::FollowerManager(
-    std::unique_ptr<replicated_state::IStorageEngineMethods> methods,
+    std::unique_ptr<replicated_state::IStorageEngineMethods> storageMethods,
     std::unique_ptr<IReplicatedStateHandle> stateHandlePtr,
     std::shared_ptr<FollowerTermInformation const> termInfo,
     std::shared_ptr<ReplicatedLogGlobalSettings const> options,
@@ -105,23 +63,24 @@ FollowerManager::FollowerManager(
     : loggerContext(deriveLoggerContext(*termInfo, logContext)),
       options(options),
       metrics(metrics),
-      storage(std::make_shared<StorageManager>(std::move(methods),
+      storage(std::make_shared<StorageManager>(std::move(storageMethods),
                                                loggerContext, scheduler)),
       compaction(std::make_shared<CompactionManager>(*storage, options,
                                                      loggerContext)),
-      stateHandle(
-          std::make_shared<StateHandleManager>(std::move(stateHandlePtr))),
+      commit(std::make_shared<FollowerCommitManager>(*storage, loggerContext,
+                                                     scheduler)),
+      stateHandle(std::make_shared<StateHandleManager>(
+          std::move(stateHandlePtr), *commit)),
       snapshot(std::make_shared<SnapshotManager>(
           *storage, *stateHandle, termInfo, leaderComm, loggerContext)),
-      commit(std::make_shared<FollowerCommitManager>(*storage, *stateHandle,
-                                                     loggerContext, scheduler)),
+      methods(std::make_shared<MethodsProvider>(commit, storage, compaction,
+                                                snapshot)),
       appendEntriesManager(std::make_shared<AppendEntriesManager>(
-          termInfo, *storage, *snapshot, *compaction, *commit, metrics,
+          termInfo, *storage, *snapshot, *compaction, *stateHandle, metrics,
           loggerContext)),
       termInfo(termInfo) {
   metrics->replicatedLogFollowerNumber->operator++();
-  auto provider = std::make_unique<MethodsProvider>(*this);
-  stateHandle->becomeFollower(std::move(provider));
+  stateHandle->becomeFollower(methods->getMethods());
   // Follower state manager is there, now get a snapshot if we need one.
   snapshot->acquireSnapshotIfNecessary();
 }

--- a/arangod/Replication2/ReplicatedLog/Components/LogFollower.h
+++ b/arangod/Replication2/ReplicatedLog/Components/LogFollower.h
@@ -51,7 +51,8 @@ struct StateHandleManager;
 struct SnapshotManager;
 struct FollowerCommitManager;
 struct AppendEntriesManager;
-struct MethodsProvider;
+struct MethodsProviderManager;
+struct MessageIdManager;
 }  // namespace comp
 }  // namespace arangodb::replication2::replicated_log
 
@@ -88,7 +89,8 @@ struct FollowerManager {
   std::shared_ptr<FollowerCommitManager> const commit;
   std::shared_ptr<StateHandleManager> const stateHandle;
   std::shared_ptr<SnapshotManager> const snapshot;
-  std::shared_ptr<MethodsProvider> const methods;
+  std::shared_ptr<MessageIdManager> const messageIdManager;
+  std::shared_ptr<MethodsProviderManager> const methodsProvider;
   std::shared_ptr<AppendEntriesManager> const appendEntriesManager;
   std::shared_ptr<FollowerTermInformation const> const termInfo;
 };

--- a/arangod/Replication2/ReplicatedLog/Components/LogFollower.h
+++ b/arangod/Replication2/ReplicatedLog/Components/LogFollower.h
@@ -51,12 +51,12 @@ struct StateHandleManager;
 struct SnapshotManager;
 struct FollowerCommitManager;
 struct AppendEntriesManager;
+struct MethodsProvider;
 }  // namespace comp
 }  // namespace arangodb::replication2::replicated_log
 
 namespace arangodb::replication2::replicated_log {
 
-struct MethodsProvider;
 struct FollowerManager {
   explicit FollowerManager(
       std::unique_ptr<replicated_state::IStorageEngineMethods> methods,
@@ -77,7 +77,6 @@ struct FollowerManager {
       -> futures::Future<AppendEntriesResult>;
 
  private:
-  friend struct MethodsProvider;
   friend struct LogFollowerImpl;
   LoggerContext const loggerContext;
   std::shared_ptr<ReplicatedLogGlobalSettings const> const options;
@@ -86,9 +85,10 @@ struct FollowerManager {
   // Make this into shared_ptrs allows types to remain incomplete in this header
   std::shared_ptr<StorageManager> const storage;
   std::shared_ptr<CompactionManager> const compaction;
+  std::shared_ptr<FollowerCommitManager> const commit;
   std::shared_ptr<StateHandleManager> const stateHandle;
   std::shared_ptr<SnapshotManager> const snapshot;
-  std::shared_ptr<FollowerCommitManager> const commit;
+  std::shared_ptr<MethodsProvider> const methods;
   std::shared_ptr<AppendEntriesManager> const appendEntriesManager;
   std::shared_ptr<FollowerTermInformation const> const termInfo;
 };

--- a/arangod/Replication2/ReplicatedLog/Components/MessageIdManager.cpp
+++ b/arangod/Replication2/ReplicatedLog/Components/MessageIdManager.cpp
@@ -1,0 +1,52 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2023-2023 ArangoDB GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Tobias Gödderz
+////////////////////////////////////////////////////////////////////////////////
+
+#include "MessageIdManager.h"
+
+namespace arangodb {
+namespace replication2 {
+namespace replicated_log {
+
+auto AppendEntriesMessageIdAcceptor::accept(MessageId id) noexcept -> bool {
+  bool const isNew = id > lastId;
+  if (isNew) {
+    lastId = id;
+  }
+
+  return isNew;
+}
+
+auto AppendEntriesMessageIdAcceptor::get() const noexcept -> MessageId {
+  return lastId;
+}
+
+auto MessageIdManager::getLastReceivedMessageId() const noexcept -> MessageId {
+  return messageIdAcceptor.getLockedGuard()->get();
+}
+
+bool MessageIdManager::acceptReceivedMessageId(MessageId id) noexcept {
+  return messageIdAcceptor.getLockedGuard()->accept(id);
+}
+
+}  // namespace replicated_log
+}  // namespace replication2
+}  // namespace arangodb

--- a/arangod/Replication2/ReplicatedLog/Components/MessageIdManager.h
+++ b/arangod/Replication2/ReplicatedLog/Components/MessageIdManager.h
@@ -20,10 +20,37 @@
 /// @author Tobias Gödderz
 ////////////////////////////////////////////////////////////////////////////////
 
-#include "IMethodsProvider.h"
+#pragma once
+
+#include "Basics/Guarded.h"
+#include "Replication2/ReplicatedLog/Components/IMessageIdManager.h"
+#include "Replication2/ReplicatedLog/NetworkMessages.h"
 
 namespace arangodb {
 namespace replication2 {
-namespace replicated_log {}  // namespace replicated_log
+namespace replicated_log {
+
+inline namespace comp {
+
+struct AppendEntriesMessageIdAcceptor {
+  auto accept(MessageId) noexcept -> bool;
+  auto get() const noexcept -> MessageId;
+
+ private:
+  MessageId lastId{0};
+};
+
+struct MessageIdManager : IMessageIdManager {
+  [[nodiscard]] auto acceptReceivedMessageId(MessageId id) noexcept
+      -> bool override;
+  [[nodiscard]] auto getLastReceivedMessageId() const noexcept
+      -> MessageId override;
+
+ private:
+  Guarded<AppendEntriesMessageIdAcceptor> messageIdAcceptor;
+};
+}  // namespace comp
+
+}  // namespace replicated_log
 }  // namespace replication2
 }  // namespace arangodb

--- a/arangod/Replication2/ReplicatedLog/Components/MethodsProvider.cpp
+++ b/arangod/Replication2/ReplicatedLog/Components/MethodsProvider.cpp
@@ -1,0 +1,107 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2023-2023 ArangoDB GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Tobias Gödderz
+////////////////////////////////////////////////////////////////////////////////
+
+#include "MethodsProvider.h"
+
+#include "Replication2/ReplicatedLog/Components/IFollowerCommitManager.h"
+#include "Replication2/ReplicatedLog/Components/IStorageManager.h"
+#include "Replication2/ReplicatedLog/Components/ISnapshotManager.h"
+#include "Replication2/ReplicatedLog/Components/ICompactionManager.h"
+#include "Replication2/ReplicatedLog/ReplicatedLog.h"
+
+namespace arangodb {
+namespace replication2 {
+namespace replicated_log {
+
+struct FollowerMethodsImpl : IReplicatedLogFollowerMethods {
+  FollowerMethodsImpl(std::shared_ptr<IFollowerCommitManager> commit,
+                      std::shared_ptr<IStorageManager> storage,
+                      std::shared_ptr<ICompactionManager> compaction,
+                      std::shared_ptr<ISnapshotManager> snapshot)
+      : commit(commit),
+        storage(storage),
+        compaction(compaction),
+        snapshot(snapshot) {}
+
+  auto releaseIndex(LogIndex index) -> void override {
+    compaction->updateReleaseIndex(index);
+  }
+
+  auto getCommittedLogIterator(std::optional<LogRange> range)
+      -> std::unique_ptr<LogRangeIterator> override {
+    return storage->getCommittedLogIterator(range);
+  }
+
+  auto waitFor(LogIndex index) -> ILogParticipant::WaitForFuture override {
+    return commit->waitFor(index);
+  }
+
+  auto waitForIterator(LogIndex index)
+      -> ILogParticipant::WaitForIteratorFuture override {
+    return commit->waitForIterator(index);
+  }
+
+  auto snapshotCompleted(std::uint64_t version) -> Result override {
+    return {};  // TODO implement me
+    // return snapshot->setSnapshotStateAvailable(
+    //     appendEntriesManager->getLastReceivedMessageId(), version);
+  }
+
+  [[nodiscard]] auto leaderConnectionEstablished() const -> bool override {
+    // Having a commit index means we've got at least one append entries request
+    // which was also applied *successfully*.
+    // Note that this is pessimistic, in the sense that it actually waits for an
+    // append entries request that was sent after leadership was established,
+    // which we don't necessarily need.
+    return commit->getCommitIndex() > LogIndex{0};
+  }
+
+  auto checkSnapshotState() const noexcept
+      -> replicated_log::SnapshotState override {
+    return snapshot->checkSnapshotState();
+  }
+
+ private:
+  std::shared_ptr<IFollowerCommitManager> const commit;
+  std::shared_ptr<IStorageManager> const storage;
+  std::shared_ptr<ICompactionManager> const compaction;
+  std::shared_ptr<ISnapshotManager> const snapshot;
+};
+
+MethodsProvider::MethodsProvider(std::shared_ptr<IFollowerCommitManager> commit,
+                                 std::shared_ptr<IStorageManager> storage,
+                                 std::shared_ptr<ICompactionManager> compaction,
+                                 std::shared_ptr<ISnapshotManager> snapshot)
+    : commit(commit),
+      storage(storage),
+      compaction(compaction),
+      snapshot(snapshot) {}
+
+auto MethodsProvider::getMethods()
+    -> std::unique_ptr<IReplicatedLogFollowerMethods> {
+  return std::make_unique<FollowerMethodsImpl>(commit, storage, compaction,
+                                               snapshot);
+}
+
+}  // namespace replicated_log
+}  // namespace replication2
+}  // namespace arangodb

--- a/arangod/Replication2/ReplicatedLog/Components/MethodsProvider.h
+++ b/arangod/Replication2/ReplicatedLog/Components/MethodsProvider.h
@@ -1,8 +1,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 /// DISCLAIMER
 ///
-/// Copyright 2014-2022 ArangoDB GmbH, Cologne, Germany
-/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+/// Copyright 2023-2023 ArangoDB GmbH, Cologne, Germany
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");
 /// you may not use this file except in compliance with the License.
@@ -18,29 +17,38 @@
 ///
 /// Copyright holder is ArangoDB GmbH, Cologne, Germany
 ///
-/// @author Lars Maier
+/// @author Tobias Gödderz
 ////////////////////////////////////////////////////////////////////////////////
+
 #pragma once
-#include "Replication2/ReplicatedLog/ILogInterfaces.h"
+
+#include "Replication2/ReplicatedLog/Components/IMethodsProvider.h"
 
 namespace arangodb {
-struct DeferredAction;
 namespace replication2 {
-struct LogIndex;
 namespace replicated_log {
 
 inline namespace comp {
+struct IFollowerCommitManager;
+struct IStorageManager;
+struct ICompactionManager;
+struct ISnapshotManager;
 
-struct IFollowerCommitManager {
-  virtual ~IFollowerCommitManager() = default;
-  virtual auto updateCommitIndex(LogIndex) noexcept
-      -> std::pair<std::optional<LogIndex>, DeferredAction> = 0;
-  virtual auto getCommitIndex() const noexcept -> LogIndex = 0;
-  virtual auto waitFor(LogIndex index) noexcept
-      -> ILogParticipant::WaitForFuture = 0;
-  virtual auto waitForIterator(LogIndex index) noexcept
-      -> ILogParticipant::WaitForIteratorFuture = 0;
+struct MethodsProvider : IMethodsProvider {
+  MethodsProvider(std::shared_ptr<IFollowerCommitManager> commit,
+                  std::shared_ptr<IStorageManager> storage,
+                  std::shared_ptr<ICompactionManager> compaction,
+                  std::shared_ptr<ISnapshotManager> snapshot);
+
+  virtual auto getMethods()
+      -> std::unique_ptr<IReplicatedLogFollowerMethods> override;
+
+  std::shared_ptr<IFollowerCommitManager> const commit;
+  std::shared_ptr<IStorageManager> const storage;
+  std::shared_ptr<ICompactionManager> const compaction;
+  std::shared_ptr<ISnapshotManager> const snapshot;
 };
+
 }  // namespace comp
 }  // namespace replicated_log
 }  // namespace replication2

--- a/arangod/Replication2/ReplicatedLog/Components/SnapshotManager.h
+++ b/arangod/Replication2/ReplicatedLog/Components/SnapshotManager.h
@@ -43,14 +43,16 @@ struct SnapshotManager : ISnapshotManager {
       std::shared_ptr<ILeaderCommunicator> leaderComm,
       LoggerContext const& loggerContext);
 
-  auto invalidateSnapshotState() -> Result override;
-  auto checkSnapshotState() const noexcept -> SnapshotState override;
+  [[nodiscard]] auto invalidateSnapshotState() -> Result override;
+  [[nodiscard]] auto checkSnapshotState() const noexcept
+      -> SnapshotState override;
 
   // should be called once after construction
   void acquireSnapshotIfNecessary();
 
-  auto setSnapshotStateAvailable(MessageId msgId, std::uint64_t version)
-      -> Result;
+  [[nodiscard]] auto setSnapshotStateAvailable(MessageId msgId,
+                                               std::uint64_t version)
+      -> Result override;
 
  private:
   struct GuardedData {

--- a/arangod/Replication2/ReplicatedState/CMakeLists.txt
+++ b/arangod/Replication2/ReplicatedState/CMakeLists.txt
@@ -5,3 +5,8 @@ target_sources(arango_replication2 PRIVATE
   ReplicatedStateToken.cpp
   StateCommon.cpp
   WaitForQueue.cpp)
+
+target_sources(arango_replication2_pure PRIVATE
+  StateStatus.h
+  StateCommon.cpp
+  )

--- a/arangod/Replication2/ReplicatedState/ReplicatedState.tpp
+++ b/arangod/Replication2/ReplicatedState/ReplicatedState.tpp
@@ -336,7 +336,8 @@ ProducerStreamProxy<S>::ProducerStreamProxy(
     : StreamProxy<S, streams::ProducerStream,
                   replicated_log::IReplicatedLogLeaderMethods>(
           std::move(methods)) {
-  ADB_PROD_ASSERT(this->_logMethods.getLockedGuard().get() != nullptr);
+  // this produces a lock inversion
+  // ADB_PROD_ASSERT(this->_logMethods.getLockedGuard().get() != nullptr);
 }
 
 template<typename S>

--- a/tests/Replication2/ReplicatedLog/Components/FollowerCommitManagerTest.cpp
+++ b/tests/Replication2/ReplicatedLog/Components/FollowerCommitManagerTest.cpp
@@ -54,7 +54,8 @@ struct StorageManagerMock : IStorageManager {
 };
 
 struct StateHandleManagerMock : IStateHandleManager {
-  MOCK_METHOD(void, updateCommitIndex, (LogIndex), (noexcept, override));
+  MOCK_METHOD(DeferredAction, updateCommitIndex, (LogIndex),
+              (noexcept, override));
   MOCK_METHOD(void, becomeFollower,
               (std::unique_ptr<IReplicatedLogFollowerMethods>),
               (noexcept, override));
@@ -91,7 +92,7 @@ struct FollowerCommitManagerTest : ::testing::Test {
 
   std::shared_ptr<FollowerCommitManager> commit =
       std::make_shared<FollowerCommitManager>(
-          storage, stateHandle, LoggerContext{Logger::REPLICATION2}, scheduler);
+          storage, LoggerContext{Logger::REPLICATION2}, scheduler);
 };
 
 TEST_F(FollowerCommitManagerTest, wait_for_update_commit_index) {

--- a/tests/Replication2/ReplicatedLog/Components/SnapshotManagerTest.cpp
+++ b/tests/Replication2/ReplicatedLog/Components/SnapshotManagerTest.cpp
@@ -79,7 +79,8 @@ struct StorageManagerMock : IStorageManager {
 };
 
 struct StateHandleManagerMock : IStateHandleManager {
-  MOCK_METHOD(void, updateCommitIndex, (LogIndex), (noexcept, override));
+  MOCK_METHOD(DeferredAction, updateCommitIndex, (LogIndex),
+              (noexcept, override));
   MOCK_METHOD(void, becomeFollower,
               (std::unique_ptr<IReplicatedLogFollowerMethods>),
               (noexcept, override));


### PR DESCRIPTION
### Scope & Purpose

Fix the following lock inversion, as detected by TSan in `StateManagerTest.get_follower_state_machine_early_with_snapshot_without_truncate`:

```mermaid
graph LR
    SHM_BF["StateHandleManager::becomeFollower"]
    RSM_BF["ReplicatedStateManager&lt;S>::becomeFollower"]
    RL_UC["ReplicatedLog::updateConfig"]
    FCM_GCI["FollowerCommitManager::getCommitIndex()"]
    FSM_GSM["FollowerStateManager&ltS>::getStateMachine()"]
    RSM_GF["ReplicatedStateManager&ltS>::getFollower()"]
    AEM_AE["AppendEntriesManager::appendEntries"]
    FCM_UCI["FollowerCommitManager::updateCommitIndex"]
    SHM_UCI["StateHandleManager::updateCommitIndex"]

    RL_UC -.-> SHM_BF -.-> RSM_BF
    RSM_GF -.-> FSM_GSM  -.-> FCM_GCI
    AEM_AE -.-> FCM_UCI -.-> SHM_UCI

    subgraph ReplicatedStateManager
        RSM_GF
        RSM_BF
    end
    subgraph ReplicatedLog
        RL_UC
    end
    subgraph FollowerCommitManager
        FCM_GCI
        FCM_UCI
    end
    subgraph StateHandleManager
        SHM_BF
        SHM_UCI
    end
    subgraph FollowerStateManager
        FSM_GSM
    end
    subgraph AppendEntriesManager
        AEM_AE
    end

    ReplicatedStateManager --> FollowerStateManager --> FollowerCommitManager --> StateHandleManager --> ReplicatedStateManager
```

- [X] :hankey: Bugfix
