### PR TITLE
Fix TimeStampTransformer

### DIFF
--- a/lib/Inspection/CMakeLists.txt
+++ b/lib/Inspection/CMakeLists.txt
@@ -1,5 +1,10 @@
 add_library(arango_inspection INTERFACE)
 
+target_link_libraries(arango_inspection
+  INTERFACE
+    date_interface
+    fmt::fmt)
+
 target_include_directories(arango_inspection
   INTERFACE
   include)

--- a/lib/Inspection/include/Inspection/Transformers.h
+++ b/lib/Inspection/include/Inspection/Transformers.h
@@ -36,7 +36,7 @@ namespace arangodb::inspection {
 struct TimeStampTransformer {
   using SerializedType = std::string;
   using clock = std::chrono::system_clock;
-  static constexpr std::string_view formatString = "%Y-%m-%d %H:%M:%S";
+  static constexpr std::string_view formatString = "%FT%TZ";
   auto toSerialized(clock::time_point source, std::string& target) const
       -> inspection::Status {
     target = date::format(formatString.data(), source);

--- a/lib/Inspection/include/Inspection/Transformers.h
+++ b/lib/Inspection/include/Inspection/Transformers.h
@@ -39,7 +39,8 @@ struct TimeStampTransformer {
   static constexpr std::string_view formatString = "%FT%TZ";
   auto toSerialized(clock::time_point source, std::string& target) const
       -> inspection::Status {
-    target = date::format(formatString.data(), source);
+    target =
+        date::format(formatString.data(), floor<std::chrono::seconds>(source));
     return {};
   }
   auto fromSerialized(std::string const& source,

--- a/lib/Inspection/include/Inspection/Transformers.h
+++ b/lib/Inspection/include/Inspection/Transformers.h
@@ -26,21 +26,34 @@
 #include <chrono>
 #include "Basics/TimeString.h"
 #include "Basics/ErrorCode.h"
+#include "Inspection/Status.h"
+
+#include "date/date.h"
+#include "fmt/core.h"
 
 namespace arangodb::inspection {
 
 struct TimeStampTransformer {
   using SerializedType = std::string;
   using clock = std::chrono::system_clock;
+  static constexpr std::string_view formatString = "%Y-%m-%d %H:%M:%S";
   auto toSerialized(clock::time_point source, std::string& target) const
       -> inspection::Status {
-    target = timepointToString(source);
+    target = date::format(formatString.data(), source);
     return {};
   }
   auto fromSerialized(std::string const& source,
                       clock::time_point& target) const -> inspection::Status {
-    target = stringToTimepoint(source);
-    return {};
+    auto in = std::istringstream{source};
+    in >> date::parse(formatString.data(), target);
+
+    if (in.fail()) {
+      return inspection::Status(
+          fmt::format("failed to parse timestamp `{}` using format string `{}`",
+                      source, formatString));
+    } else {
+      return {};
+    }
   }
 };
 

--- a/tests/Inspection/CMakeLists.txt
+++ b/tests/Inspection/CMakeLists.txt
@@ -7,6 +7,7 @@ target_include_directories(arango_inspection_test_helper
 add_library(arango_tests_inspection OBJECT
   InspectionTest.cpp
   JsonPrintTest.cpp
+  TransformerTest.cpp
   ValidateTest.cpp
   ValidateTest.cpp
   VPackLoadTest.cpp
@@ -15,7 +16,6 @@ add_library(arango_tests_inspection OBJECT
 target_link_libraries(arango_tests_inspection
   PRIVATE gtest
           velocypack
-          fmt::fmt
           arango_lightweight # jezas.
           arango_inspection
           arango_inspection_test_helper)

--- a/tests/Inspection/TransformerTest.cpp
+++ b/tests/Inspection/TransformerTest.cpp
@@ -1,0 +1,142 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2023 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Markus Pfeiffer
+////////////////////////////////////////////////////////////////////////////////
+#include "gtest/gtest.h"
+
+#include "date/date.h"
+
+#include <string>
+#include <chrono>
+
+#include "Inspection/Transformers.h"
+#include "Inspection/VPackWithErrorT.h"
+#include "VelocypackUtils/VelocyPackStringLiteral.h"
+
+using namespace arangodb;
+using namespace arangodb::velocypack;
+
+struct TimeStampTransformerTest : public ::testing::Test {
+  using TimeStamp = std::chrono::system_clock::time_point;
+  inspection::TimeStampTransformer transformer{};
+};
+
+TEST_F(TimeStampTransformerTest, transforms_min) {
+  auto target = std::string{};
+  auto result = transformer.toSerialized(TimeStamp::min(), target);
+
+  EXPECT_TRUE(result.ok());
+  EXPECT_EQ(date::format("%Y-%m-%d %H:%M:%S", TimeStamp::min()), target);
+}
+
+TEST_F(TimeStampTransformerTest, transforms_now) {
+  auto const& now = std::chrono::system_clock::now();
+
+  auto target = std::string{};
+  auto result = transformer.toSerialized(now, target);
+
+  EXPECT_TRUE(result.ok());
+  EXPECT_EQ(date::format("%Y-%m-%d %H:%M:%S", now), target);
+}
+
+TEST_F(TimeStampTransformerTest, transforms_back) {
+  using namespace std::chrono;
+  constexpr auto testinput = "2021-11-11 11:11:11";
+  constexpr system_clock::time_point testoutput =
+      std::chrono::sys_days{2021y / 11 / 11} + 11h + 11min + 11s;
+
+  auto target = std::chrono::system_clock::time_point{};
+  auto result = transformer.fromSerialized(testinput, target);
+
+  EXPECT_EQ(target, testoutput);
+
+  EXPECT_TRUE(result.ok());
+}
+
+TEST_F(TimeStampTransformerTest, parse_fails) {
+  auto const& testinput = "2021-11-11 __:??:11";
+  auto target = std::chrono::system_clock::time_point{};
+  auto result = transformer.fromSerialized(testinput, target);
+
+  ASSERT_EQ(result.error(),
+            "failed to parse timestamp `2021-11-11 __:??:11` using format "
+            "string `%Y-%m-%d %H:%M:%S`");
+  EXPECT_FALSE(result.ok());
+}
+
+namespace {
+struct IContainATimeStamp {
+  std::chrono::system_clock::time_point stamp;
+
+  auto operator<=>(IContainATimeStamp const& other) const = default;
+};
+template<class Inspector>
+auto inspect(Inspector& f, IContainATimeStamp& x) {
+  return f.object(x).fields(
+      f.field("timeStamp", x.stamp)
+          .transformWith(inspection::TimeStampTransformer{}));
+}
+
+}  // namespace
+
+TEST_F(TimeStampTransformerTest, struct_with_timestamp_serializes) {
+  using namespace std::chrono;
+  auto input = IContainATimeStamp{
+      .stamp = std::chrono::sys_days{2021y / 11 / 11} + 11h + 11min + 11s};
+
+  auto res = inspection::serializeWithErrorT(input);
+
+  ASSERT_TRUE(res.ok());
+  ASSERT_EQ(res.get().toJson(),
+            R"json({"timeStamp":"2021-11-11 11:11:11.000000000"})json");
+}
+
+TEST_F(TimeStampTransformerTest, struct_with_timestamp_deserializes) {
+  using namespace std::chrono;
+
+  auto input = R"({"timeStamp":"1900-01-01 11:11:11.000000000"})"_vpack;
+
+  auto res = inspection::deserializeWithErrorT<IContainATimeStamp>(input);
+
+  ASSERT_TRUE(res.ok());
+  ASSERT_EQ(res.get(),
+            IContainATimeStamp{.stamp = std::chrono::sys_days{1900y / 1 / 1} +
+                                        11h + 11min + 11s});
+}
+
+TEST_F(TimeStampTransformerTest, transformer_is_left_inverse) {
+  using namespace std::chrono;
+  constexpr system_clock::time_point test =
+      std::chrono::sys_days{2021y / 1 / 27} + 11h + 17min + 19s;
+
+  auto deserialized = system_clock::time_point{};
+  auto serialized = std::string{};
+
+  auto serResult = transformer.toSerialized(test, serialized);
+
+  EXPECT_TRUE(serResult.ok());
+  EXPECT_EQ(date::format("2021-01-27 11:17:19.000000000", test), serialized);
+
+  auto deserResult = transformer.fromSerialized(serialized, deserialized);
+
+  EXPECT_TRUE(deserResult.ok());
+  EXPECT_EQ(test, deserialized);
+}

--- a/tests/Inspection/TransformerTest.cpp
+++ b/tests/Inspection/TransformerTest.cpp
@@ -44,7 +44,7 @@ TEST_F(TimeStampTransformerTest, transforms_min) {
   auto result = transformer.toSerialized(TimeStamp::min(), target);
 
   EXPECT_TRUE(result.ok());
-  EXPECT_EQ(date::format("%Y-%m-%d %H:%M:%S", TimeStamp::min()), target);
+  EXPECT_EQ(date::format("%FT%TZ", TimeStamp::min()), target);
 }
 
 TEST_F(TimeStampTransformerTest, transforms_now) {
@@ -54,12 +54,12 @@ TEST_F(TimeStampTransformerTest, transforms_now) {
   auto result = transformer.toSerialized(now, target);
 
   EXPECT_TRUE(result.ok());
-  EXPECT_EQ(date::format("%Y-%m-%d %H:%M:%S", now), target);
+  EXPECT_EQ(date::format("%FT%TZ", now), target);
 }
 
 TEST_F(TimeStampTransformerTest, transforms_back) {
   using namespace std::chrono;
-  constexpr auto testinput = "2021-11-11 11:11:11";
+  constexpr auto testinput = "2021-11-11T11:11:11Z";
   constexpr system_clock::time_point testoutput =
       std::chrono::sys_days{2021y / 11 / 11} + 11h + 11min + 11s;
 
@@ -78,7 +78,7 @@ TEST_F(TimeStampTransformerTest, parse_fails) {
 
   ASSERT_EQ(result.error(),
             "failed to parse timestamp `2021-11-11 __:??:11` using format "
-            "string `%Y-%m-%d %H:%M:%S`");
+            "string `%FT%TZ`");
   EXPECT_FALSE(result.ok());
 }
 
@@ -106,13 +106,13 @@ TEST_F(TimeStampTransformerTest, struct_with_timestamp_serializes) {
 
   ASSERT_TRUE(res.ok());
   ASSERT_EQ(res.get().toJson(),
-            R"json({"timeStamp":"2021-11-11 11:11:11.000000000"})json");
+            R"json({"timeStamp":"2021-11-11T11:11:11.000000000Z"})json");
 }
 
 TEST_F(TimeStampTransformerTest, struct_with_timestamp_deserializes) {
   using namespace std::chrono;
 
-  auto input = R"({"timeStamp":"1900-01-01 11:11:11.000000000"})"_vpack;
+  auto input = R"({"timeStamp":"1900-01-01T11:11:11.000000000Z"})"_vpack;
 
   auto res = inspection::deserializeWithErrorT<IContainATimeStamp>(input);
 
@@ -133,7 +133,7 @@ TEST_F(TimeStampTransformerTest, transformer_is_left_inverse) {
   auto serResult = transformer.toSerialized(test, serialized);
 
   EXPECT_TRUE(serResult.ok());
-  EXPECT_EQ(date::format("2021-01-27 11:17:19.000000000", test), serialized);
+  EXPECT_EQ(date::format("2021-01-27T11:17:19.000000000Z", test), serialized);
 
   auto deserResult = transformer.fromSerialized(serialized, deserialized);
 

--- a/tests/Inspection/TransformerTest.cpp
+++ b/tests/Inspection/TransformerTest.cpp
@@ -86,7 +86,9 @@ namespace {
 struct IContainATimeStamp {
   std::chrono::system_clock::time_point stamp;
 
-  auto operator<=>(IContainATimeStamp const& other) const = default;
+  auto operator==(IContainATimeStamp const& other) const {
+    return stamp == other.stamp;
+  }
 };
 template<class Inspector>
 auto inspect(Inspector& f, IContainATimeStamp& x) {


### PR DESCRIPTION
Previously the implementation of `TimeStampTransformer`, which takes a `std::chrono::system_clock::time_point` and transforms it into a string used the ArangoDB library function `timepointToString`.

This function in turn converted the `time_point` into a `time_t` and then uses `TRI_gmtime` to format the `time_point`.

If one uses std::chrono::system_clock::time_point::min() as input value to timepointToString, this yields an invalid time_t on some platforms (in particular here Windows), leading to an error in gmtime.

The ArangoDB library function ignores that error and continues.

This leads to invalid characters being left in the serialisation of the timepoint.

This PR changes the `TimeStampTransformer` to use formatting and parsing functions from the `date.h` library to perform (de)serialisation of timestamps.

It also adds some tests.

### Scope & Purpose

*(Please describe the changes in this PR for reviewers, motivation, rationale - **mandatory**)*

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [x] Tests
  - [ ] **Regression tests**
  - [x] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*
  - [ ] Backport for 3.9: *(Please link PR)*

