### PR TITLE
Fix more shell_client tests for replication2

### DIFF
--- a/arangod/Transaction/Methods.cpp
+++ b/arangod/Transaction/Methods.cpp
@@ -2253,6 +2253,18 @@ Result transaction::Methods::determineReplicationTypeAndFollowers(
     velocypack::Slice value, OperationOptions& options,
     ReplicationType& replicationType,
     std::shared_ptr<std::vector<ServerID> const>& followers) {
+  if (_state->isDBServer()) {
+    // This failure point is to test the case that a former leader has
+    // resigned in the meantime but still gets an insert request from
+    // a coordinator who does not know this yet. That is, the test sets
+    // the failure point on all servers, including the current leader.
+    TRI_IF_FAILURE("documents::insertLeaderRefusal") {
+      if (operationName == "insert" && value.isObject() &&
+          value.hasKey("ThisIsTheRetryOnLeaderRefusalTest")) {
+        return {TRI_ERROR_CLUSTER_SHARD_LEADER_RESIGNED};
+      }
+    }
+  }
   auto replicationVersion = collection.replicationVersion();
   if (replicationVersion == replication::Version::ONE) {
     return determineReplication1TypeAndFollowers(
@@ -2274,17 +2286,6 @@ Result transaction::Methods::determineReplication1TypeAndFollowers(
   TRI_ASSERT(followers == nullptr);
 
   if (_state->isDBServer()) {
-    // This failure point is to test the case that a former leader has
-    // resigned in the meantime but still gets an insert request from
-    // a coordinator who does not know this yet. That is, the test sets
-    // the failure point on all servers, including the current leader.
-    TRI_IF_FAILURE("documents::insertLeaderRefusal") {
-      if (operationName == "insert" && value.isObject() &&
-          value.hasKey("ThisIsTheRetryOnLeaderRefusalTest")) {
-        return {TRI_ERROR_CLUSTER_SHARD_LEADER_RESIGNED};
-      }
-    }
-
     // Block operation early if we are not supposed to perform it:
     auto const& followerInfo = collection.followers();
     std::string theLeader = followerInfo->getLeader();

--- a/tests/js/client/shell/shell-collection-properties-propagation-cluster.js
+++ b/tests/js/client/shell/shell-collection-properties-propagation-cluster.js
@@ -105,6 +105,11 @@ function CollectionPropertiesPropagationSuite() {
     },
     
     testCreateOtherWithDifferentWriteConcern : function () {
+      if (db._properties().replicationVersion === "2") {
+        // in replication 2 the writeConcern is associated with the log (i.e., with the collection group),
+        // so we cannot create a collection with a different writeConcern
+        return;
+      }
       let c = db._create(other, { distributeShardsLike: proto, writeConcern: 1 });
 
       let p = c.properties();

--- a/tests/js/client/shell/shell-collection-properties-propagation-cluster.js
+++ b/tests/js/client/shell/shell-collection-properties-propagation-cluster.js
@@ -182,12 +182,20 @@ function CollectionPropertiesPropagationSuite() {
         assertEqual(3, p[s].replicationFactor, {s, p});
       });
 
-      // dependent collection won't see the replicationFactor update
       p = c.properties();
       assertEqual(proto, p.distributeShardsLike);
-      assertEqual(3, p.replicationFactor);
-
-      // nor do its shards
+      let expectedRF;
+      if (db._properties().replicationVersion === "2") {
+        // with replication 2, the collection's replicationFactor is tied to the replicationFactor
+        // of the collection group, so it will report the correct value#
+        assertEqual(2, p.replicationFactor, p);
+      } else {
+        // with replication1, dependent collection won't see the replicationFactor update
+        assertEqual(3, p.replicationFactor, p);
+      }
+      
+      // the individual shards currently do not report the updated replicationFactor,
+      // neither for replication 1 nor 2
       p = propertiesOnDBServers(c);
       keys = Object.keys(p);
       assertTrue(keys.length > 0);

--- a/tests/js/client/shell/shell-dropped-followers-elcheapo-commit-cluster.js
+++ b/tests/js/client/shell/shell-dropped-followers-elcheapo-commit-cluster.js
@@ -349,7 +349,9 @@ function lockTimeoutSuite() {
 let ep = getEndpointsByType('dbserver');
 if (ep.length && debugCanUseFailAt(ep[0])) {
   // only execute if failure tests are available
-  jsunity.run(dropFollowersElCheapoSuite);
+  if (db._properties().replicationVersion !== "2") {
+    jsunity.run(dropFollowersElCheapoSuite);
+  }
   jsunity.run(lockTimeoutSuite);
 }
 return jsunity.done();


### PR DESCRIPTION
### Scope & Purpose

- move a failure point so it works for replication 1 and 2
- disable tests that are not relevant for replication2
- with replication2 a replication factor update is propagated to all collections in the collection group
