### PR TITLE
[INSPECTION] Use `T const&` instead of `T&` for `serializeWithErrorT`

### DIFF
--- a/lib/Inspection/include/Inspection/VPackWithErrorT.h
+++ b/lib/Inspection/include/Inspection/VPackWithErrorT.h
@@ -29,7 +29,7 @@
 namespace arangodb::inspection {
 
 template<typename T>
-[[nodiscard]] auto serializeWithErrorT(T& value)
+[[nodiscard]] auto serializeWithErrorT(T const& value)
     -> errors::ErrorT<Status, velocypack::SharedSlice> {
   auto builder = velocypack::Builder();
   VPackSaveInspector<> inspector(builder);


### PR DESCRIPTION
This matches how inspection's apply method is defined and enables in-place construction of arguments for more readable code.