### PR TITLE
Checkout enterprise only when building enterprise

### DIFF
--- a/.circleci/base_config.yml
+++ b/.circleci/base_config.yml
@@ -157,8 +157,11 @@ jobs:
             git checkout $CIRCLE_SHA1
             git submodule init
             git submodule update --recursive --depth 1 --jobs 8
-      - checkout-enterprise:
-          destination: "/root/project/enterprise"
+      - when:
+          condition: << parameters.enterprise >>
+          steps:
+            - checkout-enterprise:
+                destination: "/root/project/enterprise"
       - run:
           name: Print SCCache Settings
           command: sccache -s


### PR DESCRIPTION
### Scope & Purpose

This change is just a micro-optimisation to checkout the enterprise repository only when compiling enterprise.