### PR TITLE
[CINFRA-595] Custom type handler

### DIFF
--- a/arangod/Replication2/StateMachines/Document/DocumentFollowerState.cpp
+++ b/arangod/Replication2/StateMachines/Document/DocumentFollowerState.cpp
@@ -328,7 +328,8 @@ auto DocumentFollowerState::handleSnapshotTransfer(
         }
 
         LOG_CTX("d6666", DEBUG, self->loggerContext)
-            << "Trying to first batch of snapshot: " << snapshotRes->snapshotId;
+            << "Trying to get first batch of snapshot: "
+            << snapshotRes->snapshotId;
         auto fut = leader->nextSnapshotBatch(snapshotRes->snapshotId);
         return self->handleSnapshotTransfer(
             snapshotRes->snapshotId, std::move(leader), waitForIndex,

--- a/arangod/RestHandler/RestBaseHandler.cpp
+++ b/arangod/RestHandler/RestBaseHandler.cpp
@@ -76,7 +76,7 @@ template<typename Payload>
 void RestBaseHandler::generateResult(rest::ResponseCode code,
                                      Payload&& payload) {
   resetResponse(code);
-  writeResult(std::forward<Payload>(payload), VPackOptions::Defaults);
+  writeResult(std::forward<Payload>(payload), getVPackOptions());
 }
 
 template<typename Payload>
@@ -117,7 +117,7 @@ void RestBaseHandler::generateOk(rest::ResponseCode code, VPackSlice payload) {
     }
     tmp.close();
 
-    writeResult(std::move(buffer), VPackOptions::Defaults);
+    writeResult(std::move(buffer), getVPackOptions());
   } catch (...) {
     // Building the error response failed
   }
@@ -137,7 +137,7 @@ void RestBaseHandler::generateOk(rest::ResponseCode code,
 
     tmp = VPackCollection::merge(tmp.slice(), payload.slice(), false);
 
-    writeResult(tmp.slice(), VPackOptions::Defaults);
+    writeResult(tmp.slice(), getVPackOptions());
   } catch (...) {
     // Building the error response failed
   }
@@ -191,6 +191,10 @@ void RestBaseHandler::writeResult(Payload&& payload,
     generateError(rest::ResponseCode::SERVER_ERROR, TRI_ERROR_INTERNAL,
                   "cannot generate output");
   }
+}
+
+VPackOptions const& RestBaseHandler::getVPackOptions() const {
+  return VPackOptions::Defaults;
 }
 
 // TODO -- rather move code to header (slower linking) or remove templates

--- a/arangod/RestHandler/RestBaseHandler.cpp
+++ b/arangod/RestHandler/RestBaseHandler.cpp
@@ -76,7 +76,7 @@ template<typename Payload>
 void RestBaseHandler::generateResult(rest::ResponseCode code,
                                      Payload&& payload) {
   resetResponse(code);
-  writeResult(std::forward<Payload>(payload), getVPackOptions());
+  writeResult(std::forward<Payload>(payload), VPackOptions::Defaults);
 }
 
 template<typename Payload>
@@ -103,7 +103,8 @@ void RestBaseHandler::generateResult(
 /// convenience function akin to generateError,
 /// renders payload in 'result' field
 /// adds proper `error`, `code` fields
-void RestBaseHandler::generateOk(rest::ResponseCode code, VPackSlice payload) {
+void RestBaseHandler::generateOk(rest::ResponseCode code, VPackSlice payload,
+                                 VPackOptions const& options) {
   resetResponse(code);
 
   try {
@@ -117,7 +118,7 @@ void RestBaseHandler::generateOk(rest::ResponseCode code, VPackSlice payload) {
     }
     tmp.close();
 
-    writeResult(std::move(buffer), getVPackOptions());
+    writeResult(std::move(buffer), options);
   } catch (...) {
     // Building the error response failed
   }
@@ -137,7 +138,7 @@ void RestBaseHandler::generateOk(rest::ResponseCode code,
 
     tmp = VPackCollection::merge(tmp.slice(), payload.slice(), false);
 
-    writeResult(tmp.slice(), getVPackOptions());
+    writeResult(tmp.slice(), VPackOptions::Defaults);
   } catch (...) {
     // Building the error response failed
   }
@@ -191,10 +192,6 @@ void RestBaseHandler::writeResult(Payload&& payload,
     generateError(rest::ResponseCode::SERVER_ERROR, TRI_ERROR_INTERNAL,
                   "cannot generate output");
   }
-}
-
-VPackOptions const& RestBaseHandler::getVPackOptions() const {
-  return VPackOptions::Defaults;
 }
 
 // TODO -- rather move code to header (slower linking) or remove templates

--- a/arangod/RestHandler/RestBaseHandler.h
+++ b/arangod/RestHandler/RestBaseHandler.h
@@ -83,6 +83,9 @@ class RestBaseHandler : public rest::RestHandler {
   template<typename Payload>
   void writeResult(Payload&&, arangodb::velocypack::Options const& options);
 
+  /// @brief returns the VPackOptions used when writing the result
+  virtual VPackOptions const& getVPackOptions() const;
+
   /// @brief configure if outgoing responses will have the potential
   /// dirty reads header set:
   void setOutgoingDirtyReadsHeader(bool flag) { _potentialDirtyReads = flag; }

--- a/arangod/RestHandler/RestBaseHandler.h
+++ b/arangod/RestHandler/RestBaseHandler.h
@@ -62,7 +62,8 @@ class RestBaseHandler : public rest::RestHandler {
   /// convenience function akin to generateError,
   /// renders payload in 'result' field
   /// adds proper `error`, `code` fields
-  void generateOk(rest::ResponseCode, velocypack::Slice);
+  void generateOk(rest::ResponseCode, velocypack::Slice,
+                  VPackOptions const& = VPackOptions::Defaults);
 
   /// Add `error` and `code` fields into your response
   void generateOk(rest::ResponseCode, velocypack::Builder const&);
@@ -82,9 +83,6 @@ class RestBaseHandler : public rest::RestHandler {
 
   template<typename Payload>
   void writeResult(Payload&&, arangodb::velocypack::Options const& options);
-
-  /// @brief returns the VPackOptions used when writing the result
-  virtual VPackOptions const& getVPackOptions() const;
 
   /// @brief configure if outgoing responses will have the potential
   /// dirty reads header set:

--- a/arangod/RestHandler/RestDocumentStateHandler.cpp
+++ b/arangod/RestHandler/RestDocumentStateHandler.cpp
@@ -62,7 +62,7 @@ RestDocumentStateHandler::RestDocumentStateHandler(ArangodServer& server,
                                                    GeneralResponse* response)
     : RestVocbaseBaseHandler(server, request, response) {
   _customTypeHandler =
-      std::make_unique<SnapshotTypeHandler>(SnapshotTypeHandler(_vocbase));
+      std::make_unique<SnapshotTypeHandler>(_vocbase);
   _options = VPackOptions::Defaults;
   _options.customTypeHandler = _customTypeHandler.get();
 }

--- a/arangod/RestHandler/RestDocumentStateHandler.cpp
+++ b/arangod/RestHandler/RestDocumentStateHandler.cpp
@@ -27,8 +27,8 @@
 #include "Replication2/ReplicatedLog/LogCommon.h"
 #include "Replication2/StateMachines/Document/DocumentStateMethods.h"
 #include "Replication2/StateMachines/Document/DocumentStateSnapshot.h"
-#include "Utils/CollectionNameResolver.h"
 #include "Transaction/Helpers.h"
+#include "Utils/CollectionNameResolver.h"
 
 #include <optional>
 #include <velocypack/Dumper.h>

--- a/arangod/RestHandler/RestDocumentStateHandler.cpp
+++ b/arangod/RestHandler/RestDocumentStateHandler.cpp
@@ -61,8 +61,7 @@ RestDocumentStateHandler::RestDocumentStateHandler(ArangodServer& server,
                                                    GeneralRequest* request,
                                                    GeneralResponse* response)
     : RestVocbaseBaseHandler(server, request, response) {
-  _customTypeHandler =
-      std::make_unique<SnapshotTypeHandler>(_vocbase);
+  _customTypeHandler = std::make_unique<SnapshotTypeHandler>(_vocbase);
   _options = VPackOptions::Defaults;
   _options.customTypeHandler = _customTypeHandler.get();
 }

--- a/arangod/RestHandler/RestDocumentStateHandler.cpp
+++ b/arangod/RestHandler/RestDocumentStateHandler.cpp
@@ -63,7 +63,7 @@ RestDocumentStateHandler::RestDocumentStateHandler(ArangodServer& server,
     : RestVocbaseBaseHandler(server, request, response) {
   _customTypeHandler =
       std::make_unique<SnapshotTypeHandler>(SnapshotTypeHandler(_vocbase));
-  _options = RestVocbaseBaseHandler::getVPackOptions();
+  _options = VPackOptions::Defaults;
   _options.customTypeHandler = _customTypeHandler.get();
 }
 
@@ -318,7 +318,7 @@ RestStatus RestDocumentStateHandler::processSnapshotRequest(
   if (result.fail()) {
     generateError(result.result());
   } else {
-    generateOk(rest::ResponseCode::OK, result.get().slice());
+    generateOk(rest::ResponseCode::OK, result.get().slice(), _options);
   }
   return RestStatus::DONE;
 }

--- a/arangod/RestHandler/RestDocumentStateHandler.h
+++ b/arangod/RestHandler/RestDocumentStateHandler.h
@@ -40,6 +40,9 @@ class RestDocumentStateHandler : public RestVocbaseBaseHandler {
   char const* name() const final { return "RestDocumentStateHandler"; }
   RequestLane lane() const final { return RequestLane::CLIENT_SLOW; }
 
+ protected:
+  VPackOptions const& getVPackOptions() const final { return _options; }
+
  private:
   RestStatus executeByMethod(replication2::DocumentStateMethods const& methods);
 
@@ -63,5 +66,9 @@ class RestDocumentStateHandler : public RestVocbaseBaseHandler {
       replication2::LogId const& logId,
       ResultT<replication2::replicated_state::document::SnapshotParams>&&
           params);
+
+ private:
+  std::unique_ptr<VPackCustomTypeHandler> _customTypeHandler;
+  VPackOptions _options;
 };
 }  // namespace arangodb

--- a/arangod/RestHandler/RestDocumentStateHandler.h
+++ b/arangod/RestHandler/RestDocumentStateHandler.h
@@ -40,9 +40,6 @@ class RestDocumentStateHandler : public RestVocbaseBaseHandler {
   char const* name() const final { return "RestDocumentStateHandler"; }
   RequestLane lane() const final { return RequestLane::CLIENT_SLOW; }
 
- protected:
-  VPackOptions const& getVPackOptions() const final { return _options; }
-
  private:
   RestStatus executeByMethod(replication2::DocumentStateMethods const& methods);
 


### PR DESCRIPTION
### Scope & Purpose

This PR removed the _DefaultCustomTypeHandler called_ message from being logged, by adding a custom type handler in the `RestDocumentStateHandler`.

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
