### PR TITLE
[OASIS-25344][3.11] API inconsistency regression test 

### DIFF
--- a/tests/js/client/shell/api/multi/document-read.js
+++ b/tests/js/client/shell/api/multi/document-read.js
@@ -606,6 +606,16 @@ function checking_a_documentSuite () {
       assertEqual(doc.code, 412);
     },
 
+    test_use_empty_array_for_documents_read: function () {
+      let cmd = `/_api/document/${cid._id}?onlyget=true`;
+      let body = [];
+      let doc = arango.PUT_RAW(cmd, body);
+
+      assertEqual(doc.code, 200);
+      assertEqual(doc.headers['content-type'], contentType);
+      assertEqual(doc.parsedBody, []);
+    },
+
   };
 }
 


### PR DESCRIPTION
### Scope & Purpose

Original ticket: https://github.com/arangodb/arangodb/pull/19364
Added a regression test only. 
Bug-itself is fixed in this branch already, see: https://github.com/arangodb/arangodb/pull/19059

- [x] :hankey: Bugfix

### Checklist

- [x] Tests
  - [x] **Regression tests**

#### Related Information

- [x] GitHub issue / Jira ticket: https://github.com/arangodb/arangodb/pull/19364

