### PR TITLE
BTS-1590: fix undefined behavior

### DIFF
--- a/arangod/Network/Methods.cpp
+++ b/arangod/Network/Methods.cpp
@@ -249,7 +249,7 @@ void actuallySendRequest(std::shared_ptr<Pack>&& p, ConnectionPool* pool,
   NetworkFeature& nf = server.getFeature<NetworkFeature>();
   nf.sendRequest(
       *pool, options, endpoint, std::move(req),
-      [pack(std::move(p)), pool, &options, endpoint](
+      [pack(std::move(p)), pool, options, endpoint](
           fuerte::Error err, std::unique_ptr<fuerte::Request> req,
           std::unique_ptr<fuerte::Response> res, bool isFromPool) mutable {
         TRI_ASSERT(req != nullptr || err == fuerte::Error::ConnectionCanceled);
@@ -258,8 +258,8 @@ void actuallySendRequest(std::shared_ptr<Pack>&& p, ConnectionPool* pool,
                            err == fuerte::Error::WriteError)) {
           // retry under certain conditions
           // cppcheck-suppress accessMoved
-          actuallySendRequest(std::move(pack), pool, options, endpoint,
-                              std::move(req));
+          actuallySendRequest(std::move(pack), pool, std::move(options),
+                              std::move(endpoint), std::move(req));
           return;
         }
 


### PR DESCRIPTION
### Scope & Purpose

Potentially fixes https://arangodb.atlassian.net/browse/BTS-1590

`options` object was captured by reference (also in previous versions), but it wasn't guaranteed that it was still alive and valid when the lambda was executed.
Hopefully this fixes the UBSan error
```
/work/ArangoDB/arangod/Network/NetworkFeature.cpp:387:40: runtime error: load of value 94, which is not a valid value for type 'bool'
```

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.11: https://github.com/arangodb/arangodb/pull/19673
  - [x] Backport for 3.10: https://github.com/arangodb/arangodb/pull/19674
  - [ ] Backport for 3.9: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [x] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/BTS-1590
- [ ] Design document: 