### PR TITLE
[CINFRA] Extra logging in case of failure

### DIFF
--- a/js/common/modules/@arangodb/testutils/document-state-helper.js
+++ b/js/common/modules/@arangodb/testutils/document-state-helper.js
@@ -323,9 +323,8 @@ const logIfFailure = function (fun, msg, dumpObjects) {
     if (dumpObjects !== undefined) {
       // dump collections
       if (dumpObjects.hasOwnProperty('collections')) {
-        let collections = {}
+        let collections = {};
         for (const collection of dumpObjects.collections) {
-
           try {
             collections[collection.name()] = collection.toArray();
           } catch (e) {
@@ -337,13 +336,15 @@ const logIfFailure = function (fun, msg, dumpObjects) {
 
       // dump logs
       if (dumpObjects.hasOwnProperty('logs')) {
+        let logs = {};
         for (const log of dumpObjects.logs) {
           try {
-            dumpMsg[log.id()] = log.head(1000);
+            logs[log.id()] = log.head(1000);
           } catch (e) {
-            dumpMsg[log.id()] = e;
+            logs[log.id()] = e;
           }
         }
+        dumpMsg['logs'] = logs;
       }
     }
 

--- a/tests/js/server/replication2/replication2-replicated-state-document-store.js
+++ b/tests/js/server/replication2/replication2-replicated-state-document-store.js
@@ -101,7 +101,10 @@ const replicatedStateDocumentStoreSuiteReplication2 = function () {
     testReplicateOperationsCommit: function() {
       const opType = "Commit";
 
-      collection.insert({_key: "abcd"});
+      dh.logIfFailure(() => {
+        collection.insert({_key: "abcd"});
+      }, `Failed to insert document in collection ${collectionName}`,{collections: [collection]});
+
       const mergedLogs = dh.mergeLogs(logs);
       let commitEntries = dh.getDocumentEntries(mergedLogs, opType);
       let insertEntries = dh.getDocumentEntries(mergedLogs, "Insert");
@@ -118,12 +121,16 @@ const replicatedStateDocumentStoreSuiteReplication2 = function () {
 
       // Insert single document
       let documents = [{_key: "foo"}, {_key: "bar"}];
-      documents.forEach(doc => collection.insert(doc));
+      dh.logIfFailure(() => {
+        documents.forEach(doc => collection.insert(doc));
+      }, `Failed to insert documents in collection ${collectionName}`, {collections: [collection]});
       dh.searchDocs(logs, documents, opType);
 
       // Insert multiple documents
       documents = [...Array(10).keys()].map(i => {return {name: "testInsert1", foobar: i};});
-      collection.insert(documents);
+      dh.logIfFailure(() => {
+        collection.insert(documents);
+      }, `Failed to insert documents in collection ${collectionName}`, {collections: [collection]});
       let result = dh.getArrayElements(logs, opType, "testInsert1");
       for (const doc of documents) {
         assertTrue(result.find(entry => entry.foobar === doc.foobar) !== undefined);
@@ -597,7 +604,9 @@ const replicatedStateRecoverySuite = function () {
         documents.push({_key: `${testName}-${counter}`, value: counter, temporary: counter});
       }
       for (let idx = 0; idx < documents.length; ++idx) {
-        collection.insert(documents[idx]);
+        dh.logIfFailure(() => {
+          collection.insert(documents[idx]);
+        }, `Failed to insert document ${JSON.stringify(documents[idx])}`, {collections: [collection], logs: [log]});
       }
 
       // The following operation will be used to trigger errors, which should be ignored during recovery.
@@ -632,13 +641,17 @@ const replicatedStateRecoverySuite = function () {
 
       // Insert a doc that has the same temporary as an existing one.
       // When the index creation is going to be replayed, it will fail, but the error should be ignored.
-      collection.insert({_key: `${testName}-temporary`, value: 1234567, temporary: 0});
+      dh.logIfFailure(() => {
+        collection.insert({_key: `${testName}-temporary`, value: 1234567, temporary: 0});
+      }, `Failed to insert document`, {collections: [collection], logs: [log]});
 
       // Insert two docs that have a common property
       const commonDoc1 = {_key: `${testName}-common1`, value: 1234};
       const commonDoc2 = {_key: `${testName}-common2`, value: 1234};
-      collection.insert(commonDoc1);
-      collection.insert(commonDoc2);
+      dh.logIfFailure(() => {
+        collection.insert(commonDoc1);
+        collection.insert(commonDoc2);
+      }, `Failed to insert document`, {collections: [collection], logs: [log]});
       // Delete the first doc
       collection.remove(commonDoc1);
       // Create an unique index. When commonDoc1 insertion is replayed, it should trigger a unique constraint violation.
@@ -681,7 +694,9 @@ const replicatedStateRecoverySuite = function () {
       const commitIndexAfterCreateShard = status.participants[leader].response.local.commitIndex + 1;
 
       // Because the last entry (i.e. CreateShard) is always kept in the log, insert another one on top.
-      col2.insert({_key: `${testName}-a`});
+      dh.logIfFailure(() => {
+        col2.insert({_key: `${testName}-a`});
+      }, `Failed to insert document`, {collections: [collection, col2], logs: [log]});
 
       let logContents = log.head(1000);
 
@@ -757,7 +772,9 @@ const replicatedStateRecoverySuite = function () {
       extraCollections = [];
 
       // Before switching to a new leader, insert some documents into the leader collection.
-      collection.insert({_key: `${testName}-foo1`, value: `${testName}-bar1`});
+      dh.logIfFailure(() => {
+        collection.insert({_key: `${testName}-foo1`, value: `${testName}-bar1`});
+      }, `Failed to insert document`, {collections: [collection], logs: [log]});
 
       // The following shard modification should not affect previously inserted documents.
       collection.properties({computedValues: [{
@@ -769,7 +786,9 @@ const replicatedStateRecoverySuite = function () {
       lh.waitFor(dh.computedValuesAppliedPredicate(collection, "createdAt"));
 
       // The following document should have a createdAt value.
-      collection.insert({_key: `${testName}-foo2`, value: `${testName}-bar2`});
+      dh.logIfFailure(() => {
+        collection.insert({_key: `${testName}-foo2`, value: `${testName}-bar2`});
+      }, `Failed to insert document`, {collections: [collection], logs: [log]});
 
       logContents = log.head(1000);
 
@@ -813,8 +832,10 @@ const replicatedStateRecoverySuite = function () {
           numberOfShards: 1,
           distributeShardsLike: collectionName,
         });
-        col.insert({_key: `${testName}-${counter}`});
         extraCollections.push(col);
+        dh.logIfFailure(() => {
+          col.insert({_key: `${testName}-${counter}`});
+        }, `Failed to insert document`, {collections: [...extraCollections, collection], logs: [log]});
       }
 
       // Wait for operations to be synced to disk
@@ -948,9 +969,11 @@ const replicatedStateSnapshotTransferSuite = function () {
       extraCollections.push(col2);
 
       // Insert a document into each collection, so the shards are not empty.
-      collection.insert({_key: testName});
-      col1.insert({_key: testName});
-      col2.insert({_key: testName});
+      dh.logIfFailure(() => {
+        collection.insert({_key: testName});
+        col1.insert({_key: testName});
+        col2.insert({_key: testName});
+      }, `Failed to insert document`, {collections: [collection, col1, col2], logs: [log]});
 
       const participants = lhttp.listLogs(coordinator, database).result[logId];
       let leaderUrl = lh.getServerUrl(participants[0]);
@@ -995,8 +1018,10 @@ const replicatedStateSnapshotTransferSuite = function () {
           numberOfShards: 1,
           distributeShardsLike: collectionName,
         });
-        col.insert({_key: `${testName}-${counter}`});
         extraCollections.push(col);
+        dh.logIfFailure(() => {
+          col.insert({_key: `${testName}-${counter}`});
+        }, `Failed to insert document`, {collections: [...extraCollections, collection], logs: [log]});
       }
 
       // Insert some documents into the original collection.
@@ -1006,7 +1031,9 @@ const replicatedStateSnapshotTransferSuite = function () {
         documents1.push({_key: `foo-${testName}-${counter}`});
       }
       for (let idx = 0; idx < documents1.length; ++idx) {
-        collection.insert(documents1[idx]);
+        dh.logIfFailure(() => {
+          collection.insert(documents1[idx]);
+        }, `Failed to insert document ${JSON.stringify(documents1[idx])}`, {collections: [...extraCollections, collection], logs: [log]});
       }
 
       // Wait for operations to be synced to disk
@@ -1029,7 +1056,9 @@ const replicatedStateSnapshotTransferSuite = function () {
         documents2.push({_key: `bar-${testName}-${counter}`});
       }
       for (let idx = 0; idx < documents2.length; ++idx) {
-        collection.insert(documents2[idx]);
+        dh.logIfFailure(() => {
+          collection.insert(documents2[idx]);
+        }, `Failed to insert document ${JSON.stringify(documents2[idx])}`, {collections: [...extraCollections, collection], logs: [log]});
       }
 
       // The following shard modification should not affect previously inserted documents.
@@ -1237,13 +1266,11 @@ const replicatedStateSnapshotTransferSuite = function () {
 
       // Insert a couple of documents, so there's something for the snapshot,
       // then compact the log in order to trigger a snapshot transfer next time a server is added.
-      try {
+      dh.logIfFailure(() => {
         for (let i = 0; i < 10; ++i) {
           collection.insert({_key: `${testName}_${i}`});
         }
-      } catch (e) {
-        throw new Error(`Failed to insert documents, error: ${e}, logId: ${logId}, log contents: ${JSON.stringify(log.head(1000))}`);
-      }
+      }, `Failed to insert document`, {collections: [collection], logs: [log]});
 
       // Wait for operations to be synced to disk
       let status = log.status();
@@ -1327,17 +1354,23 @@ const replicatedStateSnapshotTransferSuite = function () {
       const stopFollower = _.without(operational, leader)[0];
       stopServerWait(stopFollower);
       lh.waitFor(checkEffectiveWriteConcern(2));
-      collection.insert({_key: `${testName}_bar`});
+      dh.logIfFailure(() => {
+        collection.insert({_key: `${testName}_bar`});
+      }, `Failed to insert document`, {collections: [collection], logs: [log]});
 
       // Now we can finish the snapshot transfer. This should raise the effective write concern to 3.
       helper.debugClearFailAt(lh.getServerUrl(leader), "DocumentStateSnapshot::infiniteSnapshot");
       lh.waitFor(checkEffectiveWriteConcern(3));
-      collection.insert({_key: `${testName}_baz`});
+      dh.logIfFailure(() => {
+        collection.insert({_key: `${testName}_baz`});
+      }, `Failed to insert document`, {collections: [collection], logs: [log]});
 
       // Resuming the follower should raise the effective write concern to 4.
       continueServerWait(stopFollower);
       lh.waitFor(checkEffectiveWriteConcern(4));
-      collection.insert({_key: `${testName}_kuh`});
+      dh.logIfFailure(() => {
+        collection.insert({_key: `${testName}_kuh`});
+      }, `Failed to insert document`, {collections: [collection], logs: [log]});
     }
   };
 };
@@ -1528,11 +1561,17 @@ const replicatedStateDocumentShardsSuite = function () {
           computeOn: ["insert"]
         }]});
 
+      // Get the log id.
+      const {logId, shardId} = dh.getSingleLogId(database, collection);
+      let log = db._replicatedLog(logId);
+
       // Wait for the shard to be modified.
       let cnt = 0;
       lh.waitFor(() => {
         ++cnt;
-        collection.insert({_key: `bar${cnt}`});
+        dh.logIfFailure(() => {
+          collection.insert({_key: `bar${cnt}`});
+        }, `Failed to insert document`, {collections: [collection], logs: [log]});
         let doc = collection.document(`bar${cnt}`);
         if ("createdAt" in doc) {
           return true;
@@ -1541,11 +1580,8 @@ const replicatedStateDocumentShardsSuite = function () {
       });
       const firstTermCollection = collection.toArray();
 
-      // Get the log id.
-      const {logId, shardId} = dh.getSingleLogId(database, collection);
-
       // Check if the ModifyShard command appears in the log during the current term.
-      let logContents = lh.dumpLogHead(logId);
+      let logContents = log.head(1000);
       let modifyShardEntryFound = _.some(logContents, entry => {
         if (entry.payload === undefined) {
           return false;
@@ -1565,7 +1601,9 @@ const replicatedStateDocumentShardsSuite = function () {
       lh.waitFor(lp.replicatedLogLeaderEstablished(database, logId, newTerm, followers));
 
       // The new leader should have executed the ModifyShard command.
-      collection.insert({_key: "foo"});
+      dh.logIfFailure(() => {
+        collection.insert({_key: "foo"});
+      }, `Failed to insert document`, {collections: [collection], logs: [log]});
       let doc = collection.document("foo");
       assertTrue('createdAt' in doc, JSON.stringify(doc));
 
@@ -1605,7 +1643,9 @@ const replicatedStateDocumentShardsSuite = function () {
 
       // Inserting docs into the collection, so there's something for the snapshot.
       for (let idx = 0; idx < 10; ++idx) {
-        collection.insert({_key: `${testName}-${idx}`});
+        dh.logIfFailure(() => {
+          collection.insert({_key: `${testName}-${idx}`});
+        }, `Failed to insert document`, {collections: [collection], logs: [log]});
       }
 
       // Wait for operations to be synced to disk


### PR DESCRIPTION
### Scope & Purpose

There's been a few cases (quite rarely) when I noticed something really weird: we try to insert a key into a newly created replication2 collection and fail. The key is definitely unique, there's no way it could have been there before, yet we get a unique constraint violation.
For example:
```
ArangoError: unique constraint violated - in index primary of type primary over '_key'; conflicting key: testDoubleCreateDropIndex-0
```
Inspecting the agency shows nothing wrong (I would've expected to see at least some failover).

**This PR adds extra logging information that should aid in investigating such failures.**

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification