### PR TITLE
Add generic MapToListTransformer

### DIFF
--- a/lib/Inspection/include/Inspection/Transformers.h
+++ b/lib/Inspection/include/Inspection/Transformers.h
@@ -24,6 +24,7 @@
 #pragma once
 #include <string>
 #include <chrono>
+#include <vector>
 #include "Basics/TimeString.h"
 #include "Basics/ErrorCode.h"
 #include "Inspection/Status.h"
@@ -91,6 +92,42 @@ struct ErrorCodeTransformer {
     return {};
   }
 };
+
+template<class Map>
+struct MapToListTransformer {
+  struct Entry {
+    typename Map::key_type key;
+    typename Map::mapped_type value;
+
+    friend inline auto inspect(auto& f, Entry& x) {
+      return f.object(x).fields(f.field("key", x.key),
+                                f.field("value", x.value));
+    }
+  };
+  using SerializedType = std::vector<Entry>;
+
+  auto toSerialized(Map const& source, SerializedType& target) const
+      -> inspection::Status {
+    target.reserve(source.size());
+    target.clear();
+    for (auto const& [key, value] : source) {
+      target.push_back({key, value});
+    }
+    return {};
+  }
+  auto fromSerialized(SerializedType const& source, Map& target) const
+      -> inspection::Status {
+    target.clear();
+    for (auto const& entry : source) {
+      target.emplace(entry.key, entry.value);
+    }
+    return {};
+  }
+};
+template<class Map>
+auto mapToListTransformer(Map const&) {
+  return MapToListTransformer<Map>{};
+}
 
 template<class Inspector>
 auto inspect(Inspector& f, ErrorCodeTransformer::ErrorCodeWithMessage& x) {

--- a/tests/Inspection/VPackLoadTest.cpp
+++ b/tests/Inspection/VPackLoadTest.cpp
@@ -207,6 +207,42 @@ TEST_F(VPackLoadInspectorTest, load_map) {
             m.unordered);
 }
 
+TEST_F(VPackLoadInspectorTest, load_transformed_map) {
+  builder.openObject();
+  builder.add(VPackValue("map"));
+  builder.openArray();
+  builder.openObject();
+  builder.add("key", 1);
+  builder.add(VPackValue("value"));
+  builder.openObject();
+  builder.add("i", VPackValue(1));
+  builder.close();
+  builder.close();
+  builder.openObject();
+  builder.add("key", 2);
+  builder.add(VPackValue("value"));
+  builder.openObject();
+  builder.add("i", VPackValue(2));
+  builder.close();
+  builder.close();
+  builder.openObject();
+  builder.add("key", 3);
+  builder.add(VPackValue("value"));
+  builder.openObject();
+  builder.add("i", VPackValue(3));
+  builder.close();
+  builder.close();
+  builder.close();
+  builder.close();
+  VPackLoadInspector inspector{builder};
+
+  TransformedMap m;
+  auto result = inspector.apply(m);
+  ASSERT_TRUE(result.ok());
+
+  EXPECT_EQ((std::map<int, Container>{{1, {1}}, {2, {2}}, {3, {3}}}), m.map);
+}
+
 TEST_F(VPackLoadInspectorTest, load_set) {
   builder.openObject();
   builder.add(VPackValue("set"));

--- a/tests/Inspection/VPackSaveTest.cpp
+++ b/tests/Inspection/VPackSaveTest.cpp
@@ -172,6 +172,27 @@ TEST_F(VPackSaveInspectorTest, store_map) {
   EXPECT_EQ(m.unordered["5"], obj["5"].getInt());
 }
 
+TEST_F(VPackSaveInspectorTest, store_transformed_map) {
+  TransformedMap m{.map = {{1, {1}}, {2, {2}}, {3, {3}}}};
+  auto result = inspector.apply(m);
+  ASSERT_TRUE(result.ok());
+
+  velocypack::Slice slice = builder.slice();
+  ASSERT_TRUE(slice.isObject());
+  auto obj = slice["map"];
+  ASSERT_TRUE(obj.isArray());
+  ASSERT_EQ(3u, obj.length());
+
+  EXPECT_EQ(1, obj[0]["key"].getInt());
+  EXPECT_EQ(m.map[1].i.value, obj[0]["value"]["i"].getInt());
+
+  EXPECT_EQ(2, obj[1]["key"].getInt());
+  EXPECT_EQ(m.map[2].i.value, obj[1]["value"]["i"].getInt());
+
+  EXPECT_EQ(3, obj[2]["key"].getInt());
+  EXPECT_EQ(m.map[3].i.value, obj[2]["value"]["i"].getInt());
+}
+
 TEST_F(VPackSaveInspectorTest, store_set) {
   static_assert(
       inspection::detail::HasInspectOverload<Set, VPackSaveInspector>::value);

--- a/tests/Inspection/include/Inspection/InspectionTestHelper.h
+++ b/tests/Inspection/include/Inspection/InspectionTestHelper.h
@@ -36,6 +36,7 @@
 
 #include "Inspection/Access.h"
 #include "Inspection/Format.h"
+#include "Inspection/Transformers.h"
 #include "Inspection/Types.h"
 
 namespace {
@@ -114,6 +115,16 @@ auto inspect(Inspector& f, Map& x) {
   return f.object(x).fields(f.field("map", x.map),
                             f.field("unordered", x.unordered));
 }
+
+struct TransformedMap {
+  std::map<int, Container> map;
+
+  friend inline auto inspect(auto& f, TransformedMap& x) {
+    return f.object(x).fields(
+        f.field("map", x.map)
+            .transformWith(arangodb::inspection::mapToListTransformer(x.map)));
+  }
+};
 
 struct Set {
   std::set<Container> set;


### PR DESCRIPTION
### Scope & Purpose

The VPack inspector requires maps to use string keys (or at least types that can be implicitly converted to strings). So in order to inspect other maps, this converter converts any map to an std::vector of a type with explicit key/value members.

- [x] :pizza: New feature

### Checklist

- [x] Tests
  - [x] C++ **Unit tests**
