### PR TITLE
Stabilize detach threads test (#20209)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -191,6 +191,8 @@ devel
 * Fixed MDS-1170: Significant performance degradation when queries are
   executed within transactions that involve edits.
 
+* Stabilize detaching of threads test.
+
 * Rebuilt included rclone v1.62.2 with go1.21.4.
 
 * Updated ArangoDB Starter to v0.17.2 and arangosync to v2.19.5.

--- a/tests/js/client/server_parameters/detach-threads-noncluster.js
+++ b/tests/js/client/server_parameters/detach-threads-noncluster.js
@@ -1,5 +1,5 @@
 /* jshint globalstrict:false, strict:false, maxlen: 200 */
-/* global fail, assertEqual, assertTrue, assertFalse, arango */
+/* global fail, assertEqual, assertTrue, assertFalse, arango, getOptions */
 
 // //////////////////////////////////////////////////////////////////////////////
 // / @brief Test detaching threads in scheduler which wait for locks.
@@ -22,6 +22,25 @@
 // /
 // / @author Max Neunhoeffer
 // //////////////////////////////////////////////////////////////////////////////
+
+// We need the following options for this test. We need a specific number 
+// of threads in the scheduler. 60 threads means that there are 30 low
+// priority lane threads. We will post 200 background jobs which will
+// start an exclusive transaction and thus get stuck in a lock.
+// This totally blocks all scheduler threads. If the detaching
+// of scheduler threads waiting for this lock works, then we can Unblock
+// this situation pretty soon (30 threads per second). So after a few
+// seconds, a normal low priority operation will go through again.
+// If you use fewer than 51 threads, then the cluster overwhelm protections
+// will also block the situation since the coordinator will no longer
+// dequeue low priority lane jobs. If you use more than 200 threads, then
+// the test will not test the detaching of threads.
+if (getOptions === true) {
+  return {
+    'server.maximal-threads' : '60',
+    'server.minimal-threads' : '60'
+  };
+}
 
 const _ = require('lodash');
 const console = require('console');


### PR DESCRIPTION
### Scope & Purpose

Stabilize detach-threads test so it does not depend on the local environment (number of cores, specifically).
The previous version of the test (without this fix) failed when the test was executed on a host system with 16 cores or less.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 