### PR TITLE
remove outdated defines from the codebase

### DIFF
--- a/arangod/Cache/PlainBucket.h
+++ b/arangod/Cache/PlainBucket.h
@@ -54,11 +54,6 @@ struct PlainBucket {
   std::uint32_t _cachedHashes[slotsData];
   CachedValue* _cachedData[slotsData];
 
-  // padding, if necessary?
-#ifdef TRI_PADDING_32
-  uint32_t _padding[slotsData];
-#endif
-
   //////////////////////////////////////////////////////////////////////////////
   /// @brief Initialize an empty bucket.
   //////////////////////////////////////////////////////////////////////////////

--- a/arangod/Cache/TransactionalBucket.h
+++ b/arangod/Cache/TransactionalBucket.h
@@ -60,11 +60,6 @@ struct TransactionalBucket {
   std::uint32_t _cachedHashes[slotsData];
   CachedValue* _cachedData[slotsData];
 
-  // padding, if necessary?
-#ifdef TRI_PADDING_32
-  uint32_t _padding[slotsData];
-#endif
-
   //////////////////////////////////////////////////////////////////////////////
   /// @brief Initialize an empty bucket.
   //////////////////////////////////////////////////////////////////////////////

--- a/lib/Basics/fasthash.cpp
+++ b/lib/Basics/fasthash.cpp
@@ -26,7 +26,7 @@
 #include "fasthash.h"
 
 uint64_t fasthash64(const void* buf, size_t len, uint64_t seed) {
-#ifndef TRI_UNALIGNED_ACCESS
+#if 1
   // byte-wise hashing to support platforms that don't permit
   // unaligned accesses of uint64_t values (which is the default
   // memory access strategy of fasthash64)

--- a/lib/Basics/operating-system.h
+++ b/lib/Basics/operating-system.h
@@ -28,44 +28,10 @@
 #endif
 
 // -----------------------------------------------------------------------------
-// --Section--                                                processor features
-// -----------------------------------------------------------------------------
-
-// padding
-
-#if defined(__amd64__) || defined(__amd64) || defined(__x86_64__) || \
-    defined(__x86_64) || defined(_M_X64) || defined(_M_AMD64) ||     \
-    defined(__aarch64__)
-#undef TRI_PADDING_32
-#else
-#define TRI_PADDING_32 1
-#endif
-
-// aligned / unaligned access
-
-#if defined(__sparc__) || defined(__arm__) || defined(__arm64__) || \
-    defined(__aarch64__)
-/* unaligned accesses not allowed */
-#undef TRI_UNALIGNED_ACCESS
-#elif defined(__ppc__) || defined(__POWERPC__) || defined(_M_PPC)
-/* unaligned accesses are slow */
-#undef TRI_UNALIGNED_ACCESS
-#elif defined(__i386__) || defined(__x86_64__) || defined(_M_IX86) || \
-    defined(_M_X64)
-/* unaligned accesses should work */
-#define TRI_UNALIGNED_ACCESS 1
-#else
-/* unknown platform. better not use unaligned accesses */
-#undef TRI_UNALIGNED_ACCESS
-#endif
-
-// -----------------------------------------------------------------------------
 // --Section--                                                       v8 features
 // -----------------------------------------------------------------------------
 
 #if defined(__arm__) || defined(__arm64__) || defined(__aarch64__)
-#define TRI_V8_MAXHEAP 1 * 1024
-#elif TRI_PADDING_32
 #define TRI_V8_MAXHEAP 1 * 1024
 #else
 #define TRI_V8_MAXHEAP 3 * 1024

--- a/lib/Rest/HttpRequest.cpp
+++ b/lib/Rest/HttpRequest.cpp
@@ -915,7 +915,8 @@ VPackSlice HttpRequest::payload(bool strictValidation) {
       TRI_ASSERT(_validatedPayload);
       return VPackSlice(_vpackBuilder->slice());
     }
-    return VPackSlice::noneSlice();  // no body
+    // no body
+    // fallthrough intentional
   } else if (_contentType == ContentType::VPACK) {
     if (!_payload.empty()) {
       if (!_validatedPayload) {
@@ -926,9 +927,10 @@ VPackSlice HttpRequest::payload(bool strictValidation) {
       }
       TRI_ASSERT(_validatedPayload);
       return VPackSlice(reinterpret_cast<uint8_t const*>(_payload.data()));
-    } else {
-      return VPackSlice::noneSlice();
     }
+    // no body
+    // fallthrough intentional
   }
+
   return VPackSlice::noneSlice();
 }

--- a/lib/Rest/Version.cpp
+++ b/lib/Rest/Version.cpp
@@ -192,11 +192,8 @@ void Version::initialize() {
   Values["sizeof int"] = arangodb::basics::StringUtils::itoa(sizeof(int));
   Values["sizeof long"] = arangodb::basics::StringUtils::itoa(sizeof(long));
   Values["sizeof void*"] = arangodb::basics::StringUtils::itoa(sizeof(void*));
-#ifdef TRI_UNALIGNED_ACCESS
-  Values["unaligned-access"] = "true";
-#else
+  // always hard-coded to "false" since 3.12
   Values["unaligned-access"] = "false";
-#endif
   Values["v8-version"] = getV8Version();
   Values["vpack-version"] = getVPackVersion();
   Values["zlib-version"] = getZLibVersion();


### PR DESCRIPTION
### Scope & Purpose

This PR removes the following defines from the codebase:
* `TRI_PADDING_32`: was set to 1 if we were on a 32 bit platform. As we don't support 32 bit platforms for many years, it is time now to retire this define. It was only used in a single code component, where it would have added padding on 32 bit systems but none on 64 bit.
* `TRI_UNALIGNED_ACCESS`: was set to 1 on x86_64/amd64, but not on aarch64. when set to 1, the fasthash code potentially did unaligned data reads of its input buffer. This works on x86_64/amd64 but is not portable. When set to 0, the fasthash code would do proper 64 bit-aligned reads, which is portable but may have a slightly negative performance impact. As the define is now removed, we always go with aligned reads, which is portable.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -
  - [ ] Backport for 3.9: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 