### PR TITLE
close a loophole for unaccounted memory usage

### DIFF
--- a/arangod/Aql/DocumentProducingHelper.cpp
+++ b/arangod/Aql/DocumentProducingHelper.cpp
@@ -191,6 +191,7 @@ DocumentProducingFunctionContext::DocumentProducingFunctionContext(
       _filter(infos.getFilter()),
       _projections(infos.getProjections()),
       _filterProjections(infos.getFilterProjections()),
+      _resourceMonitor(infos.getResourceMonitor()),
       _numScanned(0),
       _numFiltered(0),
       _outputVariable(infos.getOutVariable()),
@@ -232,6 +233,7 @@ DocumentProducingFunctionContext::DocumentProducingFunctionContext(
       _filter(infos.getFilter()),
       _projections(infos.getProjections()),
       _filterProjections(infos.getFilterProjections()),
+      _resourceMonitor(infos.getResourceMonitor()),
       _numScanned(0),
       _numFiltered(0),
       _outputVariable(infos.getOutVariable()),
@@ -272,7 +274,10 @@ DocumentProducingFunctionContext::DocumentProducingFunctionContext(
   }
 }
 
-DocumentProducingFunctionContext::~DocumentProducingFunctionContext() = default;
+DocumentProducingFunctionContext::~DocumentProducingFunctionContext() {
+  // must be called to count down memory usage
+  reset();
+}
 
 void DocumentProducingFunctionContext::setOutputRow(
     OutputAqlItemRow* outputRow) {
@@ -361,6 +366,14 @@ bool DocumentProducingFunctionContext::checkUniqueness(
       // Document already in list. Skip this
       return false;
     }
+    // increase memory usage for unique values in set.
+    // note: we assume some there is some overhead here for
+    // managing the set. right now there is no way to track
+    // this overhead accurately, so we don't even try.
+    // this is ok as long as recorded memory usage grows
+    // with each item in the set
+    _resourceMonitor.increaseMemoryUsage(
+        sizeof(decltype(_alreadyReturned)::value_type));
   } else {
     // only check for duplicates
     if (_alreadyReturned.contains(token)) {
@@ -414,6 +427,10 @@ bool DocumentProducingFunctionContext::checkFilter(
 
 void DocumentProducingFunctionContext::reset() {
   if (_checkUniqueness) {
+    // count down memory usage
+    _resourceMonitor.decreaseMemoryUsage(
+        _alreadyReturned.size() *
+        sizeof(decltype(_alreadyReturned)::value_type));
     _alreadyReturned.clear();
     _isLastIndex = false;
   }

--- a/arangod/Aql/DocumentProducingHelper.h
+++ b/arangod/Aql/DocumentProducingHelper.h
@@ -49,6 +49,7 @@ class Builder;
 class Slice;
 }  // namespace velocypack
 class PhysicalCollection;
+struct ResourceMonitor;
 enum class ReadOwnWrites : bool;
 namespace aql {
 struct AqlValue;
@@ -146,6 +147,8 @@ struct DocumentProducingFunctionContext {
   Expression* _filter;
   aql::Projections const& _projections;
   aql::Projections const& _filterProjections;
+  ResourceMonitor& _resourceMonitor;
+
   uint64_t _numScanned;
   uint64_t _numFiltered;
 

--- a/arangod/Aql/EnumerateCollectionExecutor.cpp
+++ b/arangod/Aql/EnumerateCollectionExecutor.cpp
@@ -84,6 +84,11 @@ Expression* EnumerateCollectionExecutorInfos::getFilter() const noexcept {
   return _filter;
 }
 
+ResourceMonitor&
+EnumerateCollectionExecutorInfos::getResourceMonitor() noexcept {
+  return _query.resourceMonitor();
+}
+
 arangodb::aql::Projections const&
 EnumerateCollectionExecutorInfos::getProjections() const noexcept {
   return _projections;

--- a/arangod/Aql/EnumerateCollectionExecutor.h
+++ b/arangod/Aql/EnumerateCollectionExecutor.h
@@ -29,17 +29,17 @@
 #include "Aql/DocumentProducingHelper.h"
 #include "Aql/ExecutionState.h"
 #include "Aql/InputAqlItemRow.h"
-#include "Transaction/Methods.h"
 #include "Aql/RegisterInfos.h"
-#include "DocumentProducingHelper.h"
+#include "Transaction/Methods.h"
 
 #include <memory>
 #include <string>
-#include <unordered_set>
 #include <vector>
 
 namespace arangodb {
 class IndexIterator;
+struct ResourceMonitor;
+
 namespace transaction {
 class Methods;
 }
@@ -82,6 +82,7 @@ class EnumerateCollectionExecutorInfos {
   Variable const* getOutVariable() const;
   QueryContext& getQuery() const;
   Expression* getFilter() const noexcept;
+  ResourceMonitor& getResourceMonitor() noexcept;
   arangodb::aql::Projections const& getProjections() const noexcept;
   arangodb::aql::Projections const& getFilterProjections() const noexcept;
   bool getProduceResult() const noexcept;

--- a/arangod/Aql/IndexExecutor.cpp
+++ b/arangod/Aql/IndexExecutor.cpp
@@ -278,6 +278,10 @@ arangodb::aql::Projections const& IndexExecutorInfos::getFilterProjections()
   return _filterProjections;
 }
 
+ResourceMonitor& IndexExecutorInfos::getResourceMonitor() noexcept {
+  return _query.resourceMonitor();
+}
+
 QueryContext& IndexExecutorInfos::query() noexcept { return _query; }
 
 Expression* IndexExecutorInfos::getFilter() const noexcept { return _filter; }

--- a/arangod/Aql/IndexExecutor.h
+++ b/arangod/Aql/IndexExecutor.h
@@ -42,6 +42,7 @@
 
 namespace arangodb {
 class IndexIterator;
+struct ResourceMonitor;
 
 namespace aql {
 
@@ -87,6 +88,7 @@ class IndexExecutorInfos {
   arangodb::aql::Projections const& getFilterProjections() const noexcept;
   aql::QueryContext& query() noexcept;
   Expression* getFilter() const noexcept;
+  ResourceMonitor& getResourceMonitor() noexcept;
   bool getProduceResult() const noexcept;
   std::vector<transaction::Methods::IndexHandle> const& getIndexes()
       const noexcept;


### PR DESCRIPTION
### Scope & Purpose

The `_alreadyReturned` set could grow indefinitely large within an AQL query. This fix tracks its approximate memory usage, so that when the set grows, the memory usage increase is accounted for an can be acted upon by setting query memory limits.

Correctness of memory usage increases/decreases is implicitly validated by the query's ResourceMonitor object, which asserts that _current == 0 in its own destructor. That means all additional memory tracked by the changes in this PR must all have been subtracted again, otherwise the assertion would fail.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*
  - [ ] Backport for 3.9: *(Please link PR)*

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 