### PR TITLE
[APM-662] Improve optimizer memory tracking

### DIFF
--- a/arangod/Aql/Query.cpp
+++ b/arangod/Aql/Query.cpp
@@ -89,6 +89,7 @@ constexpr std::string_view fullcountTrue("fullcount:true");
 constexpr std::string_view fullcountFalse("fullcount:false");
 constexpr std::string_view countTrue("count:true");
 constexpr std::string_view countFalse("count:false");
+constexpr auto planMemoryBytes = 2 * 1024 * 1024;
 }  // namespace
 
 /// @brief internal constructor, Used to construct a full query or a
@@ -238,7 +239,11 @@ void Query::destroy() {
   exitV8Context();
 
   _snippets.clear();  // simon: must be before plan
+
+  TRI_ASSERT(_plans.size() == 1);
   _plans.clear();     // simon: must be before AST
+  resourceMonitor().decreaseMemoryUsage(planMemoryBytes);
+
   _ast.reset();
 
   LOG_TOPIC("f5cee", DEBUG, Logger::QUERIES)
@@ -463,8 +468,10 @@ std::unique_ptr<ExecutionPlan> Query::preparePlan() {
   Optimizer opt(_queryOptions.maxNumberOfPlans);
   // get enabled/disabled rules
   opt.createPlans(std::move(plan), _queryOptions, false);
+  resourceMonitor().increaseMemoryUsage(opt._stats.plansCreated * planMemoryBytes);
   // Now plan and all derived plans belong to the optimizer
   plan = opt.stealBest();  // Now we own the best one again
+  resourceMonitor().decreaseMemoryUsage((opt._stats.plansCreated - 1) * planMemoryBytes);
 
   TRI_ASSERT(plan != nullptr);
 

--- a/arangod/Aql/Query.cpp
+++ b/arangod/Aql/Query.cpp
@@ -241,7 +241,7 @@ void Query::destroy() {
   _snippets.clear();  // simon: must be before plan
 
   TRI_ASSERT(_plans.size() == 1);
-  _plans.clear();     // simon: must be before AST
+  _plans.clear();  // simon: must be before AST
   resourceMonitor().decreaseMemoryUsage(planMemoryBytes);
 
   _ast.reset();
@@ -468,10 +468,12 @@ std::unique_ptr<ExecutionPlan> Query::preparePlan() {
   Optimizer opt(_queryOptions.maxNumberOfPlans);
   // get enabled/disabled rules
   opt.createPlans(std::move(plan), _queryOptions, false);
-  resourceMonitor().increaseMemoryUsage(opt._stats.plansCreated * planMemoryBytes);
+  resourceMonitor().increaseMemoryUsage(opt._stats.plansCreated *
+                                        planMemoryBytes);
   // Now plan and all derived plans belong to the optimizer
   plan = opt.stealBest();  // Now we own the best one again
-  resourceMonitor().decreaseMemoryUsage((opt._stats.plansCreated - 1) * planMemoryBytes);
+  resourceMonitor().decreaseMemoryUsage((opt._stats.plansCreated - 1) *
+                                        planMemoryBytes);
 
   TRI_ASSERT(plan != nullptr);
 

--- a/arangod/Aql/Query.cpp
+++ b/arangod/Aql/Query.cpp
@@ -238,7 +238,7 @@ void Query::destroy() {
   exitV8Context();
 
   _snippets.clear();  // simon: must be before plan
-  _plans.clear();  // simon: must be before AST
+  _plans.clear();     // simon: must be before AST
   _ast.reset();
 
   LOG_TOPIC("f5cee", DEBUG, Logger::QUERIES)
@@ -463,9 +463,9 @@ std::unique_ptr<ExecutionPlan> Query::preparePlan() {
   Optimizer opt(_queryOptions.maxNumberOfPlans);
   // get enabled/disabled rules
   opt.createPlans(std::move(plan), _queryOptions, false);
-
   // Now plan and all derived plans belong to the optimizer
   plan = opt.stealBest();  // Now we own the best one again
+
   TRI_ASSERT(plan != nullptr);
 
   // return the V8 context if we are in one

--- a/tests/js/client/server_parameters/log-queries-failed-and-memory.js
+++ b/tests/js/client/server_parameters/log-queries-failed-and-memory.js
@@ -31,7 +31,7 @@ const fs = require('fs');
 if (getOptions === true) {
   return {
     'query.log-failed': 'true',
-    'query.log-memory-usage-threshold': '1048576',
+    'query.log-memory-usage-threshold': '3145728',
     'query.max-artifact-log-length': '1024',
   };
 }
@@ -126,15 +126,15 @@ return require('internal').options()["log.output"];
       // should not be logged:
       //   /*LOG TEST low memory usage*/ FOR i IN 1..1024 RETURN i
       assertEqual(0, lines.filter((line) => line.match(/LOG TEST low memory usage/)).length);
-      
+
       // should not be logged:
       //   /*LOG TEST large bind1*/ FOR i IN 1..1024 FILTER i IN @values RETURN i
       assertEqual(0, lines.filter((line) => line.match(/LOG TEST large bind1/)).length);
-      
+
       // should be logged:
       //   /*LOG TEST large bind1*/ FOR i IN 1..1024 FILTER i IN @values RETURN PIFF()
       assertEqual(1, lines.filter((line) => line.match(/LOG TEST large bind2/)).length);
- 
+
       // test truncation after 1024 chars:
       assertEqual(1, lines.filter((line) => line.includes("/*LOG TEST large bind2*/ FOR i IN 1..1024 FILTER i IN @values RETURN PIFF()', bind vars: {\"values\":[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99,100,101,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,121,122,123,124,125,126,127,128,129,130,131,132,133,134,135,136,137,138,139,140,141,142,143,144,145,146,147,148,149,150,151,152,153,154,155,156,157,158,159,160,161,162,163,164,165,166,167,168,169,170,171,172,173,174,175,176,177,178,179,180,181,182,183,184,185,186,187,188,189,190,191,192,193,194,195,196,197,198,199,200,201,202,203,204,205,206,207,208,209,210,211,212,213,214,215,216,217,218,219,220,221,222,223,224,225,226,227,228,229,230,231,232,233,234,235,236,237,238,239,240,241,242,243,244,245,246,247,248,249,250,251,252,253,254,255,256,257,258,259,260,261,262,263,264,265,266,267,268,269,270,271,272,273,274,275,276,277,278,279,... (2985)")).length);
     },


### PR DESCRIPTION
### Scope & Purpose

Better and more precise memory tracking in optimizer plan nodes.
This is required, as those types of nodes are being used during AQL queries and currently not counted into used memory. Which conflicts to the maximum amount of memory a user can define for each single query execution.

This PR improves improves the memory accounting for plans in a simplified way. We currently estimate about ~2MB for each plan we create during optimization phase. 

This is the second pr of a pr series. Follow-up prs will take this further.

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*
  - [ ] Backport for 3.9: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

