### PR TITLE
Fixed BTS-1669

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,11 +5,10 @@ v3.11.5 (XXXX-XX-XX)
   Transaction.
   There was a small time window of around 2 seconds in which aborting expired
   transactions would return "transaction aborted" instead of returning success.
-  The time window was between when a transaction expired (according to its
-  TTL value) and when the transaction manager's garbage collection aborted
-  the transaction. The issue only happened for transactions which outlived
-  their TTL value and for which an abort operation was attempted in that
-  time window.
+  The time window was between when a transaction expired (according to its TTL
+  value) and when the transaction manager's garbage collection aborted the
+  transaction. The issue only happened for transactions which outlived their TTL
+  value and for which an abort operation was attempted in that time window.
 
 * Backport multiple fixes for the scheduler behavior during ArangoDB shutdown.
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,16 @@
 v3.11.5 (XXXX-XX-XX)
 --------------------
 
+* Fixed BTS-1669 Transaction Manager returns Error if we Abort an Expired
+  Transaction.
+  There was a small time window of around 2 seconds in which aborting expired
+  transactions would return "transaction aborted" instead of returning success.
+  The time window was between when a transaction expired (according to its
+  TTL value) and when the transaction manager's garbage collection aborted
+  the transaction. The issue only happened for transactions which outlived
+  their TTL value and for which an abort operation was attempted in that
+  time window.
+
 * Backport multiple fixes for the scheduler behavior during ArangoDB shutdown.
 
 * FE-374: Query UI - fix switching from table to JSON.

--- a/tests/Transaction/ManagerTest.cpp
+++ b/tests/Transaction/ManagerTest.cpp
@@ -24,6 +24,7 @@
 #include "Aql/Query.h"
 
 #include "Basics/ScopeGuard.h"
+#include "Basics/debugging.h"
 #include "Cluster/ServerState.h"
 #include "Rest/GeneralResponse.h"
 #include "Transaction/Manager.h"
@@ -599,3 +600,85 @@ TEST_F(TransactionManagerTest, permission_denied_forbidden) {
   Result res = mgr->ensureManagedTrx(vocbase, tid, json->slice(), false);
   ASSERT_EQ(res.errorNumber(), TRI_ERROR_FORBIDDEN);
 }
+
+#ifdef ARANGODB_ENABLE_FAILURE_TESTS
+TEST_F(TransactionManagerTest, expired_transaction) {
+  auto guard = scopeGuard([]() noexcept { TRI_ClearFailurePointsDebugging(); });
+
+  std::shared_ptr<LogicalCollection> coll;
+  {
+    auto json = VPackParser::fromJson("{ \"name\": \"testCollection\" }");
+    coll = vocbase.createCollection(json->slice());
+  }
+  ASSERT_NE(coll, nullptr);
+
+  auto json = arangodb::velocypack::Parser::fromJson(
+      "{ \"collections\":{\"write\": [\"testCollection\"]}}");
+
+  // disables garbage-collection
+  TRI_AddFailurePointDebugging("transaction::Manager::noGC");
+  // sets TTL for transaction to a very low value
+  TRI_AddFailurePointDebugging("transaction::Manager::shortTTL");
+  Result res = mgr->ensureManagedTrx(vocbase, tid, json->slice(), false);
+  ASSERT_TRUE(res.ok());
+
+  // wait until trx is expired
+  std::this_thread::sleep_for(std::chrono::milliseconds(150));
+
+  // we cannot use the transaction anymore
+  auto ctx = mgr->leaseManagedTrx(tid, AccessMode::Type::WRITE, false);
+  ASSERT_EQ(ctx.get(), nullptr);
+
+  // aborting it is fine though
+  res = mgr->abortManagedTrx(tid, vocbase.name());
+  ASSERT_TRUE(res.ok());
+
+  res = mgr->commitManagedTrx(tid, vocbase.name());
+  ASSERT_FALSE(res.ok());
+  ASSERT_EQ(TRI_ERROR_TRANSACTION_DISALLOWED_OPERATION, res.errorNumber());
+}
+#endif
+
+#ifdef ARANGODB_ENABLE_FAILURE_TESTS
+TEST_F(TransactionManagerTest, lock_usage_of_expired_transaction) {
+  auto guard = scopeGuard([]() noexcept { TRI_ClearFailurePointsDebugging(); });
+
+  std::shared_ptr<LogicalCollection> coll;
+  {
+    auto json = VPackParser::fromJson("{ \"name\": \"testCollection\" }");
+    coll = vocbase.createCollection(json->slice());
+  }
+  ASSERT_NE(coll, nullptr);
+
+  auto json1 = arangodb::velocypack::Parser::fromJson(
+      "{ \"collections\":{\"exclusive\": [\"testCollection\"]}}");
+
+  // sets TTL for transaction to a very low value
+  TRI_AddFailurePointDebugging("transaction::Manager::shortTTL");
+  Result res = mgr->ensureManagedTrx(vocbase, tid, json1->slice(), false);
+  ASSERT_TRUE(res.ok());
+
+  // wait until trx is expired
+  std::this_thread::sleep_for(std::chrono::milliseconds(150));
+
+  // we must now be able to open a second transaction on the
+  // underlying collection, at least after the garbage collection
+  mgr->garbageCollect(/*abortAll*/ false);
+
+  TRI_ClearFailurePointsDebugging();
+
+  TransactionId tid2 = TransactionId::createLeader();
+  auto json2 = arangodb::velocypack::Parser::fromJson(
+      "{ \"collections\":{\"write\": [\"testCollection\"]}}");
+  res = mgr->ensureManagedTrx(vocbase, tid2, json2->slice(), false);
+  ASSERT_TRUE(res.ok());
+
+  // aborting trx1 is still fine, even though it is expired
+  res = mgr->abortManagedTrx(tid, vocbase.name());
+  ASSERT_TRUE(res.ok());
+
+  // committing trx2 must be ok
+  res = mgr->commitManagedTrx(tid2, vocbase.name());
+  ASSERT_TRUE(res.ok());
+}
+#endif


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/20042

https://arangodb.atlassian.net/browse/BTS-1669

* Fixed BTS-1669 Transaction Manager returns Error if we Abort an Expired Transaction. There was a small time window of around 2 seconds in which aborting expired transactions would return "transaction aborted" instead of returning success. The time window was between when a transaction expired (according to its TTL value) and when the transaction manager's garbage collection aborted the transaction. The issue only happened for transactions which outlived their TTL value and for which an abort operation was attempted in that time window.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [x] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.11: https://github.com/arangodb/arangodb/pull/20043
  - [x] Backport for 3.10: https://github.com/arangodb/arangodb/pull/20044

#### Related Information

- [ ] Docs PR: 
- [x] Enterprise PR: https://arangodb.atlassian.net/browse/BTS-1669
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 