### PR TITLE
remove unnecessary projection attributes from JoinNode

### DIFF
--- a/arangod/Aql/JoinExecutor.cpp
+++ b/arangod/Aql/JoinExecutor.cpp
@@ -47,9 +47,12 @@ RegisterId JoinExecutorInfos::registerForVariable(
 
 void JoinExecutorInfos::determineProjectionsForRegisters() {
   if (!projectionsInitialized) {
+    bool producesOutput = false;
     for (auto& it : indexes) {
       it.hasProjectionsForRegisters = it.projections.hasOutputRegisters();
+      producesOutput |= it.producesOutput;
     }
+    producesAnyOutput = producesOutput;
     projectionsInitialized = true;
   }
 }
@@ -139,7 +142,7 @@ auto JoinExecutor::produceRows(AqlItemBlockInputRange& inputRange,
                                   std::span<VPackSlice> projections) -> bool {
       LOG_JOIN << "BEGIN OF ROW " << rowCount++;
 
-      LOG_JOIN << "PROJECTIONS: ";
+      LOG_JOIN << "PROJECTIONS:";
       for (auto p : projections) {
         LOG_JOIN << p.toJson();
       }
@@ -294,13 +297,12 @@ auto JoinExecutor::produceRows(AqlItemBlockInputRange& inputRange,
       }
 
       // Now produce the documents
+      TRI_ASSERT(_infos.projectionsInitialized);
       projectionsOffset = 0;
       for (std::size_t k = 0; k < docIds.size(); k++) {
         auto& idx = _infos.indexes[k];
 
         if (!idx.producesOutput) {
-          output.cloneValueInto(_infos.indexes[k].documentOutputRegister,
-                                _currentRow, AqlValue(AqlValueHintNull()));
           continue;
         }
 
@@ -362,6 +364,11 @@ auto JoinExecutor::produceRows(AqlItemBlockInputRange& inputRange,
         }
       }
 
+      if (!_infos.producesAnyOutput) {
+        output.handleEmptyRow(_currentRow);
+      }
+
+      TRI_ASSERT(output.produced());
       output.advanceRow();
       LOG_JOIN << "OUTPUT ROW " << (rowCount - 1);
       return !output.isFull();

--- a/arangod/Aql/JoinExecutor.h
+++ b/arangod/Aql/JoinExecutor.h
@@ -108,6 +108,7 @@ struct JoinExecutorInfos {
   QueryContext* query;
   containers::FlatHashMap<VariableId, RegisterId> varsToRegister;
   bool projectionsInitialized = false;
+  bool producesAnyOutput = true;
 };
 
 /**

--- a/arangod/Aql/JoinNode.cpp
+++ b/arangod/Aql/JoinNode.cpp
@@ -260,13 +260,17 @@ std::unique_ptr<ExecutionBlock> JoinNode::createBlock(
       TRI_ASSERT(var != nullptr);
       auto regId = variableToRegisterId(var);
       varsToRegs.emplace(var->id, regId);
-      writableOutputRegisters.emplace(regId);
+      if (idx.producesOutput) {
+        writableOutputRegisters.emplace(regId);
+      }
     }
 
     RegisterId documentOutputRegister = RegisterId::maxRegisterId;
     if (!p.hasOutputRegisters()) {
       documentOutputRegister = variableToRegisterId(idx.outVariable);
-      writableOutputRegisters.emplace(documentOutputRegister);
+      if (idx.producesOutput) {
+        writableOutputRegisters.emplace(documentOutputRegister);
+      }
     }
 
     // TODO probably those data structures can become one

--- a/arangod/Aql/JoinNode.h
+++ b/arangod/Aql/JoinNode.h
@@ -43,15 +43,9 @@ class ExecutionEngine;
 class ExecutionPlan;
 
 // not yet supported:
-// - post-filtering
 // - IndexIteratorOptions: sorted, ascending, evalFCalls, useCache, waitForSync,
 // limit, lookahead
 // - reverse iteration
-// - support from GatherNodes
-// - producesResult
-// - read own writes
-// - proper cost estimates
-// - profile output in explainer
 class JoinNode : public ExecutionNode {
   friend class ExecutionBlock;
 

--- a/arangod/Aql/OptimizerRules.cpp
+++ b/arangod/Aql/OptimizerRules.cpp
@@ -9416,6 +9416,8 @@ void arangodb::aql::joinIndexNodesRule(Optimizer* opt,
           }
 
           if (eligible) {
+            // we will now replace all candidate IndexNodes with a JoinNode,
+            // and remove the previous IndexNodes from the plan
             LOG_INDEX_OPTIMIZER_RULE << "Should be eligible for index join";
             std::vector<JoinNode::IndexInfo> indexInfos;
             indexInfos.reserve(candidates.size());
@@ -9442,50 +9444,101 @@ void arangodb::aql::joinIndexNodesRule(Optimizer* opt,
             for (size_t i = 1; i < candidates.size(); ++i) {
               plan->unlinkNode(candidates[i]);
             }
-            // clear up now-unused projections
-            // TODO: move out of here
-            {
+            // remove any now-unused projections from the JoinNode.
+            // these are projections that are not used after the JoinNode,
+            // and that are not used by any of the JoinNodes post-filters.
+            // we _can_ remove all projections that are only used inside
+            // the JoinNode and that are part of the JoinNode's join
+            // conditions.
+            [plan = plan.get(),
+             jn]() {
+              // we are executing the removal inside an IIFE for better
+              // scoping of variables.
+
+              // we need to refresh the variable usage in the execution
+              // plan first because we changed nodes around before.
               plan->findVarUsage();
               auto& indexInfos = jn->getIndexInfos();
+              // for every index in the JoinNode, check if it is has
+              // projections. if it has projections, check if the index
+              // out variable is used after the JoinNode. if it is,
+              // we do not attempt further optimizations.
+              // if the index out variable is only used inside the
+              // JoinNode itself, we check for every projection if the
+              // project is not used in the following index lookup's
+              // post-filter conditions. if it is not used there, it
+              // is safe to remove the projection completely.
+
+              // for every index in the JoinNode...
               for (size_t i = 0; i < indexInfos.size(); ++i) {
+                // check if it has projections
                 if (indexInfos[i].projections.empty()) {
+                  // no projections => no projections to optimize away.
+                  // this check is important because further down we
+                  // rely on that projections have been present.
                   continue;
                 }
                 Variable const* outVariable = indexInfos[i].outVariable;
                 if (jn->isVarUsedLater(outVariable)) {
+                  // output variable of index in JoinNode is used by
+                  // query parts following the JoinNode. we can not
+                  // remove anything safely.
                   continue;
                 }
+                // output variable of current index in JoinNode is not
+                // used after the JoinNode itself. now check if the projection
+                // is used by any of the following indexes' filter conditions.
+                // in that case we need to keep the projection, otherwise
+                // we can remove it.
+
+                // remove all projections for which the lambda returns true:
+                TRI_ASSERT(!indexInfos[i].projections.empty());
                 indexInfos[i].projections.erase(
-                    [i, &indexInfos, plan = plan.get(),
-                     outVariable](Projections::Projection& p) -> bool {
+                    [i, plan, outVariable,
+                     &indexInfos](Projections::Projection& p) -> bool {
                       containers::FlatHashSet<AttributeNamePath> attributes;
+                      // look into all following indexes in the JoinNode
+                      // (i.e. south of us)
                       for (size_t j = i + 1; j < indexInfos.size(); ++j) {
                         if (indexInfos[j].filter == nullptr) {
+                          // following index does not have a post filter
+                          // condition, and thus cannot use a projection
                           continue;
                         }
+                        // collect all used attribute names in the index (j)
+                        // post filter condition that refer to our (i) output
+                        // variable:
                         if (!Ast::getReferencedAttributesRecursive(
                                 indexInfos[j].filter->node(), outVariable, "",
                                 attributes,
                                 plan->getAst()->query().resourceMonitor())) {
-                          // do not remove projection
+                          // unable to determine referenced attributes safely.
+                          // we better do not remove the projection.
                           return false;
                         }
-                        for (auto const& a : attributes) {
-                          if (a == p.path) {
-                            // projection is used in later filter condition
-                            return false;
-                          }
+                        if (std::find(attributes.begin(), attributes.end(),
+                                      p.path) != attributes.end()) {
+                          // projection of index (i) is used in post filter
+                          // condition of index (j). we cannot remove it
+                          return false;
                         }
                       }
-                      // projection is not used later
+                      // projection of index (i) is not used in any of the
+                      // following indexes (i + 1..n).
+                      // we return true so the superfluous projection will be
+                      // removed
                       return true;
                     });
                 if (indexInfos[i].projections.empty() &&
                     indexInfos[i].producesOutput) {
+                  // if we had projections before and now removed all
+                  // projections, it means we removed all remaining projections
+                  // for the index. that means we also can make it not produce
+                  // any output.
                   indexInfos[i].producesOutput = false;
                 }
               }
-            }
+            }();
             modified = true;
           } else {
             LOG_INDEX_OPTIMIZER_RULE << "Not eligible for index join";

--- a/tests/js/client/aql/aql-index-join.js
+++ b/tests/js/client/aql/aql-index-join.js
@@ -1,5 +1,5 @@
 /*jshint globalstrict:false, strict:false, maxlen: 500 */
-/*global fail, assertEqual, assertNotEqual, assertTrue */
+/*global fail, assertEqual, assertNotEqual, assertTrue, assertFalse */
 
 ////////////////////////////////////////////////////////////////////////////////
 /// DISCLAIMER

--- a/tests/js/client/aql/aql-index-join.js
+++ b/tests/js/client/aql/aql-index-join.js
@@ -120,7 +120,7 @@ const IndexJoinTestSuite = function () {
   };
 
   const runAndCheckQuery = function (query) {
-    const plan = db._createStatement({query: query, bindVars:  null, options:  queryOptions}).explain().plan;
+    const plan = db._createStatement({query, bindVars: null, options: queryOptions}).explain().plan;
     let planNodes = plan.nodes.map(function (node) {
       return node.type;
     });
@@ -130,7 +130,7 @@ const IndexJoinTestSuite = function () {
     }
     assertNotEqual(planNodes.indexOf("JoinNode"), -1);
 
-    const result = db._createStatement({query: query, bindVars:  null, options:  queryOptions}).execute();
+    const result = db._createStatement({query, bindVars: null, options: queryOptions}).execute();
     return result.toArray();
   };
 
@@ -323,7 +323,7 @@ const IndexJoinTestSuite = function () {
               RETURN [doc1.x, doc2.x]
       `;
 
-      const plan = db._createStatement({query: query, bindVars:  null, options:  queryOptions}).explain().plan;
+      const plan = db._createStatement({query, bindVars: null, options: queryOptions}).explain().plan;
       const join = plan.nodes[1];
 
       assertEqual(join.type, "JoinNode");
@@ -353,7 +353,7 @@ const IndexJoinTestSuite = function () {
               RETURN [doc1.x, doc2.x]
       `;
 
-      const plan = db._createStatement({query: query, bindVars:  null, options:  queryOptions}).explain().plan;
+      const plan = db._createStatement({query, bindVars: null, options: queryOptions}).explain().plan;
       const join = plan.nodes[1];
 
       assertEqual(join.type, "JoinNode");
@@ -383,7 +383,7 @@ const IndexJoinTestSuite = function () {
               RETURN [doc1.y, doc2.x]
       `;
 
-      const plan = db._createStatement({query: query, bindVars:  null, options:  queryOptions}).explain().plan;
+      const plan = db._createStatement({query, bindVars: null, options: queryOptions}).explain().plan;
       const join = plan.nodes[1];
 
       assertEqual(join.type, "JoinNode");
@@ -413,7 +413,7 @@ const IndexJoinTestSuite = function () {
               RETURN [doc1.y, doc2.x]
       `;
 
-      const plan = db._createStatement({query: query, bindVars:  null, options:  queryOptions}).explain().plan;
+      const plan = db._createStatement({query, bindVars: null, options: queryOptions}).explain().plan;
       const join = plan.nodes[1];
 
       assertEqual(join.type, "JoinNode");
@@ -443,7 +443,7 @@ const IndexJoinTestSuite = function () {
               RETURN [doc1.y, doc2.x]
       `;
 
-      const plan = db._createStatement({query: query, bindVars:  null, options:  queryOptions}).explain().plan;
+      const plan = db._createStatement({query, bindVars: null, options: queryOptions}).explain().plan;
       const join = plan.nodes[1];
 
       assertEqual(join.type, "JoinNode");
@@ -473,7 +473,7 @@ const IndexJoinTestSuite = function () {
               RETURN [doc1.y, doc2.x]
       `;
 
-      const plan = db._createStatement({query: query, bindVars:  null, options:  queryOptions}).explain().plan;
+      const plan = db._createStatement({query, bindVars: null, options: queryOptions}).explain().plan;
       const join = plan.nodes[1];
 
       assertEqual(join.type, "JoinNode");
@@ -503,7 +503,7 @@ const IndexJoinTestSuite = function () {
               RETURN [doc1.y, doc2.x]
       `;
 
-      const plan = db._createStatement({query: query, bindVars:  null, options:  queryOptions}).explain().plan;
+      const plan = db._createStatement({query, bindVars: null, options: queryOptions}).explain().plan;
       const join = plan.nodes[1];
 
       assertEqual(join.type, "JoinNode");
@@ -516,6 +516,140 @@ const IndexJoinTestSuite = function () {
       assertEqual(result.length, 10);
       for (const [a, b] of result) {
         assertEqual(a, 2 * b);
+      }
+    },
+    
+    testProjectionsOptimizedAway: function () {
+      const A = fillCollection("A", singleAttributeGenerator(10, "x", x => x));
+      A.ensureIndex({type: "persistent", fields: ["x"]});
+      const B = fillCollection("B", singleAttributeGenerator(10, "x", x => x));
+      B.ensureIndex({type: "persistent", fields: ["x"]});
+
+      const query = `
+        FOR doc1 IN A
+          SORT doc1.x
+          FOR doc2 IN B
+              FILTER doc1.x == doc2.x
+              RETURN 1
+      `;
+
+      const plan = db._createStatement({query, bindVars: null, options: queryOptions}).explain().plan;
+      const join = plan.nodes[2];
+
+      assertEqual(join.type, "JoinNode");
+
+      assertEqual(normalize(join.indexInfos[0].projections), normalize([]));
+      assertFalse(join.indexInfos[0].producesOutput);
+      assertEqual(normalize(join.indexInfos[1].projections), normalize([]));
+      assertFalse(join.indexInfos[1].producesOutput);
+
+      const result = runAndCheckQuery(query);
+
+      assertEqual(result.length, 10);
+      for (const x of result) {
+        assertEqual(1, x);
+      }
+    },
+    
+    testProjectionsFirstOptimizedAway: function () {
+      const A = fillCollection("A", singleAttributeGenerator(10, "x", x => x));
+      A.ensureIndex({type: "persistent", fields: ["x"]});
+      const B = fillCollection("B", attributeGenerator(10, {x: x => x, y: x => 2 * x}));
+      B.ensureIndex({type: "persistent", fields: ["x"]});
+
+      const query = `
+        FOR doc1 IN A
+          SORT doc1.x
+          FOR doc2 IN B
+              FILTER doc1.x == doc2.x
+              RETURN doc2.y
+      `;
+
+      const plan = db._createStatement({query, bindVars: null, options: queryOptions}).explain().plan;
+      const join = plan.nodes[1];
+
+      assertEqual(join.type, "JoinNode");
+
+      assertEqual(normalize(join.indexInfos[0].projections), normalize([]));
+      assertEqual(normalize(join.indexInfos[0].filterProjections), normalize([]));
+      assertFalse(join.indexInfos[0].producesOutput);
+      assertEqual(normalize(join.indexInfos[1].projections), normalize(["y"]));
+      assertEqual(normalize(join.indexInfos[1].filterProjections), normalize([]));
+      assertTrue(join.indexInfos[1].producesOutput);
+
+      const result = runAndCheckQuery(query);
+
+      assertEqual(result.length, 10);
+      for (const x of result) {
+        assertEqual(x % 2, 0);
+      }
+    },
+    
+    testProjectionsNotOptimizedAway1: function () {
+      const A = fillCollection("A", attributeGenerator(10, {x: x => 2 * x, y: x => 2 * x}));
+      A.ensureIndex({type: "persistent", fields: ["x"]});
+      const B = fillCollection("B", attributeGenerator(10, {x: x => 2 * x, y: x => 2 * x}));
+      B.ensureIndex({type: "persistent", fields: ["x"]});
+
+      const query = `
+        FOR doc1 IN A
+          SORT doc1.x
+          FOR doc2 IN B
+              FILTER doc1.x == doc2.x FILTER doc1.y >= 0
+              RETURN doc2.x
+      `;
+
+      const plan = db._createStatement({query, bindVars: null, options: queryOptions}).explain().plan;
+      const join = plan.nodes[1];
+
+      assertEqual(join.type, "JoinNode");
+
+      assertEqual(normalize(join.indexInfos[0].projections), normalize([]));
+      assertEqual(normalize(join.indexInfos[0].filterProjections), normalize(["y"]));
+      assertFalse(join.indexInfos[0].producesOutput);
+      assertEqual(normalize(join.indexInfos[1].projections), normalize(["x"]));
+      assertEqual(normalize(join.indexInfos[1].filterProjections), normalize([]));
+      assertTrue(join.indexInfos[1].producesOutput);
+
+      const result = runAndCheckQuery(query);
+
+      assertEqual(result.length, 10);
+      for (const x of result) {
+        assertEqual(x % 2, 0);
+      }
+    },
+    
+    testProjectionsNotOptimizedAway2: function () {
+      const A = fillCollection("A", attributeGenerator(10, {x: x => 2 * x, y: x => 2 * x}));
+      A.ensureIndex({type: "persistent", fields: ["x"]});
+      const B = fillCollection("B", attributeGenerator(10, {x: x => 2 * x, y: x => 2 * x}));
+      B.ensureIndex({type: "persistent", fields: ["x"]});
+
+      const query = `
+        FOR doc1 IN A
+          SORT doc1.x
+          FOR doc2 IN B
+              FILTER doc1.x == doc2.x FILTER doc1.y >= 0 FILTER doc2.y >= 0
+              RETURN doc2.x
+      `;
+
+      const plan = db._createStatement({query, bindVars: null, options: queryOptions}).explain().plan;
+      const join = plan.nodes[1];
+
+      assertEqual(join.type, "JoinNode");
+
+      assertEqual(normalize(join.indexInfos[0].projections), normalize([]));
+      assertEqual(normalize(join.indexInfos[0].filterProjections), normalize(["y"]));
+      assertFalse(join.indexInfos[0].producesOutput);
+      assertEqual(normalize(join.indexInfos[1].projections), normalize(["x"]));
+      assertEqual(normalize(join.indexInfos[1].filterProjections), normalize(["y"]));
+      assertTrue(join.indexInfos[1].producesOutput);
+
+      const result = runAndCheckQuery(query);
+
+      assertEqual(result.length, 10);
+      for (const x of result) {
+        assertEqual(x % 2, 0);
       }
     },
 
@@ -534,7 +668,7 @@ const IndexJoinTestSuite = function () {
               RETURN [doc1.x, doc1.y, doc2.x]
       `;
 
-      const plan = db._createStatement({query: query, bindVars:  null, options:  queryOptions}).explain().plan;
+      const plan = db._createStatement({query, bindVars: null, options: queryOptions}).explain().plan;
       const join = plan.nodes[1];
 
       assertEqual(join.type, "JoinNode");
@@ -566,7 +700,7 @@ const IndexJoinTestSuite = function () {
               RETURN [doc1, doc2.x]
       `;
 
-      const plan = db._createStatement({query: query, bindVars:  null, options:  queryOptions}).explain().plan;
+      const plan = db._createStatement({query, bindVars: null, options: queryOptions}).explain().plan;
       const join = plan.nodes[1];
 
       assertEqual(join.type, "JoinNode");
@@ -598,7 +732,7 @@ const IndexJoinTestSuite = function () {
               RETURN [doc1.x, doc2.x]
       `;
 
-      const plan = db._createStatement({query: query, bindVars:  null, options:  queryOptions}).explain().plan;
+      const plan = db._createStatement({query, bindVars: null, options: queryOptions}).explain().plan;
       const join = plan.nodes[1];
 
       assertEqual(join.type, "JoinNode");
@@ -635,7 +769,7 @@ const IndexJoinTestSuite = function () {
               RETURN [doc1, doc2.x]
       `;
 
-      const plan = db._createStatement({query: query, bindVars:  null, options:  queryOptions}).explain().plan;
+      const plan = db._createStatement({query, bindVars: null, options: queryOptions}).explain().plan;
       const join = plan.nodes[1];
 
       assertEqual(join.type, "JoinNode");


### PR DESCRIPTION
### Scope & Purpose

Remove unnecessary projections from JoinNode if the projected attributes are only used inside the JoinNode itself but not later, and are not referring to the join attributes.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [x] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 