### PR TITLE
BTS-486: fishbowl collection creation interferes with hot backup.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,26 @@
 devel
 -----
 
+* Remove function `getFishbowlStorage()` from bundled JavaScript module 
+  `@arangodb/foxx/manager`. This function was publicly exposed in previous
+  versions, and returned a handle to the `_fishbowl` system collection.
+  Applications should not have depended on it, because that collection was
+  only used to temporarily store the list of Foxx applications stored in
+  a central Github repository maintained by ArangoDB.
+
+* BTS-486: fishbowl collection creation interferes with hot backup.
+
+  Do not dynamically create the `_fishbowl` system collections anymore to
+  store the list of Foxx applications stored from a central Github repository 
+  maintained by ArangoDB. Instead, store the list in memory.
+  This has the advantage that the `_fishbowl` system collection does not need
+  to be created on the fly, which could have interfered with backups running
+  at the very same time. 
+  Additionally the previous `_fishbowl` collection was database-specific, so
+  one instance of the collection could be created per database in a deployment.
+  Now, the list of applications stored in memory is shared between all 
+  databases in a deployment.
+
 * Updated arangosync to v2.17.0-preview-1.
 
 * FE-243: add support for geo_s2 analyzer.

--- a/js/common/modules/@arangodb/foxx/store.js
+++ b/js/common/modules/@arangodb/foxx/store.js
@@ -47,18 +47,6 @@ function getFishbowlUrl () {
 }
 
 // //////////////////////////////////////////////////////////////////////////////
-// / @brief returns the fishbowl collection
-// /
-// / this will create the collection if it does not exist. this is better than
-// / needlessly creating the collection for each database in case it is not
-// / used in context of the database.
-// //////////////////////////////////////////////////////////////////////////////
-
-var getFishbowlStorage = function () {
-  return db._collection('_fishbowl');
-};
-
-// //////////////////////////////////////////////////////////////////////////////
 // / @brief comparator for services
 // //////////////////////////////////////////////////////////////////////////////
 
@@ -82,12 +70,10 @@ var compareServices = function (l, r) {
 // //////////////////////////////////////////////////////////////////////////////
 
 var updateFishbowlFromZip = function (filename) {
-  var i;
-  var tempPath = fs.getTempPath();
-  var toSave = [];
+  let tempPath = fs.getTempPath();
 
   fs.makeDirectoryRecursive(tempPath);
-  var root = fs.join(tempPath, 'foxx-apps-master/applications');
+  let root = fs.join(tempPath, 'foxx-apps-master/applications');
 
   // remove any previous files in the directory
   fs.listTree(root).forEach(function (file) {
@@ -104,19 +90,19 @@ var updateFishbowlFromZip = function (filename) {
     throw new Error("'applications' directory is missing in foxx-apps-master, giving up");
   }
 
-  var m = fs.listTree(root);
-  var reSub = /(.*)\.json$/;
-  var f, match, service, desc;
+  const m = fs.listTree(root);
+  const reSub = /(.*)\.json$/;
 
-  for (i = 0; i < m.length; ++i) {
-    f = m[i];
-    match = reSub.exec(f);
+  let toSave = [];
+  for (let i = 0; i < m.length; ++i) {
+    let f = m[i];
+    let match = reSub.exec(f);
     if (match === null) {
       continue;
     }
 
-    service = fs.join(root, f);
-
+    let service = fs.join(root, f);
+    let desc;
     try {
       desc = JSON.parse(fs.read(service));
     } catch (err1) {
@@ -134,43 +120,8 @@ var updateFishbowlFromZip = function (filename) {
   }
 
   if (toSave.length > 0) {
-    let fishbowl = getFishbowlStorage();
-    if (!fishbowl) {
-      // collection is not present. now create it
-      try {
-        fishbowl = db._create('_fishbowl', { isSystem: true, distributeShardsLike: '_graphs' });
-      } catch (err) {
-        try {
-          fishbowl = db._create('_fishbowl', { isSystem: true, distributeShardsLike: '_users' });
-        } catch (err) {
-          require('console').warn('Unable to create _fishbowl collection for application results: ' + String(err));
-        }
-      }
-    }
-
-    if (fishbowl) {
-      let toRemove = {};
-      fishbowl.toArray().forEach((doc) => {
-        toRemove[doc._key] = { _key: doc._key };
-      });
-      toSave.forEach((doc) => {
-        delete toRemove[doc._key];
-      });
-     
-      // first insert/replace all apps that are new or remain
-      fishbowl.insert(toSave, { overwriteMode: "replace" });
-
-      // second remove all apps that are not present anymore
-      // (very unlikely)
-      toRemove = Object.values(toRemove);
-      // execute remove and insert in 2 separate steps. this is not transactional
-      // but cheaper
-      if (toRemove.length > 0) {
-        fishbowl.remove(toRemove);
-      }
-
-      require('console').debug('Updated local Foxx repository with ' + toSave.length + ' service(s)');
-    }
+    global.FISHBOWL_SET(toSave);
+    require('console').debug('Updated local Foxx repository with ' + toSave.length + ' service(s)');
   }
 };
 
@@ -179,21 +130,28 @@ var updateFishbowlFromZip = function (filename) {
 // //////////////////////////////////////////////////////////////////////////////
 
 var searchJson = function (name) {
-  var fishbowl = getFishbowlStorage();
+  let fishbowl = global.FISHBOWL_GET();
 
-  if (!fishbowl || fishbowl.count() === 0) {
+  if (!fishbowl || fishbowl.length === 0) {
     arangodb.print("Repository is empty, please use 'update'");
-
     return [];
   }
 
   if (name === undefined || (typeof name === 'string' && name.length === 0)) {
-    return fishbowl.toArray();
+    return fishbowl;
   } else {
-    name = name.replace(/[^a-zA-Z0-9]/g, ' ');
+    name = name.replace(/[^a-zA-Z0-9]/g, ' ').toLowerCase();
 
     // get results by looking in "description" and "name" attributes
-    return db._query('FOR doc IN @@collection FILTER CONTAINS(doc.description, @name) || CONTAINS(doc.name, @name) RETURN doc', { name, '@collection': fishbowl.name() }).toArray();
+    return fishbowl.filter((entry) => {
+      if (entry.description && entry.description.toLowerCase().includes(name)) {
+        return true;
+      }
+      if (entry.name && entry.name.toLowerCase().includes(name)) {
+        return true;
+      }
+      return false;
+    });
   }
 };
 
@@ -263,12 +221,9 @@ function extractMaxVersion (matchEngine, versionDoc) {
 function availableJson (matchEngine) {
   let result = [];
 
-  let fishbowl = getFishbowlStorage();
-  if (fishbowl && fishbowl.count() > 0) {
-    let cursor = fishbowl.all();
-
-    while (cursor.hasNext()) {
-      let doc = cursor.next();
+  let fishbowl = global.FISHBOWL_GET();
+  if (fishbowl && fishbowl.length > 0) {
+    fishbowl.forEach((doc) => {
       let latestVersion = extractMaxVersion(matchEngine, doc.versions);
 
       if (latestVersion) {
@@ -292,7 +247,7 @@ function availableJson (matchEngine) {
 
         result.push(res);
       }
-    }
+    });
   }
 
   return result;
@@ -312,7 +267,7 @@ var update = function () {
   }
 
   try {
-    var result = download(url, '', {
+    let result = download(url, '', {
       method: 'get',
       followRedirects: true,
       timeout: 15
@@ -349,7 +304,7 @@ var update = function () {
 // //////////////////////////////////////////////////////////////////////////////
 
 var available = function (matchEngine) {
-  var list = availableJson(matchEngine);
+  const list = availableJson(matchEngine);
 
   arangodb.printTable(
     list.sort(compareServices),
@@ -373,16 +328,22 @@ var available = function (matchEngine) {
 // //////////////////////////////////////////////////////////////////////////////
 
 var infoJson = function (name) {
-  var fishbowl = getFishbowlStorage();
+  let fishbowl = global.FISHBOWL_GET();
 
-  if (!fishbowl || fishbowl.count() === 0) {
+  if (!fishbowl || fishbowl.length === 0) {
     arangodb.print("Repository is empty, please use 'update'");
     return;
   }
 
-  var desc = db._query(
-    'FOR u IN @@storage FILTER u.name == @name OR @name IN u.aliases RETURN DISTINCT u',
-    { '@storage': fishbowl.name(), 'name': name }).toArray();
+  let desc = fishbowl.filter((entry) => {
+    if (entry.name && entry.name.toLowerCase() == name) {
+      return true;
+    }
+    if (entry.aliases && Array.isArray(entry.aliases) && entry.aliases.includes(name)) {
+      return true;
+    }
+    return false;
+  });
 
   if (desc.length === 0) {
     arangodb.print("No service '" + name + "' available, please try 'search'");
@@ -513,7 +474,6 @@ var info = function (name) {
 exports.available = available;
 exports.availableJson = availableJson;
 exports.installationInfo = installationInfo;
-exports.getFishbowlStorage = getFishbowlStorage;
 exports.info = info;
 exports.search = search;
 exports.searchJson = searchJson;

--- a/js/server/modules/@arangodb/foxx/manager.js
+++ b/js/server/modules/@arangodb/foxx/manager.js
@@ -1158,7 +1158,6 @@ exports.listDevelopmentJson = utils.listDevelopmentJson;
 
 exports.available = store.available;
 exports.availableJson = store.availableJson;
-exports.getFishbowlStorage = store.getFishbowlStorage;
 exports.search = store.search;
 exports.searchJson = store.searchJson;
 exports.update = store.update;

--- a/lib/V8/v8-utils.cpp
+++ b/lib/V8/v8-utils.cpp
@@ -49,6 +49,7 @@
 #include <functional>
 #include <iostream>
 #include <memory>
+#include <mutex>
 #include <set>
 #include <string>
 #include <string_view>
@@ -116,6 +117,7 @@
 #include <unistd.h>
 #endif
 
+#include <velocypack/Builder.h>
 #include <velocypack/Validator.h>
 
 using namespace arangodb;
@@ -133,8 +135,8 @@ static UniformCharacter JSSaltGenerator(
     "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%^&*(){}"
     "[]:;<>,.?/|");
 
-arangodb::Result doSleep(
-    double n, arangodb::application_features::ApplicationServer& server) {
+Result doSleep(double n,
+               arangodb::application_features::ApplicationServer& server) {
   double until = TRI_microtime() + n;
 
   while (true) {
@@ -153,6 +155,17 @@ arangodb::Result doSleep(
     std::this_thread::sleep_for(std::chrono::microseconds(duration));
   }
 }
+
+// the following is a local, in-memory replacement for what used to be the
+// _fishbowl collection. instead of creating the collection _fishbowl, we
+// now will simply store the Foxx apps information in memory. there are
+// functions FISHBOWL_SET and FISHBOWL_GET to access the contents. these
+// functions are supposed to be used only internally
+
+// lock for protecting access to fishbowlData
+std::mutex fishbowlLock;
+// contents of _fishbowl
+std::shared_ptr<velocypack::Builder> fishbowlData;
 
 }  // namespace
 
@@ -5169,6 +5182,53 @@ static void JS_termsize(v8::FunctionCallbackInfo<v8::Value> const& args) {
   TRI_V8_TRY_CATCH_END
 }
 
+static void JS_FishbowlSet(v8::FunctionCallbackInfo<v8::Value> const& args) {
+  TRI_V8_TRY_CATCH_BEGIN(isolate);
+  v8::HandleScope scope(isolate);
+
+  // extract the arguments
+  if (args.Length() != 1 || !args[0]->IsArray()) {
+    TRI_V8_THROW_EXCEPTION_USAGE("FISHBOWL_SET(<value>)");
+  }
+
+  ISOLATE;
+  auto builder = std::make_shared<VPackBuilder>();
+  TRI_V8ToVPack(isolate, *builder, args[0], false);
+
+  std::lock_guard<std::mutex> guard(::fishbowlLock);
+  ::fishbowlData = std::move(builder);
+
+  TRI_V8_RETURN_UNDEFINED();
+  TRI_V8_TRY_CATCH_END
+}
+
+static void JS_FishbowlGet(v8::FunctionCallbackInfo<v8::Value> const& args) {
+  TRI_V8_TRY_CATCH_BEGIN(isolate);
+  v8::HandleScope scope(isolate);
+
+  // extract the arguments
+  if (args.Length() != 0) {
+    TRI_V8_THROW_EXCEPTION_USAGE("FISHBOWL_GET()");
+  }
+
+  std::shared_ptr<VPackBuilder> builder;
+  {
+    std::lock_guard<std::mutex> guard(::fishbowlLock);
+    builder = ::fishbowlData;
+  }
+
+  ISOLATE;
+  v8::Handle<v8::Value> result;
+  if (builder == nullptr) {
+    result = v8::Array::New(isolate);
+  } else {
+    result = TRI_VPackToV8(isolate, builder->slice());
+  }
+
+  TRI_V8_RETURN(result);
+  TRI_V8_TRY_CATCH_END
+}
+
 /// @brief convert a V8 value to VPack
 static void JS_V8ToVPack(v8::FunctionCallbackInfo<v8::Value> const& args) {
   TRI_V8_TRY_CATCH_BEGIN(isolate);
@@ -6145,6 +6205,13 @@ void TRI_InitV8Utils(v8::Isolate* isolate, v8::Handle<v8::Context> context,
       isolate, TRI_V8_ASCII_STRING(isolate, "SYS_IS_STOPPING"), JS_IsStopping);
   TRI_AddGlobalFunctionVocbase(
       isolate, TRI_V8_ASCII_STRING(isolate, "SYS_TERMINAL_SIZE"), JS_termsize);
+
+  TRI_AddGlobalFunctionVocbase(isolate,
+                               TRI_V8_ASCII_STRING(isolate, "FISHBOWL_GET"),
+                               JS_FishbowlGet, true);
+  TRI_AddGlobalFunctionVocbase(isolate,
+                               TRI_V8_ASCII_STRING(isolate, "FISHBOWL_SET"),
+                               JS_FishbowlSet, true);
 
   TRI_AddGlobalFunctionVocbase(
       isolate, TRI_V8_ASCII_STRING(isolate, "V8_TO_VPACK"), JS_V8ToVPack);


### PR DESCRIPTION
### Scope & Purpose

* BTS-486: fishbowl collection creation interferes with hot backup.

  Do not dynamically create the `_fishbowl` system collections anymore to
  store the list of Foxx applications stored from a central Github repository
  maintained by ArangoDB. Instead, store the list in memory.
  This has the advantage that the `_fishbowl` system collection does not need
  to be created on the fly, which could have interfered with backups running
  at the very same time.
  Additionally the previous `_fishbowl` collection was database-specific, so
  one instance of the collection could be created per database in a deployment.
  Now, the list of applications stored in memory is shared between all
  databases in a deployment.

  Remove function `getFishbowlStorage()` from bundled JavaScript module
  `@arangodb/foxx/manager`. This function was publicly exposed in previous
  versions, and returned a handle to the `_fishbowl` system collection.
  Applications should not have depended on it, because that collection was
  only used to temporarily store the list of Foxx applications stored in
  a central Github repository maintained by ArangoDB.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: -
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 