### PR TITLE
track sizes of requests more accurately

### DIFF
--- a/arangod/GeneralServer/RestHandler.cpp
+++ b/arangod/GeneralServer/RestHandler.cpp
@@ -72,7 +72,7 @@ RestHandler::RestHandler(ArangodServer& server, GeneralRequest* request,
       server.isEnabled<GeneralServerFeature>()) {
     _requestBodySizeTracker = metrics::GaugeCounterGuard<std::uint64_t>{
         server.getFeature<GeneralServerFeature>()._requestBodySize,
-        _request->rawPayload().size()};
+        _request->memoryUsage()};
   }
 }
 

--- a/arangod/RestHandler/RestBaseHandler.h
+++ b/arangod/RestHandler/RestBaseHandler.h
@@ -78,15 +78,17 @@ class RestBaseHandler : public rest::RestHandler {
   void generateForbidden();
 
  protected:
-  /// @brief parses the body (request) as VelocyPack, generates body
-  arangodb::velocypack::Slice parseVPackBody(bool& success);
+  /// @brief parses the request body as VelocyPack, generates body
+  velocypack::Slice parseVPackBody(bool& success);
 
   template<typename Payload>
-  void writeResult(Payload&&, arangodb::velocypack::Options const& options);
+  void writeResult(Payload&&, velocypack::Options const& options);
 
   /// @brief configure if outgoing responses will have the potential
   /// dirty reads header set:
-  void setOutgoingDirtyReadsHeader(bool flag) { _potentialDirtyReads = flag; }
+  void setOutgoingDirtyReadsHeader(bool flag) noexcept {
+    _potentialDirtyReads = flag;
+  }
 
   /// @brief Flag, if the outgoing response should have an HTTP header
   /// indicating potential dirty reads:

--- a/arangod/RestHandler/RestBatchHandler.cpp
+++ b/arangod/RestHandler/RestBatchHandler.cpp
@@ -204,18 +204,14 @@ bool RestBatchHandler::executeNextHandler() {
   if (bodyLength > 0) {
     LOG_TOPIC("63afb", TRACE, arangodb::Logger::REPLICATION)
         << "part body is '" << std::string(bodyStart, bodyLength) << "'";
-    request->body().clear();
-    request->body().reserve(bodyLength + 1);
-    request->body().append(bodyStart, bodyLength);
-    request->body().push_back('\0');
-    request->body().resetTo(bodyLength);  // ensure null terminated
+    request->clearBody();
+    request->appendBody(bodyStart, bodyLength);
+    request->appendNullTerminator();
   }
 
   if (!authorization.empty()) {
     // inject Authorization header of multipart message into part message
-    request->setHeader(StaticStrings::Authorization.c_str(),
-                       StaticStrings::Authorization.size(),
-                       authorization.c_str(), authorization.size());
+    request->setHeader(StaticStrings::Authorization, authorization);
   }
 
   std::shared_ptr<RestHandler> handler;

--- a/arangod/RestHandler/RestImportHandler.cpp
+++ b/arangod/RestHandler/RestImportHandler.cpp
@@ -462,18 +462,12 @@ bool RestImportHandler::createFromJson(std::string const& type) {
 
   else {
     // the entire request body is one JSON document
+    bool success = false;
+    VPackSlice documents = parseVPackBody(success);
 
-    VPackSlice documents;
-    try {
-      documents = _request->payload();
-    } catch (VPackException const& ex) {
-      generateError(
-          rest::ResponseCode::BAD, TRI_ERROR_HTTP_BAD_PARAMETER,
-          std::string("expecting a valid JSON array in the request. got: ") +
-              ex.what());
+    if (!success) {
       return false;
     }
-
     if (!documents.isArray()) {
       generateError(rest::ResponseCode::BAD, TRI_ERROR_HTTP_BAD_PARAMETER,
                     "expecting a JSON array in the request");
@@ -582,8 +576,12 @@ bool RestImportHandler::createFromVPack(std::string const& type) {
   VPackBuilder babies;
   babies.openArray();
 
-  VPackSlice const documents = _request->payload();
+  bool success = false;
+  VPackSlice documents = parseVPackBody(success);
 
+  if (!success) {
+    return false;
+  }
   if (!documents.isArray()) {
     generateError(rest::ResponseCode::BAD, TRI_ERROR_HTTP_BAD_PARAMETER,
                   "expecting a JSON array in the request");

--- a/lib/Rest/GeneralRequest.cpp
+++ b/lib/Rest/GeneralRequest.cpp
@@ -24,21 +24,59 @@
 
 #include "GeneralRequest.h"
 
+#include "Basics/StaticStrings.h"
 #include "Basics/StringUtils.h"
 #include "Basics/VelocyPackHelper.h"
 #include "Basics/debugging.h"
 #include "Logger/LogMacros.h"
-#include "Logger/Logger.h"
-#include "Logger/LoggerStream.h"
 #include "Rest/RequestContext.h"
 
 using namespace arangodb;
 using namespace arangodb::basics;
 
 namespace {
-// intentionally empty
-std::string const empty{};
+rest::RequestType translateMethodHelper(std::string_view method) noexcept {
+  if (method == "DELETE") {
+    return RequestType::DELETE_REQ;
+  } else if (method == "GET") {
+    return RequestType::GET;
+  } else if (method == "HEAD") {
+    return RequestType::HEAD;
+  } else if (method == "OPTIONS") {
+    return RequestType::OPTIONS;
+  } else if (method == "PATCH") {
+    return RequestType::PATCH;
+  } else if (method == "POST") {
+    return RequestType::POST;
+  } else if (method == "PUT") {
+    return RequestType::PUT;
+  }
+  return RequestType::ILLEGAL;
+}
+
 }  // namespace
+
+GeneralRequest::GeneralRequest(ConnectionInfo const& connectionInfo,
+                               uint64_t mid)
+    : _connectionInfo(connectionInfo),
+      _messageId(mid),
+      _requestContext(nullptr),
+      _tokenExpiry(0.0),
+      _memoryUsage(0),
+      _authenticationMethod(rest::AuthenticationMethod::NONE),
+      _type(RequestType::ILLEGAL),
+      _contentType(ContentType::UNSET),
+      _contentTypeResponse(ContentType::UNSET),
+      _acceptEncoding(EncodingType::UNSET),
+      _isRequestContextOwner(false),
+      _authenticated(false) {}
+
+GeneralRequest::~GeneralRequest() {
+  // only delete if we are the owner of the context
+  if (_requestContext != nullptr && _isRequestContextOwner) {
+    delete _requestContext;
+  }
+}
 
 std::string_view GeneralRequest::translateMethod(RequestType method) {
   switch (method) {
@@ -72,27 +110,6 @@ std::string_view GeneralRequest::translateMethod(RequestType method) {
 
   return {"UNKNOWN"};  // in order to please MSVC
 }
-
-namespace {
-rest::RequestType translateMethodHelper(std::string_view method) {
-  if (method == "DELETE") {
-    return RequestType::DELETE_REQ;
-  } else if (method == "GET") {
-    return RequestType::GET;
-  } else if (method == "HEAD") {
-    return RequestType::HEAD;
-  } else if (method == "OPTIONS") {
-    return RequestType::OPTIONS;
-  } else if (method == "PATCH") {
-    return RequestType::PATCH;
-  } else if (method == "POST") {
-    return RequestType::POST;
-  } else if (method == "PUT") {
-    return RequestType::PUT;
-  }
-  return RequestType::ILLEGAL;
-}
-}  // namespace
 
 rest::RequestType GeneralRequest::translateMethod(std::string_view method) {
   auto ret = ::translateMethodHelper(method);
@@ -150,13 +167,6 @@ rest::RequestType GeneralRequest::findRequestType(char const* ptr,
   return RequestType::ILLEGAL;
 }
 
-GeneralRequest::~GeneralRequest() {
-  // only delete if we are the owner of the context
-  if (_requestContext != nullptr && _isRequestContextOwner) {
-    delete _requestContext;
-  }
-}
-
 void GeneralRequest::setRequestContext(RequestContext* requestContext,
                                        bool isRequestContextOwner) {
   TRI_ASSERT(requestContext != nullptr);
@@ -174,9 +184,34 @@ void GeneralRequest::setRequestContext(RequestContext* requestContext,
   _isRequestContextOwner = isRequestContextOwner;
 }
 
+void GeneralRequest::setFullUrl(std::string fullUrl) {
+  setStringValue(_fullUrl, std::move(fullUrl));
+  if (_fullUrl.empty()) {
+    _fullUrl.push_back('/');
+    _memoryUsage += 1;
+  }
+}
+
+void GeneralRequest::setRequestPath(std::string path) {
+  setStringValue(_requestPath, std::move(path));
+}
+
+void GeneralRequest::setDatabaseName(std::string databaseName) {
+  setStringValue(_databaseName, std::move(databaseName));
+}
+
+void GeneralRequest::setUser(std::string user) {
+  setStringValue(_user, std::move(user));
+}
+
+void GeneralRequest::setPrefix(std::string prefix) {
+  setStringValue(_prefix, std::move(prefix));
+}
+
 void GeneralRequest::addSuffix(std::string part) {
   // part will not be URL-decoded here!
   _suffixes.emplace_back(std::move(part));
+  _memoryUsage += _suffixes.back().size();
 }
 
 std::vector<std::string> GeneralRequest::decodedSuffixes() const {
@@ -194,7 +229,7 @@ std::string const& GeneralRequest::header(std::string const& key,
   auto it = _headers.find(key);
   if (it == _headers.end()) {
     found = false;
-    return ::empty;
+    return StaticStrings::Empty;
   }
 
   found = true;
@@ -204,6 +239,24 @@ std::string const& GeneralRequest::header(std::string const& key,
 std::string const& GeneralRequest::header(std::string const& key) const {
   bool unused = true;
   return header(key, unused);
+}
+
+void GeneralRequest::removeHeader(std::string const& key) {
+  auto it = _headers.find(key);
+  if (it != _headers.end()) {
+    auto old = (*it).first.size() + (*it).second.size();
+    _headers.erase(it);
+    TRI_ASSERT(_memoryUsage >= old);
+    _memoryUsage -= old;
+  }
+}
+
+void GeneralRequest::addHeader(std::string key, std::string value) {
+  auto memoryUsage = key.size() + value.size();
+  auto it = _headers.try_emplace(std::move(key), std::move(value));
+  if (it.second) {
+    _memoryUsage += memoryUsage;
+  }
 }
 
 std::string const& GeneralRequest::value(std::string const& key,
@@ -218,7 +271,7 @@ std::string const& GeneralRequest::value(std::string const& key,
   }
 
   found = false;
-  return ::empty;
+  return StaticStrings::Empty;
 }
 
 std::string const& GeneralRequest::value(std::string const& key) const {
@@ -232,6 +285,14 @@ std::map<std::string, std::string> GeneralRequest::parameters() const {
     parameters.try_emplace(paramPair.first, paramPair.second);
   }
   return parameters;
+}
+
+void GeneralRequest::setStringValue(std::string& target, std::string&& value) {
+  auto old = target.size();
+  target = std::move(value);
+  _memoryUsage += target.size();
+  TRI_ASSERT(_memoryUsage >= old);
+  _memoryUsage -= old;
 }
 
 // needs to be here because of a gcc bug with templates and namespaces
@@ -304,7 +365,7 @@ template auto GeneralRequest::parsedValue<double>(std::string const&, double)
 /// @brief get VelocyPack options for validation. effectively turns off
 /// validation if strictValidation is false. This optimization can be used for
 /// internal requests
-arangodb::velocypack::Options const* GeneralRequest::validationOptions(
+velocypack::Options const* GeneralRequest::validationOptions(
     bool strictValidation) {
   if (strictValidation) {
     return &basics::VelocyPackHelper::strictRequestValidationOptions;

--- a/lib/Rest/GeneralRequest.h
+++ b/lib/Rest/GeneralRequest.h
@@ -57,44 +57,24 @@ class GeneralRequest {
  public:
   GeneralRequest(GeneralRequest&&) = default;
 
+  explicit GeneralRequest(ConnectionInfo const& connectionInfo, uint64_t mid);
+
+  virtual ~GeneralRequest();
+
   // translate an RequestType enum value into an "HTTP method string"
   static std::string_view translateMethod(RequestType);
 
   // translate "HTTP method string" into RequestType enum value
   static RequestType translateMethod(std::string_view method);
 
- protected:
-  static RequestType findRequestType(char const*, size_t const);
+  size_t memoryUsage() const noexcept { return _memoryUsage; }
+  void increaseMemoryUsage(size_t value) noexcept { _memoryUsage += value; }
 
-  /// @brief get VelocyPack options for validation. effectively turns off
-  /// validation if strictValidation is false. This optimization can be used for
-  /// internal requests
-  arangodb::velocypack::Options const* validationOptions(bool strictValidation);
-
- public:
-  explicit GeneralRequest(ConnectionInfo const& connectionInfo, uint64_t mid)
-      : _connectionInfo(connectionInfo),
-        _messageId(mid),
-        _requestContext(nullptr),
-        _tokenExpiry(0.0),
-        _authenticationMethod(rest::AuthenticationMethod::NONE),
-        _type(RequestType::ILLEGAL),
-        _contentType(ContentType::UNSET),
-        _contentTypeResponse(ContentType::UNSET),
-        _acceptEncoding(EncodingType::UNSET),
-        _isRequestContextOwner(false),
-        _authenticated(false) {}
-
-  virtual ~GeneralRequest();
-
- public:
   ConnectionInfo const& connectionInfo() const { return _connectionInfo; }
 
   /// Database used for this request, _system by default
   std::string const& databaseName() const { return _databaseName; }
-  void setDatabaseName(std::string const& databaseName) {
-    _databaseName = databaseName;
-  }
+  void setDatabaseName(std::string databaseName);
 
   /// @brief User exists on this server or on external auth system
   ///  and password was checked. Must not imply any access rights
@@ -107,7 +87,7 @@ class GeneralRequest {
 
   // @brief User sending this request
   std::string const& user() const { return _user; }
-  void setUser(std::string const& user) { _user = user; }
+  void setUser(std::string user);
 
   /// @brief the request context depends on the application
   RequestContext* requestContext() const { return _requestContext; }
@@ -121,17 +101,20 @@ class GeneralRequest {
   void setRequestType(RequestType type) { _type = type; }
 
   std::string const& fullUrl() const { return _fullUrl; }
+  void setFullUrl(std::string fullUrl);
+
   std::string const& requestUrl() const { return _fullUrl; }
 
   // consists of the URL without the host and without any parameters.
   std::string const& requestPath() const { return _requestPath; }
+  void setRequestPath(std::string path);
 
   // The request path consists of the URL without the host and without any
   // parameters.  The request path is split into two parts: the prefix, namely
   // the part of the request path that was match by a handler and the suffix
   // with all the remaining arguments.
   std::string prefix() const { return _prefix; }
-  void setPrefix(std::string const& prefix) { _prefix = prefix; }
+  void setPrefix(std::string prefix);
 
   // Returns the request path suffixes in non-URL-decoded form
   std::vector<std::string> const& suffixes() const { return _suffixes; }
@@ -139,7 +122,14 @@ class GeneralRequest {
   void addSuffix(std::string part);
 
 #ifdef ARANGODB_USE_GOOGLE_TESTS
-  void clearSuffixes() { _suffixes.clear(); }
+  void clearSuffixes() {
+    size_t memoryUsage = 0;
+    for (auto const& it : _suffixes) {
+      memoryUsage += it.size();
+    }
+    _suffixes.clear();
+    _memoryUsage -= memoryUsage;
+  }
 #endif
 
   // Returns the request path suffixes in URL-decoded form. Note: this will
@@ -148,7 +138,7 @@ class GeneralRequest {
 
   uint64_t messageId() const { return _messageId; }
 
-  virtual arangodb::Endpoint::TransportType transportType() = 0;
+  virtual Endpoint::TransportType transportType() = 0;
 
   // get value from headers map. The key must be lowercase.
   std::string const& header(std::string const& key) const;
@@ -157,10 +147,8 @@ class GeneralRequest {
     return _headers;
   }
 
-  void removeHeader(std::string const& key) { _headers.erase(key); }
-  void addHeader(std::string key, std::string value) {
-    _headers.emplace(std::move(key), std::move(value));
-  }
+  void removeHeader(std::string const& key);
+  void addHeader(std::string key, std::string value);
 
   // the value functions give access to to query string parameters
   std::string const& value(std::string const& key) const;
@@ -193,7 +181,7 @@ class GeneralRequest {
   /// @brief parsed request payload
   virtual velocypack::Slice payload(bool strictValidation = true) = 0;
   /// @brief overwrite payload
-  virtual void setPayload(arangodb::velocypack::Buffer<uint8_t> buffer) = 0;
+  virtual void setPayload(velocypack::Buffer<uint8_t> buffer) = 0;
 
   virtual void setDefaultContentType() = 0;
   /// @brieg should reflect the Content-Type header
@@ -215,6 +203,15 @@ class GeneralRequest {
   }
 
  protected:
+  static RequestType findRequestType(char const*, size_t const);
+
+  void setStringValue(std::string& target, std::string&& value);
+
+  /// @brief get VelocyPack options for validation. effectively turns off
+  /// validation if strictValidation is false. This optimization can be used for
+  /// internal requests
+  velocypack::Options const* validationOptions(bool strictValidation);
+
   ConnectionInfo _connectionInfo;  /// connection info
 
   /// request payload buffer, exact access semantics are defined in subclass
@@ -242,6 +239,8 @@ class GeneralRequest {
   RequestContext* _requestContext;
 
   double _tokenExpiry;
+
+  size_t _memoryUsage;
 
   rest::AuthenticationMethod _authenticationMethod;
 

--- a/lib/Rest/GeneralRequest.h
+++ b/lib/Rest/GeneralRequest.h
@@ -175,19 +175,22 @@ class GeneralRequest {
   auto parsedValue(std::string const& key) -> std::optional<T>;
 
   /// @brief the content length
-  virtual size_t contentLength() const = 0;
+  virtual size_t contentLength() const noexcept = 0;
   /// @brief unprocessed request payload
   virtual std::string_view rawPayload() const = 0;
   /// @brief parsed request payload
   virtual velocypack::Slice payload(bool strictValidation = true) = 0;
   /// @brief overwrite payload
-  virtual void setPayload(velocypack::Buffer<uint8_t> buffer) = 0;
+  virtual void setPayload(velocypack::Buffer<uint8_t> buffer);
 
-  virtual void setDefaultContentType() = 0;
+  virtual void setDefaultContentType() noexcept = 0;
   /// @brieg should reflect the Content-Type header
-  ContentType contentType() const { return _contentType; }
+  ContentType contentType() const noexcept { return _contentType; }
   /// @brief should generally reflect the Accept header
-  ContentType contentTypeResponse() const { return _contentTypeResponse; }
+  ContentType contentTypeResponse() const noexcept {
+    return _contentTypeResponse;
+  }
+
   std::string const& contentTypeResponsePlain() const {
     return _contentTypeResponsePlain;
   }
@@ -204,6 +207,8 @@ class GeneralRequest {
 
  protected:
   static RequestType findRequestType(char const*, size_t const);
+  void setValue(std::string key, std::string value);
+  void setArrayValue(std::string key, std::string value);
 
   void setStringValue(std::string& target, std::string&& value);
 

--- a/lib/Rest/HttpRequest.cpp
+++ b/lib/Rest/HttpRequest.cpp
@@ -643,27 +643,6 @@ void HttpRequest::setHeader(std::string key, std::string value) {
   _memoryUsage += memoryUsage;
 }
 
-void HttpRequest::setValue(std::string key, std::string value) {
-  auto memoryUsage = key.size() + value.size();
-  auto it = _values.try_emplace(std::move(key), std::move(value));
-  if (!it.second) {
-    auto old = it.first->first.size() + it.first->second.size();
-    _values[std::move(key)] = std::move(value);
-    _memoryUsage -= old;
-  }
-  _memoryUsage += memoryUsage;
-}
-
-void HttpRequest::setArrayValue(std::string key, std::string value) {
-  auto memoryUsage = value.size();
-  auto it = _arrayValues.find(key);
-  if (it == _arrayValues.end()) {
-    memoryUsage += key.size();
-  }
-  _arrayValues[std::move(key)].emplace_back(std::move(value));
-  _memoryUsage += memoryUsage;
-}
-
 void HttpRequest::setValues(char* buffer, char* end) {
   char* keyBegin = nullptr;
   char* key = nullptr;
@@ -948,12 +927,4 @@ VPackSlice HttpRequest::payload(bool strictValidation) {
   }
 
   return VPackSlice::noneSlice();
-}
-
-void HttpRequest::setPayload(velocypack::Buffer<uint8_t> buffer) {
-  auto old = _payload.size();
-  _payload = std::move(buffer);
-  _memoryUsage += _payload.size();
-  TRI_ASSERT(_memoryUsage >= old);
-  _memoryUsage -= old;
 }

--- a/lib/Rest/HttpRequest.h
+++ b/lib/Rest/HttpRequest.h
@@ -55,15 +55,14 @@ class HttpRequest final : public GeneralRequest {
     return _cookies;
   }
 
-  void setDefaultContentType() override {
+  void setDefaultContentType() noexcept override {
     _contentType = rest::ContentType::JSON;
   }
   /// @brief the body content length
-  size_t contentLength() const override { return _payload.size(); }
+  size_t contentLength() const noexcept override { return _payload.size(); }
   // Payload
   std::string_view rawPayload() const override;
   velocypack::Slice payload(bool strictValidation) override;
-  void setPayload(velocypack::Buffer<uint8_t> buffer) override;
 
   velocypack::Buffer<uint8_t> const& body() { return _payload; }
   void appendBody(char const* data, size_t size);
@@ -76,8 +75,6 @@ class HttpRequest final : public GeneralRequest {
   void setHeader(std::string key, std::string value);
 
  private:
-  void setValue(std::string key, std::string value);
-  void setArrayValue(std::string key, std::string value);
   void setCookie(std::string key, std::string value);
   /// used by RestBatchHandler (an API straight from hell)
   void parseHeader(char* buffer, size_t length);

--- a/lib/Rest/VstRequest.cpp
+++ b/lib/Rest/VstRequest.cpp
@@ -56,10 +56,43 @@ VstRequest::VstRequest(ConnectionInfo const& connectionInfo,
       _validatedPayload(false) {
   _contentType = ContentType::UNSET;  // intentional
   _contentTypeResponse = ContentType::VPACK;
-  _payload = std::move(buffer), parseHeaderInformation();
+  _payload = std::move(buffer);
+  _memoryUsage += _payload.size();
+  parseHeaderInformation();
+  _memoryUsage += sizeof(VstRequest);
 }
 
-size_t VstRequest::contentLength() const {
+VstRequest::~VstRequest() {
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+  auto expected = sizeof(VstRequest) + _fullUrl.size() + _requestPath.size() +
+                  _databaseName.size() + _user.size() + _prefix.size() +
+                  _contentTypeResponsePlain.size() + _payload.size();
+  for (auto const& it : _suffixes) {
+    expected += it.size();
+  }
+  for (auto const& it : _headers) {
+    expected += it.first.size() + it.second.size();
+  }
+  for (auto const& it : _values) {
+    expected += it.first.size() + it.second.size();
+  }
+  for (auto const& it : _arrayValues) {
+    expected += it.first.size();
+    for (auto const& it2 : it.second) {
+      expected += it2.size();
+    }
+  }
+  if (_vpackBuilder) {
+    expected += _vpackBuilder->bufferRef().size();
+  }
+
+  TRI_ASSERT(_memoryUsage == expected)
+      << "expected memory usage: " << expected << ", actual: " << _memoryUsage
+      << ", diff: " << (_memoryUsage - expected);
+#endif
+}
+
+size_t VstRequest::contentLength() const noexcept {
   TRI_ASSERT(_payload.size() >= _payloadOffset);
   if (_payload.size() < _payloadOffset) {
     return 0;
@@ -82,6 +115,7 @@ VPackSlice VstRequest::payload(bool strictValidation) {
       _vpackBuilder = VPackParser::fromJson(
           _payload.data() + _payloadOffset, _payload.size() - _payloadOffset,
           validationOptions(strictValidation));
+      _memoryUsage += _vpackBuilder->bufferRef().size();
     }
     if (_vpackBuilder) {
       return _vpackBuilder->slice();
@@ -106,7 +140,7 @@ VPackSlice VstRequest::payload(bool strictValidation) {
 }
 
 void VstRequest::setPayload(arangodb::velocypack::Buffer<uint8_t> buffer) {
-  _payload = std::move(buffer);
+  GeneralRequest::setPayload(std::move(buffer));
   _payloadOffset = 0;
 }
 
@@ -123,9 +157,9 @@ void VstRequest::setHeader(VPackSlice keySlice, VPackSlice valSlice) {
     StringUtils::tolowerInPlace(value);
     _contentTypeResponse = rest::stringToContentType(value, ContentType::VPACK);
     if (value.find(',') != std::string::npos) {
-      _contentTypeResponsePlain = value;
+      setStringValue(_contentTypeResponsePlain, std::move(value));
     } else {
-      _contentTypeResponsePlain.clear();
+      setStringValue(_contentTypeResponsePlain, std::string());
     }
     return;  // don't insert this header!!
   } else if ((_contentType == ContentType::UNSET) &&
@@ -142,8 +176,14 @@ void VstRequest::setHeader(VPackSlice keySlice, VPackSlice valSlice) {
     }
   }
 
-  // must lower-case the header key
-  _headers.try_emplace(std::move(key), std::move(value));
+  auto memoryUsage = key.size() + value.size();
+  auto it = _headers.try_emplace(std::move(key), std::move(value));
+  if (!it.second) {
+    auto old = it.first->first.size() + it.first->second.size();
+    _headers[std::move(key)] = std::move(value);
+    _memoryUsage -= old;
+  }
+  _memoryUsage += memoryUsage;
 }
 
 void VstRequest::parseHeaderInformation() {
@@ -161,7 +201,7 @@ void VstRequest::parseHeaderInformation() {
     auto type = vHeader.at(1).getInt();     // type
     {
       VPackSlice dbName = vHeader.at(2);  // database
-      _databaseName = dbName.copyString();
+      setDatabaseName(dbName.copyString());
       if (_databaseName != normalizeUtf8ToNFC(_databaseName)) {
         THROW_ARANGO_EXCEPTION_MESSAGE(
             TRI_ERROR_ARANGO_ILLEGAL_NAME,
@@ -169,9 +209,9 @@ void VstRequest::parseHeaderInformation() {
       }
     }
     _type = meta::toEnum<RequestType>(vHeader.at(3).getInt());  // request type
-    _requestPath = vHeader.at(4).copyString();  // request (path)
-    VPackSlice params = vHeader.at(5);          // parameter
-    VPackSlice meta = vHeader.at(6);            // meta
+    setRequestPath(vHeader.at(4).copyString());  // request (path)
+    VPackSlice params = vHeader.at(5);           // parameter
+    VPackSlice meta = vHeader.at(6);             // meta
 
     if (version != 1) {
       LOG_TOPIC("e7fe5", WARN, Logger::COMMUNICATION)
@@ -184,13 +224,11 @@ void VstRequest::parseHeaderInformation() {
 
     for (auto it : VPackObjectIterator(params, true)) {
       if (it.value.isArray()) {
-        std::vector<std::string> tmp;
         for (auto itInner : VPackArrayIterator(it.value)) {
-          tmp.emplace_back(itInner.copyString());
+          setArrayValue(it.key.copyString(), itInner.copyString());
         }
-        _arrayValues.try_emplace(it.key.copyString(), std::move(tmp));
       } else {
-        _values.try_emplace(it.key.copyString(), it.value.copyString());
+        setValue(it.key.copyString(), it.value.copyString());
       }
     }
 
@@ -199,6 +237,7 @@ void VstRequest::parseHeaderInformation() {
     }
 
     // fullUrl should not be necessary for Vst
+    auto old = _fullUrl.size();
     _fullUrl = _requestPath;
     _fullUrl.push_back('?');  // intentional
     for (auto const& param : _values) {
@@ -215,7 +254,9 @@ void VstRequest::parseHeaderInformation() {
       }
     }
     _fullUrl.pop_back();  // remove last & or ?
-
+    _memoryUsage += _fullUrl.size();
+    TRI_ASSERT(_memoryUsage >= old);
+    _memoryUsage -= old;
   } catch (std::exception const& e) {
     throw std::runtime_error(
         std::string("Error during Parsing of VstHeader: ") + e.what());

--- a/lib/Rest/VstRequest.h
+++ b/lib/Rest/VstRequest.h
@@ -38,7 +38,6 @@ namespace arangodb {
 struct ConnectionInfo;
 namespace velocypack {
 class Builder;
-struct Options;
 }  // namespace velocypack
 
 class VstRequest final : public GeneralRequest {
@@ -47,20 +46,20 @@ class VstRequest final : public GeneralRequest {
              velocypack::Buffer<uint8_t> buffer, size_t payloadOffset,
              uint64_t messageId);
 
-  ~VstRequest() = default;
+  ~VstRequest();
 
-  size_t contentLength() const override;
+  size_t contentLength() const noexcept override;
   std::string_view rawPayload() const override;
   velocypack::Slice payload(bool strictValidation = true) override;
   void setPayload(arangodb::velocypack::Buffer<uint8_t> buffer) override;
 
-  virtual void setDefaultContentType() override {
+  void setDefaultContentType() noexcept override {
     _contentType = rest::ContentType::VPACK;
   }
 
-  arangodb::Endpoint::TransportType transportType() override {
-    return arangodb::Endpoint::TransportType::VST;
-  };
+  Endpoint::TransportType transportType() override {
+    return Endpoint::TransportType::VST;
+  }
 
  private:
   void setHeader(velocypack::Slice key, velocypack::Slice content);

--- a/tests/IResearch/RestHandlerMock.cpp
+++ b/tests/IResearch/RestHandlerMock.cpp
@@ -41,7 +41,9 @@ GeneralRequestMock::GeneralRequestMock(TRI_vocbase_t& vocbase)
 }
 GeneralRequestMock::~GeneralRequestMock() = default;
 
-size_t GeneralRequestMock::contentLength() const { return _contentLength; }
+size_t GeneralRequestMock::contentLength() const noexcept {
+  return _contentLength;
+}
 
 std::string_view GeneralRequestMock::rawPayload() const {
   return std::string_view(reinterpret_cast<char const*>(_payload.data()),

--- a/tests/IResearch/RestHandlerMock.h
+++ b/tests/IResearch/RestHandlerMock.h
@@ -45,17 +45,15 @@ struct GeneralRequestMock : public arangodb::GeneralRequest {
   GeneralRequestMock(TRI_vocbase_t& vocbase);
   ~GeneralRequestMock();
   using arangodb::GeneralRequest::addSuffix;
-  virtual size_t contentLength() const override;
-  virtual void setDefaultContentType() override {
+  size_t contentLength() const noexcept override;
+  void setDefaultContentType() noexcept override {
     _contentType = arangodb::rest::ContentType::VPACK;
   }
-  virtual std::string_view rawPayload() const override;
-  virtual arangodb::velocypack::Slice payload(
-      bool strictValidation = true) override;
-  virtual void setPayload(
-      arangodb::velocypack::Buffer<uint8_t> buffer) override;
-  virtual void setData(arangodb::velocypack::Slice slice);
-  virtual arangodb::Endpoint::TransportType transportType() override;
+  std::string_view rawPayload() const override;
+  arangodb::velocypack::Slice payload(bool strictValidation = true) override;
+  void setPayload(arangodb::velocypack::Buffer<uint8_t> buffer) override;
+  void setData(arangodb::velocypack::Slice slice);
+  arangodb::Endpoint::TransportType transportType() override;
   std::unordered_map<std::string, std::string>& values() { return _values; }
 };
 

--- a/tests/js/client/shell/api/multi/import-novst.js
+++ b/tests/js/client/shell/api/multi/import-novst.js
@@ -128,7 +128,7 @@ function import_self_contained_documentsSuite () {
 
       assertEqual(doc.code, internal.errors.ERROR_HTTP_BAD_PARAMETER.code);
       assertTrue(doc.parsedBody['error']);
-      assertEqual(doc.parsedBody['errorNum'], internal.errors.ERROR_HTTP_BAD_PARAMETER.code);
+      assertEqual(doc.parsedBody['errorNum'], internal.errors.ERROR_HTTP_CORRUPTED_JSON.code);
     },
 
     test_JSONA_empty_body: function() {


### PR DESCRIPTION
### Scope & Purpose

Track request sizes more accurately. Includes HTTP and VST requests.
Overheads of contains (capacity vs. size) are not tracked, but only payload sizes.
Correctness is currently validated via assertions in the destructors.
The PR also slightly cleans up the internal APIs of HttpRequest and GeneralRequest and moves responsibilities for a few things.

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -
  - [ ] Backport for 3.9: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 