### PR TITLE
disable `parallelize-gather` optimizer rules for some cases

### DIFF
--- a/arangod/Aql/OptimizerRules.cpp
+++ b/arangod/Aql/OptimizerRules.cpp
@@ -8001,8 +8001,11 @@ namespace {
 /// @brief is the node parallelizable?
 struct ParallelizableFinder final
     : public WalkerWorker<ExecutionNode, WalkerUniqueness::NonUnique> {
-  bool _isParallelizable = true;
-  bool _hasParallelTraversal = false;
+  bool const _parallelizeWrites;
+  bool _isParallelizable;
+
+  explicit ParallelizableFinder(bool parallelizeWrites)
+      : _parallelizeWrites(parallelizeWrites), _isParallelizable(true) {}
 
   ~ParallelizableFinder() = default;
 
@@ -8011,12 +8014,9 @@ struct ParallelizableFinder final
   }
 
   bool before(ExecutionNode* node) override final {
-    if ((node->getType() == ExecutionNode::SCATTER ||
-         node->getType() == ExecutionNode::DISTRIBUTE) &&
-        _hasParallelTraversal) {
-      // we cannot parallelize the gather if we have a parallel traversal which
-      // itself depends again on a scatter/distribute node, because we are
-      // currently lacking synchronization for that scatter/distribute node.
+    if (node->getType() == ExecutionNode::SCATTER ||
+        node->getType() == ExecutionNode::GATHER ||
+        node->getType() == ExecutionNode::DISTRIBUTE) {
       _isParallelizable = false;
       return true;  // true to abort the whole walking process
     }
@@ -8025,11 +8025,21 @@ struct ParallelizableFinder final
         node->getType() == ExecutionNode::SHORTEST_PATH ||
         node->getType() == ExecutionNode::ENUMERATE_PATHS) {
       auto* gn = ExecutionNode::castTo<GraphNode*>(node);
-      _hasParallelTraversal |= gn->options()->parallelism() > 1;
       if (!gn->isLocalGraphNode()) {
         _isParallelizable = false;
         return true;  // true to abort the whole walking process
       }
+    }
+
+    // write operations of type REMOVE, REPLACE and UPDATE
+    // can be parallelized, provided the rest of the plan
+    // does not prohibit this
+    if (node->isModificationNode() &&
+        (!_parallelizeWrites || (node->getType() != ExecutionNode::REMOVE &&
+                                 node->getType() != ExecutionNode::REPLACE &&
+                                 node->getType() != ExecutionNode::UPDATE))) {
+      _isParallelizable = false;
+      return true;  // true to abort the whole walking process
     }
 
     // continue inspecting
@@ -8038,13 +8048,13 @@ struct ParallelizableFinder final
 };
 
 /// no modification nodes, ScatterNodes etc
-bool isParallelizable(GatherNode* node) {
+bool isParallelizable(GatherNode* node, bool parallelizeWrites) {
   if (node->parallelism() == GatherNode::Parallelism::Serial) {
     // node already defined to be serial
     return false;
   }
 
-  ParallelizableFinder finder;
+  ParallelizableFinder finder(parallelizeWrites);
   for (ExecutionNode* e : node->getDependencies()) {
     e->walk(finder);
     if (!finder._isParallelizable) {
@@ -8350,21 +8360,58 @@ void arangodb::aql::parallelizeGatherRule(Optimizer* opt,
 
   bool modified = false;
 
+  // find all GatherNodes in the main query, starting from the query's root node
+  // (the node most south when looking at the query execution plan).
+  //
+  // for now, we effectively stop right after the first GatherNode we found,
+  // regardless of whether we can make that node use parallelism or not. the
+  // reason we have to stop here is that if we have multiple query snippets on a
+  // server they will use the same underlying transaction object. however,
+  // transactions are not thread-safe right now, so we must avoid any
+  // parallelism when there can be another snippet with the same transaction on
+  // the same server.
+  //
+  // for example consider the following query, joining the shards of two
+  // collections on 2 database servers:
+  //
+  //   (4)      DBS1                            DBS2               database
+  //        users, shard 1                 users, shard 2          servers
+  //       --------------------------------------------------------
+  //   (3)                      Gather                             coordinator
+  //       --------------------------------------------------------
+  //   (2)      DBS1            Scatter         DBS2               database
+  //       orders, shard 1                orders, shard 2          servers
+  //       --------------------------------------------------------
+  //   (1)                      Gather                             coordinator
+  //
+  // the query starts with a GatherNode (1). if we make that parallel, then it
+  // will ask the shards of `orders` on the database servers in parallel (2). So
+  // there can be 2 threads in (2), on different servers. all is fine until
+  // here. however, if the thread for DBS1 fetches upstream data from the
+  // coordinator (3), then the coordinator may reach out to DBS2 to get more
+  // data from the `users` collection (4). so one thread will be on DBS2 and
+  // using the transaction. at the very same time we already have another thread
+  // working on the same server on (2). they are using the same transaction
+  // object, which currently is not thread-safe. we need to avoid any such
+  // situation, and thus we cannot make any of the GatherNodes thread-safe here.
+  // the only case in which we currently can employ parallelization is when
+  // there is only a single GatherNode. all other restrictions for
+  // parallelization (e.g. no DistributeNodes around) still apply.
   containers::SmallVector<ExecutionNode*, 8> nodes;
-  containers::SmallVector<ExecutionNode*, 8> graphNodes;
   plan->findNodesOfType(nodes, EN::GATHER, true);
 
-  for (auto node : nodes) {
-    GatherNode* gn = ExecutionNode::castTo<GatherNode*>(node);
+  if (nodes.size() == 1 && !plan->contains(EN::DISTRIBUTE) &&
+      !plan->contains(EN::SCATTER)) {
+    constexpr bool parallelizeWrites = true;
+    GatherNode* gn = ExecutionNode::castTo<GatherNode*>(nodes[0]);
 
-    if (!gn->isInSubquery() && isParallelizable(gn)) {
+    if (!gn->isInSubquery() && isParallelizable(gn, parallelizeWrites)) {
       // find all graph nodes and make sure that they all are using satellite
-      graphNodes.clear();
+      nodes.clear();
       plan->findNodesOfType(
-          graphNodes, {EN::TRAVERSAL, EN::SHORTEST_PATH, EN::ENUMERATE_PATHS},
-          true);
+          nodes, {EN::TRAVERSAL, EN::SHORTEST_PATH, EN::ENUMERATE_PATHS}, true);
       bool const allSatellite =
-          std::all_of(graphNodes.begin(), graphNodes.end(), [](auto n) {
+          std::all_of(nodes.begin(), nodes.end(), [](auto n) {
             GraphNode* graphNode = ExecutionNode::castTo<GraphNode*>(n);
             return graphNode->isLocalGraphNode();
           });

--- a/tests/js/server/aql/aql-optimizer-rule-parallelize-gather-cluster.js
+++ b/tests/js/server/aql/aql-optimizer-rule-parallelize-gather-cluster.js
@@ -76,7 +76,11 @@ function optimizerRuleTestSuite () {
     },
 
     testRuleNoEffect : function () {
-      let queries = [
+      let queries = [  
+        "FOR doc IN " + cn + " LIMIT 10 UPDATE doc WITH {} IN " + cn,
+        "FOR i IN 1..1000 INSERT {} IN " + cn,
+        "FOR doc1 IN " + cn + " FOR doc2 IN " + cn + " FILTER doc1._key == doc2._key RETURN doc1",
+        "FOR doc1 IN " + cn + " FOR doc2 IN " + cn + " FOR doc3 IN " + cn + " FILTER doc1._key == doc2._key FILTER doc2._key == doc3._key RETURN doc1",
         "FOR i IN 1..100 LET sub = (FOR doc IN " + cn + " FILTER doc.value == i RETURN doc) RETURN sub",
         "LET sub = (FOR doc IN " + cn + " FILTER doc.value == 12 LIMIT 10 RETURN doc) FOR doc IN sub RETURN doc",
         "FOR v, e, p IN 1..1 OUTBOUND '" + cn + "/1' " + en + " RETURN p",
@@ -104,21 +108,22 @@ function optimizerRuleTestSuite () {
         "FOR doc IN " + cn + " SORT doc.value1 LIMIT 1000 RETURN doc",
         "FOR doc IN " + cn + " SORT doc.value1 LIMIT 1000, 1000 RETURN doc",
         "FOR i IN 1..1000 FOR doc IN " + cn + " FILTER doc.value == i RETURN doc",
-        "FOR doc IN " + cn + " LIMIT 10 UPDATE doc WITH {} IN " + cn,
-        "FOR i IN 1..1000 INSERT {} IN " + cn,
-        "FOR doc1 IN " + cn + " FOR doc2 IN " + cn + " FILTER doc1._key == doc2._key RETURN doc1",
-        "FOR doc1 IN " + cn + " FOR doc2 IN " + cn + " FOR doc3 IN " + cn + " FILTER doc1._key == doc2._key FILTER doc2._key == doc3._key RETURN doc1",
-        "FOR doc IN " + cn + " REMOVE doc IN " + cn,
-        "FOR doc IN " + cn + " REMOVE doc._key IN " + cn,
-        "FOR doc IN " + cn + " REPLACE doc WITH {} IN " + cn,
-        "FOR doc IN " + cn + " REPLACE doc WITH {a: 1} IN " + cn,
-        "FOR doc IN " + cn + " REPLACE doc._key WITH {} IN " + cn,
-        "FOR doc IN " + cn + " REPLACE doc._key WITH {a:1} IN " + cn,
-        "FOR doc IN " + cn + " UPDATE doc WITH {} IN " + cn,
-        "FOR doc IN " + cn + " UPDATE doc WITH {a: 1} IN " + cn,
-        "FOR doc IN " + cn + " UPDATE doc._key WITH {} IN " + cn,
-        "FOR doc IN " + cn + " UPDATE doc._key WITH {a:1} IN " + cn,
       ];
+
+      if (require("internal").options()["query.parallelize-gather-writes"]) {
+        queries.concat([
+          "FOR doc IN " + cn + " REMOVE doc IN " + cn,
+          "FOR doc IN " + cn + " REMOVE doc._key IN " + cn,
+          "FOR doc IN " + cn + " REPLACE doc WITH {} IN " + cn,
+          "FOR doc IN " + cn + " REPLACE doc WITH {a: 1} IN " + cn,
+          "FOR doc IN " + cn + " REPLACE doc._key WITH {} IN " + cn,
+          "FOR doc IN " + cn + " REPLACE doc._key WITH {a:1} IN " + cn,
+          "FOR doc IN " + cn + " UPDATE doc WITH {} IN " + cn,
+          "FOR doc IN " + cn + " UPDATE doc WITH {a: 1} IN " + cn,
+          "FOR doc IN " + cn + " UPDATE doc._key WITH {} IN " + cn,
+          "FOR doc IN " + cn + " UPDATE doc._key WITH {a:1} IN " + cn,
+        ]);
+      }
 
       queries.forEach(function(query) {
         // the one rule is singled out here because it leads to a different execution
@@ -137,17 +142,22 @@ function optimizerRuleTestSuite () {
         "FOR doc IN " + cn + " SORT doc.value1 RETURN doc",
         "FOR doc IN " + cn + " SORT doc.value1 LIMIT 1000 RETURN doc",
         "FOR doc IN " + cn + " SORT doc.value1 LIMIT 1000, 1000 RETURN doc",
-        "FOR doc IN " + cn + " REMOVE doc IN " + cn,
-        "FOR doc IN " + cn + " REMOVE doc._key IN " + cn,
-        "FOR doc IN " + cn + " REPLACE doc WITH {} IN " + cn,
-        "FOR doc IN " + cn + " REPLACE doc WITH {a: 1} IN " + cn,
-        "FOR doc IN " + cn + " REPLACE doc._key WITH {} IN " + cn,
-        "FOR doc IN " + cn + " REPLACE doc._key WITH {a:1} IN " + cn,
-        "FOR doc IN " + cn + " UPDATE doc WITH {} IN " + cn,
-        "FOR doc IN " + cn + " UPDATE doc WITH {a: 1} IN " + cn,
-        "FOR doc IN " + cn + " UPDATE doc._key WITH {} IN " + cn,
-        "FOR doc IN " + cn + " UPDATE doc._key WITH {a:1} IN " + cn,
       ];
+
+      if (require("internal").options()["query.parallelize-gather-writes"]) {
+        queries.concat([
+          "FOR doc IN " + cn + " REMOVE doc IN " + cn,
+          "FOR doc IN " + cn + " REMOVE doc._key IN " + cn,
+          "FOR doc IN " + cn + " REPLACE doc WITH {} IN " + cn,
+          "FOR doc IN " + cn + " REPLACE doc WITH {a: 1} IN " + cn,
+          "FOR doc IN " + cn + " REPLACE doc._key WITH {} IN " + cn,
+          "FOR doc IN " + cn + " REPLACE doc._key WITH {a:1} IN " + cn,
+          "FOR doc IN " + cn + " UPDATE doc WITH {} IN " + cn,
+          "FOR doc IN " + cn + " UPDATE doc WITH {a: 1} IN " + cn,
+          "FOR doc IN " + cn + " UPDATE doc._key WITH {} IN " + cn,
+          "FOR doc IN " + cn + " UPDATE doc._key WITH {a:1} IN " + cn,
+        ]);
+      }
 
       queries.forEach(function(query) {
         let result = AQL_EXPLAIN(query,);


### PR DESCRIPTION
### Scope & Purpose

Enterprise companion PR: https://github.com/arangodb/enterprise/pull/1269

disable `parallelize-gather` optimizer rules for some cases in which it can lead to "query id ... not found" errors. this change reverts the behavior of the `parallelize-gather` optimizer rule to the same state it had in 3.10. the rule will be disabled for some queries for which it was previously enabled only in devel/3.11. the rule will be enabled again for these queries with a separate PR that will contain a fix for the "query id ... not found" error and reenable the rule.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: -
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -

#### Related Information

- [ ] Docs PR: 
- [x] Enterprise PR: https://github.com/arangodb/enterprise/pull/1269
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 