### PR TITLE
[BTS-1460][3.10] Directly kill aborted query, do not wait for GC 

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 v3.10.11 (XXXX-XX-XX)
 ---------------------
 
+* Whenever there is a query request timeout in AQL (e.g., a server died)
+  which causes the query to fail, the DBServers will now all directly kill
+  their potentially ongoing parts of the query and not wait for garbage collection.
+
 * Upgraded Swagger-UI to v5.4.1.
 
 * Fixed BTS-1590: Fixed potentially undefined behavior in NetworkFeature, when

--- a/arangod/Aql/QueryRegistry.cpp
+++ b/arangod/Aql/QueryRegistry.cpp
@@ -289,7 +289,7 @@ std::shared_ptr<ClusterQuery> QueryRegistry::destroyQuery(
       TRI_ASSERT(!q->second->_isTombstone);
 
       // query in use by another thread/request
-      if (errorCode == TRI_ERROR_QUERY_KILLED) {
+      if (errorCode != TRI_ERROR_NO_ERROR) {
         q->second->_query->kill();
       }
       q->second->_expires = 0.0;

--- a/arangod/Aql/RemoteExecutor.cpp
+++ b/arangod/Aql/RemoteExecutor.cpp
@@ -538,6 +538,11 @@ Result ExecutionBlockImpl<RemoteExecutor>::sendAsyncRequest(
 
   _requestInFlight = true;
   auto ticket = generateRequestTicket();
+  TRI_IF_FAILURE("RemoteExecutor::impatienceTimeout") {
+    // Vastly lower the request timeout. This should guarantee
+    // a network timeout triggered and not continue with the query.
+    req->timeout(std::chrono::seconds(2));
+  }
   conn->sendRequest(
       std::move(req),
       [this, ticket, spec, sqs = _engine->sharedState()](


### PR DESCRIPTION
### Scope & Purpose

If a query throws an error right now (most likely timeout) all DBServers are informed with this error, that the query will fail. However so far they only react on "query killed" to locally abort. With this PR we enable that every error triggers a kill query on all snippets, so we avoid to wait for garbage collection and can quickly stop working on the query.

- [x] :hankey: Bugfix

### Checklist

- [x] Tests
  - [x] **integration tests**
- [x] :book: CHANGELOG entry made
- [x] Backports
  - [x] Backport for 3.11: already done (https://github.com/arangodb/arangodb/pull/19226)

#### Related Information

- [x] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/BTS-1460?focusedCommentId=95203

