### PR TITLE
do not make _globalVersion go backwards

### DIFF
--- a/arangod/Auth/TokenCache.cpp
+++ b/arangod/Auth/TokenCache.cpp
@@ -129,9 +129,7 @@ auth::TokenCache::Entry auth::TokenCache::checkAuthenticationBasic(
     WRITE_LOCKER(guard, _basicLock);
     _basicCache.clear();
     _basicCacheVersion.store(version, std::memory_order_release);
-  }
-
-  {
+  } else {
     READ_LOCKER(guard, _basicLock);
     auto const& it = _basicCache.find(secret);
     if (it != _basicCache.end() && !it->second.expired()) {

--- a/arangod/Auth/UserManager.cpp
+++ b/arangod/Auth/UserManager.cpp
@@ -425,6 +425,27 @@ void auth::UserManager::triggerCacheRevalidation() {
   loadFromDB();
 }
 
+void auth::UserManager::setGlobalVersion(uint64_t version) noexcept {
+  uint64_t previous = _globalVersion.load(std::memory_order_relaxed);
+  while (version > previous) {
+    if (_globalVersion.compare_exchange_strong(previous, version,
+                                               std::memory_order_release,
+                                               std::memory_order_relaxed)) {
+      break;
+    }
+  }
+}
+
+/// @brief reload user cache and token caches
+void auth::UserManager::triggerLocalReload() noexcept {
+  _internalVersion.store(0, std::memory_order_release);
+}
+
+/// @brief used for caching
+uint64_t auth::UserManager::globalVersion() const noexcept {
+  return _globalVersion.load(std::memory_order_acquire);
+}
+
 /// Trigger eventual reload, user facing API call
 void auth::UserManager::triggerGlobalReload() {
   if (!ServerState::instance()->isCoordinator()) {

--- a/arangod/Auth/UserManager.h
+++ b/arangod/Auth/UserManager.h
@@ -75,19 +75,13 @@ class UserManager {
   typedef std::function<Result(auth::User const&)> ConstUserCallback;
 
   /// Tells coordinator to reload its data. Only called in HeartBeat thread
-  void setGlobalVersion(uint64_t version) {
-    _globalVersion.store(version, std::memory_order_release);
-  }
+  void setGlobalVersion(uint64_t version) noexcept;
 
   /// @brief reload user cache and token caches
-  void triggerLocalReload() {
-    _internalVersion.store(0, std::memory_order_release);
-  }
+  void triggerLocalReload() noexcept;
 
   /// @brief used for caching
-  uint64_t globalVersion() const {
-    return _globalVersion.load(std::memory_order_acquire);
-  }
+  uint64_t globalVersion() const noexcept;
 
   /// Trigger eventual reload on all other coordinators (and in TokenCache)
   void triggerGlobalReload();


### PR DESCRIPTION
### Scope & Purpose

Do not make `_globalVersion` in UserManager go backwards. Otherwise it may prevent the `_basicCache` from being invalidated in case it must be invalidated.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.10: https://github.com/arangodb/arangodb/pull/18727
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 