### PR TITLE
fix assertion failure

### DIFF
--- a/arangod/RocksDBEngine/RocksDBMetaCollection.cpp
+++ b/arangod/RocksDBEngine/RocksDBMetaCollection.cpp
@@ -620,9 +620,13 @@ bool RocksDBMetaCollection::needToPersistRevisionTree(
     rocksdb::SequenceNumber maxCommitSeq,
     std::unique_lock<std::mutex> const& lock) const {
   TRI_ASSERT(lock.owns_lock());
-  TRI_ASSERT(_logicalCollection.useSyncByRevision());
 
-  if (!_revisionTreeCanBeSerialized) {
+  if (!_revisionTreeCanBeSerialized ||
+      !_logicalCollection.useSyncByRevision()) {
+    // note: useSyncByRevision() can return false nowadays once a collection
+    // is marked as deleted. the deletion can even happen while
+    // RocksDBSettingsManager::sync() is running. we can thus ignore all
+    // collections here for which useSyncByRevision() returns false.
     return false;
   }
 


### PR DESCRIPTION
### Scope & Purpose

Fix assertion failure
UseSyncByRevision() can return false nowadays once a collection is marked as deleted. The deletion can even happen while RocksDBSettingsManager::sync() is running. We can thus ignore all collections here for which useSyncByRevision() returns false.
No backports required because the behavior is different in previous versions.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 