### PR TITLE
[BTS-1526] Prevent purging WAL files during HotBackup

### DIFF
--- a/arangod/RocksDBEngine/RocksDBEngine.cpp
+++ b/arangod/RocksDBEngine/RocksDBEngine.cpp
@@ -2753,24 +2753,10 @@ void RocksDBEngine::pruneWalFiles() {
   for (auto it = _prunableWalFiles.begin(); it != _prunableWalFiles.end();
        /* no hoisting */) {
     // check if WAL file is expired
-    bool deleteFile = false;
-
-    if ((*it).second <= 0.0) {
-      // file can be deleted because we outgrew the configured max archive size,
-      // but only if there are no other threads currently inside the WAL tailing
-      // section
-      deleteFile = purgeEnabler.canPurge();
-      LOG_TOPIC("817bc", TRACE, Logger::ENGINES)
-          << "pruneWalFiles checking overflowed file '" << (*it).first
-          << "', canPurge: " << deleteFile;
-    } else if ((*it).second < TRI_microtime()) {
-      // file has expired, and it is always safe to delete it
-      deleteFile = true;
-      LOG_TOPIC("e7674", TRACE, Logger::ENGINES)
-          << "pruneWalFiles checking expired file '" << (*it).first
-          << "', canPurge: " << deleteFile;
-    }
-
+    auto deleteFile = purgeEnabler.canPurge();
+    LOG_TOPIC("e7674", TRACE, Logger::ENGINES)
+        << "pruneWalFiles checking expired file '" << (*it).first
+        << "', canPurge: " << deleteFile;
     if (deleteFile) {
       LOG_TOPIC("68e4a", DEBUG, Logger::ENGINES)
           << "deleting RocksDB WAL file '" << (*it).first << "'";

--- a/arangod/RocksDBEngine/RocksDBEngine.cpp
+++ b/arangod/RocksDBEngine/RocksDBEngine.cpp
@@ -2755,7 +2755,7 @@ void RocksDBEngine::pruneWalFiles() {
     // check if WAL file is expired
     auto deleteFile = purgeEnabler.canPurge();
     LOG_TOPIC("e7674", TRACE, Logger::ENGINES)
-        << "pruneWalFiles checking expired file '" << (*it).first
+        << "pruneWalFiles checking file '" << (*it).first
         << "', canPurge: " << deleteFile;
     if (deleteFile) {
       LOG_TOPIC("68e4a", DEBUG, Logger::ENGINES)


### PR DESCRIPTION
### Scope & Purpose

The issue described in BTS-1526 is caused by ArangoDB's DBEngine deleting a file from under RocksDB's snapshot code (as amended by ArangoDB to store all WAL files).

This patch removes some code that eagerly prunes WAL files even if the lock on these files is held. The enterprise companion makes sure that HotBackup takes the lock while a hotbackup is in progress.  

Requires: https://github.com/arangodb/enterprise/pull/1331

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification


