### PR TITLE
[BTS-1402] [3.11] Don't apply parallelize gather rule for one-shard DBs

### DIFF
--- a/arangod/Aql/OptimizerRules.cpp
+++ b/arangod/Aql/OptimizerRules.cpp
@@ -8358,6 +8358,11 @@ void arangodb::aql::parallelizeGatherRule(Optimizer* opt,
                                           OptimizerRule const& rule) {
   TRI_ASSERT(ServerState::instance()->isCoordinator());
 
+  if (plan->getAst()->query().vocbase().isOneShard()) {
+    opt->addPlan(std::move(plan), rule, false);
+    return;
+  }
+
   bool modified = false;
 
   // find all GatherNodes in the main query, starting from the query's root node


### PR DESCRIPTION
### Scope & Purpose

Enterprise companion: https://github.com/arangodb/enterprise/pull/1271

- [x] :hankey: Bugfix

### Checklist

- [x] Tests
  - [x] **Regression tests** - see enterprise companion
- [x] Backports
  - [x] Backport for devel: #18998 

#### Related Information

- Jira ticket: https://arangodb.atlassian.net/browse/BTS-1402


