### PR TITLE
Allow usage of `_id` attribute in stored values of persistent indexes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 devel
 -----
 
+* Allow the usage of the `_id` attribute in the stored values of persistent
+  indexes.
+
 * Updated arangosync to v2.19.4-preview-8.
 
 * Fix updating of collection properties (schema) when the collection has a

--- a/arangod/ClusterEngine/ClusterIndexFactory.cpp
+++ b/arangod/ClusterEngine/ClusterIndexFactory.cpp
@@ -331,7 +331,9 @@ void ClusterIndexFactory::prepareIndexes(
   TRI_ASSERT(indexesSlice.isArray());
 
   for (VPackSlice v : VPackArrayIterator(indexesSlice)) {
-    if (!validateFieldsDefinition(v, StaticStrings::IndexFields, 0, SIZE_MAX)
+    if (!validateFieldsDefinition(v, StaticStrings::IndexFields, 0, SIZE_MAX,
+                                  /*allowSubAttributes*/ true,
+                                  /*allowIdAttribute*/ false)
              .ok()) {
       // We have an error here. Do not add.
       continue;

--- a/arangod/IResearch/IResearchRocksDBInvertedIndex.cpp
+++ b/arangod/IResearch/IResearchRocksDBInvertedIndex.cpp
@@ -135,7 +135,8 @@ Result IResearchRocksDBInvertedIndexFactory::normalize(
   TRI_ASSERT(normalized.isOpenObject());
 
   auto res = IndexFactory::validateFieldsDefinition(
-      definition, arangodb::StaticStrings::IndexFields, 0, SIZE_MAX, true);
+      definition, arangodb::StaticStrings::IndexFields, 0, SIZE_MAX,
+      /*allowSubAttributes*/ true, /*allowIdAttribute*/ false);
   if (res.fail()) {
     return res;
   }

--- a/arangod/Indexes/IndexFactory.h
+++ b/arangod/Indexes/IndexFactory.h
@@ -130,14 +130,16 @@ class IndexFactory {
   static Result validateFieldsDefinition(velocypack::Slice definition,
                                          std::string const& attributeName,
                                          size_t minFields, size_t maxFields,
-                                         bool allowSubAttributes = true);
+                                         bool allowSubAttributes,
+                                         bool allowIdAttribute);
 
   /// @brief process the "fields" list, deduplicate it, and add it to the json
   static Result processIndexFields(velocypack::Slice definition,
                                    velocypack::Builder& builder,
                                    size_t minFields, size_t maxFields,
                                    bool create, bool allowExpansion,
-                                   bool allowSubAttributes);
+                                   bool allowSubAttributes,
+                                   bool allowIdAttribute);
 
   /// @brief process the "storedValues" list, deduplicate it, and add it to the
   /// json

--- a/arangod/RocksDBEngine/RocksDBIndexFactory.cpp
+++ b/arangod/RocksDBEngine/RocksDBIndexFactory.cpp
@@ -433,7 +433,9 @@ void RocksDBIndexFactory::prepareIndexes(
   IndexId last = IndexId::primary();
 
   for (VPackSlice v : VPackArrayIterator(indexesSlice)) {
-    if (!validateFieldsDefinition(v, StaticStrings::IndexFields, 0, SIZE_MAX)
+    if (!validateFieldsDefinition(v, StaticStrings::IndexFields, 0, SIZE_MAX,
+                                  /*allowSubAttributes*/ true,
+                                  /*allowIdAttribute*/ false)
              .ok()) {
       continue;
     }

--- a/arangod/RocksDBEngine/RocksDBVPackIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBVPackIndex.cpp
@@ -1731,7 +1731,15 @@ Result RocksDBVPackIndex::insertUnique(
     transaction::BuilderLeaser leased(&trx);
     leased->openArray(true);
     for (auto const& it : _storedValuesPaths) {
-      VPackSlice s = doc.get(it);
+      VPackSlice s;
+      if (it.size() == 1 && it[0] == StaticStrings::IdString) {
+        // instead of storing the value of _id, we instead store the
+        // value of _key. we will retranslate the value to an _id later
+        // again upon retrieval
+        s = transaction::helpers::extractKeyFromDocument(doc);
+      } else {
+        s = doc.get(it);
+      }
       if (s.isNone()) {
         s = VPackSlice::nullSlice();
       }
@@ -1845,7 +1853,15 @@ Result RocksDBVPackIndex::insertNonUnique(
     transaction::BuilderLeaser leased(&trx);
     leased->openArray(true);
     for (auto const& it : _storedValuesPaths) {
-      VPackSlice s = doc.get(it);
+      VPackSlice s;
+      if (it.size() == 1 && it[0] == StaticStrings::IdString) {
+        // instead of storing the value of _id, we instead store the
+        // value of _key. we will retranslate the value to an _id later
+        // again upon retrieval
+        s = transaction::helpers::extractKeyFromDocument(doc);
+      } else {
+        s = doc.get(it);
+      }
       if (s.isNone()) {
         s = VPackSlice::nullSlice();
       }


### PR DESCRIPTION
### Scope & Purpose

Docs PR: https://github.com/arangodb/docs-hugo/pull/275

Allow usage of `_id` attribute in stored values of persistent indexes.
Using the `_id` attribute in stored values was previously forbidden. It is still unsupported to use the `_id` attribute as part of normal index attributes.

TODO: adjust existing tests, add new tests.

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [x] Docs PR: https://github.com/arangodb/docs-hugo/pull/275
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 