### PR TITLE
Reactivate building devel in CI on merge.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,6 +48,7 @@ workflows:
   setup:
     when:
       or:
+        - equal: [ devel, << pipeline.git.branch >> ]
         - equal: [ api, << pipeline.trigger_source >> ]
         - equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
     jobs:


### PR DESCRIPTION
### Scope & Purpose

Build `devel` on PR merges automatically again; this should allow detecting PR merges that break `devel` more quickly.