### PR TITLE
Fix supervision: set schema to null instead of removing it

### DIFF
--- a/arangod/Cluster/Maintenance.cpp
+++ b/arangod/Cluster/Maintenance.cpp
@@ -103,23 +103,45 @@ static std::shared_ptr<VPackBuilder> createProps(VPackSlice const& s) {
       arangodb::velocypack::Collection::remove(s, alwaysRemoveProperties));
 }
 
+namespace {
+std::array<std::string_view, 7> replication1CompareProperties{
+    StaticStrings::Schema,
+    StaticStrings::CacheEnabled,
+    StaticStrings::InternalValidatorTypes,
+    StaticStrings::ComputedValues,
+    StaticStrings::GraphSmartGraphAttribute,
+    StaticStrings::WaitForSyncString,
+    StaticStrings::WriteConcern};
+
+std::array<std::string_view, 5> replication2CompareProperties{
+    StaticStrings::Schema, StaticStrings::CacheEnabled,
+    StaticStrings::InternalValidatorTypes, StaticStrings::ComputedValues,
+    StaticStrings::GraphSmartGraphAttribute};
+}  // namespace
+
 static std::shared_ptr<VPackBuilder> compareRelevantProps(
-    VPackSlice const& first, VPackSlice const& second) {
-  std::array<std::string_view, 7> const compareProperties{
-      StaticStrings::WaitForSyncString,
-      StaticStrings::Schema,
-      StaticStrings::WriteConcern,
-      StaticStrings::CacheEnabled,
-      StaticStrings::InternalValidatorTypes,
-      StaticStrings::ComputedValues,
-      StaticStrings::GraphSmartGraphAttribute};
+    VPackSlice const& first, VPackSlice const& second, bool isReplication2) {
+  std::string_view* begin;
+  std::string_view* end;
+  if (isReplication2) {
+    begin = replication2CompareProperties.data();
+    end = begin + replication2CompareProperties.size();
+  } else {
+    begin = replication1CompareProperties.data();
+    end = begin + replication1CompareProperties.size();
+  }
   auto result = std::make_shared<VPackBuilder>();
   {
     VPackObjectBuilder b(result.get());
-    for (auto const& property : compareProperties) {
-      auto const& planned = first.get(property);
+    for (auto ptr = begin; ptr != end; ++ptr) {
+      auto const& property = *ptr;
+      auto planned = first.get(property);
+      auto local = second.get(property);
       if (planned.isNone()) {
-        continue;
+        if (local.isNone()) {
+          continue;
+        }
+        planned = VPackSlice::nullSlice();
       }
       bool isSame = true;
       // Register any change
@@ -127,7 +149,7 @@ static std::shared_ptr<VPackBuilder> compareRelevantProps(
         // special handling for schemas is required here, because the
         // format for schemas seems to have changed, and we need to
         // compare them in a more fuzzy way
-        if (!ValidatorBase::isSame(planned, second.get(property))) {
+        if (!ValidatorBase::isSame(planned, local)) {
           isSame = false;
         }
       } else if (property == StaticStrings::ComputedValues) {
@@ -138,14 +160,12 @@ static std::shared_ptr<VPackBuilder> compareRelevantProps(
           return slice.isNone() || slice.isNull() || slice.isEmptyArray();
         };
 
-        if (!isEmpty(planned) || !isEmpty(second.get(property))) {
-          if (!basics::VelocyPackHelper::equal(planned, second.get(property),
-                                               false)) {
+        if (!isEmpty(planned) || !isEmpty(local)) {
+          if (!basics::VelocyPackHelper::equal(planned, local, false)) {
             isSame = false;
           }
         }
-      } else if (!basics::VelocyPackHelper::equal(planned, second.get(property),
-                                                  false)) {
+      } else if (!basics::VelocyPackHelper::equal(planned, local, false)) {
         isSame = false;
       }
 
@@ -320,8 +340,9 @@ static void handlePlanShard(
   std::shared_ptr<ActionDescription> description;
 
   bool shouldBeLeading = serverId == leaderId;
+  bool isReplication2 = replicationVersion == replication::Version::TWO;
   bool replication2Leader =
-      replicationVersion == replication::Version::TWO &&
+      isReplication2 &&
       isReplication2Leader(shname, localLogs.value(), shardsToLogs.value());
 
   commonShrds.emplace(shname);
@@ -331,7 +352,7 @@ static void handlePlanShard(
 
     std::string_view const localLeader = lcol.get(THE_LEADER).stringView();
     bool leading = localLeader.empty();
-    auto properties = compareRelevantProps(cprops, lcol);
+    auto properties = compareRelevantProps(cprops, lcol, isReplication2);
 
     auto fullShardLabel = dbname + "/" + colname + "/" + shname;
 

--- a/tests/js/client/shell/multi/shell-validation.js
+++ b/tests/js/client/shell/multi/shell-validation.js
@@ -507,8 +507,8 @@ function ValidationBasicsSuite() {
         assertEqual(ERRORS.ERROR_VALIDATION_FAILED.code, err.errorNum);
       }
       testCollection.properties({"schema": {}});
-      const shardList = testCollection.shards(true);
       waitInClusterUntil(() => {
+        const shardList = testCollection.shards(true);
         for (const [shard, servers] of Object.entries(shardList)) {
           const endpoint = getEndpointById(servers[0]);
           const resp = request.get(`${endpoint}/_api/collection/${shard}/properties`);
@@ -532,8 +532,8 @@ function ValidationBasicsSuite() {
         assertEqual(ERRORS.ERROR_VALIDATION_FAILED.code, err.errorNum);
       }
       testCollection.properties({"schema": null});
-      const shardList = testCollection.shards(true);
       waitInClusterUntil(() => {
+        const shardList = testCollection.shards(true);
         for (const [shard, servers] of Object.entries(shardList)) {
           const endpoint = getEndpointById(servers[0]);
           const resp = request.get(`${endpoint}/_api/collection/${shard}/properties`);

--- a/tests/js/client/shell/multi/shell-validation.js
+++ b/tests/js/client/shell/multi/shell-validation.js
@@ -30,6 +30,8 @@
 const jsunity = require("jsunity");
 
 const internal = require("internal");
+const { getEndpointById } = require('@arangodb/test-helper');
+const request = require('@arangodb/request');
 const db = internal.db;
 const arangodb = require("@arangodb");
 const ERRORS = arangodb.errors;
@@ -40,12 +42,12 @@ const waitInClusterUntil = func => {
   if (!isCluster) {
     return;
   }
-  let tries = 10;
+  let tries = 15;
   while (tries-- > 0) {
-    internal.wait(0.2, false);
     if (func()) {
       return;
     }
+    internal.wait(0.2, false);
   }
 };
 
@@ -505,7 +507,18 @@ function ValidationBasicsSuite() {
         assertEqual(ERRORS.ERROR_VALIDATION_FAILED.code, err.errorNum);
       }
       testCollection.properties({"schema": {}});
-      waitInClusterUntil(() => testCollection.properties().schema == null);
+      const shardList = testCollection.shards(true);
+      waitInClusterUntil(() => {
+        for (const [shard, servers] of Object.entries(shardList)) {
+          const endpoint = getEndpointById(servers[0]);
+          const resp = request.get(`${endpoint}/_api/collection/${shard}/properties`);
+          assertEqual(resp.statusCode, 200);
+          if (resp.json.schema != null) {
+            return false;
+          }
+        }
+        return true;
+      });
       assertEqual(testCollection.properties().schema, null);
       testCollection.insert(badDoc);
       assertEqual(1, testCollection.count());
@@ -519,7 +532,17 @@ function ValidationBasicsSuite() {
         assertEqual(ERRORS.ERROR_VALIDATION_FAILED.code, err.errorNum);
       }
       testCollection.properties({"schema": null});
-      waitInClusterUntil(() => testCollection.properties().schema == null);
+      waitInClusterUntil(() => {
+        for (const [shard, servers] of Object.entries(shardList)) {
+          const endpoint = getEndpointById(servers[0]);
+          const resp = request.get(`${endpoint}/_api/collection/${shard}/properties`);
+          assertEqual(resp.statusCode, 200);
+          if (resp.json.schema != null) {
+            return false;
+          }
+        }
+        return true;
+      });
       assertEqual(testCollection.properties().schema, null);
       testCollection.insert(badDoc);
       assertEqual(1, testCollection.count());

--- a/tests/js/client/shell/multi/shell-validation.js
+++ b/tests/js/client/shell/multi/shell-validation.js
@@ -532,6 +532,7 @@ function ValidationBasicsSuite() {
         assertEqual(ERRORS.ERROR_VALIDATION_FAILED.code, err.errorNum);
       }
       testCollection.properties({"schema": null});
+      const shardList = testCollection.shards(true);
       waitInClusterUntil(() => {
         for (const [shard, servers] of Object.entries(shardList)) {
           const endpoint = getEndpointById(servers[0]);


### PR DESCRIPTION
### Scope & Purpose

~Previously, if the planned slice did not contain a property, we simply ignored it, even if we still had that property in local. Now we always consider this property as null for the comparison. However, for replication2 we must not compare WriteConcern and WaitForSync, because there these properties are managed differently.~

The proposed maintenance fix does not work, because it does not correctly handle cases of old agency schemas where a property did not yet exist.

Instead we now fixed the supervision code to set the schema to null instead of completely removing it.

Also fixes potential race in a test -  when fetching the schema, the coordinator only looks in plan, but this does not guarantee that the DB servers have picked up and applied the update.

- [x] :hankey: Bugfix

### Checklist

- [x] Tests 
  - [x] **integration tests** - this issue occurred in the existing tests when using replication2 as default
