### PR TITLE
BugFix: CreateCollection with null attributes

### DIFF
--- a/arangod/VocBase/Properties/CreateCollectionBody.cpp
+++ b/arangod/VocBase/Properties/CreateCollectionBody.cpp
@@ -275,6 +275,10 @@ auto handleNumberOfShards(std::string_view key, VPackSlice value,
                           VPackSlice fullBody,
                           DatabaseConfiguration const& config,
                           VPackBuilder& result) {
+  if (value.isNull()) {
+    // We ignore the null.
+    return;
+  }
   if (!hasDistributeShardsLike(fullBody, config) || isSmart(fullBody)) {
     justKeep(key, value, fullBody, config, result);
   } else if (config.maxNumberOfShards > 0 && value.isNumber() &&
@@ -290,6 +294,10 @@ auto handleNumberOfShardsRestore(std::string_view key, VPackSlice value,
                                  VPackSlice fullBody,
                                  DatabaseConfiguration const& config,
                                  VPackBuilder& result) {
+  if (value.isNull()) {
+    // We ignore the null.
+    return;
+  }
   if (!hasDistributeShardsLike(fullBody, config) || isSmart(fullBody)) {
     if (isSingleServer()) {
       justKeep(key, value, fullBody, config, result);
@@ -334,6 +342,10 @@ auto handleDistributeShardsLike(std::string_view key, VPackSlice value,
                                 VPackSlice fullBody,
                                 DatabaseConfiguration const& config,
                                 VPackBuilder& result) {
+  if (value.isNull()) {
+    // We ignore the null.
+    return;
+  }
   if (!config.isOneShardDB) {
     if (isSingleServer() && !isSmart(fullBody)) {
       // Community can not use distributeShardsLike on SingleServer

--- a/tests/js/common/shell/shell-collection-api.js
+++ b/tests/js/common/shell/shell-collection-api.js
@@ -1480,11 +1480,11 @@ function CreateCollectionsSuite() {
 function IgnoreIllegalTypesSuite() {
   // Lists of illegal type values, for each test to iterate over.
   const testValues = {
-    string: [1, -3.6, true, false, [], {foo: "bar"}],
-    integer: [-3, 5.1, true, false, [2], {foo: "bar"}, "test"],
-    bool: [1, -3.1, [true], {foo: "bar"}, "test"],
-    object: [0, -2.1, true, false, [], "test"],
-    array: [0, -2.1, true, false, {foo: "bar"}, "test"]
+    string: [1, -3.6, true, false, [], {foo: "bar"}, null],
+    integer: [-3, 5.1, true, false, [2], {foo: "bar"}, "test", null],
+    bool: [1, -3.1, [true], {foo: "bar"}, "test", null],
+    object: [0, -2.1, true, false, [], "test", null],
+    array: [0, -2.1, true, false, {foo: "bar"}, "test", null]
   };
   // Definition of value types.
   const propertiesToTest = {
@@ -1538,7 +1538,12 @@ function IgnoreIllegalTypesSuite() {
               break;
             }
             case "computedValues": {
-              isDisallowed(ERROR_HTTP_BAD_PARAMETER.code, ERROR_BAD_PARAMETER.code, res, testParam);
+              if (ignoredValue === null) {
+                assertTrue(res.result, `Result: ${JSON.stringify(res)} on input ${JSON.stringify(testParam)}`);
+                validateProperties({computedValues: null}, collname, 2);
+              } else {
+                isDisallowed(ERROR_HTTP_BAD_PARAMETER.code, ERROR_BAD_PARAMETER.code, res, testParam);
+              }
               break;
             }
             case "shardKeys": {
@@ -1555,7 +1560,12 @@ function IgnoreIllegalTypesSuite() {
                     validateProperties({numberOfShards: Math.floor(ignoredValue)}, collname, 2);
                   }
                 } else {
-                  isDisallowed(ERROR_HTTP_BAD_PARAMETER.code, ERROR_BAD_PARAMETER.code, res, testParam);
+                  if (ignoredValue === null) {
+                    // Allowed default to one shard
+                    isAllowed(res, collname, testParam, false);
+                  } else {
+                    isDisallowed(ERROR_HTTP_BAD_PARAMETER.code, ERROR_BAD_PARAMETER.code, res, testParam);
+                  }
                 }
               } else {
                 if (typeof ignoredValue === "number") {
@@ -1565,13 +1575,23 @@ function IgnoreIllegalTypesSuite() {
                     isAllowed(res, collname, testParam, false);
                   }
                 } else {
-                  isDisallowed(ERROR_HTTP_BAD_PARAMETER.code, ERROR_BAD_PARAMETER.code, res, testParam);
+                  if (ignoredValue === null) {
+                    // Allowed default to one shard
+                    isAllowed(res, collname, testParam, false);
+                  } else {
+                    isDisallowed(ERROR_HTTP_BAD_PARAMETER.code, ERROR_BAD_PARAMETER.code, res, testParam);
+                  }
                 }
               }
               break;
             }
             case "schema": {
-              isDisallowed(ERROR_HTTP_BAD_PARAMETER.code, ERROR_VALIDATION_BAD_PARAMETER.code, res, testParam);
+              if (ignoredValue === null) {
+                assertTrue(res.result, `Result: ${JSON.stringify(res)} on input ${JSON.stringify(testParam)}`);
+                validateProperties({schema: null}, collname, 2);
+              } else {
+                isDisallowed(ERROR_HTTP_BAD_PARAMETER.code, ERROR_VALIDATION_BAD_PARAMETER.code, res, testParam);
+              }
               break;
             }
             case "replicationFactor":
@@ -1613,7 +1633,12 @@ function IgnoreIllegalTypesSuite() {
             case "distributeShardsLike": {
               if (isCluster) {
                 // Can only be strings
-                isDisallowed(ERROR_HTTP_BAD_PARAMETER.code, ERROR_BAD_PARAMETER.code, res, testParam);
+                if (ignoredValue === null) {
+                  // Allowed default to one shard
+                  isAllowed(res, collname, testParam, false);
+                } else {
+                  isDisallowed(ERROR_HTTP_BAD_PARAMETER.code, ERROR_BAD_PARAMETER.code, res, testParam);
+                }
               } else {
                 isAllowed(res, collname, testParam);
               }

--- a/tests/js/common/shell/shell-collection-api.js
+++ b/tests/js/common/shell/shell-collection-api.js
@@ -1562,7 +1562,7 @@ function IgnoreIllegalTypesSuite() {
                 } else {
                   if (ignoredValue === null) {
                     // Allowed default to one shard
-                    isAllowed(res, collname, testParam, false);
+                    isAllowed(res, collname, testParam);
                   } else {
                     isDisallowed(ERROR_HTTP_BAD_PARAMETER.code, ERROR_BAD_PARAMETER.code, res, testParam);
                   }
@@ -1635,13 +1635,18 @@ function IgnoreIllegalTypesSuite() {
                 // Can only be strings
                 if (ignoredValue === null) {
                   // Allowed default to one shard
-                  isAllowed(res, collname, testParam, false);
+                  isAllowed(res, collname, testParam);
                 } else {
                   isDisallowed(ERROR_HTTP_BAD_PARAMETER.code, ERROR_BAD_PARAMETER.code, res, testParam);
                 }
               } else {
                 isAllowed(res, collname, testParam);
               }
+              break;
+            }
+            case "shardingStrategy": {
+              // Do not expect deprecation messages for null
+              isAllowed(res, collname, testParam, ignoredValue !== null);
               break;
             }
             default: {

--- a/tests/js/common/shell/shell-collection-api.js
+++ b/tests/js/common/shell/shell-collection-api.js
@@ -1634,7 +1634,7 @@ function IgnoreIllegalTypesSuite() {
               if (isCluster) {
                 // Can only be strings
                 if (ignoredValue === null) {
-                  // Allowed default to one shard
+                  // Allowed default to no distributeShardsLike
                   isAllowed(res, collname, testParam);
                 } else {
                   isDisallowed(ERROR_HTTP_BAD_PARAMETER.code, ERROR_BAD_PARAMETER.code, res, testParam);


### PR DESCRIPTION
### Scope & Purpose

*In the first round of backwards compatibility we forgot to test `null` as special case. It turns out we actually have different behavior in devel and 3.11 on this null for some values. This difference should now be removed. As this is not released yet on Purpose no CHANGELOG entry.*

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*
  - [ ] Backport for 3.9: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

