### PR TITLE
fixed issue #20216

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,13 @@
 v3.11.6 (XXXX-XX-XX)
 --------------------
 
+* Fix an issue when forced index hints were used in a query, but the optimizer
+  selected a query execution plan that would not use the selected index.
+  Previously, the query failed with a "Could not serve index hint" error
+  message. With the fix, the optimizer will select the next best plan(s) until
+  all index hints are either satisfied, or there are no further plans to
+  select from. In the latter case, the query still aborts with said error.
+
 * FE-403: Fix loader instantiation.
 
 * Fix display of "unique" column in indexes overview of collections.

--- a/arangod/Aql/Optimizer.cpp
+++ b/arangod/Aql/Optimizer.cpp
@@ -393,9 +393,15 @@ void Optimizer::createPlans(std::unique_ptr<ExecutionPlan> plan,
   estimateCosts(queryOptions, estimateAllPlans);
 
   // Best plan should not have forced hints left.
-  // There might be other plans that has, but we don't care
-  if (auto& bestPlan = _plans.list.front().first;
-      bestPlan->hasForcedIndexHints()) {
+  while (true) {
+    auto& bestPlan = _plans.list.front().first;
+    if (!bestPlan->hasForcedIndexHints()) {
+      // no forced index hints in best plan
+      break;
+    }
+    // our best plan contains forced index hints.
+    // now check if they are all satisfied.
+    bool foundForcedHint = false;
     containers::SmallVector<ExecutionNode*, 8> nodes;
     bestPlan->findNodesOfType(nodes, ExecutionNode::ENUMERATE_COLLECTION, true);
     for (auto n : nodes) {
@@ -405,10 +411,24 @@ void Optimizer::createPlans(std::unique_ptr<ExecutionPlan> plan,
           ExecutionNode::castTo<EnumerateCollectionNode const*>(n);
       auto const& hint = en->hint();
       if (hint.type() == aql::IndexHint::HintType::Simple && hint.isForced()) {
-        THROW_ARANGO_EXCEPTION_MESSAGE(
-            TRI_ERROR_QUERY_FORCED_INDEX_HINT_UNUSABLE,
-            "could not use index hint to serve query; " + hint.toString());
+        // unsatisfied index hint.
+        foundForcedHint = true;
+        if (_plans.size() == 1) {
+          // we are the last plan and cannot satisfy the index hint -> fail
+          THROW_ARANGO_EXCEPTION_MESSAGE(
+              TRI_ERROR_QUERY_FORCED_INDEX_HINT_UNUSABLE,
+              "could not use index hint to serve query; " + hint.toString());
+        }
+
+        // there are more plans left to try.
+        // discard the current plan and continue with the next-best plan.
+        _plans.list.pop_front();
+        break;
       }
+    }
+    if (!foundForcedHint) {
+      // all index hints satisified in current best plan
+      break;
     }
   }
 


### PR DESCRIPTION
### Scope & Purpose

Fix for https://github.com/arangodb/arangodb/issues/20216

* Fix an issue when forced index hints were used in a query, but the optimizer selected a query execution plan that would not use the selected index. Previously, the query failed with a "Could not serve index hint" error message. With the fix, the optimizer will select the next best plan(s) until all index hints are either satisfied, or there are no further plans to select from. In the latter case, the query still aborts with said error.

Devel PR is https://github.com/arangodb/arangodb/pull/20201

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [x] GitHub issue / Jira ticket: https://github.com/arangodb/arangodb/issues/20216
- [ ] Design document: 