### PR TITLE
Wrap imports into SmartGraph edge collection into managed trx

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 devel
 -----
 
+* Wrap imports into SmartGraph edge collections via the REST import API
+  (POST `/_api/import`) into a managed transaction, so that edge data is
+  either completely inserted or not at all.
+
 * Changed default values for the following options related to the in-memory
   cache subsystem:
 

--- a/arangod/RestHandler/RestDocumentHandler.cpp
+++ b/arangod/RestHandler/RestDocumentHandler.cpp
@@ -296,8 +296,7 @@ RestStatus RestDocumentHandler::insertDocument() {
                   }
 
                   generateSaved(
-                      opres, cname,
-                      TRI_col_type_e(_activeTrx->getCollectionType(cname)),
+                      opres, cname, _activeTrx->getCollectionType(cname),
                       _activeTrx->transactionContextPtr()->getVPackOptions(),
                       isMultiple);
                 });
@@ -675,8 +674,7 @@ RestStatus RestDocumentHandler::modifyDocument(bool isPatch) {
               }
 
               generateSaved(
-                  opRes, cname,
-                  TRI_col_type_e(_activeTrx->getCollectionType(cname)),
+                  opRes, cname, _activeTrx->getCollectionType(cname),
                   _activeTrx->transactionContextPtr()->getVPackOptions(),
                   isArrayCase);
             });
@@ -825,8 +823,7 @@ RestStatus RestDocumentHandler::removeDocument() {
                   }
 
                   generateDeleted(
-                      opRes, cname,
-                      TRI_col_type_e(_activeTrx->getCollectionType(cname)),
+                      opRes, cname, _activeTrx->getCollectionType(cname),
                       _activeTrx->transactionContextPtr()->getVPackOptions(),
                       isMultiple);
                 });

--- a/arangod/Transaction/Methods.cpp
+++ b/arangod/Transaction/Methods.cpp
@@ -2001,14 +2001,8 @@ DataSourceId transaction::Methods::addCollectionAtRuntime(
 }
 
 /// @brief return the type of a collection
-bool transaction::Methods::isEdgeCollection(
-    std::string const& collectionName) const {
-  return getCollectionType(collectionName) == TRI_COL_TYPE_EDGE;
-}
-
-/// @brief return the type of a collection
 TRI_col_type_e transaction::Methods::getCollectionType(
-    std::string const& collectionName) const {
+    std::string_view collectionName) const {
   auto collection = resolver()->getCollection(collectionName);
 
   return collection ? collection->type() : TRI_COL_TYPE_UNKNOWN;

--- a/arangod/Transaction/Methods.h
+++ b/arangod/Transaction/Methods.h
@@ -257,8 +257,7 @@ class Methods {
                                               AccessMode::Type type);
 
   /// @brief return the type of a collection
-  bool isEdgeCollection(std::string const& collectionName) const;
-  TRI_col_type_e getCollectionType(std::string const& collectionName) const;
+  TRI_col_type_e getCollectionType(std::string_view collectionName) const;
 
   /// @brief return one  document from a collection, fast path
   ///        If everything went well the result will contain the found document


### PR DESCRIPTION
### Scope & Purpose

* Wrap imports into SmartGraph edge collections via the REST import API (POST `/_api/import`) into a managed transaction, so that edge data is either completely inserted or not at all.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -
  - [ ] Backport for 3.9: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 