### PR TITLE
fix value of `internal.extendedNames` after restart

### DIFF
--- a/arangod/RestServer/FrontendFeature.cpp
+++ b/arangod/RestServer/FrontendFeature.cpp
@@ -60,8 +60,6 @@ void FrontendFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
 void FrontendFeature::prepare() {
   V8DealerFeature& dealer = server().getFeature<V8DealerFeature>();
   dealer.defineBoolean("FE_VERSION_CHECK", _versionCheck);
-  dealer.defineBoolean("FE_EXTENDED_NAMES",
-                       server().getFeature<DatabaseFeature>().extendedNames());
 }
 
 }  // namespace arangodb

--- a/arangod/V8Server/V8DealerFeature.cpp
+++ b/arangod/V8Server/V8DealerFeature.cpp
@@ -47,6 +47,8 @@
 #include "Logger/LogMacros.h"
 #include "Logger/Logger.h"
 #include "Logger/LoggerStream.h"
+#include "Metrics/CounterBuilder.h"
+#include "Metrics/MetricsFeature.h"
 #include "ProgramOptions/ProgramOptions.h"
 #include "ProgramOptions/Section.h"
 #include "Random/RandomGenerator.h"
@@ -54,8 +56,6 @@
 #include "RestServer/DatabaseFeature.h"
 #include "RestServer/DatabasePathFeature.h"
 #include "RestServer/FrontendFeature.h"
-#include "Metrics/CounterBuilder.h"
-#include "Metrics/MetricsFeature.h"
 #include "RestServer/QueryRegistryFeature.h"
 #include "RestServer/ScriptFeature.h"
 #include "RestServer/SystemDatabaseFeature.h"
@@ -1811,7 +1811,7 @@ std::unique_ptr<V8Context> V8DealerFeature::buildContext(TRI_vocbase_t* vocbase,
                                      TRI_V8_ASCII_STRING(isolate, "APP_PATH"),
                                      TRI_V8_STD_STRING(isolate, _appPath));
 
-        for (auto j : _definedBooleans) {
+        for (auto const& j : _definedBooleans) {
           localContext->Global()
               ->DefineOwnProperty(TRI_IGETC,
                                   TRI_V8_STD_STRING(isolate, j.first),
@@ -1820,7 +1820,7 @@ std::unique_ptr<V8Context> V8DealerFeature::buildContext(TRI_vocbase_t* vocbase,
               .FromMaybe(false);  // Ignore it...
         }
 
-        for (auto j : _definedDoubles) {
+        for (auto const& j : _definedDoubles) {
           localContext->Global()
               ->DefineOwnProperty(
                   TRI_IGETC, TRI_V8_STD_STRING(isolate, j.first),

--- a/arangod/V8Server/v8-vocbase.cpp
+++ b/arangod/V8Server/v8-vocbase.cpp
@@ -2373,6 +2373,15 @@ void TRI_InitV8VocBridge(v8::Isolate* isolate, v8::Handle<v8::Context> context,
                           v8::Object::New(isolate), v8::DontEnum)
       .FromMaybe(false);  // ignore result
 
+  // extended names enabled
+  context->Global()
+      ->DefineOwnProperty(
+          TRI_IGETC, TRI_V8_ASCII_STRING(isolate, "FE_EXTENDED_NAMES"),
+          v8::Boolean::New(
+              isolate, server.getFeature<DatabaseFeature>().extendedNames()),
+          v8::PropertyAttribute(v8::ReadOnly | v8::DontEnum))
+      .FromMaybe(false);  // ignore result
+
   // current thread number
   context->Global()
       ->DefineOwnProperty(


### PR DESCRIPTION
### Scope & Purpose

fix value of `internal.extendedNames` after restart when startup option `--database.extended-names` was not explicitly specified, but a previous run set it to `true`.
in this case, the value was reported as `false`, although it should have been reported as `true`.

manually tested

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: -
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 