### PR TITLE
[GORDO-1617] Get data out of actors safely

### DIFF
--- a/arangod/Pregel/PregelFeature.h
+++ b/arangod/Pregel/PregelFeature.h
@@ -35,10 +35,12 @@
 #include <velocypack/Builder.h>
 #include <velocypack/Slice.h>
 
+#include "Actor/ActorPID.h"
 #include "Pregel/ArangoExternalDispatcher.h"
 #include "Actor/Runtime.h"
 #include "Basics/Common.h"
 #include "Pregel/ExecutionNumber.h"
+#include "Pregel/ResultActor.h"
 #include "Pregel/SpawnMessages.h"
 #include "Pregel/PregelOptions.h"
 #include "Pregel/StatusActor.h"
@@ -71,6 +73,11 @@ struct PregelScheduler {
     auto workItem = scheduler->queueDelayed(
         "pregel-actors", RequestLane::INTERNAL_LOW, delay, fn);
   }
+};
+
+struct ResultActorReference {
+  actor::ActorPID pid;
+  std::shared_ptr<PregelResult> data;
 };
 
 class Conductor;
@@ -173,7 +180,8 @@ class PregelFeature final : public ArangodFeature {
   std::shared_ptr<actor::Runtime<PregelScheduler, ArangoExternalDispatcher>>
       _actorRuntime;
 
-  Guarded<std::unordered_map<ExecutionNumber, actor::ActorPID>> _resultActor;
+  Guarded<std::unordered_map<ExecutionNumber, ResultActorReference>>
+      _resultActor;
   // conductor actor is only used on the coordinator
   Guarded<std::unordered_map<ExecutionNumber, actor::ActorPID>> _conductorActor;
   Guarded<std::unordered_map<ExecutionNumber, actor::ActorPID>> _statusActors;

--- a/arangod/Pregel/PregelFeature.h
+++ b/arangod/Pregel/PregelFeature.h
@@ -79,6 +79,10 @@ struct ResultActorReference {
   actor::ActorPID pid;
   std::shared_ptr<PregelResult> data;
 };
+struct StatusActorReference {
+  actor::ActorPID pid;
+  std::shared_ptr<PregelStatus> status;
+};
 
 class Conductor;
 class IWorker;
@@ -117,7 +121,7 @@ class PregelFeature final : public ArangodFeature {
   void cleanupConductor(ExecutionNumber executionNumber);
   void cleanupWorker(ExecutionNumber executionNumber);
   [[nodiscard]] ResultT<PregelResults> getResults(ExecutionNumber execNr);
-  [[nodiscard]] ResultT<StatusState> getStatus(ExecutionNumber execNr);
+  [[nodiscard]] ResultT<PregelStatus> getStatus(ExecutionNumber execNr);
 
   void handleConductorRequest(TRI_vocbase_t& vocbase, std::string const& path,
                               VPackSlice const& body,
@@ -182,9 +186,10 @@ class PregelFeature final : public ArangodFeature {
 
   Guarded<std::unordered_map<ExecutionNumber, ResultActorReference>>
       _resultActor;
-  // conductor actor is only used on the coordinator
+  // conductor and status actors are only used on the coordinator
   Guarded<std::unordered_map<ExecutionNumber, actor::ActorPID>> _conductorActor;
-  Guarded<std::unordered_map<ExecutionNumber, actor::ActorPID>> _statusActors;
+  Guarded<std::unordered_map<ExecutionNumber, StatusActorReference>>
+      _statusActors;
 };
 
 }  // namespace arangodb::pregel

--- a/arangod/Pregel/REST/RestControlPregelHandler.cpp
+++ b/arangod/Pregel/REST/RestControlPregelHandler.cpp
@@ -231,9 +231,22 @@ void RestControlPregelHandler::handleGetRequest() {
     }
     auto executionNumber = arangodb::pregel::ExecutionNumber{
         arangodb::basics::StringUtils::uint64(suffixes[0])};
-    pregel::statuswriter::CollectionStatusWriter cWriter{_vocbase,
-                                                         executionNumber};
-    return handlePregelHistoryResult(cWriter.readResult(), true);
+    auto actorStatus = _pregel.getStatus(executionNumber);
+    // if this was not an actor run, this can be a non-actor run
+    if (actorStatus.fail()) {
+      pregel::statuswriter::CollectionStatusWriter cWriter{_vocbase,
+                                                           executionNumber};
+      return handlePregelHistoryResult(cWriter.readResult(), true);
+    }
+    auto serializedState = inspection::serializeWithErrorT(actorStatus.get());
+    if (!serializedState.ok()) {
+      generateError(rest::ResponseCode::NOT_FOUND, TRI_ERROR_CURSOR_NOT_FOUND,
+                    fmt::format("Cannot serialize status: {}",
+                                serializedState.error().error()));
+      return;
+    }
+    generateResult(rest::ResponseCode::OK, serializedState.get().slice());
+    return;
   } else if ((suffixes.size() >= 1 || suffixes.size() <= 2) &&
              suffixes.at(0) == "history") {
     if (_pregel.isStopping()) {

--- a/arangod/Pregel/ResultActor.h
+++ b/arangod/Pregel/ResultActor.h
@@ -33,19 +33,66 @@
 
 namespace arangodb::pregel {
 
+struct PregelResult {
+  ResultT<PregelResults> results = {PregelResults{}};
+  std::atomic<bool> complete{false};
+  auto add(ResultT<PregelResults> moreResults, bool lastResult) -> void {
+    if (complete.load()) {
+      return;
+    }
+    if (results.fail()) {
+      return;
+    }
+    if (moreResults.fail()) {
+      results = moreResults;
+      complete.store(true);
+      return;
+    }
+
+    VPackBuilder newResultsBuilder;
+    {
+      VPackArrayBuilder ab(&newResultsBuilder);
+      // Add existing results to new builder
+      if (!moreResults.get().results.isEmpty()) {
+        newResultsBuilder.add(
+            VPackArrayIterator(moreResults.get().results.slice()));
+      }
+      // add new results from message to builder
+      newResultsBuilder.add(
+          VPackArrayIterator(moreResults.get().results.slice()));
+    }
+    results = {PregelResults{.results = std::move(newResultsBuilder)}};
+
+    if (lastResult) {
+      complete.store(true);
+    }
+  }
+  auto set(ResultT<PregelResults> moreResults) -> void {
+    results = moreResults;
+    complete.store(true);
+  }
+  auto get() -> std::optional<ResultT<PregelResults>> {
+    if (not complete.load()) {
+      return std::nullopt;
+    }
+    return results;
+  }
+};
+template<typename Inspector>
+auto inspect(Inspector& f, PregelResult& x) {
+  return f.object(x).fields(f.field("results", x.results));
+}
 struct ResultState {
   ResultState() = default;
   ResultState(TTL ttl) : ttl{ttl} {};
-  ResultT<PregelResults> results = {PregelResults{}};
-  bool complete{false};
+  std::shared_ptr<PregelResult> data = std::make_shared<PregelResult>();
   std::vector<actor::ActorPID> otherResultActors;
   TTL ttl;
   std::chrono::system_clock::time_point expiration;
 };
-
 template<typename Inspector>
 auto inspect(Inspector& f, ResultState& x) {
-  return f.object(x).fields(f.field("results", x.results));
+  return f.object(x).fields(f.field("data", x.data));
 }
 
 template<typename Runtime>
@@ -70,49 +117,17 @@ struct ResultHandler : actor::HandlerBase<Runtime, ResultState> {
     return std::move(this->state);
   }
 
-  auto operator()(message::SaveResults start) -> std::unique_ptr<ResultState> {
-    this->state->results = {start.results};
-    this->state->complete = true;
+  auto operator()(message::SaveResults msg) -> std::unique_ptr<ResultState> {
+    this->state->data->set(msg.results);
     setExpiration();
     return std::move(this->state);
   }
 
   auto operator()(message::AddResults msg) -> std::unique_ptr<ResultState> {
-    if (this->state->complete) {
-      return std::move(this->state);
-    }
-
-    if (this->state->results.fail()) {
-      return std::move(this->state);
-    }
-
-    if (msg.results.fail()) {
-      this->state->results = msg.results;
-      this->state->complete = true;
-      setExpiration();
-      return std::move(this->state);
-    }
-
-    VPackBuilder newResultsBuilder;
-    {
-      VPackArrayBuilder ab(&newResultsBuilder);
-      // Add existing results to new builder
-      if (!msg.results.get().results.isEmpty()) {
-        newResultsBuilder.add(
-            VPackArrayIterator(msg.results.get().results.slice()));
-      }
-      // add new results from message to builder
-      newResultsBuilder.add(
-          VPackArrayIterator(msg.results.get().results.slice()));
-    }
-    this->state->results = {
-        PregelResults{.results = std::move(newResultsBuilder)}};
-
-    if (msg.receivedAllResults) {
-      this->state->complete = true;
+    this->state->data->add(msg.results, msg.receivedAllResults);
+    if (this->state->data->complete.load()) {
       setExpiration();
     }
-
     return std::move(this->state);
   }
 

--- a/arangod/Pregel/StatusActor.h
+++ b/arangod/Pregel/StatusActor.h
@@ -224,7 +224,7 @@ auto inspect(Inspector& f, StatusDetails& x) {
                             f.field("perWorker", x.perWorker));
 }
 
-struct StatusState {
+struct PregelStatus {
   std::string stateName;
   std::optional<std::string> errorMessage;
   ExecutionNumber id;
@@ -242,7 +242,7 @@ struct StatusState {
   StatusDetails details;
 };
 template<typename Inspector>
-auto inspect(Inspector& f, StatusState& x) {
+auto inspect(Inspector& f, PregelStatus& x) {
   // TODO: Fix formatting.
   auto formatted_created = fmt::format("{}", x.created.time_since_epoch());
   auto formatted_expires =
@@ -264,16 +264,23 @@ auto inspect(Inspector& f, StatusState& x) {
       f.field("vertexCount", x.vertexCount), f.field("edgeCount", x.edgeCount),
       f.field("details", x.details));
 }
+struct StatusState {
+  std::shared_ptr<PregelStatus> status = std::make_shared<PregelStatus>();
+};
+template<typename Inspector>
+auto inspect(Inspector& f, StatusState& x) {
+  return f.object(x).fields(f.field("status", x.status));
+}
 
 template<typename Runtime>
 struct StatusHandler : actor::HandlerBase<Runtime, StatusState> {
   auto operator()(message::StatusStart& msg) -> std::unique_ptr<StatusState> {
-    this->state->stateName = msg.state;
-    this->state->id = msg.id;
-    this->state->database = msg.database;
-    this->state->algorithm = msg.algorithm;
-    this->state->ttl = msg.ttl;
-    this->state->parallelism = msg.parallelism;
+    this->state->status->stateName = msg.state;
+    this->state->status->id = msg.id;
+    this->state->status->database = msg.database;
+    this->state->status->algorithm = msg.algorithm;
+    this->state->status->ttl = msg.ttl;
+    this->state->status->parallelism = msg.parallelism;
 
     LOG_TOPIC("ea4f4", INFO, Logger::PREGEL)
         << fmt::format("Status Actor {} started", this->self);
@@ -282,26 +289,27 @@ struct StatusHandler : actor::HandlerBase<Runtime, StatusState> {
 
   auto operator()(message::LoadingStarted loading)
       -> std::unique_ptr<StatusState> {
-    this->state->stateName = loading.state;
-    this->state->timings.loading.setStart(loading.time);
+    this->state->status->stateName = loading.state;
+    this->state->status->timings.loading.setStart(loading.time);
     return std::move(this->state);
   }
   auto operator()(message::GraphLoadingUpdate msg)
       -> std::unique_ptr<StatusState> {
-    this->state->details.update(
+    this->state->status->details.update(
         this->sender.server,
         GraphLoadingDetails{.verticesLoaded = msg.verticesLoaded,
                             .edgesLoaded = msg.edgesLoaded,
                             .memoryBytesUsed = msg.memoryBytesUsed});
-    this->state->vertexCount =
-        this->state->details.combined.loading.verticesLoaded;
-    this->state->edgeCount = this->state->details.combined.loading.edgesLoaded;
+    this->state->status->vertexCount =
+        this->state->status->details.combined.loading.verticesLoaded;
+    this->state->status->edgeCount =
+        this->state->status->details.combined.loading.edgesLoaded;
     return std::move(this->state);
   }
 
   auto operator()(message::GlobalSuperStepUpdate msg)
       -> std::unique_ptr<StatusState> {
-    this->state->details.update(
+    this->state->status->details.update(
         this->sender.server, msg.gss,
         GlobalSuperStepDetails{
             .verticesProcessed = msg.verticesProcessed,
@@ -313,18 +321,18 @@ struct StatusHandler : actor::HandlerBase<Runtime, StatusState> {
 
   auto operator()(message::GraphStoringUpdate msg)
       -> std::unique_ptr<StatusState> {
-    this->state->details.update(
+    this->state->status->details.update(
         this->sender.server,
         GraphStoringDetails{.verticesStored = msg.verticesStored});
     return std::move(this->state);
   }
 
   auto operator()(message::PregelStarted msg) -> std::unique_ptr<StatusState> {
-    this->state->stateName = msg.state;
-    this->state->timings.totalRuntime.setStart(msg.time);
+    this->state->status->stateName = msg.state;
+    this->state->status->timings.totalRuntime.setStart(msg.time);
 
     auto duration = std::chrono::microseconds{msg.time.value};
-    this->state->created =
+    this->state->status->created =
         std::chrono::time_point<std::chrono::steady_clock>{duration};
 
     return std::move(this->state);
@@ -332,61 +340,63 @@ struct StatusHandler : actor::HandlerBase<Runtime, StatusState> {
 
   auto operator()(message::ComputationStarted msg)
       -> std::unique_ptr<StatusState> {
-    this->state->stateName = msg.state;
-    this->state->timings.loading.setStop(msg.time);
-    this->state->timings.computation.setStart(msg.time);
-    this->state->timings.gss.push_back(PrintableDuration::withStart(msg.time));
+    this->state->status->stateName = msg.state;
+    this->state->status->timings.loading.setStop(msg.time);
+    this->state->status->timings.computation.setStart(msg.time);
+    this->state->status->timings.gss.push_back(
+        PrintableDuration::withStart(msg.time));
     return std::move(this->state);
   }
 
   auto operator()(message::StoringStarted msg) -> std::unique_ptr<StatusState> {
-    this->state->stateName = msg.state;
-    this->state->timings.computation.setStop(msg.time);
+    this->state->status->stateName = msg.state;
+    this->state->status->timings.computation.setStop(msg.time);
 
-    if (not this->state->timings.gss.empty()) {
-      this->state->timings.gss.back().setStop(msg.time);
+    if (not this->state->status->timings.gss.empty()) {
+      this->state->status->timings.gss.back().setStop(msg.time);
     }
 
-    this->state->timings.storing.setStart(msg.time);
+    this->state->status->timings.storing.setStart(msg.time);
     return std::move(this->state);
   }
 
   auto operator()(message::GlobalSuperStepStarted msg)
       -> std::unique_ptr<StatusState> {
-    this->state->stateName = msg.state;
-    this->state->gss = msg.gss;
-    if (not this->state->timings.gss.empty()) {
-      this->state->timings.gss.back().setStop(msg.time);
+    this->state->status->stateName = msg.state;
+    this->state->status->gss = msg.gss;
+    if (not this->state->status->timings.gss.empty()) {
+      this->state->status->timings.gss.back().setStop(msg.time);
     }
-    this->state->timings.gss.push_back(PrintableDuration::withStart(msg.time));
-    this->state->aggregators = std::move(msg.aggregators);
-    this->state->vertexCount = msg.vertexCount;
-    this->state->edgeCount = msg.edgeCount;
+    this->state->status->timings.gss.push_back(
+        PrintableDuration::withStart(msg.time));
+    this->state->status->aggregators = std::move(msg.aggregators);
+    this->state->status->vertexCount = msg.vertexCount;
+    this->state->status->edgeCount = msg.edgeCount;
     return std::move(this->state);
   }
 
   auto operator()(message::PregelFinished& msg)
       -> std::unique_ptr<StatusState> {
-    this->state->stateName = msg.state;
-    this->state->expires =
-        std::chrono::steady_clock::now() + this->state->ttl.duration;
-    this->state->timings.storing.setStop(msg.time);
-    this->state->timings.totalRuntime.setStop(msg.time);
+    this->state->status->stateName = msg.state;
+    this->state->status->expires =
+        std::chrono::steady_clock::now() + this->state->status->ttl.duration;
+    this->state->status->timings.storing.setStop(msg.time);
+    this->state->status->timings.totalRuntime.setStop(msg.time);
 
     return std::move(this->state);
   }
 
   auto operator()(message::InFatalError& msg) -> std::unique_ptr<StatusState> {
-    this->state->stateName = msg.state;
-    this->state->errorMessage = msg.errorMessage;
-    this->state->timings.stopAll(msg.time);
+    this->state->status->stateName = msg.state;
+    this->state->status->errorMessage = msg.errorMessage;
+    this->state->status->timings.stopAll(msg.time);
 
     return std::move(this->state);
   }
 
   auto operator()(message::Canceled& msg) -> std::unique_ptr<StatusState> {
-    this->state->stateName = msg.state;
-    this->state->timings.stopAll(msg.time);
+    this->state->status->stateName = msg.state;
+    this->state->status->timings.stopAll(msg.time);
 
     return std::move(this->state);
   }

--- a/arangod/V8Server/v8-pregel.cpp
+++ b/arangod/V8Server/v8-pregel.cpp
@@ -217,8 +217,23 @@ static void JS_PregelStatus(v8::FunctionCallbackInfo<v8::Value> const& args) {
 
   auto executionNum = arangodb::pregel::ExecutionNumber{
       TRI_ObjectToUInt64(isolate, args[0], true)};
-  pregel::statuswriter::CollectionStatusWriter cWriter{vocbase, executionNum};
-  handlePregelHistoryV8Result(cWriter.readResult(), true);
+  auto& pregel = vocbase.server().getFeature<arangodb::pregel::PregelFeature>();
+  auto actorStatus = pregel.getStatus(executionNum);
+  // if this was not an actor run, this can be a non-actor run
+  if (actorStatus.fail()) {
+    pregel::statuswriter::CollectionStatusWriter cWriter{vocbase, executionNum};
+    handlePregelHistoryV8Result(cWriter.readResult(), true);
+    return;
+  }
+  auto serializedState = inspection::serializeWithErrorT(actorStatus.get());
+  if (!serializedState.ok()) {
+    TRI_V8_THROW_EXCEPTION_MESSAGE(
+        TRI_ERROR_CURSOR_NOT_FOUND,
+        fmt::format("Cannot serialize status {}",
+                    serializedState.error().error()));
+    return;
+  }
+  TRI_V8_RETURN(TRI_VPackToV8(isolate, serializedState.get().slice()));
 
   return;
   TRI_V8_TRY_CATCH_END

--- a/tests/Pregel/Actor/Actors/EgressActor.h
+++ b/tests/Pregel/Actor/Actors/EgressActor.h
@@ -1,0 +1,110 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2020 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Markus Pfeiffer
+////////////////////////////////////////////////////////////////////////////////
+#pragma once
+
+#include <thread>
+
+#include "Actor/Actor.h"
+
+namespace arangodb::pregel::actor::test {
+
+struct EgressData {
+  auto set(std::string newContent) -> void {
+    content = std::move(newContent);
+    finished.store(true);
+  }
+  auto get() -> std::optional<std::string> {
+    if (not finished.load()) {
+      return std::nullopt;
+    }
+    return content;
+  }
+  std::atomic<bool> finished;
+  std::string content;
+};
+
+struct EgressState {
+  bool operator==(const EgressState&) const = default;
+  EgressState() : data{std::make_shared<EgressData>()} {};
+  std::shared_ptr<EgressData> data;
+};
+template<typename Inspector>
+auto inspect(Inspector& f, EgressState& x) {
+  return f.object(x).fields();
+}
+
+namespace message {
+
+struct EgressStart {};
+template<typename Inspector>
+auto inspect(Inspector& f, EgressStart& x) {
+  return f.object(x).fields();
+}
+
+struct EgressSet {
+  std::string data;
+};
+template<typename Inspector>
+auto inspect(Inspector& f, EgressSet& x) {
+  return f.object(x).fields(f.field("store", x.data));
+}
+
+struct EgressMessages : std::variant<EgressStart, EgressSet> {
+  using std::variant<EgressStart, EgressSet>::variant;
+};
+template<typename Inspector>
+auto inspect(Inspector& f, EgressMessages& x) {
+  return f.variant(x).unqualified().alternatives(
+      arangodb::inspection::type<EgressStart>("start"),
+      arangodb::inspection::type<EgressSet>("set"));
+}
+
+}  // namespace message
+
+template<typename Runtime>
+struct EgressHandler : HandlerBase<Runtime, EgressState> {
+  auto operator()(message::EgressStart msg) -> std::unique_ptr<EgressState> {
+    return std::move(this->state);
+  }
+
+  auto operator()(message::EgressSet msg) -> std::unique_ptr<EgressState> {
+    this->state->data->set(msg.data);
+    return std::move(this->state);
+  }
+
+  auto operator()(auto&& rest) -> std::unique_ptr<EgressState> {
+    fmt::print(stderr, "EgressActor: handles rest\n");
+    return std::move(this->state);
+  }
+};
+
+struct EgressActor {
+  using State = EgressState;
+  using Message = message::EgressMessages;
+  template<typename Runtime>
+  using Handler = EgressHandler<Runtime>;
+  static constexpr auto typeName() -> std::string_view {
+    return "EgressActor";
+  };
+};
+}  // namespace arangodb::pregel::actor::test

--- a/tests/Pregel/Actor/CMakeLists.txt
+++ b/tests/Pregel/Actor/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_library(arango_tests_actor OBJECT
   ActorListTest.cpp
   ActorTest.cpp
+  EgressActorTest.cpp
   RuntimeTest.cpp
   MultiRuntimeTest.cpp
   MPSCQueueTest.cpp)

--- a/tests/Pregel/Actor/EgressActorTest.cpp
+++ b/tests/Pregel/Actor/EgressActorTest.cpp
@@ -1,0 +1,102 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2020 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Markus Pfeiffer
+////////////////////////////////////////////////////////////////////////////////
+
+#include <gtest/gtest.h>
+
+#include "Actor/Runtime.h"
+#include "Actors/EgressActor.h"
+#include "ThreadPoolScheduler.h"
+
+using namespace arangodb::pregel::actor;
+using namespace arangodb::pregel::actor::test;
+
+struct MockScheduler {
+  auto start(size_t number_of_threads) -> void{};
+  auto stop() -> void{};
+  auto operator()(auto fn) { fn(); }
+  auto delay(std::chrono::seconds delay, std::function<void(bool)>&& fn) {
+    fn(true);
+  }
+};
+struct EmptyExternalDispatcher {
+  auto operator()(ActorPID sender, ActorPID receiver,
+                  arangodb::velocypack::SharedSlice msg) -> void {}
+};
+using ActorTestRuntime = Runtime<MockScheduler, EmptyExternalDispatcher>;
+
+template<typename T>
+class EgressActorTest : public testing::Test {
+ public:
+  EgressActorTest() : scheduler{std::make_shared<T>()} {
+    scheduler->start(number_of_threads);
+  }
+
+  std::shared_ptr<T> scheduler;
+  size_t number_of_threads = 128;
+};
+using SchedulerTypes = ::testing::Types<MockScheduler, ThreadPoolScheduler>;
+TYPED_TEST_SUITE(EgressActorTest, SchedulerTypes);
+
+TYPED_TEST(EgressActorTest,
+           outside_world_can_look_at_set_data_inside_egress_actor) {
+  auto dispatcher = std::make_shared<EmptyExternalDispatcher>();
+  auto runtime = std::make_shared<Runtime<TypeParam, EmptyExternalDispatcher>>(
+      "A", "myID", this->scheduler, dispatcher);
+
+  auto actorState = std::make_unique<EgressState>();
+
+  // keep a shared pointer to the outbox
+  auto outbox = actorState->data;
+
+  auto actor = runtime->template spawn<EgressActor>(
+      "database", std::move(actorState), test::message::EgressStart{});
+
+  runtime->dispatch(
+      ActorPID{.server = "A", .database = "database", .id = actor},
+      ActorPID{.server = "A", .database = "database", .id = actor},
+      EgressActor::Message{test::message::EgressSet{.data = "Hallo"}});
+
+  this->scheduler->stop();
+
+  ASSERT_EQ(outbox->get(), "Hallo");
+  runtime->softShutdown();
+}
+
+TYPED_TEST(EgressActorTest, egress_data_is_empty_when_not_set) {
+  auto dispatcher = std::make_shared<EmptyExternalDispatcher>();
+  auto runtime = std::make_shared<Runtime<TypeParam, EmptyExternalDispatcher>>(
+      "A", "myID", this->scheduler, dispatcher);
+
+  auto actorState = std::make_unique<EgressState>();
+
+  // keep a shared pointer to the outbox
+  auto outbox = actorState->data;
+
+  runtime->template spawn<EgressActor>("database", std::move(actorState),
+                                       test::message::EgressStart{});
+
+  this->scheduler->stop();
+
+  ASSERT_EQ(outbox->get(), std::nullopt);
+  runtime->softShutdown();
+}


### PR DESCRIPTION
When running pregel with actors, we have to get the pregel result and the status out of an actor. The method `getActorStateByID` we used before is not save because the state is moved back and forth when the actor is working and results in sporadic test failures.
This PR solves this by having a shared_ptr to the needed data inside the actor state. This ptr is saved in the feature and is used when the feature requests the data. 