### PR TITLE
Don't abandon promise

### DIFF
--- a/arangod/Replication2/ReplicatedState/ReplicatedState.tpp
+++ b/arangod/Replication2/ReplicatedState/ReplicatedState.tpp
@@ -594,6 +594,9 @@ auto FollowerStateManager<S>::GuardedData::maybeScheduleApplyEntries(
                   rttGuard.fire();
                   promise.setTry(std::move(tryResult));
                 });
+      } else {
+        promise.setException(replicated_log::ParticipantResignedException(
+            TRI_ERROR_REPLICATION_REPLICATED_LOG_FOLLOWER_RESIGNED, ADB_HERE));
       }
     });
 


### PR DESCRIPTION
### Scope & Purpose

Don't abandon the shared state to facilitate proper error handling down the line.