### PR TITLE
attempt to stabilize a flaky test

### DIFF
--- a/arangod/Scheduler/SupervisedScheduler.h
+++ b/arangod/Scheduler/SupervisedScheduler.h
@@ -60,7 +60,7 @@ class SupervisedScheduler final : public Scheduler {
   void trackBeginOngoingLowPriorityTask() noexcept;
   void trackEndOngoingLowPriorityTask() noexcept;
 
-  void trackQueueTimeViolation();
+  void trackQueueTimeViolation() noexcept;
 
   /// @brief returns the last stored dequeue time [ms]
   uint64_t getLastLowPriorityDequeueTime() const noexcept override;


### PR DESCRIPTION
### Scope & Purpose

Try to make test more robust.
Previously the test sometimes produced the following error:
```
=== server_parameters_1 ===
* Test "server_parameters_1"
    [FAILED]  tests/js/client/server_parameters/test-return-queue-time-header-on.js

      "testQueueTimeHeaderNonZero" failed: Error: at assertion #754: assertTrue: (false) does not evaluate to true
(Error
    at Object.testQueueTimeHeaderNonZero (tests/js/client/server_parameters/test-return-queue-time-header-on.js:98:7)
    at tests/js/client/server_parameters/test-return-queue-time-header-on.js:170:9
    at tests/js/client/server_parameters/test-return-queue-time-header-on.js:172:3
......    at Object.server_parameters (/work/ArangoDB/js/client/modules/@arangodb/testsuites/server_permissions.js:287:62)
 - test failed
```
The changes in this PR still do not make the test fully deterministic but should increase the likelihood of the test passing.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: -
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 