### PR TITLE
[CINFRA] Replication2 adaptation of shell-transaction-intermediate-commit-cluster

### DIFF
--- a/tests/js/client/shell/transaction/shell-transaction-intermediate-commit-cluster.js
+++ b/tests/js/client/shell/transaction/shell-transaction-intermediate-commit-cluster.js
@@ -57,12 +57,14 @@ function assertInSync(leader, follower, shardId) {
 function transactionIntermediateCommitsSingleSuite() {
   'use strict';
   const cn = 'UnitTestsTransaction';
+  let isReplication2 = false;
 
   return {
 
     setUp: function () {
       getEndpointsByType("dbserver").forEach((ep) => debugClearFailAt(ep));
       db._drop(cn);
+      isReplication2 = db._properties().replicationVersion === "2";
     },
 
     tearDown: function () {
@@ -138,7 +140,13 @@ function transactionIntermediateCommitsSingleSuite() {
       assertEqual(droppedFollowersBefore, droppedFollowersAfter);
       
       let intermediateCommitsAfter = getMetric(follower, "arangodb_intermediate_commits_total");
-      assertEqual(intermediateCommitsBefore + 10, intermediateCommitsAfter);
+      if (isReplication2) {
+        // No intermediate commits are performed by the follower in replication 2,
+        // unless they are replicated from the leader.
+        assertEqual(intermediateCommitsBefore, intermediateCommitsAfter);
+      } else {
+        assertEqual(intermediateCommitsBefore + 10, intermediateCommitsAfter);
+      }
       
       assertInSync(leader, follower, shardId);
     },
@@ -165,14 +173,22 @@ function transactionIntermediateCommitsSingleSuite() {
       } catch (err) {
       }
       assertEqual(didWork, false);
-      
-      // follower must have been dropped
-      let droppedFollowersAfter = getMetric(leader, "arangodb_dropped_followers_total");
-      assertEqual(droppedFollowersBefore + 1, droppedFollowersAfter);
+
+      if (!isReplication2) {
+        // follower must have been dropped
+        let droppedFollowersAfter = getMetric(leader, "arangodb_dropped_followers_total");
+        assertEqual(droppedFollowersBefore + 1, droppedFollowersAfter);
+      }
     
       let intermediateCommitsAfter = getMetric(follower, "arangodb_intermediate_commits_total");
-      assertEqual(intermediateCommitsBefore + 9, intermediateCommitsAfter);
-      
+      if (isReplication2) {
+        // No intermediate commits are performed by the follower in replication 2,
+        // unless they are replicated from the leader.
+        assertEqual(intermediateCommitsBefore, intermediateCommitsAfter);
+      } else {
+        assertEqual(intermediateCommitsBefore + 9, intermediateCommitsAfter);
+      }
+
       assertInSync(leader, follower, shardId);
     },
     
@@ -214,7 +230,13 @@ function transactionIntermediateCommitsSingleSuite() {
       assertEqual(droppedFollowersBefore, droppedFollowersAfter);
     
       let intermediateCommitsAfter = getMetric(follower, "arangodb_intermediate_commits_total");
-      assertEqual(intermediateCommitsBefore + 10, intermediateCommitsAfter);
+      if (isReplication2) {
+        // No intermediate commits are performed by the follower in replication 2,
+        // unless they are replicated from the leader.
+        assertEqual(intermediateCommitsBefore, intermediateCommitsAfter);
+      } else {
+        assertEqual(intermediateCommitsBefore + 10, intermediateCommitsAfter);
+      }
       
       assertInSync(leader, follower, shardId);
     },
@@ -261,13 +283,22 @@ function transactionIntermediateCommitsSingleSuite() {
       assertEqual(didWork, false);
 
       // follower must have been dropped
-      let droppedFollowersAfter = getMetric(leader, "arangodb_dropped_followers_total");
-      assertEqual(droppedFollowersBefore + 1, droppedFollowersAfter);
+      if (!isReplication2) {
+        let droppedFollowersAfter = getMetric(leader, "arangodb_dropped_followers_total");
+        assertEqual(droppedFollowersBefore + 1, droppedFollowersAfter);
+      }
 
-      // By coming back in sync the follower removes 10000 entries which results in another intermediate commit
       assertInSync(leader, follower, shardId);
       let intermediateCommitsAfter = getMetric(follower, "arangodb_intermediate_commits_total");
-      assertEqual(intermediateCommitsBefore + 10 + 1, intermediateCommitsAfter);
+
+      if (isReplication2) {
+        // No intermediate commits are performed by the follower in replication 2,
+        // unless they are replicated from the leader.
+        assertEqual(intermediateCommitsBefore, intermediateCommitsAfter);
+      } else {
+        // By coming back in sync the follower removes 10000 entries which results in another intermediate commit
+        assertEqual(intermediateCommitsBefore + 10 + 1, intermediateCommitsAfter);
+      }
 
       debugClearFailAt(follower, "logAfterIntermediateCommit");
     },
@@ -312,12 +343,18 @@ function transactionIntermediateCommitsSingleSuite() {
       trx.abort();
       
       // follower must have been dropped
-      let droppedFollowersAfter = getMetric(leader, "arangodb_dropped_followers_total");
-      assertEqual(droppedFollowersBefore + 1, droppedFollowersAfter);
+      if (!isReplication2) {
+        let droppedFollowersAfter = getMetric(leader, "arangodb_dropped_followers_total");
+        assertEqual(droppedFollowersBefore + 1, droppedFollowersAfter);
+      }
     
       let intermediateCommitsAfter = getMetric(follower, "arangodb_intermediate_commits_total");
-      assertEqual(intermediateCommitsBefore + 9, intermediateCommitsAfter);
-      
+      if (isReplication2) {
+        assertEqual(intermediateCommitsBefore, intermediateCommitsAfter);
+      } else {
+        assertEqual(intermediateCommitsBefore + 9, intermediateCommitsAfter);
+      }
+
       assertEqual(0, c.count());
       assertInSync(leader, follower, shardId);
     },
@@ -328,6 +365,7 @@ function transactionIntermediateCommitsSingleSuite() {
 function transactionIntermediateCommitsMultiSuite() {
   'use strict';
   const cn = 'UnitTestsTransaction';
+  let isReplication2 = false;
 
   const createCollectionsSameFollowerDifferentLeader = () => {
     const c1 = db._create(cn + "1", {numberOfShards: 1, replicationFactor: 2});
@@ -371,6 +409,7 @@ function transactionIntermediateCommitsMultiSuite() {
       getEndpointsByType("dbserver").forEach((ep) => debugClearFailAt(ep));
       db._drop(cn + "1");
       db._drop(cn + "2");
+      isReplication2 = db._properties().replicationVersion === "2";
     },
 
     tearDown: function () {
@@ -432,8 +471,13 @@ function transactionIntermediateCommitsMultiSuite() {
       // follower must have been dropped
       let droppedFollowersAfter1 = getMetric(leader1, "arangodb_dropped_followers_total");
       let droppedFollowersAfter2 = getMetric(leader2, "arangodb_dropped_followers_total");
-      assertEqual(droppedFollowersBefore1 + 1, droppedFollowersAfter1);
-      assertEqual(droppedFollowersBefore2 + 1, droppedFollowersAfter2);
+      if (isReplication2) {
+        assertEqual(droppedFollowersBefore1, droppedFollowersAfter1);
+        assertEqual(droppedFollowersBefore2, droppedFollowersAfter2);
+      } else {
+        assertEqual(droppedFollowersBefore1 + 1, droppedFollowersAfter1);
+        assertEqual(droppedFollowersBefore2 + 1, droppedFollowersAfter2);
+      }
     
       assertInSync(leader1, follower1, shardId1);
       assertInSync(leader2, follower2, shardId2);
@@ -517,8 +561,12 @@ function transactionIntermediateCommitsMultiSuite() {
       let intermediateCommitsAfter = getMetric(follower1, "arangodb_intermediate_commits_total");
       assertEqual(droppedFollowersBefore1, droppedFollowersAfter1);
       assertEqual(droppedFollowersBefore2, droppedFollowersAfter2);
-      assertEqual(intermediateCommitsBefore + Math.floor((9950 + 9950) / 1000), intermediateCommitsAfter);
-    
+      if (isReplication2) {
+        assertEqual(intermediateCommitsBefore, intermediateCommitsAfter);
+      } else {
+        assertEqual(intermediateCommitsBefore + Math.floor((9950 + 9950) / 1000), intermediateCommitsAfter);
+      }
+
       assertInSync(leader1, follower1, shardId1);
       assertInSync(leader2, follower2, shardId2);
     },


### PR DESCRIPTION
### Scope & Purpose

This PR provides the necessary adaptations for the `shell-transaction-intermediate-commit-cluster.js` suite, making it run-able with replication2 default.

Most of these changes revolve around the following two differences:
- In replication2 we do not "drop" followers
- In replication2, followers do not perform intermediate commits by themselves, unless the leader replicates an `IntermediateCommit` operation. This means that if intermediate commits are disabled on the leader, they are inherently disabled on the follower.

Although they were initially targeted at replication1-specific behavior, I believe the suite is still relevant for replication2, at least from the perspective of a more general sanity check: making sure we don't crash, and the leader and follower are kept in sync.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification