### PR TITLE
remove integration of starter building from CMake

### DIFF
--- a/3rdParty/CMakeLists.txt
+++ b/3rdParty/CMakeLists.txt
@@ -294,35 +294,6 @@ add_subdirectory(fmt)
 
 set(LINK_DIRECTORIES "${LINK_DIRECTORIES}" PARENT_SCOPE)
 
-set(STARTER_SOURCE "${PROJECT_SOURCE_DIR}/3rdParty/arangodb-starter/")
-set(STARTER_BUILD "${CMAKE_CURRENT_BINARY_DIR}/arangodb-starter/")
-set(STARTER_BINARY "${STARTER_BUILD}/arangodb${CMAKE_EXECUTABLE_SUFFIX}")
-if (EXISTS ${STARTER_SOURCE})
-  find_program(GO_COMMAND "go")
-  if (GO_COMMAND)
-    MESSAGE("-- building arangodb starter.")
-    ExternalProject_Add(arangodb_starter_build
-      SOURCE_DIR
-      ${STARTER_SOURCE}
-      CONFIGURE_COMMAND
-      ""
-      BINARY_DIR
-      ${STARTER_BUILD}
-      BUILD_COMMAND
-      $(MAKE) -f "${STARTER_SOURCE}Makefile" "NODOCKER=1" "BUILDDIR=${STARTER_BUILD}" "SCRIPTDIR=${STARTER_SOURCE}" local
-      LOG_INSTALL 1
-      INSTALL_DIR
-      ${CMAKE_INSTALL_BINDIR}
-      INSTALL_COMMAND
-      ${CMAKE_COMMAND} -E copy ${STARTER_BINARY} ${CMAKE_INSTALL_BINDIR}
-      )
-    list(APPEND THIRDPARTY_BIN ${STARTER_BINARY})
-    set(THIRDPARTY_BIN ${THIRDPARTY_BIN} PARENT_SCOPE)
-  else()
-    MESSAGE(WARNING "arangodb starter source present, but no go command to build it found.")
-  endif()
-endif()
-
 ################################################################################
 ## fuerte
 ################################################################################


### PR DESCRIPTION
### Scope & Purpose

Remove some CMake directives that supported building the ArangoDB starter if it was checked out in `3rdParty/arangodb-starter`.
It was confirmed by several people that we are not using this functionality for builds or tests.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 