### PR TITLE
fix taking hot backups with allowInconsistent=false

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,14 @@
 v3.11.4 (XXXX-XX-XX)
 --------------------
 
+* Fix MDS-1157: taking hot backups with --allow-inconsistent=false option
+  always reported a warning that the backup was potentially inconsistent,
+  although taking the backup actually succeeded.
+
+  The warning message was `Failed to get write lock before proceeding with
+  backup. Backup may contain some inconsistencies.`, but it was a false
+  positive and the backups taken were actually consistent.
+
 * Fixed issue with `keepNull=false` updates not being properly replicated to
   followers.
 


### PR DESCRIPTION
### Scope & Purpose

Fixes https://arangodb.atlassian.net/browse/MDS-1157
Enterprise companion PR: https://github.com/arangodb/enterprise/pull/1384

v3.11.3 always reported "potentiallyInconsistent": true for all backups
taken, regardless of whether they were actually consistent.
this is a regression compared to v3.11.2.
now all backups taken report as "potentiallyInconsistent": false,
because of the changed way that hot backups are taken since v3.11.3
(there are no inconsistent backups anymore).

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [x] GitHub issue / Jira ticket: https://github.com/arangodb/enterprise/pull/1384
- [ ] Design document: 