### PR TITLE
attempt to fix invalid vptr in InitialSyncer dtor

### DIFF
--- a/arangod/Replication/InitialSyncer.cpp
+++ b/arangod/Replication/InitialSyncer.cpp
@@ -44,7 +44,12 @@ InitialSyncer::~InitialSyncer() {
 
   try {
     if (!_state.isChildSyncer) {
-      _batch.finish(_state.connection, _progress, _state.syncerId);
+      // we cannot pass _progress here because it refers to
+      // some properties of the derived class (DatabaseInitialSyncer).
+      // instead we create our own progress info object here
+      // that does nothing.
+      replutils::ProgressInfo progress([](std::string const&) {});
+      _batch.finish(_state.connection, progress, _state.syncerId);
     }
   } catch (...) {
   }


### PR DESCRIPTION
### Scope & Purpose

In the destructor of `InitialSyncer`, it hands `_progress` to `replication::BatchInfo::finish(...)`. That method can invoke `_progress` under some conditions. If it does, then it will call `DatabaseInitialSyncer::setProgress(...)`, which refers to the already destroyed `DatabaseInitialSyncer` derived class.
This PR is a potential bugfix for this.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 