### PR TITLE
Backport ZKD Stored Values 3.11

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 v3.11.7 (XXXX-XX-XX)
 --------------------
 
+* Added stored values support for ZKD indexes.
+
 * Fix cmake setup for jemalloc library for the case of memory profiling.
 
 * BTS-1714: Within writing AQL queries the lock timeout was accidentally set to

--- a/arangod/ClusterEngine/ClusterIndex.cpp
+++ b/arangod/ClusterEngine/ClusterIndex.cpp
@@ -80,6 +80,10 @@ ClusterIndex::ClusterIndex(IndexId id, LogicalCollection& collection,
           _fields,
           Index::parseFields(info.get(StaticStrings::IndexStoredValues),
                              /*allowEmpty*/ true, /*allowExpansion*/ false));
+    } else if (_indexType == TRI_IDX_TYPE_ZKD_INDEX) {
+      _coveredFields =
+          Index::parseFields(info.get(StaticStrings::IndexStoredValues),
+                             /*allowEmpty*/ true, /*allowExpansion*/ false);
     }
 
     // check for "estimates" attribute

--- a/arangod/Indexes/IndexFactory.cpp
+++ b/arangod/Indexes/IndexFactory.cpp
@@ -491,7 +491,8 @@ Result IndexFactory::processIndexStoredValues(VPackSlice definition,
                                               VPackBuilder& builder,
                                               size_t minFields,
                                               size_t maxFields, bool create,
-                                              bool allowSubAttributes) {
+                                              bool allowSubAttributes,
+                                              bool allowOverlappingFields) {
   TRI_ASSERT(builder.isOpenObject());
 
   Result res;
@@ -512,7 +513,8 @@ Result IndexFactory::processIndexStoredValues(VPackSlice definition,
         auto normalFields = definition.get(StaticStrings::IndexFields);
         TRI_ASSERT(normalFields.isArray());
         for (VPackSlice it : VPackArrayIterator(normalFields)) {
-          if (!fields.insert(it.stringView()).second) {
+          if (!allowOverlappingFields &&
+              !fields.insert(it.stringView()).second) {
             res.reset(TRI_ERROR_BAD_PARAMETER,
                       "duplicate attribute name (overlap between index fields "
                       "and index "
@@ -635,7 +637,8 @@ Result IndexFactory::enhanceJsonIndexGeneric(VPackSlice definition,
   if (res.ok()) {
     // "storedValues"
     res = processIndexStoredValues(definition, builder, 1, 32, create,
-                                   /*allowSubAttributes*/ true);
+                                   /*allowSubAttributes*/ true,
+                                   /* allowOverlappingFields */ false);
   }
 
   if (res.ok()) {
@@ -761,6 +764,16 @@ Result IndexFactory::enhanceJsonIndexZkd(VPackSlice definition,
   Result res =
       processIndexFields(definition, builder, 1, INT_MAX, create,
                          /*allowExpansion*/ false, /*allowSubAttributes*/ true);
+
+  if (res.ok()) {
+    // "storedValues"
+    // Since the indexed attributes are encoded and then bit interleaves
+    // they can not be used for projections. Thus, we allow the same fields
+    // to appear in the stored values for them to be projected out of the index.
+    res = processIndexStoredValues(definition, builder, 1, 32, create,
+                                   /*allowSubAttributes*/ true,
+                                   /* allowOverlappingFields */ true);
+  }
 
   if (res.ok()) {
     if (auto isSparse = definition.get(StaticStrings::IndexSparse).isTrue();

--- a/arangod/Indexes/IndexFactory.h
+++ b/arangod/Indexes/IndexFactory.h
@@ -144,7 +144,8 @@ class IndexFactory {
   static Result processIndexStoredValues(velocypack::Slice definition,
                                          velocypack::Builder& builder,
                                          size_t minFields, size_t maxFields,
-                                         bool create, bool allowSubAttributes);
+                                         bool create, bool allowSubAttributes,
+                                         bool allowOverlappingFields);
 
   /// @brief process the "cacheEnabled" flag and add it to the json
   static void processIndexCacheEnabled(velocypack::Slice definition,

--- a/arangod/RocksDBEngine/RocksDBValue.cpp
+++ b/arangod/RocksDBEngine/RocksDBValue.cpp
@@ -65,13 +65,13 @@ RocksDBValue RocksDBValue::VPackIndexValue(VPackSlice data) {
   return RocksDBValue(RocksDBEntryType::VPackIndexValue, data);
 }
 
-RocksDBValue RocksDBValue::ZkdIndexValue() {
-  return RocksDBValue(RocksDBEntryType::ZkdIndexValue);
+RocksDBValue RocksDBValue::ZkdIndexValue(VPackSlice data) {
+  return RocksDBValue(RocksDBEntryType::ZkdIndexValue, data);
 }
 
-RocksDBValue RocksDBValue::UniqueZkdIndexValue(LocalDocumentId const& docId) {
-  return RocksDBValue(RocksDBEntryType::UniqueZkdIndexValue, docId,
-                      RevisionId::none());
+RocksDBValue RocksDBValue::UniqueZkdIndexValue(LocalDocumentId docId,
+                                               VPackSlice data) {
+  return RocksDBValue(RocksDBEntryType::UniqueZkdIndexValue, docId, data);
 }
 
 RocksDBValue RocksDBValue::UniqueVPackIndexValue(LocalDocumentId const& docId) {
@@ -225,7 +225,8 @@ RocksDBValue::RocksDBValue(RocksDBEntryType type, LocalDocumentId const& docId,
                            VPackSlice data)
     : _type(type), _buffer() {
   switch (_type) {
-    case RocksDBEntryType::UniqueVPackIndexValue: {
+    case RocksDBEntryType::UniqueVPackIndexValue:
+    case RocksDBEntryType::UniqueZkdIndexValue: {
       size_t byteSize = static_cast<size_t>(data.byteSize());
       _buffer.reserve(sizeof(uint64_t) + byteSize);
       uint64ToPersistent(_buffer, docId.id());  // LocalDocumentId
@@ -242,6 +243,7 @@ RocksDBValue::RocksDBValue(RocksDBEntryType type, VPackSlice data)
     : _type(type), _buffer() {
   switch (_type) {
     case RocksDBEntryType::VPackIndexValue:
+    case RocksDBEntryType::ZkdIndexValue:
       TRI_ASSERT(data.isArray());
       [[fallthrough]];
 

--- a/arangod/RocksDBEngine/RocksDBValue.h
+++ b/arangod/RocksDBEngine/RocksDBValue.h
@@ -55,8 +55,10 @@ class RocksDBValue {
   static RocksDBValue EdgeIndexValue(std::string_view vertexId);
   static RocksDBValue VPackIndexValue();
   static RocksDBValue VPackIndexValue(VPackSlice data);
-  static RocksDBValue ZkdIndexValue();
-  static RocksDBValue UniqueZkdIndexValue(LocalDocumentId const& docId);
+
+  static RocksDBValue ZkdIndexValue(VPackSlice data);
+  static RocksDBValue UniqueZkdIndexValue(LocalDocumentId docId,
+                                          VPackSlice data);
   static RocksDBValue UniqueVPackIndexValue(LocalDocumentId const& docId);
   static RocksDBValue UniqueVPackIndexValue(LocalDocumentId const& docId,
                                             VPackSlice data);

--- a/arangod/RocksDBEngine/RocksDBZkdIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBZkdIndex.cpp
@@ -101,8 +101,8 @@ class RocksDBZkdIndexIterator final : public IndexIterator {
     return _lookahead;
   }
 
-  bool nextImpl(LocalDocumentIdCallback const& callback,
-                uint64_t limit) override {
+  template<typename F>
+  bool findNext(F&& callback, uint64_t limit) {
     for (uint64_t i = 0; i < limit;) {
       switch (_iterState) {
         case IterState::SEEK_ITER_TO_CUR: {
@@ -153,14 +153,7 @@ class RocksDBZkdIndexIterator final : public IndexIterator {
               _iterState = IterState::SEEK_ITER_TO_CUR;
             }
           } else {
-            auto const documentId = std::invoke([&] {
-              if constexpr (isUnique) {
-                return RocksDBValue::documentId(_iter->value());
-              } else {
-                return RocksDBKey::indexDocumentId(rocksKey);
-              }
-            });
-            std::ignore = callback(documentId);
+            callback(rocksKey, _iter->value());
             ++i;
             _iter->Next();
             if (!_iter->Valid()) {
@@ -179,6 +172,55 @@ class RocksDBZkdIndexIterator final : public IndexIterator {
     }
 
     return true;
+  }
+
+  bool nextImpl(LocalDocumentIdCallback const& callback,
+                uint64_t limit) override {
+    return findNext(
+        [&](rocksdb::Slice key, rocksdb::Slice value) {
+          auto const documentId = std::invoke([&] {
+            if constexpr (isUnique) {
+              return RocksDBValue::documentId(value);
+            } else {
+              return RocksDBKey::indexDocumentId(key);
+            }
+          });
+          std::ignore = callback(documentId);
+        },
+        limit);
+  }
+
+  bool nextCoveringImpl(CoveringCallback const& callback,
+                        uint64_t limit) override {
+    struct CoveringData : IndexIteratorCoveringData {
+      explicit CoveringData(const velocypack::Slice& data) : _data(data) {}
+      VPackSlice at(size_t i) const override { return _data.at(i); }
+      bool isArray() const noexcept override { return true; }
+      velocypack::ValueLength length() const override { return _data.length(); }
+
+      velocypack::Slice _data;
+    };
+    return findNext(
+        [&](rocksdb::Slice key, rocksdb::Slice value) {
+          auto const documentId = std::invoke([&] {
+            if constexpr (isUnique) {
+              return RocksDBValue::documentId(value);
+            } else {
+              return RocksDBKey::indexDocumentId(key);
+            }
+          });
+
+          auto storedValues = std::invoke([&] {
+            if constexpr (isUnique) {
+              return RocksDBValue::uniqueIndexStoredValues(value);
+            } else {
+              return RocksDBValue::indexStoredValues(value);
+            }
+          });
+          CoveringData coveringData{storedValues};
+          std::ignore = callback(documentId, coveringData);
+        },
+        limit);
   }
 
  private:
@@ -474,6 +516,40 @@ auto zkd::specializeCondition(Index const* index, aql::AstNode* condition,
   return condition;
 }
 
+namespace {
+auto extractStoredValues(
+    transaction::Methods& trx,
+    std::vector<std::vector<basics::AttributeName>> const& storedValues,
+    velocypack::Slice doc) {
+  transaction::BuilderLeaser leased(&trx);
+  leased->openArray(true);
+  for (auto const& it : storedValues) {
+    VPackSlice s;
+    if (it.size() == 1 && it[0].name == StaticStrings::IdString) {
+      // instead of storing the value of _id, we instead store the
+      // value of _key. we will retranslate the value to an _id later
+      // again upon retrieval
+      s = transaction::helpers::extractKeyFromDocument(doc);
+    } else {
+      s = doc;
+      for (auto const& part : it) {
+        s = s.get(part.name);
+        if (s.isNone()) {
+          break;
+        }
+      }
+    }
+    if (s.isNone()) {
+      s = VPackSlice::nullSlice();
+    }
+    leased->add(s);
+  }
+  leased->close();
+
+  return leased;
+}
+}  // namespace
+
 Result RocksDBZkdIndexBase::insert(transaction::Methods& trx,
                                    RocksDBMethods* methods,
                                    LocalDocumentId const& documentId,
@@ -490,7 +566,8 @@ Result RocksDBZkdIndexBase::insert(transaction::Methods& trx,
   RocksDBKey rocks_key;
   rocks_key.constructZkdIndexValue(objectId(), key_value, documentId);
 
-  auto value = RocksDBValue::ZkdIndexValue();
+  auto storedValues = extractStoredValues(trx, _storedValues, doc);
+  auto value = RocksDBValue::ZkdIndexValue(storedValues->slice());
   auto s = methods->PutUntracked(_cf, rocks_key, value.string());
   if (!s.ok()) {
     return rocksutils::convertStatus(s);
@@ -531,13 +608,29 @@ RocksDBZkdIndexBase::RocksDBZkdIndexBase(IndexId iid, LogicalCollection& coll,
                    coll.vocbase()
                        .server()
                        .getFeature<EngineSelectorFeature>()
-                       .engine<RocksDBEngine>()) {}
+                       .engine<RocksDBEngine>()),
+      _storedValues(
+          Index::parseFields(info.get(StaticStrings::IndexStoredValues),
+                             /*allowEmpty*/ true, /*allowExpansion*/ false)) {}
 
 void RocksDBZkdIndexBase::toVelocyPack(
     velocypack::Builder& builder,
     std::underlying_type<Index::Serialize>::type type) const {
   VPackObjectBuilder ob(&builder);
   RocksDBIndex::toVelocyPack(builder, type);
+
+  if (!_storedValues.empty()) {
+    builder.add(velocypack::Value(StaticStrings::IndexStoredValues));
+    builder.openArray();
+
+    for (auto const& field : _storedValues) {
+      std::string fieldString;
+      TRI_AttributeNamesToString(field, fieldString);
+      builder.add(VPackValue(fieldString));
+    }
+
+    builder.close();
+  }
 }
 
 Index::FilterCosts RocksDBZkdIndexBase::supportsFilterCondition(
@@ -603,7 +696,9 @@ Result RocksDBUniqueZkdIndex::insert(transaction::Methods& trx,
     }
   }
 
-  auto value = RocksDBValue::UniqueZkdIndexValue(documentId);
+  auto storedValues = extractStoredValues(trx, _storedValues, doc);
+  auto value =
+      RocksDBValue::UniqueZkdIndexValue(documentId, storedValues->slice());
 
   if (auto s = methods->PutUntracked(_cf, rocks_key, value.string()); !s.ok()) {
     return rocksutils::convertStatus(s);

--- a/arangod/RocksDBEngine/RocksDBZkdIndex.h
+++ b/arangod/RocksDBEngine/RocksDBZkdIndex.h
@@ -44,7 +44,7 @@ class RocksDBZkdIndexBase : public RocksDBIndex {
   std::vector<std::vector<basics::AttributeName>> const& coveredFields()
       const override {
     // index does not cover the index attributes!
-    return Index::emptyCoveredFields;
+    return _storedValues;
   }
 
   Result insert(transaction::Methods& trx, RocksDBMethods* methods,
@@ -69,6 +69,8 @@ class RocksDBZkdIndexBase : public RocksDBIndex {
       const aql::AstNode* node, const aql::Variable* reference,
       const IndexIteratorOptions& opts, ReadOwnWrites readOwnWrites,
       int) override;
+
+  std::vector<std::vector<basics::AttributeName>> const _storedValues;
 };
 
 class RocksDBZkdIndex final : public RocksDBZkdIndexBase {

--- a/js/apps/system/_admin/aardvark/APP/react/src/views/collections/indices/addIndex/useCreateZKDIndex.ts
+++ b/js/apps/system/_admin/aardvark/APP/react/src/views/collections/indices/addIndex/useCreateZKDIndex.ts
@@ -5,6 +5,7 @@ import { useCreateIndex } from "./useCreateIndex";
 export const INITIAL_VALUES = {
   type: "zkd",
   fields: commonFieldsMap.fields.initialValue,
+  storedValues: "",
   inBackground: commonFieldsMap.inBackground.initialValue,
   name: commonFieldsMap.name.initialValue,
   fieldValueTypes: "double"
@@ -13,6 +14,13 @@ export const INITIAL_VALUES = {
 export const FIELDS = [
   commonFieldsMap.fields,
   commonFieldsMap.name,
+  {
+    label: "Extra stored values",
+    name: "storedValues",
+    type: "string",
+    tooltip:
+      "A comma-separated list of extra attribute paths. The values of these attributes will be stored in the index as well. They can be used for projections, but cannot be used for filtering or sorting."
+  },
   {
     label: "Field Value Types",
     name: "fieldValueTypes",
@@ -28,8 +36,9 @@ export const SCHEMA = Yup.object({
   ...commonSchema
 });
 
-type ValuesType = Omit<typeof INITIAL_VALUES, "fields"> & {
+type ValuesType = Omit<typeof INITIAL_VALUES, "fields" | "storedValues"> & {
   fields: string[];
+  storedValues?: string[];
 };
 
 export const useCreateZKDIndex = () => {
@@ -37,6 +46,7 @@ export const useCreateZKDIndex = () => {
   const onCreate = async ({ values }: { values: typeof INITIAL_VALUES }) => {
     return onCreateIndex({
       ...values,
+      storedValues: values.storedValues ? values.storedValues.split(",") : undefined,
       fields: values.fields.split(",")
     });
   };

--- a/tests/js/server/aql/aql-optimizer-zkdindex-stored-values.js
+++ b/tests/js/server/aql/aql-optimizer-zkdindex-stored-values.js
@@ -1,0 +1,106 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2021-2021 ArangoDB GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+'use strict';
+
+const jsunity = require("jsunity");
+const arangodb = require("@arangodb");
+const db = arangodb.db;
+const aql = arangodb.aql;
+const {assertTrue, assertFalse, assertEqual} = jsunity.jsUnity.assertions;
+const _ = require("lodash");
+const normalize = require("@arangodb/aql-helper").normalizeProjections;
+
+function zkdIndexStoredValues() {
+  const colName = 'UnitTestZkdIndexCollection';
+  let col;
+
+  return {
+    setUpAll: function () {
+      col = db._create(colName);
+      col.ensureIndex({
+        type: 'zkd',
+        name: 'zkdIndex',
+        fields: ['x', 'y'],
+        fieldValueTypes: 'double',
+        storedValues: ['x', 'y', 'z', 'w.w']
+      });
+      db._query(aql`
+        FOR i IN 0..1000
+          LET x = i / 100
+          LET y = i / 100
+          INSERT {x, y, z: [x, y], w: {w: i}} INTO ${col}
+      `);
+    },
+
+    tearDownAll: function () {
+      col.drop();
+    },
+
+    testSimpleProjections: function () {
+      const query = aql`
+        FOR d IN ${col}
+          FILTER d.x >= 5 && d.y <= 7
+          RETURN [d.w.w, d.z]
+      `;
+
+      const res = db._createStatement({query: query.query, bindVars: query.bindVars}).explain();
+      const indexNodes = res.plan.nodes.filter(n => n.type === "IndexNode");
+      assertEqual(indexNodes.length, 1);
+      const index = indexNodes[0];
+      assertTrue(index.indexCoversProjections, true);
+      assertEqual(index.projections, [ [ "w", "w" ], "z" ]);
+
+      const result = db._createStatement({query: query.query, bindVars: query.bindVars}).execute().toArray();
+      assertEqual(result.length, 201); // 5.0 - 7.0
+      for (const [w, [a, b], id] of result) {
+        assertEqual(a, b, id);
+        assertTrue(0 <= w && w <= 1000, id);
+      }
+    },
+
+    testWithPostFilter: function () {
+      const query = aql`
+        FOR d IN ${col}
+          FILTER d.x > 5 && d.y < 7
+          RETURN [d.w.w, d.z]
+      `;
+
+      const res = db._createStatement({query: query.query, bindVars: query.bindVars}).explain();
+      const indexNodes = res.plan.nodes.filter(n => n.type === "IndexNode");
+      assertEqual(indexNodes.length, 1);
+      const index = indexNodes[0];
+      assertTrue(index.indexCoversProjections, true);
+      assertEqual(index.projections, [ [ "w", "w" ], "x", "y", "z" ]);
+
+      const result = db._createStatement({query: query.query, bindVars: query.bindVars}).execute().toArray();
+      assertEqual(result.length, 199); // 5.1 - 6.9
+      for (const [w, [a, b], id] of result) {
+        assertEqual(a, b, id);
+        assertTrue(0 <= w && w <= 1000, id);
+      }
+    },
+
+  };
+}
+
+jsunity.run(zkdIndexStoredValues);
+
+return jsunity.done();


### PR DESCRIPTION
### Scope & Purpose

Backport of stored values for zkd index.
Actually this is a forward port of https://github.com/arangodb/arangodb/pull/20356

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.11: this PR
  - [x] Backport for 3.10: https://github.com/arangodb/arangodb/pull/20356

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 