### PR TITLE
BTS-1590: fix undefined behavior

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,10 @@
+v3.11.4 (XXXX-XX-XX)
+--------------------
+
+* Fixed BTS-1590: Fixed potentially undefined behavior in NetworkFeature, when
+  it was referring to an options object that could have been destroyed already.
+
+
 v3.11.3 (2023-08-17)
 --------------------
 
@@ -13,9 +20,6 @@ v3.11.3 (2023-08-17)
 * BTS-1549: adjust permission handling in experimental dump to the same behavior
   as in non-experimental dump.
 
-* Fixed BTS-1554: wrong aggregation count when an "in" or "or" condition was
-  executed through an index lookup.
-
 * Fixed AQL WINDOW statement for OneShard databases: Whenever WINDOW is used in
   the row based variant like (e.g. WINDOW { preceding: 1, following: 1 }) it
   errored with:  mandatory variable "inVariable" not found. This variable is now
@@ -24,9 +28,6 @@ v3.11.3 (2023-08-17)
 * Fixed AQL WINDOW statement for OneShard databases: Whenever WINDOW is used on
   a OneShardDatabase, or on data from a collection that only has one shard, the
   preceding and following clauses were flipped.
-
-* Fixed BTS-1554: wrong aggregation count when an "in" or "or" condition was
-  executed through an index lookup.
 
 * Updated arangosync to v2.19.3.
 

--- a/arangod/Network/Methods.cpp
+++ b/arangod/Network/Methods.cpp
@@ -245,7 +245,7 @@ void actuallySendRequest(std::shared_ptr<Pack>&& p, ConnectionPool* pool,
   NetworkFeature& nf = server.getFeature<NetworkFeature>();
   nf.sendRequest(
       *pool, options, endpoint, std::move(req),
-      [p(std::move(p)), pool, &options, endpoint](
+      [p(std::move(p)), pool, options, endpoint](
           fuerte::Error err, std::unique_ptr<fuerte::Request> req,
           std::unique_ptr<fuerte::Response> res, bool isFromPool) mutable {
         TRI_ASSERT(req != nullptr || err == fuerte::Error::ConnectionCanceled);
@@ -254,8 +254,8 @@ void actuallySendRequest(std::shared_ptr<Pack>&& p, ConnectionPool* pool,
                            err == fuerte::Error::WriteError)) {
           // retry under certain conditions
           // cppcheck-suppress accessMoved
-          actuallySendRequest(std::move(p), pool, options, endpoint,
-                              std::move(req));
+          actuallySendRequest(std::move(p), pool, std::move(options),
+                              std::move(endpoint), std::move(req));
           return;
         }
 


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/19672
Potentially fixes https://arangodb.atlassian.net/browse/BTS-1590

`options` object was captured by reference (also in previous versions), but it wasn't guaranteed that it was still alive and valid when the lambda was executed.
Hopefully this fixes the UBSan error
```
/work/ArangoDB/arangod/Network/NetworkFeature.cpp:387:40: runtime error: load of value 94, which is not a valid value for type 'bool'
```

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.11: this PR
  - [x] Backport for 3.10: https://github.com/arangodb/arangodb/pull/19674
  - [ ] Backport for 3.9: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [x] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/BTS-1590
- [ ] Design document: 