### PR TITLE
[CINFRA-780] Report reboot id and use in election

### DIFF
--- a/arangod/Replication2/ReplicatedLog/AgencyLogSpecification.cpp
+++ b/arangod/Replication2/ReplicatedLog/AgencyLogSpecification.cpp
@@ -90,8 +90,12 @@ auto agency::operator<<(std::ostream& os, LogPlanSpecification const& term)
 
 LogCurrentLocalState::LogCurrentLocalState(LogTerm term,
                                            TermIndexPair spearhead,
-                                           bool snapshot) noexcept
-    : term(term), spearhead(spearhead), snapshotAvailable(snapshot) {}
+                                           bool snapshot,
+                                           RebootId rebootId) noexcept
+    : term(term),
+      spearhead(spearhead),
+      snapshotAvailable(snapshot),
+      rebootId(rebootId) {}
 
 auto agency::to_string(LogCurrentSupervisionElection::ErrorCode ec) noexcept
     -> std::string_view {

--- a/arangod/Replication2/ReplicatedLog/AgencyLogSpecification.h
+++ b/arangod/Replication2/ReplicatedLog/AgencyLogSpecification.h
@@ -174,9 +174,11 @@ struct LogCurrentLocalState {
   TermIndexPair spearhead{};
   bool snapshotAvailable{false};
   replicated_log::LocalStateMachineStatus state;
+  RebootId rebootId = RebootId(0);
 
   LogCurrentLocalState() = default;
-  LogCurrentLocalState(LogTerm, TermIndexPair, bool) noexcept;
+  LogCurrentLocalState(LogTerm, TermIndexPair, bool,
+                       RebootId rebootId) noexcept;
   friend auto operator==(LogCurrentLocalState const& s,
                          LogCurrentLocalState const& s2) noexcept
       -> bool = default;
@@ -200,7 +202,7 @@ struct LogCurrentSupervisionElection {
   std::size_t participantsRequired{};
   std::size_t participantsAvailable{};
   std::unordered_map<ParticipantId, ErrorCode> detail;
-  std::vector<ParticipantId> electibleLeaderSet;
+  std::vector<ServerInstanceReference> electibleLeaderSet;
 
   friend auto operator==(LogCurrentSupervisionElection const&,
                          LogCurrentSupervisionElection const&) noexcept -> bool;

--- a/arangod/Replication2/ReplicatedLog/AgencySpecificationInspectors.h
+++ b/arangod/Replication2/ReplicatedLog/AgencySpecificationInspectors.h
@@ -86,7 +86,8 @@ auto inspect(Inspector& f, LogCurrentLocalState& x) {
   return f.object(x).fields(f.field(StaticStrings::Term, x.term),
                             f.field(StaticStrings::Spearhead, x.spearhead),
                             f.field("state", x.state),
-                            f.field("snapshotAvailable", x.snapshotAvailable));
+                            f.field("snapshotAvailable", x.snapshotAvailable),
+                            f.field("rebootId", x.rebootId));
 }
 
 template<typename Enum>

--- a/arangod/Replication2/ReplicatedLog/Supervision.cpp
+++ b/arangod/Replication2/ReplicatedLog/Supervision.cpp
@@ -259,13 +259,15 @@ auto runElectionCampaign(LogCurrentLocalStates const& states,
     election.detail.emplace(participant, reason);
 
     if (reason == LogCurrentSupervisionElection::ErrorCode::OK) {
+      TRI_ASSERT(maybeStatus.has_value());
       election.participantsAvailable += 1;
 
       if (maybeStatus->spearhead >= election.bestTermIndex) {
         if (maybeStatus->spearhead != election.bestTermIndex) {
           election.electibleLeaderSet.clear();
         }
-        election.electibleLeaderSet.push_back(participant);
+        election.electibleLeaderSet.emplace_back(participant,
+                                                 maybeStatus->rebootId);
         election.bestTermIndex = maybeStatus->spearhead;
       }
     }
@@ -352,26 +354,18 @@ auto checkLeaderPresent(SupervisionContext& ctx, Log const& log,
     auto const maxIdx = static_cast<uint16_t>(numElectible - 1);
     auto const& newLeader =
         election.electibleLeaderSet.at(RandomGenerator::interval(maxIdx));
-    auto const& newLeaderRebootId = health.getRebootId(newLeader);
 
     auto effectiveWriteConcern =
         computeEffectiveWriteConcern(log.target.config, current, plan, health);
 
-    if (newLeaderRebootId.has_value()) {
-      ctx.reportStatus<LogCurrentSupervision::LeaderElectionSuccess>(election);
-      ctx.createAction<LeaderElectionAction>(
-          ServerInstanceReference(newLeader, *newLeaderRebootId),
-          effectiveWriteConcern,
-          std::min(current.supervision->assumedWriteConcern,
-                   effectiveWriteConcern),
-          election);
-      return;
-    } else {
-      // TODO: better error
-      //       return LeaderElectionImpossibleAction();
-      //      ctx.reportStatus
-      return;
-    }
+    ctx.reportStatus<LogCurrentSupervision::LeaderElectionSuccess>(election);
+    ctx.createAction<LeaderElectionAction>(
+        newLeader, effectiveWriteConcern,
+        std::min(current.supervision->assumedWriteConcern,
+                 effectiveWriteConcern),
+        election);
+    return;
+
   } else {
     // Not enough participants were available to form a quorum, so
     // we can't elect a leader

--- a/tests/Replication2/ReplicatedLog/Supervision/SupervisionTest.cpp
+++ b/tests/Replication2/ReplicatedLog/Supervision/SupervisionTest.cpp
@@ -86,9 +86,9 @@ TEST_F(LeaderElectionCampaignTest, test_runElectionCampaign_allElectible) {
       {"A",
        {LogTerm{1}, TermIndexPair{LogTerm{1}, LogIndex{1}}, true, RebootId(1)}},
       {"B",
-       {LogTerm{1}, TermIndexPair{LogTerm{1}, LogIndex{1}}, true, RebootId(1)}},
+       {LogTerm{1}, TermIndexPair{LogTerm{1}, LogIndex{1}}, true, RebootId(2)}},
       {"C",
-       {LogTerm{1}, TermIndexPair{LogTerm{1}, LogIndex{1}}, true, RebootId(1)}},
+       {LogTerm{1}, TermIndexPair{LogTerm{1}, LogIndex{1}}, true, RebootId(3)}},
   };
 
   auto health = ParticipantsHealth{._health{
@@ -110,11 +110,15 @@ TEST_F(LeaderElectionCampaignTest, test_runElectionCampaign_allElectible) {
   EXPECT_EQ(campaign.bestTermIndex, (TermIndexPair{LogTerm{1}, LogIndex{1}}));
   // TODO: FIXME<< campaign;
 
-  auto expectedElectible = std::set<ParticipantId>{"A", "B", "C"};
-  auto electible = std::set<ParticipantId>{};
-  std::copy(std::begin(campaign.electibleLeaderSet),
-            std::end(campaign.electibleLeaderSet),
-            std::inserter(electible, std::begin(electible)));
+  auto expectedElectible = std::map<ParticipantId, RebootId>{
+      {"A", RebootId(1)}, {"B", RebootId(2)}, {"C", RebootId(3)}};
+  auto electible = std::map<ParticipantId, RebootId>{};
+  std::transform(std::begin(campaign.electibleLeaderSet),
+                 std::end(campaign.electibleLeaderSet),
+                 std::inserter(electible, std::begin(electible)),
+                 [](auto&& server) {
+                   return std::pair(server.serverId, server.rebootId);
+                 });
   EXPECT_EQ(electible, expectedElectible);
 }
 
@@ -123,9 +127,9 @@ TEST_F(LeaderElectionCampaignTest, test_runElectionCampaign_oneElectible) {
       {"A",
        {LogTerm{1}, TermIndexPair{LogTerm{1}, LogIndex{1}}, true, RebootId(1)}},
       {"B",
-       {LogTerm{2}, TermIndexPair{LogTerm{1}, LogIndex{1}}, true, RebootId(1)}},
+       {LogTerm{2}, TermIndexPair{LogTerm{1}, LogIndex{1}}, true, RebootId(2)}},
       {"C",
-       {LogTerm{2}, TermIndexPair{LogTerm{2}, LogIndex{1}}, true, RebootId(1)}},
+       {LogTerm{2}, TermIndexPair{LogTerm{2}, LogIndex{1}}, true, RebootId(3)}},
   };
 
   auto health = ParticipantsHealth{._health{
@@ -145,11 +149,15 @@ TEST_F(LeaderElectionCampaignTest, test_runElectionCampaign_oneElectible) {
   EXPECT_EQ(campaign.participantsAvailable, 1U);
   EXPECT_EQ(campaign.bestTermIndex, (TermIndexPair{LogTerm{2}, LogIndex{1}}));
 
-  auto expectedElectible = std::set<ParticipantId>{"C"};
-  auto electible = std::set<ParticipantId>{};
-  std::copy(std::begin(campaign.electibleLeaderSet),
-            std::end(campaign.electibleLeaderSet),
-            std::inserter(electible, std::begin(electible)));
+  auto expectedElectible =
+      std::map<ParticipantId, RebootId>{{"C", RebootId(3)}};
+  auto electible = std::map<ParticipantId, RebootId>{};
+  std::transform(std::begin(campaign.electibleLeaderSet),
+                 std::end(campaign.electibleLeaderSet),
+                 std::inserter(electible, std::begin(electible)),
+                 [](auto&& server) {
+                   return std::pair(server.serverId, server.rebootId);
+                 });
   EXPECT_EQ(electible, expectedElectible);
 }
 
@@ -161,9 +169,9 @@ TEST_F(LeaderElectionCampaignTest,
       {"A",
        {LogTerm{1}, TermIndexPair{LogTerm{1}, LogIndex{3}}, true, RebootId(1)}},
       {"B",
-       {LogTerm{1}, TermIndexPair{LogTerm{1}, LogIndex{1}}, true, RebootId(1)}},
+       {LogTerm{1}, TermIndexPair{LogTerm{1}, LogIndex{1}}, true, RebootId(2)}},
       {"C",
-       {LogTerm{1}, TermIndexPair{LogTerm{1}, LogIndex{1}}, true, RebootId(1)}},
+       {LogTerm{1}, TermIndexPair{LogTerm{1}, LogIndex{1}}, true, RebootId(3)}},
   };
 
   auto health = ParticipantsHealth{._health{
@@ -182,11 +190,15 @@ TEST_F(LeaderElectionCampaignTest,
   EXPECT_EQ(campaign.participantsAvailable, 2U);
   EXPECT_EQ(campaign.bestTermIndex, (TermIndexPair{LogTerm{1}, LogIndex{1}}));
 
-  auto expectedElectible = std::set<ParticipantId>{"B", "C"};
-  auto electible = std::set<ParticipantId>{};
-  std::copy(std::begin(campaign.electibleLeaderSet),
-            std::end(campaign.electibleLeaderSet),
-            std::inserter(electible, std::begin(electible)));
+  auto expectedElectible =
+      std::map<ParticipantId, RebootId>{{"B", RebootId(2)}, {"C", RebootId(3)}};
+  auto electible = std::map<ParticipantId, RebootId>{};
+  std::transform(std::begin(campaign.electibleLeaderSet),
+                 std::end(campaign.electibleLeaderSet),
+                 std::inserter(electible, std::begin(electible)),
+                 [](auto&& server) {
+                   return std::pair(server.serverId, server.rebootId);
+                 });
   EXPECT_EQ(electible, expectedElectible);
 }
 


### PR DESCRIPTION
### Scope & Purpose

Necessary ex ante work to implement conservative leader election (which is necessary for waitForSync=false); see https://arangodb.atlassian.net/wiki/spaces/CInfra/pages/2061369370/Concept+Conservative+leader+election for details.

On leader election, all participants now report their current RebootId to `Current/`, along with their spearhead and status. This RebootId is then used when a leader is elected, instead of the one from `Health/`, which is prone to races (with waitForSync=false).

- [X] :pizza: New feature

### Checklist

- [X] Tests
  - [X] C++ **Unit tests**

