### PR TITLE
harden callback functions against exceptions

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,12 @@
 v3.11.3 (XXXX-XX-XX)
 --------------------
 
+* Harden HTTP/2 internal callback functions against exceptions.
+
+  These callback functions are called from C code which cannot handle
+  exceptions in any way. Instead, we now turn any exception into the return
+  code `HPE_INTERNAL` to signal that an error occurred.
+
 * Updated OpenSSL to 3.0.10 and OpenLDAP to 2.6.6.
 
 * Updated ArangoDB Starter to 0.17.0.

--- a/arangod/GeneralServer/H2CommTask.cpp
+++ b/arangod/GeneralServer/H2CommTask.cpp
@@ -43,6 +43,8 @@
 
 #include <cstring>
 
+#include <llhttp.h>
+
 // Work-around for nghttp2 non-standard definition ssize_t under windows
 // https://github.com/nghttp2/nghttp2/issues/616
 #if defined(_WIN32) && defined(_MSC_VER)
@@ -72,12 +74,12 @@ struct H2Response : public HttpResponse {
 template<SocketType T>
 /*static*/ int H2CommTask<T>::on_begin_headers(nghttp2_session* session,
                                                const nghttp2_frame* frame,
-                                               void* user_data) {
+                                               void* user_data) try {
   H2CommTask<T>* me = static_cast<H2CommTask<T>*>(user_data);
 
   if (frame->hd.type != NGHTTP2_HEADERS ||
       frame->headers.cat != NGHTTP2_HCAT_REQUEST) {
-    return 0;
+    return HPE_OK;
   }
 
   int32_t const sid = frame->hd.stream_id;
@@ -90,7 +92,11 @@ template<SocketType T>
   LOG_TOPIC("33598", TRACE, Logger::REQUESTS)
       << "<http2> creating new stream " << sid;
 
-  return 0;
+  return HPE_OK;
+} catch (...) {
+  // the caller of this function is a C function, which doesn't know
+  // exceptions. we must not let an exception escape from here.
+  return HPE_INTERNAL;
 }
 
 template<SocketType T>
@@ -98,18 +104,18 @@ template<SocketType T>
                                         const nghttp2_frame* frame,
                                         const uint8_t* name, size_t namelen,
                                         const uint8_t* value, size_t valuelen,
-                                        uint8_t flags, void* user_data) {
+                                        uint8_t flags, void* user_data) try {
   H2CommTask<T>* me = static_cast<H2CommTask<T>*>(user_data);
   int32_t const sid = frame->hd.stream_id;
 
   if (frame->hd.type != NGHTTP2_HEADERS ||
       frame->headers.cat != NGHTTP2_HCAT_REQUEST) {
-    return 0;
+    return HPE_OK;
   }
 
   Stream* strm = me->findStream(sid);
   if (!strm) {
-    return 0;
+    return HPE_OK;
   }
 
   // prevent stream headers from becoming too large
@@ -136,13 +142,17 @@ template<SocketType T>
     strm->request->setHeaderV2(std::string(field), std::string(val));
   }
 
-  return 0;
+  return HPE_OK;
+} catch (...) {
+  // the caller of this function is a C function, which doesn't know
+  // exceptions. we must not let an exception escape from here.
+  return HPE_INTERNAL;
 }
 
 template<SocketType T>
 /*static*/ int H2CommTask<T>::on_frame_recv(nghttp2_session* session,
                                             const nghttp2_frame* frame,
-                                            void* user_data) {
+                                            void* user_data) try {
   H2CommTask<T>* me = static_cast<H2CommTask<T>*>(user_data);
 
   switch (frame->hd.type) {
@@ -163,15 +173,17 @@ template<SocketType T>
     }
   }
 
-  return 0;
+  return HPE_OK;
+} catch (...) {
+  // the caller of this function is a C function, which doesn't know
+  // exceptions. we must not let an exception escape from here.
+  return HPE_INTERNAL;
 }
 
 template<SocketType T>
-/*static*/ int H2CommTask<T>::on_data_chunk_recv(nghttp2_session* session,
-                                                 uint8_t flags,
-                                                 int32_t stream_id,
-                                                 const uint8_t* data,
-                                                 size_t len, void* user_data) {
+/*static*/ int H2CommTask<T>::on_data_chunk_recv(
+    nghttp2_session* session, uint8_t flags, int32_t stream_id,
+    const uint8_t* data, size_t len, void* user_data) try {
   LOG_TOPIC("2823c", TRACE, Logger::REQUESTS)
       << "<http2> received data for stream " << stream_id;
   H2CommTask<T>* me = static_cast<H2CommTask<T>*>(user_data);
@@ -180,14 +192,18 @@ template<SocketType T>
     strm->request->body().append(data, len);
   }
 
-  return 0;
+  return HPE_OK;
+} catch (...) {
+  // the caller of this function is a C function, which doesn't know
+  // exceptions. we must not let an exception escape from here.
+  return HPE_INTERNAL;
 }
 
 template<SocketType T>
 /*static*/ int H2CommTask<T>::on_stream_close(nghttp2_session* session,
                                               int32_t stream_id,
                                               uint32_t error_code,
-                                              void* user_data) {
+                                              void* user_data) try {
   H2CommTask<T>* me = static_cast<H2CommTask<T>*>(user_data);
   auto it = me->_streams.find(stream_id);
   if (it != me->_streams.end()) {
@@ -204,7 +220,11 @@ template<SocketType T>
         << nghttp2_http2_strerror(error_code) << "' (" << error_code << ")";
   }
 
-  return 0;
+  return HPE_OK;
+} catch (...) {
+  // the caller of this function is a C function, which doesn't know
+  // exceptions. we must not let an exception escape from here.
+  return HPE_INTERNAL;
 }
 
 template<SocketType T>
@@ -212,16 +232,16 @@ template<SocketType T>
                                             const nghttp2_frame* frame,
                                             void* user_data) {
   // can be used for push promises
-  return 0;
+  return HPE_OK;
 }
 
 template<SocketType T>
 /*static*/ int H2CommTask<T>::on_frame_not_send(nghttp2_session* session,
                                                 const nghttp2_frame* frame,
                                                 int lib_error_code,
-                                                void* user_data) {
+                                                void* user_data) try {
   if (frame->hd.type != NGHTTP2_HEADERS) {
-    return 0;
+    return HPE_OK;
   }
 
   int32_t const sid = frame->hd.stream_id;
@@ -233,7 +253,11 @@ template<SocketType T>
   nghttp2_submit_rst_stream(session, NGHTTP2_FLAG_NONE, sid,
                             NGHTTP2_INTERNAL_ERROR);
 
-  return 0;
+  return HPE_OK;
+} catch (...) {
+  // the caller of this function is a C function, which doesn't know
+  // exceptions. we must not let an exception escape from here.
+  return HPE_INTERNAL;
 }
 
 template<SocketType T>
@@ -264,21 +288,29 @@ H2CommTask<T>::~H2CommTask() noexcept {
 
 namespace {
 int on_error_callback(nghttp2_session* session, int lib_error_code,
-                      const char* msg, size_t len, void*) {
+                      const char* msg, size_t len, void*) try {
   // use INFO log level, its still hidden by default
   LOG_TOPIC("bfcd0", INFO, Logger::REQUESTS)
-      << "http2 connection error: \"" << std::string(msg, len) << "\" ("
+      << "http2 connection error: \"" << std::string_view(msg, len) << "\" ("
       << lib_error_code << ")";
-  return 0;
+  return HPE_OK;
+} catch (...) {
+  // the caller of this function is a C function, which doesn't know
+  // exceptions. we must not let an exception escape from here.
+  return HPE_INTERNAL;
 }
 
 int on_invalid_frame_recv(nghttp2_session* session, const nghttp2_frame* frame,
-                          int lib_error_code, void* user_data) {
+                          int lib_error_code, void* user_data) try {
   LOG_TOPIC("b5de2", INFO, Logger::REQUESTS)
       << "received illegal data frame on stream " << frame->hd.stream_id
       << ": '" << nghttp2_strerror(lib_error_code) << "' (" << lib_error_code
       << ")";
-  return 0;
+  return HPE_OK;
+} catch (...) {
+  // the caller of this function is a C function, which doesn't know
+  // exceptions. we must not let an exception escape from here.
+  return HPE_INTERNAL;
 }
 
 constexpr uint32_t window_size = (1 << 30) - 1;  // 1 GiB

--- a/arangod/GeneralServer/H2CommTask.h
+++ b/arangod/GeneralServer/H2CommTask.h
@@ -26,9 +26,12 @@
 #include "GeneralServer/AsioSocket.h"
 #include "GeneralServer/GeneralCommTask.h"
 
-#include <boost/lockfree/queue.hpp>
+#include <atomic>
 #include <memory>
 #include <map>
+
+#include <boost/lockfree/queue.hpp>
+#include <velocypack/Buffer.h>
 
 // Work-around for nghttp2 non-standard definition ssize_t under windows
 // https://github.com/nghttp2/nghttp2/issues/616
@@ -92,7 +95,6 @@ class H2CommTask final : public GeneralCommTask<T> {
                                const nghttp2_frame* frame, int lib_error_code,
                                void* user_data);
 
- private:
   // ongoing Http2 stream
   struct Stream final {
     explicit Stream(std::unique_ptr<HttpRequest> req)


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/19554

Harden callback functions against exceptions.

These callback functions are called from C code which cannot handle exceptions in any way. Instead, we need to return HPE_INTERNAL (or whatever other error) to the C code to signal that an error occurred.

Also replaced previous occurrences of `return 0` which `return HPE_OK`. `HPE_OK` is defined to `0` in llhttp.h, and is more telling than `return 0`.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.11: this PR
  - [ ] Backport for 3.10: -
  - [ ] Backport for 3.9: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 