### PR TITLE
Build without V8 on CircleCI

### DIFF
--- a/.circleci/base_config.yml
+++ b/.circleci/base_config.yml
@@ -418,6 +418,16 @@ workflows:
           enterprise: true
           publish-artifacts: false
           build-tests: false
+      - compile-linux:
+          context:
+            - sccache-aws-bucket # add the environment variables to setup sccache for the S3 bucket
+          resource-class: xlarge
+          name: build-ee-non-v8-x64
+          preset: enterprise-pr-non-v8
+          enterprise: true
+          publish-artifacts: false
+          build-tests: false
+
       - run-cppcheck:
           name: cppcheck
           requires:

--- a/.circleci/base_config.yml
+++ b/.circleci/base_config.yml
@@ -423,7 +423,7 @@ workflows:
             - sccache-aws-bucket # add the environment variables to setup sccache for the S3 bucket
           resource-class: xlarge
           name: build-ee-non-v8-x64
-          preset: enterprise-pr-non-v8
+          preset: enterprise-pr-no-v8
           enterprise: true
           publish-artifacts: false
           build-tests: false

--- a/.circleci/base_config.yml
+++ b/.circleci/base_config.yml
@@ -422,7 +422,7 @@ workflows:
           context:
             - sccache-aws-bucket # add the environment variables to setup sccache for the S3 bucket
           resource-class: xlarge
-          name: build-ee-non-v8-x64
+          name: build-ee-no-v8-x64
           preset: enterprise-pr-no-v8
           enterprise: true
           publish-artifacts: false

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -282,12 +282,20 @@
       "configurePreset": "community-pr"
     },
     {
+      "name": "community-pr-no-v8",
+      "configurePreset": "community-pr-no-v8"
+    },
+    {
       "name": "community-pr-non-maintainer",
       "configurePreset": "community-pr-non-maintainer"
     },
     {
       "name": "enterprise-pr",
       "configurePreset": "enterprise-pr"
+    },
+    {
+      "name": "enterprise-pr-no-v8",
+      "configurePreset": "enterprise-pr-no-v8"
     },
     {
       "name": "enterprise-pr-non-maintainer",

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -147,6 +147,15 @@
       "displayName": "PR Build ArangoDB Community Edition"
     },
     {
+      "name": "community-pr-no-v8",
+      "inherits": [
+        "pr",
+        "community",
+				"no-v8"
+      ],
+      "displayName": "PR Build ArangoDB Community Edition (without V8)"
+    },
+    {
       "name": "community-pr",
       "inherits": [
         "maintainer",
@@ -155,11 +164,11 @@
       "displayName": "PR Build ArangoDB Community Edition Maintainer Mode"
     },
     {
-      "name": "enterprise-pr-non-v8",
+      "name": "enterprise-pr-no-v8",
       "inherits": [
         "pr",
         "enterprise",
-				"non-v8"
+				"no-v8"
       ],
       "displayName": "PR Build ArangoDB Enterprise Edition (without V8)"
     },

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -102,6 +102,13 @@
       }
     },
     {
+      "hidden": true,
+      "name": "no-v8",
+      "cacheVariables": {
+        "USE_V8": "Off"
+      }
+    },
+    {
       "name": "community",
       "inherits": "release-base",
       "displayName": "Build ArangoDB Community Edition (Release Build)",
@@ -146,6 +153,15 @@
         "community-pr-non-maintainer"
       ],
       "displayName": "PR Build ArangoDB Community Edition Maintainer Mode"
+    },
+    {
+      "name": "enterprise-pr-non-v8",
+      "inherits": [
+        "pr",
+        "enterprise",
+				"non-v8"
+      ],
+      "displayName": "PR Build ArangoDB Enterprise Edition (without V8)"
     },
     {
       "name": "enterprise-pr-non-maintainer",


### PR DESCRIPTION
### Scope & Purpose

Adds building without V8 which was added in ~#19879~ #19907 to CircleCI to prevent bitrot.