### PR TITLE
[CINFRA-708] Removing waitForIndex parameter

### DIFF
--- a/arangod/Replication2/ReplicatedState/ReplicatedState.tpp
+++ b/arangod/Replication2/ReplicatedState/ReplicatedState.tpp
@@ -725,9 +725,8 @@ void FollowerStateManager<S>::acquireSnapshot(ServerID leader, LogIndex index,
   MeasureTimeGuard rttGuard(*_metrics->replicatedStateAcquireSnapshotRtt);
   GaugeScopedCounter snapshotCounter(
       *_metrics->replicatedStateNumberWaitingForSnapshot);
-  auto fut = _guardedData.doUnderLock([&](auto& self) {
-    return self._followerState->acquireSnapshot(leader, index);
-  });
+  auto fut = _guardedData.doUnderLock(
+      [&](auto& self) { return self._followerState->acquireSnapshot(leader); });
   // note that we release the lock before calling "then" to avoid deadlocks
 
   // must be posted on the scheduler to avoid deadlocks with the log

--- a/arangod/Replication2/ReplicatedState/StateInterfaces.h
+++ b/arangod/Replication2/ReplicatedState/StateInterfaces.h
@@ -143,8 +143,7 @@ struct IReplicatedFollowerState : IReplicatedStateImplBase<S>,
    * @return Future with Result value. If the result contains an error,
    *    the operation is eventually retried.
    */
-  virtual auto acquireSnapshot(ParticipantId const& leader,
-                               LogIndex localCommitIndex) noexcept
+  virtual auto acquireSnapshot(ParticipantId const& leader) noexcept
       -> futures::Future<Result> = 0;
 
   /**

--- a/arangod/Replication2/StateMachines/BlackHole/BlackHoleStateMachine.cpp
+++ b/arangod/Replication2/StateMachines/BlackHole/BlackHoleStateMachine.cpp
@@ -48,9 +48,8 @@ auto BlackHoleLeaderState::resign() && noexcept
   return std::move(_core);
 }
 
-auto BlackHoleFollowerState::acquireSnapshot(ParticipantId const& destination,
-                                             LogIndex) noexcept
-    -> futures::Future<Result> {
+auto BlackHoleFollowerState::acquireSnapshot(
+    ParticipantId const& destination) noexcept -> futures::Future<Result> {
   return {TRI_ERROR_NO_ERROR};
 }
 

--- a/arangod/Replication2/StateMachines/BlackHole/BlackHoleStateMachine.h
+++ b/arangod/Replication2/StateMachines/BlackHole/BlackHoleStateMachine.h
@@ -78,7 +78,7 @@ struct BlackHoleFollowerState
       -> std::unique_ptr<BlackHoleCore> override;
 
  protected:
-  auto acquireSnapshot(ParticipantId const& destination, LogIndex) noexcept
+  auto acquireSnapshot(ParticipantId const& destination) noexcept
       -> futures::Future<Result> override;
   auto applyEntries(std::unique_ptr<EntryIterator> ptr) noexcept
       -> futures::Future<Result> override;

--- a/arangod/Replication2/StateMachines/Document/DocumentFollowerState.cpp
+++ b/arangod/Replication2/StateMachines/Document/DocumentFollowerState.cpp
@@ -82,9 +82,8 @@ auto DocumentFollowerState::getAssociatedShardList() const
   return shardIds;
 }
 
-auto DocumentFollowerState::acquireSnapshot(ParticipantId const& destination,
-                                            LogIndex waitForIndex) noexcept
-    -> futures::Future<Result> {
+auto DocumentFollowerState::acquireSnapshot(
+    ParticipantId const& destination) noexcept -> futures::Future<Result> {
   LOG_CTX("1f67d", DEBUG, loggerContext)
       << "Trying to acquire snapshot from destination " << destination;
 
@@ -117,8 +116,7 @@ auto DocumentFollowerState::acquireSnapshot(ParticipantId const& destination,
   // established. A retry will occur in that case.
   auto leader = _networkHandler->getLeaderInterface(destination);
   auto fut = leader->startSnapshot();
-  return handleSnapshotTransfer(leader, waitForIndex, snapshotVersion.get(),
-                                std::move(fut))
+  return handleSnapshotTransfer(leader, snapshotVersion.get(), std::move(fut))
       .thenValue([leader, self = shared_from_this()](
                      auto&& snapshotTransferResult) -> futures::Future<Result> {
         if (!snapshotTransferResult.snapshotId.has_value()) {
@@ -241,11 +239,11 @@ auto DocumentFollowerState::populateLocalShard(
 
 auto DocumentFollowerState::handleSnapshotTransfer(
     std::shared_ptr<IDocumentStateLeaderInterface> leader,
-    LogIndex waitForIndex, std::uint64_t snapshotVersion,
+    std::uint64_t snapshotVersion,
     futures::Future<ResultT<SnapshotConfig>>&& snapshotFuture) noexcept
     -> futures::Future<SnapshotTransferResult> {
   return std::move(snapshotFuture)
-      .then([weak = weak_from_this(), leader = std::move(leader), waitForIndex,
+      .then([weak = weak_from_this(), leader = std::move(leader),
              snapshotVersion](
                 futures::Try<ResultT<SnapshotConfig>>&& tryResult) mutable
             -> futures::Future<SnapshotTransferResult> {
@@ -331,21 +329,20 @@ auto DocumentFollowerState::handleSnapshotTransfer(
             << "Trying to get first batch of snapshot: "
             << snapshotRes->snapshotId;
         auto fut = leader->nextSnapshotBatch(snapshotRes->snapshotId);
-        return self->handleSnapshotTransfer(
-            snapshotRes->snapshotId, std::move(leader), waitForIndex,
-            snapshotVersion, std::nullopt, std::move(fut));
+        return self->handleSnapshotTransfer(snapshotRes->snapshotId,
+                                            std::move(leader), snapshotVersion,
+                                            std::nullopt, std::move(fut));
       });
 }
 
 auto DocumentFollowerState::handleSnapshotTransfer(
     SnapshotId snapshotId,
     std::shared_ptr<IDocumentStateLeaderInterface> leader,
-    LogIndex waitForIndex, std::uint64_t snapshotVersion,
-    std::optional<ShardID> currentShard,
+    std::uint64_t snapshotVersion, std::optional<ShardID> currentShard,
     futures::Future<ResultT<SnapshotBatch>>&& snapshotFuture) noexcept
     -> futures::Future<SnapshotTransferResult> {
   return std::move(snapshotFuture)
-      .then([weak = weak_from_this(), leader = std::move(leader), waitForIndex,
+      .then([weak = weak_from_this(), leader = std::move(leader),
              snapshotVersion, snapshotId,
              currentShard = std::move(currentShard)](
                 futures::Try<ResultT<SnapshotBatch>>&& tryResult) mutable
@@ -453,7 +450,7 @@ auto DocumentFollowerState::handleSnapshotTransfer(
               << snapshotRes->snapshotId;
           auto fut = leader->nextSnapshotBatch(snapshotId);
           return self->handleSnapshotTransfer(
-              snapshotId, std::move(leader), waitForIndex, snapshotVersion,
+              snapshotId, std::move(leader), snapshotVersion,
               std::move(currentShard), std::move(fut));
         }
 

--- a/arangod/Replication2/StateMachines/Document/DocumentFollowerState.h
+++ b/arangod/Replication2/StateMachines/Document/DocumentFollowerState.h
@@ -53,7 +53,7 @@ struct DocumentFollowerState
  protected:
   [[nodiscard]] auto resign() && noexcept
       -> std::unique_ptr<DocumentCore> override;
-  auto acquireSnapshot(ParticipantId const& destination, LogIndex) noexcept
+  auto acquireSnapshot(ParticipantId const& destination) noexcept
       -> futures::Future<Result> override;
   auto applyEntries(std::unique_ptr<EntryIterator> ptr) noexcept
       -> futures::Future<Result> override;
@@ -72,14 +72,13 @@ struct DocumentFollowerState
 
   auto handleSnapshotTransfer(
       std::shared_ptr<IDocumentStateLeaderInterface> leader,
-      LogIndex waitForIndex, std::uint64_t snapshotVersion,
+      std::uint64_t snapshotVersion,
       futures::Future<ResultT<SnapshotConfig>>&& snapshotFuture) noexcept
       -> futures::Future<SnapshotTransferResult>;
   auto handleSnapshotTransfer(
       SnapshotId shapshotId,
       std::shared_ptr<IDocumentStateLeaderInterface> leader,
-      LogIndex waitForIndex, std::uint64_t snapshotVersion,
-      std::optional<ShardID> currentShard,
+      std::uint64_t snapshotVersion, std::optional<ShardID> currentShard,
       futures::Future<ResultT<SnapshotBatch>>&& snapshotFuture) noexcept
       -> futures::Future<SnapshotTransferResult>;
 

--- a/tests/Replication2/Mocks/DocumentStateMocks.h
+++ b/tests/Replication2/Mocks/DocumentStateMocks.h
@@ -324,10 +324,9 @@ struct DocumentFollowerStateWrapper
     return std::move(*this).DocumentFollowerState::resign();
   }
 
-  auto acquireSnapshot(ParticipantId const& destination,
-                       LogIndex waitForIndex) noexcept
+  auto acquireSnapshot(ParticipantId const& destination) noexcept
       -> futures::Future<Result> override {
-    return DocumentFollowerState::acquireSnapshot(destination, waitForIndex);
+    return DocumentFollowerState::acquireSnapshot(destination);
   }
 
   auto applyEntries(std::unique_ptr<EntryIterator> ptr) noexcept

--- a/tests/Replication2/Mocks/FakeReplicatedState.h
+++ b/tests/Replication2/Mocks/FakeReplicatedState.h
@@ -55,7 +55,7 @@ struct EmptyFollowerType : replicated_state::IReplicatedFollowerState<S> {
       -> futures::Future<Result> override {
     return futures::Future<Result>{std::in_place};
   }
-  auto acquireSnapshot(ParticipantId const&, LogIndex) noexcept
+  auto acquireSnapshot(ParticipantId const&) noexcept
       -> futures::Future<Result> override {
     return futures::Future<Result>{std::in_place};
   }

--- a/tests/Replication2/ReplicatedState/StateMachines/DocumentState/CoreTest.cpp
+++ b/tests/Replication2/ReplicatedState/StateMachines/DocumentState/CoreTest.cpp
@@ -88,7 +88,7 @@ TEST_F(DocumentStateMachineTest,
       *transactionHandlerMock,
       applyEntry(ReplicatedOperation::buildAbortAllOngoingTrxOperation()))
       .Times(1);
-  auto res = follower->acquireSnapshot("participantId", LogIndex{1});
+  auto res = follower->acquireSnapshot("participantId");
   EXPECT_TRUE(res.isReady() && res.get().ok());
   Mock::VerifyAndClearExpectations(transactionHandlerMock.get());
 

--- a/tests/Replication2/ReplicatedState/StateMachines/DocumentState/FollowerTest.cpp
+++ b/tests/Replication2/ReplicatedState/StateMachines/DocumentState/FollowerTest.cpp
@@ -37,7 +37,7 @@ TEST_F(DocumentStateFollowerTest, follower_associated_shard_map) {
 
   auto transactionHandlerMock = createRealTransactionHandler();
   auto follower = createFollower();
-  auto res = follower->acquireSnapshot("participantId", LogIndex{1});
+  auto res = follower->acquireSnapshot("participantId");
   EXPECT_TRUE(res.isReady() && res.get().ok());
 
   ON_CALL(*shardHandlerMock, getShardMap()).WillByDefault(Return(shardMap));
@@ -67,7 +67,7 @@ TEST_F(DocumentStateFollowerTest,
       .Times(1);
 
   auto follower = createFollower();
-  auto res = follower->acquireSnapshot("participantId", LogIndex{1});
+  auto res = follower->acquireSnapshot("participantId");
   EXPECT_TRUE(res.isReady() && res.get().ok());
 
   Mock::VerifyAndClearExpectations(networkHandlerMock.get());
@@ -109,7 +109,7 @@ TEST_F(DocumentStateFollowerTest,
       });
 
   std::thread t([follower]() {
-    auto res = follower->acquireSnapshot("participantId", LogIndex{1});
+    auto res = follower->acquireSnapshot("participantId");
     EXPECT_TRUE(res.isReady());
     EXPECT_TRUE(res.get().fail());
     EXPECT_TRUE(res.get().errorNumber() ==
@@ -127,7 +127,7 @@ TEST_F(DocumentStateFollowerTest,
 
   auto transactionHandlerMock = createRealTransactionHandler();
   auto follower = createFollower();
-  auto res = follower->acquireSnapshot("participantId", LogIndex{1});
+  auto res = follower->acquireSnapshot("participantId");
   EXPECT_TRUE(res.isReady() && res.get().ok());
   auto stream = std::make_shared<MockProducerStream>();
   follower->setStream(stream);
@@ -159,7 +159,7 @@ TEST_F(DocumentStateFollowerTest,
 
   auto transactionHandlerMock = createRealTransactionHandler();
   auto follower = createFollower();
-  auto res = follower->acquireSnapshot("participantId", LogIndex{1});
+  auto res = follower->acquireSnapshot("participantId");
   EXPECT_TRUE(res.isReady() && res.get().ok());
   auto stream = std::make_shared<MockProducerStream>();
   follower->setStream(stream);
@@ -185,7 +185,7 @@ TEST_F(DocumentStateFollowerTest,
 
   auto transactionHandlerMock = createRealTransactionHandler();
   auto follower = createFollower();
-  auto res = follower->acquireSnapshot("participantId", LogIndex{1});
+  auto res = follower->acquireSnapshot("participantId");
   EXPECT_TRUE(res.isReady() && res.get().ok());
   auto stream = std::make_shared<MockProducerStream>();
   follower->setStream(stream);
@@ -212,7 +212,7 @@ TEST_F(DocumentStateFollowerTest,
 
   auto transactionHandlerMock = createRealTransactionHandler();
   auto follower = createFollower();
-  auto res = follower->acquireSnapshot("participantId", LogIndex{1});
+  auto res = follower->acquireSnapshot("participantId");
   EXPECT_TRUE(res.isReady() && res.get().ok());
   auto stream = std::make_shared<MockProducerStream>();
   follower->setStream(stream);
@@ -235,7 +235,7 @@ TEST_F(DocumentStateFollowerTest,
 
   auto transactionHandlerMock = createRealTransactionHandler();
   auto follower = createFollower();
-  auto res = follower->acquireSnapshot("participantId", LogIndex{1});
+  auto res = follower->acquireSnapshot("participantId");
   EXPECT_TRUE(res.isReady() && res.get().ok());
   auto stream = std::make_shared<MockProducerStream>();
   follower->setStream(stream);
@@ -264,7 +264,7 @@ TEST_F(DocumentStateFollowerTest,
 
   // First abort then commit
   follower = createFollower();
-  res = follower->acquireSnapshot("participantId", LogIndex{1});
+  res = follower->acquireSnapshot("participantId");
   EXPECT_TRUE(res.isReady() && res.get().ok());
   stream = std::make_shared<MockProducerStream>();
   follower->setStream(stream);
@@ -295,7 +295,7 @@ TEST_F(DocumentStateFollowerTest,
 
   auto transactionHandlerMock = createRealTransactionHandler();
   auto follower = createFollower();
-  auto res = follower->acquireSnapshot("participantId", LogIndex{1});
+  auto res = follower->acquireSnapshot("participantId");
   EXPECT_TRUE(res.isReady() && res.get().ok());
 
   auto stream = std::make_shared<MockProducerStream>();
@@ -333,7 +333,7 @@ TEST_F(DocumentStateFollowerTest,
 
   auto transactionHandlerMock = createRealTransactionHandler();
   auto follower = createFollower();
-  auto res = follower->acquireSnapshot("participantId", LogIndex{1});
+  auto res = follower->acquireSnapshot("participantId");
   EXPECT_TRUE(res.isReady() && res.get().ok());
   auto stream = std::make_shared<MockProducerStream>();
   follower->setStream(stream);
@@ -361,7 +361,7 @@ TEST_F(DocumentStateFollowerTest, follower_ignores_invalid_transactions) {
 
   auto transactionHandlerMock = createRealTransactionHandler();
   auto follower = createFollower();
-  auto res = follower->acquireSnapshot("participantId", LogIndex{1});
+  auto res = follower->acquireSnapshot("participantId");
   EXPECT_TRUE(res.isReady() && res.get().ok());
   auto stream = std::make_shared<MockProducerStream>();
   follower->setStream(stream);
@@ -413,7 +413,7 @@ TEST_F(DocumentStateFollowerTest,
 
   auto transactionHandlerMock = createRealTransactionHandler();
   auto follower = createFollower();
-  auto res = follower->acquireSnapshot("participantId", LogIndex{1});
+  auto res = follower->acquireSnapshot("participantId");
   EXPECT_TRUE(res.isReady() && res.get().ok());
   auto stream = std::make_shared<MockProducerStream>();
   follower->setStream(stream);

--- a/tests/Replication2/ReplicatedState/StateMachines/DocumentState/SnapshotTest.cpp
+++ b/tests/Replication2/ReplicatedState/StateMachines/DocumentState/SnapshotTest.cpp
@@ -93,7 +93,7 @@ TEST_F(DocumentStateSnapshotTest,
 
   // Acquire a snapshot containing a single shard
   auto follower = createFollower();
-  auto res = follower->acquireSnapshot("participantId", LogIndex{1});
+  auto res = follower->acquireSnapshot("participantId");
   EXPECT_TRUE(res.isReady() && res.get().ok());
 
   // We now acquire a second snapshot with a different set of shards
@@ -119,7 +119,7 @@ TEST_F(DocumentStateSnapshotTest,
       .Times(1);
   EXPECT_CALL(*shardHandlerMock, ensureShard(shardId2, collectionId, _))
       .Times(1);
-  follower->acquireSnapshot("participantId", LogIndex{1});
+  follower->acquireSnapshot("participantId");
   EXPECT_TRUE(res.isReady() && res.get().ok());
 
   Mock::VerifyAndClearExpectations(shardHandlerMock.get());


### PR DESCRIPTION
### Scope & Purpose

The _waitForIndex_ parameter is no longer needed. It was previously used during `acquireSnapshot`. This PR removes it.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [x] C++ **Unit tests**
  - [x] **integration tests**
  - [ ] **resilience tests**