### PR TITLE
Disable version check in scripts/startLocalCluster

### DIFF
--- a/scripts/startLocalCluster.sh
+++ b/scripts/startLocalCluster.sh
@@ -174,6 +174,12 @@ EOM
           --database.auto-upgrade true \
           2>&1 | tee cluster/$PORT.stdout
     fi
+    
+    # ignore version mismatch between database directory and executable.
+    # this allows us to switch executable versions easier without having
+    # to run --database.auto-upgrade first.
+    AGENCY_OPTIONS="$AGENCY_OPTIONS --database.check-version false --database.upgrade-check false"
+
     $ARANGOD $AGENCY_OPTIONS \
         2>&1 | tee cluster/$PORT.stdout &
 done
@@ -231,6 +237,8 @@ start() {
       --server.descriptors-minimum 0
       --javascript.allow-admin-execute true
       --http.trusted-origin all
+      --database.check-version false
+      --database.upgrade-check false
 EOM
 
     SERVER_OPTIONS="$SERVER_OPTIONS $SYSTEM_REPLICATION_FACTOR $AUTHENTICATION $SSLKEYFILE $ENCRYPTION"
@@ -239,6 +247,12 @@ EOM
           --database.auto-upgrade true \
           2>&1 | tee cluster/$PORT.stdout
     fi
+
+    # ignore version mismatch between database directory and executable.
+    # this allows us to switch executable versions easier without having
+    # to run --database.auto-upgrade first.
+    SERVER_OPTIONS="$SERVER_OPTIONS --database.check-version false --database.upgrade-check false"
+
     $CMD $SERVER_OPTIONS \
         2>&1 | tee cluster/$PORT.stdout &
 }


### PR DESCRIPTION
### Scope & Purpose

Disable version check in scripts/startLocalCluster.sh
This allows us to switch between different executable versions easier, without having to start with `--database.auto-upgrade true` before.

This change only affects a helper script for developers.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: -
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 