### PR TITLE
Stabilize ReadWriteLock test

### DIFF
--- a/tests/Basics/ReadWriteLockTest.cpp
+++ b/tests/Basics/ReadWriteLockTest.cpp
@@ -240,7 +240,7 @@ TEST(ReadWriteLockTest, testTryLockWriteForWakeUpReaders) {
   threads.emplace_back(
       [&]() {
         s.waitForStart();
-        auto timeout = std::chrono::microseconds(100);
+        auto timeout = std::chrono::milliseconds(100);
         auto gotLock = lock.tryLockWriteFor(timeout);
         EXPECT_FALSE(gotLock)
             << "We got a write lock although the read lock was held";
@@ -266,9 +266,10 @@ TEST(ReadWriteLockTest, testTryLockWriteForWakeUpReaders) {
         return;
       }
     }
-    // NOTE: This time out is twice as high as the WRITE timeout.
-    // So we need to be woken up if the Writer is released.
-    auto timeout = std::chrono::microseconds(200);
+    // NOTE: This time out is **much larger** than the write timeout.
+    // So we need to be woken up if the Writer is released. If not
+    // (old buggy behaviour), we will still wait for 30 seconds:
+    auto timeout = std::chrono::seconds(30);
     auto gotLock = lock.tryLockReadFor(timeout);
     EXPECT_TRUE(gotLock)
         << "We did not get the read lock after the write lock got into timeout";


### PR DESCRIPTION
### Scope & Purpose

This stabilizes the new ReadWriteLock test for Windows. I simply
increase some timeouts, which have been shown to be critical on Windows.

I have tried out the same fix in my not yet merged branch for devel.

- [*] :hankey: Bugfix

### Checklist

- [*] Tests
  - [*] C++ **Unit tests**

