### PR TITLE
BTS-1398 Fix GEO_DISTANCE filter

### DIFF
--- a/arangod/IResearch/GeoFilter.cpp
+++ b/arangod/IResearch/GeoFilter.cpp
@@ -479,8 +479,7 @@ irs::filter::prepared::ptr prepareOpenInterval(
             auto& excl = root.add<irs::Not>().filter<GeoDistanceFilter>();
             *excl.mutable_field() = field;
             auto& opts = *excl.mutable_options();
-            opts.prefix = options.prefix;
-            opts.options = options.options;
+            opts = options;
             opts.range.min = 0;
             opts.range.min_type = irs::BoundType::INCLUSIVE;
             opts.range.max = 0;

--- a/tests/js/server/aql/aql-geo.inc
+++ b/tests/js/server/aql/aql-geo.inc
@@ -515,8 +515,17 @@
       testPointNearCentroidOfPolygon : function () {
         chooseCollectionSet('createThreePolygons');
         let c = compare(
-          `FILTER GEO_DISTANCE([15, 15], d.geo) <= 5000`,
-          `SEARCH ANALYZER(GEO_DISTANCE([15, 15], d.geo) <= 5000, "${analyzerName}")`
+          `FILTER GEO_DISTANCE([25, 15], d.geo) <= 5000`,
+          `SEARCH ANALYZER(GEO_DISTANCE([25, 15], d.geo) <= 5000, "${analyzerName}")`
+        );
+        assertTrue(c.cmpResFullScanWithIndexes.good && c.cmpResView.good && c.cmpResInvertedIndex.good, c.cmpResFullScanWithIndexes.msg + c.cmpResView.msg + c.cmpResInvertedIndex.msg);
+      },
+      
+      testPointOutsideOfPolygon : function () {
+        chooseCollectionSet('createNearSlidingObject');
+        let c = compare(
+          `FILTER GEO_DISTANCE(d.geo, GEO_POINT(6.93, 10.94)) > 0`,
+          `SEARCH ANALYZER(GEO_DISTANCE(d.geo, GEO_POINT(6.93, 10.94)) > 0, "${analyzerName}")`
         );
         assertTrue(c.cmpResFullScanWithIndexes.good && c.cmpResView.good && c.cmpResInvertedIndex.good, c.cmpResFullScanWithIndexes.msg + c.cmpResView.msg + c.cmpResInvertedIndex.msg);
       },


### PR DESCRIPTION
### Scope & Purpose

In case of query like GEO_DISTANCE(....) >0 custom storage value encoding was not set for internal filter. Now internal filter gets a copy of outer filter options and only then applies custom overrides.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [x] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [x] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: *(Please link PR)*
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

