### PR TITLE
fix wrong underlying parameter type

### DIFF
--- a/arangod/RocksDBEngine/RocksDBOptionFeature.cpp
+++ b/arangod/RocksDBEngine/RocksDBOptionFeature.cpp
@@ -273,6 +273,7 @@ RocksDBOptionFeature::RocksDBOptionFeature(Server& server)
       // note: this is a default value from RocksDB (db/column_family.cc,
       // kAdjustedTtl):
       _periodicCompactionTtl(30 * 24 * 60 * 60),
+      _recycleLogFileNum(rocksDBDefaults.recycle_log_file_num),
       _compressionType(::kCompressionTypeLZ4),
       _blobCompressionType(::kCompressionTypeLZ4),
       _blockCacheType(::kBlockCacheTypeLRU),
@@ -289,7 +290,6 @@ RocksDBOptionFeature::RocksDBOptionFeature(Server& server)
       _reserveTableBuilderMemory(false),
       _reserveTableReaderMemory(false),
       _reserveFileMetadataMemory(false),
-      _recycleLogFileNum(rocksDBDefaults.recycle_log_file_num),
       _enforceBlockCacheSizeLimit(false),
       _cacheIndexAndFilterBlocks(true),
       _cacheIndexAndFilterBlocksWithHighPriority(
@@ -977,7 +977,7 @@ the overall size of the block cache.)");
   options->addOption(
       "--rocksdb.recycle-log-file-num",
       "If enabled, keep a pool of log files around for recycling.",
-      new BooleanParameter(&_recycleLogFileNum),
+      new SizeTParameter(&_recycleLogFileNum),
       arangodb::options::makeFlags(
           arangodb::options::Flags::Uncommon,
           arangodb::options::Flags::DefaultNoComponents,
@@ -1750,7 +1750,7 @@ void RocksDBOptionFeature::start() {
       << _pinl0FilterAndIndexBlocksInCache
       << ", pin_top_level_index_and_filter: " << std::boolalpha
       << _pinTopLevelIndexAndFilter << ", table_block_size: " << _tableBlockSize
-      << ", recycle_log_file_num: " << std::boolalpha << _recycleLogFileNum
+      << ", recycle_log_file_num: " << _recycleLogFileNum
       << ", compaction_read_ahead_size: " << _compactionReadaheadSize
       << ", level0_compaction_trigger: " << _level0CompactionTrigger
       << ", level0_slowdown_trigger: " << _level0SlowdownTrigger

--- a/arangod/RocksDBEngine/RocksDBOptionFeature.h
+++ b/arangod/RocksDBEngine/RocksDBOptionFeature.h
@@ -132,6 +132,7 @@ class RocksDBOptionFeature final : public ArangodFeature,
   uint64_t _pendingCompactionBytesSlowdownTrigger;
   uint64_t _pendingCompactionBytesStopTrigger;
   uint64_t _periodicCompactionTtl;
+  size_t _recycleLogFileNum;
   std::string _compressionType;
   std::string _blobCompressionType;
   std::string _blockCacheType;
@@ -147,7 +148,6 @@ class RocksDBOptionFeature final : public ArangodFeature,
   bool _reserveTableBuilderMemory;
   bool _reserveTableReaderMemory;
   bool _reserveFileMetadataMemory;
-  bool _recycleLogFileNum;
   bool _enforceBlockCacheSizeLimit;
   bool _cacheIndexAndFilterBlocks;
   bool _cacheIndexAndFilterBlocksWithHighPriority;


### PR DESCRIPTION
### Scope & Purpose

for `--rocksdb.recycle-log-file-num`. The option does not make any difference to use with the default WAL recovery mode we are using. RocksDB automatically sanitizes the option to a value of `0`.

Previously we exposed this startup option as a boolean value, but it should rather be a size_t. Interestingly, the RocksDB code also uses the option with a wrong type in at least one place of their code.

This change should not modify the behavior in any way, except if the option is now set to a non-zero value and non-default recovery mode is selected.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -
  - [ ] Backport for 3.9: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 