### PR TITLE
Update iresearch and fix missing include

### DIFF
--- a/3rdParty/V8/v7.9.317/src/base/logging.h
+++ b/3rdParty/V8/v7.9.317/src/base/logging.h
@@ -5,6 +5,7 @@
 #ifndef V8_BASE_LOGGING_H_
 #define V8_BASE_LOGGING_H_
 
+#include <cstdint>
 #include <cstring>
 #include <sstream>
 #include <string>

--- a/3rdParty/V8/v7.9.317/src/base/macros.h
+++ b/3rdParty/V8/v7.9.317/src/base/macros.h
@@ -5,6 +5,7 @@
 #ifndef V8_BASE_MACROS_H_
 #define V8_BASE_MACROS_H_
 
+#include <cstdint>
 #include <limits>
 #include <type_traits>
 

--- a/3rdParty/V8/v7.9.317/src/inspector/v8-string-conversions.h
+++ b/3rdParty/V8/v7.9.317/src/inspector/v8-string-conversions.h
@@ -5,6 +5,7 @@
 #ifndef V8_INSPECTOR_V8_STRING_CONVERSIONS_H_
 #define V8_INSPECTOR_V8_STRING_CONVERSIONS_H_
 
+#include <cstdint>
 #include <string>
 
 // Conversion routines between UT8 and UTF16, used by string-16.{h,cc}. You may

--- a/arangod/Aql/AttributeNamePath.h
+++ b/arangod/Aql/AttributeNamePath.h
@@ -23,6 +23,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <functional>
 #include <iosfwd>
 #include <string>

--- a/arangod/Aql/IndexHint.h
+++ b/arangod/Aql/IndexHint.h
@@ -23,6 +23,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <iosfwd>
 #include <string>
 #include <vector>

--- a/arangod/Aql/QueryString.h
+++ b/arangod/Aql/QueryString.h
@@ -25,6 +25,7 @@
 
 #include "Basics/Common.h"
 
+#include <cstdint>
 #include <iosfwd>
 #include <string>
 #include <string_view>

--- a/arangod/Graph/Helpers/TraceEntry.h
+++ b/arangod/Graph/Helpers/TraceEntry.h
@@ -24,6 +24,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <limits>
 #include <numeric>
 #include <ostream>

--- a/arangod/Utils/UrlHelper.h
+++ b/arangod/Utils/UrlHelper.h
@@ -23,6 +23,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <optional>
 #include <variant>
 

--- a/arangod/Zkd/ZkdHelper.h
+++ b/arangod/Zkd/ZkdHelper.h
@@ -22,6 +22,8 @@
 /// @author Lars Maier
 ////////////////////////////////////////////////////////////////////////////////
 #pragma once
+
+#include <cstdint>
 #include <cstddef>
 #include <iosfwd>
 #include <limits>

--- a/lib/Basics/conversions.h
+++ b/lib/Basics/conversions.h
@@ -23,6 +23,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 
 #include "Basics/Common.h"

--- a/lib/Basics/threads.h
+++ b/lib/Basics/threads.h
@@ -23,6 +23,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "Basics/ErrorCode.h"
 #include "Basics/operating-system.h"
 

--- a/lib/Containers/details/HashSetImpl.h
+++ b/lib/Containers/details/HashSetImpl.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <algorithm>
+#include <cstdint>
 #include <cstring>
 #include <initializer_list>
 #include <iterator>

--- a/lib/Rest/CommonDefines.h
+++ b/lib/Rest/CommonDefines.h
@@ -23,6 +23,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <ostream>
 #include <string>
 

--- a/lib/Ssl/SslInterface.h
+++ b/lib/Ssl/SslInterface.h
@@ -23,6 +23,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <cstdlib>
 #include <string>
 #include <string_view>


### PR DESCRIPTION
### Scope & Purpose

Missing include caused build error for new libstdc++

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*
  - [ ] Backport for 3.9: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

