### PR TITLE
Increase container size for shell_server_aql tests to avoid OOM kills

### DIFF
--- a/tests/test-definitions.txt
+++ b/tests/test-definitions.txt
@@ -97,7 +97,7 @@ shell_client_multi priority=1500 cluster suffix=http2 -- --http2 true
 shell_client_multi priority=2500 cluster suffix=vst -- --vst true
 
 # different number of buckets in cluster
-shell_server_aql priority=1000 cluster sniff buckets=16 -- --dumpAgencyOnError true --sniffFilter graph
+shell_server_aql priority=1000 size=medium+ cluster sniff buckets=16 -- --dumpAgencyOnError true --sniffFilter graph
 shell_client priority=500 cluster buckets=5 -- --dumpAgencyOnError true
 shell_client_transaction priority=500 cluster parallelity=5 size=small buckets=5 -- --dumpAgencyOnError true
 shell_client_replication2_recovery priority=500 size=small cluster -- --dumpAgencyOnError true


### PR DESCRIPTION
### Scope & Purpose

This is just a quick fix. Long term we should identify the tests that cause the memory usage to grow so much and either optimize them or move them to a separate "large" suite.

- [x] :hankey: Bugfix