### PR TITLE
make dump tests better aware of sudden instance death in mid-air, so we get better results

### DIFF
--- a/js/client/modules/@arangodb/testutils/instance-manager.js
+++ b/js/client/modules/@arangodb/testutils/instance-manager.js
@@ -826,6 +826,7 @@ class instanceManager {
         print(e.stack);
       }
     }
+    return false;
   }
 
   _forceTerminate(moreReason="") {


### PR DESCRIPTION
### Scope & Purpose

the dump tests should catch errors, and use our facilities to force shutdown & debug the SUT so we have an easier life.

- [x] :hankey: Bugfix
