### PR TITLE
improve client-side cursor API

### DIFF
--- a/js/client/modules/@arangodb/arango-query-cursor.js
+++ b/js/client/modules/@arangodb/arango-query-cursor.js
@@ -153,7 +153,7 @@ ArangoQueryCursor.prototype.toString = function () {
 // //////////////////////////////////////////////////////////////////////////////
 
 ArangoQueryCursor.prototype.toArray = function () {
-  var result = [];
+  let result = [];
 
   while (this.hasNext()) {
     result.push(this.next());
@@ -186,6 +186,18 @@ var helpArangoQueryCursor = arangosh.createHelpHeadline('ArangoQueryCursor help'
 
 ArangoQueryCursor.prototype._help = function () {
   internal.print(helpArangoQueryCursor);
+};
+
+ArangoQueryCursor.prototype.cached = function () {
+  return this._cached;
+};
+
+ArangoQueryCursor.prototype.stream = function () {
+  return this._stream;
+};
+
+ArangoQueryCursor.prototype.retriable = function () {
+  return this._retriable;
 };
 
 // //////////////////////////////////////////////////////////////////////////////
@@ -294,7 +306,7 @@ ArangoQueryCursor.prototype.dispose = function () {
     return;
   }
 
-  var requestResult = this._database._connection.DELETE(this._baseurl());
+  let requestResult = this._database._connection.DELETE(this._baseurl());
   arangosh.checkRequestResult(requestResult);
   this.data.id = undefined;
 };

--- a/js/common/modules/@arangodb/aql/explainer.js
+++ b/js/common/modules/@arangodb/aql/explainer.js
@@ -2135,17 +2135,17 @@ function processQuery(query, explain, planIndex) {
         if (info.condition && info.condition.hasOwnProperty('type')) {
           filter = '   ' + keyword('FILTER') + ' ' + buildExpression(info.condition);
         }
-        let projectString = '';
-        if (info.projections) {
-          projectString = '   /*' + projections(info, "projections", "projections");
-          if (!info.indexCoversProjections) {
-            projectString += " index scan + document lookup";
-          } else {
-            projectString += " index scan";
-          }
-          projectString += ' */';
+        let accessString = '';
+        if (!info.indexCoversProjections) {
+          accessString += "index scan + document lookup";
+        } else {
+          accessString += "index scan";
         }
-        line += indent(level, false) + label + filter + projectString;
+        if (info.projections) {
+          accessString += projections(info, "projections", "projections");
+        }
+        accessString = '   ' + annotation('/* ' + accessString + ' */');
+        line += indent(level, false) + label + filter + accessString;
         stringBuilder.appendLine(line);
       });
       --level;

--- a/tests/js/client/shell/api/cursor.js
+++ b/tests/js/client/shell/api/cursor.js
@@ -31,8 +31,8 @@
 const jsunity = require("jsunity");
 const internal = require('internal');
 const sleep = internal.sleep;
-let api = "/_api/cursor";
-let reId = /^\d+$/;
+const api = "/_api/cursor";
+const reId = /^\d+$/;
 const forceJson = internal.options().hasOwnProperty('server.force-json') && internal.options()['server.force-json'];
 const contentType = forceJson ? "application/json" : "application/x-velocypack";
 

--- a/tests/js/client/shell/shell-statement.js
+++ b/tests/js/client/shell/shell-statement.js
@@ -51,6 +51,9 @@ function StatementSuite () {
       var stmt = db._createStatement({ query: "FOR i IN 1..11 RETURN i", count: true });
       var cursor = stmt.execute();
 
+      assertFalse(cursor.stream());
+      assertFalse(cursor.retriable());
+      assertFalse(cursor.cached());
       assertEqual(11, cursor.count());
       for (var i = 1; i <= 11; ++i) {
         assertEqual(i, cursor.next());
@@ -68,6 +71,9 @@ function StatementSuite () {
       var stmt = db._createStatement({ query: "FOR i IN 1..11 RETURN i", count: true });
       var cursor = stmt.execute();
 
+      assertFalse(cursor.stream());
+      assertFalse(cursor.retriable());
+      assertFalse(cursor.cached());
       assertEqual(11, cursor.count());
       assertTrue(cursor.hasNext());
 
@@ -81,6 +87,7 @@ function StatementSuite () {
       }
 
       assertFalse(cursor.hasNext());
+      assertFalse(cursor.stream());
     },
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -91,6 +98,9 @@ function StatementSuite () {
       var stmt = db._createStatement({ query: "FOR i IN 1..11 RETURN i", count: true });
       var cursor = stmt.execute();
 
+      assertFalse(cursor.stream());
+      assertFalse(cursor.retriable());
+      assertFalse(cursor.cached());
       assertEqual(11, cursor.count());
       assertTrue(cursor.hasNext());
 
@@ -98,6 +108,7 @@ function StatementSuite () {
       cursor.toString();
       assertTrue(more === cursor);
 
+      assertFalse(cursor.stream());
       cursor.toString();
       for (var i = 1; i <= 11; ++i) {
         assertEqual(i, cursor.next());
@@ -105,6 +116,7 @@ function StatementSuite () {
       }
 
       assertFalse(cursor.hasNext());
+      assertFalse(cursor.stream());
     },
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -115,6 +127,9 @@ function StatementSuite () {
       var stmt = db._createStatement({ query: "FOR i IN 1..11 RETURN i", count: true });
       var cursor = stmt.execute();
 
+      assertFalse(cursor.stream());
+      assertFalse(cursor.retriable());
+      assertFalse(cursor.cached());
       assertEqual(11, cursor.count());
       assertTrue(cursor.hasNext());
 
@@ -122,6 +137,7 @@ function StatementSuite () {
       cursor.toString();
       assertTrue(more === cursor);
 
+      assertFalse(cursor.stream());
       cursor.toString();
       try {
         cursor.toString();
@@ -130,6 +146,7 @@ function StatementSuite () {
         // we're expecting the cursor to be at the end
       }
       
+      assertFalse(cursor.stream());
       assertTrue(cursor.hasNext());
       for (var i = 1; i <= 11; ++i) {
         assertEqual(i, cursor.next());
@@ -137,8 +154,8 @@ function StatementSuite () {
       }
 
       assertFalse(cursor.hasNext());
+      assertFalse(cursor.stream());
     },
-
 
   };
 }
@@ -162,6 +179,7 @@ function StatementStreamSuite () {
                                        batchSize: 50});
       var cursor = stmt.execute();
 
+      assertTrue(cursor.stream());
       assertEqual(undefined, cursor.count());
       for (var i = 1; i <= 100; ++i) {
         assertEqual(i, cursor.next());
@@ -177,6 +195,7 @@ function StatementStreamSuite () {
                                        batchSize: 50});
       var cursor = stmt.execute();
 
+      assertTrue(cursor.stream());
       assertEqual(undefined, cursor.count());
       for (var i = 1; i <= 100; ++i) {
         assertEqual(i, cursor.next());
@@ -184,6 +203,24 @@ function StatementStreamSuite () {
       }
 
       assertFalse(cursor.hasNext());
+    },
+    
+    testStreamCursorRetriable : function () {
+      var stmt = db._createStatement({ query: "FOR i IN 1..100 RETURN i",
+                                       stream: true, options: {allowRetry: true},
+                                       batchSize: 50});
+      var cursor = stmt.execute();
+
+      assertTrue(cursor.retriable());
+      assertTrue(cursor.stream());
+      assertEqual(undefined, cursor.count());
+      for (var i = 1; i <= 100; ++i) {
+        assertEqual(i, cursor.next());
+        assertEqual(i !== 100, cursor.hasNext());
+      }
+
+      assertFalse(cursor.hasNext());
+      assertTrue(cursor.retriable());
     },
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -195,6 +232,7 @@ function StatementStreamSuite () {
                                        options: { stream: true } });
       var cursor = stmt.execute();
 
+      assertTrue(cursor.stream());
       assertEqual(undefined, cursor.count()); // count is not supported
       assertTrue(cursor.hasNext());
 
@@ -216,6 +254,7 @@ function StatementStreamSuite () {
                                        stream: true });
       var cursor = stmt.execute();
 
+      assertTrue(cursor.stream());
       assertEqual(undefined, cursor.count()); // count is not supported
       assertTrue(cursor.hasNext());
 


### PR DESCRIPTION
### Scope & Purpose

improve client-side cursor API by providing the follow extra functions for ArangoQueryCursor:
- cached(): returns true if the cursor result came from a cached query, false otherwise
- stream(): returns true if the cursor is from a streaming query, false otherwise
- retriable(): returns true if the cursor supports retriable fetching of the last batch, false otherwise

also improve explain output for `JoinNode`, so that it looks similar to the output from IndexNodes.

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 