### PR TITLE
[GORDO-1600] Multiple Quiver<V,E>s in a Worker

### DIFF
--- a/arangod/Pregel/GraphStore/CMakeLists.txt
+++ b/arangod/Pregel/GraphStore/CMakeLists.txt
@@ -2,4 +2,5 @@ target_sources(arango_pregel PRIVATE
   GraphLoader.cpp
   GraphStorer.cpp
   GraphVPackBuilderStorer.cpp
+  Magazine.cpp
   Quiver.cpp)

--- a/arangod/Pregel/GraphStore/GraphLoader.cpp
+++ b/arangod/Pregel/GraphStore/GraphLoader.cpp
@@ -84,8 +84,8 @@ auto GraphLoader<V, E>::requestVertexIds(uint64_t numVertices) -> void {
 }
 
 template<typename V, typename E>
-auto GraphLoader<V, E>::load() -> std::shared_ptr<Quiver<V, E>> {
-  auto result = std::shared_ptr<Quiver<V, E>>{};
+auto GraphLoader<V, E>::load() -> Magazine<V, E> {
+  auto result = Magazine<V, E>{};
   // Contains the shards located on this db server in the right order
   // assuming edges are sharded after _from, vertices after _key
   // then every ith vertex shard has the corresponding edges in
@@ -129,7 +129,7 @@ auto GraphLoader<V, E>::load() -> std::shared_ptr<Quiver<V, E>> {
       }
 
       try {
-        result = loadVertices(vertexShard, edges);
+        result.emplace(loadVertices(vertexShard, edges));
       } catch (basics::Exception const& ex) {
         LOG_PREGEL("8682a", WARN)
             << "caught exception while loading pregel graph: " << ex.what();
@@ -145,8 +145,8 @@ auto GraphLoader<V, E>::load() -> std::shared_ptr<Quiver<V, E>> {
 
   std::visit(overload{[&](ActorLoadingUpdate const& update) {
                         update.fn(message::GraphLoadingUpdate{
-                            .verticesLoaded = result->numberOfVertices(),
-                            .edgesLoaded = result->numberOfEdges(),
+                            .verticesLoaded = result.numberOfVertices(),
+                            .edgesLoaded = result.numberOfEdges(),
                             .memoryBytesUsed = 0  // TODO
                         });
                       },

--- a/arangod/Pregel/GraphStore/GraphLoader.h
+++ b/arangod/Pregel/GraphStore/GraphLoader.h
@@ -59,7 +59,7 @@ struct GraphLoader : GraphLoaderBase<V, E> {
         resourceMonitor(GlobalResourceMonitor::instance()),
         config(config),
         updateCallback(updateCallback) {}
-  auto load() -> std::shared_ptr<Quiver<V, E>> override;
+  auto load() -> Magazine<V, E> override;
 
   auto loadVertices(ShardID const& vertexShard,
                     std::vector<ShardID> const& edgeShards)

--- a/arangod/Pregel/GraphStore/GraphLoader.h
+++ b/arangod/Pregel/GraphStore/GraphLoader.h
@@ -55,23 +55,20 @@ struct GraphLoader : GraphLoaderBase<V, E> {
   explicit GraphLoader(std::shared_ptr<WorkerConfig const> config,
                        std::shared_ptr<GraphFormat<V, E> const> graphFormat,
                        LoadingUpdateCallback updateCallback)
-      : result(std::make_shared<Quiver<V, E>>()),
-        graphFormat(graphFormat),
+      : graphFormat(graphFormat),
         resourceMonitor(GlobalResourceMonitor::instance()),
         config(config),
         updateCallback(updateCallback) {}
-
   auto load() -> std::shared_ptr<Quiver<V, E>> override;
 
   auto loadVertices(ShardID const& vertexShard,
-                    std::vector<ShardID> const& edgeShards) -> void;
+                    std::vector<ShardID> const& edgeShards)
+      -> std::shared_ptr<Quiver<V, E>>;
   auto loadEdges(transaction::Methods& trx, Vertex<V, E>& vertex,
                  std::string_view documentID,
                  traverser::EdgeCollectionInfo& info) -> void;
 
   auto requestVertexIds(uint64_t numVertices) -> void;
-
-  std::shared_ptr<Quiver<V, E>> result;
 
   std::shared_ptr<GraphFormat<V, E> const> graphFormat;
   ResourceMonitor resourceMonitor;

--- a/arangod/Pregel/GraphStore/GraphLoaderBase.h
+++ b/arangod/Pregel/GraphStore/GraphLoaderBase.h
@@ -26,7 +26,7 @@
 #include <memory>
 #include <functional>
 
-#include <Pregel/GraphStore/Quiver.h>
+#include <Pregel/GraphStore/Magazine.h>
 
 namespace arangodb::pregel {
 
@@ -37,7 +37,7 @@ struct Quiver;
 
 template<typename V, typename E>
 struct GraphLoaderBase {
-  virtual auto load() -> std::shared_ptr<Quiver<V, E>> = 0;
+  virtual auto load() -> Magazine<V, E> = 0;
   virtual ~GraphLoaderBase() = default;
 };
 

--- a/arangod/Pregel/GraphStore/GraphVPackBuilderStorer.cpp
+++ b/arangod/Pregel/GraphStore/GraphVPackBuilderStorer.cpp
@@ -59,7 +59,6 @@ auto GraphVPackBuilderStorer<V, E>::store(std::shared_ptr<Quiver<V, E>> quiver)
     -> void {
   std::string tmp;
 
-  result->openArray(/*unindexed*/ true);
   for (auto& vertex : *quiver) {
     ADB_PROD_ASSERT(vertex.shard().value < config->globalShardIDs().size());
     ShardID const& shardId = config->globalShardID(vertex.shard());
@@ -88,7 +87,6 @@ auto GraphVPackBuilderStorer<V, E>::store(std::shared_ptr<Quiver<V, E>> quiver)
     }
     result->close();
   }
-  result->close();
 }
 
 }  // namespace arangodb::pregel

--- a/arangod/Pregel/GraphStore/GraphVPackBuilderStorer.cpp
+++ b/arangod/Pregel/GraphStore/GraphVPackBuilderStorer.cpp
@@ -57,8 +57,6 @@ namespace arangodb::pregel {
 template<typename V, typename E>
 auto GraphVPackBuilderStorer<V, E>::store(std::shared_ptr<Quiver<V, E>> quiver)
     -> void {
-  result = std::make_unique<VPackBuilder>();
-
   std::string tmp;
 
   result->openArray(/*unindexed*/ true);

--- a/arangod/Pregel/GraphStore/GraphVPackBuilderStorer.h
+++ b/arangod/Pregel/GraphStore/GraphVPackBuilderStorer.h
@@ -56,12 +56,19 @@ struct GraphVPackBuilderStorer : GraphStorerBase<V, E> {
       bool withId, std::shared_ptr<WorkerConfig> config,
       std::shared_ptr<GraphFormat<V, E> const> graphFormat,
       std::function<void()> const& statusUpdateCallback)
-      : withId(withId),
+      : result(std::make_unique<VPackBuilder>()),
+        withId(withId),
         graphFormat(graphFormat),
         config(config),
-        statusUpdateCallback(statusUpdateCallback) {}
+        statusUpdateCallback(statusUpdateCallback) {
+    result->openArray(/*unindexed*/ true);
+  }
 
   auto store(std::shared_ptr<Quiver<V, E>> quiver) -> void override;
+  auto stealResult() -> std::unique_ptr<VPackBuilder> {
+    result->close();
+    return std::move(result);
+  }
 
   std::unique_ptr<VPackBuilder> result;
   bool withId{false};

--- a/arangod/Pregel/GraphStore/Magazine.cpp
+++ b/arangod/Pregel/GraphStore/Magazine.cpp
@@ -1,0 +1,63 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2023 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Markus Pfeiffer
+////////////////////////////////////////////////////////////////////////////////
+
+#include "Magazine.h"
+#include <cstdint>
+
+#include "Pregel/Algos/ColorPropagation/ColorPropagationValue.h"
+#include "Pregel/Algos/DMID/DMIDValue.h"
+#include "Pregel/Algos/EffectiveCloseness/ECValue.h"
+#include "Pregel/Algos/HITS/HITSValue.h"
+#include "Pregel/Algos/HITSKleinberg/HITSKleinbergValue.h"
+#include "Pregel/Algos/LabelPropagation/LPValue.h"
+#include "Pregel/Algos/SCC/SCCValue.h"
+#include "Pregel/Algos/SLPA/SLPAValue.h"
+#include "Pregel/Algos/WCC/WCCValue.h"
+
+template struct arangodb::pregel::Magazine<int64_t, int64_t>;
+template struct arangodb::pregel::Magazine<uint64_t, uint64_t>;
+template struct arangodb::pregel::Magazine<uint64_t, uint8_t>;
+template struct arangodb::pregel::Magazine<float, float>;
+template struct arangodb::pregel::Magazine<double, float>;
+template struct arangodb::pregel::Magazine<double, double>;
+template struct arangodb::pregel::Magazine<float, uint8_t>;
+
+// specific algo combos
+template struct arangodb::pregel::Magazine<arangodb::pregel::algos::WCCValue,
+                                           uint64_t>;
+template struct arangodb::pregel::Magazine<arangodb::pregel::algos::SCCValue,
+                                           int8_t>;
+template struct arangodb::pregel::Magazine<arangodb::pregel::algos::ECValue,
+                                           int8_t>;
+template struct arangodb::pregel::Magazine<arangodb::pregel::algos::HITSValue,
+                                           int8_t>;
+template struct arangodb::pregel::Magazine<
+    arangodb::pregel::algos::HITSKleinbergValue, int8_t>;
+template struct arangodb::pregel::Magazine<arangodb::pregel::algos::DMIDValue,
+                                           float>;
+template struct arangodb::pregel::Magazine<arangodb::pregel::algos::LPValue,
+                                           int8_t>;
+template struct arangodb::pregel::Magazine<arangodb::pregel::algos::SLPAValue,
+                                           int8_t>;
+template struct arangodb::pregel::Magazine<
+    arangodb::pregel::algos::ColorPropagationValue, int8_t>;

--- a/arangod/Pregel/GraphStore/Magazine.h
+++ b/arangod/Pregel/GraphStore/Magazine.h
@@ -1,0 +1,71 @@
+///////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2022 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Markus Pfeiffer
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "Pregel/GraphStore/Quiver.h"
+
+/*
+ * A magazine is a collection of quivers.
+ *
+ * This is a temporary measure as we store multiple Quivers per
+ * worker.
+ *
+ */
+namespace arangodb::pregel {
+template<typename V, typename E>
+struct Magazine {
+  std::vector<std::shared_ptr<Quiver<V, E>>> quivers;
+
+  auto emplace(std::shared_ptr<Quiver<V, E>>&& quiver) {
+    return quivers.emplace_back(std::move(quiver));
+  }
+
+  auto begin() const { return std::begin(quivers); }
+  auto end() const { return std::end(quivers); }
+
+  auto begin() { return std::begin(quivers); }
+  auto end() { return std::end(quivers); }
+
+  auto numberOfVertices() const -> size_t {
+    auto sum = size_t{0};
+    for (auto const& quiver : quivers) {
+      sum += quiver->numberOfVertices();
+    }
+    return sum;
+  }
+  auto numberOfEdges() const -> size_t {
+    auto sum = size_t{0};
+    for (auto const& quiver : quivers) {
+      sum += quiver->numberOfEdges();
+    }
+    return sum;
+  }
+};
+
+template<typename V, typename E, typename Inspector>
+auto inspect(Inspector& f, Magazine<V, E>& s) {
+  return f.object(s).fields(f.field("quivers", s.quivers));
+}
+
+}  // namespace arangodb::pregel

--- a/arangod/Pregel/GraphStore/Quiver.h
+++ b/arangod/Pregel/GraphStore/Quiver.h
@@ -43,8 +43,11 @@ struct Quiver {
     edgeCounter += v._edges.size();
     vertices.emplace_back(std::move(v));
   }
-  auto numberOfVertices() -> size_t { return vertices.size(); }
-  auto numberOfEdges() -> size_t { return edgeCounter; }
+  auto numberOfVertices() const -> size_t { return vertices.size(); }
+  auto numberOfEdges() const -> size_t { return edgeCounter; }
+
+  auto begin() const { return std::begin(vertices); }
+  auto end() const { return std::end(vertices); }
 
   auto begin() { return std::begin(vertices); }
   auto end() { return std::end(vertices); }
@@ -57,5 +60,4 @@ template<typename V, typename E, typename Inspector>
 auto inspect(Inspector& f, Quiver<V, E>& s) {
   return f.object(s).fields(f.field("vertices", s.vertices));
 }
-
 }  // namespace arangodb::pregel

--- a/arangod/Pregel/VertexComputation.h
+++ b/arangod/Pregel/VertexComputation.h
@@ -48,7 +48,6 @@ class VertexContext {
   uint64_t _gss = 0;
   uint64_t _lss = 0;
   WorkerContext* _context = nullptr;
-  std::shared_ptr<Quiver<V, E>> _quiver = nullptr;
   AggregatorHandler* _readAggregators = nullptr;
   AggregatorHandler* _writeAggregators = nullptr;
   Vertex<V, E>* _vertexEntry = nullptr;

--- a/arangod/Pregel/Worker/Handler.h
+++ b/arangod/Pregel/Worker/Handler.h
@@ -85,14 +85,14 @@ struct WorkerHandler : actor::HandlerBase<Runtime, WorkerState<V, E, M>> {
                   this->template dispatch<pregel::message::StatusMessages>(
                       this->state->statusActor, update);
                 }});
-        this->state->quiver = loader.load();
+        this->state->magazine = loader.load();
 
         LOG_TOPIC("5206c", WARN, Logger::PREGEL)
             << fmt::format("Worker {} has finished loading.", this->self);
         return {conductor::message::GraphLoaded{
             .executionNumber = this->state->config->executionNumber(),
-            .vertexCount = this->state->quiver->numberOfVertices(),
-            .edgeCount = this->state->quiver->numberOfEdges()}};
+            .vertexCount = this->state->magazine.numberOfVertices(),
+            .edgeCount = this->state->magazine.numberOfEdges()}};
       } catch (std::exception const& ex) {
         return Result{
             TRI_ERROR_INTERNAL,
@@ -160,37 +160,39 @@ struct WorkerHandler : actor::HandlerBase<Runtime, WorkerState<V, E, M>> {
 
     size_t verticesProcessed = 0;
     size_t activeCount = 0;
-    for (auto& vertexEntry : *this->state->quiver) {
-      MessageIterator<M> messages = this->state->readCache->getMessages(
-          vertexEntry.shard(), vertexEntry.key());
-      this->state->messageStats.receivedCount += messages.size();
-      // _feature.metrics()->pregelMessagesReceived->count(
-      //     _readCache->containedMessageCount());
-      this->state->messageStats.memoryBytesUsedForMessages +=
-          messages.size() * sizeof(M);
+    for (auto& quiver : this->state->magazine) {
+      for (auto& vertexEntry : *quiver) {
+        MessageIterator<M> messages = this->state->readCache->getMessages(
+            vertexEntry.shard(), vertexEntry.key());
+        this->state->messageStats.receivedCount += messages.size();
+        // _feature.metrics()->pregelMessagesReceived->count(
+        //     _readCache->containedMessageCount());
+        this->state->messageStats.memoryBytesUsedForMessages +=
+            messages.size() * sizeof(M);
 
-      if (messages.size() > 0 || vertexEntry.active()) {
-        vertexComputation->_vertexEntry = &vertexEntry;
-        vertexComputation->compute(messages);
-        if (vertexEntry.active()) {
-          activeCount++;
+        if (messages.size() > 0 || vertexEntry.active()) {
+          vertexComputation->_vertexEntry = &vertexEntry;
+          vertexComputation->compute(messages);
+          if (vertexEntry.active()) {
+            activeCount++;
+          }
         }
-      }
 
-      this->state->messageStats.sendCount = outCache->sendCount();
-      verticesProcessed++;
-      if (verticesProcessed %
-              Utils::batchOfVerticesProcessedBeforeUpdatingStatus ==
-          0) {
-        this->template dispatch<pregel::message::StatusMessages>(
-            this->state->statusActor,
-            pregel::message::GlobalSuperStepUpdate{
-                .gss = this->state->config->globalSuperstep(),
-                .verticesProcessed = verticesProcessed,
-                .messagesSent = this->state->messageStats.sendCount,
-                .messagesReceived = this->state->messageStats.receivedCount,
-                .memoryBytesUsedForMessages =
-                    this->state->messageStats.memoryBytesUsedForMessages});
+        this->state->messageStats.sendCount = outCache->sendCount();
+        verticesProcessed++;
+        if (verticesProcessed %
+                Utils::batchOfVerticesProcessedBeforeUpdatingStatus ==
+            0) {
+          this->template dispatch<pregel::message::StatusMessages>(
+              this->state->statusActor,
+              pregel::message::GlobalSuperStepUpdate{
+                  .gss = this->state->config->globalSuperstep(),
+                  .verticesProcessed = verticesProcessed,
+                  .messagesSent = this->state->messageStats.sendCount,
+                  .messagesReceived = this->state->messageStats.receivedCount,
+                  .memoryBytesUsedForMessages =
+                      this->state->messageStats.memoryBytesUsedForMessages});
+        }
       }
     }
 
@@ -226,7 +228,7 @@ struct WorkerHandler : actor::HandlerBase<Runtime, WorkerState<V, E, M>> {
         this->state->statusActor,
         pregel::message::GlobalSuperStepUpdate{
             .gss = this->state->config->globalSuperstep(),
-            .verticesProcessed = this->state->quiver->numberOfVertices(),
+            .verticesProcessed = this->state->magazine.numberOfVertices(),
             .messagesSent = this->state->messageStats.sendCount,
             .messagesReceived = this->state->messageStats.receivedCount,
             .memoryBytesUsedForMessages =
@@ -245,8 +247,8 @@ struct WorkerHandler : actor::HandlerBase<Runtime, WorkerState<V, E, M>> {
         this->state->messageStats,
         verticesProcessed.sendCountPerActor,
         verticesProcessed.activeCount,
-        this->state->quiver->numberOfVertices(),
-        this->state->quiver->numberOfEdges(),
+        this->state->magazine.numberOfVertices(),
+        this->state->magazine.numberOfEdges(),
         aggregators};
     LOG_TOPIC("ade5b", DEBUG, Logger::PREGEL)
         << fmt::format("Finished GSS: {}", gssFinishedEvent);
@@ -357,7 +359,9 @@ struct WorkerHandler : actor::HandlerBase<Runtime, WorkerState<V, E, M>> {
                   this->template dispatch<pregel::message::StatusMessages>(
                       this->state->statusActor, update);
                 }});
-        storer.store(this->state->quiver);
+        for (auto& quiver : this->state->magazine) {
+          storer.store(quiver);
+        }
         return conductor::message::Stored{};
       } catch (std::exception const& ex) {
         return Result{
@@ -396,7 +400,9 @@ struct WorkerHandler : actor::HandlerBase<Runtime, WorkerState<V, E, M>> {
             GraphVPackBuilderStorer<V, E>(msg.withID, this->state->config,
                                           this->state->algorithm->inputFormat(),
                                           std::move(statusUpdateCallback));
-        storer.store(this->state->quiver);
+        for (auto& quiver : this->state->magazine) {
+          storer.store(quiver);
+        }
         return PregelResults{*storer.result};
       } catch (std::exception const& ex) {
         return Result{TRI_ERROR_INTERNAL,

--- a/arangod/Pregel/Worker/Handler.h
+++ b/arangod/Pregel/Worker/Handler.h
@@ -137,7 +137,6 @@ struct WorkerHandler : actor::HandlerBase<Runtime, WorkerState<V, E, M>> {
     ctx->_gss = this->state->config->globalSuperstep();
     ctx->_lss = this->state->config->localSuperstep();
     ctx->_context = this->state->workerContext.get();
-    ctx->_quiver = this->state->quiver;
     ctx->_readAggregators = this->state->workerContext->_readAggregators.get();
   }
 

--- a/arangod/Pregel/Worker/State.h
+++ b/arangod/Pregel/Worker/State.h
@@ -105,7 +105,7 @@ struct WorkerState {
   const actor::ActorPID spawnActor;
   const actor::ActorPID resultActor;
   const actor::ActorPID statusActor;
-  std::shared_ptr<Quiver<V, E>> quiver = std::make_unique<Quiver<V, E>>();
+  Magazine<V, E> magazine;
   MessageStats messageStats;
 };
 template<typename V, typename E, typename M, typename Inspector>

--- a/arangod/Pregel/Worker/Worker.cpp
+++ b/arangod/Pregel/Worker/Worker.cpp
@@ -201,7 +201,7 @@ void Worker<V, E, M>::setupWorker() {
                        auto loader = GraphLoader<V, E>(
                            _config, _algorithm->inputFormat(),
                            OldLoadingUpdate{.fn = statusUpdateCallback});
-                       _magazine.emplace(std::move(loader.load()));
+                       _magazine = std::move(loader.load());
                      } catch (std::exception const& ex) {
                        LOG_PREGEL("a47c4", WARN)
                            << "caught exception in loadShards: " << ex.what();

--- a/arangod/Pregel/Worker/Worker.cpp
+++ b/arangod/Pregel/Worker/Worker.cpp
@@ -88,7 +88,7 @@ Worker<V, E, M>::Worker(TRI_vocbase_t& vocbase, Algorithm<V, E, M>* algo,
       _state(WorkerState::IDLE),
       _config(std::make_shared<WorkerConfig>(&vocbase)),
       _algorithm(algo),
-      _quiver(nullptr) {
+      _magazine() {
   _config->updateConfig(parameters);
 
   std::lock_guard guard{_commandMutex};
@@ -172,8 +172,8 @@ void Worker<V, E, M>::setupWorker() {
                        _config->executionNumber());
     auto graphLoaded = GraphLoaded{.executionNumber = _config->_executionNumber,
                                    .sender = ServerState::instance()->getId(),
-                                   .vertexCount = _quiver->numberOfVertices(),
-                                   .edgeCount = _quiver->numberOfEdges()};
+                                   .vertexCount = _magazine.numberOfVertices(),
+                                   .edgeCount = _magazine.numberOfEdges()};
     auto serialized = inspection::serializeWithErrorT(graphLoaded);
     if (!serialized.ok()) {
       THROW_ARANGO_EXCEPTION_MESSAGE(
@@ -201,7 +201,7 @@ void Worker<V, E, M>::setupWorker() {
                        auto loader = GraphLoader<V, E>(
                            _config, _algorithm->inputFormat(),
                            OldLoadingUpdate{.fn = statusUpdateCallback});
-                       _quiver = loader.load();
+                       _magazine.emplace(std::move(loader.load()));
                      } catch (std::exception const& ex) {
                        LOG_PREGEL("a47c4", WARN)
                            << "caught exception in loadShards: " << ex.what();
@@ -269,8 +269,8 @@ GlobalSuperStepPrepared Worker<V, E, M>::prepareGlobalStep(
   return GlobalSuperStepPrepared{.executionNumber = _config->_executionNumber,
                                  .sender = ServerState::instance()->getId(),
                                  .activeCount = _activeCount,
-                                 .vertexCount = _quiver->numberOfVertices(),
-                                 .edgeCount = _quiver->numberOfEdges(),
+                                 .vertexCount = _magazine.numberOfVertices(),
+                                 .edgeCount = _magazine.numberOfEdges(),
                                  .aggregators = aggregators};
 }
 
@@ -382,29 +382,31 @@ bool Worker<V, E, M>::_processVertices() {
   vertexComputation->_cache = outCache;
 
   size_t activeCount = 0;
-  for (auto& vertexEntry : *_quiver) {
-    MessageIterator<M> messages =
-        _readCache->getMessages(vertexEntry.shard(), vertexEntry.key());
-    _currentGssObservables.messagesReceived += messages.size();
-    _currentGssObservables.memoryBytesUsedForMessages +=
-        messages.size() * sizeof(M);
+  for (auto& quiver : _magazine) {
+    for (auto& vertexEntry : *quiver) {
+      MessageIterator<M> messages =
+          _readCache->getMessages(vertexEntry.shard(), vertexEntry.key());
+      _currentGssObservables.messagesReceived += messages.size();
+      _currentGssObservables.memoryBytesUsedForMessages +=
+          messages.size() * sizeof(M);
 
-    if (messages.size() > 0 || vertexEntry.active()) {
-      vertexComputation->_vertexEntry = &vertexEntry;
-      vertexComputation->compute(messages);
-      if (vertexEntry.active()) {
-        activeCount++;
+      if (messages.size() > 0 || vertexEntry.active()) {
+        vertexComputation->_vertexEntry = &vertexEntry;
+        vertexComputation->compute(messages);
+        if (vertexEntry.active()) {
+          activeCount++;
+        }
       }
-    }
-    if (_state != WorkerState::COMPUTING) {
-      break;
-    }
+      if (_state != WorkerState::COMPUTING) {
+        break;
+      }
 
-    ++_currentGssObservables.verticesProcessed;
-    if (_currentGssObservables.verticesProcessed %
-            Utils::batchOfVerticesProcessedBeforeUpdatingStatus ==
-        0) {
-      _makeStatusCallback()();
+      ++_currentGssObservables.verticesProcessed;
+      if (_currentGssObservables.verticesProcessed %
+              Utils::batchOfVerticesProcessedBeforeUpdatingStatus ==
+          0) {
+        _makeStatusCallback()();
+      }
     }
   }
 
@@ -534,7 +536,9 @@ void Worker<V, E, M>::finalizeExecution(FinalizeExecution const& msg,
                 _config, _algorithm->inputFormat(), _config->globalShardIDs(),
                 OldStoringUpdate{.fn = std::move(statusUpdateCallback)});
             _feature.metrics()->pregelWorkersStoringNumber->fetch_add(1);
-            storer.store(_quiver);
+            for (auto& quiver : _magazine) {
+              storer.store(quiver);
+            }
           } catch (std::exception const& ex) {
             LOG_PREGEL("a4774", WARN)
                 << "caught exception in store: " << ex.what();
@@ -557,7 +561,9 @@ auto Worker<V, E, M>::aqlResult(bool withId) const -> PregelResults {
       GraphVPackBuilderStorer<V, E>(withId, _config, _algorithm->inputFormat(),
                                     std::move(_makeStatusCallback()));
 
-  storer.store(_quiver);
+  for (auto& quiver : _magazine) {
+    storer.store(quiver);
+  }
   return PregelResults{.results = *storer.result};  // Yes, this is a copy rn.
 }
 

--- a/arangod/Pregel/Worker/Worker.cpp
+++ b/arangod/Pregel/Worker/Worker.cpp
@@ -358,7 +358,6 @@ void Worker<V, E, M>::_initializeVertexContext(VertexContext<V, E, M>* ctx) {
   ctx->_gss = _config->globalSuperstep();
   ctx->_lss = _config->localSuperstep();
   ctx->_context = _workerContext.get();
-  ctx->_quiver = _quiver;
   ctx->_readAggregators = _workerContext->_readAggregators.get();
 }
 

--- a/arangod/Pregel/Worker/Worker.cpp
+++ b/arangod/Pregel/Worker/Worker.cpp
@@ -564,7 +564,8 @@ auto Worker<V, E, M>::aqlResult(bool withId) const -> PregelResults {
   for (auto& quiver : _magazine) {
     storer.store(quiver);
   }
-  return PregelResults{.results = *storer.result};  // Yes, this is a copy rn.
+  return PregelResults{.results =
+                           *storer.stealResult()};  // Yes, this is a copy rn.
 }
 
 template<typename V, typename E, typename M>

--- a/arangod/Pregel/Worker/Worker.h
+++ b/arangod/Pregel/Worker/Worker.h
@@ -32,7 +32,7 @@
 #include "Pregel/AggregatorHandler.h"
 #include "Pregel/Algorithm.h"
 #include "Pregel/Conductor/Messages.h"
-#include "Pregel/GraphStore/Quiver.h"
+#include "Pregel/GraphStore/Magazine.h"
 #include "Pregel/Statistics.h"
 #include "Pregel/Status/Status.h"
 #include "Pregel/Worker/Messages.h"
@@ -104,7 +104,7 @@ class Worker : public IWorker {
 
   std::unique_ptr<AggregatorHandler> _conductorAggregators;
   std::unique_ptr<AggregatorHandler> _workerAggregators;
-  std::shared_ptr<Quiver<V, E>> _quiver;
+  Magazine<V, E> _magazine;
   std::unique_ptr<MessageFormat<M>> _messageFormat;
   std::unique_ptr<MessageCombiner<M>> _messageCombiner;
 


### PR DESCRIPTION
### Scope & Purpose

As a pre-step to re-parallelisation support multiple `Quiver<V, E>` in a Worker; they are summarised in a `Magazine<V,E>`.

Currently there is a 1-1 correspondence between `Quiver<V,E>`s and a shard of a vertex collection, so we can load vertex shards concurrently, and later process `Quiver<V,E>`s concurrently.