### PR TITLE
avoid duplicate creation of edge AqlValues

### DIFF
--- a/arangod/Graph/Cache/RefactoredTraverserCache.cpp
+++ b/arangod/Graph/Cache/RefactoredTraverserCache.cpp
@@ -175,7 +175,6 @@ bool RefactoredTraverserCache::appendEdge(EdgeDocumentToken const& idToken,
                   } else {
                     result = aql::AqlValue(edge);
                   }
-                  result = aql::AqlValue(edge);
                 } else if constexpr (std::is_same_v<ResultType,
                                                     velocypack::Builder>) {
                   if (!_edgeProjections.empty()) {


### PR DESCRIPTION
### Scope & Purpose

Performance optimization: 
Avoid duplicate creation of edge AqlValues inside single-server- or DB-server-based traversals. 
The previous version of the code always built the AqlValue container for the edge data twice, both when no projections were used and when projections were used. when projections were used, the result value was always reverted to the full edge, e.g. the projections optimization was not used.

Backport of https://github.com/arangodb/arangodb/pull/19889

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [x] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.11: https://github.com/arangodb/arangodb/pull/19894
  - [x] Backport for 3.10: this PR

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 