### PR TITLE
Deal with race in leader change [BTS-1647][BTS-1658]

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,13 @@
 v3.11.5 (XXXX-XX-XX)
 --------------------
 
+* Fixed a race in controlled leader change which could lead to a situation 
+  in which a shard follower is dropped when the first write operation
+  happens. This fixes BTS-1647.
+
+* Fixed an unnecessary follower drop in controlled leader change, which will
+  speed up leader changes. This fixes BTS-1658.
+
 * Backport multiple fixes for the scheduler behavior during ArangoDB shutdown.
 
 * FE-374: Query UI - fix switching from table to JSON.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -415,6 +415,12 @@ Depending on the platform, ArangoDB tries to locate the temporary directory:
 - Windows: the [W32 API function GetTempPath()](https://msdn.microsoft.com/en-us/library/windows/desktop/aa364992%28v=vs.85%29.aspx) is called
 - all platforms: `--temp.path` overrules the above system provided settings.
 
+This can be used in tests if you need a place for temporary data in the
+file system, to which all instances in the cluster have access.
+
+Use `require("fs").getTempPath()` from JavaScript and `TRI_GetTempPath`
+from C++ to get a path for that place.
+
 ### Local Cluster Startup
 
 The scripts `scripts/startLocalCluster` helps you to quickly fire up a testing

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -415,11 +415,11 @@ Depending on the platform, ArangoDB tries to locate the temporary directory:
 - Windows: the [W32 API function GetTempPath()](https://msdn.microsoft.com/en-us/library/windows/desktop/aa364992%28v=vs.85%29.aspx) is called
 - all platforms: `--temp.path` overrules the above system provided settings.
 
-This can be used in tests if you need a place for temporary data in the
-file system, to which all instances in the cluster have access.
-
-Use `require("fs").getTempPath()` from JavaScript and `TRI_GetTempPath`
-from C++ to get a path for that place.
+Our testing framework uses this path in the cluster test cases to set an
+environment variable `ARANGOTEST_ROOT_DIR` which is global to the running
+cluster, but specific to the current test suite. You can access this as 
+`global.instanceManager.rootDir` in Javascript client tests and via the
+environment variable on the C++ level.
 
 ### Local Cluster Startup
 

--- a/arangod/Cluster/ClusterInfo.cpp
+++ b/arangod/Cluster/ClusterInfo.cpp
@@ -2180,14 +2180,15 @@ void ClusterInfo::loadCurrent() {
             collectionDataCurrent->servers(shardID)  // args
         );
 
+        // We do not expect the list of servers to be empty, but who knows???
+        std::string newLeader = servers->empty() ? "" : servers->front();
         newShardsToCurrentServers.insert_or_assign(std::move(shardID),
                                                    std::move(servers));
         TRI_IF_FAILURE("ClusterInfo::loadCurrentSeesLeader") {
-          if (!xx.empty()) {  // just in case
+          if (!newLeader.empty()) {
             std::string myShortName = ServerState::instance()->getShortName();
-            observeGlobalEvent(
-                "ClusterInfo::loadCurrentSeesLeader",
-                absl::StrCat(myShortName, ":", shardID, ":", xx[0]));
+            observeGlobalEvent("ClusterInfo::loadCurrentSeesLeader",
+                               myShortName + ":" + shardID + ":" + newLeader);
           }
         }
       }

--- a/arangod/Cluster/DBServerAgencySync.cpp
+++ b/arangod/Cluster/DBServerAgencySync.cpp
@@ -24,6 +24,7 @@
 #include "DBServerAgencySync.h"
 
 #include "ApplicationFeatures/ApplicationServer.h"
+#include "Basics/GlobalSerialization.h"
 #include "Basics/ScopeGuard.h"
 #include "Basics/StringUtils.h"
 #include "Basics/application-exit.h"
@@ -297,6 +298,11 @@ DBServerAgencySyncResult DBServerAgencySync::execute() {
     // locked *now*. Then `getLocalCollections`.
     currentShardLocks = mfeature.getShardLocks();
 
+    TRI_IF_FAILURE("Maintenance::BeforePhaseTwo") {
+      observeGlobalEvent("Maintenance::BeforePhaseTwo",
+                         ServerState::instance()->getShortName());
+    }
+
     local.clear();
     localLogs.clear();
     glc = getLocalCollections(dirty, local, localLogs);
@@ -318,6 +324,11 @@ DBServerAgencySyncResult DBServerAgencySync::execute() {
     tmp = arangodb::maintenance::phaseTwo(plan, current, currentIndex, dirty,
                                           local, serverId, mfeature, rb,
                                           currentShardLocks, localLogs);
+
+    TRI_IF_FAILURE("Maintenance::AfterPhaseTwo") {
+      observeGlobalEvent("Maintenance::AfterPhaseTwo",
+                         ServerState::instance()->getShortName());
+    }
 
     LOG_TOPIC("dfc54", TRACE, Logger::MAINTENANCE)
         << "DBServerAgencySync::phaseTwo done";

--- a/arangod/Cluster/SynchronizeShard.cpp
+++ b/arangod/Cluster/SynchronizeShard.cpp
@@ -26,6 +26,7 @@
 
 #include "Agency/AgencyStrings.h"
 #include "ApplicationFeatures/ApplicationServer.h"
+#include "Basics/GlobalSerialization.h"
 #include "Basics/ScopeGuard.h"
 #include "Basics/StringUtils.h"
 #include "Basics/TimeString.h"
@@ -39,6 +40,7 @@
 #include "Cluster/FollowerInfo.h"
 #include "Cluster/Maintenance.h"
 #include "Cluster/MaintenanceFeature.h"
+#include "Cluster/ResignShardLeadership.h"
 #include "Cluster/ReplicationTimeoutFeature.h"
 #include "Cluster/ServerState.h"
 #include "GeneralServer/AuthenticationFeature.h"
@@ -907,6 +909,14 @@ bool SynchronizeShard::first() {
       << "SynchronizeShard: synchronizing shard '" << database << "/" << shard
       << "' for central '" << database << "/" << planId << "'";
 
+  TRI_IF_FAILURE("SynchronizeShard::beginning") {
+    std::string shortName = ServerState::instance()->getShortName();
+    waitForGlobalEvent("SynchronizeShard::beginning",
+                       absl::StrCat(shortName, ":", shard));
+    waitForGlobalEvent("SynchronizeShard::beginning2",
+                       absl::StrCat(shortName, ":", shard));
+  }
+
   auto& clusterInfo =
       _feature.server().getFeature<ClusterFeature>().clusterInfo();
   auto const ourselves = arangodb::ServerState::instance()->getId();
@@ -1150,9 +1160,31 @@ bool SynchronizeShard::first() {
         config.add("verbose", VPackValue(false));
       }
 
+      TRI_IF_FAILURE("SynchronizeShard::beforeSetTheLeader") {
+        std::string shortName = ServerState::instance()->getShortName();
+        waitForGlobalEvent("SynchronizeShard::beforeSetTheLeader",
+                           absl::StrCat(shortName, ":", shard));
+      }
       // Configure the shard to follow the leader without any following
-      // term id:
+      // term id, this is necessary, such that no replication requests
+      // from synchronous replication can interfere with the initial
+      // synchronization, regardless of whether they come from an old
+      // leader or from the right leader with whom we want to synchronize.
+      // Note that it is possible that the proper leader thinks that we
+      // are in sync, but we still run this SynchronizeShard job, simply
+      // because it was scheduled earlier:
       collection->followers()->setTheLeader(leader);
+
+      // If we fail to get in sync with this task, then we want to make
+      // sure that the leader is reset to a known value, such that the
+      // Maintenance will trigger another SynchronizeShard job eventually:
+      ScopeGuard rollbackTheLeader([&]() noexcept {
+        collection->followers()->setTheLeader(
+            ResignShardLeadership::LeaderNotYetKnownString);
+        LOG_TOPIC("ca777", INFO, Logger::MAINTENANCE)
+            << "SynchronizeShard failed for shard " << collection->name()
+            << ", resetting shard leader to trigger new run.";
+      });
 
       startTime = std::chrono::system_clock::now();
 
@@ -1164,12 +1196,24 @@ bool SynchronizeShard::first() {
       auto const endTime = std::chrono::system_clock::now();
 
       // Long shard sync initialization
-      if (endTime - startTime > seconds(5)) {
+      if (endTime - startTime > seconds(15)) {
         LOG_TOPIC("ca7e3", INFO, Logger::MAINTENANCE)
-            << "synchronizeOneShard: long call to syncCollection for shard"
+            << "synchronizeOneShard: call to syncCollection for shard"
             << database << "/" << shard << " " << syncRes.errorMessage()
             << " start time: " << timepointToString(startTime)
-            << ", end time: " << timepointToString(endTime);
+            << ", end time: " << timepointToString(endTime) << ", duration: "
+            << std::chrono::duration_cast<std::chrono::seconds>(endTime -
+                                                                startTime)
+                   .count()
+            << " seconds.";
+      }
+
+      TRI_IF_FAILURE("SynchronizeShard::fail") {
+        LOG_TOPIC("ca778", INFO, Logger::MAINTENANCE)
+            << "SynchronizeShard failed for shard " << collection->name()
+            << " because of a failure point.";
+        result(TRI_ERROR_FAILED, "Failure point");
+        return false;
       }
 
       // If this did not work, then we cannot go on:
@@ -1186,7 +1230,7 @@ bool SynchronizeShard::first() {
         std::stringstream error;
         error << "could not initially synchronize shard " << database << "/"
               << shard << ": " << syncRes.errorMessage();
-        LOG_TOPIC("c1b31", DEBUG, Logger::MAINTENANCE)
+        LOG_TOPIC("c1b31", INFO, Logger::MAINTENANCE)
             << "SynchronizeOneShard: " << error.str();
 
         result(syncRes.errorNumber(), error.str());
@@ -1256,6 +1300,12 @@ bool SynchronizeShard::first() {
         result(res);
         return false;
       }
+
+      // Now that we have set the correct leader with the correct
+      // FollowerTermInfo, we must stop the rollbackTheLeader scope
+      // guard from wasting everything:
+      rollbackTheLeader.cancel();
+
     } catch (basics::Exception const& e) {
       // don't log errors for already dropped databases/collections
       if (e.code() != TRI_ERROR_ARANGO_DATABASE_NOT_FOUND &&

--- a/arangod/Cluster/SynchronizeShard.cpp
+++ b/arangod/Cluster/SynchronizeShard.cpp
@@ -911,10 +911,8 @@ bool SynchronizeShard::first() {
 
   TRI_IF_FAILURE("SynchronizeShard::beginning") {
     std::string shortName = ServerState::instance()->getShortName();
-    waitForGlobalEvent("SynchronizeShard::beginning",
-                       absl::StrCat(shortName, ":", shard));
-    waitForGlobalEvent("SynchronizeShard::beginning2",
-                       absl::StrCat(shortName, ":", shard));
+    waitForGlobalEvent("SynchronizeShard::beginning", shortName + ":" + shard);
+    waitForGlobalEvent("SynchronizeShard::beginning2", shortName + ":" + shard);
   }
 
   auto& clusterInfo =
@@ -1163,7 +1161,7 @@ bool SynchronizeShard::first() {
       TRI_IF_FAILURE("SynchronizeShard::beforeSetTheLeader") {
         std::string shortName = ServerState::instance()->getShortName();
         waitForGlobalEvent("SynchronizeShard::beforeSetTheLeader",
-                           absl::StrCat(shortName, ":", shard));
+                           shortName + ":" + shard);
       }
       // Configure the shard to follow the leader without any following
       // term id, this is necessary, such that no replication requests

--- a/arangod/Cluster/TakeoverShardLeadership.cpp
+++ b/arangod/Cluster/TakeoverShardLeadership.cpp
@@ -225,7 +225,7 @@ static void handleLeadership(uint64_t planIndex, LogicalCollection& collection,
     TRI_IF_FAILURE("HandleLeadership::before") {
       std::string shortName = ServerState::instance()->getShortName();
       waitForGlobalEvent("HandleLeadership::before",
-                         absl::StrCat(shortName, ":", collection.name()));
+                         shortName + ":" + collection.name());
     }
 
     if (!currentServers.empty()) {
@@ -253,7 +253,7 @@ static void handleLeadership(uint64_t planIndex, LogicalCollection& collection,
     TRI_IF_FAILURE("HandleLeadership::after") {
       std::string shortName = ServerState::instance()->getShortName();
       waitForGlobalEvent("HandleLeadership::after",
-                         absl::StrCat(shortName, ":", collection.name()));
+                         shortName + ":" + collection.name());
     }
   }
 }

--- a/arangod/RestHandler/RestReplicationHandler.cpp
+++ b/arangod/RestHandler/RestReplicationHandler.cpp
@@ -2735,6 +2735,12 @@ void RestReplicationHandler::handleCommandSetTheLeader() {
       arangodb::maintenance::ResignShardLeadership::LeaderNotYetKnownString) {
     // We have resigned, check that we are the old leader
     currentLeader = ServerState::instance()->getId();
+  } else {
+    auto pos = currentLeader.find(
+        '_');  // this separates the FollowingTermId // from the actual leader
+    if (pos != std::string::npos) {
+      currentLeader = currentLeader.substr(0, pos);
+    }
   }
 
   if (leaderId != currentLeader) {
@@ -2744,6 +2750,9 @@ void RestReplicationHandler::handleCommandSetTheLeader() {
     }
 
     if (!oldLeaderIdSlice.isEqualString(currentLeader)) {
+      LOG_TOPIC("aaee2", WARN, Logger::MAINTENANCE)
+          << "SetTheLeader: Old leader not as expected: oldLeaderIdSlice: "
+          << oldLeaderIdSlice.toJson() << ", currentLeader: " << currentLeader;
       generateError(rest::ResponseCode::FORBIDDEN, TRI_ERROR_FORBIDDEN,
                     "old leader not as expected");
       return;

--- a/js/client/modules/@arangodb/testutils/instance-manager.js
+++ b/js/client/modules/@arangodb/testutils/instance-manager.js
@@ -77,6 +77,7 @@ class instanceManager {
     this.addArgs = addArgs;
     this.tmpDir = tmpDir || fs.getTempPath();
     this.rootDir = fs.join(this.tmpDir, testname);
+    process.env['ARANGOTEST_ROOT_DIR'] = this.rootDir;
     this.options.agency = this.options.agency || this.options.cluster || this.options.activefailover;
     this.agencyConfig = new inst.agencyConfig(options, this);
     this.dumpedAgency = false;

--- a/lib/Basics/FileUtils.h
+++ b/lib/Basics/FileUtils.h
@@ -66,6 +66,12 @@ void spit(std::string const& filename, char const* ptr, size_t len,
 void spit(std::string const& filename, std::string const& content,
           bool sync = false);
 
+// appends to an existing file
+void appendToFile(std::string const& filename, char const* ptr, size_t len,
+                  bool sync = false);
+void appendToFile(std::string const& filename, std::string_view s,
+                  bool sync = false);
+
 // if a file could be removed returns TRI_ERROR_NO_ERROR.
 // otherwise, returns TRI_ERROR_SYS_ERROR and sets LastError.
 [[nodiscard]] ErrorCode remove(std::string const& fileName);

--- a/lib/Basics/GlobalSerialization.cpp
+++ b/lib/Basics/GlobalSerialization.cpp
@@ -1,0 +1,150 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2023-2023 ArangoDB GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Max Neunhoeffer
+////////////////////////////////////////////////////////////////////////////////
+
+#include "Basics/GlobalSerialization.h"
+
+#include <mutex>
+#include <thread>
+
+#include "Basics/FileUtils.h"
+#include "Basics/StringUtils.h"
+#include "Basics/files.h"
+#include "Logger/LogMacros.h"
+
+namespace arangodb {
+
+namespace {
+std::pair<std::string, std::string> findSLPProgramPaths() {
+  std::string path = "/tmp";
+  TRI_GETENV("ARANGOTEST_ROOT_DIR", path);
+  std::string progPath =
+      basics::FileUtils::buildFilename(path.c_str(), "globalSLP");
+  std::string pcPath =
+      basics::FileUtils::buildFilename(path.c_str(), "globalSLP_PC");
+  return std::pair(progPath, pcPath);
+}
+
+std::vector<std::string> readSLPProgram(std::string const& progPath) {
+  // Read program:
+  std::vector<std::string> progLines;
+  try {
+    std::string prog = arangodb::basics::FileUtils::slurp(progPath);
+    if (prog.empty()) {
+      return progLines;
+    }
+    progLines = arangodb::basics::StringUtils::split(prog, '\n');
+    progLines.pop_back();  // Ignore last line, since every line is
+                           // ended by \n.
+  } catch (std::exception const&) {
+    // No program, return empty
+  }
+  return progLines;
+}
+
+std::mutex globalSLPModificationMutex;
+
+}  // namespace
+
+void waitForGlobalEvent(std::string_view id, std::string_view selector) {
+  auto [progPath, pcPath] = findSLPProgramPaths();
+  std::vector<std::string> progLines = readSLPProgram(progPath);
+  if (progLines.empty()) {
+    return;
+  }
+  LOG_TOPIC("ace32", INFO, Logger::MAINTENANCE)
+      << "Waiting for global event " << id << " with selector " << selector
+      << "...";
+  while (true) {
+    // Read pc
+    std::vector<std::string> executedLines = readSLPProgram(pcPath);
+    if (executedLines.size() >= progLines.size()) {
+      return;  // program already finished
+    }
+    std::string current = progLines[executedLines.size()];
+    std::vector<std::string> parts =
+        arangodb::basics::StringUtils::split(current, ' ');
+    if (parts.size() >= 2 && id == parts[0] && selector == parts[1]) {
+      // Hurray! We can make progress:
+      if (parts.size() >= 3) {
+        LOG_TOPIC("ace33", INFO, Logger::MAINTENANCE)
+            << "Global event " << id << " with selector " << selector
+            << " and comment " << parts[2] << " has happened...";
+      } else {
+        LOG_TOPIC("ace34", INFO, Logger::MAINTENANCE)
+            << "Global event " << id << " with selector " << selector
+            << " has happened...";
+      }
+      current.push_back('\n');
+      try {
+        std::lock_guard<std::mutex> guard(globalSLPModificationMutex);
+        arangodb::basics::FileUtils::appendToFile(pcPath, current);
+      } catch (std::exception const&) {
+        // ignore
+      }
+      return;
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(300));
+  }
+}
+
+void observeGlobalEvent(std::string_view id, std::string_view selector) {
+  auto [progPath, pcPath] = findSLPProgramPaths();
+  std::vector<std::string> progLines = readSLPProgram(progPath);
+  if (progLines.empty()) {
+    return;
+  }
+  std::string path = TRI_GetTempPath();
+  LOG_TOPIC("ace35", INFO, Logger::MAINTENANCE)
+      << "Observing global event " << id << " with selector " << selector
+      << "...";
+  // Read pc
+  std::vector<std::string> executedLines = readSLPProgram(pcPath);
+  if (executedLines.size() >= progLines.size()) {
+    LOG_TOPIC("ace38", DEBUG, Logger::MAINTENANCE)
+        << "SLP has already finished";
+    return;  // program already finished
+  }
+  std::string current = progLines[executedLines.size()];
+  std::vector<std::string> parts =
+      arangodb::basics::StringUtils::split(current, ' ');
+  if (parts.size() >= 2 && id == parts[0] && selector == parts[1]) {
+    // Hurray! We can make progress:
+    if (parts.size() >= 3) {
+      LOG_TOPIC("ace36", INFO, Logger::MAINTENANCE)
+          << "Global event " << id << " with selector " << selector
+          << " and comment " << parts[2] << " was observed...";
+    } else {
+      LOG_TOPIC("ace37", INFO, Logger::MAINTENANCE)
+          << "Global event " << id << " with selector " << selector
+          << " was observed...";
+    }
+    current.push_back('\n');
+    try {
+      std::lock_guard<std::mutex> guard(globalSLPModificationMutex);
+      arangodb::basics::FileUtils::appendToFile(pcPath, current);
+    } catch (std::exception const&) {
+      // ignore
+    }
+  }
+}
+
+}  // namespace arangodb

--- a/lib/Basics/GlobalSerialization.h
+++ b/lib/Basics/GlobalSerialization.h
@@ -1,0 +1,97 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2023-2023 ArangoDB GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Max Neunhoeffer
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+// This functionality should only ever be used in test code and the
+// global synchronization points must only be in TRI_IF_FAILURE blocks.
+// Otherwise this could have catastrophic consequences for performance.
+// In particular should these synchronization primitimes never be used
+// to ensure proper logic!
+
+#include <string_view>
+
+namespace arangodb {
+
+// The following two functions can be used to serialize events globally
+// in a cluster. Note that this only works for "local" clusters, in which
+// all `arangod` instances share a common file system and use the same
+// temporary path. This is the typical situation for our integration tests.
+//
+// In such a test, one can specify a straight line program of events,
+// which provides the serialization which the test wants to stage.
+// Each line of the straight line program is of the form
+//
+//   <SOURCEID> <SELECTOR> <LABEL>
+//
+// The line must contain exactly 3 spaces separating the 3 parts. The
+// `<SOURCEID>` is an identifier used in the code to mark the code
+// place, it corresponds to the `id` argument in the functions below.
+// The `<SELECTOR>` is a string (without spaces) which can be used that
+// not every passing of the code place triggers. It can for example be
+// used to only trigger on a specific server or for a specific shard.
+// This corresponds to the `selector` argument in the functions below.
+// The `<LABEL>` part is only a label to indicate in logs, which line of
+// the straight line program was triggered.
+//
+// The serialization semantics are implemented as follows. The straight
+// line program resides in some file in the file system, to which all
+// `arangod` instances have access. It is called `globalSLP` and resides
+// in the temporary path (which can be specified by an environment variable).
+// In the same directory there is a file `globalSLP_PC`, which serves
+// as the program counter of the straight line program. This file is initially
+// empty and each line of the straight line program which is triggered,
+// is then appended to the file to track progress. In this way, there is
+// always a "next line" to be executed, which is the first line in
+// `globalSLP` which is not (yet) in `globalSLP_PC`.
+//
+// The semantics are as follows:
+//
+// If `waitForGlobalEvent` is called, then the SLP is read and it is
+// determined, if the current line matches `id` and `selector`. If not,
+// the function waits until it is. Once the current line matches the
+// current line is advanced by one, a log message is written and the
+// function returns. If the straight line program is completed (all
+// lines were triggered) or the `globalSLP_PC` file no longer exists,
+// then `waitForGlobalEvent` immediately returns with no further
+// action.
+//
+// If `observeGlobalEvent` is called, then the SLP is read and it is
+// determined, if the current line matches `id` and `selector`. If so,
+// the current line is advanced, otherwise it stays. In any case, the
+// function returns immediately.
+//
+// For an example test which uses this see
+//   tests/js/client/shell/shell-move-shard-sync-fail-cluster.js
+//
+// PLEASE NOTE THAT THIS APPROACH HAS SOME SERIOUS LIMITATIONS:
+//
+//  - this only works in **local** clusters, in which all arangod instances
+//    share the same file system and temporary path!
+//  - the SLP file is **global**, it resides in a path which contains
+//    the name of the test suite (e.g. shell-client), but should at some
+//    stage multiple tests in this suite run concurrently **in the same
+//    cluster**, this will break! Beware of this!
+
+void waitForGlobalEvent(std::string_view id, std::string_view selector);
+void observeGlobalEvent(std::string_view id, std::string_view selector);
+}  // namespace arangodb

--- a/lib/Basics/win-utils.cpp
+++ b/lib/Basics/win-utils.cpp
@@ -266,8 +266,7 @@ int TRI_OPEN_WIN32(char const* filename, int openFlags) {
     return -1;
   }
 
-  fileDescriptor = _open_osfhandle((intptr_t)(fileHandle),
-                                   (openFlags & O_ACCMODE) | _O_BINARY);
+  fileDescriptor = _open_osfhandle((intptr_t)(fileHandle), openFlags);
   return fileDescriptor;
 }
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -167,6 +167,7 @@ add_library(arango STATIC
   Basics/FeatureFlags.cpp
   Basics/FunctionUtils.cpp
   Basics/GlobalResourceMonitor.cpp
+  Basics/GlobalSerialization.cpp
   Basics/HybridLogicalClock.cpp
   Basics/IndexIter.h
   Basics/LdapUrlParser.cpp

--- a/tests/js/client/shell/shell-move-shard-sync-fail-cluster.js
+++ b/tests/js/client/shell/shell-move-shard-sync-fail-cluster.js
@@ -162,7 +162,6 @@ function moveShardSynchronizeShardFailureSuite() {
         debugSetFailAt(leaderEndpoint, "ClusterInfo::loadCurrentSeesLeader");
         debugSetFailAt(leaderEndpoint, "ClusterInfo::loadCurrentDone");
         debugSetFailAt(leaderEndpoint, "SynchronizeShard::fail");
-        console.error("Full SLP:", prog);
 
         // Now move the shard:
         let res = moveShard("_system", cn, collInfo.shard, collInfo.leader, collInfo.follower, false /* dontwait */);
@@ -175,7 +174,6 @@ function moveShardSynchronizeShardFailureSuite() {
           // Take care of some silly Windows magic which messes with my 
           // line ends.
           nrSteps = steps.length - 1;
-          console.error("executed steps in SLP:", steps);
           if (nrSteps === prog.length - 1) {
             break;
           }

--- a/tests/js/client/shell/shell-move-shard-sync-fail-cluster.js
+++ b/tests/js/client/shell/shell-move-shard-sync-fail-cluster.js
@@ -1,0 +1,202 @@
+/* jshint globalstrict:false, strict:false, maxlen: 200 */
+/* global fail, assertEqual, assertTrue, assertFalse, arango */
+
+// //////////////////////////////////////////////////////////////////////////////
+// / @brief Test failure of SynchronizeShard during leader change.
+// /
+// / DISCLAIMER
+// /
+// / Copyright 2023 ArangoDB GmbH, Cologne, Germany
+// /
+// / Licensed under the Apache License, Version 2.0 (the "License")
+// / you may not use this file except in compliance with the License.
+// / You may obtain a copy of the License at
+// /
+// /     http://www.apache.org/licenses/LICENSE-2.0
+// /
+// / Unless required by applicable law or agreed to in writing, software
+// / distributed under the License is distributed on an "AS IS" BASIS,
+// / WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// / See the License for the specific language governing permissions and
+// / limitations under the License.
+// /
+// / @author Max Neunhoeffer
+// //////////////////////////////////////////////////////////////////////////////
+
+const _ = require('lodash');
+const console = require('console');
+let jsunity = require('jsunity');
+let internal = require('internal');
+let arangodb = require('@arangodb');
+let fs = require('fs');
+let db = arangodb.db;
+let { debugCanUseFailAt, debugRemoveFailAt, debugSetFailAt, debugClearFailAt, waitForShardsInSync } = require('@arangodb/test-helper');
+
+function queryAgencyJob (id) {
+  let query = arango.GET(`/_admin/cluster/queryAgencyJob?id=${id}`);
+  if (query.status === "Finished") {
+    return {error: false, id, status: query.status};
+  }
+  return {error: true, errorMsg: "Did not find job.", id};
+}
+
+function getEndpointAndIdMap() {
+  const health = arango.GET("/_admin/cluster/health").Health;
+  const endpointMap = {};
+  const idMap = {};
+  for (let sid in health) {
+    endpointMap[health[sid].ShortName] = health[sid].Endpoint;
+    idMap[health[sid].ShortName] = sid;
+  }
+  return {endpointMap, idMap};
+}
+
+function createCollectionWithKnownLeaderAndFollower(cn) {
+  db._create(cn, {numberOfShards:1, replicationFactor:2});
+  // Get dbserver names first:
+  let { endpointMap, idMap } = getEndpointAndIdMap();
+  let plan = arango.GET("/_admin/cluster/shardDistribution").results[cn].Plan;
+  let shard = Object.keys(plan)[0];
+  let coordinator = "Coordinator0001";
+  let leader = plan[shard].leader;
+  let follower = plan[shard].followers[0];
+  return { endpointMap, idMap, coordinator, leader, follower, shard };
+}
+
+function moveShard(database, collection, shard, fromServer, toServer, dontwait) {
+  let body = {database, collection, shard, fromServer, toServer};
+  let result;
+  try {
+    result = arango.POST_RAW("/_admin/cluster/moveShard", body);
+  } catch (err) {
+    console.error(
+      "Exception for PUT /_admin/cluster/moveShard:", err.stack);
+    return false;
+  }
+  if (dontwait) {
+    return result;
+  }
+  // Now wait until the job we triggered is finished:
+  let count = 600;   // seconds
+  while (true) {
+    let job = queryAgencyJob(result.parsedBody.id);
+    if (job.error === false && job.status === "Finished") {
+      return result;
+    }
+    if (count-- < 0) {
+      console.error(
+        "Timeout in waiting for moveShard to complete: "
+        + JSON.stringify(body));
+      return false;
+    }
+    require("internal").wait(1.0);
+  }
+}
+
+function moveShardSynchronizeShardFailureSuite() {
+  'use strict';
+  const cn = 'UnitTestsMoveShardSyncShardFailure';
+
+  const setupTeardown = function () {
+    db._drop(cn);
+  };
+
+  return {
+    setUp: setupTeardown,
+    tearDown: setupTeardown,
+    
+    testMoveShardSynchronizeShardFailure: function() {
+      let collInfo = createCollectionWithKnownLeaderAndFollower(cn);
+      // We have a shard whose leader and follower is known to us.
+      
+      let followerEndpoint = collInfo.endpointMap[collInfo.follower];
+      let leaderEndpoint = collInfo.endpointMap[collInfo.leader];
+      let followerId = collInfo.idMap[collInfo.follower];
+      let slpPath = global.instanceManager.rootDir;
+      // C++ will find this directory via ARANGOTEST_ROOT_DIR from the
+      // environment.
+      let progPath = fs.join(slpPath, "globalSLP");
+      let pcPath = fs.join(slpPath, "globalSLP_PC");
+
+      try {
+        // Let's insert some documents:
+        let c = db._collection(cn);
+        for (let i = 0; i < 100; ++i) {
+          c.insert({Hallo:i});
+        }
+
+        // Deploy a straight line program to stage events:
+        // Note that `collInfo.leader` is the **old** leader and
+        // `collInfo.follower` is the **old** follower, whose roles 
+        // are supposed to swap during the moveShard!
+        // We want that first the old leader discovers a SynchronizeShard,
+        // and that then the new leader takes over shard leadership,
+        // tells its followers and reports to Current, and that **only then**
+        // the SynchrnoizeShard job is executed on the old leader (now 
+        // follower) and then fails.
+        let prog = [
+          `SynchronizeShard::beginning ${collInfo.leader}:${collInfo.shard} SynchronizeShardStarted`,
+          `HandleLeadership::before ${collInfo.follower}:${collInfo.shard} HandleLeadershipBefore`,
+          `HandleLeadership::after ${collInfo.follower}:${collInfo.shard} HandleLeadershipAfter`,
+          `Maintenance::BeforePhaseTwo ${collInfo.follower} LeaderSendsCurrent`,
+          `Maintenance::AfterPhaseTwo ${collInfo.follower} LeaderSentCurrent`,
+          `ClusterInfo::loadCurrentSeesLeader ${collInfo.leader}:${collInfo.shard}:${followerId} FollowerUpdatesCurrent`,
+          `ClusterInfo::loadCurrentDone ${collInfo.leader} FollowerHasUpdatedCurrent`,
+          `SynchronizeShard::beginning2 ${collInfo.leader}:${collInfo.shard} SynchronizeShardStartedContinuing`,
+          `SynchronizeShard::beforeSetTheLeader ${collInfo.leader}:${collInfo.shard} SynchronizeShardRunning`,
+          `SynchronizeShard::beginning ${collInfo.leader}:${collInfo.shard} SynchronizeShardStarted2`,
+          `SynchronizeShard::beginning2 ${collInfo.leader}:${collInfo.shard} SynchronizeShardStartedContinuing2`,
+          `SynchronizeShard::beforeSetTheLeader ${collInfo.leader}:${collInfo.shard} SynchronizeShardRunning2`,
+          ""  // want to have a new line at the end of the last line!
+        ];
+        fs.writeFileSync(progPath, prog.join("\n"));
+        fs.writeFileSync(pcPath, "");
+
+        // Activate failure points in leader and follower:
+        debugSetFailAt(followerEndpoint, "HandleLeadership::before");
+        debugSetFailAt(followerEndpoint, "HandleLeadership::after");
+        debugSetFailAt(followerEndpoint, "Maintenance::BeforePhaseTwo");
+        debugSetFailAt(followerEndpoint, "Maintenance::AfterPhaseTwo");
+        debugSetFailAt(leaderEndpoint, "SynchronizeShard::beginning");
+        debugSetFailAt(leaderEndpoint, "SynchronizeShard::beforeSetTheLeader");
+        debugSetFailAt(leaderEndpoint, "ClusterInfo::loadCurrentSeesLeader");
+        debugSetFailAt(leaderEndpoint, "ClusterInfo::loadCurrentDone");
+        debugSetFailAt(leaderEndpoint, "SynchronizeShard::fail");
+        console.error("Full SLP:", prog);
+
+        // Now move the shard:
+        let res = moveShard("_system", cn, collInfo.shard, collInfo.leader, collInfo.follower, false /* dontwait */);
+
+        // See if the program was executed:
+        let count = 0;
+        let nrSteps;
+        while (count <= 600) {
+          let steps = fs.readFileSync(pcPath).toString().split(/\r\n|\r|\n/g);
+          // Take care of some silly Windows magic which messes with my 
+          // line ends.
+          nrSteps = steps.length - 1;
+          console.error("executed steps in SLP:", steps);
+          if (nrSteps === prog.length - 1) {
+            break;
+          }
+          count += 1;
+          internal.wait(1);
+        }
+        assertEqual(nrSteps, prog.length - 1);
+      } finally {
+        // Remove program and failure points:
+        fs.remove(progPath);
+        fs.remove(pcPath);
+        debugClearFailAt(leaderEndpoint);
+        debugClearFailAt(followerEndpoint);
+      }
+    },
+    
+  };
+}
+
+if (db._properties().replicationVersion !== "2" &&
+    internal.debugCanUseFailAt()) {
+  jsunity.run(moveShardSynchronizeShardFailureSuite);
+}
+return jsunity.done();


### PR DESCRIPTION
### Scope & Purpose

This deals with https://arangodb.atlassian.net/browse/BTS-1647.

This is a backport of https://github.com/arangodb/arangodb/pull/19996

Short problem description:

Due to a race during moveShard for leader change it is possible that a shard gets into a state such that both leader and follower believe they are in sync, but the FollowerTermId is incorrectly set in the follower. This means that the follower is dropped on the first write operation to the shard.

This PR fixes this by properly cleaning up `_theLeader` on the follower in case of an error.

Furthermore, we ensure that something is logged on INFO level whenever a shard synchronization fails. This is crucial for debugging.

Testing this is tricky. Therefore we introduce a new system to serialize events in a local cluster globally. This is implemented in
```
  lib/Basics/GlobalSerialization.h
  lib/Basics/GlobalSerialization.cpp
```
and can be used to stage test scenarios that depend on such a global event order.

Finally, this fixes a second problem in leader change. If A was leader and B and C follower, and we switch from leader A to B, then C was never adopted as new follower and had to resync. This is due to a wrong check for the old leader, which is fixed now. I did not find a way to reliably test this, since very occasionally it can happen that due to some sequence of events a `SynchronizeShard` is triggered in this situation.


- [*] :hankey: Bugfix

### Checklist

- [*] Tests
  - [*] **Regression tests**
  - [*] **integration tests**
- [*] :book: CHANGELOG entry made
- [*] Backports
  - [*] Backport for 3.11: this is it

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [*] Enterprise PR: - 
- [*] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/BTS-1647.
- [*] Devel PR: https://github.com/arangodb/arangodb/pull/19996


