### PR TITLE
[BTS-1402] Don't apply parallelize gather rule for one-shard DBs

### DIFF
--- a/arangod/Aql/OptimizerRules.cpp
+++ b/arangod/Aql/OptimizerRules.cpp
@@ -8348,6 +8348,11 @@ void arangodb::aql::parallelizeGatherRule(Optimizer* opt,
                                           OptimizerRule const& rule) {
   TRI_ASSERT(ServerState::instance()->isCoordinator());
 
+  if (plan->getAst()->query().vocbase().isOneShard()) {
+    opt->addPlan(std::move(plan), rule, false);
+    return;
+  }
+
   bool modified = false;
 
   containers::SmallVector<ExecutionNode*, 8> nodes;


### PR DESCRIPTION
### Scope & Purpose

Enterprise companion: https://github.com/arangodb/enterprise/pull/1270

- [x] :hankey: Bugfix

### Checklist

- [x] Tests
  - [x] **Regression tests** - see enterprise companion
- [ ] Backports
  - [ ] Backport for 3.11: *(Please link PR)*

#### Related Information

- Jira ticket: https://arangodb.atlassian.net/browse/BTS-1402

