### PR TITLE
reduce memory usage for incremental sync replication

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,25 @@
+v3.10.7 (XXXX-XX-XX)
+--------------------
+
+* Reduce memory usage for incremental sync replication.
+
+  The incremental sync protocol that was used for collections created with
+  3.8 or higher had memory usage issues in case the follower already had
+  some local data and its dataset was much larger than the leader's. For
+  example, this can happen if a follower gets disconnected, then a lot of
+  document removals happen on the leader and afterwards the follower tries
+  to get back into sync.
+
+  In this case, the follower buffered the ids of documents it had to
+  remove locally in a vector, which could grow arbitrarily large. The
+  removal of the documents contained in this vector would only happen at
+  the end, potentially even without performing intermediate commits.
+
+  The change in this PR is to trigger the document removal earlier, once
+  the vector has reached some size threshold, and also to use intermediate
+  commits during the removals.
+
+
 v3.10.6 (XXXX-XX-XX)
 --------------------
 

--- a/arangod/Cluster/SynchronizeShard.cpp
+++ b/arangod/Cluster/SynchronizeShard.cpp
@@ -590,7 +590,8 @@ static arangodb::ResultT<SyncerId> replicationSynchronize(
     SynchronizeShard& job,
     std::chrono::time_point<std::chrono::steady_clock> endTime,
     std::shared_ptr<arangodb::LogicalCollection> const& col, VPackSlice config,
-    std::shared_ptr<DatabaseTailingSyncer> tailingSyncer, VPackBuilder& sy) {
+    std::shared_ptr<DatabaseTailingSyncer> tailingSyncer, VPackBuilder& sy,
+    bool syncByRevision) {
   auto& vocbase = col->vocbase();
   auto database = vocbase.name();
 
@@ -673,7 +674,10 @@ static arangodb::ResultT<SyncerId> replicationSynchronize(
   SyncerId syncerId{syncer->syncerId()};
 
   try {
-    std::string const context = "syncing shard " + database + "/" + col->name();
+    std::string context = "syncing shard " + database + "/" + col->name();
+    if (syncByRevision) {
+      context += " using sync-by-revision";
+    }
     Result r = syncer->run(configuration._incremental, context.c_str());
 
     if (r.fail()) {
@@ -1147,9 +1151,9 @@ bool SynchronizeShard::first() {
       startTime = std::chrono::system_clock::now();
 
       VPackBuilder builder;
-      ResultT<SyncerId> syncRes =
-          replicationSynchronize(*this, _endTimeForAttempt, collection,
-                                 config.slice(), tailingSyncer, builder);
+      ResultT<SyncerId> syncRes = replicationSynchronize(
+          *this, _endTimeForAttempt, collection, config.slice(), tailingSyncer,
+          builder, syncByRevision);
 
       auto const endTime = std::chrono::system_clock::now();
 

--- a/arangod/Replication/DatabaseInitialSyncer.cpp
+++ b/arangod/Replication/DatabaseInitialSyncer.cpp
@@ -53,6 +53,7 @@
 #include "StorageEngine/StorageEngine.h"
 #include "StorageEngine/TransactionState.h"
 #include "Transaction/Helpers.h"
+#include "Transaction/Hints.h"
 #include "Transaction/Methods.h"
 #include "Transaction/StandaloneContext.h"
 #include "Utils/CollectionGuard.h"
@@ -111,6 +112,8 @@ arangodb::Result removeRevisions(
   using arangodb::PhysicalCollection;
   using arangodb::Result;
 
+  arangodb::Result res;
+
   if (!toRemove.empty()) {
     PhysicalCollection* physical = collection.getPhysical();
 
@@ -127,28 +130,35 @@ arangodb::Result removeRevisions(
       auto documentId = arangodb::LocalDocumentId::create(rid);
 
       tempBuilder->clear();
-      auto r = physical->lookupDocument(trx, documentId, *tempBuilder,
-                                        /*readCache*/ true, /*fillCache*/ false,
-                                        arangodb::ReadOwnWrites::yes);
+      res = physical->lookupDocument(trx, documentId, *tempBuilder,
+                                     /*readCache*/ true, /*fillCache*/ false,
+                                     arangodb::ReadOwnWrites::yes);
 
-      if (r.ok()) {
-        r = physical->remove(trx, documentId, rid, tempBuilder->slice(),
-                             options);
+      if (res.ok()) {
+        res = physical->remove(trx, documentId, rid, tempBuilder->slice(),
+                               options);
       }
 
-      if (r.ok()) {
+      if (res.ok()) {
         ++stats.numDocsRemoved;
-      } else if (r.isNot(TRI_ERROR_ARANGO_DOCUMENT_NOT_FOUND)) {
+      } else if (res.isNot(TRI_ERROR_ARANGO_DOCUMENT_NOT_FOUND)) {
         // ignore not found, we remove conflicting docs ahead of time
         stats.waitedForRemovals += TRI_microtime() - t;
-        return r;
+        break;
       }
     }
 
+    toRemove.clear();
+
+    TRI_ASSERT(trx.state()->hasHint(
+        arangodb::transaction::Hints::Hint::INTERMEDIATE_COMMITS));
+
+    res = trx.state()->performIntermediateCommitIfRequired(collection.id());
     stats.waitedForRemovals += TRI_microtime() - t;
   }
 
-  return {};
+  TRI_ASSERT(toRemove.empty());
+  return res;
 }
 
 arangodb::Result fetchRevisions(
@@ -156,7 +166,7 @@ arangodb::Result fetchRevisions(
     arangodb::DatabaseInitialSyncer::Configuration& config,
     arangodb::Syncer::SyncerState& state,
     arangodb::LogicalCollection& collection, std::string const& leader,
-    bool encodeAsHLC, std::vector<arangodb::RevisionId> const& toFetch,
+    bool encodeAsHLC, std::vector<arangodb::RevisionId>& toFetch,
     arangodb::ReplicationMetricsFeature::InitialSyncStats& stats) {
   using arangodb::PhysicalCollection;
   using arangodb::RestReplicationHandler;
@@ -469,6 +479,9 @@ arangodb::Result fetchRevisions(
       futures.pop_front();
       shoppingLists.pop_front();
       TRI_ASSERT(futures.size() == shoppingLists.size());
+
+      TRI_ASSERT(trx.state()->hasHint(
+          arangodb::transaction::Hints::Hint::INTERMEDIATE_COMMITS));
       res = trx.state()->performIntermediateCommitIfRequired(collection.id());
       if (res.fail()) {
         return res;
@@ -476,6 +489,7 @@ arangodb::Result fetchRevisions(
     }
   }
 
+  toFetch.clear();
   return Result();
 }
 }  // namespace
@@ -1893,9 +1907,49 @@ Result DatabaseInitialSyncer::fetchCollectionSyncByRevisions(
         *static_cast<RevisionReplicationIterator*>(iter.get());
 
     uint64_t const documentsFound = treeLocal->count();
+    auto& nf = coll->vocbase().server().getFeature<arangodb::NetworkFeature>();
 
     std::vector<RevisionId> toFetch;
     std::vector<RevisionId> toRemove;
+
+    auto handleFetch = [this, &toFetch, &nf, &trx, &coll, &leaderColl,
+                        &encodeAsHLC, &stats](RevisionId const& id) -> Result {
+      if (toFetch.empty()) {
+        toFetch.reserve(4096);
+      }
+      toFetch.emplace_back(id);
+
+      Result res;
+      // check if we need to do something to prevent toFetch from growing too
+      // much in memory. note: we are not using the intermediateCommitCount
+      // limit here, because fetchRevisions splits the revisions to fetch in
+      // chunks of 5000 and fetches them all in parallel. using a too low limit
+      // here would counteract that.
+      if (toFetch.size() >= 250000) {
+        res = ::fetchRevisions(nf, *trx, _config, _state, *coll, leaderColl,
+                               encodeAsHLC, toFetch, stats);
+        toFetch.clear();
+      }
+      return res;
+    };
+
+    auto handleRemoval = [&toRemove, &options, &coll, &trx,
+                          &stats](RevisionId const& id) -> Result {
+      // make sure we don't realloc uselessly for the initial inserts
+      if (toRemove.empty()) {
+        toRemove.reserve(4096);
+      }
+      toRemove.emplace_back(id);
+
+      Result res;
+      // check if we need to do something to prevent toRemove from growing too
+      // much in memory
+      if (toRemove.size() >= options.intermediateCommitCount) {
+        res = ::removeRevisions(*trx, *coll, toRemove, stats);
+        toRemove.clear();
+      }
+      return res;
+    };
 
     std::string const requestPayload = requestBuilder.slice().toJson();
     std::string const url = baseUrl + "/" + RestReplicationHandler::Ranges +
@@ -1919,7 +1973,6 @@ Result DatabaseInitialSyncer::fetchCollectionSyncByRevisions(
     // Builder will be recycled
     VPackBuilder responseBuilder;
 
-    auto& nf = coll->vocbase().server().getFeature<arangodb::NetworkFeature>();
     while (requestResume < RevisionId::max()) {
       std::unique_ptr<httpclient::SimpleHttpResult> chunkResponse;
 
@@ -2058,7 +2111,11 @@ Result DatabaseInitialSyncer::fetchCollectionSyncByRevisions(
         TRI_ASSERT(mixedBound <= RevisionId{currentRange.second});
 
         while (local.hasMore() && local.revision() < removalBound) {
-          toRemove.emplace_back(local.revision());
+          res = handleRemoval(local.revision());
+          if (res.fail()) {
+            return res;
+          }
+
           iterResume = std::max(iterResume, local.revision().next());
           local.next();
         }
@@ -2073,11 +2130,18 @@ Result DatabaseInitialSyncer::fetchCollectionSyncByRevisions(
           }
 
           if (local.revision() < leaderRev) {
-            toRemove.emplace_back(local.revision());
+            res = handleRemoval(local.revision());
+            if (res.fail()) {
+              return res;
+            }
+
             iterResume = std::max(iterResume, local.revision().next());
             local.next();
           } else if (leaderRev < local.revision()) {
-            toFetch.emplace_back(leaderRev);
+            res = handleFetch(leaderRev);
+            if (res.fail()) {
+              return res;
+            }
             ++index;
             iterResume = std::max(iterResume, leaderRev.next());
           } else {
@@ -2096,14 +2160,21 @@ Result DatabaseInitialSyncer::fetchCollectionSyncByRevisions(
             leaderRev = RevisionId::fromSlice(leaderSlice.at(index));
           }
           // fetch any leftovers
-          toFetch.emplace_back(leaderRev);
+          res = handleFetch(leaderRev);
+          if (res.fail()) {
+            return res;
+          }
           iterResume = std::max(iterResume, leaderRev.next());
         }
 
         while (local.hasMore() &&
                local.revision() <= std::min(requestResume.previous(),
                                             RevisionId{currentRange.second})) {
-          toRemove.emplace_back(local.revision());
+          res = handleRemoval(local.revision());
+          if (res.fail()) {
+            return res;
+          }
+
           iterResume = std::max(iterResume, local.revision().next());
           local.next();
         }
@@ -2117,20 +2188,14 @@ Result DatabaseInitialSyncer::fetchCollectionSyncByRevisions(
       if (res.fail()) {
         return res;
       }
-      toRemove.clear();
+      TRI_ASSERT(toRemove.empty());
 
       res = ::fetchRevisions(nf, *trx, _config, _state, *coll, leaderColl,
                              encodeAsHLC, toFetch, stats);
       if (res.fail()) {
         return res;
       }
-      toFetch.clear();
-
-      res = trx->state()->performIntermediateCommitIfRequired(coll->id());
-
-      if (res.fail()) {
-        return res;
-      }
+      TRI_ASSERT(toFetch.empty());
     }
 
     // adjust counts

--- a/tests/js/server/replication/sync/replication-sync.js
+++ b/tests/js/server/replication/sync/replication-sync.js
@@ -69,11 +69,9 @@ const compare = function (leaderFunc, followerInitFunc, followerCompareFunc, inc
   db._flushCache();
   leaderFunc(state);
 
-  db._flushCache();
   connectToFollower();
 
   followerInitFunc(state);
-  internal.wait(0.1, false);
 
   replication.syncCollection(system ? sysCn : cn, {
     endpoint: leaderEndpoint,
@@ -386,6 +384,139 @@ function BaseTestConfig () {
           assertEqual(state.indexDef.type, i.type);
         },
         true, true
+      );
+    },
+    
+    testLeaderHasMoreData : function () {
+      connectToLeader();
+
+      let st = {};
+      compare(
+        function (state) {
+          let c = db._create(cn);
+          let docs = [];
+
+          for (let i = 0; i < 5000; ++i) {
+            docs.push({ value1: i, value2: 'test' + i });
+          }
+
+          while (c.count() < 100 * 1000) {
+            c.insert(docs);
+          }
+
+          // sync the initial part to follower
+          connectToFollower();
+          replication.syncCollection(cn, {
+            endpoint: leaderEndpoint,
+            verbose: true,
+            includeSystem: true,
+            incremental: true,
+            username: "root",
+            password: "",
+          });
+
+          // remove docs from leader
+          connectToLeader();
+          while (db[cn].count() <= 240000) {
+            db._query(`FOR i IN 1..10000 INSERT { value1: i, value2: CONCAT('test', i) } IN ${cn}`);
+          }
+          st = _.clone({ count: collectionCount(cn), checksum: collectionChecksum(cn) });
+        },
+        function (state) {
+        },
+        function (state) {
+          assertEqual(st.count, collectionCount(cn));
+          assertEqual(st.checksum, collectionChecksum(cn));
+        },
+        true
+      );
+    },
+    
+    testFollowerHasMoreData : function () {
+      connectToLeader();
+
+      let st = {};
+      compare(
+        function (state) {
+          let c = db._create(cn);
+          let docs = [];
+
+          for (let i = 0; i < 5000; ++i) {
+            docs.push({ value1: i, value2: 'test' + i });
+          }
+
+          while (c.count() < 500 * 1000) {
+            c.insert(docs);
+          }
+
+          // sync the initial part to follower
+          connectToFollower();
+          replication.syncCollection(cn, {
+            endpoint: leaderEndpoint,
+            verbose: true,
+            includeSystem: true,
+            incremental: true,
+            username: "root",
+            password: "",
+          });
+
+          // remove docs from leader
+          connectToLeader();
+          while (db[cn].count() > 50000) {
+            db._query(`FOR doc IN ${cn} LIMIT 20000 REMOVE doc IN ${cn}`);
+          }
+          st = _.clone({ count: collectionCount(cn), checksum: collectionChecksum(cn) });
+        },
+        function (state) {
+        },
+        function (state) {
+          assertEqual(st.count, collectionCount(cn));
+          assertEqual(st.checksum, collectionChecksum(cn));
+        },
+        true
+      );
+    },
+    
+    testLeaderHasDifferentData : function () {
+      connectToLeader();
+
+      let st = {};
+      compare(
+        function (state) {
+          let c = db._create(cn);
+      
+          // create empty collection on follower already
+          connectToFollower();
+          replication.syncCollection(cn, {
+            endpoint: leaderEndpoint,
+            verbose: true,
+            incremental: true,
+            username: "root",
+            password: "",
+          });
+
+          connectToLeader();
+          let docs = [];
+
+          for (let i = 0; i < 5000; ++i) {
+            docs.push({ value1: i, value2: 'test' + i });
+          }
+
+          while (c.count() < 200 * 1000) {
+            c.insert(docs);
+          }
+          st = _.clone({ count: collectionCount(cn), checksum: collectionChecksum(cn) });
+        },
+        function (state) {
+          while (db[cn].count() <= 150000) {
+            db._query(`FOR i IN 1..10000 INSERT { value1: i, value2: CONCAT('test', i) } IN ${cn}`);
+          }
+        },
+        function (state) {
+          assertEqual(st.count, collectionCount(cn));
+          assertEqual(st.checksum, collectionChecksum(cn));
+        },
+        true
       );
     },
 
@@ -1188,9 +1319,7 @@ function BaseTestConfig () {
       db._create(cn);
       db._createView(cn + 'View', 'arangosearch', {consolidationIntervalMsec:0});
 
-      db._flushCache();
       connectToFollower();
-      internal.wait(0.1, false);
       //  sync on follower
       replication.sync({ endpoint: leaderEndpoint, username: "root", password: "" });
 
@@ -1222,7 +1351,6 @@ function BaseTestConfig () {
         view.properties({ links });
       }
 
-      db._flushCache();
       connectToFollower();
 
       replication.sync({ endpoint: leaderEndpoint, username: "root", password: "" });
@@ -1272,9 +1400,7 @@ function BaseTestConfig () {
         links: { _analyzers: { analyzers: [ analyzer.name ], includeAllFields:true } }
       });
 
-      db._flushCache();
       connectToFollower();
-      internal.wait(0.1, false);
       //  sync on follower
       replication.sync({ endpoint: leaderEndpoint, username: "root", password: "" });
 
@@ -1312,7 +1438,6 @@ function BaseTestConfig () {
       connectToLeader();
 
       //  create view & collection on leader
-      db._flushCache();
       let c = db._create(cn);
       let idx = c.ensureIndex({ type: "inverted", fields: [ { name: "value" } ], name: "inverted_idx" });
       let view = db._createView(cn + 'View', 'search-alias', {
@@ -1325,9 +1450,7 @@ function BaseTestConfig () {
       });
       assertEqual(1, view.properties().indexes.length);
 
-      db._flushCache();
       connectToFollower();
-      internal.wait(0.1, false);
       //  sync on follower
       replication.sync({ endpoint: leaderEndpoint, username: "root", password: "" });
 
@@ -1353,15 +1476,12 @@ function BaseTestConfig () {
       connectToLeader();
 
       //  create view & collection on leader
-      db._flushCache();
       let c = db._create(cn);
       let idx = c.ensureIndex({ type: "inverted", fields: [ { name: "value" } ], name: "inverted_idx" });
       let view = db._createView(cn + 'View', 'search-alias', {});
       assertEqual(0, view.properties().indexes.length);
 
-      db._flushCache();
       connectToFollower();
-      internal.wait(0.1, false);
       //  sync on follower
       replication.sync({ endpoint: leaderEndpoint, username: "root", password: "" });
 
@@ -1393,7 +1513,6 @@ function BaseTestConfig () {
         assertEqual(1, view.properties().indexes.length);
       }
 
-      db._flushCache();
       connectToFollower();
 
       replication.sync({ endpoint: leaderEndpoint, username: "root", password: "" });
@@ -2415,18 +2534,10 @@ function ReplicationIncrementalKeyConflict () {
 
   return {
 
-    // //////////////////////////////////////////////////////////////////////////////
-    // / @brief set up
-    // //////////////////////////////////////////////////////////////////////////////
-
     setUp: function () {
       connectToLeader();
       db._drop(cn);
     },
-
-    // //////////////////////////////////////////////////////////////////////////////
-    // / @brief tear down
-    // //////////////////////////////////////////////////////////////////////////////
 
     tearDown: function () {
       connectToLeader();
@@ -2488,7 +2599,6 @@ function ReplicationIncrementalKeyConflict () {
       assertEqual(3, c.document('z').value);
 
       connectToLeader();
-      db._flushCache();
       c = db._collection(cn);
       c.remove('z');
       c.insert({
@@ -2523,7 +2633,6 @@ function ReplicationIncrementalKeyConflict () {
 
       
       connectToLeader();
-      db._flushCache();
       c = db._collection(cn);
 
       c.remove('w');
@@ -2583,7 +2692,6 @@ function ReplicationIncrementalKeyConflict () {
       });
 
       connectToLeader();
-      db._flushCache();
       c = db._collection(cn);
      
       function shuffle(array) {
@@ -2643,7 +2751,6 @@ function ReplicationIncrementalKeyConflict () {
       }
 
       connectToLeader();
-      db._flushCache();
       c = db._collection(cn);
       
       for (let i = 0; i < 1000; ++i) {
@@ -2704,7 +2811,6 @@ function ReplicationIncrementalKeyConflict () {
       assertTrue(c.getIndexes()[1].unique);
 
       connectToLeader();
-      db._flushCache();
       c = db._collection(cn);
 
       c.remove('test0');
@@ -2825,7 +2931,6 @@ function ReplicationNonIncrementalKeyConflict () {
       assertTrue(c.getIndexes()[1].unique);
 
       connectToLeader();
-      db._flushCache();
       c = db._collection(cn);
       c.remove('z');
       c.insert({
@@ -2892,7 +2997,6 @@ function ReplicationNonIncrementalKeyConflict () {
       assertTrue(c.getIndexes()[1].unique);
 
       connectToLeader();
-      db._flushCache();
       c = db._collection(cn);
 
       c.remove('test0');


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/18833

the incremental sync protocol that was used for collections created with 3.8 or higher had memory usage issues in case the follower already had some local data and its dataset was much larger than the leader's. For example, this can happen if a follower gets disconnected, then a lot of document removals happen on the leader and afterwards the follower tries to get back into sync.

in this case, the follower buffered the ids of documents it had to remove locally in a vector, which could grow arbitrarily large. the removal of the documents contained in this vector would only happen at the end, potentially even without performing intermediate commits.

the change in this PR is to trigger the document removal earlier, once the vector has reached some size threshold, and also to use intermediate commits during the removals.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [x] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.10: this PR
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 