### PR TITLE
BTS-1590: fix undefined behavior

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 v3.10.11 (XXXX-XX-XX)
 ---------------------
 
+* Fixed BTS-1590: Fixed potentially undefined behavior in NetworkFeature, when
+  it was referring to an options object that could have been destroyed already.
+
 * BTS-1549: adjust permission handling in experimental dump to the same behavior
   as in non-experimental dump.
 

--- a/arangod/Network/Methods.cpp
+++ b/arangod/Network/Methods.cpp
@@ -236,7 +236,7 @@ void actuallySendRequest(std::shared_ptr<Pack>&& p, ConnectionPool* pool,
   NetworkFeature& nf = server.getFeature<NetworkFeature>();
   nf.sendRequest(
       *pool, options, endpoint, std::move(req),
-      [p(std::move(p)), pool, &options, endpoint](
+      [p(std::move(p)), pool, options, endpoint](
           fuerte::Error err, std::unique_ptr<fuerte::Request> req,
           std::unique_ptr<fuerte::Response> res, bool isFromPool) mutable {
         TRI_ASSERT(req != nullptr || err == fuerte::Error::ConnectionCanceled);
@@ -245,8 +245,8 @@ void actuallySendRequest(std::shared_ptr<Pack>&& p, ConnectionPool* pool,
                            err == fuerte::Error::WriteError)) {
           // retry under certain conditions
           // cppcheck-suppress accessMoved
-          actuallySendRequest(std::move(p), pool, options, endpoint,
-                              std::move(req));
+          actuallySendRequest(std::move(p), pool, std::move(options),
+                              std::move(endpoint), std::move(req));
           return;
         }
 


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/19672
Potentially fixes https://arangodb.atlassian.net/browse/BTS-1590

`options` object was captured by reference (also in previous versions), but it wasn't guaranteed that it was still alive and valid when the lambda was executed.
Hopefully this fixes the UBSan error
```
/work/ArangoDB/arangod/Network/NetworkFeature.cpp:387:40: runtime error: load of value 94, which is not a valid value for type 'bool'
```

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.11: https://github.com/arangodb/arangodb/pull/19673
  - [x] Backport for 3.10: this PR
  - [ ] Backport for 3.9: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [x] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/BTS-1590
- [ ] Design document: 