### PR TITLE
Fix updating of collection properties when there are views

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 v3.11.4 (XXXX-XX-XX)
 --------------------
 
+* Fix updating of collection properties (schema) when the collection has a
+  view on top.
+
 * Slightly extended hot backup release lock timeout on coordinators from
   `timeout + 5` seconds to `timeout + 30` seconds, to prevent premature release
   of hot backup commit locks on coordinators.

--- a/arangod/ClusterEngine/ClusterCollection.cpp
+++ b/arangod/ClusterEngine/ClusterCollection.cpp
@@ -143,7 +143,8 @@ Result ClusterCollection::updateProperties(velocypack::Slice slice) {
     // note: we have to exclude inverted indexes here,
     // as they are a different class type (no relationship to
     // ClusterIndex).
-    if (idx->type() != Index::TRI_IDX_TYPE_INVERTED_INDEX) {
+    if (idx->type() != Index::TRI_IDX_TYPE_INVERTED_INDEX &&
+        idx->type() != Index::TRI_IDX_TYPE_IRESEARCH_LINK) {
       TRI_ASSERT(dynamic_cast<ClusterIndex*>(idx.get()) != nullptr);
       std::static_pointer_cast<ClusterIndex>(idx)->updateProperties(
           _info.slice());


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/19900

* Fix updating of collection properties (schema) when the collection has a view on top.

Fixes https://arangodb.atlassian.net/browse/OASIS-25523

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [x] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.11: this PR
  - [x] Backport for 3.10: https://github.com/arangodb/arangodb/pull/19899

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [x] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/OASIS-25523
- [ ] Design document: 