### PR TITLE
Silence TSAN w.r.t. SCHEDULER pointer on shutdown [BTS-1671]

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 devel
 -----
 
+* Silence TSAN for shutdown for access to the SchedulerFeature::SCHEDULER
+  pointer using atomic references.
+
 * Fixed a race in controlled leader change which could lead to a situation 
   in which a shard follower is dropped when the first write operation
   happens. This fixes BTS-1647.

--- a/arangod/Scheduler/SchedulerFeature.cpp
+++ b/arangod/Scheduler/SchedulerFeature.cpp
@@ -369,7 +369,17 @@ void SchedulerFeature::stop() {
 }
 
 void SchedulerFeature::unprepare() {
-  SCHEDULER = nullptr;
+  // SCHEDULER = nullptr;
+  // This is to please the TSAN sanitizer: On shutdown, we set this global
+  // pointer to nullptr. Other threads read the pointer, but the logic of
+  // ApplicationFeatures should ensure that nobody will read the pointer
+  // out after the SchedulerFeature has run its unprepare method.
+  // Sometimes the TSAN sanitizer cannot recognize this indirect
+  // synchronization and complains about reads that have happened before
+  // this write here, but are not officially inter-thread synchronized.
+  // We use the atomic reference here and in these places to silence TSAN.
+  std::atomic_ref<Scheduler*> schedulerRef{SCHEDULER};
+  schedulerRef.store(nullptr, std::memory_order_relaxed);
   _scheduler.reset();
 }
 


### PR DESCRIPTION
### Scope & Purpose

This addresses https://arangodb.atlassian.net/browse/BTS-1671.

It is to silence TSAN in some shutdown cases in RTA.

There is a global pointer called SchedulerFeature::SCHEDULER. On
shutdown, we set this pointer to nullptr in the
SchedulerFeature::unprepare method. In various other places, we read out
the pointer.

The logic of ApplicationFeatures should ensure that nobody will read
the pointer out after the SchedulerFeature has run its unprepare
method. Sometimes the TSAN sanitizer cannot recognize this indirect
synchronization and complains about reads that have happened before the
write there, but are not officially inter-thread synchronized. We use
atomic references in some places to silence TSAN.

- [*] :hankey: Bugfix

### Checklist

- [*] :book: CHANGELOG entry made
- [ ] Backports
  - [*] Backport for 3.11: https://github.com/arangodb/arangodb/pull/20062
  - [ ] Backport for 3.10:

#### Related Information

- [*] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/BTS-1671

