### PR TITLE
Avoid lockup with trace logging and log rotation, BTS-1326.

### DIFF
--- a/lib/Basics/files.cpp
+++ b/lib/Basics/files.cpp
@@ -884,9 +884,6 @@ ErrorCode TRI_RenameFile(char const* old, char const* filename,
     if (systemErrorStr != nullptr) {
       *systemErrorStr = windowsErrorBuf;
     }
-    LOG_TOPIC("1f6ac", TRACE, arangodb::Logger::FIXME)
-        << "cannot rename file from '" << old << "' to '" << filename
-        << "': " << errno << " - " << windowsErrorBuf;
     res = -1;
   } else {
     res = 0;
@@ -902,9 +899,6 @@ ErrorCode TRI_RenameFile(char const* old, char const* filename,
     if (systemErrorStr != nullptr) {
       *systemErrorStr = TRI_LAST_ERROR_STR;
     }
-    LOG_TOPIC("d8b28", TRACE, arangodb::Logger::FIXME)
-        << "cannot rename file from '" << old << "' to '" << filename
-        << "': " << TRI_LAST_ERROR_STR;
     return TRI_set_errno(TRI_ERROR_SYS_ERROR);
   }
 

--- a/lib/Logger/LogAppenderFile.cpp
+++ b/lib/Logger/LogAppenderFile.cpp
@@ -229,6 +229,8 @@ std::string LogAppenderFile::details() const {
 }
 
 void LogAppenderFile::reopenAll() {
+  // We must not log anything in this function or in anything it calls! This
+  // is because this is called under the `_appendersLock`.
   std::unique_lock<std::mutex> guard(_openAppendersMutex);
 
   for (auto& it : _openAppenders) {


### PR DESCRIPTION
### Scope & Purpose

Original PR: https://github.com/arangodb/arangodb/pull/18737

This fixes a deadlock situation in a rare case of trace logging together
with log rotation. The problem is described in detail here:

  https://arangodb.atlassian.net/browse/BTS-1326

The only actual change is to remove a log message in TRI_RenameFile
which can do harm.

- [*] :hankey: Bugfix
- [*] :book: CHANGELOG entry made
- [*] Backports
  - [*] Backport for 3.10: This is it

#### Related Information

- [*] Jira ticket: https://arangodb.atlassian.net/browse/PRESUPP-556
- [*] BTS ticket: https://arangodb.atlassian.net/browse/BTS-1326


