### PR TITLE
testing: on the client we now only have the global instanceManager object anymore.

### DIFF
--- a/js/client/modules/@arangodb/test-helper.js
+++ b/js/client/modules/@arangodb/test-helper.js
@@ -104,7 +104,7 @@ exports.debugSetFailAt = function (endpoint, failAt) {
     reconnectRetry(endpoint, db._name(), "root", "");
     let res = arango.PUT_RAW('/_admin/debug/failat/' + failAt, {});
     if (res.parsedBody !== true) {
-      throw "Error setting failure point + " + res;
+      throw `Error setting failure point on ${endpoint}: "${res}"`;
     }
     return true;
   } finally {

--- a/tests/js/client/communication/test-communication.js
+++ b/tests/js/client/communication/test-communication.js
@@ -64,8 +64,7 @@ const debug = function (text) {
 
 function getEndpointById(id) {
   const toEndpoint = (d) => (d.endpoint);
-  const instanceInfo = JSON.parse(internal.env.INSTANCEINFO);
-  return instanceInfo.arangods.filter((d) => (d.id === id))
+  return global.instanceManager.arangods.filter((d) => (d.id === id))
     .map(toEndpoint)
     .map(endpointToURL)[0];
 }
@@ -239,8 +238,7 @@ function CommunicationSuite() {
       return 'http' + endpoint.substr(pos);
     };
 
-    const instanceInfo = JSON.parse(internal.env.INSTANCEINFO);
-    return instanceInfo.arangods.filter(isType)
+    return global.instanceManager.arangods.filter(isType)
       .map(toEndpoint)
       .map(endpointToURL);
   }


### PR DESCRIPTION
### Scope & Purpose

the runInClient implementation dropped to serialize the instance manager.
Hence tests must now use the `global.instanceManager` to work with instances.

- [x] :hankey: Bugfix
