### PR TITLE
remove duplicate entry from CHANGELOG

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,10 +9,6 @@ v3.9.11 (XXXX-XX-XX)
   This has now been fixed so that aborted/finished queries are cleaned up in a
   timely manner.
 
-* Adjusted timeouts for cluster internal commit and abort requests to withstand
-  network delays better. This fixes some problems when the networking
-  infrastructure delays requests.
-
 * SEARCH-466 Fix leaking into individual link definition inherited properties
   from view.
 


### PR DESCRIPTION
### Scope & Purpose

Documentation-only fix.
Remove a duplicate entry from the 3.9.11 CHANGELOG.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: -
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 