### PR TITLE
Exclude linker detection on MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -454,14 +454,16 @@ else ()
   add_definitions(-DUSE_BUILD_ID_READER=false)
 endif ()
 
+if (NOT MSVC)
 # Guess whether we're using mold
-execute_process(
-  COMMAND ${CMAKE_CXX_COMPILER} ${CMAKE_EXE_LINKER_FLAGS} -Wl,--version
-  OUTPUT_VARIABLE LINKER_VERSION_OUT)
-if (LINKER_VERSION_OUT MATCHES ^mold)
-  SET(LINKER_IS_MOLD TRUE)
-else ()
-  SET(LINKER_IS_MOLD FALSE)
+  execute_process(
+    COMMAND ${CMAKE_CXX_COMPILER} ${CMAKE_EXE_LINKER_FLAGS} -Wl,--version
+    OUTPUT_VARIABLE LINKER_VERSION_OUT)
+  if (LINKER_VERSION_OUT MATCHES ^mold)
+    SET(LINKER_IS_MOLD TRUE)
+  else ()
+    SET(LINKER_IS_MOLD FALSE)
+  endif ()
 endif ()
 
 # mold doesn't support the linker scripts currently used for the build id reader, and will result in the error


### PR DESCRIPTION
### Scope & Purpose

Avoid errors on MSVC:

```
cl : Command line error D8021: invalid numeric argument '/Wl,--version' [D:\win03-colo2\oskar\work\ArangoDB\build\package-arangodb-server-nsis.vcxproj]
```

introduced by https://github.com/arangodb/arangodb/pull/19635.
