### PR TITLE
Add document projections for join nodes.

### DIFF
--- a/tests/js/server/aql/aql-index-join-noncluster.js
+++ b/tests/js/server/aql/aql-index-join-noncluster.js
@@ -245,6 +245,26 @@ const IndexJoinTestSuite = function () {
         assertEqual(a, 2 * b);
       }
     },
+
+    testProjectionsFromDocument: function () {
+      const A = fillCollection("A", attributeGenerator(10, {x: x => x, y: x => 2 * x}));
+      A.ensureIndex({type: "persistent", fields: ["x"]});
+      const B = fillCollection("B", singleAttributeGenerator(10, "x", x => x));
+      B.ensureIndex({type: "persistent", fields: ["x"]});
+
+      const result = runAndCheckQuery(`
+        FOR doc1 IN A
+          SORT doc1.x
+          FOR doc2 IN B
+              FILTER doc1.x == doc2.x
+              RETURN [doc1.y, doc2.x]
+      `);
+
+      assertEqual(result.length, 10);
+      for (const [a, b] of result) {
+        assertEqual(a, 2 * b);
+      }
+    },
     /*
         testMultipleJoins: function () {
           const A = fillCollection("A", singleAttributeGenerator(1000, "x", x => x));

--- a/tests/js/server/aql/aql-index-join-noncluster.js
+++ b/tests/js/server/aql/aql-index-join-noncluster.js
@@ -74,25 +74,27 @@ const IndexJoinTestSuite = function () {
     };
   };
 
-  const runAndCheckQuery = function (query) {
-    const opts = {
-      optimizer: {
-        rules: ["+join-index-nodes"]
-      },
-      maxNumberOfPlans: 1
-    };
+  const queryOptions = {
+    optimizer: {
+      rules: ["+join-index-nodes"]
+    },
+    maxNumberOfPlans: 1
+  };
 
-    const plan = AQL_EXPLAIN(query, null, opts).plan;
+
+  const runAndCheckQuery = function (query) {
+
+    const plan = AQL_EXPLAIN(query, null, queryOptions).plan;
     let planNodes = plan.nodes.map(function (node) {
       return node.type;
     });
 
     if (planNodes.indexOf("JoinNode") === -1) {
-      db._explain(query, null, opts);
+      db._explain(query, null, queryOptions);
     }
     assertNotEqual(planNodes.indexOf("JoinNode"), -1);
 
-    const result = AQL_EXECUTE(query, null, opts);
+    const result = AQL_EXECUTE(query, null, queryOptions);
     return result.json;
   };
 
@@ -192,13 +194,23 @@ const IndexJoinTestSuite = function () {
       const B = fillCollection("B", singleAttributeGenerator(10, "x", x => 0));
       B.ensureIndex({type: "persistent", fields: ["x"]});
 
-      const result = runAndCheckQuery(`
+      const query = `
         FOR doc1 IN A
           SORT doc1.x
           FOR doc2 IN B
               FILTER doc1.x == doc2.x
               RETURN [doc1.x, doc2.x]
-      `);
+      `;
+
+      const plan = AQL_EXPLAIN(query, null, queryOptions).plan;
+      const join = plan.nodes[1];
+
+      assertEqual(join.type, "JoinNode");
+
+      assertEqual(join.indexInfos[0].projections, ["x"]);
+      assertEqual(join.indexInfos[1].projections, ["x"]);
+
+      const result = runAndCheckQuery(query);
 
       assertEqual(result.length, 100);
       for (const [a, b] of result) {
@@ -212,13 +224,23 @@ const IndexJoinTestSuite = function () {
       const B = fillCollection("B", singleAttributeGenerator(10, "x", x => x));
       B.ensureIndex({type: "persistent", fields: ["x"]});
 
-      const result = runAndCheckQuery(`
+      const query = `
         FOR doc1 IN A
           SORT doc1.x
           FOR doc2 IN B
               FILTER doc1.x == doc2.x
               RETURN [doc1.y, doc2.x]
-      `);
+      `;
+
+      const plan = AQL_EXPLAIN(query, null, queryOptions).plan;
+      const join = plan.nodes[1];
+
+      assertEqual(join.type, "JoinNode");
+
+      assertEqual(join.indexInfos[0].projections, ["x", "y"]);
+      assertEqual(join.indexInfos[1].projections, ["x"]);
+
+      const result = runAndCheckQuery(query);
 
       assertEqual(result.length, 10);
       for (const [a, b] of result) {
@@ -232,13 +254,23 @@ const IndexJoinTestSuite = function () {
       const B = fillCollection("B", singleAttributeGenerator(10, "x", x => x));
       B.ensureIndex({type: "persistent", fields: ["x"]});
 
-      const result = runAndCheckQuery(`
+      const query = `
         FOR doc1 IN A
           SORT doc1.x
           FOR doc2 IN B
               FILTER doc1.x == doc2.x
               RETURN [doc1.y, doc2.x]
-      `);
+      `;
+
+      const plan = AQL_EXPLAIN(query, null, queryOptions).plan;
+      const join = plan.nodes[1];
+
+      assertEqual(join.type, "JoinNode");
+
+      assertEqual(join.indexInfos[0].projections, ["x", "y"]);
+      assertEqual(join.indexInfos[1].projections, ["x"]);
+
+      const result = runAndCheckQuery(query);
 
       assertEqual(result.length, 10);
       for (const [a, b] of result) {
@@ -252,13 +284,23 @@ const IndexJoinTestSuite = function () {
       const B = fillCollection("B", singleAttributeGenerator(10, "x", x => x));
       B.ensureIndex({type: "persistent", fields: ["x"]});
 
-      const result = runAndCheckQuery(`
+      const query = `
         FOR doc1 IN A
           SORT doc1.x
           FOR doc2 IN B
               FILTER doc1.x == doc2.x
               RETURN [doc1.y, doc2.x]
-      `);
+      `;
+
+      const plan = AQL_EXPLAIN(query, null, queryOptions).plan;
+      const join = plan.nodes[1];
+
+      assertEqual(join.type, "JoinNode");
+
+      assertEqual(join.indexInfos[0].projections, ["x", "y"]);
+      assertEqual(join.indexInfos[1].projections, ["x"]);
+
+      const result = runAndCheckQuery(query);
 
       assertEqual(result.length, 10);
       for (const [a, b] of result) {


### PR DESCRIPTION
### Scope & Purpose
The projections PR only added projections for values from the index. But arangodb assumes that we also support projections from documents. 