### PR TITLE
Implement wildcard analyzer

### DIFF
--- a/arangod/IResearch/CMakeLists.txt
+++ b/arangod/IResearch/CMakeLists.txt
@@ -87,6 +87,12 @@ add_library(arango_iresearch STATIC
   VelocyPackHelper.h
   ViewSnapshot.cpp
   ViewSnapshot.h
+  Wildcard/Analyzer.cpp
+  Wildcard/Analyzer.h
+  Wildcard/Filter.cpp
+  Wildcard/Filter.h
+  Wildcard/Options.cpp
+  Wildcard/Options.h
   ${PROJECT_SOURCE_DIR}/arangod/RestHandler/RestAnalyzerHandler.cpp
   ${PROJECT_SOURCE_DIR}/arangod/RestHandler/RestAnalyzerHandler.h)
 

--- a/arangod/IResearch/IResearchAnalyzerFeature.cpp
+++ b/arangod/IResearch/IResearchAnalyzerFeature.cpp
@@ -65,6 +65,7 @@
 #include "IResearch/IResearchIdentityAnalyzer.h"
 #include "IResearch/IResearchLink.h"
 #include "IResearch/IResearchKludge.h"
+#include "IResearch/Wildcard/Analyzer.h"
 #include "Logger/LogMacros.h"
 #include "Network/Methods.h"
 #include "Network/NetworkFeature.h"
@@ -131,6 +132,8 @@ REGISTER_ANALYZER_VPACK(GeoVPackAnalyzer, GeoVPackAnalyzer::make,
                         GeoVPackAnalyzer::normalize);
 REGISTER_ANALYZER_VPACK(GeoPointAnalyzer, GeoPointAnalyzer::make,
                         GeoPointAnalyzer::normalize);
+REGISTER_ANALYZER_VPACK(wildcard::Analyzer, wildcard::Analyzer::make,
+                        wildcard::Analyzer::normalize);
 REGISTER_ANALYZER_VPACK(AqlAnalyzer, AqlAnalyzer::make_vpack,
                         AqlAnalyzer::normalize_vpack);
 REGISTER_ANALYZER_JSON(AqlAnalyzer, AqlAnalyzer::make_json,
@@ -810,6 +813,9 @@ getAnalyzerMeta(irs::analysis::analyzer const* analyzer) noexcept {
   } else if (type == irs::type<GeoPointAnalyzer>::id()) {
     return {AnalyzerValueType::Object | AnalyzerValueType::Array,
             AnalyzerValueType::String, &GeoPointAnalyzer::store};
+  } else if (type == irs::type<wildcard::Analyzer>::id()) {
+    return {AnalyzerValueType::String, AnalyzerValueType::String,
+            &wildcard::Analyzer::store};
   }
 
 #ifdef ARANGODB_USE_GOOGLE_TESTS
@@ -918,8 +924,7 @@ bool AnalyzerPool::operator==(AnalyzerPool const& rhs) const {
          basics::VelocyPackHelper::equal(_properties, rhs._properties, true);
 }
 
-bool AnalyzerPool::init(std::string_view const& type,
-                        VPackSlice const properties,
+bool AnalyzerPool::init(std::string_view type, VPackSlice const properties,
                         AnalyzersRevision::Revision revision, Features features,
                         LinkVersion version) {
   try {
@@ -1198,7 +1203,7 @@ Result IResearchAnalyzerFeature::createAnalyzerPool(
 
   // validate that features are supported by arangod an ensure that their
   // dependencies are met
-  const auto validationRes = features.validate();
+  const auto validationRes = features.validate(type);
   if (validationRes.fail()) {
     return validationRes;
   }
@@ -1261,7 +1266,7 @@ Result IResearchAnalyzerFeature::emplaceAnalyzer(
 
   // validate that features are supported by arangod an ensure that their
   // dependencies are met
-  auto validationRes = features.validate();
+  auto validationRes = features.validate(type);
   if (validationRes.fail()) {
     return validationRes;
   }
@@ -3098,7 +3103,7 @@ bool Features::add(std::string_view featureName) {
   return false;
 }
 
-Result Features::validate() const {
+Result Features::validate(std::string_view type) const {
   if (hasFeatures(irs::IndexFeatures::OFFS) &&
       !hasFeatures(irs::IndexFeatures::POS)) {
     return {TRI_ERROR_BAD_PARAMETER,
@@ -3113,9 +3118,14 @@ Result Features::validate() const {
             "specified"};
   }
 
-  constexpr irs::IndexFeatures kSupportedFeatures = irs::IndexFeatures::OFFS |
-                                                    irs::IndexFeatures::POS |
-                                                    irs::IndexFeatures::FREQ;
+  // wildcard shouldn't have offs in the index
+  // TODO(MBkkt) geo analyzers shouldn't have freq, pos, offs in the index
+  bool isWildcardAnalyzer = type == wildcard::Analyzer::type_name();
+
+  irs::IndexFeatures kSupportedFeatures =
+      irs::IndexFeatures::FREQ | irs::IndexFeatures::POS |
+      (isWildcardAnalyzer ? irs::IndexFeatures::NONE
+                          : irs::IndexFeatures::OFFS);
 
   if (kSupportedFeatures != (_indexFeatures | kSupportedFeatures)) {
     return {

--- a/arangod/IResearch/IResearchAnalyzerFeature.h
+++ b/arangod/IResearch/IResearchAnalyzerFeature.h
@@ -125,7 +125,7 @@ class Features {
   ///        dependencies are met
   /// @return Result containing error description if any
   //////////////////////////////////////////////////////////////////////////////
-  Result validate() const;
+  Result validate(std::string_view type = {}) const;
 
   //////////////////////////////////////////////////////////////////////////////
   /// @brief visit feature names
@@ -147,14 +147,14 @@ class Features {
     return !(*this == rhs);
   }
 
- private:
   bool hasFeatures(irs::IndexFeatures test) const noexcept {
     return (test == (_indexFeatures & test));
   }
 
+ private:
   FieldFeatures _fieldFeatures{FieldFeatures::NONE};
   irs::IndexFeatures _indexFeatures{irs::IndexFeatures::NONE};
-};  // Features
+};
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @class AnalyzerPool
@@ -206,9 +206,6 @@ class AnalyzerPool : private irs::util::noncopyable {
   irs::features_t fieldFeatures() const noexcept {
     return {_fieldFeatures.data(), _fieldFeatures.size()};
   }
-  irs::IndexFeatures indexFeatures() const noexcept {
-    return features().indexFeatures();
-  }
   std::string const& name() const noexcept { return _name; }
   VPackSlice properties() const noexcept { return _properties; }
   std::string_view const& type() const noexcept { return _type; }
@@ -242,7 +239,7 @@ class AnalyzerPool : private irs::util::noncopyable {
 
   void toVelocyPack(velocypack::Builder& builder, std::string_view const& name);
 
-  bool init(std::string_view const& type, VPackSlice const properties,
+  bool init(std::string_view type, VPackSlice const properties,
             AnalyzersRevision::Revision revision, Features features,
             LinkVersion version);
   void setKey(std::string_view type);

--- a/arangod/IResearch/IResearchDataStore.cpp
+++ b/arangod/IResearch/IResearchDataStore.cpp
@@ -1194,6 +1194,7 @@ irs::IndexWriterOptions IResearchDataStore::getWriterOptions(
     }
   }
   // setup columnstore compression/encryption if requested by storage engine
+  // TODO(MBkkt) we probably want to disable encryption for geo and norm columns
   auto const encrypt =
       (nullptr != _dataStore._directory->attributes().encryption());
   options.column_info =

--- a/arangod/IResearch/IResearchDocument.cpp
+++ b/arangod/IResearch/IResearchDocument.cpp
@@ -596,7 +596,7 @@ bool FieldIterator<IndexMetaStruct>::setValue(
         _value._indexFeatures = context.indexFeatures();
       } else {
         _value._fieldFeatures = pool->fieldFeatures();
-        _value._indexFeatures = pool->indexFeatures();
+        _value._indexFeatures = pool->features().indexFeatures();
       }
       _value._name = _nameBuffer;
     } break;

--- a/arangod/IResearch/IResearchKludge.cpp
+++ b/arangod/IResearch/IResearchKludge.cpp
@@ -32,6 +32,7 @@
 #ifdef USE_ENTERPRISE
 #include "Enterprise/IResearch/GeoAnalyzerEE.h"
 #endif
+#include "IResearch/Wildcard/Analyzer.h"
 
 #include <frozen/set.h>
 
@@ -202,7 +203,7 @@ bool isGeoAnalyzer(std::string_view type) noexcept {
 }
 
 bool isPrimitiveAnalyzer(std::string_view type) noexcept {
-  return !isGeoAnalyzer(type);
+  return type != wildcard::Analyzer::type_name() && !isGeoAnalyzer(type);
 }
 
 }  // namespace iresearch::kludge

--- a/arangod/IResearch/IResearchRocksDBRecoveryHelper.cpp
+++ b/arangod/IResearch/IResearchRocksDBRecoveryHelper.cpp
@@ -286,7 +286,6 @@ IResearchRocksDBRecoveryHelper::getRanges(uint64_t objectId) {
 
 IResearchRocksDBRecoveryHelper::Ranges
 IResearchRocksDBRecoveryHelper::makeRanges(uint64_t objectId) {
-  TRI_ASSERT(!_skipAllItems);
   auto collection = lookupCollection(objectId);
   if (!collection) {
     // TODO(MBkkt) it was ok in the old implementation

--- a/arangod/IResearch/Wildcard/Analyzer.cpp
+++ b/arangod/IResearch/Wildcard/Analyzer.cpp
@@ -1,0 +1,236 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2023 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Valery Mironov
+////////////////////////////////////////////////////////////////////////////////
+
+#include "Assertions/Assert.h"
+#include "Basics/DownCast.h"
+#include "Basics/Result.h"
+#include "IResearch/IResearchCommon.h"
+#include "IResearch/VelocyPackHelper.h"
+#include "IResearch/Wildcard/Analyzer.h"
+#include "Logger/LogMacros.h"
+
+#include "analysis/token_streams.hpp"
+#include "utils/bytes_utils.hpp"
+#include "utils/vpack_utils.hpp"
+
+#include <velocypack/Builder.h>
+
+namespace arangodb::iresearch::wildcard {
+namespace {
+
+constexpr std::string_view kNgramSize = "ngramSize";
+constexpr std::string_view kParseError =
+    ", failed to parse options for wildcard analyzer";
+constexpr size_t kMinNgram = 2;
+
+bool ParseNgramSize(velocypack::Slice input, size_t& ngramSize) {
+  IRS_ASSERT(input.isObject());
+  input = input.get(kNgramSize);
+  if (!input.isNumber<size_t>()) {
+    IRS_LOG_ERROR(
+        absl::StrCat(kNgramSize, " attribute must be size_t", kParseError));
+    return false;
+  }
+  ngramSize = input.getNumber<size_t>();
+  if (ngramSize < kMinNgram) {
+    IRS_LOG_ERROR(absl::StrCat(kNgramSize, " attribute must be at least ",
+                               kMinNgram, kParseError));
+    return false;
+  }
+  return true;
+}
+
+bool ParseOptions(velocypack::Slice slice, Analyzer::Options& options) {
+  if (!slice.isObject()) {
+    return false;
+  }
+  if (!ParseNgramSize(slice, options.ngramSize)) {
+    return false;
+  }
+  if (!irs::analysis::analyzers::MakeAnalyzer(slice, options.analyzer)) {
+    IRS_LOG_ERROR(absl::StrCat("Invalid analyzer definition in ",
+                               irs::slice_to_string(slice), kParseError));
+    return false;
+  }
+  return true;
+}
+
+irs::analysis::analyzer::ptr MakeImpl(velocypack::Slice slice) {
+  if (Analyzer::Options opts; ParseOptions(slice, opts)) {
+    return std::make_unique<Analyzer>(std::move(opts));
+  }
+  return {};
+}
+
+bool NormalizeImpl(velocypack::Slice input, velocypack::Builder& output) {
+  if (!input.isObject()) {
+    return false;
+  }
+  size_t ngram_size = 0;
+  if (!ParseNgramSize(input, ngram_size)) {
+    return false;
+  }
+  velocypack::ObjectBuilder scope{&output};
+  output.add(kNgramSize, velocypack::Value{ngram_size});
+  if (!irs::analysis::analyzers::NormalizeAnalyzer(input, output)) {
+    IRS_LOG_ERROR(absl::StrCat("Invalid analyzer definition in ",
+                               irs::slice_to_string(input), kParseError));
+    return false;
+  }
+  return true;
+}
+
+static constexpr std::string_view kFill = "00000\xFF";
+
+constexpr std::string_view fill(size_t len) noexcept {
+  return {kFill.data() + kFill.size() - len, len};
+}
+
+irs::byte_type const* nextUTF8(irs::byte_type const* it,
+                               irs::byte_type const* end) noexcept {
+  const uint32_t cp_start = *it++;
+  if (IRS_UNLIKELY(cp_start >= 0b1000'0000)) {
+    if (cp_start < 0b1110'0000) {
+      ++it;
+    } else if (cp_start < 0b1111'0000) {
+      it += 2;
+    } else if (cp_start < 0b1111'1000) {
+      it += 3;
+    }
+    if (it > end) {
+      it = end;
+    }
+  }
+  return it;
+}
+
+}  // namespace
+
+bool Analyzer::normalize(std::string_view args, std::string& definition) {
+  if (args.empty()) {
+    IRS_LOG_ERROR(absl::StrCat("Empty arguments", kParseError));
+    return false;
+  }
+  velocypack::Slice input{reinterpret_cast<const uint8_t*>(args.data())};
+  velocypack::Builder output;
+  if (!NormalizeImpl(input, output)) {
+    return false;
+  }
+  definition.assign(output.slice().startAs<char>(), output.slice().byteSize());
+  return true;
+}
+
+irs::analysis::analyzer::ptr Analyzer::make(std::string_view args) {
+  if (args.empty()) {
+    IRS_LOG_ERROR(absl::StrCat("Empty arguments", kParseError));
+    return {};
+  }
+  velocypack::Slice slice{reinterpret_cast<const uint8_t*>(args.data())};
+  return MakeImpl(slice);
+}
+
+irs::attribute* Analyzer::get_mutable(irs::type_info::type_id type) {
+  if (type == irs::type<irs::offset>::id()) {
+    return nullptr;
+  }
+  return _ngram->get_mutable(type);
+}
+
+bool Analyzer::reset(std::string_view data) {
+  if (!_analyzer->reset(data)) {
+    return false;
+  }
+  _terms.clear();
+  while (_analyzer->next()) {
+    auto const size = _term->value.size();
+    if (size > std::numeric_limits<int32_t>::max()) {
+      // TODO(MBkkt) icu doesn't support more
+      LOG_TOPIC("14345", ERR, TOPIC)
+          << "too long input for wildcard analyzer: " << size;
+      continue;
+    }
+    // TODO(MBkkt) We can add offsets here
+    auto const idx = _terms.size();
+    absl::StrAppend(&_terms, fill(irs::bytes_io<uint32_t>::vsize(size) + 1),
+                    irs::ViewCast<char>(_term->value), fill(1));
+    auto* data = begin() + idx;
+    irs::vwrite<uint32_t>(data, size);
+  }
+  _termsBegin = begin();
+  _termsEnd = _termsBegin + _terms.size();
+  return _termsBegin != _termsEnd;
+}
+
+irs::bytes_view Analyzer::store(irs::token_stream* ctx,
+                                velocypack::Slice slice) {
+  auto& impl = basics::downCast<Analyzer>(*ctx);
+  return irs::ViewCast<irs::byte_type>(std::string_view{impl._terms});
+}
+
+bool Analyzer::next() {
+  if (IRS_LIKELY(_ngram->next())) {
+    return true;
+  }
+  if (auto size = _ngramTerm->value.size(); size > 1) {
+    auto* begin = _ngramTerm->value.data();
+    auto* end = begin + size;
+    begin = nextUTF8(begin, end);
+    _ngramTerm->value = {begin, end};
+    return true;
+  }
+  if (_termsBegin == _termsEnd) {
+    return false;
+  }
+  auto const size = irs::vread<uint32_t>(_termsBegin) + 2U;
+  irs::bytes_view term{_termsBegin, size};
+  _ngram->reset(irs::ViewCast<char>(term));
+  _termsBegin += size;
+  if (!_ngram->next()) {
+    _ngramTerm->value = term;
+  }
+  return true;
+}
+
+Analyzer::Analyzer(Options&& options) noexcept
+    : _analyzer{std::move(options.analyzer)} {
+  if (!_analyzer) {
+    // Fallback to default implementation
+    _analyzer = std::make_unique<irs::string_token_stream>();
+  }
+  auto ptr = Ngram::make({
+      options.ngramSize,
+      options.ngramSize,
+      false,
+      Ngram::InputType::UTF8,
+      {},
+      {},
+  });
+  _ngram = decltype(_ngram){basics::downCast<Ngram>(ptr.release())};
+  TRI_ASSERT(_ngram);
+  _term = irs::get<irs::term_attribute>(*_analyzer);
+  TRI_ASSERT(_term);
+  _ngramTerm = irs::get_mutable<irs::term_attribute>(_ngram.get());
+  TRI_ASSERT(_ngramTerm);
+}
+
+}  // namespace arangodb::iresearch::wildcard

--- a/arangod/IResearch/Wildcard/Analyzer.cpp
+++ b/arangod/IResearch/Wildcard/Analyzer.cpp
@@ -191,10 +191,12 @@ bool Analyzer::next() {
   }
   if (auto size = _ngramTerm->value.size(); size > 1) {
     auto* begin = _ngramTerm->value.data();
-    auto* end = begin + size;
+    auto* end = begin + _ngramTerm->value.size();
     begin = nextUTF8(begin, end);
     _ngramTerm->value = {begin, end};
-    return true;
+    if (_ngramTerm->value.size() > 1) {
+      return true;
+    }
   }
   if (_termsBegin == _termsEnd) {
     return false;

--- a/arangod/IResearch/Wildcard/Analyzer.cpp
+++ b/arangod/IResearch/Wildcard/Analyzer.cpp
@@ -176,7 +176,7 @@ bool Analyzer::reset(std::string_view data) {
         fill(irs::bytes_io<uint32_t>::vsize(static_cast<uint32_t>(size)) + 1),
         irs::ViewCast<char>(_term->value), fill(1));
     auto* data = begin() + idx;
-    irs::vwrite<uint32_t>(data, size);
+    irs::vwrite<uint32_t>(data, static_cast<uint32_t>(size));
   }
   _termsBegin = begin();
   _termsEnd = _termsBegin + _terms.size();

--- a/arangod/IResearch/Wildcard/Analyzer.cpp
+++ b/arangod/IResearch/Wildcard/Analyzer.cpp
@@ -23,11 +23,7 @@
 
 #include "Assertions/Assert.h"
 #include "Basics/DownCast.h"
-#include "Basics/Result.h"
-#include "IResearch/IResearchCommon.h"
-#include "IResearch/VelocyPackHelper.h"
 #include "IResearch/Wildcard/Analyzer.h"
-#include "Logger/LogMacros.h"
 
 #include "analysis/token_streams.hpp"
 #include "utils/bytes_utils.hpp"
@@ -165,8 +161,8 @@ bool Analyzer::reset(std::string_view data) {
     auto const size = _term->value.size();
     if (size > std::numeric_limits<int32_t>::max()) {
       // TODO(MBkkt) icu doesn't support more
-      LOG_TOPIC("14345", ERR, TOPIC)
-          << "too long input for wildcard analyzer: " << size;
+      IRS_LOG_WARN(
+          absl::StrCat("too long input for wildcard analyzer: ", size));
       continue;
     }
     // TODO(MBkkt) We can add offsets here

--- a/arangod/IResearch/Wildcard/Analyzer.cpp
+++ b/arangod/IResearch/Wildcard/Analyzer.cpp
@@ -171,8 +171,10 @@ bool Analyzer::reset(std::string_view data) {
     }
     // TODO(MBkkt) We can add offsets here
     auto const idx = _terms.size();
-    absl::StrAppend(&_terms, fill(irs::bytes_io<uint32_t>::vsize(size) + 1),
-                    irs::ViewCast<char>(_term->value), fill(1));
+    absl::StrAppend(
+        &_terms,
+        fill(irs::bytes_io<uint32_t>::vsize(static_cast<uint32_t>(size)) + 1),
+        irs::ViewCast<char>(_term->value), fill(1));
     auto* data = begin() + idx;
     irs::vwrite<uint32_t>(data, size);
   }

--- a/arangod/IResearch/Wildcard/Analyzer.h
+++ b/arangod/IResearch/Wildcard/Analyzer.h
@@ -1,0 +1,80 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2023 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Valery Mironov
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "Assertions/Assert.h"
+#include "analysis/analyzer.hpp"
+#include "analysis/token_attributes.hpp"
+#include "analysis/ngram_token_stream.hpp"
+
+#include <velocypack/Slice.h>
+
+namespace arangodb::iresearch::wildcard {
+
+class Analyzer final : public irs::analysis::TypedAnalyzer<Analyzer>,
+                       private irs::util::noncopyable {
+  using Ngram = irs::analysis::ngram_token_stream<
+      irs::analysis::ngram_token_stream_base::InputType::UTF8>;
+
+ public:
+  struct Options {
+    analyzer::ptr analyzer;
+    size_t ngramSize = 3;
+  };
+
+  static constexpr std::string_view type_name() noexcept { return "wildcard"; }
+  static bool normalize(std::string_view args, std::string& definition);
+  static analyzer::ptr make(std::string_view args);
+
+  explicit Analyzer(Options&& options) noexcept;
+
+  irs::attribute* get_mutable(irs::type_info::type_id type) final;
+
+  bool reset(std::string_view data) final;
+
+  static irs::bytes_view store(irs::token_stream* ctx, velocypack::Slice slice);
+
+  bool next() final;
+
+  auto& ngram() const noexcept {
+    TRI_ASSERT(_ngram);
+    return *_ngram;
+  }
+
+ private:
+  irs::byte_type* begin() noexcept {
+    return reinterpret_cast<irs::byte_type*>(_terms.data());
+  }
+
+  analyzer::ptr _analyzer;
+  std::unique_ptr<Ngram> _ngram;
+  irs::term_attribute const* _term{};
+  irs::term_attribute* _ngramTerm{};
+  irs::bytes_view _lastNgram;
+  std::string _terms;
+  irs::byte_type const* _termsBegin{};
+  irs::byte_type const* _termsEnd{};
+};
+
+}  // namespace arangodb::iresearch::wildcard

--- a/arangod/IResearch/Wildcard/Analyzer.h
+++ b/arangod/IResearch/Wildcard/Analyzer.h
@@ -71,7 +71,6 @@ class Analyzer final : public irs::analysis::TypedAnalyzer<Analyzer>,
   std::unique_ptr<Ngram> _ngram;
   irs::term_attribute const* _term{};
   irs::term_attribute* _ngramTerm{};
-  irs::bytes_view _lastNgram;
   std::string _terms;
   irs::byte_type const* _termsBegin{};
   irs::byte_type const* _termsEnd{};

--- a/arangod/IResearch/Wildcard/Filter.cpp
+++ b/arangod/IResearch/Wildcard/Filter.cpp
@@ -91,7 +91,7 @@ class Iterator : public irs::doc_iterator {
     auto* terms_end = terms_begin + _stored->value.size();
     while (terms_begin != terms_end) {
       auto size = irs::vread<uint32_t>(terms_begin);
-      ++terms_begin;
+      ++terms_begin;  // skip begin marker
 
       auto term = icu::UnicodeString::fromUTF8(
           icu::StringPiece{reinterpret_cast<char const*>(terms_begin),
@@ -103,7 +103,7 @@ class Iterator : public irs::doc_iterator {
         return true;
       }
 
-      terms_begin += size + 1;
+      terms_begin += size + 1;  // skip data and end marker
     }
 
     return false;
@@ -169,8 +169,8 @@ irs::filter::prepared::ptr Filter::prepare(
   // except first, last and all not intersected
 
   if (size == 0) {
-    if (options().prefix) {
-      irs::bytes_view token = options().token;
+    irs::bytes_view token = options().token;
+    if (token.back() != 0xFF) {
       TRI_IF_FAILURE("wildcard::Filter::dissallowPrefix") {
         THROW_ARANGO_EXCEPTION_MESSAGE(
             TRI_ERROR_DEBUG,

--- a/arangod/IResearch/Wildcard/Filter.cpp
+++ b/arangod/IResearch/Wildcard/Filter.cpp
@@ -1,0 +1,238 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2023 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Valery Mironov
+////////////////////////////////////////////////////////////////////////////////
+
+#include "IResearch/Wildcard/Filter.h"
+#include "IResearch/IResearchFilterFactoryCommon.h"
+#include "IResearch/IResearchFilterFactory.h"
+#include "Basics/Exceptions.h"
+#include "Basics/voc-errors.h"
+
+#include "analysis/token_attributes.hpp"
+#include "search/boolean_query.hpp"
+
+namespace arangodb::iresearch::wildcard {
+
+class Iterator : public irs::doc_iterator {
+ public:
+  Iterator(icu::RegexMatcher* matcher, doc_iterator::ptr&& approx,
+           doc_iterator::ptr&& columnIt)
+      : _approx{std::move(approx)}, _columnIt{std::move(columnIt)} {
+    TRI_ASSERT(_approx);
+    TRI_ASSERT(_columnIt);
+    _doc = irs::get<irs::document>(*_approx);
+    _stored = irs::get<irs::payload>(*_columnIt);
+    TRI_ASSERT(matcher);
+    // We need to create our own matcher to avoid data race on matcher
+    auto status = U_ZERO_ERROR;
+    matcher = matcher->pattern().matcher(status);
+    if (!matcher) {
+      THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_INTERNAL_AQL,
+                                     "Cannot create matcher for this pattern");
+    }
+    TRI_ASSERT(status == U_ZERO_ERROR);
+    _matcher = matcher;
+  }
+
+  irs::attribute* get_mutable(irs::type_info::type_id type) final {
+    return _approx->get_mutable(type);
+  }
+
+  irs::doc_id_t value() const final { return _doc->value; }
+
+  bool next() final {
+    while (_approx->next()) {
+      if (Check(value())) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  irs::doc_id_t seek(irs::doc_id_t target) final {
+    target = _approx->seek(target);
+    if (Check(target)) {
+      return target;
+    }
+    next();
+    return value();
+  }
+
+  ~Iterator() override { delete _matcher; }
+
+ private:
+  bool Check(irs::doc_id_t doc) const {
+    // TODO(MBkkt) we can reduce count of matches if we will account
+    // positions of subiterators in _approx (they should growth)
+    if (_columnIt->seek(doc) != doc) {
+      return false;  // it's assert case
+    }
+
+    auto* terms_begin = _stored->value.data();
+    auto* terms_end = terms_begin + _stored->value.size();
+    while (terms_begin != terms_end) {
+      auto size = irs::vread<uint32_t>(terms_begin);
+      ++terms_begin;
+
+      auto term = icu::UnicodeString::fromUTF8(
+          icu::StringPiece{reinterpret_cast<char const*>(terms_begin),
+                           static_cast<int32_t>(size)});
+
+      _matcher->reset(term);
+
+      if (auto status = U_ZERO_ERROR; _matcher->matches(status)) {
+        return true;
+      }
+
+      terms_begin += size + 1;
+    }
+
+    return false;
+  }
+
+  // TODO(MBkkt) we want to use re2 instead of icu, because it works with utf-8
+  icu::RegexMatcher* _matcher;
+  doc_iterator::ptr _approx;
+  doc_iterator::ptr _columnIt;
+  irs::document const* _doc{};
+  irs::payload const* _stored{};
+};
+
+class Query : public irs::filter::prepared {
+ public:
+  Query(icu::RegexMatcher* matcher, std::string_view field,
+        prepared::ptr&& approx)
+      : _matcher{matcher}, _field{field}, _approx{std::move(approx)} {
+    TRI_ASSERT(_approx);
+    TRI_IF_FAILURE("wildcard::Filter::needsMatcher") {
+      if (!_matcher) {
+        THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_DEBUG, "no matcher");
+      }
+    }
+    TRI_IF_FAILURE("wildcard::Filter::dissallowMatcher") {
+      if (_matcher) {
+        THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_DEBUG, "matcher setted");
+      }
+    }
+  }
+
+  irs::doc_iterator::ptr execute(const irs::ExecutionContext& ctx) const final {
+    auto approx = _approx->execute(ctx);
+    if (!_matcher || approx == irs::doc_iterator::empty()) {
+      return approx;
+    }
+    auto* column = ctx.segment.column(_field);
+    if (column == nullptr) {
+      return irs::doc_iterator::empty();
+    }
+    auto columnIt = column->iterator(irs::ColumnHint::kNormal);
+    return irs::memory::make_managed<Iterator>(_matcher, std::move(approx),
+                                               std::move(columnIt));
+  }
+
+  void visit(const irs::SubReader& segment, irs::PreparedStateVisitor& visitor,
+             irs::score_t boost) const final {
+    THROW_ARANGO_EXCEPTION(TRI_ERROR_NOT_IMPLEMENTED);
+  }
+
+ private:
+  icu::RegexMatcher* _matcher{};
+  std::string _field;
+  prepared::ptr _approx;
+};
+
+irs::filter::prepared::ptr Filter::prepare(
+    const irs::PrepareContext& ctx) const {
+  auto& parts = options().parts;
+  auto size = parts.size();
+  prepared::ptr p;
+  // TODO(MBkkt) by_phrase don't need to make position check for any ngram
+  // except first, last and all not intersected
+
+  if (size == 0) {
+    if (options().prefix) {
+      irs::bytes_view token = options().token;
+      TRI_IF_FAILURE("wildcard::Filter::dissallowPrefix") {
+        THROW_ARANGO_EXCEPTION_MESSAGE(
+            TRI_ERROR_DEBUG,
+            absl::StrCat("prefix disabled for: ", irs::ViewCast<char>(token)));
+      }
+      p = irs::by_prefix::prepare(ctx, field(), token,
+                                  FilterConstants::DefaultScoringTermsLimit);
+    } else {
+      TRI_IF_FAILURE("wildcard::Filter::needsPrefix") {
+        THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_DEBUG,
+                                       "term instead of prefix");
+      }
+      p = irs::by_term::prepare(ctx, field(), options().token);
+    }
+  } else if (size == 1 && options().hasPos) {
+    TRI_IF_FAILURE("wildcard::Filter::needsPrefix") {
+      THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_DEBUG,
+                                     "phrase instead of prefix");
+    }
+    p = irs::by_phrase::Prepare(ctx, field(), std::move(parts[0]));
+  }
+
+  if (p) {
+    if (p == prepared::empty()) {
+      return p;
+    }
+    return irs::memory::make_tracked<Query>(ctx.memory, options().matcher,
+                                            field(), std::move(p));
+  }
+  TRI_IF_FAILURE("wildcard::Filter::needsPrefix") {
+    THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_DEBUG,
+                                   "phrases instead of prefix");
+  }
+
+  irs::AndQuery::queries_t queries{{ctx.memory}};
+  if (options().hasPos) {
+    queries.resize(size);
+    for (size_t i = 0; auto& part : parts) {
+      p = irs::by_phrase::Prepare(ctx, field(), part);
+      if (p == prepared::empty()) {
+        return p;
+      }
+      queries[i++] = std::move(p);
+    }
+  } else {
+    for (auto& part : parts) {
+      for (auto const& term : part) {
+        auto p = irs::by_term::prepare(
+            ctx, field(), std::get<irs::by_term_options>(term.second).term);
+        if (p == prepared::empty()) {
+          return p;
+        }
+        queries.push_back(std::move(p));
+      }
+    }
+    size = queries.size();
+  }
+  auto conjunction = irs::memory::make_tracked<irs::AndQuery>(ctx.memory);
+  conjunction->prepare(ctx, irs::ScoreMergeType::kSum, std::move(queries),
+                       size);
+  return irs::memory::make_tracked<Query>(ctx.memory, options().matcher,
+                                          field(), std::move(conjunction));
+}
+
+}  // namespace arangodb::iresearch::wildcard

--- a/arangod/IResearch/Wildcard/Filter.h
+++ b/arangod/IResearch/Wildcard/Filter.h
@@ -1,0 +1,37 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2023 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Valery Mironov
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "IResearch/Wildcard/Options.h"
+
+#include "search/filter.hpp"
+
+namespace arangodb::iresearch::wildcard {
+
+class Filter final : public irs::filter_base<Options> {
+ public:
+  prepared::ptr prepare(const irs::PrepareContext& ctx) const final;
+};
+
+}  // namespace arangodb::iresearch::wildcard

--- a/arangod/IResearch/Wildcard/Options.cpp
+++ b/arangod/IResearch/Wildcard/Options.cpp
@@ -82,9 +82,7 @@ Options::Options(std::string_view pattern, AnalyzerPool const& analyzer,
       *patternLast++ = *patternCurr;
     }
   }
-  if (escaped) {
-    *patternLast++ = '\\';
-  }
+  TRI_ASSERT(!escaped);  // AQL validates pattern
   if (patternFirst != patternLast) {
     *patternLast++ = '\xFF';
     makeParts(patternFirst, patternLast);

--- a/arangod/IResearch/Wildcard/Options.cpp
+++ b/arangod/IResearch/Wildcard/Options.cpp
@@ -82,7 +82,7 @@ Options::Options(std::string_view pattern, AnalyzerPool const& analyzer,
       *patternLast++ = *patternCurr;
     }
   }
-  TRI_ASSERT(!escaped);  // AQL validates pattern
+  // We ignore escaped because post-filtering ignore it
   if (patternFirst != patternLast) {
     *patternLast++ = '\xFF';
     makeParts(patternFirst, patternLast);

--- a/arangod/IResearch/Wildcard/Options.cpp
+++ b/arangod/IResearch/Wildcard/Options.cpp
@@ -1,0 +1,101 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2023 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Valery Mironov
+////////////////////////////////////////////////////////////////////////////////
+
+#include "IResearch/Wildcard/Options.h"
+#include "Aql/ExpressionContext.h"
+#include "IResearch/Wildcard/Analyzer.h"
+#include "Basics/DownCast.h"
+
+namespace arangodb::iresearch::wildcard {
+
+Options::Options(std::string_view pattern, AnalyzerPool const& analyzer,
+                 aql::ExpressionContext* ctx) {
+  auto& ngram = basics::downCast<wildcard::Analyzer>(*analyzer.get()).ngram();
+  auto const* term = irs::get<irs::term_attribute>(ngram);
+  auto makePartsImpl = [&](std::string_view v) {
+    if (!ngram.reset(v)) {
+      return false;
+    }
+    irs::by_phrase_options part;
+    for (size_t i = 0; ngram.next(); ++i) {
+      part.insert(irs::by_term_options{irs::bstring{term->value}}, i);
+    }
+    if (part.empty()) {
+      return false;
+    }
+    parts.push_back(std::move(part));
+    return true;
+  };
+
+  irs::bytes_view best;
+  auto makeParts = [&](auto const* begin, auto const* end) {
+    TRI_ASSERT(begin <= end);
+    std::string_view v{begin, end};
+    if (!makePartsImpl(v) && best.size() <= v.size()) {
+      best = irs::ViewCast<irs::byte_type>(v);
+    }
+  };
+
+  std::string patternStr;
+  patternStr.resize(2 + pattern.size());
+  auto* patternFirst = patternStr.data();
+  auto* patternLast = patternFirst;
+  *patternLast++ = '\xFF';
+  auto* patternCurr = pattern.data();
+  auto* patternEnd = patternCurr + pattern.size();
+  bool needsMatcher = false;
+  for (bool escaped = false; patternCurr != patternEnd; ++patternCurr) {
+    if (escaped) {
+      escaped = false;
+      *patternLast++ = *patternCurr;
+    } else if (*patternCurr == '\\') {
+      escaped = true;
+    } else if (*patternCurr == '_' || *patternCurr == '%') {
+      bool any = *patternCurr == '_';
+      if (any ||
+          (patternCurr != pattern.data() && patternCurr != patternEnd - 1)) {
+        needsMatcher = true;
+      }
+      makeParts(patternFirst, patternLast);
+      patternFirst = patternLast;
+    } else {
+      *patternLast++ = *patternCurr;
+    }
+  }
+  if (patternFirst != patternLast) {
+    *patternLast++ = '\xFF';
+    makeParts(patternFirst, patternLast);
+  }
+  if (parts.empty()) {
+    TRI_ASSERT(!best.empty());
+    prefix = best.back() != 0xFF;
+    token = best;
+  } else {
+    hasPos = analyzer.features().hasFeatures(irs::IndexFeatures::POS);
+  }
+  if (needsMatcher || !hasPos) {
+    matcher = ctx->buildLikeMatcher(pattern, true);
+  }
+}
+
+}  // namespace arangodb::iresearch::wildcard

--- a/arangod/IResearch/Wildcard/Options.h
+++ b/arangod/IResearch/Wildcard/Options.h
@@ -1,0 +1,66 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2023 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Valery Mironov
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "IResearch/IResearchAnalyzerFeature.h"
+#include "search/phrase_filter.hpp"
+#include "utils/string.hpp"
+
+#include <unicode/regex.h>
+
+#include <vector>
+#include <string>
+#include <cstddef>
+
+namespace arangodb::aql {
+
+class ExpressionContext;
+
+}  // namespace arangodb::aql
+namespace arangodb::iresearch::wildcard {
+
+class Filter;
+
+struct Options {
+  using filter_type = Filter;
+
+  std::vector<irs::by_phrase_options> parts;
+  irs::bstring token;
+  bool prefix{false};
+  bool hasPos{true};
+  icu::RegexMatcher* matcher{};
+
+  // TODO(MBkkt) implement this when we will make filter caching
+  bool operator==(const Options& rhs) const noexcept { return false; }
+  size_t hash() const noexcept { return 0; }
+
+  Options() noexcept = default;
+  Options(Options&&) noexcept = default;
+  Options& operator=(Options&&) noexcept = default;
+
+  Options(std::string_view pattern, AnalyzerPool const& analyzer,
+          aql::ExpressionContext* ctx);
+};
+
+}  // namespace arangodb::iresearch::wildcard

--- a/arangod/IResearch/Wildcard/Options.h
+++ b/arangod/IResearch/Wildcard/Options.h
@@ -47,7 +47,6 @@ struct Options {
 
   std::vector<irs::by_phrase_options> parts;
   irs::bstring token;
-  bool prefix{false};
   bool hasPos{true};
   icu::RegexMatcher* matcher{};
 

--- a/tests/IResearch/IResearchAnalyzerFeatureTest.cpp
+++ b/tests/IResearch/IResearchAnalyzerFeatureTest.cpp
@@ -2342,7 +2342,7 @@ TEST_F(IResearchAnalyzerFeatureTest, test_analyzer_features) {
             .ok());
     ASSERT_NE(nullptr, pool);
     ASSERT_EQ(arangodb::iresearch::Features{}, pool->features());
-    ASSERT_EQ(irs::IndexFeatures::NONE, pool->indexFeatures());
+    ASSERT_EQ(irs::IndexFeatures::NONE, pool->features().indexFeatures());
     ASSERT_TRUE(pool->fieldFeatures().empty());
   }
 
@@ -2359,7 +2359,7 @@ TEST_F(IResearchAnalyzerFeatureTest, test_analyzer_features) {
     ASSERT_NE(nullptr, pool);
     ASSERT_EQ(arangodb::iresearch::Features{irs::IndexFeatures::FREQ},
               pool->features());
-    ASSERT_EQ(irs::IndexFeatures::FREQ, pool->indexFeatures());
+    ASSERT_EQ(irs::IndexFeatures::FREQ, pool->features().indexFeatures());
     ASSERT_TRUE(pool->fieldFeatures().empty());
   }
 
@@ -2381,7 +2381,7 @@ TEST_F(IResearchAnalyzerFeatureTest, test_analyzer_features) {
         (arangodb::iresearch::Features{arangodb::iresearch::FieldFeatures::NORM,
                                        irs::IndexFeatures::FREQ}),
         pool->features());
-    ASSERT_EQ(irs::IndexFeatures::FREQ, pool->indexFeatures());
+    ASSERT_EQ(irs::IndexFeatures::FREQ, pool->features().indexFeatures());
     irs::type_info::type_id const expected[]{irs::type<irs::Norm>::id()};
     auto features = pool->fieldFeatures();
     ASSERT_TRUE(
@@ -2406,7 +2406,7 @@ TEST_F(IResearchAnalyzerFeatureTest, test_analyzer_features) {
         (arangodb::iresearch::Features{arangodb::iresearch::FieldFeatures::NORM,
                                        irs::IndexFeatures::FREQ}),
         pool->features());
-    ASSERT_EQ(irs::IndexFeatures::FREQ, pool->indexFeatures());
+    ASSERT_EQ(irs::IndexFeatures::FREQ, pool->features().indexFeatures());
     irs::type_info::type_id const expected[]{irs::type<irs::Norm2>::id()};
     auto features = pool->fieldFeatures();
     ASSERT_TRUE(

--- a/tests/IResearch/IResearchQueryNGramMatchTest.cpp
+++ b/tests/IResearch/IResearchQueryNGramMatchTest.cpp
@@ -653,7 +653,8 @@ class QueryNGramMatch : public QueryTest {
     // test via default analyzer
     if (flags & kAnalyzerIdentity) {
       std::vector<arangodb::velocypack::Slice> expected = {
-          // no results  will be found as identity analyzer has no positions
+          // exact match because fallback to term query in case of single ngram
+          _insertedDocs[0].slice(),
       };
       auto result = arangodb::tests::executeQuery(
           vocbase,
@@ -666,7 +667,7 @@ class QueryNGramMatch : public QueryTest {
 
       for (arangodb::velocypack::ArrayIterator itr(slice); itr.valid(); ++itr) {
         auto const resolved = itr.value().resolveExternals();
-        EXPECT_TRUE(i < expected.size());
+        ASSERT_TRUE(i < expected.size()) << slice.toJson();
         EXPECT_TRUE((0 == arangodb::basics::VelocyPackHelper::compare(
                               expected[i++], resolved, true)));
       }
@@ -1142,7 +1143,8 @@ class QueryNGramMatch : public QueryTest {
     // test via default analyzer
     if (flags & kAnalyzerIdentity) {
       std::vector<arangodb::velocypack::Slice> expected = {
-          // no results  will be found as identity analyzer has no positions
+          // exact match because fallback to term query in case of single ngram
+          _insertedDocs[0].slice(),
       };
       auto result = arangodb::tests::executeQuery(
           vocbase,
@@ -1155,7 +1157,7 @@ class QueryNGramMatch : public QueryTest {
 
       for (arangodb::velocypack::ArrayIterator itr(slice); itr.valid(); ++itr) {
         auto const resolved = itr.value().resolveExternals();
-        EXPECT_TRUE(i < expected.size());
+        ASSERT_TRUE(i < expected.size()) << slice.toJson();
         EXPECT_TRUE((0 == arangodb::basics::VelocyPackHelper::compare(
                               expected[i++], resolved, true)));
       }

--- a/tests/js/client/aql/aql-arangosearch-wildcard-analyzer.js
+++ b/tests/js/client/aql/aql-arangosearch-wildcard-analyzer.js
@@ -1,0 +1,203 @@
+/*jshint globalstrict:false, strict:false, maxlen: 500 */
+/*global fail, assertEqual, assertNotEqual, assertTrue */
+
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2023 ArangoDB GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Valery Mironov
+////////////////////////////////////////////////////////////////////////////////
+
+let arangodb = require("@arangodb");
+let analyzers = require("@arangodb/analyzers");
+let db = arangodb.db;
+let internal = require("internal");
+let jsunity = require("jsunity");
+const deriveTestSuite = require('@arangodb/test-helper').deriveTestSuite;
+
+function ArangoSearchWildcardAnalyzer(hasPos) {
+  const dbName = "ArangoSearchWildcardAnalyzer" + hasPos;
+
+  let cleanup = function() {
+    internal.debugClearFailAt();
+    db._useDatabase("_system");
+    try { db._dropDatabase(dbName); } catch (err) {}
+  };
+
+  let query = function(pattern, needsPrefix, needsMatcher) {
+    internal.debugClearFailAt();
+    if (needsPrefix) {
+      internal.debugSetFailAt("wildcard::Filter::needsPrefix");
+    } else {
+      internal.debugSetFailAt("wildcard::Filter::dissallowPrefix");
+    }
+    if (needsMatcher) {
+      internal.debugSetFailAt("wildcard::Filter::needsMatcher");
+    } else {
+      internal.debugSetFailAt("wildcard::Filter::dissallowMatcher");
+    }
+    let r = db._query("FOR d in v SEARCH ANALYZER(d.s LIKE '" + pattern + "', 'w') RETURN d.s").toArray().sort();
+    return r;
+  };
+
+  return {
+    setUpAll : function () { 
+      cleanup();
+
+      db._createDatabase(dbName);
+      db._useDatabase(dbName);
+      if (hasPos) {
+        analyzers.save("w", "wildcard", { ngramSize: 4 }, ["frequency", "position"]);
+      } else {
+        analyzers.save("w", "wildcard", { ngramSize: 4 }, []);
+      }
+      let c = db._create("c");
+      c.insert({s: ""});
+      c.insert({s: "abcdef"});
+      c.insert({s:  "bcde"});
+      c.insert({s:   "c"});
+      c.insert({s: "qwerty"});
+      c.insert({s:  "wert"});
+      c.insert({s:   "e"});
+      c.insert({s:   "a"});
+      c.insert({s:   "f"});
+      c.insert({s: "abcdef qwerty"});
+      c.insert({s: "qwerty abcdef"});
+      db._createView("v", "arangosearch",
+          { links: { c: { fields: {s: {}}, analyzers: ["w"] } } });
+    },
+
+    tearDownAll : function () { 
+      cleanup();
+    },
+
+    testExactEmpty: function() {
+      let res = query("", false, false);
+      assertEqual(res, [""]);
+    },
+
+    testExactShort: function() {
+      let res = query("c", false, false);
+      assertEqual(res, ["c"]);
+    },
+
+    testExactMid: function() {
+      let res = query("bcde", false, !hasPos);
+      assertEqual(res, ["bcde"]);
+    },
+
+    testExactLong: function() {
+      let res = query("abcdef", false, !hasPos);
+      assertEqual(res, ["abcdef"]);
+    },
+
+    testAnyShort: function() {
+      let res = query("_", false, true);
+      assertEqual(res, ["a", "c", "e", "f"]);
+    },
+
+    testAnyMid: function() {
+      let res = query("bcd_", false, true);
+      assertEqual(res, ["bcde"]);
+    },
+
+    testAnyLong: function() {
+      let res = query("a_cd_f", false, true);
+      assertEqual(res, ["abcdef"]);
+    },
+
+    testPrefixShort: function() {
+      let res = query("a%", true, false);
+      assertEqual(res, ["a", "abcdef", "abcdef qwerty"]);
+    },
+
+    testPrefixMed: function() {
+      let res = query("abcd%", false, !hasPos);
+      assertEqual(res, ["abcdef", "abcdef qwerty"]);
+    },
+
+    testPrefixLong: function() {
+      let res = query("abcdef%", false, !hasPos);
+      assertEqual(res, ["abcdef", "abcdef qwerty"]);
+    },
+
+    testSuffixShort: function() {
+      let res = query("%f", false, false);
+      assertEqual(res, ["abcdef", "f", "qwerty abcdef"]);
+    },
+
+    testSuffixMed: function() {
+      let res = query("%cdef", false, !hasPos);
+      assertEqual(res, ["abcdef", "qwerty abcdef"]);
+    },
+
+    testSuffixLong: function() {
+      let res = query("%abcdef", false, !hasPos);
+      assertEqual(res, ["abcdef", "qwerty abcdef"]);
+    },
+
+    testAllShort: function() {
+      let res = query("%c%", true, false);
+      assertEqual(res, ["abcdef", "abcdef qwerty", "bcde", "c", "qwerty abcdef"]);
+    },
+
+    testAllMed: function() {
+      let res = query("%bcde%", false, !hasPos);
+      assertEqual(res, ["abcdef", "abcdef qwerty", "bcde", "qwerty abcdef"]);
+    },
+
+    testAllLong: function() {
+      let res = query("%abcdef%", false, !hasPos);
+      assertEqual(res, ["abcdef", "abcdef qwerty", "qwerty abcdef"]);
+    },
+
+    testAll: function() {
+      let res = query("%", false, false);
+      assertEqual(res.length, 11);
+      res = query("%%", false, false);
+      assertEqual(res.length, 11);
+      res = query("%%%", false, true);
+      assertEqual(res.length, 11);
+    },
+  };
+}
+
+function ArangoSearchWildcardAnalyzerNoPos() {
+  let suite = {};
+  deriveTestSuite(
+    ArangoSearchWildcardAnalyzer(false),
+    suite,
+    "_no_pos"
+  );
+  return suite;
+}
+
+function ArangoSearchWildcardAnalyzerHasPos() {
+  let suite = {};
+  deriveTestSuite(
+    ArangoSearchWildcardAnalyzer(true),
+    suite,
+    "_has_pos"
+  );
+  return suite;
+}
+
+jsunity.run(ArangoSearchWildcardAnalyzerNoPos);
+jsunity.run(ArangoSearchWildcardAnalyzerHasPos);
+
+return jsunity.done();

--- a/tests/js/client/aql/aql-arangosearch-wildcard-analyzer.js
+++ b/tests/js/client/aql/aql-arangosearch-wildcard-analyzer.js
@@ -111,8 +111,13 @@ function ArangoSearchWildcardAnalyzer(hasPos) {
       assertEqual(res, ["a", "c", "e", "f"]);
     },
 
-    testAnyMid: function() {
+    testAnyMid1: function() {
       let res = query("bcd_", false, true);
+      assertEqual(res, ["bcde"]);
+    },
+
+    testAnyMid2: function() {
+      let res = query("_cde", false, true);
       assertEqual(res, ["bcde"]);
     },
 
@@ -163,6 +168,11 @@ function ArangoSearchWildcardAnalyzer(hasPos) {
 
     testAllLong: function() {
       let res = query("%abcdef%", false, !hasPos);
+      assertEqual(res, ["abcdef", "abcdef qwerty", "qwerty abcdef"]);
+    },
+
+    testAllBetweenLong: function() {
+      let res = query("%ab%ef%", false, true);
       assertEqual(res, ["abcdef", "abcdef qwerty", "qwerty abcdef"]);
     },
 

--- a/tests/js/client/aql/aql-arangosearch-wildcard-analyzer.js
+++ b/tests/js/client/aql/aql-arangosearch-wildcard-analyzer.js
@@ -68,6 +68,7 @@ function ArangoSearchWildcardAnalyzer(hasPos) {
       }
       let c = db._create("c");
       c.insert({s: ""});
+      c.insert({s: "\\"});
       c.insert({s: "abcdef"});
       c.insert({s:  "bcde"});
       c.insert({s:   "c"});
@@ -84,6 +85,19 @@ function ArangoSearchWildcardAnalyzer(hasPos) {
 
     tearDownAll : function () { 
       cleanup();
+    },
+
+    testExactEscapeInvalid: function() {
+      try {
+        query("\\", false, false);
+        fail("invalid pattern should be disallowed by AQL");
+      } catch (e) {
+      }
+    },
+ 
+    testExactEscapeValid: function() {
+      let res = query("\\\\", false, false);
+      assertEqual(res, ["\\"]);
     },
 
     testExactEmpty: function() {
@@ -108,7 +122,7 @@ function ArangoSearchWildcardAnalyzer(hasPos) {
 
     testAnyShort: function() {
       let res = query("_", false, true);
-      assertEqual(res, ["a", "c", "e", "f"]);
+      assertEqual(res, ["\\", "a", "c", "e", "f"]);
     },
 
     testAnyMid1: function() {
@@ -172,8 +186,8 @@ function ArangoSearchWildcardAnalyzer(hasPos) {
     },
 
     testAllBetweenLong: function() {
-      let res = query("%ab%ef%", false, true);
-      assertEqual(res, ["abcdef", "abcdef qwerty", "qwerty abcdef"]);
+      let res = query("%abcdef% ", false, true);
+      assertEqual(res, ["abcdef qwerty"]);
     },
 
     testAll: function() {


### PR DESCRIPTION
### Scope & Purpose

Using ngram to approximate wildcard queries

For 11 * 1e6 strings, with average length 800 and pattern like `"%fjdkajfkajdgagh%"`:
|cold | hot | memory | analyzer|
|----| ----| ---|---|
| \>= 200s | 35s | 8.3Gb | identity |
| 7ms | 6ms | 20.9Gb | wildcard 3 (position) |
| 20ms | < 1ms | 21.3Gb | wildcard 4 (position) |
| 25ms | < 1ms | 12.9Gb | wildcard 5 (without position) |

csd -- 8.5 Gb, can be compressed...

Can be done in the future:
1. Avoiding additional compute for positions
2. Implement another analyzer without column.
3. Allowing reads from analyzer column
4. Optimize "in" for such field (disjunction of ngram_matches)

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [x] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

