### PR TITLE
[BTS-1686] Get rid of data race when killing aql query

### DIFF
--- a/arangod/Aql/Query.h
+++ b/arangod/Aql/Query.h
@@ -371,7 +371,7 @@ class Query : public QueryContext, public std::enable_shared_from_this<Query> {
 
   /// @brief return the final query result status code (0 = no error,
   /// > 0 = error, one of TRI_ERROR_...)
-  std::optional<ErrorCode> _resultCode;
+  std::atomic<std::optional<ErrorCode>> _resultCode;
 
   /// @brief user that started the query
   std::string _user;

--- a/arangod/Aql/Query.h
+++ b/arangod/Aql/Query.h
@@ -371,7 +371,7 @@ class Query : public QueryContext, public std::enable_shared_from_this<Query> {
 
   /// @brief return the final query result status code (0 = no error,
   /// > 0 = error, one of TRI_ERROR_...)
-  std::atomic<std::optional<ErrorCode>> _resultCode;
+  std::atomic<std::optional<ErrorCode>> _resultCode{std::nullopt};
 
   /// @brief user that started the query
   std::string _user;


### PR DESCRIPTION
Data race:
When one of the participating DBServers fails before an AQL query is executed on it, the query is killed on all DBServers and the coordinator (this happens inside `ExecutionEngine::buildEngines()`). The kill command starts a new thread and calls `Query::cleanupPlanAndEngine(...)`. Another thread on the coordinator is already working on the Query and when it also calls `Query::cleanupPlanAndEngine(...)` there is a data race on the `Query` class members `_resultCode` and `_endTime` (e.g. the TSAN noticed this data race because the coordinator called `Query::executeV8(...)`, ran into an exception there and then called `Query::cleanupPlanAndEngine(...)`). 
(Nothing worse is happening because the atomic `Query` member `_shutdownState` guards the following execution of `Query::cleanupTrxAndEngines`.

Fix:
`Query::_resultCode` is now an atomic and `_endTime` and `_resultCode` are only updated if `_resultCode` is empty. The race condition is still there - we don't know which thread wins and sets both `_endTime` and `_resultCode` but for a killed query this is not that relevant.

Reproduced race via:
```
diff --git a/arangod/Aql/ExecutionEngine.cpp b/arangod/Aql/ExecutionEngine.cpp
index eae54f8084b..4b51df35a7a 100644
--- a/arangod/Aql/ExecutionEngine.cpp
+++ b/arangod/Aql/ExecutionEngine.cpp
@@ -22,7 +22,9 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #include "ExecutionEngine.h"
 
+#include "Network/NetworkFeature.h"
 #include "ApplicationFeatures/ApplicationServer.h"
 #include "Aql/BlocksWithClients.h"
 #include "Aql/Collection.h"

@@ -571,8 +574,12 @@ struct DistributedQueryInstanciator final
         std::string comment = std::string("AQL query from coordinator ") +
                               ServerState::instance()->getId();
 
+        auto stillInThread = std::make_shared<bool>(true);
+
         std::function<void(void)> f = [srvr = server, id = _query.id(),
-                                       vn = _query.vocbase().name(), &df]() {
+                                       vn = _query.vocbase().name(), &df,
+                                       stillInThread]() {
+          TRI_ASSERT(!*stillInThread);
           LOG_TOPIC("d2554", INFO, Logger::QUERIES)
               << "killing query " << id << " because participating DB server "
               << srvr << " is unavailable";
@@ -587,6 +594,17 @@ struct DistributedQueryInstanciator final
 
         engine->rebootTrackers().emplace_back(ci.rebootTracker().callMeOnChange(
             {server, rebootId}, std::move(f), std::move(comment)));
+
+        NetworkFeature& nf =
+            _query.vocbase().server().getFeature<NetworkFeature>();
+        auto pool = nf.pool();
+
+        std::ignore = arangodb::network::sendRequest(pool, "server:" + server,
+                                                     fuerte::RestVerb::Delete,
+                                                     "_admin/shutdown")
+                          .get();
+        std::this_thread::sleep_for(std::chrono::seconds(30));
+        *stillInThread = false;
       }
     }
```
This will result in a failed coordinator due to the added TRI_ASSERT.