### PR TITLE
Reuse spearhead nodes as read db.

### DIFF
--- a/arangod/Agency/Agent.cpp
+++ b/arangod/Agency/Agent.cpp
@@ -2467,6 +2467,7 @@ void Agent::syncActiveAndAcknowledged() {
 
 std::shared_ptr<Node const> Agent::IntermediateStateStore::commitIndex(
     index_t idx) {
+  LOG_DEVEL << "calling commitIndex(" << idx << ")";
   ADB_PROD_ASSERT(_first <= idx)
       << "first index is " << _first << " but commit index is " << idx;
   auto delta = idx - _first;
@@ -2480,6 +2481,10 @@ std::shared_ptr<Node const> Agent::IntermediateStateStore::commitIndex(
 
 void Agent::IntermediateStateStore::emplace(index_t idx,
                                             std::shared_ptr<const Node> state) {
+  LOG_DEVEL << "calling emplace(" << idx << ")";
+  if (_deque.empty()) {
+    _first = idx;
+  }
   auto next = _deque.size() + _first;
   ADB_PROD_ASSERT(next == idx)
       << "next index is " << next << " but insert index is " << idx;

--- a/arangod/Agency/Agent.cpp
+++ b/arangod/Agency/Agent.cpp
@@ -2468,20 +2468,27 @@ void Agent::syncActiveAndAcknowledged() {
 std::shared_ptr<Node const> Agent::IntermediateStateStore::commitIndex(
     index_t idx) {
   LOG_DEVEL << "calling commitIndex(" << idx << ")";
+  LOG_DEVEL << "_first        = " << _first;
+  LOG_DEVEL << "_deque.size() = " << _deque.size();
   ADB_PROD_ASSERT(_first <= idx)
       << "first index is " << _first << " but commit index is " << idx;
   auto delta = idx - _first;
   ADB_PROD_ASSERT(delta < _deque.size())
       << "delta is " << delta << " but queue size is only " << _deque.size();
+  LOG_DEVEL << "delta         = " << delta;
   auto node = _deque.at(delta);
   _deque.erase(_deque.begin(), _deque.begin() + delta + 1);
   _first = idx + 1;
+  LOG_DEVEL << "_first        = " << _first;
+  LOG_DEVEL << "_deque.size() = " << _deque.size();
   return node;
 }
 
 void Agent::IntermediateStateStore::emplace(index_t idx,
                                             std::shared_ptr<const Node> state) {
   LOG_DEVEL << "calling emplace(" << idx << ")";
+  LOG_DEVEL << "_first        = " << _first;
+  LOG_DEVEL << "_deque.size() = " << _deque.size();
   if (_deque.empty()) {
     _first = idx;
   }
@@ -2489,6 +2496,8 @@ void Agent::IntermediateStateStore::emplace(index_t idx,
   ADB_PROD_ASSERT(next == idx)
       << "next index is " << next << " but insert index is " << idx;
   _deque.emplace_back(std::move(state));
+  LOG_DEVEL << "_first        = " << _first;
+  LOG_DEVEL << "_deque.size() = " << _deque.size();
 }
 
 Agent::IntermediateStateStore::IntermediateStateStore() : _first{1} {}

--- a/arangod/Agency/Agent.h
+++ b/arangod/Agency/Agent.h
@@ -428,6 +428,12 @@ class Agent final : public arangodb::ServerThread<ArangodServer>,
   /// @brief Stores intermediate states
   IntermediateStateStore _inflightStates;
 
+  /// @brief This mutex guard against the race of inserting transactions into
+  ///     the log and placing the modified state in the IntermediateStateStore.
+  ///     When we advance the commit index, it could otherwise happen, that
+  ///     the new state was not yet inserted.
+  std::mutex _logAndIntermediateStateMutex;
+
   /// @brief Committed (read) kv-store for transient data. This is
   /// protected by the _transientLock mutex.
   Store _transient;

--- a/arangod/Agency/Agent.h
+++ b/arangod/Agency/Agent.h
@@ -416,6 +416,34 @@ class Agent final : public arangodb::ServerThread<ArangodServer>,
   /// @brief Committed (read) kv-store
   Store _readDB;
 
+  // TODO replace this implementation with something faster. For now we try
+  //   to get the logic of everything else right.
+  struct IntermediateStateStore {
+    void emplace(index_t idx, std::shared_ptr<Node const> state) {
+      ADB_PROD_ASSERT(_map.empty() || _map.rbegin()->first < idx)
+          << "inserted inflight state with index " << idx
+          << " but we are already at "
+          << (_map.empty() ? 0 : _map.rbegin()->first);
+      auto [it, inserted] = _map.emplace(idx, std::move(state));
+      TRI_ASSERT(inserted);
+    }
+
+    std::shared_ptr<Node const> commitIndex(index_t idx) {
+      auto it = _map.find(idx);
+      ADB_PROD_ASSERT(it != _map.end())
+          << "inflight did not contain index " << idx;
+
+      auto node = std::move(it->second);
+      _map.erase(_map.begin(), std::next(it));
+      return node;
+    }
+
+    std::map<index_t, std::shared_ptr<Node const>> _map;
+  };
+
+  /// @brief Stores intermediate states
+  IntermediateStateStore _inflightStates;
+
   /// @brief Committed (read) kv-store for transient data. This is
   /// protected by the _transientLock mutex.
   Store _transient;

--- a/arangod/Agency/Agent.h
+++ b/arangod/Agency/Agent.h
@@ -420,6 +420,7 @@ class Agent final : public arangodb::ServerThread<ArangodServer>,
     IntermediateStateStore();
     void emplace(index_t idx, std::shared_ptr<Node const> state);
     std::shared_ptr<Node const> commitIndex(index_t idx);
+    void clear() noexcept;
 
     index_t _first;
     std::deque<std::shared_ptr<Node const>> _deque;

--- a/arangod/Agency/Store.cpp
+++ b/arangod/Agency/Store.cpp
@@ -88,6 +88,9 @@ std::vector<apply_ret_t> Store::applyTransactions(
     }
     try {
       for (auto const& i : VPackArrayIterator(query)) {
+        if (states) {
+          states->emplace_back(nullptr);
+        }
         if (!wmode.privileged()) {
           bool found = false;
           for (auto const& o : VPackObjectIterator(i[0])) {
@@ -105,9 +108,7 @@ std::vector<apply_ret_t> Store::applyTransactions(
 
         bool ok;
         std::lock_guard storeLocker{_storeLock};
-        if (states) {
-          states->emplace_back(nullptr);
-        }
+
         switch (i.length()) {
           case 1:  // No precondition
             ok = applies(i[0]);

--- a/arangod/Agency/Store.cpp
+++ b/arangod/Agency/Store.cpp
@@ -75,22 +75,17 @@ Store& Store::operator=(Store&& rhs) {
 /// Default dtor
 Store::~Store() = default;
 
-index_t Store::applyTransactions(std::vector<log_t> const& queries) {
-  std::lock_guard storeLocker{_storeLock};
-
-  for (auto const& query : queries) {
-    applies(Slice(query.entry->data()));
-  }
-  return queries.empty() ? 0 : queries.back().index;
-}
-
 /// Apply array of transactions multiple queries to store
 /// Return vector of according success
 std::vector<apply_ret_t> Store::applyTransactions(
-    VPackSlice query, Agent::WriteMode const& wmode) {
+    VPackSlice query, Agent::WriteMode const& wmode,
+    std::vector<std::shared_ptr<Node const>>* states) {
   std::vector<apply_ret_t> success;
 
   if (query.isArray()) {
+    if (states) {
+      states->reserve(query.length());
+    }
     try {
       for (auto const& i : VPackArrayIterator(query)) {
         if (!wmode.privileged()) {
@@ -108,15 +103,27 @@ std::vector<apply_ret_t> Store::applyTransactions(
           }
         }
 
+        bool ok;
         std::lock_guard storeLocker{_storeLock};
+        if (states) {
+          states->emplace_back(nullptr);
+        }
         switch (i.length()) {
           case 1:  // No precondition
-            success.push_back(applies(i[0]) ? APPLIED : UNKNOWN_ERROR);
+            ok = applies(i[0]);
+            success.push_back(ok ? APPLIED : UNKNOWN_ERROR);
+            if (states) {
+              states->back() = _node;
+            }
             break;
           case 2:  // precondition + uuid
           case 3:
             if (check(i[1]).successful()) {
-              success.push_back(applies(i[0]) ? APPLIED : UNKNOWN_ERROR);
+              ok = applies(i[0]);
+              success.push_back(ok ? APPLIED : UNKNOWN_ERROR);
+              if (states) {
+                states->back() = _node;
+              }
             } else {  // precondition failed
               LOG_TOPIC("f6873", TRACE, Logger::AGENCY)
                   << "Precondition failed!";
@@ -762,4 +769,8 @@ void Store::registerPrefixTrigger(std::string const& prefix,
 
 std::vector<std::string> Store::split(std::string_view str) {
   return Node::split(str);
+}
+
+void Store::setRootNode(std::shared_ptr<const Node> node) noexcept {
+  _node = std::move(node);
 }

--- a/arangod/Agency/Store.h
+++ b/arangod/Agency/Store.h
@@ -100,9 +100,8 @@ class Store {
   /// in the next method.
   std::vector<apply_ret_t> applyTransactions(
       arangodb::velocypack::Slice query,
-      AgentInterface::WriteMode const& wmode = AgentInterface::WriteMode());
-
-  index_t applyTransactions(std::vector<log_t> const& queries);
+      AgentInterface::WriteMode const& wmode = AgentInterface::WriteMode(),
+      std::vector<std::shared_ptr<Node const>>* = nullptr);
 
   /// @brief Apply single transaction in query, here query is an array and the
   /// first entry is a write transaction (i.e. an array of length 1, 2 or 3),
@@ -165,6 +164,8 @@ class Store {
       std::function<void(std::string_view path, VPackSlice trx)>;
 
   void registerPrefixTrigger(std::string const& prefix, AgencyTriggerCallback);
+
+  void setRootNode(std::shared_ptr<Node const>) noexcept;
 
  private:
   /// @brief Apply single slice


### PR DESCRIPTION
### Scope & Purpose
Final step in the refactoring of the agency nodes. Instead of applying transactions twice and storing the agency state twice, we keep the old spearhead pointers around and reuse them as readDB once the index is committed.