### PR TITLE
fix for date library printing #STDOFF messages

### DIFF
--- a/3rdParty/date/src/tz.cpp
+++ b/3rdParty/date/src/tz.cpp
@@ -3462,6 +3462,10 @@ init_tzdb()
                 {
                     db->zones.back().add(line);
                 }
+                else if (word.size() > 0 && word[0] == '#')
+                {
+                    continue;
+                }                
                 else
                 {
                     std::cerr << line << '\n';


### PR DESCRIPTION
### Scope & Purpose

fix for date library printing #STDOFF messages during parsing of tzdata files at startup.
fix forward-ported from upstream fix
https://github.com/HowardHinnant/date/commit/22ceabf205d8d678710a43154da5a06b701c5830

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.10: https://github.com/arangodb/arangodb/pull/18623
  - [x] Backport for 3.9: https://github.com/arangodb/arangodb/pull/18624
  - [ ] Backport for 3.8: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 