### PR TITLE
[CINFRA] Index Creation Race

### DIFF
--- a/arangod/Cluster/ClusterInfo.h
+++ b/arangod/Cluster/ClusterInfo.h
@@ -883,6 +883,11 @@ class ClusterInfo final {
     return _planVersion;
   }
 
+  uint64_t getPlanIndex() const {
+    READ_LOCKER(readLocker, _planProt.lock);
+    return _planIndex;
+  }
+
   uint64_t getCurrentVersion() const {
     READ_LOCKER(guard, _currentProt.lock);
     return _currentVersion;


### PR DESCRIPTION
### Scope & Purpose

The replication2 index creation code (_ensureIndexCoordinatorReplication2Inner_) is affected by a race. This PR provides the fix.

**Problem we're trying to fix**

There are 3 things that have play along:
- clusterInfo.loadPlan()
- callbackRegistry.waitFor()
- clusterInfo.waitForPlan()

The race is as follows:

1. We try to create the index. Coordinator writes index to Target. Agency sees the index in Target, writes it to Plan and increments Plan/Version.
2. Coordinator is slow. Before even registering the callback for the index in Plan, ClusterInfo (via the syncer thread on coordinator) does `loadPlan()` and observes the change (because the plan version is updated). This also updates the raft index in ClusterInfo.
3. Before the coordinator registers the Plan agency callback, something random happens in the agency, say a server goes bad. This pushes the commitIndex further, without modifying the planVersion, therefore not triggering another loadPlan.
4. Coordinator finally registers callbackRegistry.waitFor() for the collection in Plan, which triggers immediately with the initial value, and returns successfully since the index is already there.
5. Subsequent clusterInfo.waitForPlan() never returns because the index observed by callbackRegistry is already higher than the last index which was seen from `loadPlan()`. Another `loadPlan()` does not happen unless Plan/Version is incremented.

For reproducing the issue reliably see https://github.com/arangodb/arangodb/pull/20163

**Solution**

Instead of waiting for the agency's raft Index, we'll make ClusterInfo catch up with the plan version. Since we already have our hands on the raft index, we still quickly check it, just in case we may be able to skip the waitFor. Otherwise, we get the plan version from the agency cache, which is guaranteed to be greater or equal to the plan version observed during index creation, and wait until ClusterInfo catches up with that.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification