### PR TITLE
BTS-1495 Inverted index cause incorrect plan optimization

### DIFF
--- a/arangod/Aql/Condition.cpp
+++ b/arangod/Aql/Condition.cpp
@@ -1093,7 +1093,8 @@ AstNode* Condition::removeCondition(ExecutionPlan const* plan,
 }
 
 /// @brief remove (now) invalid variables from the condition
-bool Condition::removeInvalidVariables(VarSet const& validVars) {
+bool Condition::removeInvalidVariables(VarSet const& validVars,
+                                       bool& isAllCoveredByIndex) {
   if (_root == nullptr) {
     return false;
   }
@@ -1134,6 +1135,7 @@ bool Condition::removeInvalidVariables(VarSet const& validVars) {
       }
 
       if (invalid) {
+        isAllCoveredByIndex = false;
         andNode->removeMemberUncheckedUnordered(j);
         // repeat with some member index
         TRI_ASSERT(nAnd > 0);

--- a/arangod/Aql/Condition.cpp
+++ b/arangod/Aql/Condition.cpp
@@ -1094,7 +1094,7 @@ AstNode* Condition::removeCondition(ExecutionPlan const* plan,
 
 /// @brief remove (now) invalid variables from the condition
 bool Condition::removeInvalidVariables(VarSet const& validVars,
-                                       bool& isAllCoveredByIndex) {
+                                       bool& noRemoves) {
   if (_root == nullptr) {
     return false;
   }
@@ -1135,7 +1135,7 @@ bool Condition::removeInvalidVariables(VarSet const& validVars,
       }
 
       if (invalid) {
-        isAllCoveredByIndex = false;
+        noRemoves = false;
         andNode->removeMemberUncheckedUnordered(j);
         // repeat with some member index
         TRI_ASSERT(nAnd > 0);

--- a/arangod/Aql/Condition.h
+++ b/arangod/Aql/Condition.h
@@ -166,7 +166,7 @@ class Condition {
                                     AstNode*, bool isPathCondition);
 
   /// @brief remove (now) invalid variables from the condition
-  bool removeInvalidVariables(VarSet const&);
+  bool removeInvalidVariables(VarSet const&, bool& isAllCoveredByIndex);
 
   /// @brief locate indexes which can be used for conditions
   /// return value is a pair indicating whether the index can be used for

--- a/arangod/Aql/Condition.h
+++ b/arangod/Aql/Condition.h
@@ -166,7 +166,7 @@ class Condition {
                                     AstNode*, bool isPathCondition);
 
   /// @brief remove (now) invalid variables from the condition
-  bool removeInvalidVariables(VarSet const&, bool& isAllCoveredByIndex);
+  bool removeInvalidVariables(VarSet const&, bool& noRemoves);
 
   /// @brief locate indexes which can be used for conditions
   /// return value is a pair indicating whether the index can be used for

--- a/arangod/Aql/ConditionFinder.cpp
+++ b/arangod/Aql/ConditionFinder.cpp
@@ -114,8 +114,9 @@ bool ConditionFinder::before(ExecutionNode* en) {
         break;
       }
 
+      bool isAllCoveredByIndex = true;
       auto condition = std::make_unique<Condition>(_plan->getAst());
-      bool ok = handleFilterCondition(en, condition);
+      bool ok = handleFilterCondition(en, condition, isAllCoveredByIndex);
       if (!ok) {
         break;
       }
@@ -129,9 +130,8 @@ bool ConditionFinder::before(ExecutionNode* en) {
       }
 
       std::vector<transaction::Methods::IndexHandle> usedIndexes;
-      bool oneIndexCondition{false};
       auto [filtering, sorting] = condition->findIndexes(
-          node, usedIndexes, sortCondition.get(), oneIndexCondition);
+          node, usedIndexes, sortCondition.get(), isAllCoveredByIndex);
 
       if (filtering || sorting) {
         bool descending = false;
@@ -163,10 +163,10 @@ bool ConditionFinder::before(ExecutionNode* en) {
         // We keep this node's change
         _changes.try_emplace(
             node->id(), arangodb::lazyConstruct([&] {
-              IndexNode* idx =
-                  new IndexNode(_plan, _plan->nextId(), node->collection(),
-                                node->outVariable(), usedIndexes,
-                                oneIndexCondition, std::move(condition), opts);
+              IndexNode* idx = new IndexNode(
+                  _plan, _plan->nextId(), node->collection(),
+                  node->outVariable(), usedIndexes, isAllCoveredByIndex,
+                  std::move(condition), opts);
               // if the enumerate collection node had the counting flag
               // set, we can copy it over to the index node as well
               idx->copyCountFlag(node);
@@ -196,7 +196,8 @@ bool ConditionFinder::enterSubquery(ExecutionNode*, ExecutionNode*) {
 }
 
 bool ConditionFinder::handleFilterCondition(
-    ExecutionNode* en, std::unique_ptr<Condition> const& condition) {
+    ExecutionNode* en, std::unique_ptr<Condition> const& condition,
+    bool& isAllCoveredByIndex) {
   bool foundCondition = false;
 
   for (auto& it : _variableDefinitions) {
@@ -260,7 +261,7 @@ bool ConditionFinder::handleFilterCondition(
   auto const& varsValid = en->getVarsValid();
 
   // remove all invalid variables from the condition
-  if (condition->removeInvalidVariables(varsValid)) {
+  if (condition->removeInvalidVariables(varsValid, isAllCoveredByIndex)) {
     // removing left a previously non-empty OR block empty...
     // this means we can't use the index to restrict the results
     return false;

--- a/arangod/Aql/ConditionFinder.cpp
+++ b/arangod/Aql/ConditionFinder.cpp
@@ -197,7 +197,7 @@ bool ConditionFinder::enterSubquery(ExecutionNode*, ExecutionNode*) {
 
 bool ConditionFinder::handleFilterCondition(
     ExecutionNode* en, std::unique_ptr<Condition> const& condition,
-    bool& isAllCoveredByIndex) {
+    bool& noRemoves) {
   bool foundCondition = false;
 
   for (auto& it : _variableDefinitions) {
@@ -261,7 +261,7 @@ bool ConditionFinder::handleFilterCondition(
   auto const& varsValid = en->getVarsValid();
 
   // remove all invalid variables from the condition
-  if (condition->removeInvalidVariables(varsValid, isAllCoveredByIndex)) {
+  if (condition->removeInvalidVariables(varsValid, noRemoves)) {
     // removing left a previously non-empty OR block empty...
     // this means we can't use the index to restrict the results
     return false;

--- a/arangod/Aql/ConditionFinder.h
+++ b/arangod/Aql/ConditionFinder.h
@@ -54,7 +54,8 @@ class ConditionFinder final
 
  protected:
   bool handleFilterCondition(ExecutionNode* en,
-                             std::unique_ptr<Condition> const& condition);
+                             std::unique_ptr<Condition> const& condition,
+                             bool& isAllCoveredByIndex);
   void handleSortCondition(ExecutionNode* en, Variable const* outVar,
                            std::unique_ptr<Condition> const& condition,
                            std::unique_ptr<SortCondition>& sortCondition);

--- a/arangod/Aql/ConditionFinder.h
+++ b/arangod/Aql/ConditionFinder.h
@@ -55,7 +55,7 @@ class ConditionFinder final
  protected:
   bool handleFilterCondition(ExecutionNode* en,
                              std::unique_ptr<Condition> const& condition,
-                             bool& isAllCoveredByIndex);
+                             bool& noRemoves);
   void handleSortCondition(ExecutionNode* en, Variable const* outVar,
                            std::unique_ptr<Condition> const& condition,
                            std::unique_ptr<SortCondition>& sortCondition);

--- a/arangod/Aql/IResearchViewOptimizerRules.cpp
+++ b/arangod/Aql/IResearchViewOptimizerRules.cpp
@@ -212,8 +212,8 @@ bool optimizeSearchCondition(IResearchViewNode& viewNode,
     auto const& varsValid = viewNode.getVarsValid();
 
     // remove all invalid variables from the condition
-    [[maybe_unused]] bool wasRemoval = false;
-    if (searchCondition.removeInvalidVariables(varsValid, wasRemoval)) {
+    [[maybe_unused]] bool noRemoves = true;
+    if (searchCondition.removeInvalidVariables(varsValid, noRemoves)) {
       // removing left a previously non-empty OR block empty...
       // this means we can't use the index to restrict the results
       return false;

--- a/arangod/Aql/IResearchViewOptimizerRules.cpp
+++ b/arangod/Aql/IResearchViewOptimizerRules.cpp
@@ -212,7 +212,8 @@ bool optimizeSearchCondition(IResearchViewNode& viewNode,
     auto const& varsValid = viewNode.getVarsValid();
 
     // remove all invalid variables from the condition
-    if (searchCondition.removeInvalidVariables(varsValid)) {
+    [[maybe_unused]] bool wasRemoval = false;
+    if (searchCondition.removeInvalidVariables(varsValid, wasRemoval)) {
       // removing left a previously non-empty OR block empty...
       // this means we can't use the index to restrict the results
       return false;

--- a/arangod/IResearch/IResearchFilterFactory.cpp
+++ b/arangod/IResearch/IResearchFilterFactory.cpp
@@ -4130,7 +4130,11 @@ Result FilterFactory::filter(irs::boolean_filter* filter,
   const auto res = makeFilter(filter, filterCtx, node);
 
   if (res.fail()) {
-    LOG_TOPIC("dfa15", WARN, TOPIC) << res.errorMessage();
+    if (filter) {
+      LOG_TOPIC("dfa15", WARN, TOPIC) << res.errorMessage();
+    } else {
+      LOG_TOPIC("dfa16", TRACE, TOPIC) << res.errorMessage();
+    }
   }
 
   return res;

--- a/tests/js/common/aql/aql-arangosearch-inverted-index-optimization.js
+++ b/tests/js/common/aql/aql-arangosearch-inverted-index-optimization.js
@@ -1,0 +1,128 @@
+/*jshint globalstrict:false, strict:false */
+/*global assertEqual, assertNotEqual, assertTrue, print */
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// Copyright 2023 ArangoDB GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License")
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Valery Mironov
+////////////////////////////////////////////////////////////////////////////////
+
+const jsunity = require("jsunity");
+const arangodb = require("@arangodb");
+const db = arangodb.db;
+const isServer = arangodb.isServer;
+
+function testOptimizeFilterCondition() {
+  const dbName = "OptimizeFilterCondition";
+  return {
+    setUpAll: function () {
+      db._createDatabase(dbName);
+      db._useDatabase(dbName);
+      db._createDocumentCollection("InventoryBelowMin_aggregated_contributions");
+      let data = [];
+      for (let i = 0; i !== 1000; ++i) {
+        data.push({"main_dimension_key": "pui", "FromDT": 0, "ToDT": 0});
+      }
+      data.push({"main_dimension_key": "pui", "FromDT": 1735682400000, "ToDT": 1748728800000});
+      db.InventoryBelowMin_aggregated_contributions.insert(data);
+      db.InventoryBelowMin_aggregated_contributions.ensureIndex({ type: "inverted", fields: [ "main_dimension_key" ], name: "inverted_InventoryBelowMinLevelPlanEffect" });
+  },
+
+    tearDownAll: function () {
+      db._useDatabase("_system");
+      db._dropDatabase(dbName);
+    },
+
+    testBTS1495_innerLoop: function() {
+      const query = `LET dates = ([
+        DATE_TIMESTAMP('2025-01-01T00:00:00.000+02:00'),
+        DATE_TIMESTAMP('2025-02-01T00:00:00.000+02:00'),
+        DATE_TIMESTAMP('2025-03-01T00:00:00.000+02:00'),
+        DATE_TIMESTAMP('2025-04-01T00:00:00.000+02:00'),
+        DATE_TIMESTAMP('2025-05-01T00:00:00.000+02:00'),
+        DATE_TIMESTAMP('2025-06-01T00:00:00.000+02:00'),
+      ])
+      FOR contribution IN InventoryBelowMin_aggregated_contributions
+      OPTIONS { indexHint: "inverted_InventoryBelowMinLevelPlanEffect", forceIndexHint: true }
+        FOR d IN dates
+          FILTER contribution.main_dimension_key == "pui"
+          FILTER IN_RANGE(d, contribution.FromDT, contribution.ToDT, true, false)
+          RETURN [contribution, d]`
+      let docs = db._query(query).toArray();
+      assertEqual(docs.length, 5);
+
+      if (isServer) {
+        const helper = require("@arangodb/aql-helper");
+        let plan = AQL_EXPLAIN(query);
+        plan = helper.getCompactPlan(plan);
+        let hasInRangeCalculationNode = false;
+        let hasFilter = false;
+        for (let node of plan) {
+          if (!hasInRangeCalculationNode) {
+            if (node.type == "CalculationNode" && node.expression.includes("IN_RANGE")) {
+              hasInRangeCalculationNode = true;
+            }
+          } else if (node.type == "FilterNode") {
+            hasFilter = true;
+          }
+        }
+        assertTrue(hasInRangeCalculationNode);
+        assertTrue(hasFilter);  
+      }
+    },
+
+    testBTS1495_earlyPrunning: function() {
+      const query =`LET dates = ([
+        DATE_TIMESTAMP('2025-01-01T00:00:00.000+02:00'),
+        DATE_TIMESTAMP('2025-02-01T00:00:00.000+02:00'),
+        DATE_TIMESTAMP('2025-03-01T00:00:00.000+02:00'),
+        DATE_TIMESTAMP('2025-04-01T00:00:00.000+02:00'),
+        DATE_TIMESTAMP('2025-05-01T00:00:00.000+02:00'),
+        DATE_TIMESTAMP('2025-06-01T00:00:00.000+02:00'),
+      ])
+      FOR d IN dates
+        FOR contribution IN InventoryBelowMin_aggregated_contributions
+        OPTIONS { indexHint: "inverted_InventoryBelowMinLevelPlanEffect", forceIndexHint: true }
+          FILTER contribution.main_dimension_key == "pui"
+          FILTER IN_RANGE(d, contribution.FromDT, contribution.ToDT, true, false)
+          COLLECT productLocationId = contribution._key
+          AGGREGATE maxCumulative = max(contribution.cumulative_quantity)
+          RETURN [productLocationId, maxCumulative]`;
+      let docs = db._query(query).toArray();
+      assertEqual(docs.length, 1);
+
+      if (isServer) {
+        const helper = require("@arangodb/aql-helper");
+        let plan = AQL_EXPLAIN(query);
+        plan = helper.getLinearizedPlan(plan);
+
+        let hasFilter = false;
+        for (let node of plan) {
+          if (node.type === "IndexNode" && node.filter !== undefined && node.filter.name === "IN_RANGE") {
+            hasFilter = true;
+          }
+        }
+        assertTrue(hasFilter);
+      }
+    }
+  };
+}
+
+jsunity.run(testOptimizeFilterCondition);
+
+return jsunity.done();

--- a/tests/js/common/aql/aql-arangosearch-inverted-index-optimization.js
+++ b/tests/js/common/aql/aql-arangosearch-inverted-index-optimization.js
@@ -1,5 +1,5 @@
 /*jshint globalstrict:false, strict:false */
-/*global assertEqual, assertNotEqual, assertTrue, print */
+/*global assertEqual, assertNotEqual, assertTrue, print, AQL_EXPLAIN */
 
 ////////////////////////////////////////////////////////////////////////////////
 ///
@@ -62,22 +62,21 @@ function testOptimizeFilterCondition() {
         FOR d IN dates
           FILTER contribution.main_dimension_key == "pui"
           FILTER IN_RANGE(d, contribution.FromDT, contribution.ToDT, true, false)
-          RETURN [contribution, d]`
+          RETURN [contribution, d]`;
       let docs = db._query(query).toArray();
       assertEqual(docs.length, 5);
 
       if (isServer) {
-        const helper = require("@arangodb/aql-helper");
         let plan = AQL_EXPLAIN(query);
-        plan = helper.getCompactPlan(plan);
+        plan = require("@arangodb/aql-helper").getCompactPlan(plan);
         let hasInRangeCalculationNode = false;
         let hasFilter = false;
         for (let node of plan) {
           if (!hasInRangeCalculationNode) {
-            if (node.type == "CalculationNode" && node.expression.includes("IN_RANGE")) {
+            if (node.type === "CalculationNode" && node.expression.includes("IN_RANGE")) {
               hasInRangeCalculationNode = true;
             }
-          } else if (node.type == "FilterNode") {
+          } else if (node.type === "FilterNode") {
             hasFilter = true;
           }
         }
@@ -107,9 +106,8 @@ function testOptimizeFilterCondition() {
       assertEqual(docs.length, 1);
 
       if (isServer) {
-        const helper = require("@arangodb/aql-helper");
         let plan = AQL_EXPLAIN(query);
-        plan = helper.getLinearizedPlan(plan);
+        plan = require("@arangodb/aql-helper").getLinearizedPlan(plan);
 
         let hasFilter = false;
         for (let node of plan) {


### PR DESCRIPTION
### Scope & Purpose

The aql generate plan without all filter variables, so inverted index incorrectly consider it handles all filter conditions in such case

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*
  - [ ] Backport for 3.9: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

