### PR TITLE
BTS-1577: include more data in cluster info memory accounting

### DIFF
--- a/arangod/Agency/Node.h
+++ b/arangod/Agency/Node.h
@@ -23,18 +23,17 @@
 
 #pragma once
 
-#include "Basics/ResultT.h"
 #include "Agency/AgencyCommon.h"
+#include "Basics/ResultT.h"
 
+#include <atomic>
+#include <chrono>
 #include <cstdint>
+#include <cstring>
 #include <string>
 #include <string_view>
-#include <cstring>
-#include <chrono>
-
-#include <vector>
-#include <unordered_map>
 #include <span>
+#include <vector>
 
 #include <velocypack/String.h>
 #include <velocypack/Slice.h>

--- a/arangod/Agency/Node.h
+++ b/arangod/Agency/Node.h
@@ -335,9 +335,6 @@ class Node : public std::enable_shared_from_this<Node> {
 
   velocypack::ValueType getVelocyPackValueType() const noexcept;
 
-  bool isLeaveNode() const noexcept { return !isObject(); }
-  bool isPrimitiveValue() const noexcept { return !isObject() && !isArray(); }
-
   bool isReadLockable(std::string_view by) const;
   bool isWriteLockable(std::string_view by) const;
   bool isWriteLocked(std::string_view by) const {

--- a/arangod/Cluster/ClusterInfo.cpp
+++ b/arangod/Cluster/ClusterInfo.cpp
@@ -531,9 +531,11 @@ ClusterInfo::ClusterInfo(ArangodServer& server,
       _plannedDatabases(_resourceMonitor),
       _planVersion(0),
       _planIndex(0),
+      _planMemoryUsage(0),
+      _currentDatabases(_resourceMonitor),
       _currentVersion(0),
       _currentIndex(0),
-      _currentDatabases(_resourceMonitor),
+      _currentMemoryUsage(0),
       _plannedCollections(_resourceMonitor),
       _newPlannedCollections(_resourceMonitor),
       _shards(_resourceMonitor),
@@ -1873,6 +1875,17 @@ void ClusterInfo::loadPlan() {
   _planVersion = changeSet.version;
   _planIndex = changeSet.ind;
   _plan.swap(newPlan);
+
+  // update memory usage
+  std::uint64_t memoryUsage = 0;
+  for (auto const& it : _plan) {
+    TRI_ASSERT(it.second != nullptr);
+    memoryUsage += it.second->slice().byteSize();
+  }
+  _resourceMonitor.decreaseMemoryUsage(_planMemoryUsage);
+  _resourceMonitor.increaseMemoryUsage(memoryUsage);
+  _planMemoryUsage = memoryUsage;
+
   LOG_TOPIC("54321", DEBUG, Logger::CLUSTER)
       << "Updating ClusterInfo plan: version=" << _planVersion
       << " index=" << _planIndex;
@@ -2148,6 +2161,15 @@ void ClusterInfo::loadCurrent() {
   WRITE_LOCKER(writeLocker, _currentProt.lock);
 
   _current.swap(newCurrent);
+  std::uint64_t memoryUsage = 0;
+  for (auto const& it : _current) {
+    TRI_ASSERT(it.second != nullptr);
+    memoryUsage += it.second->slice().byteSize();
+  }
+  _resourceMonitor.decreaseMemoryUsage(_currentMemoryUsage);
+  _resourceMonitor.increaseMemoryUsage(memoryUsage);
+  _currentMemoryUsage = memoryUsage;
+
   _currentVersion = changeSet.version;
   _currentIndex = changeSet.ind;
   LOG_TOPIC("feddd", TRACE, Logger::CLUSTER)

--- a/arangod/Cluster/ClusterInfo.cpp
+++ b/arangod/Cluster/ClusterInfo.cpp
@@ -581,7 +581,12 @@ ClusterInfo::ClusterInfo(ArangodServer& server,
 /// @brief destroys a cluster info object
 ////////////////////////////////////////////////////////////////////////////////
 
-ClusterInfo::~ClusterInfo() = default;
+ClusterInfo::~ClusterInfo() {
+  _resourceMonitor.decreaseMemoryUsage(_planMemoryUsage);
+  _planMemoryUsage = 0;
+  _resourceMonitor.decreaseMemoryUsage(_currentMemoryUsage);
+  _currentMemoryUsage = 0;
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief cleanup method which frees cluster-internal shared ptrs on shutdown

--- a/arangod/Cluster/ClusterInfo.h
+++ b/arangod/Cluster/ClusterInfo.h
@@ -1133,19 +1133,23 @@ class ClusterInfo final {
 
   ProtectionData _planProt;
 
-  uint64_t _planVersion;     // This is the version in the Plan which underlies
-                             // the data in _plannedCollections and _shards
-  uint64_t _planIndex;       // This is the Raft index, which corresponds to the
-                             // above plan version
+  uint64_t _planVersion;  // This is the version in the Plan which underlies
+                          // the data in _plannedCollections and _shards
+  uint64_t _planIndex;    // This is the Raft index, which corresponds to the
+                          // above plan version
+  uint64_t _planMemoryUsage;  // memory usage of VPack objects inside _plan
+
+  AssocUnorderedContainer<pmr::DatabaseID,
+                          AssocUnorderedContainer<pmr::ServerID, VPackSlice>>
+      _currentDatabases;  // from Current/Databases
+  ProtectionData _currentProt;
   uint64_t _currentVersion;  // This is the version in Current which underlies
                              // the data in _currentDatabases,
                              // _currentCollections and _shardsIds
   uint64_t _currentIndex;    // This is the Raft index, which corresponds to the
                              // above current version
-  AssocUnorderedContainer<pmr::DatabaseID,
-                          AssocUnorderedContainer<pmr::ServerID, VPackSlice>>
-      _currentDatabases;  // from Current/Databases
-  ProtectionData _currentProt;
+  uint64_t
+      _currentMemoryUsage;  // memory usage of VPack objects inside _current
 
   // We need information about collections, again we have
   // data from Plan and from Current.


### PR DESCRIPTION
### Scope & Purpose

https://arangodb.atlassian.net/browse/BTS-1577
Include more data in ClusterInfo memory accounting.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -
  - [ ] Backport for 3.9: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [x] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/BTS-1577
- [ ] Design document: 