### PR TITLE
Simplify and fix timepointToString and stringToTimepoint

### DIFF
--- a/lib/Basics/TimeString.h
+++ b/lib/Basics/TimeString.h
@@ -28,7 +28,8 @@
 
 inline std::string timepointToString(
     std::chrono::system_clock::time_point const& t) {
-  return date::format("%Y-%m-%dT%H:%M:%SZ", std::floor<std::chrono::seconds>(t));
+  return date::format("%Y-%m-%dT%H:%M:%SZ",
+                      std::chrono::floor<std::chrono::seconds>(t));
 }
 
 inline std::string timepointToString(

--- a/lib/Basics/TimeString.h
+++ b/lib/Basics/TimeString.h
@@ -24,19 +24,11 @@
 #pragma once
 
 #include <chrono>
-#include "Basics/Common.h"
-
-#include "Basics/system-functions.h"
+#include "date/date.h"
 
 inline std::string timepointToString(
     std::chrono::system_clock::time_point const& t) {
-  time_t tt = std::chrono::system_clock::to_time_t(t);
-  struct tm tb;
-  size_t const len(21);
-  char buffer[len];
-  TRI_gmtime(tt, &tb);
-  ::strftime(buffer, sizeof(buffer), "%Y-%m-%dT%H:%M:%SZ", &tb);
-  return std::string(buffer, len - 1);
+  return date::format("%Y-%m-%dT%H:%M:%SZ", floor<std::chrono::seconds>(t));
 }
 
 inline std::string timepointToString(
@@ -46,24 +38,15 @@ inline std::string timepointToString(
 
 inline std::chrono::system_clock::time_point stringToTimepoint(
     std::string_view s) {
-  auto const strvtoi = [](std::string_view sv) -> int {
-    return static_cast<int>(std::strtol(sv.data(), nullptr, 10));
-  };
+  // FIXME: now copy :(
+  auto in = std::istringstream{std::string{s}};
+  auto target = std::chrono::system_clock::time_point{};
+  in >> date::parse("%Y-%m-%dT%H:%M:%SZ", target);
 
-  if (!s.empty()) {
-    try {
-      std::tm tt{};
-      tt.tm_year = strvtoi(s.substr(0, 4)) - 1900;
-      tt.tm_mon = strvtoi(s.substr(5, 2)) - 1;
-      tt.tm_mday = strvtoi(s.substr(8, 2));
-      tt.tm_hour = strvtoi(s.substr(11, 2));
-      tt.tm_min = strvtoi(s.substr(14, 2));
-      tt.tm_sec = strvtoi(s.substr(17, 2));
-      tt.tm_isdst = 0;
-      auto time_c = TRI_timegm(&tt);
-      return std::chrono::system_clock::from_time_t(time_c);
-    } catch (...) {
-    }
+  // FIXME: error handling would be nice.
+  if (!in.fail()) {
+    return target;
+  } else {
+    return {};
   }
-  return {};
 }

--- a/lib/Basics/TimeString.h
+++ b/lib/Basics/TimeString.h
@@ -28,7 +28,7 @@
 
 inline std::string timepointToString(
     std::chrono::system_clock::time_point const& t) {
-  return date::format("%Y-%m-%dT%H:%M:%SZ", floor<std::chrono::seconds>(t));
+  return date::format("%Y-%m-%dT%H:%M:%SZ", std::floor<std::chrono::seconds>(t));
 }
 
 inline std::string timepointToString(


### PR DESCRIPTION
### Scope & Purpose

A slightly more general, albeit risky, fix for the problem shown in #19138: rewrite `timepointToString` and `stringToTimepoint` to use the `date.h` C++ library instead of subtly incompatible C functions.
 
- [X] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*
  - [ ] Backport for 3.9: *(Please link PR)*
