### PR TITLE
Update Operation for Agency Transactions

### DIFF
--- a/arangod/Agency/Node.h
+++ b/arangod/Agency/Node.h
@@ -62,6 +62,7 @@ namespace arangodb::consensus {
 
 enum Operation {
   SET,
+  UPDATE,
   INCREMENT,
   DECREMENT,
   PUSH,

--- a/tests/Agency/StoreTestAPI.cpp
+++ b/tests/Agency/StoreTestAPI.cpp
@@ -925,6 +925,38 @@ TEST_F(StoreTestAPI, transaction_insert_remove_same_key) {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// @brief Transaction update operation
+////////////////////////////////////////////////////////////////////////////////
+
+TEST_F(StoreTestAPI, transaction_update) {
+  writeAndCheck(R"([[{"a":{"op":"update", "val":{"b":12}}}]])");
+  assertEqual(read(R"([["/"]])"), R"( [{"a":{"b":12}}])");
+  writeAndCheck(
+      R"([[{"a":{"op":"update", "keepNull": true, "val":{"b":null}}}]])");
+  assertEqual(read(R"([["/"]])"), R"( [{"a":{"b":null}}])");
+  writeAndCheck(
+      R"([[{"a":{"op":"update", "keepNull": false, "val":{"b":null}}}]])");
+  assertEqual(read(R"([["/"]])"), R"( [{"a":{}}])");
+  writeAndCheck(R"([[{"a":{"op":"update", "val":{"b":1, "c":2}}}]])");
+  assertEqual(read(R"([["/"]])"), R"( [{"a":{"b":1, "c":2}}])");
+  writeAndCheck(R"([[{"a":{"op":"update", "val":{"b":3}}}]])");
+  assertEqual(read(R"([["/"]])"), R"( [{"a":{"b":3, "c":2}}])");
+
+  writeAndCheck(R"([[{"a":{"op":"update", "val":{"b":1, "c":{}}}}]])");
+  assertEqual(read(R"([["/"]])"), R"( [{"a":{"b":1, "c":{}}}])");
+  writeAndCheck(R"([[{"a":{"op":"update", "val":{"c":{"d":4}}}}]])");
+  assertEqual(read(R"([["/"]])"), R"( [{"a":{"b":1, "c":{"d":4}}}])");
+
+  writeAndCheck(
+      R"([[{"a":{"op":"update", "mergeObjects": false, "val":{"c":{"e":4}}}}]])");
+  assertEqual(read(R"([["/"]])"), R"( [{"a":{"b":1, "c":{"e":4}}}])");
+
+  writeAndCheck(
+      R"([[{"a":{"op":"update", "mergeObjects": true, "val":{"c":{"d":4}}}}]])");
+  assertEqual(read(R"([["/"]])"), R"( [{"a":{"b":1, "c":{"d": 4, "e":4}}}])");
+}
+
+////////////////////////////////////////////////////////////////////////////////
 /// @brief Huge transaction package, all different keys
 ////////////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
### Scope & Purpose
In internal discussions we found that an `update` operation similar to the document update operation could be useful.

This PR adds such an operation. Here is an example of such a transaction:
```
[[
{"a":
    {"op":"update", 
     "mergeObjects": true,  // default value is true
     "keepNull": false, // default value is false
      "val":{"c":{"d":4}}
    }
}
]]
```

The optional attribute `mergeObjects` defaults to `true` and indicates whether objects should be merged recursively or just be replaced on top-level keys. `keepNull` is by default `false`, which indicates that values which are updated to `null` should be removed. If set to `true`, null values are kept.