### PR TITLE
Automatically repair revision trees after shard sync failures

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,13 @@
 v3.9.11 (XXXX-XX-XX)
 --------------------
 
+* Automatically repair revision trees after several failed shard
+  synchronization attempts. This can help to get permanently out-of-sync
+  shards back into sync.
+
+  The functionality can be turned off by setting the startup option
+  `--replication.auto-repair-revision-trees` to `false` on DB-Servers.
+
 * Apply intermediate commits for replication transactions during initial sync
   phase of replication in case the follower already had documents.
   This fixes issues with large replication transactions consuming a lot of

--- a/Documentation/Metrics/arangodb_sync_tree_rebuilds_total.yaml
+++ b/Documentation/Metrics/arangodb_sync_tree_rebuilds_total.yaml
@@ -1,0 +1,21 @@
+name: arangodb_sync_tree_rebuilds_total
+introducedIn: "3.10.6"
+help: |
+  Number of times a revision tree for a shard was completely 
+  rebuilt because of too many subsequent failures in the shard
+  synchronization.
+unit: number
+type: counter
+category: Replication
+complexity: medium
+exposedBy:
+  - dbserver
+  - single
+description: |
+  Number of times a revision tree for a shard was completely
+  rebuilt because of too many subsequent failures in the shard
+  synchronization.
+  If shards cannot get in sync after several attempts, the shard's
+  revision tree is first rebuilt on the follower, and then on the
+  leader. If the value is greater than zero, it means there have
+  been shard synchronization failures.

--- a/Documentation/Metrics/arangodb_sync_tree_rebuilds_total.yaml
+++ b/Documentation/Metrics/arangodb_sync_tree_rebuilds_total.yaml
@@ -1,5 +1,5 @@
 name: arangodb_sync_tree_rebuilds_total
-introducedIn: "3.10.6"
+introducedIn: "3.9.11"
 help: |
   Number of times a revision tree for a shard was completely 
   rebuilt because of too many subsequent failures in the shard

--- a/arangod/Cluster/ClusterFeature.cpp
+++ b/arangod/Cluster/ClusterFeature.cpp
@@ -582,6 +582,9 @@ DECLARE_COUNTER(arangodb_sync_wrong_checksum_total,
 DECLARE_COUNTER(arangodb_sync_rebuilds_total,
                 "Number of times a follower shard needed to be completely "
                 "rebuilt because of too many synchronization failures");
+DECLARE_COUNTER(arangodb_sync_tree_rebuilds_total,
+                "Number of times a shard rebuilt its revision tree "
+                "completely because of too many synchronization failures");
 
 // IMPORTANT: Please read the first comment block a couple of lines down, before
 // Adding code to this section.
@@ -662,6 +665,9 @@ void ClusterFeature::start() {
     _followersTotalRebuildCounter =
         server().getFeature<arangodb::MetricsFeature>().add(
             arangodb_sync_rebuilds_total{});
+    _syncTreeRebuildCounter =
+        server().getFeature<arangodb::MetricsFeature>().add(
+            arangodb_sync_tree_rebuilds_total{});
   }
 
   LOG_TOPIC("b6826", INFO, arangodb::Logger::CLUSTER)

--- a/arangod/Cluster/ClusterFeature.h
+++ b/arangod/Cluster/ClusterFeature.h
@@ -111,6 +111,7 @@ class ClusterFeature : public application_features::ApplicationFeature {
   Counter& followersTotalRebuildCounter() {
     return _followersTotalRebuildCounter->get();
   }
+  Counter& syncTreeRebuildCounter() { return _syncTreeRebuildCounter->get(); }
 
   /**
    * @brief Add databases to dirty list
@@ -205,7 +206,10 @@ class ClusterFeature : public application_features::ApplicationFeature {
   std::optional<std::reference_wrapper<Counter>> _followersDroppedCounter;
   std::optional<std::reference_wrapper<Counter>> _followersRefusedCounter;
   std::optional<std::reference_wrapper<Counter>> _followersWrongChecksumCounter;
+  // note: this metric is only there for downwards-compatibility reasons. it
+  // will always have a value of 0.
   std::optional<std::reference_wrapper<Counter>> _followersTotalRebuildCounter;
+  std::optional<std::reference_wrapper<Counter>> _syncTreeRebuildCounter;
   std::shared_ptr<AgencyCallback> _hotbackupRestoreCallback;
 
   /// @brief lock for dirty database list

--- a/arangod/Cluster/MaintenanceFeature.h
+++ b/arangod/Cluster/MaintenanceFeature.h
@@ -35,6 +35,7 @@
 #include "ProgramOptions/ProgramOptions.h"
 #include "RestServer/MetricsFeature.h"
 
+#include <map>
 #include <memory>
 #include <mutex>
 #include <queue>
@@ -90,7 +91,6 @@ class MaintenanceFeature : public application_features::ApplicationFeature {
   /// @brief Highest limit for worker threads
   static constexpr uint32_t const maxThreadLimit = 64;
 
- public:
   void collectOptions(std::shared_ptr<options::ProgramOptions>) override;
   void validateOptions(std::shared_ptr<options::ProgramOptions>) override;
 
@@ -407,6 +407,14 @@ class MaintenanceFeature : public application_features::ApplicationFeature {
   /// @brief maximum number of replication error occurrences that are kept per
   /// shard.
   static constexpr size_t maxReplicationErrorsPerShard = 20;
+
+  /// @brief maximum number of replication error occurrences that are tolerated
+  /// before an auto-repair is attempted
+  static constexpr size_t maxReplicationErrorsPerShardBeforeAutoRepair =
+      maxReplicationErrorsPerShard - 3;
+
+  static_assert(maxReplicationErrorsPerShard >
+                maxReplicationErrorsPerShardBeforeAutoRepair);
 
   /// @brief maximum age of replication error occurrences that are kept per
   /// shard. error occurrences older than this max age will be removed only

--- a/arangod/Cluster/SynchronizeShard.cpp
+++ b/arangod/Cluster/SynchronizeShard.cpp
@@ -50,6 +50,7 @@
 #include "Replication/ReplicationFeature.h"
 #include "RestServer/DatabaseFeature.h"
 #include "RestServer/ServerIdFeature.h"
+#include "RocksDBEngine/RocksDBCollection.h"
 #include "StorageEngine/EngineSelectorFeature.h"
 #include "StorageEngine/PhysicalCollection.h"
 #include "StorageEngine/StorageEngine.h"
@@ -305,6 +306,28 @@ static arangodb::Result addShardFollower(
         }
 #endif
       }
+
+      TRI_IF_FAILURE("synchronizeShardSendTreeData") {
+        // include revision tree data (hash and count value) in the
+        // request. the leader can use this to compare its own revision
+        // tree with the revision tree of the follower.
+        // we normally don't transfer this data, because there may
+        // be buffered writes for the revision trees which are not
+        // yet applied to the tree. additionally, writes may go on
+        // on the leader so there is no good way to determine which
+        // revision tree state to use and compare on the leader.
+        auto context =
+            transaction::StandaloneContext::Create(collection->vocbase());
+        SingleCollectionTransaction trx(context, *collection,
+                                        AccessMode::Type::READ, {});
+
+        auto res = trx.begin();
+        if (res.ok()) {
+          auto tree = collection->getPhysical()->revisionTree(trx);
+          body.add("treeHash", VPackValue(std::to_string(tree->rootValue())));
+          body.add("treeCount", VPackValue(std::to_string(tree->count())));
+        }
+      }
     }
 
     network::RequestOptions options;
@@ -330,9 +353,6 @@ static arangodb::Result addShardFollower(
       } else {
         LOG_TOPIC("abf2e", INFO, Logger::MAINTENANCE)
             << errorMessage << " with shortcut (can happen, no problem).";
-        if (result.errorNumber() == TRI_ERROR_REPLICATION_SHARD_NONEMPTY) {
-          return result;  // hand on leader protest
-        }
       }
       return arangodb::Result(
           result.errorNumber(),
@@ -720,6 +740,133 @@ bool SynchronizeShard::first() {
                         _description.get(SYNC_BY_REVISION) == "true";
 
   size_t failuresInRow = _feature.replicationErrors(database, shard);
+
+  bool autoRepairRevisionTrees = _feature.server()
+                                     .getFeature<ReplicationFeature>()
+                                     .autoRepairRevisionTrees();
+
+  if (autoRepairRevisionTrees &&
+      failuresInRow ==
+          MaintenanceFeature::maxReplicationErrorsPerShardBeforeAutoRepair) {
+    // rebuild revision tree on follower
+    auto& df = _feature.server().getFeature<DatabaseFeature>();
+    DatabaseGuard guard(df, database);
+    auto vocbase = &guard.database();
+
+    auto collection = vocbase->lookupCollection(shard);
+    if (collection != nullptr && syncByRevision &&
+        collection->useSyncByRevision()) {
+      LOG_TOPIC("7a2cf", WARN, Logger::MAINTENANCE)
+          << "SynchronizeShard: synchronizing shard '" << database << "/"
+          << shard << "' for central '" << database << "/" << planId
+          << "' encountered " << failuresInRow
+          << " failures in a row. now auto-repairing revision tree of follower "
+             "shard";
+
+      // increase a metric for rebuilt revisions trees on this server
+      ++_feature.server().getFeature<ClusterFeature>().syncTreeRebuildCounter();
+
+      Result res = static_cast<RocksDBCollection*>(collection->getPhysical())
+                       ->rebuildRevisionTree();
+
+      if (res.ok()) {
+        LOG_TOPIC("02969", INFO, Logger::MAINTENANCE)
+            << "SynchronizeShard: synchronizing shard '" << database << "/"
+            << shard << "' for central '" << database << "/" << planId
+            << "' successfully rebuilt revision tree for follower shard";
+        // still mark the current attempt as failed, because we are still not in
+        // sync and don't know if we will get in sync upon the next attempt
+        res.reset(TRI_ERROR_REPLICATION_WRONG_CHECKSUM);
+      } else {
+        LOG_TOPIC("dd893", WARN, Logger::MAINTENANCE)
+            << "SynchronizeShard: synchronizing shard '" << database << "/"
+            << shard << "' for central '" << database << "/" << planId
+            << "' could not rebuild revision tree for follower shard: "
+            << res.errorMessage();
+      }
+
+      // we intentionally let the shard synchronization run fail here.
+      // although we have rebuilt the revision tree now, we can't be sure
+      // that upon the next sync attempt the shard will get in sync.
+      // the reason is that the leader's revision tree could also have
+      // problems.
+      // so we simply run the synchronization another time, and then it
+      // either succeeds, or it will fail and we will rebuild the revision
+      // tree on the leader shard then.
+      TRI_ASSERT(res.fail());
+      result(res.errorNumber());
+      return false;
+    }
+  }
+
+  if (autoRepairRevisionTrees &&
+      failuresInRow ==
+          MaintenanceFeature::maxReplicationErrorsPerShardBeforeAutoRepair +
+              1) {
+    // rebuild revision tree on leader
+    auto& df = _feature.server().getFeature<DatabaseFeature>();
+    DatabaseGuard guard(df, database);
+    auto vocbase = &guard.database();
+
+    auto collection = vocbase->lookupCollection(shard);
+    if (collection != nullptr && syncByRevision &&
+        collection->useSyncByRevision()) {
+      LOG_TOPIC("614fa", WARN, Logger::MAINTENANCE)
+          << "SynchronizeShard: synchronizing shard '" << database << "/"
+          << shard << "' for central '" << database << "/" << planId
+          << "' encountered " << failuresInRow
+          << " failures in a row. now auto-repairing revision tree of leader "
+             "shard";
+
+      VPackBuffer<uint8_t> buffer;
+      VPackBuilder tmp(buffer);
+      tmp.add(VPackSlice::emptyObjectSlice());
+
+      network::RequestOptions reqOpts;
+      reqOpts.database = database;
+      reqOpts.timeout = network::Timeout(6000.0);  // this can be slow!!!
+      reqOpts.skipScheduler = true;  // hack to speed up future.get()
+      reqOpts.param("collection", shard);
+
+      std::string const url = "/_api/replication/revisions/tree";
+
+      // send out the request
+      NetworkFeature& nf = _feature.server().getFeature<NetworkFeature>();
+      network::ConnectionPool* pool = nf.pool();
+
+      auto& clusterInfo =
+          _feature.server().getFeature<ClusterFeature>().clusterInfo();
+      auto ep = clusterInfo.getServerEndpoint(leader);
+      auto future = network::sendRequest(pool, ep, fuerte::RestVerb::Post, url,
+                                         std::move(buffer), reqOpts);
+
+      network::Response const& r = future.get();
+      Result res = r.combinedResult();
+      if (res.ok()) {
+        LOG_TOPIC("ddcc1", INFO, Logger::MAINTENANCE)
+            << "SynchronizeShard: synchronizing shard '" << database << "/"
+            << shard << "' for central '" << database << "/" << planId
+            << "' successfully rebuilt revision tree for leader shard";
+        // still mark the current attempt as failed, because we are still not in
+        // sync and don't know if we will get in sync upon the next attempt
+        res.reset(TRI_ERROR_REPLICATION_WRONG_CHECKSUM);
+      } else {
+        LOG_TOPIC("29822", WARN, Logger::MAINTENANCE)
+            << "SynchronizeShard: synchronizing shard '" << database << "/"
+            << shard << "' for central '" << database << "/" << planId
+            << "' could not rebuild revision tree for leader shard: "
+            << res.errorMessage();
+      }
+
+      // we intentionally let the shard synchronization run fail here.
+      // we simply run the synchronization another time, and then it
+      // either succeeds, or it will fail again for reasons that we do
+      // not handle yet.
+      TRI_ASSERT(res.fail());
+      result(res.errorNumber());
+      return false;
+    }
+  }
 
   // from this many number of failures in a row, we will step on the brake
   constexpr size_t delayThreshold = 4;

--- a/arangod/Replication/DatabaseInitialSyncer.cpp
+++ b/arangod/Replication/DatabaseInitialSyncer.cpp
@@ -1723,7 +1723,6 @@ Result DatabaseInitialSyncer::fetchCollectionSyncByRevisions(
   });
 
   // diff with local tree
-  // std::pair<std::size_t, std::size_t> fullRange = treeLeader->range();
   auto treeLocal = physical->revisionTree(*trx);
   if (!treeLocal) {
     // local collection does not support syncing by revision, fall back to

--- a/arangod/Replication/ReplicationFeature.cpp
+++ b/arangod/Replication/ReplicationFeature.cpp
@@ -319,6 +319,13 @@ bool ReplicationFeature::autoRepairRevisionTrees() const noexcept {
   return _autoRepairRevisionTrees;
 }
 
+#ifdef ARANGODB_USE_GOOGLE_TESTS
+// only used during testing
+void ReplicationFeature::autoRepairRevisionTrees(bool value) noexcept {
+  _autoRepairRevisionTrees = value;
+}
+#endif
+
 // start the replication applier for a single database
 void ReplicationFeature::startApplier(TRI_vocbase_t* vocbase) {
   TRI_ASSERT(vocbase->type() == TRI_VOCBASE_TYPE_NORMAL);

--- a/arangod/Replication/ReplicationFeature.cpp
+++ b/arangod/Replication/ReplicationFeature.cpp
@@ -94,6 +94,7 @@ ReplicationFeature::ReplicationFeature(ApplicationServer& server)
       _replicationApplierAutoStart(true),
       _enableActiveFailover(false),
       _syncByRevision(true),
+      _autoRepairRevisionTrees(true),
       _connectionCache{server, httpclient::ConnectionCache::Options{5}},
       _parallelTailingInvocations(0),
       _maxParallelTailingInvocations(0),
@@ -174,6 +175,16 @@ void ReplicationFeature::collectOptions(
           "Whether to use the newer revision-based replication protocol",
           new BooleanParameter(&_syncByRevision))
       .setIntroducedIn(30700);
+
+  options
+      ->addOption("--replication.auto-repair-revision-trees",
+                  "Whether to automatically repair revision trees of shards "
+                  "after too many shard synchronization failures.",
+                  new BooleanParameter(&_autoRepairRevisionTrees),
+                  arangodb::options::makeFlags(
+                      arangodb::options::Flags::DefaultNoComponents,
+                      arangodb::options::Flags::OnDBServer))
+      .setIntroducedIn(31100);
 }
 
 void ReplicationFeature::validateOptions(
@@ -300,7 +311,13 @@ bool ReplicationFeature::isActiveFailoverEnabled() const {
   return _enableActiveFailover;
 }
 
-bool ReplicationFeature::syncByRevision() const { return _syncByRevision; }
+bool ReplicationFeature::syncByRevision() const noexcept {
+  return _syncByRevision;
+}
+
+bool ReplicationFeature::autoRepairRevisionTrees() const noexcept {
+  return _autoRepairRevisionTrees;
+}
 
 // start the replication applier for a single database
 void ReplicationFeature::startApplier(TRI_vocbase_t* vocbase) {

--- a/arangod/Replication/ReplicationFeature.cpp
+++ b/arangod/Replication/ReplicationFeature.cpp
@@ -184,7 +184,7 @@ void ReplicationFeature::collectOptions(
                   arangodb::options::makeFlags(
                       arangodb::options::Flags::DefaultNoComponents,
                       arangodb::options::Flags::OnDBServer))
-      .setIntroducedIn(31100);
+      .setIntroducedIn(30911);
 }
 
 void ReplicationFeature::validateOptions(

--- a/arangod/Replication/ReplicationFeature.h
+++ b/arangod/Replication/ReplicationFeature.h
@@ -88,7 +88,9 @@ class ReplicationFeature final
   /// @brief automatic failover of replication using the agency
   bool isActiveFailoverEnabled() const;
 
-  bool syncByRevision() const;
+  bool syncByRevision() const noexcept;
+
+  bool autoRepairRevisionTrees() const noexcept;
 
   /// @brief track the number of (parallel) tailing operations
   /// will throw an exception if the number of concurrently running operations
@@ -133,6 +135,10 @@ class ReplicationFeature final
 
   /// Use the revision-based replication protocol
   bool _syncByRevision;
+
+  /// automatically repair revision trees of shards after too many failed
+  /// shard synchronization attempts
+  bool _autoRepairRevisionTrees;
 
   /// @brief cache for reusable connections
   httpclient::ConnectionCache _connectionCache;

--- a/arangod/Replication/ReplicationFeature.h
+++ b/arangod/Replication/ReplicationFeature.h
@@ -92,6 +92,11 @@ class ReplicationFeature final
 
   bool autoRepairRevisionTrees() const noexcept;
 
+#ifdef ARANGODB_USE_GOOGLE_TESTS
+  // only used during testing
+  void autoRepairRevisionTrees(bool value) noexcept;
+#endif
+
   /// @brief track the number of (parallel) tailing operations
   /// will throw an exception if the number of concurrently running operations
   /// would exceed the configured maximum

--- a/arangod/RestHandler/RestReplicationHandler.cpp
+++ b/arangod/RestHandler/RestReplicationHandler.cpp
@@ -56,6 +56,7 @@
 #include "Replication/ReplicationFeature.h"
 #include "RestServer/DatabaseFeature.h"
 #include "RestServer/ServerIdFeature.h"
+#include "RocksDBEngine/RocksDBCollection.h"
 #include "Sharding/ShardingInfo.h"
 #include "StorageEngine/EngineSelectorFeature.h"
 #include "StorageEngine/PhysicalCollection.h"
@@ -446,6 +447,10 @@ RestStatus RestReplicationHandler::execute() {
           handleCommandRevisionTree();
         } else if (type == rest::RequestType::POST && subCommand == Tree) {
           handleCommandRebuildRevisionTree();
+#ifdef ARANGODB_ENABLE_FAILURE_TESTS
+        } else if (type == rest::RequestType::PUT && subCommand == Tree) {
+          handleCommandCorruptRevisionTree();
+#endif
         } else if (type == rest::RequestType::PUT && subCommand == Ranges) {
           handleCommandRevisionRanges();
         } else if (type == rest::RequestType::PUT && subCommand == Documents) {
@@ -2560,6 +2565,41 @@ void RestReplicationHandler::handleCommandAddFollower() {
     return;
   }
 
+#ifdef ARANGODB_ENABLE_FAILURE_TESTS
+  // compare hash and count values of the local revision tree in case the
+  // caller posted the revision tree data as well.
+  // this check is only performed during failure-testing.
+  // it is not safe to activate it in general, because revision trees on the
+  // leader can advance when there are further writes into the shard.
+  if (body.get("treeHash").isString() && body.get("treeCount").isString()) {
+    auto context = transaction::StandaloneContext::Create(_vocbase);
+    SingleCollectionTransaction trx(context, *col, AccessMode::Type::READ, {});
+
+    auto res = trx.begin();
+    if (res.ok()) {
+      auto tree = col->getPhysical()->revisionTree(trx);
+      if (std::to_string(tree->rootValue()) !=
+          body.get("treeHash").stringView()) {
+        generateError(
+            rest::ResponseCode::BAD, TRI_ERROR_REPLICATION_WRONG_CHECKSUM,
+            "revision tree hashes are different. Expected (leader): " +
+                std::to_string(tree->rootValue()) +
+                ". actual (follower): " + body.get("treeHash").copyString());
+        return;
+      }
+
+      if (std::to_string(tree->count()) != body.get("treeCount").stringView()) {
+        generateError(
+            rest::ResponseCode::BAD, TRI_ERROR_REPLICATION_WRONG_CHECKSUM,
+            "revision tree counts are different. Expected (leader): " +
+                std::to_string(tree->count()) +
+                ". actual (follower): " + body.get("treeCount").copyString());
+        return;
+      }
+    }
+  }
+#endif
+
   Result res = col->followers()->add(followerId);
 
   if (res.fail()) {
@@ -3017,17 +3057,15 @@ bool RestReplicationHandler::prepareRevisionOperation(
   LOG_TOPIC("253e2", TRACE, arangodb::Logger::REPLICATION)
       << "enter prepareRevisionOperation";
 
-  bool found = false;
-
-  // get collection Name
-  ctx.cname = _request->value("collection");
-  if (ctx.cname.empty()) {
-    generateError(rest::ResponseCode::BAD, TRI_ERROR_HTTP_BAD_PARAMETER,
-                  "invalid collection parameter");
+  // get collection name
+  if (!prepareCollectionForRevisionOperation(ctx)) {
     return false;
   }
+  TRI_ASSERT(!ctx.cname.empty());
+  TRI_ASSERT(ctx.collection != nullptr);
 
   // get batchId
+  bool found = false;
   std::string const& batchIdString = _request->value("batchId", found);
   if (found) {
     ctx.batchId = StringUtils::uint64(batchIdString);
@@ -3061,6 +3099,32 @@ bool RestReplicationHandler::prepareRevisionOperation(
       << "requested revision tree for collection '" << ctx.cname
       << "' using contextId '" << ctx.batchId << "'";
 
+  ctx.iter = ctx.collection->getPhysical()->getReplicationIterator(
+      ReplicationIterator::Ordering::Revision, ctx.batchId);
+  if (!ctx.iter) {
+    generateError(rest::ResponseCode::SERVER_ERROR, TRI_ERROR_INTERNAL,
+                  "could not get replication iterator for collection '" +
+                      ctx.cname + "'");
+    return false;
+  }
+
+  return true;
+}
+
+bool RestReplicationHandler::prepareCollectionForRevisionOperation(
+    RevisionOperationContext& ctx) {
+  // get collection Name
+  ctx.cname = _request->value("collection");
+  if (ctx.cname.empty()) {
+    generateError(rest::ResponseCode::BAD, TRI_ERROR_HTTP_BAD_PARAMETER,
+                  "invalid collection parameter");
+    return false;
+  }
+
+  // print request
+  LOG_TOPIC("6e075", TRACE, arangodb::Logger::REPLICATION)
+      << "requested revision tree for collection '" << ctx.cname << "'";
+
   ExecContextSuperuserScope escope(ExecContext::current().isAdminUser());
 
   if (!ExecContext::current().canUseCollection(_vocbase.name(), ctx.cname,
@@ -3082,23 +3146,21 @@ bool RestReplicationHandler::prepareRevisionOperation(
     return false;
   }
 
-  ctx.iter = ctx.collection->getPhysical()->getReplicationIterator(
-      ReplicationIterator::Ordering::Revision, ctx.batchId);
-  if (!ctx.iter) {
-    generateError(rest::ResponseCode::SERVER_ERROR, TRI_ERROR_INTERNAL,
-                  "could not get replication iterator for collection '" +
-                      ctx.cname + "'");
-    return false;
-  }
-
   return true;
 }
 
 void RestReplicationHandler::handleCommandRebuildRevisionTree() {
   RevisionOperationContext ctx;
-  if (!prepareRevisionOperation(ctx)) {
+  // get collection Name
+  if (!prepareCollectionForRevisionOperation(ctx)) {
+    // error was already generator by called function
     return;
   }
+  TRI_ASSERT(!ctx.cname.empty());
+  TRI_ASSERT(ctx.collection != nullptr);
+
+  // increase metric
+  ++server().getFeature<ClusterFeature>().syncTreeRebuildCounter();
 
   Result res = ctx.collection->getPhysical()->rebuildRevisionTree();
   if (res.fail()) {
@@ -3108,6 +3170,26 @@ void RestReplicationHandler::handleCommandRebuildRevisionTree() {
 
   generateResult(rest::ResponseCode::NO_CONTENT, VPackSlice::nullSlice());
 }
+
+#ifdef ARANGODB_ENABLE_FAILURE_TESTS
+void RestReplicationHandler::handleCommandCorruptRevisionTree() {
+  RevisionOperationContext ctx;
+  // get collection name
+  if (!prepareCollectionForRevisionOperation(ctx)) {
+    // error was already generated by called function
+    return;
+  }
+  TRI_ASSERT(!ctx.cname.empty());
+  TRI_ASSERT(ctx.collection != nullptr);
+
+  auto count = _request->parsedValue("count", uint64_t(0));
+  auto hash = _request->parsedValue("hash", uint64_t(0xbadbadbadbadULL));
+  static_cast<RocksDBCollection*>(ctx.collection->getPhysical())
+      ->corruptRevisionTree(count, hash);
+
+  generateResult(rest::ResponseCode::OK, VPackSlice::nullSlice());
+}
+#endif
 
 //////////////////////////////////////////////////////////////////////////////
 /// @brief return the requested revision ranges for a given collection, if

--- a/arangod/RestHandler/RestReplicationHandler.h
+++ b/arangod/RestHandler/RestReplicationHandler.h
@@ -296,6 +296,11 @@ class RestReplicationHandler : public RestVocbaseBaseHandler {
 
   void handleCommandRebuildRevisionTree();
 
+#ifdef ARANGODB_ENABLE_FAILURE_TESTS
+  /// @brief intentionally corrupt the revision of a collection
+  void handleCommandCorruptRevisionTree();
+#endif
+
   //////////////////////////////////////////////////////////////////////////////
   /// @brief return the requested revision ranges for a given collection, if
   ///        available
@@ -339,6 +344,8 @@ class RestReplicationHandler : public RestVocbaseBaseHandler {
   bool prepareRevisionOperation(RevisionOperationContext&);
 
  private:
+  bool prepareCollectionForRevisionOperation(RevisionOperationContext&);
+
   //////////////////////////////////////////////////////////////////////////////
   /// @brief restores the structure of a collection
   //////////////////////////////////////////////////////////////////////////////

--- a/arangod/RocksDBEngine/RocksDBTransactionCollection.cpp
+++ b/arangod/RocksDBEngine/RocksDBTransactionCollection.cpp
@@ -59,7 +59,12 @@ RocksDBTransactionCollection::RocksDBTransactionCollection(
                            .getFeature<arangodb::RocksDBOptionFeature>()
                            ._exclusiveWrites) {}
 
-RocksDBTransactionCollection::~RocksDBTransactionCollection() = default;
+RocksDBTransactionCollection::~RocksDBTransactionCollection() {
+  try {
+    releaseUsage();
+  } catch (...) {
+  }
+}
 
 /// @brief whether or not any write operations for the collection happened
 bool RocksDBTransactionCollection::hasOperations() const {
@@ -123,6 +128,7 @@ void RocksDBTransactionCollection::releaseUsage() {
   if (_transaction->hasHint(transaction::Hints::Hint::LOCK_NEVER) ||
       _transaction->hasHint(transaction::Hints::Hint::NO_USAGE_LOCK)) {
     TRI_ASSERT(!_usageLocked);
+    TRI_ASSERT(!isLocked());
     _collection = nullptr;
     return;
   }
@@ -469,6 +475,7 @@ Result RocksDBTransactionCollection::ensureCollection() {
       _usageLocked = true;
     } else {
       // use without usage-lock (lock already set externally)
+      TRI_ASSERT(!_usageLocked);
       _collection = _transaction->vocbase().lookupCollection(_cid);
 
       if (_collection == nullptr) {

--- a/arangod/RocksDBEngine/RocksDBTransactionCollection.cpp
+++ b/arangod/RocksDBEngine/RocksDBTransactionCollection.cpp
@@ -59,12 +59,7 @@ RocksDBTransactionCollection::RocksDBTransactionCollection(
                            .getFeature<arangodb::RocksDBOptionFeature>()
                            ._exclusiveWrites) {}
 
-RocksDBTransactionCollection::~RocksDBTransactionCollection() {
-  try {
-    releaseUsage();
-  } catch (...) {
-  }
-}
+RocksDBTransactionCollection::~RocksDBTransactionCollection() = default;
 
 /// @brief whether or not any write operations for the collection happened
 bool RocksDBTransactionCollection::hasOperations() const {
@@ -128,7 +123,6 @@ void RocksDBTransactionCollection::releaseUsage() {
   if (_transaction->hasHint(transaction::Hints::Hint::LOCK_NEVER) ||
       _transaction->hasHint(transaction::Hints::Hint::NO_USAGE_LOCK)) {
     TRI_ASSERT(!_usageLocked);
-    TRI_ASSERT(!isLocked());
     _collection = nullptr;
     return;
   }
@@ -475,7 +469,6 @@ Result RocksDBTransactionCollection::ensureCollection() {
       _usageLocked = true;
     } else {
       // use without usage-lock (lock already set externally)
-      TRI_ASSERT(!_usageLocked);
       _collection = _transaction->vocbase().lookupCollection(_cid);
 
       if (_collection == nullptr) {

--- a/tests/Mocks/Servers.cpp
+++ b/tests/Mocks/Servers.cpp
@@ -60,6 +60,7 @@
 #include "Logger/LogTopic.h"
 #include "Logger/Logger.h"
 #include "Network/NetworkFeature.h"
+#include "Replication/ReplicationFeature.h"
 #include "Rest/Version.h"
 #include "RestServer/AqlFeature.h"
 #include "RestServer/DatabaseFeature.h"
@@ -786,6 +787,11 @@ MockDBServer::MockDBServer(bool start, bool useAgencyMock)
                         arangodb::ServerState::RoleEnum::ROLE_DBSERVER) {
   addFeature<arangodb::FlushFeature>(false);        // do not start the thread
   addFeature<arangodb::MaintenanceFeature>(false);  // do not start the thread
+
+  // turn off auto-repairing of revision trees for unit tests
+  auto& rf = addFeature<arangodb::ReplicationFeature>(false);  // do not start
+  rf.autoRepairRevisionTrees(false);
+
   if (start) {
     MockDBServer::startFeatures();
     MockDBServer::createDatabase("_system");

--- a/tests/js/client/shell/shell-replication-auto-repair-cluster.js
+++ b/tests/js/client/shell/shell-replication-auto-repair-cluster.js
@@ -1,0 +1,300 @@
+/* jshint globalstrict:false, strict:false, maxlen: 200 */
+/* global fail, assertEqual, assertNotEqual, assertFalse, assertTrue */
+
+// //////////////////////////////////////////////////////////////////////////////
+// / DISCLAIMER
+// /
+// / Copyright 2018 ArangoDB GmbH, Cologne, Germany
+// /
+// / Licensed under the Apache License, Version 2.0 (the "License")
+// / you may not use this file except in compliance with the License.
+// / You may obtain a copy of the License at
+// /
+// /     http://www.apache.org/licenses/LICENSE-2.0
+// /
+// / Unless required by applicable law or agreed to in writing, software
+// / distributed under the License is distributed on an "AS IS" BASIS,
+// / WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// / See the License for the specific language governing permissions and
+// / limitations under the License.
+// /
+// / Copyright holder is triAGENS GmbH, Cologne, Germany
+// /
+// / @author Jan Steemann
+// //////////////////////////////////////////////////////////////////////////////
+
+let jsunity = require('jsunity');
+let internal = require('internal');
+let arangodb = require('@arangodb');
+let db = arangodb.db;
+let request = require("@arangodb/request");
+let errors = arangodb.errors;
+let { getEndpointById,
+      getEndpointsByType,
+      debugCanUseFailAt,
+      debugSetFailAt,
+      debugClearFailAt,
+      getChecksum,
+      getMetric
+    } = require('@arangodb/test-helper');
+  
+const cn = 'UnitTestsReplication';
+  
+let getBatch = (ep) => {
+  let result = request({ 
+    method: "POST", 
+    url: ep + "/_api/replication/batch",
+    body: { ttl: 60 },
+    json: true
+  });
+  assertEqual(200, result.status);
+  return result.json.id;
+};
+    
+let deleteBatch = (ep, batchId) => {
+  let result = request({ method: "DELETE", url: ep + "/_api/replication/batch/" + batchId });
+  assertEqual(204, result.status);
+};
+    
+let getTree = (ep, batchId, shardId) => {
+  let result = request({ 
+    method: "GET", 
+    url: ep + "/_api/replication/revisions/tree?collection=" + encodeURIComponent(shardId) + "&verification=true&onlyPopulated=true&batchId=" + batchId 
+  });
+  assertEqual(200, result.status);
+  return result.json;
+};
+
+function assertInSync(leader, follower, shardId) {
+  // compare trees of leader and follower
+  let leaderEqual = false;
+  let followerEqual = false;
+  let tries = 0;
+  while (++tries < 300) {
+    let batchId = getBatch(leader);
+    let result = getTree(leader, batchId, shardId);
+    deleteBatch(leader, batchId);
+
+    if (result.equal) {
+      leaderEqual = true;
+    
+      let batchId = getBatch(follower);
+      let result = getTree(follower, batchId, shardId);
+      deleteBatch(follower, batchId);
+      
+      if (result.equal) {
+        followerEqual = true;
+        break;
+      }
+    }
+    internal.sleep(1);
+  }
+  assertTrue(leaderEqual);
+  assertTrue(followerEqual);
+}
+
+function replicationAutoRepairSuite() {
+  'use strict';
+  let getEndpoints = () => {
+    let shards = db._collection(cn).shards(true);
+    let shardId = Object.keys(shards)[0];
+    let endpoints = [];
+    shards[shardId].forEach((s) => {
+      endpoints.push(getEndpointById(s));
+    });
+    return [shardId, endpoints];
+  };
+
+  let logLevels = {};
+
+  return {
+    setUp: function () {
+      getEndpointsByType("dbserver").forEach((ep) => {
+        debugClearFailAt(ep);
+      
+        // store original log levels
+        let result = request({ method: "GET", url: ep + "/_admin/log/level" });
+        logLevels[ep] = result.json;
+        // adjust log level for replication topic
+        request({ method: "PUT", url: ep + "/_admin/log/level", body: { replication: "debug", maintenance: "info" }, json: true });
+      });
+    },
+
+    tearDown: function () {
+      getEndpointsByType("dbserver").forEach((ep) => {
+        debugClearFailAt(ep);
+        // restore original log level
+        request({ method: "PUT", url: ep + "/_admin/log/level", body: logLevels[ep], json: true });
+      });
+      db._drop(cn);
+    },
+    
+    testAutoRepairWhenTreeBrokenOnLeader: function () {
+      let c = db._create(cn, { numberOfShards: 1, replicationFactor: 2 });
+      let [shardId, [leader, follower]] = getEndpoints();
+
+      let docs = [];
+      for (let i = 0; i < 5000; ++i) {
+        docs.push({ value1: i, value2: "testmann" + i });
+      }
+
+      // insert docs, but only half of them on the follower
+      const n = 60 * 1000;
+      let count = 0;
+      while (true) {
+        count = c.count();
+        if (count >= n) {
+          break;
+        }
+        if (count === n / 2) {
+          // do not replicate from leader to follower after half of documents
+          debugSetFailAt(leader, "replicateOperations::skip");
+        }
+        c.insert(docs);
+      }
+     
+      // verify document counts
+      {
+        // leader should have all the documents
+        let result = request({ method: "GET", url: leader + "/_api/collection/" + shardId + "/count" });
+        assertEqual(200, result.status);
+        assertEqual(n, result.json.count);
+        // follower should have only half the documents
+        result = request({ method: "GET", url: follower + "/_api/collection/" + shardId + "/count" });
+        assertEqual(200, result.status);
+        assertEqual(n / 2, result.json.count);
+      }
+      
+      // corrupt the leader's revision tree
+      {
+        // first make sure that the leader has a tree for the shard
+        let batchId = getBatch(leader);
+        let result = getTree(leader, batchId, shardId);
+        deleteBatch(leader, batchId);
+
+        // and now corrupt it
+        result = request({ method: "PUT", url: leader + "/_api/replication/revisions/tree?collection=" + encodeURIComponent(shardId) + "&count=1234&hash=42" });
+        assertEqual(200, result.status);
+      }
+      
+      debugClearFailAt(leader);
+
+      // this will trigger a drop-follower operation on the next insert on the leader
+      debugSetFailAt(leader, "replicateOperationsDropFollower");
+     
+      // enable sending of revision-tree data from follower to leader for comparison
+      debugSetFailAt(follower, "synchronizeShardSendTreeData");
+
+      // disable intentional delays of subsequent replication attempts on follower
+      debugSetFailAt(follower, "SynchronizeShard::noSleepOnSyncError");
+
+      let leaderRebuildsBefore = getMetric(leader, "arangodb_sync_tree_rebuilds_total");
+      let droppedFollowersBefore = getMetric(leader, "arangodb_dropped_followers_total");
+
+      // insert a single document. this will drop the follower, and trigger a resync. 
+      // the follower will need to get in sync using the incremental sync protocol
+      c.insert({});
+      
+      debugClearFailAt(leader);
+    
+      // follower must have been dropped by the insert
+      let droppedFollowersAfter = getMetric(leader, "arangodb_dropped_followers_total");
+      assertTrue(droppedFollowersBefore < droppedFollowersAfter, { droppedFollowersBefore, droppedFollowersAfter });
+      
+      // wait for shards to get in sync and revision trees to get repaired
+      assertInSync(leader, follower, shardId);
+
+      // we must have seen one tree rebuild on the leader
+      let leaderRebuildsAfter = getMetric(leader, "arangodb_sync_tree_rebuilds_total");
+      assertTrue(leaderRebuildsBefore < leaderRebuildsAfter, { leaderRebuildsBefore, leaderRebuildsAfter });
+    },
+    
+    testAutoRepairWhenTreeBrokenOnFollower: function () {
+      let c = db._create(cn, { numberOfShards: 1, replicationFactor: 2 });
+      let [shardId, [leader, follower]] = getEndpoints();
+
+      let docs = [];
+      for (let i = 0; i < 5000; ++i) {
+        docs.push({ value1: i, value2: "testmann" + i });
+      }
+
+      // insert docs, but only half of them on the follower
+      const n = 60 * 1000;
+      let count = 0;
+      while (true) {
+        count = c.count();
+        if (count >= n) {
+          break;
+        }
+        if (count === n / 2) {
+          // do not replicate from leader to follower after half of documents
+          debugSetFailAt(leader, "replicateOperations::skip");
+        }
+        c.insert(docs);
+      }
+     
+      // verify document counts
+      {
+        // leader should have all the documents
+        let result = request({ method: "GET", url: leader + "/_api/collection/" + shardId + "/count" });
+        assertEqual(200, result.status);
+        assertEqual(n, result.json.count);
+        // follower should have only half the documents
+        result = request({ method: "GET", url: follower + "/_api/collection/" + shardId + "/count" });
+        assertEqual(200, result.status);
+        assertEqual(n / 2, result.json.count);
+      }
+      
+      debugClearFailAt(leader);
+    
+      // corrupt the followers's revision tree
+      {
+        // first make sure that the follower has a tree for the shard
+        let batchId = getBatch(follower);
+        let result = getTree(follower, batchId, shardId);
+        deleteBatch(follower, batchId);
+
+        // and now corrupt it
+        result = request({ method: "PUT", url: follower + "/_api/replication/revisions/tree?collection=" + encodeURIComponent(shardId) + "&count=1234&hash=42" });
+        assertEqual(200, result.status);
+      }
+
+      // this will trigger a drop-follower operation on the next insert on the leader
+      debugSetFailAt(leader, "replicateOperationsDropFollower");
+     
+      // enable sending of revision-tree data from follower to leader for comparison
+      debugSetFailAt(follower, "synchronizeShardSendTreeData");
+
+      // disable intentional delays of subsequent replication attempts on follower
+      debugSetFailAt(follower, "SynchronizeShard::noSleepOnSyncError");
+
+      let followerRebuildsBefore = getMetric(follower, "arangodb_sync_tree_rebuilds_total");
+      let droppedFollowersBefore = getMetric(leader, "arangodb_dropped_followers_total");
+
+      // insert a single document. this will drop the follower, and trigger a resync. 
+      // the follower will need to get in sync using the incremental sync protocol
+      c.insert({});
+      
+      debugClearFailAt(leader);
+    
+      // follower must have been dropped by the insert
+      let droppedFollowersAfter = getMetric(leader, "arangodb_dropped_followers_total");
+      assertTrue(droppedFollowersBefore < droppedFollowersAfter, { droppedFollowersBefore, droppedFollowersAfter });
+      
+      // wait for shards to get in sync and revision trees to get repaired
+      assertInSync(leader, follower, shardId);
+
+      // we must have seen one tree rebuild on the follower
+      let followerRebuildsAfter = getMetric(follower, "arangodb_sync_tree_rebuilds_total");
+      assertTrue(followerRebuildsBefore < followerRebuildsAfter, { followerRebuildsBefore, followerRebuildsAfter });
+    },
+      
+  };
+}
+
+let ep = getEndpointsByType('dbserver');
+if (ep.length && debugCanUseFailAt(ep[0])) {
+  // only execute if failure tests are available
+  jsunity.run(replicationAutoRepairSuite);
+}
+return jsunity.done();


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/18710

Automatically repair revision trees after several failed shard synchronization attempts. This can help to get permanently out-of-sync shards back into sync.

The functionality can be turned off by setting the startup option `--replication.auto-repair-revision-trees` to `false` on DB-Servers.

- [x] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [x] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.10: https://github.com/arangodb/arangodb/pull/18711
  - [x] Backport for 3.9: this PR
  - [ ] Backport for 3.8: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 