### PR TITLE
add thread-id to log output during tests

### DIFF
--- a/etc/testing/arangod-common.conf
+++ b/etc/testing/arangod-common.conf
@@ -1,12 +1,13 @@
 [log]
-line-number = false
 force-direct = false
 level = info
 level = replication2=debug
 level = rep-state=debug
 level = replication=warn
+line-number = false
 role = true
-log.time-format = utc-datestring-micros
+time-format = utc-datestring-micros
+thread = true
 
 [database]
 extended-names = true

--- a/tests/js/client/server_parameters/log-json-no-shorten.js
+++ b/tests/js/client/server_parameters/log-json-no-shorten.js
@@ -36,6 +36,7 @@ if (getOptions === true) {
     'log.role': 'false',
     'log.output': 'file://' + fs.getTempFile() + '.$PID',
     'log.foreground-tty': 'false',
+    'log.thread': 'false',
   };
 }
 

--- a/tests/js/client/server_parameters/log-json-shorten.js
+++ b/tests/js/client/server_parameters/log-json-shorten.js
@@ -36,6 +36,7 @@ if (getOptions === true) {
     'log.role': 'false',
     'log.output': 'file://' + fs.getTempFile() + '.$PID',
     'log.foreground-tty': 'false',
+    'log.thread': 'false',
   };
 }
 

--- a/tests/js/client/server_parameters/log-json.js
+++ b/tests/js/client/server_parameters/log-json.js
@@ -34,6 +34,7 @@ if (getOptions === true) {
     'log.role': 'false',
     'log.output': 'file://' + fs.getTempFile() + '.$PID',
     'log.foreground-tty': 'false',
+    'log.thread': 'false',
   };
 }
 


### PR DESCRIPTION
### Scope & Purpose

Add thread-id to log output during tests.
This improves usability of logs when debugging multi-thread issues.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 