### PR TITLE
Fix MemoryAccounting Agency Node Array

### DIFF
--- a/arangod/Agency/Node.cpp
+++ b/arangod/Agency/Node.cpp
@@ -1019,5 +1019,8 @@ NodePtr consensus::Node::allocateNode(Args&&... args) {
 
 // Create an explicit instantiation for VPackString using the Node
 // AccountingAllocator
-template struct arangodb::velocypack::BasicString<
-    typename arangodb::consensus::Node::allocator_type::rebind<uint8_t>::type>;
+using AllocatorType =
+    typename arangodb::consensus::Node::allocator_type::rebind<uint8_t>::type;
+template struct arangodb::velocypack::BasicString<AllocatorType>;
+template Slice arangodb::velocypack::BasicString<AllocatorType>::get(
+    std::string_view attribute) const;

--- a/arangod/Agency/Node.cpp
+++ b/arangod/Agency/Node.cpp
@@ -1022,3 +1022,6 @@ NodePtr consensus::Node::allocateNode(Args&&... args) {
 using AllocatorType =
     typename arangodb::consensus::Node::allocator_type::rebind<uint8_t>::type;
 template struct arangodb::velocypack::BasicString<AllocatorType>;
+template struct arangodb::velocypack::SliceBase<
+    arangodb::velocypack::BasicString<AllocatorType>,
+    arangodb::velocypack::Slice>;

--- a/arangod/Agency/Node.cpp
+++ b/arangod/Agency/Node.cpp
@@ -1022,5 +1022,3 @@ NodePtr consensus::Node::allocateNode(Args&&... args) {
 using AllocatorType =
     typename arangodb::consensus::Node::allocator_type::rebind<uint8_t>::type;
 template struct arangodb::velocypack::BasicString<AllocatorType>;
-template Slice arangodb::velocypack::BasicString<AllocatorType>::get(
-    std::string_view attribute) const;

--- a/arangod/Agency/Node.cpp
+++ b/arangod/Agency/Node.cpp
@@ -1021,7 +1021,7 @@ NodePtr consensus::Node::allocateNode(Args&&... args) {
 // AccountingAllocator
 using AllocatorType =
     typename arangodb::consensus::Node::allocator_type::rebind<uint8_t>::type;
-template struct arangodb::velocypack::BasicString<AllocatorType>;
-template struct arangodb::velocypack::SliceBase<
-    arangodb::velocypack::BasicString<AllocatorType>,
-    arangodb::velocypack::Slice>;
+
+namespace arangodb::velocypack {
+INSTANTIATE_TYPE(BasicString<AllocatorType>, Slice)
+}

--- a/arangod/Agency/Node.h
+++ b/arangod/Agency/Node.h
@@ -186,8 +186,7 @@ class Node : public std::enable_shared_from_this<Node> {
   using Children = ::immer::map<StringType, NodePtr, TransparentHash,
                                 TransparentEqual, AccountingMemoryPolicy>;
 
-  using Array =
-      ::immer::flex_vector<velocypack::String, AccountingMemoryPolicy>;
+  using Array = ::immer::flex_vector<VPackStringType, AccountingMemoryPolicy>;
 
   using VariantType = std::variant<Children, Array, VPackStringType>;
 


### PR DESCRIPTION
### Scope & Purpose
Due to an oversight, velocypack data in arrays was not accounted for.

Should improve memory accounting and fix an issue reported in https://arangodb.atlassian.net/browse/BTS-1584