### PR TITLE
attempt to fix chaos tests

### DIFF
--- a/js/client/modules/@arangodb/test-helper.js
+++ b/js/client/modules/@arangodb/test-helper.js
@@ -267,8 +267,8 @@ const buildCode = function(key, command, cn, duration) {
   let file = fs.getTempFile() + "-" + key;
   fs.write(file, `
 (function() {
-// For chaos tests additional 10 secs might be not enough
-require('internal').SetGlobalExecutionDeadlineTo((${duration} + 60) * 1000);
+// For chaos tests additional 10 secs might be not enough, so add 3 minutes buffer
+require('internal').SetGlobalExecutionDeadlineTo((${duration} + 180) * 1000);
 let tries = 0;
 while (true) {
   if (++tries % 3 === 0) {
@@ -331,7 +331,7 @@ exports.runParallelArangoshTests = function (tests, duration, cn) {
           }
         }
       });
-      if (count > duration) {
+      if (count >= duration + 10) {
         clients.forEach(function (client) {
           if (!client.done) {
             debug(`force terminating ${client.pid} since we're aborting the tests`);


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/19409

Attempt to fix chaos tests.
Potentially some of the existing timeouts have been too low. This PR adjusts them.
Test-only bugfix.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.11: this PR
  - [ ] Backport for 3.10: -
  - [ ] Backport for 3.9: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 