### PR TITLE
[CINFRA] Preventing test from failing due to high system load

### DIFF
--- a/js/common/modules/@arangodb/testutils/replicated-logs-helper.js
+++ b/js/common/modules/@arangodb/testutils/replicated-logs-helper.js
@@ -408,8 +408,9 @@ const getReplicatedLogLeaderPlan = function (database, logId, nothrow = false) {
     throw error;
   }
   const leader = plan.currentTerm.leader.serverId;
+  const rebootId = plan.currentTerm.leader.rebootId;
   const term = plan.currentTerm.term;
-  return {leader, term};
+  return {leader, term, rebootId};
 };
 
 const getReplicatedLogLeaderTarget = function (database, logId) {


### PR DESCRIPTION
### Scope & Purpose

As it aims to test the maintenance, the `testCheckExcludedServers` is a plan-only test. This means there is no supervision involved. The test itself is simple:
1. Write a replicated log configuration to plan and wait for all server to report in current.
2. Disallow the followers from the quorum.
3. Expect the leader to report that it cannot commit.
I have seen the test failing due to high system load. When heartbeat responses are slow, the leader's reboot ID might be increased. This is unrelated to the test, but it causes it to fail.

High system load cannot be prevented. If the leader restarts, the test is doomed to fail. This PR adds the code to detect reboot ID changes and print a message, skipping the test if necessary. The decision to skip the test is a trade off between the test's reliability and reducing the number of false positives in our CI. I expect this to occur rarely.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification