### PR TITLE
random code willification

### DIFF
--- a/arangod/Agency/State.cpp
+++ b/arangod/Agency/State.cpp
@@ -649,7 +649,8 @@ std::vector<log_t> State::get(index_t start, index_t end) const {
 
   for (size_t i = s; i < e; ++i) {
     // only for debugging purposes
-    TRI_ASSERT(i < _log.size()) << [this, sNow = s, eNow = e, start, end]() {
+    ADB_PROD_ASSERT(i < _log.size()) << [this, sNow = s, eNow = e, start,
+                                         end]() {
       std::stringstream s;
       s << "log size: " << _log.size() << ", start: " << sNow
         << ", end: " << eNow << ", cur: " << _cur << ", orig start: " << start


### PR DESCRIPTION
### Scope & Purpose

Random willification of code:
change `TRI_ASSERT(...)` to `ADB_PROD_ASSERT(...)` so that we get the assertion failure and its output during RTA (release test automation), which builds in release mode with maintainer mode turned off.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: *(Please link PR)*
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 