### PR TITLE
[BTS-1373] fix error in test code

### DIFF
--- a/arangod/StorageEngine/TransactionState.cpp
+++ b/arangod/StorageEngine/TransactionState.cpp
@@ -138,7 +138,8 @@ Result TransactionState::addCollection(DataSourceId cid,
     defined(ARANGODB_ENABLE_FAILURE_TESTS)
   TRI_IF_FAILURE(("WaitOnLock::" + cname).c_str()) {
     auto& raceController = basics::DebugRaceController::sharedInstance();
-    if (auto data = raceController.waitForOthers(2, _id, vocbase().server()); data) {
+    if (auto data = raceController.waitForOthers(2, _id, vocbase().server());
+        data) {
       TRI_ASSERT(data->size() == 2);
       // Slice out the first char, then we have a number
       uint32_t shardNum = basics::StringUtils::uint32(&cname.back(), 1);

--- a/lib/Basics/DebugRaceController.h
+++ b/lib/Basics/DebugRaceController.h
@@ -27,6 +27,7 @@
 
 #include <any>
 #include <condition_variable>
+#include <memory>
 #include <mutex>
 #include <optional>
 #include <vector>
@@ -43,7 +44,7 @@ class DebugRaceController {
  public:
   static DebugRaceController& sharedInstance();
 
-  DebugRaceController();
+  DebugRaceController() = default;
 
   // Reset the stored state here, will free the stored data.
   void reset();
@@ -52,8 +53,13 @@ class DebugRaceController {
   // Otherwise, a concurrent thread might try to read it,
   // after the caller has freed the memory.
   auto waitForOthers(
-      size_t numberOfThreadsToWaitFor, std::any myData,
+      std::size_t numberOfThreadsToWaitFor, std::any myData,
       arangodb::application_features::ApplicationServer const& server) -> std::optional<std::vector<std::any>>;
+
+ private:
+  bool didTrigger(
+      std::unique_lock<std::mutex> const& guard,
+      std::size_t numberOfThreadsToWaitFor) const;
 
  private:
   std::mutex mutable _mutex{};

--- a/lib/Basics/DebugRaceController.h
+++ b/lib/Basics/DebugRaceController.h
@@ -28,6 +28,7 @@
 #include <any>
 #include <condition_variable>
 #include <mutex>
+#include <optional>
 #include <vector>
 
 namespace arangodb {
@@ -44,25 +45,20 @@ class DebugRaceController {
 
   DebugRaceController();
 
-  // Reset the sotread state here, will free the stored data
-  // and remove the didTrigger flag
+  // Reset the stored state here, will free the stored data.
   void reset();
 
-  // Access the data stored by waiting threads.
-  std::vector<std::any> data() const;
-
   // Caller is required to COPY the data to store here.
-  // Otherwise a concurrent thread might try to read it,
+  // Otherwise, a concurrent thread might try to read it,
   // after the caller has freed the memory.
   auto waitForOthers(
       size_t numberOfThreadsToWaitFor, std::any myData,
-      arangodb::application_features::ApplicationServer const& server) -> bool;
+      arangodb::application_features::ApplicationServer const& server) -> std::optional<std::vector<std::any>>;
 
  private:
-  bool _didTrigger{false};
   std::mutex mutable _mutex{};
-  std::vector<std::any> _data{};
   std::condition_variable _condVariable{};
+  std::vector<std::any> _data{};
 };
 }  // namespace basics
 }  // namespace arangodb

--- a/lib/Basics/DebugRaceController.h
+++ b/lib/Basics/DebugRaceController.h
@@ -54,12 +54,12 @@ class DebugRaceController {
   // after the caller has freed the memory.
   auto waitForOthers(
       std::size_t numberOfThreadsToWaitFor, std::any myData,
-      arangodb::application_features::ApplicationServer const& server) -> std::optional<std::vector<std::any>>;
+      arangodb::application_features::ApplicationServer const& server)
+      -> std::optional<std::vector<std::any>>;
 
  private:
-  bool didTrigger(
-      std::unique_lock<std::mutex> const& guard,
-      std::size_t numberOfThreadsToWaitFor) const;
+  bool didTrigger(std::unique_lock<std::mutex> const& guard,
+                  std::size_t numberOfThreadsToWaitFor) const;
 
  private:
   std::mutex mutable _mutex{};


### PR DESCRIPTION
### Scope & Purpose

Fix a possible crash in a failure test, when the race controller is reset unexpectedly early.

This strictly only affects failure test code, which is not part of production executables. It also shouldn't occur when the tests run as expected, without "external" failures.

Previous PRs this is based on:
- https://github.com/arangodb/arangodb/pull/13207
- https://github.com/arangodb/arangodb/pull/16244 
