### PR TITLE
Suppressing cppcheck warning

### DIFF
--- a/arangod/Auth/TokenCache.cpp
+++ b/arangod/Auth/TokenCache.cpp
@@ -396,6 +396,7 @@ bool auth::TokenCache::validateJwtHMAC256Signature(
   absl::WebSafeBase64Unescape(signatureWebBase64, &signature);
 
   READ_LOCKER(guard, _jwtSecretLock);
+  // cppcheck-suppress invalidLifetime
   return verifyHMAC(_jwtActiveSecret.data(), _jwtActiveSecret.size(),
                     message.data(), message.size(), signature.data(),
                     signature.size(),

--- a/arangod/Auth/TokenCache.cpp
+++ b/arangod/Auth/TokenCache.cpp
@@ -396,11 +396,10 @@ bool auth::TokenCache::validateJwtHMAC256Signature(
   absl::WebSafeBase64Unescape(signatureWebBase64, &signature);
 
   READ_LOCKER(guard, _jwtSecretLock);
-  // cppcheck-suppress invalidLifetime
-  return verifyHMAC(_jwtActiveSecret.data(), _jwtActiveSecret.size(),
-                    message.data(), message.size(), signature.data(),
-                    signature.size(),
-                    SslInterface::Algorithm::ALGORITHM_SHA256);
+  return verifyHMAC(
+      _jwtActiveSecret.data(), _jwtActiveSecret.size(), message.data(),
+      message.size(), signature.data(),  // cppcheck-suppress invalidLifetime
+      signature.size(), SslInterface::Algorithm::ALGORITHM_SHA256);
 }
 #endif
 

--- a/arangod/Auth/TokenCache.cpp
+++ b/arangod/Auth/TokenCache.cpp
@@ -397,7 +397,8 @@ bool auth::TokenCache::validateJwtHMAC256Signature(
 
   READ_LOCKER(guard, _jwtSecretLock);
   return verifyHMAC(
-      _jwtActiveSecret.data(), _jwtActiveSecret.size(), message.data(),
+      _jwtActiveSecret.data(), _jwtActiveSecret.size(),
+      message.data(),                    // cppcheck-suppress invalidLifetime
       message.size(), signature.data(),  // cppcheck-suppress invalidLifetime
       signature.size(), SslInterface::Algorithm::ALGORITHM_SHA256);
 }


### PR DESCRIPTION
### Scope & Purpose

cppcheck failed during nighly: https://jenkins01.arangodb.biz/job/arangodb-devel-cppcheck/848/  
The warning was related to the `verifyHMAC` call: "Using object that points to local variable 'message' that is out of scope.. Pointer to container is created here.".

cppcheck is overly cautious in this context.  There's nothing indicating that message goes out of scope within the function. The only usage of `validateJwtHMAC256Signature` occurs here:
```cpp
std::string const message = header + "." + body;
if (!validateJwtHMAC256Signature(message, signature)) {
  //...
}
```
The underlying data referenced by the `string_view` remains valid for its entire use. Therefore, I suppressed this warning.

cppcheck: https://jenkins01.arangodb.biz/job/arangodb-ANY-cppcheck/980/