### PR TITLE
Fix chaos test timeouts: BTS-1356

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 v3.11.0 (XXXX-XX-XX)
 --------------------
 
+* Got rid of hard timeout of 10s in sub-arangoshs of tests to make chaos
+  tests more stable.
+
 * Add metric `arangodb_file_descriptors_limit` to expose the system limit for
   the number of open files for the arangod process.
 

--- a/js/client/modules/@arangodb/test-helper.js
+++ b/js/client/modules/@arangodb/test-helper.js
@@ -245,7 +245,6 @@ const runShell = function(args, prefix) {
     'server.database': arango.getDatabaseName(),
     'server.username': arango.connectedUser(),
     'server.password': '',
-    'server.request-timeout': '10',
     'log.foreground-tty': 'false',
     'log.output': 'file://' + prefix + '.log'
   };


### PR DESCRIPTION
### Scope & Purpose

This is a backport of https://github.com/arangodb/arangodb/pull/18913

This tries to fix https://arangodb.atlassian.net/browse/BTS-1356 .

What happens is that there is currently a global timeout of 10s for all
`arangosh` subshells which are spawned by our testing framework. The
chaos tests use this for parallelism and at the same time they create
many situations in which shard followers get out of sync. The catchup
phase of a follower with its leader needs to stop writes to the shard
for some time, which can in testing situations be well more than 10s.
Therefore, we often hit timeouts in this situation.

The solution is to remove the artificial timeout of 10s for subshells
and go back to the default timeout of 1200s.

- [*] :hankey: Bugfix

### Checklist

- [*] Tests
  - [*] **integration tests**
- [*] :book: CHANGELOG entry made
- [*] Backports
  - [*] Backport for 3.11: this is it


