### PR TITLE
expose endianness

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,13 @@
 devel
 -----
 
+* Remove attribute `dfdb` from response of storage engine API (GET 
+  `/_api/engine`). 
+
+* The storage engine API (GET `/_api/engine`) now returns an `endianness`
+  attribute for the RocksDB storage engine on single servers and database
+  servers.
+
 * Allow compression content-negotation in metrics API, so that responses from
   the metrics API at `/_admin/metrics` can be sent compressed if the client
   supports it.

--- a/arangod/Metrics/MetricsFeature.cpp
+++ b/arangod/Metrics/MetricsFeature.cpp
@@ -134,7 +134,7 @@ void MetricsFeature::validateOptions(std::shared_ptr<options::ProgramOptions>) {
 
 void MetricsFeature::toPrometheus(std::string& result, CollectMode mode) const {
   // minimize reallocs
-  result.reserve(32768);
+  result.reserve(64 * 1024);
 
   // QueryRegistryFeature
   auto& q = server().getFeature<QueryRegistryFeature>();

--- a/arangod/RocksDBEngine/RocksDBEngine.h
+++ b/arangod/RocksDBEngine/RocksDBEngine.h
@@ -183,6 +183,7 @@ class RocksDBEngine final : public StorageEngine {
   std::unique_ptr<PhysicalCollection> createPhysicalCollection(
       LogicalCollection& collection, velocypack::Slice info) override;
 
+  void getCapabilities(velocypack::Builder& builder) const override;
   void getStatistics(velocypack::Builder& builder) const override;
   void getStatistics(std::string& result) const override;
 

--- a/arangod/RocksDBEngine/RocksDBFormat.cpp
+++ b/arangod/RocksDBEngine/RocksDBFormat.cpp
@@ -82,6 +82,10 @@ void (*uint16ToPersistent)(std::string& p, uint16_t value) = nullptr;
 void (*uint32ToPersistent)(std::string& p, uint32_t value) = nullptr;
 void (*uint64ToPersistent)(std::string& p, uint64_t value) = nullptr;
 
+RocksDBEndianness getRocksDBKeyFormatEndianness() noexcept {
+  return rocksDBEndianness;
+}
+
 void setRocksDBKeyFormatEndianess(RocksDBEndianness e) {
   rocksDBEndianness = e;
 

--- a/arangod/RocksDBEngine/RocksDBFormat.h
+++ b/arangod/RocksDBEngine/RocksDBFormat.h
@@ -43,17 +43,7 @@ extern void (*uint64ToPersistent)(std::string& p, uint64_t value);
 /// Enable litte endian or big-endian key formats
 void setRocksDBKeyFormatEndianess(RocksDBEndianness);
 
-inline uint64_t doubleToInt(double d) {
-  uint64_t i;
-  std::memcpy(&i, &d, sizeof(i));
-  return i;
-}
-
-inline double intToDouble(uint64_t i) {
-  double d;
-  std::memcpy(&d, &i, sizeof(i));
-  return d;
-}
+RocksDBEndianness getRocksDBKeyFormatEndianness() noexcept;
 
 template<typename T>
 inline T uintFromPersistentLittleEndian(char const* p) {

--- a/arangod/RocksDBEngine/RocksDBTypes.cpp
+++ b/arangod/RocksDBEngine/RocksDBTypes.cpp
@@ -28,6 +28,18 @@ using namespace arangodb;
 /// @brief rocksdb format version
 char arangodb::rocksDBFormatVersion() { return '1'; }
 
+std::string_view arangodb::rocksDBEndiannessString(RocksDBEndianness value) {
+  switch (value) {
+    case RocksDBEndianness::Big:
+      return "big";
+    case RocksDBEndianness::Little:
+      return "little";
+    case RocksDBEndianness::Invalid:
+      break;
+  }
+  return "invalid";
+}
+
 namespace {
 
 static RocksDBEntryType placeholder = arangodb::RocksDBEntryType::Placeholder;
@@ -162,7 +174,8 @@ static rocksdb::Slice UniqueZdkIndexValue(
     1);
 }  // namespace
 
-char const* arangodb::rocksDBEntryTypeName(arangodb::RocksDBEntryType type) {
+std::string_view arangodb::rocksDBEntryTypeName(
+    arangodb::RocksDBEntryType type) {
   switch (type) {
     case arangodb::RocksDBEntryType::Placeholder:
       return "Placeholder";
@@ -212,7 +225,7 @@ char const* arangodb::rocksDBEntryTypeName(arangodb::RocksDBEntryType type) {
   return "Invalid";
 }
 
-char const* arangodb::rocksDBLogTypeName(arangodb::RocksDBLogType type) {
+std::string_view arangodb::rocksDBLogTypeName(arangodb::RocksDBLogType type) {
   switch (type) {
     case arangodb::RocksDBLogType::DatabaseCreate:
       return "DatabaseCreate";

--- a/arangod/RocksDBEngine/RocksDBTypes.h
+++ b/arangod/RocksDBEngine/RocksDBTypes.h
@@ -28,6 +28,8 @@
 
 #include <rocksdb/slice.h>
 
+#include <string_view>
+
 namespace arangodb {
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -61,7 +63,7 @@ enum class RocksDBEntryType : char {
   UniqueZkdIndexValue = 'Z',
 };
 
-char const* rocksDBEntryTypeName(RocksDBEntryType);
+std::string_view rocksDBEntryTypeName(RocksDBEntryType);
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Used to for various metadata in the write-ahead-log
@@ -111,9 +113,11 @@ enum class RocksDBSettingsType : char {
 /// @brief endianess value
 enum class RocksDBEndianness : char { Invalid = 0, Little = 'L', Big = 'B' };
 
+std::string_view rocksDBEndiannessString(RocksDBEndianness value);
+
 /// @brief rocksdb format version
 char rocksDBFormatVersion();
 
-char const* rocksDBLogTypeName(RocksDBLogType);
+std::string_view rocksDBLogTypeName(RocksDBLogType);
 rocksdb::Slice const& rocksDBSlice(RocksDBEntryType const& type);
 }  // namespace arangodb

--- a/arangod/RocksDBEngine/RocksDBValue.cpp
+++ b/arangod/RocksDBEngine/RocksDBValue.cpp
@@ -37,6 +37,20 @@
 using namespace arangodb;
 using namespace arangodb::rocksutils;
 
+namespace {
+uint64_t doubleToInt(double d) {
+  uint64_t i;
+  std::memcpy(&i, &d, sizeof(i));
+  return i;
+}
+
+double intToDouble(uint64_t i) {
+  double d;
+  std::memcpy(&d, &i, sizeof(i));
+  return d;
+}
+}  // namespace
+
 RocksDBValue RocksDBValue::Database(VPackSlice data) {
   return RocksDBValue(RocksDBEntryType::Database, data);
 }
@@ -178,9 +192,9 @@ VPackSlice RocksDBValue::uniqueIndexStoredValues(rocksdb::Slice const& slice) {
 S2Point RocksDBValue::centroid(rocksdb::Slice const& s) {
   TRI_ASSERT(s.size() == sizeof(double) * 3);
   return S2Point(
-      intToDouble(uint64FromPersistent(s.data())),
-      intToDouble(uint64FromPersistent(s.data() + sizeof(uint64_t))),
-      intToDouble(uint64FromPersistent(s.data() + sizeof(uint64_t) * 2)));
+      ::intToDouble(uint64FromPersistent(s.data())),
+      ::intToDouble(uint64FromPersistent(s.data() + sizeof(uint64_t))),
+      ::intToDouble(uint64FromPersistent(s.data() + sizeof(uint64_t) * 2)));
 }
 
 replication2::LogTerm RocksDBValue::logTerm(rocksdb::Slice const& slice) {
@@ -293,9 +307,9 @@ RocksDBValue::RocksDBValue(RocksDBEntryType type,
 RocksDBValue::RocksDBValue(S2Point const& p)
     : _type(RocksDBEntryType::GeoIndexValue), _buffer() {
   _buffer.reserve(sizeof(uint64_t) * 3);
-  uint64ToPersistent(_buffer, rocksutils::doubleToInt(p.x()));
-  uint64ToPersistent(_buffer, rocksutils::doubleToInt(p.y()));
-  uint64ToPersistent(_buffer, rocksutils::doubleToInt(p.z()));
+  uint64ToPersistent(_buffer, ::doubleToInt(p.x()));
+  uint64ToPersistent(_buffer, ::doubleToInt(p.y()));
+  uint64ToPersistent(_buffer, ::doubleToInt(p.z()));
 }
 
 LocalDocumentId RocksDBValue::documentId(char const* data, uint64_t size) {

--- a/arangod/StorageEngine/StorageEngine.cpp
+++ b/arangod/StorageEngine/StorageEngine.cpp
@@ -93,9 +93,8 @@ IndexFactory const& StorageEngine::indexFactory() const {
 void StorageEngine::getCapabilities(velocypack::Builder& builder) const {
   builder.openObject();
   builder.add("name", velocypack::Value(typeName()));
+
   builder.add("supports", velocypack::Value(VPackValueType::Object));
-  // legacy attribute, always false since 3.7.
-  builder.add("dfdb", velocypack::Value(false));
 
   builder.add("indexes", velocypack::Value(VPackValueType::Array));
   for (auto const& it : indexFactory().supportedIndexes()) {

--- a/arangod/StorageEngine/StorageEngine.h
+++ b/arangod/StorageEngine/StorageEngine.h
@@ -351,7 +351,7 @@ class StorageEngine : public ArangodFeature {
                             uint64_t tickEnd, velocypack::Builder& builder) = 0;
   virtual WalAccess const* walAccess() const = 0;
 
-  void getCapabilities(velocypack::Builder& builder) const;
+  virtual void getCapabilities(velocypack::Builder& builder) const;
 
   virtual void getStatistics(velocypack::Builder& builder) const;
 


### PR DESCRIPTION
### Scope & Purpose

To improve debuggability,

* Remove attribute `dfdb` from response of storage engine API (GET `/_api/engine`).

* The storage engine API (GET `/_api/engine`) now returns an `endianness` attribute for the RocksDB storage engine on single servers and database servers.

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -
  - [ ] Backport for 3.9: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 