### PR TITLE
Trying to work around OS cache

### DIFF
--- a/tests/js/server/recovery/foxx-directories.js
+++ b/tests/js/server/recovery/foxx-directories.js
@@ -53,7 +53,18 @@ function runSetup () {
 
   db._createDatabase('UnitTestsRecovery2');
 
-  fs.write(fs.join(appPath, 'UnitTestsRecovery2', 'bar.json'), 'test');
+  const path = fs.join(appPath, 'UnitTestsRecovery2', 'bar.json');
+  fs.write(path, 'test');
+
+  // tries to force the operating system to refresh its inode cache
+  function fileExists(path) {
+    try {
+      fs.readFileSync(path);
+      return true;
+    } catch (err) {
+      return false;
+    }
+  }
 
   db._dropDatabase('UnitTestsRecovery2');
   // garbage-collect once
@@ -61,11 +72,10 @@ function runSetup () {
 
   // we need to wait long enough for the DatabaseManagerThread to 
   // physically carry out the deletion
-  let path = fs.join(appPath, 'UnitTestsRecovery2');
   let gone = false;
   let tries = 0;
   while (++tries < 120) {
-    if (!fs.isDirectory(path)) {
+    if (!fileExists(path)) {
       gone = true;
       require("console").log("database directory for UnitTestsRecovery2 is gone");
       break;


### PR DESCRIPTION
### Scope & Purpose

This PR aims at making _foxx-directories.js_ tests somewhat more stable. It has been known to fail when the system is under heavy load.

The test creates a database which is then dropped. After dropping the database, it waits for the database folder to be deleted. This relies on the `DatabaseManagerThread` to kick in and do the cleanup, which is already problematic when the operating system is under stress. However, even if this succeeds, it's not entirely impossible that we could encounter a scenario where the directory entry is still available in the operating system cache even after the directory has been deleted.

Such situations are rare and usually occur only in cases of high file system load. This is an attempt to ensure that the information is up-to-date, as trying to read the contents of a file from *within the database directory* might force the operating system to refresh its inode cache.

For reference, see the failure encountered during the [nightly build](https://jenkins01.arangodb.biz/job/arangodb-ANY-linux-matrix.x86-64/EDITION=community,STORAGE_ENGINE=rocksdb,TEST_SUITE=single,limit=linux&&test&&x86-64/4252/artifact/testfailures.txt)

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification
