### PR TITLE
add IPO/LTO for third party modules

### DIFF
--- a/3rdParty/CMakeLists.txt
+++ b/3rdParty/CMakeLists.txt
@@ -9,18 +9,6 @@ include(UpdateModule)
 
 remove_definitions("-DUSE_ENTERPRISE=1")
 
-# Disable IPO for 3rdParty libs. This is because they currently all use old
-# cmake versions, missing policy CMP0069.
-# Hopefully this can be removed later - just try it out and look for warnings in
-# cmake's output. Also, you can use the compile_commands.json optionally emitted
-# by cmake (see CMAKE_EXPORT_COMPILE_COMMANDS) and jq to get a list of files we
-# do not compile with IPO (assuming gcc or clang) with this command:
-#   < compile_commands.json jq '.[] | select(.command | test("-flto") | not) | .file' -r
-if (${IPO_ENABLED})
-  message ("Disabling IPO for 3rdParty libraries")
-  set(CMAKE_INTERPROCEDURAL_OPTIMIZATION False)
-endif ()
-
 ################################################################################
 ## gtest
 ################################################################################
@@ -115,6 +103,8 @@ set(ICU_DT "${ICU_DT}" PARENT_SCOPE)
 set(ICU_DT_DEST "${ICU_DT_DEST}" PARENT_SCOPE)
 set(ICU_LIBRARY_DIR "${ICU_LIBRARY_DIR}" PARENT_SCOPE)
 set(ICU_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/V8/${V8_SUB_DIR}/third_party/icu/")
+
+set(V8_INTERNAL_INCLUDE_DIR ${V8_INTERNAL_INCLUDE_DIR} PARENT_SCOPE)
 
 ################################################################################
 ## Google Abseil
@@ -285,6 +275,7 @@ target_include_directories(linenoise-ng SYSTEM PUBLIC
 ################################################################################
 ## fmt
 ################################################################################
+
 UpdateModule(${GIT_EXECUTABLE} "fmt" ${CMAKE_CURRENT_SOURCE_DIR} "README.rst")
 add_subdirectory(fmt)
 
@@ -326,20 +317,22 @@ endif()
 ################################################################################
 ## fuerte
 ################################################################################
+
 add_subdirectory(fuerte)
 
-set(V8_INTERNAL_INCLUDE_DIR ${V8_INTERNAL_INCLUDE_DIR} PARENT_SCOPE)
-
+################################################################################
+## taojson
+################################################################################
 
 set(TAOCPP_JSON_BUILD_TESTS    OFF CACHE BOOL "Build taocpp::json test programs"    FORCE)
 set(TAOCPP_JSON_BUILD_EXAMPLES OFF CACHE BOOL "Build taocpp::json example programs" FORCE)
 add_subdirectory(taocpp-json)
 add_subdirectory(json-schema-validation)
 
-
 ################################################################################
 ## tzdata
 ################################################################################
+
 LIST(APPEND TZ_DATA_FILES
   "${CMAKE_CURRENT_SOURCE_DIR}/tzdata/africa"
   "${CMAKE_CURRENT_SOURCE_DIR}/tzdata/antarctica"


### PR DESCRIPTION
### Scope & Purpose

Enable interprocedural optimization (IPO) / link time optimization (LTO) for third party modules.
IPO/LTO was previously disabled for third party modules.
There is potentially no legitimate reason anymore to disable it, except potentially longer build/link times.

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 