### PR TITLE
deprecate arangodump startup options

### DIFF
--- a/client-tools/Dump/DumpFeature.cpp
+++ b/client-tools/Dump/DumpFeature.cpp
@@ -782,13 +782,18 @@ void DumpFeature::collectOptions(
                   "Wrap each document into a {type, data} envelope "
                   "(this is required for compatibility with v3.7 and before).",
                   new BooleanParameter(&_options.useEnvelope))
-      .setIntroducedIn(30800);
+      .setIntroducedIn(30800)
+      .setDeprecatedIn(31104);
 
-  options->addOption("--tick-start", "Only include data after this tick.",
-                     new UInt64Parameter(&_options.tickStart));
+  options
+      ->addOption("--tick-start", "Only include data after this tick.",
+                  new UInt64Parameter(&_options.tickStart))
+      .setDeprecatedIn(31104);
 
-  options->addOption("--tick-end", "Last tick to be included in data dump.",
-                     new UInt64Parameter(&_options.tickEnd));
+  options
+      ->addOption("--tick-end", "Last tick to be included in data dump.",
+                  new UInt64Parameter(&_options.tickEnd))
+      .setDeprecatedIn(31104);
 
   options
       ->addOption("--maskings", "A path to a file with masking definitions.",


### PR DESCRIPTION
### Scope & Purpose

This PR deprecates the following arangodump startup options:

* `--envelope`: setting this option to true previously wrapped every dumped document into a {data, type} envelope. This was useful for the MMFiles storage engine, where dumps could also include document removals. With the RocksDB storage engine, the envelope only caused overhead and increased the size of the dumps. The default value of `--envelope` was changed to false in ArangoDB 3.9 already, so by default all arangodump invocations since then created non-envelope dumps.
* `--tick-start`: setting this option allowed to restrict the dumped data to some time range with the MMFiles storage engine. It has no effect for the RocksDB storage engine.
* `--tick-end`: setting this option allowed to restrict the dumped data to some time range with the MMFiles storage engine. It has no effect for the RocksDB storage engine.

These options will be fully obsoleted in ArangoDB 3.12 via https://github.com/arangodb/arangodb/pull/19680

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.11: this PR
  - [x] Backport for 3.10: https://github.com/arangodb/arangodb/pull/19688
  - [ ] Backport for 3.9: -

#### Related Information

- [x] Docs PR: https://github.com/arangodb/docs/pull/1461
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 