### PR TITLE
Enable Join Rule

### DIFF
--- a/arangod/Aql/OptimizerRulesFeature.cpp
+++ b/arangod/Aql/OptimizerRulesFeature.cpp
@@ -796,11 +796,10 @@ optimizations.)");
 
   // replace adjacent index nodes with a join node if the indexes qualify
   // for it.
-  registerRule(
-      "join-index-nodes", joinIndexNodesRule, OptimizerRule::joinIndexNodesRule,
-      OptimizerRule::makeFlags(OptimizerRule::Flags::CanBeDisabled,
-                               OptimizerRule::Flags::DisabledByDefault),
-      R"(Join adjacent index nodes and replace them with a join node
+  registerRule("join-index-nodes", joinIndexNodesRule,
+               OptimizerRule::joinIndexNodesRule,
+               OptimizerRule::makeFlags(OptimizerRule::Flags::CanBeDisabled),
+               R"(Join adjacent index nodes and replace them with a join node
 in case the indexes qualify for it.)");
 
   // allow nodes to asynchronously prefetch the next batch while processing the

--- a/tests/js/server/aql/aql-optimizer-stats-noncluster.js
+++ b/tests/js/server/aql/aql-optimizer-stats-noncluster.js
@@ -79,7 +79,7 @@ function optimizerStatsTestSuite () {
 
       assertEqual(2, stats.plansCreated);
       assertNotEqual(0, stats.rulesExecuted);
-      assertEqual(1, stats.rulesSkipped);
+      assertEqual(0, stats.rulesSkipped);
     },
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -95,7 +95,7 @@ function optimizerStatsTestSuite () {
       assertTrue(stats.hasOwnProperty("rulesSkipped"));
 
       assertEqual(1, stats.plansCreated);
-      assertNotEqual(0, stats.rulesExecuted);
+      assertNotEqual(1, stats.rulesExecuted);
       assertEqual(1, stats.rulesSkipped);
     },
 

--- a/tests/js/server/aql/aql-optimizer-stats-noncluster.js
+++ b/tests/js/server/aql/aql-optimizer-stats-noncluster.js
@@ -62,7 +62,7 @@ function optimizerStatsTestSuite () {
 
       assertEqual(1, stats.plansCreated);
       assertNotEqual(0, stats.rulesExecuted);
-      assertEqual(1, stats.rulesSkipped);
+      assertEqual(0, stats.rulesSkipped);
     },
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -79,7 +79,7 @@ function optimizerStatsTestSuite () {
 
       assertEqual(2, stats.plansCreated);
       assertNotEqual(0, stats.rulesExecuted);
-      assertEqual(2, stats.rulesSkipped);
+      assertEqual(1, stats.rulesSkipped);
     },
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -96,7 +96,7 @@ function optimizerStatsTestSuite () {
 
       assertEqual(1, stats.plansCreated);
       assertNotEqual(0, stats.rulesExecuted);
-      assertEqual(2, stats.rulesSkipped);
+      assertEqual(1, stats.rulesSkipped);
     },
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
### Scope & Purpose
The Join rule is currently disabled by default. To use the join node, it has to be explicitly enabled.

This PR changes this behavior.  As a consequence of this, some queries in the tests will be optimized differently.