### PR TITLE
improve PlainCache::freeMemoryWhile() performance

### DIFF
--- a/arangod/Cache/PlainCache.cpp
+++ b/arangod/Cache/PlainCache.cpp
@@ -253,8 +253,9 @@ bool PlainCache<Hasher>::freeMemoryWhile(
       break;
     }
 
-    auto [status, guard] = getBucket(Table::BucketId{index}, Cache::triesFast,
-                                     /*singleOperation*/ false);
+    auto [status, guard] =
+        getBucket(table.get(), Table::BucketId{index}, Cache::triesFast,
+                  /*singleOperation*/ false);
 
     if (status != TRI_ERROR_NO_ERROR) {
       continue;


### PR DESCRIPTION
### Scope & Purpose

Improve PlainCache::freeMemoryWhile() performance as in other branches.
The last merged PR did not fully implement the improvement.
Note: PlainCache is not used in devel, so effectively this won't make any difference.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 