### PR TITLE
Bug-Fix/FE-211: Allow gravatars for users

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 devel
 -----
 
+* FE-211: Allow admins to edit gravatar email
+
 * MDS-1098: In 3.10 we have introduced an optimization on Traversals to pull
   post-filter conditions into the traversal-statements, like the following:
 

--- a/js/apps/system/_admin/aardvark/APP/frontend/js/views/userManagementView.js
+++ b/js/apps/system/_admin/aardvark/APP/frontend/js/views/userManagementView.js
@@ -1,6 +1,6 @@
 /* jshint browser: true */
 /* jshint unused: false */
-/* global frontendConfig, window, Backbone, $, arangoHelper, templateEngine, Joi */
+/* global frontendConfig, window, Backbone, $, arangoHelper, templateEngine, Joi, _ */
 (function () {
   'use strict';
 
@@ -178,8 +178,12 @@
         user: userName,
         passwd: userPassword,
         active: status,
-        extra: {name: name, img: profileImg}
+        extra: {name: name}
       };
+
+      if(!_.isEmpty(profileImg)) {
+        options.extra.img = profileImg;
+      }
 
       if (frontendConfig.isEnterprise && $('#newRole').is(':checked')) {
         options.user = ':role:' + userName;

--- a/js/apps/system/_admin/aardvark/APP/frontend/js/views/userManagementView.js
+++ b/js/apps/system/_admin/aardvark/APP/frontend/js/views/userManagementView.js
@@ -154,10 +154,21 @@
       this.createCreateUserModal();
     },
 
+    parseImgString: function (img) {
+      // if already md5
+      if (img.indexOf('@') === -1) {
+        return img;
+      }
+      // else generate md5
+      return CryptoJS.MD5(img).toString();
+    },
+
     submitCreateUser: function () {
       var self = this;
       var userName = $('#newUsername').val();
       var name = $('#newName').val();
+      var profileImg = $('#profileImg').val();
+      profileImg = this.parseImgString(profileImg);
       var userPassword = $('#newPassword').val();
       var status = $('#newStatus').is(':checked');
       if (!this.validateUserInfo(name, userName, userPassword, status)) {
@@ -167,7 +178,7 @@
         user: userName,
         passwd: userPassword,
         active: status,
-        extra: {name: name}
+        extra: {name: name, img: profileImg}
       };
 
       if (frontendConfig.isEnterprise && $('#newRole').is(':checked')) {
@@ -268,6 +279,19 @@
       tableContent.push(
         window.modalView.createTextEntry('newName', 'Name', '', false, 'Name', false)
       );
+      if(frontendConfig.db === '_system') {
+        tableContent.push(
+          window.modalView.createTextEntry(
+            'profileImg',
+            'Gravatar account (Mail)',
+            '',
+            'Mailaddress or its md5 representation of your gravatar account.' +
+            'The address will be converted into a md5 string. ' +
+            'Only the md5 string will be stored, not the mailaddress.',
+            'myAccount(at)gravatar.com'
+          )
+        );
+      }
       tableContent.push(
         window.modalView.createPasswordEntry('newPassword', 'Password', '', false, '', false)
       );

--- a/js/apps/system/_admin/aardvark/APP/frontend/js/views/userView.js
+++ b/js/apps/system/_admin/aardvark/APP/frontend/js/views/userView.js
@@ -214,7 +214,6 @@
           title: 'Save',
           type: window.modalView.buttons.SUCCESS,
           callback: this.submitEditUser.bind(this, username)
-          //callback: this.submitEditUser.bind(this)
         }
       );
 

--- a/js/apps/system/_admin/aardvark/APP/frontend/js/views/userView.js
+++ b/js/apps/system/_admin/aardvark/APP/frontend/js/views/userView.js
@@ -148,19 +148,11 @@
     },
 
     createEditUserModal: function (username, name, active) {
-      console.log("window.App.userCollection.activeUser: ", window.App.userCollection.activeUser);
-      console.log("frontendConfig.db: ", frontendConfig.db);
       var isAdmin = frontendConfig.db === '_system';
-      console.log("isAdmin: ", isAdmin);
       var url = arangoHelper.databaseUrl('/_api/user/' +
         encodeURIComponent(window.App.userCollection.activeUser || "root") +
         '/database/' + encodeURIComponent(frontendConfig.db));
-      console.log("username: ", username);
-      console.log("self: ", self);
-      console.log("this.currentUser.get('user'): ", this.currentUser.get('user'));
-      console.log("Lets get the access for the user ", username);
-      //var userAccess = db.getUserAccessLevel(username, {database: "_system"});
-      //console.log("userAccess: ", userAccess);
+
       var buttons, tableContent;
       tableContent = [
         {
@@ -183,7 +175,7 @@
           id: 'editStatus'
         }
       ];
-      console.log("this.currentUser.get('extra').img: ", this.currentUser.get('extra').img);
+
       if(frontendConfig.db === '_system') {
         tableContent.push(
           window.modalView.createTextEntry(
@@ -256,16 +248,12 @@
     },
 
     submitEditCurrentUserProfile: function () {
-      console.log("IN FUNCTION: submitEditCurrentUserProfile");
       var self = this;
       var name = $('#editCurrentName').val();
       var img = $('#editCurrentUserProfileImg').val();
       img = this.parseImgString(img);
 
-      // THIS "callback"-function probably has to go to line 345 !!!!! Viking
       var callback = function (error, data) {
-        console.log("data: ", data);
-
         if (error) {
           arangoHelper.arangoError('User', 'Could not edit user settings');
         } else {
@@ -282,7 +270,6 @@
             } else {
               extra.img = null;
             }
-            console.log("extra: ", extra);
             self.currentUser.set('extra', extra);
 
             // rerender navigation containing userBarView
@@ -292,8 +279,6 @@
           arangoHelper.arangoNotification('User', 'Changes confirmed.');
         }
       };
-
-      console.log("callback: ", callback);
 
       this.currentUser.setExtras(name, img, callback);
       window.modalView.hide();
@@ -331,18 +316,10 @@
     },
 
     submitEditUser: function (username) {
-    //submitEditUser: function () {
-      console.log("IN FUNCTION: submitEditUser");
-      console.log(this);
       var name = $('#editName').val();
-      console.log("name: ", name);
       var status = $('#editStatus').is(':checked');
-      console.log("status: ", status);
-
       var img = $('#editCurrentUserProfileImg').val();
-      console.log("img (1): ", img);
       img = this.parseImgString(img);
-      console.log("img (2): ", img);
 
 
       if (!this.validateStatus(status)) {
@@ -350,42 +327,22 @@
         return;
       }
       var user = this.collection.findWhere({'user': username});
-      console.log("user1: ", user);
 
-      var callback = function (error, user, data) {
-        if (error) {
-          arangoHelper.arangoError('User', 'Could not edit user settings');
-        } else {
-          // THIS probably has to go to line 345 !!!!! Viking
-          if (data) {
-            //var extra = self.currentUser.get('extra');
-            var extra = user.get('extra');
-            if (data.extra && data.extra.name) {
-              extra.name = data.extra.name;
-            } else {
-              extra.name = null;
-            }
+      var generateUserObj = function (user, name, img, status) {
+        var currentExtraData = user.get('extra');
 
-            if (data.extra && data.extra.img) {
-              extra.img = data.extra.img;
-            } else {
-              extra.img = null;
-            }
-            user.set('extra', extra);
+        var userObj = {};
+        currentExtraData.name = name;
+        currentExtraData.img = img;
+        userObj.extra = currentExtraData;
+        userObj.active = status;
 
-            // rerender navigation containing userBarView
-            window.App.naviView.render();
-          }
+        return userObj;
+      }
 
-          arangoHelper.arangoNotification('User', 'Changes confirmed.');
-        }
-      };
-      
-      this.currentUser.setExtras(name, img, callback);
+      var userObj = generateUserObj(user, name, img, status);
 
-      console.log("user2: ", user);
-
-      user.save({'extra': {'name': name}, 'active': status}, {
+      user.save(userObj, {
         type: 'PATCH',
         success: function () {
           arangoHelper.arangoNotification('User', user.get('user') + ' updated.');

--- a/js/apps/system/_admin/aardvark/APP/frontend/js/views/userView.js
+++ b/js/apps/system/_admin/aardvark/APP/frontend/js/views/userView.js
@@ -148,6 +148,19 @@
     },
 
     createEditUserModal: function (username, name, active) {
+      console.log("window.App.userCollection.activeUser: ", window.App.userCollection.activeUser);
+      console.log("frontendConfig.db: ", frontendConfig.db);
+      var isAdmin = frontendConfig.db === '_system';
+      console.log("isAdmin: ", isAdmin);
+      var url = arangoHelper.databaseUrl('/_api/user/' +
+        encodeURIComponent(window.App.userCollection.activeUser || "root") +
+        '/database/' + encodeURIComponent(frontendConfig.db));
+      console.log("username: ", username);
+      console.log("self: ", self);
+      console.log("this.currentUser.get('user'): ", this.currentUser.get('user'));
+      console.log("Lets get the access for the user ", username);
+      //var userAccess = db.getUserAccessLevel(username, {database: "_system"});
+      //console.log("userAccess: ", userAccess);
       var buttons, tableContent;
       tableContent = [
         {
@@ -170,6 +183,20 @@
           id: 'editStatus'
         }
       ];
+      console.log("this.currentUser.get('extra').img: ", this.currentUser.get('extra').img);
+      if(frontendConfig.db === '_system') {
+        tableContent.push(
+          window.modalView.createTextEntry(
+            'editCurrentUserProfileImg',
+            'Gravatar account (Mail)',
+            this.currentUser.get('extra').img,
+            'Mailaddress or its md5 representation of your gravatar account.' +
+            'The address will be converted into a md5 string. ' +
+            'Only the md5 string will be stored, not the mailaddress.',
+            'myAccount(at)gravatar.com'
+          )
+        );
+      }
       buttons = [];
       buttons.push(
         {
@@ -200,6 +227,7 @@
           title: 'Save',
           type: window.modalView.buttons.SUCCESS,
           callback: this.submitEditUser.bind(this, username)
+          //callback: this.submitEditUser.bind(this)
         }
       );
 
@@ -228,12 +256,16 @@
     },
 
     submitEditCurrentUserProfile: function () {
+      console.log("IN FUNCTION: submitEditCurrentUserProfile");
       var self = this;
       var name = $('#editCurrentName').val();
       var img = $('#editCurrentUserProfileImg').val();
       img = this.parseImgString(img);
 
+      // THIS "callback"-function probably has to go to line 345 !!!!! Viking
       var callback = function (error, data) {
+        console.log("data: ", data);
+
         if (error) {
           arangoHelper.arangoError('User', 'Could not edit user settings');
         } else {
@@ -250,6 +282,7 @@
             } else {
               extra.img = null;
             }
+            console.log("extra: ", extra);
             self.currentUser.set('extra', extra);
 
             // rerender navigation containing userBarView
@@ -259,6 +292,8 @@
           arangoHelper.arangoNotification('User', 'Changes confirmed.');
         }
       };
+
+      console.log("callback: ", callback);
 
       this.currentUser.setExtras(name, img, callback);
       window.modalView.hide();
@@ -296,14 +331,60 @@
     },
 
     submitEditUser: function (username) {
+    //submitEditUser: function () {
+      console.log("IN FUNCTION: submitEditUser");
+      console.log(this);
       var name = $('#editName').val();
+      console.log("name: ", name);
       var status = $('#editStatus').is(':checked');
+      console.log("status: ", status);
+
+      var img = $('#editCurrentUserProfileImg').val();
+      console.log("img (1): ", img);
+      img = this.parseImgString(img);
+      console.log("img (2): ", img);
+
 
       if (!this.validateStatus(status)) {
         $('#editStatus').closest('th').css('backgroundColor', 'red');
         return;
       }
       var user = this.collection.findWhere({'user': username});
+      console.log("user1: ", user);
+
+      var callback = function (error, user, data) {
+        if (error) {
+          arangoHelper.arangoError('User', 'Could not edit user settings');
+        } else {
+          // THIS probably has to go to line 345 !!!!! Viking
+          if (data) {
+            //var extra = self.currentUser.get('extra');
+            var extra = user.get('extra');
+            if (data.extra && data.extra.name) {
+              extra.name = data.extra.name;
+            } else {
+              extra.name = null;
+            }
+
+            if (data.extra && data.extra.img) {
+              extra.img = data.extra.img;
+            } else {
+              extra.img = null;
+            }
+            user.set('extra', extra);
+
+            // rerender navigation containing userBarView
+            window.App.naviView.render();
+          }
+
+          arangoHelper.arangoNotification('User', 'Changes confirmed.');
+        }
+      };
+      
+      this.currentUser.setExtras(name, img, callback);
+
+      console.log("user2: ", user);
+
       user.save({'extra': {'name': name}, 'active': status}, {
         type: 'PATCH',
         success: function () {

--- a/js/apps/system/_admin/aardvark/APP/frontend/js/views/userView.js
+++ b/js/apps/system/_admin/aardvark/APP/frontend/js/views/userView.js
@@ -148,11 +148,6 @@
     },
 
     createEditUserModal: function (username, name, active) {
-      var isAdmin = frontendConfig.db === '_system';
-      var url = arangoHelper.databaseUrl('/_api/user/' +
-        encodeURIComponent(window.App.userCollection.activeUser || "root") +
-        '/database/' + encodeURIComponent(frontendConfig.db));
-
       var buttons, tableContent;
       tableContent = [
         {


### PR DESCRIPTION
### Scope & Purpose

Admins couldn't edit gravatars for users. Only the user itself was able to edit his gravatar. This PR displays the gravatar field when creating a new user or an admin is editing an existing user.

- [x] :hankey: Bugfix

### Checklist

- [x] Manually tested
- [x] :book: CHANGELOG entry made
- [ ] Backports
  - [ ] Backport for 3.11: ToDo
  - [ ] Backport for 3.10: ToDo
  - [ ] Backport for 3.9: ?
  - [ ] Backport for 3.8: ?

#### Related Information

- [x] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/FE-211

