### PR TITLE
fix potential recursive lock invocation

### DIFF
--- a/arangod/Cache/Manager.cpp
+++ b/arangod/Cache/Manager.cpp
@@ -251,6 +251,7 @@ void Manager::shutdown() {
       std::shared_ptr<Cache> cache = _caches.begin()->second;
       SpinUnlocker unguard(SpinUnlocker::Mode::Write, _lock);
       cache->shutdown();
+      cache.reset();
     }
 
     TRI_ASSERT(_activeTables == 0);
@@ -443,12 +444,33 @@ std::tuple<bool, Metadata, std::shared_ptr<Table>> Manager::createTable(
 }
 
 void Manager::unregisterCache(std::uint64_t id) {
-  SpinLocker guard(SpinLocker::Mode::Write, _lock);
-  _accessStats.purgeRecord(id);
-  if (_caches.erase(id) > 0) {
+  std::shared_ptr<Cache> cache;
+  {
+    SpinLocker guard(SpinLocker::Mode::Write, _lock);
+
+    auto it = _caches.find(id);
+    if (it == _caches.end()) {
+      return;
+    }
+
+    // move shared_ptr into our own scope
+    cache = std::move((*it).second);
+    _caches.erase(it);
+
+    // remove access statistics
+    _accessStats.purgeRecord(id);
+
+    // count down global overhead
     TRI_ASSERT(_globalAllocation >= kCacheRecordOverhead + _fixedAllocation);
     _globalAllocation -= kCacheRecordOverhead;
   }
+
+  // let the cache go out of scope without holding the lock. this
+  // is necessary because the cache can acquire _lock in write mode
+  // in its dtor!
+  // note: the reset is not necessary here, it is just here so that
+  // the cache variable will not be identified as unused somehow.
+  cache.reset();
 }
 
 std::pair<bool, Manager::time_point> Manager::requestGrow(Cache* cache) {


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/19853

Fix a potential recursive lock invocation.
This only happened if the cache manager was destroyed while caches were still in use. 
In this case, the Manager's dtor called `Manager::shutdown()`, which went through all still-available caches, and called `Cache::shutdown()` on them. The Cache shutdown would call `Manager::unregisterCache(), which could acquire the Manager `_lock`, and then remove the Cache object from the map of caches (_caches). If the last shared_ptr to the Cache was destroyed, the Cache's dtor could try to call into the Manager for a memory allocation ajdusted. this could against acquire the Manager's `_lock` again, so there would be a recursive invocation.
This only happened upon shutdown, and in no released versions.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [x] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.11: this PR
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 