### PR TITLE
Fix testCreateInParallel

### DIFF
--- a/tests/js/common/shell/shell-index.js
+++ b/tests/js/common/shell/shell-index.js
@@ -1650,7 +1650,7 @@ function ParallelIndexSuite() {
           break;
         }
         for (let i = indexes.length - 1; i < Math.min(noIndexes, indexes.length - 1 + maxThreads); ++i) {
-          let command = 'require("internal").db._collection("' + cn + '").ensureIndex({ type: "persistent", fields: ["value' + i + '"] }); require("internal").wait(5);';
+          let command = 'require("internal").db._collection("' + cn + '").ensureIndex({ type: "persistent", fields: ["value' + i + '"] });';
           tasks.register({name: "UnitTestsIndexCreate" + i, command: command});
         }
         if (time() - start > 180) {


### PR DESCRIPTION
Previously this test suite could run into the situation that tasks that were created by a previous test would interfere with the current test case.

This PR adapts the teardown method to make sure all tasks that were started by a test have actually finished (or fail by means of a timeout otherwise)

This should fix failures of this type https://jenkins01.arangodb.biz/job/arangodb-matrix-pr-windows/21100/EDITION=community,ST[…]b,TEST_SUITE=cluster,limit=windows&&test&&!rta&&!release/