### PR TITLE
better reporting for hotbackup errors

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,10 +3,6 @@ devel
 
 * Improve logging in case hot backup locks cannot be taken on coordinators.
 
-* Abandon expired local hot backup locks 4 hours after they have been acquired.
-  The assumption is that such locks are abandoned when not released within
-  that time period.
-
 * Speed up incremental hotbackup upload by parallelization of
   remote-to-remote copies. Tolerate deletion of old backups during
   incremental upload.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,12 @@
 devel
 -----
 
+* Improve logging in case hot backup locks cannot be taken on coordinators.
+
+* Abandon expired local hot backup locks 4 hours after they have been acquired.
+  The assumption is that such locks are abandoned when not released within
+  that time period.
+
 * Speed up incremental hotbackup upload by parallelization of
   remote-to-remote copies. Tolerate deletion of old backups during
   incremental upload.

--- a/arangod/Cluster/ClusterMethods.cpp
+++ b/arangod/Cluster/ClusterMethods.cpp
@@ -3097,7 +3097,7 @@ arangodb::Result controlMaintenanceFeature(
           network::fuerteToArangoErrorCode(r),
           std::string("Communication error while executing " + command +
                       " maintenance on ") +
-              r.destination);
+              r.destination + ": " + r.combinedResult().errorMessage());
     }
 
     VPackSlice resSlice = r.slice();
@@ -3161,7 +3161,8 @@ arangodb::Result restoreOnDBServers(network::ConnectionPool* pool,
       // oh-oh cluster is in a bad state
       return arangodb::Result(
           network::fuerteToArangoErrorCode(r),
-          std::string("Communication error list backups on ") + r.destination);
+          std::string("Communication error list backups on ") + r.destination +
+              ": " + r.combinedResult().errorMessage());
     }
 
     VPackSlice resSlice = r.slice();
@@ -3511,7 +3512,7 @@ arangodb::Result lockServersTrxCommit(network::ConnectionPool* pool,
     if (r.fail()) {
       reportError(TRI_ERROR_LOCAL_LOCK_FAILED,
                   std::string("Communication error locking transactions on ") +
-                      r.destination);
+                      r.destination + ": " + r.combinedResult().errorMessage());
       continue;
     }
     VPackSlice slc = r.slice();
@@ -3832,9 +3833,9 @@ arangodb::Result removeLocalBackups(network::ConnectionPool* pool,
 std::vector<std::string> const versionPath =
     std::vector<std::string>{"arango", "Plan", "Version"};
 
-arangodb::Result hotbackupAsyncLockDBServersTransactions(
+arangodb::Result hotbackupAsyncLockCoordinatorsTransactions(
     network::ConnectionPool* pool, std::string const& backupId,
-    std::vector<ServerID> const& dbServers, double const& lockWait,
+    std::vector<ServerID> const& coordinators, double const& lockWait,
     std::unordered_map<std::string, std::string>& serverLockIds) {
   std::string const url = apiStr + "lock";
 
@@ -3856,14 +3857,14 @@ arangodb::Result hotbackupAsyncLockDBServersTransactions(
   reqOpts.timeout = network::Timeout(lockWait + 5.0);
 
   std::vector<Future<network::Response>> futures;
-  futures.reserve(dbServers.size());
+  futures.reserve(coordinators.size());
 
-  for (auto const& dbServer : dbServers) {
+  for (auto const& coordinator : coordinators) {
     network::Headers headers;
     headers.emplace(StaticStrings::Async, "store");
     futures.emplace_back(network::sendRequestRetry(
-        pool, "server:" + dbServer, fuerte::RestVerb::Post, url, body, reqOpts,
-        std::move(headers)));
+        pool, "server:" + coordinator, fuerte::RestVerb::Post, url, body,
+        reqOpts, std::move(headers)));
   }
 
   // Perform the requests
@@ -3874,7 +3875,7 @@ arangodb::Result hotbackupAsyncLockDBServersTransactions(
       return arangodb::Result(
           TRI_ERROR_LOCAL_LOCK_FAILED,
           std::string("Communication error locking transactions on ") +
-              r.destination);
+              r.destination + ": " + r.combinedResult().errorMessage());
     }
 
     if (r.statusCode() != 202) {
@@ -3900,7 +3901,7 @@ arangodb::Result hotbackupAsyncLockDBServersTransactions(
   return arangodb::Result();
 }
 
-arangodb::Result hotbackupWaitForLockDBServersTransactions(
+arangodb::Result hotbackupWaitForLockCoordinatorsTransactions(
     network::ConnectionPool* pool, std::string const& backupId,
     std::unordered_map<std::string, std::string>& serverLockIds,
     std::vector<ServerID>& lockedServers, double const& lockWait) {
@@ -3928,7 +3929,7 @@ arangodb::Result hotbackupWaitForLockDBServersTransactions(
       return arangodb::Result(
           TRI_ERROR_LOCAL_LOCK_FAILED,
           std::string("Communication error locking transactions on ") +
-              r.destination);
+              r.destination + ": " + r.combinedResult().errorMessage());
     }
     // continue on 204 No Content
     if (r.statusCode() == 204) {
@@ -4164,6 +4165,9 @@ arangodb::Result hotBackupCoordinator(ClusterFeature& feature,
         unlockServersTrxCommit(pool, backupId, lockedServers);
         lockedServers.clear();
         if (result.is(TRI_ERROR_LOCAL_LOCK_FAILED)) {  // Unrecoverable
+          LOG_TOPIC("99dbe", WARN, Logger::BACKUP)
+              << "unable to lock servers for hot backup: "
+              << result.errorMessage();
           // release the lock
           releaseAgencyLock.fire();
           events::CreateHotbackup(timeStamp + "_" + backupId,
@@ -4210,7 +4214,7 @@ arangodb::Result hotBackupCoordinator(ClusterFeature& feature,
             milliseconds(static_cast<uint64_t>(1000 * timeout));
 
       // send the locks
-      result = hotbackupAsyncLockDBServersTransactions(
+      result = hotbackupAsyncLockCoordinatorsTransactions(
           pool, backupId, serversToBeLocked, lockWait, lockJobIds);
       if (result.fail()) {
         events::CreateHotbackup(timeStamp + "_" + backupId,
@@ -4236,9 +4240,12 @@ arangodb::Result hotBackupCoordinator(ClusterFeature& feature,
         }
 
         // wait for locks, servers that got the lock are removed from lockJobIds
-        result = hotbackupWaitForLockDBServersTransactions(
+        result = hotbackupWaitForLockCoordinatorsTransactions(
             pool, backupId, lockJobIds, lockedServers, lockWait);
         if (result.fail()) {
+          LOG_TOPIC("b6496", WARN, Logger::BACKUP)
+              << "Waiting for hot backup server locks failed: "
+              << result.errorMessage();
           events::CreateHotbackup(timeStamp + "_" + backupId,
                                   result.errorNumber());
           return result;

--- a/arangod/Cluster/ClusterMethods.cpp
+++ b/arangod/Cluster/ClusterMethods.cpp
@@ -4185,7 +4185,7 @@ arangodb::Result hotBackupCoordinator(ClusterFeature& feature,
 
     if (!result.ok() && force) {
       // About this code:
-      // it first creates async requests to lock all dbservers.
+      // it first creates async requests to lock all coordinators.
       //    the corresponding lock ids are stored int the map lockJobIds.
       // Then we continously abort all trx while checking all the above jobs
       //    for completion.
@@ -4268,7 +4268,7 @@ arangodb::Result hotBackupCoordinator(ClusterFeature& feature,
       result.reset(
           TRI_ERROR_HOT_BACKUP_INTERNAL,
           StringUtils::concatT(
-              "failed to acquire global transaction lock on all db servers: ",
+              "failed to acquire global transaction lock on all coordinators: ",
               result.errorMessage()));
       LOG_TOPIC("b7d09", ERR, Logger::BACKUP) << result.errorMessage();
       events::CreateHotbackup(timeStamp + "_" + backupId, result.errorNumber());
@@ -4288,7 +4288,7 @@ arangodb::Result hotBackupCoordinator(ClusterFeature& feature,
       releaseAgencyLock.fire();
       result.reset(
           TRI_ERROR_HOT_BACKUP_INTERNAL,
-          StringUtils::concatT("failed to hot backup on all db servers: ",
+          StringUtils::concatT("failed to hot backup on all coordinators: ",
                                result.errorMessage()));
       LOG_TOPIC("6b333", ERR, Logger::BACKUP) << result.errorMessage();
       removeLocalBackups(pool, backupId, dbServers, dummy);

--- a/arangod/Transaction/Manager.cpp
+++ b/arangod/Transaction/Manager.cpp
@@ -120,7 +120,7 @@ void Manager::releaseTransactions() noexcept {
 void Manager::cancelExpiredHotbackupLock() noexcept {
   std::unique_lock<std::mutex> guard(_hotbackupMutex);
   if (_hotbackupCommitLockHeld &&
-      _hotbackupCommitLockExpireTime < std::chrono::steady_clock::now()) {
+      _hotbackupCommitLockExpireStamp < std::chrono::steady_clock::now()) {
     // the hot backup lock is still taken, but it already expired.
     // we now unlock it, so that subsequent hot backups can make progress
     LOG_TOPIC("f73cb", INFO, Logger::TRANSACTIONS)
@@ -128,7 +128,7 @@ void Manager::cancelExpiredHotbackupLock() noexcept {
            "backup";
     _hotbackupCommitLock.unlockWrite();
     _hotbackupCommitLockHeld = false;
-    _hotbackupCommitLockExpireTime = {};
+    _hotbackupCommitLockExpireStamp = {};
   }
 }
 

--- a/arangod/Transaction/Manager.h
+++ b/arangod/Transaction/Manager.h
@@ -42,7 +42,6 @@
 #include <absl/hash/hash.h>
 
 #include <atomic>
-#include <chrono>
 #include <functional>
 #include <memory>
 #include <unordered_map>
@@ -230,8 +229,6 @@ class Manager final : public IManager {
         LOG_TOPIC("eeddb", TRACE, Logger::TRANSACTIONS)
             << "Got write lock to hold transactions.";
         _hotbackupCommitLockHeld = true;
-        _hotbackupCommitLockExpireStamp =
-            std::chrono::steady_clock::now() + hotBackupCommitLockExpireTime;
       } else {
         LOG_TOPIC("eeddc", TRACE, Logger::TRANSACTIONS)
             << "Did not get write lock to hold transactions.";
@@ -242,8 +239,6 @@ class Manager final : public IManager {
 
   // remove the block
   void releaseTransactions() noexcept;
-
-  void cancelExpiredHotbackupLock() noexcept;
 
   using TransactionCommitGuard = basics::ReadLocker<basics::ReadWriteLock>;
 
@@ -321,12 +316,6 @@ class Manager final : public IManager {
                                // the same time.
   basics::ReadWriteLock _hotbackupCommitLock;
   bool _hotbackupCommitLockHeld;
-  // the time the lock taken for hot backup expires, if
-  // _hotbackupCommitLockHeld is set
-  std::chrono::time_point<std::chrono::steady_clock>
-      _hotbackupCommitLockExpireStamp;
-
-  static constexpr auto hotBackupCommitLockExpireTime = std::chrono::hours(4);
 
   double _streamingLockTimeout;
 


### PR DESCRIPTION
### Scope & Purpose

* Abandon expired local hot backup locks on coordinators a bit later than before. Previously, the timeout was `timeout + 5` seconds on each coordinator. There can be issues when multiple coordinators need to acquire the lock, so that the first coordinator acquires the lock successfully and its unlock clock starts ticking, whereas the subsequent coordinators may need to lock acquire the lock. In this case, the lock on the first coordinators could have been released already, even though the backup hasn't even started. This PR increases the per-coordinator timeout to `timeout + 30` seconds, which improves the situation, but is still not 100% safe.

* Improve logging in case hot backup locks cannot be taken on coordinators.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.11: https://github.com/arangodb/arangodb/pull/19873
  - [x] Backport for 3.10: https://github.com/arangodb/arangodb/pull/19874

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 