### PR TITLE
Reduce number of shared_ptr copies in cache subsystem

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 v3.11.5 (XXXX-XX-XX)
 --------------------
 
+* Reduce number of atomic shared_ptr copies in in-memory cache subsystem.
+
 * Updated arangosync to v2.19.4.
 
 * Add cluster-internal connectivity checks.

--- a/arangod/Cache/Cache.h
+++ b/arangod/Cache/Cache.h
@@ -234,7 +234,8 @@ class Cache : public std::enable_shared_from_this<Cache> {
 
  protected:
   void requestGrow();
-  void requestMigrate(std::uint32_t requestedLogSize = 0);
+  void requestMigrate(Table* table, std::uint32_t requestedLogSize,
+                      std::uint32_t currentLogSize);
 
   static void freeValue(CachedValue* value) noexcept;
   bool reclaimMemory(std::uint64_t size) noexcept;
@@ -242,7 +243,7 @@ class Cache : public std::enable_shared_from_this<Cache> {
   void recordHit();
   void recordMiss();
 
-  bool reportInsert(bool hadEviction);
+  bool reportInsert(Table* table, bool hadEviction);
 
   // management
   Metadata& metadata();
@@ -264,7 +265,7 @@ class Cache : public std::enable_shared_from_this<Cache> {
   virtual bool freeMemoryWhile(
       std::function<bool(std::uint64_t)> const& cb) = 0;
 
-  virtual void migrateBucket(void* sourcePtr,
+  virtual void migrateBucket(Table* table, void* sourcePtr,
                              std::unique_ptr<Table::Subtable> targets,
                              Table& newTable) = 0;
 

--- a/arangod/Cache/Manager.cpp
+++ b/arangod/Cache/Manager.cpp
@@ -99,6 +99,9 @@ Manager::Manager(SharedPRNGFeature& sharedPRNG, PostFn schedulerPost,
       _freeMemoryTasks(0),
       _migrateTasksDuration(0),
       _freeMemoryTasksDuration(0),
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+      _tableCalls(0),
+#endif
       _schedulerPost(std::move(schedulerPost)),
       _outstandingTasks(0),
       _rebalancingTasks(0),
@@ -320,7 +323,7 @@ std::uint64_t Manager::globalAllocation() const noexcept {
   return _globalAllocation;
 }
 
-std::optional<Manager::MemoryStats> Manager::memoryStats(
+Manager::MemoryStats Manager::memoryStats(
     std::uint64_t maxTries) const noexcept {
   SpinLocker guard(SpinLocker::Mode::Read, _lock,
                    static_cast<size_t>(maxTries));
@@ -339,10 +342,24 @@ std::optional<Manager::MemoryStats> Manager::memoryStats(
     result.freeMemoryTasks = _freeMemoryTasks;
     result.migrateTasksDuration = _migrateTasksDuration;
     result.freeMemoryTasksDuration = _freeMemoryTasksDuration;
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+    result.tableCalls = _tableCalls;
+#endif
+
+    guard.release();
+    {
+      // store result for next time
+      std::lock_guard<std::mutex> statsGuard(_lastMemoryStatsMutex);
+      _lastMemoryStatsResult = result;
+    }
     return result;
   }
 
-  return std::nullopt;
+  // couldn't acquire the cache manager mutex in time.
+  // in this case, we simply return the last memory stats that we
+  // previously returned. this is better than returning no data at all.
+  std::lock_guard<std::mutex> statsGuard(_lastMemoryStatsMutex);
+  return _lastMemoryStatsResult;
 }
 
 std::pair<double, double> Manager::globalHitRates() {
@@ -782,6 +799,12 @@ void Manager::trackFreeMemoryTaskDuration(std::uint64_t duration) noexcept {
   SpinLocker guard(SpinLocker::Mode::Write, _lock);
   _freeMemoryTasksDuration += duration;
 }
+
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+void Manager::trackTableCall() noexcept {
+  _tableCalls.fetch_add(1, std::memory_order_relaxed);
+}
+#endif
 
 #ifdef ARANGODB_ENABLE_FAILURE_TESTS
 void Manager::freeUnusedTablesForTesting() {

--- a/arangod/Cache/Manager.h
+++ b/arangod/Cache/Manager.h
@@ -41,7 +41,7 @@
 #include <limits>
 #include <map>
 #include <memory>
-#include <optional>
+#include <mutex>
 #include <stack>
 #include <utility>
 
@@ -91,6 +91,9 @@ class Manager {
     std::uint64_t freeMemoryTasks = 0;
     std::uint64_t migrateTasksDuration = 0;     // total, micros
     std::uint64_t freeMemoryTasksDuration = 0;  // total, micros
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+    std::uint64_t tableCalls = 0;
+#endif
   };
 
   static constexpr std::size_t kFindStatsCapacity = 8192;
@@ -177,8 +180,7 @@ class Manager {
   //////////////////////////////////////////////////////////////////////////////
   /// @brief Return some statistics about available caches
   //////////////////////////////////////////////////////////////////////////////
-  [[nodiscard]] std::optional<MemoryStats> memoryStats(
-      std::uint64_t maxTries) const noexcept;
+  [[nodiscard]] MemoryStats memoryStats(std::uint64_t maxTries) const noexcept;
 
   [[nodiscard]] std::pair<double, double> globalHitRates();
 
@@ -214,6 +216,10 @@ class Manager {
   void trackMigrateTaskDuration(std::uint64_t duration) noexcept;
   // track duration of free memory task, in ms
   void trackFreeMemoryTaskDuration(std::uint64_t duration) noexcept;
+
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+  void trackTableCall() noexcept;
+#endif
 
  private:
   // assume at most 16 slots in each stack -- TODO: check validity
@@ -265,6 +271,21 @@ class Manager {
   std::uint64_t _freeMemoryTasks;
   std::uint64_t _migrateTasksDuration;     // total, micros
   std::uint64_t _freeMemoryTasksDuration;  // total, micros
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+  // number of calls to the function `Cache::table()`.
+  // calling this function is expensive, because it loads an
+  // atomic shared_ptr, which currently requires an internal
+  // mutex.
+  // we can expect one call to Cache::table() for every
+  // cache lookup, one call for every cache insert, and one
+  // for every cache removal. we can also expect calls to this
+  // function when the cache runs a "free memory" task.
+  std::atomic<std::uint64_t> _tableCalls;
+#endif
+
+  // last memory stats returned.
+  std::mutex mutable _lastMemoryStatsMutex;
+  MemoryStats mutable _lastMemoryStatsResult;
 
   // transaction management
   TransactionManager _transactions;

--- a/arangod/Cache/ManagerTasks.cpp
+++ b/arangod/Cache/ManagerTasks.cpp
@@ -29,6 +29,7 @@
 #include "Cache/Cache.h"
 #include "Cache/Manager.h"
 #include "Cache/Metadata.h"
+#include "Logger/LogMacros.h"
 #include "Random/RandomGenerator.h"
 
 #include <chrono>
@@ -121,8 +122,14 @@ void FreeMemoryTask::run() {
     toggleResizingGuard.cancel();
   }
 
+  LOG_TOPIC("dce52", TRACE, Logger::CACHE)
+      << "freeMemory task took "
+      << std::chrono::duration_cast<std::chrono::milliseconds>(diff).count()
+      << "ms";
+
   if (_triggerShrinking) {
-    _cache->requestMigrate(_cache->table()->idealSize());
+    std::shared_ptr<Table> table = _cache->table();
+    _cache->requestMigrate(table.get(), table->idealSize(), table->logSize());
   }
 }
 
@@ -183,6 +190,11 @@ void MigrateTask::run() {
   auto diff = std::chrono::steady_clock::now() - now;
   _manager.trackMigrateTaskDuration(
       std::chrono::duration_cast<std::chrono::microseconds>(diff).count());
+
+  LOG_TOPIC("f4c44", TRACE, Logger::CACHE)
+      << "migrate task on table with " << _table->size() << " slots took "
+      << std::chrono::duration_cast<std::chrono::milliseconds>(diff).count()
+      << "ms";
 
   // migrate() must have unset the migrating flag, but we
   // cannot check it here because another MigrateTask may

--- a/arangod/Cache/PlainCache.h
+++ b/arangod/Cache/PlainCache.h
@@ -109,9 +109,9 @@ class PlainCache final : public Cache {
                                        bool enableWindowedStats);
 
   bool freeMemoryWhile(std::function<bool(std::uint64_t)> const& cb) override;
-  virtual void migrateBucket(void* sourcePtr,
-                             std::unique_ptr<Table::Subtable> targets,
-                             Table& newTable) override;
+  void migrateBucket(Table* table, void* sourcePtr,
+                     std::unique_ptr<Table::Subtable> targets,
+                     Table& newTable) override;
 
   // helpers
   std::pair<::ErrorCode, Table::BucketLocker> getBucket(

--- a/arangod/Cache/Table.cpp
+++ b/arangod/Cache/Table.cpp
@@ -185,7 +185,7 @@ Table::Table(std::uint32_t logSize, Manager* manager)
       _disabled(true),
       _evictions(false),
       _size(static_cast<std::uint64_t>(1) << _logSize),
-      _shift(32 - _logSize),
+      _shift(kMaxLogSize - _logSize),
       _mask(static_cast<std::uint32_t>((_size - 1) << _shift)),
       _buffer(std::make_unique<std::uint8_t[]>((_size * kBucketSizeInBytes) +
                                                kPadding)),
@@ -197,6 +197,10 @@ Table::Table(std::uint32_t logSize, Manager* manager)
       _bucketClearer(defaultClearer),
       _slotsTotal(_size),
       _slotsUsed(static_cast<std::uint64_t>(0)) {
+  TRI_ASSERT(_logSize <= kMaxLogSize);
+  TRI_ASSERT(_size == (std::uint64_t(1) << _logSize));
+  TRI_ASSERT(_size <= std::numeric_limits<std::uint32_t>::max());
+
   for (std::size_t i = 0; i < _size; i++) {
     // use placement new in order to properly initialize the bucket
     new (_buckets + i) GenericBucket();

--- a/arangod/Cache/TransactionalCache.h
+++ b/arangod/Cache/TransactionalCache.h
@@ -127,7 +127,8 @@ class TransactionalCache final : public Cache {
                                        bool enableWindowedStats);
 
   bool freeMemoryWhile(std::function<bool(std::uint64_t)> const& cb) override;
-  void migrateBucket(void* sourcePtr, std::unique_ptr<Table::Subtable> targets,
+  void migrateBucket(Table* table, void* sourcePtr,
+                     std::unique_ptr<Table::Subtable> targets,
                      Table& newTable) override;
 
   // helpers

--- a/arangod/RocksDBEngine/RocksDBEngine.cpp
+++ b/arangod/RocksDBEngine/RocksDBEngine.cpp
@@ -3448,31 +3448,34 @@ void RocksDBEngine::getStatistics(VPackBuilder& builder) const {
         server().getFeature<CacheManagerFeature>().manager();
 
     std::pair<double, double> rates;
-    std::optional<cache::Manager::MemoryStats> stats;
+    cache::Manager::MemoryStats stats;
     if (manager != nullptr) {
       // cache turned on
       stats = manager->memoryStats(cache::Cache::triesFast);
       rates = manager->globalHitRates();
     }
-    if (!stats.has_value()) {
-      stats = cache::Manager::MemoryStats{};
-    }
-    TRI_ASSERT(stats.has_value());
 
-    builder.add("cache.limit", VPackValue(stats->globalLimit));
-    builder.add("cache.allocated", VPackValue(stats->globalAllocation));
-    builder.add("cache.peak-allocated",
-                VPackValue(stats->peakGlobalAllocation));
-    builder.add("cache.active-tables", VPackValue(stats->activeTables));
-    builder.add("cache.unused-memory", VPackValue(stats->spareAllocation));
-    builder.add("cache.unused-tables", VPackValue(stats->spareTables));
-    builder.add("cache.migrate-tasks-total", VPackValue(stats->migrateTasks));
+    builder.add("cache.limit", VPackValue(stats.globalLimit));
+    builder.add("cache.allocated", VPackValue(stats.globalAllocation));
+    builder.add("cache.peak-allocated", VPackValue(stats.peakGlobalAllocation));
+    builder.add("cache.active-tables", VPackValue(stats.activeTables));
+    builder.add("cache.unused-memory", VPackValue(stats.spareAllocation));
+    builder.add("cache.unused-tables", VPackValue(stats.spareTables));
+    builder.add("cache.migrate-tasks-total", VPackValue(stats.migrateTasks));
     builder.add("cache.free-memory-tasks-total",
-                VPackValue(stats->freeMemoryTasks));
+                VPackValue(stats.freeMemoryTasks));
     builder.add("cache.migrate-tasks-duration-total",
-                VPackValue(stats->migrateTasksDuration));
+                VPackValue(stats.migrateTasksDuration));
     builder.add("cache.free-memory-tasks-duration-total",
-                VPackValue(stats->freeMemoryTasksDuration));
+                VPackValue(stats.freeMemoryTasksDuration));
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+    // only here for debugging. the value is not exposed in non-maintainer
+    // mode builds. the reason for this is to make calls to the `table` function
+    // more lightweight, and because we would need to put a metrics
+    // description into Documentation/Metrics for an optional metric.
+
+    // builder.add("cache.table-calls", VPackValue(stats.tableCalls));
+#endif
 
     // edge cache compression ratio
     double compressionRatio = 0.0;

--- a/tests/Cache/Manager.cpp
+++ b/tests/Cache/Manager.cpp
@@ -67,19 +67,19 @@ TEST(CacheManagerTest, test_memory_usage_for_cache_creation) {
 
   {
     auto beforeStats = manager.memoryStats(cache::Cache::triesGuarantee);
-    ASSERT_EQ(0, beforeStats->activeTables);
+    ASSERT_EQ(0, beforeStats.activeTables);
 
     auto cache = manager.createCache<BinaryKeyHasher>(CacheType::Transactional);
     ASSERT_NE(nullptr, cache);
 
     auto afterStats = manager.memoryStats(cache::Cache::triesGuarantee);
-    ASSERT_EQ(1, afterStats->activeTables);
+    ASSERT_EQ(1, afterStats.activeTables);
 
     manager.destroyCache(std::move(cache));
 
     auto afterStats2 = manager.memoryStats(cache::Cache::triesGuarantee);
-    ASSERT_EQ(0, afterStats2->activeTables);
-    ASSERT_EQ(beforeStats->globalAllocation, afterStats2->globalAllocation);
+    ASSERT_EQ(0, afterStats2.activeTables);
+    ASSERT_EQ(beforeStats.globalAllocation, afterStats2.globalAllocation);
   }
 }
 
@@ -101,7 +101,7 @@ TEST(CacheManagerTest, test_memory_usage_for_cache_reusage) {
 
   {
     auto beforeStats = manager.memoryStats(cache::Cache::triesGuarantee);
-    ASSERT_EQ(0, beforeStats->activeTables);
+    ASSERT_EQ(0, beforeStats.activeTables);
 
     auto cache = manager.createCache<BinaryKeyHasher>(CacheType::Transactional);
     ASSERT_NE(nullptr, cache);
@@ -109,30 +109,30 @@ TEST(CacheManagerTest, test_memory_usage_for_cache_reusage) {
     manager.destroyCache(std::move(cache));
 
     auto afterStats = manager.memoryStats(cache::Cache::triesGuarantee);
-    ASSERT_EQ(0, afterStats->activeTables);
-    ASSERT_EQ(1, afterStats->spareTables);
-    ASSERT_LT(beforeStats->globalAllocation, afterStats->globalAllocation);
+    ASSERT_EQ(0, afterStats.activeTables);
+    ASSERT_EQ(1, afterStats.spareTables);
+    ASSERT_LT(beforeStats.globalAllocation, afterStats.globalAllocation);
 
     cache = manager.createCache<BinaryKeyHasher>(CacheType::Transactional);
 
     auto afterStats2 = manager.memoryStats(cache::Cache::triesGuarantee);
-    ASSERT_EQ(1, afterStats2->activeTables);
-    ASSERT_EQ(0, afterStats2->spareTables);
-    ASSERT_EQ(afterStats->globalAllocation,
-              afterStats2->globalAllocation - Manager::kCacheRecordOverhead);
+    ASSERT_EQ(1, afterStats2.activeTables);
+    ASSERT_EQ(0, afterStats2.spareTables);
+    ASSERT_EQ(afterStats.globalAllocation,
+              afterStats2.globalAllocation - Manager::kCacheRecordOverhead);
 
     manager.destroyCache(std::move(cache));
 
     auto afterStats3 = manager.memoryStats(cache::Cache::triesGuarantee);
-    ASSERT_EQ(afterStats->globalAllocation, afterStats3->globalAllocation);
+    ASSERT_EQ(afterStats.globalAllocation, afterStats3.globalAllocation);
 
 #ifdef ARANGODB_ENABLE_FAILURE_TESTS
     manager.freeUnusedTablesForTesting();
 
     auto afterStats4 = manager.memoryStats(cache::Cache::triesGuarantee);
-    ASSERT_EQ(0, afterStats4->activeTables);
-    ASSERT_EQ(0, afterStats4->spareTables);
-    ASSERT_EQ(beforeStats->globalAllocation, afterStats4->globalAllocation);
+    ASSERT_EQ(0, afterStats4.activeTables);
+    ASSERT_EQ(0, afterStats4.spareTables);
+    ASSERT_EQ(beforeStats.globalAllocation, afterStats4.globalAllocation);
 #endif
   }
 }
@@ -174,7 +174,7 @@ TEST(CacheManagerTest,
     manager.freeUnusedTablesForTesting();
 
     auto afterStats = manager.memoryStats(cache::Cache::triesGuarantee);
-    ASSERT_EQ(beforeStats->globalAllocation, afterStats->globalAllocation);
+    ASSERT_EQ(beforeStats.globalAllocation, afterStats.globalAllocation);
   }
 
   {
@@ -188,7 +188,7 @@ TEST(CacheManagerTest,
     manager.freeUnusedTablesForTesting();
 
     auto afterStats = manager.memoryStats(cache::Cache::triesGuarantee);
-    ASSERT_EQ(beforeStats->globalAllocation, afterStats->globalAllocation);
+    ASSERT_EQ(beforeStats.globalAllocation, afterStats.globalAllocation);
   }
 
   {
@@ -202,7 +202,7 @@ TEST(CacheManagerTest,
     manager.freeUnusedTablesForTesting();
 
     auto afterStats = manager.memoryStats(cache::Cache::triesGuarantee);
-    ASSERT_EQ(beforeStats->globalAllocation, afterStats->globalAllocation);
+    ASSERT_EQ(beforeStats.globalAllocation, afterStats.globalAllocation);
   }
 }
 #endif
@@ -236,8 +236,8 @@ TEST(CacheManagerTest,
     ASSERT_EQ(nullptr, cache);
 
     auto afterStats = manager.memoryStats(cache::Cache::triesGuarantee);
-    ASSERT_EQ(beforeStats->globalAllocation, afterStats->globalAllocation);
-    ASSERT_EQ(beforeStats->activeTables, afterStats->activeTables);
+    ASSERT_EQ(beforeStats.globalAllocation, afterStats.globalAllocation);
+    ASSERT_EQ(beforeStats.activeTables, afterStats.activeTables);
   }
 
   {
@@ -249,8 +249,8 @@ TEST(CacheManagerTest,
         manager.createCache<BinaryKeyHasher>(CacheType::Transactional));
 
     auto afterStats = manager.memoryStats(cache::Cache::triesGuarantee);
-    ASSERT_EQ(beforeStats->globalAllocation, afterStats->globalAllocation);
-    ASSERT_EQ(beforeStats->activeTables, afterStats->activeTables);
+    ASSERT_EQ(beforeStats.globalAllocation, afterStats.globalAllocation);
+    ASSERT_EQ(beforeStats.activeTables, afterStats.activeTables);
   }
 
   {
@@ -262,8 +262,8 @@ TEST(CacheManagerTest,
         manager.createCache<BinaryKeyHasher>(CacheType::Transactional));
 
     auto afterStats = manager.memoryStats(cache::Cache::triesGuarantee);
-    ASSERT_EQ(beforeStats->globalAllocation, afterStats->globalAllocation);
-    ASSERT_EQ(beforeStats->activeTables, afterStats->activeTables);
+    ASSERT_EQ(beforeStats.globalAllocation, afterStats.globalAllocation);
+    ASSERT_EQ(beforeStats.activeTables, afterStats.activeTables);
   }
 }
 #endif
@@ -287,7 +287,7 @@ TEST(CacheManagerTest, test_create_and_destroy_caches) {
 
   for (size_t i = 0; i < 8; ++i) {
     auto beforeStats = manager.memoryStats(cache::Cache::triesGuarantee);
-    ASSERT_EQ(i, beforeStats->activeTables);
+    ASSERT_EQ(i, beforeStats.activeTables);
 
     auto cache = manager.createCache<BinaryKeyHasher>(CacheType::Transactional);
     ASSERT_NE(nullptr, cache);
@@ -295,11 +295,11 @@ TEST(CacheManagerTest, test_create_and_destroy_caches) {
               40 * 1024);  // size of each cache is about 40kb without stats
 
     auto afterStats = manager.memoryStats(cache::Cache::triesGuarantee);
-    ASSERT_LT(beforeStats->globalAllocation, afterStats->globalAllocation);
-    ASSERT_EQ(i + 1, afterStats->activeTables);
+    ASSERT_LT(beforeStats.globalAllocation, afterStats.globalAllocation);
+    ASSERT_EQ(i + 1, afterStats.activeTables);
 
-    ASSERT_EQ(0, afterStats->spareAllocation);
-    ASSERT_EQ(0, afterStats->spareTables);
+    ASSERT_EQ(0, afterStats.spareAllocation);
+    ASSERT_EQ(0, afterStats.spareTables);
 
     caches.emplace_back(std::move(cache));
   }
@@ -307,7 +307,7 @@ TEST(CacheManagerTest, test_create_and_destroy_caches) {
   std::uint64_t spareTables = 0;
   while (!caches.empty()) {
     auto beforeStats = manager.memoryStats(cache::Cache::triesGuarantee);
-    ASSERT_EQ(spareTables, beforeStats->spareTables);
+    ASSERT_EQ(spareTables, beforeStats.spareTables);
 
     auto cache = caches.back();
     std::uint64_t size = cache->size();
@@ -315,17 +315,17 @@ TEST(CacheManagerTest, test_create_and_destroy_caches) {
     manager.destroyCache(std::move(cache));
 
     auto afterStats = manager.memoryStats(cache::Cache::triesGuarantee);
-    if (afterStats->spareTables == beforeStats->spareTables) {
+    if (afterStats.spareTables == beforeStats.spareTables) {
       // table deleted
-      ASSERT_GT(beforeStats->globalAllocation, afterStats->globalAllocation);
-      ASSERT_EQ(spareTables, afterStats->spareTables);
+      ASSERT_GT(beforeStats.globalAllocation, afterStats.globalAllocation);
+      ASSERT_EQ(spareTables, afterStats.spareTables);
     } else {
       // table recycled
       ++spareTables;
-      ASSERT_GT(afterStats->spareAllocation, spareTables * 16384);
-      ASSERT_EQ(spareTables, afterStats->spareTables);
+      ASSERT_GT(afterStats.spareAllocation, spareTables * 16384);
+      ASSERT_EQ(spareTables, afterStats.spareTables);
     }
-    ASSERT_EQ(caches.size() - 1, afterStats->activeTables);
+    ASSERT_EQ(caches.size() - 1, afterStats.activeTables);
 
     caches.pop_back();
   }
@@ -455,7 +455,7 @@ TEST(CacheManagerTest, test_memory_usage_for_data) {
   guard.fire();
 
   auto afterStats = manager.memoryStats(cache::Cache::triesGuarantee);
-  ASSERT_LT(beforeStats->globalAllocation, afterStats->globalAllocation);
+  ASSERT_LT(beforeStats.globalAllocation, afterStats.globalAllocation);
 
   std::string key;
   std::string value;
@@ -488,17 +488,17 @@ TEST(CacheManagerTest, test_memory_usage_for_data) {
   }
 
   auto afterStats2 = manager.memoryStats(cache::Cache::triesGuarantee);
-  ASSERT_LT(beforeStats->globalAllocation + totalSize,
-            afterStats2->globalAllocation);
+  ASSERT_LT(beforeStats.globalAllocation + totalSize,
+            afterStats2.globalAllocation);
 
   manager.destroyCache(std::move(cache));
 
   manager.freeUnusedTablesForTesting();
 
   auto afterStats3 = manager.memoryStats(cache::Cache::triesGuarantee);
-  ASSERT_EQ(0, afterStats3->activeTables);
-  ASSERT_EQ(0, afterStats3->spareTables);
-  ASSERT_EQ(beforeStats->globalAllocation, afterStats3->globalAllocation);
+  ASSERT_EQ(0, afterStats3.activeTables);
+  ASSERT_EQ(0, afterStats3.spareTables);
+  ASSERT_EQ(beforeStats.globalAllocation, afterStats3.globalAllocation);
 }
 #endif
 


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/19958

Reduce number of shared_ptr copies in cache subsystem

- `Cache::migrate()` migrates data for all buckets in a cache table. for each bucket, it calls `migrateBucket(...)`. `migrateBucket` created a copy of the table's atomic shared_ptr, which internally uses a lock. this is now changed so that the table pointer is passed into the call to `migrateBucket`, so that we do not need to copy the shared_pointer repeatedly. this saves n copies of the atomic shared_ptr, where n is the size of the table.
- `Cache::requestMigrate(...)` also created a copy of the table's atomic shared_ptr, which is now saved by passing the table pointer into the function.
- `Cache::reportInsert()` could be called after inserting data into a cache table. `reportInsert()` also created a copy of the table's atomic shared_ptr, which is now also saved.
- added an internal metric in the code for tracking the number of calls to `Cache::table()`. this metric is not enabled by default to remove the overhead of the tracking. the code can be enabled easily when debugging.
- replace a modulus calculation in `freeMemoryWhile(...)` with a bit operation, as cache table sizes are always power-of-2 values.
- cache tables have a maximum size of 4 * 1024 * 1024 entries. some internals in `Cache::Table` use a uint32_t when indexing cache table entries. added code that ensures that no cache tables with larger sizes can be created.
- added trace log messages for MigrateTask and FreeMemoryTask so that their internals can be inspected.

Also make cache metrics more reliable:
The previous implementation that returned the metrics for the in-memory cache subsystem could return all metrics set to 0 if it could not acquire the cache manager lock in time.
now, instead of returning zeroed results, we simply return the same result that we returned last time. so now in the worst case we return slightly stale metrics, but this is a lot better than returning zeroed metrics.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [x] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.11: this PR
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 