### PR TITLE
fix authentication differences in experimental dump

### DIFF
--- a/arangod/GeneralServer/RestHandler.cpp
+++ b/arangod/GeneralServer/RestHandler.cpp
@@ -175,6 +175,12 @@ futures::Future<Result> RestHandler::forwardRequest(bool& forwarded) {
     return futures::makeFuture(Result());
   }
 
+  // we must use the request's permissions here and set them in the
+  // thread-local variable when calling forwardingTarget().
+  // this is because forwardingTarget() may run permission checks.
+  ExecContext* exec = static_cast<ExecContext*>(_request->requestContext());
+  ExecContextScope scope(exec);
+
   ResultT forwardResult = forwardingTarget();
   if (forwardResult.fail()) {
     return futures::makeFuture(forwardResult.result());


### PR DESCRIPTION
### Scope & Purpose

Fix differences in permission handling between experimental dump and non-experimental dump.
Fixes a nightly test (`scripts/unittest authentication --test dump --cluster true`).

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.11: https://github.com/arangodb/arangodb/pull/19563
  - [x] Backport for 3.10: https://github.com/arangodb/arangodb/pull/19596.diff
  - [ ] Backport for 3.9: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 