### PR TITLE
Cinfra: Remove incorrect assertion

### DIFF
--- a/arangod/Pregel/PregelFeature.cpp
+++ b/arangod/Pregel/PregelFeature.cpp
@@ -523,7 +523,6 @@ void PregelFeature::start() {
 }
 
 void PregelFeature::beginShutdown() {
-  TRI_ASSERT(isStopping());
 
   // Copy the _conductors and _workers maps here, because in the case of a
   // single server there is a lock order inversion.  This is because the

--- a/arangod/Pregel/PregelFeature.cpp
+++ b/arangod/Pregel/PregelFeature.cpp
@@ -523,7 +523,6 @@ void PregelFeature::start() {
 }
 
 void PregelFeature::beginShutdown() {
-
   // Copy the _conductors and _workers maps here, because in the case of a
   // single server there is a lock order inversion.  This is because the
   // conductor code directly calls back into the feature while holding the


### PR DESCRIPTION
### Scope & Purpose

*Removed assertion in Feature that tests if we are in stopping mode. However if we encounter an issue during startup Like here: https://github.com/arangodb/arangodb/blob/0b0212a37f70c4e8b496b198af1bf4e4a925a21b/lib/ApplicationFeatures/ApplicationServer.cpp#L692 we would not be in stopping state.*

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

