### PR TITLE
Remove ManagedDoc and resolveExternals

### DIFF
--- a/arangod/Aql/Aggregator.cpp
+++ b/arangod/Aql/Aggregator.cpp
@@ -617,7 +617,7 @@ struct AggregatorUnique : public Aggregator {
   void reduce(AqlValue const& cmpValue) override {
     AqlValueMaterializer materializer(_vpackOptions);
 
-    VPackSlice s = materializer.slice(cmpValue, true);
+    VPackSlice s = materializer.slice(cmpValue);
 
     if (seen.contains(s)) {
       // already saw the same value
@@ -660,7 +660,7 @@ struct AggregatorUniqueStep2 final : public AggregatorUnique {
   void reduce(AqlValue const& cmpValue) override final {
     AqlValueMaterializer materializer(_vpackOptions);
 
-    VPackSlice s = materializer.slice(cmpValue, true);
+    VPackSlice s = materializer.slice(cmpValue);
 
     if (!s.isArray()) {
       return;
@@ -700,7 +700,7 @@ struct AggregatorSortedUnique : public Aggregator {
   void reduce(AqlValue const& cmpValue) override {
     AqlValueMaterializer materializer(_vpackOptions);
 
-    VPackSlice s = materializer.slice(cmpValue, true);
+    VPackSlice s = materializer.slice(cmpValue);
 
     if (seen.find(s) != seen.end()) {
       // already saw the same value
@@ -735,7 +735,7 @@ struct AggregatorSortedUniqueStep2 final : public AggregatorSortedUnique {
   void reduce(AqlValue const& cmpValue) override final {
     AqlValueMaterializer materializer(_vpackOptions);
 
-    VPackSlice s = materializer.slice(cmpValue, true);
+    VPackSlice s = materializer.slice(cmpValue);
 
     if (!s.isArray()) {
       return;
@@ -771,7 +771,7 @@ struct AggregatorCountDistinct : public Aggregator {
   void reduce(AqlValue const& cmpValue) override {
     AqlValueMaterializer materializer(_vpackOptions);
 
-    VPackSlice s = materializer.slice(cmpValue, true);
+    VPackSlice s = materializer.slice(cmpValue);
 
     if (seen.contains(s)) {
       // already saw the same value
@@ -832,7 +832,7 @@ struct AggregatorCountDistinctStep2 final : public AggregatorCountDistinct {
   void reduce(AqlValue const& cmpValue) override {
     AqlValueMaterializer materializer(_vpackOptions);
 
-    VPackSlice s = materializer.slice(cmpValue, true);
+    VPackSlice s = materializer.slice(cmpValue);
 
     if (!s.isArray()) {
       return;

--- a/arangod/Aql/AqlFunctionsInternalCache.cpp
+++ b/arangod/Aql/AqlFunctionsInternalCache.cpp
@@ -62,7 +62,7 @@ icu::RegexMatcher* AqlFunctionsInternalCache::buildSplitMatcher(
   std::string rx;
 
   AqlValueMaterializer materializer(opts);
-  VPackSlice slice = materializer.slice(splitExpression, false);
+  VPackSlice slice = materializer.slice(splitExpression);
   if (splitExpression.isArray()) {
     for (VPackSlice it : VPackArrayIterator(slice)) {
       if (!it.isString() || it.getStringLength() == 0) {

--- a/arangod/Aql/AqlItemBlock.cpp
+++ b/arangod/Aql/AqlItemBlock.cpp
@@ -804,8 +804,7 @@ void AqlItemBlock::toVelocyPack(size_t from, size_t to,
 
         if (it == table.end()) {
           currentState = Next;
-          a.toVelocyPack(trxOptions, raw, /*resolveExternals*/ false,
-                         /*allowUnindexed*/ true);
+          a.toVelocyPack(trxOptions, raw, /*allowUnindexed*/ true);
           table.try_emplace(a, pos++);
         } else {
           currentState = Positional;
@@ -870,8 +869,7 @@ void AqlItemBlock::rowToSimpleVPack(
     if (ref.isEmpty()) {
       builder.add(VPackSlice::noneSlice());
     } else {
-      ref.toVelocyPack(options, builder, /*resolveExternals*/ false,
-                       /*allowUnindexed*/ true);
+      ref.toVelocyPack(options, builder, /*allowUnindexed*/ true);
     }
   }
 }

--- a/arangod/Aql/AqlValue.h
+++ b/arangod/Aql/AqlValue.h
@@ -177,10 +177,9 @@ struct AqlValue final {
   /// PD - pointer data
   /// MO - memory origin
   /// ML - managed slice length
-  /// ID - isDocument flag
   /// XX - unused
   /// | 0  | 1  | 2  | 3  | 4  | 5  | 6  | 7  | 8  | 9  | 10 | 11 | 12 | 13 | 14 | 15 | Bytes
-  /// | AT | ID | XX | XX | XX | XX | XX | XX | PD | PD | PD | PD | PD | PD | PD | PD | VPACK_SLICE_POINTER
+  /// | AT | XX | XX | XX | XX | XX | XX | XX | PD | PD | PD | PD | PD | PD | PD | PD | VPACK_SLICE_POINTER
   /// | AT | MO | ML | ML | ML | ML | ML | ML | PD | PD | PD | PD | PD | PD | PD | PD | VPACK_MANAGED_SLICE
   /// | AT | XX | XX | XX | XX | XX | XX | XX | PD | PD | PD | PD | PD | PD | PD | PD | VPACK_MANAGED_STRING
   /// | AT | XX | XX | XX | XX | XX | XX | XX | PD | PD | PD | PD | PD | PD | PD | PD | RANGE
@@ -240,9 +239,7 @@ struct AqlValue final {
 
     // VPACK_SLICE_POINTER
     struct {
-      uint8_t padding;
-      uint8_t isManagedDoc;
-      uint8_t padding2[6];
+      uint8_t padding[8];
       uint8_t const* pointer;
     } slicePointerMeta;
     static_assert(sizeof(slicePointerMeta) == 16,
@@ -355,9 +352,6 @@ struct AqlValue final {
 
   /// @brief whether or not the value is a pointer
   bool isPointer() const noexcept;
-
-  /// @brief whether or not the value is an external manager document
-  bool isManagedDocument() const noexcept;
 
   /// @brief whether or not the value is a range
   bool isRange() const noexcept;
@@ -485,7 +479,6 @@ struct AqlValue final {
   /// @brief sets the value type
   void setType(AqlValueType type) noexcept;
 
-  template<bool isManagedDoc>
   void setPointer(uint8_t const* pointer) noexcept;
 
   /// @brief return the memory origin type for values of type

--- a/arangod/Aql/AqlValue.h
+++ b/arangod/Aql/AqlValue.h
@@ -434,11 +434,10 @@ struct AqlValue final {
 
   /// @brief materializes a value into the builder
   void toVelocyPack(velocypack::Options const*, velocypack::Builder&,
-                    bool resolveExternals, bool allowUnindexed) const;
+                    bool allowUnindexed) const;
 
   /// @brief materialize a value into a new one. this expands ranges
-  AqlValue materialize(velocypack::Options const*, bool& hasCopied,
-                       bool resolveExternals) const;
+  AqlValue materialize(velocypack::Options const*, bool& hasCopied) const;
 
   /// @brief return the slice for the value
   /// this will throw if the value type is not VPACK_SLICE_POINTER,
@@ -463,9 +462,7 @@ struct AqlValue final {
   static int Compare(velocypack::Options const*, AqlValue const& left,
                      AqlValue const& right, bool useUtf8);
 
-  /// @brief Returns the type of this value. If true it uses an external pointer
-  /// if false it uses the internal data structure.
-  /// Do not move it to cpp file as MSVC does not inline it.
+  /// @brief Returns the type of this value
   AqlValueType type() const noexcept {
     return static_cast<AqlValueType>(_data.aqlValueType);
   }

--- a/arangod/Aql/AqlValueMaterializer.cpp
+++ b/arangod/Aql/AqlValueMaterializer.cpp
@@ -32,7 +32,7 @@
 #include <velocypack/Slice.h>
 
 using namespace arangodb;
-using namespace arangodb::aql;
+using namespace aql;
 
 AqlValueMaterializer::AqlValueMaterializer(velocypack::Options const* options)
     : options(options), materialized(), hasCopied(false) {}
@@ -98,8 +98,7 @@ AqlValueMaterializer::~AqlValueMaterializer() {
   }
 }
 
-arangodb::velocypack::Slice AqlValueMaterializer::slice(AqlValue const& value,
-                                                        bool resolveExternals) {
-  materialized = value.materialize(options, hasCopied, resolveExternals);
+velocypack::Slice AqlValueMaterializer::slice(AqlValue const& value) {
+  materialized = value.materialize(options, hasCopied);
   return materialized.slice();
 }

--- a/arangod/Aql/AqlValueMaterializer.h
+++ b/arangod/Aql/AqlValueMaterializer.h
@@ -56,11 +56,10 @@ struct AqlValueMaterializer {
 
   ~AqlValueMaterializer();
 
-  arangodb::velocypack::Slice slice(arangodb::aql::AqlValue const& value,
-                                    bool resolveExternals);
+  velocypack::Slice slice(AqlValue const& value);
 
-  arangodb::velocypack::Options const* options;
-  arangodb::aql::AqlValue materialized;
+  velocypack::Options const* options;
+  AqlValue materialized;
   bool hasCopied;
 };
 

--- a/arangod/Aql/Ast.cpp
+++ b/arangod/Aql/Ast.cpp
@@ -3496,7 +3496,7 @@ AstNode* Ast::optimizeBinaryOperatorRelational(
 
   AqlValueMaterializer materializer(
       trx.transactionContextPtr()->getVPackOptions());
-  return nodeFromVPack(materializer.slice(a, false), true);
+  return nodeFromVPack(materializer.slice(a), true);
 }
 
 /// @brief optimizes the binary arithmetic operators +, -, *, / and %
@@ -3799,7 +3799,7 @@ AstNode* Ast::optimizeFunctionCall(
 
   AqlValueMaterializer materializer(
       trx.transactionContextPtr()->getVPackOptions());
-  return nodeFromVPack(materializer.slice(a, false), true);
+  return nodeFromVPack(materializer.slice(a), true);
 }
 
 /// @brief optimizes indexed access, e.g. a[0] or a['foo']

--- a/arangod/Aql/Expression.cpp
+++ b/arangod/Aql/Expression.cpp
@@ -666,7 +666,6 @@ AqlValue Expression::executeSimpleExpressionArray(ExpressionContext& ctx,
         executeSimpleExpression(ctx, member, localMustDestroy, false);
     AqlValueGuard guard(result, localMustDestroy);
     result.toVelocyPack(&trx.vpackOptions(), *builder.get(),
-                        /*resolveExternals*/ false,
                         /*allowUnindexed*/ false);
   }
 
@@ -721,7 +720,7 @@ AqlValue Expression::executeSimpleExpressionObject(ExpressionContext& ctx,
 
       // make sure key is a string, and convert it if not
       AqlValueMaterializer materializer(&vopts);
-      VPackSlice slice = materializer.slice(result, false);
+      VPackSlice slice = materializer.slice(result);
 
       buffer->clear();
       functions::Stringify(&vopts, adapter, slice);
@@ -780,8 +779,7 @@ AqlValue Expression::executeSimpleExpressionObject(ExpressionContext& ctx,
     AqlValue result =
         executeSimpleExpression(ctx, member, localMustDestroy, false);
     AqlValueGuard guard(result, localMustDestroy);
-    result.toVelocyPack(&vopts, *builder.get(), /*resolveExternals*/ false,
-                        /*allowUnindexed*/ false);
+    result.toVelocyPack(&vopts, *builder.get(), /*allowUnindexed*/ false);
   }
 
   builder->close();
@@ -1769,7 +1767,7 @@ AqlValue Expression::executeSimpleExpressionExpansion(ExpressionContext& ctx,
 
     AqlValueMaterializer materializer(&vopts);
     // register temporary variable in context
-    ctx.setVariable(variable, materializer.slice(item, false));
+    ctx.setVariable(variable, materializer.slice(item));
 
     bool takeItem = true;
 
@@ -1798,8 +1796,7 @@ AqlValue Expression::executeSimpleExpressionExpansion(ExpressionContext& ctx,
         if (!isBoolean) {
           AqlValue sub = executeSimpleExpression(ctx, projectionNode,
                                                  localMustDestroy, false);
-          sub.toVelocyPack(&vopts, builder, /*resolveExternals*/ true,
-                           /*allowUnindexed*/ false);
+          sub.toVelocyPack(&vopts, builder, /*allowUnindexed*/ false);
           if (localMustDestroy) {
             sub.destroy();
           }

--- a/arangod/Aql/FixedVarExpressionContext.cpp
+++ b/arangod/Aql/FixedVarExpressionContext.cpp
@@ -78,8 +78,7 @@ void FixedVarExpressionContext::serializeAllVariables(
   for (auto const& it : _vars) {
     builder.openArray();
     it.first->toVelocyPack(builder);
-    it.second.toVelocyPack(&opts, builder, /*resolveExternals*/ true,
-                           /*allowUnindexed*/ false);
+    it.second.toVelocyPack(&opts, builder, /*allowUnindexed*/ false);
     builder.close();
   }
 }

--- a/arangod/Aql/HashedCollectExecutor.cpp
+++ b/arangod/Aql/HashedCollectExecutor.cpp
@@ -445,7 +445,6 @@ void HashedCollectExecutor::addToIntoRegister(InputAqlItemRow const& input,
     // get result of INTO expression variable
     input.getValue(_infos.getExpressionRegister())
         .toVelocyPack(_infos.getVPackOptions(), builder,
-                      /*resolveExternals*/ false,
                       /*allowUnindexed*/ false);
   } else {
     // copy variables / keep variables into result register
@@ -454,7 +453,6 @@ void HashedCollectExecutor::addToIntoRegister(InputAqlItemRow const& input,
       builder.add(VPackValue(pair.first));
       input.getValue(pair.second)
           .toVelocyPack(_infos.getVPackOptions(), builder,
-                        /*resolveExternals*/ false,
                         /*allowUnindexed*/ false);
     }
     builder.close();

--- a/arangod/Aql/IndexExecutor.cpp
+++ b/arangod/Aql/IndexExecutor.cpp
@@ -735,7 +735,7 @@ void IndexExecutor::executeExpressions(InputAqlItemRow const& input) {
     AqlValueGuard guard(a, mustDestroy);
 
     AqlValueMaterializer materializer(&_trx.vpackOptions());
-    VPackSlice slice = materializer.slice(a, false);
+    VPackSlice slice = materializer.slice(a);
     AstNode* evaluatedNode = _ast.nodeFromVPack(slice, true);
 
     AstNode* tmp = condition;

--- a/arangod/Aql/Query.cpp
+++ b/arangod/Aql/Query.cpp
@@ -590,7 +590,6 @@ ExecutionState Query::execute(QueryResult& queryResult) {
 
               if (!val.isEmpty()) {
                 val.toVelocyPack(&vpackOpts, resultBuilder,
-                                 /*resolveExternals*/ useQueryCache,
                                  /*allowUnindexed*/ true);
               }
             }
@@ -827,9 +826,7 @@ QueryResultV8 Query::executeV8(v8::Isolate* isolate) {
                   .FromMaybe(false);
 
               if (useQueryCache) {
-                val.toVelocyPack(&vpackOpts, *builder,
-                                 /*resolveExternals*/ true,
-                                 /*allowUnindexed*/ true);
+                val.toVelocyPack(&vpackOpts, *builder, /*allowUnindexed*/ true);
               }
               memoryUsage += sizeof(v8::Value);
               if (val.requiresDestruction()) {

--- a/arangod/Aql/QueryCursor.cpp
+++ b/arangod/Aql/QueryCursor.cpp
@@ -420,8 +420,7 @@ ExecutionState QueryStreamCursor::writeResult(VPackBuilder& builder) {
         if (!value.isEmpty()) {  // ignore empty blocks (e.g. from UpdateBlock)
           uint64_t oldCapacity = buffer.capacity();
 
-          value.toVelocyPack(&vopts, builder, /*resolveExternals*/ false,
-                             /*allowUnindexed*/ true);
+          value.toVelocyPack(&vopts, builder, /*allowUnindexed*/ true);
           ++rowsWritten;
 
           // track memory usage

--- a/arangod/Aql/SortedCollectExecutor.cpp
+++ b/arangod/Aql/SortedCollectExecutor.cpp
@@ -171,7 +171,6 @@ void SortedCollectExecutor::CollectGroup::addLine(
       // compute the expression
       input.getValue(infos.getExpressionRegister())
           .toVelocyPack(infos.getVPackOptions(), _builder,
-                        /*resolveExternals*/ false,
                         /*allowUnindexed*/ false);
     } else {
       // copy variables / keep variables into result register
@@ -181,7 +180,6 @@ void SortedCollectExecutor::CollectGroup::addLine(
         _builder.add(VPackValue(pair.first));
         input.getValue(pair.second)
             .toVelocyPack(infos.getVPackOptions(), _builder,
-                          /*resolveExternals*/ false,
                           /*allowUnindexed*/ false);
       }
       _builder.close();
@@ -230,7 +228,6 @@ void SortedCollectExecutor::CollectGroup::groupValuesToArray(
   builder.openArray();
   for (auto const& value : groupValues) {
     value.toVelocyPack(infos.getVPackOptions(), builder,
-                       /*resolveExternals*/ false,
                        /*allowUnindexed*/ false);
   }
 

--- a/arangod/Aql/SubqueryEndExecutor.cpp
+++ b/arangod/Aql/SubqueryEndExecutor.cpp
@@ -155,7 +155,6 @@ void SubqueryEndExecutor::Accumulator::addValue(AqlValue const& value) {
 
   TRI_ASSERT(_builder.isOpenArray());
   value.toVelocyPack(_options, _builder,
-                     /*resolveExternals*/ false,
                      /*allowUnindexed*/ false);
   ++_numValues;
 

--- a/arangod/Aql/Variable.cpp
+++ b/arangod/Aql/Variable.cpp
@@ -91,8 +91,7 @@ void Variable::toVelocyPack(velocypack::Builder& builder,
 
   if (type() == Variable::Type::Const) {
     builder.add(VPackValue("constantValue"));
-    _constantValue.toVelocyPack(nullptr, builder, /*resolveExternals*/ false,
-                                /*allowUnindexed*/ true);
+    _constantValue.toVelocyPack(nullptr, builder, /*allowUnindexed*/ true);
   }
 }
 

--- a/arangod/Graph/BaseOptions.cpp
+++ b/arangod/Graph/BaseOptions.cpp
@@ -237,7 +237,7 @@ void BaseOptions::LookupInfo::calculateIndexExpressions(
     AqlValueGuard guard(a, mustDestroy);
 
     AqlValueMaterializer materializer(&(ctx.trx().vpackOptions()));
-    VPackSlice slice = materializer.slice(a, false);
+    VPackSlice slice = materializer.slice(a);
     AstNode* evaluatedNode = ast->nodeFromVPack(slice, true);
 
     AstNode* tmp = indexCondition;

--- a/arangod/Graph/Cursors/RefactoredSingleServerEdgeCursor.cpp
+++ b/arangod/Graph/Cursors/RefactoredSingleServerEdgeCursor.cpp
@@ -264,7 +264,7 @@ void RefactoredSingleServerEdgeCursor<
     AqlValueGuard guard(a, mustDestroy);
 
     AqlValueMaterializer materializer(&(ctx.trx().vpackOptions()));
-    VPackSlice slice = materializer.slice(a, false);
+    VPackSlice slice = materializer.slice(a);
     AstNode* evaluatedNode = ast->nodeFromVPack(slice, true);
 
     AstNode* tmp = _accessor->getCondition();

--- a/arangod/IResearch/AqlHelper.h
+++ b/arangod/IResearch/AqlHelper.h
@@ -350,9 +350,7 @@ class ScopedAqlValue : private irs::util::noncopyable {
   void toVelocyPack(velocypack::Builder& builder) const {
     _node->isConstant()
         ? _node->toVelocyPackValue(builder)
-        : _value.toVelocyPack(static_cast<velocypack::Options const*>(nullptr),
-                              builder, /*resoveExternals*/ false,
-                              /*allowUnindexed*/ false);
+        : _value.toVelocyPack(nullptr, builder, /*allowUnindexed*/ false);
   }
 
  private:

--- a/arangod/IResearch/IResearchFeature.cpp
+++ b/arangod/IResearch/IResearchFeature.cpp
@@ -198,7 +198,7 @@ aql::AqlValue contextFunc(aql::ExpressionContext* ctx, aql::AstNode const&,
   TRI_ASSERT(!args.empty());  // ensured by function signature
 
   aql::AqlValueMaterializer materializer(&ctx->trx().vpackOptions());
-  return aql::AqlValue{materializer.slice(args[0], true)};
+  return aql::AqlValue{materializer.slice(args[0])};
 }
 
 // Register invalid argument warning

--- a/arangod/VocBase/ComputedValues.cpp
+++ b/arangod/VocBase/ComputedValues.cpp
@@ -307,7 +307,7 @@ void ComputedValues::ComputedValue::computeAttribute(
 
   auto const& vopts = ctx.trx().vpackOptions();
   aql::AqlValueMaterializer materializer(&vopts);
-  output.add(_name, materializer.slice(result, false));
+  output.add(_name, materializer.slice(result));
 }
 
 ComputedValues::ComputedValues(TRI_vocbase_t& vocbase,

--- a/tests/Aql/AqlValueMemoryLayoutTest.cpp
+++ b/tests/Aql/AqlValueMemoryLayoutTest.cpp
@@ -45,7 +45,6 @@ void runChecksForNumber(AqlValue const& value, uint8_t const* expected) {
   EXPECT_FALSE(value.requiresDestruction());
   EXPECT_FALSE(value.isEmpty());
   EXPECT_FALSE(value.isPointer());
-  EXPECT_FALSE(value.isManagedDocument());
   EXPECT_FALSE(value.isRange());
   EXPECT_FALSE(value.isNone());
   EXPECT_FALSE(value.isNull(false));


### PR DESCRIPTION
### Scope & Purpose

It reduces complexity and speedup cases without externals.

ManagedDoc currently used inside execution block, for things like early pruning.
In such cases using slice with pointer almost same, exception is only some unrealistic cases like:
```
FOR d in c FILTER [d] == [...] RETURN ...
FOR d in c FILTER {"...": d} == {...} RETURN ...
```

TODO:
* remove AqlValueMaterializer
* remove most call resolveExternal(s)

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

