### PR TITLE
Maintenance shutdown hanger

### DIFF
--- a/arangod/Cluster/ClusterInfo.cpp
+++ b/arangod/Cluster/ClusterInfo.cpp
@@ -7227,6 +7227,8 @@ void ClusterInfo::shutdownSyncers() {
   if (_curSyncer != nullptr) {
     _curSyncer->beginShutdown();
   }
+
+  drainSyncers();
 }
 
 void ClusterInfo::waitForSyncersToStop() {

--- a/arangod/Cluster/ClusterInfo.cpp
+++ b/arangod/Cluster/ClusterInfo.cpp
@@ -7219,8 +7219,6 @@ void ClusterInfo::drainSyncers() {
 }
 
 void ClusterInfo::shutdownSyncers() {
-  drainSyncers();
-
   if (_planSyncer != nullptr) {
     _planSyncer->beginShutdown();
   }
@@ -7413,6 +7411,11 @@ futures::Future<arangodb::Result> ClusterInfo::waitForCurrent(
   if (raftIndex <= _currentIndex) {
     return futures::makeFuture(arangodb::Result());
   }
+
+  if (_curSyncer == nullptr || _curSyncer->isStopping()) {
+    return _syncerShutdownCode;
+  }
+
   // intentionally don't release _storeLock here until we have inserted the
   // promise
   std::lock_guard w(_waitCurrentLock);
@@ -7426,6 +7429,11 @@ futures::Future<arangodb::Result> ClusterInfo::waitForCurrentVersion(
   if (currentVersion <= _currentVersion) {
     return futures::makeFuture(arangodb::Result());
   }
+
+  if (_curSyncer == nullptr || _curSyncer->isStopping()) {
+    return _syncerShutdownCode;
+  }
+
   // intentionally don't release _storeLock here until we have inserted the
   // promise
   std::lock_guard w(_waitCurrentVersionLock);
@@ -7440,6 +7448,10 @@ futures::Future<arangodb::Result> ClusterInfo::waitForPlan(uint64_t raftIndex) {
     return futures::makeFuture(arangodb::Result());
   }
 
+  if (_planSyncer == nullptr || _planSyncer->isStopping()) {
+    return _syncerShutdownCode;
+  }
+
   // intentionally don't release _storeLock here until we have inserted the
   // promise
   std::lock_guard w(_waitPlanLock);
@@ -7451,6 +7463,10 @@ futures::Future<Result> ClusterInfo::waitForPlanVersion(uint64_t planVersion) {
   READ_LOCKER(readLocker, _planProt.lock);
   if (planVersion <= _planVersion) {
     return futures::makeFuture(arangodb::Result());
+  }
+
+  if (_planSyncer == nullptr || _planSyncer->isStopping()) {
+    return _syncerShutdownCode;
   }
 
   // intentionally don't release _storeLock here until we have inserted the


### PR DESCRIPTION
### Scope & Purpose

**Background**
The replication2 restart tests used to get stuck sometimes in a _shutdown hanger_. During the test, one or more servers were being restarted gracefully through the shutdown API.  
The system waits for the _Heartbeat thread_ to be gracefully shut stopped. The _Heartbeat thread_ hangs during `DBServerAgencySync::execute()`, where the DBServer is supposed to wait for its own writes to become visible in its local copy of _Current_:
```cpp
AgencyCommResult r = comm.sendTransactionWithFailover(currentTransaction);
if (!r.successful()) {
  //...
} else {
  // wait for own writes to become visible locally in Current
  auto waitIndex = resultsSlice[0].getNumber<uint64_t>();
  std::ignore = clusterInfo.waitForCurrent(waitIndex).get();
  // the above Future might not be resolved
}
```
For details on how it gets to this point, please see **Details**.

**Issues**
1. _syncer queues_ are drained before the _syncer threads_ are stopped -> new Futures can be created even after the _syncer queues_ are drained
2. After marking the _syncer threads_ as stopped, there is nothing preventing us from creating new Futures in `waitForCurrent` or `waitForPlan`.

**Solution**
1. Drain _syncer queues_ only after _syncer threads_ are stopped. This way, we ensure that all Futures created in the meantime will still be resolved.
2. Before creating new futures, check the state of the _syncer threads_. If a thread that's supposed to resolve the future is about to stop, return a result immediately.
Note that we need both (1) and (2), because we want to resolve all futures that were already there before shutdown, and to make sure that no new ones are being created after shutdown.

**Details**
In order to understand the problem, we need to take a step back and observe the shutdown procedure of a cluster, the main points being `ClusterFeature::beginShutdown` and `ClusterFeature::stop`. To my understanding, `beginShutdown` is always triggered before `stop`.  
The `beginShutdown` method calls into `_clusterInfo->shutdownSyncers();`. This is the method where `_curSyncer` and `_planSyncer`, the two threads responsible for keeping the local _Current_ and _Plan_ in sync, are being stopped. The `ClusterInfo::drainSyncers` method resolves all Futures waiting for Plan or Current changes. This is where issue (1) occurs.
The `stop` method is called after `beginShutdown`. For the purpose of this PR, it is important to note that it calls into `ClusterFeature::shutdownHeartbeatThread`, which eventually waits for the _Maintenance thread_ to stop (inside `HeartbeatThread::beginShutdown`).


It is this time window, between `beginShutdown` and stopping the maintenance thread, where `DBServerAgencySync` (as part of the maintenace) might create a Future that never gets resolved (because the syncers _might_ have been stopped), therefore preventing the maintenance thread from being stopped gracefully.


Note that this is not easily reproducible in all situations. During `ClusterInfo::shutdownSyncers` we are just marking the _syncer threads_ as stopped, but we are not waiting for them to stop. Hence, even when a Future gets created after `beginShutdown`, it sometimes might get resolved.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

