### PR TITLE
Enable scheduled pipeline triggers on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,6 +40,8 @@ jobs:
 workflows:
   setup:
     when:
-      equal: [api, << pipeline.trigger_source >>]
+      or:
+        - equal: [ api, << pipeline.trigger_source >> ]
+        - equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
     jobs:
       - setup


### PR DESCRIPTION
### Scope & Purpose

Enable setup workflow for pipelines started by a scheduled pipeline trigger. This allows to at least have nightly PR builds for the devel branch since we have currently disabled the push based devel builds.


