### PR TITLE
cinfra - Made all Graphs OneShard aware

### DIFF
--- a/arangod/Graph/Graph.cpp
+++ b/arangod/Graph/Graph.cpp
@@ -160,6 +160,9 @@ Graph::Graph(TRI_vocbase_t& vocbase, std::string&& graphName,
       _vertexColls(),
       _edgeColls(),
       _numberOfShards(1),
+      /* In OneShardDatabases this value is not used internally. It mostly has
+       * informative value on how your graph is sharded. The OneShard feature
+       * will overwrite this setting */
       _replicationFactor(vocbase.getDatabaseConfiguration().isOneShardDB
                              ? (std::max)(vocbase.replicationFactor(),
                                           vocbase.server()

--- a/arangod/Graph/Graph.cpp
+++ b/arangod/Graph/Graph.cpp
@@ -841,8 +841,8 @@ auto Graph::prepareCreateCollectionBodyEdge(
   body.name = name;
   body.type = TRI_col_type_e::TRI_COL_TYPE_EDGE;
 
-  auto res =
-      injectShardingToCollectionBody(body, leadingCollection, satellites, config);
+  auto res = injectShardingToCollectionBody(body, leadingCollection, satellites,
+                                            config);
   if (res.fail()) {
     return res;
   }

--- a/arangod/Graph/Graph.h
+++ b/arangod/Graph/Graph.h
@@ -333,8 +333,7 @@ class Graph {
       CreateCollectionBody& body,
       std::optional<std::string> const& leadingCollection,
       std::unordered_set<std::string> const& satellites,
-      DatabaseConfiguration const& config) const noexcept
-      -> Result;
+      DatabaseConfiguration const& config) const noexcept -> Result;
 
  private:
   /// @brief Parse the edgeDefinition slice and inject it into this graph

--- a/arangod/Graph/Graph.h
+++ b/arangod/Graph/Graph.h
@@ -292,13 +292,15 @@ class Graph {
   auto prepareCreateCollectionBodyEdge(
       std::string_view name,
       std::optional<std::string> const& leadingCollection,
-      std::unordered_set<std::string> const& satellites) const noexcept
+      std::unordered_set<std::string> const& satellites,
+      DatabaseConfiguration const& config) const noexcept
       -> ResultT<CreateCollectionBody>;
 
   auto prepareCreateCollectionBodyVertex(
       std::string_view name,
       std::optional<std::string> const& leadingCollection,
-      std::unordered_set<std::string> const& satellites) const noexcept
+      std::unordered_set<std::string> const& satellites,
+      DatabaseConfiguration const& config) const noexcept
       -> ResultT<CreateCollectionBody>;
 
   /**
@@ -330,7 +332,8 @@ class Graph {
   virtual auto injectShardingToCollectionBody(
       CreateCollectionBody& body,
       std::optional<std::string> const& leadingCollection,
-      std::unordered_set<std::string> const& satellites) const noexcept
+      std::unordered_set<std::string> const& satellites,
+      DatabaseConfiguration const& config) const noexcept
       -> Result;
 
  private:

--- a/arangod/Graph/GraphManager.cpp
+++ b/arangod/Graph/GraphManager.cpp
@@ -667,8 +667,8 @@ Result GraphManager::ensureCollections(
     };
   }
   for (auto const& c : documentCollectionsToCreate) {
-    auto col = graph.prepareCreateCollectionBodyVertex(
-        c, leadingCollection, satellites, config);
+    auto col = graph.prepareCreateCollectionBodyVertex(c, leadingCollection,
+                                                       satellites, config);
     if (col.fail()) {
       return col.result();
     }
@@ -676,8 +676,8 @@ Result GraphManager::ensureCollections(
   }
 
   for (auto const& c : edgeCollectionsToCreate) {
-    auto col =
-        graph.prepareCreateCollectionBodyEdge(c, leadingCollection, satellites, config);
+    auto col = graph.prepareCreateCollectionBodyEdge(c, leadingCollection,
+                                                     satellites, config);
     if (col.fail()) {
       return col.result();
     }

--- a/arangod/Graph/GraphManager.cpp
+++ b/arangod/Graph/GraphManager.cpp
@@ -667,27 +667,19 @@ Result GraphManager::ensureCollections(
     };
   }
   for (auto const& c : documentCollectionsToCreate) {
-    auto col = graph.prepareCreateCollectionBodyVertex(c, leadingCollection,
-                                                       satellites);
+    auto col = graph.prepareCreateCollectionBodyVertex(
+        c, leadingCollection, satellites, config);
     if (col.fail()) {
       return col.result();
-    }
-    auto res = col->applyDefaultsAndValidateDatabaseConfiguration(config);
-    if (res.fail()) {
-      return res;
     }
     createRequests.emplace_back(std::move(col.get()));
   }
 
   for (auto const& c : edgeCollectionsToCreate) {
     auto col =
-        graph.prepareCreateCollectionBodyEdge(c, leadingCollection, satellites);
+        graph.prepareCreateCollectionBodyEdge(c, leadingCollection, satellites, config);
     if (col.fail()) {
       return col.result();
-    }
-    auto res = col->applyDefaultsAndValidateDatabaseConfiguration(config);
-    if (res.fail()) {
-      return res;
     }
     createRequests.emplace_back(std::move(col.get()));
   }


### PR DESCRIPTION
### Scope & Purpose

*As our windows tests are started with a different default configuration they unveiled a bug in GraphManager when creating enterprise grade graphs in OneShard database. The feature is not really a practical use-case however now Graphs again honor OneShard rules.*

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*
  - [ ] Backport for 3.9: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [x] Enterprise PR: https://github.com/arangodb/enterprise/pull/1301
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

