### PR TITLE
Add prefetching for WAL tailing

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,11 @@
 devel
 -----
-    
+
+* Make replication WAL tailing schedule prefetch requests via the global
+  scheduler, in the same way as the initial dump phase does. In the best
+  case, this can speed up the getting-in-sync phase when getting shards in
+  snyc.
+
 * FE-365: fix query import breaking due to extra fields.
 
 * Fixed BTS-1239: Restoring a single server dump with system collections

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,7 +4,7 @@ devel
 * Make replication WAL tailing schedule prefetch requests via the global
   scheduler, in the same way as the initial dump phase does. In the best
   case, this can speed up the getting-in-sync phase when getting shards in
-  snyc.
+  sync.
 
 * FE-365: fix query import breaking due to extra fields.
 

--- a/arangod/Replication/DatabaseInitialSyncer.cpp
+++ b/arangod/Replication/DatabaseInitialSyncer.cpp
@@ -557,7 +557,6 @@ DatabaseInitialSyncer::Configuration::Configuration(
     : applier{a},
       batch{bat},
       connection{c},
-      flushed{f},
       leader{l},
       progress{p},
       state{s},
@@ -1010,14 +1009,6 @@ void DatabaseInitialSyncer::fetchDumpChunk(
     // assemble URL to call
     std::string url =
         absl::StrCat(baseUrl, "&from=", fromTick, "&chunkSize=", chunkSize);
-
-    if (_config.flushed) {
-      url += "&flush=false";
-    } else {
-      // only flush WAL once
-      url += "&flush=true";
-      _config.flushed = true;
-    }
 
     bool isVPack = false;
     auto headers = replutils::createHeaders();

--- a/arangod/Replication/DatabaseInitialSyncer.cpp
+++ b/arangod/Replication/DatabaseInitialSyncer.cpp
@@ -990,8 +990,8 @@ Result DatabaseInitialSyncer::parseCollectionDump(
 /// @brief order a new chunk from the /dump API
 void DatabaseInitialSyncer::fetchDumpChunk(
     std::shared_ptr<Syncer::JobSynchronizer> sharedStatus,
-    std::string const& baseUrl, LogicalCollection* coll,
-    std::string const& leaderColl, int batch, TRI_voc_tick_t fromTick,
+    std::string_view baseUrl, LogicalCollection* coll,
+    std::string_view leaderColl, int batch, TRI_voc_tick_t fromTick,
     uint64_t chunkSize) {
   if (isAborted()) {
     sharedStatus->gotResponse(Result(TRI_ERROR_REPLICATION_APPLIER_STOPPED));

--- a/arangod/Replication/DatabaseInitialSyncer.h
+++ b/arangod/Replication/DatabaseInitialSyncer.h
@@ -33,6 +33,8 @@
 
 #include <chrono>
 #include <memory>
+#include <string>
+#include <string_view>
 
 struct TRI_vocbase_t;
 
@@ -183,8 +185,8 @@ class DatabaseInitialSyncer : public InitialSyncer {
 
   /// @brief order a new chunk from the /dump API
   void fetchDumpChunk(std::shared_ptr<Syncer::JobSynchronizer> sharedStatus,
-                      std::string const& baseUrl, LogicalCollection* coll,
-                      std::string const& leaderColl, int batch,
+                      std::string_view baseUrl, LogicalCollection* coll,
+                      std::string_view leaderColl, int batch,
                       TRI_voc_tick_t fromTick, uint64_t chunkSize);
 
   /// @brief fetch the server's inventory

--- a/arangod/Replication/DatabaseInitialSyncer.h
+++ b/arangod/Replication/DatabaseInitialSyncer.h
@@ -76,15 +76,13 @@ class DatabaseInitialSyncer : public InitialSyncer {
     /// @brief replication applier config (from the base Syncer)
     ReplicationApplierConfiguration const& applier;
     /// @brief the dump batch state (from the base InitialSyncer)
-    replutils::BatchInfo& batch;  // TODO worker safety
+    replutils::BatchInfo& batch;
     /// @brief the client connection (from the base Syncer)
     replutils::Connection& connection;
-    /// @brief whether or not we have flushed the WAL on the remote server
-    bool flushed;  // TODO worker safety
     /// @brief info about leader node (from the base Syncer)
     replutils::LeaderInfo& leader;
     /// @brief the progress info (from the base InitialSyncer)
-    replutils::ProgressInfo& progress;  // TODO worker safety
+    replutils::ProgressInfo& progress;
     /// @brief the syncer state (from the base Syncer)
     SyncerState& state;
     /// @brief the database to dump

--- a/arangod/Replication/DatabaseTailingSyncer.cpp
+++ b/arangod/Replication/DatabaseTailingSyncer.cpp
@@ -201,11 +201,10 @@ Result DatabaseTailingSyncer::inheritFromInitialSyncer(
 }
 
 Result DatabaseTailingSyncer::registerOnLeader() {
-  std::string const url = tailingBaseUrl("tail") + "chunkSize=1024" +
-                          "&from=" + StringUtils::itoa(_initialTick) +
-                          "&trackOnly=true" +
-                          "&serverId=" + _state.localServerIdString +
-                          "&syncerId=" + syncerId().toString();
+  std::string const url =
+      absl::StrCat(tailingBaseUrl("tail"), "chunkSize=1024&from=", _initialTick,
+                   "&trackOnly=true&serverId=", _state.localServerIdString,
+                   "&syncerId=", syncerId().toString());
   LOG_TOPIC("41510", DEBUG, Logger::REPLICATION)
       << "registering tailing syncer on leader, url: " << url;
 
@@ -228,9 +227,9 @@ void DatabaseTailingSyncer::unregisterFromLeader(bool hard) {
     try {
       _state.connection.lease([&](httpclient::SimpleHttpClient* client) {
         std::unique_ptr<httpclient::SimpleHttpResult> response;
-        std::string url = tailingBaseUrl("tail") +
-                          "serverId=" + _state.localServerIdString +
-                          "&syncerId=" + syncerId().toString();
+        std::string url = absl::StrCat(tailingBaseUrl("tail"),
+                                       "serverId=", _state.localServerIdString,
+                                       "&syncerId=", syncerId().toString());
         LOG_TOPIC("22640", DEBUG, Logger::REPLICATION)
             << "unregistering tailing syncer from leader, url: " << url;
 
@@ -254,7 +253,7 @@ void DatabaseTailingSyncer::unregisterFromLeader(bool hard) {
 /// @brief order a new chunk from the /tail API
 void DatabaseTailingSyncer::fetchWalChunk(
     std::shared_ptr<Syncer::JobSynchronizer> sharedStatus,
-    std::string const& baseUrl, std::string const& collectionName,
+    std::string_view baseUrl, std::string_view collectionName,
     TRI_voc_tick_t fromTick, TRI_voc_tick_t lastScannedTick) {
   if (vocbase()->server().isStopping()) {
     sharedStatus->gotResponse(Result(TRI_ERROR_SHUTTING_DOWN));

--- a/arangod/Replication/DatabaseTailingSyncer.cpp
+++ b/arangod/Replication/DatabaseTailingSyncer.cpp
@@ -43,6 +43,7 @@
 #include "VocBase/voc-types.h"
 #include "VocBase/vocbase.h"
 
+#include <absl/strings/str_cat.h>
 #include <velocypack/Builder.h>
 #include <velocypack/Iterator.h>
 #include <velocypack/Parser.h>
@@ -116,11 +117,13 @@ Result DatabaseTailingSyncer::syncCollectionCatchup(
       // that we don't block WAL pruning
       unregisterFromLeader(false);
     }
+    _stats.publish();
     return res;
   } catch (std::exception const& ex) {
     // when we leave this method, we must unregister ourselves from the leader,
     // otherwise the leader may keep WAL logs around for us for too long
     unregisterFromLeader(false);
+    _stats.publish();
     return {TRI_ERROR_INTERNAL, ex.what()};
   }
 }
@@ -248,6 +251,51 @@ void DatabaseTailingSyncer::unregisterFromLeader(bool hard) {
   }
 }
 
+/// @brief order a new chunk from the /tail API
+void DatabaseTailingSyncer::fetchWalChunk(
+    std::shared_ptr<Syncer::JobSynchronizer> sharedStatus,
+    std::string const& baseUrl, std::string const& collectionName,
+    TRI_voc_tick_t fromTick, TRI_voc_tick_t lastScannedTick) {
+  if (vocbase()->server().isStopping()) {
+    sharedStatus->gotResponse(Result(TRI_ERROR_SHUTTING_DOWN));
+    return;
+  }
+
+  try {
+    // assemble URL to call
+    std::string url = absl::StrCat(baseUrl, "&from=", fromTick,
+                                   "&lastScanned=", lastScannedTick);
+
+    LOG_TOPIC("066a8", DEBUG, Logger::REPLICATION)
+        << "tailing WAL for collection '" << collectionName
+        << "', url: " << url;
+
+    double t = TRI_microtime();
+
+    // send request
+    std::unique_ptr<httpclient::SimpleHttpResult> response;
+    _state.connection.lease([&](httpclient::SimpleHttpClient* client) {
+      response.reset(
+          client->retryRequest(rest::RequestType::GET, url, nullptr, 0));
+    });
+
+    t = TRI_microtime() - t;
+
+    if (replutils::hasFailed(response.get())) {
+      sharedStatus->gotResponse(
+          replutils::buildHttpError(response.get(), url, _state.connection), t);
+      return;
+    }
+
+    // success!
+    sharedStatus->gotResponse(std::move(response), t);
+  } catch (basics::Exception const& ex) {
+    sharedStatus->gotResponse(Result(ex.code(), ex.what()));
+  } catch (std::exception const& ex) {
+    sharedStatus->gotResponse(Result(TRI_ERROR_INTERNAL, ex.what()));
+  }
+}
+
 /// @brief finalize the synchronization of a collection by tailing the WAL
 /// and filtering on the collection name until no more data is available
 Result DatabaseTailingSyncer::syncCollectionCatchupInternal(
@@ -302,16 +350,46 @@ Result DatabaseTailingSyncer::syncCollectionCatchupInternal(
         << fromTick;
   }
 
+  double t = TRI_microtime();
+
   VPackBuilder builder;  // will be recycled for every batch
 
   auto clock = std::chrono::steady_clock();
   auto startTime = clock.now();
 
-  while (true) {
-    if (vocbase()->server().isStopping()) {
-      return Result(TRI_ERROR_SHUTTING_DOWN);
-    }
+  std::string baseUrl =
+      absl::StrCat(tailingBaseUrl("tail"),
+                   "collection=", StringUtils::urlEncode(collectionName),
+                   "&chunkSize=", _state.applier._chunkSize,
+                   "&serverId=", _state.localServerIdString);
 
+  if (syncerId().value > 0) {
+    // we must only send the syncerId along if it is != 0, otherwise we will
+    // trigger an error on the leader
+    baseUrl += "&syncerId=" + syncerId().toString();
+  }
+  if (hard) {
+    baseUrl += "&withHardLock=true";
+  }
+
+  // optional upper bound for tailing (used to stop tailing if we have the
+  // exclusive lock on the leader and can be sure that no writes can happen on
+  // the leader)
+  if (_toTick > 0) {
+    baseUrl += "&to=" + StringUtils::itoa(_toTick);
+  }
+
+  // the shared status will wait in its destructor until all posted
+  // requests have been completed/canceled!
+  auto self = shared_from_this();
+  auto sharedStatus = std::make_shared<Syncer::JobSynchronizer>(self);
+
+  // order initial chunk. this will block until the initial response
+  // has arrived
+  fetchWalChunk(sharedStatus, baseUrl, collectionName, fromTick,
+                lastScannedTick);
+
+  while (true) {
     if (_checkCancellation) {
       // execute custom check for abortion only every few seconds, in case
       // it is expensive
@@ -332,47 +410,18 @@ Result DatabaseTailingSyncer::syncCollectionCatchupInternal(
       }
     }
 
-    std::string url =
-        tailingBaseUrl("tail") +
-        "collection=" + StringUtils::urlEncode(collectionName) +
-        "&lastScanned=" + StringUtils::itoa(lastScannedTick) +
-        "&chunkSize=" + StringUtils::itoa(_state.applier._chunkSize) +
-        "&from=" + StringUtils::itoa(fromTick) +
-        "&serverId=" + _state.localServerIdString;
-
-    if (syncerId().value > 0) {
-      // we must only send the syncerId along if it is != 0, otherwise we will
-      // trigger an error on the leader
-      url += "&syncerId=" + syncerId().toString();
-    }
-    if (hard) {
-      url += "&withHardLock=true";
-    }
-
-    // optional upper bound for tailing (used to stop tailing if we have the
-    // exclusive lock on the leader and can be sure that no writes can happen on
-    // the leader)
-    if (_toTick > 0) {
-      url += "&to=" + StringUtils::itoa(_toTick);
-    }
-
-    LOG_TOPIC("066a8", DEBUG, Logger::REPLICATION)
-        << "tailing WAL for collection '" << collectionName
-        << "', url: " << url;
-
-    // send request
-    double start = TRI_microtime();
     std::unique_ptr<httpclient::SimpleHttpResult> response;
-    _state.connection.lease([&](httpclient::SimpleHttpClient* client) {
-      ++_stats.numTailingRequests;
-      response.reset(client->request(rest::RequestType::GET, url, nullptr, 0));
-    });
 
-    _stats.waitedForTailing += TRI_microtime() - start;
+    // block until we either got a response or were shut down
+    r = sharedStatus->waitForResponse(response);
 
-    if (replutils::hasFailed(response.get())) {
+    ++_stats.numTailingRequests;
+    _stats.waitedForTailing += sharedStatus->time();
+
+    if (r.fail()) {
       until = fromTick;
-      return replutils::buildHttpError(response.get(), url, _state.connection);
+      // no response or error or shutdown
+      return r;
     }
 
     if (response->getHttpReturnCode() == 204) {
@@ -405,10 +454,10 @@ Result DatabaseTailingSyncer::syncCollectionCatchupInternal(
     if (!found) {
       until = fromTick;
       return Result(TRI_ERROR_REPLICATION_INVALID_RESPONSE,
-                    std::string("got invalid response from leader at ") +
-                        _state.leader.endpoint + ": required header " +
-                        StaticStrings::ReplicationHeaderLastIncluded +
-                        " is missing");
+                    absl::StrCat("got invalid response from leader at ",
+                                 _state.leader.endpoint, ": required header ",
+                                 StaticStrings::ReplicationHeaderLastIncluded,
+                                 " is missing"));
     }
     TRI_voc_tick_t lastIncludedTick = StringUtils::uint64(header);
 
@@ -425,24 +474,16 @@ Result DatabaseTailingSyncer::syncCollectionCatchupInternal(
       ++_stats.numFollowTickNotPresent;
       return Result(
           TRI_ERROR_REPLICATION_START_TICK_NOT_PRESENT,
-          std::string("required follow tick value '") +
-              StringUtils::itoa(lastIncludedTick) +
-              "' is not present (anymore?) on leader at " +
-              _state.leader.endpoint + ". Last tick available on leader is '" +
-              StringUtils::itoa(lastIncludedTick) +
+          absl::StrCat(
+              "required follow tick value '", lastIncludedTick,
+              "' is not present (anymore?) on leader at ",
+              _state.leader.endpoint, ". Last tick available on leader is '",
+              lastIncludedTick,
               "'. It may be required to do a full resync and increase the "
-              "number of historic logfiles on the leader.");
+              "number of historic logfiles on the leader."));
     }
 
-    builder.clear();
-
-    ApplyStats applyStats;
-    uint64_t ignoreCount = 0;
-    r = applyLog(response.get(), fromTick, applyStats, builder, ignoreCount);
-    if (r.fail()) {
-      until = fromTick;
-      return r;
-    }
+    TRI_voc_tick_t oldFromTick = fromTick;
 
     // update the tick from which we will fetch in the next round
     if (lastIncludedTick > fromTick) {
@@ -456,6 +497,26 @@ Result DatabaseTailingSyncer::syncCollectionCatchupInternal(
       LOG_TOPIC("098be", WARN, Logger::REPLICATION)
           << "we got the same tick again, "
           << "this indicates we're at the end";
+    }
+
+    if (checkMore) {
+      // already fetch next batch in the background, by posting the
+      // request to the scheduler, which can run it asynchronously
+      sharedStatus->request([this, self, baseUrl, sharedStatus, collectionName,
+                             fromTick, lastScannedTick]() {
+        fetchWalChunk(sharedStatus, baseUrl, collectionName, fromTick,
+                      lastScannedTick);
+      });
+    }
+
+    builder.clear();
+
+    ApplyStats applyStats;
+    uint64_t ignoreCount = 0;
+    r = applyLog(response.get(), oldFromTick, applyStats, builder, ignoreCount);
+    if (r.fail()) {
+      until = fromTick;
+      return r;
     }
 
     // If this is non-hard, we employ some heuristics to stop early:
@@ -490,7 +551,8 @@ Result DatabaseTailingSyncer::syncCollectionCatchupInternal(
           << ", last fromTick: " << fromTick
           << ", toTick: " << (_toTick > 0 ? std::to_string(_toTick) : "")
           << ", tailing requests: " << _stats.numTailingRequests
-          << ", waited for tailing: " << _stats.waitedForTailing << "s";
+          << ", waited for tailing: " << _stats.waitedForTailing
+          << "s, total catchup time: " << (TRI_microtime() - t) << "s";
 
       return r;
     }
@@ -498,8 +560,6 @@ Result DatabaseTailingSyncer::syncCollectionCatchupInternal(
     LOG_TOPIC("2598f", DEBUG, Logger::REPLICATION)
         << "Fetching more data, fromTick: " << fromTick
         << ", lastScannedTick: " << lastScannedTick;
-
-    _stats.publish();
   }
 }
 

--- a/arangod/Replication/DatabaseTailingSyncer.h
+++ b/arangod/Replication/DatabaseTailingSyncer.h
@@ -107,6 +107,11 @@ class DatabaseTailingSyncer : public TailingSyncer {
   bool skipMarker(velocypack::Slice slice) override;
 
  private:
+  void fetchWalChunk(std::shared_ptr<Syncer::JobSynchronizer> sharedStatus,
+                     std::string const& baseUrl,
+                     std::string const& collectionName, TRI_voc_tick_t fromTick,
+                     TRI_voc_tick_t lastScannedTick);
+
   /// @brief vocbase to use for this run
   TRI_vocbase_t* _vocbase;
 

--- a/arangod/Replication/DatabaseTailingSyncer.h
+++ b/arangod/Replication/DatabaseTailingSyncer.h
@@ -30,6 +30,7 @@
 
 #include <memory>
 #include <string>
+#include <string_view>
 
 struct TRI_vocbase_t;
 
@@ -108,9 +109,8 @@ class DatabaseTailingSyncer : public TailingSyncer {
 
  private:
   void fetchWalChunk(std::shared_ptr<Syncer::JobSynchronizer> sharedStatus,
-                     std::string const& baseUrl,
-                     std::string const& collectionName, TRI_voc_tick_t fromTick,
-                     TRI_voc_tick_t lastScannedTick);
+                     std::string_view baseUrl, std::string_view collectionName,
+                     TRI_voc_tick_t fromTick, TRI_voc_tick_t lastScannedTick);
 
   /// @brief vocbase to use for this run
   TRI_vocbase_t* _vocbase;

--- a/arangod/Replication/Syncer.cpp
+++ b/arangod/Replication/Syncer.cpp
@@ -400,7 +400,7 @@ Result Syncer::JobSynchronizer::waitForResponse(
   }
 }
 
-void Syncer::JobSynchronizer::request(std::function<void()> const& cb) {
+void Syncer::JobSynchronizer::request(fu2::unique_function<void()> cb) {
   TRI_ASSERT(cb);
 
   // by indicating that we have posted an async job, the caller
@@ -415,12 +415,12 @@ void Syncer::JobSynchronizer::request(std::function<void()> const& cb) {
     std::unique_lock guard{_condition.mutex};
     id = ++_nextId;
     _id = id;
-    _cb = cb;
+    _cb = std::move(cb);
   }
 
   SchedulerFeature::SCHEDULER->queue(
       RequestLane::INTERNAL_LOW, [this, self = shared_from_this(), id]() {
-        std::function<void()> cb;
+        fu2::unique_function<void()> cb;
 
         {
           std::unique_lock guard{_condition.mutex};

--- a/arangod/Replication/Syncer.cpp
+++ b/arangod/Replication/Syncer.cpp
@@ -296,15 +296,16 @@ namespace arangodb {
 
 Syncer::JobSynchronizer::JobSynchronizer(
     std::shared_ptr<Syncer const> const& syncer)
-    : _syncer(syncer), _gotResponse(false), _time(0.0), _jobsInFlight(0) {}
+    : _syncer(syncer),
+      _gotResponse(false),
+      _time(0.0),
+      _id(0),
+      _nextId(0),
+      _jobsInFlight(0) {}
 
 Syncer::JobSynchronizer::~JobSynchronizer() {
   // signal that we have got something
-  try {
-    gotResponse(Result(TRI_ERROR_REPLICATION_APPLIER_STOPPED));
-  } catch (...) {
-    // must not throw from here
-  }
+  gotResponse(Result(TRI_ERROR_REPLICATION_APPLIER_STOPPED));
 
   // wait until all posted jobs have been completed/canceled
   while (hasJobInFlight()) {
@@ -350,9 +351,32 @@ void Syncer::JobSynchronizer::gotResponse(arangodb::Result&& res,
 /// there is a response or the syncer/server is shut down
 Result Syncer::JobSynchronizer::waitForResponse(
     std::unique_ptr<arangodb::httpclient::SimpleHttpResult>& response) {
+  // clear result response
+  response.reset();
+
   while (true) {
     {
       std::unique_lock guard{_condition.mutex};
+
+      // check if the scheduler has already executed the callback.
+      // if not, then we will execute the callback ourselves here.
+      if (_cb) {
+        auto cb = std::move(_cb);
+        _id = 0;
+        TRI_ASSERT(!_cb);
+
+        // execute callback without holding the lock
+        guard.unlock();
+
+        {
+          // must be in an extra scope because jobDone() reacquires
+          // the mutex
+          auto markAsDone = scopeGuard([this]() noexcept { jobDone(); });
+          cb();
+        }
+
+        guard.lock();
+      }
 
       if (!_gotResponse) {
         _condition.cv.wait_for(guard, std::chrono::seconds{1});
@@ -367,36 +391,57 @@ Result Syncer::JobSynchronizer::waitForResponse(
     }
 
     if (_syncer->isAborted()) {
-      // clear result response
-      response.reset();
-
       std::lock_guard guard{_condition.mutex};
       _gotResponse = false;
       _response.reset();
       _res.reset();
-
-      // will result in returning TRI_ERROR_REPLICATION_APPLIER_STOPPED
-      break;
+      return Result(TRI_ERROR_REPLICATION_APPLIER_STOPPED);
     }
   }
-
-  return Result(TRI_ERROR_REPLICATION_APPLIER_STOPPED);
 }
 
 void Syncer::JobSynchronizer::request(std::function<void()> const& cb) {
+  TRI_ASSERT(cb);
+
   // by indicating that we have posted an async job, the caller
   // will block on exit until all posted jobs have finished
   if (!jobPosted()) {
     THROW_ARANGO_EXCEPTION(TRI_ERROR_REPLICATION_APPLIER_STOPPED);
   }
 
+  uint64_t id = 0;
+  {
+    // store callback
+    std::unique_lock guard{_condition.mutex};
+    id = ++_nextId;
+    _id = id;
+    _cb = cb;
+  }
+
   SchedulerFeature::SCHEDULER->queue(
-      RequestLane::INTERNAL_LOW, [self = shared_from_this(), cb]() {
+      RequestLane::INTERNAL_LOW, [this, self = shared_from_this(), id]() {
+        std::function<void()> cb;
+
+        {
+          std::unique_lock guard{_condition.mutex};
+          // check if we are still looking at the same job that was posted,
+          // or if someone already posted a different job.
+          if (_id != id) {
+            return;
+          }
+          TRI_ASSERT(_id != 0);
+          // claim callback
+          _id = 0;
+          cb = std::move(_cb);
+          TRI_ASSERT(!_cb);
+        }
+        // execute callback without holding the lock
+
         // whatever happens next, when we leave this here, we need to indicate
         // that there is no more posted job.
         // otherwise the calling thread may block forever waiting on the
         // posted jobs to finish
-        auto guard = scopeGuard([self]() noexcept { self->jobDone(); });
+        auto markAsDone = scopeGuard([self]() noexcept { self->jobDone(); });
 
         cb();
       });

--- a/arangod/Replication/Syncer.h
+++ b/arangod/Replication/Syncer.h
@@ -121,6 +121,22 @@ class Syncer : public std::enable_shared_from_this<Syncer> {
     /// response was received or if something went wrong)
     arangodb::Result _res;
 
+    /// @brief the callback to execute
+    std::function<void()> _cb;
+
+    /// @brief id of the current callback to execute. this is necessary
+    /// because if we post a job to the scheduler and then execute it
+    /// ourselves before the scheduler has a chance to do so, we need a
+    /// way to abort the scheduler callback, so it does not execute the
+    /// old job once more. we do so by posting the job's original id
+    /// along with the job to the scheduler, and check in the scheduler
+    /// callback if the stored id is still the same as the posted one.
+    uint64_t _id;
+
+    /// @brief id of the last job posted (will be increased whenever a new
+    /// job is posted)
+    uint64_t _nextId;
+
     /// @brief the response received by the job (nullptr if no response
     /// received)
     std::unique_ptr<arangodb::httpclient::SimpleHttpResult> _response;

--- a/arangod/Replication/Syncer.h
+++ b/arangod/Replication/Syncer.h
@@ -33,6 +33,8 @@
 #include "VocBase/Identifiers/ServerId.h"
 #include "VocBase/ticks.h"
 
+#include <function2.hpp>
+
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -87,7 +89,7 @@ class Syncer : public std::enable_shared_from_this<Syncer> {
     /// @brief post an async request to the scheduler
     /// this will increase the number of inflight jobs, and count it down
     /// when the posted request has finished
-    void request(std::function<void()> const& cb);
+    void request(fu2::unique_function<void()> cb);
 
     /// @brief notifies that a job was posted
     /// returns false if job counter could not be increased (e.g. because
@@ -122,7 +124,7 @@ class Syncer : public std::enable_shared_from_this<Syncer> {
     arangodb::Result _res;
 
     /// @brief the callback to execute
-    std::function<void()> _cb;
+    fu2::unique_function<void()> _cb;
 
     /// @brief id of the current callback to execute. this is necessary
     /// because if we post a job to the scheduler and then execute it


### PR DESCRIPTION
### Scope & Purpose

Make replication WAL tailing schedule prefetch requests via the global scheduler, in the same way as the initial dump phase does. In the best case, this can speed up the getting-in-sync phase when getting shards in sync.

Prefetching is automatically enabled and will be used during shard synchronization, in single-to-single replication and active failover.

The PR also improves the existing `JobSynchronizer` in Syncer.h/cpp to not wait for the job to be executed by the scheduler if the main thread is actually quicker. This can further improve replication performance on servers that have longer scheduler queues. Now the prefetching will be executed by either the scheduler or by the main thread, whichever is first.

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [x] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 