### PR TITLE
Optimize FilterProjections

### DIFF
--- a/arangod/Aql/Expression.cpp
+++ b/arangod/Aql/Expression.cpp
@@ -125,6 +125,10 @@ AqlValue Expression::execute(ExpressionContext* ctx, bool& mustDestroy) {
       return _accessor->get(*resolver, ctx, mustDestroy);
     }
 
+    case EXTERNAL_VALUE_REFERENCE: {
+      return AqlValue(ctx->getExternalValueReference(_externalValueIndex));
+    }
+
     case UNPROCESSED: {
       // fall-through to exception
     }
@@ -189,6 +193,7 @@ void Expression::freeInternals() noexcept {
       break;
     }
 
+    case EXTERNAL_VALUE_REFERENCE:
     case SIMPLE:
     case UNPROCESSED: {
       // nothing to do
@@ -1998,6 +2003,8 @@ std::string Expression::typeString() {
       return "simple";
     case ATTRIBUTE_ACCESS:
       return "attribute";
+    case EXTERNAL_VALUE_REFERENCE:
+      return "external-value-reference";
     case UNPROCESSED: {
     }
   }

--- a/arangod/Aql/Expression.h
+++ b/arangod/Aql/Expression.h
@@ -65,7 +65,8 @@ class Expression {
     UNPROCESSED,
     JSON,
     SIMPLE,
-    ATTRIBUTE_ACCESS
+    ATTRIBUTE_ACCESS,
+    EXTERNAL_VALUE_REFERENCE,
   };
 
   Expression(Expression const&) = delete;
@@ -309,6 +310,7 @@ class Expression {
   union {
     uint8_t* _data;
     AttributeAccessor* _accessor;
+    std::uint64_t _externalValueIndex;
   };
 
   // we keep the amount of used bytes by the buffer stored in "_data" here.

--- a/arangod/Aql/ExpressionContext.h
+++ b/arangod/Aql/ExpressionContext.h
@@ -24,9 +24,12 @@
 #pragma once
 
 #include "Basics/ErrorCode.h"
+#include "velocypack/Slice.h"
 
 #include <string_view>
 #include <unicode/regex.h>
+#include <span>
+#include <cstdint>
 
 struct TRI_vocbase_t;
 
@@ -37,7 +40,6 @@ class Methods;
 }
 namespace velocypack {
 struct Options;
-class Slice;
 }  // namespace velocypack
 
 namespace aql {
@@ -78,6 +80,16 @@ class ExpressionContext {
 
   // unregister a temporary variable from the ExpressionContext.
   virtual void clearVariable(Variable const* variable) noexcept = 0;
+
+  velocypack::Slice getExternalValueReference(uint64_t idx) {
+    // TRI_ASSERT(idx < _externalValueReferences.size())
+    //     << "idx = " << idx << " size() = " <<
+    //     _externalValueReferences.size();
+    return _externalValueReferences[idx];
+  }
+
+ protected:
+  std::span<velocypack::Slice> _externalValueReferences;
 };
 }  // namespace aql
 }  // namespace arangodb


### PR DESCRIPTION
### Scope & Purpose
This PR tries to reduce the amount of copied data for filter projections. If a post filter can be served by projections from the indexed values or stored values, a document is built in memory and passed to the filter expression. Instead one could reference the slices directly by modifying the expression.

This PR introduces references to these external values.