### PR TITLE
improve performance of logging

### DIFF
--- a/lib/Logger/LoggerStream.cpp
+++ b/lib/Logger/LoggerStream.cpp
@@ -61,7 +61,7 @@ LoggerStreamBase& LoggerStreamBase::operator<<(
   try {
     std::ostringstream tmp;
     tmp << std::setprecision(value._precision) << std::fixed << value._value;
-    _out << tmp.str();
+    _out << tmp.view();
   } catch (...) {
     // ignore any errors here. logging should not have side effects
   }
@@ -111,12 +111,12 @@ LoggerStream::~LoggerStream() {
   try {
     // TODO: with c++20, we can get a view on the stream's underlying buffer,
     // without copying it
-    Logger::log(_logid, _function, _file, _line, _level, _topicId, _out.str());
+    Logger::log(_logid, _function, _file, _line, _level, _topicId, _out.view());
   } catch (...) {
     try {
       // logging the error may fail as well, and we should never throw in the
       // dtor
-      std::cerr << "failed to log: " << _out.str() << std::endl;
+      std::cerr << "failed to log: " << _out.view() << std::endl;
     } catch (...) {
     }
   }


### PR DESCRIPTION
### Scope & Purpose

improve performance of logging by not copying the string that is underlying the log message's stringstream via `stream.str()`.
since C++20, a view of the underlying character sequence can be retrieved by calling `stream.view()`.
last time I checked, not all our target compilers supported that feature. let's see how it is in 2023.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [x] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: -
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 