### PR TITLE
Fix handling of premature follower trx abortion

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,16 @@
 devel
 -----
 
+* Fix an issue that causes followers to be dropped due to premature transaction
+  abortions as a result of query failures.
+  When we have a query that results in a failure this will cause the leaders to
+  abort the transaction on the followers. However, if the followers have
+  transactions that are shared with leaders of other shards, and if one of those
+  leaders has not yet seen the error, then it will happily continue to replicate
+  to that follower. But if the follower has already aborted the transaction,
+  then it will reject the replication request. Previously this would cause the
+  follower to be dropped, but now this should be handled gracefully.
+      
 * Updated arangosync to v2.17.0-preview-1.
 
 * FE-243: add support for geo_s2 analyzer.

--- a/arangod/Transaction/Methods.cpp
+++ b/arangod/Transaction/Methods.cpp
@@ -3364,6 +3364,17 @@ Future<Result> Methods::replicateOperations(
 
         } else {
           auto r = resp.combinedResult();
+
+          // Special case if the follower has already aborted the transaction.
+          // This can happen if a query fails and causes the leaders to abort
+          // the transaction on the followers. However, if the followers have
+          // transactions that are shared with leaders of other shards and one
+          // of those leaders has not yet seen the error, then it will happily
+          // continue to replicate to that follower. But if the follower has
+          // already aborted the transaction, then it will reject the
+          // replication request. In this case we do not want to drop the
+          // follower, but simply return the error and abort our local
+          // transaction.
           if (r.is(TRI_ERROR_TRANSACTION_ABORTED) &&
               this->state()->hasHint(
                   transaction::Hints::Hint::FROM_TOPLEVEL_AQL)) {

--- a/arangod/Transaction/Methods.cpp
+++ b/arangod/Transaction/Methods.cpp
@@ -3364,6 +3364,12 @@ Future<Result> Methods::replicateOperations(
 
         } else {
           auto r = resp.combinedResult();
+          if (r.is(TRI_ERROR_TRANSACTION_ABORTED) &&
+              this->state()->hasHint(
+                  transaction::Hints::Hint::FROM_TOPLEVEL_AQL)) {
+            return r;
+          }
+
           bool followerRefused =
               (r.errorNumber() ==
                TRI_ERROR_CLUSTER_SHARD_LEADER_REFUSES_REPLICATION);

--- a/tests/js/client/shell/transaction/replication2_recovery/shell-transaction-replication2-recovery.js
+++ b/tests/js/client/shell/transaction/replication2_recovery/shell-transaction-replication2-recovery.js
@@ -179,7 +179,7 @@ function transactionReplication2Recovery() {
         fail('Insert was expected to fail due to transaction abort.');
       } catch (ex) {
         logContents = replicatedLogsHelper.dumpShardLog(shardId);
-        assertEqual(internal.errors.ERROR_TRANSACTION_NOT_FOUND.code, ex.errorNum,
+        assertEqual(internal.errors.ERROR_TRANSACTION_ABORTED.code, ex.errorNum,
           `Log ${logId} contents ${JSON.stringify(logContents)}.`);
       }
 

--- a/tests/js/client/shell/transaction/shell-transaction-dropped-followers-cluster.js
+++ b/tests/js/client/shell/transaction/shell-transaction-dropped-followers-cluster.js
@@ -239,6 +239,58 @@ function transactionDroppedFollowersSuite() {
         assertTrue(intermediateCommitsBefore[s] + 5 < intermediateCommitsAfter[s]);
       });
     },
+
+    testFollowerPrematureTrxAbort: function () {
+      db._create(cn, { numberOfShards: 20, replicationFactor: 3 });
+      const servers = [...new Set(Object.values(db._collection(cn).shards(true)).flat())];
+      const droppedFollowersBefore = getDroppedFollowers(servers);
+
+      // We have a query that results in a failure after the first 9000
+      // documents because of a bad key. This will cause the leaders to abort
+      // the transaction on the followers. However, the followers have
+      // transactions that are shared with leaders of other shards. If one of
+      // those leaders has not yet seen the error, then it will happily
+      // continue to replicate to that follower. But if the follower has
+      // already aborted the transaction, then it will reject the replication
+      // request. Previusly this would cause the follower to be dropped, but
+      // now this should be handled gracefully.
+      for (let i = 0; i < 10; ++i) {
+        try {
+          db._query(`FOR i IN 1..10000 INSERT { _key: i >= 9000 ? '' : CONCAT('test', i), value: i } INTO ${cn}`);
+          fail();
+        } catch (err) {
+          assertEqual(arangodb.ERROR_ARANGO_DOCUMENT_KEY_BAD, err.errorNum);
+        }
+        assertEqual(0, db[cn].count());
+        const droppedFollowersAfter = getDroppedFollowers(servers);
+        assertEqual(droppedFollowersBefore, droppedFollowersAfter);
+      }
+    },
+
+    testFollowerPrematureTrxAbortStreamingTransaction: function () {
+      db._create(cn, { numberOfShards: 20, replicationFactor: 3 });
+      const servers = [...new Set(Object.values(db._collection(cn).shards(true)).flat())];
+      const droppedFollowersBefore = getDroppedFollowers(servers);
+
+      // Same as the test above, but using a streaming transaction.
+      for (let i = 0; i < 10; ++i) {
+        const trx = db._createTransaction({ collections: { write: [cn] } });
+        const col = trx.collection(cn);
+        assertEqual(0, col.count());
+        col.insert({});
+        try {
+          trx.query(`FOR i IN 1..10000 INSERT { _key: i >= 9000 ? '' : CONCAT('test', i), value: i } INTO ${cn}`);
+          fail();
+        } catch (err) {
+          assertEqual(arangodb.ERROR_ARANGO_DOCUMENT_KEY_BAD, err.errorNum);
+        }
+        assertTrue(col.count() > 0);
+        trx.abort();
+        assertEqual(0, db[cn].count());
+        const droppedFollowersAfter = getDroppedFollowers(servers);
+        assertEqual(droppedFollowersBefore, droppedFollowersAfter);
+      }
+    },
   };
 }
 

--- a/tests/js/client/shell/transaction/shell-transaction-dropped-followers-cluster.js
+++ b/tests/js/client/shell/transaction/shell-transaction-dropped-followers-cluster.js
@@ -252,7 +252,7 @@ function transactionDroppedFollowersSuite() {
       // those leaders has not yet seen the error, then it will happily
       // continue to replicate to that follower. But if the follower has
       // already aborted the transaction, then it will reject the replication
-      // request. Previusly this would cause the follower to be dropped, but
+      // request. Previously this would cause the follower to be dropped, but
       // now this should be handled gracefully.
       for (let i = 0; i < 10; ++i) {
         try {

--- a/tests/js/client/shell/transaction/shell-transaction-intermediate-commit-cluster.js
+++ b/tests/js/client/shell/transaction/shell-transaction-intermediate-commit-cluster.js
@@ -100,7 +100,7 @@ function transactionIntermediateCommitsSingleSuite() {
         tc.insert({});
         fail();
       } catch (err) {
-        assertEqual(err.errorNum, errors.ERROR_TRANSACTION_NOT_FOUND.code);
+        assertEqual(err.errorNum, errors.ERROR_TRANSACTION_ABORTED.code);
       }
 
       assertEqual(0, c.count());


### PR DESCRIPTION
### Scope & Purpose

When we have a query that results in a failure this will cause the leaders to abort the transaction on the followers. However, if the followers have transactions that are shared with leaders of other shards, and if one of those leaders has not yet seen the error, then it will happily continue to replicate to that follower. But if the follower has already aborted the transaction, then it will reject the replication request. Previously this would cause the follower to be dropped, but now this should be handled gracefully.

- [x] :hankey: Bugfix

### Checklist

- [x] Tests
  - [x] **integration tests**
- [x] Backports
  - [x] Backport for 3.11: #18887
