### PR TITLE
Fix bug with index in iterator and count aggregation [BTS-1554]

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,7 @@
 v3.11.3 (XXXX-XX-XX)
 --------------------
 
-* Fix BTS-1554: wrong aggregation count when an "in" or "or" condition
+* Fixed BTS-1554: wrong aggregation count when an "in" or "or" condition
   was executed through an index lookup.
 
 * Updated arangosync to v2.19.3.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 v3.11.3 (XXXX-XX-XX)
 --------------------
 
+* Fix BTS-1554: wrong aggregation count when an "in" or "or" condition
+  was executed through an index lookup.
+
 * Updated arangosync to v2.19.3.
 
 * Harden HTTP/2 internal callback functions against exceptions.

--- a/arangod/Indexes/IndexIterator.cpp
+++ b/arangod/Indexes/IndexIterator.cpp
@@ -140,15 +140,6 @@ void IndexIterator::skipImpl(uint64_t count, uint64_t& skipped) {
   // is more to get"! In this case, we need to check, if we have already
   // skipped the requested count, and if not, try again (with a potentially
   // reduced count):
-#if 0
-  nextImpl(
-      [&skipped](LocalDocumentId const&) {
-        ++skipped;
-        return true;
-      },
-      count);
-#endif
-#if 1
   uint64_t skippedInitial = skipped;
   do {
     TRI_ASSERT(skipped >= skippedInitial && skipped - skippedInitial <= count);
@@ -161,5 +152,4 @@ void IndexIterator::skipImpl(uint64_t count, uint64_t& skipped) {
       return;
     }
   } while (skipped - skippedInitial < count);
-#endif
 }

--- a/arangod/Indexes/IndexIterator.cpp
+++ b/arangod/Indexes/IndexIterator.cpp
@@ -151,7 +151,7 @@ void IndexIterator::skipImpl(uint64_t count, uint64_t& skipped) {
 #if 1
   uint64_t skippedInitial = skipped;
   do {
-    // Invariant: skipped-skippedInitial <= count
+    TRI_ASSERT(skipped >= skippedInitial && skipped - skippedInitial <= count);
     if (!nextImpl(
             [&skipped](LocalDocumentId const&) {
               ++skipped;

--- a/tests/js/server/aql/aql-index-or-aggregation.js
+++ b/tests/js/server/aql/aql-index-or-aggregation.js
@@ -86,6 +86,37 @@ function VPackIndexInAggregationSuite (unique) {
       assertEqual(2, results[0]);
     },
     
+    testVPackAggregateBySingleAttributeUsingInAndLimit22: function () {
+      for (i = 2; i <= 4; ++i) {
+        const q = `FOR doc IN ${cn} FILTER doc.value1 in ["000","001","002","003", "004"] LIMIT 2, ${i} RETURN doc`;
+
+        let nodes = AQL_EXPLAIN(q).plan.nodes;
+        let indexNodes = nodes.filter((node) => node.type === 'IndexNode');
+        assertEqual(1, indexNodes.length);
+        assertEqual(1, indexNodes[0].indexes.length);
+        assertEqual("UnitTestsIndex", indexNodes[0].indexes[0].name);
+
+        let qr = db._query(q);
+        let results = qr.toArray();
+        assertEqual(Math.min(i, 3), results.length);
+      }
+    },
+    
+    testVPackAggregateBySingleAttributeUsingOrAndLimit22: function () {
+      for (i = 2; i <= 4; ++i) {
+        const q = `FOR doc IN ${cn} FILTER doc.value1 == "000" || doc.value1 == "001" || doc.value1 == "002" || doc.value1 == "003" || doc.value1 == "004" LIMIT 2, 2 RETURN doc`;
+
+        let nodes = AQL_EXPLAIN(q).plan.nodes;
+        let indexNodes = nodes.filter((node) => node.type === 'IndexNode');
+        assertEqual(1, indexNodes.length);
+        assertEqual(1, indexNodes[0].indexes.length);
+        assertEqual("UnitTestsIndex", indexNodes[0].indexes[0].name);
+
+        let qr = db._query(q);
+        let results = qr.toArray();
+        assertEqual(Math.min(2, i), results.length);
+      }
+    },
   };
 }
 

--- a/tests/js/server/aql/aql-index-or-aggregation.js
+++ b/tests/js/server/aql/aql-index-or-aggregation.js
@@ -1,0 +1,95 @@
+/*jshint globalstrict:true, strict:true, esnext: true */
+/*global AQL_EXPLAIN, assertEqual, assertFalse */
+
+"use strict";
+
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2023 ArangoDB GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Max Neunhoeffer
+////////////////////////////////////////////////////////////////////////////////
+
+const db = require('@arangodb').db;
+const jsunity = require("jsunity");
+const { deriveTestSuite } = require('@arangodb/test-helper');
+
+function VPackIndexInAggregationSuite (unique) {
+  const cn = "UnitTestsCollection";
+  const n = 10;
+
+  return {
+    setUpAll : function () {
+      db._drop(cn);
+      let c = db._create(cn);
+
+      let docs = [];
+      for (let i = 0; i < n; ++i) {
+        docs.push({ value1: String(i).padStart(3, "0") });
+      }
+      c.insert(docs);
+      c.ensureIndex({ type: "persistent", fields: ["value1"], name: "UnitTestsIndex", unique });
+    },
+    
+    tearDownAll : function () {
+      db._drop(cn);
+    },
+    
+    testVPackAggregateBySingleAttributeUsingIn: function () {
+      for (let i = 1; i < 3; i += 1) {
+        const values = [];
+        for (let j = 0; j < i; ++j) {
+          values.push(String(j).padStart(3, "0"));
+        }
+        const q = `LET values = @values FOR doc IN ${cn} FILTER doc.value1 IN values COLLECT WITH COUNT INTO count RETURN count`;
+
+        const opts = {};
+
+        let nodes = AQL_EXPLAIN(q, {values}, opts).plan.nodes;
+        let indexNodes = nodes.filter((node) => node.type === 'IndexNode');
+        assertEqual(1, indexNodes.length);
+        assertEqual(1, indexNodes[0].indexes.length);
+        assertEqual("UnitTestsIndex", indexNodes[0].indexes[0].name);
+
+        let qr = db._query(q, {values}, opts);
+        let results = qr.toArray();
+        assertEqual(i, results[0]);
+      }
+    },
+    
+  };
+}
+
+function VPackIndexInUniqueSuite() {
+  'use strict';
+  let suite = {};
+  deriveTestSuite(VPackIndexInAggregationSuite(/*unique*/ true), suite, '_in_unique');
+  return suite;
+}
+
+function VPackIndexInNonUniqueSuite() {
+  'use strict';
+  let suite = {};
+  deriveTestSuite(VPackIndexInAggregationSuite(/*unique*/ false), suite, '_in_nonUnique');
+  return suite;
+}
+
+jsunity.run(VPackIndexInUniqueSuite);
+jsunity.run(VPackIndexInNonUniqueSuite);
+
+return jsunity.done();

--- a/tests/js/server/aql/aql-index-or-aggregation.js
+++ b/tests/js/server/aql/aql-index-or-aggregation.js
@@ -87,7 +87,7 @@ function VPackIndexInAggregationSuite (unique) {
     },
     
     testVPackAggregateBySingleAttributeUsingInAndLimit22: function () {
-      for (i = 2; i <= 4; ++i) {
+      for (let i = 2; i <= 4; ++i) {
         const q = `FOR doc IN ${cn} FILTER doc.value1 in ["000","001","002","003", "004"] LIMIT 2, ${i} RETURN doc`;
 
         let nodes = AQL_EXPLAIN(q).plan.nodes;
@@ -103,7 +103,7 @@ function VPackIndexInAggregationSuite (unique) {
     },
     
     testVPackAggregateBySingleAttributeUsingOrAndLimit22: function () {
-      for (i = 2; i <= 4; ++i) {
+      for (let i = 2; i <= 4; ++i) {
         const q = `FOR doc IN ${cn} FILTER doc.value1 == "000" || doc.value1 == "001" || doc.value1 == "002" || doc.value1 == "003" || doc.value1 == "004" LIMIT 2, 2 RETURN doc`;
 
         let nodes = AQL_EXPLAIN(q).plan.nodes;

--- a/tests/js/server/aql/aql-index-or-aggregation.js
+++ b/tests/js/server/aql/aql-index-or-aggregation.js
@@ -51,7 +51,7 @@ function VPackIndexInAggregationSuite (unique) {
     },
     
     testVPackAggregateBySingleAttributeUsingIn: function () {
-      for (let i = 1; i < 3; i += 1) {
+      for (let i = 1; i < 4; i += 1) {
         const values = [];
         for (let j = 0; j < i; ++j) {
           values.push(String(j).padStart(3, "0"));
@@ -70,6 +70,20 @@ function VPackIndexInAggregationSuite (unique) {
         let results = qr.toArray();
         assertEqual(i, results[0]);
       }
+    },
+    
+    testVPackAggregateBySingleAttributeUsingOr: function () {
+      const q = `FOR doc IN ${cn} FILTER doc.value1 == "000" OR doc.value1 == "001" COLLECT WITH COUNT INTO count RETURN count`;
+
+      let nodes = AQL_EXPLAIN(q).plan.nodes;
+      let indexNodes = nodes.filter((node) => node.type === 'IndexNode');
+      assertEqual(1, indexNodes.length);
+      assertEqual(1, indexNodes[0].indexes.length);
+      assertEqual("UnitTestsIndex", indexNodes[0].indexes[0].name);
+
+      let qr = db._query(q);
+      let results = qr.toArray();
+      assertEqual(2, results[0]);
     },
     
   };


### PR DESCRIPTION
### Scope & Purpose

This addresses https://arangodb.atlassian.net/browse/BTS-1554
See description there.

Original PR for devel: https://github.com/arangodb/arangodb/pull/19571

- [*] :hankey: Bugfix

The bad behaviour comes from the fact that the generic 
IndexIterator::skipImpl which uses the `nextImpl` method
does not look at the return value of `nextImpl` and forgets
to loop to indeed skip as much as required.

### Checklist

- [*] Tests
  - [*] **Regression tests**
- [*] :book: CHANGELOG entry made
- [*] Backports
  - [*] Backport for 3.11: This is the backport for 3.11

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [*] Jira ticket: https://arangodb.atlassian.net/browse/BTS-1554
- [*] Jira ticket: https://arangodb.atlassian.net/browse/MDS-1147

