### PR TITLE
[BTS-1613] Do not check revisions on single

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 devel
 -----
 
+* Fixed BTS-1613: Fixed processing analyzers imported from Cluster dump
+  to the Single server database.
+
 * Fixed BTS-1553: Fixed a rare occuring issue during AQL queries where
   the inner amount of a limit in the LimitExecutor is set to a wrong
   value which lead to some data rows not being returned to the client.


### PR DESCRIPTION
### Scope & Purpose

If analyzers collection was imported on single server from cluster dump - analyzers might have non zero revisions.
That was preventing load of analyzer as Single server also checked the revision but expected only 0.
This PR disables checking revisions for SingleServer

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [x] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [x] RT-makedata::getTestData_607 (https://github.com/arangodb/arangodb/pull/19718)
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information



- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

