### PR TITLE
Using ASSERT_EQ in DurationTest

### DIFF
--- a/tests/Pregel/DurationTest.cpp
+++ b/tests/Pregel/DurationTest.cpp
@@ -39,8 +39,12 @@ TEST(DurationTest, test_duration) {
   ASSERT_TRUE(d1.hasStarted());
   ASSERT_FALSE(d1.hasFinished());
 
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
   auto elapsed = d1.elapsedSeconds();
   ASSERT_GT(elapsed.count(), 0);
+
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
 
   auto moreElapsed = d1.elapsedSeconds();
   ASSERT_GT(moreElapsed, elapsed);
@@ -49,9 +53,13 @@ TEST(DurationTest, test_duration) {
   ASSERT_TRUE(d1.hasStarted());
   ASSERT_TRUE(d1.hasFinished());
 
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
   auto evenMoreElapsed = d1.elapsedSeconds();
 
   ASSERT_GT(evenMoreElapsed, moreElapsed);
+
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
 
   auto notMoreElapsed = d1.elapsedSeconds();
 

--- a/tests/Pregel/DurationTest.cpp
+++ b/tests/Pregel/DurationTest.cpp
@@ -39,27 +39,26 @@ TEST(DurationTest, test_duration) {
   ASSERT_TRUE(d1.hasStarted());
   ASSERT_FALSE(d1.hasFinished());
 
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  // Note that we're using ASSERT_GE instead of ASSERT_GT, in order to validate
+  // the amount of time elapsed. That is because the steady_clock is not
+  // guaranteed to go forward, just guaranteed to not go backwards. There is no
+  // guaranteed precision as when it will tick, and therefore it might appear as
+  // if no time has elapsed at all between two measurements (we have seen this
+  // happen on macOS).
 
   auto elapsed = d1.elapsedSeconds();
-  ASSERT_GT(elapsed.count(), 0);
-
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  ASSERT_GE(elapsed.count(), 0);
 
   auto moreElapsed = d1.elapsedSeconds();
-  ASSERT_GT(moreElapsed, elapsed);
+  ASSERT_GE(moreElapsed, elapsed);
 
   d1.finish();
   ASSERT_TRUE(d1.hasStarted());
   ASSERT_TRUE(d1.hasFinished());
 
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
-
   auto evenMoreElapsed = d1.elapsedSeconds();
 
-  ASSERT_GT(evenMoreElapsed, moreElapsed);
-
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  ASSERT_GE(evenMoreElapsed, moreElapsed);
 
   auto notMoreElapsed = d1.elapsedSeconds();
 


### PR DESCRIPTION
### Scope & Purpose

Although with very low probability, the *DurationTest* test has been [seen failing on the mac](https://jenkins01.arangodb.biz/job/arangodb-ANY-mac-matrix.arm64/290/EDITION=enterprise,STORAGE_ENGINE=rocksdb,TEST_SUITE=single,limit=mac&&test&&arm64/artifact/testfailures.txt).
```
      "test" failed: /Users/jenkins/hw33-mac-m1/oskar/work/ArangoDB/tests/Pregel/DurationTest.cpp:46
Expected: (moreElapsed) > (elapsed), actual: 8-byte object <A3-F9 B2-A0 6F-8C 66-3E> vs 8-byte object <A3-F9 B2-A0 6F-8C 66-3E>
```

This looks like the test ran so fast that the time turned out to be the same when comparing `moreElapsed` to `elapsed`. ~~I added a few timeouts to prevent this from happening~~. I replaced `ASSERT_GT` with `ASSERT_GE`.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
