### PR TITLE
Disable missing-field-initializers warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -867,6 +867,8 @@ function(add_compile_warnings_flags)
       if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
         # This option has too many false positives
         add_compile_options(-Wno-error=maybe-uninitialized)
+        # This prevents useful partial initializations
+        add_compile_options(-Wno-missing-field-initializers)
       endif()
     endif ()
   endif ()

--- a/tests/Replication2/CMakeLists.txt
+++ b/tests/Replication2/CMakeLists.txt
@@ -48,11 +48,6 @@ add_library(arango_tests_replication2 OBJECT
   ${ARANGODB_REPLICATION2_TEST_HELPER_SOURCES}
   )
 
-if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-    # turn off annoying warning in test files
-    target_compile_options(arango_tests_replication2 PRIVATE -Wno-missing-field-initializers)
-endif ()
-
 target_include_directories(arango_tests_replication2 PUBLIC
   ${PROJECT_SOURCE_DIR}/arangod
   ${PROJECT_SOURCE_DIR}/lib

--- a/tests/Replication2/ReplicatedLog/Components/SnapshotManagerTest.cpp
+++ b/tests/Replication2/ReplicatedLog/Components/SnapshotManagerTest.cpp
@@ -37,11 +37,6 @@
 #include "Replication2/Mocks/StateHandleManagerMock.h"
 #include "Replication2/Mocks/StorageManagerMock.h"
 
-#if defined(__GNUC__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmissing-field-initializers"
-#endif
-
 using namespace arangodb;
 using namespace arangodb::replication2;
 using namespace arangodb::replication2::test;


### PR DESCRIPTION
### Scope & Purpose

Disable warning for missing field initializers. It prevents using them partially, which can be useful and convenient.