### PR TITLE
[3.9] [BTS-1511] Fix AqlValues with 7-byte integers

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,17 @@
 v3.9.12 (XXXX-X-XX)
 --------------------
 
+* BTS-1511: AQL: Fixed access of integers in the ranges
+  [-36028797018963968, -281474976710657] and
+  [281474976710656, 36028797018963968], i.e. those whose representation require
+  7 bytes. These values were misinterpreted as different integers.
+  Simple passing of values (i.e. writing to or reading from documents) was not
+  affected: Only accesses of those values as numbers by AQL was. E.g. arithmetic
+  (addition, multiplication, ...), certain AQL functions, comparing/sorting -
+  the latter only if the numbers are compared directly, but not as part of a
+  value. For example, `SORT x` lead to an unexpected order if x was such a
+  number. `SORT [x]` however worked as expected.
+
 * Updated ArangoDB Starter to 0.16.0.
 
 * Fixed two possible deadlocks which could occur if all medium priority threads

--- a/arangod/Aql/AqlValue.cpp
+++ b/arangod/Aql/AqlValue.cpp
@@ -885,7 +885,8 @@ int64_t AqlValue::toInt64() const {
           _data.longNumberMeta.data.intLittleEndian.val);
     case VPACK_INLINE_UINT64:
       if (ADB_UNLIKELY(
-              _data.longNumberMeta.data.uintLittleEndian.val >
+              basics::littleToHost(
+                  _data.longNumberMeta.data.uintLittleEndian.val) >
               static_cast<uint64_t>(std::numeric_limits<int64_t>::max()))) {
         throw velocypack::Exception(velocypack::Exception::NumberOutOfRange);
       }
@@ -1659,6 +1660,31 @@ void AqlValue::initFromSlice(arangodb::velocypack::Slice slice,
                                : AqlValueType::VPACK_INLINE_INT64);
         memcpy(_data.longNumberMeta.data.slice.slice, slice.begin(),
                static_cast<size_t>(length));
+        // If length == 9, we're done;
+        // If length == 8, there's one byte left to fill.
+
+        if (length == 8) {
+          // For correct sign extent, we need 0xff for negative, and 0x00 for
+          // all nonnegative integers.
+          auto const filler =
+              slice.isUInt() || std::int8_t(slice.begin()[length - 1]) >= 0
+                  ? 0x00
+                  : 0xff;
+
+          _data.longNumberMeta.data.slice.slice[length] = filler;
+        } else {
+          TRI_ASSERT(length == 9);
+        }
+
+        TRI_ASSERT(
+            slice.isUInt()
+                ? slice.getUInt() >
+                          static_cast<uint64_t>(
+                              std::numeric_limits<std::int64_t>().max()) ||
+                      slice.getUInt() == static_cast<uint64_t>(this->toInt64())
+                : slice.getInt() == this->toInt64())
+            << (slice.isUInt() ? "uint " : "int ") << slice.toJson()
+            << " != " << this->toInt64();
       } else {
         memcpy(_data.shortNumberMeta.data.slice.slice, slice.begin(),
                static_cast<size_t>(length));

--- a/arangod/Aql/AqlValue.h
+++ b/arangod/Aql/AqlValue.h
@@ -485,9 +485,6 @@ struct AqlValue final {
   }
 
  private:
-  /// @brief initializes value from a slice
-  void initFromSlice(arangodb::velocypack::Slice slice);
-
   /// @brief initializes value from a slice, when the length is already known
   void initFromSlice(arangodb::velocypack::Slice slice,
                      arangodb::velocypack::ValueLength length);

--- a/tests/Aql/AqlValueMemoryLayoutTest.cpp
+++ b/tests/Aql/AqlValueMemoryLayoutTest.cpp
@@ -140,7 +140,6 @@ void runChecksForSlice(velocypack::Slice value, std::uint8_t const* expected) {
     EXPECT_EQ(ival != 0, aqlValue.toBoolean());
     EXPECT_EQ(ival, aqlValue.slice().getNumber<std::int64_t>());
     EXPECT_EQ(ival, aqlValue.toInt64());
-    EXPECT_EQ(ival, aqlValue.slice().getNumber<std::int64_t>());
   } else {
     TRI_ASSERT(false) << "Unexpected type " << value.typeName();
   }

--- a/tests/Aql/AqlValueMemoryLayoutTest.cpp
+++ b/tests/Aql/AqlValueMemoryLayoutTest.cpp
@@ -25,9 +25,9 @@
 
 #include "Aql/AqlValue.h"
 #include "Basics/Endian.h"
-#include "VelocypackUtils/VelocyPackStringLiteral.h"
 
 #include <velocypack/Builder.h>
+#include <velocypack/Parser.h>
 #include <velocypack/Slice.h>
 #include <velocypack/SharedSlice.h>
 #include <velocypack/velocypack-aliases.h>
@@ -36,7 +36,6 @@
 
 using namespace arangodb;
 using namespace arangodb::aql;
-using arangodb::velocypack::operator""_vpack;
 
 namespace {
 
@@ -145,6 +144,18 @@ void runChecksForSlice(velocypack::Slice value, std::uint8_t const* expected) {
   } else {
     TRI_ASSERT(false) << "Unexpected type " << value.typeName();
   }
+}
+
+auto vpackFromJsonString(char const* c) -> std::shared_ptr<VPackBuilder> {
+  velocypack::Options options;
+  options.checkAttributeUniqueness = true;
+  velocypack::Parser parser(&options);
+  parser.parse(c);
+  return parser.steal();
+}
+
+auto operator"" _vpack(const char* json, size_t) -> velocypack::SharedSlice {
+  return vpackFromJsonString(json)->sharedSlice();
 }
 
 // note: in all following tests, the value UNINITIALIZED (0xa5) has a special

--- a/tests/Aql/AqlValueMemoryLayoutTest.cpp
+++ b/tests/Aql/AqlValueMemoryLayoutTest.cpp
@@ -25,13 +25,18 @@
 
 #include "Aql/AqlValue.h"
 #include "Basics/Endian.h"
+#include "VelocypackUtils/VelocyPackStringLiteral.h"
 
 #include <velocypack/Builder.h>
 #include <velocypack/Slice.h>
+#include <velocypack/SharedSlice.h>
 #include <velocypack/velocypack-aliases.h>
+
+#include <cstdint>
 
 using namespace arangodb;
 using namespace arangodb::aql;
+using arangodb::velocypack::operator""_vpack;
 
 namespace {
 
@@ -61,24 +66,23 @@ void runChecksForNumber(AqlValue const& value, uint8_t const* expected) {
       if (expected[i] == UNINITIALIZED) {
         continue;
       }
-      EXPECT_EQ(data[i], expected[i]);
+      EXPECT_EQ(data[i], expected[i]) << "i=" << (int)i;
     }
   }
 }
 
+struct alignas(16) AqlValueMemory {
+  AqlValueMemory() {
+    // poison memory with some garbage values
+    memset(&buffer[0], 0x99, sizeof(buffer));
+  }
+  uint8_t buffer[16];
+
+  static_assert(sizeof(buffer) == 16, "invalid size of AqlValueMemory buffer");
+};
+static_assert(sizeof(AqlValueMemory) == 16, "invalid size of AqlValueMemory");
+
 void runChecksForUInt64(uint64_t value, uint8_t const* expected) {
-  struct alignas(16) AqlValueMemory {
-    AqlValueMemory() {
-      // poison memory with some garbage values
-      memset(&buffer[0], 0x99, sizeof(buffer));
-    }
-    uint8_t buffer[16];
-
-    static_assert(sizeof(buffer) == 16,
-                  "invalid size of AqlValueMemory buffer");
-  };
-  static_assert(sizeof(AqlValueMemory) == 16, "invalid size of AqlValueMemory");
-
   // poison some memory with 0x99 values
   AqlValueMemory memory;
   void* p = reinterpret_cast<void*>(&memory);
@@ -102,6 +106,44 @@ void runChecksForUInt64(uint64_t value, uint8_t const* expected) {
     EXPECT_EQ(static_cast<int64_t>(value), aqlValue.toInt64());
     EXPECT_EQ(static_cast<int64_t>(value),
               aqlValue.slice().getNumber<int64_t>());
+  }
+}
+
+void runChecksForSlice(velocypack::Slice value, std::uint8_t const* expected) {
+  // poison some memory with 0x99 values
+  AqlValueMemory memory;
+  void* p = reinterpret_cast<void*>(&memory);
+
+  // initialize aql value from a slice. note: we are using placement new here,
+  // so that the AqlValue uses the poisoned memory region
+  new (p) AqlValue(value);
+  // although we are using placement new here, we don't need to call the
+  // destructor here, as the AqlValue with the payloads we use here won't
+  // do anything in its destructor
+
+  AqlValue& aqlValue = *reinterpret_cast<AqlValue*>(p);
+  runChecksForNumber(aqlValue, expected);
+
+  if (value.isUInt()) {
+    auto uval = value.getUInt();
+
+    EXPECT_EQ(uval != 0, aqlValue.toBoolean());
+    EXPECT_EQ(uval, aqlValue.slice().getNumber<std::uint64_t>());
+
+    if (uval <=
+        static_cast<std::uint64_t>(std::numeric_limits<std::int64_t>().max())) {
+      auto ival = static_cast<std::int64_t>(uval);
+      EXPECT_EQ(ival, aqlValue.toInt64());
+      EXPECT_EQ(ival, aqlValue.slice().getNumber<std::int64_t>());
+    }
+  } else if (value.isInt() || value.isSmallInt()) {
+    auto ival = value.getInt();
+    EXPECT_EQ(ival != 0, aqlValue.toBoolean());
+    EXPECT_EQ(ival, aqlValue.slice().getNumber<std::int64_t>());
+    EXPECT_EQ(ival, aqlValue.toInt64());
+    EXPECT_EQ(ival, aqlValue.slice().getNumber<std::int64_t>());
+  } else {
+    TRI_ASSERT(false) << "Unexpected type " << value.typeName();
   }
 }
 
@@ -830,6 +872,222 @@ TEST(AqlValueMemoryLayoutTest, UnsignedLargerValues64Bit_18446744073709551615) {
       0xff,
   };
   runChecksForUInt64(uint64_t(18446744073709551615ULL), expected);
+}
+
+TEST(AqlValueMemoryLayoutTest, Slice_Unsigned64Bit_36028797018963968) {
+  auto value = "36028797018963968"_vpack;
+  // 00 00 00 00 00 00 80 00
+  uint8_t const expected[] = {
+      AqlValue::AqlValueType::VPACK_INLINE_UINT64,
+      UNINITIALIZED,
+      UNINITIALIZED,
+      UNINITIALIZED,
+      UNINITIALIZED,
+      UNINITIALIZED,
+      UNINITIALIZED,
+      0x2e,
+      0x00,
+      0x00,
+      0x00,
+      0x00,
+      0x00,
+      0x00,
+      0x80,
+      0x00,
+  };
+
+  runChecksForSlice(value.slice(), expected);
+}
+
+TEST(AqlValueMemoryLayoutTest, Slice_Unsigned64Bit_36028797018963969) {
+  auto value = "36028797018963969"_vpack;
+  // 01 00 00 00 00 00 80 00
+  uint8_t const expected[] = {
+      AqlValue::AqlValueType::VPACK_INLINE_UINT64,
+      UNINITIALIZED,
+      UNINITIALIZED,
+      UNINITIALIZED,
+      UNINITIALIZED,
+      UNINITIALIZED,
+      UNINITIALIZED,
+      0x2e,
+      0x01,
+      0x00,
+      0x00,
+      0x00,
+      0x00,
+      0x00,
+      0x80,
+      0x00,
+  };
+  runChecksForSlice(value.slice(), expected);
+}
+
+TEST(AqlValueMemoryLayoutTest, Slice_Unsigned64Bit_72057594037927935) {
+  auto value = "72057594037927935"_vpack;
+  // ff ff ff ff ff ff ff 00
+  uint8_t const expected[] = {
+      AqlValue::AqlValueType::VPACK_INLINE_UINT64,
+      UNINITIALIZED,
+      UNINITIALIZED,
+      UNINITIALIZED,
+      UNINITIALIZED,
+      UNINITIALIZED,
+      UNINITIALIZED,
+      0x2e,
+      0xff,
+      0xff,
+      0xff,
+      0xff,
+      0xff,
+      0xff,
+      0xff,
+      0x00,
+  };
+  runChecksForSlice(value.slice(), expected);
+}
+
+TEST(AqlValueMemoryLayoutTest, Slice_Unsigned64Bit_72057594037927936) {
+  auto value = "72057594037927936"_vpack;
+  // 00 00 00 00 00 00 00 01
+  uint8_t const expected[] = {
+      AqlValue::AqlValueType::VPACK_INLINE_UINT64,
+      UNINITIALIZED,
+      UNINITIALIZED,
+      UNINITIALIZED,
+      UNINITIALIZED,
+      UNINITIALIZED,
+      UNINITIALIZED,
+      0x2f,
+      0x00,
+      0x00,
+      0x00,
+      0x00,
+      0x00,
+      0x00,
+      0x00,
+      0x01,
+  };
+  runChecksForSlice(value.slice(), expected);
+}
+TEST(AqlValueMemoryLayoutTest, Slice_Unsigned64Bit_18446744073709551615) {
+  auto value = "18446744073709551615"_vpack;
+  // ff ff ff ff ff ff ff ff
+  uint8_t const expected[] = {
+      AqlValue::AqlValueType::VPACK_INLINE_UINT64,
+      UNINITIALIZED,
+      UNINITIALIZED,
+      UNINITIALIZED,
+      UNINITIALIZED,
+      UNINITIALIZED,
+      UNINITIALIZED,
+      0x2f,
+      0xff,
+      0xff,
+      0xff,
+      0xff,
+      0xff,
+      0xff,
+      0xff,
+      0xff,
+  };
+  runChecksForSlice(value.slice(), expected);
+}
+
+TEST(AqlValueMemoryLayoutTest, Slice_Signed64Bit_minus_17979145283436031) {
+  auto value = "-17979145283436031"_vpack;
+  // 01 02 04 08 10 20 c0 ff
+  uint8_t const expected[] = {
+      AqlValue::AqlValueType::VPACK_INLINE_INT64,
+      UNINITIALIZED,
+      UNINITIALIZED,
+      UNINITIALIZED,
+      UNINITIALIZED,
+      UNINITIALIZED,
+      UNINITIALIZED,
+      0x26,
+      0x01,
+      0x02,
+      0x04,
+      0x08,
+      0x10,
+      0x20,
+      0xc0,
+      0xff,
+  };
+  runChecksForSlice(value.slice(), expected);
+}
+
+TEST(AqlValueMemoryLayoutTest, Slice_Signed64Bit_minus_36028797018963968) {
+  auto value = "-36028797018963968"_vpack;
+  // 00 00 00 00 00 00 80 ff
+  uint8_t const expected[] = {
+      AqlValue::AqlValueType::VPACK_INLINE_INT64,
+      UNINITIALIZED,
+      UNINITIALIZED,
+      UNINITIALIZED,
+      UNINITIALIZED,
+      UNINITIALIZED,
+      UNINITIALIZED,
+      0x26,
+      0x00,
+      0x00,
+      0x00,
+      0x00,
+      0x00,
+      0x00,
+      0x80,
+      0xff,
+  };
+  runChecksForSlice(value.slice(), expected);
+}
+
+TEST(AqlValueMemoryLayoutTest, Slice_Signed64Bit_minus_36028797018963969) {
+  auto value = "-36028797018963969"_vpack;
+  // ff ff ff ff ff ff 7f ff
+  uint8_t const expected[] = {
+      AqlValue::AqlValueType::VPACK_INLINE_INT64,
+      UNINITIALIZED,
+      UNINITIALIZED,
+      UNINITIALIZED,
+      UNINITIALIZED,
+      UNINITIALIZED,
+      UNINITIALIZED,
+      0x27,
+      0xff,
+      0xff,
+      0xff,
+      0xff,
+      0xff,
+      0xff,
+      0x7f,
+      0xff,
+  };
+  runChecksForSlice(value.slice(), expected);
+}
+
+TEST(AqlValueMemoryLayoutTest, Slice_Signed64Bit_minus_9223372036854775808) {
+  auto value = "-9223372036854775808"_vpack;
+  // 00 00 00 00 00 00 00 80
+  uint8_t const expected[] = {
+      AqlValue::AqlValueType::VPACK_INLINE_INT64,
+      UNINITIALIZED,
+      UNINITIALIZED,
+      UNINITIALIZED,
+      UNINITIALIZED,
+      UNINITIALIZED,
+      UNINITIALIZED,
+      0x27,
+      0x00,
+      0x00,
+      0x00,
+      0x00,
+      0x00,
+      0x00,
+      0x00,
+      0x80,
+  };
+  runChecksForSlice(value.slice(), expected);
 }
 
 }  // namespace

--- a/tests/Aql/SortExecutorTest.cpp
+++ b/tests/Aql/SortExecutorTest.cpp
@@ -45,6 +45,9 @@
 #include "Transaction/Context.h"
 #include "Transaction/Methods.h"
 
+#include "VelocypackUtils/VelocyPackStringLiteral.h"
+#include "Basics/VelocyPackHelper.h"
+
 #include "AqlItemBlockHelper.h"
 #include "search/sort.hpp"
 
@@ -289,4 +292,29 @@ TEST_P(SortExecutorTest, skip_nested_subquery_no_data) {
       .expectedState(ExecutionState::DONE)
       .run();
 }
+
+// Regression test for BTS-1511:
+// https://arangodb.atlassian.net/browse/BTS-1511
+// The query
+//   FOR x IN [-220000000000002, 1, 10] SORT x RETURN x
+// resulted in
+//   [ 1, 10, -220000000000002 ]
+// while
+//   [ -220000000000002, 1, 10 ]
+// would be expected.
+TEST_P(SortExecutorTest, regression_bts_1511) {
+  AqlCall call{};          // unlimited produce
+  ExecutionStats stats{};  // No stats here
+  makeExecutorTestHelper()
+      .addConsumer<SortExecutor>(makeRegisterInfos(), makeExecutorInfos(),
+                                 ExecutionNode::SORT)
+      .setInputSplitType(getSplit())
+      .setInputValueList(R"(-220000000000002)", 1, 10)
+      .expectOutput({0}, {{R"(-220000000000002)"}, {1}, {10}})
+      .setCall(call)
+      .expectSkipped(0)
+      .expectedState(ExecutionState::DONE)
+      .run();
+}
+
 }  // namespace arangodb::tests::aql

--- a/tests/Aql/SortExecutorTest.cpp
+++ b/tests/Aql/SortExecutorTest.cpp
@@ -45,7 +45,6 @@
 #include "Transaction/Context.h"
 #include "Transaction/Methods.h"
 
-#include "VelocypackUtils/VelocyPackStringLiteral.h"
 #include "Basics/VelocyPackHelper.h"
 
 #include "AqlItemBlockHelper.h"


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/19449.

Changes to `lib/` aren't backported, therefore the tests use velocypack::SharedSlice instead of velocypack::String. Also, `VelocyPackStringLiteral.h` doesn't exist yet, so added an ad-hoc implementation of `operator""_vpack`.