### PR TITLE
FE-309: Store created_at timestamp for queries in web UI.

### DIFF
--- a/js/apps/system/_admin/aardvark/APP/react/src/views/query/editor/ImportQueryModal.tsx
+++ b/js/apps/system/_admin/aardvark/APP/react/src/views/query/editor/ImportQueryModal.tsx
@@ -9,6 +9,7 @@ import {
 } from "../../../components/modal";
 import { getAardvarkRouteForCurrentDb } from "../../../utils/arangoClient";
 import { useQueryContext } from "../QueryContextProvider";
+import { QueryType } from "./useFetchUserSavedQueries";
 
 export const ImportQueryModal = ({
   isOpen,
@@ -41,8 +42,15 @@ export const ImportQueryModal = ({
       reader.onload = async () => {
         const data = reader.result;
         if (typeof data !== "string") return;
-        const queries = JSON.parse(data);
-        await onSaveQueryList(queries);
+        const queries = JSON.parse(data) as QueryType[];
+        await onSaveQueryList(
+          queries.map(query => {
+            return {
+              ...query,
+              created_at: Date.now()
+            };
+          })
+        );
         await mutate("/savedQueries");
         setIsUploading(false);
         onClose();

--- a/js/apps/system/_admin/aardvark/APP/react/src/views/query/editor/SavedQueryView.tsx
+++ b/js/apps/system/_admin/aardvark/APP/react/src/views/query/editor/SavedQueryView.tsx
@@ -150,7 +150,18 @@ const TABLE_COLUMNS = [
       filterType: "text"
     }
   }),
-  columnHelper.accessor("modified_at", {
+  columnHelper.accessor(row => row.created_at || 0, {
+    header: "Created At",
+    id: "created_at",
+    enableColumnFilter: false,
+    cell: info => {
+      const cellValue = info.cell.getValue();
+      return cellValue
+        ? momentMin(cellValue).format("YYYY-MM-DD HH:mm:ss")
+        : "-";
+    }
+  }),
+  columnHelper.accessor(row => row.modified_at || 0, {
     header: "Modified At",
     id: "modified_at",
     enableColumnFilter: false,
@@ -186,6 +197,12 @@ const SavedQueryTable = ({ savedQueries }: { savedQueries?: QueryType[] }) => {
   const tableInstance = useSortableReactTable<QueryType>({
     columns: TABLE_COLUMNS,
     data: finalData,
+    initialSorting: [
+      {
+        id: "created_at",
+        desc: true
+      }
+    ],
     initialRowSelection: {
       0: true
     },

--- a/js/apps/system/_admin/aardvark/APP/react/src/views/query/editor/useFetchUserSavedQueries.tsx
+++ b/js/apps/system/_admin/aardvark/APP/react/src/views/query/editor/useFetchUserSavedQueries.tsx
@@ -5,6 +5,7 @@ export type QueryType = {
   name: string;
   value: string;
   modified_at?: number;
+  created_at?: number;
   parameter: any;
   isTemplate?: boolean;
 };

--- a/js/apps/system/_admin/aardvark/APP/react/src/views/query/useSavedQueriesHandlers.tsx
+++ b/js/apps/system/_admin/aardvark/APP/react/src/views/query/useSavedQueriesHandlers.tsx
@@ -20,7 +20,12 @@ export const useSavedQueriesHandlers = ({
   const onSaveAs = async (queryName: string) => {
     const newQueries = [
       ...(savedQueries || []),
-      { name: queryName, value: queryValue, parameter: queryBindParams }
+      {
+        name: queryName,
+        value: queryValue,
+        parameter: queryBindParams,
+        created_at: Date.now()
+      }
     ];
     await patchQueries({
       queries: newQueries,
@@ -39,6 +44,7 @@ export const useSavedQueriesHandlers = ({
             name: queryName,
             value: queryValue,
             parameter: queryBindParams,
+            created_at: query.created_at,
             modified_at: Date.now()
           };
         }


### PR DESCRIPTION
### Scope & Purpose

This PR stores the created_at time for queries, shows it in 'saved queries' table, and sorts using that by default. Current sorting depends on the order of addition.

- [x] :pizza: New feature

### Checklist

- [x] Tests
  - [x] Manually tested
- [x] :book: CHANGELOG entry made


#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [x] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/FE-309

