### PR TITLE
Fix counting for RealLeaders on Replication2

### DIFF
--- a/arangod/Cluster/ClusterInfo.cpp
+++ b/arangod/Cluster/ClusterInfo.cpp
@@ -168,8 +168,8 @@ void addToShardStatistics(ShardStatistics& stats,
           if (!hasDistributeShardsLike) {
             auto groupId = collection.get(StaticStrings::GroupId);
             if (groupId.isNumber()) {
-              auto gid =
-                  groupId.getNumber<replication2::agency::CollectionGroupId>();
+              auto gid = replication2::agency::CollectionGroupId{
+                  groupId.getNumber<uint64_t>()};
               auto maybeLeader = designatedGroupLeader.find(gid);
               if (maybeLeader == designatedGroupLeader.end()) {
                 // Just declare this collection to "lead" the group
@@ -238,8 +238,8 @@ void addToShardStatistics(
           if (!hasDistributeShardsLike) {
             auto groupId = collection.get(StaticStrings::GroupId);
             if (groupId.isNumber()) {
-              auto gid =
-                  groupId.getNumber<replication2::agency::CollectionGroupId>();
+              auto gid = replication2::agency::CollectionGroupId{
+                  groupId.getNumber<uint64_t>()};
               auto maybeLeader = designatedGroupLeader.find(gid);
               if (maybeLeader == designatedGroupLeader.end()) {
                 // Just declare this collection to "lead" the group


### PR DESCRIPTION
### Scope & Purpose

*In Replication2 we do not have the internal concept of distributeShardsLike anymore. Hence we need to adapt the reporting of "realLeaders" which was based on this value internally. For compatibility reasons distributeShardsLike is still exposed and used via API and internally translated.*

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

