### PR TITLE
[CINFRA-825] Remove external release api from replicated log

### DIFF
--- a/arangod/Replication2/Methods.cpp
+++ b/arangod/Replication2/Methods.cpp
@@ -47,6 +47,7 @@
 #include "Replication2/ReplicatedLog/LogStatus.h"
 #include "Replication2/ReplicatedLog/ReplicatedLog.h"
 #include "Replication2/ReplicatedState/ReplicatedState.h"
+#include "Replication2/StateMachines/BlackHole/BlackHoleStateMachine.h"
 #include "VocBase/vocbase.h"
 
 #include "Agency/AgencyPaths.h"
@@ -220,10 +221,31 @@ struct ReplicatedLogMethodsDBServer final
 
   auto release(LogId id, LogIndex index) const
       -> futures::Future<Result> override {
-    // TODO Call via state machine?
-    // auto log = vocbase.getReplicatedLogById(id);
-    // return log->getParticipant()->release(index);
-    THROW_ARANGO_EXCEPTION(TRI_ERROR_NOT_IMPLEMENTED);
+    auto stateBase = vocbase.getReplicatedStateById(id);
+    if (!stateBase.ok()) {
+      return std::move(stateBase).result();
+    }
+    if (auto state =
+            std::dynamic_pointer_cast<replicated_state::ReplicatedState<
+                replicated_state::black_hole::BlackHoleState>>(stateBase.get());
+        state != nullptr) {
+      if (auto leaderState = state->getLeader(); leaderState != nullptr) {
+        return leaderState->release(index);
+      } else {
+        return Result(
+            TRI_ERROR_HTTP_FORBIDDEN,
+            fmt::format("/release API is only allowed on leaders; while "
+                        "trying to release state machine {} on {}.",
+                        id, ServerState::instance()->getId()));
+      }
+    } else {
+      return Result(
+          TRI_ERROR_HTTP_FORBIDDEN,
+          fmt::format(
+              "/release API is only allowed for state machines of the "
+              "`black-hole` type. The requested state {} is of type {}.",
+              id, stateBase.get()->type()));
+    }
   }
 
   auto replaceParticipant(LogId id, ParticipantId const& participantToRemove,

--- a/arangod/Replication2/Methods.cpp
+++ b/arangod/Replication2/Methods.cpp
@@ -220,8 +220,10 @@ struct ReplicatedLogMethodsDBServer final
 
   auto release(LogId id, LogIndex index) const
       -> futures::Future<Result> override {
-    auto log = vocbase.getReplicatedLogById(id);
-    return log->getParticipant()->release(index);
+    // TODO Call via state machine?
+    // auto log = vocbase.getReplicatedLogById(id);
+    // return log->getParticipant()->release(index);
+    THROW_ARANGO_EXCEPTION(TRI_ERROR_NOT_IMPLEMENTED);
   }
 
   auto replaceParticipant(LogId id, ParticipantId const& participantToRemove,

--- a/arangod/Replication2/Methods.h
+++ b/arangod/Replication2/Methods.h
@@ -27,6 +27,7 @@
 #include "Replication2/ReplicatedLog/LogEntry.h"
 #include "Replication2/ReplicatedLog/LogPayload.h"
 #include "Replication2/ReplicatedLog/LogStatus.h"
+#include "Replication2/StateMachines/BlackHole/BlackHoleStateMachine.h"
 #include "VocBase/vocbase.h"
 
 #include <string>
@@ -172,8 +173,11 @@ auto inspect(Inspector& f, ReplicatedLogMethods::CreateOptions& x) {
       f.field("waitForReady", x.waitForReady).fallback(true),
       f.field("id", x.id), f.field("config", x.config),
       f.field("spec", x.spec)
-          .fallback(agency::ImplementationSpec{.type = "black-hole",
-                                               .parameters = {}}),
+          .fallback(agency::ImplementationSpec{
+              .type =
+                  std::string{
+                      replicated_state::black_hole::BlackHoleState::NAME},
+              .parameters = {}}),
       f.field("leader", x.leader),
       f.field("numberOfServers", x.numberOfServers),
       f.field("servers", x.servers).fallback(std::vector<ParticipantId>{}));

--- a/arangod/Replication2/ReplicatedLog/Components/LogFollower.cpp
+++ b/arangod/Replication2/ReplicatedLog/Components/LogFollower.cpp
@@ -253,11 +253,6 @@ auto LogFollowerImpl::getInternalLogIterator(
   return guarded.getLockedGuard()->storage->getLogIterator(bounds);
 }
 
-auto LogFollowerImpl::release(LogIndex doneWithIdx) -> Result {
-  guarded.getLockedGuard()->compaction->updateReleaseIndex(doneWithIdx);
-  return {};
-}
-
 auto LogFollowerImpl::compact() -> ResultT<CompactionResult> {
   // TODO clean up CompacionResult vs ICompactionManager::CompactResult
   auto result = guarded.getLockedGuard()->compaction->compact().get();

--- a/arangod/Replication2/ReplicatedLog/Components/LogFollower.h
+++ b/arangod/Replication2/ReplicatedLog/Components/LogFollower.h
@@ -119,8 +119,6 @@ struct LogFollowerImpl : ILogFollower {
   [[nodiscard]] auto getInternalLogIterator(std::optional<LogRange> bounds)
       const -> std::unique_ptr<LogIterator> override;
 
-  auto release(LogIndex doneWithIdx) -> Result override;
-
   auto compact() -> ResultT<CompactionResult> override;
 
   auto getParticipantId() const noexcept -> ParticipantId const& override;

--- a/arangod/Replication2/ReplicatedLog/ILogInterfaces.h
+++ b/arangod/Replication2/ReplicatedLog/ILogInterfaces.h
@@ -94,7 +94,6 @@ struct ILogParticipant {
   [[nodiscard]] virtual auto getInternalLogIterator(
       std::optional<LogRange> bounds = std::nullopt) const
       -> std::unique_ptr<LogIterator> = 0;
-  [[nodiscard]] virtual auto release(LogIndex doneWithIdx) -> Result = 0;
   [[nodiscard]] virtual auto compact() -> ResultT<CompactionResult> = 0;
 };
 

--- a/arangod/Replication2/ReplicatedLog/LogLeader.cpp
+++ b/arangod/Replication2/ReplicatedLog/LogLeader.cpp
@@ -728,9 +728,7 @@ auto replicated_log::LogLeader::GuardedLeaderData::updateCommitIndexLeader(
   struct MethodsImpl : IReplicatedLogLeaderMethods {
     explicit MethodsImpl(LogLeader& log) : _log(log) {}
     auto releaseIndex(LogIndex index) -> void override {
-      if (auto res = _log.release(index); res.fail()) {
-        THROW_ARANGO_EXCEPTION(res);
-      }
+      return _log.updateReleaseIndex(index);
     }
     auto getCommittedLogIterator(std::optional<LogRange> range)
         -> std::unique_ptr<LogViewRangeIterator> override {
@@ -1219,9 +1217,8 @@ replicated_log::LogLeader::GuardedLeaderData::GuardedLeaderData(
     std::unique_ptr<IReplicatedStateHandle> stateHandle, LogIndex firstIndex)
     : _self(self), _stateHandle(std::move(stateHandle)) {}
 
-auto replicated_log::LogLeader::release(LogIndex doneWithIdx) -> Result {
-  _compactionManager->updateReleaseIndex(doneWithIdx);
-  return {};
+void replicated_log::LogLeader::updateReleaseIndex(LogIndex doneWithIdx) {
+  return _compactionManager->updateReleaseIndex(doneWithIdx);
 }
 
 auto replicated_log::LogLeader::compact() -> ResultT<CompactionResult> {

--- a/arangod/Replication2/ReplicatedLog/LogLeader.h
+++ b/arangod/Replication2/ReplicatedLog/LogLeader.h
@@ -145,7 +145,6 @@ class LogLeader : public std::enable_shared_from_this<LogLeader>,
 
   [[nodiscard]] auto getParticipantId() const noexcept -> ParticipantId const&;
 
-  [[nodiscard]] auto release(LogIndex doneWithIdx) -> Result override;
   [[nodiscard]] auto compact() -> ResultT<CompactionResult> override;
   [[nodiscard]] auto getLogConsumerIterator(std::optional<LogRange> bounds)
       const -> std::unique_ptr<LogViewRangeIterator>;
@@ -362,6 +361,8 @@ class LogLeader : public std::enable_shared_from_this<LogLeader>,
   [[nodiscard]] auto insertInternal(
       std::variant<LogMetaPayload, LogPayload> payload, bool waitForSync)
       -> LogIndex;
+
+  void updateReleaseIndex(LogIndex doneWithIdx);
 
   [[nodiscard]] static auto instantiateFollowers(
       LoggerContext const& logContext,

--- a/arangod/Replication2/ReplicatedState/ReplicatedState.h
+++ b/arangod/Replication2/ReplicatedState/ReplicatedState.h
@@ -77,6 +77,8 @@ struct ReplicatedStateBase {
       std::optional<velocypack::SharedSlice> const& coreParameters)
       -> std::unique_ptr<replicated_log::IReplicatedStateHandle> = 0;
 
+  [[nodiscard]] virtual auto type() const noexcept -> std::string_view = 0;
+
  private:
   [[nodiscard]] virtual auto getLeaderBase()
       -> std::shared_ptr<IReplicatedLeaderStateBase> = 0;
@@ -119,6 +121,8 @@ struct ReplicatedState final
       TRI_vocbase_t& vocbase,
       std::optional<velocypack::SharedSlice> const& coreParameter)
       -> std::unique_ptr<replicated_log::IReplicatedStateHandle> override;
+
+  auto type() const noexcept -> std::string_view override { return S::NAME; }
 
  private:
   auto buildCore(TRI_vocbase_t& vocbase,

--- a/arangod/Replication2/ReplicatedState/ReplicatedStateFeature.h
+++ b/arangod/Replication2/ReplicatedState/ReplicatedStateFeature.h
@@ -48,14 +48,15 @@ struct ReplicatedStateFeature {
    * i.e. ReplicatedStateTraits<S>::FactoryType.
    */
   template<typename S, typename... Args>
-  void registerStateType(std::string const& name, Args&&... args) {
+  void registerStateType(std::string_view name, Args&&... args) {
     using Factory = typename ReplicatedStateTraits<S>::FactoryType;
     static_assert(std::is_constructible_v<Factory, Args...>);
     auto factory = std::make_shared<InternalFactory<S, Factory>>(
         std::in_place, std::forward<Args>(args)...);
     auto metrics = createMetricsObjectIndirect(name);
     auto [iter, wasInserted] = implementations.try_emplace(
-        name, StateImplementation{std::move(factory), std::move(metrics)});
+        std::string{name},
+        StateImplementation{std::move(factory), std::move(metrics)});
     assertWasInserted(name, wasInserted);
   }
 

--- a/arangod/Replication2/StateMachines/BlackHole/BlackHoleStateMachine.cpp
+++ b/arangod/Replication2/StateMachines/BlackHole/BlackHoleStateMachine.cpp
@@ -20,6 +20,8 @@
 ///
 /// @author Lars Maier
 ////////////////////////////////////////////////////////////////////////////////
+
+#include <Basics/Exceptions.h>
 #include <Basics/voc-errors.h>
 #include <Futures/Future.h>
 
@@ -46,6 +48,15 @@ BlackHoleLeaderState::BlackHoleLeaderState(std::unique_ptr<BlackHoleCore> core)
 auto BlackHoleLeaderState::resign() && noexcept
     -> std::unique_ptr<BlackHoleCore> {
   return std::move(_core);
+}
+
+auto BlackHoleLeaderState::release(LogIndex idx) const
+    -> futures::Future<Result> {
+  auto const& stream = getStream();
+  return basics::catchToResult([&]() -> Result {
+    stream->release(idx);
+    return {TRI_ERROR_NO_ERROR};
+  });
 }
 
 auto BlackHoleFollowerState::acquireSnapshot(

--- a/arangod/Replication2/StateMachines/BlackHole/BlackHoleStateMachine.h
+++ b/arangod/Replication2/StateMachines/BlackHole/BlackHoleStateMachine.h
@@ -42,6 +42,8 @@ struct BlackHoleFollowerState;
 struct BlackHoleCore;
 
 struct BlackHoleState {
+  static constexpr std::string_view NAME = "black-hole";
+
   using LeaderType = BlackHoleLeaderState;
   using FollowerType = BlackHoleFollowerState;
   using EntryType = BlackHoleLogEntry;
@@ -62,6 +64,8 @@ struct BlackHoleLeaderState
 
   [[nodiscard]] auto resign() && noexcept
       -> std::unique_ptr<BlackHoleCore> override;
+
+  auto release(LogIndex) const -> futures::Future<Result>;
 
  protected:
   auto recoverEntries(std::unique_ptr<EntryIterator> ptr)

--- a/arangod/Replication2/StateMachines/BlackHole/BlackHoleStateMachineFeature.cpp
+++ b/arangod/Replication2/StateMachines/BlackHole/BlackHoleStateMachineFeature.cpp
@@ -40,5 +40,5 @@ BlackHoleStateMachineFeature::BlackHoleStateMachineFeature(Server& server)
 
 void BlackHoleStateMachineFeature::prepare() {
   auto& feature = server().getFeature<ReplicatedStateAppFeature>();
-  feature.registerStateType<BlackHoleState>("black-hole");
+  feature.registerStateType<BlackHoleState>(BlackHoleState::NAME);
 }

--- a/tests/Replication2/Mocks/FakeFollower.cpp
+++ b/tests/Replication2/Mocks/FakeFollower.cpp
@@ -34,12 +34,6 @@ using namespace arangodb;
 using namespace arangodb::replication2;
 using namespace arangodb::replication2::test;
 
-auto FakeFollower::release(arangodb::replication2::LogIndex doneWithIdx)
-    -> arangodb::Result {
-  guarded.getLockedGuard()->doneWithIdx = doneWithIdx;
-  return {};  // return ok
-}
-
 auto FakeFollower::getParticipantId() const noexcept -> ParticipantId const& {
   return id;
 }

--- a/tests/Replication2/Mocks/FakeFollower.h
+++ b/tests/Replication2/Mocks/FakeFollower.h
@@ -49,7 +49,6 @@ struct FakeFollower final : replicated_log::ILogFollower,
   auto waitFor(LogIndex index) -> WaitForFuture override;
   auto waitForIterator(LogIndex index) -> WaitForIteratorFuture override;
 
-  auto release(LogIndex doneWithIdx) -> Result override;
   auto compact() -> ResultT<
       arangodb::replication2::replicated_log::CompactionResult> override {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_NOT_IMPLEMENTED);

--- a/tests/Replication2/ReplicatedLog/ReplicatedLogConnectTest.cpp
+++ b/tests/Replication2/ReplicatedLog/ReplicatedLogConnectTest.cpp
@@ -112,7 +112,6 @@ struct LogLeaderMock : replicated_log::ILogLeader {
   MOCK_METHOD(WaitForIteratorFuture, waitForIterator, (LogIndex), (override));
   MOCK_METHOD(std::unique_ptr<LogIterator>, getInternalLogIterator,
               (std::optional<LogRange> bounds), (const, override));
-  MOCK_METHOD(Result, release, (LogIndex), (override));
   MOCK_METHOD(ResultT<arangodb::replication2::replicated_log::CompactionResult>,
               compact, (), (override));
   MOCK_METHOD(LogIndex, ping, (std::optional<std::string>), (override));
@@ -134,7 +133,6 @@ struct LogFollowerMock : replicated_log::ILogFollower {
   MOCK_METHOD(WaitForIteratorFuture, waitForIterator, (LogIndex), (override));
   MOCK_METHOD(std::unique_ptr<LogIterator>, getInternalLogIterator,
               (std::optional<LogRange> bounds), (const, override));
-  MOCK_METHOD(Result, release, (LogIndex), (override));
   MOCK_METHOD(ResultT<arangodb::replication2::replicated_log::CompactionResult>,
               compact, (), (override));
 

--- a/tests/Replication2/ReplicatedState/StateManagerTest.cpp
+++ b/tests/Replication2/ReplicatedState/StateManagerTest.cpp
@@ -57,6 +57,8 @@ using namespace arangodb::replication2::replicated_state;
 
 namespace {
 struct EmptyState {
+  static constexpr std::string_view NAME = "empty-state";
+
   using LeaderType = test::EmptyLeaderType<EmptyState>;
   using FollowerType = test::EmptyFollowerType<EmptyState>;
   using EntryType = test::DefaultEntryType;
@@ -66,6 +68,8 @@ struct EmptyState {
   using CleanupHandlerType = void;
 };
 struct FakeState {
+  static constexpr std::string_view NAME = "fake-state";
+
   using LeaderType = test::FakeLeaderType<FakeState>;
   using FollowerType = test::FakeFollowerType<FakeState>;
   using EntryType = test::DefaultEntryType;

--- a/tests/js/common/shell/shell-replicated-logs-cluster.js
+++ b/tests/js/common/shell/shell-replicated-logs-cluster.js
@@ -254,14 +254,19 @@ function ReplicatedLogsWriteSuite() {
     },
 
     testRelease: function () {
-      for (let i = 0; i < 2000; i++) {
-        log.insert({foo: i});
+      const payloads = [...Array(2000).keys()].map(i => ({foo: i}));
+      for (const batch of _.chunk(payloads, 1000)) {
+        log.multiInsert(batch);
       }
-      let s1 = getLeaderStatus(log);
+      const s1 = getLeaderStatus(log);
       assertEqual(s1.local.firstIndex, 1);
+      assertEqual(s1.local.spearhead.index, 2001);
+      assertEqual(s1.local.commitIndex, 2001);
+
       log.release(1500);
-      let s2 = getLeaderStatus(log);
-      // Compaction runs asynchronous, so we can not expect the firstIndex to be 1500
+
+      const s2 = getLeaderStatus(log);
+      // Compaction runs asynchronously, so we can not expect the firstIndex to be 1500 as well (yet)
       assertEqual(s2.local.releaseIndex, 1500);
     },
 


### PR DESCRIPTION
### Scope & Purpose

Remove the public release API of replicated logs: It must only ever be used by the corresponding replicated state.

In order to keep js-tests working, implement `release` via the `black-hole` state machine (only).

Improved runtime of `testRelease` in `shell-replicated-logs-cluster.js`.