### PR TITLE
[CINFRA] Reduce difference between single server and cluster again

### DIFF
--- a/arangod/VocBase/Methods/Collections.cpp
+++ b/arangod/VocBase/Methods/Collections.cpp
@@ -959,8 +959,7 @@ void Collections::applySystemCollectionProperties(
   if (col.name == designatedLeaderName) {
     // The leading collection needs to define sharding
     col.replicationFactor = vocbase.replicationFactor();
-    if (!ServerState::instance()->isSingleServer() &&
-        vocbase.server().hasFeature<ClusterFeature>()) {
+    if (vocbase.server().hasFeature<ClusterFeature>()) {
       col.replicationFactor =
           (std::max)(col.replicationFactor.value(),
                      static_cast<uint64_t>(vocbase.server()

--- a/arangod/VocBase/vocbase.cpp
+++ b/arangod/VocBase/vocbase.cpp
@@ -1718,8 +1718,7 @@ void TRI_SanitizeObject(VPackSlice slice, VPackBuilder& builder) {
   config.maxReplicationFactor = cl.maxReplicationFactor();
   config.enforceReplicationFactor = true;
   config.defaultNumberOfShards = 1;
-  config.defaultReplicationFactor =
-      std::max(replicationFactor(), cl.systemReplicationFactor());
+  config.defaultReplicationFactor = replicationFactor();
 
   config.defaultWriteConcern = writeConcern();
 

--- a/arangod/VocBase/vocbase.cpp
+++ b/arangod/VocBase/vocbase.cpp
@@ -1718,13 +1718,8 @@ void TRI_SanitizeObject(VPackSlice slice, VPackBuilder& builder) {
   config.maxReplicationFactor = cl.maxReplicationFactor();
   config.enforceReplicationFactor = true;
   config.defaultNumberOfShards = 1;
-
-  if (ServerState::instance()->isSingleServer()) {
-    config.defaultReplicationFactor = replicationFactor();
-  } else {
-    config.defaultReplicationFactor =
-        std::max(replicationFactor(), cl.systemReplicationFactor());
-  }
+  config.defaultReplicationFactor =
+      std::max(replicationFactor(), cl.systemReplicationFactor());
 
   config.defaultWriteConcern = writeConcern();
 

--- a/tests/js/client/server_parameters/test-telemetrics-true-auth.js
+++ b/tests/js/client/server_parameters/test-telemetrics-true-auth.js
@@ -303,10 +303,9 @@ function telemetricsShellReconnectSmartGraphTestsuite() {
                 assertEqual(coll.idxs.length, 4);
               } else {
                 assertEqual(nDocs, 0);
-                //system collections have replication factor 2
-                if (!isCluster) {
-                  assertEqual(coll["rep_factor"], 1);
-                }
+                //system collections would have replication factor 2, our one has 1, so both are allowed
+                // We cannot distinguish which variant we analyse.
+                assertTrue(coll["rep_factor"] === 1 || coll["rep_factor"] === 2);
                 assertEqual(coll["n_primary"], 1);
                 assertEqual(coll["n_persistent"], 0);
                 assertEqual(coll["n_geo"], 0);
@@ -319,9 +318,9 @@ function telemetricsShellReconnectSmartGraphTestsuite() {
             database["colls"].forEach(coll => {
               assertEqual(coll["n_primary"], 1);
               assertEqual(coll["n_persistent"], 0);
-              if (!isCluster) {
-                assertEqual(coll["rep_factor"], 1);
-              }
+              //system collections would have replication factor 2, our one has 1, so both are allowed
+              // We cannot distinguish which variant we analyse.
+              assertTrue(coll["rep_factor"] === 1 || coll["rep_factor"] === 2);
               assertEqual(coll["n_geo"], 0);
             });
           }
@@ -435,9 +434,9 @@ function telemetricsShellReconnectGraphTestsuite() {
               } else {
                 assertEqual(nDocs, 0);
                 //system collections have replication factor 2
-                if (!isCluster) {
-                  assertEqual(coll["rep_factor"], 1);
-                }
+                //system collections would have replication factor 2, our one has 1, so both are allowed
+                // We cannot distinguish which variant we analyse.
+                assertTrue(coll["rep_factor"] === 1 || coll["rep_factor"] === 2);
                 assertEqual(coll["n_primary"], 1);
                 assertEqual(coll["n_persistent"], 0);
                 assertEqual(coll["n_geo"], 0);
@@ -451,9 +450,9 @@ function telemetricsShellReconnectGraphTestsuite() {
             database["colls"].forEach(coll => {
               assertEqual(coll["n_primary"], 1);
               assertEqual(coll["n_persistent"], 0);
-              if (!isCluster) {
-                assertEqual(coll["rep_factor"], 1);
-              }
+              //system collections would have replication factor 2, our one has 1, so both are allowed
+              // We cannot distinguish which variant we analyse.
+              assertTrue(coll["rep_factor"] === 1 || coll["rep_factor"] === 2);
               assertEqual(coll["n_geo"], 0);
             });
           }
@@ -558,9 +557,9 @@ function telemetricsApiReconnectSmartGraphTestsuite() {
               } else {
                 assertEqual(nDocs, 0);
                 //system collections would have replication factor 2
-                if (!isCluster) {
-                  assertEqual(coll["rep_factor"], 1);
-                }
+                //system collections would have replication factor 2, our one has 1, so both are allowed
+                // We cannot distinguish which variant we analyse.
+                assertTrue(coll["rep_factor"] === 1 || coll["rep_factor"] === 2);
                 assertEqual(coll["n_primary"], 1);
                 assertEqual(coll["n_persistent"], 0);
                 assertEqual(coll["n_geo"], 0);
@@ -573,9 +572,9 @@ function telemetricsApiReconnectSmartGraphTestsuite() {
             database["colls"].forEach(coll => {
               assertEqual(coll["n_primary"], 1);
               assertEqual(coll["n_persistent"], 0);
-              if (!isCluster) {
-                assertEqual(coll["rep_factor"], 1);
-              }
+              //system collections would have replication factor 2, our one has 1, so both are allowed
+              // We cannot distinguish which variant we analyse.
+              assertTrue(coll["rep_factor"] === 1 || coll["rep_factor"] === 2);
               assertEqual(coll["n_geo"], 0);
             });
           }
@@ -698,10 +697,9 @@ function telemetricsApiReconnectGraphTestsuite() {
                 assertEqual(coll.idxs.length, 4);
               } else {
                 assertEqual(nDocs, 0);
-                //system collections would have replication factor 2
-                if (!isCluster) {
-                  assertEqual(coll["rep_factor"], 1);
-                }
+                //system collections would have replication factor 2, our one has 1, so both are allowed
+                // We cannot distinguish which variant we analyse.
+                assertTrue(coll["rep_factor"] === 1 || coll["rep_factor"] === 2);
                 assertEqual(coll["n_primary"], 1);
                 assertEqual(coll["n_persistent"], 0);
                 assertEqual(coll["n_geo"], 0);
@@ -714,9 +712,7 @@ function telemetricsApiReconnectGraphTestsuite() {
             database["colls"].forEach(coll => {
               assertEqual(coll["n_primary"], 1);
               assertEqual(coll["n_persistent"], 0);
-              if (!isCluster) {
-                assertEqual(coll["rep_factor"], 1);
-              }
+              assertTrue(coll["rep_factor"] === 1 || coll["rep_factor"] === 2);
               assertEqual(coll["n_geo"], 0);
             });
           }


### PR DESCRIPTION

### Scope & Purpose

*This just removes some singleServer checks around default replication factor. We always have the ClusterFeature, so we can just use it in any case.*

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: *(Please link PR)*
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

