### PR TITLE
[Bug-Fix BTS-1556] Cancel ongoing AgencyCommunication on shutdown

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,12 @@
 devel
 -----
 
+* Fixed BTS-1556: Potential shutdown race, when the server is shutting down
+  and still AgencyCommunication was going on it could use the scheduler
+  which was already deleted, causing a crash right before a normal shutdown.
+  This should not have any negative effect, as all state preserving operations
+  are done by then, it just wasn't a clean exit.
+
 * Fixed BTS-1554: wrong aggregation count when an "in" or "or" condition
   was executed through an index lookup.
 

--- a/arangod/Cluster/ClusterFeature.cpp
+++ b/arangod/Cluster/ClusterFeature.cpp
@@ -949,6 +949,10 @@ void ClusterFeature::stop() {
 
   AsyncAgencyCommManager::INSTANCE->setStopping(true);
   shutdownAgencyCache();
+
+  // We try to actively cancel all open requests that may still be in the Agency
+  // We cannot react to them anymore.
+  _asyncAgencyCommPool->shutdownConnections();
 }
 
 void ClusterFeature::setUnregisterOnShutdown(bool unregisterOnShutdown) {


### PR DESCRIPTION
### Scope & Purpose

*When we shutdown the server, and still have open AgencyCommunication, this could get into crashes. So we now actively cancel all AgencyRequests very late in the shutdown, but before we get into dangerous area. Such a crash should not yield any real issue, as all required steps for a clean shutdown are taken, we are just freeing in-memory objects after it.*

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*
  - [ ] Backport for 3.9: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket: BTS-1556
- [ ] Design document: 

