### PR TITLE
Chore/cinfra fix cppcheck staging

### DIFF
--- a/arangod/Agency/ResignLeadership.cpp
+++ b/arangod/Agency/ResignLeadership.cpp
@@ -403,6 +403,7 @@ void ResignLeadership::scheduleJobsR2(std::shared_ptr<Builder>& trx,
           database, logTarget.id,
           {ReconfigureOperation{
               ReconfigureOperation::SetLeader{.participant = replacement}}},
+          // cppcheck-suppress accessMoved
           std::move(undo))
           .create(trx);
     }

--- a/arangod/RestHandler/RestDocumentStateHandler.cpp
+++ b/arangod/RestHandler/RestDocumentStateHandler.cpp
@@ -60,9 +60,9 @@ struct SnapshotTypeHandler final : public VPackCustomTypeHandler {
 RestDocumentStateHandler::RestDocumentStateHandler(ArangodServer& server,
                                                    GeneralRequest* request,
                                                    GeneralResponse* response)
-    : RestVocbaseBaseHandler(server, request, response) {
-  _customTypeHandler = std::make_unique<SnapshotTypeHandler>(_vocbase);
-  _options = VPackOptions::Defaults;
+    : RestVocbaseBaseHandler(server, request, response),
+      _customTypeHandler{std::make_unique<SnapshotTypeHandler>(_vocbase)},
+      _options{VPackOptions::Defaults} {
   _options.customTypeHandler = _customTypeHandler.get();
 }
 


### PR DESCRIPTION
### Scope & Purpose

*Fix CPP check warnings detected in our staging branch that are not present in devel*

Detected CPP check issues:
https://jenkins01.arangodb.biz/job/arangodb-ANY-cppcheck/937/

Files that are touched by replication 2 staging:
ResignLeadership.cpp
RestDocumentStateHandler.cpp

all others are not part of the staging PR.

CPPCHeck on this branch only:
https://jenkins01.arangodb.biz/job/arangodb-ANY-cppcheck/938/