### PR TITLE
Fix issues with statistics memory usage

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,20 @@
 v3.11.6 (XXXX-XX-XX)
 --------------------
 
+* Track memory usage of internal connection statistics and request statistics:
+  - `arangodb_connection_statistics_memory_usage`
+  - `arangodb_requests_statistics_memory_usage`
+  These metrics will remain at 0 if the server is started with the option
+  `--server.statistics false`. Otherwise they will contain the memory usage
+  used by connection and request statistics. Memory usage should remain pretty
+  constant over time, unless there are bursts of new connections and/or 
+  requests.
+
+* Avoid memory leak in case an arangod instance is started with the option 
+  `--server.statistics false`. Previously, with that setting the request
+  and connection statistics were built up in memory, but were never released
+  because the statistics background thread was not running.
+
 * Remove version check on startup of arangosh. This can speed up the startup of
   the arangosh considerably because it won't do a network request to
   www.arangodb.com.

--- a/Documentation/Metrics/arangodb_connection_statistics_memory_usage.yaml
+++ b/Documentation/Metrics/arangodb_connection_statistics_memory_usage.yaml
@@ -1,0 +1,24 @@
+name: arangodb_connection_statistics_memory_usage
+introducedIn: "3.11.6"
+help: |
+  Total memory usage of connection statistics.
+unit: bytes
+type: gauge
+category: Statistics
+complexity: advanced
+exposedBy:
+  - coordinator
+  - dbserver
+  - agent
+  - single
+description: |
+  Total memory usage of connection statistics. 
+  If the startup option `--server.statistics` is set to `true`, then some
+  connection statistics are built up in memory for every connection that is
+  made to the arangod server.
+  It is expected that the memory usage reported by this metric remains
+  relatively constant over time. It should grow only when there are bursts of 
+  new connections.
+  Some memory is pre-allocated at startup for higher efficiency.
+  No memory will be allocated for connection statistics if the startup option
+  is set to `false`.

--- a/Documentation/Metrics/arangodb_request_statistics_memory_usage.yaml
+++ b/Documentation/Metrics/arangodb_request_statistics_memory_usage.yaml
@@ -1,0 +1,23 @@
+name: arangodb_request_statistics_memory_usage
+introducedIn: "3.11.6"
+help: |
+  Total memory usage of request statistics.
+unit: bytes
+type: gauge
+category: Statistics
+complexity: advanced
+exposedBy:
+  - coordinator
+  - dbserver
+  - agent
+  - single
+description: |
+  Total memory usage of request statistics. 
+  If the startup option `--server.statistics` is set to `true`, then some
+  request statistics are built up in memory for incoming requests.
+  Some memory is pre-allocated at startup for higher efficiency.
+  It is expected that the memory usage reported by this metric remains
+  relatively constant over time. It should grow only when there are bursts of 
+  incoming requests.
+  No memory will be allocated for request statistics if the startup option
+  is set to `false`.

--- a/arangod/GeneralServer/CommTask.cpp
+++ b/arangod/GeneralServer/CommTask.cpp
@@ -147,7 +147,7 @@ bool queueTimeViolated(GeneralRequest const& req) {
 CommTask::CommTask(GeneralServer& server, ConnectionInfo info)
     : _server(server),
       _connectionInfo(std::move(info)),
-      _connectionStatistics(ConnectionStatistics::acquire()),
+      _connectionStatistics(acquireConnectionStatistics()),
       _auth(AuthenticationFeature::instance()) {
   TRI_ASSERT(_auth != nullptr);
   _connectionStatistics.SET_START();
@@ -506,7 +506,7 @@ void CommTask::executeRequest(std::unique_ptr<GeneralRequest> request,
 
   if (mode == ServerState::Mode::STARTUP) {
     // request during startup phase
-    handler->setStatistics(stealStatistics(messageId));
+    handler->setRequestStatistics(stealRequestStatistics(messageId));
     handleRequestStartup(std::move(handler));
     return;
   }
@@ -515,12 +515,13 @@ void CommTask::executeRequest(std::unique_ptr<GeneralRequest> request,
   bool forwarded;
   auto res = handler->forwardRequest(forwarded);
   if (forwarded) {
-    statistics(messageId).SET_SUPERUSER();
-    std::move(res).thenFinal([self(shared_from_this()), h(std::move(handler)),
-                              messageId](
-                                 futures::Try<Result>&& /*ignored*/) -> void {
-      self->sendResponse(h->stealResponse(), self->stealStatistics(messageId));
-    });
+    requestStatistics(messageId).SET_SUPERUSER();
+    std::move(res).thenFinal(
+        [self(shared_from_this()), h(std::move(handler)),
+         messageId](futures::Try<Result>&& /*ignored*/) -> void {
+          self->sendResponse(h->stealResponse(),
+                             self->stealRequestStatistics(messageId));
+        });
     return;
   }
 
@@ -536,9 +537,9 @@ void CommTask::executeRequest(std::unique_ptr<GeneralRequest> request,
 
   // asynchronous request
   if (found && (asyncExec == "true" || asyncExec == "store")) {
-    RequestStatistics::Item stats = stealStatistics(messageId);
+    RequestStatistics::Item stats = stealRequestStatistics(messageId);
     stats.SET_ASYNC();
-    handler->setStatistics(std::move(stats));
+    handler->setRequestStatistics(std::move(stats));
     handler->setIsAsyncRequest();
 
     uint64_t jobId = 0;
@@ -571,7 +572,7 @@ void CommTask::executeRequest(std::unique_ptr<GeneralRequest> request,
     }
   } else {
     // synchronous request
-    handler->setStatistics(stealStatistics(messageId));
+    handler->setRequestStatistics(stealRequestStatistics(messageId));
     // handleRequestSync adds an error response
     handleRequestSync(std::move(handler));
   }
@@ -586,19 +587,32 @@ void CommTask::setStatistics(uint64_t id, RequestStatistics::Item&& stat) {
   _statisticsMap.insert_or_assign(id, std::move(stat));
 }
 
-RequestStatistics::Item const& CommTask::acquireStatistics(uint64_t id) {
-  RequestStatistics::Item stat = RequestStatistics::acquire();
+ConnectionStatistics::Item CommTask::acquireConnectionStatistics() {
+  ConnectionStatistics::Item stat;
+  if (_server.server().getFeature<StatisticsFeature>().isEnabled()) {
+    // only acquire a new item if the statistics are enabled.
+    stat = ConnectionStatistics::acquire();
+  }
+  return stat;
+}
+
+RequestStatistics::Item const& CommTask::acquireRequestStatistics(uint64_t id) {
+  RequestStatistics::Item stat;
+  if (_server.server().getFeature<StatisticsFeature>().isEnabled()) {
+    // only acquire a new item if the statistics are enabled.
+    stat = RequestStatistics::acquire();
+  }
 
   std::lock_guard<std::mutex> guard(_statisticsMutex);
   return _statisticsMap.insert_or_assign(id, std::move(stat)).first->second;
 }
 
-RequestStatistics::Item const& CommTask::statistics(uint64_t id) {
+RequestStatistics::Item const& CommTask::requestStatistics(uint64_t id) {
   std::lock_guard<std::mutex> guard(_statisticsMutex);
   return _statisticsMap[id];
 }
 
-RequestStatistics::Item CommTask::stealStatistics(uint64_t id) {
+RequestStatistics::Item CommTask::stealRequestStatistics(uint64_t id) {
   RequestStatistics::Item result;
   std::lock_guard<std::mutex> guard(_statisticsMutex);
 
@@ -621,7 +635,7 @@ void CommTask::sendSimpleResponse(rest::ResponseCode code,
     if (!buffer.empty()) {
       resp->setPayload(std::move(buffer), VPackOptions::Defaults);
     }
-    sendResponse(std::move(resp), this->stealStatistics(mid));
+    sendResponse(std::move(resp), this->stealRequestStatistics(mid));
   } catch (...) {
     LOG_TOPIC("fc831", WARN, Logger::REQUESTS)
         << "addSimpleResponse received an exception, closing connection";
@@ -691,7 +705,8 @@ void CommTask::handleRequestStartup(std::shared_ptr<RestHandler> handler) {
     handler->trackTaskEnd();
     try {
       // Pass the response to the io context
-      self->sendResponse(handler->stealResponse(), handler->stealStatistics());
+      self->sendResponse(handler->stealResponse(),
+                         handler->stealRequestStatistics());
     } catch (...) {
       LOG_TOPIC("e1322", WARN, Logger::REQUESTS)
           << "got an exception while sending response, closing connection";
@@ -727,7 +742,7 @@ void CommTask::handleRequestSync(std::shared_ptr<RestHandler> handler) {
       try {
         // Pass the response to the io context
         self->sendResponse(handler->stealResponse(),
-                           handler->stealStatistics());
+                           handler->stealRequestStatistics());
       } catch (...) {
         LOG_TOPIC("fc834", WARN, Logger::REQUESTS)
             << "got an exception while sending response, closing connection";
@@ -959,7 +974,7 @@ void CommTask::processCorsOptions(std::unique_ptr<GeneralRequest> req,
   }
 
   // discard request and send response
-  sendResponse(std::move(resp), stealStatistics(req->messageId()));
+  sendResponse(std::move(resp), stealRequestStatistics(req->messageId()));
 }
 
 auth::TokenCache::Entry CommTask::checkAuthHeader(GeneralRequest& req,

--- a/arangod/GeneralServer/CommTask.h
+++ b/arangod/GeneralServer/CommTask.h
@@ -121,9 +121,11 @@ class CommTask : public std::enable_shared_from_this<CommTask> {
                       std::unique_ptr<GeneralResponse> response,
                       ServerState::Mode mode);
 
-  RequestStatistics::Item const& acquireStatistics(uint64_t id);
-  RequestStatistics::Item const& statistics(uint64_t id);
-  RequestStatistics::Item stealStatistics(uint64_t id);
+  [[nodiscard]] ConnectionStatistics::Item acquireConnectionStatistics();
+  [[nodiscard]] RequestStatistics::Item const& acquireRequestStatistics(
+      uint64_t id);
+  [[nodiscard]] RequestStatistics::Item const& requestStatistics(uint64_t id);
+  [[nodiscard]] RequestStatistics::Item stealRequestStatistics(uint64_t id);
 
   /// @brief send response including error response body
   void sendErrorResponse(rest::ResponseCode, rest::ContentType,

--- a/arangod/GeneralServer/H2CommTask.cpp
+++ b/arangod/GeneralServer/H2CommTask.cpp
@@ -83,7 +83,7 @@ template<SocketType T>
   }
 
   int32_t const sid = frame->hd.stream_id;
-  me->acquireStatistics(sid).SET_READ_START(TRI_microtime());
+  me->acquireRequestStatistics(sid).SET_READ_START(TRI_microtime());
   auto req =
       std::make_unique<HttpRequest>(me->_connectionInfo, /*messageId*/ sid,
                                     /*allowMethodOverride*/ false);
@@ -623,7 +623,7 @@ void H2CommTask<T>::processRequest(Stream& stream,
   // store origin header for later use
   stream.origin = req->header(StaticStrings::Origin);
   auto messageId = req->messageId();
-  RequestStatistics::Item const& stat = this->statistics(messageId);
+  RequestStatistics::Item const& stat = this->requestStatistics(messageId);
   stat.SET_REQUEST_TYPE(req->requestType());
   stat.ADD_RECEIVED_BYTES(stream.headerBuffSize + req->body().size());
   stat.SET_READ_END();

--- a/arangod/GeneralServer/HttpCommTask.cpp
+++ b/arangod/GeneralServer/HttpCommTask.cpp
@@ -101,7 +101,7 @@ int HttpCommTask<T>::on_message_began(llhttp_t* p) try {
   me->_messageDone = false;
 
   // acquire a new statistics entry for the request
-  me->acquireStatistics(1UL).SET_READ_START(TRI_microtime());
+  me->acquireRequestStatistics(1UL).SET_READ_START(TRI_microtime());
   return HPE_OK;
 } catch (...) {
   // the caller of this function is a C function, which doesn't know
@@ -118,7 +118,7 @@ int HttpCommTask<T>::on_url(llhttp_t* p, const char* at, size_t len) try {
                            rest::ContentType::UNSET, 1, VPackBuffer<uint8_t>());
     return HPE_USER;
   }
-  me->statistics(1UL).SET_REQUEST_TYPE(me->_request->requestType());
+  me->requestStatistics(1UL).SET_REQUEST_TYPE(me->_request->requestType());
 
   me->_url.append(at, len);
   return HPE_OK;
@@ -247,7 +247,7 @@ int HttpCommTask<T>::on_message_complete(llhttp_t* p) try {
   HttpCommTask<T>* me = static_cast<HttpCommTask<T>*>(p->data);
   me->_request->parseUrl(me->_url.data(), me->_url.size());
 
-  me->statistics(1UL).SET_READ_END();
+  me->requestStatistics(1UL).SET_READ_END();
   me->_messageDone = true;
 
   return HPE_PAUSED;
@@ -333,7 +333,7 @@ bool HttpCommTask<T>::readCallback(asio_ns::error_code ec) {
     // Remove consumed data from receive buffer.
     this->_protocol->buffer.consume(nparsed);
     // And count it in the statistics:
-    this->statistics(1UL).ADD_RECEIVED_BYTES(nparsed);
+    this->requestStatistics(1UL).ADD_RECEIVED_BYTES(nparsed);
 
     if (_messageDone) {
       TRI_ASSERT(err == HPE_PAUSED);
@@ -424,7 +424,7 @@ void HttpCommTask<T>::checkVSTPrefix() {
       auto commTask = std::make_unique<VstCommTask<T>>(
           me._server, me._connectionInfo, std::move(me._protocol),
           fuerte::vst::VST1_0);
-      commTask->setStatistics(1UL, me.stealStatistics(1UL));
+      commTask->setStatistics(1UL, me.stealRequestStatistics(1UL));
       me._server.registerTask(std::move(commTask));
       me.close(ec);
       return;  // vst 1.0
@@ -435,7 +435,7 @@ void HttpCommTask<T>::checkVSTPrefix() {
       auto commTask = std::make_unique<VstCommTask<T>>(
           me._server, me._connectionInfo, std::move(me._protocol),
           fuerte::vst::VST1_1);
-      commTask->setStatistics(1UL, me.stealStatistics(1UL));
+      commTask->setStatistics(1UL, me.stealRequestStatistics(1UL));
       me._server.registerTask(std::move(commTask));
       me.close(ec);
       return;  // vst 1.1
@@ -445,7 +445,7 @@ void HttpCommTask<T>::checkVSTPrefix() {
       // do not remove preface here, H2CommTask will read it from buffer
       auto commTask = std::make_unique<H2CommTask<T>>(
           me._server, me._connectionInfo, std::move(me._protocol));
-      commTask->setStatistics(1UL, me.stealStatistics(1UL));
+      commTask->setStatistics(1UL, me.stealRequestStatistics(1UL));
       me._server.registerTask(std::move(commTask));
       me.close(ec);
       return;  // http2 upgrade
@@ -523,7 +523,7 @@ void HttpCommTask<T>::doProcessRequest() {
     if (h2 == "h2c" && found && !settings.empty()) {
       auto task = std::make_shared<H2CommTask<T>>(
           this->_server, this->_connectionInfo, std::move(this->_protocol));
-      task->setStatistics(1UL, this->stealStatistics(1UL));
+      task->setStatistics(1UL, this->stealRequestStatistics(1UL));
       task->upgradeHttp1(std::move(_request));
       this->close();
       return;
@@ -571,7 +571,7 @@ void HttpCommTask<T>::doProcessRequest() {
 
   // We want to separate superuser token traffic:
   if (_request->authenticated() && _request->user().empty()) {
-    this->statistics(1UL).SET_SUPERUSER();
+    this->requestStatistics(1UL).SET_SUPERUSER();
   }
 
   // first check whether we allow the request to continue

--- a/arangod/GeneralServer/RestHandler.cpp
+++ b/arangod/GeneralServer/RestHandler.cpp
@@ -152,11 +152,11 @@ void RestHandler::trackTaskEnd() noexcept {
   }
 }
 
-RequestStatistics::Item&& RestHandler::stealStatistics() {
+RequestStatistics::Item&& RestHandler::stealRequestStatistics() {
   return std::move(_statistics);
 }
 
-void RestHandler::setStatistics(RequestStatistics::Item&& stat) {
+void RestHandler::setRequestStatistics(RequestStatistics::Item&& stat) {
   _statistics = std::move(stat);
 }
 

--- a/arangod/GeneralServer/RestHandler.h
+++ b/arangod/GeneralServer/RestHandler.h
@@ -92,11 +92,12 @@ class RestHandler : public std::enable_shared_from_this<RestHandler> {
   ArangodServer& server() noexcept { return _server; }
   ArangodServer const& server() const noexcept { return _server; }
 
-  RequestStatistics::Item const& statistics() const noexcept {
+  [[nodiscard]] RequestStatistics::Item const& requestStatistics()
+      const noexcept {
     return _statistics;
   }
-  RequestStatistics::Item&& stealStatistics();
-  void setStatistics(RequestStatistics::Item&& stat);
+  [[nodiscard]] RequestStatistics::Item&& stealRequestStatistics();
+  void setRequestStatistics(RequestStatistics::Item&& stat);
 
   void setIsAsyncRequest() noexcept { _isAsyncRequest = true; }
 

--- a/arangod/GeneralServer/VstCommTask.cpp
+++ b/arangod/GeneralServer/VstCommTask.cpp
@@ -200,7 +200,7 @@ bool VstCommTask<T>::processChunk(fuerte::vst::Chunk const& chunk) {
   }
 
   if (chunk.header.isFirst()) {
-    this->acquireStatistics(chunk.header.messageID())
+    this->acquireRequestStatistics(chunk.header.messageID())
         .SET_READ_START(TRI_microtime());
 
     // single chunk optimization
@@ -289,7 +289,7 @@ void VstCommTask<T>::processMessage(velocypack::Buffer<uint8_t> buffer,
     // error is handled below
   }
 
-  RequestStatistics::Item const& stat = this->statistics(messageId);
+  RequestStatistics::Item const& stat = this->requestStatistics(messageId);
   stat.SET_READ_END();
   stat.ADD_RECEIVED_BYTES(buffer.size());
 
@@ -565,7 +565,7 @@ void VstCommTask<T>::handleVstAuthRequest(VPackSlice header, uint64_t mId,
   // a forwarding, since we always forward with HTTP.
   if (_authMethod != AuthenticationMethod::NONE && _authToken.authenticated() &&
       _authToken.username().empty()) {
-    this->statistics(mId).SET_SUPERUSER();
+    this->requestStatistics(mId).SET_SUPERUSER();
   }
 
   if (_authToken.authenticated() || !this->_auth->isActive()) {

--- a/arangod/Statistics/ConnectionStatistics.cpp
+++ b/arangod/Statistics/ConnectionStatistics.cpp
@@ -25,6 +25,7 @@
 
 #include "Rest/CommonDefines.h"
 
+#include <atomic>
 #include <mutex>
 #include <thread>
 #include <vector>
@@ -38,6 +39,14 @@ using namespace arangodb;
 // -----------------------------------------------------------------------------
 
 namespace {
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+// this variable is only used in maintainer mode, to check that we are
+// only acquiring memory for statistics in case they are enabled.
+bool statisticsEnabled = false;
+#endif
+
+std::atomic<uint64_t> memoryUsage = 0;
+
 // initial amount of empty statistics items to be created in statisticsItems
 constexpr size_t kInitialQueueSize = 32;
 
@@ -56,6 +65,10 @@ std::vector<std::unique_ptr<ConnectionStatistics>> statisticsItems;
 static boost::lockfree::queue<ConnectionStatistics*> freeList;
 
 bool enqueueItem(ConnectionStatistics* item) noexcept {
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+  TRI_ASSERT(statisticsEnabled);
+#endif
+
   int tries = 0;
 
   try {
@@ -94,7 +107,16 @@ void ConnectionStatistics::Item::SET_HTTP() {
   }
 }
 
+uint64_t ConnectionStatistics::memoryUsage() noexcept {
+  return ::memoryUsage.load(std::memory_order_relaxed);
+}
+
 void ConnectionStatistics::initialize() {
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+  TRI_ASSERT(!statisticsEnabled);
+  statisticsEnabled = true;
+#endif
+
   std::lock_guard guard{::statisticsMutex};
 
   ::freeList.reserve(kInitialQueueSize * 2);
@@ -111,9 +133,18 @@ void ConnectionStatistics::initialize() {
       ::statisticsItems.pop_back();
     }
   }
+
+  ::memoryUsage.fetch_add(::statisticsItems.size() *
+                              (sizeof(decltype(::statisticsItems)::value_type) +
+                               sizeof(ConnectionStatistics)),
+                          std::memory_order_relaxed);
 }
 
 ConnectionStatistics::Item ConnectionStatistics::acquire() noexcept {
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+  TRI_ASSERT(statisticsEnabled);
+#endif
+
   ConnectionStatistics* statistics = nullptr;
 
   // try the happy path first
@@ -125,8 +156,14 @@ ConnectionStatistics::Item ConnectionStatistics::acquire() noexcept {
       // store pointer for just-created item
       statistics = cs.get();
 
-      std::lock_guard guard{::statisticsMutex};
-      ::statisticsItems.emplace_back(std::move(cs));
+      {
+        std::lock_guard guard{::statisticsMutex};
+        ::statisticsItems.emplace_back(std::move(cs));
+      }
+
+      ::memoryUsage.fetch_add(sizeof(decltype(::statisticsItems)::value_type) +
+                                  sizeof(ConnectionStatistics),
+                              std::memory_order_relaxed);
     } catch (...) {
       statistics = nullptr;
     }
@@ -136,6 +173,10 @@ ConnectionStatistics::Item ConnectionStatistics::acquire() noexcept {
 }
 
 void ConnectionStatistics::release() noexcept {
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+  TRI_ASSERT(statisticsEnabled);
+#endif
+
   if (_http) {
     statistics::HttpConnections.decCounter();
   }

--- a/arangod/Statistics/ConnectionStatistics.h
+++ b/arangod/Statistics/ConnectionStatistics.h
@@ -31,6 +31,7 @@
 namespace arangodb {
 class ConnectionStatistics {
  public:
+  static uint64_t memoryUsage() noexcept;
   static void initialize();
 
   class Item {

--- a/arangod/Statistics/RequestStatistics.h
+++ b/arangod/Statistics/RequestStatistics.h
@@ -30,9 +30,13 @@
 #include "Statistics/StatisticsFeature.h"
 #include "Statistics/figures.h"
 
+#include <cstddef>
+#include <cstdint>
+
 namespace arangodb {
 class RequestStatistics {
  public:
+  static uint64_t memoryUsage() noexcept;
   static void initialize();
   static size_t processAll();
 

--- a/arangod/Statistics/StatisticsFeature.cpp
+++ b/arangod/Statistics/StatisticsFeature.cpp
@@ -249,6 +249,10 @@ DECLARE_GAUGE(arangodb_v8_context_max, double,
               "Maximum number of concurrent V8 contexts");
 DECLARE_GAUGE(arangodb_v8_context_min, double,
               "Minimum number of concurrent V8 contexts");
+DECLARE_GAUGE(arangodb_request_statistics_memory_usage, uint64_t,
+              "Memory used by the internal request statistics");
+DECLARE_GAUGE(arangodb_connection_statistics_memory_usage, uint64_t,
+              "Memory used by the internal connection statistics");
 
 namespace {
 // local_name: {"prometheus_name", "type", "help"}
@@ -609,7 +613,13 @@ StatisticsFeature::StatisticsFeature(Server& server)
       _statisticsHistory(true),
       _statisticsHistoryTouched(false),
       _statisticsAllDatabases(true),
-      _descriptions(server) {
+      _descriptions(server),
+      _requestStatisticsMemoryUsage{
+          server.getFeature<metrics::MetricsFeature>().add(
+              arangodb_request_statistics_memory_usage{})},
+      _connectionStatisticsMemoryUsage{
+          server.getFeature<metrics::MetricsFeature>().add(
+              arangodb_connection_statistics_memory_usage{})} {
   setOptional(true);
   startsAfter<AqlFeaturePhase>();
   startsAfter<NetworkFeature>();
@@ -723,8 +733,10 @@ void StatisticsFeature::validateOptions(
 
 void StatisticsFeature::prepare() {
   // initialize counters for all HTTP request types
-  ConnectionStatistics::initialize();
-  RequestStatistics::initialize();
+  if (_statistics) {
+    ConnectionStatistics::initialize();
+    RequestStatistics::initialize();
+  }
 }
 
 void StatisticsFeature::start() {
@@ -887,6 +899,18 @@ void StatisticsFeature::appendMetric(std::string& result,
 
 void StatisticsFeature::toPrometheus(std::string& result, double now,
                                      bool ensureWhitespace) {
+  // these metrics should always be 0 if statistics are disabled
+  TRI_ASSERT(isEnabled() || (RequestStatistics::memoryUsage() == 0 &&
+                             ConnectionStatistics::memoryUsage() == 0));
+  if (isEnabled()) {
+    // update arangodb_request_statistics_memory_usage and
+    // arangodb_connection_statistics_memory_usage metrics
+    _requestStatisticsMemoryUsage.store(RequestStatistics::memoryUsage(),
+                                        std::memory_order_relaxed);
+    _connectionStatisticsMemoryUsage.store(ConnectionStatistics::memoryUsage(),
+                                           std::memory_order_relaxed);
+  }
+
   ProcessInfo info = TRI_ProcessInfoSelf();
   uint64_t rss = static_cast<uint64_t>(info._residentSize);
   double rssp = 0;

--- a/arangod/Statistics/StatisticsFeature.h
+++ b/arangod/Statistics/StatisticsFeature.h
@@ -28,6 +28,7 @@
 
 #include "Basics/Result.h"
 #include "Basics/system-functions.h"
+#include "Metrics/Fwd.h"
 #include "Rest/CommonDefines.h"
 #include "RestServer/arangod.h"
 #include "Statistics/Descriptions.h"
@@ -126,6 +127,9 @@ class StatisticsFeature final : public ArangodFeature {
   stats::Descriptions _descriptions;
   std::unique_ptr<Thread> _statisticsThread;
   std::unique_ptr<StatisticsWorker> _statisticsWorker;
+
+  metrics::Gauge<uint64_t>& _requestStatisticsMemoryUsage;
+  metrics::Gauge<uint64_t>& _connectionStatisticsMemoryUsage;
 };
 
 }  // namespace arangodb

--- a/arangod/Statistics/StatisticsWorker.cpp
+++ b/arangod/Statistics/StatisticsWorker.cpp
@@ -58,25 +58,27 @@
 #include <velocypack/Exception.h>
 #include <velocypack/Iterator.h>
 
+#include <string_view>
+
 namespace {
-std::string const garbageCollectionQuery(
+constexpr std::string_view garbageCollectionQuery(
     "FOR s in @@collection FILTER s.time < @start RETURN s._key");
 
-std::string const lastEntryQuery(
+constexpr std::string_view lastEntryQuery(
     "FOR s in @@collection FILTER s.time >= @start SORT s.time DESC LIMIT 1 "
     "RETURN s");
-std::string const filteredLastEntryQuery(
+constexpr std::string_view filteredLastEntryQuery(
     "FOR s in @@collection FILTER s.time >= @start FILTER s.clusterId == "
     "@clusterId SORT s.time DESC LIMIT 1 RETURN s");
 
-std::string const fifteenMinuteQuery(
+constexpr std::string_view fifteenMinuteQuery(
     "FOR s in _statistics FILTER s.time >= @start SORT s.time RETURN s");
 
-std::string const filteredFifteenMinuteQuery(
+constexpr std::string_view filteredFifteenMinuteQuery(
     "FOR s in _statistics FILTER s.time >= @start FILTER s.clusterId == "
     "@clusterId SORT s.time RETURN s");
 
-double extractNumber(VPackSlice slice, char const* attribute) {
+double extractNumber(VPackSlice slice, std::string_view attribute) {
   if (!slice.isObject()) {
     return 0.0;
   }

--- a/js/common/bootstrap/errors.js
+++ b/js/common/bootstrap/errors.js
@@ -340,6 +340,7 @@
     "ERROR_SUPERVISION_GENERAL_FAILURE" : { "code" : 20501, "message" : "general supervision failure" },
     "ERROR_QUEUE_FULL"             : { "code" : 21003, "message" : "queue is full" },
     "ERROR_QUEUE_TIME_REQUIREMENT_VIOLATED" : { "code" : 21004, "message" : "queue time violated" },
+    "ERROR_TOO_MANY_DETACHED_THREADS" : { "code" : 21005, "message" : "too many detached scheduler threads" },
     "ERROR_ACTION_OPERATION_UNABORTABLE" : { "code" : 6002, "message" : "this maintenance action cannot be stopped" },
     "ERROR_ACTION_UNFINISHED"      : { "code" : 6003, "message" : "maintenance action still processing" },
     "ERROR_HOT_BACKUP_INTERNAL"    : { "code" : 7001, "message" : "internal hot backup error" },

--- a/tests/js/client/server_parameters/statistics-off.js
+++ b/tests/js/client/server_parameters/statistics-off.js
@@ -76,6 +76,15 @@ function testSuite() {
       assertEqual(0, count);
     },
 
+    testMemoryUsage : function() {
+      // issue some random requests to the server
+      for (let i = 0; i < 10; ++i) {
+         arango.GET_RAW("/_admin/metrics");
+      }
+      // metric values should always be 0 if statistics are disabled
+      assertEqual(0, getMetric("arangodb_connection_statistics_memory_usage"));
+      assertEqual(0, getMetric("arangodb_request_statistics_memory_usage"));
+    },
   };
 }
 

--- a/tests/js/client/server_parameters/statistics-on.js
+++ b/tests/js/client/server_parameters/statistics-on.js
@@ -1,5 +1,5 @@
 /*jshint globalstrict:false, strict:false */
-/* global getOptions, assertTrue, arango */
+/* global getOptions, assertTrue, assertEqual, assertNotEqual, arango */
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief test for server startup options
@@ -87,6 +87,24 @@ function testSuite() {
       }
       assertTrue(count > 0, { count });
     },
+
+    testMemoryUsageMetrics : function() {
+      // metric values should never be 0 if statistics are enabled
+      const connectionsBefore = getMetric("arangodb_connection_statistics_memory_usage");
+      assertNotEqual(0, connectionsBefore);
+      const requestsBefore = getMetric("arangodb_request_statistics_memory_usage");
+      assertNotEqual(0, requestsBefore);
+      
+      // issue some random requests to the server
+      for (let i = 0; i < 10; ++i) {
+         arango.GET_RAW("/_admin/metrics");
+      }
+      
+      // metrics values shouldn't have changed, because the statistics memory
+      // is allocated at startup and shouldn't grow under normal circumstances
+      assertEqual(connectionsBefore, getMetric("arangodb_connection_statistics_memory_usage"));
+      assertEqual(requestsBefore, getMetric("arangodb_request_statistics_memory_usage"));
+    }
 
   };
 }


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/20169

Fix issues with statistics memory usage

* Track memory usage of internal connection statistics and request statistics:
  - `arangodb_connection_statistics_memory_usage`
  - `arangodb_requests_statistics_memory_usage` These metrics will remain at 0 if the server is started with the option `--server.statistics false`. Otherwise they will contain the memory usage used by connection and request statistics. Memory usage should remain pretty constant over time, unless there are bursts of new connections and/or requests.

* Avoid memory leak in case an arangod instance is started with the option `--server.statistics false`. Previously, with that setting the request and connection statistics were built up in memory, but were never released because the statistics background thread was not running.

- [x] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [x] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.11: this PR
  - [x] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 