### PR TITLE
Fixes second issue of BTS-1490

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,29 @@
 v3.10.8 (XXXX-XX-XX)
 --------------------
 
+* BTS-1490: Allow performing AQL updates locally without using DISTRIBUTE in 
+  case the update AQL is of the pattern 
+
+      FOR doc IN collection
+        UPDATE <doc> IN collection
+
+  Previously the optimization was only possible if the update AQL was of the
+  pattern 
+
+      FOR doc IN collection
+        UPDATE <key> WITH <doc> IN collection
+
+  Both <key> and <doc> refer to data from the collection enumeration variable
+  `doc` here.
+
+  Also fix the optimization in case a shard key attribute is updated with a
+  value from a different attribute, e.g.
+
+     FOR doc IN collection
+       UPDATE { _key: doc.abc, abc: doc._key } IN collection
+
+  In this case the optimization was previously applied although it shouldn't.
+
 * Fixed two possible deadlocks which could occur if all medium priority
   threads are busy. One is that in this case the AgencyCache could no longer
   receive updates from the agency and another that queries could no longer

--- a/arangod/Aql/OptimizerRules.cpp
+++ b/arangod/Aql/OptimizerRules.cpp
@@ -5380,8 +5380,18 @@ class RemoveToEnumCollFinder final
           toRemove =
               ExecutionNode::castTo<ReplaceNode const*>(en)->inKeyVariable();
         } else if (en->getType() == EN::UPDATE) {
+          // first try if we have the pattern UPDATE <key> WITH <doc> IN
+          // collection. if so, then toRemove will contain <key>.
           toRemove =
               ExecutionNode::castTo<UpdateNode const*>(en)->inKeyVariable();
+
+          if (toRemove == nullptr) {
+            // if we don't have that pattern, we can if instead have
+            // UPDATE <doc> IN collection.
+            // in this case toRemove will contain <doc>.
+            toRemove =
+                ExecutionNode::castTo<UpdateNode const*>(en)->inDocVariable();
+          }
         } else if (en->getType() == EN::REMOVE) {
           toRemove = ExecutionNode::castTo<RemoveNode const*>(en)->inVariable();
         } else {
@@ -5437,8 +5447,8 @@ class RemoveToEnumCollFinder final
             for (auto const& it : shardKeys) {
               toFind.emplace(it);
             }
-            // for REMOVE, we must also know the _key value, otherwise
-            // REMOVE will not work
+            // for UPDATE/REPLACE/REMOVE, we must also know the _key value,
+            // otherwise they will not work.
             toFind.emplace(arangodb::StaticStrings::KeyString);
 
             // go through the input object attribute by attribute
@@ -5453,14 +5463,17 @@ class RemoveToEnumCollFinder final
                 continue;
               }
 
-              auto it = toFind.find(sub->getString());
+              std::string attributeName = sub->getString();
+              auto it = toFind.find(attributeName);
 
               if (it != toFind.end()) {
                 // we found one of the shard keys!
                 // remove the attribute from our to-do list
                 auto value = sub->getMember(0);
 
-                if (value->type == NODE_TYPE_ATTRIBUTE_ACCESS) {
+                // check if we have something like: { key: source.key }
+                if (value->type == NODE_TYPE_ATTRIBUTE_ACCESS &&
+                    value->getStringView() == attributeName) {
                   // check if all values for the shard keys are referring to
                   // the same FOR loop variable
                   auto var = value->getMember(0);

--- a/tests/js/common/shell/shell-explain-cluster.js
+++ b/tests/js/common/shell/shell-explain-cluster.js
@@ -382,25 +382,13 @@ function ExplainSuite () {
       assertEqual(cn, node.collection);
 
       node = nodes[2];
-      assertEqual("RemoteNode", node.type);
-
-      node = nodes[3];
-      assertEqual("GatherNode", node.type);
-
-      node = nodes[4];
-      assertEqual("DistributeNode", node.type);
-
-      node = nodes[5];
-      assertEqual("RemoteNode", node.type);
-
-      node = nodes[6];
       assertEqual("UpdateNode", node.type);
       assertEqual(cn, node.collection);
 
-      node = nodes[7];
+      node = nodes[3];
       assertEqual("RemoteNode", node.type);
 
-      node = nodes[8];
+      node = nodes[4];
       assertEqual("GatherNode", node.type);
     },
 
@@ -421,25 +409,13 @@ function ExplainSuite () {
       assertEqual(cn, node.collection);
 
       node = nodes[2];
-      assertEqual("RemoteNode", node.type);
-
-      node = nodes[3];
-      assertEqual("GatherNode", node.type);
-
-      node = nodes[4];
-      assertEqual("DistributeNode", node.type);
-
-      node = nodes[5];
-      assertEqual("RemoteNode", node.type);
-
-      node = nodes[6];
       assertEqual("UpdateNode", node.type);
       assertEqual(cn, node.collection);
 
-      node = nodes[7];
+      node = nodes[3];
       assertEqual("RemoteNode", node.type);
 
-      node = nodes[8];
+      node = nodes[4];
       assertEqual("GatherNode", node.type);
     },
 


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/19306

Fixed "note 2" from https://arangodb.atlassian.net/browse/BTS-1490.

* BTS-1490: Allow performing AQL updates locally without using DISTRIBUTE in case the update AQL is of the pattern

      FOR doc IN collection
        UPDATE <doc> IN collection

  Previously the optimization was only possible if the update AQL was of the pattern

      FOR doc IN collection
        UPDATE <key> WITH <doc> IN collection

  Both <key> and <doc> refer to data from the collection enumeration variable `doc` here.

  Also fix the optimization in case a shard key attribute is updated with a value from a different attribute, e.g.

     FOR doc IN collection
       UPDATE { _key: doc.abc, abc: doc._key } IN collection

  In this case the optimization was previously applied although it shouldn't.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [x] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.11: https://github.com/arangodb/arangodb/pull/19307
  - [ ] Backport for 3.10: this PR
  - [ ] Backport for 3.9: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [x] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/BTS-1490
- [ ] Design document: