### PR TITLE
[CINFRA] Replicated Log and Shard bound together

### DIFF
--- a/arangod/Cluster/DBServerAgencySync.cpp
+++ b/arangod/Cluster/DBServerAgencySync.cpp
@@ -74,7 +74,7 @@ void DBServerAgencySync::work() {
 Result DBServerAgencySync::getLocalCollections(
     containers::FlatHashSet<std::string> const& dirty,
     AgencyCache::databases_t& databases, LocalLogsMap& replLogs,
-    LocalShardsToLogsMap& shardIdToLogId) {
+    LocalShardsToLogsMap& localShardIdToLogId) {
   TRI_ASSERT(ServerState::instance()->isDBServer());
 
   using namespace arangodb::basics;
@@ -118,8 +118,8 @@ Result DBServerAgencySync::getLocalCollections(
     if (vocbase.replicationVersion() == replication::Version::TWO) {
       // Create a mapping from db to [shard -> log id]
       // This will indicate the responsible logs for each shard on this system
-      auto [it, created] =
-          shardIdToLogId.try_emplace(dbname, maintenance::ShardIdToLogIdMap{});
+      auto [it, created] = localShardIdToLogId.try_emplace(
+          dbname, maintenance::ShardIdToLogIdMap{});
       if (!created) {
         LOG_TOPIC("76d1a", WARN, Logger::MAINTENANCE)
             << "Failed to emplace new database entry in local ShardId-to-LogId "
@@ -143,7 +143,7 @@ Result DBServerAgencySync::getLocalCollections(
                             << collection->name();
           return maybeShardID.result();
         }
-        auto [it, created] = shardIdToLogId[dbname].try_emplace(
+        auto [it, created] = localShardIdToLogId[dbname].try_emplace(
             maybeShardID.get(), collection->replicatedStateId());
         if (!created) {
           LOG_TOPIC("0aacc", WARN, Logger::MAINTENANCE)
@@ -277,10 +277,11 @@ DBServerAgencySyncResult DBServerAgencySync::execute() {
 
   AgencyCache::databases_t local;
   LocalLogsMap localLogs;
-  maintenance::ShardIdToLogIdMapByDatabase shardIdToLogId;
+  maintenance::ShardIdToLogIdMapByDatabase localShardIdToLogId;
   LOG_TOPIC("54261", TRACE, Logger::MAINTENANCE)
       << "Before getLocalCollections for phaseOne";
-  Result glc = getLocalCollections(dirty, local, localLogs, shardIdToLogId);
+  Result glc =
+      getLocalCollections(dirty, local, localLogs, localShardIdToLogId);
 
   LOG_TOPIC("54262", TRACE, Logger::MAINTENANCE)
       << "After getLocalCollections for phaseOne";
@@ -309,7 +310,8 @@ DBServerAgencySyncResult DBServerAgencySync::execute() {
 
     tmp = arangodb::maintenance::phaseOne(
         plan, planIndex, current, currentIndex, dirty, moreDirt, local,
-        serverId, mfeature, rb, currentShardLocks, localLogs, shardIdToLogId);
+        serverId, mfeature, rb, currentShardLocks, localLogs,
+        localShardIdToLogId);
 
     auto endTimePhaseOne = std::chrono::steady_clock::now();
     LOG_TOPIC("93f83", TRACE, Logger::MAINTENANCE)
@@ -346,8 +348,8 @@ DBServerAgencySyncResult DBServerAgencySync::execute() {
 
     local.clear();
     localLogs.clear();
-    shardIdToLogId.clear();
-    glc = getLocalCollections(dirty, local, localLogs, shardIdToLogId);
+    localShardIdToLogId.clear();
+    glc = getLocalCollections(dirty, local, localLogs, localShardIdToLogId);
     // We intentionally refetch local collections here, such that phase 2
     // can already see potential changes introduced by phase 1. The two
     // phases are sufficiently independent that this is OK.
@@ -365,7 +367,7 @@ DBServerAgencySyncResult DBServerAgencySync::execute() {
 
     tmp = arangodb::maintenance::phaseTwo(
         plan, current, currentIndex, dirty, local, serverId, mfeature, rb,
-        currentShardLocks, localLogs, shardIdToLogId);
+        currentShardLocks, localLogs, localShardIdToLogId);
 
     LOG_TOPIC("dfc54", TRACE, Logger::MAINTENANCE)
         << "DBServerAgencySync::phaseTwo done";
@@ -392,12 +394,13 @@ DBServerAgencySyncResult DBServerAgencySync::execute() {
             auto const key = ao.key.copyString();
             auto const op = ao.value.get("op").copyString();
 
-            auto const precondition = ao.value.get("precondition");
-            if (!precondition.isNone()) {
-              // have a precondition
-              preconditions.push_back(AgencyPrecondition(
-                  precondition.keyAt(0).copyString(),
-                  AgencyPrecondition::Type::VALUE, precondition.valueAt(0)));
+            auto const precs = ao.value.get("preconditions");
+            if (precs.isObject()) {
+              for (auto const& p : VPackObjectIterator(precs)) {
+                preconditions.emplace_back(p.key.copyString(),
+                                           AgencyPrecondition::Type::VALUE,
+                                           p.value);
+              }
             }
 
             if (op == "set") {

--- a/arangod/Cluster/DBServerAgencySync.h
+++ b/arangod/Cluster/DBServerAgencySync.h
@@ -89,7 +89,7 @@ class DBServerAgencySync {
       containers::FlatHashSet<std::string> const& dirty,
       containers::FlatHashMap<std::string, std::shared_ptr<VPackBuilder>>&
           collections,
-      LocalLogsMap& replLogs, LocalShardsToLogsMap& shardIdToLogId);
+      LocalLogsMap& replLogs, LocalShardsToLogsMap& localShardIdToLogId);
 
   double requestTimeout() const noexcept;
 

--- a/arangod/Cluster/Maintenance.cpp
+++ b/arangod/Cluster/Maintenance.cpp
@@ -268,16 +268,19 @@ static std::string CreateLeaderString(std::string const& leaderId,
 
 static bool isReplication2Leader(ShardID const& shname,
                                  ReplicatedLogStatusMap const& localLogs,
-                                 ShardIdToLogIdMap const& shardsToLogs) {
-  auto it = shardsToLogs.find(shname);
+                                 ShardIdToLogIdMap const& localShardsToLogs) {
+  auto it = localShardsToLogs.find(shname);
   // If the shard is not found, then it has not been created yet.
-  if (it != std::end(shardsToLogs)) {
+  if (it != std::end(localShardsToLogs)) {
     auto logId = it->second;
     auto logStatus = localLogs.find(logId);
-    ADB_PROD_ASSERT(logStatus != std::end(localLogs))
-        << "Log " << logId
-        << " not found. If the shard is found, then the log must be also "
-           "there.";
+    if (logStatus == std::end(localLogs)) {
+      LOG_TOPIC("c1d8d", WARN, Logger::MAINTENANCE)
+          << "Replicated log " << logId << " not found. Since the shard "
+          << shname << " exists, so must the log";
+      TRI_ASSERT(false) << logId << " " << shname << " " << localShardsToLogs;
+      return false;
+    }
     return logStatus->second.status.role ==
            replication2::replicated_log::ParticipantRole::kLeader;
   }
@@ -732,7 +735,7 @@ arangodb::Result arangodb::maintenance::diffPlanLocal(
     std::vector<std::shared_ptr<ActionDescription>>& actions,
     MaintenanceFeature::ShardActionMap const& shardActionMap,
     ReplicatedLogStatusMapByDatabase const& localLogsByDatabase,
-    ShardIdToLogIdMapByDatabase const& shardIdToLogId) {
+    ShardIdToLogIdMapByDatabase const& localShardIdToLogId) {
   // You are entering the functional sector.
   // Vous entrez dans le secteur fonctionel.
   // Sie betreten den funktionalen Sektor.
@@ -752,17 +755,25 @@ arangodb::Result arangodb::maintenance::diffPlanLocal(
     auto const& pdb = pb.get(std::vector<std::string>{AgencyCommHelper::path(),
                                                       PLAN, DATABASES, dbname});
 
+    if (!pdb.isObject()) {
+      LOG_TOPIC("490dc", DEBUG, Logger::MAINTENANCE)
+          << "Invalid object found in plan for database " << dbname
+          << ", skipping";
+      continue;
+    }
+
     if (auto rv = pdb.get("replicationVersion"); !rv.isNone()) {
       auto version = replication::parseVersion(rv);
       TRI_ASSERT(version.ok());
       replicationVersion.emplace(dbname, version.get());
     } else {
-      // if the "replicationVersion" field is missing this has to be an old
-      // DB which defaults to version ONE.
+      // If the "replicationVersion" field is missing this has to be an old
+      // DB which defaults to version ONE. Note that while processing shards,
+      // we'll take decisions based on the replication version.
       replicationVersion.emplace(dbname, replication::Version::ONE);
     }
 
-    if (pdb.isObject() && local.find(dbname) == local.end()) {
+    if (local.find(dbname) == local.end()) {
       if (errors.databases.find(dbname) == errors.databases.end()) {
         makeDirty.insert(dbname);
         callNotify = true;
@@ -856,8 +867,8 @@ arangodb::Result arangodb::maintenance::diffPlanLocal(
   // Obtain a shardID -> LogId map (for replication2 only)
   auto getShardsToLogs =
       [&](DatabaseID const& dbname) -> std::optional<ShardIdToLogIdMap> {
-    auto it = shardIdToLogId.find(dbname);
-    if (it != std::end(shardIdToLogId)) {
+    auto it = localShardIdToLogId.find(dbname);
+    if (it != std::end(localShardIdToLogId)) {
       return it->second;
     }
     LOG_TOPIC("f9399", ERR, Logger::MAINTENANCE)
@@ -898,7 +909,8 @@ arangodb::Result arangodb::maintenance::diffPlanLocal(
                               ? getShardsToLogs(dbname)
                               : std::nullopt;
       if (rv == replication::Version::TWO && !shardsToLogs) {
-        TRI_ASSERT(false) << "dbname: " << dbname << "; map: " << shardIdToLogId
+        TRI_ASSERT(false) << "dbname: " << dbname
+                          << "; map: " << localShardIdToLogId
                           << "; local: " << lit->second->toJson()
                           << "; plan: " << pit->second->toJson();
         continue;
@@ -908,7 +920,8 @@ arangodb::Result arangodb::maintenance::diffPlanLocal(
                            ? getLocalLogsStatus(dbname)
                            : std::nullopt;
       if (rv == replication::Version::TWO && !localLogs) {
-        TRI_ASSERT(false) << "dbname: " << dbname << "; map: " << shardIdToLogId
+        TRI_ASSERT(false) << "dbname: " << dbname
+                          << "; map: " << localShardIdToLogId
                           << "; local: " << lit->second->toJson()
                           << "; plan: " << pit->second->toJson();
         continue;
@@ -998,7 +1011,7 @@ arangodb::Result arangodb::maintenance::diffPlanLocal(
                                 : std::nullopt;
         if (rv == replication::Version::TWO && !shardsToLogs) {
           TRI_ASSERT(false)
-              << "dbname: " << dbname << "; map: " << shardIdToLogId
+              << "dbname: " << dbname << "; map: " << localShardIdToLogId
               << "; local: " << lit->second->toJson()
               << "; plan: " << pit->second->toJson();
           continue;
@@ -1009,7 +1022,7 @@ arangodb::Result arangodb::maintenance::diffPlanLocal(
                              : std::nullopt;
         if (rv == replication::Version::TWO && !localLogs) {
           TRI_ASSERT(false)
-              << "dbname: " << dbname << "; map: " << shardIdToLogId
+              << "dbname: " << dbname << "; map: " << localShardIdToLogId
               << "; local: " << lit->second->toJson()
               << "; plan: " << pit->second->toJson();
           continue;
@@ -1121,7 +1134,7 @@ arangodb::Result arangodb::maintenance::executePlan(
     VPackBuilder& report,
     MaintenanceFeature::ShardActionMap const& shardActionMap,
     ReplicatedLogStatusMapByDatabase const& localLogs,
-    ShardIdToLogIdMapByDatabase const& shardIdToLogId) {
+    ShardIdToLogIdMapByDatabase const& localShardIdToLogId) {
   // Errors from maintenance feature
   MaintenanceFeature::errors_t errors;
   arangodb::Result result = feature.copyAllErrors(errors);
@@ -1146,7 +1159,7 @@ arangodb::Result arangodb::maintenance::executePlan(
         feature.server().getFeature<EngineSelectorFeature>().engine();
     diffPlanLocal(engine, plan, planIndex, current, currentIndex, dirty, local,
                   serverId, errors, makeDirty, callNotify, actions,
-                  shardActionMap, localLogs, shardIdToLogId);
+                  shardActionMap, localLogs, localShardIdToLogId);
     feature.addDirty(makeDirty, callNotify);
   }
 
@@ -1281,7 +1294,7 @@ arangodb::Result arangodb::maintenance::phaseOne(
     VPackBuilder& report,
     MaintenanceFeature::ShardActionMap const& shardActionMap,
     ReplicatedLogStatusMapByDatabase const& localLogs,
-    ShardIdToLogIdMapByDatabase const& shardIdToLogId) {
+    ShardIdToLogIdMapByDatabase const& localShardIdToLogId) {
   auto start = std::chrono::steady_clock::now();
 
   arangodb::Result result;
@@ -1294,7 +1307,7 @@ arangodb::Result arangodb::maintenance::phaseOne(
     try {
       result = executePlan(plan, planIndex, current, currentIndex, dirty,
                            moreDirt, local, serverId, feature, report,
-                           shardActionMap, localLogs, shardIdToLogId);
+                           shardActionMap, localLogs, localShardIdToLogId);
     } catch (std::exception const& e) {
       LOG_TOPIC("55938", ERR, Logger::MAINTENANCE)
           << "Error executing plan: " << e.what();
@@ -1681,7 +1694,7 @@ static void writeUpdateReplicatedLogLeader(
     report.add(VPackValue("payload"));
     velocypack::serialize(report, leader);
     {
-      VPackObjectBuilder preconditionBuilder(&report, "precondition");
+      VPackObjectBuilder preconditionBuilder(&report, "preconditions");
       report.add(preconditionPath, VPackValue(localTerm));
     }
   }
@@ -1734,7 +1747,7 @@ static void writeUpdateReplicatedLogSafeRebootIds(
     report.add(VPackValue("payload"));
     velocypack::serialize(report, safeRebootIds);
     {
-      VPackObjectBuilder preconditionBuilder(&report, "precondition");
+      VPackObjectBuilder preconditionBuilder(&report, "preconditions");
       report.add(preconditionPath, VPackValue(localTerm));
     }
   }
@@ -1778,7 +1791,7 @@ static void writeUpdateReplicatedLogLocal(
     report.add(VPackValue("payload"));
     velocypack::serialize(report, local);
     {
-      VPackObjectBuilder preconditionBuilder(&report, "precondition");
+      VPackObjectBuilder preconditionBuilder(&report, "preconditions");
       report.add(preconditionPath, VPackValue(localTerm));
     }
   }
@@ -1874,7 +1887,7 @@ arangodb::Result arangodb::maintenance::reportInCurrent(
     MaintenanceFeature::errors_t const& allErrors, std::string const& serverId,
     VPackBuilder& report, ShardStatistics& shardStats,
     ReplicatedLogStatusMapByDatabase const& localLogs,
-    ShardIdToLogIdMapByDatabase const& shardIdToLogId) {
+    ShardIdToLogIdMapByDatabase const& localShardIdToLogId) {
   for (auto const& dbName : dirty) {
     auto lit = local.find(dbName);
     VPackSlice ldb;
@@ -1896,7 +1909,28 @@ arangodb::Result arangodb::maintenance::reportInCurrent(
       cur = cit->second->slice()[0];
     }
 
-    auto replicationVersion = replication::Version::ONE;
+    auto& df = feature.server().getFeature<DatabaseFeature>();
+    auto localDBExists = false;
+    auto replicationVersion = std::invoke([&]() {
+      // Fetch the replication version locally, instead of using the one from
+      // Plan. This is because the database might have been removed from Plan in
+      // the meantime.
+      auto res = basics::catchToResultT([&]() -> replication::Version {
+        DatabaseGuard guard(df, dbName);
+        localDBExists = true;
+        return guard->replicationVersion();
+      });
+      if (res.ok()) {
+        return res.get();
+      }
+
+      LOG_TOPIC("fbff0", DEBUG, Logger::MAINTENANCE)
+          << "Could not get the replication version of database (most likely "
+             "it is no longer available): "
+          << dbName << ", assuming replication version 1; " << res.result();
+      return replication::Version::ONE;
+    });
+
     VPackBuilder shardMap;
     auto pit = plan.find(dbName);
     VPackSlice pdb;
@@ -1911,16 +1945,18 @@ arangodb::Result arangodb::maintenance::reportInCurrent(
                                      COLLECTIONS, dbName};
       TRI_ASSERT(pdb.isObject());
 
-      std::vector<std::string> dbpath{AgencyCommHelper::path(), PLAN, DATABASES,
-                                      dbName};
-      if (auto db = pdb.get(dbpath); db.isObject()) {
-        if (auto rv = db.get("replicationVersion"); rv.isString()) {
-          auto result = replication::parseVersion(rv);
-          TRI_ASSERT(result.ok());
-          replicationVersion = std::move(result.get());
-        } else {
-          // if "replicationVersion" field is not found this must be an old DB
-          // which defaults to version ONE.
+      if (!localDBExists) {
+        // If the local database is not found, the replication version is
+        // assumed to be ONE. As fallback, the following code checks for the
+        // replication version in Plan.
+        std::vector<std::string> dbpath{AgencyCommHelper::path(), PLAN,
+                                        DATABASES, dbName};
+        if (auto db = pdb.get(dbpath); db.isObject()) {
+          if (auto rv = db.get("replicationVersion"); rv.isString()) {
+            auto result = replication::parseVersion(rv);
+            TRI_ASSERT(result.ok()) << result.result();
+            replicationVersion = result.get();
+          }
         }
       }
 
@@ -1935,7 +1971,6 @@ arangodb::Result arangodb::maintenance::reportInCurrent(
                                             DATABASES, dbName, serverId};
 
     if (ldb.isObject()) {
-      auto& df = feature.server().getFeature<DatabaseFeature>();
       if (cur.isNone() || (cur.isObject() && !cur.hasKey(cdbpath))) {
         auto const localDatabaseInfo =
             assembleLocalDatabaseInfo(df, dbName, allErrors);
@@ -1952,15 +1987,16 @@ arangodb::Result arangodb::maintenance::reportInCurrent(
       }
 
       auto shardsToLogs = replicationVersion == replication::Version::TWO
-                              ? shardIdToLogId.find(dbName)
-                              : std::end(shardIdToLogId);
+                              ? localShardIdToLogId.find(dbName)
+                              : std::end(localShardIdToLogId);
       if (replicationVersion == replication::Version::TWO &&
-          shardsToLogs == std::end(shardIdToLogId)) {
+          shardsToLogs == std::end(localShardIdToLogId)) {
         LOG_TOPIC("4c3c9", ERR, Logger::MAINTENANCE)
             << "Could not get the shard to log mapping of replication2 "
                "database: "
             << dbName;
-        TRI_ASSERT(false) << "dbname: " << dbName << "; map: " << shardIdToLogId
+        TRI_ASSERT(false) << "dbname: " << dbName
+                          << "; map: " << localShardIdToLogId
                           << "; local: " << lit->second->toJson()
                           << "; plan: " << pit->second->toJson();
         continue;
@@ -1974,7 +2010,8 @@ arangodb::Result arangodb::maintenance::reportInCurrent(
         LOG_TOPIC("04470", ERR, Logger::MAINTENANCE)
             << "Could not get the local logs status of replication2 database: "
             << dbName;
-        TRI_ASSERT(false) << "dbname: " << dbName << "; map: " << shardIdToLogId
+        TRI_ASSERT(false) << "dbname: " << dbName
+                          << "; map: " << localShardIdToLogId
                           << "; local: " << lit->second->toJson()
                           << "; plan: " << pit->second->toJson();
         continue;
@@ -2016,10 +2053,43 @@ arangodb::Result arangodb::maintenance::reportInCurrent(
 
             TRI_ASSERT(pdb.isObject() && pdb.hasKey(planPath));
 
+            // In the context of replication2, the leadership is attributed to a
+            // replicated log, rather than a shard. Therefore, we must perform
+            // similar leadership checks from the replicated log perspective.
+            using CurrentTerm =
+                std::pair<replication2::LogId, replication2::LogTerm>;
+            auto fetchReplicatedLogTerm = [&]() -> std::optional<CurrentTerm> {
+              // We have already checked that the local shard has a
+              // corresponding replicated log and this server is the leader of
+              // it. The assertions are here just as a double sanity check.
+              auto logId = shardsToLogs->second.find(shName);
+              TRI_ASSERT(logId != std::end(shardsToLogs->second));
+              auto logStatus = logs->second.find(logId->second);
+              TRI_ASSERT(logStatus != std::end(logs->second));
+              auto currentTerm = logStatus->second.status.getCurrentTerm();
+              if (currentTerm.has_value()) {
+                return std::make_pair(logId->second, *currentTerm);
+              }
+              return std::nullopt;
+            };
+
+            // While the local replicated log believes to be the leader, there's
+            // a slight chance that this is no longer the case in Plan. In order
+            // for the corresponding list of severs to be updated under
+            // `planPath`, another supervision round must be triggered. Hence,
+            // we have to use a precondition in order to update Current for this
+            // shard.
+            std::optional<CurrentTerm> localTerm =
+                replicationVersion == replication::Version::TWO
+                    ? fetchReplicatedLogTerm()
+                    : std::nullopt;
+
             VPackSlice thePlanList = pdb.get(planPath);
             if (!thePlanList.isArray() || thePlanList.length() == 0 ||
                 !thePlanList[0].isString() ||
-                !thePlanList[0].isEqualStringUnchecked(serverId)) {
+                !thePlanList[0].isEqualStringUnchecked(serverId) ||
+                (replicationVersion == replication::Version::TWO &&
+                 !localTerm.has_value())) {
               LOG_TOPIC("87776", DEBUG, Logger::MAINTENANCE)
                   << "Ooops, we have a shard for which we believe to be the "
                      "leader,"
@@ -2072,12 +2142,27 @@ arangodb::Result arangodb::maintenance::reportInCurrent(
                 report.add("payload", localCollectionInfo.slice());
                 // ... if and only if plan for this shard has changed in the
                 // meantime Add a precondition:
-                report.add(VPackValue("precondition"));
+                report.add(VPackValue("preconditions"));
                 {
                   VPackObjectBuilder p(&report);
                   report.add(PLAN_COLLECTIONS + dbName + "/" + colName +
                                  "/shards/" + shName,
                              thePlanList);
+
+                  if (replicationVersion == replication::Version::TWO) {
+                    // Precondition that the replicated log corresponding to
+                    // this shard is still leader in plan. We verify this by
+                    // ensuring the term has not changed.
+                    TRI_ASSERT(localTerm.has_value())
+                        << "The replicated log leader must have established "
+                           "leadership before reporting to Current; dbname: "
+                        << dbName << " shard " << shName;
+                    report.add(PLAN_REPLICATED_LOGS + dbName + "/" +
+                                   to_string(localTerm->first) + "/" +
+                                   StaticStrings::CurrentTerm + "/" +
+                                   StaticStrings::Term,
+                               VPackValue(localTerm->second));
+                  }
                 }
               }
             }
@@ -2170,7 +2255,7 @@ arangodb::Result arangodb::maintenance::reportInCurrent(
                     report.add(OP, VP_SET);
                     report.add("payload", ns.slice());
                     {
-                      VPackObjectBuilder p(&report, "precondition");
+                      VPackObjectBuilder p(&report, "preconditions");
                       report.add(PLAN_COLLECTIONS + dbName + "/" + colName +
                                      "/shards/" + shName,
                                  thePlanList);
@@ -2596,7 +2681,7 @@ arangodb::Result arangodb::maintenance::phaseTwo(
     VPackBuilder& report,
     MaintenanceFeature::ShardActionMap const& shardActionMap,
     ReplicatedLogStatusMapByDatabase const& localLogs,
-    ShardIdToLogIdMapByDatabase const& shardIdToLogId) {
+    ShardIdToLogIdMapByDatabase const& localShardIdToLogId) {
   auto start = std::chrono::steady_clock::now();
 
   MaintenanceFeature::errors_t allErrors;
@@ -2617,7 +2702,7 @@ arangodb::Result arangodb::maintenance::phaseTwo(
       try {
         result = reportInCurrent(feature, plan, dirty, cur, local, allErrors,
                                  serverId, report, shardStats, localLogs,
-                                 shardIdToLogId);
+                                 localShardIdToLogId);
       } catch (std::exception const& e) {
         LOG_TOPIC("c9a75", ERR, Logger::MAINTENANCE)
             << "Error reporting in current: " << e.what();

--- a/arangod/Cluster/Maintenance.h
+++ b/arangod/Cluster/Maintenance.h
@@ -136,7 +136,7 @@ arangodb::Result diffPlanLocal(
     std::vector<std::shared_ptr<ActionDescription>>& actions,
     MaintenanceFeature::ShardActionMap const& shardActionMap,
     ReplicatedLogStatusMapByDatabase const& localLogs,
-    ShardIdToLogIdMapByDatabase const& shardIdToLogId);
+    ShardIdToLogIdMapByDatabase const& localShardIdToLogId);
 
 /**
  * @brief          Difference Plan and local for phase 1 of Maintenance run
@@ -214,7 +214,7 @@ arangodb::Result phaseOne(
     VPackBuilder& report,
     MaintenanceFeature::ShardActionMap const& shardActionMap,
     ReplicatedLogStatusMapByDatabase const& localLogs,
-    ShardIdToLogIdMapByDatabase const& shardIdToLogId);
+    ShardIdToLogIdMapByDatabase const& localShardIdToLogId);
 
 /**
  * @brief          Phase two: Report in agency
@@ -240,7 +240,7 @@ arangodb::Result phaseTwo(
     VPackBuilder& report,
     MaintenanceFeature::ShardActionMap const& shardActionMap,
     ReplicatedLogStatusMapByDatabase const& localLogs,
-    ShardIdToLogIdMapByDatabase const& shardsToLogs);
+    ShardIdToLogIdMapByDatabase const& localShardsToLogs);
 
 /**
  * @brief          Report local changes to current
@@ -272,7 +272,7 @@ arangodb::Result reportInCurrent(
     MaintenanceFeature::errors_t const& allErrors, std::string const& serverId,
     VPackBuilder& report, ShardStatistics& shardStats,
     ReplicatedLogStatusMapByDatabase const& localLogs,
-    ShardIdToLogIdMapByDatabase const& shardIdToLogId);
+    ShardIdToLogIdMapByDatabase const& localShardIdToLogId);
 
 /**
  * @brief            Schedule synchroneous replications

--- a/arangod/RestServer/DatabaseFeature.cpp
+++ b/arangod/RestServer/DatabaseFeature.cpp
@@ -810,9 +810,13 @@ ErrorCode DatabaseFeature::dropDatabase(std::string_view name) {
 
     TRI_vocbase_t* vocbase = it->second;
 
-    // Signal replicated logs to stop here, while they still have access to the
-    // database.
-    vocbase->shutdownReplicatedLogs();
+    // Shutdown and clear replicated logs here, while they still have access to
+    // the vocbase. This also drops all shards and resources associated with
+    // these replicated logs, so essentially there should be no collections left
+    // in this vocbase after this method gets executed. Note that the remains of
+    // the replicated logs will still be present on disk. They will be erased in
+    // bulk while executing the `dropDatabase` method of the storage engine.
+    vocbase->dropReplicatedLogs();
 
     auto next = _databases.make(prev);
     next->erase(name);

--- a/arangod/VocBase/vocbase.cpp
+++ b/arangod/VocBase/vocbase.cpp
@@ -1581,6 +1581,10 @@ void TRI_vocbase_t::shutdownReplicatedLogs() noexcept {
   _logManager->resignAll();
 }
 
+void TRI_vocbase_t::dropReplicatedLogs() noexcept {
+  return _logManager->prepareDropAll();
+}
+
 auto TRI_vocbase_t::updateReplicatedState(
     LogId id, agency::LogPlanTermSpecification const& term,
     agency::ParticipantsConfig const& config) -> Result {

--- a/arangod/VocBase/vocbase.h
+++ b/arangod/VocBase/vocbase.h
@@ -214,6 +214,7 @@ struct TRI_vocbase_t {
       -> std::shared_ptr<arangodb::replication2::replicated_log::ILogFollower>;
 
   void shutdownReplicatedLogs() noexcept;
+  void dropReplicatedLogs() noexcept;
 
   [[nodiscard]] auto getDatabaseConfiguration()
       -> arangodb::DatabaseConfiguration;


### PR DESCRIPTION
### Scope & Purpose

We've noted a few crashes in the `isReplication2Leader()` method, due to the replicated log being dropped, while the corresponding shard was still there.

_Drop the replicated log and corresponding shards together_
Before, while dropping the vocbase, we had to use `shutdownReplicatedLogs()`. Only after that, we dropped collections. This leaves a small time window where the collections can still be found locally, but the replicated logs are gone. To fix this problem, I introduced the `prepareDropAll()` method, which cleans up the corresponding resources of all replicated states, similar to how `dropReplicatedState()` would do.

_Add preconditions while reporting to Current_
We're taking the replication version from local databases. This is safer, because previously, we used to take it from Plan, but fallback on replication ONE if database was not to be found in Plan.
Also, note that in order to report a shard in Current, we're adding a precondition that the server is indeed the leader of the corresponding replicated log in Plan.

_Do not crash in production_
I am replacing the assertion in `isReplication2Leader()` with a regular `TRI_ASSERT`, because, while the covered scenario is still problematic, I don't see a good enough reason to crash. Emitting a warning and returning `false` would lead the maintenance to believe that the current server is not the leader, which in the worst case does nothing (believes it is a follower) and best case is correct (it is indeed a follower).

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
