### PR TITLE
[3.10] [BTS-1511] Fix AqlValues with 7-byte integers

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,17 @@
 v3.10.10 (XXXX-XX-XX)
 ---------------------
 
+* BTS-1511: AQL: Fixed access of integers in the ranges
+  [-36028797018963968, -281474976710657] and
+  [281474976710656, 36028797018963968], i.e. those whose representation require
+  7 bytes. These values were misinterpreted as different integers.
+  Simple passing of values (i.e. writing to or reading from documents) was not
+  affected: Only accesses of those values as numbers by AQL was. E.g. arithmetic
+  (addition, multiplication, ...), certain AQL functions, comparing/sorting -
+  the latter only if the numbers are compared directly, but not as part of a
+  value. For example, `SORT x` lead to an unexpected order if x was such a
+  number. `SORT [x]` however worked as expected.
+
 * Updated ArangoDB Starter to 0.16.0.
 
 * Avoid recursive lock during agency startup.

--- a/arangod/Aql/AqlValue.cpp
+++ b/arangod/Aql/AqlValue.cpp
@@ -875,7 +875,8 @@ int64_t AqlValue::toInt64() const {
           _data.longNumberMeta.data.intLittleEndian.val);
     case VPACK_INLINE_UINT64:
       if (ADB_UNLIKELY(
-              _data.longNumberMeta.data.uintLittleEndian.val >
+              basics::littleToHost(
+                  _data.longNumberMeta.data.uintLittleEndian.val) >
               static_cast<uint64_t>(std::numeric_limits<int64_t>::max()))) {
         throw velocypack::Exception(velocypack::Exception::NumberOutOfRange);
       }
@@ -1649,6 +1650,31 @@ void AqlValue::initFromSlice(arangodb::velocypack::Slice slice,
                                : AqlValueType::VPACK_INLINE_INT64);
         memcpy(_data.longNumberMeta.data.slice.slice, slice.begin(),
                static_cast<size_t>(length));
+        // If length == 9, we're done;
+        // If length == 8, there's one byte left to fill.
+
+        if (length == 8) {
+          // For correct sign extent, we need 0xff for negative, and 0x00 for
+          // all nonnegative integers.
+          auto const filler =
+              slice.isUInt() || std::int8_t(slice.begin()[length - 1]) >= 0
+                  ? 0x00
+                  : 0xff;
+
+          _data.longNumberMeta.data.slice.slice[length] = filler;
+        } else {
+          TRI_ASSERT(length == 9);
+        }
+
+        TRI_ASSERT(
+            slice.isUInt()
+                ? slice.getUInt() >
+                          static_cast<uint64_t>(
+                              std::numeric_limits<std::int64_t>().max()) ||
+                      slice.getUInt() == static_cast<uint64_t>(this->toInt64())
+                : slice.getInt() == this->toInt64())
+            << (slice.isUInt() ? "uint " : "int ") << slice.toJson()
+            << " != " << this->toInt64();
       } else {
         memcpy(_data.shortNumberMeta.data.slice.slice, slice.begin(),
                static_cast<size_t>(length));

--- a/arangod/Aql/AqlValue.h
+++ b/arangod/Aql/AqlValue.h
@@ -481,9 +481,6 @@ struct AqlValue final {
   }
 
  private:
-  /// @brief initializes value from a slice
-  void initFromSlice(arangodb::velocypack::Slice slice);
-
   /// @brief initializes value from a slice, when the length is already known
   void initFromSlice(arangodb::velocypack::Slice slice,
                      arangodb::velocypack::ValueLength length);

--- a/tests/Aql/AqlValueMemoryLayoutTest.cpp
+++ b/tests/Aql/AqlValueMemoryLayoutTest.cpp
@@ -139,7 +139,6 @@ void runChecksForSlice(velocypack::Slice value, std::uint8_t const* expected) {
     EXPECT_EQ(ival != 0, aqlValue.toBoolean());
     EXPECT_EQ(ival, aqlValue.slice().getNumber<std::int64_t>());
     EXPECT_EQ(ival, aqlValue.toInt64());
-    EXPECT_EQ(ival, aqlValue.slice().getNumber<std::int64_t>());
   } else {
     TRI_ASSERT(false) << "Unexpected type " << value.typeName();
   }

--- a/tests/Aql/AqlValueMemoryLayoutTest.cpp
+++ b/tests/Aql/AqlValueMemoryLayoutTest.cpp
@@ -25,9 +25,9 @@
 
 #include "Aql/AqlValue.h"
 #include "Basics/Endian.h"
-#include "VelocypackUtils/VelocyPackStringLiteral.h"
 
 #include <velocypack/Builder.h>
+#include <velocypack/Parser.h>
 #include <velocypack/Slice.h>
 #include <velocypack/SharedSlice.h>
 
@@ -35,7 +35,6 @@
 
 using namespace arangodb;
 using namespace arangodb::aql;
-using arangodb::velocypack::operator""_vpack;
 
 namespace {
 
@@ -144,6 +143,18 @@ void runChecksForSlice(velocypack::Slice value, std::uint8_t const* expected) {
   } else {
     TRI_ASSERT(false) << "Unexpected type " << value.typeName();
   }
+}
+
+auto vpackFromJsonString(char const* c) -> std::shared_ptr<VPackBuilder> {
+  velocypack::Options options;
+  options.checkAttributeUniqueness = true;
+  velocypack::Parser parser(&options);
+  parser.parse(c);
+  return parser.steal();
+}
+
+auto operator"" _vpack(const char* json, size_t) -> velocypack::SharedSlice {
+  return vpackFromJsonString(json)->sharedSlice();
 }
 
 // note: in all following tests, the value UNINITIALIZED (0xa5) has a special

--- a/tests/Aql/SortExecutorTest.cpp
+++ b/tests/Aql/SortExecutorTest.cpp
@@ -46,7 +46,6 @@
 #include "Transaction/Context.h"
 #include "Transaction/Methods.h"
 
-#include "VelocypackUtils/VelocyPackStringLiteral.h"
 #include "Basics/VelocyPackHelper.h"
 
 #include "AqlItemBlockHelper.h"


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/19449.

Changes to `lib/` aren't backported, therefore the tests use velocypack::SharedSlice instead of velocypack::String. Also, `VelocyPackStringLiteral.h` doesn't exist yet, so added an ad-hoc implementation of `operator""_vpack`.