### PR TITLE
Fixed BTS-1669

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,16 @@
 devel
 -----
 
+* Fixed BTS-1669 Transaction Manager returns Error if we Abort an Expired
+  Transaction.
+  There was a small time window of around 2 seconds in which aborting expired
+  transactions would return "transaction aborted" instead of returning success.
+  The time window was between when a transaction expired (according to its
+  TTL value) and when the transaction manager's garbage collection aborted
+  the transaction. The issue only happened for transactions which outlived
+  their TTL value and for which an abort operation was attempted in that
+  time window.
+
 * Change default value of arangodump startup option `--use-parallel-dump` 
   from `false` to `true`.
   This enables the more parallel dump procedure by default, which allows


### PR DESCRIPTION
### Scope & Purpose

https://arangodb.atlassian.net/browse/BTS-1669

* Fixed BTS-1669 Transaction Manager returns Error if we Abort an Expired Transaction. There was a small time window of around 2 seconds in which aborting expired transactions would return "transaction aborted" instead of returning success. The time window was between when a transaction expired (according to its TTL value) and when the transaction manager's garbage collection aborted the transaction. The issue only happened for transactions which outlived their TTL value and for which an abort operation was attempted in that time window.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [x] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.11: https://github.com/arangodb/arangodb/pull/20043
  - [x] Backport for 3.10: https://github.com/arangodb/arangodb/pull/20044

#### Related Information

- [ ] Docs PR: 
- [x] Enterprise PR: https://arangodb.atlassian.net/browse/BTS-1669
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 