### PR TITLE
[POC] Try to improve exclusive lock situations by letting exclusive locked operations pass.

### DIFF
--- a/arangod/RestHandler/RestDocumentHandler.cpp
+++ b/arangod/RestHandler/RestDocumentHandler.cpp
@@ -78,10 +78,25 @@ RequestLane RestDocumentHandler::lane() const {
       std::ignore = _request->value(
           StaticStrings::IsSynchronousReplicationString, isSyncReplication);
       if (isSyncReplication) {
+        static_assert(
+            PriorityRequestLane(RequestLane::SERVER_SYNCHRONOUS_REPLICATION) ==
+                RequestPriority::HIGH,
+            "invalid request lane priority");
         return RequestLane::SERVER_SYNCHRONOUS_REPLICATION;
         // This leads to the high queue, we want replication requests to be
         // executed with a higher prio than leader requests, even if they
         // are done from AQL.
+      }
+      bool hasTrxId = false;
+      std::ignore = _request->header(StaticStrings::TransactionId, hasTrxId);
+      if (hasTrxId) {
+        // If we have an existing transaction id, we will not be lazy-locking
+        // for write we want to avoid that we need to wait in line with
+        // operations that potentially need to wait until they could get a lock.
+        static_assert(PriorityRequestLane(RequestLane::CLUSTER_AQL_DOCUMENT) ==
+                          RequestPriority::MED,
+                      "invalid request lane priority");
+        return RequestLane::CLUSTER_AQL_DOCUMENT;
       }
 
       // fall through for not-GET, non-replication requests

--- a/arangod/RestHandler/RestTransactionHandler.h
+++ b/arangod/RestHandler/RestTransactionHandler.h
@@ -55,6 +55,12 @@ class RestTransactionHandler : public arangodb::RestVocbaseBaseHandler {
         // higher prio than leader requests, even if they are done from
         // AQL.
       }
+      auto const& type = _request->requestType();
+      if (type == rest::RequestType::PUT ||
+          type == rest::RequestType::DELETE_REQ) {
+        // Let Transaction Commit and abort move to Medium lane
+        return RequestLane::CONTINUATION;
+      }
     }
     return RequestLane::CLIENT_V8;
   }

--- a/lib/Basics/ReadWriteLock.cpp
+++ b/lib/Basics/ReadWriteLock.cpp
@@ -92,18 +92,21 @@ bool ReadWriteLock::tryLockWriteFor(std::chrono::microseconds timeout) {
   auto state = _state.fetch_sub(QUEUED_WRITER_INC, std::memory_order_relaxed) -
                QUEUED_WRITER_INC;
 
-  if (state == 0) {
-    // no queued writers and no locks acquired
-    // no more writers -> wake up any waiting readings
-    { std::lock_guard<std::mutex> guard(_reader_mutex); }
-    _readers_bell.notify_all();
-  } else if ((state & QUEUED_WRITER_MASK) != 0 && (state & WRITE_LOCK) == 0) {
-    // there are other writers waiting and the lock is not acquired -> wake up
-    // one of them
-    { std::lock_guard<std::mutex> guard(_writer_mutex); }
-    _writers_bell.notify_one();
+  if ((state & WRITE_LOCK) == 0) {
+    // No one was quick enough to already get the write lock.
+    // So we need to wake up someone.
+    if ((state & QUEUED_WRITER_MASK) != 0) {
+      // there are other writers waiting and the lock is not acquired -> wake up
+      // one of them
+      { std::lock_guard<std::mutex> guard(_writer_mutex); }
+      _writers_bell.notify_one();
+    } else {
+      // no queued writers and no locks acquired
+      // no more writers -> wake up any waiting readings
+      { std::lock_guard<std::mutex> guard(_reader_mutex); }
+      _readers_bell.notify_all();
+    }
   }
-
   return false;
 }
 


### PR DESCRIPTION
### Scope & Purpose

This PR contains 3 changes:

* BugFix in ReadWriteLocker: If we hold the ReadLock, then queue a Writer, then queue another Reader. If we then timeout the Writer, the queued Reader is not informed, and will not start working.
* Change: Move Transaction Commit/Abort onto a higher Scheduler lane. In a situation where we have an exclusive lock we may have all LOW prior entries wait for the Exclusive Lock to be released, and causing the Commit/Abort for this Lock to be queued.
* Change: Move Document operations with TransactionID to a higher lane. Those operations cannot do lazy locking for writes, therefore they do not have the potential to wait on locks. Idea here is again, if we have an Exclusive Transaction that we use, let the operation pass all operations that have to wait until the Exclusive transaction is completed.

NOTE: Tests are not added yet, so is the CHANGELOG. Right now this is a Proof of Concept only.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [x] GitHub issue / Jira ticket:
    - Fixes: https://arangodb.atlassian.net/browse/BTS-1668
    - avoids some situations of https://arangodb.atlassian.net/browse/BTS-1670 (no fix!)
- [ ] Design document: 

