### PR TITLE
[3.11][Test_only] Add another test for backwards compatibility on SmartJoins

### DIFF
--- a/tests/js/common/shell/shell-collection-api.js
+++ b/tests/js/common/shell/shell-collection-api.js
@@ -723,7 +723,7 @@ function CreateCollectionsSuite() {
             validatePropertiesDoNotExist(collname, ["smartJoinAttribute"]);
           } else {
             assertTrue(res.result, `Result: ${JSON.stringify(res)}`);
-            validateProperties({smartJoinAttribute: "test", numberOfShards: 3, shardKeys: ["_key:"], numberOfShards: 3}, collname, 2);
+            validateProperties({smartJoinAttribute: "test", numberOfShards: 3, shardKeys: ["_key:"]}, collname, 2);
           }
         }
       } finally {

--- a/tests/js/common/shell/shell-collection-api.js
+++ b/tests/js/common/shell/shell-collection-api.js
@@ -708,6 +708,29 @@ function CreateCollectionsSuite() {
       }
     },
 
+    testSmartJoinPrefixShardKey: function () {
+      const res = tryCreate({name: collname, smartJoinAttribute: "test", numberOfShards: 3, shardKeys: ["_key:"]});
+      try {
+        if (!isEnterprise) {
+          assertTrue(res.result, `Result: ${JSON.stringify(res)}`);
+          validateProperties({shardKeys: ["_key:"], numberOfShards: 3}, collname, 2);
+          validatePropertiesDoNotExist(collname, ["smartJoinAttribute"]);
+          validateDeprecationLogEntryWritten();
+        } else {
+          if (!isCluster) {
+            assertTrue(res.result, `Result: ${JSON.stringify(res)}`);
+            validateProperties({}, collname, 2);
+            validatePropertiesDoNotExist(collname, ["smartJoinAttribute"]);
+          } else {
+            assertTrue(res.result, `Result: ${JSON.stringify(res)}`);
+            validateProperties({smartJoinAttribute: "test", numberOfShards: 3, shardKeys: ["_key:"], numberOfShards: 3}, collname, 2);
+          }
+        }
+      } finally {
+        db._drop(collname);
+      }
+    },
+
     testSmartJoinCorrect: function () {
       const leader = tryCreate({name: leaderName, numberOfShards: 3});
       try {


### PR DESCRIPTION
### Scope & Purpose
**No production impact**
*This PR only adds a test for the existing API. We detected a backwards incompatibly change moving from 3.11 to devel on this specific test. So we add this test in 3.11 as well. to make sure API in 3.11 stays identical.*

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [x] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*
  - [ ] Backport for 3.9: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

