### PR TITLE
BTS-1539: backport a change from devel

### DIFF
--- a/tests/js/client/shell/multi/shell-computed-values-cluster.js
+++ b/tests/js/client/shell/multi/shell-computed-values-cluster.js
@@ -66,6 +66,28 @@ function collectionComputedValuesClusterSuite() {
       });
       assertEqual(randValues[servers[0].id], randValues[servers[1].id]);
     },
+
+    testEmptyComputedValuesSpecialCase: function () {
+      let c = db._create(cn, {
+        numberOfShards: 1, replicationFactor: 2, computedValues: []
+      });
+
+      // create write transaction
+      let trx = db._createTransaction( {
+        collections: {
+          write: [ cn ]
+        }
+      });
+
+      let tc = trx.collection(cn);
+      tc.insert({_key: "foo"});
+
+      // now insert a document not within the transaction. it should not
+      // produce a deadlock
+      c.insert({_key: "bar"});
+
+      trx.commit();
+    },
   };
 }
 


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/19515

https://arangodb.atlassian.net/browse/BTS-1539

Backport a change from devel that relaxes a comparison made in the cluster maintenance for computed values. 
Not having computed values is stored as `null` normally, but under some condition not having computed values can also be stored as an empty array in devel. 
Both values should be treated equal by the maintenance. If the maintenance treats `null` and `[]` as different, it may initiate a busy loop, trying forever to adjust the `computedValues` property of the shard.

Although we believe that in 3.11 having no computed values is always stoted as `null`, this backport is made to avoid potential issues during upgrades or in case other changes are backported from devel. the added test should run into an issue in case the problem from devel occurs.

So this is not a bugfix, but a precautionary backport. Thus intentionally no CHANGELOG entry.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.11: this PR
  - [ ] Backport for 3.10: -
  - [ ] Backport for 3.9: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [x] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/BTS-1539
- [ ] Design document: 