### PR TITLE
fixed potential deadlock() in cache::Manager::unprepareTask()

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 v3.10.10 (XXXX-XX-XX)
 ---------------------
 
+* Fixed potential deadlock() in cache::Manager::unprepareTask() in case a 
+  MigrateTask could not be scheduled successfully (in case of a full scheduler 
+  queue on DB servers).
+
 * Added startup option `--database.max-databases` to limit the maximum number
   of databases that can exist in parallel on a deployment. This option can be
   used to limit resources used by database objects. If the option is used and

--- a/arangod/Cache/Manager.cpp
+++ b/arangod/Cache/Manager.cpp
@@ -539,12 +539,13 @@ void Manager::prepareTask(Manager::TaskEnvironment environment) {
   }
 }
 
-void Manager::unprepareTask(Manager::TaskEnvironment environment) {
+void Manager::unprepareTask(Manager::TaskEnvironment environment,
+                            bool internal) noexcept {
   switch (environment) {
     case TaskEnvironment::rebalancing: {
       TRI_ASSERT(_rebalancingTasks > 0);
       if (--_rebalancingTasks == 0) {
-        SpinLocker guard(SpinLocker::Mode::Write, _lock);
+        SpinLocker guard(SpinLocker::Mode::Write, _lock, !internal);
         _rebalancing = false;
         _rebalanceCompleted = std::chrono::steady_clock::now();
       }
@@ -553,7 +554,7 @@ void Manager::unprepareTask(Manager::TaskEnvironment environment) {
     case TaskEnvironment::resizing: {
       TRI_ASSERT(_resizingTasks > 0);
       if (--_resizingTasks == 0) {
-        SpinLocker guard(SpinLocker::Mode::Write, _lock);
+        SpinLocker guard(SpinLocker::Mode::Write, _lock, !internal);
         _resizing = false;
       }
       break;

--- a/arangod/Cache/Manager.h
+++ b/arangod/Cache/Manager.h
@@ -295,7 +295,7 @@ class Manager {
 
   // coordinate state with task lifecycles
   void prepareTask(TaskEnvironment environment);
-  void unprepareTask(TaskEnvironment environment);
+  void unprepareTask(TaskEnvironment environment, bool internal) noexcept;
 
   // periodically run to rebalance allocations globally
   ErrorCode rebalance(bool onlyCalculate = false);

--- a/tests/Cache/Rebalancer.cpp
+++ b/tests/Cache/Rebalancer.cpp
@@ -30,6 +30,7 @@
 #include <thread>
 #include <vector>
 
+#include "Basics/ScopeGuard.h"
 #include "Basics/voc-errors.h"
 #include "Cache/BinaryKeyHasher.h"
 #include "Cache/Common.h"
@@ -336,3 +337,155 @@ TEST(CacheRebalancerTest,
 
   RandomGenerator::shutdown();
 }
+
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+TEST(
+    CacheRebalancerTest,
+    test_rebalancing_with_transactionalcache_and_dispatch_failures_LongRunning) {
+  RandomGenerator::initialize(RandomGenerator::RandomType::MERSENNE);
+  MockScheduler scheduler(4);
+  auto postFn = [&scheduler](std::function<void()> fn) -> bool {
+    scheduler.post(fn);
+    return true;
+  };
+  MockMetricsServer server;
+  SharedPRNGFeature& sharedPRNG = server.getFeature<SharedPRNGFeature>();
+  Manager manager(sharedPRNG, postFn, 128 * 1024 * 1024, true);
+  Rebalancer rebalancer(&manager);
+
+  std::size_t cacheCount = 4;
+  std::size_t threadCount = 4;
+  std::vector<std::shared_ptr<Cache>> caches;
+  for (std::size_t i = 0; i < cacheCount; i++) {
+    caches.emplace_back(
+        manager.createCache<BinaryKeyHasher>(CacheType::Transactional));
+  }
+
+  std::atomic_bool doneRebalancing = false;
+  auto rebalanceWorker = [&rebalancer, &doneRebalancing]() -> void {
+    while (!doneRebalancing) {
+      auto status = rebalancer.rebalance();
+      if (status != TRI_ERROR_ARANGO_BUSY) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(150));
+      } else {
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+      }
+    }
+  };
+
+  ThreadGuard rebalancerThread(std::make_unique<std::thread>(rebalanceWorker));
+
+  std::uint64_t chunkSize = 4 * 1024 * 1024;
+  std::uint64_t initialInserts = 2 * 1024 * 1024;
+  std::uint64_t operationCount = 8 * 1024 * 1024;
+  std::atomic<std::uint64_t> hitCount(0);
+  std::atomic<std::uint64_t> missCount(0);
+  auto worker = [&manager, &caches, cacheCount, initialInserts, operationCount,
+                 &hitCount,
+                 &missCount](std::uint64_t lower, std::uint64_t upper) -> void {
+    Transaction* tx = manager.beginTransaction(false);
+    // fill with some initial data
+    for (std::uint64_t i = 0; i < initialInserts; i++) {
+      std::uint64_t item = lower + i;
+      std::size_t cacheIndex = item % cacheCount;
+      CachedValue* value = CachedValue::construct(&item, sizeof(std::uint64_t),
+                                                  &item, sizeof(std::uint64_t));
+      TRI_ASSERT(value != nullptr);
+      auto status = caches[cacheIndex]->insert(value);
+      if (status.fail()) {
+        delete value;
+      }
+    }
+
+    // initialize valid range for keys that *might* be in cache
+    std::uint64_t validLower = lower;
+    std::uint64_t validUpper = lower + initialInserts - 1;
+    std::uint64_t banishUpper = validUpper;
+
+    // commence mixed workload
+    for (std::uint64_t i = 0; i < operationCount; i++) {
+      std::uint32_t r =
+          RandomGenerator::interval(static_cast<std::uint32_t>(99UL));
+
+      if (r >= 99) {  // remove something
+        if (validLower == validUpper) {
+          continue;  // removed too much
+        }
+
+        std::uint64_t item = validLower++;
+        std::size_t cacheIndex = item % cacheCount;
+
+        caches[cacheIndex]->remove(&item, sizeof(std::uint64_t));
+      } else if (r >= 90) {  // insert something
+        if (validUpper == upper) {
+          continue;  // already maxed out range
+        }
+
+        std::uint64_t item = ++validUpper;
+        if (validUpper > banishUpper) {
+          banishUpper = validUpper;
+        }
+        std::size_t cacheIndex = item % cacheCount;
+        CachedValue* value = CachedValue::construct(
+            &item, sizeof(std::uint64_t), &item, sizeof(std::uint64_t));
+        TRI_ASSERT(value != nullptr);
+        auto status = caches[cacheIndex]->insert(value);
+        if (status.fail()) {
+          delete value;
+        }
+      } else if (r >= 80) {  // banish something
+        if (banishUpper == upper) {
+          continue;  // already maxed out range
+        }
+
+        std::uint64_t item = ++banishUpper;
+        std::size_t cacheIndex = item % cacheCount;
+        caches[cacheIndex]->banish(&item, sizeof(std::uint64_t));
+      } else {  // lookup something
+        std::uint64_t item = RandomGenerator::interval(
+            static_cast<int64_t>(validLower), static_cast<int64_t>(validUpper));
+        std::size_t cacheIndex = item % cacheCount;
+
+        Finding f = caches[cacheIndex]->find(&item, sizeof(std::uint64_t));
+        if (f.found()) {
+          hitCount++;
+          TRI_ASSERT(f.value() != nullptr);
+          TRI_ASSERT(BinaryKeyHasher::sameKey(f.value()->key(),
+                                              f.value()->keySize(), &item,
+                                              sizeof(std::uint64_t)));
+        } else {
+          missCount++;
+          TRI_ASSERT(f.value() == nullptr);
+        }
+      }
+    }
+    manager.endTransaction(tx);
+  };
+
+  TRI_AddFailurePointDebugging("CacheManagerTasks::dispatchFailures");
+  auto guard = scopeGuard([]() noexcept { TRI_ClearFailurePointsDebugging(); });
+
+  std::vector<ThreadGuard> threads;
+  // dispatch threads
+  for (std::size_t i = 0; i < threadCount; i++) {
+    std::uint64_t lower = i * chunkSize;
+    std::uint64_t upper = ((i + 1) * chunkSize) - 1;
+    threads.emplace_back(std::make_unique<std::thread>(worker, lower, upper));
+  }
+
+  // join threads
+  threads.clear();
+
+  doneRebalancing = true;
+  rebalancerThread.join();
+
+  guard.fire();
+
+  for (auto cache : caches) {
+    manager.destroyCache(std::move(cache));
+  }
+  caches.clear();
+
+  RandomGenerator::shutdown();
+}
+#endif


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/19475

Fixed potential deadlock() in cache::Manager::unprepareTask() in case a MigrateTask could not be scheduled successfully (in case of a full scheduler queue on DB servers).
This issue was found during testing changes that were made in devel. This PR backports also backports a test that can reproduce the problem.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.11: https://github.com/arangodb/arangodb/pull/19475
  - [x] Backport for 3.10: this PR
  - [ ] Backport for 3.9: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 