### PR TITLE
[BTS-1226] Added minMaxDepth to path validator.

### DIFF
--- a/arangod/Aql/TraversalNode.cpp
+++ b/arangod/Aql/TraversalNode.cpp
@@ -697,6 +697,9 @@ std::unique_ptr<ExecutionBlock> TraversalNode::createBlock(
       opts->tmpVar(), opts->getExpressionCtx(), isDisjointIsSat.first,
       isDisjointIsSat.second, isClusterOneShardRuleEnabled()};
 
+  // set min/max depth
+  validatorOptions.setMinMaxDepth(opts->minDepth, opts->maxDepth);
+
   // Prune Section
   if (pruneExpression() != nullptr) {
     std::shared_ptr<aql::PruneExpressionEvaluator> pruneEvaluator;

--- a/arangod/Graph/PathManagement/PathValidator.cpp
+++ b/arangod/Graph/PathManagement/PathValidator.cpp
@@ -302,6 +302,19 @@ auto PathValidator<ProviderType, PathStore, vertexUniqueness, edgeUniqueness>::
     }
   }
 
+  if (_options.usesMinMaxDepth()) {
+    auto [minDepth, maxDepth] = _options.getMinMaxDepth();
+    if (step.getDepth() >= maxDepth) {
+      res.combine(ValidationResult::Type::PRUNE);
+    }
+
+    if (step.getDepth() < minDepth) {
+      res.combine(ValidationResult::Type::FILTER);
+      // returning here is ok, because there is no condition for pruning left.
+      return res;
+    }
+  }
+
   if (res.isPruned() && res.isFiltered()) {
     return res;
   }

--- a/arangod/Graph/PathManagement/PathValidatorOptions.cpp
+++ b/arangod/Graph/PathManagement/PathValidatorOptions.cpp
@@ -156,3 +156,18 @@ aql::Variable const* PathValidatorOptions::getTempVar() const {
 aql::FixedVarExpressionContext& PathValidatorOptions::getExpressionContext() {
   return _expressionCtx;
 }
+
+bool PathValidatorOptions::usesMinMaxDepth() const noexcept {
+  return _optMinMaxDepth.has_value();
+}
+void PathValidatorOptions::setMinMaxDepth(std::size_t minDepth,
+                                          std::size_t maxDepth) {
+  _optMinMaxDepth.emplace(minDepth, maxDepth);
+}
+
+std::pair<std::size_t, std::size_t> PathValidatorOptions::getMinMaxDepth()
+    const {
+  std::pair<std::size_t, std::size_t> defaulValue = {
+      0, std::numeric_limits<std::size_t>::max()};
+  return _optMinMaxDepth.value_or(defaulValue);
+}

--- a/arangod/Graph/PathManagement/PathValidatorOptions.h
+++ b/arangod/Graph/PathManagement/PathValidatorOptions.h
@@ -94,6 +94,7 @@ class PathValidatorOptions {
    */
   bool usesPrune() const;
   bool usesPostFilter() const;
+  bool usesMinMaxDepth() const noexcept;
 
   /**
    * @brief In case prune or postFilter has been enabled, we need to unprepare
@@ -109,6 +110,7 @@ class PathValidatorOptions {
    */
   void setPruneContext(aql::InputAqlItemRow& inputRow);
   void setPostFilterContext(aql::InputAqlItemRow& inputRow);
+  void setMinMaxDepth(std::size_t minDepth, std::size_t maxDepth);
 
   /**
    * @brief Get the Expression a vertex needs to hold if defined on the given
@@ -127,6 +129,8 @@ class PathValidatorOptions {
   aql::Variable const* getTempVar() const;
 
   aql::FixedVarExpressionContext& getExpressionContext();
+
+  std::pair<std::size_t, std::size_t> getMinMaxDepth() const;
 
   // @brief If a graph is asked for the first vertex and that is filtered
   void setBfsResultHasToIncludeFirstVertex() {
@@ -161,6 +165,8 @@ class PathValidatorOptions {
   bool _isDisjoint;
   bool _isSatelliteLeader;
   bool _enabledClusterOneShardRule;
+
+  std::optional<std::pair<std::size_t, std::size_t>> _optMinMaxDepth;
 };
 }  // namespace graph
 }  // namespace arangodb


### PR DESCRIPTION
### Scope & Purpose
BTS: https://arangodb.atlassian.net/browse/BTS-1226

Given the following query:
```
  for i in a
    for v, e, p in 2 OUTBOUND i e, f
        filter v._key == "3"
        return k
```
The path validator will load all vertices, even those that are not at depth 2, to check the post condition. Thus it might access a collection that is not listed in the cluster in the `with` statement. 

This PR changes that behavior and only tests for the post condition on vertices that are at min depth. (and thus only loads those documents)