### PR TITLE
don't trip over a testcase not having a message

### DIFF
--- a/js/client/modules/@arangodb/testutils/result-processing.js
+++ b/js/client/modules/@arangodb/testutils/result-processing.js
@@ -309,7 +309,13 @@ function saveToJunitXML(options, results) {
       state.seenTestCases = true;
       if (!success) {
         state.xml.elem('failure');
-        state.xml.text('<![CDATA[' + stripAnsiColors(testCase.message) + ']]>\n');
+        let msg;
+        if (testCase.hasOwnProperty('message')) {
+          msg = stripAnsiColors(testCase.message);
+        } else {
+          msg = stripAnsiColors(`testcase doesn't have a messeage! ${JSON.dumps(testCase)}`);
+        }
+        state.xml.text('<![CDATA[' + msg  + ']]>\n');
         state.xml.elem('/failure');
         state.xml.elem('/testcase');
       }

--- a/js/client/modules/@arangodb/testutils/result-processing.js
+++ b/js/client/modules/@arangodb/testutils/result-processing.js
@@ -314,7 +314,7 @@ function saveToJunitXML(options, results) {
         if (testCase.hasOwnProperty('message')) {
           msg = stripAnsiColors(testCase.message);
         } else {
-          msg = stripAnsiColors(`testcase ${testCaseName} doesn't have a messeage! ${JSON.stringify(testCase)}`);
+          msg = stripAnsiColors(`testcase ${testCaseName} doesn't have a message! ${JSON.stringify(testCase)}`);
         }
         state.xml.text('<![CDATA[' + msg  + ']]>\n');
         state.xml.elem('/failure');

--- a/js/client/modules/@arangodb/testutils/result-processing.js
+++ b/js/client/modules/@arangodb/testutils/result-processing.js
@@ -49,6 +49,7 @@ const YELLOW = internal.COLORS.COLOR_YELLOW;
 const internalMembers = [
   'crashreport',
   'code',
+  'exitCode',
   'error',
   'status',
   'duration',
@@ -313,7 +314,7 @@ function saveToJunitXML(options, results) {
         if (testCase.hasOwnProperty('message')) {
           msg = stripAnsiColors(testCase.message);
         } else {
-          msg = stripAnsiColors(`testcase doesn't have a messeage! ${JSON.dumps(testCase)}`);
+          msg = stripAnsiColors(`testcase ${testCaseName} doesn't have a messeage! ${JSON.stringify(testCase)}`);
         }
         state.xml.text('<![CDATA[' + msg  + ']]>\n');
         state.xml.elem('/failure');


### PR DESCRIPTION
### Scope & Purpose

a testcase might not have the message attribute. don't trip over this while generating the xml:

```
Exception occured in running tests: Cannot read property 'replace' of undefined
TypeError: Cannot read property 'replace' of undefined
    at stripAnsiColors (/Users/jenkins/hw41-mac/oskar/work/ArangoDB/js/client/modules/@arangodb/testutils/result-processing.js:235:14)
    at Object.testCase (/Users/jenkins/hw41-mac/oskar/work/ArangoDB/js/client/modules/@arangodb/testutils/result-processing.js:312:38)
    at iterateTestResults (/Users/jenkins/hw41-mac/oskar/work/ArangoDB/js/client/modules/@arangodb/testutils/result-processing.js:164:22)
    at Object.saveToJunitXML (/Users/jenkins/hw41-mac/oskar/work/ArangoDB/js/client/modules/@arangodb/testutils/result-processing.js:274:3)
    at main (/Users/jenkins/hw41-mac/oskar/work/ArangoDB/js/client/modules/@arangodb/testutils/unittest.js:107:18)
    at /Users/jenkins/hw41-mac/oskar/work/ArangoDB/js/client/modules/@arangodb/testutils/unittest.js:120:14
```

- [x] :hankey: Bugfix
