### PR TITLE
[CINFRA-794] Prepare for custom WAL implementation

### DIFF
--- a/arangod/Replication2/Methods.cpp
+++ b/arangod/Replication2/Methods.cpp
@@ -244,9 +244,9 @@ struct VPackLogIterator final : PersistedLogIterator {
       : buffer(std::move(buffer_ptr)),
         iter(VPackSlice(buffer->data()).get("result")) {}
 
-  auto next() -> std::optional<PersistingLogEntry> override {
+  auto next() -> std::optional<LogEntry> override {
     while (iter != std::default_sentinel) {
-      return PersistingLogEntry::fromVelocyPack(*iter++);
+      return LogEntry::fromVelocyPack(*iter++);
     }
     return std::nullopt;
   }

--- a/arangod/Replication2/Methods.cpp
+++ b/arangod/Replication2/Methods.cpp
@@ -115,7 +115,7 @@ struct ReplicatedLogMethodsDBServer final
   }
 
   auto slice(LogId id, LogIndex start, LogIndex stop) const
-      -> futures::Future<std::unique_ptr<PersistedLogIterator>> override {
+      -> futures::Future<std::unique_ptr<LogIterator>> override {
     auto iter = vocbase.getReplicatedLogById(id)
                     ->getParticipant()
                     ->getInternalLogIterator(LogRange(start, stop));
@@ -123,20 +123,20 @@ struct ReplicatedLogMethodsDBServer final
   }
 
   auto poll(LogId id, LogIndex index, std::size_t limit) const
-      -> futures::Future<std::unique_ptr<PersistedLogIterator>> override {
+      -> futures::Future<std::unique_ptr<LogIterator>> override {
     auto leader = vocbase.getReplicatedLogLeaderById(id);
     return vocbase.getReplicatedLogById(id)
         ->getParticipant()
         ->waitFor(index)
         .thenValue([index, limit, leader = std::move(leader),
                     self = shared_from_this()](
-                       auto&&) -> std::unique_ptr<PersistedLogIterator> {
+                       auto&&) -> std::unique_ptr<LogIterator> {
           return leader->getInternalLogIterator(LogRange(index, index + limit));
         });
   }
 
   auto tail(LogId id, std::size_t limit) const
-      -> futures::Future<std::unique_ptr<PersistedLogIterator>> override {
+      -> futures::Future<std::unique_ptr<LogIterator>> override {
     auto participant = vocbase.getReplicatedLogById(id)->getParticipant();
     auto status = participant->getQuickStatus();
     auto logStats = status.local.value();
@@ -146,7 +146,7 @@ struct ReplicatedLogMethodsDBServer final
   }
 
   auto head(LogId id, std::size_t limit) const
-      -> futures::Future<std::unique_ptr<PersistedLogIterator>> override {
+      -> futures::Future<std::unique_ptr<LogIterator>> override {
     auto participant = vocbase.getReplicatedLogById(id)->getParticipant();
     auto status = participant->getQuickStatus();
     auto logStats = status.local.value();
@@ -238,7 +238,7 @@ struct ReplicatedLogMethodsDBServer final
 };
 
 namespace {
-struct VPackLogIterator final : PersistedLogIterator {
+struct VPackLogIterator final : LogIterator {
   explicit VPackLogIterator(
       std::shared_ptr<velocypack::Buffer<uint8_t>> buffer_ptr)
       : buffer(std::move(buffer_ptr)),
@@ -468,7 +468,7 @@ struct ReplicatedLogMethodsCoordinator final
   }
 
   auto slice(LogId id, LogIndex start, LogIndex stop) const
-      -> futures::Future<std::unique_ptr<PersistedLogIterator>> override {
+      -> futures::Future<std::unique_ptr<LogIterator>> override {
     auto path = basics::StringUtils::joinT("/", "_api/log", id, "slice");
 
     network::RequestOptions opts;
@@ -477,19 +477,19 @@ struct ReplicatedLogMethodsCoordinator final
     opts.parameters["stop"] = to_string(stop);
     return network::sendRequest(pool, "server:" + getLogLeader(id),
                                 fuerte::RestVerb::Get, path, {}, opts)
-        .thenValue([](network::Response&& resp)
-                       -> std::unique_ptr<PersistedLogIterator> {
-          if (resp.fail() || !fuerte::statusIsSuccess(resp.statusCode())) {
-            THROW_ARANGO_EXCEPTION(resp.combinedResult());
-          }
+        .thenValue(
+            [](network::Response&& resp) -> std::unique_ptr<LogIterator> {
+              if (resp.fail() || !fuerte::statusIsSuccess(resp.statusCode())) {
+                THROW_ARANGO_EXCEPTION(resp.combinedResult());
+              }
 
-          return std::make_unique<VPackLogIterator>(
-              resp.response().stealPayload());
-        });
+              return std::make_unique<VPackLogIterator>(
+                  resp.response().stealPayload());
+            });
   }
 
   auto poll(LogId id, LogIndex index, std::size_t limit) const
-      -> futures::Future<std::unique_ptr<PersistedLogIterator>> override {
+      -> futures::Future<std::unique_ptr<LogIterator>> override {
     auto path = basics::StringUtils::joinT("/", "_api/log", id, "poll");
 
     network::RequestOptions opts;
@@ -498,19 +498,19 @@ struct ReplicatedLogMethodsCoordinator final
     opts.parameters["limit"] = std::to_string(limit);
     return network::sendRequest(pool, "server:" + getLogLeader(id),
                                 fuerte::RestVerb::Get, path, {}, opts)
-        .thenValue([](network::Response&& resp)
-                       -> std::unique_ptr<PersistedLogIterator> {
-          if (resp.fail() || !fuerte::statusIsSuccess(resp.statusCode())) {
-            THROW_ARANGO_EXCEPTION(resp.combinedResult());
-          }
+        .thenValue(
+            [](network::Response&& resp) -> std::unique_ptr<LogIterator> {
+              if (resp.fail() || !fuerte::statusIsSuccess(resp.statusCode())) {
+                THROW_ARANGO_EXCEPTION(resp.combinedResult());
+              }
 
-          return std::make_unique<VPackLogIterator>(
-              resp.response().stealPayload());
-        });
+              return std::make_unique<VPackLogIterator>(
+                  resp.response().stealPayload());
+            });
   }
 
   auto tail(LogId id, std::size_t limit) const
-      -> futures::Future<std::unique_ptr<PersistedLogIterator>> override {
+      -> futures::Future<std::unique_ptr<LogIterator>> override {
     auto path = basics::StringUtils::joinT("/", "_api/log", id, "tail");
 
     network::RequestOptions opts;
@@ -518,19 +518,19 @@ struct ReplicatedLogMethodsCoordinator final
     opts.parameters["limit"] = std::to_string(limit);
     return network::sendRequest(pool, "server:" + getLogLeader(id),
                                 fuerte::RestVerb::Get, path, {}, opts)
-        .thenValue([](network::Response&& resp)
-                       -> std::unique_ptr<PersistedLogIterator> {
-          if (resp.fail() || !fuerte::statusIsSuccess(resp.statusCode())) {
-            THROW_ARANGO_EXCEPTION(resp.combinedResult());
-          }
+        .thenValue(
+            [](network::Response&& resp) -> std::unique_ptr<LogIterator> {
+              if (resp.fail() || !fuerte::statusIsSuccess(resp.statusCode())) {
+                THROW_ARANGO_EXCEPTION(resp.combinedResult());
+              }
 
-          return std::make_unique<VPackLogIterator>(
-              resp.response().stealPayload());
-        });
+              return std::make_unique<VPackLogIterator>(
+                  resp.response().stealPayload());
+            });
   }
 
   auto head(LogId id, std::size_t limit) const
-      -> futures::Future<std::unique_ptr<PersistedLogIterator>> override {
+      -> futures::Future<std::unique_ptr<LogIterator>> override {
     auto path = basics::StringUtils::joinT("/", "_api/log", id, "head");
 
     network::RequestOptions opts;
@@ -538,15 +538,15 @@ struct ReplicatedLogMethodsCoordinator final
     opts.parameters["limit"] = std::to_string(limit);
     return network::sendRequest(pool, "server:" + getLogLeader(id),
                                 fuerte::RestVerb::Get, path, {}, opts)
-        .thenValue([](network::Response&& resp)
-                       -> std::unique_ptr<PersistedLogIterator> {
-          if (resp.fail() || !fuerte::statusIsSuccess(resp.statusCode())) {
-            THROW_ARANGO_EXCEPTION(resp.combinedResult());
-          }
+        .thenValue(
+            [](network::Response&& resp) -> std::unique_ptr<LogIterator> {
+              if (resp.fail() || !fuerte::statusIsSuccess(resp.statusCode())) {
+                THROW_ARANGO_EXCEPTION(resp.combinedResult());
+              }
 
-          return std::make_unique<VPackLogIterator>(
-              resp.response().stealPayload());
-        });
+              return std::make_unique<VPackLogIterator>(
+                  resp.response().stealPayload());
+            });
   }
 
   auto insert(LogId id, LogPayload payload, bool waitForSync) const

--- a/arangod/Replication2/Methods.h
+++ b/arangod/Replication2/Methods.h
@@ -24,9 +24,9 @@
 
 #include "Agency/AgencyCommon.h"
 #include "Replication2/ReplicatedLog/LogCommon.h"
+#include "Replication2/ReplicatedLog/LogEntry.h"
 #include "Replication2/ReplicatedLog/LogPayload.h"
 #include "Replication2/ReplicatedLog/LogStatus.h"
-#include "Replication2/ReplicatedLog/PersistingLogEntry.h"
 #include "VocBase/vocbase.h"
 
 #include <string>

--- a/arangod/Replication2/Methods.h
+++ b/arangod/Replication2/Methods.h
@@ -102,13 +102,13 @@ struct ReplicatedLogMethods {
   virtual auto getStatus(LogId) const -> futures::Future<GenericLogStatus> = 0;
 
   virtual auto slice(LogId, LogIndex start, LogIndex stop) const
-      -> futures::Future<std::unique_ptr<PersistedLogIterator>> = 0;
+      -> futures::Future<std::unique_ptr<LogIterator>> = 0;
   virtual auto poll(LogId, LogIndex, std::size_t limit) const
-      -> futures::Future<std::unique_ptr<PersistedLogIterator>> = 0;
+      -> futures::Future<std::unique_ptr<LogIterator>> = 0;
   virtual auto head(LogId, std::size_t limit) const
-      -> futures::Future<std::unique_ptr<PersistedLogIterator>> = 0;
+      -> futures::Future<std::unique_ptr<LogIterator>> = 0;
   virtual auto tail(LogId, std::size_t limit) const
-      -> futures::Future<std::unique_ptr<PersistedLogIterator>> = 0;
+      -> futures::Future<std::unique_ptr<LogIterator>> = 0;
 
   virtual auto ping(LogId, std::optional<std::string> message) const
       -> futures::Future<

--- a/arangod/Replication2/ReplicatedLog/CMakeLists.txt
+++ b/arangod/Replication2/ReplicatedLog/CMakeLists.txt
@@ -19,13 +19,13 @@ target_sources(arango_replication2_pure PRIVATE
   InMemoryLogEntry.cpp
   IRebootIdCache.h
   LogCommon.cpp
+  LogEntry.cpp
   LogEntryView.cpp
   LogLeader.cpp
   LogMetaPayload.cpp
   LogPayload.cpp
   LogStatus.cpp
   NetworkMessages.cpp
-  PersistingLogEntry.cpp
   ReplicatedLog.cpp
   ReplicatedLogMetrics.tpp
   Supervision.cpp

--- a/arangod/Replication2/ReplicatedLog/Components/IInMemoryLogManager.h
+++ b/arangod/Replication2/ReplicatedLog/Components/IInMemoryLogManager.h
@@ -66,12 +66,13 @@ struct IInMemoryLogManager {
 
   [[nodiscard]] virtual auto getLogConsumerIterator(
       std::optional<LogRange> bounds) const
-      -> std::unique_ptr<LogRangeIterator> = 0;
+      -> std::unique_ptr<LogViewRangeIterator> = 0;
 
   // If there's at least one log entry with a payload on the given range,
   // returns a LogRangeIterator. Otherwise the next index to wait for.
-  [[nodiscard]] virtual auto getNonEmptyLogConsumerIterator(LogIndex firstIdx)
-      const -> std::variant<std::unique_ptr<LogRangeIterator>, LogIndex> = 0;
+  [[nodiscard]] virtual auto getNonEmptyLogConsumerIterator(
+      LogIndex firstIdx) const
+      -> std::variant<std::unique_ptr<LogViewRangeIterator>, LogIndex> = 0;
 };
 
 }  // namespace comp

--- a/arangod/Replication2/ReplicatedLog/Components/IStorageManager.h
+++ b/arangod/Replication2/ReplicatedLog/Components/IStorageManager.h
@@ -77,7 +77,7 @@ struct IStorageManager {
       -> std::unique_ptr<TypedLogRangeIterator<LogEntryView>> = 0;
   [[nodiscard]] virtual auto getCommittedMetaInfo() const
       -> storage::PersistedStateInfo = 0;
-  [[nodiscard]] virtual auto getPersistedLogIterator(LogIndex first) const
+  [[nodiscard]] virtual auto getLogIterator(LogIndex first) const
       -> std::unique_ptr<LogIterator> = 0;
   [[nodiscard]] virtual auto getSyncIndex() const -> LogIndex = 0;
 

--- a/arangod/Replication2/ReplicatedLog/Components/IStorageManager.h
+++ b/arangod/Replication2/ReplicatedLog/Components/IStorageManager.h
@@ -38,7 +38,7 @@ namespace replication2 {
 struct LogRange;
 struct LogIndex;
 class LogEntryView;
-struct PersistedLogIterator;
+struct LogIterator;
 template<typename T>
 struct TypedLogRangeIterator;
 namespace replicated_log {
@@ -78,7 +78,7 @@ struct IStorageManager {
   [[nodiscard]] virtual auto getCommittedMetaInfo() const
       -> storage::PersistedStateInfo = 0;
   [[nodiscard]] virtual auto getPersistedLogIterator(LogIndex first) const
-      -> std::unique_ptr<PersistedLogIterator> = 0;
+      -> std::unique_ptr<LogIterator> = 0;
   [[nodiscard]] virtual auto getSyncIndex() const -> LogIndex = 0;
 
   virtual auto beginMetaInfoTrx() -> std::unique_ptr<IStateInfoTransaction> = 0;

--- a/arangod/Replication2/ReplicatedLog/Components/InMemoryLogManager.cpp
+++ b/arangod/Replication2/ReplicatedLog/Components/InMemoryLogManager.cpp
@@ -138,7 +138,7 @@ auto InMemoryLogManager::getInternalLogIterator(LogIndex firstIdx) const
           return inMemoryLog.getMemtryIteratorFrom(firstIdx);
         }
 
-        auto diskIter = _storageManager->getPersistedLogIterator(firstIdx);
+        auto diskIter = _storageManager->getLogIterator(firstIdx);
 
         struct OverlayIterator : InMemoryLogIterator {
           explicit OverlayIterator(

--- a/arangod/Replication2/ReplicatedLog/Components/InMemoryLogManager.cpp
+++ b/arangod/Replication2/ReplicatedLog/Components/InMemoryLogManager.cpp
@@ -109,8 +109,7 @@ auto InMemoryLogManager::appendLogEntry(
     bool const isMetaLogEntry = std::holds_alternative<LogMetaPayload>(payload);
 
     auto logEntry = InMemoryLogEntry(
-        PersistingLogEntry(TermIndexPair{term, index}, std::move(payload)),
-        waitForSync);
+        LogEntry(TermIndexPair{term, index}, std::move(payload)), waitForSync);
     logEntry.setInsertTp(insertTp);
     auto size = logEntry.entry().approxByteSize();
     data._inMemoryLog.appendInPlace(_logContext, std::move(logEntry));

--- a/arangod/Replication2/ReplicatedLog/Components/InMemoryLogManager.cpp
+++ b/arangod/Replication2/ReplicatedLog/Components/InMemoryLogManager.cpp
@@ -142,7 +142,7 @@ auto InMemoryLogManager::getInternalLogIterator(LogIndex firstIdx) const
 
         struct OverlayIterator : InMemoryLogIterator {
           explicit OverlayIterator(
-              std::unique_ptr<PersistedLogIterator> diskIter,
+              std::unique_ptr<LogIterator> diskIter,
               std::unique_ptr<InMemoryLogIterator> inMemoryIter,
               LogRange inMemoryRange)
               : _diskIter(std::move(diskIter)),
@@ -166,7 +166,7 @@ auto InMemoryLogManager::getInternalLogIterator(LogIndex firstIdx) const
             return _inMemoryIter->next();
           }
 
-          std::unique_ptr<PersistedLogIterator> _diskIter;
+          std::unique_ptr<LogIterator> _diskIter;
           std::unique_ptr<InMemoryLogIterator> _inMemoryIter;
           LogRange _inMemoryRange;
         };

--- a/arangod/Replication2/ReplicatedLog/Components/InMemoryLogManager.h
+++ b/arangod/Replication2/ReplicatedLog/Components/InMemoryLogManager.h
@@ -56,9 +56,9 @@ struct InMemoryLogManager : IInMemoryLogManager {
   auto getInternalLogIterator(LogIndex firstIdx) const
       -> std::unique_ptr<InMemoryLogIterator> override;
   auto getLogConsumerIterator(std::optional<LogRange> bounds) const
-      -> std::unique_ptr<LogRangeIterator> override;
+      -> std::unique_ptr<LogViewRangeIterator> override;
   auto getNonEmptyLogConsumerIterator(LogIndex firstIdx) const
-      -> std::variant<std::unique_ptr<LogRangeIterator>, LogIndex> override;
+      -> std::variant<std::unique_ptr<LogViewRangeIterator>, LogIndex> override;
 
   void resign() && noexcept;
 
@@ -71,7 +71,7 @@ struct InMemoryLogManager : IInMemoryLogManager {
 
     auto getLogConsumerIterator(IStorageManager& storageManager,
                                 std::optional<LogRange> bounds) const
-        -> std::unique_ptr<LogRangeIterator>;
+        -> std::unique_ptr<LogViewRangeIterator>;
   };
   LoggerContext const _logContext;
   std::shared_ptr<ReplicatedLogMetrics> const _metrics;

--- a/arangod/Replication2/ReplicatedLog/Components/LogFollower.cpp
+++ b/arangod/Replication2/ReplicatedLog/Components/LogFollower.cpp
@@ -245,8 +245,8 @@ auto LogFollowerImpl::waitForIterator(LogIndex index)
   return guarded.getLockedGuard()->commit->waitForIterator(index);
 }
 
-auto LogFollowerImpl::getInternalLogIterator(std::optional<LogRange> bounds)
-    const -> std::unique_ptr<PersistedLogIterator> {
+auto LogFollowerImpl::getInternalLogIterator(
+    std::optional<LogRange> bounds) const -> std::unique_ptr<LogIterator> {
   return guarded.getLockedGuard()->storage->getPersistedLogIterator(bounds);
 }
 

--- a/arangod/Replication2/ReplicatedLog/Components/LogFollower.cpp
+++ b/arangod/Replication2/ReplicatedLog/Components/LogFollower.cpp
@@ -247,7 +247,7 @@ auto LogFollowerImpl::waitForIterator(LogIndex index)
 
 auto LogFollowerImpl::getInternalLogIterator(
     std::optional<LogRange> bounds) const -> std::unique_ptr<LogIterator> {
-  return guarded.getLockedGuard()->storage->getPersistedLogIterator(bounds);
+  return guarded.getLockedGuard()->storage->getLogIterator(bounds);
 }
 
 auto LogFollowerImpl::release(LogIndex doneWithIdx) -> Result {

--- a/arangod/Replication2/ReplicatedLog/Components/LogFollower.h
+++ b/arangod/Replication2/ReplicatedLog/Components/LogFollower.h
@@ -117,7 +117,7 @@ struct LogFollowerImpl : ILogFollower {
   auto waitForIterator(LogIndex index) -> WaitForIteratorFuture override;
 
   [[nodiscard]] auto getInternalLogIterator(std::optional<LogRange> bounds)
-      const -> std::unique_ptr<PersistedLogIterator> override;
+      const -> std::unique_ptr<LogIterator> override;
 
   auto release(LogIndex doneWithIdx) -> Result override;
 

--- a/arangod/Replication2/ReplicatedLog/Components/MethodsProvider.cpp
+++ b/arangod/Replication2/ReplicatedLog/Components/MethodsProvider.cpp
@@ -50,7 +50,7 @@ struct FollowerMethodsImpl : IReplicatedLogFollowerMethods {
   }
 
   auto getCommittedLogIterator(std::optional<LogRange> range)
-      -> std::unique_ptr<LogRangeIterator> override {
+      -> std::unique_ptr<LogViewRangeIterator> override {
     return storage->getCommittedLogIterator(range);
   }
 

--- a/arangod/Replication2/ReplicatedLog/Components/StorageManager.cpp
+++ b/arangod/Replication2/ReplicatedLog/Components/StorageManager.cpp
@@ -378,7 +378,8 @@ auto StorageManager::getPersistedLogIterator(std::optional<LogRange> bounds)
         TRI_ERROR_REPLICATION_REPLICATED_LOG_PARTICIPANT_GONE);
   }
 
-  auto diskIter = guard->methods->read(range.from);
+  auto diskIter = guard->methods->getIterator(
+      storage::IteratorPosition::fromLogIndex(range.from));
 
   struct Iterator : PersistedLogIterator {
     explicit Iterator(LogRange range,
@@ -415,9 +416,10 @@ auto StorageManager::getCommittedLogIterator(
   if (bounds) {
     range = intersect(*bounds, range);
   }
-  auto diskIter = guard->methods->read(range.from);
+  auto diskIter = guard->methods->getIterator(
+      storage::IteratorPosition::fromLogIndex(range.from));
 
-  struct Iterator : TypedLogRangeIterator<LogEntryView> {
+  struct Iterator : LogRangeIterator {
     explicit Iterator(LogRange range,
                       std::unique_ptr<PersistedLogIterator> disk)
         : _range(range), _disk(std::move(disk)) {}

--- a/arangod/Replication2/ReplicatedLog/Components/StorageManager.cpp
+++ b/arangod/Replication2/ReplicatedLog/Components/StorageManager.cpp
@@ -95,7 +95,7 @@ struct comp::StorageManagerTransaction : IStorageTransaction {
         << "tried to append non matching slice - log range is: "
         << guard->spearheadMapping.getIndexRange() << " new piece starts at "
         << slice.getFirstIndex();
-    auto iter = slice.getPersistedLogIterator();
+    auto iter = slice.getLogIterator();
     auto mapping = guard->spearheadMapping;
     auto sliceMapping = slice.computeTermIndexMap();
     mapping.append(sliceMapping);
@@ -368,14 +368,14 @@ auto StorageManager::getTermIndexMapping() const -> TermIndexMapping {
   return guardedData.getLockedGuard()->onDiskMapping;
 }
 
-auto StorageManager::getPersistedLogIterator(LogIndex first) const
+auto StorageManager::getLogIterator(LogIndex first) const
     -> std::unique_ptr<LogIterator> {
-  return getPersistedLogIterator(
+  return getLogIterator(
       LogRange{first, LogIndex{static_cast<std::uint64_t>(-1)}});
 }
 
-auto StorageManager::getPersistedLogIterator(
-    std::optional<LogRange> bounds) const -> std::unique_ptr<LogIterator> {
+auto StorageManager::getLogIterator(std::optional<LogRange> bounds) const
+    -> std::unique_ptr<LogIterator> {
   auto range = bounds.value_or(
       LogRange{LogIndex{0}, LogIndex{static_cast<std::uint64_t>(-1)}});
 

--- a/arangod/Replication2/ReplicatedLog/Components/StorageManager.cpp
+++ b/arangod/Replication2/ReplicatedLog/Components/StorageManager.cpp
@@ -393,7 +393,7 @@ auto StorageManager::getPersistedLogIterator(std::optional<LogRange> bounds)
                       std::unique_ptr<PersistedLogIterator> disk)
         : _range(range), _disk(std::move(disk)) {}
 
-    auto next() -> std::optional<PersistingLogEntry> override {
+    auto next() -> std::optional<LogEntry> override {
       auto entry = _disk->next();
       if (not entry) {
         return std::nullopt;
@@ -449,7 +449,7 @@ auto StorageManager::getCommittedLogIterator(std::optional<LogRange> bounds)
 
     LogRange _range;
     std::unique_ptr<PersistedLogIterator> _disk;
-    std::optional<PersistingLogEntry> _entry;
+    std::optional<LogEntry> _entry;
   };
 
   return std::make_unique<Iterator>(range, std::move(diskIter));

--- a/arangod/Replication2/ReplicatedLog/Components/StorageManager.cpp
+++ b/arangod/Replication2/ReplicatedLog/Components/StorageManager.cpp
@@ -411,8 +411,8 @@ auto StorageManager::getPersistedLogIterator(std::optional<LogRange> bounds)
   return std::make_unique<Iterator>(range, std::move(diskIter));
 }
 
-auto StorageManager::getCommittedLogIterator(
-    std::optional<LogRange> bounds) const -> std::unique_ptr<LogRangeIterator> {
+auto StorageManager::getCommittedLogIterator(std::optional<LogRange> bounds)
+    const -> std::unique_ptr<LogViewRangeIterator> {
   auto guard = guardedData.getLockedGuard();
   if (guard->methods == nullptr) {
     THROW_ARANGO_EXCEPTION(
@@ -426,7 +426,7 @@ auto StorageManager::getCommittedLogIterator(
   auto diskIter = guard->methods->getIterator(
       storage::IteratorPosition::fromLogIndex(range.from));
 
-  struct Iterator : LogRangeIterator {
+  struct Iterator : LogViewRangeIterator {
     explicit Iterator(LogRange range,
                       std::unique_ptr<PersistedLogIterator> disk)
         : _range(range), _disk(std::move(disk)) {}

--- a/arangod/Replication2/ReplicatedLog/Components/StorageManager.h
+++ b/arangod/Replication2/ReplicatedLog/Components/StorageManager.h
@@ -46,7 +46,7 @@ struct StorageManager : IStorageManager,
   auto resign() noexcept -> std::unique_ptr<IStorageEngineMethods>;
   auto transaction() -> std::unique_ptr<IStorageTransaction> override;
   auto getCommittedLogIterator(std::optional<LogRange> range) const
-      -> std::unique_ptr<LogRangeIterator> override;
+      -> std::unique_ptr<LogViewRangeIterator> override;
   auto getPersistedLogIterator(LogIndex first) const
       -> std::unique_ptr<PersistedLogIterator> override;
   auto getPersistedLogIterator(std::optional<LogRange> range) const

--- a/arangod/Replication2/ReplicatedLog/Components/StorageManager.h
+++ b/arangod/Replication2/ReplicatedLog/Components/StorageManager.h
@@ -47,9 +47,9 @@ struct StorageManager : IStorageManager,
   auto transaction() -> std::unique_ptr<IStorageTransaction> override;
   auto getCommittedLogIterator(std::optional<LogRange> range) const
       -> std::unique_ptr<LogViewRangeIterator> override;
-  auto getPersistedLogIterator(LogIndex first) const
+  auto getLogIterator(LogIndex first) const
       -> std::unique_ptr<LogIterator> override;
-  auto getPersistedLogIterator(std::optional<LogRange> range) const
+  auto getLogIterator(std::optional<LogRange> range) const
       -> std::unique_ptr<LogIterator>;
   auto getTermIndexMapping() const -> TermIndexMapping override;
   auto beginMetaInfoTrx() -> std::unique_ptr<IStateInfoTransaction> override;

--- a/arangod/Replication2/ReplicatedLog/Components/StorageManager.h
+++ b/arangod/Replication2/ReplicatedLog/Components/StorageManager.h
@@ -85,6 +85,8 @@ struct StorageManager : IStorageManager,
     std::deque<StorageRequest> queue;
     storage::PersistedStateInfo info;
     bool workerActive{false};
+
+    auto computeTermIndexMap() const -> TermIndexMapping;
   };
   Guarded<GuardedData> guardedData;
   using GuardType = Guarded<GuardedData>::mutex_guard_type;

--- a/arangod/Replication2/ReplicatedLog/Components/StorageManager.h
+++ b/arangod/Replication2/ReplicatedLog/Components/StorageManager.h
@@ -48,9 +48,9 @@ struct StorageManager : IStorageManager,
   auto getCommittedLogIterator(std::optional<LogRange> range) const
       -> std::unique_ptr<LogViewRangeIterator> override;
   auto getPersistedLogIterator(LogIndex first) const
-      -> std::unique_ptr<PersistedLogIterator> override;
+      -> std::unique_ptr<LogIterator> override;
   auto getPersistedLogIterator(std::optional<LogRange> range) const
-      -> std::unique_ptr<PersistedLogIterator>;
+      -> std::unique_ptr<LogIterator>;
   auto getTermIndexMapping() const -> TermIndexMapping override;
   auto beginMetaInfoTrx() -> std::unique_ptr<IStateInfoTransaction> override;
   auto commitMetaInfoTrx(std::unique_ptr<IStateInfoTransaction> ptr)

--- a/arangod/Replication2/ReplicatedLog/ILogInterfaces.h
+++ b/arangod/Replication2/ReplicatedLog/ILogInterfaces.h
@@ -83,7 +83,7 @@ struct ILogParticipant {
   using WaitForPromise = futures::Promise<WaitForResult>;
   using WaitForFuture = futures::Future<WaitForResult>;
   using WaitForIteratorFuture =
-      futures::Future<std::unique_ptr<LogRangeIterator>>;
+      futures::Future<std::unique_ptr<LogViewRangeIterator>>;
   using WaitForQueue = std::multimap<LogIndex, WaitForPromise>;
 
   [[nodiscard]] virtual auto waitFor(LogIndex index) -> WaitForFuture = 0;

--- a/arangod/Replication2/ReplicatedLog/ILogInterfaces.h
+++ b/arangod/Replication2/ReplicatedLog/ILogInterfaces.h
@@ -93,7 +93,7 @@ struct ILogParticipant {
   // Passing no bounds means everything.
   [[nodiscard]] virtual auto getInternalLogIterator(
       std::optional<LogRange> bounds = std::nullopt) const
-      -> std::unique_ptr<PersistedLogIterator> = 0;
+      -> std::unique_ptr<LogIterator> = 0;
   [[nodiscard]] virtual auto release(LogIndex doneWithIdx) -> Result = 0;
   [[nodiscard]] virtual auto compact() -> ResultT<CompactionResult> = 0;
 };

--- a/arangod/Replication2/ReplicatedLog/InMemoryLog.cpp
+++ b/arangod/Replication2/ReplicatedLog/InMemoryLog.cpp
@@ -244,7 +244,7 @@ auto replicated_log::InMemoryLog::getMemtryIteratorRange(LogRange range) const
   return getMemtryIteratorRange(range.from, range.to);
 }
 
-auto replicated_log::InMemoryLog::getPersistedLogIterator() const
+auto replicated_log::InMemoryLog::getLogIterator() const
     -> std::unique_ptr<LogIterator> {
   return std::make_unique<InMemoryPersistedLogIterator>(_log);
 }

--- a/arangod/Replication2/ReplicatedLog/InMemoryLog.cpp
+++ b/arangod/Replication2/ReplicatedLog/InMemoryLog.cpp
@@ -211,12 +211,12 @@ auto replicated_log::InMemoryLog::operator=(
 }
 
 auto replicated_log::InMemoryLog::getIteratorFrom(LogIndex fromIdx) const
-    -> std::unique_ptr<LogIterator> {
+    -> std::unique_ptr<LogViewIterator> {
   return getRangeIteratorFrom(fromIdx);
 }
 
 auto replicated_log::InMemoryLog::getRangeIteratorFrom(LogIndex fromIdx) const
-    -> std::unique_ptr<LogRangeIterator> {
+    -> std::unique_ptr<LogViewRangeIterator> {
   // if we want to have read from log entry 1 onwards, we have to drop
   // no entries, because log entry 0 does not exist.
   auto log = _log.drop(fromIdx.saturatedDecrement(_first.value).value);
@@ -251,7 +251,7 @@ auto replicated_log::InMemoryLog::getPersistedLogIterator() const
 
 auto replicated_log::InMemoryLog::getIteratorRange(LogIndex fromIdx,
                                                    LogIndex toIdx) const
-    -> std::unique_ptr<LogRangeIterator> {
+    -> std::unique_ptr<LogViewRangeIterator> {
   auto log = _log.take(toIdx.saturatedDecrement(_first.value).value)
                  .drop(fromIdx.saturatedDecrement(_first.value).value);
   return std::make_unique<ReplicatedLogIterator>(std::move(log));
@@ -415,7 +415,7 @@ auto replicated_log::InMemoryLog::loadFromMethods(
 }
 
 auto replicated_log::InMemoryLog::getIteratorRange(LogRange bounds) const
-    -> std::unique_ptr<LogRangeIterator> {
+    -> std::unique_ptr<LogViewRangeIterator> {
   return getIteratorRange(bounds.from, bounds.to);
 }
 

--- a/arangod/Replication2/ReplicatedLog/InMemoryLog.cpp
+++ b/arangod/Replication2/ReplicatedLog/InMemoryLog.cpp
@@ -24,9 +24,11 @@
 #include "InMemoryLog.h"
 
 #include "Replication2/LoggerContext.h"
+#include "Replication2/ReplicatedLog/InMemoryLogEntry.h"
 #include "Replication2/ReplicatedLog/ReplicatedLogIterator.h"
 #include "Replication2/ReplicatedLog/TermIndexMapping.h"
 #include "Replication2/Storage/IStorageEngineMethods.h"
+#include "Replication2/Storage/IteratorPosition.h"
 
 #include <Basics/Exceptions.h>
 #include <Basics/StringUtils.h>
@@ -355,7 +357,9 @@ auto replicated_log::InMemoryLog::computeTermIndexMap() const
   // itself and update it as we go.
   TermIndexMapping mapping;
   for (auto const& ent : _log) {
-    mapping.insert(ent.entry().logIndex(), ent.entry().logTerm());
+    mapping.insert(
+        storage::IteratorPosition::fromLogIndex(ent.entry().logIndex()),
+        ent.entry().logTerm());
   }
   return mapping;
 }

--- a/arangod/Replication2/ReplicatedLog/InMemoryLog.cpp
+++ b/arangod/Replication2/ReplicatedLog/InMemoryLog.cpp
@@ -403,17 +403,6 @@ auto replicated_log::InMemoryLog::getFirstIndex() const noexcept -> LogIndex {
   return _first;
 }
 
-auto replicated_log::InMemoryLog::loadFromMethods(
-    storage::IStorageEngineMethods& methods) -> InMemoryLog {
-  auto iter =
-      methods.getIterator(storage::IteratorPosition::fromLogIndex(LogIndex{0}));
-  auto log = log_type::transient_type{};
-  while (auto entry = iter->next()) {
-    log.push_back(InMemoryLogEntry(std::move(entry).value()));
-  }
-  return InMemoryLog{log.persistent()};
-}
-
 auto replicated_log::InMemoryLog::getIteratorRange(LogRange bounds) const
     -> std::unique_ptr<LogViewRangeIterator> {
   return getIteratorRange(bounds.from, bounds.to);

--- a/arangod/Replication2/ReplicatedLog/InMemoryLog.cpp
+++ b/arangod/Replication2/ReplicatedLog/InMemoryLog.cpp
@@ -244,27 +244,6 @@ auto replicated_log::InMemoryLog::getMemtryIteratorRange(LogRange range) const
   return getMemtryIteratorRange(range.from, range.to);
 }
 
-auto replicated_log::InMemoryLog::getInternalIteratorFrom(
-    LogIndex fromIdx) const -> std::unique_ptr<PersistedLogIterator> {
-  // if we want to have read from log entry 1 onwards, we have to drop
-  // no entries, because log entry 0 does not exist.
-  auto log = _log.drop(fromIdx.saturatedDecrement(_first.value).value);
-  return std::make_unique<InMemoryPersistedLogIterator>(std::move(log));
-}
-
-auto replicated_log::InMemoryLog::getInternalIteratorRange(LogIndex fromIdx,
-                                                           LogIndex toIdx) const
-    -> std::unique_ptr<PersistedLogIterator> {
-  auto log = _log.take(toIdx.saturatedDecrement(_first.value).value)
-                 .drop(fromIdx.saturatedDecrement(_first.value).value);
-  return std::make_unique<InMemoryPersistedLogIterator>(std::move(log));
-}
-
-auto replicated_log::InMemoryLog::getInternalIteratorRange(
-    LogRange bounds) const -> std::unique_ptr<PersistedLogIterator> {
-  return getInternalIteratorRange(bounds.from, bounds.to);
-}
-
 auto replicated_log::InMemoryLog::getPersistedLogIterator() const
     -> std::unique_ptr<PersistedLogIterator> {
   return std::make_unique<InMemoryPersistedLogIterator>(_log);

--- a/arangod/Replication2/ReplicatedLog/InMemoryLog.cpp
+++ b/arangod/Replication2/ReplicatedLog/InMemoryLog.cpp
@@ -426,7 +426,8 @@ auto replicated_log::InMemoryLog::getFirstIndex() const noexcept -> LogIndex {
 
 auto replicated_log::InMemoryLog::loadFromMethods(
     storage::IStorageEngineMethods& methods) -> InMemoryLog {
-  auto iter = methods.read(LogIndex{0});
+  auto iter =
+      methods.getIterator(storage::IteratorPosition::fromLogIndex(LogIndex{0}));
   auto log = log_type::transient_type{};
   while (auto entry = iter->next()) {
     log.push_back(InMemoryLogEntry(std::move(entry).value()));

--- a/arangod/Replication2/ReplicatedLog/InMemoryLog.cpp
+++ b/arangod/Replication2/ReplicatedLog/InMemoryLog.cpp
@@ -245,7 +245,7 @@ auto replicated_log::InMemoryLog::getMemtryIteratorRange(LogRange range) const
 }
 
 auto replicated_log::InMemoryLog::getPersistedLogIterator() const
-    -> std::unique_ptr<PersistedLogIterator> {
+    -> std::unique_ptr<LogIterator> {
   return std::make_unique<InMemoryPersistedLogIterator>(_log);
 }
 

--- a/arangod/Replication2/ReplicatedLog/InMemoryLog.h
+++ b/arangod/Replication2/ReplicatedLog/InMemoryLog.h
@@ -125,8 +125,7 @@ struct InMemoryLog {
       -> std::unique_ptr<LogViewIterator>;
   [[nodiscard]] auto getRangeIteratorFrom(LogIndex fromIdx) const
       -> std::unique_ptr<LogViewRangeIterator>;
-  [[nodiscard]] auto getPersistedLogIterator() const
-      -> std::unique_ptr<LogIterator>;
+  [[nodiscard]] auto getLogIterator() const -> std::unique_ptr<LogIterator>;
   [[nodiscard]] auto getMemtryIteratorFrom(LogIndex fromIdx) const
       -> std::unique_ptr<InMemoryLogIterator>;
   [[nodiscard]] auto getMemtryIteratorRange(LogIndex fromIdx,

--- a/arangod/Replication2/ReplicatedLog/InMemoryLog.h
+++ b/arangod/Replication2/ReplicatedLog/InMemoryLog.h
@@ -123,15 +123,8 @@ struct InMemoryLog {
 
   [[nodiscard]] auto getIteratorFrom(LogIndex fromIdx) const
       -> std::unique_ptr<LogIterator>;
-  [[nodiscard]] auto getInternalIteratorFrom(LogIndex fromIdx) const
-      -> std::unique_ptr<PersistedLogIterator>;
   [[nodiscard]] auto getRangeIteratorFrom(LogIndex fromIdx) const
       -> std::unique_ptr<LogRangeIterator>;
-  [[nodiscard]] auto getInternalIteratorRange(LogIndex fromIdx,
-                                              LogIndex toIdx) const
-      -> std::unique_ptr<PersistedLogIterator>;
-  [[nodiscard]] auto getInternalIteratorRange(LogRange bounds) const
-      -> std::unique_ptr<PersistedLogIterator>;
   [[nodiscard]] auto getPersistedLogIterator() const
       -> std::unique_ptr<PersistedLogIterator>;
   [[nodiscard]] auto getMemtryIteratorFrom(LogIndex fromIdx) const

--- a/arangod/Replication2/ReplicatedLog/InMemoryLog.h
+++ b/arangod/Replication2/ReplicatedLog/InMemoryLog.h
@@ -151,9 +151,6 @@ struct InMemoryLog {
   [[nodiscard]] static auto dump(log_type const& log) -> std::string;
   [[nodiscard]] auto dump() const -> std::string;
 
-  [[nodiscard]] static auto loadFromMethods(storage::IStorageEngineMethods&)
-      -> InMemoryLog;
-
  protected:
   explicit InMemoryLog(log_type log, LogIndex first);
 };

--- a/arangod/Replication2/ReplicatedLog/InMemoryLog.h
+++ b/arangod/Replication2/ReplicatedLog/InMemoryLog.h
@@ -122,9 +122,9 @@ struct InMemoryLog {
       -> InMemoryLog;
 
   [[nodiscard]] auto getIteratorFrom(LogIndex fromIdx) const
-      -> std::unique_ptr<LogIterator>;
+      -> std::unique_ptr<LogViewIterator>;
   [[nodiscard]] auto getRangeIteratorFrom(LogIndex fromIdx) const
-      -> std::unique_ptr<LogRangeIterator>;
+      -> std::unique_ptr<LogViewRangeIterator>;
   [[nodiscard]] auto getPersistedLogIterator() const
       -> std::unique_ptr<PersistedLogIterator>;
   [[nodiscard]] auto getMemtryIteratorFrom(LogIndex fromIdx) const
@@ -136,9 +136,9 @@ struct InMemoryLog {
       -> std::unique_ptr<InMemoryLogIterator>;
   // get an iterator for range [from, to).
   [[nodiscard]] auto getIteratorRange(LogIndex fromIdx, LogIndex toIdx) const
-      -> std::unique_ptr<LogRangeIterator>;
+      -> std::unique_ptr<LogViewRangeIterator>;
   [[nodiscard]] auto getIteratorRange(LogRange bounds) const
-      -> std::unique_ptr<LogRangeIterator>;
+      -> std::unique_ptr<LogViewRangeIterator>;
 
   [[nodiscard]] auto takeSnapshotUpToAndIncluding(LogIndex until) const
       -> InMemoryLog;

--- a/arangod/Replication2/ReplicatedLog/InMemoryLog.h
+++ b/arangod/Replication2/ReplicatedLog/InMemoryLog.h
@@ -26,8 +26,8 @@
 #include "Replication2/LoggerContext.h"
 #include "Replication2/ReplicatedLog/LogCommon.h"
 #include "Replication2/ReplicatedLog/InMemoryLogEntry.h"
+#include "Replication2/ReplicatedLog/LogEntry.h"
 #include "Replication2/ReplicatedLog/LogEntryView.h"
-#include "Replication2/ReplicatedLog/PersistingLogEntry.h"
 
 #include <Containers/ImmerMemoryPolicy.h>
 #include <velocypack/Builder.h>
@@ -69,7 +69,7 @@ struct InMemoryLog {
   using log_type_t =
       ::immer::flex_vector<T, arangodb::immer::arango_memory_policy>;
   using log_type = log_type_t<InMemoryLogEntry>;
-  using log_type_persisted = log_type_t<PersistingLogEntry>;
+  using log_type_persisted = log_type_t<LogEntry>;
 
  private:
   log_type _log{};

--- a/arangod/Replication2/ReplicatedLog/InMemoryLog.h
+++ b/arangod/Replication2/ReplicatedLog/InMemoryLog.h
@@ -126,7 +126,7 @@ struct InMemoryLog {
   [[nodiscard]] auto getRangeIteratorFrom(LogIndex fromIdx) const
       -> std::unique_ptr<LogViewRangeIterator>;
   [[nodiscard]] auto getPersistedLogIterator() const
-      -> std::unique_ptr<PersistedLogIterator>;
+      -> std::unique_ptr<LogIterator>;
   [[nodiscard]] auto getMemtryIteratorFrom(LogIndex fromIdx) const
       -> std::unique_ptr<InMemoryLogIterator>;
   [[nodiscard]] auto getMemtryIteratorRange(LogIndex fromIdx,

--- a/arangod/Replication2/ReplicatedLog/InMemoryLogEntry.cpp
+++ b/arangod/Replication2/ReplicatedLog/InMemoryLogEntry.cpp
@@ -25,7 +25,7 @@
 
 namespace arangodb::replication2 {
 
-InMemoryLogEntry::InMemoryLogEntry(PersistingLogEntry entry, bool waitForSync)
+InMemoryLogEntry::InMemoryLogEntry(LogEntry entry, bool waitForSync)
     : _waitForSync(waitForSync), _logEntry(std::move(entry)) {}
 
 void InMemoryLogEntry::setInsertTp(clock::time_point tp) noexcept {
@@ -36,7 +36,7 @@ auto InMemoryLogEntry::insertTp() const noexcept -> clock::time_point {
   return _insertTp;
 }
 
-auto InMemoryLogEntry::entry() const noexcept -> PersistingLogEntry const& {
+auto InMemoryLogEntry::entry() const noexcept -> LogEntry const& {
   // Note that while get() isn't marked as noexcept, it actually is.
   return _logEntry.get();
 }

--- a/arangod/Replication2/ReplicatedLog/InMemoryLogEntry.h
+++ b/arangod/Replication2/ReplicatedLog/InMemoryLogEntry.h
@@ -23,7 +23,7 @@
 
 #pragma once
 
-#include "Replication2/ReplicatedLog/PersistingLogEntry.h"
+#include "Replication2/ReplicatedLog/LogEntry.h"
 
 namespace arangodb::replication2 {
 
@@ -33,18 +33,17 @@ class InMemoryLogEntry {
  public:
   using clock = std::chrono::steady_clock;
 
-  explicit InMemoryLogEntry(PersistingLogEntry entry, bool waitForSync = false);
+  explicit InMemoryLogEntry(LogEntry entry, bool waitForSync = false);
 
   [[nodiscard]] auto insertTp() const noexcept -> clock::time_point;
   void setInsertTp(clock::time_point) noexcept;
-  [[nodiscard]] auto entry() const noexcept -> PersistingLogEntry const&;
+  [[nodiscard]] auto entry() const noexcept -> LogEntry const&;
   [[nodiscard]] bool getWaitForSync() const noexcept { return _waitForSync; }
 
  private:
   bool _waitForSync;
   // Immutable box that allows sharing, i.e. cheap copying.
-  ::immer::box<PersistingLogEntry, ::arangodb::immer::arango_memory_policy>
-      _logEntry;
+  ::immer::box<LogEntry, ::arangodb::immer::arango_memory_policy> _logEntry;
   // Timepoint at which the insert was started (not the point in time where it
   // was committed)
   clock::time_point _insertTp{};

--- a/arangod/Replication2/ReplicatedLog/LogEntry.h
+++ b/arangod/Replication2/ReplicatedLog/LogEntry.h
@@ -30,6 +30,11 @@
 
 namespace arangodb::replication2 {
 
+// This class represents a complete log entry with all the necessary
+// information to be persisted and replicated. It contains a payload
+// that also owns the data.
+// On top of the LogEntry there are InMemoryLogEntry and PersistedLogEntry
+// which contain additional contextual information.
 class LogEntry {
  public:
   LogEntry(LogTerm term, LogIndex index, LogPayload payload)

--- a/arangod/Replication2/ReplicatedLog/LogEntry.h
+++ b/arangod/Replication2/ReplicatedLog/LogEntry.h
@@ -69,7 +69,7 @@ class LogEntry {
   static inline constexpr auto approxMetaDataSize = std::size_t{42 * 2};
 };
 
-// ReplicatedLog-internal iterator over PersistingLogEntries
+// ReplicatedLog-internal iterator over LogEntries
 struct LogIterator : TypedLogIterator<LogEntry> {};
 
 }  // namespace arangodb::replication2

--- a/arangod/Replication2/ReplicatedLog/LogEntry.h
+++ b/arangod/Replication2/ReplicatedLog/LogEntry.h
@@ -30,14 +30,13 @@
 
 namespace arangodb::replication2 {
 
-class PersistingLogEntry {
+class LogEntry {
  public:
-  PersistingLogEntry(LogTerm term, LogIndex index, LogPayload payload)
-      : PersistingLogEntry(TermIndexPair{term, index}, std::move(payload)) {}
-  PersistingLogEntry(TermIndexPair, std::variant<LogMetaPayload, LogPayload>);
-  PersistingLogEntry(
-      LogIndex,
-      velocypack::Slice persisted);  // RocksDB from disk constructor
+  LogEntry(LogTerm term, LogIndex index, LogPayload payload)
+      : LogEntry(TermIndexPair{term, index}, std::move(payload)) {}
+  LogEntry(TermIndexPair, std::variant<LogMetaPayload, LogPayload>);
+  LogEntry(LogIndex,
+           velocypack::Slice persisted);  // RocksDB from disk constructor
 
   [[nodiscard]] auto logTerm() const noexcept -> LogTerm;
   [[nodiscard]] auto logIndex() const noexcept -> LogIndex;
@@ -52,10 +51,10 @@ class PersistingLogEntry {
   constexpr static auto omitLogIndex = OmitLogIndex();
   void toVelocyPack(velocypack::Builder& builder) const;
   void toVelocyPack(velocypack::Builder& builder, OmitLogIndex) const;
-  static auto fromVelocyPack(velocypack::Slice slice) -> PersistingLogEntry;
+  static auto fromVelocyPack(velocypack::Slice slice) -> LogEntry;
 
-  friend auto operator==(PersistingLogEntry const&,
-                         PersistingLogEntry const&) noexcept -> bool = default;
+  friend auto operator==(LogEntry const&, LogEntry const&) noexcept
+      -> bool = default;
 
  private:
   void entriesWithoutIndexToVelocyPack(velocypack::Builder& builder) const;
@@ -66,11 +65,11 @@ class PersistingLogEntry {
   std::variant<LogMetaPayload, LogPayload> _payload;
 
   // TODO this is a magic constant "measuring" the size of
-  //      of the non-payload data in a PersistingLogEntry
+  //      of the non-payload data in a LogEntry
   static inline constexpr auto approxMetaDataSize = std::size_t{42 * 2};
 };
 
 // ReplicatedLog-internal iterator over PersistingLogEntries
-struct PersistedLogIterator : TypedLogIterator<PersistingLogEntry> {};
+struct PersistedLogIterator : TypedLogIterator<LogEntry> {};
 
 }  // namespace arangodb::replication2

--- a/arangod/Replication2/ReplicatedLog/LogEntry.h
+++ b/arangod/Replication2/ReplicatedLog/LogEntry.h
@@ -70,6 +70,6 @@ class LogEntry {
 };
 
 // ReplicatedLog-internal iterator over PersistingLogEntries
-struct PersistedLogIterator : TypedLogIterator<LogEntry> {};
+struct LogIterator : TypedLogIterator<LogEntry> {};
 
 }  // namespace arangodb::replication2

--- a/arangod/Replication2/ReplicatedLog/LogEntryView.h
+++ b/arangod/Replication2/ReplicatedLog/LogEntryView.h
@@ -56,7 +56,7 @@ class LogEntryView {
   velocypack::Slice _payload;
 };
 
-using LogIterator = TypedLogIterator<LogEntryView>;
-using LogRangeIterator = TypedLogRangeIterator<LogEntryView>;
+using LogViewIterator = TypedLogIterator<LogEntryView>;
+using LogViewRangeIterator = TypedLogRangeIterator<LogEntryView>;
 
 }  // namespace arangodb::replication2

--- a/arangod/Replication2/ReplicatedLog/LogLeader.cpp
+++ b/arangod/Replication2/ReplicatedLog/LogLeader.cpp
@@ -1577,13 +1577,12 @@ auto replicated_log::LogLeader::resign() && -> std::tuple<
 }
 
 auto replicated_log::LogLeader::getInternalLogIterator(
-    std::optional<LogRange> bounds) const
-    -> std::unique_ptr<PersistedLogIterator> {
+    std::optional<LogRange> bounds) const -> std::unique_ptr<LogIterator> {
   auto range =
       bounds ? *bounds : LogRange{LogIndex{0}, LogIndex{std::uint64_t(-1)}};
   auto iter = _inMemoryLogManager->getInternalLogIterator(range.from);
 
-  struct Adapter : PersistedLogIterator {
+  struct Adapter : LogIterator {
     explicit Adapter(std::unique_ptr<InMemoryLogIterator> iter, LogRange range)
         : iter(std::move(iter)), range(range) {}
 

--- a/arangod/Replication2/ReplicatedLog/LogLeader.cpp
+++ b/arangod/Replication2/ReplicatedLog/LogLeader.cpp
@@ -732,7 +732,7 @@ auto replicated_log::LogLeader::GuardedLeaderData::updateCommitIndexLeader(
       }
     }
     auto getCommittedLogIterator(std::optional<LogRange> range)
-        -> std::unique_ptr<LogRangeIterator> override {
+        -> std::unique_ptr<LogViewRangeIterator> override {
       return _log.getLogConsumerIterator(range);
     }
     auto insert(LogPayload payload) -> LogIndex override {
@@ -1244,7 +1244,7 @@ auto replicated_log::LogLeader::waitForIterator(LogIndex index)
 
     return std::visit(
         overload{
-            [](std::unique_ptr<LogRangeIterator> iter)
+            [](std::unique_ptr<LogViewRangeIterator> iter)
                 -> WaitForIteratorFuture { return iter; },
             [this](LogIndex indexToWaitFor) -> WaitForIteratorFuture {
               // call here, otherwise we deadlock with waitFor
@@ -1256,7 +1256,8 @@ auto replicated_log::LogLeader::waitForIterator(LogIndex index)
 }
 
 auto replicated_log::LogLeader::getLogConsumerIterator(
-    std::optional<LogRange> bounds) const -> std::unique_ptr<LogRangeIterator> {
+    std::optional<LogRange> bounds) const
+    -> std::unique_ptr<LogViewRangeIterator> {
   return _inMemoryLogManager->getLogConsumerIterator(bounds);
 }
 

--- a/arangod/Replication2/ReplicatedLog/LogLeader.cpp
+++ b/arangod/Replication2/ReplicatedLog/LogLeader.cpp
@@ -1587,7 +1587,7 @@ auto replicated_log::LogLeader::getInternalLogIterator(
     explicit Adapter(std::unique_ptr<InMemoryLogIterator> iter, LogRange range)
         : iter(std::move(iter)), range(range) {}
 
-    auto next() -> std::optional<PersistingLogEntry> override {
+    auto next() -> std::optional<LogEntry> override {
       auto entry = iter->next();
       if (entry && range.contains(entry->entry().logIndex())) {
         return entry->entry();

--- a/arangod/Replication2/ReplicatedLog/LogLeader.h
+++ b/arangod/Replication2/ReplicatedLog/LogLeader.h
@@ -150,7 +150,7 @@ class LogLeader : public std::enable_shared_from_this<LogLeader>,
   [[nodiscard]] auto getLogConsumerIterator(std::optional<LogRange> bounds)
       const -> std::unique_ptr<LogViewRangeIterator>;
   [[nodiscard]] auto getInternalLogIterator(std::optional<LogRange> bounds)
-      const -> std::unique_ptr<PersistedLogIterator> override;
+      const -> std::unique_ptr<LogIterator> override;
 
   auto waitForLeadership() -> WaitForFuture override;
   auto ping(std::optional<std::string> message) -> LogIndex override;

--- a/arangod/Replication2/ReplicatedLog/LogLeader.h
+++ b/arangod/Replication2/ReplicatedLog/LogLeader.h
@@ -148,7 +148,7 @@ class LogLeader : public std::enable_shared_from_this<LogLeader>,
   [[nodiscard]] auto release(LogIndex doneWithIdx) -> Result override;
   [[nodiscard]] auto compact() -> ResultT<CompactionResult> override;
   [[nodiscard]] auto getLogConsumerIterator(std::optional<LogRange> bounds)
-      const -> std::unique_ptr<LogRangeIterator>;
+      const -> std::unique_ptr<LogViewRangeIterator>;
   [[nodiscard]] auto getInternalLogIterator(std::optional<LogRange> bounds)
       const -> std::unique_ptr<PersistedLogIterator> override;
 

--- a/arangod/Replication2/ReplicatedLog/LogLeader.h
+++ b/arangod/Replication2/ReplicatedLog/LogLeader.h
@@ -49,6 +49,7 @@
 #include "Replication2/ReplicatedLog/WaitForBag.h"
 #include "Replication2/ReplicatedLog/types.h"
 #include "Replication2/ReplicatedLog/ReplicatedLog.h"
+#include "Replication2/Storage/IteratorPosition.h"
 #include "Scheduler/Scheduler.h"
 #include "Replication2/IScheduler.h"
 #include "Replication2/ReplicatedLog/Components/InMemoryLogManager.h"
@@ -190,7 +191,7 @@ class LogLeader : public std::enable_shared_from_this<LogLeader>,
     std::chrono::steady_clock::time_point _errorBackoffEndTP{};
     std::shared_ptr<AbstractFollower> _impl;
     TermIndexPair lastAckedIndex = TermIndexPair{LogTerm{0}, LogIndex{0}};
-    LogIndex nextPrevLogIndex = LogIndex{0};
+    storage::IteratorPosition nextPrevLogPosition;
     LogIndex lastAckedCommitIndex = LogIndex{0};
     LogIndex lastAckedLowestIndexToKeep = LogIndex{0};
     LogIndex syncIndex = LogIndex{0};

--- a/arangod/Replication2/ReplicatedLog/NetworkMessages.cpp
+++ b/arangod/Replication2/ReplicatedLog/NetworkMessages.cpp
@@ -325,7 +325,7 @@ auto replicated_log::AppendEntriesRequest::fromVelocyPack(
     auto transientEntries = EntryContainer::transient_type{};
     for (auto it : entriesVp) {
       transientEntries.push_back(
-          InMemoryLogEntry(PersistingLogEntry::fromVelocyPack(it)));
+          InMemoryLogEntry(LogEntry::fromVelocyPack(it)));
     }
     return std::move(transientEntries).persistent();
   });

--- a/arangod/Replication2/ReplicatedLog/PersistedLogEntry.h
+++ b/arangod/Replication2/ReplicatedLog/PersistedLogEntry.h
@@ -1,0 +1,53 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2023 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Manuel Pöter
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "Replication2/ReplicatedLog/LogEntry.h"
+#include "Replication2/Storage/IteratorPosition.h"
+
+namespace arangodb::replication2 {
+
+// A log entry enriched with additional information about the position of where
+// this entry is stored. This allows us to efficiently acquire an iterator
+// starting at this entry.
+struct PersistedLogEntry {
+  PersistedLogEntry(LogEntry&& entry, storage::IteratorPosition position)
+      : _entry(std::move(entry)), _position(position) {}
+
+  [[nodiscard]] auto entry() const noexcept -> LogEntry const& {
+    return _entry;
+  }
+
+  [[nodiscard]] auto position() const noexcept -> storage::IteratorPosition {
+    return _position;
+  }
+
+ private:
+  LogEntry _entry;
+  storage::IteratorPosition _position;
+};
+
+struct PersistedLogIterator : TypedLogIterator<PersistedLogEntry> {};
+
+}  // namespace arangodb::replication2

--- a/arangod/Replication2/ReplicatedLog/PersistedLogEntry.h
+++ b/arangod/Replication2/ReplicatedLog/PersistedLogEntry.h
@@ -33,7 +33,9 @@ namespace arangodb::replication2 {
 // starting at this entry.
 struct PersistedLogEntry {
   PersistedLogEntry(LogEntry&& entry, storage::IteratorPosition position)
-      : _entry(std::move(entry)), _position(position) {}
+      : _entry(std::move(entry)), _position(position) {
+    TRI_ASSERT(_entry.logIndex() == _position.index());
+  }
 
   [[nodiscard]] auto entry() const noexcept -> LogEntry const& {
     return _entry;

--- a/arangod/Replication2/ReplicatedLog/ReplicatedLog.h
+++ b/arangod/Replication2/ReplicatedLog/ReplicatedLog.h
@@ -65,7 +65,7 @@ struct IReplicatedLogMethodsBase {
   // no range means everything
   virtual auto getCommittedLogIterator(
       std::optional<LogRange> range = std::nullopt)
-      -> std::unique_ptr<LogRangeIterator> = 0;
+      -> std::unique_ptr<LogViewRangeIterator> = 0;
   virtual auto waitFor(LogIndex) -> ILogParticipant::WaitForFuture = 0;
   virtual auto waitForIterator(LogIndex)
       -> ILogParticipant::WaitForIteratorFuture = 0;

--- a/arangod/Replication2/ReplicatedLog/ReplicatedLogIterator.h
+++ b/arangod/Replication2/ReplicatedLog/ReplicatedLogIterator.h
@@ -46,7 +46,7 @@
 
 namespace arangodb::replication2::replicated_log {
 
-class ReplicatedLogIterator : public LogRangeIterator {
+class ReplicatedLogIterator : public LogViewRangeIterator {
  public:
   using log_type = ::immer::flex_vector<InMemoryLogEntry,
                                         arangodb::immer::arango_memory_policy>;

--- a/arangod/Replication2/ReplicatedLog/ReplicatedLogIterator.h
+++ b/arangod/Replication2/ReplicatedLog/ReplicatedLogIterator.h
@@ -41,6 +41,8 @@
 #endif
 
 #include "Replication2/ReplicatedLog/LogCommon.h"
+#include "Replication2/ReplicatedLog/InMemoryLogEntry.h"
+#include "Replication2/ReplicatedLog/LogEntryView.h"
 
 namespace arangodb::replication2::replicated_log {
 

--- a/arangod/Replication2/ReplicatedLog/ReplicatedLogIterator.h
+++ b/arangod/Replication2/ReplicatedLog/ReplicatedLogIterator.h
@@ -83,7 +83,7 @@ class ReplicatedLogIterator : public LogViewRangeIterator {
   log_type::const_iterator _end;
 };
 
-class InMemoryPersistedLogIterator : public PersistedLogIterator {
+class InMemoryPersistedLogIterator : public LogIterator {
  public:
   using log_type = ::immer::flex_vector<InMemoryLogEntry,
                                         arangodb::immer::arango_memory_policy>;

--- a/arangod/Replication2/ReplicatedLog/ReplicatedLogIterator.h
+++ b/arangod/Replication2/ReplicatedLog/ReplicatedLogIterator.h
@@ -93,7 +93,7 @@ class InMemoryPersistedLogIterator : public PersistedLogIterator {
         _begin(_container.begin()),
         _end(_container.end()) {}
 
-  auto next() -> std::optional<PersistingLogEntry> override {
+  auto next() -> std::optional<LogEntry> override {
     if (_begin != _end) {
       auto const& it = *_begin;
       ++_begin;

--- a/arangod/Replication2/ReplicatedLog/ReplicatedLogIterator.h
+++ b/arangod/Replication2/ReplicatedLog/ReplicatedLogIterator.h
@@ -83,31 +83,6 @@ class ReplicatedLogIterator : public LogViewRangeIterator {
   log_type::const_iterator _end;
 };
 
-class InMemoryPersistedLogIterator : public LogIterator {
- public:
-  using log_type = ::immer::flex_vector<InMemoryLogEntry,
-                                        arangodb::immer::arango_memory_policy>;
-
-  explicit InMemoryPersistedLogIterator(log_type container)
-      : _container(std::move(container)),
-        _begin(_container.begin()),
-        _end(_container.end()) {}
-
-  auto next() -> std::optional<LogEntry> override {
-    if (_begin != _end) {
-      auto const& it = *_begin;
-      ++_begin;
-      return it.entry();
-    }
-    return std::nullopt;
-  }
-
- private:
-  log_type _container;
-  log_type::const_iterator _begin;
-  log_type::const_iterator _end;
-};
-
 struct InMemoryLogIteratorImpl : InMemoryLogIterator {
   using log_type = ::immer::flex_vector<InMemoryLogEntry,
                                         arangodb::immer::arango_memory_policy>;

--- a/arangod/Replication2/ReplicatedLog/TermIndexMapping.cpp
+++ b/arangod/Replication2/ReplicatedLog/TermIndexMapping.cpp
@@ -125,20 +125,18 @@ auto TermIndexMapping::getFirstIndex() const noexcept
   return std::nullopt;
 }
 
-void TermIndexMapping::insert(LogIndex idx, LogTerm term) noexcept {
+void TermIndexMapping::insert(storage::IteratorPosition position,
+                              LogTerm term) noexcept {
+  auto idx = position.index();
   auto iter = std::invoke([&] {
     if (_mapping.empty()) {
-      return _mapping
-          .emplace(term, TermInfo{LogRange{idx, idx},
-                                  storage::IteratorPosition::fromLogIndex(idx)})
+      return _mapping.emplace(term, TermInfo{LogRange{idx, idx}, position})
           .first;
     } else if (auto iter = _mapping.rbegin(); iter->first != term) {
       ADB_PROD_ASSERT(iter->first < term);
       ADB_PROD_ASSERT(iter->second.range.to == idx);
 
-      return _mapping
-          .emplace(term, TermInfo{LogRange{idx, idx},
-                                  storage::IteratorPosition::fromLogIndex(idx)})
+      return _mapping.emplace(term, TermInfo{LogRange{idx, idx}, position})
           .first;
     } else {
       return std::prev(_mapping.end());

--- a/arangod/Replication2/ReplicatedLog/TermIndexMapping.h
+++ b/arangod/Replication2/ReplicatedLog/TermIndexMapping.h
@@ -51,7 +51,7 @@ struct TermIndexMapping {
   void removeFront(LogIndex stop) noexcept;
   void removeBack(LogIndex start) noexcept;
   void insert(LogRange, LogTerm) noexcept;
-  void insert(LogIndex, LogTerm) noexcept;
+  void insert(storage::IteratorPosition, LogTerm) noexcept;
 
   void append(TermIndexMapping const&) noexcept;
 

--- a/arangod/Replication2/ReplicatedLog/TermIndexMapping.h
+++ b/arangod/Replication2/ReplicatedLog/TermIndexMapping.h
@@ -22,6 +22,10 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #pragma once
+
+#include "Replication2/ReplicatedLog/LogCommon.h"
+#include "Replication2/Storage/IteratorPosition.h"
+
 #include <optional>
 #include <map>
 
@@ -52,7 +56,11 @@ struct TermIndexMapping {
   void append(TermIndexMapping const&) noexcept;
 
  private:
-  using ContainerType = std::map<LogTerm, LogRange>;
+  struct TermInfo {
+    LogRange range;
+    storage::IteratorPosition startPosition;
+  };
+  using ContainerType = std::map<LogTerm, TermInfo>;
   ContainerType _mapping;
 };
 

--- a/arangod/Replication2/ReplicatedState/FollowerStateManager.h
+++ b/arangod/Replication2/ReplicatedState/FollowerStateManager.h
@@ -30,6 +30,7 @@
 #include "Replication2/ReplicatedState/WaitForQueue.h"
 
 #include "Basics/Guarded.h"
+#include "Replication2/Storage/IteratorPosition.h"
 
 namespace arangodb {
 class Result;
@@ -102,7 +103,7 @@ struct FollowerStateManager
     std::shared_ptr<StreamImpl> _stream;
     WaitForQueue _waitQueue{};
     LogIndex _commitIndex = LogIndex{0};
-    LogIndex _lastAppliedIndex = LogIndex{0};
+    storage::IteratorPosition _lastAppliedPosition{};
     std::optional<Result> _lastSnapshotError{};
     std::uint64_t _snapshotErrorCounter{0};
     std::optional<LogIndex> _applyEntriesIndexInFlight = std::nullopt;

--- a/arangod/Replication2/Storage/ILogPersistor.h
+++ b/arangod/Replication2/Storage/ILogPersistor.h
@@ -23,6 +23,7 @@
 #pragma once
 
 #include "Replication2/ReplicatedLog/LogCommon.h"
+#include "Replication2/ReplicatedLog/PersistedLogEntry.h"
 #include "Replication2/Storage/IPersistor.h"
 #include "Replication2/Storage/IteratorPosition.h"
 
@@ -46,7 +47,7 @@ struct ILogPersistor : virtual IPersistor {
   virtual ~ILogPersistor() = default;
 
   [[nodiscard]] virtual auto getIterator(IteratorPosition position)
-      -> std::unique_ptr<LogIterator> = 0;
+      -> std::unique_ptr<PersistedLogIterator> = 0;
 
   struct WriteOptions {
     bool waitForSync = false;

--- a/arangod/Replication2/Storage/ILogPersistor.h
+++ b/arangod/Replication2/Storage/ILogPersistor.h
@@ -24,6 +24,7 @@
 
 #include "Replication2/ReplicatedLog/LogCommon.h"
 #include "Replication2/Storage/IPersistor.h"
+#include "Replication2/Storage/IteratorPosition.h"
 
 namespace arangodb {
 template<typename T>
@@ -44,7 +45,7 @@ namespace arangodb::replication2::storage {
 struct ILogPersistor : virtual IPersistor {
   virtual ~ILogPersistor() = default;
 
-  [[nodiscard]] virtual auto read(LogIndex first)
+  [[nodiscard]] virtual auto getIterator(IteratorPosition position)
       -> std::unique_ptr<PersistedLogIterator> = 0;
 
   struct WriteOptions {

--- a/arangod/Replication2/Storage/ILogPersistor.h
+++ b/arangod/Replication2/Storage/ILogPersistor.h
@@ -38,7 +38,7 @@ class Future;
 }  // namespace arangodb::futures
 
 namespace arangodb::replication2 {
-struct PersistedLogIterator;
+struct LogIterator;
 }
 namespace arangodb::replication2::storage {
 
@@ -46,7 +46,7 @@ struct ILogPersistor : virtual IPersistor {
   virtual ~ILogPersistor() = default;
 
   [[nodiscard]] virtual auto getIterator(IteratorPosition position)
-      -> std::unique_ptr<PersistedLogIterator> = 0;
+      -> std::unique_ptr<LogIterator> = 0;
 
   struct WriteOptions {
     bool waitForSync = false;
@@ -54,8 +54,7 @@ struct ILogPersistor : virtual IPersistor {
 
   using SequenceNumber = std::uint64_t;
 
-  virtual auto insert(std::unique_ptr<PersistedLogIterator>,
-                      WriteOptions const&)
+  virtual auto insert(std::unique_ptr<LogIterator>, WriteOptions const&)
       -> futures::Future<ResultT<SequenceNumber>> = 0;
   virtual auto removeFront(LogIndex stop, WriteOptions const&)
       -> futures::Future<ResultT<SequenceNumber>> = 0;

--- a/arangod/Replication2/Storage/IteratorPosition.h
+++ b/arangod/Replication2/Storage/IteratorPosition.h
@@ -1,0 +1,43 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2023 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Manuel Pöter
+////////////////////////////////////////////////////////////////////////////////
+#pragma once
+
+#include "Replication2/ReplicatedLog/LogCommon.h"
+
+namespace arangodb::replication2::storage {
+
+struct IteratorPosition {
+  IteratorPosition() = default;
+
+  static IteratorPosition fromLogIndex(LogIndex index) {
+    return IteratorPosition(index);
+  }
+
+  [[nodiscard]] auto index() const noexcept -> LogIndex { return logIndex; }
+
+ private:
+  explicit IteratorPosition(LogIndex index) : logIndex(index) {}
+  LogIndex logIndex{0};
+};
+
+}  // namespace arangodb::replication2::storage

--- a/arangod/Replication2/Storage/LogStorageMethods.cpp
+++ b/arangod/Replication2/Storage/LogStorageMethods.cpp
@@ -46,7 +46,7 @@ ResultT<PersistedStateInfo> LogStorageMethods::readMetadata() {
   return _statePersistor->readMetadata();
 }
 
-std::unique_ptr<PersistedLogIterator> LogStorageMethods::getIterator(
+std::unique_ptr<LogIterator> LogStorageMethods::getIterator(
     IteratorPosition position) {
   return _logPersistor->getIterator(position);
 }
@@ -61,7 +61,7 @@ auto LogStorageMethods::removeBack(LogIndex start, WriteOptions const& opts)
   return _logPersistor->removeBack(start, opts);
 }
 
-auto LogStorageMethods::insert(std::unique_ptr<PersistedLogIterator> iter,
+auto LogStorageMethods::insert(std::unique_ptr<LogIterator> iter,
                                WriteOptions const& opts)
     -> futures::Future<ResultT<SequenceNumber>> {
   return _logPersistor->insert(std::move(iter), opts);

--- a/arangod/Replication2/Storage/LogStorageMethods.cpp
+++ b/arangod/Replication2/Storage/LogStorageMethods.cpp
@@ -46,7 +46,7 @@ ResultT<PersistedStateInfo> LogStorageMethods::readMetadata() {
   return _statePersistor->readMetadata();
 }
 
-std::unique_ptr<LogIterator> LogStorageMethods::getIterator(
+std::unique_ptr<PersistedLogIterator> LogStorageMethods::getIterator(
     IteratorPosition position) {
   return _logPersistor->getIterator(position);
 }

--- a/arangod/Replication2/Storage/LogStorageMethods.cpp
+++ b/arangod/Replication2/Storage/LogStorageMethods.cpp
@@ -28,6 +28,7 @@
 #include <Futures/Future.h>
 
 #include "Replication2/ReplicatedLog/PersistingLogEntry.h"
+#include "Replication2/Storage/IteratorPosition.h"
 
 namespace arangodb::replication2::storage {
 
@@ -45,8 +46,9 @@ ResultT<PersistedStateInfo> LogStorageMethods::readMetadata() {
   return _statePersistor->readMetadata();
 }
 
-std::unique_ptr<PersistedLogIterator> LogStorageMethods::read(LogIndex first) {
-  return _logPersistor->read(first);
+std::unique_ptr<PersistedLogIterator> LogStorageMethods::getIterator(
+    IteratorPosition position) {
+  return _logPersistor->getIterator(position);
 }
 
 auto LogStorageMethods::removeFront(LogIndex stop, WriteOptions const& opts)

--- a/arangod/Replication2/Storage/LogStorageMethods.cpp
+++ b/arangod/Replication2/Storage/LogStorageMethods.cpp
@@ -27,7 +27,7 @@
 #include <Basics/ResultT.h>
 #include <Futures/Future.h>
 
-#include "Replication2/ReplicatedLog/PersistingLogEntry.h"
+#include "Replication2/ReplicatedLog/LogEntry.h"
 #include "Replication2/Storage/IteratorPosition.h"
 
 namespace arangodb::replication2::storage {

--- a/arangod/Replication2/Storage/LogStorageMethods.h
+++ b/arangod/Replication2/Storage/LogStorageMethods.h
@@ -24,6 +24,7 @@
 #pragma once
 
 #include "Replication2/Storage/IStorageEngineMethods.h"
+#include "Replication2/Storage/IteratorPosition.h"
 
 #include <memory>
 
@@ -32,27 +33,24 @@ namespace arangodb::replication2::storage {
 struct ILogPersistor;
 struct IStatePersistor;
 
-struct LogStorageMethods final : replication2::storage::IStorageEngineMethods {
+struct LogStorageMethods final : IStorageEngineMethods {
   LogStorageMethods(std::unique_ptr<ILogPersistor> logPersistor,
                     std::unique_ptr<IStatePersistor> statePersistor);
 
-  [[nodiscard]] auto updateMetadata(
-      replication2::storage::PersistedStateInfo info) -> Result override;
-  [[nodiscard]] auto readMetadata()
-      -> ResultT<replication2::storage::PersistedStateInfo> override;
-  [[nodiscard]] auto read(replication2::LogIndex first)
-      -> std::unique_ptr<replication2::PersistedLogIterator> override;
-  [[nodiscard]] auto insert(
-      std::unique_ptr<replication2::PersistedLogIterator> ptr,
-      WriteOptions const&) -> futures::Future<ResultT<SequenceNumber>> override;
-  [[nodiscard]] auto removeFront(replication2::LogIndex stop,
-                                 WriteOptions const&)
+  [[nodiscard]] auto updateMetadata(PersistedStateInfo info) -> Result override;
+  [[nodiscard]] auto readMetadata() -> ResultT<PersistedStateInfo> override;
+
+  [[nodiscard]] auto getIterator(IteratorPosition position)
+      -> std::unique_ptr<PersistedLogIterator> override;
+  [[nodiscard]] auto insert(std::unique_ptr<PersistedLogIterator> ptr,
+                            WriteOptions const&)
       -> futures::Future<ResultT<SequenceNumber>> override;
-  [[nodiscard]] auto removeBack(replication2::LogIndex start,
-                                WriteOptions const&)
+  [[nodiscard]] auto removeFront(LogIndex stop, WriteOptions const&)
+      -> futures::Future<ResultT<SequenceNumber>> override;
+  [[nodiscard]] auto removeBack(LogIndex start, WriteOptions const&)
       -> futures::Future<ResultT<SequenceNumber>> override;
   [[nodiscard]] auto getObjectId() -> std::uint64_t override;
-  [[nodiscard]] auto getLogId() -> replication2::LogId override;
+  [[nodiscard]] auto getLogId() -> LogId override;
 
   [[nodiscard]] auto getSyncedSequenceNumber() -> SequenceNumber override;
   [[nodiscard]] auto waitForSync(SequenceNumber number)

--- a/arangod/Replication2/Storage/LogStorageMethods.h
+++ b/arangod/Replication2/Storage/LogStorageMethods.h
@@ -41,8 +41,8 @@ struct LogStorageMethods final : IStorageEngineMethods {
   [[nodiscard]] auto readMetadata() -> ResultT<PersistedStateInfo> override;
 
   [[nodiscard]] auto getIterator(IteratorPosition position)
-      -> std::unique_ptr<PersistedLogIterator> override;
-  [[nodiscard]] auto insert(std::unique_ptr<PersistedLogIterator> ptr,
+      -> std::unique_ptr<LogIterator> override;
+  [[nodiscard]] auto insert(std::unique_ptr<LogIterator> ptr,
                             WriteOptions const&)
       -> futures::Future<ResultT<SequenceNumber>> override;
   [[nodiscard]] auto removeFront(LogIndex stop, WriteOptions const&)

--- a/arangod/Replication2/Storage/LogStorageMethods.h
+++ b/arangod/Replication2/Storage/LogStorageMethods.h
@@ -41,7 +41,7 @@ struct LogStorageMethods final : IStorageEngineMethods {
   [[nodiscard]] auto readMetadata() -> ResultT<PersistedStateInfo> override;
 
   [[nodiscard]] auto getIterator(IteratorPosition position)
-      -> std::unique_ptr<LogIterator> override;
+      -> std::unique_ptr<PersistedLogIterator> override;
   [[nodiscard]] auto insert(std::unique_ptr<LogIterator> ptr,
                             WriteOptions const&)
       -> futures::Future<ResultT<SequenceNumber>> override;

--- a/arangod/Replication2/Storage/RocksDB/AsyncLogWriteBatcher.cpp
+++ b/arangod/Replication2/Storage/RocksDB/AsyncLogWriteBatcher.cpp
@@ -282,8 +282,7 @@ auto AsyncLogWriteBatcher::prepareRequest(Request const& req,
 }
 
 auto AsyncLogWriteBatcher::queueInsert(
-    AsyncLogWriteContext& ctx,
-    std::unique_ptr<replication2::PersistedLogIterator> iter,
+    AsyncLogWriteContext& ctx, std::unique_ptr<replication2::LogIterator> iter,
     WriteOptions const& opts) -> futures::Future<ResultT<SequenceNumber>> {
   return queue(ctx, InsertEntries{.iter = std::move(iter)}, opts);
 }

--- a/arangod/Replication2/Storage/RocksDB/AsyncLogWriteBatcher.cpp
+++ b/arangod/Replication2/Storage/RocksDB/AsyncLogWriteBatcher.cpp
@@ -29,7 +29,7 @@
 #include "Metrics/Histogram.h"
 #include "Metrics/LogScale.h"
 #include "Replication2/MetricsHelper.h"
-#include "Replication2/ReplicatedLog/PersistingLogEntry.h"
+#include "Replication2/ReplicatedLog/LogEntry.h"
 #include "Replication2/Storage/RocksDB/AsyncLogWriteContext.h"
 #include "Replication2/Storage/RocksDB/AsyncLogWriteBatcherMetrics.h"
 #include "RocksDBEngine/RocksDBKey.h"
@@ -124,7 +124,7 @@ void AsyncLogWriteBatcher::runPersistorWorker(Lane& lane) noexcept {
         // For simplicity, a single LogIterator of a specific PersistRequest
         // (i.e. *nextReqToWrite->iter) is always written as a whole in a write
         // batch. This is not strictly necessary for correctness, as long as an
-        // error is reported when any PersistingLogEntry is not written. Because
+        // error is reported when any LogEntry is not written. Because
         // then, the write will be retried, and it does not hurt that the
         // persisted log already has some entries that are not yet confirmed
         // (which may be overwritten later). This could still be improved upon a

--- a/arangod/Replication2/Storage/RocksDB/AsyncLogWriteBatcher.h
+++ b/arangod/Replication2/Storage/RocksDB/AsyncLogWriteBatcher.h
@@ -86,7 +86,7 @@ struct AsyncLogWriteBatcher final
   ~AsyncLogWriteBatcher() override;
 
   struct InsertEntries {
-    std::unique_ptr<PersistedLogIterator> iter;
+    std::unique_ptr<LogIterator> iter;
   };
 
   struct RemoveFront {
@@ -112,7 +112,7 @@ struct AsyncLogWriteBatcher final
 
   auto prepareRequest(Request const& req, ::rocksdb::WriteBatch& wb) -> Result;
   auto queueInsert(AsyncLogWriteContext& ctx,
-                   std::unique_ptr<replication2::PersistedLogIterator> iter,
+                   std::unique_ptr<replication2::LogIterator> iter,
                    const WriteOptions& opts)
       -> futures::Future<ResultT<SequenceNumber>> override;
   auto queueRemoveFront(AsyncLogWriteContext& ctx, replication2::LogIndex stop,

--- a/arangod/Replication2/Storage/RocksDB/IAsyncLogWriteBatcher.h
+++ b/arangod/Replication2/Storage/RocksDB/IAsyncLogWriteBatcher.h
@@ -49,7 +49,7 @@ struct IAsyncLogWriteBatcher {
   using SequenceNumber = IStorageEngineMethods::SequenceNumber;
 
   virtual auto queueInsert(AsyncLogWriteContext& ctx,
-                           std::unique_ptr<PersistedLogIterator> iter,
+                           std::unique_ptr<LogIterator> iter,
                            WriteOptions const& opts)
       -> futures::Future<ResultT<SequenceNumber>> = 0;
 

--- a/arangod/Replication2/Storage/RocksDB/LogIterator.h
+++ b/arangod/Replication2/Storage/RocksDB/LogIterator.h
@@ -34,7 +34,7 @@
 
 namespace arangodb::replication2::storage::rocksdb {
 
-struct LogIterator : LogIterator {
+struct LogIterator : replication2::LogIterator {
   ~LogIterator() override = default;
 
   LogIterator(std::uint64_t objectId, ::rocksdb::DB* db,

--- a/arangod/Replication2/Storage/RocksDB/LogIterator.h
+++ b/arangod/Replication2/Storage/RocksDB/LogIterator.h
@@ -24,7 +24,7 @@
 #pragma once
 
 #include "Basics/RocksDBUtils.h"
-#include "Replication2/ReplicatedLog/PersistingLogEntry.h"
+#include "Replication2/ReplicatedLog/LogEntry.h"
 #include "RocksDBEngine/RocksDBKey.h"
 #include "RocksDBEngine/RocksDBKeyBounds.h"
 #include "RocksDBEngine/RocksDBValue.h"
@@ -51,7 +51,7 @@ struct LogIterator : PersistedLogIterator {
     _iter->Seek(first.string());
   }
 
-  auto next() -> std::optional<PersistingLogEntry> override {
+  auto next() -> std::optional<LogEntry> override {
     if (!_first) {
       _iter->Next();
     }
@@ -67,9 +67,9 @@ struct LogIterator : PersistedLogIterator {
       return std::nullopt;
     }
 
-    return std::optional<PersistingLogEntry>{
-        std::in_place, RocksDBKey::logIndex(_iter->key()),
-        RocksDBValue::data(_iter->value())};
+    return std::optional<LogEntry>{std::in_place,
+                                   RocksDBKey::logIndex(_iter->key()),
+                                   RocksDBValue::data(_iter->value())};
   }
 
   RocksDBKeyBounds const _bounds;

--- a/arangod/Replication2/Storage/RocksDB/LogIterator.h
+++ b/arangod/Replication2/Storage/RocksDB/LogIterator.h
@@ -34,7 +34,7 @@
 
 namespace arangodb::replication2::storage::rocksdb {
 
-struct LogIterator : PersistedLogIterator {
+struct LogIterator : LogIterator {
   ~LogIterator() override = default;
 
   LogIterator(std::uint64_t objectId, ::rocksdb::DB* db,

--- a/arangod/Replication2/Storage/RocksDB/LogPersistor.cpp
+++ b/arangod/Replication2/Storage/RocksDB/LogPersistor.cpp
@@ -46,7 +46,7 @@ LogPersistor::LogPersistor(LogId logId, uint64_t objectId,
       db(db),
       logCf(logCf) {}
 
-std::unique_ptr<LogIterator> LogPersistor::getIterator(
+std::unique_ptr<replication2::LogIterator> LogPersistor::getIterator(
     IteratorPosition position) {
   return std::make_unique<LogIterator>(ctx.objectId, db, logCf,
                                        position.index());
@@ -76,7 +76,7 @@ auto LogPersistor::removeBack(LogIndex start, WriteOptions const& opts)
       });
 }
 
-auto LogPersistor::insert(std::unique_ptr<LogIterator> iter,
+auto LogPersistor::insert(std::unique_ptr<replication2::LogIterator> iter,
                           WriteOptions const& opts)
     -> futures::Future<ResultT<SequenceNumber>> {
   IAsyncLogWriteBatcher::WriteOptions wo;

--- a/arangod/Replication2/Storage/RocksDB/LogPersistor.cpp
+++ b/arangod/Replication2/Storage/RocksDB/LogPersistor.cpp
@@ -46,8 +46,10 @@ LogPersistor::LogPersistor(LogId logId, uint64_t objectId,
       db(db),
       logCf(logCf) {}
 
-std::unique_ptr<PersistedLogIterator> LogPersistor::read(LogIndex first) {
-  return std::make_unique<LogIterator>(ctx.objectId, db, logCf, first);
+std::unique_ptr<PersistedLogIterator> LogPersistor::getIterator(
+    IteratorPosition position) {
+  return std::make_unique<LogIterator>(ctx.objectId, db, logCf,
+                                       position.index());
 }
 
 auto LogPersistor::removeFront(LogIndex stop, WriteOptions const& opts)

--- a/arangod/Replication2/Storage/RocksDB/LogPersistor.cpp
+++ b/arangod/Replication2/Storage/RocksDB/LogPersistor.cpp
@@ -46,7 +46,7 @@ LogPersistor::LogPersistor(LogId logId, uint64_t objectId,
       db(db),
       logCf(logCf) {}
 
-std::unique_ptr<PersistedLogIterator> LogPersistor::getIterator(
+std::unique_ptr<LogIterator> LogPersistor::getIterator(
     IteratorPosition position) {
   return std::make_unique<LogIterator>(ctx.objectId, db, logCf,
                                        position.index());
@@ -76,7 +76,7 @@ auto LogPersistor::removeBack(LogIndex start, WriteOptions const& opts)
       });
 }
 
-auto LogPersistor::insert(std::unique_ptr<PersistedLogIterator> iter,
+auto LogPersistor::insert(std::unique_ptr<LogIterator> iter,
                           WriteOptions const& opts)
     -> futures::Future<ResultT<SequenceNumber>> {
   IAsyncLogWriteBatcher::WriteOptions wo;

--- a/arangod/Replication2/Storage/RocksDB/LogPersistor.cpp
+++ b/arangod/Replication2/Storage/RocksDB/LogPersistor.cpp
@@ -46,10 +46,10 @@ LogPersistor::LogPersistor(LogId logId, uint64_t objectId,
       db(db),
       logCf(logCf) {}
 
-std::unique_ptr<replication2::LogIterator> LogPersistor::getIterator(
+std::unique_ptr<replication2::PersistedLogIterator> LogPersistor::getIterator(
     IteratorPosition position) {
-  return std::make_unique<LogIterator>(ctx.objectId, db, logCf,
-                                       position.index());
+  return std::make_unique<rocksdb::LogIterator>(ctx.objectId, db, logCf,
+                                                position.index());
 }
 
 auto LogPersistor::removeFront(LogIndex stop, WriteOptions const& opts)

--- a/arangod/Replication2/Storage/RocksDB/LogPersistor.h
+++ b/arangod/Replication2/Storage/RocksDB/LogPersistor.h
@@ -43,8 +43,8 @@ struct LogPersistor final : ILogPersistor {
                std::shared_ptr<AsyncLogWriteBatcherMetrics> metrics);
 
   [[nodiscard]] auto getIterator(IteratorPosition position)
-      -> std::unique_ptr<PersistedLogIterator> override;
-  [[nodiscard]] auto insert(std::unique_ptr<PersistedLogIterator> ptr,
+      -> std::unique_ptr<LogIterator> override;
+  [[nodiscard]] auto insert(std::unique_ptr<LogIterator> ptr,
                             WriteOptions const&)
       -> futures::Future<ResultT<SequenceNumber>> override;
   [[nodiscard]] auto removeFront(LogIndex stop, WriteOptions const&)

--- a/arangod/Replication2/Storage/RocksDB/LogPersistor.h
+++ b/arangod/Replication2/Storage/RocksDB/LogPersistor.h
@@ -26,6 +26,7 @@
 #include <rocksdb/db.h>
 
 #include "Replication2/Storage/ILogPersistor.h"
+#include "Replication2/Storage/IteratorPosition.h"
 #include "Replication2/Storage/RocksDB/AsyncLogWriteContext.h"
 
 namespace arangodb::replication2::storage::rocksdb {
@@ -34,26 +35,24 @@ struct AsyncLogWriteBatcherMetrics;
 struct AsyncLogWriteContext;
 struct IAsyncLogWriteBatcher;
 
-struct LogPersistor final : storage::ILogPersistor {
+struct LogPersistor final : ILogPersistor {
   LogPersistor(LogId logId, uint64_t objectId, std::uint64_t vocbaseId,
                ::rocksdb::DB* const db,
                ::rocksdb::ColumnFamilyHandle* const logCf,
                std::shared_ptr<IAsyncLogWriteBatcher> batcher,
                std::shared_ptr<AsyncLogWriteBatcherMetrics> metrics);
 
-  [[nodiscard]] auto read(replication2::LogIndex first)
-      -> std::unique_ptr<replication2::PersistedLogIterator> override;
-  [[nodiscard]] auto insert(
-      std::unique_ptr<replication2::PersistedLogIterator> ptr,
-      WriteOptions const&) -> futures::Future<ResultT<SequenceNumber>> override;
-  [[nodiscard]] auto removeFront(replication2::LogIndex stop,
-                                 WriteOptions const&)
+  [[nodiscard]] auto getIterator(IteratorPosition position)
+      -> std::unique_ptr<PersistedLogIterator> override;
+  [[nodiscard]] auto insert(std::unique_ptr<PersistedLogIterator> ptr,
+                            WriteOptions const&)
       -> futures::Future<ResultT<SequenceNumber>> override;
-  [[nodiscard]] auto removeBack(replication2::LogIndex start,
-                                WriteOptions const&)
+  [[nodiscard]] auto removeFront(LogIndex stop, WriteOptions const&)
+      -> futures::Future<ResultT<SequenceNumber>> override;
+  [[nodiscard]] auto removeBack(LogIndex start, WriteOptions const&)
       -> futures::Future<ResultT<SequenceNumber>> override;
   [[nodiscard]] auto getObjectId() -> std::uint64_t override;
-  [[nodiscard]] auto getLogId() -> replication2::LogId override;
+  [[nodiscard]] auto getLogId() -> LogId override;
 
   [[nodiscard]] auto getSyncedSequenceNumber() -> SequenceNumber override;
   [[nodiscard]] auto waitForSync(SequenceNumber number)

--- a/arangod/Replication2/Storage/RocksDB/LogPersistor.h
+++ b/arangod/Replication2/Storage/RocksDB/LogPersistor.h
@@ -43,7 +43,7 @@ struct LogPersistor final : ILogPersistor {
                std::shared_ptr<AsyncLogWriteBatcherMetrics> metrics);
 
   [[nodiscard]] auto getIterator(IteratorPosition position)
-      -> std::unique_ptr<LogIterator> override;
+      -> std::unique_ptr<PersistedLogIterator> override;
   [[nodiscard]] auto insert(std::unique_ptr<LogIterator> ptr,
                             WriteOptions const&)
       -> futures::Future<ResultT<SequenceNumber>> override;

--- a/arangod/RestHandler/RestLogHandler.cpp
+++ b/arangod/RestHandler/RestLogHandler.cpp
@@ -450,7 +450,7 @@ RestStatus RestLogHandler::handleGetPoll(ReplicatedLogMethods const& methods,
   limit = limitFound ? limit : ReplicatedLogMethods::kDefaultLimit;
 
   auto fut = methods.poll(logId, logIdx, limit)
-                 .thenValue([&](std::unique_ptr<PersistedLogIterator> iter) {
+                 .thenValue([&](std::unique_ptr<LogIterator> iter) {
                    VPackBuilder builder;
                    {
                      VPackArrayBuilder ab(&builder);
@@ -478,7 +478,7 @@ RestStatus RestLogHandler::handleGetTail(ReplicatedLogMethods const& methods,
   limit = limitFound ? limit : ReplicatedLogMethods::kDefaultLimit;
 
   auto fut = methods.tail(logId, limit)
-                 .thenValue([&](std::unique_ptr<PersistedLogIterator> iter) {
+                 .thenValue([&](std::unique_ptr<LogIterator> iter) {
                    VPackBuilder builder;
                    {
                      VPackArrayBuilder ab(&builder);
@@ -506,7 +506,7 @@ RestStatus RestLogHandler::handleGetHead(ReplicatedLogMethods const& methods,
   limit = limitFound ? limit : ReplicatedLogMethods::kDefaultLimit;
 
   auto fut = methods.head(logId, limit)
-                 .thenValue([&](std::unique_ptr<PersistedLogIterator> iter) {
+                 .thenValue([&](std::unique_ptr<LogIterator> iter) {
                    VPackBuilder builder;
                    {
                      VPackArrayBuilder ab(&builder);
@@ -535,7 +535,7 @@ RestStatus RestLogHandler::handleGetSlice(ReplicatedLogMethods const& methods,
   stop = stopFound ? stop : start + ReplicatedLogMethods::kDefaultLimit + 1;
 
   auto fut = methods.slice(logId, start, stop)
-                 .thenValue([&](std::unique_ptr<PersistedLogIterator> iter) {
+                 .thenValue([&](std::unique_ptr<LogIterator> iter) {
                    VPackBuilder builder;
                    {
                      VPackArrayBuilder ab(&builder);
@@ -602,7 +602,7 @@ RestStatus RestLogHandler::handleGetEntry(ReplicatedLogMethods const& methods,
 
   auto fut =
       methods.slice(logId, logIdx, logIdx + 1)
-          .thenValue([this](std::unique_ptr<PersistedLogIterator>&& iter) {
+          .thenValue([this](std::unique_ptr<LogIterator>&& iter) {
             if (auto entry = iter->next(); entry) {
               VPackBuilder result;
               entry->toVelocyPack(result);

--- a/arangod/RocksDBEngine/RocksDBValue.cpp
+++ b/arangod/RocksDBEngine/RocksDBValue.cpp
@@ -29,7 +29,7 @@
 #include "Basics/NumberUtils.h"
 #include "Basics/StaticStrings.h"
 #include "Basics/StringUtils.h"
-#include "Replication2/ReplicatedLog/PersistingLogEntry.h"
+#include "Replication2/ReplicatedLog/LogEntry.h"
 #include "RocksDBEngine/RocksDBFormat.h"
 
 #include "Transaction/Helpers.h"
@@ -103,8 +103,7 @@ RocksDBValue RocksDBValue::Empty(RocksDBEntryType type) {
   return RocksDBValue(type);
 }
 
-RocksDBValue RocksDBValue::LogEntry(
-    replication2::PersistingLogEntry const& entry) {
+RocksDBValue RocksDBValue::LogEntry(replication2::LogEntry const& entry) {
   return RocksDBValue(RocksDBEntryType::LogEntry, entry);
 }
 
@@ -282,11 +281,11 @@ RocksDBValue::RocksDBValue(RocksDBEntryType type, std::string_view data)
 }
 
 RocksDBValue::RocksDBValue(RocksDBEntryType type,
-                           replication2::PersistingLogEntry const& entry) {
+                           replication2::LogEntry const& entry) {
   TRI_ASSERT(type == RocksDBEntryType::LogEntry);
   _type = type;
   VPackBuilder builder;
-  entry.toVelocyPack(builder, replication2::PersistingLogEntry::omitLogIndex);
+  entry.toVelocyPack(builder, replication2::LogEntry::omitLogIndex);
   _buffer.reserve(builder.size());
   _buffer.append(reinterpret_cast<const char*>(builder.data()), builder.size());
 }

--- a/arangod/RocksDBEngine/RocksDBValue.h
+++ b/arangod/RocksDBEngine/RocksDBValue.h
@@ -39,7 +39,7 @@ namespace arangodb {
 namespace replication2 {
 struct LogTerm;
 struct LogPayload;
-class PersistingLogEntry;
+class LogEntry;
 }  // namespace replication2
 
 class RocksDBValue {
@@ -67,7 +67,7 @@ class RocksDBValue {
   static RocksDBValue ReplicationApplierConfig(VPackSlice data);
   static RocksDBValue KeyGeneratorValue(VPackSlice data);
   static RocksDBValue S2Value(S2Point const& c);
-  static RocksDBValue LogEntry(replication2::PersistingLogEntry const& entry);
+  static RocksDBValue LogEntry(replication2::LogEntry const& entry);
 
   //////////////////////////////////////////////////////////////////////////////
   /// @brief Used to construct an empty value of the given type for retrieval
@@ -166,7 +166,7 @@ class RocksDBValue {
                VPackSlice data);
   RocksDBValue(RocksDBEntryType type, VPackSlice data);
   RocksDBValue(RocksDBEntryType type, std::string_view data);
-  RocksDBValue(RocksDBEntryType type, replication2::PersistingLogEntry const&);
+  RocksDBValue(RocksDBEntryType type, replication2::LogEntry const&);
   explicit RocksDBValue(S2Point const&);
 
   static RocksDBEntryType type(char const* data, size_t size);

--- a/tests/Replication2/Mocks/FakeAsyncExecutor.cpp
+++ b/tests/Replication2/Mocks/FakeAsyncExecutor.cpp
@@ -23,7 +23,7 @@
 #include "FakeAsyncExecutor.h"
 
 #include "Basics/ResultT.h"
-#include "Replication2/ReplicatedLog/PersistingLogEntry.h"
+#include "Replication2/ReplicatedLog/LogEntry.h"
 
 #include <gtest/gtest.h>
 

--- a/tests/Replication2/Mocks/FakeFollower.cpp
+++ b/tests/Replication2/Mocks/FakeFollower.cpp
@@ -83,7 +83,7 @@ auto FakeFollower::getQuickStatus() const -> replicated_log::QuickLogStatus {
 auto FakeFollower::addEntry(LogPayload payload) -> LogIndex {
   auto index = guarded.doUnderLock([&](GuardedFollowerData& data) {
     auto index = data.log.getNextIndex();
-    auto memtry = InMemoryLogEntry(PersistingLogEntry(term, index, payload));
+    auto memtry = InMemoryLogEntry(LogEntry(term, index, payload));
     data.log.appendInPlace(LoggerContext(Logger::REPLICATION2),
                            std::move(memtry));
     return index;

--- a/tests/Replication2/Mocks/FakeFollower.cpp
+++ b/tests/Replication2/Mocks/FakeFollower.cpp
@@ -129,7 +129,7 @@ void FakeFollower::resign() & {
 }
 
 auto FakeFollower::getInternalLogIterator(std::optional<LogRange> bounds) const
-    -> std::unique_ptr<PersistedLogIterator> {
+    -> std::unique_ptr<LogIterator> {
   THROW_ARANGO_EXCEPTION(TRI_ERROR_NOT_IMPLEMENTED);
 }
 

--- a/tests/Replication2/Mocks/FakeFollower.cpp
+++ b/tests/Replication2/Mocks/FakeFollower.cpp
@@ -107,7 +107,7 @@ auto FakeFollower::waitFor(LogIndex index) -> WaitForFuture {
 auto FakeFollower::waitForIterator(LogIndex index)
     -> replicated_log::ILogParticipant::WaitForIteratorFuture {
   return waitFor(index).thenValue(
-      [this, index](auto&&) -> std::unique_ptr<LogRangeIterator> {
+      [this, index](auto&&) -> std::unique_ptr<LogViewRangeIterator> {
         auto guard = guarded.getLockedGuard();
         return guard->log.getIteratorRange(index, guard->commitIndex + 1);
       });

--- a/tests/Replication2/Mocks/FakeFollower.h
+++ b/tests/Replication2/Mocks/FakeFollower.h
@@ -64,7 +64,7 @@ struct FakeFollower final : replicated_log::ILogFollower,
   auto addEntry(LogPayload) -> LogIndex;
   void triggerLeaderAcked();
   auto getInternalLogIterator(std::optional<LogRange> bounds) const
-      -> std::unique_ptr<PersistedLogIterator> override;
+      -> std::unique_ptr<LogIterator> override;
 
   template<typename State>
   auto insertMultiplexedValue(typename State::EntryType const& t) -> LogIndex {

--- a/tests/Replication2/Mocks/FakeLeader.cpp
+++ b/tests/Replication2/Mocks/FakeLeader.cpp
@@ -133,7 +133,7 @@ void FakeLeader::resign() & {
 auto FakeLeader::insert(LogPayload payload) -> LogIndex {
   auto index = guarded.doUnderLock([&](GuardedLeaderData& data) {
     auto index = data.log.getNextIndex();
-    auto memtry = InMemoryLogEntry(PersistingLogEntry(term, index, payload));
+    auto memtry = InMemoryLogEntry(LogEntry(term, index, payload));
     data.log.appendInPlace(LoggerContext(Logger::REPLICATION2),
                            std::move(memtry));
     return index;

--- a/tests/Replication2/Mocks/FakeStorageEngineMethods.cpp
+++ b/tests/Replication2/Mocks/FakeStorageEngineMethods.cpp
@@ -24,6 +24,7 @@
 
 #include <utility>
 #include "Basics/Result.h"
+#include "Replication2/Storage/IteratorPosition.h"
 
 namespace {
 template<typename F, typename R = std::invoke_result_t<F>>
@@ -60,7 +61,7 @@ auto FakeStorageEngineMethods::readMetadata()
   }
 }
 
-auto FakeStorageEngineMethods::read(replication2::LogIndex start)
+auto FakeStorageEngineMethods::getIterator(IteratorPosition position)
     -> std::unique_ptr<PersistedLogIterator> {
   struct ContainerIterator : PersistedLogIterator {
     using Container = FakeStorageEngineMethodsContext::LogContainerType;
@@ -84,7 +85,7 @@ auto FakeStorageEngineMethods::read(replication2::LogIndex start)
     Iterator _end;
   };
 
-  return std::make_unique<ContainerIterator>(_self.log, start);
+  return std::make_unique<ContainerIterator>(_self.log, position.index());
 }
 
 auto FakeStorageEngineMethods::insert(

--- a/tests/Replication2/Mocks/FakeStorageEngineMethods.cpp
+++ b/tests/Replication2/Mocks/FakeStorageEngineMethods.cpp
@@ -62,8 +62,8 @@ auto FakeStorageEngineMethods::readMetadata()
 }
 
 auto FakeStorageEngineMethods::getIterator(IteratorPosition position)
-    -> std::unique_ptr<PersistedLogIterator> {
-  struct ContainerIterator : PersistedLogIterator {
+    -> std::unique_ptr<LogIterator> {
+  struct ContainerIterator : LogIterator {
     using Container = FakeStorageEngineMethodsContext::LogContainerType;
     using Iterator = Container ::iterator;
     ContainerIterator(Container store, LogIndex start)
@@ -89,7 +89,7 @@ auto FakeStorageEngineMethods::getIterator(IteratorPosition position)
 }
 
 auto FakeStorageEngineMethods::insert(
-    std::unique_ptr<PersistedLogIterator> iter,
+    std::unique_ptr<LogIterator> iter,
     const storage::IStorageEngineMethods::WriteOptions& options)
     -> arangodb::futures::Future<
         arangodb::ResultT<storage::IStorageEngineMethods::SequenceNumber>> {

--- a/tests/Replication2/Mocks/FakeStorageEngineMethods.cpp
+++ b/tests/Replication2/Mocks/FakeStorageEngineMethods.cpp
@@ -71,7 +71,7 @@ auto FakeStorageEngineMethods::getIterator(IteratorPosition position)
           _current(_store.lower_bound(start)),
           _end(_store.end()) {}
 
-    auto next() -> std::optional<PersistingLogEntry> override {
+    auto next() -> std::optional<LogEntry> override {
       if (_current != _end) {
         auto it = _current;
         ++_current;
@@ -186,10 +186,10 @@ FakeStorageEngineMethodsContext::FakeStorageEngineMethodsContext(
 void FakeStorageEngineMethodsContext::emplaceLogRange(LogRange range,
                                                       LogTerm term) {
   for (auto idx : range) {
-    log.emplace(idx, PersistingLogEntry{term, idx,
-                                        LogPayload::createFromString(
-                                            "(" + to_string(term) + "," +
-                                            to_string(idx) + ")")});
+    log.emplace(
+        idx, LogEntry{term, idx,
+                      LogPayload::createFromString("(" + to_string(term) + "," +
+                                                   to_string(idx) + ")")});
   }
 }
 

--- a/tests/Replication2/Mocks/FakeStorageEngineMethods.h
+++ b/tests/Replication2/Mocks/FakeStorageEngineMethods.h
@@ -55,10 +55,9 @@ struct FakeStorageEngineMethods : IStorageEngineMethods {
   auto readMetadata() -> ResultT<storage::PersistedStateInfo> override;
 
   auto getIterator(IteratorPosition position)
-      -> std::unique_ptr<PersistedLogIterator> override;
+      -> std::unique_ptr<LogIterator> override;
 
-  auto insert(std::unique_ptr<PersistedLogIterator> ptr,
-              const WriteOptions& options)
+  auto insert(std::unique_ptr<LogIterator> ptr, const WriteOptions& options)
       -> futures::Future<ResultT<SequenceNumber>> override;
 
   auto removeFront(LogIndex stop, const WriteOptions& options)

--- a/tests/Replication2/Mocks/FakeStorageEngineMethods.h
+++ b/tests/Replication2/Mocks/FakeStorageEngineMethods.h
@@ -55,7 +55,7 @@ struct FakeStorageEngineMethods : IStorageEngineMethods {
   auto readMetadata() -> ResultT<storage::PersistedStateInfo> override;
 
   auto getIterator(IteratorPosition position)
-      -> std::unique_ptr<LogIterator> override;
+      -> std::unique_ptr<PersistedLogIterator> override;
 
   auto insert(std::unique_ptr<LogIterator> ptr, const WriteOptions& options)
       -> futures::Future<ResultT<SequenceNumber>> override;

--- a/tests/Replication2/Mocks/FakeStorageEngineMethods.h
+++ b/tests/Replication2/Mocks/FakeStorageEngineMethods.h
@@ -29,7 +29,7 @@
 namespace arangodb::replication2::storage::test {
 
 struct FakeStorageEngineMethodsContext {
-  using LogContainerType = std::map<LogIndex, PersistingLogEntry>;
+  using LogContainerType = std::map<LogIndex, LogEntry>;
   using SequenceNumber = IStorageEngineMethods::SequenceNumber;
 
   FakeStorageEngineMethodsContext(

--- a/tests/Replication2/Mocks/FakeStorageEngineMethods.h
+++ b/tests/Replication2/Mocks/FakeStorageEngineMethods.h
@@ -23,6 +23,7 @@
 
 #include "Replication2/ReplicatedLog/ReplicatedLog.h"
 #include "Replication2/Storage/IStorageEngineMethods.h"
+#include "Replication2/Storage/IteratorPosition.h"
 #include "Replication2/Storage/RocksDB/AsyncLogWriteBatcher.h"
 
 namespace arangodb::replication2::storage::test {
@@ -53,7 +54,8 @@ struct FakeStorageEngineMethods : IStorageEngineMethods {
 
   auto readMetadata() -> ResultT<storage::PersistedStateInfo> override;
 
-  auto read(LogIndex first) -> std::unique_ptr<PersistedLogIterator> override;
+  auto getIterator(IteratorPosition position)
+      -> std::unique_ptr<PersistedLogIterator> override;
 
   auto insert(std::unique_ptr<PersistedLogIterator> ptr,
               const WriteOptions& options)

--- a/tests/Replication2/Mocks/PersistedLog.cpp
+++ b/tests/Replication2/Mocks/PersistedLog.cpp
@@ -34,7 +34,7 @@ struct MockLogContainerIterator : PersistedLogIterator {
         _current(_store.lower_bound(start)),
         _end(_store.end()) {}
 
-  auto next() -> std::optional<PersistingLogEntry> override {
+  auto next() -> std::optional<LogEntry> override {
     if (_current != _end) {
       auto it = _current;
       ++_current;
@@ -89,7 +89,7 @@ AsyncMockLog::AsyncMockLog(replication2::LogId id)
 
 AsyncMockLog::~AsyncMockLog() noexcept { stop(); }
 
-void MockLog::setEntry(replication2::PersistingLogEntry entry) {
+void MockLog::setEntry(replication2::LogEntry entry) {
   _storage.emplace(entry.logIndex(), std::move(entry));
 }
 

--- a/tests/Replication2/Mocks/PersistedLog.cpp
+++ b/tests/Replication2/Mocks/PersistedLog.cpp
@@ -9,7 +9,7 @@ using namespace arangodb::replication2;
 using namespace arangodb::replication2::replicated_log;
 using namespace arangodb::replication2::test;
 
-auto MockLog::insert(PersistedLogIterator& iter, WriteOptions const& opts)
+auto MockLog::insert(LogIterator& iter, WriteOptions const& opts)
     -> arangodb::Result {
   auto lastIndex = LogIndex{0};
 
@@ -28,7 +28,7 @@ auto MockLog::insert(PersistedLogIterator& iter, WriteOptions const& opts)
 }
 
 template<typename I>
-struct MockLogContainerIterator : PersistedLogIterator {
+struct MockLogContainerIterator : LogIterator {
   MockLogContainerIterator(MockLog::storeType store, LogIndex start)
       : _store(std::move(store)),
         _current(_store.lower_bound(start)),
@@ -49,7 +49,7 @@ struct MockLogContainerIterator : PersistedLogIterator {
 };
 
 auto MockLog::read(replication2::LogIndex start)
-    -> std::unique_ptr<PersistedLogIterator> {
+    -> std::unique_ptr<LogIterator> {
   return std::make_unique<MockLogContainerIterator<iteratorType>>(_storage,
                                                                   start);
 }
@@ -93,12 +93,12 @@ void MockLog::setEntry(replication2::LogEntry entry) {
   _storage.emplace(entry.logIndex(), std::move(entry));
 }
 
-auto MockLog::insertAsync(std::unique_ptr<PersistedLogIterator> iter,
+auto MockLog::insertAsync(std::unique_ptr<LogIterator> iter,
                           WriteOptions const& opts) -> futures::Future<Result> {
   return insert(*iter, opts);
 }
 
-auto AsyncMockLog::insertAsync(std::unique_ptr<PersistedLogIterator> iter,
+auto AsyncMockLog::insertAsync(std::unique_ptr<LogIterator> iter,
                                WriteOptions const& opts)
     -> futures::Future<Result> {
   auto entry = std::make_shared<QueueEntry>();
@@ -140,7 +140,7 @@ void AsyncMockLog::runWorker() {
 }
 
 auto DelayedMockLog::insertAsync(
-    std::unique_ptr<replication2::PersistedLogIterator> iter,
+    std::unique_ptr<replication2::LogIterator> iter,
     PersistedLog::WriteOptions const& opts) -> futures::Future<Result> {
   TRI_ASSERT(!_pending.has_value());
   return _pending.emplace(std::move(iter), opts).promise.getFuture();
@@ -157,6 +157,5 @@ void DelayedMockLog::runAsyncInsert() {
 }
 
 DelayedMockLog::PendingRequest::PendingRequest(
-    std::unique_ptr<replication2::PersistedLogIterator> iter,
-    WriteOptions options)
+    std::unique_ptr<replication2::LogIterator> iter, WriteOptions options)
     : iter(std::move(iter)), options(options) {}

--- a/tests/Replication2/Mocks/PersistedLog.h
+++ b/tests/Replication2/Mocks/PersistedLog.h
@@ -43,12 +43,12 @@ struct MockLog : replication2::replicated_log::PersistedLog {
   explicit MockLog(replication2::GlobalLogIdentifier gid);
   MockLog(replication2::LogId id, storeType storage);
 
-  auto insert(replication2::PersistedLogIterator& iter, WriteOptions const&)
+  auto insert(replication2::LogIterator& iter, WriteOptions const&)
       -> Result override;
-  auto insertAsync(std::unique_ptr<replication2::PersistedLogIterator> iter,
+  auto insertAsync(std::unique_ptr<replication2::LogIterator> iter,
                    WriteOptions const&) -> futures::Future<Result> override;
   auto read(replication2::LogIndex start)
-      -> std::unique_ptr<replication2::PersistedLogIterator> override;
+      -> std::unique_ptr<replication2::LogIterator> override;
   auto removeFront(replication2::LogIndex stop)
       -> futures::Future<Result> override;
   auto removeBack(replication2::LogIndex start) -> Result override;
@@ -73,7 +73,7 @@ struct MockLog : replication2::replicated_log::PersistedLog {
 struct DelayedMockLog : MockLog {
   explicit DelayedMockLog(replication2::LogId id) : MockLog(id) {}
 
-  auto insertAsync(std::unique_ptr<replication2::PersistedLogIterator> iter,
+  auto insertAsync(std::unique_ptr<replication2::LogIterator> iter,
                    WriteOptions const&) -> futures::Future<Result> override;
 
   auto hasPendingInsert() const noexcept -> bool {
@@ -82,9 +82,9 @@ struct DelayedMockLog : MockLog {
   void runAsyncInsert();
 
   struct PendingRequest {
-    PendingRequest(std::unique_ptr<replication2::PersistedLogIterator> iter,
+    PendingRequest(std::unique_ptr<replication2::LogIterator> iter,
                    WriteOptions options);
-    std::unique_ptr<replication2::PersistedLogIterator> iter;
+    std::unique_ptr<replication2::LogIterator> iter;
     WriteOptions options;
     futures::Promise<Result> promise;
   };
@@ -97,7 +97,7 @@ struct AsyncMockLog : MockLog {
 
   ~AsyncMockLog() noexcept;
 
-  auto insertAsync(std::unique_ptr<replication2::PersistedLogIterator> iter,
+  auto insertAsync(std::unique_ptr<replication2::LogIterator> iter,
                    WriteOptions const&) -> futures::Future<Result> override;
 
   auto stop() noexcept -> void {
@@ -114,7 +114,7 @@ struct AsyncMockLog : MockLog {
  private:
   struct QueueEntry {
     WriteOptions opts;
-    std::unique_ptr<replication2::PersistedLogIterator> iter;
+    std::unique_ptr<replication2::LogIterator> iter;
     futures::Promise<Result> promise;
   };
 

--- a/tests/Replication2/Mocks/PersistedLog.h
+++ b/tests/Replication2/Mocks/PersistedLog.h
@@ -37,8 +37,7 @@ namespace arangodb::replication2::test {
 using namespace replicated_log;
 
 struct MockLog : replication2::replicated_log::PersistedLog {
-  using storeType =
-      std::map<replication2::LogIndex, replication2::PersistingLogEntry>;
+  using storeType = std::map<replication2::LogIndex, replication2::LogEntry>;
 
   explicit MockLog(replication2::LogId id);
   explicit MockLog(replication2::GlobalLogIdentifier gid);
@@ -57,7 +56,7 @@ struct MockLog : replication2::replicated_log::PersistedLog {
 
   void setEntry(replication2::LogIndex idx, replication2::LogTerm term,
                 replication2::LogPayload payload);
-  void setEntry(replication2::PersistingLogEntry);
+  void setEntry(replication2::LogEntry);
 
   [[nodiscard]] storeType getStorage() const { return _storage; }
 

--- a/tests/Replication2/Mocks/StorageEngineMethodsMock.h
+++ b/tests/Replication2/Mocks/StorageEngineMethodsMock.h
@@ -34,11 +34,10 @@ namespace arangodb::replication2::storage::tests {
 struct StorageEngineMethodsGMock : IStorageEngineMethods {
   MOCK_METHOD(Result, updateMetadata, (PersistedStateInfo), (override));
   MOCK_METHOD(ResultT<PersistedStateInfo>, readMetadata, (), (override));
-  MOCK_METHOD(std::unique_ptr<PersistedLogIterator>, getIterator,
-              (IteratorPosition), (override));
-  MOCK_METHOD(futures::Future<ResultT<SequenceNumber>>, insert,
-              (std::unique_ptr<PersistedLogIterator>, WriteOptions const&),
+  MOCK_METHOD(std::unique_ptr<LogIterator>, getIterator, (IteratorPosition),
               (override));
+  MOCK_METHOD(futures::Future<ResultT<SequenceNumber>>, insert,
+              (std::unique_ptr<LogIterator>, WriteOptions const&), (override));
   MOCK_METHOD(futures::Future<ResultT<SequenceNumber>>, removeFront,
               (LogIndex stop, WriteOptions const&), (override));
   MOCK_METHOD(futures::Future<ResultT<SequenceNumber>>, removeBack,

--- a/tests/Replication2/Mocks/StorageEngineMethodsMock.h
+++ b/tests/Replication2/Mocks/StorageEngineMethodsMock.h
@@ -34,8 +34,8 @@ namespace arangodb::replication2::storage::tests {
 struct StorageEngineMethodsGMock : IStorageEngineMethods {
   MOCK_METHOD(Result, updateMetadata, (PersistedStateInfo), (override));
   MOCK_METHOD(ResultT<PersistedStateInfo>, readMetadata, (), (override));
-  MOCK_METHOD(std::unique_ptr<PersistedLogIterator>, read, (LogIndex),
-              (override));
+  MOCK_METHOD(std::unique_ptr<PersistedLogIterator>, getIterator,
+              (IteratorPosition), (override));
   MOCK_METHOD(futures::Future<ResultT<SequenceNumber>>, insert,
               (std::unique_ptr<PersistedLogIterator>, WriteOptions const&),
               (override));

--- a/tests/Replication2/Mocks/StorageEngineMethodsMock.h
+++ b/tests/Replication2/Mocks/StorageEngineMethodsMock.h
@@ -34,8 +34,8 @@ namespace arangodb::replication2::storage::tests {
 struct StorageEngineMethodsGMock : IStorageEngineMethods {
   MOCK_METHOD(Result, updateMetadata, (PersistedStateInfo), (override));
   MOCK_METHOD(ResultT<PersistedStateInfo>, readMetadata, (), (override));
-  MOCK_METHOD(std::unique_ptr<LogIterator>, getIterator, (IteratorPosition),
-              (override));
+  MOCK_METHOD(std::unique_ptr<PersistedLogIterator>, getIterator,
+              (IteratorPosition), (override));
   MOCK_METHOD(futures::Future<ResultT<SequenceNumber>>, insert,
               (std::unique_ptr<LogIterator>, WriteOptions const&), (override));
   MOCK_METHOD(futures::Future<ResultT<SequenceNumber>>, removeFront,

--- a/tests/Replication2/Mocks/StorageManagerMock.h
+++ b/tests/Replication2/Mocks/StorageManagerMock.h
@@ -38,8 +38,8 @@ struct StorageManagerMock
   MOCK_METHOD(std::unique_ptr<TypedLogRangeIterator<LogEntryView>>,
               getCommittedLogIterator, (std::optional<LogRange>),
               (const, override));
-  MOCK_METHOD(std::unique_ptr<PersistedLogIterator>, getPersistedLogIterator,
-              (LogIndex), (const, override));
+  MOCK_METHOD(std::unique_ptr<LogIterator>, getPersistedLogIterator, (LogIndex),
+              (const, override));
   MOCK_METHOD(arangodb::replication2::replicated_log::TermIndexMapping,
               getTermIndexMapping, (), (const, override));
   MOCK_METHOD(storage::PersistedStateInfo, getCommittedMetaInfo, (),

--- a/tests/Replication2/Mocks/StorageManagerMock.h
+++ b/tests/Replication2/Mocks/StorageManagerMock.h
@@ -38,7 +38,7 @@ struct StorageManagerMock
   MOCK_METHOD(std::unique_ptr<TypedLogRangeIterator<LogEntryView>>,
               getCommittedLogIterator, (std::optional<LogRange>),
               (const, override));
-  MOCK_METHOD(std::unique_ptr<LogIterator>, getPersistedLogIterator, (LogIndex),
+  MOCK_METHOD(std::unique_ptr<LogIterator>, getLogIterator, (LogIndex),
               (const, override));
   MOCK_METHOD(arangodb::replication2::replicated_log::TermIndexMapping,
               getTermIndexMapping, (), (const, override));

--- a/tests/Replication2/ReplicatedLog/AppendEntriesBatchTest.cpp
+++ b/tests/Replication2/ReplicatedLog/AppendEntriesBatchTest.cpp
@@ -84,9 +84,9 @@ TEST_P(AppendEntriesBatchTest, test_with_sized_batches) {
     }
     {
       // Add first entry in term
-      currentSize += PersistingLogEntry{TermIndexPair{LogTerm{5}, LogIndex{1}},
-                                        LogMetaPayload{}}
-                         .approxByteSize();
+      currentSize +=
+          LogEntry{TermIndexPair{LogTerm{5}, LogIndex{1}}, LogMetaPayload{}}
+              .approxByteSize();
       if (currentSize >= _optionsMock->_thresholdNetworkBatchSize) {
         numRequests += 1;
         currentSize = 0;

--- a/tests/Replication2/ReplicatedLog/Components/FollowerCommitManagerTest.cpp
+++ b/tests/Replication2/ReplicatedLog/Components/FollowerCommitManagerTest.cpp
@@ -52,7 +52,7 @@ auto makeRangeIter(LogRange range) -> std::unique_ptr<LogViewRangeIterator> {
   auto transient = log.transient();
   for (auto idx : range) {
     transient.push_back(InMemoryLogEntry{
-        PersistingLogEntry{LogTerm{1}, idx, LogPayload::createFromString("")}});
+        LogEntry{LogTerm{1}, idx, LogPayload::createFromString("")}});
   }
   return InMemoryLog(transient.persistent()).getIteratorRange(range);
 }

--- a/tests/Replication2/ReplicatedLog/Components/FollowerCommitManagerTest.cpp
+++ b/tests/Replication2/ReplicatedLog/Components/FollowerCommitManagerTest.cpp
@@ -47,7 +47,7 @@ auto makeRange(LogRange range) -> TermIndexMapping {
   return mapping;
 }
 
-auto makeRangeIter(LogRange range) -> std::unique_ptr<LogRangeIterator> {
+auto makeRangeIter(LogRange range) -> std::unique_ptr<LogViewRangeIterator> {
   InMemoryLog::log_type log;
   auto transient = log.transient();
   for (auto idx : range) {

--- a/tests/Replication2/ReplicatedLog/Components/InMemoryLogTest.cpp
+++ b/tests/Replication2/ReplicatedLog/Components/InMemoryLogTest.cpp
@@ -140,7 +140,7 @@ struct InMemoryLogAppendTest
     auto result = InMemoryLog::log_type_persisted::transient_type{};
     for (auto idx : LogRange(first, first + length)) {
       result.push_back(
-          PersistingLogEntry{term, idx, LogPayload::createFromString("foo")});
+          LogEntry{term, idx, LogPayload::createFromString("foo")});
     }
     return result.persistent();
   }

--- a/tests/Replication2/ReplicatedLog/Components/StorageManagerTest.cpp
+++ b/tests/Replication2/ReplicatedLog/Components/StorageManagerTest.cpp
@@ -150,7 +150,7 @@ auto makeRange(LogTerm term, LogRange range) -> InMemoryLog {
   auto transient = log.transient();
   for (auto idx : range) {
     transient.push_back(InMemoryLogEntry{
-        PersistingLogEntry{term, idx, LogPayload::createFromString("")}});
+        LogEntry{term, idx, LogPayload::createFromString("")}});
   }
   return InMemoryLog(transient.persistent());
 }

--- a/tests/Replication2/ReplicatedLog/Components/StorageManagerTest.cpp
+++ b/tests/Replication2/ReplicatedLog/Components/StorageManagerTest.cpp
@@ -254,10 +254,12 @@ struct StorageEngineMethodsMockFactory {
     auto ptr = std::make_unique<storage::tests::StorageEngineMethodsGMock>();
     lastPtr = ptr.get();
 
-    EXPECT_CALL(*ptr, read).Times(1).WillOnce([](LogIndex idx) {
-      auto log = makeRange(LogTerm{1}, {LogIndex{10}, LogIndex{100}});
-      return log.getPersistedLogIterator();
-    });
+    EXPECT_CALL(*ptr, getIterator)
+        .Times(1)
+        .WillOnce([](storage::IteratorPosition pos) {
+          auto log = makeRange(LogTerm{1}, {LogIndex{10}, LogIndex{100}});
+          return log.getPersistedLogIterator();
+        });
 
     EXPECT_CALL(*ptr, readMetadata).Times(1).WillOnce([]() {
       return storage::PersistedStateInfo{.stateId = LogId{1},

--- a/tests/Replication2/ReplicatedLog/Components/StorageManagerTest.cpp
+++ b/tests/Replication2/ReplicatedLog/Components/StorageManagerTest.cpp
@@ -356,7 +356,7 @@ TEST_F(StorageManagerSyncIndexTest, wait_for_sync_false_index_update) {
 
   EXPECT_CALL(*methods, insert)
       .Times(2)
-      .WillRepeatedly([&](std::unique_ptr<PersistedLogIterator> ptr,
+      .WillRepeatedly([&](std::unique_ptr<LogIterator> ptr,
                           IStorageEngineMethods::WriteOptions const& options) {
         StorageEngineFuture promise;
         promise.setValue(ResultT<decltype(seqNumber)>{seqNumber});
@@ -414,7 +414,7 @@ TEST_F(StorageManagerSyncIndexTest, wait_for_sync_false_update_fails) {
   auto syncIndex1 = storageManager->getSyncIndex();
 
   EXPECT_CALL(*methods, insert)
-      .WillOnce([&](std::unique_ptr<PersistedLogIterator> ptr,
+      .WillOnce([&](std::unique_ptr<LogIterator> ptr,
                     IStorageEngineMethods::WriteOptions const& options) {
         StorageEngineFuture promise;
         promise.setValue(ResultT<decltype(seqNumber)>{seqNumber});
@@ -439,7 +439,7 @@ TEST_F(StorageManagerSyncIndexTest, manager_unavailable_during_update) {
   IStorageEngineMethods::SequenceNumber seqNumber{1};
 
   EXPECT_CALL(*methods, insert)
-      .WillOnce([&](std::unique_ptr<PersistedLogIterator> ptr,
+      .WillOnce([&](std::unique_ptr<LogIterator> ptr,
                     IStorageEngineMethods::WriteOptions const& options) {
         StorageEngineFuture promise;
         promise.setValue(ResultT<decltype(seqNumber)>{seqNumber});
@@ -462,7 +462,7 @@ TEST_F(StorageManagerSyncIndexTest, manager_unavailable_during_update) {
 
 TEST_F(StorageManagerSyncIndexTest, methods_insertion_fails) {
   EXPECT_CALL(*methods, insert)
-      .WillOnce([](std::unique_ptr<PersistedLogIterator> ptr,
+      .WillOnce([](std::unique_ptr<LogIterator> ptr,
                    IStorageEngineMethods::WriteOptions const& options) {
         StorageEngineFuture promise;
         promise.setValue(Result{TRI_ERROR_WAS_ERLAUBE});

--- a/tests/Replication2/ReplicatedLog/Components/StorageManagerTest.cpp
+++ b/tests/Replication2/ReplicatedLog/Components/StorageManagerTest.cpp
@@ -258,7 +258,7 @@ struct StorageEngineMethodsMockFactory {
         .Times(1)
         .WillOnce([](storage::IteratorPosition pos) {
           auto log = makeRange(LogTerm{1}, {LogIndex{10}, LogIndex{100}});
-          return log.getPersistedLogIterator();
+          return log.getLogIterator();
         });
 
     EXPECT_CALL(*ptr, readMetadata).Times(1).WillOnce([]() {

--- a/tests/Replication2/ReplicatedLog/Components/TermIndexMapping.cpp
+++ b/tests/Replication2/ReplicatedLog/Components/TermIndexMapping.cpp
@@ -24,6 +24,7 @@
 #include "Basics/debugging.h"
 
 #include "Replication2/ReplicatedLog/TermIndexMapping.h"
+#include "Replication2/Storage/IteratorPosition.h"
 
 using namespace arangodb::replication2;
 using namespace arangodb::replication2::replicated_log;
@@ -128,10 +129,10 @@ TEST_F(TermIndexMappingTest, get_last_and_first_index) {
 }
 
 TEST_F(TermIndexMappingTest, insert_single_entry) {
-  mapping.insert(1_Lx, 1_T);
-  mapping.insert(2_Lx, 2_T);
-  mapping.insert(3_Lx, 2_T);
-  mapping.insert(4_Lx, 3_T);
+  mapping.insert(storage::IteratorPosition::fromLogIndex(1_Lx), 1_T);
+  mapping.insert(storage::IteratorPosition::fromLogIndex(2_Lx), 2_T);
+  mapping.insert(storage::IteratorPosition::fromLogIndex(3_Lx), 2_T);
+  mapping.insert(storage::IteratorPosition::fromLogIndex(4_Lx), 3_T);
 
   EXPECT_EQ(mapping.getFirstIndex(), (TermIndexPair{1_T, 1_Lx}));
   EXPECT_EQ(mapping.getLastIndex(), (TermIndexPair{3_T, 4_Lx}));

--- a/tests/Replication2/ReplicatedLog/Integration/StorageEngineMethodsTest.cpp
+++ b/tests/Replication2/ReplicatedLog/Integration/StorageEngineMethodsTest.cpp
@@ -26,6 +26,7 @@
 #include "Basics/RocksDBUtils.h"
 #include "Basics/files.h"
 #include "Replication2/ReplicatedLog/LogCommon.h"
+#include "Replication2/Storage/IteratorPosition.h"
 #include "Replication2/Storage/LogStorageMethods.h"
 #include "Replication2/Storage/RocksDB/AsyncLogWriteBatcher.h"
 #include "Replication2/Storage/RocksDB/AsyncLogWriteBatcherMetrics.h"
@@ -293,7 +294,8 @@ TYPED_TEST(StorageEngineMethodsTest, write_log_entries) {
   }
 
   {
-    auto iter = this->methods->read(LogIndex{0});
+    auto iter = this->methods->getIterator(
+        storage::IteratorPosition::fromLogIndex(LogIndex{0}));
     for (auto const& expected : entries) {
       ASSERT_EQ(iter->next(), expected);
     }
@@ -329,7 +331,8 @@ TYPED_TEST(StorageEngineMethodsTest, write_log_entries_remove_front_back) {
   }
 
   {
-    auto iter = this->methods->read(LogIndex{0});
+    auto iter = this->methods->getIterator(
+        storage::IteratorPosition::fromLogIndex(LogIndex{0}));
     auto next = iter->next();
     ASSERT_TRUE(next.has_value());
     EXPECT_EQ(next->logIndex(), LogIndex{2});
@@ -357,7 +360,8 @@ TYPED_TEST(StorageEngineMethodsTest, write_log_entries_iter_after_remove) {
   }
 
   // obtain iterator
-  auto iter = this->methods->read(LogIndex{0});
+  auto iter = this->methods->getIterator(
+      storage::IteratorPosition::fromLogIndex(LogIndex{0}));
 
   {
     // remove log entries

--- a/tests/Replication2/ReplicatedLog/Integration/StorageEngineMethodsTest.cpp
+++ b/tests/Replication2/ReplicatedLog/Integration/StorageEngineMethodsTest.cpp
@@ -294,7 +294,7 @@ TYPED_TEST(StorageEngineMethodsTest, write_log_entries) {
     auto iter = this->methods->getIterator(
         storage::IteratorPosition::fromLogIndex(LogIndex{0}));
     for (auto const& expected : entries) {
-      ASSERT_EQ(iter->next(), expected);
+      ASSERT_EQ(iter->next()->entry(), expected);
     }
     ASSERT_EQ(iter->next(), std::nullopt);
   }
@@ -329,8 +329,8 @@ TYPED_TEST(StorageEngineMethodsTest, write_log_entries_remove_front_back) {
         storage::IteratorPosition::fromLogIndex(LogIndex{0}));
     auto next = iter->next();
     ASSERT_TRUE(next.has_value());
-    EXPECT_EQ(next->logIndex(), LogIndex{2});
-    EXPECT_EQ(next->logTerm(), LogTerm{1});
+    EXPECT_EQ(next->entry().logIndex(), LogIndex{2});
+    EXPECT_EQ(next->entry().logTerm(), LogTerm{1});
     ASSERT_EQ(iter->next(), std::nullopt);
   }
 }
@@ -363,7 +363,7 @@ TYPED_TEST(StorageEngineMethodsTest, write_log_entries_iter_after_remove) {
   {
     // should see all log entries
     for (auto const& expected : entries) {
-      ASSERT_EQ(iter->next(), expected);
+      ASSERT_EQ(iter->next()->entry(), expected);
     }
     ASSERT_EQ(iter->next(), std::nullopt);
   }

--- a/tests/Replication2/ReplicatedLog/Integration/StorageEngineMethodsTest.cpp
+++ b/tests/Replication2/ReplicatedLog/Integration/StorageEngineMethodsTest.cpp
@@ -70,7 +70,7 @@ struct SimpleIterator : PersistedLogIterator {
   SimpleIterator(I begin, I end) : current(begin), end(end) {}
   ~SimpleIterator() override = default;
 
-  auto next() -> std::optional<PersistingLogEntry> override {
+  auto next() -> std::optional<LogEntry> override {
     if (current == end) {
       return std::nullopt;
     }
@@ -277,14 +277,11 @@ TYPED_TEST(StorageEngineMethodsTest, write_drop_data) {
 
 TYPED_TEST(StorageEngineMethodsTest, write_log_entries) {
   auto const entries = std::vector{
-      PersistingLogEntry{LogTerm{1}, LogIndex{1},
-                         LogPayload::createFromString("first")},
-      PersistingLogEntry{LogTerm{1}, LogIndex{2},
-                         LogPayload::createFromString("second")},
-      PersistingLogEntry{LogTerm{2}, LogIndex{3},
-                         LogPayload::createFromString("third")},
-      PersistingLogEntry{LogTerm{2}, LogIndex{1000},
-                         LogPayload::createFromString("thousand")},
+      LogEntry{LogTerm{1}, LogIndex{1}, LogPayload::createFromString("first")},
+      LogEntry{LogTerm{1}, LogIndex{2}, LogPayload::createFromString("second")},
+      LogEntry{LogTerm{2}, LogIndex{3}, LogPayload::createFromString("third")},
+      LogEntry{LogTerm{2}, LogIndex{1000},
+               LogPayload::createFromString("thousand")},
   };
 
   {
@@ -305,14 +302,11 @@ TYPED_TEST(StorageEngineMethodsTest, write_log_entries) {
 
 TYPED_TEST(StorageEngineMethodsTest, write_log_entries_remove_front_back) {
   auto const entries = std::vector{
-      PersistingLogEntry{LogTerm{1}, LogIndex{1},
-                         LogPayload::createFromString("first")},
-      PersistingLogEntry{LogTerm{1}, LogIndex{2},
-                         LogPayload::createFromString("second")},
-      PersistingLogEntry{LogTerm{2}, LogIndex{3},
-                         LogPayload::createFromString("third")},
-      PersistingLogEntry{LogTerm{2}, LogIndex{1000},
-                         LogPayload::createFromString("thousand")},
+      LogEntry{LogTerm{1}, LogIndex{1}, LogPayload::createFromString("first")},
+      LogEntry{LogTerm{1}, LogIndex{2}, LogPayload::createFromString("second")},
+      LogEntry{LogTerm{2}, LogIndex{3}, LogPayload::createFromString("third")},
+      LogEntry{LogTerm{2}, LogIndex{1000},
+               LogPayload::createFromString("thousand")},
   };
 
   {
@@ -343,14 +337,11 @@ TYPED_TEST(StorageEngineMethodsTest, write_log_entries_remove_front_back) {
 
 TYPED_TEST(StorageEngineMethodsTest, write_log_entries_iter_after_remove) {
   auto const entries = std::vector{
-      PersistingLogEntry{LogTerm{1}, LogIndex{1},
-                         LogPayload::createFromString("first")},
-      PersistingLogEntry{LogTerm{1}, LogIndex{2},
-                         LogPayload::createFromString("second")},
-      PersistingLogEntry{LogTerm{2}, LogIndex{3},
-                         LogPayload::createFromString("third")},
-      PersistingLogEntry{LogTerm{2}, LogIndex{1000},
-                         LogPayload::createFromString("thousand")},
+      LogEntry{LogTerm{1}, LogIndex{1}, LogPayload::createFromString("first")},
+      LogEntry{LogTerm{1}, LogIndex{2}, LogPayload::createFromString("second")},
+      LogEntry{LogTerm{2}, LogIndex{3}, LogPayload::createFromString("third")},
+      LogEntry{LogTerm{2}, LogIndex{1000},
+               LogPayload::createFromString("thousand")},
   };
 
   {

--- a/tests/Replication2/ReplicatedLog/Integration/StorageEngineMethodsTest.cpp
+++ b/tests/Replication2/ReplicatedLog/Integration/StorageEngineMethodsTest.cpp
@@ -66,7 +66,7 @@ struct RocksDBInstance {
 };
 
 template<typename I>
-struct SimpleIterator : PersistedLogIterator {
+struct SimpleIterator : LogIterator {
   SimpleIterator(I begin, I end) : current(begin), end(end) {}
   ~SimpleIterator() override = default;
 

--- a/tests/Replication2/ReplicatedLog/LogFollower/AppendEntriesTest.cpp
+++ b/tests/Replication2/ReplicatedLog/LogFollower/AppendEntriesTest.cpp
@@ -55,7 +55,7 @@ auto generateEntries(LogTerm term, LogRange range)
   auto tr = AppendEntriesRequest::EntryContainer::transient_type{};
   for (auto idx : range) {
     tr.push_back(InMemoryLogEntry{
-        PersistingLogEntry{term, idx, LogPayload::createFromString("foo")}});
+        LogEntry{term, idx, LogPayload::createFromString("foo")}});
   }
   return tr.persistent();
 }

--- a/tests/Replication2/ReplicatedLog/ReplicatedLogConnectTest.cpp
+++ b/tests/Replication2/ReplicatedLog/ReplicatedLogConnectTest.cpp
@@ -110,7 +110,7 @@ struct LogLeaderMock : replicated_log::ILogLeader {
   MOCK_METHOD(WaitForFuture, waitForLeadership, (), (override));
   MOCK_METHOD(WaitForFuture, waitFor, (LogIndex), (override));
   MOCK_METHOD(WaitForIteratorFuture, waitForIterator, (LogIndex), (override));
-  MOCK_METHOD(std::unique_ptr<PersistedLogIterator>, getInternalLogIterator,
+  MOCK_METHOD(std::unique_ptr<LogIterator>, getInternalLogIterator,
               (std::optional<LogRange> bounds), (const, override));
   MOCK_METHOD(Result, release, (LogIndex), (override));
   MOCK_METHOD(ResultT<arangodb::replication2::replicated_log::CompactionResult>,
@@ -132,7 +132,7 @@ struct LogFollowerMock : replicated_log::ILogFollower {
 
   MOCK_METHOD(WaitForFuture, waitFor, (LogIndex), (override));
   MOCK_METHOD(WaitForIteratorFuture, waitForIterator, (LogIndex), (override));
-  MOCK_METHOD(std::unique_ptr<PersistedLogIterator>, getInternalLogIterator,
+  MOCK_METHOD(std::unique_ptr<LogIterator>, getInternalLogIterator,
               (std::optional<LogRange> bounds), (const, override));
   MOCK_METHOD(Result, release, (LogIndex), (override));
   MOCK_METHOD(ResultT<arangodb::replication2::replicated_log::CompactionResult>,

--- a/tests/Replication2/ReplicatedLog/RewriteLogTest.cpp
+++ b/tests/Replication2/ReplicatedLog/RewriteLogTest.cpp
@@ -33,14 +33,12 @@ struct RewriteLogTest : ReplicatedLogTest {};
 
 TEST_F(RewriteLogTest, rewrite_old_leader) {
   auto const entries = std::vector{
-      replication2::PersistingLogEntry(
-          LogTerm{1}, LogIndex{1}, LogPayload::createFromString("first entry")),
-      replication2::PersistingLogEntry(
-          LogTerm{2}, LogIndex{2},
-          LogPayload::createFromString("second entry")),
-      replication2::PersistingLogEntry(
-          LogTerm{2}, LogIndex{3},
-          LogPayload::createFromString("third entry"))};
+      replication2::LogEntry(LogTerm{1}, LogIndex{1},
+                             LogPayload::createFromString("first entry")),
+      replication2::LogEntry(LogTerm{2}, LogIndex{2},
+                             LogPayload::createFromString("second entry")),
+      replication2::LogEntry(LogTerm{2}, LogIndex{3},
+                             LogPayload::createFromString("third entry"))};
 
   // create one log that has three entries
   auto followerLog = std::invoke([&] {
@@ -126,7 +124,7 @@ TEST_F(RewriteLogTest, rewrite_old_leader) {
   }
 
   {
-    auto entry = std::optional<PersistingLogEntry>();
+    auto entry = std::optional<LogEntry>();
     auto log = getPersistedLogById(LogId{1});
     auto iter = log->read(LogIndex{1});  // The mock log returns all entries
 

--- a/tests/Replication2/ReplicatedLog/SimpleInsertTests.cpp
+++ b/tests/Replication2/ReplicatedLog/SimpleInsertTests.cpp
@@ -104,7 +104,7 @@ TEST_F(ReplicatedLogTest, write_single_entry_to_follower) {
 
     {
       // check the leader log, there should be two entries written
-      auto entry = std::optional<PersistingLogEntry>{};
+      auto entry = std::optional<LogEntry>{};
       auto followerLog = getPersistedLogById(LogId{1});
       auto iter = followerLog->read(LogIndex{1});
 
@@ -148,7 +148,7 @@ TEST_F(ReplicatedLogTest, write_single_entry_to_follower) {
 
     {
       // check the follower log, there should be two entries written
-      auto entry = std::optional<PersistingLogEntry>{};
+      auto entry = std::optional<LogEntry>{};
       auto followerLog = getPersistedLogById(LogId{2});
       auto iter = followerLog->read(LogIndex{1});
 
@@ -216,14 +216,12 @@ TEST_F(ReplicatedLogTest, write_single_entry_to_follower) {
 
 TEST_F(ReplicatedLogTest, wake_up_as_leader_with_persistent_data) {
   auto const entries = {
-      replication2::PersistingLogEntry(
-          LogTerm{1}, LogIndex{1}, LogPayload::createFromString("first entry")),
-      replication2::PersistingLogEntry(
-          LogTerm{1}, LogIndex{2},
-          LogPayload::createFromString("second entry")),
-      replication2::PersistingLogEntry(
-          LogTerm{2}, LogIndex{3},
-          LogPayload::createFromString("third entry"))};
+      replication2::LogEntry(LogTerm{1}, LogIndex{1},
+                             LogPayload::createFromString("first entry")),
+      replication2::LogEntry(LogTerm{1}, LogIndex{2},
+                             LogPayload::createFromString("second entry")),
+      replication2::LogEntry(LogTerm{2}, LogIndex{3},
+                             LogPayload::createFromString("third entry"))};
 
   auto coreA = std::unique_ptr<LogCore>(nullptr);
   {
@@ -460,14 +458,12 @@ TEST_F(ReplicatedLogTest, multiple_follower) {
 TEST_F(ReplicatedLogTest,
        write_concern_one_immediate_leader_commit_on_startup) {
   auto const entries = {
-      replication2::PersistingLogEntry(
-          LogTerm{1}, LogIndex{1}, LogPayload::createFromString("first entry")),
-      replication2::PersistingLogEntry(
-          LogTerm{1}, LogIndex{2},
-          LogPayload::createFromString("second entry")),
-      replication2::PersistingLogEntry(
-          LogTerm{2}, LogIndex{3},
-          LogPayload::createFromString("third entry"))};
+      replication2::LogEntry(LogTerm{1}, LogIndex{1},
+                             LogPayload::createFromString("first entry")),
+      replication2::LogEntry(LogTerm{1}, LogIndex{2},
+                             LogPayload::createFromString("second entry")),
+      replication2::LogEntry(LogTerm{2}, LogIndex{3},
+                             LogPayload::createFromString("third entry"))};
 
   auto coreA = std::unique_ptr<LogCore>(nullptr);
   {

--- a/tests/Replication2/ReplicatedState/StateManagerTest.cpp
+++ b/tests/Replication2/ReplicatedState/StateManagerTest.cpp
@@ -389,7 +389,7 @@ TEST_F(StateManagerTest_EmptyState,
     auto payload = LogMetaPayload{std::move(meta)};
     auto const termIndexPair = TermIndexPair(term, LogIndex(1));
     auto logEntry = InMemoryLogEntry(
-        PersistingLogEntry(termIndexPair, std::move(payload)), waitForSync);
+        LogEntry(termIndexPair, std::move(payload)), waitForSync);
     auto request = AppendEntriesRequest(
         term, leaderId, TermIndexPair(LogTerm(0), LogIndex(0)), LogIndex(1),
         LogIndex(0), MessageId(1), waitForSync,
@@ -494,7 +494,7 @@ TEST_F(
     // This should result in a truncate
     auto const termIndexPair = TermIndexPair(term, LogIndex(2));
     auto logEntry = InMemoryLogEntry(
-        PersistingLogEntry(termIndexPair, std::move(payload)), waitForSync);
+        LogEntry(termIndexPair, std::move(payload)), waitForSync);
     auto request = AppendEntriesRequest(
         term, leaderId, TermIndexPair(LogTerm(0), LogIndex(0)), LogIndex(1),
         LogIndex(0), MessageId(1), waitForSync,
@@ -619,7 +619,7 @@ TEST_F(
     // This should result in a truncate
     auto const termIndexPair = TermIndexPair(term, LogIndex(2));
     auto logEntry = InMemoryLogEntry(
-        PersistingLogEntry(termIndexPair, std::move(payload)), waitForSync);
+        LogEntry(termIndexPair, std::move(payload)), waitForSync);
     auto request = AppendEntriesRequest(
         term, leaderId, TermIndexPair(LogTerm(0), LogIndex(0)), LogIndex(1),
         LogIndex(0), MessageId(1), waitForSync,
@@ -741,7 +741,7 @@ TEST_F(
     auto payload = LogMetaPayload{std::move(meta)};
     auto const termIndexPair = TermIndexPair(term, LogIndex(1));
     auto logEntry = InMemoryLogEntry(
-        PersistingLogEntry(termIndexPair, std::move(payload)), waitForSync);
+        LogEntry(termIndexPair, std::move(payload)), waitForSync);
     auto request = AppendEntriesRequest(
         term, leaderId, TermIndexPair(LogTerm(0), LogIndex(0)), LogIndex(1),
         LogIndex(0), MessageId(1), waitForSync,
@@ -882,7 +882,7 @@ TEST_F(
     auto payload = LogMetaPayload{std::move(meta)};
     auto const termIndexPair = TermIndexPair(term, LogIndex(1));
     auto logEntry = InMemoryLogEntry(
-        PersistingLogEntry(termIndexPair, std::move(payload)), waitForSync);
+        LogEntry(termIndexPair, std::move(payload)), waitForSync);
     auto request = AppendEntriesRequest(
         term, leaderId, TermIndexPair(LogTerm(0), LogIndex(0)), LogIndex(1),
         LogIndex(0), MessageId(1), waitForSync,
@@ -971,7 +971,7 @@ TEST_F(StateManagerTest_FakeState, follower_acquire_snapshot) {
     auto payload = LogMetaPayload{std::move(meta)};
     auto const termIndexPair = TermIndexPair(term, LogIndex(1));
     auto logEntry = InMemoryLogEntry(
-        PersistingLogEntry(termIndexPair, std::move(payload)), waitForSync);
+        LogEntry(termIndexPair, std::move(payload)), waitForSync);
     auto request = AppendEntriesRequest(
         term, leaderId, TermIndexPair(LogTerm(0), LogIndex(0)), LogIndex(1),
         LogIndex(0), MessageId(1), waitForSync,


### PR DESCRIPTION
### Scope & Purpose

Some renaming for better consistency (`PersistingLogEntry` -> `LogEntry`, `PersistedLogIterator` -> `LogIterator`).
Introduce the new concept of `PersistedLogEntry` which represents a `LogEntry` plus additional information of how/where it is persisted (plus a new corresponding `PersistedLogIterator`).

- [x] :hammer: Refactoring/simplification
