### PR TITLE
[CINFRA] Fix Snapshot API

### DIFF
--- a/arangod/RestHandler/RestDocumentStateHandler.cpp
+++ b/arangod/RestHandler/RestDocumentStateHandler.cpp
@@ -115,7 +115,7 @@ RestStatus RestDocumentStateHandler::handleGetRequest(
 
   auto const& verb = suffixes[1];
   if (verb == "snapshot") {
-    if (suffixes.size() != 3) {
+    if (suffixes.size() < 3) {
       generateError(
           rest::ResponseCode::BAD, TRI_ERROR_HTTP_BAD_PARAMETER,
           "expect GET /_api/document-state/<state-id>/snapshot/<action>");

--- a/tests/js/server/replication2/replication2-replicated-state-document-store.js
+++ b/tests/js/server/replication2/replication2-replicated-state-document-store.js
@@ -766,7 +766,7 @@ const replicatedStateSnapshotTransferSuite = function () {
       result = dh.startSnapshot(leaderUrl, database, logId, follower, rebootId - 1);
       if (result.json.error) {
         // This is OK. The snapshot has been removed before we could return the response.
-        assertEqual(result.json.error.errorNum, internal.errors.ERROR_INTERNAL.code);
+        assertEqual(result.json.errorNum, internal.errors.ERROR_INTERNAL.code, JSON.stringify(result.json));
       } else {
         // We need a waitFor here, because the snapshot cleanup is enqueued on the scheduler.
         snapshotId = result.json.result.snapshotId;


### PR DESCRIPTION
### Scope & Purpose

This PR adds two fixes:

1. The correct way to get the `errorNum` out of a request result is `result.json.errorNum`.
2. The `RestDocumentStateHandler` can accept either 3 or 4 suffixes when querying the status of one or more snapshots.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

