### PR TITLE
Added `--query.max-collections-per-query` option

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 devel
 -----
 
+* Added startup option `--query.max-collections-per-query` to adjust the
+  limit for the maximum number of collections/shards per query. The option
+  defaults to `2048`, which is equivalent to the previous hardcoded value.
+
 * Updated bundled version of libunwind to 1.7-rc2.
 
 * In batched query results, when executing requests for 

--- a/arangod/Aql/Collections.cpp
+++ b/arangod/Aql/Collections.cpp
@@ -55,9 +55,9 @@ Collection* Collections::add(std::string const& name,
   auto it = _collections.find(name);
 
   if (it == _collections.end()) {
-    if (_collections.size() > _vocbase->server()
-                                  .getFeature<QueryRegistryFeature>()
-                                  .maxCollectionsPerQuery()) {
+    if (_collections.size() >= _vocbase->server()
+                                   .getFeature<QueryRegistryFeature>()
+                                   .maxCollectionsPerQuery()) {
       THROW_ARANGO_EXCEPTION(TRI_ERROR_QUERY_TOO_MANY_COLLECTIONS);
     }
 

--- a/arangod/Aql/Collections.cpp
+++ b/arangod/Aql/Collections.cpp
@@ -22,17 +22,18 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #include "Collections.h"
+#include "ApplicationFeatures/ApplicationServer.h"
 #include "Aql/Collection.h"
 #include "Basics/Exceptions.h"
-#include "VocBase/AccessMode.h"
+#include "RestServer/QueryRegistryFeature.h"
+#include "VocBase/vocbase.h"
 
 #include <velocypack/Builder.h>
 
 using namespace arangodb;
 using namespace arangodb::aql;
 
-Collections::Collections(TRI_vocbase_t* vocbase)
-    : _vocbase(vocbase), _collections() {}
+Collections::Collections(TRI_vocbase_t* vocbase) : _vocbase(vocbase) {}
 
 Collections::~Collections() = default;
 
@@ -54,7 +55,9 @@ Collection* Collections::add(std::string const& name,
   auto it = _collections.find(name);
 
   if (it == _collections.end()) {
-    if (_collections.size() >= MaxCollections) {
+    if (_collections.size() > _vocbase->server()
+                                  .getFeature<QueryRegistryFeature>()
+                                  .maxCollectionsPerQuery()) {
       THROW_ARANGO_EXCEPTION(TRI_ERROR_QUERY_TOO_MANY_COLLECTIONS);
     }
 

--- a/arangod/Aql/Collections.h
+++ b/arangod/Aql/Collections.h
@@ -72,8 +72,6 @@ class Collections {
 
   std::map<std::string, std::unique_ptr<aql::Collection>, std::less<>>
       _collections;
-
-  static size_t const MaxCollections = 2048;
 };
 }  // namespace aql
 }  // namespace arangodb

--- a/arangod/Cluster/ClusterMethods.cpp
+++ b/arangod/Cluster/ClusterMethods.cpp
@@ -2944,6 +2944,12 @@ ClusterMethods::persistCollectionsInAgency(
     std::vector<std::string> dbServers = ci.getCurrentDBServers();
     infos.reserve(collections.size());
 
+    TRI_IF_FAILURE("allShardsOnSameServer") {
+      while (dbServers.size() > 1) {
+        dbServers.pop_back();
+      }
+    }
+
     std::vector<std::shared_ptr<VPackBuffer<uint8_t>>> vpackData;
     vpackData.reserve(collections.size());
 

--- a/arangod/RestServer/QueryRegistryFeature.cpp
+++ b/arangod/RestServer/QueryRegistryFeature.cpp
@@ -181,6 +181,7 @@ QueryRegistryFeature::QueryRegistryFeature(Server& server)
       _allowCollectionsInExpressions(false),
       _logFailedQueries(false),
       _maxQueryStringLength(4096),
+      _maxCollectionsPerQuery(2048),
       _peakMemoryUsageThreshold(4294967296),  // 4GB
       _queryGlobalMemoryLimit(
           defaultMemoryLimit(PhysicalMemory::getValue(), 0.1, 0.90)),
@@ -690,6 +691,19 @@ usage for such conditions. Once the threshold value is reached during the DNF
 conversion of a FILTER condition, the conversion will be aborted, and the query
 will continue with a simplified internal representation of the condition, which
 cannot be used for index lookups.")");
+
+  options
+      ->addOption(
+          "--query.max-collections-per-query",
+          "The maximum number of collections/shards that can be used in "
+          "one AQL query.",
+          new SizeTParameter(&_maxCollectionsPerQuery),
+          arangodb::options::makeDefaultFlags(
+              arangodb::options::Flags::Uncommon,
+              arangodb::options::Flags::DefaultNoComponents,
+              arangodb::options::Flags::OnCoordinator,
+              arangodb::options::Flags::OnSingle))
+      .setIntroducedIn(31007);
 }
 
 void QueryRegistryFeature::validateOptions(

--- a/arangod/RestServer/QueryRegistryFeature.h
+++ b/arangod/RestServer/QueryRegistryFeature.h
@@ -73,6 +73,9 @@ class QueryRegistryFeature final : public ArangodFeature {
   bool requireWith() const noexcept { return _requireWith; }
 #ifdef USE_ENTERPRISE
   bool smartJoins() const noexcept { return _smartJoins; }
+  size_t maxCollectionsPerQuery() const noexcept {
+    return _maxCollectionsPerQuery;
+  }
   bool parallelizeTraversals() const noexcept { return _parallelizeTraversals; }
 #endif
   bool allowCollectionsInExpressions() const noexcept {
@@ -107,6 +110,7 @@ class QueryRegistryFeature final : public ArangodFeature {
   bool _allowCollectionsInExpressions;
   bool _logFailedQueries;
   size_t _maxQueryStringLength;
+  size_t _maxCollectionsPerQuery;
   uint64_t _peakMemoryUsageThreshold;
   uint64_t _queryGlobalMemoryLimit;
   uint64_t _queryMemoryLimit;

--- a/arangod/RestServer/QueryRegistryFeature.h
+++ b/arangod/RestServer/QueryRegistryFeature.h
@@ -73,11 +73,11 @@ class QueryRegistryFeature final : public ArangodFeature {
   bool requireWith() const noexcept { return _requireWith; }
 #ifdef USE_ENTERPRISE
   bool smartJoins() const noexcept { return _smartJoins; }
+  bool parallelizeTraversals() const noexcept { return _parallelizeTraversals; }
+#endif
   size_t maxCollectionsPerQuery() const noexcept {
     return _maxCollectionsPerQuery;
   }
-  bool parallelizeTraversals() const noexcept { return _parallelizeTraversals; }
-#endif
   bool allowCollectionsInExpressions() const noexcept {
     return _allowCollectionsInExpressions;
   }

--- a/tests/js/client/server_parameters/max-collections-per-query-cluster.js
+++ b/tests/js/client/server_parameters/max-collections-per-query-cluster.js
@@ -1,0 +1,95 @@
+/*jshint globalstrict:false, strict:false */
+/*global assertEqual, fail, getOptions*/
+
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2010-2012 triagens GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is triAGENS GmbH, Cologne, Germany
+///
+/// @author Jan Christoph Uhde
+/// @author Copyright 2019, triAGENS GmbH, Cologne, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+if (getOptions === true) {
+  return {
+    'query.max-collections-per-query': '400',
+  };
+}
+
+const jsunity = require("jsunity");
+const arangodb = require("@arangodb");
+const db = arangodb.db;
+const errors = arangodb.errors;
+const { getEndpointsByType, debugCanUseFailAt, debugSetFailAt, debugClearFailAt } = require('@arangodb/test-helper');
+const ep = getEndpointsByType('coordinator');
+
+function OptionsTestSuite () {
+  const cn = "UnitTestsCollection";
+
+  return {
+
+    setUp : function () {
+      // make all shards end up on the same DB server
+      ep.forEach((ep) => {
+        debugSetFailAt(ep, "allShardsOnSameServer");
+      });
+
+      for (let i = 0; i < 5; ++i) {
+        let options = { numberOfShards: 100, replicationFactor: 1 };
+        if (i > 0) {
+          options.distributeShardsLike = cn + "0";
+        }
+        db._create(cn + i, options);
+      }
+    },
+
+    tearDown : function () {
+      ep.forEach((ep) => debugClearFailAt(ep));
+      // must delete in reverse order because of distributeShardsLike
+      for (let i = 5; i > 0; --i) {
+        db._drop(cn + (i - 1));
+      }
+    },
+
+    testTooManyCollections : function () {
+      for (let i = 0; i < 5; ++i) {
+        let parts = [];
+        for (let j = 0; j <= i; ++j) {
+          parts.push("FOR d" + j + " IN " + cn + j);
+        }
+        let query = parts.join(" ") + " RETURN 1";
+        if (i <= 3) {
+          let res = db._query(query).toArray();
+          assertEqual(0, res.length);
+        } else {
+          try {
+            db._query(query);
+            fail();
+          } catch (err) {
+            assertEqual(errors.ERROR_QUERY_TOO_MANY_COLLECTIONS.code, err.errorNum);
+          }
+        }
+      }
+    },
+
+  };
+}
+
+if (ep.length && debugCanUseFailAt(ep[0])) {
+  jsunity.run(OptionsTestSuite);
+}
+return jsunity.done();


### PR DESCRIPTION
### Scope & Purpose

Should fix https://arangodb.atlassian.net/browse/ES-1588

* Added startup option `--query.max-collections-per-query` to adjust the limit for the maximum number of collections/shards per query. The option defaults to `2048`, which is equivalent to the previous hardcoded value.

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.11: https://github.com/arangodb/arangodb/pull/19067
  - [x] Backport for 3.10: https://github.com/arangodb/arangodb/pull/19068
  - [ ] Backport for 3.9: -
  - [ ] Backport for 3.8: -

#### Related Information

- [x] Docs PR: https://github.com/arangodb/docs/pull/1376
- [ ] Enterprise PR:
- [x] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/ES-1588
- [ ] Design document: 