### PR TITLE
fix BTS-1672: initialize flags of shared, constant node ahead of time

### DIFF
--- a/arangod/Aql/Ast.cpp
+++ b/arangod/Aql/Ast.cpp
@@ -322,19 +322,12 @@ std::unordered_map<int, AstNodeType> const Ast::ReversedOperators{
      NODE_TYPE_OPERATOR_BINARY_GE}};
 
 Ast::SpecialNodes::SpecialNodes()
-    : NopNode{NODE_TYPE_NOP},
-      NullNode{AstNodeValue()},
-      FalseNode{AstNodeValue(false)},
-      TrueNode{AstNodeValue(true)},
-      ZeroNode{AstNodeValue(int64_t(0))},
-      EmptyStringNode{AstNodeValue("", uint32_t(0))} {
-  NopNode.setFlag(AstNodeFlagType::FLAG_INTERNAL_CONST);
-  NullNode.setFlag(AstNodeFlagType::FLAG_INTERNAL_CONST);
-  FalseNode.setFlag(AstNodeFlagType::FLAG_INTERNAL_CONST);
-  TrueNode.setFlag(AstNodeFlagType::FLAG_INTERNAL_CONST);
-  ZeroNode.setFlag(AstNodeFlagType::FLAG_INTERNAL_CONST);
-  EmptyStringNode.setFlag(AstNodeFlagType::FLAG_INTERNAL_CONST);
-
+    : NopNode{NODE_TYPE_NOP, AstNode::InternalNode{}},
+      NullNode{AstNodeValue(), AstNode::InternalNode{}},
+      FalseNode{AstNodeValue(false), AstNode::InternalNode{}},
+      TrueNode{AstNodeValue(true), AstNode::InternalNode{}},
+      ZeroNode{AstNodeValue(int64_t(0), AstNode::InternalNode{})},
+      EmptyStringNode{AstNodeValue("", uint32_t(0)), AstNode::InternalNode{}} {
   // the const-away casts are necessary API-wise. however, we are never ever
   // modifying the computed values for these special nodes.
   NullNode.setComputedValue(

--- a/arangod/Aql/Ast.cpp
+++ b/arangod/Aql/Ast.cpp
@@ -326,7 +326,7 @@ Ast::SpecialNodes::SpecialNodes()
       NullNode{AstNodeValue(), AstNode::InternalNode{}},
       FalseNode{AstNodeValue(false), AstNode::InternalNode{}},
       TrueNode{AstNodeValue(true), AstNode::InternalNode{}},
-      ZeroNode{AstNodeValue(int64_t(0), AstNode::InternalNode{})},
+      ZeroNode{AstNodeValue(int64_t(0)), AstNode::InternalNode{}},
       EmptyStringNode{AstNodeValue("", uint32_t(0)), AstNode::InternalNode{}} {
   // the const-away casts are necessary API-wise. however, we are never ever
   // modifying the computed values for these special nodes.

--- a/arangod/Aql/AstNode.cpp
+++ b/arangod/Aql/AstNode.cpp
@@ -415,7 +415,21 @@ int compareAstNodes(AstNode const* lhs, AstNode const* rhs, bool compareUtf8) {
 
 /// @brief create the node
 AstNode::AstNode(AstNodeType type)
-    : type(type), flags(0), _computedValue(nullptr), members{} {
+    : type(type), flags(0), _computedValue(nullptr) {
+  // properly zero-initialize all members
+  value.value._int = 0;
+  value.length = 0;
+  value.type = VALUE_TYPE_NULL;
+}
+
+/// @brief create the node, and make it an internal const node
+AstNode::AstNode(AstNodeType type, InternalNode /*internal*/)
+    : type(type),
+      flags(makeFlags(DETERMINED_SORTED, DETERMINED_CONSTANT, DETERMINED_SIMPLE,
+                      DETERMINED_NONDETERMINISTIC, DETERMINED_RUNONDBSERVER,
+                      DETERMINED_CHECKUNIQUENESS, DETERMINED_V8,
+                      VALUE_RUNONDBSERVER, FLAG_INTERNAL_CONST)),
+      _computedValue(nullptr) {
   // properly zero-initialize all members
   value.value._int = 0;
   value.length = 0;
@@ -429,8 +443,18 @@ AstNode::AstNode(AstNodeValue const& value)
                       VALUE_SIMPLE, DETERMINED_RUNONDBSERVER,
                       VALUE_RUNONDBSERVER)),
       value(value),
-      _computedValue(nullptr),
-      members{} {}
+      _computedValue(nullptr) {}
+
+/// @brief create a node, with defining a value and making it an
+/// internal const node
+AstNode::AstNode(AstNodeValue const& value, InternalNode /*internal*/)
+    : type(NODE_TYPE_VALUE),
+      flags(makeFlags(DETERMINED_SORTED, DETERMINED_CONSTANT, DETERMINED_SIMPLE,
+                      DETERMINED_NONDETERMINISTIC, DETERMINED_RUNONDBSERVER,
+                      DETERMINED_CHECKUNIQUENESS, DETERMINED_V8, VALUE_CONSTANT,
+                      VALUE_SIMPLE, VALUE_RUNONDBSERVER, FLAG_INTERNAL_CONST)),
+      value(value),
+      _computedValue(nullptr) {}
 
 /// @brief create the node from VPack
 AstNode::AstNode(Ast* ast, arangodb::velocypack::Slice slice)

--- a/arangod/Aql/AstNode.h
+++ b/arangod/Aql/AstNode.h
@@ -231,6 +231,10 @@ static_assert(NODE_TYPE_ARRAY < NODE_TYPE_OBJECT, "incorrect node types order");
 struct AstNode {
   friend class Ast;
 
+  /// @brief a simple tag that marks the AstNode as a constant node
+  /// that will never change after being created
+  struct InternalNode {};
+
   /// @brief array values with at least this number of members that
   /// are in IN or NOT IN lookups will be sorted, so that we can use
   /// a binary sort to do lookups
@@ -239,8 +243,12 @@ struct AstNode {
   /// @brief create the node
   explicit AstNode(AstNodeType);
 
+  explicit AstNode(AstNodeType, InternalNode);
+
   /// @brief create a node, with defining a value
   explicit AstNode(AstNodeValue const& value);
+
+  explicit AstNode(AstNodeValue const& value, InternalNode);
 
   /// @brief create the node from VPack
   explicit AstNode(Ast*, arangodb::velocypack::Slice slice);

--- a/arangod/IResearch/AqlHelper.cpp
+++ b/arangod/IResearch/AqlHelper.cpp
@@ -351,7 +351,11 @@ void visitReferencedVariables(
   aql::Ast::traverseReadOnly(&root, preVisitor, postVisitor);
 }
 
-aql::AstNode const ScopedAqlValue::INVALID_NODE(aql::NODE_TYPE_ROOT);
+// create the node as an InternalNode. this will already properly initialized
+// the relevant node flags, so there are no races when multiple threads try to
+// read and mutate the node's flags concurrently.
+aql::AstNode const ScopedAqlValue::INVALID_NODE(aql::NODE_TYPE_ROOT,
+                                                aql::AstNode::InternalNode{});
 
 bool ScopedAqlValue::execute(iresearch::QueryContext const& ctx) {
   if (_executed && _node->isDeterministic()) {


### PR DESCRIPTION
### Scope & Purpose

Avoid concurrent calls into `AstNode::isConstant()` etc. for shared nodes that can be used from multiple queries concurrently.
Should fix https://arangodb.atlassian.net/browse/BTS-1672

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [x] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/BTS-1672
- [ ] Design document: 