### PR TITLE
Clarify comment

### DIFF
--- a/arangod/Network/Methods.cpp
+++ b/arangod/Network/Methods.cpp
@@ -265,10 +265,15 @@ void actuallySendRequest(std::shared_ptr<Pack>&& p, ConnectionPool* pool,
 
         // We access the global SCHEDULER pointer here via an atomic
         // reference. This is to silence TSAN, which often detects a data
-        // race on this pointer, since this read access here can occasionally
-        // happen before the write in SchedulerFeature::unprepare, which
-        // invalidates the pointer. But even if the read here would happen
-        // later, we check for nullptr below, so all would be good.
+        // race on this pointer, which is actually totally harmless.
+        // What happens is that this access here occurs earlier in time
+        // than the write in SchedulerFeature::unprepare, which
+        // invalidates the pointer. TSAN does not see an official "happens
+        // before" relation between the two threads and complains.
+        // However, this is totally fine (and to some extent expected),
+        // since potentially network responses might come in later than
+        // the time when the scheduler has been shut down. Even in that
+        // case, all is fine, since we check for nullptr below.
         std::atomic_ref<Scheduler*> schedulerRef{SchedulerFeature::SCHEDULER};
         auto* sch = schedulerRef.load(std::memory_order_relaxed);
         // cppcheck-suppress accessMoved


### PR DESCRIPTION
### Scope & Purpose

Just clarify a comment about TSAN silencing.
This was requested by reviewers in a backport pR, but the PR was already
merged in devel.

https://github.com/arangodb/arangodb/pull/20062#discussion_r1381713603

