### PR TITLE
[GORDO-1642] Try and address some obvious timewasters

### DIFF
--- a/arangod/Pregel/Algorithm.h
+++ b/arangod/Pregel/Algorithm.h
@@ -116,7 +116,7 @@ struct Algorithm : IAlgorithm {
   }
   virtual std::set<std::string> initialActiveSet() { return {}; }
 
-  [[deprecated]] [[nodiscard]] virtual uint32_t messageBatchSize(
+  [[deprecated]] [[nodiscard]] virtual size_t messageBatchSize(
       std::shared_ptr<WorkerConfig const> config,
       MessageStats const& stats) const {
     if (config->localSuperstep() == 0) {
@@ -126,7 +126,7 @@ struct Algorithm : IAlgorithm {
           static_cast<double>(stats.sendCount) / stats.superstepRuntimeSecs;
       msgsPerSec /= static_cast<double>(config->parallelism());  // per thread
       msgsPerSec *= 0.06;
-      return msgsPerSec > 250.0 ? (uint32_t)msgsPerSec : 250;
+      return msgsPerSec > 250.0 ? (size_t)msgsPerSec : 250;
     }
   }
 };

--- a/arangod/Pregel/Algos/SSSP/SSSP.cpp
+++ b/arangod/Pregel/Algos/SSSP/SSSP.cpp
@@ -70,7 +70,7 @@ SSSPAlgorithm::SSSPAlgorithm(VPackSlice userParams) {
     }
   }
 }
-uint32_t SSSPAlgorithm::messageBatchSize(
+size_t SSSPAlgorithm::messageBatchSize(
     std::shared_ptr<WorkerConfig const> config,
     MessageStats const& stats) const {
   if (config->localSuperstep() <= 1) {

--- a/arangod/Pregel/Algos/SSSP/SSSP.h
+++ b/arangod/Pregel/Algos/SSSP/SSSP.h
@@ -73,8 +73,8 @@ class SSSPAlgorithm : public Algorithm<int64_t, int64_t, int64_t> {
   VertexCompensation<int64_t, int64_t, int64_t>* createCompensation(
       std::shared_ptr<WorkerConfig const>) const override;
 
-  uint32_t messageBatchSize(std::shared_ptr<WorkerConfig const> config,
-                            MessageStats const& stats) const override;
+  size_t messageBatchSize(std::shared_ptr<WorkerConfig const> config,
+                          MessageStats const& stats) const override;
 
   [[nodiscard]] auto workerContext(
       std::unique_ptr<AggregatorHandler> readAggregators,

--- a/arangod/Pregel/GraphStore/GraphSerdeConfig.h
+++ b/arangod/Pregel/GraphStore/GraphSerdeConfig.h
@@ -26,6 +26,8 @@
 #include <set>
 #include <unordered_set>
 
+#include "Containers/FlatHashSet.h"
+
 #include "Pregel/GraphStore/PregelShard.h"
 #include "Pregel/GraphStore/LoadableVertexShard.h"
 #include "Pregel/DatabaseTypes.h"
@@ -64,8 +66,8 @@ struct GraphSerdeConfig {
 
   // Actual set of pregel shard id's located here
   [[nodiscard]] auto localPregelShardIDs(ServerID server) const
-      -> std::set<PregelShard> {
-    auto result = std::set<PregelShard>{};
+      -> containers::FlatHashSet<PregelShard> {
+    auto result = containers::FlatHashSet<PregelShard>{};
 
     for (auto&& loadableVertexShard : loadableVertexShards) {
       if (loadableVertexShard.responsibleServer == server) {

--- a/arangod/Pregel/IncomingCache.cpp
+++ b/arangod/Pregel/IncomingCache.cpp
@@ -105,9 +105,9 @@ void InCache<M>::storeMessage(PregelShard shard, std::string_view vertexId,
 template<typename M>
 ArrayInCache<M>::ArrayInCache(containers::FlatHashSet<PregelShard> localShards,
                               MessageFormat<M> const* format)
-    : InCache<M>(format), _localShards(localShards) {
+    : InCache<M>(format), _localShards(std::move(localShards)) {
   // one mutex per shard, we will see how this scales
-  for (PregelShard pregelShard : _localShards) {
+  for (PregelShard const& pregelShard : _localShards) {
     this->_bucketLocker[pregelShard];
     _shardMap[pregelShard];
   }

--- a/arangod/Pregel/IncomingCache.cpp
+++ b/arangod/Pregel/IncomingCache.cpp
@@ -103,7 +103,7 @@ void InCache<M>::storeMessage(PregelShard shard, std::string_view vertexId,
 // ================== ArrayIncomingCache ==================
 
 template<typename M>
-ArrayInCache<M>::ArrayInCache(std::set<PregelShard> localShards,
+ArrayInCache<M>::ArrayInCache(containers::FlatHashSet<PregelShard> localShards,
                               MessageFormat<M> const* format)
     : InCache<M>(format), _localShards(localShards) {
   // one mutex per shard, we will see how this scales
@@ -215,9 +215,9 @@ void ArrayInCache<M>::forEach(
 // ================== CombiningIncomingCache ==================
 
 template<typename M>
-CombiningInCache<M>::CombiningInCache(std::set<PregelShard> localShards,
-                                      MessageFormat<M> const* format,
-                                      MessageCombiner<M> const* combiner)
+CombiningInCache<M>::CombiningInCache(
+    containers::FlatHashSet<PregelShard> localShards,
+    MessageFormat<M> const* format, MessageCombiner<M> const* combiner)
     : InCache<M>(format), _combiner(combiner), _localShards(localShards) {
   // one mutex per shard, we will see how this scales
   for (PregelShard pregelShard : localShards) {

--- a/arangod/Pregel/OutgoingCache.cpp
+++ b/arangod/Pregel/OutgoingCache.cpp
@@ -85,8 +85,8 @@ void ArrayOutCache<M>::appendMessage(PregelShard shard,
 }
 template<typename M>
 auto ArrayOutCache<M>::messagesToVPack(
-    std::unordered_map<std::string, std::vector<M>> const& messagesForVertices)
-    -> std::tuple<size_t, VPackBuilder> {
+    containers::NodeHashMap<std::string, std::vector<M>> const&
+        messagesForVertices) -> std::tuple<size_t, VPackBuilder> {
   VPackBuilder messagesVPack;
   size_t messageCount = 0;
   {
@@ -171,7 +171,7 @@ void CombiningOutCache<M>::appendMessage(PregelShard shard,
     this->_localCache->storeMessageNoLock(shard, key, data);
     this->_sendCount++;
   } else {
-    std::unordered_map<std::string_view, M>& vertexMap = _shardMap[shard];
+    auto& vertexMap = _shardMap[shard];
     auto it = vertexMap.find(key);
     if (it != vertexMap.end()) {  // more than one message
       auto& ref = (*it).second;   // will be modified by combine(...)
@@ -188,7 +188,7 @@ void CombiningOutCache<M>::appendMessage(PregelShard shard,
 
 template<typename M>
 auto CombiningOutCache<M>::messagesToVPack(
-    std::unordered_map<std::string_view, M> const& messagesForVertices)
+    containers::NodeHashMap<std::string_view, M> const& messagesForVertices)
     -> VPackBuilder {
   VPackBuilder messagesVPack;
   {
@@ -278,8 +278,8 @@ void ArrayOutActorCache<M>::appendMessage(PregelShard shard,
 }
 template<typename M>
 auto ArrayOutActorCache<M>::messagesToVPack(
-    std::unordered_map<std::string, std::vector<M>> const& messagesForVertices)
-    -> std::tuple<size_t, VPackBuilder> {
+    containers::NodeHashMap<std::string, std::vector<M>> const&
+        messagesForVertices) -> std::tuple<size_t, VPackBuilder> {
   VPackBuilder messagesVPack;
   size_t messageCount = 0;
   {
@@ -351,7 +351,7 @@ void CombiningOutActorCache<M>::appendMessage(PregelShard shard,
     this->_localCache->storeMessageNoLock(shard, key, data);
     this->_sendCount++;
   } else {
-    std::unordered_map<std::string_view, M>& vertexMap = _shardMap[shard];
+    auto& vertexMap = _shardMap[shard];
     auto it = vertexMap.find(key);
     if (it != vertexMap.end()) {  // more than one message
       auto& ref = (*it).second;   // will be modified by combine(...)
@@ -371,7 +371,7 @@ void CombiningOutActorCache<M>::appendMessage(PregelShard shard,
 
 template<typename M>
 auto CombiningOutActorCache<M>::messagesToVPack(
-    std::unordered_map<std::string_view, M> const& messagesForVertices)
+    containers::NodeHashMap<std::string_view, M> const& messagesForVertices)
     -> VPackBuilder {
   VPackBuilder messagesVPack;
   {

--- a/arangod/Pregel/OutgoingCache.cpp
+++ b/arangod/Pregel/OutgoingCache.cpp
@@ -52,7 +52,7 @@ using namespace arangodb::pregel::algos;
 
 template<typename M>
 OutCache<M>::OutCache(std::shared_ptr<WorkerConfig const> state,
-                      std::set<PregelShard> localShards,
+                      containers::FlatHashSet<PregelShard> localShards,
                       MessageFormat<M> const* format)
     : _config(std::move(state)),
       _localShards(std::move(localShards)),

--- a/arangod/Pregel/OutgoingCache.h
+++ b/arangod/Pregel/OutgoingCache.h
@@ -26,6 +26,7 @@
 #include "Actor/ActorPID.h"
 #include "Basics/Common.h"
 #include "Cluster/ClusterInfo.h"
+#include "Containers/FlatHashSet.h"
 #include "Pregel/Worker/Messages.h"
 #include "VocBase/voc-types.h"
 
@@ -55,7 +56,7 @@ template<typename M>
 class OutCache {
  protected:
   std::shared_ptr<WorkerConfig const> _config;
-  std::set<PregelShard> _localShards;
+  containers::FlatHashSet<PregelShard> _localShards;
   MessageFormat<M> const* _format;
   InCache<M>* _localCache = nullptr;
   InCache<M>* _localCacheNextGSS = nullptr;
@@ -74,7 +75,8 @@ class OutCache {
 
  public:
   OutCache(std::shared_ptr<WorkerConfig const> state,
-           std::set<PregelShard> localShards, MessageFormat<M> const* format);
+           containers::FlatHashSet<PregelShard> localShards,
+           MessageFormat<M> const* format);
   virtual ~OutCache() = default;
 
   size_t sendCount() const { return _sendCount; }
@@ -118,7 +120,7 @@ class ArrayOutCache : public OutCache<M> {
 
  public:
   ArrayOutCache(std::shared_ptr<WorkerConfig const> state,
-                std::set<PregelShard> localShards,
+                containers::FlatHashSet<PregelShard> localShards,
                 MessageFormat<M> const* format)
       : OutCache<M>(std::move(state), std::move(localShards), format) {}
   ~ArrayOutCache() = default;
@@ -144,7 +146,7 @@ class CombiningOutCache : public OutCache<M> {
 
  public:
   CombiningOutCache(std::shared_ptr<WorkerConfig const> state,
-                    std::set<PregelShard> localShards,
+                    containers::FlatHashSet<PregelShard> localShards,
                     MessageFormat<M> const* format,
                     MessageCombiner<M> const* combiner)
       : OutCache<M>(std::move(state), std::move(localShards), format),
@@ -181,7 +183,7 @@ class ArrayOutActorCache : public OutCache<M> {
 
  public:
   ArrayOutActorCache(std::shared_ptr<WorkerConfig const> state,
-                     std::set<PregelShard> localShards,
+                     containers::FlatHashSet<PregelShard> localShards,
                      MessageFormat<M> const* format)
       : OutCache<M>{std::move(state), std::move(localShards), format} {};
   ~ArrayOutActorCache() = default;
@@ -228,7 +230,7 @@ class CombiningOutActorCache : public OutCache<M> {
 
  public:
   CombiningOutActorCache(std::shared_ptr<WorkerConfig const> state,
-                         std::set<PregelShard> localShards,
+                         containers::FlatHashSet<PregelShard> localShards,
                          MessageFormat<M> const* format,
                          MessageCombiner<M> const* combiner)
       : OutCache<M>{state, std::move(localShards), format},

--- a/arangod/Pregel/OutgoingCache.h
+++ b/arangod/Pregel/OutgoingCache.h
@@ -63,7 +63,7 @@ class OutCache {
   InCache<M>* _localCache = nullptr;
   InCache<M>* _localCacheNextGSS = nullptr;
   std::string _baseUrl;
-  uint32_t _batchSize = 1000;
+  size_t _batchSize = 1000;
 
   /// @brief current number of vertices stored
   size_t _containedMessages = 0;
@@ -82,8 +82,8 @@ class OutCache {
   virtual ~OutCache() = default;
 
   size_t sendCount() const { return _sendCount; }
-  uint32_t batchSize() const { return _batchSize; }
-  void setBatchSize(uint32_t bs) { _batchSize = bs; }
+  size_t batchSize() const { return _batchSize; }
+  void setBatchSize(size_t bs) { _batchSize = bs; }
   inline void setLocalCache(InCache<M>* cache) { _localCache = cache; }
 
   void clear() {

--- a/arangod/Pregel/Worker/Handler.h
+++ b/arangod/Pregel/Worker/Handler.h
@@ -265,7 +265,7 @@ struct WorkerHandler : actor::HandlerBase<Runtime, WorkerState<V, E, M>> {
 
     uint64_t tn = this->state->config->parallelism();
     uint64_t s = this->state->messageStats.sendCount / tn / 2UL;
-    this->state->messageBatchSize = s > 1000 ? (uint32_t)s : 1000;
+    this->state->messageBatchSize = s > 1000 ? (size_t)s : 1000;
     this->state->messageStats.reset();
     LOG_TOPIC("a3dbf", TRACE, Logger::PREGEL)
         << fmt::format("Message batch size: {}", this->state->messageBatchSize);

--- a/arangod/Pregel/Worker/State.h
+++ b/arangod/Pregel/Worker/State.h
@@ -98,7 +98,7 @@ struct WorkerState {
   std::unique_ptr<MessageCombiner<M>> messageCombiner;
   std::unique_ptr<InCache<M>> readCache = nullptr;
   std::unique_ptr<InCache<M>> writeCache = nullptr;
-  uint32_t messageBatchSize = 500;
+  size_t messageBatchSize = 500;
   std::unordered_map<ShardID, actor::ActorPID> responsibleActorPerShard;
 
   const actor::ActorPID conductor;

--- a/arangod/Pregel/Worker/VertexProcessor.cpp
+++ b/arangod/Pregel/Worker/VertexProcessor.cpp
@@ -48,7 +48,8 @@ VertexProcessor<V, E, M>::VertexProcessor(
     std::unique_ptr<MessageFormat<M>>& messageFormat) {
   if (messageCombiner != nullptr) {
     localMessageCache = std::make_shared<CombiningInCache<M>>(
-        std::set<PregelShard>{}, messageFormat.get(), messageCombiner.get());
+        containers::FlatHashSet<PregelShard>{}, messageFormat.get(),
+        messageCombiner.get());
     outCache = std::make_shared<CombiningOutCache<M>>(
         workerConfig,
         workerConfig->graphSerdeConfig().localPregelShardIDs(
@@ -56,7 +57,7 @@ VertexProcessor<V, E, M>::VertexProcessor(
         messageFormat.get(), messageCombiner.get());
   } else {
     localMessageCache = std::make_shared<ArrayInCache<M>>(
-        std::set<PregelShard>{}, messageFormat.get());
+        containers::FlatHashSet<PregelShard>{}, messageFormat.get());
     outCache = std::make_shared<ArrayOutCache<M>>(
         workerConfig,
         workerConfig->graphSerdeConfig().localPregelShardIDs(
@@ -122,7 +123,8 @@ ActorVertexProcessor<V, E, M>::ActorVertexProcessor(
         responsibleActorPerShard) {
   if (messageCombiner != nullptr) {
     localMessageCache = std::make_shared<CombiningInCache<M>>(
-        std::set<PregelShard>{}, messageFormat.get(), messageCombiner.get());
+        containers::FlatHashSet<PregelShard>{}, messageFormat.get(),
+        messageCombiner.get());
     outCache = std::make_shared<CombiningOutActorCache<M>>(
         workerConfig,
         workerConfig->graphSerdeConfig().localPregelShardIDs(
@@ -130,7 +132,7 @@ ActorVertexProcessor<V, E, M>::ActorVertexProcessor(
         messageFormat.get(), messageCombiner.get());
   } else {
     localMessageCache = std::make_shared<ArrayInCache<M>>(
-        std::set<PregelShard>{}, messageFormat.get());
+        containers::FlatHashSet<PregelShard>{}, messageFormat.get());
     outCache = std::make_shared<ArrayOutActorCache<M>>(
         workerConfig,
         workerConfig->graphSerdeConfig().localPregelShardIDs(

--- a/arangod/Pregel/Worker/VertexProcessor.cpp
+++ b/arangod/Pregel/Worker/VertexProcessor.cpp
@@ -45,7 +45,7 @@ VertexProcessor<V, E, M>::VertexProcessor(
     std::unique_ptr<Algorithm<V, E, M>>& algorithm,
     std::unique_ptr<WorkerContext>& workerContext,
     std::unique_ptr<MessageCombiner<M>>& messageCombiner,
-    std::unique_ptr<MessageFormat<M>>& messageFormat) {
+    std::unique_ptr<MessageFormat<M>>& messageFormat, size_t messageBatchSize) {
   if (messageCombiner != nullptr) {
     localMessageCache = std::make_shared<CombiningInCache<M>>(
         containers::FlatHashSet<PregelShard>{}, messageFormat.get(),

--- a/arangod/Pregel/Worker/VertexProcessor.h
+++ b/arangod/Pregel/Worker/VertexProcessor.h
@@ -123,7 +123,7 @@ struct ActorVertexProcessor {
   std::shared_ptr<VertexComputation<V, E, M>> vertexComputation;
   std::unique_ptr<AggregatorHandler> workerAggregator;
 
-  uint32_t messageBatchSize = 5000;
+  size_t messageBatchSize = 5000;
 };
 
 }  // namespace arangodb::pregel

--- a/arangod/Pregel/Worker/VertexProcessor.h
+++ b/arangod/Pregel/Worker/VertexProcessor.h
@@ -56,7 +56,8 @@ struct VertexProcessor {
                   std::unique_ptr<Algorithm<V, E, M>>& algorithm,
                   std::unique_ptr<WorkerContext>& workerContext,
                   std::unique_ptr<MessageCombiner<M>>& messageCombiner,
-                  std::unique_ptr<MessageFormat<M>>& messageFormat);
+                  std::unique_ptr<MessageFormat<M>>& messageFormat,
+                  size_t messageBatchSize);
   ~VertexProcessor();
 
   auto process(Vertex<V, E>* vertexEntry, MessageIterator<M> messages) -> void;
@@ -75,8 +76,6 @@ struct VertexProcessor {
   std::shared_ptr<InCache<M>> localMessageCache;
   std::shared_ptr<VertexComputation<V, E, M>> vertexComputation;
   std::unique_ptr<AggregatorHandler> workerAggregator;
-
-  uint32_t messageBatchSize = 5000;
 };
 
 struct ActorVertexProcessorResult {

--- a/arangod/Pregel/Worker/Worker.cpp
+++ b/arangod/Pregel/Worker/Worker.cpp
@@ -312,11 +312,12 @@ void Worker<V, E, M>::_startProcessing() {
   for (auto futureN = size_t{0}; futureN < _config->parallelism(); ++futureN) {
     futures.emplace_back(SchedulerFeature::SCHEDULER->queueWithFuture(
         RequestLane::INTERNAL_LOW, [self, this, quiverIdx, futureN]() {
-          LOG_PREGEL("ee2ac", DEBUG)
-              << fmt::format("Starting vertex processor number {}", futureN);
-          auto processor =
-              VertexProcessor<V, E, M>(_config, _algorithm, _workerContext,
-                                       _messageCombiner, _messageFormat);
+          LOG_PREGEL("ee2ac", DEBUG) << fmt::format(
+              "Starting vertex processor number {} with batch size", futureN,
+              _messageBatchSize);
+          auto processor = VertexProcessor<V, E, M>(
+              _config, _algorithm, _workerContext, _messageCombiner,
+              _messageFormat, _messageBatchSize);
 
           while (true) {
             auto myCurrentQuiver = quiverIdx->fetch_add(1);

--- a/arangod/Pregel/Worker/Worker.h
+++ b/arangod/Pregel/Worker/Worker.h
@@ -99,7 +99,7 @@ class Worker : public IWorker {
   std::atomic<WorkerState> _state = WorkerState::DEFAULT;
   std::shared_ptr<WorkerConfig> _config;
   uint64_t _expectedGSS = 0;
-  uint32_t _messageBatchSize = 500;
+  size_t _messageBatchSize = 500;
   std::unique_ptr<Algorithm<V, E, M>> _algorithm;
   std::unique_ptr<WorkerContext> _workerContext;
   // locks modifying member vars


### PR DESCRIPTION
### Scope & Purpose

Since we saw the little buggers in the profile, try and replace them with the abseil alternatives; while this might address the immediate pains of the performance regression between 3.10 and 3.11/devel it is not really a solution to the underlying performance problem.

This PR also reintroduces scaling the batch size for message caches as it was in 3.10; this is also a rather desparate move to get a handle on the performance differences between 3.10 and 3.11