### PR TITLE
3.10: [BTS-1610] Fix shadowrow forwarding 

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 v3.10.11 (XXXX-XX-XX)
 ---------------------
 
+* Fixed BTS-1610: In certain situations with at least three levels of nested
+  subqueries, of which some of the outer iterations don't return any results,
+  results of later iterations could be lost.
+
 * Updated arangosync to v2.19.4.
 
 * Fix updating of collection properties (schema) when the collection has a view

--- a/arangod/Aql/AqlCallStack.cpp
+++ b/arangod/Aql/AqlCallStack.cpp
@@ -68,6 +68,17 @@ auto AqlCallStack::popCall() -> AqlCallList {
   return call;
 }
 
+void AqlCallStack::popDepthsLowerThan(size_t depth) {
+  TRI_ASSERT(!_operations.empty());
+  TRI_ASSERT(depth <= _operations.size());
+  for (auto i = _operations.size() - depth; i < _operations.size(); ++i) {
+    auto& operation = _operations[i];
+    if (operation.hasMoreCalls()) {
+      std::ignore = operation.popNextCall();
+    }
+  }
+}
+
 auto AqlCallStack::peek() const -> AqlCall const& {
   TRI_ASSERT(!_operations.empty());
   return _operations.back().peekNextCall();
@@ -234,3 +245,13 @@ auto AqlCallStack::requestLessDataThan(AqlCallStack const& other) const noexcept
   }
   return true;
 }
+
+#ifdef ARANGODB_USE_GOOGLE_TESTS
+// For tests
+AqlCallStack::AqlCallStack(std::initializer_list<AqlCallList> calls)
+    : _operations{std::move(calls)} {
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+  validateNoCallHasSkippedRows();
+#endif
+}
+#endif

--- a/arangod/Aql/AqlCallStack.h
+++ b/arangod/Aql/AqlCallStack.h
@@ -58,6 +58,11 @@ class AqlCallStack {
   AqlCallStack(AqlCallStack const& other) = default;
   AqlCallStack(AqlCallStack&& other) noexcept = default;
 
+#ifdef ARANGODB_USE_GOOGLE_TESTS
+  // For tests
+  explicit AqlCallStack(std::initializer_list<AqlCallList> calls);
+#endif
+
   AqlCallStack& operator=(AqlCallStack const& other) = default;
   AqlCallStack& operator=(AqlCallStack&& other) noexcept = default;
 
@@ -68,6 +73,8 @@ class AqlCallStack {
   // Get the top most Call element.
   // This is popped of the stack and caller can take responsibility for it
   AqlCallList popCall();
+
+  void popDepthsLowerThan(size_t depth);
 
   // Peek at the topmost Call element (this must be relevant).
   // The responsibility for the peek-ed call will stay with the stack

--- a/arangod/Aql/ExecutionBlockImpl.cpp
+++ b/arangod/Aql/ExecutionBlockImpl.cpp
@@ -1071,6 +1071,8 @@ auto ExecutionBlockImpl<SubqueryEndExecutor>::shadowRowForwarding(
     // Let client call again
     return ExecState::NEXTSUBQUERY;
   }
+  bool const hasDoneNothing =
+      _outputItemRow->numRowsWritten() == 0 and _skipped.nothingSkipped();
   auto&& [state, shadowRow] = _lastRange.nextShadowRow();
   TRI_ASSERT(shadowRow.isInitialized());
   if (shadowRow.isRelevant()) {

--- a/arangod/Aql/OutputAqlItemRow.cpp
+++ b/arangod/Aql/OutputAqlItemRow.cpp
@@ -488,7 +488,9 @@ void OutputAqlItemRow::doCopyOrMoveRow(ItemRowType& sourceRow,
   size_t const rowDepth = baseRowDepth + delta;
 
   auto const roffset = rowDepth + 1;
-  TRI_ASSERT(roffset <= registersToKeep().size());
+  TRI_ASSERT(roffset <= registersToKeep().size())
+      << "roffset: " << roffset << " size: " << registersToKeep().size()
+      << " baseRowDepth: " << baseRowDepth << " delta: " << delta;
   auto idx = registersToKeep().size() - roffset;
   auto const& regsToKeep = registersToKeep().at(idx);
 

--- a/arangod/Aql/ShadowAqlItemRow.cpp
+++ b/arangod/Aql/ShadowAqlItemRow.cpp
@@ -62,7 +62,9 @@ AqlValue const& ShadowAqlItemRow::getValue(RegisterId registerId) const {
 
 AqlValue ShadowAqlItemRow::stealAndEraseValue(RegisterId registerId) {
   TRI_ASSERT(isInitialized());
-  TRI_ASSERT(registerId < getNumRegisters());
+  TRI_ASSERT(registerId < getNumRegisters())
+      << "registerId: " << registerId.value()
+      << " getNumRegisters(): " << getNumRegisters();
   // caller needs to take immediate ownership.
   return block().stealAndEraseValue(_baseIndex, registerId);
 }

--- a/arangod/Aql/SubqueryStartExecutionNode.cpp
+++ b/arangod/Aql/SubqueryStartExecutionNode.cpp
@@ -82,7 +82,7 @@ std::unique_ptr<ExecutionBlock> SubqueryStartNode::createBlock(
 
   // On purpose exclude the _subqueryOutVariable
   return std::make_unique<ExecutionBlockImpl<SubqueryStartExecutor>>(
-      &engine, this, registerInfos, RegisterInfos{registerInfos});
+      &engine, this, registerInfos, registerInfos);
 }
 
 ExecutionNode* SubqueryStartNode::clone(ExecutionPlan* plan,

--- a/tests/Aql/AqlItemBlockHelper.h
+++ b/tests/Aql/AqlItemBlockHelper.h
@@ -136,10 +136,8 @@ SharedAqlItemBlockPtr buildBlock(
     }
   }
 
-  if (!shadowRows.empty()) {
-    for (auto const& it : shadowRows) {
-      block->makeShadowRow(it.first, it.second);
-    }
+  for (auto const& it : shadowRows) {
+    block->makeShadowRow(it.first, it.second);
   }
 
   return block;

--- a/tests/Aql/CalculationExecutorTest.cpp
+++ b/tests/Aql/CalculationExecutorTest.cpp
@@ -64,9 +64,7 @@ namespace arangodb {
 namespace tests {
 namespace aql {
 
-using CalculationExecutorTestHelper = ExecutorTestHelper<2, 2>;
-using CalculationExecutorSplitType = CalculationExecutorTestHelper::SplitType;
-using CalculationExecutorInputParam = std::tuple<CalculationExecutorSplitType>;
+using CalculationExecutorInputParam = std::tuple<SplitType>;
 
 // TODO Add tests for both
 // CalculationExecutor<CalculationType::V8Condition> and
@@ -104,7 +102,7 @@ class CalculationExecutorTest
                       2 /*out width*/, RegIdSet{} /*to clear*/,
                       RegIdSetStack{{}} /*to keep*/) {}
 
-  auto getSplit() -> CalculationExecutorSplitType {
+  auto getSplit() -> SplitType {
     auto [split] = GetParam();
     return split;
   }
@@ -118,11 +116,9 @@ class CalculationExecutorTest
 };
 
 template<size_t... vs>
-const CalculationExecutorSplitType splitIntoBlocks =
-    CalculationExecutorSplitType{std::vector<std::size_t>{vs...}};
+const SplitType splitIntoBlocks = SplitType{std::vector<std::size_t>{vs...}};
 template<size_t step>
-const CalculationExecutorSplitType splitStep =
-    CalculationExecutorSplitType{step};
+const SplitType splitStep = SplitType{step};
 
 INSTANTIATE_TEST_CASE_P(CalculationExecutor, CalculationExecutorTest,
                         ::testing::Values(splitIntoBlocks<2, 3>,

--- a/tests/Aql/CountCollectExecutorTest.cpp
+++ b/tests/Aql/CountCollectExecutorTest.cpp
@@ -41,9 +41,7 @@ namespace arangodb {
 namespace tests {
 namespace aql {
 
-using CountCollectTestHelper = ExecutorTestHelper<1, 1>;
-using CountCollectSplitType = CountCollectTestHelper::SplitType;
-using CountCollectParamType = std::tuple<CountCollectSplitType>;
+using CountCollectParamType = std::tuple<SplitType>;
 
 class CountCollectExecutorTest
     : public AqlExecutorTestCaseWithParam<CountCollectParamType, false> {
@@ -58,7 +56,7 @@ class CountCollectExecutorTest
       -> CountCollectExecutorInfos {
     return CountCollectExecutorInfos{outReg};
   }
-  auto GetSplit() -> CountCollectSplitType {
+  auto GetSplit() -> SplitType {
     auto const& [split] = GetParam();
     return split;
   }
@@ -148,15 +146,14 @@ class CountCollectExecutorTest
 };
 
 template<size_t... vs>
-const CountCollectSplitType splitIntoBlocks =
-    CountCollectSplitType{std::vector<std::size_t>{vs...}};
+const SplitType splitIntoBlocks = SplitType{std::vector<std::size_t>{vs...}};
 template<size_t step>
-const CountCollectSplitType splitStep = CountCollectSplitType{step};
+const SplitType splitStep = SplitType{step};
 
-INSTANTIATE_TEST_CASE_P(
-    CountCollectExecutor, CountCollectExecutorTest,
-    ::testing::Values(CountCollectSplitType{std::monostate()}, splitStep<1>,
-                      splitIntoBlocks<2, 3>, splitStep<2>));
+INSTANTIATE_TEST_CASE_P(CountCollectExecutor, CountCollectExecutorTest,
+                        ::testing::Values(SplitType{std::monostate()},
+                                          splitStep<1>, splitIntoBlocks<2, 3>,
+                                          splitStep<2>));
 
 TEST_P(CountCollectExecutorTest, empty_input) {
   makeExecutorTestHelper<1, 1>()

--- a/tests/Aql/DistinctCollectExecutorTest.cpp
+++ b/tests/Aql/DistinctCollectExecutorTest.cpp
@@ -55,10 +55,9 @@ namespace tests {
 namespace aql {
 
 using DistinctCollectTestHelper = ExecutorTestHelper<1, 1>;
-using DistinctCollectSplitType = DistinctCollectTestHelper::SplitType;
 
-class DistinctCollectExecutorTest : public AqlExecutorTestCaseWithParam<
-                                        std::tuple<DistinctCollectSplitType>> {
+class DistinctCollectExecutorTest
+    : public AqlExecutorTestCaseWithParam<std::tuple<SplitType>> {
  protected:
   ExecutionState state;
   arangodb::GlobalResourceMonitor global{};
@@ -128,10 +127,9 @@ TEST_P(DistinctCollectExecutorTest, split_2) {
 }
 
 template<size_t... vs>
-const DistinctCollectSplitType splitIntoBlocks =
-    DistinctCollectSplitType{std::vector<std::size_t>{vs...}};
+const SplitType splitIntoBlocks = SplitType{std::vector<std::size_t>{vs...}};
 template<size_t step>
-const DistinctCollectSplitType splitStep = DistinctCollectSplitType{step};
+const SplitType splitStep = SplitType{step};
 
 INSTANTIATE_TEST_CASE_P(DistinctCollectExecutor, DistinctCollectExecutorTest,
                         ::testing::Values(splitIntoBlocks<2, 3>,

--- a/tests/Aql/EnumerateCollectionExecutorTest.cpp
+++ b/tests/Aql/EnumerateCollectionExecutorTest.cpp
@@ -248,11 +248,7 @@ TEST_F(EnumerateCollectionExecutorTest, the_skip_datarange) {
 
 // new framework tests
 
-// This is only to get a split-type. The Type is independent of actual template
-// parameters
-using EnumerateCollectionTestHelper = ExecutorTestHelper<1, 1>;
-using EnumerateCollectionSplitType = EnumerateCollectionTestHelper::SplitType;
-using EnumerateCollectionInputParam = std::tuple<EnumerateCollectionSplitType>;
+using EnumerateCollectionInputParam = std::tuple<SplitType>;
 
 class EnumerateCollectionExecutorTestProduce
     : public AqlExecutorTestCaseWithParam<EnumerateCollectionInputParam> {
@@ -469,11 +465,9 @@ TEST_P(EnumerateCollectionExecutorTestProduce,
 }
 
 template<size_t... vs>
-const EnumerateCollectionSplitType splitIntoBlocks =
-    EnumerateCollectionSplitType{std::vector<std::size_t>{vs...}};
+const SplitType splitIntoBlocks = SplitType{std::vector<std::size_t>{vs...}};
 template<size_t step>
-const EnumerateCollectionSplitType splitStep =
-    EnumerateCollectionSplitType{step};
+const SplitType splitStep = SplitType{step};
 
 INSTANTIATE_TEST_CASE_P(EnumerateCollectionExecutor,
                         EnumerateCollectionExecutorTestProduce,

--- a/tests/Aql/EnumerateListExecutorTest.cpp
+++ b/tests/Aql/EnumerateListExecutorTest.cpp
@@ -147,8 +147,7 @@ TEST_F(EnumerateListExecutorTest, test_check_state_second_row_border) {
 
 // new framework tests
 using EnumerateListTestHelper = ExecutorTestHelper<1, 1>;
-using EnumerateListSplitType = EnumerateListTestHelper::SplitType;
-using EnumerateListParamType = std::tuple<EnumerateListSplitType>;
+using EnumerateListParamType = std::tuple<SplitType>;
 
 class EnumerateListExecutorTestProduce
     : public AqlExecutorTestCaseWithParam<EnumerateListParamType, false> {
@@ -413,10 +412,9 @@ TEST_P(EnumerateListExecutorTestProduce,
 }
 
 template<size_t... vs>
-const EnumerateListSplitType splitIntoBlocks =
-    EnumerateListSplitType{std::vector<std::size_t>{vs...}};
+const SplitType splitIntoBlocks = SplitType{std::vector<std::size_t>{vs...}};
 template<size_t step>
-const EnumerateListSplitType splitStep = EnumerateListSplitType{step};
+const SplitType splitStep = SplitType{step};
 
 INSTANTIATE_TEST_CASE_P(EnumerateListExecutor, EnumerateListExecutorTestProduce,
                         ::testing::Values(splitIntoBlocks<2, 3>,

--- a/tests/Aql/ExecutorTestHelper.h
+++ b/tests/Aql/ExecutorTestHelper.h
@@ -44,6 +44,8 @@
 #include "Aql/OutputAqlItemRow.h"
 #include "Aql/Query.h"
 #include "Aql/SharedAqlItemBlockPtr.h"
+#include "Containers/Enumerate.h"
+#include "Aql/SharedQueryState.h"
 #include "Logger/LogMacros.h"
 
 #include <numeric>
@@ -95,11 +97,26 @@ class asserthelper {
           std::nullopt) -> void;
 };
 
+using SplitType =
+    std::variant<std::vector<std::size_t>, std::size_t, std::monostate>;
+
+auto inline to_string(SplitType const& splitType) -> std::string {
+  using namespace std::string_literals;
+  return std::visit(overload{
+                        [](std::vector<std::size_t> list) {
+                          return fmt::format("list{{{}}}",
+                                             fmt::join(list, ","));
+                        },
+                        [](std::size_t interval) {
+                          return fmt::format("interval{{{}}}", interval);
+                        },
+                        [](std::monostate) { return "none"s; },
+                    },
+                    splitType);
+}
+
 template<std::size_t inputColumns = 1, std::size_t outputColumns = 1>
 struct ExecutorTestHelper {
-  using SplitType =
-      std::variant<std::vector<std::size_t>, std::size_t, std::monostate>;
-
   ExecutorTestHelper(ExecutorTestHelper const&) = delete;
   ExecutorTestHelper(ExecutorTestHelper&&) = delete;
   explicit ExecutorTestHelper(Query& query,
@@ -127,14 +144,18 @@ struct ExecutorTestHelper {
     return *this;
   }
 
-  auto setInputValue(MatrixBuilder<inputColumns> in) -> ExecutorTestHelper& {
+  auto setInputValue(MatrixBuilder<inputColumns> in,
+                     std::vector<std::pair<size_t, uint64_t>> shadowRows = {})
+      -> ExecutorTestHelper& {
     _input = std::move(in);
+    _inputShadowRows = std::move(shadowRows);
     return *this;
   }
 
   template<typename... Ts>
   auto setInputValueList(Ts&&... ts) -> ExecutorTestHelper& {
     _input = MatrixBuilder<inputColumns>{{ts}...};
+    _inputShadowRows = {};
     return *this;
   }
 
@@ -144,12 +165,12 @@ struct ExecutorTestHelper {
     for (auto i = size_t{0}; i < rows; ++i) {
       _input.emplace_back(RowBuilder<1>{static_cast<int>(i)});
     }
+    _inputShadowRows = {};
     return *this;
   }
 
-  auto setInputSplit(std::vector<std::size_t> const& list)
-      -> ExecutorTestHelper& {
-    _inputSplit = list;
+  auto setInputSplit(std::vector<std::size_t> list) -> ExecutorTestHelper& {
+    _inputSplit = std::move(list);
     return *this;
   }
 
@@ -173,6 +194,11 @@ struct ExecutorTestHelper {
   auto setTesteeNodeType(ExecutionNode::NodeType nodeType)
       -> ExecutorTestHelper& {
     _testeeNodeType = nodeType;
+    return *this;
+  }
+
+  auto setInputSubqueryDepth(std::size_t depth) -> ExecutorTestHelper& {
+    _inputSubqueryDepth = depth;
     return *this;
   }
 
@@ -229,6 +255,11 @@ struct ExecutorTestHelper {
     // NOTE: the above will increment didSkip by the first entry.
     // For all following entries it will first increment the subquery depth
     // and then add the didSkip on them.
+    return *this;
+  }
+
+  auto expectSkipped(SkipResult expectedSkip) -> ExecutorTestHelper& {
+    _expectedSkip = std::move(expectedSkip);
     return *this;
   }
 
@@ -444,7 +475,30 @@ struct ExecutorTestHelper {
       end = std::get<VectorSizeT>(_inputSplit).end();
     }
 
-    for (auto const& value : _input) {
+    auto sit = _inputShadowRows.begin();
+    auto const send = _inputShadowRows.end();
+
+    auto baseRowIndex = std::size_t{0};
+
+    auto const buildAndEnqueueBlock =
+        [&itemBlockManager, &blockDeque, &sit, &send, &baseRowIndex](
+            MatrixBuilder<inputColumns> matrix, std::size_t currentRowIndex) {
+          SharedAqlItemBlockPtr inputBlock =
+              buildBlock<inputColumns>(itemBlockManager, std::move(matrix));
+          // inputBlock contains the _input slice [baseRowIndex,
+          // currentRowIndex] (inclusive). Set shadow rows where necessary:
+          TRI_ASSERT(sit == send or baseRowIndex <= sit->first);
+          for (; sit != send && sit->first <= currentRowIndex; ++sit) {
+            auto const [sidx, sdepth] = *sit;
+            inputBlock->makeShadowRow(sidx - baseRowIndex, sdepth);
+          }
+          blockDeque.emplace_back(std::move(inputBlock));
+          matrix.clear();
+          // set base index for the next block (if any)
+          baseRowIndex = currentRowIndex + 1;
+        };
+
+    for (auto const& [currentRowIndex, value] : enumerate(_input)) {
       matrix.push_back(value);
 
       TRI_ASSERT(!_inputSplit.valueless_by_exception());
@@ -459,20 +513,15 @@ struct ExecutorTestHelper {
                      return false;
                    },
                    [&](std::size_t size) { return matrix.size() == size; },
-                   [](auto) { return false; }},
+                   [](std::monostate) { return false; }},
           _inputSplit);
       if (openNewBlock) {
-        SharedAqlItemBlockPtr inputBlock =
-            buildBlock<inputColumns>(itemBlockManager, std::move(matrix));
-        blockDeque.emplace_back(inputBlock);
-        matrix.clear();
+        buildAndEnqueueBlock(std::move(matrix), currentRowIndex);
       }
     }
 
     if (!matrix.empty()) {
-      SharedAqlItemBlockPtr inputBlock =
-          buildBlock<inputColumns>(itemBlockManager, std::move(matrix));
-      blockDeque.emplace_back(inputBlock);
+      buildAndEnqueueBlock(std::move(matrix), _input.size());
     }
     if (_appendEmptyBlock) {
       blockDeque.emplace_back(nullptr);
@@ -480,13 +529,14 @@ struct ExecutorTestHelper {
 
     return std::make_unique<WaitingExecutionBlockMock>(
         _query.rootEngine(), _dummyNode.get(), std::move(blockDeque),
-        _waitingBehaviour, 0, _wakeupCallback);
+        _waitingBehaviour, _inputSubqueryDepth, _wakeupCallback);
   }
 
   // Default initialize with a fetchAll call.
   AqlCallStack _callStack{AqlCallList{AqlCall{}}};
   MatrixBuilder<inputColumns> _input;
   MatrixBuilder<outputColumns> _output;
+  std::vector<std::pair<size_t, uint64_t>> _inputShadowRows{};
   std::vector<std::pair<size_t, uint64_t>> _outputShadowRows{};
   std::array<RegisterId, outputColumns> _outputRegisters;
   SkipResult _expectedSkip;
@@ -500,6 +550,7 @@ struct ExecutorTestHelper {
   bool _unorderedOutput;
   bool _appendEmptyBlock;
   std::size_t _unorderedSkippedRows;
+  std::size_t _inputSubqueryDepth = 0;
 
   SplitType _inputSplit = {std::monostate()};
   SplitType _outputSplit = {std::monostate()};

--- a/tests/Aql/FilterExecutorTest.cpp
+++ b/tests/Aql/FilterExecutorTest.cpp
@@ -49,9 +49,7 @@ namespace arangodb {
 namespace tests {
 namespace aql {
 
-using FilterExecutorTestHelper = ExecutorTestHelper<2, 2>;
-using FilterExecutorSplitType = FilterExecutorTestHelper::SplitType;
-using FilterExecutorInputParam = std::tuple<FilterExecutorSplitType>;
+using FilterExecutorInputParam = std::tuple<SplitType>;
 
 class FilterExecutorTest
     : public AqlExecutorTestCaseWithParam<FilterExecutorInputParam> {
@@ -70,7 +68,7 @@ class FilterExecutorTest
         outputRegisters(),
         infos(0) {}
 
-  auto getSplit() -> FilterExecutorSplitType {
+  auto getSplit() -> SplitType {
     auto [split] = GetParam();
     return split;
   }
@@ -84,10 +82,9 @@ class FilterExecutorTest
 };
 
 template<size_t... vs>
-const FilterExecutorSplitType splitIntoBlocks =
-    FilterExecutorSplitType{std::vector<std::size_t>{vs...}};
+const SplitType splitIntoBlocks = SplitType{std::vector<std::size_t>{vs...}};
 template<size_t step>
-const FilterExecutorSplitType splitStep = FilterExecutorSplitType{step};
+const SplitType splitStep = SplitType{step};
 
 INSTANTIATE_TEST_CASE_P(FilterExecutor, FilterExecutorTest,
                         ::testing::Values(splitIntoBlocks<2, 3>,

--- a/tests/Aql/HashedCollectExecutorTest.cpp
+++ b/tests/Aql/HashedCollectExecutorTest.cpp
@@ -52,16 +52,12 @@ namespace arangodb {
 namespace tests {
 namespace aql {
 
-// This is only to get a split-type. The Type is independent of actual template
-// parameters
-using HashedCollectTestHelper = ExecutorTestHelper<1, 1>;
-using HashedCollectSplitType = HashedCollectTestHelper::SplitType;
-using HashedCollectInputParam = std::tuple<HashedCollectSplitType, bool>;
+using HashedCollectInputParam = std::tuple<SplitType, bool>;
 
 class HashedCollectExecutorTest
     : public AqlExecutorTestCaseWithParam<HashedCollectInputParam> {
  protected:
-  auto getSplit() -> HashedCollectSplitType {
+  auto getSplit() -> SplitType {
     auto [split, empty] = GetParam();
     return split;
   }
@@ -125,10 +121,9 @@ class HashedCollectExecutorTest
 };
 
 template<size_t... vs>
-const HashedCollectSplitType splitIntoBlocks =
-    HashedCollectSplitType{std::vector<std::size_t>{vs...}};
+const SplitType splitIntoBlocks = SplitType{std::vector<std::size_t>{vs...}};
 template<size_t step>
-const HashedCollectSplitType splitStep = HashedCollectSplitType{step};
+const SplitType splitStep = SplitType{step};
 
 INSTANTIATE_TEST_CASE_P(
     HashedCollect, HashedCollectExecutorTest,
@@ -542,13 +537,12 @@ std::ostream& operator<<(std::ostream& out, AggregateInput const& agg) {
   return out;
 }
 
-using HashedCollectAggregateInputParam =
-    std::tuple<HashedCollectSplitType, AggregateInput>;
+using HashedCollectAggregateInputParam = std::tuple<SplitType, AggregateInput>;
 
 class HashedCollectExecutorTestAggregate
     : public AqlExecutorTestCaseWithParam<HashedCollectAggregateInputParam> {
  protected:
-  auto getSplit() -> HashedCollectSplitType {
+  auto getSplit() -> SplitType {
     auto [split, unused] = GetParam();
     return split;
   }

--- a/tests/Aql/NoResultsExecutorTest.cpp
+++ b/tests/Aql/NoResultsExecutorTest.cpp
@@ -36,14 +36,12 @@ namespace arangodb {
 namespace tests {
 namespace aql {
 
-using NoResultsTestHelper = ExecutorTestHelper<1, 1>;
-using NoResultsSplitType = NoResultsTestHelper::SplitType;
-using NoResultsInputParam = std::tuple<NoResultsSplitType, AqlCall, size_t>;
+using NoResultsInputParam = std::tuple<SplitType, AqlCall, size_t>;
 
 class NoResultsExecutorTest
     : public AqlExecutorTestCaseWithParam<NoResultsInputParam> {
  protected:
-  auto getSplit() -> NoResultsSplitType {
+  auto getSplit() -> SplitType {
     auto const& [split, call, inputRows] = GetParam();
     return split;
   }
@@ -64,10 +62,9 @@ class NoResultsExecutorTest
 };
 
 template<size_t... vs>
-const NoResultsSplitType splitIntoBlocks =
-    NoResultsSplitType{std::vector<std::size_t>{vs...}};
+const SplitType splitIntoBlocks = SplitType{std::vector<std::size_t>{vs...}};
 template<size_t step>
-const NoResultsSplitType splitStep = NoResultsSplitType{step};
+const SplitType splitStep = SplitType{step};
 
 auto NoResultsInputSplits =
     ::testing::Values(splitIntoBlocks<2, 3>, splitStep<1>, splitStep<2>);

--- a/tests/Aql/ReturnExecutorTest.cpp
+++ b/tests/Aql/ReturnExecutorTest.cpp
@@ -45,16 +45,12 @@ namespace arangodb {
 namespace tests {
 namespace aql {
 
-// This is only to get a split-type. The Type is independent of actual template
-// parameters
-using ReturnExecutorTestHelper = ExecutorTestHelper<1, 1>;
-using ReturnExecutorSplitType = ReturnExecutorTestHelper::SplitType;
-using ReturnExecutorParamType = std::tuple<ReturnExecutorSplitType, bool>;
+using ReturnExecutorParamType = std::tuple<SplitType, bool>;
 
 class ReturnExecutorTest
     : public AqlExecutorTestCaseWithParam<ReturnExecutorParamType> {
  protected:
-  auto getSplit() -> ReturnExecutorSplitType {
+  auto getSplit() -> SplitType {
     auto [split, unused] = GetParam();
     return split;
   }
@@ -74,10 +70,9 @@ class ReturnExecutorTest
 };
 
 template<size_t... vs>
-const ReturnExecutorSplitType splitIntoBlocks =
-    ReturnExecutorSplitType{std::vector<std::size_t>{vs...}};
+const SplitType splitIntoBlocks = SplitType{std::vector<std::size_t>{vs...}};
 template<size_t step>
-const ReturnExecutorSplitType splitStep = ReturnExecutorSplitType{step};
+const SplitType splitStep = SplitType{step};
 
 INSTANTIATE_TEST_CASE_P(
     ReturnExecutor, ReturnExecutorTest,

--- a/tests/Aql/ShadowRowForwardingTest.cpp
+++ b/tests/Aql/ShadowRowForwardingTest.cpp
@@ -1,0 +1,721 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2023-2023 ArangoDB GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Tobias Gödderz
+////////////////////////////////////////////////////////////////////////////////
+
+#include <gtest/gtest.h>
+
+#include "Aql/AqlExecutorTestCase.h"
+#include "Aql/TestLambdaExecutor.h"
+
+#include "Aql/FilterExecutor.h"
+#include "Aql/SubqueryStartExecutor.h"
+#include "Aql/SubqueryEndExecutor.h"
+
+using namespace arangodb;
+using namespace arangodb::tests;
+using namespace arangodb::tests::aql;
+
+namespace {
+
+// Static strings to use as datainput for test blocks.
+static std::vector<std::string> const rowContent{
+    R"("data row")",           R"("shadow row depth 1")",
+    R"("shadow row depth 2")", R"("shadow row depth 3")",
+    R"("shadow row depth 4")", R"("shadow row depth 5")",
+    R"("shadow row depth 6")"};
+
+static std::string const emptySubqueryResult{R"([])"};
+static std::string const oneSubqueryResult{R"(["data row"])"};
+
+RegisterInfos MakeBaseInfos(RegisterCount numRegs, size_t subqueryDepth = 2) {
+  RegIdSet prototype{};
+  for (RegisterId::value_t r = 0; r < numRegs; ++r) {
+    prototype.emplace(r);
+  }
+  RegIdSetStack regsToKeep{};
+  for (size_t i = 0; i <= subqueryDepth; ++i) {
+    regsToKeep.push_back({prototype});
+  }
+  return RegisterInfos({}, {}, numRegs, numRegs, {}, regsToKeep);
+}
+
+RegisterInfos MakeSubqueryEndBaseInfos(RegisterCount numRegs,
+                                       size_t subqueryDepth = 2) {
+  RegIdSet prototype{};
+  for (RegisterId::value_t r = 0; r < numRegs - 1; ++r) {
+    prototype.emplace(r);
+  }
+  RegIdSetStack regsToKeep{};
+  for (size_t i = 0; i < subqueryDepth; ++i) {
+    regsToKeep.push_back({prototype});
+  }
+
+  return RegisterInfos(RegIdSet{0}, RegIdSet{1}, numRegs, numRegs, {},
+                       regsToKeep);
+}
+
+auto createProduceCall() -> ProduceCall {
+  return [](AqlItemBlockInputRange& input, OutputAqlItemRow& output)
+             -> std::tuple<ExecutorState, NoStats, AqlCall> {
+    while (input.hasDataRow() && !output.isFull()) {
+      auto const [state, row] = input.nextDataRow();
+      output.copyRow(row);
+      output.advanceRow();
+    }
+    NoStats stats{};
+    AqlCall call{};
+
+    return {input.upstreamState(), stats, call};
+  };
+};
+
+auto createSkipCall() -> SkipCall {
+  return
+      [](AqlItemBlockInputRange& input,
+         AqlCall& call) -> std::tuple<ExecutorState, NoStats, size_t, AqlCall> {
+        TRI_ASSERT(false);
+        THROW_ARANGO_EXCEPTION(TRI_ERROR_NOT_IMPLEMENTED);
+      };
+};
+
+LambdaSkipExecutorInfos MakeNonPassThroughInfos() {
+  return LambdaSkipExecutorInfos{createProduceCall(), createSkipCall()};
+}
+
+auto generateCallStack(
+    size_t nestedSubqueryLevels, size_t callWithoutContinue,
+    ExecutionNode::NodeType type = ExecutionNode::CALCULATION) -> AqlCallStack {
+  TRI_ASSERT(callWithoutContinue < nestedSubqueryLevels);
+  size_t indexWithoutContinueCall =
+      nestedSubqueryLevels - 1 - callWithoutContinue;
+  // MainQuery never has a continue call
+  AqlCallStack stack{AqlCallList{AqlCall{}}};
+  for (size_t i = 0; i < nestedSubqueryLevels; ++i) {
+    if (i == indexWithoutContinueCall) {
+      stack.pushCall(AqlCallList{AqlCall{}});  // no continue call
+    } else {
+      stack.pushCall(AqlCallList{AqlCall{}, AqlCall{}});
+    }
+  }
+  if (type == ExecutionNode::SUBQUERY_START) {
+    // Add the call within subquery.
+    // Use Continue here, we have specific subquery tests somewhere else.
+    stack.pushCall(AqlCallList{AqlCall{}, AqlCall{}});
+  }
+  // LOG_DEVEL << "Generated Stack " << stack.toString();
+  return stack;
+}
+
+struct RunConfiguration {
+  size_t splitSize;
+  size_t nestedSubqueries;
+  size_t skippedRowsAtFront;
+  size_t callWithoutContinue;
+
+  /// Returns the amount of rows staring with the datarow, and one row per
+  /// subquery level.
+  size_t getFullBlockSize() const { return nestedSubqueries + 1; }
+
+  /// Returns the amount of blocks we can return with the given split size
+  /// before we reach the next data row
+  size_t getNumberOfFullSplitBlocks() const {
+    return (getFullBlockSize() - skippedRowsAtFront) / splitSize;
+  }
+
+  /// Returns the amount of rows for the last split block, which has to stop
+  /// before the next data row. Can be 0, in this case we do not need another
+  /// split block.
+  size_t getSizeOfLastSplitBlock() const {
+    return (getFullBlockSize() - skippedRowsAtFront) % splitSize;
+  }
+
+  /// Returns the number of rows we can consume before we would violate the
+  /// "no-default-call" on the subquery.
+  size_t getNumberOfConsumableRowsInFirstCall() const {
+    // How this calculation comes to be:
+    // +1 is added to make it 1 aligned and not 0
+    // +1 is added for the dataRow
+    // +1 is added because we can produce the next ShadowRow AFTER the shadowRow
+    // without continue call.
+    // + callWithoutContinue is the level of subquery we cannot continue.
+    // - skippedRowsAtFront is to align the calculation to the rows we have
+    // "seen before".
+    size_t positionOfNonDefaultMember =
+        2 + callWithoutContinue - skippedRowsAtFront;
+    return std::min(
+        static_cast<size_t>(std::ceil(
+            static_cast<double>(positionOfNonDefaultMember) / splitSize)) *
+            splitSize,
+        getFullBlockSize() - skippedRowsAtFront);
+  }
+
+  /// Returns the number of rows we can consume before we would violate the
+  /// "no-default-call" on the subquery.
+  size_t getNumberOfConsumableRowsInFirstCallSubqueryEnd() const {
+    // How this calculation comes to be:
+    // +1 is added to make it 1 aligned and not 0
+    // +1 is added for the dataRow
+    // +1 is added because we can produce the next ShadowRow AFTER the shadowRow
+    // without continue call.
+    // + callWithoutContinue is the level of subquery we cannot continue.
+    // - skippedRowsAtFront is to align the calculation to the rows we have
+    // "seen before".
+    size_t positionOfNonDefaultMember =
+        2 + callWithoutContinue - skippedRowsAtFront + 1;
+    return std::min(
+        static_cast<size_t>(std::ceil(
+            static_cast<double>(positionOfNonDefaultMember) / splitSize)) *
+            splitSize,
+        getFullBlockSize() - skippedRowsAtFront);
+  }
+
+  void validate() const {
+    TRI_ASSERT(callWithoutContinue < nestedSubqueries);
+    TRI_ASSERT(skippedRowsAtFront <= callWithoutContinue + 1);
+    TRI_ASSERT(splitSize > 0);
+    TRI_ASSERT(nestedSubqueries > 0);
+  }
+
+  std::string toString() const {
+    return "with split type " + std::to_string(splitSize) +
+           " subqueryLevels: " + std::to_string(nestedSubqueries) +
+           " skippedRowsAtFront: " + std::to_string(skippedRowsAtFront) +
+           " indexWithoutContinueCall: " + std::to_string(callWithoutContinue);
+  }
+};
+
+template<size_t numRows>
+struct DataBlockInput {
+  MatrixBuilder<numRows> data;
+  std::vector<std::pair<size_t, uint64_t>> shadowRows;
+  SkipResult skip;
+};
+
+/*
+ * This will generate a Matrix of data rows with a single column.
+ * The matrix will always follow the pattern:
+ * DataRow
+ * D1 Subquery
+ * D2 Subquery
+ * ...
+ * Dn Subquery
+ * DataRow
+ * D1 Subquery
+ * D2 Subquery
+ * ...
+ * Dn Subquery
+ *
+ * So we have a DataRow followed by all higher level Subqueries, repeated 2
+ * times. with skipFrontRows we can skip rows from the beginning of the matrix.
+ * (At most nestedSubqueryLevels many rows.)
+ * We can limit the amount of returned rows by setting the rowLimit.
+ * rowLimit == 0 means no limit, otherwise we write exactly that many rows
+ */
+auto generateOutputRowData(size_t nestedSubqueryLevels, size_t skipFrontRows,
+                           size_t rowLimit, ExecutionNode::NodeType nodeType)
+    -> DataBlockInput<1> {
+  // Add the "data row"
+  size_t numRows = nestedSubqueryLevels + 1;
+  TRI_ASSERT(numRows <= rowContent.size())
+      << "If this ASSERT kicks in just add value for more shadow rows to the "
+         "static list of values.";
+  TRI_ASSERT(skipFrontRows < numRows);
+  MatrixBuilder<1> data{};
+  std::vector<std::pair<size_t, uint64_t>> shadowRows{};
+  size_t subqueryExecutorOffset = 0;
+  // We start at skipFrontRows to skip the first ones
+  for (size_t i = skipFrontRows; i < numRows * 2; ++i) {
+    auto index = i % numRows;
+    data.emplace_back(RowBuilder<1>{rowContent[index].data()});
+    if (nodeType == ExecutionNode::SUBQUERY_START) {
+      if (index > 0) {
+        // Writes index one higher than other block
+        shadowRows.emplace_back(
+            std::make_pair(i - skipFrontRows + subqueryExecutorOffset, index));
+      } else {
+        // Subquery Start writes a DataRow followed by a ShadowRow
+        subqueryExecutorOffset++;
+        data.emplace_back(RowBuilder<1>{rowContent[index].data()});
+        shadowRows.emplace_back(
+            std::make_pair(i - skipFrontRows + subqueryExecutorOffset, 0));
+      }
+    } else {
+      if (index > 0) {
+        shadowRows.emplace_back(std::make_pair(i - skipFrontRows, index - 1));
+      }
+    }
+    if (rowLimit > 0) {
+      rowLimit--;
+      if (rowLimit == 0) {
+        break;
+      }
+    }
+  }
+  SkipResult skipResult;
+  for (size_t i = 0; i < nestedSubqueryLevels; ++i) {
+    skipResult.incrementSubquery();
+  }
+  if (nodeType == ExecutionNode::SUBQUERY_START) {
+    // Subquery Start adds another level of subqueries.
+    skipResult.incrementSubquery();
+  }
+  return DataBlockInput<1>{std::move(data), std::move(shadowRows),
+                           std::move(skipResult)};
+}
+
+auto generateOutputSubqueryEndRowData(size_t nestedSubqueryLevels,
+                                      size_t skipFrontRows, size_t rowLimit)
+    -> DataBlockInput<2> {
+  // Add the "data row"
+  size_t numRows = nestedSubqueryLevels + 2;
+  TRI_ASSERT(numRows < rowContent.size())
+      << "If this ASSERT kicks in just add value for more shadow rows to the "
+         "static list of values.";
+  TRI_ASSERT(skipFrontRows < numRows);
+  MatrixBuilder<2> data{};
+  std::vector<std::pair<size_t, uint64_t>> shadowRows{};
+  // We start at skipFrontRows to skip the first ones
+  bool needToWriteDataRow = false;
+  size_t subqueryOffset = 0;
+  for (size_t i = skipFrontRows; i < numRows * 2; ++i) {
+    auto index = i % numRows;
+    if (index == 0) {
+      needToWriteDataRow = true;
+      subqueryOffset++;
+    } else {
+      // We need to pick the data entry of one higher level, As subquery end
+      // pops the top level.
+      if (index == 1) {
+        if (needToWriteDataRow) {
+          data.emplace_back(RowBuilder<2>{rowContent[index].data(),
+                                          oneSubqueryResult.data()});
+        } else {
+          data.emplace_back(RowBuilder<2>{rowContent[index].data(),
+                                          emptySubqueryResult.data()});
+        }
+        needToWriteDataRow = false;
+      } else {
+        data.emplace_back(RowBuilder<2>{rowContent[index].data()});
+        shadowRows.emplace_back(
+            std::make_pair(i - skipFrontRows - subqueryOffset, index - 2));
+      }
+    }
+
+    if (rowLimit > 0) {
+      rowLimit--;
+      if (rowLimit == 0) {
+        break;
+      }
+    }
+  }
+  SkipResult skipResult;
+  for (size_t i = 0; i < nestedSubqueryLevels; ++i) {
+    skipResult.incrementSubquery();
+  }
+  return DataBlockInput<2>{std::move(data), std::move(shadowRows),
+                           std::move(skipResult)};
+}
+
+auto generateInputRowData(size_t nestedSubqueryLevels, size_t skipFrontRows)
+    -> DataBlockInput<1> {
+  // Type should not be any subquery variant here, we just want a full block, no
+  // special handling
+  return generateOutputRowData(nestedSubqueryLevels, skipFrontRows, 0,
+                               ExecutionNode::CALCULATION);
+}
+
+auto generateSplitPattern(RunConfiguration const& config) -> SplitType {
+  std::vector<std::size_t> splits{};
+  for (size_t i = 0; i < config.getNumberOfFullSplitBlocks(); ++i) {
+    // Add as many standard sized split blocks as required
+    splits.emplace_back(config.splitSize);
+  }
+  auto lastBlock = config.getSizeOfLastSplitBlock();
+  if (lastBlock > 0) {
+    // If required add the last block so we get a fresh start with new subquery
+    splits.emplace_back(lastBlock);
+  }
+  // Add the remainder of the input block
+  splits.emplace_back(config.getFullBlockSize());
+  return splits;
+}
+
+}  // namespace
+
+constexpr bool enableQueryTrace = false;
+struct ShadowRowForwardingTest : AqlExecutorTestCase<enableQueryTrace> {
+  arangodb::ResourceMonitor monitor{global};
+  auto MakeSubqueryEndExecutorInfos(RegisterId inputRegister)
+      -> SubqueryEndExecutor::Infos {
+    auto const outputRegister =
+        RegisterId{static_cast<RegisterId::value_t>(inputRegister.value() + 1)};
+
+    return SubqueryEndExecutor::Infos(nullptr, monitor, inputRegister,
+                                      outputRegister);
+  }
+};
+
+TEST_F(ShadowRowForwardingTest, subqueryStart1) {
+  auto const test = [&](SplitType splitType) {
+    SCOPED_TRACE("with split type " + to_string(splitType));
+
+    auto inputVal = generateInputRowData(2, 2);
+    makeExecutorTestHelper<1, 1>()
+        .addConsumer<SubqueryStartExecutor>(MakeBaseInfos(1, 3),
+                                            MakeBaseInfos(1, 3),
+                                            ExecutionNode::SUBQUERY_START)
+        .setInputSubqueryDepth(2)
+        .setInputValue(std::move(inputVal.data), std::move(inputVal.shadowRows))
+        .setInputSplitType(splitType)
+        .setCallStack(generateCallStack(3, 1))
+        .expectedStats(ExecutionStats{})
+        .expectedState(ExecutionState::HASMORE)
+        .expectOutput(
+            {0},
+            {
+                {rowContent[2].data()},
+                // {R"("data row")"},
+                // {R"("data row")"},  // this is now a relevant shadow row
+                // {R"("inner shadow row")"},
+                // {R"("outer shadow row")"},
+            },
+            {
+                {0, 2},
+                // // {1, data row}
+                // {2, 0},
+                // {3, 1},
+                // {4, 2},
+            })
+        .expectSkipped(0, 0, 0, 0)
+        .run();
+  };
+
+  test(std::monostate{});
+  test(std::size_t{1});
+  test(std::vector<std::size_t>{1, 3});
+};
+
+TEST_F(ShadowRowForwardingTest, subqueryEnd1) {
+  auto const test = [&](SplitType splitType) {
+    SCOPED_TRACE("with split type " + to_string(splitType));
+
+    makeExecutorTestHelper<1, 1>()
+        .addConsumer<SubqueryEndExecutor>(MakeBaseInfos(1, 3),
+                                          MakeSubqueryEndExecutorInfos(1),
+                                          ExecutionNode::SUBQUERY_END)
+        .setInputSubqueryDepth(3)
+        .setInputValue(
+            {
+                {R"("outer shadow row")"},
+                {R"("relevant shadow row")"},
+                {R"("inner shadow row")"},
+                {R"("outer shadow row")"},
+            },
+            {
+                {0, 2},
+                {1, 0},
+                {2, 1},
+                {3, 2},
+            })
+        .setInputSplitType(splitType)
+        .setCallStack(generateCallStack(2, 1))
+        .expectedStats(ExecutionStats{})
+        .expectedState(ExecutionState::HASMORE)
+        .expectOutput(
+            {0},
+            {
+                {R"("outer shadow row")"},
+                // {R"([])"}, // data row (previously relevant shadow row)
+                // {R"("inner shadow row")"},
+                // {R"("outer shadow row")"},
+            },
+            {
+                {0, 1},
+                // // {1, data row}
+                // {2, 0},
+                // {3, 1},
+            })
+        .expectSkipped(0, 0, 0)
+        .run();
+  };
+
+  test(std::monostate{});
+  test(std::size_t{1});
+  test(std::vector<std::size_t>{1, 3});
+};
+
+/**
+ * The following set of tests tries to simulate the different situations
+ * on Subqueries a Executor can be presented, and test it's reaction
+ * if there is no "default" call for one of the Subqueries.
+ * If we do not have a default call, we are not allowed to start the next
+ * Subquery run on this level.
+ * => If we do not have a deaultCall on depth 2, we can continue main and depth
+ * 1 and depth 2. But as soon as we only see a depth3 (or higher) shadow row, we
+ * have to stop asking from upstream And have to return. We can however return
+ * all higher shadowRows we already have from upstream, we are just not allowed
+ * to ask for more (even if it would be higher shadowRows, but we cannot see
+ * this)
+ *
+ *
+ * Therefore this test try to nest several levels of subqueries, the ask for a
+ * callstack which contains one call without a default in all possible levels.
+ * And checks if the Executor forwards only exactly those ShadowRows it can see
+ * from upstream. The upstream is split into several chunks of ShadowRows, the
+ * executor can never return a new datarow on first call, and it can only return
+ * the chunk of ShadowRows which contains the shadowRow one level higher than
+ * the one without default call.
+ */
+
+TEST_F(ShadowRowForwardingTest, nonForwardingExecutor) {
+  auto const test = [&](RunConfiguration config) {
+    config.validate();
+    SCOPED_TRACE(config.toString());
+    SplitType splitType = generateSplitPattern(config);
+
+    auto inputVal = generateInputRowData(config.nestedSubqueries,
+                                         config.skippedRowsAtFront);
+    {
+      SCOPED_TRACE("only looking at first output block");
+      // We can always return all rows before the next data row, as this input
+      // only appends shadowRows of higher depth.
+      // Which is 1 dataRow + all ShadowRows - the ones we skipped at the front.
+      auto expectedRows = config.getNumberOfConsumableRowsInFirstCall();
+      auto outputVal = generateOutputRowData(
+          config.nestedSubqueries, config.skippedRowsAtFront, expectedRows,
+          ExecutionNode::CALCULATION);
+      makeExecutorTestHelper<1, 1>()
+          .addConsumer<TestLambdaSkipExecutor>(
+              MakeBaseInfos(1, config.nestedSubqueries),
+              MakeNonPassThroughInfos(), ExecutionNode::CALCULATION)
+          .setInputSubqueryDepth(config.nestedSubqueries)
+          .setInputValue(inputVal.data, inputVal.shadowRows)
+          .setInputSplitType(splitType)
+          .setCallStack(generateCallStack(config.nestedSubqueries,
+                                          config.callWithoutContinue))
+          .expectedStats(ExecutionStats{})
+          .expectedState(ExecutionState::HASMORE)
+          .expectOutput({0}, std::move(outputVal.data),
+                        std::move(outputVal.shadowRows))
+          .expectSkipped(std::move(outputVal.skip))
+          .run();
+    }
+    {
+      SCOPED_TRACE("simulating full run");
+      // With a full run everything has to eventually be returned.
+      // This tests if we get into undefined behaviour if we continue after
+      // the first block is returned.
+
+      makeExecutorTestHelper<1, 1>()
+          .addConsumer<TestLambdaSkipExecutor>(
+              MakeBaseInfos(1, config.nestedSubqueries),
+              MakeNonPassThroughInfos(), ExecutionNode::CALCULATION)
+          .setInputSubqueryDepth(config.nestedSubqueries)
+          .setInputValue(inputVal.data, inputVal.shadowRows)
+          .setInputSplitType(splitType)
+          .setCallStack(generateCallStack(config.nestedSubqueries,
+                                          config.callWithoutContinue))
+          .expectedStats(ExecutionStats{})
+          .expectedState(ExecutionState::DONE)
+          .expectOutput({0}, std::move(inputVal.data),
+                        std::move(inputVal.shadowRows))
+          .expectSkipped(std::move(inputVal.skip))
+          .run(true);
+    }
+  };
+
+  for (size_t nestedSubqueries = 2; nestedSubqueries < 6; ++nestedSubqueries) {
+    for (size_t callWithoutContinue = 0; callWithoutContinue < nestedSubqueries;
+         ++callWithoutContinue) {
+      for (size_t skippedRowsAtFront = 0;
+           skippedRowsAtFront <= callWithoutContinue + 1;
+           ++skippedRowsAtFront) {
+        for (size_t splitSize = 1;
+             splitSize < nestedSubqueries + 1 - skippedRowsAtFront;
+             ++splitSize) {
+          test({splitSize, nestedSubqueries, skippedRowsAtFront,
+                callWithoutContinue});
+        }
+      }
+    }
+  }
+}
+
+TEST_F(ShadowRowForwardingTest, subqueryStartExecutor) {
+  auto const test = [&](RunConfiguration config) {
+    config.validate();
+    SCOPED_TRACE(config.toString());
+    SplitType splitType = generateSplitPattern(config);
+
+    auto inputVal = generateInputRowData(config.nestedSubqueries,
+                                         config.skippedRowsAtFront);
+    {
+      SCOPED_TRACE("only looking at first output block");
+      // We can always return all rows before the next data row, as this input
+      // only appends shadowRows of higher depth.
+      // Which is 1 dataRow + all ShadowRows - the ones we skipped at the front.
+      auto expectedRows = config.getNumberOfConsumableRowsInFirstCall();
+      auto outputVal = generateOutputRowData(
+          config.nestedSubqueries, config.skippedRowsAtFront, expectedRows,
+          ExecutionNode::SUBQUERY_START);
+      makeExecutorTestHelper<1, 1>()
+          .addConsumer<SubqueryStartExecutor>(
+              MakeBaseInfos(1, config.nestedSubqueries + 1),
+              MakeBaseInfos(1, config.nestedSubqueries + 1),
+              ExecutionNode::SUBQUERY_START)
+          .setInputSubqueryDepth(config.nestedSubqueries)
+          .setInputValue(inputVal.data, inputVal.shadowRows)
+          .setInputSplitType(splitType)
+          .setCallStack(generateCallStack(config.nestedSubqueries,
+                                          config.callWithoutContinue,
+                                          ExecutionNode::SUBQUERY_START))
+          .expectedStats(ExecutionStats{})
+          .expectedState(ExecutionState::HASMORE)
+          .expectOutput({0}, std::move(outputVal.data),
+                        std::move(outputVal.shadowRows))
+          .expectSkipped(std::move(outputVal.skip))
+          .run();
+    }
+    {
+      SCOPED_TRACE("simulating full run");
+      // With a full run everything has to eventually be returned.
+      // This tests if we get into undefined behaviour if we continue after
+      // the first block is returned.
+      auto outputVal = generateOutputRowData(config.nestedSubqueries,
+                                             config.skippedRowsAtFront, 0,
+                                             ExecutionNode::SUBQUERY_START);
+
+      makeExecutorTestHelper<1, 1>()
+          .addConsumer<SubqueryStartExecutor>(
+              MakeBaseInfos(1, config.nestedSubqueries + 1),
+              MakeBaseInfos(1, config.nestedSubqueries + 1),
+              ExecutionNode::SUBQUERY_START)
+          .setInputSubqueryDepth(config.nestedSubqueries)
+          .setInputValue(inputVal.data, inputVal.shadowRows)
+          .setInputSplitType(splitType)
+          .setCallStack(generateCallStack(config.nestedSubqueries,
+                                          config.callWithoutContinue,
+                                          ExecutionNode::SUBQUERY_START))
+          .expectedStats(ExecutionStats{})
+          .expectedState(ExecutionState::DONE)
+          .expectOutput({0}, std::move(outputVal.data),
+                        std::move(outputVal.shadowRows))
+          .expectSkipped(std::move(outputVal.skip))
+          .run(true);
+    }
+  };
+
+  for (size_t nestedSubqueries = 2; nestedSubqueries < 5; ++nestedSubqueries) {
+    for (size_t callWithoutContinue = 0;
+         callWithoutContinue < nestedSubqueries - 1; ++callWithoutContinue) {
+      for (size_t skippedRowsAtFront = 0;
+           skippedRowsAtFront <= callWithoutContinue + 1;
+           ++skippedRowsAtFront) {
+        for (size_t splitSize = 1;
+             splitSize < nestedSubqueries + 1 - skippedRowsAtFront;
+             ++splitSize) {
+          test({splitSize, nestedSubqueries, skippedRowsAtFront,
+                callWithoutContinue});
+        }
+      }
+    }
+  }
+}
+
+TEST_F(ShadowRowForwardingTest, subqueryEndExecutor) {
+  auto const test = [&](RunConfiguration config) {
+    config.validate();
+    SCOPED_TRACE(config.toString());
+    SplitType splitType = generateSplitPattern(config);
+
+    auto inputVal = generateInputRowData(config.nestedSubqueries + 1,
+                                         config.skippedRowsAtFront);
+    {
+      SCOPED_TRACE("only looking at first output block");
+      // We can always return all rows before the next data row, as this input
+      // only appends shadowRows of higher depth.
+      // Which is 1 dataRow + all ShadowRows - the ones we skipped at the front.
+      auto expectedRows =
+          config.getNumberOfConsumableRowsInFirstCallSubqueryEnd();
+      auto outputVal = generateOutputSubqueryEndRowData(
+          config.nestedSubqueries, config.skippedRowsAtFront, expectedRows);
+
+      makeExecutorTestHelper<1, 2>()
+          .addConsumer<SubqueryEndExecutor>(
+              MakeSubqueryEndBaseInfos(2, config.nestedSubqueries + 1),
+              MakeSubqueryEndExecutorInfos(0), ExecutionNode::SUBQUERY_END)
+          .setInputSubqueryDepth(config.nestedSubqueries + 1)
+          .setInputValue(inputVal.data, inputVal.shadowRows)
+          .setInputSplitType(splitType)
+          .setCallStack(generateCallStack(config.nestedSubqueries,
+                                          config.callWithoutContinue,
+                                          ExecutionNode::SUBQUERY_END))
+          .expectedStats(ExecutionStats{})
+          .expectedState(ExecutionState::HASMORE)
+          .expectOutput({0, 1}, std::move(outputVal.data),
+                        std::move(outputVal.shadowRows))
+          .expectSkipped(std::move(outputVal.skip))
+          .run();
+    }
+    {
+      SCOPED_TRACE("simulating full run");
+      // With a full run everything has to eventually be returned.
+      // This tests if we get into undefined behaviour if we continue after
+      // the first block is returned.
+
+      auto outputVal = generateOutputSubqueryEndRowData(
+          config.nestedSubqueries, config.skippedRowsAtFront, 0);
+
+      makeExecutorTestHelper<1, 2>()
+          .addConsumer<SubqueryEndExecutor>(
+              MakeSubqueryEndBaseInfos(2, config.nestedSubqueries + 1),
+              MakeSubqueryEndExecutorInfos(0), ExecutionNode::SUBQUERY_END)
+          .setInputSubqueryDepth(config.nestedSubqueries + 1)
+          .setInputValue(inputVal.data, inputVal.shadowRows)
+          .setInputSplitType(splitType)
+          .setCallStack(generateCallStack(config.nestedSubqueries,
+                                          config.callWithoutContinue,
+                                          ExecutionNode::SUBQUERY_END))
+          .expectedStats(ExecutionStats{})
+          .expectedState(ExecutionState::DONE)
+          .expectOutput({0, 1}, std::move(outputVal.data),
+                        std::move(outputVal.shadowRows))
+          .expectSkipped(std::move(outputVal.skip))
+          .run(true);
+    }
+  };
+
+  for (size_t nestedSubqueries = 2; nestedSubqueries < 5; ++nestedSubqueries) {
+    for (size_t callWithoutContinue = 0;
+         callWithoutContinue < nestedSubqueries - 1; ++callWithoutContinue) {
+      for (size_t skippedRowsAtFront = 0;
+           skippedRowsAtFront <= callWithoutContinue + 1;
+           ++skippedRowsAtFront) {
+        for (size_t splitSize = 1;
+             splitSize < nestedSubqueries + 1 - skippedRowsAtFront;
+             ++splitSize) {
+          test({splitSize, nestedSubqueries, skippedRowsAtFront,
+                callWithoutContinue});
+        }
+      }
+    }
+  }
+}

--- a/tests/Aql/SortExecutorTest.cpp
+++ b/tests/Aql/SortExecutorTest.cpp
@@ -62,7 +62,6 @@ using SortInputParam = std::tuple<SplitType>;
 
 class SortExecutorTest : public AqlExecutorTestCaseWithParam<SortInputParam> {
  protected:
-
   auto getSplit() -> SplitType {
     auto const& [split] = GetParam();
     return split;

--- a/tests/Aql/SortExecutorTest.cpp
+++ b/tests/Aql/SortExecutorTest.cpp
@@ -58,13 +58,12 @@ using namespace arangodb::aql;
 
 namespace arangodb::tests::aql {
 
-using SortTestHelper = ExecutorTestHelper<1, 1>;
-using SortSplitType = SortTestHelper::SplitType;
-using SortInputParam = std::tuple<SortSplitType>;
+using SortInputParam = std::tuple<SplitType>;
 
 class SortExecutorTest : public AqlExecutorTestCaseWithParam<SortInputParam> {
  protected:
-  auto getSplit() -> SortSplitType {
+
+  auto getSplit() -> SplitType {
     auto const& [split] = GetParam();
     return split;
   }
@@ -142,10 +141,9 @@ class SortExecutorTest : public AqlExecutorTestCaseWithParam<SortInputParam> {
 };
 
 template<size_t... vs>
-const SortSplitType splitIntoBlocks =
-    SortSplitType{std::vector<std::size_t>{vs...}};
+const SplitType splitIntoBlocks = SplitType{std::vector<std::size_t>{vs...}};
 template<size_t step>
-const SortSplitType splitStep = SortSplitType{step};
+const SplitType splitStep = SplitType{step};
 
 INSTANTIATE_TEST_CASE_P(SortExecutorTest, SortExecutorTest,
                         ::testing::Values(splitIntoBlocks<2, 3>,

--- a/tests/Aql/SortedCollectExecutorTest.cpp
+++ b/tests/Aql/SortedCollectExecutorTest.cpp
@@ -944,11 +944,8 @@ TEST_F(SortedCollectExecutorTestSkip, skip_5) {
   clientCall.resetSkipCount();
 }
 
-using SortedCollectTestHelper = ExecutorTestHelper<1, 1>;
-using SortedCollectSplitType = SortedCollectTestHelper::SplitType;
-
 class SortedCollectExecutorTestSplit
-    : public AqlExecutorTestCaseWithParam<std::tuple<SortedCollectSplitType>> {
+    : public AqlExecutorTestCaseWithParam<std::tuple<SplitType>> {
  protected:
   std::vector<std::pair<RegisterId, RegisterId>> groupRegisters;
 
@@ -1026,10 +1023,9 @@ TEST_P(SortedCollectExecutorTestSplit, split_3) {
 }
 
 template<size_t... vs>
-const SortedCollectSplitType splitIntoBlocks =
-    SortedCollectSplitType{std::vector<std::size_t>{vs...}};
+const SplitType splitIntoBlocks = SplitType{std::vector<std::size_t>{vs...}};
 template<size_t step>
-const SortedCollectSplitType splitStep = SortedCollectSplitType{step};
+const SplitType splitStep = SplitType{step};
 
 INSTANTIATE_TEST_CASE_P(SortedCollectExecutor, SortedCollectExecutorTestSplit,
                         ::testing::Values(splitIntoBlocks<2, 3>,

--- a/tests/Aql/SplicedSubqueryIntegrationTest.cpp
+++ b/tests/Aql/SplicedSubqueryIntegrationTest.cpp
@@ -57,9 +57,7 @@ using namespace arangodb::tests;
 using namespace arangodb::tests::aql;
 using namespace arangodb::basics;
 
-using SubqueryExecutorTestHelper = ExecutorTestHelper<1, 1>;
-using SubqueryExecutorSplitType = SubqueryExecutorTestHelper::SplitType;
-using SubqueryExecutorParamType = std::tuple<SubqueryExecutorSplitType>;
+using SubqueryExecutorParamType = std::tuple<SplitType>;
 
 using RegisterSet = std::unordered_set<RegisterId>;
 using LambdaExePassThrough = TestLambdaExecutor;
@@ -236,17 +234,16 @@ class SplicedSubqueryIntegrationTest
       return {input.upstreamState(), stats, call};
     };
   }
-  auto getSplit() -> SubqueryExecutorSplitType {
+  auto getSplit() -> SplitType {
     auto [split] = GetParam();
     return split;
   }
 };
 
 template<size_t... vs>
-const SubqueryExecutorSplitType splitIntoBlocks =
-    SubqueryExecutorSplitType{std::vector<std::size_t>{vs...}};
+const SplitType splitIntoBlocks = SplitType{std::vector<std::size_t>{vs...}};
 template<size_t step>
-const SubqueryExecutorSplitType splitStep = SubqueryExecutorSplitType{step};
+const SplitType splitStep = SplitType{step};
 
 INSTANTIATE_TEST_CASE_P(SplicedSubqueryIntegrationTest,
                         SplicedSubqueryIntegrationTest,

--- a/tests/Aql/SubqueryStartExecutorTest.cpp
+++ b/tests/Aql/SubqueryStartExecutorTest.cpp
@@ -58,13 +58,10 @@ RegisterInfos MakeBaseInfos(RegisterCount numRegs, size_t subqueryDepth = 2) {
 }
 }  // namespace
 
-using SubqueryStartSplitType = ExecutorTestHelper<1, 1>::SplitType;
-
 class SubqueryStartExecutorTest
-    : public AqlExecutorTestCaseWithParam<std::tuple<SubqueryStartSplitType>,
-                                          false> {
+    : public AqlExecutorTestCaseWithParam<std::tuple<SplitType>, false> {
  protected:
-  auto GetSplit() const -> SubqueryStartSplitType {
+  auto GetSplit() const -> SplitType {
     auto const [split] = GetParam();
     return split;
   }
@@ -82,10 +79,9 @@ class SubqueryStartExecutorTest
 };
 
 template<size_t... vs>
-const SubqueryStartSplitType splitIntoBlocks =
-    SubqueryStartSplitType{std::vector<std::size_t>{vs...}};
+const SplitType splitIntoBlocks = SplitType{std::vector<std::size_t>{vs...}};
 template<size_t step>
-const SubqueryStartSplitType splitStep = SubqueryStartSplitType{step};
+const SplitType splitStep = SplitType{step};
 
 INSTANTIATE_TEST_CASE_P(SubqueryStartExecutorTest, SubqueryStartExecutorTest,
                         ::testing::Values(splitIntoBlocks<2, 3>,

--- a/tests/Aql/WindowExecutorTest.cpp
+++ b/tests/Aql/WindowExecutorTest.cpp
@@ -51,17 +51,10 @@ namespace arangodb {
 namespace tests {
 namespace aql {
 
-// This is only to get a split-type. The Type is independent of actual template
-// parameters
-using WindowTestHelper = ExecutorTestHelper<1, 1>;
-using WindowSplitType = WindowTestHelper::SplitType;
-using WindowInputParam = std::tuple<WindowSplitType, bool>;
-
 template<size_t... vs>
-const WindowSplitType splitIntoBlocks =
-    WindowSplitType{std::vector<std::size_t>{vs...}};
+const SplitType splitIntoBlocks = SplitType{std::vector<std::size_t>{vs...}};
 template<size_t step>
-const WindowSplitType splitStep = WindowSplitType{step};
+const SplitType splitStep = SplitType{step};
 
 struct WindowInput {
   WindowBounds bounds;
@@ -86,12 +79,12 @@ std::ostream& operator<<(std::ostream& out, WindowInput const& agg) {
   return out;
 }
 
-using WindowAggregateInputParam = std::tuple<WindowSplitType, WindowInput>;
+using WindowAggregateInputParam = std::tuple<SplitType, WindowInput>;
 
 class WindowExecutorTest
     : public AqlExecutorTestCaseWithParam<WindowAggregateInputParam> {
  protected:
-  auto getSplit() -> WindowSplitType {
+  auto getSplit() -> SplitType {
     auto [split, unused] = GetParam();
     return split;
   }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -153,6 +153,7 @@ set(ARANGODB_TESTS_SOURCES
   Aql/ReturnExecutorTest.cpp
   Aql/RowFetcherHelper.cpp
   Aql/ScatterExecutorTest.cpp
+  Aql/ShadowRowForwardingTest.cpp
   Aql/ShortestPathExecutorTest.cpp
   Aql/ShortestPathNodeTest.cpp
   Aql/SkipResultTest.cpp


### PR DESCRIPTION
### Scope & Purpose

Backport of: https://github.com/arangodb/arangodb/pull/19778
Mostly Straight forward Cherry-pick
Only the ExecutionBlockImpl file is reordered in comparison to 3.11 and newer.

Non-relevant shadow rows (which mark the end of an iteration of an _outer_ subquery) must make an execution block return the output it has accumulated so far. When an aql item block starts with a non-relevant shadow row (i.e. it ends the iteration of an _outer_ subquery), this previously did not happen correctly, and nodes would collect more output into the same block. This would then lead pass-through nodes to return early (when encountering the non-relevant shadow row), thereby dropping some rows. In maintainer mode, this would lead to an assertion.

What was missing is that in such a scenario, a node must pop calls from all call lists with a depth lower than the encountered shadow row; i.e., from subqueries more innermost than the shadow row. Without that, a specific call on a subquery level without a default would be repeated, when it mustn't.

- [X] :hankey: Bugfix

### Checklist

- [X] Tests
  - [X] **Regression tests**
  - [ ] C++ **Unit tests**
- [X] :book: CHANGELOG entry made
- [ ] Backports
  - [ ] Backport for 3.11: **TODO**
  - [ ] Backport for 3.10: **TODO**

#### Related Information

- [X] Jira ticket: https://arangodb.atlassian.net/browse/BTS-1610

