### PR TITLE
FE-396: fix JSON editor undo broken for inverted index addition

### DIFF
--- a/js/apps/system/_admin/aardvark/APP/react/src/views/collections/indices/addIndex/invertedIndex/InvertedIndexFormJSONEditor.tsx
+++ b/js/apps/system/_admin/aardvark/APP/react/src/views/collections/indices/addIndex/invertedIndex/InvertedIndexFormJSONEditor.tsx
@@ -3,8 +3,8 @@ import Ajv from "ajv";
 import { useFormikContext } from "formik";
 import { ValidationError } from "jsoneditor-react";
 import React, { useState } from "react";
-import { JSONErrors } from "../../../../../components/jsonEditor/JSONErrors";
 import { ControlledJSONEditor } from "../../../../../components/jsonEditor/ControlledJSONEditor";
+import { JSONErrors } from "../../../../../components/jsonEditor/JSONErrors";
 import { useInvertedIndexJSONSchema } from "./useInvertedIndexJSONSchema";
 
 const ajv = new Ajv({
@@ -34,9 +34,14 @@ export const InvertedIndexFormJSONEditor = ({
         ajv={ajv}
         history
         schema={schema}
-        onChange={json => {
-          if (JSON.stringify(json) !== JSON.stringify(values)) {
-            setValues(json);
+        onChangeText={jsonString => {
+          try {
+            const json = JSON.parse(jsonString);
+            if (JSON.stringify(json) !== JSON.stringify(values)) {
+              setValues(json);
+            }
+          } catch (e) {
+            // ignore
           }
         }}
         htmlElementProps={{


### PR DESCRIPTION
### Scope & Purpose

This fixes the broken undo behaviour by switching to using onChangeText, which gives the proper updated JSON

- [x] :hankey: Bugfix


### Checklist

- [x] Tests
	- [x] Manually tested
- [ ] :book: CHANGELOG entry made

#### Related Information

- [ ] Jira ticket: https://arangodb.atlassian.net/browse/FE-396

