### PR TITLE
[BTS-1400] Fix query not found issue with parallel-gather

### DIFF
--- a/arangod/Aql/QueryRegistry.cpp
+++ b/arangod/Aql/QueryRegistry.cpp
@@ -30,12 +30,14 @@
 #include "Basics/ReadLocker.h"
 #include "Basics/WriteLocker.h"
 #include "Basics/system-functions.h"
+#include "Basics/voc-errors.h"
 #include "Cluster/CallbackGuard.h"
 #include "Cluster/ServerState.h"
 #include "Cluster/TraverserEngine.h"
 #include "Futures/Future.h"
 #include "Logger/LogMacros.h"
 #include "Logger/Logger.h"
+#include "Scheduler/SchedulerFeature.h"
 #include "Transaction/Methods.h"
 #include "Transaction/Status.h"
 
@@ -135,7 +137,8 @@ void QueryRegistry::insertQuery(std::shared_ptr<ClusterQuery> query, double ttl,
 }
 
 /// @brief open
-void* QueryRegistry::openEngine(EngineId id, EngineType type) {
+ResultT<void*> QueryRegistry::openEngine(EngineId id, EngineType type,
+                                         EngineCallback callback) {
   LOG_TOPIC("8c204", DEBUG, arangodb::Logger::AQL)
       << "trying to open engine with id " << id;
   // std::cout << "Taking out query with ID " << id << std::endl;
@@ -145,7 +148,7 @@ void* QueryRegistry::openEngine(EngineId id, EngineType type) {
   if (it == _engines.end()) {
     LOG_TOPIC("c3ae4", DEBUG, arangodb::Logger::AQL)
         << "Found no engine with id " << id;
-    return nullptr;
+    return {TRI_ERROR_QUERY_NOT_FOUND};
   }
 
   EngineInfo& ei = it->second;
@@ -153,21 +156,23 @@ void* QueryRegistry::openEngine(EngineId id, EngineType type) {
   if (ei._type != type) {
     LOG_TOPIC("c3af5", DEBUG, arangodb::Logger::AQL)
         << "Engine with id " << id << " has other type";
-    return nullptr;
+    return {TRI_ERROR_QUERY_NOT_FOUND};
   }
 
   if (ei._isOpen) {
     LOG_TOPIC("7c2a3", DEBUG, arangodb::Logger::AQL)
         << "Engine with id " << id << " is already open";
-    THROW_ARANGO_EXCEPTION_MESSAGE(
-        TRI_ERROR_LOCKED, "query with given vocbase and id is already open");
+    if (callback) {
+      ei._waitingCallbacks.emplace_back(std::move(callback));
+    }
+    return {TRI_ERROR_LOCKED};
   }
 
   ei._isOpen = true;
   if (ei._queryInfo) {
     if (ei._queryInfo->_expires == 0 || ei._queryInfo->_finished) {
       ei._isOpen = false;
-      return nullptr;
+      return {TRI_ERROR_QUERY_NOT_FOUND};
     }
     TRI_ASSERT(ei._queryInfo->_expires != 0);
     ei._queryInfo->_expires = TRI_microtime() + ei._queryInfo->_timeToLive;
@@ -182,7 +187,7 @@ void* QueryRegistry::openEngine(EngineId id, EngineType type) {
         << "opening engine " << id << ", no query";
   }
 
-  return ei._engine;
+  return {ei._engine};
 }
 
 /// @brief close
@@ -214,6 +219,7 @@ void QueryRegistry::closeEngine(EngineId engineId) {
     }
 
     ei._isOpen = false;
+    ei.scheduleCallback();
 
     if (ei._queryInfo) {
       TRI_ASSERT(ei._queryInfo->_numOpen > 0);
@@ -604,3 +610,22 @@ QueryRegistry::QueryInfo::QueryInfo(ErrorCode errorCode, double ttl)
       _isTombstone(true) {}
 
 QueryRegistry::QueryInfo::~QueryInfo() = default;
+
+QueryRegistry::EngineInfo::~EngineInfo() {
+  // TODO - can we guarantee this?
+  TRI_ASSERT(_waitingCallbacks.empty());
+  while (!_waitingCallbacks.empty()) {
+    scheduleCallback();
+  }
+}
+
+void QueryRegistry::EngineInfo::scheduleCallback() {
+  if (!_waitingCallbacks.empty()) {
+    // we have at least one request handler waiting for this engine.
+    // schedule the callback to be executed so request handler can continue
+    auto callback = std::move(_waitingCallbacks.front());
+    _waitingCallbacks.pop_front();
+    SchedulerFeature::SCHEDULER->queue(RequestLane::INTERNAL_LOW,
+                                       std::move(callback));
+  }
+}

--- a/arangod/Aql/QueryRegistry.h
+++ b/arangod/Aql/QueryRegistry.h
@@ -86,13 +86,7 @@ class QueryRegistry {
     return static_cast<ExecutionEngine*>(res.get());
   }
 
-  traverser::BaseEngine* openGraphEngine(EngineId eid) {
-    auto res = openEngine(eid, EngineType::Graph, {});
-    if (res.fail()) {
-      return nullptr;
-    }
-    return static_cast<traverser::BaseEngine*>(res.get());
-  }
+  traverser::BaseEngine* openGraphEngine(EngineId eid);
 
   /// @brief close, return a query to the registry, if the query is not found,
   /// an exception is thrown. If the ttl is negative (the default is), the

--- a/arangod/Aql/QueryRegistry.h
+++ b/arangod/Aql/QueryRegistry.h
@@ -26,10 +26,12 @@
 #include "Aql/types.h"
 #include "Basics/Common.h"
 #include "Basics/ErrorCode.h"
+#include "Basics/ResultT.h"
 #include "Basics/ReadWriteLock.h"
 #include "Cluster/CallbackGuard.h"
 #include "Futures/Promise.h"
 
+#include <deque>
 #include <unordered_map>
 
 namespace arangodb {
@@ -47,6 +49,8 @@ class QueryRegistry {
 
  public:
   enum class EngineType : uint8_t { Execution = 1, Graph = 2 };
+
+  using EngineCallback = std::function<void()>;
 
   /// @brief insert, this inserts the query <query> for the vocbase <vocbase>
   /// and the id <id> into the registry. It is in error if there is already
@@ -71,15 +75,23 @@ class QueryRegistry {
   /// Note that an open query will not expire, so users should please
   /// protect against leaks. If an already open query is found, an exception
   /// is thrown.
-  void* openEngine(EngineId eid, EngineType type);
-  ExecutionEngine* openExecutionEngine(EngineId eid) {
-    return static_cast<ExecutionEngine*>(
-        openEngine(eid, EngineType::Execution));
+  ResultT<void*> openEngine(EngineId eid, EngineType type,
+                            EngineCallback callback);
+  ResultT<ExecutionEngine*> openExecutionEngine(EngineId eid,
+                                                EngineCallback callback) {
+    auto res = openEngine(eid, EngineType::Execution, std::move(callback));
+    if (res.fail()) {
+      return std::move(res).result();
+    }
+    return static_cast<ExecutionEngine*>(res.get());
   }
 
   traverser::BaseEngine* openGraphEngine(EngineId eid) {
-    return static_cast<traverser::BaseEngine*>(
-        openEngine(eid, EngineType::Graph));
+    auto res = openEngine(eid, EngineType::Graph, {});
+    if (res.fail()) {
+      return nullptr;
+    }
+    return static_cast<traverser::BaseEngine*>(res.get());
   }
 
   /// @brief close, return a query to the registry, if the query is not found,
@@ -183,10 +195,18 @@ class QueryRegistry {
           _type(EngineType::Graph),
           _isOpen(false) {}
 
+    ~EngineInfo();
+
+    void scheduleCallback();
+
     void* _engine;
     QueryInfo* _queryInfo;
     const EngineType _type;
     bool _isOpen;
+
+    // list of callbacks from handlers that are waiting for the engine to become
+    // available
+    std::deque<EngineCallback> _waitingCallbacks;
   };
 
   using QueryInfoMap = std::unordered_map<QueryId, std::unique_ptr<QueryInfo>>;

--- a/arangod/Aql/RestAqlHandler.cpp
+++ b/arangod/Aql/RestAqlHandler.cpp
@@ -369,7 +369,8 @@ RestStatus RestAqlHandler::useQuery(std::string const& operation,
   }
 
   if (!_engine) {  // the PUT verb
-    // TRI_ASSERT(this->state() == RestHandler::HandlerState::EXECUTE);
+    TRI_ASSERT(this->state() == RestHandler::HandlerState::EXECUTE ||
+               this->state() == RestHandler::HandlerState::PAUSED);
 
     auto res = findEngine(idString);
     if (res.fail()) {
@@ -503,7 +504,6 @@ RestStatus RestAqlHandler::continueExecute() {
   if (type == rest::RequestType::PUT) {
     // This cannot be changed!
     TRI_ASSERT(suffixes.size() == 2);
-    // TRI_ASSERT(_engine != nullptr);
     return useQuery(suffixes[0], suffixes[1]);
   } else if (type == rest::RequestType::DELETE_REQ && suffixes[0] == "finish") {
     return RestStatus::DONE;  // uses futures

--- a/arangod/Aql/RestAqlHandler.cpp
+++ b/arangod/Aql/RestAqlHandler.cpp
@@ -370,7 +370,7 @@ RestStatus RestAqlHandler::useQuery(std::string const& operation,
 
   if (!_engine) {  // the PUT verb
     TRI_ASSERT(this->state() == RestHandler::HandlerState::EXECUTE ||
-               this->state() == RestHandler::HandlerState::PAUSED);
+               this->state() == RestHandler::HandlerState::CONTINUED);
 
     auto res = findEngine(idString);
     if (res.fail()) {

--- a/arangod/Aql/RestAqlHandler.cpp
+++ b/arangod/Aql/RestAqlHandler.cpp
@@ -43,6 +43,7 @@
 #include "Cluster/RebootTracker.h"
 #include "Cluster/ServerState.h"
 #include "Cluster/TraverserEngine.h"
+#include "GeneralServer/RestHandler.h"
 #include "Logger/LogMacros.h"
 #include "Logger/Logger.h"
 #include "Random/RandomGenerator.h"
@@ -368,11 +369,20 @@ RestStatus RestAqlHandler::useQuery(std::string const& operation,
   }
 
   if (!_engine) {  // the PUT verb
-    TRI_ASSERT(this->state() == RestHandler::HandlerState::EXECUTE);
+    // TRI_ASSERT(this->state() == RestHandler::HandlerState::EXECUTE);
 
-    _engine = findEngine(idString);
-    if (!_engine) {
-      return RestStatus::DONE;
+    auto res = findEngine(idString);
+    if (res.fail()) {
+      if (res.is(TRI_ERROR_LOCKED)) {
+        // engine is still in use, but we have enqueued a callback to be woken
+        // up once it is free again
+        return RestStatus::WAITING;
+      } else {
+        TRI_ASSERT(res.is(TRI_ERROR_QUERY_NOT_FOUND));
+        generateError(rest::ResponseCode::NOT_FOUND, TRI_ERROR_QUERY_NOT_FOUND,
+                      "query ID " + idString + " not found");
+        return RestStatus::DONE;
+      }
     }
     std::shared_ptr<SharedQueryState> ss = _engine->sharedState();
     ss->setWakeupHandler(withLogContext(
@@ -493,7 +503,7 @@ RestStatus RestAqlHandler::continueExecute() {
   if (type == rest::RequestType::PUT) {
     // This cannot be changed!
     TRI_ASSERT(suffixes.size() == 2);
-    TRI_ASSERT(_engine != nullptr);
+    // TRI_ASSERT(_engine != nullptr);
     return useQuery(suffixes[0], suffixes[1]);
   } else if (type == rest::RequestType::DELETE_REQ && suffixes[0] == "finish") {
     return RestStatus::DONE;  // uses futures
@@ -528,94 +538,72 @@ void RestAqlHandler::shutdownExecute(bool isFinalized) noexcept {
 }
 
 // dig out the query from ID, handle errors
-ExecutionEngine* RestAqlHandler::findEngine(std::string const& idString) {
+Result RestAqlHandler::findEngine(std::string const& idString) {
   TRI_ASSERT(_engine == nullptr);
   uint64_t qId = arangodb::basics::StringUtils::uint64(idString);
 
-  // sleep for 10ms each time, wait for at most 30 seconds...
-  static int64_t const SingleWaitPeriod = 10 * 1000;
-  static int64_t const MaxIterations = static_cast<int64_t>(
-      30.0 * 1000000.0 / static_cast<double>(SingleWaitPeriod));
-
-  int64_t iterations = 0;
-
-  ExecutionEngine* q = nullptr;
-  // probably need to cycle here until we can get hold of the query
-  while (++iterations < MaxIterations) {
-    if (server().isStopping()) {
-      // don't loop for long here if we are shutting down anyway
-      generateError(ResponseCode::BAD, TRI_ERROR_SHUTTING_DOWN);
-      break;
-    }
-    try {
-      TRI_IF_FAILURE("RestAqlHandler::killBeforeOpen") {
-        auto engine = _queryRegistry->openExecutionEngine(qId);
-        // engine may be null if the query was killed before we got here.
-        // This can happen if another db server has already processed this
-        // failure point, killed the query and reported back to the coordinator,
-        // which then sent the finish request. If this finish request is
-        // processed before the query is opened here, the query is already gone.
-        if (engine != nullptr) {
-          auto queryId = engine->getQuery().id();
-          _queryRegistry->destroyQuery(queryId, TRI_ERROR_QUERY_KILLED);
-          _queryRegistry->closeEngine(qId);
-          // Here Engine must be gone because we killed it and when closeEngine
-          // drops the last reference it will be destroyed
-          TRI_ASSERT(_queryRegistry->openExecutionEngine(qId) == nullptr);
-        }
-      }
-      TRI_IF_FAILURE("RestAqlHandler::completeFinishBeforeOpen") {
-        auto errorCode = TRI_ERROR_QUERY_KILLED;
-        auto engine = _queryRegistry->openExecutionEngine(qId);
-        // engine may be null here due to the race described above
-        if (engine != nullptr) {
-          auto queryId = engine->getQuery().id();
-          // Unuse the engine, so we can abort properly
-          _queryRegistry->closeEngine(qId);
-
-          auto fut = _queryRegistry->finishQuery(queryId, errorCode);
-          TRI_ASSERT(fut.isReady());
-          auto query = fut.get();
-          if (query != nullptr) {
-            auto f = query->finalizeClusterQuery(errorCode);
-            // Wait for query to be fully finalized, as a finish call would do.
-            f.wait();
-            // Here Engine must be gone because we finalized it and since there
-            // should not be any other references this should also destroy it.
-            TRI_ASSERT(_queryRegistry->openExecutionEngine(qId) == nullptr);
-          }
-        }
-      }
-      TRI_IF_FAILURE("RestAqlHandler::prematureCommitBeforeOpen") {
-        auto engine = _queryRegistry->openExecutionEngine(qId);
-        if (engine != nullptr) {
-          auto queryId = engine->getQuery().id();
-          _queryRegistry->destroyQuery(queryId, TRI_ERROR_NO_ERROR);
-          _queryRegistry->closeEngine(qId);
-          // Here Engine could be gone
-        }
-      }
-      q = _queryRegistry->openExecutionEngine(qId);
-      // we got the query (or it was not found - at least no one else
-      // can now have access to the same query)
-      break;
-    } catch (...) {
-      // we can only get here if the query is currently used by someone
-      // else. in this case we sleep for a while and re-try
-      std::this_thread::sleep_for(std::chrono::microseconds(SingleWaitPeriod));
+  TRI_IF_FAILURE("RestAqlHandler::killBeforeOpen") {
+    auto res = _queryRegistry->openExecutionEngine(qId, {});
+    // engine may not be available if the query was killed before we got here.
+    // This can happen if another db server has already processed this
+    // failure point, killed the query and reported back to the coordinator,
+    // which then sent the finish request. If this finish request is
+    // processed before the query is opened here, the query is already gone.
+    if (res.ok()) {
+      auto engine = res.get();
+      auto queryId = engine->getQuery().id();
+      _queryRegistry->destroyQuery(queryId, TRI_ERROR_QUERY_KILLED);
+      _queryRegistry->closeEngine(qId);
+      // Here Engine must be gone because we killed it and when closeEngine
+      // drops the last reference it will be destroyed
+      TRI_ASSERT(_queryRegistry->openExecutionEngine(qId, {}).is(
+          TRI_ERROR_QUERY_NOT_FOUND));
     }
   }
+  TRI_IF_FAILURE("RestAqlHandler::completeFinishBeforeOpen") {
+    auto errorCode = TRI_ERROR_QUERY_KILLED;
+    auto res = _queryRegistry->openExecutionEngine(qId, {});
+    // engine may not be available due to the race described above
+    if (res.ok()) {
+      auto engine = res.get();
+      auto queryId = engine->getQuery().id();
+      // Unuse the engine, so we can abort properly
+      _queryRegistry->closeEngine(qId);
 
-  if (q == nullptr) {
-    LOG_TOPIC_IF("baef6", ERR, Logger::AQL, iterations == MaxIterations)
-        << "Timeout waiting for query " << qId;
-    generateError(rest::ResponseCode::NOT_FOUND, TRI_ERROR_QUERY_NOT_FOUND,
-                  "query ID " + idString + " not found");
+      auto fut = _queryRegistry->finishQuery(queryId, errorCode);
+      TRI_ASSERT(fut.isReady());
+      auto query = fut.get();
+      if (query != nullptr) {
+        auto f = query->finalizeClusterQuery(errorCode);
+        // Wait for query to be fully finalized, as a finish call would do.
+        f.wait();
+        // Here Engine must be gone because we finalized it and since there
+        // should not be any other references this should also destroy it.
+        TRI_ASSERT(_queryRegistry->openExecutionEngine(qId, {}).is(
+            TRI_ERROR_QUERY_NOT_FOUND));
+      }
+    }
+  }
+  TRI_IF_FAILURE("RestAqlHandler::prematureCommitBeforeOpen") {
+    auto res = _queryRegistry->openExecutionEngine(qId, {});
+    if (res.ok()) {
+      auto engine = res.get();
+      auto queryId = engine->getQuery().id();
+      _queryRegistry->destroyQuery(queryId, TRI_ERROR_NO_ERROR);
+      _queryRegistry->closeEngine(qId);
+      // Here Engine could be gone
+    }
+  }
+  auto res = _queryRegistry->openExecutionEngine(
+      qId, [self = shared_from_this()]() { self->wakeupHandler(); });
+  if (res.fail()) {
+    return std::move(res).result();
   }
 
-  TRI_ASSERT(q == nullptr || q->engineId() == qId);
+  _engine = res.get();
+  TRI_ASSERT(_engine != nullptr || _engine->engineId() == qId);
 
-  return q;
+  return Result{};
 }
 
 class AqlExecuteCall {

--- a/arangod/Aql/RestAqlHandler.h
+++ b/arangod/Aql/RestAqlHandler.h
@@ -131,7 +131,7 @@ class RestAqlHandler : public RestVocbaseBaseHandler {
 
  private:
   // dig out vocbase from context and query from ID, handle errors
-  ExecutionEngine* findEngine(std::string const& idString);
+  Result findEngine(std::string const& idString);
 
   // our query registry
   QueryRegistry* _queryRegistry;

--- a/tests/js/client/shell/shell-aql-regression-cluster.js
+++ b/tests/js/client/shell/shell-aql-regression-cluster.js
@@ -105,5 +105,28 @@ function ShellAqlRegressionSuite () {
   };
 }
 
+function ShellAqlParallelGatherSuite() {
+  const colName = 'UnitTestsCollection';
+  return {
+    setUpAll: function () {
+      const numberOfShards = 2;
+      const col = db._create(colName, {numberOfShards});
+      col.insert({});
+    },
+
+    tearDownAll: function () {
+      db._drop(colName);
+    },
+
+    testLongRunningUpstream: function () {
+      // Regression test for https://arangodb.atlassian.net/browse/BTS-1400
+      // Previously an upstream operation that took longer than 30s would cause
+      // the request to abort with an error "query ID xxx not found"
+      db._query("FOR d in @@col  LET x = SLEEP(35) INSERT {} INTO @@col", { "@col": colName });
+    },
+  };
+}
+
 jsunity.run(ShellAqlRegressionSuite);
+jsunity.run(ShellAqlParallelGatherSuite);
 return jsunity.done();

--- a/tests/js/client/shell/shell-aql-regression-cluster.js
+++ b/tests/js/client/shell/shell-aql-regression-cluster.js
@@ -120,9 +120,39 @@ function ShellAqlParallelGatherSuite() {
 
     testLongRunningUpstream: function () {
       // Regression test for https://arangodb.atlassian.net/browse/BTS-1400
-      // Previously an upstream operation that took longer than 30s would cause
-      // the request to abort with an error "query ID xxx not found"
+      // Previously we would only wait for up to 30s when trying to open an engine.
+      // If this failed, we would return with this "query ID xxx not found" error.
+      // However, there is no good reason to give up after 30s. In fact, there are
+      // enough cases where the upstream operation can take longer than 30s, so we
+      // have to wait for as long as it takes.
+      assertEqual(1, db[colName].count);
       db._query("FOR d in @@col  LET x = SLEEP(35) INSERT {} INTO @@col", { "@col": colName });
+      assertEqual(2, db[colName].count);
+
+      // The explain output for this query looks as follows:
+      // Execution plan:
+      //  Id   NodeType          Site  Est.   Comment
+      //   1   SingletonNode     DBS      1   * ROOT
+      //   4   CalculationNode   DBS      1     - LET #3 = {  }   /* json expression */   /* const assignment */
+      //  14   IndexNode         DBS      1     - FOR d IN UnitTestsCollection   /* primary index scan, scan only, 2 shard(s) */    
+      //   3   CalculationNode   DBS      1       - LET x = SLEEP(35)   /* simple expression */
+      //  12   RemoteNode        COOR     1       - REMOTE
+      //  13   GatherNode        COOR     1       - GATHER   /* parallel, unsorted */
+      //  15   CalculationNode   COOR     1       - LET #5 = MAKE_DISTRIBUTE_INPUT_WITH_KEY_CREATION(#3, null, { "allowSpecifiedKeys" : false, "ignoreErrors" : false, "collection" : "UnitTestsCollection" })   /* simple expression */
+      //   6   DistributeNode    COOR     1       - DISTRIBUTE #5
+      //   7   RemoteNode        DBS      1       - REMOTE
+      //   5   InsertNode        DBS      0       - INSERT #5 IN UnitTestsCollection 
+      //   8   RemoteNode        COOR     0       - REMOTE
+      //   9   GatherNode        COOR     0       - GATHER   /* parallel, unsorted */
+
+      // In the first parallel gather we fan out to the db servers, which then go
+      // back to the coordinator. These requests to the coordinator may come in
+      // concurrently. However, only the first one will be able to open the engine
+      // and then perform the next request to the db server. The engine will not
+      // be released while we wait for this response. Since the db server sleeps
+      // for 35s this can take a while during which the other requests have to
+      // wait and must not abort the query.
+      // This test basically just checks that the query does not fail.
     },
   };
 }

--- a/tests/js/client/shell/shell-aql-regression-cluster.js
+++ b/tests/js/client/shell/shell-aql-regression-cluster.js
@@ -125,9 +125,9 @@ function ShellAqlParallelGatherSuite() {
       // However, there is no good reason to give up after 30s. In fact, there are
       // enough cases where the upstream operation can take longer than 30s, so we
       // have to wait for as long as it takes.
-      assertEqual(1, db[colName].count);
+      assertEqual(1, db[colName].count());
       db._query("FOR d in @@col  LET x = SLEEP(35) INSERT {} INTO @@col", { "@col": colName });
-      assertEqual(2, db[colName].count);
+      assertEqual(2, db[colName].count());
 
       // The explain output for this query looks as follows:
       // Execution plan:


### PR DESCRIPTION
### Scope & Purpose

Previously an upstream operation that took longer than 30s would cause the request to abort with an error "query ID xxx not found"

- [x] :hankey: Bugfix

### Checklist

- [x] Tests
  - [x] **Regression tests**
- [x] Backports
  - [x] Backport for 3.11: #18978 