### PR TITLE
[BTS-1124] Waiting for license to be applied

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 devel
 -----
 
+* BTS-1124: wait for license to be applied locally before responding to the request.
+
 * BTS-1566: remove redundant responsibility for creating local databases on
   coordinators.
 

--- a/arangod/Cluster/ServerState.cpp
+++ b/arangod/Cluster/ServerState.cpp
@@ -351,13 +351,13 @@ bool ServerState::readOnlyByLicense() {
 bool ServerState::setReadOnly(ReadOnlyMode ro) {
   auto ret = readOnly();
   if (ro == API_FALSE) {
-    ::serverStateReadOnly.exchange(false, std::memory_order_release);
+    ::serverStateReadOnly.store(false, std::memory_order_release);
   } else if (ro == API_TRUE) {
-    ::serverStateReadOnly.exchange(true, std::memory_order_release);
+    ::serverStateReadOnly.store(true, std::memory_order_release);
   } else if (ro == LICENSE_FALSE) {
-    ::licenseReadOnly.exchange(false, std::memory_order_release);
+    ::licenseReadOnly.store(false, std::memory_order_release);
   } else if (ro == LICENSE_TRUE) {
-    ::licenseReadOnly.exchange(true, std::memory_order_release);
+    ::licenseReadOnly.store(true, std::memory_order_release);
   }
   return ret;
 }


### PR DESCRIPTION
### Scope & Purpose

When applying a new license, we are responding slightly earlier than we should. This is just a timing issue and does not impact the license application itself. See the enterprise PR for more details.

- [x] :hankey: Bugfix

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

- [x] Enterprise PR: https://github.com/arangodb/enterprise/pull/1360
- [x] Jira ticket: [BTS-1124](https://arangodb.atlassian.net/browse/BTS-1124)



[BTS-1124]: https://arangodb.atlassian.net/browse/BTS-1124?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ