### PR TITLE
[BTS-1589] Fix read after free

### DIFF
--- a/arangod/VocBase/LogicalCollection.cpp
+++ b/arangod/VocBase/LogicalCollection.cpp
@@ -356,7 +356,7 @@ replication::Version LogicalCollection::replicationVersion() const noexcept {
   return vocbase().replicationVersion();
 }
 
-std::string const& LogicalCollection::distributeShardsLike() const noexcept {
+std::string LogicalCollection::distributeShardsLike() const noexcept {
   if (ServerState::instance()->isCoordinator() &&
       replicationVersion() == replication::Version::TWO) {
     auto& cf = vocbase().server().getFeature<ClusterFeature>();
@@ -377,6 +377,8 @@ std::string const& LogicalCollection::distributeShardsLike() const noexcept {
       // If i am the leader, return the empty string
       return StaticStrings::Empty;
     }
+    // Note that this string must be copied before the shared_ptr is dropped,
+    // so the return value cannot be a reference.
     return myGroup->groupLeader;
   } else {
     TRI_ASSERT(_sharding != nullptr);

--- a/arangod/VocBase/LogicalCollection.h
+++ b/arangod/VocBase/LogicalCollection.h
@@ -224,7 +224,7 @@ class LogicalCollection : public LogicalDataSource {
   size_t replicationFactor() const noexcept;
   size_t writeConcern() const noexcept;
   replication::Version replicationVersion() const noexcept;
-  std::string const& distributeShardsLike() const noexcept;
+  std::string distributeShardsLike() const noexcept;
   bool isSatellite() const noexcept;
   bool usesDefaultShardKeys() const noexcept;
   std::vector<std::string> const& shardKeys() const noexcept;


### PR DESCRIPTION
### Scope & Purpose

TSan found a data race by a write during `~NewStuffByDatabase`, when destroying a `shared_ptr<CollectionGroupPlanSpecification>`, and a read in `ClusterInfo::dropCollectionCoordinator`. While not 100% clear from the stack trace, the only candidate seems to be a `std::string const&` returned by `LogicalCollection::distributeShardsLike`, which is taken from `ClusterInfo::_collectionGroups` for replication v2 since https://github.com/arangodb/arangodb/pull/19659. Note that `_newStuffByDatabase` shares its `shared_ptr<CollectionGroupPlanSpecification>` with `_collectionGroups`.

Having `distributeShardsLike` return a copy of that string instead of a reference should solve that problem.

- [X] :hankey: Bugfix

#### Related Information

Introduced by https://github.com/arangodb/arangodb/pull/19659. No need for backports.

