### PR TITLE
Fixed wrong changelog entry

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,11 +4,10 @@ v3.10.9 (XXXX-XX-XX)
 * Add a `description` field to OptimizerRule and dump the explanations via the
   `GET /_api/query/rules` endpoint.
 
-
-v3.10.8 (XXXX-XX-XX)
---------------------
-
 * Attempt to avoid busy looping when locking collections with a timeout
+
+v3.10.8 (2023-06-23)
+--------------------
 
 * Fixed two possible deadlocks which could occur if all medium priority
   threads are busy. One is that in this case the AgencyCache could no longer


### PR DESCRIPTION
### Scope & Purpose

Set date in CHANGELOG and moved wrong entry to 3.10.9

- [X] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*
  - [ ] Backport for 3.9: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

