### PR TITLE
[BTS-1618] Empty AQL Query Result

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 v3.10.11 (XXXX-XX-XX)
 ---------------------
 
+* Fixed BTS-1618: Buggy AQL query returning empty results, due to incorrect
+  use of index projections.
+
 * Improve performance of the in-memory cache's memory reclamation procedure.
   The previous implementation acquired too many locks, which could drive system
   CPU time up.

--- a/arangod/Aql/IndexNode.h
+++ b/arangod/Aql/IndexNode.h
@@ -192,9 +192,8 @@ class IndexNode : public ExecutionNode,
   /// @brief We have single index and this index covered whole condition
   bool _allCoveredByOneIndex;
 
-  /// @brief if the (post) filter condition is fully covered by the index
-  /// attributes
-  bool _indexCoversFilterCondition;
+  /// @brief if the projections are fully covered by the index attributes
+  std::optional<bool> _indexCoversProjections;
 
   /// @brief the index iterator options - same for all indexes
   IndexIteratorOptions _options;

--- a/tests/js/server/aql/aql-projections.js
+++ b/tests/js/server/aql/aql-projections.js
@@ -1,5 +1,5 @@
 /*jshint globalstrict:false, strict:false, maxlen: 500 */
-/*global assertEqual, assertTrue, assertFalse, assertNotEqual, AQL_EXPLAIN */
+/*global assertEqual, assertTrue, assertFalse, assertNotEqual, AQL_EXPLAIN, AQL_EXECUTE */
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief tests for optimizer rules
@@ -714,6 +714,23 @@ function projectionsExtractionTestSuite () {
         assertEqual(query[3], results);
       });
     },
+
+    testExtractSecondSubAttribute : function () {
+      // While the index is created on [p.s, p.k], the query filters by p.k but only extracts p.s.
+      c.ensureIndex({ type: "persistent", fields: ["p.s", "p.k"]});
+      c.insert({"p": {"s": 1234, "k": "hund"}});
+      c.insert({"p": {"s": 1235, "k": "katze"}});
+      c.insert({"p": {"s": 1236, "k": "schnecke"}});
+      c.insert({"p": {"s": 1237, "k": "kuh"}});
+      let bindVars = {'@coll': cn};
+      let q = "" +
+        "FOR doc in @@coll " +
+        "FILTER doc.p.k == 'hund' " +
+        "SORT doc.p.s DESC " +
+        "RETURN doc.p.s";
+      let result = AQL_EXECUTE(q, bindVars);
+      assertEqual(result.json, [1234]);
+    }
   };
 }
 


### PR DESCRIPTION
### Scope & Purpose

_For a more in-depth explanation, see this [recording](https://drive.google.com/file/d/1xd9Dm0H_Nnra_8gPcAXPdLPhFQleZvDG/view?usp=sharing)_

**Problem**
Assume we have a collection where each document has the field "p", with subfields "s" and "k". For example:
```
{"p": {"s": 1234, "k": "hund"}}
{"p": {"s": 1235, "k": "katze"}}
```

There's an index created on ["p.s", "p.k"].

Given the following query:
```aql
FOR doc in @@coll
  FILTER doc.p.k == 'hund'
  SORT doc.p.s DESC
  RETURN doc.p.s
```
This should return `[1234]`, but on 3.10 it returns `[]`.

**Key observations**
Notice the sub-optimal usage of the index. If we were to create the index on ["p.k", "p.s"], not only the query would be faster, but the returned result would be correct. However, the bug is still there.  
It is also important to note that this is only reproducible in a cluster. On a single-server it works just fine.

**AQL internals**
I wrote this part to facilitate an easier review. Feel free to skip it.  
The coordinator receives the above query and builds the AST. This contains a lot of nodes, and is not optimized to use any indexes. Next step is to optimize the query.  
It gets reduced to the following nodes:
```
SingletonNode
IndexNode
CalculationNode
RemoteNode
GatherNode
ReturnNode
```

Lots of optimization rules are applied, but one two of them are relevant here:
```
move-filters-into-enumerate
reduce-extraction-to-projection
```
Now, because we're using an index, the optimizer figures that it may not need to fetch the document, but use the index projection instead. There are two fields used to indicate this: _projections_ and _filterProjections_. **Note that if projections are fully covered by the index, then the filterProjections are ignored**

**Messing up the projections**
1. On the _coordinator_, the `move-filters-into-enumerate` initializes both projection fields correctly: `projections = [["p","s"], ["p","k"]];  filterProjections = [["p","k"]]`. However, upon executing `Projections::removeSharedPrefixes()`, the projections are reduced to `projections=["p"]`. This is not longer the case in devel, as it has been changed in https://github.com/arangodb/arangodb/pull/17465.
2. Still on the _coordinator_, the `reduce-extraction-to-projection`  rule kicks in. Note that currently, the projections are not covered by the index. The `IndexNode::prepareProjections()` method is where an important decision is going to be made: if the index covers the _projections_, we keep them and wipe out _filterProjections_, or we calculate new _filterProjections_ and new _projections_. At this point on the coordinator, we take the latter, which yields `projections = [["p","s"]]; filterProjections = [["p","k"]]`.
3. On the _dbserver_, we get the projections as "p.s", which are covered by the index. Therefore, we take to former condition, wipe out _filterProjections_ and (wrongly) projection only "p.s". Eventually, the dbserver checks the filter in the `DocumentProducingCallbackVariant::WithProjectionsCoveredByIndex` callback and fails to find any document, because it doesn't have access to "p.k".

**Solution**
The problem is, as noted by a comment in `IndexNode::prepareProjections()` _idx->covers(...) modifies the projections object_. This creates a misunderstanding between the coordinator and the dbserver, where the former believes that projections are not covered by the index, while the latter thinks they are.  
Therefore, we are now sending the information over, exactly as the coordinator perceives it, through the `_indexCoversProjections` field. This way, we make sure the dbserver goes on the same path as the coordinator.  
Surprisingly, some of the work was already there. The "indexCoversProjections" vpack value existed before, together with `_indexCoversFilterCondition`, although neither was used anywhere in the code. This PR "finishes" that implementation.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [x] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

Other PRs created to prevent this:
- devel https://github.com/arangodb/arangodb/pull/19869
- 3.11 https://github.com/arangodb/arangodb/pull/19871

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [x] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/BTS-1618
- [ ] Design document: 

