### PR TITLE
replace some memory function shims for Windows

### DIFF
--- a/arangod/Aql/Functions.cpp
+++ b/arangod/Aql/Functions.cpp
@@ -2366,14 +2366,15 @@ AqlValue functions::Contains(ExpressionContext* ctx, AstNode const&,
     size_t const searchLength = buffer->length() - valueLength;
 
     if (searchLength > 0) {
-      char const* found = static_cast<char const*>(
-          memmem(buffer->data(), valueLength, buffer->data() + searchOffset,
-                 searchLength));
+      std::string_view haystack(buffer->data(), valueLength);
+      std::string_view needle(buffer->data() + searchOffset, searchLength);
 
-      if (found != nullptr) {
+      size_t found = haystack.find(needle);
+
+      if (found != std::string_view::npos) {
         if (willReturnIndex) {
           // find offset into string
-          int bytePosition = static_cast<int>(found - buffer->data());
+          int bytePosition = static_cast<int>(found);
           char const* p = buffer->data();
           int pos = 0;
           while (pos < bytePosition) {

--- a/client-tools/Restore/RestoreFeature.cpp
+++ b/client-tools/Restore/RestoreFeature.cpp
@@ -1671,17 +1671,16 @@ Result RestoreFeature::RestoreMainJob::restoreData(
           length = buffer->length();
         } else {
           // look for the last \n in the buffer
-          char const* found = static_cast<char const*>(
-              memrchr(static_cast<void const*>(buffer->begin()), '\n',
-                      buffer->length()));
+          std::string_view sv(buffer->begin(), buffer->length());
+          size_t found = sv.rfind('\n');
 
-          if (found == nullptr) {
+          if (found == std::string_view::npos) {
             // no \n in buffer...
             // don't have a complete line yet, read more
             continue;
           }
           // found a \n somewhere; break at line
-          length = found - buffer->begin();
+          length = found;
         }
       }
 

--- a/lib/Basics/operating-system.h
+++ b/lib/Basics/operating-system.h
@@ -113,8 +113,6 @@
 
 #define TRI_OVERLOAD_FUNCS_SIZE_T 1
 
-#define ARANGODB_MISSING_MEMRCHR 1
-
 #define TRI_SC_NPROCESSORS_ONLN 1
 
 // alignment and limits
@@ -611,7 +609,6 @@
 #define TRI_HAVE_WIN32_THREADS 1
 
 #define TRI_HAVE_ANONYMOUS_MMAP 1
-#define ARANGODB_MISSING_MEMRCHR 1
 
 #ifndef va_copy
 #define va_copy(d, s) ((d) = (s))

--- a/lib/Basics/system-functions.cpp
+++ b/lib/Basics/system-functions.cpp
@@ -33,50 +33,6 @@
 using namespace arangodb;
 using namespace arangodb::utilities;
 
-#ifdef ARANGODB_MISSING_MEMRCHR
-void* memrchr(void const* block, int c, size_t size) {
-  if (size) {
-    unsigned char const* p = static_cast<unsigned char const*>(block);
-
-    for (p += size - 1; size; p--, size--) {
-      if (*p == c) {
-        return (void*)p;
-      }
-    }
-  }
-  return nullptr;
-}
-#endif
-
-#ifdef _WIN32
-void* memmem(void const* haystack, size_t haystackLength, void const* needle,
-             size_t needleLength) {
-  if (haystackLength == 0 || needleLength == 0 ||
-      haystackLength < needleLength) {
-    return nullptr;
-  }
-
-  char const* n = static_cast<char const*>(needle);
-
-  if (needleLength == 1) {
-    return memchr(const_cast<void*>(haystack), static_cast<int>(*n),
-                  haystackLength);
-  }
-
-  char const* current = static_cast<char const*>(haystack);
-  char const* end =
-      static_cast<char const*>(haystack) + haystackLength - needleLength;
-
-  for (; current <= end; ++current) {
-    if (*current == *n && memcmp(needle, current, needleLength) == 0) {
-      return const_cast<void*>(static_cast<void const*>(current));
-    }
-  }
-
-  return nullptr;
-}
-#endif
-
 #ifdef TRI_HAVE_WIN32_GETTIMEOFDAY
 int gettimeofday(struct timeval* tv, void* tz) {
   union {

--- a/lib/Basics/system-functions.h
+++ b/lib/Basics/system-functions.h
@@ -27,15 +27,6 @@
 
 #include "Basics/Common.h"
 
-#ifdef ARANGODB_MISSING_MEMRCHR
-void* memrchr(void const* block, int c, size_t size);
-#endif
-
-#ifdef _WIN32
-void* memmem(void const* haystack, size_t haystackLength, void const* needle,
-             size_t needleLength);
-#endif
-
 #ifdef TRI_HAVE_WIN32_GETTIMEOFDAY
 int gettimeofday(struct timeval* tv, void* tz);
 #endif
@@ -52,11 +43,9 @@ time_t TRI_timegm(struct tm*);
 // seconds with microsecond resolution
 double TRI_microtime() noexcept;
 
-namespace arangodb {
-namespace utilities {
+namespace arangodb::utilities {
 // return the current time as string in format "YYYY-MM-DDTHH:MM:SSZ"
 std::string timeString(char sep = 'T', char fin = 'Z');
 
 std::string hostname();
-}  // namespace utilities
-}  // namespace arangodb
+}  // namespace arangodb::utilities


### PR DESCRIPTION
### Scope & Purpose

Remove `memmem` and `memrchr` shims for Windows, and replace the usage of `memmem` and `memrchr` with std::string_view::find/rfind calls.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 