### PR TITLE
Fix set_exception overloads for Try

### DIFF
--- a/lib/Futures/include/Futures/Try.h
+++ b/lib/Futures/include/Futures/Try.h
@@ -381,10 +381,6 @@ class Try<void> {
 
   /// Set an exception value into this Try object.
   /// This has the effect of clearing any existing exception stored
-  void set_exception(std::exception_ptr e) noexcept { _exception = e; }
-
-  /// Set an exception value into this Try object.
-  /// This has the effect of clearing any existing exception stored
   void set_exception(std::exception_ptr const& e) noexcept { _exception = e; }
 
   /// Set an exception value into this Try object.


### PR DESCRIPTION
### Scope & Purpose

We have 3 overloads `Value, Value const&, Value&&`.
For some cases it causes compiler error about ambiguities.
Also first overload is unnecessary.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

