### PR TITLE
Wait for writes to Current to become visible locally.

### DIFF
--- a/arangod/Cluster/DBServerAgencySync.cpp
+++ b/arangod/Cluster/DBServerAgencySync.cpp
@@ -373,7 +373,18 @@ DBServerAgencySyncResult DBServerAgencySync::execute() {
                 << " message: " << r.errorMessage()
                 << ". This can be ignored, since it will be retried "
                    "automatically.";
+          } else {
+            if (VPackSlice resultsSlice = r.slice().get("results");
+                resultsSlice.length() > 0) {
+              auto waitIndex = resultsSlice[0].getNumber<uint64_t>();
+              LOG_TOPIC("cdc71", TRACE, Logger::MAINTENANCE)
+                  << "waiting for local current version to update";
+              std::ignore = clusterInfo.waitForCurrent(waitIndex).get();
+              LOG_TOPIC("3f185", TRACE, Logger::MAINTENANCE)
+                  << "current version updated";
+            }
           }
+
         } else {
           LOG_TOPIC("a07e6", TRACE, Logger::MAINTENANCE)
               << "DBServerAgencySync: Nothing to report to Current.";


### PR DESCRIPTION
### Scope & Purpose
It happens from time to time that servers update Current with information that are already present. It appears as if the server does not see its own previous write. Indeed, there is no mechanism that ensures that the maintenance sees its own writes of a previous round.

This PR fixes that.

Note: Some noop-writes are still possible because of the `FollowerInfo`. When it updates the failover candidates after the first write, it might report the same data again.