### PR TITLE
do not ignore `--javascript.*` startup options

### DIFF
--- a/lib/ProgramOptions/ProgramOptions.cpp
+++ b/lib/ProgramOptions/ProgramOptions.cpp
@@ -421,11 +421,13 @@ bool ProgramOptions::require(std::string const& name) {
   auto it = _sections.find(parts.first);
 
   if (it == _sections.end()) {
+#ifndef USE_V8
     if (modernized.starts_with("javascript.") ||
         modernized.starts_with("--javascript.")) {
       // hack: ignore all options starting with --javascript if V8 is disabled
       return true;
     }
+#endif
     unknownOption(modernized);
     return false;
   }
@@ -433,11 +435,13 @@ bool ProgramOptions::require(std::string const& name) {
   auto it2 = (*it).second.options.find(parts.second);
 
   if (it2 == (*it).second.options.end()) {
+#ifndef USE_V8
     if (modernized.starts_with("javascript.") ||
         modernized.starts_with("--javascript.")) {
       // hack: ignore all options starting with --javascript if V8 is disabled
       return true;
     }
+#endif
     unknownOption(modernized);
     return false;
   }
@@ -479,12 +483,14 @@ bool ProgramOptions::setValue(std::string const& name,
   auto it2 = (*it).second.options.find(parts.second);
 
   if (it2 == (*it).second.options.end()) {
+#ifndef USE_V8
     if (modernized.starts_with("javascript.") ||
         modernized.starts_with("--javascript.")) {
       // hack: ignore all options starting with --javascript if V8 is disabled
       _processingResult.touch(modernized);
       return true;
     }
+#endif
     unknownOption(modernized);
     return false;
   }
@@ -606,11 +612,13 @@ Option& ProgramOptions::addObsoleteOption(std::string const& name,
 bool ProgramOptions::requiresValue(std::string const& name) {
   std::string const& modernized = modernize(name);
 
+#ifndef USE_V8
   if (modernized.starts_with("javascript.") ||
       modernized.starts_with("--javascript.")) {
-    // hack: make all options starting with --javascript require a value
-    return true;
+    // hack: make all options starting with --javascript not require a value
+    return false;
   }
+#endif
 
   auto parts = Option::splitName(modernized);
   auto it = _sections.find(parts.first);


### PR DESCRIPTION
### Scope & Purpose

Do not ignore `--javascript.*` startup options when building with V8. The previous implementation accepted all `--javascript.*` startup options unconditionally even when V8 was enabled.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 