### PR TITLE
remove `_clusterId` member

### DIFF
--- a/arangod/Cluster/ClusterInfo.cpp
+++ b/arangod/Cluster/ClusterInfo.cpp
@@ -673,12 +673,6 @@ bool ClusterInfo::doesDatabaseExist(std::string_view databaseID) {
 ////////////////////////////////////////////////////////////////////////////////
 
 std::vector<DatabaseID> ClusterInfo::databases() {
-  std::vector<DatabaseID> result;
-
-  if (_clusterId.empty()) {
-    loadClusterId();
-  }
-
   if (!_planProt.isValid) {
     Result r = waitForPlan(1).get();
     if (r.fail()) {
@@ -706,6 +700,7 @@ std::vector<DatabaseID> ClusterInfo::databases() {
     expectedSize = _dbServers.size();
   }
 
+  std::vector<DatabaseID> result;
   {
     READ_LOCKER(readLockerPlanned, _planProt.lock);
     READ_LOCKER(readLockerCurrent, _currentProt.lock);
@@ -723,20 +718,6 @@ std::vector<DatabaseID> ClusterInfo::databases() {
   }
 
   return result;
-}
-
-/// @brief Load cluster ID
-void ClusterInfo::loadClusterId() {
-  // Contact agency for /<prefix>/Cluster
-
-  auto& agencyCache = _server.getFeature<ClusterFeature>().agencyCache();
-  auto [acb, index] = agencyCache.get("Cluster");
-
-  // Parse
-  VPackSlice slice = acb->slice();
-  if (slice.isString()) {
-    _clusterId = slice.copyString();
-  }
 }
 
 /// @brief create a new collecion object from the data, using the cache if

--- a/arangod/Cluster/ClusterInfo.h
+++ b/arangod/Cluster/ClusterInfo.h
@@ -984,7 +984,6 @@ class ClusterInfo final {
 
   Result waitForDatabaseInCurrent(CreateDatabaseInfo const& database,
                                   AgencyWriteTransaction const& trx);
-  void loadClusterId();
 
   void triggerWaiting(AssocMultiMap<uint64_t, futures::Promise<Result>>& mm,
                       uint64_t commitIndex);
@@ -1086,8 +1085,6 @@ class ClusterInfo final {
 
   FlatMapShared<pmr::DatabaseID, VPackBuilder> _plan;
   FlatMapShared<pmr::DatabaseID, VPackBuilder> _current;
-
-  std::string _clusterId;
 
   FlatMap<pmr::DatabaseID, VPackSlice>
       _plannedDatabases;  // from Plan/Databases


### PR DESCRIPTION
### Scope & Purpose

Remove `_clusterId` member.
This member was only populated once when querying the list of databases, but it was not used for anything afterwards. It was also not thread-safe.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 