### PR TITLE
Fixes second issue of BTS-1490

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,28 @@
 v3.11.2 (XXXX-XX-XX)
 --------------------
 
+* BTS-1490: Allow performing AQL updates locally without using DISTRIBUTE in 
+  case the update AQL is of the pattern 
+
+      FOR doc IN collection
+        UPDATE <doc> IN collection
+
+  Previously the optimization was only possible if the update AQL was of the
+  pattern 
+
+      FOR doc IN collection
+        UPDATE <key> WITH <doc> IN collection
+
+  Both <key> and <doc> refer to data from the collection enumeration variable
+  `doc` here.
+
+  Also fix the optimization in case a shard key attribute is updated with a
+  value from a different attribute, e.g.
+
+     FOR doc IN collection
+       UPDATE { _key: doc.abc, abc: doc._key } IN collection
+
+  In this case the optimization was previously applied although it shouldn't.
 
 * FE-20: fix UI placeholder format for locale when creating analyzers.
 
@@ -19,7 +41,6 @@ v3.11.2 (XXXX-XX-XX)
   threads are busy. One is that in this case the AgencyCache could no longer
   receive updates from the agency and another that queries could no longer
   be finished. This fixes BTS-1475 and BTS-1486.
-
 
 
 v3.11.1 (2023-06-12)

--- a/tests/js/common/shell/shell-explain-cluster.js
+++ b/tests/js/common/shell/shell-explain-cluster.js
@@ -382,25 +382,13 @@ function ExplainSuite () {
       assertEqual(cn, node.collection);
 
       node = nodes[2];
-      assertEqual("RemoteNode", node.type);
-
-      node = nodes[3];
-      assertEqual("GatherNode", node.type);
-
-      node = nodes[4];
-      assertEqual("DistributeNode", node.type);
-
-      node = nodes[5];
-      assertEqual("RemoteNode", node.type);
-
-      node = nodes[6];
       assertEqual("UpdateNode", node.type);
       assertEqual(cn, node.collection);
 
-      node = nodes[7];
+      node = nodes[3];
       assertEqual("RemoteNode", node.type);
 
-      node = nodes[8];
+      node = nodes[4];
       assertEqual("GatherNode", node.type);
     },
 
@@ -421,25 +409,13 @@ function ExplainSuite () {
       assertEqual(cn, node.collection);
 
       node = nodes[2];
-      assertEqual("RemoteNode", node.type);
-
-      node = nodes[3];
-      assertEqual("GatherNode", node.type);
-
-      node = nodes[4];
-      assertEqual("DistributeNode", node.type);
-
-      node = nodes[5];
-      assertEqual("RemoteNode", node.type);
-
-      node = nodes[6];
       assertEqual("UpdateNode", node.type);
       assertEqual(cn, node.collection);
 
-      node = nodes[7];
+      node = nodes[3];
       assertEqual("RemoteNode", node.type);
 
-      node = nodes[8];
+      node = nodes[4];
       assertEqual("GatherNode", node.type);
     },
 


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/19306

Fixed "note 2" from https://arangodb.atlassian.net/browse/BTS-1490.

* BTS-1490: Allow performing AQL updates locally without using DISTRIBUTE in case the update AQL is of the pattern

      FOR doc IN collection
        UPDATE <doc> IN collection

  Previously the optimization was only possible if the update AQL was of the pattern

      FOR doc IN collection
        UPDATE <key> WITH <doc> IN collection

  Both <key> and <doc> refer to data from the collection enumeration variable `doc` here.

  Also fix the optimization in case a shard key attribute is updated with a value from a different attribute, e.g.

     FOR doc IN collection
       UPDATE { _key: doc.abc, abc: doc._key } IN collection

  In this case the optimization was previously applied although it shouldn't.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [x] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.11: this PR
  - [x] Backport for 3.10: https://github.com/arangodb/arangodb/pull/19308
  - [ ] Backport for 3.9: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [x] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/BTS-1490
- [ ] Design document: