### PR TITLE
Fixed BTS-1703: Cannot chain multiple UPSERTS

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 devel
 -----
+
+* Fixed BTS-1703: Cannot chain multiple UPSERTS.
+
 * Fixed issue #17673: Adds timezone conversion as an optional parameter in
   all relevant date functions.
 

--- a/arangod/Aql/grammar.cpp
+++ b/arangod/Aql/grammar.cpp
@@ -3961,7 +3961,7 @@ yyreduce:
                       {
       // reserve a variable named "$OLD", we might need it in the update expression
       // and in a later return thing
-      AstNode* variableNode = parser->ast()->createNodeVariable(Variable::NAME_OLD, true);
+      AstNode* variableNode = parser->ast()->createNodeVariable(Variable::NAME_OLD, false);
       parser->pushStack(variableNode);
 
       auto scopes = parser->ast()->scopes();
@@ -4041,7 +4041,7 @@ yyreduce:
                           {
       // reserve a variable named "$OLD", we might need it in the update expression
       // and in a later return thing
-      AstNode* variableNode = parser->ast()->createNodeVariable(Variable::NAME_OLD, true);
+      AstNode* variableNode = parser->ast()->createNodeVariable(Variable::NAME_OLD, false);
 
       auto scopes = parser->ast()->scopes();
 

--- a/arangod/Aql/grammar.y
+++ b/arangod/Aql/grammar.y
@@ -1431,7 +1431,7 @@ upsert_statement:
     T_UPSERT T_FILTER {
       // reserve a variable named "$OLD", we might need it in the update expression
       // and in a later return thing
-      AstNode* variableNode = parser->ast()->createNodeVariable(Variable::NAME_OLD, true);
+      AstNode* variableNode = parser->ast()->createNodeVariable(Variable::NAME_OLD, false);
       parser->pushStack(variableNode);
 
       auto scopes = parser->ast()->scopes();
@@ -1494,7 +1494,7 @@ upsert_statement:
   | T_UPSERT upsert_input {
       // reserve a variable named "$OLD", we might need it in the update expression
       // and in a later return thing
-      AstNode* variableNode = parser->ast()->createNodeVariable(Variable::NAME_OLD, true);
+      AstNode* variableNode = parser->ast()->createNodeVariable(Variable::NAME_OLD, false);
 
       auto scopes = parser->ast()->scopes();
 

--- a/tests/js/client/aql/aql-modify-Modify-noncluster.js
+++ b/tests/js/client/aql/aql-modify-Modify-noncluster.js
@@ -777,7 +777,22 @@ function ahuacatlModifySuite () {
 
       assertEqual(999999, c1.document("test999999").value1);
       assertEqual(1, c1.document("test999999").value2);
-    }
+    },
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief multiple upserts on top level
+////////////////////////////////////////////////////////////////////////////////
+    
+    testMultipleUpsertsOnTopLevel : function () {
+      const actual = db._query("UPSERT { _key: 'foo' } INSERT {} UPDATE { updated: true } IN @@cn1 UPSERT { _key: 'foo' } INSERT {} UPDATE { updated: true } IN @@cn2", { "@cn1": cn1, "@cn2": cn2 });
+
+      const expected = { writesExecuted: 2, writesIgnored: 0 };
+      assertEqual(expected, sanitizeStats(actual.getExtra().stats));
+      assertEqual([], actual.toArray());
+
+      assertTrue(c1.document("foo").updated);
+      assertTrue(c2.document("foo").updated);
+    },
 
   };
 }


### PR DESCRIPTION
### Scope & Purpose

Fixed issue https://arangodb.atlassian.net/browse/BTS-1703.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [x] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [x] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/BTS-1703
- [ ] Design document: 