### PR TITLE
Refuse server startup with outdated little-endian on-disk format.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,34 @@
 devel
 -----
 
+* Refuse server startup with outdated little-endian on-disk format.
+  The little-endian on-disk format was used for deployments that were created
+  with either ArangoDB 3.2 or 3.3 when using the RocksDB storage engine.
+  Since ArangoDB 3.4, a big-endian on-disk format was used for the RocksDB
+  storage engine, which is more performant.
+  Deployments that were set up with the RocksDB storage engine using ArangoDB
+  3.2 or 3.3 and that have been upgraded since then will still use the old
+  format. This should not affect many users, because the default storage
+  engine in ArangoDB 3.2 and 3.3 was the MMFiles storage engine. Furthermore,
+  deployments that have been recreated from an arangodump since ArangoDB 3.4
+  will not be affected, because restoring an arangodump into a fresh 
+  deployment will also make ArangoDB use the big-endian on-disk format.
+
+  When the outdated little-endian on-disk format is detected at startup, the
+  server will bail out with a descriptive error message. The recommend way to
+  migrate the database from the little-endian storage format to the big-endian
+  storage format is to
+
+  1. create a full logical backup of the database using arangodump
+  2. stop the database servers in the deployment
+  3. wipe the existing database directories
+  4. restart the servers in the deployment
+  5. restore the logical dump into the deployment
+
+  It will not be sufficient to take a hot backup of a little-endian dataset
+  and restore it, because when restoring a hot backup, the original database
+  format will be restored as it was at time of the backup.
+
 * Fixed BTS-1541: Old legacy little endian key format for RocksDB database
   (created in ArangoDB 3.2 and 3.3) showed wrong behavior on newer
   versions. This fixes a persistent index corruption bug with the old

--- a/arangod/RocksDBEngine/RocksDBEngine.cpp
+++ b/arangod/RocksDBEngine/RocksDBEngine.cpp
@@ -1335,24 +1335,6 @@ void RocksDBEngine::start() {
   // metrics are correctly populated once the HTTP interface comes
   // up
   determineWalFilesInitial();
-
-  if (auto endianness = rocksutils::getRocksDBKeyFormatEndianness();
-      endianness == RocksDBEndianness::Little) {
-    LOG_TOPIC("31103", WARN, Logger::ENGINES)
-        << "detected outdated on-disk format with "
-        << rocksDBEndiannessString(endianness)
-        << " endianness from ArangoDB 3.2 or 3.3. Using this on-disk format "
-           "can have a severe impact on write performance. It is recommended "
-           "to move to the "
-        << rocksDBEndiannessString(RocksDBEndianness::Big)
-        << " endian format by performing a full logical dump of the deployment "
-           "using arangodump, and restoring it into a fresh deployment using "
-           "arangorestore. Taking a hot backup and restoring it is not "
-           "sufficient "
-           "to change the on-disk format, only a logical dump and restore into "
-           "a "
-           "fresh deployment will do.";
-  }
 }
 
 void RocksDBEngine::beginShutdown() {

--- a/arangod/RocksDBEngine/RocksDBUpgrade.cpp
+++ b/arangod/RocksDBEngine/RocksDBUpgrade.cpp
@@ -113,6 +113,25 @@ void arangodb::rocksdbStartupVersionCheck(ArangodServer& server,
         TRI_ASSERT(endianSlice.data()[0] == 'L' ||
                    endianSlice.data()[0] == 'B');
         endianess = static_cast<RocksDBEndianness>(endianSlice.data()[0]);
+
+        if (endianess == RocksDBEndianness::Little) {
+          LOG_TOPIC("31103", FATAL, Logger::ENGINES)
+              << "detected outdated on-disk format with "
+              << rocksDBEndiannessString(endianess)
+              << " endianness from ArangoDB 3.2 or 3.3. Using this on-disk "
+                 "format "
+                 "has a severe negative impact on write performance and is not "
+                 "compatible with several newer ArangoDB features. Please move "
+                 "to the "
+              << rocksDBEndiannessString(RocksDBEndianness::Big)
+              << " endian format by performing a full logical dump of the "
+                 "deployment using arangodump, and restoring it into a fresh "
+                 "deployment using arangorestore. It is not sufficient to take "
+                 "a hot backup and restore it into a fresh deployment, because "
+                 "in a hot backup, the existing on-disk format will be "
+                 "preseved.";
+          FATAL_ERROR_EXIT();
+        }
       } else {
         LOG_TOPIC("b0083", FATAL, Logger::ENGINES)
             << "Error reading key-format, your db directory is invalid";


### PR DESCRIPTION
### Scope & Purpose

Docs PR: https://github.com/arangodb/docs/pull/1465

* Refuse server startup with outdated little-endian on-disk format. The little-endian on-disk format was used for deployments that were created with either ArangoDB 3.2 or 3.3 when using the RocksDB storage engine. Since ArangoDB 3.4, a big-endian on-disk format was used for the RocksDB storage engine, which is more performant. Deployments that were set up with the RocksDB storage engine using ArangoDB 3.2 or 3.3 and that have been upgraded since then will still use the old format. This should not affect many users, because the default storage engine in ArangoDB 3.2 and 3.3 was the MMFiles storage engine. Furthermore, deployments that have been recreated from an arangodump since ArangoDB 3.4 will not be affected, because restoring an arangodump into a fresh deployment will also make ArangoDB use the big-endian on-disk format.

  When the outdated little-endian on-disk format is detected at startup, the server will bail out with a descriptive error message. The recommend way to migrate the database from the little-endian storage format to the big-endian storage format is to

  1. create a full logical backup of the database using arangodump
  2. stop the database servers in the deployment
  3. wipe the existing database directories
  4. restart the servers in the deployment
  5. restore the logical dump into the deployment

  It will not be sufficient to take a hot backup of a little-endian dataset
  and restore it, because when restoring a hot backup, the original database
  format will be restored as it was at time of the backup.

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [x] Docs PR: https://github.com/arangodb/docs/pull/1465
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 