### PR TITLE
always return `warnings` attribute for `/_api/query`

### DIFF
--- a/arangod/RestHandler/RestQueryHandler.cpp
+++ b/arangod/RestHandler/RestQueryHandler.cpp
@@ -318,13 +318,13 @@ void RestQueryHandler::parseQuery() {
     return;
   }
 
-  std::string const queryString =
+  std::string queryString =
       VelocyPackHelper::checkAndGetStringValue(body, "query");
 
   auto origin = transaction::OperationOriginAQL{"parsing AQL query"};
   auto query =
       Query::create(transaction::StandaloneContext::create(_vocbase, origin),
-                    QueryString(queryString), nullptr);
+                    QueryString(std::move(queryString)), nullptr);
   auto parseResult = query->parse();
 
   if (parseResult.result.fail()) {
@@ -340,13 +340,13 @@ void RestQueryHandler::parseQuery() {
     result.add("parsed", VPackValue(true));
 
     result.add("collections", VPackValue(VPackValueType::Array));
-    for (const auto& it : parseResult.collectionNames) {
+    for (auto const& it : parseResult.collectionNames) {
       result.add(VPackValue(it));
     }
     result.close();  // collections
 
     result.add("bindVars", VPackValue(VPackValueType::Array));
-    for (const auto& it : parseResult.bindParameters) {
+    for (auto const& it : parseResult.bindParameters) {
       result.add(VPackValue(it));
     }
     result.close();  // bindVars
@@ -355,6 +355,8 @@ void RestQueryHandler::parseQuery() {
 
     if (parseResult.extra && parseResult.extra->slice().hasKey("warnings")) {
       result.add("warnings", parseResult.extra->slice().get("warnings"));
+    } else {
+      result.add("warnings", VPackSlice::emptyArraySlice());
     }
   }
 


### PR DESCRIPTION
### Scope & Purpose

Docs PR: https://github.com/arangodb/docs-hugo/pull/272

Always return `warnings` attribute for `/_api/query`.
Previously the attribute was only returned if there were warnings. This puts unnecessary burden on the caller.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [x] Docs PR: https://github.com/arangodb/docs-hugo/pull/272
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 