### PR TITLE
fix query performance regression

### DIFF
--- a/arangod/Aql/IndexExecutor.cpp
+++ b/arangod/Aql/IndexExecutor.cpp
@@ -397,7 +397,8 @@ IndexExecutor::CursorReader::CursorReader(
             : infos.isLateMaterialized() ? Type::LateMaterialized
             : (!infos.getProduceResult() && !infos.getFilter()) ? Type::NoResult
             : (infos.getProjections().usesCoveringIndex(index) &&
-               infos.getFilterProjections().usesCoveringIndex(index))
+               (infos.getFilterProjections().usesCoveringIndex(index) ||
+                infos.getFilterProjections().empty()))
                 ? Type::Covering
             : infos.getFilterProjections().usesCoveringIndex(index)
                 ? Type::CoveringFilterOnly


### PR DESCRIPTION
### Scope & Purpose

Fix query performance regression for queries that used projections that were covered by indexes.
The regression was unintentionally introduced by d13e0a2232e4393a0e086ef7cae95b1091f284a3, and made queries with covering indexes not use projections from the index data.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

