### PR TITLE
add possibility to provide Arguments to cluster instances similar as to the starter

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -411,6 +411,7 @@ _Hint_: You shouldn't lean on these variables in your Foxx services.
 To debug AQL execution blocks, two steps are required:
 
 - turn on logging for queries using `--extraArgs:log.level queries=info`
+- divert this facilities logoutput into individual files: `--extraArgs --log.output queries file://@ARANGODB_SERVER_DIR@/arangod_queries.log`
 - send queries enabling block debugging: `db._query('RETURN 1', {}, { profile: 4 })`
 
 You now will get log entries with the contents being passed between the blocks.

--- a/js/client/modules/@arangodb/testutils/instance.js
+++ b/js/client/modules/@arangodb/testutils/instance.js
@@ -656,6 +656,7 @@ class instance {
       print(Date() + ' starting process ' + cmd + ' with arguments: ' + JSON.stringify(argv));
     }
 
+    process.env['ARANGODB_SERVER_DIR'] = this.rootDir;
     return executeExternal(cmd, argv, false, pu.coverageEnvironment());
   }
   // //////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
### Scope & Purpose

in clusters one may want to divert log facilities into individual files. Use similar mechanism as the starter provides

- [x] :pizza: New feature
