### PR TITLE
[CINFRA-745] Improve Error Reporting

### DIFF
--- a/arangod/Cluster/ClusterCollectionMethods.cpp
+++ b/arangod/Cluster/ClusterCollectionMethods.cpp
@@ -385,8 +385,10 @@ Result impl(ClusterInfo& ci, ArangodServer& server,
         return Result{TRI_ERROR_SHUTTING_DOWN};
       }
     } else {
-      // TODO: Clean this up should not return DEBUG here
-      return {TRI_ERROR_DEBUG, res.errorMessage()};
+      return {TRI_ERROR_INTERNAL,
+              fmt::format("Failed to create collection, the operation has been "
+                          "rejected by the agency ({})",
+                          res.errorMessage())};
     }
   }
 }


### PR DESCRIPTION
### Scope & Purpose

In v8-vocindex.cpp, the CreateVocbase function calls into methods::Collections::create, which upon failure, throws an exception. The error message ends up to the client, which might be faced with “precondition failed”. We should handle such failures in a more user-friendly way.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification
