### PR TITLE
Fix set out of sync for very old iresearch links

### DIFF
--- a/arangod/IResearch/IResearchDataStore.cpp
+++ b/arangod/IResearch/IResearchDataStore.cpp
@@ -1388,16 +1388,20 @@ Result IResearchDataStore::initDataStore(
         const auto recoveryTick = linkLock->_engine->recoveryTick();
 
         bool isOutOfSync = linkLock->isOutOfSync();
+        auto const dataStoreTick =
+            dataStore._recoveryTickHigh != std::numeric_limits<uint64_t>::max()
+                ? dataStore._recoveryTickHigh
+                : dataStore._recoveryTickLow;
         if (isOutOfSync) {
           LOG_TOPIC("2721a", WARN, iresearch::TOPIC)
               << "Marking ArangoSearch index '" << index.id().id()
               << "' as out of sync, consider to drop and re-create the index "
                  "in order to synchronize it";
 
-        } else if (dataStore._recoveryTickHigh > recoveryTick) {
+        } else if (dataStoreTick > recoveryTick) {
           LOG_TOPIC("5b59f", WARN, iresearch::TOPIC)
               << "ArangoSearch index: " << index.id()
-              << " is recovered at tick " << dataStore._recoveryTickHigh
+              << " is recovered at tick " << dataStoreTick
               << " greater than storage engine tick " << recoveryTick
               << ", it seems WAL tail was lost and index is out of sync with "
                  "the underlying collection: "


### PR DESCRIPTION
### Scope & Purpose

In very old format we don't have two ticks, so second is uint64_t::max

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: https://github.com/arangodb/arangodb/pull/19223
  - [ ] Backport for 3.10: https://github.com/arangodb/arangodb/pull/19222
  - [ ] Backport for 3.9: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

