### PR TITLE
further improve performance of `freeMemoryWhile`

### DIFF
--- a/arangod/Cache/Cache.cpp
+++ b/arangod/Cache/Cache.cpp
@@ -506,16 +506,10 @@ bool Cache::freeMemory() {
   bool underLimit = reclaimMemory(0ULL);
   if (!underLimit) {
     underLimit = freeMemoryWhile([this](std::uint64_t reclaimed) -> bool {
-      if (reclaimed > 0) {
-        bool underLimit = reclaimMemory(reclaimed);
-        if (underLimit) {
-          // we have free enough memory.
-          // don't continue
-          return false;
-        }
-      }
-      // check if shutdown is in progress. then give up
-      return !isShutdown();
+      TRI_ASSERT(reclaimed > 0);
+      bool underLimit = reclaimMemory(reclaimed);
+      // continue only if we are not under the limit yet (after reclamation)
+      return !underLimit;
     });
   }
 

--- a/arangod/Cache/PlainCache.cpp
+++ b/arangod/Cache/PlainCache.cpp
@@ -266,10 +266,10 @@ bool PlainCache<Hasher>::freeMemoryWhile(
     std::uint64_t reclaimed = bucket.evictCandidate();
     if (reclaimed > 0) {
       maybeMigrate |= guard.source()->slotEmptied();
-    }
 
-    if (!cb(reclaimed)) {
-      break;
+      if (!cb(reclaimed)) {
+        break;
+      }
     }
   }
 

--- a/arangod/Cache/TransactionalCache.cpp
+++ b/arangod/Cache/TransactionalCache.cpp
@@ -314,10 +314,10 @@ bool TransactionalCache<Hasher>::freeMemoryWhile(
 
     if (reclaimed > 0) {
       maybeMigrate |= guard.source()->slotEmptied();
-    }
 
-    if (!cb(reclaimed)) {
-      break;
+      if (!cb(reclaimed)) {
+        break;
+      }
     }
   }
 


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/19842
Further improve performance of `freeMemoryWhile`, by not invoking the callback function if nothing was reclaimed.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [x] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.11: this PR
  - [x] Backport for 3.10: https://github.com/arangodb/arangodb/pull/19846

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 