### PR TITLE
CINFRA: Fix DeadLock on DropShard / DropCollection

### DIFF
--- a/arangod/Aql/Query.cpp
+++ b/arangod/Aql/Query.cpp
@@ -1776,7 +1776,6 @@ ExecutionState Query::cleanupTrxAndEngines(ErrorCode errorCode) {
       _shutdownState.store(ShutdownState::None, std::memory_order_relaxed);
     });
     futures::Future<Result> commitResult = _trx->commitAsync();
-    TRI_ASSERT(commitResult.isReady());
     if (commitResult.get().fail()) {
       THROW_ARANGO_EXCEPTION(std::move(commitResult).get());
     }

--- a/arangod/Cluster/Maintenance.cpp
+++ b/arangod/Cluster/Maintenance.cpp
@@ -275,10 +275,15 @@ static bool isReplication2Leader(ShardID const& shname,
     auto logId = it->second;
     auto logStatus = localLogs.find(logId);
     if (logStatus == std::end(localLogs)) {
+      // NOTE: We would like to guarantee that the log exists, but we cannot
+      // do that right now, we can eventually have the log removed by the
+      // maintenance before the shard is dropped. Also note: The Log could be
+      // stolen from the lookup map for shard and log deletion where there is a
+      // small time-window, where the shard and log still exist, but are not
+      // listed.
       LOG_TOPIC("c1d8d", WARN, Logger::MAINTENANCE)
           << "Replicated log " << logId << " not found. Since the shard "
           << shname << " exists, so must the log";
-      TRI_ASSERT(false) << logId << " " << shname << " " << localShardsToLogs;
       return false;
     }
     return logStatus->second.status.role ==

--- a/arangod/VocBase/VocBaseLogManager.cpp
+++ b/arangod/VocBase/VocBaseLogManager.cpp
@@ -142,46 +142,38 @@ void VocBaseLogManager::prepareDropAll() noexcept {
 auto VocBaseLogManager::dropReplicatedState(arangodb::replication2::LogId id)
     -> arangodb::Result {
   LOG_CTX("658c6", DEBUG, _logContext) << "Dropping replicated state " << id;
-  StorageEngine& engine = _server.getFeature<EngineSelectorFeature>().engine();
-  auto result = _guardedData.doUnderLock([&](GuardedData& data) {
-    if (auto iter = data.statesAndLogs.find(id);
-        iter != data.statesAndLogs.end()) {
-      auto resignRes = basics::catchToResultT(
-          [&]()
-              -> std::unique_ptr<replication2::storage::IStorageEngineMethods> {
-            return resignAndDrop(iter->second);
-          });
-      if (resignRes.fail()) {
-        LOG_CTX("18db5", ERR, _logContext)
-            << "failed to drop replicated log " << resignRes.result();
-        return resignRes.result();
-      }
 
-      // Now we may delete the persistent metadata.
-      auto storage = std::move(*resignRes);
-      auto res = engine.dropReplicatedState(_vocbase, storage);
-
-      if (res.fail()) {
-        TRI_ASSERT(storage != nullptr);
-        LOG_CTX("998cc", ERR, _logContext)
-            << "failed to drop replicated log " << res.errorMessage();
-        return res;
-      }
-      TRI_ASSERT(storage == nullptr);
-      data.statesAndLogs.erase(iter);
-
-      return Result();
-    }
-
-    return Result(TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND);
-  });
-
-  if (result.ok()) {
-    auto& feature = _server.getFeature<ReplicatedLogFeature>();
-    feature.metrics()->replicatedLogDeletionNumber->count();
+  auto stateAndLog = _guardedData.getLockedGuard()->stealReplicatedState(id);
+  if (stateAndLog.fail()) {
+    return stateAndLog.result();
   }
+  auto resignRes = basics::catchToResultT(
+      [&]()
+          -> std::unique_ptr<replication2::storage::IStorageEngineMethods> {
+        return resignAndDrop(stateAndLog.get());
+      });
+  if (resignRes.fail()) {
+    LOG_CTX("18db5", ERR, _logContext)
+        << "failed to drop replicated log " << resignRes.result();
+    return resignRes.result();
+  }
+  // Now we may delete the persistent metadata.
+  auto storage = std::move(*resignRes);
+  StorageEngine& engine = _server.getFeature<EngineSelectorFeature>().engine();
+  auto res = engine.dropReplicatedState(_vocbase, storage);
 
-  return result;
+  if (res.fail()) {
+    TRI_ASSERT(storage != nullptr);
+    LOG_CTX("998cc", ERR, _logContext)
+        << "failed to drop replicated log " << res.errorMessage();
+    return res;
+  }
+  TRI_ASSERT(storage == nullptr);
+
+  auto& feature = _server.getFeature<ReplicatedLogFeature>();
+  feature.metrics()->replicatedLogDeletionNumber->count();
+
+  return {};
 }
 
 auto VocBaseLogManager::resignAndDrop(GuardedData::StateAndLog& stateAndLog)
@@ -466,4 +458,15 @@ auto VocBaseLogManager::GuardedData::buildReplicatedStateWithMethods(
   std::abort();
 } catch (...) {
   std::abort();
+}
+
+auto VocBaseLogManager::GuardedData::stealReplicatedState(
+    replication2::LogId id) -> ResultT<GuardedData::StateAndLog>  {
+  if (auto iter = statesAndLogs.find(id); iter != statesAndLogs.end()) {
+    auto stateAndLog = std::move(iter->second);
+    statesAndLogs.erase(iter);
+    return stateAndLog;
+  } else {
+    return Result(TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND);
+  }
 }

--- a/arangod/VocBase/VocBaseLogManager.cpp
+++ b/arangod/VocBase/VocBaseLogManager.cpp
@@ -122,7 +122,8 @@ auto VocBaseLogManager::updateReplicatedState(
 }
 
 void VocBaseLogManager::prepareDropAll() noexcept {
-  std::map<arangodb::replication2::LogId, GuardedData::StateAndLog> statesAndLogs;
+  std::map<arangodb::replication2::LogId, GuardedData::StateAndLog>
+      statesAndLogs;
   {
     // We steal all logs from the _guardedData.
     // We need to give up the guarded Log, and we also
@@ -155,8 +156,7 @@ auto VocBaseLogManager::dropReplicatedState(arangodb::replication2::LogId id)
     return stateAndLog.result();
   }
   auto resignRes = basics::catchToResultT(
-      [&]()
-          -> std::unique_ptr<replication2::storage::IStorageEngineMethods> {
+      [&]() -> std::unique_ptr<replication2::storage::IStorageEngineMethods> {
         return resignAndDrop(stateAndLog.get());
       });
   if (resignRes.fail()) {
@@ -468,7 +468,7 @@ auto VocBaseLogManager::GuardedData::buildReplicatedStateWithMethods(
 }
 
 auto VocBaseLogManager::GuardedData::stealReplicatedState(
-    replication2::LogId id) -> ResultT<GuardedData::StateAndLog>  {
+    replication2::LogId id) -> ResultT<GuardedData::StateAndLog> {
   if (auto iter = statesAndLogs.find(id); iter != statesAndLogs.end()) {
     auto stateAndLog = std::move(iter->second);
     statesAndLogs.erase(iter);

--- a/arangod/VocBase/VocBaseLogManager.h
+++ b/arangod/VocBase/VocBaseLogManager.h
@@ -136,6 +136,9 @@ struct VocBaseLogManager {
         TRI_vocbase_t& vocbase)
         -> ResultT<std::shared_ptr<
             replication2::replicated_state::ReplicatedStateBase>>;
+
+    auto stealReplicatedState(replication2::LogId id)
+        -> ResultT<GuardedData::StateAndLog>;
   };
   Guarded<GuardedData> _guardedData;
 


### PR DESCRIPTION
### Scope & Purpose

*When we drop a shard we acquired the VocBaseLogManager GuardedData lock, and then the Collection Status lock on drop.
On other operations (e.g. queries) we get first CollectionStatusLock and then the GuardedDataLock.
This lead to a deadlock. Now we release the GuardedDataLock on Drop earlier.
*

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

