### PR TITLE
Fast path locking timeout only for AQL setup

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,11 @@
 v3.10.12 (XXXX-XX-XX)
 ---------------------
 
+* BTS-1714: Within writing AQL queries the lock timeout was accidentally
+  set to 2 seconds for all write operations on followers. This could lead
+  to dropped followers when an index of a large shard was finalized on an
+  follower.
+
 * Updated OpenSSL to 3.0.12.
 
 * Fixed a problem in ReadWriteLock which could prevent waiting readers from

--- a/arangod/Aql/ClusterQuery.cpp
+++ b/arangod/Aql/ClusterQuery.cpp
@@ -43,6 +43,9 @@
 using namespace arangodb;
 using namespace arangodb::aql;
 
+// Wait 2s to get the Lock in FastPath, otherwise assume dead-lock.
+const double FAST_PATH_LOCK_TIMEOUT = 2.0;
+
 ClusterQuery::ClusterQuery(QueryId id,
                            std::shared_ptr<transaction::Context> ctx,
                            QueryOptions options)
@@ -89,7 +92,7 @@ std::shared_ptr<ClusterQuery> ClusterQuery::create(
 void ClusterQuery::prepareClusterQuery(
     VPackSlice querySlice, VPackSlice collections, VPackSlice variables,
     VPackSlice snippets, VPackSlice traverserSlice, VPackBuilder& answerBuilder,
-    QueryAnalyzerRevisions const& analyzersRevision) {
+    QueryAnalyzerRevisions const& analyzersRevision, bool fastPathLocking) {
   LOG_TOPIC("9636f", DEBUG, Logger::QUERIES)
       << elapsedSince(_startTime) << " ClusterQuery::prepareClusterQuery"
       << " this: " << (uintptr_t)this;
@@ -138,10 +141,17 @@ void ClusterQuery::prepareClusterQuery(
     }
   }
 
+  double origLockTimeout = _trx->state()->options().lockTimeout;
+  if (fastPathLocking) {
+    _trx->state()->options().lockTimeout = FAST_PATH_LOCK_TIMEOUT;
+  }
+
   Result res = _trx->begin();
   if (!res.ok()) {
     THROW_ARANGO_EXCEPTION(res);
   }
+
+  _trx->state()->options().lockTimeout = origLockTimeout;
 
   enterState(QueryExecutionState::ValueType::PARSING);
 

--- a/arangod/Aql/ClusterQuery.h
+++ b/arangod/Aql/ClusterQuery.h
@@ -49,13 +49,11 @@ class ClusterQuery : public Query {
 
   auto const& traversers() const { return _traversers; }
 
-  void prepareClusterQuery(velocypack::Slice querySlice,
-                           velocypack::Slice collections,
-                           velocypack::Slice variables,
-                           velocypack::Slice snippets,
-                           velocypack::Slice traversals,
-                           velocypack::Builder& answer,
-                           QueryAnalyzerRevisions const& analyzersRevision);
+  void prepareClusterQuery(
+      velocypack::Slice querySlice, velocypack::Slice collections,
+      velocypack::Slice variables, velocypack::Slice snippets,
+      velocypack::Slice traversals, velocypack::Builder& answer,
+      QueryAnalyzerRevisions const& analyzersRevision, bool fastPathLocking);
 
   futures::Future<Result> finalizeClusterQuery(ErrorCode errorCode);
 

--- a/arangod/Aql/EngineInfoContainerDBServerServerBased.h
+++ b/arangod/Aql/EngineInfoContainerDBServerServerBased.h
@@ -125,8 +125,8 @@ class EngineInfoContainerDBServerServerBased {
       transaction::Methods& trx, ServerID const& server, VPackSlice infoSlice,
       std::vector<bool> didCreateEngine, MapRemoteToSnippet& snippetIds,
       aql::ServerQueryIdList& serverToQueryId, std::mutex& serverToQueryIdLock,
-      network::ConnectionPool* pool,
-      network::RequestOptions const& options) const;
+      network::ConnectionPool* pool, network::RequestOptions const& options,
+      bool fastPath) const;
 
   [[nodiscard]] bool isNotSatelliteLeader(VPackSlice infoSlice) const;
 

--- a/arangod/Aql/RestAqlHandler.cpp
+++ b/arangod/Aql/RestAqlHandler.cpp
@@ -121,6 +121,11 @@ void RestAqlHandler::setupClusterQuery() {
     }
   }
 
+  bool fastPath = false;  // Default false, now check HTTP header:
+  if (!_request->header(StaticStrings::AqlFastPath).empty()) {
+    fastPath = true;
+  }
+
   bool success = false;
   VPackSlice querySlice = this->parseVPackBody(success);
   if (!success) {
@@ -323,7 +328,7 @@ void RestAqlHandler::setupClusterQuery() {
   }
   q->prepareClusterQuery(querySlice, collectionBuilder.slice(), variablesSlice,
                          snippetsSlice, traverserSlice, answerBuilder,
-                         analyzersRevision);
+                         analyzersRevision, fastPath);
 
   answerBuilder.close();  // result
   answerBuilder.close();

--- a/arangod/RocksDBEngine/RocksDBMetaCollection.cpp
+++ b/arangod/RocksDBEngine/RocksDBMetaCollection.cpp
@@ -133,6 +133,15 @@ void RocksDBMetaCollection::unlockWrite() noexcept {
 
 /// @brief read locks a collection, with a timeout
 ErrorCode RocksDBMetaCollection::lockRead(double timeout) {
+  TRI_IF_FAILURE("assertLockTimeoutLow") {
+    // In the test we expect that fast path locking is done with 2s timeout.
+    TRI_ASSERT(timeout < 10);
+  }
+  TRI_IF_FAILURE("assertLockTimeoutHigh") {
+    // In the test we expect that an lazy locking happens on the follower
+    // with the default timeout of more than 2 seconds:
+    TRI_ASSERT(timeout > 10);
+  }
   return doLock(timeout, AccessMode::Type::READ);
 }
 

--- a/arangod/Transaction/Manager.cpp
+++ b/arangod/Transaction/Manager.cpp
@@ -451,9 +451,13 @@ Result Manager::prepareOptions(transaction::Options& options) {
     // replicate changes to followers. replication to followers is only done
     // once the locks have been acquired on the leader(s). so if there are any
     // locking issues, they are supposed to happen first on leaders, and not
-    // affect followers. that's why we can hard-code the lock timeout here to a
-    // rather low value on followers
-    constexpr double followerLockTimeout = 15.0;
+    // affect followers.
+    // Having said that, even on a follower it can happen that for example
+    // an index is finalized on a shard. And then the collection could be
+    // locked exclusively for some period of time. Therefore, we should not
+    // set the locking timeout too low here. We choose 5 minutes as a
+    // compromise:
+    constexpr double followerLockTimeout = 300.0;
     if (options.lockTimeout == 0.0 ||
         options.lockTimeout >= followerLockTimeout) {
       options.lockTimeout = followerLockTimeout;

--- a/arangod/V8Server/v8-vocbase.cpp
+++ b/arangod/V8Server/v8-vocbase.cpp
@@ -794,7 +794,7 @@ static void JS_ExecuteAqlJson(v8::FunctionCallbackInfo<v8::Value> const& args) {
   query->prepareClusterQuery(VPackSlice::emptyObjectSlice(), collections,
                              variables, snippetBuilder.slice(),
                              VPackSlice::noneSlice(), ignoreResponse,
-                             analyzersRevision);
+                             analyzersRevision, false /* fastPath */);
 
   aql::QueryResult queryResult = query->executeSync();
 

--- a/lib/Basics/StaticStrings.cpp
+++ b/lib/Basics/StaticStrings.cpp
@@ -426,6 +426,7 @@ std::string const StaticStrings::BackupSearchToDeleteName(
 // aql api strings
 std::string const StaticStrings::SerializationFormat("serializationFormat");
 std::string const StaticStrings::AqlDocumentCall("x-arango-aql-document-aql");
+std::string const StaticStrings::AqlFastPath("x-arango-fast-path");
 std::string const StaticStrings::AqlRemoteExecute("execute");
 std::string const StaticStrings::AqlRemoteCallStack("callStack");
 std::string const StaticStrings::AqlRemoteLimit("limit");

--- a/lib/Basics/StaticStrings.h
+++ b/lib/Basics/StaticStrings.h
@@ -398,6 +398,7 @@ class StaticStrings {
   // aql api strings
   static std::string const SerializationFormat;
   static std::string const AqlDocumentCall;
+  static std::string const AqlFastPath;
   static std::string const AqlRemoteExecute;
   static std::string const AqlRemoteCallStack;
   static std::string const AqlRemoteLimit;

--- a/tests/js/client/shell/shell-dropped-followers-elcheapo-commit-cluster.js
+++ b/tests/js/client/shell/shell-dropped-followers-elcheapo-commit-cluster.js
@@ -303,19 +303,14 @@ function lockTimeoutSuite() {
   const cn = 'UnitTestsLockTimeout';
   let collInfo = {};
 
-  const endpointMap = getEndpointMap();
-  const info = { endpointMap, coordinator: "Coordinator0001" };
-
   return {
     setUp: function () {
-      switchConnectionToCoordinator(info);
       getEndpointsByType("dbserver").forEach((ep) => debugClearFailAt(ep));
       db._drop(cn);
       collInfo = createCollectionWithTwoShardsSameLeaderAndFollower(cn);
     },
 
     tearDown: function () {
-      switchConnectionToCoordinator(info);
       getEndpointsByType("dbserver").forEach((ep) => debugClearFailAt(ep));
       db._drop(cn);
     },

--- a/tests/js/client/shell/shell-dropped-followers-elcheapo-commit-cluster.js
+++ b/tests/js/client/shell/shell-dropped-followers-elcheapo-commit-cluster.js
@@ -298,9 +298,48 @@ function dropFollowersElCheapoSuite() {
   };
 }
 
+function lockTimeoutSuite() {
+  'use strict';
+  const cn = 'UnitTestsLockTimeout';
+  let collInfo = {};
+
+  const endpointMap = getEndpointMap();
+  const info = { endpointMap, coordinator: "Coordinator0001" };
+
+  return {
+    setUp: function () {
+      switchConnectionToCoordinator(info);
+      getEndpointsByType("dbserver").forEach((ep) => debugClearFailAt(ep));
+      db._drop(cn);
+      collInfo = createCollectionWithTwoShardsSameLeaderAndFollower(cn);
+    },
+
+    tearDown: function () {
+      switchConnectionToCoordinator(info);
+      getEndpointsByType("dbserver").forEach((ep) => debugClearFailAt(ep));
+      db._drop(cn);
+    },
+    
+    testLockTimeouts: function() {
+      // All we want to do is a single query and for that switch on some
+      // assertions:
+
+      switchConnectionToLeader(collInfo);
+      arango.PUT("/_admin/debug/failat/assertLockTimeoutLow",{});
+      switchConnectionToFollower(collInfo);
+      arango.PUT("/_admin/debug/failat/assertLockTimeoutHigh",{});
+      switchConnectionToCoordinator(collInfo);
+
+      let r = db._query(`FOR i IN 1..100 INSERT {Hallo:i} INTO ${cn} RETURN NEW`).toArray();
+
+    },
+  };
+}
+
 let ep = getEndpointsByType('dbserver');
 if (ep.length && debugCanUseFailAt(ep[0])) {
   // only execute if failure tests are available
   jsunity.run(dropFollowersElCheapoSuite);
+  jsunity.run(lockTimeoutSuite);
 }
 return jsunity.done();


### PR DESCRIPTION
### Scope & Purpose

Fix BTS-1714.

The short locking timeout of 2s should only be used for the AQL setup
collection locking and not for later operations like write replications.

This is a backport of: https://github.com/arangodb/arangodb/pull/20287

- [*] :hankey: Bugfix

### Checklist

- [*] Tests
  - [*] **Regression tests**
  - [*] **integration tests**
- [*] :book: CHANGELOG entry made
- [*] Backports
  - [*] Backport for 3.10: This is it.

#### Related Information

- [*] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/BTS-1714



