### PR TITLE
[CINFRA] Update collection API test to expect groupId for Replication2 collections 

### DIFF
--- a/js/client/modules/@arangodb/arango-collection.js
+++ b/js/client/modules/@arangodb/arango-collection.js
@@ -325,6 +325,7 @@ ArangoCollection.prototype.properties = function (properties) {
     'syncByRevision': false,
     'schema' : true,
     'isDisjoint': false,
+    'groupId': false,
   };
 
   let requestResult;

--- a/tests/js/common/shell/shell-collection-api.js
+++ b/tests/js/common/shell/shell-collection-api.js
@@ -1718,23 +1718,32 @@ function CreateCollectionsInOneShardSuite() {
         const value = v === "replicationFactor" ? 3 : 2;
         const res = tryCreate({name: collname, [v]: value});
         try {
-          assertTrue(res.result, `Result: ${JSON.stringify(res)}`);
-          if (isCluster) {
-            if (v === "minReplicationFactor" || v === "writeConcern") {
-              // On Replication1 writeConcern is allowed to differ per Collection.
-              // On Replication2 it is not.
-              validateProperties({...getOneShardShardingValues(), writeConcern: value, minReplicationFactor: value}, collname, 2);
-            } else {
-              validateProperties(getOneShardShardingValues(), collname, 2);
-              validateDeprecationLogEntryWritten();
-            }
+          if (isCluster && db._properties().replicationVersion === "2" && (v === "minReplicationFactor" || v === "writeConcern")) {
+            // For Replication2 the writeConcern is per CollectionGroup. We cannot create a follower with a different one.
+            assertTrue(res.error, `Result: ${JSON.stringify(res)}`);
+            isDisallowed(ERROR_HTTP_BAD_PARAMETER.code, ERROR_BAD_PARAMETER.code, res, {[v]: value});
           } else {
-            // OneShard has no meaning in single server, just assert values are taken
-            if (v === "minReplicationFactor" || v === "writeConcern") {
-              validateProperties({writeConcern: value}, collname, 2);
+            assertTrue(res.result, `Result: ${JSON.stringify(res)}`);
+            if (isCluster) {
+              if (v === "minReplicationFactor" || v === "writeConcern") {
+                // On Replication1 writeConcern is allowed to differ per Collection.
+                validateProperties({
+                  ...getOneShardShardingValues(),
+                  writeConcern: value,
+                  minReplicationFactor: value
+                }, collname, 2);
+              } else {
+                validateProperties(getOneShardShardingValues(), collname, 2);
+                validateDeprecationLogEntryWritten();
+              }
             } else {
-              validateProperties({}, collname, 2);
-              validateDeprecationLogEntryWritten();
+              // OneShard has no meaning in single server, just assert values are taken
+              if (v === "minReplicationFactor" || v === "writeConcern") {
+                validateProperties({writeConcern: value}, collname, 2);
+              } else {
+                validateProperties({}, collname, 2);
+                validateDeprecationLogEntryWritten();
+              }
             }
           }
         } finally {

--- a/tests/js/common/shell/shell-collection-api.js
+++ b/tests/js/common/shell/shell-collection-api.js
@@ -164,7 +164,7 @@ const validateProperties = (overrides, colName, type, keepEnterpriseSimulationAt
   }
   if (isCluster && db._properties().replicationVersion === "2") {
     // Replication 2 always exposes the group id
-    assertTrue(props.hasOwnProperty("groupId"));
+    assertTrue(props.hasOwnProperty("groupId"), `${JSON.stringify(props)} is missing groupId`);
   }
   assertEqual(col.name(), colName);
   assertEqual(col.type(), type);
@@ -233,7 +233,7 @@ const isAllowed = (res, collname, input, expectLogEntry = true) => {
 
 const validatePropertiesDoNotExist = (colName, illegalProperties) => {
   const col = db._collection(colName);
-  const props = col.properties(true);
+  const props = col.properties();
   for (const key of illegalProperties) {
     assertFalse(props.hasOwnProperty(key), `Property ${key} should not exist`);
   }

--- a/tests/js/common/shell/shell-collection-api.js
+++ b/tests/js/common/shell/shell-collection-api.js
@@ -162,6 +162,10 @@ const validateProperties = (overrides, colName, type, keepEnterpriseSimulationAt
     // This is a local property only exposed on dbServer and singleServer
     assertTrue(props.hasOwnProperty("objectId"));
   }
+  if (isCluster && db._properties().replicationVersion === "2") {
+    // Replication 2 always exposes the group id
+    assertTrue(props.hasOwnProperty("groupId"));
+  }
   assertEqual(col.name(), colName);
   assertEqual(col.type(), type);
   const expectedProps = {...defaultProps, ...overrides};
@@ -185,6 +189,10 @@ const validateProperties = (overrides, colName, type, keepEnterpriseSimulationAt
     // The objectId is generated, so we cannot compare equality, we should make
     // sure it is always there.
     expectedKeys.push("objectId");
+  }
+  if (isCluster && db._properties().replicationVersion === "2" && !overrides.hasOwnProperty("groupId")) {
+    // Replication 2 always exposes the group id
+    expectedKeys.push("groupId");
   }
   if (isServer && isCluster && overrides.isSmart && type === 3) {
     // Special attribute for smartEdgeColelctions


### PR DESCRIPTION
### Scope & Purpose

*This PR contains two changes:
1) The properties wrapper on Client side now passes the "groupId" as returned from API into arangosh. It does not allow to pass in the value to try and change it.
2) Adapt the api-collection test to expect to always find a "groupdId" on Replication2 collections. It does not do specific tests on correctness of those Ids yet.
*

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [x] Tests
  - [x] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

