### PR TITLE
add debug output for agency segfault

### DIFF
--- a/arangod/Agency/State.cpp
+++ b/arangod/Agency/State.cpp
@@ -613,7 +613,7 @@ std::pair<index_t, index_t> State::determineLogBounds(
 
   // start must be greater than or equal to the lowest index
   // and smaller than or equal to the largest index
-  if (start < _log[0].index) {
+  if (start < _log.front().index) {
     start = _log.front().index;
   } else if (start > _log.back().index) {
     start = _log.back().index;
@@ -646,7 +646,20 @@ std::vector<log_t> State::get(index_t start, index_t end) const {
   }
 
   auto [s, e] = determineLogBounds(start, end);
+
   for (size_t i = s; i < e; ++i) {
+    // only for debugging purposes
+    TRI_ASSERT(i < _log.size()) << [this, sNow = s, eNow = e, start, end]() {
+      std::stringstream s;
+      s << "log size: " << _log.size() << ", start: " << sNow
+        << ", end: " << eNow << ", cur: " << _cur << ", orig start: " << start
+        << ", orig end: " << end << ", log entry indexes:";
+      for (auto const& it : _log) {
+        s << " " << it.index;
+      }
+      return s.str();
+    }();
+
     entries.push_back(_log[i]);
   }
 


### PR DESCRIPTION
### Scope & Purpose

Debug aid for https://arangodb.atlassian.net/browse/BTS-1395
Add debug output in case a segfault happens when fetching agency logs.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.11: https://github.com/arangodb/arangodb/pull/18902
  - [ ] Backport for 3.10: -
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [x] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/BTS-1395
- [ ] Design document: 