### PR TITLE
FE 242: fix support for cache fields

### DIFF
--- a/js/apps/system/_admin/aardvark/APP/react/src/views/collections/indices/addIndex/invertedIndex/useCreateInvertedIndex.ts
+++ b/js/apps/system/_admin/aardvark/APP/react/src/views/collections/indices/addIndex/invertedIndex/useCreateInvertedIndex.ts
@@ -34,6 +34,7 @@ export type InvertedIndexFieldType = {
   searchField?: boolean;
   includeAllFields?: boolean;
   trackListPositions?: boolean;
+  cache?: boolean;
   nested?: Omit<
     InvertedIndexFieldType,
     "includeAllFields" | "trackListPositions"
@@ -52,6 +53,7 @@ export type InvertedIndexValuesType = {
   primarySort?: {
     fields: PrimarySortFieldType[];
     compression: "lz4" | "none";
+    cache?: boolean;
   };
   storedValues?: {
     fields: string[];
@@ -65,6 +67,7 @@ export type InvertedIndexValuesType = {
   writebufferSizeMax?: number;
   consolidationPolicy?: ConsolidationPolicy;
   fields?: InvertedIndexFieldType[];
+  primaryKeyCache?: boolean;
 };
 
 const initialValues: InvertedIndexValuesType = {
@@ -285,7 +288,8 @@ export const useCreateInvertedIndex = () => {
       name: values.name || undefined,
       primarySort: {
         compression: values.primarySort?.compression || "lz4",
-        fields: primarySortFields
+        fields: primarySortFields,
+        cache: values.primarySort?.cache
       },
       storedValues: storedValues
     });

--- a/js/apps/system/_admin/aardvark/APP/react/src/views/collections/indices/addIndex/invertedIndex/useInvertedIndexJSONSchema.tsx
+++ b/js/apps/system/_admin/aardvark/APP/react/src/views/collections/indices/addIndex/invertedIndex/useInvertedIndexJSONSchema.tsx
@@ -77,6 +77,10 @@ const invertedIndexJSONSchema: JSONSchemaType<InvertedIndexValuesType> = {
             type: "boolean",
             nullable: true
           },
+          cache: {
+            type: "boolean",
+            nullable: true
+          },
           nested: {
             type: "array",
             $ref: "invertedIndexFields.json",
@@ -119,6 +123,10 @@ const invertedIndexJSONSchema: JSONSchemaType<InvertedIndexValuesType> = {
           type: "string",
           enum: ["lz4", "none"],
           default: "lz4"
+        },
+        cache: {
+          type: "boolean",
+          nullable: true
         }
       },
       required: ["compression", "fields"]
@@ -235,6 +243,10 @@ const invertedIndexJSONSchema: JSONSchemaType<InvertedIndexValuesType> = {
       nullable: true,
       minimum: 0,
       default: 33554432
+    },
+    primaryKeyCache: {
+      type: "boolean",
+      nullable: true
     }
   },
   required: ["type"],

--- a/js/apps/system/_admin/aardvark/APP/react/src/views/collections/indices/addIndex/useCreateIndex.ts
+++ b/js/apps/system/_admin/aardvark/APP/react/src/views/collections/indices/addIndex/useCreateIndex.ts
@@ -24,7 +24,6 @@ export const useCreateIndex = <
   const { collectionName, collectionId, onCloseForm } =
     useCollectionIndicesContext();
   const { encoded: encodedCollectionName } = encodeHelper(collectionName);
-
   const onCreate = async (values: TValues) => {
     window.arangoHelper.checkDatabasePermissions(
       function () {
@@ -39,7 +38,7 @@ export const useCreateIndex = <
             `index`,
             {
               ...values,
-              name: String(values.name)?.normalize() || undefined
+              name: values.name ? String(values.name)?.normalize() : undefined
             },
             `collection=${encodedCollectionName}`,
             {

--- a/js/apps/system/_admin/aardvark/APP/react/src/views/views/constants.ts
+++ b/js/apps/system/_admin/aardvark/APP/react/src/views/views/constants.ts
@@ -61,6 +61,7 @@ export type LinkProperties = {
   trackListPositions?: boolean;
   storeValues?: 'none' | 'id';
   inBackground?: boolean;
+  cache?: boolean;
 };
 
 type BaseFormState = {
@@ -114,7 +115,11 @@ export const linksSchema = {
     inBackground: {
       type: 'boolean',
       nullable: false
-    }
+    },
+    cache: {
+      type: 'boolean',
+      nullable: false
+    },
   },
   additionalProperties: false
 };


### PR DESCRIPTION
### Scope & Purpose

adds support for `fields` -> `cache` , `primarySort` -> `cache`, and `primaryKeySort` options

- [x] :hankey: Bugfix

### Checklist

- [x] Tests
  - [x] Manually tested
- [ ] :book: CHANGELOG entry made
#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [x] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/FE-242

