### PR TITLE
APM-709 Update iresearch with wand

### DIFF
--- a/arangod/Aql/IResearchViewExecutor.h
+++ b/arangod/Aql/IResearchViewExecutor.h
@@ -289,8 +289,8 @@ class IndexReadBuffer {
   }
 
   void pushSortedValue(StorageSnapshot const& snapshot, ValueType&& value,
-                       std::span<float_t const> scores,
-                       irs::score_threshold* threshold);
+                       std::span<float_t const> scores, irs::score& score,
+                       irs::score_t& threshold);
 
   void finalizeHeapSort();
   // A note on the scores: instead of saving an array of AqlValues, we could

--- a/arangod/Aql/IResearchViewExecutor.tpp
+++ b/arangod/Aql/IResearchViewExecutor.tpp
@@ -163,6 +163,12 @@ class BufferHeapSortContext {
     return false;
   }
 
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+  bool descScore() const noexcept {
+    return !_scoresSort.empty() && !_scoresSort.front().second;
+  }
+#endif
+
  private:
   size_t _numScoreRegisters;
   std::span<std::pair<size_t, bool> const> _scoresSort;
@@ -400,11 +406,11 @@ void IndexReadBuffer<ValueType, copySorted>::finalizeHeapSort() {
 template<typename ValueType, bool copySorted>
 void IndexReadBuffer<ValueType, copySorted>::pushSortedValue(
     StorageSnapshot const& snapshot, ValueType&& value,
-    std::span<float_t const> scores, irs::score_threshold* threshold) {
+    std::span<float_t const> scores, irs::score& score,
+    irs::score_t& threshold) {
   BufferHeapSortContext sortContext(_numScoreRegisters, _scoresSort,
                                     _scoreBuffer);
   TRI_ASSERT(_maxSize);
-  TRI_ASSERT(threshold == nullptr || !scores.empty());
   if (ADB_LIKELY(!_heapSizeLeft)) {
     if (sortContext.compareInput(_rows.front(), scores.data())) {
       return;  // not interested in this document
@@ -424,11 +430,12 @@ void IndexReadBuffer<ValueType, copySorted>::pushSortedValue(
       ++bufferIt;
     }
     std::push_heap(_rows.begin(), _rows.end(), sortContext);
-    if (threshold) {
-      TRI_ASSERT(threshold->min <=
-                 _scoreBuffer[_rows.front() * _numScoreRegisters]);
-      threshold->min = _scoreBuffer[_rows.front() * _numScoreRegisters];
-    }
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+    TRI_ASSERT(!sortContext.descScore() ||
+               threshold <= _scoreBuffer[_rows.front() * _numScoreRegisters]);
+#endif
+    threshold = _scoreBuffer[_rows.front() * _numScoreRegisters];
+    score.Min(threshold);
   } else {
     _keyBuffer.emplace_back(snapshot, std::move(value));
     size_t i = 0;
@@ -1149,10 +1156,9 @@ bool IResearchViewHeapSortExecutor<ExecutionTraits>::fillBufferInternal(
 
   irs::doc_iterator::ptr itr;
   irs::document const* doc{};
-  irs::score_threshold* threshold{};
-  irs::score_t threshold_value = 0.f;
+  irs::score* scr = const_cast<irs::score*>(&irs::score::kNoScore);
   size_t numScores{0};
-  irs::score const* scr;
+  irs::score_t threshold = 0.f;
   for (size_t readerOffset = 0; readerOffset < count;) {
     if (!itr) {
       auto& segmentReader = (*this->_reader)[readerOffset];
@@ -1166,34 +1172,22 @@ bool IResearchViewHeapSortExecutor<ExecutionTraits>::fillBufferInternal(
       doc = irs::get<irs::document>(*itr);
       TRI_ASSERT(doc);
       if constexpr (ExecutionTraits::Ordered) {
-        scr = irs::get<irs::score>(*itr);
-        if (!scr) {
-          scr = &irs::score::kNoScore;
-          numScores = 0;
-          threshold = nullptr;
-        } else {
+        auto* score = irs::get_mutable<irs::score>(itr.get());
+        if (score != nullptr) {
+          scr = score;
           numScores = scores.size();
-          threshold = irs::get_mutable<irs::score_threshold>(itr.get());
-          if (threshold != nullptr && this->_wand.Enabled()) {
-            TRI_ASSERT(threshold->min == 0.f);
-            threshold->min = threshold_value;
-          } else {
-            threshold = nullptr;
-          }
+          scr->Min(threshold);
         }
       }
       itr = segmentReader.mask(std::move(itr));
       TRI_ASSERT(itr);
     }
     if (!itr->next()) {
-      if (threshold != nullptr) {
-        TRI_ASSERT(threshold_value <= threshold->min);
-        threshold_value = threshold->min;
-      }
       ++readerOffset;
       itr.reset();
       doc = nullptr;
-      scr = nullptr;
+      scr = const_cast<irs::score*>(&irs::score::kNoScore);
+      numScores = 0;
       continue;
     }
     ++_totalCount;
@@ -1204,7 +1198,7 @@ bool IResearchViewHeapSortExecutor<ExecutionTraits>::fillBufferInternal(
         this->_reader->snapshot(readerOffset),
         typename decltype(this->_indexReadBuffer)::KeyValueType(doc->value,
                                                                 readerOffset),
-        std::span{scores.data(), numScores}, threshold);
+        std::span{scores.data(), numScores}, *scr, threshold);
   }
   this->_indexReadBuffer.finalizeHeapSort();
   _bufferedCount = this->_indexReadBuffer.size();

--- a/arangod/Aql/IResearchViewNode.h
+++ b/arangod/Aql/IResearchViewNode.h
@@ -178,6 +178,7 @@ class IResearchViewNode final : public aql::ExecutionNode {
   auto& shards() noexcept { return _shards; }
 
   // Return the scorers to pass to the view.
+  auto& scorers() noexcept { return _scorers; }
   auto const& scorers() const noexcept { return _scorers; }
 
   // Return current snapshot key

--- a/tests/IResearch/ExpressionFilterTest.cpp
+++ b/tests/IResearch/ExpressionFilterTest.cpp
@@ -187,7 +187,8 @@ struct custom_sort final : public irs::ScorerBase<void> {
             ctxImpl.sort_.scorerScore(doc_id, res);
           }
         },
-        *this, segment, features, stats, doc_attrs);
+        irs::ScoreFunction::DefaultMin, *this, segment, features, stats,
+        doc_attrs);
   }
 
   irs::TermCollector::ptr prepare_term_collector() const final {
@@ -1118,7 +1119,7 @@ TEST_F(IResearchExpressionFilterTest, test) {
     EXPECT_EQ(irs::doc_limits::invalid(), docs->value());
     auto* score = irs::get<irs::score>(*docs);
     EXPECT_TRUE(score);
-    EXPECT_TRUE(*score == irs::ScoreFunction::DefaultScore);
+    EXPECT_TRUE(score->IsDefault());
 
     // set reachable filter condition
     {
@@ -1265,7 +1266,7 @@ TEST_F(IResearchExpressionFilterTest, test) {
     EXPECT_EQ(irs::doc_limits::invalid(), docs->value());
     auto* score = irs::get<irs::score>(*docs);
     EXPECT_TRUE(score);
-    EXPECT_FALSE(*score == irs::ScoreFunction::DefaultScore);
+    EXPECT_FALSE(score->IsDefault());
     auto* cost = irs::get<irs::cost>(*docs);
     ASSERT_TRUE(cost);
     EXPECT_EQ(arangodb::velocypack::ArrayIterator(testDataRoot).size(),
@@ -1389,7 +1390,7 @@ TEST_F(IResearchExpressionFilterTest, test) {
     EXPECT_EQ(irs::doc_limits::invalid(), docs->value());
     auto* score = irs::get<irs::score>(*docs);
     EXPECT_TRUE(score);
-    EXPECT_TRUE(*score == irs::ScoreFunction::DefaultScore);
+    EXPECT_TRUE(score->IsDefault());
     auto* cost = irs::get<irs::cost>(*docs);
     ASSERT_TRUE(cost);
     EXPECT_EQ(arangodb::velocypack::ArrayIterator(testDataRoot).size(),

--- a/tests/IResearch/GeoDistanceFilterTest.cpp
+++ b/tests/IResearch/GeoDistanceFilterTest.cpp
@@ -147,7 +147,8 @@ struct custom_sort final : public irs::ScorerBase<void> {
             ctxImpl.sort_.scorerScore(doc_id, res);
           }
         },
-        *this, segment, features, stats, doc_attrs);
+        irs::ScoreFunction::DefaultMin, *this, segment, features, stats,
+        doc_attrs);
   }
 
   irs::TermCollector::ptr prepare_term_collector() const final {
@@ -483,7 +484,7 @@ TEST(GeoDistanceFilterTest, query) {
 
       auto* score = irs::get<irs::score>(*it);
       EXPECT_NE(nullptr, score);
-      EXPECT_TRUE(*score == irs::ScoreFunction::DefaultScore);
+      EXPECT_TRUE(score->IsDefault());
 
       auto* doc = irs::get<irs::document>(*it);
       EXPECT_NE(nullptr, doc);
@@ -997,10 +998,10 @@ TEST(GeoDistanceFilterTest, checkScorer) {
 
       auto* score = irs::get<irs::score>(*it);
       EXPECT_NE(nullptr, score);
-      EXPECT_FALSE(*score == irs::ScoreFunction::DefaultScore);
+      EXPECT_FALSE(score->IsDefault());
       auto* seek_score = irs::get<irs::score>(*seek_it);
       EXPECT_NE(nullptr, seek_score);
-      EXPECT_FALSE(*seek_score == irs::ScoreFunction::DefaultScore);
+      EXPECT_FALSE(seek_score->IsDefault());
 
       auto* doc = irs::get<irs::document>(*it);
       EXPECT_NE(nullptr, doc);

--- a/tests/IResearch/GeoFilterTest.cpp
+++ b/tests/IResearch/GeoFilterTest.cpp
@@ -149,7 +149,8 @@ struct custom_sort final : public irs::ScorerBase<void> {
             ctxImpl.sort_.scorerScore(doc_id, res);
           }
         },
-        *this, segment, features, stats, doc_attrs);
+        irs::ScoreFunction::DefaultMin, *this, segment, features, stats,
+        doc_attrs);
   }
 
   irs::TermCollector::ptr prepare_term_collector() const final {
@@ -403,7 +404,7 @@ TEST(GeoFilterTest, query) {
 
       auto* score = irs::get<irs::score>(*it);
       EXPECT_NE(nullptr, score);
-      EXPECT_TRUE(*score == irs::ScoreFunction::DefaultScore);
+      EXPECT_TRUE(score->IsDefault());
 
       auto* doc = irs::get<irs::document>(*it);
       EXPECT_NE(nullptr, doc);
@@ -779,7 +780,7 @@ TEST(GeoFilterTest, checkScorer) {
 
       auto* score = irs::get<irs::score>(*it);
       EXPECT_NE(nullptr, score);
-      EXPECT_FALSE(*score == irs::ScoreFunction::DefaultScore);
+      EXPECT_FALSE(score->IsDefault());
 
       auto* doc = irs::get<irs::document>(*it);
       EXPECT_NE(nullptr, doc);

--- a/tests/IResearch/IResearchOrderTest.cpp
+++ b/tests/IResearch/IResearchOrderTest.cpp
@@ -103,7 +103,7 @@ struct dummy_scorer final : public irs::ScorerBase<void> {
       const irs::byte_type* /*stats*/,
       const irs::attribute_provider& /*doc_attrs*/,
       irs::score_t /*boost*/) const noexcept final {
-    return irs::ScoreFunction::Empty();
+    return irs::ScoreFunction::Default(0);
   }
 
   dummy_scorer() = default;

--- a/tests/IResearch/IResearchViewTest.cpp
+++ b/tests/IResearch/IResearchViewTest.cpp
@@ -135,7 +135,7 @@ struct DocIdScorer final : public irs::ScorerBase<void> {
           auto* state = static_cast<ScoreCtx*>(ctx);
           *res = static_cast<irs::score_t>(state->_doc->value);
         },
-        doc);
+        irs::ScoreFunction::DefaultMin, doc);
   }
 
   struct ScoreCtx : public irs::score_ctx {

--- a/tests/IResearch/common.cpp
+++ b/tests/IResearch/common.cpp
@@ -301,7 +301,7 @@ struct BoostScorer final : public irs::ScorerBase<void> {
         [](irs::score_ctx* ctx, irs::score_t* res) noexcept {
           *res = static_cast<ScoreCtx*>(ctx)->boost;
         },
-        boost);
+        irs::ScoreFunction::DefaultMin, boost);
   }
 
   static irs::Scorer::ptr make(std::string_view) {
@@ -350,7 +350,7 @@ struct CustomScorer final : public irs::ScorerBase<void> {
         [](irs::score_ctx* ctx, irs::score_t* res) noexcept {
           *res = static_cast<ScoreCtx const*>(ctx)->scoreValue;
         },
-        this->i);
+        irs::ScoreFunction::DefaultMin, this->i);
   }
 
   bool equals(irs::Scorer const& other) const noexcept final {


### PR DESCRIPTION
### Scope & Purpose

This change implement wand for conjunction, min_match and disjunction more than 2 iterators

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [x] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*
  - [ ] Backport for 3.9: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

