### PR TITLE
[SEARCH-480] [APM-766] Speedup ArangoSearch recovery

### DIFF
--- a/arangod/IResearch/IResearchDataStore.cpp
+++ b/arangod/IResearch/IResearchDataStore.cpp
@@ -1504,7 +1504,6 @@ void IResearchDataStore::properties(LinkLock linkLock,
 }
 
 IResearchTrxState* IResearchDataStore::getContext(TransactionState& state) {
-  TRI_ASSERT(!isOutOfSync());
   void const* key = this;
   auto* context = basics::downCast<IResearchTrxState>(state.cookie(key));
   if (ADB_LIKELY(context)) {

--- a/arangod/IResearch/IResearchDataStore.cpp
+++ b/arangod/IResearch/IResearchDataStore.cpp
@@ -1069,6 +1069,8 @@ void IResearchDataStore::shutdownDataStore() noexcept {
         << "caught something while removeMetrics arangosearch data store '"
         << index().id().id() << "'";
   }
+  _recoveryRemoves.reset();
+  _recoveryTrx.Abort();
   _dataStore.resetDataStore();
 }
 

--- a/arangod/IResearch/IResearchDataStore.cpp
+++ b/arangod/IResearch/IResearchDataStore.cpp
@@ -1645,7 +1645,7 @@ void IResearchDataStore::recoveryInsert(uint64_t recoveryTick,
   try {
     std::ignore = insertDocument<FieldIteratorType>(*this, _recoveryTrx, doc,
                                                     documentId, meta);
-  } catch (std::bad_alloc const& e) {
+  } catch (std::bad_alloc const&) {
     throw;
   } catch (...) {
   }

--- a/arangod/IResearch/IResearchDataStore.cpp
+++ b/arangod/IResearch/IResearchDataStore.cpp
@@ -1691,6 +1691,7 @@ void IResearchDataStore::afterTruncate(TRI_voc_tick_t tick,
   TRI_ASSERT(_dataStore);  // must be valid if _asyncSelf->get() is valid
 
   if (trx != nullptr) {
+    TRI_ASSERT(_recoveryRemoves == nullptr);
     auto* key = this;
 
     auto& state = *(trx->state());

--- a/arangod/IResearch/IResearchDataStore.cpp
+++ b/arangod/IResearch/IResearchDataStore.cpp
@@ -227,9 +227,9 @@ auto getIndexFeatures() {
 template<typename FieldIteratorType, typename MetaType>
 Result insertDocument(IResearchDataStore const& dataStore,
                       irs::IndexWriter::Transaction& ctx,
-                      transaction::Methods const& trx,
                       velocypack::Slice document, LocalDocumentId documentId,
-                      MetaType const& meta, IndexId id) {
+                      MetaType const& meta) {
+  auto const id = dataStore.index().id();
   auto const collectionNameString = [&] {
     if (!ServerState::instance()->isSingleServer()) {
       return std::string{};
@@ -243,7 +243,7 @@ Result insertDocument(IResearchDataStore const& dataStore,
   std::string_view collection = collectionNameString.empty()
                                     ? meta.collectionName()
                                     : collectionNameString;
-  FieldIteratorType body{collection, dataStore.index().id()};
+  FieldIteratorType body{collection, id};
   body.reset(document, meta);  // reset reusable container to doc
 
   if (!body.valid()) {
@@ -280,7 +280,7 @@ Result insertDocument(IResearchDataStore const& dataStore,
 
   // Sorted field
   {
-    SortedValue field{collection, dataStore.index().id(), document};
+    SortedValue field{collection, id, document};
     for (auto& sortField : meta._sort.fields()) {
       field.slice = get(document, sortField, VPackSlice::nullSlice());
       doc.template Insert<irs::Action::STORE_SORTED>(field);
@@ -289,7 +289,7 @@ Result insertDocument(IResearchDataStore const& dataStore,
 
   // Stored value field
   {
-    StoredValue field{collection, dataStore.index().id(), document};
+    StoredValue field{collection, id, document};
     for (auto const& column : meta._storedValues.columns()) {
       field.fieldName = column.name;
       field.fields = &column.fields;
@@ -339,6 +339,15 @@ auto makeAfterCommitCallback(void* key) {
     }
   };
 }
+
+std::string MakeMessage(std::string_view begin, Index const& index,
+                        TransactionState& state, LocalDocumentId documentId,
+                        auto&&... args) {
+  return absl::StrCat(begin, " ArangoSearch index: ", index.id().id(),
+                      ", tid: ", state.id().id(),
+                      ", documentId: ", documentId.id(),
+                      std::forward<decltype(args)>(args)...);
+};
 
 static std::atomic_bool kHasClusterMetrics{false};
 
@@ -635,7 +644,6 @@ IResearchDataStore::IResearchDataStore(
     : _asyncFeature(&server.getFeature<IResearchFeature>()),
       // mark as data store not initialized
       _asyncSelf(std::make_shared<AsyncLinkHandle>(nullptr)),
-      _error(DataStoreError::kNoError),
       _maintenanceState(std::make_shared<MaintenanceState>()) {
   // initialize transaction callback
 #ifdef USE_ENTERPRISE
@@ -823,22 +831,16 @@ IResearchDataStore::UnsafeOpResult IResearchDataStore::commitUnsafe(
     result.reset(TRI_ERROR_DEBUG);
   }
 
-  if (result.fail() && !isOutOfSync()) {
-    // mark DataStore as out of sync if it wasn't marked like that before.
-
-    if (setOutOfSync()) {
-      // persist "outOfSync" flag in RocksDB once. note: if this fails, it will
-      // throw an exception
-      try {
-        _engine->changeCollection(index().collection().vocbase(),
-                                  index().collection());
-      } catch (std::exception const& ex) {
-        // we couldn't persist the outOfSync flag, but we can't mark the data
-        // store as "not outOfSync" again. not much we can do except logging.
-        LOG_TOPIC("211d2", WARN, iresearch::TOPIC)
-            << "failed to store 'outOfSync' flag for ArangoSearch index '"
-            << index().id() << "': " << ex.what();
-      }
+  if (result.fail() && setOutOfSync()) {
+    try {
+      markOutOfSyncUnsafe();
+    } catch (std::exception const& e) {
+      // We couldn't persist the outOfSync flag,
+      // but we can't mark the data store as "not outOfSync" again.
+      // Not much we can do except logging.
+      LOG_TOPIC("211d2", WARN, TOPIC)
+          << "failed to store 'outOfSync' flag for ArangoSearch index '"
+          << index().id() << "': " << e.what();
     }
   }
 
@@ -1089,29 +1091,30 @@ bool IResearchDataStore::failQueriesOnOutOfSync() const noexcept {
 }
 
 bool IResearchDataStore::setOutOfSync() noexcept {
-  // should never be called on coordinators, only on DB servers and
-  // single servers
   TRI_ASSERT(!ServerState::instance()->isCoordinator());
+  auto error = _error.load(std::memory_order_relaxed);
+  return error == DataStoreError::kNoError &&
+         _error.compare_exchange_strong(error, DataStoreError::kOutOfSync,
+                                        std::memory_order_relaxed,
+                                        std::memory_order_relaxed);
+}
 
-  auto error = _error.load(std::memory_order_acquire);
-  if (error == DataStoreError::kNoError) {
-    if (_error.compare_exchange_strong(error, DataStoreError::kOutOfSync,
-                                       std::memory_order_release)) {
-      // increase metric for number of out-of-sync links, only once per link
-      TRI_ASSERT(_asyncFeature != nullptr);
-      _asyncFeature->trackOutOfSyncLink();
-
-      return true;
-    }
-  }
-
-  return false;
+void IResearchDataStore::markOutOfSyncUnsafe() {
+  // Only once per link:
+  // 1. increase metric for number of OutOfSync links
+  // 2. persist OutOfSync flag in RocksDB
+  // note: if this fails, it will throw an exception
+  TRI_ASSERT(_asyncFeature != nullptr);
+  TRI_ASSERT(_engine != nullptr);
+  _asyncFeature->trackOutOfSyncLink();
+  _engine->changeCollection(index().collection().vocbase(),
+                            index().collection());
 }
 
 bool IResearchDataStore::isOutOfSync() const noexcept {
-  // the out of sync flag is expected to be set either during the
-  // recovery phase, or when a commit goes wrong.
-  return _error.load(std::memory_order_acquire) == DataStoreError::kOutOfSync;
+  // The OutOfSync flag is expected to be set either
+  // during the recovery phase, or when a commit goes wrong
+  return _error.load(std::memory_order_relaxed) == DataStoreError::kOutOfSync;
 }
 
 void IResearchDataStore::initAsyncSelf() {
@@ -1273,12 +1276,10 @@ Result IResearchDataStore::initDataStore(
       [[fallthrough]];
     case RecoveryState::DONE: {  // Link is being created after recovery
       // Will be adjusted in post-recovery callback
-      _dataStore._inRecovery.store(true, std::memory_order_release);
       _dataStore._recoveryTickHigh = _dataStore._recoveryTickLow =
           _engine->recoveryTick();
     } break;
     case RecoveryState::IN_PROGRESS: {  // Link is being created during recovery
-      _dataStore._inRecovery.store(false, std::memory_order_release);
       _dataStore._recoveryTickHigh = _dataStore._recoveryTickLow =
           _engine->releasedTick();
     } break;
@@ -1359,6 +1360,11 @@ Result IResearchDataStore::initDataStore(
   }
   auto& dbFeature = server.getFeature<DatabaseFeature>();
 
+  if (_engine->inRecovery()) {
+    _recoveryRemoves = makePrimaryKeysFilter(_hasNestedFields);
+    _recoveryTrx = _dataStore._writer->GetBatch();
+  }
+
   return dbFeature.registerPostRecoveryCallback(  // register callback
       [asyncSelf = _asyncSelf, asyncFeature = _asyncFeature,
        pathExists]() -> Result {
@@ -1372,44 +1378,38 @@ Result IResearchDataStore::initDataStore(
         }
 
         auto& dataStore = linkLock->_dataStore;
+        auto& index = linkLock->index();
 
         // recovery finished
-        dataStore._inRecovery.store(linkLock->_engine->inRecovery(),
-                                    std::memory_order_release);
+        TRI_ASSERT(!linkLock->_engine->inRecovery());
 
-        bool outOfSync = false;
-        if (asyncFeature->linkSkippedDuringRecovery(linkLock->index().id())) {
+        const auto recoveryTick = linkLock->_engine->recoveryTick();
+
+        bool isOutOfSync = linkLock->isOutOfSync();
+        if (isOutOfSync) {
           LOG_TOPIC("2721a", WARN, iresearch::TOPIC)
-              << "Marking ArangoSearch index '" << linkLock->index().id().id()
+              << "Marking ArangoSearch index '" << index.id().id()
               << "' as out of sync, consider to drop and re-create the index "
                  "in order to synchronize it";
 
-          outOfSync = true;
-        } else if (dataStore._recoveryTickLow >
-                   linkLock->_engine->recoveryTick()) {
+        } else if (dataStore._recoveryTickHigh > recoveryTick) {
           LOG_TOPIC("5b59f", WARN, iresearch::TOPIC)
-              << "ArangoSearch index '" << linkLock->index().id()
-              << "' is recovered at tick '" << dataStore._recoveryTickLow
-              << "' greater than storage engine tick '"
-              << linkLock->_engine->recoveryTick()
-              << "', it seems WAL tail was lost and index is out of sync with "
-                 "the underlying collection '"
+              << "ArangoSearch index: " << index.id()
+              << " is recovered at tick " << dataStore._recoveryTickHigh
+              << " greater than storage engine tick " << recoveryTick
+              << ", it seems WAL tail was lost and index is out of sync with "
+                 "the underlying collection: "
               << linkLock->index().collection().name()
-              << "', consider to re-create the index in order to synchronize "
-                 "it";
+              << ", consider to re-create the index in order to synchronize it";
 
-          outOfSync = true;
+          isOutOfSync = linkLock->setOutOfSync();
+          TRI_ASSERT(isOutOfSync);
         }
 
-        if (outOfSync) {
-          // mark link as out of sync
-          linkLock->setOutOfSync();
-          // persist "out of sync" flag in RocksDB. note: if this fails, it
-          // will throw an exception and abort the recovery & startup.
-          linkLock->_engine->changeCollection(
-              linkLock->index().collection().vocbase(),
-              linkLock->index().collection());
-
+        if (isOutOfSync) {
+          // note: if this fails,
+          // it will throw an exception and abort the recovery & startup.
+          linkLock->markOutOfSyncUnsafe();
           if (asyncFeature->failQueriesOnOutOfSync()) {
             // we cannot return an error from here as this would abort the
             // entire recovery and fail the startup.
@@ -1417,28 +1417,35 @@ Result IResearchDataStore::initDataStore(
           }
         }
 
+        // Make last batch Commit if necessary
+        if (auto& removes = linkLock->_recoveryRemoves; removes != nullptr) {
+          if (!removes->empty()) {
+            linkLock->_recoveryTrx.Remove(std::move(removes));
+          }
+          removes.reset();
+          linkLock->_recoveryTrx.Commit(recoveryTick);
+        }
+
         // register flush subscription
         if (pathExists) {
           linkLock->finishCreation();
         }
 
-        irs::ProgressReportCallback progress =
-            [id = linkLock->index().id(), asyncFeature](
-                std::string_view phase, size_t current, size_t total) {
-              // forward progress reporting to asyncFeature
-              asyncFeature->reportRecoveryProgress(id, phase, current, total);
-            };
+        auto progress = [id = index.id(), asyncFeature](std::string_view phase,
+                                                        size_t current,
+                                                        size_t total) {
+          // forward progress reporting to asyncFeature
+          asyncFeature->reportRecoveryProgress(id, phase, current, total);
+        };
 
         LOG_TOPIC("5b59c", TRACE, iresearch::TOPIC)
-            << "Start sync for ArangoSearch index '" << linkLock->index().id()
-            << "'";
+            << "Start sync for ArangoSearch index: " << index.id();
 
         auto code = CommitResult::UNDEFINED;
         auto [res, timeMs] = linkLock->commitUnsafe(true, progress, code);
 
         LOG_TOPIC("0e0ca", TRACE, iresearch::TOPIC)
-            << "Finish sync for ArangoSearch index '" << linkLock->index().id()
-            << "'";
+            << "Finish sync for ArangoSearch index:" << index.id();
 
         // setup asynchronous tasks for commit, cleanup if enabled
         if (dataStore._meta._commitIntervalMsec) {
@@ -1500,109 +1507,56 @@ void IResearchDataStore::properties(LinkLock linkLock,
   linkLock->_dataStore._writer->Options(properties);
 }
 
+IResearchTrxState* IResearchDataStore::getContext(TransactionState& state) {
+  TRI_ASSERT(!isOutOfSync());
+  void const* key = this;
+  auto* context = basics::downCast<IResearchTrxState>(state.cookie(key));
+  if (ADB_LIKELY(context)) {
+    return context;
+  }
+  auto linkLock = _asyncSelf->lock();
+  if (ADB_UNLIKELY(!linkLock)) {
+    return nullptr;
+  }
+  TRI_ASSERT(_dataStore);
+  auto ptr = std::make_unique<IResearchTrxState>(
+      std::move(linkLock), *_dataStore._writer, _hasNestedFields);
+  context = ptr.get();
+  TRI_ASSERT(context);
+  state.cookie(key, std::move(ptr));
+  state.addBeforeCommitCallback(&_beforeCommitCallback);
+  state.addAfterCommitCallback(&_afterCommitCallback);
+  return context;
+}
+
 Result IResearchDataStore::remove(transaction::Methods& trx,
-                                  LocalDocumentId documentId, bool nested,
-                                  uint64_t const* recoveryTick) {
+                                  LocalDocumentId documentId) {
   TRI_ASSERT(trx.state());
-
-  auto& state = *(trx.state());
-
+  auto& state = *trx.state();
   TRI_ASSERT(!state.hasHint(transaction::Hints::Hint::INDEX_CREATION));
-
-  if (recoveryTick && *recoveryTick <= _dataStore._recoveryTickLow) {
-    LOG_TOPIC("7d228", TRACE, TOPIC)
-        << "skipping 'removal', operation tick '" << *recoveryTick
-        << "', recovery tick '" << _dataStore._recoveryTickLow << "'";
-
+  if (ADB_UNLIKELY(failQueriesOnOutOfSync() && isOutOfSync())) {
     return {};
   }
-
-  if (_asyncFeature->failQueriesOnOutOfSync() && isOutOfSync()) {
-    return {};
+  auto* ctx = getContext(state);
+  if (ADB_UNLIKELY(!ctx)) {
+    return {TRI_ERROR_ARANGO_INDEX_HANDLE_BAD,
+            MakeMessage("While removing document failed to lock", index(),
+                        state, documentId)};
   }
-
-  auto* key = this;
-  // TODO FIXME find a better way to look up a ViewState
-  auto* ctx = basics::downCast<IResearchTrxState>(state.cookie(key));
-  if (!ctx) {
-    // '_dataStore' can be asynchronously modified
-    auto linkLock = _asyncSelf->lock();
-    if (!linkLock) {
-      // the current link is no longer valid
-      // (checked after ReadLock acquisition)
-
-      return {TRI_ERROR_ARANGO_INDEX_HANDLE_BAD,
-              absl::StrCat(
-                  "failed to lock ArangoSearch index '", index().id().id(),
-                  "'while removing a document from it: tid '", state.id().id(),
-                  "', documentId '", documentId.id(), "'")};
-    }
-
-    TRI_ASSERT(_dataStore);  // must be valid if _asyncSelf->get() is valid
-
-    auto ptr = std::make_unique<IResearchTrxState>(
-        std::move(linkLock), *(_dataStore._writer), nested);
-
-    ctx = ptr.get();
-    state.cookie(key, std::move(ptr));
-    if (!ctx) {
-      return {
-          TRI_ERROR_INTERNAL,
-          absl::StrCat(
-              "failed to store state into a TransactionState for remove from "
-              "ArangoSearch index '",
-              index().id().id(), "', tid '", state.id().id(), "', documentId '",
-              documentId.id(), "'")};
-    }
-    state.addBeforeCommitCallback(&_beforeCommitCallback);
-    state.addAfterCommitCallback(&_afterCommitCallback);
-  }
-
-  // ...........................................................................
-  // if an exception occurs below than the transaction is dropped including
-  // all all of its fid stores, no impact to iResearch View data integrity
-  // ...........................................................................
-  try {
-    ctx->remove(documentId);
-
-    return {TRI_ERROR_NO_ERROR};
-  } catch (basics::Exception const& e) {
-    return {e.code(), absl::StrCat("caught exception while removing document "
-                                   "from ArangoSearch index '",
-                                   index().id().id(), "', documentId '",
-                                   documentId.id(), "': ", e.message())};
-  } catch (std::exception const& e) {
-    return {TRI_ERROR_INTERNAL,
-            absl::StrCat("caught exception while removing document from "
-                         "ArangoSearch index '",
-                         index().id().id(), "', documentId '", documentId.id(),
-                         "': ", e.what())};
-  } catch (...) {
-    return {TRI_ERROR_INTERNAL,
-            absl::StrCat("caught exception while removing document from "
-                         "ArangoSearch index '",
-                         index().id().id(), "', documentId '", documentId.id(),
-                         "'")};
-  }
-
+  ctx->remove(documentId);
   return {};
 }
 
-bool IResearchDataStore::exists(IResearchDataStore::Snapshot const& snapshot,
-                                LocalDocumentId documentId,
-                                TRI_voc_tick_t const* recoveryTick) const {
-  if (recoveryTick == nullptr) {
-    // skip recovery check
-  } else if (*recoveryTick <= _dataStore._recoveryTickLow) {
-    LOG_TOPIC("6e128", TRACE, TOPIC)
-        << "skipping 'exists', operation tick '" << *recoveryTick
-        << "', recovery tick low '" << _dataStore._recoveryTickLow << "'";
+void IResearchDataStore::recoveryRemove(LocalDocumentId documentId) {
+  TRI_ASSERT(!isOutOfSync());
+  TRI_ASSERT(_recoveryRemoves);
+  _recoveryRemoves->emplace(documentId);
+}
 
-    return true;
-  } else if (*recoveryTick > _dataStore._recoveryTickHigh) {
-    LOG_TOPIC("6e129", TRACE, TOPIC)
-        << "skipping 'exists', operation tick '" << *recoveryTick
-        << "', recovery tick high '" << _dataStore._recoveryTickHigh << "'";
+bool IResearchDataStore::exists(LocalDocumentId documentId) const {
+  auto snapshot = this->snapshot();
+  auto& reader = snapshot.getDirectoryReader();
+  if (ADB_UNLIKELY(!reader)) {
     return false;
   }
 
@@ -1612,16 +1566,15 @@ bool IResearchDataStore::exists(IResearchDataStore::Snapshot const& snapshot,
       irs::numeric_utils::numeric_traits<LocalDocumentId::BaseType>::raw_ref(
           encoded);
 
-  for (auto const& segment : snapshot.getDirectoryReader()) {
+  for (auto const& segment : reader) {
     auto const* pkField = segment.field(DocumentPrimaryKey::PK());
 
     if (ADB_UNLIKELY(!pkField)) {
       continue;
     }
-
-    auto const meta = pkField->term(pk);
-
-    if (meta.docs_count) {
+    auto doc = irs::doc_limits::invalid();
+    pkField->read_documents(pk, {&doc, 1});
+    if (irs::doc_limits::valid(doc)) {
       return true;
     }
   }
@@ -1632,105 +1585,84 @@ bool IResearchDataStore::exists(IResearchDataStore::Snapshot const& snapshot,
 template<typename FieldIteratorType, typename MetaType>
 Result IResearchDataStore::insert(transaction::Methods& trx,
                                   LocalDocumentId documentId,
-                                  velocypack::Slice doc, MetaType const& meta,
-                                  uint64_t const* recoveryTick) {
+                                  velocypack::Slice doc, MetaType const& meta) {
   TRI_ASSERT(trx.state());
-
-  auto& state = *(trx.state());
-
-  if (recoveryTick && *recoveryTick <= _dataStore._recoveryTickLow) {
-    LOG_TOPIC("7c228", TRACE, TOPIC)
-        << "skipping 'insert', operation tick '" << *recoveryTick
-        << "', recovery tick '" << _dataStore._recoveryTickLow << "'";
-
+  auto& state = *trx.state();
+  if (ADB_UNLIKELY(failQueriesOnOutOfSync() && isOutOfSync())) {
     return {};
   }
 
-  if (_asyncFeature->failQueriesOnOutOfSync() && isOutOfSync()) {
-    return {};
-  }
-
-  auto insertImpl = [&, &self = *this, id = index().id()](
-                        irs::IndexWriter::Transaction& ctx) -> Result {
+  auto insertImpl = [&, this](irs::IndexWriter::Transaction& ctx) -> Result {
+    auto messege = [&](auto&&... args) {
+      return MakeMessage("While inserting document caught exception", index(),
+                         state, documentId,
+                         std::forward<decltype(args)>(args)...);
+    };
     try {
-      return insertDocument<FieldIteratorType>(self, ctx, trx, doc, documentId,
-                                               meta, id);
+      return insertDocument<FieldIteratorType>(*this, ctx, doc, documentId,
+                                               meta);
     } catch (basics::Exception const& e) {
-      return {e.code(), absl::StrCat("caught exception while inserting "
-                                     "document into arangosearch index '",
-                                     id.id(), "', documentId '",
-                                     documentId.id(), "': ", e.what())};
+      return {e.code(), messege(", ", e.what())};
     } catch (std::exception const& e) {
-      return {TRI_ERROR_INTERNAL,
-              absl::StrCat("caught exception while inserting document into "
-                           "arangosearch index '",
-                           id.id(), "', documentId '", documentId.id(),
-                           "': ", e.what())};
+      return {TRI_ERROR_INTERNAL, messege(", ", e.what())};
     } catch (...) {
-      return {TRI_ERROR_INTERNAL,
-              absl::StrCat("caught exception while inserting document into "
-                           "arangosearch index '",
-                           id.id(), "', documentId '", documentId.id(), "'")};
+      return {TRI_ERROR_INTERNAL, messege()};
     }
   };
 
-  TRI_IF_FAILURE("ArangoSearch::BlockInsertsWithoutIndexCreationHint") {
-    if (!state.hasHint(transaction::Hints::Hint::INDEX_CREATION)) {
-      return {TRI_ERROR_DEBUG};
-    }
-  }
-
-  if (state.hasHint(transaction::Hints::Hint::INDEX_CREATION)) {
+  if (ADB_UNLIKELY(state.hasHint(transaction::Hints::Hint::INDEX_CREATION))) {
     auto linkLock = _asyncSelf->lock();
-    if (!linkLock) {
+    if (ADB_UNLIKELY(!linkLock)) {
       return {TRI_ERROR_INTERNAL};
     }
     auto ctx = _dataStore._writer->GetBatch();
-    auto res = insertImpl(ctx);
-    if (!res.ok()) {
+    if (auto r = insertImpl(ctx); ADB_UNLIKELY(!r.ok())) {
       ctx.Abort();
-      return res;
+      return r;
     }
     TRI_IF_FAILURE("ArangoSearch::MisreportCreationInsertAsFailed") {
       return {TRI_ERROR_DEBUG};
     }
-    return res;
-  }
-  auto* key = this;
-  // TODO FIXME find a better way to look up a ViewState
-  auto* ctx = basics::downCast<IResearchTrxState>(state.cookie(key));
-  if (!ctx) {
-    // '_dataStore' can be asynchronously modified
-    auto linkLock = _asyncSelf->lock();
-
-    if (!linkLock) {
-      // the current link is no longer valid (checked after ReadLock
-      // acquisition)
-      return {
-          TRI_ERROR_ARANGO_INDEX_HANDLE_BAD,
-          absl::StrCat("failed to lock ArangoSearch index '", index().id().id(),
-                       "' while inserting a document into it")};
-    }
-
-    TRI_ASSERT(_dataStore);  // must be valid if _asyncSelf->get() is valid
-    auto ptr = std::make_unique<IResearchTrxState>(
-        std::move(linkLock), *(_dataStore._writer), meta.hasNested());
-
-    ctx = ptr.get();
-    state.cookie(key, std::move(ptr));
-
-    if (!ctx) {
-      return {TRI_ERROR_INTERNAL,
-              absl::StrCat("failed to store state into a TransactionState for "
-                           "insert into ArangoSearch index '",
-                           index().id().id(), "', tid '", state.id().id(),
-                           "', revision '", documentId.id(), "'")};
-    }
-    state.addBeforeCommitCallback(&_beforeCommitCallback);
-    state.addAfterCommitCallback(&_afterCommitCallback);
+    return {};
   }
 
+  TRI_IF_FAILURE("ArangoSearch::BlockInsertsWithoutIndexCreationHint") {
+    return {TRI_ERROR_DEBUG};
+  }
+
+  auto* ctx = getContext(state);
+  if (ADB_UNLIKELY(!ctx)) {
+    return {TRI_ERROR_ARANGO_INDEX_HANDLE_BAD,
+            MakeMessage("While inserting document failed to lock", index(),
+                        state, documentId)};
+  }
   return insertImpl(ctx->_ctx);
+}
+
+template<typename FieldIteratorType, typename MetaType>
+void IResearchDataStore::recoveryInsert(uint64_t recoveryTick,
+                                        LocalDocumentId documentId,
+                                        velocypack::Slice doc,
+                                        MetaType const& meta) {
+  TRI_ASSERT(recoveryTickLow() < recoveryTick);
+  TRI_ASSERT(!isOutOfSync());
+  TRI_ASSERT(_recoveryRemoves);
+  try {
+    std::ignore = insertDocument<FieldIteratorType>(*this, _recoveryTrx, doc,
+                                                    documentId, meta);
+  } catch (std::bad_alloc const& e) {
+    throw;
+  } catch (...) {
+  }
+  if (!_recoveryTrx.FlushRequired()) {
+    return;
+  }
+  if (!_recoveryRemoves->empty()) {
+    _recoveryTrx.Remove(std::move(_recoveryRemoves));
+    _recoveryRemoves = makePrimaryKeysFilter(_hasNestedFields);
+  }
+  _recoveryTrx.Commit(recoveryTick);
+  // TODO(MBkkt) IndexWriter::Commit? Probably makes sense only if were removes
 }
 
 void IResearchDataStore::afterTruncate(TRI_voc_tick_t tick,
@@ -1773,6 +1705,9 @@ void IResearchDataStore::afterTruncate(TRI_voc_tick_t tick,
       // clear
       state.cookie(key, nullptr);
     }
+  } else if (_recoveryRemoves != nullptr) {  // TODO(MBkkt) should be assert?
+    _recoveryRemoves->clear();
+    _recoveryTrx.Abort();
   }
 
   std::lock_guard commitLock{_commitMutex};
@@ -1843,7 +1778,7 @@ IResearchDataStore::Stats IResearchDataStore::updateStatsUnsafe() const {
   stats.numSegments = reader->size();
   stats.numDocs = reader->docs_count();
 #ifdef USE_ENTERPRISE
-  if (hasNestedFields()) {
+  if (_hasNestedFields) {
     stats.numPrimaryDocs = getPrimaryDocsCount(reader);
   } else {
     stats.numPrimaryDocs = stats.numDocs;
@@ -1993,15 +1928,24 @@ std::filesystem::path getPersistedPath(DatabasePathFeature const& dbPathFeature,
 template Result
 IResearchDataStore::insert<FieldIterator<FieldMeta>, IResearchLinkMeta>(
     transaction::Methods& trx, LocalDocumentId documentId,
-    velocypack::Slice doc, IResearchLinkMeta const& meta,
-    uint64_t const* recoveryTick);
+    velocypack::Slice doc, IResearchLinkMeta const& meta);
 
 template Result IResearchDataStore::insert<
     FieldIterator<IResearchInvertedIndexMetaIndexingContext>,
     IResearchInvertedIndexMetaIndexingContext>(
     transaction::Methods& trx, LocalDocumentId documentId,
     velocypack::Slice doc,
-    IResearchInvertedIndexMetaIndexingContext const& meta,
-    uint64_t const* recoveryTick);
+    IResearchInvertedIndexMetaIndexingContext const& meta);
+
+template void
+IResearchDataStore::recoveryInsert<FieldIterator<FieldMeta>, IResearchLinkMeta>(
+    uint64_t tick, LocalDocumentId documentId, velocypack::Slice doc,
+    IResearchLinkMeta const& meta);
+
+template void IResearchDataStore::recoveryInsert<
+    FieldIterator<IResearchInvertedIndexMetaIndexingContext>,
+    IResearchInvertedIndexMetaIndexingContext>(
+    uint64_t tick, LocalDocumentId documentId, velocypack::Slice doc,
+    IResearchInvertedIndexMetaIndexingContext const& meta);
 
 }  // namespace arangodb::iresearch

--- a/arangod/IResearch/IResearchDataStore.cpp
+++ b/arangod/IResearch/IResearchDataStore.cpp
@@ -1590,7 +1590,7 @@ Result IResearchDataStore::insert(transaction::Methods& trx,
   }
 
   auto insertImpl = [&, this](irs::IndexWriter::Transaction& ctx) -> Result {
-    auto messege = [&](auto&&... args) {
+    auto message = [&](auto&&... args) {
       return MakeMessage("While inserting document caught exception", index(),
                          state, documentId,
                          std::forward<decltype(args)>(args)...);
@@ -1599,11 +1599,11 @@ Result IResearchDataStore::insert(transaction::Methods& trx,
       return insertDocument<FieldIteratorType>(*this, ctx, doc, documentId,
                                                meta);
     } catch (basics::Exception const& e) {
-      return {e.code(), messege(", ", e.what())};
+      return {e.code(), message(", ", e.what())};
     } catch (std::exception const& e) {
-      return {TRI_ERROR_INTERNAL, messege(", ", e.what())};
+      return {TRI_ERROR_INTERNAL, message(", ", e.what())};
     } catch (...) {
-      return {TRI_ERROR_INTERNAL, messege()};
+      return {TRI_ERROR_INTERNAL, message()};
     }
   };
 

--- a/arangod/IResearch/IResearchDataStore.h
+++ b/arangod/IResearch/IResearchDataStore.h
@@ -435,6 +435,9 @@ class IResearchDataStore {
   ////////////////////////////////////////////////////////////////////////////////
   std::tuple<uint64_t, uint64_t, uint64_t> avgTime() const;
 #endif
+
+  void recoveryCommit(uint64_t tick);
+
  protected:
   enum class DataStoreError : uint8_t {
     // data store has no issues

--- a/arangod/IResearch/IResearchDataStore.h
+++ b/arangod/IResearch/IResearchDataStore.h
@@ -71,10 +71,7 @@ struct IResearchTrxState final : public TransactionState::Cookie {
                     bool nested) noexcept
       : _linkLock{std::move(linkLock)},
         _ctx{writer.GetBatch()},
-        _removals{nested ? std::static_pointer_cast<PrimaryKeysFilterBase>(
-                               std::make_shared<PrimaryKeysFilter<true>>())
-                         : std::static_pointer_cast<PrimaryKeysFilterBase>(
-                               std::make_shared<PrimaryKeysFilter<false>>())} {}
+        _removals{makePrimaryKeysFilter(nested)} {}
 
   ~IResearchTrxState() final {
     // TODO(MBkkt) Make Abort in ~Transaction()
@@ -199,19 +196,22 @@ class IResearchDataStore {
   [[nodiscard]] virtual AnalyzerPool::ptr findAnalyzer(
       AnalyzerPool const& analyzer) const = 0;
 
-  auto recoveryTickHigh() const noexcept {
+  uint64_t recoveryTickLow() const noexcept {
+    return _dataStore._recoveryTickLow;
+  }
+  uint64_t recoveryTickHigh() const noexcept {
     return _dataStore._recoveryTickHigh;
   }
 
-  bool exists(Snapshot const& snapshot, LocalDocumentId documentId,
-              uint64_t const* recoveryTick) const;
+  IResearchTrxState* getContext(TransactionState& state);
+  bool exists(LocalDocumentId documentId) const;
 
   ////////////////////////////////////////////////////////////////////////////////
   /// @brief remove an ArangoDB document from an iResearch View
   /// @note arangodb::Index override
   ////////////////////////////////////////////////////////////////////////////////
-  Result remove(transaction::Methods& trx, LocalDocumentId documentId,
-                bool nested, uint64_t const* recoveryTick);
+  Result remove(transaction::Methods& trx, LocalDocumentId documentId);
+  void recoveryRemove(LocalDocumentId documentId);
 
   ////////////////////////////////////////////////////////////////////////////////
   /// @brief insert an ArangoDB document into an iResearch View using '_meta'
@@ -220,8 +220,10 @@ class IResearchDataStore {
   ////////////////////////////////////////////////////////////////////////////////
   template<typename FieldIteratorType, typename MetaType>
   Result insert(transaction::Methods& trx, LocalDocumentId documentId,
-                velocypack::Slice doc, MetaType const& meta,
-                uint64_t const* recoveryTick);
+                velocypack::Slice doc, MetaType const& meta);
+  template<typename FieldIteratorType, typename MetaType>
+  void recoveryInsert(uint64_t tick, LocalDocumentId documentId,
+                      velocypack::Slice doc, MetaType const& meta);
 
   //////////////////////////////////////////////////////////////////////////////
   /// @brief update runtine data processing properties
@@ -255,6 +257,7 @@ class IResearchDataStore {
   /// sync before.
   //////////////////////////////////////////////////////////////////////////////
   bool setOutOfSync() noexcept;
+  void markOutOfSyncUnsafe();
 
   //////////////////////////////////////////////////////////////////////////////
   /// @brief whether or not the data store is out of sync (i.e. has incomplete
@@ -311,8 +314,6 @@ class IResearchDataStore {
     // the tick at which data store was recovered
     uint64_t _recoveryTickLow{0};
     uint64_t _recoveryTickHigh{0};
-    // data store is in recovery
-    std::atomic_bool _inRecovery{false};
     explicit operator bool() const noexcept { return _directory && _writer; }
 
     void resetDataStore() noexcept {
@@ -485,11 +486,10 @@ class IResearchDataStore {
   // the iresearch data store, protected by _asyncSelf->mutex()
   DataStore _dataStore;
 
-  // data store error state
-  std::atomic<DataStoreError> _error;
-
   std::shared_ptr<FlushSubscription> _flushSubscription;
   std::shared_ptr<MaintenanceState> _maintenanceState;
+  // data store error state
+  std::atomic<DataStoreError> _error{DataStoreError::kNoError};
   bool _hasNestedFields{false};
   bool _isCreation{true};
 #ifdef USE_ENTERPRISE
@@ -505,6 +505,8 @@ class IResearchDataStore {
   std::mutex _commitMutex;
 
   // for insert(...)/remove(...)
+  irs::IndexWriter::Transaction _recoveryTrx;
+  std::shared_ptr<PrimaryKeysFilterBase> _recoveryRemoves;
   TransactionState::BeforeCommitCallback _beforeCommitCallback;
   TransactionState::AfterCommitCallback _afterCommitCallback;
 

--- a/arangod/IResearch/IResearchDocument.cpp
+++ b/arangod/IResearch/IResearchDocument.cpp
@@ -169,7 +169,7 @@ arangodb::iresearch::FieldMeta const* findMeta(
   return meta != context->_fields.end() ? &meta->second : context;
 }
 
-bool inObjectFiltered(std::string& buffer, size_t buffer_hash,
+bool inObjectFiltered(std::string& buffer,
                       arangodb::iresearch::FieldMeta const*& context,
                       arangodb::iresearch::IteratorValue const& value) {
   std::string_view key;

--- a/arangod/IResearch/IResearchDocument.cpp
+++ b/arangod/IResearch/IResearchDocument.cpp
@@ -169,7 +169,7 @@ arangodb::iresearch::FieldMeta const* findMeta(
   return meta != context->_fields.end() ? &meta->second : context;
 }
 
-bool inObjectFiltered(std::string& buffer,
+bool inObjectFiltered(std::string& buffer, size_t buffer_hash,
                       arangodb::iresearch::FieldMeta const*& context,
                       arangodb::iresearch::IteratorValue const& value) {
   std::string_view key;

--- a/arangod/IResearch/IResearchFeature.cpp
+++ b/arangod/IResearch/IResearchFeature.cpp
@@ -1336,14 +1336,6 @@ std::pair<size_t, size_t> IResearchFeature::limits(ThreadGroup id) const {
   return _async->get(id).limits();
 }
 
-bool IResearchFeature::linkSkippedDuringRecovery(
-    arangodb::IndexId id) const noexcept {
-  if (_recoveryHelper != nullptr) {
-    return _recoveryHelper->wasSkipped(id);
-  }
-  return false;
-}
-
 void IResearchFeature::trackOutOfSyncLink() noexcept { ++_outOfSyncLinks; }
 
 void IResearchFeature::untrackOutOfSyncLink() noexcept {

--- a/arangod/IResearch/IResearchFeature.h
+++ b/arangod/IResearch/IResearchFeature.h
@@ -135,8 +135,6 @@ class IResearchFeature final : public ArangodFeature {
   template<typename Engine>
   IndexTypeFactory& factory();
 
-  bool linkSkippedDuringRecovery(arangodb::IndexId id) const noexcept;
-
   void trackOutOfSyncLink() noexcept;
   void untrackOutOfSyncLink() noexcept;
 

--- a/arangod/IResearch/IResearchPrimaryKeyFilter.cpp
+++ b/arangod/IResearch/IResearchPrimaryKeyFilter.cpp
@@ -58,9 +58,9 @@ bool PrimaryKeysFilter<Nested>::next() {
     auto const pkRef =
         irs::numeric_utils::numeric_traits<LocalDocumentId::BaseType>::raw_ref(
             pk);
-    auto doc = irs::doc_limits::eof();
+    auto doc = irs::doc_limits::invalid();
     _pkField->read_documents(pkRef, {&doc, 1});
-    if (irs::doc_limits::eof(doc) || _segment->docs_mask()->contains(doc)) {
+    if (!irs::doc_limits::valid(doc) || _segment->docs_mask()->contains(doc)) {
       ++_pos;
       continue;
     }

--- a/arangod/IResearch/IResearchPrimaryKeyFilter.h
+++ b/arangod/IResearch/IResearchPrimaryKeyFilter.h
@@ -36,6 +36,8 @@ class PrimaryKeysFilterBase : public irs::filter,
                               public irs::filter::prepared,
                               public irs::doc_iterator {
  public:
+  void clear() noexcept { return _pks.clear(); }
+
   void emplace(LocalDocumentId value) {
     _pks.emplace_back(DocumentPrimaryKey::encode(value));
   }
@@ -107,5 +109,13 @@ class PrimaryKeysFilter final : public PrimaryKeysFilterBase {
  private:
   bool next() final;
 };
+
+inline std::shared_ptr<PrimaryKeysFilterBase> makePrimaryKeysFilter(
+    bool nested) {
+  if (nested) {
+    return std::make_shared<PrimaryKeysFilter<true>>();
+  }
+  return std::make_shared<PrimaryKeysFilter<false>>();
+}
 
 }  // namespace arangodb::iresearch

--- a/arangod/IResearch/IResearchRocksDBInvertedIndex.h
+++ b/arangod/IResearch/IResearchRocksDBInvertedIndex.h
@@ -150,20 +150,12 @@ class IResearchRocksDBInvertedIndex final : public RocksDBIndex,
     return IResearchInvertedIndex::specializeCondition(trx, node, reference);
   }
 
-  Result insertInRecovery(transaction::Methods& trx,
-                          LocalDocumentId const& documentId, VPackSlice doc,
-                          rocksdb::SequenceNumber tick) {
-    return IResearchDataStore::insert<
+  void recoveryInsert(uint64_t tick, LocalDocumentId documentId,
+                      VPackSlice doc) {
+    IResearchDataStore::recoveryInsert<
         FieldIterator<IResearchInvertedIndexMetaIndexingContext>,
-        IResearchInvertedIndexMetaIndexingContext>(
-        trx, documentId, doc, *meta()._indexingContext, &tick);
-  }
-
-  Result removeInRecovery(transaction::Methods& trx,
-                          LocalDocumentId const& documentId,
-                          rocksdb::SequenceNumber tick) {
-    return IResearchDataStore::remove(trx, documentId, meta().hasNested(),
-                                      &tick);
+        IResearchInvertedIndexMetaIndexingContext>(tick, documentId, doc,
+                                                   *meta()._indexingContext);
   }
 
   Result insert(transaction::Methods& trx, RocksDBMethods* /*methods*/,
@@ -172,15 +164,14 @@ class IResearchRocksDBInvertedIndex final : public RocksDBIndex,
                 bool /*performChecks*/) final {
     return IResearchDataStore::insert<
         FieldIterator<IResearchInvertedIndexMetaIndexingContext>,
-        IResearchInvertedIndexMetaIndexingContext>(
-        trx, documentId, doc, *meta()._indexingContext, nullptr);
+        IResearchInvertedIndexMetaIndexingContext>(trx, documentId, doc,
+                                                   *meta()._indexingContext);
   }
 
   Result remove(transaction::Methods& trx, RocksDBMethods*,
                 LocalDocumentId const& documentId, VPackSlice,
                 OperationOptions const& /*options*/) final {
-    return IResearchDataStore::remove(trx, documentId, meta().hasNested(),
-                                      nullptr);
+    return IResearchDataStore::remove(trx, documentId);
   }
 
  private:

--- a/arangod/IResearch/IResearchRocksDBLink.h
+++ b/arangod/IResearch/IResearchRocksDBLink.h
@@ -49,25 +49,17 @@ class IResearchRocksDBLink final : public RocksDBIndex, public IResearchLink {
 
   bool canBeDropped() const final { return IResearchDataStore::canBeDropped(); }
 
-  Result drop() final /*noexcept*/ { return IResearchLink::drop(); }
+  Result drop() /*noexcept*/ final { return IResearchLink::drop(); }
 
   bool hasSelectivityEstimate() const final {
     return IResearchDataStore::hasSelectivityEstimate();
   }
 
-  Result insertInRecovery(transaction::Methods& trx,
-                          LocalDocumentId const& documentId, VPackSlice doc,
-                          rocksdb::SequenceNumber tick) {
-    return IResearchDataStore::insert<FieldIterator<FieldMeta>,
-                                      IResearchLinkMeta>(trx, documentId, doc,
-                                                         meta(), &tick);
-  }
-
-  Result removeInRecovery(transaction::Methods& trx,
-                          LocalDocumentId const& documentId,
-                          rocksdb::SequenceNumber tick) {
-    return IResearchDataStore::remove(trx, documentId, meta().hasNested(),
-                                      &tick);
+  void recoveryInsert(uint64_t tick, LocalDocumentId documentId,
+                      VPackSlice doc) {
+    return IResearchDataStore::recoveryInsert<FieldIterator<FieldMeta>,
+                                              IResearchLinkMeta>(
+        tick, documentId, doc, meta());
   }
 
   Result insert(transaction::Methods& trx, RocksDBMethods* /*methods*/,
@@ -76,14 +68,13 @@ class IResearchRocksDBLink final : public RocksDBIndex, public IResearchLink {
                 bool /*performChecks*/) final {
     return IResearchDataStore::insert<FieldIterator<FieldMeta>,
                                       IResearchLinkMeta>(trx, documentId, doc,
-                                                         meta(), nullptr);
+                                                         meta());
   }
 
-  Result remove(transaction::Methods& trx, RocksDBMethods*,
-                LocalDocumentId const& documentId, VPackSlice,
+  Result remove(transaction::Methods& trx, RocksDBMethods* /*methods*/,
+                LocalDocumentId const& documentId, VPackSlice /*doc*/,
                 OperationOptions const& /*options*/) final {
-    return IResearchDataStore::remove(trx, documentId, meta().hasNested(),
-                                      nullptr);
+    return IResearchDataStore::remove(trx, documentId);
   }
 
   bool isSorted() const final { return IResearchLink::isSorted(); }

--- a/arangod/IResearch/IResearchRocksDBLink.h
+++ b/arangod/IResearch/IResearchRocksDBLink.h
@@ -57,9 +57,9 @@ class IResearchRocksDBLink final : public RocksDBIndex, public IResearchLink {
 
   void recoveryInsert(uint64_t tick, LocalDocumentId documentId,
                       VPackSlice doc) {
-    return IResearchDataStore::recoveryInsert<FieldIterator<FieldMeta>,
-                                              IResearchLinkMeta>(
-        tick, documentId, doc, meta());
+    IResearchDataStore::recoveryInsert<FieldIterator<FieldMeta>,
+                                       IResearchLinkMeta>(tick, documentId, doc,
+                                                          meta());
   }
 
   Result insert(transaction::Methods& trx, RocksDBMethods* /*methods*/,

--- a/arangod/IResearch/IResearchRocksDBRecoveryHelper.cpp
+++ b/arangod/IResearch/IResearchRocksDBRecoveryHelper.cpp
@@ -101,7 +101,7 @@ void IResearchRocksDBRecoveryHelper::prepare() {
 template<bool Force>
 void IResearchRocksDBRecoveryHelper::clear() noexcept {
   if constexpr (!Force) {
-    if (_indexes.size() < kMaxSize || _links.size() < kMaxSize ||
+    if (_indexes.size() < kMaxSize && _links.size() < kMaxSize &&
         _ranges.size() < kMaxSize) {
       return;
     }

--- a/arangod/IResearch/IResearchRocksDBRecoveryHelper.cpp
+++ b/arangod/IResearch/IResearchRocksDBRecoveryHelper.cpp
@@ -65,316 +65,270 @@
 #include <absl/strings/str_cat.h>
 #include <absl/strings/str_split.h>
 
-namespace arangodb::transaction {
+namespace arangodb {
+namespace transaction {
+
 class Context;
-}
 
-namespace {
-
-std::shared_ptr<arangodb::LogicalCollection> lookupCollection(
-    arangodb::DatabaseFeature& db, arangodb::RocksDBEngine& engine,
-    uint64_t objectId) {
-  auto pair = engine.mapObjectToCollection(objectId);
-  auto vocbase = db.useDatabase(pair.first);
-
-  return vocbase ? vocbase->lookupCollection(pair.second) : nullptr;
-}
-
-}  // namespace
-
-namespace arangodb::iresearch {
+}  // namespace transaction
+namespace iresearch {
 
 IResearchRocksDBRecoveryHelper::IResearchRocksDBRecoveryHelper(
     ArangodServer& server, std::span<std::string const> skipRecoveryItems)
-    : _server(server), _skipAllItems(false) {
+    : _server{&server} {
   for (auto const& item : skipRecoveryItems) {
     if (item == "all") {
       _skipAllItems = true;
-      _skipRecoveryItems.clear();
+      _skipRecoveryItems = {};
       break;
     }
-
-    std::pair<std::string_view, std::string_view> parts =
-        absl::StrSplit(item, '/');
-    // look for collection part
-    auto it = _skipRecoveryItems.find(parts.first);
-    if (it == _skipRecoveryItems.end()) {
-      // collection not found, insert new set into map with the index id/name
-      _skipRecoveryItems.emplace(
-          parts.first,
-          containers::FlatHashSet<std::string>{std::string{parts.second}});
-    } else {
-      // collection found. append index/name to existing set
-      it->second.emplace(parts.second);
-    }
+    auto parts = absl::StrSplit(item, '/');
+    auto parts_it = parts.begin();
+    auto it = _skipRecoveryItems.try_emplace(*parts_it);
+    ++parts_it;
+    it.first->second.emplace(*parts_it);
   }
 }
 
 void IResearchRocksDBRecoveryHelper::prepare() {
-  _dbFeature = &_server.getFeature<DatabaseFeature>();
+  TRI_ASSERT(_server);
   _engine =
-      &_server.getFeature<EngineSelectorFeature>().engine<RocksDBEngine>();
+      &_server->getFeature<EngineSelectorFeature>().engine<RocksDBEngine>();
+  _dbFeature = &_server->getFeature<DatabaseFeature>();
   _documentCF = RocksDBColumnFamilyManager::get(
                     RocksDBColumnFamilyManager::Family::Documents)
                     ->GetID();
 }
 
-void IResearchRocksDBRecoveryHelper::PutCF(uint32_t column_family_id,
-                                           const rocksdb::Slice& key,
-                                           const rocksdb::Slice& value,
-                                           rocksdb::SequenceNumber tick) {
+template<bool Force>
+void IResearchRocksDBRecoveryHelper::clear() noexcept {
+  if constexpr (!Force) {
+    if (_indexes.size() < kMaxSize || _links.size() < kMaxSize ||
+        _ranges.size() < kMaxSize) {
+      return;
+    }
+  }
+  _ranges.clear();
+  _indexes.clear();
+  _links.clear();
+}
+
+template<bool Exists, typename Func>
+void IResearchRocksDBRecoveryHelper::applyCF(uint32_t column_family_id,
+                                             rocksdb::Slice key,
+                                             rocksdb::SequenceNumber tick,
+                                             Func&& func) {
   if (column_family_id != _documentCF) {
     return;
   }
 
-  auto coll =
-      lookupCollection(*_dbFeature, *_engine, RocksDBKey::objectId(key));
+  auto const objectId = RocksDBKey::objectId(key);
 
-  if (coll == nullptr) {
+  auto ranges = getRanges(objectId);
+  if (ranges.empty()) {
     return;
   }
 
-  LinkContainer links;
-  auto mustReplay = lookupLinks(links, *coll);
+  irs::Finally cleanup = [&]() noexcept { clear<false>(); };
 
-  if (links.empty()) {
-    // no links found. nothing to do
-    TRI_ASSERT(!mustReplay);
-    return;
-  }
+  auto const documentId = RocksDBKey::documentId(key);
 
-  if (!mustReplay) {
-    // links found, but the recovery for all of them will be skipped.
-    // so we need to mark all the links as out-of-sync
-    for (auto const& link : links) {
-      TRI_ASSERT(link.second);
-      _skippedIndexes.emplace(link.first->id());
+  std::optional<decltype(_skipRecoveryItems.end())> skipIt;
+  auto skip = [&](auto& impl) {
+    TRI_ASSERT(!impl.isOutOfSync());
+    if (_skipAllItems) {
+      return true;
     }
-    return;
-  }
-
-  auto docId = RocksDBKey::documentId(key);
-  auto doc = RocksDBValue::data(value);
-
-  transaction::StandaloneContext ctx(coll->vocbase());
-  _skipExisted.clear();
-  mustReplay = false;
-  for (auto const& link : links) {
-    if (link.second) {  // link excluded from recovery
-      _skippedIndexes.emplace(link.first->id());
-      continue;
+    if (ADB_UNLIKELY(!skipIt)) {
+      skipIt = _skipRecoveryItems.find(impl.collection().name());
     }
-    auto apply = [&](auto& impl) {
-      if (tick > impl.recoveryTickHigh()) {
-        mustReplay = true;
-        return;
+    return *skipIt != _skipRecoveryItems.end() &&
+           ((**skipIt).second.contains(impl.name()) ||
+            (**skipIt).second.contains(absl::AlphaNum{impl.id().id()}.Piece()));
+  };
+
+  auto apply = [&](auto range, auto& values, bool& needed) {
+    if (range.empty()) {
+      return;
+    }
+    auto begin = values.begin();
+    auto it = begin + range.begin;
+    auto end = range.end != kMaxSize ? begin + range.end : values.end();
+    for (; it != end; ++it) {
+      if (*it == nullptr) {
+        continue;
       }
-      auto snapshotCookie = _cookies.lazy_emplace(
-          link.first.get(),
-          [&](auto const& ctor) { ctor(link.first.get(), impl.snapshot()); });
-      if (impl.exists(snapshotCookie->second, docId, &tick)) {
-        _skipExisted.emplace(link.first->id());
-      } else {
-        mustReplay = true;
+      if (tick <= (**it).recoveryTickLow()) {
+        needed = true;
+        continue;
       }
-    };
-    if (link.first->type() == Index::IndexType::TRI_IDX_TYPE_INVERTED_INDEX) {
-      auto& impl =
-          basics::downCast<IResearchRocksDBInvertedIndex>(*(link.first));
-      apply(impl);
-    } else {
-      TRI_ASSERT(link.first->type() ==
-                 Index::IndexType::TRI_IDX_TYPE_IRESEARCH_LINK);
-      auto& impl = basics::downCast<IResearchRocksDBLink>(*(link.first));
-      apply(impl);
-    }
-  }
-  if (!mustReplay) {
-    return;
-  }
-
-  SingleCollectionTransaction trx(
-      std::shared_ptr<transaction::Context>(
-          std::shared_ptr<transaction::Context>(), &ctx),
-      *coll, AccessMode::Type::WRITE);
-
-  Result res = trx.begin();
-
-  if (res.fail()) {
-    THROW_ARANGO_EXCEPTION(res);
-  }
-
-  for (auto const& link : links) {
-    if (!link.second && !_skipExisted.contains(link.first->id())) {
-      if (link.first->type() == Index::TRI_IDX_TYPE_INVERTED_INDEX) {
-        basics::downCast<IResearchRocksDBInvertedIndex>(*(link.first))
-            .insertInRecovery(trx, docId, doc, tick);
-      } else {
-        TRI_ASSERT(link.first->type() == Index::TRI_IDX_TYPE_IRESEARCH_LINK);
-        basics::downCast<IResearchRocksDBLink>(*(link.first))
-            .insertInRecovery(trx, docId, doc, tick);
-      }
-    }
-  }
-
-  res = trx.commit();
-
-  if (res.fail()) {
-    THROW_ARANGO_EXCEPTION(res);
-  }
-}
-
-// common implementation for DeleteCF / SingleDeleteCF
-void IResearchRocksDBRecoveryHelper::handleDeleteCF(
-    uint32_t column_family_id, const rocksdb::Slice& key,
-    rocksdb::SequenceNumber tick) {
-  if (column_family_id != _documentCF) {
-    return;
-  }
-
-  auto coll =
-      lookupCollection(*_dbFeature, *_engine, RocksDBKey::objectId(key));
-
-  if (coll == nullptr) {
-    return;
-  }
-
-  LinkContainer links;
-  auto mustReplay = lookupLinks(links, *coll);
-
-  if (links.empty()) {
-    // no links found. nothing to do
-    TRI_ASSERT(!mustReplay);
-    return;
-  }
-
-  if (!mustReplay) {
-    // links found, but the recovery for all of them will be skipped.
-    // so we need to mark all the links as out of sync
-    for (auto const& link : links) {
-      TRI_ASSERT(link.second);
-      _skippedIndexes.emplace(link.first->id());
-    }
-    return;
-  }
-
-  auto docId = RocksDBKey::documentId(key);
-
-  transaction::StandaloneContext ctx(coll->vocbase());
-
-  SingleCollectionTransaction trx(
-      std::shared_ptr<transaction::Context>(
-          std::shared_ptr<transaction::Context>(), &ctx),
-      *coll, AccessMode::Type::WRITE);
-
-  Result res = trx.begin();
-
-  if (res.fail()) {
-    THROW_ARANGO_EXCEPTION(res);
-  }
-
-  for (auto const& link : links) {
-    if (link.second) {
-      // link excluded from recovery
-      _skippedIndexes.emplace(link.first->id());
-    } else {
-      // link participates in recovery
-      if (link.first->type() == Index::TRI_IDX_TYPE_INVERTED_INDEX) {
-        auto& impl =
-            basics::downCast<IResearchRocksDBInvertedIndex>(*(link.first));
-        impl.removeInRecovery(trx, docId, tick);
-      } else {
-        TRI_ASSERT(link.first->type() == Index::TRI_IDX_TYPE_IRESEARCH_LINK);
-        auto& impl = basics::downCast<IResearchRocksDBLink>(*(link.first));
-        impl.removeInRecovery(trx, docId, tick);
-      }
-    }
-  }
-
-  res = trx.commit();
-
-  if (res.fail()) {
-    THROW_ARANGO_EXCEPTION(res);
-  }
-}
-
-void IResearchRocksDBRecoveryHelper::LogData(const rocksdb::Slice& blob,
-                                             rocksdb::SequenceNumber tick) {
-  RocksDBLogType const type = RocksDBLogValue::type(blob);
-
-  switch (type) {
-    case RocksDBLogType::IndexCreate: {
-      // Intentional NOOP. Index is committed upon creation.
-      // So if this marker was written  - index was persisted already.
-      break;
-    }
-    case RocksDBLogType::CollectionTruncate: {
-      TRI_ASSERT(_dbFeature);
-      TRI_ASSERT(_engine);
-      uint64_t objectId = RocksDBLogValue::objectId(blob);
-      auto coll = lookupCollection(*_dbFeature, *_engine, objectId);
-
-      if (coll == nullptr) {
-        return;
-      }
-
-      LinkContainer links;
-      auto mustReplay = lookupLinks(links, *coll);
-
-      if (links.empty()) {
-        // no links found. nothing to do
-        TRI_ASSERT(!mustReplay);
-        return;
-      }
-
-      for (auto const& link : links) {
-        if (link.second) {
-          _skippedIndexes.emplace(link.first->id());
-        } else {
-          link.first->afterTruncate(tick, nullptr);
+      if constexpr (Exists) {
+        if (tick <= (**it).recoveryTickHigh() && (**it).exists(documentId)) {
+          needed = true;
+          continue;
         }
       }
-      break;
+      if (!skip(**it)) {
+        func(**it, documentId);
+        needed = true;
+      } else {
+        (**it).setOutOfSync();
+        *it = nullptr;
+      }
     }
+  };
+
+  bool indexes_needed = false;
+  apply(ranges.indexes, _indexes, indexes_needed);
+
+  bool links_needed = false;
+  apply(ranges.links, _links, links_needed);
+
+  if (!indexes_needed &&
+      ranges.indexes.end >= static_cast<uint16_t>(_indexes.size())) {
+    _indexes.resize(ranges.indexes.begin);
+    _ranges[objectId].indexes = {};
+  }
+
+  if (!links_needed &&
+      ranges.links.end >= static_cast<uint16_t>(_links.size())) {
+    _links.resize(ranges.links.begin);
+    _ranges[objectId].links = {};
+  }
+}
+
+void IResearchRocksDBRecoveryHelper::PutCF(uint32_t column_family_id,
+                                           rocksdb::Slice const& key,
+                                           rocksdb::Slice const& value,
+                                           rocksdb::SequenceNumber tick) {
+  return applyCF<true>(column_family_id, key, tick,
+                       [&](auto& impl, LocalDocumentId documentId) {
+                         auto doc = RocksDBValue::data(value);
+                         impl.recoveryInsert(tick, documentId, doc);
+                       });
+}
+
+void IResearchRocksDBRecoveryHelper::DeleteCF(uint32_t column_family_id,
+                                              rocksdb::Slice const& key,
+                                              rocksdb::SequenceNumber tick) {
+  return applyCF<false>(column_family_id, key, tick,
+                        [&](auto& impl, LocalDocumentId documentId) {
+                          impl.recoveryRemove(documentId);
+                        });
+}
+
+void IResearchRocksDBRecoveryHelper::LogData(rocksdb::Slice const& blob,
+                                             rocksdb::SequenceNumber tick) {
+  auto const type = RocksDBLogValue::type(blob);
+
+  switch (type) {
+    case RocksDBLogType::DatabaseCreate:
+    case RocksDBLogType::CollectionCreate:
+      // TODO(MBkkt) Do we really need clear for these?
+    case RocksDBLogType::DatabaseDrop:
+    case RocksDBLogType::CollectionDrop:
+    case RocksDBLogType::IndexCreate:
+    case RocksDBLogType::IndexDrop:
+      // TODO(MBkkt) Clear only necessary entries
+      clear<true>();
+      break;
+    case RocksDBLogType::CollectionTruncate: {
+      // TODO(MBkkt) Truncate could recover index from OutOfSync state
+      auto const objectId = RocksDBLogValue::objectId(blob);
+
+      auto ranges = getRanges(objectId);
+      if (ranges.empty()) {
+        return;
+      }
+
+      irs::Finally cleanup = [&]() noexcept { clear<false>(); };
+
+      auto apply = [&](auto range, auto& values) {
+        if (range.empty()) {
+          return;
+        }
+        auto begin = values.begin();
+        auto it = begin + range.begin;
+        auto end = range.end != kMaxSize ? begin + range.end : values.end();
+        for (; it != end; ++it) {
+          if (*it == nullptr) {
+            continue;
+          }
+          if (tick <= (**it).recoveryTickLow()) {
+            continue;
+          }
+          (**it).afterTruncate(tick, nullptr);
+        }
+      };
+
+      apply(ranges.indexes, _indexes);
+      apply(ranges.links, _links);
+    } break;
     default:
       break;  // shut up the compiler
   }
 }
 
-bool IResearchRocksDBRecoveryHelper::lookupLinks(
-    LinkContainer& result, LogicalCollection& coll) const {
-  TRI_ASSERT(result.empty());
+std::shared_ptr<LogicalCollection>
+IResearchRocksDBRecoveryHelper::lookupCollection(uint64_t objectId) {
+  TRI_ASSERT(_engine);
+  TRI_ASSERT(_dbFeature);
+  auto const [databaseName, collectionId] =
+      _engine->mapObjectToCollection(objectId);
+  auto vocbase = _dbFeature->useDatabase(databaseName);
+  return vocbase ? vocbase->lookupCollection(collectionId) : nullptr;
+}
 
-  bool mustReplay = false;
+IResearchRocksDBRecoveryHelper::Ranges
+IResearchRocksDBRecoveryHelper::getRanges(uint64_t objectId) {
+  auto [it, emplaced] = _ranges.try_emplace(objectId);
+  if (!emplaced) {
+    return it->second;
+  }
+  return it->second = makeRanges(objectId);
+}
 
-  auto indexes = coll.getIndexes();
+IResearchRocksDBRecoveryHelper::Ranges
+IResearchRocksDBRecoveryHelper::makeRanges(uint64_t objectId) {
+  TRI_ASSERT(!_skipAllItems);
+  auto collection = lookupCollection(objectId);
+  if (!collection) {
+    // TODO(MBkkt) it was ok in old implementation
+    // but I don't know why, for me it looks like assert
+    return {};
+  }
 
-  // filter out non iresearch links
-  const auto it = std::remove_if(
-      indexes.begin(), indexes.end(), [](std::shared_ptr<Index> const& idx) {
-        return idx->type() != Index::TRI_IDX_TYPE_IRESEARCH_LINK &&
-               idx->type() != Index::TRI_IDX_TYPE_INVERTED_INDEX;
-      });
-  indexes.erase(it, indexes.end());
+  auto const indexesBegin = _indexes.size();
+  auto const linksBegin = _links.size();
+  TRI_ASSERT(indexesBegin < kMaxSize);
+  TRI_ASSERT(linksBegin < kMaxSize);
 
-  result.reserve(indexes.size());
-  for (auto& index : indexes) {
-    bool mustFail = _skipAllItems;
-    if (!mustFail && !_skipRecoveryItems.empty()) {
-      if (auto it = _skipRecoveryItems.find(coll.name());
-          it != _skipRecoveryItems.end()) {
-        mustFail =
-            it->second.contains(index->name()) ||
-            it->second.contains(absl::AlphaNum{index->id().id()}.Piece());
-      }
+  auto add = [&](auto& values, auto& value) {
+    if (!value.isOutOfSync()) {
+      values.push_back(&value);
     }
-    result.emplace_back(std::make_pair(std::move(index), mustFail));
-    if (!mustFail) {
-      mustReplay = true;
+  };
+
+  for (auto&& index : collection->getIndexes()) {
+    TRI_ASSERT(index != nullptr);
+    if (index->type() == Index::TRI_IDX_TYPE_INVERTED_INDEX) {
+      add(_indexes, basics::downCast<IResearchRocksDBInvertedIndex>(*index));
+    } else if (index->type() == Index::TRI_IDX_TYPE_IRESEARCH_LINK) {
+      add(_links, basics::downCast<IResearchRocksDBLink>(*index));
     }
   }
 
-  return mustReplay;
+  auto const indexesEnd = _indexes.size();
+  auto const linksEnd = _links.size();
+
+  return {.indexes = {.begin = static_cast<uint16_t>(indexesBegin),
+                      .end = indexesEnd < kMaxSize
+                                 ? static_cast<uint16_t>(indexesEnd)
+                                 : kMaxSize},
+          .links = {.begin = static_cast<uint16_t>(linksBegin),
+                    .end = linksEnd < kMaxSize ? static_cast<uint16_t>(linksEnd)
+                                               : kMaxSize}};
 }
 
-}  // namespace arangodb::iresearch
+}  // namespace iresearch
+}  // namespace arangodb

--- a/arangod/IResearch/IResearchRocksDBRecoveryHelper.cpp
+++ b/arangod/IResearch/IResearchRocksDBRecoveryHelper.cpp
@@ -216,7 +216,8 @@ void IResearchRocksDBRecoveryHelper::LogData(rocksdb::Slice const& blob,
   auto const type = RocksDBLogValue::type(blob);
 
   switch (type) {
-    case RocksDBLogType::IndexCreate: {
+    case RocksDBLogType::IndexCreate:
+    case RocksDBLogType::IndexDrop: {
       // TODO(MBkkt) More granular cache invalidation
       clear<true>();
     } break;

--- a/arangod/IResearch/IResearchRocksDBRecoveryHelper.cpp
+++ b/arangod/IResearch/IResearchRocksDBRecoveryHelper.cpp
@@ -122,7 +122,7 @@ void IResearchRocksDBRecoveryHelper::applyCF(uint32_t column_family_id,
 
   auto const objectId = RocksDBKey::objectId(key);
 
-  auto ranges = getRanges(objectId);
+  auto& ranges = getRanges(objectId);
   if (ranges.empty()) {
     return;
   }
@@ -183,13 +183,13 @@ void IResearchRocksDBRecoveryHelper::applyCF(uint32_t column_family_id,
   if (!indexes_needed &&
       ranges.indexes.end >= static_cast<uint16_t>(_indexes.size())) {
     _indexes.resize(ranges.indexes.begin);
-    _ranges[objectId].indexes = {};
+    ranges.indexes = {};
   }
 
   if (!links_needed &&
       ranges.links.end >= static_cast<uint16_t>(_links.size())) {
     _links.resize(ranges.links.begin);
-    _ranges[objectId].links = {};
+    ranges.links = {};
   }
 }
 
@@ -267,7 +267,7 @@ IResearchRocksDBRecoveryHelper::lookupCollection(uint64_t objectId) {
   return vocbase ? vocbase->lookupCollection(collectionId) : nullptr;
 }
 
-IResearchRocksDBRecoveryHelper::Ranges
+IResearchRocksDBRecoveryHelper::Ranges&
 IResearchRocksDBRecoveryHelper::getRanges(uint64_t objectId) {
   auto [it, emplaced] = _ranges.try_emplace(objectId);
   if (!emplaced) {

--- a/arangod/IResearch/IResearchRocksDBRecoveryHelper.cpp
+++ b/arangod/IResearch/IResearchRocksDBRecoveryHelper.cpp
@@ -82,11 +82,9 @@ IResearchRocksDBRecoveryHelper::IResearchRocksDBRecoveryHelper(
       _skipRecoveryItems = {};
       break;
     }
-    auto parts = absl::StrSplit(item, '/');
-    auto parts_it = parts.begin();
-    auto it = _skipRecoveryItems.try_emplace(*parts_it);
-    ++parts_it;
-    it.first->second.emplace(*parts_it);
+    std::pair<std::string_view, std::string_view> parts =
+        absl::StrSplit(item, '/');
+    _skipRecoveryItems[parts.first].emplace(parts.second);
   }
 }
 
@@ -293,7 +291,7 @@ IResearchRocksDBRecoveryHelper::makeRanges(uint64_t objectId) {
   TRI_ASSERT(!_skipAllItems);
   auto collection = lookupCollection(objectId);
   if (!collection) {
-    // TODO(MBkkt) it was ok in old implementation
+    // TODO(MBkkt) it was ok in the old implementation
     // but I don't know why, for me it looks like assert
     return {};
   }

--- a/arangod/IResearch/IResearchRocksDBRecoveryHelper.cpp
+++ b/arangod/IResearch/IResearchRocksDBRecoveryHelper.cpp
@@ -217,8 +217,8 @@ void IResearchRocksDBRecoveryHelper::LogData(rocksdb::Slice const& blob,
 
   switch (type) {
     case RocksDBLogType::IndexCreate: {
-      auto const objectId = RocksDBLogValue::objectId(blob);
-      _ranges.erase(objectId);
+      // TODO(MBkkt) More granular cache invalidation
+      clear<true>();
     } break;
     case RocksDBLogType::CollectionTruncate: {
       // TODO(MBkkt) Truncate could recover index from OutOfSync state

--- a/arangod/IResearch/IResearchRocksDBRecoveryHelper.h
+++ b/arangod/IResearch/IResearchRocksDBRecoveryHelper.h
@@ -84,7 +84,6 @@ class IResearchRocksDBRecoveryHelper final : public RocksDBRecoveryHelper {
   template<bool NeedExists, typename Func>
   void applyCF(uint32_t column_family_id, rocksdb::Slice key,
                rocksdb::SequenceNumber tick, Func&& func);
-  void skipAll(uint64_t objectId, rocksdb::SequenceNumber tick);
 
   static constexpr auto kMaxSize = std::numeric_limits<uint16_t>::max();
 
@@ -105,6 +104,9 @@ class IResearchRocksDBRecoveryHelper final : public RocksDBRecoveryHelper {
   Ranges& getRanges(uint64_t objectId);
   Ranges makeRanges(uint64_t objectId);
   std::shared_ptr<LogicalCollection> lookupCollection(uint64_t objectId);
+
+  template<typename Impl>
+  bool skip(Impl& impl);
 
   template<bool Force>
   void clear() noexcept;

--- a/arangod/IResearch/IResearchRocksDBRecoveryHelper.h
+++ b/arangod/IResearch/IResearchRocksDBRecoveryHelper.h
@@ -102,7 +102,7 @@ class IResearchRocksDBRecoveryHelper final : public RocksDBRecoveryHelper {
     bool empty() const noexcept { return indexes.empty() && links.empty(); }
   };
 
-  Ranges getRanges(uint64_t objectId);
+  Ranges& getRanges(uint64_t objectId);
   Ranges makeRanges(uint64_t objectId);
   std::shared_ptr<LogicalCollection> lookupCollection(uint64_t objectId);
 

--- a/arangod/IResearch/Search.cpp
+++ b/arangod/IResearch/Search.cpp
@@ -566,14 +566,6 @@ Result Search::properties(velocypack::Slice definition, bool isUserRequest,
   return r;
 }
 
-void Search::open() {
-  // if (ServerState::instance()->isSingleServer()) {
-  //   auto& engine =
-  //       vocbase().server().getFeature<EngineSelectorFeature>().engine();
-  //   _inRecovery.store(engine.inRecovery(), std::memory_order_seq_cst);
-  // }
-}
-
 bool Search::visitCollections(CollectionVisitor const& visitor) const {
   std::shared_lock lock{_mutex};
   for (auto& [cid, handles] : _indexes) {

--- a/arangod/IResearch/Search.h
+++ b/arangod/IResearch/Search.h
@@ -132,7 +132,7 @@ class Search final : public LogicalView {
   //////////////////////////////////////////////////////////////////////////////
   /// @brief opens an existing view when the server is restarted
   //////////////////////////////////////////////////////////////////////////////
-  void open() final;
+  void open() final {}
 
   //////////////////////////////////////////////////////////////////////////////
   /// @brief invoke visitor on all collections that a view will return
@@ -177,7 +177,6 @@ class Search final : public LogicalView {
   AsyncSearchPtr _asyncSelf;
   std::function<void(transaction::Methods& trx, transaction::Status status)>
       _trxCallback;  // for snapshot(...)
-  // std::atomic_bool _inRecovery{false};
 
   std::shared_ptr<SearchMeta const> _meta;
 

--- a/arangod/RocksDBEngine/RocksDBRecoveryHelper.h
+++ b/arangod/RocksDBEngine/RocksDBRecoveryHelper.h
@@ -57,8 +57,6 @@ class RocksDBRecoveryHelper {
 
   virtual void LogData(const rocksdb::Slice& blob,
                        rocksdb::SequenceNumber tick) {}
-
-  virtual bool wasSkipped(IndexId /*id*/) const noexcept { return false; }
 };
 
 }  // end namespace arangodb

--- a/tests/IResearch/IResearchInvertedIndexIteratorTest.cpp
+++ b/tests/IResearch/IResearchInvertedIndexIteratorTest.cpp
@@ -156,7 +156,7 @@ class IResearchInvertedIndexIteratorTestBase
                                 arangodb::iresearch::
                                     IResearchInvertedIndexMetaIndexingContext>(
                            trx, doc->first, doc->second->slice(),
-                           *_index->meta()._indexingContext, nullptr)
+                           *_index->meta()._indexingContext)
                        .ok();
         EXPECT_TRUE(res);
         ++doc;
@@ -176,7 +176,7 @@ class IResearchInvertedIndexIteratorTestBase
                               arangodb::iresearch::
                                   IResearchInvertedIndexMetaIndexingContext>(
                          trx, doc->first, doc->second->slice(),
-                         *_index->meta()._indexingContext, nullptr)
+                         *_index->meta()._indexingContext)
                      .ok();
       EXPECT_TRUE(res);
       ++doc;

--- a/tests/IResearch/IResearchLinkTest.cpp
+++ b/tests/IResearch/IResearchLinkTest.cpp
@@ -1051,9 +1051,7 @@ TEST_F(IResearchLinkTest, test_write) {
     EXPECT_TRUE((trx.begin().ok()));
     auto* l = dynamic_cast<arangodb::iresearch::IResearchLinkMock*>(link.get());
     ASSERT_TRUE(l != nullptr);
-    EXPECT_TRUE((l->remove(trx, arangodb::LocalDocumentId(2),
-                           l->meta().hasNested(), nullptr)
-                     .ok()));
+    EXPECT_TRUE((l->remove(trx, arangodb::LocalDocumentId(2)).ok()));
     EXPECT_TRUE((trx.commit().ok()));
     EXPECT_TRUE((l->commit().ok()));
   }
@@ -2339,9 +2337,7 @@ class IResearchLinkMetricsTest : public IResearchLinkTest {
         kEmpty, kEmpty, arangodb::transaction::Options());
     EXPECT_TRUE(trx.begin().ok());
     for (; begin != end; ++begin) {
-      EXPECT_TRUE(l->remove(trx, arangodb::LocalDocumentId(begin),
-                            l->meta().hasNested(), nullptr)
-                      .ok());
+      EXPECT_TRUE(l->remove(trx, arangodb::LocalDocumentId(begin)).ok());
     }
 
     EXPECT_TRUE(trx.commit().ok());

--- a/tests/IResearch/IResearchViewTest.cpp
+++ b/tests/IResearch/IResearchViewTest.cpp
@@ -1877,8 +1877,7 @@ TEST_F(IResearchViewTest, test_cleanup) {
         arangodb::transaction::StandaloneContext::Create(vocbase), EMPTY, EMPTY,
         EMPTY, arangodb::transaction::Options());
     EXPECT_TRUE((trx.begin().ok()));
-    EXPECT_TRUE(
-        (link->remove(trx, arangodb::LocalDocumentId(0), false, nullptr).ok()));
+    EXPECT_TRUE((link->remove(trx, arangodb::LocalDocumentId(0)).ok()));
     EXPECT_TRUE((trx.commit().ok()));
     EXPECT_TRUE(link->commit().ok());
   }
@@ -3274,37 +3273,29 @@ TEST_F(IResearchViewTest, test_insert) {
       auto docJson =
           arangodb::velocypack::Parser::fromJson("{\"abc\": \"def\"}");
       arangodb::iresearch::IResearchLinkMeta linkMeta;
-      arangodb::transaction::Methods trx(
-          arangodb::transaction::StandaloneContext::Create(vocbase), EMPTY,
-          EMPTY, EMPTY, arangodb::transaction::Options());
 
       linkMeta._includeAllFields = true;
-      EXPECT_TRUE((trx.begin().ok()));
 
       // skip tick operations before recovery tick
       StorageEngineMock::recoveryTickResult = 41;
-      EXPECT_TRUE(link->insertInRecovery(trx, arangodb::LocalDocumentId(1),
-                                         docJson->slice(),
-                                         StorageEngineMock::recoveryTickResult)
-                      .ok());
+      if (StorageEngineMock::recoveryTickResult > link->recoveryTickLow()) {
+        link->recoveryInsert(StorageEngineMock::recoveryTickResult,
+                             arangodb::LocalDocumentId(1), docJson->slice());
+      }
       StorageEngineMock::recoveryTickResult = 42;
-      EXPECT_TRUE(link->insertInRecovery(trx, arangodb::LocalDocumentId(2),
-                                         docJson->slice(),
-                                         StorageEngineMock::recoveryTickResult)
-                      .ok());
-
+      if (StorageEngineMock::recoveryTickResult > link->recoveryTickLow()) {
+        link->recoveryInsert(StorageEngineMock::recoveryTickResult,
+                             arangodb::LocalDocumentId(2), docJson->slice());
+      }
       // insert operations after recovery tick
       StorageEngineMock::recoveryTickResult = 43;
-      EXPECT_TRUE(link->insertInRecovery(trx, arangodb::LocalDocumentId(1),
-                                         docJson->slice(),
-                                         StorageEngineMock::recoveryTickResult)
-                      .ok());
-      EXPECT_TRUE(link->insertInRecovery(trx, arangodb::LocalDocumentId(2),
-                                         docJson->slice(),
-                                         StorageEngineMock::recoveryTickResult)
-                      .ok());
-
-      EXPECT_TRUE(trx.commit().ok());
+      if (StorageEngineMock::recoveryTickResult > link->recoveryTickLow()) {
+        link->recoveryInsert(StorageEngineMock::recoveryTickResult,
+                             arangodb::LocalDocumentId(1), docJson->slice());
+        link->recoveryInsert(StorageEngineMock::recoveryTickResult,
+                             arangodb::LocalDocumentId(2), docJson->slice());
+      }
+      link->recoveryCommit(StorageEngineMock::recoveryTickResult);
       EXPECT_TRUE(link->commit().ok());
     }
 
@@ -3357,9 +3348,6 @@ TEST_F(IResearchViewTest, test_insert) {
       auto docJson =
           arangodb::velocypack::Parser::fromJson("{\"abc\": \"def\"}");
       arangodb::iresearch::IResearchLinkMeta linkMeta;
-      arangodb::transaction::Methods trx(
-          arangodb::transaction::StandaloneContext::Create(vocbase), EMPTY,
-          EMPTY, EMPTY, arangodb::transaction::Options());
 
       std::vector<
           std::pair<arangodb::LocalDocumentId, arangodb::velocypack::Slice>>
@@ -3369,25 +3357,30 @@ TEST_F(IResearchViewTest, test_insert) {
           };
 
       linkMeta._includeAllFields = true;
-      EXPECT_TRUE((trx.begin().ok()));
       // insert operations before recovery tick
       StorageEngineMock::recoveryTickResult = 41;
-      for (auto const& pair : batch) {
-        link->insertInRecovery(trx, pair.first, pair.second,
-                               StorageEngineMock::recoveryTickResult);
+      if (StorageEngineMock::recoveryTickResult > link->recoveryTickLow()) {
+        for (auto const& pair : batch) {
+          link->recoveryInsert(StorageEngineMock::recoveryTickResult,
+                               pair.first, pair.second);
+        }
       }
       StorageEngineMock::recoveryTickResult = 42;
-      for (auto const& pair : batch) {
-        link->insertInRecovery(trx, pair.first, pair.second,
-                               StorageEngineMock::recoveryTickResult);
+      if (StorageEngineMock::recoveryTickResult > link->recoveryTickLow()) {
+        for (auto const& pair : batch) {
+          link->recoveryInsert(StorageEngineMock::recoveryTickResult,
+                               pair.first, pair.second);
+        }
       }
       // insert operations after recovery tick
       StorageEngineMock::recoveryTickResult = 43;
-      for (auto const& pair : batch) {
-        link->insertInRecovery(trx, pair.first, pair.second,
-                               StorageEngineMock::recoveryTickResult);
+      if (StorageEngineMock::recoveryTickResult > link->recoveryTickLow()) {
+        for (auto const& pair : batch) {
+          link->recoveryInsert(StorageEngineMock::recoveryTickResult,
+                               pair.first, pair.second);
+        }
       }
-      EXPECT_TRUE((trx.commit().ok()));
+      link->recoveryCommit(StorageEngineMock::recoveryTickResult);
       EXPECT_TRUE(link->commit().ok());
     }
 
@@ -3712,9 +3705,9 @@ TEST_F(IResearchViewTest, test_remove_within_trx) {
                              empty, empty, empty, transaction::Options());
     EXPECT_TRUE(trx.begin().ok());
     EXPECT_TRUE(link->insert(trx, LocalDocumentId(0), doc0->slice()).ok());
-    EXPECT_TRUE(link->remove(trx, LocalDocumentId(0), false, nullptr).ok());
+    EXPECT_TRUE(link->remove(trx, LocalDocumentId(0)).ok());
     EXPECT_TRUE(link->insert(trx, LocalDocumentId(1), doc1->slice()).ok());
-    EXPECT_TRUE(link->remove(trx, LocalDocumentId(1), false, nullptr).ok());
+    EXPECT_TRUE(link->remove(trx, LocalDocumentId(1)).ok());
     EXPECT_TRUE(link->insert(trx, LocalDocumentId(2), doc2->slice()).ok());
     EXPECT_TRUE(trx.commit().ok());
     EXPECT_TRUE(link->commit().ok());
@@ -3797,46 +3790,37 @@ TEST_F(IResearchViewTest, test_remove) {
       auto docJson =
           arangodb::velocypack::Parser::fromJson("{\"abc\": \"def\"}");
       arangodb::iresearch::IResearchLinkMeta linkMeta;
-      arangodb::transaction::Methods trx(
-          arangodb::transaction::StandaloneContext::Create(vocbase), EMPTY,
-          EMPTY, EMPTY, arangodb::transaction::Options());
 
       linkMeta._includeAllFields = true;
-      EXPECT_TRUE((trx.begin().ok()));
 
       // insert operations after recovery tick
       StorageEngineMock::recoveryTickResult = 43;
-      EXPECT_TRUE(link->insertInRecovery(trx, arangodb::LocalDocumentId(1),
-                                         docJson->slice(),
-                                         StorageEngineMock::recoveryTickResult)
-                      .ok());
-      EXPECT_TRUE(link->insertInRecovery(trx, arangodb::LocalDocumentId(2),
-                                         docJson->slice(),
-                                         StorageEngineMock::recoveryTickResult)
-                      .ok());
-      EXPECT_TRUE(link->insertInRecovery(trx, arangodb::LocalDocumentId(3),
-                                         docJson->slice(),
-                                         StorageEngineMock::recoveryTickResult)
-                      .ok());
+      link->recoveryInsert(StorageEngineMock::recoveryTickResult,
+                           arangodb::LocalDocumentId(1), docJson->slice());
+      link->recoveryInsert(StorageEngineMock::recoveryTickResult,
+                           arangodb::LocalDocumentId(2), docJson->slice());
+      link->recoveryInsert(StorageEngineMock::recoveryTickResult,
+                           arangodb::LocalDocumentId(3), docJson->slice());
 
       // skip tick operations before recovery tick
       StorageEngineMock::recoveryTickResult = 41;
-      EXPECT_TRUE(link->remove(trx, arangodb::LocalDocumentId(1), false,
-                               &StorageEngineMock::recoveryTickResult)
-                      .ok());
+      if (StorageEngineMock::recoveryTickResult > link->recoveryTickLow()) {
+        link->recoveryRemove(arangodb::LocalDocumentId(1));
+      }
       StorageEngineMock::recoveryTickResult = 42;
-      EXPECT_TRUE(link->insertInRecovery(trx, arangodb::LocalDocumentId(2),
-                                         VPackSlice::noneSlice(),
-                                         StorageEngineMock::recoveryTickResult)
-                      .ok());
+      if (StorageEngineMock::recoveryTickResult > link->recoveryTickLow()) {
+        link->recoveryInsert(StorageEngineMock::recoveryTickResult,
+                             arangodb::LocalDocumentId(2),
+                             VPackSlice::noneSlice());
+      }
 
       // apply remove after recovery tick
       StorageEngineMock::recoveryTickResult = 43;
-      EXPECT_TRUE(link->remove(trx, arangodb::LocalDocumentId(3), false,
-                               &StorageEngineMock::recoveryTickResult)
-                      .ok());
+      if (StorageEngineMock::recoveryTickResult > link->recoveryTickLow()) {
+        link->recoveryRemove(arangodb::LocalDocumentId(3));
+      }
 
-      EXPECT_TRUE(trx.commit().ok());
+      link->recoveryCommit(StorageEngineMock::recoveryTickResult);
       EXPECT_TRUE(link->commit().ok());
     }
 
@@ -3888,9 +3872,6 @@ TEST_F(IResearchViewTest, test_remove) {
       auto docJson =
           arangodb::velocypack::Parser::fromJson("{\"abc\": \"def\"}");
       arangodb::iresearch::IResearchLinkMeta linkMeta;
-      arangodb::transaction::Methods trx(
-          arangodb::transaction::StandaloneContext::Create(vocbase), EMPTY,
-          EMPTY, EMPTY, arangodb::transaction::Options());
 
       std::vector<
           std::pair<arangodb::LocalDocumentId, arangodb::velocypack::Slice>>
@@ -3900,25 +3881,30 @@ TEST_F(IResearchViewTest, test_remove) {
           };
 
       linkMeta._includeAllFields = true;
-      EXPECT_TRUE((trx.begin().ok()));
       // insert operations before recovery tick
       StorageEngineMock::recoveryTickResult = 41;
-      for (auto const& pair : batch) {
-        link->insertInRecovery(trx, pair.first, pair.second,
-                               StorageEngineMock::recoveryTickResult);
+      if (StorageEngineMock::recoveryTickResult > link->recoveryTickLow()) {
+        for (auto const& pair : batch) {
+          link->recoveryInsert(StorageEngineMock::recoveryTickResult,
+                               pair.first, pair.second);
+        }
       }
-      StorageEngineMock::recoveryTickResult = 42;
-      for (auto const& pair : batch) {
-        link->insertInRecovery(trx, pair.first, pair.second,
-                               StorageEngineMock::recoveryTickResult);
+      if (StorageEngineMock::recoveryTickResult > link->recoveryTickLow()) {
+        StorageEngineMock::recoveryTickResult = 42;
+        for (auto const& pair : batch) {
+          link->recoveryInsert(StorageEngineMock::recoveryTickResult,
+                               pair.first, pair.second);
+        }
       }
       // insert operations after recovery tick
       StorageEngineMock::recoveryTickResult = 43;
-      for (auto const& pair : batch) {
-        link->insertInRecovery(trx, pair.first, pair.second,
-                               StorageEngineMock::recoveryTickResult);
+      if (StorageEngineMock::recoveryTickResult > link->recoveryTickLow()) {
+        for (auto const& pair : batch) {
+          link->recoveryInsert(StorageEngineMock::recoveryTickResult,
+                               pair.first, pair.second);
+        }
       }
-      EXPECT_TRUE((trx.commit().ok()));
+      link->recoveryCommit(StorageEngineMock::recoveryTickResult);
       EXPECT_TRUE(link->commit().ok());
     }
 

--- a/tests/Mocks/IResearchInvertedIndexMock.cpp
+++ b/tests/Mocks/IResearchInvertedIndexMock.cpp
@@ -138,8 +138,7 @@ Result IResearchInvertedIndexMock::insert(transaction::Methods& trx,
   IResearchInvertedIndexMetaIndexingContext ctx(&this->meta());
   return IResearchDataStore::insert<
       FieldIterator<IResearchInvertedIndexMetaIndexingContext>,
-      IResearchInvertedIndexMetaIndexingContext>(trx, documentId, doc, ctx,
-                                                 nullptr);
+      IResearchInvertedIndexMetaIndexingContext>(trx, documentId, doc, ctx);
 }
 
 AnalyzerPool::ptr IResearchInvertedIndexMock::findAnalyzer(

--- a/tests/Mocks/IResearchLinkMock.cpp
+++ b/tests/Mocks/IResearchLinkMock.cpp
@@ -83,14 +83,11 @@ void IResearchLinkMock::toVelocyPack(
 std::function<irs::directory_attributes()> IResearchLinkMock::InitCallback;
 
 Result IResearchLinkMock::remove(transaction::Methods& trx,
-                                 LocalDocumentId documentId, bool nested,
-                                 uint64_t const* recoveryTick) {
-  if (recoveryTick == nullptr) {
-    auto* state = basics::downCast<::TransactionStateMock>(trx.state());
-    TRI_ASSERT(state != nullptr);
-    state->incrementRemove();
-  }
-  return IResearchDataStore::remove(trx, documentId, nested, recoveryTick);
+                                 LocalDocumentId documentId) {
+  auto* state = basics::downCast<::TransactionStateMock>(trx.state());
+  TRI_ASSERT(state != nullptr);
+  state->incrementRemove();
+  return IResearchDataStore::remove(trx, documentId);
 }
 
 }  // namespace arangodb::iresearch

--- a/tests/Mocks/IResearchLinkMock.h
+++ b/tests/Mocks/IResearchLinkMock.h
@@ -59,23 +59,21 @@ class IResearchLinkMock final : public Index, public IResearchLink {
     return IResearchDataStore::hasSelectivityEstimate();
   }
 
-  Result insert(transaction::Methods& trx, LocalDocumentId const& documentId,
-                velocypack::Slice const doc) {
+  Result insert(transaction::Methods& trx, LocalDocumentId documentId,
+                velocypack::Slice doc) {
     return IResearchDataStore::insert<FieldIterator<FieldMeta>,
                                       IResearchLinkMeta>(trx, documentId, doc,
-                                                         meta(), nullptr);
+                                                         meta());
   }
 
-  Result insertInRecovery(transaction::Methods& trx,
-                          LocalDocumentId const& documentId,
-                          velocypack::Slice doc, uint64_t tick) {
-    return IResearchDataStore::insert<FieldIterator<FieldMeta>,
-                                      IResearchLinkMeta>(trx, documentId, doc,
-                                                         meta(), &tick);
+  void recoveryInsert(uint64_t tick, LocalDocumentId documentId,
+                      velocypack::Slice doc) {
+    return IResearchDataStore::recoveryInsert<FieldIterator<FieldMeta>,
+                                              IResearchLinkMeta>(
+        tick, documentId, doc, meta());
   }
 
-  Result remove(transaction::Methods& trx, LocalDocumentId documentId,
-                bool nested, uint64_t const* recoveryTick);
+  Result remove(transaction::Methods& trx, LocalDocumentId documentId);
 
   bool isSorted() const final { return IResearchLink::isSorted(); }
 

--- a/tests/Mocks/IResearchLinkMock.h
+++ b/tests/Mocks/IResearchLinkMock.h
@@ -68,9 +68,9 @@ class IResearchLinkMock final : public Index, public IResearchLink {
 
   void recoveryInsert(uint64_t tick, LocalDocumentId documentId,
                       velocypack::Slice doc) {
-    return IResearchDataStore::recoveryInsert<FieldIterator<FieldMeta>,
-                                              IResearchLinkMeta>(
-        tick, documentId, doc, meta());
+    IResearchDataStore::recoveryInsert<FieldIterator<FieldMeta>,
+                                       IResearchLinkMeta>(tick, documentId, doc,
+                                                          meta());
   }
 
   Result remove(transaction::Methods& trx, LocalDocumentId documentId);


### PR DESCRIPTION
### Scope & Purpose

* Remove arangodb transaction abstractions from ArangoSearch recovery
* Add caching for get links/indexes in PutCF/DeleteCF
* Add batching for removes in recovery (for inserts too, but for them almost no difference)
* Also make OutOfSync more optimistic:
  Before these changes, even if link doesn't need recovery it can be marked as OutOfSync

For single link and 1e6 replaces (remove/insert) in recovery this PR improves time in 2 times:
30 sec instead of 1 min

For multiple links improvement could be in a few times better.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [x] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*
  - [ ] Backport for 3.9: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

