### PR TITLE
[BTS-842] Attempt to somewhat improve error message

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 devel
 -----
-
+* BTS-842: make the error message for edge document validation slightly
+  clearer
+>
 * ES-1727: Fix `UPDATE`, `REPLACE`, and `UPSERT ... UPDATE/REPLACE` failing with
   "conflict, _rev values do not match" for non-local edges in Smart- and
   EnterpriseGraphs, when `OPTIONS { ignoreRevs: false }` is supplied.

--- a/js/common/bootstrap/errors.js
+++ b/js/common/bootstrap/errors.js
@@ -94,7 +94,7 @@
     "ERROR_ARANGO_DATABASE_NAME_INVALID" : { "code" : 1229, "message" : "database name invalid" },
     "ERROR_ARANGO_USE_SYSTEM_DATABASE" : { "code" : 1230, "message" : "operation only allowed in system database" },
     "ERROR_ARANGO_INVALID_KEY_GENERATOR" : { "code" : 1232, "message" : "invalid key generator" },
-    "ERROR_ARANGO_INVALID_EDGE_ATTRIBUTE" : { "code" : 1233, "message" : "Expecting both `_from` and `_to` to be defined in edge document and have format `collectionName/vertexKey` " },
+    "ERROR_ARANGO_INVALID_EDGE_ATTRIBUTE" : { "code" : 1233, "message" : "Expecting both `_from` and `_to` attributes to be defined in the edge document and have the format `collectionName/vertexKey` " },
     "ERROR_ARANGO_INDEX_CREATION_FAILED" : { "code" : 1235, "message" : "index creation failed" },
     "ERROR_ARANGO_COLLECTION_TYPE_MISMATCH" : { "code" : 1237, "message" : "collection type mismatch" },
     "ERROR_ARANGO_COLLECTION_NOT_LOADED" : { "code" : 1238, "message" : "collection not loaded" },

--- a/js/common/bootstrap/errors.js
+++ b/js/common/bootstrap/errors.js
@@ -94,7 +94,7 @@
     "ERROR_ARANGO_DATABASE_NAME_INVALID" : { "code" : 1229, "message" : "database name invalid" },
     "ERROR_ARANGO_USE_SYSTEM_DATABASE" : { "code" : 1230, "message" : "operation only allowed in system database" },
     "ERROR_ARANGO_INVALID_KEY_GENERATOR" : { "code" : 1232, "message" : "invalid key generator" },
-    "ERROR_ARANGO_INVALID_EDGE_ATTRIBUTE" : { "code" : 1233, "message" : "edge attribute missing or invalid" },
+    "ERROR_ARANGO_INVALID_EDGE_ATTRIBUTE" : { "code" : 1233, "message" : "Expecting both `_from` and `_to` to be defined in edge document and have format `collectionName/vertexKey` " },
     "ERROR_ARANGO_INDEX_CREATION_FAILED" : { "code" : 1235, "message" : "index creation failed" },
     "ERROR_ARANGO_COLLECTION_TYPE_MISMATCH" : { "code" : 1237, "message" : "collection type mismatch" },
     "ERROR_ARANGO_COLLECTION_NOT_LOADED" : { "code" : 1238, "message" : "collection not loaded" },

--- a/js/common/bootstrap/errors.js
+++ b/js/common/bootstrap/errors.js
@@ -94,7 +94,7 @@
     "ERROR_ARANGO_DATABASE_NAME_INVALID" : { "code" : 1229, "message" : "database name invalid" },
     "ERROR_ARANGO_USE_SYSTEM_DATABASE" : { "code" : 1230, "message" : "operation only allowed in system database" },
     "ERROR_ARANGO_INVALID_KEY_GENERATOR" : { "code" : 1232, "message" : "invalid key generator" },
-    "ERROR_ARANGO_INVALID_EDGE_ATTRIBUTE" : { "code" : 1233, "message" : "Expecting both `_from` and `_to` attributes to be defined in the edge document and have the format `collectionName/vertexKey` " },
+    "ERROR_ARANGO_INVALID_EDGE_ATTRIBUTE" : { "code" : 1233, "message" : "expecting both `_from` and `_to` attributes to be defined in the edge document and have the format `collectionName/vertexKey` " },
     "ERROR_ARANGO_INDEX_CREATION_FAILED" : { "code" : 1235, "message" : "index creation failed" },
     "ERROR_ARANGO_COLLECTION_TYPE_MISMATCH" : { "code" : 1237, "message" : "collection type mismatch" },
     "ERROR_ARANGO_COLLECTION_NOT_LOADED" : { "code" : 1238, "message" : "collection not loaded" },

--- a/lib/Basics/errors.dat
+++ b/lib/Basics/errors.dat
@@ -117,7 +117,7 @@ ERROR_ARANGO_DATABASE_NOT_FOUND,1228,"database not found","Will be raised when a
 ERROR_ARANGO_DATABASE_NAME_INVALID,1229,"database name invalid","Will be raised when an invalid database name is used."
 ERROR_ARANGO_USE_SYSTEM_DATABASE,1230,"operation only allowed in system database","Will be raised when an operation is requested in a database other than the system database."
 ERROR_ARANGO_INVALID_KEY_GENERATOR,1232,"invalid key generator","Will be raised when an invalid key generator description is used."
-ERROR_ARANGO_INVALID_EDGE_ATTRIBUTE,1233,"expecting both `_from` and `_to` attributes to be defined in the edge document and have the format `collectionName/vertexKey` ","will be raised when the _from or _to values of an edge are undefined or contain an invalid value."
+ERROR_ARANGO_INVALID_EDGE_ATTRIBUTE,1233,"expecting both `_from` and `_to` attributes to be defined in the edge document and have the format `<collectionName>/<vertexKey>` ","will be raised when the _from or _to values of an edge are undefined or contain an invalid value."
 ERROR_ARANGO_INDEX_CREATION_FAILED,1235,"index creation failed","Will be raised when an attempt to create an index has failed."
 ERROR_ARANGO_COLLECTION_TYPE_MISMATCH,1237,"collection type mismatch","Will be raised when a collection has a different type from what has been expected."
 ERROR_ARANGO_COLLECTION_NOT_LOADED,1238,"collection not loaded","Will be raised when a collection is accessed that is not yet loaded."

--- a/lib/Basics/errors.dat
+++ b/lib/Basics/errors.dat
@@ -117,7 +117,7 @@ ERROR_ARANGO_DATABASE_NOT_FOUND,1228,"database not found","Will be raised when a
 ERROR_ARANGO_DATABASE_NAME_INVALID,1229,"database name invalid","Will be raised when an invalid database name is used."
 ERROR_ARANGO_USE_SYSTEM_DATABASE,1230,"operation only allowed in system database","Will be raised when an operation is requested in a database other than the system database."
 ERROR_ARANGO_INVALID_KEY_GENERATOR,1232,"invalid key generator","Will be raised when an invalid key generator description is used."
-ERROR_ARANGO_INVALID_EDGE_ATTRIBUTE,1233,"edge attribute missing or invalid","will be raised when the _from or _to values of an edge are undefined or contain an invalid value."
+ERROR_ARANGO_INVALID_EDGE_ATTRIBUTE,1233,"Expecting both `_from` and `_to` to be defined in edge document and have format `collectionName/vertexKey` ","will be raised when the _from or _to values of an edge are undefined or contain an invalid value."
 ERROR_ARANGO_INDEX_CREATION_FAILED,1235,"index creation failed","Will be raised when an attempt to create an index has failed."
 ERROR_ARANGO_COLLECTION_TYPE_MISMATCH,1237,"collection type mismatch","Will be raised when a collection has a different type from what has been expected."
 ERROR_ARANGO_COLLECTION_NOT_LOADED,1238,"collection not loaded","Will be raised when a collection is accessed that is not yet loaded."

--- a/lib/Basics/errors.dat
+++ b/lib/Basics/errors.dat
@@ -117,7 +117,7 @@ ERROR_ARANGO_DATABASE_NOT_FOUND,1228,"database not found","Will be raised when a
 ERROR_ARANGO_DATABASE_NAME_INVALID,1229,"database name invalid","Will be raised when an invalid database name is used."
 ERROR_ARANGO_USE_SYSTEM_DATABASE,1230,"operation only allowed in system database","Will be raised when an operation is requested in a database other than the system database."
 ERROR_ARANGO_INVALID_KEY_GENERATOR,1232,"invalid key generator","Will be raised when an invalid key generator description is used."
-ERROR_ARANGO_INVALID_EDGE_ATTRIBUTE,1233,"Expecting both `_from` and `_to` to be defined in edge document and have format `collectionName/vertexKey` ","will be raised when the _from or _to values of an edge are undefined or contain an invalid value."
+ERROR_ARANGO_INVALID_EDGE_ATTRIBUTE,1233,"expecting both `_from` and `_to` attributes to be defined in the edge document and have the format `collectionName/vertexKey` ","will be raised when the _from or _to values of an edge are undefined or contain an invalid value."
 ERROR_ARANGO_INDEX_CREATION_FAILED,1235,"index creation failed","Will be raised when an attempt to create an index has failed."
 ERROR_ARANGO_COLLECTION_TYPE_MISMATCH,1237,"collection type mismatch","Will be raised when a collection has a different type from what has been expected."
 ERROR_ARANGO_COLLECTION_NOT_LOADED,1238,"collection not loaded","Will be raised when a collection is accessed that is not yet loaded."

--- a/tests/js/client/shell/api/multi/general-graph.js
+++ b/tests/js/client/shell/api/multi/general-graph.js
@@ -1004,7 +1004,7 @@ function check_edge_operationSuite () {
       let doc = replace_edge(sync, graph_name, friend_collection, key, {"type2": "divorced", "_from": "1", "_to": "2"});
       assertEqual(doc.code, internal.errors.ERROR_HTTP_BAD_PARAMETER.code);
       assertTrue(doc.parsedBody['error']);
-      assertMatch(/.*edge attribute missing or invalid.*/, doc.parsedBody['errorMessage'], doc);
+      assertMatch(/.*expecting both `_from` and `_to` attributes to be defined.*/, doc.parsedBody['errorMessage'], doc);
       assertEqual(doc.parsedBody['code'], internal.errors.ERROR_HTTP_BAD_PARAMETER.code);
     },
 
@@ -1215,7 +1215,7 @@ function check400 (doc) {
   assertTrue(doc.parsedBody['error']);
   assertEqual(doc.parsedBody['code'], internal.errors.ERROR_HTTP_BAD_PARAMETER.code);
   // puts doc.parsedBody['errorMessage'];
-  assertMatch(/.*edge attribute missing or invalid.*/, doc.parsedBody['errorMessage'], doc);
+  assertMatch(/.*expecting both `_from` and `_to` attributes to be defined.*/, doc.parsedBody['errorMessage'], doc);
 }
 
 function check404Edge (doc) {
@@ -1286,7 +1286,7 @@ function check400_edge_missing (doc) {
   assertTrue(doc.parsedBody['error']);
   assertEqual(doc.parsedBody['code'], internal.errors.ERROR_HTTP_BAD_PARAMETER.code);
   assertEqual(doc.parsedBody['errorNum'], internal.errors.ERROR_ARANGO_INVALID_EDGE_ATTRIBUTE.code);
-  assertMatch(/.*edge attribute missing or invalid.*/, doc.parsedBody['errorMessage'], doc);
+  assertMatch(/.*expecting both `_from` and `_to` attributes to be defined.*/, doc.parsedBody['errorMessage'], doc);
 }
 
 function check404_graph_not_found (doc) {

--- a/tests/js/common/aql/aql-insert-multiple-cluster.js
+++ b/tests/js/common/aql/aql-insert-multiple-cluster.js
@@ -598,7 +598,7 @@ function InsertMultipleDocumentsSuite(params) {
           db._query(query);
           fail();
         } catch (err) {
-          assertTrue(err.errorMessage.includes("edge attribute missing"));
+          assertEqual(err.errorNum, 1233, "expecting error 1233 to be thrown, got ${err.errorNum}");
           assertEqual(db[edges].count(), edgesCount + 1);
           assertEqual(db["_from_" + edges].count(), db["_to_" + edges].count());
         }


### PR DESCRIPTION
Improve error message when parsing of edge document fails.

This is not an ideal solution, but the error reporting facilities currently do not allow for an error message that reports exactly what the parse error is.