### PR TITLE
Fix build of client-tools

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1386,6 +1386,6 @@ if (USE_ENTERPRISE)
 endif ()
 
 add_custom_target(arangodb
-   DEPENDS arangod arangotools)
+   DEPENDS arangod client-tools)
 
 add_subdirectory(utils/gdb-pretty-printers/immer/test)


### PR DESCRIPTION
### Scope & Purpose
This PR fixes this build error:
```
gmake[3]: *** No rule to make target 'arangotools', needed by 'CMakeFiles/arangodb'.  Stop.
gmake[2]: *** [CMakeFiles/Makefile2:4120: CMakeFiles/arangodb.dir/all] Error 2
gmake[1]: *** [CMakeFiles/Makefile2:4127: CMakeFiles/arangodb.dir/rule] Error 2
gmake: *** [Makefile:342: arangodb] Error 2
16:31:11: The process "/snap/bin/cmake" exited with code 2.
Error while building/deploying project arangodb3 (kit: Imported Kit)
When executing step "CMake Build"
```

Follow-up of https://github.com/arangodb/arangodb/pull/19768

- [X] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

