### PR TITLE
keep jwt secret when using `arango.reconnect(...)`

### DIFF
--- a/client-tools/Shell/V8ClientConnection.cpp
+++ b/client-tools/Shell/V8ClientConnection.cpp
@@ -664,7 +664,11 @@ static void ClientConnection_reconnect(
   }
 
   if (args.Length() > 5 && !args[5]->IsUndefined()) {
+    // only use JWT from parameters when specified
     client->setJwtSecret(TRI_ObjectToString(isolate, args[5]));
+  } else if (args.Length() >= 4) {
+    // password specified, but no JWT
+    client->setJwtSecret("");
   }
 
   client->setEndpoint(endpoint);
@@ -1931,6 +1935,39 @@ static void ClientConnection_setDatabaseName(
   TRI_V8_TRY_CATCH_END
 }
 
+static void ClientConnection_setJwtSecret(
+    v8::FunctionCallbackInfo<v8::Value> const& args) {
+  TRI_V8_TRY_CATCH_BEGIN(isolate);
+  v8::HandleScope scope(isolate);
+
+  if (isExecutionDeadlineReached(isolate)) {
+    return;
+  }
+
+  // get the connection
+  V8ClientConnection* v8connection = TRI_UnwrapClass<V8ClientConnection>(
+      args.Holder(), WRAP_TYPE_CONNECTION, TRI_IGETC);
+
+  v8::Local<v8::External> wrap = v8::Local<v8::External>::Cast(args.Data());
+  ClientFeature* client = static_cast<ClientFeature*>(wrap->Value());
+
+  if (v8connection == nullptr || client == nullptr) {
+    TRI_V8_THROW_EXCEPTION_INTERNAL(
+        "setJwtSecret() must be invoked on an arango connection object "
+        "instance.");
+  }
+
+  if (args.Length() != 1 || !args[0]->IsString()) {
+    TRI_V8_THROW_EXCEPTION_USAGE("setJwtSecret(<value>)");
+  }
+
+  std::string const value = TRI_ObjectToString(isolate, args[0]);
+  client->setJwtSecret(value);
+
+  TRI_V8_RETURN_TRUE();
+  TRI_V8_TRY_CATCH_END
+}
+
 v8::Local<v8::Value> V8ClientConnection::getData(
     v8::Isolate* isolate, std::string_view location,
     std::unordered_map<std::string, std::string> const& headerFields,
@@ -2641,6 +2678,10 @@ void V8ClientConnection::initServer(v8::Isolate* isolate,
       isolate, "setDatabaseName",
       v8::FunctionTemplate::New(isolate, ClientConnection_setDatabaseName,
                                 v8client));
+
+  connection_proto->Set(isolate, "setJwtSecret",
+                        v8::FunctionTemplate::New(
+                            isolate, ClientConnection_setJwtSecret, v8client));
 
   connection_proto->Set(
       isolate, "importCsv",

--- a/client-tools/Shell/V8ClientConnection.cpp
+++ b/client-tools/Shell/V8ClientConnection.cpp
@@ -617,7 +617,7 @@ static void ClientConnection_reconnect(
     // Note that there are two additional parameters, which aren't advertised,
     // namely `warnConnect` and `jwtSecret`.
     TRI_V8_THROW_EXCEPTION_USAGE(
-        "reconnect(<endpoint>, <database>, [ <username>, <password> ])");
+        "reconnect(<endpoint>, <database> [, <username>, <password> ])");
   }
 
   std::string const endpoint = TRI_ObjectToString(isolate, args[0]);
@@ -655,11 +655,6 @@ static void ClientConnection_reconnect(
     warnConnect = TRI_ObjectToBoolean(isolate, args[4]);
   }
 
-  std::string jwtSecret;
-  if (args.Length() > 5 && !args[5]->IsUndefined()) {
-    jwtSecret = TRI_ObjectToString(isolate, args[5]);
-  }
-
   V8SecurityFeature& v8security =
       v8connection->server().getFeature<V8SecurityFeature>();
   if (!v8security.isAllowedToConnectToEndpoint(isolate, endpoint, endpoint)) {
@@ -668,12 +663,15 @@ static void ClientConnection_reconnect(
         std::string("not allowed to connect to this endpoint") + endpoint);
   }
 
+  if (args.Length() > 5 && !args[5]->IsUndefined()) {
+    client->setJwtSecret(TRI_ObjectToString(isolate, args[5]));
+  }
+
   client->setEndpoint(endpoint);
   client->setDatabaseName(databaseName);
   client->setUsername(username);
   client->setPassword(password);
   client->setWarnConnect(warnConnect);
-  client->setJwtSecret(jwtSecret);
 
   try {
     v8connection->reconnect();

--- a/tests/js/client/server_parameters/database-password-noncluster.js
+++ b/tests/js/client/server_parameters/database-password-noncluster.js
@@ -53,6 +53,26 @@ function OptionsTestSuite () {
       arango.reconnect(arango.getEndpoint(), db._name(), arango.connectedUser(), "testi1234");
       assertTrue(arango.isConnected());
     },
+    
+    testConnectNoUserNoPassword: function () {
+      arango.setJwtSecret("haxxmann");
+      try {
+        arango.reconnect(arango.getEndpoint(), db._name());
+        assertTrue(arango.isConnected());
+      } finally {
+        arango.setJwtSecret("");
+      }
+    },
+    
+    testConnectNoPassword: function () {
+      arango.setJwtSecret("haxxmann");
+      try {
+        arango.reconnect(arango.getEndpoint(), db._name(), arango.connectedUser());
+        assertTrue(arango.isConnected());
+      } finally {
+        arango.setJwtSecret("");
+      }
+    },
   
   };
 }


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/18997

Keep original JWT secret in arangosh when using `arango.reconnect(...)` when not overriding the JWT.
This restores behavior that used to work in 3.9.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.11: https://github.com/arangodb/arangodb/pull/18999
  - [x] Backport for 3.10: this PR
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 