### PR TITLE
Remove special handling for backups taken with ArangoDB 3.5

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 devel
 -----
 
+* Remove special handling for backups taken with ArangoDB 3.5 in hot backup
+  restore.
+
 * Extend the internal state of ReadWriteLocks from 32-bit to 64-bit to prevent
   potential overflows. Previously creating more than 64k streaming transactions
   at the same time could produce an overflow that would effectively result in


### PR DESCRIPTION
### Scope & Purpose

Enterprise companion PR: https://github.com/arangodb/enterprise/pull/1382

Remove special handling for backups taken with ArangoDB 3.5 in hot backup restore.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [x] GitHub issue / Jira ticket: https://github.com/arangodb/enterprise/pull/1382
- [ ] Design document: 