### PR TITLE
Make Pregel work on OneShard databases without issues

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 devel
 -----
 
+* Fix Pregel running on OneShard deployments
+
 * BTS-1544: The _system database now properly reports its sharding value.
 
 * Fixed AQL WINDOW statement for OneShard databases: Whenever WINDOW is used

--- a/arangod/Pregel/GraphStore/GraphSerdeConfigBuilderCluster.cpp
+++ b/arangod/Pregel/GraphStore/GraphSerdeConfigBuilderCluster.cpp
@@ -72,8 +72,11 @@ GraphSerdeConfigBuilderCluster::GraphSerdeConfigBuilderCluster(
       if (!coll->isSmart()) {
         std::vector<std::string> eKeys = coll->shardKeys();
 
-        if (eKeys.size() != 1 ||
-            eKeys[0] != graphByCollections.shardKeyAttribute) {
+        // In a OneShard database sharding is acceptable
+        // for pregel by default.
+        if (!vocbase.isOneShard() &&
+            (eKeys.size() != 1 ||
+             eKeys[0] != graphByCollections.shardKeyAttribute)) {
           return Result{
               TRI_ERROR_BAD_PARAMETER,
               "Edge collection needs to be sharded "

--- a/arangod/Pregel/PregelFeature.cpp
+++ b/arangod/Pregel/PregelFeature.cpp
@@ -205,7 +205,7 @@ ResultT<ExecutionNumber> PregelFeature::startExecution(TRI_vocbase_t& vocbase,
   auto maybeGraphSerdeConfig =
       buildGraphSerdeConfig(vocbase, graphByCollections);
   if (!maybeGraphSerdeConfig.ok()) {
-    return maybeGraphByCollections.error();
+    return maybeGraphSerdeConfig.error();
   }
   auto graphSerdeConfig = maybeGraphSerdeConfig.get();
 


### PR DESCRIPTION
### Scope & Purpose

Pregel can work without issues on a OneShard database, so don't error out in that case.

Enterprise part with a test: https://github.com/arangodb/enterprise/pull/1350
