### PR TITLE
avoid recursive locking agency

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 v3.10.10 (XXXX-XX-XX)
 ---------------------
 
+* Avoid recursive lock during agency startup.
+
 * FE-20: fix UI placeholder format for locale when creating analyzers.
 
 * FE-304, FE-305: use navigator.onLine for checking internet connection, correct

--- a/arangod/Agency/State.cpp
+++ b/arangod/Agency/State.cpp
@@ -1002,16 +1002,24 @@ index_t State::loadCompacted() {
 
 /// Load persisted configuration
 bool State::loadOrPersistConfiguration() {
-  std::string const aql(
-      "FOR c in configuration FILTER c._key==\"0\" RETURN c.cfg");
+  // this must be in a lambda so the query lifetime does not overlap
+  // with the lifetime of the other transaction in this function.
+  // otherwise, they may both try to acquire the status lock of the
+  // same collection at the same time, which would be recursive locking.
+  auto loadConfiguration = [&]() -> aql::QueryResult {
+    std::string const aql(
+        "FOR c in configuration FILTER c._key==\"0\" RETURN c.cfg");
 
-  TRI_ASSERT(nullptr !=
-             _vocbase);  // this check was previously in the Query constructor
-  auto query = arangodb::aql::Query::create(
-      transaction::StandaloneContext::Create(*_vocbase), aql::QueryString(aql),
-      nullptr);
+    TRI_ASSERT(nullptr !=
+               _vocbase);  // this check was previously in the Query constructor
+    auto query = arangodb::aql::Query::create(
+        transaction::StandaloneContext::Create(*_vocbase),
+        aql::QueryString(aql), nullptr);
 
-  aql::QueryResult queryResult = query->executeSync();
+    return query->executeSync();
+  };
+
+  aql::QueryResult queryResult = loadConfiguration();
 
   if (queryResult.result.fail()) {
     THROW_ARANGO_EXCEPTION(queryResult.result);


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/19446

when loading configuration with an AQL query (which acquires the collection's status lock) and then starting a transaction on the same collection (acquires the status lock once more) while the query object is still in scope. this leads to the same thread locking the same rw lock in read mode twice, which can be dangerous if a writer is queued for the lock. then the two threads will deadlock.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.11: https://github.com/arangodb/arangodb/pull/19448
  - [x] Backport for 3.10: this PR
  - [ ] Backport for 3.9: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 