### PR TITLE
CMakePresets.json in 3.10 branch

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,268 @@
+{
+  "version": 3,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 20,
+    "patch": 0
+  },
+  "configurePresets": [
+    {
+      "hidden": true,
+      "name": "pr-base",
+      "binaryDir": "${sourceDir}/build",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+        "CMAKE_C_FLAGS": "-fno-stack-protector",
+        "CMAKE_CXX_FLAGS": "-fno-stack-protector",
+        "CMAKE_EXE_LINKER_FLAGS": "-Wl,--build-id",
+        "USE_IPO": "Off",
+        "USE_STRICT_OPENSSL_VERSION": "On",
+        "USE_MINIMAL_DEBUGINFO": "On",
+        "STATIC_EXECUTABLES": "On"
+      }
+    },
+    {
+      "hidden": true,
+      "name": "release-base",
+      "binaryDir": "${sourceDir}/build-presets/${presetName}",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "USE_ENTERPRISE": "Off",
+        "USE_JEMALLOC": "On",
+        "USE_IPO": "On",
+        "USE_GOOGLE_TESTS": "Off",
+        "USE_FAILURE_TESTS": "Off",
+        "STATIC_EXECUTABLES": "On"
+      }
+    },
+    {
+      "hidden": true,
+      "name": "x86_64",
+      "cacheVariables": {
+        "USE_LIBUNWIND": "On",
+        "TARGET_ARCHITECTURE": "sandy-bridge"
+      }
+    },
+    {
+      "hidden": true,
+      "name": "arm",
+      "cacheVariables": {
+        "USE_LIBUNWIND": "Off"
+      }
+    },
+    {
+      "hidden": true,
+      "name": "pr",
+      "inherits": [ "pr-base", "x86_64" ]
+    },
+    {
+      "hidden": true,
+      "name": "pr-arm",
+      "inherits": [ "pr-base", "arm" ]
+    },
+    {
+      "hidden": true,
+      "name": "maintainer",
+      "cacheVariables": {
+        "USE_MAINTAINER_MODE": "On",
+        "USE_GOOGLE_TESTS": "On",
+        "USE_FAILURE_TESTS": "On"
+      }
+    },
+    {
+      "hidden": true,
+      "name": "tsan",
+      "cacheVariables": {
+        "CMAKE_CXX_FLAGS": "-fsanitize=thread",
+        "CMAKE_C_FLAGS": "-fsanitize=thread",
+        "USE_JEMALLOC": "Off"
+      }
+    },
+    {
+      "hidden": true,
+      "name": "asan-ubsan",
+      "cacheVariables": {
+        "CMAKE_CXX_FLAGS": "-fsanitize=address -fsanitize=leak -fsanitize=undefined -fsanitize=float-divide-by-zero -fsanitize-address-use-after-return=never -fno-sanitize=vptr -fno-sanitize=alignment",
+        "CMAKE_C_FLAGS": "-fsanitize=address -fsanitize=leak -fsanitize=undefined -fsanitize=float-divide-by-zero -fsanitize-address-use-after-return=never -fno-sanitize=alignment",
+        "USE_JEMALLOC": "Off"
+      }
+    },
+    {
+      "hidden": true,
+      "name": "gcov",
+      "cacheVariables": {
+        "USE_COVERAGE": "On",
+        "USE_JEMALLOC": "On"
+      }
+    },
+    {
+      "name": "community",
+      "inherits": "release-base",
+      "displayName": "Build ArangoDB Community Edition (Release Build)",
+      "binaryDir": "${sourceDir}/build-presets/${presetName}",
+      "cacheVariables": {
+      }
+    },
+    {
+      "name": "enterprise",
+      "inherits": "release-base",
+      "displayName": "Build ArangoDB Enterprise Edition (Release Build)",
+      "cacheVariables": {
+        "USE_ENTERPRISE": "On"
+      }
+    },
+    {
+      "name": "community-developer",
+      "inherits": [ "maintainer", "community" ],
+      "displayName": "Build ArangoDB Community Edition (Developer Build)",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "USE_IPO": "Off",
+        "USE_FAIL_ON_WARNINGS": "On",
+        "STATIC_EXECUTABLES": "On",
+        "USE_STRICT_OPENSSL_VERSION": "Off"
+      }
+    },
+    {
+      "name": "community-pr",
+      "inherits": [
+        "pr",
+        "maintainer",
+        "community"
+      ],
+      "displayName": "PR Build ArangoDB Community Edition"
+    },
+    {
+      "name": "enterprise-pr",
+      "inherits": [
+        "pr",
+        "maintainer",
+        "enterprise"
+      ],
+      "displayName": "PR Build ArangoDB Enterprise Edition"
+    },
+    {
+      "name": "community-pr-arm",
+      "inherits": [
+        "pr-arm",
+        "maintainer",
+        "community"
+      ],
+      "displayName": "PR Build ArangoDB Community Edition (ARM)"
+    },
+    {
+      "name": "enterprise-developer",
+      "inherits": [ "maintainer", "enterprise"],
+      "displayName": "Build ArangoDB Enterprise Edition (Developer Build)",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "USE_IPO": "Off",
+        "USE_FAIL_ON_WARNINGS": "On",
+        "USE_STRICT_OPENSSL_VERSION": "Off"
+      }
+    },
+    {
+      "name": "community-developer-tsan",
+      "inherits": [ "tsan", "community-developer" ],
+      "displayName": "Build ArangoDB Community Edition (TSAN Build)"
+    },
+    {
+      "name": "enterprise-developer-tsan",
+      "inherits": [ "tsan", "enterprise-developer" ],
+      "displayName": "Build ArangoDB Enterprise Edition (TSAN Build)"
+    },
+    {
+      "name": "community-developer-asan-ubsan",
+      "inherits": [ "asan-ubsan", "community-developer" ],
+      "displayName": "Build ArangoDB Community Edition (ASAN and UBSAN Build)"
+    },
+    {
+      "name": "enterprise-developer-asan-ubsan",
+      "inherits": [ "asan-ubsan", "enterprise-developer" ],
+      "displayName": "Build ArangoDB Enterprise Edition (ASAN and UBSAN Build)"
+    },
+    {
+      "name": "community-developer-coverage",
+      "inherits": [ "gcov", "community-developer" ],
+      "displayName": "Build ArangoDB Community Edition (Coverage Build)"
+    },
+    {
+      "name": "enterprise-developer-coverage",
+      "inherits": [ "gcov", "enterprise-developer" ],
+      "displayName": "Build ArangoDB Enterprise Edition (Coverage Build)"
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "community",
+      "configurePreset": "community"
+    },
+    {
+      "name": "enterprise",
+      "configurePreset": "enterprise"
+    },
+    {
+      "name": "community-developer",
+      "configurePreset": "community-developer"
+    },
+    {
+      "name": "enterprise-developer",
+      "configurePreset": "enterprise-developer"
+    },
+    {
+      "name": "community-pr",
+      "configurePreset": "community-pr"
+    },
+    {
+      "name": "enterprise-pr",
+      "configurePreset": "enterprise-pr"
+    },
+    {
+      "name": "community-pr-arm",
+      "configurePreset": "community-pr-arm"
+    },
+    {
+      "name": "community-developer-tsan",
+      "configurePreset": "community-developer-tsan"
+    },
+    {
+      "name": "enterprise-developer-tsan",
+      "configurePreset": "enterprise-developer-tsan"
+    },
+    {
+      "name": "community-developer-asan-ubsan",
+      "configurePreset": "community-developer-asan-ubsan"
+    },
+    {
+      "name": "enterprise-developer-asan-ubsan",
+      "configurePreset": "enterprise-developer-asan-ubsan"
+    },
+    {
+      "name": "community-developer-coverage",
+      "configurePreset": "community-developer-coverage"
+    },
+    {
+      "name": "enterprise-developer-coverage",
+      "configurePreset": "enterprise-developer-coverage"
+    }
+  ],
+  "testPresets": [
+    {
+      "name": "enterprise-developer",
+      "configurePreset": "enterprise-developer"
+    },
+    {
+      "name": "community-developer",
+      "configurePreset": "community-developer"
+    },
+    {
+      "name": "community-pr",
+      "configurePreset": "community-pr"
+    },
+    {
+      "name": "enterprise-pr",
+      "configurePreset": "enterprise-pr"
+    }
+
+  ]
+}


### PR DESCRIPTION
### Scope & Purpose

Add `CMakePresets.json` to the 3.10 branch to ease the use of tooling to build documentation and CI in the future.

This should normally not affect anyone who doesn't use presets. 

It could also be one step towards being able to run CircleCI on the 3.10 branch. 