### PR TITLE
remove version check at arangosh startup

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,8 +1,8 @@
 v3.10.12 (XXXX-XX-XX)
 ---------------------
 
-* Remove version check on startup of arangosh. This can speed up the startup
-  of the arangosh considerably because it won't do a network request to
+* Remove version check on startup of arangosh. This can speed up the startup of
+  the arangosh considerably because it won't do a network request to
   www.arangodb.com.
 
 * MDS-1164: Added Publisher and Company to the Windows binaries.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 v3.10.12 (XXXX-XX-XX)
 ---------------------
 
+* Remove version check on startup of arangosh. This can speed up the startup
+  of the arangosh considerably because it won't do a network request to
+  www.arangodb.com.
+
 * MDS-1164: Added Publisher and Company to the Windows binaries.
 
 * Fixed a race in controlled leader change which could lead to a situation in

--- a/js/common/modules/@arangodb/common.js
+++ b/js/common/modules/@arangodb/common.js
@@ -573,10 +573,10 @@ exports.enterpriseLicenseVisibility = function() {
 // //////////////////////////////////////////////////////////////////////////////
 
 exports.checkAvailableVersions = function() {
-  var version = internal.version;
-  var isServer = require('@arangodb').isServer;
-  var console = require('console');
-  var log;
+  let version = internal.version;
+  let isServer = require('@arangodb').isServer;
+  let console = require('console');
+  let log;
 
   if (isServer) {
     log = console.info;
@@ -584,115 +584,16 @@ exports.checkAvailableVersions = function() {
     log = internal.print;
   }
 
-  if(internal.isEnterprise()) {
+  if (internal.isEnterprise()) {
     exports.enterpriseLicenseVisibility();
   }
 
-  let isStable = true;
-  if (version.match(/beta|alpha|preview|milestone|devel/) !== null) {
-    isStable = false;
-    if (internal.quiet !== true) {
-      log(
-        "You are using a milestone/alpha/beta/preview version ('" +
-          version +
-          "') of ArangoDB"
-      );
-    }
-  }
-
-  if (isServer && internal.isEnterprise()) {
-    // don't check for version updates in arangod in Enterprise Edition
-    return;
-  }
-  if (!isServer && internal.isEnterprise() && isStable) {
-    // don't check for version updates in arangosh in stable Enterprise Edition
-    return;
-  }
-
-  try {
-    var hash = "A" + Math.random();
-    var engine = "unknown";
-    var platform = internal.platform;
-    var license = (internal.isEnterprise() ? "enterprise" : "community");
-
-    if (isServer) {
-      engine = internal.db._engine().name;
-      var role = global.ArangoServerState.role();
-
-      if (role === "COORDINATOR") {
-        try {
-          var c = ArangoClusterInfo.getCoordinators().length.toString(16).toUpperCase();
-          var d = ArangoClusterInfo.getDBServers().length.toString(16).toUpperCase();
-        } catch (err) {
-          hash = "1-FFFF-0001-arangod";
-        }
-        hash = "1-" + c + "-" + d + "-" + global.ArangoServerState.id();
-      } else if (role === "PRIMARY") {
-        hash = "1-FFFF-0002-arangod";
-      } else if (role === "AGENT") {
-        hash = "1-FFFF-0003-arangod";
-      } else if (role === "SINGLE") {
-        hash = "1-FFFF-0004-arangod";
-      } else {
-        hash = "1-FFFF-0005-arangod";
-      }
-
-      hash = internal.base64Encode(hash);
-    } else {
-      try {
-        var result = arango.GET('/_admin/status?overview=true');
-        version = result.version;
-        hash = result.hash;
-        engine = result.engine;
-        platform = result.platform;
-        license = result.license;
-      } catch (err) {
-        if (console && console.debug) {
-          console.debug('cannot check for newer version: ', err.stack);
-        }
-      }
-    }
-
-    var u =
-      'https://www.arangodb.com/versions.php?'
-        + 'version=' + encodeURIComponent(version)
-        + '&platform=' + encodeURIComponent(platform)
-        + '&engine=' + encodeURIComponent(engine)
-        + '&license=' + encodeURIComponent(license)
-        + '&source=' + (isServer ? "arangod" : "arangosh")
-        + '&hash=' + encodeURIComponent(hash);
-    var d2 = internal.download(u, '', {timeout: 3});
-    var v = JSON.parse(d2.body);
-
-    if (!isServer && internal.quiet !== true) {
-      if (v.hasOwnProperty('bugfix')) {
-        log(
-          "Please note that a new bugfix version '" +
-            v.bugfix.version +
-            "' is available"
-        );
-      }
-
-      if (v.hasOwnProperty('minor')) {
-        log(
-          "Please note that a new minor version '" +
-            v.minor.version +
-            "' is available"
-        );
-      }
-
-      if (v.hasOwnProperty('major')) {
-        log(
-          "Please note that a new major version '" +
-            v.major.version +
-            "' is available"
-        );
-      }
-    }
-  } catch (err) {
-    if (console && console.debug) {
-      console.debug('cannot check for newer version: ', err.stack);
-    }
+  if (version.match(/beta|alpha|preview|milestone|devel/) !== null && internal.quiet !== true) {
+    log(
+      "You are using a milestone/alpha/beta/preview version ('" +
+        version +
+        "') of ArangoDB"
+    );
   }
 };
 


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/20153

Remove version check at arangosh startup.
This can speed up the startup of the arangosh considerably, as it won't make a network request to [www.arangodb.com](http://www.arangodb.com/) anymore.

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.11: https://github.com/arangodb/arangodb/pull/20154
  - [x] Backport for 3.10: this PR

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 