### PR TITLE
Clean up collection if it was created successfully.

### DIFF
--- a/tests/js/client/active-failover/disconnected-leader-nonwindows-nocov-noasan.js
+++ b/tests/js/client/active-failover/disconnected-leader-nonwindows-nocov-noasan.js
@@ -344,6 +344,9 @@ function LeaderDisconnectedSuite() {
         // a new leader, this collection creation however will succeed.
         // unfortunately we cannot reliably test this here.
         db._create(cname + "2");
+        // also drop the collection, otherwise the testing framework will complain
+        // about a missing cleanup.
+        db[cname + "2"].drop();
       } catch (err) {
         assertEqual(errors.ERROR_CLUSTER_LEADERSHIP_CHALLENGE_ONGOING.code, err.errorNum, err);
       }


### PR DESCRIPTION
### Scope & Purpose
As the comment says, it might or might not happen that the collection `cname + "2"` is created. If it is created, the test does not bother cleaning it up. And the test framework complains about a missing cleanup.

Thus, create it and then delete it again.