### PR TITLE
do not copy underlying container for `enumerate(c)`

### DIFF
--- a/lib/Containers/Enumerate.h
+++ b/lib/Containers/Enumerate.h
@@ -90,7 +90,7 @@ auto enumerate_iterator<T, C>::operator*() const -> reference {
 template<typename T, typename C>
 struct enumerate_wrapper {
   using I = typename std::decay_t<T>::iterator;
-  T _t;
+  T const& _t;
   C _c;
 
   auto begin() { return enumerate_iterator(_t.begin(), _c); }


### PR DESCRIPTION
### Scope & Purpose

It seems that the `enumerate()` helper copies its underlying container when doing `for (auto [i, value] = enumerate(container)`. Turn the copy into a const reference.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 