### PR TITLE
[CINFRA] Handle leader resignation gracefully

### DIFF
--- a/arangod/RocksDBEngine/ReplicatedRocksDBTransactionState.cpp
+++ b/arangod/RocksDBEngine/ReplicatedRocksDBTransactionState.cpp
@@ -189,6 +189,10 @@ futures::Future<Result> ReplicatedRocksDBTransactionState::doCommit() {
                 return r.is(
                     TRI_ERROR_REPLICATION_REPLICATED_LOG_LEADER_RESIGNED);
               })) {
+        // Although on this server, the transaction has not made any progress
+        // locally, it may have been committed by other replicated log leaders,
+        // if they are located on other servers. This problem could be fixed by
+        // distributed transactions.
         return Result{
             TRI_ERROR_REPLICATION_REPLICATED_LOG_LEADER_RESIGNED,
             fmt::format(
@@ -217,7 +221,7 @@ futures::Future<Result> ReplicatedRocksDBTransactionState::doCommit() {
         << partialResults;
     TRI_ASSERT(false) << partialResults;
     // The leader is out of sync.
-    // It makes sense to crash here, because the  in the hopes that this server
+    // It makes sense to crash here, in the hopes that this server
     // becomes a follower and it re-applies the transaction successfully.
     FATAL_ERROR_EXIT();
   });


### PR DESCRIPTION
### Scope & Purpose

Before committing a transaction locally, all replicated log leaders involved in that transaction must replicate the `CommitOperation` marker. If **all of them** fail to do so, then there's no reason to panic. The transaction is going to be aborted and none of the servers had any chance to get out of sync. This is a special case where it is actually ok for the commit to fail.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification