### PR TITLE
[CINFRA-781] Have leaders track their participants' RebootIds

### DIFF
--- a/arangod/Agency/AgencyPaths.h
+++ b/arangod/Agency/AgencyPaths.h
@@ -1671,6 +1671,37 @@ class Root : public std::enable_shared_from_this<Root>, public Path {
             std::shared_ptr<Leader const> leader() const {
               return Leader::make_shared(shared_from_this());
             }
+
+            class SafeRebootIds : public StaticComponent<SafeRebootIds, Log> {
+             public:
+              constexpr char const* component() const noexcept {
+                return "safeRebootIds";
+              }
+
+              using BaseType::StaticComponent;
+
+              class Participant
+                  : public DynamicComponent<Participant, SafeRebootIds,
+                                            ServerID> {
+               public:
+                char const* component() const noexcept {
+                  return value().c_str();
+                }
+
+                using BaseType::DynamicComponent;
+              };
+
+              std::shared_ptr<Participant const> participant(
+                  std::string value) const {
+                return Participant::make_shared(shared_from_this(),
+                                                std::move(value));
+              }
+            };
+
+            std::shared_ptr<SafeRebootIds const> safeRebootIds() const {
+              return SafeRebootIds::make_shared(shared_from_this());
+            }
+
             class Actions : public StaticComponent<Actions, Log> {
              public:
               constexpr char const* component() const noexcept {

--- a/arangod/Cluster/ClusterTypes.cpp
+++ b/arangod/Cluster/ClusterTypes.cpp
@@ -61,6 +61,17 @@ std::ostream& operator<<(std::ostream& o, ServerHealthState const& r) {
   return o << "RebootId: " << r.rebootId << " Status: " << r.status;
 }
 
+auto to_string(PeerState const& peerState) -> std::string {
+  VPackBuilder builder;
+  velocypack::serialize(builder, peerState);
+  return builder.slice().toJson();
+}
+
+auto operator<<(std::ostream& ostream, PeerState const& peerState)
+    -> std::ostream& {
+  return ostream << to_string(peerState);
+}
+
 void QueryAnalyzerRevisions::toVelocyPack(VPackBuilder& builder) const {
   VPackObjectBuilder scope(&builder,
                            StaticStrings::ArangoSearchAnalyzersRevision);

--- a/arangod/Cluster/ClusterTypes.h
+++ b/arangod/Cluster/ClusterTypes.h
@@ -56,6 +56,24 @@ std::ostream& operator<<(std::ostream& o, ServerHealthState const& r);
 
 using ServersKnown = containers::FlatHashMap<ServerID, ServerHealthState>;
 
+struct PeerState {
+  std::string serverId;
+  RebootId rebootId{0};
+
+  friend auto operator==(PeerState const&, PeerState const&) noexcept
+      -> bool = default;
+
+  template<typename Inspector>
+  friend auto inspect(Inspector& f, PeerState& x) {
+    return f.object(x).fields(f.field("serverId", x.serverId),
+                              f.field("rebootId", x.rebootId));
+  }
+};
+
+auto to_string(PeerState const& peerState) -> std::string;
+auto operator<<(std::ostream& ostream, PeerState const& peerState)
+    -> std::ostream&;
+
 namespace velocypack {
 class Builder;
 class Slice;

--- a/arangod/Cluster/Maintenance.cpp
+++ b/arangod/Cluster/Maintenance.cpp
@@ -1558,7 +1558,7 @@ static void writeUpdateReplicatedLogSafeRebootIds(
         safeRebootIds) {
   // update Current/ReplicatedLogs/<dbname>/<logId>/safeRebootIds
   // with precondition
-  // Plan/ReplicatedLogs/<dbname>/<logId>/term/term == currentTerm
+  // Plan/ReplicatedLogs/<dbname>/<logId>/currentTerm/term == localTerm
   using namespace cluster::paths;
   auto reportPath = aliases::current()
                         ->replicatedLogs()

--- a/arangod/Cluster/RebootTracker.cpp
+++ b/arangod/Cluster/RebootTracker.cpp
@@ -112,8 +112,7 @@ void RebootTracker::updateServerState(ServersKnown state) {
   _state = std::move(state);
 }
 
-CallbackGuard RebootTracker::callMeOnChange(RebootTracker::PeerState peer,
-                                            Callback callback,
+CallbackGuard RebootTracker::callMeOnChange(PeerState peer, Callback callback,
                                             std::string description) {
   std::lock_guard guard{_mutex};
   auto const it = _state.find(peer.serverId);
@@ -191,7 +190,7 @@ void RebootTracker::queueCallback(DescriptedCallback&& callback) noexcept {
                     });
 }
 
-void RebootTracker::unregisterCallback(RebootTracker::PeerState const& peer,
+void RebootTracker::unregisterCallback(PeerState const& peer,
                                        CallbackId callbackId) noexcept {
   std::lock_guard guard{_mutex};
   if (auto const it = _callbacks.find(peer.serverId); it != _callbacks.end()) {

--- a/arangod/Cluster/RebootTracker.h
+++ b/arangod/Cluster/RebootTracker.h
@@ -62,13 +62,12 @@ class RebootTracker {
       std::map<RebootId,
                containers::FlatHashMap<CallbackId, DescriptedCallback>>;
   using Callbacks = containers::FlatHashMap<ServerID, RebootIds>;
-  struct PeerState {
-    std::string serverId;
-    RebootId rebootId{0};
-  };
 
   explicit RebootTracker(SchedulerPointer scheduler);
 
+  // Register `callback`, which is executed once if the state of `peer` changes.
+  // Destroying or overwriting the returned CallbackGuard will unregister the
+  // callback. The description is used for logging related to the callback.
   CallbackGuard callMeOnChange(PeerState peer, Callback callback,
                                std::string description);
 

--- a/arangod/Replication2/ReplicatedLog/AgencyLogSpecification.h
+++ b/arangod/Replication2/ReplicatedLog/AgencyLogSpecification.h
@@ -367,6 +367,9 @@ struct LogCurrent {
   // Will be nullopt until a leader has assumed leadership
   std::optional<Leader> leader;
 
+  // Lower bounds of RebootIds used in the last committed log entry.
+  std::unordered_map<ParticipantId, RebootId> safeRebootIds;
+
   // Temporary hack until Actions are de-serializable.
   struct ActionDummy {
     std::string timestamp;

--- a/arangod/Replication2/ReplicatedLog/AgencySpecificationInspectors.h
+++ b/arangod/Replication2/ReplicatedLog/AgencySpecificationInspectors.h
@@ -49,6 +49,7 @@ auto constexpr LeadershipEstablished =
 auto constexpr CommitStatus = std::string_view{"commitStatus"};
 auto constexpr Supervision = std::string_view{"supervision"};
 auto constexpr Leader = std::string_view{"leader"};
+auto constexpr SafeRebootIds = std::string_view{"safeRebootIds"};
 auto constexpr TargetVersion = std::string_view{"targetVersion"};
 auto constexpr Version = std::string_view{"version"};
 auto constexpr Actions = std::string_view{"actions"};
@@ -287,6 +288,8 @@ auto inspect(Inspector& f, LogCurrent& x) {
           .fallback(std::unordered_map<ParticipantId, LogCurrentLocalState>{}),
       f.field(static_strings::Supervision, x.supervision),
       f.field(static_strings::Leader, x.leader),
+      f.field(static_strings::SafeRebootIds, x.safeRebootIds)
+          .fallback(std::unordered_map<ParticipantId, RebootId>{}),
       f.field(static_strings::Actions, x.actions)
           .fallback(std::vector<LogCurrent::ActionDummy>{}));
 }

--- a/arangod/Replication2/ReplicatedLog/CMakeLists.txt
+++ b/arangod/Replication2/ReplicatedLog/CMakeLists.txt
@@ -7,7 +7,9 @@ target_sources(arango_replication2 PRIVATE
   ReplicatedLog.cpp
   SupervisionAgencyTrx.cpp
   ReplicatedLogFeature.cpp
-  ReplicatedLogMetrics.tpp)
+  ReplicatedLogMetrics.tpp
+  DefaultRebootIdCache.cpp DefaultRebootIdCache.h
+  )
 
 target_sources(arango_replication2_pure PRIVATE
   LogCommon.cpp
@@ -27,6 +29,7 @@ target_sources(arango_replication2_pure PRIVATE
   NetworkMessages.cpp
   ReplicatedLogMetrics.tpp
   TermIndexMapping.cpp
+  IRebootIdCache.h
   Components/AppendEntriesManager.cpp Components/AppendEntriesManager.h
   Components/CompactionManager.cpp Components/CompactionManager.h
   Components/ExclusiveBool.h

--- a/arangod/Replication2/ReplicatedLog/DefaultRebootIdCache.cpp
+++ b/arangod/Replication2/ReplicatedLog/DefaultRebootIdCache.cpp
@@ -1,0 +1,78 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2023-2023 ArangoDB GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Tobias Gödderz
+////////////////////////////////////////////////////////////////////////////////
+
+#include "DefaultRebootIdCache.h"
+
+#include "Cluster/ClusterInfo.h"
+
+#include <fmt/core.h>
+#include <fmt/ranges.h>
+
+template<>
+struct fmt::formatter<::arangodb::ServerHealthState>
+    : fmt::formatter<string_view> {
+  template<class FormatContext>
+  auto format(::arangodb::ServerHealthState state, FormatContext& fc) const {
+    std::stringstream ss;
+    ss << state;
+    return formatter<string_view>::format(ss.str(), fc);
+  }
+};
+
+namespace arangodb::replication2::replicated_log {
+
+DefaultRebootIdCache::DefaultRebootIdCache(ClusterInfo& clusterInfo)
+    : clusterInfo(clusterInfo) {}
+
+auto DefaultRebootIdCache::getRebootIdsFor(
+    std::vector<ParticipantId> const& participants) const
+    -> std::unordered_map<ParticipantId, RebootId> {
+  auto result = std::unordered_map<ParticipantId, RebootId>{};
+  auto rebootIds = clusterInfo.rebootIds();
+  for (auto const& participant : participants) {
+    auto serverStateIt = rebootIds.find(participant);
+    if (serverStateIt != rebootIds.end()) {
+      result.try_emplace(participant, serverStateIt->second.rebootId);
+    } else {
+      // We need to report a RebootId for each participant. Reporting 0 is
+      // always safe, as it is the most pessimistic assumption.
+      result.try_emplace(participant, RebootId(0));
+      // All participants should always be available in the lists of known
+      // servers (I think).
+      TRI_ASSERT(false) << fmt::format(
+          "Participant {} not found in ServersKnown. LogLeader asked for these "
+          "participants: {} while the ClusterInfo provided these servers: {}",
+          participant, participants, rebootIds);
+    }
+  }
+
+  return result;
+}
+
+auto DefaultRebootIdCache::registerCallbackOnChange(
+    PeerState peer, IRebootIdCache::Callback callback, std::string description)
+    -> cluster::CallbackGuard {
+  return clusterInfo.rebootTracker().callMeOnChange(
+      std::move(peer), std::move(callback), std::move(description));
+}
+
+}  // namespace arangodb::replication2::replicated_log

--- a/arangod/Replication2/ReplicatedLog/DefaultRebootIdCache.h
+++ b/arangod/Replication2/ReplicatedLog/DefaultRebootIdCache.h
@@ -1,0 +1,46 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2023-2023 ArangoDB GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Tobias Gödderz
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "Replication2/ReplicatedLog/IRebootIdCache.h"
+
+namespace arangodb {
+class ClusterInfo;
+}
+
+namespace arangodb::replication2::replicated_log {
+
+struct DefaultRebootIdCache : IRebootIdCache {
+  explicit DefaultRebootIdCache(ClusterInfo&);
+  ~DefaultRebootIdCache() override = default;
+  auto getRebootIdsFor(std::vector<ParticipantId> const& participants) const
+      -> std::unordered_map<ParticipantId, RebootId> override;
+  auto registerCallbackOnChange(PeerState peer, Callback callback,
+                                std::string description)
+      -> cluster::CallbackGuard override;
+
+ private:
+  ClusterInfo& clusterInfo;
+};
+
+}  // namespace arangodb::replication2::replicated_log

--- a/arangod/Replication2/ReplicatedLog/IRebootIdCache.h
+++ b/arangod/Replication2/ReplicatedLog/IRebootIdCache.h
@@ -1,0 +1,58 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2023-2023 ArangoDB GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Tobias Gödderz
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "Basics/RebootId.h"
+#include "Replication2/ReplicatedLog/LogCommon.h"
+
+#include <function2.hpp>
+
+#include <unordered_map>
+#include <vector>
+
+namespace arangodb {
+struct PeerState;
+}
+namespace arangodb::cluster {
+class CallbackGuard;
+}
+
+namespace arangodb::replication2::replicated_log {
+
+struct IRebootIdCache {
+  using Callback = fu2::unique_function<void()>;
+
+  virtual ~IRebootIdCache() = default;
+  virtual auto getRebootIdsFor(std::vector<ParticipantId> const& participants)
+      const -> std::unordered_map<ParticipantId, RebootId> = 0;
+  virtual auto registerCallbackOnChange(PeerState peer, Callback callback,
+                                        std::string description)
+      -> cluster::CallbackGuard = 0;
+
+  // convenience method
+  auto getRebootIdFor(ParticipantId const& participant) const -> RebootId {
+    return getRebootIdsFor({participant}).begin()->second;
+  }
+};
+
+}  // namespace arangodb::replication2::replicated_log

--- a/arangod/Replication2/ReplicatedLog/LogEntries.cpp
+++ b/arangod/Replication2/ReplicatedLog/LogEntries.cpp
@@ -225,10 +225,13 @@ auto LogMetaPayload::withFirstEntryOfTerm(ParticipantId leader,
                                          .participants = std::move(config)}};
 }
 
-auto LogMetaPayload::withUpdateParticipantsConfig(
-    agency::ParticipantsConfig config) -> LogMetaPayload {
+auto LogMetaPayload::withUpdateInnerTermConfig(
+    agency::ParticipantsConfig config,
+    std::unordered_map<ParticipantId, RebootId> safeRebootIds)
+    -> LogMetaPayload {
   return LogMetaPayload{
-      UpdateParticipantsConfig{.participants = std::move(config)}};
+      UpdateInnerTermConfig{.participants = std::move(config),
+                            .safeRebootIds = std::move(safeRebootIds)}};
 }
 
 auto LogMetaPayload::withPing(std::optional<std::string> message,

--- a/arangod/Replication2/ReplicatedLog/LogEntries.h
+++ b/arangod/Replication2/ReplicatedLog/LogEntries.h
@@ -75,19 +75,23 @@ struct LogMetaPayload {
                                    agency::ParticipantsConfig config)
       -> LogMetaPayload;
 
-  struct UpdateParticipantsConfig {
+  struct UpdateInnerTermConfig {
     agency::ParticipantsConfig participants;
+    std::unordered_map<ParticipantId, RebootId> safeRebootIds;
 
-    friend auto operator==(UpdateParticipantsConfig const&,
-                           UpdateParticipantsConfig const&) noexcept
+    friend auto operator==(UpdateInnerTermConfig const&,
+                           UpdateInnerTermConfig const&) noexcept
         -> bool = default;
     template<typename Inspector>
-    friend auto inspect(Inspector& f, UpdateParticipantsConfig& x) {
-      return f.object(x).fields(f.field("participants", x.participants));
+    friend auto inspect(Inspector& f, UpdateInnerTermConfig& x) {
+      return f.object(x).fields(f.field("participants", x.participants),
+                                f.field("safeRebootIds", x.safeRebootIds));
     }
   };
 
-  static auto withUpdateParticipantsConfig(agency::ParticipantsConfig config)
+  static auto withUpdateInnerTermConfig(
+      agency::ParticipantsConfig config,
+      std::unordered_map<ParticipantId, RebootId> safeRebootIds)
       -> LogMetaPayload;
 
   struct Ping {
@@ -112,14 +116,14 @@ struct LogMetaPayload {
   static auto fromVelocyPack(velocypack::Slice) -> LogMetaPayload;
   void toVelocyPack(velocypack::Builder&) const;
 
-  std::variant<FirstEntryOfTerm, UpdateParticipantsConfig, Ping> info;
+  std::variant<FirstEntryOfTerm, UpdateInnerTermConfig, Ping> info;
 
   template<typename Inspector>
   friend auto inspect(Inspector& f, LogMetaPayload& x) {
     namespace insp = arangodb::inspection;
     return f.variant(x.info).embedded("type").alternatives(
         insp::type<FirstEntryOfTerm>("FirstEntryOfTerm"),
-        insp::type<UpdateParticipantsConfig>("UpdateParticipantsConfig"),
+        insp::type<UpdateInnerTermConfig>("UpdateInnerTermConfig"),
         insp::type<Ping>("Ping"));
   }
 

--- a/arangod/Replication2/ReplicatedLog/LogLeader.cpp
+++ b/arangod/Replication2/ReplicatedLog/LogLeader.cpp
@@ -70,7 +70,6 @@
 #include "Replication2/IScheduler.h"
 #include "Replication2/ReplicatedLog/Components/StorageManager.h"
 #include "Replication2/ReplicatedLog/Components/CompactionManager.h"
-#include "Replication2/ReplicatedLog/IRebootIdCache.h"
 
 #if (_MSC_VER >= 1)
 // suppress warnings:

--- a/arangod/Replication2/ReplicatedLog/LogLeader.h
+++ b/arangod/Replication2/ReplicatedLog/LogLeader.h
@@ -330,7 +330,6 @@ class LogLeader : public std::enable_shared_from_this<LogLeader>,
     LogIndex activeInnerConfigLogIndex;
     // committed - latest active config that has committed at least one entry
     // Note that this will be nullptr until leadership is established!
-    // std::shared_ptr<InnerTermConfig const> committedInnerTermConfig;
     std::shared_ptr<InnerTermConfig const> committedInnerTermConfig;
   };
 

--- a/arangod/Replication2/ReplicatedLog/LogStatus.h
+++ b/arangod/Replication2/ReplicatedLog/LogStatus.h
@@ -58,6 +58,10 @@ struct QuickLogStatus {
   // been established!
   std::shared_ptr<agency::ParticipantsConfig const>
       committedParticipantsConfig{};
+  // Note that safeRebootIds will be nullptr until leadership has been
+  // established!
+  std::shared_ptr<std::unordered_map<ParticipantId, RebootId> const>
+      safeRebootIds{};
 
   std::vector<ParticipantId> followersWithSnapshot{};
 
@@ -81,10 +85,14 @@ auto inspect(Inspector& f, QuickLogStatus& x) {
   auto activeParticipantsConfig = std::shared_ptr<agency::ParticipantsConfig>();
   auto committedParticipantsConfig =
       std::shared_ptr<agency::ParticipantsConfig>();
+  auto safeRebootIds =
+      std::shared_ptr<std::unordered_map<ParticipantId, RebootId>>();
   if constexpr (!Inspector::isLoading) {
     activeParticipantsConfig = std::make_shared<agency::ParticipantsConfig>();
     committedParticipantsConfig =
         std::make_shared<agency::ParticipantsConfig>();
+    safeRebootIds =
+        std::make_shared<std::unordered_map<ParticipantId, RebootId>>();
   }
   auto res = f.object(x).fields(
       f.field("role", x.role).transformWith(ParticipantRoleStringTransformer{}),
@@ -95,10 +103,12 @@ auto inspect(Inspector& f, QuickLogStatus& x) {
       f.field("commitFailReason", x.commitFailReason),
       f.field("followersWithSnapshot", x.followersWithSnapshot),
       f.field("activeParticipantsConfig", activeParticipantsConfig),
-      f.field("committedParticipantsConfig", committedParticipantsConfig));
+      f.field("committedParticipantsConfig", committedParticipantsConfig),
+      f.field("safeRebootIds", safeRebootIds));
   if constexpr (Inspector::isLoading) {
     x.activeParticipantsConfig = activeParticipantsConfig;
     x.committedParticipantsConfig = committedParticipantsConfig;
+    x.safeRebootIds = safeRebootIds;
   }
   return res;
 }
@@ -181,6 +191,7 @@ struct LeaderStatus {
   CompactionStatus compactionStatus;
   agency::ParticipantsConfig activeParticipantsConfig;
   std::optional<agency::ParticipantsConfig> committedParticipantsConfig;
+  std::optional<std::unordered_map<ParticipantId, RebootId>> safeRebootIds;
 
   friend auto operator==(LeaderStatus const& left,
                          LeaderStatus const& right) noexcept -> bool = default;
@@ -201,7 +212,8 @@ auto inspect(Inspector& f, LeaderStatus& x) {
       f.field("lastCommitStatus", x.lastCommitStatus),
       f.field("compactionStatus", x.compactionStatus),
       f.field("activeParticipantsConfig", x.activeParticipantsConfig),
-      f.field("committedParticipantsConfig", x.committedParticipantsConfig));
+      f.field("committedParticipantsConfig", x.committedParticipantsConfig),
+      f.field("safeRebootIds", x.safeRebootIds));
 }
 
 struct FollowerStatus {

--- a/arangod/Replication2/ReplicatedLog/ReplicatedLog.cpp
+++ b/arangod/Replication2/ReplicatedLog/ReplicatedLog.cpp
@@ -39,6 +39,7 @@
 #include "Metrics/Gauge.h"
 #include "Logger/LogContextKeys.h"
 #include "Replication2/IScheduler.h"
+#include "Replication2/ReplicatedLog/IRebootIdCache.h"
 
 namespace arangodb::replication2::replicated_log {
 struct AbstractFollower;
@@ -333,12 +334,15 @@ auto DefaultParticipantsFactory::constructLeader(
       std::move(methods), std::move(info.initialConfig), std::move(info.myself),
       info.term, context.loggerContext, std::move(context.metrics),
       std::move(context.options), std::move(context.stateHandle),
-      followerFactory, scheduler);
+      followerFactory, scheduler, rebootIdCache);
 }
 
 DefaultParticipantsFactory::DefaultParticipantsFactory(
     std::shared_ptr<IAbstractFollowerFactory> followerFactory,
-    std::shared_ptr<IScheduler> scheduler)
+    std::shared_ptr<IScheduler> scheduler,
+    std::shared_ptr<IRebootIdCache> rebootIdCache)
     : followerFactory(std::move(followerFactory)),
-      scheduler(std::move(scheduler)) {}
+      scheduler(std::move(scheduler)),
+      rebootIdCache(std::move(rebootIdCache)) {}
+
 }  // namespace arangodb::replication2::replicated_log

--- a/arangod/Replication2/ReplicatedLog/ReplicatedLog.h
+++ b/arangod/Replication2/ReplicatedLog/ReplicatedLog.h
@@ -44,6 +44,7 @@
 namespace arangodb::replication2::replicated_log {
 class LogLeader;
 struct AbstractFollower;
+struct IRebootIdCache;
 }  // namespace arangodb::replication2::replicated_log
 namespace arangodb::replication2::maintenance {
 struct LogStatus;
@@ -255,7 +256,8 @@ struct ReplicatedLogConnection {
 struct DefaultParticipantsFactory : IParticipantsFactory {
   explicit DefaultParticipantsFactory(
       std::shared_ptr<IAbstractFollowerFactory> followerFactory,
-      std::shared_ptr<IScheduler> scheduler);
+      std::shared_ptr<IScheduler> scheduler,
+      std::shared_ptr<IRebootIdCache> rebootIdCache);
   auto constructFollower(
       std::unique_ptr<replicated_state::IStorageEngineMethods>&&,
       FollowerTermInfo info, ParticipantContext context)
@@ -267,6 +269,7 @@ struct DefaultParticipantsFactory : IParticipantsFactory {
 
   std::shared_ptr<IAbstractFollowerFactory> followerFactory;
   std::shared_ptr<IScheduler> scheduler;
+  std::shared_ptr<IRebootIdCache> rebootIdCache;
 };
 
 }  // namespace arangodb::replication2::replicated_log

--- a/arangod/Replication2/StateMachines/Document/DocumentStateSnapshotHandler.cpp
+++ b/arangod/Replication2/StateMachines/Document/DocumentStateSnapshotHandler.cpp
@@ -55,7 +55,7 @@ auto DocumentStateSnapshotHandler::create(ShardMap shards,
     auto& guardRef = emplacement.first->second;
     auto res = ResultT<std::weak_ptr<Snapshot>>::success(guardRef.snapshot);
     guardRef.cbGuard = _rebootTracker.callMeOnChange(
-        cluster::RebootTracker::PeerState{params.serverId, params.rebootId},
+        PeerState{params.serverId, params.rebootId},
         [id, params, weak = weak_from_this()]() {
           if (auto self = weak.lock(); self != nullptr) {
             self->abort(id);

--- a/arangod/Transaction/Options.h
+++ b/arangod/Transaction/Options.h
@@ -95,7 +95,7 @@ struct Options {
   /// abort the transaction should the coordinator die or be rebooted.
   /// the server id and reboot id are intentionally empty in single server
   /// case.
-  arangodb::cluster::RebootTracker::PeerState origin;
+  arangodb::PeerState origin;
 
   /// @brief determines whether this transaction requires the changes to be
   /// replicated. E.g., transactions that _must not_ be replicated are those

--- a/js/common/modules/@arangodb/testutils/replicated-logs-helper.js
+++ b/js/common/modules/@arangodb/testutils/replicated-logs-helper.js
@@ -77,6 +77,14 @@ const getServerRebootId = function (serverId) {
   return readAgencyValueAt(`Current/ServersKnown/${serverId}/rebootId`);
 };
 
+const bumpServerRebootId = function (serverId) {
+  const response = serverHelper.agency.increaseVersion(`Current/ServersKnown/${serverId}/rebootId`);
+  if (response !== true) {
+    return undefined;
+  }
+  return getServerRebootId(serverId);
+};
+
 const getParticipantsObjectForServers = function (servers) {
   return _.reduce(servers, (a, v) => {
     a[v] = {allowedInQuorum: true, allowedAsLeader: true, forced: false};
@@ -161,7 +169,8 @@ const coordinators = (function () {
  *         localStatus: Object<string, Object>,
  *         localState: Object,
  *         supervision?: Object,
- *         leader?: Object
+ *         leader?: Object,
+ *         safeRebootIds?: Object<string, number>
  *       }
  *   }}
  */
@@ -722,6 +731,7 @@ exports.getReplicatedLogLeaderPlan = getReplicatedLogLeaderPlan;
 exports.getReplicatedLogLeaderTarget = getReplicatedLogLeaderTarget;
 exports.getServerHealth = getServerHealth;
 exports.getServerRebootId = getServerRebootId;
+exports.bumpServerRebootId = bumpServerRebootId;
 exports.getServerUrl = getServerUrl;
 exports.getSupervisionActionTypes = getSupervisionActionTypes;
 exports.getSupervisionActions = getSupervisionActions;

--- a/lib/Basics/RebootId.h
+++ b/lib/Basics/RebootId.h
@@ -27,7 +27,10 @@
 #include <limits>
 #include <memory>
 #include <string>
-#include "velocypack/Builder.h"
+
+#include <velocypack/Builder.h>
+
+#include "Inspection/Factory.h"
 
 namespace arangodb {
 class RebootId {
@@ -93,5 +96,12 @@ struct velocypack::Extractor<arangodb::RebootId> {
     return RebootId{slice.getNumericValue<std::size_t>()};
   }
 };
+
+namespace inspection {
+template<>
+struct Factory<RebootId> : BaseFactory<RebootId> {
+  static auto make_value() -> RebootId { return RebootId(0); }
+};
+}  // namespace inspection
 
 }  // namespace arangodb

--- a/tests/Replication2/CMakeLists.txt
+++ b/tests/Replication2/CMakeLists.txt
@@ -24,8 +24,10 @@ set(ARANGODB_REPLICATION2_TEST_HELPER_SOURCES
   Mocks/MockOracle.h
   Mocks/MockVocbase.h
   Mocks/LeaderCommunicatorMock.h
+  Mocks/RebootIdCacheMock.h
   Mocks/StorageManagerMock.h
-  Mocks/StateHandleManagerMock.h)
+  Mocks/StateHandleManagerMock.h
+  )
 
 
 set(ARANGODB_REPLICATION2_TEST_SOURCES

--- a/tests/Replication2/Mocks/RebootIdCacheMock.h
+++ b/tests/Replication2/Mocks/RebootIdCacheMock.h
@@ -1,0 +1,49 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2023-2023 ArangoDB GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Tobias Gödderz
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include <gmock/gmock.h>
+
+#include "Replication2/ReplicatedLog/IRebootIdCache.h"
+
+namespace arangodb::replication2::test {
+
+struct RebootIdCacheMock : IRebootIdCache {
+  MOCK_METHOD((std::unordered_map<ParticipantId, RebootId>), getRebootIdsFor,
+              (std::vector<ParticipantId> const&), (const, override));
+  MOCK_METHOD((cluster::CallbackGuard), registerCallbackOnChange,
+              (PeerState, Callback, std::string), (override));
+
+  RebootIdCacheMock() {
+    ON_CALL(*this, getRebootIdsFor)
+        .WillByDefault([](std::vector<ParticipantId> const& participants) {
+          auto result = std::unordered_map<ParticipantId, RebootId>{};
+          for (auto const& participant : participants) {
+            result.emplace(participant, RebootId{0});
+          }
+          return result;
+        });
+  }
+};
+
+}  // namespace arangodb::replication2::test

--- a/tests/js/server/replication2/replication2-maintenance-replicated-log-cluster.js
+++ b/tests/js/server/replication2/replication2-maintenance-replicated-log-cluster.js
@@ -281,17 +281,9 @@ const replicatedLogSuite = function () {
       lh.replicatedLogUpdateTargetParticipants(database, log.id(), {
         [newFollower]: {
           allowedInQuorum: true,
-          allowedAsLeader: true
+          allowedAsLeader: true,
         },
         [oldFollower]: null,
-      });
-      lh.waitFor(() => {
-        const {target, plan} = lh.readReplicatedLogAgency(database, log.id());
-        if (_.isEqual(Object.keys(plan.participantsConfig.participants).sort(), Object.keys(target.participants).sort())) {
-          return true;
-        } else {
-          return Error(`Plan participants haven't caught up with target. ${JSON.stringify({target, plan})}`);
-        }
       });
 
       const newFollowerRebootId = lh.getServerRebootId(newFollower);
@@ -300,10 +292,12 @@ const replicatedLogSuite = function () {
 
       lh.waitFor(() => {
         const {current} = lh.readReplicatedLogAgency(database, log.id());
-        if (current.safeRebootIds.hasOwnProperty(newFollower)) {
-          return true;
-        } else {
+        if (!current.safeRebootIds.hasOwnProperty(newFollower)) {
           return Error(`Reboot id of ${newFollower} is not yet reported.`);
+        } else if (current.safeRebootIds.hasOwnProperty(newFollower)) {
+          return Error(`Reboot id of ${oldFollower} is still being reported.`);
+        } else {
+          return true;
         }
       });
       const finalCurrent = lh.readReplicatedLogAgency(database, log.id()).current;

--- a/tests/js/server/replication2/replication2-maintenance-replicated-log-cluster.js
+++ b/tests/js/server/replication2/replication2-maintenance-replicated-log-cluster.js
@@ -285,6 +285,14 @@ const replicatedLogSuite = function () {
         },
         [oldFollower]: null,
       });
+      lh.waitFor(() => {
+        const {target, plan} = lh.readReplicatedLogAgency(database, log.id());
+        if (_.isEqual(Object.keys(plan.participantsConfig.participants).sort(), Object.keys(target.participants).sort())) {
+          return true;
+        } else {
+          return Error(`Plan participants haven't caught up with target. ${JSON.stringify({target, plan})}`);
+        }
+      });
 
       const newFollowerRebootId = lh.getServerRebootId(newFollower);
       delete expectedRebootIds[oldFollower];

--- a/tests/js/server/replication2/replication2-maintenance-replicated-log-cluster.js
+++ b/tests/js/server/replication2/replication2-maintenance-replicated-log-cluster.js
@@ -1,5 +1,4 @@
 /*jshint strict: true */
-/*global assertEqual */
 'use strict';
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -24,10 +23,13 @@
 /// @author Lars Maier
 ////////////////////////////////////////////////////////////////////////////////
 const jsunity = require('jsunity');
+const {assertTrue, assertEqual} = jsunity.jsUnity.assertions;
 const _ = require('lodash');
 const lh = require("@arangodb/testutils/replicated-logs-helper");
 const lp = require("@arangodb/testutils/replicated-logs-predicates");
 const lhttp = require("@arangodb/testutils/replicated-logs-http-helper");
+const arangodb = require("@arangodb");
+const {db} = arangodb;
 
 const database = 'ReplLogsMaintenanceTest';
 
@@ -207,6 +209,97 @@ const replicatedLogSuite = function () {
       });
       lh.waitFor(lp.replicatedLogParticipantsFlag(database, logId, {[toBeRemoved]: null}));
       lh.replicatedLogDeletePlan(database, logId);
+    },
+
+    testReportSafeRebootIdsToCurrentAfterCreation: function () {
+      const targetConfig = {
+        writeConcern: 3,
+        softWriteConcern: 3,
+        waitForSync: false,
+      };
+      const log = db._createReplicatedLog({config: targetConfig});
+      const {target, current} = lh.readReplicatedLogAgency(database, log.id());
+      const expectedRebootIds = Object.fromEntries(
+        Object.keys(target.participants).map(p => [p, lh.getServerRebootId(p)])
+      );
+      assertTrue(current.hasOwnProperty("safeRebootIds"));
+      assertEqual(Object.keys(target.participants), Object.keys(current.safeRebootIds));
+      assertEqual(expectedRebootIds, current.safeRebootIds);
+    },
+
+    testReportSafeRebootIdsToCurrentAfterBump: function () {
+      const targetConfig = {
+        writeConcern: 3,
+        softWriteConcern: 3,
+        waitForSync: false,
+      };
+      const log = db._createReplicatedLog({config: targetConfig});
+      const {target, plan, current} = lh.readReplicatedLogAgency(database, log.id());
+      const expectedRebootIds = Object.fromEntries(
+        Object.keys(target.participants).map(p => [p, lh.getServerRebootId(p)])
+      );
+      assertTrue(current.hasOwnProperty("safeRebootIds"));
+      assertEqual(Object.keys(target.participants), Object.keys(current.safeRebootIds));
+      assertEqual(expectedRebootIds, current.safeRebootIds);
+      const leader = plan.currentTerm.leader.serverId;
+      const follower = _.sample(Object.keys(plan.participantsConfig.participants).filter(p => p !== leader));
+      const newRebootId = lh.bumpServerRebootId(follower);
+      assertTrue(expectedRebootIds[follower] < newRebootId);
+      expectedRebootIds[follower] = newRebootId;
+      lh.waitFor(() => {
+        const {current} = lh.readReplicatedLogAgency(database, log.id());
+        const reportedRebootId = current.safeRebootIds[follower];
+        if (reportedRebootId === newRebootId) {
+          return true;
+        } else {
+          return Error(`Reboot id of ${follower} is ${newRebootId}, but still reported as ${reportedRebootId}.`);
+        }
+      });
+      const finalCurrent = lh.readReplicatedLogAgency(database, log.id()).current;
+      assertEqual(expectedRebootIds, finalCurrent.safeRebootIds);
+    },
+
+    testReportSafeRebootIdsToCurrentAfterReplaceParticipant: function () {
+      const targetConfig = {
+        writeConcern: 3,
+        softWriteConcern: 3,
+        waitForSync: false,
+      };
+      const log = db._createReplicatedLog({config: targetConfig});
+      const {target, plan, current} = lh.readReplicatedLogAgency(database, log.id());
+      const expectedRebootIds = Object.fromEntries(
+        Object.keys(target.participants).map(p => [p, lh.getServerRebootId(p)])
+      );
+      assertTrue(current.hasOwnProperty("safeRebootIds"));
+      assertEqual(Object.keys(target.participants), Object.keys(current.safeRebootIds));
+      assertEqual(expectedRebootIds, current.safeRebootIds);
+      const leader = plan.currentTerm.leader.serverId;
+      const participants = Object.keys(plan.participantsConfig.participants);
+      const oldFollower = _.sample(participants.filter(p => p !== leader));
+      const newFollower = _.sample(_.difference(lh.dbservers, participants));
+
+      lh.replicatedLogUpdateTargetParticipants(database, log.id(), {
+        [newFollower]: {
+          allowedInQuorum: true,
+          allowedAsLeader: true
+        },
+        [oldFollower]: null,
+      });
+
+      const newFollowerRebootId = lh.getServerRebootId(newFollower);
+      delete expectedRebootIds[oldFollower];
+      expectedRebootIds[newFollower] = newFollowerRebootId;
+
+      lh.waitFor(() => {
+        const {current} = lh.readReplicatedLogAgency(database, log.id());
+        if (current.safeRebootIds.hasOwnProperty(newFollower)) {
+          return true;
+        } else {
+          return Error(`Reboot id of ${newFollower} is not yet reported.`);
+        }
+      });
+      const finalCurrent = lh.readReplicatedLogAgency(database, log.id()).current;
+      assertEqual(expectedRebootIds, finalCurrent.safeRebootIds);
     },
   };
 };

--- a/tests/js/server/replication2/replication2-maintenance-replicated-log-cluster.js
+++ b/tests/js/server/replication2/replication2-maintenance-replicated-log-cluster.js
@@ -294,7 +294,7 @@ const replicatedLogSuite = function () {
         const {current} = lh.readReplicatedLogAgency(database, log.id());
         if (!current.safeRebootIds.hasOwnProperty(newFollower)) {
           return Error(`Reboot id of ${newFollower} is not yet reported.`);
-        } else if (current.safeRebootIds.hasOwnProperty(newFollower)) {
+        } else if (current.safeRebootIds.hasOwnProperty(oldFollower)) {
           return Error(`Reboot id of ${oldFollower} is still being reported.`);
         } else {
           return true;

--- a/tests/js/server/replication2/replication2-replicated-log-entry-cluster.js
+++ b/tests/js/server/replication2/replication2-replicated-log-entry-cluster.js
@@ -86,10 +86,11 @@ const replicatedLogEntrySuite = function () {
       lh.replicatedLogDeleteTarget(database, logId);
     },
 
-    testCheckUpdateParticipantsConfig: function () {
+    testCheckUpdateInnerTermConfig: function () {
       const {logId, servers, followers} = lh.createReplicatedLog(database, targetConfig);
       waitForReplicatedLogAvailable(logId);
       const follower = _.sample(followers);
+      const rebootIds = Object.fromEntries(servers.map(server => [server, lh.getServerRebootId(server)]));
 
       lh.replicatedLogUpdateTargetParticipants(database, logId, {
         [follower]: {forced: true},
@@ -110,10 +111,12 @@ const replicatedLogEntrySuite = function () {
       assertEqual(entry.logPayload, undefined);
       assertTrue(entry.meta !== undefined);
       const meta = entry.meta;
-      assertEqual(meta.type, "UpdateParticipantsConfig");
+      assertEqual(meta.type, "UpdateInnerTermConfig");
       assertEqual(meta.leader, undefined);
       assertEqual(meta.participants.generation, 2);
       assertEqual(Object.keys(meta.participants.participants).sort(), servers.sort());
+      assertEqual(Object.keys(meta.safeRebootIds).sort(), servers.sort());
+      assertEqual(meta.safeRebootIds, rebootIds);
       lh.replicatedLogDeleteTarget(database, logId);
     },
 


### PR DESCRIPTION
### Scope & Purpose

https://arangodb.atlassian.net/browse/CINFRA-781

The leader has to track its participant’s RebootIds and report them to Current.

In order to do that, on startup it has to:

* copy the map participantId => rebootId from the agency cache (before establishing leadership)
* report the map to current after leadership has been established

Later, if any participant’s RebootId changes (register callback in the RebootTracker):

* get the RebootId of the participant from the agency cache
* insert an empty log entry
* after the log entry has been committed, report the map to current

- [X] :pizza: New feature

### Checklist

- [X] Tests
  - [X] **integration tests**

