### PR TITLE
Fix set out of sync for very old iresearch links 3.10

### DIFF
--- a/arangod/IResearch/IResearchDataStore.cpp
+++ b/arangod/IResearch/IResearchDataStore.cpp
@@ -1385,17 +1385,20 @@ Result IResearchDataStore::initDataStore(
         const auto recoveryTick = linkLock->_engine->recoveryTick();
 
         bool isOutOfSync = linkLock->isOutOfSync();
+        auto const dataStoreTick =
+            dataStore._recoveryTickHigh != std::numeric_limits<uint64_t>::max()
+                ? dataStore._recoveryTickHigh
+                : dataStore._recoveryTickLow;
         if (isOutOfSync) {
           LOG_TOPIC("2721a", WARN, iresearch::TOPIC)
               << "marking ArangoSearch index '" << id.id()
               << "' as out of sync, consider to drop and re-create the index "
                  "in order to synchronize it";
 
-        } else if (dataStore._recoveryTickHigh > recoveryTick) {
+        } else if (dataStoreTick > recoveryTick) {
           LOG_TOPIC("5b59f", WARN, iresearch::TOPIC)
               << "ArangoSearch index '" << id.id() << "' is recovered at tick '"
-              << dataStore._recoveryTickHigh
-              << "' greater than storage engine tick '"
+              << dataStoreTick << "' greater than storage engine tick '"
               << linkLock->_engine->recoveryTick()
               << "', it seems WAL tail was lost and index is out of sync with "
                  "the underlying collection: "


### PR DESCRIPTION
### Scope & Purpose

https://github.com/arangodb/arangodb/pull/19221

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*
  - [ ] Backport for 3.9: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

