### PR TITLE
Fix typos in hotbackup error messages

### DIFF
--- a/client-tools/Backup/arangobackup.cpp
+++ b/client-tools/Backup/arangobackup.cpp
@@ -101,12 +101,12 @@ int main(int argc, char* argv[]) {
       }
     } catch (std::exception const& ex) {
       LOG_TOPIC("78140", ERR, arangodb::Logger::FIXME)
-          << "arangodump terminated because of an unhandled exception: "
+          << "arangobackup terminated because of an unhandled exception: "
           << ex.what();
       ret = EXIT_FAILURE;
     } catch (...) {
       LOG_TOPIC("cc40d", ERR, arangodb::Logger::FIXME)
-          << "arangodump terminated because of an unhandled exception of "
+          << "arangobackup terminated because of an unhandled exception of "
              "unknown type";
       ret = EXIT_FAILURE;
     }


### PR DESCRIPTION
### Scope & Purpose

If `arangobackup` exits with an exception it used to show `arangodump` as the command that failed. This might be confusing so it might well be fixed right away. It is unclear to me how one could even trigger this kind of failure, though.