### PR TITLE
BTS-1549: adjust collection access permissions

### DIFF
--- a/arangod/RestServer/VocbaseContext.cpp
+++ b/arangod/RestServer/VocbaseContext.cpp
@@ -60,9 +60,8 @@ VocbaseContext* VocbaseContext::create(GeneralRequest& req,
 
   // superusers will have an empty username. This MUST be invalid
   // for users authenticating with name / password
-  const bool isSuperUser =
-      req.authenticated() && req.user().empty() &&
-      req.authenticationMethod() == AuthenticationMethod::JWT;
+  bool isSuperUser = req.authenticated() && req.user().empty() &&
+                     req.authenticationMethod() == AuthenticationMethod::JWT;
   if (isSuperUser) {
     return new VocbaseContext(req, vocbase, ExecContext::Type::Internal,
                               /*sysLevel*/ auth::Level::RW,
@@ -94,7 +93,7 @@ VocbaseContext* VocbaseContext::create(GeneralRequest& req,
   if (req.user().empty()) {
     std::string msg = "only jwt can be used to authenticate as superuser";
     LOG_TOPIC("2d0f6", WARN, Logger::AUTHENTICATION) << msg;
-    THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_BAD_PARAMETER, msg);
+    THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_BAD_PARAMETER, std::move(msg));
   }
 
   auth::UserManager* um = auth->userManager();

--- a/arangod/RestServer/VocbaseContext.h
+++ b/arangod/RestServer/VocbaseContext.h
@@ -35,7 +35,7 @@ namespace arangodb {
 /// @brief just also stores the context
 class VocbaseContext final : public arangodb::ExecContext {
  public:
-  virtual ~VocbaseContext();
+  ~VocbaseContext();
 
   static VocbaseContext* create(GeneralRequest& req, TRI_vocbase_t& vocbase);
   TEST_VIRTUAL TRI_vocbase_t& vocbase() const { return _vocbase; }
@@ -47,15 +47,15 @@ class VocbaseContext final : public arangodb::ExecContext {
   void forceReadOnly();
 
 #ifdef USE_ENTERPRISE
-  virtual std::string clientAddress() const override {
+  std::string clientAddress() const override {
     return _request.connectionInfo().fullClient();
   }
-  virtual std::string requestUrl() const override { return _request.fullUrl(); }
-  virtual std::string authMethod() const override;
+  std::string requestUrl() const override { return _request.fullUrl(); }
+  std::string authMethod() const override;
 #endif
 
   /// @brief tells you if this execution was canceled
-  virtual bool isCanceled() const override {
+  bool isCanceled() const override {
     return _canceled.load(std::memory_order_relaxed);
   }
 

--- a/arangod/RocksDBEngine/RocksDBDumpManager.cpp
+++ b/arangod/RocksDBEngine/RocksDBDumpManager.cpp
@@ -39,7 +39,7 @@ using namespace arangodb;
 RocksDBDumpManager::RocksDBDumpManager(RocksDBEngine& engine)
     : _engine(engine) {}
 
-RocksDBDumpManager::~RocksDBDumpManager() { _contexts.clear(); }
+RocksDBDumpManager::~RocksDBDumpManager() = default;
 
 std::shared_ptr<RocksDBDumpContext> RocksDBDumpManager::createContext(
     RocksDBDumpContextOptions opts, std::string const& user,

--- a/arangod/Utils/CollectionNameResolver.cpp
+++ b/arangod/Utils/CollectionNameResolver.cpp
@@ -29,9 +29,9 @@
 #include "Basics/ReadLocker.h"
 #include "Basics/StringUtils.h"
 #include "Basics/WriteLocker.h"
-#include "Logger/LogMacros.h"
 #include "Cluster/ClusterFeature.h"
 #include "Cluster/ClusterInfo.h"
+#include "Logger/LogMacros.h"
 #include "VocBase/LogicalCollection.h"
 #include "VocBase/LogicalView.h"
 #include "VocBase/vocbase.h"
@@ -42,6 +42,9 @@ constexpr std::string_view kUnknown = "_unknown";
 
 }  // namespace
 namespace arangodb {
+
+CollectionNameResolver::CollectionNameResolver(TRI_vocbase_t& vocbase)
+    : _vocbase(vocbase), _serverRole(ServerState::instance()->getRole()) {}
 
 #if defined(__GNUC__)
 #pragma GCC diagnostic push

--- a/arangod/Utils/CollectionNameResolver.h
+++ b/arangod/Utils/CollectionNameResolver.h
@@ -23,7 +23,6 @@
 
 #pragma once
 
-#include "Basics/ReadWriteLock.h"
 #include "Cluster/ServerState.h"
 #include "Containers/FlatHashMap.h"
 #include "VocBase/Identifiers/DataSourceId.h"
@@ -31,13 +30,11 @@
 
 #include <shared_mutex>
 
-enum TRI_col_type_e : uint32_t;
-
 namespace arangodb {
 
 class LogicalCollection;
 class LogicalDataSource;
-class LogicalView;  // forward declaration
+class LogicalView;
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief data-source id/name resolver and cache (single-server and cluster)
@@ -45,11 +42,8 @@ class LogicalView;  // forward declaration
 ////////////////////////////////////////////////////////////////////////////////
 class CollectionNameResolver {
  public:
-  //////////////////////////////////////////////////////////////////////////////
-  /// @brief create the resolver
-  //////////////////////////////////////////////////////////////////////////////
-  explicit CollectionNameResolver(TRI_vocbase_t& vocbase)
-      : _vocbase(vocbase), _serverRole(ServerState::instance()->getRole()) {}
+  explicit CollectionNameResolver(TRI_vocbase_t& vocbase);
+  ~CollectionNameResolver() = default;
 
   // copy an existing resolver
   CollectionNameResolver(CollectionNameResolver const& other);
@@ -59,11 +53,6 @@ class CollectionNameResolver {
       delete;
   CollectionNameResolver(CollectionNameResolver&& other) = delete;
   CollectionNameResolver& operator=(CollectionNameResolver&& other) = delete;
-
-  //////////////////////////////////////////////////////////////////////////////
-  /// @brief destroy the resolver
-  //////////////////////////////////////////////////////////////////////////////
-  ~CollectionNameResolver() = default;
 
   //////////////////////////////////////////////////////////////////////////////
   /// @brief look up a collection struct for a collection id
@@ -161,7 +150,7 @@ class CollectionNameResolver {
   //////////////////////////////////////////////////////////////////////////////
   /// @brief the vocbase instance this resolver instance uses
   //////////////////////////////////////////////////////////////////////////////
-  TRI_vocbase_t& vocbase() const { return _vocbase; }
+  TRI_vocbase_t& vocbase() const noexcept { return _vocbase; }
 
   //////////////////////////////////////////////////////////////////////////////
   /// @brief invoke visitor on all collections that map to the specified 'id'

--- a/client-tools/Dump/DumpFeature.cpp
+++ b/client-tools/Dump/DumpFeature.cpp
@@ -71,7 +71,7 @@ constexpr uint64_t MinChunkSize = 1024 * 128;
 constexpr uint64_t MaxChunkSize = 1024 * 1024 * 96;
 
 /// @brief generic error for if server returns bad/unexpected json
-const arangodb::Result ErrorMalformedJsonResponse = {
+arangodb::Result const ErrorMalformedJsonResponse = {
     TRI_ERROR_INTERNAL, "got malformed JSON response from server"};
 
 /// @brief checks that a file pointer is valid and file status is ok
@@ -985,7 +985,7 @@ Result DumpFeature::runDump(httpclient::SimpleHttpClient& client,
   } catch (...) {
     return ::ErrorMalformedJsonResponse;
   }
-  VPackSlice const body = parsedBody->slice();
+  VPackSlice body = parsedBody->slice();
   if (!body.isObject()) {
     return ::ErrorMalformedJsonResponse;
   }
@@ -1023,7 +1023,7 @@ Result DumpFeature::runDump(httpclient::SimpleHttpClient& client,
   }
 
   // parse collections array
-  VPackSlice const collections = body.get("collections");
+  VPackSlice collections = body.get("collections");
   if (!collections.isArray()) {
     return ::ErrorMalformedJsonResponse;
   }
@@ -1051,12 +1051,6 @@ Result DumpFeature::runDump(httpclient::SimpleHttpClient& client,
   // create a lookup table for collections
   std::map<std::string, arangodb::velocypack::Slice> restrictList;
   for (auto const& name : _options.collections) {
-    if (name.starts_with('_')) {
-      // if the user explictly asked for dumping certain collections, toggle the
-      // system collection flag automatically
-      _options.includeSystemCollections = true;
-    }
-
     restrictList.emplace(name, arangodb::velocypack::Slice::noneSlice());
   }
   // restrictList now contains all collections the user has requested (can be
@@ -1068,7 +1062,7 @@ Result DumpFeature::runDump(httpclient::SimpleHttpClient& client,
     if (!collection.isObject()) {
       return ::ErrorMalformedJsonResponse;
     }
-    VPackSlice const parameters = collection.get("parameters");
+    VPackSlice parameters = collection.get("parameters");
 
     if (!parameters.isObject()) {
       return ::ErrorMalformedJsonResponse;
@@ -1089,12 +1083,12 @@ Result DumpFeature::runDump(httpclient::SimpleHttpClient& client,
       continue;
     }
     if (name.starts_with('_') && !_options.includeSystemCollections) {
+      // exclude system collections
       continue;
     }
 
     // filter by specified names
-    if (!_options.collections.empty() &&
-        restrictList.find(name) == restrictList.end()) {
+    if (!_options.collections.empty() && !restrictList.contains(name)) {
       // collection name not in list
       continue;
     }
@@ -1432,6 +1426,12 @@ void DumpFeature::start() {
       }
 
       try {
+        // if any of the specified collections is a system collection, we
+        // auto-enable --include-system-collections for the user
+        _options.includeSystemCollections |= std::any_of(
+            _options.collections.begin(), _options.collections.end(),
+            [&](auto const& name) { return name.starts_with('_'); });
+
         if (_options.clusterMode) {
           res = runClusterDump(*httpClient, db);
         } else {
@@ -1831,6 +1831,10 @@ DumpFeature::DumpFileProvider::DumpFileProvider(
     // to create a file for each collection, even if it is empty. Otherwise,
     // arangorestore complains.
     for (auto const& [name, info] : collectionInfo) {
+      if (info.isNone()) {
+        // collection name present in dump
+        continue;
+      }
       std::string const hexString(arangodb::rest::SslInterface::sslMD5(name));
       std::string escapedName =
           escapedCollectionName(name, info.get("parameters"));

--- a/lib/Rest/RequestContext.h
+++ b/lib/Rest/RequestContext.h
@@ -25,11 +25,11 @@
 
 namespace arangodb {
 class RequestContext {
-  RequestContext(const RequestContext&) = delete;
-  RequestContext& operator=(const RequestContext&) = delete;
+  RequestContext(RequestContext const&) = delete;
+  RequestContext& operator=(RequestContext const&) = delete;
 
  public:
-  RequestContext() {}
+  RequestContext() = default;
   virtual ~RequestContext() = default;
 };
 }  // namespace arangodb

--- a/tests/js/client/shell/shell-dump-integration.js
+++ b/tests/js/client/shell/shell-dump-integration.js
@@ -2,9 +2,6 @@
 /* global fail, assertTrue, assertFalse, assertEqual, assertNotEqual, arango */
 
 // //////////////////////////////////////////////////////////////////////////////
-// / @brief ArangoTransaction sTests
-// /
-// /
 // / DISCLAIMER
 // /
 // / Copyright 2018 ArangoDB GmbH, Cologne, Germany
@@ -192,7 +189,7 @@ function dumpIntegrationSuite() {
     } else {
       if (readable) {
         files.forEach((f) => {
-          data = data.concat(fs.readGzip(fs.join(path, f)).toString().trim().split('\n'));
+          data = data.concat(fs.readFileSync(fs.join(path, f)).toString().trim().split('\n'));
         });
         checkFn(data, envelopes);
       } else {
@@ -247,8 +244,16 @@ function dumpIntegrationSuite() {
       escapedName = cn;
     }
     return checkDataFileInternal(tree, path, /*split*/ false, compressed, envelopes, readable, cn, escapedName, function (data, envelopes) {
-      assertEqual(1000, data.length);
+      if (cn.startsWith('_')) {
+        // system collection
+        assertTrue(data.length > 0);
+      } else {
+        assertEqual(1000, data.length);
+      }
       data.forEach(function (line) {
+        if (line.trim() === '') {
+          return;
+        }
         line = JSON.parse(line);
         if (envelopes) {
           assertEqual(2300, line.type);
@@ -343,13 +348,21 @@ function dumpIntegrationSuite() {
       });
     },
     
+    setUp: function () {
+      db._useDatabase("_system");
+    },
+    
+    tearDown: function () {
+      db._useDatabase("_system");
+    },
+    
     testNonExperimentalDump: function () {
       let path = fs.getTempFile();
       let args = ['--collection', cn, '--compress-output', 'false', '--use-experimental-dump', 'false'];
       let tree = runDump(path, args, 0);
       checkEncryption(tree, path, "none");
       checkStructureFile(tree, path, true, cn);
-      checkDataFile(tree, path, /*split*/ false, false, false, false, cn);
+      checkDataFile(tree, path, /*split*/ false, false, false, true, cn);
       fs.removeDirectoryRecursive(path, true);
     },
     
@@ -375,7 +388,7 @@ function dumpIntegrationSuite() {
       let tree = runDump(path, args, 0);
       checkEncryption(tree, path, "none");
       checkStructureFile(tree, path, true, cn);
-      checkDataFile(tree, path, /*split*/ false, false, false, false, cn);
+      checkDataFile(tree, path, /*split*/ false, false, false, true, cn);
       fs.removeDirectoryRecursive(path, true);
     },
     
@@ -396,7 +409,7 @@ function dumpIntegrationSuite() {
       checkEncryption(tree, path, "none");
       checkStructureFile(tree, path, true, cn);
       // experimental dump and thus splitting are not supported in single server
-      checkDataFile(tree, path, /*split*/ false, false, false, false, cn);
+      checkDataFile(tree, path, /*split*/ false, false, false, true, cn);
       fs.removeDirectoryRecursive(path, true);
     },
     
@@ -409,7 +422,37 @@ function dumpIntegrationSuite() {
       let tree = runDump(path, args, 0);
       checkEncryption(tree, path, "none");
       checkStructureFile(tree, path, true, cn);
-      checkDataFile(tree, path, /*split*/ true, false, false, false, cn);
+      checkDataFile(tree, path, /*split*/ true, false, false, true, cn);
+      fs.removeDirectoryRecursive(path, true);
+    },
+    
+    testExperimentalDumpIncludeSystemCollections: function () {
+      if (!isCluster) {
+        return;
+      }
+      let path = fs.getTempFile();
+      let args = ['--compress-output', 'false', '--use-experimental-dump', 'true', '--include-system-collections', 'true'];
+      let tree = runDump(path, args, 0);
+      checkEncryption(tree, path, "none");
+      checkStructureFile(tree, path, true, cn);
+      checkStructureFile(tree, path, true, "_apps");
+      checkDataFile(tree, path, /*split*/ false, false, false, true, cn);
+      checkDataFile(tree, path, /*split*/ false, false, false, true, "_apps");
+      fs.removeDirectoryRecursive(path, true);
+    },
+    
+    testExperimentalDumpUsersCollection: function () {
+      if (!isCluster) {
+        return;
+      }
+      let path = fs.getTempFile();
+      let args = ['--collection', cn, '--compress-output', 'false', '--use-experimental-dump', 'true', '--collection', '_users'];
+      let tree = runDump(path, args, 0);
+      checkEncryption(tree, path, "none");
+      checkStructureFile(tree, path, true, cn);
+      checkStructureFile(tree, path, true, "_users");
+      checkDataFile(tree, path, /*split*/ false, false, false, true, cn);
+      checkDataFile(tree, path, /*split*/ false, false, false, true, "_users");
       fs.removeDirectoryRecursive(path, true);
     },
 
@@ -419,7 +462,7 @@ function dumpIntegrationSuite() {
       let tree = runDump(path, args, 0);
       checkEncryption(tree, path, "none");
       checkStructureFile(tree, path, true, cn + "WithSchema");
-      checkDataFile(tree, path, /*split*/ false, false, false, false, cn + "WithSchema");
+      checkDataFile(tree, path, /*split*/ false, false, false, true, cn + "WithSchema");
       fs.removeDirectoryRecursive(path, true);
     },
 


### PR DESCRIPTION
### Scope & Purpose

https://arangodb.atlassian.net/browse/BTS-1549

BTS-1549: adjust collection access permissions for experimental dump so that they behave as in non-experimental dump

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.11: https://github.com/arangodb/arangodb/pull/19563
  - [x] Backport for 3.10: https://github.com/arangodb/arangodb/pull/19564
  - [ ] Backport for 3.9: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [x] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/BTS-1549
- [ ] Design document: 