### PR TITLE
don't output 'undefined' - this will give NaN in the xml

### DIFF
--- a/js/client/modules/@arangodb/testutils/result-processing.js
+++ b/js/client/modules/@arangodb/testutils/result-processing.js
@@ -291,7 +291,7 @@ function saveToJunitXML(options, results) {
   }
 
   const addOptionalDuration = (elem, test) => {
-    if (test.hasOwnProperty('duration')) {
+    if (test.hasOwnProperty('duration') && test.duration !== undefined) {
       // time is in seconds
       elem['time'] =  test.duration / 1000;
     }


### PR DESCRIPTION
### Scope & Purpose

we would output NaN into the xml file, this came from the value `undefined`.

- [x] :hankey: Bugfix
- [x] Backports:
  - [x] [3.11](https://github.com/arangodb/arangodb/pull/20079)
  - [x] [3.10](https://github.com/arangodb/arangodb/pull/20080)
