### PR TITLE
adjust options for RocksDB WAL file deletion

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,20 @@
 devel
 -----
 
+* Set threshold for RocksDB automatic WAL file deletion by age from 30 days
+  to 30 years.
+  This should effectively not change any behavior, as we don't rely on 
+  RocksDB's built-in WAL file deletion mechanism. Instead, we tell RocksDB
+  explicitly to delete which WAL files, depending on what other functionality
+  (e.g. replication, index creation) still needs them or not.
+
+* Deprecate the startup option `--rocksdb.wal-archive-size-limit` because
+  it can be unsafe to use in environments that use replication (cluster,
+  active failover, single-to-single replication). When using the option and
+  limiting the total size of the WAL files in the archive, this may lead
+  to still-needed WAL files being pruned too early. This can have side
+  effects, such as aborting ongoing replication or index creation attempts.
+
 * Added new startup options `--cache.ideal-lower-fill-ratio` and 
   `--cache.ideal-upper-fill-ratio` to control the minimum and maximum fill
   ratios for cache tables that trigger shrinking and growing of the table

--- a/arangod/RocksDBEngine/RocksDBEngine.cpp
+++ b/arangod/RocksDBEngine/RocksDBEngine.cpp
@@ -719,6 +719,7 @@ exit code if there is an error in any of the .sst files.)");
                       arangodb::options::Flags::OnDBServer,
                       arangodb::options::Flags::OnSingle,
                       arangodb::options::Flags::Uncommon))
+      .setDeprecatedIn(31200)
       .setLongDescription(R"(A value of `0` does not restrict the size of the
 archive, so the leader removes archived WAL files when there are no replication
 clients needing them. Any non-zero value restricts the size of the WAL files
@@ -742,7 +743,11 @@ You can use the option to force a deletion of WAL files from the archive even if
 there are followers attached that may want to read the archive. In case the
 option is set and a leader deletes files from the archive that followers want to
 read, this aborts the replication on the followers. Followers can restart the
-replication doing a resync, however.)");
+replication doing a resync, though, but they may not be able to catch up if WAL
+file deletion happens too early.
+
+Thus it is best to leave this option at its default value of `0` except in cases
+when disk size is very constrained and no replication is used.)");
 
   options
       ->addOption("--rocksdb.auto-flush-min-live-wal-files",

--- a/arangod/RocksDBEngine/RocksDBOptionFeature.cpp
+++ b/arangod/RocksDBEngine/RocksDBOptionFeature.cpp
@@ -1800,11 +1800,10 @@ rocksdb::Options RocksDBOptionFeature::doGetOptions() const {
     result.db_write_buffer_size = _totalWriteBufferSize;
   }
 
-  // WAL_ttl_seconds needs to be bigger than the sync interval of the count
-  // manager. Should be several times bigger counter_sync_seconds
-  result.WAL_ttl_seconds = 60 * 60 * 24 * 30;  // we manage WAL file deletion
-  // ourselves, don't let RocksDB
-  // garbage collect them
+  // we manage WAL file deletion ourselves, don't let RocksDB garbage-collect
+  // obsolete files.
+  result.WAL_ttl_seconds =
+      933120000;  // ~30 years (60 * 60 * 24 * 30 * 12 * 30)
   result.WAL_size_limit_MB = 0;
   result.memtable_prefix_bloom_size_ratio = 0.2;  // TODO: pick better value?
   // TODO: enable memtable_insert_with_hint_prefix_extractor?

--- a/lib/ApplicationFeatures/OptionsCheckFeature.cpp
+++ b/lib/ApplicationFeatures/OptionsCheckFeature.cpp
@@ -53,7 +53,8 @@ void OptionsCheckFeature::prepare() {
         if (option.hasDeprecatedIn()) {
           LOG_TOPIC("78b1e", WARN, Logger::STARTUP)
               << "option '" << option.displayName() << "' is deprecated since "
-              << option.deprecatedInString();
+              << option.deprecatedInString()
+              << " and may be removed or unsupported in a future version";
         }
       },
       true, true);


### PR DESCRIPTION
### Scope & Purpose

Adjust options for RocksDB WAL file deletion as follows:

* Set threshold for RocksDB automatic WAL file deletion by age from 30 days to 30 years. This should effectively not change any behavior, as we don't rely on RocksDB's built-in WAL file deletion mechanism. Instead, we tell RocksDB explicitly to delete which WAL files, depending on what other functionality (e.g. replication, index creation) still needs them or not.

* Deprecate the startup option `--rocksdb.wal-archive-size-limit` because it can be unsafe to use in environments that use replication (cluster, active failover, single-to-single replication). When using the option and limiting the total size of the WAL files in the archive, this may lead to still-needed WAL files being pruned too early. This can have side effects, such as aborting ongoing replication or index creation attempts.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -
  - [ ] Backport for 3.9: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 