### PR TITLE
[PREGEL] Fix load-balancing-pregel-auth-cluster test

### DIFF
--- a/arangod/Pregel/Conductor/Conductor.h
+++ b/arangod/Pregel/Conductor/Conductor.h
@@ -71,6 +71,7 @@ class Conductor : public std::enable_shared_from_this<Conductor> {
   PregelFeature& _feature;
   const DatabaseGuard _vocbaseGuard;
   ExecutionSpecifications _specifications;
+  std::string _user;
 
   std::unique_ptr<MasterContext> _masterContext;
   std::unique_ptr<IAlgorithm> _algorithm;
@@ -120,7 +121,7 @@ class Conductor : public std::enable_shared_from_this<Conductor> {
   void finishedWorkerFinalize(Finished const& data);
 
  public:
-  Conductor(ExecutionSpecifications const& specifications,
+  Conductor(ExecutionSpecifications const& specifications, std::string user,
             TRI_vocbase_t& vocbase, PregelFeature& feature);
 
   ~Conductor();

--- a/arangod/Pregel/PregelFeature.cpp
+++ b/arangod/Pregel/PregelFeature.cpp
@@ -418,8 +418,8 @@ ResultT<ExecutionNumber> PregelFeature::startExecution(TRI_vocbase_t& vocbase,
 
     return en;
   } else {
-    auto c = std::make_shared<pregel::Conductor>(executionSpecifications,
-                                                 vocbase, *this);
+    auto c = std::make_shared<pregel::Conductor>(
+        executionSpecifications, ExecContext::current().user(), vocbase, *this);
     addConductor(std::move(c), en);
     TRI_ASSERT(conductor(en));
     conductor(en)->start();
@@ -717,7 +717,7 @@ void PregelFeature::addConductor(std::shared_ptr<Conductor>&& c,
     THROW_ARANGO_EXCEPTION(TRI_ERROR_SHUTTING_DOWN);
   }
 
-  std::string user = ExecContext::current().user();
+  std::string user = c->_user;
   std::lock_guard guard{_mutex};
   _conductors.try_emplace(
       executionNumber,

--- a/arangod/Pregel/PregelOptions.h
+++ b/arangod/Pregel/PregelOptions.h
@@ -152,7 +152,7 @@ auto inspect(Inspector& f, ExecutionSpecifications& x) {
       f.field("maxSuperstep", x.maxSuperstep),
       f.field("storeResults", x.storeResults), f.field("ttl", x.ttl),
       f.field("parallelism", x.parallelism),
-      f.field("userParamters", x.userParameters));
+      f.field("userParameters", x.userParameters));
 }
 
 }  // namespace arangodb::pregel


### PR DESCRIPTION
Should fix https://jenkins01.arangodb.biz/job/arangodb-matrix-pr-windows/21263/EDITION=community,STORAGE_ENGINE=rocksdb,TEST_SUITE=cluster,limit=windows&&test&&!rta&&!release/testReport/junit/EE_load_balancing_auth__tests_js_client_load-balancing_load-balancing-pregel-auth-cluster/js/EE_testPregelForwardingSameUser/

We now write the correct user into the historic pregel collection. Before, we wrote `ExecContext::current().user()` into the collection, which first can be null depending on which thread this is executed on (this null gave us the occasional bug) and second is not correct: We want to always write the user that started the pregel run.

Additionally, the test is improved: In the test we now make sure that the pregel run was created before we request its status, same for canceling the run.