### PR TITLE
SEARCH-479 Use less memory for n removes in single transaction

### DIFF
--- a/arangod/IResearch/IResearchDataStore.cpp
+++ b/arangod/IResearch/IResearchDataStore.cpp
@@ -331,11 +331,6 @@ auto makeAfterCommitCallback(void* key) {
     }
     // TODO FIXME find a better way to look up a ViewState
     auto& ctx = basics::downCast<IResearchTrxState>(*prev);
-    if (!ctx._removals.empty()) {
-      auto filter =
-          std::make_shared<PrimaryKeyFilterContainer>(std::move(ctx._removals));
-      ctx._ctx.Remove<false>(std::move(filter));
-    }
     if constexpr (WasCreated) {
       auto const lastOperationTick = state.lastOperationTick();
       ctx._ctx.Commit(lastOperationTick);
@@ -658,6 +653,11 @@ IResearchDataStore::IResearchDataStore(
     }
     // TODO FIXME find a better way to look up a ViewState
     auto& ctx = basics::downCast<IResearchTrxState>(*prev);
+    TRI_ASSERT(ctx._removals != nullptr);
+    if (!ctx._removals->empty()) {
+      ctx._ctx.Remove(std::move(ctx._removals));
+    }
+    ctx._removals.reset();
     ctx._ctx.RegisterFlush();
   };
   _afterCommitCallback = makeAfterCommitCallback<false>(this);
@@ -1540,8 +1540,8 @@ Result IResearchDataStore::remove(transaction::Methods& trx,
 
     TRI_ASSERT(_dataStore);  // must be valid if _asyncSelf->get() is valid
 
-    auto ptr = std::make_unique<IResearchTrxState>(std::move(linkLock),
-                                                   *(_dataStore._writer));
+    auto ptr = std::make_unique<IResearchTrxState>(
+        std::move(linkLock), *(_dataStore._writer), nested);
 
     ctx = ptr.get();
     state.cookie(key, std::move(ptr));
@@ -1563,7 +1563,7 @@ Result IResearchDataStore::remove(transaction::Methods& trx,
   // all all of its fid stores, no impact to iResearch View data integrity
   // ...........................................................................
   try {
-    ctx->remove(documentId, nested);
+    ctx->remove(documentId);
 
     return {TRI_ERROR_NO_ERROR};
   } catch (basics::Exception const& e) {
@@ -1713,8 +1713,8 @@ Result IResearchDataStore::insert(transaction::Methods& trx,
     }
 
     TRI_ASSERT(_dataStore);  // must be valid if _asyncSelf->get() is valid
-    auto ptr = std::make_unique<IResearchTrxState>(std::move(linkLock),
-                                                   *(_dataStore._writer));
+    auto ptr = std::make_unique<IResearchTrxState>(
+        std::move(linkLock), *(_dataStore._writer), meta.hasNested());
 
     ctx = ptr.get();
     state.cookie(key, std::move(ptr));

--- a/arangod/IResearch/IResearchDataStore.h
+++ b/arangod/IResearch/IResearchDataStore.h
@@ -65,19 +65,23 @@ struct IResearchTrxState final : public TransactionState::Cookie {
   // prevent data-store deallocation (lock @ AsyncSelf)
   LinkLock _linkLock;  // should be first field to destroy last
   irs::IndexWriter::Transaction _ctx;
-  PrimaryKeyFilterContainer _removals;  // list of document removals
+  std::shared_ptr<PrimaryKeysFilterBase> _removals;
 
-  IResearchTrxState(LinkLock&& linkLock, irs::IndexWriter& writer) noexcept
-      : _linkLock{std::move(linkLock)}, _ctx{writer.GetBatch()} {}
+  IResearchTrxState(LinkLock&& linkLock, irs::IndexWriter& writer,
+                    bool nested) noexcept
+      : _linkLock{std::move(linkLock)},
+        _ctx{writer.GetBatch()},
+        _removals{nested ? std::static_pointer_cast<PrimaryKeysFilterBase>(
+                               std::make_shared<PrimaryKeysFilter<true>>())
+                         : std::static_pointer_cast<PrimaryKeysFilterBase>(
+                               std::make_shared<PrimaryKeysFilter<false>>())} {}
 
   ~IResearchTrxState() final {
-    _removals.clear();
+    // TODO(MBkkt) Make Abort in ~Transaction()
     _ctx.Abort();
   }
 
-  void remove(LocalDocumentId value, bool nested) {
-    _ctx.Remove(_removals.emplace(value, nested));
-  }
+  void remove(LocalDocumentId value) { _removals->emplace(value); }
 };
 
 void clusterCollectionName(LogicalCollection const& collection, ClusterInfo* ci,

--- a/arangod/IResearch/IResearchInvertedIndexMeta.h
+++ b/arangod/IResearch/IResearchInvertedIndexMeta.h
@@ -176,6 +176,8 @@ struct IResearchInvertedIndexMetaIndexingContext {
 
   Features const& features() const noexcept { return _features; }
 
+  bool hasNested() const noexcept { return _hasNested; }
+
   absl::flat_hash_map<std::string_view,
                       IResearchInvertedIndexMetaIndexingContext>
       _fields;

--- a/arangod/IResearch/IResearchPrimaryKeyFilter.h
+++ b/arangod/IResearch/IResearchPrimaryKeyFilter.h
@@ -36,7 +36,9 @@ class PrimaryKeysFilterBase : public irs::filter,
                               public irs::filter::prepared,
                               public irs::doc_iterator {
  public:
-  void emplace(LocalDocumentId value) { _pks.emplace_back(value.id()); }
+  void emplace(LocalDocumentId value) {
+    _pks.emplace_back(DocumentPrimaryKey::encode(value));
+  }
 
   bool empty() const noexcept { return _pks.empty(); }
 

--- a/arangod/IResearch/IResearchPrimaryKeyFilter.h
+++ b/arangod/IResearch/IResearchPrimaryKeyFilter.h
@@ -30,131 +30,80 @@
 #include "search/filter.hpp"
 #include "utils/type_limits.hpp"
 
-namespace arangodb {
-class StorageEngine;
-namespace iresearch {
+namespace arangodb::iresearch {
 
-///////////////////////////////////////////////////////////////////////////////
-/// @class PrimaryKeyFilter
-/// @brief iresearch filter optimized for filtering on primary keys
-///////////////////////////////////////////////////////////////////////////////
-class PrimaryKeyFilter final : public irs::filter,
-                               public irs::filter::prepared {
+class PrimaryKeysFilterBase : public irs::filter,
+                              public irs::filter::prepared,
+                              public irs::doc_iterator {
  public:
-  static constexpr std::string_view type_name() noexcept {
-    return "arangodb::iresearch::PrimaryKeyFilter";
-  }
+  void emplace(LocalDocumentId value) { _pks.emplace_back(value.id()); }
 
-  PrimaryKeyFilter(LocalDocumentId value, bool nested) noexcept;
+  bool empty() const noexcept { return _pks.empty(); }
 
-  irs::type_info::type_id type() const noexcept final {
-    return irs::type<PrimaryKeyFilter>::id();
-  }
-  irs::doc_iterator::ptr execute(irs::ExecutionContext const& ctx) const final;
-
-  size_t hash() const noexcept final;
-
-  using irs::filter::prepare;
-  filter::prepared::ptr prepare(
-      irs::IndexReader const& index, irs::Scorers const& /*ord*/,
-      irs::score_t /*boost*/,
-      irs::attribute_provider const* /*ctx*/) const final;
-
-  void visit(irs::SubReader const&, irs::PreparedStateVisitor&,
-             irs::score_t) const final {
-    // NOOP
-  }
-
- private:
-  bool equals(filter const& rhs) const noexcept final;
-
-  struct PrimaryKeyIterator final : public irs::doc_iterator {
-    PrimaryKeyIterator() = default;
-
-    bool next() noexcept final {
-      if (_count != 0) {
-        ++_doc.value;
-        --_count;
-        return true;
-      }
-
-      _doc.value = irs::doc_limits::eof();
-      return false;
-    }
-
-    irs::doc_id_t seek(irs::doc_id_t) noexcept final {
-      TRI_ASSERT(false);
-      // We don't expect this is ever called for removals.
-      _count = 0;
-      _doc.value = irs::doc_limits::eof();
-      return irs::doc_limits::eof();
-    }
-
-    irs::doc_id_t value() const noexcept final { return _doc.value; }
-
-    irs::attribute* get_mutable(irs::type_info::type_id id) noexcept final {
-      return irs::type<irs::document>::id() == id ? &_doc : nullptr;
-    }
-
-    void reset(irs::doc_id_t begin, irs::doc_id_t end) noexcept {
-      if (ADB_LIKELY(irs::doc_limits::valid(begin) &&
-                     !irs::doc_limits::eof(begin) && begin <= end)) {
-        _doc.value = begin - 1;
-        _count = end - begin + 1;
-      } else {
-        _count = 0;
-      }
-    }
-
-    void reset() noexcept {
-      _doc.value = irs::doc_limits::eof();
-      _count = 0;
-    }
-
-    // We intentionally violate iresearch iterator specification
-    // to keep memory footprint as small as possible.
-    irs::document _doc;
-    irs::doc_id_t _count{0};
-  };
-
-  mutable LocalDocumentId::BaseType _pk;
-  mutable PrimaryKeyIterator _pkIterator;
-  bool _nested;
-};
-
-///////////////////////////////////////////////////////////////////////////////
-/// @class PrimaryKeyFilterContainer
-/// @brief container for storing 'PrimaryKeyFilter's, does nothing as a filter
-///////////////////////////////////////////////////////////////////////////////
-class PrimaryKeyFilterContainer final : public irs::filter {
- public:
+ protected:
   static constexpr std::string_view type_name() noexcept {
     return "arangodb::iresearch::PrimaryKeyFilterContainer";
   }
 
-  PrimaryKeyFilterContainer() = default;
-  PrimaryKeyFilterContainer(PrimaryKeyFilterContainer&&) = default;
-  PrimaryKeyFilterContainer& operator=(PrimaryKeyFilterContainer&&) = default;
-
-  PrimaryKeyFilter& emplace(LocalDocumentId value, bool nested) {
-    return _filters.emplace_back(value, nested);
-  }
-
-  bool empty() const noexcept { return _filters.empty(); }
-
-  void clear() noexcept { _filters.clear(); }
-
   irs::type_info::type_id type() const noexcept final {
-    return irs::type<PrimaryKeyFilterContainer>::id();
+    return irs::type<PrimaryKeysFilterBase>::id();
   }
 
-  filter::prepared::ptr prepare(irs::IndexReader const& rdr,
-                                irs::Scorers const& ord, irs::score_t boost,
-                                irs::attribute_provider const* ctx) const final;
+  filter::prepared::ptr prepare(
+      irs::IndexReader const& rdr, irs::Scorers const& ord, irs::score_t boost,
+      irs::attribute_provider const* ctx) const final {
+    if (_pks.empty()) {
+      return irs::filter::prepared::empty();
+    }
+    return irs::memory::to_managed<irs::filter::prepared const>(*this);
+  }
 
- private:
-  std::deque<PrimaryKeyFilter> _filters;  // pointers remain valid
+  irs::doc_iterator::ptr execute(irs::ExecutionContext const& ctx) const final {
+    _segment = &ctx.segment;
+    _pkField = _segment->field(DocumentPrimaryKey::PK());
+    if (IRS_UNLIKELY(!_pkField)) {  // TODO(MBkkt) assert?
+      return irs::doc_iterator::empty();
+    }
+    _pos = 0;
+    _doc.value = irs::doc_limits::invalid();
+    _last_doc = irs::doc_limits::invalid();
+    return irs::memory::to_managed<irs::doc_iterator>(
+        const_cast<PrimaryKeysFilterBase&>(*this));
+  }
+
+  void visit(irs::SubReader const&, irs::PreparedStateVisitor&,
+             irs::score_t) const final {}
+
+  irs::attribute* get_mutable(irs::type_info::type_id id) noexcept final {
+    return irs::type<irs::document>::id() == id ? &_doc : nullptr;
+  }
+
+  irs::doc_id_t value() const noexcept final { return _doc.value; }
+
+  irs::doc_id_t seek(irs::doc_id_t) noexcept final {
+    TRI_ASSERT(false);
+    return _doc.value = irs::doc_limits::eof();
+  }
+
+  mutable std::vector<LocalDocumentId::BaseType> _pks;
+
+  // Iterator over different LocalDocumentId
+  mutable irs::SubReader const* _segment{};  // TODO(MBkkt) maybe doc_mask?
+  mutable irs::term_reader const* _pkField{};
+  mutable size_t _pos{0};
+
+  // Iterator over different doc_id
+  mutable irs::document _doc;
+  mutable irs::doc_id_t _last_doc{irs::doc_limits::invalid()};
 };
 
-}  // namespace iresearch
-}  // namespace arangodb
+template<bool Nested>
+class PrimaryKeysFilter final : public PrimaryKeysFilterBase {
+ public:
+  PrimaryKeysFilter() = default;
+
+ private:
+  bool next() final;
+};
+
+}  // namespace arangodb::iresearch

--- a/tests/IResearch/IResearchDocumentTest.cpp
+++ b/tests/IResearch/IResearchDocumentTest.cpp
@@ -2603,19 +2603,15 @@ TEST_F(IResearchDocumentTest, test_rid_encoding) {
     EXPECT_TRUE(pkField);
     EXPECT_EQ(size, pkField->docs_count());
 
-    arangodb::iresearch::PrimaryKeyFilterContainer filters;
+    arangodb::iresearch::PrimaryKeysFilter<false> filters;
     EXPECT_TRUE(filters.empty());
-    auto& filter = filters.emplace(arangodb::LocalDocumentId(rid), false);
+    filters.emplace(arangodb::LocalDocumentId(rid));
     EXPECT_FALSE(filters.empty());
 
     // first execution
     {
-      auto prepared = filter.prepare(*reader);
+      auto prepared = static_cast<irs::filter&>(filters).prepare(*reader);
       ASSERT_TRUE(prepared);
-      EXPECT_EQ(prepared, filter.prepare(*reader));  // same object
-      EXPECT_TRUE(&filter ==
-                  dynamic_cast<arangodb::iresearch::PrimaryKeyFilter const*>(
-                      prepared.get()));  // same object
 
       for (auto& segment : *reader) {
         auto docs = prepared->execute(segment);
@@ -2779,17 +2775,13 @@ TEST_F(IResearchDocumentTest, test_rid_filter) {
       EXPECT_TRUE(ridSlice.isNumber<uint64_t>());
 
       auto rid = ridSlice.getNumber<uint64_t>();
-      arangodb::iresearch::PrimaryKeyFilterContainer filters;
+      arangodb::iresearch::PrimaryKeysFilter<false> filters;
       EXPECT_TRUE(filters.empty());
-      auto& filter = filters.emplace(arangodb::LocalDocumentId(rid), false);
+      filters.emplace(arangodb::LocalDocumentId(rid));
       EXPECT_FALSE(filters.empty());
 
-      auto prepared = filter.prepare(*store.reader);
+      auto prepared = static_cast<irs::filter&>(filters).prepare(*store.reader);
       ASSERT_TRUE(prepared);
-      EXPECT_EQ(prepared, filter.prepare(*store.reader));  // same object
-      EXPECT_TRUE((&filter ==
-                   dynamic_cast<arangodb::iresearch::PrimaryKeyFilter const*>(
-                       prepared.get())));  // same object
 
       for (auto& segment : *store.reader) {
         auto docs = prepared->execute(segment);


### PR DESCRIPTION
### Scope & Purpose

`n * 1 * 8 + с1` instead of `n * 11 * 8 + с2` bytes

`c1 = sizeof PrimaryKeysFilter (8*12) + two counters in shared_ptr (8*2)`, probably can be less (2 score_t, counters, a lot of vptr are unnecessary.

`c2 = sizeof PrimaryKeyFilterContainer(8*12) + two counters in shared_ptr (8*2)`

So I assume new memory layout always smaller, except zero removes case

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [x] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*
  - [ ] Backport for 3.9: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

