### PR TITLE
[APM-750] Fix some data races

### DIFF
--- a/arangod/Replication2/ReplicatedLog/Components/AppendEntriesManager.cpp
+++ b/arangod/Replication2/ReplicatedLog/Components/AppendEntriesManager.cpp
@@ -51,12 +51,12 @@ auto AppendEntriesManager::appendEntries(AppendEntriesRequest request)
           .with<logContextKeyPrevLogIdx>(request.prevLogEntry);
   LOG_CTX("7f407", TRACE, lctx) << "receiving append entries";
 
+  auto self = shared_from_this();  // required for coroutine to keep this alive
   Guarded<GuardedData>::mutex_guard_type guard = guarded.getLockedGuard();
   if (guard->resigned) {
     throw ParticipantResignedException(
         TRI_ERROR_REPLICATION_REPLICATED_LOG_FOLLOWER_RESIGNED, ADB_HERE);
   }
-  auto self = shared_from_this();  // required for coroutine to keep this alive
   auto requestGuard = guard->requestInFlight.acquire();
   if (not requestGuard) {
     LOG_CTX("58043", INFO, lctx)

--- a/client-tools/Import/SenderThread.cpp
+++ b/client-tools/Import/SenderThread.cpp
@@ -109,9 +109,12 @@ bool SenderThread::isDone() {
 }
 
 void SenderThread::run() {
-  while (!isStopping() && !_hasError) {
+  while (!isStopping()) {
     {
       std::unique_lock guard{_condition.mutex};
+      if (_hasError) {
+        break;
+      }
       _ready = true;
       if (_idle) {
         _condition.cv.wait(guard);

--- a/tsan_arangodb_suppressions.txt
+++ b/tsan_arangodb_suppressions.txt
@@ -30,7 +30,7 @@ thread:DatabaseFeature::start
 
 # TODO Fix lock order inversion
 deadlock:consensus::Agent::setPersistedState
-# TODO BTS-1502: should be fixed or explaining here why it's false positive
+# TODO BTS-1502: should be fixed or explained here why it's false positive
 deadlock:replication2::replicated_log::LogLeader::triggerAsyncReplication
 deadlock:replication2::replicated_state::ReplicatedStateManager
 

--- a/tsan_arangodb_suppressions.txt
+++ b/tsan_arangodb_suppressions.txt
@@ -30,8 +30,12 @@ thread:DatabaseFeature::start
 
 # TODO Fix lock order inversion
 deadlock:consensus::Agent::setPersistedState
+# TODO BTS-1502: should be fixed or explaining here why it's false positive
 deadlock:replication2::replicated_log::LogLeader::triggerAsyncReplication
 deadlock:replication2::replicated_state::ReplicatedStateManager
 
 # TODO Fix data race in arangodbtests
 race:DummyConnection::sendRequest
+
+# TODO BTS-1501: should be fixed 
+race:setCacheEnabled

--- a/tsan_arangodb_suppressions.txt
+++ b/tsan_arangodb_suppressions.txt
@@ -30,12 +30,12 @@ thread:DatabaseFeature::start
 
 # TODO Fix lock order inversion
 deadlock:consensus::Agent::setPersistedState
-# TODO BTS-1502: should be fixed or explained here why it's false positive
+# TODO BTS-1503: should be fixed or explained here why it's false positive
 deadlock:replication2::replicated_log::LogLeader::triggerAsyncReplication
 deadlock:replication2::replicated_state::ReplicatedStateManager
 
 # TODO Fix data race in arangodbtests
 race:DummyConnection::sendRequest
 
-# TODO BTS-1501: should be fixed 
+# TODO BTS-1502: should be fixed 
 race:setCacheEnabled


### PR DESCRIPTION
### Scope & Purpose

Try to make cluster tsan blue except known issues.

https://jenkins.arangodb.biz/job/arangodb-ANY-linux-san.x86-64/1946/EDITION=enterprise,SAN_MODE=TSan,STORAGE_ENGINE=rocksdb,TEST_SUITE=cluster,limit=linux&&test&&x86-64/

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*
  - [ ] Backport for 3.9: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

