### PR TITLE
Implement actor monitoring

### DIFF
--- a/arangod/Pregel/Conductor/Handler.h
+++ b/arangod/Pregel/Conductor/Handler.h
@@ -159,7 +159,7 @@ struct ConductorHandler : actor::HandlerBase<Runtime, ConductorState> {
         this->state->executionState->receive(this->sender, start);
     if (stateChange.has_value()) {
       changeState(std::move(stateChange.value()));
-      this->finish(actor::Error::kNoError);
+      this->finish(actor::ExitReason::kFinished);
       this->template dispatch<pregel::message::SpawnMessages>(
           this->state->spawnActor, pregel::message::SpawnCleanup{});
       this->template dispatch<pregel::message::StatusMessages>(

--- a/arangod/Pregel/Conductor/Handler.h
+++ b/arangod/Pregel/Conductor/Handler.h
@@ -159,7 +159,7 @@ struct ConductorHandler : actor::HandlerBase<Runtime, ConductorState> {
         this->state->executionState->receive(this->sender, start);
     if (stateChange.has_value()) {
       changeState(std::move(stateChange.value()));
-      this->finish();
+      this->finish(actor::Error::kNoError);
       this->template dispatch<pregel::message::SpawnMessages>(
           this->state->spawnActor, pregel::message::SpawnCleanup{});
       this->template dispatch<pregel::message::StatusMessages>(

--- a/arangod/Pregel/MetricsActor.h
+++ b/arangod/Pregel/MetricsActor.h
@@ -94,7 +94,7 @@ struct MetricsHandler : actor::HandlerBase<Runtime, MetricsState> {
         break;
     }
 
-    this->finish();
+    this->finish(actor::Error::kNoError);
 
     return std::move(this->state);
   }

--- a/arangod/Pregel/MetricsActor.h
+++ b/arangod/Pregel/MetricsActor.h
@@ -94,7 +94,7 @@ struct MetricsHandler : actor::HandlerBase<Runtime, MetricsState> {
         break;
     }
 
-    this->finish(actor::Error::kNoError);
+    this->finish(actor::ExitReason::kFinished);
 
     return std::move(this->state);
   }

--- a/arangod/Pregel/ResultActor.h
+++ b/arangod/Pregel/ResultActor.h
@@ -135,7 +135,7 @@ struct ResultHandler : actor::HandlerBase<Runtime, ResultState> {
   auto operator()(message::CleanupResultWhenExpired msg)
       -> std::unique_ptr<ResultState> {
     if (this->state->expiration <= std::chrono::system_clock::now()) {
-      this->finish();
+      this->finish(actor::Error::kNoError);
     } else {
       // send this message every 20 seconds
       std::chrono::seconds offset = std::chrono::seconds(20);
@@ -146,7 +146,7 @@ struct ResultHandler : actor::HandlerBase<Runtime, ResultState> {
   }
 
   auto operator()(message::CleanupResults msg) -> std::unique_ptr<ResultState> {
-    this->finish();
+    this->finish(actor::Error::kNoError);
     for (auto const& actor : this->state->otherResultActors) {
       this->template dispatch<pregel::message::ResultMessages>(
           actor, pregel::message::CleanupResults{});

--- a/arangod/Pregel/ResultActor.h
+++ b/arangod/Pregel/ResultActor.h
@@ -135,7 +135,7 @@ struct ResultHandler : actor::HandlerBase<Runtime, ResultState> {
   auto operator()(message::CleanupResultWhenExpired msg)
       -> std::unique_ptr<ResultState> {
     if (this->state->expiration <= std::chrono::system_clock::now()) {
-      this->finish(actor::Error::kNoError);
+      this->finish(actor::ExitReason::kFinished);
     } else {
       // send this message every 20 seconds
       std::chrono::seconds offset = std::chrono::seconds(20);
@@ -146,7 +146,7 @@ struct ResultHandler : actor::HandlerBase<Runtime, ResultState> {
   }
 
   auto operator()(message::CleanupResults msg) -> std::unique_ptr<ResultState> {
-    this->finish(actor::Error::kNoError);
+    this->finish(actor::ExitReason::kFinished);
     for (auto const& actor : this->state->otherResultActors) {
       this->template dispatch<pregel::message::ResultMessages>(
           actor, pregel::message::CleanupResults{});

--- a/arangod/Pregel/SpawnActor.h
+++ b/arangod/Pregel/SpawnActor.h
@@ -203,7 +203,7 @@ struct SpawnHandler : actor::HandlerBase<Runtime, SpawnState> {
   }
 
   auto operator()(message::SpawnCleanup msg) -> std::unique_ptr<SpawnState> {
-    this->finish();
+    this->finish(actor::Error::kNoError);
     return std::move(this->state);
   }
 

--- a/arangod/Pregel/SpawnActor.h
+++ b/arangod/Pregel/SpawnActor.h
@@ -203,7 +203,7 @@ struct SpawnHandler : actor::HandlerBase<Runtime, SpawnState> {
   }
 
   auto operator()(message::SpawnCleanup msg) -> std::unique_ptr<SpawnState> {
-    this->finish(actor::Error::kNoError);
+    this->finish(actor::ExitReason::kFinished);
     return std::move(this->state);
   }
 

--- a/arangod/Pregel/StatusActor.h
+++ b/arangod/Pregel/StatusActor.h
@@ -497,7 +497,7 @@ struct StatusHandler : actor::HandlerBase<Runtime, StatusState> {
   }
 
   auto operator()(message::Cleanup& msg) -> std::unique_ptr<StatusState> {
-    this->finish();
+    this->finish(actor::Error::kNoError);
     return std::move(this->state);
   }
 

--- a/arangod/Pregel/StatusActor.h
+++ b/arangod/Pregel/StatusActor.h
@@ -497,7 +497,7 @@ struct StatusHandler : actor::HandlerBase<Runtime, StatusState> {
   }
 
   auto operator()(message::Cleanup& msg) -> std::unique_ptr<StatusState> {
-    this->finish(actor::Error::kNoError);
+    this->finish(actor::ExitReason::kFinished);
     return std::move(this->state);
   }
 

--- a/arangod/Pregel/Worker/Handler.h
+++ b/arangod/Pregel/Worker/Handler.h
@@ -157,7 +157,7 @@ struct WorkerHandler : actor::HandlerBase<Runtime, WorkerState<V, E, M>> {
 
   auto operator()([[maybe_unused]] message::Cleanup message)
       -> std::unique_ptr<WorkerState<V, E, M>> {
-    this->finish();
+    this->finish(actor::Error::kNoError);
 
     LOG_TOPIC("664f5", INFO, Logger::PREGEL)
         << fmt::format("Worker Actor {} is cleaned", this->self);

--- a/arangod/Pregel/Worker/Handler.h
+++ b/arangod/Pregel/Worker/Handler.h
@@ -157,7 +157,7 @@ struct WorkerHandler : actor::HandlerBase<Runtime, WorkerState<V, E, M>> {
 
   auto operator()([[maybe_unused]] message::Cleanup message)
       -> std::unique_ptr<WorkerState<V, E, M>> {
-    this->finish(actor::Error::kNoError);
+    this->finish(actor::ExitReason::kFinished);
 
     LOG_TOPIC("664f5", INFO, Logger::PREGEL)
         << fmt::format("Worker Actor {} is cleaned", this->self);

--- a/lib/Actor/include/Actor/Actor.h
+++ b/lib/Actor/include/Actor/Actor.h
@@ -133,10 +133,10 @@ struct Actor : ActorBase<typename Runtime::ActorPID> {
   }
 
   auto finish(ExitReason reason) -> void override {
-    finishReason = reason;
+    exitReason = reason;
     auto s = status.fetch_or(Status::kFinished);
     if (s & Status::kIdle) {
-      runtime->stopActor(pid, finishReason);
+      runtime->stopActor(pid, exitReason);
     }
   }
 
@@ -201,7 +201,7 @@ struct Actor : ActorBase<typename Runtime::ActorPID> {
 
     auto s = status.fetch_or(Status::kIdle);
     if (s & Status::kFinished) {
-      runtime->stopActor(pid, finishReason);
+      runtime->stopActor(pid, exitReason);
       return;
     }
 
@@ -213,7 +213,7 @@ struct Actor : ActorBase<typename Runtime::ActorPID> {
         kick();
       }
     } else if (status.load() & Status::kFinished) {
-      runtime->stopActor(pid, finishReason);
+      runtime->stopActor(pid, exitReason);
     }
   }
 
@@ -255,7 +255,7 @@ struct Actor : ActorBase<typename Runtime::ActorPID> {
     static constexpr std::uint8_t kFinished = 2;
   };
   std::atomic<std::uint8_t> status{Status::kIdle};
-  ExitReason finishReason = ExitReason::kFinished;
+  ExitReason exitReason = ExitReason::kFinished;
   arangodb::actor::MPSCQueue<InternalMessage> inbox;
   std::shared_ptr<Runtime> runtime;
   // tunable parameter: maximal number of processed messages per work() call

--- a/lib/Actor/include/Actor/Actor.h
+++ b/lib/Actor/include/Actor/Actor.h
@@ -132,7 +132,7 @@ struct Actor : ActorBase<typename Runtime::ActorPID> {
     }
   }
 
-  auto finish(Error reason) -> void override {
+  auto finish(ExitReason reason) -> void override {
     finishReason = reason;
     auto s = status.fetch_or(Status::kFinished);
     if (s & Status::kIdle) {
@@ -255,7 +255,7 @@ struct Actor : ActorBase<typename Runtime::ActorPID> {
     static constexpr std::uint8_t kFinished = 2;
   };
   std::atomic<std::uint8_t> status{Status::kIdle};
-  Error finishReason = Error::kNoError;
+  ExitReason finishReason = ExitReason::kFinished;
   arangodb::actor::MPSCQueue<InternalMessage> inbox;
   std::shared_ptr<Runtime> runtime;
   // tunable parameter: maximal number of processed messages per work() call

--- a/lib/Actor/include/Actor/ActorBase.h
+++ b/lib/Actor/include/Actor/ActorBase.h
@@ -25,7 +25,7 @@
 #pragma once
 
 #include "Actor/DistributedActorPID.h"
-#include "Actor/Error.h"
+#include "Actor/ExitReason.h"
 #include "Actor/IWorkable.h"
 #include "Actor/Message.h"
 
@@ -39,7 +39,7 @@ struct ActorBase : IWorkable {
       -> void = 0;
   virtual auto typeName() -> std::string_view = 0;
   virtual auto serialize() -> velocypack::SharedSlice = 0;
-  virtual auto finish(Error reason) -> void = 0;
+  virtual auto finish(ExitReason reason) -> void = 0;
   virtual auto isFinishedAndIdle() -> bool = 0;
   virtual auto isIdle() -> bool = 0;
 };

--- a/lib/Actor/include/Actor/ActorID.h
+++ b/lib/Actor/include/Actor/ActorID.h
@@ -35,6 +35,11 @@ struct ActorID {
   auto operator<=>(ActorID const& other) const = default;
 };
 
+inline std::ostream& operator<<(std::ostream& o, ActorID const& id) {
+  o << id.id;
+  return o;
+}
+
 template<typename Inspector>
 auto inspect(Inspector& f, ActorID& x) {
   if constexpr (Inspector::isLoading) {

--- a/lib/Actor/include/Actor/ActorID.h
+++ b/lib/Actor/include/Actor/ActorID.h
@@ -36,7 +36,7 @@ struct ActorID {
 };
 
 inline std::ostream& operator<<(std::ostream& o, ActorID const& id) {
-  o << id.id;
+  o << "ActorID(" << id.id << ")";
   return o;
 }
 

--- a/lib/Actor/include/Actor/ActorList.h
+++ b/lib/Actor/include/Actor/ActorList.h
@@ -24,6 +24,9 @@
 
 #pragma once
 
+#include <initializer_list>
+#include <memory>
+#include <vector>
 #include "Actor/ActorBase.h"
 #include "Actor/ActorID.h"
 #include "Basics/Guarded.h"
@@ -38,18 +41,28 @@ concept Predicate =
 
 template<typename ActorPID>
 struct ActorList {
- private:
-  struct ActorMap
-      : std::unordered_map<ActorID, std::shared_ptr<ActorBase<ActorPID>>> {};
-  Guarded<ActorMap> actors;
-  struct ActorInfo {
-    ActorID id;
-    std::string_view type;
+  struct Entry {
+    explicit Entry(std::shared_ptr<ActorBase<ActorPID>>&& actor)
+        : actor(std::move(actor)) {}
+
+    std::shared_ptr<ActorBase<ActorPID>> actor;
+    std::vector<ActorID> monitors;
+
+    template<class Inspector>
+    friend inline auto inspect(Inspector& f, Entry& x) {
+      return f.object(x).fields(f.field("type", x.actor->typeName()),
+                                f.field("monitors", x.monitors));
+    }
   };
 
- public:
-  ActorList(ActorMap map) : actors{std::move(map)} {}
   ActorList() = default;
+  ActorList(std::initializer_list<
+            std::pair<ActorID, std::shared_ptr<ActorBase<ActorPID>>>>
+                list) {
+    for (auto& [id, actor] : list) {
+      add(id, std::move(actor));
+    }
+  }
 
   auto contains(ActorID id) const -> bool {
     return actors.doUnderLock(
@@ -65,26 +78,35 @@ struct ActorList {
           if (a == std::end(map)) {
             return std::nullopt;
           }
-          auto& [_, actor] = *a;
-          return actor;
+          auto& [_, entry] = *a;
+          return entry.actor;
         });
   }
 
   auto add(ActorID id, std::shared_ptr<ActorBase<ActorPID>> actor) -> void {
-    actors.doUnderLock(
-        [&id, &actor](ActorMap& map) { map.emplace(id, std::move(actor)); });
+    actors.doUnderLock([&id, &actor](ActorMap& map) {
+      map.emplace(id, Entry{std::move(actor)});
+    });
   }
 
-  auto remove(ActorID id) -> void {
-    actors.doUnderLock([id](ActorMap& map) { map.erase(id); });
+  auto remove(ActorID id) -> std::optional<Entry> {
+    return actors.doUnderLock([id](ActorMap& map) -> std::optional<Entry> {
+      auto it = map.find(id);
+      if (it != map.end()) {
+        std::optional<Entry> result{std::move(it->second)};
+        map.erase(it);
+        return result;
+      }
+      return {};
+    });
   }
 
   template<Predicate<ActorPID> F>
   auto removeIf(F&& isDeletable) -> void {
     actors.doUnderLock([&isDeletable](ActorMap& map) {
       std::erase_if(map, [&isDeletable](const auto& item) {
-        auto& [_, actor] = item;
-        return isDeletable(actor);
+        auto& [_, entry] = item;
+        return isDeletable(entry.actor);
       });
     });
   }
@@ -95,8 +117,8 @@ struct ActorList {
   }
   auto apply(F&& fn) -> void {
     actors.doUnderLock([&fn](ActorMap& map) {
-      for (auto&& [_, actor] : map) {
-        fn(actor);
+      for (auto&& [_, entry] : map) {
+        fn(entry.actor);
       }
     });
   }
@@ -104,8 +126,8 @@ struct ActorList {
   template<Predicate<ActorPID> F>
   auto checkAll(F&& check) const -> bool {
     return actors.doUnderLock([&check](ActorMap const& map) {
-      for (auto const& [_, actor] : map) {
-        if (not check(actor)) {
+      for (auto const& [_, entry] : map) {
+        if (not check(entry.actor)) {
           return false;
         }
       }
@@ -128,6 +150,28 @@ struct ActorList {
     return actors.doUnderLock([](ActorMap const& map) { return map.size(); });
   }
 
+  auto monitor(ActorID monitoringActor, ActorID monitoredActor) -> bool {
+    return actors.doUnderLock(
+        [&monitoringActor, &monitoredActor](ActorMap& map) {
+          auto it = map.find(monitoredActor);
+          if (it == std::end(map)) {
+            return false;
+          }
+          it->second.monitors.emplace_back(monitoringActor);
+          return true;
+        });
+  }
+
+  auto getMonitors(ActorID actor) -> std::vector<ActorID> {
+    return actors.doUnderLock([&](auto& map) -> std::vector<ActorID> {
+      auto it = map.find(actor);
+      if (it != map.end()) {
+        return it->second.monitors;
+      }
+      return {};
+    });
+  }
+
   template<typename Inspector>
   friend inline auto inspect(Inspector& f, ActorList const& x) {
     static_assert(not Inspector::isLoading);
@@ -135,24 +179,9 @@ struct ActorList {
         [&f](typename ActorList::ActorMap const& map) { return f.apply(map); });
   }
 
-  template<typename Inspector>
-  friend inline auto inspect(Inspector& f, ActorList::ActorInfo& x) {
-    return f.object(x).fields(f.field("id", x.id), f.field("type", x.type));
-  }
-  template<typename Inspector>
-  friend inline auto inspect(Inspector& f, ActorList::ActorMap const& x) {
-    if constexpr (Inspector::isLoading) {
-      return inspection::Status{};
-    } else {
-      auto actorInfos = std::vector<ActorList::ActorInfo>{};
-      actorInfos.reserve(x.size());
-      for (auto const& [id, actor] : x) {
-        actorInfos.emplace_back(
-            ActorList::ActorInfo{.id = id, .type = actor->typeName()});
-      }
-      return f.apply(actorInfos);
-    }
-  }
+ private:
+  struct ActorMap : std::unordered_map<ActorID, Entry> {};
+  Guarded<ActorMap> actors;
 };
 
 };  // namespace arangodb::actor

--- a/lib/Actor/include/Actor/ActorList.h
+++ b/lib/Actor/include/Actor/ActorList.h
@@ -101,16 +101,6 @@ struct ActorList {
     });
   }
 
-  template<Predicate<ActorPID> F>
-  auto removeIf(F&& isDeletable) -> void {
-    actors.doUnderLock([&isDeletable](ActorMap& map) {
-      std::erase_if(map, [&isDeletable](const auto& item) {
-        auto& [_, entry] = item;
-        return isDeletable(entry.actor);
-      });
-    });
-  }
-
   template<typename F>
   requires requires(F fn, std::shared_ptr<ActorBase<ActorPID>>& actor) {
     {fn(actor)};

--- a/lib/Actor/include/Actor/Assert.h
+++ b/lib/Actor/include/Actor/Assert.h
@@ -25,7 +25,7 @@
 
 #ifdef STANDALONE
 #define ACTOR_ASSERT(expr) \
-  if (not expr) {          \
+  if (not(expr)) {         \
     std::abort();          \
   }
 #else

--- a/lib/Actor/include/Actor/Error.h
+++ b/lib/Actor/include/Actor/Error.h
@@ -1,4 +1,4 @@
-////////////////////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////////////
 /// DISCLAIMER
 ///
 /// Copyright 2014-2022 ArangoDB GmbH, Cologne, Germany
@@ -18,30 +18,23 @@
 ///
 /// Copyright holder is ArangoDB GmbH, Cologne, Germany
 ///
-/// @author Markus Pfeiffer
-/// @author Julia Volmer
+/// @author Manuel Pöter
 ////////////////////////////////////////////////////////////////////////////////
 
 #pragma once
 
-#include "Actor/DistributedActorPID.h"
-#include "Actor/Error.h"
-#include "Actor/IWorkable.h"
-#include "Actor/Message.h"
-
 namespace arangodb::actor {
 
-template<typename ActorPID>
-struct ActorBase : IWorkable {
-  virtual ~ActorBase() = default;
-  virtual auto process(ActorPID sender, MessagePayloadBase& msg) -> void = 0;
-  virtual auto process(ActorPID sender, velocypack::SharedSlice msg)
-      -> void = 0;
-  virtual auto typeName() -> std::string_view = 0;
-  virtual auto serialize() -> velocypack::SharedSlice = 0;
-  virtual auto finish(Error reason) -> void = 0;
-  virtual auto isFinishedAndIdle() -> bool = 0;
-  virtual auto isIdle() -> bool = 0;
+enum class Error {
+  kNoError,       //
+  kUnknownActor,  //
+  kShutdown
 };
+
+template<typename Inspector>
+auto inspect(Inspector& f, Error& x) {
+  return f.enumeration(x).values(Error::kNoError, "NoError",  //
+                                 Error::kShutdown, "Shutdown");
+}
 
 }  // namespace arangodb::actor

--- a/lib/Actor/include/Actor/ExitReason.h
+++ b/lib/Actor/include/Actor/ExitReason.h
@@ -25,16 +25,17 @@
 
 namespace arangodb::actor {
 
-enum class Error {
-  kNoError,       //
-  kUnknownActor,  //
+enum class ExitReason {
+  kFinished,  //
+  kUnknown,   //
   kShutdown
 };
 
 template<typename Inspector>
-auto inspect(Inspector& f, Error& x) {
-  return f.enumeration(x).values(Error::kNoError, "NoError",  //
-                                 Error::kShutdown, "Shutdown");
+auto inspect(Inspector& f, ExitReason& x) {
+  return f.enumeration(x).values(ExitReason::kFinished, "Finished",  //
+                                 ExitReason::kUnknown, "Unknown",    //
+                                 ExitReason::kShutdown, "Shutdown");
 }
 
 }  // namespace arangodb::actor

--- a/lib/Actor/include/Actor/HandlerBase.h
+++ b/lib/Actor/include/Actor/HandlerBase.h
@@ -56,7 +56,7 @@ struct HandlerBase {
                                                 initialMessage);
   }
 
-  auto finish() -> void { runtime->finishActor(self); }
+  auto finish(Error reason) -> void { runtime->finishActor(self, reason); }
 
  protected:
   ActorPID const self;

--- a/lib/Actor/include/Actor/HandlerBase.h
+++ b/lib/Actor/include/Actor/HandlerBase.h
@@ -56,7 +56,7 @@ struct HandlerBase {
                                                 initialMessage);
   }
 
-  auto finish(Error reason) -> void { runtime->finishActor(self, reason); }
+  auto finish(ExitReason reason) -> void { runtime->finishActor(self, reason); }
 
  protected:
   ActorPID const self;

--- a/lib/Actor/include/Actor/Message.h
+++ b/lib/Actor/include/Actor/Message.h
@@ -30,7 +30,7 @@
 
 #include <velocypack/Builder.h>
 
-#include "Actor/Error.h"
+#include "Actor/ExitReason.h"
 #include "Actor/MPSCQueue.h"
 
 namespace arangodb::actor {
@@ -57,7 +57,7 @@ namespace message {
 template<typename PID>
 struct ActorDown {
   PID actor;
-  Error reason;
+  ExitReason reason;
 
   template<typename Inspector>
   friend inline auto inspect(Inspector& f, ActorDown& x) {

--- a/lib/Actor/include/Actor/Message.h
+++ b/lib/Actor/include/Actor/Message.h
@@ -25,6 +25,7 @@
 
 #include <Inspection/VPackWithErrorT.h>
 #include <memory>
+#include <type_traits>
 #include <variant>
 
 #include <velocypack/Builder.h>
@@ -43,33 +44,46 @@ struct MessagePayload : MessagePayloadBase {
   MessagePayload(Args&&... args) : payload(std::forward<Args>(args)...) {}
 
   Payload payload;
+
+  template<typename Inspector>
+  friend inline auto inspect(Inspector& f, MessagePayload& x) {
+    return f.object(x).fields(f.field("payload", x.payload));
+  }
 };
-template<typename Payload, typename Inspector>
-auto inspect(Inspector& f, MessagePayload<Payload>& x) {
-  return f.object(x).fields(f.field("payload", x.payload));
-}
 
 namespace message {
+
+template<typename PID>
+struct ActorDown {
+  PID actor;
+
+  template<typename Inspector>
+  friend inline auto inspect(Inspector& f, ActorDown& x) {
+    return f.object(x).fields(f.field("actor", x.actor));
+  }
+};
 
 template<typename PID>
 struct UnknownMessage {
   PID sender;
   PID receiver;
+
+  template<typename Inspector>
+  friend inline auto inspect(Inspector& f, UnknownMessage& x) {
+    return f.object(x).fields(f.field("sender", x.sender),
+                              f.field("receiver", x.receiver));
+  }
 };
-template<typename Inspector, typename PID>
-auto inspect(Inspector& f, UnknownMessage<PID>& x) {
-  return f.object(x).fields(f.field("sender", x.sender),
-                            f.field("receiver", x.receiver));
-}
 
 template<typename PID>
 struct ActorNotFound {
   PID actor;
+
+  template<typename Inspector>
+  friend inline auto inspect(Inspector& f, ActorNotFound& x) {
+    return f.object(x).fields(f.field("actor", x.actor));
+  }
 };
-template<typename Inspector, typename PID>
-auto inspect(Inspector& f, ActorNotFound<PID>& x) {
-  return f.object(x).fields(f.field("actor", x.actor));
-}
 
 struct NetworkError {
   std::string message;
@@ -84,20 +98,21 @@ struct ActorError
     : std::variant<UnknownMessage<PID>, ActorNotFound<PID>, NetworkError> {
   using std::variant<UnknownMessage<PID>, ActorNotFound<PID>,
                      NetworkError>::variant;
-};
-template<typename Inspector, typename PID>
-auto inspect(Inspector& f, ActorError<PID>& x) {
-  return f.variant(x).unqualified().alternatives(
-      arangodb::inspection::type<UnknownMessage<PID>>("UnknownMessage"),
-      arangodb::inspection::type<ActorNotFound<PID>>("ActorNotFound"),
-      arangodb::inspection::type<NetworkError>("NetworkError"));
-}
 
-template<typename T, typename U>
+  template<typename Inspector>
+  friend inline auto inspect(Inspector& f, ActorError& x) {
+    return f.variant(x).unqualified().alternatives(
+        arangodb::inspection::type<UnknownMessage<PID>>("UnknownMessage"),
+        arangodb::inspection::type<ActorNotFound<PID>>("ActorNotFound"),
+        arangodb::inspection::type<NetworkError>("NetworkError"));
+  }
+};
+
+template<typename T, typename U, typename... Msgs>
 struct concatenator;
-template<typename... Args0, typename... Args1>
-struct concatenator<std::variant<Args0...>, std::variant<Args1...>> {
-  std::variant<Args0..., Args1...> item;
+template<typename... Args0, typename... Args1, typename... Msgs>
+struct concatenator<std::variant<Args0...>, std::variant<Args1...>, Msgs...> {
+  std::variant<Args0..., Args1..., Msgs...> item;
   concatenator(std::variant<Args0...> a) {
     std::visit([this](auto&& arg) { this->item = std::move(arg); },
                std::move(a));
@@ -106,14 +121,19 @@ struct concatenator<std::variant<Args0...>, std::variant<Args1...>> {
     std::visit([this](auto&& arg) { this->item = std::move(arg); },
                std::move(b));
   }
+  template<typename Msg>
+  requires((std::is_same_v<Msg, Msgs> || ...)) concatenator(Msg msg)
+      : item(std::move(msg)) {}
 };
 
 template<typename T, typename PID>
 struct MessageOrError
-    : concatenator<typename T::variant, typename ActorError<PID>::variant> {
-  using concatenator<typename T::variant,
-                     typename ActorError<PID>::variant>::concatenator;
+    : concatenator<typename T::variant, typename ActorError<PID>::variant,
+                   ActorDown<PID>> {
+  using concatenator<typename T::variant, typename ActorError<PID>::variant,
+                     ActorDown<PID>>::concatenator;
 };
+
 }  // namespace message
 
 }  // namespace arangodb::actor

--- a/lib/Actor/include/Actor/Message.h
+++ b/lib/Actor/include/Actor/Message.h
@@ -30,7 +30,8 @@
 
 #include <velocypack/Builder.h>
 
-#include "MPSCQueue.h"
+#include "Actor/Error.h"
+#include "Actor/MPSCQueue.h"
 
 namespace arangodb::actor {
 
@@ -56,10 +57,12 @@ namespace message {
 template<typename PID>
 struct ActorDown {
   PID actor;
+  Error reason;
 
   template<typename Inspector>
   friend inline auto inspect(Inspector& f, ActorDown& x) {
-    return f.object(x).fields(f.field("actor", x.actor));
+    return f.object(x).fields(f.field("actor", x.actor),
+                              f.field("reason", x.reason));
   }
 };
 

--- a/lib/Actor/include/Actor/Message.h
+++ b/lib/Actor/include/Actor/Message.h
@@ -150,3 +150,6 @@ struct fmt::formatter<arangodb::actor::message::ActorNotFound<PID>>
 template<>
 struct fmt::formatter<arangodb::actor::message::NetworkError>
     : arangodb::inspection::inspection_formatter {};
+template<typename PID>
+struct fmt::formatter<arangodb::actor::message::ActorDown<PID>>
+    : arangodb::inspection::inspection_formatter {};

--- a/tests/Actor/ActorListTest.cpp
+++ b/tests/Actor/ActorListTest.cpp
@@ -46,7 +46,9 @@ struct ActorBaseMock : ActorBase {
   auto serialize() -> arangodb::velocypack::SharedSlice override {
     return arangodb::velocypack::SharedSlice();
   }
-  auto finish() -> void override { finished = true; }
+  auto finish(arangodb::actor::Error reason) -> void override {
+    finished = true;
+  }
   auto isFinishedAndIdle() -> bool override { return finished; }
   auto isIdle() -> bool override { return true; }
 
@@ -136,8 +138,9 @@ TEST(ActorListTest, applies_function_to_each_actor) {
                          {ActorID{3}, std::make_shared<ActorBaseMock>()},
                          {ActorID{4}, std::make_shared<ActorBaseMock>()}});
 
-  list.apply(
-      [](std::shared_ptr<ActorBase>& actor) -> void { actor->finish(); });
+  list.apply([](std::shared_ptr<ActorBase>& actor) -> void {
+    actor->finish(arangodb::actor::Error::kNoError);
+  });
   ASSERT_TRUE(list.find(ActorID{1}).value()->isFinishedAndIdle());
   ASSERT_TRUE(list.find(ActorID{2}).value()->isFinishedAndIdle());
   ASSERT_TRUE(list.find(ActorID{3}).value()->isFinishedAndIdle());

--- a/tests/Actor/ActorListTest.cpp
+++ b/tests/Actor/ActorListTest.cpp
@@ -130,39 +130,6 @@ TEST(ActorListTest, gives_all_actor_ids_in_list) {
                                        ActorID{10}}));
 }
 
-TEST(ActorListTest, removes_actors_by_precondition_from_list) {
-  auto list =
-      ActorList({{ActorID{1}, std::make_shared<ActorBaseMock>("deletable")},
-                 {ActorID{2}, std::make_shared<ActorBaseMock>("non-deletable")},
-                 {ActorID{3}, std::make_shared<ActorBaseMock>("deletable")},
-                 {ActorID{4}, std::make_shared<ActorBaseMock>("deletable")}});
-  ASSERT_EQ(list.size(), 4);
-
-  list.removeIf([](std::shared_ptr<ActorBase> const& actor) -> bool {
-    return actor->typeName() == "deletable";
-  });
-  ASSERT_EQ(list.size(), 1);
-  ASSERT_EQ(list.allIDs(), std::vector<ActorID>{ActorID{2}});
-}
-
-TEST(ActorListTest,
-     removes_actors_by_precondition_without_destroying_actors_in_use) {
-  auto list =
-      ActorList({{ActorID{1}, std::make_shared<ActorBaseMock>("deletable")},
-                 {ActorID{2}, std::make_shared<ActorBaseMock>("non-deletable")},
-                 {ActorID{3}, std::make_shared<ActorBaseMock>("deletable")},
-                 {ActorID{4}, std::make_shared<ActorBaseMock>("deletable")}});
-  ASSERT_EQ(list.size(), 4);
-
-  auto actorInUse = list.find(ActorID{1});
-  list.removeIf([](std::shared_ptr<ActorBase> const& actor) -> bool {
-    return actor->typeName() == "deletable";
-  });
-  ASSERT_EQ(list.size(), 1);
-  ASSERT_EQ(list.allIDs(), std::vector<ActorID>{ActorID{2}});
-  ASSERT_EQ(actorInUse->use_count(), 1);
-}
-
 TEST(ActorListTest, applies_function_to_each_actor) {
   auto list = ActorList({{ActorID{1}, std::make_shared<ActorBaseMock>()},
                          {ActorID{2}, std::make_shared<ActorBaseMock>()},

--- a/tests/Actor/ActorListTest.cpp
+++ b/tests/Actor/ActorListTest.cpp
@@ -46,7 +46,7 @@ struct ActorBaseMock : ActorBase {
   auto serialize() -> arangodb::velocypack::SharedSlice override {
     return arangodb::velocypack::SharedSlice();
   }
-  auto finish(arangodb::actor::Error reason) -> void override {
+  auto finish(arangodb::actor::ExitReason reason) -> void override {
     finished = true;
   }
   auto isFinishedAndIdle() -> bool override { return finished; }
@@ -139,7 +139,7 @@ TEST(ActorListTest, applies_function_to_each_actor) {
                          {ActorID{4}, std::make_shared<ActorBaseMock>()}});
 
   list.apply([](std::shared_ptr<ActorBase>& actor) -> void {
-    actor->finish(arangodb::actor::Error::kNoError);
+    actor->finish(arangodb::actor::ExitReason::kFinished);
   });
   ASSERT_TRUE(list.find(ActorID{1}).value()->isFinishedAndIdle());
   ASSERT_TRUE(list.find(ActorID{2}).value()->isFinishedAndIdle());

--- a/tests/Actor/ActorListTest.cpp
+++ b/tests/Actor/ActorListTest.cpp
@@ -24,6 +24,7 @@
 
 #include <gtest/gtest.h>
 #include "Actor/ActorBase.h"
+#include "Actor/ActorID.h"
 #include "Actor/ActorList.h"
 #include "Actor/DistributedActorPID.h"
 
@@ -57,19 +58,19 @@ struct ActorBaseMock : ActorBase {
 
 TEST(ActorListTest, finds_actor_by_actor_id_in_list) {
   auto list =
-      ActorList({{{ActorID{1}, std::make_shared<ActorBaseMock>("some")},
-                  {ActorID{2}, std::make_shared<ActorBaseMock>("search")},
-                  {ActorID{3}, std::make_shared<ActorBaseMock>("some")},
-                  {ActorID{4}, std::make_shared<ActorBaseMock>("some")}}});
+      ActorList({{ActorID{1}, std::make_shared<ActorBaseMock>("some")},
+                 {ActorID{2}, std::make_shared<ActorBaseMock>("search")},
+                 {ActorID{3}, std::make_shared<ActorBaseMock>("some")},
+                 {ActorID{4}, std::make_shared<ActorBaseMock>("some")}});
   auto foundActor = list.find(ActorID{2});
   ASSERT_EQ(foundActor.value()->typeName(), "search");
 }
 
 TEST(ActorListTest, gives_nothing_when_searching_for_unknown_actor_id) {
-  auto list = ActorList({{{ActorID{1}, std::make_shared<ActorBaseMock>()},
-                          {ActorID{2}, std::make_shared<ActorBaseMock>()},
-                          {ActorID{3}, std::make_shared<ActorBaseMock>()},
-                          {ActorID{4}, std::make_shared<ActorBaseMock>()}}});
+  auto list = ActorList({{ActorID{1}, std::make_shared<ActorBaseMock>()},
+                         {ActorID{2}, std::make_shared<ActorBaseMock>()},
+                         {ActorID{3}, std::make_shared<ActorBaseMock>()},
+                         {ActorID{4}, std::make_shared<ActorBaseMock>()}});
   auto foundActor = list.find(ActorID{10});
   ASSERT_EQ(foundActor, std::nullopt);
 }
@@ -84,7 +85,7 @@ TEST(ActorListTest, adds_actor_to_list) {
 
 TEST(ActorListTest, neglects_added_actors_with_already_existing_actor_id) {
   auto list =
-      ActorList({{{ActorID{1}, std::make_shared<ActorBaseMock>("existing")}}});
+      ActorList({{ActorID{1}, std::make_shared<ActorBaseMock>("existing")}});
 
   list.add(ActorID{1}, std::make_shared<ActorBaseMock>("added"));
   ASSERT_EQ(list.size(), 1);
@@ -92,7 +93,7 @@ TEST(ActorListTest, neglects_added_actors_with_already_existing_actor_id) {
 }
 
 TEST(ActorListTest, removes_actor_by_id_from_list) {
-  auto list = ActorList({{{ActorID{1}, std::make_shared<ActorBaseMock>()}}});
+  auto list = ActorList({{ActorID{1}, std::make_shared<ActorBaseMock>()}});
   ASSERT_EQ(list.size(), 1);
 
   list.remove(ActorID{1});
@@ -100,7 +101,7 @@ TEST(ActorListTest, removes_actor_by_id_from_list) {
 }
 
 TEST(ActorListTest, ignores_removal_of_non_existing_actor) {
-  auto list = ActorList({{{ActorID{1}, std::make_shared<ActorBaseMock>()}}});
+  auto list = ActorList({{ActorID{1}, std::make_shared<ActorBaseMock>()}});
   ASSERT_EQ(list.size(), 1);
 
   list.remove(ActorID{2});
@@ -108,7 +109,7 @@ TEST(ActorListTest, ignores_removal_of_non_existing_actor) {
 }
 
 TEST(ActorListTest, removes_actor_in_use_without_destroying_it) {
-  auto list = ActorList({{{ActorID{1}, std::make_shared<ActorBaseMock>()}}});
+  auto list = ActorList({{ActorID{1}, std::make_shared<ActorBaseMock>()}});
   ASSERT_EQ(list.size(), 1);
 
   auto actorInUse = list.find(ActorID{1});
@@ -118,10 +119,10 @@ TEST(ActorListTest, removes_actor_in_use_without_destroying_it) {
 }
 
 TEST(ActorListTest, gives_all_actor_ids_in_list) {
-  auto list = ActorList({{{ActorID{1}, std::make_shared<ActorBaseMock>()},
-                          {ActorID{5}, std::make_shared<ActorBaseMock>()},
-                          {ActorID{3}, std::make_shared<ActorBaseMock>()},
-                          {ActorID{10}, std::make_shared<ActorBaseMock>()}}});
+  auto list = ActorList({{ActorID{1}, std::make_shared<ActorBaseMock>()},
+                         {ActorID{5}, std::make_shared<ActorBaseMock>()},
+                         {ActorID{3}, std::make_shared<ActorBaseMock>()},
+                         {ActorID{10}, std::make_shared<ActorBaseMock>()}});
   auto ids = list.allIDs();
   ASSERT_EQ(ids.size(), 4);
   sort(ids.begin(), ids.end());
@@ -130,11 +131,11 @@ TEST(ActorListTest, gives_all_actor_ids_in_list) {
 }
 
 TEST(ActorListTest, removes_actors_by_precondition_from_list) {
-  auto list = ActorList(
-      {{{ActorID{1}, std::make_shared<ActorBaseMock>("deletable")},
-        {ActorID{2}, std::make_shared<ActorBaseMock>("non-deletable")},
-        {ActorID{3}, std::make_shared<ActorBaseMock>("deletable")},
-        {ActorID{4}, std::make_shared<ActorBaseMock>("deletable")}}});
+  auto list =
+      ActorList({{ActorID{1}, std::make_shared<ActorBaseMock>("deletable")},
+                 {ActorID{2}, std::make_shared<ActorBaseMock>("non-deletable")},
+                 {ActorID{3}, std::make_shared<ActorBaseMock>("deletable")},
+                 {ActorID{4}, std::make_shared<ActorBaseMock>("deletable")}});
   ASSERT_EQ(list.size(), 4);
 
   list.removeIf([](std::shared_ptr<ActorBase> const& actor) -> bool {
@@ -146,11 +147,11 @@ TEST(ActorListTest, removes_actors_by_precondition_from_list) {
 
 TEST(ActorListTest,
      removes_actors_by_precondition_without_destroying_actors_in_use) {
-  auto list = ActorList(
-      {{{ActorID{1}, std::make_shared<ActorBaseMock>("deletable")},
-        {ActorID{2}, std::make_shared<ActorBaseMock>("non-deletable")},
-        {ActorID{3}, std::make_shared<ActorBaseMock>("deletable")},
-        {ActorID{4}, std::make_shared<ActorBaseMock>("deletable")}}});
+  auto list =
+      ActorList({{ActorID{1}, std::make_shared<ActorBaseMock>("deletable")},
+                 {ActorID{2}, std::make_shared<ActorBaseMock>("non-deletable")},
+                 {ActorID{3}, std::make_shared<ActorBaseMock>("deletable")},
+                 {ActorID{4}, std::make_shared<ActorBaseMock>("deletable")}});
   ASSERT_EQ(list.size(), 4);
 
   auto actorInUse = list.find(ActorID{1});
@@ -163,10 +164,10 @@ TEST(ActorListTest,
 }
 
 TEST(ActorListTest, applies_function_to_each_actor) {
-  auto list = ActorList({{{ActorID{1}, std::make_shared<ActorBaseMock>()},
-                          {ActorID{2}, std::make_shared<ActorBaseMock>()},
-                          {ActorID{3}, std::make_shared<ActorBaseMock>()},
-                          {ActorID{4}, std::make_shared<ActorBaseMock>()}}});
+  auto list = ActorList({{ActorID{1}, std::make_shared<ActorBaseMock>()},
+                         {ActorID{2}, std::make_shared<ActorBaseMock>()},
+                         {ActorID{3}, std::make_shared<ActorBaseMock>()},
+                         {ActorID{4}, std::make_shared<ActorBaseMock>()}});
 
   list.apply(
       [](std::shared_ptr<ActorBase>& actor) -> void { actor->finish(); });
@@ -179,10 +180,10 @@ TEST(ActorListTest, applies_function_to_each_actor) {
 TEST(ActorListTest,
      unsucessfully_checks_condition_not_fulfilled_by_all_actors) {
   auto list =
-      ActorList({{{ActorID{1}, std::make_shared<ActorBaseMock>("true")},
-                  {ActorID{2}, std::make_shared<ActorBaseMock>("true")},
-                  {ActorID{3}, std::make_shared<ActorBaseMock>("false")},
-                  {ActorID{4}, std::make_shared<ActorBaseMock>("false")}}});
+      ActorList({{ActorID{1}, std::make_shared<ActorBaseMock>("true")},
+                 {ActorID{2}, std::make_shared<ActorBaseMock>("true")},
+                 {ActorID{3}, std::make_shared<ActorBaseMock>("false")},
+                 {ActorID{4}, std::make_shared<ActorBaseMock>("false")}});
 
   auto check = list.checkAll([](std::shared_ptr<ActorBase> const& actor) {
     return actor->typeName() == "true";
@@ -193,14 +194,30 @@ TEST(ActorListTest,
 
 TEST(ActorListTest, sucessfully_checks_condition_fulfilled_by_all_actors) {
   auto list =
-      ActorList({{{ActorID{1}, std::make_shared<ActorBaseMock>("true")},
-                  {ActorID{2}, std::make_shared<ActorBaseMock>("true")},
-                  {ActorID{3}, std::make_shared<ActorBaseMock>("true")},
-                  {ActorID{4}, std::make_shared<ActorBaseMock>("true")}}});
+      ActorList({{ActorID{1}, std::make_shared<ActorBaseMock>("true")},
+                 {ActorID{2}, std::make_shared<ActorBaseMock>("true")},
+                 {ActorID{3}, std::make_shared<ActorBaseMock>("true")},
+                 {ActorID{4}, std::make_shared<ActorBaseMock>("true")}});
 
   auto check = list.checkAll([](std::shared_ptr<ActorBase> const& actor) {
     return actor->typeName() == "true";
   });
 
   ASSERT_TRUE(check);
+}
+
+TEST(ActorListTest,
+     monitor_adds_monitoring_actor_to_monitor_list_and_returns_true) {
+  auto list =
+      ActorList({{ActorID{1}, std::make_shared<ActorBaseMock>("monitored")}});
+
+  EXPECT_TRUE(list.monitor(ActorID{42}, ActorID{1}));
+  EXPECT_EQ(std::vector<ActorID>{ActorID{42}}, list.getMonitors(ActorID{1}));
+}
+
+TEST(ActorListTest,
+     monitor_returns_false_if_actor_id_to_monitor_does_not_exist) {
+  auto list = ActorList();
+
+  EXPECT_FALSE(list.monitor(ActorID{42}, ActorID{1}));
 }

--- a/tests/Actor/ActorTest.cpp
+++ b/tests/Actor/ActorTest.cpp
@@ -23,6 +23,7 @@
 
 #include <gtest/gtest.h>
 #include <memory>
+#include "Actor/Error.h"
 #include "fmt/core.h"
 #include "velocypack/SharedSlice.h"
 #include "Inspection/VPackWithErrorT.h"
@@ -129,7 +130,7 @@ TEST(ActorTest, sets_itself_to_finish) {
       runtime, std::make_unique<TrivialState>());
   ASSERT_FALSE(actor->isFinishedAndIdle());
 
-  actor->finish();
+  actor->finish(Error::kNoError);
 
   ASSERT_TRUE(actor->isFinishedAndIdle());
 }
@@ -141,7 +142,7 @@ TYPED_TEST(ActorTest, does_not_work_on_new_messages_after_actor_finished) {
   auto actor = std::make_shared<Actor<DistributedRuntime, TrivialActor>>(
       DistributedActorPID{.server = "A", .database = "database", .id = {1}},
       runtime, std::make_unique<TrivialState>());
-  actor->finish();
+  actor->finish(Error::kNoError);
 
   // send message to actor
   auto message =

--- a/tests/Actor/ActorTest.cpp
+++ b/tests/Actor/ActorTest.cpp
@@ -23,7 +23,6 @@
 
 #include <gtest/gtest.h>
 #include <memory>
-#include "Actor/Error.h"
 #include "fmt/core.h"
 #include "velocypack/SharedSlice.h"
 #include "Inspection/VPackWithErrorT.h"
@@ -31,6 +30,7 @@
 #include "Actor/Actor.h"
 #include "Actor/DistributedActorPID.h"
 #include "Actor/DistributedRuntime.h"
+#include "Actor/ExitReason.h"
 #include "Actor/Message.h"
 #include "Actor/MPSCQueue.h"
 
@@ -130,7 +130,7 @@ TEST(ActorTest, sets_itself_to_finish) {
       runtime, std::make_unique<TrivialState>());
   ASSERT_FALSE(actor->isFinishedAndIdle());
 
-  actor->finish(Error::kNoError);
+  actor->finish(ExitReason::kFinished);
 
   ASSERT_TRUE(actor->isFinishedAndIdle());
 }
@@ -142,7 +142,7 @@ TYPED_TEST(ActorTest, does_not_work_on_new_messages_after_actor_finished) {
   auto actor = std::make_shared<Actor<DistributedRuntime, TrivialActor>>(
       DistributedActorPID{.server = "A", .database = "database", .id = {1}},
       runtime, std::make_unique<TrivialState>());
-  actor->finish(Error::kNoError);
+  actor->finish(ExitReason::kFinished);
 
   // send message to actor
   auto message =

--- a/tests/Actor/Actors/FinishingActor.h
+++ b/tests/Actor/Actors/FinishingActor.h
@@ -52,7 +52,7 @@ auto inspect(Inspector& f, FinishingStart& x) {
 }
 
 struct FinishingFinish {
-  Error reason;
+  ExitReason reason;
 };
 template<typename Inspector>
 auto inspect(Inspector& f, FinishingFinish& x) {

--- a/tests/Actor/Actors/FinishingActor.h
+++ b/tests/Actor/Actors/FinishingActor.h
@@ -52,11 +52,11 @@ auto inspect(Inspector& f, FinishingStart& x) {
 }
 
 struct FinishingFinish {
-  bool finish;
+  Error reason;
 };
 template<typename Inspector>
 auto inspect(Inspector& f, FinishingFinish& x) {
-  return f.object(x).fields(f.field("finish", x.finish));
+  return f.object(x).fields(f.field("reason", x.reason));
 }
 
 struct FinishingMessages : std::variant<FinishingStart, FinishingFinish> {
@@ -80,7 +80,7 @@ struct FinishingHandler : HandlerBase<Runtime, FinishingState> {
 
   auto operator()(message::FinishingFinish msg)
       -> std::unique_ptr<FinishingState> {
-    this->finish();
+    this->finish(msg.reason);
     return std::move(this->state);
   }
 

--- a/tests/Actor/Actors/MonitoringActor.h
+++ b/tests/Actor/Actors/MonitoringActor.h
@@ -37,7 +37,7 @@
 namespace arangodb::actor::test {
 
 struct MonitoringState {
-  std::vector<std::pair<ActorID, Error>> deadActors;
+  std::vector<std::pair<ActorID, ExitReason>> deadActors;
   bool operator==(const MonitoringState&) const = default;
 
   template<typename Inspector>

--- a/tests/Actor/Actors/MonitoringActor.h
+++ b/tests/Actor/Actors/MonitoringActor.h
@@ -23,6 +23,7 @@
 #pragma once
 
 #include <chrono>
+#include <ostream>
 #include <string_view>
 #include <thread>
 #include <string>
@@ -41,7 +42,13 @@ struct MonitoringState {
 
   template<typename Inspector>
   friend inline auto inspect(Inspector& f, MonitoringState& x) {
-    return f.object(x).fields();
+    return f.object(x).fields(f.field("deadActors", x.deadActors));
+  }
+
+  friend inline std::ostream& operator<<(std::ostream& stream,
+                                         MonitoringState state) {
+    stream << inspection::json(state);
+    return stream;
   }
 };
 

--- a/tests/Actor/Actors/MonitoringActor.h
+++ b/tests/Actor/Actors/MonitoringActor.h
@@ -37,7 +37,7 @@
 namespace arangodb::actor::test {
 
 struct MonitoringState {
-  std::vector<ActorID> deadActors;
+  std::vector<std::pair<ActorID, Error>> deadActors;
   bool operator==(const MonitoringState&) const = default;
 
   template<typename Inspector>
@@ -75,7 +75,7 @@ template<typename Runtime>
 struct MonitoringHandler : HandlerBase<Runtime, MonitoringState> {
   auto operator()(actor::message::ActorDown<typename Runtime::ActorPID> msg)
       -> std::unique_ptr<MonitoringState> {
-    this->state->deadActors.push_back(msg.actor.id);
+    this->state->deadActors.push_back({msg.actor.id, msg.reason});
     return std::move(this->state);
   }
 

--- a/tests/Actor/Actors/MonitoringActor.h
+++ b/tests/Actor/Actors/MonitoringActor.h
@@ -1,0 +1,90 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2020 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Manuel Pöter
+////////////////////////////////////////////////////////////////////////////////
+#pragma once
+
+#include <chrono>
+#include <string_view>
+#include <thread>
+#include <string>
+#include <memory>
+#include <variant>
+
+#include "Inspection/InspectorBase.h"
+#include "Actor/Actor.h"
+#include "TrivialActor.h"
+
+namespace arangodb::actor::test {
+
+struct MonitoringState {
+  std::vector<ActorID> deadActors;
+  bool operator==(const MonitoringState&) const = default;
+
+  template<typename Inspector>
+  friend inline auto inspect(Inspector& f, MonitoringState& x) {
+    return f.object(x).fields();
+  }
+};
+
+namespace message {
+
+struct DummyMessage {};
+template<typename Inspector>
+auto inspect(Inspector& f, DummyMessage& x) {
+  return f.object(x).fields();
+}
+
+struct MonitoringMessages : std::variant<DummyMessage> {
+  using std::variant<DummyMessage>::variant;
+};
+template<typename Inspector>
+auto inspect(Inspector& f, MonitoringMessages& x) {
+  return f.variant(x).unqualified().alternatives(
+      arangodb::inspection::type<DummyMessage>("dummy"));
+}
+
+}  // namespace message
+
+template<typename Runtime>
+struct MonitoringHandler : HandlerBase<Runtime, MonitoringState> {
+  auto operator()(actor::message::ActorDown<typename Runtime::ActorPID> msg)
+      -> std::unique_ptr<MonitoringState> {
+    this->state->deadActors.push_back(msg.actor.id);
+    return std::move(this->state);
+  }
+
+  auto operator()(auto&& rest) -> std::unique_ptr<MonitoringState> {
+    fmt::print(stderr, "Monitoring actor: handles rest\n");
+    return std::move(this->state);
+  }
+};
+
+struct MonitoringActor {
+  using State = MonitoringState;
+  using Message = message::MonitoringMessages;
+  template<typename Runtime>
+  using Handler = MonitoringHandler<Runtime>;
+  static constexpr auto typeName() -> std::string_view {
+    return "MonitoringActor";
+  };
+};
+}  // namespace arangodb::actor::test


### PR DESCRIPTION
### Scope & Purpose

This PR adds monitoring support for actors. At the moment this is limited to the local server, so an actor can only monitor other actors running on the same server (in the same runtime to be precise). When an actor is stopped, it sends `ActorDown` messages to all monitoring actors. This message includes the PID of the finished actor, together with an error code indicating the reason why the actor stopped. If an actor tries to monitor an actor that no longer exists (or may have never existed - don't have enough information to differentiate the two cases), we immediately send an `ActorDown` message to that actor with reason `UknownActor`.

- [x] :pizza: New feature

### Checklist

- [x] Tests
  - [x] C++ **Unit tests**