### PR TITLE
Added USE_JEMALLOC_CHECKS cmake option

### DIFF
--- a/3rdParty/jemalloc/CMakeLists.txt
+++ b/3rdParty/jemalloc/CMakeLists.txt
@@ -27,16 +27,22 @@ if (LINUX OR DARWIN)
     set(JEMALLOC_CONFIG "background_thread:true,cache_oblivious:false")
   endif ()
 
+  if (USE_JEMALLOC_CHECKS)
+    set(JEMALLOC_CHECKS "--enable-opt-safety-checks" "--enable-opt-size-checks")
+  else ()
+    set(JEMALLOC_CHECKS "")
+  endif ()
+
   if (USE_JEMALLOC_PROF)
-      if (USE_LIBUNWIND)
-        # Note that CPPFLAGS are passed by jemalloc to both C and C++ compilers,
-        # and to the preprocessor, and to dependency file generation. This is the
-        # right place for includes.
-        SET(JEMALLOC_CPPFLAGS "-I${LIBUNWIND_HOME}/include")
-        SET(JEMALLOC_PROF "--enable-prof" "--enable-prof-libunwind" "--with-static-libunwind=${LIBUNWIND_LIB}")
-      else ()
-          SET(JEMALLOC_PROF "--enable-prof")
-      endif()
+    if (USE_LIBUNWIND)
+      # Note that CPPFLAGS are passed by jemalloc to both C and C++ compilers,
+      # and to the preprocessor, and to dependency file generation. This is the
+      # right place for includes.
+      set(JEMALLOC_CPPFLAGS "-I${LIBUNWIND_HOME}/include")
+      set(JEMALLOC_PROF "--enable-prof" "--enable-prof-libunwind" "--with-static-libunwind=${LIBUNWIND_LIB}")
+    else ()
+      set(JEMALLOC_PROF "--enable-prof")
+    endif()
   endif ()
 
   set(JEMALLOC_LIB "${CMAKE_CURRENT_BINARY_DIR}/lib/libjemalloc.a")
@@ -66,9 +72,8 @@ if (LINUX OR DARWIN)
         --prefix=${CMAKE_CURRENT_BINARY_DIR}
         --with-malloc-conf=${JEMALLOC_CONFIG}
         --with-version=${JEMALLOC_VERSION}-0-g0
-        --enable-opt-safety-checks
-        --enable-opt-size-checks
         ${JEMALLOC_PROF}
+        ${JEMALLOC_CHECKS}
     BUILD_COMMAND
       $(MAKE) build_lib_static
     INSTALL_COMMAND

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,10 @@
 devel
 -----
+
+* Added CMake option `USE_JEMALLOC_CHECKS` to toggle the usage of extra safety 
+  checks in jemalloc. The option is currently enabled by default, but can be
+  turned off when there are performance concerns.
+
 * Fixed issue #17673: Adds timezone conversion as an optional parameter in
   all relevant date functions.
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -813,6 +813,7 @@ endfunction()
 # ------------------------------------------------------------------------------
 
 option(USE_JEMALLOC_PROF "use jemalloc profiler" ON)
+option(USE_JEMALLOC_CHECKS "use jemalloc extended safety checks" ON)
 
 if (USE_JEMALLOC)
   add_definitions("-DARANGODB_HAVE_JEMALLOC=1")


### PR DESCRIPTION
### Scope & Purpose

* Added CMake option `USE_JEMALLOC_CHECKS` to toggle the usage of extra safety checks in jemalloc. The option is currently enabled by default, but can be turned off when there are performance concerns.

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 