### PR TITLE
print signal sub code when crash handler is invoked

### DIFF
--- a/lib/Basics/signals.cpp
+++ b/lib/Basics/signals.cpp
@@ -258,6 +258,7 @@ std::string_view subtypeName(int signal, int subCode) noexcept {
         default:
           break;
       }
+      break;
     }
     case SIGFPE: {
       switch (subCode) {
@@ -304,6 +305,7 @@ std::string_view subtypeName(int signal, int subCode) noexcept {
         default:
           break;
       }
+      break;
     }
     case SIGSEGV: {
       switch (subCode) {
@@ -342,8 +344,8 @@ std::string_view subtypeName(int signal, int subCode) noexcept {
         default:
           break;
       }
+      break;
     }
-
     case SIGBUS: {
       switch (subCode) {
 #ifdef BUS_ADRALN
@@ -371,6 +373,7 @@ std::string_view subtypeName(int signal, int subCode) noexcept {
         default:
           break;
       }
+      break;
     }
     case SIGTRAP: {
       switch (subCode) {
@@ -401,6 +404,7 @@ std::string_view subtypeName(int signal, int subCode) noexcept {
         default:
           break;
       }
+      break;
     }
 
     default:

--- a/lib/Basics/signals.cpp
+++ b/lib/Basics/signals.cpp
@@ -213,6 +213,203 @@ std::string_view name(int signal) noexcept {
   }
 }
 
+std::string_view subtypeName(int signal, int subCode) noexcept {
+#ifndef _WIN32
+  // the following meanings are taken from /usr/include/asm-generic/siginfo.h
+  switch (signal) {
+    case SIGILL: {
+      switch (subCode) {
+#ifdef ILL_ILLOPC
+        case ILL_ILLOPC:
+          return "ILL_ILLOPC: illegal opcode";
+#endif
+#ifdef ILL_ILLOPN
+        case ILL_ILLOPN:
+          return "ILL_ILLOPN: illegal operand";
+#endif
+#ifdef ILL_ILLADR
+        case ILL_ILLADR:
+          return "ILL_ILLADR: illegal addressing mode";
+#endif
+#ifdef ILL_ILLTRP
+        case ILL_ILLTRP:
+          return "ILL_ILLTRP: illegal trap";
+#endif
+#ifdef ILL_PRVOPC
+        case ILL_PRVOPC:
+          return "ILL_PRVOPC: privileged opcode";
+#endif
+#ifdef ILL_PRVREG
+        case ILL_PRVREG:
+          return "ILL_PRVREG: privileged register";
+#endif
+#ifdef ILL_COPROC
+        case ILL_COPROC:
+          return "ILL_COPROC: coprocessor error";
+#endif
+#ifdef ILL_BADSTK
+        case ILL_BADSTK:
+          return "ILL_BADSTK: internal stack error";
+#endif
+#ifdef ILL_BADIADDR
+        case ILL_BADIADDR:
+          return "ILL_BADIADDR: unimplemented instruction address";
+#endif
+        default:
+          break;
+      }
+    }
+    case SIGFPE: {
+      switch (subCode) {
+#ifdef FPE_INTDIV
+        case FPE_INTDIV:
+          return "FPE_INTDIV: integer divide by zero";
+#endif
+#ifdef FPE_INTOVF
+        case FPE_INTOVF:
+          return "FPE_INTOVF: integer overflow";
+#endif
+#ifdef FPE_FLTDIV
+        case FPE_FLTDIV:
+          return "FPE_FLTDIV: floating point divide by zero";
+#endif
+#ifdef FPE_FLTOVF
+        case FPE_FLTOVF:
+          return "FPE_FLTOVF: floating point overflow";
+#endif
+#ifdef FPE_FLTUND
+        case FPE_FLTUND:
+          return "FPE_FLTUND: floating point underflow";
+#endif
+#ifdef FPE_FLTRES
+        case FPE_FLTRES:
+          return "FPE_FLTRES: floating point inexact result";
+#endif
+#ifdef FPE_FLTINV
+        case FPE_FLTINV:
+          return "FPE_FLTINV: floating point invalid operation";
+#endif
+#ifdef FPE_FLTSUB
+        case FPE_FLTSUB:
+          return "FPE_FLTSUB: subscript out of range";
+#endif
+#ifdef FPE_FLTUNK
+        case FPE_FLTUNK:
+          return "FPE_FLTUNK: undiagnosed floating-point exception";
+#endif
+#ifdef FPE_CONDTRAP
+        case FPE_CONDTRAP:
+          return "FPE_CONDTRAP: trap on condition";
+#endif
+        default:
+          break;
+      }
+    }
+    case SIGSEGV: {
+      switch (subCode) {
+#ifdef SEGV_MAPERR
+        case SEGV_MAPERR:
+          return "SEGV_MAPERR: address not mapped to object";
+#endif
+#ifdef SEGV_ACCERR
+        case SEGV_ACCERR:
+          return "SEGV_ACCERR: invalid permissions for mapped object";
+#endif
+#ifdef SEGV_PKUERR
+        case SEGV_PKUERR:
+          return "SEGV_PKUERR: failed protection key checks";
+#endif
+#ifdef SEGV_ACCADI
+        case SEGV_ACCADI:
+          return "SEGV_ACCADI: ADI not enabled for mapped object";
+#endif
+#ifdef SEGV_ADIDERR
+        case SEGV_ADIDERR:
+          return "SEGV_ADIDERR: Disrupting MCD error";
+#endif
+#ifdef SEGV_ADIPERR
+        case SEGV_ADIPERR:
+          return "SEGV_ADIPERR: Precise MCD exception";
+#endif
+#ifdef SEGV_MTEAERR
+        case SEGV_MTEAERR:
+          return "SEGV_MTEAERR: Asynchronous ARM MTE error";
+#endif
+#ifdef SEGV_MTESERR
+        case SEGV_MTESERR:
+          return "SEGV_MTESERR: Synchronous ARM MTE exception";
+#endif
+        default:
+          break;
+      }
+    }
+
+    case SIGBUS: {
+      switch (subCode) {
+#ifdef BUS_ADRALN
+        case BUS_ADRALN:
+          return "BUS_ADRALN: invalid address alignment";
+#endif
+#ifdef BUS_ADRERR
+        case BUS_ADRERR:
+          return "BUS_ADRERR: non-existent physical address";
+#endif
+#ifdef BUS_OBJERR
+        case BUS_OBJERR:
+          return "BUS_OBJERR: object specific hardware error";
+#endif
+#ifdef BUS_MCEERR_AR
+        case BUS_MCEERR_AR:
+          return "BUS_MCEERR_AR: hardware memory error consumed on a machine "
+                 "check";
+#endif
+#ifdef BUS_MCEERR_AO
+        case BUS_MCEERR_AO:
+          return "BUS_MCEERR_AO: hardware memory error "
+                 "detected in process but not consumed";
+#endif
+        default:
+          break;
+      }
+    }
+    case SIGTRAP: {
+      switch (subCode) {
+#ifdef TRAP_BRKPT
+        case TRAP_BRKPT:
+          return "TRAP_BRKPT: process breakpoint";
+#endif
+#ifdef TRAP_TRACE
+        case TRAP_TRACE:
+          return "TRAP_TRACE: process trace trap";
+#endif
+#ifdef TRAP_BRANCH
+        case TRAP_BRANCH:
+          return "TRAP_BRANCH: process taken branch trap";
+#endif
+#ifdef TRAP_HWBKPT
+        case TRAP_HWBKPT:
+          return "TRAP_HWBKPT: hardware breakpoint/watchpoint";
+#endif
+#ifdef TRAP_UNK
+        case TRAP_UNK:
+          return "TRAP_UNK: undiagnosed trap";
+#endif
+#ifdef TRAP_PERF
+        case TRAP_PERF:
+          return "TRAP_PERF: perf event with sigtrap=1";
+#endif
+        default:
+          break;
+      }
+    }
+
+    default:
+      break;
+  }
+#endif
+  return "unknown";
+}
+
 std::atomic<bool> isServer = true;
 
 void maskAllSignalsServer() {

--- a/lib/Basics/signals.h
+++ b/lib/Basics/signals.h
@@ -40,6 +40,8 @@ bool isDeadly(int signal) noexcept;
 /// @brief return the name for a signal
 std::string_view name(int signal) noexcept;
 
+std::string_view subtypeName(int signal, int subCode) noexcept;
+
 void maskAllSignals();
 void maskAllSignalsServer();
 void maskAllSignalsClient();

--- a/lib/CrashHandler/CrashHandler.cpp
+++ b/lib/CrashHandler/CrashHandler.cpp
@@ -191,6 +191,13 @@ void buildLogMessage(SmallString& buffer, std::string_view context, int signal,
   buffer.append(" (").append(arangodb::signals::name(signal));
 #ifndef _WIN32
   if (info != nullptr) {
+    // signal sub type, if available
+    std::string_view subType =
+        arangodb::signals::subtypeName(signal, info->si_code);
+    if (!subType.empty()) {
+      buffer.append(", sub type ");
+      buffer.append(subType);
+    }
     // pid that sent the signal
     buffer.append(") from pid ").appendUInt64(uint64_t(info->si_pid));
     printed = true;


### PR DESCRIPTION
### Scope & Purpose

Print signal sub code when crash handler is invoked.
This can help to shed more light on the crash that occurred.

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 