### PR TITLE
[CINFRA-851] Fixing DropIndex test

### DIFF
--- a/js/common/modules/@arangodb/testutils/document-state-helper.js
+++ b/js/common/modules/@arangodb/testutils/document-state-helper.js
@@ -296,7 +296,7 @@ const getCollectionShardsAndLogs = function (db, collection) {
 
 const isIndexInCurrent = function (database, collectionId, indexId) {
   const shards = lh.readAgencyValueAt(`Current/Collections/${database}/${collectionId}`);
-  return Object.values(shards).every(shard => shard.indexes.some(index => index.id === indexId));
+  return Object.values(shards).some(shard => shard.indexes.some(index => index.id === indexId));
 };
 
 exports.getLocalValue = getLocalValue;

--- a/tests/js/server/replication2/replication2-replicated-state-document-store.js
+++ b/tests/js/server/replication2/replication2-replicated-state-document-store.js
@@ -973,7 +973,7 @@ const replicatedStateDocumentShardsSuite = function () {
   const indexTestHelper = function (unique, inBackground) {
     return () => {
       let collection = db._create(collectionName, {numberOfShards: 2, writeConcern: 3, replicationFactor: 3});
-      let {logs} = dh.getCollectionShardsAndLogs(db, collection);
+      let {shardsToLogs, logs} = dh.getCollectionShardsAndLogs(db, collection);
 
       // Create an index.
       let index = collection.ensureIndex({
@@ -988,6 +988,7 @@ const replicatedStateDocumentShardsSuite = function () {
       if (unique) {
         assertTrue(index.unique);
       }
+      const indexId = index.id.split('/')[1];
 
       // Check if the CreateIndex operation appears in the log.
       for (let log of logs) {
@@ -995,9 +996,6 @@ const replicatedStateDocumentShardsSuite = function () {
         assertTrue(dh.getOperationsByType(logContents, "CreateIndex").length > 0,
           `CreateIndex not found! Contents of log ${log.id()}: ${JSON.stringify(logContents)}`);
       }
-
-      const indexId = index.id.split('/')[1];
-      const shardsToLogs = lh.getShardsToLogsMapping(database, collection._id);
 
       // Check that the newly created index is available on all participants.
       for (const [shard, log] of Object.entries(shardsToLogs)) {


### PR DESCRIPTION
### Scope & Purpose

After we drop an index, we expect the `DropIndex` log entry to be replicated. However, we can only know for sure that this happened once the index is removed from the `Current` entry of the shard. Before, in `isIndexInCurrent` we used `Object.values(shards).every(...)`, which checks that every shard still has the index. However, some shards may remove the index before others, so using `every` is prone to errors. We have to use `some` instead, which signals that the index is still in `Current` even if if that's true for only one shard.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
