### PR TITLE
[3.11] Fix TimeStampTransformer

### DIFF
--- a/lib/Inspection/CMakeLists.txt
+++ b/lib/Inspection/CMakeLists.txt
@@ -1,5 +1,10 @@
 add_library(arango_inspection INTERFACE)
 
+target_link_libraries(arango_inspection
+  INTERFACE
+    date_interface
+    fmt::fmt)
+
 target_include_directories(arango_inspection
   INTERFACE
   include)

--- a/lib/Inspection/include/Inspection/Transformers.h
+++ b/lib/Inspection/include/Inspection/Transformers.h
@@ -26,21 +26,34 @@
 #include <chrono>
 #include "Basics/TimeString.h"
 #include "Basics/ErrorCode.h"
+#include "Inspection/Status.h"
+
+#include "date/date.h"
+#include "fmt/core.h"
 
 namespace arangodb::inspection {
 
 struct TimeStampTransformer {
   using SerializedType = std::string;
   using clock = std::chrono::system_clock;
+  static constexpr const char* formatString = "%FT%TZ";
   auto toSerialized(clock::time_point source, std::string& target) const
       -> inspection::Status {
-    target = timepointToString(source);
+    target = date::format(formatString, floor<std::chrono::seconds>(source));
     return {};
   }
   auto fromSerialized(std::string const& source,
                       clock::time_point& target) const -> inspection::Status {
-    target = stringToTimepoint(source);
-    return {};
+    auto in = std::istringstream{source};
+    in >> date::parse(formatString, target);
+
+    if (in.fail()) {
+      return inspection::Status(
+          fmt::format("failed to parse timestamp `{}` using format string `{}`",
+                      source, formatString));
+    } else {
+      return {};
+    }
   }
 };
 


### PR DESCRIPTION
This is a backport of #19138 and #19261

Previously the implementation of TimeStampTransformer, which takes a std::chrono::system_clock::time_point and transforms it into a string used the ArangoDB library function timepointToString.

This function in turn converted the time_point into a time_t and then
 uses TRI_gmtime to format the time_point.

If one uses std::chrono::system_clock::time_point::min() as input value to timepointToString, this yields an invalid time_t on some platforms (in particular here Windows), leading to an error in gmtime.

The ArangoDB library function ignores that error and continues.

This leads to invalid characters being left in the serialisation of the timepoint.

This PR changes the TimeStampTransformer to use formatting and parsing functions from the date.h library to perform (de)serialisation of timestamps.

It also adds some tests.

### Scope & Purpose

*(Please describe the changes in this PR for reviewers, motivation, rationale - **mandatory**)*

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*
  - [ ] Backport for 3.9: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

