### PR TITLE
Feature/use materialize multi node for inverted index

### DIFF
--- a/arangod/Aql/ExecutionNode.cpp
+++ b/arangod/Aql/ExecutionNode.cpp
@@ -2869,7 +2869,7 @@ MaterializeNode* materialize::createMaterializeNode(
     ExecutionPlan* plan, arangodb::velocypack::Slice const base) {
   auto isMulti = base.get(kMaterializeNodeMultiNodeParam);
   if (isMulti.isBoolean() && isMulti.getBoolean()) {
-    return new MaterializeMultiNode(plan, base);
+    return new MaterializeSearchNode(plan, base);
   }
   auto inLocalDocId = base.get(kMaterializeNodeInLocalDocIdParam);
   if (inLocalDocId.isBoolean() && inLocalDocId.getBoolean()) {
@@ -2924,24 +2924,24 @@ std::vector<Variable const*> MaterializeNode::getVariablesSetHere() const {
   return std::vector<Variable const*>{_outVariable};
 }
 
-MaterializeMultiNode::MaterializeMultiNode(ExecutionPlan* plan,
-                                           ExecutionNodeId id,
-                                           aql::Variable const& inDocId,
-                                           aql::Variable const& outVariable)
+MaterializeSearchNode::MaterializeSearchNode(ExecutionPlan* plan,
+                                             ExecutionNodeId id,
+                                             aql::Variable const& inDocId,
+                                             aql::Variable const& outVariable)
     : MaterializeNode(plan, id, inDocId, outVariable) {}
 
-MaterializeMultiNode::MaterializeMultiNode(
+MaterializeSearchNode::MaterializeSearchNode(
     ExecutionPlan* plan, arangodb::velocypack::Slice const& base)
     : MaterializeNode(plan, base) {}
 
-void MaterializeMultiNode::doToVelocyPack(velocypack::Builder& nodes,
-                                          unsigned flags) const {
+void MaterializeSearchNode::doToVelocyPack(velocypack::Builder& nodes,
+                                           unsigned flags) const {
   // call base class method
   MaterializeNode::doToVelocyPack(nodes, flags);
   nodes.add(kMaterializeNodeMultiNodeParam, velocypack::Value(true));
 }
 
-std::unique_ptr<ExecutionBlock> MaterializeMultiNode::createBlock(
+std::unique_ptr<ExecutionBlock> MaterializeSearchNode::createBlock(
     ExecutionEngine& engine) const {
   ExecutionNode const* previousNode = getFirstDependency();
   TRI_ASSERT(previousNode != nullptr);
@@ -2972,9 +2972,9 @@ std::unique_ptr<ExecutionBlock> MaterializeMultiNode::createBlock(
       &engine, this, std::move(registerInfos), std::move(executorInfos));
 }
 
-ExecutionNode* MaterializeMultiNode::clone(ExecutionPlan* plan,
-                                           bool withDependencies,
-                                           bool withProperties) const {
+ExecutionNode* MaterializeSearchNode::clone(ExecutionPlan* plan,
+                                            bool withDependencies,
+                                            bool withProperties) const {
   TRI_ASSERT(plan);
 
   auto* outVariable = _outVariable;
@@ -2986,7 +2986,7 @@ ExecutionNode* MaterializeMultiNode::clone(ExecutionPlan* plan,
         plan->getAst()->variables()->createVariable(inNonMaterializedDocId);
   }
 
-  auto c = std::make_unique<MaterializeMultiNode>(
+  auto c = std::make_unique<MaterializeSearchNode>(
       plan, _id, *inNonMaterializedDocId, *outVariable);
   return cloneHelper(std::move(c), withDependencies, withProperties);
 }

--- a/arangod/Aql/ExecutionNode.h
+++ b/arangod/Aql/ExecutionNode.h
@@ -1195,14 +1195,14 @@ class MaterializeNode : public ExecutionNode {
   Variable const* _outVariable;
 };
 
-class MaterializeMultiNode : public MaterializeNode {
+class MaterializeSearchNode : public MaterializeNode {
  public:
-  MaterializeMultiNode(ExecutionPlan* plan, ExecutionNodeId id,
-                       aql::Variable const& inDocId,
-                       aql::Variable const& outVariable);
+  MaterializeSearchNode(ExecutionPlan* plan, ExecutionNodeId id,
+                        aql::Variable const& inDocId,
+                        aql::Variable const& outVariable);
 
-  MaterializeMultiNode(ExecutionPlan* plan,
-                       arangodb::velocypack::Slice const& base);
+  MaterializeSearchNode(ExecutionPlan* plan,
+                        arangodb::velocypack::Slice const& base);
 
   /// @brief creates corresponding ExecutionBlock
   std::unique_ptr<ExecutionBlock> createBlock(

--- a/arangod/Aql/IResearchViewOptimizerRules.cpp
+++ b/arangod/Aql/IResearchViewOptimizerRules.cpp
@@ -1053,7 +1053,7 @@ void lateDocumentMaterializationArangoSearchRule(
         viewNode.setLateMaterialized(*localDocIdTmp);
         // insert a materialize node
         auto* materializeNode = plan->registerNode(
-            std::make_unique<materialize::MaterializeMultiNode>(
+            std::make_unique<materialize::MaterializeSearchNode>(
                 plan.get(), plan->nextId(), *localDocIdTmp, var));
         TRI_ASSERT(materializeNode);
 

--- a/arangod/Aql/IndexNodeOptimizerRules.cpp
+++ b/arangod/Aql/IndexNodeOptimizerRules.cpp
@@ -339,9 +339,8 @@ void arangodb::aql::lateDocumentMaterializationRule(
         // insert a materialize node
         auto makeMaterializer = [&]() -> std::unique_ptr<ExecutionNode> {
           if (index->type() == Index::TRI_IDX_TYPE_INVERTED_INDEX) {
-            return std::make_unique<materialize::MaterializeSingleNode<false>>(
-                plan.get(), plan->nextId(), indexNode->collection(),
-                *localDocIdTmp, *var);
+            return std::make_unique<materialize::MaterializeMultiNode>(
+                plan.get(), plan->nextId(), *localDocIdTmp, *var);
           }
           return std::make_unique<materialize::MaterializeSingleNode<true>>(
               plan.get(), plan->nextId(), indexNode->collection(),

--- a/arangod/Aql/IndexNodeOptimizerRules.cpp
+++ b/arangod/Aql/IndexNodeOptimizerRules.cpp
@@ -339,7 +339,7 @@ void arangodb::aql::lateDocumentMaterializationRule(
         // insert a materialize node
         auto makeMaterializer = [&]() -> std::unique_ptr<ExecutionNode> {
           if (index->type() == Index::TRI_IDX_TYPE_INVERTED_INDEX) {
-            return std::make_unique<materialize::MaterializeMultiNode>(
+            return std::make_unique<materialize::MaterializeSearchNode>(
                 plan.get(), plan->nextId(), *localDocIdTmp, *var);
           }
           return std::make_unique<materialize::MaterializeSingleNode<true>>(


### PR DESCRIPTION
### Scope & Purpose
1. Rename `MaterializeMultiNode` to `MaterializeSearchNode` because it makes more sense. (it's probably called multi because it potentially accesses multiple collections)
2. Use `MaterializeSearchNode` for inverted indexes as well.