### PR TITLE
Allow CircleCI to optionally hand in a compiler name

### DIFF
--- a/.circleci/base_config.yml
+++ b/.circleci/base_config.yml
@@ -212,6 +212,11 @@ jobs:
           name: Print SCCache Settings
           command: sccache -s
       - run:
+          name: Setup SCCache for clang
+          command: |
+            ln /usr/bin/sccache /usr/local/bin/clang
+            ln /usr/bin/sccache /usr/local/bin/clang++
+      - run:
           name: Configure
           command: |
             cmake --preset << parameters.preset >> -DCMAKE_C_COMPILER=<< pipeline.parameters.c-compiler >> -DCMAKE_CXX_COMPILER=<< pipeline.parameters.cxx-compiler >> -DCMAKE_EXE_LINKER_FLAGS="-fuse-ld=lld" -DCMAKE_LIBRARY_PATH=$OPENSSL_ROOT_DIR/lib

--- a/.circleci/base_config.yml
+++ b/.circleci/base_config.yml
@@ -212,11 +212,6 @@ jobs:
           name: Print SCCache Settings
           command: sccache -s
       - run:
-          name: Setup SCCache for clang
-          command: |
-            ln /usr/bin/sccache /usr/local/bin/clang
-            ln /usr/bin/sccache /usr/local/bin/clang++
-      - run:
           name: Configure
           command: |
             cmake --preset << parameters.preset >> -DCMAKE_C_COMPILER=<< pipeline.parameters.c-compiler >> -DCMAKE_CXX_COMPILER=<< pipeline.parameters.cxx-compiler >> -DCMAKE_EXE_LINKER_FLAGS="-fuse-ld=lld" -DCMAKE_LIBRARY_PATH=$OPENSSL_ROOT_DIR/lib

--- a/.circleci/base_config.yml
+++ b/.circleci/base_config.yml
@@ -1,12 +1,26 @@
 version: 2.1
 
 orbs:
-  win: circleci/windows@5.0 # The Windows orb gives you everything you need to start using the 
+  win: circleci/windows@5.0 # The Windows orb gives you everything you need to start using the
 
 parameters:
   enterprise-commit:
     type: string
     default: ""
+  build-docker-image:
+    type: string
+    default: ""
+  # Unused here, but it will be forwarded from config and will cause errors if not defined
+  replication-two:
+    type: boolean
+    default: false
+  c-compiler:
+    type: string
+    default: "gcc"
+  cxx-compiler:
+    type: string
+    default: "g++"
+  # these are basically global constants
   build-targets:
     type: string
     default: "arangod arangoimport arangoexport arangodump arangorestore arangobench"
@@ -19,20 +33,6 @@ parameters:
   v8-build-targets:
     type: string
     default: "arangosh"
-  build-docker-tag:
-    type: string
-    default: arangodb/build-alpine:3.16-gcc11.2-openssl3.1.4-f3c77755ece
-  # Unused here, but it will be forwarded from config and will cause errors if not defined
-  replication-two:
-    type: boolean
-    # We use replication1 as default.
-    default: false
-  c-compiler:
-    type: string
-    default: "gcc"
-  cxx-compiler:
-    type: string
-    default: "g++"
 
 commands:
   checkout-arangodb:
@@ -192,7 +192,7 @@ jobs:
         type: string
         default: ""
     docker:
-      - image: << pipeline.parameters.build-docker-tag >>
+      - image: << pipeline.parameters.build-docker-image >>
     resource_class: << parameters.resource-class >>
     environment:
       GIT_SSH_COMMAND: ssh
@@ -384,13 +384,13 @@ jobs:
             Get-ChildItem *.ifc -Recurse | foreach { Remove-Item -Path $_.FullName }
             Get-ChildItem *.ilk -Recurse | foreach { Remove-Item -Path $_.FullName }
             Get-ChildItem *.tlog -Recurse | where { ! $_.PSIsContainer } | foreach { Remove-Item -Path $_.FullName }
-#            Get-ChildItem *.dat -Recurse | foreach { Remove-Item -Path $_.FullName }
+      #            Get-ChildItem *.dat -Recurse | foreach { Remove-Item -Path $_.FullName }
       # - run:
       #     name: Save workspace for development
       #     shell: powershell.exe
       #     command: |
       #       cd D:/CircleCI/project/
-      #       7z a -r ./workspace CMakePresets.json build/ scripts/ js/ enterprise/js etc/ tests/js enterprise/tests/js utils UnitTests 3rdParty/iresearch/tests/resources 3rdParty/rta-makedata            
+      #       7z a -r ./workspace CMakePresets.json build/ scripts/ js/ enterprise/js etc/ tests/js enterprise/tests/js utils UnitTests 3rdParty/iresearch/tests/resources 3rdParty/rta-makedata
       # - run:
       #     name: SCCache Statistics
       #     command: sccache -s
@@ -561,18 +561,18 @@ jobs:
 
   run-cppcheck:
     docker:
-      - image: << pipeline.parameters.build-docker-tag >>
+      - image: << pipeline.parameters.build-docker-image >>
     resource_class: medium+
     steps:
       - run:
           name: Prepare container
           command: |
             mkdir -p /root/workspace/ 
-            mkdir -p /root/project/ 
+            mkdir -p /root/project/
       - attach_workspace:
           at: "/root/workspace/"
       - checkout-arangodb:
-          with-submodules: true 
+          with-submodules: true
           destination: "/root/project"
       - checkout-enterprise:
           destination: "/root/project/enterprise"
@@ -581,7 +581,7 @@ jobs:
           command: |
             ln -s /root/workspace/build/ /root/project/
             cd /root/project/ 
-            utils/cppcheck-circleci.sh /root/workspace/build/compile_commands.json  
+            utils/cppcheck-circleci.sh /root/workspace/build/compile_commands.json
       - run:
           name: Format result
           when: always

--- a/.circleci/base_config.yml
+++ b/.circleci/base_config.yml
@@ -27,6 +27,12 @@ parameters:
     type: boolean
     # We use replication1 as default.
     default: false
+  c-compiler:
+    type: string
+    default: "gcc"
+  cxx-compiler:
+    type: string
+    default: "g++"
 
 commands:
   checkout-arangodb:
@@ -208,7 +214,7 @@ jobs:
       - run:
           name: Configure
           command: |
-            cmake --preset << parameters.preset >> -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DCMAKE_EXE_LINKER_FLAGS="-fuse-ld=lld" -DCMAKE_LIBRARY_PATH=$OPENSSL_ROOT_DIR/lib
+            cmake --preset << parameters.preset >> -DCMAKE_C_COMPILER=<< pipeline.parameters.c-compiler >> -DCMAKE_CXX_COMPILER=<< pipeline.parameters.cxx-compiler >> -DCMAKE_EXE_LINKER_FLAGS="-fuse-ld=lld" -DCMAKE_LIBRARY_PATH=$OPENSSL_ROOT_DIR/lib
       - run:
           name: Build
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,13 @@ parameters:
     type: boolean
     # We use replication1 as default.
     default: false
+  c-compiler:
+    type: string
+    default: "gcc"
+  cxx-compiler:
+    type: string
+    default: "g++"
+
 
 # our defined job, and its steps
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ parameters:
     default: ""
   build-docker-image:
     type: string
-    default: arangodb/build-alpine:3.16-gcc11.2-openssl3.1.3-4999848556c
+    default: arangodb/build-alpine:3.16-gcc11.2-openssl3.1.4-f3c77755ece
   replication-two:
     type: boolean
     default: false # We use replication1 as default.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,17 +12,18 @@ parameters:
     # contains a branch with the same name as the arangodb repo. If this is the case
     # we use it, otherwise we fall back to "devel".
     default: ""
+  build-docker-image:
+    type: string
+    default: arangodb/build-alpine:3.16-gcc11.2-openssl3.1.3-4999848556c
   replication-two:
     type: boolean
-    # We use replication1 as default.
-    default: false
+    default: false # We use replication1 as default.
   c-compiler:
     type: string
     default: "gcc"
   cxx-compiler:
     type: string
     default: "g++"
-
 
 # our defined job, and its steps
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,7 +86,7 @@ jobs:
             fi
             ENTERPRISE_COMMIT=`git ls-remote --heads git@github.com:arangodb/enterprise.git $ENTERPRISE_BRANCH | cut -f1`
             echo "Using enterprise branch $ENTERPRISE_BRANCH (sha $ENTERPRISE_COMMIT)"
-            echo "{\"enterprise-commit\": \"$ENTERPRISE_COMMIT\"}" > parameters.json
+            echo "{\"enterprise-commit\": \"$ENTERPRISE_COMMIT\", \"build-docker-image\": \"<< pipeline.parameters.build-docker-image >>\"" "}" > parameters.json
             cat parameters.json
 
       - run:


### PR DESCRIPTION
### Scope & Purpose

*CircleCI only change:
We now allow the two parameters:
c-compiler : string
cxx-compiler : string

This allows us to select a specific compiler on Linux.
The compiler needs to be installed on the build image we are using right now, it will not be installed.

e.g.
c-compiler: gcc (default)
and
c-compiler: clang

Both work with our current build image, including their resp. c++ variants.
*

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

