### PR TITLE
Fix broken test (abort long running)

### DIFF
--- a/tests/js/client/shell/abort-long-running-operations-noncluster.js
+++ b/tests/js/client/shell/abort-long-running-operations-noncluster.js
@@ -54,7 +54,7 @@ let setupCollection = (type) => {
   
 let shutdownTask = (task) => {
   db._useDatabase("_system");   // We need to switch to the _system database
-                                // such that we are not tripped off by an
+                                // such that we are not tripped off by a
                                 // "database not found" exception. This is
                                 // only necessary for the drop database test.
   try {

--- a/tests/js/client/shell/abort-long-running-operations-noncluster.js
+++ b/tests/js/client/shell/abort-long-running-operations-noncluster.js
@@ -53,6 +53,10 @@ let setupCollection = (type) => {
 };
   
 let shutdownTask = (task) => {
+  db._useDatabase("_system");   // We need to switch to the _system database
+                                // such that we are not tripped off by an
+                                // "database not found" exception. This is
+                                // only necessary for the drop database test.
   try {
     if (task === undefined) {
       tasks.unregister(taskName);


### PR DESCRIPTION
### Scope & Purpose

This fixes the tests in
  tests/js/client/shell/abort-long-running-operations-noncluster.js

There, one of the tests is that if the working database is dropped, some
long running operations stop. The test is implemented using background
tasks on the server.

The test was unstable since the dropping of the database could have
prevented the `shutdownTask` procedure from working, since it could
run into a `database not found` error. Therefore it was not properly
waiting for the task to complete.

A single additional `db._useDatabase("_system");` should fix the
problem.

- [*] :hankey: Bugfix

### Checklist

- [*] Tests
  - [*] **integration tests**
- [*] Backports
  - [*] Backport for 3.11: https://github.com/arangodb/arangodb/pull/18840
