### PR TITLE
change error message for document not found error

### DIFF
--- a/lib/Basics/RocksDBUtils.cpp
+++ b/lib/Basics/RocksDBUtils.cpp
@@ -94,15 +94,15 @@ arangodb::Result convertStatus(rocksdb::Status const& status, StatusHint hint) {
     case rocksdb::Status::Code::kNotFound:
       switch (hint) {
         case StatusHint::collection:
-          return {TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND, status.ToString()};
+          return {TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND};
         case StatusHint::database:
-          return {TRI_ERROR_ARANGO_DATABASE_NOT_FOUND, status.ToString()};
+          return {TRI_ERROR_ARANGO_DATABASE_NOT_FOUND};
         case StatusHint::document:
-          return {TRI_ERROR_ARANGO_DOCUMENT_NOT_FOUND, status.ToString()};
+          return {TRI_ERROR_ARANGO_DOCUMENT_NOT_FOUND};
         case StatusHint::index:
-          return {TRI_ERROR_ARANGO_INDEX_NOT_FOUND, status.ToString()};
+          return {TRI_ERROR_ARANGO_INDEX_NOT_FOUND};
         case StatusHint::view:
-          return {TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND, status.ToString()};
+          return {TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND};
         case StatusHint::wal:
           // suppress this error if the WAL is queried for changes that are not
           // available

--- a/tests/js/common/shell/shell-error-messages.js
+++ b/tests/js/common/shell/shell-error-messages.js
@@ -1,0 +1,112 @@
+/*jshint globalstrict:false, strict:false, maxlen: 5000 */
+/*global fail, assertEqual, assertMatch */
+
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2010-2012 triagens GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is triAGENS GmbH, Cologne, Germany
+///
+/// @author Jan Steemann
+/// @author Copyright 2012, triAGENS GmbH, Cologne, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+const jsunity = require("jsunity");
+const arangodb = require("@arangodb");
+const ERRORS = arangodb.errors;
+const db = arangodb.db;
+
+function ErrorMessagesSuite () {
+  'use strict';
+
+  const cn = "UnitTestsCollection";
+
+  return {
+    setUp : function () {
+      db._drop(cn);
+      db._create(cn);
+    },
+
+    tearDown : function () {
+      db._drop(cn);
+    },
+    
+    testSimpleUpdateNotFound : function () {
+      try {
+        db[cn].update("testi", {});
+        fail();
+      } catch (err) {
+        assertEqual(ERRORS.ERROR_ARANGO_DOCUMENT_NOT_FOUND.code, err.errorNum);
+        assertMatch(/document not found/, err.errorMessage);
+      }
+    },
+    
+    testSimpleReplaceNotFound : function () {
+      try {
+        db[cn].replace("testi", {});
+        fail();
+      } catch (err) {
+        assertEqual(ERRORS.ERROR_ARANGO_DOCUMENT_NOT_FOUND.code, err.errorNum);
+        assertMatch(/document not found/, err.errorMessage);
+      }
+    },
+
+    testSimpleRemoveNotFound : function () {
+      try {
+        db[cn].remove("testi");
+        fail();
+      } catch (err) {
+        assertEqual(ERRORS.ERROR_ARANGO_DOCUMENT_NOT_FOUND.code, err.errorNum);
+        assertMatch(/document not found/, err.errorMessage);
+      }
+    },
+    
+    testAqlUpdateNotFound : function () {
+      try {
+        db._query("FOR i IN 1..5 UPDATE CONCAT('test', i) WITH {} IN " + cn);
+        fail();
+      } catch (err) {
+        assertEqual(ERRORS.ERROR_ARANGO_DOCUMENT_NOT_FOUND.code, err.errorNum);
+        assertMatch(/document not found/, err.errorMessage);
+      }
+    },
+    
+    testAqlReplaceNotFound : function () {
+      try {
+        db._query("FOR i IN 1..5 REPLACE CONCAT('test', i) WITH {} IN " + cn);
+        fail();
+      } catch (err) {
+        assertEqual(ERRORS.ERROR_ARANGO_DOCUMENT_NOT_FOUND.code, err.errorNum);
+        assertMatch(/document not found/, err.errorMessage);
+      }
+    },
+
+    testAqlRemoveNotFound : function () {
+      try {
+        db._query("FOR i IN 1..5 REMOVE CONCAT('test', i) IN " + cn);
+        fail();
+      } catch (err) {
+        assertEqual(ERRORS.ERROR_ARANGO_DOCUMENT_NOT_FOUND.code, err.errorNum);
+        assertMatch(/document not found/, err.errorMessage);
+      }
+    },
+    
+  };
+}
+
+jsunity.run(ErrorMessagesSuite);
+
+return jsunity.done();


### PR DESCRIPTION
### Scope & Purpose

change error message for document not found error

3.10 threw a "document not found" error with a nice error message. 3.11/devel unintentionally changed this error message to just "NotFound:", because it is the underlying error message from RocksDB.

this PR changes the error message back to how it should be.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: https://github.com/arangodb/arangodb/pull/18860
  - [ ] Backport for 3.10: -
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 