### PR TITLE
fix an assertion failure in chaos tests

### DIFF
--- a/arangod/RocksDBEngine/RocksDBMethodsMemoryTracker.cpp
+++ b/arangod/RocksDBEngine/RocksDBMethodsMemoryTracker.cpp
@@ -125,11 +125,14 @@ void RocksDBMethodsMemoryTracker::popSavePoint() noexcept {
 
 void RocksDBMethodsMemoryTracker::beginQuery(ResourceMonitor* resourceMonitor) {
   // note: resourceMonitor can be a nullptr if we are called from truncate
-  TRI_ASSERT(_resourceMonitor == nullptr);
-  TRI_ASSERT(_memoryUsageAtBeginQuery == 0);
+  TRI_ASSERT(_resourceMonitor == nullptr ||
+             resourceMonitor == _resourceMonitor);
+  if (_resourceMonitor == nullptr) {
+    TRI_ASSERT(_memoryUsageAtBeginQuery == 0);
 
-  _resourceMonitor = resourceMonitor;
-  _memoryUsageAtBeginQuery = _memoryUsage;
+    _resourceMonitor = resourceMonitor;
+    _memoryUsageAtBeginQuery = _memoryUsage;
+  }
 }
 
 void RocksDBMethodsMemoryTracker::endQuery() noexcept {


### PR DESCRIPTION
### Scope & Purpose

Fix an assertion failure during chaos testing (`scripts/unittest chaos --cluster true --skipNightly false`).

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 