### PR TITLE
Traversal improvements

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,11 @@
 devel
 -----
 
+* Support pulling more complex FILTER conditions into traversals.
+  Previously, filter conditions that contained logical ORs were not pulled
+  into traversals. Now such filter conditions can be pulled into traversals
+  too.
+
 * Fix updating of collection properties (schema) when the collection has a
   view on top.
 

--- a/arangod/Aql/Expression.cpp
+++ b/arangod/Aql/Expression.cpp
@@ -1265,8 +1265,6 @@ AqlValue Expression::executeSimpleExpressionNaryAndOr(ExpressionContext& ctx,
     }
   }
 
-  // anything else... we shouldn't get here
-  TRI_ASSERT(false);
   return AqlValue(AqlValueHintBool(false));
 }
 

--- a/arangod/Aql/InAndOutRowExpressionContext.cpp
+++ b/arangod/Aql/InAndOutRowExpressionContext.cpp
@@ -121,15 +121,15 @@ AqlValue InAndOutRowExpressionContext::getVariableValue(
       });
 }
 
-bool InAndOutRowExpressionContext::needsVertexValue() const {
+bool InAndOutRowExpressionContext::needsVertexValue() const noexcept {
   return _vertexVarIdx < _regs.size();
 }
 
-bool InAndOutRowExpressionContext::needsEdgeValue() const {
+bool InAndOutRowExpressionContext::needsEdgeValue() const noexcept {
   return _edgeVarIdx < _regs.size();
 }
 
-bool InAndOutRowExpressionContext::needsPathValue() const {
+bool InAndOutRowExpressionContext::needsPathValue() const noexcept {
   return _pathVarIdx < _regs.size();
 }
 

--- a/arangod/Aql/InAndOutRowExpressionContext.h
+++ b/arangod/Aql/InAndOutRowExpressionContext.h
@@ -57,9 +57,9 @@ class InAndOutRowExpressionContext final : public QueryExpressionContext {
   AqlValue getVariableValue(Variable const* variable, bool doCopy,
                             bool& mustDestroy) const override;
 
-  bool needsVertexValue() const;
-  bool needsEdgeValue() const;
-  bool needsPathValue() const;
+  bool needsVertexValue() const noexcept;
+  bool needsEdgeValue() const noexcept;
+  bool needsPathValue() const noexcept;
 
   /// @brief inject the result value when asked for the Vertex data
   /// This will not copy ownership of slice content. caller needs to make sure

--- a/arangod/Aql/OptimizerRules.cpp
+++ b/arangod/Aql/OptimizerRules.cpp
@@ -6503,8 +6503,7 @@ void arangodb::aql::removeFiltersCoveredByTraversal(
             if (outVariable == nullptr) {
               return false;
             }
-            if (varsUsedByCondition.find(outVariable) ==
-                varsUsedByCondition.end()) {
+            if (!varsUsedByCondition.contains(outVariable)) {
               return false;
             }
 

--- a/arangod/Aql/PruneExpressionEvaluator.h
+++ b/arangod/Aql/PruneExpressionEvaluator.h
@@ -39,6 +39,9 @@ class Expression;
 class QueryContext;
 class InputAqlItemRow;
 
+// in contrast to its name, the PruneExpressionEvaluator is used to
+// compute both the results of PRUNE expressions and inline traversal
+// FILTER conditions.
 class PruneExpressionEvaluator {
  public:
   PruneExpressionEvaluator(transaction::Methods& trx, QueryContext& query,
@@ -56,15 +59,15 @@ class PruneExpressionEvaluator {
   }
   void unPrepareContext() { _ctx.invalidateInputRow(); }
 
-  bool needsVertex() const { return _ctx.needsVertexValue(); }
+  bool needsVertex() const noexcept { return _ctx.needsVertexValue(); }
   void injectVertex(velocypack::Slice v) { _ctx.setVertexValue(v); }
-  bool needsEdge() const { return _ctx.needsEdgeValue(); }
+  bool needsEdge() const noexcept { return _ctx.needsEdgeValue(); }
   void injectEdge(velocypack::Slice e) { _ctx.setEdgeValue(e); }
-  bool needsPath() const { return _ctx.needsPathValue(); }
+  bool needsPath() const noexcept { return _ctx.needsPathValue(); }
   void injectPath(velocypack::Slice p) { _ctx.setPathValue(p); }
 
  private:
-  /// @brief The condition given in PRUNE (might be empty)
+  /// @brief The condition given in PRUNE or inline FILTER (might be empty)
   ///        The Node keeps responsibility
   aql::Expression* _pruneExpression;
 

--- a/arangod/Aql/TraversalConditionFinder.h
+++ b/arangod/Aql/TraversalConditionFinder.h
@@ -27,8 +27,8 @@
 #include "Aql/ExecutionNode.h"
 #include "Aql/WalkerWorker.h"
 
-namespace arangodb {
-namespace aql {
+namespace arangodb::aql {
+class TraversalNode;
 
 /// @brief Traversal condition finder
 class TraversalConditionFinder final
@@ -43,13 +43,18 @@ class TraversalConditionFinder final
   bool enterSubquery(ExecutionNode*, ExecutionNode*) override final;
 
  private:
+  std::unique_ptr<Condition> optimizeForNode(TraversalNode* node,
+                                             bool& conditionIsImpossible);
+
   bool isTrueOnNull(AstNode* condition, Variable const* pathVar) const;
 
- private:
+  void ensureCondition();
+  void resetCondition() noexcept;
+  bool haveNonEmptyCondition() const noexcept;
+
   ExecutionPlan* _plan;
   std::unique_ptr<Condition> _condition;
   ::arangodb::containers::HashSet<VariableId> _filterVariables;
   bool* _planAltered;
 };
-}  // namespace aql
-}  // namespace arangodb
+}  // namespace arangodb::aql

--- a/tests/js/server/aql/aql-optimizer-rule-optimize-traversals-spec.js
+++ b/tests/js/server/aql/aql-optimizer-rule-optimize-traversals-spec.js
@@ -156,9 +156,6 @@ describe('Rule optimize-traversals', () => {
       FILTER p.edges[-1].theTruth == true
       RETURN {v:v,e:e,p:p}`,
       `FOR v, e, p IN 1..5 OUTBOUND 'circles/A' GRAPH '${graphName}'
-      FILTER p.edges[*].theTruth == true or p.edges[1].label == 'bar'
-      RETURN {v:v,e:e,p:p}`,
-      `FOR v, e, p IN 1..5 OUTBOUND 'circles/A' GRAPH '${graphName}'
       FILTER p.edges[RAND()].theFalse == false
       RETURN {v:v,e:e,p:p}`,
       `FOR v, e, p IN 1..5 OUTBOUND 'circles/A' GRAPH '${graphName}'
@@ -196,6 +193,9 @@ describe('Rule optimize-traversals', () => {
       `FOR v, e, p IN 1..5 OUTBOUND 'circles/A' GRAPH '${graphName}'
       FILTER p.edges[0].theTruth == true FILTER p.edges[1].label == 'bar'
       RETURN {v,e,p}`,
+      `FOR v, e, p IN 1..5 OUTBOUND 'circles/A' GRAPH '${graphName}'
+      FILTER p.edges[*].theTruth == true or p.edges[1].label == 'bar'
+      RETURN {v:v,e:e,p:p}`,
       `FOR snippet IN ['a', 'b']
       LET test = CONCAT(snippet, 'ar')
       FOR v, e, p IN 1..5 OUTBOUND 'circles/A' GRAPH '${graphName}'


### PR DESCRIPTION
### Scope & Purpose

* Support pulling more complex FILTER conditions into traversals. Previously, filter conditions that contained logical ORs were not pulled into traversals. Now such filter conditions can be pulled into traversals too.

* Improve traversal performance of pruning/post-filtering by recycling Builder objects upon repeated evaluation of prune/filter conditions.

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [x] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 