### PR TITLE
Bug fix/bts 1460 Directly kill aborted query, do not wait for GC 

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 devel
 -----
 
+* Whenever there is an query request timeout in AQL (e.g. a server died)
+  which causes the query to fail, the DBServers will now all directly kill
+  their potentially ongoing parts of the query and not wait for garbage collection.
+
 * Updated arangosync to v2.18.1.
 
 * FE-211: Allow admins to edit gravatar email.

--- a/arangod/Aql/QueryRegistry.cpp
+++ b/arangod/Aql/QueryRegistry.cpp
@@ -352,7 +352,7 @@ auto QueryRegistry::lookupQueryForFinalization(QueryId id, ErrorCode errorCode)
   if (queryInfo._numOpen > 0) {
     TRI_ASSERT(!queryInfo._isTombstone);
     // query in use by another thread/request
-    if (errorCode == TRI_ERROR_QUERY_KILLED) {
+    if (errorCode != TRI_ERROR_NO_ERROR) {
       queryInfo._query->kill();
     }
     queryInfo._expires = 0.0;

--- a/arangod/Aql/RemoteExecutor.cpp
+++ b/arangod/Aql/RemoteExecutor.cpp
@@ -385,6 +385,11 @@ Result ExecutionBlockImpl<RemoteExecutor>::sendAsyncRequest(
 
   _requestInFlight = true;
   auto ticket = generateRequestTicket();
+  TRI_IF_FAILURE("RemoteExecutor::impatienceTimeout") {
+    // Vastly lower the request timeout. This should guarantee
+    // a network timeout triggered and not continue with the query.
+    req->timeout(std::chrono::seconds(2));
+  }
   conn->sendRequest(
       std::move(req),
       [this, ticket, spec, sqs = _engine->sharedState()](


### PR DESCRIPTION
### Scope & Purpose

*If a query throws an error right now (most likely timeout) all DBServers are informed with this error, that the query will fail. However so far they only react on "query killed" to locally abort. With this PR we enable that every error triggers a kill query on all snippets, so we avoid to wait for garbage collection and can quickly stop working on the query.*

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [x] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [x] Tests
  - [x] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [x] Backports
  - [x] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*
  - [ ] Backport for 3.9: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR: NO enterprise part
- [ ] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/BTS-1460?focusedCommentId=95203
- [ ] Design document: 

