### PR TITLE
some further small AQL refactoring

### DIFF
--- a/arangod/Aql/AqlCall.h
+++ b/arangod/Aql/AqlCall.h
@@ -307,10 +307,10 @@ constexpr bool operator==(AqlCall const& left, AqlCall const& right) {
 }
 
 auto operator<<(std::ostream& out,
-                const arangodb::aql::AqlCall::LimitPrinter& limit)
+                arangodb::aql::AqlCall::LimitPrinter const& limit)
     -> std::ostream&;
 
-auto operator<<(std::ostream& out, const arangodb::aql::AqlCall& call)
+auto operator<<(std::ostream& out, arangodb::aql::AqlCall const& call)
     -> std::ostream&;
 
 }  // namespace arangodb::aql

--- a/arangod/Aql/AqlCallList.cpp
+++ b/arangod/Aql/AqlCallList.cpp
@@ -68,7 +68,8 @@ AqlCallList::AqlCallList(AqlCall const& specificCall,
   return _defaultCall.value();
 }
 
-[[nodiscard]] auto AqlCallList::peekNextCall() const -> AqlCall const& {
+[[nodiscard]] auto AqlCallList::peekNextCall() const noexcept
+    -> AqlCall const& {
   TRI_ASSERT(hasMoreCalls());
   if (!_specificCalls.empty()) {
     // We only implemented for a single given call.

--- a/arangod/Aql/AqlCallList.h
+++ b/arangod/Aql/AqlCallList.h
@@ -95,7 +95,7 @@ class AqlCallList {
    *
    * @return AqlCall The next call
    */
-  [[nodiscard]] auto peekNextCall() const -> AqlCall const&;
+  [[nodiscard]] auto peekNextCall() const noexcept -> AqlCall const&;
 
   /**
    * @brief Test if there are more calls available in the list.

--- a/arangod/Aql/AqlCallStack.cpp
+++ b/arangod/Aql/AqlCallStack.cpp
@@ -68,7 +68,7 @@ auto AqlCallStack::popCall() -> AqlCallList {
   return call;
 }
 
-auto AqlCallStack::peek() const -> AqlCall const& {
+auto AqlCallStack::peek() const noexcept -> AqlCall const& {
   TRI_ASSERT(!_operations.empty());
   return _operations.back().peekNextCall();
 }

--- a/arangod/Aql/AqlCallStack.h
+++ b/arangod/Aql/AqlCallStack.h
@@ -71,7 +71,7 @@ class AqlCallStack {
 
   // Peek at the topmost Call element (this must be relevant).
   // The responsibility for the peek-ed call will stay with the stack
-  AqlCall const& peek() const;
+  AqlCall const& peek() const noexcept;
 
   // Put another call on top of the stack.
   void pushCall(AqlCallList&& call);

--- a/arangod/Aql/AqlItemBlockInputRange.cpp
+++ b/arangod/Aql/AqlItemBlockInputRange.cpp
@@ -24,7 +24,6 @@
 #include "AqlItemBlockInputRange.h"
 #include "Aql/ShadowAqlItemRow.h"
 
-#include <velocypack/Builder.h>
 #include <algorithm>
 #include <numeric>
 
@@ -141,20 +140,28 @@ AqlItemBlockInputRange::nextShadowRow() {
                         ShadowAqlItemRow{CreateInvalidShadowRowHint{}});
 }
 
-size_t AqlItemBlockInputRange::skipAllRemainingDataRows() {
+size_t AqlItemBlockInputRange::skipAllRemainingDataRows() noexcept {
   while (hasDataRow()) {
     ++_rowIndex;
   }
   return 0;
 }
 
-size_t AqlItemBlockInputRange::countAndSkipAllRemainingDataRows() {
+size_t AqlItemBlockInputRange::countAndSkipAllRemainingDataRows() noexcept {
   size_t skipped = 0;
   while (hasDataRow()) {
     ++_rowIndex;
     ++skipped;
   }
   return skipped;
+}
+
+size_t AqlItemBlockInputRange::numRowsLeft() const noexcept {
+  if (_block == nullptr) {
+    return 0;
+  }
+  TRI_ASSERT(_block->numRows() >= _rowIndex);
+  return _block->numRows() - _rowIndex;
 }
 
 template<int depthOffset>

--- a/arangod/Aql/AqlItemBlockInputRange.h
+++ b/arangod/Aql/AqlItemBlockInputRange.h
@@ -41,7 +41,7 @@ class AqlItemBlockInputRange {
                                   std::size_t skipped = 0);
 
   AqlItemBlockInputRange(MainQueryState, std::size_t skipped,
-                         arangodb::aql::SharedAqlItemBlockPtr,
+                         SharedAqlItemBlockPtr,
                          std::size_t startIndex) noexcept;
 
   void reset() noexcept { _block.reset(nullptr); }
@@ -55,15 +55,14 @@ class AqlItemBlockInputRange {
 
   bool hasDataRow() const noexcept;
 
-  std::pair<ExecutorState, arangodb::aql::InputAqlItemRow> peekDataRow() const;
+  std::pair<ExecutorState, InputAqlItemRow> peekDataRow() const;
 
-  std::pair<ExecutorState, arangodb::aql::InputAqlItemRow> nextDataRow();
+  std::pair<ExecutorState, InputAqlItemRow> nextDataRow();
 
   /// @brief optimized version of nextDataRow, only to be used when it is known
   /// that there is a next data row (i.e. if a previous call to hasDataRow()
   /// returned true)
-  std::pair<ExecutorState, arangodb::aql::InputAqlItemRow> nextDataRow(
-      HasDataRow);
+  std::pair<ExecutorState, InputAqlItemRow> nextDataRow(HasDataRow);
 
   /// @brief moves the row index one forward if we are at a row right now
   void advanceDataRow() noexcept;
@@ -72,11 +71,11 @@ class AqlItemBlockInputRange {
 
   bool hasShadowRow() const noexcept;
 
-  arangodb::aql::ShadowAqlItemRow peekShadowRow() const;
+  ShadowAqlItemRow peekShadowRow() const;
 
-  std::pair<ExecutorState, arangodb::aql::ShadowAqlItemRow> nextShadowRow();
+  std::pair<ExecutorState, ShadowAqlItemRow> nextShadowRow();
 
-  size_t skipAllRemainingDataRows();
+  size_t skipAllRemainingDataRows() noexcept;
 
   // depthOffset is added to depth, except it won't underflow.
   template<int depthOffset>
@@ -111,7 +110,9 @@ class AqlItemBlockInputRange {
    * @brief Skip over all remaining data rows until the next shadow row.
    * Count how many rows are skipped
    */
-  [[nodiscard]] auto countAndSkipAllRemainingDataRows() -> std::size_t;
+  [[nodiscard]] auto countAndSkipAllRemainingDataRows() noexcept -> std::size_t;
+
+  [[nodiscard]] auto numRowsLeft() const noexcept -> std::size_t;
 
  private:
   bool isIndexValid(std::size_t index) const noexcept;
@@ -123,7 +124,7 @@ class AqlItemBlockInputRange {
   template<LookAhead doPeek, RowType type>
   ExecutorState nextState() const noexcept;
 
-  arangodb::aql::SharedAqlItemBlockPtr _block{nullptr};
+  SharedAqlItemBlockPtr _block{nullptr};
   std::size_t _rowIndex{};
   MainQueryState _finalState{MainQueryState::HASMORE};
   // How many rows were skipped upstream

--- a/arangod/Aql/AsyncExecutor.cpp
+++ b/arangod/Aql/AsyncExecutor.cpp
@@ -28,7 +28,6 @@
 #include "Aql/ConstFetcher.h"
 #include "Aql/ExecutionEngine.h"
 #include "Aql/ExecutionNode.h"
-#include "Aql/OutputAqlItemRow.h"
 #include "Aql/QueryOptions.h"
 #include "Aql/SingleRowFetcher.h"
 #include "Aql/SharedQueryState.h"

--- a/arangod/Aql/AsyncExecutor.h
+++ b/arangod/Aql/AsyncExecutor.h
@@ -36,8 +36,6 @@ namespace arangodb {
 namespace aql {
 
 class AsyncNode;
-class NoStats;
-class OutputAqlItemRow;
 class SharedQueryState;
 
 // The RemoteBlock is actually implemented by specializing ExecutionBlockImpl,
@@ -49,9 +47,7 @@ class AsyncExecutor final {
     static constexpr BlockPassthrough allowsBlockPassthrough =
         BlockPassthrough::Enable;
   };
-  // using Fetcher = std::monostate;
   using Infos = std::monostate;
-  // using Stats = NoStats;
 };
 
 /**

--- a/arangod/Aql/ConstFetcher.cpp
+++ b/arangod/Aql/ConstFetcher.cpp
@@ -40,7 +40,7 @@ ConstFetcher::ConstFetcher() : _currentBlock{nullptr}, _rowIndex(0) {}
 ConstFetcher::ConstFetcher(DependencyProxy& executionBlock)
     : _currentBlock{nullptr}, _rowIndex(0) {}
 
-auto ConstFetcher::execute(AqlCallStack& stack)
+auto ConstFetcher::execute(AqlCallStack const& stack)
     -> std::tuple<ExecutionState, SkipResult, AqlItemBlockInputRange> {
   // We only peek the call here, as we do not take over ownership.
   // We can replace this by pop again if all executors also only take a

--- a/arangod/Aql/ConstFetcher.h
+++ b/arangod/Aql/ConstFetcher.h
@@ -71,7 +71,7 @@ class ConstFetcher {
    *   size_t => Amount of documents skipped
    *   DataRange => Resulting data
    */
-  auto execute(AqlCallStack& stack)
+  auto execute(AqlCallStack const& stack)
       -> std::tuple<ExecutionState, SkipResult, DataRange>;
 
   void injectBlock(SharedAqlItemBlockPtr block, SkipResult skipped);

--- a/arangod/Aql/DependencyProxy.cpp
+++ b/arangod/Aql/DependencyProxy.cpp
@@ -34,7 +34,7 @@ using namespace arangodb::aql;
 
 template<BlockPassthrough blockPassthrough>
 std::tuple<ExecutionState, SkipResult, SharedAqlItemBlockPtr>
-DependencyProxy<blockPassthrough>::execute(AqlCallStack& stack) {
+DependencyProxy<blockPassthrough>::execute(AqlCallStack const& stack) {
   ExecutionState state = ExecutionState::HASMORE;
   SkipResult skipped;
   SharedAqlItemBlockPtr block = nullptr;
@@ -56,8 +56,8 @@ DependencyProxy<blockPassthrough>::execute(AqlCallStack& stack) {
 
 template<BlockPassthrough blockPassthrough>
 std::tuple<ExecutionState, SkipResult, SharedAqlItemBlockPtr>
-DependencyProxy<blockPassthrough>::executeForDependency(size_t dependency,
-                                                        AqlCallStack& stack) {
+DependencyProxy<blockPassthrough>::executeForDependency(
+    size_t dependency, AqlCallStack const& stack) {
   ExecutionState state = ExecutionState::HASMORE;
   SkipResult skipped;
   SharedAqlItemBlockPtr block = nullptr;

--- a/arangod/Aql/DependencyProxy.h
+++ b/arangod/Aql/DependencyProxy.h
@@ -71,10 +71,10 @@ class DependencyProxy {
 
   // TODO Implement and document properly!
   TEST_VIRTUAL std::tuple<ExecutionState, SkipResult, SharedAqlItemBlockPtr>
-  execute(AqlCallStack& stack);
+  execute(AqlCallStack const& stack);
 
   TEST_VIRTUAL std::tuple<ExecutionState, SkipResult, SharedAqlItemBlockPtr>
-  executeForDependency(size_t dependency, AqlCallStack& stack);
+  executeForDependency(size_t dependency, AqlCallStack const& stack);
 
   [[nodiscard]] RegisterCount getNrInputRegisters() const;
 

--- a/arangod/Aql/ExecutionBlockImpl.tpp
+++ b/arangod/Aql/ExecutionBlockImpl.tpp
@@ -626,6 +626,12 @@ template<class Executor>
 void ExecutionBlockImpl<Executor>::ensureOutputBlock(AqlCall&& call) {
   if (_outputItemRow == nullptr || !_outputItemRow->isInitialized()) {
     _outputItemRow = allocateOutputBlock(std::move(call));
+    TRI_ASSERT(_outputItemRow->numRowsLeft() ==
+               std::min(_outputItemRow->blockNumRows(),
+                        _outputItemRow->getClientCall().getLimit()))
+        << "output numRowsLeft: " << _outputItemRow->numRowsLeft()
+        << ", blockNumRows: " << _outputItemRow->blockNumRows()
+        << ", call: " << _outputItemRow->getClientCall();
   } else {
     _outputItemRow->setCall(std::move(call));
   }

--- a/arangod/Aql/IResearchViewExecutor.tpp
+++ b/arangod/Aql/IResearchViewExecutor.tpp
@@ -24,16 +24,15 @@
 
 #pragma once
 
-#include "Aql/MultiGet.h"
 #include "IResearchViewExecutor.h"
 
 #include "Aql/AqlCall.h"
 #include "Aql/ExecutionStats.h"
+#include "Aql/MultiGet.h"
 #include "Aql/OutputAqlItemRow.h"
 #include "Aql/Query.h"
 #include "Aql/SingleRowFetcher.h"
 #include "ApplicationFeatures/ApplicationServer.h"
-#include "Basics/StringUtils.h"
 #include "IResearch/IResearchCommon.h"
 #include "IResearch/IResearchDocument.h"
 #include "IResearch/IResearchFilterFactory.h"

--- a/arangod/Aql/MultiDependencySingleRowFetcher.h
+++ b/arangod/Aql/MultiDependencySingleRowFetcher.h
@@ -119,7 +119,7 @@ class MultiDependencySingleRowFetcher {
   // May only be called once, after the dependencies are injected.
   void initDependencies();
 
-  size_t numberDependencies();
+  size_t numberDependencies() const noexcept;
 
   [[nodiscard]] auto execute(AqlCallStack const&, AqlCallSet const&)
       -> std::tuple<ExecutionState, SkipResult,
@@ -157,7 +157,7 @@ class MultiDependencySingleRowFetcher {
 
  private:
   [[nodiscard]] auto executeForDependency(size_t dependency,
-                                          AqlCallStack& stack)
+                                          AqlCallStack const& stack)
       -> std::tuple<ExecutionState, SkipResult, AqlItemBlockInputRange>;
 
   /**

--- a/arangod/Aql/OutputAqlItemRow.cpp
+++ b/arangod/Aql/OutputAqlItemRow.cpp
@@ -43,6 +43,8 @@ The following conditions need to hold true, we need to add c++ tests for this.
 
 #include <velocypack/Builder.h>
 
+#include <iostream>
+
 using namespace arangodb;
 using namespace arangodb::aql;
 
@@ -332,11 +334,11 @@ AqlCall const& OutputAqlItemRow::getClientCall() const noexcept {
   return _call;
 }
 
-AqlCall& OutputAqlItemRow::getModifiableClientCall() { return _call; }
-
+#ifdef ARANGODB_USE_GOOGLE_TESTS
 AqlCall&& OutputAqlItemRow::stealClientCall() { return std::move(_call); }
+#endif
 
-void OutputAqlItemRow::setCall(AqlCall call) {
+void OutputAqlItemRow::setCall(AqlCall call) noexcept {
   // We cannot create an output row if we still have unreported skipCount
   // in the call.
   TRI_ASSERT(_call.getSkipCount() == 0);
@@ -627,3 +629,12 @@ template void OutputAqlItemRow::moveValueInto<InputAqlItemRow, VPackSlice>(
 template void OutputAqlItemRow::moveValueInto<ShadowAqlItemRow, VPackSlice>(
     RegisterId registerId, ShadowAqlItemRow const& sourceRow,
     VPackSlice& value);
+
+auto aql::operator<<(std::ostream& out, OutputAqlItemRow const& output)
+    -> std::ostream& {
+  return out << "{ OutputAqlItemRow " << static_cast<void const*>(&output)
+             << ", blockNumRows: " << output.blockNumRows()
+             << ", numRowsLeft: " << output.numRowsLeft()
+             << ", isFull: " << output.isFull()
+             << ", call: " << output.getClientCall() << " }";
+}

--- a/arangod/Aql/OutputAqlItemRow.h
+++ b/arangod/Aql/OutputAqlItemRow.h
@@ -32,6 +32,7 @@
 #include "Aql/types.h"
 #include "Containers/HashSet.h"
 
+#include <iosfwd>
 #include <memory>
 
 namespace arangodb::aql {
@@ -213,11 +214,15 @@ class OutputAqlItemRow {
 
   AqlCall const& getClientCall() const noexcept;
 
-  AqlCall& getModifiableClientCall();
-
+#ifdef ARANGODB_USE_GOOGLE_TESTS
   AqlCall&& stealClientCall();
+#endif
 
-  void setCall(AqlCall call);
+  void setCall(AqlCall call) noexcept;
+
+  size_t blockNumRows() const noexcept {
+    return _block == nullptr ? 0 : _block->numRows();
+  }
 
  private:
   [[nodiscard]] RegIdSet const& outputRegisters() const noexcept {
@@ -350,4 +355,7 @@ class OutputAqlItemRow {
   RegIdFlatSetStack const& _registersToKeep;
   RegIdFlatSet const& _registersToClear;
 };
+
+auto operator<<(std::ostream& out, arangodb::aql::OutputAqlItemRow const&)
+    -> std::ostream&;
 }  // namespace arangodb::aql

--- a/arangod/Aql/RemoveModifier.cpp
+++ b/arangod/Aql/RemoveModifier.cpp
@@ -27,7 +27,6 @@
 #include "Aql/ModificationExecutor.h"
 #include "Aql/ModificationExecutorAccumulator.h"
 #include "Aql/ModificationExecutorHelpers.h"
-#include "Aql/OutputAqlItemRow.h"
 #include "Aql/QueryContext.h"
 #include "Basics/Common.h"
 #include "Basics/StaticStrings.h"

--- a/arangod/Aql/SingleRowFetcher.cpp
+++ b/arangod/Aql/SingleRowFetcher.cpp
@@ -47,7 +47,7 @@ SingleRowFetcher<passBlocksThrough>::SingleRowFetcher()
 
 template<BlockPassthrough passBlocksThrough>
 std::tuple<ExecutionState, SkipResult, AqlItemBlockInputRange>
-SingleRowFetcher<passBlocksThrough>::execute(AqlCallStack& stack) {
+SingleRowFetcher<passBlocksThrough>::execute(AqlCallStack const& stack) {
   auto [state, skipped, block] = _dependencyProxy->execute(stack);
   if (state == ExecutionState::WAITING) {
     // On waiting we have nothing to return

--- a/arangod/Aql/SingleRowFetcher.h
+++ b/arangod/Aql/SingleRowFetcher.h
@@ -74,7 +74,7 @@ class SingleRowFetcher {
    *   DataRange => Resulting data
    */
   std::tuple<ExecutionState, SkipResult, DataRange> execute(
-      AqlCallStack& stack);
+      AqlCallStack const& stack);
 
   void setDistributeId(std::string const& id);
 

--- a/arangod/Aql/UpdateReplaceModifier.cpp
+++ b/arangod/Aql/UpdateReplaceModifier.cpp
@@ -28,15 +28,12 @@
 #include "Aql/ModificationExecutor.h"
 #include "Aql/ModificationExecutorAccumulator.h"
 #include "Aql/ModificationExecutorHelpers.h"
-#include "Aql/OutputAqlItemRow.h"
 #include "Aql/QueryContext.h"
 #include "Basics/Common.h"
 #include "Transaction/Methods.h"
 #include "VocBase/LogicalCollection.h"
 
 #include <velocypack/Collection.h>
-
-#include "Logger/LogMacros.h"
 
 class CollectionNameResolver;
 

--- a/arangod/Aql/UpsertModifier.cpp
+++ b/arangod/Aql/UpsertModifier.cpp
@@ -28,7 +28,6 @@
 #include "Aql/ModificationExecutor.h"
 #include "Aql/ModificationExecutorAccumulator.h"
 #include "Aql/ModificationExecutorHelpers.h"
-#include "Aql/OutputAqlItemRow.h"
 #include "Aql/QueryContext.h"
 #include "Basics/Common.h"
 #include "Basics/StaticStrings.h"

--- a/arangod/Graph/PathManagement/PathValidatorOptions.h
+++ b/arangod/Graph/PathManagement/PathValidatorOptions.h
@@ -113,7 +113,7 @@ class PathValidatorOptions {
   /**
    * @brief Get the Expression a vertex needs to hold if defined on the given
    * depth. It may return a nullptr if all vertices are valid.
-   * Caller does NOT take responsibilty. Do not delete this pointer.
+   * Caller does NOT take responsibility. Do not delete this pointer.
    */
   aql::Expression* getVertexExpression(uint64_t depth) const;
 

--- a/arangod/Pregel/Algos/ShortestPath/ShortestPath.cpp
+++ b/arangod/Pregel/Algos/ShortestPath/ShortestPath.cpp
@@ -22,7 +22,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #include "Pregel/Algos/ShortestPath/ShortestPath.h"
-#include "Aql/ExecutionBlockImpl.tpp"
 #include "Pregel/Aggregator.h"
 #include "Pregel/Algorithm.h"
 #include "Pregel/MasterContext.h"

--- a/tests/Aql/DependencyProxyMock.cpp
+++ b/tests/Aql/DependencyProxyMock.cpp
@@ -124,10 +124,9 @@ DependencyProxyMock<passBlocksThrough>::andThenReturn(
 
 template<BlockPassthrough passBlocksThrough>
 std::tuple<ExecutionState, SkipResult, SharedAqlItemBlockPtr>
-DependencyProxyMock<passBlocksThrough>::execute(AqlCallStack& stack) {
+DependencyProxyMock<passBlocksThrough>::execute(AqlCallStack const& /*stack*/) {
   TRI_ASSERT(_block != nullptr);
-  SkipResult res{};
-  return {arangodb::aql::ExecutionState::DONE, res, _block};
+  return {arangodb::aql::ExecutionState::DONE, SkipResult{}, _block};
 }
 
 template<BlockPassthrough passBlocksThrough>

--- a/tests/Aql/DependencyProxyMock.h
+++ b/tests/Aql/DependencyProxyMock.h
@@ -47,13 +47,12 @@ class DependencyProxyMock
   explicit DependencyProxyMock(arangodb::ResourceMonitor& monitor,
                                ::arangodb::aql::RegisterCount nrRegisters);
 
- public:
   // mock methods
-  inline size_t numberDependencies() const override { return 1; }
+  size_t numberDependencies() const noexcept override { return 1; }
 
   std::tuple<arangodb::aql::ExecutionState, arangodb::aql::SkipResult,
              arangodb::aql::SharedAqlItemBlockPtr>
-  execute(arangodb::aql::AqlCallStack& stack) override;
+  execute(arangodb::aql::AqlCallStack const& stack) override;
 
  private:
   using FetchBlockReturnItem = std::pair<arangodb::aql::ExecutionState,
@@ -94,14 +93,12 @@ class MultiDependencyProxyMock
                            ::arangodb::aql::RegisterCount nrRegisters,
                            size_t nrDeps);
 
- public:
   // mock methods
 
-  inline size_t numberDependencies() const override {
+  size_t numberDependencies() const noexcept override {
     return _dependencyMocks.size();
   }
 
- public:
   // additional test methods
   DependencyProxyMock<passBlocksThrough>& getDependencyMock(size_t dependency) {
     TRI_ASSERT(dependency < _dependencyMocks.size());


### PR DESCRIPTION
### Scope & Purpose

Some further small AQL refactoring:
- make several methods const and/or noexcept
- make `AqlCallStack` parameters const where applicable
- avoid copy of `_dependencySkipReports` in MultiDependencySingleRowFetcher.cpp
- remove unused includes
- added `operator<<` support for `OutputAqlItemBlock`

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 