### PR TITLE
[CINFRA-826] Fix replication2 TSAN

### DIFF
--- a/arangod/RocksDBEngine/RocksDBEngine.cpp
+++ b/arangod/RocksDBEngine/RocksDBEngine.cpp
@@ -1277,7 +1277,7 @@ void RocksDBEngine::start() {
   _logPersistor = logPersistor;
 
   if (auto* syncer = syncThread(); syncer != nullptr) {
-    syncer->registerSyncListener(logPersistor);
+    syncer->registerSyncListener(std::move(logPersistor));
   } else {
     LOG_TOPIC("0a5df", WARN, Logger::REPLICATION2)
         << "In replication2 databases, setting waitForSync to false will not "

--- a/arangod/RocksDBEngine/RocksDBSyncThread.cpp
+++ b/arangod/RocksDBEngine/RocksDBSyncThread.cpp
@@ -103,6 +103,7 @@ void RocksDBSyncThread::beginShutdown() {
 
 void RocksDBSyncThread::registerSyncListener(
     std::shared_ptr<ISyncListener> listener) {
+  std::unique_lock lock{_syncListenersMutex};
   _syncListeners.emplace_back(std::move(listener));
 }
 
@@ -204,6 +205,7 @@ void RocksDBSyncThread::run() {
 
 void RocksDBSyncThread::notifySyncListeners(
     rocksdb::SequenceNumber seq) noexcept {
+  std::shared_lock lock(_syncListenersMutex);
   for (auto& listener : _syncListeners) {
     listener->onSync(seq);
   }

--- a/arangod/RocksDBEngine/RocksDBSyncThread.h
+++ b/arangod/RocksDBEngine/RocksDBSyncThread.h
@@ -31,6 +31,7 @@
 #include <rocksdb/types.h>
 
 #include <chrono>
+#include <shared_mutex>
 
 namespace rocksdb {
 class DB;
@@ -92,8 +93,8 @@ class RocksDBSyncThread final : public Thread {
   arangodb::basics::ConditionVariable _condition;
 
   /// @brief listeners to be notified when _lastSequenceNumber is updated after
-  /// a sync. We don't need to protect this vector because it is only
-  /// modified once after the syncer thread is started.
+  /// a sync.
+  std::shared_mutex _syncListenersMutex;
   std::vector<std::shared_ptr<ISyncListener>> _syncListeners;
 
   /// @brief notify listeners about the sequence number update


### PR DESCRIPTION
### Scope & Purpose

This PR attempts to fix the current TSAN issues that were introduced in https://github.com/arangodb/arangodb/pull/19285
- protect the `_syncListeners` with the `_syncListenersMutex`
- `std::move()` the additional `logPersistor` copy
 
Here is the [tsan.log](https://jenkins.arangodb.biz/job/arangodb-ANY-linux-san.x86-64/2056/EDITION=enterprise,SAN_MODE=TSan,STORAGE_ENGINE=rocksdb,TEST_SUITE=single,limit=linux&&test&&x86-64/artifact/tsan.log.arangod.47013.log) file

Jenkins: https://jenkins01.arangodb.biz/job/arangodb-ANY-linux-san.x86-64/2063/

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification