### PR TITLE
fix issue in ReadWriteLockTest

### DIFF
--- a/tests/Basics/ReadWriteLockTest.cpp
+++ b/tests/Basics/ReadWriteLockTest.cpp
@@ -53,15 +53,14 @@ struct Synchronizer {
   }
   void start(int nr) {
     while (true) {
-      std::unique_lock lock(mutex);
-      if (waiting >= nr) {
-        break;
+      {
+        std::unique_lock lock(mutex);
+        if (waiting >= nr) {
+          ready = true;
+          break;
+        }
       }
       std::this_thread::sleep_for(std::chrono::milliseconds(10));
-    }
-    {
-      std::unique_lock lock(mutex);
-      ready = true;
     }
     cv.notify_all();
   }


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/20278

Fix issue in ReadWriteLockTest.
The test could spend potentially endless time in `waitForStart()`, because the relevant synchronization mutex was held while the thread went to sleep.
Test-only bugfix.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.11: this PR
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 