### PR TITLE
Simple filter support for dumps

### DIFF
--- a/arangod/RocksDBEngine/RocksDBDumpContext.cpp
+++ b/arangod/RocksDBEngine/RocksDBDumpContext.cpp
@@ -350,7 +350,7 @@ void RocksDBDumpContext::extendLifetime() noexcept {
 
 bool RocksDBDumpContext::applyFilter(
     velocypack::Slice const& documentSlice) const {
-  return std::ranges::all_of(_options.filters, [&](auto&& filter) {
+  return std::ranges::all_of(_options.filters.conditions, [&](auto&& filter) {
     return basics::VelocyPackHelper::equal(documentSlice.get(filter.path),
                                            filter.value.slice(), true);
   });

--- a/arangod/RocksDBEngine/RocksDBDumpContext.cpp
+++ b/arangod/RocksDBEngine/RocksDBDumpContext.cpp
@@ -348,6 +348,14 @@ void RocksDBDumpContext::extendLifetime() noexcept {
   _expires.store(now + _options.ttl);
 }
 
+bool RocksDBDumpContext::applyFilter(
+    velocypack::Slice const& documentSlice) const {
+  return std::ranges::all_of(_options.filters, [&](auto&& filter) {
+    return basics::VelocyPackHelper::equal(documentSlice.get(filter.path),
+                                           filter.value.slice(), true);
+  });
+}
+
 std::shared_ptr<RocksDBDumpContext::Batch const> RocksDBDumpContext::next(
     std::uint64_t batchId, std::optional<std::uint64_t> lastBatch) {
   std::unique_lock guard(_batchesMutex);
@@ -440,31 +448,33 @@ void RocksDBDumpContext::handleWorkItem(WorkItem item) {
     auto documentSlice = velocypack::Slice(
         reinterpret_cast<std::uint8_t const*>(it->value().data()));
 
-    auto storedSlice = [&]() -> VPackSlice {
-      if (_options.projections) {
-        projectionsBuilder.clear();
-        {
-          VPackObjectBuilder ob(&projectionsBuilder);
-          for (auto const& [projKey, path] : *_options.projections) {
-            auto value = documentSlice.get(path);
-            if (path.size() == 1 && path[0] == "_id") {
-              auto id = _customTypeHandler->toString(value, &vpackOptions,
-                                                     documentSlice);
-              projectionsBuilder.add(projKey, VPackValue(id));
-            } else if (!value.isNone()) {
-              projectionsBuilder.add(projKey, value);
+    if (applyFilter(documentSlice)) {
+      auto storedSlice = [&]() -> VPackSlice {
+        if (_options.projections) {
+          projectionsBuilder.clear();
+          {
+            VPackObjectBuilder ob(&projectionsBuilder);
+            for (auto const& [projKey, path] : *_options.projections) {
+              auto value = documentSlice.get(path);
+              if (path.size() == 1 && path[0] == "_id") {
+                auto id = _customTypeHandler->toString(value, &vpackOptions,
+                                                       documentSlice);
+                projectionsBuilder.add(projKey, VPackValue(id));
+              } else if (!value.isNone()) {
+                projectionsBuilder.add(projKey, value);
+              }
             }
           }
+
+          return projectionsBuilder.slice();
         }
 
-        return projectionsBuilder.slice();
-      }
+        return documentSlice;
+      }();
 
-      return documentSlice;
-    }();
-
-    batch->add(storedSlice);
-    ++docsProduced;
+      batch->add(storedSlice);
+      ++docsProduced;
+    }
 
     if (batch->byteSize() >= batchSize ||
         batch->count() >= _options.docsPerBatch) {
@@ -501,7 +511,7 @@ void RocksDBDumpContext::handleWorkItem(WorkItem item) {
     }
   }
 
-  if (batch != nullptr) {
+  if (batch != nullptr && batch->count() > 0) {
     // push remainder out
     batch->close();
     TRI_ASSERT(batch->byteSize() > 0);

--- a/arangod/RocksDBEngine/RocksDBDumpContext.h
+++ b/arangod/RocksDBEngine/RocksDBDumpContext.h
@@ -74,6 +74,21 @@ struct RocksDBDumpSimpleFilter {
   }
 };
 
+struct RocksDBDumpFilterSpec {
+  std::string type;
+  std::vector<RocksDBDumpSimpleFilter> conditions;
+
+  template<class Inspector>
+  inline friend auto inspect(Inspector& f, RocksDBDumpFilterSpec& o) {
+    return f.object(o).fields(
+        f.field("type", o.type).invariant([](auto&& v) {
+          return v == "simple";
+        }),
+        f.field("conditions", o.conditions)
+            .fallback(std::vector<RocksDBDumpSimpleFilter>{}));
+  }
+};
+
 struct RocksDBDumpContextOptions {
   std::uint64_t docsPerBatch = 10 * 1000;
   std::uint64_t batchSize = 16 * 1024;
@@ -84,7 +99,7 @@ struct RocksDBDumpContextOptions {
 
   std::optional<std::unordered_map<std::string, std::vector<std::string>>>
       projections;
-  std::vector<RocksDBDumpSimpleFilter> filters;
+  RocksDBDumpFilterSpec filters;
 
   template<class Inspector>
   inline friend auto inspect(Inspector& f, RocksDBDumpContextOptions& o) {
@@ -96,8 +111,7 @@ struct RocksDBDumpContextOptions {
         f.field("ttl", o.ttl).fallback(f.keep()),
         f.field("shards", o.shards).fallback(f.keep()),
         f.field("projections", o.projections),
-        f.field("filters", o.filters)
-            .fallback(std::vector<RocksDBDumpSimpleFilter>{}));
+        f.field("filters", o.filters).fallback(RocksDBDumpFilterSpec{}));
   }
 };
 

--- a/tests/js/client/shell/api/dump-cluster.js
+++ b/tests/js/client/shell/api/dump-cluster.js
@@ -237,7 +237,8 @@ function DumpAPI() {
       const servers = getShardsByServer(collection);
       const server = Object.keys(servers)[0];
       const ctx = createContext(server, {shards: servers[server],
-                                         filters: [{attributePath: ["flag"], value: 0}]});
+                                         filters: {type: "simple",
+                                                   conditions: [{attributePath: ["flag"], value: 0}]}});
 
       for (const [doc, shard] of ctx.read()) {
         assertEqual(doc.flag, 0);
@@ -249,8 +250,9 @@ function DumpAPI() {
       const servers = getShardsByServer(collection);
       const server = Object.keys(servers)[0];
       const ctx = createContext(server, {shards: servers[server],
-                                         filters: [{attributePath: ["flag"], value: 1},
-                                                   {attributePath: ["some", "nested", "value"], value: 1234}]});
+                                         filters: {type: "simple",
+                                                   conditions: [{attributePath: ["flag"], value: 1},
+                                                                {attributePath: ["some", "nested", "value"], value: 1234}]}});
 
       for (const [doc, shard] of ctx.read()) {
         assertEqual(doc.flag, 1);
@@ -263,7 +265,8 @@ function DumpAPI() {
       const servers = getShardsByServer(collection);
       const server = Object.keys(servers)[0];
       const ctx = createContext(server, {shards: servers[server],
-                                         filters: [{attributePath: ["some"], value: {"nested": {"value": 1234}}}]});
+                                         filters: {type: "simple",
+                                                   conditions: [{attributePath: ["some"], value: {"nested": {"value": 1234}}}]}});
 
       for (const [doc, shard] of ctx.read()) {
         assertEqual(doc.some, {nested: {value: 1234}}, JSON.stringify(doc.some));

--- a/tests/js/client/shell/api/dump-cluster.js
+++ b/tests/js/client/shell/api/dump-cluster.js
@@ -249,10 +249,24 @@ function DumpAPI() {
       const servers = getShardsByServer(collection);
       const server = Object.keys(servers)[0];
       const ctx = createContext(server, {shards: servers[server],
-                                         filters: [{attributePath: ["flag", "that", "nests"], value: 0}]});
+                                         filters: [{attributePath: ["flag"], value: 1},
+                                                   {attributePath: ["some", "nested", "value"], value: 1234}]});
 
       for (const [doc, shard] of ctx.read()) {
-        assertEqual(doc.flag, 0);
+        assertEqual(doc.flag, 1);
+        assertEqual(doc.some.nested.value, 1234);
+      }
+      ctx.drop();
+    },
+
+    testFilterWithObjectVal: function () {
+      const servers = getShardsByServer(collection);
+      const server = Object.keys(servers)[0];
+      const ctx = createContext(server, {shards: servers[server],
+                                         filters: [{attributePath: ["some"], value: {"nested": {"value": 1234}}}]});
+
+      for (const [doc, shard] of ctx.read()) {
+        assertEqual(doc.some, {nested: {value: 1234}}, JSON.stringify(doc.some));
       }
       ctx.drop();
     },


### PR DESCRIPTION
### Scope & Purpose

This PR augments the dump endpoint with very simple filtering; by adding a field
```
  filters: {"type": "simple", "conditions": [{"attributePath": ["colour"], "value": "green"}]}
```
while dumping the condition whether the attributes at the given path have the given value is tested using `VelocyPackHelper::equal()` on every document.

Only documents that satisfy all filters are dumped out.