### PR TITLE
do not restrict AQL cursor garbage collection too much

### DIFF
--- a/arangod/Utils/CursorRepository.h
+++ b/arangod/Utils/CursorRepository.h
@@ -97,7 +97,7 @@ class CursorRepository {
   Cursor* addCursor(std::unique_ptr<Cursor> cursor);
 
   /// @brief maximum number of cursors to garbage-collect in one go
-  static constexpr size_t maxCollectCount = 32;
+  static constexpr size_t maxCollectCount = 1024;
 
   TRI_vocbase_t& _vocbase;
 


### PR DESCRIPTION
### Scope & Purpose

Do not restrict AQL cursor garbage collection too much.
Otherwise it may have trouble keeping up with foreground query work, and cursors may pile up and consume lots of memory.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.11: https://github.com/arangodb/arangodb/pull/19994
  - [x] Backport for 3.10: https://github.com/arangodb/arangodb/pull/19995

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 