### PR TITLE
Teach PathValidator a global condition on edges

### DIFF
--- a/arangod/Graph/PathManagement/PathValidator.cpp
+++ b/arangod/Graph/PathManagement/PathValidator.cpp
@@ -302,6 +302,18 @@ auto PathValidator<ProviderType, PathStore, vertexUniqueness, edgeUniqueness>::
     }
   }
 
+  auto edgeExpr = _options.getEdgeExpression();
+  if (edgeExpr != nullptr) {
+    edgeBuilder.clear();
+    _provider.addEdgeToBuilder(step.getEdge(), edgeBuilder);
+
+    bool satisfiesCondition =
+        evaluateVertexExpression(edgeExpr, edgeBuilder.slice());
+    if (!satisfiesCondition) {
+      return ValidationResult{ValidationResult::Type::FILTER_AND_PRUNE};
+    }
+  }
+
   if (res.isPruned() && res.isFiltered()) {
     return res;
   }

--- a/arangod/Graph/PathManagement/PathValidator.cpp
+++ b/arangod/Graph/PathManagement/PathValidator.cpp
@@ -292,7 +292,7 @@ auto PathValidator<ProviderType, PathStore, vertexUniqueness, edgeUniqueness>::
 
     // evaluate expression
     bool satifiesCondition =
-        evaluateVertexExpression(vertexExpr, vertexBuilder.slice());
+        evaluateExpression(vertexExpr, vertexBuilder.slice());
     if (!satifiesCondition) {
       if (_options.bfsResultHasToIncludeFirstVertex() && step.isFirst()) {
         res.combine(ValidationResult::Type::PRUNE);
@@ -309,7 +309,7 @@ auto PathValidator<ProviderType, PathStore, vertexUniqueness, edgeUniqueness>::
 
       _provider.addEdgeToBuilder(step.getEdge(), edgeBuilder);
       bool satisfiesCondition =
-          evaluateVertexExpression(edgeExpr, edgeBuilder.slice());
+          evaluateExpression(edgeExpr, edgeBuilder.slice());
       if (!satisfiesCondition) {
         return ValidationResult{ValidationResult::Type::FILTER_AND_PRUNE};
       }
@@ -354,8 +354,8 @@ template<class ProviderType, class PathStore,
          VertexUniquenessLevel vertexUniqueness,
          EdgeUniquenessLevel edgeUniqueness>
 auto PathValidator<ProviderType, PathStore, vertexUniqueness, edgeUniqueness>::
-    evaluateVertexExpression(arangodb::aql::Expression* expression,
-                             VPackSlice value) -> bool {
+    evaluateExpression(arangodb::aql::Expression* expression, VPackSlice value)
+        -> bool {
   if (expression == nullptr) {
     return true;
   }

--- a/arangod/Graph/PathManagement/PathValidator.cpp
+++ b/arangod/Graph/PathManagement/PathValidator.cpp
@@ -304,13 +304,17 @@ auto PathValidator<ProviderType, PathStore, vertexUniqueness, edgeUniqueness>::
 
   auto edgeExpr = _options.getEdgeExpression();
   if (edgeExpr != nullptr) {
-    edgeBuilder.clear();
-    _provider.addEdgeToBuilder(step.getEdge(), edgeBuilder);
+    if (step.getEdge().isValid()) {
+      edgeBuilder.clear();
 
-    bool satisfiesCondition =
-        evaluateVertexExpression(edgeExpr, edgeBuilder.slice());
-    if (!satisfiesCondition) {
-      return ValidationResult{ValidationResult::Type::FILTER_AND_PRUNE};
+      _provider.addEdgeToBuilder(step.getEdge(), edgeBuilder);
+      bool satisfiesCondition =
+          evaluateVertexExpression(edgeExpr, edgeBuilder.slice());
+      if (!satisfiesCondition) {
+        return ValidationResult{ValidationResult::Type::FILTER_AND_PRUNE};
+      }
+    } else {
+      // TODO: at the moment we smile and wave...
     }
   }
 

--- a/arangod/Graph/PathManagement/PathValidator.h
+++ b/arangod/Graph/PathManagement/PathValidator.h
@@ -127,8 +127,8 @@ class PathValidator {
       -> ::arangodb::containers::HashSet<VertexRef, std::hash<VertexRef>,
                                          std::equal_to<VertexRef>> const&;
 
-  auto evaluateVertexExpression(arangodb::aql::Expression* expression,
-                                arangodb::velocypack::Slice value) -> bool;
+  auto evaluateExpression(arangodb::aql::Expression* expression,
+                          arangodb::velocypack::Slice value) -> bool;
 
   auto checkValidDisjointPath(typename PathStore::Step const& lastStep)
       -> arangodb::graph::ValidationResult::Type;

--- a/arangod/Graph/PathManagement/PathValidatorOptions.cpp
+++ b/arangod/Graph/PathManagement/PathValidatorOptions.cpp
@@ -57,6 +57,13 @@ void PathValidatorOptions::setAllVerticesExpression(
   _allVerticesExpression = std::move(expression);
 }
 
+void PathValidatorOptions::setAllEdgesExpression(
+    std::unique_ptr<aql::Expression> expression) {
+  // All edge expression should not be set before
+  TRI_ASSERT(_allEdgesExpression == nullptr);
+  _allEdgesExpression = std::move(expression);
+}
+
 void PathValidatorOptions::setPruneEvaluator(
     std::shared_ptr<aql::PruneExpressionEvaluator>&& expression) {
   _pruneEvaluator = std::move(expression);
@@ -115,6 +122,10 @@ aql::Expression* PathValidatorOptions::getVertexExpression(
   }
 
   return _allVerticesExpression.get();
+}
+
+aql::Expression* PathValidatorOptions::getEdgeExpression() const {
+  return _allEdgesExpression.get();
 }
 
 void PathValidatorOptions::unpreparePruneContext() {

--- a/arangod/Graph/PathManagement/PathValidatorOptions.h
+++ b/arangod/Graph/PathManagement/PathValidatorOptions.h
@@ -64,6 +64,11 @@ class PathValidatorOptions {
   void setAllVerticesExpression(std::unique_ptr<aql::Expression> expression);
 
   /**
+   * @brief Set the expression that needs to hold true ALL edges on a path.
+   */
+  void setAllEdgesExpression(std::unique_ptr<aql::Expression> expression);
+
+  /**
    * @brief Set the expression that needs to hold true for the vertex on the
    * given depth. NOTE: This will overrule the ALL vertex expression, so make
    * sure this expression contains everything the ALL expression covers.
@@ -116,6 +121,7 @@ class PathValidatorOptions {
    * Caller does NOT take responsibility. Do not delete this pointer.
    */
   aql::Expression* getVertexExpression(uint64_t depth) const;
+  aql::Expression* getEdgeExpression() const;
 
   void addAllowedVertexCollection(std::string const& collectionName);
 
@@ -146,6 +152,7 @@ class PathValidatorOptions {
  private:
   // Vertex expression section
   std::shared_ptr<aql::Expression> _allVerticesExpression;
+  std::shared_ptr<aql::Expression> _allEdgesExpression;
   containers::FlatHashMap<uint64_t, std::shared_ptr<aql::Expression>>
       _vertexExpressionOnDepth;
   std::vector<std::string> _allowedVertexCollections;

--- a/tests/Mocks/MockGraphProvider.cpp
+++ b/tests/Mocks/MockGraphProvider.cpp
@@ -183,6 +183,8 @@ auto MockGraphProvider::addEdgeToBuilder(const Step::Edge& edge,
     -> void {
   std::string fromId = edge.getEdge()._from;
   std::string toId = edge.getEdge()._to;
+  ADB_PROD_ASSERT(fromId.size() >= 2) << "fromId: `" << fromId << "`";
+  ADB_PROD_ASSERT(toId.size() >= 2) << "toId: `" << toId << "`";
   std::string keyId = fromId.substr(2) + "-" + toId.substr(2);
 
   builder.openObject();


### PR DESCRIPTION
### Scope & Purpose

The PathValidator class can already enforce a global condition on all vertices; this patch also allows it to filter all edges on a path.
