### PR TITLE
extended chaos tests so that they run on OneShard too

### DIFF
--- a/js/client/modules/@arangodb/test-helper.js
+++ b/js/client/modules/@arangodb/test-helper.js
@@ -84,6 +84,22 @@ function getInstanceInfo() {
 
 let reconnectRetry = exports.reconnectRetry = require('@arangodb/replication-common').reconnectRetry;
 
+exports.clearAllFailurePoints = function () {
+  const old = db._name();
+  try {
+    for (const server of exports.getDBServers()) {
+      exports.debugClearFailAt(exports.getEndpointById(server.id));
+    }
+    for (const server of exports.getCoordinators()) {
+      exports.debugClearFailAt(exports.getEndpointById(server.id));
+    }
+  } finally {
+    // need to restore original database, as debugFailAt() can 
+    // change into a different database...
+    db._useDatabase(old);
+  }
+};
+
 /// @brief set failure point
 exports.debugCanUseFailAt = function (endpoint) {
   const primaryEndpoint = arango.getEndpoint();
@@ -263,7 +279,7 @@ const runShell = function(args, prefix) {
   return result.pid;
 };
 
-const buildCode = function(key, command, cn, duration) {
+const buildCode = function(dbname, key, command, cn, duration) {
   let file = fs.getTempFile() + "-" + key;
   fs.write(file, `
 (function() {
@@ -272,8 +288,12 @@ require('internal').SetGlobalExecutionDeadlineTo((${duration} + 180) * 1000);
 let tries = 0;
 while (true) {
   if (++tries % 3 === 0) {
-    if (db['${cn}'].exists('stop')) {
-      break;
+    try {
+      if (db['${cn}'].exists('stop')) {
+        break;
+      }
+    } catch (err) {
+      // the operation may actually fail because of failure points
     }
   }
   ${command}
@@ -292,6 +312,7 @@ while (++saveTries < 100) {
   `);
 
   let args = {'javascript.execute': file};
+  args["--server.database"] = dbname;
   let pid = runShell(args, file);
   debug("started client with key '" + key + "', pid " + pid + ", args: " + JSON.stringify(args));
   return { key, file, pid };
@@ -310,7 +331,7 @@ exports.runParallelArangoshTests = function (tests, duration, cn) {
     tests.forEach(function (test) {
       let key = test[0];
       let code = test[1];
-      let client = buildCode(key, code, cn, duration);
+      let client = buildCode(db._name(), key, code, cn, duration);
       client.done = false;
       client.failed = true; // assume the worst
       clients.push(client);
@@ -343,8 +364,11 @@ exports.runParallelArangoshTests = function (tests, duration, cn) {
       }
     }
 
+    // clear failure points
+    debug("clearing failure points");
+    exports.clearAllFailurePoints();
+  
     debug("stopping all test clients");
-
     // broad cast stop signal
     assertFalse(db[cn].exists("stop"));
     let saveTries = 0;

--- a/tests/js/client/chaos/test-chaos-load-common.inc
+++ b/tests/js/client/chaos/test-chaos-load-common.inc
@@ -34,6 +34,7 @@ const analyzers = require("@arangodb/analyzers");
 const request = require("@arangodb/request");
 const db = arangodb.db;
 const {
+  clearAllFailurePoints,
   debugSetFailAt,
   debugClearFailAt,
   deriveTestSuite,
@@ -71,7 +72,7 @@ const checkCollectionConsistency = (cn) => {
   const shardInfo = c.shards(true);
   
   let failed = false;
-  const getServerUrl = (serverId) => servers.filter((server) => server.id === serverId)[0].url;
+  const getServerUrl = (serverId) => servers.filter((server) => server.id === serverId)[0].url + '/_db/' + encodeURIComponent(db._name());
   let tries = 0;
   do {
     failed = false;
@@ -155,16 +156,8 @@ const checkViewConsistency = (cn, isSearchAlias, isMaterialize, viewCounts) => {
   checkView(isMaterialize);
 };
 
-const clearAllFailurePoints = () => {
-  for (const server of getDBServers()) {
-    debugClearFailAt(getEndpointById(server.id));
-  }
-  for (const server of getCoordinators()) {
-    debugClearFailAt(getEndpointById(server.id));
-  }
-};
-
 function BaseChaosSuite(testOpts) {
+  const dbname = "test";
   // generate a random collection name
   const cn = "UnitTests" + require("@arangodb/crypto").md5(internal.genRandomAlphaNumbers(32));
   const coordination_cn = cn + "_coord";
@@ -276,13 +269,21 @@ function BaseChaosSuite(testOpts) {
 
   return {
     setUp: function () {
-      createAnalyzers();
+      if (testOpts.withOneShard) {
+        db._createDatabase(dbname,  {sharding:"single"});
+      } else {
+        db._createDatabase(dbname);
+      }
+      db._useDatabase(dbname);
+
+      if (testOpts.withViews) {
+        createAnalyzers();
+      }
       db._drop(cn);
       db._drop(coordination_cn);
-      let rf = Math.max(2, getDBServers().length);
-      db._create(cn, {numberOfShards: rf * 2, replicationFactor: rf});
-      // TODO when we fix intermediate commit needs to remove this and add checkView option to matrix
-      testOpts.withViews = true;
+      const replicationFactor = Math.max(2, getDBServers().length);
+      const numberOfShards = (testOpts.withOneShard ? 1 : replicationFactor * 2);
+      db._create(cn, {numberOfShards, replicationFactor});
       if (testOpts.withViews) {
         createViews(false);
         createViews(true);
@@ -327,27 +328,35 @@ function BaseChaosSuite(testOpts) {
     },
 
     tearDown: function () {
-      print(Date() + " tearDown: flushing failurepoints");
-      clearAllFailurePoints();
-      if (testOpts.withViews) {
-        removeViews(false);
-        removeViews(true);
-      }
-      print(Date() + " tearDown: dropping " + cn);
-      db._drop(cn);
+      db._useDatabase(dbname);
+      try {
+        print(Date() + " tearDown: flushing failurepoints");
+        clearAllFailurePoints();
+        if (testOpts.withViews) {
+          removeViews(false);
+          removeViews(true);
+        }
+        print(Date() + " tearDown: dropping " + cn);
+        db._drop(cn);
 
-      const shells = db[coordination_cn].all();
-      if (shells.length > 0) {
-        print("Found remaining docs in coordination collection:");
-        print(shells);
+        const shells = db[coordination_cn].all();
+        if (shells.length > 0) {
+          print("Found remaining docs in coordination collection:");
+          print(shells);
+        }
+        print(Date() + " tearDown: dropping " + coordination_cn);
+        db._drop(coordination_cn);
+        print(Date() + " tearDown: done.");
+        if (testOpts.withViews) {
+          analyzers.remove('testAnalyzer');
+        }
+      } finally {
+        db._useDatabase("_system");
+        db._dropDatabase(dbname);
       }
-      print(Date() + " tearDown: dropping " + coordination_cn);
-      db._drop(coordination_cn);
-      print(Date() + " tearDown: done.");
-      analyzers.remove('testAnalyzer');
     },
     
-    testWorkInParallel: function () {
+    testRunChaos: function () {
       let code = (testOpts) => {
         const pid = require("internal").getPid();
         // The idea here is to use the birthday paradox and have a certain amount of collisions.
@@ -468,6 +477,22 @@ function BaseChaosSuite(testOpts) {
               let o = opts(limit);
               log(`RUNNING DOCUMENT LOOKUP AND WRITE QUERY WITH LIMIT=${limit}. OPTIONS: ${JSON.stringify(0)}`);
               query("FOR doc IN " + c.name() + " LIMIT @limit LET d = DOCUMENT(doc._id) INSERT UNSET(doc, '_key') INTO " + c.name(), {limit}, o);
+            } else if (d >= 0.60) {
+              const limit = Math.floor(Math.random() * 100) + 1;
+              let keys = [];
+              for (let i = 0; i < keys; ++i) {
+                keys.push(key());
+              }
+              log(`RUNNING DOCUMENT BATCH LOOKUP.`);
+              c.document(keys);
+            } else if (d >= 0.55) {
+              const limit = Math.floor(Math.random() * 100) + 1;
+              let keys = [];
+              for (let i = 0; i < keys; ++i) {
+                keys.push(key());
+              }
+              log(`RUNNING DOCUMENT AQL LOOKUP.`);
+              query("FOR doc IN " + c.name() + " FILTER doc._key IN @keys RETURN doc", {keys});
             } else if (d >= 0.25) {
               let d = docs();
               let o = opts(d.length);
@@ -484,7 +509,7 @@ function BaseChaosSuite(testOpts) {
         }
         
         let willAbort = Math.random() < 0.2;
-        while(trx) {
+        while (trx) {
           try {
             if (willAbort) {
               log(`ABORTING`);
@@ -494,11 +519,15 @@ function BaseChaosSuite(testOpts) {
               trx.commit();
             }
             trx = null;
-          } catch(e) {
-            // due to contention we could have a lock timeout here
-            if(require("@arangodb").errors.ERROR_LOCKED.code !== e.errorNum) {
-               throw e;
+          } catch (e) {
+            if (require("@arangodb").errors.ERROR_TRANSACTION_NOT_FOUND.code === e.errorNum) {
+              break;
             }
+            // due to contention we could have a lock timeout here
+            if (require("@arangodb").errors.ERROR_LOCKED.code !== e.errorNum) {
+              throw e;
+            }
+            log("unable to " + (willAbort ? "abort" : "commit") + " transaction: " + String(e));
             require('internal').sleep(1);
           }
         }
@@ -507,63 +536,95 @@ function BaseChaosSuite(testOpts) {
       testOpts.collection = cn;
       code = `(${code.toString()})(${JSON.stringify(testOpts)});`;
       
+      const concurrency = 3;
       let tests = [];
-      for (let i = 0; i < 3; ++i) {
+      for (let i = 0; i < concurrency; ++i) {
         tests.push(["p" + i, code]);
       }
 
-      // run the suite for 3 minutes
-      let client_ret = runParallelArangoshTests(tests, 3 * 60, coordination_cn);
+      const old = db._name();
+      db._useDatabase(dbname);
 
-      print(Date() + " Finished load test; Clearing failurepoints");
-      clearAllFailurePoints();
-      print(Date() + " Waiting for shards to get in sync");
-      waitForShardsInSync(cn, 300, db[cn].properties().replicationFactor - 1);
-      print(Date() + " checking consistency");
-      checkCollectionConsistency(cn);
-      let viewCounts = [];
-      if (testOpts.withViews) {
-        print(Date() + " checking view 1 consistency");
-        checkViewConsistency(cn, false, false, viewCounts);
-        print(Date() + " checking view 2 consistency");
-        checkViewConsistency(cn, true, false, viewCounts);
-        print(Date() + " checking view 3 consistency");
-        checkViewConsistency(cn, false, true, viewCounts);
-        print(Date() + " checking view 4 consistency");
-        checkViewConsistency(cn, true, true, viewCounts);
+      try {
+        // run the suite for a few minutes
+        const minutes = 3;
+        let client_ret = runParallelArangoshTests(tests, minutes * 60, coordination_cn);
+
+        print(Date() + " Finished load test; Clearing failurepoints");
+        clearAllFailurePoints();
+        print(Date() + " Waiting for shards to get in sync");
+        waitForShardsInSync(cn, 300, db[cn].properties().replicationFactor - 1);
+        print(Date() + " checking consistency");
+        checkCollectionConsistency(cn);
+        let viewCounts = [];
+        if (testOpts.withViews) {
+          print(Date() + " checking view 1 consistency");
+          checkViewConsistency(cn, false, false, viewCounts);
+          print(Date() + " checking view 2 consistency");
+          checkViewConsistency(cn, true, false, viewCounts);
+          print(Date() + " checking view 3 consistency");
+          checkViewConsistency(cn, false, true, viewCounts);
+          print(Date() + " checking view 4 consistency");
+          checkViewConsistency(cn, true, true, viewCounts);
+        }
+        print(Date() + " checking consistency done.");
+        let failedViews = "";
+        for (const c of viewCounts) {
+          if (c.viewCount !== c.collectionCount) {
+            print(viewCounts);
+            failedViews = " and views count mismatch";
+            break;
+          }
+        }
+        client_ret.forEach(client => { if (client.failed) { throw new Error("clients did not finish successfully " + failedViews); }});
+        assertEqual(failedViews, "");
+      } finally {
+        // always change back into original database
+        db._useDatabase(old);
       }
-      print(Date() + " checking consistency done.");
-      let failedViews = "";
-      for (const c of viewCounts) {
-         if(c.viewCount !== c.collectionCount) {
-           print(viewCounts);
-           failedViews = " and views count mismatch";
-           break;
-         }
-      }
-      client_ret.forEach(client => { if (client.failed) { throw new Error("clients did not finish successfully " + failedViews); }});
-      assertEqual(failedViews, "");
     }
   };
 }
 
-const params = ["IntermediateCommits", "FailurePoints", "Delays", "StreamingTransactions"];
+const params = ["IntermediateCommits", "FailurePoints", "Delays", "StreamingTransactions", "OneShard"];
+const fixedParams = ["Truncate", "VaryingOverwriteMode", "Views"]; // these parameters are always enabled
 
-const fixedParams = ["Truncate", "VaryingOverwriteMode"]; // these parameters are always enabled
+// these aliases are used to shorten the names of test cases and filenames.
+// if we use the full-length names, we would create filenames which are too 
+// long on some filesystems.
+const aliases = {
+  "IntermediateCommits": "IntermComm",
+  "FailurePoints": "Failures",
+  "StreamingTransactions": "StreamTrx",
+  "OneShard": "1Shard",
+  "VaryingOverwriteMode": "OverwrMode",
+};
 
 const makeConfig = (paramValues) => {
   let suffix = "";
-  let opts = {};
+  let options = {};
+
+  const build = (name, value) => {
+    suffix += value ? "_with" : "_no";
+    if (aliases.hasOwnProperty(name)) {
+      // use alias to shorten filename
+      suffix += aliases[name];
+    } else {
+      suffix += name;
+    }
+    // use full-length name for options
+    options["with" + name] = value;
+  };
+
+  // variable parameters
   for (let j = 0; j < params.length; ++j) {
-    suffix += paramValues[j] ? "_with_" : "_no_";
-    suffix += params[j];
-    opts["with" + params[j]] = paramValues[j];
+    build(params[j], paramValues[j]);
   }
+  // fixed parameters
   for (const p of fixedParams) {
-    suffix += "_with_" + p;
-    opts["with" + p] = true;
+    build(p, true);
   }
-  return { suffix: suffix, options: opts };
+  return { suffix, options };
 };
 
 const run = () => {


### PR DESCRIPTION
### Scope & Purpose

Extend (nightly) chaos tests so that they also test running in a OneShard database.
This adds a OneShard parameter to the tests, which will result in more test combinations available.
Effectively, adding a new parameter to the tests will **double** the number of test combinations. So this change is not without downsides, as it increases the overall runtime of the chaos tests considerably.

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -
  - [ ] Backport for 3.9: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 