### PR TITLE
Improve replace-equal-attribute-access rule.

### DIFF
--- a/arangod/Aql/ExecutionPlan.cpp
+++ b/arangod/Aql/ExecutionPlan.cpp
@@ -35,6 +35,7 @@
 #include "Aql/Function.h"
 #include "Aql/IResearchViewNode.h"
 #include "Aql/IndexHint.h"
+#include "Aql/IndexNode.h"
 #include "Aql/EnumeratePathsNode.h"
 #include "Aql/ModificationNodes.h"
 #include "Aql/NodeFinder.h"
@@ -2892,8 +2893,15 @@ struct Shower final
         auto const& calcNode =
             *ExecutionNode::castTo<CalculationNode const*>(&node);
         auto type = std::string{node.getTypeString()};
-        type += " $" + calcNode.outVariable()->name + " = ";
+        type += " $" + std::to_string(calcNode.outVariable()->id) + " = ";
         calcNode.expression()->stringify(type);
+        return type;
+      }
+      case ExecutionNode::FILTER: {
+        auto const& filterNode =
+            *ExecutionNode::castTo<FilterNode const*>(&node);
+        auto type = std::string{node.getTypeString()};
+        type += " $" + std::to_string(filterNode.inVariable()->id);
         return type;
       }
       case ExecutionNode::TRAVERSAL:
@@ -2906,7 +2914,14 @@ struct Shower final
         }
         return type;
       }
-      case ExecutionNode::INDEX:
+      case ExecutionNode::INDEX: {
+        auto* indexNode = ExecutionNode::castTo<IndexNode const*>(&node);
+        auto type = std::string{node.getTypeString()};
+        type += " " + indexNode->collection()->name();
+        type += std::string{" -> "} + indexNode->outVariable()->name;
+        type += std::string{" "} + indexNode->condition()->root()->toString();
+        return type;
+      }
       case ExecutionNode::ENUMERATE_COLLECTION:
       case ExecutionNode::UPDATE:
       case ExecutionNode::INSERT:

--- a/arangod/Aql/Optimizer.cpp
+++ b/arangod/Aql/Optimizer.cpp
@@ -314,7 +314,8 @@ void Optimizer::createPlans(std::unique_ptr<ExecutionPlan> plan,
         // skip over rules if we should
         // however, we don't want to skip those rules that will not create
         // additional plans
-        if (p->isDisabledRule(rule.level) ||
+        auto ruleDisabled = p->isDisabledRule(rule.level);
+        if (ruleDisabled ||
             (_runOnlyRequiredRules && rule.canCreateAdditionalPlans() &&
              rule.canBeDisabled())) {
           // we picked a disabled rule or we have reached the max number of
@@ -323,7 +324,8 @@ void Optimizer::createPlans(std::unique_ptr<ExecutionPlan> plan,
                  // iteration
           _newPlans.push_back(std::move(p), it);  // nothing to do, just keep it
 
-          if (!rule.isHidden()) {
+          if (!rule.isHidden() &&
+              !(rule.isDisabledByDefault() && ruleDisabled)) {
             ++_stats.rulesSkipped;
           }
 

--- a/arangod/Aql/OptimizerRule.h
+++ b/arangod/Aql/OptimizerRule.h
@@ -149,7 +149,6 @@ struct OptimizerRule {
 
     // replace attribute accesses that are equal due to a filter statement
     // with the same value. This might enable other optimizations later on.
-    replaceEqualAttributeAccesses,
 
     // "Pass 4": moving nodes "up" (potentially outside loops) (second try):
     // ======================================================
@@ -161,6 +160,8 @@ struct OptimizerRule {
     // move filters up the dependency chain (to make result sets as small
     // as possible as early as possible)
     moveFiltersUpRule2,
+
+    replaceEqualAttributeAccesses,
 
     /// "Pass 5": try to remove redundant or unnecessary nodes (second try)
     // remove filters from the query that are not necessary at all

--- a/arangod/Aql/OptimizerRuleReplaceEqualAttributeAccess.cpp
+++ b/arangod/Aql/OptimizerRuleReplaceEqualAttributeAccess.cpp
@@ -38,6 +38,7 @@
 #include "Containers/NodeHashMap.h"
 #include "Containers/HashSet.h"
 #include "Containers/SmallVector.h"
+#include "Containers/ImmutableMap.h"
 #include "Logger/LogMacros.h"
 #include "OptimizerRules.h"
 
@@ -193,40 +194,63 @@ auto findDominatingVariable(ExecutionPlan& plan, EqualCondition& eq) {
   }
 }
 
-struct EquivalenceClass {
+struct Replacement {
   Variable const* var;
 };
 
-}  // namespace
+struct EquivalenceSet {
+  containers::ImmutableMap<Replacement const*, Replacement const*> unionFind;
+  containers::ImmutableMap<VarAttribKey, std::shared_ptr<Replacement>,
+                           boost::hash<VarAttribKey>>
+      variableToClass;
+};
 
-void arangodb::aql::replaceEqualAttributeAccesses(
-    Optimizer* opt, std::unique_ptr<ExecutionPlan> plan,
-    OptimizerRule const& rule) {
+bool processQuery(ExecutionPlan& plan, ExecutionNode* root,
+                  EquivalenceSet equivalences, std::size_t currentLimitCount) {
   bool modified = false;
 
-  containers::SmallVector<ExecutionNode*, 8> nodes;
-  containers::NodeHashMap<VarAttribKey, std::shared_ptr<EquivalenceClass>,
-                          boost::hash<VarAttribKey>>
-      equivalenceClasses;
+  auto const findRoot = [&](Replacement const* replacement) {
+    while (replacement != nullptr) {
+      auto other = equivalences.unionFind.find(replacement);
+      if (other == nullptr) {
+        break;
+      }
+      replacement = *other;
+    }
+    return replacement;
+  };
 
-  for (auto* node = plan->root()->getSingleton(); node != nullptr;
+  for (auto* node = root->getSingleton(); node != nullptr;
        node = node->getFirstParent()) {
     LOG_RULE << "[" << node->id() << "] " << node->getTypeString();
     // replace all known equivalence classes
-    for (auto& [var, cls] : equivalenceClasses) {
+    for (auto& [var, cls] : equivalences.variableToClass) {
+      auto* clsRoot = findRoot(cls.get());
+      TRI_ASSERT(clsRoot->var != nullptr);
+
       if (var.path.empty()) {
-        if (var.var->id == cls->var->id) {
+        if (var.var->id == clsRoot->var->id) {
           continue;
         }
-        LOG_RULE << "REPLACEING " << var.var->name << " -> " << cls->var->name;
-        node->replaceVariables({{var.var->id, cls->var}});
+        LOG_RULE << "REPLACEING " << var.var->name << " -> "
+                 << clsRoot->var->name;
+        node->replaceVariables({{var.var->id, clsRoot->var}});
       } else {
         node->replaceAttributeAccess(
             node, var.var,
             {const_cast<std::string_view*>(var.path.data()), var.path.size()},
-            cls->var, 0);
+            clsRoot->var, 0);
       }
       modified = true;
+    }
+
+    if (node->getType() == EN::SUBQUERY) {
+      auto* sn = ExecutionNode::castTo<SubqueryNode*>(node);
+      LOG_RULE << "ENTER SUBQUERY";
+      modified |= processQuery(plan, sn->getSubquery(), equivalences,
+                               currentLimitCount);
+      LOG_RULE << "LEAVE SUBQUERY";
+      continue;
     }
 
     // check if this is a filter node
@@ -235,7 +259,7 @@ void arangodb::aql::replaceEqualAttributeAccesses(
     }
 
     auto* fn = ExecutionNode::castTo<FilterNode*>(node);
-    auto* n = plan->getVarSetBy(fn->inVariable()->id);
+    auto* n = plan.getVarSetBy(fn->inVariable()->id);
     TRI_ASSERT(n->getType() == EN::CALCULATION);
     auto* cn = ExecutionNode::castTo<CalculationNode*>(n);
 
@@ -248,50 +272,76 @@ void arangodb::aql::replaceEqualAttributeAccesses(
       LOG_RULE << lhs.var->name << " is declared before " << rhs.var->name;
 
       // check if one of the two is already identified
-      auto lhsIter = equivalenceClasses.find(lhs);
-      auto rhsIter = equivalenceClasses.find(rhs);
+      auto lhsIter = equivalences.variableToClass.find(lhs);
+      auto rhsIter = equivalences.variableToClass.find(rhs);
 
-      bool const lhsKnown = lhsIter != equivalenceClasses.end();
-      bool const rhsKnown = rhsIter != equivalenceClasses.end();
+      bool const lhsKnown = lhsIter != nullptr;
+      bool const rhsKnown = rhsIter != nullptr;
 
       if (lhsKnown && !rhsKnown) {
         // simply identify rhs as well
         LOG_RULE << "IDENTIFY " << lhs << " == " << rhs;
-        equivalenceClasses.emplace(rhs, lhsIter->second);
+        equivalences.variableToClass =
+            std::move(equivalences.variableToClass).set(rhs, *lhsIter);
 
       } else if (!lhsKnown && rhsKnown) {
         // simply identify lhs as well
         LOG_RULE << "IDENTIFY " << lhs << " == " << rhs;
-        equivalenceClasses.emplace(lhs, rhsIter->second);
+        equivalences.variableToClass =
+            std::move(equivalences.variableToClass).set(lhs, *rhsIter);
       } else if (lhsKnown && rhsKnown) {
         // merge the two equivalence classes
         LOG_RULE << "MERGE " << lhs << " == " << rhs;
-        rhsIter->second->var = lhsIter->second->var;
+        auto lhsRoot = findRoot(lhsIter->get());
+        auto rhsRoot = findRoot(rhsIter->get());
+        equivalences.unionFind =
+            std::move(equivalences.unionFind).set(lhsRoot, rhsRoot);
       } else {
-        auto [lhs, rhs] = findDominatingVariable(*plan, pair);
+        auto [lhs, rhs] = findDominatingVariable(plan, pair);
 
         LOG_RULE << "CREATE " << lhs << " == " << rhs;
         // create a new equivalence class
-        // introduce a new variable
-        auto variable = plan->getAst()->variables()->createTemporaryVariable();
+        // introduce a new variable if necessary
+        auto variable = [&]() -> Variable const* {
+          if (lhs.path.empty()) {
+            return lhs.var;
+          } else {
+            auto variable =
+                plan.getAst()->variables()->createTemporaryVariable();
+            // substitute
+            auto subst = plan.createNode<CalculationNode>(
+                &plan, plan.nextId(),
+                std::make_unique<Expression>(plan.getAst(),
+                                             lhs.expr->clone(plan.getAst())),
+                variable);
+            plan.insertAfter(cn, subst);
+            return variable;
+          }
+        }();
         LOG_RULE << "WITNESS VAR " << variable->name;
-        // substitute
-        auto subst = plan->createNode<CalculationNode>(
-            plan.get(), plan->nextId(),
-            std::make_unique<Expression>(plan->getAst(),
-                                         lhs.expr->clone(plan->getAst())),
-            variable);
-        plan->insertAfter(cn, subst);
+
         modified = true;
 
-        auto cls =
-            std::make_shared<EquivalenceClass>(EquivalenceClass{variable});
-        equivalenceClasses.emplace(lhs, cls);
-        equivalenceClasses.emplace(rhs, cls);
-        equivalenceClasses.emplace(VarAttribKey{variable, {}}, cls);
+        auto cls = std::make_shared<Replacement>(Replacement{variable});
+        equivalences.variableToClass =
+            std::move(equivalences.variableToClass).set(lhs, cls);
+        equivalences.variableToClass =
+            std::move(equivalences.variableToClass).set(rhs, cls);
+        equivalences.variableToClass =
+            std::move(equivalences.variableToClass)
+                .set(VarAttribKey{variable, {}}, cls);
       }
     }
   }
 
+  return modified;
+}
+
+}  // namespace
+
+void arangodb::aql::replaceEqualAttributeAccesses(
+    Optimizer* opt, std::unique_ptr<ExecutionPlan> plan,
+    OptimizerRule const& rule) {
+  bool modified = processQuery(*plan, plan->root(), {}, 0);
   opt->addPlan(std::move(plan), rule, modified);
 }

--- a/arangod/Aql/OptimizerRulesFeature.cpp
+++ b/arangod/Aql/OptimizerRulesFeature.cpp
@@ -275,10 +275,14 @@ multiple loops, which may enable further optimizations by other rules.)");
 
   // replace attribute accesses that are equal due to a filter statement
   // with the same value. This might enable other optimizations later on.
+  // WARNING: THIS RULE HAS BEEN DISABLED because while it can lead to new
+  // optimizations it can do harm to other optimizations. Furthermore, the
+  // user can always rewrite the query to make this rule unnecessary.
   registerRule(
       "replace-equal-attribute-accesses", replaceEqualAttributeAccesses,
       OptimizerRule::replaceEqualAttributeAccesses,
-      OptimizerRule::makeFlags(OptimizerRule::Flags::CanBeDisabled),
+      OptimizerRule::makeFlags(OptimizerRule::Flags::DisabledByDefault,
+                               OptimizerRule::Flags::CanBeDisabled),
       R"(Replace attribute accesses that are equal due to a filter statement
 with the same value. This might enable other optimizations later on.)");
 

--- a/tests/js/client/aql/aql-optimizer-rule-optimize-projections.js
+++ b/tests/js/client/aql/aql-optimizer-rule-optimize-projections.js
@@ -115,7 +115,7 @@ function optimizerRuleTestSuite () {
         queries = queries.concat([
           // JoinNode
           ["FOR doc1 IN @@cn SORT doc1.indexed1 FOR doc2 IN @@cn FILTER doc1.indexed1 == doc2.indexed1 RETURN doc1._key", jnn, [["_key"], []], 0 ],
-          ["FOR doc1 IN @@cn SORT doc1.indexed1 FOR doc2 IN @@cn FILTER doc1.indexed1 == doc2.indexed1 RETURN [doc1._key, doc2.indexed1]", jnn, [["_key", "indexed1"]], 1 ],
+          ["FOR doc1 IN @@cn SORT doc1.indexed1 FOR doc2 IN @@cn FILTER doc1.indexed1 == doc2.indexed1 RETURN [doc1._key, doc2.indexed1]", jnn, [["_key"], ["indexed1"]], 1 ],
           ["FOR doc1 IN @@cn SORT doc1.indexed1 FOR doc2 IN @@cn FILTER doc1.indexed1 == doc2.indexed1 RETURN [doc1._key, doc2._key, doc2.foo]", jnn, [["_key"], ["_key", "foo"]], 1 ],
         ]);
       }

--- a/tests/js/client/aql/aql-optimizer-rule-replace-equal-attribute-access-noncluster.js
+++ b/tests/js/client/aql/aql-optimizer-rule-replace-equal-attribute-access-noncluster.js
@@ -29,6 +29,9 @@ const _ = require('lodash');
 const database = "ReplaceEqualAccessDatabase";
 
 function optimizerRuleReplaceEqualAttributeAccess() {
+
+  const options = {optimizer: {rules: ["+replace-equal-attribute-accesses"]}};
+
   return {
 
     setUpAll: function () {
@@ -54,7 +57,7 @@ function optimizerRuleReplaceEqualAttributeAccess() {
             return [x, y]
       `;
 
-      const stmt = db._createStatement({query});
+      const stmt = db._createStatement({query, options});
       const plan = stmt.explain().plan;
       assertNotEqual(plan.rules.indexOf("replace-equal-attribute-accesses"), -1);
 
@@ -83,7 +86,7 @@ function optimizerRuleReplaceEqualAttributeAccess() {
             return [x, y, z]
       `;
 
-      const stmt = db._createStatement({query});
+      const stmt = db._createStatement({query, options});
       const plan = stmt.explain().plan;
       assertEqual(plan.rules.indexOf("replace-equal-attribute-accesses"), -1);
     },
@@ -98,7 +101,7 @@ function optimizerRuleReplaceEqualAttributeAccess() {
             return [x, y, z, w]
       `;
       // TODO make the rule more robust and detect more cases
-      const stmt = db._createStatement({query});
+      const stmt = db._createStatement({query, options});
       const plan = stmt.explain().plan;
       assertEqual(plan.rules.indexOf("replace-equal-attribute-accesses"), -1);
     },
@@ -111,7 +114,10 @@ function optimizerRuleReplaceEqualAttributeAccess() {
             return [x.x, y.x]
       `;
 
-      const stmt = db._createStatement({query, options: {optimizer: {rules: ["-join-index-nodes"]}}});
+      const stmt = db._createStatement({
+        query,
+        options: {optimizer: {rules: ["+replace-equal-attribute-accesses", "-join-index-nodes"]}}
+      });
       const plan = stmt.explain().plan;
       assertNotEqual(plan.rules.indexOf("replace-equal-attribute-accesses"), -1);
 
@@ -151,7 +157,7 @@ function optimizerRuleReplaceEqualAttributeAccess() {
             return [a.x, b.x, c.x]
       `;
 
-      const stmt = db._createStatement({query});
+      const stmt = db._createStatement({query, options});
       const plan = stmt.explain().plan;
       assertNotEqual(plan.rules.indexOf("replace-equal-attribute-accesses"), -1);
       assertNotEqual(plan.rules.indexOf("join-index-nodes"), -1);
@@ -182,7 +188,7 @@ function optimizerRuleReplaceEqualAttributeAccess() {
             return [a.x, b.x, c.x]
       `;
 
-      const stmt = db._createStatement({query});
+      const stmt = db._createStatement({query, options});
       const plan = stmt.explain().plan;
       assertNotEqual(plan.rules.indexOf("replace-equal-attribute-accesses"), -1);
       assertNotEqual(plan.rules.indexOf("join-index-nodes"), -1);
@@ -213,7 +219,7 @@ function optimizerRuleReplaceEqualAttributeAccess() {
               return [c, i, j]
       `;
 
-      const stmt = db._createStatement({query});
+      const stmt = db._createStatement({query, options});
       const plan = stmt.explain().plan;
       assertNotEqual(plan.rules.indexOf("replace-equal-attribute-accesses"), -1);
 
@@ -250,7 +256,7 @@ function optimizerRuleReplaceEqualAttributeAccess() {
                 limit 10
                 return [x, i, j, k, m]`;
 
-      const stmt = db._createStatement({query});
+      const stmt = db._createStatement({query, options});
       const plan = stmt.explain().plan;
       assertNotEqual(plan.rules.indexOf("replace-equal-attribute-accesses"), -1);
 


### PR DESCRIPTION
### Scope & Purpose

The `replace-equal-attribute-access` rule now works for subqueries as well. Furthermore, if one side is already a single variable expression, it uses this variable instead of introducing another alias variable.

Finally the optimizer rule was moved after `moveFiltersUpRule2` which ensures that we can replace as many values as possible.