### PR TITLE
Use sync rocksdb methods for replicated logs.

### DIFF
--- a/arangod/RocksDBEngine/RocksDBEngine.cpp
+++ b/arangod/RocksDBEngine/RocksDBEngine.cpp
@@ -3136,7 +3136,7 @@ void RocksDBEngine::loadReplicatedStates(TRI_vocbase_t& vocbase) {
     }
 
     auto info = velocypack::deserialize<RocksDBReplicatedStateInfo>(slice);
-    auto methods = std::make_unique<RocksDBLogStorageMethods>(
+    auto methods = std::make_unique<RocksDBSyncLogStorageMethods>(
         info.objectId, vocbase.id(), info.stateId, _logPersistor, _db,
         RocksDBColumnFamilyManager::get(
             RocksDBColumnFamilyManager::Family::Definitions),
@@ -3944,7 +3944,7 @@ auto RocksDBEngine::createReplicatedState(
     -> ResultT<std::unique_ptr<
         replication2::replicated_state::IStorageEngineMethods>> {
   auto objectId = TRI_NewTickServer();
-  auto methods = std::make_unique<RocksDBLogStorageMethods>(
+  auto methods = std::make_unique<RocksDBSyncLogStorageMethods>(
       objectId, vocbase.id(), id, _logPersistor, _db,
       RocksDBColumnFamilyManager::get(
           RocksDBColumnFamilyManager::Family::Definitions),

--- a/arangod/RocksDBEngine/RocksDBPersistedLog.h
+++ b/arangod/RocksDBEngine/RocksDBPersistedLog.h
@@ -264,7 +264,7 @@ auto inspect(Inspector& f, RocksDBReplicatedStateInfo& x) {
       f.field("state", x.state));
 }
 
-struct RocksDBLogStorageMethods final
+struct RocksDBLogStorageMethods
     : replication2::replicated_state::IStorageEngineMethods {
   explicit RocksDBLogStorageMethods(
       uint64_t objectId, std::uint64_t vocbaseId, replication2::LogId logId,
@@ -307,6 +307,19 @@ struct RocksDBLogStorageMethods final
   rocksdb::ColumnFamilyHandle* const logCf;
   AsyncLogWriteContext ctx;
   std::shared_ptr<RocksDBAsyncLogWriteBatcherMetrics> const _metrics;
+};
+
+struct RocksDBSyncLogStorageMethods : RocksDBLogStorageMethods {
+  using RocksDBLogStorageMethods::RocksDBLogStorageMethods;
+  [[nodiscard]] auto insert(
+      std::unique_ptr<replication2::PersistedLogIterator> ptr,
+      WriteOptions const&) -> futures::Future<ResultT<SequenceNumber>> override;
+  [[nodiscard]] auto removeFront(replication2::LogIndex stop,
+                                 WriteOptions const&)
+      -> futures::Future<ResultT<SequenceNumber>> override;
+  [[nodiscard]] auto removeBack(replication2::LogIndex start,
+                                WriteOptions const&)
+      -> futures::Future<ResultT<SequenceNumber>> override;
 };
 
 }  // namespace arangodb


### PR DESCRIPTION
### Scope & Purpose
Directly write into rocksdb instead of passing the write request to the write batcher. This is just a test and not intended for merging.