### PR TITLE
Fix: db can already be gone when we process the reconfigureReplicatedLog action

### DIFF
--- a/arangod/Agency/Supervision.cpp
+++ b/arangod/Agency/Supervision.cpp
@@ -3593,15 +3593,6 @@ void Supervision::checkUndoLeaderChangeActions() {
         return Result{TRI_ERROR_BAD_PARAMETER, "server missing"};
       }
 
-      if (!isReplication2(*database)) {
-        auto result = Result{TRI_ERROR_BAD_PARAMETER,
-                             "reconfigureReplicatedLog "
-                             "job for non-replication2 "
-                             "database"};
-        TRI_ASSERT(false) << result;
-        return result;
-      }
-
       auto logId = replication2::LogId::fromString(id);
       if (!logId.has_value()) {
         auto result = Result{TRI_ERROR_BAD_PARAMETER,


### PR DESCRIPTION
### Scope & Purpose

The isReplication2 check can return false when the db is not longer found. However, the returned undo action already handles the case when the DB is already gone, and in contrast to replication1, replication2 does not operate on plan, but on target, so this check was superfluous.

This sometimes lead to assertion failures in rebalance tests.

- [x] :hankey: Bugfix

### Checklist

- [x] Tests
  - [x] **integration tests**
