### PR TITLE
Remove 3.9 from PR Template

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -19,7 +19,6 @@
 - [ ] Backports
   - [ ] Backport for 3.11: *(Please link PR)*
   - [ ] Backport for 3.10: *(Please link PR)*
-  - [ ] Backport for 3.9: *(Please link PR)*
 
 #### Related Information
 


### PR DESCRIPTION
### Scope & Purpose

Remove 3.9 from PR Template, as it is EOL.

