### PR TITLE
fix lock code when a lock timeout occurs

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 v3.11.2 (XXXX-XX-XX)
 --------------------
 
+* Fixed issue with lock starvation when an AQL insert operation with multiple
+  static documents was executed as part of a streaming transaction.
+
 * Added startup option `--database.max-databases` to limit the maximum number
   of databases that can exist in parallel on a deployment. This option can be
   used to limit resources used by database objects. If the option is used and

--- a/lib/Basics/ReadWriteLock.cpp
+++ b/lib/Basics/ReadWriteLock.cpp
@@ -89,10 +89,18 @@ bool ReadWriteLock::tryLockWriteFor(std::chrono::microseconds timeout) {
   }
 
   // Undo the counting of us as queued writer:
-  _state.fetch_sub(QUEUED_WRITER_INC, std::memory_order_relaxed);
-
-  { std::lock_guard<std::mutex> guard(_reader_mutex); }
-  _readers_bell.notify_all();
+  auto state = _state.fetch_sub(QUEUED_WRITER_INC, std::memory_order_relaxed) - QUEUED_WRITER_INC;
+ 
+  if (state == 0) {
+    // no queued writers and no locks acquired
+    // no more writers -> wake up any waiting readings
+    { std::lock_guard<std::mutex> guard(_reader_mutex); }
+    _readers_bell.notify_all();
+  } else if ((state & QUEUED_WRITER_MASK) != 0 && (state & WRITE_LOCK) == 0) {
+    // there are other writers waiting and the lock is not acquired -> wake up one of them
+    { std::lock_guard<std::mutex> guard(_writer_mutex); }
+    _writers_bell.notify_one();
+  }
 
   return false;
 }

--- a/lib/Basics/ReadWriteLock.cpp
+++ b/lib/Basics/ReadWriteLock.cpp
@@ -73,7 +73,7 @@ bool ReadWriteLock::tryLockWriteFor(std::chrono::microseconds timeout) {
   std::cv_status status(std::cv_status::no_timeout);
   {
     std::unique_lock<std::mutex> guard(_writer_mutex);
-    while (std::cv_status::no_timeout == status) {
+    do {
       auto state = _state.load(std::memory_order_relaxed);
       // try to acquire write lock as long as no readers or writers are active,
       while ((state & ~QUEUED_WRITER_MASK) == 0) {
@@ -84,16 +84,23 @@ bool ReadWriteLock::tryLockWriteFor(std::chrono::microseconds timeout) {
           return true;
         }
       }
-      // TODO: it seems this may repeatedly wait for the timeout
-      // it is not guaranteed to finish within timeout
       status = _writers_bell.wait_until(guard, end_time);
-    }
+    } while (std::cv_status::no_timeout == status);
   }
 
   // Undo the counting of us as queued writer:
-  _state.fetch_sub(QUEUED_WRITER_INC, std::memory_order_relaxed);
-  { std::lock_guard<std::mutex> guard(_reader_mutex); }
-  _readers_bell.notify_all();
+  auto state = _state.fetch_sub(QUEUED_WRITER_INC, std::memory_order_relaxed) -
+               QUEUED_WRITER_INC;
+
+  if ((state & QUEUED_WRITER_MASK) != 0) {
+    // there are other writers waiting -> wake up one of them
+    { std::lock_guard<std::mutex> guard(_writer_mutex); }
+    _writers_bell.notify_one();
+  } else {
+    // no more writers -> wake up any waiting readings
+    { std::lock_guard<std::mutex> guard(_reader_mutex); }
+    _readers_bell.notify_all();
+  }
 
   return false;
 }

--- a/lib/Basics/ReadWriteLock.cpp
+++ b/lib/Basics/ReadWriteLock.cpp
@@ -89,15 +89,17 @@ bool ReadWriteLock::tryLockWriteFor(std::chrono::microseconds timeout) {
   }
 
   // Undo the counting of us as queued writer:
-  auto state = _state.fetch_sub(QUEUED_WRITER_INC, std::memory_order_relaxed) - QUEUED_WRITER_INC;
- 
+  auto state = _state.fetch_sub(QUEUED_WRITER_INC, std::memory_order_relaxed) -
+               QUEUED_WRITER_INC;
+
   if (state == 0) {
     // no queued writers and no locks acquired
     // no more writers -> wake up any waiting readings
     { std::lock_guard<std::mutex> guard(_reader_mutex); }
     _readers_bell.notify_all();
   } else if ((state & QUEUED_WRITER_MASK) != 0 && (state & WRITE_LOCK) == 0) {
-    // there are other writers waiting and the lock is not acquired -> wake up one of them
+    // there are other writers waiting and the lock is not acquired -> wake up
+    // one of them
     { std::lock_guard<std::mutex> guard(_writer_mutex); }
     _writers_bell.notify_one();
   }

--- a/tests/Basics/ReadWriteLockTest.cpp
+++ b/tests/Basics/ReadWriteLockTest.cpp
@@ -24,12 +24,364 @@
 
 #include "Basics/Common.h"
 #include "Basics/ReadWriteLock.h"
+#include "Basics/ScopeGuard.h"
 
 #include "gtest/gtest.h"
 
 #include <chrono>
+#include <condition_variable>
+#include <cstdint>
+#include <mutex>
+#include <thread>
 
 using namespace arangodb::basics;
+
+TEST(ReadWriteLockTest, testLockWriteParallel) {
+  ReadWriteLock lock;
+
+  constexpr size_t n = 4;
+  std::vector<std::thread> threads;
+  threads.reserve(n);
+
+  auto guard = arangodb::scopeGuard([&]() noexcept {
+    for (auto& t : threads) {
+      t.join();
+    }
+  });
+
+  std::mutex mutex;
+  std::condition_variable cv;
+  bool ready = false;
+
+  auto waitForStart = [&]() {
+    std::unique_lock lock(mutex);
+    cv.wait(lock, [&] { return ready; });
+  };
+  auto start = [&]() {
+    {
+      std::unique_lock lock(mutex);
+      ready = true;
+    }
+    cv.notify_all();
+  };
+
+  constexpr size_t iterations = 5000000;
+  uint64_t counter = 0;
+
+  for (size_t i = 0; i < n; ++i) {
+    threads.emplace_back([&]() {
+      waitForStart();
+
+      for (size_t i = 0; i < iterations; ++i) {
+        lock.lockWrite();
+        ++counter;
+        lock.unlock();
+      }
+    });
+  }
+
+  start();
+
+  guard.fire();
+  ASSERT_EQ(iterations * n, counter);
+}
+
+TEST(ReadWriteLockTest, testTryLockWriteParallel) {
+  ReadWriteLock lock;
+
+  constexpr size_t n = 4;
+  std::vector<std::thread> threads;
+  threads.reserve(n);
+
+  auto guard = arangodb::scopeGuard([&]() noexcept {
+    for (auto& t : threads) {
+      t.join();
+    }
+  });
+
+  std::mutex mutex;
+  std::condition_variable cv;
+  bool ready = false;
+
+  auto waitForStart = [&]() {
+    std::unique_lock lock(mutex);
+    cv.wait(lock, [&] { return ready; });
+  };
+  auto start = [&]() {
+    {
+      std::unique_lock lock(mutex);
+      ready = true;
+    }
+    cv.notify_all();
+  };
+
+  constexpr size_t iterations = 5000000;
+  uint64_t counter = 0;
+
+  for (size_t i = 0; i < n; ++i) {
+    threads.emplace_back([&]() {
+      waitForStart();
+      for (size_t i = 0; i < iterations; ++i) {
+        while (!lock.tryLockWrite()) {
+        }
+        ++counter;
+        lock.unlock();
+      }
+    });
+  }
+
+  start();
+
+  guard.fire();
+  ASSERT_EQ(iterations * n, counter);
+}
+
+TEST(ReadWriteLockTest, testTryLockWriteForParallel) {
+  ReadWriteLock lock;
+
+  constexpr size_t n = 4;
+  std::vector<std::thread> threads;
+  threads.reserve(n);
+
+  auto guard = arangodb::scopeGuard([&]() noexcept {
+    for (auto& t : threads) {
+      t.join();
+    }
+  });
+
+  std::mutex mutex;
+  std::condition_variable cv;
+  bool ready = false;
+
+  auto waitForStart = [&]() {
+    std::unique_lock lock(mutex);
+    cv.wait(lock, [&] { return ready; });
+  };
+  auto start = [&]() {
+    {
+      std::unique_lock lock(mutex);
+      ready = true;
+    }
+    cv.notify_all();
+  };
+
+  auto timeout = std::chrono::duration_cast<std::chrono::microseconds>(
+      std::chrono::duration<double>(60.0 /*seconds*/));
+  constexpr size_t iterations = 5000000;
+  uint64_t counter = 0;
+
+  for (size_t i = 0; i < n; ++i) {
+    threads.emplace_back([&]() {
+      waitForStart();
+      for (size_t i = 0; i < iterations; ++i) {
+        while (!lock.tryLockWriteFor(timeout)) {
+        }
+        ++counter;
+        lock.unlock();
+      }
+    });
+  }
+
+  start();
+
+  guard.fire();
+  ASSERT_EQ(iterations * n, counter);
+}
+
+TEST(ReadWriteLockTest, testTryLockWriteForParallelLowTimeout) {
+  ReadWriteLock lock;
+
+  constexpr size_t n = 4;
+  std::vector<std::thread> threads;
+  threads.reserve(n);
+
+  auto guard = arangodb::scopeGuard([&]() noexcept {
+    for (auto& t : threads) {
+      t.join();
+    }
+  });
+
+  std::mutex mutex;
+  std::condition_variable cv;
+  bool ready = false;
+
+  auto waitForStart = [&]() {
+    std::unique_lock lock(mutex);
+    cv.wait(lock, [&] { return ready; });
+  };
+  auto start = [&]() {
+    {
+      std::unique_lock lock(mutex);
+      ready = true;
+    }
+    cv.notify_all();
+  };
+
+  auto timeout = std::chrono::microseconds(1);
+  constexpr size_t iterations = 5000000;
+  uint64_t counter = 0;
+
+  for (size_t i = 0; i < n; ++i) {
+    threads.emplace_back([&]() {
+      waitForStart();
+      for (size_t i = 0; i < iterations; ++i) {
+        while (!lock.tryLockWriteFor(timeout)) {
+        }
+        ++counter;
+        lock.unlock();
+      }
+    });
+  }
+
+  start();
+
+  guard.fire();
+  ASSERT_EQ(iterations * n, counter);
+}
+
+TEST(ReadWriteLockTest, testLockWriteLockReadParallel) {
+  ReadWriteLock lock;
+
+  constexpr size_t n = 4;
+  std::vector<std::thread> threads;
+  threads.reserve(n);
+
+  auto guard = arangodb::scopeGuard([&]() noexcept {
+    for (auto& t : threads) {
+      t.join();
+    }
+  });
+
+  std::mutex mutex;
+  std::condition_variable cv;
+  bool ready = false;
+
+  auto waitForStart = [&]() {
+    std::unique_lock lock(mutex);
+    cv.wait(lock, [&] { return ready; });
+  };
+  auto start = [&]() {
+    {
+      std::unique_lock lock(mutex);
+      ready = true;
+    }
+    cv.notify_all();
+  };
+
+  constexpr size_t iterations = 5000000;
+  uint64_t counter = 0;
+
+  for (size_t i = 0; i < n; ++i) {
+    if (i >= n / 2) {
+      threads.emplace_back([&]() {
+        waitForStart();
+        for (size_t i = 0; i < iterations; ++i) {
+          lock.lockWrite();
+          ++counter;
+          lock.unlock();
+        }
+      });
+    } else {
+      threads.emplace_back([&]() {
+        waitForStart();
+        [[maybe_unused]] uint64_t total = 0;
+        for (size_t i = 0; i < iterations; ++i) {
+          lock.lockRead();
+          total += counter;
+          lock.unlock();
+        }
+      });
+    }
+  }
+
+  start();
+
+  guard.fire();
+  ASSERT_EQ(iterations * (n / 2), counter);
+}
+
+TEST(ReadWriteLockTest, testMixedParallel) {
+  ReadWriteLock lock;
+
+  constexpr size_t n = 8;
+  std::vector<std::thread> threads;
+  threads.reserve(n);
+
+  auto guard = arangodb::scopeGuard([&]() noexcept {
+    for (auto& t : threads) {
+      t.join();
+    }
+  });
+
+  std::mutex mutex;
+  std::condition_variable cv;
+  bool ready = false;
+
+  auto waitForStart = [&]() {
+    std::unique_lock lock(mutex);
+    cv.wait(lock, [&] { return ready; });
+  };
+  auto start = [&]() {
+    {
+      std::unique_lock lock(mutex);
+      ready = true;
+    }
+    cv.notify_all();
+  };
+
+  auto timeout = std::chrono::duration_cast<std::chrono::microseconds>(
+      std::chrono::duration<double>(60.0 /*seconds*/));
+  constexpr size_t iterations = 5000000;
+  uint64_t counter = 0;
+
+  for (size_t i = 0; i < n; ++i) {
+    if (i == 0 || i == 1) {
+      threads.emplace_back([&]() {
+        waitForStart();
+        for (size_t i = 0; i < iterations; ++i) {
+          lock.lockWrite();
+          ++counter;
+          lock.unlock();
+        }
+      });
+    } else if (i == 2 || i == 3) {
+      threads.emplace_back([&]() {
+        waitForStart();
+        for (size_t i = 0; i < iterations; ++i) {
+          while (!lock.tryLockWrite()) {
+          }
+          ++counter;
+          lock.unlock();
+        }
+      });
+    } else if (i == 4 || i == 5) {
+      threads.emplace_back([&]() {
+        waitForStart();
+        for (size_t i = 0; i < iterations; ++i) {
+          while (!lock.tryLockWriteFor(timeout)) {
+          }
+          ++counter;
+          lock.unlock();
+        }
+      });
+    } else {
+      threads.emplace_back([&]() {
+        waitForStart();
+        [[maybe_unused]] uint64_t total = 0;
+        for (size_t i = 0; i < iterations; ++i) {
+          lock.lockRead();
+          total += counter;
+          lock.unlock();
+        }
+      });
+    }
+  }
+
+  start();
+
+  guard.fire();
+  ASSERT_EQ(iterations * 6, counter);
+}
 
 TEST(ReadWriteLockTest, testTryLockWrite) {
   ReadWriteLock lock;

--- a/tests/Basics/ReadWriteLockTest.cpp
+++ b/tests/Basics/ReadWriteLockTest.cpp
@@ -25,9 +25,12 @@
 #include "Basics/Common.h"
 #include "Basics/ReadWriteLock.h"
 #include "Basics/ScopeGuard.h"
+#include "Basics/system-compiler.h"
+#include "Random/RandomGenerator.h"
 
 #include "gtest/gtest.h"
 
+#include <atomic>
 #include <chrono>
 #include <condition_variable>
 #include <cstdint>
@@ -35,6 +38,27 @@
 #include <thread>
 
 using namespace arangodb::basics;
+
+namespace {
+struct Synchronizer {
+  std::mutex mutex;
+  std::condition_variable cv;
+  bool ready = false;
+
+  void waitForStart() {
+    std::unique_lock lock(mutex);
+    cv.wait(lock, [&] { return ready; });
+  }
+  void start() {
+    {
+      std::unique_lock lock(mutex);
+      ready = true;
+    }
+    cv.notify_all();
+  }
+};
+
+}  // namespace
 
 TEST(ReadWriteLockTest, testLockWriteParallel) {
   ReadWriteLock lock;
@@ -49,28 +73,14 @@ TEST(ReadWriteLockTest, testLockWriteParallel) {
     }
   });
 
-  std::mutex mutex;
-  std::condition_variable cv;
-  bool ready = false;
-
-  auto waitForStart = [&]() {
-    std::unique_lock lock(mutex);
-    cv.wait(lock, [&] { return ready; });
-  };
-  auto start = [&]() {
-    {
-      std::unique_lock lock(mutex);
-      ready = true;
-    }
-    cv.notify_all();
-  };
+  Synchronizer s;
 
   constexpr size_t iterations = 5000000;
   uint64_t counter = 0;
 
   for (size_t i = 0; i < n; ++i) {
     threads.emplace_back([&]() {
-      waitForStart();
+      s.waitForStart();
 
       for (size_t i = 0; i < iterations; ++i) {
         lock.lockWrite();
@@ -80,7 +90,7 @@ TEST(ReadWriteLockTest, testLockWriteParallel) {
     });
   }
 
-  start();
+  s.start();
 
   guard.fire();
   ASSERT_EQ(iterations * n, counter);
@@ -99,28 +109,14 @@ TEST(ReadWriteLockTest, testTryLockWriteParallel) {
     }
   });
 
-  std::mutex mutex;
-  std::condition_variable cv;
-  bool ready = false;
-
-  auto waitForStart = [&]() {
-    std::unique_lock lock(mutex);
-    cv.wait(lock, [&] { return ready; });
-  };
-  auto start = [&]() {
-    {
-      std::unique_lock lock(mutex);
-      ready = true;
-    }
-    cv.notify_all();
-  };
+  Synchronizer s;
 
   constexpr size_t iterations = 5000000;
   uint64_t counter = 0;
 
   for (size_t i = 0; i < n; ++i) {
     threads.emplace_back([&]() {
-      waitForStart();
+      s.waitForStart();
       for (size_t i = 0; i < iterations; ++i) {
         while (!lock.tryLockWrite()) {
         }
@@ -130,7 +126,7 @@ TEST(ReadWriteLockTest, testTryLockWriteParallel) {
     });
   }
 
-  start();
+  s.start();
 
   guard.fire();
   ASSERT_EQ(iterations * n, counter);
@@ -149,21 +145,7 @@ TEST(ReadWriteLockTest, testTryLockWriteForParallel) {
     }
   });
 
-  std::mutex mutex;
-  std::condition_variable cv;
-  bool ready = false;
-
-  auto waitForStart = [&]() {
-    std::unique_lock lock(mutex);
-    cv.wait(lock, [&] { return ready; });
-  };
-  auto start = [&]() {
-    {
-      std::unique_lock lock(mutex);
-      ready = true;
-    }
-    cv.notify_all();
-  };
+  Synchronizer s;
 
   auto timeout = std::chrono::duration_cast<std::chrono::microseconds>(
       std::chrono::duration<double>(60.0 /*seconds*/));
@@ -172,7 +154,7 @@ TEST(ReadWriteLockTest, testTryLockWriteForParallel) {
 
   for (size_t i = 0; i < n; ++i) {
     threads.emplace_back([&]() {
-      waitForStart();
+      s.waitForStart();
       for (size_t i = 0; i < iterations; ++i) {
         while (!lock.tryLockWriteFor(timeout)) {
         }
@@ -182,7 +164,7 @@ TEST(ReadWriteLockTest, testTryLockWriteForParallel) {
     });
   }
 
-  start();
+  s.start();
 
   guard.fire();
   ASSERT_EQ(iterations * n, counter);
@@ -201,21 +183,7 @@ TEST(ReadWriteLockTest, testTryLockWriteForParallelLowTimeout) {
     }
   });
 
-  std::mutex mutex;
-  std::condition_variable cv;
-  bool ready = false;
-
-  auto waitForStart = [&]() {
-    std::unique_lock lock(mutex);
-    cv.wait(lock, [&] { return ready; });
-  };
-  auto start = [&]() {
-    {
-      std::unique_lock lock(mutex);
-      ready = true;
-    }
-    cv.notify_all();
-  };
+  Synchronizer s;
 
   auto timeout = std::chrono::microseconds(1);
   constexpr size_t iterations = 5000000;
@@ -223,7 +191,7 @@ TEST(ReadWriteLockTest, testTryLockWriteForParallelLowTimeout) {
 
   for (size_t i = 0; i < n; ++i) {
     threads.emplace_back([&]() {
-      waitForStart();
+      s.waitForStart();
       for (size_t i = 0; i < iterations; ++i) {
         while (!lock.tryLockWriteFor(timeout)) {
         }
@@ -233,7 +201,7 @@ TEST(ReadWriteLockTest, testTryLockWriteForParallelLowTimeout) {
     });
   }
 
-  start();
+  s.start();
 
   guard.fire();
   ASSERT_EQ(iterations * n, counter);
@@ -252,21 +220,7 @@ TEST(ReadWriteLockTest, testLockWriteLockReadParallel) {
     }
   });
 
-  std::mutex mutex;
-  std::condition_variable cv;
-  bool ready = false;
-
-  auto waitForStart = [&]() {
-    std::unique_lock lock(mutex);
-    cv.wait(lock, [&] { return ready; });
-  };
-  auto start = [&]() {
-    {
-      std::unique_lock lock(mutex);
-      ready = true;
-    }
-    cv.notify_all();
-  };
+  Synchronizer s;
 
   constexpr size_t iterations = 5000000;
   uint64_t counter = 0;
@@ -274,16 +228,17 @@ TEST(ReadWriteLockTest, testLockWriteLockReadParallel) {
   for (size_t i = 0; i < n; ++i) {
     if (i >= n / 2) {
       threads.emplace_back([&]() {
-        waitForStart();
+        s.waitForStart();
         for (size_t i = 0; i < iterations; ++i) {
-          lock.lockWrite();
+          while (!lock.tryLockWrite()) {
+          }
           ++counter;
           lock.unlock();
         }
       });
     } else {
       threads.emplace_back([&]() {
-        waitForStart();
+        s.waitForStart();
         [[maybe_unused]] uint64_t total = 0;
         for (size_t i = 0; i < iterations; ++i) {
           lock.lockRead();
@@ -294,7 +249,7 @@ TEST(ReadWriteLockTest, testLockWriteLockReadParallel) {
     }
   }
 
-  start();
+  s.start();
 
   guard.fire();
   ASSERT_EQ(iterations * (n / 2), counter);
@@ -313,21 +268,7 @@ TEST(ReadWriteLockTest, testMixedParallel) {
     }
   });
 
-  std::mutex mutex;
-  std::condition_variable cv;
-  bool ready = false;
-
-  auto waitForStart = [&]() {
-    std::unique_lock lock(mutex);
-    cv.wait(lock, [&] { return ready; });
-  };
-  auto start = [&]() {
-    {
-      std::unique_lock lock(mutex);
-      ready = true;
-    }
-    cv.notify_all();
-  };
+  Synchronizer s;
 
   auto timeout = std::chrono::duration_cast<std::chrono::microseconds>(
       std::chrono::duration<double>(60.0 /*seconds*/));
@@ -337,7 +278,7 @@ TEST(ReadWriteLockTest, testMixedParallel) {
   for (size_t i = 0; i < n; ++i) {
     if (i == 0 || i == 1) {
       threads.emplace_back([&]() {
-        waitForStart();
+        s.waitForStart();
         for (size_t i = 0; i < iterations; ++i) {
           lock.lockWrite();
           ++counter;
@@ -346,7 +287,7 @@ TEST(ReadWriteLockTest, testMixedParallel) {
       });
     } else if (i == 2 || i == 3) {
       threads.emplace_back([&]() {
-        waitForStart();
+        s.waitForStart();
         for (size_t i = 0; i < iterations; ++i) {
           while (!lock.tryLockWrite()) {
           }
@@ -356,7 +297,7 @@ TEST(ReadWriteLockTest, testMixedParallel) {
       });
     } else if (i == 4 || i == 5) {
       threads.emplace_back([&]() {
-        waitForStart();
+        s.waitForStart();
         for (size_t i = 0; i < iterations; ++i) {
           while (!lock.tryLockWriteFor(timeout)) {
           }
@@ -366,7 +307,7 @@ TEST(ReadWriteLockTest, testMixedParallel) {
       });
     } else {
       threads.emplace_back([&]() {
-        waitForStart();
+        s.waitForStart();
         [[maybe_unused]] uint64_t total = 0;
         for (size_t i = 0; i < iterations; ++i) {
           lock.lockRead();
@@ -377,10 +318,91 @@ TEST(ReadWriteLockTest, testMixedParallel) {
     }
   }
 
-  start();
+  s.start();
 
   guard.fire();
   ASSERT_EQ(iterations * 6, counter);
+}
+
+TEST(ReadWriteLockTest, testRandomMixedParallel) {
+  ReadWriteLock lock;
+
+  constexpr size_t n = 6;
+  std::vector<std::thread> threads;
+  threads.reserve(n);
+
+  auto guard = arangodb::scopeGuard([&]() noexcept {
+    for (auto& t : threads) {
+      t.join();
+    }
+  });
+
+  Synchronizer s;
+
+  constexpr size_t iterations = 5000000;
+  uint64_t counter = 0;
+
+  std::atomic<size_t> total = 0;
+
+  for (size_t i = 0; i < n; ++i) {
+    threads.emplace_back([&]() {
+      s.waitForStart();
+      size_t expected = 0;
+      for (size_t i = 0; i < iterations; ++i) {
+        auto r = arangodb::RandomGenerator::interval(static_cast<uint32_t>(4));
+        switch (r) {
+          case 0: {
+            lock.lockWrite();
+            ++counter;
+            ++expected;
+            lock.unlock();
+            break;
+          }
+          case 1: {
+            if (lock.tryLockWrite()) {
+              ++counter;
+              ++expected;
+              lock.unlock();
+            }
+            break;
+          }
+          case 2: {
+            if (lock.tryLockRead()) {
+              [[maybe_unused]] uint64_t value = counter;
+              lock.unlock();
+            }
+            break;
+          }
+          case 3: {
+            lock.lockRead();
+            [[maybe_unused]] uint64_t value = counter;
+            lock.unlock();
+            break;
+          }
+          case 4: {
+            if (lock.tryLockWriteFor(std::chrono::microseconds(
+                    arangodb::RandomGenerator::interval(
+                        static_cast<uint32_t>(1000))))) {
+              ++counter;
+              ++expected;
+              lock.unlock();
+            }
+            break;
+          }
+          default: {
+            ADB_UNREACHABLE;
+          }
+        }
+      }
+
+      total.fetch_add(expected);
+    });
+  }
+
+  s.start();
+
+  guard.fire();
+  ASSERT_EQ(total, counter);
 }
 
 TEST(ReadWriteLockTest, testTryLockWrite) {

--- a/tests/js/server/aql/aql-temp-rocksdb-storage.js
+++ b/tests/js/server/aql/aql-temp-rocksdb-storage.js
@@ -74,6 +74,7 @@ function StorageForQueryWithCollectionSortSuite() {
       let queryStats = res.getExtra().stats;
       assertTrue(queryStats.hasOwnProperty("peakMemoryUsage"));
       const memoryUsage1 = queryStats.peakMemoryUsage;
+      res.dispose();
 
       res = db._query(query, null, {spillOverThresholdNumRows: 5000, stream: true});
       assertResult("asc", res, 500000);
@@ -83,6 +84,7 @@ function StorageForQueryWithCollectionSortSuite() {
         current: queryStats.peakMemoryUsage,
         previous: memoryUsage1
       });
+      res.dispose();
 
       res = db._query(query, null, {spillOverThresholdMemoryUsage: 5000, stream: true});
       assertResult("asc", res, 500000);
@@ -92,6 +94,7 @@ function StorageForQueryWithCollectionSortSuite() {
         current: queryStats.peakMemoryUsage,
         previous: memoryUsage1
       });
+      res.dispose();
     },
 
     testSortComparePeakMemoryUsageDescCollection: function() {
@@ -101,6 +104,7 @@ function StorageForQueryWithCollectionSortSuite() {
       let queryStats = res.getExtra().stats;
       assertTrue(queryStats.hasOwnProperty("peakMemoryUsage"));
       const memoryUsage1 = queryStats.peakMemoryUsage;
+      res.dispose();
 
       res = db._query(query, null, {spillOverThresholdNumRows: 5000, stream: true});
       assertResult("desc", res, 500000);
@@ -110,6 +114,7 @@ function StorageForQueryWithCollectionSortSuite() {
         current: queryStats.peakMemoryUsage,
         previous: memoryUsage1
       });
+      res.dispose();
 
       res = db._query(query, null, {spillOverThresholdMemoryUsage: 5000, stream: true});
       assertResult("desc", res, 500000);
@@ -119,6 +124,7 @@ function StorageForQueryWithCollectionSortSuite() {
         current: queryStats.peakMemoryUsage,
         previous: memoryUsage1
       });
+      res.dispose();
     },
 
   };


### PR DESCRIPTION
### Scope & Purpose

* Fix lock code when a timeout occurs. In this case it was possible that a queued writer was not notified.
* Disable multi-insert optimization in AQL when it is executed as part of a streaming transaction. This is necessary because the multi-insert optimization will start its own sub-transaction, and does not know about if it is invoked from an outer streaming transaction. If it is invoked from inside a streaming transaction that holds write locks and then starts its own transaction that tries to acquire the same locks, it will deadlock.
* (unimportant) Adjust a test so that it does not acquire a lock recursively on the same collection 3 times.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.11: this PR
  - [x] Backport for 3.10: https://github.com/arangodb/arangodb/pull/19440
  - [x] Backport for 3.9: not needed

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 