### PR TITLE
Fix potential read off end of format string

### DIFF
--- a/lib/Inspection/include/Inspection/Transformers.h
+++ b/lib/Inspection/include/Inspection/Transformers.h
@@ -36,17 +36,16 @@ namespace arangodb::inspection {
 struct TimeStampTransformer {
   using SerializedType = std::string;
   using clock = std::chrono::system_clock;
-  static constexpr std::string_view formatString = "%FT%TZ";
+  static constexpr const char* formatString = "%FT%TZ";
   auto toSerialized(clock::time_point source, std::string& target) const
       -> inspection::Status {
-    target =
-        date::format(formatString.data(), floor<std::chrono::seconds>(source));
+    target = date::format(formatString, floor<std::chrono::seconds>(source));
     return {};
   }
   auto fromSerialized(std::string const& source,
                       clock::time_point& target) const -> inspection::Status {
     auto in = std::istringstream{source};
-    in >> date::parse(formatString.data(), target);
+    in >> date::parse(formatString, target);
 
     if (in.fail()) {
       return inspection::Status(


### PR DESCRIPTION
Fix https://github.com/arangodb/arangodb/pull/19138/files#r1233999301 ; std::string_view.data() is not guaranteed to be 0-terminated. Just use a const char*.


### Scope & Purpose

*(Please describe the changes in this PR for reviewers, motivation, rationale - **mandatory**)*

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [x] Tests
  - [ ] **Regression tests**
  - [x] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*
  - [ ] Backport for 3.9: *(Please link PR)*
