### PR TITLE
Cleanup ShortestPathOptions

### DIFF
--- a/arangod/Aql/EnumeratePathsNode.cpp
+++ b/arangod/Aql/EnumeratePathsNode.cpp
@@ -384,7 +384,7 @@ std::unique_ptr<ExecutionBlock> EnumeratePathsNode::createBlock(
   TRI_ASSERT(pathType() != arangodb::graph::PathType::Type::ShortestPath);
 
   arangodb::graph::TwoSidedEnumeratorOptions enumeratorOptions{
-      opts->minDepth, opts->maxDepth, pathType()};
+      opts->getMinDepth(), opts->getMaxDepth(), pathType()};
   PathValidatorOptions validatorOptions(opts->tmpVar(),
                                         opts->getExpressionCtx());
 

--- a/arangod/Aql/ExecutionPlan.cpp
+++ b/arangod/Aql/ExecutionPlan.cpp
@@ -376,8 +376,8 @@ std::unique_ptr<graph::BaseOptions> createShortestPathOptions(
 
   aql::QueryContext& query = ast->query();
   auto options = std::make_unique<graph::ShortestPathOptions>(query);
-  options->minDepth = minDepth;
-  options->maxDepth = maxDepth;
+  options->setMinDepth(minDepth);
+  options->setMaxDepth(maxDepth);
 
   if (optionsNode != nullptr && optionsNode->type == NODE_TYPE_OBJECT) {
     size_t n = optionsNode->numMembers();

--- a/arangod/Graph/ShortestPathOptions.cpp
+++ b/arangod/Graph/ShortestPathOptions.cpp
@@ -41,11 +41,7 @@ using namespace arangodb::traverser;
 using VPackHelper = arangodb::basics::VelocyPackHelper;
 
 ShortestPathOptions::ShortestPathOptions(aql::QueryContext& query)
-    : BaseOptions(query),
-      minDepth(1),
-      maxDepth(1),
-      bidirectional(true),
-      multiThreaded(true) {
+    : BaseOptions(query), minDepth(1), maxDepth(1), multiThreaded(true) {
   setWeightAttribute("");
   setDefaultWeight(1);
 }
@@ -74,9 +70,7 @@ ShortestPathOptions::ShortestPathOptions(aql::QueryContext& query,
 ShortestPathOptions::ShortestPathOptions(aql::QueryContext& query,
                                          VPackSlice info,
                                          VPackSlice collections)
-    : BaseOptions(query, info, collections),
-      bidirectional(true),
-      multiThreaded(true) {
+    : BaseOptions(query, info, collections), multiThreaded(true) {
   TRI_ASSERT(info.isObject());
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   VPackSlice type = info.get("type");
@@ -233,7 +227,6 @@ ShortestPathOptions::ShortestPathOptions(ShortestPathOptions const& other,
       maxDepth(other.maxDepth),
       start{other.start},
       end{other.end},
-      bidirectional{other.bidirectional},
       multiThreaded{other.multiThreaded},
       _reverseLookupInfos{other._reverseLookupInfos},
       _weightAttribute{other._weightAttribute},

--- a/arangod/Graph/ShortestPathOptions.cpp
+++ b/arangod/Graph/ShortestPathOptions.cpp
@@ -41,7 +41,7 @@ using namespace arangodb::traverser;
 using VPackHelper = arangodb::basics::VelocyPackHelper;
 
 ShortestPathOptions::ShortestPathOptions(aql::QueryContext& query)
-    : BaseOptions(query), minDepth(1), maxDepth(1), multiThreaded(true) {
+    : BaseOptions(query), minDepth(1), maxDepth(1) {
   setWeightAttribute("");
   setDefaultWeight(1);
 }
@@ -70,7 +70,7 @@ ShortestPathOptions::ShortestPathOptions(aql::QueryContext& query,
 ShortestPathOptions::ShortestPathOptions(aql::QueryContext& query,
                                          VPackSlice info,
                                          VPackSlice collections)
-    : BaseOptions(query, info, collections), multiThreaded(true) {
+    : BaseOptions(query, info, collections) {
   TRI_ASSERT(info.isObject());
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   VPackSlice type = info.get("type");
@@ -227,7 +227,6 @@ ShortestPathOptions::ShortestPathOptions(ShortestPathOptions const& other,
       maxDepth(other.maxDepth),
       start{other.start},
       end{other.end},
-      multiThreaded{other.multiThreaded},
       _reverseLookupInfos{other._reverseLookupInfos},
       _weightAttribute{other._weightAttribute},
       _defaultWeight{other._defaultWeight} {

--- a/arangod/Graph/ShortestPathOptions.cpp
+++ b/arangod/Graph/ShortestPathOptions.cpp
@@ -106,9 +106,9 @@ ShortestPathOptions::ShortestPathOptions(ShortestPathOptions const& other,
     : BaseOptions(other, allowAlreadyBuiltCopy),
       _minDepth(other._minDepth),
       _maxDepth(other._maxDepth),
-      _reverseLookupInfos{other._reverseLookupInfos},
       _weightAttribute{other._weightAttribute},
-      _defaultWeight{other._defaultWeight} {
+      _defaultWeight{other._defaultWeight},
+      _reverseLookupInfos{other._reverseLookupInfos} {
   TRI_ASSERT(other._defaultWeight >= 0.);
 }
 

--- a/arangod/Graph/ShortestPathOptions.cpp
+++ b/arangod/Graph/ShortestPathOptions.cpp
@@ -106,8 +106,6 @@ ShortestPathOptions::ShortestPathOptions(ShortestPathOptions const& other,
     : BaseOptions(other, allowAlreadyBuiltCopy),
       _minDepth(other._minDepth),
       _maxDepth(other._maxDepth),
-      _start{other._start},
-      _end{other._end},
       _reverseLookupInfos{other._reverseLookupInfos},
       _weightAttribute{other._weightAttribute},
       _defaultWeight{other._defaultWeight} {

--- a/arangod/Graph/ShortestPathOptions.h
+++ b/arangod/Graph/ShortestPathOptions.h
@@ -46,7 +46,6 @@ struct ShortestPathOptions : public BaseOptions {
   uint64_t maxDepth;
   std::string start;
   std::string end;
-  bool multiThreaded;
 
   explicit ShortestPathOptions(aql::QueryContext& query);
 

--- a/arangod/Graph/ShortestPathOptions.h
+++ b/arangod/Graph/ShortestPathOptions.h
@@ -94,24 +94,27 @@ struct ShortestPathOptions : public BaseOptions {
 
   auto estimateDepth() const noexcept -> uint64_t override;
 
-  auto setWeightAttribute(std::string attribute) -> void;
-  auto getWeightAttribute() const& -> std::string;
-  auto setDefaultWeight(double weight) -> void;
-  auto getDefaultWeight() const -> double;
-
   auto setMinDepth(uint64_t minDepth) noexcept -> void;
   auto getMinDepth() const noexcept -> uint64_t;
+
   auto setMaxDepth(uint64_t maxDepth) noexcept -> void;
   auto getMaxDepth() const noexcept -> uint64_t;
 
+  auto setWeightAttribute(std::string attribute) -> void;
+  auto getWeightAttribute() const& -> std::string;
+
+  auto setDefaultWeight(double weight) -> void;
+  auto getDefaultWeight() const -> double;
+
  private:
+  /// These options come from the query's text
   uint64_t _minDepth;
   uint64_t _maxDepth;
+  std::string _weightAttribute;
+  double _defaultWeight;
 
   /// @brief Lookup info to find all reverse edges.
   std::vector<LookupInfo> _reverseLookupInfos;
-  std::string _weightAttribute;
-  double _defaultWeight;
 };
 
 }  // namespace graph

--- a/arangod/Graph/ShortestPathOptions.h
+++ b/arangod/Graph/ShortestPathOptions.h
@@ -42,11 +42,6 @@ class EdgeCursor;
 
 struct ShortestPathOptions : public BaseOptions {
  public:
-  uint64_t minDepth;
-  uint64_t maxDepth;
-  std::string start;
-  std::string end;
-
   explicit ShortestPathOptions(aql::QueryContext& query);
 
   ShortestPathOptions(aql::QueryContext& query,
@@ -56,7 +51,7 @@ struct ShortestPathOptions : public BaseOptions {
   ShortestPathOptions(aql::QueryContext& query,
                       arangodb::velocypack::Slice info,
                       arangodb::velocypack::Slice collections);
-  ~ShortestPathOptions() override;
+  ~ShortestPathOptions() override = default;
 
   /// @brief This copy constructor is only working during planning phase.
   ///        After planning this node should not be copied anywhere.
@@ -104,7 +99,17 @@ struct ShortestPathOptions : public BaseOptions {
   auto setDefaultWeight(double weight) -> void;
   auto getDefaultWeight() const -> double;
 
+  auto setMinDepth(uint64_t minDepth) noexcept -> void;
+  auto getMinDepth() const noexcept -> uint64_t;
+  auto setMaxDepth(uint64_t maxDepth) noexcept -> void;
+  auto getMaxDepth() const noexcept -> uint64_t;
+
  private:
+  uint64_t _minDepth;
+  uint64_t _maxDepth;
+  std::string _start;
+  std::string _end;
+
   /// @brief Lookup info to find all reverse edges.
   std::vector<LookupInfo> _reverseLookupInfos;
   std::string _weightAttribute;

--- a/arangod/Graph/ShortestPathOptions.h
+++ b/arangod/Graph/ShortestPathOptions.h
@@ -46,7 +46,6 @@ struct ShortestPathOptions : public BaseOptions {
   uint64_t maxDepth;
   std::string start;
   std::string end;
-  bool bidirectional;
   bool multiThreaded;
 
   explicit ShortestPathOptions(aql::QueryContext& query);

--- a/arangod/Graph/ShortestPathOptions.h
+++ b/arangod/Graph/ShortestPathOptions.h
@@ -107,8 +107,6 @@ struct ShortestPathOptions : public BaseOptions {
  private:
   uint64_t _minDepth;
   uint64_t _maxDepth;
-  std::string _start;
-  std::string _end;
 
   /// @brief Lookup info to find all reverse edges.
   std::vector<LookupInfo> _reverseLookupInfos;


### PR DESCRIPTION
This PR does a small cleanup of `struct ShortestPathOptions`;
* removes the unused members `bidirectional` and `multiThreaded`, `start` and `end`
* renames `minDepth`, and `maxDepth` to `_minDepth` and `_maxDepth` and accesses them through accessors

