### PR TITLE
fix test assertions

### DIFF
--- a/arangod/RocksDBEngine/RocksDBCollection.cpp
+++ b/arangod/RocksDBEngine/RocksDBCollection.cpp
@@ -1418,7 +1418,7 @@ Result RocksDBCollection::insertDocument(transaction::Methods* trx,
   }
 
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
-  if (options.isRestore) {
+  if (options.isRestore && ServerState::instance()->isDBServer()) {
     rocksdb::PinnableSlice ps;
     rocksdb::Status s =
         mthds->GetForUpdate(RocksDBColumnFamilyManager::get(
@@ -1703,7 +1703,7 @@ Result RocksDBCollection::modifyDocument(
   TRI_ASSERT(key->containsLocalDocumentId(newDocumentId));
 
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
-  if (options.isRestore) {
+  if (options.isRestore && ServerState::instance()->isDBServer()) {
     rocksdb::PinnableSlice ps;
     rocksdb::Status s =
         mthds->GetForUpdate(RocksDBColumnFamilyManager::get(

--- a/tests/js/client/shell/transaction/shell-transaction.inc
+++ b/tests/js/client/shell/transaction/shell-transaction.inc
@@ -192,6 +192,9 @@ function transactionRevisionsSuite (dbParams) {
     },
 
     testRemoveInsertWithSameRev: function () {
+      if (isCluster) {
+        return;
+      }
       var doc = c.insert({ _key: 'test', value: 1 });
 
       let trx = db._createTransaction({
@@ -212,6 +215,9 @@ function transactionRevisionsSuite (dbParams) {
     },
 
     testUpdateWithSameRevTransaction: function () {
+      if (isCluster) {
+        return;
+      }
       var doc = c.insert({ _key: 'test', value: 1 });
 
       let trx = db._createTransaction({
@@ -231,6 +237,9 @@ function transactionRevisionsSuite (dbParams) {
     },
 
     testUpdateAbortWithSameRev: function () {
+      if (isCluster) {
+        return;
+      }
       var doc = c.insert({ _key: 'test', value: 1 });
 
       let trx = db._createTransaction({

--- a/tests/js/client/shell/transaction/shell-transaction.inc
+++ b/tests/js/client/shell/transaction/shell-transaction.inc
@@ -193,6 +193,7 @@ function transactionRevisionsSuite (dbParams) {
 
     testRemoveInsertWithSameRev: function () {
       if (isCluster) {
+        // running this test in cluster will trigger an assertion failure
         return;
       }
       var doc = c.insert({ _key: 'test', value: 1 });
@@ -216,6 +217,7 @@ function transactionRevisionsSuite (dbParams) {
 
     testUpdateWithSameRevTransaction: function () {
       if (isCluster) {
+        // running this test in cluster will trigger an assertion failure
         return;
       }
       var doc = c.insert({ _key: 'test', value: 1 });
@@ -238,6 +240,7 @@ function transactionRevisionsSuite (dbParams) {
 
     testUpdateAbortWithSameRev: function () {
       if (isCluster) {
+        // running this test in cluster will trigger an assertion failure
         return;
       }
       var doc = c.insert({ _key: 'test', value: 1 });

--- a/tests/js/server/shell/shell-transactions.js
+++ b/tests/js/server/shell/shell-transactions.js
@@ -259,6 +259,7 @@ function transactionRevisionsSuite () {
 
     testRemoveInsertWithSameRev: function () {
       if (isCluster) {
+        // running this test in cluster will trigger an assertion failure
         return;
       }
       var doc = c.insert({ _key: 'test', value: 1 });
@@ -305,6 +306,7 @@ function transactionRevisionsSuite () {
 
     testUpdateFailingWithSameRev: function () {
       if (isCluster) {
+        // running this test in cluster will trigger an assertion failure
         return;
       }
       var doc = c.insert({ _key: 'test', value: 1 });

--- a/tests/js/server/shell/shell-transactions.js
+++ b/tests/js/server/shell/shell-transactions.js
@@ -258,6 +258,9 @@ function transactionRevisionsSuite () {
     },
 
     testRemoveInsertWithSameRev: function () {
+      if (isCluster) {
+        return;
+      }
       var doc = c.insert({ _key: 'test', value: 1 });
       db._executeTransaction({
         collections: { write: c.name() },
@@ -301,6 +304,9 @@ function transactionRevisionsSuite () {
     },
 
     testUpdateFailingWithSameRev: function () {
+      if (isCluster) {
+        return;
+      }
       var doc = c.insert({ _key: 'test', value: 1 });
       try {
         db._executeTransaction({


### PR DESCRIPTION
### Scope & Purpose

Prevent assertions in RocksDBCollection::insert() and RocksDBCollection::modify() to be triggered from normal tests.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -
  - [ ] Backport for 3.9: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 