### PR TITLE
simplify execution block setup

### DIFF
--- a/arangod/Aql/AqlCallStack.cpp
+++ b/arangod/Aql/AqlCallStack.cpp
@@ -35,6 +35,8 @@
 using namespace arangodb;
 using namespace arangodb::aql;
 
+AqlCallStack::AqlCallStack(AqlCallStack::Empty) {}
+
 AqlCallStack::AqlCallStack(AqlCallList call) : _operations{{std::move(call)}} {}
 
 AqlCallStack::AqlCallStack(AqlCallStack const& other, AqlCallList call)

--- a/arangod/Aql/AqlCallStack.h
+++ b/arangod/Aql/AqlCallStack.h
@@ -50,7 +50,10 @@ namespace aql {
  */
 class AqlCallStack {
  public:
+  struct Empty {};
+
   // Initial
+  explicit AqlCallStack(Empty);
   explicit AqlCallStack(AqlCallList call);
   // Used in subquery
   AqlCallStack(AqlCallStack const& other, AqlCallList call);

--- a/arangod/Aql/ExecutionBlock.cpp
+++ b/arangod/Aql/ExecutionBlock.cpp
@@ -79,7 +79,6 @@ ExecutionBlock::ExecutionBlock(ExecutionEngine* engine, ExecutionNode const* ep)
     : _engine(engine),
       _upstreamState(ExecutionState::HASMORE),
       _exeNode(ep),
-      _dependencies(),
       _dependencyPos(_dependencies.end()),
       _profileLevel(engine->getQuery().queryOptions().getProfileLevel()),
       _startOfExecution(-1.0),

--- a/arangod/Aql/ExecutionBlockImpl.tpp
+++ b/arangod/Aql/ExecutionBlockImpl.tpp
@@ -304,12 +304,8 @@ ExecutionBlockImpl<Executor>::ExecutionBlockImpl(
       _lastRange{MainQueryState::HASMORE},
       _upstreamRequest{},
       _clientRequest{},
-      _stackBeforeWaiting{AqlCallList{AqlCall{}}},
+      _stackBeforeWaiting{AqlCallStack::Empty{}},
       _hasUsedDataRangeBlock{false} {
-  // Break the stack before waiting.
-  // We should not use this here.
-  _stackBeforeWaiting.popCall();
-
   if (_exeNode->isCallstackSplitEnabled()) {
     _callstackSplit = std::make_unique<CallstackSplit>(*this);
   }


### PR DESCRIPTION
### Scope & Purpose

instead of setting up the execution block with a callstack with one item and then immediately discarding the item from the callstack, we can set up the execution block with an empty callstack.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 