### PR TITLE
further improve performance of `freeMemoryWhile`

### DIFF
--- a/arangod/Cache/Cache.cpp
+++ b/arangod/Cache/Cache.cpp
@@ -404,16 +404,10 @@ bool Cache::freeMemory() {
   }
 
   auto cb = [this](std::uint64_t reclaimed) -> bool {
-    if (reclaimed > 0) {
-      bool underLimit = reclaimMemory(reclaimed);
-      if (underLimit) {
-        // we have free enough memory.
-        // don't continue
-        return false;
-      }
-    }
-    // check if shutdown is in progress. then give up
-    return !isShutdown();
+    TRI_ASSERT(reclaimed > 0);
+    bool underLimit = reclaimMemory(reclaimed);
+    // continue only if we are not under the limit yet (after reclamation)
+    return !underLimit;
   };
 
   bool underLimit = reclaimMemory(0ULL);

--- a/arangod/Cache/PlainCache.cpp
+++ b/arangod/Cache/PlainCache.cpp
@@ -269,10 +269,10 @@ bool PlainCache<Hasher>::freeMemoryWhile(
       bucket.evict(candidate);
       freeValue(candidate);
       maybeMigrate |= guard.source()->slotEmptied();
-    }
 
-    if (!cb(reclaimed)) {
-      break;
+      if (!cb(reclaimed)) {
+        break;
+      }
     }
   }
 

--- a/arangod/Cache/TransactionalCache.cpp
+++ b/arangod/Cache/TransactionalCache.cpp
@@ -309,10 +309,10 @@ bool TransactionalCache<Hasher>::freeMemoryWhile(
 
     if (reclaimed > 0) {
       maybeMigrate |= guard.source()->slotEmptied();
-    }
 
-    if (!cb(reclaimed)) {
-      break;
+      if (!cb(reclaimed)) {
+        break;
+      }
     }
   }
 


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/19842
Further improve performance of `freeMemoryWhile`, by not invoking the callback function if nothing was reclaimed.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [x] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.11: https://github.com/arangodb/arangodb/pull/19843
  - [x] Backport for 3.10: this PR

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 