### PR TITLE
[POC] - reorder lane priorites

### DIFF
--- a/arangod/Aql/RestAqlHandler.cpp
+++ b/arangod/Aql/RestAqlHandler.cpp
@@ -834,7 +834,7 @@ RequestLane RestAqlHandler::lane() const {
   if (ServerState::instance()->isDBServer()) {
     bool isPartOfTransaction = false;
     // We do not care for the real value, enough if it is there.
-    std::ignore = _request->value(
+    std::ignore = _request->header(
         StaticStrings::TransactionId, isPartOfTransaction);
     if (isPartOfTransaction) {
       // If we are part of a transaction we already have all CollectionLocks

--- a/arangod/RestHandler/RestDocumentHandler.cpp
+++ b/arangod/RestHandler/RestDocumentHandler.cpp
@@ -78,25 +78,10 @@ RequestLane RestDocumentHandler::lane() const {
       std::ignore = _request->value(
           StaticStrings::IsSynchronousReplicationString, isSyncReplication);
       if (isSyncReplication) {
-        static_assert(
-            PriorityRequestLane(RequestLane::SERVER_SYNCHRONOUS_REPLICATION) ==
-                RequestPriority::HIGH,
-            "invalid request lane priority");
         return RequestLane::SERVER_SYNCHRONOUS_REPLICATION;
         // This leads to the high queue, we want replication requests to be
         // executed with a higher prio than leader requests, even if they
         // are done from AQL.
-      }
-      bool hasTrxId = false;
-      std::ignore = _request->header(StaticStrings::TransactionId, hasTrxId);
-      if (hasTrxId) {
-        // If we have an existing transaction id, we will not be lazy-locking
-        // for write we want to avoid that we need to wait in line with
-        // operations that potentially need to wait until they could get a lock.
-        static_assert(PriorityRequestLane(RequestLane::CLUSTER_AQL_DOCUMENT) ==
-                          RequestPriority::MED,
-                      "invalid request lane priority");
-        return RequestLane::CLUSTER_AQL_DOCUMENT;
       }
 
       // fall through for not-GET, non-replication requests

--- a/arangod/RestHandler/RestDocumentHandler.cpp
+++ b/arangod/RestHandler/RestDocumentHandler.cpp
@@ -89,7 +89,7 @@ RequestLane RestDocumentHandler::lane() const {
 
       bool isPartOfTransaction = false;
       // We do not care for the real value, enough if it is there.
-      std::ignore = _request->value(
+      std::ignore = _request->header(
           StaticStrings::TransactionId, isPartOfTransaction);
       if (isPartOfTransaction) {
         static_assert(PriorityRequestLane(RequestLane::CONTINUATION) ==

--- a/arangod/RestHandler/RestDocumentHandler.cpp
+++ b/arangod/RestHandler/RestDocumentHandler.cpp
@@ -87,25 +87,21 @@ RequestLane RestDocumentHandler::lane() const {
         // executed with a higher prio than leader requests, even if they
         // are done from AQL.
       }
+      bool hasTrxId = false;
+      std::ignore = _request->header(StaticStrings::TransactionId, hasTrxId);
+      if (hasTrxId) {
+        // If we have an existing transaction id, we will not be lazy-locking
+        // for write we want to avoid that we need to wait in line with
+        // operations that potentially need to wait until they could get a lock.
+        static_assert(PriorityRequestLane(RequestLane::CLUSTER_AQL_DOCUMENT) ==
+                          RequestPriority::MED,
+                      "invalid request lane priority");
+        return RequestLane::CLUSTER_AQL_DOCUMENT;
+      }
+
       // fall through for not-GET, non-replication requests
     }
   }
-
-  bool hasTrxId = false;
-  std::ignore = _request->header(StaticStrings::TransactionId, hasTrxId);
-  if (hasTrxId) {
-    // If we have an existing transaction id, we will not be lazy-locking
-    // for write we want to avoid that we need to wait in line with
-    // operations that potentially need to wait until they could get a lock.
-    // Note: On Coordinator this bypasses the ongoing low-priority-threshold
-    // on purpose. Such a request is required to complete an already
-    // started transaction.
-    static_assert(PriorityRequestLane(RequestLane::CLUSTER_AQL_DOCUMENT) ==
-                      RequestPriority::MED,
-                  "invalid request lane priority");
-    return RequestLane::CLUSTER_AQL_DOCUMENT;
-  }
-
   return RequestLane::CLIENT_SLOW;
 }
 

--- a/arangod/RestHandler/RestDocumentHandler.cpp
+++ b/arangod/RestHandler/RestDocumentHandler.cpp
@@ -78,10 +78,25 @@ RequestLane RestDocumentHandler::lane() const {
       std::ignore = _request->value(
           StaticStrings::IsSynchronousReplicationString, isSyncReplication);
       if (isSyncReplication) {
+        static_assert(
+            PriorityRequestLane(RequestLane::SERVER_SYNCHRONOUS_REPLICATION) ==
+                RequestPriority::HIGH,
+            "invalid request lane priority");
         return RequestLane::SERVER_SYNCHRONOUS_REPLICATION;
         // This leads to the high queue, we want replication requests to be
         // executed with a higher prio than leader requests, even if they
         // are done from AQL.
+      }
+      bool hasTrxId = false;
+      std::ignore = _request->header(StaticStrings::TransactionId, hasTrxId);
+      if (hasTrxId) {
+        // If we have an existing transaction id, we will not be lazy-locking
+        // for write we want to avoid that we need to wait in line with
+        // operations that potentially need to wait until they could get a lock.
+        static_assert(PriorityRequestLane(RequestLane::CLUSTER_AQL_DOCUMENT) ==
+                          RequestPriority::MED,
+                      "invalid request lane priority");
+        return RequestLane::CLUSTER_AQL_DOCUMENT;
       }
 
       // fall through for not-GET, non-replication requests

--- a/arangod/RestHandler/RestTransactionHandler.cpp
+++ b/arangod/RestHandler/RestTransactionHandler.cpp
@@ -100,6 +100,13 @@ RequestLane RestTransactionHandler::lane() const {
                       "invalid request lane priority");
         return RequestLane::CONTINUATION;
       }
+      default: {
+        // Not implemented, put it on high to get rid of it.
+        static_assert(PriorityRequestLane(RequestLane::CLUSTER_INTERNAL) ==
+                          RequestPriority::HIGH,
+                      "invalid request lane priority");
+        return RequestLane::CLUSTER_INTERNAL;
+      }
 
     }
   }

--- a/arangod/RestHandler/RestTransactionHandler.h
+++ b/arangod/RestHandler/RestTransactionHandler.h
@@ -55,12 +55,6 @@ class RestTransactionHandler : public arangodb::RestVocbaseBaseHandler {
         // higher prio than leader requests, even if they are done from
         // AQL.
       }
-      auto const& type = _request->requestType();
-      if (type == rest::RequestType::PUT ||
-          type == rest::RequestType::DELETE_REQ) {
-        // Let Transaction Commit and abort move to Medium lane
-        return RequestLane::CONTINUATION;
-      }
     }
     return RequestLane::CLIENT_V8;
   }

--- a/arangod/RestHandler/RestTransactionHandler.h
+++ b/arangod/RestHandler/RestTransactionHandler.h
@@ -59,15 +59,15 @@ class RestTransactionHandler : public arangodb::RestVocbaseBaseHandler {
         // higher prio than leader requests, even if they are done from
         // AQL.
       }
-      auto const& type = _request->requestType();
-      if (type == rest::RequestType::PUT ||
-          type == rest::RequestType::DELETE_REQ) {
-        // Let Transaction Commit and abort move to Medium lane
-        static_assert(PriorityRequestLane(RequestLane::CONTINUATION) ==
-                          RequestPriority::MED,
-                      "invalid request lane priority");
-        return RequestLane::CONTINUATION;
-      }
+    }
+    auto const& type = _request->requestType();
+    if (type == rest::RequestType::PUT ||
+        type == rest::RequestType::DELETE_REQ) {
+      // Let Transaction Commit and abort move to Medium lane
+      static_assert(PriorityRequestLane(RequestLane::CONTINUATION) ==
+                        RequestPriority::MED,
+                    "invalid request lane priority");
+      return RequestLane::CONTINUATION;
     }
     static_assert(
         PriorityRequestLane(RequestLane::CLIENT_V8) == RequestPriority::LOW,

--- a/arangod/RestHandler/RestTransactionHandler.h
+++ b/arangod/RestHandler/RestTransactionHandler.h
@@ -49,10 +49,6 @@ class RestTransactionHandler : public arangodb::RestVocbaseBaseHandler {
       std::ignore = _request->value(
           StaticStrings::IsSynchronousReplicationString, isSyncReplication);
       if (isSyncReplication) {
-        static_assert(
-            PriorityRequestLane(RequestLane::SERVER_SYNCHRONOUS_REPLICATION) ==
-                RequestPriority::HIGH,
-            "invalid request lane priority");
         return RequestLane::SERVER_SYNCHRONOUS_REPLICATION;
         // This leads to the high queue, we want replication requests (for
         // commit or abort in the El Cheapo case) to be executed with a
@@ -63,15 +59,9 @@ class RestTransactionHandler : public arangodb::RestVocbaseBaseHandler {
       if (type == rest::RequestType::PUT ||
           type == rest::RequestType::DELETE_REQ) {
         // Let Transaction Commit and abort move to Medium lane
-        static_assert(PriorityRequestLane(RequestLane::CONTINUATION) ==
-                          RequestPriority::MED,
-                      "invalid request lane priority");
         return RequestLane::CONTINUATION;
       }
     }
-    static_assert(
-        PriorityRequestLane(RequestLane::CLIENT_V8) == RequestPriority::LOW,
-        "invalid request lane priority");
     return RequestLane::CLIENT_V8;
   }
   RestStatus execute() override;

--- a/arangod/RestHandler/RestTransactionHandler.h
+++ b/arangod/RestHandler/RestTransactionHandler.h
@@ -59,15 +59,15 @@ class RestTransactionHandler : public arangodb::RestVocbaseBaseHandler {
         // higher prio than leader requests, even if they are done from
         // AQL.
       }
-    }
-    auto const& type = _request->requestType();
-    if (type == rest::RequestType::PUT ||
-        type == rest::RequestType::DELETE_REQ) {
-      // Let Transaction Commit and abort move to Medium lane
-      static_assert(PriorityRequestLane(RequestLane::CONTINUATION) ==
-                        RequestPriority::MED,
-                    "invalid request lane priority");
-      return RequestLane::CONTINUATION;
+      auto const& type = _request->requestType();
+      if (type == rest::RequestType::PUT ||
+          type == rest::RequestType::DELETE_REQ) {
+        // Let Transaction Commit and abort move to Medium lane
+        static_assert(PriorityRequestLane(RequestLane::CONTINUATION) ==
+                          RequestPriority::MED,
+                      "invalid request lane priority");
+        return RequestLane::CONTINUATION;
+      }
     }
     static_assert(
         PriorityRequestLane(RequestLane::CLIENT_V8) == RequestPriority::LOW,

--- a/arangod/RestHandler/RestTransactionHandler.h
+++ b/arangod/RestHandler/RestTransactionHandler.h
@@ -42,22 +42,7 @@ class RestTransactionHandler : public arangodb::RestVocbaseBaseHandler {
 
  public:
   char const* name() const override final { return "RestTransactionHandler"; }
-  RequestLane lane() const override final {
-    if (ServerState::instance()->isDBServer()) {
-      bool isSyncReplication = false;
-      // We do not care for the real value, enough if it is there.
-      std::ignore = _request->value(
-          StaticStrings::IsSynchronousReplicationString, isSyncReplication);
-      if (isSyncReplication) {
-        return RequestLane::SERVER_SYNCHRONOUS_REPLICATION;
-        // This leads to the high queue, we want replication requests (for
-        // commit or abort in the El Cheapo case) to be executed with a
-        // higher prio than leader requests, even if they are done from
-        // AQL.
-      }
-    }
-    return RequestLane::CLIENT_V8;
-  }
+  RequestLane lane() const override final;
   RestStatus execute() override;
   void cancel() override final;
 

--- a/arangod/RestHandler/RestTransactionHandler.h
+++ b/arangod/RestHandler/RestTransactionHandler.h
@@ -55,6 +55,12 @@ class RestTransactionHandler : public arangodb::RestVocbaseBaseHandler {
         // higher prio than leader requests, even if they are done from
         // AQL.
       }
+      auto const& type = _request->requestType();
+      if (type == rest::RequestType::PUT ||
+          type == rest::RequestType::DELETE_REQ) {
+        // Let Transaction Commit and abort move to Medium lane
+        return RequestLane::CONTINUATION;
+      }
     }
     return RequestLane::CLIENT_V8;
   }

--- a/lib/Basics/ReadWriteLock.cpp
+++ b/lib/Basics/ReadWriteLock.cpp
@@ -92,18 +92,21 @@ bool ReadWriteLock::tryLockWriteFor(std::chrono::microseconds timeout) {
   auto state = _state.fetch_sub(QUEUED_WRITER_INC, std::memory_order_relaxed) -
                QUEUED_WRITER_INC;
 
-  if (state == 0) {
-    // no queued writers and no locks acquired
-    // no more writers -> wake up any waiting readings
-    { std::lock_guard<std::mutex> guard(_reader_mutex); }
-    _readers_bell.notify_all();
-  } else if ((state & QUEUED_WRITER_MASK) != 0 && (state & WRITE_LOCK) == 0) {
-    // there are other writers waiting and the lock is not acquired -> wake up
-    // one of them
-    { std::lock_guard<std::mutex> guard(_writer_mutex); }
-    _writers_bell.notify_one();
+  if ((state & WRITE_LOCK) == 0) {
+    // No one was quick enough to already get the write lock.
+    // So we need to wake up someone.
+    if ((state & QUEUED_WRITER_MASK) != 0) {
+      // there are other writers waiting and the lock is not acquired -> wake up
+      // one of them
+      { std::lock_guard<std::mutex> guard(_writer_mutex); }
+      _writers_bell.notify_one();
+    } else {
+      // no queued writers and no locks acquired
+      // no more writers -> wake up any waiting readings
+      { std::lock_guard<std::mutex> guard(_reader_mutex); }
+      _readers_bell.notify_all();
+    }
   }
-
   return false;
 }
 


### PR DESCRIPTION
### Scope & Purpose

*This PR tries to reorder priority lanes such that all operations that require getting a CollectionLock are of lower priorities then all requests using the CollectionLock*

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

