### PR TITLE
Improve recovery speed for updates

### DIFF
--- a/arangod/IResearch/IResearchRocksDBRecoveryHelper.h
+++ b/arangod/IResearch/IResearchRocksDBRecoveryHelper.h
@@ -71,11 +71,6 @@ class IResearchRocksDBRecoveryHelper final : public RocksDBRecoveryHelper {
   void DeleteCF(uint32_t column_family_id, const rocksdb::Slice& key,
                 rocksdb::SequenceNumber tick) final;
 
-  void SingleDeleteCF(uint32_t column_family_id, const rocksdb::Slice& key,
-                      rocksdb::SequenceNumber tick) final {
-    DeleteCF(column_family_id, key, tick);
-  }
-
   void LogData(const rocksdb::Slice& blob, rocksdb::SequenceNumber tick) final;
 
  private:

--- a/arangod/RocksDBEngine/RocksDBRecoveryHelper.h
+++ b/arangod/RocksDBEngine/RocksDBRecoveryHelper.h
@@ -46,15 +46,6 @@ class RocksDBRecoveryHelper {
   virtual void DeleteCF(uint32_t column_family_id, const rocksdb::Slice& key,
                         rocksdb::SequenceNumber tick) {}
 
-  virtual void SingleDeleteCF(uint32_t column_family_id,
-                              const rocksdb::Slice& key,
-                              rocksdb::SequenceNumber tick) {}
-
-  virtual void DeleteRangeCF(uint32_t column_family_id,
-                             const rocksdb::Slice& begin_key,
-                             const rocksdb::Slice& end_key,
-                             rocksdb::SequenceNumber tick) {}
-
   virtual void LogData(const rocksdb::Slice& blob,
                        rocksdb::SequenceNumber tick) {}
 };

--- a/arangod/RocksDBEngine/RocksDBRecoveryManager.cpp
+++ b/arangod/RocksDBEngine/RocksDBRecoveryManager.cpp
@@ -565,7 +565,7 @@ class WALReader final : public WALReaderBase {
       storeMaxHLC(documentId);
       storeMaxTick(objectId);
 
-      auto coll = findCollection(RocksDBKey::objectId(key));
+      auto coll = findCollection(objectId);
 
       if (coll) {
         coll->meta().adjustNumberDocumentsInRecovery(_currentSequence,


### PR DESCRIPTION
### Scope & Purpose

In WAL sometime exists pattern:
`insert d ... remove d`
for an example, in such case:
`update d (d0->d1) ... update d (d1->d2) ... update d (d2->d3)` =>
`remove d0, insert d1 ... remove d1, insert d2 ... remove d2, insert d3`
we can reduce it to 
`remove d0,` ~~insert d1 ... remove d1, insert d2 ... remove d2,~~` insert d3`

Such optimization is especially important for ArangoSearch because how removes work for it

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

