### PR TITLE
Try to make cluster tests tsan run more useful

### DIFF
--- a/arangod/Agency/Supervision.cpp
+++ b/arangod/Agency/Supervision.cpp
@@ -2919,7 +2919,7 @@ void Supervision::checkReplicatedLogs() {
 
   envelope.done();
   if (builder.slice().length() > 0) {
-    _shouldRunAgain = true;
+    notify();
     write_ret_t res = _agent->write(builder.slice());
     if (!res.successful()) {
       LOG_TOPIC("12d36", WARN, Logger::SUPERVISION)
@@ -2965,7 +2965,7 @@ void Supervision::checkCollectionGroups() {
 
   envelope.done();
   if (builder.slice().length() > 0) {
-    _shouldRunAgain = true;
+    notify();
     write_ret_t res = _agent->write(builder.slice());
     if (!res.successful()) {
       LOG_TOPIC("12f36", WARN, Logger::SUPERVISION)

--- a/arangod/Metrics/ClusterMetricsFeature.cpp
+++ b/arangod/Metrics/ClusterMetricsFeature.cpp
@@ -253,11 +253,11 @@ bool ClusterMetricsFeature::writeData(uint64_t version,
     return false;
   }
   auto metrics = parse(std::move(raw).get());
-  bool const currEmpty = metrics.values.empty();
-  if (currEmpty && _prevEmpty) {
+  bool currEmpty = metrics.values.empty();
+  bool prevEmpty = _prevEmpty.exchange(currEmpty, std::memory_order_relaxed);
+  if (currEmpty && prevEmpty) {
     return true;
   }
-  _prevEmpty = currEmpty;
   velocypack::Builder builder;
   builder.openObject();
   builder.add("ServerId", VPackValue{ServerState::instance()->getId()});
@@ -286,7 +286,7 @@ bool ClusterMetricsFeature::readData(futures::Try<LeaderResponse>&& raw) {
   }
   auto data = Data::fromVPack(metrics);
   data->packed = std::move(raw).get();
-  _prevEmpty = data->metrics.values.empty();
+  _prevEmpty.store(data->metrics.values.empty(), std::memory_order_relaxed);
   std::atomic_store_explicit(&_data, std::move(data),
                              std::memory_order_release);
   return true;

--- a/arangod/Metrics/ClusterMetricsFeature.h
+++ b/arangod/Metrics/ClusterMetricsFeature.h
@@ -166,7 +166,8 @@ class ClusterMetricsFeature final : public ArangodFeature {
   bool wasStop() const noexcept;
 
   // We don't want to update constantly empty data
-  bool _prevEmpty{true};
+  // It should be atomic only because write_global could cause parallel update
+  std::atomic_bool _prevEmpty{true};
   std::shared_ptr<Data> _data;
   Scheduler::WorkHandle _update;
   Scheduler::WorkHandle _timer;

--- a/arangod/Pregel/PregelFeature.cpp
+++ b/arangod/Pregel/PregelFeature.cpp
@@ -531,13 +531,16 @@ void PregelFeature::beginShutdown() {
   std::unique_lock guard{_mutex};
   _gcHandle.reset();
 
+  for (auto& it : _conductors) {
+    it.second.conductor->_shutdown = true;
+  }
+
   auto cs = _conductors;
   auto ws = _workers;
   guard.unlock();
 
   // cancel all conductors and workers
   for (auto& it : cs) {
-    it.second.conductor->_shutdown = true;
     it.second.conductor->cancel();
   }
   for (auto it : ws) {

--- a/tsan_arangodb_suppressions.txt
+++ b/tsan_arangodb_suppressions.txt
@@ -30,6 +30,8 @@ thread:DatabaseFeature::start
 
 # TODO Fix lock order inversion
 deadlock:consensus::Agent::setPersistedState
+deadlock:replication2::replicated_log::LogLeader::triggerAsyncReplication
+deadlock:replication2::replicated_state::ReplicatedStateManager
 
 # TODO Fix data race in arangodbtests
 race:DummyConnection::sendRequest

--- a/tsan_arangodb_suppressions.txt
+++ b/tsan_arangodb_suppressions.txt
@@ -11,15 +11,6 @@ race:SharedAqlItemBlockPtr::operator->
 signal:lib/Basics/CrashHandler.cpp
 signal:crashHandlerSignalHandler
 
-# accesses to the function pointers can be racy
-# this is most likely benign, but strictly speaking it is still UB so should be
-# addressed eventually
-race:3rdParty/velocypack/src/asm-functions.cpp
-race:doInitCopy
-race:doInitCopyCheckUtf8
-race:doInitSkip
-race:doInitValidateUtf8String
-
 # A compiler optimization in DBImpl::ReleaseSnapshot() produces code where a
 # register is populated with different addresses based on some condition, and
 # this register is later read to populate the variable `oldest_snapshot`.
@@ -42,12 +33,3 @@ deadlock:consensus::Agent::setPersistedState
 
 # TODO Fix data race in arangodbtests
 race:DummyConnection::sendRequest
-
-# TODO It's "false positive" caused by code:
-# 1. ctx_lock lock
-# 2. ctx_lock unlock; wait_for on ctx_lock; ctx_lock lock
-# 3. s[i].flush_mutex lock
-# 4. ctx_lock unlock; wait_for on ctx_lock; ctx_lock lock
-# 5. s[i + 1].flush_mutex lock
-# It should be fixed in future, because current code doing a lot unnecessary stuff
-deadlock:irs::IndexWriter::FlushPending


### PR DESCRIPTION
### Scope & Purpose

* Suppress very popular and easy to reproduce replication2 lock order inversions
  These errors make all report unreadable because they spam it
* Fix 3 simple data races
* Remove already unnecessary suppressions

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*
  - [ ] Backport for 3.9: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

