### PR TITLE
[GORDO-1643] Create Pregel Status Collection entry on creation

### DIFF
--- a/arangod/Pregel/Conductor/Conductor.cpp
+++ b/arangod/Pregel/Conductor/Conductor.cpp
@@ -759,34 +759,15 @@ void Conductor::persistPregelState(ExecutionState state) {
   }
 
   TRI_ASSERT(state != ExecutionState::DEFAULT);
-  if (state == ExecutionState::LOADING) {
-    // During state LOADING we need to initially create the document in the
-    // collection
-    auto storeResult = cWriter.createResult(stateBuilder.slice());
-    if (storeResult.ok()) {
-      LOG_PREGEL("063x1", INFO)
-          << "Stored result into: \"" << StaticStrings::PregelCollection
-          << "\" collection for PID: " << executionNumber();
-    } else {
-      LOG_PREGEL("063x2", INFO)
-          << "Could not store result into: \""
-          << StaticStrings::PregelCollection
-          << "\" collection for PID: " << executionNumber();
-    }
+  auto updateResult = cWriter.updateResult(stateBuilder.slice());
+  if (updateResult.ok()) {
+    LOG_PREGEL("063x3", INFO)
+        << "Updated state into: \"" << StaticStrings::PregelCollection
+        << "\" collection for PID: " << executionNumber();
   } else {
-    // During all other states, we will just simply update the already created
-    // document
-    auto updateResult = cWriter.updateResult(stateBuilder.slice());
-    if (updateResult.ok()) {
-      LOG_PREGEL("063x3", INFO)
-          << "Updated state into: \"" << StaticStrings::PregelCollection
-          << "\" collection for PID: " << executionNumber();
-    } else {
-      LOG_PREGEL("063x4", INFO)
-          << "Could not store result into: \""
-          << StaticStrings::PregelCollection
-          << "\" collection for PID: " << executionNumber();
-    }
+    LOG_PREGEL("063x4", INFO)
+        << "Could not store result into: \"" << StaticStrings::PregelCollection
+        << "\" collection for PID: " << executionNumber();
   }
 }
 

--- a/arangod/Pregel/PregelFeature.cpp
+++ b/arangod/Pregel/PregelFeature.cpp
@@ -130,11 +130,11 @@ Result PregelFeature::persistExecution(TRI_vocbase_t& vocbase,
   // collection
   auto storeResult = cWriter.createResult(stateBuilder.slice());
   if (storeResult.ok()) {
-    LOG_TOPIC("063x1", INFO, Logger::PREGEL) << fmt::format(
+    LOG_TOPIC("a63f1", INFO, Logger::PREGEL) << fmt::format(
         "[job {}] Stored result into: {}", en, StaticStrings::PregelCollection);
     return {};
   } else {
-    LOG_TOPIC("063x2", WARN, Logger::PREGEL)
+    LOG_TOPIC("063f2", WARN, Logger::PREGEL)
         << fmt::format("[job {}] Could not store result into: {}", en,
                        StaticStrings::PregelCollection);
     return TRI_ERROR_INTERNAL;

--- a/arangod/Pregel/PregelFeature.cpp
+++ b/arangod/Pregel/PregelFeature.cpp
@@ -181,6 +181,23 @@ ResultT<ExecutionNumber> PregelFeature::startExecution(TRI_vocbase_t& vocbase,
   auto graphSerdeConfig = maybeGraphSerdeConfig.get();
 
   auto en = createExecutionNumber();
+  {
+    statuswriter::CollectionStatusWriter cWriter{vocbase, en};
+    VPackBuilder stateBuilder;
+    // TODO: Here we should also write the Coordinator's ServerID into the
+    // collection
+    auto storeResult = cWriter.createResult(stateBuilder.slice());
+    if (storeResult.ok()) {
+      LOG_PREGEL("063x1", INFO)
+          << "Stored result into: \"" << StaticStrings::PregelCollection
+          << "\" collection for PID: " << executionNumber();
+    } else {
+      LOG_PREGEL("063x2", INFO)
+          << "Could not store result into: \""
+          << StaticStrings::PregelCollection
+          << "\" collection for PID: " << executionNumber();
+    }
+  }
 
   auto executionSpecifications = ExecutionSpecifications{
       .executionNumber = en,

--- a/arangod/Pregel/PregelFeature.h
+++ b/arangod/Pregel/PregelFeature.h
@@ -117,6 +117,7 @@ class PregelFeature final : public ArangodFeature {
   explicit PregelFeature(Server& server);
   ~PregelFeature();
 
+  Result persistExecution(TRI_vocbase_t& vocbase, ExecutionNumber en);
   ResultT<ExecutionNumber> startExecution(TRI_vocbase_t& vocbase,
                                           PregelOptions options);
 


### PR DESCRIPTION
### Scope & Purpose

To address a race condition between a client knowing an execution number for a pregel run and this execution number appearing in the Pregel status collection ready to query, create the entry in the status collection before the execution number is communicated to the client.

