### PR TITLE
[BTS-1618] Prevent projection problems

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 v3.11.4 (XXXX-XX-XX)
 --------------------
 
+* BTS-1618: Preventing the problem from ever occurring on 3.11.
+
 * Improve performance of the in-memory cache's memory reclamation procedure.
   The previous implementation acquired too many locks, which could drive system
   CPU time up.

--- a/arangod/Aql/IndexNode.cpp
+++ b/arangod/Aql/IndexNode.cpp
@@ -108,6 +108,11 @@ IndexNode::IndexNode(ExecutionPlan* plan,
     _options.ascending = !base.get("reverse").getBool();
   }
 
+  if (auto indexCoversProjections = base.get("indexCoversProjections");
+      indexCoversProjections.isBool()) {
+    _indexCoversProjections = indexCoversProjections.getBool();
+  }
+
   VPackSlice indexes = base.get("indexes");
 
   if (!indexes.isArray()) {
@@ -575,7 +580,17 @@ void IndexNode::prepareProjections() {
     return;
   }
 
-  if (idx->covers(_projections)) {
+  auto coversProjections = std::invoke([&]() {
+    if (_indexCoversProjections.has_value()) {
+      // On a DBServer, already got this information from the Coordinator.
+      return *_indexCoversProjections;
+    } else {
+      // On the Coordinator, let's check.
+      return idx->covers(_projections);
+    }
+  });
+
+  if (coversProjections) {
     _projections.setCoveringContext(collection()->id(), idx);
   } else if (this->hasFilter()) {
     // if we have a covering index and a post-filter condition,

--- a/arangod/Aql/IndexNode.cpp
+++ b/arangod/Aql/IndexNode.cpp
@@ -583,7 +583,16 @@ void IndexNode::prepareProjections() {
   auto coversProjections = std::invoke([&]() {
     if (_indexCoversProjections.has_value()) {
       // On a DBServer, already got this information from the Coordinator.
-      return *_indexCoversProjections;
+      if (*_indexCoversProjections) {
+        // Although we have the information, we still need to call covers() for
+        // its side effects, as it sets some _projections fields.
+        auto coveringResult = idx->covers(_projections);
+        TRI_ASSERT(coveringResult)
+            << "Coordinator thinks the index is covering the projections, but "
+               "the DBServer found that it is not.";
+        return coveringResult;
+      }
+      return false;
     } else {
       // On the Coordinator, let's check.
       return idx->covers(_projections);

--- a/arangod/Aql/IndexNode.h
+++ b/arangod/Aql/IndexNode.h
@@ -192,9 +192,8 @@ class IndexNode : public ExecutionNode,
   /// @brief We have single index and this index covered whole condition
   bool _allCoveredByOneIndex;
 
-  /// @brief if the (post) filter condition is fully covered by the index
-  /// attributes
-  bool _indexCoversFilterCondition;
+  /// @brief if the projections are fully covered by the index attributes
+  std::optional<bool> _indexCoversProjections;
 
   /// @brief the index iterator options - same for all indexes
   IndexIteratorOptions _options;


### PR DESCRIPTION
### Scope & Purpose

The purpose of this PR is to **prevent** a bug that has affected 3.10. The bug does not occur in devel, due to changes in optimizer behavior and [projections handling](https://github.com/arangodb/arangodb/pull/17465). However, because the prevention mechanism is pretty simple, it's well worth doing it. In case the projections algorithm ever becomes more pessimistic, this would prevent the bug.
Also, I believe the integration test would be a good addition to our suite.

For an in-depth explanation, see https://github.com/arangodb/arangodb/pull/19864

- [x] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: https://github.com/arangodb/arangodb/pull/19864

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

