### PR TITLE
avoid recursive locking in agency

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 v3.11.2 (XXXX-XX-XX)
 --------------------
 
+* Avoid recursive lock during agency startup.
+
 * Added startup option `--database.max-databases` to limit the maximum number
   of databases that can exist in parallel on a deployment. This option can be
   used to limit resources used by database objects. If the option is used and

--- a/arangod/Agency/State.cpp
+++ b/arangod/Agency/State.cpp
@@ -1027,9 +1027,9 @@ bool State::loadOrPersistConfiguration() {
     TRI_ASSERT(nullptr !=
                _vocbase);  // this check was previously in the Query constructor
     auto query = arangodb::aql::Query::create(
-        transaction::StandaloneContext::Create(*_vocbase), aql::QueryString(aql),
-        nullptr);
-    
+        transaction::StandaloneContext::Create(*_vocbase),
+        aql::QueryString(aql), nullptr);
+
     return query->executeSync();
   };
 


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/19446

when loading configuration with an AQL query (which acquires the collection's status lock) and then starting a transaction on the same collection (acquires the status lock once more) while the query object is still in scope. this leads to the same thread locking the same rw lock in read mode twice, which can be dangerous if a writer is queued for the lock. then the two threads will deadlock.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.11: this PR
  - [x] Backport for 3.10: https://github.com/arangodb/arangodb/pull/19447
  - [ ] Backport for 3.9: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 