### PR TITLE
fix: frontend build broken due to a stray keyword

### DIFF
--- a/js/apps/system/_admin/aardvark/APP/frontend/js/routers/startApp.js
+++ b/js/apps/system/_admin/aardvark/APP/frontend/js/routers/startApp.js
@@ -1,4 +1,3 @@
-global 
 (function () {
   'use strict';
   // We have to start the app only in production mode, not in test mode


### PR DESCRIPTION
### Scope & Purpose

a single line change - removed `global` keyword at the top of `startApp.js`, which throws a cryptic error and crashes the frontend

Introduced here: https://github.com/arangodb/arangodb/pull/18449/files#diff-0216a3b0e5813d32feeee0f6edbaba7c757c2fcfd573aac1332aed224cc0d790

- [x] :hankey: Bugfix

### Checklist

- [x] Tests
  - [x] Manually tested

#### Related Information

- [x] GitHub issue / Jira ticket: https://github.com/arangodb/arangodb/pull/18449

