### PR TITLE
[3.11] [ES-1727] Fix Smart- and EnterpriseGraph modifications with ignoreRevs: false

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 v3.11.4 (XXXX-XX-XX)
 --------------------
 
+* ES-1727: Fix `UPDATE`, `REPLACE`, and `UPSERT ... UPDATE/REPLACE` failing with
+  "conflict, _rev values do not match" for non-local edges in Smart- and
+  EnterpriseGraphs, when `OPTIONS { ignoreRevs: false }` is supplied.
+
 * Fixed BTS-1590: Fixed potentially undefined behavior in NetworkFeature, when
   it was referring to an options object that could have been destroyed already.
 


### PR DESCRIPTION
Backport of #19683