### PR TITLE
Make the actor implementation a bit more generic

### DIFF
--- a/arangod/Pregel/ArangoExternalDispatcher.h
+++ b/arangod/Pregel/ArangoExternalDispatcher.h
@@ -45,8 +45,8 @@ struct ArangoExternalDispatcher : actor::IExternalDispatcher {
         .thenValue([sender, receiver, this](auto&& result) -> void {
           auto out = errorHandling(result);
           if (out.fail()) {
-            auto error =
-                actor::message::ActorError{actor::message::NetworkError{
+            auto error = actor::message::ActorError<actor::DistributedActorPID>{
+                actor::message::NetworkError{
                     .message = (std::string)out.errorMessage()}};
             auto payload = inspection::serializeWithErrorT(error);
             ADB_PROD_ASSERT(payload.ok());

--- a/arangod/Pregel/Conductor/Handler.h
+++ b/arangod/Pregel/Conductor/Handler.h
@@ -38,6 +38,7 @@ namespace arangodb::pregel::conductor {
 
 template<typename Runtime>
 struct ConductorHandler : actor::HandlerBase<Runtime, ConductorState> {
+  using ActorPID = typename Runtime::ActorPID;
   auto operator()(message::ConductorStart start)
       -> std::unique_ptr<ConductorState> {
     LOG_TOPIC("5adb0", INFO, Logger::PREGEL) << fmt::format(
@@ -200,7 +201,7 @@ struct ConductorHandler : actor::HandlerBase<Runtime, ConductorState> {
     return std::move(this->state);
   }
 
-  auto operator()(actor::message::ActorNotFound notFound)
+  auto operator()(actor::message::ActorNotFound<ActorPID> notFound)
       -> std::unique_ptr<ConductorState> {
     LOG_TOPIC("ea585", INFO, Logger::PREGEL)
         << fmt::format("Conductor Actor: Error - receiving actor {} not found",

--- a/arangod/Pregel/Conductor/Handler.h
+++ b/arangod/Pregel/Conductor/Handler.h
@@ -193,7 +193,7 @@ struct ConductorHandler : actor::HandlerBase<Runtime, ConductorState> {
     return std::move(this->state);
   }
 
-  auto operator()(actor::message::UnknownMessage unknown)
+  auto operator()(actor::message::UnknownMessage<ActorPID> unknown)
       -> std::unique_ptr<ConductorState> {
     LOG_TOPIC("d1791", INFO, Logger::PREGEL)
         << fmt::format("Conductor Actor: Error - sent unknown message to {}",

--- a/arangod/Pregel/MetricsActor.h
+++ b/arangod/Pregel/MetricsActor.h
@@ -43,6 +43,7 @@ auto inspect(Inspector& f, MetricsState& x) {
 
 template<typename Runtime>
 struct MetricsHandler : actor::HandlerBase<Runtime, MetricsState> {
+  using ActorPID = typename Runtime::ActorPID;
   auto operator()(metrics::message::MetricsStart msg) {
     LOG_TOPIC("89eac", INFO, Logger::PREGEL)
         << fmt::format("Metric Actor {} started", this->self);
@@ -157,7 +158,7 @@ struct MetricsHandler : actor::HandlerBase<Runtime, MetricsState> {
     return std::move(this->state);
   }
 
-  auto operator()(actor::message::ActorNotFound notFound)
+  auto operator()(actor::message::ActorNotFound<ActorPID> notFound)
       -> std::unique_ptr<MetricsState> {
     LOG_TOPIC("c944d", INFO, Logger::PREGEL) << fmt::format(
         "Metrics Actor: Error - receiving actor {} not found", notFound.actor);

--- a/arangod/Pregel/MetricsActor.h
+++ b/arangod/Pregel/MetricsActor.h
@@ -151,7 +151,7 @@ struct MetricsHandler : actor::HandlerBase<Runtime, MetricsState> {
     return std::move(this->state);
   }
 
-  auto operator()(actor::message::UnknownMessage unknown)
+  auto operator()(actor::message::UnknownMessage<ActorPID> unknown)
       -> std::unique_ptr<MetricsState> {
     LOG_TOPIC("edc16", INFO, Logger::PREGEL) << fmt::format(
         "Metrics Actor: Error - sent unknown message to {}", unknown.receiver);

--- a/arangod/Pregel/PregelFeature.cpp
+++ b/arangod/Pregel/PregelFeature.cpp
@@ -121,7 +121,7 @@ PregelScheduler::PregelScheduler(Scheduler* scheduler) : _scheduler{scheduler} {
   TRI_ASSERT(_scheduler != nullptr);
 }
 
-void PregelScheduler::queue(actor::ActorWorker&& worker) {
+void PregelScheduler::queue(actor::LazyWorker&& worker) {
   _scheduler->queue(RequestLane::INTERNAL_LOW, std::move(worker));
 }
 

--- a/arangod/Pregel/PregelFeature.h
+++ b/arangod/Pregel/PregelFeature.h
@@ -64,7 +64,7 @@ namespace arangodb::pregel {
 
 struct PregelScheduler : actor::IScheduler {
   explicit PregelScheduler(Scheduler* scheduler);
-  void queue(actor::ActorWorker&& worker) override;
+  void queue(actor::LazyWorker&& worker) override;
   void delay(std::chrono::seconds delay,
              std::function<void(bool)>&& fn) override;
 

--- a/arangod/Pregel/ResultActor.h
+++ b/arangod/Pregel/ResultActor.h
@@ -154,7 +154,7 @@ struct ResultHandler : actor::HandlerBase<Runtime, ResultState> {
     return std::move(this->state);
   }
 
-  auto operator()(actor::message::UnknownMessage unknown)
+  auto operator()(actor::message::UnknownMessage<ActorPID> unknown)
       -> std::unique_ptr<ResultState> {
     LOG_TOPIC("eb602", INFO, Logger::PREGEL)
         << fmt::format("Result Actor: Error - sent unknown message to {}",

--- a/arangod/Pregel/ResultActor.h
+++ b/arangod/Pregel/ResultActor.h
@@ -97,6 +97,7 @@ auto inspect(Inspector& f, ResultState& x) {
 
 template<typename Runtime>
 struct ResultHandler : actor::HandlerBase<Runtime, ResultState> {
+  using ActorPID = typename Runtime::ActorPID;
   auto setExpiration() {
     this->state->expiration =
         std::chrono::system_clock::now() + this->state->ttl.duration;
@@ -161,7 +162,7 @@ struct ResultHandler : actor::HandlerBase<Runtime, ResultState> {
     return std::move(this->state);
   }
 
-  auto operator()(actor::message::ActorNotFound notFound)
+  auto operator()(actor::message::ActorNotFound<ActorPID> notFound)
       -> std::unique_ptr<ResultState> {
     LOG_TOPIC("e3156", INFO, Logger::PREGEL)
         << fmt::format("Result Actor: Error - receiving actor {} not found",

--- a/arangod/Pregel/SpawnActor.h
+++ b/arangod/Pregel/SpawnActor.h
@@ -69,6 +69,7 @@ auto inspect(Inspector& f, SpawnState& x) {
 
 template<typename Runtime>
 struct SpawnHandler : actor::HandlerBase<Runtime, SpawnState> {
+  using ActorPID = typename Runtime::ActorPID;
   auto operator()(message::SpawnStart start) -> std::unique_ptr<SpawnState> {
     LOG_TOPIC("4a414", INFO, Logger::PREGEL)
         << fmt::format("Spawn Actor {} started", this->self);
@@ -213,7 +214,7 @@ struct SpawnHandler : actor::HandlerBase<Runtime, SpawnState> {
     return std::move(this->state);
   }
 
-  auto operator()(actor::message::ActorNotFound notFound)
+  auto operator()(actor::message::ActorNotFound<ActorPID> notFound)
       -> std::unique_ptr<SpawnState> {
     LOG_TOPIC("03156", INFO, Logger::PREGEL) << fmt::format(
         "Spawn Actor: Error - receiving actor {} not found", notFound.actor);

--- a/arangod/Pregel/SpawnActor.h
+++ b/arangod/Pregel/SpawnActor.h
@@ -207,7 +207,7 @@ struct SpawnHandler : actor::HandlerBase<Runtime, SpawnState> {
     return std::move(this->state);
   }
 
-  auto operator()(actor::message::UnknownMessage unknown)
+  auto operator()(actor::message::UnknownMessage<ActorPID> unknown)
       -> std::unique_ptr<SpawnState> {
     LOG_TOPIC("7b602", INFO, Logger::PREGEL) << fmt::format(
         "Spawn Actor: Error - sent unknown message to {}", unknown.receiver);

--- a/arangod/Pregel/StatusActor.h
+++ b/arangod/Pregel/StatusActor.h
@@ -29,6 +29,7 @@
 #include "Inspection/Status.h"
 #include "Inspection/Format.h"
 #include "Inspection/VPackWithErrorT.h"
+#include "Logger/LogMacros.h"
 #include "Pregel/DatabaseTypes.h"
 #include "Pregel/StatusMessages.h"
 #include "Pregel/StatusWriter/CollectionStatusWriter.h"
@@ -302,6 +303,7 @@ auto inspect(Inspector& f, StatusState& x) {
 
 template<typename Runtime>
 struct StatusHandler : actor::HandlerBase<Runtime, StatusState> {
+  using ActorPID = typename Runtime::ActorPID;
   auto updateStatusDocument() {
     statuswriter::CollectionStatusWriter cWriter{
         this->state->vocbaseGuard.database(), this->state->status->id.number};
@@ -507,7 +509,7 @@ struct StatusHandler : actor::HandlerBase<Runtime, StatusState> {
     return std::move(this->state);
   }
 
-  auto operator()(actor::message::ActorNotFound notFound)
+  auto operator()(actor::message::ActorNotFound<ActorPID> notFound)
       -> std::unique_ptr<StatusState> {
     LOG_TOPIC("e31f6", INFO, Logger::PREGEL)
         << fmt::format("Status Actor: Error - receiving actor {} not found",

--- a/arangod/Pregel/StatusActor.h
+++ b/arangod/Pregel/StatusActor.h
@@ -501,7 +501,7 @@ struct StatusHandler : actor::HandlerBase<Runtime, StatusState> {
     return std::move(this->state);
   }
 
-  auto operator()(actor::message::UnknownMessage unknown)
+  auto operator()(actor::message::UnknownMessage<ActorPID> unknown)
       -> std::unique_ptr<StatusState> {
     LOG_TOPIC("eb6f2", INFO, Logger::PREGEL)
         << fmt::format("Status Actor: Error - sent unknown message to {}",

--- a/arangod/Pregel/Worker/Handler.h
+++ b/arangod/Pregel/Worker/Handler.h
@@ -54,6 +54,7 @@ struct VerticesProcessed {
 
 template<typename V, typename E, typename M, typename Runtime>
 struct WorkerHandler : actor::HandlerBase<Runtime, WorkerState<V, E, M>> {
+  using ActorPID = typename Runtime::ActorPID;
   DispatchStatus const& dispatchStatus =
       [this](pregel::message::StatusMessages message) -> void {
     this->template dispatch<pregel::message::StatusMessages>(
@@ -177,7 +178,7 @@ struct WorkerHandler : actor::HandlerBase<Runtime, WorkerState<V, E, M>> {
     return std::move(this->state);
   }
 
-  auto operator()(actor::message::ActorNotFound notFound)
+  auto operator()(actor::message::ActorNotFound<ActorPID> notFound)
       -> std::unique_ptr<WorkerState<V, E, M>> {
     LOG_TOPIC("2d647", INFO, Logger::PREGEL) << fmt::format(
         "Worker Actor: Error - receiving actor {} not found", notFound.actor);

--- a/arangod/Pregel/Worker/Handler.h
+++ b/arangod/Pregel/Worker/Handler.h
@@ -171,7 +171,7 @@ struct WorkerHandler : actor::HandlerBase<Runtime, WorkerState<V, E, M>> {
     return std::move(this->state);
   }
 
-  auto operator()(actor::message::UnknownMessage unknown)
+  auto operator()(actor::message::UnknownMessage<ActorPID> unknown)
       -> std::unique_ptr<WorkerState<V, E, M>> {
     LOG_TOPIC("7ee4d", INFO, Logger::PREGEL) << fmt::format(
         "Worker Actor: Error - sent unknown message to {}", unknown.receiver);

--- a/lib/Actor/include/Actor/ActorBase.h
+++ b/lib/Actor/include/Actor/ActorBase.h
@@ -30,7 +30,7 @@
 
 namespace arangodb::actor {
 
-template<class ActorPID>
+template<typename ActorPID>
 struct ActorBase : IWorkable {
   virtual ~ActorBase() = default;
   virtual auto process(ActorPID sender, MessagePayloadBase& msg) -> void = 0;

--- a/lib/Actor/include/Actor/ActorBase.h
+++ b/lib/Actor/include/Actor/ActorBase.h
@@ -25,23 +25,22 @@
 #pragma once
 
 #include "Actor/DistributedActorPID.h"
+#include "Actor/IWorkable.h"
 #include "Actor/Message.h"
 
 namespace arangodb::actor {
 
-struct ActorBase : std::enable_shared_from_this<ActorBase> {
+template<class ActorPID>
+struct ActorBase : IWorkable {
   virtual ~ActorBase() = default;
-  virtual auto process(DistributedActorPID sender, MessagePayloadBase& msg)
-      -> void = 0;
-  virtual auto process(DistributedActorPID sender, velocypack::SharedSlice msg)
+  virtual auto process(ActorPID sender, MessagePayloadBase& msg) -> void = 0;
+  virtual auto process(ActorPID sender, velocypack::SharedSlice msg)
       -> void = 0;
   virtual auto typeName() -> std::string_view = 0;
   virtual auto serialize() -> velocypack::SharedSlice = 0;
   virtual auto finish() -> void = 0;
   virtual auto isFinishedAndIdle() -> bool = 0;
   virtual auto isIdle() -> bool = 0;
-
-  virtual void work() = 0;
 };
 
 }  // namespace arangodb::actor

--- a/lib/Actor/include/Actor/ActorList.h
+++ b/lib/Actor/include/Actor/ActorList.h
@@ -30,13 +30,13 @@
 
 namespace arangodb::actor {
 
-template<typename F, class ActorPID>
+template<typename F, typename ActorPID>
 concept Predicate =
     requires(F fn, std::shared_ptr<ActorBase<ActorPID>> const& actor) {
   { fn(actor) } -> std::same_as<bool>;
 };
 
-template<class ActorPID>
+template<typename ActorPID>
 struct ActorList {
  private:
   struct ActorMap

--- a/lib/Actor/include/Actor/DistributedRuntime.h
+++ b/lib/Actor/include/Actor/DistributedRuntime.h
@@ -43,6 +43,8 @@
 namespace arangodb::actor {
 
 struct DistributedRuntime : std::enable_shared_from_this<DistributedRuntime> {
+  using ActorPID = DistributedActorPID;
+
   DistributedRuntime() = delete;
   DistributedRuntime(DistributedRuntime const&) = delete;
   DistributedRuntime(DistributedRuntime&&) = delete;
@@ -51,10 +53,8 @@ struct DistributedRuntime : std::enable_shared_from_this<DistributedRuntime> {
                      std::shared_ptr<IExternalDispatcher> externalDispatcher)
       : myServerID(myServerID),
         runtimeID(runtimeID),
-        scheduler(scheduler),
+        _scheduler(scheduler),
         externalDispatcher(externalDispatcher) {}
-
-  using ActorPID = DistributedActorPID;
 
   template<typename ActorConfig>
   auto spawn(std::unique_ptr<typename ActorConfig::State> initialState,
@@ -133,8 +133,8 @@ struct DistributedRuntime : std::enable_shared_from_this<DistributedRuntime> {
   template<typename ActorMessage>
   auto dispatchDelayed(std::chrono::seconds delay, ActorPID sender,
                        ActorPID receiver, ActorMessage const& message) -> void {
-    scheduler->delay(delay, [self = this->weak_from_this(), sender, receiver,
-                             message](bool canceled) {
+    _scheduler->delay(delay, [self = this->weak_from_this(), sender, receiver,
+                              message](bool canceled) {
       auto me = self.lock();
       if (me != nullptr) {
         me->dispatch(sender, receiver, message);
@@ -143,9 +143,10 @@ struct DistributedRuntime : std::enable_shared_from_this<DistributedRuntime> {
   }
 
   auto areAllActorsIdle() -> bool {
-    return actors.checkAll([](std::shared_ptr<ActorBase> const& actor) {
-      return actor->isIdle();
-    });
+    return actors.checkAll(
+        [](std::shared_ptr<ActorBase<ActorPID>> const& actor) {
+          return actor->isIdle();
+        });
   }
 
   auto finish(ActorPID pid) -> void {
@@ -157,29 +158,41 @@ struct DistributedRuntime : std::enable_shared_from_this<DistributedRuntime> {
 
   // TODO call this function regularly
   auto garbageCollect() {
-    actors.removeIf([](std::shared_ptr<ActorBase> const& actor) -> bool {
-      return actor->isFinishedAndIdle();
-    });
+    actors.removeIf(
+        [](std::shared_ptr<ActorBase<ActorPID>> const& actor) -> bool {
+          return actor->isFinishedAndIdle();
+        });
   }
 
   auto softShutdown() -> void {
-    actors.apply(
-        [](std::shared_ptr<ActorBase> const& actor) { actor->finish(); });
+    actors.apply([](std::shared_ptr<ActorBase<ActorPID>> const& actor) {
+      actor->finish();
+    });
     garbageCollect();  // TODO call gc several times with some timeout
   }
 
-  ServerID myServerID;
+  IScheduler& scheduler() { return *_scheduler; }
+
+  ServerID const myServerID;
   std::string const runtimeID;
 
-  std::shared_ptr<IScheduler> scheduler;
+  template<typename Inspector>
+  friend inline auto inspect(Inspector& f, DistributedRuntime& x) {
+    return f.object(x).fields(
+        f.field("myServerID", x.myServerID), f.field("runtimeID", x.runtimeID),
+        f.field("uniqueActorIDCounter", x.uniqueActorIDCounter.load()),
+        f.field("actors", x.actors));
+  }
+
+  ActorList<ActorPID> actors;
+
+ private:
+  std::shared_ptr<IScheduler> _scheduler;
   std::shared_ptr<IExternalDispatcher> externalDispatcher;
 
   // actor id 0 is reserved for special messages
   std::atomic<size_t> uniqueActorIDCounter{1};
 
-  ActorList actors;
-
- private:
   template<typename ActorMessage>
   auto dispatchLocally(ActorPID sender, ActorPID receiver,
                        ActorMessage const& message) -> void {
@@ -202,12 +215,5 @@ struct DistributedRuntime : std::enable_shared_from_this<DistributedRuntime> {
     externalDispatcher->dispatch(sender, receiver, payload.get());
   }
 };
-template<typename Inspector>
-auto inspect(Inspector& f, DistributedRuntime& x) {
-  return f.object(x).fields(
-      f.field("myServerID", x.myServerID), f.field("runtimeID", x.runtimeID),
-      f.field("uniqueActorIDCounter", x.uniqueActorIDCounter.load()),
-      f.field("actors", x.actors));
-}
 
 };  // namespace arangodb::actor

--- a/lib/Actor/include/Actor/DistributedRuntime.h
+++ b/lib/Actor/include/Actor/DistributedRuntime.h
@@ -112,8 +112,8 @@ struct DistributedRuntime : std::enable_shared_from_this<DistributedRuntime> {
     if (actor.has_value()) {
       actor.value()->process(sender, msg);
     } else {
-      auto error =
-          message::ActorError{message::ActorNotFound{.actor = receiver}};
+      auto error = message::ActorError<ActorPID>{
+          message::ActorNotFound<ActorPID>{.actor = receiver}};
       auto payload = inspection::serializeWithErrorT(error);
       ACTOR_ASSERT(payload.ok());
       dispatch(receiver, sender, payload.get());
@@ -189,7 +189,8 @@ struct DistributedRuntime : std::enable_shared_from_this<DistributedRuntime> {
       actor->get()->process(sender, payload);
     } else {
       dispatch(receiver, sender,
-               message::ActorError{message::ActorNotFound{.actor = receiver}});
+               message::ActorError<ActorPID>{
+                   message::ActorNotFound<ActorPID>{.actor = receiver}});
     }
   }
 

--- a/lib/Actor/include/Actor/IWorkable.h
+++ b/lib/Actor/include/Actor/IWorkable.h
@@ -23,17 +23,13 @@
 
 #pragma once
 
-#include <chrono>
-#include <functional>
-#include "Actor/LazyWorker.h"
+#include <memory>
 
 namespace arangodb::actor {
 
-struct IScheduler {
-  virtual ~IScheduler() = default;
-  virtual void queue(LazyWorker&& worker) = 0;
-  virtual void delay(std::chrono::seconds delay,
-                     std::function<void(bool)>&& fn) = 0;
+struct IWorkable : std::enable_shared_from_this<IWorkable> {
+  virtual ~IWorkable() = default;
+  virtual void work() = 0;
 };
 
 }  // namespace arangodb::actor

--- a/lib/Actor/include/Actor/LazyWorker.h
+++ b/lib/Actor/include/Actor/LazyWorker.h
@@ -23,24 +23,24 @@
 
 #pragma once
 
-#include "Actor/ActorBase.h"
+#include "Actor/IWorkable.h"
 
 namespace arangodb::actor {
 
-struct ActorWorker {
-  // capture a weak_ptr to the actor: this way, the actor can be destroyed
+struct LazyWorker {
+  // capture a weak_ptr to the workable: this way, the workable can be destroyed
   // although this worker is still waiting in the scheduler. When this worker is
-  // executed in the queue after actor was destroyed, the weak_ptr will
+  // executed in the queue after workable was destroyed, the weak_ptr will
   // be empty and work will just not be executed
-  explicit ActorWorker(ActorBase* actor) : actor(actor->weak_from_this()) {}
+  explicit LazyWorker(IWorkable* work) : work(work->weak_from_this()) {}
 
   void operator()() {
-    auto me = actor.lock();
+    auto me = work.lock();
     if (me != nullptr) {
       me->work();
     }
   }
-  std::weak_ptr<ActorBase> actor;
+  std::weak_ptr<IWorkable> work;
 };
 
 }  // namespace arangodb::actor

--- a/lib/Actor/include/Actor/Message.h
+++ b/lib/Actor/include/Actor/Message.h
@@ -51,22 +51,22 @@ auto inspect(Inspector& f, MessagePayload<Payload>& x) {
 
 namespace message {
 
-template<class PID>
+template<typename PID>
 struct UnknownMessage {
   PID sender;
   PID receiver;
 };
-template<typename Inspector, class PID>
+template<typename Inspector, typename PID>
 auto inspect(Inspector& f, UnknownMessage<PID>& x) {
   return f.object(x).fields(f.field("sender", x.sender),
                             f.field("receiver", x.receiver));
 }
 
-template<class PID>
+template<typename PID>
 struct ActorNotFound {
   PID actor;
 };
-template<typename Inspector, class PID>
+template<typename Inspector, typename PID>
 auto inspect(Inspector& f, ActorNotFound<PID>& x) {
   return f.object(x).fields(f.field("actor", x.actor));
 }
@@ -79,13 +79,13 @@ auto inspect(Inspector& f, NetworkError& x) {
   return f.object(x).fields(f.field("server", x.message));
 }
 
-template<class PID>
+template<typename PID>
 struct ActorError
     : std::variant<UnknownMessage<PID>, ActorNotFound<PID>, NetworkError> {
   using std::variant<UnknownMessage<PID>, ActorNotFound<PID>,
                      NetworkError>::variant;
 };
-template<typename Inspector, class PID>
+template<typename Inspector, typename PID>
 auto inspect(Inspector& f, ActorError<PID>& x) {
   return f.variant(x).unqualified().alternatives(
       arangodb::inspection::type<UnknownMessage<PID>>("UnknownMessage"),
@@ -108,7 +108,7 @@ struct concatenator<std::variant<Args0...>, std::variant<Args1...>> {
   }
 };
 
-template<typename T, class PID>
+template<typename T, typename PID>
 struct MessageOrError
     : concatenator<typename T::variant, typename ActorError<PID>::variant> {
   using concatenator<typename T::variant,
@@ -121,10 +121,10 @@ struct MessageOrError
 template<typename Payload>
 struct fmt::formatter<arangodb::actor::MessagePayload<Payload>>
     : arangodb::inspection::inspection_formatter {};
-template<class PID>
+template<typename PID>
 struct fmt::formatter<arangodb::actor::message::UnknownMessage<PID>>
     : arangodb::inspection::inspection_formatter {};
-template<class PID>
+template<typename PID>
 struct fmt::formatter<arangodb::actor::message::ActorNotFound<PID>>
     : arangodb::inspection::inspection_formatter {};
 template<>

--- a/tests/Actor/ActorListTest.cpp
+++ b/tests/Actor/ActorListTest.cpp
@@ -25,15 +25,20 @@
 #include <gtest/gtest.h>
 #include "Actor/ActorBase.h"
 #include "Actor/ActorList.h"
+#include "Actor/DistributedActorPID.h"
 
-using namespace arangodb::actor;
+using arangodb::actor::ActorID;
+using arangodb::actor::DistributedActorPID;
+
+using ActorList = arangodb::actor::ActorList<DistributedActorPID>;
+using ActorBase = arangodb::actor::ActorBase<DistributedActorPID>;
 
 struct ActorBaseMock : ActorBase {
   ActorBaseMock(std::string type) : type{std::move(type)} {}
   ActorBaseMock() = default;
   ~ActorBaseMock() = default;
-  auto process(DistributedActorPID sender, MessagePayloadBase& msg)
-      -> void override {}
+  auto process(DistributedActorPID sender,
+               arangodb::actor::MessagePayloadBase& msg) -> void override {}
   auto process(DistributedActorPID sender,
                arangodb::velocypack::SharedSlice msg) -> void override {}
   auto typeName() -> std::string_view override { return type; }

--- a/tests/Actor/Actors/TrivialActor.h
+++ b/tests/Actor/Actors/TrivialActor.h
@@ -80,6 +80,7 @@ auto inspect(Inspector& f, TrivialMessages& x) {
 
 template<typename Runtime>
 struct TrivialHandler : HandlerBase<Runtime, TrivialState> {
+  using ActorPID = typename Runtime::ActorPID;
   auto operator()(message::TrivialStart msg) -> std::unique_ptr<TrivialState> {
     this->state->called++;
     return std::move(this->state);
@@ -100,7 +101,7 @@ struct TrivialHandler : HandlerBase<Runtime, TrivialState> {
     return std::move(this->state);
   }
 
-  auto operator()(actor::message::ActorNotFound notFound)
+  auto operator()(actor::message::ActorNotFound<ActorPID> notFound)
       -> std::unique_ptr<TrivialState> {
     this->state->called++;
     this->state->state =

--- a/tests/Actor/Actors/TrivialActor.h
+++ b/tests/Actor/Actors/TrivialActor.h
@@ -93,7 +93,7 @@ struct TrivialHandler : HandlerBase<Runtime, TrivialState> {
     return std::move(this->state);
   }
 
-  auto operator()(actor::message::UnknownMessage unknown)
+  auto operator()(actor::message::UnknownMessage<ActorPID> unknown)
       -> std::unique_ptr<TrivialState> {
     this->state->called++;
     this->state->state =

--- a/tests/Actor/MockScheduler.h
+++ b/tests/Actor/MockScheduler.h
@@ -29,7 +29,7 @@ namespace arangodb::actor::test {
 struct MockScheduler : IScheduler {
   auto start(size_t number_of_threads) -> void{};
   auto stop() -> void{};
-  void queue(ActorWorker&& worker) override { worker(); }
+  void queue(LazyWorker&& worker) override { worker(); }
   void delay(std::chrono::seconds delay,
              std::function<void(bool)>&& fn) override {
     fn(true);

--- a/tests/Actor/MultiRuntimeTest.cpp
+++ b/tests/Actor/MultiRuntimeTest.cpp
@@ -48,8 +48,10 @@ struct MockExternalDispatcher : IExternalDispatcher {
     if (receiving_runtime != std::end(runtimes)) {
       receiving_runtime->second->receive(sender, receiver, msg);
     } else {
-      auto error = actor::message::ActorError{actor::message::NetworkError{
-          .message = fmt::format("Cannot find server {}", receiver.server)}};
+      auto error =
+          actor::message::ActorError<ActorPID>{actor::message::NetworkError{
+              .message =
+                  fmt::format("Cannot find server {}", receiver.server)}};
       auto payload = inspection::serializeWithErrorT(error);
       if (payload.ok()) {
         runtimes[sender.server]->dispatch(receiver, sender, payload.get());

--- a/tests/Actor/ThreadPoolScheduler.h
+++ b/tests/Actor/ThreadPoolScheduler.h
@@ -33,7 +33,7 @@
 struct ThreadPoolScheduler : arangodb::actor::IScheduler {
  private:
   arangodb::ThreadGuard threads;
-  std::queue<arangodb::actor::ActorWorker> jobs;
+  std::queue<arangodb::actor::LazyWorker> jobs;
   std::mutex queue_mutex;
   std::condition_variable mutex_condition;
   bool should_terminate = false;
@@ -72,7 +72,7 @@ struct ThreadPoolScheduler : arangodb::actor::IScheduler {
     threads.joinAll();
   }
 
-  void queue(arangodb::actor::ActorWorker&& job) override {
+  void queue(arangodb::actor::LazyWorker&& job) override {
     {
       std::unique_lock lock(queue_mutex);
       jobs.push(std::move(job));


### PR DESCRIPTION
### Scope & Purpose

Follow up PR of #20111 in preparation of the parallel follower implementation.

Some generic messages previously relied on the `DistributedActorPID`, but other runtime implementations may use different PID types, so these messages are now templatized on the PID type. Similarly the `ActorBase` has been templatized for the same reason, and a new interface has been extracted so that the `IScheduler` has a minimal dependency (interface segregation principle).

- [x] :hammer: Refactoring/simplification
