### PR TITLE
[CINFRA-735] Fix lock inversion on the Leader Log/State

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -71,7 +71,8 @@
       "name": "tsan",
       "cacheVariables": {
         "CMAKE_CXX_FLAGS": "-fsanitize=thread",
-        "CMAKE_C_FLAGS": "-fsanitize=thread"
+        "CMAKE_C_FLAGS": "-fsanitize=thread",
+        "USE_JEMALLOC": "Off"
       }
     },
     {

--- a/arangod/Replication2/ReplicatedLog/Components/InMemoryLogManager.cpp
+++ b/arangod/Replication2/ReplicatedLog/Components/InMemoryLogManager.cpp
@@ -26,6 +26,7 @@
 #include "Metrics/Gauge.h"
 #include "Metrics/Histogram.h"
 #include "Metrics/LogScale.h"
+#include "Replication2/Exceptions/ParticipantResignedException.h"
 #include "Replication2/ReplicatedLog/Components/IStorageManager.h"
 #include "Replication2/ReplicatedLog/ReplicatedLogMetrics.h"
 #include "Replication2/ReplicatedLog/TermIndexMapping.h"
@@ -92,6 +93,15 @@ auto InMemoryLogManager::appendLogEntry(
     InMemoryLogEntry::clock::time_point insertTp, bool waitForSync)
     -> LogIndex {
   return _guardedData.doUnderLock([&](auto& data) -> LogIndex {
+    if (data._resigned) {
+      throw ParticipantResignedException(
+          TRI_ERROR_REPLICATION_REPLICATED_LOG_LEADER_RESIGNED, ADB_HERE);
+    }
+
+    // TODO for now only waitForSync=true is supported.
+    waitForSync = true;  // by setting this to true, the waitForSync flag is set
+                         // for all log entries, independent of the log config.
+
     auto const index = data._inMemoryLog.getNextIndex();
 
     auto logEntry = InMemoryLogEntry(
@@ -253,6 +263,9 @@ auto InMemoryLogManager::getTermOfIndex(LogIndex logIndex) const noexcept
               logIndex);
         }
       });
+}
+void InMemoryLogManager::resign() && noexcept {
+  _guardedData.getLockedGuard()->_resigned = true;
 }
 
 InMemoryLogManager::GuardedData::GuardedData(LogIndex firstIndex)

--- a/arangod/Replication2/ReplicatedLog/Components/InMemoryLogManager.h
+++ b/arangod/Replication2/ReplicatedLog/Components/InMemoryLogManager.h
@@ -60,11 +60,14 @@ struct InMemoryLogManager : IInMemoryLogManager {
   auto getNonEmptyLogConsumerIterator(LogIndex firstIdx) const
       -> std::variant<std::unique_ptr<LogRangeIterator>, LogIndex> override;
 
+  void resign() && noexcept;
+
  private:
   struct GuardedData {
     explicit GuardedData(LogIndex firstIndex);
     InMemoryLog _inMemoryLog;
     LogIndex _commitIndex{0};
+    bool _resigned = false;
 
     auto getLogConsumerIterator(IStorageManager& storageManager,
                                 std::optional<LogRange> bounds) const

--- a/arangod/Replication2/ReplicatedLog/LogLeader.h
+++ b/arangod/Replication2/ReplicatedLog/LogLeader.h
@@ -305,11 +305,6 @@ class LogLeader : public std::enable_shared_from_this<LogLeader>,
         FollowerInfo& follower, TermIndexPair const& lastAvailableIndex) const
         -> std::pair<AppendEntriesRequest, TermIndexPair>;
 
-    auto insertInternal(
-        std::variant<LogMetaPayload, LogPayload>, bool waitForSync,
-        std::optional<InMemoryLogEntry::clock::time_point> insertTp)
-        -> LogIndex;
-
     [[nodiscard]] auto waitForResign()
         -> std::pair<futures::Future<futures::Unit>, DeferredAction>;
 

--- a/lib/Inspection/include/Inspection/SaveInspectorBase.h
+++ b/lib/Inspection/include/Inspection/SaveInspectorBase.h
@@ -218,7 +218,7 @@ struct SaveInspectorBase : InspectorBase<Derived, Context> {
     if constexpr (Idx < End) {
       return process(this->self(), std::get<Idx>(data))  //
              | [&]() {
-                 return this->self().processTuple<Idx + 1, End>(data);
+                 return this->self().template processTuple<Idx + 1, End>(data);
                };  //
     } else {
       return Status::Success{};


### PR DESCRIPTION
### Scope & Purpose

Fix the following lock inversion:

```mermaid
graph LR
    LL_I["LogLeader::insert"]
    LSM_RE["LeaderStateManager&lt;S>::recoverEntries()"]
    LSM_RE -.-> LL_I

    RSM_LE["ReplicatedStateManager&lt;S>::leadershipEstablished"]
    LL_EAER["LogLeader::executeAppendEntriesRequests"]
    LL_EAER -.-> RSM_LE

    LSM_GSM["LeaderStateManager&lt;S>::getStateMachine()"]
    RSM_GL["ReplicatedStateManager&lt;S>::getLeader()"]
    RSM_GL -.-> LSM_GSM
    
    subgraph LeaderStateManager
        LSM_RE
        LSM_GSM
    end
    subgraph ReplicatedStateManager
        RSM_LE
        RSM_GL
    end
    subgraph LogLeader
        LL_I
        LL_EAER
    end
    LeaderStateManager --> LogLeader --> ReplicatedStateManager --> LeaderStateManager
```

This PR removes the need for the LogLeader to acquire its mutex in `insert()`. Most of the work was moved to the `InMemoryLogManager` in #18578 already: Now `InMemoryLogManager` is resigned explicitly, so it can prevent inserts after.

- [X] :hankey: Bugfix
- [X] :hammer: Refactoring/simplification
