### PR TITLE
Fixup and cleanup checkLogIds

### DIFF
--- a/.circleci/base_config.yml
+++ b/.circleci/base_config.yml
@@ -13,6 +13,9 @@ jobs:
     environment:
       GIT_SSH_COMMAND: ssh -v
     steps:
+      - add_ssh_keys:
+          fingerprints:
+            - "f9:49:75:1a:ad:44:89:10:4b:3c:70:70:ba:d3:c3:ce"
       - run:
           name: Checkout
           command: |
@@ -20,6 +23,25 @@ jobs:
             git remote add origin https://github.com/arangodb/arangodb.git
             git fetch --depth 1 origin $CIRCLE_SHA1
             git checkout $CIRCLE_SHA1
+      - run:
+          name: Checkout Enterprise
+          command: |
+            ssh-keyscan github.com >> ~/.ssh/known_hosts
+            if ["<< pipeline.parameters.enterprise-branch >>" == ""]; then
+              set +e
+              git ls-remote --exit-code --heads git@github.com:arangodb/enterprise.git "$CIRCLE_BRANCH"
+              if [ "$?" == "0" ] ; then
+                ENTERPRISE_BRANCH=$CIRCLE_BRANCH
+              else
+                ENTERPRISE_BRANCH=devel
+              fi
+              set -e
+            else
+              ENTERPRISE_BRANCH=<< pipeline.parameters.enterprise-branch >>
+            fi
+            echo "Using enterprise branch $ENTERPRISE_BRANCH"
+            git clone --depth 1 git@github.com:arangodb/enterprise.git --branch "$ENTERPRISE_BRANCH" /root/project/enterprise
+          fi
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/base_config.yml
+++ b/.circleci/base_config.yml
@@ -13,9 +13,6 @@ jobs:
     environment:
       GIT_SSH_COMMAND: ssh -v
     steps:
-      - add_ssh_keys:
-          fingerprints:
-            - "f9:49:75:1a:ad:44:89:10:4b:3c:70:70:ba:d3:c3:ce"
       - run:
           name: Checkout
           command: |
@@ -23,25 +20,6 @@ jobs:
             git remote add origin https://github.com/arangodb/arangodb.git
             git fetch --depth 1 origin $CIRCLE_SHA1
             git checkout $CIRCLE_SHA1
-      - run:
-          name: Checkout Enterprise
-          command: |
-            ssh-keyscan github.com >> ~/.ssh/known_hosts
-            if ["<< pipeline.parameters.enterprise-branch >>" == ""]; then
-              set +e
-              git ls-remote --exit-code --heads git@github.com:arangodb/enterprise.git "$CIRCLE_BRANCH"
-              if [ "$?" == "0" ] ; then
-                ENTERPRISE_BRANCH=$CIRCLE_BRANCH
-              else
-                ENTERPRISE_BRANCH=devel
-              fi
-              set -e
-            else
-              ENTERPRISE_BRANCH=<< pipeline.parameters.enterprise-branch >>
-            fi
-            echo "Using enterprise branch $ENTERPRISE_BRANCH"
-            git clone --depth 1 git@github.com:arangodb/enterprise.git --branch "$ENTERPRISE_BRANCH" /root/project/enterprise
-          fi
       - persist_to_workspace:
           root: .
           paths:

--- a/arangod/Pregel/Conductor/Conductor.cpp
+++ b/arangod/Pregel/Conductor/Conductor.cpp
@@ -761,11 +761,11 @@ void Conductor::persistPregelState(ExecutionState state) {
   TRI_ASSERT(state != ExecutionState::DEFAULT);
   auto updateResult = cWriter.updateResult(stateBuilder.slice());
   if (updateResult.ok()) {
-    LOG_PREGEL("063x3", INFO)
+    LOG_PREGEL("07323", INFO)
         << "Updated state into: \"" << StaticStrings::PregelCollection
         << "\" collection for PID: " << executionNumber();
   } else {
-    LOG_PREGEL("063x4", INFO)
+    LOG_PREGEL("0ffa4", INFO)
         << "Could not store result into: \"" << StaticStrings::PregelCollection
         << "\" collection for PID: " << executionNumber();
   }

--- a/utils/checkLogIds.py
+++ b/utils/checkLogIds.py
@@ -17,7 +17,7 @@ def check_file(fullpath, project_path, id_database, invalid_logid_database):
             match = g_log_topic_pattern.search(line)
 
             if match:
-                location_string = "{}:{}".format(project_path, cnt)
+                location_string = "{}:{}".format(project_path, cnt + 1)
                 macro = match.group('macro')
                 rest = match.group('rest')
                 param = match.group('param').strip()

--- a/utils/checkLogIds.py
+++ b/utils/checkLogIds.py
@@ -3,23 +3,27 @@
 import sys
 import os
 
-from enum import Enum
-
 import re
-g_log_topic_pattern = re.compile(r'(?P<macro>LOG_(TOPIC(_IF)?|TRX|CTX(_IF)?|QUERY|PREGEL))\((?P<param>[^),]*),(?P<rest>.*)')
+g_log_topic_pattern = re.compile( \
+    r'(?P<macro>LOG_(TOPIC(_IF)?|TRX|CTX(_IF)?|QUERY|PREGEL))\((?P<param>[^),]*),(?P<rest>.*)')
 
 # a LogId is exactly 5 hexadecimal digits
 g_log_id_pattern = re.compile(r'"[0-9a-f]{5}"')
 
-def check_file(fullpath, project_path, id_database, invalid_logid_database):
-    with open(fullpath) as source_file_handle:
+def check_file(fullpath, id_database, invalid_logid_database):
+    """
+    Collects LogIDs and invalid LogID attempts from file given in fullpath
+
+        :param fullpath: full path to the file to open
+        :param id_database: dict containing all occurrences of LogIDs
+        :param invalid_logid_database: locations in which invalid LogID attempts have been found
+    """
+    with open(fullpath, encoding="UTF-8") as source_file_handle:
         for cnt, line in enumerate(source_file_handle):
             match = g_log_topic_pattern.search(line)
 
             if match:
-                location_string = "{}:{}".format(fullpath, cnt + 1)
-                macro = match.group('macro')
-                rest = match.group('rest')
+                location_string = f"{fullpath}:{cnt+1}"
                 param = match.group('param').strip()
 
                 if g_log_id_pattern.match(param):
@@ -32,7 +36,8 @@ def check_file(fullpath, project_path, id_database, invalid_logid_database):
                         id_database[uid]=[location_string]
 
                 elif param == "logId":
-                    # TODO: warn?
+                    # This is made to pass over macro definitions that
+                    # look like invocations to our primitive regex
                     pass
                 else:
                     invalid_logid_database[location_string] = param
@@ -49,8 +54,8 @@ def check_log_ids_main(root_directory, directories_to_include, directories_or_fi
         :rtype: dict
     """
 
-    id_database = dict()
-    invalid_logid_database = dict()
+    id_database = {}
+    invalid_logid_database = {}
 
     include = [ root_directory + os.path.sep + d for d in directories_to_include ]
     exclude = [ root_directory + os.path.sep + d for d in directories_or_files_to_exclude ]
@@ -65,22 +70,15 @@ def check_log_ids_main(root_directory, directories_to_include, directories_or_fi
             if fullpath in exclude:
                 continue
             if filename.endswith((".cpp", ".h", ".tpp")):
-                check_file(fullpath, root_directory, id_database, invalid_logid_database)
+                check_file(fullpath, id_database, invalid_logid_database)
 
     return [id_database, invalid_logid_database]
 
 if __name__ == "__main__":
-    """
-    Returns non zero status if there is a duplicate id!
+    my_root = os.path.dirname(__file__)
+    my_root = os.path.abspath(os.path.join(my_root, os.pardir))
 
-    Note:
-    `check_only` must be set to true for normal operation mode.
-    """
-
-    root = os.path.dirname(__file__)
-    root = os.path.abspath(root + os.path.sep + os.pardir)
-
-    id_database, invalid_logid_database = check_log_ids_main(root,
+    my_id_database, my_invalid_logid_database = check_log_ids_main(my_root,
                        ["arangod", "client-tools", "enterprise", "lib"],
                        [".", "lib/Logger/LogMacros.h",
                         "arangod/StorageEngine/TransactionState.h",
@@ -88,17 +86,17 @@ if __name__ == "__main__":
 
     return_value = 0
 
-    for k, v in id_database.items():
+    for k, v in my_id_database.items():
         if len(v) > 1:
             return_value = 1
-            print("LogId {} is used more than once:".format(k))
+            print(f"LogId {k} is used more than once:")
             for loc in v:
-                print("  {}".format(loc))
+                print(f"  {loc}")
 
-    if invalid_logid_database:
+    if my_invalid_logid_database:
         return_value = 1
         print("Found the following invalid LogIds: ")
-        for loc, logId in invalid_logid_database.items():
-            print(" {} at {}".format(logId, loc))
+        for loc, logId in my_invalid_logid_database.items():
+            print(f" {logId} at {loc}")
 
     sys.exit(return_value)

--- a/utils/checkLogIds.py
+++ b/utils/checkLogIds.py
@@ -5,71 +5,17 @@ import os
 
 from enum import Enum
 
-class Operation(Enum):
-    READ = 1
-    MODIFY = 2
-
 class Status(Enum):
     OK = 0
-    OK_REPLACED = 1
-    FAIL = 2
-
-def is_good(status):
-    return status in (Status.OK, Status.OK_REPLACED)
+    FAIL = 1
 
 import re
 g_log_topic_pattern = re.compile(r'(?P<macro>LOG_(TOPIC(_IF)?|TRX|CTX(_IF)?|QUERY|PREGEL))\((?P<param>[^),]*),(?P<rest>.*)')
 
-import hashlib
-g_hash_algorithm = hashlib.md5()
+# a LogId is exactly 5 hexadecimal digits
+g_log_id_pattern = re.compile(r'"[0-9a-f]{5}"')
 
-
-def generate_id(location_string, params, rest, id_database):
-    sys.exit(1) #disabled on purpose
-
-    id_len = 5
-    g_hash_algorithm.update((location_string + params + rest).encode())
-    digest = g_hash_algorithm.hexdigest()
-    uid = digest[0:id_len]
-
-    while uid in id_database:
-        print("collision on id {} \n{}\n{}\n".format(uid, location_string, id_database[uid]))
-        g_hash_algorithm.update((location_string + digest).encode())
-        digest = g_hash_algorithm.hexdigest()
-        uid = digest[0:id_len]
-
-    id_database[uid]=location_string
-
-    return uid
-
-def handle_file(fullpath, project_root, id_database, operation):
-    project_path = os.path.relpath(fullpath, project_root)
-    status = Status.OK
-
-    levels = ( 'TRACE', 'INFO', 'WARN', 'DEBUG', 'ERR', 'FATAL')
-
-    if operation == Operation.MODIFY:
-        target_file = fullpath + ".replacement"
-        with open(target_file, 'w') as target_file_handle:
-            status = do_operation(fullpath, project_path, target_file_handle, id_database, levels, operation)
-
-        if status == Status.OK_REPLACED:
-            os.rename(target_file, fullpath)
-        else:
-            os.unlink(target_file)
-
-    else:
-        #not modifying operation
-        status = do_operation(fullpath, project_path, None, id_database, levels, operation)
-
-
-    if is_good(status):
-        return Status.OK # filter OK_REPLACED
-    return status
-
-
-def do_operation(fullpath, project_path, target_file_handle, id_database, levels, operation):
-    status = Status.OK
+def check_file(fullpath, project_path, id_database, invalid_logid_database):
     with open(fullpath) as source_file_handle:
         for cnt, line in enumerate(source_file_handle):
             match = g_log_topic_pattern.search(line)
@@ -80,117 +26,54 @@ def do_operation(fullpath, project_path, target_file_handle, id_database, levels
                 rest = match.group('rest')
                 param = match.group('param').strip()
 
-                if operation == Operation.MODIFY:
-                    if param in levels:
-                        # replace with new id
-                        uid = generate_id(location_string, param, rest, id_database)
-                        replacement = '{}("{}", {},{}'.format(macro ,uid, param, rest.replace('\\', '\\\\' ))
-                        output = "{} -- {}".format(location_string, replacement)
-                        #print(output)
-                        status = Status.OK_REPLACED
-                        newline = g_log_topic_pattern.sub(replacement, line)
-                        target_file_handle.write(newline)
+                if g_log_id_pattern.match(param):
+                    # we need to store / check the id
+                    uid = param[1:-1]
 
-                    elif len(param) == 5:
-                        # nothing to do - just copy
-                        target_file_handle.write(line)
-
+                    if uid in id_database:
+                        id_database[uid]=id_database[uid] + [location_string]
                     else:
-                        print("BROKEN PARAMS IN: " + project_path + ":" + str(cnt))
-                        print(operation)
-                        print(line)
-                        print("macro: " + macro)
-                        print("param: " +  param)
-                        print("rest:" + rest)
-                        status = Status.FAIL
+                        id_database[uid]=[location_string]
 
-                if operation == Operation.READ:
-                    if param in levels:
-                        # still unmodified
-                        continue
-
-                    elif len(param) == 7 and param.startswith('"') and param.endswith('"'):
-                        # we need to store / check the id
-                        uid = param[1:-1]
-
-                        if uid in id_database:
-                            print("collision check failed - the following lines contain equal ids:")
-                            print(location_string)
-                            print(id_database[uid])
-                            status = Status.FAIL
-                        else:
-                            id_database[uid]=location_string
-
-                    elif param == "logId":
-                        # additional macro
-                        pass 
-
-                    else:
-                        print("BROKEN PARAMS IN: " + project_path + ":" + str(cnt))
-                        print(operation)
-                        print(line)
-                        print("macro: " + macro)
-                        print("param: " +  param)
-                        print("rest:" + rest)
-                        status = Status.FAIL
-
-                else:
-                    #ignore operation
+                elif param == "logId":
+                    # TODO: warn?
                     pass
+                else:
+                    invalid_logid_database[location_string] = param
 
-
-            elif operation == Operation.MODIFY:
-                #no match but we need to modify
-                target_file_handle.write(line)
-
-            if not is_good(status):
-                return status
-
-    return status
-
-
-def generate_ids_main(check_only, project_root, directories_to_include, directories_or_files_to_exclude, id_database):
+def check_log_ids_main(root_directory, directories_to_include, directories_or_files_to_exclude):
     """
-    Library function to check arangodb project for valid unique log ids.
+    Function to check arangodb project for valid unique log ids.
 
-    If `check_only` is set to False it will also convert macros form old style
-    logging to new the new style inserting unique ids.
-
-        :param check_only: check for uniqueness but do not modify
-        :param project_root: path to project_root
+        :param root_directory: path to project_root
         :param directories_to_include: list of directories to include
         :param directories_or_files_to_exclude: list of directories and files to exclude
 
-        :return: status
-        :rtype: int
+        :return: dict of LogIds with locations of use
+        :rtype: dict
     """
 
-    include = [ project_root + os.path.sep + d for d in directories_to_include ]
-    exclude = [ project_root + os.path.sep + d for d in directories_or_files_to_exclude ]
+    id_database = dict()
+    invalid_logid_database = dict()
 
-    operations = [ Operation.READ ]
-    if not check_only:
-        operations.append(Operation.MODIFY)
+    include = [ root_directory + os.path.sep + d for d in directories_to_include ]
+    exclude = [ root_directory + os.path.sep + d for d in directories_or_files_to_exclude ]
 
-    for root, dirs, files in os.walk(project_root):
+    for root, dirs, files in os.walk(root_directory):
         status = Status.OK
 
         dirs[:] = [ d for d in dirs if (root + os.path.sep + d).startswith(tuple(include)) ]
         if root in exclude:
             continue
 
-        for operation in operations:
-            for filename in files:
-                fullpath = root + os.path.sep + filename
-                if fullpath in exclude:
-                    continue
-                if (filename.endswith((".cpp",".h"))):
-                    status = handle_file(fullpath, project_root, id_database, operation)
+        for filename in files:
+            fullpath = root + os.path.sep + filename
+            if fullpath in exclude:
+                continue
+            if (filename.endswith((".cpp", ".h", ".tpp"))):
+                status = check_file(fullpath, root_directory, id_database, invalid_logid_database)
 
-                if not is_good(status):
-                    return status
-
-    return 0
+    return [id_database, invalid_logid_database]
 
 if __name__ == "__main__":
     """
@@ -202,11 +85,26 @@ if __name__ == "__main__":
 
     root = os.path.dirname(__file__)
     root = os.path.abspath(root + os.path.sep + os.pardir)
-    check_only = True
-    sys.exit(generate_ids_main(check_only, root              #project_root
-            ,["arangod", "client-tools", "enterprise", "lib"]    #dirs to include
-            ,[".", "lib/Logger/LogMacros.h",
-              "arangod/StorageEngine/TransactionState.h",
-              "arangod/Replication2/LoggerContext.h"]    #dirs and files to exclude (does not purge the dir)
-            , dict()                                         #database
-            ))
+
+    id_database, invalid_logid_database = check_log_ids_main(root,
+                       ["arangod", "client-tools", "enterprise", "lib"],
+                       [".", "lib/Logger/LogMacros.h",
+                        "arangod/StorageEngine/TransactionState.h",
+                        "arangod/Replication2/LoggerContext.h"])
+
+    return_value = 0
+
+    for k, v in id_database.items():
+        if len(v) > 1:
+            return_value = 1
+            print("LogId {} is used more than once:".format(k))
+            for loc in v:
+                print("  {}".format(loc))
+
+    if invalid_logid_database:
+        return_value = 1
+        print("Found the following invalid LogIds: ")
+        for loc, logId in invalid_logid_database.items():
+            print(" {} at {}".format(logId, loc))
+
+    sys.exit(return_value)

--- a/utils/checkLogIds.py
+++ b/utils/checkLogIds.py
@@ -17,7 +17,7 @@ def check_file(fullpath, project_path, id_database, invalid_logid_database):
             match = g_log_topic_pattern.search(line)
 
             if match:
-                location_string = "{}:{}".format(project_path, cnt + 1)
+                location_string = "{}:{}".format(fullpath, cnt + 1)
                 macro = match.group('macro')
                 rest = match.group('rest')
                 param = match.group('param').strip()

--- a/utils/checkLogIds.py
+++ b/utils/checkLogIds.py
@@ -70,7 +70,7 @@ def check_log_ids_main(root_directory, directories_to_include, directories_or_fi
             fullpath = root + os.path.sep + filename
             if fullpath in exclude:
                 continue
-            if (filename.endswith((".cpp", ".h", ".tpp"))):
+            if filename.endswith((".cpp", ".h", ".tpp")):
                 status = check_file(fullpath, root_directory, id_database, invalid_logid_database)
 
     return [id_database, invalid_logid_database]

--- a/utils/checkLogIds.py
+++ b/utils/checkLogIds.py
@@ -5,10 +5,6 @@ import os
 
 from enum import Enum
 
-class Status(Enum):
-    OK = 0
-    FAIL = 1
-
 import re
 g_log_topic_pattern = re.compile(r'(?P<macro>LOG_(TOPIC(_IF)?|TRX|CTX(_IF)?|QUERY|PREGEL))\((?P<param>[^),]*),(?P<rest>.*)')
 
@@ -60,8 +56,6 @@ def check_log_ids_main(root_directory, directories_to_include, directories_or_fi
     exclude = [ root_directory + os.path.sep + d for d in directories_or_files_to_exclude ]
 
     for root, dirs, files in os.walk(root_directory):
-        status = Status.OK
-
         dirs[:] = [ d for d in dirs if (root + os.path.sep + d).startswith(tuple(include)) ]
         if root in exclude:
             continue
@@ -71,7 +65,7 @@ def check_log_ids_main(root_directory, directories_to_include, directories_or_fi
             if fullpath in exclude:
                 continue
             if filename.endswith((".cpp", ".h", ".tpp")):
-                status = check_file(fullpath, root_directory, id_database, invalid_logid_database)
+                check_file(fullpath, root_directory, id_database, invalid_logid_database)
 
     return [id_database, invalid_logid_database]
 


### PR DESCRIPTION
### Scope & Purpose

The `checkLogIds.py` script looked like it was written for a purpose different from what it was used for.

In particular, it was renamed from `generateLogIds.py` in the past, and the checking logIds for uniqueness was hardcoded, so the script itself was not usable for any other purpose.

For the purpose of checking logIds it was also broken: it did not check whether a logId it found was valid leading to code passing CircleCI checks and failing Jenkins checks.

All the unused code is now deleted and replaced by code that explicitly does the following:
* collect all places that have invalid logIds. A logId consists of precisely 5 characters from the set `[a-f0-9]`.
* collect logIds that are used more than once
* print this information in a vaguely useful way.

Note that the check that is run on Jenkins is *different* from the one performed in `checkLogIds`, and has a separate issue in that it does not detect `LOG_PREGEL` macros.