### PR TITLE
clean up temporary backup directory if backup fails

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 v3.10.9 (XXXX-XX-XX)
 --------------------
 
+* Remove temporary `CREATING_{number}` directories from hot backup in case a
+  hot backup runs into an error.
 
 * BTS-1490: Allow performing AQL updates locally without using DISTRIBUTE in 
   case the update AQL is of the pattern 
@@ -31,6 +33,7 @@ v3.10.9 (XXXX-XX-XX)
 * Attempt to avoid busy looping when locking collections with a timeout
 
 * BTS-1490: query can use a lot more memory when using COLLECT WITH COUNT.
+
 
 v3.10.8 (2023-06-23)
 --------------------


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/19329
Enterprise companion PR: https://github.com/arangodb/enterprise/pull/1309

when a hot backup is executed, it will store data in a temporary directoy named CREATING_{number}, where {number} is a number between 1m and 2m. If the backup succeeds, the temporary directory is given a name that contains both a timestamp and the backup id. but if the hot backup fails in the middle, the temporary directory is left behind. as the leftover directory contains backups, this can lead to large amounts of disk space being used for it or the files that it still links to.
this change now removes the temporary directory in case the hot backup goes wrong.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [x] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.11: https://github.com/arangodb/arangodb/pull/19330
  - [x] Backport for 3.10: this PR
  - [x] Backport for 3.9: https://github.com/arangodb/arangodb/pull/19332

#### Related Information

- [ ] Docs PR: 
- [x] Enterprise PR: https://github.com/arangodb/enterprise/pull/1309
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 