### PR TITLE
[BTS-1443] Fix Github issue #19175

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,12 @@
+v3.11.2 (XXXX-XX-XX)
+--------------------
+
+* Fixed Github issue #19175.
+  This fixes a problem in traversal query optimization that was introduced
+  in 3.11 and that can lead to traversal queries being aborted with an error
+  `AQL: cannot and-combine normalized condition`.
+
+
 v3.11.1 (2023-06-12)
 --------------------
 

--- a/arangod/Aql/Condition.cpp
+++ b/arangod/Aql/Condition.cpp
@@ -662,12 +662,6 @@ std::unique_ptr<Condition> Condition::clone() const {
 /// @brief add a sub-condition to the condition
 /// the sub-condition will be AND-combined with the existing condition(s)
 void Condition::andCombine(AstNode const* node) {
-  if (_isNormalized) {
-    // already normalized
-    THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_INTERNAL,
-                                   "cannot and-combine normalized condition");
-  }
-
   if (_root == nullptr) {
     // condition was empty before
     _root = _ast->clone(node);
@@ -678,6 +672,12 @@ void Condition::andCombine(AstNode const* node) {
   }
 
   TRI_ASSERT(_root != nullptr);
+
+  // note: it seems that andCombine() is sometimes called even for
+  // conditions that have been normalized already. in this case, we
+  // clear the normalization flag again after we have modified the
+  // condition.
+  _isNormalized = false;
 }
 
 /// @brief locate indexes for each condition


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/19188

Fix an issue and added a regression test for issue #19175, found by a community user.

The issue was caused by the following:

The expected usage of an AQL `Condition` object is to append things to it via `Condition::andCombine(...)` any number of times, and then at the end call `Condition::normalize(...)` exactly once on it. And then not call `Condition::andCombine(...)` on the already normalized object anymore. This is because `andCombine(...)` will throw if it is invoked on an already normalized condition.

However, there was one glitch: up to including 3.10, an AQL `Condition` object would not set its `_isNormalized` boolean flag when calling `Conndition::normalize(...)`, so the fact that the condition was normalized was not properly recoded. This looked unintuitive and wrong. So one could normalize a condition and then end up with the Condition’s `_isNormalized` flag still being false. And any follow-up calls to `andCombine(...)` would not throw but succeed.

And exactly that behavior was changed in 3.11: whenever `Condition::normalize(...)` was called, we would now set `_isNormalized = true`. Any following calls to `andCombine(...)` would then fail, as in the issue reported by the user.

The change was believed to be ok, because all existing tests passed with the change in place.

It seems that the issue reported by the user was triggered by some traversal optimization code that tried to pull filter conditions into the traversal. And in this code, the condition was first normalized and then `andCombine(...)` was called, which violated the above assumptions. However, that traversal optimization code relies on `normalize(...)` being executed first, so we can’t make `andCombine(...)` fail here.

The solution I picked in my fix is to all invocations of `andCombine(...)` even for normalized conditions. In fact, this was already allowed before, because calling `normalize(...)` on a condition previously did not set `_isNormalized = true`. So we can now officially allow it. We can still set `_isNormalized = true` in `normalize(...)`. Additionally, after invoking `andCombine(...)` on a condition, we need to reset its `_isNormalized` flag.

This change makes the new test pass.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [x] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.11: this PR
  - [ ] Backport for 3.10: not needed
  - [ ] Backport for 3.9: not needed

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [x] Jira ticket: https://arangodb.atlassian.net/browse/BTS-1443
- [x] GitHub issue: https://github.com/arangodb/arangodb/issues/19175
- [ ] Design document: 