### PR TITLE
Extract projections in registers - Index

### DIFF
--- a/arangod/Aql/ClusterNodes.cpp
+++ b/arangod/Aql/ClusterNodes.cpp
@@ -641,7 +641,6 @@ void GatherNode::replaceVariables(
     std::unordered_map<VariableId, Variable const*> const& replacements) {
   for (auto& it : _elements) {
     it.var = Variable::replace(it.var, replacements);
-    it.var = v;
     it.attributePath.clear();
   }
 }

--- a/arangod/Aql/ClusterNodes.cpp
+++ b/arangod/Aql/ClusterNodes.cpp
@@ -21,11 +21,6 @@
 /// @author Max Neunhoeffer
 ////////////////////////////////////////////////////////////////////////////////
 
-#include <string_view>
-#include <type_traits>
-
-#include <velocypack/Iterator.h>
-
 #include "ClusterNodes.h"
 
 #include "ApplicationFeatures/ApplicationServer.h"
@@ -56,8 +51,12 @@
 #include "Basics/StaticStrings.h"
 #include "Basics/VelocyPackHelper.h"
 #include "Cluster/ServerState.h"
-#include "Logger/LogMacros.h"
 #include "Transaction/Methods.h"
+
+#include <velocypack/Iterator.h>
+
+#include <string_view>
+#include <type_traits>
 
 using namespace arangodb;
 using namespace arangodb::basics;
@@ -642,9 +641,7 @@ void GatherNode::replaceVariables(
     std::unordered_map<VariableId, Variable const*> const& replacements) {
   for (auto& it : _elements) {
     auto v = Variable::replace(it.var, replacements);
-    if (v != it.var) {
-      it.var = v;
-    }
+    it.var = v;
     it.attributePath.clear();
   }
 }
@@ -653,7 +650,24 @@ void GatherNode::replaceAttributeAccess(ExecutionNode const* self,
                                         Variable const* searchVariable,
                                         std::span<std::string_view> attribute,
                                         Variable const* replaceVariable) {
-  // TODO!!!
+  auto equal = [](auto const& v1, auto const& v2) {
+    size_t n = v1.size();
+    if (n != v2.size()) {
+      return false;
+    }
+    for (size_t i = 0; i < n; ++i) {
+      if (v1[i] != v2[i]) {
+        return false;
+      }
+    }
+    return true;
+  };
+  for (auto& it : _elements) {
+    if (it.var == searchVariable && equal(it.attributePath, attribute)) {
+      it.var = replaceVariable;
+      it.attributePath.clear();
+    }
+  }
 }
 
 void GatherNode::getVariablesUsedHere(VarSet& vars) const {

--- a/arangod/Aql/ClusterNodes.cpp
+++ b/arangod/Aql/ClusterNodes.cpp
@@ -640,7 +640,7 @@ GatherNode::Parallelism GatherNode::evaluateParallelism(
 void GatherNode::replaceVariables(
     std::unordered_map<VariableId, Variable const*> const& replacements) {
   for (auto& it : _elements) {
-    auto v = Variable::replace(it.var, replacements);
+    it.var = Variable::replace(it.var, replacements);
     it.var = v;
     it.attributePath.clear();
   }

--- a/arangod/Aql/ClusterNodes.cpp
+++ b/arangod/Aql/ClusterNodes.cpp
@@ -649,7 +649,8 @@ void GatherNode::replaceVariables(
 void GatherNode::replaceAttributeAccess(ExecutionNode const* self,
                                         Variable const* searchVariable,
                                         std::span<std::string_view> attribute,
-                                        Variable const* replaceVariable) {
+                                        Variable const* replaceVariable,
+                                        size_t /*index*/) {
   auto equal = [](auto const& v1, auto const& v2) {
     size_t n = v1.size();
     if (n != v2.size()) {

--- a/arangod/Aql/ClusterNodes.h
+++ b/arangod/Aql/ClusterNodes.h
@@ -315,7 +315,8 @@ class GatherNode final : public ExecutionNode {
   void replaceAttributeAccess(ExecutionNode const* self,
                               Variable const* searchVariable,
                               std::span<std::string_view> attribute,
-                              Variable const* replaceVariable) override;
+                              Variable const* replaceVariable,
+                              size_t index) override;
 
   /// @brief getVariablesUsedHere, modifying the set in-place
   void getVariablesUsedHere(VarSet& vars) const override final;

--- a/arangod/Aql/DocumentExpressionContext.cpp
+++ b/arangod/Aql/DocumentExpressionContext.cpp
@@ -26,6 +26,7 @@
 #include "Aql/AqlValue.h"
 #include "Aql/InputAqlItemRow.h"
 #include "Aql/Variable.h"
+#include "Basics/system-compiler.h"
 
 using namespace arangodb::aql;
 
@@ -89,9 +90,11 @@ AqlValue GenericDocumentExpressionContext::getVariableValue(
         TRI_ASSERT(regId != RegisterId::maxRegisterId)
             << "variable " << variable->name << " (" << variable->id
             << ") not found";
-        if (regId != RegisterId::maxRegisterId) {
+        if (ADB_LIKELY(regId != RegisterId::maxRegisterId)) {
           // we can only get here in a post-filter expression
-          TRI_ASSERT(regId < _inputRow.getNumRegisters());
+          TRI_ASSERT(regId < _inputRow.getNumRegisters())
+              << "variable " << variable->name << " (" << variable->id
+              << "), register " << regId.value() << " not found";
           if (doCopy) {
             return _inputRow.getValue(regId).clone();
           }

--- a/arangod/Aql/DocumentProducingHelper.cpp
+++ b/arangod/Aql/DocumentProducingHelper.cpp
@@ -38,9 +38,6 @@
 #include "Transaction/Methods.h"
 #include "VocBase/LogicalCollection.h"
 
-#define DO_LOG 0
-#include "Logger/LogMacros.h"
-
 #include <function2.hpp>
 #include <velocypack/Builder.h>
 #include <velocypack/Slice.h>
@@ -63,11 +60,6 @@ IndexIterator::DocumentCallback aql::getCallback(
       }
     }
 
-#if DO_LOG
-    LOG_DEVEL << "GETCALLBACK - WITH PROJECTIONS NOT COVERED BY INDEX "
-              << slice.toJson();
-#endif
-
     context.incrScanned();
 
     if (context.hasFilter() && !context.checkFilter(slice)) {
@@ -84,9 +76,6 @@ IndexIterator::DocumentCallback aql::getCallback(
     TRI_ASSERT(!output.isFull());
 
     if (context.getProjectionsForRegisters().empty()) {
-#if DO_LOG
-      LOG_DEVEL << "GET CALLBACK - NO REGISTERS";
-#endif
       // write all projections combined into the global output register
       // recycle our Builder object
       VPackBuilder& objectBuilder = context.getBuilder();
@@ -100,9 +89,6 @@ IndexIterator::DocumentCallback aql::getCallback(
       RegisterId registerId = context.getOutputRegister();
       output.moveValueInto(registerId, input, s);
     } else {
-#if DO_LOG
-      LOG_DEVEL << "GET CALLBACK - WITH REGISTERS";
-#endif
       // write projections into individual output registers
       context.getProjectionsForRegisters().produceFromDocument(
           context.getBuilder(), slice, context.getTrxPtr(),
@@ -135,10 +121,6 @@ IndexIterator::DocumentCallback aql::getCallback(
       }
     }
 
-#if DO_LOG
-    LOG_DEVEL << "GETCALLBACK - DOCUMENTCOPY";
-#endif
-
     context.incrScanned();
 
     if (context.hasFilter() && !context.checkFilter(s)) {
@@ -150,9 +132,6 @@ IndexIterator::DocumentCallback aql::getCallback(
       return true;
     }
 
-#if DO_LOG
-    LOG_DEVEL << "FULL COPY";
-#endif
     InputAqlItemRow const& input = context.getInputRow();
     OutputAqlItemRow& output = context.getOutputRow();
     RegisterId registerId = context.getOutputRegister();
@@ -200,10 +179,6 @@ IndexIterator::LocalDocumentIdCallback aql::getNullCallback(
         return false;
       }
     }
-
-#if DO_LOG
-    LOG_DEVEL << "GETNULLCALLBACK";
-#endif
 
     context.incrScanned();
 
@@ -554,10 +529,6 @@ IndexIterator::CoveringCallback aql::getCallback(
       }
     }
 
-#if DO_LOG
-    LOG_DEVEL << "GETCALLBACK - WITHPROJECTIONSCOVEREDBYINDEX";
-#endif
-
     context.incrScanned();
 
     if (context.hasFilter() && !context.checkFilter(&covering)) {
@@ -570,9 +541,6 @@ IndexIterator::CoveringCallback aql::getCallback(
       InputAqlItemRow const& input = context.getInputRow();
 
       if (context.getProjectionsForRegisters().empty()) {
-#if DO_LOG
-        LOG_DEVEL << "PROJECTIONS COVERED BY INDEX - NO REGS";
-#endif
         // write all projections combined into the global output register
         // recycle our Builder object
         VPackBuilder& objectBuilder = context.getBuilder();
@@ -590,9 +558,6 @@ IndexIterator::CoveringCallback aql::getCallback(
         VPackSlice s = objectBuilder.slice();
         output.moveValueInto(registerId, input, s);
       } else {
-#if DO_LOG
-        LOG_DEVEL << "PROJECTIONS COVERED BY INDEX - WITH REGS";
-#endif
         // write projections into individual output registers
         context.getProjectionsForRegisters().produceFromIndex(
             context.getBuilder(), covering, context.getTrxPtr(),
@@ -629,10 +594,6 @@ IndexIterator::CoveringCallback aql::getCallback(
       }
     }
 
-#if DO_LOG
-    LOG_DEVEL << "GETCALLBACK - WITHFILTERCOVEREDBYINDEX";
-#endif
-
     context.incrScanned();
 
     if (!context.checkFilter(&covering)) {
@@ -659,9 +620,6 @@ IndexIterator::CoveringCallback aql::getCallback(
           }
         } else {
           if (context.getProjectionsForRegisters().empty()) {
-#if DO_LOG
-            LOG_DEVEL << "FILTER COVERED BY INDEX - NO REGS";
-#endif
             // write all projections combined into the global output register
             // recycle our Builder object
             VPackBuilder& objectBuilder = context.getBuilder();
@@ -677,9 +635,6 @@ IndexIterator::CoveringCallback aql::getCallback(
             VPackSlice projectedSlice = objectBuilder.slice();
             output.moveValueInto(registerId, input, projectedSlice);
           } else {
-#if DO_LOG
-            LOG_DEVEL << "FILTER COVERED BY INDEX - WITH REGS";
-#endif
             // write projections into individual output registers
             context.getProjectionsForRegisters().produceFromDocument(
                 context.getBuilder(), s, context.getTrxPtr(),

--- a/arangod/Aql/DocumentProducingNode.cpp
+++ b/arangod/Aql/DocumentProducingNode.cpp
@@ -92,8 +92,8 @@ void DocumentProducingNode::cloneInto(ExecutionPlan* plan,
     c.setFilter(
         std::unique_ptr<Expression>(_filter->clone(plan->getAst(), true)));
   }
-  c.setProjections(_projections);
-  c.setFilterProjections(_filterProjections);
+  c._projections = _projections;
+  c._filterProjections = _filterProjections;
   c.copyCountFlag(this);
   c.setCanReadOwnWrites(canReadOwnWrites());
   c.setMaxProjections(maxProjections());

--- a/arangod/Aql/DocumentProducingNode.cpp
+++ b/arangod/Aql/DocumentProducingNode.cpp
@@ -103,7 +103,7 @@ void DocumentProducingNode::cloneInto(ExecutionPlan* plan,
 void DocumentProducingNode::replaceVariables(
     std::unordered_map<VariableId, Variable const*> const& replacements) {
   if (hasFilter()) {
-    _filter->replaceVariables(replacements);
+    filter()->replaceVariables(replacements);
   }
 }
 
@@ -220,6 +220,8 @@ AsyncPrefetchEligibility DocumentProducingNode::canUseAsyncPrefetching()
 bool DocumentProducingNode::recalculateProjections(ExecutionPlan* plan) {
   auto filterProjectionsHash = _filterProjections.hash();
   auto projectionsHash = _projections.hash();
+  TRI_ASSERT(!_projections.hasOutputRegisters());
+  TRI_ASSERT(!_filterProjections.hasOutputRegisters());
   _filterProjections.clear();
   _projections.clear();
 
@@ -242,6 +244,8 @@ bool DocumentProducingNode::recalculateProjections(ExecutionPlan* plan) {
       _projections = Projections(std::move(attributes));
     }
   }
+
+  TRI_ASSERT(!_filterProjections.hasOutputRegisters());
 
   return projectionsHash != _projections.hash() ||
          filterProjectionsHash != _filterProjections.hash();

--- a/arangod/Aql/ExecutionNode.cpp
+++ b/arangod/Aql/ExecutionNode.cpp
@@ -737,7 +737,7 @@ void ExecutionNode::replaceVariables(
 void ExecutionNode::replaceAttributeAccess(
     ExecutionNode const* /*self*/, Variable const* /*searchVariable*/,
     std::span<std::string_view> /*attribute*/,
-    Variable const* /*replaceVariable*/) {
+    Variable const* /*replaceVariable*/, size_t /*index*/) {
   // default implementation does nothing
 }
 
@@ -1856,7 +1856,8 @@ void EnumerateCollectionNode::replaceVariables(
 
 void EnumerateCollectionNode::replaceAttributeAccess(
     ExecutionNode const* self, Variable const* searchVariable,
-    std::span<std::string_view> attribute, Variable const* replaceVariable) {
+    std::span<std::string_view> attribute, Variable const* replaceVariable,
+    size_t /*index*/) {
   DocumentProducingNode::replaceAttributeAccess(self, searchVariable, attribute,
                                                 replaceVariable);
 }
@@ -2374,7 +2375,8 @@ void CalculationNode::replaceVariables(
 
 void CalculationNode::replaceAttributeAccess(
     ExecutionNode const* self, Variable const* searchVariable,
-    std::span<std::string_view> attribute, Variable const* replaceVariable) {
+    std::span<std::string_view> attribute, Variable const* replaceVariable,
+    size_t /*index*/) {
   expression()->replaceAttributeAccess(searchVariable, attribute,
                                        replaceVariable);
 }

--- a/arangod/Aql/ExecutionNode.cpp
+++ b/arangod/Aql/ExecutionNode.cpp
@@ -3029,7 +3029,7 @@ constexpr std::string_view kMaterializeNodeInLocalDocIdParam = "inLocalDocId";
 MaterializeNode* materialize::createMaterializeNode(
     ExecutionPlan* plan, arangodb::velocypack::Slice const base) {
   auto isMulti = base.get(kMaterializeNodeMultiNodeParam);
-  if (isMulti.isBoolean() && isMulti.getBoolean()) {
+  if (isMulti.isTrue()) {
     return new MaterializeSearchNode(plan, base);
   }
   return new MaterializeRocksDBNode(plan, base);

--- a/arangod/Aql/ExecutionNode.h
+++ b/arangod/Aql/ExecutionNode.h
@@ -371,7 +371,8 @@ class ExecutionNode {
   virtual void replaceAttributeAccess(ExecutionNode const* self,
                                       Variable const* searchVariable,
                                       std::span<std::string_view> attribute,
-                                      Variable const* replaceVariable);
+                                      Variable const* replaceVariable,
+                                      size_t index);
 
   /// @brief check equality of ExecutionNodes
   virtual bool isEqualTo(ExecutionNode const& other) const;
@@ -706,7 +707,8 @@ class EnumerateCollectionNode : public ExecutionNode,
   void replaceAttributeAccess(ExecutionNode const* self,
                               Variable const* searchVariable,
                               std::span<std::string_view> attribute,
-                              Variable const* replaceVariable) override;
+                              Variable const* replaceVariable,
+                              size_t index) override;
 
   /// @brief the cost of an enumerate collection node is a multiple of the cost
   /// of its unique dependency
@@ -911,7 +913,8 @@ class CalculationNode : public ExecutionNode {
   void replaceAttributeAccess(ExecutionNode const* self,
                               Variable const* searchVariable,
                               std::span<std::string_view> attribute,
-                              Variable const* replaceVariable) override;
+                              Variable const* replaceVariable,
+                              size_t index) override;
 
   /// @brief getVariablesUsedHere, modifying the set in-place
   void getVariablesUsedHere(VarSet& vars) const override final;

--- a/arangod/Aql/IResearchViewNode.cpp
+++ b/arangod/Aql/IResearchViewNode.cpp
@@ -1825,8 +1825,8 @@ void IResearchViewNode::replaceVariables(
 
 void IResearchViewNode::replaceAttributeAccess(
     aql::ExecutionNode const* self, aql::Variable const* searchVariable,
-    std::span<std::string_view> attribute,
-    aql::Variable const* replaceVariable) {
+    std::span<std::string_view> attribute, aql::Variable const* replaceVariable,
+    size_t /*index*/) {
   Ast* ast = plan()->getAst();
   // replace in filter condition
   aql::AstNode const& search = filterCondition();

--- a/arangod/Aql/IResearchViewNode.h
+++ b/arangod/Aql/IResearchViewNode.h
@@ -180,7 +180,8 @@ class IResearchViewNode final : public aql::ExecutionNode,
   void replaceAttributeAccess(aql::ExecutionNode const* self,
                               aql::Variable const* searchVariable,
                               std::span<std::string_view> attribute,
-                              aql::Variable const* replaceVariable) override;
+                              aql::Variable const* replaceVariable,
+                              size_t index) override;
 
   std::vector<aql::Variable const*> getVariablesSetHere() const final;
 

--- a/arangod/Aql/IndexNode.cpp
+++ b/arangod/Aql/IndexNode.cpp
@@ -570,7 +570,6 @@ void IndexNode::replaceAttributeAccess(ExecutionNode const* self,
                                        replaceVariable);
   }
   if (hasFilter() && self != this) {
-    // TODO: validate
     _filter->replaceAttributeAccess(searchVariable, attribute, replaceVariable);
   }
 }
@@ -649,7 +648,6 @@ void IndexNode::getVariablesUsedHere(VarSet& vars) const {
     vars.erase(it.first);
   }
   // projection output variables.
-  // TODO: validate
   for (size_t i = 0; i < _projections.size(); ++i) {
     if (_projections[i].variable != nullptr) {
       vars.erase(_projections[i].variable);
@@ -690,7 +688,6 @@ std::vector<Variable const*> IndexNode::getVariablesSetHere() const {
                  [](auto const& indVar) { return indVar.first; });
 
   // projection output variables
-  // TODO: validate
   for (size_t i = 0; i < _projections.size(); ++i) {
     // output registers are not necessarily set yet
     if (_projections[i].variable != nullptr) {
@@ -748,7 +745,6 @@ bool IndexNode::recalculateProjections(ExecutionPlan* plan) {
   }
 
   if (isLateMaterialized()) {
-    // TODO: validate
     _projections.clear();
     return false;
   }

--- a/arangod/Aql/IndexNode.cpp
+++ b/arangod/Aql/IndexNode.cpp
@@ -548,7 +548,8 @@ void IndexNode::replaceVariables(
 void IndexNode::replaceAttributeAccess(ExecutionNode const* self,
                                        Variable const* searchVariable,
                                        std::span<std::string_view> attribute,
-                                       Variable const* replaceVariable) {
+                                       Variable const* replaceVariable,
+                                       size_t /*index*/) {
   DocumentProducingNode::replaceAttributeAccess(self, searchVariable, attribute,
                                                 replaceVariable);
   if (_condition && self != this) {

--- a/arangod/Aql/IndexNode.h
+++ b/arangod/Aql/IndexNode.h
@@ -211,6 +211,8 @@ class IndexNode : public ExecutionNode,
                       unsigned flags) const override final;
 
  private:
+  void updateProjectionsIndexInfo();
+
   /// @brief determine the IndexNode strategy
   Strategy strategy() const;
 

--- a/arangod/Aql/IndexNode.h
+++ b/arangod/Aql/IndexNode.h
@@ -139,7 +139,8 @@ class IndexNode : public ExecutionNode,
   void replaceAttributeAccess(ExecutionNode const* self,
                               Variable const* searchVariable,
                               std::span<std::string_view> attribute,
-                              Variable const* replaceVariable) override;
+                              Variable const* replaceVariable,
+                              size_t index) override;
 
   /// @brief getVariablesSetHere
   std::vector<Variable const*> getVariablesSetHere() const override final;

--- a/arangod/Aql/IndexNodeOptimizerRules.cpp
+++ b/arangod/Aql/IndexNodeOptimizerRules.cpp
@@ -78,12 +78,12 @@ bool processCalculationNode(
           expression->nodeForModification(), var, node)) {
     // is not safe for optimization
     return false;
-  } else if (!node.attrs.empty()) {
+  }
+  if (!node.attrs.empty()) {
     if (!attributesMatch(index, node)) {
       return false;
-    } else {
-      nodesToChange.emplace_back(std::move(node));
     }
+    nodesToChange.emplace_back(std::move(node));
   }
   return true;
 }
@@ -141,7 +141,7 @@ void arangodb::aql::lateDocumentMaterializationRule(
         TRI_ASSERT(filter);
         VarSet currentUsedVars;
         Ast::getReferencedVariables(filter->node(), currentUsedVars);
-        if (currentUsedVars.find(var) != currentUsedVars.end() &&
+        if (currentUsedVars.contains(var) &&
             !processCalculationNode(var, index, nullptr, filter,
                                     nodesToChange)) {
           // IndexNode has an early pruning filter which references variables
@@ -205,7 +205,7 @@ void arangodb::aql::lateDocumentMaterializationRule(
         if (!stopSearch && valid && type != ExecutionNode::CALCULATION) {
           VarSet currentUsedVars;
           current->getVariablesUsedHere(currentUsedVars);
-          if (currentUsedVars.find(var) != currentUsedVars.end()) {
+          if (currentUsedVars.contains(var)) {
             valid = false;
             if (ExecutionNode::SUBQUERY == type) {
               auto& subqueryNode =
@@ -222,7 +222,7 @@ void arangodb::aql::lateDocumentMaterializationRule(
                              scn->getType() == ExecutionNode::CALCULATION);
                   currentUsedVars.clear();
                   scn->getVariablesUsedHere(currentUsedVars);
-                  if (currentUsedVars.find(var) != currentUsedVars.end()) {
+                  if (currentUsedVars.contains(var)) {
                     auto* calculationNode =
                         ExecutionNode::castTo<CalculationNode*>(scn);
                     TRI_ASSERT(calculationNode);

--- a/arangod/Aql/JoinExecutor.cpp
+++ b/arangod/Aql/JoinExecutor.cpp
@@ -180,6 +180,7 @@ auto JoinExecutor::produceRows(AqlItemBlockInputRange& inputRange,
         bool filtered = false;
 
         auto filterCallback = [&](auto docPtr) {
+          TRI_ASSERT(!useFilterProjections);
           auto doc = extractSlice(docPtr);
           LOG_JOIN << "INDEX " << k << " read document " << doc.toJson();
           GenericDocumentExpressionContext ctx{_trx,
@@ -196,7 +197,7 @@ auto JoinExecutor::produceRows(AqlItemBlockInputRange& inputRange,
           LOG_JOIN << "INDEX " << k << " filter = " << std::boolalpha
                    << filtered;
 
-          if (!filtered && !useFilterProjections) {
+          if (!filtered) {
             // add document to the list
             _documents[k] = std::make_unique<std::string>(
                 doc.template startAs<char>(), doc.byteSize());

--- a/arangod/Aql/JoinExecutor.cpp
+++ b/arangod/Aql/JoinExecutor.cpp
@@ -22,13 +22,14 @@
 /// @author Lars Maier
 ////////////////////////////////////////////////////////////////////////////////
 
-#include "Aql/JoinExecutor.h"
-#include "Aql/OutputAqlItemRow.h"
+#include "JoinExecutor.h"
 #include "Aql/Collection.h"
+#include "Aql/DocumentExpressionContext.h"
+#include "Aql/OutputAqlItemRow.h"
 #include "Aql/QueryContext.h"
-#include "VocBase/LogicalCollection.h"
+#include "Basics/system-compiler.h"
 #include "Logger/LogMacros.h"
-#include "DocumentExpressionContext.h"
+#include "VocBase/LogicalCollection.h"
 
 using namespace arangodb;
 using namespace arangodb::aql;
@@ -136,7 +137,7 @@ auto JoinExecutor::produceRows(AqlItemBlockInputRange& inputRange,
                                return true;
                              }}},
                          {});
-        if (result.fail()) {
+        if (ADB_UNLIKELY(result.fail())) {
           THROW_ARANGO_EXCEPTION_MESSAGE(
               result.errorNumber(),
               basics::StringUtils::concatT(

--- a/arangod/Aql/JoinExecutor.cpp
+++ b/arangod/Aql/JoinExecutor.cpp
@@ -48,14 +48,7 @@ RegisterId JoinExecutorInfos::registerForVariable(
 void JoinExecutorInfos::determineProjectionsForRegisters() {
   if (!projectionsInitialized) {
     for (auto& it : indexes) {
-      bool found = false;
-      for (size_t i = 0; i < it.projections.size(); ++i) {
-        if (it.projections[i].variable != nullptr) {
-          found = true;
-          break;
-        }
-      }
-      it.hasProjectionsForRegisters = found;
+      it.hasProjectionsForRegisters = it.projections.hasOutputRegisters();
     }
     projectionsInitialized = true;
   }

--- a/arangod/Aql/JoinExecutor.h
+++ b/arangod/Aql/JoinExecutor.h
@@ -33,11 +33,18 @@
 #include "Aql/JoinNode.h"
 #include "Aql/InputAqlItemRow.h"
 #include "Aql/NonConstExpressionContainer.h"
+#include "Aql/RegisterId.h"
 #include "Aql/RegisterInfos.h"
 #include "Aql/Stats.h"
+#include "Aql/Variable.h"
+#include "Containers/FlatHashMap.h"
 #include "Transaction/Methods.h"
 
+#include <velocypack/Builder.h>
+
 #include <memory>
+#include <optional>
+#include <vector>
 
 namespace arangodb {
 class IndexIterator;
@@ -73,6 +80,8 @@ struct JoinExecutorInfos {
     // Values used for projection
     Projections projections;
 
+    bool hasProjectionsForRegisters = false;
+
     struct FilterInformation {
       // post filter expression
       std::unique_ptr<Expression> expression;
@@ -91,8 +100,13 @@ struct JoinExecutorInfos {
     std::optional<FilterInformation> filter;
   };
 
+  RegisterId registerForVariable(VariableId id) const noexcept;
+  void determineProjectionsForRegisters();
+
   std::vector<IndexInfo> indexes;
   QueryContext* query;
+  containers::FlatHashMap<VariableId, RegisterId> varsToRegister;
+  bool projectionsInitialized = false;
 };
 
 /**

--- a/arangod/Aql/JoinNode.cpp
+++ b/arangod/Aql/JoinNode.cpp
@@ -360,7 +360,6 @@ void JoinNode::replaceAttributeAccess(ExecutionNode const* self,
                                            replaceVariable);
     }
     if (it.filter && self != this) {
-      // TODO: validate
       it.filter->replaceAttributeAccess(searchVariable, attribute,
                                         replaceVariable);
     }
@@ -430,6 +429,12 @@ void JoinNode::getVariablesUsedHere(VarSet& vars) const {
   }
   for (auto const& it : _indexInfos) {
     vars.erase(it.outVariable);
+    // projection output variables.
+    for (size_t i = 0; i < it.projections.size(); ++i) {
+      if (it.projections[i].variable != nullptr) {
+        vars.erase(it.projections[i].variable);
+      }
+    }
   }
 }
 

--- a/arangod/Aql/JoinNode.cpp
+++ b/arangod/Aql/JoinNode.cpp
@@ -44,6 +44,7 @@
 #include "Basics/AttributeNameParser.h"
 #include "Basics/StringUtils.h"
 #include "Basics/VelocyPackHelper.h"
+#include "Containers/FlatHashMap.h"
 #include "Containers/FlatHashSet.h"
 #include "Indexes/Index.h"
 #include "StorageEngine/EngineSelectorFeature.h"
@@ -181,8 +182,6 @@ void JoinNode::doToVelocyPack(VPackBuilder& builder, unsigned flags) const {
 
   for (auto const& it : _indexInfos) {
     builder.openObject();
-    // TODO: check if this works in cluster, where we likely need shards and not
-    // collections
     if (!it.usedShard.empty()) {
       builder.add("collection", VPackValue(it.usedShard));
       builder.add("usedShard", VPackValue(it.usedShard));
@@ -240,6 +239,7 @@ std::unique_ptr<ExecutionBlock> JoinNode::createBlock(
   TRI_ASSERT(previousNode != nullptr);
 
   RegIdSet writableOutputRegisters;
+  containers::FlatHashMap<VariableId, RegisterId> varsToRegs;
 
   JoinExecutorInfos infos;
   infos.query = &engine.getQuery();
@@ -247,6 +247,21 @@ std::unique_ptr<ExecutionBlock> JoinNode::createBlock(
   for (auto const& idx : _indexInfos) {
     auto documentOutputRegister = variableToRegisterId(idx.outVariable);
     writableOutputRegisters.emplace(documentOutputRegister);
+
+    auto const& p = idx.projections;
+    // create one register per projection.
+    for (size_t i = 0; i < p.size(); ++i) {
+      Variable const* var = p[i].variable;
+      if (var == nullptr) {
+        // the output register can be a nullptr if the "optimize-projections"
+        // rule was not executed (potentially because it was disabled).
+        continue;
+      }
+      TRI_ASSERT(var != nullptr);
+      auto regId = variableToRegisterId(var);
+      varsToRegs.emplace(var->id, regId);
+      writableOutputRegisters.emplace(regId);
+    }
 
     // TODO probably those data structures can become one
     auto& data = infos.indexes.emplace_back();
@@ -266,7 +281,7 @@ std::unique_ptr<ExecutionBlock> JoinNode::createBlock(
 
       filter.filterVarsToRegs.reserve(inVars.size());
 
-      for (auto& var : inVars) {
+      for (auto const& var : inVars) {
         TRI_ASSERT(var != nullptr);
         auto regId = variableToRegisterId(var);
         filter.filterVarsToRegs.emplace_back(var->id, regId);
@@ -287,6 +302,8 @@ std::unique_ptr<ExecutionBlock> JoinNode::createBlock(
       }
     }
   }
+
+  infos.varsToRegister = std::move(varsToRegs);
 
   auto registerInfos = createRegisterInfos({}, writableOutputRegisters);
 
@@ -323,7 +340,31 @@ ExecutionNode* JoinNode::clone(ExecutionPlan* plan, bool withDependencies,
 /// replacements are { old variable id => new variable }
 void JoinNode::replaceVariables(
     std::unordered_map<VariableId, Variable const*> const& replacements) {
-  // TODO: replace variables inside index conditions.
+  for (auto& it : _indexInfos) {
+    if (it.condition) {
+      it.condition->replaceVariables(replacements);
+    }
+    if (it.filter != nullptr) {
+      it.filter->replaceVariables(replacements);
+    }
+  }
+}
+
+void JoinNode::replaceAttributeAccess(ExecutionNode const* self,
+                                      Variable const* searchVariable,
+                                      std::span<std::string_view> attribute,
+                                      Variable const* replaceVariable) {
+  for (auto& it : _indexInfos) {
+    if (it.condition && self != this) {
+      it.condition->replaceAttributeAccess(searchVariable, attribute,
+                                           replaceVariable);
+    }
+    if (it.filter && self != this) {
+      // TODO: validate
+      it.filter->replaceAttributeAccess(searchVariable, attribute,
+                                        replaceVariable);
+    }
+  }
 }
 
 /// @brief the cost of an join node is a multiple of the cost of
@@ -383,6 +424,7 @@ AsyncPrefetchEligibility JoinNode::canUseAsyncPrefetching() const noexcept {
 void JoinNode::getVariablesUsedHere(VarSet& vars) const {
   for (auto const& it : _indexInfos) {
     if (it.condition != nullptr && it.condition->root() != nullptr) {
+      // lookup condition
       Ast::getReferencedVariables(it.condition->root(), vars);
     }
   }
@@ -402,8 +444,20 @@ std::vector<Variable const*> JoinNode::getVariablesSetHere() const {
   vars.reserve(_indexInfos.size());
 
   for (auto const& it : _indexInfos) {
-    vars.emplace_back(it.outVariable);
+    size_t found = 0;
+    // projection output variables
+    for (size_t i = 0; i < it.projections.size(); ++i) {
+      // output registers are not necessarily set yet
+      if (it.projections[i].variable != nullptr) {
+        vars.push_back(it.projections[i].variable);
+        ++found;
+      }
+    }
+    if (found == 0) {
+      vars.emplace_back(it.outVariable);
+    }
   }
+
   return vars;
 }
 
@@ -435,22 +489,6 @@ Index::FilterCosts JoinNode::costsForIndexInfo(
                                                 itemsInCollection);
   }
   return costs;
-}
-
-void JoinNode::replaceAttributeAccess(const ExecutionNode* self,
-                                      const Variable* searchVariable,
-                                      std::span<std::string_view> attribute,
-                                      const Variable* replaceVariable) {
-  for (auto& idx : _indexInfos) {
-    if (idx.condition) {
-      idx.condition->replaceAttributeAccess(searchVariable, attribute,
-                                            replaceVariable);
-    }
-    if (idx.filter) {
-      idx.filter->replaceAttributeAccess(searchVariable, attribute,
-                                         replaceVariable);
-    }
-  }
 }
 
 std::ostream& arangodb::operator<<(std::ostream& os,

--- a/arangod/Aql/JoinNode.cpp
+++ b/arangod/Aql/JoinNode.cpp
@@ -488,7 +488,7 @@ bool JoinNode::isDeterministic() {
       return false;
     }
   }
-  return false;
+  return true;
 }
 
 Index::FilterCosts JoinNode::costsForIndexInfo(

--- a/arangod/Aql/JoinNode.h
+++ b/arangod/Aql/JoinNode.h
@@ -100,7 +100,8 @@ class JoinNode : public ExecutionNode {
   void replaceAttributeAccess(ExecutionNode const* self,
                               Variable const* searchVariable,
                               std::span<std::string_view> attribute,
-                              Variable const* replaceVariable) override;
+                              Variable const* replaceVariable,
+                              size_t index) override;
 
   /// @brief getVariablesSetHere
   std::vector<Variable const*> getVariablesSetHere() const override final;
@@ -118,8 +119,7 @@ class JoinNode : public ExecutionNode {
   std::vector<IndexInfo> const& getIndexInfos() const;
   std::vector<IndexInfo>& getIndexInfos();
 
-  /// TODO: check if this is adequate
-  bool isDeterministic() override final { return true; }
+  bool isDeterministic() override final;
 
  protected:
   /// @brief export to VelocyPack

--- a/arangod/Aql/JoinNode.h
+++ b/arangod/Aql/JoinNode.h
@@ -97,6 +97,11 @@ class JoinNode : public ExecutionNode {
   void replaceVariables(std::unordered_map<VariableId, Variable const*> const&
                             replacements) override;
 
+  void replaceAttributeAccess(ExecutionNode const* self,
+                              Variable const* searchVariable,
+                              std::span<std::string_view> attribute,
+                              Variable const* replaceVariable) override;
+
   /// @brief getVariablesSetHere
   std::vector<Variable const*> getVariablesSetHere() const override final;
 
@@ -115,11 +120,6 @@ class JoinNode : public ExecutionNode {
 
   /// TODO: check if this is adequate
   bool isDeterministic() override final { return true; }
-
-  void replaceAttributeAccess(ExecutionNode const* self,
-                              Variable const* searchVariable,
-                              std::span<std::string_view> attribute,
-                              Variable const* replaceVariable) override;
 
  protected:
   /// @brief export to VelocyPack

--- a/arangod/Aql/ModificationNodes.cpp
+++ b/arangod/Aql/ModificationNodes.cpp
@@ -276,7 +276,8 @@ void InsertNode::replaceVariables(
 void InsertNode::replaceAttributeAccess(ExecutionNode const* self,
                                         Variable const* searchVariable,
                                         std::span<std::string_view> attribute,
-                                        Variable const* replaceVariable) {
+                                        Variable const* replaceVariable,
+                                        size_t /*index*/) {
   if (_inVariable != nullptr && searchVariable == _inVariable &&
       attribute.size() == 1 && attribute[0] == StaticStrings::KeyString) {
     _inVariable = replaceVariable;
@@ -329,7 +330,8 @@ void UpdateReplaceNode::replaceVariables(
 
 void UpdateReplaceNode::replaceAttributeAccess(
     ExecutionNode const* self, Variable const* searchVariable,
-    std::span<std::string_view> attribute, Variable const* replaceVariable) {
+    std::span<std::string_view> attribute, Variable const* replaceVariable,
+    size_t /*index*/) {
   auto replace = [&](Variable const*& variable) {
     if (variable != nullptr && searchVariable == variable &&
         attribute.size() == 1 && attribute[0] == StaticStrings::KeyString) {
@@ -400,7 +402,8 @@ void RemoveNode::replaceVariables(
 void RemoveNode::replaceAttributeAccess(ExecutionNode const* self,
                                         Variable const* searchVariable,
                                         std::span<std::string_view> attribute,
-                                        Variable const* replaceVariable) {
+                                        Variable const* replaceVariable,
+                                        size_t /*index*/) {
   if (_inVariable != nullptr && searchVariable == _inVariable &&
       attribute.size() == 1 && attribute[0] == StaticStrings::KeyString) {
     // replace the following patterns:
@@ -650,7 +653,8 @@ void UpsertNode::replaceVariables(
 void UpsertNode::replaceAttributeAccess(ExecutionNode const* self,
                                         Variable const* searchVariable,
                                         std::span<std::string_view> attribute,
-                                        Variable const* replaceVariable) {
+                                        Variable const* replaceVariable,
+                                        size_t /*index*/) {
   auto replace = [&](Variable const*& variable) {
     if (variable != nullptr && searchVariable == variable &&
         attribute.size() == 1 && attribute[0] == StaticStrings::KeyString) {

--- a/arangod/Aql/ModificationNodes.h
+++ b/arangod/Aql/ModificationNodes.h
@@ -189,7 +189,8 @@ class RemoveNode : public ModificationNode {
   void replaceAttributeAccess(ExecutionNode const* self,
                               Variable const* searchVariable,
                               std::span<std::string_view> attribute,
-                              Variable const* replaceVariable) override;
+                              Variable const* replaceVariable,
+                              size_t index) override;
 
   /// @brief getVariablesUsedHere, modifying the set in-place
   void getVariablesUsedHere(VarSet& vars) const override final {
@@ -249,7 +250,8 @@ class InsertNode : public ModificationNode {
   void replaceAttributeAccess(ExecutionNode const* self,
                               Variable const* searchVariable,
                               std::span<std::string_view> attribute,
-                              Variable const* replaceVariable) override;
+                              Variable const* replaceVariable,
+                              size_t index) override;
 
   /// @brief getVariablesUsedHere, modifying the set in-place
   void getVariablesUsedHere(VarSet& vars) const override final {
@@ -307,7 +309,8 @@ class UpdateReplaceNode : public ModificationNode {
   void replaceAttributeAccess(ExecutionNode const* self,
                               Variable const* searchVariable,
                               std::span<std::string_view> attribute,
-                              Variable const* replaceVariable) override;
+                              Variable const* replaceVariable,
+                              size_t index) override;
 
   /// @brief set the input key variable
   void setInKeyVariable(Variable const* var) { _inKeyVariable = var; }
@@ -440,7 +443,8 @@ class UpsertNode : public ModificationNode {
   void replaceAttributeAccess(ExecutionNode const* self,
                               Variable const* searchVariable,
                               std::span<std::string_view> attribute,
-                              Variable const* replaceVariable) override;
+                              Variable const* replaceVariable,
+                              size_t index) override;
 
   /// @brief getVariablesUsedHere, modifying the set in-place
   void getVariablesUsedHere(VarSet& vars) const override final {

--- a/arangod/Aql/OptimizerRule.h
+++ b/arangod/Aql/OptimizerRule.h
@@ -362,13 +362,13 @@ struct OptimizerRule {
     lateMaterialiationOffsetInfoRule,
 #endif
 
-    // remove unnecessary projections & store projection attributes in
-    // individual registers
-    optimizeProjections,
-
     // replace adjacent index nodes with a join node if the indexes qualify
     // for it.
     joinIndexNodesRule,
+
+    // remove unnecessary projections & store projection attributes in
+    // individual registers
+    optimizeProjections,
 
     // final cleanup, after projections
     removeUnnecessaryCalculationsRule4,

--- a/arangod/Aql/OptimizerRule.h
+++ b/arangod/Aql/OptimizerRule.h
@@ -367,21 +367,26 @@ struct OptimizerRule {
     joinIndexNodesRule,
 
     // remove unnecessary projections & store projection attributes in
-    // individual registers
-    optimizeProjections,
+    // individual registers. must be executed after the joinIndexNodesRule,
+    // otherwise the projections handling of JoinNodes will be incorrect.
+    optimizeProjectionsRule,
 
     // final cleanup, after projections
     removeUnnecessaryCalculationsRule4,
 
     // allows execution nodes to asynchronously prefetch the next batch from
     // their upstream node.
-    asyncPrefetch,
+    asyncPrefetchRule,
 
     // splice subquery into the place of a subquery node
     // enclosed by a SubqueryStartNode and a SubqueryEndNode
     // Must run last.
     spliceSubqueriesRule
   };
+
+  static_assert(lateDocumentMaterializationRule < optimizeProjectionsRule);
+  static_assert(joinIndexNodesRule < optimizeProjectionsRule);
+  static_assert(optimizeProjectionsRule < removeUnnecessaryCalculationsRule4);
 
 #ifdef USE_ENTERPRISE
   static_assert(clusterOneShardRule < distributeInClusterRule);

--- a/arangod/Aql/OptimizerRules.cpp
+++ b/arangod/Aql/OptimizerRules.cpp
@@ -9435,9 +9435,6 @@ void arangodb::aql::optimizeProjections(Optimizer* opt,
     auto* documentNode = ExecutionNode::castTo<DocumentProducingNode*>(n);
     modified |= documentNode->recalculateProjections(plan.get());
 
-    if (n->getType() != EN::ENUMERATE_COLLECTION) {
-      continue;
-    }
     auto& p = documentNode->projections();
     std::vector<std::string_view> path;
     for (size_t i = 0; i < p.size(); ++i) {

--- a/arangod/Aql/OptimizerRulesFeature.cpp
+++ b/arangod/Aql/OptimizerRulesFeature.cpp
@@ -453,7 +453,7 @@ pulled into the traversal, significantly reducing overhead.)");
 
   registerRule(
       "optimize-projections", optimizeProjections,
-      OptimizerRule::optimizeProjections,
+      OptimizerRule::optimizeProjectionsRule,
       OptimizerRule::makeFlags(OptimizerRule::Flags::CanBeDisabled),
       R"(Remove projections that are no longer used and store projection
 results in separate output registers.)");
@@ -827,7 +827,7 @@ in case the indexes qualify for it.)");
   // current batch. this effectively allows parts of the query to run in
   // parallel. this is only supported by certain types of nodes and queries.
   registerRule("async-prefetch", asyncPrefetchRule,
-               OptimizerRule::asyncPrefetch,
+               OptimizerRule::asyncPrefetchRule,
                OptimizerRule::makeFlags(OptimizerRule::Flags::CanBeDisabled),
                R"(Allow query execution nodes to asynchronously prefetch the
 next batch while processing the current batch, allowing parts of the query to

--- a/arangod/Aql/OptimizerUtils.cpp
+++ b/arangod/Aql/OptimizerUtils.cpp
@@ -1089,7 +1089,7 @@ bool findProjections(ExecutionNode* n, Variable const* v,
       vars.clear();
       current->getVariablesUsedHere(vars);
 
-      if (vars.find(v) != vars.end()) {
+      if (vars.contains(v)) {
         // original variable is still used here
         return false;
       }

--- a/arangod/Aql/OutputAqlItemRow.cpp
+++ b/arangod/Aql/OutputAqlItemRow.cpp
@@ -114,7 +114,7 @@ void OutputAqlItemRow::cloneValueInto(RegisterId registerId,
 template<class ItemRowType, class ValueType>
 void OutputAqlItemRow::moveValueWithoutRowCopy(RegisterId registerId,
                                                ValueType value) {
-  TRI_ASSERT(isOutputRegister(registerId));
+  TRI_ASSERT(isOutputRegister(registerId)) << registerId.value();
   // This is already implicitly asserted by isOutputRegister:
   TRI_ASSERT(registerId.isRegularRegister());
   TRI_ASSERT(registerId < getNumRegisters());

--- a/arangod/Aql/Projections.cpp
+++ b/arangod/Aql/Projections.cpp
@@ -114,14 +114,11 @@ void Projections::produceFromDocument(
         cb) const {
   TRI_ASSERT(slice.isObject());
 
-  size_t levelsOpen = 0;
-
   for (auto const& it : _projections) {
     TRI_ASSERT(it.variable != nullptr);
 
     if (it.type == AttributeNamePath::Type::IdAttribute) {
       // projection for "_id"
-      TRI_ASSERT(levelsOpen == 0);
       TRI_ASSERT(it.path.size() == 1);
 
       b.clear();
@@ -130,71 +127,46 @@ void Projections::produceFromDocument(
       cb(it.variable, b.slice());
     } else if (it.type == AttributeNamePath::Type::KeyAttribute) {
       // projection for "_key"
-      TRI_ASSERT(levelsOpen == 0);
       TRI_ASSERT(it.path.size() == 1);
       b.clear();
       cb(it.variable, transaction::helpers::extractKeyFromDocument(slice));
     } else if (it.type == AttributeNamePath::Type::FromAttribute) {
       // projection for "_from"
-      TRI_ASSERT(levelsOpen == 0);
       TRI_ASSERT(it.path.size() == 1);
       cb(it.variable, transaction::helpers::extractFromFromDocument(slice));
     } else if (it.type == AttributeNamePath::Type::ToAttribute) {
       // projection for "_to"
-      TRI_ASSERT(levelsOpen == 0);
       TRI_ASSERT(it.path.size() == 1);
       cb(it.variable, transaction::helpers::extractToFromDocument(slice));
     } else if (it.type == AttributeNamePath::Type::SingleAttribute) {
       // projection for any other top-level attribute
-      TRI_ASSERT(levelsOpen == 0);
       TRI_ASSERT(it.path.size() == 1);
       cb(it.variable, slice.get(it.path.get().at(0)));
     } else {
       // projection for a sub-attribute, e.g. a.b.c
-      // this is a lot more complex, because we may need to open and close
-      // multiple sub-objects, e.g. a projection on the sub-attribute a.b.c
-      // needs to build
-      //   { a: { b: { c: valueOfC } } }
-      TRI_ASSERT(levelsOpen <= it.startsAtLevel);
-      TRI_ASSERT(it.type == AttributeNamePath::Type::MultiAttribute);
-      TRI_ASSERT(it.path.size() > 1);
-
-      // TODO: simplify level handling
-      VPackSlice found = slice;
-      VPackSlice prev = found;
-      size_t level = 0;
-      while (level < it.path.size()) {
-        found = found.get(it.path[level]);
-        if (found.isNone() || level == it.path.size() - 1 ||
-            !found.isObject()) {
+      auto const& path = it.path.get();
+      // we need to keep track of the object on the previous level because
+      // of _id. materializing the value of _id requires access to _key.
+      velocypack::Slice prev = slice;
+      velocypack::Slice found = slice;
+      for (size_t i = 0; i < path.size(); ++i) {
+        if (!found.isObject()) {
+          found = VPackSlice::nullSlice();
           break;
         }
-        if (level >= levelsOpen) {
-          ++levelsOpen;
-        }
-        ++level;
         prev = found;
+        found = found.get(path[i]);
       }
-      if (level >= it.startsAtLevel) {
-        if (found.isCustom()) {
-          b.clear();
-          b.add(VPackValue(transaction::helpers::extractIdString(
-              trxPtr->resolver(), found, prev)));
-          cb(it.variable, b.slice());
-        } else {
-          cb(it.variable, found);
-        }
-      }
-
-      TRI_ASSERT(it.path.size() > it.levelsToClose);
-      size_t closeUntil = it.path.size() - it.levelsToClose;
-      while (levelsOpen >= closeUntil) {
-        --levelsOpen;
+      if (found.isCustom()) {
+        b.clear();
+        b.add(VPackValue(transaction::helpers::extractIdString(
+            trxPtr->resolver(), found, prev)));
+        cb(it.variable, b.slice());
+      } else {
+        cb(it.variable, found);
       }
     }
   }
-
-  TRI_ASSERT(levelsOpen == 0);
 }
 
 /// @brief projections from a covering index
@@ -204,8 +176,6 @@ void Projections::produceFromIndex(
     fu2::unique_function<void(Variable const*, velocypack::Slice) const> const&
         cb) const {
   TRI_ASSERT(_index != nullptr);
-
-  size_t levelsOpen = 0;
 
   bool const isArray = covering.isArray();
   for (auto const& it : _projections) {
@@ -218,47 +188,31 @@ void Projections::produceFromIndex(
       TRI_ASSERT(isCoveringIndexPosition(it.coveringIndexPosition));
       VPackSlice found = covering.at(it.coveringIndexPosition);
 
-      // TODO: remove entire level handling
-      TRI_ASSERT(levelsOpen <= it.startsAtLevel);
-      size_t level = 0;
-      size_t const n =
-          std::min(it.path.size(), static_cast<size_t>(it.coveringIndexCutoff));
-      while (level < n) {
-        if (level == n - 1) {
-          break;
+      // _id cannot be part of a user-defined index, but can be used
+      // from within stored values
+      if (it.type == AttributeNamePath::Type::IdAttribute) {
+        // _id attribute
+        b.clear();
+        b.add(VPackValue(transaction::helpers::makeIdFromParts(
+            trxPtr->resolver(), _datasourceId, found)));
+        cb(it.variable, b.slice());
+      } else {
+        auto const& path = it.path.get();
+        if (it.coveringIndexCutoff < path.size()) {
+          for (size_t i = it.coveringIndexCutoff; i < path.size(); ++i) {
+            if (!found.isObject()) {
+              found = VPackSlice::nullSlice();
+            } else {
+              found = found.get(path[i]);
+            }
+          }
         }
-        if (level >= levelsOpen) {
-          ++levelsOpen;
-        }
-        ++level;
-      }
-      if (level >= it.startsAtLevel) {
-        // _id cannot be part of a user-defined index, but can be used
-        // from within stored values
-        if (it.type == AttributeNamePath::Type::IdAttribute) {
-          // _id attribute
-          b.add(it.path[level],
-                VPackValue(transaction::helpers::makeIdFromParts(
-                    trxPtr->resolver(), _datasourceId, found)));
-          b.clear();
-          b.add(VPackValue(transaction::helpers::makeIdFromParts(
-              trxPtr->resolver(), _datasourceId, found)));
-          cb(it.variable, b.slice());
-        } else {
-          cb(it.variable, found);
-        }
-      }
-
-      TRI_ASSERT(it.path.size() > it.levelsToClose);
-      size_t closeUntil = it.path.size() - it.levelsToClose;
-      while (levelsOpen >= closeUntil) {
-        --levelsOpen;
+        cb(it.variable, found);
       }
     } else {
       // no array Slice... this case will be triggered for indexes that
       // contain simple string values, such as the primary index or the
       // edge index
-      TRI_ASSERT(levelsOpen == 0);
       TRI_ASSERT(it.path.size() == 1);
 
       auto slice = covering.value();
@@ -272,8 +226,6 @@ void Projections::produceFromIndex(
       }
     }
   }
-
-  TRI_ASSERT(levelsOpen == 0);
 }
 
 void Projections::toVelocyPackFromDocument(

--- a/arangod/Aql/Projections.cpp
+++ b/arangod/Aql/Projections.cpp
@@ -91,6 +91,13 @@ bool Projections::isSingle(std::string_view attribute) const noexcept {
   return _projections.size() == 1 && _projections[0].path[0] == attribute;
 }
 
+/// @brief returns true if any of the projections will write into an
+/// output variable/register
+bool Projections::hasOutputRegisters() const noexcept {
+  return std::any_of(_projections.begin(), _projections.end(),
+                     [](Projection const& p) { return p.variable != nullptr; });
+}
+
 // return the covering index position for a specific attribute type.
 // will throw if the index does not cover!
 uint16_t Projections::coveringIndexPosition(

--- a/arangod/Aql/Projections.h
+++ b/arangod/Aql/Projections.h
@@ -151,6 +151,12 @@ class Projections {
       fu2::unique_function<void(Variable const*, velocypack::Slice)
                                const> const& cb) const;
 
+  void produceFromIndexCompactArray(
+      velocypack::Builder& b, IndexIteratorCoveringData& covering,
+      transaction::Methods const* trxPtr,
+      fu2::unique_function<void(Variable const*, velocypack::Slice)
+                               const> const& cb) const;
+
   /// @brief extract projections from a full document
   void toVelocyPackFromDocument(velocypack::Builder& b, velocypack::Slice slice,
                                 transaction::Methods const* trxPtr) const;

--- a/arangod/Aql/Projections.h
+++ b/arangod/Aql/Projections.h
@@ -121,6 +121,10 @@ class Projections {
   /// @brief checks if we have a single attribute projection on the attribute
   bool isSingle(std::string_view attribute) const noexcept;
 
+  /// @brief returns true if any of the projections will write into an
+  /// output variable/register
+  bool hasOutputRegisters() const noexcept;
+
   // return the covering index position for a specific attribute type.
   // will throw if the index does not cover!
   uint16_t coveringIndexPosition(aql::AttributeNamePath::Type type) const;

--- a/arangod/Aql/QuerySnippet.h
+++ b/arangod/Aql/QuerySnippet.h
@@ -24,15 +24,14 @@
 #pragma once
 
 #include "Aql/Query.h"
-#include "Cluster/ClusterInfo.h"
 #include "Basics/ResultT.h"
+#include "Cluster/ClusterInfo.h"
 
 #include <map>
 #include <set>
 #include <vector>
 
-namespace arangodb {
-namespace aql {
+namespace arangodb::aql {
 
 class DistributeConsumerNode;
 class ExecutionNode;
@@ -112,5 +111,4 @@ class QuerySnippet {
 
   Id const _id;
 };
-}  // namespace aql
-}  // namespace arangodb
+}  // namespace arangodb::aql

--- a/arangod/Aql/RegisterInfos.cpp
+++ b/arangod/Aql/RegisterInfos.cpp
@@ -20,10 +20,10 @@
 ///
 /// @author Tobias Gödderz
 ////////////////////////////////////////////////////////////////////////////////
-#include "RegisterInfos.h"
-#include "Logger/LogMacros.h"
 
+#include "RegisterInfos.h"
 #include "Basics/debugging.h"
+#include "Logger/LogMacros.h"
 
 using namespace arangodb::aql;
 
@@ -82,10 +82,13 @@ RegisterInfos::RegisterInfos(RegIdSet readableInputRegisters,
                _registersToKeep.back().end());
   }
   TRI_ASSERT(!_registersToKeep.empty());
-  for (RegisterId const regToKeep : _registersToKeep.back()) {
-    TRI_ASSERT(regToKeep < nrInputRegisters);
-    TRI_ASSERT(regToKeep < nrOutputRegisters);
-    TRI_ASSERT(_registersToClear.find(regToKeep) == _registersToClear.end());
+  for (RegisterId regToKeep : _registersToKeep.back()) {
+    TRI_ASSERT(regToKeep < nrInputRegisters)
+        << "register: " << regToKeep.value();
+    TRI_ASSERT(regToKeep < nrOutputRegisters)
+        << "register: " << regToKeep.value();
+    TRI_ASSERT(_registersToClear.find(regToKeep) == _registersToClear.end())
+        << "register: " << regToKeep.value();
   }
 #endif
 }

--- a/arangod/Aql/RegisterInfos.h
+++ b/arangod/Aql/RegisterInfos.h
@@ -34,8 +34,7 @@
 #include <memory>
 #include <unordered_set>
 
-namespace arangodb {
-namespace aql {
+namespace arangodb::aql {
 
 /**
  * @brief Class to be handed into ExecutionBlock during construction
@@ -133,5 +132,4 @@ class RegisterInfos {
   RegIdFlatSet _registersToClear;
 };
 
-}  // namespace aql
-}  // namespace arangodb
+}  // namespace arangodb::aql

--- a/arangod/Aql/RegisterPlan.cpp
+++ b/arangod/Aql/RegisterPlan.cpp
@@ -598,7 +598,8 @@ auto RegisterPlanT<T>::variableToRegisterId(Variable const* variable) const
     -> RegisterId {
   TRI_ASSERT(variable != nullptr);
   auto it = varInfo.find(variable->id);
-  TRI_ASSERT(it != varInfo.end());
+  TRI_ASSERT(it != varInfo.end())
+      << "variable " << variable->name << " (" << variable->id << ")";
   RegisterId rv = it->second.registerId;
   TRI_ASSERT(rv.isValid());
   return rv;

--- a/arangod/Aql/TraversalNode.cpp
+++ b/arangod/Aql/TraversalNode.cpp
@@ -379,7 +379,8 @@ void TraversalNode::replaceVariables(
 
 void TraversalNode::replaceAttributeAccess(
     ExecutionNode const* self, Variable const* searchVariable,
-    std::span<std::string_view> attribute, Variable const* replaceVariable) {
+    std::span<std::string_view> attribute, Variable const* replaceVariable,
+    size_t /*index*/) {
   // this is an important assertion: if options are already built,
   // we would need to carry out the replacements in several other
   // places as well

--- a/arangod/Aql/TraversalNode.h
+++ b/arangod/Aql/TraversalNode.h
@@ -153,7 +153,8 @@ class TraversalNode : public virtual GraphNode {
   void replaceAttributeAccess(ExecutionNode const* self,
                               Variable const* searchVariable,
                               std::span<std::string_view> attribute,
-                              Variable const* replaceVariable) override;
+                              Variable const* replaceVariable,
+                              size_t index) override;
 
   /// @brief getVariablesUsedHere
   void getVariablesUsedHere(VarSet& result) const override final;

--- a/js/common/modules/@arangodb/aql/explainer.js
+++ b/js/common/modules/@arangodb/aql/explainer.js
@@ -21,7 +21,7 @@ const isCoordinator = function () {
   } else {
     try {
       if (arango) {
-        var result = arango.GET('/_admin/server/role');
+        let result = arango.GET('/_admin/server/role');
         if (result.role === 'COORDINATOR') {
           isCoordinator = true;
         }
@@ -2100,6 +2100,18 @@ function processQuery(query, explain, planIndex) {
           accessString += projections(info, 'filterProjections', 'filter projections');
         }
         accessString = '   ' + annotation('/* ' + accessString + ' */');
+        if (info.projections) {
+          // produce LET nodes for each projection output register
+          let parts = [];
+          info.projections.forEach((p) => {
+            if (p.hasOwnProperty('variable')) {
+              parts.push(variableName(p.variable) + ' = ' + variableName(info.outVariable) + '.' + p.path.map((p) => attribute(p)).join('.'));
+            }
+          });
+          if (parts.length) {
+            accessString = '   ' + keyword('LET') + ' ' + parts.join(', ') + accessString;
+          }
+        }
         line += indent(level, false) + label + filter + accessString;
         stringBuilder.appendLine(line);
       });

--- a/js/common/modules/@arangodb/aql/joinHelper.js
+++ b/js/common/modules/@arangodb/aql/joinHelper.js
@@ -1,5 +1,5 @@
 /*jshint globalstrict:false, strict:false, maxlen: 500 */
-/*global fail, assertEqual, assertNotEqual, assertTrue, AQL_EXECUTE, AQL_EXPLAIN */
+/*global fail, assertEqual, assertNotEqual, assertTrue */
 
 ////////////////////////////////////////////////////////////////////////////////
 /// DISCLAIMER
@@ -166,7 +166,7 @@ const generateTestFunction = function (config) {
   return function () {
     const query = buildQuery(config);
 
-    const plan = db._createStatement({query: query, options: queryOptions}).explain().plan;
+    const plan = db._createStatement({query, options: queryOptions}).explain().plan;
     const nodes = plan.nodes.map(x => x.type);
     if (nodes.indexOf("JoinNode") === -1) {
       db._explain(query, null, queryOptions);

--- a/tests/js/client/aql/aql-filter-projections.js
+++ b/tests/js/client/aql/aql-filter-projections.js
@@ -8,8 +8,7 @@ const ruleName = "reduce-extraction-to-projection";
 const cn = "UnitTestsOptimizer";
 
 function query_explain(query, bindVars = null, options = {}) {
-  let stmt = db._createStatement({query, bindVars: bindVars, options: options});
-  return stmt.explain();
+  return db._createStatement({query, bindVars, options}).explain();
 };
 
 function filterProjectionsPlansTestSuite () {

--- a/tests/js/client/aql/aql-gather-block-cluster.js
+++ b/tests/js/client/aql/aql-gather-block-cluster.js
@@ -436,7 +436,59 @@ function gatherBlockTestSuite () {
     },
 
     testMultipleShardsWithIndex : function () {
+      const opts = { optimizer: { rules: ["-optimize-projections"] } };
       idx = c1.ensureIndex({ type: "skiplist", fields: ["Hallo"] });
+      let query = "FOR doc IN " + cn1 + " SORT doc.Hallo RETURN doc.Hallo";
+      // check the return value
+      let result = db._query(query, null, opts).toArray();
+      let last = -1;
+      result.forEach(function(value) {
+        assertTrue(value >= last);
+        last = value;
+      });
+      
+      let nodes = query_explain(query, null, opts).plan.nodes;
+      let nodeTypes = nodes.map(function(node) { return node.type; });
+      // must have no sort but a gather node
+      assertNotEqual(-1, nodeTypes.indexOf("IndexNode"));
+      let indexNode = nodes[nodeTypes.indexOf("IndexNode")];
+      assertTrue(indexNode.ascending);
+      assertEqual(-1, nodeTypes.indexOf("SortNode"));
+      assertNotEqual(-1, nodeTypes.indexOf("GatherNode"));
+      let gatherNode = nodes[nodeTypes.indexOf("GatherNode")];
+      assertEqual(1, gatherNode.elements.length); // must do sorting in GatherNode
+      assertEqual(["Hallo"], gatherNode.elements[0].path); 
+      assertTrue(gatherNode.elements[0].ascending);
+    },
+    
+    testMultipleShardsWithIndexDescending : function () {
+      const opts = { optimizer: { rules: ["-optimize-projections"] } };
+      idx = c1.ensureIndex({ type: "skiplist", fields: ["Hallo"] });
+      let query = "FOR doc IN " + cn1 + " SORT doc.Hallo DESC RETURN doc.Hallo";
+      // check the return value
+      let result = db._query(query, null, opts).toArray();
+      let last = 99999999999;
+      result.forEach(function(value) {
+        assertTrue(value <= last);
+        last = value;
+      });
+      
+      let nodes = query_explain(query, null, opts).plan.nodes;
+      let nodeTypes = nodes.map(function(node) { return node.type; });
+      // must have no sort but a gather node
+      assertNotEqual(-1, nodeTypes.indexOf("IndexNode"));
+      let indexNode = nodes[nodeTypes.indexOf("IndexNode")];
+      assertFalse(indexNode.ascending);
+      assertEqual(-1, nodeTypes.indexOf("SortNode"));
+      assertNotEqual(-1, nodeTypes.indexOf("GatherNode"));
+      let gatherNode = nodes[nodeTypes.indexOf("GatherNode")];
+      assertEqual(1, gatherNode.elements.length); // must do sorting in GatherNode
+      assertEqual(["Hallo"], gatherNode.elements[0].path); 
+      assertFalse(gatherNode.elements[0].ascending);
+    },
+    
+    testMultipleShardsWithIndexAndProjection : function () {
+      idx = c1.ensureIndex({ type: "persistent", fields: ["Hallo"] });
       let query = "FOR doc IN " + cn1 + " SORT doc.Hallo RETURN doc.Hallo";
       // check the return value
       let result = db._query(query).toArray();
@@ -454,35 +506,14 @@ function gatherBlockTestSuite () {
       assertTrue(indexNode.ascending);
       assertEqual(-1, nodeTypes.indexOf("SortNode"));
       assertNotEqual(-1, nodeTypes.indexOf("GatherNode"));
+      assertEqual(1, indexNode.projections.length);
+      assertEqual(["Hallo"], indexNode.projections[0].path);
+      assertTrue(indexNode.projections[0].hasOwnProperty("variable"));
+      assertTrue(indexNode.projections[0].variable.hasOwnProperty("id"));
       let gatherNode = nodes[nodeTypes.indexOf("GatherNode")];
       assertEqual(1, gatherNode.elements.length); // must do sorting in GatherNode
-      assertEqual(["Hallo"], gatherNode.elements[0].path); 
+      assertUndefined(gatherNode.elements[0].path); 
       assertTrue(gatherNode.elements[0].ascending);
-    },
-    
-    testMultipleShardsWithIndexDescending : function () {
-      idx = c1.ensureIndex({ type: "skiplist", fields: ["Hallo"] });
-      let query = "FOR doc IN " + cn1 + " SORT doc.Hallo DESC RETURN doc.Hallo";
-      // check the return value
-      let result = db._query(query).toArray();
-      let last = 99999999999;
-      result.forEach(function(value) {
-        assertTrue(value <= last);
-        last = value;
-      });
-      
-      let nodes = query_explain(query).plan.nodes;
-      let nodeTypes = nodes.map(function(node) { return node.type; });
-      // must have no sort but a gather node
-      assertNotEqual(-1, nodeTypes.indexOf("IndexNode"));
-      let indexNode = nodes[nodeTypes.indexOf("IndexNode")];
-      assertFalse(indexNode.ascending);
-      assertEqual(-1, nodeTypes.indexOf("SortNode"));
-      assertNotEqual(-1, nodeTypes.indexOf("GatherNode"));
-      let gatherNode = nodes[nodeTypes.indexOf("GatherNode")];
-      assertEqual(1, gatherNode.elements.length); // must do sorting in GatherNode
-      assertEqual(["Hallo"], gatherNode.elements[0].path); 
-      assertFalse(gatherNode.elements[0].ascending);
     },
     
     testMultipleShardsCollect : function () {

--- a/tests/js/client/aql/aql-gather-block-cluster.js
+++ b/tests/js/client/aql/aql-gather-block-cluster.js
@@ -1,5 +1,5 @@
 /*jshint globalstrict:false, strict:false, maxlen: 500 */
-/*global assertEqual, assertNotEqual, assertTrue, assertFalse */
+/*global assertEqual, assertNotEqual, assertTrue, assertFalse, assertUndefined */
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief tests for optimizer rules

--- a/tests/js/client/aql/aql-optimizer-indexes-multi.js
+++ b/tests/js/client/aql/aql-optimizer-indexes-multi.js
@@ -1024,14 +1024,9 @@ function optimizerIndexesMultiTestSuite () {
         assertNotEqual(-1, nodeTypes.indexOf("IndexNode"),
                        "no index used for: " + query);
         assertEqual("ReturnNode", nodeTypes[nodeTypes.length - 1], query);
-
-        // This is somewhat fragile, we test whether the 3rd node is
-        // a calculation node and the 4th is the Return Node
-        // No filtering needed any more
-        // Furthermore, we check the type of expression in the CalcNode
-        // and the number of subnodes:
-        assertEqual("CalculationNode", plan.nodes[2].type, query);
         assertEqual(-1, nodeTypes.indexOf("FilterNode"), "filter used for: " + query);
+        assertEqual(-1, nodeTypes.indexOf("SortNode"));
+        assertEqual(-1, nodeTypes.indexOf("CalculationNode"));
 
         var results = db._query(query);
         var correct = makeResult(maker).map(function(x) { return x.a; });
@@ -1242,12 +1237,8 @@ function optimizerIndexesMultiTestSuite () {
         assertNotEqual(-1, nodeTypes.indexOf("IndexNode"),
                        "no index used for: " + query);
         assertEqual("ReturnNode", nodeTypes[nodeTypes.length - 1], query);
-
-        // This is somewhat fragile, we test whether the 3rd node is
-        // a calculation node and the 4th is a filter refering to it.
-        // Furthermore, we check the type of expression in the CalcNode
-        // and the number of subnodes:
-        assertEqual("CalculationNode", plan.nodes[2].type, query);
+        assertEqual(-1, nodeTypes.indexOf("SortNode"));
+        assertEqual(-1, nodeTypes.indexOf("CalculationNode"));
 
         var results = db._query(query);
         var correct = makeResult(maker).map(function(x) { return x.a; });
@@ -1303,12 +1294,8 @@ function optimizerIndexesMultiTestSuite () {
         assertNotEqual(-1, nodeTypes.indexOf("IndexNode"),
                        "no index used for: " + query);
         assertEqual("ReturnNode", nodeTypes[nodeTypes.length - 1], query);
-
-        // This is somewhat fragile, we test whether the 3rd node is
-        // a calculation node and the 4th is a ReturnNode refering to it.
-        // Furthermore, we check the type of expression in the CalcNode
-        // and the number of subnodes:
-        assertEqual("CalculationNode", plan.nodes[2].type, query);
+        assertEqual(-1, nodeTypes.indexOf("SortNode"));
+        assertEqual(-1, nodeTypes.indexOf("CalculationNode"));
         
         var results = db._query(query);
         var correct = makeResult(maker).map(function(x) { return x.a; });
@@ -1360,12 +1347,8 @@ function optimizerIndexesMultiTestSuite () {
         assertNotEqual(-1, nodeTypes.indexOf("IndexNode"),
                        "no index used for: " + query);
         assertEqual("ReturnNode", nodeTypes[nodeTypes.length - 1], query);
-
-        // This is somewhat fragile, we test whether the 3rd node is
-        // a calculation node and the 4th is a SortNode.
-        // Furthermore, we check the type of expression in the CalcNode
-        // and the number of subnodes:
-        assertEqual("CalculationNode", plan.nodes[2].type, query);
+        assertEqual(-1, nodeTypes.indexOf("SortNode"));
+        assertEqual(-1, nodeTypes.indexOf("CalculationNode"));
         
         var results = db._query(query);
         var correct = makeResult(maker).map(function(x) { return x.a; });

--- a/tests/js/client/aql/aql-optimizer-rule-late-document-materialization.js
+++ b/tests/js/client/aql/aql-optimizer-rule-late-document-materialization.js
@@ -482,7 +482,7 @@ function lateDocumentMaterializationRuleTestSuite () {
       for (i = 0; i < numOfCollectionIndexes; ++i) {
         let query = "FOR c IN " + collectionNames[i] + " FILTER c.obj.a == 'a_val_1' SORT c.obj.c LIMIT 10 " +
                     "FOR d IN " + collectionNames[(i + 1) % numOfCollectionIndexes] + " FILTER c.obj.a == d.obj.a RETURN d";
-        let plan = db._createStatement({query: query, bindVars:  null, options:  {optimizer:{rules:["-reduce-extraction-to-projection"]}}}).explain().plan;
+        let plan = db._createStatement({query, bindVars: null, options: {optimizer:{rules:["-reduce-extraction-to-projection"]}}}).explain().plan;
         assertNotEqual(-1, plan.rules.indexOf(ruleName));
         let result = db._query(query).toArray();
         assertEqual(1, result.length);
@@ -634,7 +634,7 @@ function lateDocumentMaterializationRuleTestSuite () {
 
     testIssue14819: function () {
       let query = "FOR doc IN UNION((FOR doc IN " + severalIndexesCollectionName + " FILTER doc.a >= 1 && doc.a <= 10 COLLECT dt = DATE_FORMAT(DATE_TRUNC(doc.a, 'day'), '%yyyy-%mm-%dd') AGGREGATE sum = SUM(doc.b) LIMIT 1000000 RETURN { dt, sum }), []) LIMIT 1000000 RETURN doc";
-      let plans = db._createStatement({query: query, bindVars: null, options: { allPlans: true }}).explain().plans; 
+      let plans = db._createStatement({query, bindVars: null, options: { allPlans: true }}).explain().plans; 
       assertEqual(2, plans.length);
       // preferred plan without late materialization
       let plan = plans[0];

--- a/tests/js/client/aql/aql-optimizer-rule-optimize-projections.js
+++ b/tests/js/client/aql/aql-optimizer-rule-optimize-projections.js
@@ -36,29 +36,42 @@ function optimizerRuleTestSuite () {
 
   return {
 
-    setUp : function () {
+    setUpAll : function () {
       c = db._create(cn);
+      c.ensureIndex({ type: "persistent", fields: ["indexed1"] });
+      c.ensureIndex({ type: "persistent", fields: ["indexed2", "indexed3"] });
     },
 
-    tearDown : function () {
+    tearDownAll : function () {
       db._drop(cn);
     },
 
     testNoProjections : function () {
       const queries = [
+        // EnumerateCollectionNode
         // note: must use disableIndex: true here, so that the optimizer does not turn the full
         // scan into an index scan
-        "FOR doc IN @@cn OPTIONS { disableIndex: true } RETURN doc",
-        "FOR doc IN @@cn OPTIONS { disableIndex: true } FILTER doc.value1 == 1 RETURN doc",
-        "FOR doc IN @@cn OPTIONS { disableIndex: true } FILTER doc.value1 == 1 RETURN DISTINCT doc",
-        "FOR doc IN @@cn OPTIONS { disableIndex: true } COLLECT value = doc.value INTO g KEEP doc RETURN [value, g]",
+        ["FOR doc IN @@cn OPTIONS { disableIndex: true } RETURN doc", false],
+        ["FOR doc IN @@cn OPTIONS { disableIndex: true } FILTER doc.value1 == 1 RETURN doc", false],
+        ["FOR doc IN @@cn OPTIONS { disableIndex: true } FILTER doc.value1 == 1 RETURN DISTINCT doc", false],
+        ["FOR doc IN @@cn OPTIONS { disableIndex: true } COLLECT value = doc.value INTO g KEEP doc RETURN [value, g]", false],
+
+        // IndexNode
+        ["FOR doc IN @@cn SORT doc.indexed1 RETURN doc", true],
+        ["FOR doc IN @@cn FILTER doc.indexed1 == 1 RETURN DISTINCT doc", true],
+        ["FOR doc IN @@cn COLLECT value = doc.indexed1 INTO g KEEP doc RETURN [value, g]", true],
       ];
 
       queries.forEach(function(query) {
-        let result = db._createStatement({query, bindVars: { "@cn" : cn }}).explain();
-        let nodes = result.plan.nodes.filter((node) => node.type === 'EnumerateCollectionNode');
-        assertEqual(1, nodes.length);
-        assertEqual([], nodes[0].projections);
+        let result = db._createStatement({query: query[0], bindVars: { "@cn" : cn }}).explain();
+        let nodes;
+        if (query[1]) {
+          nodes = result.plan.nodes.filter((node) => node.type === 'IndexNode');
+        } else {
+          nodes = result.plan.nodes.filter((node) => node.type === 'EnumerateCollectionNode');
+        }
+        assertEqual(1, nodes.length, query);
+        assertEqual([], nodes[0].projections, query);
         if (nodes[0].filterProjections.length) {
           assertNotEqual(-1, result.plan.rules.indexOf(ruleName), query);
         } else {
@@ -66,32 +79,64 @@ function optimizerRuleTestSuite () {
         }
       });
     },
-
+    
     testProjections : function () {
+      const enn = "EnumerateCollectionNode";
+      const inn = "IndexNode";
+      const jnn = "JoinNode";
+
       const queries = [
+        // EnumerateCollectionNode
         // note: must use disableIndex: true here, so that the optimizer does not turn the full
         // scan into an index scan
-        ["FOR doc IN @@cn OPTIONS { disableIndex: true } RETURN doc.value1", ["value1"], 0 ],
-        ["FOR doc IN @@cn OPTIONS { disableIndex: true } FILTER doc.value1 > 3 RETURN doc.value1", ["value1"], 0 ],
-        ["FOR doc IN @@cn OPTIONS { disableIndex: true } FILTER doc.value1 > 3 RETURN doc.value2", ["value2"], 0 ],
-        ["FOR doc IN @@cn OPTIONS { disableIndex: true } FILTER doc.value1 > 3 RETURN [doc.value1, doc.value2]", ["value1", "value2"], 1 ],
-        ["FOR doc IN @@cn OPTIONS { disableIndex: true } FILTER doc.value1 > 3 FILTER doc.value2 > 3 RETURN doc.value5", ["value5"], 0 ],
-        ["FOR doc IN @@cn OPTIONS { disableIndex: true } FILTER doc.value1 > 3 FILTER doc.value2 > 3 RETURN [doc.value4, doc.value5]", ["value4", "value5"], 1 ],
-        ["FOR doc IN @@cn OPTIONS { disableIndex: true } FILTER doc.value1 > 3 FILTER doc.value2 > 3 FILTER doc.value3 > 4 RETURN doc.value5", ["value5"], 0 ],
-        ["FOR doc IN @@cn OPTIONS { disableIndex: true } FILTER doc.value1 > 3 FILTER doc.value2 > 3 FILTER doc.value3 > 4 RETURN doc.value1 + doc.value2 + doc.value3", ["value1", "value2", "value3"], 1 ],
+        ["FOR doc IN @@cn OPTIONS { disableIndex: true } RETURN doc.value1", enn, ["value1"], 0 ],
+        ["FOR doc IN @@cn OPTIONS { disableIndex: true } FILTER doc.value1 > 3 RETURN doc.value1", enn, ["value1"], 0 ],
+        ["FOR doc IN @@cn OPTIONS { disableIndex: true } FILTER doc.value1 > 3 RETURN doc.value2", enn, ["value2"], 0 ],
+        ["FOR doc IN @@cn OPTIONS { disableIndex: true } FILTER doc.value1 > 3 RETURN [doc.value1, doc.value2]", enn, ["value1", "value2"], 1 ],
+        ["FOR doc IN @@cn OPTIONS { disableIndex: true } FILTER doc.value1 > 3 FILTER doc.value2 > 3 RETURN doc.value5", enn, ["value5"], 0 ],
+        ["FOR doc IN @@cn OPTIONS { disableIndex: true } FILTER doc.value1 > 3 FILTER doc.value2 > 3 RETURN [doc.value4, doc.value5]", enn, ["value4", "value5"], 1 ],
+        ["FOR doc IN @@cn OPTIONS { disableIndex: true } FILTER doc.value1 > 3 FILTER doc.value2 > 3 FILTER doc.value3 > 4 RETURN doc.value5", enn, ["value5"], 0 ],
+        ["FOR doc IN @@cn OPTIONS { disableIndex: true } FILTER doc.value1 > 3 FILTER doc.value2 > 3 FILTER doc.value3 > 4 RETURN doc.value1 + doc.value2 + doc.value3", enn, ["value1", "value2", "value3"], 1 ],
+        
+        // IndexNode
+        ["FOR doc IN @@cn FILTER doc.indexed1 == 1 RETURN doc.indexed1", inn, ["indexed1"], 0 ],
+        ["FOR doc IN @@cn FILTER doc.indexed1 == 1 RETURN doc.indexed2", inn, ["indexed2"], 0 ],
+        ["FOR doc IN @@cn FILTER doc.indexed1 == 1 RETURN [doc.indexed1, doc.indexed2]", inn, ["indexed1", "indexed2"], 1 ],
+        ["FOR doc IN @@cn FILTER doc.indexed1 == 1 RETURN [doc._key, doc.indexed2]", inn, ["_key", "indexed2"], 1 ],
+        ["FOR doc IN @@cn FILTER doc.indexed1 == 1 FILTER doc.indexed2 == 2 RETURN doc.indexed2", inn, ["indexed2"], 0 ],
+        ["FOR doc IN @@cn FILTER doc.indexed1 == 1 FILTER doc.indexed2 == 2 RETURN doc._key", inn, ["_key"], 0 ],
+        ["FOR doc IN @@cn FILTER doc.indexed1 == 1 FILTER doc.indexed2 == 2 RETURN doc._id", inn, ["_id"], 0 ],
+        ["FOR doc IN @@cn SORT doc.indexed2 FILTER doc.indexed3 == 2 RETURN doc.indexed2", inn, ["indexed2"], 0 ],
+        ["FOR doc IN @@cn SORT doc.indexed2 FILTER doc.indexed3 == 2 RETURN doc._id", inn, ["_id"], 0 ],
+        
+        // JoinNode
+        ["FOR doc1 IN @@cn SORT doc1.indexed1 FOR doc2 IN @@cn FILTER doc1.indexed1 == doc2.indexed1 RETURN doc1._key", jnn, [["_key", "indexed1"], []], 0 ],
+        ["FOR doc1 IN @@cn SORT doc1.indexed1 FOR doc2 IN @@cn FILTER doc1.indexed1 == doc2.indexed1 RETURN [doc1._key, doc2.indexed1]", jnn, [["_key", "indexed1"], ["indexed1"]], 1 ],
+        ["FOR doc1 IN @@cn SORT doc1.indexed1 FOR doc2 IN @@cn FILTER doc1.indexed1 == doc2.indexed1 RETURN [doc1._key, doc2._key, doc2.foo]", jnn, [["_key", "indexed1"], ["_key", "foo"]], 1 ],
       ];
 
       queries.forEach(function(query) {
-        let result = db._createStatement({query: query[0], bindVars:{ "@cn" : cn }}).explain();
-        let nodes = result.plan.nodes.filter((node) => node.type === 'EnumerateCollectionNode');
-        assertEqual(1, nodes.length);
-        assertEqual(normalize(query[1]), normalize(nodes[0].projections), query);
-        nodes[0].projections.forEach((p) => {
-          assertTrue(p.hasOwnProperty("variable"));
-          assertMatch(/^\d+$/, p.variable.name);
-        });
+        let result = db._createStatement({query: query[0], bindVars: { "@cn" : cn }, options: {optimizer: { rules: ["-interchange-adjacent-enumerations"] }}}).explain();
+        let nodes = result.plan.nodes.filter((node) => node.type === query[1]);
+        assertEqual(1, nodes.length, query);
+        if (query[1] === jnn) {
+          // JoinNode needs special handling
+          nodes[0].indexInfos.forEach((ii, i) => {
+            assertEqual(normalize(query[2][i]), normalize(ii.projections), query);
+            ii.projections.forEach((p) => {
+              assertTrue(p.hasOwnProperty("variable"));
+              assertMatch(/^\d+$/, p.variable.name);
+            });
+          });
+        } else {
+          assertEqual(normalize(query[2]), normalize(nodes[0].projections), query);
+          nodes[0].projections.forEach((p) => {
+            assertTrue(p.hasOwnProperty("variable"));
+            assertMatch(/^\d+$/, p.variable.name);
+          });
+        }
         assertNotEqual(-1, result.plan.rules.indexOf(ruleName), query);
-        assertEqual(query[2], result.plan.nodes.filter((node) => node.type === 'CalculationNode').length, query);
+        assertEqual(query[3], result.plan.nodes.filter((node) => node.type === 'CalculationNode').length, query);
       });
     },
 

--- a/tests/js/client/aql/aql-optimizer-zkdindex-unique.js
+++ b/tests/js/client/aql/aql-optimizer-zkdindex-unique.js
@@ -72,7 +72,7 @@ function optimizerRuleZkd2dIndexTestSuite() {
             const explainRes = db._createStatement({query: query.query, bindVars:  query.bindVars}).explain();
             const appliedRules = explainRes.plan.rules;
             const nodeTypes = explainRes.plan.nodes.map(n => n.type).filter(n => !["GatherNode", "RemoteNode"].includes(n));
-            assertEqual(["SingletonNode", "IndexNode", "CalculationNode", "ReturnNode"], nodeTypes);
+            assertEqual(["SingletonNode", "IndexNode", "ReturnNode"], nodeTypes);
             assertTrue(appliedRules.includes(useIndexes));
             assertTrue(appliedRules.includes(removeFilterCoveredByIndex));
             const executeRes = db._query(query.query, query.bindVars);
@@ -90,7 +90,7 @@ function optimizerRuleZkd2dIndexTestSuite() {
             const explainRes = db._createStatement({query: query.query, bindVars:  query.bindVars}).explain();
             const appliedRules = explainRes.plan.rules;
             const nodeTypes = explainRes.plan.nodes.map(n => n.type).filter(n => !["GatherNode", "RemoteNode"].includes(n));
-            assertEqual(["SingletonNode", "IndexNode", "CalculationNode", "ReturnNode"], nodeTypes);
+            assertEqual(["SingletonNode", "IndexNode", "ReturnNode"], nodeTypes);
             assertTrue(appliedRules.includes(useIndexes));
             assertTrue(appliedRules.includes(removeFilterCoveredByIndex));
             const executeRes = db._query(query.query, query.bindVars);

--- a/tests/js/client/aql/aql-optimizer-zkdindex.js
+++ b/tests/js/client/aql/aql-optimizer-zkdindex.js
@@ -61,7 +61,7 @@ function optimizerRuleZkd2dIndexTestSuite() {
           FILTER d.i == 0
           RETURN d
       `;
-            const res = db._createStatement({query: query.query, bindVars:  query.bindVars}).explain();
+            const res = db._createStatement({query: query.query, bindVars: query.bindVars}).explain();
             const nodeTypes = res.plan.nodes.map(n => n.type).filter(n => !["GatherNode", "RemoteNode"].includes(n));
             const appliedRules = res.plan.rules;
             assertEqual(["SingletonNode", "EnumerateCollectionNode", "ReturnNode"], nodeTypes);
@@ -75,7 +75,7 @@ function optimizerRuleZkd2dIndexTestSuite() {
           FILTER d.x >= 0 && d.i == 0
           RETURN d
       `;
-            const res = db._createStatement({query: query.query, bindVars:  query.bindVars}).explain();
+            const res = db._createStatement({query: query.query, bindVars: query.bindVars}).explain();
             const nodeTypes = res.plan.nodes.map(n => n.type).filter(n => !["GatherNode", "RemoteNode"].includes(n));
             const appliedRules = res.plan.rules;
             assertEqual(["SingletonNode", "IndexNode", "ReturnNode"], nodeTypes);
@@ -90,10 +90,10 @@ function optimizerRuleZkd2dIndexTestSuite() {
           FILTER 0 <= d.x && d.x <= 1
           RETURN d.x
       `;
-            const explainRes = db._createStatement({query: query.query, bindVars:  query.bindVars}).explain();
+            const explainRes = db._createStatement({query: query.query, bindVars: query.bindVars}).explain();
             const appliedRules = explainRes.plan.rules;
             const nodeTypes = explainRes.plan.nodes.map(n => n.type).filter(n => !["GatherNode", "RemoteNode"].includes(n));
-            assertEqual(["SingletonNode", "IndexNode", "CalculationNode", "ReturnNode"], nodeTypes);
+            assertEqual(["SingletonNode", "IndexNode", "ReturnNode"], nodeTypes);
             assertTrue(appliedRules.includes(useIndexes));
             assertTrue(appliedRules.includes(removeFilterCoveredByIndex));
             const executeRes = db._query(query.query, query.bindVars);
@@ -108,10 +108,10 @@ function optimizerRuleZkd2dIndexTestSuite() {
           FILTER 0 <= d.x && d.y <= 1
           RETURN d.x
       `;
-            const explainRes = db._createStatement({query: query.query, bindVars:  query.bindVars}).explain();
+            const explainRes = db._createStatement({query: query.query, bindVars: query.bindVars}).explain();
             const appliedRules = explainRes.plan.rules;
             const nodeTypes = explainRes.plan.nodes.map(n => n.type).filter(n => !["GatherNode", "RemoteNode"].includes(n));
-            assertEqual(["SingletonNode", "IndexNode", "CalculationNode", "ReturnNode"], nodeTypes);
+            assertEqual(["SingletonNode", "IndexNode", "ReturnNode"], nodeTypes);
             assertTrue(appliedRules.includes(useIndexes));
             assertTrue(appliedRules.includes(removeFilterCoveredByIndex));
             const executeRes = db._query(query.query, query.bindVars);
@@ -127,10 +127,10 @@ function optimizerRuleZkd2dIndexTestSuite() {
           FILTER 10 <= d.y && d.y <= 16
           RETURN d.x
       `;
-            const explainRes = db._createStatement({query: query.query, bindVars:  query.bindVars}).explain();
+            const explainRes = db._createStatement({query: query.query, bindVars: query.bindVars}).explain();
             const appliedRules = explainRes.plan.rules;
             const nodeTypes = explainRes.plan.nodes.map(n => n.type).filter(n => !["GatherNode", "RemoteNode"].includes(n));
-            assertEqual(["SingletonNode", "IndexNode", "CalculationNode", "ReturnNode"], nodeTypes);
+            assertEqual(["SingletonNode", "IndexNode", "ReturnNode"], nodeTypes);
             assertTrue(appliedRules.includes(useIndexes));
             assertTrue(appliedRules.includes(removeFilterCoveredByIndex));
             const executeRes = db._query(query.query, query.bindVars);
@@ -146,10 +146,10 @@ function optimizerRuleZkd2dIndexTestSuite() {
           FILTER d.y >= 0 && d.y <= 11
           RETURN d.x
       `;
-            const explainRes = db._createStatement({query: query.query, bindVars:  query.bindVars}).explain();
+            const explainRes = db._createStatement({query: query.query, bindVars: query.bindVars}).explain();
             const appliedRules = explainRes.plan.rules;
             const nodeTypes = explainRes.plan.nodes.map(n => n.type).filter(n => !["GatherNode", "RemoteNode"].includes(n));
-            assertEqual(["SingletonNode", "IndexNode", "CalculationNode", "FilterNode", "CalculationNode", "ReturnNode"], nodeTypes);
+            assertEqual(["SingletonNode", "IndexNode", "CalculationNode", "FilterNode", "ReturnNode"], nodeTypes);
             assertTrue(appliedRules.includes(useIndexes));
             //assertTrue(appliedRules.includes(removeFilterCoveredByIndex)); -- TODO
             const executeRes = db._query(query.query, query.bindVars);
@@ -164,10 +164,10 @@ function optimizerRuleZkd2dIndexTestSuite() {
           FILTER 0 == d.x
           RETURN d.x
       `;
-            const explainRes = db._createStatement({query: query.query, bindVars:  query.bindVars}).explain();
+            const explainRes = db._createStatement({query: query.query, bindVars: query.bindVars}).explain();
             const appliedRules = explainRes.plan.rules;
             const nodeTypes = explainRes.plan.nodes.map(n => n.type).filter(n => !["GatherNode", "RemoteNode"].includes(n));
-            assertEqual(["SingletonNode", "IndexNode", "CalculationNode", "ReturnNode"], nodeTypes);
+            assertEqual(["SingletonNode", "IndexNode", "ReturnNode"], nodeTypes);
             assertTrue(appliedRules.includes(useIndexes));
             assertTrue(appliedRules.includes(removeFilterCoveredByIndex));
             const executeRes = db._query(query.query, query.bindVars);
@@ -182,10 +182,10 @@ function optimizerRuleZkd2dIndexTestSuite() {
           FILTER 0 == d.x && 0 == d.y
           RETURN d.x
       `;
-            const explainRes = db._createStatement({query: query.query, bindVars:  query.bindVars}).explain();
+            const explainRes = db._createStatement({query: query.query, bindVars: query.bindVars}).explain();
             const appliedRules = explainRes.plan.rules;
             const nodeTypes = explainRes.plan.nodes.map(n => n.type).filter(n => !["GatherNode", "RemoteNode"].includes(n));
-            assertEqual(["SingletonNode", "IndexNode", "CalculationNode", "ReturnNode"], nodeTypes);
+            assertEqual(["SingletonNode", "IndexNode", "ReturnNode"], nodeTypes);
             assertTrue(appliedRules.includes(useIndexes));
             assertTrue(appliedRules.includes(removeFilterCoveredByIndex));
             const executeRes = db._query(query.query, query.bindVars);
@@ -200,10 +200,10 @@ function optimizerRuleZkd2dIndexTestSuite() {
           FILTER 0 < d.x && d.y <= 1
           RETURN d.x
       `;
-            const explainRes = db._createStatement({query: query.query, bindVars:  query.bindVars}).explain();
+            const explainRes = db._createStatement({query: query.query, bindVars: query.bindVars}).explain();
             const appliedRules = explainRes.plan.rules;
             const nodeTypes = explainRes.plan.nodes.map(n => n.type).filter(n => !["GatherNode", "RemoteNode"].includes(n));
-            assertEqual(["SingletonNode", "IndexNode", "CalculationNode", "ReturnNode"], nodeTypes);
+            assertEqual(["SingletonNode", "IndexNode", "ReturnNode"], nodeTypes);
             assertTrue(appliedRules.includes(useIndexes));
             assertTrue(appliedRules.includes(removeFilterCoveredByIndex));
             assertTrue(appliedRules.includes(moveFiltersIntoEnumerate));

--- a/tests/js/client/aql/aql-profiler-noncluster.js
+++ b/tests/js/client/aql/aql-profiler-noncluster.js
@@ -353,7 +353,6 @@ function ahuacatlProfilerTestSuite() {
           {type: CalculationBlock, calls: 1, items: 1, filtered: 0},
           {type: EnumerateListBlock, calls: batches, items: rows, filtered: 0},
           {type: IndexBlock, calls: indexBatches, items: rows, filtered: 0},
-          {type: CalculationBlock, calls: indexBatches, items: rows, filtered: 0},
           {type: ReturnBlock, calls: indexBatches, items: rows, filtered: 0}
         ];
       };
@@ -427,7 +426,6 @@ function ahuacatlProfilerTestSuite() {
           {type: CalculationBlock, calls: 1, items: 1, filtered: 0},
           {type: EnumerateListBlock, calls: enumBatches, items: enumRows, filtered: 0},
           {type: IndexBlock, calls: indexBatches, items: indexRows, filtered: 0},
-          {type: CalculationBlock, calls: indexBatches, items: indexRows, filtered: 0},
           {type: ReturnBlock, calls: indexBatches, items: indexRows, filtered: 0}
         ];
       };
@@ -478,7 +476,6 @@ function ahuacatlProfilerTestSuite() {
         return [
           {type: SingletonBlock, calls: 1, items: 1, filtered: 0},
           {type: IndexBlock, calls: batches, items: rows, filtered: 0},
-          {type: CalculationBlock, calls: batches, items: rows, filtered: 0},
           {type: ReturnBlock, calls: batches, items: rows, filtered: 0}
         ];
       };

--- a/tests/js/client/aql/aql-refaccess-attribute.js
+++ b/tests/js/client/aql/aql-refaccess-attribute.js
@@ -48,10 +48,6 @@ function ahuacatlRefAccessAttributeTestSuite () {
 
   return {
 
-////////////////////////////////////////////////////////////////////////////////
-/// @brief set up
-////////////////////////////////////////////////////////////////////////////////
-
     setUpAll : function () {
       internal.db._drop("UnitTestsAhuacatlRefAccess");
       collection = internal.db._create("UnitTestsAhuacatlRefAccess");
@@ -65,10 +61,6 @@ function ahuacatlRefAccessAttributeTestSuite () {
       collection.ensureIndex({ type: "persistent", fields: ["val"] });
     },
 
-////////////////////////////////////////////////////////////////////////////////
-/// @brief tear down
-////////////////////////////////////////////////////////////////////////////////
-
     tearDownAll : function () {
       internal.db._drop("UnitTestsAhuacatlRefAccess");
     },
@@ -78,7 +70,7 @@ function ahuacatlRefAccessAttributeTestSuite () {
 ////////////////////////////////////////////////////////////////////////////////
 
     testRefEq : function () {
-      var expected = [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ];
+      const expected = [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ];
 
       assertEqual(expected, runQuery("(i.val == j.val)"));
       assertEqual(expected, runQuery("(j.val == i.val)"));
@@ -89,7 +81,7 @@ function ahuacatlRefAccessAttributeTestSuite () {
 ////////////////////////////////////////////////////////////////////////////////
 
     testRefGt : function () {
-      var expected = [ 2, 3, 3, 4, 4, 4, 5, 5, 5, 5, 6, 6, 6, 6, 6, 7, 7, 7, 7, 7, 7, 8, 8, 8, 8, 8, 8, 8, 9, 9, 9, 9, 9, 9, 9, 9, 10, 10, 10, 10, 10, 10, 10, 10, 10 ];
+      const expected = [ 2, 3, 3, 4, 4, 4, 5, 5, 5, 5, 6, 6, 6, 6, 6, 7, 7, 7, 7, 7, 7, 8, 8, 8, 8, 8, 8, 8, 9, 9, 9, 9, 9, 9, 9, 9, 10, 10, 10, 10, 10, 10, 10, 10, 10 ];
 
       assertEqual(expected, runQuery("(i.val > j.val)"));
       assertEqual(expected, runQuery("(j.val < i.val)")); 
@@ -100,7 +92,7 @@ function ahuacatlRefAccessAttributeTestSuite () {
 ////////////////////////////////////////////////////////////////////////////////
 
     testRefGe : function () {
-      var expected = [ 1, 2, 2, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5, 5, 6, 6, 6, 6, 6, 6, 7, 7, 7, 7, 7, 7, 7, 8, 8, 8, 8, 8, 8, 8, 8, 9, 9, 9, 9, 9, 9, 9, 9, 9, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10 ];
+      const expected = [ 1, 2, 2, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5, 5, 6, 6, 6, 6, 6, 6, 7, 7, 7, 7, 7, 7, 7, 8, 8, 8, 8, 8, 8, 8, 8, 9, 9, 9, 9, 9, 9, 9, 9, 9, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10 ];
 
       assertEqual(expected, runQuery("(i.val >= j.val)"));
       assertEqual(expected, runQuery("(j.val <= i.val)"));
@@ -111,7 +103,7 @@ function ahuacatlRefAccessAttributeTestSuite () {
 ////////////////////////////////////////////////////////////////////////////////
 
     testRefLt : function () {
-      var expected = [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 4, 4, 4, 4, 4, 4, 5, 5, 5, 5, 5, 6, 6, 6, 6, 7, 7, 7, 8, 8, 9 ];
+      const expected = [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 4, 4, 4, 4, 4, 4, 5, 5, 5, 5, 5, 6, 6, 6, 6, 7, 7, 7, 8, 8, 9 ];
 
       assertEqual(expected, runQuery("(i.val < j.val)"));
       assertEqual(expected, runQuery("(j.val > i.val)"));
@@ -122,7 +114,7 @@ function ahuacatlRefAccessAttributeTestSuite () {
 ////////////////////////////////////////////////////////////////////////////////
 
     testRefLe : function () {
-      var expected = [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 4, 4, 4, 4, 4, 4, 4, 5, 5, 5, 5, 5, 5, 6, 6, 6, 6, 6, 7, 7, 7, 7, 8, 8, 8, 9, 9, 10 ];
+      const expected = [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 4, 4, 4, 4, 4, 4, 4, 5, 5, 5, 5, 5, 5, 6, 6, 6, 6, 6, 7, 7, 7, 7, 8, 8, 8, 9, 9, 10 ];
 
       assertEqual(expected, runQuery("(i.val <= j.val)"));
       assertEqual(expected, runQuery("(j.val >= i.val)"));
@@ -133,7 +125,7 @@ function ahuacatlRefAccessAttributeTestSuite () {
 ////////////////////////////////////////////////////////////////////////////////
 
     testRefMergeAnd1 : function () {
-      var expected = [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ];
+      const expected = [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ];
 
       assertEqual(expected, runQuery("(i.val == j.val && i.val >= j.val)"));
       assertEqual(expected, runQuery("(j.val == i.val && j.val <= i.val)"));
@@ -159,7 +151,7 @@ function ahuacatlRefAccessAttributeTestSuite () {
 ////////////////////////////////////////////////////////////////////////////////
 
     testRefMergeAnd2 : function () {
-      var expected = [ 2, 3, 3, 4, 4, 4, 5, 5, 5, 5, 6, 6, 6, 6, 6, 7, 7, 7, 7, 7, 7, 8, 8, 8, 8, 8, 8, 8, 9, 9, 9, 9, 9, 9, 9, 9, 10, 10, 10, 10, 10, 10, 10, 10, 10 ];
+      const expected = [ 2, 3, 3, 4, 4, 4, 5, 5, 5, 5, 6, 6, 6, 6, 6, 7, 7, 7, 7, 7, 7, 8, 8, 8, 8, 8, 8, 8, 9, 9, 9, 9, 9, 9, 9, 9, 10, 10, 10, 10, 10, 10, 10, 10, 10 ];
 
       assertEqual(expected, runQuery("(i.val > j.val && i.val >= j.val)"));
       assertEqual(expected, runQuery("(j.val < i.val && j.val <= i.val)"));
@@ -172,7 +164,7 @@ function ahuacatlRefAccessAttributeTestSuite () {
 ////////////////////////////////////////////////////////////////////////////////
 
     testRefMergeAnd3 : function () {
-      var expected = [ 1, 2, 2, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5, 5, 6, 6, 6, 6, 6, 6, 7, 7, 7, 7, 7, 7, 7, 8, 8, 8, 8, 8, 8, 8, 8, 9, 9, 9, 9, 9, 9, 9, 9, 9, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10 ];
+      const expected = [ 1, 2, 2, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5, 5, 6, 6, 6, 6, 6, 6, 7, 7, 7, 7, 7, 7, 7, 8, 8, 8, 8, 8, 8, 8, 8, 9, 9, 9, 9, 9, 9, 9, 9, 9, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10 ];
 
       assertEqual(expected, runQuery("(i.val >= j.val && i.val >= j.val)"));
       assertEqual(expected, runQuery("(j.val <= i.val && j.val <= i.val)"));
@@ -183,7 +175,7 @@ function ahuacatlRefAccessAttributeTestSuite () {
 ////////////////////////////////////////////////////////////////////////////////
 
     testRefMergeAnd4 : function () {
-      var expected = [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 4, 4, 4, 4, 4, 4, 5, 5, 5, 5, 5, 6, 6, 6, 6, 7, 7, 7, 8, 8, 9 ];
+      const expected = [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 4, 4, 4, 4, 4, 4, 5, 5, 5, 5, 5, 6, 6, 6, 6, 7, 7, 7, 8, 8, 9 ];
 
       assertEqual(expected, runQuery("(i.val < j.val && i.val <= j.val)"));
       assertEqual(expected, runQuery("(j.val > i.val && j.val >= i.val)"));
@@ -196,7 +188,7 @@ function ahuacatlRefAccessAttributeTestSuite () {
 ////////////////////////////////////////////////////////////////////////////////
 
     testRefMergeAnd5 : function () {
-      var expected = [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 4, 4, 4, 4, 4, 4, 4, 5, 5, 5, 5, 5, 5, 6, 6, 6, 6, 6, 7, 7, 7, 7, 8, 8, 8, 9, 9, 10 ];
+      const expected = [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 4, 4, 4, 4, 4, 4, 4, 5, 5, 5, 5, 5, 5, 6, 6, 6, 6, 6, 7, 7, 7, 7, 8, 8, 8, 9, 9, 10 ];
 
       assertEqual(expected, runQuery("(i.val <= j.val && i.val <= j.val)"));
       assertEqual(expected, runQuery("(j.val >= i.val && j.val >= i.val)"));
@@ -207,7 +199,7 @@ function ahuacatlRefAccessAttributeTestSuite () {
 ////////////////////////////////////////////////////////////////////////////////
 
     testRefMergeAnd6 : function () {
-      var expected = [ ];
+      const expected = [ ];
 
       assertEqual(expected, runQuery("(i.val > j.val && i.val < j.val)"));
       assertEqual(expected, runQuery("(j.val < i.val && j.val > i.val)"));


### PR DESCRIPTION
### Scope & Purpose

Follow-up PR to https://github.com/arangodb/arangodb/pull/20023

Extract document attribute projections of `INDEX` nodes and `JOIN` nodes into individual output registers, instead of storing them in a combined VelocyPack object.
Previously, the projected attributes of a document were all stored together in a newly-built VelocyPack object. For example, if the projections "a" and "b" were used, a new VelocyPack object {"a":..., "b": ... } was built and stored in the ExecutionNode's main output register.

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [x] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
