### PR TITLE
[DEVEL][BTS-431] Additional KPaths tests

### DIFF
--- a/js/server/modules/@arangodb/testutils/aql-graph-traversal-generic-tests.js
+++ b/js/server/modules/@arangodb/testutils/aql-graph-traversal-generic-tests.js
@@ -2899,6 +2899,80 @@ function testSmallCircleKPathsOutbound(testGraph) {
   assertResIsEqualInPathList(necessaryPaths, foundPaths);
 }
 
+function testSmallCircleKPathsOutboundLimitAndFilter(testGraph) {
+  assertTrue(testGraph.name().startsWith(protoGraphs.smallCircle.name()));
+  const query = aql`
+        FOR path IN 1..3 OUTBOUND K_PATHS ${testGraph.vertex('A')} TO ${testGraph.vertex('D')}
+        GRAPH ${testGraph.name()}
+        FILTER LENGTH(path.vertices[*]._key) ALL == 1 
+        LIMIT 1
+        RETURN path.vertices[* RETURN CURRENT.key]
+      `;
+
+  const necessaryPaths = [
+    ["A", "B", "C", "D"]
+  ];
+
+  const res = db._query(query);
+  const foundPaths = res.toArray();
+
+  assertResIsEqualInPathList(necessaryPaths, foundPaths);
+}
+
+function testSmallCircleKPathsInboundMinZero(testGraph) {
+  assertTrue(testGraph.name().startsWith(protoGraphs.smallCircle.name()));
+  const query = aql`
+        FOR path IN 0..2 INBOUND K_PATHS ${testGraph.vertex('C')} TO ${testGraph.vertex('A')}
+        GRAPH ${testGraph.name()}
+        RETURN path.vertices[* RETURN CURRENT.key]
+      `;
+
+  const necessaryPaths = [
+    ["C", "B", "A"]
+  ];
+
+  const res = db._query(query);
+  const foundPaths = res.toArray();
+
+  assertResIsEqualInPathList(necessaryPaths, foundPaths);
+}
+
+function testSmallCircleKPathsNoDepthDeclared(testGraph) {
+  assertTrue(testGraph.name().startsWith(protoGraphs.smallCircle.name()));
+  const query = aql`
+        FOR path IN INBOUND K_PATHS ${testGraph.vertex('C')} TO ${testGraph.vertex('A')}
+        GRAPH ${testGraph.name()}
+        RETURN path.vertices[* RETURN CURRENT.key]
+      `;
+
+  const necessaryPaths = [
+    []
+  ];
+
+  const res = db._query(query);
+  const foundPaths = res.toArray();
+
+  assertResIsEqualInPathList(necessaryPaths, foundPaths);
+}
+
+function testSmallCircleKPathsSourceAndTargetIdentical(testGraph) {
+  assertTrue(testGraph.name().startsWith(protoGraphs.smallCircle.name()));
+  const query = aql`
+        FOR path IN INBOUND K_PATHS ${testGraph.vertex('A')} TO ${testGraph.vertex('A')}
+        GRAPH ${testGraph.name()}
+        RETURN path.vertices[* RETURN CURRENT.key]
+      `;
+
+  const necessaryPaths = [
+    ["A"]
+  ];
+
+  const res = db._query(query);
+  const foundPaths = res.toArray();
+
+  assertResIsEqualInPathList(necessaryPaths, foundPaths);
+}
+
 function testSmallCircleKPathsAny(testGraph) {
   assertTrue(testGraph.name().startsWith(protoGraphs.smallCircle.name()));
   const query = aql`
@@ -6696,6 +6770,10 @@ const testsByGraph = {
     testSmallCircleBFSParallelismSubqueryOuterLoopSecondTraversal,
     testSmallCircleShortestPath,
     testSmallCircleKPathsOutbound,
+    testSmallCircleKPathsOutboundLimitAndFilter,
+    testSmallCircleKPathsInboundMinZero,
+    testSmallCircleKPathsNoDepthDeclared,
+    testSmallCircleKPathsSourceAndTargetIdentical,
     testSmallCircleKPathsAny,
     testSmallCircleKPathsInbound,
     testSmallCircleShortestPathEnabledWeightCheck,


### PR DESCRIPTION
### Scope & Purpose

Added additional KPATHs related tests

* KPaths Query, where min and max are not declared at all.
* KPaths Query, where min=0 and max > 0.
* KPaths Query, where source and targer are identical.
* KPaths Query with LIMIT and FILTER keywords

Not added: 

* KPaths Query with non-existing vertices, not added here as we have this case under test:
  * File: tests/js/server/aql/aql-graph.js, Test: testKPathsConnectedButInnerVertexDeleted
  
* KPaths Query, where OPTIONS are set (support is implemented, but currently no effect with KPATHS)
  * File: tests/js/server/aql/aql-graph.js, Test: testKPathsInvalidOptionsParameter

### Checklist

- [x] Tests
  - [x] **integration tests**
- [ ] Backports
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*
  - [ ] Backport for 3.9: *(Please link PR)*

#### Related Information

- [x] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/BTS-431

