### PR TITLE
Fixed a backwards incompatible change on SmartJoins

### DIFF
--- a/tests/js/common/shell/shell-collection-api.js
+++ b/tests/js/common/shell/shell-collection-api.js
@@ -724,6 +724,29 @@ function CreateCollectionsSuite() {
       }
     },
 
+    testSmartJoinPrefixShardKey: function () {
+      const res = tryCreate({name: collname, smartJoinAttribute: "test", numberOfShards: 3, shardKeys: ["_key:"]});
+      try {
+        if (!isEnterprise) {
+          assertTrue(res.result, `Result: ${JSON.stringify(res)}`);
+          validateProperties({shardKeys: ["_key:"], numberOfShards: 3}, collname, 2);
+          validatePropertiesDoNotExist(collname, ["smartJoinAttribute"]);
+          validateDeprecationLogEntryWritten();
+        } else {
+          if (!isCluster) {
+            assertTrue(res.result, `Result: ${JSON.stringify(res)}`);
+            validateProperties({}, collname, 2);
+            validatePropertiesDoNotExist(collname, ["smartJoinAttribute"]);
+          } else {
+            assertTrue(res.result, `Result: ${JSON.stringify(res)}`);
+            validateProperties({smartJoinAttribute: "test", numberOfShards: 3, shardKeys: ["_key:"]}, collname, 2);
+          }
+        }
+      } finally {
+        db._drop(collname);
+      }
+    },
+
     testSmartJoinCorrect: function () {
       const leader = tryCreate({name: leaderName, numberOfShards: 3});
       try {


### PR DESCRIPTION
### Scope & Purpose

*SmartJoins only work in combination with distributeShardsLike. However old versions allowed to create SmartJoins without it.
This PR reactivates this invalid creation of Collections to avoid breaking change in API. Actual change in Enterprise code*

As this is in no released version on Purpose no CHANGLOG entry written

- [x] 🎪 
- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [x] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*
  - [ ] Backport for 3.9: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [x] Enterprise PR: https://github.com/arangodb/enterprise/pull/1351
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

