### PR TITLE
add more cache metrics

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,17 @@
 v3.10.11 (XXXX-XX-XX)
 ---------------------
 
+* Added the following metrics to improve observability of in-memory cache
+  subsystem:
+  - `rocksdb_cache_free_memory_tasks_total`: total number of `freeMemory`
+    tasks scheduled
+  - `rocksdb_cache_migrate_tasks_total`: total number of `migrate` tasks
+    scheduled
+  - `rocksdb_cache_free_memory_tasks_duration_total`: total time (microseconds)
+    spent in `freeMemory` tasks
+  - `rocksdb_cache_migrate_tasks_duration_total`: total time (microseconds)
+    spent in `migrate` tasks
+
 * Improve performance of the in-memory cache's memory reclamation procedure.
   The previous implementation acquired too many locks, which could drive system
   CPU time up.

--- a/Documentation/Metrics/rocksdb_cache_free_memory_tasks_duration_total.yaml
+++ b/Documentation/Metrics/rocksdb_cache_free_memory_tasks_duration_total.yaml
@@ -1,0 +1,17 @@
+name: rocksdb_cache_free_memory_tasks_duration_total
+introducedIn: "3.10.11"
+help: |
+  Total amount of time spent in 'free memory' tasks of the in-memory 
+  cache subsystem.
+unit: us
+type: counter
+category: Statistics
+complexity: advanced
+exposedBy:
+  - dbserver
+  - agent
+  - single
+description: |
+  Total amount of time spent inside 'free memory' tasks of the in-memory
+  cache subsystem. 'free memory' tasks are scheduled by the cache subsystem
+  to free up memory in existing cache hash tables.

--- a/Documentation/Metrics/rocksdb_cache_free_memory_tasks_total.yaml
+++ b/Documentation/Metrics/rocksdb_cache_free_memory_tasks_total.yaml
@@ -1,0 +1,20 @@
+name: rocksdb_cache_free_memory_tasks_total
+introducedIn: "3.10.11"
+help: |
+  Total number of 'free memory' tasks scheduled by the in-memory
+  cache subsystem.
+unit: number
+type: counter
+category: Statistics
+complexity: advanced
+exposedBy:
+  - dbserver
+  - agent
+  - single
+description: |
+  Total number of 'free memory' tasks that were scheduled by the
+  in-memory edge cache subsystem. This metric will be increased
+  whenever the cache subsystem schedules a task to free up memory
+  in one of the managed in-memory caches. It is expected to see
+  this metric rising when the cache subsystem hits its global
+  memory budget.

--- a/Documentation/Metrics/rocksdb_cache_migrate_tasks_duration_total.yaml
+++ b/Documentation/Metrics/rocksdb_cache_migrate_tasks_duration_total.yaml
@@ -1,0 +1,17 @@
+name: rocksdb_cache_migrate_tasks_duration_total
+introducedIn: "3.10.11"
+help: |
+  Total amount of time spent in 'migrate' tasks of the in-memory 
+  cache subsystem.
+unit: us
+type: counter
+category: Statistics
+complexity: advanced
+exposedBy:
+  - dbserver
+  - agent
+  - single
+description: |
+  Total amount of time spent inside 'migrate' tasks of the in-memory
+  cache subsystem. 'migrate' tasks are scheduled by the cache subsystem
+  to migrate existing cache hash tables to a bigger or smaller table.

--- a/Documentation/Metrics/rocksdb_cache_migrate_tasks_total.yaml
+++ b/Documentation/Metrics/rocksdb_cache_migrate_tasks_total.yaml
@@ -1,0 +1,18 @@
+name: rocksdb_cache_migrate_tasks_total
+introducedIn: "3.10.11"
+help: |
+  Total number of 'migrate' tasks scheduled by the in-memory
+  cache subsystem.
+unit: number
+type: counter
+category: Statistics
+complexity: advanced
+exposedBy:
+  - dbserver
+  - agent
+  - single
+description: |
+  Total number of 'migrate' tasks that were scheduled by the
+  in-memory edge cache subsystem. This metric will be increased
+  whenever the cache subsystem schedules a task to migrate an
+  existing cache hash table to a bigger or smaller size.

--- a/arangod/Cache/Manager.h
+++ b/arangod/Cache/Manager.h
@@ -85,6 +85,10 @@ class Manager {
     std::uint64_t spareAllocation = 0;
     std::uint64_t activeTables = 0;
     std::uint64_t spareTables = 0;
+    std::uint64_t migrateTasks = 0;
+    std::uint64_t freeMemoryTasks = 0;
+    std::uint64_t migrateTasksDuration = 0;     // total, micros
+    std::uint64_t freeMemoryTasksDuration = 0;  // total, micros
   };
 
   static constexpr std::uint64_t kMinSize = 1024 * 1024;
@@ -194,6 +198,11 @@ class Manager {
 
   SharedPRNGFeature& sharedPRNG() const noexcept { return _sharedPRNG; }
 
+  // track duration of migrate task, in ms
+  void trackMigrateTaskDuration(std::uint64_t duration) noexcept;
+  // track duration of free memory task, in ms
+  void trackFreeMemoryTaskDuration(std::uint64_t duration) noexcept;
+
  private:
   // use sizeof(uint64_t) + sizeof(std::shared_ptr<Cache>) + 64 for upper bound
   // on size of std::set<std::shared_ptr<Cache>> node -- should be valid for
@@ -244,6 +253,10 @@ class Manager {
   std::uint64_t _peakGlobalAllocation;
   std::uint64_t _activeTables;
   std::uint64_t _spareTables;
+  std::uint64_t _migrateTasks;
+  std::uint64_t _freeMemoryTasks;
+  std::uint64_t _migrateTasksDuration;     // total, micros
+  std::uint64_t _freeMemoryTasksDuration;  // total, micros
 
   // transaction management
   TransactionManager _transactions;

--- a/arangod/Cache/ManagerTasks.cpp
+++ b/arangod/Cache/ManagerTasks.cpp
@@ -31,6 +31,8 @@
 #include "Cache/Metadata.h"
 #include "Random/RandomGenerator.h"
 
+#include <chrono>
+
 namespace arangodb::cache {
 
 FreeMemoryTask::FreeMemoryTask(Manager::TaskEnvironment environment,
@@ -87,7 +89,12 @@ void FreeMemoryTask::run() {
     TRI_ASSERT(!metadata.isResizing());
   });
 
+  // execute freeMemory() with timing
+  auto now = std::chrono::steady_clock::now();
   bool ran = _cache->freeMemory();
+  auto diff = std::chrono::steady_clock::now() - now;
+  _manager.trackFreeMemoryTaskDuration(
+      std::chrono::duration_cast<std::chrono::microseconds>(diff).count());
 
   // flag must still be set after freeMemory()
   TRI_ASSERT(_cache->isResizingFlagSet());
@@ -166,7 +173,11 @@ void MigrateTask::run() {
   TRI_ASSERT(_cache->isMigratingFlagSet());
 
   // do the actual migration
+  auto now = std::chrono::steady_clock::now();
   bool ran = _cache->migrate(_table);
+  auto diff = std::chrono::steady_clock::now() - now;
+  _manager.trackMigrateTaskDuration(
+      std::chrono::duration_cast<std::chrono::microseconds>(diff).count());
 
   // migrate() must have unset the migrating flag, but we
   // cannot check it here because another MigrateTask may


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/19841

* Added the following metrics to improve observability of in-memory cache subsystem:
  - `rocksdb_cache_free_memory_tasks_total`: total number of `freeMemory` tasks scheduled
  - `rocksdb_cache_migrate_tasks_total`: total number of `migrate` tasks scheduled
  - `rocksdb_cache_free_memory_tasks_duration_total`: total time (microseconds) spent in `freeMemory` tasks
  - `rocksdb_cache_migrate_tasks_duration_total`: total time (microseconds) spent in `migrate` tasks

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.11: https://github.com/arangodb/arangodb/pull/19841
  - [x] Backport for 3.10: this PR

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 