### PR TITLE
make {Plain,Transactional}Cache::freeMemoryWhile() cheaper

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,11 @@
+v3.10.9.1 (XXXX-XX-XX)
+----------------------
+
+* Improve performance of the in-memory cache's memory reclamation procedure.
+  The previous implementation acquired too many locks, which could drive
+  system CPU time up.
+
+
 v3.10.9 (2023-06-30)
 --------------------
 

--- a/arangod/Cache/PlainCache.cpp
+++ b/arangod/Cache/PlainCache.cpp
@@ -245,8 +245,15 @@ bool PlainCache<Hasher>::freeMemoryWhile(
   for (std::size_t i = 0; i < n; ++i) {
     std::uint64_t index = (offset + i) % n;
 
-    auto [status, guard] = getBucket(Table::BucketId{index}, Cache::triesFast,
-                                     /*singleOperation*/ false);
+    // we can do a lot of iterations from here. don't check for
+    // shutdown in every iteration, but only in every 1000th.
+    if (index % 1024 == 0 && ADB_UNLIKELY(isShutdown())) {
+      break;
+    }
+
+    auto [status, guard] =
+        getBucket(table.get(), Table::BucketId{index}, Cache::triesFast,
+                  /*singleOperation*/ false);
 
     if (status != TRI_ERROR_NO_ERROR) {
       continue;
@@ -349,14 +356,26 @@ std::pair<::ErrorCode, Table::BucketLocker> PlainCache<Hasher>::getBucket(
   if (ADB_UNLIKELY(isShutdown() || table == nullptr)) {
     status = TRI_ERROR_SHUTTING_DOWN;
   } else {
-    if (singleOperation) {
-      _manager->reportAccess(_id);
-    }
+    std::tie(status, guard) =
+        getBucket(table.get(), bucket, maxTries, singleOperation);
+  }
 
-    guard = table->fetchAndLockBucket(bucket, maxTries);
-    if (!guard.isLocked()) {
-      status = TRI_ERROR_LOCK_TIMEOUT;
-    }
+  return std::make_pair(status, std::move(guard));
+}
+
+template<typename Hasher>
+std::pair<::ErrorCode, Table::BucketLocker> PlainCache<Hasher>::getBucket(
+    Table* table, Table::HashOrId bucket, std::uint64_t maxTries,
+    bool singleOperation) {
+  ::ErrorCode status = TRI_ERROR_NO_ERROR;
+
+  if (singleOperation) {
+    _manager->reportAccess(_id);
+  }
+
+  Table::BucketLocker guard = table->fetchAndLockBucket(bucket, maxTries);
+  if (!guard.isLocked()) {
+    status = TRI_ERROR_LOCK_TIMEOUT;
   }
 
   return std::make_pair(status, std::move(guard));

--- a/arangod/Cache/PlainCache.h
+++ b/arangod/Cache/PlainCache.h
@@ -125,6 +125,11 @@ class PlainCache final : public Cache {
       Table::HashOrId bucket, std::uint64_t maxTries,
       bool singleOperation = true);
 
+  std::pair<::ErrorCode, Table::BucketLocker> getBucket(Table* table,
+                                                        Table::HashOrId bucket,
+                                                        std::uint64_t maxTries,
+                                                        bool singleOperation);
+
   static Table::BucketClearer bucketClearer(Metadata* metadata);
 };
 

--- a/arangod/Cache/TransactionalCache.cpp
+++ b/arangod/Cache/TransactionalCache.cpp
@@ -289,8 +289,15 @@ bool TransactionalCache<Hasher>::freeMemoryWhile(
   for (std::size_t i = 0; i < n; ++i) {
     std::uint64_t index = (offset + i) % n;
 
-    auto [status, guard] = getBucket(Table::BucketId{index}, Cache::triesFast,
-                                     /*singleOperation*/ false);
+    // we can do a lot of iterations from here. don't check for
+    // shutdown in every iteration, but only in every 1000th.
+    if (index % 1024 == 0 && ADB_UNLIKELY(isShutdown())) {
+      break;
+    }
+
+    auto [status, guard] =
+        getBucket(table.get(), Table::BucketId{index}, Cache::triesFast,
+                  /*singleOperation*/ false);
 
     if (status != TRI_ERROR_NO_ERROR) {
       continue;
@@ -445,17 +452,30 @@ TransactionalCache<Hasher>::getBucket(Table::HashOrId bucket,
   if (ADB_UNLIKELY(isShutdown() || table == nullptr)) {
     status = TRI_ERROR_SHUTTING_DOWN;
   } else {
-    if (singleOperation) {
-      _manager->reportAccess(_id);
-    }
+    std::tie(status, guard) =
+        getBucket(table.get(), bucket, maxTries, singleOperation);
+  }
 
-    std::uint64_t term = _manager->_transactions.term();
-    guard = table->fetchAndLockBucket(bucket, maxTries);
-    if (guard.isLocked()) {
-      guard.bucket<TransactionalBucket>().updateBanishTerm(term);
-    } else {
-      status = TRI_ERROR_LOCK_TIMEOUT;
-    }
+  return std::make_tuple(status, std::move(guard));
+}
+
+template<typename Hasher>
+std::tuple<::ErrorCode, Table::BucketLocker>
+TransactionalCache<Hasher>::getBucket(Table* table, Table::HashOrId bucket,
+                                      std::uint64_t maxTries,
+                                      bool singleOperation) {
+  ::ErrorCode status = TRI_ERROR_NO_ERROR;
+
+  if (singleOperation) {
+    _manager->reportAccess(_id);
+  }
+
+  std::uint64_t term = _manager->_transactions.term();
+  Table::BucketLocker guard = table->fetchAndLockBucket(bucket, maxTries);
+  if (guard.isLocked()) {
+    guard.bucket<TransactionalBucket>().updateBanishTerm(term);
+  } else {
+    status = TRI_ERROR_LOCK_TIMEOUT;
   }
 
   return std::make_tuple(status, std::move(guard));

--- a/arangod/Cache/TransactionalCache.h
+++ b/arangod/Cache/TransactionalCache.h
@@ -140,6 +140,11 @@ class TransactionalCache final : public Cache {
       Table::HashOrId bucket, std::uint64_t maxTries,
       bool singleOperation = true);
 
+  std::tuple<::ErrorCode, Table::BucketLocker> getBucket(Table* table,
+                                                         Table::HashOrId bucket,
+                                                         std::uint64_t maxTries,
+                                                         bool singleOperation);
+
   static Table::BucketClearer bucketClearer(Metadata* metadata);
 };
 


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/19831

The previous implementation of the function called `getBucket()` for each slot it looked at. 
`getBucket()` then acquired a shared pointer on the underlying table, which is not lock-free on x86_64. Instead, the calls to `Cache::table()` are guarded via a pthread_mutex_lock and _unlock, which has prohibitive costs when called too often.
The code is now changed so that there is a `getBucket()` overload which gets the Table pointer from the outside, avoiding repeated calls to acquire the Table pointer from `freeMemoryWhile()`.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.11: https://github.com/arangodb/arangodb/pull/19832
  - [x] Backport for 3.10: https://github.com/arangodb/arangodb/pull/19833

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 