### PR TITLE
Fix copy + use after free in path search code

### DIFF
--- a/arangod/Graph/Enumerators/WeightedTwoSidedEnumerator.cpp
+++ b/arangod/Graph/Enumerators/WeightedTwoSidedEnumerator.cpp
@@ -195,25 +195,19 @@ template<class QueueType, class PathStoreType, class ProviderType,
 auto WeightedTwoSidedEnumerator<
     QueueType, PathStoreType, ProviderType,
     PathValidator>::Ball::fetchResults(CandidatesStore& candidates) -> void {
-  std::vector<Step*> looseEnds{};
-
-  if (_direction == Direction::FORWARD) {
-    for (auto& [weight, leftMeetingPoint, rightMeetingPoint] :
-         candidates.getQueue()) {
-      auto& step = leftMeetingPoint;
-      if (!step.isProcessable()) {
-        looseEnds.emplace_back(&step);
+  auto looseEnds = [&]() {
+    switch (_direction) {
+      case Direction::FORWARD: {
+        return candidates.getLeftLooseEnds();
+      }
+      case Direction::BACKWARD: {
+        return candidates.getRightLooseEnds();
+      }
+      default: {
+        TRI_ASSERT(false);
       }
     }
-  } else {
-    for (auto& [weight, leftMeetingPoint, rightMeetingPoint] :
-         candidates.getQueue()) {
-      auto& step = rightMeetingPoint;
-      if (!step.isProcessable()) {
-        looseEnds.emplace_back(&step);
-      }
-    }
-  }
+  }();
 
   if (!looseEnds.empty()) {
     // Will throw all network errors here

--- a/arangod/Graph/Enumerators/WeightedTwoSidedEnumerator.h
+++ b/arangod/Graph/Enumerators/WeightedTwoSidedEnumerator.h
@@ -101,9 +101,29 @@ class WeightedTwoSidedEnumerator {
 
     [[nodiscard]] bool isEmpty() const { return _queue.empty(); }
 
-    [[nodiscard]] std::vector<CalculatedCandidate> getQueue() const& {
-      return _queue;
-    };
+    [[nodiscard]] std::vector<Step*> getLeftLooseEnds() {
+      std::vector<Step*> steps;
+
+      for (auto& [_, step, __] : _queue) {
+        if (!step.isProcessable()) {
+          steps.emplace_back(&step);
+        }
+      }
+
+      return steps;
+    }
+
+    [[nodiscard]] std::vector<Step*> getRightLooseEnds() {
+      std::vector<Step*> steps;
+
+      for (auto& [_, __, step] : _queue) {
+        if (!step.isProcessable()) {
+          steps.emplace_back(&step);
+        }
+      }
+
+      return steps;
+    }
 
     [[nodiscard]] CalculatedCandidate& peek() {
       TRI_ASSERT(!_queue.empty());


### PR DESCRIPTION
### Scope & Purpose

The old code took a copy of the queue of candidates and then stored pointers into that copy for fetching results. This blew up in recent tests after simplification.

This fix isn't exactly pretty, but is modeled after the `getLooseEnds` in other Queue constructs in path search and addresses the immediate problem.

I am working on further patches that simplify this code but they will take longer to materialise.
