### PR TITLE
Update CMakePresets.json

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -106,7 +106,7 @@
     {
       "name": "enterprise",
       "inherits": "release-base",
-      "displayName": "Build ArangoDB Enterprise Edition",
+      "displayName": "Build ArangoDB Enterprise Edition (Release Build)",
       "cacheVariables": {
         "USE_ENTERPRISE": "On"
       }

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -98,7 +98,7 @@
     {
       "name": "community",
       "inherits": "release-base",
-      "displayName": "Build ArangoDB Community Edition",
+      "displayName": "Build ArangoDB Community Edition (Release Build)",
       "binaryDir": "${sourceDir}/build-presets/${presetName}",
       "cacheVariables": {
       }

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -7,17 +7,6 @@
   },
   "configurePresets": [
     {
-      "name": "community",
-      "displayName": "Build ArangoDB Community Edition",
-      "binaryDir": "${sourceDir}/build-presets/${presetName}",
-      "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Release",
-        "USE_ENTERPRISE": "Off",
-        "USE_JEMALLOC": "On",
-        "USE_IPO": "On"
-      }
-    },
-    {
       "hidden": true,
       "name": "pr-base",
       "binaryDir": "${sourceDir}/build",
@@ -29,6 +18,20 @@
         "USE_IPO": "Off",
         "USE_STRICT_OPENSSL_VERSION": "On",
         "USE_MINIMAL_DEBUGINFO": "On",
+        "STATIC_EXECUTABLES": "On"
+      }
+    },
+    {
+      "hidden": true,
+      "name": "release-base",
+      "binaryDir": "${sourceDir}/build-presets/${presetName}",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "USE_ENTERPRISE": "Off",
+        "USE_JEMALLOC": "On",
+        "USE_IPO": "On",
+        "USE_GOOGLE_TESTS": "Off",
+        "USE_FAILURE_TESTS": "Off",
         "STATIC_EXECUTABLES": "On"
       }
     },
@@ -92,14 +95,19 @@
       }
     },
     {
+      "name": "community",
+      "inherits": "release-base",
+      "displayName": "Build ArangoDB Community Edition",
+      "binaryDir": "${sourceDir}/build-presets/${presetName}",
+      "cacheVariables": {
+      }
+    },
+    {
       "name": "enterprise",
-      "inherits": "community",
+      "inherits": "release-base",
       "displayName": "Build ArangoDB Enterprise Edition",
       "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Release",
-        "USE_ENTERPRISE": "On",
-        "USE_JEMALLOC": "On",
-        "USE_IPO": "On"
+        "USE_ENTERPRISE": "On"
       }
     },
     {

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -74,7 +74,8 @@
       "name": "tsan",
       "cacheVariables": {
         "CMAKE_CXX_FLAGS": "-fsanitize=thread",
-        "CMAKE_C_FLAGS": "-fsanitize=thread"
+        "CMAKE_C_FLAGS": "-fsanitize=thread",
+        "USE_JEMALLOC": "Off"
       }
     },
     {


### PR DESCRIPTION
### Scope & Purpose

In an attempt to bring things built from `CMakePresets.json` into a useful state make the `community` and `enterprise` "Release" builds into actual release builds. 

In particular, for ArangoDB do not identify itself as a maintainer version, it has to be built with `USE_GOOGLE_TESTS=Off` *and* `USE_MAINTAINER_MODE=Off`.

TSAN does not work (anymore?) with `jemalloc`, so deactivate that for TSAN builds, too.

Also do some refactoring.