### PR TITLE
[CINFRA] Make ResponseCodes of Replication2 compatible to Replication1

### DIFF
--- a/arangod/RestHandler/RestCollectionHandler.cpp
+++ b/arangod/RestHandler/RestCollectionHandler.cpp
@@ -508,7 +508,7 @@ RestStatus RestCollectionHandler::handleCommandPut() {
     _activeTrx->addHint(transaction::Hints::Hint::ALLOW_RANGE_DELETE);
     res = _activeTrx->begin();
     if (res.fail()) {
-      generateError(res);
+      generateTransactionError(coll->name(), OperationResult(res, opts), "");
       _activeTrx.reset();
       return RestStatus::DONE;
     }

--- a/arangod/RocksDBEngine/ReplicatedRocksDBTransactionCollection.cpp
+++ b/arangod/RocksDBEngine/ReplicatedRocksDBTransactionCollection.cpp
@@ -211,7 +211,13 @@ auto ReplicatedRocksDBTransactionCollection::ensureCollection() -> Result {
       // index creation is read-only, but might still use an exclusive lock
       !_transaction->hasHint(transaction::Hints::Hint::INDEX_CREATION) &&
       _leaderState == nullptr) {
-    _leaderState = _collection->getDocumentStateLeader();
+    try {
+      _leaderState = _collection->getDocumentStateLeader();
+    } catch (basics::Exception const& ex) {
+      return {ex.code(), std::move(ex.message())};
+    } catch (...) {
+      throw;
+    }
     ADB_PROD_ASSERT(_leaderState != nullptr);
   }
 

--- a/arangod/Transaction/Methods.cpp
+++ b/arangod/Transaction/Methods.cpp
@@ -2383,6 +2383,10 @@ Result transaction::Methods::determineReplication2TypeAndFollowers(
     replicationType = ReplicationType::NONE;
     return {};
   }
+  // API compatibility: Let us always refuse a Replication request
+  if (!options.isSynchronousReplicationFrom.empty()) {
+    return {TRI_ERROR_CLUSTER_SHARD_LEADER_REFUSES_REPLICATION};
+  }
 
   // The context type is a good indicator of the replication type.
   // A transaction created on a follower always has a ReplicatedContext, whereas


### PR DESCRIPTION
### Scope & Purpose

*In the Document and Collection API if we send an Replication1 type request, the Replication2 API now returns the same error codes if send to wrong server (leader and follower). Fixes parts of: https://arangodb.atlassian.net/browse/BTS-1565*

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [x] GitHub issue / Jira ticket: Fixes parts of: https://arangodb.atlassian.net/browse/BTS-1565
- [ ] Design document: 

