### PR TITLE
enable extended names by default

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,22 @@
 devel
 -----
 
+* Change default value for `--database.extended-names` from `false` to `true`.
+  This will allow end users to use Unicode characters inside database names,
+  collection names, view names and index names by default, unless the
+  functionality is explicitly turned off.
+
+  Note: once a server in the deployment has been started with the flag set
+  to `true`, it will store that setting permanently. Switching the startup
+  option back to `false` will raise a warning about the option change at
+  startup, but not block the startup. Existing databases, collections, views
+  and indexes with extended names can still be used even with the option set
+  back to `false`, but no new database objects with extended names can be 
+  created with the option set back to `false`. So this state is only meant
+  to facilitate downgrading or reverting the option change. When the option
+  is supposed to be left at a value of `false`, all database objects with
+  extended names that were created in the meantime should be removed manually.
+
 * Fix updating of collection properties (schema) when the collection has a
   view on top.
 

--- a/arangod/Cluster/ClusterInfo.cpp
+++ b/arangod/Cluster/ClusterInfo.cpp
@@ -1048,6 +1048,12 @@ void ClusterInfo::loadPlan() {
       // that validate _existing_ databases. this must not fail.
       info.strictValidation(false);
 
+      // do not validate database names for existing databases.
+      // the rationale is that if a database was already created with
+      // an extended name, we should not declare it invalid and abort
+      // the startup once the extended names option is turned off.
+      info.validateNames(false);
+
       Result res = info.load(dbSlice, VPackSlice::emptyArraySlice());
 
       if (res.fail()) {

--- a/arangod/Cluster/HeartbeatThread.cpp
+++ b/arangod/Cluster/HeartbeatThread.cpp
@@ -1412,6 +1412,11 @@ bool HeartbeatThread::handlePlanChangeCoordinator(uint64_t currentPlanVersion) {
     // we don't want the heartbeat thread to fail here in case some
     // invalid settings are present
     info.strictValidation(false);
+    // do not validate database names for existing databases.
+    // the rationale is that if a database was already created with
+    // an extended name, we should not declare it invalid and abort
+    // the startup once the extended names option is turned off.
+    info.validateNames(false);
     // when loading we allow system database names
     auto infoResult = info.load(options.value, VPackSlice::emptyArraySlice());
     if (infoResult.fail()) {

--- a/arangod/Cluster/ServerState.cpp
+++ b/arangod/Cluster/ServerState.cpp
@@ -711,6 +711,10 @@ bool ServerState::checkNamingConventionsEquality(AgencyComm& comm) {
     auto checkSetting = [](velocypack::Slice servers,
                            std::string_view optionName, std::string_view key,
                            bool localValue) -> bool {
+      bool isFirst = true;
+      bool unequal = false;
+      bool checkFor = true;
+
       for (auto pair : VPackObjectIterator(servers)) {
         if (!pair.value.isObject()) {
           continue;
@@ -722,46 +726,60 @@ bool ServerState::checkNamingConventionsEquality(AgencyComm& comm) {
           continue;
         }
 
+        if (isFirst) {
+          checkFor = setting.isTrue();
+          isFirst = false;
+        } else if (checkFor != setting.isTrue()) {
+          unequal = true;
+          break;
+        }
+
         if (!localValue && setting.isTrue()) {
           // different settings detected:
-          //  stored value ii true, but we are locally setting it to false
-          // bail out!
-          LOG_TOPIC("75972", ERR, arangodb::Logger::STARTUP)
-              << "The usage of different settings for object naming "
-              << "conventions (i.e. `--" << optionName << "` settings) "
-              << "in the cluster is unsupported and may cause follow-up "
-                 "issues. "
-              << "Please unify the settings for the startup option "
-                 "`--"
-              << optionName << "` "
-              << "on all coordinators and DB servers in this cluster.";
-
-          std::string msg;
-          for (auto p : VPackObjectIterator(servers)) {
-            if (!p.value.isObject()) {
-              continue;
-            }
-            VPackSlice s = p.value.get(key);
-            if (!msg.empty()) {
-              msg += ", ";
-            }
-            msg += "[" + p.key.copyString() + ": " +
-                   (s.isBool() ? (s.getBool() ? "true" : "false") : "not set") +
-                   "]";
-          }
-
-          if (!msg.empty()) {
-            LOG_TOPIC("1220d", INFO, arangodb::Logger::STARTUP)
-                << "The following effective settings exist for "
-                   "`--"
-                << optionName << "` "
-                << "for the servers in this cluster, either explicitly "
-                   "configured or persisted on database servers: "
-                << msg;
-          }
-          return false;
+          // stored value is true, but we are locally setting it to false
+          unequal = true;
         }
       }
+
+      if (unequal) {
+        LOG_TOPIC("c12dc", ERR, arangodb::Logger::STARTUP)
+            << "It is unsupported to change the value of the startup "
+               "option `--"
+            << optionName << "`"
+            << " back to `false` after it was set to `true` before, "
+            << "or to use different settings for object naming "
+            << "conventions (i.e. different `--" << optionName << "` settings) "
+            << "in the cluster. This may cause cause follow-up issues. "
+            << "Please remove the setting `--" << optionName
+            << " false` from the startup options, or unify the settings "
+            << "for the startup option `--" << optionName
+            << "` on all coordinators and DB servers in this cluster.";
+
+        std::string msg;
+        for (auto p : VPackObjectIterator(servers)) {
+          if (!p.value.isObject()) {
+            continue;
+          }
+          VPackSlice s = p.value.get(key);
+          if (!msg.empty()) {
+            msg += ", ";
+          }
+          msg += "[" + p.key.copyString() + ": " +
+                 (s.isBool() ? (s.getBool() ? "true" : "false") : "not set") +
+                 "]";
+        }
+
+        if (!msg.empty()) {
+          LOG_TOPIC("1220d", INFO, arangodb::Logger::STARTUP)
+              << "The following effective settings exist for "
+                 "`--"
+              << optionName << "` "
+              << "for the servers in this cluster, either explicitly "
+                 "configured or persisted on database servers: "
+              << msg;
+        }
+      }
+      // start anyway
       return true;
     };
 
@@ -772,8 +790,8 @@ bool ServerState::checkNamingConventionsEquality(AgencyComm& comm) {
     // --database.extended-names
     if (!checkSetting(servers, "database.extended-names", ::extendedNamesKey,
                       df.extendedNames())) {
-      // settings mismatch
-      return false;
+      // settings mismatch. start anyway!
+      return true;
     }
   }
 

--- a/arangod/RestHandler/RestViewHandler.cpp
+++ b/arangod/RestHandler/RestViewHandler.cpp
@@ -270,12 +270,14 @@ void RestViewHandler::modifyView(bool partialUpdate) {
   }
 
   auto name = basics::StringUtils::urlDecode(suffixes[0]);
-  bool extendedNames = server().getFeature<DatabaseFeature>().extendedNames();
-  auto r = ViewNameValidator::validateName(
-      /*allowSystem*/ false, extendedNames, name);
-  if (!r.ok()) {
-    return generateError(r);
-  }
+
+  // bool extendedNames =
+  // server().getFeature<DatabaseFeature>().extendedNames(); auto r =
+  // ViewNameValidator::validateName(
+  //    /*allowSystem*/ false, extendedNames, name);
+  // if (!r.ok()) {
+  //  return generateError(r);
+  //}
 
   CollectionNameResolver resolver{_vocbase};
   auto view = resolver.getView(name);
@@ -292,7 +294,7 @@ void RestViewHandler::modifyView(bool partialUpdate) {
 
   auto& analyzers = server().getFeature<iresearch::IResearchAnalyzerFeature>();
   // First refresh our analyzers cache to see all latest changes in analyzers
-  r = analyzers.loadAvailableAnalyzers(
+  auto r = analyzers.loadAvailableAnalyzers(
       _vocbase.name(), transaction::OperationOriginREST{"modifiying view"});
   if (!r.ok()) {
     return generateError(r);
@@ -323,7 +325,10 @@ void RestViewHandler::modifyView(bool partialUpdate) {
 
   if (isRename) {
     // handle rename functionality
-    r = view->rename(body.copyString());
+    if (view->name() != body.stringView()) {
+      // only carry out an actual name change
+      r = view->rename(body.copyString());
+    }
   } else {
     // handle update functionality
     r = view->properties(body, true, partialUpdate);
@@ -367,18 +372,18 @@ void RestViewHandler::deleteView() {
 
   auto name = arangodb::basics::StringUtils::urlDecode(suffixes[0]);
 
-  if (name.empty() || name[0] < '0' || name[0] > '9') {
-    // not a numeric view id. now validate view name
-    bool extendedNames =
-        _vocbase.server().getFeature<DatabaseFeature>().extendedNames();
-    if (auto res = ViewNameValidator::validateName(
-            /*allowSystem*/ false, extendedNames, name);
-        res.fail()) {
-      generateError(res);
-      events::DropView(_vocbase.name(), name, res.errorNumber());
-      return;
-    }
-  }
+  // if (name.empty() || name[0] < '0' || name[0] > '9') {
+  //  // not a numeric view id. now validate view name
+  //  bool extendedNames =
+  //      _vocbase.server().getFeature<DatabaseFeature>().extendedNames();
+  //  if (auto res = ViewNameValidator::validateName(
+  //          /*allowSystem*/ false, extendedNames, name);
+  //      res.fail()) {
+  //    generateError(res);
+  //    events::DropView(_vocbase.name(), name, res.errorNumber());
+  //    return;
+  //  }
+  //}
 
   auto allowDropSystem =
       _request->parsedValue(StaticStrings::DataSourceSystem, false);

--- a/arangod/RestServer/DatabaseFeature.cpp
+++ b/arangod/RestServer/DatabaseFeature.cpp
@@ -395,15 +395,6 @@ void DatabaseFeature::initCalculationVocbase(ArangodServer& server) {
 }
 
 void DatabaseFeature::start() {
-  if (_extendedNames) {
-    LOG_TOPIC("2c0c6", WARN, arangodb::Logger::FIXME)
-        << "Enabling extended names for databases, collections, view, and "
-           "indexes "
-        << " is an experimental feature which can "
-           "cause incompatibility issues with not-yet-prepared drivers and "
-           "applications - do not use in production!";
-  }
-
 #ifdef USE_V8
   auto& dealer = server().getFeature<V8DealerFeature>();
   if (dealer.isEnabled()) {
@@ -693,12 +684,12 @@ Result DatabaseFeature::createDatabase(CreateDatabaseInfo&& info,
   }
   result = nullptr;
 
-  bool extendedNames = this->extendedNames();
-  if (auto res = DatabaseNameValidator::validateName(/*allowSystem*/ false,
-                                                     extendedNames, name);
-      res.fail()) {
-    return res;
-  }
+  // bool extendedNames = this->extendedNames();
+  // if (auto res = DatabaseNameValidator::validateName(/*allowSystem*/ false,
+  //                                                   extendedNames, name);
+  //    res.fail()) {
+  //  return res;
+  //}
 
   std::unique_ptr<TRI_vocbase_t> vocbase;
 
@@ -1210,14 +1201,22 @@ ErrorCode DatabaseFeature::iterateDatabases(velocypack::Slice databases) {
     // we don't want the server start to fail here in case some
     // invalid settings are present
     info.strictValidation(false);
+
+    // do not validate database names for existing databases.
+    // the rationale is that if a database was already created with
+    // an extended name, we should not declare it invalid and abort
+    // the startup once the extended names option is turned off.
+    info.validateNames(false);
+
     auto res = info.load(it, velocypack::Slice::emptyArraySlice());
 
     if (res.fail()) {
       std::string errorMsg;
       // note: TRI_ERROR_ARANGO_DATABASE_NAME_INVALID should not be
       // used anymore in 3.11 and higher.
-      if (res.is(TRI_ERROR_ARANGO_DATABASE_NAME_INVALID) ||
-          res.is(TRI_ERROR_ARANGO_ILLEGAL_NAME)) {
+      bool isNameError = res.is(TRI_ERROR_ARANGO_DATABASE_NAME_INVALID) ||
+                         res.is(TRI_ERROR_ARANGO_ILLEGAL_NAME);
+      if (isNameError) {
         // special case: if we find an invalid database name during startup,
         // we will give the user some hint how to fix it
         absl::StrAppend(&errorMsg, res.errorMessage(), ": '", name, "'");
@@ -1237,8 +1236,15 @@ ErrorCode DatabaseFeature::iterateDatabases(velocypack::Slice databases) {
                         "': ", res.errorMessage());
       }
 
-      res.reset(res.errorNumber(), std::move(errorMsg));
-      THROW_ARANGO_EXCEPTION(res);
+      if (!isNameError) {
+        // rethrow all errors but "illegal name" errors.
+        // the "illegal name" errors will be silenced during startup,
+        // so that it will be possible to start a database server
+        // with existing databases with extended database names even
+        // if the extended names feature was turned off later.
+        res.reset(res.errorNumber(), std::move(errorMsg));
+        THROW_ARANGO_EXCEPTION(res);
+      }
     }
 
     auto database = engine.openDatabase(std::move(info), _upgrade);

--- a/arangod/RestServer/DatabaseFeature.h
+++ b/arangod/RestServer/DatabaseFeature.h
@@ -196,7 +196,7 @@ class DatabaseFeature final : public ArangodFeature {
   bool _checkVersion{false};
   bool _upgrade{false};
   // allow extended names for databases, collections, views and indexes
-  bool _extendedNames{false};
+  bool _extendedNames{true};
   bool _performIOHeartbeat{true};
   std::atomic_bool _started{false};
 

--- a/arangod/RocksDBEngine/RocksDBUpgrade.cpp
+++ b/arangod/RocksDBEngine/RocksDBUpgrade.cpp
@@ -180,8 +180,6 @@ void arangodb::rocksdbStartupVersionCheck(ArangodServer& server,
           << rocksutils::convertStatus(s).errorMessage();
       FATAL_ERROR_EXIT();
     }
-
-    TRI_ASSERT(s.ok());
   }
 
   // fetch stored values of startup options
@@ -206,26 +204,25 @@ void arangodb::rocksdbStartupVersionCheck(ArangodServer& server,
                                  std::string{optionName})) {
             // user is trying to switch back from extended names to traditional
             // names. this is unsupported
-            LOG_TOPIC("1d4f6", FATAL, Logger::ENGINES)
+            LOG_TOPIC("1d4f6", ERR, Logger::ENGINES)
                 << "It is unsupported to change the value of the startup "
                    "option `--"
                 << optionName << "`"
                 << " back to `false` after it was set to `true` before. "
-                << "Please remove the setting "
-                   "`--"
-                << optionName
-                << " false` from the startup "
-                   "options.";
-            FATAL_ERROR_EXIT();
+                << "Please remove the setting `--" << optionName
+                << " false` from the startup options.";
+            // still continue, so it is possible to downgrade the ArangoDB
+            // version later.
           }
         }
         // set flag for our local instance
-        cb(storedValue[0] == '1');
+        cb(localValue);
       } else if (!s.IsNotFound()) {
         // arbitrary error. we need to abort
         LOG_TOPIC("f3a71", FATAL, Logger::ENGINES)
             << "Error reading stored value for --" << optionName
-            << " from storage engine";
+            << " from storage engine: "
+            << rocksutils::convertStatus(s).errorMessage();
         FATAL_ERROR_EXIT();
       }
     }

--- a/arangod/VocBase/LogicalCollection.cpp
+++ b/arangod/VocBase/LogicalCollection.cpp
@@ -166,15 +166,13 @@ LogicalCollection::LogicalCollection(TRI_vocbase_t& vocbase, VPackSlice info,
   }
 
   TRI_ASSERT(info.isObject());
-
-  bool extendedNames =
-      vocbase.server().getFeature<DatabaseFeature>().extendedNames();
-  if (auto res = CollectionNameValidator::validateName(system(), extendedNames,
-                                                       name());
-      res.fail()) {
-    THROW_ARANGO_EXCEPTION(res);
-  }
-
+  /*
+    bool extendedNames =
+        vocbase.server().getFeature<DatabaseFeature>().extendedNames();
+    if (auto res = CollectionNameValidator::validateName(system(),
+    extendedNames, name()); res.fail()) { THROW_ARANGO_EXCEPTION(res);
+    }
+  */
   if (_version < minimumVersion()) {
     // collection is too "old"
     std::string errorMsg(std::string("collection '") + name() +

--- a/arangod/VocBase/Methods/Collections.cpp
+++ b/arangod/VocBase/Methods/Collections.cpp
@@ -1152,6 +1152,12 @@ Result Collections::rename(LogicalCollection& collection,
     return {TRI_ERROR_FORBIDDEN};
   }
 
+  std::string const oldName(collection.name());
+  if (oldName == newName) {
+    // no actual name change
+    return {};
+  }
+
   // check required to pass
   // shell-collection-rocksdb-noncluster.js::testSystemSpecial
   if (collection.system()) {
@@ -1159,7 +1165,7 @@ Result Collections::rename(LogicalCollection& collection,
   }
 
   if (!doOverride) {
-    bool const isSystem = NameValidator::isSystemName(collection.name());
+    bool const isSystem = NameValidator::isSystemName(oldName);
 
     if (isSystem != NameValidator::isSystemName(newName)) {
       // a system collection shall not be renamed to a non-system collection
@@ -1180,7 +1186,6 @@ Result Collections::rename(LogicalCollection& collection,
     }
   }
 
-  std::string const oldName(collection.name());
   auto res = collection.vocbase().renameCollection(collection.id(), newName);
 
   if (!res.ok()) {

--- a/arangod/VocBase/Methods/Databases.cpp
+++ b/arangod/VocBase/Methods/Databases.cpp
@@ -499,14 +499,14 @@ Result Databases::drop(ExecContext const& exec, TRI_vocbase_t* systemVocbase,
     return TRI_ERROR_FORBIDDEN;
   }
 
-  bool extendedNames =
-      systemVocbase->server().getFeature<DatabaseFeature>().extendedNames();
-
-  if (auto res = DatabaseNameValidator::validateName(
-          /*allowSystem*/ false, extendedNames, dbName);
-      res.fail()) {
-    return res;
-  }
+  // bool extendedNames =
+  //    systemVocbase->server().getFeature<DatabaseFeature>().extendedNames();
+  //
+  // if (auto res = DatabaseNameValidator::validateName(
+  //        /*allowSystem*/ false, extendedNames, dbName);
+  //    res.fail()) {
+  //  return res;
+  //}
 
   Result res;
   auto& server = systemVocbase->server();

--- a/arangod/VocBase/VocbaseInfo.cpp
+++ b/arangod/VocBase/VocbaseInfo.cpp
@@ -308,10 +308,13 @@ Result CreateDatabaseInfo::checkOptions() {
            "and then restore the data.";
   }
 
-  bool isSystem = _name == StaticStrings::SystemDatabase;
-  bool extendedNames = _server.getFeature<DatabaseFeature>().extendedNames();
+  if (_validateNames) {
+    bool isSystem = _name == StaticStrings::SystemDatabase;
+    bool extendedNames = _server.getFeature<DatabaseFeature>().extendedNames();
 
-  return DatabaseNameValidator::validateName(isSystem, extendedNames, _name);
+    return DatabaseNameValidator::validateName(isSystem, extendedNames, _name);
+  }
+  return {};
 }
 
 #ifdef ARANGODB_USE_GOOGLE_TESTS

--- a/arangod/VocBase/VocbaseInfo.h
+++ b/arangod/VocBase/VocbaseInfo.h
@@ -92,6 +92,8 @@ class CreateDatabaseInfo {
 
   uint64_t getId() const;
 
+  void validateNames(bool value) noexcept { _validateNames = value; }
+
   void strictValidation(bool value) noexcept { _strictValidation = value; }
 
   bool valid() const noexcept { return _valid; }
@@ -150,7 +152,6 @@ class CreateDatabaseInfo {
                         bool extractName = true);
   Result checkOptions();
 
- private:
   ArangodServer& _server;
   ExecContext const& _context;
 
@@ -165,6 +166,7 @@ class CreateDatabaseInfo {
   ShardingPrototype _shardingPrototype = ShardingPrototype::Undefined;
 
   bool _strictValidation = true;
+  bool _validateNames = true;
   bool _validId = false;
   bool _valid = false;
 };


### PR DESCRIPTION
### Scope & Purpose

Enable extended names by default

* Change default value for `--database.extended-names` from `false` to `true`. This will allow end users to use Unicode characters inside database names, collection names, view names and index names by default, unless the functionality is explicitly turned off.

  Note: once a server in the deployment has been started with the flag set to `true`, it will store that setting permanently. Switching the startup option back to `false` will raise a warning about the option change at startup, but not block the startup. Existing databases, collections, views and indexes with extended names can still be used even with the option set back to `false`, but no new database objects with extended names can be created with the option set back to `false`. So this state is only meant to facilitate downgrading or reverting the option change. When the option is supposed to be left at a value of `false`, all database objects with extended names that were created in the meantime should be removed manually.

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 