### PR TITLE
small AQL cleanup

### DIFF
--- a/arangod/Aql/AsyncExecutor.h
+++ b/arangod/Aql/AsyncExecutor.h
@@ -48,7 +48,6 @@ class AsyncExecutor final {
     static constexpr bool preservesOrder = true;
     static constexpr BlockPassthrough allowsBlockPassthrough =
         BlockPassthrough::Enable;
-    static constexpr bool inputSizeRestrictsOutputSize = false;
   };
   // using Fetcher = std::monostate;
   using Infos = std::monostate;

--- a/arangod/Aql/CalculationExecutor.h
+++ b/arangod/Aql/CalculationExecutor.h
@@ -88,8 +88,6 @@ class CalculationExecutor {
     static constexpr bool preservesOrder = true;
     static constexpr BlockPassthrough allowsBlockPassthrough =
         BlockPassthrough::Enable;
-    /* This could be set to true after some investigation/fixes */
-    static constexpr bool inputSizeRestrictsOutputSize = false;
   };
   using Fetcher = SingleRowFetcher<Properties::allowsBlockPassthrough>;
   using Infos = CalculationExecutorInfos;

--- a/arangod/Aql/ConstrainedSortExecutor.cpp
+++ b/arangod/Aql/ConstrainedSortExecutor.cpp
@@ -300,7 +300,7 @@ auto ConstrainedSortExecutor::skipRowsRange(AqlItemBlockInputRange& inputRange,
   return {state, NoStats{}, call.getSkipCount(), AqlCall{}};
 }
 
-[[nodiscard]] auto ConstrainedSortExecutor::expectedNumberOfRowsNew(
+[[nodiscard]] auto ConstrainedSortExecutor::expectedNumberOfRows(
     AqlItemBlockInputRange const& input, AqlCall const& call) const noexcept
     -> size_t {
   size_t rowsPerBlock = _infos.limit();

--- a/arangod/Aql/ConstrainedSortExecutor.h
+++ b/arangod/Aql/ConstrainedSortExecutor.h
@@ -60,7 +60,6 @@ class ConstrainedSortExecutor {
     static constexpr bool preservesOrder = false;
     static constexpr BlockPassthrough allowsBlockPassthrough =
         BlockPassthrough::Disable;
-    static constexpr bool inputSizeRestrictsOutputSize = true;
   };
   using Fetcher = SingleRowFetcher<Properties::allowsBlockPassthrough>;
   using Infos = SortExecutorInfos;
@@ -94,8 +93,8 @@ class ConstrainedSortExecutor {
    *        It also knows that it could produce less if the upstream only has
    * fewer rows.
    */
-  [[nodiscard]] auto expectedNumberOfRowsNew(
-      AqlItemBlockInputRange const& input, AqlCall const& call) const noexcept
+  [[nodiscard]] auto expectedNumberOfRows(AqlItemBlockInputRange const& input,
+                                          AqlCall const& call) const noexcept
       -> size_t;
 
  private:

--- a/arangod/Aql/CountCollectExecutor.cpp
+++ b/arangod/Aql/CountCollectExecutor.cpp
@@ -97,7 +97,7 @@ auto CountCollectExecutor::skipRowsRange(AqlItemBlockInputRange& inputRange,
           AqlCall{0, false, 0, AqlCall::LimitType::HARD}};
 }
 
-auto CountCollectExecutor::expectedNumberOfRowsNew(
+auto CountCollectExecutor::expectedNumberOfRows(
     AqlItemBlockInputRange const& input, AqlCall const& call) const noexcept
     -> size_t {
   auto subqueries = input.countShadowRows();

--- a/arangod/Aql/CountCollectExecutor.h
+++ b/arangod/Aql/CountCollectExecutor.h
@@ -72,7 +72,6 @@ class CountCollectExecutor {
     static constexpr bool preservesOrder = false;
     static constexpr BlockPassthrough allowsBlockPassthrough =
         BlockPassthrough::Disable;
-    static constexpr bool inputSizeRestrictsOutputSize = true;
   };
   using Fetcher = SingleRowFetcher<Properties::allowsBlockPassthrough>;
   using Infos = CountCollectExecutorInfos;
@@ -104,8 +103,8 @@ class CountCollectExecutor {
                                    AqlCall& call)
       -> std::tuple<ExecutorState, Stats, size_t, AqlCall>;
 
-  [[nodiscard]] auto expectedNumberOfRowsNew(
-      AqlItemBlockInputRange const& input, AqlCall const& call) const noexcept
+  [[nodiscard]] auto expectedNumberOfRows(AqlItemBlockInputRange const& input,
+                                          AqlCall const& call) const noexcept
       -> size_t;
 
  private:

--- a/arangod/Aql/DistinctCollectExecutor.cpp
+++ b/arangod/Aql/DistinctCollectExecutor.cpp
@@ -73,7 +73,7 @@ DistinctCollectExecutor::~DistinctCollectExecutor() { destroyValues(); }
 
 void DistinctCollectExecutor::initializeCursor() { destroyValues(); }
 
-[[nodiscard]] auto DistinctCollectExecutor::expectedNumberOfRowsNew(
+[[nodiscard]] auto DistinctCollectExecutor::expectedNumberOfRows(
     AqlItemBlockInputRange const& input, AqlCall const& call) const noexcept
     -> size_t {
   if (input.finalState() == MainQueryState::DONE) {

--- a/arangod/Aql/DistinctCollectExecutor.h
+++ b/arangod/Aql/DistinctCollectExecutor.h
@@ -91,7 +91,6 @@ class DistinctCollectExecutor {
     static constexpr bool preservesOrder = false;
     static constexpr BlockPassthrough allowsBlockPassthrough =
         BlockPassthrough::Disable;
-    static constexpr bool inputSizeRestrictsOutputSize = true;
   };
   using Fetcher = SingleRowFetcher<Properties::allowsBlockPassthrough>;
   using Infos = DistinctCollectExecutorInfos;
@@ -119,8 +118,8 @@ class DistinctCollectExecutor {
                                    AqlCall& call)
       -> std::tuple<ExecutorState, Stats, size_t, AqlCall>;
 
-  [[nodiscard]] auto expectedNumberOfRowsNew(
-      AqlItemBlockInputRange const& input, AqlCall const& call) const noexcept
+  [[nodiscard]] auto expectedNumberOfRows(AqlItemBlockInputRange const& input,
+                                          AqlCall const& call) const noexcept
       -> size_t;
 
  private:

--- a/arangod/Aql/EnumerateCollectionExecutor.cpp
+++ b/arangod/Aql/EnumerateCollectionExecutor.cpp
@@ -254,7 +254,7 @@ void EnumerateCollectionExecutor::initializeNewRow(
   _cursorHasMore = _cursor->hasMore();
 }
 
-[[nodiscard]] auto EnumerateCollectionExecutor::expectedNumberOfRowsNew(
+[[nodiscard]] auto EnumerateCollectionExecutor::expectedNumberOfRows(
     AqlItemBlockInputRange const& input, AqlCall const& call) const noexcept
     -> size_t {
   if (_infos.getCount()) {

--- a/arangod/Aql/EnumerateCollectionExecutor.h
+++ b/arangod/Aql/EnumerateCollectionExecutor.h
@@ -119,9 +119,6 @@ class EnumerateCollectionExecutor {
     static constexpr bool preservesOrder = true;
     static constexpr BlockPassthrough allowsBlockPassthrough =
         BlockPassthrough::Disable;
-    /* With some more modifications this could be turned to true. Actually the
-   output of this block is input * itemsInCollection */
-    static constexpr bool inputSizeRestrictsOutputSize = false;
   };
   using Fetcher = SingleRowFetcher<Properties::allowsBlockPassthrough>;
   using Infos = EnumerateCollectionExecutorInfos;
@@ -145,8 +142,8 @@ class EnumerateCollectionExecutor {
    * @brief This Executor in some cases knows how many rows it will produce and
    * most by itself
    */
-  [[nodiscard]] auto expectedNumberOfRowsNew(
-      AqlItemBlockInputRange const& input, AqlCall const& call) const noexcept
+  [[nodiscard]] auto expectedNumberOfRows(AqlItemBlockInputRange const& input,
+                                          AqlCall const& call) const noexcept
       -> size_t;
 
   /**

--- a/arangod/Aql/EnumerateListExecutor.h
+++ b/arangod/Aql/EnumerateListExecutor.h
@@ -79,7 +79,6 @@ class EnumerateListExecutor {
     static constexpr bool preservesOrder = true;
     static constexpr BlockPassthrough allowsBlockPassthrough =
         BlockPassthrough::Disable;
-    static constexpr bool inputSizeRestrictsOutputSize = false;
   };
   using Fetcher = SingleRowFetcher<Properties::allowsBlockPassthrough>;
   using Infos = EnumerateListExecutorInfos;

--- a/arangod/Aql/EnumeratePathsExecutor.h
+++ b/arangod/Aql/EnumeratePathsExecutor.h
@@ -125,7 +125,6 @@ class EnumeratePathsExecutor {
     static constexpr bool preservesOrder = true;
     static constexpr BlockPassthrough allowsBlockPassthrough =
         BlockPassthrough::Disable;
-    static constexpr bool inputSizeRestrictsOutputSize = false;
   };
   using Fetcher = SingleRowFetcher<Properties::allowsBlockPassthrough>;
   using Infos = EnumeratePathsExecutorInfos<FinderType>;

--- a/arangod/Aql/ExecutionBlockImpl.tpp
+++ b/arangod/Aql/ExecutionBlockImpl.tpp
@@ -245,7 +245,6 @@ using namespace arangodb::aql;
 CREATE_HAS_MEMBER_CHECK(initializeCursor, hasInitializeCursor);
 CREATE_HAS_MEMBER_CHECK(expectedNumberOfRows, hasExpectedNumberOfRows);
 CREATE_HAS_MEMBER_CHECK(skipRowsRange, hasSkipRowsRange);
-CREATE_HAS_MEMBER_CHECK(expectedNumberOfRowsNew, hasExpectedNumberOfRowsNew);
 
 #ifdef ARANGODB_USE_GOOGLE_TESTS
 // Forward declaration of Test Executors.
@@ -577,7 +576,7 @@ auto ExecutionBlockImpl<Executor>::allocateOutputBlock(AqlCall&& call)
 
     // Non-Passthrough variant, we need to allocate the block ourselfs
     size_t blockSize = ExecutionBlock::DefaultBatchSize;
-    if constexpr (hasExpectedNumberOfRowsNew<Executor>::value) {
+    if constexpr (hasExpectedNumberOfRows<Executor>::value) {
       // Only limit the output size if there will be no more
       // data from upstream. Or if we have ordered a SOFT LIMIT.
       // Otherwise we will overallocate here.
@@ -586,7 +585,7 @@ auto ExecutionBlockImpl<Executor>::allocateOutputBlock(AqlCall&& call)
       // returns HASMORE.
       if (_lastRange.finalState() == MainQueryState::DONE ||
           call.hasSoftLimit()) {
-        blockSize = executor().expectedNumberOfRowsNew(_lastRange, call);
+        blockSize = executor().expectedNumberOfRows(_lastRange, call);
         if (_lastRange.finalState() == MainQueryState::HASMORE) {
           // There might be more from above!
           blockSize = std::max(call.getLimit(), blockSize);

--- a/arangod/Aql/FilterExecutor.cpp
+++ b/arangod/Aql/FilterExecutor.cpp
@@ -98,7 +98,7 @@ auto FilterExecutor::produceRows(AqlItemBlockInputRange& inputRange,
   return {inputRange.upstreamState(), stats, AqlCall{}};
 }
 
-[[nodiscard]] auto FilterExecutor::expectedNumberOfRowsNew(
+[[nodiscard]] auto FilterExecutor::expectedNumberOfRows(
     AqlItemBlockInputRange const& input, AqlCall const& call) const noexcept
     -> size_t {
   if (input.finalState() == MainQueryState::DONE) {

--- a/arangod/Aql/FilterExecutor.h
+++ b/arangod/Aql/FilterExecutor.h
@@ -69,7 +69,6 @@ class FilterExecutor {
     static constexpr bool preservesOrder = true;
     static constexpr BlockPassthrough allowsBlockPassthrough =
         BlockPassthrough::Disable;
-    static constexpr bool inputSizeRestrictsOutputSize = true;
   };
   using Fetcher = SingleRowFetcher<Properties::allowsBlockPassthrough>;
   using Infos = FilterExecutorInfos;
@@ -99,8 +98,8 @@ class FilterExecutor {
   [[nodiscard]] std::tuple<ExecutorState, Stats, size_t, AqlCall> skipRowsRange(
       AqlItemBlockInputRange& inputRange, AqlCall& call);
 
-  [[nodiscard]] auto expectedNumberOfRowsNew(
-      AqlItemBlockInputRange const& input, AqlCall const& call) const noexcept
+  [[nodiscard]] auto expectedNumberOfRows(AqlItemBlockInputRange const& input,
+                                          AqlCall const& call) const noexcept
       -> size_t;
 
  private:

--- a/arangod/Aql/HashedCollectExecutor.cpp
+++ b/arangod/Aql/HashedCollectExecutor.cpp
@@ -410,7 +410,7 @@ HashedCollectExecutor::findOrEmplaceGroup(InputAqlItemRow& input) {
   return result;
 }
 
-[[nodiscard]] auto HashedCollectExecutor::expectedNumberOfRowsNew(
+[[nodiscard]] auto HashedCollectExecutor::expectedNumberOfRows(
     AqlItemBlockInputRange const& input, AqlCall const& call) const noexcept
     -> size_t {
   if (!_isInitialized) {

--- a/arangod/Aql/HashedCollectExecutor.h
+++ b/arangod/Aql/HashedCollectExecutor.h
@@ -149,7 +149,6 @@ class HashedCollectExecutor {
     static constexpr bool preservesOrder = false;
     static constexpr BlockPassthrough allowsBlockPassthrough =
         BlockPassthrough::Disable;
-    static constexpr bool inputSizeRestrictsOutputSize = true;
   };
   using Fetcher = SingleRowFetcher<Properties::allowsBlockPassthrough>;
   using Infos = HashedCollectExecutorInfos;
@@ -187,8 +186,8 @@ class HashedCollectExecutor {
    * it knows that it can only create as many new rows as pulled from upstream.
    * So it will overestimate.
    */
-  [[nodiscard]] auto expectedNumberOfRowsNew(
-      AqlItemBlockInputRange const& input, AqlCall const& call) const noexcept
+  [[nodiscard]] auto expectedNumberOfRows(AqlItemBlockInputRange const& input,
+                                          AqlCall const& call) const noexcept
       -> size_t;
 
  private:

--- a/arangod/Aql/IResearchViewExecutor.h
+++ b/arangod/Aql/IResearchViewExecutor.h
@@ -484,7 +484,6 @@ class IResearchViewExecutorBase {
     static constexpr bool preservesOrder = true;
     static constexpr BlockPassthrough allowsBlockPassthrough =
         BlockPassthrough::Disable;
-    static constexpr bool inputSizeRestrictsOutputSize = false;
   };
   using Fetcher = SingleRowFetcher<Properties::allowsBlockPassthrough>;
   using Infos = IResearchViewExecutorInfos;

--- a/arangod/Aql/IdExecutor.h
+++ b/arangod/Aql/IdExecutor.h
@@ -96,7 +96,6 @@ class IdExecutor {
     static constexpr bool preservesOrder = true;
     static constexpr BlockPassthrough allowsBlockPassthrough =
         BlockPassthrough::Enable;
-    static constexpr bool inputSizeRestrictsOutputSize = false;
   };
   // Only Supports SingleRowFetcher and ConstFetcher
   using Fetcher = UsedFetcher;

--- a/arangod/Aql/IndexExecutor.cpp
+++ b/arangod/Aql/IndexExecutor.cpp
@@ -816,7 +816,7 @@ bool IndexExecutor::needsUniquenessCheck() const noexcept {
   return _infos.getIndexes().size() > 1 || _infos.hasMultipleExpansions();
 }
 
-[[nodiscard]] auto IndexExecutor::expectedNumberOfRowsNew(
+[[nodiscard]] auto IndexExecutor::expectedNumberOfRows(
     AqlItemBlockInputRange const& input, AqlCall const& call) const noexcept
     -> size_t {
   if (_infos.getCount()) {

--- a/arangod/Aql/IndexExecutor.h
+++ b/arangod/Aql/IndexExecutor.h
@@ -280,7 +280,6 @@ class IndexExecutor {
     static constexpr bool preservesOrder = true;
     static constexpr BlockPassthrough allowsBlockPassthrough =
         BlockPassthrough::Disable;
-    static constexpr bool inputSizeRestrictsOutputSize = false;
   };
 
   using Fetcher = SingleRowFetcher<Properties::allowsBlockPassthrough>;
@@ -297,8 +296,8 @@ class IndexExecutor {
    * @brief This Executor in some cases knows how many rows it will produce and
    * most by itself
    */
-  [[nodiscard]] auto expectedNumberOfRowsNew(
-      AqlItemBlockInputRange const& input, AqlCall const& call) const noexcept
+  [[nodiscard]] auto expectedNumberOfRows(AqlItemBlockInputRange const& input,
+                                          AqlCall const& call) const noexcept
       -> size_t;
 
   auto produceRows(AqlItemBlockInputRange& inputRange, OutputAqlItemRow& output)

--- a/arangod/Aql/LimitExecutor.h
+++ b/arangod/Aql/LimitExecutor.h
@@ -80,7 +80,6 @@ class LimitExecutor {
     static constexpr bool preservesOrder = true;
     static constexpr BlockPassthrough allowsBlockPassthrough =
         BlockPassthrough::Enable;
-    static constexpr bool inputSizeRestrictsOutputSize = false;
   };
   using Fetcher = SingleRowFetcher<Properties::allowsBlockPassthrough>;
   using Infos = LimitExecutorInfos;

--- a/arangod/Aql/MaterializeExecutor.h
+++ b/arangod/Aql/MaterializeExecutor.h
@@ -106,8 +106,6 @@ class MaterializeExecutor {
     // FIXME(gnusi): enable?
     static constexpr BlockPassthrough allowsBlockPassthrough =
         BlockPassthrough::Disable;
-    // TODO this could be set to true!
-    static constexpr bool inputSizeRestrictsOutputSize = false;
   };
   using Fetcher = SingleRowFetcher<Properties::allowsBlockPassthrough>;
   using Infos = MaterializerExecutorInfos<T>;

--- a/arangod/Aql/ModificationExecutor.h
+++ b/arangod/Aql/ModificationExecutor.h
@@ -164,7 +164,6 @@ class ModificationExecutor {
     static constexpr bool preservesOrder = true;
     static constexpr BlockPassthrough allowsBlockPassthrough =
         BlockPassthrough::Disable;
-    static constexpr bool inputSizeRestrictsOutputSize = false;
   };
   using Fetcher = FetcherType;
   using Infos = ModificationExecutorInfos;

--- a/arangod/Aql/MultipleRemoteModificationExecutor.h
+++ b/arangod/Aql/MultipleRemoteModificationExecutor.h
@@ -63,7 +63,6 @@ struct MultipleRemoteModificationExecutor {
     static constexpr bool preservesOrder = true;
     static constexpr BlockPassthrough allowsBlockPassthrough =
         BlockPassthrough::Disable;
-    static constexpr bool inputSizeRestrictsOutputSize = false;
   };
   using Infos = MultipleRemoteModificationInfos;
   using Fetcher = SingleRowFetcher<Properties::allowsBlockPassthrough>;

--- a/arangod/Aql/NoResultsExecutor.cpp
+++ b/arangod/Aql/NoResultsExecutor.cpp
@@ -47,7 +47,7 @@ auto NoResultsExecutor::skipRowsRange(AqlItemBlockInputRange& inputRange,
           AqlCall{0, false, 0, AqlCall::LimitType::HARD}};
 };
 
-[[nodiscard]] auto NoResultsExecutor::expectedNumberOfRowsNew(
+[[nodiscard]] auto NoResultsExecutor::expectedNumberOfRows(
     AqlItemBlockInputRange const& input, AqlCall const& call) const noexcept
     -> size_t {
   // Well nevermind the input, but we will always return 0 rows here.

--- a/arangod/Aql/NoResultsExecutor.h
+++ b/arangod/Aql/NoResultsExecutor.h
@@ -50,7 +50,6 @@ class NoResultsExecutor {
     static constexpr bool preservesOrder = true;
     static constexpr BlockPassthrough allowsBlockPassthrough =
         BlockPassthrough::Disable;
-    static constexpr bool inputSizeRestrictsOutputSize = true;
   };
   using Fetcher = SingleRowFetcher<Properties::allowsBlockPassthrough>;
   using Infos = EmptyExecutorInfos;
@@ -76,8 +75,8 @@ class NoResultsExecutor {
                                    AqlCall& call) const noexcept
       -> std::tuple<ExecutorState, Stats, size_t, AqlCall>;
 
-  [[nodiscard]] auto expectedNumberOfRowsNew(
-      AqlItemBlockInputRange const& input, AqlCall const& call) const noexcept
+  [[nodiscard]] auto expectedNumberOfRows(AqlItemBlockInputRange const& input,
+                                          AqlCall const& call) const noexcept
       -> size_t;
 };
 }  // namespace aql

--- a/arangod/Aql/OutputAqlItemRow.cpp
+++ b/arangod/Aql/OutputAqlItemRow.cpp
@@ -238,7 +238,7 @@ auto OutputAqlItemRow::fastForwardAllRows(InputAqlItemRow const& sourceRow,
   // We have the guarantee that we have all data in our block.
   // We only need to adjust internal indexes.
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
-  // Safely assert that the API is not missused.
+  // Safely assert that the API is not misused.
   TRI_ASSERT(_baseIndex + rows <= _block->numRows());
   for (size_t i = _baseIndex; i < _baseIndex + rows; ++i) {
     TRI_ASSERT(!_block->isShadowRow(i));

--- a/arangod/Aql/ParallelUnsortedGatherExecutor.h
+++ b/arangod/Aql/ParallelUnsortedGatherExecutor.h
@@ -52,7 +52,6 @@ class ParallelUnsortedGatherExecutor {
     static constexpr bool preservesOrder = true;
     static constexpr BlockPassthrough allowsBlockPassthrough =
         BlockPassthrough::Disable;
-    static constexpr bool inputSizeRestrictsOutputSize = false;
   };
 
   using Fetcher = MultiDependencySingleRowFetcher;

--- a/arangod/Aql/ReturnExecutor.cpp
+++ b/arangod/Aql/ReturnExecutor.cpp
@@ -102,7 +102,7 @@ auto ReturnExecutor::produceRows(AqlItemBlockInputRange& inputRange,
   return {inputRange.upstreamState(), stats, output.getClientCall()};
 }
 
-[[nodiscard]] auto ReturnExecutor::expectedNumberOfRowsNew(
+[[nodiscard]] auto ReturnExecutor::expectedNumberOfRows(
     AqlItemBlockInputRange const& input, AqlCall const& call) const noexcept
     -> size_t {
   if (input.finalState() == MainQueryState::DONE) {

--- a/arangod/Aql/ReturnExecutor.h
+++ b/arangod/Aql/ReturnExecutor.h
@@ -79,7 +79,6 @@ class ReturnExecutor {
     // block with only this column.
     static constexpr BlockPassthrough allowsBlockPassthrough =
         BlockPassthrough::Disable;
-    static constexpr bool inputSizeRestrictsOutputSize = true;
   };
   using Fetcher = SingleRowFetcher<Properties::allowsBlockPassthrough>;
   using Infos = ReturnExecutorInfos;
@@ -107,8 +106,8 @@ class ReturnExecutor {
                                  OutputAqlItemRow& output)
       -> std::tuple<ExecutorState, Stats, AqlCall>;
 
-  [[nodiscard]] auto expectedNumberOfRowsNew(
-      AqlItemBlockInputRange const& input, AqlCall const& call) const noexcept
+  [[nodiscard]] auto expectedNumberOfRows(AqlItemBlockInputRange const& input,
+                                          AqlCall const& call) const noexcept
       -> size_t;
 
  private:

--- a/arangod/Aql/ShortestPathExecutor.h
+++ b/arangod/Aql/ShortestPathExecutor.h
@@ -147,7 +147,6 @@ class ShortestPathExecutor {
     static constexpr bool preservesOrder = true;
     static constexpr BlockPassthrough allowsBlockPassthrough =
         BlockPassthrough::Disable;
-    static constexpr bool inputSizeRestrictsOutputSize = false;
   };
   using Fetcher = SingleRowFetcher<Properties::allowsBlockPassthrough>;
   using Infos = ShortestPathExecutorInfos<FinderType>;

--- a/arangod/Aql/SingleRemoteModificationExecutor.h
+++ b/arangod/Aql/SingleRemoteModificationExecutor.h
@@ -79,7 +79,6 @@ struct SingleRemoteModificationExecutor {
     static constexpr bool preservesOrder = true;
     static constexpr BlockPassthrough allowsBlockPassthrough =
         BlockPassthrough::Disable;
-    static constexpr bool inputSizeRestrictsOutputSize = false;
   };
   using Infos = SingleRemoteModificationInfos;
   using Fetcher = SingleRowFetcher<Properties::allowsBlockPassthrough>;

--- a/arangod/Aql/SortExecutor.h
+++ b/arangod/Aql/SortExecutor.h
@@ -129,7 +129,6 @@ class SortExecutor {
     static constexpr bool preservesOrder = false;
     static constexpr BlockPassthrough allowsBlockPassthrough =
         BlockPassthrough::Disable;
-    static constexpr bool inputSizeRestrictsOutputSize = true;
   };
   using Fetcher = SingleRowFetcher<Properties::allowsBlockPassthrough>;
   using Infos = SortExecutorInfos;

--- a/arangod/Aql/SortedCollectExecutor.cpp
+++ b/arangod/Aql/SortedCollectExecutor.cpp
@@ -283,7 +283,7 @@ void SortedCollectExecutor::CollectGroup::writeToOutput(
   output.advanceRow();
 }
 
-[[nodiscard]] auto SortedCollectExecutor::expectedNumberOfRowsNew(
+[[nodiscard]] auto SortedCollectExecutor::expectedNumberOfRows(
     AqlItemBlockInputRange const& input, AqlCall const& call) const noexcept
     -> size_t {
   if (input.finalState() == MainQueryState::DONE) {

--- a/arangod/Aql/SortedCollectExecutor.h
+++ b/arangod/Aql/SortedCollectExecutor.h
@@ -166,7 +166,6 @@ class SortedCollectExecutor {
     static constexpr bool preservesOrder = false;
     static constexpr BlockPassthrough allowsBlockPassthrough =
         BlockPassthrough::Disable;
-    static constexpr bool inputSizeRestrictsOutputSize = true;
   };
   using Fetcher = SingleRowFetcher<Properties::allowsBlockPassthrough>;
   using Infos = SortedCollectExecutorInfos;
@@ -202,8 +201,8 @@ class SortedCollectExecutor {
    * it will produce exactly. It can however only
    * overestimate never underestimate.
    */
-  [[nodiscard]] auto expectedNumberOfRowsNew(
-      AqlItemBlockInputRange const& input, AqlCall const& call) const noexcept
+  [[nodiscard]] auto expectedNumberOfRows(AqlItemBlockInputRange const& input,
+                                          AqlCall const& call) const noexcept
       -> size_t;
 
  private:

--- a/arangod/Aql/SortingGatherExecutor.h
+++ b/arangod/Aql/SortingGatherExecutor.h
@@ -108,7 +108,6 @@ class SortingGatherExecutor {
     static constexpr bool preservesOrder = true;
     static constexpr BlockPassthrough allowsBlockPassthrough =
         BlockPassthrough::Disable;
-    static constexpr bool inputSizeRestrictsOutputSize = true;
   };
 
   using Fetcher = MultiDependencySingleRowFetcher;

--- a/arangod/Aql/SubqueryEndExecutor.cpp
+++ b/arangod/Aql/SubqueryEndExecutor.cpp
@@ -217,7 +217,7 @@ size_t SubqueryEndExecutor::Accumulator::numValues() const noexcept {
 // We do not write any output for inbound dataRows
 // We will only write output for shadowRows. This is accounted for in
 // ExecutionBlockImpl
-[[nodiscard]] auto SubqueryEndExecutor::expectedNumberOfRowsNew(
+[[nodiscard]] auto SubqueryEndExecutor::expectedNumberOfRows(
     AqlItemBlockInputRange const&, AqlCall const&) const noexcept -> size_t {
   return 0;
 }

--- a/arangod/Aql/SubqueryEndExecutor.h
+++ b/arangod/Aql/SubqueryEndExecutor.h
@@ -73,7 +73,6 @@ class SubqueryEndExecutor {
     static constexpr bool preservesOrder = true;
     static constexpr BlockPassthrough allowsBlockPassthrough =
         BlockPassthrough::Disable;
-    static constexpr bool inputSizeRestrictsOutputSize = true;
   };
 
   using Fetcher = SingleRowFetcher<Properties::allowsBlockPassthrough>;
@@ -98,8 +97,8 @@ class SubqueryEndExecutor {
   [[nodiscard]] auto skipRowsRange(AqlItemBlockInputRange& input, AqlCall& call)
       -> std::tuple<ExecutorState, Stats, size_t, AqlCall>;
 
-  [[nodiscard]] auto expectedNumberOfRowsNew(
-      AqlItemBlockInputRange const& input, AqlCall const& call) const noexcept
+  [[nodiscard]] auto expectedNumberOfRows(AqlItemBlockInputRange const& input,
+                                          AqlCall const& call) const noexcept
       -> size_t;
 
   /**

--- a/arangod/Aql/SubqueryStartExecutor.cpp
+++ b/arangod/Aql/SubqueryStartExecutor.cpp
@@ -92,7 +92,7 @@ auto SubqueryStartExecutor::produceShadowRow(AqlItemBlockInputRange& input,
   return false;
 }
 
-[[nodiscard]] auto SubqueryStartExecutor::expectedNumberOfRowsNew(
+[[nodiscard]] auto SubqueryStartExecutor::expectedNumberOfRows(
     AqlItemBlockInputRange const& input, AqlCall const& call) const noexcept
     -> size_t {
   // The DataRow is consumed after a shadowRow is produced.

--- a/arangod/Aql/SubqueryStartExecutor.h
+++ b/arangod/Aql/SubqueryStartExecutor.h
@@ -45,7 +45,6 @@ class SubqueryStartExecutor {
     static constexpr bool preservesOrder = true;
     static constexpr BlockPassthrough allowsBlockPassthrough =
         BlockPassthrough::Disable;
-    static constexpr bool inputSizeRestrictsOutputSize = true;
   };
 
   using Fetcher = SingleRowFetcher<Properties::allowsBlockPassthrough>;
@@ -72,8 +71,8 @@ class SubqueryStartExecutor {
   auto produceShadowRow(AqlItemBlockInputRange& input, OutputAqlItemRow& output)
       -> bool;
 
-  [[nodiscard]] auto expectedNumberOfRowsNew(
-      AqlItemBlockInputRange const& input, AqlCall const& call) const noexcept
+  [[nodiscard]] auto expectedNumberOfRows(AqlItemBlockInputRange const& input,
+                                          AqlCall const& call) const noexcept
       -> size_t;
 
  private:

--- a/arangod/Aql/TraversalExecutor.h
+++ b/arangod/Aql/TraversalExecutor.h
@@ -193,7 +193,6 @@ class TraversalExecutor {
     static constexpr bool preservesOrder = true;
     static constexpr BlockPassthrough allowsBlockPassthrough =
         BlockPassthrough::Disable;
-    static constexpr bool inputSizeRestrictsOutputSize = false;
   };
   using Fetcher = SingleRowFetcher<Properties::allowsBlockPassthrough>;
   using Infos = TraversalExecutorInfos;

--- a/arangod/Aql/UnsortedGatherExecutor.h
+++ b/arangod/Aql/UnsortedGatherExecutor.h
@@ -57,14 +57,6 @@ class UnsortedGatherExecutor {
     static constexpr bool preservesOrder = false;
     static constexpr BlockPassthrough allowsBlockPassthrough =
         BlockPassthrough::Disable;
-    // This (inputSizeRestrictsOutputSize) could be set to true, but its
-    // usefulness would be limited.
-    // We either can only use it for the last dependency, in which case it's
-    // already too late to avoid a large allocation for a small result set; or
-    // we'd have to prefetch all dependencies (at least until we got >=1000
-    // rows) before answering hasExpectedNumberOfRows(). This might be okay,
-    // but would increase the latency.
-    static constexpr bool inputSizeRestrictsOutputSize = false;
   };
   using Fetcher = MultiDependencySingleRowFetcher;
   // TODO I should probably implement custom Infos, we don't need

--- a/arangod/Aql/WindowExecutor.cpp
+++ b/arangod/Aql/WindowExecutor.cpp
@@ -203,7 +203,7 @@ auto AccuWindowExecutor::skipRowsRange(AqlItemBlockInputRange& inputRange,
           upstreamCall};
 }
 
-[[nodiscard]] auto AccuWindowExecutor::expectedNumberOfRowsNew(
+[[nodiscard]] auto AccuWindowExecutor::expectedNumberOfRows(
     AqlItemBlockInputRange const& input, AqlCall const& call) const noexcept
     -> size_t {
   if (input.finalState() == MainQueryState::DONE) {
@@ -440,7 +440,7 @@ WindowExecutor::skipRowsRange(AqlItemBlockInputRange& inputRange,
   return {state, NoStats{}, call.getSkipCount(), upstreamCall};
 }
 
-[[nodiscard]] auto WindowExecutor::expectedNumberOfRowsNew(
+[[nodiscard]] auto WindowExecutor::expectedNumberOfRows(
     AqlItemBlockInputRange const& input, AqlCall const& call) const noexcept
     -> size_t {
   if (input.finalState() == MainQueryState::DONE) {

--- a/arangod/Aql/WindowExecutor.h
+++ b/arangod/Aql/WindowExecutor.h
@@ -131,7 +131,6 @@ class AccuWindowExecutor : public BaseWindowExecutor {
     static constexpr bool preservesOrder = true;
     static constexpr BlockPassthrough allowsBlockPassthrough =
         BlockPassthrough::Enable;
-    static constexpr bool inputSizeRestrictsOutputSize = true;
   };
   using Fetcher = SingleRowFetcher<Properties::allowsBlockPassthrough>;
   using Infos = WindowExecutorInfos;
@@ -171,8 +170,8 @@ class AccuWindowExecutor : public BaseWindowExecutor {
    * it knows that it can only create as many new rows as pulled from upstream.
    * So it will overestimate.
    */
-  [[nodiscard]] auto expectedNumberOfRowsNew(
-      AqlItemBlockInputRange const& input, AqlCall const& call) const noexcept
+  [[nodiscard]] auto expectedNumberOfRows(AqlItemBlockInputRange const& input,
+                                          AqlCall const& call) const noexcept
       -> size_t;
 };
 
@@ -223,8 +222,8 @@ class WindowExecutor : public BaseWindowExecutor {
    * it knows that it can only create as many new rows as pulled from upstream.
    * So it will overestimate.
    */
-  [[nodiscard]] auto expectedNumberOfRowsNew(
-      AqlItemBlockInputRange const& input, AqlCall const& call) const noexcept
+  [[nodiscard]] auto expectedNumberOfRows(AqlItemBlockInputRange const& input,
+                                          AqlCall const& call) const noexcept
       -> size_t;
 
  private:

--- a/arangod/Aql/WindowExecutor.h
+++ b/arangod/Aql/WindowExecutor.h
@@ -184,7 +184,6 @@ class WindowExecutor : public BaseWindowExecutor {
     static constexpr bool preservesOrder = true;
     static constexpr BlockPassthrough allowsBlockPassthrough =
         BlockPassthrough::Disable;
-    static constexpr bool inputSizeRestrictsOutputSize = true;
   };
   using Fetcher = SingleRowFetcher<Properties::allowsBlockPassthrough>;
   using Infos = WindowExecutorInfos;

--- a/tests/Aql/SubqueryEndExecutorTest.cpp
+++ b/tests/Aql/SubqueryEndExecutorTest.cpp
@@ -69,10 +69,7 @@ TEST_F(SubqueryEndExecutorTest, check_properties) {
             ::arangodb::aql::BlockPassthrough::Disable)
       << "The block cannot be passThrough, as it increases the number of "
          "rows.";
-  EXPECT_TRUE(SubqueryEndExecutor::Properties::inputSizeRestrictsOutputSize)
-      << "The block produces one output row per input row plus potentially a "
-         "shadow rows which is bounded by the structure of the query";
-};
+}
 
 TEST_F(SubqueryEndExecutorTest, count_shadow_rows_test) {
   // NOTE: This is a regression test for BTS-673

--- a/tests/Aql/SubqueryStartExecutorTest.cpp
+++ b/tests/Aql/SubqueryStartExecutorTest.cpp
@@ -98,9 +98,6 @@ TEST_P(SubqueryStartExecutorTest, check_properties) {
   EXPECT_EQ(SubqueryStartExecutor::Properties::allowsBlockPassthrough,
             ::arangodb::aql::BlockPassthrough::Disable)
       << "The block cannot be passThrough, as it increases the number of rows.";
-  EXPECT_TRUE(SubqueryStartExecutor::Properties::inputSizeRestrictsOutputSize)
-      << "The block is restricted by input, it will atMost produce 2 times the "
-         "input. (Might be less if input contains shadowRows";
 }
 
 TEST_P(SubqueryStartExecutorTest, empty_input_does_not_add_shadow_rows) {

--- a/tests/Aql/TestEmptyExecutorHelper.h
+++ b/tests/Aql/TestEmptyExecutorHelper.h
@@ -48,7 +48,6 @@ class TestEmptyExecutorHelper {
     static const bool preservesOrder = true;
     static const BlockPassthrough allowsBlockPassthrough =
         BlockPassthrough::Disable;
-    static const bool inputSizeRestrictsOutputSize = false;
   };
   using Fetcher = SingleRowFetcher<Properties::allowsBlockPassthrough>;
   using Infos = EmptyExecutorInfos;

--- a/tests/Aql/TestLambdaExecutor.h
+++ b/tests/Aql/TestLambdaExecutor.h
@@ -122,7 +122,6 @@ class TestLambdaExecutor {
     static const bool preservesOrder = true;
     static const BlockPassthrough allowsBlockPassthrough =
         BlockPassthrough::Enable;
-    static const bool inputSizeRestrictsOutputSize = false;
   };
   using Fetcher = SingleRowFetcher<Properties::allowsBlockPassthrough>;
   using Infos = LambdaExecutorInfos;
@@ -162,7 +161,6 @@ class TestLambdaSkipExecutor {
     static const bool preservesOrder = true;
     static const BlockPassthrough allowsBlockPassthrough =
         BlockPassthrough::Disable;
-    static const bool inputSizeRestrictsOutputSize = false;
   };
   using Fetcher = SingleRowFetcher<Properties::allowsBlockPassthrough>;
   using Infos = LambdaSkipExecutorInfos;


### PR DESCRIPTION
### Scope & Purpose

Enterprise companion PR: https://github.com/arangodb/enterprise/pull/1379

Small AQL code cleanup:

- remove `inputSizeRestrictsOutputSize`: this flag was unused
- rename `expectedNumberOfRowsNew` to `expectedNumberOfRows`

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [x] GitHub issue / Jira ticket: https://github.com/arangodb/enterprise/pull/1379
- [ ] Design document: 