### PR TITLE
Fix K_SHORTEST_PATHS

### DIFF
--- a/arangod/Graph/Enumerators/TwoSidedEnumerator.cpp
+++ b/arangod/Graph/Enumerators/TwoSidedEnumerator.cpp
@@ -216,20 +216,22 @@ auto TwoSidedEnumerator<QueueType, PathStoreType, ProviderType, PathValidator>::
 
   ValidationResult res = _validator.validatePath(step);
 
+  if (!res.isFiltered()) {
+    // Check if other Ball knows this Vertex.
+    // Include it in results.
+    if (getDepth() + other.getDepth() >= _minDepth) {
+      // One side of the path is checked, the other side is unclear:
+      // We need to combine the test of both sides.
+
+      // For GLOBAL: We ignore otherValidator, On FIRST match: Add this match
+      // as result, clear both sides. => This will give the shortest path.
+      // TODO: Check if the GLOBAL holds true for weightedEdges
+      other.matchResultsInShell(step, results, _validator);
+    }
+  }
+
   if (!res.isPruned()) {
     _provider.expand(step, previous, [&](Step n) -> void {
-      // Check if other Ball knows this Vertex.
-      // Include it in results.
-      if (getDepth() + other.getDepth() >= _minDepth) {
-        // One side of the path is checked, the other side is unclear:
-        // We need to combine the test of both sides.
-
-        // For GLOBAL: We ignore otherValidator, On FIRST match: Add this match
-        // as result, clear both sides. => This will give the shortest path.
-        // TODO: Check if the GLOBAL holds true for weightedEdges
-        other.matchResultsInShell(n, results, _validator);
-      }
-
       // Add the step to our shell
       _shell.emplace(std::move(n));
     });

--- a/arangod/Graph/Enumerators/TwoSidedEnumerator.cpp
+++ b/arangod/Graph/Enumerators/TwoSidedEnumerator.cpp
@@ -234,8 +234,9 @@ auto TwoSidedEnumerator<QueueType, PathStoreType, ProviderType, PathValidator>::
         // One side of the path is checked, the other side is unclear:
         // We need to combine the test of both sides.
 
-        // For GLOBAL: We ignore otherValidator, On FIRST match: Add this match
-        // as result, clear both sides. => This will give the shortest path.
+        // For GLOBAL: We ignore otherValidator, On FIRST match: Add this
+        // match as result, clear both sides. => This will give the shortest
+        // path.
         other.matchResultsInShell(n, results, _validator);
       }
       if (!uniqueness.isPruned()) {

--- a/arangod/Graph/Enumerators/TwoSidedEnumerator.cpp
+++ b/arangod/Graph/Enumerators/TwoSidedEnumerator.cpp
@@ -211,27 +211,22 @@ auto TwoSidedEnumerator<QueueType, PathStoreType, ProviderType, PathValidator>::
     TRI_ASSERT(_queue.hasProcessableElement());
   }
 
-  auto step = _queue.pop();
-  auto previous = _interior.append(step);
-  _provider.expand(step, previous, [&](Step n) -> void {
-    ValidationResult res = _validator.validatePath(n);
+  auto tmp = _queue.pop();
+  auto posPrevious = _interior.append(std::move(tmp));
+  auto& step = _interior.getStepReference(posPrevious);
 
-    // Check if other Ball knows this Vertex.
-    // Include it in results.
-    if ((getDepth() + other.getDepth() >= _minDepth) && !res.isFiltered()) {
-      // One side of the path is checked, the other side is unclear:
-      // We need to combine the test of both sides.
+  auto res = _validator.validatePath(step);
 
-      // For GLOBAL: We ignore otherValidator, On FIRST match: Add this match as
-      // result, clear both sides. => This will give the shortest path.
-      // TODO: Check if the GLOBAL holds true for weightedEdges
-      other.matchResultsInShell(n, results, _validator);
+  if (!res.isFiltered()) {
+    if (getDepth() + other.getDepth() >= _minDepth) {
+      other.matchResultsInShell(step, results, _validator);
     }
-    if (!res.isPruned()) {
-      // Add the step to our shell
-      _shell.emplace(std::move(n));
-    }
-  });
+  }
+
+  if (!res.isPruned()) {
+    _provider.expand(step, posPrevious,
+                     [&](Step n) -> void { _shell.emplace(std::move(n)); });
+  }
 }
 
 template<class QueueType, class PathStoreType, class ProviderType,

--- a/arangod/Graph/Enumerators/TwoSidedEnumerator.cpp
+++ b/arangod/Graph/Enumerators/TwoSidedEnumerator.cpp
@@ -213,29 +213,25 @@ auto TwoSidedEnumerator<QueueType, PathStoreType, ProviderType, PathValidator>::
 
   auto step = _queue.pop();
   auto previous = _interior.append(step);
+  _provider.expand(step, previous, [&](Step n) -> void {
+    ValidationResult res = _validator.checkPathUniqueness(n);
 
-  ValidationResult res = _validator.validatePath(step);
-
-  if (!res.isFiltered()) {
     // Check if other Ball knows this Vertex.
     // Include it in results.
-    if (getDepth() + other.getDepth() >= _minDepth) {
+    if ((getDepth() + other.getDepth() >= _minDepth) && !res.isFiltered()) {
       // One side of the path is checked, the other side is unclear:
       // We need to combine the test of both sides.
 
-      // For GLOBAL: We ignore otherValidator, On FIRST match: Add this match
-      // as result, clear both sides. => This will give the shortest path.
+      // For GLOBAL: We ignore otherValidator, On FIRST match: Add this match as
+      // result, clear both sides. => This will give the shortest path.
       // TODO: Check if the GLOBAL holds true for weightedEdges
-      other.matchResultsInShell(step, results, _validator);
+      other.matchResultsInShell(n, results, _validator);
     }
-  }
-
-  if (!res.isPruned()) {
-    _provider.expand(step, previous, [&](Step n) -> void {
+    if (!res.isPruned()) {
       // Add the step to our shell
       _shell.emplace(std::move(n));
-    });
-  }
+    }
+  });
 }
 
 template<class QueueType, class PathStoreType, class ProviderType,

--- a/arangod/Graph/Enumerators/TwoSidedEnumerator.cpp
+++ b/arangod/Graph/Enumerators/TwoSidedEnumerator.cpp
@@ -214,25 +214,35 @@ auto TwoSidedEnumerator<QueueType, PathStoreType, ProviderType, PathValidator>::
   auto step = _queue.pop();
   auto previous = _interior.append(step);
 
-  _provider.expand(step, previous, [&](Step n) -> void {
-    ValidationResult res = _validator.validatePathUniqueness(n);
+  // validatePath does the full validation of the path up to here including
+  // checking vertex/path document conditions.
+  //
+  // The full validation cannot be run during the expand step, because
+  // the vertex document has not been fetched yet.
+  auto validation = _validator.validatePath(step);
+  if (!validation.isPruned()) {
+    _provider.expand(step, previous, [&](Step n) -> void {
+      // this uniqueness check is all that can be done at this point, as
+      // all that is known about the edge is the edge and the vertex-id (but
+      // crucially not the vertex document.)
+      auto uniqueness = _validator.validatePathUniqueness(n);
 
-    // Check if other Ball knows this Vertex.
-    // Include it in results.
-    if ((getDepth() + other.getDepth() >= _minDepth) && !res.isFiltered()) {
-      // One side of the path is checked, the other side is unclear:
-      // We need to combine the test of both sides.
+      // Check if other Ball knows this Vertex.
+      // Include it in results.
+      if ((getDepth() + other.getDepth() >= _minDepth) &&
+          !uniqueness.isFiltered()) {
+        // One side of the path is checked, the other side is unclear:
+        // We need to combine the test of both sides.
 
-      // For GLOBAL: We ignore otherValidator, On FIRST match: Add this match as
-      // result, clear both sides. => This will give the shortest path.
-      // TODO: Check if the GLOBAL holds true for weightedEdges
-      other.matchResultsInShell(n, results, _validator);
-    }
-    if (!res.isPruned()) {
-      // Add the step to our shell
-      _shell.emplace(std::move(n));
-    }
-  });
+        // For GLOBAL: We ignore otherValidator, On FIRST match: Add this match
+        // as result, clear both sides. => This will give the shortest path.
+        other.matchResultsInShell(n, results, _validator);
+      }
+      if (!uniqueness.isPruned()) {
+        _shell.emplace(std::move(n));
+      }
+    });
+  }
 }
 
 template<class QueueType, class PathStoreType, class ProviderType,

--- a/arangod/Graph/Enumerators/TwoSidedEnumerator.cpp
+++ b/arangod/Graph/Enumerators/TwoSidedEnumerator.cpp
@@ -213,8 +213,9 @@ auto TwoSidedEnumerator<QueueType, PathStoreType, ProviderType, PathValidator>::
 
   auto step = _queue.pop();
   auto previous = _interior.append(step);
+
   _provider.expand(step, previous, [&](Step n) -> void {
-    ValidationResult res = _validator.checkPathUniqueness(n);
+    ValidationResult res = _validator.validatePathUniqueness(n);
 
     // Check if other Ball knows this Vertex.
     // Include it in results.

--- a/arangod/Graph/PathManagement/PathValidator.cpp
+++ b/arangod/Graph/PathManagement/PathValidator.cpp
@@ -68,16 +68,12 @@ template<class ProviderType, class PathStore,
 auto PathValidator<ProviderType, PathStore, vertexUniqueness, edgeUniqueness>::
     checkPathUniqueness(typename PathStore::Step& step)
         -> ValidationResult::Type {
-  //  auto res = ValidationResult::Type::TAKE;
-
 #ifdef USE_ENTERPRISE
   if (isDisjoint()) {
     auto validDisjPathRes = checkValidDisjointPath(step);
     if (validDisjPathRes == ValidationResult::Type::FILTER_AND_PRUNE ||
         validDisjPathRes == ValidationResult::Type::FILTER) {
       return validDisjPathRes;
-      // res.combine(validDisjPathRes);
-      // return handleValidationResult(res, step);
     }
   }
 #endif
@@ -99,7 +95,6 @@ auto PathValidator<ProviderType, PathStore, vertexUniqueness, edgeUniqueness>::
       // Nothing is going to change this value later as
       // FILTER_AND_PRUNE is the TOP of the lattice ValidationResult::Type
       return ValidationResult::Type::FILTER_AND_PRUNE;
-      //      res.combine(ValidationResult::Type::FILTER_AND_PRUNE);
     }
   }
   if constexpr (vertexUniqueness == VertexUniquenessLevel::GLOBAL) {
@@ -110,7 +105,6 @@ auto PathValidator<ProviderType, PathStore, vertexUniqueness, edgeUniqueness>::
     // If this add fails, we need to exclude this path
     if (!addedVertex) {
       return ValidationResult::Type::FILTER_AND_PRUNE;
-      //      res.combine(ValidationResult::Type::FILTER_AND_PRUNE);
     }
   }
   if constexpr (vertexUniqueness == VertexUniquenessLevel::NONE &&
@@ -133,13 +127,11 @@ auto PathValidator<ProviderType, PathStore, vertexUniqueness, edgeUniqueness>::
       // If this add fails, we need to exclude this path
       if (!edgeSuccess) {
         return ValidationResult::Type::FILTER_AND_PRUNE;
-        //        res.combine(ValidationResult::Type::FILTER_AND_PRUNE);
       }
     }
   }
-  // TODO justify why this is the correct thing to do (as opposed to ::UNKNOWN
+
   return ValidationResult::Type::TAKE;
-  //  return handleValidationResult(res, step);
 }
 
 template<class ProviderType, class PathStore,

--- a/arangod/Graph/PathManagement/PathValidator.cpp
+++ b/arangod/Graph/PathManagement/PathValidator.cpp
@@ -65,6 +65,77 @@ PathValidator<ProviderType, PathStore, vertexUniqueness,
 template<class ProviderType, class PathStore,
          VertexUniquenessLevel vertexUniqueness,
          EdgeUniquenessLevel edgeUniqueness>
+auto PathValidator<ProviderType, PathStore, vertexUniqueness, edgeUniqueness>::
+    checkPathUniqueness(typename PathStore::Step& step) -> ValidationResult {
+  auto res = ValidationResult(ValidationResult::Type::TAKE);
+
+#ifdef USE_ENTERPRISE
+  if (isDisjoint()) {
+    auto validDisjPathRes = checkValidDisjointPath(step);
+    if (validDisjPathRes == ValidationResult::Type::FILTER_AND_PRUNE ||
+        validDisjPathRes == ValidationResult::Type::FILTER) {
+      res.combine(validDisjPathRes);
+      return handleValidationResult(res, step);
+    }
+  }
+#endif
+
+  if constexpr (vertexUniqueness == VertexUniquenessLevel::PATH) {
+    reset();
+    // Reserving here is pointless, we will test paths that increase by at most
+    // 1 entry.
+
+    bool success = _store.visitReversePath(
+        step, [&](typename PathStore::Step const& step) -> bool {
+          auto const& [unusedV, addedVertex] =
+              _uniqueVertices.emplace(step.getVertexIdentifier());
+
+          // If this add fails, we need to exclude this path
+          return addedVertex;
+        });
+    if (!success) {
+      res.combine(ValidationResult::Type::FILTER_AND_PRUNE);
+    }
+  }
+  if constexpr (vertexUniqueness == VertexUniquenessLevel::GLOBAL) {
+    // In case we have VertexUniquenessLevel::GLOBAL, we do not have to take
+    // care about the EdgeUniquenessLevel.
+    auto const& [unusedV, addedVertex] =
+        _uniqueVertices.emplace(step.getVertexIdentifier());
+    // If this add fails, we need to exclude this path
+    if (!addedVertex) {
+      res.combine(ValidationResult::Type::FILTER_AND_PRUNE);
+    }
+  }
+  if constexpr (vertexUniqueness == VertexUniquenessLevel::NONE &&
+                edgeUniqueness == EdgeUniquenessLevel::PATH) {
+    if (step.getDepth() > 1) {
+      reset();
+
+      bool edgeSuccess = _store.visitReversePath(
+          step, [&](typename PathStore::Step const& step) -> bool {
+            if (step.isFirst()) {
+              return true;
+            }
+
+            auto const& [unusedE, addedEdge] =
+                _uniqueEdges.emplace(step.getEdgeIdentifier());
+            // If this add fails, we need to exclude this path
+            return addedEdge;
+          });
+
+      // If this add fails, we need to exclude this path
+      if (!edgeSuccess) {
+        res.combine(ValidationResult::Type::FILTER_AND_PRUNE);
+      }
+    }
+  }
+  return handleValidationResult(res, step);
+}
+
+template<class ProviderType, class PathStore,
+         VertexUniquenessLevel vertexUniqueness,
+         EdgeUniquenessLevel edgeUniqueness>
 auto PathValidator<ProviderType, PathStore, vertexUniqueness,
                    edgeUniqueness>::validatePath(typename PathStore::Step& step)
     -> ValidationResult {

--- a/arangod/Graph/PathManagement/PathValidator.h
+++ b/arangod/Graph/PathManagement/PathValidator.h
@@ -68,6 +68,8 @@ class PathValidator {
                 PathValidatorOptions opts);
   ~PathValidator();
 
+  auto checkPathUniqueness(typename PathStore::Step& step) -> ValidationResult;
+
   auto validatePath(typename PathStore::Step& step) -> ValidationResult;
   auto validatePath(typename PathStore::Step const& step,
                     PathValidator<Provider, PathStore, vertexUniqueness,

--- a/arangod/Graph/PathManagement/PathValidator.h
+++ b/arangod/Graph/PathManagement/PathValidator.h
@@ -68,8 +68,8 @@ class PathValidator {
                 PathValidatorOptions opts);
   ~PathValidator();
 
-  auto checkPathUniqueness(typename PathStore::Step& step) -> ValidationResult;
-
+  auto validatePathUniqueness(typename PathStore::Step& step)
+      -> ValidationResult;
   auto validatePath(typename PathStore::Step& step) -> ValidationResult;
   auto validatePath(typename PathStore::Step const& step,
                     PathValidator<Provider, PathStore, vertexUniqueness,
@@ -125,15 +125,19 @@ class PathValidator {
       -> ValidationResult;
   auto evaluateVertexRestriction(typename PathStore::Step const& step) -> bool;
 
+  [[nodiscard]] auto checkPathUniqueness(typename PathStore::Step& step)
+      -> ValidationResult::Type;
+
+  [[nodiscard]] auto checkValidDisjointPath(
+      typename PathStore::Step const& lastStep)
+      -> arangodb::graph::ValidationResult::Type;
+
   [[nodiscard]] auto exposeUniqueVertices() const
       -> ::arangodb::containers::HashSet<VertexRef, std::hash<VertexRef>,
                                          std::equal_to<VertexRef>> const&;
 
   auto evaluateExpression(arangodb::aql::Expression* expression,
                           arangodb::velocypack::Slice value) -> bool;
-
-  auto checkValidDisjointPath(typename PathStore::Step const& lastStep)
-      -> arangodb::graph::ValidationResult::Type;
 
   auto isDisjoint() const { return _options.isDisjoint(); }
   auto isSatelliteLeader() const {

--- a/tests/Graph/AllShortestPathsFinderTest.cpp
+++ b/tests/Graph/AllShortestPathsFinderTest.cpp
@@ -369,7 +369,7 @@ TEST_P(AllShortestPathsFinderTest, shortcut_paths) {
   {
     aql::TraversalStats stats = finder.stealStats();
     // We have to lookup both vertices, and the edge
-    EXPECT_EQ(stats.getScannedIndex(), 15U);
+    EXPECT_EQ(stats.getScannedIndex(), 11U);
   }
 }
 
@@ -409,7 +409,7 @@ TEST_P(AllShortestPathsFinderTest, hexagon_path) {
   {
     aql::TraversalStats stats = finder.stealStats();
     // We have to lookup both vertices, and the edge
-    EXPECT_EQ(stats.getScannedIndex(), 6U);
+    EXPECT_EQ(stats.getScannedIndex(), 4U);
   }
 }
 
@@ -449,7 +449,7 @@ TEST_P(AllShortestPathsFinderTest, binary_tree) {
   {
     aql::TraversalStats stats = finder.stealStats();
     // We have to lookup both vertices, and the edge
-    EXPECT_EQ(stats.getScannedIndex(), 12U);
+    EXPECT_EQ(stats.getScannedIndex(), 11U);
   }
 }
 
@@ -489,7 +489,7 @@ TEST_P(AllShortestPathsFinderTest, binary_trees_connected) {
   {
     aql::TraversalStats stats = finder.stealStats();
     // We have to lookup both vertices, and the edge
-    EXPECT_EQ(stats.getScannedIndex(), 8U);
+    EXPECT_EQ(stats.getScannedIndex(), 7U);
   }
 }
 
@@ -581,7 +581,7 @@ TEST_P(AllShortestPathsFinderTest, grid_paths) {
   {
     aql::TraversalStats stats = finder.stealStats();
     // We have to lookup both vertices, and the edge
-    EXPECT_EQ(stats.getScannedIndex(), 48U);
+    EXPECT_EQ(stats.getScannedIndex(), 42U);
   }
 }
 
@@ -631,7 +631,7 @@ TEST_P(AllShortestPathsFinderTest, multiple_edges_between_pair) {
   {
     aql::TraversalStats stats = finder.stealStats();
     // We have to lookup both vertices, and the edge
-    EXPECT_EQ(stats.getScannedIndex(), 8U);
+    EXPECT_EQ(stats.getScannedIndex(), 6U);
   }
 }
 

--- a/tests/Graph/AllShortestPathsFinderTest.cpp
+++ b/tests/Graph/AllShortestPathsFinderTest.cpp
@@ -369,7 +369,7 @@ TEST_P(AllShortestPathsFinderTest, shortcut_paths) {
   {
     aql::TraversalStats stats = finder.stealStats();
     // We have to lookup both vertices, and the edge
-    EXPECT_EQ(stats.getScannedIndex(), 11U);
+    EXPECT_EQ(stats.getScannedIndex(), 15U);
   }
 }
 
@@ -409,7 +409,7 @@ TEST_P(AllShortestPathsFinderTest, hexagon_path) {
   {
     aql::TraversalStats stats = finder.stealStats();
     // We have to lookup both vertices, and the edge
-    EXPECT_EQ(stats.getScannedIndex(), 4U);
+    EXPECT_EQ(stats.getScannedIndex(), 6U);
   }
 }
 
@@ -449,7 +449,7 @@ TEST_P(AllShortestPathsFinderTest, binary_tree) {
   {
     aql::TraversalStats stats = finder.stealStats();
     // We have to lookup both vertices, and the edge
-    EXPECT_EQ(stats.getScannedIndex(), 11U);
+    EXPECT_EQ(stats.getScannedIndex(), 12U);
   }
 }
 
@@ -489,7 +489,7 @@ TEST_P(AllShortestPathsFinderTest, binary_trees_connected) {
   {
     aql::TraversalStats stats = finder.stealStats();
     // We have to lookup both vertices, and the edge
-    EXPECT_EQ(stats.getScannedIndex(), 7U);
+    EXPECT_EQ(stats.getScannedIndex(), 8U);
   }
 }
 
@@ -581,7 +581,7 @@ TEST_P(AllShortestPathsFinderTest, grid_paths) {
   {
     aql::TraversalStats stats = finder.stealStats();
     // We have to lookup both vertices, and the edge
-    EXPECT_EQ(stats.getScannedIndex(), 42U);
+    EXPECT_EQ(stats.getScannedIndex(), 48U);
   }
 }
 
@@ -631,7 +631,7 @@ TEST_P(AllShortestPathsFinderTest, multiple_edges_between_pair) {
   {
     aql::TraversalStats stats = finder.stealStats();
     // We have to lookup both vertices, and the edge
-    EXPECT_EQ(stats.getScannedIndex(), 6U);
+    EXPECT_EQ(stats.getScannedIndex(), 8U);
   }
 }
 

--- a/tests/Graph/WeightedShortestPathTest.cpp
+++ b/tests/Graph/WeightedShortestPathTest.cpp
@@ -433,7 +433,7 @@ TEST_P(WeightedShortestPathTest, shortest_path_A_F_outbound) {
     aql::TraversalStats stats = finder.stealStats();
     // We have to lookup the vertex
     // 4x vertices, 3x edges
-    EXPECT_EQ(stats.getScannedIndex(), 25U);
+    EXPECT_EQ(stats.getScannedIndex(), 26U);
   }
 
   {
@@ -482,7 +482,7 @@ TEST_P(WeightedShortestPathTest, shortest_path_A_F_inbound) {
     aql::TraversalStats stats = finder.stealStats();
     // We have to lookup the vertex
     // 4x vertices, 3x edges
-    EXPECT_EQ(stats.getScannedIndex(), 25U);
+    EXPECT_EQ(stats.getScannedIndex(), 26U);
   }
 
   {


### PR DESCRIPTION
### Scope & Purpose

This PR attempts to be a small solution to the problem that presents itself with path searches and global conditions on vertices and edges.

The code that executes path/vertex conditions while enumerating paths was as yet untested and hence crashed on the first use.

This is due to the fact that path validation, inspecting the vertex documents on the path, was called at a time when the vertex document wasn't known yet.

This PR moves the full path validation that inspects a vertex document to a point where the vertex document is known.

This is after the vertex has been popped from the (priority-)queue, but retains redundancy checks on expansion, that is if a vertex-id has been seen already it is not put on the queue again for the enumerator without weights.

The weighted two sided enumerator is simplified a little bit.
