### PR TITLE
Increase chaos client timeout

### DIFF
--- a/js/client/modules/@arangodb/test-helper.js
+++ b/js/client/modules/@arangodb/test-helper.js
@@ -268,7 +268,8 @@ const buildCode = function(key, command, cn, duration) {
   let file = fs.getTempFile() + "-" + key;
   fs.write(file, `
 (function() {
-require('internal').SetGlobalExecutionDeadlineTo((${duration} + 10) * 1000);
+// For chaos tests additional 10 secs might be not enough
+require('internal').SetGlobalExecutionDeadlineTo((${duration} + 60) * 1000);
 let tries = 0;
 while (true) {
   if (++tries % 3 === 0) {


### PR DESCRIPTION
### Scope & Purpose

As we see sometimes chaos test clients run into "Execution deadline reached" error. This leads to inconsistent chaos tests results. 10s is not enough to finish executions, so this PR increases it to 60s. 

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: *(Please link PR)*
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

