### PR TITLE
add diagnostic information when incosistency is found

### DIFF
--- a/arangod/RocksDBEngine/RocksDBCollection.cpp
+++ b/arangod/RocksDBEngine/RocksDBCollection.cpp
@@ -273,18 +273,26 @@ struct TruncateTimeTracker final : public TimeTracker {
   }
 };
 
-void reportPrimaryIndexInconsistencyIfNotFound(Result const& res,
-                                               std::string_view key,
-                                               LocalDocumentId const& rev) {
-  if (res.is(TRI_ERROR_ARANGO_DOCUMENT_NOT_FOUND)) {
-    // Scandal! A primary index entry is pointing to nowhere! Let's report
-    // this to the authorities immediately:
-    LOG_TOPIC("42536", ERR, arangodb::Logger::ENGINES)
-        << "Found primary index entry for which there is no actual "
-           "document: _key="
-        << key << ", _rev=" << rev.id();
-    TRI_ASSERT(false);
-  }
+void reportPrimaryIndexInconsistencyIfNotFound(
+    Result const& res, LogicalCollection const& collection,
+    std::string_view key, LocalDocumentId const& rev,
+    ReadOwnWrites readOwnWrites, RocksDBTransactionState const* state) {
+  TRI_ASSERT(res.is(TRI_ERROR_ARANGO_DOCUMENT_NOT_FOUND));
+  // Scandal! A primary index entry is pointing to nowhere! Let's report
+  // this to the authorities immediately:
+  LOG_TOPIC("42536", ERR, arangodb::Logger::ENGINES)
+      << "Found primary index entry for which there is no actual "
+         "document: "
+      << res.errorMessage() << ", collection: " << collection.vocbase().name()
+      << "/" << collection.name() << ", type: "
+      << (collection.type() == TRI_COL_TYPE_EDGE ? "edge" : "document")
+      << ", smart: " << (collection.isSmart() ? "yes" : "no")
+      << ", _key=" << key << ", _rev=" << RevisionId(rev).toHLC() << " ("
+      << rev.id() << "), read own writes: "
+      << (readOwnWrites == ReadOwnWrites::yes ? "yes" : "no")
+      << ", state: " << state->debugInfo()
+      << ", hlc: " << TRI_HybridLogicalClock();
+  TRI_ASSERT(false);
 }
 
 size_t getParallelism(velocypack::Slice slice) {
@@ -1043,7 +1051,11 @@ Result RocksDBCollection::read(transaction::Methods* trx, std::string_view key,
     }
   } while (res.is(TRI_ERROR_ARANGO_DOCUMENT_NOT_FOUND) &&
            RocksDBTransactionState::toState(trx)->ensureSnapshot());
-  ::reportPrimaryIndexInconsistencyIfNotFound(res, key, documentId);
+  if (res.is(TRI_ERROR_ARANGO_DOCUMENT_NOT_FOUND)) {
+    ::reportPrimaryIndexInconsistencyIfNotFound(
+        res, _logicalCollection, key, documentId, readOwnWrites,
+        RocksDBTransactionState::toState(trx));
+  }
   return res;
 }
 
@@ -1405,11 +1417,27 @@ Result RocksDBCollection::insertDocument(transaction::Methods* trx,
     return res.reset(TRI_ERROR_DEBUG);
   }
 
-  rocksdb::Status s = mthds->PutUntracked(
-      RocksDBColumnFamilyManager::get(
-          RocksDBColumnFamilyManager::Family::Documents),
-      key.ref(),
-      rocksdb::Slice(doc.startAs<char>(), static_cast<size_t>(doc.byteSize())));
+  rocksdb::Status s;
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+  // use Put() instead of PutUntracked()
+  if (options.isRestore) {
+    s = mthds->Put(RocksDBColumnFamilyManager::get(
+                       RocksDBColumnFamilyManager::Family::Documents),
+                   key.ref(),
+                   rocksdb::Slice(doc.startAs<char>(),
+                                  static_cast<size_t>(doc.byteSize())),
+                   /*assume_tracked*/ false);
+  } else
+#endif
+  {
+    s = mthds->PutUntracked(
+        RocksDBColumnFamilyManager::get(
+            RocksDBColumnFamilyManager::Family::Documents),
+        key.ref(),
+        rocksdb::Slice(doc.startAs<char>(),
+                       static_cast<size_t>(doc.byteSize())));
+  }
+
   if (!s.ok()) {
     res.reset(rocksutils::convertStatus(s, rocksutils::document));
     res.withError([&doc](result::Error& err) {
@@ -1505,6 +1533,27 @@ Result RocksDBCollection::removeDocument(transaction::Methods* trx,
   TRI_IF_FAILURE("RocksDBCollection::removeFail1Always") {
     return res.reset(TRI_ERROR_DEBUG);
   }
+
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+  if (options.isRestore) {
+    // lock the underlying RocksDB key and validate that it exists
+    rocksdb::PinnableSlice ps;
+    rocksdb::Status s =
+        mthds->GetForUpdate(RocksDBColumnFamilyManager::get(
+                                RocksDBColumnFamilyManager::Family::Documents),
+                            key->string(), &ps);
+    if (s.IsNotFound()) {
+      res.reset(rocksutils::convertStatus(s, rocksutils::document));
+      res.withError([&doc](result::Error& err) {
+        TRI_ASSERT(doc.get(StaticStrings::KeyString).isString());
+        err.appendErrorMessage("; key: ");
+        err.appendErrorMessage(doc.get(StaticStrings::KeyString).copyString());
+      });
+      TRI_ASSERT(false) << "remove: " << res.errorMessage()
+                        << ", options: " << options;
+    }
+  }
+#endif
 
   rocksdb::Status s =
       mthds->SingleDelete(RocksDBColumnFamilyManager::get(
@@ -1633,6 +1682,32 @@ Result RocksDBCollection::modifyDocument(
     return res.reset(TRI_ERROR_DEBUG);
   }
 
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+  if (options.isRestore) {
+    // lock the underlying RocksDB key and validate that it exists
+    rocksdb::PinnableSlice ps;
+    rocksdb::Status s =
+        mthds->GetForUpdate(RocksDBColumnFamilyManager::get(
+                                RocksDBColumnFamilyManager::Family::Documents),
+                            key->string(), &ps);
+    if (s.IsNotFound()) {
+      res.reset(rocksutils::convertStatus(s, rocksutils::document));
+      res.withError([&oldDoc, &newDoc](result::Error& err) {
+        TRI_ASSERT(oldDoc.get(StaticStrings::KeyString).isString());
+        TRI_ASSERT(newDoc.get(StaticStrings::KeyString).isString());
+        err.appendErrorMessage("; old key: ");
+        err.appendErrorMessage(
+            oldDoc.get(StaticStrings::KeyString).copyString());
+        err.appendErrorMessage("; new key: ");
+        err.appendErrorMessage(
+            newDoc.get(StaticStrings::KeyString).copyString());
+      });
+      TRI_ASSERT(false) << "modify: " << res.errorMessage()
+                        << ", options: " << options;
+    }
+  }
+#endif
+
   rocksdb::Status s =
       mthds->SingleDelete(RocksDBColumnFamilyManager::get(
                               RocksDBColumnFamilyManager::Family::Documents),
@@ -1663,12 +1738,27 @@ Result RocksDBCollection::modifyDocument(
 
   key->constructDocument(objectId(), newDocumentId);
   TRI_ASSERT(key->containsLocalDocumentId(newDocumentId));
-  s = mthds->PutUntracked(
-      RocksDBColumnFamilyManager::get(
-          RocksDBColumnFamilyManager::Family::Documents),
-      key.ref(),
-      rocksdb::Slice(newDoc.startAs<char>(),
-                     static_cast<size_t>(newDoc.byteSize())));
+
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+  if (options.isRestore) {
+    // use Put() instead of PutUntracked()
+    s = mthds->Put(RocksDBColumnFamilyManager::get(
+                       RocksDBColumnFamilyManager::Family::Documents),
+                   key.ref(),
+                   rocksdb::Slice(newDoc.startAs<char>(),
+                                  static_cast<size_t>(newDoc.byteSize())),
+                   /*assume_tracked*/ false);
+  } else
+#endif
+  {
+    s = mthds->PutUntracked(
+        RocksDBColumnFamilyManager::get(
+            RocksDBColumnFamilyManager::Family::Documents),
+        key.ref(),
+        rocksdb::Slice(newDoc.startAs<char>(),
+                       static_cast<size_t>(newDoc.byteSize())));
+  }
+
   if (!s.ok()) {
     return res.reset(rocksutils::convertStatus(s, rocksutils::document));
   }

--- a/arangod/RocksDBEngine/RocksDBKey.cpp
+++ b/arangod/RocksDBEngine/RocksDBKey.cpp
@@ -29,6 +29,8 @@
 #include "RocksDBEngine/RocksDBFormat.h"
 #include "RocksDBEngine/RocksDBTypes.h"
 
+#include <iostream>
+
 using namespace arangodb;
 using namespace arangodb::rocksutils;
 

--- a/arangod/RocksDBEngine/RocksDBKey.h
+++ b/arangod/RocksDBEngine/RocksDBKey.h
@@ -31,6 +31,7 @@
 #include "VocBase/voc-types.h"
 #include "Zkd/ZkdHelper.h"
 
+#include <iosfwd>
 #include <string>
 #include <string_view>
 

--- a/arangod/RocksDBEngine/RocksDBTransactionState.cpp
+++ b/arangod/RocksDBEngine/RocksDBTransactionState.cpp
@@ -330,6 +330,11 @@ bool RocksDBTransactionState::isOnlyExclusiveTransaction() const noexcept {
   });
 }
 
+std::string RocksDBTransactionState::debugInfo() const {
+  // can be overriden by derived classes
+  return "n/a";
+}
+
 bool RocksDBTransactionState::hasFailedOperations() const noexcept {
   return (_status == transaction::Status::ABORTED) && hasOperations();
 }

--- a/arangod/RocksDBEngine/RocksDBTransactionState.h
+++ b/arangod/RocksDBEngine/RocksDBTransactionState.h
@@ -131,6 +131,9 @@ class RocksDBTransactionState : public TransactionState {
   /// @brief whether or not a transaction only has exclusive or read accesses
   bool isOnlyExclusiveTransaction() const noexcept;
 
+  /// @brief provide debug info for transaction state
+  virtual std::string debugInfo() const;
+
   [[nodiscard]] virtual rocksdb::SequenceNumber beginSeq() const = 0;
 
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE

--- a/arangod/RocksDBEngine/SimpleRocksDBTransactionState.h
+++ b/arangod/RocksDBEngine/SimpleRocksDBTransactionState.h
@@ -77,6 +77,9 @@ class SimpleRocksDBTransactionState final : public RocksDBTransactionState,
   [[nodiscard]] futures::Future<Result> performIntermediateCommitIfRequired(
       DataSourceId collectionId) override;
 
+  /// @brief provide debug info for transaction state
+  std::string debugInfo() const override;
+
  protected:
   // IRocksDBTransactionCallback methods
   rocksdb::SequenceNumber prepare() override;

--- a/arangod/StorageEngine/TransactionState.h
+++ b/arangod/StorageEngine/TransactionState.h
@@ -143,13 +143,15 @@ class TransactionState : public std::enable_shared_from_this<TransactionState> {
     }
   }
 
-  [[nodiscard]] bool waitForSync() const { return _options.waitForSync; }
-  void waitForSync(bool value) { _options.waitForSync = value; }
+  [[nodiscard]] bool waitForSync() const noexcept {
+    return _options.waitForSync;
+  }
+  void waitForSync(bool value) noexcept { _options.waitForSync = value; }
 
-  [[nodiscard]] bool allowImplicitCollectionsForRead() const {
+  [[nodiscard]] bool allowImplicitCollectionsForRead() const noexcept {
     return _options.allowImplicitCollectionsForRead;
   }
-  void allowImplicitCollectionsForRead(bool value) {
+  void allowImplicitCollectionsForRead(bool value) noexcept {
     _options.allowImplicitCollectionsForRead = value;
   }
 
@@ -223,14 +225,14 @@ class TransactionState : public std::enable_shared_from_this<TransactionState> {
   [[nodiscard]] virtual bool ensureSnapshot() = 0;
 
   /// @brief begin a transaction
-  virtual arangodb::Result beginTransaction(transaction::Hints hints) = 0;
+  virtual Result beginTransaction(transaction::Hints hints) = 0;
 
   /// @brief commit a transaction
-  virtual futures::Future<arangodb::Result> commitTransaction(
+  virtual futures::Future<Result> commitTransaction(
       transaction::Methods* trx) = 0;
 
   /// @brief abort a transaction
-  virtual arangodb::Result abortTransaction(transaction::Methods* trx) = 0;
+  virtual Result abortTransaction(transaction::Methods* trx) = 0;
 
   virtual Result triggerIntermediateCommit() = 0;
 

--- a/arangod/Transaction/Hints.cpp
+++ b/arangod/Transaction/Hints.cpp
@@ -1,0 +1,86 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2023 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Jan Steemann
+////////////////////////////////////////////////////////////////////////////////
+
+#include "Transaction/Hints.h"
+
+#include <iostream>
+#include <string>
+
+namespace arangodb::transaction {
+
+std::string Hints::toString() const {
+  std::string result;
+
+  auto append = [&result](std::string_view value) {
+    if (!result.empty()) {
+      result.append(", ");
+    }
+    result.append(value);
+  };
+
+  if (has(Hint::SINGLE_OPERATION)) {
+    append("single operation");
+  }
+  if (has(Hint::LOCK_NEVER)) {
+    append("lock never");
+  }
+  if (has(Hint::NO_DLD)) {
+    append("no dld");
+  }
+  if (has(Hint::NO_INDEXING)) {
+    append("no indexing");
+  }
+  if (has(Hint::INTERMEDIATE_COMMITS)) {
+    append("intermediate commits");
+  }
+  if (has(Hint::ALLOW_RANGE_DELETE)) {
+    append("allow range delete");
+  }
+  if (has(Hint::FROM_TOPLEVEL_AQL)) {
+    append("from toplevel aql");
+  }
+  if (has(Hint::GLOBAL_MANAGED)) {
+    append("global managed");
+  }
+  if (has(Hint::INDEX_CREATION)) {
+    append("index creation");
+  }
+  if (has(Hint::IS_FOLLOWER_TRX)) {
+    append("is follower trx");
+  }
+  if (has(Hint::ALLOW_FAST_LOCK_ROUND_CLUSTER)) {
+    append("allow fast lock round cluster");
+  }
+  if (result.empty()) {
+    append("none");
+  }
+
+  return result;
+}
+
+std::ostream& operator<<(std::ostream& stream, Hints const& hints) {
+  stream << hints.toString();
+  return stream;
+}
+
+}  // namespace arangodb::transaction

--- a/arangod/Transaction/Hints.h
+++ b/arangod/Transaction/Hints.h
@@ -24,12 +24,14 @@
 #pragma once
 
 #include <cstdint>
+#include <iosfwd>
+#include <string>
 
 namespace arangodb::transaction {
 
 class Hints {
  public:
-  typedef std::uint32_t ValueType;
+  using ValueType = std::uint32_t;
 
   /// @brief individual hint flags that can be used for transactions
   enum class Hint : ValueType {
@@ -52,30 +54,32 @@ class Hints {
                // DBServers), and if that fails revert to slow-lock path
   };
 
-  Hints() : _value(0) {}
-  explicit Hints(Hint value) : _value(static_cast<ValueType>(value)) {}
-  explicit Hints(ValueType value) : _value(value) {}
+  Hints() noexcept : _value(0) {}
+  explicit Hints(Hint value) noexcept : _value(static_cast<ValueType>(value)) {}
+  explicit Hints(ValueType value) noexcept : _value(value) {}
 
-  inline bool has(ValueType value) const noexcept {
-    return (_value & value) != 0;
-  }
+  bool has(ValueType value) const noexcept { return (_value & value) != 0; }
 
-  inline bool has(Hint value) const noexcept {
+  bool has(Hint value) const noexcept {
     return has(static_cast<ValueType>(value));
   }
 
-  inline void set(ValueType value) { _value |= value; }
+  void set(ValueType value) noexcept { _value |= value; }
 
-  inline void set(Hint value) { set(static_cast<ValueType>(value)); }
+  void set(Hint value) noexcept { set(static_cast<ValueType>(value)); }
 
-  inline void unset(ValueType value) { _value &= ~value; }
+  void unset(ValueType value) noexcept { _value &= ~value; }
 
-  inline void unset(Hint value) { unset(static_cast<ValueType>(value)); }
+  void unset(Hint value) noexcept { unset(static_cast<ValueType>(value)); }
 
-  inline ValueType toInt() const { return static_cast<ValueType>(_value); }
+  ValueType toInt() const noexcept { return static_cast<ValueType>(_value); }
+
+  std::string toString() const;
 
  private:
   ValueType _value;
 };
+
+std::ostream& operator<<(std::ostream&, Hints const&);
 
 }  // namespace arangodb::transaction

--- a/arangod/arangoserver.cmake
+++ b/arangod/arangoserver.cmake
@@ -172,6 +172,7 @@ add_library(arangoserver STATIC
   Transaction/Context.cpp
   Transaction/CountCache.cpp
   Transaction/Helpers.cpp
+  Transaction/Hints.cpp
   Transaction/IndexesSnapshot.cpp
   Transaction/Manager.cpp
   Transaction/ManagedContext.cpp

--- a/tests/js/server/shell/shell-transactions.js
+++ b/tests/js/server/shell/shell-transactions.js
@@ -272,7 +272,7 @@ function transactionRevisionsSuite () {
     },
 
     testUpdateWithSameRev: function () {
-      if (isCluster()) {
+      if (isCluster) {
         // running this test in cluster will trigger an assertion failure
         return;
       }
@@ -284,7 +284,7 @@ function transactionRevisionsSuite () {
     },
 
     testUpdateWithSameRevTransaction: function () {
-      if (isCluster()) {
+      if (isCluster) {
         // running this test in cluster will trigger an assertion failure
         return;
       }

--- a/tests/js/server/shell/shell-transactions.js
+++ b/tests/js/server/shell/shell-transactions.js
@@ -272,6 +272,10 @@ function transactionRevisionsSuite () {
     },
 
     testUpdateWithSameRev: function () {
+      if (isCluster()) {
+        // running this test in cluster will trigger an assertion failure
+        return;
+      }
       var doc = c.insert({ _key: 'test', value: 1 });
       c.update('test', { _key: 'test', _rev: doc._rev, value: 2 }, { isRestore: true });
 
@@ -280,6 +284,10 @@ function transactionRevisionsSuite () {
     },
 
     testUpdateWithSameRevTransaction: function () {
+      if (isCluster()) {
+        // running this test in cluster will trigger an assertion failure
+        return;
+      }
       var doc = c.insert({ _key: 'test', value: 1 });
       db._executeTransaction({
         collections: { write: c.name() },


### PR DESCRIPTION
### Scope & Purpose

Add diagnostic information when incosistency is found between primary index and documents cf. Also validate document existence and lock document keys properly when isRestore=true and we are in maintainer mode.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -
  - [ ] Backport for 3.9: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 