### PR TITLE
Avoid busy looping when locking collections with a timeout [3.10]

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,11 +1,12 @@
 v3.10.8 (XXXX-XX-XX)
 --------------------
 
+* Attempt to avoid busy looping when locking collections with a timeout
+
 * Fixed two possible deadlocks which could occur if all medium priority
   threads are busy. One is that in this case the AgencyCache could no longer
   receive updates from the agency and another that queries could no longer
   be finished. This fixes BTS-1475 and BTS-1486.
-
 
 v3.10.7 (2023-06-12)
 --------------------

--- a/arangod/RocksDBEngine/RocksDBMetaCollection.cpp
+++ b/arangod/RocksDBEngine/RocksDBMetaCollection.cpp
@@ -1659,7 +1659,7 @@ ErrorCode RocksDBMetaCollection::doLock(double timeout, AccessMode::Type mode) {
     if (now - startTime < 0.001) {
       std::this_thread::yield();
     } else {
-      std::this_thread::sleep_for(std::chrono::microseconds(waitTime));
+      std::this_thread::sleep_for(std::chrono::milliseconds(waitTime));
 
       if (waitTime < 32) {
         waitTime *= 2;


### PR DESCRIPTION
### Scope & Purpose

*Avoid busy looping when locking collections with a timeout*

- [X] :hankey: Bugfix
- [ ] :pizza: New feature
- [X] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*
  - [ ] Backport for 3.9: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

