### PR TITLE
[GORDO-1636] Remove ResponsibleServerMap

### DIFF
--- a/arangod/Pregel/GraphStore/GraphSerdeConfig.h
+++ b/arangod/Pregel/GraphStore/GraphSerdeConfig.h
@@ -37,25 +37,21 @@
 namespace arangodb::pregel {
 
 struct GraphSerdeConfig {
-  LoadableVertexShards loadableVertexShards;
+  std::vector<LoadableVertexShard> loadableVertexShards;
 
   [[nodiscard]] auto collectionName(PregelShard pregelShard) const
       -> std::string const& {
-    ADB_PROD_ASSERT(pregelShard.value <
-                    loadableVertexShards.loadableVertexShards.size());
-    return loadableVertexShards.loadableVertexShards.at(pregelShard.value)
-        .collectionName;
+    ADB_PROD_ASSERT(pregelShard.value < loadableVertexShards.size());
+    return loadableVertexShards.at(pregelShard.value).collectionName;
   }
 
   [[nodiscard]] auto shardID(PregelShard pregelShard) const -> ShardID {
-    ADB_PROD_ASSERT(pregelShard.value <
-                    loadableVertexShards.loadableVertexShards.size());
-    return loadableVertexShards.loadableVertexShards.at(pregelShard.value)
-        .vertexShard;
+    ADB_PROD_ASSERT(pregelShard.value < loadableVertexShards.size());
+    return loadableVertexShards.at(pregelShard.value).vertexShard;
   }
   [[nodiscard]] auto pregelShard(ShardID responsibleShard) const
       -> PregelShard {
-    for (auto const& lvs : loadableVertexShards.loadableVertexShards) {
+    for (auto const& lvs : loadableVertexShards) {
       if (lvs.vertexShard == responsibleShard) {
         return lvs.pregelShard;
       }
@@ -71,8 +67,7 @@ struct GraphSerdeConfig {
       -> std::set<PregelShard> {
     auto result = std::set<PregelShard>{};
 
-    for (auto&& loadableVertexShard :
-         loadableVertexShards.loadableVertexShards) {
+    for (auto&& loadableVertexShard : loadableVertexShards) {
       if (loadableVertexShard.responsibleServer == server) {
         result.insert(loadableVertexShard.pregelShard);
       }
@@ -84,8 +79,7 @@ struct GraphSerdeConfig {
       -> std::vector<LoadableVertexShard> {
     auto result = std::vector<LoadableVertexShard>{};
 
-    for (auto&& loadableVertexShard :
-         loadableVertexShards.loadableVertexShards) {
+    for (auto&& loadableVertexShard : loadableVertexShards) {
       if (loadableVertexShard.responsibleServer == server) {
         result.push_back(loadableVertexShard);
       }
@@ -96,8 +90,7 @@ struct GraphSerdeConfig {
   [[nodiscard]] auto localShardIDs(ServerID server) const -> std::set<ShardID> {
     auto result = std::set<ShardID>{};
 
-    for (auto&& loadableVertexShard :
-         loadableVertexShards.loadableVertexShards) {
+    for (auto&& loadableVertexShard : loadableVertexShards) {
       if (loadableVertexShard.responsibleServer == server) {
         result.insert(loadableVertexShard.vertexShard);
       }
@@ -107,8 +100,7 @@ struct GraphSerdeConfig {
 
   [[nodiscard]] auto responsibleServerSet() const -> std::set<ServerID> {
     auto result = std::set<ServerID>{};
-    for (auto&& loadableVertexShard :
-         loadableVertexShards.loadableVertexShards) {
+    for (auto&& loadableVertexShard : loadableVertexShards) {
       result.insert(loadableVertexShard.responsibleServer);
     }
     return result;

--- a/arangod/Pregel/GraphStore/GraphSerdeConfigBuilder.cpp
+++ b/arangod/Pregel/GraphStore/GraphSerdeConfigBuilder.cpp
@@ -69,10 +69,8 @@ auto buildGraphSerdeConfig(TRI_vocbase_t& vocbase,
     return errors::ErrorT<Result, GraphSerdeConfig>::error(edgeCollectionsOk);
   }
 
-  auto loadableVertexShards = configBuilder->loadableVertexShards();
-
-  return errors::ErrorT<Result, GraphSerdeConfig>::ok(
-      GraphSerdeConfig{.loadableVertexShards = loadableVertexShards});
+  return errors::ErrorT<Result, GraphSerdeConfig>::ok(GraphSerdeConfig{
+      .loadableVertexShards = configBuilder->loadableVertexShards()});
 }
 
 // TODO: maybe this belongs into GraphSerdeConfigBuilderBase and should also be

--- a/arangod/Pregel/GraphStore/GraphSerdeConfigBuilder.cpp
+++ b/arangod/Pregel/GraphStore/GraphSerdeConfigBuilder.cpp
@@ -70,12 +70,9 @@ auto buildGraphSerdeConfig(TRI_vocbase_t& vocbase,
   }
 
   auto loadableVertexShards = configBuilder->loadableVertexShards();
-  auto responsibleServerMap =
-      configBuilder->responsibleServerMap(loadableVertexShards);
 
   return errors::ErrorT<Result, GraphSerdeConfig>::ok(
-      GraphSerdeConfig{.loadableVertexShards = loadableVertexShards,
-                       .responsibleServerMap = responsibleServerMap});
+      GraphSerdeConfig{.loadableVertexShards = loadableVertexShards});
 }
 
 // TODO: maybe this belongs into GraphSerdeConfigBuilderBase and should also be

--- a/arangod/Pregel/GraphStore/GraphSerdeConfigBuilder.h
+++ b/arangod/Pregel/GraphStore/GraphSerdeConfigBuilder.h
@@ -40,7 +40,7 @@ struct GraphSerdeConfigBuilderBase {
   [[nodiscard]] virtual auto checkEdgeCollections() const -> Result = 0;
 
   [[nodiscard]] virtual auto loadableVertexShards() const
-      -> LoadableVertexShards = 0;
+      -> std::vector<LoadableVertexShard> = 0;
   [[nodiscard]] static auto construct(
       TRI_vocbase_t& vocbase, GraphByCollections const& graphByCollections)
       -> std::unique_ptr<GraphSerdeConfigBuilderBase>;

--- a/arangod/Pregel/GraphStore/GraphSerdeConfigBuilder.h
+++ b/arangod/Pregel/GraphStore/GraphSerdeConfigBuilder.h
@@ -41,9 +41,6 @@ struct GraphSerdeConfigBuilderBase {
 
   [[nodiscard]] virtual auto loadableVertexShards() const
       -> LoadableVertexShards = 0;
-  [[nodiscard]] virtual auto responsibleServerMap(
-      LoadableVertexShards const& loadableVertexShards) const
-      -> ResponsibleServerMap = 0;
   [[nodiscard]] static auto construct(
       TRI_vocbase_t& vocbase, GraphByCollections const& graphByCollections)
       -> std::unique_ptr<GraphSerdeConfigBuilderBase>;

--- a/arangod/Pregel/GraphStore/GraphSerdeConfigBuilderCluster.cpp
+++ b/arangod/Pregel/GraphStore/GraphSerdeConfigBuilderCluster.cpp
@@ -134,23 +134,6 @@ GraphSerdeConfigBuilderCluster::GraphSerdeConfigBuilderCluster(
   return result;
 }
 
-[[nodiscard]] auto GraphSerdeConfigBuilderCluster::responsibleServerMap(
-    LoadableVertexShards const& loadableVertexShards) const
-    -> ResponsibleServerMap {
-  auto result = ResponsibleServerMap{};
-
-  for (auto const& [idx, shard] :
-       enumerate(loadableVertexShards.loadableVertexShards)) {
-    std::shared_ptr<std::vector<ServerID> const> servers =
-        clusterInfo.getResponsibleServer(shard.vertexShard);
-    ADB_PROD_ASSERT(servers->size() > 0);
-    if (servers->size() > 0) {
-      result.responsibleServerMap.push_back(servers->at(0));
-    }
-  }
-  return result;
-}
-
 [[nodiscard]] auto GraphSerdeConfigBuilderCluster::resolveCollectionNameToIds(
     CollectionName collectionName) const -> std::vector<DataSourceId> {
   auto logicalCollection =

--- a/arangod/Pregel/GraphStore/GraphSerdeConfigBuilderCluster.cpp
+++ b/arangod/Pregel/GraphStore/GraphSerdeConfigBuilderCluster.cpp
@@ -97,8 +97,8 @@ GraphSerdeConfigBuilderCluster::GraphSerdeConfigBuilderCluster(
 }
 
 [[nodiscard]] auto GraphSerdeConfigBuilderCluster::loadableVertexShards() const
-    -> LoadableVertexShards {
-  auto result = LoadableVertexShards{};
+    -> std::vector<LoadableVertexShard> {
+  auto result = std::vector<LoadableVertexShard>{};
 
   std::vector<std::vector<ShardID>> vertexShardTable;
   std::vector<std::vector<ShardID>> edgeShardTable;
@@ -114,7 +114,7 @@ GraphSerdeConfigBuilderCluster::GraphSerdeConfigBuilderCluster(
     for (auto shardIdx = size_t{0}; shardIdx < vertexShardTable[collIdx].size();
          ++shardIdx) {
       auto loadableVertexShard = LoadableVertexShard{
-          .pregelShard = PregelShard(result.loadableVertexShards.size()),
+          .pregelShard = PregelShard(result.size()),
           .vertexShard = vertexShardTable[collIdx][shardIdx],
           .collectionName = graphByCollections.vertexCollections[collIdx],
           .edgeShards = {}};
@@ -128,7 +128,7 @@ GraphSerdeConfigBuilderCluster::GraphSerdeConfigBuilderCluster(
               edgeShardTable[edgeCollIdx][shardIdx]);
         }
       }
-      result.loadableVertexShards.emplace_back(loadableVertexShard);
+      result.emplace_back(loadableVertexShard);
     }
   }
   return result;

--- a/arangod/Pregel/GraphStore/GraphSerdeConfigBuilderCluster.h
+++ b/arangod/Pregel/GraphStore/GraphSerdeConfigBuilderCluster.h
@@ -38,7 +38,7 @@ struct GraphSerdeConfigBuilderCluster : GraphSerdeConfigBuilderBase {
   [[nodiscard]] virtual auto checkEdgeCollections() const -> Result override;
 
   [[nodiscard]] virtual auto loadableVertexShards() const
-      -> LoadableVertexShards override;
+      -> std::vector<LoadableVertexShard> override;
 
   [[nodiscard]] auto getShardIds(ShardID collection) const
       -> std::vector<ShardID>;

--- a/arangod/Pregel/GraphStore/GraphSerdeConfigBuilderCluster.h
+++ b/arangod/Pregel/GraphStore/GraphSerdeConfigBuilderCluster.h
@@ -40,10 +40,6 @@ struct GraphSerdeConfigBuilderCluster : GraphSerdeConfigBuilderBase {
   [[nodiscard]] virtual auto loadableVertexShards() const
       -> LoadableVertexShards override;
 
-  [[nodiscard]] virtual auto responsibleServerMap(
-      LoadableVertexShards const& loadableVertexShards) const
-      -> ResponsibleServerMap override;
-
   [[nodiscard]] auto getShardIds(ShardID collection) const
       -> std::vector<ShardID>;
   [[nodiscard]] auto resolveCollectionNameToIds(CollectionName name) const

--- a/arangod/Pregel/GraphStore/GraphSerdeConfigBuilderSingleServer.cpp
+++ b/arangod/Pregel/GraphStore/GraphSerdeConfigBuilderSingleServer.cpp
@@ -57,8 +57,8 @@ GraphSerdeConfigBuilderSingleServer::GraphSerdeConfigBuilderSingleServer(
 }
 
 [[nodiscard]] auto GraphSerdeConfigBuilderSingleServer::loadableVertexShards()
-    const -> LoadableVertexShards {
-  auto result = LoadableVertexShards{};
+    const -> std::vector<LoadableVertexShard> {
+  auto result = std::vector<LoadableVertexShard>{};
 
   for (auto const [idx, vertexCollection] :
        enumerate(graphByCollections.vertexCollections)) {
@@ -73,7 +73,7 @@ GraphSerdeConfigBuilderSingleServer::GraphSerdeConfigBuilderSingleServer(
         loadableVertexShard.edgeShards.emplace_back(edgeCollection);
       }
     }
-    result.loadableVertexShards.emplace_back(loadableVertexShard);
+    result.emplace_back(loadableVertexShard);
   }
   return result;
 }

--- a/arangod/Pregel/GraphStore/GraphSerdeConfigBuilderSingleServer.cpp
+++ b/arangod/Pregel/GraphStore/GraphSerdeConfigBuilderSingleServer.cpp
@@ -78,14 +78,4 @@ GraphSerdeConfigBuilderSingleServer::GraphSerdeConfigBuilderSingleServer(
   return result;
 }
 
-[[nodiscard]] auto GraphSerdeConfigBuilderSingleServer::responsibleServerMap(
-    LoadableVertexShards const& loadableVertexShards) const
-    -> ResponsibleServerMap {
-  auto result = ResponsibleServerMap{};
-
-  result.responsibleServerMap.resize(
-      loadableVertexShards.loadableVertexShards.size(), "");
-  return result;
-}
-
 }  // namespace arangodb::pregel

--- a/arangod/Pregel/GraphStore/GraphSerdeConfigBuilderSingleServer.h
+++ b/arangod/Pregel/GraphStore/GraphSerdeConfigBuilderSingleServer.h
@@ -34,9 +34,6 @@ struct GraphSerdeConfigBuilderSingleServer : GraphSerdeConfigBuilderBase {
   [[nodiscard]] virtual auto checkEdgeCollections() const -> Result override;
   [[nodiscard]] virtual auto loadableVertexShards() const
       -> LoadableVertexShards override;
-  [[nodiscard]] virtual auto responsibleServerMap(
-      LoadableVertexShards const& loadableVertexShards) const
-      -> ResponsibleServerMap override;
 
   TRI_vocbase_t& vocbase;
   GraphByCollections const& graphByCollections;

--- a/arangod/Pregel/GraphStore/GraphSerdeConfigBuilderSingleServer.h
+++ b/arangod/Pregel/GraphStore/GraphSerdeConfigBuilderSingleServer.h
@@ -33,7 +33,7 @@ struct GraphSerdeConfigBuilderSingleServer : GraphSerdeConfigBuilderBase {
   [[nodiscard]] virtual auto checkVertexCollections() const -> Result override;
   [[nodiscard]] virtual auto checkEdgeCollections() const -> Result override;
   [[nodiscard]] virtual auto loadableVertexShards() const
-      -> LoadableVertexShards override;
+      -> std::vector<LoadableVertexShard> override;
 
   TRI_vocbase_t& vocbase;
   GraphByCollections const& graphByCollections;

--- a/arangod/Pregel/GraphStore/LoadableVertexShard.h
+++ b/arangod/Pregel/GraphStore/LoadableVertexShard.h
@@ -31,6 +31,7 @@ namespace arangodb::pregel {
 struct LoadableVertexShard {
   PregelShard pregelShard;
   ShardID vertexShard;
+  ServerID responsibleServer;
   CollectionName collectionName;
   std::vector<ShardID> edgeShards;
 };
@@ -38,6 +39,7 @@ template<typename Inspector>
 auto inspect(Inspector& f, LoadableVertexShard& x) {
   return f.object(x).fields(f.field("pregelShard", x.pregelShard),
                             f.field("vertexShard", x.vertexShard),
+                            f.field("responsibleServer", x.responsibleServer),
                             f.field("collectionName", x.collectionName),
                             f.field("edgeShards", x.edgeShards));
 }
@@ -49,7 +51,9 @@ struct LoadableVertexShards {
   [[nodiscard]] auto at(size_t pos) const -> LoadableVertexShard const& {
     return loadableVertexShards.at(pos);
   }
-
+  auto add(LoadableVertexShard&& item) -> void {
+    loadableVertexShards.emplace_back(std::move(item));
+  }
   std::vector<LoadableVertexShard> loadableVertexShards;
 };
 template<typename Inspector>

--- a/arangod/Pregel/GraphStore/LoadableVertexShard.h
+++ b/arangod/Pregel/GraphStore/LoadableVertexShard.h
@@ -43,22 +43,4 @@ auto inspect(Inspector& f, LoadableVertexShard& x) {
                             f.field("collectionName", x.collectionName),
                             f.field("edgeShards", x.edgeShards));
 }
-
-struct LoadableVertexShards {
-  [[nodiscard]] auto size() const -> size_t {
-    return loadableVertexShards.size();
-  }
-  [[nodiscard]] auto at(size_t pos) const -> LoadableVertexShard const& {
-    return loadableVertexShards.at(pos);
-  }
-  auto add(LoadableVertexShard&& item) -> void {
-    loadableVertexShards.emplace_back(std::move(item));
-  }
-  std::vector<LoadableVertexShard> loadableVertexShards;
-};
-template<typename Inspector>
-auto inspect(Inspector& f, LoadableVertexShards& x) {
-  return f.object(x).fields(f.field("vertexShards", x.loadableVertexShards));
-}
-
 }  // namespace arangodb::pregel

--- a/tests/Pregel/ConductorStateTest.cpp
+++ b/tests/Pregel/ConductorStateTest.cpp
@@ -83,7 +83,7 @@ TEST(CreateWorkersStateTest, creates_as_many_messages_as_required_servers) {
   for (auto const& servers : amountOfServers) {
     auto execSpec = ExecutionSpecifications();
     for (auto server : servers) {
-      execSpec.graphSerdeConfig.loadableVertexShards.add(
+      execSpec.graphSerdeConfig.loadableVertexShards.emplace_back(
           LoadableVertexShard{.pregelShard = {},
                               .vertexShard = {},
                               .responsibleServer = server,
@@ -110,7 +110,7 @@ TEST(CreateWorkersStateTest, creates_worker_pids_from_received_messages) {
 
   auto execSpec = ExecutionSpecifications();
   for (auto server : servers) {
-    execSpec.graphSerdeConfig.loadableVertexShards.add(
+    execSpec.graphSerdeConfig.loadableVertexShards.emplace_back(
         LoadableVertexShard{.pregelShard = {},
                             .vertexShard = {},
                             .responsibleServer = server,
@@ -152,7 +152,7 @@ TEST(CreateWorkersStateTest,
   std::vector<std::string> servers = {"ServerA", "ServerB", "ServerC"};
   auto execSpec = ExecutionSpecifications();
   for (auto server : servers) {
-    execSpec.graphSerdeConfig.loadableVertexShards.add(
+    execSpec.graphSerdeConfig.loadableVertexShards.emplace_back(
         LoadableVertexShard{.pregelShard = {},
                             .vertexShard = {},
                             .responsibleServer = server,

--- a/tests/Pregel/ConductorStateTest.cpp
+++ b/tests/Pregel/ConductorStateTest.cpp
@@ -82,9 +82,14 @@ TEST(CreateWorkersStateTest, creates_as_many_messages_as_required_servers) {
       {}, {"ServerA"}, {"ServerA", "ServerB"}};
   for (auto const& servers : amountOfServers) {
     auto execSpec = ExecutionSpecifications();
-
-    execSpec.graphSerdeConfig.responsibleServerMap.responsibleServerMap =
-        servers;
+    for (auto server : servers) {
+      execSpec.graphSerdeConfig.loadableVertexShards.add(
+          LoadableVertexShard{.pregelShard = {},
+                              .vertexShard = {},
+                              .responsibleServer = server,
+                              .collectionName = {},
+                              .edgeShards = {}});
+    }
 
     auto cState = ConductorState(std::make_unique<AlgorithmFake>(), execSpec,
                                  fakeActorPID, fakeActorPID, fakeActorPID);
@@ -104,7 +109,14 @@ TEST(CreateWorkersStateTest, creates_worker_pids_from_received_messages) {
   std::vector<std::string> servers = {"ServerA", "ServerB", "ServerC"};
 
   auto execSpec = ExecutionSpecifications();
-  execSpec.graphSerdeConfig.responsibleServerMap.responsibleServerMap = servers;
+  for (auto server : servers) {
+    execSpec.graphSerdeConfig.loadableVertexShards.add(
+        LoadableVertexShard{.pregelShard = {},
+                            .vertexShard = {},
+                            .responsibleServer = server,
+                            .collectionName = {},
+                            .edgeShards = {}});
+  }
 
   auto cState = ConductorState(std::make_unique<AlgorithmFake>(), execSpec,
                                fakeActorPID, fakeActorPID, fakeActorPID);
@@ -139,7 +151,15 @@ TEST(CreateWorkersStateTest,
 
   std::vector<std::string> servers = {"ServerA", "ServerB", "ServerC"};
   auto execSpec = ExecutionSpecifications();
-  execSpec.graphSerdeConfig.responsibleServerMap.responsibleServerMap = servers;
+  for (auto server : servers) {
+    execSpec.graphSerdeConfig.loadableVertexShards.add(
+        LoadableVertexShard{.pregelShard = {},
+                            .vertexShard = {},
+                            .responsibleServer = server,
+                            .collectionName = {},
+                            .edgeShards = {}});
+  }
+
   auto cState = ConductorState(std::make_unique<AlgorithmFake>(), execSpec,
                                fakeActorPID, fakeActorPID, fakeActorPID);
   auto createWorkers = CreateWorkers(cState);


### PR DESCRIPTION
### Scope & Purpose

Simplify the `GraphSerdeConfig` and remove a superflous datastructure to pin down the API a bit more.
