### PR TITLE
Remove weird template parameter.

### DIFF
--- a/arangod/Aql/ExecutionBlockImpl.tpp
+++ b/arangod/Aql/ExecutionBlockImpl.tpp
@@ -81,7 +81,7 @@ template<class UsedFetcher>
 class IdExecutor;
 class IndexExecutor;
 class JoinExecutor;
-template<typename T, bool localDocumentId>
+template<bool localDocumentId>
 class MaterializeExecutor;
 template<typename FetcherType, typename ModifierType>
 class ModificationExecutor;
@@ -795,9 +795,7 @@ static SkipRowsRangeVariant constexpr skipRowsType() {
                   MultipleRemoteModificationExecutor, SortExecutor,
                   // only available in Enterprise
                   arangodb::iresearch::OffsetMaterializeExecutor,
-                  MaterializeExecutor<void, false>,
-                  MaterializeExecutor<std::string const&, true>,
-                  MaterializeExecutor<std::string const&, false>>) ||
+                  MaterializeExecutor<false>, MaterializeExecutor<true>>) ||
           IsSearchExecutor<Executor>::value,
       "Unexpected executor for SkipVariants::EXECUTOR");
 

--- a/arangod/Aql/MaterializeExecutor.cpp
+++ b/arangod/Aql/MaterializeExecutor.cpp
@@ -37,8 +37,8 @@
 
 namespace arangodb::aql {
 
-template<typename T, bool localDocumentId>
-MaterializeExecutor<T, localDocumentId>::ReadContext::ReadContext(Infos& infos)
+template<bool localDocumentId>
+MaterializeExecutor<localDocumentId>::ReadContext::ReadContext(Infos& infos)
     : infos{&infos} {
   if constexpr (localDocumentId) {
     callback = [this](LocalDocumentId /*id*/, VPackSlice doc) {
@@ -53,9 +53,9 @@ MaterializeExecutor<T, localDocumentId>::ReadContext::ReadContext(Infos& infos)
   }
 }
 
-template<typename T, bool localDocumentId>
-void MaterializeExecutor<T, localDocumentId>::ReadContext::ReadContext::
-    moveInto(std::unique_ptr<uint8_t[]> data) {
+template<bool localDocumentId>
+void MaterializeExecutor<localDocumentId>::ReadContext::ReadContext::moveInto(
+    std::unique_ptr<uint8_t[]> data) {
   TRI_ASSERT(infos);
   TRI_ASSERT(outputRow);
   TRI_ASSERT(inputRow);
@@ -68,15 +68,15 @@ void MaterializeExecutor<T, localDocumentId>::ReadContext::ReadContext::
                            guard);
 }
 
-template<typename T, bool localDocumentId>
-MaterializeExecutor<T, localDocumentId>::MaterializeExecutor(
-    MaterializeExecutor<T, localDocumentId>::Fetcher& /*fetcher*/, Infos& infos)
+template<bool localDocumentId>
+MaterializeExecutor<localDocumentId>::MaterializeExecutor(
+    MaterializeExecutor<localDocumentId>::Fetcher& /*fetcher*/, Infos& infos)
     : _buffer{infos.query().resourceMonitor()},
       _trx{infos.query().newTrxContext()},
       _readCtx{infos} {}
 
-template<typename T, bool localDocumentId>
-void MaterializeExecutor<T, localDocumentId>::Buffer::fill(
+template<bool localDocumentId>
+void MaterializeExecutor<localDocumentId>::Buffer::fill(
     AqlItemBlockInputRange& inputRange, ReadContext& ctx) {
   TRI_ASSERT(!localDocumentId);
   docs.clear();
@@ -148,9 +148,9 @@ void MaterializeExecutor<T, localDocumentId>::Buffer::fill(
   }
 }
 
-template<typename T, bool localDocumentId>
+template<bool localDocumentId>
 std::tuple<ExecutorState, MaterializeStats, AqlCall>
-MaterializeExecutor<T, localDocumentId>::produceRows(
+MaterializeExecutor<localDocumentId>::produceRows(
     AqlItemBlockInputRange& inputRange, OutputAqlItemRow& output) {
   MaterializeStats stats;
 
@@ -253,9 +253,9 @@ MaterializeExecutor<T, localDocumentId>::produceRows(
   return {inputRange.upstreamState(), stats, upstreamCall};
 }
 
-template<typename T, bool localDocumentId>
+template<bool localDocumentId>
 std::tuple<ExecutorState, MaterializeStats, size_t, AqlCall>
-MaterializeExecutor<T, localDocumentId>::skipRowsRange(
+MaterializeExecutor<localDocumentId>::skipRowsRange(
     AqlItemBlockInputRange& inputRange, AqlCall& call) {
   size_t skipped = 0;
 
@@ -275,11 +275,10 @@ MaterializeExecutor<T, localDocumentId>::skipRowsRange(
   return {inputRange.upstreamState(), MaterializeStats{}, skipped, call};
 }
 
-template class MaterializeExecutor<void, false>;
-template class MaterializeExecutor<std::string const&, false>;
-template class MaterializeExecutor<std::string const&, true>;
+template class MaterializeExecutor<false>;
+template class MaterializeExecutor<true>;
 
-template class MaterializerExecutorInfos<void>;
-template class MaterializerExecutorInfos<std::string const&>;
+template class MaterializerExecutorInfos<true>;
+template class MaterializerExecutorInfos<false>;
 
 }  // namespace arangodb::aql


### PR DESCRIPTION
### Scope & Purpose
This is the first clean up step for the materialize executor. The executor had two template parameters, but only two of the possible four combinations were used, while only three of them were actually compiled.

In the end, what matters is if the documents are materialized using a local document id or a arango search document id.

More simplifications will follow.