### PR TITLE
Remove automatic circleci run on devel branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,8 +40,6 @@ jobs:
 workflows:
   setup:
     when:
-      or:
-        - equal: [devel, << pipeline.git.branch >>]
-        - equal: [api, << pipeline.trigger_source >>]
+      - equal: [api, << pipeline.trigger_source >>]
     jobs:
       - setup

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,6 +40,6 @@ jobs:
 workflows:
   setup:
     when:
-      - equal: [api, << pipeline.trigger_source >>]
+      equal: [api, << pipeline.trigger_source >>]
     jobs:
       - setup


### PR DESCRIPTION
### Scope & Purpose

*(Please describe the changes in this PR for reviewers, motivation, rationale - **mandatory**)*

Right now CircleCI is set up to run every time we merge a PR to devel.
during the fixing of nightlies phase, this is a waste of resources.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [X] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification


