### PR TITLE
remove compile option `-fno-stack-protector`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -205,7 +205,7 @@ endif ()
 # enable code coverage
 option(USE_COVERAGE "enable gcov code coverage" OFF)
 if (USE_COVERAGE)
-  add_compile_options(-fno-stack-protector -fprofile-arcs -ftest-coverage)
+  add_compile_options(-fprofile-arcs -ftest-coverage)
   add_link_options(--coverage)
   add_definitions("-DUSE_COVERAGE=1")
 endif ()

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -12,8 +12,6 @@
       "binaryDir": "${sourceDir}/build",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "RelWithDebInfo",
-        "CMAKE_C_FLAGS": "-fno-stack-protector",
-        "CMAKE_CXX_FLAGS": "-fno-stack-protector",
         "CMAKE_EXE_LINKER_FLAGS": "-Wl,--build-id",
         "USE_IPO": "Off",
         "USE_STRICT_OPENSSL_VERSION": "On",


### PR DESCRIPTION
### Scope & Purpose

Removes compile option `-fno-stack-protector`, which is potentially not needed anymore. This can slightly simplify the build process.
Oskar PR: https://github.com/arangodb/oskar/pull/529
Performance test run: https://jenkins.arangodb.biz/view/Performance/job/perf-simple-branch/97/

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -
  - [ ] Backport for 3.9: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 