### PR TITLE
Make our waitpid implementation interupteable by the monitoring thread

### DIFF
--- a/client-tools/Shell/ProcessMonitoringFeature.cpp
+++ b/client-tools/Shell/ProcessMonitoringFeature.cpp
@@ -126,7 +126,7 @@ void ProcessMonitorThread::run() {  // override
   while (!isStopping()) {
     try {
       _processMonitorFeature.visitMonitoring([&](auto const& pid) {
-        auto status = TRI_CheckExternalProcess(pid, false, 0);
+        auto status = TRI_CheckExternalProcess(pid, false, 0, noDeadLine);
         if ((status._status == TRI_EXT_TERMINATED) ||
             (status._status == TRI_EXT_ABORTED) ||
             (status._status == TRI_EXT_NOT_FOUND)) {

--- a/client-tools/Shell/v8-deadline.cpp
+++ b/client-tools/Shell/v8-deadline.cpp
@@ -78,7 +78,7 @@ static void JS_SetExecutionDeadlineTo(
   TRI_V8_TRY_CATCH_END
 }
 
-bool isExecutionDeadlineReached(v8::Isolate* isolate) {
+bool isExecutionDeadlineReached() {
   std::lock_guard mutex{singletonDeadlineMutex};
   auto when = executionDeadline;
   if (when < 0.00001) {
@@ -89,8 +89,15 @@ bool isExecutionDeadlineReached(v8::Isolate* isolate) {
     return false;
   }
 
-  TRI_CreateErrorObject(isolate, TRI_ERROR_DISABLED, errorState, true);
   return true;
+}
+
+bool isExecutionDeadlineReached(v8::Isolate* isolate) {
+  if (isExecutionDeadlineReached()) {
+    TRI_CreateErrorObject(isolate, TRI_ERROR_DISABLED, errorState, true);
+    return true;
+  }
+  return false;
 }
 
 double correctTimeoutToExecutionDeadlineS(double timeoutSeconds) {

--- a/lib/Basics/FileUtils.cpp
+++ b/lib/Basics/FileUtils.cpp
@@ -764,7 +764,7 @@ std::string slurpProgram(std::string const& program) {
     }
     output.append(buf, nRead);
   }
-  res = TRI_CheckExternalProcess(external, true, 0);
+  res = TRI_CheckExternalProcess(external, true, 0, noDeadLine);
   if (error) {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_SYS_ERROR);
   }

--- a/lib/Basics/process-utils.cpp
+++ b/lib/Basics/process-utils.cpp
@@ -1128,7 +1128,7 @@ ExternalProcessStatus TRI_CheckExternalProcess(
           break;
         }
         if (deadlineReached) {
-          timeoutHappened = !deadlineReached();
+          timeoutHappened = deadlineReached();
           if (timeoutHappened) {
             break;
           }

--- a/lib/Basics/process-utils.h
+++ b/lib/Basics/process-utils.h
@@ -23,13 +23,14 @@
 
 #pragma once
 
+#include <functional>
+#include <mutex>
 #include <string>
 #include <vector>
 #include <optional>
 
 #include "Basics/Common.h"
 #include "Basics/threads.h"
-#include <mutex>
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief invalid process id
@@ -209,9 +210,9 @@ bool TRI_WritePipe(ExternalProcess const* process, char const* buffer,
 /// @brief returns the status of an external process
 ////////////////////////////////////////////////////////////////////////////////
 
-ExternalProcessStatus TRI_CheckExternalProcess(ExternalId pid, bool wait,
-                                               uint32_t timeout,
-                                               bool(deadlineReached)(void));
+ExternalProcessStatus TRI_CheckExternalProcess(
+    ExternalId pid, bool wait, uint32_t timeout,
+    std::function<bool()> const& deadlineReached = {});
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief kills an external process

--- a/lib/Basics/process-utils.h
+++ b/lib/Basics/process-utils.h
@@ -244,4 +244,4 @@ void TRI_ShutdownProcess();
 
 std::string TRI_SetPriority(ExternalId pid, int prio);
 
-bool noDeadLine() { return false;}
+inline bool noDeadLine() { return false; }

--- a/lib/Basics/process-utils.h
+++ b/lib/Basics/process-utils.h
@@ -210,7 +210,8 @@ bool TRI_WritePipe(ExternalProcess const* process, char const* buffer,
 ////////////////////////////////////////////////////////////////////////////////
 
 ExternalProcessStatus TRI_CheckExternalProcess(ExternalId pid, bool wait,
-                                               uint32_t timeout);
+                                               uint32_t timeout,
+                                               bool(deadlineReached)(void));
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief kills an external process
@@ -242,3 +243,5 @@ void TRI_ShutdownProcess();
 ////////////////////////////////////////////////////////////////////////////////
 
 std::string TRI_SetPriority(ExternalId pid, int prio);
+
+bool noDeadLine() { return false;}

--- a/lib/V8/v8-deadline.h
+++ b/lib/V8/v8-deadline.h
@@ -37,6 +37,7 @@ class ApplicationServer;
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief set a point in time after which we will abort external connection
 ////////////////////////////////////////////////////////////////////////////////
+bool isExecutionDeadlineReached();
 bool isExecutionDeadlineReached(v8::Isolate* isolate);
 double correctTimeoutToExecutionDeadlineS(double timeoutSeconds);
 std::chrono::milliseconds correctTimeoutToExecutionDeadline(

--- a/lib/V8/v8-no-deadline.cpp
+++ b/lib/V8/v8-no-deadline.cpp
@@ -25,6 +25,7 @@
 // arangod dummy implementation doing nothing
 void setExecutionDeadlineInMS(uint64_t timeout) {}
 
+bool isExecutionDeadlineReached() { return false; }
 bool isExecutionDeadlineReached(v8::Isolate* isolate) { return false; }
 
 double correctTimeoutToExecutionDeadlineS(double timeoutSeconds) {

--- a/lib/V8/v8-utils.cpp
+++ b/lib/V8/v8-utils.cpp
@@ -4619,8 +4619,9 @@ static void JS_StatusExternal(v8::FunctionCallbackInfo<v8::Value> const& args) {
   if (historicStatus.has_value()) {
     external = *historicStatus;
   } else {
-    external = TRI_CheckExternalProcess(pid, wait, timeoutms,
-                                        isExecutionDeadlineReached);
+    external = TRI_CheckExternalProcess(pid, wait, timeoutms, [&]() {
+      return isExecutionDeadlineReached(isolate);
+    });
   }
 
   v8::Handle<v8::Object> result = v8::Object::New(isolate);
@@ -4830,8 +4831,9 @@ static void JS_ExecuteExternalAndWait(
   ExternalId pid;
   pid._pid = external._pid;
 
-  auto external_status = TRI_CheckExternalProcess(pid, true, timeoutms,
-                                                  isExecutionDeadlineReached);
+  auto external_status = TRI_CheckExternalProcess(pid, true, timeoutms, [&]() {
+    return isExecutionDeadlineReached(isolate);
+  });
 
   convertStatusToV8(args, result, external_status, external);
 

--- a/lib/V8/v8-utils.cpp
+++ b/lib/V8/v8-utils.cpp
@@ -4619,7 +4619,8 @@ static void JS_StatusExternal(v8::FunctionCallbackInfo<v8::Value> const& args) {
   if (historicStatus.has_value()) {
     external = *historicStatus;
   } else {
-    external = TRI_CheckExternalProcess(pid, wait, timeoutms);
+    external = TRI_CheckExternalProcess(pid, wait, timeoutms,
+                                        isExecutionDeadlineReached);
   }
 
   v8::Handle<v8::Object> result = v8::Object::New(isolate);
@@ -4829,7 +4830,8 @@ static void JS_ExecuteExternalAndWait(
   ExternalId pid;
   pid._pid = external._pid;
 
-  auto external_status = TRI_CheckExternalProcess(pid, true, timeoutms);
+  auto external_status = TRI_CheckExternalProcess(pid, true, timeoutms,
+                                                  isExecutionDeadlineReached);
 
   convertStatusToV8(args, result, external_status, external);
 


### PR DESCRIPTION
### Scope & Purpose

We have process monitoring & deadline handling. 
If we spawn & wait for subprocesses this would not work.
Add that for the linux case. 

- [x] :pizza: New feature

