### PR TITLE
optionally allow partitioning of .sst files

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,31 @@
 devel
 -----
 
+* Added experimental startup options for RocksDB .sst file partitioning:
+
+  - `--rocksdb.partition-files-for-documents`
+  - `--rocksdb.partition-files-for-primary-index`
+  - `--rocksdb.partition-files-for-edge-index`
+  - `--rocksdb.partition-files-for-persistent-index`
+
+  Enabling any of these options will make RocksDB's compaction write the 
+  data for different collections/shards/indexes into different .sst files. 
+  Otherwise the document data from different collections/shards/indexes 
+  can be mixed and written into the same .sst files.
+
+  Enabling these options usually has the benefit of making the RocksDB
+  compaction more efficient when a lot of different collections/shards/indexes
+  are written to in parallel.
+  The disavantage of enabling this option is that there can be more .sst
+  files than when the option is turned off, and the disk space used by
+  these .sst files can be higher than if there are fewer .sst files (this
+  is because there is some per-.sst file overhead).
+  In particular on deployments with many collections/shards/indexes this can 
+  lead to a very high number of .sst files, with the potential of outgrowing 
+  the maximum number of file descriptors the ArangoDB process can open. 
+  Thus the option should only be enabled on deployments with a limited number
+  of collections/shards/indexes.
+
 * BTS-1511: AQL: Fixed access of integers in the ranges
   [-36028797018963968, -281474976710657] and
   [281474976710656, 36028797018963968], i.e. those whose representation require

--- a/arangod/RocksDBEngine/RocksDBOptionFeature.cpp
+++ b/arangod/RocksDBEngine/RocksDBOptionFeature.cpp
@@ -1393,7 +1393,24 @@ option to `0`.)");
                       arangodb::options::Flags::OnAgent,
                       arangodb::options::Flags::OnDBServer,
                       arangodb::options::Flags::OnSingle))
-      .setIntroducedIn(31200);
+      .setIntroducedIn(31200)
+      .setLongDescription(R"(Enabling this option will make RocksDB's
+compaction write the document data for different collections/shards
+into different .sst files. Otherwise the document data from different 
+collections/shards can be mixed and written into the same .sst files.
+
+Enabling this option usually has the benefit of making the RocksDB
+compaction more efficient when a lot of different collections/shards
+are written to in parallel.
+The disavantage of enabling this option is that there can be more .sst
+files than when the option is turned off, and the disk space used by
+these .sst files can be higher than if there are fewer .sst files (this
+is because there is some per-.sst file overhead).
+In particular on deployments with many collections/shards
+this can lead to a very high number of .sst files, with the potential
+of outgrowing the maximum number of file descriptors the ArangoDB process 
+can open. Thus the option should only be enabled on deployments with a
+limited number of collections/shards.)");
 
   options
       ->addOption("--rocksdb.partition-files-for-primary-index",
@@ -1408,7 +1425,24 @@ option to `0`.)");
                       arangodb::options::Flags::OnAgent,
                       arangodb::options::Flags::OnDBServer,
                       arangodb::options::Flags::OnSingle))
-      .setIntroducedIn(31200);
+      .setIntroducedIn(31200)
+      .setLongDescription(R"(Enabling this option will make RocksDB's
+compaction write the primary index data for different collections/shards
+into different .sst files. Otherwise the primary index data from different 
+collections/shards can be mixed and written into the same .sst files.
+
+Enabling this option usually has the benefit of making the RocksDB
+compaction more efficient when a lot of different collections/shards
+are written to in parallel.
+The disavantage of enabling this option is that there can be more .sst
+files than when the option is turned off, and the disk space used by
+these .sst files can be higher than if there are fewer .sst files (this
+is because there is some per-.sst file overhead).
+In particular on deployments with many collections/shards
+this can lead to a very high number of .sst files, with the potential
+of outgrowing the maximum number of file descriptors the ArangoDB process 
+can open. Thus the option should only be enabled on deployments with a
+limited number of collections/shards.)");
 
   options
       ->addOption("--rocksdb.partition-files-for-edge-index",
@@ -1422,7 +1456,24 @@ option to `0`.)");
                       arangodb::options::Flags::OnAgent,
                       arangodb::options::Flags::OnDBServer,
                       arangodb::options::Flags::OnSingle))
-      .setIntroducedIn(31200);
+      .setIntroducedIn(31200)
+      .setLongDescription(R"(Enabling this option will make RocksDB's
+compaction write the edge index data for different edge collections/shards
+into different .sst files. Otherwise the edge index data from different 
+edge collections/shards can be mixed and written into the same .sst files.
+
+Enabling this option usually has the benefit of making the RocksDB
+compaction more efficient when a lot of different edge collections/shards
+are written to in parallel.
+The disavantage of enabling this option is that there can be more .sst
+files than when the option is turned off, and the disk space used by
+these .sst files can be higher than if there are fewer .sst files (this
+is because there is some per-.sst file overhead).
+In particular on deployments with many edge collections/shards
+this can lead to a very high number of .sst files, with the potential
+of outgrowing the maximum number of file descriptors the ArangoDB process 
+can open. Thus the option should only be enabled on deployments with a
+limited number of edge collections/shards.)");
 
   options
       ->addOption("--rocksdb.partition-files-for-persistent-index",
@@ -1436,7 +1487,25 @@ option to `0`.)");
                       arangodb::options::Flags::OnAgent,
                       arangodb::options::Flags::OnDBServer,
                       arangodb::options::Flags::OnSingle))
-      .setIntroducedIn(31200);
+      .setIntroducedIn(31200)
+      .setLongDescription(R"(Enabling this option will make RocksDB's
+compaction write the persistent index data for different persistent
+indexes (also indexes from different collections/shards) into different 
+.sst files. Otherwise the persistent index data from different 
+collections/shards/indexes can be mixed and written into the same .sst files.
+
+Enabling this option usually has the benefit of making the RocksDB
+compaction more efficient when a lot of different collections/shards/indexes
+are written to in parallel.
+The disavantage of enabling this option is that there can be more .sst
+files than when the option is turned off, and the disk space used by
+these .sst files can be higher than if there are fewer .sst files (this
+is because there is some per-.sst file overhead).
+In particular on deployments with many collections/shards/indexes
+this can lead to a very high number of .sst files, with the potential
+of outgrowing the maximum number of file descriptors the ArangoDB process 
+can open. Thus the option should only be enabled on deployments with a
+limited number of edge collections/shards/indexes.)");
 
   //////////////////////////////////////////////////////////////////////////////
   /// add column family-specific options now

--- a/arangod/RocksDBEngine/RocksDBOptionFeature.cpp
+++ b/arangod/RocksDBEngine/RocksDBOptionFeature.cpp
@@ -51,6 +51,7 @@
 #include <rocksdb/memory_allocator.h>
 #include <rocksdb/options.h>
 #include <rocksdb/slice_transform.h>
+#include <rocksdb/sst_partitioner.h>
 #include <rocksdb/statistics.h>
 #include <rocksdb/table.h>
 #include <rocksdb/utilities/transaction_db.h>
@@ -314,6 +315,10 @@ RocksDBOptionFeature::RocksDBOptionFeature(Server& server)
       _enableBlobGarbageCollection(true),
       _exclusiveWrites(false),
       _minWriteBufferNumberToMergeTouched(false),
+      _partitionFilesForDocumentsCf(false),
+      _partitionFilesForPrimaryIndexCf(false),
+      _partitionFilesForEdgeIndexCf(false),
+      _partitionFilesForVPackIndexCf(false),
       _maxWriteBufferNumberCf{0, 0, 0, 0, 0, 0, 0} {
   // setting the number of background jobs to
   _maxBackgroundJobs = static_cast<int32_t>(
@@ -1375,6 +1380,64 @@ support (which is the default on Linux).)");
 avoid periodic auto-compaction and the I/O caused by it, you can set this
 option to `0`.)");
 
+  options
+      ->addOption("--rocksdb.partition-files-for-documents",
+                  "If enabled, the document data for different "
+                  "collections/shards will end up in "
+                  "different .sst files.",
+                  new BooleanParameter(&_partitionFilesForDocumentsCf),
+                  arangodb::options::makeFlags(
+                      arangodb::options::Flags::Uncommon,
+                      arangodb::options::Flags::Experimental,
+                      arangodb::options::Flags::DefaultNoComponents,
+                      arangodb::options::Flags::OnAgent,
+                      arangodb::options::Flags::OnDBServer,
+                      arangodb::options::Flags::OnSingle))
+      .setIntroducedIn(31200);
+
+  options
+      ->addOption("--rocksdb.partition-files-for-primary-index",
+                  "If enabled, the primary index data for different "
+                  "collections/shards will end up in "
+                  "different .sst files.",
+                  new BooleanParameter(&_partitionFilesForPrimaryIndexCf),
+                  arangodb::options::makeFlags(
+                      arangodb::options::Flags::Uncommon,
+                      arangodb::options::Flags::Experimental,
+                      arangodb::options::Flags::DefaultNoComponents,
+                      arangodb::options::Flags::OnAgent,
+                      arangodb::options::Flags::OnDBServer,
+                      arangodb::options::Flags::OnSingle))
+      .setIntroducedIn(31200);
+
+  options
+      ->addOption("--rocksdb.partition-files-for-edge-index",
+                  "If enabled, the index data for different edge "
+                  "indexes will end up in different .sst files.",
+                  new BooleanParameter(&_partitionFilesForEdgeIndexCf),
+                  arangodb::options::makeFlags(
+                      arangodb::options::Flags::Uncommon,
+                      arangodb::options::Flags::Experimental,
+                      arangodb::options::Flags::DefaultNoComponents,
+                      arangodb::options::Flags::OnAgent,
+                      arangodb::options::Flags::OnDBServer,
+                      arangodb::options::Flags::OnSingle))
+      .setIntroducedIn(31200);
+
+  options
+      ->addOption("--rocksdb.partition-files-for-persistent-index",
+                  "If enabled, the index data for different persistent "
+                  "indexes will end up in different .sst files.",
+                  new BooleanParameter(&_partitionFilesForVPackIndexCf),
+                  arangodb::options::makeFlags(
+                      arangodb::options::Flags::Uncommon,
+                      arangodb::options::Flags::Experimental,
+                      arangodb::options::Flags::DefaultNoComponents,
+                      arangodb::options::Flags::OnAgent,
+                      arangodb::options::Flags::OnDBServer,
+                      arangodb::options::Flags::OnSingle))
+      .setIntroducedIn(31200);
+
   //////////////////////////////////////////////////////////////////////////////
   /// add column family-specific options now
   //////////////////////////////////////////////////////////////////////////////
@@ -1962,7 +2025,36 @@ rocksdb::ColumnFamilyOptions RocksDBOptionFeature::getColumnFamilyOptions(
       // use whatever block cache we use for blobs as well
       result.blob_cache = getTableOptions().block_cache;
     }
+    if (_partitionFilesForDocumentsCf) {
+      // partition .sst files by object id prefix
+      result.sst_partitioner_factory =
+          rocksdb::NewSstPartitionerFixedPrefixFactory(sizeof(uint64_t));
+    }
 #endif
+  }
+
+  if (family == RocksDBColumnFamilyManager::Family::PrimaryIndex) {
+    // partition .sst files by object id prefix
+    if (_partitionFilesForPrimaryIndexCf) {
+      result.sst_partitioner_factory =
+          rocksdb::NewSstPartitionerFixedPrefixFactory(sizeof(uint64_t));
+    }
+  }
+
+  if (family == RocksDBColumnFamilyManager::Family::EdgeIndex) {
+    // partition .sst files by object id prefix
+    if (_partitionFilesForEdgeIndexCf) {
+      result.sst_partitioner_factory =
+          rocksdb::NewSstPartitionerFixedPrefixFactory(sizeof(uint64_t));
+    }
+  }
+
+  if (family == RocksDBColumnFamilyManager::Family::VPackIndex) {
+    // partition .sst files by object id prefix
+    if (_partitionFilesForVPackIndexCf) {
+      result.sst_partitioner_factory =
+          rocksdb::NewSstPartitionerFixedPrefixFactory(sizeof(uint64_t));
+    }
   }
 
   // override

--- a/arangod/RocksDBEngine/RocksDBOptionFeature.h
+++ b/arangod/RocksDBEngine/RocksDBOptionFeature.h
@@ -168,6 +168,10 @@ class RocksDBOptionFeature final : public ArangodFeature,
   bool _enableBlobGarbageCollection;
   bool _exclusiveWrites;
   bool _minWriteBufferNumberToMergeTouched;
+  bool _partitionFilesForDocumentsCf;
+  bool _partitionFilesForPrimaryIndexCf;
+  bool _partitionFilesForEdgeIndexCf;
+  bool _partitionFilesForVPackIndexCf;
 
   /// per column family write buffer limits
   std::array<uint64_t, RocksDBColumnFamilyManager::numberOfColumnFamilies>


### PR DESCRIPTION
### Scope & Purpose

Optionally allow partitioning of .sst files for different collections/shards and indexes.
This is a potential performance improvement which allows RocksDB compactions to be more efficient.
We don't have performance test results yet, so it is only a _potential_ improvement that we need to try out.

* Added experimental startup options for RocksDB .sst file partitioning:

  - `--rocksdb.partition-files-for-documents`
  - `--rocksdb.partition-files-for-primary-index`
  - `--rocksdb.partition-files-for-edge-index`
  - `--rocksdb.partition-files-for-persistent-index`

  Enabling any of these options will make RocksDB's compaction write the 
  data for different collections/shards/indexes into different .sst files. 
  Otherwise the document data from different collections/shards/indexes 
  can be mixed and written into the same .sst files.

  Enabling these options usually has the benefit of making the RocksDB
  compaction more efficient when a lot of different collections/shards/indexes
  are written to in parallel.
  The disavantage of enabling this option is that there can be more .sst
  files than when the option is turned off, and the disk space used by
  these .sst files can be higher than if there are fewer .sst files (this
  is because there is some per-.sst file overhead).
  In particular on deployments with many collections/shards/indexes this can 
  lead to a very high number of .sst files, with the potential of outgrowing 
  the maximum number of file descriptors the ArangoDB process can open. 
  Thus the option should only be enabled on deployments with a limited number
  of collections/shards/indexes.

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [x] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.11: https://github.com/arangodb/arangodb/pull/19476
  - [ ] Backport for 3.10: -
  - [ ] Backport for 3.9: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 