### PR TITLE
BTS-1546: Fix buffer overflow in crashdump

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 v3.11.3 (XXXX-XX-XX)
 --------------------
 
+* Prevent potential buffer overflow in the crash handler.
+
 * Updated OpenSSL to 3.0.10 and OpenLDAP to 2.6.6.
 
 * Updated ArangoDB Starter to 0.17.0.

--- a/arangod/RestServer/arangod.cpp
+++ b/arangod/RestServer/arangod.cpp
@@ -69,6 +69,8 @@ static int runServer(int argc, char** argv, ArangoGlobalContext& context) {
 
     server.addReporter(
         {[&](ArangodServer::State state) {
+           CrashHandler::setState(ArangodServer::stringifyState(state));
+
            if (state == ArangodServer::State::IN_START) {
              // drop priveleges before starting features
              server.getFeature<PrivilegeFeature>().dropPrivilegesPermanently();

--- a/lib/Basics/SizeLimitedString.h
+++ b/lib/Basics/SizeLimitedString.h
@@ -113,7 +113,7 @@ class SizeLimitedString {
     static_assert(std::is_integral_v<T> || std::is_pointer_v<T>);
     // copy value into local buffer
     std::array<unsigned char, sizeof(T)> buffer;
-    memcpy(buffer.begin(), &value, sizeof(T));
+    memcpy(reinterpret_cast<void*>(buffer.data()), &value, sizeof(T));
     if constexpr (basics::isLittleEndian()) {
       std::reverse(buffer.begin(), buffer.end());
     }

--- a/lib/Basics/SizeLimitedString.h
+++ b/lib/Basics/SizeLimitedString.h
@@ -1,0 +1,181 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2023 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Jan Steemann
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include <cstring>
+#include <string_view>
+#include <type_traits>
+
+#include "Basics/Endian.h"
+#include "Basics/StringUtils.h"
+#include "Basics/debugging.h"
+
+namespace arangodb {
+
+// small utility class providing a fixed-size string.
+// the maximum length of the string is provided at compile time.
+// data can be added to the string until the fixed capacity is exceeded.
+// from that point on, all further append operations will do nothing
+// (i.e. not append to the buffer or overrun it), nor throw an exception.
+// all operations of this class are noexcept.
+template<size_t N>
+class SizeLimitedString {
+  static_assert(N > 0);
+
+ public:
+  SizeLimitedString(SizeLimitedString const&) = delete;
+  SizeLimitedString& operator=(SizeLimitedString const&) = delete;
+
+  SizeLimitedString() noexcept { clear(); }
+
+  std::string_view view() const noexcept {
+    TRI_ASSERT(_offset <= N);
+    return std::string_view(&_buffer[0], _offset);
+  }
+
+  void clear() noexcept {
+    memset(&_buffer[0], 0, sizeof(_buffer));
+    _offset = 0;
+    _full = false;
+  }
+
+  bool empty() const noexcept { return _offset == 0; }
+
+  size_t capacity() const noexcept { return N; }
+
+  size_t size() const noexcept {
+    TRI_ASSERT(N >= _offset);
+    return _offset;
+  }
+
+  void push_back(char c) noexcept {
+    if (_full) {
+      return;
+    }
+    _buffer[_offset] = c;
+    ++_offset;
+    recalculateState();
+  }
+
+  SizeLimitedString& append(std::string_view data) noexcept {
+    return append(data.data(), data.size());
+  }
+
+  SizeLimitedString& append(char const* data) noexcept {
+    return append(data, strlen(data));
+  }
+
+  SizeLimitedString& append(char const* data, size_t length) noexcept {
+    if (!_full) {
+      // append as much as is possible (potentially only a prefix)
+      length = std::min(length, remaining());
+      memcpy(_buffer + _offset, data, length);
+      _offset += length;
+      recalculateState();
+    }
+    return *this;
+  }
+
+  // append a uint64_t value as a string. will only append the value if
+  // there is enough capacity in the buffer for the maximum possible
+  // uint64_t value (which is 21 bytes long).
+  SizeLimitedString& appendUInt64(uint64_t value) noexcept {
+    if (!_full) {
+      if (basics::maxUInt64StringSize > remaining()) {
+        _full = true;
+      } else {
+        _offset += basics::StringUtils::itoa(value, _buffer + _offset);
+        recalculateState();
+      }
+    }
+    return *this;
+  }
+
+  // append a hex-encoded value.
+  // will append up to as many bytes as there is remaining space in the buffer.
+  template<typename T>
+  SizeLimitedString& appendHexValue(T value, bool stripLeadingZeros) noexcept {
+    static_assert(std::is_integral_v<T> || std::is_pointer_v<T>);
+    // copy value into local buffer
+    unsigned char buffer[sizeof(T)];
+    memcpy(buffer, &value, sizeof(T));
+
+    // stringify value. if string is already full, this may do some
+    // iterations, but not append to the buffer. we are not optimizing for
+    // this case.
+    constexpr char chars[] = "0123456789abcdef";
+    unsigned char const* e = &buffer[0] + sizeof(T);
+
+    if constexpr (basics::isLittleEndian()) {
+      while (--e >= &buffer[0]) {
+        unsigned char c = *e;
+        if (!stripLeadingZeros || (c >> 4U) != 0) {
+          push_back(chars[c >> 4U]);
+          stripLeadingZeros = false;
+        }
+        if (!stripLeadingZeros || (c & 0xfU) != 0) {
+          push_back(chars[c & 0xfU]);
+          stripLeadingZeros = false;
+        }
+      }
+      if (stripLeadingZeros) {
+        push_back('0');
+      }
+    } else {
+      unsigned char const* p = &buffer[0];
+      while (p < e) {
+        unsigned char c = *p;
+        if (!stripLeadingZeros || (c >> 4U) != 0) {
+          push_back(chars[c >> 4U]);
+          stripLeadingZeros = false;
+        }
+        if (!stripLeadingZeros || (c & 0xfU) != 0) {
+          push_back(chars[c & 0xfU]);
+          stripLeadingZeros = false;
+        }
+        ++p;
+      }
+      if (stripLeadingZeros) {
+        push_back('0');
+      }
+    }
+    return *this;
+  }
+
+ private:
+  size_t remaining() const noexcept {
+    TRI_ASSERT(N >= _offset);
+    return N - _offset;
+  }
+
+  void recalculateState() noexcept {
+    _full |= (_offset >= N);
+    TRI_ASSERT(_offset <= N);
+  }
+
+  char _buffer[N];
+  size_t _offset;
+  bool _full;
+};
+}  // namespace arangodb

--- a/lib/CrashHandler/CrashHandler.cpp
+++ b/lib/CrashHandler/CrashHandler.cpp
@@ -194,9 +194,7 @@ void buildLogMessage(SmallString& buffer, std::string_view context, int signal,
   if (info != nullptr && (signal == SIGSEGV || signal == SIGBUS)) {
     // dump address that was accessed when the failure occurred (this is
     // somewhat likely a nullptr)
-    buffer.append(" accessing address 0x");
-    auto const* x = reinterpret_cast<void const*>(info->si_addr);
-    buffer.appendHexValue(x, false);
+    buffer.append(" accessing address 0x").appendHexValue(info->si_addr, false);
   }
 #endif
 
@@ -207,9 +205,7 @@ void buildLogMessage(SmallString& buffer, std::string_view context, int signal,
     // AT_PHDR points to the program header, which is located after the ELF
     // header. This allows us to calculate the base address of the executable.
     auto baseAddr = getauxval(AT_PHDR) - sizeof(Elf64_Ehdr);
-    buffer.append(" - image base address: 0x");
-    auto const* x = reinterpret_cast<void const*>(baseAddr);
-    buffer.appendHexValue(x, false);
+    buffer.append(" - image base address: 0x").appendHexValue(baseAddr, false);
   }
 #if defined(__ARM_NEON) || defined(__ARM_NEON__)
   // FIXME: implement ARM64 context output
@@ -217,10 +213,7 @@ void buildLogMessage(SmallString& buffer, std::string_view context, int signal,
 #else
   if (auto ctx = static_cast<ucontext_t*>(ucontext); ctx) {
     auto appendRegister = [ctx, &buffer](char const* prefix, int reg) {
-      buffer.append(prefix);
-      auto const* s =
-          reinterpret_cast<greg_t const*>(&ctx->uc_mcontext.gregs[reg]);
-      buffer.appendHexValue(*s, false);
+      buffer.append(prefix).appendHexValue(ctx->uc_mcontext.gregs[reg], false);
     };
     buffer.append(" - CPU context:");
     appendRegister(" rip: 0x", REG_RIP);

--- a/lib/CrashHandler/CrashHandler.cpp
+++ b/lib/CrashHandler/CrashHandler.cpp
@@ -187,7 +187,7 @@ void buildLogMessage(SmallString& buffer, std::string_view context, int signal,
   }
 
   if (char const* ss = ::stateString.load(); ss != nullptr) {
-    buffer.append(" in state \"").append(ss).append("\" ");
+    buffer.append(" in state \"").append(ss).append("\"");
   }
 
 #ifndef _WIN32

--- a/lib/CrashHandler/CrashHandler.cpp
+++ b/lib/CrashHandler/CrashHandler.cpp
@@ -48,6 +48,7 @@
 
 #include "CrashHandler.h"
 #include "Basics/PhysicalMemory.h"
+#include "Basics/SizeLimitedString.h"
 #include "Basics/StringUtils.h"
 #include "Basics/Thread.h"
 #include "Basics/files.h"
@@ -71,6 +72,8 @@
 #endif
 
 namespace {
+
+using SmallString = arangodb::SizeLimitedString<4096>;
 
 #ifdef _WIN32
 
@@ -96,6 +99,9 @@ std::atomic<bool> enableStacktraces(true);
 /// @brief kill process hard using SIGKILL, in order to circumvent core
 /// file generation etc.
 std::atomic<bool> killHard(false);
+
+/// @brief string with server state information. must be null-terminated
+std::atomic<char const*> stateString = nullptr;
 
 /// @brief kills the process with the given signal
 [[noreturn]] void killProcess(int signal) {
@@ -139,149 +145,84 @@ std::atomic<bool> killHard(false);
   std::abort();
 }
 
-/// @brief appends null-terminated string src to dst,
-/// advances dst pointer by length of src
-void appendNullTerminatedString(std::string_view src, char*& dst) {
-  memcpy(static_cast<void*>(dst), src.data(), src.size());
-  dst += src.size();
-  *dst = '\0';
-}
-
-void appendNullTerminatedString(char const* src, size_t maxLength, char*& dst) {
-  size_t len = std::min(strlen(src), maxLength);
-  memcpy(static_cast<void*>(dst), src, len);
-  dst += len;
-  *dst = '\0';
-}
-
-/// @brief appends null-terminated hex string value to dst
-/// advances dst pointer by at most len * 2.
-/// if stripLeadingZeros is true, omits all leading zero characters.
-/// If the value is 0x0 itself, prints one zero character.
-void appendHexValue(unsigned char const* src, size_t len, char*& dst,
-                    bool stripLeadingZeros) {
-  constexpr char chars[] = "0123456789abcdef";
-  unsigned char const* e = src + len;
-  while (--e >= src) {
-    unsigned char c = *e;
-    if (!stripLeadingZeros || (c >> 4U) != 0) {
-      *dst++ = chars[c >> 4U];
-      stripLeadingZeros = false;
-    }
-    if (!stripLeadingZeros || (c & 0xfU) != 0) {
-      *dst++ = chars[c & 0xfU];
-      stripLeadingZeros = false;
-    }
-  }
-  if (stripLeadingZeros) {
-    *dst++ = '0';
-  }
-}
-
-template<typename T>
-void appendHexValue(T value, char*& dst, bool stripLeadingZeros) {
-  static_assert(std::is_integral_v<T> || std::is_pointer_v<T>);
-  unsigned char buffer[sizeof(T)];
-  memcpy(buffer, &value, sizeof(T));
-  appendHexValue(buffer, sizeof(T), dst, stripLeadingZeros);
-}
-
 #ifdef ARANGODB_HAVE_LIBUNWIND
-void appendAddress(unw_word_t pc, long base, char*& dst) {
+void appendAddress(SmallString& dst, unw_word_t pc, long base) {
   if (base == 0) {
     // absolute address of pc
-    appendNullTerminatedString(" [$0x", dst);
-    appendHexValue(reinterpret_cast<unsigned char const*>(&pc),
-                   sizeof(decltype(pc)), dst, false);
+    dst.append(" [$0x").appendHexValue(pc, false).append("] ");
   } else {
     // relative offset of pc
-    appendNullTerminatedString(" [+0x", dst);
     decltype(pc) relative = pc - base;
-    unsigned char const* s = reinterpret_cast<unsigned char const*>(&relative);
-    appendHexValue(s, sizeof(relative), dst, false);
+    dst.append(" [+0x").appendHexValue(relative, false).append("] ");
   }
-  appendNullTerminatedString("] ", dst);
 }
 #endif
 
 /// @brief builds a log message to be logged to the logfile later
 /// does not allocate any memory, so should be safe to call even
 /// in context of SIGSEGV, with a broken heap etc.
-/// Assumes that the buffer pointed to by s has enough space to
-/// hold the thread id, the thread name and the signal name
-/// (4096 bytes should be more than enough).
-size_t buildLogMessage(char* s, std::string_view context, int signal,
-                       siginfo_t const* info, void* ucontext) {
+void buildLogMessage(SmallString& buffer, std::string_view context, int signal,
+                     siginfo_t const* info, void* ucontext) {
   // build a crash message
-  char* p = s;
-  appendNullTerminatedString("💥 ArangoDB ", p);
-  appendNullTerminatedString(ARANGODB_VERSION_FULL, p);
-  appendNullTerminatedString(", thread ", p);
-  p += arangodb::basics::StringUtils::itoa(
-      uint64_t(arangodb::Thread::currentThreadNumber()), p);
+  buffer.append("💥 ArangoDB ").append(ARANGODB_VERSION_FULL);
+  buffer.append(", thread ")
+      .appendUInt64(uint64_t(arangodb::Thread::currentThreadNumber()));
 
 #ifdef __linux__
   arangodb::ThreadNameFetcher nameFetcher;
-  std::string_view name = nameFetcher.get();
-  appendNullTerminatedString(" [", p);
-  appendNullTerminatedString(name, p);
-  appendNullTerminatedString("]", p);
+  buffer.append(" [").append(nameFetcher.get()).append("]");
 #endif
 
   bool printed = false;
-  appendNullTerminatedString(" caught unexpected signal ", p);
-  p += arangodb::basics::StringUtils::itoa(uint64_t(signal), p);
-  appendNullTerminatedString(" (", p);
-  appendNullTerminatedString(arangodb::signals::name(signal), p);
+  buffer.append(" caught unexpected signal ").appendUInt64(uint64_t(signal));
+  buffer.append(" (").append(arangodb::signals::name(signal));
 #ifndef _WIN32
   if (info != nullptr) {
-    appendNullTerminatedString(") from pid ", p);
-    p += arangodb::basics::StringUtils::itoa(uint64_t(info->si_pid), p);
+    buffer.append(") from pid ").appendUInt64(uint64_t(info->si_pid));
     printed = true;
   }
 #endif
   if (!printed) {
-    appendNullTerminatedString(")", p);
+    buffer.append(")");
+  }
+
+  if (char const* ss = ::stateString.load(); ss != nullptr) {
+    buffer.append(" in state \"").append(ss).append("\" ");
   }
 
 #ifndef _WIN32
   if (info != nullptr && (signal == SIGSEGV || signal == SIGBUS)) {
     // dump address that was accessed when the failure occurred (this is
     // somewhat likely a nullptr)
-    appendNullTerminatedString(" accessing address 0x", p);
-    unsigned char const* x =
-        reinterpret_cast<unsigned char const*>(info->si_addr);
-    unsigned char const* s = reinterpret_cast<unsigned char const*>(&x);
-    appendHexValue(s, sizeof(unsigned char const*), p, false);
+    buffer.append(" accessing address 0x");
+    auto const* x = reinterpret_cast<void const*>(info->si_addr);
+    buffer.appendHexValue(x, false);
   }
 #endif
 
-  appendNullTerminatedString(": ", p);
-  appendNullTerminatedString(context, p);
+  buffer.append(": ").append(context);
 
 #ifdef __linux__
   {
     // AT_PHDR points to the program header, which is located after the ELF
     // header. This allows us to calculate the base address of the executable.
     auto baseAddr = getauxval(AT_PHDR) - sizeof(Elf64_Ehdr);
-    appendNullTerminatedString(" - image base address: 0x", p);
-    unsigned char const* x = reinterpret_cast<unsigned char const*>(baseAddr);
-    unsigned char const* s = reinterpret_cast<unsigned char const*>(&x);
-    appendHexValue(s, sizeof(unsigned char const*), p, false);
+    buffer.append(" - image base address: 0x");
+    auto const* x = reinterpret_cast<void const*>(baseAddr);
+    buffer.appendHexValue(x, false);
   }
 #if defined(__ARM_NEON) || defined(__ARM_NEON__)
   // FIXME: implement ARM64 context output
-  appendNullTerminatedString(" ARM64 CPU context: is not available ", p);
+  buffer.append(" ARM64 CPU context: is not available ");
 #else
-  auto ctx = static_cast<ucontext_t*>(ucontext);
-  if (ctx) {
-    auto appendRegister = [ctx, &p](const char* prefix, int reg) {
-      appendNullTerminatedString(prefix, p);
-      unsigned char const* s =
-          reinterpret_cast<unsigned char const*>(&ctx->uc_mcontext.gregs[reg]);
-      appendHexValue(s, sizeof(greg_t), p, false);
+  if (auto ctx = static_cast<ucontext_t*>(ucontext); ctx) {
+    auto appendRegister = [ctx, &buffer](char const* prefix, int reg) {
+      buffer.append(prefix);
+      auto const* s =
+          reinterpret_cast<greg_t const*>(&ctx->uc_mcontext.gregs[reg]);
+      buffer.appendHexValue(*s, false);
     };
-    appendNullTerminatedString(" - CPU context:", p);
+    buffer.append(" - CPU context:");
     appendRegister(" rip: 0x", REG_RIP);
     appendRegister(", rsp: 0x", REG_RSP);
     appendRegister(", efl: 0x", REG_EFL);
@@ -303,21 +244,16 @@ size_t buildLogMessage(char* s, std::string_view context, int signal,
   }
 #endif
 #endif
-
-  return p - s;
 }
 
 void logCrashInfo(std::string_view context, int signal, siginfo_t* info,
                   void* ucontext) try {
-  // buffer for constructing temporary log messages (to avoid malloc)
-  char buffer[4096];
-  memset(&buffer[0], 0, sizeof(buffer));
+  // fixed buffer for constructing temporary log messages (to avoid malloc)
+  SmallString buffer;
 
-  char* p = &buffer[0];
-  size_t length = buildLogMessage(p, context, signal, info, ucontext);
+  buildLogMessage(buffer, context, signal, info, ucontext);
   // note: LOG_TOPIC() can allocate memory
-  LOG_TOPIC("a7902", FATAL, arangodb::Logger::CRASH)
-      << std::string_view(&buffer[0], length);
+  LOG_TOPIC("a7902", FATAL, arangodb::Logger::CRASH) << buffer.view();
 } catch (...) {
   // we better not throw an exception from inside a signal handler
 }
@@ -336,23 +272,14 @@ void logBacktrace() try {
   }
 
 #ifdef ARANGODB_HAVE_LIBUNWIND
-  // buffer for constructing temporary log messages (to avoid malloc)
-  char buffer[4096];
-  memset(&buffer[0], 0, sizeof(buffer));
+  // fixed buffer for constructing temporary log messages (to avoid malloc)
+  SmallString buffer;
 
-  {
-    char* p = &buffer[0];
-    appendNullTerminatedString("Backtrace of thread ", p);
+  buffer.append("Backtrace of thread ");
+  buffer.appendUInt64(arangodb::Thread::currentThreadNumber());
+  buffer.append(" [").append(currentThreadName).append("]");
 
-    p += arangodb::basics::StringUtils::itoa(
-        uint64_t(arangodb::Thread::currentThreadNumber()), p);
-    appendNullTerminatedString(" [", p);
-    appendNullTerminatedString(currentThreadName, p);
-    appendNullTerminatedString("]", p);
-
-    LOG_TOPIC("c962b", INFO, arangodb::Logger::CRASH)
-        << std::string_view(&buffer[0], p - &buffer[0]);
-  }
+  LOG_TOPIC("c962b", INFO, arangodb::Logger::CRASH) << buffer.view();
 
   // log backtrace, of up to maxFrames depth
   {
@@ -390,31 +317,26 @@ void logBacktrace() try {
         }
 
         if (frame == maxFrames + skipFrames) {
-          memset(&buffer[0], 0, sizeof(buffer));
-          char* p = &buffer[0];
-          appendNullTerminatedString("..reached maximum frame display depth (",
-                                     p);
-          p += arangodb::basics::StringUtils::itoa(uint64_t(maxFrames), p);
-          appendNullTerminatedString("). stopping backtrace", p);
+          buffer.clear();
+          buffer.append("..reached maximum frame display depth (");
+          buffer.appendUInt64(maxFrames);
+          buffer.append("). stopping backtrace");
 
-          size_t length = p - &buffer[0];
-          LOG_TOPIC("bbb04", INFO, arangodb::Logger::CRASH)
-              << std::string_view(&buffer[0], length);
+          LOG_TOPIC("bbb04", INFO, arangodb::Logger::CRASH) << buffer.view();
           break;
         }
 
         if (frame >= skipFrames) {
           // this is a stack frame we want to display
-          memset(&buffer[0], 0, sizeof(buffer));
-          char* p = &buffer[0];
-          appendNullTerminatedString("frame ", p);
+          buffer.clear();
+          buffer.append("frame ");
           if (frame < 10) {
             // pad frame id to 2 digits length
-            *p++ = ' ';
+            buffer.push_back(' ');
           }
-          p += arangodb::basics::StringUtils::itoa(uint64_t(frame), p);
+          buffer.appendUInt64(uint64_t(frame));
 
-          appendAddress(pc, base, p);
+          appendAddress(buffer, pc, base);
 
           char mangled[512];
           memset(&mangled[0], 0, sizeof(mangled));
@@ -430,26 +352,20 @@ void logBacktrace() try {
             boost::core::scoped_demangled_name demangled(&mangled[0]);
 
             if (demangled.get()) {
-              appendNullTerminatedString(demangled.get(), p);
+              buffer.append(demangled.get());
             } else {
               // demangling has failed.
               // in this case, append mangled version. still better than nothing
-              appendNullTerminatedString(mangled, p);
+              buffer.append(mangled);
             }
             // print offset into function
-            appendNullTerminatedString(" (+0x", p);
-            appendHexValue(reinterpret_cast<unsigned char const*>(&offset),
-                           sizeof(decltype(offset)), p, true);
-            appendNullTerminatedString(")", p);
+            buffer.append(" (+0x").appendHexValue(offset, true).append(")");
           } else {
             // unable to retrieve symbol information
-            appendNullTerminatedString(
-                "*no symbol name available for this frame", p);
+            buffer.append("*no symbol name available for this frame");
           }
 
-          size_t length = p - &buffer[0];
-          LOG_TOPIC("308c3", INFO, arangodb::Logger::CRASH)
-              << std::string_view(&buffer[0], length);
+          LOG_TOPIC("308c3", INFO, arangodb::Logger::CRASH) << buffer.view();
         }
       } while (++frame < (maxFrames + skipFrames + 1) && unw_step(&cursor) > 0);
       // flush logs as early as possible
@@ -464,27 +380,20 @@ void logBacktrace() try {
 
 // log info about the current process
 void logProcessInfo() {
-  // buffer for constructing temporary log messages (to avoid malloc)
-  char buffer[4096];
-  memset(&buffer[0], 0, sizeof(buffer));
-
   auto processInfo = TRI_ProcessInfoSelf();
-  char* p = &buffer[0];
-  appendNullTerminatedString("available physical memory: ", p);
-  p += arangodb::basics::StringUtils::itoa(arangodb::PhysicalMemory::getValue(),
-                                           p);
-  appendNullTerminatedString(", rss usage: ", p);
-  p += arangodb::basics::StringUtils::itoa(uint64_t(processInfo._residentSize),
-                                           p);
-  appendNullTerminatedString(", vsz usage: ", p);
-  p += arangodb::basics::StringUtils::itoa(uint64_t(processInfo._virtualSize),
-                                           p);
-  appendNullTerminatedString(", threads: ", p);
-  p += arangodb::basics::StringUtils::itoa(uint64_t(processInfo._numberThreads),
-                                           p);
 
-  LOG_TOPIC("ded81", INFO, arangodb::Logger::CRASH)
-      << std::string_view(&buffer[0], p - &buffer[0]);
+  // fixed buffer for constructing temporary log messages (to avoid malloc)
+  SmallString buffer;
+  buffer.append("available physical memory: ")
+      .appendUInt64(uint64_t(arangodb::PhysicalMemory::getValue()));
+  buffer.append(", rss usage: ")
+      .appendUInt64(uint64_t(processInfo._residentSize));
+  buffer.append(", vsz usage: ")
+      .appendUInt64(uint64_t(processInfo._virtualSize));
+  buffer.append(", threads: ")
+      .appendUInt64(uint64_t(processInfo._numberThreads));
+
+  LOG_TOPIC("ded81", INFO, arangodb::Logger::CRASH) << buffer.view();
 }
 
 /// @brief Logs the reception of a signal to the logfile.
@@ -549,8 +458,7 @@ void createMiniDump(EXCEPTION_POINTERS* pointers) {
   // we have to serialize calls to MiniDumpWriteDump
   std::lock_guard<std::mutex> lock(miniDumpLock);
 
-  char buffer[4096];
-  memset(&buffer[0], 0, sizeof(buffer));
+  SmallString buffer;
 
   time_t rawtime;
   time(&rawtime);
@@ -567,11 +475,9 @@ void createMiniDump(EXCEPTION_POINTERS* pointers) {
                             FILE_ATTRIBUTE_NORMAL, NULL);
 
   if (hFile == INVALID_HANDLE_VALUE) {
-    char* p = &buffer[0];
-    appendNullTerminatedString("Could not open minidump file: ", p);
-    p += arangodb::basics::StringUtils::itoa(GetLastError(), p);
-    LOG_TOPIC("ba80e", WARN, arangodb::Logger::CRASH)
-        << std::string_view(&buffer[0], p - &buffer[0]);
+    buffer.append("Could not open minidump file: ");
+    buffer.appendUInt64(GetLastError());
+    LOG_TOPIC("ba80e", WARN, arangodb::Logger::CRASH) << buffer.view();
     return;
   }
 
@@ -680,6 +586,7 @@ void createMiniDump(EXCEPTION_POINTERS* pointers) {
 
   MINIDUMP_CALLBACK_INFORMATION callbackInfo{callback, &param};
 
+  buffer.clear();
   if (MiniDumpWriteDump(
           GetCurrentProcess(), GetCurrentProcessId(), hFile,
           MINIDUMP_TYPE(MiniDumpNormal | MiniDumpWithProcessThreadData |
@@ -687,17 +594,13 @@ void createMiniDump(EXCEPTION_POINTERS* pointers) {
                         MiniDumpIgnoreInaccessibleMemory),
           pointers ? &exceptionInfo : nullptr, nullptr,
           pointers ? &callbackInfo : nullptr)) {
-    char* p = &buffer[0];
-    appendNullTerminatedString("Wrote minidump: ", p);
-    appendNullTerminatedString(filename, p);
-    LOG_TOPIC("93315", INFO, arangodb::Logger::CRASH)
-        << std::string_view(&buffer[0], p - &buffer[0]);
+    buffer.append("Wrote minidump: ");
+    buffer.append(filename);
+    LOG_TOPIC("93315", INFO, arangodb::Logger::CRASH) << buffer.view();
   } else {
-    char* p = &buffer[0];
-    appendNullTerminatedString("Failed to write minidump: ", p);
-    p += arangodb::basics::StringUtils::itoa(GetLastError(), p);
-    LOG_TOPIC("af06b", WARN, arangodb::Logger::CRASH)
-        << std::string_view(&buffer[0], p - &buffer[0]);
+    buffer.append("Failed to write minidump: ");
+    buffer.appendUInt64(GetLastError());
+    LOG_TOPIC("af06b", WARN, arangodb::Logger::CRASH) << buffer.view();
   }
 
   CloseHandle(hFile);
@@ -706,19 +609,16 @@ void createMiniDump(EXCEPTION_POINTERS* pointers) {
 LONG CALLBACK unhandledExceptionFilter(EXCEPTION_POINTERS* pointers) {
   TRI_ASSERT(pointers && pointers->ExceptionRecord);
 
-  {
-    char buffer[4096];
-    memset(&buffer[0], 0, sizeof(buffer));
-    char* p = &buffer[0];
-    appendNullTerminatedString("Unhandled exception: ", p);
-    appendHexValue(pointers->ExceptionRecord->ExceptionCode, p, false);
-    appendNullTerminatedString(" at address ", p);
-    appendHexValue(pointers->ContextRecord->Rip, p, false);
-    appendNullTerminatedString(" in thread ", p);
-    appendHexValue(GetCurrentThreadId(), p, true);
-    LOG_TOPIC("87ff4", INFO, arangodb::Logger::CRASH)
-        << std::string_view(&buffer[0], p - &buffer[0]);
-  }
+  SmallString buffer;
+  buffer.append("Unhandled exception: ");
+  buffer.appendHexValue(pointers->ExceptionRecord->ExceptionCode, false);
+  buffer.append(" at address ");
+  buffer.appendHexValue(pointers->ContextRecord->Rip, false);
+  buffer.append(" in thread ");
+  buffer.appendHexValue(GetCurrentThreadId(), true);
+
+  LOG_TOPIC("87ff4", INFO, arangodb::Logger::CRASH) << buffer.view();
+
   createMiniDump(pointers);
   return EXCEPTION_CONTINUE_SEARCH;
 }
@@ -746,33 +646,32 @@ void CrashHandler::crash(std::string_view context) {
   ::killProcess(SIGABRT);
 }
 
+void CrashHandler::setState(std::string_view state) {
+  ::stateString.store(state.data());
+}
+
 /// @brief logs an assertion failure and crashes the program
 [[noreturn]] void CrashHandler::assertionFailure(char const* file, int line,
                                                  char const* func,
                                                  char const* context,
                                                  char const* message) {
   // assemble an "assertion failured in file:line: message" string
-  char buffer[4096];
-  memset(&buffer[0], 0, sizeof(buffer));
+  SmallString buffer;
 
-  char* p = &buffer[0];
-  appendNullTerminatedString("assertion failed in ", p);
-  appendNullTerminatedString((file == nullptr ? "unknown file" : file), 128, p);
-  appendNullTerminatedString(":", p);
-  p += arangodb::basics::StringUtils::itoa(uint64_t(line), p);
+  buffer.append("assertion failed in ")
+      .append(file == nullptr ? "unknown file" : file)
+      .append(":");
+  buffer.appendUInt64(uint64_t(line));
   if (func != nullptr) {
-    appendNullTerminatedString(" [", p);
-    appendNullTerminatedString(func, p);
-    appendNullTerminatedString("]", p);
+    buffer.append(" [").append(func).append("]");
   }
-  appendNullTerminatedString(": ", p);
-  appendNullTerminatedString(context, 256, p);
+  buffer.append(": ");
+  buffer.append(context);
   if (message != nullptr) {
-    appendNullTerminatedString(" ; ", p);
-    appendNullTerminatedString(message, p);
+    buffer.append(" ; ").append(message);
   }
 
-  crash(std::string_view(&buffer[0], p - &buffer[0]));
+  crash(buffer.view());
 }
 
 /// @brief set flag to kill process hard using SIGKILL, in order to circumvent
@@ -840,12 +739,7 @@ void CrashHandler::installCrashHandler() {
 
   // install handler for std::terminate()
   std::set_terminate([]() {
-    using namespace std::string_view_literals;
-
-    constexpr static auto bufferSize = 256;
-    char buffer[bufferSize];
-    memset(&buffer[0], 0, sizeof(buffer));
-    char* p = &buffer[0];
+    SmallString buffer;
 
     if (auto ex = std::current_exception()) {
       // there is an active exception going on...
@@ -853,38 +747,22 @@ void CrashHandler::installCrashHandler() {
         // rethrow so we can get the exception type and its message
         std::rethrow_exception(ex);
       } catch (std::exception const& ex) {
-        constexpr static auto msg =
-            "handler for std::terminate() invoked with an std::exception: "sv;
-        static_assert(msg.size() < bufferSize);
-        appendNullTerminatedString(msg, p);
+        buffer.append(
+            "handler for std::terminate() invoked with an std::exception: ");
         char const* e = ex.what();
         if (e != nullptr) {
-          constexpr static auto maxDynMsgSize = bufferSize - msg.size() - 1;
-          if (strlen(e) > maxDynMsgSize) {
-            constexpr static auto truncatedSuffix = " (truncated)"sv;
-            static_assert(truncatedSuffix.size() <= maxDynMsgSize);
-            constexpr static auto remainingMsgSize =
-                maxDynMsgSize - truncatedSuffix.size();
-            static_assert(remainingMsgSize > 100);
-            memcpy(p, e, remainingMsgSize);
-            p += remainingMsgSize;
-            appendNullTerminatedString(truncatedSuffix, p);
-          } else {
-            appendNullTerminatedString(e, p);
-          }
+          buffer.append(e);
         }
       } catch (...) {
-        constexpr static auto msg =
-            "handler for std::terminate() invoked with an unknown exception"sv;
-        appendNullTerminatedString(msg, p);
+        buffer.append(
+            "handler for std::terminate() invoked with an unknown exception");
       }
     } else {
-      constexpr static auto msg =
-          "handler for std::terminate() invoked without active exception"sv;
-      appendNullTerminatedString(msg, p);
+      buffer.append(
+          "handler for std::terminate() invoked without active exception");
     }
 
-    CrashHandler::crash(std::string_view(&buffer[0], p - &buffer[0]));
+    CrashHandler::crash(buffer.view());
   });
 }
 

--- a/lib/CrashHandler/CrashHandler.h
+++ b/lib/CrashHandler/CrashHandler.h
@@ -31,6 +31,11 @@ class CrashHandler {
   /// @brief log backtrace for current thread to logfile
   static void logBacktrace();
 
+  /// @brief set server state string as context for crash messages.
+  /// state string will be advanced whenever the application server
+  /// changes its state. state string must be null-terminated!
+  static void setState(std::string_view state);
+
   /// @brief logs a fatal message and crashes the program
   [[noreturn]] static void crash(std::string_view context);
 

--- a/tests/Basics/CMakeLists.txt
+++ b/tests/Basics/CMakeLists.txt
@@ -27,6 +27,7 @@ target_sources(arangodbtests
   RandomTest.cpp
   ReadWriteLockTest.cpp
   RecursiveLockerTest.cpp
+  SizeLimitedStringTest.cpp
   SpinLockTest.cpp
   StringBufferTest.cpp
   StringUtilsTest.cpp

--- a/tests/Basics/SizeLimitedStringTest.cpp
+++ b/tests/Basics/SizeLimitedStringTest.cpp
@@ -1,0 +1,289 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2020 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Jan Steemann
+////////////////////////////////////////////////////////////////////////////////
+
+#include "gtest/gtest.h"
+
+#include "Basics/SizeLimitedString.h"
+
+#include <cstddef>
+#include <string>
+#include <string_view>
+
+using namespace arangodb;
+
+TEST(SizeLimitedStringTest, test_empty) {
+  SizeLimitedString<100> testee;
+
+  EXPECT_TRUE(testee.empty());
+
+  testee.push_back('a');
+  EXPECT_FALSE(testee.empty());
+
+  testee.clear();
+  EXPECT_TRUE(testee.empty());
+
+  for (size_t i = 0; i < 100; ++i) {
+    testee.push_back('x');
+    EXPECT_FALSE(testee.empty());
+  }
+
+  testee.push_back('y');
+  EXPECT_FALSE(testee.empty());
+
+  testee.clear();
+  EXPECT_TRUE(testee.empty());
+}
+
+TEST(SizeLimitedStringTest, test_size) {
+  SizeLimitedString<100> testee;
+
+  EXPECT_EQ(0, testee.size());
+
+  testee.push_back('a');
+  EXPECT_EQ(1, testee.size());
+
+  testee.clear();
+  EXPECT_EQ(0, testee.size());
+
+  for (size_t i = 0; i < 100; ++i) {
+    EXPECT_EQ(i, testee.size());
+    testee.push_back('x');
+    EXPECT_EQ(i + 1, testee.size());
+  }
+
+  testee.push_back('y');
+  EXPECT_EQ(100, testee.size());
+
+  testee.clear();
+  EXPECT_EQ(0, testee.size());
+}
+
+TEST(SizeLimitedStringTest, test_capacity) {
+  {
+    SizeLimitedString<100> testee;
+    EXPECT_EQ(0, testee.size());
+    EXPECT_EQ(100, testee.capacity());
+  }
+
+  {
+    SizeLimitedString<1000> testee;
+    EXPECT_EQ(0, testee.size());
+    EXPECT_EQ(1000, testee.capacity());
+  }
+}
+
+TEST(SizeLimitedStringTest, test_view) {
+  SizeLimitedString<100> testee;
+
+  EXPECT_EQ(std::string_view(), testee.view());
+
+  testee.push_back('a');
+  EXPECT_EQ(std::string_view("a"), testee.view());
+
+  testee.clear();
+  EXPECT_EQ(std::string_view(), testee.view());
+
+  std::string cmp;
+  for (size_t i = 0; i < 100; ++i) {
+    testee.push_back('x');
+    cmp.push_back('x');
+
+    EXPECT_EQ(cmp, testee.view());
+    EXPECT_EQ(cmp.size(), testee.size());
+  }
+
+  testee.push_back('y');
+  EXPECT_EQ(cmp, testee.view());
+
+  testee.clear();
+  EXPECT_EQ(std::string_view(), testee.view());
+}
+
+TEST(SizeLimitedStringTest, test_append) {
+  SizeLimitedString<100> testee;
+
+  constexpr std::string_view value("the fox");
+  testee.append(value);
+  EXPECT_EQ(value, testee.view());
+  EXPECT_EQ(value.size(), testee.size());
+
+  testee.clear();
+  EXPECT_EQ(std::string_view(), testee.view());
+  EXPECT_EQ(0, testee.size());
+  EXPECT_TRUE(testee.empty());
+
+  std::string cmp;
+  for (size_t i = 0; i < 100; ++i) {
+    testee.append(value);
+    cmp.append(value);
+
+    if (cmp.size() > 100) {
+      cmp = cmp.substr(0, 100);
+    }
+    EXPECT_EQ(cmp, testee.view());
+  }
+
+  testee.clear();
+  EXPECT_EQ(std::string_view(), testee.view());
+}
+
+TEST(SizeLimitedStringTest, test_too_long_string) {
+  SizeLimitedString<10> testee;
+
+  constexpr std::string_view value("the quick brown fox jumped");
+  testee.append(value);
+  EXPECT_EQ(value.substr(0, 10), testee.view());
+  EXPECT_EQ(10, testee.size());
+}
+
+TEST(SizeLimitedStringTest, test_append_uint64) {
+  {
+    uint64_t value = 0;
+    // buffer to short for a large uint64_t value
+    SizeLimitedString<10> testee;
+    testee.appendUInt64(value);
+    EXPECT_EQ(std::string_view(""), testee.view());
+  }
+
+  {
+    uint64_t value = 0;
+    // buffer still to short for a large uint64_t value
+    SizeLimitedString<20> testee;
+    testee.appendUInt64(value);
+    EXPECT_EQ(std::string_view(""), testee.view());
+  }
+
+  {
+    uint64_t value = 0;
+    SizeLimitedString<21> testee;
+    testee.appendUInt64(value);
+    EXPECT_EQ(std::string_view("0"), testee.view());
+  }
+
+  {
+    uint64_t value = 42;
+    SizeLimitedString<21> testee;
+    testee.appendUInt64(value);
+    EXPECT_EQ(std::string_view("42"), testee.view());
+  }
+
+  {
+    uint64_t value = 12345;
+    SizeLimitedString<21> testee;
+    testee.appendUInt64(value);
+    EXPECT_EQ(std::string_view("12345"), testee.view());
+  }
+
+  {
+    uint64_t value = 123456789;
+    SizeLimitedString<21> testee;
+    testee.appendUInt64(value);
+    EXPECT_EQ(std::string_view("123456789"), testee.view());
+  }
+
+  {
+    uint64_t value = 12345678901;
+    SizeLimitedString<21> testee;
+    testee.appendUInt64(value);
+    EXPECT_EQ(std::string_view("12345678901"), testee.view());
+  }
+
+  {
+    uint64_t value = 18446744073709551615ULL;
+    SizeLimitedString<21> testee;
+    testee.appendUInt64(value);
+    EXPECT_EQ(std::string_view("18446744073709551615"), testee.view());
+  }
+}
+
+TEST(SizeLimitedStringTest, test_append_hex_value_le) {
+  {
+    uint32_t value = 0;
+    SizeLimitedString<10> testee;
+    testee.appendHexValue(value, false);
+    EXPECT_EQ(std::string_view("00000000"), testee.view());
+  }
+
+  {
+    uint32_t value = 0xdeadbeef;
+    SizeLimitedString<10> testee;
+    testee.appendHexValue(value, false);
+    EXPECT_EQ(std::string_view("deadbeef"), testee.view());
+  }
+
+  {
+    char const* value = nullptr;
+    SizeLimitedString<16> testee;
+    testee.appendHexValue(value, false);
+    EXPECT_EQ(std::string_view("0000000000000000"), testee.view());
+  }
+
+  {
+    char const* value = nullptr;
+    SizeLimitedString<16> testee;
+    testee.appendHexValue(value, true);
+    EXPECT_EQ(std::string_view("0"), testee.view());
+  }
+
+  {
+    uintptr_t value = 0xabcdef01234;
+    SizeLimitedString<16> testee;
+    testee.appendHexValue(value, false);
+    EXPECT_EQ(std::string_view("00000abcdef01234"), testee.view());
+  }
+
+  {
+    uintptr_t value = 0xabcdef01234;
+    SizeLimitedString<16> testee;
+    testee.appendHexValue(value, true);
+    EXPECT_EQ(std::string_view("abcdef01234"), testee.view());
+  }
+
+  {
+    uint64_t value = 0x0fffffffffffffffULL;
+    SizeLimitedString<16> testee;
+    testee.appendHexValue(value, false);
+    EXPECT_EQ(std::string_view("0fffffffffffffff"), testee.view());
+  }
+
+  {
+    uint64_t value = 0x0fffffffffffffffULL;
+    SizeLimitedString<16> testee;
+    testee.appendHexValue(value, true);
+    EXPECT_EQ(std::string_view("fffffffffffffff"), testee.view());
+  }
+
+  {
+    uint64_t value = 0xffffffffffffffffULL;
+    SizeLimitedString<16> testee;
+    testee.appendHexValue(value, false);
+    EXPECT_EQ(std::string_view("ffffffffffffffff"), testee.view());
+  }
+
+  {
+    uint64_t value = 0xffffffffffffffffULL;
+    SizeLimitedString<16> testee;
+    testee.appendHexValue(value, true);
+    EXPECT_EQ(std::string_view("ffffffffffffffff"), testee.view());
+  }
+}


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/19540

This fixes a buffer overflow in the crash dumper, which was observed in the wild and prevented us from getting stack traces at all.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.11: this PR
  - [x] Backport for 3.10: https://github.com/arangodb/arangodb/pull/19547
  - [ ] Backport for 3.9: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 