### PR TITLE
BTS-1598: Bug fix/fix unprotected access

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,8 +1,11 @@
 devel
 -----
+
+* BTS-1598: fix race in agency
+
 * BTS-842: make the error message for edge document validation slightly
   clearer
->
+
 * ES-1727: Fix `UPDATE`, `REPLACE`, and `UPSERT ... UPDATE/REPLACE` failing with
   "conflict, _rev values do not match" for non-local edges in Smart- and
   EnterpriseGraphs, when `OPTIONS { ignoreRevs: false }` is supplied.

--- a/arangod/Agency/State.cpp
+++ b/arangod/Agency/State.cpp
@@ -931,8 +931,11 @@ bool State::loadPersisted() {
       LOG_TOPIC("1a476", INFO, Logger::AGENCY)
           << "Non matching compaction and log indexes. Dropping both "
              "collections";
-      _log.clear();
-      _cur = 0;
+      {
+        std::lock_guard logLock{_logLock};
+        _log.clear();
+        _cur = 0;
+      }
       dropCollection("log");
       dropCollection("compact");
     }


### PR DESCRIPTION
### Scope & Purpose

access to _log needs to be done in mutex. Else other access may garble.

- [x] :hankey: Bugfix

### Checklist
- [x] :book: CHANGELOG entry made
- [x] Backports
  - [x] Backport for 3.11: https://github.com/arangodb/arangodb/pull/19693
  - [x] Backport for 3.10: https://github.com/arangodb/arangodb/pull/19694

#### Related Information

- [x] [Jira ticket](https://arangodb.atlassian.net/browse/BTS-1598)

