### PR TITLE
Fix updating of collection properties when there are views

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,8 +1,8 @@
 v3.10.11 (XXXX-XX-XX)
 ---------------------
 
-* Fix updating of collection properties (schema) when the collection has a
-  view on top.
+* Fix updating of collection properties (schema) when the collection has a view
+  on top.
 
 * FE-323: allow 'nested' property in view JSON UI.
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 v3.10.11 (XXXX-XX-XX)
 ---------------------
 
+* Fix updating of collection properties (schema) when the collection has a
+  view on top.
+
 * FE-323: allow 'nested' property in view JSON UI.
 
 * FE-317: add graph name validations.

--- a/arangod/ClusterEngine/ClusterCollection.cpp
+++ b/arangod/ClusterEngine/ClusterCollection.cpp
@@ -159,7 +159,8 @@ Result ClusterCollection::updateProperties(VPackSlice const& slice,
     // note: we have to exclude inverted indexes here,
     // as they are a different class type (no relationship to
     // ClusterIndex).
-    if (idx->type() != Index::TRI_IDX_TYPE_INVERTED_INDEX) {
+    if (idx->type() != Index::TRI_IDX_TYPE_INVERTED_INDEX &&
+        idx->type() != Index::TRI_IDX_TYPE_IRESEARCH_LINK) {
       TRI_ASSERT(dynamic_cast<ClusterIndex*>(idx.get()) != nullptr);
       static_cast<ClusterIndex*>(idx.get())->updateProperties(_info.slice());
     }

--- a/tests/js/common/shell/shell-index.js
+++ b/tests/js/common/shell/shell-index.js
@@ -1635,11 +1635,56 @@ function ParallelIndexSuite() {
   };
 }
 
+function IndexUpdateSuite() {
+  'use strict';
+
+  return {
+
+    setUp: function() {
+      internal.db._drop(cn);
+      internal.db._create(cn, { replicationFactor: 2 });
+    },
+
+    tearDown: function() {
+      internal.db._drop(cn);
+    },
+
+    testUpdateCollectionPropertiesWithView: function() {
+      let view = internal.db._createView(cn + "View", "arangosearch", {});
+
+      try {
+        view.properties({ links: { [cn] : { includeAllFields: true } } });
+
+        const schema = {
+          rule: { 
+            properties: { nums: { type: "array", items: { type: "number", maximum: 6 } } }, 
+            additionalProperties: { type: "string" },
+            required: ["nums"]
+          },
+          level: "moderate",
+          message: "The document does not contain an array of numbers in attribute 'nums', or one of the numbers is greater than 6."
+        };
+
+        internal.db[cn].properties({ cacheEnabled: true, schema }); 
+
+        let props = internal.db[cn].properties();
+        assertTrue(props.cacheEnabled);
+        let s = props.schema;
+        delete s.type;
+        assertEqual(schema, s);
+      } finally {
+        internal.db._dropView(cn + "View");
+      }
+    }
+  };
+}
+
 jsunity.run(IndexSuite);
 jsunity.run(GetIndexesSuite);
 jsunity.run(GetIndexesEdgesSuite);
 jsunity.run(DuplicateValuesSuite);
 jsunity.run(MultiIndexRollbackSuite);
 jsunity.run(ParallelIndexSuite);
+jsunity.run(IndexUpdateSuite);
 
 return jsunity.done();


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/19900

* Fix updating of collection properties (schema) when the collection has a view on top.

Fixes https://arangodb.atlassian.net/browse/OASIS-25523

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [x] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.11: https://github.com/arangodb/arangodb/pull/19897
  - [x] Backport for 3.10: this PR

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [x] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/OASIS-25523
- [ ] Design document: 