### PR TITLE
Fixed issue with `keepNull=false` updates

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 v3.10.11 (XXXX-XX-XX)
 ---------------------
 
+* Fixed issue with `keepNull=false` updates not being properly replicated
+  to followers.
+
 * Updated JavaScript dependencies:
 
   qs: 6.11.0 -> 6.11.2

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,8 +1,8 @@
 v3.10.11 (XXXX-XX-XX)
 ---------------------
 
-* Fixed issue with `keepNull=false` updates not being properly replicated
-  to followers.
+* Fixed issue with `keepNull=false` updates not being properly replicated to
+  followers.
 
 * Updated JavaScript dependencies:
 

--- a/tests/js/client/chaos/test-chaos-load-common.inc
+++ b/tests/js/client/chaos/test-chaos-load-common.inc
@@ -345,6 +345,27 @@ function BaseChaosSuite(testOpts) {
     testWorkInParallel: function () {
       let code = (testOpts) => {
         const pid = require("internal").getPid();
+        
+        const generateAttributes = (n) => {
+          let attrs = "";
+          // start letter
+          let s = 65 + Math.floor(Math.random() * 20);
+          for (let i = 0; i < n; ++i) {
+            if (attrs !== "") {
+              attrs += ", ";
+            }
+            attrs += String.fromCharCode(s + i) + ": ";
+            if (Math.random() > 0.66) {
+              attrs += Math.random().toFixed(8);
+            } else if (Math.random() >= 0.33) {
+              attrs += '"' + require('internal').genRandomAlphaNumbers(Math.floor(Math.random() * 100) + 1) + '"';
+            } else {
+              attrs += "null";
+            }
+          }
+          // returns "a: null, b: 24.534, c: "abhtr"
+          return attrs;
+        };
         // The idea here is to use the birthday paradox and have a certain amount of collisions.
         // The babies API is supposed to go through and report individual collisions. Same with
         // removes,so we intentionally try to remove lots of documents which are not actually there.
@@ -364,7 +385,7 @@ function BaseChaosSuite(testOpts) {
         };
 
         let c = db._collection(testOpts.collection);
-        const opts = (length) => {
+        const opts = (length, keepNull = false) => {
           let result = {};
           if (testOpts.withIntermediateCommits) {
             if (Math.random() <= 0.5) {
@@ -384,6 +405,10 @@ function BaseChaosSuite(testOpts) {
             } else if (r >= 0.25) {
               result.overwriteMode = "ignore";
             } 
+          }
+
+          if (keepNull && Math.random() >= 0.5) {
+            result.keepNull = true;
           }
           return result;
         };
@@ -426,11 +451,18 @@ function BaseChaosSuite(testOpts) {
               let o = opts(limit);
               log(`RUNNING AQL REMOVE WITH LIMIT=${limit}. OPTIONS: ${JSON.stringify(o)}`);
               query("FOR doc IN " + c.name() + " LIMIT @limit REMOVE doc IN " + c.name(), {limit}, o);
-            } else if (d >= 0.7) {
+            } else if (d >= 0.75) {
               const limit = Math.floor(Math.random() * 2000);
               let o = opts(limit);
               log(`RUNNING AQL REPLACE WITH LIMIT=${limit}. OPTIONS: ${JSON.stringify(o)}`);
-              query("FOR doc IN " + c.name() + " LIMIT @limit REPLACE doc WITH { pfihg: 434, fjgjg: 555 } IN " + c.name(), {limit}, o);
+              // generate random attribute values for random attribures
+              query("FOR doc IN " + c.name() + " LIMIT @limit REPLACE doc WITH { pfihg: 434, fjgjg: RAND(), " + generateAttributes(3) + " } IN " + c.name(), {limit}, o);
+            } else if (d >= 0.70) {
+              const limit = Math.floor(Math.random() * 2000);
+              let o = opts(limit, /*keepNull*/ true);
+              log(`RUNNING AQL UPDATE WITH LIMIT=${limit}. OPTIONS: ${JSON.stringify(o)}`);
+              // generate random attribute values for random attribures
+              query("FOR doc IN " + c.name() + " LIMIT @limit UPDATE doc WITH { pfihg: RAND(), " + generateAttributes(3) + " } IN " + c.name(), {limit}, o);
             } else if (d >= 0.68) {
               const limit = Math.floor(Math.random() * 10) + 1;
               log(`RUNNING DOCUMENT SINGLE LOOKUP QUERY WITH LIMIT=${limit}`);

--- a/tests/js/client/shell/shell-document-keepnull-cluster.js
+++ b/tests/js/client/shell/shell-document-keepnull-cluster.js
@@ -1,0 +1,111 @@
+/*jshint globalstrict:false, strict:false, maxlen: 5000 */
+/* global assertTrue, assertFalse, assertEqual */
+
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2010-2012 triagens GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is triAGENS GmbH, Cologne, Germany
+///
+/// @author Jan Steemann
+/// @author Copyright 2012, triAGENS GmbH, Cologne, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+'use strict';
+
+const jsunity = require("jsunity");
+const request = require("@arangodb/request");
+const db = require("@arangodb").db;
+const {
+  getCoordinators,
+  getDBServers,
+  waitForShardsInSync,
+} = require('@arangodb/test-helper');
+
+const cn = "UnitTestsCollection";
+
+function UpdateKeepNullSuite() {
+  return {
+    setUp : function () {
+      db._create(cn, { replicationFactor: 3 });
+    },
+
+    tearDown : function () {
+      db._drop(cn);
+    },
+    
+    testInsertOverwriteWithKeepNull : function () {
+      db._query("INSERT { _key: 'test', a: 1, b: 2, c: 3 } INTO @@cn", { "@cn" : cn }); 
+      db._query("INSERT { _key: 'test', a: null } IN @@cn OPTIONS { keepNull: false, overwriteMode: 'update' }", { "@cn" : cn }); 
+      db._query("INSERT { _key: 'test', b: 3, d: 5 } IN @@cn OPTIONS { keepNull: false, overwriteMode: 'update' }", { "@cn" : cn }); 
+      db._query("INSERT { _key: 'test', c: 4, d: null } IN @@cn OPTIONS { keepNull: false, overwriteMode: 'update' }", { "@cn" : cn }); 
+
+      let doc = db[cn].document("test");
+      let shards = db[cn].shards(true); 
+      let shard = Object.keys(shards)[0]; 
+      let servers = Object.values(shards)[0];
+
+      getDBServers().forEach((server) => {
+        if (!servers.includes(server.id)) {
+          return;
+        }
+        let result = request({ method: "POST", url: server.url + "/_api/cursor", body: { query: "FOR doc IN @@cn RETURN doc", bindVars: { "@cn" : shard } }, json: true });
+        assertEqual(201, result.status);
+        
+        result = result.json.result[0];
+        assertFalse(result.hasOwnProperty("a"));
+        assertEqual(3, result.b);
+        assertEqual(4, result.c);
+        assertFalse(result.hasOwnProperty("d"));
+      });
+          
+      waitForShardsInSync(cn, 60, 1); 
+    },
+
+    testUpdateWithKeepNull : function () {
+      db._query("INSERT { _key: 'test', a: 1, b: 2, c: 3 } INTO @@cn", { "@cn" : cn }); 
+      db._query("UPDATE { _key: 'test' } WITH { a: null } IN @@cn OPTIONS { keepNull: false }", { "@cn" : cn }); 
+      db._query("UPDATE { _key: 'test' } WITH { b: 3, d: 5 } IN @@cn OPTIONS { keepNull: false }", { "@cn" : cn }); 
+      db._query("UPDATE { _key: 'test' } WITH { c: 4, d: null } IN @@cn OPTIONS { keepNull: false }", { "@cn" : cn }); 
+
+      let doc = db[cn].document("test");
+      let shards = db[cn].shards(true); 
+      let shard = Object.keys(shards)[0]; 
+      let servers = Object.values(shards)[0];
+
+      getDBServers().forEach((server) => {
+        if (!servers.includes(server.id)) {
+          return;
+        }
+        let result = request({ method: "POST", url: server.url + "/_api/cursor", body: { query: "FOR doc IN @@cn RETURN doc", bindVars: { "@cn" : shard } }, json: true });
+        assertEqual(201, result.status);
+        
+        result = result.json.result[0];
+        assertFalse(result.hasOwnProperty("a"));
+        assertEqual(3, result.b);
+        assertEqual(4, result.c);
+        assertFalse(result.hasOwnProperty("d"));
+      });
+          
+      waitForShardsInSync(cn, 60, 1); 
+    },
+  };
+}
+
+jsunity.run(UpdateKeepNullSuite);
+
+return jsunity.done();
+


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/19807
Fixed issue with `keepNull=false` updates not being properly replicated to followers.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.11: https://github.com/arangodb/arangodb/pull/19808
  - [x] Backport for 3.10: this PR

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 