### PR TITLE
BTS-1512: testing: if we have a crashdump, test state must be failed

### DIFF
--- a/arangod/IResearch/IResearchDataStore.cpp
+++ b/arangod/IResearch/IResearchDataStore.cpp
@@ -1684,6 +1684,7 @@ void IResearchDataStore::truncateCommit(TruncateGuard&& guard,
   };
 
   TRI_IF_FAILURE("ArangoSearchTruncateFailure") {
+    CrashHandler::setHardKill();
     THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
   }
 

--- a/scripts/test/testing_runner.py
+++ b/scripts/test/testing_runner.py
@@ -489,7 +489,8 @@ class TestingRunner:
                 core_max_count,
             )
             return
-
+        self.crashed = True
+        self.success = False
         core_zip_dir = get_workspace() / "coredumps"
         core_zip_dir.mkdir(parents=True, exist_ok=True)
         zip_slots = psutil.cpu_count(logical=False)


### PR DESCRIPTION
- forward port of https://github.com/arangodb/oskar/pull/526/files to circle ci
- don't create coredumps on failure points

- [x] Backports
 - [x] 3.11 https://github.com/arangodb/arangodb/pull/19411
 - [x] 3.10 https://github.com/arangodb/arangodb/pull/19412
 - [x] 3.9 https://github.com/arangodb/arangodb/pull/19413
