### PR TITLE
[CINFRA-750] Fix flaky test

### DIFF
--- a/js/common/modules/@arangodb/testutils/replicated-logs-predicates.js
+++ b/js/common/modules/@arangodb/testutils/replicated-logs-predicates.js
@@ -93,6 +93,11 @@ const replicatedLogLeaderEstablished = function (database, logId, term, particip
     if (current === undefined) {
       return Error("current not yet defined");
     }
+    if (plan === undefined) {
+      // This may seem strange, but it's actually needed. Due to supervision logging actions to Current,
+      // we can end up with an entry in Current, before the Plan is created.
+      return Error("plan not yet defined");
+    }
 
     for (const srv of participants) {
       if (!current.localStatus || !current.localStatus[srv]) {


### PR DESCRIPTION
### Scope & Purpose

The _testDropReplicatedState_ failed while creating the replicated log. This is not due to the test itself, as the problem I'm going to describe could occur in any other replication2 integration test that uses the `createReplicatedLogWithState` function, available in the `replicated-logs-helper`.

The `createReplicatedLogWithState` works by writing the necessary entry to _Target_ and then waiting on the `replicatedLogLeaderEstablished` predicate to be satisfied. It's important to note that the `maxActionsTraceLength` parameter is used in _Target_, which allows the supervision to write actions into _Current_ (for debugging purposes). This might create a rather unexpected state: depending on the supervision's timing, we might end up with an entry in _Current_, before having a valid entry in _Plan_. The entry in _Current_ contains only the _actions_ array, without any other information about the log itself.

Under normal circumstances (in production), this would not happen, but due to supervision logging its actions to _Current_, the described race condition could take place. This PR adds an extra check, making sure that `Plan` is valid.



- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [x] **integration tests**
  - [ ] **resilience tests**

#### Related Information

See the Jenkins failure [here](https://jenkins01.arangodb.biz/job/arangodb-matrix-pr-linux.aarch64/7532/EDITION=enterprise,STORAGE_ENGINE=rocksdb,TEST_SUITE=cluster,limit=linux&&test&&aarch64/testReport/junit/EE_replication2_server__tests_js_server_replication2_replication2-replicated-state-http-api-cluster/js/EE_testDropReplicatedState/)
