### PR TITLE
Stabilize detach threads test

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 v3.11.6 (XXXX-XX-XX)
 --------------------
 
+* Stabilize detaching of threads test.
+
 * Rebuilt included rclone v1.62.2 with go1.21.4.
 
 * Updated ArangoDB Starter to v0.17.2 and arangosync to v2.19.5.

--- a/tests/js/client/server_parameters/detach-threads-noncluster.js
+++ b/tests/js/client/server_parameters/detach-threads-noncluster.js
@@ -1,5 +1,5 @@
 /* jshint globalstrict:false, strict:false, maxlen: 200 */
-/* global fail, assertEqual, assertTrue, assertFalse, arango */
+/* global fail, assertEqual, assertTrue, assertFalse, arango, getOptions */
 
 // //////////////////////////////////////////////////////////////////////////////
 // / @brief Test detaching threads in scheduler which wait for locks.
@@ -22,6 +22,25 @@
 // /
 // / @author Max Neunhoeffer
 // //////////////////////////////////////////////////////////////////////////////
+
+// We need the following options for this test. We need a specific number 
+// of threads in the scheduler. 60 threads means that there are 30 low
+// priority lane threads. We will post 200 background jobs which will
+// start an exclusive transaction and thus get stuck in a lock.
+// This totally blocks all scheduler threads. If the detaching
+// of scheduler threads waiting for this lock works, then we can Unblock
+// this situation pretty soon (30 threads per second). So after a few
+// seconds, a normal low priority operation will go through again.
+// If you use fewer than 51 threads, then the cluster overwhelm protections
+// will also block the situation since the coordinator will no longer
+// dequeue low priority lane jobs. If you use more than 200 threads, then
+// the test will not test the detaching of threads.
+if (getOptions === true) {
+  return {
+    'server.maximal-threads' : '60',
+    'server.minimal-threads' : '60'
+  };
+}
 
 const _ = require('lodash');
 const console = require('console');


### PR DESCRIPTION
The test in question needs a certain number of threads and is unstable
otherwise. Therefore it is moved to the server_parameters suite and a
specific number of threads is used. This makes it stable.

- Fix test.
- CHANGELOG.

### Scope & Purpose

*(Please describe the changes in this PR for reviewers, motivation, rationale - **mandatory**)*

- [*] :hankey: Bugfix

### Checklist

- [*] Tests
  - [*] **integration tests**
- [*] :book: CHANGELOG entry made
- [*] Backports
  - [*] Backport for 3.11: This is the backport for 3.11

#### Related Information

- [*] PR with the corresponding change for devel: https://github.com/arangodb/arangodb/pull/20162, 3.10 is not affected.

