### PR TITLE
Show "dynamic default" hint for startup options

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 devel
 -----
 
+* If a startup option has a dynamic default value (e.g. if the default value
+  depends on the amount of available RAM), display a "dynamic default" hint
+  when invoking `--help`.
+
 * FE-229: Improve shard rebalancing UI.
 
 * FE-20: fix UI placeholder format for locale when creating analyzers.

--- a/lib/ProgramOptions/Option.cpp
+++ b/lib/ProgramOptions/Option.cpp
@@ -185,7 +185,11 @@ void Option::printHelp(std::string const& search, size_t tw, size_t ow,
       }
 
       if (!hasFlag(arangodb::options::Flags::Command)) {
-        value += " (default: " + parameter->valueString() + ")";
+        if (hasFlag(arangodb::options::Flags::Dynamic)) {
+          value += " (dynamic default: " + parameter->valueString() + ")";
+        } else {
+          value += " (default: " + parameter->valueString() + ")";
+        }
       }
       if (hasIntroducedIn()) {
         value += " (introduced in " + introducedInString() + ")";


### PR DESCRIPTION
### Scope & Purpose

Trivial change: if a startup option has a dynamic default value (e.g. if the default value depends on the amount of available RAM), display a "dynamic default" hint when invoking `--help`.

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -
  - [ ] Backport for 3.9: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 