### PR TITLE
Use libunwind in jemalloc heap profiling

### DIFF
--- a/3rdParty/CMakeLists.txt
+++ b/3rdParty/CMakeLists.txt
@@ -78,6 +78,11 @@ if (USE_JEMALLOC)
   set(JEMALLOC_HOME "${JEMALLOC_HOME}" PARENT_SCOPE)
   set(SYS_LIBS ${SYS_LIBS} jemalloc PARENT_SCOPE)
   set(JEMALLOC_LIB "${JEMALLOC_LIB}" PARENT_SCOPE)
+  if (USE_JEMALLOC_PROF)
+    if (USE_LIBUNWIND)
+      add_dependencies(jemalloc_build libunwind_build)
+    endif()
+  endif()
 endif ()
 
 ################################################################################

--- a/3rdParty/jemalloc/CMakeLists.txt
+++ b/3rdParty/jemalloc/CMakeLists.txt
@@ -31,8 +31,14 @@ if (LINUX OR DARWIN)
     set(JEMALLOC_CONFIG "background_thread:true,cache_oblivious:false")
   endif ()
 
+  SET(JEMALLOC_C_FLAGS ${CMAKE_C_FLAGS})
   if (USE_JEMALLOC_PROF)
-    SET(JEMALLOC_PROF "--enable-prof")
+      if (USE_LIBUNWIND)
+          SET(JEMALLOC_PROF "--enable-prof" "--enable-prof-libunwind" "--with-static-libunwind=${LIBUNWIND_LIB}")
+          SET(JEMALLOC_C_FLAGS "${CMAKE_C_FLAGS} -I${LIBUNWIND_HOME}/include")
+      else ()
+          SET(JEMALLOC_PROF "--enable-prof")
+      endif()
   endif ()
 
   set(JEMALLOC_LIB "${CMAKE_CURRENT_BINARY_DIR}/lib/libjemalloc.a")
@@ -49,7 +55,7 @@ if (LINUX OR DARWIN)
     CONFIGURE_COMMAND
       "${JEMALLOC_SOURCE_DIR}/configure" CC=${JEMALLOC_CC_TMP}
                   CXX=${JEMALLOC_CXX_TMP}
-                  CFLAGS=${CMAKE_C_FLAGS}
+                  CFLAGS=${JEMALLOC_C_FLAGS}
                   CXXFLAGS=${CMAKE_CXX_FLAGS}
                   --prefix=${CMAKE_CURRENT_BINARY_DIR}
                   --with-malloc-conf=${JEMALLOC_CONFIG}

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 v3.10.7 (XXXX-XX-XX)
 --------------------
 
+* Use libunwind in jemalloc profiling to make it available with libmusl
+  and static binaries.
+
 * FE-211: Allow admins to edit gravatar email.
 
 * BTS-1255: Fix sporadic memory usage accounting underflows in in-memory cache


### PR DESCRIPTION
Use libunwind in jemalloc heap profiling if available.

This is necessary to get jemalloc heap profiling to work with libmusl
builds and static binaries.

This implements the following:

If USE_LIBUNWIND is on, then we add a dependency in the build process
such that jemalloc_build can rely on the fact that libunwind is already
built. Furthermore, the configure script of jemalloc gets the newly
built libunwind.a and the included headers and can then be switched to
libunwind profiling mode.

### Scope & Purpose

- [*] :hankey: Bugfix

### Checklist

- [*] :book: CHANGELOG entry made
- [*] Backports
  - [*] Backport for 3.10: This is it.

