### PR TITLE
do not restrict AQL cursor garbage collection too much

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 v3.10.11 (XXXX-XX-XX)
 ---------------------
 
+* Make AQL query cursor garbage-collection clean up more expired cursors in a
+  single run than before. This change can help to reclaim memory of expired
+  cursors quicker than in previous versions.
+
 * Reduce number of atomic shared_ptr copies in in-memory cache subsystem.
 
 * Fixed BTS-1610: In certain situations with at least three levels of nested

--- a/arangod/Utils/CursorRepository.cpp
+++ b/arangod/Utils/CursorRepository.cpp
@@ -51,7 +51,7 @@ bool authorized(std::pair<arangodb::Cursor*, std::string> const& cursor) {
 
 using namespace arangodb;
 
-size_t const CursorRepository::MaxCollectCount = 32;
+size_t const CursorRepository::MaxCollectCount = 1024;
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief create a cursor repository


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/19993

Do not restrict AQL cursor garbage collection too much.
Otherwise it may have trouble keeping up with foreground query work, and cursors may pile up and consume lots of memory.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.11: https://github.com/arangodb/arangodb/pull/19994
  - [x] Backport for 3.10: this PR

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 