### PR TITLE
Fixed COLLECT variable validation loophole

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,11 @@
 v3.10.11 (XXXX-XX-XX)
 ---------------------
 
+* Fixed a loophole in COLLECT variable name validation: in COLLECT INTO 
+  expressions it was possible to refer to variables that the COLLECT just
+  introduced. This was undefined behavior and not caught by the previous
+  version of COLLECT's variable checking.
+
 * BTS-1598: fix race in agency.
 
 * ES-1727: Fix `UPDATE`, `REPLACE`, and `UPSERT ... UPDATE/REPLACE` failing with

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,10 +1,10 @@
 v3.10.11 (XXXX-XX-XX)
 ---------------------
 
-* Fixed a loophole in COLLECT variable name validation: in COLLECT INTO 
+* Fixed a loophole in COLLECT variable name validation: in COLLECT INTO
   expressions it was possible to refer to variables that the COLLECT just
-  introduced. This was undefined behavior and not caught by the previous
-  version of COLLECT's variable checking.
+  introduced. This was undefined behavior and not caught by the previous version
+  of COLLECT's variable checking.
 
 * BTS-1598: fix race in agency.
 

--- a/arangod/Aql/Ast.cpp
+++ b/arangod/Aql/Ast.cpp
@@ -947,7 +947,8 @@ AstNode* Ast::createNodeReference(Variable const* variable) {
 }
 
 /// @brief create an AST subquery reference node
-AstNode* Ast::createNodeSubqueryReference(std::string_view variableName) {
+AstNode* Ast::createNodeSubqueryReference(std::string_view variableName,
+                                          AstNode const* subquery) {
   AstNode* node = createNode(NODE_TYPE_REFERENCE);
   node->setFlag(AstNodeFlagType::FLAG_SUBQUERY_REFERENCE);
 
@@ -959,6 +960,8 @@ AstNode* Ast::createNodeSubqueryReference(std::string_view variableName) {
   }
 
   node->setData(variable);
+
+  _subqueries.emplace(variable->id, subquery);
 
   return node;
 }
@@ -4427,3 +4430,10 @@ void Ast::setContainsParallelNode() noexcept {
 bool Ast::willUseV8() const noexcept { return _willUseV8; }
 
 void Ast::setWillUseV8() noexcept { _willUseV8 = true; }
+
+AstNode const* Ast::getSubqueryForVariable(Variable const* variable) const {
+  if (auto it = _subqueries.find(variable->id); it != _subqueries.end()) {
+    return it->second;
+  }
+  return nullptr;
+}

--- a/arangod/Aql/Ast.h
+++ b/arangod/Aql/Ast.h
@@ -42,6 +42,7 @@
 #include "Aql/VariableGenerator.h"
 #include "Aql/types.h"
 #include "Basics/AttributeNameParser.h"
+#include "Containers/FlatHashMap.h"
 #include "Containers/HashSet.h"
 #include "Graph/PathType.h"
 #include "VocBase/AccessMode.h"
@@ -275,7 +276,8 @@ class Ast {
   AstNode* createNodeReference(Variable const* variable);
 
   /// @brief create an AST subquery reference node
-  AstNode* createNodeSubqueryReference(std::string_view variableName);
+  AstNode* createNodeSubqueryReference(std::string_view variableName,
+                                       AstNode const*);
 
   /// @brief create an AST parameter node for a value literal
   AstNode* createNodeParameter(std::string_view name);
@@ -524,6 +526,8 @@ class Ast {
   /// of the operation is a constant number
   AstNode* optimizeUnaryOperatorArithmetic(AstNode*);
 
+  AstNode const* getSubqueryForVariable(Variable const* variable) const;
+
  private:
   /// @brief make condition from example
   AstNode* makeConditionFromExample(AstNode const*);
@@ -656,8 +660,13 @@ class Ast {
   /// @brief root node of the AST
   AstNode* _root;
 
-  /// @brief root nodes of queries and subqueries
+  /// @brief root nodes of queries and subqueries. this container is added
+  /// to whenever we enter a subquery, but it is removed from when a subquery
+  /// is left
   std::vector<AstNode*> _queries;
+
+  /// @brief all subqueries used in the query
+  containers::FlatHashMap<VariableId, AstNode const*> _subqueries;
 
   /// @brief which collection is going to be modified in the query
   /// maps from NODE_TYPE_COLLECTION/NODE_TYPE_PARAMETER_DATASOURCE to

--- a/arangod/Aql/grammar.hpp
+++ b/arangod/Aql/grammar.hpp
@@ -140,7 +140,7 @@ extern int Aqldebug;
 #if ! defined YYSTYPE && ! defined YYSTYPE_IS_DECLARED
 union YYSTYPE
 {
-#line 43 "Aql/grammar.y"
+#line 46 "Aql/grammar.y"
 
   arangodb::aql::AstNode*  node;
   struct {


### PR DESCRIPTION
### Scope & Purpose

Minimal backport of https://github.com/arangodb/arangodb/pull/19709

* Fixed a loophole in COLLECT variable name validation: in COLLECT INTO expressions it was possible to refer to variables that the COLLECT just introduced. This was undefined behavior and not caught by the previous version of COLLECT's variable checking.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [x] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.11: https://github.com/arangodb/arangodb/pull/19722
  - [x] Backport for 3.10: this PR

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 