### PR TITLE
fix UB in NetworkFeature

### DIFF
--- a/arangod/Network/NetworkFeature.cpp
+++ b/arangod/Network/NetworkFeature.cpp
@@ -285,7 +285,7 @@ void NetworkFeature::prepare() {
 
 void NetworkFeature::start() {
   Scheduler* scheduler = SchedulerFeature::SCHEDULER;
-  if (scheduler != nullptr) {  // is nullptr in catch tests
+  if (scheduler != nullptr) {  // is nullptr in unit tests
     auto off = std::chrono::seconds(1);
     ::queueGarbageCollection(_workItemMutex, _workItem, _gcfunc, off);
   }
@@ -534,8 +534,6 @@ void NetworkFeature::retryRequest(
 
   // this will automatically cancel the request when we leave this
   // method, unless we are canceling this scopeGuard explicitly.
-  // note that the mutex lock will be unlocked before the scopeGuard
-  // fires.
   auto cancelGuard = scopeGuard([req]() noexcept {
     if (req) {
       req->cancel();

--- a/arangod/Network/NetworkFeature.h
+++ b/arangod/Network/NetworkFeature.h
@@ -96,20 +96,24 @@ class NetworkFeature final : public ArangodFeature {
                      std::unique_ptr<fuerte::Response>& res);
 
  private:
+  // configuration
   std::string _protocol;
   uint64_t _maxOpenConnections;
   uint64_t _idleTtlMilli;
   uint32_t _numIOThreads;
   bool _verifyHosts;
+
   std::atomic<bool> _prepared;
 
-  std::mutex _workItemMutex;
-  Scheduler::WorkHandle _workItem;
   /// @brief where rhythm is life, and life is rhythm :)
   std::function<void(bool)> _gcfunc;
 
   std::unique_ptr<network::ConnectionPool> _pool;
   std::atomic<network::ConnectionPool*> _poolPtr;
+
+  // protects _workItem and _retryRequests
+  std::mutex _workItemMutex;
+  Scheduler::WorkHandle _workItem;
 
   std::unordered_map<std::shared_ptr<network::RetryableRequest>,
                      Scheduler::WorkHandle>


### PR DESCRIPTION
### Scope & Purpose

Fix UB in NetworkFeature
in case a specific failure point was set for the NetworkFeature, this could lead to two threads racing for modifying the same Promise. this could cause random failures, the most prominent one seems to have been the exception "Promise already satisfied.".
This does not affect any released version.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 