### PR TITLE
re-allow deletion by view id

### DIFF
--- a/arangod/RestHandler/RestViewHandler.cpp
+++ b/arangod/RestHandler/RestViewHandler.cpp
@@ -448,14 +448,17 @@ void RestViewHandler::deleteView() {
 
   auto name = arangodb::basics::StringUtils::urlDecode(suffixes[0]);
 
-  bool extendedNames =
-      _vocbase.server().getFeature<DatabaseFeature>().extendedNames();
-  if (auto res = ViewNameValidator::validateName(
-          /*allowSystem*/ false, extendedNames, name);
-      res.fail()) {
-    generateError(res);
-    events::DropView(_vocbase.name(), name, res.errorNumber());
-    return;
+  if (name.empty() || name[0] < '0' || name[0] > '9') {
+    // not a numeric view id. now validate view name
+    bool extendedNames =
+        _vocbase.server().getFeature<DatabaseFeature>().extendedNames();
+    if (auto res = ViewNameValidator::validateName(
+            /*allowSystem*/ false, extendedNames, name);
+        res.fail()) {
+      generateError(res);
+      events::DropView(_vocbase.name(), name, res.errorNumber());
+      return;
+    }
   }
 
   auto allowDropSystem =


### PR DESCRIPTION
### Scope & Purpose

Allow deletion by view id again.
This functionality broke due to a recent commit, and this went undetected because we did not have a test for it.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [x] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: -
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 