### PR TITLE
fix unstable cache test

### DIFF
--- a/tests/js/client/shell/shell-auto-refill-index-caches-on-modify-noncluster.js
+++ b/tests/js/client/shell/shell-auto-refill-index-caches-on-modify-noncluster.js
@@ -160,16 +160,18 @@ function AutoRefillIndexCachesEdge() {
     },
     
     testInsertEdgeBatchEnabled: function() {
-      const oldValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
-      let docs = [];
-      for (let i = 0; i < n; ++i) {
-        docs.push({_from: 'v/test' + i, _to: 'v/test' + (i % 25)});
-      }
-      db[cn].insert(docs, { refillIndexCaches: true });
-      const newValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
+      runWithRetry(() => {
+        const oldValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
+        let docs = [];
+        for (let i = 0; i < n; ++i) {
+          docs.push({_from: 'v/test' + i, _to: 'v/test' + (i % 25)});
+        }
+        db[cn].insert(docs, { refillIndexCaches: true });
+        const newValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
 
-      assertTrue(newValue - oldValue >= 2 * n, { oldValue, newValue });
-      runCheck(true);
+        assertTrue(newValue - oldValue >= 2 * n, { oldValue, newValue });
+        runCheck(true);
+      }, runWithRetryFailCb);
     },
     
     testUpdateEdgeAqlDisabled: function() {
@@ -218,20 +220,22 @@ function AutoRefillIndexCachesEdge() {
     },
     
     testUpdateEdgeBatchEnabled: function() {
-      insertInitialEdges();
-      
-      const oldValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
-      let keys = [];
-      let docs = [];
-      for (let i = 0; i < n; ++i) {
-        keys.push({_key: 'test' + i});
-        docs.push({value: i + 1 });
-      }
-      db[cn].update(keys, docs, { refillIndexCaches: true });
-      const newValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
+      runWithRetry(() => {
+        insertInitialEdges();
 
-      assertTrue(newValue - oldValue >= 2 * n, { oldValue, newValue });
-      runCheck(true);
+        const oldValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
+        let keys = [];
+        let docs = [];
+        for (let i = 0; i < n; ++i) {
+          keys.push({_key: 'test' + i});
+          docs.push({value: i + 1 });
+        }
+        db[cn].update(keys, docs, { refillIndexCaches: true });
+        const newValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
+
+        assertTrue(newValue - oldValue >= 2 * n, { oldValue, newValue });
+        runCheck(true);
+      }, runWithRetryFailCb);
     },
     
     testReplaceEdgeAqlDisabled: function() {
@@ -280,20 +284,22 @@ function AutoRefillIndexCachesEdge() {
     },
     
     testReplaceEdgeBatchEnabled: function() {
-      insertInitialEdges();
+      runWithRetry(() => {
+        insertInitialEdges();
       
-      const oldValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
-      let keys = [];
-      let docs = [];
-      for (let i = 0; i < n; ++i) {
-        keys.push({_key: 'test' + i});
-        docs.push({_from: 'v/test' + i, _to: 'v/test' + (i % 25), value: i + 1 });
-      }
-      db[cn].replace(keys, docs, { refillIndexCaches: true });
-      const newValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
+        const oldValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
+        let keys = [];
+        let docs = [];
+        for (let i = 0; i < n; ++i) {
+          keys.push({_key: 'test' + i});
+          docs.push({_from: 'v/test' + i, _to: 'v/test' + (i % 25), value: i + 1 });
+        }
+        db[cn].replace(keys, docs, { refillIndexCaches: true });
+        const newValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
 
-      assertTrue(newValue - oldValue >= 2 * n, { oldValue, newValue });
-      runCheck(true);
+        assertTrue(newValue - oldValue >= 2 * n, { oldValue, newValue });
+        runCheck(true);
+      }, runWithRetryFailCb);
     },
     
     testRemoveEdgeAqlDisabled: function() {
@@ -340,18 +346,20 @@ function AutoRefillIndexCachesEdge() {
     },
     
     testRemoveEdgeBatchEnabled: function() {
-      insertInitialEdges();
-      
-      const oldValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
-      let keys = [];
-      for (let i = 0; i < n / 2; ++i) {
-        keys.push({_key: 'test' + i});
-      }
-      db[cn].remove(keys, { refillIndexCaches: true });
-      const newValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
+      runWithRetry(() => {
+        insertInitialEdges();
+        
+        const oldValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
+        let keys = [];
+        for (let i = 0; i < n / 2; ++i) {
+          keys.push({_key: 'test' + i});
+        }
+        db[cn].remove(keys, { refillIndexCaches: true });
+        const newValue = getMetric("rocksdb_cache_auto_refill_loaded_total");
 
-      assertTrue(newValue - oldValue >= n / 2, { oldValue, newValue });
-      runRemoveCheck(true);
+        assertTrue(newValue - oldValue >= n / 2, { oldValue, newValue });
+        runRemoveCheck(true);
+      }, runWithRetryFailCb);
     },
   };
 }


### PR DESCRIPTION
### Scope & Purpose

Test-only bugfix.
Attempt to fix unstable test
```
    [FAILED]  tests/js/client/shell/shell-auto-refill-index-caches-on-modify-noncluster.js

      "testReplaceEdgeBatchEnabled" failed: Error: at assertion #5003: { 
  "writesExecuted" : 0, 
  "writesIgnored" : 0, 
  "scannedFull" : 0, 
  "scannedIndex" : 5000, 
  "cursorsCreated" : 1, 
  "cursorsRearmed" : 4999, 
  "cacheHits" : 0, 
  "cacheMisses" : 5000, 
  "filtered" : 0, 
  "httpRequests" : 0, 
  "executionTime" : 0.05387298599998758, 
  "peakMemoryUsage" : 98304, 
  "intermediateCommits" : 0 
}: (false) does not evaluate to true
(Error
    at runCheck (tests/js/client/shell/shell-auto-refill-index-caches-on-modify-noncluster.js:66:7)
    at Object.testReplaceEdgeBatchEnabled (tests/js/client/shell/shell-auto-refill-index-caches-on-modify-noncluster.js:296:7)
    at tests/js/client/shell/shell-auto-refill-index-caches-on-modify-noncluster.js:619:9
....    at Object.shellClient [as shell_client] (/work/ArangoDB/js/client/modules/@arangodb/testsuites/aql.js:208:79)
 - test failed

   Suites failed: 1 Tests Failed: 1
```

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: -
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 