### PR TITLE
[3.10] LogAppender: Ensure we do not implicitly add ones under ReadLock #20102

### DIFF
--- a/lib/Logger/LogAppender.cpp
+++ b/lib/Logger/LogAppender.cpp
@@ -180,7 +180,6 @@ void LogAppender::logGlobal(LogGroup const& group, LogMessage const& message) {
     TRI_ASSERT(false) << "no global appender for group " << group.id();
     // This should never happen, however if it does we should not crash
     // but we also cannot log anything, as we are the logger.
-    return;
   }
 }
 
@@ -224,7 +223,6 @@ void LogAppender::log(LogGroup const& group, LogMessage const& message) {
     TRI_ASSERT(false) << "no topic 2 appender match for group " << group.id();
     // This should never happen, however if it does we should not crash
     // but we also cannot log anything, as we are the logger.
-    return;
   }
 }
 

--- a/lib/Logger/LogAppender.cpp
+++ b/lib/Logger/LogAppender.cpp
@@ -93,9 +93,9 @@ void LogAppender::addAppender(LogGroup const& group,
 
   std::shared_ptr<LogAppender> appender;
 
-  auto& definitionsMap = _definition2appenders[group.id()];
-
   WRITE_LOCKER(guard, _appendersLock);
+
+  auto& definitionsMap = _definition2appenders[group.id()];
 
   auto it = definitionsMap.find(key);
 
@@ -327,14 +327,14 @@ bool LogAppender::haveAppenders(LogGroup const& group, size_t topicId) {
   // other solutions.
   READ_LOCKER(guard, _appendersLock);
   try {
-    auto const& appenders = _topics2appenders[group.id()];
+    auto const& appenders = _topics2appenders.at(group.id());
     auto haveTopicAppenders = [&appenders](size_t topicId) {
       auto it = appenders.find(topicId);
       return it != appenders.end() && !it->second.empty();
     };
     return haveTopicAppenders(topicId) ||
            haveTopicAppenders(LogTopic::MAX_LOG_TOPICS) ||
-           !_globalAppenders[group.id()].empty();
+           !_globalAppenders.at(group.id()).empty();
   } catch (std::out_of_range const&) {
     // no topic 2 appenders entry for this group.
     TRI_ASSERT(false) << "no topic 2 appender match for group " << group.id();

--- a/lib/Logger/LogAppender.cpp
+++ b/lib/Logger/LogAppender.cpp
@@ -188,7 +188,6 @@ void LogAppender::log(LogGroup const& group, LogMessage const& message) {
   // output to appenders
   READ_LOCKER(guard, _appendersLock);
   try {
-
     auto& topicsMap = _topics2appenders.at(group.id());
     auto output = [&topicsMap](LogGroup const& group, LogMessage const& message,
                                size_t n) -> bool {
@@ -211,7 +210,6 @@ void LogAppender::log(LogGroup const& group, LogMessage const& message) {
 
     // try to find a topic-specific appender
     size_t topicId = message._topicId;
-
 
     if (topicId < LogTopic::MAX_LOG_TOPICS) {
       shown = output(group, message, topicId);


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/20102

*The LogAppenders do have a lock on the lists of appenders. We recently moved some of it from write to read lock. Now make sure we do not write under deadlock by using `.at()` instead of `[]` which could write implicitly. I do not think this has a real effect as the lists should be filled after startup.*

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

