### PR TITLE
Fixed BTS-1380

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,43 +1,45 @@
 devel
 -----
 
+* BTS-1380: Added traversal order (dfs, bfs, weighted) to explain output.
+
 * Updated ArangoDB Starter to 0.17.1-preview-1.
 
 * Renamed arangodump startup option `--use-experimental-dump` to
-       `--parallel-dump`.
+  `--parallel-dump`.
 
 * Improved experimental dump functionality in arangodump to work in single
-       server mode and to support transport compression and dumping velocypack data.
+  server mode and to support transport compression and dumping velocypack data.
 
 * Obsolete the following options of arangodump:
-       - `--envelope`: setting this option to true previously wrapped every dumped
-               document into a {data, type} envelope. This was useful for the MMFiles
-               storage engine, where dumps could also include document removals. With the
-               RocksDB storage engine, the envelope only caused overhead and increased the
-               size of the dumps. The default value of `--envelope` was changed to `false`
-               in ArangoDB 3.9 already, so by default all arangodump invocations since
-               then created non-envelope dumps. With the option being removed now, all
-               arangodump invocations will unconditionally create non-envelope dumps.
-       - `--tick-start`: setting this option allowed to restrict the dumped data
-               to some time range with the MMFiles storage engine. It had no effect for
-               the RocksDB storage engine and so it is removed now.
-       - `--tick-end`: setting this option allowed to restrict the dumped data
-               to some time range with the MMFiles storage engine. It had no effect for
-               the RocksDB storage engine and so it is removed now.
+  - `--envelope`: setting this option to true previously wrapped every dumped
+    document into a {data, type} envelope. This was useful for the MMFiles
+    storage engine, where dumps could also include document removals. With the
+    RocksDB storage engine, the envelope only caused overhead and increased the
+    size of the dumps. The default value of `--envelope` was changed to `false`
+    in ArangoDB 3.9 already, so by default all arangodump invocations since
+    then created non-envelope dumps. With the option being removed now, all
+    arangodump invocations will unconditionally create non-envelope dumps.
+  - `--tick-start`: setting this option allowed to restrict the dumped data
+    to some time range with the MMFiles storage engine. It had no effect for
+    the RocksDB storage engine and so it is removed now.
+  - `--tick-end`: setting this option allowed to restrict the dumped data
+    to some time range with the MMFiles storage engine. It had no effect for
+    the RocksDB storage engine and so it is removed now.
 
 * Added experimental options to arangodump:
-       - `--compress-transfer`: setting this option enables gzip-compression for the
-               server responses to dump requests. Enabling it can significantly reduce
-               traffic volume from the server back to arangodump, in exchange for some CPU
-               overhead for compression on the server and decompression in arangodump.
-               The default value for this option is false. Setting this option only
-               affects the transfer, but not the on-disk format of dumps.
-       - `--dump-vpack`: setting this option will dump data in raw velocypack
-               format. This will make arangodump operate faster and create smaller dumps.
-               The default value for this option is false, as enabling it would
-               incompatibly change the on-disk format of dumps.
+  - `--compress-transfer`: setting this option enables gzip-compression for the
+    server responses to dump requests. Enabling it can significantly reduce
+    traffic volume from the server back to arangodump, in exchange for some CPU
+    overhead for compression on the server and decompression in arangodump.
+    The default value for this option is false. Setting this option only
+    affects the transfer, but not the on-disk format of dumps.
+  - `--dump-vpack`: setting this option will dump data in raw velocypack
+    format. This will make arangodump operate faster and create smaller dumps.
+    The default value for this option is false, as enabling it would
+    incompatibly change the on-disk format of dumps.
 
-* FE-300: Implement new Views list UI
+* FE-300: Implement new Views list UI.
 
 * Fix a timeout discrepancy between HeartbeatThread and DBServerAgencySync
   during shutdown.

--- a/js/common/modules/@arangodb/aql/explainer.js
+++ b/js/common/modules/@arangodb/aql/explainer.js
@@ -603,20 +603,22 @@ function printTraversalDetails(traversals) {
 
 
   var optify = function (options, colorize) {
-    var opts = {
+    let opts = {
       bfs: options.bfs || undefined, /* only print if set to true to save room */
       neighbors: options.neighbors || undefined, /* only print if set to true to save room */
       uniqueVertices: options.uniqueVertices,
-      uniqueEdges: options.uniqueEdges
+      uniqueEdges: options.uniqueEdges,
+      order: options.order || 'dfs',
+      weightAttribute: options.order === 'weighted' && options.weightAttribute || undefined,
     };
 
     var result = '';
     for (var att in opts) {
-      if (result.length > 0) {
-        result += ', ';
-      }
       if (opts[att] === undefined) {
         continue;
+      }
+      if (result.length > 0) {
+        result += ', ';
       }
       if (colorize) {
         result += keyword(att) + ': ';
@@ -1423,7 +1425,7 @@ function processQuery(query, explain, planIndex) {
           `   ${annotation(`/* ${types.join(', ')}${projections(node, 'filterProjections', 'filter projections')}${projections(node, 'projections', 'projections')}${node.satellite ? ', satellite' : ''}${restriction(node)} */`)} ` + filter +
           '   ' + annotation(indexAnnotation);
 
-      case 'TraversalNode':
+      case 'TraversalNode': {
         if (node.hasOwnProperty("options")) {
           node.minMaxDepth = node.options.minDepth + '..' + node.options.maxDepth;
         } else if (node.hasOwnProperty("traversalFlags")) {
@@ -1590,8 +1592,16 @@ function processQuery(query, explain, planIndex) {
         if (node.options && node.options.hasOwnProperty('parallelism') && node.options.parallelism > 1) {
           rc += annotation(' /* parallelism: ' + node.options.parallelism + ' */');
         }
+        if (node.options && node.options.order) {
+          let order = node.options.order;
+          if (node.options.order === 'weighted') {
+            order += ', weight attribute: ' + node.options.weightAttribute;
+          }
+          rc += annotation(' /* order: ' + order + ' /*');
+        }
 
         return rc;
+      }
       case 'ShortestPathNode': {
         if (node.hasOwnProperty('vertexOutVariable')) {
           parts.push(variableName(node.vertexOutVariable) + '  ' + annotation('/* vertex */'));

--- a/js/common/modules/@arangodb/aql/explainer.js
+++ b/js/common/modules/@arangodb/aql/explainer.js
@@ -1597,7 +1597,7 @@ function processQuery(query, explain, planIndex) {
           if (node.options.order === 'weighted') {
             order += ', weight attribute: ' + node.options.weightAttribute;
           }
-          rc += annotation(' /* order: ' + order + ' /*');
+          rc += annotation(' /* order: ' + order + ' */');
         }
 
         return rc;


### PR DESCRIPTION
### Scope & Purpose

Fix https://arangodb.atlassian.net/browse/BTS-1380 and https://arangodb.atlassian.net/browse/BTS-1381

* BTS-1380: Added traversal order (dfs, bfs, weighted) to explain output.

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [x] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/BTS-1380, https://arangodb.atlassian.net/browse/BTS-1381
- [ ] Design document: 