### PR TITLE
[CINFRA-777] Report syncIndex to the leader

### DIFF
--- a/arangod/Replication2/ReplicatedLog/Components/AppendEntriesManager.cpp
+++ b/arangod/Replication2/ReplicatedLog/Components/AppendEntriesManager.cpp
@@ -65,7 +65,8 @@ auto AppendEntriesManager::appendEntries(AppendEntriesRequest request)
         termInfo->term, request.messageId,
         AppendEntriesErrorReason{
             AppendEntriesErrorReason::ErrorType::kPrevAppendEntriesInFlight},
-        guard->snapshot.checkSnapshotState() == SnapshotState::AVAILABLE);
+        guard->snapshot.checkSnapshotState() == SnapshotState::AVAILABLE,
+        guard->storage.getSyncIndex());
   }
 
   if (auto error = guard->preflightChecks(request, *termInfo, lctx); error) {
@@ -87,7 +88,8 @@ auto AppendEntriesManager::appendEntries(AppendEntriesRequest request)
         LOG_CTX("c0981", ERR, lctx) << "failed to persist: " << result;
         co_return AppendEntriesResult::withPersistenceError(
             termInfo->term, request.messageId, result,
-            guard->snapshot.checkSnapshotState() == SnapshotState::AVAILABLE);
+            guard->snapshot.checkSnapshotState() == SnapshotState::AVAILABLE,
+            guard->storage.getSyncIndex());
       }
     }
   }
@@ -116,7 +118,8 @@ auto AppendEntriesManager::appendEntries(AppendEntriesRequest request)
         LOG_CTX("0982a", ERR, lctx) << "failed to persist: " << result;
         co_return AppendEntriesResult::withPersistenceError(
             termInfo->term, request.messageId, result,
-            guard->snapshot.checkSnapshotState() == SnapshotState::AVAILABLE);
+            guard->snapshot.checkSnapshotState() == SnapshotState::AVAILABLE,
+            guard->storage.getSyncIndex());
       }
       store = guard->storage.transaction();
     }
@@ -140,7 +143,8 @@ auto AppendEntriesManager::appendEntries(AppendEntriesRequest request)
             << "failed to persist new entries: " << result;
         co_return AppendEntriesResult::withPersistenceError(
             termInfo->term, request.messageId, result,
-            guard->snapshot.checkSnapshotState() == SnapshotState::AVAILABLE);
+            guard->snapshot.checkSnapshotState() == SnapshotState::AVAILABLE,
+            guard->storage.getSyncIndex());
       }
     }
   }
@@ -150,12 +154,13 @@ auto AppendEntriesManager::appendEntries(AppendEntriesRequest request)
       guard->snapshot.checkSnapshotState() == SnapshotState::AVAILABLE;
   auto action =
       guard->stateHandle.updateCommitIndex(request.leaderCommit, hasSnapshot);
+  auto syncIndex = guard->storage.getSyncIndex();
   guard.unlock();
   action.fire();
   requestGuard.reset();
   LOG_CTX("f5ecd", TRACE, lctx) << "append entries successful";
   co_return AppendEntriesResult::withOk(termInfo->term, request.messageId,
-                                        hasSnapshot);
+                                        hasSnapshot, syncIndex);
 }
 
 AppendEntriesManager::AppendEntriesManager(
@@ -199,7 +204,8 @@ auto AppendEntriesManager::GuardedData::preflightChecks(
         << " found " << request.leaderTerm;
     return AppendEntriesResult::withRejection(
         termInfo.term, request.messageId,
-        {AppendEntriesErrorReason::ErrorType::kWrongTerm}, false);
+        {AppendEntriesErrorReason::ErrorType::kWrongTerm}, false,
+        storage.getSyncIndex());
   }
 
   if (not messageIdManager.acceptReceivedMessageId(request.messageId)) {
@@ -209,7 +215,8 @@ auto AppendEntriesManager::GuardedData::preflightChecks(
         << messageIdManager.getLastReceivedMessageId();
     return AppendEntriesResult::withRejection(
         termInfo.term, request.messageId,
-        {AppendEntriesErrorReason::ErrorType::kMessageOutdated}, false);
+        {AppendEntriesErrorReason::ErrorType::kMessageOutdated}, false,
+        storage.getSyncIndex());
   }
 
   if (request.leaderId != termInfo.leader) {
@@ -218,7 +225,8 @@ auto AppendEntriesManager::GuardedData::preflightChecks(
         << termInfo.leader.value_or("<none>") << " found " << request.leaderId;
     return AppendEntriesResult::withRejection(
         termInfo.term, request.messageId,
-        {AppendEntriesErrorReason::ErrorType::kInvalidLeaderId}, false);
+        {AppendEntriesErrorReason::ErrorType::kInvalidLeaderId}, false,
+        storage.getSyncIndex());
   }
 
   // It is always allowed to replace the log entirely
@@ -232,7 +240,8 @@ auto AppendEntriesManager::GuardedData::preflightChecks(
           << "rejecting append entries - log conflict - reason "
           << to_string(reason) << " next " << next;
       return AppendEntriesResult::withConflict(termInfo.term, request.messageId,
-                                               next, false);
+                                               next, false,
+                                               storage.getSyncIndex());
     }
   }
 

--- a/arangod/Replication2/ReplicatedLog/LogLeader.cpp
+++ b/arangod/Replication2/ReplicatedLog/LogLeader.cpp
@@ -1040,6 +1040,10 @@ auto replicated_log::LogLeader::GuardedLeaderData::handleAppendEntriesResponse(
             response.snapshotAvailable, response.messageId);
       }
 
+      TRI_ASSERT(response.syncIndex >= follower.syncIndex)
+          << response.syncIndex << " vs. " << follower.syncIndex;
+      follower.syncIndex = response.syncIndex;
+
       follower.lastErrorReason = response.reason;
       if (response.isSuccess()) {
         follower.numErrorsSinceLastAnswer = 0;

--- a/arangod/Replication2/ReplicatedLog/LogLeader.cpp
+++ b/arangod/Replication2/ReplicatedLog/LogLeader.cpp
@@ -1276,7 +1276,7 @@ auto replicated_log::LogLeader::LocalFollower::appendEntries(
 
   auto returnAppendEntriesResult =
       [term = request.leaderTerm, messageId = request.messageId,
-       logContext = messageLogContext,
+       storageManager = _storageManager, logContext = messageLogContext,
        measureTime = std::move(measureTimeGuard)](Result const& res) mutable {
         // fire here because the lambda is destroyed much later in a future
         measureTime.fire();
@@ -1287,7 +1287,8 @@ auto replicated_log::LogLeader::LocalFollower::appendEntries(
         }
         LOG_CTX("e0800", TRACE, logContext)
             << "local follower completed append entries";
-        return AppendEntriesResult{term, messageId, true};
+        return AppendEntriesResult{term, messageId, true,
+                                   storageManager->getSyncIndex()};
       };
 
   LOG_CTX("6fa8b", TRACE, messageLogContext)

--- a/arangod/Replication2/ReplicatedLog/LogLeader.h
+++ b/arangod/Replication2/ReplicatedLog/LogLeader.h
@@ -193,6 +193,7 @@ class LogLeader : public std::enable_shared_from_this<LogLeader>,
     LogIndex nextPrevLogIndex = LogIndex{0};
     LogIndex lastAckedCommitIndex = LogIndex{0};
     LogIndex lastAckedLowestIndexToKeep = LogIndex{0};
+    LogIndex syncIndex = LogIndex{0};
     MessageId lastSentMessageId{0};
     std::size_t numErrorsSinceLastAnswer = 0;
     AppendEntriesErrorReason lastErrorReason;

--- a/arangod/Replication2/ReplicatedLog/NetworkMessages.cpp
+++ b/arangod/Replication2/ReplicatedLog/NetworkMessages.cpp
@@ -170,6 +170,7 @@ void replicated_log::AppendEntriesResult::toVelocyPack(
     reason.toVelocyPack(builder);
     builder.add("messageId", VPackValue(messageId));
     builder.add("snapshotAvailable", VPackValue(snapshotAvailable));
+    builder.add("syncIndex", VPackValue(syncIndex));
     if (conflict.has_value()) {
       TRI_ASSERT(errorCode ==
                  TRI_ERROR_REPLICATION_REPLICATED_LOG_APPEND_ENTRIES_REJECTED);
@@ -188,84 +189,102 @@ auto replicated_log::AppendEntriesResult::fromVelocyPack(
   auto reason = AppendEntriesErrorReason::fromVelocyPack(slice.get("reason"));
   auto messageId = slice.get("messageId").extract<MessageId>();
   auto snapshotAvailable = slice.get("snapshotAvailable").isTrue();
+  auto syncIndex = slice.get("syncIndex").extract<LogIndex>();
 
   if (reason.error == AppendEntriesErrorReason::ErrorType::kNoPrevLogMatch) {
     TRI_ASSERT(errorCode ==
                TRI_ERROR_REPLICATION_REPLICATED_LOG_APPEND_ENTRIES_REJECTED);
     auto conflict = slice.get("conflict");
     TRI_ASSERT(conflict.isObject());
-    return AppendEntriesResult{logTerm, messageId,
+    return AppendEntriesResult{logTerm,
+                               messageId,
                                TermIndexPair::fromVelocyPack(conflict),
-                               std::move(reason), snapshotAvailable};
+                               std::move(reason),
+                               snapshotAvailable,
+                               syncIndex};
   }
 
   TRI_ASSERT(errorCode == TRI_ERROR_NO_ERROR ||
              reason.error != AppendEntriesErrorReason::ErrorType::kNone);
-  return AppendEntriesResult{logTerm, errorCode, reason, messageId,
-                             snapshotAvailable};
+  return AppendEntriesResult{logTerm,   errorCode,         reason,
+                             messageId, snapshotAvailable, syncIndex};
 }
 
 replicated_log::AppendEntriesResult::AppendEntriesResult(
     LogTerm logTerm, ErrorCode errorCode, AppendEntriesErrorReason reason,
-    MessageId id, bool snapshotAvailable) noexcept
+    MessageId id, bool snapshotAvailable, LogIndex syncIndex) noexcept
     : logTerm(logTerm),
       errorCode(errorCode),
       reason(std::move(reason)),
       messageId(id),
-      snapshotAvailable(snapshotAvailable) {
+      snapshotAvailable(snapshotAvailable),
+      syncIndex(syncIndex) {
   static_assert(std::is_nothrow_move_constructible_v<AppendEntriesErrorReason>);
   TRI_ASSERT(errorCode == TRI_ERROR_NO_ERROR ||
              reason.error != AppendEntriesErrorReason::ErrorType::kNone);
 }
 
 replicated_log::AppendEntriesResult::AppendEntriesResult(
-    LogTerm logTerm, MessageId id, bool snapshotAvailable) noexcept
+    LogTerm logTerm, MessageId id, bool snapshotAvailable,
+    LogIndex syncIndex) noexcept
     : AppendEntriesResult(logTerm, TRI_ERROR_NO_ERROR, {}, id,
-                          snapshotAvailable) {}
+                          snapshotAvailable, syncIndex) {}
 
 replicated_log::AppendEntriesResult::AppendEntriesResult(
     LogTerm term, replicated_log::MessageId id, TermIndexPair conflict,
-    AppendEntriesErrorReason reason, bool snapshotAvailable) noexcept
+    AppendEntriesErrorReason reason, bool snapshotAvailable,
+    LogIndex syncIndex) noexcept
     : AppendEntriesResult(
           term, TRI_ERROR_REPLICATION_REPLICATED_LOG_APPEND_ENTRIES_REJECTED,
-          std::move(reason), id, snapshotAvailable) {
+          std::move(reason), id, snapshotAvailable, syncIndex) {
   static_assert(std::is_nothrow_move_constructible_v<AppendEntriesErrorReason>);
   this->conflict = conflict;
 }
 
 auto replicated_log::AppendEntriesResult::withConflict(
     LogTerm term, replicated_log::MessageId id, TermIndexPair conflict,
-    bool snapshotAvailable) noexcept -> replicated_log::AppendEntriesResult {
+    bool snapshotAvailable, LogIndex syncIndex) noexcept
+    -> replicated_log::AppendEntriesResult {
   return {term,
           id,
           conflict,
           {AppendEntriesErrorReason::ErrorType::kNoPrevLogMatch},
-          snapshotAvailable};
+          snapshotAvailable,
+          syncIndex};
 }
 
 auto replicated_log::AppendEntriesResult::withRejection(
     LogTerm term, MessageId id, AppendEntriesErrorReason reason,
-    bool snapshotAvailable) noexcept -> AppendEntriesResult {
+    bool snapshotAvailable, LogIndex syncIndex) noexcept
+    -> AppendEntriesResult {
   static_assert(std::is_nothrow_move_constructible_v<AppendEntriesErrorReason>);
-  return {term, TRI_ERROR_REPLICATION_REPLICATED_LOG_APPEND_ENTRIES_REJECTED,
-          std::move(reason), id, snapshotAvailable};
+  return {term,
+          TRI_ERROR_REPLICATION_REPLICATED_LOG_APPEND_ENTRIES_REJECTED,
+          std::move(reason),
+          id,
+          snapshotAvailable,
+          syncIndex};
 }
 
 auto replicated_log::AppendEntriesResult::withPersistenceError(
     LogTerm term, replicated_log::MessageId id, Result const& res,
-    bool snapshotAvailable) noexcept -> replicated_log::AppendEntriesResult {
+    bool snapshotAvailable, LogIndex syncIndex) noexcept
+    -> replicated_log::AppendEntriesResult {
   return {term,
           res.errorNumber(),
           {AppendEntriesErrorReason::ErrorType::kPersistenceFailure,
            std::string{res.errorMessage()}},
           id,
-          snapshotAvailable};
+          snapshotAvailable,
+          syncIndex};
 }
 
-auto replicated_log::AppendEntriesResult::withOk(
-    LogTerm term, replicated_log::MessageId id, bool snapshotAvailable) noexcept
+auto replicated_log::AppendEntriesResult::withOk(LogTerm term,
+                                                 replicated_log::MessageId id,
+                                                 bool snapshotAvailable,
+                                                 LogIndex syncIndex) noexcept
     -> replicated_log::AppendEntriesResult {
-  return {term, id, snapshotAvailable};
+  return {term, id, snapshotAvailable, syncIndex};
 }
 
 auto replicated_log::AppendEntriesResult::isSuccess() const noexcept -> bool {

--- a/arangod/Replication2/ReplicatedLog/NetworkMessages.h
+++ b/arangod/Replication2/ReplicatedLog/NetworkMessages.h
@@ -108,31 +108,35 @@ struct AppendEntriesResult {
   //      this should be an optional<bool>.
   bool snapshotAvailable{false};
 
+  LogIndex syncIndex;
+
   std::optional<TermIndexPair> conflict;
 
   [[nodiscard]] auto isSuccess() const noexcept -> bool;
 
   AppendEntriesResult(LogTerm term, MessageId id, TermIndexPair conflict,
-                      AppendEntriesErrorReason reason,
-                      bool snapshotAvailable) noexcept;
-  AppendEntriesResult(LogTerm, MessageId, bool snapshotAvailable) noexcept;
+                      AppendEntriesErrorReason reason, bool snapshotAvailable,
+                      LogIndex syncIndex) noexcept;
+  AppendEntriesResult(LogTerm, MessageId, bool snapshotAvailable,
+                      LogIndex syncIndex) noexcept;
   AppendEntriesResult(LogTerm logTerm, ErrorCode errorCode,
                       AppendEntriesErrorReason reason, MessageId,
-                      bool snapshotAvailable) noexcept;
+                      bool snapshotAvailable, LogIndex syncIndex) noexcept;
   void toVelocyPack(velocypack::Builder& builder) const;
   static auto fromVelocyPack(velocypack::Slice slice) -> AppendEntriesResult;
 
   static auto withConflict(LogTerm, MessageId, TermIndexPair conflict,
-                           bool snapshotAvailable) noexcept
+                           bool snapshotAvailable, LogIndex syncIndex) noexcept
       -> AppendEntriesResult;
   static auto withRejection(LogTerm, MessageId, AppendEntriesErrorReason,
-                            bool snapshotAvailable) noexcept
+                            bool snapshotAvailable, LogIndex syncIndex) noexcept
       -> AppendEntriesResult;
   static auto withPersistenceError(LogTerm, MessageId, Result const&,
-                                   bool snapshotAvailable) noexcept
+                                   bool snapshotAvailable,
+                                   LogIndex syncIndex) noexcept
       -> AppendEntriesResult;
-  static auto withOk(LogTerm, MessageId, bool snapshotAvailable) noexcept
-      -> AppendEntriesResult;
+  static auto withOk(LogTerm, MessageId, bool snapshotAvailable,
+                     LogIndex syncIndex) noexcept -> AppendEntriesResult;
 };
 #if (defined(__GNUC__) && !defined(__clang__))
 #pragma GCC diagnostic pop

--- a/tests/Replication2/ReplicatedLog/LogFollower/AppendEntriesTest.cpp
+++ b/tests/Replication2/ReplicatedLog/LogFollower/AppendEntriesTest.cpp
@@ -50,6 +50,16 @@ struct ReplicatedStateHandleMock : IReplicatedStateHandle {
               (const, override));
 };
 
+auto generateEntries(LogTerm term, LogRange range)
+    -> AppendEntriesRequest::EntryContainer {
+  auto tr = AppendEntriesRequest::EntryContainer::transient_type{};
+  for (auto idx : range) {
+    tr.push_back(InMemoryLogEntry{
+        PersistingLogEntry{term, idx, LogPayload::createFromString("foo")}});
+  }
+  return tr.persistent();
+}
+
 }  // namespace
 
 struct AppendEntriesFollowerTest : ::testing::Test {
@@ -60,18 +70,7 @@ struct AppendEntriesFollowerTest : ::testing::Test {
   std::shared_ptr<test::SyncScheduler> scheduler =
       std::make_shared<test::SyncScheduler>();
 
-  storage::test::FakeStorageEngineMethodsContext storage{
-      objectId,
-      logId,
-      executor,
-      {LogIndex{1}, LogIndex{100}},
-      storage::PersistedStateInfo{
-          .stateId = logId,
-          .snapshot = {.status = SnapshotStatus::kCompleted,
-                       .timestamp = {},
-                       .error = {}},
-          .generation = {},
-          .specification = {}}};
+  std::shared_ptr<storage::test::FakeStorageEngineMethodsContext> storage;
 
   std::shared_ptr<ReplicatedLogGlobalSettings> options =
       std::make_shared<ReplicatedLogGlobalSettings>();
@@ -86,10 +85,26 @@ struct AppendEntriesFollowerTest : ::testing::Test {
 
   auto makeFollowerManager() {
     return std::make_shared<FollowerManager>(
-        storage.getMethods(),
+        storage->getMethods(),
         std::unique_ptr<ReplicatedStateHandleMock>(stateHandle), termInfo,
         options, metrics, nullptr, scheduler,
         LoggerContext{Logger::REPLICATION2});
+  }
+
+  void SetUp() override {
+    storage = std::make_shared<storage::test::FakeStorageEngineMethodsContext>(
+        storage::test::FakeStorageEngineMethodsContext{
+            objectId,
+            logId,
+            executor,
+            {LogIndex{1}, LogIndex{100}},
+            storage::PersistedStateInfo{
+                .stateId = logId,
+                .snapshot = {.status = SnapshotStatus::kCompleted,
+                             .timestamp = {},
+                             .error = {}},
+                .generation = {},
+                .specification = {}}});
   }
 };
 
@@ -192,6 +207,57 @@ TEST_F(AppendEntriesFollowerTest, append_entries_no_match) {
   }
 }
 
+TEST_F(AppendEntriesFollowerTest, append_entries_update_syncIndex) {
+  termInfo->leader = "leader";
+  termInfo->term = LogTerm{1};
+  options->_thresholdLogCompaction = 0;
+
+  auto methods = std::unique_ptr<IReplicatedLogFollowerMethods>{};
+  EXPECT_CALL(*stateHandle, becomeFollower)
+      .Times(1)
+      .WillOnce([&](auto&& newMethods) { methods = std::move(newMethods); });
+  auto follower = makeFollowerManager();
+  methods->releaseIndex(LogIndex{50});  // allow compaction upto 50
+
+  EXPECT_CALL(*stateHandle, updateCommitIndex(LogIndex{55})).Times(1);
+
+  auto oldMessageId = ++lastMessageId;
+
+  {
+    AppendEntriesRequest request;
+    request.messageId = ++lastMessageId;
+    request.lowestIndexToKeep = LogIndex{40};  // compaction up to 40
+    request.leaderCommit = LogIndex{55};
+    request.leaderId = "leader";
+    request.leaderTerm = LogTerm{1};
+    request.prevLogEntry = TermIndexPair{LogTerm{1}, LogIndex{99}};
+    request.entries =
+        generateEntries(LogTerm{1}, LogRange{LogIndex{100}, LogIndex{120}});
+    auto result = follower->appendEntries(request).get();
+    EXPECT_TRUE(result.isSuccess());
+    EXPECT_EQ(result.syncIndex, LogIndex{119});
+  }
+
+  EXPECT_EQ(storage->log.begin()->first, LogIndex{40});    // compacted
+  EXPECT_EQ(storage->log.rbegin()->first, LogIndex{119});  // [40, 120)
+
+  // We report the correct syncIndex even in case of an append entries error
+  {
+    AppendEntriesRequest request;
+    request.messageId = oldMessageId;
+    request.lowestIndexToKeep = LogIndex{40};
+    request.leaderCommit = LogIndex{55};
+    request.leaderId = "leader";
+    request.leaderTerm = LogTerm{1};
+    request.prevLogEntry = TermIndexPair{LogTerm{1}, LogIndex{119}};
+    request.entries =
+        generateEntries(LogTerm{1}, LogRange{LogIndex{230}, LogIndex{240}});
+    auto result = follower->appendEntries(request).get();
+    EXPECT_FALSE(result.isSuccess());
+    EXPECT_EQ(result.syncIndex, LogIndex{119});
+  }
+}
+
 TEST_F(AppendEntriesFollowerTest, append_entries_trigger_compaction) {
   termInfo->leader = "leader";
   termInfo->term = LogTerm{1};
@@ -220,21 +286,9 @@ TEST_F(AppendEntriesFollowerTest, append_entries_trigger_compaction) {
   }
 
   // we expect compaction to happen
-  ASSERT_FALSE(storage.log.empty());
-  EXPECT_EQ(storage.log.begin()->first, LogIndex{50});
+  ASSERT_FALSE(storage->log.empty());
+  EXPECT_EQ(storage->log.begin()->first, LogIndex{50});
 }
-
-namespace {
-auto generateEntries(LogTerm term, LogRange range)
-    -> AppendEntriesRequest::EntryContainer {
-  auto tr = AppendEntriesRequest::EntryContainer::transient_type{};
-  for (auto idx : range) {
-    tr.push_back(InMemoryLogEntry{
-        PersistingLogEntry{term, idx, LogPayload::createFromString("foo")}});
-  }
-  return tr.persistent();
-}
-}  // namespace
 
 TEST_F(AppendEntriesFollowerTest, append_entries_trigger_snapshot) {
   termInfo->leader = "leader";
@@ -268,10 +322,10 @@ TEST_F(AppendEntriesFollowerTest, append_entries_trigger_snapshot) {
 
   // we expect the snapshot to be invalidated
   // and the log truncated
-  ASSERT_FALSE(storage.log.empty());
-  EXPECT_EQ(storage.log.begin()->first, LogIndex{200});
-  ASSERT_TRUE(storage.meta.has_value());
-  EXPECT_EQ(storage.meta->snapshot.status, SnapshotStatus::kInvalidated);
+  ASSERT_FALSE(storage->log.empty());
+  EXPECT_EQ(storage->log.begin()->first, LogIndex{200});
+  ASSERT_TRUE(storage->meta.has_value());
+  EXPECT_EQ(storage->meta->snapshot.status, SnapshotStatus::kInvalidated);
 }
 
 TEST_F(AppendEntriesFollowerTest, append_entries_rewrite) {
@@ -305,9 +359,9 @@ TEST_F(AppendEntriesFollowerTest, append_entries_rewrite) {
 
   // we expect the snapshot to be invalidated
   // and the log truncated
-  ASSERT_FALSE(storage.log.empty());
-  EXPECT_EQ(storage.log.begin()->first, LogIndex{40});   // compacted
-  EXPECT_EQ(storage.log.rbegin()->first, LogIndex{59});  // [40, 60)
+  ASSERT_FALSE(storage->log.empty());
+  EXPECT_EQ(storage->log.begin()->first, LogIndex{40});   // compacted
+  EXPECT_EQ(storage->log.rbegin()->first, LogIndex{59});  // [40, 60)
 }
 
 TEST_F(AppendEntriesFollowerTest, outdated_message_id) {


### PR DESCRIPTION
### Scope & Purpose

Followers report their `syncIndex` to the leader (in the `AppendEntriesResponse`), and let the leader track it for all participants.

This is the continuation of https://github.com/arangodb/arangodb/pull/19285

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**