### PR TITLE
Make the docker tag to build with a parameter

### DIFF
--- a/.circleci/base_config.yml
+++ b/.circleci/base_config.yml
@@ -19,6 +19,9 @@ parameters:
   v8-build-targets:
     type: string
     default: "arangosh"
+  build-docker-tag:
+    type: string
+    default: arangodb/build-alpine:3.16-gcc11.2-openssl3.1.3-4999848556c
 
 commands:
   checkout-arangodb:
@@ -187,7 +190,7 @@ jobs:
         type: string
         default: ""
     docker:
-      - image: arangodb/build-alpine:3.16-gcc11.2-openssl3.1.3-4999848556c
+      - image: << pipeline.parameters.build-docker-tag >>
     resource_class: << parameters.resource-class >>
     environment:
       GIT_SSH_COMMAND: ssh
@@ -478,7 +481,7 @@ jobs:
 
   run-cppcheck:
     docker:
-      - image: arangodb/build-alpine:3.16-gcc11.2-openssl3.1.3-4999848556c
+      - image: << pipeline.parameters.build-docker-tag >>
     resource_class: medium+
     steps:
       - run:


### PR DESCRIPTION
### Scope & Purpose

This makes the docker container that is built with a pipeline parameter. Reduces the number of places to edit when updating, and enables testing docker images without changing the repository.