### PR TITLE
Add --database.max-databases

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,17 @@
 v3.10.10 (XXXX-XX-XX)
 ---------------------
 
+* Added startup option `--database.max-databases` to limit the maximum number
+  of databases that can exist in parallel on a deployment. This option can be
+  used to limit resources used by database objects. If the option is used and
+  there already exist as many databases as configured by this option, any
+  attempt to create an additional database will fail with error 32
+  (`ERROR_RESOURCE_LIMIT`). Additional databases can then only be created if
+  other databases are dropped first.
+  The default value for this option is unlimited, so technically an arbitrary
+  amount of databases can be created (although effectively the number of
+  databases is limited by memory and processing resources).
+
 * Updated ArangoDB Starter to 0.16.0.
 
 * Avoid recursive lock during agency startup.

--- a/arangod/RestServer/DatabaseFeature.cpp
+++ b/arangod/RestServer/DatabaseFeature.cpp
@@ -533,6 +533,15 @@ collections (e.g. test suites).)");
       .setIntroducedIn(30807)
       .setIntroducedIn(30902);
 
+  options
+      ->addOption("--database.max-databases",
+                  "The maximum number of databases that can exist in parallel.",
+                  new options::SizeTParameter(&_maxDatabases))
+      .setLongDescription(R"(If the maximum number of databases is reached, no
+additional databases can be created in the deployment. In order to create additional
+databases, other databases need to be removed first.")")
+      .setIntroducedIn(31120);
+
   // the following option was obsoleted in 3.9
   options->addObsoleteOption(
       "--database.old-system-collections",
@@ -909,6 +918,18 @@ Result DatabaseFeature::createDatabase(CreateDatabaseInfo&& info,
         // name already in use
         return Result(TRI_ERROR_ARANGO_DUPLICATE_NAME,
                       std::string("duplicate database name '") + name + "'");
+      }
+
+      if (ServerState::instance()->isSingleServerOrCoordinator() &&
+          databases->size() >= maxDatabases()) {
+        // intentionally do not validate number of databases on DB servers,
+        // because they only carry out operations that are initiated by
+        // coordinators
+        return {TRI_ERROR_RESOURCE_LIMIT,
+                absl::StrCat(
+                    "unable to create additional database because it would "
+                    "exceed the configured maximum number of databases (",
+                    maxDatabases(), ")")};
       }
     }
 

--- a/arangod/RestServer/DatabaseFeature.cpp
+++ b/arangod/RestServer/DatabaseFeature.cpp
@@ -921,7 +921,7 @@ Result DatabaseFeature::createDatabase(CreateDatabaseInfo&& info,
       }
 
       if (ServerState::instance()->isSingleServerOrCoordinator() &&
-          databases->size() >= maxDatabases()) {
+          theLists->_databases.size() >= maxDatabases()) {
         // intentionally do not validate number of databases on DB servers,
         // because they only carry out operations that are initiated by
         // coordinators

--- a/arangod/RestServer/DatabaseFeature.cpp
+++ b/arangod/RestServer/DatabaseFeature.cpp
@@ -540,7 +540,7 @@ collections (e.g. test suites).)");
       .setLongDescription(R"(If the maximum number of databases is reached, no
 additional databases can be created in the deployment. In order to create additional
 databases, other databases need to be removed first.")")
-      .setIntroducedIn(31120);
+      .setIntroducedIn(31010);
 
   // the following option was obsoleted in 3.9
   options->addObsoleteOption(

--- a/arangod/RestServer/DatabaseFeature.h
+++ b/arangod/RestServer/DatabaseFeature.h
@@ -207,6 +207,8 @@ class DatabaseFeature : public ArangodFeature {
     std::unordered_set<TRI_vocbase_t*> _droppedDatabases;
   };
 
+  size_t maxDatabases() const noexcept { return _maxDatabases; }
+
   static TRI_vocbase_t& getCalculationVocbase();
 
  private:
@@ -257,6 +259,8 @@ class DatabaseFeature : public ArangodFeature {
   // arangodb::basics::DataProtector<64>
   mutable arangodb::basics::DataProtector _databasesProtector;
   mutable arangodb::Mutex _databasesMutex;
+
+  size_t _maxDatabases{SIZE_MAX};
 
   std::atomic<bool> _started;
 

--- a/tests/js/client/server_parameters/max-databases-limit.js
+++ b/tests/js/client/server_parameters/max-databases-limit.js
@@ -1,0 +1,88 @@
+/*jshint globalstrict:false, strict:false */
+/*global assertEqual, assertNotEqual, assertTrue, fail, getOptions*/
+
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2010-2012 triagens GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is triAGENS GmbH, Cologne, Germany
+///
+/// @author Jan Steemann
+/// @author Copyright 2019, triAGENS GmbH, Cologne, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+if (getOptions === true) {
+  return {
+    'database.max-databases': '5',
+  };
+}
+
+const jsunity = require("jsunity");
+const arangodb = require("@arangodb");
+const db = arangodb.db;
+const errors = arangodb.errors;
+
+function MaxDatabasesTestSuite () {
+  return {
+    tearDown: function () {
+      db._databases().filter((d) => d !== '_system').forEach((d) => {
+        db._dropDatabase(d);
+      });
+    },
+
+    testMaxDatabases: function () {
+      const n = "testDatabase";
+
+      // "_system" must be there
+      assertEqual(1, db._databases().length);
+
+      for (let i = 0; i < 10; ++i) {
+        if (db._databases().length < 5) {
+          db._createDatabase(n + i);
+          assertNotEqual(-1, db._databases().indexOf(n + i));
+        } else {
+          try {
+            db._createDatabase(n + i);
+            fail();
+          } catch (err) {
+            assertEqual(errors.ERROR_RESOURCE_LIMIT.code, err.errorNum);
+          }
+          assertEqual(-1, db._databases().indexOf(n + i));
+        }
+      }
+
+      // drop one of the databases, so there should be capacity
+      // for yet another one.
+      db._dropDatabase(n + "2");
+      assertEqual(-1, db._databases().indexOf(n + "2"));
+      
+      db._createDatabase(n + "99");
+      assertNotEqual(-1, db._databases().indexOf(n + "99"));
+
+      try {
+        db._createDatabase(n + "98");
+        fail();
+      } catch (err) {
+        assertEqual(errors.ERROR_RESOURCE_LIMIT.code, err.errorNum);
+      }
+    },
+
+  };
+}
+
+jsunity.run(MaxDatabasesTestSuite);
+
+return jsunity.done();

--- a/tests/js/client/server_parameters/max-databases-unlimited.js
+++ b/tests/js/client/server_parameters/max-databases-unlimited.js
@@ -1,0 +1,62 @@
+/*jshint globalstrict:false, strict:false */
+/*global assertEqual, assertNotEqual, assertTrue, getOptions*/
+
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2010-2012 triagens GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is triAGENS GmbH, Cologne, Germany
+///
+/// @author Jan Steemann
+/// @author Copyright 2019, triAGENS GmbH, Cologne, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+if (getOptions === true) {
+  return {};
+}
+
+const jsunity = require("jsunity");
+const arangodb = require("@arangodb");
+const db = arangodb.db;
+const errors = arangodb.errors;
+
+function MaxDatabasesTestSuite () {
+  return {
+    tearDown: function () {
+      db._databases().filter((d) => d !== '_system').forEach((d) => {
+        db._dropDatabase(d);
+      });
+    },
+
+    testMaxDatabases: function () {
+      const n = "testDatabase";
+
+      // "_system" must be there
+      assertEqual(1, db._databases().length);
+
+      for (let i = 0; i < 10; ++i) {
+        // should just work
+        db._createDatabase(n + i);
+        assertNotEqual(-1, db._databases().indexOf(n + i));
+      }
+    },
+
+  };
+}
+
+jsunity.run(MaxDatabasesTestSuite);
+
+return jsunity.done();


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/19417

* Added startup option `--database.max-databases` to limit the maximum number
  of databases that can exist in parallel on a deployment. This option can be
  used to limit resources used by database objects. If the option is used and
  there already exist as many databases as configured by this option, any
  attempt to create an additional database will fail with error 32
  (`ERROR_RESOURCE_LIMIT`). Additional databases can then only be created if
  other databases are dropped first.
  The default value for this option is unlimited, so technically an arbitrary
  amount of databases can be created (although effectively the number of
  databases is limited by memory and processing resources).

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [x] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.11: https://github.com/arangodb/arangodb/pull/19437
  - [x] Backport for 3.10: this PR
  - [ ] Backport for 3.9: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 