### PR TITLE
Reset log level to normal on agents after startup.

### DIFF
--- a/js/client/modules/@arangodb/testutils/instance-manager.js
+++ b/js/client/modules/@arangodb/testutils/instance-manager.js
@@ -1081,6 +1081,12 @@ class instanceManager {
         }
         if (haveLeader === 1 && haveConfig === this.agencyConfig.agencySize) {
           print("Agency Up!");
+          try {
+            // set back log level to info for agents
+            for (let agentIndex = 0; agentIndex < this.agencyConfig.agencySize; agentIndex ++) {
+              this.agencyConfig.agencyInstances[agentIndex].getAgent('/_admin/log/level', 'PUT', JSON.stringify({"agency":"info"}));
+            }
+          } catch (err) {}
           return;
         }
         if (count === 0) {

--- a/js/client/modules/@arangodb/testutils/instance.js
+++ b/js/client/modules/@arangodb/testutils/instance.js
@@ -862,10 +862,13 @@ class instance {
     }
     throw new Error(`unable to connect in ${count}s`);
   }
-  getAgent(path, method) {
+  getAgent(path, method, body = null) {
     let opts = {
       method: method
     };
+    if (body === null) {
+      body = (method === 'POST') ? '[["/"]]' : '';
+    }
 
     if (this.args.hasOwnProperty('authOpts')) {
       opts['jwt'] = crypto.jwtEncode(this.authOpts['server.jwt-secret'], {'server_id': 'none', 'iss': 'arangodb'}, 'HS256');
@@ -874,7 +877,7 @@ class instance {
     } else if (this.jwtFiles) {
       opts['jwt'] = crypto.jwtEncode(fs.read(this.jwtFiles[0]), {'server_id': 'none', 'iss': 'arangodb'}, 'HS256');
     }
-    return download(this.url + path, method === 'POST' ? '[["/"]]' : '', opts);
+    return download(this.url + path, body, opts);
   }
 
   dumpAgent(path, method, fn, dumpdir) {


### PR DESCRIPTION
### Scope & Purpose
Set the log level to info after startup. It was set to debug to investigate the startup behavior of agents.