### PR TITLE
[CINFRA-774] Conservative leader election

### DIFF
--- a/arangod/Replication2/ReplicatedLog/AgencyLogSpecification.cpp
+++ b/arangod/Replication2/ReplicatedLog/AgencyLogSpecification.cpp
@@ -33,6 +33,8 @@
 #include "Replication2/ReplicatedLog/AgencySpecificationInspectors.h"
 #include "Basics/VelocyPackHelper.h"
 
+#include <fmt/ranges.h>
+
 #include <velocypack/Iterator.h>
 
 #include <type_traits>
@@ -97,6 +99,31 @@ LogCurrentLocalState::LogCurrentLocalState(LogTerm term,
       snapshotAvailable(snapshot),
       rebootId(rebootId) {}
 
+auto agency::operator<<(std::ostream& ostream,
+                        LogCurrentSupervisionElection const& el)
+    -> std::ostream& {
+  using namespace fmt::literals;
+  ostream << fmt::format(
+      "Election {{ "
+      "term: {term}, "
+      "bestTermIndex: {bestTerm}:{bestIndex}, "
+      "participantsRequired: {participantsRequired}, "
+      "participantsVoting: {participantsVoting}, "
+      "electibleLeaderSet: {electibleLeaderSet}, "
+      "allParticipantsAttending: {allParticipantsAttending}, "
+      "detail: {detail} "
+      "}}",
+      "term"_a = el.term.value, "bestTerm"_a = el.bestTermIndex.term.value,
+      "bestIndex"_a = el.bestTermIndex.index.value,
+      "participantsRequired"_a = el.participantsRequired,
+      "participantsVoting"_a = el.participantsVoting,
+      "electibleLeaderSet"_a = el.electibleLeaderSet,
+      "allParticipantsAttending"_a = el.allParticipantsAttending,
+      "detail"_a = el.detail);
+
+  return ostream;
+}
+
 auto agency::to_string(LogCurrentSupervisionElection::ErrorCode ec) noexcept
     -> std::string_view {
   switch (ec) {
@@ -121,7 +148,7 @@ auto agency::operator==(const LogCurrentSupervisionElection& left,
                         const LogCurrentSupervisionElection& right) noexcept
     -> bool {
   return left.term == right.term &&
-         left.participantsAvailable == right.participantsAvailable &&
+         left.participantsVoting == right.participantsVoting &&
          left.participantsRequired == right.participantsRequired &&
          left.detail == right.detail;
 }

--- a/arangod/Replication2/ReplicatedLog/AgencyLogSpecification.h
+++ b/arangod/Replication2/ReplicatedLog/AgencyLogSpecification.h
@@ -25,9 +25,12 @@
 #include <iosfwd>
 #include "Agency/AgencyPaths.h"
 #include "Basics/StaticStrings.h"
+#include "Basics/StringUtils.h"
 #include "Cluster/ClusterTypes.h"
 #include "Replication2/ReplicatedLog/LogCommon.h"
 #include "Replication2/ReplicatedLog/types.h"
+
+#include <fmt/core.h>
 
 #include <velocypack/Builder.h>
 #include <velocypack/Slice.h>
@@ -199,9 +202,18 @@ struct LogCurrentSupervisionElection {
 
   TermIndexPair bestTermIndex;
 
+  // minimum quorum size of voters
   std::size_t participantsRequired{};
-  std::size_t participantsAvailable{};
+  // number of participants that are attending (i.e. reported back during this
+  // election)
+  std::size_t participantsAttending{};
+  // number of participants that are attending and also eligible to vote
+  std::size_t participantsVoting{};
+  // whether all participants attend this election.
+  bool allParticipantsAttending{};
   std::unordered_map<ParticipantId, ErrorCode> detail;
+  // set of participants which are attending, eligible, and have the maximum
+  // spearhead amongst all attending and eligible participants.
   std::vector<ServerInstanceReference> electibleLeaderSet;
 
   friend auto operator==(LogCurrentSupervisionElection const&,
@@ -214,6 +226,9 @@ struct LogCurrentSupervisionElection {
 
   LogCurrentSupervisionElection() = default;
 };
+
+auto operator<<(std::ostream&, LogCurrentSupervisionElection const&)
+    -> std::ostream&;
 
 auto operator==(LogCurrentSupervisionElection const&,
                 LogCurrentSupervisionElection const&) noexcept -> bool;
@@ -429,3 +444,30 @@ struct Log {
 };
 
 }  // namespace arangodb::replication2::agency
+
+template<>
+struct fmt::formatter<arangodb::replication2::agency::ServerInstanceReference>
+    : formatter<string_view> {
+  // parse is inherited from formatter<string_view>.
+  template<typename FormatContext>
+  auto format(
+      arangodb::replication2::agency::ServerInstanceReference const& inst,
+      FormatContext& ctx) const {
+    return fmt::format_to(ctx.out(), "{}@{}", inst.serverId,
+                          inst.rebootId.value());
+  }
+};
+
+template<>
+struct fmt::formatter<
+    arangodb::replication2::agency::LogCurrentSupervisionElection::ErrorCode>
+    : formatter<string_view> {
+  // parse is inherited from formatter<string_view>.
+  template<typename FormatContext>
+  auto format(
+      arangodb::replication2::agency::LogCurrentSupervisionElection::ErrorCode
+          errorCode,
+      FormatContext& ctx) const {
+    return fmt::format_to(ctx.out(), "{}", to_string(errorCode));
+  }
+};

--- a/arangod/Replication2/ReplicatedLog/AgencySpecificationInspectors.h
+++ b/arangod/Replication2/ReplicatedLog/AgencySpecificationInspectors.h
@@ -35,8 +35,11 @@ auto constexpr CommittedParticipantsConfig =
 auto constexpr ParticipantsConfig = std::string_view{"participantsConfig"};
 auto constexpr BestTermIndex = std::string_view{"bestTermIndex"};
 auto constexpr ParticipantsRequired = std::string_view{"participantsRequired"};
-auto constexpr ParticipantsAvailable =
-    std::string_view{"participantsAvailable"};
+auto constexpr ParticipantsAttending =
+    std::string_view{"participantsAttending"};
+auto constexpr ParticipantsVoting = std::string_view{"participantsVoting"};
+auto constexpr AllParticipantsAttending =
+    std::string_view{"allParticipantsAttending"};
 auto constexpr Details = std::string_view{"details"};
 auto constexpr ElectibleLeaderSet = std::string_view{"electibleLeaderSet"};
 auto constexpr Error = std::string_view{"error"};
@@ -132,7 +135,10 @@ auto inspect(Inspector& f, LogCurrentSupervisionElection& x) {
       f.field(StaticStrings::Term, x.term),
       f.field(static_strings::BestTermIndex, x.bestTermIndex),
       f.field(static_strings::ParticipantsRequired, x.participantsRequired),
-      f.field(static_strings::ParticipantsAvailable, x.participantsAvailable),
+      f.field(static_strings::ParticipantsAttending, x.participantsAttending),
+      f.field(static_strings::ParticipantsVoting, x.participantsVoting),
+      f.field(static_strings::AllParticipantsAttending,
+              x.allParticipantsAttending),
       f.field(static_strings::Details, x.detail),
       f.field(static_strings::ElectibleLeaderSet, x.electibleLeaderSet));
 }

--- a/arangod/Replication2/ReplicatedLog/Supervision.cpp
+++ b/arangod/Replication2/ReplicatedLog/Supervision.cpp
@@ -232,35 +232,77 @@ auto computeReason(std::optional<LogCurrentLocalState> const& maybeStatus,
   }
 }
 
+// Report whether a server is clean, meaning it hasn't lost any data since the
+// last commit. This is allowed to have false negatives (i.e. not report a
+// server as clean, which actually is clean), but not to have false positives
+// (i.e. all servers reported as clean really must be).
+// For waitForSync=true, all servers are always clean.
+// False negatives may inhibit leader election and thus stall the log, until
+// either all servers report back or the unclean server(s) are replaced.
+auto CleanOracle::serverIsClean(ServerInstanceReference,
+                                const bool assumedWaitForSync) -> bool {
+  // Trivial implementation.
+  // It is exact for waitForSync=true.
+  // It is safe for waitForSync=false, but maximally pessimistic.
+  // To be improved later: see
+  //   https://arangodb.atlassian.net/wiki/spaces/CInfra/pages/2061369370/Concept+Conservative+leader+election
+  //   for details.
+  return assumedWaitForSync;
+}
+
 auto runElectionCampaign(LogCurrentLocalStates const& states,
                          ParticipantsConfig const& participantsConfig,
-                         ParticipantsHealth const& health, LogTerm term)
+                         ParticipantsHealth const& health, LogTerm const term,
+                         bool const assumedWaitForSync, CleanOracle mrProper)
     -> LogCurrentSupervisionElection {
   auto election = LogCurrentSupervisionElection();
   election.term = term;
+  auto const getMaybeStatus =
+      [&states](ParticipantId const& p) -> std::optional<LogCurrentLocalState> {
+    auto status = states.find(p);
+    if (status != states.end()) {
+      return status->second;
+    } else {
+      return std::nullopt;
+    }
+  };
+
+  bool const allParticipantsAttendingElection =
+      std::all_of(participantsConfig.participants.begin(),
+                  participantsConfig.participants.end(), [&](auto const& it) {
+                    auto const& participantId = it.first;
+                    if (auto status = getMaybeStatus(participantId); status) {
+                      return status->term == term;
+                    } else {
+                      return false;
+                    }
+                  });
 
   for (auto const& [participant, flags] : participantsConfig.participants) {
     auto const excluded = not flags.allowedAsLeader;
     auto const healthy = health.notIsFailed(participant);
 
-    auto maybeStatus = std::invoke(
-        [&states](
-            ParticipantId const& p) -> std::optional<LogCurrentLocalState> {
-          auto status = states.find(p);
-          if (status != states.end()) {
-            return status->second;
-          } else {
-            return std::nullopt;
-          }
-        },
-        participant);
+    auto maybeStatus = getMaybeStatus(participant);
 
     auto reason = computeReason(maybeStatus, healthy, excluded, term);
     election.detail.emplace(participant, reason);
 
     if (reason == LogCurrentSupervisionElection::ErrorCode::OK) {
       TRI_ASSERT(maybeStatus.has_value());
-      election.participantsAvailable += 1;
+      auto const isClean = mrProper.serverIsClean(
+          {participant, maybeStatus->rebootId}, assumedWaitForSync);
+      // Servers that aren't clean can still be electible, but don't count
+      // against the quorum size when voting for a leader.
+      // With waitForSync=true, servers are always clean.
+      // If all participants are attending the election, the election can take
+      // place as if all servers were clean. Note that (only) in this situation
+      // data might have been lost with waitForSync=false.
+      // TODO It might be nice to log a warning in case an election can _only_
+      //      take place because all participants are attending, indicating
+      //      possible data loss due to waitForSync=false.
+      if (isClean || allParticipantsAttendingElection) {
+        election.participantsAvailable += 1;
+      }
 
       if (maybeStatus->spearhead >= election.bestTermIndex) {
         if (maybeStatus->spearhead != election.bestTermIndex) {
@@ -336,7 +378,8 @@ auto checkLeaderPresent(SupervisionContext& ctx, Log const& log,
 
   // Find the participants that are healthy and that have the best LogTerm
   auto election = runElectionCampaign(
-      current.localState, plan.participantsConfig, health, currentTerm.term);
+      current.localState, plan.participantsConfig, health, currentTerm.term,
+      current.supervision->assumedWaitForSync, CleanOracle{});
   election.participantsRequired = requiredNumberOfOKParticipants;
 
   auto const numElectible = election.electibleLeaderSet.size();

--- a/arangod/Replication2/ReplicatedLog/Supervision.h
+++ b/arangod/Replication2/ReplicatedLog/Supervision.h
@@ -61,9 +61,16 @@ auto computeReason(std::optional<LogCurrentLocalState> const& maybeStatus,
                    bool healthy, bool excluded, LogTerm term)
     -> LogCurrentSupervisionElection::ErrorCode;
 
-auto runElectionCampaign(LogCurrentLocalStates const& states,
+struct CleanOracle {
+  TEST_VIRTUAL auto serverIsClean(ServerInstanceReference,
+                                  bool const assumedWaitForSync) -> bool;
+  TEST_VIRTUAL ~CleanOracle() = default;
+};
+
+auto runElectionCampaign(LogCurrentLocalStates const& participantId,
                          ParticipantsConfig const& participantsConfig,
-                         ParticipantsHealth const& health, LogTerm term)
+                         ParticipantsHealth const& health, LogTerm term,
+                         bool assumedWaitForSync, CleanOracle)
     -> LogCurrentSupervisionElection;
 
 auto getParticipantsAcceptableAsLeaders(

--- a/arangod/Replication2/ReplicatedLog/Supervision.h
+++ b/arangod/Replication2/ReplicatedLog/Supervision.h
@@ -62,15 +62,21 @@ auto computeReason(std::optional<LogCurrentLocalState> const& maybeStatus,
     -> LogCurrentSupervisionElection::ErrorCode;
 
 struct CleanOracle {
-  TEST_VIRTUAL auto serverIsClean(ServerInstanceReference,
-                                  bool const assumedWaitForSync) -> bool;
   TEST_VIRTUAL ~CleanOracle() = default;
+
+  auto serverIsClean(ServerInstanceReference const& participant,
+                     bool assumedWaitForSync) -> bool;
+
+ protected:
+  // Implementation of serverIsClean for waitForSync=false
+  TEST_VIRTUAL auto serverIsCleanWfsFalse(ServerInstanceReference const&)
+      -> bool;
 };
 
 auto runElectionCampaign(LogCurrentLocalStates const& participantId,
                          ParticipantsConfig const& participantsConfig,
                          ParticipantsHealth const& health, LogTerm term,
-                         bool assumedWaitForSync, CleanOracle)
+                         bool assumedWaitForSync, CleanOracle&)
     -> LogCurrentSupervisionElection;
 
 auto getParticipantsAcceptableAsLeaders(

--- a/tests/Replication2/CMakeLists.txt
+++ b/tests/Replication2/CMakeLists.txt
@@ -21,6 +21,7 @@ set(ARANGODB_REPLICATION2_TEST_HELPER_SOURCES
   Mocks/ReplicatedStateMetricsMock.cpp Mocks/ReplicatedStateMetricsMock.h
 
   Mocks/DocumentStateMocks.cpp Mocks/DocumentStateMocks.h
+  Mocks/MockOracle.h
   Mocks/MockVocbase.h
   Mocks/LeaderCommunicatorMock.h
   Mocks/StorageManagerMock.h

--- a/tests/Replication2/Mocks/MockOracle.h
+++ b/tests/Replication2/Mocks/MockOracle.h
@@ -1,0 +1,36 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2023-2023 ArangoDB GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Tobias Gödderz
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include <gmock/gmock.h>
+
+#include "Replication2/ReplicatedLog/Supervision.h"
+
+namespace arangodb::replication2::tests {
+
+struct MockCleanOracle : replicated_log::CleanOracle {
+  MOCK_METHOD(bool, serverIsCleanWfsFalse, (ServerInstanceReference const&),
+              (override));
+};
+
+}  // namespace arangodb::replication2::tests

--- a/tests/Replication2/ReplicatedLog/Supervision/SupervisionTest.cpp
+++ b/tests/Replication2/ReplicatedLog/Supervision/SupervisionTest.cpp
@@ -103,7 +103,8 @@ TEST_F(LeaderElectionCampaignTest, test_runElectionCampaign_allElectible) {
           {"B", ParticipantFlags{.forced = false, .allowedAsLeader = true}},
           {"C", ParticipantFlags{.forced = false, .allowedAsLeader = true}}}};
 
-  auto campaign = runElectionCampaign(localStates, config, health, LogTerm{1});
+  auto campaign =
+      runElectionCampaign(localStates, config, health, LogTerm{1}, true, {});
 
   EXPECT_EQ(campaign.participantsAvailable, 3U);  // TODO: Fixme
                                                   // << campaign;
@@ -144,7 +145,8 @@ TEST_F(LeaderElectionCampaignTest, test_runElectionCampaign_oneElectible) {
           {"B", ParticipantFlags{.forced = false, .allowedAsLeader = true}},
           {"C", ParticipantFlags{.forced = false, .allowedAsLeader = true}}}};
 
-  auto campaign = runElectionCampaign(localStates, config, health, LogTerm{2});
+  auto campaign =
+      runElectionCampaign(localStates, config, health, LogTerm{2}, true, {});
 
   EXPECT_EQ(campaign.participantsAvailable, 1U);
   EXPECT_EQ(campaign.bestTermIndex, (TermIndexPair{LogTerm{2}, LogIndex{1}}));
@@ -185,7 +187,8 @@ TEST_F(LeaderElectionCampaignTest,
           {"B", ParticipantFlags{.forced = false, .allowedAsLeader = true}},
           {"C", ParticipantFlags{.forced = false, .allowedAsLeader = true}}}};
 
-  auto campaign = runElectionCampaign(localStates, config, health, LogTerm{1});
+  auto campaign =
+      runElectionCampaign(localStates, config, health, LogTerm{1}, true, {});
 
   EXPECT_EQ(campaign.participantsAvailable, 2U);
   EXPECT_EQ(campaign.bestTermIndex, (TermIndexPair{LogTerm{1}, LogIndex{1}}));

--- a/tests/js/server/replication2/replication2-supervision-replicated-log-target-cluster.js
+++ b/tests/js/server/replication2/replication2-supervision-replicated-log-target-cluster.js
@@ -298,7 +298,7 @@ const replicatedLogSuite = function () {
         const election = current.supervision.StatusReport[0].detail.election;
         assertEqual(election.term, term + 1);
         assertEqual(election.participantsRequired, 2);
-        assertEqual(election.participantsAvailable, 1);
+        assertEqual(election.participantsVoting, 1);
         const detail = election.details;
         assertEqual(detail[leader].code, 1);
         assertEqual(detail[followers[0]].code, 1);


### PR DESCRIPTION
### Scope & Purpose

Implement conservative leader election, still with a trivial clean oracle, as described in https://arangodb.atlassian.net/wiki/spaces/CInfra/pages/2061369370/Concept+Conservative+leader+election.

This makes leader election with `waitForSync=false` safe, but basically by making election impossible unless all participants are available. This will improve with an improved oracle implementation later.

- [X] :pizza: New feature

### Checklist

- [X] Tests
  - [X] C++ **Unit tests**