### PR TITLE
Respect frontendConfig.basePath configuration in views page and other aardvark pages

### DIFF
--- a/js/apps/system/_admin/aardvark/APP/react/src/utils/arangoClient.ts
+++ b/js/apps/system/_admin/aardvark/APP/react/src/utils/arangoClient.ts
@@ -4,7 +4,7 @@ import { memoize } from "lodash";
 export const getDB = memoize(
   (db: string) =>
     new Database({
-      url: window.location.origin,
+      url: window.location.origin + window.frontendConfig.basePath,
       databaseName: db,
       auth: {
         token: window.arangoHelper.getCurrentJwt()


### PR DESCRIPTION
frontend/js/arango/arango.js already appends basePath to window.host, so adding it here makes it consistent.

This enables proxying the ArangoDB UI on a subpath again.

### Scope & Purpose

*(Please describe the changes in this PR for reviewers, motivation, rationale - **mandatory**)*

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

