### PR TITLE
BTS-1696: enterprise read only mode leaves statistics log-spamming

### DIFF
--- a/arangod/Statistics/StatisticsWorker.cpp
+++ b/arangod/Statistics/StatisticsWorker.cpp
@@ -1118,7 +1118,8 @@ void StatisticsWorker::saveSlice(VPackSlice slice,
   // or abort if an error occured.
   // result stays valid!
   res = trx.finish(result.result);
-  if (res.fail()) {
+  if (res.fail() && res.isNot(TRI_ERROR_ARANGO_READ_ONLY)) {
+    // BTS-1696: suppress log spam when we are in read-only mode.
     LOG_TOPIC("82af5", WARN, Logger::STATISTICS)
         << "could not commit stats to " << collection << ": "
         << res.errorMessage();

--- a/js/server/modules/@arangodb/foxx/queues/manager.js
+++ b/js/server/modules/@arangodb/foxx/queues/manager.js
@@ -179,13 +179,16 @@ const resetDeadJobs = function () {
           global.KEYSPACE_CREATE('queue-control', 1, true);
         }
         done = true;
-      } catch(e) {
-        if (e.code === errors.ERROR_SHUTTING_DOWN.code) {
+      } catch (e) {
+        if (e.errorNum === errors.ERROR_SHUTTING_DOWN.code) {
           warn("Shutting down while resetting dead jobs on database " + name + ", aborting.");
           done = true; // we're quitting because shutdown is in progress
-        } else if (e.code === errors.ERROR_ARANGO_DATA_SOURCE_NOT_FOUND.code) {
+        } else if (e.errorNum === errors.ERROR_ARANGO_DATA_SOURCE_NOT_FOUND.code) {
           warn("'_jobs' collection not found while resetting dead jobs on database " + name + ", aborting.");
           done = true; // we're quitting because the _jobs collection is missing
+        } else if (e.errorNum === errors.ERROR_ARANGO_READ_ONLY.code) {
+          warn("'_jobs' collection is read only while resetting dead jobs on database " + name + ", aborting.");
+          done = true;
         } else {
           maxTries--;
           warn("Exception while resetting dead jobs on database " + name + ": " + e.message +


### PR DESCRIPTION
### Scope & Purpose

Fix BTS-1696: enterprise read only mode leaves statistics log-spamming

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR: 
- [x] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/BTS-1696
- [ ] Design document: 