### PR TITLE
Add more complexity to testing

### DIFF
--- a/tests/js/client/aql/aql-index-join-multi-unique-false-sort-false-bucket0_3.js
+++ b/tests/js/client/aql/aql-index-join-multi-unique-false-sort-false-bucket0_3.js
@@ -1,0 +1,37 @@
+/*jshint globalstrict:false, strict:false, maxlen: 500 */
+/*global fail, assertEqual, assertNotEqual, assertTrue, __filename */
+
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2010-2016 ArangoDB GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+const jsunity = require("jsunity");
+const joinHelper = require("@arangodb/testutils/joinHelper.js");
+
+const unique = false;
+const sort = false;
+
+const parameters = joinHelper.createParameters(unique, sort, 0, 3);
+
+for (const configs of Object.values(parameters)) {
+  jsunity.run(function () {
+    return joinHelper.createIndexJoinTestMultiSuite(configs);
+  });
+}
+return jsunity.done();

--- a/tests/js/client/aql/aql-index-join-multi-unique-false-sort-false-bucket0_3.js
+++ b/tests/js/client/aql/aql-index-join-multi-unique-false-sort-false-bucket0_3.js
@@ -1,5 +1,5 @@
 /*jshint globalstrict:false, strict:false, maxlen: 500 */
-/*global fail, assertEqual, assertNotEqual, assertTrue, __filename */
+/*global fail, assertEqual, assertNotEqual, assertTrue */
 
 ////////////////////////////////////////////////////////////////////////////////
 /// DISCLAIMER

--- a/tests/js/client/aql/aql-index-join-multi-unique-false-sort-false-bucket1_3.js
+++ b/tests/js/client/aql/aql-index-join-multi-unique-false-sort-false-bucket1_3.js
@@ -1,0 +1,37 @@
+/*jshint globalstrict:false, strict:false, maxlen: 500 */
+/*global fail, assertEqual, assertNotEqual, assertTrue, __filename */
+
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2010-2016 ArangoDB GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+const jsunity = require("jsunity");
+const joinHelper = require("@arangodb/testutils/joinHelper.js");
+
+const unique = false;
+const sort = false;
+
+const parameters = joinHelper.createParameters(unique, sort, 1, 3);
+
+for (const configs of Object.values(parameters)) {
+  jsunity.run(function () {
+    return joinHelper.createIndexJoinTestMultiSuite(configs);
+  });
+}
+return jsunity.done();

--- a/tests/js/client/aql/aql-index-join-multi-unique-false-sort-false-bucket1_3.js
+++ b/tests/js/client/aql/aql-index-join-multi-unique-false-sort-false-bucket1_3.js
@@ -1,5 +1,5 @@
 /*jshint globalstrict:false, strict:false, maxlen: 500 */
-/*global fail, assertEqual, assertNotEqual, assertTrue, __filename */
+/*global fail, assertEqual, assertNotEqual, assertTrue */
 
 ////////////////////////////////////////////////////////////////////////////////
 /// DISCLAIMER

--- a/tests/js/client/aql/aql-index-join-multi-unique-false-sort-false-bucket2_3.js
+++ b/tests/js/client/aql/aql-index-join-multi-unique-false-sort-false-bucket2_3.js
@@ -1,0 +1,37 @@
+/*jshint globalstrict:false, strict:false, maxlen: 500 */
+/*global fail, assertEqual, assertNotEqual, assertTrue, __filename */
+
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2010-2016 ArangoDB GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+const jsunity = require("jsunity");
+const joinHelper = require("@arangodb/testutils/joinHelper.js");
+
+const unique = false;
+const sort = false;
+
+const parameters = joinHelper.createParameters(unique, sort, 2, 3);
+
+for (const configs of Object.values(parameters)) {
+  jsunity.run(function () {
+    return joinHelper.createIndexJoinTestMultiSuite(configs);
+  });
+}
+return jsunity.done();

--- a/tests/js/client/aql/aql-index-join-multi-unique-false-sort-false-bucket2_3.js
+++ b/tests/js/client/aql/aql-index-join-multi-unique-false-sort-false-bucket2_3.js
@@ -1,5 +1,5 @@
 /*jshint globalstrict:false, strict:false, maxlen: 500 */
-/*global fail, assertEqual, assertNotEqual, assertTrue, __filename */
+/*global fail, assertEqual, assertNotEqual, assertTrue */
 
 ////////////////////////////////////////////////////////////////////////////////
 /// DISCLAIMER

--- a/tests/js/client/aql/aql-index-join-multi-unique-false-sort-true-bucket0_3.js
+++ b/tests/js/client/aql/aql-index-join-multi-unique-false-sort-true-bucket0_3.js
@@ -1,5 +1,5 @@
 /*jshint globalstrict:false, strict:false, maxlen: 500 */
-/*global fail, assertEqual, assertNotEqual, assertTrue, __filename */
+/*global fail, assertEqual, assertNotEqual, assertTrue */
 
 ////////////////////////////////////////////////////////////////////////////////
 /// DISCLAIMER

--- a/tests/js/client/aql/aql-index-join-multi-unique-false-sort-true-bucket0_3.js
+++ b/tests/js/client/aql/aql-index-join-multi-unique-false-sort-true-bucket0_3.js
@@ -1,0 +1,37 @@
+/*jshint globalstrict:false, strict:false, maxlen: 500 */
+/*global fail, assertEqual, assertNotEqual, assertTrue, __filename */
+
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2010-2016 ArangoDB GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+const jsunity = require("jsunity");
+const joinHelper = require("@arangodb/testutils/joinHelper.js");
+
+const unique = false;
+const sort = true;
+
+const parameters = joinHelper.createParameters(unique, sort, 0, 3);
+
+for (const configs of Object.values(parameters)) {
+  jsunity.run(function () {
+    return joinHelper.createIndexJoinTestMultiSuite(configs);
+  });
+}
+return jsunity.done();

--- a/tests/js/client/aql/aql-index-join-multi-unique-false-sort-true-bucket1_3.js
+++ b/tests/js/client/aql/aql-index-join-multi-unique-false-sort-true-bucket1_3.js
@@ -1,5 +1,5 @@
 /*jshint globalstrict:false, strict:false, maxlen: 500 */
-/*global fail, assertEqual, assertNotEqual, assertTrue, __filename */
+/*global fail, assertEqual, assertNotEqual, assertTrue */
 
 ////////////////////////////////////////////////////////////////////////////////
 /// DISCLAIMER

--- a/tests/js/client/aql/aql-index-join-multi-unique-false-sort-true-bucket1_3.js
+++ b/tests/js/client/aql/aql-index-join-multi-unique-false-sort-true-bucket1_3.js
@@ -1,0 +1,37 @@
+/*jshint globalstrict:false, strict:false, maxlen: 500 */
+/*global fail, assertEqual, assertNotEqual, assertTrue, __filename */
+
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2010-2016 ArangoDB GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+const jsunity = require("jsunity");
+const joinHelper = require("@arangodb/testutils/joinHelper.js");
+
+const unique = false;
+const sort = true;
+
+const parameters = joinHelper.createParameters(unique, sort, 1, 3);
+
+for (const configs of Object.values(parameters)) {
+  jsunity.run(function () {
+    return joinHelper.createIndexJoinTestMultiSuite(configs);
+  });
+}
+return jsunity.done();

--- a/tests/js/client/aql/aql-index-join-multi-unique-false-sort-true-bucket2_3.js
+++ b/tests/js/client/aql/aql-index-join-multi-unique-false-sort-true-bucket2_3.js
@@ -1,5 +1,5 @@
 /*jshint globalstrict:false, strict:false, maxlen: 500 */
-/*global fail, assertEqual, assertNotEqual, assertTrue */
+/*global fail, assertEqual, assertNotEqual, assertTrue, __filename */
 
 ////////////////////////////////////////////////////////////////////////////////
 /// DISCLAIMER
@@ -22,12 +22,12 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 const jsunity = require("jsunity");
-const joinHelper = require("@arangodb/aql/joinHelper.js");
+const joinHelper = require("@arangodb/testutils/joinHelper.js");
 
-const unique = true;
-const sort = false;
+const unique = false;
+const sort = true;
 
-const parameters = joinHelper.createParameters(unique, sort);
+const parameters = joinHelper.createParameters(unique, sort, 2, 3);
 
 for (const configs of Object.values(parameters)) {
   jsunity.run(function () {

--- a/tests/js/client/aql/aql-index-join-multi-unique-false-sort-true-bucket2_3.js
+++ b/tests/js/client/aql/aql-index-join-multi-unique-false-sort-true-bucket2_3.js
@@ -1,5 +1,5 @@
 /*jshint globalstrict:false, strict:false, maxlen: 500 */
-/*global fail, assertEqual, assertNotEqual, assertTrue, __filename */
+/*global fail, assertEqual, assertNotEqual, assertTrue */
 
 ////////////////////////////////////////////////////////////////////////////////
 /// DISCLAIMER

--- a/tests/js/client/aql/aql-index-join-multi-unique-true-sort-false-bucket0_3.js
+++ b/tests/js/client/aql/aql-index-join-multi-unique-true-sort-false-bucket0_3.js
@@ -1,5 +1,5 @@
 /*jshint globalstrict:false, strict:false, maxlen: 500 */
-/*global fail, assertEqual, assertNotEqual, assertTrue, __filename */
+/*global fail, assertEqual, assertNotEqual, assertTrue */
 
 ////////////////////////////////////////////////////////////////////////////////
 /// DISCLAIMER

--- a/tests/js/client/aql/aql-index-join-multi-unique-true-sort-false-bucket0_3.js
+++ b/tests/js/client/aql/aql-index-join-multi-unique-true-sort-false-bucket0_3.js
@@ -1,0 +1,37 @@
+/*jshint globalstrict:false, strict:false, maxlen: 500 */
+/*global fail, assertEqual, assertNotEqual, assertTrue, __filename */
+
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2010-2016 ArangoDB GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+const jsunity = require("jsunity");
+const joinHelper = require("@arangodb/testutils/joinHelper.js");
+
+const unique = true;
+const sort = false;
+
+const parameters = joinHelper.createParameters(unique, sort, 0, 3);
+
+for (const configs of Object.values(parameters)) {
+  jsunity.run(function () {
+    return joinHelper.createIndexJoinTestMultiSuite(configs);
+  });
+}
+return jsunity.done();

--- a/tests/js/client/aql/aql-index-join-multi-unique-true-sort-false-bucket1_3.js
+++ b/tests/js/client/aql/aql-index-join-multi-unique-true-sort-false-bucket1_3.js
@@ -1,5 +1,5 @@
 /*jshint globalstrict:false, strict:false, maxlen: 500 */
-/*global fail, assertEqual, assertNotEqual, assertTrue, __filename */
+/*global fail, assertEqual, assertNotEqual, assertTrue */
 
 ////////////////////////////////////////////////////////////////////////////////
 /// DISCLAIMER

--- a/tests/js/client/aql/aql-index-join-multi-unique-true-sort-false-bucket1_3.js
+++ b/tests/js/client/aql/aql-index-join-multi-unique-true-sort-false-bucket1_3.js
@@ -1,5 +1,5 @@
 /*jshint globalstrict:false, strict:false, maxlen: 500 */
-/*global fail, assertEqual, assertNotEqual, assertTrue */
+/*global fail, assertEqual, assertNotEqual, assertTrue, __filename */
 
 ////////////////////////////////////////////////////////////////////////////////
 /// DISCLAIMER
@@ -22,12 +22,12 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 const jsunity = require("jsunity");
-const joinHelper = require("@arangodb/aql/joinHelper.js");
+const joinHelper = require("@arangodb/testutils/joinHelper.js");
 
-const unique = false;
+const unique = true;
 const sort = false;
 
-const parameters = joinHelper.createParameters(unique, sort);
+const parameters = joinHelper.createParameters(unique, sort, 1, 3);
 
 for (const configs of Object.values(parameters)) {
   jsunity.run(function () {

--- a/tests/js/client/aql/aql-index-join-multi-unique-true-sort-false-bucket2_3.js
+++ b/tests/js/client/aql/aql-index-join-multi-unique-true-sort-false-bucket2_3.js
@@ -1,5 +1,5 @@
 /*jshint globalstrict:false, strict:false, maxlen: 500 */
-/*global fail, assertEqual, assertNotEqual, assertTrue, __filename */
+/*global fail, assertEqual, assertNotEqual, assertTrue */
 
 ////////////////////////////////////////////////////////////////////////////////
 /// DISCLAIMER

--- a/tests/js/client/aql/aql-index-join-multi-unique-true-sort-false-bucket2_3.js
+++ b/tests/js/client/aql/aql-index-join-multi-unique-true-sort-false-bucket2_3.js
@@ -1,5 +1,5 @@
 /*jshint globalstrict:false, strict:false, maxlen: 500 */
-/*global fail, assertEqual, assertNotEqual, assertTrue */
+/*global fail, assertEqual, assertNotEqual, assertTrue, __filename */
 
 ////////////////////////////////////////////////////////////////////////////////
 /// DISCLAIMER
@@ -22,12 +22,12 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 const jsunity = require("jsunity");
-const joinHelper = require("@arangodb/aql/joinHelper.js");
+const joinHelper = require("@arangodb/testutils/joinHelper.js");
 
-const unique = false;
-const sort = true;
+const unique = true;
+const sort = false;
 
-const parameters = joinHelper.createParameters(unique, sort);
+const parameters = joinHelper.createParameters(unique, sort, 2, 3);
 
 for (const configs of Object.values(parameters)) {
   jsunity.run(function () {

--- a/tests/js/client/aql/aql-index-join-multi-unique-true-sort-true-bucket0_3.js
+++ b/tests/js/client/aql/aql-index-join-multi-unique-true-sort-true-bucket0_3.js
@@ -1,5 +1,5 @@
 /*jshint globalstrict:false, strict:false, maxlen: 500 */
-/*global fail, assertEqual, assertNotEqual, assertTrue, __filename */
+/*global fail, assertEqual, assertNotEqual, assertTrue */
 
 ////////////////////////////////////////////////////////////////////////////////
 /// DISCLAIMER

--- a/tests/js/client/aql/aql-index-join-multi-unique-true-sort-true-bucket0_3.js
+++ b/tests/js/client/aql/aql-index-join-multi-unique-true-sort-true-bucket0_3.js
@@ -1,5 +1,5 @@
 /*jshint globalstrict:false, strict:false, maxlen: 500 */
-/*global fail, assertEqual, assertNotEqual, assertTrue */
+/*global fail, assertEqual, assertNotEqual, assertTrue, __filename */
 
 ////////////////////////////////////////////////////////////////////////////////
 /// DISCLAIMER
@@ -22,12 +22,12 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 const jsunity = require("jsunity");
-const joinHelper = require("@arangodb/aql/joinHelper.js");
+const joinHelper = require("@arangodb/testutils/joinHelper.js");
 
 const unique = true;
 const sort = true;
 
-const parameters = joinHelper.createParameters(unique, sort);
+const parameters = joinHelper.createParameters(unique, sort, 0, 3);
 
 for (const configs of Object.values(parameters)) {
   jsunity.run(function () {

--- a/tests/js/client/aql/aql-index-join-multi-unique-true-sort-true-bucket1_3.js
+++ b/tests/js/client/aql/aql-index-join-multi-unique-true-sort-true-bucket1_3.js
@@ -1,5 +1,5 @@
 /*jshint globalstrict:false, strict:false, maxlen: 500 */
-/*global fail, assertEqual, assertNotEqual, assertTrue, __filename */
+/*global fail, assertEqual, assertNotEqual, assertTrue */
 
 ////////////////////////////////////////////////////////////////////////////////
 /// DISCLAIMER

--- a/tests/js/client/aql/aql-index-join-multi-unique-true-sort-true-bucket1_3.js
+++ b/tests/js/client/aql/aql-index-join-multi-unique-true-sort-true-bucket1_3.js
@@ -1,0 +1,37 @@
+/*jshint globalstrict:false, strict:false, maxlen: 500 */
+/*global fail, assertEqual, assertNotEqual, assertTrue, __filename */
+
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2010-2016 ArangoDB GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+const jsunity = require("jsunity");
+const joinHelper = require("@arangodb/testutils/joinHelper.js");
+
+const unique = true;
+const sort = true;
+
+const parameters = joinHelper.createParameters(unique, sort, 1, 3);
+
+for (const configs of Object.values(parameters)) {
+  jsunity.run(function () {
+    return joinHelper.createIndexJoinTestMultiSuite(configs);
+  });
+}
+return jsunity.done();

--- a/tests/js/client/aql/aql-index-join-multi-unique-true-sort-true-bucket2_3.js
+++ b/tests/js/client/aql/aql-index-join-multi-unique-true-sort-true-bucket2_3.js
@@ -1,5 +1,5 @@
 /*jshint globalstrict:false, strict:false, maxlen: 500 */
-/*global fail, assertEqual, assertNotEqual, assertTrue, __filename */
+/*global fail, assertEqual, assertNotEqual, assertTrue */
 
 ////////////////////////////////////////////////////////////////////////////////
 /// DISCLAIMER

--- a/tests/js/client/aql/aql-index-join-multi-unique-true-sort-true-bucket2_3.js
+++ b/tests/js/client/aql/aql-index-join-multi-unique-true-sort-true-bucket2_3.js
@@ -1,0 +1,37 @@
+/*jshint globalstrict:false, strict:false, maxlen: 500 */
+/*global fail, assertEqual, assertNotEqual, assertTrue, __filename */
+
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2010-2016 ArangoDB GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+const jsunity = require("jsunity");
+const joinHelper = require("@arangodb/testutils/joinHelper.js");
+
+const unique = true;
+const sort = true;
+
+const parameters = joinHelper.createParameters(unique, sort, 2, 3);
+
+for (const configs of Object.values(parameters)) {
+  jsunity.run(function () {
+    return joinHelper.createIndexJoinTestMultiSuite(configs);
+  });
+}
+return jsunity.done();

--- a/tests/js/client/aql/aql-index-join-unique.js
+++ b/tests/js/client/aql/aql-index-join-unique.js
@@ -31,7 +31,6 @@ const isCluster = internal.isCluster();
 const isEnterprise = internal.isEnterprise();
 
 const IndexUniqueJoinTestSuite = function () {
-
   if (isCluster && !isEnterprise) {
     return {};
   }
@@ -91,9 +90,6 @@ const IndexUniqueJoinTestSuite = function () {
   };
 
   const queryOptions = {
-    optimizer: {
-      rules: ["+join-index-nodes"]
-    },
     maxNumberOfPlans: 1
   };
 

--- a/tests/js/client/aql/aql-index-join.js
+++ b/tests/js/client/aql/aql-index-join.js
@@ -706,9 +706,7 @@ const IndexJoinTestSuite = function () {
   };
 };
 
-if (isCluster && !isEnterprise) {
-  return jsunity.done();
-} else {
+if (!isCluster || isEnterprise) {
   jsunity.run(IndexJoinTestSuite);
 }
 return jsunity.done();


### PR DESCRIPTION
### Scope & Purpose

According to @dothebart, the CI doesn't like execution of the join tests.
This PR adds more code and complexity to the testing by manually splitting the join tests into buckets to make things work again.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/ ~simplification~

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 