### PR TITLE
do not make _globalVersion go backwards

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 v3.10.6 (XXXX-XX-XX)
 --------------------
 
+* Fix race condition in invalidation of token cache on coordinators.
+
 * SEARCH-461: Added option "--arangosearch.columns-cache-only-leader". Used only
   on EE DBServers. Default is false.
   If set to true only leader shards have ArangoSearch caches enabled - this will

--- a/arangod/Auth/TokenCache.cpp
+++ b/arangod/Auth/TokenCache.cpp
@@ -129,9 +129,7 @@ auth::TokenCache::Entry auth::TokenCache::checkAuthenticationBasic(
     WRITE_LOCKER(guard, _basicLock);
     _basicCache.clear();
     _basicCacheVersion.store(version, std::memory_order_release);
-  }
-
-  {
+  } else {
     READ_LOCKER(guard, _basicLock);
     auto const& it = _basicCache.find(secret);
     if (it != _basicCache.end() && !it->second.expired()) {

--- a/arangod/Auth/UserManager.h
+++ b/arangod/Auth/UserManager.h
@@ -74,19 +74,13 @@ class UserManager {
   typedef std::function<Result(auth::User const&)> ConstUserCallback;
 
   /// Tells coordinator to reload its data. Only called in HeartBeat thread
-  void setGlobalVersion(uint64_t version) {
-    _globalVersion.store(version, std::memory_order_release);
-  }
+  void setGlobalVersion(uint64_t version) noexcept;
 
   /// @brief reload user cache and token caches
-  void triggerLocalReload() {
-    _internalVersion.store(0, std::memory_order_release);
-  }
+  void triggerLocalReload() noexcept;
 
   /// @brief used for caching
-  uint64_t globalVersion() const {
-    return _globalVersion.load(std::memory_order_acquire);
-  }
+  uint64_t globalVersion() const noexcept;
 
   /// Trigger eventual reload on all other coordinators (and in TokenCache)
   void triggerGlobalReload();


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/18719

Do not make `_globalVersion` in UserManager go backwards. Otherwise it may prevent the `_basicCache` from being invalidated in case it must be invalidated.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 