### PR TITLE
Test for createCollection / callback deadlock

### DIFF
--- a/tests/js/server/shell/shell-recreate-database-nightly-cluster.js
+++ b/tests/js/server/shell/shell-recreate-database-nightly-cluster.js
@@ -1,0 +1,118 @@
+/*jshint globalstrict:false, strict:false */
+/*global assertEqual, assertNotEqual */
+
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2023-2023 ArangoDB GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Michael Hackstein
+////////////////////////////////////////////////////////////////////////////////
+
+'use strict';
+
+const jsunity = require("jsunity");
+const arangodb = require("@arangodb");
+const db = arangodb.db;
+const tasks = require("@arangodb/tasks");
+const internal = require("internal");
+
+function RecreateDatabaseSuite() {
+    const tasksCompleted = () => {
+        return 0 === tasks.get().filter((task) => {
+            return (task.id.match(/^UnitTest/) || task.name.match(/^UnitTest/));
+        }).length;
+    };
+
+    const waitForTasks = () => {
+        const time = internal.time;
+        const start = time();
+        while (!tasksCompleted()) {
+            if (time() - start > 300) { // wait for 5 minutes maximum
+                fail("Timeout after 5 minutes");
+            }
+            internal.sleep(0.5);
+        }
+    };
+    const threadsEach = 3;
+    const iterations = 15;
+    const dbName = "UnitTestDatabase";
+
+    /**
+     * This test is a chaos test.
+     * We try to enforce a previous deadlock
+     * which could onyl show up under load, and with a
+     * bad ordering of events when dropping and recreating of a database works in parallel
+     * This test is best-effort test to trigger, as many components need to get into bad timing to fail.
+     */
+    const createDatabaseCode = `
+      let db = require("internal").db;
+      for (let i = 0; i < ${iterations}; ++i) {
+        require("internal").print("Create iteration " + i);
+        try {
+          db._createDatabase("${dbName}");
+          require("internal").print("Create iteration " + i + " success");
+        } catch (e) {
+          require("internal").print("Create iteration " + i + " failed: " + JSON.stringify(e));
+        }
+      }
+    `;
+
+    const dropDatabaseCode = `
+      let db = require("internal").db;
+      for (let i = 0; i < ${iterations}; ++i) {
+        require("internal").print("Drop iteration " + i);
+        try {
+          db._dropDatabase("${dbName}");
+          require("internal").print("Drop iteration " + i + " success");
+        } catch (e) {
+          require("internal").print("Drop iteration " + i + " failed: " + JSON.stringify(e));
+        }
+      }
+    `;
+
+    return {
+        setUp: () => {
+            db._createDatabase(dbName);
+        },
+        tearDown: () => {
+            tasks.get().forEach(function(task) {
+                if (task.id.match(/^UnitTest/) || task.name.match(/^UnitTest/)) {
+                    try {
+                        tasks.unregister(task);
+                    } catch (err) {
+                    }
+                }
+            });
+        },
+
+        testCreateDropInParallel: function() {
+            for (let i = 0; i < threadsEach; ++i) {
+                tasks.register({ name: `UnitTestsCreateDatabase${i}`, command: createDatabaseCode });
+                tasks.register({ name: `UnitTestsDropDatabase${i}`, command: dropDatabaseCode });
+            }
+
+            // wait for insertion tasks to complete
+            waitForTasks();
+        }
+    }
+
+}
+
+jsunity.run(RecreateDatabaseSuite);
+
+return jsunity.done();


### PR DESCRIPTION
### Scope & Purpose

*This PR should add a best effort test for the bug-fix within: https://github.com/arangodb/arangodb/pull/18747
However right now it is in a draft state as the drop operation could get into a longish timeout if someone creates the same database in parallel. Which is fine in production, but will cause this test to show false negatives.
Therefore I decided to separate the test from the bug-fix as we will need some more thought on this test.
*

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: *(Please link PR)*
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

