### PR TITLE
Fix compilation with newer clang versions and musl

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -78,6 +78,7 @@ add_library(arango_lightweight STATIC
         Basics/tri-strings.cpp
         Containers/ImmerMemoryPolicy.h
         Logger/Escaper.cpp
+        Logger/FindSyslogFacilityByName.c
         Logger/LogAppender.cpp
         Logger/LogAppenderFile.cpp
         Logger/LogAppenderSyslog.cpp

--- a/lib/Logger/FindSyslogFacilityByName.c
+++ b/lib/Logger/FindSyslogFacilityByName.c
@@ -1,0 +1,49 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2023 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+//
+// This is C code to prevent clang from complaining about the
+// expansion of the facilitynames macro on musl libc yielding char *
+// to character constants (and hence failing to compile) when
+// compiling C++
+//
+#include <stddef.h>
+
+// we need to define SYSLOG_NAMES for linux to get a list of names
+#define SYSLOG_NAMES
+#include <syslog.h>
+#include <string.h>
+
+#include "Basics/operating-system.h"
+
+#if defined(ARANGODB_ENABLE_SYSLOG)
+
+int find_syslog_facility_by_name(const char* facility) {
+  CODE* ptr = facilitynames;
+
+  while (ptr->c_name != NULL) {
+    if (strcmp(ptr->c_name, facility) == 0) {
+      return ptr->c_val;
+    }
+  }
+  return LOG_LOCAL0;
+}
+#endif

--- a/lib/Logger/FindSyslogFacilityByName.h
+++ b/lib/Logger/FindSyslogFacilityByName.h
@@ -1,0 +1,26 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2023 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+extern "C" {
+int find_syslog_facility_by_name(const char* facility);
+};

--- a/lib/Logger/LogAppenderSyslog.cpp
+++ b/lib/Logger/LogAppenderSyslog.cpp
@@ -27,8 +27,9 @@ using namespace arangodb;
 
 #ifdef ARANGODB_ENABLE_SYSLOG
 
+#include "Logger/FindSyslogFacilityByName.h"
+
 // we need to define SYSLOG_NAMES for linux to get a list of names
-#define SYSLOG_NAMES
 #include <syslog.h>
 
 #ifdef ARANGODB_ENABLE_SYSLOG_STRINGS
@@ -59,16 +60,7 @@ LogAppenderSyslog::LogAppenderSyslog(std::string const& facility,
   if ('0' <= facility[0] && facility[0] <= '9') {
     value = StringUtils::int32(facility);
   } else {
-    CODE* ptr = reinterpret_cast<CODE*>(facilitynames);
-
-    while (ptr->c_name != nullptr) {
-      if (strcmp(ptr->c_name, facility.c_str()) == 0) {
-        value = ptr->c_val;
-        break;
-      }
-
-      ++ptr;
-    }
+    value = find_syslog_facility_by_name(facility.c_str());
   }
 
   // from man 3 syslog:


### PR DESCRIPTION
### Scope & Purpose

When compiling arangodb with clang 15 or 16 it complains

```
ISO C++11 does not allow conversion from string literal to 'char *' [-Werror,-Wwritable-strings]
    CODE* ptr = reinterpret_cast<CODE*>(facilitynames);ISO C++11 does not allow conversion from string literal to 'char *' [-Werror,-Wwritable-strings]
    CODE* ptr = reinterpret_cast<CODE*>(facilitynames);
```

This is a very reasonable complained caused by musl libc declaring `CODE` to contain a `char *`.

This PR introduces an interface function `find_syslog_facility_by_name` between the libc C code and C++ code which is compiled as C code.