### PR TITLE
testing: we need to know the PID in order to calculate the filename

### DIFF
--- a/js/client/modules/@arangodb/testutils/crash-utils.js
+++ b/js/client/modules/@arangodb/testutils/crash-utils.js
@@ -97,8 +97,7 @@ function analyzeCoreDump (instanceInfo, options, storeArangodPath, pid) {
   }
 
   const args = ['-c', command];
-  print(JSON.stringify(args));
-  
+  print("launching GDB in foreground: " + JSON.stringify(args));
   sleep(5);
   executeExternalAndWait('/bin/bash', args);
   GDB_OUTPUT += `--------------------------------------------------------------------------------
@@ -147,6 +146,7 @@ function generateCoreDumpGDB (instanceInfo, options, storeArangodPath, pid, gene
       storeArangodPath,
       '-p', instanceInfo.pid
     ]);
+  print("launching GDB in background: " + JSON.stringify(command));
   return {
     pid: executeExternal('gdb', command),
     file: gdbOutputFile,
@@ -180,7 +180,7 @@ function analyzeCoreDumpMac (instanceInfo, options, storeArangodPath, pid) {
   command += ' -c /cores/core.' + pid;
   command += ' > ' + lldbOutputFile + ' 2>&1';
   const args = ['-c', command];
-  print(JSON.stringify(args));
+  print("launching LLDB in foreground: " + JSON.stringify(args));
 
   sleep(5);
   executeExternalAndWait('/bin/bash', args);
@@ -230,7 +230,7 @@ function generateCoreDumpMac (instanceInfo, options, storeArangodPath, pid, gene
   command += storeArangodPath;
   command += ' > ' + lldbOutputFile + ' 2>&1';
   const args = ['-c', command];
-  print(JSON.stringify(args));
+  print("launching LLDB in background: " + JSON.stringify(command));
   return {
     pid: executeExternal('/bin/bash', args),
     file: lldbOutputFile,
@@ -386,7 +386,7 @@ function analyzeCoreDumpWindows (instanceInfo) {
   ];
 
   sleep(5);
-  print('running cdb ' + JSON.stringify(args));
+  print('running cdb in foreground: ' + JSON.stringify(args));
   process.env['_NT_DEBUG_LOG_FILE_OPEN'] = cdbOutputFile;
   executeExternalAndWait('cdb', args);
   GDB_OUTPUT += `--------------------------------------------------------------------------------
@@ -418,7 +418,7 @@ function generateCoreDumpWindows (instanceInfo) {
     dbgCmds.join('; ')
   ];
 
-  print('running cdb ' + JSON.stringify(args));
+  print('running cdb in background: ' + JSON.stringify(args));
   process.env['_NT_DEBUG_LOG_FILE_OPEN'] = cdbOutputFile;
   return {
     pid: executeExternal('cdb', args),

--- a/js/client/modules/@arangodb/testutils/instance.js
+++ b/js/client/modules/@arangodb/testutils/instance.js
@@ -891,14 +891,17 @@ class instance {
     }
   }
   killWithCoreDump (message) {
+    let pid = this.pid;
     if (this.options.enableAliveMonitor) {
       internal.removePidFromMonitor(this.pid);
     }
     this.getInstanceProcessStatus();
     this.serverCrashedLocal = true;
     if (this.pid === null) {
+      this.pid = pid;
       print(`${RED}${Date()} instance already gone? ${this.name} ${JSON.stringify(this.exitStatus)}${RESET}`);
       this.analyzeServerCrash(`instance ${this.name} during force terminate server already dead? ${JSON.stringify(this.exitStatus)}`);
+      this.pid = null;
     } else {
       print(`${RED}${Date()} attempting to generate crashdump of: ${this.name} ${JSON.stringify(this.exitStatus)}${RESET}`);
       crashUtils.generateCrashDump(pu.ARANGOD_BIN, this, this.options, message);


### PR DESCRIPTION
### Scope & Purpose

temporarily restore the PID for locating coredumps on disk

- [x] :hankey: Bugfix
- [x] Backport 3.11 https://github.com/arangodb/arangodb/pull/18889