### PR TITLE
Increase log level + increase timeout.

### DIFF
--- a/js/client/modules/@arangodb/testsuites/fuerte.js
+++ b/js/client/modules/@arangodb/testsuites/fuerte.js
@@ -114,7 +114,10 @@ function gtestRunner(options) {
   // start server
   print('Starting server...');
 
-  let instanceManager = new im.instanceManager('tcp', options, {"http.keep-alive-timeout" : "10"}, 'fuerte');
+  let instanceManager = new im.instanceManager('tcp', options, {
+    "http.keep-alive-timeout": "10",
+    "log.level": "requests=TRACE"
+  }, 'fuerte');
   instanceManager.prepareInstance();
   instanceManager.launchTcpDump("");
   if (!instanceManager.launchInstance()) {

--- a/tests/Fuerte/ConnectionConcurrentTest.cpp
+++ b/tests/Fuerte/ConnectionConcurrentTest.cpp
@@ -160,7 +160,9 @@ TEST_P(ConcurrentConnectionF, CreateDocumentsParallel) {
     });
   }
   ASSERT_TRUE(wg->wait_for(
-      std::chrono::seconds(300)));  // wait for all threads to return
+      std::chrono::seconds(600)));  // wait for all threads to return
+  // This test is suspected to timeout. I enabled request logging to figure out
+  // if the requests reach the server or if fuerte deadlocks internally.
 
   // wait for all threads to end
   joins.joinAll();


### PR DESCRIPTION
### Scope & Purpose
Increase information for more test visibility. Maybe its just to slow, maybe its a deadlock in fuerte. 