### PR TITLE
fix small issues in client-tools, add split file support for dump/restore

### DIFF
--- a/client-tools/Backup/arangobackup.cpp
+++ b/client-tools/Backup/arangobackup.cpp
@@ -100,12 +100,12 @@ int main(int argc, char* argv[]) {
       }
     } catch (std::exception const& ex) {
       LOG_TOPIC("78140", ERR, arangodb::Logger::FIXME)
-          << "arangodump terminated because of an unhandled exception: "
+          << "arangobackup terminated because of an unhandled exception: "
           << ex.what();
       ret = EXIT_FAILURE;
     } catch (...) {
       LOG_TOPIC("cc40d", ERR, arangodb::Logger::FIXME)
-          << "arangodump terminated because of an unhandled exception of "
+          << "arangobackup terminated because of an unhandled exception of "
              "unknown type";
       ret = EXIT_FAILURE;
     }

--- a/client-tools/Dump/DumpFeature.h
+++ b/client-tools/Dump/DumpFeature.h
@@ -143,7 +143,6 @@ class DumpFeature final : public ArangoDumpFeature {
 
     Result run(arangodb::httpclient::SimpleHttpClient& client) override;
 
-    VPackSlice const collectionInfo;
     std::string const shardName;
     std::string const server;
     std::shared_ptr<ManagedDirectory::File> file;

--- a/client-tools/Import/SenderThread.cpp
+++ b/client-tools/Import/SenderThread.cpp
@@ -111,9 +111,12 @@ bool SenderThread::isDone() {
 }
 
 void SenderThread::run() {
-  while (!isStopping() && !_hasError) {
+  while (!isStopping()) {
     {
       CONDITION_LOCKER(guard, _condition);
+      if (_hasError) {
+        break;
+      }
       _ready = true;
       if (_idle) {
         guard.wait();

--- a/client-tools/Restore/RestoreFeature.cpp
+++ b/client-tools/Restore/RestoreFeature.cpp
@@ -30,6 +30,7 @@
 
 #include <algorithm>
 #include <chrono>
+#include <regex>
 #include <string>
 #include <string_view>
 #include <thread>
@@ -37,8 +38,6 @@
 
 #include "ApplicationFeatures/ApplicationServer.h"
 #include "Basics/FileUtils.h"
-#include "Basics/Mutex.h"
-#include "Basics/MutexLocker.h"
 #include "Basics/NumberOfCores.h"
 #include "Basics/Result.h"
 #include "Basics/StaticStrings.h"
@@ -54,7 +53,9 @@
 #include "Logger/LogMacros.h"
 #include "Logger/Logger.h"
 #include "Logger/LoggerStream.h"
+#include "ProgramOptions/Parameters.h"
 #include "ProgramOptions/ProgramOptions.h"
+#include "Random/RandomGenerator.h"
 #include "Shell/ClientFeature.h"
 #include "SimpleHttpClient/GeneralClientConnection.h"
 #include "SimpleHttpClient/HttpResponseChecker.h"
@@ -68,6 +69,8 @@
 #endif
 
 namespace {
+std::regex const splitFilesRegex(".*\\.[0-9]+\\.data\\.json(\\.gz)?$",
+                                 std::regex::ECMAScript);
 
 /// @brief return the target replication factor for the specified collection
 uint64_t getReplicationFactor(arangodb::RestoreFeature::Options const& options,
@@ -787,9 +790,9 @@ arangodb::Result processInputDirectory(
 
       if (progressTracker.getStatus(name.copyString()).state <
           arangodb::RestoreFeature::CREATED) {
-        progressTracker.updateStatus(name.copyString(),
-                                     arangodb::RestoreFeature::CollectionStatus{
-                                         arangodb::RestoreFeature::CREATED});
+        progressTracker.updateStatus(
+            name.copyString(), arangodb::RestoreFeature::CollectionStatus{
+                                   arangodb::RestoreFeature::CREATED, {}});
       }
 
       if (name.isString() &&
@@ -822,6 +825,15 @@ arangodb::Result processInputDirectory(
     }
 
     auto createViews = [&](std::string_view type) {
+      auto const specialName = "_VIEW_MARKER_" + std::string{type};
+      auto status = progressTracker.getStatus(specialName);
+
+      if (status.state == arangodb::RestoreFeature::RESTORED) {
+        LOG_TOPIC("79e1b", INFO, Logger::RESTORE)
+            << "# " << type << " views already created...";
+        return Result{};
+      }
+
       if (options.importStructure && !views.empty()) {
         LOG_TOPIC("f723c", INFO, Logger::RESTORE)
             << "# Creating " << type << " views...";
@@ -839,6 +851,9 @@ arangodb::Result processInputDirectory(
           }
         }
       }
+      status.state = arangodb::RestoreFeature::RESTORED;
+      progressTracker.updateStatus(specialName, status);
+
       return Result{};
     };
 
@@ -1133,8 +1148,8 @@ RestoreFeature::RestoreJob::RestoreJob(RestoreFeature& feature,
 RestoreFeature::RestoreJob::~RestoreJob() = default;
 
 Result RestoreFeature::RestoreJob::sendRestoreData(
-    arangodb::httpclient::SimpleHttpClient& client, size_t readOffset,
-    char const* buffer, size_t bufferSize) {
+    arangodb::httpclient::SimpleHttpClient& client,
+    MultiFileReadOffset readOffset, char const* buffer, size_t bufferSize) {
   using arangodb::basics::StringUtils::urlEncode;
   using arangodb::httpclient::SimpleHttpResult;
 
@@ -1162,14 +1177,14 @@ Result RestoreFeature::RestoreJob::sendRestoreData(
     // leave readOffset in place in readOffsets, because the job did not succeed
     {
       // store error
-      MUTEX_LOCKER(locker, sharedState->mutex);
+      std::lock_guard locker{sharedState->mutex};
       sharedState->result = res;
     }
   } else {
     // no error
 
     {
-      MUTEX_LOCKER(locker, sharedState->mutex);
+      std::lock_guard locker{sharedState->mutex};
       TRI_ASSERT(!sharedState->readOffsets.empty());
 
 #ifdef ARANGODB_ENABLE_FAILURE_TESTS
@@ -1201,11 +1216,11 @@ Result RestoreFeature::RestoreJob::sendRestoreData(
 }
 
 void RestoreFeature::RestoreJob::updateProgress() {
-  MUTEX_LOCKER(locker, sharedState->mutex);
+  std::unique_lock locker{sharedState->mutex};
 
   if (!sharedState->readOffsets.empty()) {
     auto it = sharedState->readOffsets.begin();
-    size_t readOffset = (*it).first;
+    auto readOffset = (*it).first;
 
     // progressTracker has its own lock
     locker.unlock();
@@ -1221,7 +1236,7 @@ void RestoreFeature::RestoreJob::updateProgress() {
 
     progressTracker.updateStatus(collectionName,
                                  arangodb::RestoreFeature::CollectionStatus{
-                                     arangodb::RestoreFeature::RESTORED, 0});
+                                     arangodb::RestoreFeature::RESTORED, {}});
   }
 }
 
@@ -1262,8 +1277,9 @@ Result RestoreFeature::RestoreMainJob::run(
 
 /// @brief dispatch restore data
 Result RestoreFeature::RestoreMainJob::dispatchRestoreData(
-    arangodb::httpclient::SimpleHttpClient& client, size_t readOffset,
-    char const* data, size_t length, bool forceDirect) {
+    arangodb::httpclient::SimpleHttpClient& client,
+    MultiFileReadOffset readOffset, char const* data, size_t length,
+    bool forceDirect) {
   size_t readLength = length;
 
   // the following object is needed for cleaning up duplicate attributes.
@@ -1340,7 +1356,7 @@ Result RestoreFeature::RestoreMainJob::dispatchRestoreData(
 
   {
     // insert the current readoffset
-    MUTEX_LOCKER(locker, sharedState->mutex);
+    std::lock_guard locker{sharedState->mutex};
     sharedState->readOffsets.emplace(readOffset, readLength);
   }
 
@@ -1395,31 +1411,65 @@ Result RestoreFeature::RestoreMainJob::restoreData(
              currentStatus.state == arangodb::RestoreFeature::RESTORING);
 
   // import data. check if we have a datafile
-  //  ... there are 4 possible names
-  bool isCompressed = false;
-  auto datafile = directory.readableFile(
-      collectionName + "_" +
-      arangodb::rest::SslInterface::sslMD5(collectionName) + ".data.json");
+  //  ... there are 6 possible names
+  std::string const nameHash =
+      arangodb::rest::SslInterface::sslMD5(collectionName);
+
+  auto datafile =
+      directory.readableFile(collectionName + "_" + nameHash + ".data.json");
   if (!datafile || datafile->status().fail()) {
-    datafile = directory.readableFile(
-        collectionName + "_" +
-        arangodb::rest::SslInterface::sslMD5(collectionName) + ".data.json.gz");
-    isCompressed = true;
+    datafile = directory.readableFile(collectionName + "_" + nameHash +
+                                      ".data.json.gz");
+  }
+  if (!datafile || datafile->status().fail()) {
+    datafile = directory.readableFile(collectionName + "_" + nameHash +
+                                      ".0.data.json.gz");
   }
   if (!datafile || datafile->status().fail()) {
     datafile = directory.readableFile(collectionName + ".data.json.gz");
-    isCompressed = true;
+  }
+  if (!datafile || datafile->status().fail()) {
+    datafile = directory.readableFile(collectionName + "_" + nameHash +
+                                      ".0.data.json");
   }
   if (!datafile || datafile->status().fail()) {
     datafile = directory.readableFile(collectionName + ".data.json");
-    isCompressed = false;
   }
   if (!datafile || datafile->status().fail()) {
-    return {TRI_ERROR_CANNOT_READ_FILE,
-            "could not open data file for collection '" + collectionName + "'"};
+    {
+      std::lock_guard locker{sharedState->mutex};
+      sharedState->readCompleteInputfile = true;
+    }
+
+    updateProgress();
+    return {TRI_ERROR_NO_ERROR};
   }
 
-  int64_t const fileSize = TRI_SizeFile(datafile->path().c_str());
+  TRI_ASSERT(datafile);
+  // check if we are dealing with compressed file(s)
+  bool const isCompressed = datafile->path().ends_with(".gz");
+  // check if we are dealing with multiple files (created via `--split-file
+  // true`)
+  bool const isMultiFile =
+      std::regex_match(datafile->path(), ::splitFilesRegex);
+
+  int64_t fileSize = TRI_SizeFile(datafile->path().c_str());
+  if (isMultiFile) {
+    fileSize = 0;
+    auto allFiles = arangodb::basics::FileUtils::listFiles(directory.path());
+    std::string const prefix = collectionName + "_" + nameHash + ".";
+    for (auto const& it : allFiles) {
+      if (!it.starts_with(prefix) || !std::regex_match(it, ::splitFilesRegex)) {
+        continue;
+      }
+      int64_t s = TRI_SizeFile(
+          arangodb::basics::FileUtils::buildFilename(directory.path(), it)
+              .c_str());
+      if (s >= 0) {
+        fileSize += s;
+      }
+    }
+  }
 
   if (options.progress) {
     LOG_TOPIC("95913", INFO, Logger::RESTORE)
@@ -1431,23 +1481,31 @@ Result RestoreFeature::RestoreMainJob::restoreData(
   int64_t numReadForThisCollection = 0;
   int64_t numReadSinceLastReport = 0;
 
-  bool const isGzip =
-      datafile->path().size() > 3 &&
-      (0 ==
-       datafile->path().substr(datafile->path().size() - 3).compare(".gz"));
+  bool const isGzip = isCompressed;
 
   std::string ofFilesize;
   if (!isGzip) {
     ofFilesize = " of " + formatSize(fileSize);
   }
 
-  size_t datafileReadOffset = 0;
+  MultiFileReadOffset datafileReadOffset;
   if (currentStatus.state == arangodb::RestoreFeature::RESTORING) {
     LOG_TOPIC("94913", INFO, Logger::RESTORE)
         << "# continuing restoring " << collectionType << " collection '"
-        << collectionName << "' from offset " << currentStatus.bytes_acked;
-    datafileReadOffset = currentStatus.bytes_acked;
-    datafile->skip(datafileReadOffset);
+        << collectionName << "' from offset " << currentStatus.bytesAcked;
+    datafileReadOffset = currentStatus.bytesAcked;
+
+    // open the nth file
+    if (datafileReadOffset.fileNo != 0) {
+      datafile = directory.readableFile(basics::StringUtils::concatT(
+          collectionName, "_", nameHash, ".", datafileReadOffset.fileNo,
+          ".data.json", isCompressed ? ".gz" : ""));
+      if (datafile->status().fail()) {
+        return datafile->status();
+      }
+    }
+
+    datafile->skip(datafileReadOffset.readOffset);
     if (datafile->status().fail()) {
       return datafile->status();
     }
@@ -1524,7 +1582,7 @@ Result RestoreFeature::RestoreMainJob::restoreData(
 
       // check if our status was changed by background jobs
       if (result.ok()) {
-        MUTEX_LOCKER(locker, sharedState->mutex);
+        std::lock_guard locker{sharedState->mutex};
 
         if (sharedState->result.fail()) {
           // yes, something failed
@@ -1542,7 +1600,7 @@ Result RestoreFeature::RestoreMainJob::restoreData(
         }
       }
 
-      datafileReadOffset += length;
+      datafileReadOffset.readOffset += length;
 
       // bytes successfully sent
       buffer->erase_front(length);
@@ -1569,7 +1627,17 @@ Result RestoreFeature::RestoreMainJob::restoreData(
     }
 
     if (numRead == 0) {  // EOF
-      break;
+      if (!isMultiFile) {
+        break;
+      }
+      datafileReadOffset.fileNo += 1;
+      datafileReadOffset.readOffset = 0;
+      datafile = directory.readableFile(basics::StringUtils::concatT(
+          collectionName, "_", nameHash, ".", datafileReadOffset.fileNo,
+          ".data.json", isCompressed ? ".gz" : ""));
+      if (!datafile || datafile->status().fail()) {
+        break;
+      }
     }
   }
 
@@ -1577,9 +1645,19 @@ Result RestoreFeature::RestoreMainJob::restoreData(
 
   // end of main job
   if (result.ok()) {
-    {
-      MUTEX_LOCKER(locker, sharedState->mutex);
-      sharedState->readCompleteInputfile = true;
+    while (true) {
+      {
+        std::lock_guard locker{sharedState->mutex};
+        if (sharedState->pendingJobs == 0) {
+          // no more pending jobs. we are done!
+          sharedState->readCompleteInputfile = true;
+          break;
+        }
+      }
+      // we still have pending jobs, which are dispatched to other
+      // threads but not yet finished. wait for all of them to be
+      // fully processed
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
     }
 
     updateProgress();
@@ -1641,12 +1719,23 @@ RestoreFeature::RestoreSendJob::RestoreSendJob(
     RestoreFeature& feature, RestoreProgressTracker& progressTracker,
     RestoreFeature::Options const& options, RestoreFeature::Stats& stats,
     bool useEnvelope, std::string const& collectionName,
-    std::shared_ptr<SharedState> sharedState, size_t readOffset,
+    std::shared_ptr<SharedState> sharedState, MultiFileReadOffset readOffset,
     std::unique_ptr<basics::StringBuffer> buffer)
     : RestoreJob(feature, progressTracker, options, stats, useEnvelope,
-                 collectionName, std::move(sharedState)),
+                 collectionName, sharedState),
       readOffset(readOffset),
-      buffer(std::move(buffer)) {}
+      buffer(std::move(buffer)) {
+  // count number of pending jobs up
+  std::lock_guard locker{sharedState->mutex};
+  ++sharedState->pendingJobs;
+}
+
+RestoreFeature::RestoreSendJob::~RestoreSendJob() {
+  // count number of pending jobs back at the end
+  std::lock_guard locker{sharedState->mutex};
+  TRI_ASSERT(sharedState->pendingJobs > 0);
+  --sharedState->pendingJobs;
+}
 
 Result RestoreFeature::RestoreSendJob::run(
     arangodb::httpclient::SimpleHttpClient& client) {
@@ -2282,7 +2371,7 @@ ClientTaskQueue<RestoreFeature::RestoreJob>& RestoreFeature::taskQueue() {
 void RestoreFeature::reportError(Result const& error) {
   try {
     {
-      MUTEX_LOCKER(lock, _workerErrorLock);
+      std::lock_guard lock{_workerErrorLock};
       _workerErrors.emplace_back(error);
     }
     _clientTaskQueue.clearQueue();
@@ -2292,7 +2381,7 @@ void RestoreFeature::reportError(Result const& error) {
 
 Result RestoreFeature::getFirstError() const {
   {
-    MUTEX_LOCKER(lock, _workerErrorLock);
+    std::lock_guard lock{_workerErrorLock};
     if (!_workerErrors.empty()) {
       return _workerErrors.front();
     }
@@ -2301,7 +2390,7 @@ Result RestoreFeature::getFirstError() const {
 }
 
 std::unique_ptr<basics::StringBuffer> RestoreFeature::leaseBuffer() {
-  MUTEX_LOCKER(lock, _buffersLock);
+  std::lock_guard lock{_buffersLock};
 
   if (_buffers.empty()) {
     // no buffers present. now insert one
@@ -2323,7 +2412,7 @@ void RestoreFeature::returnBuffer(
   TRI_ASSERT(buffer != nullptr);
   buffer->clear();
 
-  MUTEX_LOCKER(lock, _buffersLock);
+  std::lock_guard lock{_buffersLock};
   try {
     _buffers.emplace_back(std::move(buffer));
   } catch (...) {
@@ -2337,7 +2426,9 @@ RestoreFeature::CollectionStatus::CollectionStatus(VPackSlice slice) {
   using arangodb::basics::VelocyPackHelper;
   state = VelocyPackHelper::getNumericValue<CollectionState>(
       slice, "state", CollectionState::UNKNOWN);
-  bytes_acked =
+  bytesAcked.fileNo =
+      VelocyPackHelper::getNumericValue<size_t>(slice, "file-no", 0);
+  bytesAcked.readOffset =
       VelocyPackHelper::getNumericValue<size_t>(slice, "bytes-acked", 0);
 }
 
@@ -2346,15 +2437,16 @@ void RestoreFeature::CollectionStatus::toVelocyPack(
   {
     VPackObjectBuilder object(&builder);
     builder.add("state", VPackValue(state));
-    if (bytes_acked != 0) {
-      builder.add("bytes-acked", VPackValue(bytes_acked));
+    if (bytesAcked != MultiFileReadOffset{}) {
+      builder.add("bytes-acked", VPackValue(bytesAcked.readOffset));
+      builder.add("file-no", VPackValue(bytesAcked.fileNo));
     }
   }
 }
 
 RestoreFeature::CollectionStatus::CollectionStatus(
-    RestoreFeature::CollectionState state, size_t bytes_acked)
-    : state(state), bytes_acked(bytes_acked) {}
+    RestoreFeature::CollectionState state, MultiFileReadOffset bytesAcked)
+    : state(state), bytesAcked(bytesAcked) {}
 
 RestoreFeature::CollectionStatus::CollectionStatus() = default;
 

--- a/client-tools/Utils/ManagedDirectory.cpp
+++ b/client-tools/Utils/ManagedDirectory.cpp
@@ -432,8 +432,9 @@ void ManagedDirectory::spitFile(std::string const& filename,
     _status = ::genericError(filename, O_WRONLY);
   } else if (file->status().fail()) {
     _status = file->status();
+  } else {
+    file->spit(content);
   }
-  file->spit(content);
 }
 
 std::string ManagedDirectory::slurpFile(std::string const& filename) {

--- a/js/client/modules/@arangodb/testutils/process-utils.js
+++ b/js/client/modules/@arangodb/testutils/process-utils.js
@@ -235,6 +235,11 @@ class ConfigBuilder {
       this.config['use-experimental-dump'] = true;
     }
   }
+  setUseSplitFiles() {
+    if (this.type === 'dump') {
+      this.config['split-files'] = true;
+    }
+  }
   deactivateEnvelopes() {
     if (this.type === 'dump') {
       this.config['--envelope'] = false;

--- a/tests/test-definitions.txt
+++ b/tests/test-definitions.txt
@@ -113,7 +113,6 @@ dump_no_envelope -- --dumpAgencyOnError true
 dump_parallel -- --dumpAgencyOnError true
 dump_mixed_cluster_single -- --dumpAgencyOnError true
 dump_mixed_single_cluster -- --dumpAgencyOnError true
-dump_parallel -- --dumpAgencyOnError true
 # takes long, needs to go first. However, doesn't utilize the SUT hard.
 dump_with_crashes parallelity=1 priority=2000 -- --dumpAgencyOnError true 
 dump_with_crashes_parallel parallelity=1 priority=2000 -- --dumpAgencyOnError true 

--- a/tests/test-definitions.txt
+++ b/tests/test-definitions.txt
@@ -110,11 +110,13 @@ dump_jwt -- --dumpAgencyOnError true
 dump_maskings -- --dumpAgencyOnError true
 dump_multiple -- --dumpAgencyOnError true
 dump_no_envelope -- --dumpAgencyOnError true
+dump_parallel -- --dumpAgencyOnError true
 dump_mixed_cluster_single -- --dumpAgencyOnError true
 dump_mixed_single_cluster -- --dumpAgencyOnError true
 dump_parallel -- --dumpAgencyOnError true
 # takes long, needs to go first. However, doesn't utilize the SUT hard.
 dump_with_crashes parallelity=1 priority=2000 -- --dumpAgencyOnError true 
+dump_with_crashes_parallel parallelity=1 priority=2000 -- --dumpAgencyOnError true 
 
 # Audit Tests
 audit_client -- --dumpAgencyOnError true


### PR DESCRIPTION
### Scope & Purpose

Wire the `--split-files` option for arangodump, so that arangodump can produce multiple output files for a single shard when using `--use-experimental-dump`. Also wire arangorestore support for restoring multiple files.
This is a backport of functionality that already exists in 3.11 and devel.
The option is experimental though.

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: -
  - [x] Backport for 3.10: this PR
  - [ ] Backport for 3.9: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 