### PR TITLE
[BTS-1642] Failover Jobs checking for clones

### DIFF
--- a/arangod/Agency/FailedFollower.cpp
+++ b/arangod/Agency/FailedFollower.cpp
@@ -302,6 +302,8 @@ bool FailedFollower::start(bool& aborts) {
         }
         // Plan still as we see it:
         addPreconditionUnchanged(job, planPath, planned);
+        // All clones still exist
+        addPreconditionClonesStillExist(job, _database, shardsLikeMe);
         // Check that failoverCandidates are still as we inspected them:
         doForAllShards(
             _snapshot, _database, shardsLikeMe,

--- a/arangod/Agency/FailedLeader.cpp
+++ b/arangod/Agency/FailedLeader.cpp
@@ -363,6 +363,8 @@ bool FailedLeader::start(bool& aborts) {
                                     Supervision::HEALTH_STATUS_GOOD);
         // Server list in plan still as before
         addPreconditionUnchanged(pending, planPath, planned);
+        // All clones still exist
+        addPreconditionClonesStillExist(pending, _database, shardsLikeMe);
         // Check that Current/servers and failoverCandidates are still as
         // we inspected them:
         doForAllShards(

--- a/arangod/Agency/Job.cpp
+++ b/arangod/Agency/Job.cpp
@@ -1043,6 +1043,19 @@ void Job::addPreconditionJobStillInPending(Builder& pre,
   }
 }
 
+void Job::addPreconditionClonesStillExist(Builder& pre,
+                                          std::string_view database,
+                                          std::vector<shard_t> const& clones) {
+  for (auto const& shard : clones) {
+    pre.add(VPackValue(StringUtils::concatT("/Plan/Collections/", database, "/",
+                                            shard.collection)));
+    {
+      VPackObjectBuilder guard(&pre);
+      pre.add("oldEmpty", VPackValue(false));
+    }
+  }
+}
+
 std::string Job::checkServerHealth(Node const& snapshot,
                                    std::string const& server) {
   auto status = snapshot.hasAsString(healthPrefix + server + "/Status");

--- a/arangod/Agency/Job.h
+++ b/arangod/Agency/Job.h
@@ -269,6 +269,9 @@ struct Job {
                                        velocypack::Value value);
   static void addPreconditionJobStillInPending(velocypack::Builder& pre,
                                                std::string const& jobId);
+  static void addPreconditionClonesStillExist(
+      velocypack::Builder& pre, std::string_view database,
+      std::vector<shard_t> const& clones);
   static std::string checkServerHealth(Node const& snapshot,
                                        std::string const& server);
 };

--- a/tests/Agency/FailedFollowerTest.cpp
+++ b/tests/Agency/FailedFollowerTest.cpp
@@ -885,6 +885,22 @@ TEST_F(FailedFollowerTest, job_should_handle_distributeshardslike) {
     EXPECT_TRUE(preconditions.get("/arango/Supervision/Shards/s99")
                     .get("oldEmpty")
                     .getBool() == true);
+    EXPECT_TRUE(
+        preconditions
+            .get("/arango/Plan/Collections/" + DATABASE + "/linkedcollection1")
+            .get("oldEmpty")
+            .getBool() == false);
+    EXPECT_TRUE(
+        preconditions
+            .get("/arango/Plan/Collections/" + DATABASE + "/linkedcollection2")
+            .get("oldEmpty")
+            .getBool() == false);
+
+    EXPECT_TRUE(
+        preconditions
+            .get("/arango/Plan/Collections/" + DATABASE + "/" + COLLECTION)
+            .get("oldEmpty")
+            .getBool() == false);
 
     return fakeTransResult;
   });

--- a/tests/Agency/FailedLeaderTest.cpp
+++ b/tests/Agency/FailedLeaderTest.cpp
@@ -499,7 +499,7 @@ class FailedLeaderTest
     ASSERT_TRUE(obj.isObject());
     // Will be set to false if ommited, or actively se t to false
     bool oldEmpty = VelocyPackHelper::getBooleanValue(obj, "oldEmpty", false);
-    // Required to be TRUE!
+    // Required to be FALSE!
     EXPECT_FALSE(oldEmpty);
   }
 

--- a/tests/Agency/FailedLeaderTest.cpp
+++ b/tests/Agency/FailedLeaderTest.cpp
@@ -285,6 +285,13 @@ class FailedLeaderTest
       }
     }
     {
+      // Assert that collection still exists
+      auto path =
+          "/arango/Plan/Collections/" + si.database + "/" + si.collection;
+      ASSERT_TRUE(pre.hasKey(path)) << path << pre.toJson();
+      AssertOldNotEmptyObject(pre.get(path));
+    }
+    {
       // Section: Protection against lost plan updates:
       if (!si.isFollower) {
         // Plan, only the leader needs to be unmodified. The Followers can only
@@ -486,6 +493,14 @@ class FailedLeaderTest
     bool oldEmpty = VelocyPackHelper::getBooleanValue(obj, "oldEmpty", false);
     // Required to be TRUE!
     EXPECT_TRUE(oldEmpty);
+  }
+
+  void AssertOldNotEmptyObject(VPackSlice obj) {
+    ASSERT_TRUE(obj.isObject());
+    // Will be set to false if ommited, or actively se t to false
+    bool oldEmpty = VelocyPackHelper::getBooleanValue(obj, "oldEmpty", false);
+    // Required to be TRUE!
+    EXPECT_FALSE(oldEmpty);
   }
 
   void AssertOldIsString(VPackSlice obj, std::string const& expected) {


### PR DESCRIPTION
### Scope & Purpose

Check that collections that are shared like the prototype collection still exist when the job is moving to pending. Otherwise we write to an already delete collection.
