### PR TITLE
clean up temporary backup directory if backup fails

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 devel
 -----
 
+* Remove temporary `CREATING_{number}` directories from hot backup in case a
+  hot backup runs into an error.
+
 * Added new startup options `--cache.ideal-lower-fill-ratio` and 
   `--cache.ideal-upper-fill-ratio` to control the minimum and maximum fill
   ratios for cache tables that trigger shrinking and growing of the table


### PR DESCRIPTION
### Scope & Purpose

Enterprise companion PR: https://github.com/arangodb/enterprise/pull/1307

when a hot backup is executed, it will store data in a temporary directoy named `CREATING_{number}`, where `{number}` is a number between 1m and 2m. If the backup succeeds, the temporary directory is given a name that contains both a timestamp and the backup id. but if the hot backup fails in the middle, the temporary directory is left behind. as the leftover directory contains backups, this can lead to large amounts of disk space being used for it or the files that it still links to.
this change now removes the temporary directory in case the hot backup goes wrong.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [x] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.11: https://github.com/arangodb/arangodb/pull/19330
  - [x] Backport for 3.10: https://github.com/arangodb/arangodb/pull/19331
  - [x] Backport for 3.9: https://github.com/arangodb/arangodb/pull/19332

#### Related Information

- [ ] Docs PR: 
- [x] Enterprise PR: https://github.com/arangodb/enterprise/pull/1307
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 