### PR TITLE
Asserting on doubles on macOS

### DIFF
--- a/tests/Cache/PlainCache.cpp
+++ b/tests/Cache/PlainCache.cpp
@@ -361,10 +361,10 @@ TEST(CachePlainCacheTest, test_hit_rate_statistics_reporting) {
   {
     auto cacheStats = cacheHit->hitRates();
     auto managerStats = manager.globalHitRates();
-    ASSERT_GE(cacheStats.first, 40.0);
-    ASSERT_GE(cacheStats.second, 40.0);
-    ASSERT_GE(managerStats.first, 40.0);
-    ASSERT_GE(managerStats.second, 40.0);
+    EXPECT_GE(cacheStats.first, 40.0);
+    EXPECT_GE(cacheStats.second, 40.0);
+    EXPECT_GE(managerStats.first, 40.0);
+    EXPECT_GE(managerStats.second, 40.0);
   }
 
   for (std::uint64_t i = 1024; i < 2048; i++) {
@@ -373,12 +373,12 @@ TEST(CachePlainCacheTest, test_hit_rate_statistics_reporting) {
   {
     auto cacheStats = cacheMiss->hitRates();
     auto managerStats = manager.globalHitRates();
-    ASSERT_EQ(cacheStats.first, 0.0);
-    ASSERT_EQ(cacheStats.second, 0.0);
-    ASSERT_GT(managerStats.first, 10.0);
-    ASSERT_LT(managerStats.first, 60.0);
-    ASSERT_GT(managerStats.second, 10.0);
-    ASSERT_LT(managerStats.second, 60.0);
+    EXPECT_DOUBLE_EQ(cacheStats.first, 0.0);
+    EXPECT_DOUBLE_EQ(cacheStats.second, 0.0);
+    EXPECT_GT(managerStats.first, 10.0);
+    EXPECT_LT(managerStats.first, 60.0);
+    EXPECT_GT(managerStats.second, 10.0);
+    EXPECT_LT(managerStats.second, 60.0);
   }
 
   for (std::uint64_t i = 0; i < 1024; i++) {
@@ -390,14 +390,14 @@ TEST(CachePlainCacheTest, test_hit_rate_statistics_reporting) {
   {
     auto cacheStats = cacheMixed->hitRates();
     auto managerStats = manager.globalHitRates();
-    ASSERT_GT(cacheStats.first, 10.0);
-    ASSERT_LT(cacheStats.first, 60.0);
-    ASSERT_GT(cacheStats.second, 10.0);
-    ASSERT_LT(cacheStats.second, 60.0);
-    ASSERT_GT(managerStats.first, 10.0);
-    ASSERT_LT(managerStats.first, 60.0);
-    ASSERT_GT(managerStats.second, 10.0);
-    ASSERT_LT(managerStats.second, 60.0);
+    EXPECT_GT(cacheStats.first, 10.0);
+    EXPECT_LT(cacheStats.first, 60.0);
+    EXPECT_GT(cacheStats.second, 10.0);
+    EXPECT_LT(cacheStats.second, 60.0);
+    EXPECT_GT(managerStats.first, 10.0);
+    EXPECT_LT(managerStats.first, 60.0);
+    EXPECT_GT(managerStats.second, 10.0);
+    EXPECT_LT(managerStats.second, 60.0);
   }
 
   manager.destroyCache(cacheHit);


### PR DESCRIPTION
### Scope & Purpose

I have seen this test failing on macOS: https://jenkins01.arangodb.biz/job/arangodb-matrix-pr-mac-onlycatch.x86-64/24288/EDITION=enterprise,limit=mac&&test&&x86-64/artifact/testfailures.txt
This is not the first time we have had such problems with floating point precision on macOS.

I introduced `EXPECT_DOUBLE_EQ` for comparing doubles and replaced `ASSERT` with `EXPECT` where possible, such that the test doesn't completely stop on error.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

