### PR TITLE
[CINFRA-732] Fix lock inversions in the leader

### DIFF
--- a/arangod/Replication2/ReplicatedLog/CMakeLists.txt
+++ b/arangod/Replication2/ReplicatedLog/CMakeLists.txt
@@ -34,11 +34,13 @@ target_sources(arango_replication2_pure PRIVATE
   Components/IAppendEntriesManager.h
   Components/ICompactionManager.h
   Components/IFollowerCommitManager.h
+  Components/IInMemoryLogManager.h
   Components/IMessageIdManager.h
   Components/IMethodsProvider.h
   Components/ISnapshotManager.h
   Components/IStateHandleManager.h
   Components/IStorageManager.h
+  Components/InMemoryLogManager.cpp Components/InMemoryLogManager.h
   Components/LogFollower.cpp Components/LogFollower.h
   Components/MessageIdManager.cpp Components/MessageIdManager.h
   Components/MethodsProvider.cpp Components/MethodsProvider.h

--- a/arangod/Replication2/ReplicatedLog/Components/IInMemoryLogManager.h
+++ b/arangod/Replication2/ReplicatedLog/Components/IInMemoryLogManager.h
@@ -59,6 +59,11 @@ struct IInMemoryLogManager {
   [[nodiscard]] virtual auto getLogConsumerIterator(
       std::optional<LogRange> bounds) const
       -> std::unique_ptr<LogRangeIterator> = 0;
+
+  // If there's at least one log entry with a payload on the given range,
+  // returns a LogRangeIterator. Otherwise the next index to wait for.
+  [[nodiscard]] virtual auto getNonEmptyLogConsumerIterator(LogIndex firstIdx)
+      const -> std::variant<std::unique_ptr<LogRangeIterator>, LogIndex> = 0;
 };
 
 }  // namespace comp

--- a/arangod/Replication2/ReplicatedLog/Components/IInMemoryLogManager.h
+++ b/arangod/Replication2/ReplicatedLog/Components/IInMemoryLogManager.h
@@ -1,0 +1,42 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2023-2023 ArangoDB GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Tobias Gödderz
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+namespace arangodb::replication2 {
+struct LogIndex;
+}
+
+namespace arangodb::replication2::replicated_log {
+inline namespace comp {
+
+struct IInMemoryLogManager {
+  virtual ~IInMemoryLogManager() = default;
+
+  virtual auto getCommitIndex() const noexcept -> LogIndex = 0;
+  // Sets the new index, returns the old one. The new index is expected to be
+  // larger than the old one.
+  virtual auto updateCommitIndex(LogIndex newIndex) noexcept -> LogIndex = 0;
+};
+
+}  // namespace comp
+}  // namespace arangodb::replication2::replicated_log

--- a/arangod/Replication2/ReplicatedLog/Components/IInMemoryLogManager.h
+++ b/arangod/Replication2/ReplicatedLog/Components/IInMemoryLogManager.h
@@ -52,6 +52,13 @@ struct IInMemoryLogManager {
       std::variant<LogMetaPayload, LogPayload> payload, LogTerm term,
       InMemoryLogEntry::clock::time_point insertTp, bool waitForSync)
       -> LogIndex = 0;
+
+  [[nodiscard]] virtual auto getInternalLogIterator(LogIndex firstIdx) const
+      -> std::unique_ptr<TypedLogIterator<InMemoryLogEntry>> = 0;
+
+  [[nodiscard]] virtual auto getLogConsumerIterator(
+      std::optional<LogRange> bounds) const
+      -> std::unique_ptr<LogRangeIterator> = 0;
 };
 
 }  // namespace comp

--- a/arangod/Replication2/ReplicatedLog/Components/IInMemoryLogManager.h
+++ b/arangod/Replication2/ReplicatedLog/Components/IInMemoryLogManager.h
@@ -41,22 +41,17 @@ struct IInMemoryLogManager {
   [[nodiscard]] virtual auto getCommitIndex() const noexcept -> LogIndex = 0;
   // Sets the new index, returns the old one. The new index is expected to be
   // larger than the old one.
-  virtual void updateCommitIndex(ReplicatedLogMetrics&,
-                                 LogIndex newIndex) noexcept = 0;
+  virtual void updateCommitIndex(LogIndex newIndex) noexcept = 0;
 
   // Get a copy (snapshot) of the InMemoryLog.
   // TODO In many cases, only one or two indexes are needed, not the whole
   //      flex_vector. It might make sense to expose them separately.
   [[nodiscard]] virtual auto getInMemoryLog() const noexcept -> InMemoryLog = 0;
 
-  struct InsertLogEntryResult {
-    LogIndex logIndex{};
-    std::size_t approximateByteSize{};
-  };
   [[nodiscard]] virtual auto appendLogEntry(
       std::variant<LogMetaPayload, LogPayload> payload, LogTerm term,
       InMemoryLogEntry::clock::time_point insertTp, bool waitForSync)
-      -> InsertLogEntryResult = 0;
+      -> LogIndex = 0;
 };
 
 }  // namespace comp

--- a/arangod/Replication2/ReplicatedLog/Components/IInMemoryLogManager.h
+++ b/arangod/Replication2/ReplicatedLog/Components/IInMemoryLogManager.h
@@ -50,13 +50,12 @@ struct IInMemoryLogManager {
   [[nodiscard]] virtual auto calculateCommitLag() const noexcept
       -> std::chrono::duration<double, std::milli> = 0;
 
+  [[nodiscard]] virtual auto getFirstInMemoryIndex() const noexcept
+      -> LogIndex = 0;
   [[nodiscard]] virtual auto getSpearheadTermIndexPair() const noexcept
       -> TermIndexPair = 0;
-
-  // Get a copy (snapshot) of the InMemoryLog.
-  // TODO In many cases, only one or two indexes are needed, not the whole
-  //      flex_vector. It might make sense to expose them separately.
-  [[nodiscard]] virtual auto getInMemoryLog() const noexcept -> InMemoryLog = 0;
+  [[nodiscard]] virtual auto getTermOfIndex(LogIndex) const noexcept
+      -> std::optional<LogTerm> = 0;
 
   [[nodiscard]] virtual auto appendLogEntry(
       std::variant<LogMetaPayload, LogPayload> payload, LogTerm term,

--- a/arangod/Replication2/ReplicatedLog/Components/IInMemoryLogManager.h
+++ b/arangod/Replication2/ReplicatedLog/Components/IInMemoryLogManager.h
@@ -26,9 +26,13 @@
 #include "Replication2/ReplicatedLog/LogCommon.h"
 #include "Replication2/ReplicatedLog/LogEntries.h"
 
+#include <chrono>
+#include <variant>
+
 namespace arangodb::replication2 {
 struct LogIndex;
-}
+struct TermIndexPair;
+}  // namespace arangodb::replication2
 
 namespace arangodb::replication2::replicated_log {
 struct InMemoryLog;
@@ -42,6 +46,12 @@ struct IInMemoryLogManager {
   // Sets the new index, returns the old one. The new index is expected to be
   // larger than the old one.
   virtual void updateCommitIndex(LogIndex newIndex) noexcept = 0;
+
+  [[nodiscard]] virtual auto calculateCommitLag() const noexcept
+      -> std::chrono::duration<double, std::milli> = 0;
+
+  [[nodiscard]] virtual auto getSpearheadTermIndexPair() const noexcept
+      -> TermIndexPair = 0;
 
   // Get a copy (snapshot) of the InMemoryLog.
   // TODO In many cases, only one or two indexes are needed, not the whole

--- a/arangod/Replication2/ReplicatedLog/Components/IStorageManager.h
+++ b/arangod/Replication2/ReplicatedLog/Components/IStorageManager.h
@@ -41,6 +41,7 @@ namespace replication2 {
 struct LogRange;
 struct LogIndex;
 class LogEntryView;
+struct PersistedLogIterator;
 template<typename T>
 struct TypedLogRangeIterator;
 namespace replicated_log {

--- a/arangod/Replication2/ReplicatedLog/Components/IStorageManager.h
+++ b/arangod/Replication2/ReplicatedLog/Components/IStorageManager.h
@@ -78,6 +78,8 @@ struct IStorageManager {
       -> std::unique_ptr<TypedLogRangeIterator<LogEntryView>> = 0;
   [[nodiscard]] virtual auto getCommittedMetaInfo() const
       -> replicated_state::PersistedStateInfo = 0;
+  [[nodiscard]] virtual auto getPersistedLogIterator(LogIndex first) const
+      -> std::unique_ptr<PersistedLogIterator> = 0;
 
   virtual auto beginMetaInfoTrx() -> std::unique_ptr<IStateInfoTransaction> = 0;
   virtual auto commitMetaInfoTrx(std::unique_ptr<IStateInfoTransaction>)

--- a/arangod/Replication2/ReplicatedLog/Components/InMemoryLogManager.cpp
+++ b/arangod/Replication2/ReplicatedLog/Components/InMemoryLogManager.cpp
@@ -22,22 +22,90 @@
 
 #include "InMemoryLogManager.h"
 
+#include "Metrics/Counter.h"
+#include "Metrics/Gauge.h"
+#include "Metrics/Histogram.h"
+#include "Metrics/LogScale.h"
+#include "Replication2/ReplicatedLog/Components/IStorageManager.h"
+#include "Replication2/ReplicatedLog/ReplicatedLogMetrics.h"
+#include "Replication2/ReplicatedLog/TermIndexMapping.h"
+
 namespace arangodb::replication2::replicated_log {
 
-InMemoryLogManager::InMemoryLogManager(LogIndex firstIndex,
+InMemoryLogManager::InMemoryLogManager(LoggerContext logContext,
+                                       LogIndex firstIndex,
                                        std::shared_ptr<IStorageManager> storage)
-    : _storageManager(std::move(storage)), _guardedData(firstIndex) {}
-LogIndex InMemoryLogManager::getCommitIndex() const noexcept {
+    : _logContext(logContext),
+      _storageManager(std::move(storage)),
+      _guardedData(firstIndex) {}
+
+auto InMemoryLogManager::getCommitIndex() const noexcept -> LogIndex {
   return _guardedData.getLockedGuard()->_commitIndex;
 }
-LogIndex InMemoryLogManager::updateCommitIndex(LogIndex newIndex) noexcept {
-  return _guardedData.doUnderLock([newIndex](auto& data) {
+
+void InMemoryLogManager::updateCommitIndex(ReplicatedLogMetrics& metrics,
+                                           LogIndex newCommitIndex) noexcept {
+  return _guardedData.doUnderLock([&](auto& data) {
     auto oldCommitIndex = data._commitIndex;
 
-    TRI_ASSERT(oldCommitIndex < newIndex)
-        << "_commitIndex == " << oldCommitIndex << ", newIndex == " << newIndex;
-    data._commitIndex = newIndex;
-    return oldCommitIndex;
+    TRI_ASSERT(oldCommitIndex < newCommitIndex)
+        << "oldCommitIndex == " << oldCommitIndex
+        << ", newCommitIndex == " << newCommitIndex;
+    data._commitIndex = newCommitIndex;
+
+    metrics.replicatedLogNumberCommittedEntries->count(newCommitIndex.value -
+                                                       oldCommitIndex.value);
+
+    // Update commit time metrics
+    auto const commitTp = InMemoryLogEntry::clock::now();
+
+    auto const newlyCommittedLogEntries =
+        data._inMemoryLog.slice(oldCommitIndex, newCommitIndex + 1);
+    for (auto const& it : newlyCommittedLogEntries) {
+      using namespace std::chrono_literals;
+      auto const entryDuration = commitTp - it.insertTp();
+      metrics.replicatedLogInsertsRtt->count(entryDuration / 1us);
+    }
+
+    // potentially evict parts of the inMemoryLog.
+    auto const maxDiskIndex =
+        _storageManager->getTermIndexMapping().getLastIndex().value_or(
+            TermIndexPair{});
+    auto const evictStopIndex = std::min(newCommitIndex, maxDiskIndex.index);
+    auto const logEntriesToEvict =
+        data._inMemoryLog.slice(LogIndex{0}, evictStopIndex);
+    auto releasedMemory = std::size_t{0};
+    auto numEntriesEvicted = std::size_t{0};
+    for (auto const& memtry : logEntriesToEvict) {
+      releasedMemory += memtry.entry().approxByteSize();
+      numEntriesEvicted += 1;
+    }
+    // remove upto commit index, but keep non-locally persisted log
+    data._inMemoryLog = data._inMemoryLog.removeFront(evictStopIndex);
+    metrics.leaderNumInMemoryEntries->fetch_sub(numEntriesEvicted);
+    metrics.leaderNumInMemoryBytes->fetch_sub(releasedMemory);
+  });
+}
+
+auto InMemoryLogManager::getInMemoryLog() const noexcept -> InMemoryLog {
+  return _guardedData.getLockedGuard()->_inMemoryLog;
+}
+
+auto InMemoryLogManager::appendLogEntry(
+    std::variant<LogMetaPayload, LogPayload> payload, LogTerm term,
+    InMemoryLogEntry::clock::time_point insertTp, bool waitForSync)
+    -> InsertLogEntryResult {
+  return _guardedData.doUnderLock([&](auto& data) -> InsertLogEntryResult {
+    auto const index = data._inMemoryLog.getNextIndex();
+
+    auto logEntry = InMemoryLogEntry(
+        PersistingLogEntry(TermIndexPair{term, index}, std::move(payload)),
+        waitForSync);
+    logEntry.setInsertTp(insertTp);
+    auto size = logEntry.entry().approxByteSize();
+
+    data._inMemoryLog.appendInPlace(_logContext, std::move(logEntry));
+    return {index, size};
   });
 }
 

--- a/arangod/Replication2/ReplicatedLog/Components/InMemoryLogManager.cpp
+++ b/arangod/Replication2/ReplicatedLog/Components/InMemoryLogManager.cpp
@@ -1,0 +1,47 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2023-2023 ArangoDB GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Tobias Gödderz
+////////////////////////////////////////////////////////////////////////////////
+
+#include "InMemoryLogManager.h"
+
+namespace arangodb::replication2::replicated_log {
+
+InMemoryLogManager::InMemoryLogManager(LogIndex firstIndex,
+                                       std::shared_ptr<IStorageManager> storage)
+    : _storageManager(std::move(storage)), _guardedData(firstIndex) {}
+LogIndex InMemoryLogManager::getCommitIndex() const noexcept {
+  return _guardedData.getLockedGuard()->_commitIndex;
+}
+LogIndex InMemoryLogManager::updateCommitIndex(LogIndex newIndex) noexcept {
+  return _guardedData.doUnderLock([newIndex](auto& data) {
+    auto oldCommitIndex = data._commitIndex;
+
+    TRI_ASSERT(oldCommitIndex < newIndex)
+        << "_commitIndex == " << oldCommitIndex << ", newIndex == " << newIndex;
+    data._commitIndex = newIndex;
+    return oldCommitIndex;
+  });
+}
+
+InMemoryLogManager::GuardedData::GuardedData(LogIndex firstIndex)
+    : _inMemoryLog(firstIndex) {}
+
+}  // namespace arangodb::replication2::replicated_log

--- a/arangod/Replication2/ReplicatedLog/Components/InMemoryLogManager.h
+++ b/arangod/Replication2/ReplicatedLog/Components/InMemoryLogManager.h
@@ -45,8 +45,10 @@ struct InMemoryLogManager : IInMemoryLogManager {
   void updateCommitIndex(LogIndex newIndex) noexcept override;
   auto calculateCommitLag() const noexcept
       -> std::chrono::duration<double, std::milli> override;
+  auto getFirstInMemoryIndex() const noexcept -> LogIndex override;
   auto getSpearheadTermIndexPair() const noexcept -> TermIndexPair override;
-  auto getInMemoryLog() const noexcept -> InMemoryLog override;
+  auto getTermOfIndex(LogIndex) const noexcept
+      -> std::optional<LogTerm> override;
   auto appendLogEntry(std::variant<LogMetaPayload, LogPayload> payload,
                       LogTerm term,
                       InMemoryLogEntry::clock::time_point insertTp,

--- a/arangod/Replication2/ReplicatedLog/Components/InMemoryLogManager.h
+++ b/arangod/Replication2/ReplicatedLog/Components/InMemoryLogManager.h
@@ -49,6 +49,10 @@ struct InMemoryLogManager : IInMemoryLogManager {
                       LogTerm term,
                       InMemoryLogEntry::clock::time_point insertTp,
                       bool waitForSync) -> LogIndex override;
+  auto getInternalLogIterator(LogIndex firstIdx) const
+      -> std::unique_ptr<TypedLogIterator<InMemoryLogEntry>> override;
+  auto getLogConsumerIterator(std::optional<LogRange> bounds) const
+      -> std::unique_ptr<LogRangeIterator> override;
 
  private:
   struct GuardedData {

--- a/arangod/Replication2/ReplicatedLog/Components/InMemoryLogManager.h
+++ b/arangod/Replication2/ReplicatedLog/Components/InMemoryLogManager.h
@@ -36,18 +36,19 @@ inline namespace comp {
 struct IStorageManager;
 
 struct InMemoryLogManager : IInMemoryLogManager {
-  explicit InMemoryLogManager(LoggerContext logContext, LogIndex firstIndex,
+  explicit InMemoryLogManager(LoggerContext logContext,
+                              std::shared_ptr<ReplicatedLogMetrics>,
+                              LogIndex firstIndex,
                               std::shared_ptr<IStorageManager> storage);
 
   auto getCommitIndex() const noexcept -> LogIndex override;
-  void updateCommitIndex(ReplicatedLogMetrics&,
-                         LogIndex newIndex) noexcept override;
+  void updateCommitIndex(LogIndex newIndex) noexcept override;
 
   auto getInMemoryLog() const noexcept -> InMemoryLog override;
   auto appendLogEntry(std::variant<LogMetaPayload, LogPayload> payload,
                       LogTerm term,
                       InMemoryLogEntry::clock::time_point insertTp,
-                      bool waitForSync) -> InsertLogEntryResult override;
+                      bool waitForSync) -> LogIndex override;
 
  private:
   struct GuardedData {
@@ -55,7 +56,8 @@ struct InMemoryLogManager : IInMemoryLogManager {
     InMemoryLog _inMemoryLog;
     LogIndex _commitIndex{0};
   };
-  LoggerContext _logContext;
+  LoggerContext const _logContext;
+  std::shared_ptr<ReplicatedLogMetrics> const _metrics;
   std::shared_ptr<IStorageManager> const _storageManager;
   Guarded<GuardedData> _guardedData;
 };

--- a/arangod/Replication2/ReplicatedLog/Components/InMemoryLogManager.h
+++ b/arangod/Replication2/ReplicatedLog/Components/InMemoryLogManager.h
@@ -53,12 +53,18 @@ struct InMemoryLogManager : IInMemoryLogManager {
       -> std::unique_ptr<TypedLogIterator<InMemoryLogEntry>> override;
   auto getLogConsumerIterator(std::optional<LogRange> bounds) const
       -> std::unique_ptr<LogRangeIterator> override;
+  auto getNonEmptyLogConsumerIterator(LogIndex firstIdx) const
+      -> std::variant<std::unique_ptr<LogRangeIterator>, LogIndex> override;
 
  private:
   struct GuardedData {
     explicit GuardedData(LogIndex firstIndex);
     InMemoryLog _inMemoryLog;
     LogIndex _commitIndex{0};
+
+    auto getLogConsumerIterator(IStorageManager& storageManager,
+                                std::optional<LogRange> bounds) const
+        -> std::unique_ptr<LogRangeIterator>;
   };
   LoggerContext const _logContext;
   std::shared_ptr<ReplicatedLogMetrics> const _metrics;

--- a/arangod/Replication2/ReplicatedLog/Components/InMemoryLogManager.h
+++ b/arangod/Replication2/ReplicatedLog/Components/InMemoryLogManager.h
@@ -1,0 +1,55 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2023-2023 ArangoDB GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Tobias Gödderz
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "Basics/Guarded.h"
+#include "Replication2/ReplicatedLog/Components/IInMemoryLogManager.h"
+#include "Replication2/ReplicatedLog/InMemoryLog.h"
+#include "Replication2/ReplicatedLog/LogCommon.h"
+
+#include <memory>
+
+namespace arangodb::replication2::replicated_log {
+
+inline namespace comp {
+struct IStorageManager;
+
+struct InMemoryLogManager : IInMemoryLogManager {
+  explicit InMemoryLogManager(LogIndex firstIndex,
+                              std::shared_ptr<IStorageManager> storage);
+
+  auto getCommitIndex() const noexcept -> LogIndex override;
+  auto updateCommitIndex(LogIndex newIndex) noexcept -> LogIndex override;
+
+ private:
+  struct GuardedData {
+    explicit GuardedData(LogIndex firstIndex);
+    InMemoryLog _inMemoryLog;
+    LogIndex _commitIndex{0};
+  };
+  std::shared_ptr<IStorageManager> const _storageManager;
+  Guarded<GuardedData> _guardedData;
+};
+
+}  // namespace comp
+}  // namespace arangodb::replication2::replicated_log

--- a/arangod/Replication2/ReplicatedLog/Components/InMemoryLogManager.h
+++ b/arangod/Replication2/ReplicatedLog/Components/InMemoryLogManager.h
@@ -43,7 +43,9 @@ struct InMemoryLogManager : IInMemoryLogManager {
 
   auto getCommitIndex() const noexcept -> LogIndex override;
   void updateCommitIndex(LogIndex newIndex) noexcept override;
-
+  auto calculateCommitLag() const noexcept
+      -> std::chrono::duration<double, std::milli> override;
+  auto getSpearheadTermIndexPair() const noexcept -> TermIndexPair override;
   auto getInMemoryLog() const noexcept -> InMemoryLog override;
   auto appendLogEntry(std::variant<LogMetaPayload, LogPayload> payload,
                       LogTerm term,

--- a/arangod/Replication2/ReplicatedLog/Components/StorageManager.h
+++ b/arangod/Replication2/ReplicatedLog/Components/StorageManager.h
@@ -48,7 +48,7 @@ struct StorageManager : IStorageManager,
   auto getCommittedLogIterator(std::optional<LogRange> range) const
       -> std::unique_ptr<LogRangeIterator> override;
   auto getPersistedLogIterator(LogIndex first) const
-      -> std::unique_ptr<PersistedLogIterator>;
+      -> std::unique_ptr<PersistedLogIterator> override;
   auto getPersistedLogIterator(std::optional<LogRange> range) const
       -> std::unique_ptr<PersistedLogIterator>;
   auto getTermIndexMapping() const -> TermIndexMapping override;

--- a/arangod/Replication2/ReplicatedLog/LogLeader.cpp
+++ b/arangod/Replication2/ReplicatedLog/LogLeader.cpp
@@ -1163,7 +1163,7 @@ auto replicated_log::LogLeader::waitForIterator(LogIndex index)
     return std::visit(
         overload{
             [](std::unique_ptr<LogRangeIterator> iter)
-                -> WaitForIteratorFuture { return std::move(iter); },
+                -> WaitForIteratorFuture { return iter; },
             [this](LogIndex indexToWaitFor) -> WaitForIteratorFuture {
               // call here, otherwise we deadlock with waitFor
               return waitForIterator(indexToWaitFor);

--- a/arangod/Replication2/ReplicatedLog/LogLeader.h
+++ b/arangod/Replication2/ReplicatedLog/LogLeader.h
@@ -49,6 +49,7 @@
 #include "Replication2/ReplicatedLog/ReplicatedLog.h"
 #include "Scheduler/Scheduler.h"
 #include "Replication2/IScheduler.h"
+#include "Replication2/ReplicatedLog/Components/InMemoryLogManager.h"
 #include "Replication2/ReplicatedLog/Components/StorageManager.h"
 #include "Replication2/ReplicatedLog/Components/CompactionManager.h"
 
@@ -297,7 +298,7 @@ class LogLeader : public std::enable_shared_from_this<LogLeader>,
         -> std::pair<LogIndex, std::vector<algorithms::ParticipantState>>;
 
     [[nodiscard]] auto updateCommitIndexLeader(
-        LogIndex newIndex, std::shared_ptr<QuorumData> quorum)
+        LogIndex newCommitIndex, std::shared_ptr<QuorumData> quorum)
         -> ResolvedPromiseSet;
 
     [[nodiscard]] auto getInternalLogIterator(LogIndex firstIdx) const
@@ -330,7 +331,6 @@ class LogLeader : public std::enable_shared_from_this<LogLeader>,
     WaitForQueue _waitForQueue{};
     WaitForBag _waitForResignQueue;
     std::shared_ptr<QuorumData> _lastQuorum{};
-    LogIndex _commitIndex{0};
     bool _didResign{false};
     bool _leadershipEstablished{false};
     CommitFailReason _lastCommitFailReason;
@@ -353,6 +353,7 @@ class LogLeader : public std::enable_shared_from_this<LogLeader>,
   LogTerm const _currentTerm;
   LogIndex const _firstIndexOfCurrentTerm;
   std::shared_ptr<StorageManager> _storageManager;
+  std::shared_ptr<InMemoryLogManager> _inMemoryLogManager;
   std::shared_ptr<CompactionManager> _compactionManager;
   // _localFollower is const after construction
   std::shared_ptr<LocalFollower> _localFollower;

--- a/arangod/Replication2/ReplicatedLog/LogLeader.h
+++ b/arangod/Replication2/ReplicatedLog/LogLeader.h
@@ -128,8 +128,6 @@ class LogLeader : public std::enable_shared_from_this<LogLeader>,
   [[nodiscard]] auto waitForIterator(LogIndex index)
       -> WaitForIteratorFuture override;
 
-  [[nodiscard]] auto getReplicatedLogSnapshot() const -> InMemoryLog::log_type;
-
   // Triggers sending of appendEntries requests to all followers. This continues
   // until all participants are perfectly in sync, and will then stop.
   // Is usually called automatically after an insert, but can be called manually
@@ -325,7 +323,6 @@ class LogLeader : public std::enable_shared_from_this<LogLeader>,
         -> std::pair<futures::Future<futures::Unit>, DeferredAction>;
 
     LogLeader& _self;
-    InMemoryLog _inMemoryLog;
     std::unordered_map<ParticipantId, std::shared_ptr<FollowerInfo>>
         _follower{};
     WaitForQueue _waitForQueue{};

--- a/arangod/Replication2/ReplicatedLog/LogLeader.h
+++ b/arangod/Replication2/ReplicatedLog/LogLeader.h
@@ -299,12 +299,6 @@ class LogLeader : public std::enable_shared_from_this<LogLeader>,
         LogIndex newCommitIndex, std::shared_ptr<QuorumData> quorum)
         -> ResolvedPromiseSet;
 
-    [[nodiscard]] auto getInternalLogIterator(LogIndex firstIdx) const
-        -> std::unique_ptr<TypedLogIterator<InMemoryLogEntry>>;
-
-    [[nodiscard]] auto getLogConsumerIterator(std::optional<LogRange> bounds)
-        const -> std::unique_ptr<LogRangeIterator>;
-
     [[nodiscard]] auto getLocalStatistics() const -> LogStatistics;
 
     [[nodiscard]] auto createAppendEntriesRequest(

--- a/arangod/Replication2/ReplicatedLog/LogLeader.h
+++ b/arangod/Replication2/ReplicatedLog/LogLeader.h
@@ -305,9 +305,6 @@ class LogLeader : public std::enable_shared_from_this<LogLeader>,
         FollowerInfo& follower, TermIndexPair const& lastAvailableIndex) const
         -> std::pair<AppendEntriesRequest, TermIndexPair>;
 
-    [[nodiscard]] auto calculateCommitLag() const noexcept
-        -> std::chrono::duration<double, std::milli>;
-
     auto insertInternal(
         std::variant<LogMetaPayload, LogPayload>, bool waitForSync,
         std::optional<InMemoryLogEntry::clock::time_point> insertTp)

--- a/tests/Replication2/CMakeLists.txt
+++ b/tests/Replication2/CMakeLists.txt
@@ -25,6 +25,7 @@ set(ARANGODB_REPLICATION2_TEST_HELPER_SOURCES
   Mocks/DocumentStateMocks.cpp Mocks/DocumentStateMocks.h
   Mocks/MockVocbase.h
   Mocks/LeaderCommunicatorMock.h
+  Mocks/StorageManagerMock.h
   )
 
 

--- a/tests/Replication2/Mocks/StorageManagerMock.h
+++ b/tests/Replication2/Mocks/StorageManagerMock.h
@@ -1,0 +1,57 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2023-2023 ArangoDB GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Tobias Gödderz
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include <gmock/gmock.h>
+
+#include "Replication2/ReplicatedLog/Components/IStorageManager.h"
+#include "Replication2/ReplicatedLog/TermIndexMapping.h"
+
+namespace arangodb::replication2::test {
+
+struct StorageManagerMock
+    : arangodb::replication2::replicated_log::IStorageManager {
+  MOCK_METHOD(std::unique_ptr<
+                  arangodb::replication2::replicated_log::IStorageTransaction>,
+              transaction, (), (override));
+  MOCK_METHOD(std::unique_ptr<TypedLogRangeIterator<LogEntryView>>,
+              getCommittedLogIterator, (std::optional<LogRange>),
+              (const, override));
+  MOCK_METHOD(std::unique_ptr<PersistedLogIterator>, getPersistedLogIterator,
+              (LogIndex), (const, override));
+  MOCK_METHOD(arangodb::replication2::replicated_log::TermIndexMapping,
+              getTermIndexMapping, (), (const, override));
+  MOCK_METHOD(replicated_state::PersistedStateInfo, getCommittedMetaInfo, (),
+              (const, override));
+  MOCK_METHOD(
+      std::unique_ptr<
+          arangodb::replication2::replicated_log::IStateInfoTransaction>,
+      beginMetaInfoTrx, (), (override));
+  MOCK_METHOD(
+      Result, commitMetaInfoTrx,
+      (std::unique_ptr<
+          arangodb::replication2::replicated_log::IStateInfoTransaction>),
+      (override));
+};
+
+}  // namespace arangodb::replication2::test

--- a/tests/Replication2/ReplicatedLog/Components/CompactionManagerTest.cpp
+++ b/tests/Replication2/ReplicatedLog/Components/CompactionManagerTest.cpp
@@ -27,6 +27,7 @@
 #include "Replication2/ReplicatedLog/InMemoryLog.h"
 #include "Replication2/ReplicatedLog/TermIndexMapping.h"
 #include "Replication2/ReplicatedState/PersistedStateInfo.h"
+#include "Replication2/Mocks/StorageManagerMock.h"
 
 #include <Futures/Future.h>
 #include <Futures/Promise.h>
@@ -35,11 +36,10 @@
 
 using namespace arangodb;
 using namespace arangodb::replication2;
+using namespace arangodb::replication2::test;
 using namespace arangodb::replication2::replicated_log;
 
 namespace {
-
-struct StorageManagerMock;
 
 struct StorageTransactionMock : IStorageTransaction {
   MOCK_METHOD(LogRange, getLogBounds, (), (const, noexcept, override));
@@ -49,21 +49,6 @@ struct StorageTransactionMock : IStorageTransaction {
               (noexcept, override));
   MOCK_METHOD(futures::Future<Result>, appendEntries, (InMemoryLog),
               (noexcept, override));
-};
-
-struct StorageManagerMock : IStorageManager {
-  MOCK_METHOD(std::unique_ptr<IStorageTransaction>, transaction, (),
-              (override));
-  MOCK_METHOD(std::unique_ptr<TypedLogRangeIterator<LogEntryView>>,
-              getCommittedLogIterator, (std::optional<LogRange>),
-              (const, override));
-  MOCK_METHOD(TermIndexMapping, getTermIndexMapping, (), (const, override));
-  MOCK_METHOD(replicated_state::PersistedStateInfo, getCommittedMetaInfo, (),
-              (const, override));
-  MOCK_METHOD(std::unique_ptr<IStateInfoTransaction>, beginMetaInfoTrx, (),
-              (override));
-  MOCK_METHOD(Result, commitMetaInfoTrx,
-              (std::unique_ptr<IStateInfoTransaction>), (override));
 };
 
 }  // namespace

--- a/tests/Replication2/ReplicatedLog/Components/FollowerCommitManagerTest.cpp
+++ b/tests/Replication2/ReplicatedLog/Components/FollowerCommitManagerTest.cpp
@@ -31,27 +31,15 @@
 #include "Replication2/ReplicatedLog/ReplicatedLog.h"
 #include "Basics/Result.h"
 #include "Replication2/Mocks/SchedulerMocks.h"
+#include "Replication2/Mocks/StorageManagerMock.h"
 
 using namespace arangodb;
 using namespace arangodb::replication2;
+using namespace arangodb::replication2::test;
 using namespace arangodb::replication2::replicated_log;
 using namespace arangodb::replication2::replicated_log::comp;
 
 namespace {
-struct StorageManagerMock : IStorageManager {
-  MOCK_METHOD(std::unique_ptr<IStorageTransaction>, transaction, (),
-              (override));
-  MOCK_METHOD(std::unique_ptr<TypedLogRangeIterator<LogEntryView>>,
-              getCommittedLogIterator, (std::optional<LogRange>),
-              (const, override));
-  MOCK_METHOD(TermIndexMapping, getTermIndexMapping, (), (const, override));
-  MOCK_METHOD(replicated_state::PersistedStateInfo, getCommittedMetaInfo, (),
-              (const, override));
-  MOCK_METHOD(std::unique_ptr<IStateInfoTransaction>, beginMetaInfoTrx, (),
-              (override));
-  MOCK_METHOD(Result, commitMetaInfoTrx,
-              (std::unique_ptr<IStateInfoTransaction>), (override));
-};
 
 struct StateHandleManagerMock : IStateHandleManager {
   MOCK_METHOD(DeferredAction, updateCommitIndex, (LogIndex),

--- a/tests/Replication2/ReplicatedLog/Components/SnapshotManagerTest.cpp
+++ b/tests/Replication2/ReplicatedLog/Components/SnapshotManagerTest.cpp
@@ -34,6 +34,7 @@
 #include "Replication2/ReplicatedLog/ReplicatedLog.h"
 
 #include "Replication2/Mocks/LeaderCommunicatorMock.h"
+#include "Replication2/Mocks/StorageManagerMock.h"
 
 #if defined(__GNUC__)
 #pragma GCC diagnostic push
@@ -42,12 +43,11 @@
 
 using namespace arangodb;
 using namespace arangodb::replication2;
+using namespace arangodb::replication2::test;
 using namespace arangodb::replication2::replicated_log;
 using namespace arangodb::replication2::replicated_state;
 
 namespace {
-
-struct StorageManagerMock;
 
 struct StorageTransactionMock : IStorageTransaction {
   MOCK_METHOD(LogRange, getLogBounds, (), (const, noexcept, override));
@@ -61,21 +61,6 @@ struct StorageTransactionMock : IStorageTransaction {
 
 struct StateInfoTransactionMock : IStateInfoTransaction {
   MOCK_METHOD(InfoType&, get, (), (noexcept, override));
-};
-
-struct StorageManagerMock : IStorageManager {
-  MOCK_METHOD(std::unique_ptr<IStorageTransaction>, transaction, (),
-              (override));
-  MOCK_METHOD(std::unique_ptr<TypedLogRangeIterator<LogEntryView>>,
-              getCommittedLogIterator, (std::optional<LogRange>),
-              (const, override));
-  MOCK_METHOD(TermIndexMapping, getTermIndexMapping, (), (const, override));
-  MOCK_METHOD(replicated_state::PersistedStateInfo, getCommittedMetaInfo, (),
-              (const, override));
-  MOCK_METHOD(std::unique_ptr<IStateInfoTransaction>, beginMetaInfoTrx, (),
-              (override));
-  MOCK_METHOD(Result, commitMetaInfoTrx,
-              (std::unique_ptr<IStateInfoTransaction>), (override));
 };
 
 struct StateHandleManagerMock : IStateHandleManager {


### PR DESCRIPTION
### Scope & Purpose

Fix the following lock inversion, as detected by TSan in `StateManagerTest.get_leader_state_machine_early`:

```mermaid
graph LR
    RSM_LE["ReplicatedStateManager&lt;S>::leadershipEstablished"]
    LL_EAER["LogLeader::executeAppendEntriesRequests"]
    LL_EAER -.-> RSM_LE
    LSM_GSM["LeaderStateManager&lt;S>::getStateMachine()"]
    RSM_GL["ReplicatedStateManager&lt;S>::getLeader()"]
    RSM_GL -.-> LSM_GSM
    LL_GLCI["LogLeader::getLogConsumerIterator"]
    LSM_RE["LeaderStateManager&lt;S>::recoverEntries()"]
    LSM_RE -.-> LL_GLCI

    subgraph ReplicatedStateManager
        RSM_LE
        RSM_GL
    end
    subgraph LogLeader
        LL_EAER
        LL_GLCI
    end
    subgraph LeaderStateManager
        LSM_GSM
        LSM_RE
    end

    ReplicatedStateManager --> LeaderStateManager --> LogLeader --> ReplicatedStateManager
```

This is fixed by moving both `_commitIndex` and `_inMemoryLog` from the `LogLeader` into the newly introduced `InMemoryLogManager`, which gets a separate mutex. `getLogConsumerIterator()` is now implement by this, and doesn't acquire the LogLeader's mutex, which breaks the cycle.

- [X] :hankey: Bugfix
- [X] :hammer: Refactoring/simplification

