### PR TITLE
Fix: cannot use rf=3 when we have only 2 servers

### DIFF
--- a/tests/js/client/restart/test-restart-replication2-view-recovery-cluster.js
+++ b/tests/js/client/restart/test-restart-replication2-view-recovery-cluster.js
@@ -312,7 +312,7 @@ function recoveryViewOnCollection() {
   "use strict";
   const namePostfix = "collection";
   const setupCollection = () => {
-    const collection = db._create("UnitTestCollection", {replicationFactor: 3, waitForSync: true});
+    const collection = db._create("UnitTestCollection", {replicationFactor: 2, waitForSync: true});
     const shards = collection.shards();
     const shardsToLogs = lh.getShardsToLogsMapping(dbn, collection._id);
     const logs = shards.map(shardId => db._replicatedLog(shardsToLogs[shardId]));


### PR DESCRIPTION
### Scope & Purpose

Adjust a test that uses an invalid replication factor. Previously this worked, because in replication2 we were missing an according check. This was fixed recently, which broke this test.