### PR TITLE
add LZ4 compression for the edge cache

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,36 @@
 v3.11.2 (XXXX-XX-XX)
 --------------------
 
+* Added transparent LZ4 compression for values in the in-memory edge cache if
+  their size exceeds a configurable threshold.
+
+  LZ4 compression of edge index cache values allows to store more data in main
+  memory than without compression, so the available memory can be used more
+  efficiently. The compression is transparent and does not require any change
+  to queries or applications. 
+  The compression can add CPU overhead for compressing values when storing them
+  in the cache, and for decompressing values when fetching them from the cache.
+  
+  The new startup option `--rocksdb.min-value-size-for-edge-compression` can be
+  used to set a threshold value size for compression edge index cache payload
+  values. The default value is `100`, i.e. values with a payload size of at 
+  least 100 bytes will be LZ4-compressed. 
+  To turn compression off, it is enough to set the option to a very large
+  value.
+
+  The following new metrics can be used to determine the usefulness of 
+  compression:
+
+  - `arangodb_edge_cache_uncompressed_entries_size`: will return the 
+    total number of bytes of all entries that were ever stored in the 
+    in-memory edge cache, before compression was applied.
+  - `arangodb_edge_cache_effective_entries_size`: will return the total
+    number of bytes of all entries that were stored in the in-memory edge cache,
+    after compression was applied.
+
+  Note that these metrics will be increased upon every insertion into the
+  edge cache, but not decreased when data gets evicted from the cache.
+
 * Remove temporary `CREATING_{number}` directories from hot backup in case a
   hot backup runs into an error.
 

--- a/Documentation/Metrics/arangodb_edge_cache_effective_entries_size.yaml
+++ b/Documentation/Metrics/arangodb_edge_cache_effective_entries_size.yaml
@@ -1,0 +1,21 @@
+name: arangodb_edge_cache_effective_entries_size
+introducedIn: "3.11.2"
+help: |
+  Total effective memory size of all edge cache entries ever stored in the edge cache.
+unit: bytes
+type: gauge
+category: Statistics
+complexity: advanced
+exposedBy:
+  - dbserver
+  - agent
+  - single
+description: |
+  Total effective memory size of all edge cache data that were ever stored in
+  the edge cache of any collection/shard. The size is calculated after any
+  potential compression, so the compression efficiency can be estimated by 
+  this metric by the size of the uncompressed edge cache entries.
+  Note that this metric is incremented upon every edge cache insert attempt.
+  It is increased also when data cannot be inserted into the cache (e.g. because
+  the cache had no memory left). The metric is not decreased when data gets 
+  evicted from the cache.

--- a/Documentation/Metrics/arangodb_edge_cache_uncompressed_entries_size.yaml
+++ b/Documentation/Metrics/arangodb_edge_cache_uncompressed_entries_size.yaml
@@ -1,0 +1,20 @@
+name: arangodb_edge_cache_uncompressed_entries_size
+introducedIn: "3.11.2"
+help: |
+  Total gross memory size of all edge cache entries ever stored in the edge cache.
+unit: bytes
+type: gauge
+category: Statistics
+complexity: advanced
+exposedBy:
+  - dbserver
+  - agent
+  - single
+description: |
+  Total gross memory size of all edge cache data that were ever stored in
+  the edge cache of any collection/shard. The size is calculated before any
+  potential compression.
+  Note that this metric is incremented upon every cache insert attempt. 
+  It is increased also when data cannot be inserted into the cache (e.g. because
+  the cache had no memory left). The metric is not decreased when data gets 
+  evicted from the cache.

--- a/arangod/Cache/CachedValue.cpp
+++ b/arangod/Cache/CachedValue.cpp
@@ -30,9 +30,6 @@
 
 namespace arangodb::cache {
 
-const std::size_t CachedValue::_headerAllocSize =
-    sizeof(CachedValue) + CachedValue::_padding;
-
 CachedValue* CachedValue::copy() const {
   // cppcheck detects a memory leak here for "buf", but this is a false
   // positive. cppcheck-suppress *
@@ -57,7 +54,7 @@ CachedValue* CachedValue::construct(void const* k, std::size_t kSize,
   }
 
   // cppcheck-suppress *
-  std::uint8_t* buf = new std::uint8_t[_headerAllocSize + kSize + vSize];
+  std::uint8_t* buf = new std::uint8_t[kCachedValueHeaderSize + kSize + vSize];
   std::uint8_t* aligned = reinterpret_cast<std::uint8_t*>(
       (reinterpret_cast<std::size_t>(buf) + _headerAllocOffset) &
       _headerAllocMask);
@@ -89,6 +86,10 @@ CachedValue::CachedValue(CachedValue const& other) noexcept
     : _refCount(0), _keySize(other._keySize), _valueSize(other._valueSize) {
   std::memcpy(const_cast<std::uint8_t*>(key()), other.key(),
               keySize() + valueSize());
+}
+
+std::size_t CachedValue::size() const noexcept {
+  return kCachedValueHeaderSize + keySize() + valueSize();
 }
 
 }  // namespace arangodb::cache

--- a/arangod/Cache/CachedValue.h
+++ b/arangod/Cache/CachedValue.h
@@ -26,8 +26,7 @@
 #include <atomic>
 #include <cstdint>
 
-namespace arangodb {
-namespace cache {
+namespace arangodb::cache {
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief This is the beginning of a cache data entry.
@@ -81,9 +80,7 @@ struct CachedValue {
   //////////////////////////////////////////////////////////////////////////////
   /// @brief Returns the allocated size of bytes including the key and value
   //////////////////////////////////////////////////////////////////////////////
-  inline std::size_t size() const noexcept {
-    return _headerAllocSize + keySize() + valueSize();
-  }
+  std::size_t size() const noexcept;
 
   //////////////////////////////////////////////////////////////////////////////
   /// @brief Increase reference count
@@ -116,12 +113,12 @@ struct CachedValue {
   //////////////////////////////////////////////////////////////////////////////
   static void operator delete(void* ptr);
 
- private:
-  static constexpr std::size_t _padding =
+  static constexpr std::size_t padding =
       alignof(std::atomic<std::uint32_t>) - 1;
-  static const std::size_t _headerAllocSize;
-  static constexpr std::size_t _headerAllocMask = ~_padding;
-  static constexpr std::size_t _headerAllocOffset = _padding;
+
+ private:
+  static constexpr std::size_t _headerAllocMask = ~padding;
+  static constexpr std::size_t _headerAllocOffset = padding;
   static constexpr std::uint32_t _keyMask = 0x00FFFFFF;
   static constexpr std::uint32_t _offsetMask = 0xFF000000;
   static constexpr std::size_t _offsetShift = 24;
@@ -130,7 +127,6 @@ struct CachedValue {
   std::uint32_t _keySize;
   std::uint32_t _valueSize;
 
- private:
   CachedValue(std::size_t off, void const* k, std::size_t kSize, void const* v,
               std::size_t vSize) noexcept;
   CachedValue(CachedValue const& other) noexcept;
@@ -140,5 +136,7 @@ struct CachedValue {
   }
 };
 
-};  // end namespace cache
-};  // end namespace arangodb
+constexpr std::size_t kCachedValueHeaderSize =
+    sizeof(CachedValue) + CachedValue::padding;
+
+};  // end namespace arangodb::cache

--- a/arangod/RocksDBEngine/RocksDBEngine.h
+++ b/arangod/RocksDBEngine/RocksDBEngine.h
@@ -484,6 +484,10 @@ class RocksDBEngine final : public StorageEngine {
 
   std::shared_ptr<StorageSnapshot> currentSnapshot() override;
 
+  void addCacheMetrics(uint64_t initial, uint64_t effective) noexcept;
+
+  size_t minValueSizeForEdgeCompression() const noexcept;
+
  private:
   void loadReplicatedStates(TRI_vocbase_t& vocbase);
   void shutdownRocksDBInstance() noexcept;
@@ -557,6 +561,8 @@ class RocksDBEngine final : public StorageEngine {
                                       // for intermediate commit
 
   uint64_t _maxParallelCompactions;
+
+  size_t _minValueSizeForEdgeCompression;
 
   // hook-ins for recovery process
   static std::vector<std::shared_ptr<RocksDBRecoveryHelper>> _recoveryHelpers;
@@ -724,6 +730,12 @@ class RocksDBEngine final : public StorageEngine {
   metrics::Counter& _metricsTreeRebuildsFailure;
   metrics::Counter& _metricsTreeHibernations;
   metrics::Counter& _metricsTreeResurrections;
+
+  // total size of uncompressed values for the edge cache
+  metrics::Gauge<uint64_t>& _metricsEdgeCacheEntriesSizeInitial;
+  // total size of values stored in the edge cache (can be smaller than the
+  // initial size because of compression)
+  metrics::Gauge<uint64_t>& _metricsEdgeCacheEntriesSizeEffective;
 
   // @brief persistor for replicated logs
   std::shared_ptr<RocksDBAsyncLogWriteBatcher> _logPersistor;

--- a/tests/js/client/shell/shell-edge-index-compression-noncluster.js
+++ b/tests/js/client/shell/shell-edge-index-compression-noncluster.js
@@ -1,0 +1,175 @@
+/*jshint globalstrict:false, strict:false */
+/* global arango, getOptions, runSetup, assertTrue, assertFalse, assertEqual */
+
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2010-2012 triagens GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB Inc, Cologne, Germany
+///
+/// @author Jan Steemann
+/// @author Copyright 2019, ArangoDB Inc, Cologne, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+const db = require('@arangodb').db;
+const jsunity = require('jsunity');
+const getMetric = require('@arangodb/test-helper').getMetricSingle;
+const runWithRetry = require('@arangodb/test-helper').runWithRetry;
+const sleep = require('internal').sleep;
+
+const cn = 'UnitTestsCollection';
+
+function EdgeIndexCompressionSuite() {
+  'use strict';
+
+  let retryCb = () => {
+    sleep(0.25);
+  };
+     
+  return {
+    tearDown: function() {
+      db._drop(cn);
+    },
+   
+    testNonCompressibleValuesFrom: function() {
+      const n = 5000;
+
+      let c = db._createEdgeCollection(cn);
+      let docs = [];
+      for (let i = 0; i < n; ++i) {
+        // only one edge per _from value. this is below the compressibility threshold.
+        docs.push({ _from: "v/test" + i, _to: "v/test" + i });
+      }
+      c.insert(docs);
+      
+      const oldUncompressedSize = getMetric("arangodb_edge_cache_uncompressed_entries_size");
+      const oldCompressedSize = getMetric("arangodb_edge_cache_effective_entries_size");
+
+      runWithRetry(() => {
+        let result = db._query(`FOR i IN 0..${n - 1} FOR e IN ${cn} FILTER e._from == CONCAT('v/test', i) RETURN e`);
+        assertEqual(n, result.toArray().length);
+        let stats = result.getExtra().stats;
+        assertEqual(n, stats.cacheHits + stats.cacheMisses, stats);
+        assertTrue(stats.cacheHits > 0, stats);
+        
+        const newUncompressedSize = getMetric("arangodb_edge_cache_uncompressed_entries_size");
+        const newCompressedSize = getMetric("arangodb_edge_cache_effective_entries_size");
+        // total values should have increased for both uncompressed and effective payload sizes
+        assertTrue(newUncompressedSize > oldUncompressedSize, { newUncompressedSize, oldUncompressedSize });
+        assertTrue(newCompressedSize > oldCompressedSize, { newCompressedSize, oldCompressedSize });
+        // increase in uncompressed size should be equal to the increase in effective size, because data was not compressible
+        assertEqual(newCompressedSize - oldCompressedSize, newUncompressedSize - oldUncompressedSize, { newCompressedSize, oldCompressedSize, newUncompressedSize, oldUncompressedSize });
+      }, retryCb);
+    },
+    
+    testNonCompressibleValuesTo: function() {
+      const n = 5000;
+
+      let c = db._createEdgeCollection(cn);
+      let docs = [];
+      for (let i = 0; i < n; ++i) {
+        // only one edge per _to value. this is below the compressibility threshold.
+        docs.push({ _from: "v/test" + i, _to: "v/test" + i });
+      }
+      c.insert(docs);
+      
+      const oldUncompressedSize = getMetric("arangodb_edge_cache_uncompressed_entries_size");
+      const oldCompressedSize = getMetric("arangodb_edge_cache_effective_entries_size");
+
+      runWithRetry(() => {
+        let result = db._query(`FOR i IN 0..${n - 1} FOR e IN ${cn} FILTER e._to == CONCAT('v/test', i) RETURN e`);
+        assertEqual(n, result.toArray().length);
+        let stats = result.getExtra().stats;
+        assertEqual(n, stats.cacheHits + stats.cacheMisses, stats);
+        assertTrue(stats.cacheHits > 0, stats);
+        
+        const newUncompressedSize = getMetric("arangodb_edge_cache_uncompressed_entries_size");
+        const newCompressedSize = getMetric("arangodb_edge_cache_effective_entries_size");
+        // total values should have increased for both uncompressed and effective payload sizes
+        assertTrue(newUncompressedSize > oldUncompressedSize, { newUncompressedSize, oldUncompressedSize });
+        assertTrue(newCompressedSize > oldCompressedSize, { newCompressedSize, oldCompressedSize });
+        // increase in uncompressed size should be equal to the increase in effective size, because data was not compressible
+        assertEqual(newCompressedSize - oldCompressedSize, newUncompressedSize - oldUncompressedSize, { newCompressedSize, oldCompressedSize, newUncompressedSize, oldUncompressedSize });
+      }, retryCb);
+    },
+    
+    testCompressibleValuesFrom: function() {
+      const n = 5000;
+
+      let c = db._createEdgeCollection(cn);
+      let docs = [];
+      for (let i = 0; i < n; ++i) {
+        // 50 edges per _from value. this is above the compressibility threshold.
+        docs.push({ _from: "v/test" + (i % 100), _to: "v/test" + i });
+      }
+      c.insert(docs);
+      
+      const oldUncompressedSize = getMetric("arangodb_edge_cache_uncompressed_entries_size");
+      const oldCompressedSize = getMetric("arangodb_edge_cache_effective_entries_size");
+
+      runWithRetry(() => {
+        let result = db._query(`FOR i IN 0..99 FOR e IN ${cn} FILTER e._from == CONCAT('v/test', i) RETURN e`);
+        assertEqual(n, result.toArray().length);
+        let stats = result.getExtra().stats;
+        assertEqual(100, stats.cacheHits + stats.cacheMisses, stats);
+        assertTrue(stats.cacheHits > 0, stats);
+        
+        const newUncompressedSize = getMetric("arangodb_edge_cache_uncompressed_entries_size");
+        const newCompressedSize = getMetric("arangodb_edge_cache_effective_entries_size");
+        // total values should have increased for both uncompressed and effective payload sizes
+        assertTrue(newUncompressedSize > oldUncompressedSize, { newUncompressedSize, oldUncompressedSize });
+        assertTrue(newCompressedSize > oldCompressedSize, { newCompressedSize, oldCompressedSize });
+        // increase in uncompressed size should be greater than the increase in effective size, because data was compressible
+        assertTrue(newCompressedSize - oldCompressedSize < newUncompressedSize - oldUncompressedSize, { newCompressedSize, oldCompressedSize, newUncompressedSize, oldUncompressedSize });
+      }, retryCb);
+    },
+    
+    testCompressibleValuesTo: function() {
+      const n = 5000;
+
+      let c = db._createEdgeCollection(cn);
+      let docs = [];
+      for (let i = 0; i < n; ++i) {
+        // 50 edges per _to value. this is above the compressibility threshold.
+        docs.push({ _from: "v/test" + i, _to: "v/test" + (i % 100) });
+      }
+      c.insert(docs);
+      
+      const oldUncompressedSize = getMetric("arangodb_edge_cache_uncompressed_entries_size");
+      const oldCompressedSize = getMetric("arangodb_edge_cache_effective_entries_size");
+
+      runWithRetry(() => {
+        let result = db._query(`FOR i IN 0..99 FOR e IN ${cn} FILTER e._to == CONCAT('v/test', i) RETURN e`);
+        assertEqual(n, result.toArray().length);
+        let stats = result.getExtra().stats;
+        assertEqual(100, stats.cacheHits + stats.cacheMisses, stats);
+        assertTrue(stats.cacheHits > 0, stats);
+        
+        const newUncompressedSize = getMetric("arangodb_edge_cache_uncompressed_entries_size");
+        const newCompressedSize = getMetric("arangodb_edge_cache_effective_entries_size");
+        // total values should have increased for both uncompressed and effective payload sizes
+        assertTrue(newUncompressedSize > oldUncompressedSize, { newUncompressedSize, oldUncompressedSize });
+        assertTrue(newCompressedSize > oldCompressedSize, { newCompressedSize, oldCompressedSize });
+        // increase in uncompressed size should be greater than the increase in effective size, because data was compressible
+        assertTrue(newCompressedSize - oldCompressedSize < newUncompressedSize - oldUncompressedSize, { newCompressedSize, oldCompressedSize, newUncompressedSize, oldUncompressedSize });
+      }, retryCb);
+    },
+
+  };
+}
+
+jsunity.run(EdgeIndexCompressionSuite);
+return jsunity.done();


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/19324

* Added transparent LZ4 compression for values in the in-memory edge cache if their size exceeds a configurable threshold.

  LZ4 compression of edge index cache values allows to store more data in main memory than without compression, so the available memory can be used more efficiently. The compression is transparent and does not require any change to queries or applications. The compression can add CPU overhead for compressing values when storing them in the cache, and for decompressing values when fetching them from the cache.

  The new startup option `--rocksdb.min-value-size-for-edge-compression` can be used to set a threshold value size for compression edge index cache payload values. The default value is `100`, i.e. values with a payload size of at least 100 bytes will be LZ4-compressed. To turn compression off, it is enough to set the option to a very large value.

  The following new metrics can be used to determine the usefulness of compression:

  - `arangodb_edge_cache_uncompressed_entries_size`: will return the total number of bytes of all entries that were ever stored in the in-memory edge cache, before compression was applied.
  - `arangodb_edge_cache_effective_entries_size`: will return the total number of bytes of all entries that were stored in the in-memory edge cache, after compression was applied.

  Note that these metrics will be increased upon every insertion into the
  edge cache, but not decreased when data gets evicted from the cache.

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [x] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.11: this PR
  - [ ] Backport for 3.10: -
  - [ ] Backport for 3.9: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 