### PR TITLE
Fix a race in failure oracle feature on server shutdown.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 v3.10.11 (XXXX-XX-XX)
 ---------------------
 
+* Fix a race in failure oracle feature on server shutdown.
+
 * Reduce number of atomic shared_ptr copies in in-memory cache subsystem.
 
 * Fixed BTS-1610: In certain situations with at least three levels of nested

--- a/arangod/Cluster/FailureOracleFeature.cpp
+++ b/arangod/Cluster/FailureOracleFeature.cpp
@@ -1,5 +1,7 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
 ///
-/// Copyright 2014-2022 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2014-2023 ArangoDB GmbH, Cologne, Germany
 /// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");
@@ -29,8 +31,10 @@
 #include "Basics/system-compiler.h"
 #include "Cluster/AgencyCache.h"
 #include "Cluster/AgencyCallback.h"
+#include "Cluster/AgencyCallbackRegistry.h"
 #include "Cluster/ClusterFeature.h"
 #include "Cluster/FailureOracle.h"
+#include "Logger/LogMacros.h"
 #include "Scheduler/Scheduler.h"
 #include "Scheduler/SchedulerFeature.h"
 
@@ -125,6 +129,7 @@ void FailureOracleImpl::stop() {
         << ex.what();
   }
 
+  std::unique_lock writeLock(_mutex);
   _flushJob->cancel();
 }
 
@@ -193,6 +198,11 @@ void FailureOracleImpl::scheduleFlush() noexcept {
     return;
   }
 
+  if (_clusterFeature.server().isStopping()) {
+    return;
+  }
+
+  std::unique_lock writeLock(_mutex);
   _flushJob = scheduler->queueDelayed(
       RequestLane::AGENCY_CLUSTER, 50s,
       [weak = weak_from_this()](bool canceled) {


### PR DESCRIPTION
### Scope & Purpose

Fixes a shutdown race detected by TSan.
Already fixed for 3.11/devel a while back via https://github.com/arangodb/arangodb/pull/17781

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: https://github.com/arangodb/arangodb/pull/17781
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 