### PR TITLE
[PREGEL] Make pregel API again backwards compatible to 3.10

### DIFF
--- a/arangod/Pregel/REST/RestControlPregelHandler.cpp
+++ b/arangod/Pregel/REST/RestControlPregelHandler.cpp
@@ -121,6 +121,67 @@ RestControlPregelHandler::forwardingTarget() {
   return {std::make_pair(std::move(coordinatorId), false)};
 }
 
+namespace {
+auto extractPregelOptions(VPackSlice body) -> ResultT<pregel::PregelOptions> {
+  // emulate 3.10 pregel API
+  // algorithm
+  std::string algorithm =
+      VelocyPackHelper::getStringValue(body, "algorithm", StaticStrings::Empty);
+  if ("" == algorithm) {
+    return Result{TRI_ERROR_HTTP_NOT_FOUND, "invalid algorithm"};
+  }
+  // extract the parameters
+  auto parameters = body.get("params");
+  if (!parameters.isObject()) {
+    parameters = VPackSlice::emptyObjectSlice();
+  }
+  VPackBuilder parameterBuilder;
+  parameterBuilder.add(parameters);
+  // extract the collections
+  auto vc = body.get("vertexCollections");
+  auto ec = body.get("edgeCollections");
+  pregel::PregelOptions options;
+  if (vc.isArray() && ec.isArray()) {
+    std::vector<std::string> vertexCollections;
+    for (auto v : VPackArrayIterator(vc)) {
+      vertexCollections.push_back(v.copyString());
+    }
+    std::vector<std::string> edgeCollections;
+    for (auto e : VPackArrayIterator(ec)) {
+      edgeCollections.push_back(e.copyString());
+    }
+    return pregel::PregelOptions{
+        .algorithm = algorithm,
+        .userParameters = parameterBuilder,
+        .graphSource = {{pregel::GraphCollectionNames{
+                            .vertexCollections = vertexCollections,
+                            .edgeCollections = edgeCollections}},
+                        {}}};
+  } else {
+    auto gs = VelocyPackHelper::getStringValue(body, "graphName", "");
+    if ("" == gs) {
+      return Result{TRI_ERROR_BAD_PARAMETER, "expecting graphName as string"};
+    }
+    return pregel::PregelOptions{
+        .algorithm = algorithm,
+        .userParameters = parameterBuilder,
+        .graphSource = {{pregel::GraphName{.graph = gs}}, {}}};
+  }
+
+  // this should be used for a more restrictive pregel API
+  // that would make more sense
+  // auto restOptions =
+  // inspection::deserializeWithErrorT<pregel::RestOptions>(
+  //     velocypack::SharedSlice(velocypack::SharedSlice{}, body));
+  // if (!restOptions.ok()) {
+  //   return Result{TRI_ERROR_HTTP_NOT_FOUND,
+  //                 fmt::format("Given pregel options are invalid: {}",
+  //                             restOptions.error().error())};
+  // }
+  // return std::move(restOptions).get().options();
+}
+}  // namespace
+
 void RestControlPregelHandler::startExecution() {
   bool parseSuccess = false;
   VPackSlice body = this->parseVPackBody(parseSuccess);
@@ -129,15 +190,18 @@ void RestControlPregelHandler::startExecution() {
     return;
   }
 
-  auto restOptions = inspection::deserializeWithErrorT<pregel::RestOptions>(
-      velocypack::SharedSlice(velocypack::SharedSlice{}, body));
-  if (!restOptions.ok()) {
-    generateError(rest::ResponseCode::NOT_FOUND, TRI_ERROR_HTTP_NOT_FOUND,
-                  restOptions.error().error());
+  auto options = extractPregelOptions(std::move(body));
+  if (options.fail()) {
+    if (options.errorNumber() == TRI_ERROR_HTTP_NOT_FOUND) {
+      generateError(rest::ResponseCode::NOT_FOUND, options.errorNumber(),
+                    options.errorMessage());
+      return;
+    }
+    generateError(rest::ResponseCode::BAD, options.errorNumber(),
+                  options.errorMessage());
+    return;
   }
-  auto options = std::move(restOptions).get().options();
-
-  auto res = _pregel.startExecution(_vocbase, options);
+  auto res = _pregel.startExecution(_vocbase, options.get());
   if (res.fail()) {
     generateError(res.result());
     return;


### PR DESCRIPTION
We made the pregel API in devel more restrictive because some values did not at all make sense to use (i.e.g you should either give a graph OR vertex and edge collections where pregel should run on, not both).
But we don't want any changes in the API in 3.11, therefore this is reverted with this PR.