### PR TITLE
Fix issues with statistics memory usage

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,20 @@
 devel
 -----
 
+* Track memory usage of internal connection statistics and request statistics:
+  - `arangodb_connection_statistics_memory_usage`
+  - `arangodb_requests_statistics_memory_usage`
+  These metrics will remain at 0 if the server is started with the option
+  `--server.statistics false`. Otherwise they will contain the memory usage
+  used by connection and request statistics. Memory usage should remain pretty
+  constant over time, unless there are bursts of new connections and/or 
+  requests.
+
+* Avoid memory leak in case an arangod instance is started with the option 
+  `--server.statistics false`. Previously, with that setting the request
+  and connection statistics were built up in memory, but were never released
+  because the statistics background thread was not running.
+
 * Updated ArangoDB Starter to 0.17.2-preview-2 and arangosync to
   v2.19.5-preview-1.
 

--- a/Documentation/Metrics/arangodb_connection_statistics_memory_usage.yaml
+++ b/Documentation/Metrics/arangodb_connection_statistics_memory_usage.yaml
@@ -1,0 +1,24 @@
+name: arangodb_connection_statistics_memory_usage
+introducedIn: "3.12.0"
+help: |
+  Total memory usage of connection statistics.
+unit: bytes
+type: gauge
+category: Statistics
+complexity: advanced
+exposedBy:
+  - coordinator
+  - dbserver
+  - agent
+  - single
+description: |
+  Total memory usage of connection statistics. 
+  If the startup option `--server.statistics` is set to `true`, then some
+  connection statistics are built up in memory for every connection that is
+  made to the arangod server.
+  It is expected that the memory usage reported by this metric remains
+  relatively constant over time. It should grow only when there are bursts of 
+  new connections.
+  Some memory is pre-allocated at startup for higher efficiency.
+  No memory will be allocated for connection statistics if the startup option
+  is set to `false`.

--- a/Documentation/Metrics/arangodb_request_statistics_memory_usage.yaml
+++ b/Documentation/Metrics/arangodb_request_statistics_memory_usage.yaml
@@ -1,0 +1,23 @@
+name: arangodb_request_statistics_memory_usage
+introducedIn: "3.12.0"
+help: |
+  Total memory usage of request statistics.
+unit: bytes
+type: gauge
+category: Statistics
+complexity: advanced
+exposedBy:
+  - coordinator
+  - dbserver
+  - agent
+  - single
+description: |
+  Total memory usage of request statistics. 
+  If the startup option `--server.statistics` is set to `true`, then some
+  request statistics are built up in memory for incoming requests.
+  Some memory is pre-allocated at startup for higher efficiency.
+  It is expected that the memory usage reported by this metric remains
+  relatively constant over time. It should grow only when there are bursts of 
+  incoming requests.
+  No memory will be allocated for request statistics if the startup option
+  is set to `false`.

--- a/arangod/GeneralServer/CommTask.h
+++ b/arangod/GeneralServer/CommTask.h
@@ -121,9 +121,11 @@ class CommTask : public std::enable_shared_from_this<CommTask> {
                       std::unique_ptr<GeneralResponse> response,
                       ServerState::Mode mode);
 
-  RequestStatistics::Item const& acquireStatistics(uint64_t id);
-  RequestStatistics::Item const& statistics(uint64_t id);
-  RequestStatistics::Item stealStatistics(uint64_t id);
+  [[nodiscard]] ConnectionStatistics::Item acquireConnectionStatistics();
+  [[nodiscard]] RequestStatistics::Item const& acquireRequestStatistics(
+      uint64_t id);
+  [[nodiscard]] RequestStatistics::Item const& requestStatistics(uint64_t id);
+  [[nodiscard]] RequestStatistics::Item stealRequestStatistics(uint64_t id);
 
   /// @brief send response including error response body
   void sendErrorResponse(rest::ResponseCode, rest::ContentType,

--- a/arangod/GeneralServer/H2CommTask.cpp
+++ b/arangod/GeneralServer/H2CommTask.cpp
@@ -85,7 +85,7 @@ template<SocketType T>
   }
 
   int32_t const sid = frame->hd.stream_id;
-  me->acquireStatistics(sid).SET_READ_START(TRI_microtime());
+  me->acquireRequestStatistics(sid).SET_READ_START(TRI_microtime());
   auto req =
       std::make_unique<HttpRequest>(me->_connectionInfo, /*messageId*/ sid);
   me->createStream(sid, std::move(req));
@@ -624,7 +624,7 @@ void H2CommTask<T>::processRequest(Stream& stream,
   // store origin header for later use
   stream.origin = req->header(StaticStrings::Origin);
   auto messageId = req->messageId();
-  RequestStatistics::Item const& stat = this->statistics(messageId);
+  RequestStatistics::Item const& stat = this->requestStatistics(messageId);
   stat.SET_REQUEST_TYPE(req->requestType());
   stat.ADD_RECEIVED_BYTES(stream.headerBuffSize + req->body().size());
   stat.SET_READ_END();

--- a/arangod/GeneralServer/RestHandler.cpp
+++ b/arangod/GeneralServer/RestHandler.cpp
@@ -161,11 +161,11 @@ void RestHandler::trackTaskEnd() noexcept {
   }
 }
 
-RequestStatistics::Item&& RestHandler::stealStatistics() {
+RequestStatistics::Item&& RestHandler::stealRequestStatistics() {
   return std::move(_statistics);
 }
 
-void RestHandler::setStatistics(RequestStatistics::Item&& stat) {
+void RestHandler::setRequestStatistics(RequestStatistics::Item&& stat) {
   _statistics = std::move(stat);
 }
 

--- a/arangod/GeneralServer/RestHandler.h
+++ b/arangod/GeneralServer/RestHandler.h
@@ -93,11 +93,12 @@ class RestHandler : public std::enable_shared_from_this<RestHandler> {
   ArangodServer& server() noexcept { return _server; }
   ArangodServer const& server() const noexcept { return _server; }
 
-  RequestStatistics::Item const& statistics() const noexcept {
+  [[nodiscard]] RequestStatistics::Item const& requestStatistics()
+      const noexcept {
     return _statistics;
   }
-  RequestStatistics::Item&& stealStatistics();
-  void setStatistics(RequestStatistics::Item&& stat);
+  [[nodiscard]] RequestStatistics::Item&& stealRequestStatistics();
+  void setRequestStatistics(RequestStatistics::Item&& stat);
 
   void setIsAsyncRequest() noexcept { _isAsyncRequest = true; }
 

--- a/arangod/GeneralServer/VstCommTask.cpp
+++ b/arangod/GeneralServer/VstCommTask.cpp
@@ -203,7 +203,7 @@ bool VstCommTask<T>::processChunk(fuerte::vst::Chunk const& chunk) {
   }
 
   if (chunk.header.isFirst()) {
-    this->acquireStatistics(chunk.header.messageID())
+    this->acquireRequestStatistics(chunk.header.messageID())
         .SET_READ_START(TRI_microtime());
 
     // single chunk optimization
@@ -292,7 +292,7 @@ void VstCommTask<T>::processMessage(velocypack::Buffer<uint8_t> buffer,
     // error is handled below
   }
 
-  RequestStatistics::Item const& stat = this->statistics(messageId);
+  RequestStatistics::Item const& stat = this->requestStatistics(messageId);
   stat.SET_READ_END();
   stat.ADD_RECEIVED_BYTES(buffer.size());
 
@@ -567,7 +567,7 @@ void VstCommTask<T>::handleVstAuthRequest(VPackSlice header, uint64_t mId,
   // a forwarding, since we always forward with HTTP.
   if (_authMethod != AuthenticationMethod::NONE && _authToken.authenticated() &&
       _authToken.username().empty()) {
-    this->statistics(mId).SET_SUPERUSER();
+    this->requestStatistics(mId).SET_SUPERUSER();
   }
 
   if (_authToken.authenticated() || !this->_auth->isActive()) {

--- a/arangod/Statistics/ConnectionStatistics.cpp
+++ b/arangod/Statistics/ConnectionStatistics.cpp
@@ -25,6 +25,7 @@
 
 #include "Rest/CommonDefines.h"
 
+#include <atomic>
 #include <mutex>
 #include <thread>
 #include <vector>
@@ -38,6 +39,14 @@ using namespace arangodb;
 // -----------------------------------------------------------------------------
 
 namespace {
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+// this variable is only used in maintainer mode, to check that we are
+// only acquiring memory for statistics in case they are enabled.
+bool statisticsEnabled = false;
+#endif
+
+std::atomic<uint64_t> memoryUsage = 0;
+
 // initial amount of empty statistics items to be created in statisticsItems
 constexpr size_t kInitialQueueSize = 32;
 
@@ -56,6 +65,10 @@ std::vector<std::unique_ptr<ConnectionStatistics>> statisticsItems;
 static boost::lockfree::queue<ConnectionStatistics*> freeList;
 
 bool enqueueItem(ConnectionStatistics* item) noexcept {
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+  TRI_ASSERT(statisticsEnabled);
+#endif
+
   int tries = 0;
 
   try {
@@ -94,7 +107,16 @@ void ConnectionStatistics::Item::SET_HTTP() {
   }
 }
 
+uint64_t ConnectionStatistics::memoryUsage() noexcept {
+  return ::memoryUsage.load(std::memory_order_relaxed);
+}
+
 void ConnectionStatistics::initialize() {
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+  TRI_ASSERT(!statisticsEnabled);
+  statisticsEnabled = true;
+#endif
+
   std::lock_guard guard{::statisticsMutex};
 
   ::freeList.reserve(kInitialQueueSize * 2);
@@ -111,9 +133,18 @@ void ConnectionStatistics::initialize() {
       ::statisticsItems.pop_back();
     }
   }
+
+  ::memoryUsage.fetch_add(::statisticsItems.size() *
+                              (sizeof(decltype(::statisticsItems)::value_type) +
+                               sizeof(ConnectionStatistics)),
+                          std::memory_order_relaxed);
 }
 
 ConnectionStatistics::Item ConnectionStatistics::acquire() noexcept {
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+  TRI_ASSERT(statisticsEnabled);
+#endif
+
   ConnectionStatistics* statistics = nullptr;
 
   // try the happy path first
@@ -125,8 +156,14 @@ ConnectionStatistics::Item ConnectionStatistics::acquire() noexcept {
       // store pointer for just-created item
       statistics = cs.get();
 
-      std::lock_guard guard{::statisticsMutex};
-      ::statisticsItems.emplace_back(std::move(cs));
+      {
+        std::lock_guard guard{::statisticsMutex};
+        ::statisticsItems.emplace_back(std::move(cs));
+      }
+
+      ::memoryUsage.fetch_add(sizeof(decltype(::statisticsItems)::value_type) +
+                                  sizeof(ConnectionStatistics),
+                              std::memory_order_relaxed);
     } catch (...) {
       statistics = nullptr;
     }
@@ -136,6 +173,10 @@ ConnectionStatistics::Item ConnectionStatistics::acquire() noexcept {
 }
 
 void ConnectionStatistics::release() noexcept {
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+  TRI_ASSERT(statisticsEnabled);
+#endif
+
   if (_http) {
     statistics::HttpConnections.decCounter();
   }

--- a/arangod/Statistics/ConnectionStatistics.h
+++ b/arangod/Statistics/ConnectionStatistics.h
@@ -31,6 +31,7 @@
 namespace arangodb {
 class ConnectionStatistics {
  public:
+  static uint64_t memoryUsage() noexcept;
   static void initialize();
 
   class Item {

--- a/arangod/Statistics/RequestStatistics.h
+++ b/arangod/Statistics/RequestStatistics.h
@@ -30,9 +30,13 @@
 #include "Statistics/StatisticsFeature.h"
 #include "Statistics/figures.h"
 
+#include <cstddef>
+#include <cstdint>
+
 namespace arangodb {
 class RequestStatistics {
  public:
+  static uint64_t memoryUsage() noexcept;
   static void initialize();
   static size_t processAll();
 

--- a/arangod/Statistics/StatisticsFeature.cpp
+++ b/arangod/Statistics/StatisticsFeature.cpp
@@ -725,21 +725,17 @@ This is less intrusive than setting the `--server.statistics` option to
 
 void StatisticsFeature::validateOptions(
     std::shared_ptr<ProgramOptions> options) {
-  if (!_statistics) {
+  if (_statistics) {
+    // initialize counters for all HTTP request types
+    ConnectionStatistics::initialize();
+    RequestStatistics::initialize();
+  } else {
     // turn ourselves off
     disable();
   }
 
   _statisticsHistoryTouched =
       options->processingResult().touched("--server.statistics-history");
-}
-
-void StatisticsFeature::prepare() {
-  // initialize counters for all HTTP request types
-  if (_statistics) {
-    ConnectionStatistics::initialize();
-    RequestStatistics::initialize();
-  }
 }
 
 void StatisticsFeature::start() {

--- a/arangod/Statistics/StatisticsFeature.cpp
+++ b/arangod/Statistics/StatisticsFeature.cpp
@@ -254,6 +254,10 @@ DECLARE_GAUGE(arangodb_v8_context_max, double,
               "Maximum number of concurrent V8 contexts");
 DECLARE_GAUGE(arangodb_v8_context_min, double,
               "Minimum number of concurrent V8 contexts");
+DECLARE_GAUGE(arangodb_request_statistics_memory_usage, uint64_t,
+              "Memory used by the internal request statistics");
+DECLARE_GAUGE(arangodb_connection_statistics_memory_usage, uint64_t,
+              "Memory used by the internal connection statistics");
 
 namespace {
 // local_name: {"prometheus_name", "type", "help"}
@@ -614,7 +618,13 @@ StatisticsFeature::StatisticsFeature(Server& server)
       _statisticsHistory(true),
       _statisticsHistoryTouched(false),
       _statisticsAllDatabases(true),
-      _descriptions(server) {
+      _descriptions(server),
+      _requestStatisticsMemoryUsage{
+          server.getFeature<metrics::MetricsFeature>().add(
+              arangodb_request_statistics_memory_usage{})},
+      _connectionStatisticsMemoryUsage{
+          server.getFeature<metrics::MetricsFeature>().add(
+              arangodb_connection_statistics_memory_usage{})} {
   setOptional(true);
   startsAfter<AqlFeaturePhase>();
   startsAfter<NetworkFeature>();
@@ -726,8 +736,10 @@ void StatisticsFeature::validateOptions(
 
 void StatisticsFeature::prepare() {
   // initialize counters for all HTTP request types
-  ConnectionStatistics::initialize();
-  RequestStatistics::initialize();
+  if (_statistics) {
+    ConnectionStatistics::initialize();
+    RequestStatistics::initialize();
+  }
 }
 
 void StatisticsFeature::start() {
@@ -881,6 +893,18 @@ void StatisticsFeature::appendMetric(std::string& result,
 void StatisticsFeature::toPrometheus(std::string& result, double now,
                                      std::string_view globals,
                                      bool ensureWhitespace) {
+  // these metrics should always be 0 if statistics are disabled
+  TRI_ASSERT(isEnabled() || (RequestStatistics::memoryUsage() == 0 &&
+                             ConnectionStatistics::memoryUsage() == 0));
+  if (isEnabled()) {
+    // update arangodb_request_statistics_memory_usage and
+    // arangodb_connection_statistics_memory_usage metrics
+    _requestStatisticsMemoryUsage.store(RequestStatistics::memoryUsage(),
+                                        std::memory_order_relaxed);
+    _connectionStatisticsMemoryUsage.store(ConnectionStatistics::memoryUsage(),
+                                           std::memory_order_relaxed);
+  }
+
   ProcessInfo info = TRI_ProcessInfoSelf();
   uint64_t rss = static_cast<uint64_t>(info._residentSize);
   double rssp = 0;

--- a/arangod/Statistics/StatisticsFeature.h
+++ b/arangod/Statistics/StatisticsFeature.h
@@ -25,6 +25,7 @@
 
 #include "Basics/Result.h"
 #include "Basics/system-functions.h"
+#include "Metrics/Fwd.h"
 #include "Rest/CommonDefines.h"
 #include "RestServer/arangod.h"
 #include "Statistics/Descriptions.h"
@@ -131,6 +132,9 @@ class StatisticsFeature final : public ArangodFeature {
   stats::Descriptions _descriptions;
   std::unique_ptr<Thread> _statisticsThread;
   std::unique_ptr<StatisticsWorker> _statisticsWorker;
+
+  metrics::Gauge<uint64_t>& _requestStatisticsMemoryUsage;
+  metrics::Gauge<uint64_t>& _connectionStatisticsMemoryUsage;
 };
 
 }  // namespace arangodb

--- a/arangod/Statistics/StatisticsFeature.h
+++ b/arangod/Statistics/StatisticsFeature.h
@@ -96,7 +96,6 @@ class StatisticsFeature final : public ArangodFeature {
 
   void collectOptions(std::shared_ptr<options::ProgramOptions>) override final;
   void validateOptions(std::shared_ptr<options::ProgramOptions>) override final;
-  void prepare() override final;
   void start() override final;
   void stop() override final;
   void toPrometheus(std::string& result, double now, std::string_view globals,

--- a/arangod/Statistics/StatisticsWorker.cpp
+++ b/arangod/Statistics/StatisticsWorker.cpp
@@ -61,25 +61,27 @@
 #include <velocypack/Exception.h>
 #include <velocypack/Iterator.h>
 
+#include <string_view>
+
 namespace {
-std::string const garbageCollectionQuery(
+constexpr std::string_view garbageCollectionQuery(
     "FOR s in @@collection FILTER s.time < @start RETURN s._key");
 
-std::string const lastEntryQuery(
+constexpr std::string_view lastEntryQuery(
     "FOR s in @@collection FILTER s.time >= @start SORT s.time DESC LIMIT 1 "
     "RETURN s");
-std::string const filteredLastEntryQuery(
+constexpr std::string_view filteredLastEntryQuery(
     "FOR s in @@collection FILTER s.time >= @start FILTER s.clusterId == "
     "@clusterId SORT s.time DESC LIMIT 1 RETURN s");
 
-std::string const fifteenMinuteQuery(
+constexpr std::string_view fifteenMinuteQuery(
     "FOR s in _statistics FILTER s.time >= @start SORT s.time RETURN s");
 
-std::string const filteredFifteenMinuteQuery(
+constexpr std::string_view filteredFifteenMinuteQuery(
     "FOR s in _statistics FILTER s.time >= @start FILTER s.clusterId == "
     "@clusterId SORT s.time RETURN s");
 
-double extractNumber(VPackSlice slice, char const* attribute) {
+double extractNumber(VPackSlice slice, std::string_view attribute) {
   if (!slice.isObject()) {
     return 0.0;
   }

--- a/tests/Basics/FpConvTest.cpp
+++ b/tests/Basics/FpConvTest.cpp
@@ -46,15 +46,14 @@ TEST(CFpconvTest, tst_nan) {
   EXPECT_TRUE(std::isnan(value));
   length = fpconv_dtoa(value, out);
 
-#ifdef _WIN32
-  EXPECT_EQ(std::string("-NaN"), std::string(out, length));
-#else
-  EXPECT_EQ(std::string("NaN"), std::string(out, length));
-#endif
+  auto sv = std::string_view(out, length);
+  // MSVC returns -NaN at least in some versions
+  EXPECT_TRUE(sv == "NaN" || sv == "-NaN") << sv;
 
   StringBuffer buf(true);
   buf.appendDecimal(value);
-  EXPECT_EQ(std::string("NaN"), std::string(buf.c_str(), buf.length()));
+  sv = std::string_view(buf.c_str(), buf.length());
+  EXPECT_TRUE(sv == "NaN" || sv == "-NaN") << sv;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tests/js/client/server_parameters/statistics-off.js
+++ b/tests/js/client/server_parameters/statistics-off.js
@@ -76,6 +76,15 @@ function testSuite() {
       assertEqual(0, count);
     },
 
+    testMemoryUsage : function() {
+      // issue some random requests to the server
+      for (let i = 0; i < 10; ++i) {
+         arango.GET_RAW("/_admin/metrics");
+      }
+      // metric values should always be 0 if statistics are disabled
+      assertEqual(0, getMetric("arangodb_connection_statistics_memory_usage"));
+      assertEqual(0, getMetric("arangodb_request_statistics_memory_usage"));
+    },
   };
 }
 

--- a/tests/js/client/server_parameters/statistics-on.js
+++ b/tests/js/client/server_parameters/statistics-on.js
@@ -1,5 +1,5 @@
 /*jshint globalstrict:false, strict:false */
-/* global getOptions, assertTrue, arango */
+/* global getOptions, assertTrue, assertEqual, assertNotEqual, arango */
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief test for server startup options
@@ -87,6 +87,24 @@ function testSuite() {
       }
       assertTrue(count > 0, { count });
     },
+
+    testMemoryUsageMetrics : function() {
+      // metric values should never be 0 if statistics are enabled
+      const connectionsBefore = getMetric("arangodb_connection_statistics_memory_usage");
+      assertNotEqual(0, connectionsBefore);
+      const requestsBefore = getMetric("arangodb_request_statistics_memory_usage");
+      assertNotEqual(0, requestsBefore);
+      
+      // issue some random requests to the server
+      for (let i = 0; i < 10; ++i) {
+         arango.GET_RAW("/_admin/metrics");
+      }
+      
+      // metrics values shouldn't have changed, because the statistics memory
+      // is allocated at startup and shouldn't grow under normal circumstances
+      assertEqual(connectionsBefore, getMetric("arangodb_connection_statistics_memory_usage"));
+      assertEqual(requestsBefore, getMetric("arangodb_request_statistics_memory_usage"));
+    }
 
   };
 }


### PR DESCRIPTION
### Scope & Purpose

Fix issues with statistics memory usage

* Track memory usage of internal connection statistics and request statistics:
  - `arangodb_connection_statistics_memory_usage`
  - `arangodb_requests_statistics_memory_usage` These metrics will remain at 0 if the server is started with the option `--server.statistics false`. Otherwise they will contain the memory usage used by connection and request statistics. Memory usage should remain pretty constant over time, unless there are bursts of new connections and/or requests.

* Avoid memory leak in case an arangod instance is started with the option `--server.statistics false`. Previously, with that setting the request and connection statistics were built up in memory, but were never released because the statistics background thread was not running.

- [x] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [x] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.11: https://github.com/arangodb/arangodb/pull/20170
  - [x] Backport for 3.10: https://github.com/arangodb/arangodb/pull/20172

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 