### PR TITLE
[GORDO-1619] Fix parallelism for processing vertices

### DIFF
--- a/arangod/Pregel/Iterators.h
+++ b/arangod/Pregel/Iterators.h
@@ -23,6 +23,8 @@
 
 #pragma once
 
+#include <cstddef>
+
 namespace arangodb::pregel {
 
 template<typename M>

--- a/arangod/Pregel/Statistics.h
+++ b/arangod/Pregel/Statistics.h
@@ -41,6 +41,10 @@ struct MessageStats {
 
   MessageStats() = default;
   MessageStats(size_t s, size_t r) : sendCount(s), receivedCount(r) {}
+  MessageStats(size_t s, size_t r, size_t memoryBytesUsedForMessages)
+      : sendCount(s),
+        receivedCount(r),
+        memoryBytesUsedForMessages(memoryBytesUsedForMessages) {}
 
   void accumulate(MessageStats const& other) {
     sendCount += other.sendCount;

--- a/arangod/Pregel/Worker/CMakeLists.txt
+++ b/arangod/Pregel/Worker/CMakeLists.txt
@@ -1,3 +1,4 @@
 target_sources(arango_pregel PRIVATE
+  VertexProcessor.cpp
   WorkerConfig.cpp
   Worker.cpp)

--- a/arangod/Pregel/Worker/VertexProcessor.cpp
+++ b/arangod/Pregel/Worker/VertexProcessor.cpp
@@ -1,0 +1,133 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2023 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Markus Pfeiffer
+////////////////////////////////////////////////////////////////////////////////
+
+#include "VertexProcessor.h"
+
+#include "Pregel/Algos/ColorPropagation/ColorPropagationValue.h"
+#include "Pregel/Algos/DMID/DMIDValue.h"
+#include "Pregel/Algos/DMID/DMIDMessage.h"
+#include "Pregel/Algos/EffectiveCloseness/ECValue.h"
+#include "Pregel/Algos/HITS/HITSValue.h"
+#include "Pregel/Algos/HITSKleinberg/HITSKleinbergValue.h"
+#include "Pregel/Algos/LabelPropagation/LPValue.h"
+#include "Pregel/Algos/SCC/SCCValue.h"
+#include "Pregel/Algos/SLPA/SLPAValue.h"
+#include "Pregel/Algos/WCC/WCCValue.h"
+
+using namespace arangodb::pregel;
+
+namespace arangodb::pregel {
+
+template<typename V, typename E, typename M>
+VertexProcessor<V, E, M>::VertexProcessor(
+    std::shared_ptr<WorkerConfig const> workerConfig,
+    std::unique_ptr<Algorithm<V, E, M>>& algorithm,
+    std::unique_ptr<WorkerContext>& workerContext,
+    std::unique_ptr<MessageCombiner<M>>& messageCombiner,
+    std::unique_ptr<MessageFormat<M>>& messageFormat) {
+  if (messageCombiner != nullptr) {
+    localMessageCache = std::make_shared<CombiningInCache<M>>(
+        std::set<PregelShard>{}, messageFormat.get(), messageCombiner.get());
+    outCache = std::make_shared<CombiningOutCache<M>>(
+        workerConfig, messageFormat.get(), messageCombiner.get());
+  } else {
+    localMessageCache = std::make_shared<ArrayInCache<M>>(
+        std::set<PregelShard>{}, messageFormat.get());
+    outCache =
+        std::make_shared<ArrayOutCache<M>>(workerConfig, messageFormat.get());
+  }
+
+  outCache->setBatchSize(messageBatchSize);
+  outCache->setLocalCache(localMessageCache.get());
+
+  workerAggregator = std::make_unique<AggregatorHandler>(algorithm.get());
+
+  vertexComputation = std::shared_ptr<VertexComputation<V, E, M>>(
+      algorithm->createComputation(workerConfig));
+  vertexComputation->_gss = workerConfig->globalSuperstep();
+  vertexComputation->_lss = workerConfig->localSuperstep();
+  vertexComputation->_context = workerContext.get();
+  vertexComputation->_readAggregators = workerContext->_readAggregators.get();
+
+  vertexComputation->_writeAggregators = workerAggregator.get();
+  vertexComputation->_cache = outCache.get();
+}
+
+template<typename V, typename E, typename M>
+VertexProcessor<V, E, M>::~VertexProcessor() {}
+
+template<typename V, typename E, typename M>
+auto VertexProcessor<V, E, M>::process(Vertex<V, E>* vertexEntry,
+                                       MessageIterator<M> messages) -> void {
+  messagesReceived += messages.size();
+  memoryBytesUsedForMessages += messages.size() * sizeof(M);
+
+  if (messages.size() > 0 || vertexEntry->active()) {
+    vertexComputation->_vertexEntry = vertexEntry;
+    vertexComputation->compute(messages);
+    if (vertexEntry->active()) {
+      activeCount++;
+    }
+  }
+  verticesProcessed += 1;
+}
+
+template<typename V, typename E, typename M>
+auto VertexProcessor<V, E, M>::result() -> VertexProcessorResult {
+  return VertexProcessorResult{
+      .activeCount = activeCount,
+      .workerAggregator = std::move(workerAggregator),
+      .messageStats = MessageStats(outCache->sendCount(), messagesReceived,
+                                   memoryBytesUsedForMessages)};
+}
+
+}  // namespace arangodb::pregel
+
+// template types to create
+template struct arangodb::pregel::VertexProcessor<int64_t, int64_t, int64_t>;
+template struct arangodb::pregel::VertexProcessor<uint64_t, uint8_t, uint64_t>;
+template struct arangodb::pregel::VertexProcessor<float, float, float>;
+template struct arangodb::pregel::VertexProcessor<double, float, double>;
+template struct arangodb::pregel::VertexProcessor<float, uint8_t, float>;
+
+// custom algorithm types
+template struct arangodb::pregel::VertexProcessor<uint64_t, uint64_t,
+                                                  SenderMessage<uint64_t>>;
+template struct arangodb::pregel::VertexProcessor<algos::WCCValue, uint64_t,
+                                                  SenderMessage<uint64_t>>;
+template struct arangodb::pregel::VertexProcessor<algos::SCCValue, int8_t,
+                                                  SenderMessage<uint64_t>>;
+template struct arangodb::pregel::VertexProcessor<algos::HITSValue, int8_t,
+                                                  SenderMessage<double>>;
+template struct arangodb::pregel::VertexProcessor<
+    algos::HITSKleinbergValue, int8_t, SenderMessage<double>>;
+template struct arangodb::pregel::VertexProcessor<algos::ECValue, int8_t,
+                                                  HLLCounter>;
+template struct arangodb::pregel::VertexProcessor<algos::DMIDValue, float,
+                                                  DMIDMessage>;
+template struct arangodb::pregel::VertexProcessor<algos::LPValue, int8_t,
+                                                  uint64_t>;
+template struct arangodb::pregel::VertexProcessor<algos::SLPAValue, int8_t,
+                                                  uint64_t>;
+template struct arangodb::pregel::VertexProcessor<
+    algos::ColorPropagationValue, int8_t, algos::ColorPropagationMessageValue>;

--- a/arangod/Pregel/Worker/VertexProcessor.h
+++ b/arangod/Pregel/Worker/VertexProcessor.h
@@ -1,0 +1,80 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2023 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Markus Pfeiffer
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include <Pregel/Algorithm.h>
+#include <Pregel/Iterators.h>
+#include <Pregel/MessageCombiner.h>
+#include <Pregel/GraphStore/Quiver.h>
+#include <Pregel/Worker/WorkerConfig.h>
+#include <Pregel/IncomingCache.h>
+#include <Pregel/OutgoingCache.h>
+#include <Pregel/VertexComputation.h>
+#include <Pregel/WorkerContext.h>
+
+namespace arangodb::pregel {
+
+struct VertexProcessorResult {
+  uint64_t activeCount;
+  std::unique_ptr<AggregatorHandler> workerAggregator;
+  MessageStats messageStats;
+};
+//
+// A vertex processor is a means to combine all infrastructure needed to
+// process batches of vertices; this is employed in Worker.cpp
+// to create multiple fibers to process vertices.
+//
+// A vertex processor is designed and supposed to run as a single thread of
+// computation
+//
+template<typename V, typename E, typename M>
+struct VertexProcessor {
+  VertexProcessor(std::shared_ptr<WorkerConfig const> workerConfig,
+                  std::unique_ptr<Algorithm<V, E, M>>& algorithm,
+                  std::unique_ptr<WorkerContext>& workerContext,
+                  std::unique_ptr<MessageCombiner<M>>& messageCombiner,
+                  std::unique_ptr<MessageFormat<M>>& messageFormat);
+  ~VertexProcessor();
+
+  auto process(Vertex<V, E>* vertexEntry, MessageIterator<M> messages) -> void;
+  [[nodiscard]] auto result() -> VertexProcessorResult;
+
+  // aggregators
+  size_t activeCount = 0;
+  size_t messagesReceived = 0;
+  size_t memoryBytesUsedForMessages = 0;
+  size_t verticesProcessed = 0;
+
+  std::shared_ptr<OutCache<M>> outCache;
+  // The outCache handles dispatching messages and will
+  // queue messages that go to shards deemed local into
+  // the localMessageCache
+  std::shared_ptr<InCache<M>> localMessageCache;
+  std::shared_ptr<VertexComputation<V, E, M>> vertexComputation;
+  std::unique_ptr<AggregatorHandler> workerAggregator;
+
+  uint32_t messageBatchSize = 500;
+};
+
+}  // namespace arangodb::pregel

--- a/arangod/Pregel/Worker/Worker.cpp
+++ b/arangod/Pregel/Worker/Worker.cpp
@@ -41,6 +41,7 @@
 #include "Pregel/GraphStore/GraphStorer.h"
 #include "Pregel/GraphStore/GraphVPackBuilderStorer.h"
 #include "Pregel/Worker/Messages.h"
+#include "Pregel/Worker/VertexProcessor.h"
 #include "Pregel/Worker/Worker.h"
 #include "Pregel/IncomingCache.h"
 #include "Pregel/OutgoingCache.h"
@@ -120,8 +121,6 @@ Worker<V, E, M>::Worker(TRI_vocbase_t& vocbase, Algorithm<V, E, M>* algo,
     _writeCache = new ArrayInCache<M>(_config->localPregelShardIDs(),
                                       _messageFormat.get());
   }
-
-  _initializeMessageCaches();
 }
 
 template<typename V, typename E, typename M>
@@ -131,40 +130,10 @@ Worker<V, E, M>::~Worker() {
       std::chrono::milliseconds(50));  // wait for threads to die
   delete _readCache;
   delete _writeCache;
-  for (InCache<M>* cache : _inCaches) {
-    delete cache;
-  }
-  for (OutCache<M>* cache : _outCaches) {
-    delete cache;
-  }
   _writeCache = nullptr;
 
   _feature.metrics()->pregelWorkersNumber->fetch_sub(1);
   _feature.metrics()->pregelMemoryUsedForGraph->fetch_sub(0);
-}
-
-template<typename V, typename E, typename M>
-void Worker<V, E, M>::_initializeMessageCaches() {
-  const size_t p = _magazine.size();
-  if (_messageCombiner) {
-    for (size_t i = 0; i < p; i++) {
-      auto incoming = std::make_unique<CombiningInCache<M>>(
-          std::set<PregelShard>{}, _messageFormat.get(),
-          _messageCombiner.get());
-      _inCaches.push_back(incoming.get());
-      _outCaches.push_back(new CombiningOutCache<M>(
-          _config, _messageFormat.get(), _messageCombiner.get()));
-      incoming.release();
-    }
-  } else {
-    for (size_t i = 0; i < p; i++) {
-      auto incoming = std::make_unique<ArrayInCache<M>>(std::set<PregelShard>{},
-                                                        _messageFormat.get());
-      _inCaches.push_back(incoming.get());
-      _outCaches.push_back(new ArrayOutCache<M>(_config, _messageFormat.get()));
-      incoming.release();
-    }
-  }
 }
 
 // @brief load the initial worker data, call conductor eventually
@@ -314,7 +283,6 @@ void Worker<V, E, M>::startGlobalStep(RunGlobalSuperStep const& data) {
         << "Starting processing on " << _magazine.size() << " shards";
 
     //  _feature.metrics()->pregelNumberOfThreads->fetch_add(1);
-    _initializeMessageCaches();
   }
   // release the lock because processing is using futures (and we do not need to
   // protect)
@@ -332,110 +300,66 @@ template<typename V, typename E, typename M>
 void Worker<V, E, M>::_startProcessing() {
   TRI_ASSERT(SchedulerFeature::SCHEDULER != nullptr);
   auto self = shared_from_this();
-  auto futures = std::vector<futures::Future<ResultT<ProcessVerticesResult>>>{};
-  for (auto [idx, quiver] : enumerate(_magazine)) {
+  auto futures = std::vector<futures::Future<VertexProcessorResult>>{};
+
+  for (auto quiver : _magazine) {
     futures.emplace_back(SchedulerFeature::SCHEDULER->queueWithFuture(
-        RequestLane::INTERNAL_LOW, [self, this, idx = idx, quiver = quiver]() {
-          return _processVertices(_inCaches[idx], _outCaches[idx], quiver);
+        RequestLane::INTERNAL_LOW, [self, this, quiver = quiver]() {
+          auto processor =
+              VertexProcessor<V, E, M>(_config, _algorithm, _workerContext,
+                                       _messageCombiner, _messageFormat);
+
+          for (auto& vertex : *quiver) {
+            auto messages =
+                _readCache->getMessages(vertex.shard(), vertex.key());
+            processor.process(&vertex, messages);
+
+            // TODO: this code looks completely out of place here;
+            // preferably it should stay out of the way of the
+            // control flow
+            // Also, the number of messages received is counted multiple
+            // times over; so this redundancy should be removed.
+            // Watch out for the fact that some algorithms want to
+            // do batch sizing based on the rate of messages sent and
+            // this might need to be taken into account.
+            _currentGssObservables.verticesProcessed.fetch_add(1);
+            _currentGssObservables.messagesReceived.fetch_add(messages.size());
+            _currentGssObservables.memoryBytesUsedForMessages.fetch_add(
+                messages.size() * sizeof(M));
+            if (_currentGssObservables.verticesProcessed %
+                    Utils::batchOfVerticesProcessedBeforeUpdatingStatus ==
+                0) {
+              _makeStatusCallback()();
+            }
+
+            // TODO: early cancel & status updates
+            if (ADB_UNLIKELY(!_writeCache)) {  // ~Worker was called
+              LOG_PREGEL("ee2ab", WARN) << "Execution aborted prematurely.";
+              // TODO return something?
+              // return {TRI_ERROR_INTERNAL};
+            }
+          }
+          processor.outCache->flushMessages();
+          _writeCache->mergeCache(processor.localMessageCache.get());
+
+          return processor.result();
         }));
   }
-
   futures::collectAll(std::move(futures))
       .thenFinal([self, this](auto&& tryResults) {
+        // TODO: exception handling
         auto&& results = tryResults.get();
         for (auto&& tryRes : results) {
+          // TODO: exception handling
           auto&& res = tryRes.get();
-          if (res.ok()) {
-            auto& processRes = res.get();
-            _workerContext->_writeAggregators->aggregateValues(
-                processRes.workerAggregator);
-            _messageStats.accumulate(processRes.stats);
-          } else {
-            // TODO: ?
-          }
+
+          _workerContext->_writeAggregators->aggregateValues(
+              *res.workerAggregator);
+          _messageStats.accumulate(res.messageStats);
+          _activeCount += res.activeCount;
         }
         _finishedProcessing();
       });
-}
-
-template<typename V, typename E, typename M>
-void Worker<V, E, M>::_initializeVertexContext(VertexContext<V, E, M>* ctx) {
-  ctx->_gss = _config->globalSuperstep();
-  ctx->_lss = _config->localSuperstep();
-  ctx->_context = _workerContext.get();
-  ctx->_readAggregators = _workerContext->_readAggregators.get();
-}
-
-// internally called in a WORKER THREAD!!
-template<typename V, typename E, typename M>
-ResultT<ProcessVerticesResult> Worker<V, E, M>::_processVertices(
-    InCache<M>* inCache, OutCache<M>* outCache,
-    std::shared_ptr<Quiver<V, E>> quiver) {
-  double start = TRI_microtime();
-
-  // thread local caches
-  outCache->setBatchSize(_messageBatchSize);
-  outCache->setLocalCache(inCache);
-  TRI_ASSERT(outCache->sendCount() == 0);
-
-  ProcessVerticesResult verticesResult{
-      .workerAggregator = AggregatorHandler(_algorithm.get()), .stats = {}};
-
-  std::unique_ptr<VertexComputation<V, E, M>> vertexComputation(
-      _algorithm->createComputation(_config));
-  _initializeVertexContext(vertexComputation.get());
-  vertexComputation->_writeAggregators = &verticesResult.workerAggregator;
-  vertexComputation->_cache = outCache;
-
-  size_t activeCount = 0;
-  for (auto& vertexEntry : *quiver) {
-    MessageIterator<M> messages =
-        _readCache->getMessages(vertexEntry.shard(), vertexEntry.key());
-    _currentGssObservables.messagesReceived += messages.size();
-    _currentGssObservables.memoryBytesUsedForMessages +=
-        messages.size() * sizeof(M);
-
-    if (messages.size() > 0 || vertexEntry.active()) {
-      vertexComputation->_vertexEntry = &vertexEntry;
-      vertexComputation->compute(messages);
-      if (vertexEntry.active()) {
-        activeCount++;
-      }
-    }
-    if (_state != WorkerState::COMPUTING) {
-      break;
-    }
-
-    ++_currentGssObservables.verticesProcessed;
-    if (_currentGssObservables.verticesProcessed %
-            Utils::batchOfVerticesProcessedBeforeUpdatingStatus ==
-        0) {
-      _makeStatusCallback()();
-    }
-  }
-
-  // ==================== send messages to other shards ====================
-  outCache->flushMessages();
-  if (ADB_UNLIKELY(!_writeCache)) {  // ~Worker was called
-    LOG_PREGEL("ee2ab", WARN) << "Execution aborted prematurely.";
-    return {TRI_ERROR_INTERNAL};
-  }
-
-  // merge thread local messages, _writeCache does locking
-  _writeCache->mergeCache(inCache);
-  _feature.metrics()->pregelMessagesSent->count(outCache->sendCount());
-
-  verticesResult.stats.sendCount = outCache->sendCount();
-  _currentGssObservables.messagesSent += outCache->sendCount();
-  _currentGssObservables.memoryBytesUsedForMessages +=
-      outCache->sendCount() * sizeof(M);
-  verticesResult.stats.superstepRuntimeSecs = TRI_microtime() - start;
-  inCache->clear();
-  outCache->clear();
-
-  _activeCount += activeCount;
-  _feature.metrics()->pregelNumberOfThreads->fetch_sub(1);
-  return {std::move(verticesResult)};
 }
 
 // called at the end of a worker thread, needs mutex

--- a/arangod/Pregel/Worker/Worker.cpp
+++ b/arangod/Pregel/Worker/Worker.cpp
@@ -131,7 +131,6 @@ Worker<V, E, M>::~Worker() {
       std::chrono::milliseconds(50));  // wait for threads to die
   delete _readCache;
   delete _writeCache;
-  delete _writeCacheNextGSS;
   for (InCache<M>* cache : _inCaches) {
     delete cache;
   }

--- a/arangod/Pregel/Worker/Worker.cpp
+++ b/arangod/Pregel/Worker/Worker.cpp
@@ -315,7 +315,7 @@ void Worker<V, E, M>::_startProcessing() {
           while (true) {
             auto myCurrentQuiver = quiverIdx->fetch_add(1);
             if (myCurrentQuiver >= _magazine.size()) {
-              LOG_PREGEL("ee2ac", DEBUG) << fmt::format(
+              LOG_PREGEL("ee215", DEBUG) << fmt::format(
                   "No more work left in vertex processor number {}", futureN);
               break;
             }

--- a/arangod/Pregel/Worker/Worker.h
+++ b/arangod/Pregel/Worker/Worker.h
@@ -117,10 +117,6 @@ class Worker : public IWorker {
   InCache<M>* _readCache = nullptr;
   // for the current or next superstep
   InCache<M>* _writeCache = nullptr;
-  // preallocated incoming caches
-  std::vector<InCache<M>*> _inCaches;
-  // preallocated ootgoing caches
-  std::vector<OutCache<M>*> _outCaches;
 
   GssObservables _currentGssObservables;
   Guarded<AllGssStatus> _allGssStatus;
@@ -133,12 +129,7 @@ class Worker : public IWorker {
   size_t _runningThreads = 0;
   Scheduler::WorkHandle _workHandle;
 
-  void _initializeMessageCaches();
-  void _initializeVertexContext(VertexContext<V, E, M>* ctx);
   void _startProcessing();
-  ResultT<ProcessVerticesResult> _processVertices(
-      InCache<M>* inCache, OutCache<M>* outCache,
-      std::shared_ptr<Quiver<V, E>> quiver);
   void _finishedProcessing();
   void _callConductor(std::string const& path,
                       VPackBuilder const& message) const;

--- a/arangod/Pregel/Worker/Worker.h
+++ b/arangod/Pregel/Worker/Worker.h
@@ -117,8 +117,6 @@ class Worker : public IWorker {
   InCache<M>* _readCache = nullptr;
   // for the current or next superstep
   InCache<M>* _writeCache = nullptr;
-  // intended for the next superstep phase
-  InCache<M>* _writeCacheNextGSS = nullptr;
   // preallocated incoming caches
   std::vector<InCache<M>*> _inCaches;
   // preallocated ootgoing caches


### PR DESCRIPTION
### Scope & Purpose

The parallelism parameter was ignored for processing vertices and one future per shard is started per DBSServer. This could be considered a bug.

With this PR one `parallelism` many futures are started and work on shards one after the other.

As a pre-step to this, all code pertaining to processing vertices is moved out of the `Worker` struct into its own `VertexProcessor` struct. 