### PR TITLE
Do not specify invalid replicationFactor and numberOfShards.

### DIFF
--- a/tests/js/client/shell/api/pregel.js
+++ b/tests/js/client/shell/api/pregel.js
@@ -48,8 +48,6 @@ function start_pregel_run() {
 			var graph = graph_module._create(graphName);
 			db._create(vColl, { numberOfShards: 4 });
 			db._createEdgeCollection(eColl, {
-				numberOfShards: 4,
-				replicationFactor: 1,
 				shardKeys: ["vertex"],
 				distributeShardsLike: vColl
 			});

--- a/tests/js/common/shell/shell-pregel-components.js
+++ b/tests/js/common/shell/shell-pregel-components.js
@@ -77,8 +77,6 @@ function componentsTestSuite() {
             });
             graph._addVertexCollection(vColl);
             db._createEdgeCollection(eColl, {
-                numberOfShards: 4,
-                replicationFactor: 1,
                 shardKeys: ["vertex"],
                 distributeShardsLike: vColl
             });


### PR DESCRIPTION
### Scope & Purpose

Do not specify replicationFactor and numberOfShards if distribute shards like is used.