### PR TITLE
Allow content negotation for metrics API responses

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,10 @@ v3.10.11 (XXXX-XX-XX)
 * BTS-1549: adjust permission handling in experimental dump to the same behavior
   as in non-experimental dump.
 
+* Allow compression content-negotation in metrics API, so that responses from
+  the metrics API at `/_admin/metrics` can be sent compressed if the client
+  supports it.
+
 * Fixed BTS-1553: Fixed a rare occuring issue during AQL queries where the inner
   amount of a limit in the LimitExecutor is set to a wrong value which lead to
   some data rows not being returned to the client.

--- a/arangod/GeneralServer/CommTask.cpp
+++ b/arangod/GeneralServer/CommTask.cpp
@@ -1033,7 +1033,7 @@ auth::TokenCache::Entry CommTask::checkAuthHeader(GeneralRequest& req,
 /// decompress content
 bool CommTask::handleContentEncoding(GeneralRequest& req) {
   // TODO consider doing the decoding on the fly
-  auto encode = [&](std::string const& encoding) {
+  auto decode = [&](std::string const& encoding) {
     std::string_view raw = req.rawPayload();
     uint8_t* src = reinterpret_cast<uint8_t*>(const_cast<char*>(raw.data()));
     size_t len = raw.size();
@@ -1060,12 +1060,12 @@ bool CommTask::handleContentEncoding(GeneralRequest& req) {
   bool found;
   std::string const& val1 = req.header(StaticStrings::TransferEncoding, found);
   if (found) {
-    return encode(val1);
+    return decode(val1);
   }
 
   std::string const& val2 = req.header(StaticStrings::ContentEncoding, found);
   if (found) {
-    return encode(val2);
+    return decode(val2);
   }
   return true;
 }

--- a/arangod/GeneralServer/RestHandler.cpp
+++ b/arangod/GeneralServer/RestHandler.cpp
@@ -602,7 +602,8 @@ void RestHandler::generateError(rest::ResponseCode code, ErrorCode errorNumber,
 }
 
 void RestHandler::compressResponse() {
-  if (_response->isCompressionAllowed()) {
+  if (_response->isCompressionAllowed() &&
+      !_response->headers().contains(StaticStrings::ContentEncoding)) {
     switch (_request->acceptEncoding()) {
       case rest::EncodingType::DEFLATE:
         _response->deflate();

--- a/arangod/RestHandler/RestMetricsHandler.cpp
+++ b/arangod/RestHandler/RestMetricsHandler.cpp
@@ -199,6 +199,8 @@ RestStatus RestMetricsHandler::execute() {
     return makeRedirection(serverId, false);
   }
 
+  _response->setAllowCompression(true);
+
   if (type == metrics::kCDJson) {
     _response->setResponseCode(rest::ResponseCode::OK);
     _response->setContentType(rest::ContentType::VPACK);

--- a/arangod/RestHandler/RestMetricsHandler.cpp
+++ b/arangod/RestHandler/RestMetricsHandler.cpp
@@ -278,29 +278,36 @@ RestStatus RestMetricsHandler::makeRedirection(std::string const& serverId,
                            _request->requestPath(), VPackBuffer<uint8_t>{},
                            options, buildHeaders(_request->headers()));
 
-  return waitForFuture(std::move(f).thenValue(
-      [self = shared_from_this(), last](network::Response&& r) {
-        auto& me = basics::downCast<RestMetricsHandler>(*self);
-        if (r.fail() || !r.hasResponse()) {
-          TRI_ASSERT(r.fail());
-          me.generateError(r.combinedResult());
-          return;
-        }
-        if (last) {
-          auto& cm = me.server().getFeature<metrics::ClusterMetricsFeature>();
-          if (cm.isEnabled()) {
-            cm.update(metrics::CollectMode::TriggerGlobal);
-          }
-        }
-        // TODO(MBkkt) move response
-        // the response will not contain any velocypack.
-        // we need to forward the request with content-type text/plain.
-        me._response->setResponseCode(rest::ResponseCode::OK);
-        me._response->setContentType(rest::ContentType::TEXT);
-        auto payload = r.response().stealPayload();
-        me._response->addRawPayload(
-            {reinterpret_cast<char const*>(payload->data()), payload->size()});
-      }));
+  return waitForFuture(std::move(f).thenValue([self = shared_from_this(),
+                                               last](network::Response&& r) {
+    auto& me = basics::downCast<RestMetricsHandler>(*self);
+    if (r.fail() || !r.hasResponse()) {
+      TRI_ASSERT(r.fail());
+      me.generateError(r.combinedResult());
+      return;
+    }
+    if (last) {
+      auto& cm = me.server().getFeature<metrics::ClusterMetricsFeature>();
+      if (cm.isEnabled()) {
+        cm.update(metrics::CollectMode::TriggerGlobal);
+      }
+    }
+    // TODO(MBkkt) move response
+    // the response will not contain any velocypack.
+    // we need to forward the request with content-type text/plain.
+    if (r.response().header.meta().contains(StaticStrings::ContentEncoding)) {
+      // forward original Content-Encoding header
+      me._response->setHeaderNC(
+          StaticStrings::ContentEncoding,
+          r.response().header.metaByKey(StaticStrings::ContentEncoding));
+    }
+
+    me._response->setResponseCode(rest::ResponseCode::OK);
+    me._response->setContentType(rest::ContentType::TEXT);
+    auto payload = r.response().stealPayload();
+    me._response->addRawPayload(
+        {reinterpret_cast<char const*>(payload->data()), payload->size()});
+  }));
 }
 
 }  // namespace arangodb


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/19627


Allow compression content-negotation in metrics API, so that responses from the metrics API at `/_admin/metrics` can be sent compressed if the client supports it.

The metrics returned by the `/_admin/metrics` API are returned as a big text string, using only a very limited alphabet. The data should be very well compressible. As metrics are queried from all servers pretty often, we could probably save a lot of traffic at least on idle servers. For busy servers the traffic reduction is probably not significant.

According to the Prometheus docs, it supports content-negotiation and the "gzip" content encoding:
https://prometheus.io/docs/instrumenting/exposition_formats/#text-based-format

Local experiments show that enabling gzip compression for metrics reduces the size of the metrics API response by about 90%.

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.11: https://github.com/arangodb/arangodb/pull/19642
  - [x] Backport for 3.10: this PR
  - [ ] Backport for 3.9: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 