### PR TITLE
add another catch - test crash may only become visible in there

### DIFF
--- a/js/client/modules/@arangodb/testutils/testrunner.js
+++ b/js/client/modules/@arangodb/testutils/testrunner.js
@@ -641,16 +641,23 @@ class testRunner {
             }
             this.results[this.translateResult(te)]['processStats']['netstat'] = this.instanceManager.getNetstat();
             this.continueTesting = true;
-            for (let j = 0; j < this.cleanupChecks.length; j++) {
-              if (!this.continueTesting || !this.cleanupChecks[j].runCheck(this, te)) {
-                print(RED + Date() + ' server posttest "' + this.cleanupChecks[j].name + '" failed!' + RESET);
-                moreReason += `server posttest '${this.cleanupChecks[j].name}' failed!`;
-                this.continueTesting = false;
-                j = this.cleanupChecks.length;
-                continue;
+            let j = 0;
+            try {
+              for (; j < this.cleanupChecks.length; j++) {
+                if (!this.continueTesting || !this.cleanupChecks[j].runCheck(this, te)) {
+                  print(RED + Date() + ' server posttest "' + this.cleanupChecks[j].name + '" failed!' + RESET);
+                  moreReason += `server posttest '${this.cleanupChecks[j].name}' failed!`;
+                  this.continueTesting = false;
+                  j = this.cleanupChecks.length;
+                  continue;
+                }
               }
+            } catch(ex) {
+              this.continueTesting = false;
+              print(`${RED}${Date()} server posttest "${this.cleanupChecks[j].name}" failed by throwing: ${ex}\n${ex.stack}!${RESET}`);
+              moreReason += `server posttest "${this.cleanupChecks[j].name}" failed by throwing: ${ex}`;
+              continue;
             }
-            
           } else {
             this.results[this.translateResult(te)].message = "Instance not healthy! " + JSON.stringify(reply);
             continue;


### PR DESCRIPTION
### Scope & Purpose

The server may take a while to coredump, and only crash during health checks:
```
ArangoError: Monitored child process exited unexpectedly
    at exports.reconnectRetry (/work/ArangoDB/js/common/modules/@arangodb/replication-common.js:69:5)
    at exports.debugGetFailurePoints (/work/ArangoDB/js/client/modules/@arangodb/test-helper.js:171:5)
    at /work/ArangoDB/js/client/modules/@arangodb/testutils/instance-manager.js:737:18
    at Array.forEach (<anonymous>)
    at instanceManager.checkServerFailurePoints (/work/ArangoDB/js/client/modules/@arangodb/testutils/instance-manager.js:732:17)
    at Object.runCheck (/work/ArangoDB/js/client/modules/@arangodb/testutils/testrunner.js:307:45)
    at runLocalInArangoshRunner.run (/work/ArangoDB/js/client/modules/@arangodb/testutils/testrunner.js:645:67)
    at Object.shellClientAql [as shell_client_aql] (/work/ArangoDB/js/client/modules/@arangodb/testsuites/aql.js:318:62)
    at iterateTests (/work/ArangoDB/js/client/modules/@arangodb/testutils/testing.js:548:36)
    at unitTest (/work/ArangoDB/js/client/modules/@arangodb/testutils/testing.js:638:12)
{}
2023-04-26T13:18:33Z [116246] ERROR [8a210] {general} JavaScript exception in file '/work/ArangoDB/js/client/modules/@arangodb/testutils/process-utils.js' at 466,3: ArangoError 36: Monitored child process exited unexpectedly
2023-04-26T13:18:33Z [116246] ERROR [409ee] {general} !  sleep(1);
```
Catch this condition, and properly abort the testrun.

- [x] :hankey: Bugfix
