### PR TITLE
remove unnecessary parameter from createBlock() API

### DIFF
--- a/arangod/Aql/ClusterNodes.cpp
+++ b/arangod/Aql/ClusterNodes.cpp
@@ -140,8 +140,7 @@ RemoteNode::RemoteNode(ExecutionPlan* plan,
 
 /// @brief creates corresponding ExecutionBlock
 std::unique_ptr<ExecutionBlock> RemoteNode::createBlock(
-    ExecutionEngine& engine,
-    std::unordered_map<ExecutionNode*, ExecutionBlock*> const&) const {
+    ExecutionEngine& engine) const {
   auto const nrOutRegs = getRegisterPlan()->nrRegs[getDepth()];
   auto const nrInRegs = nrOutRegs;
 
@@ -195,8 +194,7 @@ ScatterNode::ScatterNode(ExecutionPlan* plan,
 
 /// @brief creates corresponding ExecutionBlock
 std::unique_ptr<ExecutionBlock> ScatterNode::createBlock(
-    ExecutionEngine& engine,
-    std::unordered_map<ExecutionNode*, ExecutionBlock*> const&) const {
+    ExecutionEngine& engine) const {
   ExecutionNode const* previousNode = getFirstDependency();
   TRI_ASSERT(previousNode != nullptr);
 
@@ -312,8 +310,7 @@ ExecutionNode* DistributeNode::clone(ExecutionPlan* plan, bool withDependencies,
 
 /// @brief creates corresponding ExecutionBlock
 std::unique_ptr<ExecutionBlock> DistributeNode::createBlock(
-    ExecutionEngine& engine,
-    std::unordered_map<ExecutionNode*, ExecutionBlock*> const&) const {
+    ExecutionEngine& engine) const {
   ExecutionNode const* previousNode = getFirstDependency();
   TRI_ASSERT(previousNode != nullptr);
 
@@ -513,8 +510,7 @@ void GatherNode::doToVelocyPack(VPackBuilder& nodes, unsigned flags) const {
 
 /// @brief creates corresponding ExecutionBlock
 std::unique_ptr<ExecutionBlock> GatherNode::createBlock(
-    ExecutionEngine& engine,
-    std::unordered_map<ExecutionNode*, ExecutionBlock*> const&) const {
+    ExecutionEngine& engine) const {
   ExecutionNode const* previousNode = getFirstDependency();
   TRI_ASSERT(previousNode != nullptr);
   auto registerInfos = createRegisterInfos({}, {});
@@ -639,8 +635,7 @@ SingleRemoteOperationNode::SingleRemoteOperationNode(
 
 /// @brief creates corresponding SingleRemoteOperationNode
 std::unique_ptr<ExecutionBlock> SingleRemoteOperationNode::createBlock(
-    ExecutionEngine& engine,
-    std::unordered_map<ExecutionNode*, ExecutionBlock*> const&) const {
+    ExecutionEngine& engine) const {
   ExecutionNode const* previousNode = getFirstDependency();
 
   TRI_ASSERT(previousNode != nullptr);

--- a/arangod/Aql/ClusterNodes.h
+++ b/arangod/Aql/ClusterNodes.h
@@ -73,9 +73,7 @@ class RemoteNode final : public DistributeConsumerNode {
 
   /// @brief creates corresponding ExecutionBlock
   std::unique_ptr<ExecutionBlock> createBlock(
-      ExecutionEngine& engine,
-      std::unordered_map<ExecutionNode*, ExecutionBlock*> const&)
-      const override;
+      ExecutionEngine& engine) const override;
 
   /// @brief clone ExecutionNode recursively
   ExecutionNode* clone(ExecutionPlan* plan, bool withDependencies,
@@ -144,9 +142,7 @@ class ScatterNode : public ExecutionNode {
 
   /// @brief creates corresponding ExecutionBlock
   std::unique_ptr<ExecutionBlock> createBlock(
-      ExecutionEngine& engine,
-      std::unordered_map<ExecutionNode*, ExecutionBlock*> const&)
-      const override;
+      ExecutionEngine& engine) const override;
 
   /// @brief clone ExecutionNode recursively
   ExecutionNode* clone(ExecutionPlan* plan, bool withDependencies,
@@ -219,9 +215,7 @@ class DistributeNode final : public ScatterNode,
 
   /// @brief creates corresponding ExecutionBlock
   std::unique_ptr<ExecutionBlock> createBlock(
-      ExecutionEngine& engine,
-      std::unordered_map<ExecutionNode*, ExecutionBlock*> const&)
-      const override;
+      ExecutionEngine& engine) const override;
 
   /// @brief clone ExecutionNode recursively
   ExecutionNode* clone(ExecutionPlan* plan, bool withDependencies,
@@ -309,9 +303,7 @@ class GatherNode final : public ExecutionNode {
 
   /// @brief creates corresponding ExecutionBlock
   std::unique_ptr<ExecutionBlock> createBlock(
-      ExecutionEngine& engine,
-      std::unordered_map<ExecutionNode*, ExecutionBlock*> const&)
-      const override;
+      ExecutionEngine& engine) const override;
 
   /// @brief estimateCost
   CostEstimate estimateCost() const override final;
@@ -398,9 +390,7 @@ class SingleRemoteOperationNode final : public ExecutionNode,
 
   /// @brief creates corresponding ExecutionBlock
   std::unique_ptr<ExecutionBlock> createBlock(
-      ExecutionEngine& engine,
-      std::unordered_map<ExecutionNode*, ExecutionBlock*> const&)
-      const override;
+      ExecutionEngine& engine) const override;
 
   /// @brief clone ExecutionNode recursively
   ExecutionNode* clone(ExecutionPlan* plan, bool withDependencies,

--- a/arangod/Aql/CollectNode.cpp
+++ b/arangod/Aql/CollectNode.cpp
@@ -253,8 +253,7 @@ CollectNode::calcInputVariableNames() const {
 
 /// @brief creates corresponding ExecutionBlock
 std::unique_ptr<ExecutionBlock> CollectNode::createBlock(
-    ExecutionEngine& engine,
-    std::unordered_map<ExecutionNode*, ExecutionBlock*> const&) const {
+    ExecutionEngine& engine) const {
   switch (aggregationMethod()) {
     case CollectOptions::CollectMethod::HASH: {
       ExecutionNode const* previousNode = getFirstDependency();

--- a/arangod/Aql/CollectNode.h
+++ b/arangod/Aql/CollectNode.h
@@ -120,9 +120,7 @@ class CollectNode : public ExecutionNode {
 
   /// @brief creates corresponding ExecutionBlock
   std::unique_ptr<ExecutionBlock> createBlock(
-      ExecutionEngine& engine,
-      std::unordered_map<ExecutionNode*, ExecutionBlock*> const&)
-      const override;
+      ExecutionEngine& engine) const override;
 
   /// @brief clone ExecutionNode recursively
   ExecutionNode* clone(ExecutionPlan* plan, bool withDependencies,

--- a/arangod/Aql/DistributeConsumerNode.cpp
+++ b/arangod/Aql/DistributeConsumerNode.cpp
@@ -50,8 +50,7 @@ void DistributeConsumerNode::doToVelocyPack(VPackBuilder& nodes,
 }
 
 std::unique_ptr<ExecutionBlock> DistributeConsumerNode::createBlock(
-    ExecutionEngine& engine,
-    std::unordered_map<ExecutionNode*, ExecutionBlock*> const&) const {
+    ExecutionEngine& engine) const {
   TRI_ASSERT(hasDependency());
   ExecutionNode const* previousNode = getFirstDependency();
   TRI_ASSERT(previousNode != nullptr);

--- a/arangod/Aql/DistributeConsumerNode.h
+++ b/arangod/Aql/DistributeConsumerNode.h
@@ -55,9 +55,7 @@ class DistributeConsumerNode : public ExecutionNode {
 
   /// @brief creates corresponding ExecutionBlock
   std::unique_ptr<ExecutionBlock> createBlock(
-      ExecutionEngine& engine,
-      std::unordered_map<ExecutionNode*, ExecutionBlock*> const&)
-      const override;
+      ExecutionEngine& engine) const override;
 
   /// @brief whether or not this node will forward initializeCursor or shutDown
   /// requests

--- a/arangod/Aql/EnumeratePathsNode.cpp
+++ b/arangod/Aql/EnumeratePathsNode.cpp
@@ -357,8 +357,7 @@ std::unique_ptr<ExecutionBlock> EnumeratePathsNode::_makeExecutionBlockImpl(
 
 /// @brief creates corresponding ExecutionBlock
 std::unique_ptr<ExecutionBlock> EnumeratePathsNode::createBlock(
-    ExecutionEngine& engine,
-    std::unordered_map<ExecutionNode*, ExecutionBlock*> const&) const {
+    ExecutionEngine& engine) const {
   ExecutionNode const* previousNode = getFirstDependency();
   TRI_ASSERT(previousNode != nullptr);
   RegIdSet inputRegisters;

--- a/arangod/Aql/EnumeratePathsNode.h
+++ b/arangod/Aql/EnumeratePathsNode.h
@@ -90,9 +90,7 @@ class EnumeratePathsNode : public virtual GraphNode {
 
   /// @brief creates corresponding ExecutionBlock
   std::unique_ptr<ExecutionBlock> createBlock(
-      ExecutionEngine& engine,
-      std::unordered_map<ExecutionNode*, ExecutionBlock*> const&)
-      const override;
+      ExecutionEngine& engine) const override;
 
   /// @brief clone ExecutionNode recursively
   ExecutionNode* clone(ExecutionPlan* plan, bool withDependencies,

--- a/arangod/Aql/ExecutionEngine.cpp
+++ b/arangod/Aql/ExecutionEngine.cpp
@@ -42,6 +42,7 @@
 #include "Aql/SkipResult.h"
 #include "Aql/SharedQueryState.h"
 #include "Basics/ScopeGuard.h"
+#include "Containers/FlatHashMap.h"
 #include "Cluster/ClusterFeature.h"
 #include "Cluster/ClusterInfo.h"
 #include "Cluster/RebootTracker.h"
@@ -133,7 +134,7 @@ Result ExecutionEngine::createBlocks(std::vector<ExecutionNode*> const& nodes,
                                      MapRemoteToSnippet const& queryIds) {
   TRI_ASSERT(arangodb::ServerState::instance()->isCoordinator());
 
-  std::unordered_map<ExecutionNode*, ExecutionBlock*> cache;
+  containers::FlatHashMap<ExecutionNode*, ExecutionBlock*> cache;
   RemoteNode* remoteNode = nullptr;
 
   // We need to traverse the nodes from back to front, the walker collects
@@ -148,15 +149,15 @@ Result ExecutionEngine::createBlocks(std::vector<ExecutionNode*> const& nodes,
     }
 
     // for all node types but REMOTEs, we create blocks
-    auto uptrEb = en->createBlock(*this, cache);
+    auto block = en->createBlock(*this);
 
-    if (!uptrEb) {
+    if (!block) {
       return {TRI_ERROR_INTERNAL, "illegal node type"};
     }
 
     // transfers ownership
     // store the pointer to the block
-    auto eb = addBlock(std::move(uptrEb));
+    auto eb = addBlock(std::move(block));
 
     for (auto const& dep : en->getDependencies()) {
       auto d = cache.find(dep);
@@ -200,8 +201,7 @@ Result ExecutionEngine::createBlocks(std::vector<ExecutionNode*> const& nodes,
             remoteNode->queryId(snippetId);
             remoteNode->server(serverID);
             remoteNode->setDistributeId({""});
-            std::unique_ptr<ExecutionBlock> r =
-                remoteNode->createBlock(*this, {});
+            std::unique_ptr<ExecutionBlock> r = remoteNode->createBlock(*this);
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
             auto remoteBlock =
                 dynamic_cast<ExecutionBlockImpl<RemoteExecutor>*>(r.get());
@@ -263,7 +263,7 @@ struct SingleServerQueryInstanciator final
     : public WalkerWorker<ExecutionNode, WalkerUniqueness::NonUnique> {
   ExecutionEngine& engine;
   ExecutionBlock* root{};
-  std::unordered_map<ExecutionNode*, ExecutionBlock*> cache;
+  containers::FlatHashMap<ExecutionNode*, ExecutionBlock*> cache;
 
   explicit SingleServerQueryInstanciator(ExecutionEngine& engine) noexcept
       : engine(engine) {}
@@ -298,7 +298,7 @@ struct SingleServerQueryInstanciator final
     }
 
     if (block == nullptr) {
-      block = engine.addBlock(en->createBlock(engine, cache));
+      block = engine.addBlock(en->createBlock(engine));
       TRI_ASSERT(block != nullptr);
       // We have visited this node earlier, so we got its dependencies
       // Now add dependencies:

--- a/arangod/Aql/ExecutionNode.cpp
+++ b/arangod/Aql/ExecutionNode.cpp
@@ -1665,8 +1665,7 @@ auto ExecutionNode::getVarsValidStack() const noexcept -> VarSetStack const& {
 
 /// @brief creates corresponding ExecutionBlock
 std::unique_ptr<ExecutionBlock> SingletonNode::createBlock(
-    ExecutionEngine& engine,
-    std::unordered_map<ExecutionNode*, ExecutionBlock*> const&) const {
+    ExecutionEngine& engine) const {
   auto registerInfos = createRegisterInfos({}, {});
   IdExecutorInfos infos(false);
 
@@ -1725,8 +1724,7 @@ void EnumerateCollectionNode::doToVelocyPack(velocypack::Builder& builder,
 
 /// @brief creates corresponding ExecutionBlock
 std::unique_ptr<ExecutionBlock> EnumerateCollectionNode::createBlock(
-    ExecutionEngine& engine,
-    std::unordered_map<ExecutionNode*, ExecutionBlock*> const&) const {
+    ExecutionEngine& engine) const {
   ExecutionNode const* previousNode = getFirstDependency();
   TRI_ASSERT(previousNode != nullptr);
 
@@ -1860,8 +1858,7 @@ void EnumerateListNode::doToVelocyPack(velocypack::Builder& nodes,
 
 /// @brief creates corresponding ExecutionBlock
 std::unique_ptr<ExecutionBlock> EnumerateListNode::createBlock(
-    ExecutionEngine& engine,
-    std::unordered_map<ExecutionNode*, ExecutionBlock*> const&) const {
+    ExecutionEngine& engine) const {
   ExecutionNode const* previousNode = getFirstDependency();
   TRI_ASSERT(previousNode != nullptr);
   RegisterId inputRegister = variableToRegisterId(_inVariable);
@@ -1946,8 +1943,7 @@ LimitNode::LimitNode(ExecutionPlan* plan,
 
 /// @brief creates corresponding ExecutionBlock
 std::unique_ptr<ExecutionBlock> LimitNode::createBlock(
-    ExecutionEngine& engine,
-    std::unordered_map<ExecutionNode*, ExecutionBlock*> const&) const {
+    ExecutionEngine& engine) const {
   ExecutionNode const* previousNode = getFirstDependency();
   TRI_ASSERT(previousNode != nullptr);
 
@@ -2109,8 +2105,7 @@ void CalculationNode::doToVelocyPack(velocypack::Builder& nodes,
 
 /// @brief creates corresponding ExecutionBlock
 std::unique_ptr<ExecutionBlock> CalculationNode::createBlock(
-    ExecutionEngine& engine,
-    std::unordered_map<ExecutionNode*, ExecutionBlock*> const&) const {
+    ExecutionEngine& engine) const {
   ExecutionNode const* previousNode = getFirstDependency();
   TRI_ASSERT(previousNode != nullptr);
 
@@ -2348,8 +2343,7 @@ bool SubqueryNode::mayAccessCollections() {
 
 /// @brief creates corresponding ExecutionBlock
 std::unique_ptr<ExecutionBlock> SubqueryNode::createBlock(
-    ExecutionEngine&,
-    std::unordered_map<ExecutionNode*, ExecutionBlock*> const&) const {
+    ExecutionEngine& /*engine*/) const {
   TRI_ASSERT(false);
   THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_INTERNAL,
                                  "cannot instantiate SubqueryExecutor");
@@ -2522,8 +2516,7 @@ void FilterNode::doToVelocyPack(velocypack::Builder& nodes,
 
 /// @brief creates corresponding ExecutionBlock
 std::unique_ptr<ExecutionBlock> FilterNode::createBlock(
-    ExecutionEngine& engine,
-    std::unordered_map<ExecutionNode*, ExecutionBlock*> const&) const {
+    ExecutionEngine& engine) const {
   ExecutionNode const* previousNode = getFirstDependency();
   TRI_ASSERT(previousNode != nullptr);
   RegisterId inputRegister = variableToRegisterId(_inVariable);
@@ -2603,8 +2596,7 @@ void ReturnNode::doToVelocyPack(velocypack::Builder& nodes,
 
 /// @brief creates corresponding ExecutionBlock
 std::unique_ptr<ExecutionBlock> ReturnNode::createBlock(
-    ExecutionEngine& engine,
-    std::unordered_map<ExecutionNode*, ExecutionBlock*> const&) const {
+    ExecutionEngine& engine) const {
   ExecutionNode const* previousNode = getFirstDependency();
   TRI_ASSERT(previousNode != nullptr);
 
@@ -2705,8 +2697,7 @@ void NoResultsNode::doToVelocyPack(velocypack::Builder&, unsigned) const {
 
 /// @brief creates corresponding ExecutionBlock
 std::unique_ptr<ExecutionBlock> NoResultsNode::createBlock(
-    ExecutionEngine& engine,
-    std::unordered_map<ExecutionNode*, ExecutionBlock*> const&) const {
+    ExecutionEngine& engine) const {
   ExecutionNode const* previousNode = getFirstDependency();
   TRI_ASSERT(previousNode != nullptr);
 
@@ -2821,8 +2812,7 @@ void AsyncNode::doToVelocyPack(velocypack::Builder&, unsigned) const {
 
 /// @brief creates corresponding ExecutionBlock
 std::unique_ptr<ExecutionBlock> AsyncNode::createBlock(
-    ExecutionEngine& engine,
-    std::unordered_map<ExecutionNode*, ExecutionBlock*> const&) const {
+    ExecutionEngine& engine) const {
   return std::make_unique<ExecutionBlockImpl<AsyncExecutor>>(&engine, this);
 }
 
@@ -2938,8 +2928,7 @@ void MaterializeMultiNode::doToVelocyPack(velocypack::Builder& nodes,
 }
 
 std::unique_ptr<ExecutionBlock> MaterializeMultiNode::createBlock(
-    ExecutionEngine& engine,
-    std::unordered_map<ExecutionNode*, ExecutionBlock*> const&) const {
+    ExecutionEngine& engine) const {
   ExecutionNode const* previousNode = getFirstDependency();
   TRI_ASSERT(previousNode != nullptr);
 
@@ -3014,8 +3003,7 @@ void MaterializeSingleNode<localDocumentId>::doToVelocyPack(
 template<bool localDocumentId>
 std::unique_ptr<ExecutionBlock>
 MaterializeSingleNode<localDocumentId>::createBlock(
-    ExecutionEngine& engine,
-    std::unordered_map<ExecutionNode*, ExecutionBlock*> const&) const {
+    ExecutionEngine& engine) const {
   ExecutionNode const* previousNode = getFirstDependency();
   TRI_ASSERT(previousNode != nullptr);
   RegisterId outDocumentRegId;

--- a/arangod/Aql/ExecutionNode.h
+++ b/arangod/Aql/ExecutionNode.h
@@ -323,9 +323,7 @@ class ExecutionNode {
 
   /// @brief creates corresponding ExecutionBlock
   virtual std::unique_ptr<ExecutionBlock> createBlock(
-      ExecutionEngine& engine,
-      std::unordered_map<ExecutionNode*, ExecutionBlock*> const& cache)
-      const = 0;
+      ExecutionEngine& engine) const = 0;
 
   /// @brief clone execution Node recursively, this makes the class abstract
   virtual ExecutionNode* clone(ExecutionPlan* plan, bool withDependencies,
@@ -622,9 +620,7 @@ class SingletonNode : public ExecutionNode {
 
   /// @brief creates corresponding ExecutionBlock
   std::unique_ptr<ExecutionBlock> createBlock(
-      ExecutionEngine& engine,
-      std::unordered_map<ExecutionNode*, ExecutionBlock*> const&)
-      const override;
+      ExecutionEngine& engine) const override;
 
   /// @brief clone ExecutionNode recursively
   ExecutionNode* clone(ExecutionPlan* plan, bool withDependencies,
@@ -667,9 +663,7 @@ class EnumerateCollectionNode : public ExecutionNode,
 
   /// @brief creates corresponding ExecutionBlock
   std::unique_ptr<ExecutionBlock> createBlock(
-      ExecutionEngine& engine,
-      std::unordered_map<ExecutionNode*, ExecutionBlock*> const&)
-      const override;
+      ExecutionEngine& engine) const override;
 
   /// @brief clone ExecutionNode recursively
   ExecutionNode* clone(ExecutionPlan* plan, bool withDependencies,
@@ -731,9 +725,7 @@ class EnumerateListNode : public ExecutionNode {
 
   /// @brief creates corresponding ExecutionBlock
   std::unique_ptr<ExecutionBlock> createBlock(
-      ExecutionEngine& engine,
-      std::unordered_map<ExecutionNode*, ExecutionBlock*> const&)
-      const override;
+      ExecutionEngine& engine) const override;
 
   /// @brief clone ExecutionNode recursively
   ExecutionNode* clone(ExecutionPlan* plan, bool withDependencies,
@@ -788,9 +780,7 @@ class LimitNode : public ExecutionNode {
 
   /// @brief creates corresponding ExecutionBlock
   std::unique_ptr<ExecutionBlock> createBlock(
-      ExecutionEngine& engine,
-      std::unordered_map<ExecutionNode*, ExecutionBlock*> const&)
-      const override;
+      ExecutionEngine& engine) const override;
 
   /// @brief clone ExecutionNode recursively
   ExecutionNode* clone(ExecutionPlan* plan, bool withDependencies,
@@ -848,9 +838,7 @@ class CalculationNode : public ExecutionNode {
 
   /// @brief creates corresponding ExecutionBlock
   std::unique_ptr<ExecutionBlock> createBlock(
-      ExecutionEngine& engine,
-      std::unordered_map<ExecutionNode*, ExecutionBlock*> const&)
-      const override;
+      ExecutionEngine& engine) const override;
 
   /// @brief clone ExecutionNode recursively
   ExecutionNode* clone(ExecutionPlan* plan, bool withDependencies,
@@ -918,9 +906,7 @@ class SubqueryNode : public ExecutionNode {
 
   /// @brief creates corresponding ExecutionBlock
   std::unique_ptr<ExecutionBlock> createBlock(
-      ExecutionEngine& engine,
-      std::unordered_map<ExecutionNode*, ExecutionBlock*> const&)
-      const override;
+      ExecutionEngine& engine) const override;
 
   /// @brief clone ExecutionNode recursively
   ExecutionNode* clone(ExecutionPlan* plan, bool withDependencies,
@@ -988,9 +974,7 @@ class FilterNode : public ExecutionNode {
 
   /// @brief creates corresponding ExecutionBlock
   std::unique_ptr<ExecutionBlock> createBlock(
-      ExecutionEngine& engine,
-      std::unordered_map<ExecutionNode*, ExecutionBlock*> const&)
-      const override;
+      ExecutionEngine& engine) const override;
 
   /// @brief clone ExecutionNode recursively
   ExecutionNode* clone(ExecutionPlan* plan, bool withDependencies,
@@ -1058,9 +1042,7 @@ class ReturnNode : public ExecutionNode {
 
   /// @brief creates corresponding ExecutionBlock
   std::unique_ptr<ExecutionBlock> createBlock(
-      ExecutionEngine& engine,
-      std::unordered_map<ExecutionNode*, ExecutionBlock*> const&)
-      const override;
+      ExecutionEngine& engine) const override;
 
   /// @brief clone ExecutionNode recursively
   ExecutionNode* clone(ExecutionPlan* plan, bool withDependencies,
@@ -1111,9 +1093,7 @@ class NoResultsNode : public ExecutionNode {
 
   /// @brief creates corresponding ExecutionBlock
   std::unique_ptr<ExecutionBlock> createBlock(
-      ExecutionEngine& engine,
-      std::unordered_map<ExecutionNode*, ExecutionBlock*> const&)
-      const override;
+      ExecutionEngine& engine) const override;
 
   /// @brief clone ExecutionNode recursively
   ExecutionNode* clone(ExecutionPlan* plan, bool withDependencies,
@@ -1146,9 +1126,7 @@ class AsyncNode : public ExecutionNode {
 
   /// @brief creates corresponding ExecutionBlock
   std::unique_ptr<ExecutionBlock> createBlock(
-      ExecutionEngine& engine,
-      std::unordered_map<ExecutionNode*, ExecutionBlock*> const&)
-      const override;
+      ExecutionEngine& engine) const override;
 
   /// @brief clone ExecutionNode recursively
   ExecutionNode* clone(ExecutionPlan* plan, bool withDependencies,
@@ -1181,9 +1159,7 @@ class MaterializeNode : public ExecutionNode {
 
   /// @brief creates corresponding ExecutionBlock
   std::unique_ptr<ExecutionBlock> createBlock(
-      ExecutionEngine& engine,
-      std::unordered_map<ExecutionNode*, ExecutionBlock*> const&)
-      const override = 0;
+      ExecutionEngine& engine) const override = 0;
 
   /// @brief clone ExecutionNode recursively
   ExecutionNode* clone(ExecutionPlan* plan, bool withDependencies,
@@ -1228,9 +1204,7 @@ class MaterializeMultiNode : public MaterializeNode {
 
   /// @brief creates corresponding ExecutionBlock
   std::unique_ptr<ExecutionBlock> createBlock(
-      ExecutionEngine& engine,
-      std::unordered_map<ExecutionNode*, ExecutionBlock*> const&)
-      const override final;
+      ExecutionEngine& engine) const override final;
 
   /// @brief clone ExecutionNode recursively
   ExecutionNode* clone(ExecutionPlan* plan, bool withDependencies,
@@ -1256,9 +1230,7 @@ class MaterializeSingleNode : public MaterializeNode,
 
   /// @brief creates corresponding ExecutionBlock
   std::unique_ptr<ExecutionBlock> createBlock(
-      ExecutionEngine& engine,
-      std::unordered_map<ExecutionNode*, ExecutionBlock*> const&)
-      const override final;
+      ExecutionEngine& engine) const override final;
 
   /// @brief clone ExecutionNode recursively
   ExecutionNode* clone(ExecutionPlan* plan, bool withDependencies,

--- a/arangod/Aql/IResearchViewNode.cpp
+++ b/arangod/Aql/IResearchViewNode.cpp
@@ -1777,9 +1777,7 @@ void IResearchViewNode::setFilterCondition(aql::AstNode const* node) noexcept {
 #pragma GCC diagnostic ignored "-Wswitch"
 #endif
 std::unique_ptr<aql::ExecutionBlock> IResearchViewNode::createBlock(
-    aql::ExecutionEngine& engine,
-    std::unordered_map<aql::ExecutionNode*, aql::ExecutionBlock*> const&)
-    const {
+    aql::ExecutionEngine& engine) const {
   auto const createNoResultsExecutor = [this](aql::ExecutionEngine& engine) {
     auto emptyRegisterInfos = createRegisterInfos({}, {});
     aql::ExecutionNode const* previousNode = getFirstDependency();

--- a/arangod/Aql/IResearchViewNode.h
+++ b/arangod/Aql/IResearchViewNode.h
@@ -227,11 +227,8 @@ class IResearchViewNode final : public aql::ExecutionNode {
 #endif
 
   // Creates corresponding ExecutionBlock.
-  // TODO(MBkkt) Use containers::FlatHashMap
   std::unique_ptr<aql::ExecutionBlock> createBlock(
-      aql::ExecutionEngine& engine,
-      std::unordered_map<aql::ExecutionNode*, aql::ExecutionBlock*> const&)
-      const final;
+      aql::ExecutionEngine& engine) const final;
 
   aql::RegIdSet calcInputRegs() const;
 

--- a/arangod/Aql/IndexNode.cpp
+++ b/arangod/Aql/IndexNode.cpp
@@ -319,8 +319,7 @@ NonConstExpressionContainer IndexNode::buildNonConstExpressions() const {
 
 /// @brief creates corresponding ExecutionBlock
 std::unique_ptr<ExecutionBlock> IndexNode::createBlock(
-    ExecutionEngine& engine,
-    std::unordered_map<ExecutionNode*, ExecutionBlock*> const&) const {
+    ExecutionEngine& engine) const {
   ExecutionNode const* previousNode = getFirstDependency();
   TRI_ASSERT(previousNode != nullptr);
 

--- a/arangod/Aql/IndexNode.h
+++ b/arangod/Aql/IndexNode.h
@@ -94,9 +94,7 @@ class IndexNode : public ExecutionNode,
 
   /// @brief creates corresponding ExecutionBlock
   std::unique_ptr<ExecutionBlock> createBlock(
-      ExecutionEngine& engine,
-      std::unordered_map<ExecutionNode*, ExecutionBlock*> const&)
-      const override;
+      ExecutionEngine& engine) const override;
 
   /// @brief clone ExecutionNode recursively
   ExecutionNode* clone(ExecutionPlan* plan, bool withDependencies,

--- a/arangod/Aql/ModificationNodes.cpp
+++ b/arangod/Aql/ModificationNodes.cpp
@@ -119,8 +119,7 @@ void RemoveNode::doToVelocyPack(VPackBuilder& nodes, unsigned flags) const {
 
 /// @brief creates corresponding ExecutionBlock
 std::unique_ptr<ExecutionBlock> RemoveNode::createBlock(
-    ExecutionEngine& engine,
-    std::unordered_map<ExecutionNode*, ExecutionBlock*> const&) const {
+    ExecutionEngine& engine) const {
   ExecutionNode const* previousNode = getFirstDependency();
 
   TRI_ASSERT(previousNode != nullptr);
@@ -199,8 +198,7 @@ void InsertNode::doToVelocyPack(VPackBuilder& nodes, unsigned flags) const {
 
 /// @brief creates corresponding ExecutionBlock
 std::unique_ptr<ExecutionBlock> InsertNode::createBlock(
-    ExecutionEngine& engine,
-    std::unordered_map<ExecutionNode*, ExecutionBlock*> const&) const {
+    ExecutionEngine& engine) const {
   using namespace arangodb::aql;
 
   ExecutionNode const* previousNode = getFirstDependency();
@@ -316,8 +314,7 @@ void UpdateReplaceNode::replaceVariables(
 
 /// @brief creates corresponding ExecutionBlock
 std::unique_ptr<ExecutionBlock> UpdateNode::createBlock(
-    ExecutionEngine& engine,
-    std::unordered_map<ExecutionNode*, ExecutionBlock*> const&) const {
+    ExecutionEngine& engine) const {
   using namespace arangodb::aql;
 
   ExecutionNode const* previousNode = getFirstDependency();
@@ -406,8 +403,7 @@ ReplaceNode::ReplaceNode(ExecutionPlan* plan,
 
 /// @brief creates corresponding ExecutionBlock
 std::unique_ptr<ExecutionBlock> ReplaceNode::createBlock(
-    ExecutionEngine& engine,
-    std::unordered_map<ExecutionNode*, ExecutionBlock*> const&) const {
+    ExecutionEngine& engine) const {
   ExecutionNode const* previousNode = getFirstDependency();
   TRI_ASSERT(previousNode != nullptr);
 
@@ -514,8 +510,7 @@ void UpsertNode::doToVelocyPack(VPackBuilder& nodes, unsigned flags) const {
 
 /// @brief creates corresponding ExecutionBlock
 std::unique_ptr<ExecutionBlock> UpsertNode::createBlock(
-    ExecutionEngine& engine,
-    std::unordered_map<ExecutionNode*, ExecutionBlock*> const&) const {
+    ExecutionEngine& engine) const {
   using namespace arangodb::aql;
 
   ExecutionNode const* previousNode = getFirstDependency();

--- a/arangod/Aql/ModificationNodes.h
+++ b/arangod/Aql/ModificationNodes.h
@@ -174,9 +174,7 @@ class RemoveNode : public ModificationNode {
 
   /// @brief creates corresponding ExecutionBlock
   std::unique_ptr<ExecutionBlock> createBlock(
-      ExecutionEngine& engine,
-      std::unordered_map<ExecutionNode*, ExecutionBlock*> const&)
-      const override;
+      ExecutionEngine& engine) const override;
 
   /// @brief clone ExecutionNode recursively
   ExecutionNode* clone(ExecutionPlan* plan, bool withDependencies,
@@ -231,9 +229,7 @@ class InsertNode : public ModificationNode {
 
   /// @brief creates corresponding ExecutionBlock
   std::unique_ptr<ExecutionBlock> createBlock(
-      ExecutionEngine& engine,
-      std::unordered_map<ExecutionNode*, ExecutionBlock*> const&)
-      const override;
+      ExecutionEngine& engine) const override;
 
   /// @brief clone ExecutionNode recursively
   ExecutionNode* clone(ExecutionPlan* plan, bool withDependencies,
@@ -341,9 +337,7 @@ class UpdateNode : public UpdateReplaceNode {
 
   /// @brief creates corresponding ExecutionBlock
   std::unique_ptr<ExecutionBlock> createBlock(
-      ExecutionEngine& engine,
-      std::unordered_map<ExecutionNode*, ExecutionBlock*> const&)
-      const override;
+      ExecutionEngine& engine) const override;
 
   /// @brief clone ExecutionNode recursively
   ExecutionNode* clone(ExecutionPlan* plan, bool withDependencies,
@@ -374,9 +368,7 @@ class ReplaceNode : public UpdateReplaceNode {
 
   /// @brief creates corresponding ExecutionBlock
   std::unique_ptr<ExecutionBlock> createBlock(
-      ExecutionEngine& engine,
-      std::unordered_map<ExecutionNode*, ExecutionBlock*> const&)
-      const override;
+      ExecutionEngine& engine) const override;
 
   /// @brief clone ExecutionNode recursively
   ExecutionNode* clone(ExecutionPlan* plan, bool withDependencies,
@@ -418,9 +410,7 @@ class UpsertNode : public ModificationNode {
 
   /// @brief creates corresponding ExecutionBlock
   std::unique_ptr<ExecutionBlock> createBlock(
-      ExecutionEngine& engine,
-      std::unordered_map<ExecutionNode*, ExecutionBlock*> const&)
-      const override;
+      ExecutionEngine& engine) const override;
 
   /// @brief clone ExecutionNode recursively
   ExecutionNode* clone(ExecutionPlan* plan, bool withDependencies,

--- a/arangod/Aql/MultipleRemoteModificationNode.cpp
+++ b/arangod/Aql/MultipleRemoteModificationNode.cpp
@@ -58,8 +58,7 @@ MultipleRemoteModificationNode::MultipleRemoteModificationNode(
 
 /// @brief creates corresponding MultipleRemoteModificationNode
 std::unique_ptr<ExecutionBlock> MultipleRemoteModificationNode::createBlock(
-    ExecutionEngine& engine,
-    std::unordered_map<ExecutionNode*, ExecutionBlock*> const&) const {
+    ExecutionEngine& engine) const {
   ExecutionNode const* previousNode = getFirstDependency();
 
   TRI_ASSERT(previousNode != nullptr);

--- a/arangod/Aql/MultipleRemoteModificationNode.h
+++ b/arangod/Aql/MultipleRemoteModificationNode.h
@@ -77,9 +77,7 @@ class MultipleRemoteModificationNode final : public ExecutionNode,
 
   /// @brief creates corresponding ExecutionBlock
   std::unique_ptr<ExecutionBlock> createBlock(
-      ExecutionEngine& engine,
-      std::unordered_map<ExecutionNode*, ExecutionBlock*> const&)
-      const override;
+      ExecutionEngine& engine) const override;
 
   /// @brief clone ExecutionNode recursively
   ExecutionNode* clone(ExecutionPlan* plan, bool withDependencies,

--- a/arangod/Aql/MutexNode.cpp
+++ b/arangod/Aql/MutexNode.cpp
@@ -72,8 +72,7 @@ void MutexNode::doToVelocyPack(VPackBuilder& nodes, unsigned flags) const {
 
 /// @brief creates corresponding ExecutionBlock
 std::unique_ptr<ExecutionBlock> MutexNode::createBlock(
-    ExecutionEngine& engine,
-    std::unordered_map<ExecutionNode*, ExecutionBlock*> const&) const {
+    ExecutionEngine& engine) const {
   ExecutionNode const* previousNode = getFirstDependency();
   TRI_ASSERT(previousNode != nullptr);
 

--- a/arangod/Aql/MutexNode.h
+++ b/arangod/Aql/MutexNode.h
@@ -48,9 +48,7 @@ class MutexNode : public ExecutionNode {
 
   /// @brief creates corresponding ExecutionBlock
   std::unique_ptr<ExecutionBlock> createBlock(
-      ExecutionEngine& engine,
-      std::unordered_map<ExecutionNode*, ExecutionBlock*> const&)
-      const override;
+      ExecutionEngine& engine) const override;
 
   /// @brief clone ExecutionNode recursively
   ExecutionNode* clone(ExecutionPlan* plan, bool withDependencies,

--- a/arangod/Aql/ShortestPathNode.cpp
+++ b/arangod/Aql/ShortestPathNode.cpp
@@ -349,8 +349,7 @@ std::unique_ptr<ExecutionBlock> ShortestPathNode::_makeExecutionBlockImpl(
 
 /// @brief creates corresponding ExecutionBlock
 std::unique_ptr<ExecutionBlock> ShortestPathNode::createBlock(
-    ExecutionEngine& engine,
-    std::unordered_map<ExecutionNode*, ExecutionBlock*> const&) const {
+    ExecutionEngine& engine) const {
   ExecutionNode const* previousNode = getFirstDependency();
   TRI_ASSERT(previousNode != nullptr);
   auto inputRegisters = _buildVariableInformation();

--- a/arangod/Aql/ShortestPathNode.h
+++ b/arangod/Aql/ShortestPathNode.h
@@ -87,9 +87,7 @@ class ShortestPathNode : public virtual GraphNode {
 
   /// @brief creates corresponding ExecutionBlock
   std::unique_ptr<ExecutionBlock> createBlock(
-      ExecutionEngine& engine,
-      std::unordered_map<ExecutionNode*, ExecutionBlock*> const&)
-      const override;
+      ExecutionEngine& engine) const override;
 
   /// @brief clone ExecutionNode recursively
   ExecutionNode* clone(ExecutionPlan* plan, bool withDependencies,

--- a/arangod/Aql/SortNode.cpp
+++ b/arangod/Aql/SortNode.cpp
@@ -178,8 +178,7 @@ SortInformation SortNode::getSortInformation() const {
 
 /// @brief creates corresponding ExecutionBlock
 std::unique_ptr<ExecutionBlock> SortNode::createBlock(
-    ExecutionEngine& engine,
-    std::unordered_map<ExecutionNode*, ExecutionBlock*> const&) const {
+    ExecutionEngine& engine) const {
   ExecutionNode const* previousNode = getFirstDependency();
   TRI_ASSERT(previousNode != nullptr);
 

--- a/arangod/Aql/SortNode.h
+++ b/arangod/Aql/SortNode.h
@@ -74,13 +74,11 @@ class SortNode : public ExecutionNode {
   size_t getMemoryUsedBytes() const override final;
 
   /// @brief whether or not the sort is stable
-  inline bool isStable() const { return _stable; }
+  bool isStable() const { return _stable; }
 
   /// @brief creates corresponding ExecutionBlock
   std::unique_ptr<ExecutionBlock> createBlock(
-      ExecutionEngine& engine,
-      std::unordered_map<ExecutionNode*, ExecutionBlock*> const&)
-      const override;
+      ExecutionEngine& engine) const override;
 
   /// @brief clone ExecutionNode recursively
   ExecutionNode* clone(ExecutionPlan* plan, bool withDependencies,

--- a/arangod/Aql/SubqueryEndExecutionNode.cpp
+++ b/arangod/Aql/SubqueryEndExecutionNode.cpp
@@ -80,8 +80,7 @@ void SubqueryEndNode::doToVelocyPack(VPackBuilder& nodes,
 }
 
 std::unique_ptr<ExecutionBlock> SubqueryEndNode::createBlock(
-    ExecutionEngine& engine,
-    std::unordered_map<ExecutionNode*, ExecutionBlock*> const& cache) const {
+    ExecutionEngine& engine) const {
   ExecutionNode const* previousNode = getFirstDependency();
   TRI_ASSERT(previousNode != nullptr);
 

--- a/arangod/Aql/SubqueryEndExecutionNode.h
+++ b/arangod/Aql/SubqueryEndExecutionNode.h
@@ -51,9 +51,7 @@ class SubqueryEndNode : public ExecutionNode {
   Variable const* outVariable() const { return _outVariable; }
 
   std::unique_ptr<ExecutionBlock> createBlock(
-      ExecutionEngine& engine,
-      std::unordered_map<ExecutionNode*, ExecutionBlock*> const&)
-      const override;
+      ExecutionEngine& engine) const override;
 
   ExecutionNode* clone(ExecutionPlan* plan, bool withDependencies,
                        bool withProperties) const override final;

--- a/arangod/Aql/SubqueryStartExecutionNode.cpp
+++ b/arangod/Aql/SubqueryStartExecutionNode.cpp
@@ -70,8 +70,7 @@ void SubqueryStartNode::doToVelocyPack(VPackBuilder& nodes,
 }
 
 std::unique_ptr<ExecutionBlock> SubqueryStartNode::createBlock(
-    ExecutionEngine& engine,
-    std::unordered_map<ExecutionNode*, ExecutionBlock*> const& cache) const {
+    ExecutionEngine& engine) const {
   ExecutionNode const* previousNode = getFirstDependency();
   TRI_ASSERT(previousNode != nullptr);
 

--- a/arangod/Aql/SubqueryStartExecutionNode.h
+++ b/arangod/Aql/SubqueryStartExecutionNode.h
@@ -50,9 +50,7 @@ class SubqueryStartNode : public ExecutionNode {
   size_t getMemoryUsedBytes() const override final;
 
   std::unique_ptr<ExecutionBlock> createBlock(
-      ExecutionEngine& engine,
-      std::unordered_map<ExecutionNode*, ExecutionBlock*> const&)
-      const override;
+      ExecutionEngine& engine) const override;
 
   ExecutionNode* clone(ExecutionPlan* plan, bool withDependencies,
                        bool withProperties) const override final;

--- a/arangod/Aql/TraversalNode.cpp
+++ b/arangod/Aql/TraversalNode.cpp
@@ -800,8 +800,7 @@ TraversalNode::getSingleServerBaseProviderOptions(
 
 /// @brief creates corresponding ExecutionBlock
 std::unique_ptr<ExecutionBlock> TraversalNode::createBlock(
-    ExecutionEngine& engine,
-    std::unordered_map<ExecutionNode*, ExecutionBlock*> const& cache) const {
+    ExecutionEngine& engine) const {
   ExecutionNode const* previousNode = getFirstDependency();
   TRI_ASSERT(previousNode != nullptr);
   auto inputRegisters = RegIdSet{};

--- a/arangod/Aql/TraversalNode.h
+++ b/arangod/Aql/TraversalNode.h
@@ -124,9 +124,7 @@ class TraversalNode : public virtual GraphNode {
 
   /// @brief creates corresponding ExecutionBlock
   std::unique_ptr<ExecutionBlock> createBlock(
-      ExecutionEngine& engine,
-      std::unordered_map<ExecutionNode*, ExecutionBlock*> const&)
-      const override;
+      ExecutionEngine& engine) const override;
 
   std::unique_ptr<ExecutionBlock> createBlock(
       ExecutionEngine& engine,

--- a/arangod/Aql/WindowNode.cpp
+++ b/arangod/Aql/WindowNode.cpp
@@ -404,8 +404,7 @@ void WindowNode::calcAggregateTypes(
 
 /// @brief creates corresponding ExecutionBlock
 std::unique_ptr<ExecutionBlock> WindowNode::createBlock(
-    ExecutionEngine& engine,
-    std::unordered_map<ExecutionNode*, ExecutionBlock*> const&) const {
+    ExecutionEngine& engine) const {
   ExecutionNode const* previousNode = getFirstDependency();
   TRI_ASSERT(previousNode != nullptr);
 

--- a/arangod/Aql/WindowNode.h
+++ b/arangod/Aql/WindowNode.h
@@ -124,9 +124,7 @@ class WindowNode : public ExecutionNode {
 
   /// @brief creates corresponding ExecutionBlock
   std::unique_ptr<ExecutionBlock> createBlock(
-      ExecutionEngine& engine,
-      std::unordered_map<ExecutionNode*, ExecutionBlock*> const&)
-      const override;
+      ExecutionEngine& engine) const override;
 
   /// @brief clone ExecutionNode recursively
   ExecutionNode* clone(ExecutionPlan* plan, bool withDependencies,

--- a/tests/Aql/MockTypedNode.cpp
+++ b/tests/Aql/MockTypedNode.cpp
@@ -46,9 +46,7 @@ ExecutionNode* MockTypedNode::clone(ExecutionPlan* plan, bool withDependencies,
 }
 
 std::unique_ptr<::arangodb::aql::ExecutionBlock> MockTypedNode::createBlock(
-    ::arangodb::aql::ExecutionEngine& engine,
-    std::unordered_map<ExecutionNode*, ::arangodb::aql::ExecutionBlock*> const&)
-    const {
+    ::arangodb::aql::ExecutionEngine& engine) const {
   THROW_ARANGO_EXCEPTION(TRI_ERROR_NOT_IMPLEMENTED);
 }
 

--- a/tests/Aql/MockTypedNode.h
+++ b/tests/Aql/MockTypedNode.h
@@ -48,10 +48,7 @@ class MockTypedNode : public ::arangodb::aql::ExecutionNode {
                       unsigned flags) const override;
 
   std::unique_ptr<::arangodb::aql::ExecutionBlock> createBlock(
-      ::arangodb::aql::ExecutionEngine& engine,
-      std::unordered_map<ExecutionNode*,
-                         ::arangodb::aql::ExecutionBlock*> const&)
-      const override;
+      ::arangodb::aql::ExecutionEngine& engine) const override;
 
   ExecutionNode* clone(::arangodb::aql::ExecutionPlan* plan,
                        bool withDependencies,

--- a/tests/IResearch/IResearchViewCoordinatorTest.cpp
+++ b/tests/IResearch/IResearchViewCoordinatorTest.cpp
@@ -7919,9 +7919,6 @@ TEST_F(IResearchViewCoordinatorTest, IResearchViewNode_createBlock) {
     );
     node.addDependency(&singleton);
 
-    std::unordered_map<arangodb::aql::ExecutionNode*,
-                       arangodb::aql::ExecutionBlock*>
-        cache;
     singleton.setVarsUsedLater({arangodb::aql::VarSet{&outVariable}});
     singleton.setVarsValid({{}});
     node.setVarsUsedLater({{}});
@@ -7930,8 +7927,8 @@ TEST_F(IResearchViewCoordinatorTest, IResearchViewNode_createBlock) {
     node.setVarUsageValid();
     singleton.planRegisters();
     node.planRegisters();
-    auto singletonBlock = singleton.createBlock(*query->rootEngine(), cache);
-    auto execBlock = node.createBlock(*query->rootEngine(), cache);
+    auto singletonBlock = singleton.createBlock(*query->rootEngine());
+    auto execBlock = node.createBlock(*query->rootEngine());
     ASSERT_TRUE(nullptr != execBlock);
     ASSERT_TRUE(nullptr !=
                 dynamic_cast<arangodb::aql::ExecutionBlockImpl<

--- a/tests/IResearch/IResearchViewNodeTest.cpp
+++ b/tests/IResearch/IResearchViewNodeTest.cpp
@@ -3520,13 +3520,9 @@ TEST_F(IResearchViewNodeTest, createBlockSingleServer) {
 
     node.planRegisters();
 
-    std::unordered_map<arangodb::aql::ExecutionNode*,
-                       arangodb::aql::ExecutionBlock*>
-        EMPTY;
-
     // before transaction has started (no snapshot)
     try {
-      auto block = node.createBlock(engine, EMPTY);
+      auto block = node.createBlock(engine);
       EXPECT_TRUE(false);
     } catch (arangodb::basics::Exception const& e) {
       EXPECT_EQ(TRI_ERROR_INTERNAL, e.code());
@@ -3561,7 +3557,7 @@ TEST_F(IResearchViewNodeTest, createBlockSingleServer) {
 
     // after transaction has started
     {
-      auto block = node.createBlock(engine, EMPTY);
+      auto block = node.createBlock(engine);
       EXPECT_NE(nullptr, block);
       EXPECT_NE(
           nullptr,
@@ -3614,9 +3610,6 @@ TEST_F(IResearchViewNodeTest, createBlockCoordinator) {
       {});      // no sort condition
   node.addDependency(&singleton);
 
-  std::unordered_map<arangodb::aql::ExecutionNode*,
-                     arangodb::aql::ExecutionBlock*>
-      EMPTY;
   singleton.setVarsUsedLater({arangodb::aql::VarSet{&outVariable}});
   singleton.setVarsValid({{}});
   node.setVarsUsedLater({{}});
@@ -3627,7 +3620,7 @@ TEST_F(IResearchViewNodeTest, createBlockCoordinator) {
   node.planRegisters();
   arangodb::ServerState::instance()->setRole(
       arangodb::ServerState::ROLE_COORDINATOR);
-  auto emptyBlock = node.createBlock(engine, EMPTY);
+  auto emptyBlock = node.createBlock(engine);
   arangodb::ServerState::instance()->setRole(
       arangodb::ServerState::ROLE_SINGLE);
   EXPECT_NE(nullptr, emptyBlock);
@@ -3670,9 +3663,6 @@ TEST_F(IResearchViewNodeTest, createBlockCoordinatorLateMaterialize) {
       {});      // no sort condition
   node.addDependency(&singleton);
   node.setLateMaterialized(outNmDocId);
-  std::unordered_map<arangodb::aql::ExecutionNode*,
-                     arangodb::aql::ExecutionBlock*>
-      EMPTY;
   singleton.setVarsUsedLater({arangodb::aql::VarSet{&outNmDocId}});
   singleton.setVarsValid({{}});
   node.setVarsUsedLater({{}});
@@ -3683,7 +3673,7 @@ TEST_F(IResearchViewNodeTest, createBlockCoordinatorLateMaterialize) {
   node.planRegisters();
   arangodb::ServerState::instance()->setRole(
       arangodb::ServerState::ROLE_COORDINATOR);
-  auto emptyBlock = node.createBlock(engine, EMPTY);
+  auto emptyBlock = node.createBlock(engine);
   arangodb::ServerState::instance()->setRole(
       arangodb::ServerState::ROLE_SINGLE);
   EXPECT_TRUE(nullptr != emptyBlock);


### PR DESCRIPTION
### Scope & Purpose

Enterprise companion PR: https://github.com/arangodb/enterprise/pull/1313
Remove an unused parameter from the createBlock() API.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -
  - [ ] Backport for 3.9: -

#### Related Information

- [ ] Docs PR: 
- [x] Enterprise PR: https://github.com/arangodb/enterprise/pull/1313
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 