### PR TITLE
fix 2 issues that g++-13 rants about

### DIFF
--- a/arangod/VocBase/Properties/CreateCollectionBody.cpp
+++ b/arangod/VocBase/Properties/CreateCollectionBody.cpp
@@ -834,7 +834,7 @@ ResultT<CreateCollectionBody> CreateCollectionBody::fromRestoreAPIBody(
     if (res.fail() && res.is(TRI_ERROR_ONLY_ENTERPRISE)) {
       // This API always returns BAD_PARAMETER for community, so we need to
       // rewrite the message
-      return Result{TRI_ERROR_BAD_PARAMETER, std::move(res.errorMessage())};
+      return Result{TRI_ERROR_BAD_PARAMETER, res.errorMessage()};
     }
     return res;
   }

--- a/lib/Containers/MerkleTree.cpp
+++ b/lib/Containers/MerkleTree.cpp
@@ -620,8 +620,8 @@ void MerkleTree<Hasher, BranchingBits>::insert(
   std::vector<std::uint64_t> sortedKeys = keys;
   std::sort(sortedKeys.begin(), sortedKeys.end());
 
-  std::uint64_t minKey = sortedKeys[0];
-  std::uint64_t maxKey = sortedKeys[sortedKeys.size() - 1];
+  std::uint64_t minKey = sortedKeys.front();
+  std::uint64_t maxKey = sortedKeys.back();
 
   std::unique_lock<std::shared_mutex> guard(_dataLock);
 
@@ -657,8 +657,8 @@ void MerkleTree<Hasher, BranchingBits>::remove(
   std::vector<std::uint64_t> sortedKeys = keys;
   std::sort(sortedKeys.begin(), sortedKeys.end());
 
-  std::uint64_t minKey = sortedKeys[0];
-  std::uint64_t maxKey = sortedKeys[sortedKeys.size() - 1];
+  std::uint64_t minKey = sortedKeys.front();
+  std::uint64_t maxKey = sortedKeys.back();
 
   std::unique_lock<std::shared_mutex> guard(_dataLock);
 


### PR DESCRIPTION
### Scope & Purpose

Fix 2 small issues that g++-13 finds unacceptable to compile.
These changes are not relevant for other compiler versions, but shouldn't cause any issues either.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 