### PR TITLE
add more cache metrics

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,17 @@
 devel
 -----
 
+* Added the following metrics to improve observability of in-memory cache
+  subsystem:
+  - `rocksdb_cache_free_memory_tasks_total`: total number of `freeMemory`
+    tasks scheduled
+  - `rocksdb_cache_migrate_tasks_total`: total number of `migrate` tasks
+    scheduled
+  - `rocksdb_cache_free_memory_tasks_duration_total`: total time (microseconds)
+    spent in `freeMemory` tasks
+  - `rocksdb_cache_migrate_tasks_duration_total`: total time (microseconds)
+    spent in `migrate` tasks
+
 * Improve performance of AQL LimitExecutor for higher limit values.
   The LimitExecutor now fast-forwards all input rows instead of working on the
   individual input rows.

--- a/Documentation/Metrics/rocksdb_cache_free_memory_tasks_duration_total.yaml
+++ b/Documentation/Metrics/rocksdb_cache_free_memory_tasks_duration_total.yaml
@@ -1,0 +1,17 @@
+name: rocksdb_cache_free_memory_tasks_duration_total
+introducedIn: "3.10.11"
+help: |
+  Total amount of time spent in 'free memory' tasks of the in-memory 
+  cache subsystem.
+unit: us
+type: counter
+category: Statistics
+complexity: advanced
+exposedBy:
+  - dbserver
+  - agent
+  - single
+description: |
+  Total amount of time spent inside 'free memory' tasks of the in-memory
+  cache subsystem. 'free memory' tasks are scheduled by the cache subsystem
+  to free up memory in existing cache hash tables.

--- a/Documentation/Metrics/rocksdb_cache_free_memory_tasks_total.yaml
+++ b/Documentation/Metrics/rocksdb_cache_free_memory_tasks_total.yaml
@@ -1,0 +1,20 @@
+name: rocksdb_cache_free_memory_tasks_total
+introducedIn: "3.10.11"
+help: |
+  Total number of 'free memory' tasks scheduled by the in-memory
+  cache subsystem.
+unit: number
+type: counter
+category: Statistics
+complexity: advanced
+exposedBy:
+  - dbserver
+  - agent
+  - single
+description: |
+  Total number of 'free memory' tasks that were scheduled by the
+  in-memory edge cache subsystem. This metric will be increased
+  whenever the cache subsystem schedules a task to free up memory
+  in one of the managed in-memory caches. It is expected to see
+  this metric rising when the cache subsystem hits its global
+  memory budget.

--- a/Documentation/Metrics/rocksdb_cache_migrate_tasks_duration_total.yaml
+++ b/Documentation/Metrics/rocksdb_cache_migrate_tasks_duration_total.yaml
@@ -1,0 +1,17 @@
+name: rocksdb_cache_migrate_tasks_duration_total
+introducedIn: "3.10.11"
+help: |
+  Total amount of time spent in 'migrate' tasks of the in-memory 
+  cache subsystem.
+unit: us
+type: counter
+category: Statistics
+complexity: advanced
+exposedBy:
+  - dbserver
+  - agent
+  - single
+description: |
+  Total amount of time spent inside 'migrate' tasks of the in-memory
+  cache subsystem. 'migrate' tasks are scheduled by the cache subsystem
+  to migrate existing cache hash tables to a bigger or smaller table.

--- a/Documentation/Metrics/rocksdb_cache_migrate_tasks_total.yaml
+++ b/Documentation/Metrics/rocksdb_cache_migrate_tasks_total.yaml
@@ -1,0 +1,18 @@
+name: rocksdb_cache_migrate_tasks_total
+introducedIn: "3.10.11"
+help: |
+  Total number of 'migrate' tasks scheduled by the in-memory
+  cache subsystem.
+unit: number
+type: counter
+category: Statistics
+complexity: advanced
+exposedBy:
+  - dbserver
+  - agent
+  - single
+description: |
+  Total number of 'migrate' tasks that were scheduled by the
+  in-memory edge cache subsystem. This metric will be increased
+  whenever the cache subsystem schedules a task to migrate an
+  existing cache hash table to a bigger or smaller size.

--- a/arangod/Cache/Manager.cpp
+++ b/arangod/Cache/Manager.cpp
@@ -97,6 +97,8 @@ Manager::Manager(SharedPRNGFeature& sharedPRNG, PostFn schedulerPost,
       _spareTables(0),
       _migrateTasks(0),
       _freeMemoryTasks(0),
+      _migrateTasksDuration(0),
+      _freeMemoryTasksDuration(0),
       _schedulerPost(std::move(schedulerPost)),
       _outstandingTasks(0),
       _rebalancingTasks(0),
@@ -334,6 +336,8 @@ std::optional<Manager::MemoryStats> Manager::memoryStats(
     result.spareTables = _spareTables;
     result.migrateTasks = _migrateTasks;
     result.freeMemoryTasks = _freeMemoryTasks;
+    result.migrateTasksDuration = _migrateTasksDuration;
+    result.freeMemoryTasksDuration = _freeMemoryTasksDuration;
     return result;
   }
 
@@ -743,6 +747,18 @@ void Manager::shrinkOvergrownCaches(Manager::TaskEnvironment environment,
 
     ++i;
   }
+}
+
+// track duration of migrate task, in micros
+void Manager::trackMigrateTaskDuration(std::uint64_t duration) noexcept {
+  SpinLocker guard(SpinLocker::Mode::Write, _lock);
+  _migrateTasksDuration += duration;
+}
+
+// track duration of free memory task, in micros
+void Manager::trackFreeMemoryTaskDuration(std::uint64_t duration) noexcept {
+  SpinLocker guard(SpinLocker::Mode::Write, _lock);
+  _freeMemoryTasksDuration += duration;
 }
 
 #ifdef ARANGODB_ENABLE_FAILURE_TESTS

--- a/arangod/Cache/Manager.h
+++ b/arangod/Cache/Manager.h
@@ -89,6 +89,8 @@ class Manager {
     std::uint64_t spareTables = 0;
     std::uint64_t migrateTasks = 0;
     std::uint64_t freeMemoryTasks = 0;
+    std::uint64_t migrateTasksDuration = 0;     // total, micros
+    std::uint64_t freeMemoryTasksDuration = 0;  // total, micros
   };
 
   static constexpr std::size_t kFindStatsCapacity = 8192;
@@ -208,6 +210,11 @@ class Manager {
   void freeUnusedTablesForTesting();
 #endif
 
+  // track duration of migrate task, in ms
+  void trackMigrateTaskDuration(std::uint64_t duration) noexcept;
+  // track duration of free memory task, in ms
+  void trackFreeMemoryTaskDuration(std::uint64_t duration) noexcept;
+
  private:
   // assume at most 16 slots in each stack -- TODO: check validity
   static constexpr std::uint64_t kTableListsOverhead =
@@ -256,6 +263,8 @@ class Manager {
   std::uint64_t _spareTables;
   std::uint64_t _migrateTasks;
   std::uint64_t _freeMemoryTasks;
+  std::uint64_t _migrateTasksDuration;     // total, micros
+  std::uint64_t _freeMemoryTasksDuration;  // total, micros
 
   // transaction management
   TransactionManager _transactions;


### PR DESCRIPTION
### Scope & Purpose

* Added the following metrics to improve observability of in-memory cache subsystem:
  - `rocksdb_cache_free_memory_tasks_total`: total number of `freeMemory` tasks scheduled
  - `rocksdb_cache_migrate_tasks_total`: total number of `migrate` tasks scheduled
  - `rocksdb_cache_free_memory_tasks_duration_total`: total time (microseconds) spent in `freeMemory` tasks
  - `rocksdb_cache_migrate_tasks_duration_total`: total time (microseconds) spent in `migrate` tasks

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 