### PR TITLE
Split Graphs.h/Graphs.cpp and cleanup

### DIFF
--- a/arangod/Aql/Ast.cpp
+++ b/arangod/Aql/Ast.cpp
@@ -33,7 +33,6 @@
 #include "Aql/Expression.h"
 #include "Aql/FixedVarExpressionContext.h"
 #include "Aql/Function.h"
-#include "Aql/Graphs.h"
 #include "Aql/ModificationOptions.h"
 #include "Aql/Quantifier.h"
 #include "Aql/QueryContext.h"

--- a/arangod/Aql/CMakeLists.txt
+++ b/arangod/Aql/CMakeLists.txt
@@ -49,6 +49,8 @@ add_library(arango_aql STATIC
   DocumentExpressionContext.cpp
   DocumentProducingHelper.cpp
   DocumentProducingNode.cpp
+  EdgeConditionBuilder.cpp
+  EdgeConditionBuilderContainer.cpp
   EngineInfoContainerCoordinator.cpp
   EngineInfoContainerDBServerServerBased.cpp
   EnumerateCollectionExecutor.cpp
@@ -70,7 +72,6 @@ add_library(arango_aql STATIC
   Functions.cpp
   GraphNode.cpp
   GraphOptimizerRules.cpp
-  Graphs.cpp
   HashedCollectExecutor.cpp
   IResearchViewNode.cpp
   IResearchViewOptimizerRules.cpp

--- a/arangod/Aql/EdgeConditionBuilder.cpp
+++ b/arangod/Aql/EdgeConditionBuilder.cpp
@@ -1,0 +1,124 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2023 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Michael Hackstein
+////////////////////////////////////////////////////////////////////////////////
+
+#include "EdgeConditionBuilder.h"
+
+#include <velocypack/Iterator.h>
+
+#include "Aql/Ast.h"
+#include "Aql/AstNode.h"
+#include "Basics/StaticStrings.h"
+#include "Basics/VelocyPackHelper.h"
+#include "Graph/Graph.h"
+
+using namespace arangodb::basics;
+using namespace arangodb::aql;
+
+EdgeConditionBuilder::EdgeConditionBuilder(Ast* ast,
+                                           EdgeConditionBuilder const& other)
+    : _fromCondition(nullptr),
+      _toCondition(nullptr),
+      _modCondition(nullptr),
+      _containsCondition(false),
+      _resourceMonitor(ast->query().resourceMonitor()) {
+  if (other._modCondition != nullptr) {
+    TRI_ASSERT(other._modCondition->type == NODE_TYPE_OPERATOR_NARY_AND);
+
+    _modCondition = ast->createNodeNaryOperator(NODE_TYPE_OPERATOR_NARY_AND);
+    TRI_ASSERT(_modCondition != nullptr);
+
+    size_t n = other._modCondition->numMembers();
+    if (other._containsCondition) {
+      TRI_ASSERT(n > 0);
+      n = n - 1;
+    }
+    _modCondition->reserve(n);
+    for (size_t i = 0; i < n; ++i) {
+      _modCondition->addMember(other._modCondition->getMember(i));
+    }
+  }
+}
+
+EdgeConditionBuilder::EdgeConditionBuilder(
+    AstNode* modCondition, arangodb::ResourceMonitor& resourceMonitor)
+    : _fromCondition(nullptr),
+      _toCondition(nullptr),
+      _modCondition(modCondition),
+      _containsCondition(false),
+      _resourceMonitor(resourceMonitor) {
+  if (_modCondition != nullptr) {
+    TRI_ASSERT(_modCondition->type == NODE_TYPE_OPERATOR_NARY_AND);
+  }
+}
+
+void EdgeConditionBuilder::addConditionPart(AstNode const* part) {
+  TRI_ASSERT(_modCondition != nullptr);
+  TRI_ASSERT(_modCondition->type == NODE_TYPE_OPERATOR_NARY_AND);
+  TRI_ASSERT(!_containsCondition);
+  // The ordering is only maintained before we request a specific
+  // condition
+  _modCondition->addMember(part);
+}
+
+void EdgeConditionBuilder::swapSides(AstNode* cond) {
+  TRI_ASSERT(cond != nullptr);
+  TRI_ASSERT(cond == _fromCondition || cond == _toCondition);
+  TRI_ASSERT(cond->type == NODE_TYPE_OPERATOR_BINARY_EQ);
+  if (_containsCondition) {
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+    // If used correctly this class guarantuees that the last element
+    // of the nary-and is the _from or _to part and is exchangable.
+    TRI_ASSERT(_modCondition->numMembers() > 0);
+    auto changeNode =
+        _modCondition->getMemberUnchecked(_modCondition->numMembers() - 1);
+    TRI_ASSERT(changeNode == _fromCondition || changeNode == _toCondition);
+#endif
+    _modCondition->changeMember(_modCondition->numMembers() - 1, cond);
+  } else {
+    _modCondition->addMember(cond);
+    _containsCondition = true;
+  }
+  TRI_ASSERT(_modCondition->numMembers() > 0);
+}
+
+AstNode* EdgeConditionBuilder::getOutboundCondition() {
+  if (_fromCondition == nullptr) {
+    buildFromCondition();
+  }
+  TRI_ASSERT(_fromCondition != nullptr);
+  swapSides(_fromCondition);
+  return _modCondition;
+}
+
+AstNode* EdgeConditionBuilder::getInboundCondition() {
+  if (_toCondition == nullptr) {
+    buildToCondition();
+  }
+  TRI_ASSERT(_toCondition != nullptr);
+  swapSides(_toCondition);
+  return _modCondition;
+}
+
+arangodb::ResourceMonitor& EdgeConditionBuilder::resourceMonitor() {
+  return _resourceMonitor;
+}

--- a/arangod/Aql/EdgeConditionBuilder.h
+++ b/arangod/Aql/EdgeConditionBuilder.h
@@ -1,0 +1,101 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2023 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Michael Hackstein
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "Aql/VariableGenerator.h"
+
+namespace arangodb {
+
+namespace velocypack {
+class Builder;
+class Slice;
+}  // namespace velocypack
+
+namespace aql {
+struct AstNode;
+
+// Helper class to generate AQL AstNode conditions
+// that can be handed over to Indexes in order to
+// query the data.
+// This class does NOT take responsibility
+// of the referenced AstNodes, the creater
+// has to free them.
+// In AQL the AST is responsible to free all nodes.
+class EdgeConditionBuilder {
+ protected:
+  /// @brief a condition checking for _from
+  /// not used directly
+  AstNode* _fromCondition;
+
+  /// @brief a condition checking for _to
+  /// not used directly
+  AstNode* _toCondition;
+
+  /// @brief the temporary condition to ask indexes
+  /// Is always in Normalized format: One n-ary-and
+  /// branch of a DNF => No OR contained.
+  AstNode* _modCondition;
+
+  /// @brief indicator if we have attached the _from or _to condition to
+  /// _modCondition
+  bool _containsCondition;
+
+  EdgeConditionBuilder(Ast*, EdgeConditionBuilder const&);
+  explicit EdgeConditionBuilder(AstNode*,
+                                arangodb::ResourceMonitor& resourceMonitor);
+
+  // Create the _fromCondition for the first time.
+  virtual void buildFromCondition() = 0;
+
+  // Create the _toCondition for the first time.
+  virtual void buildToCondition() = 0;
+
+ public:
+  virtual ~EdgeConditionBuilder() = default;
+
+  EdgeConditionBuilder(EdgeConditionBuilder const&) = delete;
+  EdgeConditionBuilder(EdgeConditionBuilder&&) = delete;
+
+  // Add a condition on the edges that is not related to
+  // the direction e.g. `label == foo`
+  void addConditionPart(AstNode const*);
+
+  // Get the complete condition for outbound edges
+  AstNode* getOutboundCondition();
+
+  // Get the complete condition for inbound edges
+  AstNode* getInboundCondition();
+
+  // Get the resource monitor
+  arangodb::ResourceMonitor& resourceMonitor();
+
+ private:
+  // Internal helper to swap _from and _to parts
+  void swapSides(AstNode* condition);
+
+  arangodb::ResourceMonitor& _resourceMonitor;
+};
+
+}  // namespace aql
+}  // namespace arangodb

--- a/arangod/Aql/EdgeConditionBuilderContainer.cpp
+++ b/arangod/Aql/EdgeConditionBuilderContainer.cpp
@@ -20,6 +20,7 @@
 ///
 /// @author Michael Hackstein
 ////////////////////////////////////////////////////////////////////////////////
+#include "EdgeConditionBuilderContainer.h"
 
 #include <velocypack/Iterator.h>
 
@@ -28,99 +29,9 @@
 #include "Basics/StaticStrings.h"
 #include "Basics/VelocyPackHelper.h"
 #include "Graph/Graph.h"
-#include "Graphs.h"
 
 using namespace arangodb::basics;
 using namespace arangodb::aql;
-
-EdgeConditionBuilder::EdgeConditionBuilder(Ast* ast,
-                                           EdgeConditionBuilder const& other)
-    : _fromCondition(nullptr),
-      _toCondition(nullptr),
-      _modCondition(nullptr),
-      _containsCondition(false),
-      _resourceMonitor(ast->query().resourceMonitor()) {
-  if (other._modCondition != nullptr) {
-    TRI_ASSERT(other._modCondition->type == NODE_TYPE_OPERATOR_NARY_AND);
-
-    _modCondition = ast->createNodeNaryOperator(NODE_TYPE_OPERATOR_NARY_AND);
-    TRI_ASSERT(_modCondition != nullptr);
-
-    size_t n = other._modCondition->numMembers();
-    if (other._containsCondition) {
-      TRI_ASSERT(n > 0);
-      n = n - 1;
-    }
-    _modCondition->reserve(n);
-    for (size_t i = 0; i < n; ++i) {
-      _modCondition->addMember(other._modCondition->getMember(i));
-    }
-  }
-}
-
-EdgeConditionBuilder::EdgeConditionBuilder(
-    AstNode* modCondition, arangodb::ResourceMonitor& resourceMonitor)
-    : _fromCondition(nullptr),
-      _toCondition(nullptr),
-      _modCondition(modCondition),
-      _containsCondition(false),
-      _resourceMonitor(resourceMonitor) {
-  if (_modCondition != nullptr) {
-    TRI_ASSERT(_modCondition->type == NODE_TYPE_OPERATOR_NARY_AND);
-  }
-}
-
-void EdgeConditionBuilder::addConditionPart(AstNode const* part) {
-  TRI_ASSERT(_modCondition != nullptr);
-  TRI_ASSERT(_modCondition->type == NODE_TYPE_OPERATOR_NARY_AND);
-  TRI_ASSERT(!_containsCondition);
-  // The ordering is only maintained before we request a specific
-  // condition
-  _modCondition->addMember(part);
-}
-
-void EdgeConditionBuilder::swapSides(AstNode* cond) {
-  TRI_ASSERT(cond != nullptr);
-  TRI_ASSERT(cond == _fromCondition || cond == _toCondition);
-  TRI_ASSERT(cond->type == NODE_TYPE_OPERATOR_BINARY_EQ);
-  if (_containsCondition) {
-#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
-    // If used correctly this class guarantuees that the last element
-    // of the nary-and is the _from or _to part and is exchangable.
-    TRI_ASSERT(_modCondition->numMembers() > 0);
-    auto changeNode =
-        _modCondition->getMemberUnchecked(_modCondition->numMembers() - 1);
-    TRI_ASSERT(changeNode == _fromCondition || changeNode == _toCondition);
-#endif
-    _modCondition->changeMember(_modCondition->numMembers() - 1, cond);
-  } else {
-    _modCondition->addMember(cond);
-    _containsCondition = true;
-  }
-  TRI_ASSERT(_modCondition->numMembers() > 0);
-}
-
-AstNode* EdgeConditionBuilder::getOutboundCondition() {
-  if (_fromCondition == nullptr) {
-    buildFromCondition();
-  }
-  TRI_ASSERT(_fromCondition != nullptr);
-  swapSides(_fromCondition);
-  return _modCondition;
-}
-
-AstNode* EdgeConditionBuilder::getInboundCondition() {
-  if (_toCondition == nullptr) {
-    buildToCondition();
-  }
-  TRI_ASSERT(_toCondition != nullptr);
-  swapSides(_toCondition);
-  return _modCondition;
-}
-
-arangodb::ResourceMonitor& EdgeConditionBuilder::resourceMonitor() {
-  return _resourceMonitor;
-}
 
 EdgeConditionBuilderContainer::EdgeConditionBuilderContainer(
     arangodb::ResourceMonitor& resourceMonitor)

--- a/arangod/Aql/EdgeConditionBuilderContainer.h
+++ b/arangod/Aql/EdgeConditionBuilderContainer.h
@@ -23,6 +23,7 @@
 
 #pragma once
 
+#include "Aql/EdgeConditionBuilder.h"
 #include "Aql/VariableGenerator.h"
 
 namespace arangodb {
@@ -34,68 +35,6 @@ class Slice;
 
 namespace aql {
 struct AstNode;
-
-// Helper class to generate AQL AstNode conditions
-// that can be handed over to Indexes in order to
-// query the data.
-// This class does NOT take responsibility
-// of the referenced AstNodes, the creater
-// has to free them.
-// In AQL the AST is responsible to free all nodes.
-class EdgeConditionBuilder {
- protected:
-  /// @brief a condition checking for _from
-  /// not used directly
-  AstNode* _fromCondition;
-
-  /// @brief a condition checking for _to
-  /// not used directly
-  AstNode* _toCondition;
-
-  /// @brief the temporary condition to ask indexes
-  /// Is always in Normalized format: One n-ary-and
-  /// branch of a DNF => No OR contained.
-  AstNode* _modCondition;
-
-  /// @brief indicator if we have attached the _from or _to condition to
-  /// _modCondition
-  bool _containsCondition;
-
-  EdgeConditionBuilder(Ast*, EdgeConditionBuilder const&);
-  explicit EdgeConditionBuilder(AstNode*,
-                                arangodb::ResourceMonitor& resourceMonitor);
-
-  // Create the _fromCondition for the first time.
-  virtual void buildFromCondition() = 0;
-
-  // Create the _toCondition for the first time.
-  virtual void buildToCondition() = 0;
-
- public:
-  virtual ~EdgeConditionBuilder() = default;
-
-  EdgeConditionBuilder(EdgeConditionBuilder const&) = delete;
-  EdgeConditionBuilder(EdgeConditionBuilder&&) = delete;
-
-  // Add a condition on the edges that is not related to
-  // the direction e.g. `label == foo`
-  void addConditionPart(AstNode const*);
-
-  // Get the complete condition for outbound edges
-  AstNode* getOutboundCondition();
-
-  // Get the complete condition for inbound edges
-  AstNode* getInboundCondition();
-
-  // Get the resource monitor
-  arangodb::ResourceMonitor& resourceMonitor();
-
- private:
-  // Internal helper to swap _from and _to parts
-  void swapSides(AstNode* condition);
-
-  arangodb::ResourceMonitor& _resourceMonitor;
-};
 
 // Wrapper around EdgeConditionBuilder that takes responsibility for all
 // AstNodes created with it. Can be used outside of an AQL query.

--- a/arangod/Aql/EdgeConditionBuilderContainer.h
+++ b/arangod/Aql/EdgeConditionBuilderContainer.h
@@ -23,15 +23,14 @@
 
 #pragma once
 
+#include "Aql/AstNode.h"
 #include "Aql/EdgeConditionBuilder.h"
+#include "Aql/Variable.h"
 #include "Aql/VariableGenerator.h"
 
-namespace arangodb {
+#include "Basics/ResourceUsage.h"
 
-namespace velocypack {
-class Builder;
-class Slice;
-}  // namespace velocypack
+namespace arangodb {
 
 namespace aql {
 struct AstNode;

--- a/arangod/Aql/EnumeratePathsNode.h
+++ b/arangod/Aql/EnumeratePathsNode.h
@@ -25,7 +25,6 @@
 #pragma once
 
 #include "Aql/GraphNode.h"
-#include "Aql/Graphs.h"
 #include "Graph/PathType.h"
 #include "Graph/Providers/BaseProviderOptions.h"
 #include "Graph/Options/TwoSidedEnumeratorOptions.h"

--- a/arangod/Aql/GraphNode.h
+++ b/arangod/Aql/GraphNode.h
@@ -25,7 +25,6 @@
 
 #include "Aql/ExecutionNode.h"
 #include "Aql/ExecutionNodeId.h"
-#include "Aql/Graphs.h"
 #include "Aql/types.h"
 #include "Cluster/ClusterTypes.h"
 #include "Transaction/OperationOrigin.h"

--- a/arangod/Aql/QueryContext.h
+++ b/arangod/Aql/QueryContext.h
@@ -24,7 +24,6 @@
 #pragma once
 
 #include "Aql/Collections.h"
-#include "Aql/Graphs.h"
 #include "Aql/QueryExecutionState.h"
 #include "Aql/QueryOptions.h"
 #include "Aql/QueryWarnings.h"

--- a/arangod/Aql/ShortestPathNode.h
+++ b/arangod/Aql/ShortestPathNode.h
@@ -24,7 +24,6 @@
 #pragma once
 
 #include "Aql/GraphNode.h"
-#include "Aql/Graphs.h"
 #include "Graph/Options/TwoSidedEnumeratorOptions.h"
 #include "Graph/PathManagement/PathValidatorOptions.h"
 #include "ShortestPathExecutor.h"

--- a/arangod/Aql/TraversalNode.h
+++ b/arangod/Aql/TraversalNode.h
@@ -23,8 +23,8 @@
 
 #pragma once
 
+#include "Aql/EdgeConditionBuilder.h"
 #include "Aql/GraphNode.h"
-#include "Aql/Graphs.h"
 #include "Aql/PruneExpressionEvaluator.h"
 #include "Aql/TraversalExecutor.h"
 #include "Graph/Types/UniquenessLevel.h"

--- a/arangod/Graph/Graph.cpp
+++ b/arangod/Graph/Graph.cpp
@@ -32,7 +32,6 @@
 
 #include "ApplicationFeatures/ApplicationServer.h"
 #include "Aql/AstNode.h"
-#include "Aql/Graphs.h"
 #include "Aql/Query.h"
 #include "Basics/ReadLocker.h"
 #include "Basics/StaticStrings.h"

--- a/arangod/Graph/GraphManager.cpp
+++ b/arangod/Graph/GraphManager.cpp
@@ -33,7 +33,6 @@
 
 #include "ApplicationFeatures/ApplicationServer.h"
 #include "Aql/AstNode.h"
-#include "Aql/Graphs.h"
 #include "Aql/Query.h"
 #include "Aql/QueryOptions.h"
 #include "Basics/ReadLocker.h"

--- a/arangod/Pregel/IndexHelpers.h
+++ b/arangod/Pregel/IndexHelpers.h
@@ -26,7 +26,7 @@
 #include <memory>
 #include <string>
 
-#include "Aql/Graphs.h"
+#include "Aql/EdgeConditionBuilderContainer.h"
 #include "Indexes/IndexIterator.h"
 
 namespace arangodb {

--- a/arangod/RestHandler/RestEdgesHandler.cpp
+++ b/arangod/RestHandler/RestEdgesHandler.cpp
@@ -25,7 +25,6 @@
 
 #include "ApplicationFeatures/ApplicationServer.h"
 #include "Aql/AstNode.h"
-#include "Aql/Graphs.h"
 #include "Aql/Query.h"
 #include "Aql/QueryString.h"
 #include "Aql/Variable.h"


### PR DESCRIPTION
Technically part of one of the Graph Refactors or cleanups: Graphs.h/Graphs.cpp
contained two classes: EdgeConditionBuilder and EdgeConditionBuilderContainer.

Split those files into the two headers and only include them wehere they are used.

Requires Enterprise PR: https://github.com/arangodb/enterprise/pull/1415