### PR TITLE
Allow to specify a factory for non default-constructible types

### DIFF
--- a/arangod/Replication2/StateMachines/Document/ReplicatedOperation.h
+++ b/arangod/Replication2/StateMachines/Document/ReplicatedOperation.h
@@ -44,7 +44,7 @@ struct ReplicatedOperation {
     ShardID shard;
     velocypack::SharedSlice payload;
 
-    explicit DocumentOperation() = default;
+    DocumentOperation() = default;
     explicit DocumentOperation(TransactionId tid, ShardID shard,
                                velocypack::SharedSlice payload);
 

--- a/lib/Inspection/include/Inspection/Access.h
+++ b/lib/Inspection/include/Inspection/Access.h
@@ -290,12 +290,12 @@ struct Access<std::optional<T>> : OptionalAccess<std::optional<T>> {
 template<class T, class Deleter>
 struct Access<std::unique_ptr<T, Deleter>>
     : OptionalAccess<std::unique_ptr<T, Deleter>> {
-  static auto make() { return std::make_unique<T>(); }
+  static auto make() { return Factory<T>::make_unique(); }
 };
 
 template<class T>
 struct Access<std::shared_ptr<T>> : OptionalAccess<std::shared_ptr<T>> {
-  static auto make() { return std::make_shared<T>(); }
+  static auto make() { return Factory<T>::make_shared(); }
 };
 
 template<>

--- a/lib/Inspection/include/Inspection/Access.h
+++ b/lib/Inspection/include/Inspection/Access.h
@@ -35,6 +35,7 @@
 #include <velocypack/Value.h>
 
 #include "Inspection/detail/traits.h"
+#include "Inspection/Factory.h"
 #include "velocypack/Builder.h"
 #include "velocypack/Slice.h"
 
@@ -283,7 +284,7 @@ struct OptionalAccess {
 
 template<class T>
 struct Access<std::optional<T>> : OptionalAccess<std::optional<T>> {
-  static auto make() { return T{}; }
+  static auto make() { return Factory<T>::make_value(); }
 };
 
 template<class T, class Deleter>

--- a/lib/Inspection/include/Inspection/Factory.h
+++ b/lib/Inspection/include/Inspection/Factory.h
@@ -50,7 +50,7 @@ struct Factory {
   }
 };
 
-template<typename T, typename Derived>
+template<typename T, typename Derived = Factory<T>>
 struct BaseFactory {
   static auto make_unique() -> std::unique_ptr<T> {
     // If you get a compile error here because T has deleted copy and move

--- a/lib/Inspection/include/Inspection/Factory.h
+++ b/lib/Inspection/include/Inspection/Factory.h
@@ -26,7 +26,7 @@ namespace arangodb::inspection {
 
 template<typename T>
 struct Factory {
-  static auto create() -> T { return T{}; }
+  static auto make_value() -> T { return T{}; }
 };
 
 }  // namespace arangodb::inspection

--- a/lib/Inspection/include/Inspection/Factory.h
+++ b/lib/Inspection/include/Inspection/Factory.h
@@ -22,11 +22,46 @@
 
 #pragma once
 
+#include <memory>
+
 namespace arangodb::inspection {
 
+// If your type T is not default constructible, you can specialize `Factory` for
+// your type and implement make_value().
+// If T has a copy or move constructor, you can derive from BaseFactory (CRTP)
+// to get default make_unique() and make_shared() implementations.
+// If it hasn't, implement them too.
 template<typename T>
 struct Factory {
-  static auto make_value() -> T { return T{}; }
+  static auto make_value() -> T {
+    // If you get a compile error here because your T is not default
+    // constructible, see comment above.
+    return T{};
+  }
+  static auto make_unique() -> std::unique_ptr<T> {
+    // If you get a compile error here because your T is not default
+    // constructible, see comment above.
+    return std::make_unique<T>();
+  }
+  static auto make_shared() -> std::shared_ptr<T> {
+    // If you get a compile error here because your T is not default
+    // constructible, see comment above.
+    return std::make_shared<T>();
+  }
+};
+
+template<typename T, typename Derived>
+struct BaseFactory {
+  static auto make_unique() -> std::unique_ptr<T> {
+    // If you get a compile error here because T has deleted copy and move
+    // constructors, see comment above Factory.
+    return std::make_unique<T>(Derived::make_value());
+  }
+  static auto make_shared() -> std::shared_ptr<T> {
+    // If you get a compile error here because T has deleted copy and move
+    // constructors, see comment above Factory.
+    return std::make_shared<T>(Derived::make_value());
+  }
 };
 
 }  // namespace arangodb::inspection

--- a/lib/Inspection/include/Inspection/Factory.h
+++ b/lib/Inspection/include/Inspection/Factory.h
@@ -1,0 +1,32 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2023-2023 ArangoDB GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Tobias Gödderz
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+namespace arangodb::inspection {
+
+template<typename T>
+struct Factory {
+  static auto create() -> T { return T{}; }
+};
+
+}  // namespace arangodb::inspection

--- a/lib/Inspection/include/Inspection/LoadInspectorBase.h
+++ b/lib/Inspection/include/Inspection/LoadInspectorBase.h
@@ -207,7 +207,7 @@ struct LoadInspectorBase : InspectorBase<Derived, Context> {
                       Args&&... args) {
     if constexpr (Arg::isInlineType) {
       if (this->self().template shouldTryType<typename Arg::Type>(type)) {
-        auto v = Factory<typename Arg::Type>::create();
+        auto v = Factory<typename Arg::Type>::make_value();
         auto res = this->apply(v);
         if (res.ok()) {
           variant.value = std::move(v);
@@ -231,7 +231,7 @@ struct LoadInspectorBase : InspectorBase<Derived, Context> {
                              Args&&... args) {
     auto loadVariant = [&]() -> Status {
       std::string_view type;
-      auto data = Factory<ValueType>::create();
+      auto data = Factory<ValueType>::make_value();
       auto res = this->self().parseVariantInformation(type, data, variant);
       if (!res.ok()) {
         return res;
@@ -380,7 +380,7 @@ struct LoadInspectorBase : InspectorBase<Derived, Context> {
                   "All inline types must be listed at the beginning of the "
                   "alternatives list");
     if (arg.tag == tag) {
-      auto v = Factory<typename Arg::Type>::create();
+      auto v = Factory<typename Arg::Type>::make_value();
       auto res = parse(v);
       if (res.ok()) {
         result = v;
@@ -404,7 +404,7 @@ struct LoadInspectorBase : InspectorBase<Derived, Context> {
     return this->self().doProcessObject(
         [&](std::string_view key, ValueType value) -> Status {
           auto ff = this->make(value);
-          auto val = Factory<typename T::mapped_type>::create();
+          auto val = Factory<typename T::mapped_type>::make_value();
           if (auto res = process(ff, val); !res.ok()) {
             return {std::move(res), "'" + std::string(key) + "'",
                     Status::ArrayTag{}};
@@ -420,7 +420,7 @@ struct LoadInspectorBase : InspectorBase<Derived, Context> {
     std::size_t idx = 0;
     return this->self().doProcessList([&](auto value) -> Status {
       auto ff = this->self().make(value);
-      auto val = Factory<typename T::value_type>::create();
+      auto val = Factory<typename T::value_type>::make_value();
       if (auto res = process(ff, val); !res.ok()) {
         return {std::move(res), std::to_string(idx), Status::ArrayTag{}};
       }

--- a/tests/Inspection/VPackLoadTest.cpp
+++ b/tests/Inspection/VPackLoadTest.cpp
@@ -444,6 +444,28 @@ TEST_F(VPackLoadInspectorTest, load_non_default_constructible_type_optional) {
   EXPECT_EQ(x, (decltype(x){NonDefaultConstructibleIntLike{42}}));
 }
 
+TEST_F(VPackLoadInspectorTest, load_non_default_constructible_type_unique_ptr) {
+  builder.add(VPackValue(42));
+
+  VPackLoadInspector inspector{builder};
+
+  auto x = std::unique_ptr<NonDefaultConstructibleIntLike>();
+  auto result = inspector.apply(x);
+  EXPECT_TRUE(result.ok());
+  EXPECT_EQ(*x, NonDefaultConstructibleIntLike{42});
+}
+
+TEST_F(VPackLoadInspectorTest, load_non_default_constructible_type_shared_ptr) {
+  builder.add(VPackValue(42));
+
+  VPackLoadInspector inspector{builder};
+
+  auto x = std::shared_ptr<NonDefaultConstructibleIntLike>();
+  auto result = inspector.apply(x);
+  EXPECT_TRUE(result.ok());
+  EXPECT_EQ(*x, NonDefaultConstructibleIntLike{42});
+}
+
 TEST_F(VPackLoadInspectorTest, load_non_default_constructible_type_variant) {
   builder.add(VPackValue(42));
 

--- a/tests/Inspection/VPackLoadTest.cpp
+++ b/tests/Inspection/VPackLoadTest.cpp
@@ -407,6 +407,32 @@ TEST_F(VPackLoadInspectorTest, load_optional) {
   EXPECT_EQ(expected.map, o.map);
 }
 
+TEST_F(VPackLoadInspectorTest, load_non_default_constructible_type_vec) {
+  builder.openArray();
+  builder.add(VPackValue(42));
+  builder.close();
+
+  VPackLoadInspector inspector{builder};
+
+  auto vec = std::vector<NonDefaultConstructibleIntLike>();
+  auto result = inspector.apply(vec);
+  EXPECT_TRUE(result.ok());
+  EXPECT_EQ(vec, decltype(vec){NonDefaultConstructibleIntLike{42}});
+}
+
+TEST_F(VPackLoadInspectorTest, load_non_default_constructible_type_map) {
+  builder.openObject();
+  builder.add("foo", VPackValue(42));
+  builder.close();
+
+  VPackLoadInspector inspector{builder};
+
+  auto map = std::map<std::string, NonDefaultConstructibleIntLike>();
+  auto result = inspector.apply(map);
+  EXPECT_TRUE(result.ok());
+  EXPECT_EQ(map, (decltype(map){{"foo", NonDefaultConstructibleIntLike{42}}}));
+}
+
 TEST_F(VPackLoadInspectorTest, load_optional_pointer) {
   builder.openObject();
   builder.add(VPackValue("vec"));

--- a/tests/Inspection/VPackLoadTest.cpp
+++ b/tests/Inspection/VPackLoadTest.cpp
@@ -433,6 +433,28 @@ TEST_F(VPackLoadInspectorTest, load_non_default_constructible_type_map) {
   EXPECT_EQ(map, (decltype(map){{"foo", NonDefaultConstructibleIntLike{42}}}));
 }
 
+TEST_F(VPackLoadInspectorTest, load_non_default_constructible_type_optional) {
+  builder.add(VPackValue(42));
+
+  VPackLoadInspector inspector{builder};
+
+  auto x = std::optional<NonDefaultConstructibleIntLike>();
+  auto result = inspector.apply(x);
+  EXPECT_TRUE(result.ok());
+  EXPECT_EQ(x, (decltype(x){NonDefaultConstructibleIntLike{42}}));
+}
+
+TEST_F(VPackLoadInspectorTest, load_non_default_constructible_type_variant) {
+  builder.add(VPackValue(42));
+
+  VPackLoadInspector inspector{builder};
+
+  auto x = VariantWithNonDefaultConstructible{};
+  auto result = inspector.apply(x);
+  EXPECT_TRUE(result.ok());
+  EXPECT_EQ(x, (decltype(x){NonDefaultConstructibleIntLike{42}}));
+}
+
 TEST_F(VPackLoadInspectorTest, load_optional_pointer) {
   builder.openObject();
   builder.add(VPackValue("vec"));

--- a/tests/Inspection/VPackLoadTest.cpp
+++ b/tests/Inspection/VPackLoadTest.cpp
@@ -466,12 +466,28 @@ TEST_F(VPackLoadInspectorTest, load_non_default_constructible_type_shared_ptr) {
   EXPECT_EQ(*x, NonDefaultConstructibleIntLike{42});
 }
 
-TEST_F(VPackLoadInspectorTest, load_non_default_constructible_type_variant) {
+TEST_F(VPackLoadInspectorTest,
+       load_non_default_constructible_type_inline_variant) {
   builder.add(VPackValue(42));
 
   VPackLoadInspector inspector{builder};
 
-  auto x = VariantWithNonDefaultConstructible{};
+  auto x = InlineVariantWithNonDefaultConstructible{};
+  auto result = inspector.apply(x);
+  EXPECT_TRUE(result.ok());
+  EXPECT_EQ(x, (decltype(x){NonDefaultConstructibleIntLike{42}}));
+}
+
+TEST_F(VPackLoadInspectorTest,
+       load_non_default_constructible_type_qualified_variant) {
+  builder.openObject();
+  builder.add("t", "nondc_type");
+  builder.add("v", VPackValue(42));
+  builder.close();
+
+  VPackLoadInspector inspector{builder};
+
+  auto x = QualifiedVariantWithNonDefaultConstructible{};
   auto result = inspector.apply(x);
   EXPECT_TRUE(result.ok());
   EXPECT_EQ(x, (decltype(x){NonDefaultConstructibleIntLike{42}}));

--- a/tests/Inspection/VPackSaveTest.cpp
+++ b/tests/Inspection/VPackSaveTest.cpp
@@ -354,12 +354,24 @@ TEST_F(VPackSaveInspectorTest,
   EXPECT_EQ(x->value, builder.slice().getInt());
 }
 
-TEST_F(VPackSaveInspectorTest, store_non_default_constructible_type_variant) {
-  auto v =
-      VariantWithNonDefaultConstructible{NonDefaultConstructibleIntLike{42}};
+TEST_F(VPackSaveInspectorTest,
+       store_non_default_constructible_type_inline_variant) {
+  auto v = InlineVariantWithNonDefaultConstructible{
+      NonDefaultConstructibleIntLike{42}};
   auto result = inspector.apply(v);
   EXPECT_TRUE(result.ok());
   EXPECT_EQ(std::get<1>(v).value, builder.slice().getInt());
+}
+
+TEST_F(VPackSaveInspectorTest,
+       store_non_default_constructible_type_qualified_variant) {
+  auto v = QualifiedVariantWithNonDefaultConstructible{
+      NonDefaultConstructibleIntLike{42}};
+  auto result = inspector.apply(v);
+  EXPECT_TRUE(result.ok());
+  ASSERT_TRUE(builder.slice().isObject());
+  EXPECT_EQ("nondc_type", builder.slice().get("t").stringView());
+  EXPECT_EQ(std::get<1>(v).value, builder.slice().get("v").getInt());
 }
 
 TEST_F(VPackSaveInspectorTest, store_object_with_fallbacks) {

--- a/tests/Inspection/VPackSaveTest.cpp
+++ b/tests/Inspection/VPackSaveTest.cpp
@@ -310,7 +310,23 @@ TEST_F(VPackSaveInspectorTest, store_optional_pointer) {
   EXPECT_TRUE(slice["y"].isNull());
 }
 
-TEST_F(VPackSaveInspectorTest, store_non_default_constructible_type) {}
+TEST_F(VPackSaveInspectorTest, store_non_default_constructible_type_vec) {
+  auto vec = std::vector<NonDefaultConstructibleIntLike>{
+      NonDefaultConstructibleIntLike{42}};
+  auto result = inspector.apply(vec);
+  EXPECT_TRUE(result.ok());
+  ASSERT_TRUE(builder.slice().isArray());
+  EXPECT_EQ(vec[0].value, builder.slice().at(0).getInt());
+}
+
+TEST_F(VPackSaveInspectorTest, store_non_default_constructible_type_map) {
+  auto vec = std::map<std::string, NonDefaultConstructibleIntLike>{
+      {"foo", NonDefaultConstructibleIntLike{42}}};
+  auto result = inspector.apply(vec);
+  EXPECT_TRUE(result.ok());
+  ASSERT_TRUE(builder.slice().isObject());
+  EXPECT_EQ(vec.at("foo").value, builder.slice().get("foo").getInt());
+}
 
 TEST_F(VPackSaveInspectorTest, store_object_with_fallbacks) {
   Fallback f;

--- a/tests/Inspection/VPackSaveTest.cpp
+++ b/tests/Inspection/VPackSaveTest.cpp
@@ -336,6 +336,24 @@ TEST_F(VPackSaveInspectorTest, store_non_default_constructible_type_optional) {
   EXPECT_EQ(x.value().value, builder.slice().getInt());
 }
 
+TEST_F(VPackSaveInspectorTest,
+       store_non_default_constructible_type_unique_ptr) {
+  auto x = std::make_unique<NonDefaultConstructibleIntLike>(
+      NonDefaultConstructibleIntLike{42});
+  auto result = inspector.apply(x);
+  EXPECT_TRUE(result.ok());
+  EXPECT_EQ(x->value, builder.slice().getInt());
+}
+
+TEST_F(VPackSaveInspectorTest,
+       store_non_default_constructible_type_shared_ptr) {
+  auto x = std::make_shared<NonDefaultConstructibleIntLike>(
+      NonDefaultConstructibleIntLike{42});
+  auto result = inspector.apply(x);
+  EXPECT_TRUE(result.ok());
+  EXPECT_EQ(x->value, builder.slice().getInt());
+}
+
 TEST_F(VPackSaveInspectorTest, store_non_default_constructible_type_variant) {
   auto v =
       VariantWithNonDefaultConstructible{NonDefaultConstructibleIntLike{42}};

--- a/tests/Inspection/VPackSaveTest.cpp
+++ b/tests/Inspection/VPackSaveTest.cpp
@@ -328,6 +328,22 @@ TEST_F(VPackSaveInspectorTest, store_non_default_constructible_type_map) {
   EXPECT_EQ(vec.at("foo").value, builder.slice().get("foo").getInt());
 }
 
+TEST_F(VPackSaveInspectorTest, store_non_default_constructible_type_optional) {
+  auto x = std::optional<NonDefaultConstructibleIntLike>{
+      NonDefaultConstructibleIntLike{42}};
+  auto result = inspector.apply(x);
+  EXPECT_TRUE(result.ok());
+  EXPECT_EQ(x.value().value, builder.slice().getInt());
+}
+
+TEST_F(VPackSaveInspectorTest, store_non_default_constructible_type_variant) {
+  auto v =
+      VariantWithNonDefaultConstructible{NonDefaultConstructibleIntLike{42}};
+  auto result = inspector.apply(v);
+  EXPECT_TRUE(result.ok());
+  EXPECT_EQ(std::get<1>(v).value, builder.slice().getInt());
+}
+
 TEST_F(VPackSaveInspectorTest, store_object_with_fallbacks) {
   Fallback f;
   auto result = inspector.apply(f);

--- a/tests/Inspection/VPackSaveTest.cpp
+++ b/tests/Inspection/VPackSaveTest.cpp
@@ -310,6 +310,8 @@ TEST_F(VPackSaveInspectorTest, store_optional_pointer) {
   EXPECT_TRUE(slice["y"].isNull());
 }
 
+TEST_F(VPackSaveInspectorTest, store_non_default_constructible_type) {}
+
 TEST_F(VPackSaveInspectorTest, store_object_with_fallbacks) {
   Fallback f;
   auto result = inspector.apply(f);

--- a/tests/Inspection/include/Inspection/InspectionTestHelper.h
+++ b/tests/Inspection/include/Inspection/InspectionTestHelper.h
@@ -371,6 +371,21 @@ auto inspect(Inspector& f, AnEmptyObject& x) {
   return f.object(x).fields();
 }
 
+struct NonDefaultConstructibleIntLike {
+  NonDefaultConstructibleIntLike() = delete;
+  explicit NonDefaultConstructibleIntLike(std::uint64_t value) : value(value) {}
+
+  friend auto operator==(NonDefaultConstructibleIntLike,
+                         NonDefaultConstructibleIntLike) -> bool = default;
+
+  std::uint64_t value{};
+};
+
+template<typename Inspector>
+auto inspect(Inspector& f, NonDefaultConstructibleIntLike& x) {
+  return f.apply(x.value);
+}
+
 }  // namespace
 
 template<>
@@ -387,6 +402,12 @@ struct Access<Specialization> : AccessBase<Specialization> {
 template<>
 struct Access<AnEnumClass>
     : StorageTransformerAccess<AnEnumClass, EnumStorage<AnEnumClass>> {};
+template<>
+struct Factory<NonDefaultConstructibleIntLike> {
+  static auto create() -> NonDefaultConstructibleIntLike {
+    return NonDefaultConstructibleIntLike(0);
+  }
+};
 }  // namespace arangodb::inspection
 
 namespace {

--- a/tests/Inspection/include/Inspection/InspectionTestHelper.h
+++ b/tests/Inspection/include/Inspection/InspectionTestHelper.h
@@ -404,7 +404,7 @@ struct Access<AnEnumClass>
     : StorageTransformerAccess<AnEnumClass, EnumStorage<AnEnumClass>> {};
 template<>
 struct Factory<NonDefaultConstructibleIntLike> {
-  static auto create() -> NonDefaultConstructibleIntLike {
+  static auto make_value() -> NonDefaultConstructibleIntLike {
     return NonDefaultConstructibleIntLike(0);
   }
 };
@@ -570,6 +570,17 @@ auto inspect(Inspector& f, InlineVariant& x) {
   return f.object(x).fields(f.field("a", x.a), f.field("b", x.b),
                             f.field("c", x.c), f.field("d", x.d),
                             f.field("e", x.e));
+}
+
+struct VariantWithNonDefaultConstructible
+    : std::variant<std::string, NonDefaultConstructibleIntLike> {};
+
+template<class Inspector>
+auto inspect(Inspector& f, VariantWithNonDefaultConstructible& x) {
+  namespace insp = arangodb::inspection;
+  return f.variant(x).unqualified().alternatives(
+      insp::inlineType<std::string>(),
+      insp::inlineType<NonDefaultConstructibleIntLike>());
 }
 
 enum class MyStringEnum {

--- a/tests/Inspection/include/Inspection/InspectionTestHelper.h
+++ b/tests/Inspection/include/Inspection/InspectionTestHelper.h
@@ -574,15 +574,26 @@ auto inspect(Inspector& f, InlineVariant& x) {
                             f.field("e", x.e));
 }
 
-struct VariantWithNonDefaultConstructible
+struct InlineVariantWithNonDefaultConstructible
     : std::variant<std::string, NonDefaultConstructibleIntLike> {};
 
 template<class Inspector>
-auto inspect(Inspector& f, VariantWithNonDefaultConstructible& x) {
+auto inspect(Inspector& f, InlineVariantWithNonDefaultConstructible& x) {
   namespace insp = arangodb::inspection;
   return f.variant(x).unqualified().alternatives(
       insp::inlineType<std::string>(),
       insp::inlineType<NonDefaultConstructibleIntLike>());
+}
+
+struct QualifiedVariantWithNonDefaultConstructible
+    : std::variant<std::string, NonDefaultConstructibleIntLike> {};
+
+template<class Inspector>
+auto inspect(Inspector& f, QualifiedVariantWithNonDefaultConstructible& x) {
+  namespace insp = arangodb::inspection;
+  return f.variant(x).qualified("t", "v").alternatives(
+      insp::inlineType<std::string>(),
+      insp::type<NonDefaultConstructibleIntLike>("nondc_type"));
 }
 
 enum class MyStringEnum {

--- a/tests/Inspection/include/Inspection/InspectionTestHelper.h
+++ b/tests/Inspection/include/Inspection/InspectionTestHelper.h
@@ -405,8 +405,7 @@ struct Access<AnEnumClass>
     : StorageTransformerAccess<AnEnumClass, EnumStorage<AnEnumClass>> {};
 template<>
 struct Factory<NonDefaultConstructibleIntLike>
-    : BaseFactory<NonDefaultConstructibleIntLike,
-                  Factory<NonDefaultConstructibleIntLike>> {
+    : BaseFactory<NonDefaultConstructibleIntLike> {
   static auto make_value() -> NonDefaultConstructibleIntLike {
     return NonDefaultConstructibleIntLike(0);
   }

--- a/tests/Inspection/include/Inspection/InspectionTestHelper.h
+++ b/tests/Inspection/include/Inspection/InspectionTestHelper.h
@@ -399,11 +399,14 @@ struct Access<Specialization> : AccessBase<Specialization> {
     return f.object(x).fields(f.field("i", x.i), f.field("s", x.s));
   }
 };
+
 template<>
 struct Access<AnEnumClass>
     : StorageTransformerAccess<AnEnumClass, EnumStorage<AnEnumClass>> {};
 template<>
-struct Factory<NonDefaultConstructibleIntLike> {
+struct Factory<NonDefaultConstructibleIntLike>
+    : BaseFactory<NonDefaultConstructibleIntLike,
+                  Factory<NonDefaultConstructibleIntLike>> {
   static auto make_value() -> NonDefaultConstructibleIntLike {
     return NonDefaultConstructibleIntLike(0);
   }


### PR DESCRIPTION
### Scope & Purpose

Allow to inspect, and in particular deserialize, types that aren't default constructible. A static factory can be specialized to allow the Inspection library to create values.

- [X] :pizza: New feature

### Checklist

- [X] Tests
  - [X] C++ **Unit tests**

