### PR TITLE
Disable one more replication2 test

### DIFF
--- a/tests/js/client/shell/transaction/shell-transaction-cluster.js
+++ b/tests/js/client/shell/transaction/shell-transaction-cluster.js
@@ -393,8 +393,8 @@ jsunity.run(transactionReplicationOnFollowersSuiteV1);
 
 if (isReplication2Enabled) {
   let suites = [
-    transactionReplication2ReplicateOperationSuite,
-    transactionReplicationOnFollowersSuiteV2,
+    //transactionReplication2ReplicateOperationSuite,
+    //transactionReplicationOnFollowersSuiteV2,
   ];
 
   for (const suite of suites) {


### PR DESCRIPTION
### Scope & Purpose

Follow-up to https://github.com/arangodb/arangodb/pull/19984
Also disabling the replication2 part of `shell-transaction-cluster.js`