### PR TITLE
[GORDO-1647] Switch on actors per default in pregel

### DIFF
--- a/arangod/Pregel/PregelOptions.h
+++ b/arangod/Pregel/PregelOptions.h
@@ -98,7 +98,7 @@ struct PregelOptions {
   GraphSource graphSource;
   // A switch between running pregel with or without actors
   // Can be deleted if we finished refactoring to use only actors
-  bool useActors = false;
+  bool useActors = true;
 };
 
 struct TTL {

--- a/arangod/Pregel/REST/RestControlPregelHandler.cpp
+++ b/arangod/Pregel/REST/RestControlPregelHandler.cpp
@@ -126,6 +126,10 @@ RestControlPregelHandler::forwardingTarget() {
 namespace {
 auto extractPregelOptions(VPackSlice body) -> ResultT<pregel::PregelOptions> {
   // emulate 3.10 pregel API
+  // A switch between running pregel with or without actors
+  // Can be deleted if we finished refactoring to use only actors
+  auto withActors =
+      basics::VelocyPackHelper::getBooleanValue(body, "actors", true);
   // algorithm
   std::string algorithm =
       VelocyPackHelper::getStringValue(body, "algorithm", StaticStrings::Empty);
@@ -158,7 +162,8 @@ auto extractPregelOptions(VPackSlice body) -> ResultT<pregel::PregelOptions> {
         .graphSource = {{pregel::GraphCollectionNames{
                             .vertexCollections = vertexCollections,
                             .edgeCollections = edgeCollections}},
-                        {}}};
+                        {}},
+        .useActors = withActors};
   } else {
     auto gs = VelocyPackHelper::getStringValue(body, "graphName", "");
     if ("" == gs) {
@@ -167,7 +172,8 @@ auto extractPregelOptions(VPackSlice body) -> ResultT<pregel::PregelOptions> {
     return pregel::PregelOptions{
         .algorithm = algorithm,
         .userParameters = parameterBuilder,
-        .graphSource = {{pregel::GraphName{.graph = gs}}, {}}};
+        .graphSource = {{pregel::GraphName{.graph = gs}}, {}},
+        .useActors = withActors};
   }
 
   // this should be used for a more restrictive pregel API

--- a/arangod/Pregel/REST/RestOptions.h
+++ b/arangod/Pregel/REST/RestOptions.h
@@ -49,7 +49,7 @@ auto inspect(Inspector& f, RestGeneralOptions& x) {
       f.field("edgeCollectionRestrictions", x.edgeCollectionRestrictions)
           .fallback(
               std::unordered_map<std::string, std::vector<std::string>>{}),
-      f.field("actors", x.useActors).fallback(false));
+      f.field("actors", x.useActors).fallback(true));
 }
 
 struct RestCollectionSettings {

--- a/js/common/modules/@arangodb/graph/pregel-test-helpers.js
+++ b/js/common/modules/@arangodb/graph/pregel-test-helpers.js
@@ -59,9 +59,9 @@ const runInFatalError = (stats) => stats.state === "fatal error";
 const runFinishedUnsuccessfully = (stats) => runCanceled(stats) || runInFatalError(stats);
 const runFinished = (stats) => runFinishedSuccessfully(stats) || runFinishedUnsuccessfully(stats);
 
-const waitUntilRunFinishedSuccessfully = function (pid, maxWaitSeconds = 120, sleepIntervalSeconds = 0.2) {
+const waitUntilRunStart = function (pid, maxWaitSeconds = 120, sleepIntervalSeconds = 0.2) {
   let wakeupsLeft = maxWaitSeconds / sleepIntervalSeconds;
-  var status;
+  let status;
   // Note: This is added because there is a race between the conductor for pid
   // being created and the user asking for the status of a pregel run for the
   // first time.
@@ -80,6 +80,13 @@ const waitUntilRunFinishedSuccessfully = function (pid, maxWaitSeconds = 120, sl
       return;
     }
   } while(status === undefined);
+
+  return wakeupsLeft;
+};
+
+const waitUntilRunFinishedSuccessfully = function (pid, maxWaitSeconds = 120, sleepIntervalSeconds = 0.2) {
+  let wakeupsLeft = waitUntilRunStart(pid, maxWaitSeconds, sleepIntervalSeconds);
+  let status;
   do {
     internal.sleep(sleepIntervalSeconds);
     try {
@@ -1831,6 +1838,7 @@ exports.assertAlmostEquals = assertAlmostEquals;
 exports.runFinished = runFinished;
 exports.runCanceled = runCanceled;
 exports.runFinishedSuccessfully = runFinishedSuccessfully;
+exports.waitUntilRunStart = waitUntilRunStart;
 exports.waitUntilRunFinishedSuccessfully = waitUntilRunFinishedSuccessfully;
 exports.waitForResultsBeeingGarbageCollected = waitForResultsBeeingGarbageCollected;
 exports.uniquePregelResults = uniquePregelResults;

--- a/tests/js/common/shell/shell-pregel-random.js
+++ b/tests/js/common/shell/shell-pregel-random.js
@@ -183,7 +183,7 @@ function randomTestSuite() {
     testCancelWithStringId: function () {
       let pid = pregel.start("hits", graphName, { threshold: 0.0000001, resultField: "score", store: false });
       assertTrue(typeof pid === "string");
-      pregelTestHelpers.waitUntilRunFinishedSuccessfully(pid);
+      pregelTestHelpers.waitUntilRunStart(pid);
       checkCancel(pid);
     },
 

--- a/tests/js/common/shell/shell-pregel-random.js
+++ b/tests/js/common/shell/shell-pregel-random.js
@@ -46,7 +46,7 @@ function randomTestSuite() {
 
   const n = 20000; // vertices
   const m = 300000; // edges
-  
+
   let checkCancel = function(pid) {
     pregel.cancel(pid);
     let i = 10000;
@@ -75,7 +75,7 @@ function randomTestSuite() {
 
     setUpAll: function () {
 
-      console.log("Beginning to insert test data with " + n + 
+      console.log("Beginning to insert test data with " + n +
                   " vertices, " + m + " edges");
 
       var exists = graph_module._list().indexOf("random") !== -1;
@@ -166,32 +166,32 @@ function randomTestSuite() {
       assertTrue(typeof pid === "string");
       pregelTestHelpers.waitUntilRunFinishedSuccessfully(Number(pid));
     },
-    
+
     testStatusWithStringId: function () {
       let pid = pregel.start("hits", graphName, { threshold: 0.0000001, resultField: "score", store: true });
       assertTrue(typeof pid === "string");
       pregelTestHelpers.waitUntilRunFinishedSuccessfully(pid);
     },
-    
+
     testCancelWithNumericId: function () {
       let pid = pregel.start("hits", graphName, { threshold: 0.0000001, resultField: "score", store: false });
       assertTrue(typeof pid === "string");
-      pregelTestHelpers.waitUntilRunFinishedSuccessfully(pid);
+      pregelTestHelpers.waitUntilRunStart(pid);
       checkCancel(Number(pid));
     },
-    
+
     testCancelWithStringId: function () {
       let pid = pregel.start("hits", graphName, { threshold: 0.0000001, resultField: "score", store: false });
       assertTrue(typeof pid === "string");
       pregelTestHelpers.waitUntilRunFinishedSuccessfully(pid);
       checkCancel(pid);
     },
-    
+
     test_garbage_collects_job: function () {
       const ttl = 15;
       let pid = pregel.start("hits", graphName, { threshold: 0.0000001, resultField: "score", store: false, ttl: ttl });
       assertTrue(typeof pid === "string");
-          
+
       let stats = pregel.status(pid);
       assertTrue(stats.hasOwnProperty('id'));
       assertEqual(stats.id, pid);

--- a/tests/js/common/shell/shell-pregel-random.js
+++ b/tests/js/common/shell/shell-pregel-random.js
@@ -192,6 +192,7 @@ function randomTestSuite() {
       let pid = pregel.start("hits", graphName, { threshold: 0.0000001, resultField: "score", store: false, ttl: ttl });
       assertTrue(typeof pid === "string");
 
+      pregelTestHelpers.waitUntilRunStart(pid);
       let stats = pregel.status(pid);
       assertTrue(stats.hasOwnProperty('id'));
       assertEqual(stats.id, pid);


### PR DESCRIPTION
With this PR, pregel tests will run using actors instead of the old pregel implementation. This PR is used to fix all the red tests when using actors.