### PR TITLE
add more tests and better error handling

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,10 +5,16 @@ v3.11.0 (XXXX-XX-XX)
   collections with `edgeCollections` traversal option.
 
   If a non-existing collection is specified in the `edgeCollections` or
-  `vertexCollections` options of an AQL traversal, the query will now fail with
-  a `collection or view not found` error. This is a behavior change compared to
-  previous versions, which ignored non-existing vertex collections and had
-  undefined behavior when specifying non-existing edge collections.
+  `vertexCollections` options of an AQL traversal, the query will now fail 
+  with a `collection or view not found` error. Also, if wrong collection
+  types are used (e.g. an edge collection for `vertexCollections` or a
+  document collection for `edgeCollections`), then an error is raised about
+  an invalid collection type being used.
+
+  This is a behavior change compared to previous versions, which ignored 
+  specifying non-existing vertex collections and had undefined behavior when 
+  specifying non-existing edge collections or using a vertex collection
+  instead of an edge collection.
 
 * Added metric `rocksdb_cache_peak_allocated` to store the peak memory
   allocation value for in-memory caches.

--- a/arangod/Aql/Collection.cpp
+++ b/arangod/Aql/Collection.cpp
@@ -23,8 +23,6 @@
 
 #include "Collection.h"
 
-#include <velocypack/Iterator.h>
-
 #include "ApplicationFeatures/ApplicationServer.h"
 #include "Basics/Exceptions.h"
 #include "Basics/StaticStrings.h"
@@ -37,6 +35,9 @@
 #include "Transaction/Methods.h"
 #include "VocBase/LogicalCollection.h"
 #include "VocBase/vocbase.h"
+
+#include <absl/strings/str_cat.h>
+#include <velocypack/Iterator.h>
 
 using namespace arangodb;
 using namespace arangodb::aql;
@@ -264,10 +265,10 @@ std::shared_ptr<arangodb::Index> Collection::indexByIdentifier(
   auto idx = this->getCollection()->lookupIndex(iid);
 
   if (!idx) {
-    THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_ARANGO_INDEX_NOT_FOUND,
-                                   "Could not find index '" + idxId +
-                                       "' in collection '" + this->name() +
-                                       "'.");
+    THROW_ARANGO_EXCEPTION_MESSAGE(
+        TRI_ERROR_ARANGO_INDEX_NOT_FOUND,
+        absl::StrCat("Could not find index '", idxId, "' in collection '",
+                     this->name(), "'."));
   }
 
   return idx;
@@ -308,7 +309,7 @@ void Collection::checkCollection() const {
   if (_collection == nullptr) {
     THROW_ARANGO_EXCEPTION_MESSAGE(
         TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND,
-        std::string(TRI_errno_string(TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND)) +
-            ": " + _name);
+        absl::StrCat(TRI_errno_string(TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND),
+                     ": ", _name));
   }
 }

--- a/arangod/Aql/ExecutionPlan.cpp
+++ b/arangod/Aql/ExecutionPlan.cpp
@@ -158,12 +158,54 @@ std::pair<uint64_t, uint64_t> getMinMaxDepths(AstNode const* steps) {
   return {minDepth, maxDepth};
 }
 
-void parseGraphCollectionRestriction(Ast* ast,
+void parseGraphCollectionRestriction(Ast* ast, std::string_view typeName,
                                      std::vector<std::string>& collections,
                                      AstNode const* src) {
-  auto addCollection = [&collections, ast](std::string&& name) {
+  auto addCollection = [&collections, typeName, ast](std::string&& name) {
+    // throws if data source cannot be found
     ast->createNodeDataSource(ast->query().resolver(), name,
                               AccessMode::Type::READ, true, true);
+
+    // now get the collection and inspect its type
+    Collection const* collection = ast->query().collections().get(name);
+    TRI_ASSERT(collection != nullptr);
+    if (collection == nullptr) {
+      // should not happen
+      THROW_ARANGO_EXCEPTION_MESSAGE(
+          TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND,
+          absl::StrCat("data source for '", typeName,
+                       "' option must be a collection"));
+    }
+
+    TRI_col_type_e type = TRI_COL_TYPE_DOCUMENT;
+    try {
+      // throws when called on a view
+      type = collection->type();
+    } catch (...) {
+      THROW_ARANGO_EXCEPTION_MESSAGE(
+          TRI_ERROR_ARANGO_COLLECTION_TYPE_INVALID,
+          absl::StrCat("data source type for '", typeName,
+                       "' option must be a collection"));
+    }
+
+    if (typeName == "edgeCollections") {
+      if (type != TRI_COL_TYPE_EDGE) {
+        THROW_ARANGO_EXCEPTION_MESSAGE(
+            TRI_ERROR_ARANGO_COLLECTION_TYPE_INVALID,
+            absl::StrCat("data source type for '", typeName,
+                         "' option must be an edge collection"));
+      }
+    } else if (typeName == "vertexCollections") {
+      if (type != TRI_COL_TYPE_DOCUMENT) {
+        THROW_ARANGO_EXCEPTION_MESSAGE(
+            TRI_ERROR_ARANGO_COLLECTION_TYPE_INVALID,
+            absl::StrCat("data source type for '", typeName,
+                         "' option must be a document collection"));
+      }
+    } else {
+      TRI_ASSERT(false);
+    }
+
     collections.emplace_back(std::move(name));
   };
 
@@ -177,8 +219,9 @@ void parseGraphCollectionRestriction(Ast* ast,
       if (!c->isStringValue()) {
         THROW_ARANGO_EXCEPTION_MESSAGE(
             TRI_ERROR_BAD_PARAMETER,
-            "collection restrictions option must be either a string or an "
-            "array of collection names");
+            absl::StrCat(
+                "collection restrictions option for '", typeName,
+                "' must be either a string or an array of collection names"));
       }
       addCollection(c->getString());
     }
@@ -266,9 +309,10 @@ std::unique_ptr<graph::BaseOptions> createTraversalOptions(
                 "or 'none' instead");
           }
         } else if (name == "edgeCollections") {
-          parseGraphCollectionRestriction(ast, options->edgeCollections, value);
+          parseGraphCollectionRestriction(ast, name, options->edgeCollections,
+                                          value);
         } else if (name == "vertexCollections") {
-          parseGraphCollectionRestriction(ast, options->vertexCollections,
+          parseGraphCollectionRestriction(ast, name, options->vertexCollections,
                                           value);
         } else if (name == StaticStrings::GraphQueryOrder && !hasBFS) {
           // dfs is the default

--- a/tests/js/server/aql/aql-traversal-restrict-collections.js
+++ b/tests/js/server/aql/aql-traversal-restrict-collections.js
@@ -37,8 +37,10 @@ const vc1Name = "v1";
 const vc2Name = "v2";
 const ec1Name = "e1";
 const ec2Name = "e2";
+const viewName = "vvvv";
 
 const cleanup = function() {
+  db._dropView(viewName);
   db._drop(vc1Name);
   db._drop(vc2Name);
   db._drop(ec1Name);
@@ -78,6 +80,7 @@ function vertexCollectionRestrictionSuite() {
     setUpAll : function () {
       cleanup();
       createBaseGraph();
+      db._createView(viewName, "arangosearch", {});
     },
 
     tearDownAll : function () {
@@ -227,6 +230,40 @@ function vertexCollectionRestrictionSuite() {
       assertEqual(actual, expected);
     },
     
+    testRestrictOnlySomeVertexCollections: function () {
+      {
+        // specify only vc1
+        const query = `WITH @@vc1, @@vc2
+                       FOR v IN 3..3 OUTBOUND "${vc1Name}/node_5" @@ec1
+                         OPTIONS {vertexCollections: ["${vc1Name}"]}
+                         SORT v._id
+                         RETURN DISTINCT v._id`;
+
+        const actual = db._query(query, {'@vc1': vc1Name, '@vc2': vc2Name, '@ec1': ec1Name }).toArray();
+        const expected = [
+          vc1Name + "/node_8",
+        ];
+
+        assertEqual(actual, expected);
+      }
+      
+      {
+        // specify only vc2
+        const query = `WITH @@vc1, @@vc2
+                       FOR v IN 3..3 OUTBOUND "${vc1Name}/node_5" @@ec1
+                         OPTIONS {vertexCollections: ["${vc2Name}"]}
+                         SORT v._id
+                         RETURN DISTINCT v._id`;
+
+        const actual = db._query(query, {'@vc1': vc1Name, '@vc2': vc2Name, '@ec1': ec1Name }).toArray();
+        const expected = [
+          vc2Name + "/node_3",
+        ];
+
+        assertEqual(actual, expected);
+      }
+    },
+    
     testRestrictEmptyVertexCollections: function () {
       const query = `WITH @@vc1, @@vc2
                      FOR v IN 3..3 OUTBOUND "${vc1Name}/node_5" @@ec1
@@ -250,6 +287,7 @@ function vertexCollectionRestrictionSuite() {
     testRestrictInvalidVertexCollections: function () {
       const query = `WITH @@vc1, @@vc2
                      FOR v IN 3..3 OUTBOUND "${vc1Name}/node_5" @@ec1
+                       // specify non-existing vertex collections
                        OPTIONS {vertexCollections: ["piff", "paff"]}
                        SORT v._id
                        RETURN DISTINCT v._id`;
@@ -259,6 +297,74 @@ function vertexCollectionRestrictionSuite() {
         fail();
       } catch (err) {
         assertEqual(errors.ERROR_ARANGO_DATA_SOURCE_NOT_FOUND.code, err.errorNum);
+      }
+    },
+    
+    testRestrictInvalidVertexCollectionType: function () {
+      const query = `WITH @@vc1, @@vc2
+                     FOR v IN 3..3 OUTBOUND "${vc1Name}/node_5" @@ec1
+                       // specify an edge collection instead of a vertex collection
+                       OPTIONS {vertexCollections: ["${ec1Name}"]}
+                       SORT v._id
+                       RETURN DISTINCT v._id`;
+
+      try {
+        db._query(query, {'@vc1': vc1Name, '@vc2': vc2Name, '@ec1': ec1Name }).toArray();
+        fail();
+      } catch (err) {
+        assertEqual(errors.ERROR_ARANGO_COLLECTION_TYPE_INVALID.code, err.errorNum);
+      }
+    },
+    
+    testRestrictViewAsVertexCollection: function () {
+      const query = `WITH @@vc1, @@vc2
+                     FOR v IN 3..3 OUTBOUND "${vc1Name}/node_5" @@ec1
+                       // specify a view collection instead of a vertex collection
+                       OPTIONS {vertexCollections: ["${viewName}"]}
+                       SORT v._id
+                       RETURN DISTINCT v._id`;
+
+      try {
+        db._query(query, {'@vc1': vc1Name, '@vc2': vc2Name, '@ec1': ec1Name }).toArray();
+        fail();
+      } catch (err) {
+        assertEqual(errors.ERROR_ARANGO_COLLECTION_TYPE_INVALID.code, err.errorNum);
+      }
+    },
+    
+    testRestrictOnlySomeEdgeCollections: function () {
+      {
+        // specify only ec1
+        const query = `WITH @@vc1, @@vc2
+                       FOR v IN 3..3 OUTBOUND "${vc1Name}/node_5" @@ec1, @@ec2
+                         OPTIONS {edgeCollections: ["${ec1Name}"]}
+                         SORT v._id
+                         RETURN DISTINCT v._id`;
+
+        const actual = db._query(query, {'@vc1': vc1Name, '@vc2': vc2Name, '@ec1': ec1Name, '@ec2': ec2Name }).toArray();
+        const expected = [
+          vc1Name + "/node_4",
+          vc1Name + "/node_6",
+          vc1Name + "/node_8",
+          vc2Name + "/node_3",
+          vc2Name + "/node_5",
+          vc2Name + "/node_7",
+        ];
+
+        assertEqual(actual, expected);
+      }
+      
+      {
+        // specify only ec2
+        const query = `WITH @@vc1, @@vc2
+                       FOR v IN 3..3 OUTBOUND "${vc1Name}/node_5" @@ec1, @@ec2
+                         OPTIONS {edgeCollections: ["${ec2Name}"]}
+                         SORT v._id
+                         RETURN DISTINCT v._id`;
+
+        const actual = db._query(query, {'@vc1': vc1Name, '@vc2': vc2Name, '@ec1': ec1Name, '@ec2': ec2Name }).toArray();
+        const expected = [];
+        assertEqual(actual, expected);
       }
     },
     
@@ -285,6 +391,7 @@ function vertexCollectionRestrictionSuite() {
     testRestrictInvalidEdgeCollections: function () {
       const query = `WITH @@vc1, @@vc2
                      FOR v IN 3..3 OUTBOUND "${vc1Name}/node_5" @@ec1
+                       // specify non-existing edge collections
                        OPTIONS {edgeCollections: ["piff", "paff"]}
                        SORT v._id
                        RETURN DISTINCT v._id`;
@@ -294,6 +401,38 @@ function vertexCollectionRestrictionSuite() {
         fail();
       } catch (err) {
         assertEqual(errors.ERROR_ARANGO_DATA_SOURCE_NOT_FOUND.code, err.errorNum);
+      }
+    },
+    
+    testRestrictInvalidEdgeCollectionType: function () {
+      const query = `WITH @@vc1, @@vc2
+                     FOR v IN 3..3 OUTBOUND "${vc1Name}/node_5" @@ec1
+                       // specify a vertex collection instead of an edge collection
+                       OPTIONS {edgeCollections: ["${vc1Name}"]}
+                       SORT v._id
+                       RETURN DISTINCT v._id`;
+
+      try {
+        db._query(query, {'@vc1': vc1Name, '@vc2': vc2Name, '@ec1': ec1Name }).toArray();
+        fail();
+      } catch (err) {
+        assertEqual(errors.ERROR_ARANGO_COLLECTION_TYPE_INVALID.code, err.errorNum);
+      }
+    },
+    
+    testRestrictViewAsEdgeCollection: function () {
+      const query = `WITH @@vc1, @@vc2
+                     FOR v IN 3..3 OUTBOUND "${vc1Name}/node_5" @@ec1
+                       // specify a view instead of an edge collection
+                       OPTIONS {edgeCollections: ["${viewName}"]}
+                       SORT v._id
+                       RETURN DISTINCT v._id`;
+
+      try {
+        db._query(query, {'@vc1': vc1Name, '@vc2': vc2Name, '@ec1': ec1Name }).toArray();
+        fail();
+      } catch (err) {
+        assertEqual(errors.ERROR_ARANGO_COLLECTION_TYPE_INVALID.code, err.errorNum);
       }
     },
 


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/18946
Follow-up to https://arangodb.atlassian.net/browse/ES-1566

add more tests and better error handling when specifying invalid values for `edgeCollections` and `vertexCollections` options of a traversal

- [x] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [x] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: -
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [x] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/ES-1566
- [ ] Design document: 