### PR TITLE
Fix issue when inspecting temporaries with embedFields

### DIFF
--- a/lib/Inspection/include/Inspection/detail/Fields.h
+++ b/lib/Inspection/include/Inspection/detail/Fields.h
@@ -153,10 +153,11 @@ struct EMPTY_BASE BasicField : InvariantMixin<Inspector, DerivedField>,
 
 template<class Inspector, typename T>
 struct EMPTY_BASE RawField : BasicField<Inspector, RawField<Inspector, T>> {
-  RawField(std::string_view name, T& value)
-      : BasicField<Inspector, RawField>(name), value(value) {}
-  using value_type = T;
-  T& value;
+  template<class TT>
+  RawField(std::string_view name, TT&& value)
+      : BasicField<Inspector, RawField>(name), value(std::forward<TT>(value)) {}
+  using value_type = std::remove_reference_t<T>;
+  T value;
 };
 
 struct IgnoreField {


### PR DESCRIPTION
### Scope & Purpose

This PR fixes an issue when inspecting temporaries with `embedFields`. It was always possible to pass rvalue references to the inspector, e.g. the result of a getter. While this does not make a load of sense for load operations, it is perfectly valid for serialization. However, in combination with `embedFields` this has previously resulted in undefined behavior. The reason is, that `Inspector::field()` creates a field that stores the relevant information for later processing. Normally this processing happens during execution of `Inspector::fields()`, at which point the temporary which has been passed to `Inspector::field()` is still valid. But in case of `embedFields`, `Inspector::fields()` produces a special result that captures all the passed fields, so they can be processed by the inspector that called `embedFields`.  That means that the processing happens outside the scope of the temporary. Previously `Inspector::field()` created objects that captured a reference to the given value. For temporaries this reference could be garbage in `embedFields`. That's why this PR changes the type of the captured field. For lvalue references, we still capture lvalue references as before. For rvalue references, we now capture the value via move construction.

- [x] :hankey: Bugfix

### Checklist

- [x] Tests
  - [x] C++ **Unit tests**