### PR TITLE
[3.11] Improve locking in Async Logger (#19989)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -15,14 +15,6 @@ v3.11.5 (XXXX-XX-XX)
   start to write log messages synchronously. This is to prevent the queue
   to grow indefinitely. The upper bound is configurable via the startup
   option `--log.max-queued-entries`. The default value is 10000.
-
-* Silence TSAN for shutdown for access to the SchedulerFeature::SCHEDULER
-  pointer using atomic references.
-
-* Fixed a race in controlled leader change which could lead to a situation 
-  in which a shard follower is dropped when the first write operation
-  happens. This fixes BTS-1647.
-
 * Fixed an unnecessary follower drop in controlled leader change, which will
   speed up leader changes. This fixes BTS-1658.
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,24 @@ v3.11.5 (XXXX-XX-XX)
   which a shard follower is dropped when the first write operation happens. This
   fixes BTS-1647.
 
+* Fixed BTS-1273: While queueing an async server log message, we could be
+  blocked by IO on the log-writer thread. This could slow down the main
+  path. In case the log-writer is configured to use slow device
+  (e.g. using syslog) this could have significant impact.
+
+* Introduced an upper bound of queued async log messages. If we would log
+  more messages then the background logger thread can actually process, we
+  start to write log messages synchronously. This is to prevent the queue
+  to grow indefinitely. The upper bound is configurable via the startup
+  option `--log.max-queued-entries`. The default value is 10000.
+
+* Silence TSAN for shutdown for access to the SchedulerFeature::SCHEDULER
+  pointer using atomic references.
+
+* Fixed a race in controlled leader change which could lead to a situation 
+  in which a shard follower is dropped when the first write operation
+  happens. This fixes BTS-1647.
+
 * Fixed an unnecessary follower drop in controlled leader change, which will
   speed up leader changes. This fixes BTS-1658.
 

--- a/arangod/RestServer/DaemonFeature.cpp
+++ b/arangod/RestServer/DaemonFeature.cpp
@@ -47,7 +47,6 @@
 #include "Logger/LogAppender.h"
 #include "Logger/LogMacros.h"
 #include "Logger/Logger.h"
-#include "Logger/LoggerFeature.h"
 #include "Logger/LoggerStream.h"
 #include "ProgramOptions/Option.h"
 #include "ProgramOptions/Parameters.h"
@@ -120,9 +119,6 @@ void DaemonFeature::validateOptions(
         << "need --pid-file in --daemon mode";
     FATAL_ERROR_EXIT();
   }
-
-  LoggerFeature& logger = server().getFeature<LoggerFeature>();
-  logger.setBackgrounded(true);
 
   // make the pid filename absolute
   std::string currentDir = FileUtils::currentDirectory().result();

--- a/lib/Logger/LogAppender.h
+++ b/lib/Logger/LogAppender.h
@@ -29,6 +29,7 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <thread>
 #include <typeindex>
 #include <utility>
 #include <vector>
@@ -68,7 +69,7 @@ class LogAppender {
   LogAppender& operator=(LogAppender const&) = delete;
 
  public:
-  virtual void logMessage(LogMessage const&) = 0;
+  void logMessageGuarded(LogMessage const&);
 
   virtual std::string details() const = 0;
 
@@ -78,6 +79,9 @@ class LogAppender {
   static Result parseDefinition(std::string const& definition,
                                 std::string& topicName, std::string& output,
                                 LogTopic*& topic);
+
+ protected:
+  virtual void logMessage(LogMessage const& message) = 0;
 
  private:
   static arangodb::basics::ReadWriteLock _appendersLock;
@@ -90,5 +94,8 @@ class LogAppender {
                     LogGroup::Count>
       _definition2appenders;
   static bool _allowStdLogging;
+
+  basics::ReadWriteLock _logOutputMutex;
+  std::atomic<std::thread::id> _logOutputMutexOwner;
 };
 }  // namespace arangodb

--- a/lib/Logger/LogThread.h
+++ b/lib/Logger/LogThread.h
@@ -47,7 +47,7 @@ class LogThread final : public Thread {
 
  public:
   explicit LogThread(application_features::ApplicationServer& server,
-                     std::string const& name);
+                     std::string const& name, uint32_t maxQueuedLogMessages);
   ~LogThread();
 
  public:
@@ -71,5 +71,7 @@ class LogThread final : public Thread {
  private:
   arangodb::basics::ConditionVariable _condition;
   boost::lockfree::queue<MessageEnvelope> _messages;
+  std::atomic<size_t> _pendingMessages{0};
+  uint32_t _maxQueuedLogMessages{10000};
 };
 }  // namespace arangodb

--- a/lib/Logger/Logger.cpp
+++ b/lib/Logger/Logger.cpp
@@ -887,7 +887,7 @@ void Logger::append(LogGroup& group, std::unique_ptr<LogMessage> msg,
 ////////////////////////////////////////////////////////////////////////////////
 
 void Logger::initialize(application_features::ApplicationServer& server,
-                        bool threaded) {
+                        bool threaded, uint32_t maxQueuedLogMessages) {
   if (_active.exchange(true, std::memory_order_acquire)) {
     THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_INTERNAL,
                                    "Logger already initialized");
@@ -895,8 +895,8 @@ void Logger::initialize(application_features::ApplicationServer& server,
 
   // logging is now active
   if (threaded) {
-    auto loggingThread =
-        std::make_unique<LogThread>(server, std::string(logThreadName));
+    auto loggingThread = std::make_unique<LogThread>(
+        server, std::string(logThreadName), maxQueuedLogMessages);
     if (!loggingThread->start()) {
       LOG_TOPIC("28bd9", FATAL, arangodb::Logger::FIXME)
           << "could not start logging thread";

--- a/lib/Logger/Logger.h
+++ b/lib/Logger/Logger.h
@@ -155,7 +155,7 @@ class Logger {
   friend class LoggerStream;
   friend class LogThread;
   friend class LogAppenderStream;
-  friend class LogAppenderFile;
+  friend struct LogAppenderFileFactory;
 
  public:
   static LogTopic AGENCY;
@@ -304,7 +304,8 @@ class Logger {
                                    : topic.level());
   }
 
-  static void initialize(application_features::ApplicationServer&, bool);
+  static void initialize(application_features::ApplicationServer&, bool,
+                         uint32_t maxQueuedLogMessages);
   static void shutdown();
   static void flush() noexcept;
 

--- a/lib/Logger/LoggerFeature.cpp
+++ b/lib/Logger/LoggerFeature.cpp
@@ -556,6 +556,21 @@ printed in the thread that triggered the log message. This is non-optimal for
 performance but can aid debugging. If set to `false`, log messages are handed
 off to an extra logging thread, which asynchronously writes the log messages.)");
 
+  options
+      ->addOption(
+          "--log.max-queued-entries",
+          "Upper limit of log entries that are queued in background thread.",
+          new UInt32Parameter(&_maxQueuedLogMessages),
+          arangodb::options::makeDefaultFlags(
+              arangodb::options::Flags::Uncommon))
+      .setIntroducedIn(31200)
+      .setLongDescription(
+          R"(If you are using the option `--log.force-direct` (default)
+log entries are pushed on a queue for asynchronous writing. In case you
+are using a slow log output (e.g. syslog) the queue might grow and eventually overflow.
+This option allows to configure the upper bound. If the queue is full, log entries
+will be written synchronously, until the queue has space again.)");
+
   options->addOption(
       "--log.request-parameters",
       "include full URLs and HTTP request parameters in trace logs",
@@ -630,7 +645,7 @@ void LoggerFeature::validateOptions(std::shared_ptr<ProgramOptions> options) {
   if (!_fileMode.empty()) {
     try {
       int result = std::stoi(_fileMode, nullptr, 8);
-      LogAppenderFile::setFileMode(result);
+      LogAppenderFileFactory::setFileMode(result);
     } catch (...) {
       LOG_TOPIC("797c2", FATAL, arangodb::Logger::FIXME)
           << "expecting an octal number for log.file-mode, got '" << _fileMode
@@ -674,7 +689,7 @@ void LoggerFeature::validateOptions(std::shared_ptr<ProgramOptions> options) {
 #endif
     }
 
-    LogAppenderFile::setFileGroup(gidNumber);
+    LogAppenderFileFactory::setFileGroup(gidNumber);
   }
 #endif
 
@@ -731,9 +746,9 @@ void LoggerFeature::prepare() {
   }
 
   if (_forceDirect || _supervisor) {
-    Logger::initialize(server(), false);
+    Logger::initialize(server(), false, _maxQueuedLogMessages);
   } else {
-    Logger::initialize(server(), _threaded);
+    Logger::initialize(server(), _threaded, _maxQueuedLogMessages);
   }
 }
 

--- a/lib/Logger/LoggerFeature.cpp
+++ b/lib/Logger/LoggerFeature.cpp
@@ -563,7 +563,7 @@ off to an extra logging thread, which asynchronously writes the log messages.)")
           new UInt32Parameter(&_maxQueuedLogMessages),
           arangodb::options::makeDefaultFlags(
               arangodb::options::Flags::Uncommon))
-      .setIntroducedIn(31200)
+      .setIntroducedIn(31105)
       .setLongDescription(
           R"(If you are using the option `--log.force-direct` (default)
 log entries are pushed on a queue for asynchronous writing. In case you

--- a/lib/Logger/LoggerFeature.h
+++ b/lib/Logger/LoggerFeature.h
@@ -62,7 +62,6 @@ class LoggerFeature final : public application_features::ApplicationFeature {
   void prepare() override final;
   void unprepare() override final;
 
-  void setBackgrounded(bool backgrounded) { _backgrounded = backgrounded; }
   void disableThreaded() { _threaded = false; }
   void setSupervisor(bool supervisor) { _supervisor = supervisor; }
 
@@ -97,12 +96,12 @@ class LoggerFeature final : public application_features::ApplicationFeature {
   bool _keepLogRotate = false;
   bool _foregroundTty = false;
   bool _forceDirect = false;
+  uint32_t _maxQueuedLogMessages = 10000;
   bool _useMicrotime = false;
   bool _showIds = true;
   bool _showRole = false;
   bool _logRequestParameters = true;
   bool _supervisor = false;
-  bool _backgrounded = false;
   bool _threaded = false;
   std::string _apiSwitch = "true";
   bool _apiEnabled = true;

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -123,7 +123,7 @@ int main(int argc, char* argv[]) {
   arangodb::ShellColorsFeature sc(server);
 
   arangodb::Logger::setShowLineNumber(logLineNumbers);
-  arangodb::Logger::initialize(server, false);
+  arangodb::Logger::initialize(server, false, 10000);
   arangodb::LogAppender::addAppender(arangodb::Logger::defaultLogGroup(), "-");
 
   sc.prepare();


### PR DESCRIPTION
### Scope & Purpose

*Right now the Logger holds a very large lock. The lock is held whenever the background thread flushes a queued log message, which is potentially slowed down by IO. If we try to do a new direct log entry in that period we need to wait for this lock to be released. With this PR the Lock is changed such that: We get a WriteLock whenever we modify the Loggers we use, but we only take a read-lock when we let the loggers print. This way we can have two or more threads using the loggers.
In turn the output message of the Logger, which does the IO operation, is guarded with a WriteLock.

In addition this PR adds an upper bound to the amount of messages in the queue. This is right now hard-coded and should not have effect under normal circumstances. If the logging is configured to use an extremely slow device we protect us here against accumulating too much memory in log messages. If the Limit is reached, we will start to directly log the message, which will have a performance impact. Also this may change the ordering of Log messages.
*

Note to reviewer: Please take extra care, this PR fiddles with Locks, and has potential to introduce undesired dead-locks.

This potentially fixes: https://arangodb.atlassian.net/browse/BTS-1273

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/BTS-1273
- [ ] Design document: 

