### PR TITLE
Fix jemalloc cmake setup for building with glibc images

### DIFF
--- a/3rdParty/jemalloc/CMakeLists.txt
+++ b/3rdParty/jemalloc/CMakeLists.txt
@@ -35,7 +35,8 @@ if (LINUX OR DARWIN)
   if (USE_JEMALLOC_PROF)
       if (USE_LIBUNWIND)
           SET(JEMALLOC_PROF "--enable-prof" "--enable-prof-libunwind" "--with-static-libunwind=${LIBUNWIND_LIB}")
-          SET(JEMALLOC_C_FLAGS "${CMAKE_C_FLAGS} -I${LIBUNWIND_HOME}/include")
+          SET(JEMALLOC_C_FLAGS "${CMAKE_C_FLAGS} -isystem ${LIBUNWIND_HOME}/include")
+          SET(MY_CPPFLAGS "-isystem ${LIBUNWIND_HOME}/include")
       else ()
           SET(JEMALLOC_PROF "--enable-prof")
       endif()
@@ -57,6 +58,7 @@ if (LINUX OR DARWIN)
                   CXX=${JEMALLOC_CXX_TMP}
                   CFLAGS=${JEMALLOC_C_FLAGS}
                   CXXFLAGS=${CMAKE_CXX_FLAGS}
+                  CPPFLAGS=${MY_CPPFLAGS}
                   --prefix=${CMAKE_CURRENT_BINARY_DIR}
                   --with-malloc-conf=${JEMALLOC_CONFIG}
                   --with-version=${JEMALLOC_VERSION}-0-g0

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 v3.11.7 (XXXX-XX-XX)
 --------------------
 
+* Fix cmake setup for jemalloc library for the case of memory profiling.
+
 * BTS-1714: Within writing AQL queries the lock timeout was accidentally
   set to 2 seconds for all write operations on followers. This could lead
   to dropped followers when an index of a large shard was finalized on an


### PR DESCRIPTION
It turns out that we have to give the include path for jemalloc to
find our own libunwind in the CPPFLAGS rather than the CFLAGS. Otherwise
it can happen that the configure/make system cannot compute the
dependencies correctly. This problem hits if there is no system wide
libunwind installed.

- Minor fix for jemalloc build setup.
- CHANGELOG.

### Scope & Purpose

*(Please describe the changes in this PR for reviewers, motivation, rationale - **mandatory**)*

- [*] :hankey: Bugfix

### Checklist

- [*] :book: CHANGELOG entry made

