### PR TITLE
expose high water multiplier

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,22 @@
 devel
 -----
 
+* Expose the "high water multiplier" for the in-memory cache subsystem via a
+  new startup option `--cache.high-water-multiplier`.
+  The high water multiplier is used to calculate the effective memory usage 
+  limit for the in-memory cache subsystem. The cache's configured memory usage 
+  limit (`--cache.size`) is multiplied by the high water multiplier, and the 
+  resulting value is used as the effective memory limit. It defaults to 95%
+  of the configured cache size.
+
+  Note that this is a behavior change. Previous versions of ArangoDB set the
+  high water multiplier to effectively 56% of the configured memory. The value
+  was hard-coded in versions before 3.11.3, and is exposed since then with a
+  default value of 56%. 
+  3.12 now sets the default value for the high water multiplier to 95%, so that
+  the configured memory limit for the cache subsystem is actually better
+  honored than before.
+
 * Changed default values for the following options related to the in-memory
   cache subsystem:
 

--- a/arangod/Cache/CacheOptionsFeature.cpp
+++ b/arangod/Cache/CacheOptionsFeature.cpp
@@ -150,6 +150,24 @@ speed.)")
 
   options
       ->addOption(
+          "--cache.high-water-multiplier",
+          "The multiplier to be used for calculating the in-memory cache's "
+          "effective memory usage limit.",
+          new DoubleParameter(&_options.highwaterMultiplier, 1.0, 0.1, 1.0),
+          arangodb::options::makeFlags(
+              arangodb::options::Flags::Uncommon,
+              arangodb::options::Flags::DefaultNoComponents,
+              arangodb::options::Flags::OnDBServer,
+              arangodb::options::Flags::OnSingle))
+      .setLongDescription(
+          R"(This value controls the cache's effective memory usage limit.
+The user-defined memory limit (i.e. `--cache.size`) is multipled with this
+value to create the effective memory limit, from which on the cache will 
+try to free up memory by evicting the oldest entries.)")
+      .setIntroducedIn(31200);
+
+  options
+      ->addOption(
           "--cache.max-spare-memory-usage",
           "The maximum memory usage for spare tables in the in-memory cache.",
           new UInt64Parameter(&_options.maxSpareAllocation),

--- a/arangod/Cache/CacheOptionsProvider.h
+++ b/arangod/Cache/CacheOptionsProvider.h
@@ -45,6 +45,13 @@ struct CacheOptions {
   std::uint64_t rebalancingInterval = 2'000'000ULL;  // 2s
   // maximum memory usage for spare hash tables kept around by the cache.
   std::uint64_t maxSpareAllocation = 67'108'864ULL;  // 64MB
+  // used internally and by tasks. this multiplier is used with the
+  // cache's memory limit, and if exceeded, triggers a shrinking of the
+  // least frequently accessed kCachesToShrinkRatio caches.
+  // it is set to 56% of the configured memory limit by default only because
+  // of compatibility reasons. the value was set to 0.7 * 0.8 of the memory
+  // limit, i.e. 0.56.
+  double highwaterMultiplier = 0.95;
   // whether or not we want recent hit rates. if this is turned off,
   // we only get global hit rates over the entire lifetime of a cache
   bool enableWindowedStats = true;

--- a/arangod/Cache/Manager.h
+++ b/arangod/Cache/Manager.h
@@ -296,10 +296,6 @@ class Manager {
   void reportHit() noexcept;
   void reportMiss() noexcept;
 
-  // used internally and by tasks. this multiplier is used with the
-  // cache's memory limit, and if exceeded, triggers a shrinking of the
-  // least frequently accessed kCachesToShrinkRatio caches
-  static constexpr double kHighwaterMultiplier = 0.95;
   // ratio of caches for which a shrinking attempt will be made if we
   // reach the cache's high water mark (memory limit plus safety buffer)
   static constexpr double kCachesToShrinkRatio = 0.20;


### PR DESCRIPTION
### Scope & Purpose

* Expose the "high water multiplier" for the in-memory cache subsystem via a new startup option `--cache.high-water-multiplier`. The high water multiplier is used to calculate the effective memory usage limit for the in-memory cache subsystem. The cache's configured memory usage limit (`--cache.size`) is multiplied by the high water multiplier, and the resulting value is used as the effective memory limit. It defaults to 95% of the configured cache size.

  Note that this is a behavior change. Previous versions of ArangoDB set the high water multiplier to effectively 56% of the configured memory. The value was hard-coded in versions before 3.11.3, and is exposed since then with a default value of 56%. 3.12 now sets the default value for the high water multiplier to 95%, so that the configured memory limit for the cache subsystem is actually better honored than before.

The high water multiplier will be added to 3.11.3 via https://github.com/arangodb/arangodb/pull/19488.

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.11: https://github.com/arangodb/arangodb/pull/19488
  - [ ] Backport for 3.10: -
  - [ ] Backport for 3.9: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 