### PR TITLE
track index selectivity estimates memory usage

### DIFF
--- a/arangod/RocksDBEngine/RocksDBEdgeIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBEdgeIndex.cpp
@@ -1041,6 +1041,16 @@ void RocksDBEdgeIndex::afterTruncate(TRI_voc_tick_t tick,
   RocksDBIndex::afterTruncate(tick, trx);
 }
 
+Result RocksDBEdgeIndex::drop() {
+  Result res = RocksDBIndex::drop();
+
+  if (res.ok() && _estimator != nullptr) {
+    _estimator->freeMemory();
+  }
+
+  return res;
+}
+
 RocksDBCuckooIndexEstimatorType* RocksDBEdgeIndex::estimator() {
   return _estimator.get();
 }

--- a/arangod/RocksDBEngine/RocksDBEdgeIndex.h
+++ b/arangod/RocksDBEngine/RocksDBEdgeIndex.h
@@ -106,6 +106,8 @@ class RocksDBEdgeIndex final : public RocksDBIndex {
 
   void afterTruncate(TRI_voc_tick_t tick, transaction::Methods* trx) override;
 
+  Result drop() override;
+
   Result insert(transaction::Methods& trx, RocksDBMethods* methods,
                 LocalDocumentId const& documentId, velocypack::Slice doc,
                 OperationOptions const& options,

--- a/arangod/RocksDBEngine/RocksDBIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBIndex.cpp
@@ -209,8 +209,8 @@ Result RocksDBIndex::drop() {
   bool const prefixSameAsStart = type() != Index::TRI_IDX_TYPE_EDGE_INDEX;
   bool const useRangeDelete = coll->meta().numberDocuments() >= 32 * 1024;
 
-  arangodb::Result r = rocksutils::removeLargeRange(
-      _engine.db(), getBounds(), prefixSameAsStart, useRangeDelete);
+  Result r = rocksutils::removeLargeRange(_engine.db(), getBounds(),
+                                          prefixSameAsStart, useRangeDelete);
 
   // Try to drop the cache as well.
   if (_cache) {

--- a/arangod/RocksDBEngine/RocksDBMetaCollection.cpp
+++ b/arangod/RocksDBEngine/RocksDBMetaCollection.cpp
@@ -77,7 +77,8 @@ RocksDBMetaCollection::RocksDBMetaCollection(LogicalCollection& collection,
       _revisionTreeApplied(0),
       _revisionTreeCreationSeq(0),
       _revisionTreeSerializedSeq(0),
-      _revisionTreeSerializedTime(std::chrono::steady_clock::now()) {
+      _revisionTreeSerializedTime(std::chrono::steady_clock::now()),
+      _revisionsBufferedMemoryUsage(0) {
   TRI_ASSERT(!ServerState::instance()->isCoordinator());
 
   TRI_ASSERT(_logicalCollection.isAStub() || _objectId != 0);
@@ -87,6 +88,27 @@ RocksDBMetaCollection::RocksDBMetaCollection(LogicalCollection& collection,
       .engine<RocksDBEngine>()
       .addCollectionMapping(_objectId, _logicalCollection.vocbase().id(),
                             _logicalCollection.id());
+}
+
+RocksDBMetaCollection::~RocksDBMetaCollection() {
+  {
+    std::unique_lock<std::mutex> lock(_revisionTreeLock);
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+    // only to validate that our math is correct and we are not missing
+    // anything.
+    uint64_t memoryUsage = 0;
+    for (auto const& it : _revisionInsertBuffers) {
+      memoryUsage +=
+          bufferedEntrySize() + bufferedEntryItemSize() * it.second.size();
+    }
+    for (auto const& it : _revisionRemovalBuffers) {
+      memoryUsage +=
+          bufferedEntrySize() + bufferedEntryItemSize() * it.second.size();
+    }
+    TRI_ASSERT(memoryUsage == _revisionsBufferedMemoryUsage);
+#endif
+    decreaseBufferedMemoryUsage(_revisionsBufferedMemoryUsage);
+  }
 }
 
 void RocksDBMetaCollection::deferDropCollection(
@@ -887,17 +909,25 @@ Result RocksDBMetaCollection::rebuildRevisionTree() {
       }
 
       {
+        uint64_t memoryUsage = 0;
         auto it = _revisionInsertBuffers.begin();
         while (it != _revisionInsertBuffers.end() && it->first <= seq) {
+          memoryUsage +=
+              bufferedEntrySize() + bufferedEntryItemSize() * it->second.size();
           it = _revisionInsertBuffers.erase(it);
         }
+        decreaseBufferedMemoryUsage(memoryUsage);
       }
 
       {
+        uint64_t memoryUsage = 0;
         auto it = _revisionRemovalBuffers.begin();
         while (it != _revisionRemovalBuffers.end() && it->first <= seq) {
+          memoryUsage +=
+              bufferedEntrySize() + bufferedEntryItemSize() * it->second.size();
           it = _revisionRemovalBuffers.erase(it);
         }
+        decreaseBufferedMemoryUsage(memoryUsage);
       }
     };
 
@@ -1250,37 +1280,21 @@ void RocksDBMetaCollection::bufferUpdates(
       << "for collection " << _logicalCollection.name();
 
   if (!inserts.empty()) {
-    // will default-construct an empty entry if it does not yet exist
-    TRI_ASSERT(_revisionInsertBuffers.find(seq) ==
-               _revisionInsertBuffers.end());
-    auto& elem = _revisionInsertBuffers[seq];
-    if (elem.empty()) {
-      elem = std::move(inserts);
-    } else {
-      // should only happen in recovery, if at all
-      TRI_ASSERT(_logicalCollection.vocbase()
-                     .server()
-                     .getFeature<EngineSelectorFeature>()
-                     .engine()
-                     .inRecovery());
-      elem.insert(elem.end(), inserts.begin(), inserts.end());
+    auto [it, inserted] =
+        _revisionInsertBuffers.emplace(seq, std::move(inserts));
+    TRI_ASSERT(inserted);
+    if (inserted) {
+      increaseBufferedMemoryUsage(bufferedEntrySize() +
+                                  bufferedEntryItemSize() * it->second.size());
     }
   }
   if (!removals.empty()) {
-    // will default-construct an empty entry if it does not yet exist
-    TRI_ASSERT(_revisionRemovalBuffers.find(seq) ==
-               _revisionRemovalBuffers.end());
-    auto& elem = _revisionRemovalBuffers[seq];
-    if (elem.empty()) {
-      elem = std::move(removals);
-    } else {
-      // should only happen in recovery, if at all
-      TRI_ASSERT(_logicalCollection.vocbase()
-                     .server()
-                     .getFeature<EngineSelectorFeature>()
-                     .engine()
-                     .inRecovery());
-      elem.insert(elem.end(), removals.begin(), removals.end());
+    auto [it, inserted] =
+        _revisionRemovalBuffers.emplace(seq, std::move(removals));
+    TRI_ASSERT(inserted);
+    if (inserted) {
+      increaseBufferedMemoryUsage(bufferedEntrySize() +
+                                  bufferedEntryItemSize() * it->second.size());
     }
   }
 }
@@ -1375,13 +1389,27 @@ void RocksDBMetaCollection::applyUpdates(
 
       if (foundTruncate) {
         TRI_ASSERT(ignoreSeq <= commitSeq);
-        while (insertIt != _revisionInsertBuffers.end() &&
-               insertIt->first <= ignoreSeq) {
-          insertIt = _revisionInsertBuffers.erase(insertIt);
+
+        {
+          uint64_t memoryUsage = 0;
+          while (insertIt != _revisionInsertBuffers.end() &&
+                 insertIt->first <= ignoreSeq) {
+            memoryUsage += bufferedEntrySize() +
+                           bufferedEntryItemSize() * insertIt->second.size();
+            insertIt = _revisionInsertBuffers.erase(insertIt);
+          }
+          decreaseBufferedMemoryUsage(memoryUsage);
         }
-        while (removeIt != _revisionRemovalBuffers.end() &&
-               removeIt->first <= ignoreSeq) {
-          removeIt = _revisionRemovalBuffers.erase(removeIt);
+
+        {
+          uint64_t memoryUsage = 0;
+          while (removeIt != _revisionRemovalBuffers.end() &&
+                 removeIt->first <= ignoreSeq) {
+            memoryUsage += bufferedEntrySize() +
+                           bufferedEntryItemSize() * removeIt->second.size();
+            removeIt = _revisionRemovalBuffers.erase(removeIt);
+          }
+          decreaseBufferedMemoryUsage(memoryUsage);
         }
 
         checkIterators();
@@ -1466,7 +1494,11 @@ void RocksDBMetaCollection::applyUpdates(
 
         // if the insert succeeded, we remove it from the list of operations,
         // so it won't be reapplied even if subsequent operations fail.
+        uint64_t memoryUsage =
+            bufferedEntrySize() +
+            bufferedEntryItemSize() * insertIt->second.size();
         insertIt = _revisionInsertBuffers.erase(insertIt);
+        decreaseBufferedMemoryUsage(memoryUsage);
       }
 
       // check for removals
@@ -1505,7 +1537,11 @@ void RocksDBMetaCollection::applyUpdates(
 
         // if the remove succeeded, we remove it from the list of operations,
         // so it won't be reapplied even if subsequent operations fail.
+        uint64_t memoryUsage =
+            bufferedEntrySize() +
+            bufferedEntryItemSize() * removeIt->second.size();
         removeIt = _revisionRemovalBuffers.erase(removeIt);
+        decreaseBufferedMemoryUsage(memoryUsage);
       }
     }
   });
@@ -2010,4 +2046,15 @@ void RocksDBMetaCollection::RevisionTreeAccessor::ensureTree() const {
   }
   TRI_ASSERT(_tree != nullptr);
   TRI_ASSERT(_compressed.empty());
+}
+
+void RocksDBMetaCollection::increaseBufferedMemoryUsage(
+    uint64_t value) noexcept {
+  _revisionsBufferedMemoryUsage += value;
+}
+
+void RocksDBMetaCollection::decreaseBufferedMemoryUsage(
+    uint64_t value) noexcept {
+  TRI_ASSERT(_revisionsBufferedMemoryUsage >= value);
+  _revisionsBufferedMemoryUsage -= value;
 }

--- a/arangod/RocksDBEngine/RocksDBMetaCollection.h
+++ b/arangod/RocksDBEngine/RocksDBMetaCollection.h
@@ -42,7 +42,7 @@ class RocksDBMetaCollection : public PhysicalCollection {
  public:
   explicit RocksDBMetaCollection(LogicalCollection& collection,
                                  velocypack::Slice info);
-  virtual ~RocksDBMetaCollection() = default;
+  virtual ~RocksDBMetaCollection();
 
   void deferDropCollection(
       std::function<bool(LogicalCollection&)> const&) override;
@@ -165,6 +165,15 @@ class RocksDBMetaCollection : public PhysicalCollection {
           std::unique_ptr<containers::RevisionTree>,
           std::unique_lock<std::mutex>& lock)> const& callback);
 
+  // used for calculating memory usage in _revisionsBufferedMemoryUsage
+  // approximate memory usage for top-level items
+  static constexpr uint64_t bufferedEntrySize() { return 40; }
+  // approximate memory usage for individual items in a top-level item
+  static constexpr uint64_t bufferedEntryItemSize() { return sizeof(uint64_t); }
+
+  void increaseBufferedMemoryUsage(uint64_t value) noexcept;
+  void decreaseBufferedMemoryUsage(uint64_t value) noexcept;
+
  protected:
   RocksDBMetadata _meta;  /// collection metadata
   /// @brief collection lock used for write access
@@ -283,6 +292,8 @@ class RocksDBMetaCollection : public PhysicalCollection {
   std::map<rocksdb::SequenceNumber, std::vector<std::uint64_t>>
       _revisionRemovalBuffers;
   std::set<rocksdb::SequenceNumber> _revisionTruncateBuffer;
+
+  uint64_t _revisionsBufferedMemoryUsage;
 };
 
 }  // namespace arangodb

--- a/arangod/RocksDBEngine/RocksDBVPackIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBVPackIndex.cpp
@@ -2717,6 +2717,16 @@ void RocksDBVPackIndex::afterTruncate(TRI_voc_tick_t tick,
   RocksDBIndex::afterTruncate(tick, trx);
 }
 
+Result RocksDBVPackIndex::drop() {
+  Result res = RocksDBIndex::drop();
+
+  if (res.ok() && _estimator != nullptr) {
+    _estimator->freeMemory();
+  }
+
+  return res;
+}
+
 std::shared_ptr<cache::Cache> RocksDBVPackIndex::makeCache() const {
   TRI_ASSERT(_cacheManager != nullptr);
   return _cacheManager->createCache<cache::VPackKeyHasher>(

--- a/arangod/RocksDBEngine/RocksDBVPackIndex.h
+++ b/arangod/RocksDBEngine/RocksDBVPackIndex.h
@@ -133,6 +133,8 @@ class RocksDBVPackIndex : public RocksDBIndex {
 
   void afterTruncate(TRI_voc_tick_t tick, transaction::Methods* trx) override;
 
+  Result drop() override;
+
   std::shared_ptr<cache::Cache> makeCache() const override;
 
   size_t numFieldsToConsiderInIndexSelection() const noexcept override {


### PR DESCRIPTION
### Scope & Purpose

This PR tracks the approximate memory usage by index selectivity estimates that use the RocksDBCuckooIndexEstimator.
Memory is tracked for the base allocation and the queued insert and remove operations. Currently, the memory is tracked by index, but the values can later be added to a global metric.
The PR also releases the memory used by the estimator early when the collection is dropped. Previously, the memory was not released until the server shutdown. this was bad when a lot of collections were created and dropped.
Still missing in this PR is making the total memory usage of estimators available as a metric.

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [x] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.10: *(Please link PR)*
  - [ ] Backport for 3.9: *(Please link PR)*
  - [ ] Backport for 3.8: *(Please link PR)*

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 