### PR TITLE
prevent potential nullptr deref

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 v3.10.10 (XXXX-XX-XX)
 ---------------------
 
+* ES-1566: instead of potentially accessing a nullptr inside graph traversal
+  setup, throw an exception. This will be handled properly and returned with
+  a proper error message.
+
 * BTS-1511: AQL: Fixed access of integers in the ranges
   [-36028797018963968, -281474976710657] and
   [281474976710656, 36028797018963968], i.e. those whose representation require

--- a/arangod/Aql/Collections.cpp
+++ b/arangod/Aql/Collections.cpp
@@ -80,6 +80,7 @@ Collection* Collections::add(std::string const& name,
     }
   }
 
+  TRI_ASSERT((*it).second != nullptr);
   return (*it).second.get();
 }
 

--- a/arangod/Aql/GraphNode.cpp
+++ b/arangod/Aql/GraphNode.cpp
@@ -576,7 +576,7 @@ void GraphNode::setGraphInfoAndCopyColls(
       if (it == nullptr) {
         THROW_ARANGO_EXCEPTION_MESSAGE(
             TRI_ERROR_BAD_PARAMETER,
-            "access to non-existing collection in AQL graph traversal");
+            "access to non-existing edge collection in AQL graph traversal");
       }
       _edgeColls.emplace_back(it);
       _graphInfo.add(VPackValue(it->name()));
@@ -588,14 +588,18 @@ void GraphNode::setGraphInfoAndCopyColls(
       if (it == nullptr) {
         THROW_ARANGO_EXCEPTION_MESSAGE(
             TRI_ERROR_BAD_PARAMETER,
-            "access to non-existing collection in AQL graph traversal");
+            "access to non-existing edge collection in AQL graph traversal");
       }
       _edgeColls.emplace_back(it);
     }
   }
 
   for (auto& it : vertexColls) {
-    TRI_ASSERT(it != nullptr);
+    if (it == nullptr) {
+      THROW_ARANGO_EXCEPTION_MESSAGE(
+          TRI_ERROR_BAD_PARAMETER,
+          "access to non-existing vertex collection in AQL graph traversal");
+    }
     addVertexCollection(*it);
   }
 }

--- a/arangod/Aql/GraphNode.cpp
+++ b/arangod/Aql/GraphNode.cpp
@@ -36,6 +36,7 @@
 #include "Aql/SortCondition.h"
 #include "Aql/TraversalExecutor.h"
 #include "Aql/Variable.h"
+#include "Basics/Exceptions.h"
 #include "Basics/tryEmplaceHelper.h"
 #include "Cluster/ClusterFeature.h"
 #include "Cluster/ServerState.h"
@@ -572,7 +573,11 @@ void GraphNode::setGraphInfoAndCopyColls(
   if (_graphObj == nullptr) {
     _graphInfo.openArray();
     for (auto& it : edgeColls) {
-      TRI_ASSERT(it != nullptr);
+      if (it == nullptr) {
+        THROW_ARANGO_EXCEPTION_MESSAGE(
+            TRI_ERROR_BAD_PARAMETER,
+            "access to non-existing collection in AQL graph traversal");
+      }
       _edgeColls.emplace_back(it);
       _graphInfo.add(VPackValue(it->name()));
     }
@@ -580,7 +585,11 @@ void GraphNode::setGraphInfoAndCopyColls(
   } else {
     _graphInfo.add(VPackValue(_graphObj->name()));
     for (auto& it : edgeColls) {
-      TRI_ASSERT(it != nullptr);
+      if (it == nullptr) {
+        THROW_ARANGO_EXCEPTION_MESSAGE(
+            TRI_ERROR_BAD_PARAMETER,
+            "access to non-existing collection in AQL graph traversal");
+      }
       _edgeColls.emplace_back(it);
     }
   }
@@ -825,8 +834,19 @@ void GraphNode::getConditionVariables(std::vector<Variable const*>& res) const {
 
 Collection const* GraphNode::getShardingPrototype() const {
   TRI_ASSERT(ServerState::instance()->isCoordinator());
+  if (_edgeColls.empty()) {
+    THROW_ARANGO_EXCEPTION_MESSAGE(
+        TRI_ERROR_BAD_PARAMETER,
+        "AQL graph traversal without edge collections");
+  }
+
   TRI_ASSERT(!_edgeColls.empty());
   for (auto const* c : _edgeColls) {
+    if (c == nullptr) {
+      THROW_ARANGO_EXCEPTION_MESSAGE(
+          TRI_ERROR_BAD_PARAMETER,
+          "access to non-existing collection in AQL graph traversal");
+    }
     // We are required to valuate non-satellites above
     // satellites, as the collection is used as the prototype
     // for this graphs sharding.

--- a/tests/js/server/aql/aql-traversal-restrict-collections.js
+++ b/tests/js/server/aql/aql-traversal-restrict-collections.js
@@ -2,10 +2,6 @@
 /*global assertEqual, assertTrue, fail */
 
 ////////////////////////////////////////////////////////////////////////////////
-/// @brief tests for regression returning blocks to the manager
-///
-/// @file
-///
 /// DISCLAIMER
 ///
 /// Copyright 2010-2014 triagens GmbH, Cologne, Germany

--- a/tests/js/server/aql/aql-traversal-restrict-edge-collections.js
+++ b/tests/js/server/aql/aql-traversal-restrict-edge-collections.js
@@ -2,10 +2,6 @@
 /*global AQL_EXPLAIN, assertEqual, assertNotEqual */
 
 ////////////////////////////////////////////////////////////////////////////////
-/// @brief tests for regression returning blocks to the manager
-///
-/// @file
-///
 /// DISCLAIMER
 ///
 /// Copyright 2010-2014 triagens GmbH, Cologne, Germany

--- a/tests/js/server/aql/aql-traversal-restrict-graph-collections-cluster.js
+++ b/tests/js/server/aql/aql-traversal-restrict-graph-collections-cluster.js
@@ -1,0 +1,165 @@
+/*jshint globalstrict:false, strict:false, maxlen: 500 */
+/*global assertEqual, assertNotEqual, fail */
+
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2010-2014 triagens GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is triAGENS GmbH, Cologne, Germany
+///
+/// @author Jan Steemann
+/// @author Copyright 2020, triAGENS GmbH, Cologne, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+const jsunity = require("jsunity");
+const db = require("@arangodb").db;
+const errors = require("internal").errors;
+const { deriveTestSuite } = require('@arangodb/test-helper');
+const isEnterprise = require("internal").isEnterprise();
+  
+const vn = "UnitTestsVertex";
+const en = "UnitTestsEdges";
+const gn = "UnitTestsGraph";
+const smartGraphAttribute = 'smart';
+
+function BaseTestConfig() {
+  return {
+    testWithDroppedEdgeCollection : function () {
+      // drop one of the edge collections
+      db._drop(en + "1");
+      
+      try {
+        db._query(`FOR v IN ANY "${vn}/A1" GRAPH "${gn}" OPTIONS { edgeCollections: "${en}1" } RETURN v`);
+        fail();
+      } catch (err) {
+        assertEqual(errors.ERROR_ARANGO_DATA_SOURCE_NOT_FOUND.code, err.errorNum);
+      }
+    },
+    
+    testWithDroppedOtherEdgeCollection : function () {
+      // drop one of the edge collections
+      db._drop(en + "1");
+      
+      try {
+        db._query(`FOR v IN ANY "${vn}/A1" GRAPH "${gn}" OPTIONS { edgeCollections: "${en}2" } RETURN v`);
+        fail();
+      } catch (err) {
+        assertEqual(errors.ERROR_ARANGO_DATA_SOURCE_NOT_FOUND.code, err.errorNum);
+      }
+    },
+    
+    testWithPoisonedEdge : function () {
+      const n = "doesnotexist";
+      db._create(n);
+      try {
+        db[en + "1"].insert({ _from: vn + "/42:test1", _to: n + "/42:test2", smartGraphAttribute: "42" });
+        
+        try {
+          db._query(`FOR v IN ANY "${vn}/42:test1" GRAPH "${gn}" RETURN v`);
+          fail();
+        } catch (err) {
+          assertEqual(errors.ERROR_QUERY_COLLECTION_LOCK_FAILED.code, err.errorNum);
+        }
+      } finally {
+        db._drop(n);
+      }
+    },
+  };
+}
+
+function GraphCollectionRestrictionGeneralGraph() {
+  'use strict';
+    
+  const graphs = require("@arangodb/general-graph");
+
+  let suite = {
+    setUp: function () {
+      graphs._create(gn, [graphs._relation(en + "1", vn, vn), graphs._relation(en + "2", vn, vn)], null, { numberOfShards: 4 });
+    },
+
+    tearDown : function () {
+      try {
+        graphs._drop(gn, true);
+      } catch (err) {}
+
+      db._drop(vn);
+      db._drop(en + "1");
+      db._drop(en + "2");
+    },
+  };
+
+  deriveTestSuite(BaseTestConfig(), suite, '_GeneralGraph');
+  return suite;
+}
+
+function GraphCollectionRestrictionSmartGraph() {
+  'use strict';
+    
+  const graphs = require("@arangodb/smart-graph");
+
+  let suite = {
+    setUp: function () {
+      graphs._create(gn, [graphs._relation(en + "1", vn, vn), graphs._relation(en + "2", vn, vn)], null, { numberOfShards: 4, smartGraphAttribute });
+    },
+
+    tearDown : function () {
+      try {
+        graphs._drop(gn, true);
+      } catch (err) {}
+
+      db._drop(vn);
+      db._drop(en + "1");
+      db._drop(en + "2");
+    },
+  };
+
+  deriveTestSuite(BaseTestConfig(), suite, '_SmartGraph');
+  return suite;
+}
+  
+function GraphCollectionRestrictionDisjointSmartGraph() {
+  'use strict';
+  
+  const graphs = require("@arangodb/smart-graph");
+
+  let suite = {
+    setUp: function () {
+      graphs._create(gn, [graphs._relation(en + "1", vn, vn), graphs._relation(en + "2", vn, vn)], null, { numberOfShards: 4, smartGraphAttribute, isDisjoint: true });
+    },
+
+    tearDown : function () {
+      try {
+        graphs._drop(gn, true);
+      } catch (err) {}
+
+      db._drop(vn);
+      db._drop(en + "1");
+      db._drop(en + "2");
+    },
+  };
+
+  deriveTestSuite(BaseTestConfig(), suite, '_DisjointSmartGraph');
+  return suite;
+}
+
+jsunity.run(GraphCollectionRestrictionGeneralGraph);
+
+if (isEnterprise) {
+  jsunity.run(GraphCollectionRestrictionSmartGraph);
+  jsunity.run(GraphCollectionRestrictionDisjointSmartGraph);
+}
+
+return jsunity.done();


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/19507
Enterprise companion PR: https://github.com/arangodb/enterprise/pull/1337

Prevent potential nullptr dereferencing.
We have seen a backtrace from method `void aql::GraphNode::addEdgeCollection(aql::Collection& col)`, indicating that there is a potentiall nullptr access in there. We do not know yet how to reproduce the problem.
This PR adjusts the said method to not derefence potential nullptrs anymore, but instead throw a proper exception.
This will still make the AQL query fail, but not crash the coordinator.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: -
  - [x] Backport for 3.10: this PR
  - [ ] Backport for 3.9: -

#### Related Information

- [ ] Docs PR: 
- [x] Enterprise PR: https://github.com/arangodb/enterprise/pull/1337
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 