### PR TITLE
Rename CircleCI Windows job

### DIFF
--- a/.circleci/base_config.yml
+++ b/.circleci/base_config.yml
@@ -553,7 +553,7 @@ workflows:
           requires:
             - build-ee-aarch64
 
-  windows-enterprise-pr:
+  windows-community-pr:
     jobs:
       - compile-windows:
           context:


### PR DESCRIPTION
At the moment we build the community instead of enterprise version.