### PR TITLE
Fix: check replicationFactor against number of available servers

### DIFF
--- a/arangod/Cluster/ClusterCollectionMethods.cpp
+++ b/arangod/Cluster/ClusterCollectionMethods.cpp
@@ -440,13 +440,11 @@ Result impl(ClusterInfo& ci, ArangodServer& server,
 Result impl(ClusterInfo& ci, ArangodServer& server,
             std::string_view databaseName, TargetCollectionAgencyWriter& writer,
             bool waitForSyncReplication) {
-  AgencyComm ac(server);
-  double pollInterval = ci.getPollInterval();
-  AgencyCallbackRegistry& callbackRegistry = ci.agencyCallbackRegistry();
+  std::vector<ServerID> availableServers = ci.getCurrentDBServers();
 
   // TODO Timeout?
-  std::vector<std::string> collectionNames = writer.collectionNames();
-  auto buildingTransaction = writer.prepareCreateTransaction(databaseName);
+  auto buildingTransaction =
+      writer.prepareCreateTransaction(databaseName, availableServers);
   if (buildingTransaction.fail()) {
     return buildingTransaction.result();
   }
@@ -456,6 +454,7 @@ Result impl(ClusterInfo& ci, ArangodServer& server,
 
   std::vector<std::pair<std::shared_ptr<AgencyCallback>, std::string>>
       callbackList;
+  AgencyCallbackRegistry& callbackRegistry = ci.agencyCallbackRegistry();
   auto unregisterCallbacksGuard =
       scopeGuard([&callbackList, &callbackRegistry]() noexcept {
         try {
@@ -486,6 +485,7 @@ Result impl(ClusterInfo& ci, ArangodServer& server,
   AsyncAgencyComm aac;
   // TODO do we need to handle Error message (thenError?)
 
+  double pollInterval = ci.getPollInterval();
   auto future =
       aac.sendWriteTransaction(120s, std::move(buildingTransaction.get()))
           .thenValue(::reactToPreconditionsCreate)

--- a/arangod/Cluster/Utils/DistributeShardsLike.cpp
+++ b/arangod/Cluster/Utils/DistributeShardsLike.cpp
@@ -32,9 +32,14 @@ DistributeShardsLike::DistributeShardsLike(
         getOriginalSharding)
     : _originalShardingProducer{std::move(getOriginalSharding)} {}
 
-Result DistributeShardsLike::planShardsOnServers(
+auto DistributeShardsLike::checkDistributionPossible(
+    std::vector<ServerID>& availableServers) -> Result {
+  return {};
+}
+
+auto DistributeShardsLike::planShardsOnServers(
     std::vector<ServerID> availableServers,
-    std::unordered_set<ServerID>& serversPlanned) {
+    std::unordered_set<ServerID>& serversPlanned) -> Result {
   auto nextSharding = _originalShardingProducer();
   if (nextSharding.fail()) {
     return nextSharding.result();

--- a/arangod/Cluster/Utils/DistributeShardsLike.h
+++ b/arangod/Cluster/Utils/DistributeShardsLike.h
@@ -33,9 +33,13 @@ struct DistributeShardsLike : public IShardDistributionFactory {
   DistributeShardsLike(
       std::function<ResultT<std::vector<ResponsibleServerList>>()>
           getOriginalSharding);
-  Result planShardsOnServers(
-      std::vector<ServerID> availableServers,
-      std::unordered_set<ServerID>& serversPlanned) override;
+
+  auto checkDistributionPossible(std::vector<ServerID>& availableServers)
+      -> Result override;
+
+  auto planShardsOnServers(std::vector<ServerID> availableServers,
+                           std::unordered_set<ServerID>& serversPlanned)
+      -> Result override;
 
  private:
   std::function<ResultT<std::vector<ResponsibleServerList>>()>

--- a/arangod/Cluster/Utils/EvenDistribution.h
+++ b/arangod/Cluster/Utils/EvenDistribution.h
@@ -31,15 +31,18 @@ struct EvenDistribution : public IShardDistributionFactory {
                    std::vector<ServerID> avoidServers,
                    bool enforceReplicationFactor);
 
-  Result planShardsOnServers(
-      std::vector<ServerID> availableServers,
-      std::unordered_set<ServerID>& serversPlanned) override;
+  auto checkDistributionPossible(std::vector<ServerID>& availableServers)
+      -> Result override;
+
+  auto planShardsOnServers(std::vector<ServerID> availableServers,
+                           std::unordered_set<ServerID>& serversPlanned)
+      -> Result override;
 
  private:
-  uint64_t _numberOfShards;
-  uint64_t _replicationFactor;
-  std::vector<ServerID> _avoidServers;
-  bool _enforceReplicationFactor;
+  uint64_t const _numberOfShards;
+  uint64_t const _replicationFactor;
+  std::vector<ServerID> const _avoidServers;
+  bool const _enforceReplicationFactor;
 };
 
 }  // namespace arangodb

--- a/arangod/Cluster/Utils/IShardDistributionFactory.h
+++ b/arangod/Cluster/Utils/IShardDistributionFactory.h
@@ -38,6 +38,15 @@ struct IShardDistributionFactory {
   virtual ~IShardDistributionFactory() = default;
 
   /**
+   * @brief Check if the distribution is possible, ie., if the replicationFactor
+   * can be fulfilled with the number of available servers.
+   * Note: availableServers is an in/out parameter, because we might remove
+   * servers that have to be avoided
+   */
+  [[nodiscard]] virtual auto checkDistributionPossible(
+      std::vector<ServerID>& availableServers) -> Result = 0;
+
+  /**
    * @brief Plan shard -> [servers] mapping.
    * This has te be called once before we send the request to the agency.
    * It can be called again to select other servers in case the operation needs

--- a/arangod/Cluster/Utils/SatelliteDistribution.cpp
+++ b/arangod/Cluster/Utils/SatelliteDistribution.cpp
@@ -32,9 +32,14 @@ SatelliteDistribution::SatelliteDistribution() {
   _shardToServerMapping.reserve(1);
 }
 
-Result SatelliteDistribution::planShardsOnServers(
+auto SatelliteDistribution::checkDistributionPossible(
+    std::vector<ServerID>& availableServers) -> Result {
+  return {};
+}
+
+auto SatelliteDistribution::planShardsOnServers(
     std::vector<ServerID> availableServers,
-    std::unordered_set<ServerID>& serversPlanned) {
+    std::unordered_set<ServerID>& serversPlanned) -> Result {
   // Caller needs to ensure we have something to place shards on
   TRI_ASSERT(!availableServers.empty());
   _shardToServerMapping.clear();

--- a/arangod/Cluster/Utils/SatelliteDistribution.h
+++ b/arangod/Cluster/Utils/SatelliteDistribution.h
@@ -28,9 +28,12 @@ namespace arangodb {
 struct SatelliteDistribution : public IShardDistributionFactory {
   SatelliteDistribution();
 
-  Result planShardsOnServers(
-      std::vector<ServerID> availableServers,
-      std::unordered_set<ServerID>& serversPlanned) override;
+  auto checkDistributionPossible(std::vector<ServerID>& availableServers)
+      -> Result override;
+
+  auto planShardsOnServers(std::vector<ServerID> availableServers,
+                           std::unordered_set<ServerID>& serversPlanned)
+      -> Result override;
 };
 
 }  // namespace arangodb

--- a/arangod/Cluster/Utils/TargetCollectionAgencyWriter.cpp
+++ b/arangod/Cluster/Utils/TargetCollectionAgencyWriter.cpp
@@ -150,7 +150,17 @@ TargetCollectionAgencyWriter::prepareCurrentWatcher(
 
 ResultT<VPackBufferUInt8>
 TargetCollectionAgencyWriter::prepareCreateTransaction(
-    std::string_view databaseName) const {
+    std::string_view databaseName,
+    std::vector<ServerID> const& availableServers) const {
+  for (auto& v : _shardDistributionsUsed) {
+    // checkDistributionPossible may modify the input vector, so we have to use
+    // separate copies
+    std::vector<ServerID> servers{availableServers};
+    if (auto res = v.second->checkDistributionPossible(servers); res.fail()) {
+      return res;
+    }
+  }
+
   auto const baseCollectionPath = pathCollectionInTarget(databaseName);
   auto const baseGroupPath = pathCollectionGroupInTarget(databaseName);
   auto const collectionNamePath = pathCollectionNamesInTarget(databaseName);

--- a/arangod/Cluster/Utils/TargetCollectionAgencyWriter.h
+++ b/arangod/Cluster/Utils/TargetCollectionAgencyWriter.h
@@ -65,7 +65,8 @@ struct TargetCollectionAgencyWriter {
       AgencyCache& agencyCache) const;
 
   [[nodiscard]] ResultT<velocypack::Buffer<uint8_t>> prepareCreateTransaction(
-      std::string_view databaseName) const;
+      std::string_view databaseName,
+      std::vector<ServerID> const& availableServers) const;
 
   [[nodiscard]] std::vector<std::string> collectionNames() const;
 

--- a/tests/Cluster/PlanCollectionEntryTest.cpp
+++ b/tests/Cluster/PlanCollectionEntryTest.cpp
@@ -58,6 +58,11 @@ struct TestShardDistribution : public IShardDistributionFactory {
     }
   }
 
+  auto checkDistributionPossible(std::vector<ServerID>& availableServers)
+      -> Result override {
+    return {};
+  }
+
   auto planShardsOnServers(std::vector<ServerID>,
                            std::unordered_set<ServerID>& serversPlanned)
       -> Result override {


### PR DESCRIPTION
### Scope & Purpose

In replication2 we plan the distribution of shards to the individual servers in the supervision. However, once the coordinator has written the relevant information to target, the agency has no way to report back any errors, but has to go through with it. So on the coordinator we at least have to check if the replicationFactor can be fulfilled with the number of available servers, before we write to target.

This should fix a couple of tests when run with replication2 as default.

- [x] :hankey: Bugfix

### Checklist

- [x] Tests
  - [x] **integration tests**
