### PR TITLE
[3.11] Reduce memory footprint while collecting agencydump

### DIFF
--- a/js/client/modules/@arangodb/testutils/instance.js
+++ b/js/client/modules/@arangodb/testutils/instance.js
@@ -957,8 +957,12 @@ class instance {
     print('--------------------------------- '+ fn + ' -----------------------------------------------');
     let agencyReply = this.getAgent(path, method);
     if (agencyReply.code === 200) {
-      let agencyValue = JSON.parse(agencyReply.body);
-      fs.write(fs.join(dumpdir, fn + '_' + this.pid + ".json"), JSON.stringify(agencyValue, null, 2));
+      if (fn === "agencyState") {
+        fs.write(fs.join(dumpdir, fn + '_' + this.pid + ".json"), agencyReply.body);
+      } else {
+        let agencyValue = JSON.parse(agencyReply.body);
+        fs.write(fs.join(dumpdir, fn + '_' + this.pid + ".json"), JSON.stringify(agencyValue, null, 2));
+      }
     } else {
       print(agencyReply);
     }


### PR DESCRIPTION
### Scope & Purpose

Backport of: https://github.com/arangodb/arangodb/pull/19588

*This PR is supposed to help with collecting information on failed Jenkins runs. It does not apply any bug-fix by itself. It is inspired by the failure visible in this. Jenkins run: https://jenkins01.arangodb.biz/job/arangodb-ANY-linux-matrix.aarch64/640/EDITION=enterprise,STORAGE_ENGINE=rocksdb,TEST_SUITE=cluster,limit=linux&&test&&aarch64/*

In Above Jenkins run we had some issue (which does not matter) and tried to collection AgencyState for it for analytics. This triggered an OOM situation on the arangosh side.
This PR also does not protect against OOM in the situation, but it should reduce the memory footprint of 3times keeping AgencyState in V8 memory down to 2times, reducing the OOM chance, and increasing chance to get usable output.

This is limited to State, because we will look at the state with a tool and not directly by human eyes, so having this output pretty printed is of no use, the other APIs using this mechanism are really human readable so I kept them as they were.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*
  - [ ] Backport for 3.9: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

