### PR TITLE
slightly improve debuggability

### DIFF
--- a/arangod/Cluster/ClusterInfo.cpp
+++ b/arangod/Cluster/ClusterInfo.cpp
@@ -5052,11 +5052,6 @@ ServersKnown ClusterInfo::rebootIds() const {
 ////////////////////////////////////////////////////////////////////////////////
 
 std::string ClusterInfo::getServerEndpoint(std::string_view serverID) {
-#ifdef ARANGODB_ENABLE_FAILURE_TESTS
-  if (serverID == "debug-follower") {
-    return "tcp://127.0.0.1:3000";
-  }
-#endif
   int tries = 0;
 
   if (!_serversProt.isValid) {
@@ -5077,7 +5072,7 @@ std::string ClusterInfo::getServerEndpoint(std::string_view serverID) {
         serverID_ = (*ita).second;
       }
 
-      // _servers is a map-type <ServerId, std::string>
+      // _servers is a map-type <ServerId, pmr::ManagedString>
       auto it = _servers.find(serverID_);
 
       if (it != _servers.end()) {

--- a/js/client/modules/@arangodb/testutils/instance.js
+++ b/js/client/modules/@arangodb/testutils/instance.js
@@ -831,7 +831,7 @@ class instance {
     this.pid = null;
     this.upAndRunning = false;
 
-    print(CYAN + Date()  + " relaunching: " + this.name + RESET);
+    print(CYAN + Date()  + " relaunching: " + this.name + ', url: ' + this.url + RESET);
     this.launchInstance(moreArgs);
     while(true) {
       const reply = download(this.url + '/_api/version', '');
@@ -852,7 +852,7 @@ class instance {
         throw new Error("restart failed! " + this.name);
       }
     }
-    print(CYAN + Date() + this.name + " running again with PID " + this.pid + RESET);
+    print(CYAN + Date() + ' ' + this.name + ', url: ' + this.url + ', running again with PID ' + this.pid + RESET);
   }
   // //////////////////////////////////////////////////////////////////////////////
   // / @brief periodic checks whether spawned arangod processes are still alive
@@ -994,7 +994,7 @@ class instance {
   // //////////////////////////////////////////////////////////////////////////////
 
   shutdownArangod (forceTerminate) {
-    print(CYAN + Date() +' stopping ' + this.name + ' force terminate: ' + forceTerminate + ' ' + this.protocol + RESET);
+    print(CYAN + Date() +' stopping ' + this.name + ', url: ' + this.url + ', force terminate: ' + forceTerminate + ' ' + this.protocol + RESET);
     if (forceTerminate === undefined) {
       forceTerminate = false;
     }
@@ -1196,7 +1196,7 @@ class instance {
       print(CYAN + Date() + ' NOT suspending "' + this.name + " again!" + RESET);
       return;
     }
-    print(CYAN + Date() + ' suspending ' + this.name + RESET);
+    print(CYAN + Date() + ' suspending ' + this.name + ', url: ' + this.url + RESET);
     if (this.options.enableAliveMonitor) {
       internal.removePidFromMonitor(this.pid);
     }
@@ -1212,7 +1212,7 @@ class instance {
       print(CYAN + Date() + ' NOT resuming "' + this.name + " again!" + RESET);
       return;
     }
-    print(CYAN + Date() + ' resuming ' + this.name + RESET);
+    print(CYAN + Date() + ' resuming ' + this.name + ', url: ' + this.url + RESET);
     if (!continueExternal(this.pid)) {
       throw new Error("Failed to resume " + this.name);
     }


### PR DESCRIPTION
### Scope & Purpose

Slightly improve debuggability:

* when restarting/stopping/resuming instances during testing, we now print not only the instance name but also its address (IP address plus port). this makes it easier to understand from the test output which servers were affected by restarting/stopping/resuming.
* suppress useless error message "did not understand destination ''" from the NetworkFeature that is expected temporarily after a server has unregistered itself from the cluster.
* remove some leftover debug code that was not used anymore.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -
  - [ ] Backport for 3.9: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 