### PR TITLE
Cinfra: Adapted test for numDocs figures.

### DIFF
--- a/tests/js/server/recovery/view-search-alias-populate-cluster.js
+++ b/tests/js/server/recovery/view-search-alias-populate-cluster.js
@@ -158,7 +158,7 @@ function recoverySuite() {
         }
         require("internal").sleep(0.5);
       }
-      // Note: This is okay to be larger, as those are not consolidated docs, which can be the cause during recovery.
+      // Note: This is okay to be larger, as those are not consolidated docs, which can be the case during recovery.
       // The number live docs is the really visible amount of documents.s
       assertTrue(figures.numDocs >= 501, `Not enough documents seen ${figures.numDocs} >= 501`);
       assertEqual(figures.numLiveDocs, 501);

--- a/tests/js/server/recovery/view-search-alias-populate-cluster.js
+++ b/tests/js/server/recovery/view-search-alias-populate-cluster.js
@@ -150,15 +150,17 @@ function recoverySuite() {
       }
       let figures;
       for (let i = 0; i < 100; ++i) {
-        require("internal").sleep(0.5);
         figures = db._collection('UnitTestsRecoveryDummy').getIndexes(true, true)
           .find(e => e.name === "i1")
           .figures;
         if (figures.numDocs > 500) {
           break;
         }
+        require("internal").sleep(0.5);
       }
-      assertEqual(figures.numDocs, 501);
+      // Note: This is okay to be larger, as those are not consolidated docs, which can be the cause during recovery.
+      // The number live docs is the really visible amount of documents.s
+      assertTrue(figures.numDocs >= 501, `Not enough documents seen ${figures.numDocs} >= 501`);
       assertEqual(figures.numLiveDocs, 501);
       assertEqual(figures.numPrimaryDocs, 501);
       assertTrue(figures.numSegments >= 1);

--- a/tests/js/server/recovery/view-search-alias-populate-cluster.js
+++ b/tests/js/server/recovery/view-search-alias-populate-cluster.js
@@ -162,7 +162,7 @@ function recoverySuite() {
       // The number live docs is the really visible amount of documents.s
       assertTrue(figures.numDocs >= 501, `Not enough documents seen ${figures.numDocs} >= 501`);
       assertEqual(figures.numLiveDocs, 501);
-      assertEqual(figures.numPrimaryDocs, 501);
+      assertTrue(figures.numPrimaryDocs >= 501, `Not enough documents seen ${figures.numPrimaryDocs} >= 501`);
       assertTrue(figures.numSegments >= 1);
       assertTrue(figures.numFiles >= 6);
       assertTrue(figures.indexSize > 0);


### PR DESCRIPTION
### Scope & Purpose

*Test only change in recovery. During recovery it is allowed for replication 2 to have non-consolidated docs in the recovery. This is now handled by a relaxed condition.*

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

