### PR TITLE
[PREGEL] Use number of cores as upper cut for pregel parallelism

### DIFF
--- a/js/server/modules/@arangodb/test-helper.js
+++ b/js/server/modules/@arangodb/test-helper.js
@@ -135,8 +135,8 @@ exports.getMetric = function (endpoint, name) {
 };
 
 exports.getMetricSingle = function (name) {
-  let res = arango.GET_RAW("/_admin/metrics");
-  if (res.code !== 200) {
+  let res = request.get("/_admin/metrics");
+  if (res.status !== 200) {
     throw "error fetching metric";
   }
   return getMetricName(res.body, name);

--- a/tests/js/common/shell/shell-pregel-multicollection-edgecol.js
+++ b/tests/js/common/shell/shell-pregel-multicollection-edgecol.js
@@ -239,7 +239,12 @@ function multiCollectionTestSuite() {
         assertEqual(stats.vertexCount, numComponents * n, stats);
         assertEqual(stats.edgeCount, numComponents * (m + n), stats);
         assertTrue(stats.hasOwnProperty("parallelism"));
-        assertEqual(parallelism, stats.parallelism);
+        const number_of_cores = require('@arangodb/test-helper').getMetricSingle("arangodb_server_statistics_cpu_core");
+        if (number_of_cores < parallelism) {
+          assertEqual(number_of_cores, stats.parallelism);
+        } else {
+          assertEqual(parallelism, stats.parallelism);
+        }
 
         let allUniquePregelResults = new Set();
         for (let j = 0; j < cn; ++j) {


### PR DESCRIPTION
Fixes "Error: at assertion #12023: assertEqual: (6) is not equal to (8) (Error at tests/js/common/shell/shell-pregel-multicollection-edgecol.js:242:9 at Object.testMultiWCCParallelism (tests/js/common/shell/shell-pregel-multicollection-edgecol.js:234:22) at tests/js/common/shell/shell-pregel-multicollection-edgecol.js:365:9 .... at Object.shellClient [as shell_client] (/Users/jenkins/hw43-mac/oskar/work/ArangoDB/js/client/modules/@arangodb/testsuites/aql.js:208:79) - test failed"
Happening on mac, e.g.: "https://jenkins01.arangodb.biz/job/arangodb-ANY-mac-matrix.x86-64/EDITION=community,STORAGE_ENGINE=rocksdb,TEST_SUITE=single,limit=mac&&test&&x86-64/4292/"

If the requested parallelism is larger than the number of cores on the running machine, pregel uses the number of cores for parallelism. Some Mac systems we run Jenkins on have only 6 cores, therefore the check on the parallelism of a pregel run that was started with 8 parallelism failed.
The test now executes a different assertion depending on the number of cores (which we get via the /_admin/metrics endpoint). 