### PR TITLE
Add a more verbose message to sporadically failing assert

### DIFF
--- a/tests/js/client/server_parameters/test-return-queue-time-header-on.js
+++ b/tests/js/client/server_parameters/test-return-queue-time-header-on.js
@@ -162,7 +162,7 @@ function testSuite() {
       waitForPending(pendingAtStart, 1, n - 30);
 
       let result = arango.GET("/_api/version", { "x-arango-queue-time-seconds": "0.00001" });
-      assertEqual(412, result.code);
+      assertEqual(412, result.code, JSON.stringify(result));
       assertEqual(errors.ERROR_QUEUE_TIME_REQUIREMENT_VIOLATED.code, result.errorNum);
       
       // try with much higher queue time. this should succeed


### PR DESCRIPTION
### Scope & Purpose

For some reason the changed assert sometimes fails with `result.code` being `undefined`; add output of the result to be able to tell slightly better what's going on once this test fails agian.