### PR TITLE
Fix devel CI build.

### DIFF
--- a/.circleci/base_config.yml
+++ b/.circleci/base_config.yml
@@ -125,7 +125,7 @@ jobs:
           name: Install eslint
           command: |
             apk add --no-cache npm
-            npm -g install eslint
+            npm -g install eslint@8.46.0
       - run:
           name: Run eslint
           command: |

--- a/js/apps/system/_admin/aardvark/APP/frontend/js/arango/arango.js
+++ b/js/apps/system/_admin/aardvark/APP/frontend/js/arango/arango.js
@@ -1,5 +1,5 @@
 /* jshint unused: false */
-/* global Noty, Blob, window, Joi, sigma, $, tippy, document, _, arangoHelper, frontendConfig, sessionStorage, localStorage, XMLHttpRequest */
+/* global Noty, window, Joi, sigma, $, tippy, document, _, arangoHelper, frontendConfig, sessionStorage, localStorage, XMLHttpRequest */
 
 (function () {
   'use strict';


### PR DESCRIPTION
### Scope & Purpose

The "sudden" failure is caused by the fact that the CircleCI lint action just installs eslint of the day. This likelly got updated and is now complaining.

This PR fixes the immediate redness, a better fix will be to fix the eslint version for linting jobs.