### PR TITLE
[EF-19] Join Node Estimations

### DIFF
--- a/arangod/Aql/JoinNode.cpp
+++ b/arangod/Aql/JoinNode.cpp
@@ -393,7 +393,7 @@ CostEstimate JoinNode::estimateCost() const {
   for (auto const& it : _indexInfos) {
     Index::FilterCosts costs = costsForIndexInfo(it);
     totalItems *= costs.estimatedItems;
-    totalCost *= costs.estimatedCosts;
+    totalCost += costs.estimatedCosts;
   }
 
   estimate.estimatedNrItems *= totalItems;

--- a/arangod/Aql/OptimizerRulesJoin.cpp
+++ b/arangod/Aql/OptimizerRulesJoin.cpp
@@ -344,8 +344,8 @@ bool checkCandidatesEligible(
       auto* lhs = root->getMember(0);
       auto* rhs = root->getMember(1);
 
-      if (!joinConditionMatches(plan, lhs, rhs, c, candidates[i - 1]) &&
-          !joinConditionMatches(plan, lhs, rhs, candidates[i - 1], c)) {
+      if (!joinConditionMatches(plan, lhs, rhs, c, candidates[0]) &&
+          !joinConditionMatches(plan, lhs, rhs, candidates[0], c)) {
         LOG_JOIN_OPTIMIZER_RULE
             << "IndexNode's lookup condition does not match";
         return false;


### PR DESCRIPTION
### Scope & Purpose
The costs for multiple nodes are *added*, the join node multiplied the costs for indexes, which made it _very_ expensive and most of the time, i.e. indexes > 3, the optimizer would bail out and not create a join node.