### PR TITLE
Bug fix-3.10/mds 1098 dropping variable content to early

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,24 @@
 v3.10.6 (XXXX-XX-XX)
 --------------------
 
+* MDS-1098: In 3.10 we have introduced an optimization on Traversals to pull
+  post-filter conditions into the traversal-statements, like the following:
+
+      FOR v,e,p IN 10 OUTBOUND @start GRAPH "myGraph"
+        FILTER v.isRelevant == true
+        RETURN p
+
+  If the comparison side contains a variable and the same variable is used as
+  the start vertex e.g. like this:
+
+  FOR candidate IN ["vertices/1", "vertices/2"]
+    FOR v,e,p IN 1 OUTBOUND candidate GRAPH "myGraph"
+      FILTER e.MostLikedNeighbor == candidate
+      RETURN v
+
+  There is a chance that we prematurely discarded this variable (candidate in
+  the example) if it is not used later. This has lead to incorrect results.
+
 * Updated arangosync to v2.16.1.
 
 * Fix potential thread starvation in in-memory edge cache.

--- a/arangod/Aql/TraversalNode.cpp
+++ b/arangod/Aql/TraversalNode.cpp
@@ -380,6 +380,13 @@ void TraversalNode::getVariablesUsedHere(VarSet& result) const {
     }
   }
 
+  for (auto const& postVar : _postFilterVariables) {
+    if (postVar != vertexOutVariable() && postVar != edgeOutVariable() &&
+        postVar != pathOutVariable()) {
+      result.emplace(postVar);
+    }
+  }
+
   if (usesInVariable()) {
     result.emplace(_inVariable);
   }

--- a/js/server/modules/@arangodb/testutils/aql-graph-traversal-generic-graphs.js
+++ b/js/server/modules/@arangodb/testutils/aql-graph-traversal-generic-graphs.js
@@ -356,7 +356,9 @@ class TestGraph {
     ec.save(edges.map(([v, w, weight]) => {
       const edge = {
         _from: verticesByName[v],
-        _to: verticesByName[w]
+        _to: verticesByName[w],
+        // Will be used in filters of tests.
+        secondFrom: verticesByName[v]
       };
       // check if our edge also has a weight defined and is a number
       if (weight && typeof weight === 'number') {

--- a/js/server/modules/@arangodb/testutils/aql-graph-traversal-generic-tests.js
+++ b/js/server/modules/@arangodb/testutils/aql-graph-traversal-generic-tests.js
@@ -3074,6 +3074,79 @@ function testSmallCircleFilterOptimization(testGraph) {
 
 }
 
+
+function testSmallCircleFilterOptimizationOverlappingVariable(testGraph) {
+  // Which Graph is used here does not matter, enough to test with one of the graphs
+  // we picked the smallCircle graph at random
+  assertTrue(testGraph.name().startsWith(protoGraphs.smallCircle.name()));
+
+  // The purpose of this test:
+  // We are reusing the StartVertex variable in different places that can be optimized into
+  // the traversal, we need to make sure the variable is retained long enough.
+  const filters = [
+    `FILTER v._id == startVertex`,
+    `FILTER e.secondFrom == startVertex`,
+    `FILTER p.vertices[-1]._id == startVertex`,
+    `FILTER p.edges[-1].secondFrom == startVertex`,
+    `FILTER p.edges[0].secondFrom == startVertex`,
+    `FILTER p.vertices[0]._id == startVertex`,
+    `FILTER startVertex IN p.vertices[*]._id`,
+    `FILTER startVertex IN p.edges[*].secondFrom`
+  ];
+
+  for (const filter of filters) {
+    // The Circle has 4 steps, so for each start vertex we do one roundtrip
+    const query = `
+      FOR startVertex IN ["${testGraph.vertex('A')}", "${testGraph.vertex('B')}", "${testGraph.vertex('C')}"]
+        FOR v,e,p IN 1..4 OUTBOUND startVertex GRAPH "${testGraph.name()}"
+          ${filter}
+          RETURN v._key
+    `;
+    const nonOptimizedResult = db._query(query, {}, {optimizer: {rules: ["-optimize-traversals"]}}).toArray();
+    assertTrue(nonOptimizedResult.length > 0, `Test queries are desigend in a way that they should always yield results This does not ${query}`);
+    const optimizedResult = db._query(query).toArray();
+    // NOTE: As we have a circle and cannot branch, the order of result is deterministic, so the two queries need to return perfect
+    // copies as results.
+    assertEqual(nonOptimizedResult, optimizedResult, `Optimized and non-optimized results do not match on query ${query}`);
+  }
+
+  const optimizableConditions = [
+    `v.color == "blue"`,
+    `"blue" == e.color`,
+    `p.edges[1].color == "blue"`,
+    `"blue" == p.vertices[1].color`,
+    `p.edges[*].color ALL == "blue"`,
+    `p.vertices[*].color ALL == "blue"`
+  ];
+
+  // Optimize a single condition
+  const filtersToTest = optimizableConditions.map(f => `FILTER ${f}`);
+  // More complex test.
+  for (let first = 0; first < optimizableConditions.length; ++first) {
+    for (let second = first + 1; second < optimizableConditions.length; ++second) {
+      // Optimize two filter nodes, and erase the filter nodes
+      filtersToTest.push(`FILTER ${optimizableConditions[first]} FILTER ${optimizableConditions[second]}`);
+    }
+  }
+
+  for (const filterCondition of filtersToTest) {
+    const query = `
+      FOR v,e,p IN 1..3 OUTBOUND "${testGraph.vertex('A')}" GRAPH "${testGraph.name()}"
+        ${filterCondition}
+        return v
+    `;
+    const plan = AQL_EXPLAIN(query, {});
+
+
+    assertEqual(findExecutionNodes(plan, "FilterNode").length, 0, query + " Still has FilterNode");
+
+    const traversals = findExecutionNodes(plan, "TraversalNode");
+    assertEqual(traversals.length, 1, query + " Somehow we have removed the Traversal");
+    const travNode = traversals[0];
+    assertTrue(travNode.hasOwnProperty("condition"));
+  }
+}
+
 function testCompleteGraphDfsUniqueVerticesPathD1(testGraph) {
   assertTrue(testGraph.name().startsWith(protoGraphs.completeGraph.name()));
   const query = aql`
@@ -6577,7 +6650,8 @@ const testsByGraph = {
     testSmallCircleKShortestPathEnabledWeightCheckWithMultipleLimits,
     testSmallCircleKShortestPathEnabledWeightCheckIndexedWithMultipleLimits,
     testSmallCircleKShortestPathEnabledWeightCheckWithMultipleLimitsWT,
-    testSmallCircleFilterOptimization
+    testSmallCircleFilterOptimization,
+    testSmallCircleFilterOptimizationOverlappingVariable
   },
   completeGraph: {
     testCompleteGraphDfsUniqueVerticesPathD1,


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/18602

*In Traversals If we use a variable as the StartVertex and also for Filtering like this:

  FOR candidate IN ["vertices/1", "vertices/2"]
    FOR v,e,p IN 1 OUTBOUND candidate GRAPH "myGraph"
      FILTER e.MostLikedNeighbor == candidate
      RETURN v

The variable candidate can be erased too early if another optimizer rule replaces the InputVaribale (e.g. for Distribution in DisjointSmartGraph case)
*

- [X] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [X] Tests
  - [X] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: *(Please link PR)*
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR: No Enterprise part
- [X] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/MDS-1098 and https://arangodb.atlassian.net/browse/BTS-1304
- [ ] Design document: 

