### PR TITLE
Feature/cursor api next batch no retriable

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,13 @@
 devel
 -----
 
+* In batched query results, when executing requests for 
+  `/_api/cursor/<cursorId>/<batchId>`, removed the restriction that the user 
+  would only be able to fetch the next batch using the next batch id in 
+  <batchId> if the query option `allowRetry` was set to true, but maintained
+  the restriction that the user can only retrieve the latest batch if the
+  query option `allowRetry` is set to true.
+
 * FE-263: Improve forceAtlas layout in the Graph Viewer.
 
 * FE-256: Minor Graph Viewer improvements:

--- a/arangod/RestHandler/RestCursorHandler.cpp
+++ b/arangod/RestHandler/RestCursorHandler.cpp
@@ -43,6 +43,8 @@
 #include <velocypack/Iterator.h>
 #include <velocypack/Value.h>
 
+#include "Logger/LogMacros.h"
+
 using namespace arangodb;
 using namespace arangodb::basics;
 using namespace arangodb::rest;
@@ -653,7 +655,9 @@ RestStatus RestCursorHandler::showLatestBatch() {
     return RestStatus::DONE;
   }
 
-  lookupCursor(suffixes[0], /*mustBeRetriable*/ true);
+  uint64_t batchId = basics::StringUtils::uint64(suffixes[1]);
+
+  lookupCursor(suffixes[0], batchId);
 
   if (_cursor == nullptr) {
     // error response already built here
@@ -662,8 +666,6 @@ RestStatus RestCursorHandler::showLatestBatch() {
 
   _cursor->setWakeupHandler(withLogContext(
       [self = shared_from_this()]() { return self->wakeupHandler(); }));
-
-  uint64_t batchId = basics::StringUtils::uint64(suffixes[1]);
 
   // POST /_api/cursor/<cid>/x and the current batchId on the server is y, then:
   //   if x == y, resend the current batch
@@ -701,7 +703,7 @@ RestStatus RestCursorHandler::modifyQueryCursor() {
   // the call to lookupCursor will populate _cursor if the cursor can be
   // found. otherwise, _cursor will remain a nullptr and an error will
   // be written to the response
-  lookupCursor(suffixes[0], /*mustBeRetriable*/ false);
+  lookupCursor(suffixes[0]);
 
   if (_cursor == nullptr) {
     return RestStatus::DONE;
@@ -751,7 +753,7 @@ RestStatus RestCursorHandler::deleteQueryCursor() {
 /// @brief look up cursor by id. side-effect: populates _cursor in case cursor
 /// was found. in case cursor was not found, writes an error into the response
 void RestCursorHandler::lookupCursor(std::string_view id,
-                                     bool mustBeRetriable) {
+                                     std::optional<uint64_t> batchId) {
   TRI_ASSERT(_cursor == nullptr);
 
   auto cursors = _vocbase.cursorRepository();
@@ -775,7 +777,8 @@ void RestCursorHandler::lookupCursor(std::string_view id,
 
   TRI_ASSERT(_cursor != nullptr);
 
-  if (mustBeRetriable && !_cursor->isRetriable()) {
+  if (batchId.has_value() && _cursor->isCurrentBatchId(batchId.value()) &&
+      !_cursor->isRetriable()) {
     releaseCursor();
     TRI_ASSERT(_cursor == nullptr);
 

--- a/arangod/RestHandler/RestCursorHandler.cpp
+++ b/arangod/RestHandler/RestCursorHandler.cpp
@@ -43,8 +43,6 @@
 #include <velocypack/Iterator.h>
 #include <velocypack/Value.h>
 
-#include "Logger/LogMacros.h"
-
 using namespace arangodb;
 using namespace arangodb::basics;
 using namespace arangodb::rest;

--- a/arangod/RestHandler/RestCursorHandler.h
+++ b/arangod/RestHandler/RestCursorHandler.h
@@ -33,6 +33,7 @@
 #include "Scheduler/Scheduler.h"
 
 #include <mutex>
+#include <optional>
 
 namespace arangodb {
 namespace velocypack {
@@ -122,7 +123,8 @@ class RestCursorHandler : public RestVocbaseBaseHandler {
 
   /// @brief look up cursor by id. side-effect: populates _cursor in case cursor
   /// was found. in case cursor was not found, writes an error into the response
-  void lookupCursor(std::string_view id, bool mustBeRetriable);
+  void lookupCursor(std::string_view id,
+                    std::optional<uint64_t> batchId = std::nullopt);
 
   /// @brief return a cursor to the repository, if one is set.
   void releaseCursor();

--- a/arangod/Utils/Cursor.h
+++ b/arangod/Utils/Cursor.h
@@ -40,8 +40,6 @@
 #include <string>
 #include <string_view>
 
-#include "Logger/LogMacros.h"
-
 namespace arangodb {
 
 namespace transaction {

--- a/arangod/Utils/Cursor.h
+++ b/arangod/Utils/Cursor.h
@@ -40,6 +40,8 @@
 #include <string>
 #include <string_view>
 
+#include "Logger/LogMacros.h"
+
 namespace arangodb {
 
 namespace transaction {
@@ -117,12 +119,10 @@ class Cursor {
   uint64_t storedBatchId() const { return _currentBatchResult.first; }
 
   void handleNextBatchIdValue(VPackBuilder& builder, bool hasMore) {
-    if (isRetriable()) {
-      _currentBatchResult.first = ++_currentBatchId;
-      if (hasMore) {
-        builder.add("nextBatchId", std::to_string(_currentBatchId + 1));
-        _lastAvailableBatchId = _currentBatchId + 1;
-      }
+    _currentBatchResult.first = ++_currentBatchId;
+    if (hasMore) {
+      builder.add("nextBatchId", std::to_string(_currentBatchId + 1));
+      _lastAvailableBatchId = _currentBatchId + 1;
     }
   }
 

--- a/js/client/modules/@arangodb/arango-query-cursor.js
+++ b/js/client/modules/@arangodb/arango-query-cursor.js
@@ -36,7 +36,7 @@ var arangosh = require('@arangodb/arangosh');
 // / @brief constructor
 // //////////////////////////////////////////////////////////////////////////////
 
-function ArangoQueryCursor(database, data, stream) {
+function ArangoQueryCursor(database, data, stream, retriable) {
   this._database = database;
   this._dbName = database._name();
   this.data = data;
@@ -47,11 +47,7 @@ function ArangoQueryCursor(database, data, stream) {
   this._total = 0;
   this._stream = stream || false;
   this._cached = false;
-  this._retriable = false;
-
-  if (data.hasOwnProperty('nextBatchId')) {
-    this._retriable = true;
-  }
+  this._retriable = retriable || false;
 
   if (data.result !== undefined) {
     this._count = data.result.length;

--- a/js/client/modules/@arangodb/arango-statement.js
+++ b/js/client/modules/@arangodb/arango-statement.js
@@ -179,8 +179,11 @@ ArangoStatement.prototype.execute = function () {
   if (!isStream && this._options && this._options.stream) {
     isStream = this._options.stream;
   }
-
-  return new ArangoQueryCursor(this._database, requestResult, isStream);
+  let allowRetry = false;
+  if (this._options && this._options.allowRetry) {
+    allowRetry = true;
+  }
+  return new ArangoQueryCursor(this._database, requestResult, isStream, allowRetry);
 };
 
 exports.ArangoStatement = ArangoStatement;

--- a/tests/js/client/shell/api/cursor.js
+++ b/tests/js/client/shell/api/cursor.js
@@ -1508,31 +1508,19 @@ function dealing_with_cursorsSuite_retriable_request_last_batch() {
       assertEqual(doc.parsedBody['result'].length, 1000);
       assertFalse(doc.parsedBody['cached']);
       assertEqual(doc.parsedBody['id'], cursorId);
+      const latestBatchId = nextBatchId;
       nextBatchId = doc.parsedBody['nextBatchId'];
       assertEqual(nextBatchId, "3");
 
-      cmd = api + `/${cursorId}/${nextBatchId}`;
+      cmd = api + `/${cursorId}/${latestBatchId}`;
       doc = arango.POST_RAW(cmd, "");
-
-      assertEqual(doc.code, 200);
+      assertEqual(doc.code, 400);
       assertEqual(doc.headers['content-type'], contentType);
-      assertFalse(doc.parsedBody['error']);
-      assertEqual(doc.parsedBody['code'], 200);
-      assertFalse(doc.parsedBody['hasMore']);
-      assertEqual(doc.parsedBody['result'].length, 1);
-      assertFalse(doc.parsedBody['cached']);
-      assertUndefined(doc.parsedBody['id'], cursorId);
-      assertUndefined(doc.parsedBody['nextBatchId']);
-
-      cmd = api + `/${cursorId}/${nextBatchId}`;
-      doc = arango.POST_RAW(cmd, "");
-
-      assertEqual(doc.code, 200);
-      assertEqual(doc.headers['content-type'], contentType);
-      assertFalse(doc.parsedBody['error']);
-      assertEqual(doc.parsedBody['code'], 200);
-      assertFalse(doc.parsedBody['hasMore']);
-      assertEqual(doc.parsedBody['result'].length, 1);
+      assertTrue(doc.parsedBody['error']);
+      assertEqual(doc.parsedBody.errorNum, 400);
+      assertEqual(doc.parsedBody.errorMessage, "expecting allowRetry option to be true");
+      assertEqual(doc.parsedBody['code'], 400);
+      assertUndefined(doc.parsedBody['hasMore']);
       assertFalse(doc.parsedBody['cached']);
       assertUndefined(doc.parsedBody['id'], cursorId);
       assertUndefined(doc.parsedBody['nextBatchId']);
@@ -1548,18 +1536,7 @@ function dealing_with_cursorsSuite_retriable_request_last_batch() {
       assertEqual(doc.parsedBody['code'], 404);
       assertUndefined(doc.parsedBody['nextBatchId']);
 
-      cmd = api + `/${cursorId}/0`;
-      doc = arango.POST_RAW(cmd, "");
-
-      assertEqual(doc.code, 404);
-      assertEqual(doc.headers['content-type'], contentType);
-      assertTrue(doc.parsedBody.error);
-      assertEqual(doc.parsedBody.errorNum, 1600);
-      assertEqual(doc.parsedBody.errorMessage, "batch id not found");
-      assertEqual(doc.parsedBody['code'], 404);
-      assertUndefined(doc.parsedBody['nextBatchId']);
-
-      cmd = api + `/${cursorId}`;
+      cmd = api + `/${cursorId}/${nextBatchId}`;
       doc = arango.POST_RAW(cmd, "");
 
       assertEqual(doc.code, 200);
@@ -1567,15 +1544,20 @@ function dealing_with_cursorsSuite_retriable_request_last_batch() {
       assertFalse(doc.parsedBody['error']);
       assertEqual(doc.parsedBody['code'], 200);
       assertFalse(doc.parsedBody['hasMore']);
-      assertUndefined(doc.parsedBody['id']);
-      assertEqual(doc.parsedBody['result'].length, 0);
+      assertEqual(doc.parsedBody['result'].length, 1);
       assertFalse(doc.parsedBody['cached']);
       assertUndefined(doc.parsedBody['id'], cursorId);
       assertUndefined(doc.parsedBody['nextBatchId']);
 
-      // must kill the cursor explicitly, so we don't need to wait for the
-      // cursor's full TTL
-      arango.DELETE_RAW(api + `/${cursorId}`, "");
+      cmd = api + `/${cursorId}/${nextBatchId}`;
+      doc = arango.POST_RAW(cmd, "");
+      assertEqual(doc.code, 404);
+      assertEqual(doc.headers['content-type'], contentType);
+      assertTrue(doc.parsedBody.error);
+      assertEqual(doc.parsedBody.errorNum, 1600);
+      assertEqual(doc.parsedBody.errorMessage, "cursor not found");
+      assertEqual(doc.parsedBody['code'], 404);
+      assertUndefined(doc.parsedBody['nextBatchId']);
     },
 
 
@@ -1694,49 +1676,41 @@ function dealing_with_cursorsSuite_retriable_request_last_batch() {
 
       assertEqual(doc.code, 200);
       assertEqual(doc.headers['content-type'], contentType);
+      assertFalse(doc.parsedBody['error']);
       assertEqual(doc.parsedBody['code'], 200);
       assertTrue(doc.parsedBody['hasMore']);
       assertEqual(doc.parsedBody['result'].length, 1000);
-      assertEqual(doc.parsedBody['id'], cursorId);
       assertFalse(doc.parsedBody['cached']);
+      assertEqual(doc.parsedBody['id'], cursorId);
+      const latestBatchId = nextBatchId;
       nextBatchId = doc.parsedBody['nextBatchId'];
-      assertEqual(nextBatchId, 3);
+      assertEqual(nextBatchId, "3");
+
+      cmd = api + `/${cursorId}/${latestBatchId}`;
+      doc = arango.POST_RAW(cmd, "");
+      assertEqual(doc.code, 400);
+      assertEqual(doc.headers['content-type'], contentType);
+      assertTrue(doc.parsedBody['error']);
+      assertEqual(doc.parsedBody.errorNum, 400);
+      assertEqual(doc.parsedBody.errorMessage, "expecting allowRetry option to be true");
+      assertEqual(doc.parsedBody['code'], 400);
+      assertUndefined(doc.parsedBody['hasMore']);
+      assertFalse(doc.parsedBody['cached']);
+      assertUndefined(doc.parsedBody['id'], cursorId);
+      assertUndefined(doc.parsedBody['nextBatchId']);
+
+      cmd = api + `/${cursorId}/${parseInt(nextBatchId) + 1}`;
+      doc = arango.POST_RAW(cmd, "");
+
+      assertEqual(doc.code, 404);
+      assertEqual(doc.headers['content-type'], contentType);
+      assertTrue(doc.parsedBody.error);
+      assertEqual(doc.parsedBody.errorNum, 1600);
+      assertEqual(doc.parsedBody.errorMessage, "batch id not found");
+      assertEqual(doc.parsedBody['code'], 404);
+      assertUndefined(doc.parsedBody['nextBatchId']);
 
       cmd = api + `/${cursorId}/${nextBatchId}`;
-      doc = arango.POST_RAW(cmd, "");
-
-      assertEqual(doc.code, 200);
-      assertEqual(doc.headers['content-type'], contentType);
-      assertEqual(doc.parsedBody['code'], 200);
-      assertFalse(doc.parsedBody['hasMore']);
-      assertEqual(doc.parsedBody['result'].length, 1);
-      assertUndefined(doc.parsedBody['id'], cursorId);
-      assertFalse(doc.parsedBody['cached']);
-      assertUndefined(doc.parsedBody['nextBatchId']);
-
-      cmd = api + `/${cursorId}/${parseInt(nextBatchId)}`;
-      doc = arango.POST_RAW(cmd, "");
-
-      assertEqual(doc.code, 404);
-      assertEqual(doc.headers['content-type'], contentType);
-      assertTrue(doc.parsedBody.error);
-      assertEqual(doc.parsedBody.errorNum, 1600);
-      assertEqual(doc.parsedBody.errorMessage, "batch id not found");
-      assertEqual(doc.parsedBody['code'], 404);
-      assertUndefined(doc.parsedBody['nextBatchId']);
-
-      cmd = api + `/${cursorId}/0`;
-      doc = arango.POST_RAW(cmd, "");
-
-      assertEqual(doc.code, 404);
-      assertEqual(doc.headers['content-type'], contentType);
-      assertTrue(doc.parsedBody.error);
-      assertEqual(doc.parsedBody.errorNum, 1600);
-      assertEqual(doc.parsedBody.errorMessage, "batch id not found");
-      assertEqual(doc.parsedBody['code'], 404);
-      assertUndefined(doc.parsedBody['nextBatchId']);
-
-      cmd = api + `/${cursorId}`;
       doc = arango.POST_RAW(cmd, "");
 
       assertEqual(doc.code, 200);
@@ -1744,13 +1718,20 @@ function dealing_with_cursorsSuite_retriable_request_last_batch() {
       assertFalse(doc.parsedBody['error']);
       assertEqual(doc.parsedBody['code'], 200);
       assertFalse(doc.parsedBody['hasMore']);
-      assertUndefined(doc.parsedBody['id']);
+      assertEqual(doc.parsedBody['result'].length, 1);
       assertFalse(doc.parsedBody['cached']);
+      assertUndefined(doc.parsedBody['id'], cursorId);
       assertUndefined(doc.parsedBody['nextBatchId']);
 
-      // must kill the cursor explicitly, so we don't need to wait for the
-      // cursor's full TTL
-      arango.DELETE_RAW(api + `/${cursorId}`, "");
+      cmd = api + `/${cursorId}/${nextBatchId}`;
+      doc = arango.POST_RAW(cmd, "");
+      assertEqual(doc.code, 404);
+      assertEqual(doc.headers['content-type'], contentType);
+      assertTrue(doc.parsedBody.error);
+      assertEqual(doc.parsedBody.errorNum, 1600);
+      assertEqual(doc.parsedBody.errorMessage, "cursor not found");
+      assertEqual(doc.parsedBody['code'], 404);
+      assertUndefined(doc.parsedBody['nextBatchId']);
     },
 
     test_cursor_stream_request_non_retriable: function () {

--- a/tests/js/client/shell/api/cursor.js
+++ b/tests/js/client/shell/api/cursor.js
@@ -1257,7 +1257,7 @@ function dealing_with_cursorsSuite_retriable_request_last_batch() {
       internal.debugClearFailAt();
       db._drop(cn);
     },
-    
+
     test_cursor_non_stream_request_retriable_multiple_refetches: function () {
       let cmd = api;
       let body = {"query": `FOR u IN ${cn} RETURN u`, "options": {"stream": false, "allowRetry": true}};
@@ -1289,7 +1289,7 @@ function dealing_with_cursorsSuite_retriable_request_last_batch() {
       assertEqual(doc.parsedBody['id'], cursorId);
       nextBatchId = doc.parsedBody['nextBatchId'];
       assertEqual(nextBatchId, "2");
-      
+
       cmd = api + `/${cursorId}/${parseInt(nextBatchId) - 1}`;
       doc = arango.POST_RAW(cmd, "");
 
@@ -1303,10 +1303,10 @@ function dealing_with_cursorsSuite_retriable_request_last_batch() {
       assertEqual(doc.parsedBody['id'], cursorId);
       nextBatchId = doc.parsedBody['nextBatchId'];
       assertEqual(nextBatchId, "2");
-      
+
       cmd = api + `/${cursorId}/${nextBatchId}`;
       doc = arango.POST_RAW(cmd, "");
-      
+
       assertEqual(doc.code, 200);
       assertEqual(doc.headers['content-type'], contentType);
       assertFalse(doc.parsedBody['error']);
@@ -1317,7 +1317,7 @@ function dealing_with_cursorsSuite_retriable_request_last_batch() {
       assertEqual(doc.parsedBody['id'], cursorId);
       nextBatchId = doc.parsedBody['nextBatchId'];
       assertEqual(nextBatchId, "3");
-      
+
       cmd = api + `/${cursorId}/${parseInt(nextBatchId) - 1}`;
       doc = arango.POST_RAW(cmd, "");
 
@@ -1331,10 +1331,10 @@ function dealing_with_cursorsSuite_retriable_request_last_batch() {
       assertEqual(doc.parsedBody['id'], cursorId);
       nextBatchId = doc.parsedBody['nextBatchId'];
       assertEqual(nextBatchId, "3");
-      
+
       cmd = api + `/${cursorId}/${parseInt(nextBatchId)}`;
       doc = arango.POST_RAW(cmd, "");
-      
+
       assertEqual(doc.code, 200);
       assertEqual(doc.headers['content-type'], contentType);
       assertFalse(doc.parsedBody['error']);
@@ -1344,10 +1344,10 @@ function dealing_with_cursorsSuite_retriable_request_last_batch() {
       assertFalse(doc.parsedBody['cached']);
       assertUndefined(doc.parsedBody['id'], cursorId);
       assertUndefined(doc.parsedBody['nextBatchId']);
-      
+
       cmd = api + `/${cursorId}/${parseInt(nextBatchId)}`;
       doc = arango.POST_RAW(cmd, "");
-      
+
       assertEqual(doc.code, 200);
       assertEqual(doc.headers['content-type'], contentType);
       assertFalse(doc.parsedBody['error']);
@@ -1357,10 +1357,10 @@ function dealing_with_cursorsSuite_retriable_request_last_batch() {
       assertFalse(doc.parsedBody['cached']);
       assertUndefined(doc.parsedBody['id'], cursorId);
       assertUndefined(doc.parsedBody['nextBatchId']);
-      
+
       cmd = api + `/${cursorId}/${parseInt(parseInt(nextBatchId) + 1)}`;
       doc = arango.POST_RAW(cmd, "");
-      
+
       assertEqual(doc.code, 404);
       assertEqual(doc.headers['content-type'], contentType);
       assertTrue(doc.parsedBody.error);
@@ -1414,7 +1414,7 @@ function dealing_with_cursorsSuite_retriable_request_last_batch() {
 
       cmd = api + `/${cursorId}/${nextBatchId}`;
       doc = arango.POST_RAW(cmd, "");
-      
+
       assertEqual(doc.code, 200);
       assertEqual(doc.headers['content-type'], contentType);
       assertFalse(doc.parsedBody['error']);
@@ -1424,10 +1424,10 @@ function dealing_with_cursorsSuite_retriable_request_last_batch() {
       assertFalse(doc.parsedBody['cached']);
       assertUndefined(doc.parsedBody['id'], cursorId);
       assertUndefined(doc.parsedBody['nextBatchId']);
-      
+
       cmd = api + `/${cursorId}/${nextBatchId}`;
       doc = arango.POST_RAW(cmd, "");
-      
+
       assertEqual(doc.code, 200);
       assertEqual(doc.headers['content-type'], contentType);
       assertFalse(doc.parsedBody['error']);
@@ -1437,7 +1437,7 @@ function dealing_with_cursorsSuite_retriable_request_last_batch() {
       assertFalse(doc.parsedBody['cached']);
       assertUndefined(doc.parsedBody['id'], cursorId);
       assertUndefined(doc.parsedBody['nextBatchId']);
-      
+
       cmd = api + `/${cursorId}/${parseInt(nextBatchId) + 1}`;
       doc = arango.POST_RAW(cmd, "");
 
@@ -1475,10 +1475,110 @@ function dealing_with_cursorsSuite_retriable_request_last_batch() {
       assertUndefined(doc.parsedBody['nextBatchId']);
 
       // must kill the cursor explicitly, so we don't need to wait for the
-      // cursor's full TTL 
+      // cursor's full TTL
       arango.DELETE_RAW(api + `/${cursorId}`, "");
     },
-    
+
+    test_cursor_non_stream_request_non_retriable_next_batch: function () {
+      let cmd = api;
+      let body = {"query": `FOR u IN ${cn} RETURN u`, "options": {"stream": false, "allowRetry": false}};
+      let doc = arango.POST_RAW(cmd, body);
+
+      assertEqual(doc.code, 201);
+      assertEqual(doc.headers['content-type'], contentType);
+      assertFalse(doc.parsedBody['error']);
+      assertEqual(doc.parsedBody['code'], 201);
+      assertEqual(typeof doc.parsedBody['id'], "string");
+      assertMatch(reId, doc.parsedBody['id']);
+      assertTrue(doc.parsedBody['hasMore']);
+      assertEqual(doc.parsedBody['result'].length, 1000);
+      assertFalse(doc.parsedBody['cached']);
+      let cursorId = doc.parsedBody['id'];
+      let nextBatchId = doc.parsedBody['nextBatchId'];
+      assertEqual(nextBatchId, "2");
+
+      cmd = api + `/${cursorId}/${nextBatchId}`;
+      doc = arango.POST_RAW(cmd, "");
+
+      assertEqual(doc.code, 200);
+      assertEqual(doc.headers['content-type'], contentType);
+      assertFalse(doc.parsedBody['error']);
+      assertEqual(doc.parsedBody['code'], 200);
+      assertTrue(doc.parsedBody['hasMore']);
+      assertEqual(doc.parsedBody['result'].length, 1000);
+      assertFalse(doc.parsedBody['cached']);
+      assertEqual(doc.parsedBody['id'], cursorId);
+      nextBatchId = doc.parsedBody['nextBatchId'];
+      assertEqual(nextBatchId, "3");
+
+      cmd = api + `/${cursorId}/${nextBatchId}`;
+      doc = arango.POST_RAW(cmd, "");
+
+      assertEqual(doc.code, 200);
+      assertEqual(doc.headers['content-type'], contentType);
+      assertFalse(doc.parsedBody['error']);
+      assertEqual(doc.parsedBody['code'], 200);
+      assertFalse(doc.parsedBody['hasMore']);
+      assertEqual(doc.parsedBody['result'].length, 1);
+      assertFalse(doc.parsedBody['cached']);
+      assertUndefined(doc.parsedBody['id'], cursorId);
+      assertUndefined(doc.parsedBody['nextBatchId']);
+
+      cmd = api + `/${cursorId}/${nextBatchId}`;
+      doc = arango.POST_RAW(cmd, "");
+
+      assertEqual(doc.code, 200);
+      assertEqual(doc.headers['content-type'], contentType);
+      assertFalse(doc.parsedBody['error']);
+      assertEqual(doc.parsedBody['code'], 200);
+      assertFalse(doc.parsedBody['hasMore']);
+      assertEqual(doc.parsedBody['result'].length, 1);
+      assertFalse(doc.parsedBody['cached']);
+      assertUndefined(doc.parsedBody['id'], cursorId);
+      assertUndefined(doc.parsedBody['nextBatchId']);
+
+      cmd = api + `/${cursorId}/${parseInt(nextBatchId) + 1}`;
+      doc = arango.POST_RAW(cmd, "");
+
+      assertEqual(doc.code, 404);
+      assertEqual(doc.headers['content-type'], contentType);
+      assertTrue(doc.parsedBody.error);
+      assertEqual(doc.parsedBody.errorNum, 1600);
+      assertEqual(doc.parsedBody.errorMessage, "batch id not found");
+      assertEqual(doc.parsedBody['code'], 404);
+      assertUndefined(doc.parsedBody['nextBatchId']);
+
+      cmd = api + `/${cursorId}/0`;
+      doc = arango.POST_RAW(cmd, "");
+
+      assertEqual(doc.code, 404);
+      assertEqual(doc.headers['content-type'], contentType);
+      assertTrue(doc.parsedBody.error);
+      assertEqual(doc.parsedBody.errorNum, 1600);
+      assertEqual(doc.parsedBody.errorMessage, "batch id not found");
+      assertEqual(doc.parsedBody['code'], 404);
+      assertUndefined(doc.parsedBody['nextBatchId']);
+
+      cmd = api + `/${cursorId}`;
+      doc = arango.POST_RAW(cmd, "");
+
+      assertEqual(doc.code, 200);
+      assertEqual(doc.headers['content-type'], contentType);
+      assertFalse(doc.parsedBody['error']);
+      assertEqual(doc.parsedBody['code'], 200);
+      assertFalse(doc.parsedBody['hasMore']);
+      assertUndefined(doc.parsedBody['id']);
+      assertEqual(doc.parsedBody['result'].length, 0);
+      assertFalse(doc.parsedBody['cached']);
+      assertUndefined(doc.parsedBody['id'], cursorId);
+      assertUndefined(doc.parsedBody['nextBatchId']);
+
+      // must kill the cursor explicitly, so we don't need to wait for the
+      // cursor's full TTL
+      arango.DELETE_RAW(api + `/${cursorId}`, "");
+    },
+
+
     test_cursor_stream_request_retriable: function () {
       let cmd = api;
       let body = {"query": `FOR u IN ${cn} RETURN u`, "options": {"stream": true, "allowRetry": true}};
@@ -1522,7 +1622,7 @@ function dealing_with_cursorsSuite_retriable_request_last_batch() {
 
       cmd = api + `/${cursorId}/${nextBatchId}`;
       doc = arango.POST_RAW(cmd, "");
-      
+
       assertEqual(doc.code, 200);
       assertEqual(doc.headers['content-type'], contentType);
       assertEqual(doc.parsedBody['code'], 200);
@@ -1531,7 +1631,7 @@ function dealing_with_cursorsSuite_retriable_request_last_batch() {
       assertUndefined(doc.parsedBody['id'], cursorId);
       assertFalse(doc.parsedBody['cached']);
       assertUndefined(doc.parsedBody['nextBatchId']);
-      
+
       cmd = api + `/${cursorId}/${parseInt(nextBatchId) + 1}`;
       doc = arango.POST_RAW(cmd, "");
 
@@ -1565,9 +1665,91 @@ function dealing_with_cursorsSuite_retriable_request_last_batch() {
       assertUndefined(doc.parsedBody['id']);
       assertFalse(doc.parsedBody['cached']);
       assertUndefined(doc.parsedBody['nextBatchId']);
-      
+
       // must kill the cursor explicitly, so we don't need to wait for the
-      // cursor's full TTL 
+      // cursor's full TTL
+      arango.DELETE_RAW(api + `/${cursorId}`, "");
+    },
+
+    test_cursor_stream_request_non_retriable_next_batch: function () {
+      let cmd = api;
+      let body = {"query": `FOR u IN ${cn} RETURN u`, "options": {"stream": true, "allowRetry": false}};
+      let doc = arango.POST_RAW(cmd, body);
+
+      assertEqual(doc.code, 201);
+      assertEqual(doc.headers['content-type'], contentType);
+      assertFalse(doc.parsedBody['error']);
+      assertEqual(doc.parsedBody['code'], 201);
+      assertEqual(typeof doc.parsedBody['id'], "string");
+      assertMatch(reId, doc.parsedBody['id']);
+      assertTrue(doc.parsedBody['hasMore']);
+      assertEqual(doc.parsedBody['result'].length, 1000);
+      assertFalse(doc.parsedBody['cached']);
+      let cursorId = doc.parsedBody['id'];
+      let nextBatchId = doc.parsedBody['nextBatchId'];
+      assertEqual(nextBatchId, 2);
+
+      cmd = api + `/${cursorId}/${nextBatchId}`;
+      doc = arango.POST_RAW(cmd, "");
+
+      assertEqual(doc.code, 200);
+      assertEqual(doc.headers['content-type'], contentType);
+      assertEqual(doc.parsedBody['code'], 200);
+      assertTrue(doc.parsedBody['hasMore']);
+      assertEqual(doc.parsedBody['result'].length, 1000);
+      assertEqual(doc.parsedBody['id'], cursorId);
+      assertFalse(doc.parsedBody['cached']);
+      nextBatchId = doc.parsedBody['nextBatchId'];
+      assertEqual(nextBatchId, 3);
+
+      cmd = api + `/${cursorId}/${nextBatchId}`;
+      doc = arango.POST_RAW(cmd, "");
+
+      assertEqual(doc.code, 200);
+      assertEqual(doc.headers['content-type'], contentType);
+      assertEqual(doc.parsedBody['code'], 200);
+      assertFalse(doc.parsedBody['hasMore']);
+      assertEqual(doc.parsedBody['result'].length, 1);
+      assertUndefined(doc.parsedBody['id'], cursorId);
+      assertFalse(doc.parsedBody['cached']);
+      assertUndefined(doc.parsedBody['nextBatchId']);
+
+      cmd = api + `/${cursorId}/${parseInt(nextBatchId)}`;
+      doc = arango.POST_RAW(cmd, "");
+
+      assertEqual(doc.code, 404);
+      assertEqual(doc.headers['content-type'], contentType);
+      assertTrue(doc.parsedBody.error);
+      assertEqual(doc.parsedBody.errorNum, 1600);
+      assertEqual(doc.parsedBody.errorMessage, "batch id not found");
+      assertEqual(doc.parsedBody['code'], 404);
+      assertUndefined(doc.parsedBody['nextBatchId']);
+
+      cmd = api + `/${cursorId}/0`;
+      doc = arango.POST_RAW(cmd, "");
+
+      assertEqual(doc.code, 404);
+      assertEqual(doc.headers['content-type'], contentType);
+      assertTrue(doc.parsedBody.error);
+      assertEqual(doc.parsedBody.errorNum, 1600);
+      assertEqual(doc.parsedBody.errorMessage, "batch id not found");
+      assertEqual(doc.parsedBody['code'], 404);
+      assertUndefined(doc.parsedBody['nextBatchId']);
+
+      cmd = api + `/${cursorId}`;
+      doc = arango.POST_RAW(cmd, "");
+
+      assertEqual(doc.code, 200);
+      assertEqual(doc.headers['content-type'], contentType);
+      assertFalse(doc.parsedBody['error']);
+      assertEqual(doc.parsedBody['code'], 200);
+      assertFalse(doc.parsedBody['hasMore']);
+      assertUndefined(doc.parsedBody['id']);
+      assertFalse(doc.parsedBody['cached']);
+      assertUndefined(doc.parsedBody['nextBatchId']);
+
+      // must kill the cursor explicitly, so we don't need to wait for the
+      // cursor's full TTL
       arango.DELETE_RAW(api + `/${cursorId}`, "");
     },
 
@@ -1587,7 +1769,8 @@ function dealing_with_cursorsSuite_retriable_request_last_batch() {
       assertFalse(doc.parsedBody['cached']);
 
       let cursorId = doc.parsedBody['id'];
-      assertUndefined(doc.parsedBody['nextBatchId']);
+      const nextBatchId = doc.parsedBody['nextBatchId'];
+      assertEqual(nextBatchId, 2);
 
       internal.debugSetFailAt("MakeConnectionErrorForRetry");
 
@@ -1598,9 +1781,8 @@ function dealing_with_cursorsSuite_retriable_request_last_batch() {
       assertTrue(doc.error);
 
       internal.debugClearFailAt();
-      // as the `batchId` field starts with 1 for the first batch, we assume the next batch id would be 2 for
-      // the failing request to send another request to retrieve its result, knowing it would fail because
-      // the flag `allowRetry`is false
+      // as we can fetch the next batch id and advance the cursor with /<cursorId>/<nextBatchId>, but can't retry the
+      // latest batch, we try to get the former batch again
       cmd = api + `/${cursorId}/2`;
       doc = arango.POST_RAW(cmd, "");
       assertEqual(doc.code, 400);
@@ -1610,12 +1792,12 @@ function dealing_with_cursorsSuite_retriable_request_last_batch() {
       assertEqual(doc.parsedBody['errorMessage'], 'expecting allowRetry option to be true');
       assertUndefined(doc.parsedBody['id']);
       assertUndefined(doc.parsedBody['nextBatchId']);
-     
+
       // must kill the cursor explicitly, so we don't need to wait for the
-      // cursor's full TTL 
+      // cursor's full TTL
       arango.DELETE_RAW(api + `/${cursorId}`, "");
     },
-    
+
     test_cursor_non_stream_retriable: function () {
       const stmt = db._createStatement({
         query: `FOR u IN ${cn} RETURN u`,
@@ -1640,7 +1822,7 @@ function dealing_with_cursorsSuite_retriable_request_last_batch() {
       assertFalse(cursor.hasNext());
       cursor.dispose();
     },
-    
+
     test_cursor_stream_retriable: function () {
       const stmt = db._createStatement({
         query: `FOR u IN ${cn} RETURN u`,
@@ -1662,7 +1844,7 @@ function dealing_with_cursorsSuite_retriable_request_last_batch() {
       assertFalse(cursor.hasNext());
       cursor.dispose();
     },
-  
+
   };
 }
 


### PR DESCRIPTION
### Scope & Purpose

In batched query results, when executing requests for  `/_api/cursor/<cursorId>/<batchId>`, removed the restriction that the user would only be able to fetch the next batch using the next batch id in `<batchId>` if the query option `allowRetry` was set to true, but maintained the restriction that the user can only retrieve the latest batch if the query option `allowRetry` is set to true.

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [x] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [x] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [x] Backports
  - [x] Backport for 3.11: https://github.com/arangodb/arangodb/pull/19009

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [x] GitHub issue / Jira ticket: not it, but related to https://arangodb.atlassian.net/browse/APM-592
- [ ] Design document: 

