### PR TITLE
Use medium container for hot backup tests to avoid OOM kills.

### DIFF
--- a/tests/test-definitions.txt
+++ b/tests/test-definitions.txt
@@ -109,7 +109,7 @@ rta_makedata cluster
 
 importing,export name=import_export parallelity=5 size=small cluster -- --dumpAgencyOnError true
 importing,export name=import_export parallelity=3 size=small single -- --dumpAgencyOnError true
-hot_backup enterprise !windows -- --dumpAgencyOnError true
+hot_backup enterprise !windows size=medium -- --dumpAgencyOnError true
 
 # frequent restarts impose more threats to the SUT, increase parallelity.
 server_parameters priority=1000 parallelity=2 buckets=3 single -- --dumpAgencyOnError true


### PR DESCRIPTION
### Scope & Purpose

Hot backup tests are too close to the 2GB limit of the small container.