### PR TITLE
better reporting for hotbackup errors

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,12 @@
 v3.10.11 (XXXX-XX-XX)
 ---------------------
 
+* Slightly extended hot backup release lock timeout on coordinators from 
+  `timeout + 5` seconds to `timeout + 30` seconds, to prevent premature release
+  of hot backup commit locks on coordinators.
+
+* Improve logging in case hot backup locks cannot be taken on coordinators.
+
 * Added the following metrics to improve observability of the in-memory cache
   subsystem:
   - `rocksdb_cache_free_memory_tasks_total`: total number of `freeMemory`


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/19866

* Abandon expired local hot backup locks on coordinators a bit later than before. Previously, the timeout was `timeout + 5` seconds on each coordinator. There can be issues when multiple coordinators need to acquire the lock, so that the first coordinator acquires the lock successfully and its unlock clock starts ticking, whereas the subsequent coordinators may need to lock acquire the lock. In this case, the lock on the first coordinators could have been released already, even though the backup hasn't even started. This PR increases the per-coordinator timeout to `timeout + 30` seconds, which improves the situation, but is still not 100% safe.

* Improve logging in case hot backup locks cannot be taken on coordinators.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.11: https://github.com/arangodb/arangodb/pull/19873
  - [x] Backport for 3.10: this PR

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 