### PR TITLE
Fixing Node API.

### DIFF
--- a/arangod/Agency/ActiveFailoverJob.cpp
+++ b/arangod/Agency/ActiveFailoverJob.cpp
@@ -116,11 +116,8 @@ bool ActiveFailoverJob::create(std::shared_ptr<VPackBuilder> envelope) {
       _jb->add(VPackValue(failedServersPrefix));
       {
         VPackObjectBuilder old(_jb.get());
-        _jb->add("old", _snapshot.get(failedServersPrefix)
-                            .value()
-                            .get()
-                            .toBuilder()
-                            .slice());
+        _jb->add("old",
+                 _snapshot.get(failedServersPrefix)->toBuilder().slice());
       }
     }  // Preconditions
   }    // transactions
@@ -179,7 +176,7 @@ bool ActiveFailoverJob::start(bool&) {
     VPackArrayBuilder t(&todo);
     if (_jb == nullptr) {
       try {
-        _snapshot.get(toDoPrefix + _jobId).value().get().toBuilder(todo);
+        _snapshot.get(toDoPrefix + _jobId)->toBuilder(todo);
       } catch (std::exception const&) {
         LOG_TOPIC("26fec", INFO, Logger::SUPERVISION)
             << "Failed to get key " << toDoPrefix << _jobId
@@ -282,8 +279,7 @@ std::string ActiveFailoverJob::findBestFollower() {
 
   // blocked; (not sure if this can even happen)
   try {
-    for (auto const& srv :
-         _snapshot.get(blockedServersPrefix).value().get().children()) {
+    for (auto const& srv : _snapshot.get(blockedServersPrefix)->children()) {
       healthy.erase(std::remove(healthy.begin(), healthy.end(), srv.first),
                     healthy.end());
     }

--- a/arangod/Agency/AddFollower.cpp
+++ b/arangod/Agency/AddFollower.cpp
@@ -145,7 +145,7 @@ bool AddFollower::start(bool&) {
     return false;
   }
   Node const& collection =
-      _snapshot.hasAsNode(planColPrefix + _database + "/" + _collection)->get();
+      *_snapshot.hasAsNode(planColPrefix + _database + "/" + _collection);
   if (collection.has("distributeShardsLike")) {
     finish("", "", false,
            "collection must not have 'distributeShardsLike' attribute");

--- a/arangod/Agency/FailedFollower.cpp
+++ b/arangod/Agency/FailedFollower.cpp
@@ -230,7 +230,7 @@ bool FailedFollower::start(bool& aborts) {
     if (_jb == nullptr) {
       auto const& jobIdNode = _snapshot.hasAsNode(toDoPrefix + _jobId);
       if (jobIdNode) {
-        jobIdNode->get().toBuilder(todo);
+        jobIdNode->toBuilder(todo);
       } else {
         LOG_TOPIC("4571c", INFO, Logger::SUPERVISION)
             << "Failed to get key " << toDoPrefix << _jobId

--- a/arangod/Agency/FailedLeader.cpp
+++ b/arangod/Agency/FailedLeader.cpp
@@ -230,7 +230,7 @@ bool FailedLeader::start(bool& aborts) {
     if (_jb == nullptr) {
       auto const& jobIdNode = _snapshot.hasAsNode(toDoPrefix + _jobId);
       if (jobIdNode) {
-        jobIdNode->get().toBuilder(todo);
+        jobIdNode->toBuilder(todo);
       } else {
         LOG_TOPIC("96395", INFO, Logger::SUPERVISION)
             << "Failed to get key " << toDoPrefix << _jobId
@@ -498,8 +498,8 @@ JOB_STATUS FailedLeader::status() {
   std::string database, shard;
   auto const& job = _snapshot.hasAsNode(pendingPrefix + _jobId);
   if (job) {
-    auto tmp_database = job->get().hasAsString("database");
-    auto tmp_shard = job->get().hasAsString("shard");
+    auto tmp_database = job->hasAsString("database");
+    auto tmp_shard = job->hasAsString("shard");
     if (tmp_database && tmp_shard) {
       database = tmp_database.value();
       shard = tmp_shard.value();

--- a/arangod/Agency/FailedServer.cpp
+++ b/arangod/Agency/FailedServer.cpp
@@ -147,7 +147,7 @@ bool FailedServer::start(bool& aborts) {
     if (_jb == nullptr) {
       auto const& toDoJob = _snapshot.hasAsNode(toDoPrefix + _jobId);
       if (toDoJob) {
-        toDoJob.value().get().toBuilder(todo);
+        toDoJob->toBuilder(todo);
       } else {
         LOG_TOPIC("729c3", INFO, Logger::SUPERVISION)
             << "Failed to get key " << toDoPrefix << _jobId
@@ -168,10 +168,8 @@ bool FailedServer::start(bool& aborts) {
       VPackObjectBuilder oper(transactions.get());
       // Add pending
 
-      auto const& databaseProperties =
-          _snapshot.hasAsChildren(planDBPrefix).value().get();
-      auto const& databases =
-          _snapshot.hasAsChildren(planColPrefix).value().get();
+      auto const& databaseProperties = *_snapshot.hasAsChildren(planDBPrefix);
+      auto const& databases = *_snapshot.hasAsChildren(planColPrefix);
 
       size_t sub = 0;
 
@@ -187,8 +185,7 @@ bool FailedServer::start(bool& aborts) {
           auto const& replicationFactorPair =
               collection.hasAsNode(StaticStrings::ReplicationFactor);
           if (replicationFactorPair) {
-            VPackSlice const replicationFactor =
-                replicationFactorPair.value().get().slice();
+            VPackSlice const replicationFactor = replicationFactorPair->slice();
             uint64_t number = 1;
             bool isSatellite = false;
 
@@ -218,8 +215,7 @@ bool FailedServer::start(bool& aborts) {
               continue;  // we only deal with the master
             }
 
-            for (auto const& shard :
-                 collection.hasAsChildren("shards").value().get()) {
+            for (auto const& shard : *collection.hasAsChildren("shards")) {
               size_t pos = 0;
 
               for (VPackSlice it : VPackArrayIterator(shard.second->slice())) {
@@ -385,10 +381,8 @@ JOB_STATUS FailedServer::status() {
 
   std::shared_ptr<Builder> deleteTodos;
 
-  Node::Children const& todos =
-      _snapshot.hasAsChildren(toDoPrefix).value().get();
-  Node::Children const& pends =
-      _snapshot.hasAsChildren(pendingPrefix).value().get();
+  Node::Children const& todos = *_snapshot.hasAsChildren(toDoPrefix);
+  Node::Children const& pends = *_snapshot.hasAsChildren(pendingPrefix);
   bool hasOpenChildTasks = false;
 
   for (auto const& subJob : todos) {

--- a/arangod/Agency/MoveShard.cpp
+++ b/arangod/Agency/MoveShard.cpp
@@ -270,7 +270,7 @@ bool MoveShard::start(bool&) {
   }
   auto const& collection =
       _snapshot.hasAsNode(planColPrefix + _database + "/" + _collection);
-  if (collection && collection->get().has("distributeShardsLike")) {
+  if (collection && collection->has("distributeShardsLike")) {
     moveShardFinish(
         false, false,
         "collection must not have 'distributeShardsLike' attribute");

--- a/arangod/Agency/Node.cpp
+++ b/arangod/Agency/Node.cpp
@@ -385,29 +385,28 @@ Node& Node::getOrCreate(std::vector<std::string> const& pv) {
 }
 
 /// @brief rh-value at path vector. Check if TTL has expired.
-std::optional<std::reference_wrapper<Node const>> Node::get(
-    std::vector<std::string> const& pv) const {
+Node const* Node::get(std::vector<std::string> const& pv) const {
   Node const* current = this;
 
   for (std::string const& key : pv) {
     if (current->_children == nullptr) {
-      return std::nullopt;
+      return nullptr;
     }
 
     auto const& children = *current->_children;
     auto const child = children.find(key);
 
     if (child == children.end() || child->second->lifetimeExpired()) {
-      return std::nullopt;
+      return nullptr;
     } else {
       current = child->second.get();
     }
   }
 
-  return *current;
+  return current;
 }
 
-std::optional<std::reference_wrapper<Node const>> Node::get(
+Node const* Node::get(
     std::shared_ptr<cluster::paths::Path const> const& path) const {
   return get(path->vec(cluster::paths::SkipComponents{1}));
 }
@@ -418,10 +417,7 @@ Node& Node::getOrCreate(std::string_view path) {
 }
 
 /// @brief rh-value at path
-std::optional<std::reference_wrapper<Node const>> Node::get(
-    std::string_view path) const {
-  return get(split(path));
-}
+Node const* Node::get(std::string_view path) const { return get(split(path)); }
 
 // lh-store
 Node const& Node::root() const {
@@ -1213,8 +1209,7 @@ std::optional<double> Node::getDouble() const noexcept {
   return slice().getNumber<double>();
 }
 
-std::optional<std::reference_wrapper<Node const>> Node::hasAsNode(
-    std::string const& url) const noexcept {
+Node const* Node::hasAsNode(std::string const& url) const noexcept {
   // retrieve node, throws if does not exist
   return get(url);
 }  // hasAsNode
@@ -1226,7 +1221,7 @@ Node& Node::hasAsWritableNode(std::string const& url) {
 
 std::optional<NodeType> Node::hasAsType(std::string const& url) const noexcept {
   if (auto node = get(url); node) {
-    return node->get().type();
+    return node->type();
   }
 
   return std::nullopt;
@@ -1234,7 +1229,7 @@ std::optional<NodeType> Node::hasAsType(std::string const& url) const noexcept {
 
 std::optional<Slice> Node::hasAsSlice(std::string const& url) const noexcept {
   if (auto node = get(url); node) {
-    return node->get().slice();
+    return node->slice();
   }
 
   return std::nullopt;
@@ -1242,7 +1237,7 @@ std::optional<Slice> Node::hasAsSlice(std::string const& url) const noexcept {
 
 std::optional<uint64_t> Node::hasAsUInt(std::string const& url) const noexcept {
   if (auto node = get(url); node) {
-    return node->get().getUInt();
+    return node->getUInt();
   }
 
   return std::nullopt;
@@ -1250,7 +1245,7 @@ std::optional<uint64_t> Node::hasAsUInt(std::string const& url) const noexcept {
 
 std::optional<bool> Node::hasAsBool(std::string const& url) const noexcept {
   if (auto node = get(url); node) {
-    return node->get().getBool();
+    return node->getBool();
   }
 
   return std::nullopt;
@@ -1258,25 +1253,24 @@ std::optional<bool> Node::hasAsBool(std::string const& url) const noexcept {
 
 std::optional<std::string> Node::hasAsString(std::string const& url) const {
   if (auto node = get(url); node) {
-    return node->get().getString();
+    return node->getString();
   }
 
   return std::nullopt;
 }  // hasAsString
 
-std::optional<std::reference_wrapper<Node::Children const>> Node::hasAsChildren(
-    std::string const& url) const {
+Node::Children const* Node::hasAsChildren(std::string const& url) const {
   if (auto node = get(url); node) {
-    return node->get().children();
+    return &node->children();
   }
 
-  return std::nullopt;
+  return nullptr;
 }  // hasAsChildren
 
 bool Node::hasAsBuilder(std::string const& url, Builder& builder,
                         bool showHidden) const {
   if (auto node = get(url); node) {
-    node->get().toBuilder(builder, showHidden);
+    node->toBuilder(builder, showHidden);
     return true;
   }
 
@@ -1286,7 +1280,7 @@ bool Node::hasAsBuilder(std::string const& url, Builder& builder,
 std::optional<Builder> Node::hasAsBuilder(std::string const& url) const {
   if (auto node = get(url); node) {
     Builder builder;
-    node->get().toBuilder(builder);
+    node->toBuilder(builder);
     return builder;
   }
 
@@ -1295,7 +1289,7 @@ std::optional<Builder> Node::hasAsBuilder(std::string const& url) const {
 
 std::optional<Slice> Node::hasAsArray(std::string const& url) const {
   if (auto node = get(url); node) {
-    return node->get().getArray();
+    return node->getArray();
   }
 
   return std::nullopt;

--- a/arangod/Agency/Node.h
+++ b/arangod/Agency/Node.h
@@ -197,11 +197,10 @@ class Node final {
   Node& getOrCreate(std::vector<std::string> const& pv);
 
   /// @brief Get node specified by path vector
-  std::optional<std::reference_wrapper<Node const>> get(
-      std::vector<std::string> const& pv) const;
+  Node const* get(std::vector<std::string> const& pv) const;
 
   /// @brief Get node specified by path
-  std::optional<std::reference_wrapper<Node const>> get(
+  Node const* get(
       std::shared_ptr<cluster::paths::Path const> const& path) const;
 
   /// @brief Get root node
@@ -297,9 +296,8 @@ class Node final {
   void timeToLive(TimePoint const& ttl);
 
   /// @brief accessor to Node object
-  /// @return  returns nullopt if not found or type doesn't match
-  std::optional<std::reference_wrapper<Node const>> hasAsNode(
-      std::string const&) const noexcept;
+  /// @return  returns nullptr if not found or type doesn't match
+  Node const* hasAsNode(std::string const&) const noexcept;
 
   /// @brief accessor to Node object
   Node& hasAsWritableNode(std::string const&);
@@ -325,9 +323,8 @@ class Node final {
   std::optional<std::string> hasAsString(std::string const&) const;
 
   /// @brief accessor to Node's _children
-  /// @return  returns nullopt if not found or type doesn't match
-  std::optional<std::reference_wrapper<Children const>> hasAsChildren(
-      std::string const&) const;
+  /// @return  returns nullptr if not found or type doesn't match
+  Children const* hasAsChildren(std::string const&) const;
 
   /// @brief accessor to Node then write to builder
   /// @return  returns true if url exists
@@ -349,8 +346,7 @@ class Node final {
   Node& getOrCreate(std::string_view path);
 
   /// @brief Get node specified by path string
-  std::optional<std::reference_wrapper<Node const>> get(
-      std::string_view path) const;
+  Node const* get(std::string_view path) const;
 
   /// @brief Get string value (throws if type NODE or if conversion fails)
   std::optional<std::string> getString() const;

--- a/arangod/Agency/NodeLoadInspector.h
+++ b/arangod/Agency/NodeLoadInspector.h
@@ -256,21 +256,21 @@ struct NodeLoadInspectorImpl
     }
 
     auto node = _node->get(variant.valueField);
-    if (!node.has_value()) {
+    if (!node) {
       return {"Variant value field \"" + std::string(variant.valueField) +
               "\" is missing"};
     }
-    data = &node->get();
+    data = node;
     return {};
   }
 
   Status loadTypeField(std::string_view fieldName, std::string_view& result) {
     auto v = _node->get(fieldName);
-    if (!v.has_value()) {
+    if (!v) {
       return {"Variant type field \"" + std::string(fieldName) +
               "\" is missing"};
     }
-    auto val = v->get().getStringView();
+    auto val = v->getStringView();
     if (!val.has_value()) {
       return {"Variant type field \"" + std::string(fieldName) +
               "\" must be a string"};

--- a/arangod/Agency/RemoveFollower.cpp
+++ b/arangod/Agency/RemoveFollower.cpp
@@ -138,9 +138,7 @@ bool RemoveFollower::start(bool&) {
     return false;
   }
   Node const& collection =
-      _snapshot.hasAsNode(planColPrefix + _database + "/" + _collection)
-          .value()
-          .get();
+      *_snapshot.hasAsNode(planColPrefix + _database + "/" + _collection);
   if (collection.has("distributeShardsLike")) {
     finish("", "", false,
            "collection must not have 'distributeShardsLike' attribute");

--- a/arangod/Agency/Store.cpp
+++ b/arangod/Agency/Store.cpp
@@ -425,9 +425,9 @@ check_ret_t Store::check(VPackSlice slice, CheckMode mode) const {
 
     // Check is guarded in ::apply
     bool found = false;
-    if (auto n = _node.get(pv); n.has_value()) {
+    if (auto n = _node.get(pv); n) {
       found = true;
-      node = &n->get();
+      node = n;
     }
 
     if (precond.value.isObject()) {
@@ -713,7 +713,7 @@ bool Store::read(VPackSlice query, Builder& ret) const {
       ret.add(VPackValue(*it));
     }
     if (e == pv.size()) {  // existing
-      _node.get(pv).value().get().toBuilder(ret, showHidden);
+      _node.get(pv)->toBuilder(ret, showHidden);
     } else {
       VPackObjectBuilder guard(&ret);
     }
@@ -728,7 +728,7 @@ bool Store::read(VPackSlice query, Builder& ret) const {
       std::vector<std::string> pv = split(path);
       size_t e = _node.exists(pv).size();
       if (e == pv.size()) {  // existing
-        copy.getOrCreate(pv) = _node.get(pv)->get();
+        copy.getOrCreate(pv) = *_node.get(pv);
       } else {  // non-existing
         for (size_t i = 0; i < pv.size() - e + 1; ++i) {
           pv.pop_back();
@@ -1018,7 +1018,7 @@ void Store::get(std::string const& path, arangodb::velocypack::Builder& b,
                 bool showHidden) const {
   std::lock_guard storeLocker{_storeLock};
   if (auto node = _node.hasAsNode(path); node) {
-    node.value().get().toBuilder(b, showHidden);
+    node->toBuilder(b, showHidden);
   } else {
     // Backwards compatibility of a refactoring. Would be better to communicate
     // this clearly via a return code or so.
@@ -1029,7 +1029,7 @@ void Store::get(std::string const& path, arangodb::velocypack::Builder& b,
 /// Get node at path under mutex
 Node Store::get(std::string const& path) const {
   std::lock_guard storeLocker{_storeLock};
-  return _node.hasAsNode(path).value().get();
+  return *_node.hasAsNode(path);
 }
 
 /// Get node at path under mutex
@@ -1088,7 +1088,7 @@ std::string Store::normalize(char const* key, size_t length) {
  *        Caller must enforce locking.
  */
 Node const* Store::nodePtr(std::string const& path) const {
-  return &_node.get(path).value().get();
+  return _node.get(path);
 }
 
 void Store::callTriggers(std::string_view key, std::string_view op,

--- a/tests/Agency/NodeLoadTest.cpp
+++ b/tests/Agency/NodeLoadTest.cpp
@@ -1178,13 +1178,11 @@ TEST_F(NodeLoadInspectorTest, load_type_with_unsafe_fields) {
   Unsafe u;
   auto result = inspector.apply(u);
   ASSERT_TRUE(result.ok());
-  EXPECT_EQ(node.get("view")->get().getStringView().value(), u.view);
-  EXPECT_EQ(node.get("view")->get().getStringView().value().data(),
-            u.view.data());
-  EXPECT_EQ(node.get("slice")->get().slice().start(), u.slice.start());
-  EXPECT_EQ(node.get("hashed")->get().getStringView().value(),
-            u.hashed.stringView());
-  EXPECT_EQ(node.get("hashed")->get().getStringView().value().data(),
+  EXPECT_EQ(node.get("view")->getStringView().value(), u.view);
+  EXPECT_EQ(node.get("view")->getStringView().value().data(), u.view.data());
+  EXPECT_EQ(node.get("slice")->slice().start(), u.slice.start());
+  EXPECT_EQ(node.get("hashed")->getStringView().value(), u.hashed.stringView());
+  EXPECT_EQ(node.get("hashed")->getStringView().value().data(),
             u.hashed.data());
 }
 

--- a/tests/Maintenance/MaintenanceTest.cpp
+++ b/tests/Maintenance/MaintenanceTest.cpp
@@ -166,11 +166,10 @@ class SharedMaintenanceTest : public ::testing::Test {
   std::map<std::string, std::string> matchShortLongIds(
       Node const& supervision) {
     std::map<std::string, std::string> ret;
-    for (auto const& dbs : supervision.get("Health").value().get().children()) {
+    for (auto const& dbs : supervision.get("Health")->children()) {
       if (dbs.first.front() == 'P') {
-        ret.emplace(
-            dbs.second->get("ShortName").value().get().getString().value(),
-            dbs.first);
+        ret.emplace(dbs.second->get("ShortName")->getString().value(),
+                    dbs.first);
       }
     }
     return ret;
@@ -356,7 +355,7 @@ class SharedMaintenanceTest : public ::testing::Test {
 
   std::map<std::string, std::string> collectionMap(Node const& plan) {
     std::map<std::string, std::string> ret;
-    auto const pb = plan.get("Collections")->get().toBuilder();
+    auto const pb = plan.get("Collections")->toBuilder();
     auto const ps = pb.slice();
     for (auto const& db : VPackObjectIterator(ps)) {
       for (auto const& col : VPackObjectIterator(db.value)) {
@@ -605,7 +604,7 @@ class MaintenanceTestActionPhaseOne : public SharedMaintenanceTest {
 
     auto vec = path->vec(paths::SkipComponents(2));
     TRI_ASSERT(plan.has(vec));
-    auto const& shardList = plan.get(vec)->get();
+    auto const& shardList = *plan.get(vec);
     std::unordered_set<std::string> res;
     for (auto const& [shard, servers] : shardList.children()) {
       auto oldValue = servers->slice();
@@ -852,7 +851,7 @@ std::vector<std::string> PLAN_SECTIONS{ANALYZERS,       COLLECTIONS,
 containers::FlatHashMap<std::string, std::shared_ptr<VPackBuilder>>
 planToChangeset(Node const& plan) {
   containers::FlatHashMap<std::string, std::shared_ptr<VPackBuilder>> ret;
-  for (auto const& db : plan.get(DATABASES)->get().children()) {
+  for (auto const& db : plan.get(DATABASES)->children()) {
     VPackBuilder& dbbuilder =
         *ret.try_emplace(db.first, std::make_shared<VPackBuilder>())
              .first->second;
@@ -872,8 +871,7 @@ planToChangeset(Node const& plan) {
               VPackObjectBuilder c(&dbbuilder);
               auto path = std::vector<std::string>{section, db.first};
               if (plan.has(path)) {
-                dbbuilder.add(db.first,
-                              plan.get(path)->get().toBuilder().slice());
+                dbbuilder.add(db.first, plan.get(path)->toBuilder().slice());
               }
             }
           }
@@ -1024,10 +1022,8 @@ TEST_F(
   createPlanCollection(dbname, colname, 1, 3, plan);
 
   auto cid = collectionMap(plan).at("db3/x");
-  auto shards = plan.getOrCreate({COLLECTIONS, dbname, cid})
-                    .hasAsChildren(SHARDS)
-                    .value()
-                    .get();
+  auto shards =
+      *plan.getOrCreate({COLLECTIONS, dbname, cid}).hasAsChildren(SHARDS);
   ASSERT_EQ(shards.size(), 1);
   std::string shardName = shards.begin()->first;
 
@@ -1235,8 +1231,7 @@ TEST_F(
         getShardsForServer(dbName(), planId(), server, originalPlan, true);
     std::vector<std::shared_ptr<ActionDescription>> actions;
 
-    auto cb =
-        local.get(dbName())->get().children().begin()->second->toBuilder();
+    auto cb = local.get(dbName())->children().begin()->second->toBuilder();
     auto collection = cb.slice();
     auto shname = collection.get(NAME).copyString();
 
@@ -1723,8 +1718,7 @@ TEST_F(MaintenanceTestActionPhaseOne, have_theleader_set_to_empty) {
   for (auto node : localNodes) {
     std::vector<std::shared_ptr<ActionDescription>> actions;
 
-    auto& collection =
-        *node.second.get(dbName())->get().children().begin()->second;
+    auto& collection = *node.second.get(dbName())->children().begin()->second;
     auto& leader = collection.getOrCreate("theLeader");
 
     bool check = false;


### PR DESCRIPTION
### Scope & Purpose
Lets get rid of the `std::optional<std::reference_wrapper<T>>` abomination, which was caused by a brain fart of mine. Now, I'm aware of the fact, that the agency will crash with a nullptr access, instead of just logging `std::bad_optional_access` over and over again. I think it is better now, because you see _where_ the nullptr access happened.