### PR TITLE
added tests to verify HLC behavior

### DIFF
--- a/lib/Basics/HybridLogicalClock.h
+++ b/lib/Basics/HybridLogicalClock.h
@@ -39,19 +39,13 @@ namespace arangodb::basics {
 
 class HybridLogicalClock {
  public:
-  typedef std::chrono::high_resolution_clock ClockT;
-
- private:
-  ClockT _clock;
-  std::atomic<uint64_t> _lastTimeStamp;
-  uint64_t _offset1970;
-
- public:
   HybridLogicalClock() : _lastTimeStamp(0), _offset1970(computeOffset1970()) {}
   HybridLogicalClock(HybridLogicalClock const& other) = delete;
   HybridLogicalClock(HybridLogicalClock&& other) = delete;
   HybridLogicalClock& operator=(HybridLogicalClock const& other) = delete;
   HybridLogicalClock& operator=(HybridLogicalClock&& other) = delete;
+
+  TEST_VIRTUAL ~HybridLogicalClock() = default;
 
   uint64_t getTimeStamp() {
     uint64_t oldTimeStamp;
@@ -165,8 +159,17 @@ class HybridLogicalClock {
     return r;
   }
 
+  static uint64_t extractTime(uint64_t t) { return t >> 20; }
+
+  static uint64_t extractCount(uint64_t t) { return t & 0xfffffUL; }
+
+  static uint64_t assembleTimeStamp(uint64_t time, uint64_t count) {
+    return (time << 20) + count;
+  }
+
+ protected:
   // helper to get the physical time in milliseconds since the epoch:
-  uint64_t getPhysicalTime() {
+  TEST_VIRTUAL uint64_t getPhysicalTime() {
     auto now = _clock.now();
     uint64_t ms = std::chrono::duration_cast<std::chrono::milliseconds>(
                       now.time_since_epoch())
@@ -178,15 +181,13 @@ class HybridLogicalClock {
   // helper to compute the offset between epoch and 1970
   uint64_t computeOffset1970();
 
-  static uint64_t extractTime(uint64_t t) { return t >> 20; }
-
-  static uint64_t extractCount(uint64_t t) { return t & 0xfffffUL; }
-
-  static uint64_t assembleTimeStamp(uint64_t time, uint64_t count) {
-    return (time << 20) + count;
-  }
-
  private:
+  using ClockT = std::chrono::high_resolution_clock;
+  ClockT _clock;
+
+  std::atomic<uint64_t> _lastTimeStamp;
+  uint64_t _offset1970;
+
   static char encodeTable[65];
 
   static signed char decodeTable[256];

--- a/tests/Basics/HybridLogicalClockTest.cpp
+++ b/tests/Basics/HybridLogicalClockTest.cpp
@@ -178,7 +178,7 @@ TEST(HybridLogicalClockTest, test_extract_time_and_count) {
 
 TEST(HybridLogicalClockTest, test_get_timestamp) {
   // arbitrary timestamp from Sep 30, 2022, that is supposed to
-  // be in the past whenever this test runs
+  // be in the past whenever this test runs.
   constexpr uint64_t dateInThePast = 1664561862434ULL;
 
   basics::HybridLogicalClock hlc;
@@ -196,6 +196,12 @@ TEST(HybridLogicalClockTest, test_get_timestamp) {
 }
 
 TEST(HybridLogicalClockTest, test_values_increase_for_same_physical_time) {
+  // arbitrary timestamp from Sep 30, 2022.
+  // this timestamp is returned as the clock's physical time.
+  // it is intentionally kept constant, so when the clock is
+  // asked for its physical time multiple times, we intentionally
+  // return the same timestamp. we still expect the HLC values
+  // to be ever-increasing.
   ::HybridLogicalClockWithFixedTime hlc(1664561862434ULL);
 
   uint64_t initial = hlc.getTimeStamp();
@@ -211,6 +217,16 @@ TEST(HybridLogicalClockTest, test_values_increase_for_same_physical_time) {
 
 TEST(HybridLogicalClockTest,
      test_values_increase_when_two_clocks_play_ping_pong) {
+  // arbitrary timestamp from Sep 30, 2022.
+  // this timestamp is returned as the clock's physical time.
+  // it is intentionally kept constant, so when the clock is
+  // asked for its physical time multiple times, we intentionally
+  // return the same timestamp. we still expect the HLC values
+  // to be ever-increasing.
+  // here we use two clocks, and we ask one clock for an HLC
+  // value using the HLC value of the other, and vice versa.
+  // the expected behavior is that we never get the same HLC
+  // value ever, and the HLC values are ever-increasing.
   ::HybridLogicalClockWithFixedTime ping(1664561862434ULL);
   ::HybridLogicalClockWithFixedTime pong(1664561862434ULL);
 
@@ -236,6 +252,11 @@ TEST(HybridLogicalClockTest,
 TEST(
     HybridLogicalClockTest,
     test_values_increase_when_two_clocks_play_ping_pong_and_one_clock_is_far_behind) {
+  // arbitrary timestamp values from 2022 and 2021.
+  // these timestamps are returned as the clocks physical times.
+  // one clock is significantly behind the other.
+  // we still expect ever-increasing HLC values to come out of
+  // both, even if one clock is severely behind.
   ::HybridLogicalClockWithFixedTime ping(1664561862434ULL);
   // pong has a lag of more than 1 year...
   ::HybridLogicalClockWithFixedTime pong(1640482451649ULL);
@@ -261,6 +282,14 @@ TEST(
 
 TEST(HybridLogicalClockTest,
      test_values_increase_even_if_physical_time_goes_backwards) {
+  // arbitrary timestamp value from 2022.
+  // these timestamps is returned as the clock's initial physical
+  // time.
+  // the clock is also faked in a way that whenever we ask it for
+  // the physical time again, it returns a timestamp that is more
+  // in the past than the previous one. in other words: this clock
+  // intentionally goes backwards.
+  // we still expect ever-increasing HLC values to come out of it.
   ::HybridLogicalClockWithFixedTime hlc(1664561862434ULL);
 
   uint64_t initial = hlc.getTimeStamp();

--- a/tests/Basics/HybridLogicalClockTest.cpp
+++ b/tests/Basics/HybridLogicalClockTest.cpp
@@ -46,6 +46,11 @@ class HybridLogicalClockWithFixedTime final
  public:
   explicit HybridLogicalClockWithFixedTime(uint64_t t) : _fixed(t) {}
 
+  void goBack() noexcept {
+    // make time go backwards 🚀
+    --_fixed;
+  }
+
  protected:
   uint64_t getPhysicalTime() override {
     // arbitrary timestamp from Sep 30, 2022.
@@ -251,5 +256,22 @@ TEST(
     ASSERT_GT(stamp, initialPing);
     ASSERT_GT(stamp, initialPong);
     initialPong = stamp;
+  }
+}
+
+TEST(HybridLogicalClockTest,
+     test_values_increase_even_if_physical_time_goes_backwards) {
+  ::HybridLogicalClockWithFixedTime hlc(1664561862434ULL);
+
+  uint64_t initial = hlc.getTimeStamp();
+  ASSERT_EQ(1664561862434ULL << 20ULL, initial);
+
+  for (size_t i = 0; i < 10'000'000; ++i) {
+    uint64_t stamp = hlc.getTimeStamp();
+    // stamps must be ever-increasing
+    ASSERT_GT(stamp, initial);
+    initial = stamp;
+
+    hlc.goBack();
   }
 }


### PR DESCRIPTION
### Scope & Purpose

Added tests to verify that HLC values are actually ever-increasing, even with delayed physical clocks.
Test-only PR: intentionally no CHANGELOG entry.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*
  - [ ] Backport for 3.9: *(Please link PR)*

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 