### PR TITLE
Fixed BTS-1669

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,15 +1,18 @@
-v3.10.11 (2023-10-19)
+v3.10.12 (XXXX-XX-XX)
 ---------------------
 
 * Fixed BTS-1669 Transaction Manager returns Error if we Abort an Expired
   Transaction.
   There was a small time window of around 2 seconds in which aborting expired
   transactions would return "transaction aborted" instead of returning success.
-  The time window was between when a transaction expired (according to its
-  TTL value) and when the transaction manager's garbage collection aborted
-  the transaction. The issue only happened for transactions which outlived
-  their TTL value and for which an abort operation was attempted in that
-  time window.
+  The time window was between when a transaction expired (according to its TTL
+  value) and when the transaction manager's garbage collection aborted the
+  transaction. The issue only happened for transactions which outlived their TTL
+  value and for which an abort operation was attempted in that time window.
+
+
+v3.10.11 (2023-10-19)
+---------------------
 
 * Fix a race in failure oracle feature on server shutdown.
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,16 @@
 v3.10.11 (2023-10-19)
 ---------------------
 
+* Fixed BTS-1669 Transaction Manager returns Error if we Abort an Expired
+  Transaction.
+  There was a small time window of around 2 seconds in which aborting expired
+  transactions would return "transaction aborted" instead of returning success.
+  The time window was between when a transaction expired (according to its
+  TTL value) and when the transaction manager's garbage collection aborted
+  the transaction. The issue only happened for transactions which outlived
+  their TTL value and for which an abort operation was attempted in that
+  time window.
+
 * Fix a race in failure oracle feature on server shutdown.
 
 * Updated OpenSSL to 3.0.11.

--- a/arangod/Transaction/Manager.cpp
+++ b/arangod/Transaction/Manager.cpp
@@ -126,6 +126,8 @@ uint64_t Manager::getActiveTransactionCount() {
 
 /*static*/ double Manager::ttlForType(ManagerFeature const& feature,
                                       Manager::MetaType type) {
+  TRI_IF_FAILURE("transaction::Manager::shortTTL") { return 0.1; }
+
   if (type == Manager::MetaType::Tombstone) {
     return tombstoneTTL;
   }
@@ -1108,7 +1110,7 @@ Result Manager::updateTransaction(TransactionId tid, transaction::Status status,
 
     if (mtrx.expired()) {
       // we will update the expire time of the tombstone shortly afterwards,
-      // so we need to store the fact that this transaction originally expired
+      // but we need to store the fact that this transaction originally expired
       wasExpired = true;
       status = transaction::Status::ABORTED;
     }
@@ -1181,8 +1183,6 @@ Result Manager::updateTransaction(TransactionId tid, transaction::Status status,
       // makes the leader drop us as a follower for all shards in the
       // transaction.
       res.reset(TRI_ERROR_CLUSTER_FOLLOWER_TRANSACTION_COMMIT_PERFORMED);
-    } else if (res.ok() && wasExpired) {
-      res.reset(TRI_ERROR_TRANSACTION_ABORTED);
     }
   }
   TRI_ASSERT(!trx.state()->isRunning());
@@ -1210,6 +1210,8 @@ void Manager::iterateManagedTrx(
 
 /// @brief collect forgotten transactions
 bool Manager::garbageCollect(bool abortAll) {
+  TRI_IF_FAILURE("transaction::Manager::noGC") { return false; }
+
   bool didWork = false;
   containers::SmallVector<TransactionId, 8> toAbort;
   containers::SmallVector<TransactionId, 8> toErase;

--- a/tests/Transaction/ManagerTest.cpp
+++ b/tests/Transaction/ManagerTest.cpp
@@ -24,6 +24,7 @@
 #include "Aql/Query.h"
 
 #include "Basics/ScopeGuard.h"
+#include "Basics/debugging.h"
 #include "Cluster/ServerState.h"
 #include "Rest/GeneralResponse.h"
 #include "Transaction/Manager.h"
@@ -600,3 +601,85 @@ TEST_F(TransactionManagerTest, permission_denied_forbidden) {
   Result res = mgr->ensureManagedTrx(vocbase, tid, json->slice(), false);
   ASSERT_EQ(res.errorNumber(), TRI_ERROR_FORBIDDEN);
 }
+
+#ifdef ARANGODB_ENABLE_FAILURE_TESTS
+TEST_F(TransactionManagerTest, expired_transaction) {
+  auto guard = scopeGuard([]() noexcept { TRI_ClearFailurePointsDebugging(); });
+
+  std::shared_ptr<LogicalCollection> coll;
+  {
+    auto json = VPackParser::fromJson("{ \"name\": \"testCollection\" }");
+    coll = vocbase.createCollection(json->slice());
+  }
+  ASSERT_NE(coll, nullptr);
+
+  auto json = arangodb::velocypack::Parser::fromJson(
+      "{ \"collections\":{\"write\": [\"testCollection\"]}}");
+
+  // disables garbage-collection
+  TRI_AddFailurePointDebugging("transaction::Manager::noGC");
+  // sets TTL for transaction to a very low value
+  TRI_AddFailurePointDebugging("transaction::Manager::shortTTL");
+  Result res = mgr->ensureManagedTrx(vocbase, tid, json->slice(), false);
+  ASSERT_TRUE(res.ok());
+
+  // wait until trx is expired
+  std::this_thread::sleep_for(std::chrono::milliseconds(150));
+
+  // we cannot use the transaction anymore
+  auto ctx = mgr->leaseManagedTrx(tid, AccessMode::Type::WRITE, false);
+  ASSERT_EQ(ctx.get(), nullptr);
+
+  // aborting it is fine though
+  res = mgr->abortManagedTrx(tid, vocbase.name());
+  ASSERT_TRUE(res.ok());
+
+  res = mgr->commitManagedTrx(tid, vocbase.name());
+  ASSERT_FALSE(res.ok());
+  ASSERT_EQ(TRI_ERROR_TRANSACTION_DISALLOWED_OPERATION, res.errorNumber());
+}
+#endif
+
+#ifdef ARANGODB_ENABLE_FAILURE_TESTS
+TEST_F(TransactionManagerTest, lock_usage_of_expired_transaction) {
+  auto guard = scopeGuard([]() noexcept { TRI_ClearFailurePointsDebugging(); });
+
+  std::shared_ptr<LogicalCollection> coll;
+  {
+    auto json = VPackParser::fromJson("{ \"name\": \"testCollection\" }");
+    coll = vocbase.createCollection(json->slice());
+  }
+  ASSERT_NE(coll, nullptr);
+
+  auto json1 = arangodb::velocypack::Parser::fromJson(
+      "{ \"collections\":{\"exclusive\": [\"testCollection\"]}}");
+
+  // sets TTL for transaction to a very low value
+  TRI_AddFailurePointDebugging("transaction::Manager::shortTTL");
+  Result res = mgr->ensureManagedTrx(vocbase, tid, json1->slice(), false);
+  ASSERT_TRUE(res.ok());
+
+  // wait until trx is expired
+  std::this_thread::sleep_for(std::chrono::milliseconds(150));
+
+  // we must now be able to open a second transaction on the
+  // underlying collection, at least after the garbage collection
+  mgr->garbageCollect(/*abortAll*/ false);
+
+  TRI_ClearFailurePointsDebugging();
+
+  TransactionId tid2 = TransactionId::createLeader();
+  auto json2 = arangodb::velocypack::Parser::fromJson(
+      "{ \"collections\":{\"write\": [\"testCollection\"]}}");
+  res = mgr->ensureManagedTrx(vocbase, tid2, json2->slice(), false);
+  ASSERT_TRUE(res.ok());
+
+  // aborting trx1 is still fine, even though it is expired
+  res = mgr->abortManagedTrx(tid, vocbase.name());
+  ASSERT_TRUE(res.ok());
+
+  // committing trx2 must be ok
+  res = mgr->commitManagedTrx(tid2, vocbase.name());
+  ASSERT_TRUE(res.ok());
+}
+#endif


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/20042

https://arangodb.atlassian.net/browse/BTS-1669

* Fixed BTS-1669 Transaction Manager returns Error if we Abort an Expired Transaction. There was a small time window of around 2 seconds in which aborting expired transactions would return "transaction aborted" instead of returning success. The time window was between when a transaction expired (according to its TTL value) and when the transaction manager's garbage collection aborted the transaction. The issue only happened for transactions which outlived their TTL value and for which an abort operation was attempted in that time window.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [x] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.11: https://github.com/arangodb/arangodb/pull/20043
  - [x] Backport for 3.10: https://github.com/arangodb/arangodb/pull/20044

#### Related Information

- [ ] Docs PR: 
- [x] Enterprise PR: https://arangodb.atlassian.net/browse/BTS-1669
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 