### PR TITLE
testing: rta-makedata debugging

### DIFF
--- a/js/client/modules/@arangodb/testsuites/rta_makedata.js
+++ b/js/client/modules/@arangodb/testsuites/rta_makedata.js
@@ -106,7 +106,7 @@ function makeDataWrapper (options) {
         if (this.options.forceJson) {
           args['server.force-json'] = true;
         }
-        if (!this.options.extremeVerbosity) {
+        if (this.options.extremeVerbosity) {
           args['log.level'] = ['warning', 'V8=debug'];
         }
         if (this.addArgs !== undefined) {

--- a/js/client/modules/@arangodb/testsuites/rta_makedata.js
+++ b/js/client/modules/@arangodb/testsuites/rta_makedata.js
@@ -107,7 +107,7 @@ function makeDataWrapper (options) {
           args['server.force-json'] = true;
         }
         if (!this.options.verbose) {
-          args['log.level'] = 'warning';
+          args['log.level'] = ['warning', 'V8=debug'];
         }
         if (this.addArgs !== undefined) {
           args = Object.assign(args, this.addArgs);

--- a/js/client/modules/@arangodb/testsuites/rta_makedata.js
+++ b/js/client/modules/@arangodb/testsuites/rta_makedata.js
@@ -108,7 +108,9 @@ function makeDataWrapper (options) {
         }
         if (this.options.extremeVerbosity) {
           args['log.level'] = ['warning', 'V8=debug'];
-        }
+        } else if (!this.options.verbose) {
+          args['log.level'] = 'warning';
+        }          
         if (this.addArgs !== undefined) {
           args = Object.assign(args, this.addArgs);
         }

--- a/js/client/modules/@arangodb/testsuites/rta_makedata.js
+++ b/js/client/modules/@arangodb/testsuites/rta_makedata.js
@@ -106,7 +106,7 @@ function makeDataWrapper (options) {
         if (this.options.forceJson) {
           args['server.force-json'] = true;
         }
-        if (!this.options.verbose) {
+        if (!this.options.extremeVerbosity) {
           args['log.level'] = ['warning', 'V8=debug'];
         }
         if (this.addArgs !== undefined) {

--- a/js/client/modules/@arangodb/testsuites/rta_makedata.js
+++ b/js/client/modules/@arangodb/testsuites/rta_makedata.js
@@ -110,7 +110,7 @@ function makeDataWrapper (options) {
           args['log.level'] = ['warning', 'V8=debug'];
         } else if (!this.options.verbose) {
           args['log.level'] = 'warning';
-        }          
+        }
         if (this.addArgs !== undefined) {
           args = Object.assign(args, this.addArgs);
         }

--- a/js/client/modules/@arangodb/testutils/test-utils.js
+++ b/js/client/modules/@arangodb/testutils/test-utils.js
@@ -487,7 +487,7 @@ class runInArangoshRunner extends testRunnerBase{
     if (!this.options.verbose) {
       args['log.level'] = 'warning';
     }
-    if (!this.options.extremeVerbosity) {
+    if (this.options.extremeVerbosity === true) {
       args['log.level'] = 'v8=debug';
     }
     if (this.addArgs !== undefined) {

--- a/js/client/modules/@arangodb/testutils/test-utils.js
+++ b/js/client/modules/@arangodb/testutils/test-utils.js
@@ -487,7 +487,9 @@ class runInArangoshRunner extends testRunnerBase{
     if (!this.options.verbose) {
       args['log.level'] = 'warning';
     }
-
+    if (!this.options.extremeVerbosity) {
+      args['log.level'] = 'v8=debug';
+    }
     if (this.addArgs !== undefined) {
       args = Object.assign(args, this.addArgs);
     }

--- a/js/client/modules/@arangodb/testutils/testing.js
+++ b/js/client/modules/@arangodb/testutils/testing.js
@@ -501,6 +501,9 @@ function iterateTests(cases, options) {
   let results = {};
   let cleanup = true;
 
+  if (options.extremeVerbosity === true) {
+    internal.logLevel('V8=debug');
+  }
   if (options.failed) {
     // we are applying the failed filter -> only consider cases with failed tests
     cases = _.filter(cases, c => options.failed.hasOwnProperty(c));


### PR DESCRIPTION
### Scope & Purpose

By default arangosh doesn't log stack traces. This can be turned on by setting `V8=debug`. 
We couple this with `--extremeVerbosity true` here, to aid testing.js and rta-makedata test development.

```
2023-04-21T10:05:00Z [3832633] ERROR [8a210] {general} JavaScript exception in file '/home/willi/src/devel/js/client/modules/@arangodb/arango-database.js' at 1203,7: ArangoError 1228: database not found
2023-04-21T10:05:00Z [3832633] ERROR [409ee] {general} !      throw err;
2023-04-21T10:05:00Z [3832633] ERROR [cb0bd] {general} !      ^
2023-04-21T10:05:00Z [3832633] DEBUG [cb0bf] {v8} !stacktrace: ArangoError: database not found\n    at Object.exports.checkRequestResult (/home/willi/src/devel/js/client/modules/@arangodb/arangosh.js:91:21)\n    at Proxy.ArangoDatabase._queryProperties (/home/willi/src/devel/js/client/modules/@arangodb/arango-database.js:617:14)\n    at Proxy.ArangoDatabase._useDatabase (/home/willi/src/devel/js/client/modules/@arangodb/arango-database.js:1196:10)\n    at clearDataDB (/home/willi/src/rta-makedata/test_data/makedata_suites/570_enterprise_graph.js:124:10)\n    at /home/willi/src/rta-makedata/test_data/common.js:71:7\n    at Array.forEach (<anonymous>)\n    at mainTestLoop (/home/willi/src/rta-makedata/test_data/common.js:69:12)\n    at ../rta-makedata/test_data/cleardata.js:118:1\n
```

The output of `cb0bf` can now be used for debugging. 

- [x] :pizza: New feature
