### PR TITLE
Set build-docker-image default value in base config

### DIFF
--- a/.circleci/base_config.yml
+++ b/.circleci/base_config.yml
@@ -9,7 +9,7 @@ parameters:
     default: ""
   build-docker-image:
     type: string
-    default: ""
+    default: "arangodb/build-alpine:3.16-gcc11.2-openssl3.1.4-f3c77755ece"
   # Unused here, but it will be forwarded from config and will cause errors if not defined
   replication-two:
     type: boolean

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ parameters:
     default: ""
   build-docker-image:
     type: string
-    default: arangodb/build-alpine:3.16-gcc11.2-openssl3.1.4-f3c77755ece
+    default: ""
   replication-two:
     type: boolean
     default: false # We use replication1 as default.
@@ -86,7 +86,7 @@ jobs:
             fi
             ENTERPRISE_COMMIT=`git ls-remote --heads git@github.com:arangodb/enterprise.git $ENTERPRISE_BRANCH | cut -f1`
             echo "Using enterprise branch $ENTERPRISE_BRANCH (sha $ENTERPRISE_COMMIT)"
-            echo "{\"enterprise-commit\": \"$ENTERPRISE_COMMIT\", \"build-docker-image\": \"<< pipeline.parameters.build-docker-image >>\"" "}" > parameters.json
+            echo "{\"enterprise-commit\": \"$ENTERPRISE_COMMIT\"}" > parameters.json
             cat parameters.json
 
       - run:


### PR DESCRIPTION
### Scope & Purpose

If a pipeline parameter is set explicitly, this value will implicitly be forwarded to the continuation pipeline. If a value is not explicitly set. but has a default value, then this value is _not_ implicitly forwarded. It can be explicitly forwarded by using the continuation's parameters, but if we do that unconditionally, this causes a problem once the parameter is again set explicitly, because then we get a "Conflicting pipeline parameters." error because the parameter is forwarded twice (once implicitly and once explicitly).
