### PR TITLE
Do not candidate if we became follower just before.

### DIFF
--- a/arangod/Agency/Constituent.h
+++ b/arangod/Agency/Constituent.h
@@ -125,7 +125,7 @@ class Constituent : public Thread {
   std::string endpoint(std::string) const;
 
   // Run for leadership
-  void candidate();
+  void candidateNoLock();
 
   // Become leader
   void lead(term_t);


### PR DESCRIPTION
### Scope & Purpose
Sometimes the agent decided to candidate, but waits on a mutex. During that time the agent is converted into a follower. This can have the strange effect that a new follower immediately candidates.
