### PR TITLE
better reporting for hotbackup errors

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 v3.11.4 (XXXX-XX-XX)
 --------------------
 
+* Slightly extended hot backup release lock timeout on coordinators from 
+  `timeout + 5` seconds to `timeout + 30` seconds, to prevent premature release
+  of hot backup commit locks on coordinators.
+
 * Improve logging in case hot backup locks cannot be taken on coordinators.
 
 * Improve performance of the in-memory cache's memory reclamation procedure.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 v3.11.4 (XXXX-XX-XX)
 --------------------
 
+* Improve logging in case hot backup locks cannot be taken on coordinators.
+
 * Improve performance of the in-memory cache's memory reclamation procedure.
   The previous implementation acquired too many locks, which could drive system
   CPU time up.

--- a/arangod/Cluster/ClusterMethods.cpp
+++ b/arangod/Cluster/ClusterMethods.cpp
@@ -3442,7 +3442,7 @@ arangodb::Result controlMaintenanceFeature(
           network::fuerteToArangoErrorCode(r),
           std::string("Communication error while executing " + command +
                       " maintenance on ") +
-              r.destination);
+              r.destination + ": " + r.combinedResult().errorMessage());
     }
 
     VPackSlice resSlice = r.slice();
@@ -3506,7 +3506,8 @@ arangodb::Result restoreOnDBServers(network::ConnectionPool* pool,
       // oh-oh cluster is in a bad state
       return arangodb::Result(
           network::fuerteToArangoErrorCode(r),
-          std::string("Communication error list backups on ") + r.destination);
+          std::string("Communication error list backups on ") + r.destination +
+              ": " + r.combinedResult().errorMessage());
     }
 
     VPackSlice resSlice = r.slice();
@@ -3800,7 +3801,7 @@ std::vector<std::string> lockPath =
 arangodb::Result lockServersTrxCommit(network::ConnectionPool* pool,
                                       std::string const& backupId,
                                       std::vector<ServerID> const& servers,
-                                      double const& lockWait,
+                                      double lockWait,
                                       std::vector<ServerID>& lockedServers) {
   using namespace std::chrono;
 
@@ -3814,7 +3815,8 @@ arangodb::Result lockServersTrxCommit(network::ConnectionPool* pool,
     VPackObjectBuilder o(&lock);
     lock.add("id", VPackValue(backupId));
     lock.add("timeout", VPackValue(lockWait));
-    lock.add("unlockTimeout", VPackValue(5.0 + lockWait));
+    // unlock timeout for commit lock on coordinator
+    lock.add("unlockTimeout", VPackValue(30.0 + lockWait));
   }
 
   LOG_TOPIC("707ed", DEBUG, Logger::BACKUP)
@@ -3828,10 +3830,9 @@ arangodb::Result lockServersTrxCommit(network::ConnectionPool* pool,
   std::vector<Future<network::Response>> futures;
   futures.reserve(servers.size());
 
-  for (auto const& dbServer : servers) {
-    futures.emplace_back(network::sendRequestRetry(pool, "server:" + dbServer,
-                                                   fuerte::RestVerb::Post, url,
-                                                   body, reqOpts));
+  for (auto const& server : servers) {
+    futures.emplace_back(network::sendRequestRetry(
+        pool, "server:" + server, fuerte::RestVerb::Post, url, body, reqOpts));
   }
 
   // Now listen to the results and report the aggregated final result:
@@ -3856,7 +3857,7 @@ arangodb::Result lockServersTrxCommit(network::ConnectionPool* pool,
     if (r.fail()) {
       reportError(TRI_ERROR_LOCAL_LOCK_FAILED,
                   std::string("Communication error locking transactions on ") +
-                      r.destination);
+                      r.destination + ": " + r.combinedResult().errorMessage());
       continue;
     }
     VPackSlice slc = r.slice();
@@ -4177,9 +4178,9 @@ arangodb::Result removeLocalBackups(network::ConnectionPool* pool,
 std::vector<std::string> const versionPath =
     std::vector<std::string>{"arango", "Plan", "Version"};
 
-arangodb::Result hotbackupAsyncLockDBServersTransactions(
+arangodb::Result hotbackupAsyncLockCoordinatorsTransactions(
     network::ConnectionPool* pool, std::string const& backupId,
-    std::vector<ServerID> const& dbServers, double const& lockWait,
+    std::vector<ServerID> const& coordinators, double const& lockWait,
     std::unordered_map<std::string, std::string>& serverLockIds) {
   std::string const url = apiStr + "lock";
 
@@ -4201,14 +4202,14 @@ arangodb::Result hotbackupAsyncLockDBServersTransactions(
   reqOpts.timeout = network::Timeout(lockWait + 5.0);
 
   std::vector<Future<network::Response>> futures;
-  futures.reserve(dbServers.size());
+  futures.reserve(coordinators.size());
 
-  for (auto const& dbServer : dbServers) {
+  for (auto const& coordinator : coordinators) {
     network::Headers headers;
     headers.emplace(StaticStrings::Async, "store");
     futures.emplace_back(network::sendRequestRetry(
-        pool, "server:" + dbServer, fuerte::RestVerb::Post, url, body, reqOpts,
-        std::move(headers)));
+        pool, "server:" + coordinator, fuerte::RestVerb::Post, url, body,
+        reqOpts, std::move(headers)));
   }
 
   // Perform the requests
@@ -4219,7 +4220,7 @@ arangodb::Result hotbackupAsyncLockDBServersTransactions(
       return arangodb::Result(
           TRI_ERROR_LOCAL_LOCK_FAILED,
           std::string("Communication error locking transactions on ") +
-              r.destination);
+              r.destination + ": " + r.combinedResult().errorMessage());
     }
 
     if (r.statusCode() != 202) {
@@ -4245,7 +4246,7 @@ arangodb::Result hotbackupAsyncLockDBServersTransactions(
   return arangodb::Result();
 }
 
-arangodb::Result hotbackupWaitForLockDBServersTransactions(
+arangodb::Result hotbackupWaitForLockCoordinatorsTransactions(
     network::ConnectionPool* pool, std::string const& backupId,
     std::unordered_map<std::string, std::string>& serverLockIds,
     std::vector<ServerID>& lockedServers, double const& lockWait) {
@@ -4273,7 +4274,7 @@ arangodb::Result hotbackupWaitForLockDBServersTransactions(
       return arangodb::Result(
           TRI_ERROR_LOCAL_LOCK_FAILED,
           std::string("Communication error locking transactions on ") +
-              r.destination);
+              r.destination + ": " + r.combinedResult().errorMessage());
     }
     // continue on 204 No Content
     if (r.statusCode() == 204) {
@@ -4509,6 +4510,9 @@ arangodb::Result hotBackupCoordinator(ClusterFeature& feature,
         unlockServersTrxCommit(pool, backupId, lockedServers);
         lockedServers.clear();
         if (result.is(TRI_ERROR_LOCAL_LOCK_FAILED)) {  // Unrecoverable
+          LOG_TOPIC("99dbe", WARN, Logger::BACKUP)
+              << "unable to lock servers for hot backup: "
+              << result.errorMessage();
           // release the lock
           releaseAgencyLock.fire();
           events::CreateHotbackup(timeStamp + "_" + backupId,
@@ -4524,9 +4528,11 @@ arangodb::Result hotBackupCoordinator(ClusterFeature& feature,
       std::this_thread::sleep_for(milliseconds(300));
     }
 
+    // TODO: the force attribute is still present and offered by arangobackup,
+    // but it can likely be removed nowadays.
     if (!result.ok() && force) {
       // About this code:
-      // it first creates async requests to lock all dbservers.
+      // it first creates async requests to lock all coordinators.
       //    the corresponding lock ids are stored int the map lockJobIds.
       // Then we continously abort all trx while checking all the above jobs
       //    for completion.
@@ -4555,8 +4561,8 @@ arangodb::Result hotBackupCoordinator(ClusterFeature& feature,
             milliseconds(static_cast<uint64_t>(1000 * timeout));
 
       // send the locks
-      result = hotbackupAsyncLockDBServersTransactions(
-          pool, backupId, dbServers, lockWait, lockJobIds);
+      result = hotbackupAsyncLockCoordinatorsTransactions(
+          pool, backupId, serversToBeLocked, lockWait, lockJobIds);
       if (result.fail()) {
         events::CreateHotbackup(timeStamp + "_" + backupId,
                                 result.errorNumber());
@@ -4581,9 +4587,12 @@ arangodb::Result hotBackupCoordinator(ClusterFeature& feature,
         }
 
         // wait for locks, servers that got the lock are removed from lockJobIds
-        result = hotbackupWaitForLockDBServersTransactions(
+        result = hotbackupWaitForLockCoordinatorsTransactions(
             pool, backupId, lockJobIds, lockedServers, lockWait);
         if (result.fail()) {
+          LOG_TOPIC("b6496", WARN, Logger::BACKUP)
+              << "Waiting for hot backup server locks failed: "
+              << result.errorMessage();
           events::CreateHotbackup(timeStamp + "_" + backupId,
                                   result.errorNumber());
           return result;
@@ -4606,7 +4615,7 @@ arangodb::Result hotBackupCoordinator(ClusterFeature& feature,
       result.reset(
           TRI_ERROR_HOT_BACKUP_INTERNAL,
           StringUtils::concatT(
-              "failed to acquire global transaction lock on all db servers: ",
+              "failed to acquire global transaction lock on all coordinators: ",
               result.errorMessage()));
       LOG_TOPIC("b7d09", ERR, Logger::BACKUP) << result.errorMessage();
       events::CreateHotbackup(timeStamp + "_" + backupId, result.errorNumber());
@@ -4626,7 +4635,7 @@ arangodb::Result hotBackupCoordinator(ClusterFeature& feature,
       releaseAgencyLock.fire();
       result.reset(
           TRI_ERROR_HOT_BACKUP_INTERNAL,
-          StringUtils::concatT("failed to hot backup on all db servers: ",
+          StringUtils::concatT("failed to hot backup on all coordinators: ",
                                result.errorMessage()));
       LOG_TOPIC("6b333", ERR, Logger::BACKUP) << result.errorMessage();
       removeLocalBackups(pool, backupId, dbServers, dummy);


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/19866

* Abandon expired local hot backup locks on coordinators a bit later than before. Previously, the timeout was `timeout + 5` seconds on each coordinator. There can be issues when multiple coordinators need to acquire the lock, so that the first coordinator acquires the lock successfully and its unlock clock starts ticking, whereas the subsequent coordinators may need to lock acquire the lock. In this case, the lock on the first coordinators could have been released already, even though the backup hasn't even started. This PR increases the per-coordinator timeout to `timeout + 30` seconds, which improves the situation, but is still not 100% safe.

* Improve logging in case hot backup locks cannot be taken on coordinators.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.11: this PR
  - [x] Backport for 3.10: https://github.com/arangodb/arangodb/pull/19874

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 