### PR TITLE
Fast path locking timeout only for AQL setup

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,11 @@
 v3.11.7 (XXXX-XX-XX)
 --------------------
 
+* BTS-1714: Within writing AQL queries the lock timeout was accidentally
+  set to 2 seconds for all write operations on followers. This could lead
+  to dropped followers when an index of a large shard was finalized on an
+  follower.
+
 * Fixed BTS-1701: Assertion triggered in AQL Traversal on edge PRUNE.
 
 * Fix an issue when forced index hints were used in a query, but the optimizer

--- a/arangod/Aql/ClusterQuery.cpp
+++ b/arangod/Aql/ClusterQuery.cpp
@@ -44,6 +44,9 @@
 using namespace arangodb;
 using namespace arangodb::aql;
 
+// Wait 2s to get the Lock in FastPath, otherwise assume dead-lock.
+const double FAST_PATH_LOCK_TIMEOUT = 2.0;
+
 ClusterQuery::ClusterQuery(QueryId id,
                            std::shared_ptr<transaction::Context> ctx,
                            QueryOptions options)
@@ -92,7 +95,7 @@ std::shared_ptr<ClusterQuery> ClusterQuery::create(
 void ClusterQuery::prepareClusterQuery(
     VPackSlice querySlice, VPackSlice collections, VPackSlice variables,
     VPackSlice snippets, VPackSlice traverserSlice, VPackBuilder& answerBuilder,
-    QueryAnalyzerRevisions const& analyzersRevision) {
+    QueryAnalyzerRevisions const& analyzersRevision, bool fastPathLocking) {
   LOG_TOPIC("9636f", DEBUG, Logger::QUERIES)
       << elapsedSince(_startTime) << " ClusterQuery::prepareClusterQuery"
       << " this: " << (uintptr_t)this;
@@ -146,10 +149,17 @@ void ClusterQuery::prepareClusterQuery(
     _trx->state()->acceptAnalyzersRevision(analyzersRevision);
   }
 
+  double origLockTimeout = _trx->state()->options().lockTimeout;
+  if (fastPathLocking) {
+    _trx->state()->options().lockTimeout = FAST_PATH_LOCK_TIMEOUT;
+  }
+
   Result res = _trx->begin();
   if (!res.ok()) {
     THROW_ARANGO_EXCEPTION(res);
   }
+
+  _trx->state()->options().lockTimeout = origLockTimeout;
 
   TRI_IF_FAILURE("Query::setupLockTimeout") {
     if (!_trx->state()->isReadOnlyTransaction() &&

--- a/arangod/Aql/ClusterQuery.h
+++ b/arangod/Aql/ClusterQuery.h
@@ -49,13 +49,11 @@ class ClusterQuery : public Query {
 
   auto const& traversers() const { return _traversers; }
 
-  void prepareClusterQuery(velocypack::Slice querySlice,
-                           velocypack::Slice collections,
-                           velocypack::Slice variables,
-                           velocypack::Slice snippets,
-                           velocypack::Slice traversals,
-                           velocypack::Builder& answer,
-                           QueryAnalyzerRevisions const& analyzersRevision);
+  void prepareClusterQuery(
+      velocypack::Slice querySlice, velocypack::Slice collections,
+      velocypack::Slice variables, velocypack::Slice snippets,
+      velocypack::Slice traversals, velocypack::Builder& answer,
+      QueryAnalyzerRevisions const& analyzersRevision, bool fastPathLocking);
 
   futures::Future<Result> finalizeClusterQuery(ErrorCode errorCode);
 

--- a/arangod/Aql/EngineInfoContainerDBServerServerBased.cpp
+++ b/arangod/Aql/EngineInfoContainerDBServerServerBased.cpp
@@ -49,8 +49,6 @@ using namespace arangodb::basics;
 
 namespace {
 const double SETUP_TIMEOUT = 60.0;
-// Wait 2s to get the Lock in FastPath, otherwise assume dead-lock.
-const double FAST_PATH_LOCK_TIMEOUT = 2.0;
 
 std::string const finishUrl("/_api/aql/finish/");
 std::string const traverserUrl("/_internal/traverser/");
@@ -189,8 +187,8 @@ EngineInfoContainerDBServerServerBased::buildSetupRequest(
     transaction::Methods& trx, ServerID const& server, VPackSlice infoSlice,
     std::vector<bool> didCreateEngine, MapRemoteToSnippet& snippetIds,
     aql::ServerQueryIdList& serverToQueryId, std::mutex& serverToQueryIdLock,
-    network::ConnectionPool* pool,
-    network::RequestOptions const& options) const {
+    network::ConnectionPool* pool, network::RequestOptions const& options,
+    bool fastPath) const {
   TRI_ASSERT(!server.starts_with("server:"));
 
   auto byteSize = infoSlice.byteSize();
@@ -200,6 +198,9 @@ EngineInfoContainerDBServerServerBased::buildSetupRequest(
   // add the transaction ID header
   network::Headers headers;
   ClusterTrxMethods::addAQLTransactionHeader(trx, server, headers);
+  if (fastPath) {
+    headers.emplace(StaticStrings::AqlFastPath, "true");
+  }
 
   TRI_ASSERT(infoSlice.isObject()) << valueTypeName(infoSlice.type());
   TRI_ASSERT(infoSlice.get("clusterQueryId").isNumber<QueryId>())
@@ -382,9 +383,6 @@ Result EngineInfoContainerDBServerServerBased::buildEngines(
                                .clusterInfo()
                                .uniqid();
 
-  // decreases lock timeout manually for fast path
-  auto oldLockTimeout = _query.getLockTimeout();
-  _query.setLockTimeout(FAST_PATH_LOCK_TIMEOUT);
   std::mutex serverToQueryIdLock{};
   std::vector<std::tuple<ServerID, std::shared_ptr<VPackBuffer<uint8_t>>,
                          std::vector<bool>>>
@@ -414,9 +412,9 @@ Result EngineInfoContainerDBServerServerBased::buildEngines(
       serversAdded.emplace(server);
     }
 
-    networkCalls.emplace_back(
-        buildSetupRequest(trx, server, infoSlice, didCreateEngine, snippetIds,
-                          serverToQueryId, serverToQueryIdLock, pool, options));
+    networkCalls.emplace_back(buildSetupRequest(
+        trx, server, infoSlice, didCreateEngine, snippetIds, serverToQueryId,
+        serverToQueryIdLock, pool, options, true /* fastPath */));
     if (!isReadOnly) {
       // need to keep a copy of the request only in case of write queries,
       // when it is possible that the initial lock request fails due to a
@@ -524,8 +522,6 @@ Result EngineInfoContainerDBServerServerBased::buildEngines(
       trx.state()->coordinatorRerollTransactionId();
     }
 
-    // set back to default lock timeout for slow path fallback
-    _query.setLockTimeout(oldLockTimeout);
     LOG_TOPIC("f5022", DEBUG, Logger::AQL)
         << "Potential deadlock detected, using slow path for locking. This "
            "is expected if exclusive locks are used.";
@@ -569,7 +565,7 @@ Result EngineInfoContainerDBServerServerBased::buildEngines(
       auto request = buildSetupRequest(
           trx, std::move(server), newRequest.slice(),
           std::move(didCreateEngine), snippetIds, serverToQueryId,
-          serverToQueryIdLock, pool, options);
+          serverToQueryIdLock, pool, options, false /* fastPath */);
       _query.incHttpRequests(unsigned(1));
       if (request.get().fail()) {
         // this will trigger the cleanupGuard.

--- a/arangod/Aql/EngineInfoContainerDBServerServerBased.h
+++ b/arangod/Aql/EngineInfoContainerDBServerServerBased.h
@@ -125,8 +125,8 @@ class EngineInfoContainerDBServerServerBased {
       transaction::Methods& trx, ServerID const& server, VPackSlice infoSlice,
       std::vector<bool> didCreateEngine, MapRemoteToSnippet& snippetIds,
       aql::ServerQueryIdList& serverToQueryId, std::mutex& serverToQueryIdLock,
-      network::ConnectionPool* pool,
-      network::RequestOptions const& options) const;
+      network::ConnectionPool* pool, network::RequestOptions const& options,
+      bool fastPath) const;
 
   [[nodiscard]] bool isNotSatelliteLeader(VPackSlice infoSlice) const;
 

--- a/arangod/Aql/RestAqlHandler.cpp
+++ b/arangod/Aql/RestAqlHandler.cpp
@@ -123,6 +123,11 @@ void RestAqlHandler::setupClusterQuery() {
     }
   }
 
+  bool fastPath = false;  // Default false, now check HTTP header:
+  if (!_request->header(StaticStrings::AqlFastPath).empty()) {
+    fastPath = true;
+  }
+
   bool success = false;
   VPackSlice querySlice = this->parseVPackBody(success);
   if (!success) {
@@ -325,7 +330,7 @@ void RestAqlHandler::setupClusterQuery() {
   }
   q->prepareClusterQuery(querySlice, collectionBuilder.slice(), variablesSlice,
                          snippetsSlice, traverserSlice, answerBuilder,
-                         analyzersRevision);
+                         analyzersRevision, fastPath);
 
   answerBuilder.close();  // result
   answerBuilder.close();

--- a/arangod/RocksDBEngine/RocksDBMetaCollection.cpp
+++ b/arangod/RocksDBEngine/RocksDBMetaCollection.cpp
@@ -131,6 +131,15 @@ void RocksDBMetaCollection::unlockWrite() noexcept {
 
 /// @brief read locks a collection, with a timeout
 ErrorCode RocksDBMetaCollection::lockRead(double timeout) {
+  TRI_IF_FAILURE("assertLockTimeoutLow") {
+    // In the test we expect that fast path locking is done with 2s timeout.
+    TRI_ASSERT(timeout < 10);
+  }
+  TRI_IF_FAILURE("assertLockTimeoutHigh") {
+    // In the test we expect that an lazy locking happens on the follower
+    // with the default timeout of more than 2 seconds:
+    TRI_ASSERT(timeout > 10);
+  }
   return doLock(timeout, AccessMode::Type::READ);
 }
 

--- a/arangod/Transaction/Manager.cpp
+++ b/arangod/Transaction/Manager.cpp
@@ -454,9 +454,13 @@ Result Manager::prepareOptions(transaction::Options& options) {
     // replicate changes to followers. replication to followers is only done
     // once the locks have been acquired on the leader(s). so if there are any
     // locking issues, they are supposed to happen first on leaders, and not
-    // affect followers. that's why we can hard-code the lock timeout here to a
-    // rather low value on followers
-    constexpr double followerLockTimeout = 15.0;
+    // affect followers.
+    // Having said that, even on a follower it can happen that for example
+    // an index is finalized on a shard. And then the collection could be
+    // locked exclusively for some period of time. Therefore, we should not
+    // set the locking timeout too low here. We choose 5 minutes as a
+    // compromise:
+    constexpr double followerLockTimeout = 300.0;
     if (options.lockTimeout == 0.0 ||
         options.lockTimeout >= followerLockTimeout) {
       options.lockTimeout = followerLockTimeout;

--- a/arangod/V8Server/v8-vocbase.cpp
+++ b/arangod/V8Server/v8-vocbase.cpp
@@ -796,7 +796,7 @@ static void JS_ExecuteAqlJson(v8::FunctionCallbackInfo<v8::Value> const& args) {
   query->prepareClusterQuery(VPackSlice::emptyObjectSlice(), collections,
                              variables, snippetBuilder.slice(),
                              VPackSlice::noneSlice(), ignoreResponse,
-                             analyzersRevision);
+                             analyzersRevision, false /* fastPath */);
 
   aql::QueryResult queryResult = query->executeSync();
 

--- a/lib/Basics/StaticStrings.cpp
+++ b/lib/Basics/StaticStrings.cpp
@@ -437,6 +437,7 @@ std::string const StaticStrings::BackupSearchToDeleteName(
 // aql api strings
 std::string const StaticStrings::SerializationFormat("serializationFormat");
 std::string const StaticStrings::AqlDocumentCall("x-arango-aql-document-aql");
+std::string const StaticStrings::AqlFastPath("x-arango-fast-path");
 std::string const StaticStrings::AqlRemoteExecute("execute");
 std::string const StaticStrings::AqlRemoteCallStack("callStack");
 std::string const StaticStrings::AqlRemoteLimit("limit");

--- a/lib/Basics/StaticStrings.h
+++ b/lib/Basics/StaticStrings.h
@@ -417,6 +417,7 @@ class StaticStrings {
   // aql api strings
   static std::string const SerializationFormat;
   static std::string const AqlDocumentCall;
+  static std::string const AqlFastPath;
   static std::string const AqlRemoteExecute;
   static std::string const AqlRemoteCallStack;
   static std::string const AqlRemoteLimit;


### PR DESCRIPTION
### Scope & Purpose

Fix BTS-1714.

The short locking timeout of 2s should only be used for the AQL setup
collection locking and not for later operations like write replications.

This is a backport of: https://github.com/arangodb/arangodb/pull/20287

- [*] :hankey: Bugfix

### Checklist

- [*] Tests
  - [*] **Regression tests**
  - [*] **integration tests**
- [*] :book: CHANGELOG entry made
- [*] Backports
  - [*] Backport for 3.11: This is it.

#### Related Information

- [*] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/BTS-1714


