### PR TITLE
Removed some long-deprecated HTTP server features

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,23 @@
 devel
 -----
 
+* Removed the following long-deprecated features for the HTTP server:
+
+  - overriding the HTTP method by setting one of the HTTP headers 
+    - `x-http-method`
+    - `x-http-method-override`
+    - `x-method-override`
+    This functionality could previously be enabled by starting the server with 
+    the startup option `--http.allow-method-override`.
+    The functionality has now been removed and setting the startup option does 
+    nothing.
+
+  - optionally hiding ArangoDB's `server` response header. This functionality
+    could optionally be enabled by starting the server with the startup option
+    `--http.hide-product-header`. 
+    The functionality has now been removed and setting the startup option does 
+    nothing.
+
 * FE-291: Refactor Query screen on web UI to React.
 
 * FE-313: Upgrade arangojs to v8.x on web UI.

--- a/arangod/GeneralServer/GeneralServerFeature.cpp
+++ b/arangod/GeneralServer/GeneralServerFeature.cpp
@@ -165,7 +165,6 @@ GeneralServerFeature::GeneralServerFeature(Server& server)
       _startedListening(false),
 #endif
       _allowEarlyConnections(false),
-      _allowMethodOverride(false),
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
       _enableTelemetrics(false),
 #else
@@ -269,29 +268,10 @@ batch processing.)");
 
   options->addSection("http", "HTTP server features");
 
-  options
-      ->addOption("--http.allow-method-override",
-                  "Allow HTTP method override using special headers.",
-                  new BooleanParameter(&_allowMethodOverride),
-                  arangodb::options::makeDefaultFlags(
-                      arangodb::options::Flags::Uncommon))
-      .setDeprecatedIn(30800)
-      .setLongDescription(R"(If you set this option to `true`, the HTTP request
-method is optionally fetched from one of the following HTTP request headers if
-present in the request:
-
-- `x-http-method`
-- `x-http-method-override`
-- `x-method-override`
-
-If the option is enabled and any of these headers is set, the request method is
-overridden by the value of the header. For example, this allows you to issue an
-HTTP DELETE request which, to the outside world, looks like an HTTP GET request.
-This allows you to bypass proxies and tools that only let certain request types
-pass.
-
-Enabling this option may impose a security risk. You should only use it in
-controlled environments.)");
+  // option was deprecated in 3.8 and removed in 3.12.
+  options->addObsoleteOption(
+      "--http.allow-method-override",
+      "Allow HTTP method override using special headers.", true);
 
   options
       ->addOption("--http.keep-alive-timeout",
@@ -301,12 +281,10 @@ controlled environments.)");
 server automatically when the timeout is reached. A keep-alive-timeout value of
 `0` disables the keep-alive feature entirely.)");
 
-  options
-      ->addOption(
-          "--http.hide-product-header",
-          "Whether to omit the `Server: ArangoDB` header in HTTP responses.",
-          new BooleanParameter(&HttpResponse::HIDE_PRODUCT_HEADER))
-      .setDeprecatedIn(30800);
+  // option was deprecated in 3.8 and removed in 3.12.
+  options->addObsoleteOption(
+      "--http.hide-product-header",
+      "Whether to omit the `Server: ArangoDB` header in HTTP responses.", true);
 
   options->addOption(
       "--http.trusted-origin",
@@ -431,14 +409,6 @@ void GeneralServerFeature::prepare() {
     _enableTelemetrics = false;
   }
 
-  if (ServerState::instance()->isDBServer() &&
-      !server().options()->processingResult().touched(
-          "http.hide-product-header")) {
-    // if we are a DB server, client applications will not talk to us
-    // directly, so we can turn off the Server signature header.
-    HttpResponse::HIDE_PRODUCT_HEADER = true;
-  }
-
   _jobManager = std::make_unique<AsyncJobManager>();
 
   // create an initial, very stripped-down RestHandlerFactory.
@@ -535,10 +505,6 @@ bool GeneralServerFeature::returnQueueTimeHeader() const noexcept {
 
 std::vector<std::string> GeneralServerFeature::trustedProxies() const {
   return _trustedProxies;
-}
-
-bool GeneralServerFeature::allowMethodOverride() const noexcept {
-  return _allowMethodOverride;
 }
 
 std::vector<std::string> const&

--- a/arangod/GeneralServer/GeneralServerFeature.h
+++ b/arangod/GeneralServer/GeneralServerFeature.h
@@ -60,7 +60,6 @@ class GeneralServerFeature final : public ArangodFeature {
   bool proxyCheck() const noexcept;
   bool returnQueueTimeHeader() const noexcept;
   std::vector<std::string> trustedProxies() const;
-  bool allowMethodOverride() const noexcept;
   std::vector<std::string> const& accessControlAllowOrigins() const;
   Result reloadTLS();
   bool permanentRootRedirect() const noexcept;
@@ -111,7 +110,6 @@ class GeneralServerFeature final : public ArangodFeature {
   bool _startedListening;
 #endif
   bool _allowEarlyConnections;
-  bool _allowMethodOverride;
   bool _enableTelemetrics;
   bool _proxyCheck;
   bool _returnQueueTimeHeader;

--- a/arangod/GeneralServer/H2CommTask.cpp
+++ b/arangod/GeneralServer/H2CommTask.cpp
@@ -83,8 +83,7 @@ template<SocketType T>
   int32_t const sid = frame->hd.stream_id;
   me->acquireStatistics(sid).SET_READ_START(TRI_microtime());
   auto req =
-      std::make_unique<HttpRequest>(me->_connectionInfo, /*messageId*/ sid,
-                                    /*allowMethodOverride*/ false);
+      std::make_unique<HttpRequest>(me->_connectionInfo, /*messageId*/ sid);
   me->createStream(sid, std::move(req));
 
   LOG_TOPIC("33598", TRACE, Logger::REQUESTS)
@@ -795,7 +794,7 @@ void H2CommTask<T>::queueHttp2Responses() {
     }
 
     // add "Server" response header
-    if (!seenServerHeader && !HttpResponse::HIDE_PRODUCT_HEADER) {
+    if (!seenServerHeader) {
       nva.push_back(
           {(uint8_t*)"server", (uint8_t*)"ArangoDB", 6, 8,
            NGHTTP2_NV_FLAG_NO_COPY_NAME | NGHTTP2_NV_FLAG_NO_COPY_VALUE});

--- a/arangod/GeneralServer/HttpCommTask.cpp
+++ b/arangod/GeneralServer/HttpCommTask.cpp
@@ -93,8 +93,8 @@ int HttpCommTask<T>::on_message_began(llhttp_t* p) try {
   me->_lastHeaderValue.clear();
   me->_origin.clear();
   me->_url.clear();
-  me->_request = std::make_unique<HttpRequest>(
-      me->_connectionInfo, /*messageId*/ 1, me->_allowMethodOverride);
+  me->_request =
+      std::make_unique<HttpRequest>(me->_connectionInfo, /*messageId*/ 1);
   me->_response.reset();
   me->_lastHeaderWasValue = false;
   me->_shouldKeepAlive = false;
@@ -263,8 +263,7 @@ HttpCommTask<T>::HttpCommTask(GeneralServer& server, ConnectionInfo info,
     : GeneralCommTask<T>(server, std::move(info), std::move(so)),
       _lastHeaderWasValue(false),
       _shouldKeepAlive(false),
-      _messageDone(false),
-      _allowMethodOverride(this->_generalServerFeature.allowMethodOverride()) {
+      _messageDone(false) {
   this->_connectionStatistics.SET_HTTP();
 
   // initialize http parsing code
@@ -694,7 +693,7 @@ void HttpCommTask<T>::sendResponse(std::unique_ptr<GeneralResponse> baseRes,
   }
 
   // add "Server" response header
-  if (!seenServerHeader && !HttpResponse::HIDE_PRODUCT_HEADER) {
+  if (!seenServerHeader) {
     _header.append(std::string_view("Server: ArangoDB\r\n"));
   }
 

--- a/arangod/GeneralServer/HttpCommTask.h
+++ b/arangod/GeneralServer/HttpCommTask.h
@@ -97,8 +97,6 @@ class HttpCommTask final : public GeneralCommTask<T> {
   bool _lastHeaderWasValue;
   bool _shouldKeepAlive;  /// keep connection open
   bool _messageDone;
-
-  bool const _allowMethodOverride;  /// allow method override
 };
 }  // namespace rest
 }  // namespace arangodb

--- a/arangod/RestHandler/RestBatchHandler.cpp
+++ b/arangod/RestHandler/RestBatchHandler.cpp
@@ -186,9 +186,8 @@ bool RestBatchHandler::executeNextHandler() {
   LOG_TOPIC("910e9", TRACE, arangodb::Logger::REPLICATION)
       << "part header is: " << std::string(headerStart, headerLength);
 
-  auto request =
-      std::make_unique<HttpRequest>(_request->connectionInfo(), /*messageId*/ 1,
-                                    /*allowMethodOverride*/ false);
+  auto request = std::make_unique<HttpRequest>(_request->connectionInfo(),
+                                               /*messageId*/ 1);
   if (0 < headerLength) {
     auto buff = std::make_unique<char[]>(headerLength + 1);
     memcpy(buff.get(), headerStart, headerLength);

--- a/lib/Rest/HttpRequest.cpp
+++ b/lib/Rest/HttpRequest.cpp
@@ -70,11 +70,8 @@ std::string urlDecode(char const* begin, char const* end) {
 }
 }  // namespace
 
-HttpRequest::HttpRequest(ConnectionInfo const& connectionInfo, uint64_t mid,
-                         bool allowMethodOverride)
-    : GeneralRequest(connectionInfo, mid),
-      _allowMethodOverride(allowMethodOverride),
-      _validatedPayload(false) {
+HttpRequest::HttpRequest(ConnectionInfo const& connectionInfo, uint64_t mid)
+    : GeneralRequest(connectionInfo, mid), _validatedPayload(false) {
   _contentType = ContentType::UNSET;
   _contentTypeResponse = ContentType::JSON;
   TRI_ASSERT(_memoryUsage == 0);
@@ -618,19 +615,6 @@ void HttpRequest::setHeader(std::string key, std::string value) {
   } else if (key == "cookie") {
     parseCookies(value.c_str(), value.size());
     return;
-  }
-
-  if (_allowMethodOverride && key.starts_with("x-")) {
-    // handle x-... headers
-
-    // override HTTP method?
-    if (key == "x-http-method" || key == "x-method-override" ||
-        key == "x-http-method-override") {
-      StringUtils::tolowerInPlace(value);
-      _type = findRequestType(value.c_str(), value.size());
-      // don't insert this header!!
-      return;
-    }
   }
 
   auto memoryUsage = key.size() + value.size();

--- a/lib/Rest/HttpRequest.h
+++ b/lib/Rest/HttpRequest.h
@@ -41,7 +41,7 @@ class HttpRequest final : public GeneralRequest {
   HttpRequest(HttpRequest&&) = delete;
 
  public:
-  HttpRequest(ConnectionInfo const&, uint64_t mid, bool allowMethodOverride);
+  HttpRequest(ConnectionInfo const&, uint64_t mid);
 
   ~HttpRequest();
 
@@ -82,9 +82,6 @@ class HttpRequest final : public GeneralRequest {
   void setValues(char* buffer, char* end);
 
   std::unordered_map<std::string, std::string> _cookies;
-  //  whether or not overriding the HTTP method via custom headers
-  // (x-http-method, x-method-override or x-http-method-override) is allowed
-  bool const _allowMethodOverride = false;
 
   /// @brief was VPack payload validated
   bool _validatedPayload = false;

--- a/lib/Rest/HttpResponse.cpp
+++ b/lib/Rest/HttpResponse.cpp
@@ -44,8 +44,6 @@
 using namespace arangodb;
 using namespace arangodb::basics;
 
-bool HttpResponse::HIDE_PRODUCT_HEADER = false;
-
 HttpResponse::HttpResponse(ResponseCode code, uint64_t mid,
                            std::unique_ptr<basics::StringBuffer> buffer)
     : GeneralResponse(code, mid), _body(std::move(buffer)), _bodySize(0) {
@@ -210,7 +208,7 @@ void HttpResponse::writeHeader(StringBuffer* output) {
   }
 
   // add "Server" response header
-  if (!seenServerHeader && !HIDE_PRODUCT_HEADER) {
+  if (!seenServerHeader) {
     output->appendText(std::string_view("Server: ArangoDB\r\n"));
   }
 

--- a/lib/Rest/HttpResponse.h
+++ b/lib/Rest/HttpResponse.h
@@ -40,8 +40,6 @@ class HttpResponse : public GeneralResponse {
   friend class RestBatchHandler;  // TODO must be removed
 
  public:
-  static bool HIDE_PRODUCT_HEADER;
-
   HttpResponse(ResponseCode code, uint64_t mid,
                std::unique_ptr<basics::StringBuffer> = nullptr);
   ~HttpResponse() = default;

--- a/tests/Maintenance/MaintenanceRestHandlerTest.cpp
+++ b/tests/Maintenance/MaintenanceRestHandlerTest.cpp
@@ -66,8 +66,7 @@ TEST(MaintenanceRestHandler, parse_rest_put) {
     body.add("collection", VPackValue("a"));
   }
 
-  auto* dummyRequest =
-      new arangodb::HttpRequest(arangodb::ConnectionInfo(), 1, false);
+  auto* dummyRequest = new arangodb::HttpRequest(arangodb::ConnectionInfo(), 1);
   dummyRequest->setDefaultContentType();  // JSON
   dummyRequest->setPayload(buffer);
   dummyRequest->setRequestType(arangodb::rest::RequestType::PUT);

--- a/tests/Rest/HttpRequestTest.cpp
+++ b/tests/Rest/HttpRequestTest.cpp
@@ -34,14 +34,14 @@ using namespace arangodb;
 
 TEST(HttpRequestTest, testMessageId) {
   ConnectionInfo ci;
-  HttpRequest request(ci, 43, true);
+  HttpRequest request(ci, 43);
 
   EXPECT_EQ(43, request.messageId());
 }
 
 TEST(HttpRequestTest, testEmptyUrl) {
   ConnectionInfo ci;
-  HttpRequest request(ci, 1, true);
+  HttpRequest request(ci, 1);
 
   std::string_view url("/");
 
@@ -53,7 +53,7 @@ TEST(HttpRequestTest, testEmptyUrl) {
 
 TEST(HttpRequestTest, testPathOnlyUrl) {
   ConnectionInfo ci;
-  HttpRequest request(ci, 1, true);
+  HttpRequest request(ci, 1);
 
   std::string_view url("/a/foo/bar");
 
@@ -65,7 +65,7 @@ TEST(HttpRequestTest, testPathOnlyUrl) {
 
 TEST(HttpRequestTest, testDuplicateForwardSlashesInUrl) {
   ConnectionInfo ci;
-  HttpRequest request(ci, 1, true);
+  HttpRequest request(ci, 1);
 
   std::string_view url("//a//foo//bar");
 
@@ -77,7 +77,7 @@ TEST(HttpRequestTest, testDuplicateForwardSlashesInUrl) {
 
 TEST(HttpRequestTest, testUrlParameters) {
   ConnectionInfo ci;
-  HttpRequest request(ci, 1, true);
+  HttpRequest request(ci, 1);
 
   std::string_view url("/foo/bar/baz?a=1&b=23&c=d&e=foobar&f=baz&bark=quxxxx");
 
@@ -93,7 +93,7 @@ TEST(HttpRequestTest, testUrlParameters) {
 
 TEST(HttpRequestTest, testEmptyUrlParameters) {
   ConnectionInfo ci;
-  HttpRequest request(ci, 1, true);
+  HttpRequest request(ci, 1);
 
   std::string_view url("/?a=&b=&c=d&e=foobar&f=");
 
@@ -108,7 +108,7 @@ TEST(HttpRequestTest, testEmptyUrlParameters) {
 
 TEST(HttpRequestTest, testUrlEncoding) {
   ConnectionInfo ci;
-  HttpRequest request(ci, 1, true);
+  HttpRequest request(ci, 1);
 
   std::string_view url(
       "/foo/bar/"
@@ -125,7 +125,7 @@ TEST(HttpRequestTest, testUrlEncoding) {
 
 TEST(HttpRequestTest, testWrongUrlEncoding) {
   ConnectionInfo ci;
-  HttpRequest request(ci, 1, true);
+  HttpRequest request(ci, 1);
 
   std::string_view url("/foo/?a=%fg");
 


### PR DESCRIPTION
### Scope & Purpose

* Removed the following long-deprecated features for the HTTP server:

  - overriding the HTTP method by setting one of the HTTP headers - `x-http-method` - `x-http-method-override` - `x-method-override` This functionality could previously be enabled by starting the server with the startup option `--http.allow-method-override`. The functionality has now been removed and setting the startup option does nothing.

  - optionally hiding ArangoDB's `server` response header. This functionality could optionally be enabled by starting the server with the startup option `--http.hide-product-header`. The functionality has now been removed and setting the startup option does nothing.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -
  - [ ] Backport for 3.9: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 