### PR TITLE
Medium prio lockups in AgencyCache and Query shutdown, BTS-1475, BTS-1486

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,12 @@
+v3.10.8 (XXXX-XX-XX)
+--------------------
+
+* Fixed two possible deadlocks which could occur if all medium priority
+  threads are busy. One is that in this case the AgencyCache could no longer
+  receive updates from the agency and another that queries could no longer
+  be finished. This fixes BTS-1475 and BTS-1486.
+
+
 v3.10.7 (2023-06-12)
 --------------------
 

--- a/arangod/Aql/Query.cpp
+++ b/arangod/Aql/Query.cpp
@@ -1537,8 +1537,12 @@ futures::Future<Result> finishDBServerParts(Query& query, ErrorCode errorCode) {
   network::RequestOptions options;
   options.database = query.vocbase().name();
   options.timeout = network::Timeout(60.0);  // Picked arbitrarily
-  options.continuationLane = RequestLane::CLUSTER_AQL_INTERNAL_COORDINATOR;
-  //  options.skipScheduler = true;
+  options.continuationLane = RequestLane::CLUSTER_INTERNAL;
+  // Most coordinator AQL code might be executed on the MEDIUM prio lane,
+  // since it comes from a continuation. Therefore, to avoid deadlock, we
+  // must use a lane which has priority HIGH. We do not want to skip the
+  // scheduler, since the cleanup code acquires locks and does some
+  // non-trivial work.
 
   VPackBuffer<uint8_t> body;
   VPackBuilder builder(body);
@@ -1714,13 +1718,14 @@ ExecutionState Query::cleanupTrxAndEngines(ErrorCode errorCode) {
     // we only get here if something in the network stack is out of order.
     // so there is no need to retry on cleaning up the engines, caller can
     // continue Also note: If an error in cleanup happens the query was
-    // completed already, so this error does not need to be reported to client.
+    // completed already, so this error does not need to be reported to
+    // client.
     _shutdownState.store(ShutdownState::Done, std::memory_order_relaxed);
 
     if (isModificationQuery()) {
-      // For modification queries these left-over locks will have negative side
-      // effects We will report those to the user. Lingering Read-locks should
-      // not block the system.
+      // For modification queries these left-over locks will have negative
+      // side effects We will report those to the user. Lingering Read-locks
+      // should not block the system.
       std::vector<std::string_view> writeLocked{};
       std::vector<std::string_view> exclusiveLocked{};
       _collections.visit([&](std::string const& name, Collection& col) -> bool {
@@ -1742,12 +1747,14 @@ ExecutionState Query::cleanupTrxAndEngines(ErrorCode errorCode) {
       LOG_TOPIC("63572", WARN, Logger::QUERIES)
           << " Failed to cleanup leftovers of a query due to communication "
              "errors. "
-          << " The DBServers will eventually clean up the state. The following "
+          << " The DBServers will eventually clean up the state. The "
+             "following "
              "locks still exist: "
           << " write: " << writeLocked
           << ": you may not drop these collections until the locks time out."
           << " exclusive: " << exclusiveLocked
-          << ": you may not be able to write into these collections until the "
+          << ": you may not be able to write into these collections until "
+             "the "
              "locks time out.";
 
       for (auto const& [server, queryId, rebootId] : _serverQueryIds) {
@@ -1823,9 +1830,10 @@ void Query::debugKillQuery() {
   // A query can only be killed under certain circumstances.
   // We assert here that one of those is true.
   // a) Query is in the list of current queries, this can be requested by the
-  // user and the query can be killed by user b) Query is in the query registry.
-  // In this case the query registry can hit a timeout, which triggers the kill
-  // c) The query id has been handed out to the user (stream query only)
+  // user and the query can be killed by user b) Query is in the query
+  // registry. In this case the query registry can hit a timeout, which
+  // triggers the kill c) The query id has been handed out to the user (stream
+  // query only)
   bool isStreaming = queryOptions().stream;
   bool isInList = false;
   bool isInRegistry = false;

--- a/arangod/Cluster/AgencyCache.cpp
+++ b/arangod/Cluster/AgencyCache.cpp
@@ -356,7 +356,7 @@ void AgencyCache::run() {
     // This is intentionally 61s timeout to avoid a client timeout, since
     // the server returns after 60s by default. This avoids broken
     // connections.
-    return AsyncAgencyComm().poll(61s, commitIndex);
+    return AsyncAgencyComm().withSkipScheduler(true).poll(61s, commitIndex);
   };
 
   // while not stopping
@@ -389,119 +389,107 @@ void AgencyCache::run() {
       //   {..., result:{commitIndex:X, log:[]}}
 
       if (server().getFeature<NetworkFeature>().prepared()) {
-        auto ret =
-            sendTransaction()
-                .thenValue([&](AsyncAgencyCommResult&& rb) {
-                  if (!rb.ok() ||
-                      rb.statusCode() != arangodb::fuerte::StatusOK) {
-                    // Error response, this includes client timeout
-                    increaseWaitTime();
-                    LOG_TOPIC("9a93e", DEBUG, Logger::CLUSTER)
-                        << "Failed to get poll result from agency.";
-                    return futures::makeFuture();
-                  }
-                  // Correct response:
-                  index_t curIndex = 0;
-                  {
-                    std::lock_guard g(_storeLock);
-                    curIndex = _commitIndex;
-                  }
-                  auto slc = rb.slice();
-                  wait = 0.;
-                  TRI_ASSERT(slc.hasKey("result"));
-                  VPackSlice rs = slc.get("result");
-                  TRI_ASSERT(rs.hasKey("commitIndex"));
-                  TRI_ASSERT(rs.get("commitIndex").isNumber());
-                  index_t commitIndex =
-                      rs.get("commitIndex").getNumber<uint64_t>();
-                  VPackSlice firstIndexSlice = rs.get("firstIndex");
-                  if (!firstIndexSlice.isNumber()) {
-                    // Nothing happened at all, server timeout
-                    return futures::makeFuture();
-                  }
-                  index_t firstIndex = firstIndexSlice.getNumber<uint64_t>();
-                  if (firstIndex > 0) {
-                    // No snapshot, this is actual some log continuation
-                    TRI_ASSERT(_initialized);
-                    // Do incoming logs match our cache's index?
-                    if (firstIndex != curIndex + 1) {
-                      LOG_TOPIC("a9a09", WARN, Logger::CLUSTER)
-                          << "Logs from poll start with index " << firstIndex
-                          << " we requested logs from and including "
-                          << curIndex << " retrying.";
-                      LOG_TOPIC("457e9", TRACE, Logger::CLUSTER)
-                          << "Incoming: " << rs.toJson();
-                      increaseWaitTime();
-                      return futures::makeFuture();
-                    }
-                    TRI_ASSERT(rs.hasKey("log"));
-                    TRI_ASSERT(rs.get("log").isArray());
-                    LOG_TOPIC("4579e", TRACE, Logger::CLUSTER)
-                        << "Applying to cache " << rs.get("log").toJson();
-                    for (auto const& i : VPackArrayIterator(rs.get("log"))) {
-                      pc.clear();
-                      cc.clear();
-                      {
-                        std::lock_guard g(_storeLock);
-                        _readDB.applyTransaction(i);  // apply logs
-                        _commitIndex = i.get("index").getNumber<uint64_t>();
+        try {
+          auto rb = sendTransaction().get();
+          if (!rb.ok() || rb.statusCode() != arangodb::fuerte::StatusOK) {
+            // Error response, this includes client timeout
+            increaseWaitTime();
+            LOG_TOPIC("9a93e", DEBUG, Logger::CLUSTER)
+                << "Failed to get poll result from agency.";
+            continue;
+          }
+          // Correct response:
+          index_t curIndex = 0;
+          {
+            std::lock_guard g(_storeLock);
+            curIndex = _commitIndex;
+          }
+          auto slc = rb.slice();
+          wait = 0.;
+          TRI_ASSERT(slc.hasKey("result"));
+          VPackSlice rs = slc.get("result");
+          TRI_ASSERT(rs.hasKey("commitIndex"));
+          TRI_ASSERT(rs.get("commitIndex").isNumber());
+          index_t commitIndex = rs.get("commitIndex").getNumber<uint64_t>();
+          VPackSlice firstIndexSlice = rs.get("firstIndex");
+          if (!firstIndexSlice.isNumber()) {
+            // Nothing happened at all, server timeout
+            continue;
+          }
+          index_t firstIndex = firstIndexSlice.getNumber<uint64_t>();
+          if (firstIndex > 0) {
+            // No snapshot, this is actually some log continuation
+            TRI_ASSERT(_initialized);
+            // Do incoming logs match our cache's index?
+            if (firstIndex != curIndex + 1) {
+              LOG_TOPIC("a9a09", WARN, Logger::CLUSTER)
+                  << "Logs from poll start with index " << firstIndex
+                  << " we requested logs from and including " << curIndex
+                  << " retrying.";
+              LOG_TOPIC("457e9", TRACE, Logger::CLUSTER)
+                  << "Incoming: " << rs.toJson();
+              increaseWaitTime();
+              continue;
+            }
+            TRI_ASSERT(rs.hasKey("log"));
+            TRI_ASSERT(rs.get("log").isArray());
+            LOG_TOPIC("4579e", TRACE, Logger::CLUSTER)
+                << "Applying to cache " << rs.get("log").toJson();
+            for (auto const& i : VPackArrayIterator(rs.get("log"))) {
+              pc.clear();
+              cc.clear();
+              {
+                std::lock_guard g(_storeLock);
+                _readDB.applyTransaction(i);  // apply logs
+                _commitIndex = i.get("index").getNumber<uint64_t>();
 
-                        {
-                          std::lock_guard g(_callbacksLock);
-                          handleCallbacksNoLock(i.get("query"), uniq, toCall,
-                                                pc, cc);
-                        }
+                {
+                  std::lock_guard g(_callbacksLock);
+                  handleCallbacksNoLock(i.get("query"), uniq, toCall, pc, cc);
+                }
 
-                        for (auto const& i : pc) {
-                          _planChanges.emplace(_commitIndex, i);
-                        }
-                        for (auto const& i : cc) {
-                          _currentChanges.emplace(_commitIndex, i);
-                        }
-                      }
-                    }
-                  } else {
-                    // firstIndex == 0, we got a snapshot:
-                    TRI_ASSERT(rs.hasKey("readDB"));
-                    std::lock_guard g(_storeLock);
-                    LOG_TOPIC("4579f", TRACE, Logger::CLUSTER)
-                        << "Fresh start: overwriting agency cache with "
-                        << rs.toJson();
-                    _readDB = rs;  // overwrite
-                    std::unordered_set<std::string> pc = reInitPlan();
-                    for (auto const& i : pc) {
-                      _planChanges.emplace(_commitIndex, i);
-                    }
-                    // !! Check documentation of the function before making
-                    // changes here !!
-                    _commitIndex = commitIndex;
-                    _lastSnapshot = commitIndex;
-                    _initialized.store(true, std::memory_order_relaxed);
-                  }
-                  triggerWaiting(commitIndex);
-                  if (firstIndex > 0) {
-                    if (!toCall.empty()) {
-                      invokeCallbacks(toCall);
-                    }
-                  } else {
-                    invokeAllCallbacks();
-                  }
-                  return futures::makeFuture();
-                })
-                .thenError<VPackException>(
-                    [&increaseWaitTime](VPackException const& e) {
-                      LOG_TOPIC("9a9f3", ERR, Logger::CLUSTER)
-                          << "Failed to parse poll result from agency: "
-                          << e.what();
-                      increaseWaitTime();
-                    })
-                .thenError<std::exception>([&increaseWaitTime](
-                                               std::exception const& e) {
-                  LOG_TOPIC("9a9e3", ERR, Logger::CLUSTER)
-                      << "Failed to get poll result from agency: " << e.what();
-                  increaseWaitTime();
-                });
-        ret.wait();
+                for (auto const& i : pc) {
+                  _planChanges.emplace(_commitIndex, i);
+                }
+                for (auto const& i : cc) {
+                  _currentChanges.emplace(_commitIndex, i);
+                }
+              }
+            }
+          } else {
+            // firstIndex == 0, we got a snapshot:
+            TRI_ASSERT(rs.hasKey("readDB"));
+            std::lock_guard g(_storeLock);
+            LOG_TOPIC("4579f", TRACE, Logger::CLUSTER)
+                << "Fresh start: overwriting agency cache with " << rs.toJson();
+            _readDB = rs;  // overwrite
+            std::unordered_set<std::string> pc = reInitPlan();
+            for (auto const& i : pc) {
+              _planChanges.emplace(_commitIndex, i);
+            }
+            // !! Check documentation of the function before making
+            // changes here !!
+            _commitIndex = commitIndex;
+            _lastSnapshot = commitIndex;
+            _initialized.store(true, std::memory_order_relaxed);
+          }
+          triggerWaiting(commitIndex);
+          if (firstIndex > 0) {
+            if (!toCall.empty()) {
+              invokeCallbacks(toCall);
+            }
+          } else {
+            invokeAllCallbacks();
+          }
+        } catch (VPackException const& e) {
+          LOG_TOPIC("9a9f3", ERR, Logger::CLUSTER)
+              << "Failed to parse poll result from agency: " << e.what();
+          increaseWaitTime();
+        } catch (std::exception const& e) {
+          LOG_TOPIC("9a9e3", ERR, Logger::CLUSTER)
+              << "Failed to get poll result from agency: " << e.what();
+          increaseWaitTime();
+        }
       } else {
         increaseWaitTime();
         LOG_TOPIC("9393e", DEBUG, Logger::CLUSTER)

--- a/tests/js/client/shell/shell-med-queue-blocked-cluster.js
+++ b/tests/js/client/shell/shell-med-queue-blocked-cluster.js
@@ -1,0 +1,142 @@
+/* jshint globalstrict:false, strict:false, maxlen: 200 */
+/* global fail, assertEqual, assertTrue, assertFalse, arango */
+
+// //////////////////////////////////////////////////////////////////////////////
+// / @brief timeouts during query setup
+// /
+// / DISCLAIMER
+// /
+// / Copyright 2023 ArangoDB GmbH, Cologne, Germany
+// /
+// / Licensed under the Apache License, Version 2.0 (the "License")
+// / you may not use this file except in compliance with the License.
+// / You may obtain a copy of the License at
+// /
+// /     http://www.apache.org/licenses/LICENSE-2.0
+// /
+// / Unless required by applicable law or agreed to in writing, software
+// / distributed under the License is distributed on an "AS IS" BASIS,
+// / WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// / See the License for the specific language governing permissions and
+// / limitations under the License.
+// /
+// / @author Max Neunhoeffer
+// //////////////////////////////////////////////////////////////////////////////
+
+let jsunity = require('jsunity');
+let arangodb = require('@arangodb');
+let db = arangodb.db;
+let { getEndpointsByType,
+      debugCanUseFailAt,
+      debugClearFailAt,
+      debugSetFailAt,
+    } = require('@arangodb/test-helper');
+      
+function medQueueBlockedSuite() {
+  'use strict';
+  const cn = 'UnitTestsMedQueueBlocked';
+
+  return {
+
+    setUp: function () {
+      db._drop(cn);
+    },
+
+    tearDown: function () {
+      db._drop(cn);
+    },
+    
+    testRunAql: function() {
+      let coll = db._create(cn, {numberOfShards:3});
+      let l = [];
+      for (let i = 0; i < 100; ++i) {
+        l.push({"Hello":i});
+      }
+      coll.insert(l);
+
+      // We now want to overload the medium prio scheduler queue, to this
+      // end, we post some perverse queries asynchronously. This should
+      // overwhelm any server without the fix. Note that we post the query
+      // with x-arango-frontend: true, such that we can start enough queries
+      // concurrently to fill the medium queue on the coordinator.
+      const f = require("@arangodb/aql/functions")
+      try {
+        f.register("USER::FUNC", function() {
+          const db = require("@arangodb").db;
+          require("internal").wait(1);
+          db._query("FOR d IN @@c RETURN d", {"@c": "UnitTestsMedQueueBlocked"});
+          return 12;
+        })
+        let start = new Date();
+        let jobs = []; 
+        for (let i = 0; i < 100; ++i) {
+          jobs.push(arango.POST_RAW("/_api/cursor",
+            {query:`LET s = USER::FUNC() FOR d IN ${cn} RETURN {d,s}`},
+            {"x-arango-async": "store", "x-arango-frontend": true}).headers["x-arango-async-id"]);
+        }
+        for (let j of jobs) {
+          while (true) {
+            let res = arango.PUT_RAW(`/_api/job/${j}`, {});
+            if (res.code !== 204) {
+              break;
+            }
+            if (new Date() - start > 50000) {
+              throw "Lost patience, almost certainly the coordinator is deadlocked!";
+            }
+            require("internal").wait(0.1);
+          }
+        }
+        let end = new Date();
+        // Why 50 seconds? If only two of the queries are executed concurrently,
+        // then this should be done in 50s. Usually, there will be a higher parallelism
+        // and it should finish much faster. Without the bug fixed, it will lock up and
+        // not finish within 50s.
+        assertTrue(end - start < 50000);   // Should be done in 50 seconds
+      } finally {
+        f.unregister("USER::FUNC");
+        coll.drop();
+      }
+    },
+
+    testCreateColl: function() {
+      try {
+        // This failure point blocks the medium priority queue. This means
+        // that the response to an AgencyCache poll operation to the AgencyCache
+        // can only work if it skips the scheduler. That means that a collection
+        // creation can only succeed if this is the case. Note that we send
+        // our collection creation request with the header "x-arango-frontend"
+        // set to true, land it on the high prio queue:
+        arango.PUT_RAW("/_admin/debug/failat/BlockSchedulerMediumQueue", {});
+        // We are using the direct connection to set the failure point here,
+        // since for this particular failure point (block scheduler medium
+        // queue) a reconnect is not possible. Therefore we cannot use
+        // debugFailAt.
+
+        let start = new Date();
+        let savedTimeout = arango.timeout();
+        arango.timeout(20);
+        let res = arango.POST_RAW("/_api/collection", {"name":cn}, {"x-arango-frontend": true});
+        let end = new Date();
+        arango.timeout(savedTimeout);
+        assertTrue(end - start < 10000);   // Should be done in 10 seconds
+      } finally {
+        // We are using the direct connection to set the failure point here,
+        // since for this particular failure point (block scheduler medium
+        // queue) a reconnect is not possible. Therefore we cannot use
+        // debugFailAt.
+        arango.DELETE_RAW("/_admin/debug/failat");
+        require("internal").wait(3);  // give the system time to finish the 
+                                      // creation of the collection, in case
+                                      // the test TestCreateColl fails.
+      }
+    },
+
+  };
+}
+
+let ep = getEndpointsByType('coordinator');
+if (ep.length && debugCanUseFailAt(ep[0])) {
+  // only execute if failure tests are available
+  jsunity.run(medQueueBlockedSuite);
+}
+return jsunity.done();

--- a/tests/js/client/shell/shell-med-queue-blocked-cluster.js
+++ b/tests/js/client/shell/shell-med-queue-blocked-cluster.js
@@ -59,14 +59,14 @@ function medQueueBlockedSuite() {
       // overwhelm any server without the fix. Note that we post the query
       // with x-arango-frontend: true, such that we can start enough queries
       // concurrently to fill the medium queue on the coordinator.
-      const f = require("@arangodb/aql/functions")
+      const f = require("@arangodb/aql/functions");
       try {
         f.register("USER::FUNC", function() {
           const db = require("@arangodb").db;
           require("internal").wait(1);
           db._query("FOR d IN @@c RETURN d", {"@c": "UnitTestsMedQueueBlocked"});
           return 12;
-        })
+        });
         let start = new Date();
         let jobs = []; 
         for (let i = 0; i < 100; ++i) {


### PR DESCRIPTION
This PR addresses two BTS tickets:

 - https://arangodb.atlassian.net/browse/BTS-1475
 - https://arangodb.atlassian.net/browse/BTS-1486

which both describe failures and lockups actually seen in production.

The details of the problems are described in the above BTS tickets.

The solution is twofold:

 - for BTS-1475 we make it so that responses to agency poll calls are
   handled without scheduler involvement, they just trigger a wakeup
   in the thread of the AgencyCache, which does the actual processing then.
 - for BTS-1486 we use the lane `CLUSTER_INTERNAL` on the HIGH prio queue
   to receive the response to the AQL shutdown requests to the dbservers.

Both achieve to avoid the deadlocks.

This is a backport of https://github.com/arangodb/arangodb/pull/19254

### Scope & Purpose

*(Please describe the changes in this PR for reviewers, motivation, rationale - **mandatory**)*

- [*] :hankey: Bugfix

### Checklist

- [*] Tests
  - [*] **integration tests**
- [*] :book: CHANGELOG entry made
- [*] Backports
  - [*] Backport for 3.10: this is it

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [*] Enterprise PR: none
- [*] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/OASIS-25311



