### PR TITLE
Change reported parameter type from "replicationVersion" to "string"

### DIFF
--- a/arangod/Replication2/Version.h
+++ b/arangod/Replication2/Version.h
@@ -41,7 +41,7 @@ namespace arangodb::replication {
 
 enum class Version { ONE = 1, TWO = 2 };
 
-constexpr static auto allowedVersions = {Version::ONE, Version::TWO};
+constexpr inline auto allowedVersions = {Version::ONE, Version::TWO};
 
 auto parseVersion(std::string_view version) -> ResultT<replication::Version>;
 auto parseVersion(velocypack::Slice version) -> ResultT<replication::Version>;

--- a/arangod/Replication2/Version.h
+++ b/arangod/Replication2/Version.h
@@ -41,41 +41,11 @@ namespace arangodb::replication {
 
 enum class Version { ONE = 1, TWO = 2 };
 
+constexpr static auto allowedVersions = {Version::ONE, Version::TWO};
+
 auto parseVersion(std::string_view version) -> ResultT<replication::Version>;
 auto parseVersion(velocypack::Slice version) -> ResultT<replication::Version>;
 
 auto versionToString(Version version) -> std::string_view;
-
-struct ReplicationVersionParameter : public options::Parameter {
-  typedef Version ValueType;
-
-  explicit ReplicationVersionParameter(ValueType* ptr) : ptr(ptr) {}
-
-  std::string name() const override { return "replicationVersion"; }
-  std::string valueString() const override {
-    return std::string{versionToString(*ptr)};
-  }
-
-  std::string set(std::string const& value) override {
-    auto r = parseVersion(value);
-    if (r.ok()) {
-      *ptr = r.get();
-      return "";
-    } else {
-      return std::string{r.errorMessage()};
-    }
-  }
-
-  std::string typeDescription() const override {
-    return Parameter::typeDescription();
-  }
-
-  void toVelocyPack(VPackBuilder& builder, bool detailed) const override {
-    builder.add(VPackValue(versionToString(*ptr)));
-  }
-
-  ValueType* ptr;
-  bool required;
-};
 
 }  // namespace arangodb::replication

--- a/arangod/RestServer/DatabaseFeature.cpp
+++ b/arangod/RestServer/DatabaseFeature.cpp
@@ -248,12 +248,12 @@ void DatabaseFeature::collectOptions(
     std::shared_ptr<options::ProgramOptions> options) {
   options->addSection("database", "database options");
 
-  auto static const allowedReplicationVersions = []{
-      auto result = std::unordered_set<std::string>();
-      for (auto const& version : replication::allowedVersions) {
-        result.emplace(replication::versionToString(version));
-      }
-      return result;
+  auto static const allowedReplicationVersions = [] {
+    auto result = std::unordered_set<std::string>();
+    for (auto const& version : replication::allowedVersions) {
+      result.emplace(replication::versionToString(version));
+    }
+    return result;
   }();
 
   options
@@ -261,8 +261,7 @@ void DatabaseFeature::collectOptions(
                   "default replication version, can be overwritten "
                   "when creating a new database, possible values: 1, 2",
                   new DiscreteValuesParameter<StringParameter>(
-                      &_defaultReplicationVersion,
-                      allowedReplicationVersions),
+                      &_defaultReplicationVersion, allowedReplicationVersions),
                   options::makeDefaultFlags(options::Flags::Uncommon,
                                             options::Flags::Experimental))
       .setIntroducedIn(31200);

--- a/arangod/RestServer/DatabaseFeature.cpp
+++ b/arangod/RestServer/DatabaseFeature.cpp
@@ -248,15 +248,24 @@ void DatabaseFeature::collectOptions(
     std::shared_ptr<options::ProgramOptions> options) {
   options->addSection("database", "database options");
 
+  auto static const allowedReplicationVersions = []{
+      auto result = std::unordered_set<std::string>();
+      for (auto const& version : replication::allowedVersions) {
+        result.emplace(replication::versionToString(version));
+      }
+      return result;
+  }();
+
   options
       ->addOption("--database.default-replication-version",
                   "default replication version, can be overwritten "
                   "when creating a new database, possible values: 1, 2",
-                  new replication::ReplicationVersionParameter(
-                      &_defaultReplicationVersion),
+                  new DiscreteValuesParameter<StringParameter>(
+                      &_defaultReplicationVersion,
+                      allowedReplicationVersions),
                   options::makeDefaultFlags(options::Flags::Uncommon,
                                             options::Flags::Experimental))
-      .setIntroducedIn(31100);
+      .setIntroducedIn(31200);
 
   options->addOption(
       "--database.wait-for-sync",

--- a/arangod/RestServer/DatabaseFeature.h
+++ b/arangod/RestServer/DatabaseFeature.h
@@ -157,7 +157,7 @@ class DatabaseFeature final : public ArangodFeature {
   bool upgrade() const noexcept { return _upgrade; }
   bool waitForSync() const noexcept { return _defaultWaitForSync; }
   replication::Version defaultReplicationVersion() const noexcept {
-    return _defaultReplicationVersion;
+    return replication::parseVersion(_defaultReplicationVersion).get();
   }
 
   /// @brief whether or not extended names for databases, collections, views
@@ -201,7 +201,7 @@ class DatabaseFeature final : public ArangodFeature {
   bool _performIOHeartbeat{true};
   std::atomic_bool _started{false};
 
-  replication::Version _defaultReplicationVersion{replication::Version::ONE};
+  std::string _defaultReplicationVersion{replication::versionToString(replication::Version::ONE)};
 
   std::unique_ptr<DatabaseManagerThread> _databaseManager;
   std::unique_ptr<IOHeartbeatThread> _ioHeartbeatThread;

--- a/arangod/RestServer/DatabaseFeature.h
+++ b/arangod/RestServer/DatabaseFeature.h
@@ -201,7 +201,8 @@ class DatabaseFeature final : public ArangodFeature {
   bool _performIOHeartbeat{true};
   std::atomic_bool _started{false};
 
-  std::string _defaultReplicationVersion{replication::versionToString(replication::Version::ONE)};
+  std::string _defaultReplicationVersion{
+      replication::versionToString(replication::Version::ONE)};
 
   std::unique_ptr<DatabaseManagerThread> _databaseManager;
   std::unique_ptr<IOHeartbeatThread> _ioHeartbeatThread;


### PR DESCRIPTION
### Scope & Purpose

`arangod --dump-options` reported, for the option `database.default-replication-version`, the `"type": "replicationVersion"`; change this to `"type": "string"`.

