### PR TITLE
Projections for JoinNode

### DIFF
--- a/arangod/Aql/JoinExecutor.cpp
+++ b/arangod/Aql/JoinExecutor.cpp
@@ -53,7 +53,6 @@ struct SpanCoveringData : arangodb::IndexIteratorCoveringData {
 auto JoinExecutor::produceRows(AqlItemBlockInputRange& inputRange,
                                OutputAqlItemRow& output)
     -> std::tuple<ExecutorState, Stats, AqlCall> {
-  VPackBuilder projectionsBuilder;
   bool hasMore = false;
   while (inputRange.hasDataRow() && !output.isFull()) {
     if (!_currentRow) {
@@ -96,13 +95,13 @@ auto JoinExecutor::produceRows(AqlItemBlockInputRange& inputRange,
               projections.begin() + projectionsOffset + idx.projections.size()};
 
           auto data = SpanCoveringData{projectionRange};
-          projectionsBuilder.clear();
-          projectionsBuilder.openObject(true);
-          idx.projections.toVelocyPackFromIndex(projectionsBuilder, data,
+          _projectionsBuilder.clear();
+          _projectionsBuilder.openObject(true);
+          idx.projections.toVelocyPackFromIndex(_projectionsBuilder, data,
                                                 &_trx);
-          projectionsBuilder.close();
+          _projectionsBuilder.close();
           output.moveValueInto(_infos.indexes[k].documentOutputRegister,
-                               _currentRow, projectionsBuilder.slice());
+                               _currentRow, _projectionsBuilder.slice());
         }
       }
 

--- a/arangod/Aql/JoinExecutor.h
+++ b/arangod/Aql/JoinExecutor.h
@@ -69,10 +69,12 @@ struct JoinExecutorInfos {
     Collection const* collection;
     // Index handle
     transaction::Methods::IndexHandle index;
+
+    // Values used for projection
+    Projections projections;
   };
 
   std::vector<IndexInfo> indexes;
-  std::vector<RegisterId> projectionOutputRegisters;
   QueryContext* query;
 };
 

--- a/arangod/Aql/JoinExecutor.h
+++ b/arangod/Aql/JoinExecutor.h
@@ -116,6 +116,7 @@ class JoinExecutor {
 
   InputAqlItemRow _currentRow{CreateInvalidInputRowHint()};
   ExecutorState _currentRowState{ExecutorState::HASMORE};
+  velocypack::Builder _projectionsBuilder;
 };
 
 }  // namespace aql

--- a/arangod/Aql/JoinNode.cpp
+++ b/arangod/Aql/JoinNode.cpp
@@ -147,6 +147,8 @@ void JoinNode::doToVelocyPack(VPackBuilder& builder, unsigned flags) const {
     // condition
     builder.add(VPackValue("condition"));
     it.condition->toVelocyPack(builder, flags);
+    // projections
+    it.projections.toVelocyPack(builder);
     // index
     builder.add(VPackValue("index"));
     it.index->toVelocyPack(builder,
@@ -186,10 +188,12 @@ std::unique_ptr<ExecutionBlock> JoinNode::createBlock(
     auto documentOutputRegister = variableToRegisterId(idx.outVariable);
     writableOutputRegisters.emplace(documentOutputRegister);
 
+    // TODO probably those data structures can become one
     auto& data = infos.indexes.emplace_back();
     data.documentOutputRegister = documentOutputRegister;
     data.index = idx.index;
     data.collection = idx.collection;
+    data.projections = idx.projections;
   }
 
   auto registerInfos = createRegisterInfos({}, writableOutputRegisters);

--- a/arangod/Aql/JoinNode.h
+++ b/arangod/Aql/JoinNode.h
@@ -65,6 +65,7 @@ class JoinNode : public ExecutionNode {
     Variable const* outVariable;
     std::unique_ptr<Condition> condition;
     transaction::Methods::IndexHandle index;
+    Projections projections;
   };
 
   JoinNode(ExecutionPlan* plan, ExecutionNodeId id,

--- a/arangod/Aql/OptimizerRules.cpp
+++ b/arangod/Aql/OptimizerRules.cpp
@@ -9233,7 +9233,8 @@ void arangodb::aql::joinIndexNodesRule(Optimizer* opt,
                   JoinNode::IndexInfo{.collection = c->collection(),
                                       .outVariable = c->outVariable(),
                                       .condition = c->condition()->clone(),
-                                      .index = c->getIndexes()[0]});
+                                      .index = c->getIndexes()[0],
+                                      .projections = c->projections()});
               handled.emplace(c);
             }
             JoinNode* jn = plan->createNode<JoinNode>(

--- a/arangod/Aql/OptimizerRules.cpp
+++ b/arangod/Aql/OptimizerRules.cpp
@@ -9091,7 +9091,7 @@ void arangodb::aql::joinIndexNodesRule(Optimizer* opt,
         return false;
       }
 
-      if (index->fields().size() != 1) {
+      if (index->fields().empty()) {
         // index on more than one attribute
         return false;
       }

--- a/arangod/RocksDBEngine/RocksDBVPackIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBVPackIndex.cpp
@@ -2924,7 +2924,7 @@ struct RocksDBVPackStreamIterator final : AqlIndexStreamIterator {
       if (idx >= _options.keyPrefixSize) {
         break;
       }
-      into[idx] = k;
+      into[idx++] = k;
     }
   }
 

--- a/arangod/RocksDBEngine/RocksDBVPackIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBVPackIndex.cpp
@@ -2949,7 +2949,6 @@ struct RocksDBVPackStreamIterator final : AqlIndexStreamIterator {
       auto valueSlice =
           isUnique ? RocksDBValue::uniqueIndexStoredValues(_iterator->value())
                    : RocksDBValue::indexStoredValues(_iterator->value());
-
       for (auto pos : _options.projectedStoredValues) {
         projections[idx++] = valueSlice.at(pos);
       }

--- a/js/common/modules/@arangodb/aql/explainer.js
+++ b/js/common/modules/@arangodb/aql/explainer.js
@@ -1364,7 +1364,7 @@ function processQuery(query, explain, planIndex) {
           info.index.condition = condition;
           iterateIndexes(info.index, 0, {id: node.id, collection: info.collection}, types, false); 
         });
-        return keyword('JOIN'); 
+        return keyword('JOIN');
       case 'IndexNode':
         collectionVariables[node.outVariable.id] = node.collection;
         if (node.filter) {
@@ -2134,6 +2134,9 @@ function processQuery(query, explain, planIndex) {
         let filter = '';
         if (info.condition && info.condition.hasOwnProperty('type')) {
           filter = '   ' + keyword('FILTER') + ' ' + buildExpression(info.condition);
+        }
+        if (info.projections) {
+          filter = '   ' + projections(info, "projections", "projections");
         }
         line += indent(level, false) + label + filter;
         stringBuilder.appendLine(line);

--- a/tests/js/server/aql/aql-index-join-noncluster.js
+++ b/tests/js/server/aql/aql-index-join-noncluster.js
@@ -174,6 +174,26 @@ const IndexJoinTestSuite = function () {
         assertEqual(a.x, b.x);
       }
     },
+
+    testProjections: function () {
+      const A = fillCollection("A", singleAttributeGenerator(10, "x", x => 0));
+      A.ensureIndex({type: "persistent", fields: ["x"]});
+      const B = fillCollection("B", singleAttributeGenerator(10, "x", x => 0));
+      B.ensureIndex({type: "persistent", fields: ["x"]});
+
+      const result = runAndCheckQuery(`
+        FOR doc1 IN A
+          SORT doc1.x
+          FOR doc2 IN B
+              FILTER doc1.x == doc2.x
+              RETURN [doc1.x, doc2.x]
+      `);
+
+      assertEqual(result.length, 100);
+      for (const [a, b] of result) {
+        assertEqual(a, b);
+      }
+    },
 /*
     testMultipleJoins: function () {
       const A = fillCollection("A", singleAttributeGenerator(1000, "x", x => x));

--- a/tests/js/server/aql/aql-index-join-noncluster.js
+++ b/tests/js/server/aql/aql-index-join-noncluster.js
@@ -206,9 +206,29 @@ const IndexJoinTestSuite = function () {
       }
     },
 
-    testProjections2: function () {
+    testProjectionsFromStoredValue: function () {
       const A = fillCollection("A", attributeGenerator(10, {x: x => x, y: x => 2 * x}));
       A.ensureIndex({type: "persistent", fields: ["x"], storedValues: ["y"]});
+      const B = fillCollection("B", singleAttributeGenerator(10, "x", x => x));
+      B.ensureIndex({type: "persistent", fields: ["x"]});
+
+      const result = runAndCheckQuery(`
+        FOR doc1 IN A
+          SORT doc1.x
+          FOR doc2 IN B
+              FILTER doc1.x == doc2.x
+              RETURN [doc1.y, doc2.x]
+      `);
+
+      assertEqual(result.length, 10);
+      for (const [a, b] of result) {
+        assertEqual(a, 2 * b);
+      }
+    },
+
+    testProjectionsFromKeyField: function () {
+      const A = fillCollection("A", attributeGenerator(10, {x: x => x, y: x => 2 * x}));
+      A.ensureIndex({type: "persistent", fields: ["x", "y"]});
       const B = fillCollection("B", singleAttributeGenerator(10, "x", x => x));
       B.ensureIndex({type: "persistent", fields: ["x"]});
 


### PR DESCRIPTION
### Scope & Purpose
This PR adds support for projections to the JoinNode/JoinExecutor. Now it can handle queries like
```
for doc1 in c1
     sort doc1.c
     for doc2 in c2
          filter doc1.x == doc2.y
          return [doc1.x, doc2.y]
```
without loading the documents. It should have support for stored values already, but this I haven't tested yet.