### PR TITLE
Retry in case the connection is aborted

### DIFF
--- a/3rdParty/fuerte/src/H1Connection.h
+++ b/3rdParty/fuerte/src/H1Connection.h
@@ -26,16 +26,14 @@
 #include <fuerte/helper.h>
 #include <fuerte/loop.h>
 #include <fuerte/message.h>
+#include <llhttp.h>
 
 #include <atomic>
 #include <chrono>
 #include <optional>
 
-#include <llhttp.h>
-
 #include "GeneralConnection.h"
 #include "http.h"
-
 
 namespace arangodb { namespace fuerte { inline namespace v1 { namespace http {
 
@@ -93,9 +91,9 @@ class H1Connection final : public fuerte::GeneralConnection<ST, RequestItem> {
       std::unique_ptr<Request>&& req, RequestCallback&& cb) override {
 #ifdef ARANGODB_ENABLE_FAILURE_TESTS
     if (req->getFuzzerReq()) {
-      return std::make_unique<RequestItem>(
-          std::move(req), std::move(cb), req->getFuzzReqHeader().value());
-    } 
+      return std::make_unique<RequestItem>(std::move(req), std::move(cb),
+                                           req->getFuzzReqHeader().value());
+    }
 #endif
     auto h = buildRequestHeader(*req);
     return std::make_unique<RequestItem>(std::move(req), std::move(cb),
@@ -115,19 +113,20 @@ class H1Connection final : public fuerte::GeneralConnection<ST, RequestItem> {
   fuerte::Error translateError(asio_ns::error_code const& e,
                                fuerte::Error c) const {
 #ifdef _WIN32
-    if (this->_timeoutOnReadWrite && (c == Error::ReadError ||
-                                      c == Error::WriteError)) {
+    if (this->_timeoutOnReadWrite &&
+        (c == Error::ReadError || c == Error::WriteError)) {
       return Error::RequestTimeout;
     }
 #endif
-    
+
     if (e == asio_ns::error::misc_errors::eof ||
-        e == asio_ns::error::connection_reset) {
+        e == asio_ns::error::connection_reset ||
+        e == asio_ns::error::connection_aborted) {
       return fuerte::Error::ConnectionClosed;
     } else if (e == asio_ns::error::operation_aborted) {
       // keepalive timeout may have expired
-      return this->_timeoutOnReadWrite ? fuerte::Error::RequestTimeout :
-                                         fuerte::Error::ConnectionCanceled;
+      return this->_timeoutOnReadWrite ? fuerte::Error::RequestTimeout
+                                       : fuerte::Error::ConnectionCanceled;
     }
     return c;
   }

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,11 @@
 devel
 -----
 
+* ECONNABORTED is treated as a ConnectionClosed error in fuerte.
+
+* Database drop operation no longer fails if we cannot remove
+  the corresponding permissions from the _users collection.
+
 * Added metric "rocksdb_total_sst_files" to count the number of sst files,
   aggregated over all levels of the LSM tree.
 

--- a/arangod/VocBase/Methods/Databases.cpp
+++ b/arangod/VocBase/Methods/Databases.cpp
@@ -546,7 +546,7 @@ Result Databases::drop(ExecContext const& exec, TRI_vocbase_t* systemVocbase,
     };
     if (auto cleanupUsersRes = um->enumerateUsers(cb, /*retryOnConflict*/ true);
         cleanupUsersRes.fail()) {
-      LOG_TOPIC("9f8b7", ERR, Logger::AUTHORIZATION)
+      LOG_TOPIC("9f8b7", WARN, Logger::AUTHORIZATION)
           << "Failed to cleanup "
              "users permissions after dropping "
              "database "

--- a/arangod/VocBase/Methods/Databases.cpp
+++ b/arangod/VocBase/Methods/Databases.cpp
@@ -544,7 +544,14 @@ Result Databases::drop(ExecContext const& exec, TRI_vocbase_t* systemVocbase,
     auto cb = [&](auth::User& entry) -> bool {
       return entry.removeDatabase(dbName);
     };
-    res = um->enumerateUsers(cb, /*retryOnConflict*/ true);
+    if (auto cleanupUsersRes = um->enumerateUsers(cb, /*retryOnConflict*/ true);
+        cleanupUsersRes.fail()) {
+      LOG_TOPIC("9f8b7", ERR, Logger::AUTHORIZATION)
+          << "Failed to cleanup "
+             "users permissions after dropping "
+             "database "
+          << dbName << ": " << cleanupUsersRes;
+    }
   }
 
   events::DropDatabase(dbName, res, exec);


### PR DESCRIPTION
### Scope & Purpose

As I'm finding this issue quite hard to reproduce (and understand), I decided to provide detailed information in the body of this PR. Feel free to jump directly to **Solution** if you only want to read about the actual changes.

**Background**
During one of the replication2 restart tests, we noticed that sometimes the `database.drop()` call returned _cluster internal HTTP connection broken_. After investigating this, it turned out to originate from a transaction started by the coordinator. A database drop, on the coordinator, involves two steps:
1. Remove the database entry from the agency.
2. Remove the corresponding permissions from the `_users` collection. This is the transaction that used to fail sporadically.

The test that reproduced this failure most often **restarted one of the DBServers**, before dropping the database. This leads to the connections between the coordinator and the respective DBServer being closed.

**Issues**
1. Although the database was dropped from Plan, and subsequently, from all DBServers, the call to `database.drop()` returned an error, due to the failing transaction on the `_users` collection. Not only the error message is confusing in this case (_connection broken_), but the user can't do anything about it. If it retries, all other subsequent `database.drop()` calls are doomed to fail with `DATABASE_NOT_FOUND`, because the database is no longer there. There is no way to reach again the code responsible for cleaning up the `_users` collection.
2. After the DBServer is restarted, its connections are closed. If the coordinator tries to lease a new connection from the connection pool, we should detect that and retry. This is what's supposed to happen in `RequestsState::handleResponse`: _If this connection comes from the pool and we immediately get a connection closed, then we do want to retry_. The problem is that fuerte considers only `ECONNRESET` as a `ClosedConnection` error, but not `ECONNABORTED`. The two are very similar, and it is a question of timing and underlying OS as to whether we get one or the other, which explains why the test was flaky on Windows. You can find more details between the two error codes [here](https://betterstack.com/community/guides/scaling-nodejs/nodejs-errors/).

**Solution**
1. Do not fail in case the `_users` collection cannot be properly cleaned up after a database drop. The client can't do anything about it, it's the job of the sysadmin. Therefore, we log an error instead. Note that stale entries in the `_users` collection cannot affect the overall functioning of the system. As a matter of fact, right now it's even possible to grant permissions to a non-existent database.
2. Label `ECONNABORTED` as a `ClosedConnection`, such that we retry, same as we do with `ECONNRESET`.

**Note** that some of the diff is due to clang-format automatically processing the files I touched in fuerte.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist
- [x] :book: CHANGELOG entry made
- [x] Backports
  - [x] Backport for 3.11: https://github.com/arangodb/arangodb/pull/19079
  - [x] Backport for 3.10: https://github.com/arangodb/arangodb/pull/19082
  - [x] Backport for 3.9: https://github.com/arangodb/arangodb/pull/19083

