### PR TITLE
[CINFRA] Disabled transaction tests

### DIFF
--- a/tests/js/client/shell/transaction/shell-transaction.js
+++ b/tests/js/client/shell/transaction/shell-transaction.js
@@ -5699,9 +5699,12 @@ if (isReplication2Enabled) {
     transactionOverlapUniqueIndexSuiteV2,
   ];
 
+  // TODO this is temporary until we update replication2
+  /*
   for (const suite of suites) {
     jsunity.run(suite);
   }
+   */
 }
 
 return jsunity.done();


### PR DESCRIPTION
### Scope & Purpose

It's best to disable replication2 transaction tests for now, until we update replication2.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

