### PR TITLE
[OASIS-25344][3.10] Fix document API inconsistency 

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 v3.10.9 (XXXX-XX-XX)
 --------------------
 
+* When trying to read multiple documents, the coordinator will now handle empty
+  lists gracefully and return an empty result set instead of an error.
+
 * Added startup option `--replication.active-failover-leader-grace-period`.
   This startup option can be used to set the amount of time (in seconds) for
   which the current leader in an active failover setup will continue to 

--- a/arangod/Cluster/ClusterMethods.cpp
+++ b/arangod/Cluster/ClusterMethods.cpp
@@ -357,6 +357,9 @@ OperationResult handleCRUDShardResponsesFast(
   std::unordered_map<::ErrorCode, size_t> errorCounter;
 
   fuerte::StatusCode code = fuerte::StatusInternalError;
+  if (results.empty()) {
+    code = fuerte::StatusOK;
+  }
   // If none of the shards responded we return a SERVER_ERROR;
 
   for (Try<arangodb::network::Response> const& tryRes : results) {

--- a/tests/js/client/shell/api/document-read.js
+++ b/tests/js/client/shell/api/document-read.js
@@ -31,7 +31,6 @@
 const jsunity = require("jsunity");
 
 const internal = require('internal');
-const sleep = internal.sleep;
 const forceJson = internal.options().hasOwnProperty('server.force-json') && internal.options()['server.force-json'];
 const contentType = forceJson ? "application/json" :  "application/x-velocypack";
 
@@ -604,6 +603,16 @@ function checking_a_documentSuite () {
       doc = arango.HEAD_RAW(cmd, hdr);
 
       assertEqual(doc.code, 412);
+    },
+
+    test_use_empty_array_for_documents_read: function () {
+      let cmd = `/_api/document/${cid._id}?onlyget=true`;
+      let body = [];
+      let doc = arango.PUT_RAW(cmd, body);
+
+      assertEqual(doc.code, 200);
+      assertEqual(doc.headers['content-type'], contentType);
+      assertEqual(doc.parsedBody, []);
     },
 
   };


### PR DESCRIPTION
### Scope & Purpose

Fix unintended API difference between SingleServer and Cluster. 
Whenever a PUT requests has been made against: `/_api/document/{aCollection}?onlyget=true`
and the body just contains an empty list `[]`, the server replied with a `internal server error`. 
The cluster environment now behaves the same as the SingleServer api and just returns the
correct result with the correct error code. 

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [x] Tests
  - [x] **Regression tests**
- [x] :book: CHANGELOG entry made
- [x] Backports
  - [x] Backport for Devel: https://github.com/arangodb/arangodb/pull/19366
  - [x] Backport for 3.11: https://github.com/arangodb/arangodb/pull/19365
  - [x] Backport for 3.9: https://github.com/arangodb/arangodb/pull/19367

#### Related Information

- [x] GitHub issue / Jira ticket:  https://arangodb.atlassian.net/browse/OASIS-25344

