### PR TITLE
allow 15 minutes of silence when running testing.js

### DIFF
--- a/scripts/test/testing_runner.py
+++ b/scripts/test/testing_runner.py
@@ -71,7 +71,7 @@ def testing_runner(testing_instance, this, arangosh):
         ret = arangosh.run_testing(
             this.suite,
             this.args,
-            999999999,
+            15*60, # 15 Minutes screen idle before timeout
             this.base_logdir,
             this.log_file,
             this.name_enum,


### PR DESCRIPTION
Limit the CI idle timeout to 15 minutes of silence, so we're quicker than circleci to detect & abort this. 