### PR TITLE
Fixed BTS-1490

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 v3.10.8 (XXXX-XX-XX)
 --------------------
 
+* BTS-1490: query can use a lot more memory when using COLLECT WITH COUNT.
+
 * Fixed two possible deadlocks which could occur if all medium priority
   threads are busy. One is that in this case the AgencyCache could no longer
   receive updates from the agency and another that queries could no longer

--- a/arangod/Aql/ModificationExecutor.cpp
+++ b/arangod/Aql/ModificationExecutor.cpp
@@ -115,12 +115,8 @@ ModificationExecutor<FetcherType, ModifierType>::produceOrSkip(
   auto stats = ModificationStats{};
 
   auto const maxRows = std::invoke([&] {
-    if constexpr (std::is_same_v<ModifierType, UpsertModifier>) {
-      return std::min(produceOrSkipData.maxOutputRows(),
-                      _modifier->getBatchSize());
-    } else {
-      return produceOrSkipData.maxOutputRows();
-    }
+    return std::min(produceOrSkipData.maxOutputRows(),
+                    _modifier->getBatchSize());
   });
 
   // Read as much input as possible

--- a/tests/js/server/aql/aql-memory-limit.js
+++ b/tests/js/server/aql/aql-memory-limit.js
@@ -347,8 +347,50 @@ function ahuacatlMemoryLimitGraphQueriesTestSuite () {
   };
 }
 
+function ahuacatlMemoryLimitSkipTestSuite () {
+  const cn = "UnitTestsCollection";
+
+  let c;
+
+  return {
+    setUpAll : function () {
+      // only one shard because that is more predictable for memory usage
+      c = db._create(cn, { numberOfShards: 1 });
+      const payload = Array(1024).join("x");
+
+      let docs = [];
+      for (let i = 0; i < 100 * 1000; ++i) {
+        docs.push({ payload });
+        if (docs.length === 1000) {
+          c.insert(docs);
+          docs = [];
+        }
+      }
+    },
+    
+    tearDownAll : function () {
+      db._drop(cn);
+    },
+
+    testUpdate : function () {
+      const query = "FOR doc IN " + cn + " UPDATE doc WITH { foobar: 'bazbarkqux', p2: doc.payload } IN " + cn;
+      
+      let actual = AQL_EXECUTE(query, null, { memoryLimit: 5 * 1000 * 1000 }).json;
+      assertEqual(0, actual.length);
+      
+      // this checks whether the same query uses substantially more memory when followed by a COLLECT WITH COUNT INTO.
+      // this is not expected to use more memory than the original query, but due to an issue in the ModificationExecutor
+      // it actually did. This was reported in OASIS-25321.
+      actual = AQL_EXECUTE(query + " COLLECT WITH COUNT INTO c RETURN c", null, { memoryLimit: 5 * 1000 * 1000 }).json;
+      assertEqual(1, actual.length);
+      assertEqual(c.count(), actual[0]);
+    },
+  };
+}
+
 jsunity.run(ahuacatlMemoryLimitStaticQueriesTestSuite);
 jsunity.run(ahuacatlMemoryLimitReadOnlyQueriesTestSuite);
 jsunity.run(ahuacatlMemoryLimitGraphQueriesTestSuite);
+jsunity.run(ahuacatlMemoryLimitSkipTestSuite);
 
 return jsunity.done();


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/19299
Fixes https://arangodb.atlassian.net/browse/BTS-1490 (first part) and https://arangodb.atlassian.net/browse/OASIS-25321.

* BTS-1490: query can use a lot more memory when using COLLECT WITH COUNT.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [x] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.11: https://github.com/arangodb/arangodb/pull/19301
  - [x] Backport for 3.10: this PR
  - [ ] Backport for 3.9: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 