### PR TITLE
Fix test for arangodb_search_writers_memory_usage

### DIFF
--- a/tests/js/client/shell/api/arangosearch-memory-metrics.inc
+++ b/tests/js/client/shell/api/arangosearch-memory-metrics.inc
@@ -92,6 +92,7 @@
 
       testArangoSearchMetrics: function () {
 
+        db._view(viewName).properties({commitIntervalMsec: 0});
         let writers_prev = getCompleteMetricsValues("arangodb_search_writers_memory_usage");
         let writers_curr = writers_prev;
         for (let i = 0; i < 5; i++) {
@@ -101,6 +102,7 @@
           assertTrue(writers_prev < writers_curr);
           writers_prev = writers_curr;
         }
+        db._view(viewName).properties({commitIntervalMsec: 100});
 
         let readers, consolidations, descriptors, mapped, scheduler_memory, num_worker_threads;
         for (let i = 0; i < 45; ++i) {


### PR DESCRIPTION
### Scope & Purpose

Attempt to fix this error in latest nightly build:
```
=== shell_client_0 ===
* Test "shell_client_0"
    [FAILED]  tests/js/client/shell/shell-improved-metrics-accounting-cluster.js

      "testArangoSearchMetrics_Repl" failed: Error: at assertion #9: assertTrue: (false) does not evaluate to true
(Error
    at Object.testArangoSearchMetrics (tests/js/client/shell/api/arangosearch-memory-metrics.inc:101:11)
    at tests/js/client/shell/shell-improved-metrics-accounting-cluster.js:83:9
    at tests/js/client/shell/shell-improved-metrics-accounting-cluster.js:99:3
...    at Object.shellClient [as shell_client] (/work/ArangoDB/js/client/modules/@arangodb/testsuites/aql.js:226:79)
 - test failed


   Suites failed: 1 Tests Failed: 1
```

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

