### PR TITLE
Reenable retry createCollection for Replication1

### DIFF
--- a/arangod/Cluster/ClusterCollectionMethods.cpp
+++ b/arangod/Cluster/ClusterCollectionMethods.cpp
@@ -392,10 +392,11 @@ Result impl(ClusterInfo& ci, ArangodServer& server,
         return Result{TRI_ERROR_SHUTTING_DOWN};
       }
     } else {
-      return {TRI_ERROR_CLUSTER_COULD_NOT_CREATE_COLLECTION,
-              fmt::format("Failed to create collection, the operation has been "
-                          "rejected by the agency ({})",
-                          res.errorMessage())};
+      // We can just retry here.
+      // Most of our preconditions are protections against dead servers and changes in plan version
+      // Those are recomputed in this loop.
+      // The only thing that we cannot retry: The CollectionName is taken. That is checked at the
+      // beginning of this retry loop
     }
   }
 }

--- a/arangod/Cluster/ClusterCollectionMethods.cpp
+++ b/arangod/Cluster/ClusterCollectionMethods.cpp
@@ -393,10 +393,10 @@ Result impl(ClusterInfo& ci, ArangodServer& server,
       }
     } else {
       // We can just retry here.
-      // Most of our preconditions are protections against dead servers and changes in plan version
-      // Those are recomputed in this loop.
-      // The only thing that we cannot retry: The CollectionName is taken. That is checked at the
-      // beginning of this retry loop
+      // Most of our preconditions are protections against dead servers and
+      // changes in plan version Those are recomputed in this loop. The only
+      // thing that we cannot retry: The CollectionName is taken. That is
+      // checked at the beginning of this retry loop
     }
   }
 }


### PR DESCRIPTION
### Scope & Purpose

*We are too eager to report an error to the user and not retry to create a collection. This is actually not necessary at all. This also solves the issue of "precondition failed" handed out to the user.*

Detected by driver tests (this work is based on arangojs) so under integration test there.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*
  - [ ] Backport for 3.9: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

