### PR TITLE
testing: proper namespacing for gtests

### DIFF
--- a/js/client/modules/@arangodb/testutils/clusterstats.js
+++ b/js/client/modules/@arangodb/testutils/clusterstats.js
@@ -72,7 +72,7 @@ while(true) {
         if (reply.hasOwnProperty('error') || reply.code !== 200) {
           print("fail: " + JSON.stringify(reply) +
                 " - ps before: " + JSON.stringify(procStats) +
-                " - ps now: " + JSON.stringify(pu.getProcessStats(arangod.pid)));
+                " - ps now: " + JSON.stringify(arangod._getProcessStats()));
           state.state = false;
           oneSet.state = false;
           oneSet[serverId] = {
@@ -93,7 +93,7 @@ while(true) {
         if (reply.hasOwnProperty('error') || reply.code !== 200) {
           print("fail: " + JSON.stringify(reply) +
                 " - ps before: " + JSON.stringify(procStats) +
-                " - ps now: " + JSON.stringify(pu.getProcessStats(arangod.pid)));
+                " - ps now: " + JSON.stringify(arangod._getProcessStats()));
           state.state = false;
           oneSet.state = false;
           oneSet[serverId] = {

--- a/js/client/modules/@arangodb/testutils/result-processing.js
+++ b/js/client/modules/@arangodb/testutils/result-processing.js
@@ -274,7 +274,7 @@ function saveToJunitXML(options, results) {
   };
   let prefix = (options.cluster ? 'CL_' : '') + (pu.isEnterpriseClient)? 'EE_' : 'CE_';
 
-  if (results.crashed && results.hasOwnProperty('crashreport')) {
+  if (results.hasOwnProperty('crashreport')) {
     results['crash'] = {
       crash_report: {
         status: false,
@@ -282,7 +282,7 @@ function saveToJunitXML(options, results) {
         all: {
           status: false,
           failed: 1,
-          message: results.crashreport
+          message: ((results.crashed)? "SUT crashed: \n": "SUT was aborted: \n") +results.crashreport
         }
       },
       staus: false,

--- a/js/client/modules/@arangodb/testutils/result-processing.js
+++ b/js/client/modules/@arangodb/testutils/result-processing.js
@@ -273,6 +273,23 @@ function saveToJunitXML(options, results) {
     seenTestCases: false,
   };
   let prefix = (options.cluster ? 'CL_' : '') + (pu.isEnterpriseClient)? 'EE_' : 'CE_';
+
+  if (results.crashed && results.hasOwnProperty('crashreport')) {
+    results['crash'] = {
+      crash_report: {
+        status: false,
+        failed: 1,
+        all: {
+          status: false,
+          failed: 1,
+          message: results.crashreport
+        }
+      },
+      staus: false,
+      failed: 1,
+    };
+  }
+
   iterateTestResults(options, results, xmlState, {
     testRun: function(options, state, testRun, testRunName) {state.testRunName = testRunName;},
     testSuite: function(options, state, testSuite, testSuiteName) {

--- a/tests/test-definitions.txt
+++ b/tests/test-definitions.txt
@@ -58,8 +58,8 @@ shell_server_aql priority=750 single buckets=5
 shell_server priority=1000 single buckets=3
 
 # C++ unit tests are executed in single env
-gtest name=gtest-iresearch priority=1000 parallelity=3 size=medium single -- --gtest_filter=IResearch*
-gtest priority=1000 parallelity=3 size=medium single -- --gtest_filter=-IResearch*:LongRunning*
+gtest_iresearch priority=1000 parallelity=3 size=medium single
+gtest_arangodb priority=1000 parallelity=3 size=medium single
 
 # Fuerte tests are executed in single env
 fuerte priority=500 single


### PR DESCRIPTION
### Scope & Purpose

- gtests could overwrite their results in `basics` which doesn't properly relate to anything in first place, use a real name
- use filters rather from .js code than from the test-definitions.txt
- map crashes into an own crasheport xml.

- [x] :hankey: Bugfix
- [x] :pizza: New feature
- [x] 3.10 Backport https://github.com/arangodb/arangodb/pull/18732
