### PR TITLE
BTS-1531

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,10 @@
 devel
 -----
+    
+* Fixed BTS-1531: Async cancel Job returns different error messages.
+  Unify error messages for canceled jobs (error code 21) to "request canceled".
+  Previously, the server could return different messages, either "request
+  canceled", "request has been canceled by user" or "handler canceled".
 
 * Fixed BTS-1541: Old legacy little endian key format for RocksDB database
   (created in ArangoDB 3.2 and 3.3) showed wrong behavior on newer

--- a/arangod/GeneralServer/RestHandler.cpp
+++ b/arangod/GeneralServer/RestHandler.cpp
@@ -456,8 +456,7 @@ void RestHandler::prepareEngine() {
   if (_canceled) {
     _state = HandlerState::FAILED;
 
-    Exception err(TRI_ERROR_REQUEST_CANCELED,
-                  "request has been canceled by user", __FILE__, __LINE__);
+    Exception err(TRI_ERROR_REQUEST_CANCELED, __FILE__, __LINE__);
     handleError(err);
     return;
   }

--- a/arangod/RestHandler/RestIndexHandler.cpp
+++ b/arangod/RestHandler/RestIndexHandler.cpp
@@ -40,6 +40,8 @@
 #include "VocBase/LogicalCollection.h"
 #include "VocBase/Methods/Indexes.h"
 
+#include <absl/strings/str_cat.h>
+
 #include <velocypack/Builder.h>
 #include <velocypack/Collection.h>
 #include <velocypack/Iterator.h>
@@ -292,11 +294,10 @@ RestStatus RestIndexHandler::getSelectivityEstimates() {
     if (idx->inProgress() || idx->isHidden()) {
       continue;
     }
-    std::string name = coll->name();
-    name.push_back(TRI_INDEX_HANDLE_SEPARATOR_CHR);
-    name.append(std::to_string(idx->id().id()));
     if (idx->hasSelectivityEstimate() || idx->unique()) {
-      builder.add(name, VPackValue(idx->selectivityEstimate()));
+      builder.add(absl::StrCat(coll->name(), TRI_INDEX_HANDLE_SEPARATOR_STR,
+                               idx->id().id()),
+                  VPackValue(idx->selectivityEstimate()));
     }
   }
   builder.close();
@@ -317,8 +318,8 @@ RestStatus RestIndexHandler::createIndex() {
     events::CreateIndexEnd(_vocbase.name(), "(unknown)", body,
                            TRI_ERROR_BAD_PARAMETER);
     generateError(rest::ResponseCode::BAD, TRI_ERROR_HTTP_BAD_PARAMETER,
-                  "expecting POST " + _request->requestPath() +
-                      "?collection=<collection-name>");
+                  absl::StrCat("expecting POST ", _request->requestPath(),
+                               "?collection=<collection-name>"));
     return RestStatus::DONE;
   }
 
@@ -433,7 +434,8 @@ RestStatus RestIndexHandler::dropIndex() {
   if (iid.starts_with(cName + TRI_INDEX_HANDLE_SEPARATOR_CHR)) {
     idBuilder.add(VPackValue(iid));
   } else {
-    idBuilder.add(VPackValue(cName + TRI_INDEX_HANDLE_SEPARATOR_CHR + iid));
+    idBuilder.add(
+        VPackValue(absl::StrCat(cName, TRI_INDEX_HANDLE_SEPARATOR_STR, iid)));
   }
 
   Result res = methods::Indexes::drop(*coll, idBuilder.slice());

--- a/arangod/VocBase/Methods/Transactions.cpp
+++ b/arangod/VocBase/Methods/Transactions.cpp
@@ -78,7 +78,7 @@ Result executeTransaction(v8::Isolate* isolate, basics::ReadWriteLock& lock,
 
   READ_LOCKER(readLock, lock);
   if (canceled) {
-    return rv.reset(TRI_ERROR_REQUEST_CANCELED, "handler canceled");
+    return rv.reset(TRI_ERROR_REQUEST_CANCELED);
   }
 
   v8::HandleScope scope(isolate);
@@ -110,13 +110,7 @@ Result executeTransaction(v8::Isolate* isolate, basics::ReadWriteLock& lock,
   READ_LOCKER(readLock2, lock);
 
   if (canceled) {  // if it was ok we would already have committed
-    if (rv.ok()) {
-      rv.reset(TRI_ERROR_REQUEST_CANCELED,
-               "handler canceled - result already committed");
-    } else {
-      rv.reset(TRI_ERROR_REQUEST_CANCELED, "handler canceled");
-    }
-    return rv;
+    return rv.reset(TRI_ERROR_REQUEST_CANCELED);
   }
 
   if (rv.fail()) {

--- a/tests/js/client/shell/api/multi/async.js
+++ b/tests/js/client/shell/api/multi/async.js
@@ -302,6 +302,7 @@ function dealing_with_async_requestsSuite () {
       cmd = "/_api/job/" + id;
       doc = wait_for_put(cmd, 410, 20);
       assertEqual(doc.code, 410);
+      assertEqual(doc.parsedBody.errorMessage, "canceled request");
     },
 
     test_checks_whether_we_can_cancel_a_transaction: function() {
@@ -326,6 +327,7 @@ function dealing_with_async_requestsSuite () {
       cmd = "/_api/job/" + id;
       doc = wait_for_put(cmd, 410, 20);
       assertEqual(doc.code, 410);
+      assertEqual(doc.parsedBody.errorMessage, "canceled request");
     },
   };
 }


### PR DESCRIPTION
### Scope & Purpose

Fix BTS-1531: https://arangodb.atlassian.net/browse/BTS-1531

* Fixed BTS-1531: Async cancel Job returns different error messages. Unify error messages for canceled jobs (error code 21) to "request canceled". Previously, the server could return different messages, either "request canceled", "request has been canceled by user" or "handler canceled".

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [x] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/BTS-1531
- [ ] Design document: 