### PR TITLE
only waitpid for the processes we actually sent a kill signal

### DIFF
--- a/scripts/test/async_client.py
+++ b/scripts/test/async_client.py
@@ -8,10 +8,9 @@ import platform
 import signal
 import sys
 from datetime import datetime, timedelta
-from subprocess import PIPE
-import psutil
-from allure_commons._allure import attach
 from abc import ABC, abstractmethod
+from allure_commons._allure import attach
+import psutil
 from tools.asciiprint import print_progress as progress
 
 # import tools.loghelper as lh
@@ -226,7 +225,8 @@ def kill_children(identifier, params, children):
         f"{identifier}: Waiting for the children to terminate {killed} {len(children)}",
         params,
     )
-    psutil.wait_procs(children, timeout=20)
+    if len(killed) > 0:
+        psutil.wait_procs(killed, timeout=20)
     return err
 
 
@@ -377,4 +377,4 @@ class ArangoCLIprogressiveTimeoutExecutor(ABC):
         identifier="",
     ):
         raise NotImplementedError("Subclasses should implement this!")
-    
+ 

--- a/scripts/test/async_client.py
+++ b/scripts/test/async_client.py
@@ -200,7 +200,7 @@ def kill_children(identifier, params, children):
             continue
         try:
             pname = one_child.name()
-            if pname not in ["svchost.exe", "conhost.exe", "mscorsvw.exe"]:
+            if pname not in ["svchost.exe", "conhost.exe", "mscorsvw.exe", "AM_Delta.exe"]:
                 killed.append(one_child.pid)
                 err += add_message_to_report(
                     params,
@@ -377,4 +377,3 @@ class ArangoCLIprogressiveTimeoutExecutor(ABC):
         identifier="",
     ):
         raise NotImplementedError("Subclasses should implement this!")
- 


### PR DESCRIPTION
### Scope & Purpose

subsequent runs would show throws by the `wait_procs` invocation which would wait for not killed processes (svchost...) and throw.

- [x] :hankey: Bugfix
