### PR TITLE
micro-performance optimization for experimental dump

### DIFF
--- a/arangod/RocksDBEngine/RocksDBDumpContext.cpp
+++ b/arangod/RocksDBEngine/RocksDBDumpContext.cpp
@@ -320,16 +320,13 @@ void RocksDBDumpContext::handleWorkItem(WorkItem item) {
   for (it->Seek(lowerBound.string()); it->Valid(); it->Next()) {
     TRI_ASSERT(it->key().compare(ci.upper) < 0);
 
-    // check if we have reached our current end position
-    if (it->key().compare(upperBound.string()) >= 0) {
-      break;
-    }
-
     ++docsProduced;
 
     if (batch == nullptr) {
       batch = std::make_unique<Batch>();
       batch->shard = ci.guard.collection()->name();
+      // save at least a few small (re)allocations
+      batch->content.reserve(64 * 1024);
       // make sink point into the string of the current batch
       sink.setBuffer(&batch->content);
     }

--- a/arangod/RocksDBEngine/RocksDBDumpContext.cpp
+++ b/arangod/RocksDBEngine/RocksDBDumpContext.cpp
@@ -320,6 +320,11 @@ void RocksDBDumpContext::handleWorkItem(WorkItem item) {
   for (it->Seek(lowerBound.string()); it->Valid(); it->Next()) {
     TRI_ASSERT(it->key().compare(ci.upper) < 0);
 
+    // check if we have reached our current end position
+    if (it->key().compare(upperBound.string()) >= 0) {
+      break;
+    }
+
     ++docsProduced;
 
     if (batch == nullptr) {


### PR DESCRIPTION
### Scope & Purpose

Small performance optimization for experimental dump:
Reserve 64k of initial memory in batch string buffers. Ideally this saves the first few reallocations in the buffer, without creating too much overhead in case not much data needs to be produced.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [x] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*
  - [ ] Backport for 3.9: *(Please link PR)*

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 