### PR TITLE
Memory Accounting Agency Nodes

### DIFF
--- a/Documentation/Metrics/arangodb_agency_node_memory_usage.yaml
+++ b/Documentation/Metrics/arangodb_agency_node_memory_usage.yaml
@@ -1,0 +1,16 @@
+name: arangodb_agency_node_memory_usage
+introducedIn: "3.12"
+help: |
+  Memory used by agency store/cache.
+unit: byte
+type: gauge
+# all other categories are too specific
+category: Statistics
+complexity: high
+exposedBy:
+  - coordinator
+  - dbserver
+  - agent
+description: |
+  Amount of memory used to represent the agency data structure. This measures memory usage on agency and the
+  cache usage on coordinators/dbservers.

--- a/arangod/Agency/Helpers.cpp
+++ b/arangod/Agency/Helpers.cpp
@@ -29,7 +29,7 @@
 namespace arangodb::consensus {
 
 bool isReplicationTwoDB(Node::Children const& databases,
-                        std::string_view dbName) {
+                        std::string const& dbName) {
   auto it = databases.find(dbName);
   if (it == nullptr) {
     // this should actually never happen, but if it does we simply claim that

--- a/arangod/Agency/Helpers.cpp
+++ b/arangod/Agency/Helpers.cpp
@@ -29,7 +29,7 @@
 namespace arangodb::consensus {
 
 bool isReplicationTwoDB(Node::Children const& databases,
-                        std::string const& dbName) {
+                        std::string_view dbName) {
   auto it = databases.find(dbName);
   if (it == nullptr) {
     // this should actually never happen, but if it does we simply claim that

--- a/arangod/Agency/Helpers.h
+++ b/arangod/Agency/Helpers.h
@@ -28,6 +28,6 @@
 namespace arangodb::consensus {
 
 bool isReplicationTwoDB(Node::Children const& databases,
-                        std::string const& dbName);
+                        std::string_view dbName);
 
 }  // namespace arangodb::consensus

--- a/arangod/Agency/Helpers.h
+++ b/arangod/Agency/Helpers.h
@@ -28,6 +28,6 @@
 namespace arangodb::consensus {
 
 bool isReplicationTwoDB(Node::Children const& databases,
-                        std::string_view dbName);
+                        std::string const& dbName);
 
 }  // namespace arangodb::consensus

--- a/arangod/Agency/Node.cpp
+++ b/arangod/Agency/Node.cpp
@@ -247,7 +247,7 @@ ResultT<NodePtr> Node::handle<ERASE>(Node const* target,
   }
 
   if (haveVal) {
-    auto trans = immer::flex_vector_transient<VPackString>{};
+    auto trans = Node::Array::transient_type{};
     for (auto const& value : array) {
       if (!VelocyPackHelper::equal(value, valToErase, true)) {
         trans.push_back(value);
@@ -634,7 +634,7 @@ bool Node::isWriteLockable(std::string_view) const {
 }
 
 bool Node::isWriteUnlockable(std::string_view by) const {
-  return std::visit(overload{[&](VPackString const& slice) {
+  return std::visit(overload{[&](VPackStringType const& slice) {
                                return slice.isString() &&
                                       slice.isEqualString(by);
                              },
@@ -643,24 +643,25 @@ bool Node::isWriteUnlockable(std::string_view by) const {
 }
 
 void Node::toBuilder(Builder& builder, bool showHidden) const {
-  std::visit(overload{[&](Children const& ch) {
-                        VPackObjectBuilder ob(&builder);
-                        for (auto const& [key, node] : ch) {
-                          if (key[0] == '.' && !showHidden) {
-                            continue;
-                          }
-                          builder.add(VPackValue(key));
-                          node->toBuilder(builder, showHidden);
-                        }
-                      },
-                      [&](Array const& ar) {
-                        VPackArrayBuilder ab(&builder);
-                        for (auto const& slice : ar) {
-                          builder.add(slice);
-                        }
-                      },
-                      [&](VPackString const& slice) { builder.add(slice); }},
-             _value);
+  std::visit(
+      overload{[&](Children const& ch) {
+                 VPackObjectBuilder ob(&builder);
+                 for (auto const& [key, node] : ch) {
+                   if (key[0] == '.' && !showHidden) {
+                     continue;
+                   }
+                   builder.add(VPackValue(key));
+                   node->toBuilder(builder, showHidden);
+                 }
+               },
+               [&](Array const& ar) {
+                 VPackArrayBuilder ab(&builder);
+                 for (auto const& slice : ar) {
+                   builder.add(slice);
+                 }
+               },
+               [&](VPackStringType const& slice) { builder.add(slice); }},
+      _value);
 }
 
 // Print internals to ostream
@@ -714,7 +715,7 @@ bool Node::has(std::vector<std::string> const& rel) const {
 bool Node::has(std::string_view rel) const { return has(split(rel)); }
 
 std::optional<int64_t> Node::getInt() const noexcept {
-  if (auto slice = std::get_if<VPackString>(&_value);
+  if (auto slice = std::get_if<VPackStringType>(&_value);
       slice && slice->isNumber<int64_t>()) {
     return slice->getNumber<int64_t>();
   }
@@ -722,7 +723,7 @@ std::optional<int64_t> Node::getInt() const noexcept {
 }
 
 std::optional<uint64_t> Node::getUInt() const noexcept {
-  if (auto slice = std::get_if<VPackString>(&_value);
+  if (auto slice = std::get_if<VPackStringType>(&_value);
       slice && slice->isNumber<uint64_t>()) {
     return slice->getNumber<uint64_t>();
   }
@@ -730,7 +731,7 @@ std::optional<uint64_t> Node::getUInt() const noexcept {
 }
 
 std::optional<bool> Node::getBool() const noexcept {
-  if (auto slice = std::get_if<VPackString>(&_value);
+  if (auto slice = std::get_if<VPackStringType>(&_value);
       slice && slice->isBool()) {
     return slice->getBool();
   }
@@ -738,29 +739,29 @@ std::optional<bool> Node::getBool() const noexcept {
 }
 
 VPackSlice Node::slice() const noexcept {
-  if (auto slice = std::get_if<VPackString>(&_value); slice) {
+  if (auto slice = std::get_if<VPackStringType>(&_value); slice) {
     return slice->slice();
   }
   return VPackSlice::noneSlice();
 }
 
 bool Node::isBool() const {
-  auto slice = std::get_if<VPackString>(&_value);
+  auto slice = std::get_if<VPackStringType>(&_value);
   return slice && slice->isBool();
 }
 
 bool Node::isDouble() const {
-  auto slice = std::get_if<VPackString>(&_value);
+  auto slice = std::get_if<VPackStringType>(&_value);
   return slice && slice->isDouble();
 }
 
 bool Node::isString() const {
-  auto slice = std::get_if<VPackString>(&_value);
+  auto slice = std::get_if<VPackStringType>(&_value);
   return slice && slice->isString();
 }
 
 bool consensus::Node::isNull() const {
-  auto slice = std::get_if<VPackString>(&_value);
+  auto slice = std::get_if<VPackStringType>(&_value);
   return slice && slice->isNull();
 }
 
@@ -769,22 +770,22 @@ bool Node::isArray() const { return std::holds_alternative<Array>(_value); }
 bool Node::isObject() const { return std::holds_alternative<Children>(_value); }
 
 bool Node::isUInt() const {
-  auto slice = std::get_if<VPackString>(&_value);
+  auto slice = std::get_if<VPackStringType>(&_value);
   return slice && (slice->isUInt() || slice->isSmallInt());
 }
 
 bool Node::isInt() const {
-  auto slice = std::get_if<VPackString>(&_value);
+  auto slice = std::get_if<VPackStringType>(&_value);
   return slice && (slice->isInt() || slice->isSmallInt());
 }
 
 bool Node::isNumber() const {
-  auto slice = std::get_if<VPackString>(&_value);
+  auto slice = std::get_if<VPackStringType>(&_value);
   return slice && slice->isNumber();
 }
 
 std::optional<double> Node::getDouble() const noexcept {
-  if (auto slice = std::get_if<VPackString>(&_value);
+  if (auto slice = std::get_if<VPackStringType>(&_value);
       slice && slice->isDouble()) {
     return slice->getDouble();
   }
@@ -861,7 +862,7 @@ Node::Array const* Node::hasAsArray(std::string const& url) const {
 }  // hasAsArray
 
 std::optional<std::string> Node::getString() const {
-  if (auto slice = std::get_if<VPackString>(&_value);
+  if (auto slice = std::get_if<VPackStringType>(&_value);
       slice && slice->isString()) {
     return slice->copyString();
   }
@@ -869,7 +870,7 @@ std::optional<std::string> Node::getString() const {
 }
 
 std::optional<std::string_view> Node::getStringView() const {
-  if (auto slice = std::get_if<VPackString>(&_value);
+  if (auto slice = std::get_if<VPackStringType>(&_value);
       slice && slice->isString()) {
     return slice->stringView();
   }
@@ -893,17 +894,12 @@ std::vector<std::string> Node::keys() const {
   return result;
 }
 
-struct Node::NodeWrapper : Node {
-  template<typename... Args>
-  NodeWrapper(Args&&... args) : Node(std::forward<Args>(args)...) {}
-};
-
 NodePtr Node::create(VPackSlice slice) {
   if (slice.isObject()) {
     if (slice.isEmptyObject()) {
       return emptyObjectValue();
     }
-    immer::map_transient<std::string, NodePtr> trans;
+    Node::Children::transient_type trans;
     for (auto const& [key, sub] : VPackObjectIterator(slice)) {
       auto keyStr = key.copyString();
       if (keyStr.find("/") != std::string::npos) {
@@ -919,16 +915,16 @@ NodePtr Node::create(VPackSlice slice) {
       //    << slice.toJson();
       trans.set(std::move(keyStr), Node::create(sub));
     }
-    return std::make_shared<NodeWrapper>(trans.persistent());
+    return allocateNode(trans.persistent());
   } else if (slice.isArray()) {
     if (slice.isEmptyArray()) {
       return emptyArrayValue();
     }
-    immer::flex_vector_transient<VPackString> a;
+    Node::Array::transient_type a;
     for (auto const& elem : VPackArrayIterator(slice)) {
       a.push_back(elem);
     }
-    return std::make_shared<NodeWrapper>(a.persistent());
+    return allocateNode(a.persistent());
   } else {
     if (slice.isTrue()) {
       return trueValue();
@@ -937,44 +933,44 @@ NodePtr Node::create(VPackSlice slice) {
     } else if (slice.isNull()) {
       return nullValue();
     }
-    return std::make_shared<NodeWrapper>(VPackString(slice));
+    return allocateNode(VPackStringType(slice));
   }
 }
 
 NodePtr Node::create() { return emptyObjectValue(); }
 
 NodePtr Node::create(Node::VariantType value) {
-  return std::make_shared<NodeWrapper>(std::move(value));
+  return allocateNode(std::move(value));
 }
 NodePtr Node::create(Node::Array value) {
-  return std::make_shared<NodeWrapper>(std::move(value));
+  return allocateNode(std::move(value));
 }
 NodePtr Node::create(Node::Children value) {
-  return std::make_shared<NodeWrapper>(std::move(value));
+  return allocateNode(std::move(value));
 }
 
 NodePtr consensus::Node::trueValue() {
-  static auto node = std::make_shared<NodeWrapper>(VPackSlice::trueSlice());
+  static auto node = allocateNode(VPackSlice::trueSlice());
   return node;
 }
 
 NodePtr consensus::Node::falseValue() {
-  static auto node = std::make_shared<NodeWrapper>(VPackSlice::falseSlice());
+  static auto node = allocateNode(VPackSlice::falseSlice());
   return node;
 }
 
 NodePtr consensus::Node::nullValue() {
-  static auto node = std::make_shared<NodeWrapper>(VPackSlice::nullSlice());
+  static auto node = allocateNode(VPackSlice::nullSlice());
   return node;
 }
 
 NodePtr consensus::Node::emptyObjectValue() {
-  static auto node = std::make_shared<NodeWrapper>();
+  static auto node = allocateNode();
   return node;
 }
 
 NodePtr consensus::Node::emptyArrayValue() {
-  static auto node = std::make_shared<NodeWrapper>(Array{});
+  static auto node = allocateNode(Array{});
   return node;
 }
 
@@ -985,4 +981,20 @@ velocypack::ValueType consensus::Node::getVelocyPackValueType() const noexcept {
           [&](Array const& ar) { return velocypack::ValueType::Array; },
           [](auto const& vpack) { return vpack.type(); }},
       _value);
+}
+
+std::atomic<std::size_t> Node::memory_usage = 0;
+
+void Node::increaseMemoryUsage(std::size_t d) noexcept { memory_usage += d; }
+
+void Node::decreaseMemoryUsage(std::size_t d) noexcept { memory_usage -= d; }
+
+template<typename... Args>
+NodePtr consensus::Node::allocateNode(Args&&... args) {
+  struct NodeWrapper : Node {
+    NodeWrapper(Args&&... args) : Node(std::forward<Args>(args)...) {}
+  };
+
+  return std::allocate_shared<NodeWrapper>(Node::allocator_type{},
+                                           std::forward<Args>(args)...);
 }

--- a/arangod/Agency/Node.cpp
+++ b/arangod/Agency/Node.cpp
@@ -983,11 +983,20 @@ velocypack::ValueType consensus::Node::getVelocyPackValueType() const noexcept {
       _value);
 }
 
-std::atomic<std::size_t> Node::memory_usage = 0;
+std::atomic<std::size_t> Node::memoryUsage = 0;
 
-void Node::increaseMemoryUsage(std::size_t d) noexcept { memory_usage += d; }
+void Node::increaseMemoryUsage(std::size_t d) noexcept { memoryUsage += d; }
 
-void Node::decreaseMemoryUsage(std::size_t d) noexcept { memory_usage -= d; }
+void Node::decreaseMemoryUsage(std::size_t d) noexcept { memoryUsage -= d; }
+
+void Node::toPrometheus(std::string& result) {
+  constexpr std::string_view name = "arangodb_agency_node_memory_usage";
+  constexpr std::string_view desc = "Memory used by agency store/cache";
+  auto nodeMemoryUsage = consensus::Node::getMemoryUsage();
+  result += basics::StringUtils::concatT("# HELP ", name, " ", desc,
+                                         "\n# TYPE ", name, " gauge\n", name,
+                                         " ", nodeMemoryUsage, "\n");
+}
 
 template<typename... Args>
 NodePtr consensus::Node::allocateNode(Args&&... args) {

--- a/arangod/Agency/Node.h
+++ b/arangod/Agency/Node.h
@@ -97,12 +97,98 @@ class Node : public std::enable_shared_from_this<Node> {
   using PathType = std::vector<std::string>;
   using PathTypeView = std::span<std::string const>;
 
-  /// @brief Child nodes
-  using Children = ::immer::map<std::string, NodePtr>;
+ private:
+  template<typename T>
+  struct accounting_allocator : std::allocator<T> {
+    template<typename U>
+    accounting_allocator(accounting_allocator<U> const&) {}
+    accounting_allocator() = default;
 
-  using Array = ::immer::flex_vector<velocypack::String>;
+    T* allocate(std::size_t n) {
+      auto mem = std::allocator<T>::allocate(n);
+      Node::increaseMemoryUsage(sizeof(T) * n);
+      return mem;
+    }
 
-  using VariantType = std::variant<Children, Array, velocypack::String>;
+    void deallocate(T* p, std::size_t n) {
+      std::allocator<T>::deallocate(p, n);
+      Node::decreaseMemoryUsage(sizeof(T) * n);
+    }
+
+    template<typename U>
+    struct rebind {
+      using type = accounting_allocator<U>;
+    };
+  };
+
+  using allocator_type = accounting_allocator<Node>;
+
+  template<typename Base>
+  struct accounting_heap : Base {
+    template<typename... Tags>
+    static void* allocate(std::size_t size, Tags... tags) {
+      auto* mem = Base::allocate(size, tags...);
+      Node::increaseMemoryUsage(size);
+      return mem;
+    }
+
+    template<typename... Tags>
+    static void deallocate(std::size_t size, void* data, Tags... tags) {
+      Base::deallocate(size, data, tags...);
+      Node::decreaseMemoryUsage(size);
+    }
+  };
+
+  using accounting_memory_policy =
+      ::immer::memory_policy<accounting_heap<::immer::default_heap_policy>,
+                             ::immer::default_refcount_policy,
+                             ::immer::default_lock_policy>;
+
+  static void increaseMemoryUsage(std::size_t) noexcept;
+  static void decreaseMemoryUsage(std::size_t) noexcept;
+  static std::atomic<std::size_t> memory_usage;
+
+ public:
+  // If you want those types to be accounted for as well, please do so.
+  // But be aware that this will change the type and the interface and you have
+  // to modify a lot of code to make this work. You have been warned.
+  using VPackStringType =
+      velocypack::BasicString</* accounting_allocator<uint8_t> */>;
+  using StringType = std::basic_string<char, std::char_traits<char>
+                                       /*, accounting_allocator<char>*/>;
+
+  struct TransparentHash {
+    using is_transparent = void;
+    template<typename Traits, typename Alloc>
+    auto operator()(std::basic_string<char, Traits, Alloc> const& str) {
+      return std::hash<std::string_view>{}(str);
+    }
+    auto operator()(std::string_view str) {
+      return std::hash<std::string_view>{}(str);
+    }
+  };
+
+  struct TransparentEqual {
+    using is_transparent = void;
+    template<typename T, typename U>
+    bool operator()(T const& t, U const& u) {
+      return t == u;
+    }
+
+    template<typename Chars, typename Traits, typename Alloc1, typename Alloc2>
+    auto operator()(std::basic_string<Chars, Traits, Alloc1> const& str,
+                    std::basic_string<Chars, Traits, Alloc2> const& other) {
+      return std::string_view{str} == other;
+    }
+  };
+
+  using Children = ::immer::map<StringType, NodePtr, TransparentHash,
+                                TransparentEqual, accounting_memory_policy>;
+
+  using Array =
+      ::immer::flex_vector<velocypack::String, accounting_memory_policy>;
+
+  using VariantType = std::variant<Children, Array, VPackStringType>;
 
   /// @brief Split strings by forward slashes, omitting empty strings,
   /// and ignoring multiple subsequent forward slashes
@@ -341,8 +427,8 @@ class Node : public std::enable_shared_from_this<Node> {
  private:
   VPackSlice slice() const noexcept;
 
-  struct NodeWrapper;
-  friend struct NodeWrapper;
+  template<typename... Args>
+  static NodePtr allocateNode(Args&&...);
 
   Node() = default;
   template<typename... Args>

--- a/arangod/Agency/Node.h
+++ b/arangod/Agency/Node.h
@@ -446,10 +446,3 @@ inline std::ostream& operator<<(std::ostream& o, Node const& n) {
 }
 
 }  // namespace arangodb::consensus
-
-// Create an explicit instantiation for VPackString using the Node
-// AccountingAllocator
-#include <velocypack/SliceBase.tpp>
-
-template class arangodb::velocypack::BasicString<
-    typename arangodb::consensus::Node::allocator_type::rebind<uint8_t>::type>;

--- a/arangod/Metrics/MetricsFeature.cpp
+++ b/arangod/Metrics/MetricsFeature.cpp
@@ -29,6 +29,7 @@
 
 #include "ApplicationFeatures/ApplicationServer.h"
 #include "ApplicationFeatures/GreetingsFeaturePhase.h"
+#include "Agency/Node.h"
 #include "Basics/application-exit.h"
 #include "Basics/debugging.h"
 #include "Cluster/ServerState.h"
@@ -171,6 +172,7 @@ void MetricsFeature::toPrometheus(std::string& result, CollectMode mode) const {
   if (hasGlobals && cm.isEnabled() && mode != CollectMode::Local) {
     cm.toPrometheus(result, _globals, _ensureWhitespace);
   }
+  consensus::Node::toPrometheus(result);
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
### Scope & Purpose
Memory accounting for agency nodes. Some members are not yet accounted for, because that would change the API to much. (For example the keys of the `Children` map are still `std::string`s.)