### PR TITLE
Disable a test that is not relevant for replication2

### DIFF
--- a/tests/js/client/shell/shell-database-failures-creation-cluster.js
+++ b/tests/js/client/shell/shell-database-failures-creation-cluster.js
@@ -154,6 +154,9 @@ function databaseFailureSuite() {
     },
 
     testDatabaseSomeExisting: function () {
+      if (db._properties().replicationVersion === "2") {
+        return;
+      }
       internal.debugSetFailAt("UpgradeTasks::CreateCollectionsExistsGraphAqlFunctions");
 
       db._createDatabase(dn);


### PR DESCRIPTION
### Scope & Purpose

This test coves an update scenario that is only relevant for old versions that predate replication2.