### PR TITLE
remove cluster-only attributes from single server dumps

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,17 @@
 devel
 -----
 
+* Make arangodump exclude the following cluster collection properties when
+  writing collection parameters files in a single server dump:
+  - replicationFactor
+  - writeConcern
+  - numberOfShards
+  - minReplicationFactor
+  - shardKeys
+  - shards
+  It is not really useful to write these attributes out when taking single 
+  server dumps, because they don't have useful values.
+
 * Fixed BTS-1273: While queueing an async server log message, we could be
   blocked by IO on the log-writer thread. This could slow down the main
   path. In case the log-writer is configured to use slow device

--- a/client-tools/Dump/DumpFeature.cpp
+++ b/client-tools/Dump/DumpFeature.cpp
@@ -671,10 +671,10 @@ Result DumpFeature::DumpCollectionJob::run(
                          VPackSlice::nullSlice());
           subObject->add(StaticStrings::ReplicationFactor,
                          VPackSlice::nullSlice());
-          subObject->add(StaticStrings::ShardKeys, VPackSlice::nullSlice());
-          subObject->add(StaticStrings::Sharding, VPackSlice::nullSlice());
-          subObject->add("shards", VPackSlice::nullSlice());
           subObject->add(StaticStrings::WriteConcern, VPackSlice::nullSlice());
+          // note: we cannot exclude shardKeys and sharding, because they
+          // can be used even in single-server SmartGraphs.
+          subObject->add("shards", VPackSlice::nullSlice());
         }
       }
     }

--- a/client-tools/Dump/DumpFeature.cpp
+++ b/client-tools/Dump/DumpFeature.cpp
@@ -660,6 +660,22 @@ Result DumpFeature::DumpCollectionJob::run(
         VPackObjectBuilder subObject(&excludes, "parameters");
         subObject->add(StaticStrings::ShadowCollections,
                        VPackSlice::nullSlice());
+
+        if (!options.clusterMode) {
+          // single server.
+          // remove replicationFactor, writeConcern and others that are
+          // only relevant in cluster
+          subObject->add(StaticStrings::MinReplicationFactor,
+                         VPackSlice::nullSlice());
+          subObject->add(StaticStrings::NumberOfShards,
+                         VPackSlice::nullSlice());
+          subObject->add(StaticStrings::ReplicationFactor,
+                         VPackSlice::nullSlice());
+          subObject->add(StaticStrings::ShardKeys, VPackSlice::nullSlice());
+          subObject->add(StaticStrings::Sharding, VPackSlice::nullSlice());
+          subObject->add("shards", VPackSlice::nullSlice());
+          subObject->add(StaticStrings::WriteConcern, VPackSlice::nullSlice());
+        }
       }
     }
 


### PR DESCRIPTION
### Scope & Purpose

Previously the arangodump collection properties from single server dumps contained the following attributes:

- replicationFactor
- writeConcern
- numberOfShards
- minReplicationFactor
- shards
- shardKeys

It is not really useful to write these attributes out when taking single server dumps, because they don't have useful values.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 