### PR TITLE
[CINFRA] Initializing syncIndex to 0

### DIFF
--- a/arangod/Replication2/ReplicatedLog/Components/AppendEntriesManager.cpp
+++ b/arangod/Replication2/ReplicatedLog/Components/AppendEntriesManager.cpp
@@ -155,6 +155,15 @@ auto AppendEntriesManager::appendEntries(AppendEntriesRequest request)
   auto action =
       guard->stateHandle.updateCommitIndex(request.leaderCommit, hasSnapshot);
   auto syncIndex = guard->storage.getSyncIndex();
+
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+  auto lastIndex = guard->storage.getTermIndexMapping()
+                       .getLastIndex()
+                       .value_or(TermIndexPair{})
+                       .index;
+  TRI_ASSERT(syncIndex <= lastIndex) << syncIndex << " > " << lastIndex;
+#endif
+
   guard.unlock();
   action.fire();
   requestGuard.reset();

--- a/arangod/Replication2/ReplicatedLog/Components/StorageManager.cpp
+++ b/arangod/Replication2/ReplicatedLog/Components/StorageManager.cpp
@@ -160,11 +160,7 @@ StorageManager::StorageManager(std::unique_ptr<IStorageEngineMethods> methods,
     : guardedData(std::move(methods)),
       loggerContext(
           loggerContext.with<logContextKeyLogComponent>("storage-manager")),
-      scheduler(std::move(scheduler)),
-      syncIndex(getTermIndexMapping()
-                    .getLastIndex()
-                    .value_or(TermIndexPair{})
-                    .index) {}
+      scheduler(std::move(scheduler)) {}
 
 auto StorageManager::resign() noexcept
     -> std::unique_ptr<IStorageEngineMethods> {

--- a/arangod/Replication2/ReplicatedLog/Components/StorageManager.h
+++ b/arangod/Replication2/ReplicatedLog/Components/StorageManager.h
@@ -90,6 +90,9 @@ struct StorageManager : IStorageManager,
   using GuardType = Guarded<GuardedData>::mutex_guard_type;
   LoggerContext const loggerContext;
   std::shared_ptr<IScheduler> const scheduler;
+
+  // The syncIndex is initially 0 and will be updated to its real value when the
+  // first append-entries is synced.
   Guarded<LogIndex> syncIndex;
 
   auto scheduleOperation(GuardType&&, TermIndexMapping mapResult,

--- a/arangod/Replication2/ReplicatedLog/LogLeader.cpp
+++ b/arangod/Replication2/ReplicatedLog/LogLeader.cpp
@@ -1049,17 +1049,10 @@ auto replicated_log::LogLeader::GuardedLeaderData::handleAppendEntriesResponse(
         follower.nextPrevLogIndex = lastIndex.index;
         follower.lastAckedCommitIndex = currentCommitIndex;
         follower.lastAckedLowestIndexToKeep = currentLITK;
-
-        // Note that it is not necessary to update the follower's syncIndex
-        // exclusively on success. While doing so after getting an
-        // AppendEntriesError, but then we might end up with a syncIndex that is
-        // greater than the lastAckedIndex, which is correct, but
-        // counterintuitive. As this is not performance critical, it would be
-        // nicer to know that the syncIndex is always = lastAckedIndex (in case
-        // of waitForSync = true).
-        TRI_ASSERT(response.syncIndex >= follower.syncIndex)
-            << response.syncIndex << " vs. " << follower.syncIndex;
         follower.syncIndex = response.syncIndex;
+
+        TRI_ASSERT(follower.syncIndex <= follower.lastAckedIndex.index)
+            << follower.syncIndex << " vs. " << follower.lastAckedIndex.index;
       } else {
         TRI_ASSERT(response.reason.error !=
                    AppendEntriesErrorReason::ErrorType::kNone);


### PR DESCRIPTION
### Scope & Purpose

**Changes**
The `syncIndex` is initialized to 0 at the start of a term and updated to its real value when the first append-entries request if successfully synced.

**Why?**
We are not initializing it with the current spearhead anymore, because in a different term the leader might replace parts of the log (using `removeBack`) - which might make it seem, at least temporarily, as if the `syncIndex` is greater than the spearhead. The safest thing to do is to initialize it to 0 - worst case, compaction may be delayed for a bit, but that is not critical.
Note that, with this change, the `syncIndex` may be decreased - it can get to 0 during a term change. This implies that `syncCommitIndex` may be decreased as well.
I have added a couple of new assertions, making sure that `syncIndex <= spearhead` always holds.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification