### PR TITLE
Automatically remove finished actors

### DIFF
--- a/arangod/Pregel/PregelFeature.cpp
+++ b/arangod/Pregel/PregelFeature.cpp
@@ -660,9 +660,6 @@ std::shared_ptr<Conductor> PregelFeature::conductor(
 }
 
 void PregelFeature::garbageCollectActors() {
-  // garbage collect all finished actors
-  _actorRuntime->garbageCollect();
-
   // clean up map
   _pregelRuns.doUnderLock([this](auto& items) {
     std::erase_if(items, [this](auto& item) {

--- a/lib/Actor/include/Actor/HandlerBase.h
+++ b/lib/Actor/include/Actor/HandlerBase.h
@@ -56,7 +56,7 @@ struct HandlerBase {
                                                 initialMessage);
   }
 
-  auto finish() -> void { runtime->finish(self); }
+  auto finish() -> void { runtime->finishActor(self); }
 
  protected:
   ActorPID const self;

--- a/tests/Actor/CMakeLists.txt
+++ b/tests/Actor/CMakeLists.txt
@@ -1,8 +1,8 @@
 add_library(arango_tests_actor OBJECT
   ActorListTest.cpp
   ActorTest.cpp
+  DistributedRuntimeTest.cpp
   EgressActorTest.cpp
-  RuntimeTest.cpp
   MultiRuntimeTest.cpp
   MPSCQueueTest.cpp)
 target_include_directories(arango_tests_actor PRIVATE


### PR DESCRIPTION
### Scope & Purpose

Previously the runtime required the user to periodically call `garbageCollect` to clean out actors that are finished and idle.
However, the actor itself knows when it is finished and idle, so this change allows the actor to remove itself at that point. This means the `garbageCollect` function is no longer necessary.
