### PR TITLE
fix some spurious test errors

### DIFF
--- a/arangod/Cluster/SynchronizeShard.cpp
+++ b/arangod/Cluster/SynchronizeShard.cpp
@@ -1029,7 +1029,7 @@ bool SynchronizeShard::first() {
       std::stringstream error;
       error << "failed to get a count on leader " << database << "/" << shard
             << ": " << res.errorMessage();
-      LOG_TOPIC("1254a", ERR, Logger::MAINTENANCE)
+      LOG_TOPIC("1254a", WARN, Logger::MAINTENANCE)
           << "SynchronizeShard " << error.str();
       result(res.errorNumber(), error.str());
       return false;

--- a/arangod/RestHandler/RestReplicationHandler.cpp
+++ b/arangod/RestHandler/RestReplicationHandler.cpp
@@ -2487,10 +2487,8 @@ void RestReplicationHandler::handleCommandAddFollower() {
   }
 
   auto col = _vocbase.lookupCollection(shardSlice.stringView());
-  if (col == nullptr) {
-    generateError(rest::ResponseCode::SERVER_ERROR,
-                  TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND,
-                  "did not find collection");
+  if (col == nullptr || col->deleted()) {
+    generateError(Result(TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND));
     return;
   }
 
@@ -2865,22 +2863,13 @@ void RestReplicationHandler::handleCommandHoldReadLockCollection() {
   TransactionId id = ExtractReadlockId(idSlice);
   auto col = _vocbase.lookupCollection(collection.stringView());
 
-  if (col == nullptr) {
-    generateError(rest::ResponseCode::SERVER_ERROR,
-                  TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND,
-                  "did not find collection");
+  if (col == nullptr || col->deleted()) {
+    generateError(Result(TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND));
     return;
   }
 
   // 0.0 means using the default timeout (whatever that is)
   double ttl = VelocyPackHelper::getNumericValue(ttlSlice, 0.0);
-
-  if (col->deleted()) {
-    generateError(rest::ResponseCode::SERVER_ERROR,
-                  TRI_ERROR_ARANGO_COLLECTION_NOT_LOADED,
-                  "collection not loaded");
-    return;
-  }
 
   // This is an optional parameter, it may not be set (backwards compatible)
   // If it is not set it will default to a hard-lock, otherwise we do a

--- a/tests/js/client/chaos/test-chaos-load-common.inc
+++ b/tests/js/client/chaos/test-chaos-load-common.inc
@@ -513,7 +513,7 @@ function BaseChaosSuite(testOpts) {
       print(Date() + " Finished load test; Clearing failurepoints");
       clearAllFailurePoints();
       print(Date() + " Waiting for shards to get in sync");
-      waitForShardsInSync(cn);
+      waitForShardsInSync(cn, 300, db[cn].properties().replicationFactor - 1);
       print(Date() + " checking consistency");
       checkCollectionConsistency(cn);
       let viewCounts = [];

--- a/tests/js/client/shell/shell-abort-replication-cluster.js
+++ b/tests/js/client/shell/shell-abort-replication-cluster.js
@@ -33,7 +33,7 @@ const jsunity = require('jsunity');
 const db = require("@arangodb").db;
 const request = require("@arangodb/request");
 const _ = require("lodash");
-let { waitForShardsInSync } = require('@arangodb/test-helper');
+const { waitForShardsInSync } = require('@arangodb/test-helper');
   
 const cn = "UnitTestsCollection";
 
@@ -92,7 +92,7 @@ function abortReplicationSuite () {
         });
       
         // wait for shards to get into sync - this really can take long on a slow CI
-        waitForShardsInSync(cn, 180);
+        waitForShardsInSync(cn, 180, servers.length - 1);
 
       } finally {
         servers.forEach((server) => {

--- a/tests/js/client/shell/shell-aql-query-setup-timeout.js
+++ b/tests/js/client/shell/shell-aql-query-setup-timeout.js
@@ -33,7 +33,6 @@ let { getEndpointsByType,
       debugCanUseFailAt,
       debugClearFailAt,
       debugSetFailAt,
-      waitForShardsInSync
     } = require('@arangodb/test-helper');
 const ERRORS = arangodb.errors;
       

--- a/tests/js/client/shell/shell-collection-counts-cluster.js
+++ b/tests/js/client/shell/shell-collection-counts-cluster.js
@@ -84,8 +84,6 @@ function BaseTestConfig () {
       // will call leaseManagedTrx and get the nullptr back
       c.properties({ replicationFactor: 2 });
       
-      waitForShardsInSync(cn, 60); 
-
       // wait until we have an in-sync follower
       let tries = 0;
       while (tries++ < 120) {
@@ -98,6 +96,7 @@ function BaseTestConfig () {
         } else if (tries === 20) {
           // wait several seconds so we can be sure the
           clearFailurePoints([]);
+          waitForShardsInSync(cn, 60, 1); 
         }
         require("internal").sleep(0.5);
       }
@@ -155,7 +154,7 @@ function BaseTestConfig () {
 
       c.properties({ replicationFactor: 2 });
       
-      waitForShardsInSync(cn, 60); 
+      waitForShardsInSync(cn, 60, 1); 
 
       // wait until we have an in-sync follower
       let tries = 0;
@@ -213,7 +212,7 @@ function BaseTestConfig () {
 
       c.properties({ replicationFactor: 2 });
       
-      waitForShardsInSync(cn, 60); 
+      waitForShardsInSync(cn, 60, 1); 
 
       // wait until we have an in-sync follower
       let tries = 0;
@@ -280,7 +279,7 @@ function BaseTestConfig () {
 
       c.properties({ replicationFactor: 2 });
       
-      waitForShardsInSync(cn, 60); 
+      waitForShardsInSync(cn, 60, 1); 
 
       // wait until we have an in-sync follower
       let tries = 0;
@@ -348,7 +347,7 @@ function BaseTestConfig () {
 
       c.properties({ replicationFactor: 2 });
       
-      waitForShardsInSync(cn, 60); 
+      waitForShardsInSync(cn, 60, 1); 
 
       // wait until we have an in-sync follower
       let tries = 0;
@@ -403,7 +402,7 @@ function BaseTestConfig () {
       let shard = Object.keys(shardInfo)[0];
       let leader = shardInfo[shard][0];
       let leaderUrl = servers.filter((server) => server.id === leader)[0].url;
-
+      
       // set a failure point to get the counts wrong on the leader
       let result = request({ method: "PUT", url: leaderUrl + "/_admin/debug/failat/RocksDBCommitCounts", body: {} });
       assertEqual(200, result.status);
@@ -415,10 +414,10 @@ function BaseTestConfig () {
       assertNotEqual(200, c.count());
       assertEqual(200, c.toArray().length);
       clearFailurePoints([]);
-
+      
       c.properties({ replicationFactor: 3 });
       
-      waitForShardsInSync(cn, 60); 
+      waitForShardsInSync(cn, 60, 2); 
 
       // wait until we have an in-sync follower
       let tries = 0;
@@ -433,7 +432,7 @@ function BaseTestConfig () {
       assertEqual(3, servers.length);
       assertEqual(200, c.count());
       assertEqual(200, c.toArray().length);
-
+      
       tries = 0;
       let total;
       while (tries++ < 120) {
@@ -443,7 +442,7 @@ function BaseTestConfig () {
             return;
           }
           let result = request({ method: "GET", url: server.url + "/_api/collection/" + shard + "/count" });
-          assertEqual(200, result.status);
+          assertEqual(200, result.status, { shard, server, servers, result: result.json });
           total += result.json.count;
         });
         if (total === 3 * 200) {
@@ -480,7 +479,7 @@ function BaseTestConfig () {
 
       c.properties({ replicationFactor: 3 });
 
-      waitForShardsInSync(cn, 60); 
+      waitForShardsInSync(cn, 60, 2); 
       
       // wait until we have an in-sync follower
       let tries = 0;
@@ -553,7 +552,7 @@ function BaseTestConfig () {
 
       c.properties({ replicationFactor: 3 });
       
-      waitForShardsInSync(cn, 60); 
+      waitForShardsInSync(cn, 60, 2); 
 
       // wait until we have an in-sync follower
       let tries = 0;
@@ -611,7 +610,7 @@ function BaseTestConfig () {
 
       c.properties({ replicationFactor: 2 });
       
-      waitForShardsInSync(cn, 60); 
+      waitForShardsInSync(cn, 60, 1); 
 
       // wait until we have an in-sync follower
       let tries = 0;
@@ -669,7 +668,7 @@ function BaseTestConfig () {
 
       c.properties({ replicationFactor: 2 });
       
-      waitForShardsInSync(cn, 60); 
+      waitForShardsInSync(cn, 60, 1); 
 
       // wait until we have an in-sync follower
       let tries = 0;
@@ -720,7 +719,7 @@ function BaseTestConfig () {
       }
       c.insert(docs);
       
-      waitForShardsInSync(cn, 60); 
+      waitForShardsInSync(cn, 60, 1); 
       
       // wait until we have an in-sync follower
       let tries = 0;
@@ -747,7 +746,7 @@ function BaseTestConfig () {
       
       clearFailurePoints([]);
       
-      waitForShardsInSync(cn, 60); 
+      waitForShardsInSync(cn, 60, 1); 
         
       // wait until we have an in-sync follower again
       tries = 0;
@@ -803,7 +802,7 @@ function BaseTestConfig () {
         c.insert({ _key: "test" + i }); 
       }
       
-      waitForShardsInSync(cn, 60); 
+      waitForShardsInSync(cn, 60, 1); 
       
       // wait until we have an in-sync follower
       let tries = 0;
@@ -826,7 +825,7 @@ function BaseTestConfig () {
       
       clearFailurePoints([]);
       
-      waitForShardsInSync(cn, 60); 
+      waitForShardsInSync(cn, 60, 1); 
         
       // wait until we have an in-sync follower again
       tries = 0;
@@ -884,7 +883,7 @@ function BaseTestConfig () {
         c.insert({ _key: "test" + i }); 
       }
       
-      waitForShardsInSync(cn, 60); 
+      waitForShardsInSync(cn, 60, 1); 
       
       // wait until we have an in-sync follower
       let tries = 0;
@@ -908,7 +907,7 @@ function BaseTestConfig () {
       
       clearFailurePoints([]);
       
-      waitForShardsInSync(cn, 60); 
+      waitForShardsInSync(cn, 60, 1); 
         
       // wait until we have an in-sync follower again
       tries = 0;
@@ -969,7 +968,7 @@ function BaseTestConfig () {
         c.insert({ _key: "test" + i }); 
       }
       
-      waitForShardsInSync(cn, 60); 
+      waitForShardsInSync(cn, 60, 1); 
       
       // wait until we have an in-sync follower
       let tries = 0;

--- a/tests/js/client/shell/shell-drop-followers-while-replicating-cluster.js
+++ b/tests/js/client/shell/shell-drop-followers-while-replicating-cluster.js
@@ -73,7 +73,7 @@ function dropFollowersWhileReplicatingSuite() {
       debugClearFailAt(getEndpointById(leader), "replicateOperationsDropFollower");
 
       assertEqual(1, c.count());
-      waitForShardsInSync(cn, 60);
+      waitForShardsInSync(cn, 60, 1);
     },
     
     testMultiOperationDropFollowerWhileReplicating: function() {
@@ -86,7 +86,7 @@ function dropFollowersWhileReplicatingSuite() {
       debugClearFailAt(getEndpointById(leader), "replicateOperationsDropFollower");
       
       assertEqual(4, c.count());
-      waitForShardsInSync(cn, 60);
+      waitForShardsInSync(cn, 60, 1);
     },
     
     testAqlDropFollowerWhileReplicating: function() {
@@ -99,7 +99,7 @@ function dropFollowersWhileReplicatingSuite() {
       debugClearFailAt(getEndpointById(leader), "replicateOperationsDropFollower");
       
       assertEqual(10, c.count());
-      waitForShardsInSync(cn, 60);
+      waitForShardsInSync(cn, 60, 1);
     },
     
     testSingleOperationBuildEmptyTransactionBody: function() {
@@ -112,7 +112,7 @@ function dropFollowersWhileReplicatingSuite() {
       debugClearFailAt(getEndpointById(leader), "buildTransactionBodyEmpty");
       
       assertEqual(1, c.count());
-      waitForShardsInSync(cn, 60);
+      waitForShardsInSync(cn, 60, 1);
     },
     
     testMultiOperationBuildEmptyTransactionBody: function() {
@@ -125,7 +125,7 @@ function dropFollowersWhileReplicatingSuite() {
       debugClearFailAt(getEndpointById(leader), "buildTransactionBodyEmpty");
       
       assertEqual(4, c.count());
-      waitForShardsInSync(cn, 60);
+      waitForShardsInSync(cn, 60, 1);
     },
     
     testAqlBuildEmptyTransactionBody: function() {
@@ -138,7 +138,7 @@ function dropFollowersWhileReplicatingSuite() {
       debugClearFailAt(getEndpointById(leader), "buildTransactionBodyEmpty");
       
       assertEqual(10, c.count());
-      waitForShardsInSync(cn, 60);
+      waitForShardsInSync(cn, 60, 1);
     },
   };
 }

--- a/tests/js/client/shell/shell-dropped-followers-elcheapo-commit-cluster.js
+++ b/tests/js/client/shell/shell-dropped-followers-elcheapo-commit-cluster.js
@@ -216,7 +216,7 @@ function dropFollowersElCheapoSuite() {
       // coordinator otherwise we do not see the follower information.
 
       switchConnectionToCoordinator(collInfo);
-      waitForShardsInSync(cn, 60);
+      waitForShardsInSync(cn, 60, 1);
 
       switchConnectionToLeader(collInfo);
       let count = _.sumBy(collInfo.shards, s => db._collection(s).count());
@@ -292,7 +292,7 @@ function dropFollowersElCheapoSuite() {
       // coordinator otherwise we do not see the follower information.
 
       switchConnectionToCoordinator(collInfo);
-      waitForShardsInSync(cn, 60);
+      waitForShardsInSync(cn, 60, 1);
 
       switchConnectionToLeader(collInfo);
       let count = _.sumBy(collInfo.shards, s => db._collection(s).count());

--- a/tests/js/client/shell/shell-following-term-id-cluster.js
+++ b/tests/js/client/shell/shell-following-term-id-cluster.js
@@ -156,7 +156,7 @@ function followingTermIdSuite() {
         // wait for everything to get back into sync
         switchConnectionToCoordinator(collInfo);
         assertEqual(1, db._collection(cn).count());
-        waitForShardsInSync(cn, 120); 
+        waitForShardsInSync(cn, 120, 1); 
 
         switchConnectionToFollower(collInfo);
         assertEqual(1, db._collection(collInfo.shard).count());
@@ -212,7 +212,7 @@ function followingTermIdSuite() {
         // wait for everything to get back into sync
         switchConnectionToCoordinator(collInfo);
         assertEqual(1, db._collection(cn).count());
-        waitForShardsInSync(cn, 120); 
+        waitForShardsInSync(cn, 120, 1); 
 
         switchConnectionToFollower(collInfo);
         assertEqual(1, db._collection(collInfo.shard).count());


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/18850

test-only bugfix

waitForShardsInSync(...) should be called with the expected number of shards that should be in sync. otherwise it may return too early in situations in which the followers are currently being created.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: -
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 