### PR TITLE
ArangoSearch view executor improvements

### DIFF
--- a/arangod/Aql/IResearchViewExecutor.tpp
+++ b/arangod/Aql/IResearchViewExecutor.tpp
@@ -55,15 +55,6 @@
 #include <search/cost.hpp>
 #include <utility>
 
-// TODO Eliminate access to the plan if possible!
-// I think it is used for two things only:
-//  - to get the Ast, which can simply be passed on its own, and
-//  - to call plan->getVarSetBy() in aql::Expression, which could be removed by
-//    passing (a reference to) plan->_varSetBy instead.
-// But changing this, even only for the IResearch part, would involve more
-// refactoring than I currently find appropriate for this.
-#include "Aql/ExecutionPlan.h"
-
 namespace arangodb::aql {
 
 inline PushTag& operator*=(PushTag& self, size_t) { return self; }
@@ -1880,9 +1871,8 @@ void IResearchViewMergeExecutor<ExecutionTraits>::reset(
                                nullptr);
         continue;
       }
-    } else {
-      TRI_ASSERT(!isSortReaderUsedInStoredValues);
     }
+    TRI_ASSERT(!isSortReaderUsedInStoredValues);
     auto itr = iresearch::sortColumn(segment);
     if (ADB_UNLIKELY(!itr)) {
       LOG_TOPIC("af4cd", WARN, iresearch::TOPIC)

--- a/arangod/IResearch/AqlHelper.cpp
+++ b/arangod/IResearch/AqlHelper.cpp
@@ -617,10 +617,6 @@ bool attributeAccessEqual(aql::AstNode const* lhs, aql::AstNode const* rhs,
       return type == rhs.type && strVal == rhs.strVal && iVal == rhs.iVal;
     }
 
-    bool operator!=(const NodeValue& rhs) const noexcept {
-      return !(*this == rhs);
-    }
-
     iresearch::ScopedAqlValue aqlValue;
     std::string_view strVal;
     int64_t iVal;

--- a/arangod/IResearch/ExpressionFilter.h
+++ b/arangod/IResearch/ExpressionFilter.h
@@ -46,10 +46,6 @@ struct ExpressionCompilationContext {
     return ast == rhs.ast && node == rhs.node;
   }
 
-  bool operator!=(ExpressionCompilationContext const& rhs) const noexcept {
-    return !(*this == rhs);
-  }
-
   explicit operator bool() const noexcept { return ast && node; }
 
   size_t hash() const noexcept;

--- a/arangod/IResearch/IResearchAnalyzerFeature.h
+++ b/arangod/IResearch/IResearchAnalyzerFeature.h
@@ -140,13 +140,6 @@ class Features {
            _fieldFeatures == rhs._fieldFeatures;
   }
 
-  //////////////////////////////////////////////////////////////////////////////
-  /// @brief compare features for inequality
-  //////////////////////////////////////////////////////////////////////////////
-  constexpr bool operator!=(Features const& rhs) const noexcept {
-    return !(*this == rhs);
-  }
-
   bool hasFeatures(irs::IndexFeatures test) const noexcept {
     return (test == (_indexFeatures & test));
   }
@@ -224,7 +217,6 @@ class AnalyzerPool : private irs::util::noncopyable {
   }
 
   bool operator==(AnalyzerPool const& rhs) const;
-  bool operator!=(AnalyzerPool const& rhs) const { return !(*this == rhs); }
 
   // definition to be stored in _analyzers collection or shown to the end user
   void toVelocyPack(velocypack::Builder& builder, bool forPersistence = false);

--- a/arangod/IResearch/IResearchDataStoreMeta.cpp
+++ b/arangod/IResearch/IResearchDataStoreMeta.cpp
@@ -533,9 +533,4 @@ bool IResearchDataStoreMeta::operator==(
   return true;
 }
 
-bool IResearchDataStoreMeta::operator!=(
-    IResearchDataStoreMeta const& other) const noexcept {
-  return !(*this == other);
-}
-
 }  // namespace arangodb::iresearch

--- a/arangod/IResearch/IResearchDataStoreMeta.h
+++ b/arangod/IResearch/IResearchDataStoreMeta.h
@@ -70,7 +70,6 @@ struct IResearchDataStoreMeta {
   };
 
   bool operator==(IResearchDataStoreMeta const& other) const noexcept;
-  bool operator!=(IResearchDataStoreMeta const& other) const noexcept;
 
   bool init(velocypack::Slice slice, std::string& errorField,
             IResearchDataStoreMeta const& defaults, Mask* mask) noexcept;

--- a/arangod/IResearch/IResearchFeature.cpp
+++ b/arangod/IResearch/IResearchFeature.cpp
@@ -1098,7 +1098,7 @@ void IResearchFeature::validateOptions(
 
   if (!args.touched(SEARCH_THREADS_LIMIT)) {
     _searchExecutionThreadsLimit =
-        static_cast<uint32_t>(2 * NumberOfCores::getValue());
+        static_cast<uint32_t>(NumberOfCores::getValue());
   }
 }
 

--- a/arangod/IResearch/IResearchLinkMeta.cpp
+++ b/arangod/IResearch/IResearchLinkMeta.cpp
@@ -652,7 +652,7 @@ IResearchLinkMeta::IResearchLinkMeta()
 
 bool IResearchLinkMeta::operator==(
     IResearchLinkMeta const& other) const noexcept {
-  if (FieldMeta::operator!=(other)) {
+  if (static_cast<FieldMeta const&>(*this) != other) {
     return false;
   }
 

--- a/arangod/IResearch/IResearchLinkMeta.h
+++ b/arangod/IResearch/IResearchLinkMeta.h
@@ -132,9 +132,6 @@ struct FieldMeta {
   FieldMeta& operator=(FieldMeta&&) = default;
 
   bool operator==(FieldMeta const& rhs) const noexcept;
-  bool operator!=(FieldMeta const& rhs) const noexcept {
-    return !(*this == rhs);
-  }
 
   ////////////////////////////////////////////////////////////////////////////////
   /// @brief initialize FieldMeta with values from a JSON description
@@ -282,9 +279,6 @@ struct IResearchLinkMeta : public FieldMeta {
   IResearchLinkMeta& operator=(IResearchLinkMeta const& other) = default;
 
   bool operator==(IResearchLinkMeta const& rhs) const noexcept;
-  bool operator!=(IResearchLinkMeta const& rhs) const noexcept {
-    return !(*this == rhs);
-  }
 
   ////////////////////////////////////////////////////////////////////////////////
   /// @brief initialize IResearchLinkMeta with values from a JSON description

--- a/arangod/IResearch/IResearchViewMeta.cpp
+++ b/arangod/IResearch/IResearchViewMeta.cpp
@@ -118,11 +118,6 @@ bool IResearchViewMeta::operator==(
   return true;
 }
 
-bool IResearchViewMeta::operator!=(
-    IResearchViewMeta const& other) const noexcept {
-  return !(*this == other);
-}
-
 IResearchViewMeta const& IResearchViewMeta::DEFAULT() {
   static const IResearchViewMeta meta;
 
@@ -351,11 +346,6 @@ bool IResearchViewMetaState::operator==(
   }
 
   return true;
-}
-
-bool IResearchViewMetaState::operator!=(
-    IResearchViewMetaState const& other) const noexcept {
-  return !(*this == other);
 }
 
 bool IResearchViewMetaState::init(VPackSlice slice, std::string& errorField,

--- a/arangod/IResearch/IResearchViewMeta.h
+++ b/arangod/IResearch/IResearchViewMeta.h
@@ -115,7 +115,6 @@ struct IResearchViewMeta : public IResearchDataStoreMeta {
   void storeFull(IResearchViewMeta&& other) noexcept;
 
   bool operator==(IResearchViewMeta const& other) const noexcept;
-  bool operator!=(IResearchViewMeta const& other) const noexcept;
 
   ////////////////////////////////////////////////////////////////////////////////
   /// @brief return default IResearchViewMeta values
@@ -181,7 +180,6 @@ struct IResearchViewMetaState {
   IResearchViewMetaState& operator=(IResearchViewMetaState const& other);
 
   bool operator==(IResearchViewMetaState const& other) const noexcept;
-  bool operator!=(IResearchViewMetaState const& other) const noexcept;
 
   ////////////////////////////////////////////////////////////////////////////////
   /// @brief initialize IResearchViewMeta with values from a JSON description

--- a/arangod/IResearch/IResearchViewStoredValues.h
+++ b/arangod/IResearch/IResearchViewStoredValues.h
@@ -33,11 +33,11 @@
 #include "Containers/FlatHashSet.h"
 
 namespace arangodb {
-
 namespace velocypack {
-class Builder;
-}
 
+class Builder;
+
+}  // namespace velocypack
 namespace iresearch {
 
 class IResearchViewStoredValues {
@@ -55,10 +55,6 @@ class IResearchViewStoredValues {
       return name == rhs.name;
     }
 
-    bool operator!=(StoredColumn const& rhs) const noexcept {
-      return !(*this == rhs);
-    }
-
     bool sameName(std::string_view str) const noexcept {
       return (name.size() == str.size() + 1) && name.ends_with(str);
     }
@@ -68,13 +64,7 @@ class IResearchViewStoredValues {
     return _storedColumns == rhs._storedColumns;
   }
 
-  bool operator!=(IResearchViewStoredValues const& rhs) const noexcept {
-    return !(*this == rhs);
-  }
-
-  std::vector<StoredColumn> const& columns() const noexcept {
-    return _storedColumns;
-  }
+  auto const& columns() const noexcept { return _storedColumns; }
 
   size_t memory() const noexcept;
 
@@ -93,7 +83,7 @@ class IResearchViewStoredValues {
   void clear() noexcept { _storedColumns.clear(); }
 
   std::vector<StoredColumn> _storedColumns;
-};  // IResearchViewStoredValues
+};
 
 }  // namespace iresearch
 }  // namespace arangodb

--- a/tests/IResearch/IResearchViewCountApproximateTest.cpp
+++ b/tests/IResearch/IResearchViewCountApproximateTest.cpp
@@ -556,19 +556,45 @@ TEST_F(IResearchViewCountApproximateTest, directSkipAllForMergeExecutorExact) {
       arangodb::iresearch::ViewSnapshotPtr{}, snapshot};
   arangodb::iresearch::IResearchViewSort sort;
   sort.emplace_back({{std::string_view("value"), false}}, true);
-  arangodb::aql::IResearchViewExecutorInfos executorInfos(
-      reader, arangodb::aql::RegisterId::makeInvalid(),
-      arangodb::aql::RegisterId::makeInvalid(), {}, *query,
+
+  arangodb::aql::IResearchViewExecutorInfos executorInfos{
+      .reader = reader,
+      .meta = nullptr,
+
+      .query = query.get(),
+      .ast = plan->getAst(),
+      .varInfo = &viewNode.getRegisterPlan()->varInfo,
+      .filter = &viewNode.filterCondition(),
+      .outVar = &viewNode.outVariable(),
+
+      .docReg = arangodb::aql::RegisterId::makeInvalid(),
+      .searchDocReg = arangodb::aql::RegisterId::makeInvalid(),
+      .scoreRegs = {},
+      .valuesRegs = {},
+
+      .scorers = emptyScorers,
+      .storedValues = &_view->storedValues(),
+
+      .heapSort = emptyScorersSort,
+      .heapSortLimit = 0,
 #ifdef USE_ENTERPRISE
-      _view->meta()._optimizeTopK,
+      .optimizeTopK = &_view->meta()._optimizeTopK,
 #endif
-      emptyScorers, {&sort, 1U}, _view->storedValues(), *plan,
-      viewNode.outVariable(), viewNode.filterCondition(), {false, false}, 0,
-      viewNode.getRegisterPlan()->varInfo, 0,
-      arangodb::iresearch::IResearchViewNode::ViewValuesRegisters{},
-      arangodb::iresearch::CountApproximate::Exact,
-      arangodb::iresearch::FilterOptimization::MAX, emptyScorersSort, 0,
-      nullptr, 1, _pool);
+      .sort = {&sort, 1U},
+
+      .depth = 0,
+      .immutableParts = 0,
+      .filterOptimization = arangodb::iresearch::FilterOptimization::MAX,
+      .countApproximate = arangodb::iresearch::CountApproximate::Exact,
+      .emptyFilter = arangodb::iresearch::isFilterConditionEmpty(
+                         &viewNode.filterCondition()) &&
+                     !reader->hasNestedFields(),
+      .volatileSort = false,
+      .volatileFilter = false,
+
+      .parallelism = 1,
+      .parallelExecutionPool = &_pool,
+  };
 
   std::vector<arangodb::aql::ExecutionBlock*> emptyExecutors;
   arangodb::aql::DependencyProxy<arangodb::aql::BlockPassthrough::Disable>
@@ -638,19 +664,45 @@ TEST_F(IResearchViewCountApproximateTest,
       arangodb::iresearch::ViewSnapshotPtr{}, snapshot};
   arangodb::iresearch::IResearchViewSort sort;
   sort.emplace_back({{std::string_view("value"), false}}, true);
-  arangodb::aql::IResearchViewExecutorInfos executorInfos(
-      reader, arangodb::aql::RegisterId::makeInvalid(),
-      arangodb::aql::RegisterId::makeInvalid(), {}, *query,
+
+  arangodb::aql::IResearchViewExecutorInfos executorInfos{
+      .reader = reader,
+      .meta = nullptr,
+
+      .query = query.get(),
+      .ast = plan->getAst(),
+      .varInfo = &viewNode.getRegisterPlan()->varInfo,
+      .filter = &viewNode.filterCondition(),
+      .outVar = &viewNode.outVariable(),
+
+      .docReg = arangodb::aql::RegisterId::makeInvalid(),
+      .searchDocReg = arangodb::aql::RegisterId::makeInvalid(),
+      .scoreRegs = {},
+      .valuesRegs = {},
+
+      .scorers = emptyScorers,
+      .storedValues = &_view->storedValues(),
+
+      .heapSort = emptyScorersSort,
+      .heapSortLimit = 0,
 #ifdef USE_ENTERPRISE
-      _view->meta()._optimizeTopK,
+      .optimizeTopK = &_view->meta()._optimizeTopK,
 #endif
-      emptyScorers, {&sort, 1U}, _view->storedValues(), *plan,
-      viewNode.outVariable(), viewNode.filterCondition(), {false, false}, 0,
-      viewNode.getRegisterPlan()->varInfo, 0,
-      arangodb::iresearch::IResearchViewNode::ViewValuesRegisters{},
-      arangodb::iresearch::CountApproximate::Exact,
-      arangodb::iresearch::FilterOptimization::MAX, emptyScorersSort, 0,
-      nullptr, 1, _pool);
+      .sort = {&sort, 1U},
+
+      .depth = 0,
+      .immutableParts = 0,
+      .filterOptimization = arangodb::iresearch::FilterOptimization::MAX,
+      .countApproximate = arangodb::iresearch::CountApproximate::Exact,
+      .emptyFilter = arangodb::iresearch::isFilterConditionEmpty(
+                         &viewNode.filterCondition()) &&
+                     !reader->hasNestedFields(),
+      .volatileSort = false,
+      .volatileFilter = false,
+
+      .parallelism = 1,
+      .parallelExecutionPool = &_pool,
+  };
 
   std::vector<arangodb::aql::ExecutionBlock*> emptyExecutors;
   arangodb::aql::DependencyProxy<arangodb::aql::BlockPassthrough::Disable>
@@ -722,19 +774,45 @@ TEST_F(IResearchViewCountApproximateTest, directSkipAllForMergeExecutorCost) {
       arangodb::iresearch::ViewSnapshotPtr{}, snapshot};
   arangodb::iresearch::IResearchViewSort sort;
   sort.emplace_back({{std::string_view("value"), false}}, true);
-  arangodb::aql::IResearchViewExecutorInfos executorInfos(
-      reader, arangodb::aql::RegisterId::makeInvalid(),
-      arangodb::aql::RegisterId::makeInvalid(), {}, *query,
+
+  arangodb::aql::IResearchViewExecutorInfos executorInfos{
+      .reader = reader,
+      .meta = nullptr,
+
+      .query = query.get(),
+      .ast = plan->getAst(),
+      .varInfo = &viewNode.getRegisterPlan()->varInfo,
+      .filter = &viewNode.filterCondition(),
+      .outVar = &viewNode.outVariable(),
+
+      .docReg = arangodb::aql::RegisterId::makeInvalid(),
+      .searchDocReg = arangodb::aql::RegisterId::makeInvalid(),
+      .scoreRegs = {},
+      .valuesRegs = {},
+
+      .scorers = emptyScorers,
+      .storedValues = &_view->storedValues(),
+
+      .heapSort = emptyScorersSort,
+      .heapSortLimit = 0,
 #ifdef USE_ENTERPRISE
-      _view->meta()._optimizeTopK,
+      .optimizeTopK = &_view->meta()._optimizeTopK,
 #endif
-      emptyScorers, {&sort, 1U}, _view->storedValues(), *plan,
-      viewNode.outVariable(), viewNode.filterCondition(), {false, false}, 0,
-      viewNode.getRegisterPlan()->varInfo, 0,
-      arangodb::iresearch::IResearchViewNode::ViewValuesRegisters{},
-      arangodb::iresearch::CountApproximate::Cost,
-      arangodb::iresearch::FilterOptimization::MAX, emptyScorersSort, 0,
-      nullptr, 1, _pool);
+      .sort = {&sort, 1U},
+
+      .depth = 0,
+      .immutableParts = 0,
+      .filterOptimization = arangodb::iresearch::FilterOptimization::MAX,
+      .countApproximate = arangodb::iresearch::CountApproximate::Cost,
+      .emptyFilter = arangodb::iresearch::isFilterConditionEmpty(
+                         &viewNode.filterCondition()) &&
+                     !reader->hasNestedFields(),
+      .volatileSort = false,
+      .volatileFilter = false,
+
+      .parallelism = 1,
+      .parallelExecutionPool = &_pool,
+  };
 
   std::vector<arangodb::aql::ExecutionBlock*> emptyExecutors;
   arangodb::aql::DependencyProxy<arangodb::aql::BlockPassthrough::Disable>


### PR DESCRIPTION
### Scope & Purpose


- [ ] Use segment tree instead of heap to change count of compare in worst case from `N * 2 * log_2(N)` to `N * log_2(N)`
- [x] Avoid sorting skipped range
- [x] Simplify initialization
- [ ] Avoid not busy but unavailable threadpool
- [x] Decrease threadpool default size
- [ ] Avoid copying rows

//

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

