### PR TITLE
documentation: print the function surce so the user can better allocate the assert

### DIFF
--- a/Documentation/Scripts/exampleHeader.js
+++ b/Documentation/Scripts/exampleHeader.js
@@ -162,8 +162,10 @@ var logErrorResponse = function (response) {
 };
 var globalAssert = function(condition, testname, sourceFile, fnsource) {
   if (! condition) {
-    internal.output(`${hashes}\nASSERTION FAILED: \n${testname} in file ${sourceFile}\nIn this Function:\n${fnsource}\n${hashes}\n`);
-    throw new Error('assertion ' + testname + ' in file ' + sourceFile + ' failed');
+    let msg = `${hashes}\nASSERTION FAILED: \n${testname} in file ${sourceFile}\nIn this Function:\n${fnsource}\n${hashes}\n`;
+    allErrors += msg;
+    internal.output(msg);
+    throw new Error(msg);
   }
 };
 

--- a/Documentation/Scripts/exampleHeader.js
+++ b/Documentation/Scripts/exampleHeader.js
@@ -160,9 +160,9 @@ var logPlainResponse = internal.appendPlainResponse(plainAppender, plainAppender
 var logErrorResponse = function (response) {
     allErrors += "Server reply was: " + JSON.stringify(response) + "\n";
 };
-var globalAssert = function(condition, testname, sourceFile) {
+var globalAssert = function(condition, testname, sourceFile, fnsource) {
   if (! condition) {
-    internal.output(hashes + '\nASSERTION FAILED: ' + testname + ' in file ' + sourceFile + '\n' + hashes + '\n');
+    internal.output(`${hashes}\nASSERTION FAILED: \n${testname} in file ${sourceFile}\nIn this Function:\n${fnsource}\n${hashes}\n`);
     throw new Error('assertion ' + testname + ' in file ' + sourceFile + ' failed');
   }
 };

--- a/tests/js/common/shell/aql-index-usage.js
+++ b/tests/js/common/shell/aql-index-usage.js
@@ -63,7 +63,6 @@ function IndexUsageSuite () {
     },
 
     testIndexUsage : function () {
-      assertTrue(1===2)
       let task = tasks.register({
         command: function(params) {
           require('jsunity').jsUnity.attachAssertions();

--- a/tests/js/common/shell/aql-index-usage.js
+++ b/tests/js/common/shell/aql-index-usage.js
@@ -63,6 +63,7 @@ function IndexUsageSuite () {
     },
 
     testIndexUsage : function () {
+      assertTrue(1===2)
       let task = tasks.register({
         command: function(params) {
           require('jsunity').jsUnity.attachAssertions();

--- a/utils/generateExamples.py
+++ b/utils/generateExamples.py
@@ -404,7 +404,7 @@ def generateArangoshOutput(testName):
   var outputDir = '%s';
   var sourceFile = '%s';
   var startTime = time();
-  var assert = function(a) { globalAssert(a, testName, sourceFile); };
+  var assert = function(a) { globalAssert(a, testName, sourceFile, assert.caller.toString()); };
   internal.startCaptureMode();
 '''    %   (
         ('/'*80),
@@ -480,7 +480,7 @@ def generateArangoshRun(testName):
   var sourceFile = '%s';
   var startTime = time();
   output = '';
-  var assert = function(a) { globalAssert(a, testName, sourceFile); };
+  var assert = function(a) { globalAssert(a, testName, sourceFile, assert.caller.toString()); };
   testFunc = function() {
 %s};
 ''' %  (


### PR DESCRIPTION
### Scope & Purpose

the information available in asserts in the examples is pretty limited. Dump out the function to give the user some context

- [x] :pizza: New feature

instead of the very limited:
```
09:20:56 RUN FAILED: RestViewDeleteViewIdentifierArangoSearch from testfile: /work/ArangoDB/Documentation/DocuBlocks/Rest/Views/delete_api_view_view.md, Error: assertion RestViewDeleteViewIdentifierArangoSearch in file /work/ArangoDB/Documentation/DocuBlocks/Rest/Views/delete_api_view_view.md failed
09:20:56 Error: assertion RestViewDeleteViewIdentifierArangoSearch in file /work/ArangoDB/Documentation/DocuBlocks/Rest/Views/delete_api_view_view.md failed
09:20:56     at globalAssert (/work/ArangoDB/arangosh.examples.js:166:11)
09:20:56     at assert (/work/ArangoDB/arangosh.examples.js:15807:30)
09:20:56     at testFunc (/work/ArangoDB/arangosh.examples.js:15816:1)
09:20:56     at runTestFunc (/work/ArangoDB/arangosh.examples.js:221:5)
09:20:56     at /work/ArangoDB/arangosh.examples.js:15820:8
09:20:56     at /work/ArangoDB/arangosh.examples.js:15829:2
09:20:56 not all collections were cleaned up after /work/ArangoDB/Documentation/DocuBlocks/Rest/Views/delete_api_view_view.md Line[31] [RestViewDeleteViewIdentifierArangoSearch]: - ["testView"]
```
output in the jenkins example documentation, you now would see this: (add timestamps, fix paths)
```
################################################################################
ASSERTION FAILED: 
RestViewDeleteViewIdentifierArangoSearch in file /home/willi/src/stable-3.11/Documentation/DocuBlocks/Rest/Views/delete_api_view_view.md
In this Function:
function() {
var viewName = "testView";
var viewType = "arangosearch";

var view = db._createView(viewName, viewType);
var url = "/_api/view/"+ view._id;

var response = logCurlRequest('DELETE', url);
assert(response.code === 200);

logJsonResponse(response);}
################################################################################
[0.008097171783447266s] ################################################################################
failed with  RestViewDeleteViewIdentifierArangoSearch, Error: assertion RestViewDeleteViewIdentifierArangoSearch in file /home/willi/src/stable-3.11/Documentation/DocuBlocks/Rest/Views/delete_api_view_view.md failed
```