### PR TITLE
BTS-1700

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,20 @@
 devel
 -----
 
+* BTS-1700: arangoimport parser should abort after a reasonable amount of parse 
+  errors without success.
+
+  This introduces an option `--max-errors` for arangoimport. This option can
+  be used to limit the amount of error messages displayed by arangoimport, and
+  to abort the import after at least this many errors have occurred.
+
+  The default value for the option is 20, so that imports will quickly stop in
+  case many errors occur.
+  This is a behavior change compared to previous versions, in which the import
+  would continue even when there were many errors.
+  To achive the same behavior with the new version, the value of the 
+  arangoimport startup option `--max-errors` can be set to a high value.
+
 * Make AQL optimizer rule "interchange-adjacent-enumerations" generate less
   plan permutations for the case the a non-collection FOR loop is followed
   by a collection-based FOR loop. This change can reduce the number of plans

--- a/client-tools/Import/AutoTuneThread.cpp
+++ b/client-tools/Import/AutoTuneThread.cpp
@@ -107,8 +107,8 @@ void AutoTuneThread::run() {
       newMax /= _importHelper.getThreadCount();
 
       // notes in Import mention an internal limit of 768MBytes
-      if ((arangodb::import::ImportHelper::MaxBatchSize) < newMax) {
-        newMax = arangodb::import::ImportHelper::MaxBatchSize;
+      if (arangodb::import::ImportHelper::kMaxBatchSize < newMax) {
+        newMax = arangodb::import::ImportHelper::kMaxBatchSize;
       }
 
       LOG_TOPIC("e815e", DEBUG, arangodb::Logger::FIXME)

--- a/client-tools/Import/ImportFeature.cpp
+++ b/client-tools/Import/ImportFeature.cpp
@@ -56,15 +56,11 @@ namespace arangodb {
 
 ImportFeature::ImportFeature(Server& server, int* result)
     : ArangoImportFeature{server, *this},
-      _filename(""),
       _useBackslash(false),
       _convert(true),
       _autoChunkSize(false),
       _chunkSize(1024 * 1024 * 8),
       _threadCount(2),
-      _collectionName(""),
-      _fromCollectionPrefix(""),
-      _toCollectionPrefix(""),
       _overwriteCollectionPrefix(false),
       _createCollection(false),
       _createDatabase(false),
@@ -77,6 +73,7 @@ ImportFeature::ImportFeature(Server& server, int* result)
       _ignoreMissing(false),
       _onDuplicateAction("error"),
       _rowsToSkip(0),
+      _maxErrors(20),
       _result(result),
       _skipValidation(false),
       _latencyStats(false) {
@@ -153,6 +150,21 @@ void ImportFeature::collectOptions(
       "--skip-lines",
       "The number of lines to skip of the input file (CSV and TSV only).",
       new UInt64Parameter(&_rowsToSkip));
+
+  options
+      ->addOption(
+          "--max-errors",
+          "The maxium number of errors after which the import will stop.",
+          new UInt64Parameter(&_maxErrors))
+      .setIntroducedIn(31200)
+      .setLongDescription(R"(The maximum number of errors after which the
+import is stopped. 
+
+Note that this is not an exact limit for the number of errors.
+arangoimport will send data to the server in batches, and likely also in parallel. 
+The server will process these in-flight batches regardless of the maximum number
+of errors configured here. arangoimport will however stop processing more input
+data once the server reported at least this many errors back.)");
 
   options->addOption(
       "--convert",
@@ -270,14 +282,14 @@ void ImportFeature::validateOptions(
     FATAL_ERROR_EXIT();
   }
 
-  if (_chunkSize > arangodb::import::ImportHelper::MaxBatchSize) {
+  if (_chunkSize > arangodb::import::ImportHelper::kMaxBatchSize) {
     // it's not sensible to raise the batch size beyond this value
     // because the server has a built-in limit for the batch size too
     // and will reject bigger HTTP request bodies
     LOG_TOPIC("e6d71", WARN, arangodb::Logger::FIXME)
         << "capping --batch-size value to "
-        << arangodb::import::ImportHelper::MaxBatchSize;
-    _chunkSize = arangodb::import::ImportHelper::MaxBatchSize;
+        << arangodb::import::ImportHelper::kMaxBatchSize;
+    _chunkSize = arangodb::import::ImportHelper::kMaxBatchSize;
   }
 
   if (_threadCount < 1) {
@@ -501,7 +513,7 @@ void ImportFeature::start() {
   SimpleHttpClientParams params = _httpClient->params();
   arangodb::import::ImportHelper ih(encryption, client, client.endpoint(),
                                     params, _chunkSize, _threadCount,
-                                    _autoChunkSize);
+                                    _maxErrors, _autoChunkSize);
 
   // create colletion
   if (_createCollection) {

--- a/client-tools/Import/ImportFeature.h
+++ b/client-tools/Import/ImportFeature.h
@@ -78,6 +78,7 @@ class ImportFeature final : public ArangoImportFeature {
   bool _ignoreMissing;
   std::string _onDuplicateAction;
   uint64_t _rowsToSkip;
+  uint64_t _maxErrors;
   int* _result;
   bool _skipValidation;
   bool _latencyStats;

--- a/client-tools/Import/ImportHelper.h
+++ b/client-tools/Import/ImportHelper.h
@@ -54,11 +54,14 @@ struct SimpleHttpClientParams;
 /// @brief class for http requests
 ////////////////////////////////////////////////////////////////////////////////
 
-namespace arangodb {
-namespace import {
+namespace arangodb::import {
 class SenderThread;
 
 struct ImportStatistics {
+  uint64_t const _maxErrors;
+
+  uint64_t _errorsLogged = 0;
+
   size_t _numberCreated = 0;
   size_t _numberErrors = 0;
   size_t _numberUpdated = 0;
@@ -67,7 +70,10 @@ struct ImportStatistics {
   std::mutex _mutex;
   QuickHistogram _histogram;
 
-  explicit ImportStatistics(application_features::ApplicationServer&);
+  explicit ImportStatistics(application_features::ApplicationServer&,
+                            uint64_t maxErrors);
+
+  bool logError(std::string_view message);
 };
 
 class ImportHelper {
@@ -86,7 +92,7 @@ class ImportHelper {
   ImportHelper(EncryptionFeature* encryption, ClientFeature const& client,
                std::string const& endpoint,
                httpclient::SimpleHttpClientParams const& params,
-               uint64_t maxUploadSize, uint32_t threadCount,
+               uint64_t maxUploadSize, uint32_t threadCount, uint64_t maxErrors,
                bool autoUploadSize = false);
 
   ~ImportHelper();
@@ -257,25 +263,25 @@ class ImportHelper {
   /// @brief get the number of lines read (meaningful for CSV only)
   //////////////////////////////////////////////////////////////////////////////
 
-  size_t getReadLines() { return _numberLines; }
+  size_t getReadLines() const { return _numberLines; }
 
   //////////////////////////////////////////////////////////////////////////////
   /// @brief get the number of documents imported
   //////////////////////////////////////////////////////////////////////////////
 
-  size_t getNumberCreated() { return _stats._numberCreated; }
+  size_t getNumberCreated() const { return _stats._numberCreated; }
 
   //////////////////////////////////////////////////////////////////////////////
   /// @brief get the number of errors
   //////////////////////////////////////////////////////////////////////////////
 
-  size_t getNumberErrors() { return _stats._numberErrors; }
+  size_t getNumberErrors() const { return _stats._numberErrors; }
 
   //////////////////////////////////////////////////////////////////////////////
   /// @brief get the number of updated documents
   //////////////////////////////////////////////////////////////////////////////
 
-  size_t getNumberUpdated() { return _stats._numberUpdated; }
+  size_t getNumberUpdated() const { return _stats._numberUpdated; }
 
   //////////////////////////////////////////////////////////////////////////////
   /// @brief get the number of ignored documents
@@ -298,6 +304,7 @@ class ImportHelper {
   //////////////////////////////////////////////////////////////////////////////
   /// @brief start the optional histogram thread
   //////////////////////////////////////////////////////////////////////////////
+
   void startHistogram() { _stats._histogram.start(); }
 
   //////////////////////////////////////////////////////////////////////////////
@@ -306,9 +313,9 @@ class ImportHelper {
   /// @return string       get the error message
   //////////////////////////////////////////////////////////////////////////////
 
-  std::vector<std::string> getErrorMessages() { return _errorMessages; }
+  std::vector<std::string> getErrorMessages() const { return _errorMessages; }
 
-  uint64_t getMaxUploadSize() {
+  uint64_t getMaxUploadSize() const {
     return (_maxUploadSize.load(std::memory_order_relaxed));
   }
   void setMaxUploadSize(uint64_t newSize) {
@@ -320,7 +327,12 @@ class ImportHelper {
 
   uint32_t getThreadCount() const { return _threadCount; }
 
-  static unsigned const MaxBatchSize;
+  ////////////////////////////////////////////////////////////////////////////////
+  /// the server has a built-in limit for the batch size
+  ///  and will reject bigger HTTP request bodies
+  ////////////////////////////////////////////////////////////////////////////////
+
+  static constexpr unsigned kMaxBatchSize = 768 * 1024 * 1024;
 
  private:
   // read headers from separate file
@@ -355,10 +367,11 @@ class ImportHelper {
   std::unique_ptr<httpclient::SimpleHttpClient> _httpClient;
   std::atomic<uint64_t> _maxUploadSize;
   std::atomic<uint64_t> _periodByteCount;
-  bool const _autoUploadSize;
   std::unique_ptr<AutoTuneThread> _autoTuneThread;
   std::vector<std::unique_ptr<SenderThread>> _senderThreads;
+  uint64_t const _maxErrors;
   uint32_t const _threadCount;
+  bool const _autoUploadSize;
   basics::ConditionVariable _threadsCondition;
   basics::StringBuffer _tempBuffer;
 
@@ -406,7 +419,6 @@ class ImportHelper {
   bool _emittedField;
   std::vector<std::string> _errorMessages;
 
-  static double const ProgressStep;
+  static constexpr double kProgressStep = 3.0;
 };
-}  // namespace import
-}  // namespace arangodb
+}  // namespace arangodb::import

--- a/client-tools/Import/SenderThread.h
+++ b/client-tools/Import/SenderThread.h
@@ -65,10 +65,10 @@ class SenderThread final : public arangodb::Thread {
 
   bool hasError();
   /// Ready to start sending
-  bool isReady();
+  bool isReady() const;
   /// Currently not sending data
-  bool isIdle();
-  bool isDone();
+  bool isIdle() const;
+  bool isDone() const;
 
   std::string const& errorMessage() const { return _errorMessage; }
 
@@ -78,7 +78,7 @@ class SenderThread final : public arangodb::Thread {
   void run() override;
 
  private:
-  basics::ConditionVariable _condition;
+  basics::ConditionVariable mutable _condition;
   std::unique_ptr<httpclient::SimpleHttpClient> _client;
   std::function<void()> _wakeup;
   std::string _url;


### PR DESCRIPTION
### Scope & Purpose

Implement https://arangodb.atlassian.net/browse/BTS-1700

* BTS-1700: arangoimport parser should abort after a reasonable amount of parse errors without success.

  This introduces an option `--max-errors` for arangoimport. This option can be used to limit the amount of error messages displayed by arangoimport, and to abort the import after at least this many errors have occurred.

  The default value for the option is 20, so that imports will quickly stop in case many errors occur. This is a behavior change compared to previous versions, in which the import would continue even when there were many errors. To achive the same behavior with the new version, the value of the arangoimport startup option `--max-errors` can be set to a high value.

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [x] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/BTS-1700
- [ ] Design document: 