### PR TITLE
ES-1515: Make metrics output format configurable

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,16 @@
+v3.10.5.2 (XXXX-XX-XX)
+----------------------
+
+* Added startup option `--server.ensure-whitespace-metrics-format`, which
+  controls whether additional whitespace is used in the metrics output 
+  format. If set to `true`, then whitespace is emitted between the exported
+  metric value and the preceeding token (metric name or labels).
+  Using whitespace may be required to make the metrics output compatible with
+  some processing tools, although Prometheus itself doesn't need it.
+
+  The option defaults to `true`, which adds additional whitespace by default.
+
+
 v3.10.5.1 (2023-03-28)
 ----------------------
 

--- a/arangod/IResearch/IResearchDataStore.cpp
+++ b/arangod/IResearch/IResearchDataStore.cpp
@@ -2058,7 +2058,8 @@ void IResearchDataStore::initClusterMetrics() const {
   };
   auto batchToPrometheus = [](std::string& result, std::string_view globals,
                               std::string_view name, std::string_view labels,
-                              ClusterMetricsFeature::MetricValue const& value) {
+                              ClusterMetricsFeature::MetricValue const& value,
+                              bool ensureWhitespace) {
     Metric::addMark(result, name, globals, labels);
     absl::StrAppend(&result, std::get<uint64_t>(value), "\n");
   };

--- a/arangod/Metrics/Batch.h
+++ b/arangod/Metrics/Batch.h
@@ -36,7 +36,8 @@ namespace arangodb::metrics {
 template<typename T>
 class Batch final : public IBatch {
  public:
-  void toPrometheus(std::string& result, std::string_view globals) const final {
+  void toPrometheus(std::string& result, std::string_view globals,
+                    bool ensureWhitespace) const final {
     TRI_ASSERT(!_metrics.empty());
     std::vector<typename T::Data> metrics;
     metrics.reserve(_metrics.size());
@@ -50,6 +51,9 @@ class Batch final : public IBatch {
       Metric::addInfo(result, T::kName[i], T::kHelp[i], T::kType[i]);
       for (size_t j = 0; auto& [labels, _] : _metrics) {
         Metric::addMark(result, T::kName[i], globals, labels);
+        if (ensureWhitespace) {
+          result.push_back(' ');
+        }
         result.append(T::kToString[i](metrics[j++])) += '\n';
       }
     }

--- a/arangod/Metrics/ClusterMetricsFeature.cpp
+++ b/arangod/Metrics/ClusterMetricsFeature.cpp
@@ -321,7 +321,8 @@ void ClusterMetricsFeature::add(std::string_view metric, MapReduce mapReduce,
 }
 
 void ClusterMetricsFeature::toPrometheus(std::string& result,
-                                         std::string_view globals) const {
+                                         std::string_view globals,
+                                         bool ensureWhitespace) const {
   auto data = getData();
   if (!data) {
     return;
@@ -339,7 +340,8 @@ void ClusterMetricsFeature::toPrometheus(std::string& result,
       }
     }
     if (it != _toPrometheus.end()) {
-      it->second(result, globals, metricName, key.labels, value);
+      it->second(result, globals, metricName, key.labels, value,
+                 ensureWhitespace);
     }
   }
 }

--- a/arangod/Metrics/ClusterMetricsFeature.h
+++ b/arangod/Metrics/ClusterMetricsFeature.h
@@ -127,7 +127,7 @@ class ClusterMetricsFeature final : public ArangodFeature {
                                 std::string_view /*global labels*/,
                                 std::string_view /*metric name*/,
                                 std::string_view /*metric labels*/,
-                                MetricValue const&);
+                                MetricValue const&, bool /*ensure whitespace*/);
 
   //////////////////////////////////////////////////////////////////////////////
   /// Registration of some metric. We need to pass it name, and callbacks.
@@ -144,7 +144,8 @@ class ClusterMetricsFeature final : public ArangodFeature {
   //////////////////////////////////////////////////////////////////////////////
   void add(std::string_view metric, MapReduce mapReduce);
 
-  void toPrometheus(std::string& result, std::string_view globals) const;
+  void toPrometheus(std::string& result, std::string_view globals,
+                    bool ensureWhitespace) const;
 
   std::shared_ptr<Data> getData() const;
 

--- a/arangod/Metrics/Counter.cpp
+++ b/arangod/Metrics/Counter.cpp
@@ -35,10 +35,13 @@ Counter::~Counter() { _b.push(); }
 
 std::string_view Counter::type() const noexcept { return "counter"; }
 
-void Counter::toPrometheus(std::string& result,
-                           std::string_view globals) const {
+void Counter::toPrometheus(std::string& result, std::string_view globals,
+                           bool ensureWhitespace) const {
   _b.push();
   Metric::addMark(result, name(), globals, labels());
+  if (ensureWhitespace) {
+    result.push_back(' ');
+  }
   result.append(std::to_string(load())) += '\n';
 }
 

--- a/arangod/Metrics/Counter.h
+++ b/arangod/Metrics/Counter.h
@@ -40,7 +40,8 @@ class Counter final : public Metric {
   ~Counter() final;
 
   [[nodiscard]] std::string_view type() const noexcept final;
-  void toPrometheus(std::string& result, std::string_view globals) const final;
+  void toPrometheus(std::string& result, std::string_view globals,
+                    bool ensureWhitespace) const final;
 
   [[nodiscard]] uint64_t load() const noexcept;
   void store(uint64_t n) noexcept;

--- a/arangod/Metrics/Gauge.h
+++ b/arangod/Metrics/Gauge.h
@@ -41,8 +41,12 @@ class Gauge final : public Metric {
 
   [[nodiscard]] std::string_view type() const noexcept final { return "gauge"; }
 
-  void toPrometheus(std::string& result, std::string_view globals) const final {
+  void toPrometheus(std::string& result, std::string_view globals,
+                    bool ensureWhitespace) const final {
     Metric::addMark(result, name(), globals, labels());
+    if (ensureWhitespace) {
+      result.push_back(' ');
+    }
     result.append(std::to_string(load())) += '\n';
   }
 

--- a/arangod/Metrics/Histogram.h
+++ b/arangod/Metrics/Histogram.h
@@ -120,7 +120,8 @@ class Histogram : public Metric {
 
   size_t size() const { return _c.size(); }
 
-  void toPrometheus(std::string& result, std::string_view globals) const final {
+  void toPrometheus(std::string& result, std::string_view globals,
+                    bool ensureWhitespace) const final {
     std::string ls;
     auto const globals_size = globals.size();
     auto const labels_size = labels().size();
@@ -138,11 +139,20 @@ class Histogram : public Metric {
         result.append(ls) += ',';
       }
       result.append("le=\"").append(_scale.delim(i)).append("\"}");
+      if (ensureWhitespace) {
+        result.push_back(' ');
+      }
       result.append(std::to_string(sum)) += '\n';
     }
     (result.append(name()).append("_count") += '{').append(ls) += '}';
+    if (ensureWhitespace) {
+      result.push_back(' ');
+    }
     result.append(std::to_string(sum)) += '\n';
     (result.append(name()).append("_sum") += '{').append(ls) += '}';
+    if (ensureWhitespace) {
+      result.push_back(' ');
+    }
     result.append(std::to_string(_sum.load(std::memory_order_relaxed))) += '\n';
   }
 

--- a/arangod/Metrics/IBatch.h
+++ b/arangod/Metrics/IBatch.h
@@ -36,8 +36,8 @@ namespace arangodb::metrics {
 
 class IBatch {
  public:
-  virtual void toPrometheus(std::string& result,
-                            std::string_view globals) const = 0;
+  virtual void toPrometheus(std::string& result, std::string_view globals,
+                            bool ensureWhitespace) const = 0;
 
   virtual void toVPack(velocypack::Builder& builder, ArangodServer&) const = 0;
 

--- a/arangod/Metrics/Metric.h
+++ b/arangod/Metrics/Metric.h
@@ -56,8 +56,8 @@ class Metric {
   /// \param result toPrometheus handler response
   /// \param globals labels that all metrics have
   //////////////////////////////////////////////////////////////////////////////
-  virtual void toPrometheus(std::string& result,
-                            std::string_view globals) const = 0;
+  virtual void toPrometheus(std::string& result, std::string_view globals,
+                            bool ensureWhitespace) const = 0;
   virtual void toVPack(velocypack::Builder& builder,
                        ArangodServer& server) const;
 

--- a/arangod/Metrics/MetricsFeature.cpp
+++ b/arangod/Metrics/MetricsFeature.cpp
@@ -48,7 +48,8 @@ namespace arangodb::metrics {
 MetricsFeature::MetricsFeature(Server& server)
     : ArangodFeature{server, *this},
       _export{true},
-      _exportReadWriteMetrics{false} {
+      _exportReadWriteMetrics{false},
+      _ensureWhitespace{true} {
   setOptional(false);
   startsAfter<LoggerFeature>();
   startsBefore<application_features::GreetingsFeaturePhase>();
@@ -74,6 +75,22 @@ void MetricsFeature::collectOptions(
                   arangodb::options::makeDefaultFlags(
                       arangodb::options::Flags::Uncommon))
       .setIntroducedIn(30707);
+
+  options
+      ->addOption(
+          "--server.ensure-whitespace-metrics-format",
+          "Set to `true` to ensure whitespace between the exported metric "
+          "value "
+          "and the preceeding token (metric name or labels) in the metrics "
+          "output.",
+          new options::BooleanParameter(&_ensureWhitespace),
+          arangodb::options::makeDefaultFlags(
+              arangodb::options::Flags::Uncommon))
+      .setLongDescription(
+          R"(Using the whitespace characters in the output may be
+required to make the metrics output compatible with some processing tools, although "
+Prometheus itself doesn't need it.)")
+      .setIntroducedIn(31006);
 }
 
 std::shared_ptr<Metric> MetricsFeature::doAdd(Builder& builder) {
@@ -104,7 +121,11 @@ bool MetricsFeature::remove(Builder const& builder) {
   return _registry.erase(key) != 0;
 }
 
-bool MetricsFeature::exportAPI() const { return _export; }
+bool MetricsFeature::exportAPI() const noexcept { return _export; }
+
+bool MetricsFeature::ensureWhitespace() const noexcept {
+  return _ensureWhitespace;
+}
 
 void MetricsFeature::validateOptions(std::shared_ptr<options::ProgramOptions>) {
   if (_exportReadWriteMetrics) {
@@ -132,25 +153,25 @@ void MetricsFeature::toPrometheus(std::string& result, CollectMode mode) const {
         last = curr;
         Metric::addInfo(result, curr, i.second->help(), i.second->type());
       }
-      i.second->toPrometheus(result, _globals);
+      i.second->toPrometheus(result, _globals, _ensureWhitespace);
     }
     for (auto const& [_, batch] : _batch) {
       TRI_ASSERT(batch);
       // TODO(MBkkt) merge vector::reserve's between IBatch::toPrometheus
-      batch->toPrometheus(result, _globals);
+      batch->toPrometheus(result, _globals, _ensureWhitespace);
     }
   }
   auto& sf = server().getFeature<StatisticsFeature>();
   auto time = std::chrono::duration<double, std::milli>(
       std::chrono::system_clock::now().time_since_epoch());
-  sf.toPrometheus(result, time.count());
+  sf.toPrometheus(result, time.count(), _ensureWhitespace);
   auto& es = server().getFeature<EngineSelectorFeature>().engine();
   if (es.typeName() == RocksDBEngine::kEngineName) {
     es.getStatistics(result);
   }
   auto& cm = server().getFeature<ClusterMetricsFeature>();
   if (hasGlobals && cm.isEnabled() && mode != CollectMode::Local) {
-    cm.toPrometheus(result, _globals);
+    cm.toPrometheus(result, _globals, _ensureWhitespace);
   }
 }
 

--- a/arangod/Metrics/MetricsFeature.h
+++ b/arangod/Metrics/MetricsFeature.h
@@ -45,7 +45,8 @@ class MetricsFeature final : public ArangodFeature {
 
   explicit MetricsFeature(Server& server);
 
-  bool exportAPI() const;
+  bool exportAPI() const noexcept;
+  bool ensureWhitespace() const noexcept;
 
   void collectOptions(std::shared_ptr<options::ProgramOptions>) final;
   void validateOptions(std::shared_ptr<options::ProgramOptions>) final;
@@ -105,6 +106,9 @@ class MetricsFeature final : public ArangodFeature {
 
   bool _export;
   bool _exportReadWriteMetrics;
+  // ensure that there is whitespace before the reported value, regardless
+  // of whether it is preceeded by labels or not.
+  bool _ensureWhitespace;
 };
 
 }  // namespace arangodb::metrics

--- a/arangod/Statistics/StatisticsFeature.h
+++ b/arangod/Statistics/StatisticsFeature.h
@@ -96,7 +96,7 @@ class StatisticsFeature final : public ArangodFeature {
   void prepare() override final;
   void start() override final;
   void stop() override final;
-  void toPrometheus(std::string& result, double const& now);
+  void toPrometheus(std::string& result, double now, bool ensureWhitespace);
 
   stats::Descriptions const& descriptions() const { return _descriptions; }
 
@@ -104,7 +104,7 @@ class StatisticsFeature final : public ArangodFeature {
       statistics::Distribution const& dist);
 
   static void appendMetric(std::string& result, std::string const& val,
-                           std::string const& label);
+                           std::string const& label, bool ensureWhitespace);
 
   Result getClusterSystemStatistics(
       TRI_vocbase_t& vocbase, double start,
@@ -117,7 +117,7 @@ class StatisticsFeature final : public ArangodFeature {
                               statistics::Distribution const& dist,
                               std::string const& label,
                               std::initializer_list<std::string> const& les,
-                              bool isInteger);
+                              bool isInteger, bool ensureWhitespace);
   bool _statistics;
   bool _statisticsHistory;
   bool _statisticsHistoryTouched;

--- a/js/client/modules/@arangodb/test-helper.js
+++ b/js/client/modules/@arangodb/test-helper.js
@@ -206,7 +206,7 @@ function getMetricName(text, name) {
   if (!matches.length) {
     throw "Metric " + name + " not found";
   }
-  return Number(matches[0].replace(/^.*{.*}([0-9.]+)$/, "$1"));
+  return Number(matches[0].replace(/^.*{.*}\s*([0-9.]+)$/, "$1"));
 }
 
 exports.getMetric = function (endpoint, name) {

--- a/js/server/modules/@arangodb/test-helper.js
+++ b/js/server/modules/@arangodb/test-helper.js
@@ -122,7 +122,7 @@ function getMetricName(text, name) {
   if (!matches.length) {
     throw "Metric " + name + " not found";
   }
-  return Number(matches[0].replace(/^.*{.*}([0-9.]+)$/, "$1"));
+  return Number(matches[0].replace(/^.*{.*}\s*([0-9.]+)$/, "$1"));
 }
 
 exports.getMetric = function (endpoint, name) {

--- a/tests/IResearch/IResearchLinkTest.cpp
+++ b/tests/IResearch/IResearchLinkTest.cpp
@@ -2321,7 +2321,7 @@ class IResearchLinkMetricsTest : public IResearchLinkTest {
     auto& f = _vocbase.server().getFeature<arangodb::metrics::MetricsFeature>();
     auto [lock, batch] = f.getBatch("arangodb_search_link_stats");
     EXPECT_TRUE(batch != nullptr);
-    batch->toPrometheus(result, "");
+    batch->toPrometheus(result, "", /*ensureWhitespace*/ false);
   }
 
   double insert(uint64_t begin, uint64_t end, size_t docId,

--- a/tests/Metrics/MetricsFeatureTest.cpp
+++ b/tests/Metrics/MetricsFeatureTest.cpp
@@ -51,10 +51,10 @@ TEST_F(MetricsFeatureTest, test_counter) {
 
   ASSERT_EQ(counter.load(), 0);
   std::string s;
-  counter.toPrometheus(s, "");
+  counter.toPrometheus(s, "", /*ensureWhitespace*/ false);
   std::cout << s << std::endl;
   s.clear();
-  labeledCounter.toPrometheus(s, "");
+  labeledCounter.toPrometheus(s, "", /*ensureWhitespace*/ false);
   std::cout << s << std::endl;
 
   thisMetric = &counter;
@@ -77,10 +77,10 @@ TEST_F(MetricsFeatureTest, test_histogram) {
       feature.add(HISTOGRAMLIN{}.withLabel("label", "label"));
 
   std::string s;
-  histogram.toPrometheus(s, "");
+  histogram.toPrometheus(s, "", /*ensureWhitespace*/ false);
   std::cout << s << std::endl;
   s.clear();
-  labeledHistogram.toPrometheus(s, "");
+  labeledHistogram.toPrometheus(s, "", /*ensureWhitespace*/ false);
   std::cout << s << std::endl;
 
   thisMetric = &histogram;
@@ -102,10 +102,10 @@ TEST_F(MetricsFeatureTest, test_gauge) {
   auto& labeledGauge = feature.add(GAUGE{}.withLabel("label", "label"));
 
   std::string s;
-  gauge.toPrometheus(s, "");
+  gauge.toPrometheus(s, "", /*ensureWhitespace*/ false);
   std::cout << s << std::endl;
   s.clear();
-  labeledGauge.toPrometheus(s, "");
+  labeledGauge.toPrometheus(s, "", /*ensureWhitespace*/ false);
   std::cout << s << std::endl;
 
   thisMetric = &gauge;

--- a/tests/Metrics/MetricsTest.cpp
+++ b/tests/Metrics/MetricsTest.cpp
@@ -574,7 +574,7 @@ void histogram_test(Scale const& scale) {
 
   // dump
   std::string s;
-  h.toPrometheus(s, "");
+  h.toPrometheus(s, "", /*ensureWhitespace*/ false);
 }
 
 TEST(MetricsTest, test_double_histogram) {

--- a/tests/js/client/server_parameters/test-ensure-whitespace-metrics-format-off.js
+++ b/tests/js/client/server_parameters/test-ensure-whitespace-metrics-format-off.js
@@ -1,0 +1,65 @@
+/*jshint globalstrict:false, strict:false */
+/* global getOptions, assertNotEqual, assertMatch, assertNotMatch, arango */
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief test metrics options
+///
+/// DISCLAIMER
+///
+/// Copyright 2010-2012 triagens GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB Inc, Cologne, Germany
+///
+/// @author Jan Steemann
+/// @author Copyright 2019, ArangoDB Inc, Cologne, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+if (getOptions === true) {
+  return {
+    'server.ensure-whitespace-metrics-format': "false",
+  };
+}
+
+const jsunity = require('jsunity');
+
+function testSuite() {
+  let getMetrics = function() {
+    let res = arango.GET_RAW(`/_admin/metrics/v2`);
+    return res.body.split(/\n/).filter((l) => l.trim() !== '').map((l) => l.trim());
+  };
+
+  return {
+    testMetricsWithLabelsContainNoWhitespace : function() {
+      let lines = getMetrics();
+      assertNotEqual(0, lines);
+
+      lines.forEach((l) => {
+        // ignore TYPE and HELP
+        if (l.match(/^#/)) {
+          return;
+        }
+        if (l.includes('}')) {
+          assertMatch(/^.*\}([0-9]+(\.[0-9]+)?)$/, l);
+        } else {
+          assertMatch(/^.*[0-9a-zA-Z]\s+([0-9]+(\.[0-9]+)?)$/, l);
+        }
+      });
+    },
+    
+  };
+}
+
+jsunity.run(testSuite);
+return jsunity.done();

--- a/tests/js/client/server_parameters/test-ensure-whitespace-metrics-format-on.js
+++ b/tests/js/client/server_parameters/test-ensure-whitespace-metrics-format-on.js
@@ -1,0 +1,63 @@
+/*jshint globalstrict:false, strict:false */
+/* global getOptions, assertNotEqual, assertMatch, assertNotMatch, arango */
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief test metrics options
+///
+/// DISCLAIMER
+///
+/// Copyright 2010-2012 triagens GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB Inc, Cologne, Germany
+///
+/// @author Jan Steemann
+/// @author Copyright 2019, ArangoDB Inc, Cologne, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+if (getOptions === true) {
+  return {
+    'server.ensure-whitespace-metrics-format': "true",
+  };
+}
+
+const jsunity = require('jsunity');
+
+function testSuite() {
+  let getMetrics = function() {
+    let res = arango.GET_RAW(`/_admin/metrics/v2`);
+    return res.body.split(/\n/).filter((l) => l.trim() !== '').map((l) => l.trim());
+  };
+
+  return {
+    testMetricsContainWhitespace : function() {
+      let lines = getMetrics();
+      assertNotEqual(0, lines);
+
+      lines.forEach((l) => {
+        // ignore TYPE and HELP
+        if (l.match(/^#/)) {
+          return;
+        }
+        assertNotMatch(/^.*[a-zA-Z\}]([0-9]+(\.[0-9]+)?)$/, l);
+        // whitespace is _required_ in this setup
+        assertMatch(/^.*[0-9a-zA-Z\}]\s+([0-9]+(\.[0-9]+)?)$/, l);
+      });
+    },
+    
+  };
+}
+
+jsunity.run(testSuite);
+return jsunity.done();


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/18702

* Added startup option `--server.ensure-whitespace-metrics-format`, which controls whether additional whitespace is used in the metrics output format. If set to `true`, then whitespace is emitted between the exported metric value and the preceeding token (metric name or labels). Using whitespace may be required to make the metrics output compatible with some processing tools, although Prometheus itself doesn't need it.
  The option defaults to `true`, which adds additional whitespace by default.

This should fix issues https://github.com/arangodb/arangodb/issues/18692 and https://arangodb.atlassian.net/browse/ES-1515.

- [x] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [x] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.10: https://github.com/arangodb/arangodb/pull/18699/
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [x] GitHub issue / Jira ticket: https://github.com/arangodb/arangodb/issues/18692, https://arangodb.atlassian.net/browse/ES-1515
- [ ] Design document: 