### PR TITLE
Reduce number of shared_ptr copies in cache subsystem

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 v3.10.11 (XXXX-XX-XX)
 ---------------------
 
+* Reduce number of atomic shared_ptr copies in in-memory cache subsystem.
+
 * Updated arangosync to v2.19.4.
 
 * Fix updating of collection properties (schema) when the collection has a view

--- a/arangod/Cache/Cache.cpp
+++ b/arangod/Cache/Cache.cpp
@@ -128,10 +128,14 @@ void Cache::sizeHint(uint64_t numElements) {
       static_cast<double>(numElements) /
       (static_cast<double>(_slotsPerBucket) * Table::idealUpperRatio));
   std::uint32_t requestedLogSize = 0;
-  for (; (static_cast<std::uint64_t>(1) << requestedLogSize) < numBuckets;
+  for (; (static_cast<std::uint64_t>(1) << requestedLogSize) < numBuckets &&
+         requestedLogSize < Table::kMaxLogSize;
        requestedLogSize++) {
   }
-  requestMigrate(requestedLogSize);
+
+  std::shared_ptr<Table> table = this->table();
+  requestedLogSize = std::min(requestedLogSize, Table::kMaxLogSize);
+  requestMigrate(table.get(), requestedLogSize, table->logSize());
 }
 
 std::pair<double, double> Cache::hitRates() {
@@ -234,7 +238,13 @@ void Cache::requestGrow() {
   }
 }
 
-void Cache::requestMigrate(std::uint32_t requestedLogSize) {
+void Cache::requestMigrate(Table* table, std::uint32_t requestedLogSize,
+                           std::uint32_t currentLogSize) {
+  TRI_ASSERT(table != nullptr);
+  if (requestedLogSize == currentLogSize) {
+    // nothing to do. exit immediately.
+    return;
+  }
   // fail fast if inside banned window
   if (isShutdown() ||
       std::chrono::steady_clock::now().time_since_epoch().count() <=
@@ -245,15 +255,13 @@ void Cache::requestMigrate(std::uint32_t requestedLogSize) {
   SpinLocker taskGuard(SpinLocker::Mode::Write, _taskLock);
   if (std::chrono::steady_clock::now().time_since_epoch().count() >
       _migrateRequestTime.load()) {
-    std::shared_ptr<cache::Table> table = this->table();
-    TRI_ASSERT(table != nullptr);
-
     bool ok = false;
     {
       SpinLocker metaGuard(SpinLocker::Mode::Read, _metadata.lock());
       ok = !_metadata.isMigrating() && (requestedLogSize != table->logSize());
     }
     if (ok) {
+      requestedLogSize = std::min(requestedLogSize, Table::kMaxLogSize);
       auto result = _manager->requestMigrate(this, requestedLogSize);
       _migrateRequestTime.store(result.second.time_since_epoch().count());
     }
@@ -302,7 +310,8 @@ void Cache::recordStat(Stat stat) {
   }
 }
 
-bool Cache::reportInsert(bool hadEviction) {
+bool Cache::reportInsert(Table* table, bool hadEviction) {
+  TRI_ASSERT(table != nullptr);
   bool shouldMigrate = false;
   if (hadEviction) {
     _insertEvictions.add(1, std::memory_order_relaxed);
@@ -315,8 +324,6 @@ bool Cache::reportInsert(bool hadEviction) {
         ((static_cast<double>(evictions) / static_cast<double>(total)) >
          _evictionRateThreshold)) {
       shouldMigrate = true;
-      std::shared_ptr<cache::Table> table = this->table();
-      TRI_ASSERT(table != nullptr);
       table->signalEvictions();
     }
     _insertEvictions.reset(std::memory_order_relaxed);
@@ -329,6 +336,9 @@ bool Cache::reportInsert(bool hadEviction) {
 Metadata& Cache::metadata() { return _metadata; }
 
 std::shared_ptr<Table> Cache::table() const {
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+  _manager->trackTableCall();
+#endif
   return std::atomic_load_explicit(&_table, std::memory_order_acquire);
 }
 
@@ -433,7 +443,7 @@ bool Cache::migrate(std::shared_ptr<Table> newTable) {
   // do the actual migration
   for (std::uint64_t i = 0; i < table->size();
        i++) {  // need uint64 for end condition
-    migrateBucket(table->primaryBucket(static_cast<uint32_t>(i)),
+    migrateBucket(table.get(), table->primaryBucket(static_cast<uint32_t>(i)),
                   table->auxiliaryBuckets(static_cast<uint32_t>(i)), *newTable);
   }
 

--- a/arangod/Cache/Cache.h
+++ b/arangod/Cache/Cache.h
@@ -258,14 +258,15 @@ class Cache : public std::enable_shared_from_this<Cache> {
   static void destroy(std::shared_ptr<Cache> const& cache);
 
   void requestGrow();
-  void requestMigrate(std::uint32_t requestedLogSize = 0);
+  void requestMigrate(Table* table, std::uint32_t requestedLogSize,
+                      std::uint32_t currentLogSize);
 
   static void freeValue(CachedValue* value) noexcept;
   bool reclaimMemory(std::uint64_t size) noexcept;
 
   void recordStat(Stat stat);
 
-  bool reportInsert(bool hadEviction);
+  bool reportInsert(Table* table, bool hadEviction);
 
   // management
   Metadata& metadata();
@@ -279,7 +280,8 @@ class Cache : public std::enable_shared_from_this<Cache> {
   // free memory while callback returns true
   virtual bool freeMemoryWhile(
       std::function<bool(std::uint64_t)> const& cb) = 0;
-  virtual void migrateBucket(void* sourcePtr,
+
+  virtual void migrateBucket(Table* table, void* sourcePtr,
                              std::unique_ptr<Table::Subtable> targets,
                              Table& newTable) = 0;
 };

--- a/arangod/Cache/Manager.cpp
+++ b/arangod/Cache/Manager.cpp
@@ -97,6 +97,9 @@ Manager::Manager(SharedPRNGFeature& sharedPRNG, PostFn schedulerPost,
       _freeMemoryTasks(0),
       _migrateTasksDuration(0),
       _freeMemoryTasksDuration(0),
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+      _tableCalls(0),
+#endif
       _schedulerPost(std::move(schedulerPost)),
       _resizeAttempt(0),
       _outstandingTasks(0),
@@ -280,6 +283,9 @@ Manager::MemoryStats Manager::memoryStats() const noexcept {
   result.freeMemoryTasks = _freeMemoryTasks;
   result.migrateTasksDuration = _migrateTasksDuration;
   result.freeMemoryTasksDuration = _freeMemoryTasksDuration;
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+  result.tableCalls = _tableCalls;
+#endif
   return result;
 }
 
@@ -678,6 +684,12 @@ void Manager::trackFreeMemoryTaskDuration(std::uint64_t duration) noexcept {
   SpinLocker guard(SpinLocker::Mode::Write, _lock);
   _freeMemoryTasksDuration += duration;
 }
+
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+void Manager::trackTableCall() noexcept {
+  _tableCalls.fetch_add(1, std::memory_order_relaxed);
+}
+#endif
 
 void Manager::freeUnusedTables() {
   TRI_ASSERT(_lock.isLockedWrite());

--- a/arangod/Cache/Manager.cpp
+++ b/arangod/Cache/Manager.cpp
@@ -99,7 +99,9 @@ Manager::Manager(SharedPRNGFeature& sharedPRNG, PostFn schedulerPost,
       _freeMemoryTasksDuration(0),
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
       _tableCalls(0),
+      _termCalls(0),
 #endif
+      _transactions(this),
       _schedulerPost(std::move(schedulerPost)),
       _resizeAttempt(0),
       _outstandingTasks(0),
@@ -284,7 +286,8 @@ Manager::MemoryStats Manager::memoryStats() const noexcept {
   result.migrateTasksDuration = _migrateTasksDuration;
   result.freeMemoryTasksDuration = _freeMemoryTasksDuration;
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
-  result.tableCalls = _tableCalls;
+  result.tableCalls = _tableCalls.load(std::memory_order_relaxed);
+  result.termCalls = _termCalls.load(std::memory_order_relaxed);
 #endif
   return result;
 }
@@ -688,6 +691,12 @@ void Manager::trackFreeMemoryTaskDuration(std::uint64_t duration) noexcept {
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
 void Manager::trackTableCall() noexcept {
   _tableCalls.fetch_add(1, std::memory_order_relaxed);
+}
+#endif
+
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+void Manager::trackTermCall() noexcept {
+  _termCalls.fetch_add(1, std::memory_order_relaxed);
 }
 #endif
 

--- a/arangod/Cache/Manager.h
+++ b/arangod/Cache/Manager.h
@@ -91,6 +91,7 @@ class Manager {
     std::uint64_t freeMemoryTasksDuration = 0;  // total, micros
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
     std::uint64_t tableCalls = 0;
+    std::uint64_t termCalls = 0;
 #endif
   };
 
@@ -210,6 +211,10 @@ class Manager {
   void trackTableCall() noexcept;
 #endif
 
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+  void trackTermCall() noexcept;
+#endif
+
  private:
   // use sizeof(uint64_t) + sizeof(std::shared_ptr<Cache>) + 64 for upper bound
   // on size of std::set<std::shared_ptr<Cache>> node -- should be valid for
@@ -274,6 +279,8 @@ class Manager {
   // for every cache removal. we can also expect calls to this
   // function when the cache runs a "free memory" task.
   std::atomic<std::uint64_t> _tableCalls;
+  // number of calls to the `term()` function.
+  std::atomic<std::uint64_t> _termCalls;
 #endif
 
   // transaction management

--- a/arangod/Cache/ManagerTasks.cpp
+++ b/arangod/Cache/ManagerTasks.cpp
@@ -29,6 +29,7 @@
 #include "Cache/Cache.h"
 #include "Cache/Manager.h"
 #include "Cache/Metadata.h"
+#include "Logger/LogMacros.h"
 #include "Random/RandomGenerator.h"
 
 #include <chrono>
@@ -122,6 +123,11 @@ void FreeMemoryTask::run() {
     // do not toggle the resizing flag twice
     toggleResizingGuard.cancel();
   }
+
+  LOG_TOPIC("dce52", TRACE, Logger::CACHE)
+      << "freeMemory task took "
+      << std::chrono::duration_cast<std::chrono::milliseconds>(diff).count()
+      << "ms";
 }
 
 MigrateTask::MigrateTask(Manager::TaskEnvironment environment, Manager& manager,
@@ -178,6 +184,11 @@ void MigrateTask::run() {
   auto diff = std::chrono::steady_clock::now() - now;
   _manager.trackMigrateTaskDuration(
       std::chrono::duration_cast<std::chrono::microseconds>(diff).count());
+
+  LOG_TOPIC("f4c44", TRACE, Logger::CACHE)
+      << "migrate task on table with " << _table->size() << " slots took "
+      << std::chrono::duration_cast<std::chrono::milliseconds>(diff).count()
+      << "ms";
 
   // migrate() must have unset the migrating flag, but we
   // cannot check it here because another MigrateTask may

--- a/arangod/Cache/PlainCache.cpp
+++ b/arangod/Cache/PlainCache.cpp
@@ -37,6 +37,7 @@
 #include "Cache/PlainBucket.h"
 #include "Cache/Table.h"
 #include "Cache/VPackKeyHasher.h"
+#include "Logger/LogMacros.h"
 #include "Random/RandomGenerator.h"
 
 namespace arangodb::cache {
@@ -122,7 +123,7 @@ Result PlainCache<Hasher>::insert(CachedValue* value) {
         if (!eviction) {
           maybeMigrate = source->slotFilled();
         }
-        maybeMigrate |= reportInsert(eviction);
+        maybeMigrate |= reportInsert(source, eviction);
       } else {
         requestGrow();  // let function do the hard work
         status.reset(TRI_ERROR_RESOURCE_LIMIT);
@@ -133,7 +134,8 @@ Result PlainCache<Hasher>::insert(CachedValue* value) {
   if (maybeMigrate) {
     // caution: calling idealSize() can have side effects
     // and trigger a table growth!
-    requestMigrate(source->idealSize());  // let function do the hard work
+    requestMigrate(source, source->idealSize(),
+                   source->logSize());  // let function do the hard work
   }
 
   return status;
@@ -175,7 +177,7 @@ Result PlainCache<Hasher>::remove(void const* key, std::uint32_t keySize) {
   if (maybeMigrate) {
     // caution: calling idealSize() can have side effects
     // and trigger a table growth!
-    requestMigrate(source->idealSize());
+    requestMigrate(source, source->idealSize(), source->logSize());
   }
 
   return status;
@@ -237,19 +239,29 @@ bool PlainCache<Hasher>::freeMemoryWhile(
     return false;
   }
 
+  TRI_ASSERT(std::popcount(n) == 1);
+
+  // table size is always a power of two value
+  std::uint64_t mask = n - 1;
+
   // pick a random start bucket for scanning, so that we don't
   // prefer some buckets over others
   std::uint64_t offset = RandomGenerator::interval(uint64_t(n));
 
+  bool freedEnough = false;
   bool maybeMigrate = false;
+  std::uint64_t totalReclaimed = 0;
+  std::uint64_t totalInspected = 0;
   for (std::size_t i = 0; i < n; ++i) {
-    std::uint64_t index = (offset + i) % n;
+    std::uint64_t index = (offset + i) & mask;
 
     // we can do a lot of iterations from here. don't check for
     // shutdown in every iteration, but only in every 1000th.
     if (index % 1024 == 0 && ADB_UNLIKELY(isShutdown())) {
       break;
     }
+
+    ++totalInspected;
 
     auto [status, guard] =
         getBucket(table.get(), Table::BucketId{index}, Cache::triesFast,
@@ -270,30 +282,35 @@ bool PlainCache<Hasher>::freeMemoryWhile(
       freeValue(candidate);
       maybeMigrate |= guard.source()->slotEmptied();
 
+      totalReclaimed += reclaimed;
       if (!cb(reclaimed)) {
+        freedEnough = true;
         break;
       }
     }
   }
 
+  LOG_TOPIC("29a85", TRACE, Logger::CACHE)
+      << "freeMemory task finished. table size (slots): " << n
+      << ", total reclaimed memory: " << totalReclaimed
+      << ", freed enough: " << freedEnough
+      << ", slots inspected: " << totalInspected;
+
   if (maybeMigrate) {
     // caution: calling idealSize() can have side effects
     // and trigger a table growth!
-    requestMigrate(table->idealSize());
+    requestMigrate(table.get(), table->idealSize(), table->logSize());
   }
 
   return maybeMigrate;
 }
 
 template<typename Hasher>
-void PlainCache<Hasher>::migrateBucket(void* sourcePtr,
+void PlainCache<Hasher>::migrateBucket(Table* table, void* sourcePtr,
                                        std::unique_ptr<Table::Subtable> targets,
                                        Table& newTable) {
   // lock current bucket
-  std::shared_ptr<Table> table = this->table();
-
-  Table::BucketLocker sourceGuard(sourcePtr, table.get(),
-                                  Cache::triesGuarantee);
+  Table::BucketLocker sourceGuard(sourcePtr, table, Cache::triesGuarantee);
   PlainBucket& source = sourceGuard.bucket<PlainBucket>();
 
   {

--- a/arangod/Cache/PlainCache.h
+++ b/arangod/Cache/PlainCache.h
@@ -116,9 +116,9 @@ class PlainCache final : public Cache {
                                        bool enableWindowedStats);
 
   bool freeMemoryWhile(std::function<bool(std::uint64_t)> const& cb) override;
-  virtual void migrateBucket(void* sourcePtr,
-                             std::unique_ptr<Table::Subtable> targets,
-                             Table& newTable) override;
+  void migrateBucket(Table* table, void* sourcePtr,
+                     std::unique_ptr<Table::Subtable> targets,
+                     Table& newTable) override;
 
   // helpers
   std::pair<::ErrorCode, Table::BucketLocker> getBucket(

--- a/arangod/Cache/Table.cpp
+++ b/arangod/Cache/Table.cpp
@@ -186,7 +186,7 @@ Table::Table(std::uint32_t logSize)
       _evictions(false),
       _logSize(std::min(logSize, kMaxLogSize)),
       _size(static_cast<std::uint64_t>(1) << _logSize),
-      _shift(32 - _logSize),
+      _shift(kMaxLogSize - _logSize),
       _mask(static_cast<std::uint32_t>((_size - 1) << _shift)),
       _buffer(new std::uint8_t[(_size * BUCKET_SIZE) + Table::padding]),
       _buckets(reinterpret_cast<GenericBucket*>(
@@ -196,6 +196,10 @@ Table::Table(std::uint32_t logSize)
       _bucketClearer(defaultClearer),
       _slotsTotal(_size),
       _slotsUsed(static_cast<std::uint64_t>(0)) {
+  TRI_ASSERT(_logSize <= kMaxLogSize);
+  TRI_ASSERT(_size == (std::uint64_t(1) << _logSize));
+  TRI_ASSERT(_size <= std::numeric_limits<std::uint32_t>::max());
+
   for (std::size_t i = 0; i < _size; i++) {
     // use placement new in order to properly initialize the bucket
     new (_buckets + i) GenericBucket();

--- a/arangod/Cache/TransactionManager.cpp
+++ b/arangod/Cache/TransactionManager.cpp
@@ -29,11 +29,14 @@
 
 #include "Basics/cpu-relax.h"
 #include "Basics/debugging.h"
+#include "Cache/Manager.h"
 #include "Cache/Transaction.h"
 
 namespace arangodb::cache {
 
-TransactionManager::TransactionManager() : _state({{0, 0, 0}, 0}) {}
+// note: manager can be a null pointer in unit tests
+TransactionManager::TransactionManager(Manager* manager)
+    : _state({{0, 0, 0}, 0}), _manager(manager) {}
 
 Transaction* TransactionManager::begin(bool readOnly) {
   auto tx = std::make_unique<Transaction>(readOnly);
@@ -99,6 +102,11 @@ void TransactionManager::end(Transaction* tx) noexcept {
 }
 
 uint64_t TransactionManager::term() const noexcept {
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+  if (_manager != nullptr) {
+    _manager->trackTermCall();
+  }
+#endif
   return _state.load(std::memory_order_acquire).term;
 }
 

--- a/arangod/Cache/TransactionManager.h
+++ b/arangod/Cache/TransactionManager.h
@@ -29,6 +29,7 @@
 #include "Cache/Transaction.h"
 
 namespace arangodb::cache {
+class Manager;
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief Manage global cache transactions.
@@ -45,7 +46,7 @@ class TransactionManager {
   //////////////////////////////////////////////////////////////////////////////
   /// @brief Initialize state with no open transactions.
   //////////////////////////////////////////////////////////////////////////////
-  TransactionManager();
+  explicit TransactionManager(Manager* manager);
 
   //////////////////////////////////////////////////////////////////////////////
   /// @brief Open a new transaction.
@@ -90,6 +91,9 @@ class TransactionManager {
   };
 
   std::atomic<State> _state;
+
+  // note: can be a null pointer in unit tests
+  Manager* _manager;
 };
 
 };  // end namespace arangodb::cache

--- a/arangod/Cache/TransactionalCache.cpp
+++ b/arangod/Cache/TransactionalCache.cpp
@@ -308,9 +308,16 @@ bool TransactionalCache<Hasher>::freeMemoryWhile(
 
     ++totalInspected;
 
+    // use a specialized simpler implementation of getBucket() here
+    // that does not report to the manager that the cache was accessed
+    // (after all, this is only a free memory operation), and that does
+    // not update the bucket's term. updating the term is not necessary
+    // here, as we are only evicting data from the bucket. evicting data
+    // does use the term. and when doing any other operation in the
+    // bucket (find, insert, remove), the term is properly updated at
+    // the beginning.
     auto [status, guard] =
-        getBucket(table.get(), Table::BucketId{index}, Cache::triesFast,
-                  /*singleOperation*/ false);
+        getBucketSimple(table.get(), Table::BucketId{index}, Cache::triesFast);
 
     if (status != TRI_ERROR_NO_ERROR) {
       continue;
@@ -470,29 +477,32 @@ TransactionalCache<Hasher>::getBucket(Table::HashOrId bucket,
   if (ADB_UNLIKELY(isShutdown() || table == nullptr)) {
     status = TRI_ERROR_SHUTTING_DOWN;
   } else {
-    std::tie(status, guard) =
-        getBucket(table.get(), bucket, maxTries, singleOperation);
+    if (singleOperation) {
+      _manager->reportAccess(_id);
+    }
+
+    std::uint64_t term = _manager->_transactions.term();
+    guard = table->fetchAndLockBucket(bucket, maxTries);
+    if (guard.isLocked()) {
+      guard.bucket<TransactionalBucket>().updateBanishTerm(term);
+    } else {
+      status = TRI_ERROR_LOCK_TIMEOUT;
+    }
   }
 
+  TRI_ASSERT(guard.isLocked() || status != TRI_ERROR_NO_ERROR);
   return std::make_tuple(status, std::move(guard));
 }
 
 template<typename Hasher>
 std::tuple<::ErrorCode, Table::BucketLocker>
-TransactionalCache<Hasher>::getBucket(Table* table, Table::HashOrId bucket,
-                                      std::uint64_t maxTries,
-                                      bool singleOperation) {
+TransactionalCache<Hasher>::getBucketSimple(Table* table,
+                                            Table::HashOrId bucket,
+                                            std::uint64_t maxTries) {
   ::ErrorCode status = TRI_ERROR_NO_ERROR;
 
-  if (singleOperation) {
-    _manager->reportAccess(_id);
-  }
-
-  std::uint64_t term = _manager->_transactions.term();
   Table::BucketLocker guard = table->fetchAndLockBucket(bucket, maxTries);
-  if (guard.isLocked()) {
-    guard.bucket<TransactionalBucket>().updateBanishTerm(term);
-  } else {
+  if (!guard.isLocked()) {
     status = TRI_ERROR_LOCK_TIMEOUT;
   }
 

--- a/arangod/Cache/TransactionalCache.cpp
+++ b/arangod/Cache/TransactionalCache.cpp
@@ -21,6 +21,7 @@
 /// @author Dan Larkin-York
 ////////////////////////////////////////////////////////////////////////////////
 
+#include <bit>
 #include <cstdint>
 
 #include "Cache/TransactionalCache.h"
@@ -38,6 +39,7 @@
 #include "Cache/TransactionalBucket.h"
 #include "Cache/VPackKeyHasher.h"
 #include "Random/RandomGenerator.h"
+#include "Logger/LogMacros.h"
 
 namespace arangodb::cache {
 
@@ -124,7 +126,7 @@ Result TransactionalCache<Hasher>::insert(CachedValue* value) {
             TRI_ASSERT(source != nullptr);
             maybeMigrate = source->slotFilled();
           }
-          maybeMigrate |= reportInsert(eviction);
+          maybeMigrate |= reportInsert(source, eviction);
         } else {
           requestGrow();  // let function do the hard work
           status.reset(TRI_ERROR_RESOURCE_LIMIT);
@@ -139,7 +141,8 @@ Result TransactionalCache<Hasher>::insert(CachedValue* value) {
     TRI_ASSERT(source != nullptr);
     // caution: calling idealSize() can have side effects
     // and trigger a table growth!
-    requestMigrate(source->idealSize());  // let function do the hard work
+    requestMigrate(source, source->idealSize(),
+                   source->logSize());  // let function do the hard work
   }
 
   return status;
@@ -183,7 +186,7 @@ Result TransactionalCache<Hasher>::remove(void const* key,
     TRI_ASSERT(source != nullptr);
     // caution: calling idealSize() can have side effects
     // and trigger a table growth!
-    requestMigrate(source->idealSize());
+    requestMigrate(source, source->idealSize(), source->logSize());
   }
 
   return status;
@@ -228,7 +231,7 @@ Result TransactionalCache<Hasher>::banish(void const* key,
     TRI_ASSERT(source != nullptr);
     // caution: calling idealSize() can have side effects
     // and trigger a table growth!
-    requestMigrate(source->idealSize());
+    requestMigrate(source, source->idealSize(), source->logSize());
   }
 
   return status;
@@ -281,19 +284,29 @@ bool TransactionalCache<Hasher>::freeMemoryWhile(
     return false;
   }
 
+  TRI_ASSERT(std::popcount(n) == 1);
+
+  // table size is always a power of two value
+  std::uint64_t mask = n - 1;
+
   // pick a random start bucket for scanning, so that we don't
   // prefer some buckets over others
   std::uint64_t offset = RandomGenerator::interval(uint64_t(n));
 
+  bool freedEnough = false;
   bool maybeMigrate = false;
+  std::uint64_t totalReclaimed = 0;
+  std::uint64_t totalInspected = 0;
   for (std::size_t i = 0; i < n; ++i) {
-    std::uint64_t index = (offset + i) % n;
+    std::uint64_t index = (offset + i) & mask;
 
     // we can do a lot of iterations from here. don't check for
     // shutdown in every iteration, but only in every 1000th.
     if (index % 1024 == 0 && ADB_UNLIKELY(isShutdown())) {
       break;
     }
+
+    ++totalInspected;
 
     auto [status, guard] =
         getBucket(table.get(), Table::BucketId{index}, Cache::triesFast,
@@ -308,18 +321,26 @@ bool TransactionalCache<Hasher>::freeMemoryWhile(
     std::uint64_t reclaimed = bucket.evictCandidate(/*moveToFront*/ false);
 
     if (reclaimed > 0) {
+      totalReclaimed += reclaimed;
       maybeMigrate |= guard.source()->slotEmptied();
 
       if (!cb(reclaimed)) {
+        freedEnough = true;
         break;
       }
     }
   }
 
+  LOG_TOPIC("37e7f", TRACE, Logger::CACHE)
+      << "freeMemory task finished. table size (slots): " << n
+      << ", total reclaimed memory: " << totalReclaimed
+      << ", freed enough: " << freedEnough
+      << ", slots inspected: " << totalInspected;
+
   if (maybeMigrate) {
     // caution: calling idealSize() can have side effects
     // and trigger a table growth!
-    requestMigrate(table->idealSize());
+    requestMigrate(table.get(), table->idealSize(), table->logSize());
   }
 
   return maybeMigrate;
@@ -327,15 +348,12 @@ bool TransactionalCache<Hasher>::freeMemoryWhile(
 
 template<typename Hasher>
 void TransactionalCache<Hasher>::migrateBucket(
-    void* sourcePtr, std::unique_ptr<Table::Subtable> targets,
+    Table* table, void* sourcePtr, std::unique_ptr<Table::Subtable> targets,
     Table& newTable) {
   std::uint64_t term = _manager->_transactions.term();
 
   // lock current bucket
-  std::shared_ptr<Table> table = this->table();
-
-  Table::BucketLocker sourceGuard(sourcePtr, table.get(),
-                                  Cache::triesGuarantee);
+  Table::BucketLocker sourceGuard(sourcePtr, table, Cache::triesGuarantee);
   TransactionalBucket& source = sourceGuard.bucket<TransactionalBucket>();
   term = std::max(term, source._banishTerm);
 

--- a/arangod/Cache/TransactionalCache.h
+++ b/arangod/Cache/TransactionalCache.h
@@ -141,10 +141,10 @@ class TransactionalCache final : public Cache {
       Table::HashOrId bucket, std::uint64_t maxTries,
       bool singleOperation = true);
 
-  std::tuple<::ErrorCode, Table::BucketLocker> getBucket(Table* table,
-                                                         Table::HashOrId bucket,
-                                                         std::uint64_t maxTries,
-                                                         bool singleOperation);
+  // simplified version of getBucket(). does not report access to the
+  // manager and does not update the bucket's term.
+  std::tuple<::ErrorCode, Table::BucketLocker> getBucketSimple(
+      Table* table, Table::HashOrId bucket, std::uint64_t maxTries);
 
   static Table::BucketClearer bucketClearer(Metadata* metadata);
 };

--- a/arangod/Cache/TransactionalCache.h
+++ b/arangod/Cache/TransactionalCache.h
@@ -132,7 +132,8 @@ class TransactionalCache final : public Cache {
                                        bool enableWindowedStats);
 
   bool freeMemoryWhile(std::function<bool(std::uint64_t)> const& cb) override;
-  void migrateBucket(void* sourcePtr, std::unique_ptr<Table::Subtable> targets,
+  void migrateBucket(Table* table, void* sourcePtr,
+                     std::unique_ptr<Table::Subtable> targets,
                      Table& newTable) override;
 
   // helpers

--- a/arangod/RocksDBEngine/RocksDBEngine.cpp
+++ b/arangod/RocksDBEngine/RocksDBEngine.cpp
@@ -3281,6 +3281,14 @@ void RocksDBEngine::getStatistics(VPackBuilder& builder) const {
                 VPackValue(stats.migrateTasksDuration));
     builder.add("cache.free-memory-tasks-duration-total",
                 VPackValue(stats.freeMemoryTasksDuration));
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+    // only here for debugging. the value is not exposed in non-maintainer
+    // mode builds. the reason for this is to make calls to the `table` function
+    // more lightweight, and because we would need to put a metrics
+    // description into Documentation/Metrics for an optional metric.
+
+    // builder.add("cache.table-calls", VPackValue(stats.tableCalls));
+#endif
     // handle NaN
     builder.add("cache.hit-rate-lifetime",
                 VPackValue(rates.first >= 0.0 ? rates.first : 0.0));

--- a/arangod/RocksDBEngine/RocksDBEngine.cpp
+++ b/arangod/RocksDBEngine/RocksDBEngine.cpp
@@ -3288,6 +3288,7 @@ void RocksDBEngine::getStatistics(VPackBuilder& builder) const {
     // description into Documentation/Metrics for an optional metric.
 
     // builder.add("cache.table-calls", VPackValue(stats.tableCalls));
+    // builder.add("cache.term-calls", VPackValue(stats.termCalls));
 #endif
     // handle NaN
     builder.add("cache.hit-rate-lifetime",

--- a/tests/Cache/TransactionManager.cpp
+++ b/tests/Cache/TransactionManager.cpp
@@ -33,7 +33,7 @@ using namespace arangodb::cache;
 
 TEST(CacheTransactionalManagerTest,
      verify_that_transaction_term_is_maintained_correctly) {
-  TransactionManager transactions;
+  TransactionManager transactions(nullptr);
   Transaction* tx1;
   Transaction* tx2;
   Transaction* tx3;


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/19958

Reduce number of shared_ptr copies in cache subsystem

- `Cache::migrate()` migrates data for all buckets in a cache table. for each bucket, it calls `migrateBucket(...)`. `migrateBucket` created a copy of the table's atomic shared_ptr, which internally uses a lock. this is now changed so that the table pointer is passed into the call to `migrateBucket`, so that we do not need to copy the shared_pointer repeatedly. this saves n copies of the atomic shared_ptr, where n is the size of the table.
- `Cache::requestMigrate(...)` also created a copy of the table's atomic shared_ptr, which is now saved by passing the table pointer into the function.
- `Cache::reportInsert()` could be called after inserting data into a cache table. `reportInsert()` also created a copy of the table's atomic shared_ptr, which is now also saved.
- added an internal metric in the code for tracking the number of calls to `Cache::table()`. this metric is not enabled by default to remove the overhead of the tracking. the code can be enabled easily when debugging.
- replace a modulus calculation in `freeMemoryWhile(...)` with a bit operation, as cache table sizes are always power-of-2 values.
- cache tables have a maximum size of 4 * 1024 * 1024 entries. some internals in `Cache::Table` use a uint32_t when indexing cache table entries. added code that ensures that no cache tables with larger sizes can be created.
- do not update bucket term from `freeMemoryWhile()` for every bucket.
  the term update is very expensive, but not needed for memory reclamation. 
- added trace log messages for MigrateTask and FreeMemoryTask so that their internals can be inspected.

Also make cache metrics more reliable:
The previous implementation that returned the metrics for the in-memory cache subsystem could return all metrics set to 0 if it could not acquire the cache manager lock in time.
now, instead of returning zeroed results, we simply return the same result that we returned last time. so now in the worst case we return slightly stale metrics, but this is a lot better than returning zeroed metrics.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [x] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.11: https://github.com/arangodb/arangodb/pull/19962
  - [x] Backport for 3.10: this PR

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 