### PR TITLE
add metric `arangodb_file_descriptors_limit`

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 devel
 -----
 
+* Add metric `arangodb_file_descriptors_limit` to expose the system limit for
+  the number of open files for the arangod process.
+
 * Fix an issue that causes followers to be dropped due to premature transaction
   abortions as a result of query failures.
   When we have a query that results in a failure this will cause the leaders to

--- a/Documentation/Metrics/arangodb_file_descriptors_limit.yaml
+++ b/Documentation/Metrics/arangodb_file_descriptors_limit.yaml
@@ -1,0 +1,19 @@
+name: arangodb_file_descriptors_limit
+introducedIn: "3.11.0"
+help: |
+  System limit for the number of open files for the arangod process.
+unit: number
+type: gauge
+category: Statistics
+complexity: medium
+exposedBy:
+  - agent
+  - coordinator
+  - dbserver
+  - single
+description: |
+  System limit for the number of open files for the arangod process.
+  It is only available on systems that support it. The limit is imposed by
+  the operating system or system configuration.
+  The value of this metric will remain constant for the entire lifetime of
+  the process.

--- a/arangod/RestServer/FileDescriptorsFeature.cpp
+++ b/arangod/RestServer/FileDescriptorsFeature.cpp
@@ -29,6 +29,8 @@
 #include "Logger/LogMacros.h"
 #include "Logger/Logger.h"
 #include "Logger/LoggerStream.h"
+#include "Metrics/GaugeBuilder.h"
+#include "Metrics/MetricsFeature.h"
 #include "ProgramOptions/Parameters.h"
 #include "ProgramOptions/ProgramOptions.h"
 #include "ProgramOptions/Section.h"
@@ -49,6 +51,10 @@ using namespace arangodb::basics;
 using namespace arangodb::options;
 
 #ifdef TRI_HAVE_GETRLIMIT
+DECLARE_GAUGE(
+    arangodb_file_descriptors_limit, uint64_t,
+    "Limit for the number of open file descriptors for the arangod process");
+
 namespace arangodb {
 
 struct FileDescriptors {
@@ -115,7 +121,9 @@ struct FileDescriptors {
 
 FileDescriptorsFeature::FileDescriptorsFeature(Server& server)
     : ArangodFeature{server, *this},
-      _descriptorsMinimum(FileDescriptors::recommendedMinimum()) {
+      _descriptorsMinimum(FileDescriptors::recommendedMinimum()),
+      _fileDescriptorsLimit(server.getFeature<metrics::MetricsFeature>().add(
+          arangodb_file_descriptors_limit{})) {
   setOptional(false);
   startsAfter<GreetingsFeaturePhase>();
   startsAfter<EnvironmentFeature>();
@@ -149,6 +157,8 @@ void FileDescriptorsFeature::prepare() {
   adjustFileDescriptors();
 
   FileDescriptors current = FileDescriptors::load();
+
+  _fileDescriptorsLimit.store(current.soft, std::memory_order_relaxed);
 
   LOG_TOPIC("a1c60", INFO, arangodb::Logger::SYSCALL)
       << "file-descriptors (nofiles) hard limit is "

--- a/arangod/RestServer/FileDescriptorsFeature.h
+++ b/arangod/RestServer/FileDescriptorsFeature.h
@@ -25,6 +25,7 @@
 
 #include "ApplicationFeatures/ApplicationFeature.h"
 #include "Basics/operating-system.h"
+#include "Metrics/Fwd.h"
 #include "RestServer/arangod.h"
 
 #ifdef TRI_HAVE_GETRLIMIT
@@ -46,6 +47,8 @@ class FileDescriptorsFeature : public ArangodFeature {
   void adjustFileDescriptors();
 
   uint64_t _descriptorsMinimum;
+
+  metrics::Gauge<uint64_t>& _fileDescriptorsLimit;
 };
 
 }  // namespace arangodb


### PR DESCRIPTION
### Scope & Purpose

Add metric `arangodb_file_descriptors_limit` to expose the system limit for the number of open files for the arangod process.
Although this metric is constant for the entire lifetime of the arangod process, it will allow us to get the `nofiles` value for the process just from the metrics, without having to inspect logfiles.
Manually tested.

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: -
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 