### PR TITLE
prevent starvation in RW lock code

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 v3.10.12 (XXXX-XX-XX)
 ---------------------
 
+* Fixed a problem in ReadWriteLock which could prevent waiting readers from
+  being woken up, when a write lock acquire timed out.
+
 * FE-395: Fix query editor map not loading.
 
 * Rebuilt included rclone v1.59.0 with go1.21.4.

--- a/lib/Basics/ReadWriteLock.cpp
+++ b/lib/Basics/ReadWriteLock.cpp
@@ -92,16 +92,14 @@ bool ReadWriteLock::tryLockWriteFor(std::chrono::microseconds timeout) {
   auto state = _state.fetch_sub(QUEUED_WRITER_INC, std::memory_order_relaxed) -
                QUEUED_WRITER_INC;
 
-  if (state == 0) {
-    // no queued writers and no locks acquired
-    // no more writers -> wake up any waiting readings
-    { std::lock_guard<std::mutex> guard(_reader_mutex); }
-    _readers_bell.notify_all();
-  } else if ((state & QUEUED_WRITER_MASK) != 0 && (state & WRITE_LOCK) == 0) {
-    // there are other writers waiting and the lock is not acquired -> wake up
-    // one of them
-    { std::lock_guard<std::mutex> guard(_writer_mutex); }
-    _writers_bell.notify_one();
+  if ((state & WRITE_LOCK) == 0) {
+    if ((state & QUEUED_WRITER_MASK) != 0) {
+      { std::lock_guard<std::mutex> guard(_writer_mutex); }
+      _writers_bell.notify_one();
+    } else {
+      { std::lock_guard<std::mutex> guard(_reader_mutex); }
+      _readers_bell.notify_all();
+    }
   }
 
   return false;


### PR DESCRIPTION
### Scope & Purpose

Fixed BTS-1668: https://arangodb.atlassian.net/browse/BTS-1668
This is a backport of the RW lock bugfix made in https://github.com/arangodb/arangodb/pull/20067/files#diff-5292d0c90206525064e5e54c98913c46cada9c267cef56489225818e1fcc49ca

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.11: https://github.com/arangodb/arangodb/pull/20067
  - [x] Backport for 3.10: this PR

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 