### PR TITLE
minor internal improvements for arangodump

### DIFF
--- a/client-tools/Dump/DumpFeature.cpp
+++ b/client-tools/Dump/DumpFeature.cpp
@@ -55,6 +55,7 @@
 
 #include <chrono>
 #include <thread>
+#include <unordered_map>
 
 #include <absl/strings/str_cat.h>
 #include <velocypack/Collection.h>
@@ -83,7 +84,7 @@ std::string serverLabel(std::string const& server) {
   return absl::StrCat(" on server '", server, "'");
 }
 
-constexpr std::string_view getSuffix(bool useVPack) noexcept {
+constexpr std::string_view getDatafileSuffix(bool useVPack) noexcept {
   std::string_view suffix("json");
   if (useVPack) {
     suffix = "vpack";
@@ -647,7 +648,7 @@ Result DumpFeature::DumpCollectionJob::run(
     // always create the file so that arangorestore does not complain
     auto file = directory.writableFile(
         absl::StrCat(escapedName, "_", hexString, ".data.",
-                     ::getSuffix(options.useVPack)),
+                     ::getDatafileSuffix(options.useVPack)),
         true /*overwrite*/, 0, true /*gzipOk*/);
     if (!::fileOk(file.get())) {
       return ::fileError(file.get(), true);
@@ -724,8 +725,8 @@ Result DumpFeature::DumpShardJob::run(
     arangodb::httpclient::SimpleHttpClient& client) {
   if (options.progress) {
     LOG_TOPIC("a27be", INFO, arangodb::Logger::DUMP)
-        << "# Dumping shard '" << shardName << "' from DBserver '" << server
-        << "' ...";
+        << "# Dumping shard '" << shardName << "' of collection '"
+        << collectionName << "' from DBserver '" << server << "'...";
   }
 
   // make sure we have a batch on this dbserver
@@ -1658,13 +1659,27 @@ void DumpFeature::ParallelDumpServer::finishDumpContext(
 Result DumpFeature::ParallelDumpServer::run(
     httpclient::SimpleHttpClient& client) {
   LOG_TOPIC("23f92", INFO, Logger::DUMP)
-      << "preparing data stream" << serverLabel(server);
+      << "preparing data stream" << serverLabel(server) << ", using "
+      << options.dbserverWorkerThreads << " DBServer worker thread(s), "
+      << options.localNetworkThreads << " network thread(s), "
+      << options.localWriterThreads
+      << " local writer thread(s), number of prefetch batches: "
+      << options.dbserverPrefetchBatches;
 
   // create context on dbserver
   createDumpContext(client);
 
-  // start n network threads
   std::vector<std::thread> threads;
+
+  auto threadGuard = scopeGuard([&threads]() noexcept {
+    // on our way out, we wait for all threads to join
+    for (auto& thrd : threads) {
+      thrd.join();
+    }
+    threads.clear();
+  });
+
+  // start n network threads
   for (size_t i = 0; i < options.localNetworkThreads; i++) {
     threads.emplace_back([&, i, guard = BoundedChannelProducerGuard{queue}] {
       runNetworkThread(i);
@@ -1676,11 +1691,7 @@ Result DumpFeature::ParallelDumpServer::run(
     threads.emplace_back(&ParallelDumpServer::runWriterThread, this);
   }
 
-  // on our way out, we wait for all threads to join
-  for (auto& thrd : threads) {
-    thrd.join();
-  }
-  threads.clear();
+  threadGuard.fire();
 
   // remove dump context from server - get a new client because the old might
   // already be disconnected.
@@ -1690,7 +1701,7 @@ Result DumpFeature::ParallelDumpServer::run(
 
   LOG_TOPIC("1b7fe", INFO, Logger::DUMP) << "all data received for " << server;
 
-  return Result{};
+  return {};
 }
 
 void DumpFeature::ParallelDumpServer::ParallelDumpServer::printBlockStats() {
@@ -1840,10 +1851,12 @@ void DumpFeature::ParallelDumpServer::runNetworkThread(
 }
 
 void DumpFeature::ParallelDumpServer::runWriterThread() {
-  std::unordered_map<std::string, std::shared_ptr<ManagedDirectory::File>>
+  std::unordered_map<
+      std::string,
+      std::pair<std::shared_ptr<ManagedDirectory::File>, std::string>>
       filesByShard;
 
-  auto const getFileForShard = [&](std::string const& shardId) {
+  auto const getDataForShard = [&](std::string const& shardId) {
     if (auto it = filesByShard.find(shardId); it != filesByShard.end()) {
       return it->second;
     } else {
@@ -1854,9 +1867,10 @@ void DumpFeature::ParallelDumpServer::runWriterThread() {
         FATAL_ERROR_EXIT();
       }
 
-      auto file = fileProvider->getFile(it2->second.collectionName);
-      filesByShard.emplace(shardId, file);
-      return file;
+      std::string collectionName = it2->second.collectionName;
+      auto file = fileProvider->getFile(collectionName);
+      filesByShard.emplace(shardId, std::make_pair(file, collectionName));
+      return std::make_pair(std::move(file), std::move(collectionName));
     }
   };
 
@@ -1908,10 +1922,13 @@ void DumpFeature::ParallelDumpServer::runWriterThread() {
       body = uncompressed;
     }
 
-    auto file = getFileForShard(shardId);
-    arangodb::Result result =
-        dumpData(stats, maskings, *file, body,
-                 shards.at(shardId).collectionName, options.useVPack);
+    auto [file, collectionName] = getDataForShard(shardId);
+    arangodb::Result result = dumpData(stats, maskings, *file, body,
+                                       collectionName, options.useVPack);
+
+    LOG_TOPIC("ab681", TRACE, Logger::DUMP)
+        << "writing data for shard '" << shardId << "' of collection '"
+        << collectionName << "' into file '" << file->path() << "'";
 
     if (result.fail()) {
       LOG_TOPIC("77881", FATAL, Logger::DUMP)
@@ -1944,7 +1961,7 @@ DumpFeature::DumpFileProvider::DumpFileProvider(
           escapedCollectionName(name, info.get("parameters"));
 
       std::string filename = absl::StrCat(escapedName, "_", hexString, ".data.",
-                                          ::getSuffix(_useVPack));
+                                          ::getDatafileSuffix(_useVPack));
       auto file = _directory.writableFile(filename, true /*overwrite*/, 0,
                                           true /*gzipOk*/);
       if (file == nullptr || file->status().fail()) {
@@ -1971,14 +1988,15 @@ std::shared_ptr<ManagedDirectory::File> DumpFeature::DumpFileProvider::getFile(
 
   if (_splitFiles) {
     auto cnt = _filesByCollection[name].count++;
-    std::string filename = absl::StrCat(escapedName, "_", hexString, ".", cnt,
-                                        ".data.", ::getSuffix(_useVPack));
+    std::string filename =
+        absl::StrCat(escapedName, "_", hexString, ".", cnt, ".data.",
+                     ::getDatafileSuffix(_useVPack));
     auto file = _directory.writableFile(filename, true /*overwrite*/, 0,
                                         true /*gzipOk*/);
     if (file == nullptr || file->status().fail()) {
       LOG_TOPIC("43543", FATAL, Logger::DUMP)
           << "Failed to open file " << filename
-          << " for writing: " << file->status().errorMessage();
+          << " for writing: " << file->status();
       FATAL_ERROR_EXIT();
     }
 


### PR DESCRIPTION
### Scope & Purpose

Small internal improvements for arangodump:

- add trace log messages to see what it is doing
- save collection name in shard => file map to avoid extra lookup later
- rename a function to make its purpose more clear
- make sure started threads are properly shut down even if an exception happens

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 