### PR TITLE
Fix bugs around legacy little endian key encoding format

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,11 @@
 v3.10.11 (XXXX-XX-XX)
 ---------------------
 
+* Fixed BTS-1541: Old legacy little endian key format for RocksDB database
+  (created in ArangoDB 3.2 and 3.3) showed wrong behavior on newer
+  versions. This fixes a persistent index corruption bug with the old
+  format.
+
 * BTS-1598: fix race in agency.
 
 * ES-1727: Fix `UPDATE`, `REPLACE`, and `UPSERT ... UPDATE/REPLACE` failing with

--- a/arangod/RocksDBEngine/RocksDBBuilderIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBBuilderIndex.cpp
@@ -30,6 +30,7 @@
 #include "Basics/debugging.h"
 #include "Basics/files.h"
 #include "Containers/HashSet.h"
+#include "RocksDBEngine/RocksDBFormat.h"
 #ifdef USE_ENTERPRISE
 #include "Enterprise/RocksDBEngine/RocksDBBuilderIndexEE.h"
 #endif
@@ -193,7 +194,8 @@ Result fillIndexSingleThreaded(
 }  // namespace arangodb
 
 RocksDBBuilderIndex::RocksDBBuilderIndex(std::shared_ptr<RocksDBIndex> wp,
-                                         uint64_t numDocsHint, size_t numTheads)
+                                         uint64_t numDocsHint,
+                                         size_t numThreads)
     : RocksDBIndex{wp->id(), wp->collection(), wp->name(), wp->fields(),
                    wp->unique(), wp->sparse(), wp->columnFamily(),
                    wp->objectId(), /*useCache*/ false,
@@ -209,7 +211,7 @@ RocksDBBuilderIndex::RocksDBBuilderIndex(std::shared_ptr<RocksDBIndex> wp,
       _numDocsHint{numDocsHint},
       _numThreads{
           numDocsHint > kSingleThreadThreshold
-              ? std::clamp(numTheads, size_t{1}, IndexFactory::kMaxParallelism)
+              ? std::clamp(numThreads, size_t{1}, IndexFactory::kMaxParallelism)
               : size_t{1}} {
   TRI_ASSERT(_wrapped);
 }
@@ -328,6 +330,15 @@ static Result fillIndex(rocksdb::DB* rootDB, RocksDBIndex& ridx,
 
   TRI_IF_FAILURE("RocksDBBuilderIndex::fillIndex") { FATAL_ERROR_EXIT(); }
 #ifdef USE_ENTERPRISE
+  if (arangodb::rocksutils::rocksDBEndianness == RocksDBEndianness::Little &&
+      numThreads > 1) {
+    LOG_TOPIC("e3241", WARN, Logger::ENGINES)
+        << "Number of threads for index generation forced from " << numThreads
+        << " down to 1 since the RocksDB internal data format is still "
+        << "little endian keys!";
+    numThreads = 1;
+  }
+
   IndexFiller indexFiller(isUnique, foreground, numThreads, batched,
                           threadBatchSize, dbOptions, batch, docsProcessed, trx,
                           ridx, snap, rootDB, std::move(it), idxPath);

--- a/arangod/RocksDBEngine/RocksDBDumpManager.cpp
+++ b/arangod/RocksDBEngine/RocksDBDumpManager.cpp
@@ -29,6 +29,7 @@
 #include "Cluster/ServerState.h"
 #include "RestServer/DatabaseFeature.h"
 #include "RocksDBEngine/RocksDBEngine.h"
+#include "RocksDBEngine/RocksDBFormat.h"
 #include "RocksDBEngine/RocksDBDumpContext.h"
 #include "VocBase/ticks.h"
 
@@ -46,6 +47,14 @@ RocksDBDumpContextGuard RocksDBDumpManager::createContext(
     std::string const& database) {
   TRI_ASSERT(ServerState::instance()->isSingleServer() ||
              ServerState::instance()->isDBServer());
+
+  // If the local RocksDB database still uses little endian key encoding,
+  // then the whole new dump method does not work, since ranges in _revs
+  // do not correspond to ranges in RocksDB keys in the documents column
+  // family. Therefore, we block the creation of a dump context right away.
+  if (rocksutils::rocksDBEndianness == RocksDBEndianness::Little) {
+    THROW_ARANGO_EXCEPTION(TRI_ERROR_ARANGO_OLD_ROCKSDB_FORMAT);
+  }
 
   // generating the dump context can throw exceptions. if it does, then
   // no harm is done, and no resources will be leaked.

--- a/arangod/RocksDBEngine/RocksDBEngine.cpp
+++ b/arangod/RocksDBEngine/RocksDBEngine.cpp
@@ -261,6 +261,7 @@ RocksDBEngine::RocksDBEngine(Server& server,
       _runningCompactions(0),
       _autoFlushCheckInterval(60.0 * 30.0),
       _autoFlushMinWalFiles(20),
+      _forceLittleEndianKeys(false),
       _metricsWalReleasedTickFlush(
           server.getFeature<metrics::MetricsFeature>().add(
               rocksdb_wal_released_tick_flush{})),
@@ -738,6 +739,28 @@ replication doing a resync, however.)");
               arangodb::options::Flags::OnSingle))
       .setIntroducedIn(31005);
 
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+  options
+      ->addOption(
+          "--rocksdb.force-legacy-little-endian-keys",
+          "Force usage of legacy little endian key encoding when creating "
+          "a new RocksDB database directory. DO NOT USE IN PRODUCTION.",
+          new BooleanParameter(&_forceLittleEndianKeys),
+          arangodb::options::makeFlags(
+              arangodb::options::Flags::DefaultNoComponents,
+              arangodb::options::Flags::Uncommon,
+              arangodb::options::Flags::Experimental,
+              arangodb::options::Flags::OnAgent,
+              arangodb::options::Flags::OnDBServer,
+              arangodb::options::Flags::OnSingle))
+      .setIntroducedIn(31200)
+      .setLongDescription(R"(If enabled and a new RocksDB database
+is generated, the legacy little endian key encoding is used.
+
+Only use this option for testing purposes! It is bad for performance and
+disables a few features like parallel index generation!)");
+#endif
+
 #ifdef USE_ENTERPRISE
   collectEnterpriseOptions(options);
 #endif
@@ -1038,7 +1061,8 @@ void RocksDBEngine::start() {
                  ->GetID() == 0);
 
   // will crash the process if version does not match
-  arangodb::rocksdbStartupVersionCheck(server(), _db, dbExisted);
+  arangodb::rocksdbStartupVersionCheck(server(), _db, dbExisted,
+                                       _forceLittleEndianKeys);
 
   _dbExisted = dbExisted;
 

--- a/arangod/RocksDBEngine/RocksDBEngine.h
+++ b/arangod/RocksDBEngine/RocksDBEngine.h
@@ -686,6 +686,8 @@ class RocksDBEngine final : public StorageEngine {
   // an auto-flush
   uint64_t _autoFlushMinWalFiles;
 
+  bool _forceLittleEndianKeys;  // force new database to use old format
+
   metrics::Gauge<uint64_t>& _metricsWalReleasedTickFlush;
   metrics::Gauge<uint64_t>& _metricsWalSequenceLowerBound;
   metrics::Gauge<uint64_t>& _metricsLiveWalFiles;

--- a/arangod/RocksDBEngine/RocksDBKeyBounds.cpp
+++ b/arangod/RocksDBEngine/RocksDBKeyBounds.cpp
@@ -415,7 +415,7 @@ RocksDBKeyBounds::RocksDBKeyBounds(RocksDBEntryType type, uint64_t first,
       uint8_t const maxSlice[] = {0x02, 0x03, 0x1f};
       VPackSlice max(maxSlice);
 
-      _internals.reserve(2 * sizeof(uint64_t) + (second ? max.byteSize() : 0));
+      _internals.reserve(2 * sizeof(uint64_t) + max.byteSize());
       uint64ToPersistent(_internals.buffer(), first);
       _internals.separate();
 
@@ -427,9 +427,18 @@ RocksDBKeyBounds::RocksDBKeyBounds(RocksDBEntryType type, uint64_t first,
         uint64ToPersistent(_internals.buffer(), first);
         _internals.buffer().append((char const*)(max.begin()), max.byteSize());
       } else {
-        // in case of forward iteration, we can use the next objectId as a quick
-        // termination case, as it will be in the next prefix
-        uint64ToPersistent(_internals.buffer(), first + 1);
+        // in case of forward iteration, we can use the next objectId as
+        // a quick termination case, as it will be in the next prefix,
+        // however, this trick only works when we have the big endian
+        // data format:
+        if (rocksDBEndianness == RocksDBEndianness::Big) {
+          uint64ToPersistent(_internals.buffer(), first + 1);
+        } else {
+          // little endian:
+          uint64ToPersistent(_internals.buffer(), first);
+          _internals.buffer().append((char const*)(max.begin()),
+                                     max.byteSize());
+        }
       }
       break;
     }
@@ -543,6 +552,20 @@ RocksDBKeyBounds::RocksDBKeyBounds(RocksDBEntryType type, uint64_t first,
       _internals.separate();
       uint64ToPersistent(_internals.buffer(), first);  // objectid
       uint64ToPersistent(_internals.buffer(), third);  // max revision
+      // This method does not work in the old, little endian encoding
+      // (used in databases created with ArangoDB 3.2 and 3.3), since
+      // in that encoding a range of document revision IDs as `uint64_t`
+      // does not map to a range of RocksDB keys. So this is unusable.
+      // Therefore, as a stop gap measure, we throw an exception here
+      // to avoid that somebody uses this code and runs into this very
+      // subtle bug. The old format is now deprecated and new features
+      // to not have to support it any more. Note that for UINT64_MAX
+      // as upper bound we can do not have to error out since endianess
+      // does not play a role. This case is used in various places!
+      if (third != UINT64_MAX &&
+          rocksDBEndianness == RocksDBEndianness::Little) {
+        THROW_ARANGO_EXCEPTION(TRI_ERROR_ARANGO_OLD_ROCKSDB_FORMAT);
+      }
       break;
     }
     case RocksDBEntryType::GeoIndexValue: {

--- a/arangod/RocksDBEngine/RocksDBUpgrade.cpp
+++ b/arangod/RocksDBEngine/RocksDBUpgrade.cpp
@@ -53,7 +53,8 @@ using namespace arangodb;
 
 void arangodb::rocksdbStartupVersionCheck(ArangodServer& server,
                                           rocksdb::TransactionDB* db,
-                                          bool dbExisted) {
+                                          bool dbExisted,
+                                          bool forceLittleEndianKeys) {
   static_assert(
       std::is_same<char, std::underlying_type<RocksDBEndianness>::type>::value,
       "RocksDBEndianness has wrong type");
@@ -119,8 +120,10 @@ void arangodb::rocksdbStartupVersionCheck(ArangodServer& server,
       }
     }
   } else {
-    // new DBs are always created with Big endian data-format
-    endianess = RocksDBEndianness::Big;
+    // new DBs are always created with Big endian data-format, Unless
+    // forced by a command line option:
+    endianess = forceLittleEndianKeys ? RocksDBEndianness::Little
+                                      : RocksDBEndianness::Big;
   }
 
   // enable correct key format
@@ -130,7 +133,7 @@ void arangodb::rocksdbStartupVersionCheck(ArangodServer& server,
 
   if (!dbExisted) {
     // store endianess forever
-    TRI_ASSERT(endianess == RocksDBEndianness::Big);
+    TRI_ASSERT(forceLittleEndianKeys || endianess == RocksDBEndianness::Big);
 
     char const endVal = static_cast<char>(endianess);
     rocksdb::Status s =

--- a/arangod/RocksDBEngine/RocksDBUpgrade.h
+++ b/arangod/RocksDBEngine/RocksDBUpgrade.h
@@ -35,5 +35,5 @@ class ApplicationServer;
 }
 
 void rocksdbStartupVersionCheck(ArangodServer& server, rocksdb::TransactionDB*,
-                                bool dbExisted);
+                                bool dbExisted, bool forceLittleEndianKeys);
 }  // namespace arangodb

--- a/js/common/bootstrap/errors.js
+++ b/js/common/bootstrap/errors.js
@@ -100,6 +100,7 @@
     "ERROR_ARANGO_COLLECTION_NOT_LOADED" : { "code" : 1238, "message" : "collection not loaded" },
     "ERROR_ARANGO_DOCUMENT_REV_BAD" : { "code" : 1239, "message" : "illegal document revision" },
     "ERROR_ARANGO_INCOMPLETE_READ" : { "code" : 1240, "message" : "incomplete read" },
+    "ERROR_ARANGO_OLD_ROCKSDB_FORMAT" : { "code" : 1241, "message" : "not supported by old legacy data format" },
     "ERROR_ARANGO_EMPTY_DATADIR"   : { "code" : 1301, "message" : "server database directory is empty" },
     "ERROR_ARANGO_TRY_AGAIN"       : { "code" : 1302, "message" : "operation should be tried again" },
     "ERROR_ARANGO_BUSY"            : { "code" : 1303, "message" : "engine is busy" },

--- a/lib/Basics/errors.dat
+++ b/lib/Basics/errors.dat
@@ -122,6 +122,7 @@ ERROR_ARANGO_COLLECTION_TYPE_MISMATCH,1237,"collection type mismatch","Will be r
 ERROR_ARANGO_COLLECTION_NOT_LOADED,1238,"collection not loaded","Will be raised when a collection is accessed that is not yet loaded."
 ERROR_ARANGO_DOCUMENT_REV_BAD,1239,"illegal document revision","Will be raised when a document revision is corrupt or is missing where needed."
 ERROR_ARANGO_INCOMPLETE_READ,1240,"incomplete read","Will be raised by the storage engine when a read cannot be completed."
+ERROR_ARANGO_OLD_ROCKSDB_FORMAT,1241,"not supported by old legacy data format","Will be raised by the storage engine when an operation cannot be performed because the old, deprecated, little endian key encoding format is still used and an operation is tried which is not supported by this format."
 
 ################################################################################
 ## Checked ArangoDB storage errors

--- a/tests/RocksDBEngine/KeyTest.cpp
+++ b/tests/RocksDBEngine/KeyTest.cpp
@@ -571,9 +571,9 @@ TEST_F(RocksDBKeyBoundsTestLittleEndian, test_hash_index) {
 
   // prefix is just object id
   auto cmp = std::make_unique<RocksDBVPackComparator>();
-  EXPECT_LT(cmp->Compare(prefixBegin, prefixEnd), 0);
+  EXPECT_EQ(cmp->Compare(prefixBegin, prefixEnd), 0);
   EXPECT_LT(cmp->Compare(prefixBegin, key1.string()), 0);
-  EXPECT_GT(cmp->Compare(prefixEnd, key1.string()), 0);
+  EXPECT_GT(cmp->Compare(bounds.end(), key1.string()), 0);
 
   EXPECT_LT(cmp->Compare(key1.string(), key2.string()), 0);
   EXPECT_LT(cmp->Compare(key2.string(), key3.string()), 0);


### PR DESCRIPTION
### Scope & Purpose

This addresses https://arangodb.atlassian.net/browse/BTS-1541

Overview: In 3.2 and 3.3 we have created the ArangoDB/RocksDB instance
with little endian key encoding, which was a very bad idea for
performance. Newer versions use big endian key encoding, which is much
better. However, legacy databases created in 3.2 and 3.3 continue to use
the old encoding and new versions should be compatible with this.

This PR fixes some compatibility problems and ensures that newer code,
which relies on the old encoding cannot be executed any more, if the
underlying format is still little endian key encoding.

More specifically:

 - A method in RocksDBKeyBounds.cpp is fixed which computes a wrong
   key range for persistent indexes in the little endian key encoding
   case.
 - Another method which computes a range for the documents column family
   is disabled for the little endian key encoding case and now reports
   an error.
 - The parallel index creation (introduced in 3.10) will automatically
   reduce the number of threads used to 1 for little endian key
   encoding. This is necessary, since the parallel index creation relies
   on the fact that ranges in `_rev` values (`uint64_t`) correspond to
   RocksDB key ranges, which is not true for little endian key encoding.
 - The new arangodump protocol (introduced in 3.10) will no longer work
   and only error out for the little endian key encoding. Again, the
   algorithms used by that protocol will subtly (and silently) break
   for little endian key encoding because ranges in `_rev` values
   (`uint64_t`) do not correspond to ranges in RocksDB keys.
 - A new hidden command line option
   `--rocksdb.enforce-legacy-little-endian-keys` is added to be able
   to generate legacy databases. This is only for testing and should
   otherwise not be used.

- [*] :hankey: Bugfix

### Checklist

- [*] :book: CHANGELOG entry made
- [*] Backports
  - [*] Backport for 3.10: This is it.

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [*] Enterprise PR: there is no enterprise part to this
- [*] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/BTS-1541
- [*] Original issue: https://arangodb.atlassian.net/browse/ES-1697
- [*] Devel PR: https://github.com/arangodb/arangodb/pull/19703



