### PR TITLE
deprecate `/_admin/database/target-version` API

### DIFF
--- a/Documentation/DocuBlocks/Rest/Administration/get_admin_database_target_version.md
+++ b/Documentation/DocuBlocks/Rest/Administration/get_admin_database_target_version.md
@@ -1,6 +1,12 @@
 @startDocuBlock get_admin_database_target_version
 
-@RESTHEADER{GET /_admin/database/target-version, Get the required database version, getDatabaseVersion}
+@RESTHEADER{GET /_admin/database/target-version, Get the required database version (deprecated), getDatabaseVersion}
+
+@HINTS
+{% hint 'warning' %}
+This endpoint is deprecated and should no longer be used. It will be removed from version 3.12.0 on.
+Use `/_admin/version` instead.
+{% endhint %}
 
 @RESTDESCRIPTION
 Returns the database version that this server requires.

--- a/Documentation/DocuBlocks/Rest/Administration/get_admin_database_target_version.md
+++ b/Documentation/DocuBlocks/Rest/Administration/get_admin_database_target_version.md
@@ -4,8 +4,8 @@
 
 @HINTS
 {% hint 'warning' %}
-This endpoint is deprecated and should no longer be used. It will be removed from version 3.12.0 on.
-Use `/_admin/version` instead.
+This endpoint is deprecated and should no longer be used. It will be removed from version 3.12.0 onward.
+Use `GET /_api/version` instead.
 {% endhint %}
 
 @RESTDESCRIPTION


### PR DESCRIPTION
### Scope & Purpose

Deprecate `/_admin/database/target-version` API from 3.11 onwards, remove it in 3.12.
Docs PR: https://github.com/arangodb/docs/pull/1448

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.11: this PR
  - [ ] Backport for 3.10: -
  - [ ] Backport for 3.9: -

#### Related Information

- [x] Docs PR: https://github.com/arangodb/docs/pull/1448
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 