### PR TITLE
Silence TSAN w.r.t. SCHEDULER pointer on shutdown

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 v3.11.5 (XXXX-XX-XX)
 --------------------
 
+* Silence TSAN for shutdown for access to the SchedulerFeature::SCHEDULER
+  pointer using atomic references.
+
 * Fixed a race in controlled leader change which could lead to a situation in
   which a shard follower is dropped when the first write operation happens. This
   fixes BTS-1647.

--- a/arangod/Network/Methods.cpp
+++ b/arangod/Network/Methods.cpp
@@ -259,7 +259,14 @@ void actuallySendRequest(std::shared_ptr<Pack>&& p, ConnectionPool* pool,
           return;
         }
 
-        auto* sch = SchedulerFeature::SCHEDULER;
+        // We access the global SCHEDULER pointer here via an atomic
+        // reference. This is to silence TSAN, which often detects a data
+        // race on this pointer, since this read access here can occasionally
+        // happen before the write in SchedulerFeature::unprepare, which
+        // invalidates the pointer. But even if the read here would happen
+        // later, we check for nullptr below, so all would be good.
+        std::atomic_ref<Scheduler*> schedulerRef{SchedulerFeature::SCHEDULER};
+        auto* sch = schedulerRef.load(std::memory_order_relaxed);
         // cppcheck-suppress accessMoved
         if (p->skipScheduler || sch == nullptr) {
           p->promise.setValue(network::Response{

--- a/arangod/Network/Methods.cpp
+++ b/arangod/Network/Methods.cpp
@@ -265,7 +265,8 @@ void actuallySendRequest(std::shared_ptr<Pack>&& p, ConnectionPool* pool,
         // happen before the write in SchedulerFeature::unprepare, which
         // invalidates the pointer. But even if the read here would happen
         // later, we check for nullptr below, so all would be good.
-        std::atomic_ref<Scheduler*> schedulerRef{SchedulerFeature::SCHEDULER};
+        std::atomic_ref<SupervisedScheduler*> schedulerRef{
+            SchedulerFeature::SCHEDULER};
         auto* sch = schedulerRef.load(std::memory_order_relaxed);
         // cppcheck-suppress accessMoved
         if (p->skipScheduler || sch == nullptr) {

--- a/arangod/Scheduler/SchedulerFeature.cpp
+++ b/arangod/Scheduler/SchedulerFeature.cpp
@@ -359,7 +359,17 @@ void SchedulerFeature::stop() {
 }
 
 void SchedulerFeature::unprepare() {
-  SCHEDULER = nullptr;
+  // SCHEDULER = nullptr;
+  // This is to please the TSAN sanitizer: On shutdown, we set this global
+  // pointer to nullptr. Other threads read the pointer, but the logic of
+  // ApplicationFeatures should ensure that nobody will read the pointer
+  // out after the SchedulerFeature has run its unprepare method.
+  // Sometimes the TSAN sanitizer cannot recognize this indirect
+  // synchronization and complains about reads that have happened before
+  // this write here, but are not officially inter-thread synchronized.
+  // We use the atomic reference here and in these places to silence TSAN.
+  std::atomic_ref<Scheduler*> schedulerRef{SCHEDULER};
+  schedulerRef.store(nullptr, std::memory_order_relaxed);
   _scheduler.reset();
 }
 

--- a/arangod/Scheduler/SchedulerFeature.cpp
+++ b/arangod/Scheduler/SchedulerFeature.cpp
@@ -368,7 +368,7 @@ void SchedulerFeature::unprepare() {
   // synchronization and complains about reads that have happened before
   // this write here, but are not officially inter-thread synchronized.
   // We use the atomic reference here and in these places to silence TSAN.
-  std::atomic_ref<Scheduler*> schedulerRef{SCHEDULER};
+  std::atomic_ref<SupervisedScheduler*> schedulerRef{SCHEDULER};
   schedulerRef.store(nullptr, std::memory_order_relaxed);
   _scheduler.reset();
 }

--- a/tsan_arangodb_suppressions.txt
+++ b/tsan_arangodb_suppressions.txt
@@ -11,6 +11,8 @@ race:SharedAqlItemBlockPtr::operator->
 signal:lib/Basics/CrashHandler.cpp
 signal:crashHandlerSignalHandler
 
+signal:c_exit_handler
+
 # A compiler optimization in DBImpl::ReleaseSnapshot() produces code where a
 # register is populated with different addresses based on some condition, and
 # this register is later read to populate the variable `oldest_snapshot`.


### PR DESCRIPTION
### Scope & Purpose

This is a backport of https://github.com/arangodb/arangodb/pull/20056 .

This addresses https://arangodb.atlassian.net/browse/BTS-1671.

It is to silence TSAN in some shutdown cases in RTA.

There is a global pointer called SchedulerFeature::SCHEDULER. On
shutdown, we set this pointer to nullptr in the
SchedulerFeature::unprepare method. In various other places, we read out
the pointer.

The logic of ApplicationFeatures should ensure that nobody will read
the pointer out after the SchedulerFeature has run its unprepare
method. Sometimes the TSAN sanitizer cannot recognize this indirect
synchronization and complains about reads that have happened before the
write there, but are not officially inter-thread synchronized. We use
atomic references in some places to silence TSAN.

- [*] :hankey: Bugfix

### Checklist

- [*] :book: CHANGELOG entry made
- [*] Backports
  - [*] Backport for 3.11: This is it.

#### Related Information

- [*] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/BTS-1671
- [*] Devel PR: https://github.com/arangodb/arangodb/pull/20056


