### PR TITLE
fix array iteration in coredump location

### DIFF
--- a/js/client/modules/@arangodb/testutils/crash-utils.js
+++ b/js/client/modules/@arangodb/testutils/crash-utils.js
@@ -661,9 +661,9 @@ function analyzeCrash (binary, instanceInfo, options, checkStr) {
 
     const knownPatterns = ["%s", "%d", "%e", "%E", "%g", "%h", "%i", "%I", "%s", "%t", "%u"];
     const replaceKnownPatterns = (s) => {
-      for (let p in knownPatterns) {
+      knownPatterns.forEach(p => {
         s = s.replace(p, "*");
-      }
+      });
       while (true) {
         let oldLength = s.length;
         s = s.replace("**", "*");


### PR DESCRIPTION
### Scope & Purpose

properly iterate the array instead of only taking the indices. 

- [x] :hankey: Bugfix
- Backports:
  - [x] [3.11](https://github.com/arangodb/arangodb/pull/20272)
  - [x] [3.10](https://github.com/arangodb/arangodb/pull/20273)