### PR TITLE
[DUMP] Retry on write, read and connect errors

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 v3.10.9 (2023-06-30)
 --------------------
 
+* Enforce that server always returns an empty body if the return code is 204.
+
 * Arangodump retries dump requests in more cases: read, write and connection
   errors.
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 v3.10.9 (2023-06-30)
 --------------------
 
+* Arangodump retries dump requests in more cases: read, write and connection
+  errors.
+
 * When trying to read multiple documents, the coordinator will now handle empty
   lists gracefully and return an empty result set instead of an error.
 

--- a/arangod/Agency/Job.cpp
+++ b/arangod/Agency/Job.cpp
@@ -40,8 +40,6 @@
 #include "Basics/voc-errors.h"
 #include "Random/RandomGenerator.h"
 
-static std::string const DBServer = "DBServer";
-
 namespace arangodb {
 namespace consensus {
 

--- a/arangod/Agency/Supervision.cpp
+++ b/arangod/Agency/Supervision.cpp
@@ -2977,7 +2977,6 @@ bool Supervision::start(Agent* agent) {
   return start();
 }
 
-static std::string const syncLatest = "/Sync/LatestID";
 
 void Supervision::getUniqueIds() {
   _lock.assertLockedByCurrentThread();

--- a/arangod/Agency/Supervision.cpp
+++ b/arangod/Agency/Supervision.cpp
@@ -2977,7 +2977,6 @@ bool Supervision::start(Agent* agent) {
   return start();
 }
 
-
 void Supervision::getUniqueIds() {
   _lock.assertLockedByCurrentThread();
 

--- a/arangod/Cluster/TraverserEngine.cpp
+++ b/arangod/Cluster/TraverserEngine.cpp
@@ -51,11 +51,9 @@ using namespace arangodb::graph;
 using namespace arangodb::traverser;
 
 static const std::string OPTIONS = "options";
-static const std::string INACCESSIBLE = "inaccessible";
 static const std::string SHARDS = "shards";
 static const std::string EDGES = "edges";
 static const std::string TYPE = "type";
-static const std::string VARIABLES = "variables";
 static const std::string VERTICES = "vertices";
 
 #ifndef USE_ENTERPRISE

--- a/arangod/GeneralServer/H2CommTask.cpp
+++ b/arangod/GeneralServer/H2CommTask.cpp
@@ -658,8 +658,6 @@ void H2CommTask<T>::sendResponse(std::unique_ptr<GeneralResponse> res,
 
   // handle response code 204 No Content
   if (tmp->responseCode() == rest::ResponseCode::NO_CONTENT) {
-    TRI_ASSERT(tmp->isResponseEmpty())
-        << "response code 204 requires body to be empty";
     tmp->clearBody();  // in non maintainer build clear the body
   }
 

--- a/arangod/GeneralServer/H2CommTask.cpp
+++ b/arangod/GeneralServer/H2CommTask.cpp
@@ -656,6 +656,13 @@ void H2CommTask<T>::sendResponse(std::unique_ptr<GeneralResponse> res,
 
   auto* tmp = static_cast<H2Response*>(res.get());
 
+  // handle response code 204 No Content
+  if (tmp->responseCode() == rest::ResponseCode::NO_CONTENT) {
+    TRI_ASSERT(tmp->isResponseEmpty())
+        << "response code 204 requires body to be empty";
+    tmp->clearBody();  // in non maintainer build clear the body
+  }
+
   if (Logger::isEnabled(LogLevel::TRACE, Logger::REQUESTS) &&
       Logger::logRequestParameters()) {
     auto& bodyBuf = tmp->body();

--- a/arangod/GeneralServer/HttpCommTask.cpp
+++ b/arangod/GeneralServer/HttpCommTask.cpp
@@ -600,6 +600,13 @@ void HttpCommTask<T>::sendResponse(std::unique_ptr<GeneralResponse> baseRes,
   // will add CORS headers if necessary
   this->finishExecution(*baseRes, _origin);
 
+  // handle response code 204 No Content
+  if (response.responseCode() == rest::ResponseCode::NO_CONTENT) {
+    TRI_ASSERT(response.isResponseEmpty())
+        << "response code 204 requires body to be empty";
+    response.clearBody();  // in non maintainer build clear the body
+  }
+
   _header.clear();
   _header.reserve(220);
 
@@ -700,6 +707,9 @@ void HttpCommTask<T>::sendResponse(std::unique_ptr<GeneralResponse> baseRes,
   }
 
   size_t len = response.bodySize();
+  TRI_ASSERT(response.responseCode() != rest::ResponseCode::NO_CONTENT ||
+             len == 0)
+      << "response code 204 requires body length to be zero";
   _header.append(std::string_view("Content-Length: "));
   _header.append(std::to_string(len));
   _header.append("\r\n\r\n", 4);
@@ -707,6 +717,9 @@ void HttpCommTask<T>::sendResponse(std::unique_ptr<GeneralResponse> baseRes,
   TRI_ASSERT(_response == nullptr);
   _response = response.stealBody();
   // append write buffer and statistics
+  TRI_ASSERT(response.responseCode() != rest::ResponseCode::NO_CONTENT ||
+             _response->empty())
+      << "response code 204 requires body length to be zero";
 
   if (Logger::isEnabled(LogLevel::TRACE, Logger::REQUESTS) &&
       Logger::logRequestParameters()) {

--- a/arangod/GeneralServer/HttpCommTask.cpp
+++ b/arangod/GeneralServer/HttpCommTask.cpp
@@ -602,8 +602,6 @@ void HttpCommTask<T>::sendResponse(std::unique_ptr<GeneralResponse> baseRes,
 
   // handle response code 204 No Content
   if (response.responseCode() == rest::ResponseCode::NO_CONTENT) {
-    TRI_ASSERT(response.isResponseEmpty())
-        << "response code 204 requires body to be empty";
     response.clearBody();  // in non maintainer build clear the body
   }
 

--- a/arangod/GeneralServer/HttpCommTask.cpp
+++ b/arangod/GeneralServer/HttpCommTask.cpp
@@ -602,7 +602,7 @@ void HttpCommTask<T>::sendResponse(std::unique_ptr<GeneralResponse> baseRes,
 
   // handle response code 204 No Content
   if (response.responseCode() == rest::ResponseCode::NO_CONTENT) {
-    response.clearBody();  // in non maintainer build clear the body
+    response.clearBody();
   }
 
   _header.clear();

--- a/arangod/Pregel/Algos/RecoveringPageRank.cpp
+++ b/arangod/Pregel/Algos/RecoveringPageRank.cpp
@@ -37,7 +37,6 @@ static float EPS = 0.00001f;
 static std::string const kConvergence = "convergence";
 static std::string const kStep = "step";
 static std::string const kRank = "rank";
-static std::string const kFailedCount = "failedCount";
 static std::string const kNonFailedCount = "nonfailedCount";
 static std::string const kScale = "scale";
 

--- a/arangod/RestHandler/RestDumpHandler.cpp
+++ b/arangod/RestHandler/RestDumpHandler.cpp
@@ -285,7 +285,7 @@ void RestDumpHandler::handleCommandDumpNext() {
 
   if (batch == nullptr) {
     // all batches have been received
-    return generateOk(rest::ResponseCode::NO_CONTENT, VPackSlice::noneSlice());
+    return resetResponse(rest::ResponseCode::NO_CONTENT);
   }
 
   // output the batch value

--- a/arangod/RestHandler/RestReplicationHandler.cpp
+++ b/arangod/RestHandler/RestReplicationHandler.cpp
@@ -90,7 +90,6 @@ using Helper = arangodb::basics::VelocyPackHelper;
 
 namespace {
 std::string const dataString("data");
-std::string const keyString("key");
 std::string const typeString("type");
 }  // namespace
 

--- a/client-tools/Dump/DumpFeature.cpp
+++ b/client-tools/Dump/DumpFeature.cpp
@@ -1412,6 +1412,33 @@ void DumpFeature::start() {
   }
 }
 
+namespace {
+bool shouldRetryRequest(httpclient::SimpleHttpResult const* response,
+                        Result const& check) {
+  if (response != nullptr) {
+    // check for retryable errors in simple http client
+    switch (response->getResultType()) {
+      case httpclient::SimpleHttpResult::COULD_NOT_CONNECT:
+        std::this_thread::sleep_for(std::chrono::milliseconds(500));
+        return true;
+      case httpclient::SimpleHttpResult::WRITE_ERROR:
+      case httpclient::SimpleHttpResult::READ_ERROR:
+        return true;  // retry loop
+      default:
+        break;
+    }
+  }
+
+  if (check.is(TRI_ERROR_CLUSTER_TIMEOUT) ||
+      check.is(TRI_ERROR_HTTP_GATEWAY_TIMEOUT)) {
+    // retry
+    return true;
+  }
+
+  return false;
+}
+}  // namespace
+
 void DumpFeature::ParallelDumpServer::createDumpContext(
     httpclient::SimpleHttpClient& client) {
   VPackBuilder builder;
@@ -1429,19 +1456,36 @@ void DumpFeature::ParallelDumpServer::createDumpContext(
   }
 
   auto bodystr = builder.toJson();
+  size_t retryCount = 100;
 
   auto url = basics::StringUtils::concatT("_api/dump/start?dbserver=", server);
-  std::unique_ptr<arangodb::httpclient::SimpleHttpResult> response(
-      client.request(arangodb::rest::RequestType::POST, url, bodystr.c_str(),
-                     bodystr.size(), {}));
+  std::unique_ptr<arangodb::httpclient::SimpleHttpResult> response;
+  while (true) {
+    response.reset(client.request(arangodb::rest::RequestType::POST, url,
+                                  bodystr.c_str(), bodystr.size(), {}));
 
-  auto check = ::arangodb::HttpResponseChecker::check(client.getErrorMessage(),
-                                                      response.get());
-  if (check.fail()) {
-    LOG_TOPIC("bdecf", FATAL, Logger::DUMP)
-        << "failed to create dump context on server " << server << ": "
-        << check.errorMessage();
-    FATAL_ERROR_EXIT();
+    auto check = ::arangodb::HttpResponseChecker::check(
+        client.getErrorMessage(), response.get());
+    if (check.fail()) {
+      LOG_TOPIC("45d6e", ERR, Logger::DUMP)
+          << "An error occurred while creating a dump context on '" << server
+          << "': " << check.errorMessage();
+      bool const retry = shouldRetryRequest(response.get(), check);
+
+      if (retry && --retryCount > 0) {
+        continue;
+      }
+
+      if (retryCount == 0) {
+        LOG_TOPIC("7a3e4", ERR, Logger::DUMP) << "Too many connection errors.";
+      }
+      LOG_TOPIC("bdecf", FATAL, Logger::DUMP)
+          << "failed to create dump context on server " << server << ": "
+          << check.errorMessage();
+      FATAL_ERROR_EXIT();
+    } else {
+      break;
+    }
   }
 
   bool headerExtracted;
@@ -1576,6 +1620,8 @@ DumpFeature::ParallelDumpServer::receiveNextBatch(
     url += "&lastBatch=" + std::to_string(*lastBatch);
   }
 
+  std::size_t retryCounter = 100;
+
   while (true) {
     std::unique_ptr<arangodb::httpclient::SimpleHttpResult> response(
         client.request(arangodb::rest::RequestType::POST, url, nullptr, 0, {}));
@@ -1586,12 +1632,11 @@ DumpFeature::ParallelDumpServer::receiveNextBatch(
           << "An error occurred while dumping from server '" << server
           << "': " << check.errorMessage();
 
-      // TODO complete this list!
-      if (check.is(TRI_ERROR_CLUSTER_TIMEOUT) ||
-          check.is(TRI_ERROR_HTTP_GATEWAY_TIMEOUT)) {
-        // retry
-        continue;
-      } else {
+      bool const retry = shouldRetryRequest(response.get(), check);
+      if (!retry || --retryCounter == 0) {
+        if (retryCounter == 0) {
+          LOG_TOPIC("684ee", FATAL, Logger::DUMP) << "Too many network errors.";
+        }
         LOG_TOPIC("5cb01", FATAL, Logger::DUMP)
             << "Unrecoverable network/http error: " << check.errorMessage();
         FATAL_ERROR_EXIT();

--- a/client-tools/Dump/DumpFeature.cpp
+++ b/client-tools/Dump/DumpFeature.cpp
@@ -1643,8 +1643,14 @@ DumpFeature::ParallelDumpServer::receiveNextBatch(
       }
     } else if (response->getHttpReturnCode() == 204) {
       return nullptr;
+    } else if (response->getHttpReturnCode() == 200) {
+      return response;
+    } else {
+      LOG_TOPIC("2668f", FATAL, Logger::DUMP)
+          << "Got invalid return code: " << response->getHttpReturnCode() << " "
+          << response->getHttpReturnMessage();
+      FATAL_ERROR_EXIT();
     }
-    return response;
   }
 }
 

--- a/client-tools/Dump/DumpFeature.cpp
+++ b/client-tools/Dump/DumpFeature.cpp
@@ -1547,6 +1547,8 @@ Result DumpFeature::ParallelDumpServer::run(
 
   printBlockStats();
 
+  LOG_TOPIC("1b7fe", INFO, Logger::DUMP) << "all data received for " << server;
+
   return Result{};
 }
 
@@ -1566,7 +1568,7 @@ void DumpFeature::ParallelDumpServer::ParallelDumpServer::printBlockStats() {
     msg += std::to_string(blockCounter[i]);
   }
 
-  LOG_TOPIC("d1349", INFO, Logger::DUMP) << "block counter " << msg;
+  LOG_TOPIC("d1349", DEBUG, Logger::DUMP) << "block counter " << msg;
 }
 
 void DumpFeature::ParallelDumpServer::ParallelDumpServer::countBlocker(

--- a/lib/Rest/HttpResponse.h
+++ b/lib/Rest/HttpResponse.h
@@ -72,6 +72,11 @@ class HttpResponse : public GeneralResponse {
   // you should call writeHeader only after the body has been created
   void writeHeader(basics::StringBuffer*);  // override;
 
+  void clearBody() noexcept {
+    _body->clear();
+    _bodySize = 0;
+  }
+
  public:
   void reset(ResponseCode code) override final;
 

--- a/lib/SimpleHttpClient/SimpleHttpClient.cpp
+++ b/lib/SimpleHttpClient/SimpleHttpClient.cpp
@@ -740,6 +740,14 @@ void SimpleHttpClient::processHeader() {
         return;
       }
 
+      else if (_result->getHttpReturnCode() == 204) {
+        _result->setResultType(SimpleHttpResult::COMPLETE);
+        _state = FINISHED;
+        // always disconnect - some servers include a response body
+        _connection->disconnect();
+        return;
+      }
+
       // no content-length header in response
       else if (!_result->hasContentLength()) {
         _state = IN_READ_BODY;

--- a/lib/SimpleHttpClient/SimpleHttpClient.cpp
+++ b/lib/SimpleHttpClient/SimpleHttpClient.cpp
@@ -740,7 +740,9 @@ void SimpleHttpClient::processHeader() {
         return;
       }
 
-      else if (_result->getHttpReturnCode() == 204) {
+      else if (_result->getHttpReturnCode() == 204 &&
+               _result->hasContentLength() &&
+               _result->getContentLength() != 0) {
         _result->setResultType(SimpleHttpResult::COMPLETE);
         _state = FINISHED;
         // always disconnect - some servers include a response body

--- a/tests/js/client/server_permissions/test-foxx-service-access-denied.js
+++ b/tests/js/client/server_permissions/test-foxx-service-access-denied.js
@@ -126,7 +126,7 @@ function testSuite() {
          const url = endpoint + mount + "/environment-variables-get-path";
          const res = download(url);
          assertEqual(204, res.code);
-         assertEqual("undefined", res.body);
+         assertEqual("", res.body);
        }
        { // modify
          const url = endpoint + mount + "/environment-variables-set-path";
@@ -138,7 +138,7 @@ function testSuite() {
          const url = endpoint + mount + "/environment-variables-get-path";
          const res = download(url);
          assertEqual(204, res.code);
-         assertEqual("undefined", res.body);
+         assertEqual("", res.body);
        }
      },
 
@@ -146,7 +146,7 @@ function testSuite() {
        const url = endpoint + mount + "/startup-options-log-file";
        const res = download(url);
        assertEqual(204, res.code);
-       assertEqual("undefined", res.body);
+       assertEqual("", res.body);
      },
 
      testReadServiceFile : function() {


### PR DESCRIPTION
### Scope & Purpose
Also retry on write, read and connect errors. Initially I thought there was no way of knowing why the request failed, but I was wrong. Additionally retry creating dump contexts.

The following things have also been changes:
1. The server enforces a empty response body if the response code is `204 No Content`. This already almost always true. The problematic exception was the new dump api.
2. The `SimpleHttpClient` will drop the body of all http responses that have response code `204`. This is done by dropping the connection if the `Content-Length` is not zero and the response code is `204`.
3. The dump api now explicitly creates an empty body in case 204.
