### PR TITLE
Added conversion from server id to string

### DIFF
--- a/arangod/Utils/SupportInfoBuilder.cpp
+++ b/arangod/Utils/SupportInfoBuilder.cpp
@@ -298,7 +298,7 @@ void SupportInfoBuilder::buildInfoMessage(VPackBuilder& result,
                      VPackValue(arangodb::basics::StringUtils::tolower(
                          ServerState::instance()->getPersistedId())));
         } else {
-          result.add("persisted_id", VPackValue(serverId));
+          result.add("persisted_id", VPackValue(std::to_string(serverId)));
         }
 
         std::string envValue;


### PR DESCRIPTION
### Scope & Purpose

This PR forces the value put in the velocypack object respective to persisted id to be a string when the server has no persisted id value and its id is used instead to prevent this error in the endpoint's parser:

`Saving messages in BiqQuery failed: '400 Provided Schema does not match Table telemetrics-project:telemetrics_dataset.telemetrics_table. Field deployment.persisted_id has changed type from STRING to INTEGER``
```

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made 
- [ ] :books: documentation written (release notes, API changes, ...)
- [x] Backports
  - [x] Backport for 3.11: https://github.com/arangodb/arangodb/pull/19232
  
#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

