### PR TITLE
Improve compatibiltiy of actor and inspector libraries for move-only types

### DIFF
--- a/arangod/Pregel/Worker/Handler.h
+++ b/arangod/Pregel/Worker/Handler.h
@@ -58,36 +58,37 @@ struct WorkerHandler : actor::HandlerBase<Runtime, WorkerState<V, E, M>> {
   DispatchStatus const& dispatchStatus =
       [this](pregel::message::StatusMessages message) -> void {
     this->template dispatch<pregel::message::StatusMessages>(
-        this->state->statusActor, message);
+        this->state->statusActor, std::move(message));
   };
   DispatchMetrics const& dispatchMetrics =
       [this](metrics::message::MetricsMessages message) -> void {
     this->template dispatch<metrics::message::MetricsMessages>(
-        this->state->metricsActor, message);
+        this->state->metricsActor, std::move(message));
   };
   DispatchConductor const& dispatchConductor =
       [this](conductor::message::ConductorMessages message) -> void {
     this->template dispatch<conductor::message::ConductorMessages>(
-        this->state->conductor, message);
+        this->state->conductor, std::move(message));
   };
   DispatchSelf const& dispatchSelf =
       [this](message::WorkerMessages message) -> void {
-    this->template dispatch<message::WorkerMessages>(this->self, message);
+    this->template dispatch<message::WorkerMessages>(this->self,
+                                                     std::move(message));
   };
   DispatchOther const& dispatchOther =
       [this](actor::DistributedActorPID other,
              message::WorkerMessages message) -> void {
-    this->template dispatch<message::WorkerMessages>(other, message);
+    this->template dispatch<message::WorkerMessages>(other, std::move(message));
   };
   DispatchResult const& dispatchResult =
       [this](pregel::message::ResultMessages message) -> void {
     this->template dispatch<pregel::message::ResultMessages>(
-        this->state->resultActor, message);
+        this->state->resultActor, std::move(message));
   };
   DispatchSpawn const& dispatchSpawn =
       [this](pregel::message::SpawnMessages message) -> void {
     this->template dispatch<pregel::message::SpawnMessages>(
-        this->state->spawnActor, message);
+        this->state->spawnActor, std::move(message));
   };
 
   Dispatcher dispatcher{.dispatchStatus = dispatchStatus,

--- a/lib/Actor/include/Actor/Actor.h
+++ b/lib/Actor/include/Actor/Actor.h
@@ -172,7 +172,8 @@ struct Actor : ActorBase<typename Runtime::ActorPID> {
     pushToQueueAndKick(std::make_unique<InternalMessage>(
         sender,
         std::make_unique<
-            message::MessageOrError<typename Config::Message, ActorPID>>(msg)));
+            message::MessageOrError<typename Config::Message, ActorPID>>(
+            std::move(msg))));
   }
 
   void kick() {
@@ -187,7 +188,7 @@ struct Actor : ActorBase<typename Runtime::ActorPID> {
       state = std::visit(
           typename Config::template Handler<Runtime>{
               {pid, msg->sender, std::move(state), runtime}},
-          msg->payload->item);
+          std::move(msg->payload->item));
       if (--i == 0) {
         break;
       }

--- a/lib/Actor/include/Actor/BaseRuntime.h
+++ b/lib/Actor/include/Actor/BaseRuntime.h
@@ -126,14 +126,14 @@ struct BaseRuntime
   }
 
   template<typename ActorMessage>
-  auto dispatch(ActorPID sender, ActorPID receiver, ActorMessage const& message)
+  auto dispatch(ActorPID sender, ActorPID receiver, ActorMessage&& message)
       -> void {
     self().doDispatch(sender, receiver, message, IgnoreDispatchFailure::no);
   }
 
   template<typename ActorMessage>
   auto dispatchDelayed(std::chrono::seconds delay, ActorPID sender,
-                       ActorPID receiver, ActorMessage const& message) -> void {
+                       ActorPID receiver, ActorMessage&& message) -> void {
     _scheduler->delay(delay, [self = this->weak_from_this(), sender, receiver,
                               message](bool canceled) {
       auto me = self.lock();

--- a/lib/Actor/include/Actor/BaseRuntime.h
+++ b/lib/Actor/include/Actor/BaseRuntime.h
@@ -70,7 +70,7 @@ struct BaseRuntime
     auto address = spawn<ActorConfig>(std::move(initialState));
 
     // Send initial message to newly created actor
-    dispatchLocally(address, address, initialMessage,
+    dispatchLocally(address, address, std::move(initialMessage),
                     IgnoreDispatchFailure::yes);
 
     return address;
@@ -217,10 +217,10 @@ struct BaseRuntime
 
   template<typename ActorMessage>
   auto dispatchLocally(ActorPID sender, ActorPID receiver,
-                       ActorMessage const& message,
+                       ActorMessage&& message,
                        IgnoreDispatchFailure ignoreFailure) -> void {
     auto actor = actors.find(receiver.id);
-    auto payload = MessagePayload<ActorMessage>(std::move(message));
+    MessagePayload<ActorMessage> payload(std::move(message));
     if (actor.has_value()) {
       actor->get()->process(sender, payload);
     } else if (ignoreFailure == IgnoreDispatchFailure::no) {

--- a/lib/Actor/include/Actor/DistributedRuntime.h
+++ b/lib/Actor/include/Actor/DistributedRuntime.h
@@ -77,19 +77,18 @@ struct DistributedRuntime
   }
 
   template<typename ActorMessage>
-  auto doDispatch(ActorPID sender, ActorPID receiver,
-                  ActorMessage const& message,
+  auto doDispatch(ActorPID sender, ActorPID receiver, ActorMessage&& message,
                   IgnoreDispatchFailure ignoreFailure) -> void {
     if (receiver.server == sender.server) {
-      dispatchLocally(sender, receiver, message, ignoreFailure);
+      dispatchLocally(sender, receiver, std::move(message), ignoreFailure);
     } else {
-      dispatchExternally(sender, receiver, message);
+      dispatchExternally(sender, receiver, std::move(message));
     }
   }
 
   template<typename ActorMessage>
   auto dispatchExternally(ActorPID sender, ActorPID receiver,
-                          ActorMessage const& message) -> void {
+                          ActorMessage&& message) -> void {
     auto payload = inspection::serializeWithErrorT(message);
     ACTOR_ASSERT(payload.ok());
     externalDispatcher->dispatch(sender, receiver, payload.get());

--- a/lib/Actor/include/Actor/HandlerBase.h
+++ b/lib/Actor/include/Actor/HandlerBase.h
@@ -39,21 +39,22 @@ struct HandlerBase {
       : self(self), sender(sender), state{std::move(state)}, runtime(runtime){};
 
   template<typename ActorMessage>
-  auto dispatch(ActorPID receiver, ActorMessage message) -> void {
-    runtime->dispatch(self, receiver, message);
+  auto dispatch(ActorPID receiver, ActorMessage&& message) -> void {
+    runtime->dispatch(self, receiver, std::forward<ActorMessage>(message));
   }
 
   template<typename ActorMessage>
   auto dispatchDelayed(std::chrono::seconds delay, ActorPID receiver,
-                       ActorMessage const& message) -> void {
-    runtime->dispatchDelayed(delay, self, receiver, message);
+                       ActorMessage&& message) -> void {
+    runtime->dispatchDelayed(delay, self, receiver,
+                             std::forward<ActorMessage>(message));
   }
 
   template<typename ActorConfig>
   auto spawn(std::unique_ptr<typename ActorConfig::State> initialState,
              typename ActorConfig::Message initialMessage) -> ActorPID {
     return runtime->template spawn<ActorConfig>(std::move(initialState),
-                                                initialMessage);
+                                                std::move(initialMessage));
   }
 
   auto finish(ExitReason reason) -> void { runtime->finishActor(self, reason); }

--- a/lib/Actor/include/Actor/LocalRuntime.h
+++ b/lib/Actor/include/Actor/LocalRuntime.h
@@ -57,10 +57,9 @@ struct LocalRuntime : BaseRuntime<LocalRuntime, LocalActorPID> {
   ActorPID makePid(ActorID id) { return ActorPID{.id = id}; }
 
   template<typename ActorMessage>
-  auto doDispatch(ActorPID sender, ActorPID receiver,
-                  ActorMessage const& message,
+  auto doDispatch(ActorPID sender, ActorPID receiver, ActorMessage&& message,
                   IgnoreDispatchFailure ignoreFailure) -> void {
-    dispatchLocally(sender, receiver, message, ignoreFailure);
+    dispatchLocally(sender, receiver, std::move(message), ignoreFailure);
   }
 };
 

--- a/lib/Inspection/include/Inspection/LoadInspectorBase.h
+++ b/lib/Inspection/include/Inspection/LoadInspectorBase.h
@@ -383,7 +383,7 @@ struct LoadInspectorBase : InspectorBase<Derived, Context> {
       auto v = Factory<typename Arg::Type>::make_value();
       auto res = parse(v);
       if (res.ok()) {
-        result = v;
+        result = std::move(v);
       } else if constexpr (!std::is_same_v<FieldNameFn, std::monostate>) {
         return {std::move(res), fieldName(arg), Status::AttributeTag{}};
       }

--- a/tests/Actor/Actors/TrivialActor.h
+++ b/tests/Actor/Actors/TrivialActor.h
@@ -58,6 +58,10 @@ auto inspect(Inspector& f, TrivialStart& x) {
 
 struct TrivialMessage {
   TrivialMessage() = default;
+  // we intentionally make this message type move-only
+  TrivialMessage(TrivialMessage&) = delete;
+  TrivialMessage(TrivialMessage&&) = default;
+  TrivialMessage& operator=(TrivialMessage&&) = default;
   TrivialMessage(std::string value) : store(std::move(value)) {}
   std::string store;
 };


### PR DESCRIPTION
### Scope & Purpose

Previously the actor library could not handle move-only message types and the inspector could not deserialize move-only types.

### Checklist

- [x] Tests
  - [x] C++ **Unit tests**