### PR TITLE
clean up AqlCall

### DIFF
--- a/arangod/Aql/AqlCall.cpp
+++ b/arangod/Aql/AqlCall.cpp
@@ -68,13 +68,13 @@ auto AqlCall::fromVelocyPack(velocypack::Slice slice) -> ResultT<AqlCall> {
       try {
         return AqlCall::Limit{slice.getNumber<std::size_t>()};
       } catch (velocypack::Exception const& ex) {
-        auto message = std::string{"When deserializating AqlCall: "};
+        auto message = std::string{"When deserializing AqlCall: "};
         message += "When reading limit: ";
         message += ex.what();
         return Result(TRI_ERROR_TYPE_ERROR, std::move(message));
       }
     } else {
-      auto message = std::string{"When deserializating AqlCall: "};
+      auto message = std::string{"When deserializing AqlCall: "};
       message += "When reading limit: ";
       if (slice.isString()) {
         message += "Unexpected value '";
@@ -95,7 +95,7 @@ auto AqlCall::fromVelocyPack(velocypack::Slice slice) -> ResultT<AqlCall> {
     }
     if (ADB_UNLIKELY(!slice.isString())) {
       auto message = std::string{
-          "When deserializating AqlCall: When reading limitType: "
+          "When deserializing AqlCall: When reading limitType: "
           "Unexpected type "};
       message += slice.typeName();
       return Result(TRI_ERROR_TYPE_ERROR, std::move(message));
@@ -107,7 +107,7 @@ auto AqlCall::fromVelocyPack(velocypack::Slice slice) -> ResultT<AqlCall> {
       return {AqlCall::LimitType::HARD};
     } else {
       auto message = std::string{
-          "When deserializating AqlCall: When reading limitType: "
+          "When deserializing AqlCall: When reading limitType: "
           "Unexpected value '"};
       message += value;
       message += "'";
@@ -118,7 +118,7 @@ auto AqlCall::fromVelocyPack(velocypack::Slice slice) -> ResultT<AqlCall> {
   auto const readFullCount = [](velocypack::Slice slice) -> ResultT<bool> {
     if (ADB_UNLIKELY(!slice.isBool())) {
       auto message = std::string{
-          "When deserializating AqlCall: When reading fullCount: "
+          "When deserializing AqlCall: When reading fullCount: "
           "Unexpected type "};
       message += slice.typeName();
       return Result(TRI_ERROR_TYPE_ERROR, std::move(message));
@@ -130,7 +130,7 @@ auto AqlCall::fromVelocyPack(velocypack::Slice slice) -> ResultT<AqlCall> {
       [](velocypack::Slice slice) -> ResultT<decltype(offset)> {
     if (!slice.isInteger()) {
       auto message = std::string{
-          "When deserializating AqlCall: When reading offset: "
+          "When deserializing AqlCall: When reading offset: "
           "Unexpected type "};
       message += slice.typeName();
       return Result(TRI_ERROR_TYPE_ERROR, std::move(message));
@@ -139,7 +139,7 @@ auto AqlCall::fromVelocyPack(velocypack::Slice slice) -> ResultT<AqlCall> {
       return slice.getNumber<decltype(offset)>();
     } catch (velocypack::Exception const& ex) {
       auto message =
-          std::string{"When deserializating AqlCall: When reading offset: "};
+          std::string{"When deserializing AqlCall: When reading offset: "};
       message += ex.what();
       return Result(TRI_ERROR_TYPE_ERROR, std::move(message));
     }
@@ -149,16 +149,15 @@ auto AqlCall::fromVelocyPack(velocypack::Slice slice) -> ResultT<AqlCall> {
     auto const keySlice = it.key;
     if (ADB_UNLIKELY(!keySlice.isString())) {
       return Result(TRI_ERROR_TYPE_ERROR,
-                    "When deserializating AqlCall: Key is not a string");
+                    "When deserializing AqlCall: Key is not a string");
     }
     auto const key = keySlice.stringView();
 
     if (auto propIt = expectedPropertiesFound.find(key);
         ADB_LIKELY(propIt != expectedPropertiesFound.end())) {
       if (ADB_UNLIKELY(propIt->second)) {
-        return Result(
-            TRI_ERROR_TYPE_ERROR,
-            "When deserializating AqlCall: Encountered duplicate key");
+        return Result(TRI_ERROR_TYPE_ERROR,
+                      "When deserializing AqlCall: Encountered duplicate key");
       }
       propIt->second = true;
     }
@@ -189,7 +188,7 @@ auto AqlCall::fromVelocyPack(velocypack::Slice slice) -> ResultT<AqlCall> {
       offset = maybeOffset.get();
     } else {
       LOG_TOPIC("404b0", WARN, Logger::AQL)
-          << "When deserializating AqlCall: Encountered unexpected key " << key;
+          << "When deserializing AqlCall: Encountered unexpected key " << key;
       // If you run into this assertion during rolling upgrades after adding a
       // new attribute, remove it in the older version.
       TRI_ASSERT(false);
@@ -198,7 +197,7 @@ auto AqlCall::fromVelocyPack(velocypack::Slice slice) -> ResultT<AqlCall> {
 
   for (auto const& it : expectedPropertiesFound) {
     if (ADB_UNLIKELY(!it.second)) {
-      auto message = std::string{"When deserializating AqlCall: missing key "};
+      auto message = std::string{"When deserializing AqlCall: missing key "};
       message += it.first;
       return Result(TRI_ERROR_TYPE_ERROR, std::move(message));
     }
@@ -218,7 +217,7 @@ auto AqlCall::fromVelocyPack(velocypack::Slice slice) -> ResultT<AqlCall> {
   } else if (ADB_UNLIKELY(!std::holds_alternative<Infinity>(limit))) {
     return Result(
         TRI_ERROR_TYPE_ERROR,
-        "When deserializating AqlCall: limit set, but limitType is missing.");
+        "When deserializing AqlCall: limit set, but limitType is missing.");
   }
 
   call.offset = offset;

--- a/arangod/Aql/AqlCall.h
+++ b/arangod/Aql/AqlCall.h
@@ -31,7 +31,6 @@
 #include <algorithm>
 #include <cstddef>
 #include <iosfwd>
-#include <tuple>
 #include <variant>
 
 namespace arangodb::velocypack {
@@ -189,12 +188,11 @@ struct AqlCall {
     return skippedRows;
   }
 
-  // TODO this is the same as shouldSkip(), remove one of them.
   [[nodiscard]] bool needSkipMore() const noexcept {
     return (0 < getOffset()) || (getLimit() == 0 && needsFullCount());
   }
 
-  void didProduce(std::size_t n) {
+  void didProduce(std::size_t n) noexcept {
     auto minus = overload{
         [n](size_t& i) {
           TRI_ASSERT(n <= i);
@@ -219,11 +217,6 @@ struct AqlCall {
   }
 
   bool needsFullCount() const noexcept { return fullCount; }
-
-  // TODO this is the same as needSkipMore(), remove one of them.
-  bool shouldSkip() const noexcept {
-    return getOffset() > 0 || (getLimit() == 0 && needsFullCount());
-  }
 
   auto requestLessDataThan(AqlCall const& other) const noexcept -> bool;
 };

--- a/arangod/Aql/EnumerateCollectionExecutor.cpp
+++ b/arangod/Aql/EnumerateCollectionExecutor.cpp
@@ -192,7 +192,7 @@ EnumerateCollectionExecutor::skipRowsRange(AqlItemBlockInputRange& inputRange,
 
   TRI_ASSERT(_documentProducingFunctionContext.getAndResetNumScanned() == 0);
   TRI_ASSERT(_documentProducingFunctionContext.getAndResetNumFiltered() == 0);
-  while ((inputRange.hasDataRow() || _cursorHasMore) && call.shouldSkip()) {
+  while ((inputRange.hasDataRow() || _cursorHasMore) && call.needSkipMore()) {
     uint64_t skipped = 0;
 
     if (!_cursorHasMore) {

--- a/arangod/Aql/EnumerateListExecutor.cpp
+++ b/arangod/Aql/EnumerateListExecutor.cpp
@@ -159,7 +159,7 @@ EnumerateListExecutor::skipRowsRange(AqlItemBlockInputRange& inputRange,
                                      AqlCall& call) {
   InputAqlItemRow input{CreateInvalidInputRowHint{}};
 
-  while (inputRange.hasDataRow() && call.shouldSkip()) {
+  while (inputRange.hasDataRow() && call.needSkipMore()) {
     if (_inputArrayLength == _inputArrayPosition) {
       // we reached either the end of an array
       // or are in our first loop iteration

--- a/arangod/Aql/EnumeratePathsExecutor.cpp
+++ b/arangod/Aql/EnumeratePathsExecutor.cpp
@@ -193,7 +193,7 @@ auto EnumeratePathsExecutor<FinderType>::skipRowsRange(
     -> std::tuple<ExecutorState, Stats, size_t, AqlCall> {
   auto skipped = size_t{0};
 
-  while (call.shouldSkip()) {
+  while (call.needSkipMore()) {
     // _finder.isDone() == true means that there is currently no path available
     // from the _finder, we can try calling fetchPaths to make one available,
     // but if that fails too, we must be DONE

--- a/arangod/Aql/IResearchViewExecutor.tpp
+++ b/arangod/Aql/IResearchViewExecutor.tpp
@@ -665,7 +665,7 @@ IResearchViewExecutorBase<Impl, ExecutionTraits>::skipRowsRange(
              (!this->infos().heapSort().empty() && needFullCount));
   auto& impl = static_cast<Impl&>(*this);
   IResearchViewStats stats{};
-  while (inputRange.hasDataRow() && call.shouldSkip()) {
+  while (inputRange.hasDataRow() && call.needSkipMore()) {
     if (!_inputRow.isInitialized()) {
       auto rowState = ExecutorState::HASMORE;
       std::tie(rowState, _inputRow) = inputRange.peekDataRow();
@@ -690,7 +690,7 @@ IResearchViewExecutorBase<Impl, ExecutionTraits>::skipRowsRange(
     // only heapsort version could possibly fetch more than skip requested
     TRI_ASSERT(_indexReadBuffer.empty() || !infos().heapSort().empty());
 
-    if (call.shouldSkip()) {
+    if (call.needSkipMore()) {
       // We still need to fetch more
       // trigger refetch of new input row
       inputRange.advanceDataRow();

--- a/arangod/Aql/SortExecutor.cpp
+++ b/arangod/Aql/SortExecutor.cpp
@@ -157,7 +157,7 @@ std::tuple<ExecutorState, NoStats, size_t, AqlCall> SortExecutor::skipRowsRange(
     _inputReady = true;
   }
 
-  while (call.shouldSkip() && _storageBackend->hasMore()) {
+  while (call.needSkipMore() && _storageBackend->hasMore()) {
     _storageBackend->skipOutputRow();
     call.didSkip(1);
   }

--- a/arangod/Aql/SubqueryStartExecutor.cpp
+++ b/arangod/Aql/SubqueryStartExecutor.cpp
@@ -57,7 +57,7 @@ auto SubqueryStartExecutor::produceRows(AqlItemBlockInputRange& input,
 auto SubqueryStartExecutor::skipRowsRange(AqlItemBlockInputRange& input,
                                           AqlCall& call)
     -> std::tuple<ExecutorState, Stats, size_t, AqlCall> {
-  TRI_ASSERT(call.shouldSkip());
+  TRI_ASSERT(call.needSkipMore());
   if (_inputRow.isInitialized()) {
     // We have not been able to report the ShadowRow.
     // Simply return DONE to trigger Impl to fetch shadow row instead.

--- a/arangod/Aql/TraversalExecutor.cpp
+++ b/arangod/Aql/TraversalExecutor.cpp
@@ -458,7 +458,7 @@ auto TraversalExecutor::skipRowsRange(AqlItemBlockInputRange& input,
     -> std::tuple<ExecutorState, Stats, size_t, AqlCall> {
   auto skipped = size_t{0};
 
-  while (call.shouldSkip()) {
+  while (call.needSkipMore()) {
     if (traversalEnumerator()->isDone()) {
       if (!initTraverser(input)) {
         TRI_ASSERT(!input.hasDataRow());

--- a/tests/Aql/ExecutionBlockImplTest.cpp
+++ b/tests/Aql/ExecutionBlockImplTest.cpp
@@ -1471,7 +1471,7 @@ class ExecutionBlockImplExecuteIntegrationTest
       skipAsserter.gotCalled(call);
 
       size_t skipped = 0;
-      while (inputRange.hasDataRow() && call.shouldSkip()) {
+      while (inputRange.hasDataRow() && call.needSkipMore()) {
         auto const& [state, input] = inputRange.nextDataRow();
         EXPECT_TRUE(input.isInitialized());
         skipped++;
@@ -1856,7 +1856,7 @@ TEST_P(ExecutionBlockImplExecuteIntegrationTest,
       -> std::tuple<ExecutorState, NoStats, size_t, AqlCall> {
     skipState.gotCalled(call);
     size_t skipped = 0;
-    while (inputRange.hasDataRow() && call.shouldSkip()) {
+    while (inputRange.hasDataRow() && call.needSkipMore()) {
       auto const& [state, input] = inputRange.nextDataRow();
       EXPECT_TRUE(input.isInitialized());
       skipped++;

--- a/tests/Aql/SplicedSubqueryIntegrationTest.cpp
+++ b/tests/Aql/SplicedSubqueryIntegrationTest.cpp
@@ -182,7 +182,7 @@ class SplicedSubqueryIntegrationTest
   auto createSkipCall() -> SkipCall {
     return [](AqlItemBlockInputRange& input, AqlCall& call)
                -> std::tuple<ExecutorState, LambdaExe::Stats, size_t, AqlCall> {
-      while (call.shouldSkip() && input.skippedInFlight() > 0) {
+      while (call.needSkipMore() && input.skippedInFlight() > 0) {
         if (call.getOffset() > 0) {
           call.didSkip(input.skip(call.getOffset()));
         } else {
@@ -193,7 +193,7 @@ class SplicedSubqueryIntegrationTest
         }
       }
       // If we overfetched and have data, throw it away
-      while (input.hasDataRow() && call.shouldSkip()) {
+      while (input.hasDataRow() && call.needSkipMore()) {
         auto const& [state, inputRow] = input.nextDataRow();
         EXPECT_TRUE(inputRow.isInitialized());
         call.didSkip(1);


### PR DESCRIPTION
### Scope & Purpose

Clean up AqlCall.
Remove AqlCall::shouldSkip(), because its implementation was redundant with AqlCall::needSkipMore(), and adjust all callers to call AqlCall::needSkipMore() instead.
Also fix typos in AqlCall error messages and remove an unused include.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 