### PR TITLE
replace several calls to deprecated APIs

### DIFF
--- a/arangod/Aql/Functions.cpp
+++ b/arangod/Aql/Functions.cpp
@@ -6831,7 +6831,7 @@ AqlValue functions::Zip(ExpressionContext* expressionContext, AstNode const&,
 
     if (keysSeen.emplace(buffer->data(), buffer->length()).second) {
       // non-duplicate key
-      builder->add(buffer->data(), buffer->length(), valuesIt.value());
+      builder->add(*buffer, valuesIt.value());
     }
 
     keysIt.next();
@@ -7923,7 +7923,7 @@ AqlValue functions::Pop(ExpressionContext* expressionContext, AstNode const&,
   transaction::BuilderLeaser builder(trx);
   builder->openArray();
   auto iterator = VPackArrayIterator(slice);
-  while (iterator.valid() && !iterator.isLast()) {
+  while (iterator.valid() && iterator.index() + 1 != iterator.size()) {
     builder->add(iterator.value());
     iterator.next();
   }

--- a/arangod/Aql/SkipResult.cpp
+++ b/arangod/Aql/SkipResult.cpp
@@ -95,7 +95,7 @@ auto SkipResult::fromVelocyPack(VPackSlice slice)
         message += slice.typeName();
         return Result(TRI_ERROR_TYPE_ERROR, std::move(message));
       }
-      if (!it.isFirst()) {
+      if (it.index() != 0) {
         res.incrementSubquery();
       }
       res.didSkip(val.getNumber<std::size_t>());

--- a/arangod/Graph/GraphManager.cpp
+++ b/arangod/Graph/GraphManager.cpp
@@ -1141,7 +1141,7 @@ ResultT<std::unique_ptr<Graph>> GraphManager::buildGraphFromInput(
     if (options.isObject()) {
       VPackSlice s = options.get(StaticStrings::ReplicationFactor);
       return ((s.isNumber() && s.getNumber<int>() == 0) ||
-              (s.isString() && s.stringRef() == "satellite"));
+              (s.isString() && s.stringView() == "satellite"));
     }
     return false;
   };

--- a/arangod/IResearch/IResearchAnalyzerFeature.cpp
+++ b/arangod/IResearch/IResearchAnalyzerFeature.cpp
@@ -356,10 +356,12 @@ aql::AqlValue aqlFnTokens(aql::ExpressionContext* expressionContext,
       default:
         processNumeric(current);
     }
-    // de-stack all closing arrays
+    // de-stack all closing arrays.
+    // arrayIteratorsStack only contains non-empty arrays.
     while (!arrayIteratorStack.empty()) {
       auto& currentArrayIterator = arrayIteratorStack.back();
-      if (!currentArrayIterator.isLast()) {
+      if (currentArrayIterator.valid() &&
+          currentArrayIterator.index() + 1 < currentArrayIterator.size()) {
         currentArrayIterator.next();
         current = currentArrayIterator.value();
         // next array for next item

--- a/arangod/IResearch/VelocyPackHelper.cpp
+++ b/arangod/IResearch/VelocyPackHelper.cpp
@@ -57,10 +57,9 @@ velocypack::Builder& addRef(velocypack::Builder& builder, std::string_view key,
 
   // store nulls verbatim
   if (irs::IsNull(value)) {
-    builder.add(key.data(), key.size(),
-                velocypack::Value(velocypack::ValueType::Null));
+    builder.add(key, velocypack::Value(velocypack::ValueType::Null));
   } else {
-    builder.add(key.data(), key.size(), toValuePair(value));
+    builder.add(key, toValuePair(value));
   }
 
   return builder;
@@ -180,7 +179,7 @@ bool mergeSliceSkipKeys(
     auto attr = key.stringView();
 
     if (acceptor(attr)) {
-      builder.add(attr.data(), attr.size(), value);
+      builder.add(attr, value);
     }
   }
 

--- a/arangod/RestHandler/RestImportHandler.cpp
+++ b/arangod/RestHandler/RestImportHandler.cpp
@@ -1062,9 +1062,7 @@ void RestImportHandler::createVelocyPackObject(VPackBuilder& result,
     VPackSlice const value = itValues.value();
 
     if (key.isString() && !value.isNone() && !value.isNull()) {
-      VPackValueLength l;
-      char const* p = key.getString(l);
-      result.add(p, l, value);
+      result.add(key.stringView(), value);
     }
 
     itKeys.next();

--- a/arangod/RestHandler/RestIndexHandler.cpp
+++ b/arangod/RestHandler/RestIndexHandler.cpp
@@ -196,9 +196,7 @@ RestStatus RestIndexHandler::getIndexes() {
     tmp.add("identifiers", VPackValue(VPackValueType::Object));
     for (VPackSlice const& index : VPackArrayIterator(indexes.slice())) {
       VPackSlice id = index.get("id");
-      VPackValueLength l = 0;
-      char const* str = id.getString(l);
-      tmp.add(str, l, index);
+      tmp.add(id.stringView(), index);
     }
     tmp.close();
     tmp.close();

--- a/arangod/RocksDBEngine/RocksDBOptimizerRules.cpp
+++ b/arangod/RocksDBEngine/RocksDBOptimizerRules.cpp
@@ -207,7 +207,7 @@ void RocksDBOptimizerRules::reduceExtractionToProjectionRule(
             // optimization, so force it - if we wouldn't force it here it would
             // mean that for a FILTER-less query we would be a lot less
             // efficient for some indexes
-            auto inode = new IndexNode(
+            auto inode = plan->createNode<IndexNode>(
                 plan.get(), plan->nextId(), en->collection(), en->outVariable(),
                 std::vector<transaction::Methods::IndexHandle>{picked},
                 false,  // here we are not using inverted index so for sure no
@@ -215,7 +215,6 @@ void RocksDBOptimizerRules::reduceExtractionToProjectionRule(
                 std::move(condition), opts);
             en->CollectionAccessingNode::cloneInto(*inode);
             en->DocumentProducingNode::cloneInto(plan.get(), *inode);
-            plan->registerNode(inode);
             plan->replaceNode(n, inode);
 
             if (en->isRestricted()) {
@@ -310,13 +309,12 @@ void RocksDBOptimizerRules::reduceExtractionToProjectionRule(
           opts.useCache = false;
           auto condition = std::make_unique<Condition>(plan->getAst());
           condition->normalize(plan.get());
-          auto inode = new IndexNode(
+          auto inode = plan->createNode<IndexNode>(
               plan.get(), plan->nextId(), en->collection(), en->outVariable(),
               std::vector<transaction::Methods::IndexHandle>{picked},
               false,  // here we are not using inverted index so for sure no
                       // "whole" coverage
               std::move(condition), opts);
-          plan->registerNode(inode);
           plan->replaceNode(n, inode);
           en->CollectionAccessingNode::cloneInto(*inode);
           en->DocumentProducingNode::cloneInto(plan.get(), *inode);


### PR DESCRIPTION
### Scope & Purpose

Replace several calls to deprecated APIs with alternatives.
Deprecated APIs are APIs that are marked with the `[[deprecated]]` attribute and thus produce compile warnings when compiling with `-Wdeprecated-declarations`.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 