### PR TITLE
Use different database name for each test.

### DIFF
--- a/tests/js/client/load-balancing/load-balancing-key-generator-noauth-cluster.js
+++ b/tests/js/client/load-balancing/load-balancing-key-generator-noauth-cluster.js
@@ -39,7 +39,7 @@ const ERRORS = require("@arangodb").errors;
 
 function KeyGeneratorSuite() {
   'use strict';
-  const cn = 'UnitTestsCollection';
+  let cn = 'UnitTestsCollection';
   let coordinators = [];
 
   function sendRequest(method, db, endpoint, body, headers, usePrimary) {
@@ -112,6 +112,11 @@ function KeyGeneratorSuite() {
       if (coordinators.length < 2) {
         throw new Error('Expecting at least two coordinators');
       }
+    },
+
+    setUp: function (name) {
+      // make database name for each test unique
+      cn = 'UnitTestsCollection_' + name;
     },
 
     testPadded: function() {


### PR DESCRIPTION
### Scope & Purpose
Due to caching effects, a database could vanish on a coordinator even after the test has started and the `waitForCoordinatorsReady` function returned. This PR makes it so that each test uses a different database name.