### PR TITLE
various unrelated cleanups

### DIFF
--- a/.circleci/base_config.yml
+++ b/.circleci/base_config.yml
@@ -262,7 +262,6 @@ jobs:
                   - tests/js
                   - enterprise/tests/js
                   - utils
-                  - UnitTests
                   - 3rdParty/iresearch/tests/resources
                   - 3rdParty/rta-makedata
 
@@ -385,7 +384,7 @@ jobs:
       #     shell: powershell.exe
       #     command: |
       #       cd D:/CircleCI/project/
-      #       7z a -r ./workspace CMakePresets.json build/ scripts/ js/ enterprise/js etc/ tests/js enterprise/tests/js utils UnitTests 3rdParty/iresearch/tests/resources 3rdParty/rta-makedata
+      #       7z a -r ./workspace CMakePresets.json build/ scripts/ js/ enterprise/js etc/ tests/js enterprise/tests/js utils 3rdParty/iresearch/tests/resources 3rdParty/rta-makedata
       # - run:
       #     name: SCCache Statistics
       #     command: sccache -s
@@ -411,7 +410,6 @@ jobs:
                   - tests/js
                   - enterprise/tests/js
                   - utils
-                  - UnitTests
                   - 3rdParty/iresearch/tests/resources
                   - 3rdParty/rta-makedata
 

--- a/3rdParty/V8/CMakeLists.txt
+++ b/3rdParty/V8/CMakeLists.txt
@@ -100,26 +100,6 @@ list(APPEND V8_GYP_ARGS
   -DV8_SRC_ROOT=${GYP_FILES_DIR}/
 )
 
-if (CROSS_COMPILING)
-  list(APPEND V8_GYP_ARGS
-  -Dhost_arch=${V8_PROC_ARCH}
-  -DGYP_CROSSCOMPILE=1
-  -DEXECUTABLE_PREFIX=${V8_PROC_ARCH}.
-  )
-  configure_file (
-    "${CMAKE_SOURCE_DIR}/lib/V8/v8-mkpeephole.in"
-    "${V8_TARGET_DIR}/${V8_PROC_ARCH}.release/${V8_PROC_ARCH}.mkpeephole"
-    NEWLINE_STYLE UNIX
-    @ONLY
-  )
-  configure_file (
-    "${CMAKE_SOURCE_DIR}/lib/V8/v8-mksnapshot.in"
-    "${V8_TARGET_DIR}/${V8_PROC_ARCH}.release/${V8_PROC_ARCH}.mksnapshot"
-    NEWLINE_STYLE UNIX
-    @ONLY
-  )
-endif()
-
 option(USE_DEBUG_V8 "compile V8 in DEBUG mode" OFF)
   
 ################################################################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -484,12 +484,6 @@ if (LINKER_IS_MOLD AND USE_BUILD_ID_READER)
   message(SEND_ERROR "It looks like you're using mold as a linker. That doesn't work together with USE_BUILD_ID_READER. Either disable USE_BUILD_ID_READER, or use another linker.")
 endif ()
 
-if (CROSS_COMPILING)
-# currently off, need additional params to configure like --host=triple <params>
-  SET(USE_JEMALLOC OFF)
-  SET(USE_LIBUNWIND OFF)
-endif()
-
 ################################################################################
 ## EXTERNAL PROGRAMS
 ################################################################################

--- a/js/client/modules/@arangodb/testutils/unittest.js
+++ b/js/client/modules/@arangodb/testutils/unittest.js
@@ -18,6 +18,11 @@ const inspect = internal.inspect;
 // //////////////////////////////////////////////////////////////////////////////
 
 function main (argv) {
+  // set deterministic locale value for all tests. 
+  // otherwise tests that depend on sort order/collation may
+  // behave differently on different platforms
+  internal.env.LC_ALL = "en_US.UTF-8";
+
   start_pretty_print();
 
   let testSuites = []; // e.g all, http_server, recovery, ...

--- a/tests/js/client/aql/aql-view-arangosearch-feature.js
+++ b/tests/js/client/aql/aql-view-arangosearch-feature.js
@@ -2191,13 +2191,19 @@ function iResearchFeatureAqlTestSuite () {
           assertEqual(1, result.length);
           assertEqual(16, result[0][0].length);
 
-          const expected = [
+          // old ICU generates this
+          const expected1 = [
             39, 6,  1158, 6, 120, 16, 1090, 26, 12,
             1, 12, 1, 1862, 1537, 1862, 1862];
 
+          // new ICU generates this
+          const expected2 = [
+            39, 6,  1158, 6, 120, 16, 1090, 26, 12,
+            1, 12, 1, 1731, 1537, 1731, 1731 ];
+
           const actual = result[0][0].split('').map(c => c.charCodeAt(0));
           assertTrue(
-            _.isEqual(expected, actual), {expected, actual});
+            _.isEqual(expected1, actual) || _.isEqual(expected2, actual), {expected1, expected2, actual});
         } finally {
           analyzers.remove(analyzerName, true);
         }

--- a/tests/js/client/authentication/user-access-right-create-search-alias-arangosearch-spec.js
+++ b/tests/js/client/authentication/user-access-right-create-search-alias-arangosearch-spec.js
@@ -1,0 +1,159 @@
+/* jshint globalstrict:true, strict:true, maxlen: 5000 */
+/* global describe, before, after, it */
+
+// //////////////////////////////////////////////////////////////////////////////
+// / @brief tests for user access rights
+// /
+// / @file
+// /
+// / DISCLAIMER
+// /
+// / Copyright 2018 ArangoDB GmbH, Cologne, Germany
+// /
+// / Licensed under the Apache License, Version 2.0 (the "License");
+// / you may not use this file except in compliance with the License.
+// / You may obtain a copy of the License at
+// /
+// /     http://www.apache.org/licenses/LICENSE-2.0
+// /
+// / Unless required by applicable law or agreed to in writing, software
+// / distributed under the License is distributed on an "AS IS" BASIS,
+// / WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// / See the License for the specific language governing permissions and
+// / limitations under the License.
+// /
+// / Copyright holder is ArangoDB GmbH, Cologne, Germany
+// /
+// / @author Vadim Kondratyev
+// / @author Copyright 2018, ArangoDB GmbH, Cologne, Germany
+// //////////////////////////////////////////////////////////////////////////////
+
+'use strict';
+
+const expect = require('chai').expect;
+const users = require('@arangodb/users');
+const helper = require('@arangodb/testutils/user-helper');
+const errors = require('@arangodb').errors;
+const db = require('@arangodb').db;
+const namePrefix = helper.namePrefix;
+const dbName = helper.dbName;
+const rightLevels = helper.rightLevels;
+const testViewName = `${namePrefix}ViewNew`;
+const testColName = `${namePrefix}ColNew`;
+const testColNameAnother = `${namePrefix}ColAnotherNew`;
+const indexName = `${namePrefix}Inverted`;
+const testViewType = "search-alias";
+
+const userSet = helper.userSet;
+const systemLevel = helper.systemLevel;
+const dbLevel = helper.dbLevel;
+const colLevel = helper.colLevel;
+
+const arango = require('internal').arango;
+for (let l of rightLevels) {
+  systemLevel[l] = new Set();
+  dbLevel[l] = new Set();
+  colLevel[l] = new Set();
+}
+
+helper.switchUser('root', '_system');
+helper.removeAllUsers();
+helper.generateAllUsers();
+
+describe('User Rights Management', () => {
+  it('should check if all users are created', () => {
+    helper.switchUser('root', '_system');
+    expect(userSet.size).to.be.greaterThan(0); 
+    expect(userSet.size).to.equal(helper.userCount);
+    for (let name of userSet) {
+      expect(users.document(name), `Could not find user: ${name}`).to.not.be.undefined;
+    }
+  });
+
+  it('should test rights for', () => {
+    describe(`view type ${testViewType}`, () => {
+      for (let name of userSet) {
+        try {
+          helper.switchUser(name, dbName);
+        } catch (e) {
+          continue;
+        }
+
+        describe(`user ${name}`, () => {
+          before(() => {
+            helper.switchUser(name, dbName);
+          });
+
+          describe('administrate on db level', () => {
+            const rootTestCollection = (colName, switchBack = true) => {
+              helper.switchUser('root', dbName);
+              let col = db._collection(colName);
+              if (switchBack) {
+                helper.switchUser(name, dbName);
+              }
+              return col !== null;
+            };
+
+            const rootDropCollection = (colName = testColName) => {
+              helper.switchUser('root', dbName);
+              try {
+                db._collection(colName).drop();
+              } catch (ignored) { }
+              helper.switchUser(name, dbName);
+            };
+
+            const rootTestView = (viewName = testViewName) => {
+              helper.switchUser('root', dbName);
+              const view = db._view(viewName);
+              helper.switchUser(name, dbName);
+              return view !== null;
+            };
+
+            const rootDropView = (viewName = testViewName) => {
+              helper.switchUser('root', dbName);
+              try {
+                db._dropView(viewName);
+              } catch (ignored) { }
+              helper.switchUser(name, dbName);
+            };
+
+            const checkError = (e) => {
+              expect(e.code).to.equal(403, "Expected to get forbidden REST error code, but got another one");
+              expect(e.errorNum).to.oneOf([errors.ERROR_FORBIDDEN.code, errors.ERROR_ARANGO_READ_ONLY.code], "Expected to get forbidden error number, but got another one");
+            };
+
+            describe('create a', () => {
+              before(() => {
+                db._useDatabase(dbName);
+              });
+
+              after(() => {
+                rootDropView(testViewName);
+                rootDropCollection(testColName);
+              });
+
+              it('view with empty (default) parameters', () => {
+                expect(rootTestView(testViewName)).to.equal(false, 'Precondition failed, the view exists');
+
+                if (dbLevel['rw'].has(name)) {
+                  db._createView(testViewName, testViewType, {});
+                  expect(rootTestView(testViewName)).to.equal(true, 'View creation reported success, but view was not found afterwards');
+                } else {
+                  try {
+                    db._createView(testViewName, testViewType, {});
+                  } catch (e) {
+                    checkError(e);
+                    return;
+                  }
+                  expect(rootTestView(testViewName)).to.equal(false, `${name} was able to create a view with insufficent rights`);
+                }
+              });
+
+            });
+          });
+        });
+      }
+    });
+
+  });
+});


### PR DESCRIPTION
### Scope & Purpose

Various unrelated cleanups. These changes were pulled out of the larger v8 upgrade PR to simplify the latter.

The following changes are made:
* remove `CROSS_COMPILING` cmake option. this option was only used for the V8 subdirectory and not maintained.
* remove mentions of non-existing `UnitTests` directory from CircleCI configs. we previously had a directory of that name, but we removed it about a year ago in favor of the `tests` directory.
* make `scripts/unittest` run all tests with a fixed locale set. otherwise the actually used locale is system-dependent and may lead to tests behaving differently with different locales. the locale value is used when starting ArangoDB for the first time, when the value of the current locale is used as the default value for `--server.language`. this then influences the server's default collation and thus influences the sorting order.
* split a larger JavaScript mocha test into 2 files. the problem is that mocha tests can generate really deep stacks, so it is useful to limit their size/nesting. the now-split test file turned out to be a problem in the new version of V8 in some environments.
* prepare a test for a different tokenization result when using a different version of ICU.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 