### PR TITLE
CINFRA: Adapt create Database test to ensure correct default version is used

### DIFF
--- a/tests/js/client/replication2/replication2-cluster.js
+++ b/tests/js/client/replication2/replication2-cluster.js
@@ -51,20 +51,23 @@ function ddlSuite() {
   return {
     testCreateDatabaseReplicationVersion: function () {
       const dbName = 'replicationVersionDb';
+      // The _system database is always created with the default
+      // version. This should be passed through all databases.
+      const defaultReplicationVersion = db._properties().replicationVersion;
 
       const tests = [
         // default to v1
         { params: undefined,
-          expected: {properties: {replicationVersion: "1"}},
+          expected: {properties: {replicationVersion: defaultReplicationVersion}},
         },
         { params: null,
-          expected: {properties: {replicationVersion: "1"}},
+          expected: {properties: {replicationVersion: defaultReplicationVersion}},
         },
         { params: {replicationVersion: undefined},
-          expected: {properties: {replicationVersion: "1"}},
+          expected: {properties: {replicationVersion: defaultReplicationVersion}},
         },
         { params: {},
-          expected: {properties: {replicationVersion: "1"}},
+          expected: {properties: {replicationVersion: defaultReplicationVersion}},
         },
         // set v1 explicitly
         { params: {replicationVersion: "1"},


### PR DESCRIPTION
### Scope & Purpose

*_createDatabase() will use the default replication version. Adjusted the test to be flexible for V1 and V2 was hard-coded to V1*

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

