### PR TITLE
load projections into registers

### DIFF
--- a/arangod/Aql/AqlValue.cpp
+++ b/arangod/Aql/AqlValue.cpp
@@ -542,7 +542,7 @@ AqlValue AqlValue::get(CollectionNameResolver const& resolver,
 }
 
 AqlValue AqlValue::get(CollectionNameResolver const& resolver,
-                       MonitoredStringVector const& names, bool& mustDestroy,
+                       std::vector<std::string> const& names, bool& mustDestroy,
                        bool doCopy) const {
   mustDestroy = false;
   if (names.empty()) {

--- a/arangod/Aql/AqlValue.h
+++ b/arangod/Aql/AqlValue.h
@@ -437,7 +437,7 @@ struct AqlValue final {
   AqlValue get(CollectionNameResolver const& resolver, std::string_view name,
                bool& mustDestroy, bool copy) const;
   AqlValue get(CollectionNameResolver const& resolver,
-               MonitoredStringVector const& names, bool& mustDestroy,
+               std::vector<std::string> const& names, bool& mustDestroy,
                bool copy) const;
   bool hasKey(std::string_view name) const;
 

--- a/arangod/Aql/Ast.cpp
+++ b/arangod/Aql/Ast.cpp
@@ -180,9 +180,7 @@ bool translateNodeStackToAttributePath(
     }
 
     // now take off all projections from the stack
-    ResourceUsageAllocator<MonitoredStringVector, ResourceMonitor> alloc = {
-        resourceMonitor};
-    MonitoredStringVector path{alloc};
+    std::vector<std::string> path;
     while (top->type == NODE_TYPE_ATTRIBUTE_ACCESS) {
       path.emplace_back(top->getString());
       state.seen.pop_back();
@@ -193,7 +191,7 @@ bool translateNodeStackToAttributePath(
     }
 
     TRI_ASSERT(!path.empty());
-    state.attributes.emplace(AttributeNamePath(std::move(path)));
+    state.attributes.emplace(std::move(path), resourceMonitor);
   }
 
   return true;
@@ -2223,9 +2221,10 @@ void Ast::injectBindParameters(BindParameters& parameters,
 }
 
 /// @brief replace an attribute access with just the variable
-AstNode* Ast::replaceAttributeAccess(
-    AstNode* node, Variable const* variable,
-    std::vector<std::string> const& attribute) {
+AstNode* Ast::replaceAttributeAccess(Ast* ast, AstNode* node,
+                                     Variable const* searchVariable,
+                                     std::span<std::string_view> attribute,
+                                     Variable const* replaceVariable) {
   TRI_ASSERT(!attribute.empty());
   if (attribute.empty()) {
     return node;
@@ -2264,9 +2263,11 @@ AstNode* Ast::replaceAttributeAccess(
 
     if (node->type == NODE_TYPE_REFERENCE) {
       auto v = static_cast<Variable*>(node->getData());
-      if (v != nullptr && v->id == variable->id) {
+      if (v != nullptr && v->id == searchVariable->id) {
         // our variable... now replace the attribute access with just the
         // variable
+        node = ast->createNode(NODE_TYPE_REFERENCE);
+        node->setData(replaceVariable);
         return node;
       }
     }

--- a/arangod/Aql/Ast.h
+++ b/arangod/Aql/Ast.h
@@ -26,6 +26,7 @@
 #include <functional>
 #include <iterator>
 #include <memory>
+#include <span>
 #include <string>
 #include <string_view>
 #include <unordered_map>
@@ -483,8 +484,9 @@ class Ast {
 
   /// @brief replace an attribute access with just the variable
   static AstNode* replaceAttributeAccess(
-      AstNode* node, Variable const* variable,
-      std::vector<std::string> const& attributeName);
+      Ast* ast, AstNode* node, Variable const* searchVariable,
+      std::span<std::string_view> attributeName,
+      Variable const* replaceVariable);
 
   /// @brief recursively clone a node
   AstNode* clone(AstNode const*);

--- a/arangod/Aql/AttributeAccessor.cpp
+++ b/arangod/Aql/AttributeAccessor.cpp
@@ -115,7 +115,7 @@ class AttributeAccessorMulti final : public AttributeAccessor {
     AqlValue const& value =
         context->getVariableValue(_variable, false, mustDestroy);
     // use general version for multiple attributes (e.g. variable.attr.subattr)
-    return value.get(resolver, _path._path, mustDestroy, true);
+    return value.get(resolver, _path.get(), mustDestroy, true);
   }
 
  private:

--- a/arangod/Aql/AttributeAccessor.h
+++ b/arangod/Aql/AttributeAccessor.h
@@ -37,7 +37,7 @@ namespace aql {
 
 class AqlItemBlock;
 struct AqlValue;
-struct AttributeNamePath;
+class AttributeNamePath;
 class ExpressionContext;
 struct Variable;
 

--- a/arangod/Aql/AttributeNamePath.cpp
+++ b/arangod/Aql/AttributeNamePath.cpp
@@ -184,6 +184,16 @@ void AttributeNamePath::add(std::string part) {
   }
 }
 
+#ifdef ARANGODB_USE_GOOGLE_TESTS
+void AttributeNamePath::pop() {
+  auto previous = memoryUsage();
+  TRI_ASSERT(!_path.empty());
+  _path.pop_back();
+  auto now = memoryUsage();
+  _resourceMonitor.decreaseMemoryUsage(previous - now);
+}
+#endif
+
 AttributeNamePath& AttributeNamePath::reverse() {
   // no change in memory usage
   std::reverse(_path.begin(), _path.end());

--- a/arangod/Aql/AttributeNamePath.h
+++ b/arangod/Aql/AttributeNamePath.h
@@ -37,7 +37,8 @@ namespace arangodb::aql {
 /// a top-level attribute (e.g. _key) will be stored in a vector with a single
 /// element. nested attributes (e.g. a.b.c) will be stored in a vector with
 /// multiple elements
-struct AttributeNamePath {
+class AttributeNamePath {
+ public:
   enum class Type : uint8_t {
     IdAttribute,      // _id
     KeyAttribute,     // _key
@@ -92,17 +93,21 @@ struct AttributeNamePath {
   /// @brief clear all path attributes
   void clear() noexcept;
 
+  /// @brief add an attribute to the path
+  void add(std::string part);
+
   /// @brief reverse the attributes in the path
   AttributeNamePath& reverse();
 
   /// @brief shorten the attributes in the path to the specified length
   AttributeNamePath& shortenTo(size_t length);
 
-  size_t memoryUsage() const noexcept;
-
   /// @brief determines the length of common prefixes
   static size_t commonPrefixLength(AttributeNamePath const& lhs,
                                    AttributeNamePath const& rhs);
+
+ private:
+  size_t memoryUsage() const noexcept;
 
   arangodb::ResourceMonitor& _resourceMonitor;
   std::vector<std::string> _path;

--- a/arangod/Aql/AttributeNamePath.h
+++ b/arangod/Aql/AttributeNamePath.h
@@ -23,12 +23,13 @@
 
 #pragma once
 
-#include "Basics/MemoryTypes/MemoryTypes.h"
+#include "Basics/ResourceUsage.h"
 
 #include <cstdint>
 #include <functional>
 #include <iosfwd>
 #include <string>
+#include <vector>
 
 namespace arangodb::aql {
 
@@ -46,20 +47,22 @@ struct AttributeNamePath {
     MultiAttribute    // sub-attribute, e.g. a.b.c
   };
 
-  explicit AttributeNamePath(
-      arangodb::ResourceMonitor& resourceMonitor) noexcept;
+  explicit AttributeNamePath(arangodb::ResourceMonitor& resourceMonitor);
 
   /// @brief construct an attribute path from a single attribute (e.g. _key)
   AttributeNamePath(std::string attribute,
                     arangodb::ResourceMonitor& resourceMonitor);
 
   /// @brief construct an attribute path from a nested attribute (e.g. a.b.c)
-  explicit AttributeNamePath(MonitoredStringVector path) noexcept;
+  AttributeNamePath(std::vector<std::string> path,
+                    arangodb::ResourceMonitor& resourceMonitor);
 
-  AttributeNamePath(AttributeNamePath const& other) = default;
-  AttributeNamePath& operator=(AttributeNamePath const& other) = default;
-  AttributeNamePath(AttributeNamePath&& other) noexcept = default;
-  AttributeNamePath& operator=(AttributeNamePath&& other) noexcept = default;
+  ~AttributeNamePath();
+
+  AttributeNamePath(AttributeNamePath const& other);
+  AttributeNamePath& operator=(AttributeNamePath const& other);
+  AttributeNamePath(AttributeNamePath&& other) noexcept;
+  AttributeNamePath& operator=(AttributeNamePath&& other) noexcept;
 
   /// @brief if the path is empty
   bool empty() const noexcept;
@@ -84,7 +87,7 @@ struct AttributeNamePath {
   bool operator<(AttributeNamePath const& other) const noexcept;
 
   /// @brief get the full path
-  [[nodiscard]] MonitoredStringVector const& get() const noexcept;
+  [[nodiscard]] std::vector<std::string> const& get() const noexcept;
 
   /// @brief clear all path attributes
   void clear() noexcept;
@@ -95,11 +98,14 @@ struct AttributeNamePath {
   /// @brief shorten the attributes in the path to the specified length
   AttributeNamePath& shortenTo(size_t length);
 
+  size_t memoryUsage() const noexcept;
+
   /// @brief determines the length of common prefixes
   static size_t commonPrefixLength(AttributeNamePath const& lhs,
                                    AttributeNamePath const& rhs);
 
-  MonitoredStringVector _path;
+  arangodb::ResourceMonitor& _resourceMonitor;
+  std::vector<std::string> _path;
 };
 
 std::ostream& operator<<(std::ostream& stream, AttributeNamePath const& path);

--- a/arangod/Aql/AttributeNamePath.h
+++ b/arangod/Aql/AttributeNamePath.h
@@ -96,6 +96,10 @@ class AttributeNamePath {
   /// @brief add an attribute to the path
   void add(std::string part);
 
+#ifdef ARANGODB_USE_GOOGLE_TESTS
+  void pop();
+#endif
+
   /// @brief reverse the attributes in the path
   AttributeNamePath& reverse();
 

--- a/arangod/Aql/CalculationExecutor.h
+++ b/arangod/Aql/CalculationExecutor.h
@@ -63,7 +63,6 @@ struct CalculationExecutorInfos {
   RegisterId getOutputRegisterId() const noexcept;
 
   QueryContext& getQuery() const noexcept;
-  transaction::Methods* getTrx() const noexcept;
 
   Expression& getExpression() const noexcept;
 

--- a/arangod/Aql/ClusterNodes.cpp
+++ b/arangod/Aql/ClusterNodes.cpp
@@ -583,13 +583,20 @@ GatherNode::Parallelism GatherNode::evaluateParallelism(
 
 void GatherNode::replaceVariables(
     std::unordered_map<VariableId, Variable const*> const& replacements) {
-  for (auto& variable : _elements) {
-    auto v = Variable::replace(variable.var, replacements);
-    if (v != variable.var) {
-      variable.var = v;
+  for (auto& it : _elements) {
+    auto v = Variable::replace(it.var, replacements);
+    if (v != it.var) {
+      it.var = v;
     }
-    variable.attributePath.clear();
+    it.attributePath.clear();
   }
+}
+
+void GatherNode::replaceAttributeAccess(ExecutionNode const* self,
+                                        Variable const* searchVariable,
+                                        std::span<std::string_view> attribute,
+                                        Variable const* replaceVariable) {
+  // TODO!!!
 }
 
 void GatherNode::getVariablesUsedHere(VarSet& vars) const {

--- a/arangod/Aql/ClusterNodes.h
+++ b/arangod/Aql/ClusterNodes.h
@@ -311,6 +311,13 @@ class GatherNode final : public ExecutionNode {
   void replaceVariables(std::unordered_map<VariableId, Variable const*> const&
                             replacements) override;
 
+  /// @brief replaces an attribute access in the internals of the execution
+  /// node with a simple variable access
+  void replaceAttributeAccess(ExecutionNode const* self,
+                              Variable const* searchVariable,
+                              std::span<std::string_view> attribute,
+                              Variable const* replaceVariable) override;
+
   /// @brief getVariablesUsedHere, modifying the set in-place
   void getVariablesUsedHere(VarSet& vars) const override final;
 

--- a/arangod/Aql/Condition.cpp
+++ b/arangod/Aql/Condition.cpp
@@ -659,6 +659,27 @@ std::unique_ptr<Condition> Condition::clone() const {
   return copy;
 }
 
+/// @brief replace variables in the condition with other variables
+void Condition::replaceVariables(
+    std::unordered_map<VariableId, Variable const*> const& replacements) {
+  if (_root == nullptr) {
+    return;
+  }
+
+  _root = Ast::replaceVariables(_root, replacements);
+}
+
+void Condition::replaceAttributeAccess(Variable const* searchVariable,
+                                       std::span<std::string_view> attribute,
+                                       Variable const* replaceVariable) {
+  if (_root == nullptr) {
+    return;
+  }
+
+  _root = Ast::replaceAttributeAccess(_ast, _root, searchVariable, attribute,
+                                      replaceVariable);
+}
+
 /// @brief add a sub-condition to the condition
 /// the sub-condition will be AND-combined with the existing condition(s)
 void Condition::andCombine(AstNode const* node) {

--- a/arangod/Aql/Condition.h
+++ b/arangod/Aql/Condition.h
@@ -29,7 +29,10 @@
 #include "Containers/HashSet.h"
 #include "Transaction/Methods.h"
 
+#include <span>
 #include <string>
+#include <string_view>
+#include <unordered_map>
 #include <vector>
 
 namespace arangodb {
@@ -136,6 +139,13 @@ class Condition {
 
   /// @brief clone the condition
   std::unique_ptr<Condition> clone() const;
+
+  void replaceVariables(
+      std::unordered_map<VariableId, Variable const*> const& replacements);
+
+  void replaceAttributeAccess(Variable const* searchVariable,
+                              std::span<std::string_view> attribute,
+                              Variable const* replaceVariable);
 
   /// @brief add a sub-condition to the condition
   /// the sub-condition will be AND-combined with the existing condition(s)

--- a/arangod/Aql/DependencyProxy.cpp
+++ b/arangod/Aql/DependencyProxy.cpp
@@ -84,11 +84,13 @@ DependencyProxy<blockPassthrough>::executeForDependency(
     THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
   }
 
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   if (skipped.nothingSkipped() && block == nullptr) {
     // We're either waiting or Done
     TRI_ASSERT(state == ExecutionState::DONE ||
                state == ExecutionState::WAITING);
   }
+#endif
   return {state, skipped, std::move(block)};
 }
 
@@ -117,19 +119,19 @@ void DependencyProxy<blockPassthrough>::reset() {
 }
 
 template<BlockPassthrough blockPassthrough>
-ExecutionBlock& DependencyProxy<blockPassthrough>::upstreamBlock() {
+ExecutionBlock& DependencyProxy<blockPassthrough>::upstreamBlock() const {
   return upstreamBlockForDependency(_currentDependency);
 }
 
 template<BlockPassthrough blockPassthrough>
 ExecutionBlock& DependencyProxy<blockPassthrough>::upstreamBlockForDependency(
-    size_t index) {
+    size_t index) const {
   TRI_ASSERT(_dependencies.size() > index);
   return *_dependencies[index];
 }
 
 template<BlockPassthrough blockPassthrough>
-bool DependencyProxy<blockPassthrough>::advanceDependency() {
+bool DependencyProxy<blockPassthrough>::advanceDependency() noexcept {
   if (_currentDependency + 1 >= _dependencies.size()) {
     return false;
   }

--- a/arangod/Aql/DependencyProxy.h
+++ b/arangod/Aql/DependencyProxy.h
@@ -31,7 +31,6 @@
 
 #include <memory>
 #include <queue>
-#include <unordered_set>
 #include <utility>
 
 namespace arangodb::aql {
@@ -85,14 +84,13 @@ class DependencyProxy {
   void setDistributeId(std::string const& distId) { _distributeId = distId; }
 
  protected:
-  [[nodiscard]] ExecutionBlock& upstreamBlock();
+  [[nodiscard]] ExecutionBlock& upstreamBlock() const;
 
-  [[nodiscard]] ExecutionBlock& upstreamBlockForDependency(size_t index);
-
- private:
-  [[nodiscard]] bool advanceDependency();
+  [[nodiscard]] ExecutionBlock& upstreamBlockForDependency(size_t index) const;
 
  private:
+  [[nodiscard]] bool advanceDependency() noexcept;
+
   std::vector<ExecutionBlock*> const& _dependencies;
   RegisterCount const _nrInputRegisters;
   std::string _distributeId;

--- a/arangod/Aql/DocumentExpressionContext.cpp
+++ b/arangod/Aql/DocumentExpressionContext.cpp
@@ -85,15 +85,15 @@ AqlValue GenericDocumentExpressionContext::getVariableValue(
           }
           return AqlValue(AqlValueHintSliceNoCopy(_document));
         }
-        for (auto const& [id, regId] : _filterVarsToRegister) {
+        auto regId = registerForVariable(variable->id);
+        TRI_ASSERT(regId != RegisterId::maxRegisterId);
+        if (regId != RegisterId::maxRegisterId) {
           // we can only get here in a post-filter expression
-          if (variable->id == id) {
-            TRI_ASSERT(regId < _inputRow.getNumRegisters());
-            if (doCopy) {
-              return _inputRow.getValue(regId).clone();
-            }
-            return _inputRow.getValue(regId);
+          TRI_ASSERT(regId < _inputRow.getNumRegisters());
+          if (doCopy) {
+            return _inputRow.getValue(regId).clone();
           }
+          return _inputRow.getValue(regId);
         }
 
         // referred-to variable not found. should never happen

--- a/arangod/Aql/DocumentExpressionContext.h
+++ b/arangod/Aql/DocumentExpressionContext.h
@@ -83,7 +83,7 @@ class SimpleDocumentExpressionContext final : public DocumentExpressionContext {
                             bool& mustDestroy) const override;
 };
 
-// expression context which only has multiple variables available
+// expression context which has multiple variables available
 class GenericDocumentExpressionContext final
     : public DocumentExpressionContext {
  public:

--- a/arangod/Aql/DocumentProducingHelper.cpp
+++ b/arangod/Aql/DocumentProducingHelper.cpp
@@ -96,6 +96,7 @@ IndexIterator::DocumentCallback aql::getCallback(
     OutputAqlItemRow& output = context.getOutputRow();
     TRI_ASSERT(!output.isFull());
 
+#if 0
     auto const& p = context.getProjections();
     for (size_t i = 0; i < p.size(); ++i) {
       RegisterId registerId = context.registerForVariable(p[i].variable->id);
@@ -115,21 +116,21 @@ IndexIterator::DocumentCallback aql::getCallback(
         }
         output.moveValueInto(registerId, input, s);
       }
-    }
-#if 0
     } else {
-      // recycle our Builder object
-      VPackBuilder& objectBuilder = context.getBuilder();
-      objectBuilder.clear();
-      objectBuilder.openObject(true);
-      context.getProjections().toVelocyPackFromDocument(objectBuilder, slice,
-                                                        context.getTrxPtr());
-      objectBuilder.close();
+#endif
+    // recycle our Builder object
+    VPackBuilder& objectBuilder = context.getBuilder();
+    objectBuilder.clear();
+    objectBuilder.openObject(true);
+    context.getProjections().toVelocyPackFromDocument(objectBuilder, slice,
+                                                      context.getTrxPtr());
+    objectBuilder.close();
 
-      RegisterId registerId = context.getOutputRegister();
+    RegisterId registerId = context.getOutputRegister();
 
-      VPackSlice s = objectBuilder.slice();
-      output.moveValueInto(registerId, input, s);
+    VPackSlice s = objectBuilder.slice();
+    output.moveValueInto(registerId, input, s);
+#if 0
     }
 #endif
     TRI_ASSERT(output.produced());

--- a/arangod/Aql/DocumentProducingHelper.h
+++ b/arangod/Aql/DocumentProducingHelper.h
@@ -135,6 +135,8 @@ struct DocumentProducingFunctionContext {
 
   velocypack::Builder& getBuilder() noexcept;
 
+  RegisterId registerForVariable(VariableId id) const noexcept;
+
  private:
   bool checkFilter(DocumentProducingExpressionContext& ctx);
 

--- a/arangod/Aql/DocumentProducingNode.h
+++ b/arangod/Aql/DocumentProducingNode.h
@@ -76,6 +76,8 @@ class DocumentProducingNode {
   /// @brief return the early pruning condition for the node
   Expression* filter() const noexcept { return _filter.get(); }
 
+  void setFilterProjections(Projections projections);
+
   Projections const& filterProjections() const noexcept;
 
   /// @brief whether or not the node has an early pruning filter condition

--- a/arangod/Aql/ExecutionNode.cpp
+++ b/arangod/Aql/ExecutionNode.cpp
@@ -1761,6 +1761,8 @@ std::unique_ptr<ExecutionBlock> EnumerateCollectionNode::createBlock(
   RegisterId outputRegister = variableToRegisterId(_outVariable);
 
   auto outputRegisters = RegIdSet{};
+  outputRegisters.emplace(outputRegister);
+#if 0
   if (projections().empty()) {
     outputRegisters.emplace(outputRegister);
   } else {
@@ -1773,6 +1775,7 @@ std::unique_ptr<ExecutionBlock> EnumerateCollectionNode::createBlock(
       outputRegisters.emplace(regId);
     }
   }
+#endif
   auto registerInfos = createRegisterInfos({}, std::move(outputRegisters));
   auto executorInfos = EnumerateCollectionExecutorInfos(
       outputRegister, engine.getQuery(), collection(), _outVariable,
@@ -1845,6 +1848,9 @@ void EnumerateCollectionNode::getVariablesUsedHere(VarSet& vars) const {
 
 std::vector<Variable const*> EnumerateCollectionNode::getVariablesSetHere()
     const {
+  std::vector<Variable const*> result;
+  result.push_back(_outVariable);
+#if 0
   // determine number of variables first
   size_t n = 0;
   auto& p = _projections;
@@ -1867,7 +1873,7 @@ std::vector<Variable const*> EnumerateCollectionNode::getVariablesSetHere()
     }
     TRI_ASSERT(result.size() == n + 1);
   }
-
+#endif
   return result;
 }
 

--- a/arangod/Aql/ExecutionNode.cpp
+++ b/arangod/Aql/ExecutionNode.cpp
@@ -261,8 +261,7 @@ void ExecutionNode::getSortElements(SortElementVector& elements,
   for (VPackSlice it : VPackArrayIterator(elementsSlice)) {
     bool ascending = it.get("ascending").getBoolean();
     Variable* v = Variable::varFromVPack(plan->getAst(), it, "inVariable");
-    elements.emplace_back(
-        SortElement{v, ascending, plan->getAst()->query().resourceMonitor()});
+    elements.emplace_back(v, ascending);
     // Is there an attribute path?
     VPackSlice path = it.get("path");
     if (path.isArray()) {
@@ -270,8 +269,7 @@ void ExecutionNode::getSortElements(SortElementVector& elements,
       auto& element = elements.back();
       for (auto const& it2 : VPackArrayIterator(path)) {
         if (it2.isString()) {
-          element.attributePath.emplace_back(MonitoredString{
-              it2.copyString(), plan->getAst()->query().resourceMonitor()});
+          element.attributePath.emplace_back(it2.copyString());
         }
       }
     }
@@ -729,6 +727,13 @@ void ExecutionNode::cloneRegisterPlan(ExecutionNode* dependency) {
 /// replacements are { old variable id => new variable }
 void ExecutionNode::replaceVariables(
     std::unordered_map<VariableId, Variable const*> const& /*replacements*/) {
+  // default implementation does nothing
+}
+
+void ExecutionNode::replaceAttributeAccess(
+    ExecutionNode const* /*self*/, Variable const* /*searchVariable*/,
+    std::span<std::string_view> /*attribute*/,
+    Variable const* /*replaceVariable*/) {
   // default implementation does nothing
 }
 
@@ -1751,10 +1756,24 @@ std::unique_ptr<ExecutionBlock> EnumerateCollectionNode::createBlock(
     }
   }
 
-  auto const produceResult =
-      this->isVarUsedLater(_outVariable) || this->_filter != nullptr;
-  auto outputRegister = variableToRegisterId(_outVariable);
-  auto registerInfos = createRegisterInfos({}, RegIdSet{outputRegister});
+  auto const produceResult = this->isVarUsedLater(_outVariable) ||
+                             this->_filter != nullptr || !projections().empty();
+  RegisterId outputRegister = variableToRegisterId(_outVariable);
+
+  auto outputRegisters = RegIdSet{};
+  if (projections().empty()) {
+    outputRegisters.emplace(outputRegister);
+  } else {
+    auto const& p = projections();
+    for (size_t i = 0; i < p.size(); ++i) {
+      Variable const* var = p[i].variable;
+      TRI_ASSERT(var != nullptr);
+      auto regId = variableToRegisterId(var);
+      filterVarsToRegs.emplace_back(var->id, regId);
+      outputRegisters.emplace(regId);
+    }
+  }
+  auto registerInfos = createRegisterInfos({}, std::move(outputRegisters));
   auto executorInfos = EnumerateCollectionExecutorInfos(
       outputRegister, engine.getQuery(), collection(), _outVariable,
       produceResult, this->_filter.get(), this->projections(),
@@ -1777,7 +1796,6 @@ ExecutionNode* EnumerateCollectionNode::clone(ExecutionPlan* plan,
   auto c = std::make_unique<EnumerateCollectionNode>(
       plan, _id, collection(), outVariable, _random, _hint);
 
-  c->_projections = _projections;
   CollectionAccessingNode::cloneInto(*c);
   DocumentProducingNode::cloneInto(plan, *c);
 
@@ -1789,6 +1807,15 @@ ExecutionNode* EnumerateCollectionNode::clone(ExecutionPlan* plan,
 void EnumerateCollectionNode::replaceVariables(
     std::unordered_map<VariableId, Variable const*> const& replacements) {
   DocumentProducingNode::replaceVariables(replacements);
+}
+
+void EnumerateCollectionNode::replaceAttributeAccess(
+    ExecutionNode const* self, Variable const* searchVariable,
+    std::span<std::string_view> attribute, Variable const* replaceVariable) {
+  if (hasFilter() && self != this) {
+    filter()->replaceAttributeAccess(searchVariable, attribute,
+                                     replaceVariable);
+  }
 }
 
 void EnumerateCollectionNode::setRandom() { _random = true; }
@@ -1805,12 +1832,47 @@ void EnumerateCollectionNode::getVariablesUsedHere(VarSet& vars) const {
     // planning's assumption is that all variables that are used in a
     // node must also be used later.
     vars.erase(outVariable());
+
+    auto const& p = _projections;
+    for (size_t i = 0; i < p.size(); ++i) {
+      if (p[i].variable == nullptr) {
+        continue;
+      }
+      vars.erase(p[i].variable);
+    }
   }
 }
 
 std::vector<Variable const*> EnumerateCollectionNode::getVariablesSetHere()
     const {
-  return std::vector<Variable const*>{_outVariable};
+  // determine number of variables first
+  size_t n = 0;
+  auto& p = _projections;
+  for (size_t i = 0; i < p.size(); ++i) {
+    TRI_ASSERT(p[i].variable != nullptr);
+    ++n;
+  }
+
+  std::vector<Variable const*> result;
+  if (n == 0) {
+    result.push_back(_outVariable);
+  } else {
+    result.reserve(n + 1);
+    result.push_back(_outVariable);
+    for (size_t i = 0; i < p.size(); ++i) {
+      if (p[i].variable == nullptr) {
+        continue;
+      }
+      result.push_back(p[i].variable);
+    }
+    TRI_ASSERT(result.size() == n + 1);
+  }
+
+  return result;
+}
+
+void EnumerateCollectionNode::setProjections(Projections projections) {
+  DocumentProducingNode::setProjections(std::move(projections));
 }
 
 /// @brief the cost of an enumerate collection node is a multiple of the cost of
@@ -2226,7 +2288,7 @@ void CalculationNode::replaceVariables(
   // check if the calculation uses any of the variables that we want to
   // replace
   for (auto const& it : variables) {
-    if (replacements.find(it->id) != replacements.end()) {
+    if (replacements.contains(it->id)) {
       // calculation uses a to-be-replaced variable
       expression()->replaceVariables(replacements);
       return;
@@ -2234,8 +2296,15 @@ void CalculationNode::replaceVariables(
   }
 }
 
+void CalculationNode::replaceAttributeAccess(
+    ExecutionNode const* self, Variable const* searchVariable,
+    std::span<std::string_view> attribute, Variable const* replaceVariable) {
+  expression()->replaceAttributeAccess(searchVariable, attribute,
+                                       replaceVariable);
+}
+
 void CalculationNode::getVariablesUsedHere(VarSet& vars) const {
-  _expression->variables(vars);
+  expression()->variables(vars);
 }
 
 std::vector<Variable const*> CalculationNode::getVariablesSetHere() const {
@@ -2745,18 +2814,12 @@ ExecutionNode* NoResultsNode::clone(ExecutionPlan* plan, bool withDependencies,
 
 size_t NoResultsNode::getMemoryUsedBytes() const { return sizeof(*this); }
 
-SortElement::SortElement(Variable const* v, bool asc,
-                         arangodb::ResourceMonitor& resourceMonitor)
-    : var(v),
-      ascending(asc),
-      attributePath(
-          ResourceUsageAllocator<MonitoredStringVector, ResourceMonitor>{
-              resourceMonitor}) {}
+SortElement::SortElement(Variable const* v, bool asc)
+    : var(v), ascending(asc) {}
 
 SortElement::SortElement(Variable const* v, bool asc,
-                         MonitoredStringVector const& path,
-                         arangodb::ResourceMonitor& resourceMonitor)
-    : var(v), ascending(asc), attributePath(path, resourceMonitor) {}
+                         std::vector<std::string> path)
+    : var(v), ascending(asc), attributePath(std::move(path)) {}
 
 std::string SortElement::toString() const {
   std::string result("$");

--- a/arangod/Aql/ExecutionNode.h
+++ b/arangod/Aql/ExecutionNode.h
@@ -55,6 +55,9 @@
 #pragma once
 
 #include <memory>
+#include <span>
+#include <string>
+#include <string_view>
 #include <vector>
 #include <unordered_map>
 
@@ -106,12 +109,11 @@ size_t estimateListLength(ExecutionPlan const* plan, Variable const* var);
 struct SortElement {
   Variable const* var;
   bool ascending;
-  MonitoredStringVector attributePath;
+  std::vector<std::string> attributePath;
 
-  SortElement(Variable const* v, bool asc, arangodb::ResourceMonitor& monitor);
+  SortElement(Variable const* v, bool asc);
 
-  SortElement(Variable const* v, bool asc, MonitoredStringVector const& path,
-              arangodb::ResourceMonitor& monitor);
+  SortElement(Variable const* v, bool asc, std::vector<std::string> path);
 
   /// @brief stringify a sort element. note: the output of this should match the
   /// stringification output of an AstNode for an attribute access
@@ -352,6 +354,13 @@ class ExecutionNode {
   /// replacements are { old variable id => new variable }
   virtual void replaceVariables(
       std::unordered_map<VariableId, Variable const*> const& replacements);
+
+  /// @brief replaces an attribute access in the internals of the execution
+  /// node with a simple variable access
+  virtual void replaceAttributeAccess(ExecutionNode const* self,
+                                      Variable const* searchVariable,
+                                      std::span<std::string_view> attribute,
+                                      Variable const* replaceVariable);
 
   /// @brief check equality of ExecutionNodes
   virtual bool isEqualTo(ExecutionNode const& other) const;
@@ -676,6 +685,13 @@ class EnumerateCollectionNode : public ExecutionNode,
   void replaceVariables(std::unordered_map<VariableId, Variable const*> const&
                             replacements) override;
 
+  /// @brief replaces an attribute access in the internals of the execution
+  /// node with a simple variable access
+  void replaceAttributeAccess(ExecutionNode const* self,
+                              Variable const* searchVariable,
+                              std::span<std::string_view> attribute,
+                              Variable const* replaceVariable) override;
+
   /// @brief the cost of an enumerate collection node is a multiple of the cost
   /// of its unique dependency
   CostEstimate estimateCost() const override final;
@@ -694,6 +710,8 @@ class EnumerateCollectionNode : public ExecutionNode,
 
   /// @brief user hint regarding which index ot use
   IndexHint const& hint() const;
+
+  void setProjections(Projections projections) override;
 
  protected:
   /// @brief export to VelocyPack
@@ -857,6 +875,13 @@ class CalculationNode : public ExecutionNode {
 
   void replaceVariables(std::unordered_map<VariableId, Variable const*> const&
                             replacements) override;
+
+  /// @brief replaces an attribute access in the internals of the execution
+  /// node with a simple variable access
+  void replaceAttributeAccess(ExecutionNode const* self,
+                              Variable const* searchVariable,
+                              std::span<std::string_view> attribute,
+                              Variable const* replaceVariable) override;
 
   /// @brief getVariablesUsedHere, modifying the set in-place
   void getVariablesUsedHere(VarSet& vars) const override final;

--- a/arangod/Aql/Expression.cpp
+++ b/arangod/Aql/Expression.cpp
@@ -161,13 +161,15 @@ void Expression::replaceVariableReference(Variable const* variable,
   invalidateAfterReplacements();
 }
 
-void Expression::replaceAttributeAccess(
-    Variable const* variable, std::vector<std::string> const& attribute) {
+void Expression::replaceAttributeAccess(Variable const* searchVariable,
+                                        std::span<std::string_view> attribute,
+                                        Variable const* replaceVariable) {
   _node = _ast->clone(_node);
   TRI_ASSERT(_node != nullptr);
 
-  _node = Ast::replaceAttributeAccess(const_cast<AstNode*>(_node), variable,
-                                      attribute);
+  _node =
+      Ast::replaceAttributeAccess(ast(), const_cast<AstNode*>(_node),
+                                  searchVariable, attribute, replaceVariable);
   invalidateAfterReplacements();
 }
 
@@ -356,13 +358,11 @@ void Expression::initAccessor() {
 
   TRI_ASSERT(_node->numMembers() == 1);
   auto member = _node->getMemberUnchecked(0);
-  ResourceUsageAllocator<MonitoredStringVector, ResourceMonitor> alloc = {
-      _resourceMonitor};
-  MonitoredStringVector parts{alloc};
+  std::vector<std::string> parts;
   parts.emplace_back(_node->getString());
 
   while (member->type == NODE_TYPE_ATTRIBUTE_ACCESS) {
-    parts.insert(parts.begin(), MonitoredString{member->getString(), alloc});
+    parts.insert(parts.begin(), member->getString());
     member = member->getMemberUnchecked(0);
   }
 
@@ -376,8 +376,8 @@ void Expression::initAccessor() {
     auto v = static_cast<Variable const*>(member->getData());
 
     // specialize the simple expression into an attribute accessor
-    _accessor =
-        AttributeAccessor::create(AttributeNamePath(std::move(parts)), v);
+    _accessor = AttributeAccessor::create(
+        AttributeNamePath(std::move(parts), _resourceMonitor), v);
     TRI_ASSERT(_accessor != nullptr);
   }
 }

--- a/arangod/Aql/Expression.h
+++ b/arangod/Aql/Expression.h
@@ -24,7 +24,9 @@
 #pragma once
 
 #include <cstdint>
+#include <span>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 
 #ifdef USE_V8
@@ -149,15 +151,17 @@ class Expression {
   void stringifyIfNotTooLong(std::string& buffer) const;
 
   /// @brief replace variables in the expression with other variables
-  void replaceVariables(std::unordered_map<VariableId, Variable const*> const&);
+  void replaceVariables(
+      std::unordered_map<VariableId, Variable const*> const& replacements);
 
   /// @brief replace a variable reference in the expression with another
   /// expression (e.g. inserting c = `a + b` into expression `c + 1` so the
   /// latter becomes `a + b + 1`
   void replaceVariableReference(Variable const*, AstNode const*);
 
-  void replaceAttributeAccess(Variable const*,
-                              std::vector<std::string> const& attribute);
+  void replaceAttributeAccess(Variable const* searchVariable,
+                              std::span<std::string_view> attribute,
+                              Variable const* replaceVariable);
 
   /// @brief reset internal attributes after variables in the expression were
   /// changed

--- a/arangod/Aql/IndexNode.cpp
+++ b/arangod/Aql/IndexNode.cpp
@@ -427,8 +427,6 @@ ExecutionNode* IndexNode::clone(ExecutionPlan* plan, bool withDependencies,
                                        _indexes, _allCoveredByOneIndex,
                                        _condition->clone(), _options);
 
-  c->_projections = _projections;
-  c->_filterProjections = _filterProjections;
   c->needsGatherNodeSort(_needsGatherNodeSort);
   c->_outNonMaterializedDocId = outNonMaterializedDocId;
   c->_outNonMaterializedIndVars = std::move(outNonMaterializedIndVars);
@@ -442,6 +440,19 @@ ExecutionNode* IndexNode::clone(ExecutionPlan* plan, bool withDependencies,
 void IndexNode::replaceVariables(
     std::unordered_map<VariableId, Variable const*> const& replacements) {
   DocumentProducingNode::replaceVariables(replacements);
+  if (_condition) {
+    _condition->replaceVariables(replacements);
+  }
+}
+
+void IndexNode::replaceAttributeAccess(ExecutionNode const* self,
+                                       Variable const* searchVariable,
+                                       std::span<std::string_view> attribute,
+                                       Variable const* replaceVariable) {
+  if (_condition) {
+    _condition->replaceAttributeAccess(searchVariable, attribute,
+                                       replaceVariable);
+  }
 }
 
 /// @brief destroy the IndexNode

--- a/arangod/Aql/IndexNode.h
+++ b/arangod/Aql/IndexNode.h
@@ -105,6 +105,11 @@ class IndexNode : public ExecutionNode,
   void replaceVariables(std::unordered_map<VariableId, Variable const*> const&
                             replacements) override;
 
+  void replaceAttributeAccess(ExecutionNode const* self,
+                              Variable const* searchVariable,
+                              std::span<std::string_view> attribute,
+                              Variable const* replaceVariable) override;
+
   /// @brief getVariablesSetHere
   std::vector<Variable const*> getVariablesSetHere() const override final;
 

--- a/arangod/Aql/JoinNode.cpp
+++ b/arangod/Aql/JoinNode.cpp
@@ -120,8 +120,9 @@ JoinNode::JoinNode(ExecutionPlan* plan, arangodb::velocypack::Slice const& base)
     // index
     std::string iid = it.get("index").get("id").copyString();
 
-    auto projections = Projections::fromVelocyPack(
-        it, "projections", plan->getAst()->query().resourceMonitor());
+    auto projections =
+        Projections::fromVelocyPack(plan->getAst(), it, "projections",
+                                    plan->getAst()->query().resourceMonitor());
 
     bool const usedAsSatellite = it.get("usedAsSatellite").isTrue();
 

--- a/arangod/Aql/LateMaterializedExpressionContext.cpp
+++ b/arangod/Aql/LateMaterializedExpressionContext.cpp
@@ -67,15 +67,15 @@ AqlValue LateMaterializedExpressionContext::getVariableValue(
           return AqlValue(AqlValueHintSliceNoCopy(s));
         }
 
-        for (auto const& [id, regId] : _filterVarsToRegister) {
+        auto regId = registerForVariable(variable->id);
+        TRI_ASSERT(regId != RegisterId::maxRegisterId);
+        if (regId != RegisterId::maxRegisterId) {
           // we can only get here in a post-filter expression
-          if (variable->id == id) {
-            TRI_ASSERT(regId < _inputRow.getNumRegisters());
-            if (doCopy) {
-              return _inputRow.getValue(regId).clone();
-            }
-            return _inputRow.getValue(regId);
+          TRI_ASSERT(regId < _inputRow.getNumRegisters());
+          if (doCopy) {
+            return _inputRow.getValue(regId).clone();
           }
+          return _inputRow.getValue(regId);
         }
 
         // should never happen

--- a/arangod/Aql/OptimizerRules.cpp
+++ b/arangod/Aql/OptimizerRules.cpp
@@ -2199,8 +2199,7 @@ void arangodb::aql::specializeCollectRule(Optimizer* opt,
           // add the post-SORT
           SortElementVector sortElements;
           for (auto const& v : collectNode->groupVariables()) {
-            sortElements.emplace_back(SortElement{
-                v.outVar, true, plan->getAst()->query().resourceMonitor()});
+            sortElements.emplace_back(v.outVar, true);
           }
 
           auto sortNode = plan->createNode<SortNode>(plan.get(), plan->nextId(),
@@ -2237,8 +2236,7 @@ void arangodb::aql::specializeCollectRule(Optimizer* opt,
         // add the post-SORT
         SortElementVector sortElements;
         for (auto const& v : newCollectNode->groupVariables()) {
-          sortElements.emplace_back(SortElement{
-              v.outVar, true, plan->getAst()->query().resourceMonitor()});
+          sortElements.emplace_back(v.outVar, true);
         }
 
         auto sortNode = newPlan->createNode<SortNode>(
@@ -2285,8 +2283,7 @@ void arangodb::aql::specializeCollectRule(Optimizer* opt,
     if (!groupVariables.empty()) {
       SortElementVector sortElements;
       for (auto const& v : groupVariables) {
-        sortElements.emplace_back(SortElement{
-            v.inVar, true, plan->getAst()->query().resourceMonitor()});
+        sortElements.emplace_back(v.inVar, true);
       }
 
       auto sortNode = plan->createNode<SortNode>(plan.get(), plan->nextId(),
@@ -3878,11 +3875,8 @@ auto insertGatherNode(
       // also check if we actually need to bother about the sortedness of the
       // result, or if we use the index for filtering only
       if (first->isSorted() && idxNode->needsGatherNodeSort()) {
-        for (auto const& path : first->trackedFieldNames(
-                 plan.getAst()->query().resourceMonitor())) {
-          elements.emplace_back(
-              SortElement{sortVariable, isSortAscending, path,
-                          plan.getAst()->query().resourceMonitor()});
+        for (auto const& path : first->fieldNames()) {
+          elements.emplace_back(sortVariable, isSortAscending, path);
         }
         for (auto const& it : allIndexes) {
           if (first != it) {

--- a/arangod/Aql/OptimizerRules.cpp
+++ b/arangod/Aql/OptimizerRules.cpp
@@ -1067,18 +1067,16 @@ bool optimizeTraversalPathVariable(
   bool producePathsWeights = false;
 
   for (auto const& it : attributes) {
-    TRI_ASSERT(!it._path.empty());
+    TRI_ASSERT(!it.empty());
     if (!producePathsVertices &&
-        it._path[0] == std::string_view{StaticStrings::GraphQueryVertices}) {
+        it[0] == std::string_view{StaticStrings::GraphQueryVertices}) {
       producePathsVertices = true;
     } else if (!producePathsEdges &&
-               it._path[0] ==
-                   std::string_view{StaticStrings::GraphQueryEdges}) {
+               it[0] == std::string_view{StaticStrings::GraphQueryEdges}) {
       producePathsEdges = true;
     } else if (!producePathsWeights &&
                options->mode == traverser::TraverserOptions::Order::WEIGHTED &&
-               it._path[0] ==
-                   std::string_view{StaticStrings::GraphQueryWeights}) {
+               it[0] == std::string_view{StaticStrings::GraphQueryWeights}) {
       producePathsWeights = true;
     }
   }

--- a/arangod/Aql/OptimizerRulesReplaceFunctions.cpp
+++ b/arangod/Aql/OptimizerRulesReplaceFunctions.cpp
@@ -316,9 +316,7 @@ AstNode* replaceNearOrWithin(AstNode* funAstNode, ExecutionNode* calcNode,
   ExecutionNode* eSortOrFilter = nullptr;
   if (isNear) {
     // use calculation node in sort node
-    SortElementVector sortElements{
-        SortElement{calcOutVariable, /*asc*/ true,
-                    plan->getAst()->query().resourceMonitor()}};
+    SortElementVector sortElements{SortElement{calcOutVariable, /*asc*/ true}};
     eSortOrFilter =
         plan->createNode<SortNode>(plan, plan->nextId(), sortElements, false);
   } else {

--- a/arangod/Aql/OptimizerUtils.cpp
+++ b/arangod/Aql/OptimizerUtils.cpp
@@ -1019,7 +1019,8 @@ bool findProjections(ExecutionNode* n, Variable const* v,
           }
           // insert attribute name into the set of attributes that we need for
           // our projection
-          attributes.emplace(AttributeNamePath(it.attributePath));
+          attributes.emplace(it.attributePath,
+                             gn->plan()->getAst()->query().resourceMonitor());
         }
       }
     } else if (current->getType() == EN::ENUMERATE_COLLECTION) {

--- a/arangod/Aql/OptimizerUtils.h
+++ b/arangod/Aql/OptimizerUtils.h
@@ -44,7 +44,7 @@ namespace aql {
 
 class Ast;
 struct AstNode;
-struct AttributeNamePath;
+class AttributeNamePath;
 struct Collection;
 class ExecutionNode;
 class IndexHint;

--- a/arangod/Aql/Projections.cpp
+++ b/arangod/Aql/Projections.cpp
@@ -22,6 +22,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #include "Aql/Projections.h"
+#include "Aql/Variable.h"
 #include "Basics/Exceptions.h"
 #include "Basics/ResourceUsage.h"
 #include "Basics/debugging.h"
@@ -49,10 +50,6 @@ namespace arangodb::aql {
 Projections::Projections() = default;
 
 Projections::Projections(std::vector<AttributeNamePath> paths) {
-  init(std::move(paths));
-}
-
-Projections::Projections(std::unordered_set<AttributeNamePath> paths) {
   init(std::move(paths));
 }
 
@@ -281,42 +278,54 @@ void Projections::toVelocyPack(velocypack::Builder& b,
                                std::string_view key) const {
   b.add(key, VPackValue(VPackValueType::Array));
   for (auto const& it : _projections) {
-    if (it.path.size() == 1) {
-      // projection on a top-level attribute. will be returned as a string
-      // for downwards-compatibility
-      b.add(VPackValue(it.path[0]));
-    } else {
-      // projection on a nested attribute (e.g. a.b.c). will be returned as an
-      // array. this kind of projection did not exist before 3.7
-      b.openArray();
-      for (auto const& attribute : it.path._path) {
-        b.add(VPackValue(attribute));
-      }
-      b.close();
+    b.openObject();
+    b.add("path", VPackValueType::Array);
+    for (auto const& attribute : it.path._path) {
+      b.add(VPackValue(attribute));
     }
+    b.close();  // path
+    if (it.variable != nullptr) {
+      b.add(VPackValue("variable"));
+      it.variable->toVelocyPack(b);
+    }
+    b.close();  // object
   }
   b.close();
 }
 
 /*static*/ Projections Projections::fromVelocyPack(
-    velocypack::Slice slice, arangodb::ResourceMonitor& resourceMonitor) {
-  return fromVelocyPack(slice, ::projectionsKey, resourceMonitor);
+    Ast* ast, velocypack::Slice slice, ResourceMonitor& resourceMonitor) {
+  return fromVelocyPack(ast, slice, ::projectionsKey, resourceMonitor);
 }
 
 /*static*/ Projections Projections::fromVelocyPack(
-    velocypack::Slice slice, std::string_view key,
-    arangodb::ResourceMonitor& resourceMonitor) {
+    Ast* ast, velocypack::Slice slice, std::string_view key,
+    ResourceMonitor& resourceMonitor) {
   std::vector<AttributeNamePath> projections;
+
+  std::unordered_map<AttributeNamePath, Variable const*> vars;
 
   VPackSlice p = slice.get(key);
   if (p.isArray()) {
-    for (auto const& it : velocypack::ArrayIterator(p)) {
-      if (it.isString()) {
+    for (auto it : velocypack::ArrayIterator(p)) {
+      if (it.isObject()) {
+        // { path: [...], variable: ... }
+        AttributeNamePath path{resourceMonitor};
+        for (auto it2 : velocypack::ArrayIterator(it.get("path"))) {
+          path._path.emplace_back(it2.copyString());
+        }
+        if (auto v = it.get("variable"); !v.isNone()) {
+          Variable const* variable =
+              Variable::varFromVPack(ast, it, "variable");
+          vars.emplace(path, variable);
+        }
+        projections.emplace_back(std::move(path));
+      } else if (it.isString()) {
         projections.emplace_back(
             AttributeNamePath(it.copyString(), resourceMonitor));
       } else if (it.isArray()) {
         AttributeNamePath path{resourceMonitor};
-        for (auto const& it2 : velocypack::ArrayIterator(it)) {
+        for (auto it2 : velocypack::ArrayIterator(it)) {
           path._path.emplace_back(it2.copyString());
         }
         projections.emplace_back(std::move(path));
@@ -324,7 +333,16 @@ void Projections::toVelocyPack(velocypack::Builder& b,
     }
   }
 
-  return Projections(std::move(projections));
+  // fiddle variables into projections
+  auto result = Projections(std::move(projections));
+
+  for (size_t i = 0; i < result.size(); ++i) {
+    auto it2 = vars.find(result[i].path);
+    if (it2 != vars.end()) {
+      result[i].variable = (*it2).second;
+    }
+  }
+  return result;
 }
 
 /// @brief shared init function
@@ -350,7 +368,8 @@ void Projections::init(T paths) {
     _projections.emplace_back(
         Projection{std::move(path), kNoCoveringIndexPosition,
                    /*coveringIndexCutoff*/ 0, /*startsAtLevel*/ 0,
-                   /*levelsToClose*/ static_cast<uint16_t>(length - 1), type});
+                   /*levelsToClose*/ static_cast<uint16_t>(length - 1), type,
+                   /*variable*/ nullptr});
   }
 
   TRI_ASSERT(_projections.size() <= paths.size());
@@ -360,10 +379,6 @@ void Projections::init(T paths) {
   std::for_each(_projections.begin(), _projections.end(),
                 [](auto const& it) { TRI_ASSERT(!it.path.empty()); });
 #endif
-
-  if (_projections.size() <= 1) {
-    //    return;
-  }
 
   // sort projections by attribute path, so we have similar prefixes next to
   // each other, e.g.
@@ -467,8 +482,6 @@ std::ostream& operator<<(std::ostream& stream, Projections const& projections) {
 
 template void Projections::init<std::vector<AttributeNamePath>>(
     std::vector<AttributeNamePath> paths);
-template void Projections::init<std::unordered_set<AttributeNamePath>>(
-    std::unordered_set<AttributeNamePath> paths);
 template void Projections::init<containers::FlatHashSet<AttributeNamePath>>(
     containers::FlatHashSet<AttributeNamePath> paths);
 

--- a/arangod/Aql/Projections.cpp
+++ b/arangod/Aql/Projections.cpp
@@ -138,7 +138,7 @@ void Projections::toVelocyPackFromDocument(
       // projection for any other top-level attribute
       TRI_ASSERT(levelsOpen == 0);
       TRI_ASSERT(it.path.size() == 1);
-      VPackSlice found = slice.get(it.path._path.at(0));
+      VPackSlice found = slice.get(it.path.get().at(0));
       if (found.isNone()) {
         // attribute not found
         b.add(it.path[0], VPackValue(VPackValueType::Null));
@@ -348,7 +348,7 @@ void Projections::toVelocyPack(velocypack::Builder& b,
   for (auto const& it : _projections) {
     b.openObject();
     b.add("path", VPackValueType::Array);
-    for (auto const& attribute : it.path._path) {
+    for (auto const& attribute : it.path.get()) {
       b.add(VPackValue(attribute));
     }
     b.close();  // path
@@ -380,7 +380,7 @@ void Projections::toVelocyPack(velocypack::Builder& b,
         // { path: [...], variable: ... }
         AttributeNamePath path{resourceMonitor};
         for (auto it2 : velocypack::ArrayIterator(it.get("path"))) {
-          path._path.emplace_back(it2.copyString());
+          path.add(it2.copyString());
         }
         if (auto v = it.get("variable"); !v.isNone()) {
           Variable const* variable =
@@ -394,7 +394,7 @@ void Projections::toVelocyPack(velocypack::Builder& b,
       } else if (it.isArray()) {
         AttributeNamePath path{resourceMonitor};
         for (auto it2 : velocypack::ArrayIterator(it)) {
-          path._path.emplace_back(it2.copyString());
+          path.add(it2.copyString());
         }
         projections.emplace_back(std::move(path));
       }

--- a/arangod/Aql/Projections.h
+++ b/arangod/Aql/Projections.h
@@ -31,7 +31,6 @@
 #include <limits>
 #include <memory>
 #include <string_view>
-#include <unordered_set>
 #include <vector>
 
 namespace arangodb {
@@ -48,6 +47,8 @@ class Slice;
 }  // namespace velocypack
 
 namespace aql {
+class Ast;
+struct Variable;
 
 /// @brief helper class to manage projections and extract attribute data from
 /// documents and index entries
@@ -68,6 +69,8 @@ class Projections {
     uint16_t levelsToClose;
     /// @brief attribute type
     AttributeNamePath::Type type;
+
+    Variable const* variable;
   };
 
   static constexpr uint16_t kNoCoveringIndexPosition =
@@ -78,7 +81,6 @@ class Projections {
   /// @brief create projections from the vector of attributes passed.
   /// attributes will be sorted and made unique inside
   explicit Projections(std::vector<AttributeNamePath> paths);
-  explicit Projections(std::unordered_set<AttributeNamePath> paths);
   explicit Projections(containers::FlatHashSet<AttributeNamePath> paths);
 
   Projections(Projections&&) = default;
@@ -145,14 +147,14 @@ class Projections {
 
   /// @brief build projections from velocypack, looking for the attribute
   /// name "projections"
-  static Projections fromVelocyPack(velocypack::Slice slice,
-                                    arangodb::ResourceMonitor& resourceMonitor);
+  static Projections fromVelocyPack(Ast* ast, velocypack::Slice slice,
+                                    ResourceMonitor& resourceMonitor);
 
   /// @brief build projections from velocypack, looking for a custom
   /// attribute name
-  static Projections fromVelocyPack(velocypack::Slice slice,
+  static Projections fromVelocyPack(Ast* ast, velocypack::Slice slice,
                                     std::string_view attributeName,
-                                    arangodb::ResourceMonitor& resourceMonitor);
+                                    ResourceMonitor& resourceMonitor);
 
  private:
   /// @brief shared init function

--- a/arangod/Aql/RegisterPlan.cpp
+++ b/arangod/Aql/RegisterPlan.cpp
@@ -37,6 +37,7 @@
 #include "Basics/Exceptions.h"
 #include "Containers/Enumerate.h"
 
+#include <absl/strings/str_cat.h>
 #include <velocypack/Builder.h>
 #include <velocypack/Iterator.h>
 #include <velocypack/Slice.h>
@@ -176,14 +177,14 @@ void RegisterPlanWalkerT<T>::after(T* en) {
             // report an error here to prevent crashing
             THROW_ARANGO_EXCEPTION_MESSAGE(
                 TRI_ERROR_INTERNAL,
-                std::string("missing variable ") +
-                    ((!v->name.empty() && v->name[0] >= '0' &&
-                      v->name[0] <= '9')
-                         ? "#"
-                         : "") +
-                    v->name + " (id " + std::to_string(v->id) + ") for node #" +
-                    std::to_string(en->id().id()) + " (" + en->getTypeString() +
-                    ") while planning registers");
+                absl::StrCat("missing variable ",
+                             ((!v->name.empty() && v->name[0] >= '0' &&
+                               v->name[0] <= '9')
+                                  ? "#"
+                                  : ""),
+                             v->name, " (id ", v->id, ") for node #",
+                             en->id().id(), " (", en->getTypeString(),
+                             ") while planning registers"));
           }
         }
       }

--- a/arangod/Aql/SimpleModifier.cpp
+++ b/arangod/Aql/SimpleModifier.cpp
@@ -210,8 +210,8 @@ ExecutionState SimpleModifier<ModifierCompletion, Enable>::transact(
   // available.
   guard.unlock();
 
-  auto self = this->shared_from_this();
-  std::move(result).thenFinal([self, sqs = _infos.engine()->sharedState()](
+  std::move(result).thenFinal([self = this->shared_from_this(),
+                               sqs = _infos.engine()->sharedState()](
                                   futures::Try<OperationResult>&& opRes) {
     sqs->executeAndWakeup([&]() noexcept {
       std::unique_lock<std::mutex> guard(self->_resultMutex);

--- a/arangod/Aql/SimpleModifier.h
+++ b/arangod/Aql/SimpleModifier.h
@@ -26,11 +26,9 @@
 #include "Aql/ExecutionBlock.h"
 #include "Aql/ExecutionState.h"
 #include "Aql/ExecutionEngine.h"
-
+#include "Aql/InsertModifier.h"
 #include "Aql/ModificationExecutorAccumulator.h"
 #include "Aql/ModificationExecutorInfos.h"
-
-#include "Aql/InsertModifier.h"
 #include "Aql/RemoveModifier.h"
 #include "Aql/UpdateReplaceModifier.h"
 
@@ -113,7 +111,6 @@ class SimpleModifier : public std::enable_shared_from_this<
     VPackArrayIterator _resultsIterator;
   };
 
- public:
   explicit SimpleModifier(ModificationExecutorInfos& infos)
       : _infos(infos),
         _completion(infos),

--- a/arangod/Aql/SortRegister.h
+++ b/arangod/Aql/SortRegister.h
@@ -25,8 +25,10 @@
 #pragma once
 
 #include "Aql/ExecutionNode.h"
-#include "Basics/MemoryTypes/MemoryTypes.h"
-#include "types.h"
+#include "Aql/types.h"
+
+#include <string>
+#include <vector>
 
 namespace arangodb {
 namespace aql {
@@ -37,7 +39,7 @@ struct SortRegister {
   SortRegister(SortRegister&) = delete;  // we can not copy the ireseach scorer
   SortRegister(SortRegister&&) = default;
 
-  MonitoredStringVector const& attributePath;
+  std::vector<std::string> const& attributePath;
   RegisterId reg;
   bool asc;
 

--- a/arangod/Graph/BaseOptions.cpp
+++ b/arangod/Graph/BaseOptions.cpp
@@ -702,8 +702,8 @@ void BaseOptions::parseShardIndependentFlags(arangodb::velocypack::Slice info) {
       _vertexProjections.clear();
     }
 
-    _vertexProjections = Projections::fromVelocyPack(info, "vertexProjections",
-                                                     resourceMonitor());
+    _vertexProjections = Projections::fromVelocyPack(
+        _query.ast(), info, "vertexProjections", resourceMonitor());
     try {
       resourceMonitor().increaseMemoryUsage(
           getVertexProjections().size() * sizeof(aql::Projections::Projection));
@@ -719,8 +719,8 @@ void BaseOptions::parseShardIndependentFlags(arangodb::velocypack::Slice info) {
           getEdgeProjections().size() * sizeof(aql::Projections::Projection));
       _edgeProjections.clear();
     }
-    _edgeProjections =
-        Projections::fromVelocyPack(info, "edgeProjections", resourceMonitor());
+    _edgeProjections = Projections::fromVelocyPack(
+        _query.ast(), info, "edgeProjections", resourceMonitor());
     try {
       resourceMonitor().increaseMemoryUsage(
           getEdgeProjections().size() * sizeof(aql::Projections::Projection));

--- a/arangod/IResearch/IResearchInvertedIndex.cpp
+++ b/arangod/IResearch/IResearchInvertedIndex.cpp
@@ -938,8 +938,8 @@ bool IResearchInvertedIndex::covers(aql::Projections& projections) const {
     aql::latematerialized::AttributeAndField<
         aql::latematerialized::IndexFieldData>
         af;
-    af.attr.reserve(projections[i].path._path.size());
-    for (auto const& a : projections[i].path._path) {
+    af.attr.reserve(projections[i].path.size());
+    for (auto const& a : projections[i].path.get()) {
       af.attr.emplace_back(a, false);  // TODO: false?
     }
     attrs.emplace_back(af);

--- a/arangod/Indexes/Index.h
+++ b/arangod/Indexes/Index.h
@@ -189,26 +189,6 @@ class Index {
     return result;
   }
 
-  /// @brief return the index fields names incl. tracking the resources
-  /// using a resourceMonitor. This needed to be implemented next to the
-  /// method above as we do not have always a resourceMonitor in place
-  /// when acquiring the index fields names.
-  std::vector<MonitoredStringVector> trackedFieldNames(
-      arangodb::ResourceMonitor& resourceMonitor) const {
-    std::vector<MonitoredStringVector> result;
-    result.reserve(_fields.size());
-
-    for (auto const& it : _fields) {
-      MonitoredStringVector parts{resourceMonitor};
-      parts.reserve(it.size());
-      for (auto const& it2 : it) {
-        parts.emplace_back(it2.name);
-      }
-      result.emplace_back(std::move(parts));
-    }
-    return result;
-  }
-
   /// @brief whether or not the ith attribute is expanded (somewhere)
   bool isAttributeExpanded(size_t i) const {
     if (i >= _fields.size()) {

--- a/arangod/RocksDBEngine/RocksDBOptimizerRules.cpp
+++ b/arangod/RocksDBEngine/RocksDBOptimizerRules.cpp
@@ -275,7 +275,7 @@ void RocksDBOptimizerRules::reduceExtractionToProjectionRule(
       } else {
         // store projections in DocumentProducingNode
         e->setProjections(std::move(projections));
-
+#if 0
         auto& p = e->projections();
         std::vector<std::string_view> path;
         for (size_t i = 0; i < p.size(); ++i) {
@@ -292,6 +292,7 @@ void RocksDBOptimizerRules::reduceExtractionToProjectionRule(
                                            p[i].variable);
           plan->root()->walk(replacer);
         }
+#endif
       }
 
       modified = true;

--- a/arangod/RocksDBEngine/RocksDBOptimizerRules.cpp
+++ b/arangod/RocksDBEngine/RocksDBOptimizerRules.cpp
@@ -45,6 +45,8 @@
 #include "Indexes/Index.h"
 #include "VocBase/LogicalCollection.h"
 
+#include <span>
+
 using namespace arangodb;
 using namespace arangodb::aql;
 using EN = arangodb::aql::ExecutionNode;
@@ -54,6 +56,37 @@ namespace {
 std::initializer_list<ExecutionNode::NodeType> const
     reduceExtractionToProjectionTypes = {ExecutionNode::ENUMERATE_COLLECTION,
                                          ExecutionNode::INDEX};
+
+class AttributeAccessReplacer final
+    : public WalkerWorker<ExecutionNode, WalkerUniqueness::NonUnique> {
+ public:
+  AttributeAccessReplacer(ExecutionNode const* self,
+                          Variable const* searchVariable,
+                          std::span<std::string_view> attribute,
+                          Variable const* replaceVariable)
+      : _self(self),
+        _searchVariable(searchVariable),
+        _attribute(attribute),
+        _replaceVariable(replaceVariable) {
+    TRI_ASSERT(_searchVariable != nullptr);
+    TRI_ASSERT(!_attribute.empty());
+    TRI_ASSERT(_replaceVariable != nullptr);
+  }
+
+  bool before(ExecutionNode* en) override final {
+    en->replaceAttributeAccess(_self, _searchVariable, _attribute,
+                               _replaceVariable);
+
+    // always continue
+    return false;
+  }
+
+ private:
+  ExecutionNode const* _self;
+  Variable const* _searchVariable;
+  std::span<std::string_view> _attribute;
+  Variable const* _replaceVariable;
+};
 
 }  // namespace
 
@@ -242,6 +275,23 @@ void RocksDBOptimizerRules::reduceExtractionToProjectionRule(
       } else {
         // store projections in DocumentProducingNode
         e->setProjections(std::move(projections));
+
+        auto& p = e->projections();
+        std::vector<std::string_view> path;
+        for (size_t i = 0; i < p.size(); ++i) {
+          TRI_ASSERT(p[i].variable == nullptr);
+          p[i].variable =
+              plan->getAst()->variables()->createTemporaryVariable();
+
+          path.clear();
+          for (auto const& it : p[i].path.get()) {
+            path.emplace_back(it);
+          }
+
+          AttributeAccessReplacer replacer(n, e->outVariable(), std::span(path),
+                                           p[i].variable);
+          plan->root()->walk(replacer);
+        }
       }
 
       modified = true;

--- a/js/common/modules/@arangodb/aql/explainer.js
+++ b/js/common/modules/@arangodb/aql/explainer.js
@@ -1167,13 +1167,24 @@ function processQuery(query, explain, planIndex) {
 
   const projections = function (value, attributeName, label) {
     if (value && value.hasOwnProperty(attributeName) && value[attributeName].length > 0) {
-      let p = value[attributeName].map(function(p) {
+      let fields = value[attributeName].map(function(p) {
         if (Array.isArray(p)) {
-          return p.join('`.`', p);
+          return '`' + p.join('`.`') + '`';
+        } else if (typeof p === 'String') {
+          return '`' + p + '`';
+        } else if (p.hasOwnProperty('path')) {
+          let path = '`' + p.path.join('`.`') + '`';
+          if (p.hasOwnProperty('variable')) {
+            if (/^[0-9_]/.test(p.variable.name)) {
+              path += ': #' + p.variable.name;
+            } else {
+              path += ': ' + p.variable.name;
+            }
+          }
+          return path;
         }
-        return p;
       });
-      return ' (' + label + ': `' + p.join('`, `') + '`)';
+      return ' (' + label + ': ' + fields.join(', ') + ')';
     }
     return '';
   };

--- a/js/common/modules/@arangodb/aql/explainer.js
+++ b/js/common/modules/@arangodb/aql/explainer.js
@@ -1170,7 +1170,7 @@ function processQuery(query, explain, planIndex) {
       let fields = value[attributeName].map(function(p) {
         if (Array.isArray(p)) {
           return '`' + p.join('`.`') + '`';
-        } else if (typeof p === 'String') {
+        } else if (typeof p === 'string') {
           return '`' + p + '`';
         } else if (p.hasOwnProperty('path')) {
           let path = '`' + p.path.join('`.`') + '`';

--- a/js/server/modules/@arangodb/aql-helper.js
+++ b/js/server/modules/@arangodb/aql-helper.js
@@ -441,6 +441,21 @@ function sanitizeStats (stats) {
   return stats;
 }
 
+function normalizeProjections (p) {
+  return (p || []).map((p) => {
+    if (Array.isArray(p)) {
+      return p;
+    }
+    if (typeof p === 'string') {
+      return [p];
+    }
+    if (p.hasOwnProperty("path")) {
+      return p.path;
+    }
+    return [];
+  }).sort();
+}
+
 exports.getParseResults = getParseResults;
 exports.assertParseError = assertParseError;
 exports.getQueryExplanation = getQueryExplanation;
@@ -461,3 +476,4 @@ exports.removeClusterNodesFromPlan = removeClusterNodesFromPlan;
 exports.removeCost = removeCost;
 exports.unpackRawExpression = unpackRawExpression;
 exports.sanitizeStats = sanitizeStats;
+exports.normalizeProjections = normalizeProjections;

--- a/tests/Aql/AttributeNamePathTest.cpp
+++ b/tests/Aql/AttributeNamePathTest.cpp
@@ -23,7 +23,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #include "Basics/GlobalResourceMonitor.h"
-#include "Basics/MemoryTypes/MemoryTypes.h"
 #include "gtest/gtest.h"
 
 #include "Aql/AttributeNamePath.h"
@@ -33,11 +32,7 @@ using namespace arangodb::aql;
 namespace {
 auto createAttributeNamePath = [](std::vector<std::string>&& vec,
                                   arangodb::ResourceMonitor& resMonitor) {
-  arangodb::MonitoredStringVector myVector{resMonitor};
-  for (auto& s : vec) {
-    myVector.emplace_back(s);
-  }
-  return AttributeNamePath(std::move(myVector));
+  return AttributeNamePath(std::move(vec), resMonitor);
 };
 }
 
@@ -48,7 +43,7 @@ TEST(AttributeNamePathTest, empty) {
   ASSERT_TRUE(p.empty());
   ASSERT_EQ(0, p.size());
 
-  p._path.emplace_back("test");
+  p.add("test");
   ASSERT_FALSE(p.empty());
   ASSERT_EQ(1, p.size());
 }
@@ -60,7 +55,7 @@ TEST(AttributeNamePathTest, size) {
   ASSERT_EQ(0, p.size());
 
   for (size_t i = 0; i < 10; ++i) {
-    p._path.emplace_back("test");
+    p.add("test");
     ASSERT_EQ(i + 1, p.size());
   }
 }
@@ -126,9 +121,9 @@ TEST(AttributeNamePathTest, atLong) {
   arangodb::GlobalResourceMonitor global{};
   arangodb::ResourceMonitor monitor{global};
   AttributeNamePath p{monitor};
-  p._path.emplace_back("foo");
-  p._path.emplace_back("bar");
-  p._path.emplace_back("baz");
+  p.add("foo");
+  p.add("bar");
+  p.add("baz");
 
   ASSERT_EQ("foo", p[0]);
   ASSERT_EQ("bar", p[1]);
@@ -146,23 +141,23 @@ TEST(AttributeNamePathTest, equalsLong) {
   arangodb::GlobalResourceMonitor global{};
   arangodb::ResourceMonitor monitor{global};
   AttributeNamePath p1{monitor};
-  p1._path.emplace_back("foo");
-  p1._path.emplace_back("bar");
-  p1._path.emplace_back("baz");
+  p1.add("foo");
+  p1.add("bar");
+  p1.add("baz");
 
   AttributeNamePath p2{monitor};
-  p2._path.emplace_back("foo");
-  p2._path.emplace_back("bar");
-  p2._path.emplace_back("baz");
+  p2.add("foo");
+  p2.add("bar");
+  p2.add("baz");
 
   ASSERT_TRUE(p1 == p2);
   ASSERT_FALSE(p1 != p2);
 
-  p1._path.pop_back();
+  p1.pop();
   ASSERT_FALSE(p1 == p2);
   ASSERT_TRUE(p1 != p2);
 
-  p2._path.pop_back();
+  p2.pop();
   ASSERT_TRUE(p1 == p2);
   ASSERT_FALSE(p1 != p2);
 }

--- a/tests/Aql/GatherExecutorCommonTest.cpp
+++ b/tests/Aql/GatherExecutorCommonTest.cpp
@@ -696,7 +696,7 @@ class CommonGatherExecutorTest
 
   // We need to retain the memory of this SortElement. Otherwise we have invalid
   // memory access, for sorting nodes.
-  SortElement _sortElement{nullptr, true, _resMonitor};
+  SortElement _sortElement{nullptr, true};
 
 };  // namespace arangodb::tests::aql
 

--- a/tests/Aql/ProjectionsTest.cpp
+++ b/tests/Aql/ProjectionsTest.cpp
@@ -43,11 +43,7 @@ using namespace arangodb::tests;
 namespace {
 auto createAttributeNamePath = [](std::vector<std::string>&& vec,
                                   arangodb::ResourceMonitor& resMonitor) {
-  arangodb::MonitoredStringVector myVector{resMonitor};
-  for (auto& s : vec) {
-    myVector.emplace_back(s);
-  }
-  return AttributeNamePath(std::move(myVector));
+  return AttributeNamePath(std::move(vec), resMonitor);
 };
 }
 

--- a/tests/Aql/SortExecutorTest.cpp
+++ b/tests/Aql/SortExecutorTest.cpp
@@ -75,7 +75,7 @@ class SortExecutorTest : public AqlExecutorTestCaseWithParam<SortInputParam> {
   }
 
   auto makeRegisterInfos(size_t nestingLevel = 1) -> RegisterInfos {
-    SortElement sl{&sortVar, true, _resMonitor};
+    SortElement sl{&sortVar, true};
     SortRegister sortReg{0, sl};
     std::vector<SortRegister> sortRegisters;
     sortRegisters.emplace_back(std::move(sortReg));
@@ -93,7 +93,7 @@ class SortExecutorTest : public AqlExecutorTestCaseWithParam<SortInputParam> {
       tempStorage = std::make_unique<TemporaryStorageFeature>(
           fakedQuery->vocbase().server());
     }
-    SortElement sl{&sortVar, true, _resMonitor};
+    SortElement sl{&sortVar, true};
     SortRegister sortReg{0, sl};
     std::vector<SortRegister> sortRegisters;
     sortRegisters.emplace_back(std::move(sortReg));

--- a/tests/IResearch/IResearchInvertedIndexConditionTest.cpp
+++ b/tests/IResearch/IResearchInvertedIndexConditionTest.cpp
@@ -52,11 +52,7 @@ using namespace arangodb::aql;
 namespace {
 auto createAttributeNamePath = [](std::vector<std::string>&& vec,
                                   arangodb::ResourceMonitor& resMonitor) {
-  arangodb::MonitoredStringVector myVector{resMonitor};
-  for (auto& s : vec) {
-    myVector.emplace_back(s);
-  }
-  return AttributeNamePath(std::move(myVector));
+  return AttributeNamePath(std::move(vec), resMonitor);
 };
 }
 

--- a/tests/js/common/shell/shell-index-stored-values.js
+++ b/tests/js/common/shell/shell-index-stored-values.js
@@ -31,6 +31,21 @@ const errors = internal.errors;
   
 const cn = "UnitTestsCollectionIdx";
 
+const normalize = (p) => {
+  return (p || []).map((p) => {
+    if (Array.isArray(p)) {
+      return p;
+    }
+    if (typeof p === 'string') {
+      return [p];
+    }
+    if (p.hasOwnProperty("path")) {
+      return p.path;
+    }
+    return [];
+  }).sort();
+};
+
 function indexStoredValuesCreateSuite() {
   'use strict';
   let c;
@@ -340,7 +355,7 @@ function indexStoredValuesPlanSuite() {
       const query =" FOR doc IN " + cn + " RETURN doc.value2"; 
       let nodes = AQL_EXPLAIN(query).plan.nodes;
       assertEqual(1, nodes.filter((n) => n.type === 'IndexNode').length);
-      assertEqual(["value2"], nodes[1].projections);
+      assertEqual(normalize(["value2"]), normalize(nodes[1].projections));
       assertTrue(nodes[1].indexCoversProjections);
       assertEqual(0, nodes.filter((n) => n.type === 'EnumerateCollectionNode').length);
     },
@@ -351,7 +366,7 @@ function indexStoredValuesPlanSuite() {
       let nodes = AQL_EXPLAIN(query).plan.nodes;
       assertEqual(1, nodes.filter((n) => n.type === 'IndexNode').length);
       assertTrue(nodes[1].indexCoversProjections);
-      assertEqual(["value1", "value2"], nodes[1].projections);
+      assertEqual(normalize(["value1", "value2"]), normalize(nodes[1].projections));
       assertEqual(0, nodes.filter((n) => n.type === 'EnumerateCollectionNode').length);
     },
     
@@ -361,7 +376,7 @@ function indexStoredValuesPlanSuite() {
       let nodes = AQL_EXPLAIN(query).plan.nodes;
       assertEqual(1, nodes.filter((n) => n.type === 'IndexNode').length);
       assertTrue(nodes[1].indexCoversProjections);
-      assertEqual(["value1", "value2"], nodes[1].projections);
+      assertEqual(normalize(["value1", "value2"]), normalize(nodes[1].projections));
       assertEqual(0, nodes.filter((n) => n.type === 'EnumerateCollectionNode').length);
     },
     
@@ -371,7 +386,7 @@ function indexStoredValuesPlanSuite() {
       let nodes = AQL_EXPLAIN(query).plan.nodes;
       assertEqual(1, nodes.filter((n) => n.type === 'IndexNode').length);
       assertFalse(nodes[1].indexCoversProjections);
-      assertEqual([], nodes[1].projections);
+      assertEqual(normalize([]), normalize(nodes[1].projections));
       assertEqual(0, nodes.filter((n) => n.type === 'EnumerateCollectionNode').length);
       assertEqual(1, nodes.filter((n) => n.type === 'MaterializeNode').length);
     },
@@ -382,7 +397,7 @@ function indexStoredValuesPlanSuite() {
       let nodes = AQL_EXPLAIN(query).plan.nodes;
       assertEqual(1, nodes.filter((n) => n.type === 'IndexNode').length);
       assertFalse(nodes[1].indexCoversProjections);
-      assertEqual([], nodes[1].projections);
+      assertEqual(normalize([]), normalize(nodes[1].projections));
       assertEqual(0, nodes.filter((n) => n.type === 'EnumerateCollectionNode').length);
       assertEqual(1, nodes.filter((n) => n.type === 'MaterializeNode').length);
     },
@@ -395,7 +410,7 @@ function indexStoredValuesPlanSuite() {
       let nodes = AQL_EXPLAIN(query).plan.nodes;
       assertEqual(1, nodes.filter((n) => n.type === 'IndexNode').length);
       assertTrue(nodes[1].indexCoversProjections);
-      assertEqual(["value1", "value2"], nodes[1].projections);
+      assertEqual(normalize(["value1", "value2"]), normalize(nodes[1].projections));
       assertEqual(0, nodes.filter((n) => n.type === 'EnumerateCollectionNode').length);
     },
     
@@ -687,7 +702,7 @@ function indexStoredValuesResultsSuite() {
       assertEqual(1, nodes.filter((n) => n.type === 'IndexNode').length);
       assertEqual(0, nodes.filter((n) => n.type === 'EnumerateCollectionNode').length);
       assertTrue(nodes[1].indexCoversProjections);
-      assertEqual([["value", "sub1"], ["value", "sub2"], ["value", "sub3"], ["value", "sub4"]], nodes[1].projections.sort());
+      assertEqual(normalize([["value", "sub1"], ["value", "sub2"], ["value", "sub3"], ["value", "sub4"]]), normalize(nodes[1].projections));
       
       for (let i = 0; i < 10; ++i) {
         let result = db._query(query, { value: i }).toArray();
@@ -711,7 +726,7 @@ function indexStoredValuesResultsSuite() {
       assertEqual(1, nodes.filter((n) => n.type === 'IndexNode').length);
       assertEqual(0, nodes.filter((n) => n.type === 'EnumerateCollectionNode').length);
       assertTrue(nodes[1].indexCoversProjections);
-      assertEqual([["value", "sub1"], ["value", "sub2"], ["value", "sub3"], ["value", "sub4"]], nodes[1].projections.sort());
+      assertEqual(normalize([["value", "sub1"], ["value", "sub2"], ["value", "sub3"], ["value", "sub4"]]), normalize(nodes[1].projections));
       
       for (let i = 0; i < 10; ++i) {
         let result = db._query(query, { value: i }).toArray();
@@ -735,7 +750,7 @@ function indexStoredValuesResultsSuite() {
       assertEqual(1, nodes.filter((n) => n.type === 'IndexNode').length);
       assertEqual(0, nodes.filter((n) => n.type === 'EnumerateCollectionNode').length);
       assertTrue(nodes[1].indexCoversProjections);
-      assertEqual([["value", "a"], ["value", "sub1", "a"], ["value", "sub1", "sub2", "sub3"]], nodes[1].projections);
+      assertEqual(normalize([["value", "a"], ["value", "sub1", "a"], ["value", "sub1", "sub2", "sub3"]]), normalize(nodes[1].projections));
       
       for (let i = 0; i < 10; ++i) {
         let result = db._query(query, { value: i }).toArray();

--- a/tests/js/server/aql/aql-filter-projections.js
+++ b/tests/js/server/aql/aql-filter-projections.js
@@ -3,6 +3,7 @@
 
 const jsunity = require("jsunity");
 const db = require("@arangodb").db;
+const normalize = require("@arangodb/aql-helper").normalizeProjections;
 const ruleName = "reduce-extraction-to-projection";
 const cn = "UnitTestsOptimizer";
 
@@ -43,8 +44,8 @@ function filterProjectionsPlansTestSuite () {
         assertEqual(1, nodes.length, query);
         assertEqual(1, nodes[0].indexes.length, query);
         assertEqual(query[1], nodes[0].indexes[0].type, query);
-        assertEqual(query[2], nodes[0].filterProjections, query);
-        assertEqual(query[3], nodes[0].projections, query);
+        assertEqual(normalize(query[2]), normalize(nodes[0].filterProjections), query);
+        assertEqual(normalize(query[3]), normalize(nodes[0].projections), query);
         if (nodes[0].projections.length > 0) {
           assertNotEqual(-1, plan.rules.indexOf(ruleName));
         }
@@ -71,8 +72,8 @@ function filterProjectionsPlansTestSuite () {
         assertEqual(1, nodes.length, query);
         assertEqual(1, nodes[0].indexes.length, query);
         assertEqual(query[1], nodes[0].indexes[0].type, query);
-        assertEqual(query[2], nodes[0].projections, query);
-        assertEqual([], nodes[0].filterProjections, query);
+        assertEqual(normalize(query[2]), normalize(nodes[0].projections), query);
+        assertEqual(normalize([]), normalize(nodes[0].filterProjections), query);
         if (nodes[0].projections.length > 0) {
           assertNotEqual(-1, plan.rules.indexOf(ruleName));
         }
@@ -96,8 +97,8 @@ function filterProjectionsPlansTestSuite () {
         assertEqual(1, nodes.length, query);
         assertEqual(1, nodes[0].indexes.length, query);
         assertEqual(query[1], nodes[0].indexes[0].type, query);
-        assertEqual(query[2], nodes[0].filterProjections, query);
-        assertEqual(query[3], nodes[0].projections, query);
+        assertEqual(normalize(query[2]), normalize(nodes[0].filterProjections), query);
+        assertEqual(normalize(query[3]), normalize(nodes[0].projections), query);
         if (nodes[0].projections.length > 0) {
           assertNotEqual(-1, plan.rules.indexOf(ruleName));
         }
@@ -123,8 +124,8 @@ function filterProjectionsPlansTestSuite () {
         assertEqual(1, nodes.length, query);
         assertEqual(1, nodes[0].indexes.length, query);
         assertEqual(query[1], nodes[0].indexes[0].type, query);
-        assertEqual(query[2], nodes[0].projections, query);
-        assertEqual([], nodes[0].filterProjections, query);
+        assertEqual(normalize(query[2]), normalize(nodes[0].projections), query);
+        assertEqual(normalize([]), normalize(nodes[0].filterProjections), query);
         if (nodes[0].projections.length > 0) {
           assertNotEqual(-1, plan.rules.indexOf(ruleName));
         }
@@ -144,8 +145,8 @@ function filterProjectionsPlansTestSuite () {
         assertEqual(1, nodes.length, query);
         assertEqual(1, nodes[0].indexes.length, query);
         assertEqual(query[1], nodes[0].indexes[0].type, query);
-        assertEqual(query[2], nodes[0].filterProjections, query);
-        assertEqual(query[3], nodes[0].projections, query);
+        assertEqual(normalize(query[2]), normalize(nodes[0].filterProjections), query);
+        assertEqual(normalize(query[3]), normalize(nodes[0].projections), query);
         assertNotEqual(-1, plan.rules.indexOf(ruleName));
       });
     },
@@ -164,8 +165,8 @@ function filterProjectionsPlansTestSuite () {
         assertEqual(1, nodes.length, query);
         assertEqual(1, nodes[0].indexes.length, query);
         assertEqual(query[1], nodes[0].indexes[0].type, query);
-        assertEqual(query[2], nodes[0].filterProjections, query);
-        assertEqual(query[3], nodes[0].projections, query);
+        assertEqual(normalize(query[2]), normalize(nodes[0].filterProjections), query);
+        assertEqual(normalize(query[3]), normalize(nodes[0].projections), query);
         assertNotEqual(-1, plan.rules.indexOf(ruleName));
         
         // query must not contain any FILTER nodes
@@ -187,8 +188,8 @@ function filterProjectionsPlansTestSuite () {
         assertEqual(1, nodes.length, query);
         assertEqual(1, nodes[0].indexes.length, query);
         assertEqual(query[1], nodes[0].indexes[0].type, query);
-        assertEqual(query[2], nodes[0].filterProjections, query);
-        assertEqual(query[3], nodes[0].projections, query);
+        assertEqual(normalize(query[2]), normalize(nodes[0].filterProjections), query);
+        assertEqual(normalize(query[3]), normalize(nodes[0].projections), query);
         assertNotEqual(-1, plan.rules.indexOf(ruleName));
       });
     },
@@ -207,8 +208,8 @@ function filterProjectionsPlansTestSuite () {
         assertEqual(1, nodes.length, query);
         assertEqual(1, nodes[0].indexes.length, query);
         assertEqual(query[1], nodes[0].indexes[0].type, query);
-        assertEqual(query[2], nodes[0].filterProjections, query);
-        assertEqual(query[3], nodes[0].projections, query);
+        assertEqual(normalize(query[2]), normalize(nodes[0].filterProjections), query);
+        assertEqual(normalize(query[3]), normalize(nodes[0].projections), query);
         assertNotEqual(-1, plan.rules.indexOf(ruleName));
         
         // query must not contain any FILTER nodes
@@ -253,7 +254,7 @@ function filterProjectionsResultsTestSuite () {
         assertEqual(1, nodes.length, query);
         assertEqual(1, nodes[0].indexes.length, query);
         assertEqual("persistent", nodes[0].indexes[0].type, query);
-        assertNotEqual([], nodes[0].filterProjections, query);
+        assertNotEqual(normalize([]), normalize(nodes[0].filterProjections), query);
         assertNotEqual(-1, plan.rules.indexOf(ruleName));
         
         // query must not contain any FILTER nodes
@@ -279,7 +280,7 @@ function filterProjectionsResultsTestSuite () {
         assertEqual(1, nodes.length, query);
         assertEqual(1, nodes[0].indexes.length, query);
         assertEqual("persistent", nodes[0].indexes[0].type, query);
-        assertNotEqual([], nodes[0].filterProjections, query);
+        assertNotEqual(normalize([]), normalize(nodes[0].filterProjections), query);
         assertNotEqual(-1, plan.rules.indexOf(ruleName));
         
         // query must not contain any FILTER nodes

--- a/tests/js/server/aql/aql-index-choice.js
+++ b/tests/js/server/aql/aql-index-choice.js
@@ -4,6 +4,7 @@
 const jsunity = require("jsunity");
 const db = require("internal").db;
 const deriveTestSuite = require('@arangodb/test-helper').deriveTestSuite;
+const normalize = require("@arangodb/aql-helper").normalizeProjections;
 const cn = 'UnitTestsCollection';
 
 let setupCollection = function(cn, n) {
@@ -136,7 +137,7 @@ function BaseTestConfig () {
         let nodes = AQL_EXPLAIN(q).plan.nodes;
         assertEqual(1, nodes.filter((n) => n.type === 'IndexNode').length);
         let indexNode = nodes.filter((n) => n.type === 'IndexNode')[0];
-        assertEqual([], indexNode.projections);
+        assertEqual(normalize([]), normalize(indexNode.projections));
         assertFalse(indexNode.indexCoversProjections);
         assertEqual(1, indexNode.indexes.length);
         let index = indexNode.indexes[0];
@@ -156,7 +157,7 @@ function BaseTestConfig () {
         let nodes = AQL_EXPLAIN(q).plan.nodes;
         assertEqual(1, nodes.filter((n) => n.type === 'IndexNode').length);
         let indexNode = nodes.filter((n) => n.type === 'IndexNode')[0];
-        assertEqual(["uid"], indexNode.projections);
+        assertEqual(normalize(["uid"]), normalize(indexNode.projections));
         assertTrue(indexNode.indexCoversProjections);
         assertEqual(1, indexNode.indexes.length);
         let index = indexNode.indexes[0];
@@ -177,7 +178,7 @@ function BaseTestConfig () {
         let nodes = AQL_EXPLAIN(q).plan.nodes;
         assertEqual(1, nodes.filter((n) => n.type === 'IndexNode').length);
         let indexNode = nodes.filter((n) => n.type === 'IndexNode')[0];
-        assertEqual([], indexNode.projections);
+        assertEqual(normalize([]), normalize(indexNode.projections));
         assertFalse(indexNode.indexCoversProjections);
         assertEqual(1, indexNode.indexes.length);
         let index = indexNode.indexes[0];
@@ -201,7 +202,7 @@ function BaseTestConfig () {
         let nodes = AQL_EXPLAIN(q).plan.nodes;
         assertEqual(1, nodes.filter((n) => n.type === 'IndexNode').length);
         let indexNode = nodes.filter((n) => n.type === 'IndexNode')[0];
-        assertEqual(["uid"], indexNode.projections);
+        assertEqual(normalize(["uid"]), normalize(indexNode.projections));
         assertTrue(indexNode.indexCoversProjections);
         assertEqual(1, indexNode.indexes.length);
         let index = indexNode.indexes[0];
@@ -220,7 +221,7 @@ function BaseTestConfig () {
         let nodes = AQL_EXPLAIN(q).plan.nodes;
         assertEqual(1, nodes.filter((n) => n.type === 'IndexNode').length);
         let indexNode = nodes.filter((n) => n.type === 'IndexNode')[0];
-        assertEqual(["dt"], indexNode.projections);
+        assertEqual(normalize(["dt"]), normalize(indexNode.projections));
         assertTrue(indexNode.indexCoversProjections);
         assertEqual(1, indexNode.indexes.length);
         let index = indexNode.indexes[0];
@@ -239,7 +240,7 @@ function BaseTestConfig () {
         let nodes = AQL_EXPLAIN(q).plan.nodes;
         assertEqual(1, nodes.filter((n) => n.type === 'IndexNode').length);
         let indexNode = nodes.filter((n) => n.type === 'IndexNode')[0];
-        assertEqual(["dt", "uid"], indexNode.projections.sort());
+        assertEqual(normalize(["dt", "uid"]), normalize(indexNode.projections));
         assertTrue(indexNode.indexCoversProjections);
         assertEqual(1, indexNode.indexes.length);
         let index = indexNode.indexes[0];
@@ -263,7 +264,7 @@ function BaseTestConfig () {
         let nodes = AQL_EXPLAIN(q).plan.nodes;
         assertEqual(1, nodes.filter((n) => n.type === 'IndexNode').length);
         let indexNode = nodes.filter((n) => n.type === 'IndexNode')[0];
-        assertEqual([], indexNode.projections);
+        assertEqual(normalize([]), normalize(indexNode.projections));
         assertFalse(indexNode.indexCoversProjections);
         assertEqual(1, indexNode.indexes.length);
         let index = indexNode.indexes[0];
@@ -284,7 +285,7 @@ function BaseTestConfig () {
         let nodes = AQL_EXPLAIN(q).plan.nodes;
         assertEqual(1, nodes.filter((n) => n.type === 'IndexNode').length);
         let indexNode = nodes.filter((n) => n.type === 'IndexNode')[0];
-        assertTrue(["uid"], indexNode.projections);
+        assertTrue(normalize(["uid"]), normalize(indexNode.projections));
         assertFalse(indexNode.indexCoversProjections);
         assertEqual(1, indexNode.indexes.length);
         let index = indexNode.indexes[0];
@@ -301,7 +302,7 @@ function BaseTestConfig () {
         let nodes = AQL_EXPLAIN(q).plan.nodes;
         assertEqual(1, nodes.filter((n) => n.type === 'IndexNode').length);
         let indexNode = nodes.filter((n) => n.type === 'IndexNode')[0];
-        assertEqual(["dt"], indexNode.projections);
+        assertEqual(normalize(["dt"]), normalize(indexNode.projections));
         assertFalse(indexNode.indexCoversProjections);
         assertEqual(1, indexNode.indexes.length);
         let index = indexNode.indexes[0];
@@ -323,7 +324,7 @@ function BaseTestConfig () {
         let nodes = AQL_EXPLAIN(q).plan.nodes;
         assertEqual(1, nodes.filter((n) => n.type === 'IndexNode').length);
         let indexNode = nodes.filter((n) => n.type === 'IndexNode')[0];
-        assertEqual([], indexNode.projections);
+        assertEqual(normalize([]), normalize(indexNode.projections));
         assertFalse(indexNode.indexCoversProjections);
         assertEqual(1, indexNode.indexes.length);
         let index = indexNode.indexes[0];
@@ -345,7 +346,7 @@ function BaseTestConfig () {
         let nodes = AQL_EXPLAIN(q).plan.nodes;
         assertEqual(1, nodes.filter((n) => n.type === 'IndexNode').length);
         let indexNode = nodes.filter((n) => n.type === 'IndexNode')[0];
-        assertEqual(["uid"], indexNode.projections);
+        assertEqual(normalize(["uid"]), normalize(indexNode.projections));
         assertTrue(indexNode.indexCoversProjections);
         assertEqual(1, indexNode.indexes.length);
         let index = indexNode.indexes[0];
@@ -362,7 +363,7 @@ function BaseTestConfig () {
         let nodes = AQL_EXPLAIN(q).plan.nodes;
         assertEqual(1, nodes.filter((n) => n.type === 'IndexNode').length);
         let indexNode = nodes.filter((n) => n.type === 'IndexNode')[0];
-        assertEqual(["dt"], indexNode.projections);
+        assertEqual(normalize(["dt"]), normalize(indexNode.projections));
         assertTrue(indexNode.indexCoversProjections);
         assertEqual(1, indexNode.indexes.length);
         let index = indexNode.indexes[0];
@@ -376,7 +377,7 @@ function BaseTestConfig () {
         let nodes = AQL_EXPLAIN(q).plan.nodes;
         assertEqual(1, nodes.filter((n) => n.type === 'IndexNode').length);
         let indexNode = nodes.filter((n) => n.type === 'IndexNode')[0];
-        assertEqual(["dt", "uid"], indexNode.projections.sort());
+        assertEqual(normalize(["dt", "uid"]), normalize(indexNode.projections));
         assertTrue(indexNode.indexCoversProjections);
         assertEqual(1, indexNode.indexes.length);
         let index = indexNode.indexes[0];
@@ -392,7 +393,7 @@ function BaseTestConfig () {
         let nodes = AQL_EXPLAIN(q).plan.nodes;
         assertEqual(1, nodes.filter((n) => n.type === 'IndexNode').length);
         let indexNode = nodes.filter((n) => n.type === 'IndexNode')[0];
-        assertEqual(["dt", "uid"], indexNode.projections.sort());
+        assertEqual(normalize(["dt", "uid"]), normalize(indexNode.projections));
         assertTrue(indexNode.indexCoversProjections);
         assertEqual(1, indexNode.indexes.length);
         let index = indexNode.indexes[0];
@@ -413,7 +414,7 @@ function BaseTestConfig () {
         assertEqual(1, nodes.filter((n) => n.type === 'IndexNode').length);
         assertEqual(1, nodes.filter((n) => n.type === 'SortNode').length);
         let indexNode = nodes.filter((n) => n.type === 'IndexNode')[0];
-        assertEqual([], indexNode.projections);
+        assertEqual(normalize([]), normalize(indexNode.projections));
         assertFalse(indexNode.indexCoversProjections);
         assertEqual(1, indexNode.indexes.length);
         let index = indexNode.indexes[0];
@@ -434,7 +435,7 @@ function BaseTestConfig () {
         assertEqual(1, nodes.filter((n) => n.type === 'IndexNode').length);
         assertEqual(0, nodes.filter((n) => n.type === 'SortNode').length);
         let indexNode = nodes.filter((n) => n.type === 'IndexNode')[0];
-        assertEqual([], indexNode.projections);
+        assertEqual(normalize([]), normalize(indexNode.projections));
         assertFalse(indexNode.indexCoversProjections);
         assertEqual(1, indexNode.indexes.length);
         let index = indexNode.indexes[0];
@@ -454,7 +455,7 @@ function BaseTestConfig () {
         assertEqual(1, nodes.filter((n) => n.type === 'IndexNode').length);
         assertEqual(0, nodes.filter((n) => n.type === 'SortNode').length);
         let indexNode = nodes.filter((n) => n.type === 'IndexNode')[0];
-        assertEqual([], indexNode.projections);
+        assertEqual(normalize([]), normalize(indexNode.projections));
         assertFalse(indexNode.indexCoversProjections);
         assertEqual(1, indexNode.indexes.length);
         let index = indexNode.indexes[0];
@@ -470,7 +471,7 @@ function BaseTestConfig () {
         assertEqual(1, nodes.filter((n) => n.type === 'IndexNode').length);
         assertEqual(1, nodes.filter((n) => n.type === 'SortNode').length);
         let indexNode = nodes.filter((n) => n.type === 'IndexNode')[0];
-        assertEqual([], indexNode.projections);
+        assertEqual(normalize([]), normalize(indexNode.projections));
         assertFalse(indexNode.indexCoversProjections);
         assertEqual(1, indexNode.indexes.length);
         let index = indexNode.indexes[0];
@@ -493,7 +494,7 @@ function BaseTestConfig () {
         assertEqual(1, nodes.filter((n) => n.type === 'IndexNode').length);
         assertEqual(0, nodes.filter((n) => n.type === 'SortNode').length);
         let indexNode = nodes.filter((n) => n.type === 'IndexNode')[0];
-        assertEqual([], indexNode.projections);
+        assertEqual(normalize([]), normalize(indexNode.projections));
         assertFalse(indexNode.indexCoversProjections);
         assertEqual(1, indexNode.indexes.length);
         let index = indexNode.indexes[0];
@@ -511,7 +512,7 @@ function BaseTestConfig () {
         assertEqual(1, nodes.filter((n) => n.type === 'IndexNode').length);
         assertEqual(0, nodes.filter((n) => n.type === 'SortNode').length);
         let indexNode = nodes.filter((n) => n.type === 'IndexNode')[0];
-        assertEqual([], indexNode.projections);
+        assertEqual(normalize([]), normalize(indexNode.projections));
         assertFalse(indexNode.indexCoversProjections);
         assertEqual(1, indexNode.indexes.length);
         let index = indexNode.indexes[0];
@@ -529,7 +530,7 @@ function BaseTestConfig () {
         assertEqual(1, nodes.filter((n) => n.type === 'IndexNode').length);
         assertEqual(1, nodes.filter((n) => n.type === 'SortNode').length);
         let indexNode = nodes.filter((n) => n.type === 'IndexNode')[0];
-        assertEqual([], indexNode.projections);
+        assertEqual(normalize([]), normalize(indexNode.projections));
         assertFalse(indexNode.indexCoversProjections);
         assertEqual(1, indexNode.indexes.length);
         let index = indexNode.indexes[0];
@@ -549,7 +550,7 @@ function BaseTestConfig () {
         assertEqual(1, nodes.filter((n) => n.type === 'IndexNode').length);
         assertEqual(1, nodes.filter((n) => n.type === 'SortNode').length);
         let indexNode = nodes.filter((n) => n.type === 'IndexNode')[0];
-        assertEqual([], indexNode.projections);
+        assertEqual(normalize([]), normalize(indexNode.projections));
         assertFalse(indexNode.indexCoversProjections);
         assertEqual(1, indexNode.indexes.length);
         let index = indexNode.indexes[0];
@@ -566,7 +567,7 @@ function BaseTestConfig () {
         assertEqual(1, nodes.filter((n) => n.type === 'IndexNode').length);
         assertEqual(0, nodes.filter((n) => n.type === 'SortNode').length);
         let indexNode = nodes.filter((n) => n.type === 'IndexNode')[0];
-        assertEqual([], indexNode.projections);
+        assertEqual(normalize([]), normalize(indexNode.projections));
         assertFalse(indexNode.indexCoversProjections);
         assertEqual(1, indexNode.indexes.length);
         let index = indexNode.indexes[0];
@@ -588,7 +589,7 @@ function BaseTestConfig () {
         assertEqual(1, nodes.filter((n) => n.type === 'IndexNode').length);
         assertEqual(0, nodes.filter((n) => n.type === 'SortNode').length);
         let indexNode = nodes.filter((n) => n.type === 'IndexNode')[0];
-        assertEqual(["dt"], indexNode.projections);
+        assertEqual(normalize(["dt"]), normalize(indexNode.projections));
         assertTrue(indexNode.indexCoversProjections);
         assertEqual(1, indexNode.indexes.length);
         let index = indexNode.indexes[0];
@@ -611,7 +612,7 @@ function BaseTestConfig () {
         assertEqual(1, nodes.filter((n) => n.type === 'IndexNode').length);
         assertEqual(0, nodes.filter((n) => n.type === 'SortNode').length);
         let indexNode = nodes.filter((n) => n.type === 'IndexNode')[0];
-        assertEqual(["dt"], indexNode.projections);
+        assertEqual(normalize(["dt"]), normalize(indexNode.projections));
         assertTrue(indexNode.indexCoversProjections);
         assertEqual(1, indexNode.indexes.length);
         let index = indexNode.indexes[0];

--- a/tests/js/server/aql/aql-index-hints.js
+++ b/tests/js/server/aql/aql-index-hints.js
@@ -2,10 +2,6 @@
 /*global fail, assertEqual, assertNotEqual, assertTrue, AQL_EXPLAIN */
 
 ////////////////////////////////////////////////////////////////////////////////
-/// @brief tests for Ahuacatl, skiplist index queries
-///
-/// @file
-///
 /// DISCLAIMER
 ///
 /// Copyright 2010-2016 ArangoDB GmbH, Cologne, Germany
@@ -31,6 +27,7 @@
 const internal = require("internal");
 const db = internal.db;
 const jsunity = require("jsunity");
+const normalize = require("@arangodb/aql-helper").normalizeProjections;
 const errors = internal.errors;
 const analyzers = require("@arangodb/analyzers");
 
@@ -1000,7 +997,7 @@ function indexHintDisableIndexSuite () {
             assertEqual(query[1], node.indexes[0].name, query);
             assertEqual(query[3], node.indexCoversProjections, query);
           }
-          assertEqual(query[2], node.projections);
+          assertEqual(normalize(query[2]), normalize(node.projections));
         });
       });
     },
@@ -1031,7 +1028,7 @@ function indexHintDisableIndexSuite () {
         let ns = nodes.filter((node) => node.type === 'EnumerateCollectionNode');
         assertEqual(1, ns.length, query);
         let node = ns[0];
-        assertEqual(query[1], node.projections.sort(), query);
+        assertEqual(normalize(query[1]), normalize(node.projections), query);
       });
     },
 

--- a/tests/js/server/aql/aql-index-join.js
+++ b/tests/js/server/aql/aql-index-join.js
@@ -2,10 +2,6 @@
 /*global fail, assertEqual, assertNotEqual, assertTrue, AQL_EXECUTE, AQL_EXPLAIN */
 
 ////////////////////////////////////////////////////////////////////////////////
-/// @brief tests for Ahuacatl, skiplist index queries
-///
-/// @file
-///
 /// DISCLAIMER
 ///
 /// Copyright 2010-2016 ArangoDB GmbH, Cologne, Germany
@@ -27,6 +23,7 @@
 
 const jsunity = require("jsunity");
 const db = require("@arangodb").db;
+const normalize = require("@arangodb/aql-helper").normalizeProjections;
 const internal = require('internal');
 const _ = require('lodash');
 
@@ -99,9 +96,7 @@ const IndexJoinTestSuite = function () {
     maxNumberOfPlans: 1
   };
 
-
   const runAndCheckQuery = function (query) {
-
     const plan = AQL_EXPLAIN(query, null, queryOptions).plan;
     let planNodes = plan.nodes.map(function (node) {
       return node.type;
@@ -245,8 +240,8 @@ const IndexJoinTestSuite = function () {
 
       assertEqual(join.type, "JoinNode");
 
-      assertEqual(join.indexInfos[0].projections, ["x"]);
-      assertEqual(join.indexInfos[1].projections, ["x"]);
+      assertEqual(normalize(join.indexInfos[0].projections), normalize(["x"]));
+      assertEqual(normalize(join.indexInfos[1].projections), normalize(["x"]));
 
       const result = runAndCheckQuery(query);
 
@@ -275,8 +270,8 @@ const IndexJoinTestSuite = function () {
 
       assertEqual(join.type, "JoinNode");
 
-      assertEqual(join.indexInfos[0].projections, ["x"]);
-      assertEqual(join.indexInfos[1].projections, ["x"]);
+      assertEqual(normalize(join.indexInfos[0].projections), normalize(["x"]));
+      assertEqual(normalize(join.indexInfos[1].projections), normalize(["x"]));
 
       const result = runAndCheckQuery(query);
 
@@ -305,8 +300,8 @@ const IndexJoinTestSuite = function () {
 
       assertEqual(join.type, "JoinNode");
 
-      assertEqual(join.indexInfos[0].projections, ["x", "y"]);
-      assertEqual(join.indexInfos[1].projections, ["x"]);
+      assertEqual(normalize(join.indexInfos[0].projections), normalize(["x", "y"]));
+      assertEqual(normalize(join.indexInfos[1].projections), normalize(["x"]));
 
       const result = runAndCheckQuery(query);
 
@@ -335,8 +330,8 @@ const IndexJoinTestSuite = function () {
 
       assertEqual(join.type, "JoinNode");
 
-      assertEqual(join.indexInfos[0].projections, ["x", "y"]);
-      assertEqual(join.indexInfos[1].projections, ["x"]);
+      assertEqual(normalize(join.indexInfos[0].projections), normalize(["x", "y"]));
+      assertEqual(normalize(join.indexInfos[1].projections), normalize(["x"]));
 
       const result = runAndCheckQuery(query);
 
@@ -365,8 +360,8 @@ const IndexJoinTestSuite = function () {
 
       assertEqual(join.type, "JoinNode");
 
-      assertEqual(join.indexInfos[0].projections, ["x", "y"]);
-      assertEqual(join.indexInfos[1].projections, ["x"]);
+      assertEqual(normalize(join.indexInfos[0].projections), normalize(["x", "y"]));
+      assertEqual(normalize(join.indexInfos[1].projections), normalize(["x"]));
 
       const result = runAndCheckQuery(query);
 
@@ -395,8 +390,8 @@ const IndexJoinTestSuite = function () {
 
       assertEqual(join.type, "JoinNode");
 
-      assertEqual(join.indexInfos[0].projections, ["x", "y"]);
-      assertEqual(join.indexInfos[1].projections, ["x"]);
+      assertEqual(normalize(join.indexInfos[0].projections), normalize(["x", "y"]));
+      assertEqual(normalize(join.indexInfos[1].projections), normalize(["x"]));
 
       const result = runAndCheckQuery(query);
 
@@ -425,8 +420,8 @@ const IndexJoinTestSuite = function () {
 
       assertEqual(join.type, "JoinNode");
 
-      assertEqual(join.indexInfos[0].projections, ["x", "y"]);
-      assertEqual(join.indexInfos[1].projections, ["x"]);
+      assertEqual(normalize(join.indexInfos[0].projections), normalize(["x", "y"]));
+      assertEqual(normalize(join.indexInfos[1].projections), normalize(["x"]));
 
       const result = runAndCheckQuery(query);
 
@@ -456,8 +451,8 @@ const IndexJoinTestSuite = function () {
 
       assertEqual(join.type, "JoinNode");
 
-      assertEqual(join.indexInfos[0].projections, ["x", "y"]);
-      assertEqual(join.indexInfos[1].projections, ["x"]);
+      assertEqual(normalize(join.indexInfos[0].projections), normalize(["x", "y"]));
+      assertEqual(normalize(join.indexInfos[1].projections), normalize(["x"]));
 
       const result = runAndCheckQuery(query);
 
@@ -488,8 +483,8 @@ const IndexJoinTestSuite = function () {
 
       assertEqual(join.type, "JoinNode");
 
-      assertEqual(join.indexInfos[0].projections, []);
-      assertEqual(join.indexInfos[1].projections, ["x"]);
+      assertEqual(normalize(join.indexInfos[0].projections), normalize([]));
+      assertEqual(normalize(join.indexInfos[1].projections), normalize(["x"]));
 
       const result = runAndCheckQuery(query);
 
@@ -520,8 +515,8 @@ const IndexJoinTestSuite = function () {
 
       assertEqual(join.type, "JoinNode");
 
-      assertEqual(join.indexInfos[0].projections, ["x", "y"]);
-      assertEqual(join.indexInfos[1].projections, ["x"]);
+      assertEqual(normalize(join.indexInfos[0].projections), normalize(["x", "y"]));
+      assertEqual(normalize(join.indexInfos[1].projections), normalize(["x"]));
 
       const result = runAndCheckQuery(query);
 
@@ -552,8 +547,8 @@ const IndexJoinTestSuite = function () {
       assertEqual(join.type, "JoinNode");
 
       assertEqual(join.indexInfos[0].projections, []);
-      assertEqual(join.indexInfos[0].filterProjections, ["y"]);
-      assertEqual(join.indexInfos[1].projections, ["x"]);
+      assertEqual(normalize(join.indexInfos[0].filterProjections), normalize(["y"]));
+      assertEqual(normalize(join.indexInfos[1].projections), normalize(["x"]));
 
       const result = runAndCheckQuery(query);
 

--- a/tests/js/server/aql/aql-optimizer-index-only.js
+++ b/tests/js/server/aql/aql-optimizer-index-only.js
@@ -4,8 +4,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief tests for produces result
 ///
-/// @file
-///
 /// DISCLAIMER
 ///
 /// Copyright 2010-2012 triagens GmbH, Cologne, Germany
@@ -30,6 +28,7 @@
 
 const jsunity = require("jsunity");
 const db = require("@arangodb").db;
+const normalize = require("@arangodb/aql-helper").normalizeProjections;
 const disableSingleDocOp = { optimizer : { rules : [ "-optimize-cluster-single-document-operations"] } };
 
 function optimizerIndexOnlyPrimaryTestSuite () {
@@ -63,7 +62,7 @@ function optimizerIndexOnlyPrimaryTestSuite () {
         let plan = AQL_EXPLAIN(query, {}, disableSingleDocOp).plan;
         let nodes = plan.nodes.filter(function(n) { return n.type === 'IndexNode'; });
         assertEqual(1, nodes.length);
-        assertEqual([], nodes[0].projections, query);
+        assertEqual(normalize([]), normalize(nodes[0].projections), query);
         assertTrue(nodes[0].producesResult);
         assertFalse(nodes[0].indexCoversProjections);
       });
@@ -84,7 +83,7 @@ function optimizerIndexOnlyPrimaryTestSuite () {
         let plan = AQL_EXPLAIN(query[0], {}, disableSingleDocOp).plan;
         let nodes = plan.nodes.filter(function(n) { return n.type === 'IndexNode'; });
         assertEqual(1, nodes.length);
-        assertEqual(query[1], nodes[0].projections.sort(), query);
+        assertEqual(normalize(query[1]), normalize(nodes[0].projections), query);
         assertFalse(nodes[0].indexCoversProjections);
       });
     },
@@ -98,7 +97,7 @@ function optimizerIndexOnlyPrimaryTestSuite () {
       let plan = AQL_EXPLAIN(query, {}, disableSingleDocOp).plan;
       let nodes = plan.nodes.filter(function(n) { return n.type === 'IndexNode'; });
       assertEqual(1, nodes.length);
-      assertEqual(["_key"], nodes[0].projections);
+      assertEqual(normalize(["_key"]), normalize(nodes[0].projections));
       assertTrue(nodes[0].indexCoversProjections);
     },
     
@@ -110,7 +109,7 @@ function optimizerIndexOnlyPrimaryTestSuite () {
       let plan = AQL_EXPLAIN(query, {}, disableSingleDocOp).plan;
       let nodes = plan.nodes.filter(function(n) { return n.type === 'IndexNode'; });
       assertEqual(1, nodes.length);
-      assertEqual(["_key"], nodes[0].projections);
+      assertEqual(normalize(["_key"]), normalize(nodes[0].projections));
       assertTrue(nodes[0].indexCoversProjections);
     }
 
@@ -155,7 +154,7 @@ function optimizerIndexOnlyEdgeTestSuite () {
         let plan = AQL_EXPLAIN(query).plan;
         let nodes = plan.nodes.filter(function(n) { return n.type === 'IndexNode'; });
         assertEqual(1, nodes.length);
-        assertEqual([], nodes[0].projections, query);
+        assertEqual(normalize([]), normalize(nodes[0].projections), query);
         assertTrue(nodes[0].producesResult);
         assertFalse(nodes[0].indexCoversProjections);
       });
@@ -184,7 +183,7 @@ function optimizerIndexOnlyEdgeTestSuite () {
         let plan = AQL_EXPLAIN(query[0]).plan;
         let nodes = plan.nodes.filter(function(n) { return n.type === 'IndexNode'; });
         assertEqual(1, nodes.length);
-        assertEqual(query[1], nodes[0].projections.sort(), query);
+        assertEqual(normalize(query[1]), normalize(nodes[0].projections), query);
         assertFalse(nodes[0].indexCoversProjections);
       });
     },
@@ -202,7 +201,7 @@ function optimizerIndexOnlyEdgeTestSuite () {
         let plan = AQL_EXPLAIN(query[0]).plan;
         let nodes = plan.nodes.filter(function(n) { return n.type === 'IndexNode'; });
         assertEqual(1, nodes.length);
-        assertEqual(query[1], nodes[0].projections);
+        assertEqual(normalize(query[1]), normalize(nodes[0].projections), query);
         assertTrue(nodes[0].indexCoversProjections);
       });
     },
@@ -213,7 +212,7 @@ function optimizerIndexOnlyEdgeTestSuite () {
       let plan = AQL_EXPLAIN(query).plan;
       let nodes = plan.nodes.filter(function(n) { return n.type === 'IndexNode'; });
       assertEqual(1, nodes.length);
-      assertEqual(["_from"], nodes[0].projections);
+      assertEqual(normalize(["_from"]), normalize(nodes[0].projections));
       assertTrue(nodes[0].indexCoversProjections);
     },
     
@@ -223,7 +222,7 @@ function optimizerIndexOnlyEdgeTestSuite () {
       let plan = AQL_EXPLAIN(query).plan;
       let nodes = plan.nodes.filter(function(n) { return n.type === 'IndexNode'; });
       assertEqual(1, nodes.length);
-      assertEqual(["_to"], nodes[0].projections);
+      assertEqual(normalize(["_to"]), normalize(nodes[0].projections));
       assertTrue(nodes[0].indexCoversProjections);
     },
     
@@ -234,7 +233,7 @@ function optimizerIndexOnlyEdgeTestSuite () {
       let plan = AQL_EXPLAIN(query).plan;
       let nodes = plan.nodes.filter(function(n) { return n.type === 'IndexNode'; });
       assertEqual(1, nodes.length);
-      assertEqual(["_to"], nodes[0].projections);
+      assertEqual(normalize(["_to"]), normalize(nodes[0].projections));
       assertTrue(nodes[0].indexCoversProjections);
     }
 
@@ -293,7 +292,7 @@ function optimizerIndexOnlyVPackTestSuite () {
         let plan = AQL_EXPLAIN(query[0]).plan;
         let nodes = plan.nodes.filter(function(n) { return n.type === 'EnumerateCollectionNode'; });
         assertEqual(1, nodes.length);
-        assertEqual(query[1], nodes[0].projections.sort());
+        assertEqual(normalize(query[1]), normalize(nodes[0].projections));
         assertTrue(nodes[0].producesResult);
       });
     },
@@ -333,7 +332,7 @@ function optimizerIndexOnlyVPackTestSuite () {
         let plan = AQL_EXPLAIN(query[0]).plan;
         let nodes = plan.nodes.filter(function(n) { return n.type === 'IndexNode'; });
         assertEqual(1, nodes.length);
-        assertEqual(query[1], nodes[0].projections.sort());
+        assertEqual(normalize(query[1]), normalize(nodes[0].projections));
         assertFalse(nodes[0].indexCoversProjections);
       });
     },
@@ -348,7 +347,7 @@ function optimizerIndexOnlyVPackTestSuite () {
       let plan = AQL_EXPLAIN(query).plan;
       let nodes = plan.nodes.filter(function(n) { return n.type === 'IndexNode'; });
       assertEqual(1, nodes.length);
-      assertEqual(["a"], nodes[0].projections);
+      assertEqual(normalize(["a"]), normalize(nodes[0].projections));
       assertTrue(nodes[0].indexCoversProjections);
     },
     
@@ -362,7 +361,7 @@ function optimizerIndexOnlyVPackTestSuite () {
       let plan = AQL_EXPLAIN(query).plan;
       let nodes = plan.nodes.filter(function(n) { return n.type === 'IndexNode'; });
       assertEqual(1, nodes.length);
-      assertEqual(["a"], nodes[0].projections);
+      assertEqual(normalize(["a"]), normalize(nodes[0].projections));
       assertTrue(nodes[0].indexCoversProjections);
     },
     
@@ -376,7 +375,7 @@ function optimizerIndexOnlyVPackTestSuite () {
       let plan = AQL_EXPLAIN(query).plan;
       let nodes = plan.nodes.filter(function(n) { return n.type === 'IndexNode'; });
       assertEqual(1, nodes.length);
-      assertEqual(["b"], nodes[0].projections);
+      assertEqual(normalize(["b"]), normalize(nodes[0].projections));
       assertTrue(nodes[0].indexCoversProjections);
     },
     
@@ -400,7 +399,7 @@ function optimizerIndexOnlyVPackTestSuite () {
         let plan = AQL_EXPLAIN(query[0]).plan;
         let nodes = plan.nodes.filter(function(n) { return n.type === 'IndexNode'; });
         assertEqual(1, nodes.length);
-        assertEqual(query[1], nodes[0].projections.sort(), query);
+        assertEqual(normalize(query[1]), normalize(nodes[0].projections), query);
         assertTrue(nodes[0].indexCoversProjections);
       });
     },
@@ -425,7 +424,7 @@ function optimizerIndexOnlyVPackTestSuite () {
         let plan = AQL_EXPLAIN(query[0]).plan;
         let nodes = plan.nodes.filter(function(n) { return n.type === 'IndexNode'; });
         assertEqual(1, nodes.length);
-        assertEqual(query[1], nodes[0].projections.sort(), query);
+        assertEqual(normalize(query[1]), normalize(nodes[0].projections), query);
         assertTrue(nodes[0].indexCoversProjections);
       });
     }

--- a/tests/js/server/aql/aql-optimizer-rule-last-access-on-path.js
+++ b/tests/js/server/aql/aql-optimizer-rule-last-access-on-path.js
@@ -5,8 +5,6 @@
 // //////////////////////////////////////////////////////////////////////////////
 // / @brief tests for optimizer rule that transforms last access on path to vertex and edge
 // /
-// / @file
-// /
 // / DISCLAIMER
 // /
 // / Copyright 2023-2023 ArangoDB GmbH, Cologne, Germany
@@ -31,6 +29,7 @@
 
 const jsunity = require("jsunity");
 const gm = require("@arangodb/general-graph");
+const normalize = require("@arangodb/aql-helper").normalizeProjections;
 const {db} = require("@arangodb");
 const ruleName = "optimize-traversal-last-element-access";
 
@@ -154,9 +153,9 @@ function TraversalOptimizeLastPathAccessTestSuite() {
     const assertHasProjection = (nodes, type, attribute) => {
         const traversalNodes = nodes.filter(n => n.type === "TraversalNode");
         assertEqual(traversalNodes.length, 1, `We do not have expected number of Traversal Nodes, please check the test query, it should contain exactly one traversal statement`);
-        const projections = traversalNodes[0].options[type];
+        const projections = normalize(traversalNodes[0].options[type]);
         assertTrue(Array.isArray(projections), `Projections not found, or unexpected format`);
-        assertEqual(projections.filter(p => p === attribute).length, 1, `Expected Projection ${attribute} not found in ${projections}`);
+        assertEqual(projections.filter(p => p.length === 1 &&  p[0] === attribute).length, 1, `Expected Projection ${attribute} not found in ${projections}`);
     };
 
     return {

--- a/tests/js/server/aql/aql-projections.js
+++ b/tests/js/server/aql/aql-projections.js
@@ -28,6 +28,7 @@
 
 const jsunity = require("jsunity");
 const db = require("@arangodb").db;
+const normalize = require("@arangodb/aql-helper").normalizeProjections;
 const ruleName = "reduce-extraction-to-projection";
 const cn = "UnitTestsOptimizer";
 
@@ -79,7 +80,7 @@ function projectionsPlansTestSuite () {
         assertEqual(1, nodes.length, query);
         assertEqual(1, nodes[0].indexes.length, query);
         assertEqual(query[1], nodes[0].indexes[0].type, query);
-        assertEqual(query[2], nodes[0].projections, query);
+        assertEqual(normalize(query[2]), normalize(nodes[0].projections), query);
         if (query[2].length) {
           assertTrue(nodes[0].indexCoversProjections, query);
           assertNotEqual(-1, plan.rules.indexOf(ruleName));
@@ -108,7 +109,7 @@ function projectionsPlansTestSuite () {
         assertEqual(1, nodes.length, query);
         assertEqual(1, nodes[0].indexes.length, query);
         assertEqual(query[1], nodes[0].indexes[0].type, query);
-        assertEqual(query[2], nodes[0].projections, query);
+        assertEqual(normalize(query[2]), normalize(nodes[0].projections), query);
         assertEqual(query[3], nodes[0].indexCoversProjections, query);
         if (query[2].length) {
           assertNotEqual(-1, plan.rules.indexOf(ruleName));
@@ -127,7 +128,7 @@ function projectionsPlansTestSuite () {
         let plan = AQL_EXPLAIN(query[0]).plan;
         let nodes = plan.nodes.filter(function(node) { return node.type === 'EnumerateCollectionNode'; });
         assertEqual(1, nodes.length, query);
-        assertEqual(query[1], nodes[0].projections, query);
+        assertEqual(normalize(query[1]), normalize(nodes[0].projections), query);
         assertNotEqual(-1, plan.rules.indexOf(ruleName));
       });
     },
@@ -171,7 +172,7 @@ function projectionsPlansTestSuite () {
         assertEqual(1, nodes.length, query);
         assertEqual(1, nodes[0].indexes.length, query);
         assertEqual(query[1], nodes[0].indexes[0].type, query);
-        assertEqual(query[2], nodes[0].projections, query);
+        assertEqual(normalize(query[2]), normalize(nodes[0].projections), query);
         assertEqual(query[3], nodes[0].indexCoversProjections, query);
         
         if (query[2].length) {
@@ -191,7 +192,7 @@ function projectionsPlansTestSuite () {
         let plan = AQL_EXPLAIN(query[0]).plan;
         let nodes = plan.nodes.filter(function(node) { return node.type === 'EnumerateCollectionNode'; });
         assertEqual(1, nodes.length, query);
-        assertEqual(query[1], nodes[0].projections, query);
+        assertEqual(normalize(query[1]), normalize(nodes[0].projections), query);
         assertNotEqual(-1, plan.rules.indexOf(ruleName));
       });
     },
@@ -235,7 +236,7 @@ function projectionsPlansTestSuite () {
         assertEqual(1, nodes.length, query);
         assertEqual(1, nodes[0].indexes.length, query);
         assertEqual(query[1], nodes[0].indexes[0].type, query);
-        assertEqual(query[2], nodes[0].projections, query);
+        assertEqual(normalize(query[2]), normalize(nodes[0].projections), query);
         assertEqual(query[3], nodes[0].indexCoversProjections, query);
         if (query[2].length) {
           assertNotEqual(-1, plan.rules.indexOf(ruleName));
@@ -255,7 +256,7 @@ function projectionsPlansTestSuite () {
         let plan = AQL_EXPLAIN(query[0]).plan;
         let nodes = plan.nodes.filter(function(node) { return node.type === 'EnumerateCollectionNode'; });
         assertEqual(1, nodes.length, query);
-        assertEqual(query[1], nodes[0].projections, query);
+        assertEqual(normalize(query[1]), normalize(nodes[0].projections), query);
         assertNotEqual(-1, plan.rules.indexOf(ruleName));
       });
     },
@@ -285,7 +286,7 @@ function projectionsPlansTestSuite () {
         assertEqual(1, nodes.length, query);
         assertEqual(1, nodes[0].indexes.length, query);
         assertEqual(query[1], nodes[0].indexes[0].type, query);
-        assertEqual(query[2], nodes[0].projections, query);
+        assertEqual(normalize(query[2]), normalize(nodes[0].projections), query);
         assertEqual(query[3], nodes[0].indexCoversProjections, query);
         if (query[2].length) {
           assertNotEqual(-1, plan.rules.indexOf(ruleName));
@@ -312,7 +313,7 @@ function projectionsPlansTestSuite () {
         let plan = AQL_EXPLAIN(query[0]).plan;
         let nodes = plan.nodes.filter(function(node) { return node.type === 'EnumerateCollectionNode'; });
         assertEqual(1, nodes.length, query);
-        assertEqual(query[1], nodes[0].projections, query);
+        assertEqual(normalize(query[1]), normalize(nodes[0].projections), query);
         if (query[1].length) {
           assertNotEqual(-1, plan.rules.indexOf(ruleName));
         } else {
@@ -346,7 +347,7 @@ function projectionsPlansTestSuite () {
         assertEqual(1, nodes.length, query);
         assertEqual(1, nodes[0].indexes.length, query);
         assertEqual(query[1], nodes[0].indexes[0].type, query);
-        assertEqual(query[2], nodes[0].projections, query);
+        assertEqual(normalize(query[2]), normalize(nodes[0].projections), query);
         assertEqual(query[3], nodes[0].indexCoversProjections, query);
         if (query[2].length) {
           assertNotEqual(-1, plan.rules.indexOf(ruleName));
@@ -371,7 +372,7 @@ function projectionsPlansTestSuite () {
         let plan = AQL_EXPLAIN(query[0]).plan;
         let nodes = plan.nodes.filter(function(node) { return node.type === 'EnumerateCollectionNode'; });
         assertEqual(1, nodes.length, query);
-        assertEqual(query[1], nodes[0].projections, query);
+        assertEqual(normalize(query[1]), normalize(nodes[0].projections), query);
         assertNotEqual(-1, plan.rules.indexOf(ruleName));
       });
     },
@@ -390,7 +391,7 @@ function projectionsPlansTestSuite () {
         assertEqual(1, nodes.length, query);
         assertEqual(1, nodes[0].indexes.length, query);
         assertEqual(query[1], nodes[0].indexes[0].type, query);
-        assertEqual(query[2], nodes[0].projections, query);
+        assertEqual(normalize(query[2]), normalize(nodes[0].projections), query);
         assertEqual(query[3], nodes[0].indexCoversProjections, query);
         if (query[2].length) {
           assertNotEqual(-1, plan.rules.indexOf(ruleName));
@@ -409,7 +410,7 @@ function projectionsPlansTestSuite () {
         let plan = AQL_EXPLAIN(query[0]).plan;
         let nodes = plan.nodes.filter(function(node) { return node.type === 'EnumerateCollectionNode'; });
         assertEqual(1, nodes.length, query);
-        assertEqual(query[1], nodes[0].projections, query);
+        assertEqual(normalize(query[1]), normalize(nodes[0].projections), query);
         assertNotEqual(-1, plan.rules.indexOf(ruleName));
       });
     },
@@ -431,7 +432,7 @@ function projectionsPlansTestSuite () {
         assertEqual(1, nodes.length, query);
         assertEqual(1, nodes[0].indexes.length, query);
         assertEqual(query[1], nodes[0].indexes[0].type, query);
-        assertEqual(query[2], nodes[0].projections, query);
+        assertEqual(normalize(query[2]), normalize(nodes[0].projections), query);
         assertEqual(query[3], nodes[0].indexCoversProjections, query);
         
         if (query[2].length) {
@@ -459,7 +460,7 @@ function projectionsPlansTestSuite () {
         assertEqual(1, nodes.length, query);
         assertEqual(1, nodes[0].indexes.length, query);
         assertEqual(query[1], nodes[0].indexes[0].type, query);
-        assertEqual(query[2], nodes[0].projections, query);
+        assertEqual(normalize(query[2]), normalize(nodes[0].projections), query);
         assertEqual(query[3], nodes[0].indexCoversProjections, query);
         
         if (query[2].length) {
@@ -486,7 +487,7 @@ function projectionsPlansTestSuite () {
         assertEqual(1, nodes.length, query);
         assertEqual(1, nodes[0].indexes.length, query);
         assertEqual(query[1], nodes[0].indexes[0].type, query);
-        assertEqual(query[2], nodes[0].projections, query);
+        assertEqual(normalize(query[2]), normalize(nodes[0].projections), query);
         assertEqual(query[3], nodes[0].indexCoversProjections, query);
         
         if (query[2].length) {
@@ -519,7 +520,7 @@ function projectionsPlansTestSuite () {
         assertEqual(1, nodes.length, query);
         assertEqual(1, nodes[0].indexes.length, query);
         assertEqual(query[1], nodes[0].indexes[0].type, query);
-        assertEqual(query[2], nodes[0].projections, query);
+        assertEqual(normalize(query[2]), normalize(nodes[0].projections), query);
         assertEqual(query[3], nodes[0].indexCoversProjections, query);
         
         if (query[2].length) {
@@ -548,7 +549,7 @@ function projectionsPlansTestSuite () {
         assertEqual(1, nodes.length, query);
         assertEqual(1, nodes[0].indexes.length, query);
         assertEqual(query[1], nodes[0].indexes[0].type, query);
-        assertEqual(query[2], nodes[0].projections, query);
+        assertEqual(normalize(query[2]), normalize(nodes[0].projections), query);
         assertEqual(query[3], nodes[0].indexCoversProjections, query);
         
         if (query[2].length) {
@@ -567,7 +568,7 @@ function projectionsPlansTestSuite () {
         let plan = AQL_EXPLAIN(query[0]).plan;
         let nodes = plan.nodes.filter(function(node) { return node.type === 'EnumerateCollectionNode'; });
         assertEqual(1, nodes.length, query);
-        assertEqual(query[1], nodes[0].projections, query);
+        assertEqual(normalize(query[1]), normalize(nodes[0].projections), query);
         assertNotEqual(-1, plan.rules.indexOf(ruleName));
       });
     },
@@ -585,7 +586,7 @@ function projectionsPlansTestSuite () {
         assertEqual(1, nodes.length, query);
         assertEqual(1, nodes[0].indexes.length, query);
         assertEqual(query[1], nodes[0].indexes[0].type, query);
-        assertEqual(query[2], nodes[0].projections, query);
+        assertEqual(normalize(query[2]), normalize(nodes[0].projections), query);
         assertEqual(query[3], nodes[0].indexCoversProjections, query);
         
         if (query[2].length) {
@@ -604,7 +605,7 @@ function projectionsPlansTestSuite () {
         let plan = AQL_EXPLAIN(query[0]).plan;
         let nodes = plan.nodes.filter(function(node) { return node.type === 'EnumerateCollectionNode'; });
         assertEqual(1, nodes.length, query);
-        assertEqual(query[1], nodes[0].projections, query);
+        assertEqual(normalize(query[1]), normalize(nodes[0].projections), query);
         assertNotEqual(-1, plan.rules.indexOf(ruleName));
       });
     },
@@ -628,7 +629,7 @@ function projectionsPlansTestSuite () {
         let plan = AQL_EXPLAIN(query[0]).plan;
         let nodes = plan.nodes.filter(function(node) { return node.type === 'EnumerateCollectionNode'; });
         assertEqual(1, nodes.length, query);
-        assertEqual(query[1], nodes[0].projections, query);
+        assertEqual(normalize(query[1]), normalize(nodes[0].projections), query);
         assertNotEqual(-1, plan.rules.indexOf(ruleName));
       });
     },
@@ -680,7 +681,7 @@ function projectionsExtractionTestSuite () {
         assertEqual(1, nodes.length, query);
         assertEqual(1, nodes[0].indexes.length, query);
         assertEqual(query[1], nodes[0].indexes[0].type, query);
-        assertEqual(query[2], nodes[0].projections, query);
+        assertEqual(normalize(query[2]), normalize(nodes[0].projections), query);
         assertEqual(query[3], nodes[0].indexCoversProjections, query);
         assertNotEqual(-1, plan.rules.indexOf(ruleName));
         let results = db._query(query[0], null, { optimizer: { rules: ["-optimize-cluster-single-document-operations"] } }).toArray();
@@ -713,7 +714,7 @@ function projectionsExtractionTestSuite () {
         let plan = AQL_EXPLAIN(query[0], null, { optimizer: { rules: ["-optimize-cluster-single-document-operations"] } }).plan;
         let nodes = plan.nodes.filter(function(node) { return node.type === 'IndexNode' || node.type === 'EnumerateCollectionNode'; });
         assertEqual(1, nodes.length, query);
-        assertEqual(query[1], nodes[0].projections, query);
+        assertEqual(normalize(query[1]), normalize(nodes[0].projections), query);
         assertEqual(query[2] ? 'IndexNode' : 'EnumerateCollectionNode', nodes[0].type, query);
         assertNotEqual(-1, plan.rules.indexOf(ruleName));
         let results = db._query(query[0], null, { optimizer: { rules: ["-optimize-cluster-single-document-operations"] } }).toArray();
@@ -745,7 +746,7 @@ function projectionsExtractionTestSuite () {
         let plan = AQL_EXPLAIN(query[0], null, { optimizer: { rules: ["-optimize-cluster-single-document-operations"] } }).plan;
         let nodes = plan.nodes.filter(function(node) { return node.type === 'IndexNode' || node.type === 'EnumerateCollectionNode'; });
         assertEqual(1, nodes.length, query);
-        assertEqual(query[1], nodes[0].projections, query);
+        assertEqual(normalize(query[1]), normalize(nodes[0].projections), query);
         assertEqual(query[2] ? 'IndexNode' : 'EnumerateCollectionNode', nodes[0].type, query);
         assertNotEqual(-1, plan.rules.indexOf(ruleName));
         let results = db._query(query[0], null, { optimizer: { rules: ["-optimize-cluster-single-document-operations"] } }).toArray();
@@ -810,7 +811,7 @@ function projectionsMaxProjectionsTestSuite () {
         let plan = AQL_EXPLAIN(query[0], null, { optimizer: { rules: ["-optimize-cluster-single-document-operations"] } }).plan;
         let nodes = plan.nodes.filter(function(node) { return node.type === 'EnumerateCollectionNode'; });
         assertEqual(1, nodes.length, query);
-        assertEqual(query[1], nodes[0].projections, query);
+        assertEqual(normalize(query[1]), normalize(nodes[0].projections), query);
         if (query[1].length) {
           assertNotEqual(-1, plan.rules.indexOf(ruleName));
         } else {
@@ -840,7 +841,7 @@ function projectionsMaxProjectionsTestSuite () {
         let plan = AQL_EXPLAIN(query[0], null, { optimizer: { rules: ["-optimize-cluster-single-document-operations"] } }).plan;
         let nodes = plan.nodes.filter(function(node) { return node.type === 'EnumerateCollectionNode'; });
         assertEqual(1, nodes.length, query);
-        assertEqual(query[1].sort(), nodes[0].projections.sort(), query);
+        assertEqual(normalize(query[1].sort()), normalize(nodes[0].projections.sort()), query);
         if (query[1].length) {
           assertNotEqual(-1, plan.rules.indexOf(ruleName));
         } else {

--- a/tests/js/server/aql/aql-queries-nested-joins.js
+++ b/tests/js/server/aql/aql-queries-nested-joins.js
@@ -26,6 +26,7 @@
 
 const jsunity = require("jsunity");
 const db = require("@arangodb").db;
+const normalize = require("@arangodb/aql-helper").normalizeProjections;
 
 function nestedJoinsTestSuite () {
   const cn = "UnitTestsCollection";
@@ -66,7 +67,7 @@ function nestedJoinsTestSuite () {
         let nodes = AQL_EXPLAIN(q).plan.nodes.filter((node) => node.type === 'IndexNode');
         assertEqual(1, nodes.length);
         assertEqual(1, nodes[0].indexes.length);
-        assertEqual(["value"], nodes[0].projections);
+        assertEqual(normalize(["value"]), normalize(nodes[0].projections));
 
         let results = db._query(q).toArray();
         assertEqual(max, results.length);
@@ -81,8 +82,8 @@ function nestedJoinsTestSuite () {
         assertEqual(2, nodes.length);
         assertEqual(1, nodes[0].indexes.length);
         assertEqual(1, nodes[1].indexes.length);
-        assertEqual([], nodes[0].projections);
-        assertEqual(["value"], nodes[1].projections);
+        assertEqual(normalize([]), normalize(nodes[0].projections));
+        assertEqual(normalize(["value"]), normalize(nodes[1].projections));
 
         let results = db._query(q).toArray();
         assertEqual(1, results.length);
@@ -97,8 +98,8 @@ function nestedJoinsTestSuite () {
         assertEqual(2, nodes.length);
         assertEqual(1, nodes[0].indexes.length);
         assertEqual(1, nodes[1].indexes.length);
-        assertEqual(["value"], nodes[0].projections);
-        assertEqual(["value"], nodes[1].projections);
+        assertEqual(normalize(["value"]), normalize(nodes[0].projections));
+        assertEqual(normalize(["value"]), normalize(nodes[1].projections));
 
         let results = db._query(q).toArray();
         assertEqual(max, results.length);
@@ -113,8 +114,8 @@ function nestedJoinsTestSuite () {
         assertEqual(2, nodes.length);
         assertEqual(1, nodes[0].indexes.length);
         assertEqual(1, nodes[1].indexes.length);
-        assertEqual([], nodes[0].projections);
-        assertEqual(["value"], nodes[1].projections);
+        assertEqual(normalize([]), normalize(nodes[0].projections));
+        assertEqual(normalize(["value"]), normalize(nodes[1].projections));
 
         let results = db._query(q).toArray();
         assertEqual(1, results.length);
@@ -129,8 +130,8 @@ function nestedJoinsTestSuite () {
         assertEqual(2, nodes.length);
         assertEqual(1, nodes[0].indexes.length);
         assertEqual(1, nodes[1].indexes.length);
-        assertEqual(["value"], nodes[0].projections);
-        assertEqual(["value"], nodes[1].projections);
+        assertEqual(normalize(["value"]), normalize(nodes[0].projections));
+        assertEqual(normalize(["value"]), normalize(nodes[1].projections));
 
         let results = db._query(q).toArray();
         assertEqual(1, results.length);

--- a/tests/js/server/aql/aql-sparse.js
+++ b/tests/js/server/aql/aql-sparse.js
@@ -4,8 +4,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief tests for sparse index usage
 ///
-/// @file
-///
 /// DISCLAIMER
 ///
 /// Copyright 2010-2012 triagens GmbH, Cologne, Germany
@@ -30,6 +28,7 @@
 
 const jsunity = require("jsunity");
 const db = require("@arangodb").db;
+const normalize = require("@arangodb/aql-helper").normalizeProjections;
 
 function optimizerSparseTestSuite () {
   let c;
@@ -423,7 +422,7 @@ function optimizerSparseTestSuite () {
       assertEqual([], collections[0].projections);
       assertEqual(c.name(), collections[1].collection);
       assertEqual("doc2", collections[1].outVariable.name);
-      assertEqual(["value1"], collections[1].projections);
+      assertEqual(normalize(["value1"]), normalize(collections[1].projections));
     },
     
     testSparseJoinFuncNeNull : function () {
@@ -446,7 +445,7 @@ function optimizerSparseTestSuite () {
       assertEqual(1, collections.length);
       assertEqual(c.name(), collections[0].collection);
       assertEqual("doc2", collections[0].outVariable.name);
-      assertEqual(["value1"], collections[0].projections);
+      assertEqual(normalize(["value1"]), normalize(collections[0].projections));
     },
     
     testSparseJoinFuncNeNullNeNull : function () {
@@ -483,7 +482,7 @@ function optimizerSparseTestSuite () {
       assertEqual(1, collections.length);
       assertEqual(c.name(), collections[0].collection);
       assertEqual("doc2", collections[0].outVariable.name);
-      assertEqual(["value1"], collections[0].projections);
+      assertEqual(normalize(["value1"]), normalize(collections[0].projections));
     },
     
     testSparseJoinFuncGtNullGtNull : function () {

--- a/tests/js/server/aql/aql-traversal-projections.js
+++ b/tests/js/server/aql/aql-traversal-projections.js
@@ -26,6 +26,7 @@
 
 const jsunity = require("jsunity");
 const db = require("@arangodb").db;
+const normalize = require("@arangodb/aql-helper").normalizeProjections;
 const cn = "UnitTestsOptimizer";
 const isCluster = require("internal").isCluster();
 
@@ -179,14 +180,6 @@ function projectionsTestSuite () {
         [`FOR v, e, p IN 1..2 OUTBOUND 'v/test0' ${cn} OPTIONS {maxProjections: 4} ${returnProjections("e", 3)}`, [], [], false, false, false],
       ];
 
-
-      // normalize projections
-      const normalize = (v) => {
-        if (v === undefined || v === null) {
-          return [];
-        }
-        return v.sort();
-      };
 
       queries.forEach(function (q) {
         let [query, vertexProjections, edgeProjections, produceVertices, producePathsVertices, producePathsEdges] = q;


### PR DESCRIPTION
### Scope & Purpose

Enterprise companion PR: https://github.com/arangodb/enterprise/pull/1395

Preparation PR for loading projection results into AqlItemBlock results.
This PR changes the format of the `projections` and `filterProjections` query plan attributes from flat arrays with the projection names to objects, which contain the projection path (always an array) and an optional outvariable.
The previous format was like this:
```
{
  "projections": [
    "a", 
    ["foo", "bar"]
  ]
}
```
Now it would look like this:
```
{
  "projections": [
    { 
      "path": ["a"]
    },
    {
      "path": ["foo", "bar"]
    }
  ]
}
```
In addition, projections in the future can also return an attribute "variable" (not shown above), which will contain the out variable for the projected attribute, if set.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 