### PR TITLE
speed up a test

### DIFF
--- a/tests/js/client/aql/aql-arangosearch-constrained-sort-optimization.inc
+++ b/tests/js/client/aql/aql-arangosearch-constrained-sort-optimization.inc
@@ -121,9 +121,18 @@
           obj: {ps:sort + 1, a: {a1: 30}, b: {b1: 31}, c: i, d: {d1: 33}, e: {e1: 34}, f: j + 1, g: 36, h: 37, j: 38}});
           cats = cats + " cat";
           sort = sort + 2;
+
+          if (data.length === 250) {
+            // start publishing data already when we have a few smaller batches ready.
+            // this allows background indexing of arangosearch to process the initial
+            // batches already while we are inserting further batches. also reduces
+            // memory usage of the test
+            c.save(data);
+            c1.save(data2);
+            data = [];
+            data2 = [];
+          }
         }
-        c.save(data);
-        c1.save(data2);
         // trigger view sync
         db._query("FOR d IN " + vn + " OPTIONS { waitForSync: true } RETURN d");
       },


### PR DESCRIPTION
### Scope & Purpose

Speed up view tests.
These tests spent a long time inside `setUpAll`.
In the previous version of the code, a large array of documents was inserted at once, and then the setup code waited for views to catch up.
Now, the large array is broken up into smaller chunks, which not only reduces memory usage, but will also allow the underlying view to start indexing the first batches while more data is being inserted.
This reduces the total test runtime by ~20 to 30%.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -
  - [ ] Backport for 3.9: -

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 