### PR TITLE
Improvements to the actor library

### DIFF
--- a/lib/Actor/include/Actor/Actor.h
+++ b/lib/Actor/include/Actor/Actor.h
@@ -133,6 +133,9 @@ struct Actor : ActorBase<typename Runtime::ActorPID> {
   }
 
   auto finish(ExitReason reason) -> void override {
+    if (status.load() & Status::kFinished) {
+      return;
+    }
     exitReason = reason;
     auto s = status.fetch_or(Status::kFinished);
     if (s & Status::kIdle) {

--- a/lib/Actor/include/Actor/BaseRuntime.h
+++ b/lib/Actor/include/Actor/BaseRuntime.h
@@ -196,6 +196,11 @@ struct BaseRuntime
     }
   }
 
+  auto shutdown() -> void {
+    softShutdown();
+    actors.waitForAll();
+  }
+
   IScheduler& scheduler() { return *_scheduler; }
 
   std::string const runtimeID;

--- a/lib/Actor/include/Actor/BaseRuntime.h
+++ b/lib/Actor/include/Actor/BaseRuntime.h
@@ -128,7 +128,8 @@ struct BaseRuntime
   template<typename ActorMessage>
   auto dispatch(ActorPID sender, ActorPID receiver, ActorMessage&& message)
       -> void {
-    self().doDispatch(sender, receiver, message, IgnoreDispatchFailure::no);
+    self().doDispatch(sender, receiver, std::move(message),
+                      IgnoreDispatchFailure::no);
   }
 
   template<typename ActorMessage>

--- a/lib/Actor/include/Actor/BaseRuntime.h
+++ b/lib/Actor/include/Actor/BaseRuntime.h
@@ -57,8 +57,9 @@ struct BaseRuntime
 
     auto address = self().makePid(newId);
 
-    auto newActor = std::make_shared<Actor<BaseRuntime, ActorConfig>>(
-        address, this->shared_from_this(), std::move(initialState));
+    auto newActor = std::make_shared<Actor<Derived, ActorConfig>>(
+        address, std::static_pointer_cast<Derived>(this->shared_from_this()),
+        std::move(initialState));
     actors.add(newId, std::move(newActor));
 
     return address;
@@ -86,7 +87,7 @@ struct BaseRuntime
     auto actorBase = actors.find(id);
     if (actorBase.has_value()) {
       auto* actor =
-          dynamic_cast<Actor<BaseRuntime, ActorConfig>*>(actorBase->get());
+          dynamic_cast<Actor<Derived, ActorConfig>*>(actorBase->get());
       if (actor != nullptr) {
         return actor->getState();
       }

--- a/tests/Actor/RuntimeTest.cpp
+++ b/tests/Actor/RuntimeTest.cpp
@@ -401,6 +401,19 @@ TYPED_TEST(RuntimeTest,
   ASSERT_EQ(runtime->actors.size(), 0);
 }
 
+TYPED_TEST(RuntimeTest, shutdown_blocks_until_all_actors_have_finished) {
+  auto runtime = this->makeRuntime();
+  constexpr unsigned numActors = 1000;
+  for (unsigned i = 0; i < numActors; ++i) {
+    runtime->template spawn<TrivialActor>(std::make_unique<TrivialState>(),
+                                          test::message::TrivialStart{});
+  }
+  ASSERT_EQ(numActors, runtime->actors.size());
+  runtime->shutdown();
+  this->scheduler->stop();
+  ASSERT_EQ(runtime->actors.size(), 0);
+}
+
 TYPED_TEST(RuntimeTest, sends_down_message_to_monitoring_actors) {
   auto runtime = this->makeRuntime();
   auto monitor1 = runtime->template spawn<MonitoringActor>(


### PR DESCRIPTION
### Scope & Purpose

- Add synchronous shutdown method that waits until all actors have finished
- Add getter in HandlerBase so we can access the runtime
- Instantiate actor with the derived Runtime type, not the BaseRuntime
- Avoid copying messages
- Fix potential data race when finishing actor

- [x] :hankey: Bugfix
- [x] :pizza: New feature

