### PR TITLE
simplify ServerState

### DIFF
--- a/arangod/Cluster/ClusterFeature.cpp
+++ b/arangod/Cluster/ClusterFeature.cpp
@@ -788,8 +788,6 @@ void ClusterFeature::start() {
 
   auto const version = comm.version();
 
-  ServerState::instance()->setInitialized();
-
   std::string const endpoints =
       AsyncAgencyCommManager::INSTANCE->getCurrentEndpoint();
 

--- a/arangod/Cluster/ServerState.cpp
+++ b/arangod/Cluster/ServerState.cpp
@@ -97,7 +97,6 @@ ServerState::ServerState(ArangodServer& server)
       _shortId(0),
       _rebootId(0),
       _state(STATE_UNDEFINED),
-      _initialized(false),
       _foxxmasterSince(0),
       _foxxmasterQueueupdate(false) {
   TRI_ASSERT(Instance == nullptr);

--- a/arangod/Cluster/v8-cluster.cpp
+++ b/arangod/Cluster/v8-cluster.cpp
@@ -1382,26 +1382,6 @@ static void JS_GetFoxxmasterSince(
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// @brief return whether the cluster is initialized
-////////////////////////////////////////////////////////////////////////////////
-
-static void JS_InitializedServerState(
-    v8::FunctionCallbackInfo<v8::Value> const& args) {
-  TRI_V8_TRY_CATCH_BEGIN(isolate);
-  v8::HandleScope scope(isolate);
-
-  if (args.Length() != 0) {
-    TRI_V8_THROW_EXCEPTION_USAGE("initialized()");
-  }
-
-  if (ServerState::instance()->initialized()) {
-    TRI_V8_RETURN_TRUE();
-  }
-  TRI_V8_RETURN_FALSE();
-  TRI_V8_TRY_CATCH_END
-}
-
-////////////////////////////////////////////////////////////////////////////////
 /// @brief whether or not the server is a coordinator
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -1806,8 +1786,6 @@ void TRI_InitV8Cluster(v8::Isolate* isolate, v8::Handle<v8::Context> context) {
   TRI_AddMethodVocbase(isolate, rt,
                        TRI_V8_ASCII_STRING(isolate, "getFoxxmasterSince"),
                        JS_GetFoxxmasterSince);
-  TRI_AddMethodVocbase(isolate, rt, TRI_V8_ASCII_STRING(isolate, "initialized"),
-                       JS_InitializedServerState);
   TRI_AddMethodVocbase(isolate, rt,
                        TRI_V8_ASCII_STRING(isolate, "isCoordinator"),
                        JS_IsCoordinatorServerState);

--- a/js/server/modules/@arangodb/cluster.js
+++ b/js/server/modules/@arangodb/cluster.js
@@ -124,7 +124,7 @@ var role = function () {
 // /////////////////////////////////////////////////////////////////////////////
 
 var status = function () {
-  if (!isCluster() || !global.ArangoServerState.initialized()) {
+  if (!isCluster()) {
     return undefined;
   }
 


### PR DESCRIPTION
### Scope & Purpose

Not related to 3.11 stabilization

simplify ServerState
- remove dependency on ReadWriteSpinLock (use regular RW lock instead)
- remove _initialized boolean variable, which was not thread-safe and used from only one place in `js/server/modules/@arangodb/cluster.js`.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: -
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 