### PR TITLE
avoid duplicate gzip encoding

### DIFF
--- a/arangod/GeneralServer/CommTask.cpp
+++ b/arangod/GeneralServer/CommTask.cpp
@@ -524,6 +524,7 @@ void CommTask::executeRequest(std::unique_ptr<GeneralRequest> request,
     RequestStatistics::Item stats = stealStatistics(messageId);
     stats.SET_ASYNC();
     handler->setStatistics(std::move(stats));
+    handler->setIsAsyncRequest();
 
     uint64_t jobId = 0;
 

--- a/arangod/GeneralServer/RestHandler.cpp
+++ b/arangod/GeneralServer/RestHandler.cpp
@@ -597,7 +597,7 @@ void RestHandler::generateError(rest::ResponseCode code, ErrorCode errorNumber,
 }
 
 void RestHandler::compressResponse() {
-  if (_response->isCompressionAllowed()) {
+  if (!_isAsyncRequest && _response->isCompressionAllowed()) {
     switch (_request->acceptEncoding()) {
       case rest::EncodingType::DEFLATE:
         _response->deflate();

--- a/arangod/GeneralServer/RestHandler.h
+++ b/arangod/GeneralServer/RestHandler.h
@@ -98,6 +98,8 @@ class RestHandler : public std::enable_shared_from_this<RestHandler> {
   RequestStatistics::Item&& stealStatistics();
   void setStatistics(RequestStatistics::Item&& stat);
 
+  void setIsAsyncRequest() noexcept { _isAsyncRequest = true; }
+
   /// Execute the rest handler state machine
   void runHandler(std::function<void(rest::RestHandler*)> cb) {
     TRI_ASSERT(_state == HandlerState::PREPARE);
@@ -213,6 +215,10 @@ class RestHandler : public std::enable_shared_from_this<RestHandler> {
   // can only be true during handler execution, and only for
   // low priority tasks
   bool _trackedAsOngoingLowPrio;
+
+  // whether or not the handler handles a request for the async
+  // job api (/_api/job) or the batch API (/_api/batch)
+  bool _isAsyncRequest = false;
 
   RequestLane _lane;
 

--- a/arangod/RestHandler/RestBatchHandler.cpp
+++ b/arangod/RestHandler/RestBatchHandler.cpp
@@ -234,6 +234,8 @@ bool RestBatchHandler::executeNextHandler() {
 
       return false;
     }
+
+    handler->setIsAsyncRequest();
   }
 
   // assume a bad lane, so the request is definitely executed via the queues


### PR DESCRIPTION
### Scope & Purpose

Avoid duplicate gzip encoding in the `/_api/job` API.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.11: https://github.com/arangodb/arangodb/pull/19104
  - [ ] Backport for 3.10: -
  - [ ] Backport for 3.9: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 