### PR TITLE
QA-411: fix counting of test failures

### DIFF
--- a/js/client/modules/@arangodb/testsuites/dump.js
+++ b/js/client/modules/@arangodb/testsuites/dump.js
@@ -112,7 +112,6 @@ class DumpRestoreHelper extends tu.runInArangoshRunner {
   }
 
   destructor(cleanup) {
-const yaml = require('js-yaml');
     if (this.fn !== undefined && fs.exists(this.fn)) {
       fs.remove(this.fn);
     }

--- a/js/client/modules/@arangodb/testsuites/dump.js
+++ b/js/client/modules/@arangodb/testsuites/dump.js
@@ -108,9 +108,11 @@ class DumpRestoreHelper extends tu.runInArangoshRunner {
     this.im2 = null;
     this.keyDir = null;
     this.otherKeyDir = null;
+    this.doCleanup = true;
   }
 
   destructor(cleanup) {
+const yaml = require('js-yaml');
     if (this.fn !== undefined && fs.exists(this.fn)) {
       fs.remove(this.fn);
     }
@@ -131,14 +133,21 @@ class DumpRestoreHelper extends tu.runInArangoshRunner {
       this.results['shutdown'] &= this.im2.shutdownInstance();
     }
     print(CYAN + 'done.' + RESET);
-    let doCleanup = this.options.cleanup && (this.results.failed === 0) && cleanup;
-    if (doCleanup) {
+
+    Object.keys(this.results).forEach(key => {
+      if (this.results[key].hasOwnProperty('failed')) {
+        this.results.failed += this.results[key].failed;
+      }
+    });
+    this.doCleanup = this.options.cleanup && (this.results.failed === 0) && cleanup;
+    if (this.doCleanup) {
       if (this.im1 !== null) {
         this.im1.destructor(this.results.failed === 0);
       }
       if (this.im2 !== null) {
         this.im2.destructor(this.results.failed === 0);
       }
+
       [this.keyDir,
        this.otherKeyDir,
        this.dumpConfig.getOutputDirectory()].forEach(dir => {
@@ -975,7 +984,7 @@ function hotBackup (options) {
       !helper.restoreHotBackup() ||
       !helper.runTests(dumpCheck, 'UnitTestsDumpDst')||
       !helper.tearDown(tearDownFile)) {
-      helper.destructor(true);
+    helper.destructor(true);
     return helper.extractResults();
   }
 
@@ -1003,10 +1012,10 @@ function hotBackup (options) {
     }
   }
 
-  if (options.cleanup) {
+  helper.destructor(true);
+  if (helper.doCleanup) {
     fs.removeDirectoryRecursive(keyDir, true);
   }
-  helper.destructor(true);
   return helper.extractResults();
 }
 


### PR DESCRIPTION
### Scope & Purpose

testsuites would cleanup their directory though errors occured. 
This was due to the global failure count wasn't aggregated yet. 

- [x] :hankey: Bugfix
- [x] Backports
  - [ ] Backport for 3.10: *(Please link PR)*
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*
