### PR TITLE
Handling empty list gracefully

### DIFF
--- a/arangod/Cluster/ClusterMethods.cpp
+++ b/arangod/Cluster/ClusterMethods.cpp
@@ -355,8 +355,10 @@ OperationResult handleCRUDShardResponsesFast(
   std::map<ShardID, int> shardError;
   std::unordered_map<::ErrorCode, size_t> errorCounter;
 
-  fuerte::StatusCode code = fuerte::StatusInternalError;
-  // If none of the shards responded we return a SERVER_ERROR;
+  fuerte::StatusCode code =
+      results.empty() ? fuerte::StatusOK : fuerte::StatusInternalError;
+  // If the list of shards is not empty and none of the shards responded we
+  // return a SERVER_ERROR;
 
   for (Try<arangodb::network::Response> const& tryRes : results) {
     network::Response const& res = tryRes.get();  // throws exceptions upwards


### PR DESCRIPTION
### Scope & Purpose

We can get multiple documents at once by accessing the API like this:
- coordinator
  ```curl -X PUT --header 'accept: application/json' --data-binary @- --dump - http://localhost:8530/_api/document/collectionName?onlyget=true <<EOF
['key1', 'key2']
EOF
  ```
- dbserver
  ```curl -X PUT --header 'accept: application/json' --data-binary @- --dump - http://localhost:8531/_api/document/shardId?onlyget=true <<EOF
['key1', 'key2']
EOF
  ```

Both requests exhibit similar behavior. However, when passing an empty list, a _dbserver_ responds with an empty list, while a _coordinator_ gives back an `internal error`. This creates a discrepancy between the two, which is awkward to handle, for example, when writing driver tests (_if coordinator expect this else expect that_).
In my opinion, the error is not only confusing, but wrong - the API should be able to handle an empty list gracefully, as it is technically valid input.

This PR aligns the two by fixing the problem on the coordinator. If it gets an empty list of documents, it responds with an empty list, just as the dbserver does.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification