### PR TITLE
Remove strange output in failed test

### DIFF
--- a/scripts/test/async_client.py
+++ b/scripts/test/async_client.py
@@ -169,6 +169,8 @@ def convert_result(result_array):
 
 def add_message_to_report(params, string, print_it=True, add_to_error=False):
     """add a message from python to the report strings/files + print it"""
+    pass
+"""
     oskar = "OSKAR"
     count = int(80 / len(oskar))
     datestr = f"  {datetime.now()} - "
@@ -191,7 +193,7 @@ def add_message_to_report(params, string, print_it=True, add_to_error=False):
         params["output"].flush()
     sys.stdout.flush()
     return string + "\n"
-
+"""
 
 def kill_children(identifier, params, children):
     """slash all processes enlisted in children - if they still exist"""


### PR DESCRIPTION
### Scope & Purpose

Output of tests look like endless
```
OSKAROSKAROSKAROSKAROSKAROSKAROSKAROSKAROSKAROSKAROSKAROSKAROSKAROSKAROSKAROSKAR
OSKAR  2023-04-02 01:26:52.391568 - HIGH SYSTEM LOAD!     40.78 >     40.32 OSKAR
OSKAROSKAROSKAROSKAROSKAROSKAROSKAROSKAROSKAROSKAROSKAROSKAROSKAROSKAROSKAROSKAR
```
[FAIL_chaos.log](https://github.com/arangodb/arangodb/files/11170166/FAIL_chaos.log)

Please if it's necessary write it to separate file

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: *(Please link PR)*
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

