### PR TITLE
[3.10] Fix race in MoveShardSyncFail Test

### DIFF
--- a/arangod/Cluster/DBServerAgencySync.cpp
+++ b/arangod/Cluster/DBServerAgencySync.cpp
@@ -309,11 +309,6 @@ DBServerAgencySyncResult DBServerAgencySync::execute() {
                                           local, serverId, mfeature, rb,
                                           currentShardLocks);
 
-    TRI_IF_FAILURE("Maintenance::AfterPhaseTwo") {
-      observeGlobalEvent("Maintenance::AfterPhaseTwo",
-                         ServerState::instance()->getShortName());
-    }
-
     LOG_TOPIC("dfc54", TRACE, Logger::MAINTENANCE)
         << "DBServerAgencySync::phaseTwo done";
 

--- a/tests/js/client/shell/shell-move-shard-sync-fail-cluster.js
+++ b/tests/js/client/shell/shell-move-shard-sync-fail-cluster.js
@@ -139,7 +139,6 @@ function moveShardSynchronizeShardFailureSuite() {
           `HandleLeadership::before ${collInfo.follower}:${collInfo.shard} HandleLeadershipBefore`,
           `HandleLeadership::after ${collInfo.follower}:${collInfo.shard} HandleLeadershipAfter`,
           `Maintenance::BeforePhaseTwo ${collInfo.follower} LeaderSendsCurrent`,
-          `Maintenance::AfterPhaseTwo ${collInfo.follower} LeaderSentCurrent`,
           `ClusterInfo::loadCurrentSeesLeader ${collInfo.leader}:${collInfo.shard}:${followerId} FollowerUpdatesCurrent`,
           `ClusterInfo::loadCurrentDone ${collInfo.leader} FollowerHasUpdatedCurrent`,
           `SynchronizeShard::beginning2 ${collInfo.leader}:${collInfo.shard} SynchronizeShardStartedContinuing`,
@@ -156,7 +155,6 @@ function moveShardSynchronizeShardFailureSuite() {
         debugSetFailAt(followerEndpoint, "HandleLeadership::before");
         debugSetFailAt(followerEndpoint, "HandleLeadership::after");
         debugSetFailAt(followerEndpoint, "Maintenance::BeforePhaseTwo");
-        debugSetFailAt(followerEndpoint, "Maintenance::AfterPhaseTwo");
         debugSetFailAt(leaderEndpoint, "SynchronizeShard::beginning");
         debugSetFailAt(leaderEndpoint, "SynchronizeShard::beforeSetTheLeader");
         debugSetFailAt(leaderEndpoint, "ClusterInfo::loadCurrentSeesLeader");


### PR DESCRIPTION
Backport of https://github.com/arangodb/arangodb/pull/20066

### Scope & Purpose

*Test only change. We do not necessarily need to wait for one condition in the Test so I removed it. There is a timewindow where the removed condition was triggered only after the following one was seen on a different server, causing the test tu stuck.*

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

