### PR TITLE
Fix more shell_client replication2 test

### DIFF
--- a/arangod/Cluster/ClusterCollectionMethods.cpp
+++ b/arangod/Cluster/ClusterCollectionMethods.cpp
@@ -115,15 +115,14 @@ auto reactToPreconditionsCreate(AsyncAgencyCommResult&& agencyRes)
   return slice.at(slice.length() - 1).getNumericValue<uint64_t>();
 }
 
-auto waitForOperationRoundtrip(ClusterInfo& ci) {
-  return [&ci](ResultT<uint64_t>&& agencyRaftIndex) -> Result {
-    // Got the Plan version while building.
-    // Let us wait for it
-    if (agencyRaftIndex.fail()) {
-      return agencyRaftIndex.result();
-    }
-    return ci.waitForPlan(agencyRaftIndex.get()).get();
-  };
+auto waitForOperationRoundtrip(ClusterInfo& ci,
+                               ResultT<uint64_t>&& agencyRaftIndex) {
+  // Got the Plan version while building.
+  // Let us wait for it
+  if (agencyRaftIndex.fail()) {
+    return agencyRaftIndex.result();
+  }
+  return ci.waitForPlan(agencyRaftIndex.get()).get();
 }
 
 auto waitForCurrentToCatchUp(
@@ -131,65 +130,58 @@ auto waitForCurrentToCatchUp(
     std::vector<std::pair<std::shared_ptr<AgencyCallback>, std::string>>&
         callbackList,
     double pollInterval) {
-  return [&server, &callbackInfos, &callbackList, pollInterval](Result&& res) {
-    // We waited on the buildingPlan to be loaded in the local cache
-    // Now let us watch for CURRENT to check if all requried changes
-    // ahve been applied
-    if (res.fail()) {
-      // TODO: TRIGGER_CLEANUP
-      return res;
+  // We waited on the buildingPlan to be loaded in the local cache
+  // Now let us watch for CURRENT to check if all required changes
+  // have been applied
+  TRI_IF_FAILURE("ClusterInfo::createCollectionsCoordinator") {
+    THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
+  }
+  // NOTE: LOGID was 98bca before, duplicate from below
+  LOG_TOPIC("98bc9", DEBUG, Logger::CLUSTER)
+      << "createCollectionCoordinator, Plan changed, waiting for "
+         "success...";
+
+  // Now "busy-loop"
+  while (!server.isStopping()) {
+    auto maybeFinalResult = callbackInfos->getResultIfAllReported();
+    if (maybeFinalResult.has_value()) {
+      // We have a final result. we are complete
+      return maybeFinalResult.value();
     }
 
-    TRI_IF_FAILURE("ClusterInfo::createCollectionsCoordinator") {
-      THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
-    }
-    // NOTE: LOGID was 98bca before, duplicate from below
-    LOG_TOPIC("98bc9", DEBUG, Logger::CLUSTER)
-        << "createCollectionCoordinator, Plan changed, waiting for "
-           "success...";
-
-    // Now "busy-loop"
-    while (!server.isStopping()) {
-      auto maybeFinalResult = callbackInfos->getResultIfAllReported();
-      if (maybeFinalResult.has_value()) {
-        // We have a final result. we are complete
-        return maybeFinalResult.value();
-      }
-
-      // We do not have a final result. Let's wait for more input
-      // Wait for the next incomplete callback
-      for (auto& [cb, cid] : callbackList) {
-        if (!callbackInfos->hasReported(cid)) {
-          // We do not have result for this collection, wait for it.
-          bool gotTimeout;
-          {
-            // This one has not responded, wait for it.
-            std::unique_lock guard(cb->_cv.mutex);
-            gotTimeout = cb->executeByCallbackOrTimeout(pollInterval);
-          }
-          if (gotTimeout) {
-            // We got woken up by waittime, not by  callback.
-            // Let us check if we skipped other callbacks as well
-            for (auto& [cb2, cid2] : callbackList) {
-              if (callbackInfos->hasReported(cid2)) {
-                // Only re check those where we have not yet found a
-                // result.
-                cb2->refetchAndUpdate(true, false);
-              }
+    // We do not have a final result. Let's wait for more input
+    // Wait for the next incomplete callback
+    for (auto& [cb, cid] : callbackList) {
+      if (!callbackInfos->hasReported(cid)) {
+        // We do not have result for this collection, wait for it.
+        bool gotTimeout;
+        {
+          // This one has not responded, wait for it.
+          std::unique_lock guard(cb->_cv.mutex);
+          gotTimeout = cb->executeByCallbackOrTimeout(pollInterval);
+        }
+        if (gotTimeout) {
+          // We got woken up by waittime, not by  callback.
+          // Let us check if we skipped other callbacks as well
+          for (auto& [cb2, cid2] : callbackList) {
+            if (callbackInfos->hasReported(cid2)) {
+              // Only re check those where we have not yet found a
+              // result.
+              cb2->refetchAndUpdate(true, false);
             }
           }
-          // Break the callback loop,
-          // continue on the check if we completed loop
-          break;
         }
+        // Break the callback loop,
+        // continue on the check if we completed loop
+        break;
       }
     }
+  }
 
-    // If we get here we are not allowed to retry.
-    // The loop above does not contain a break
-    TRI_ASSERT(server.isStopping());
-    return Result{TRI_ERROR_SHUTTING_DOWN};
-  };
+  // If we get here we are not allowed to retry.
+  // The loop above does not contain a break
+  TRI_ASSERT(server.isStopping());
+  return Result{TRI_ERROR_SHUTTING_DOWN};
 }
 
 Result impl(ClusterInfo& ci, ArangodServer& server,
@@ -486,16 +478,19 @@ Result impl(ClusterInfo& ci, ArangodServer& server,
   // TODO do we need to handle Error message (thenError?)
 
   double pollInterval = ci.getPollInterval();
-  auto future =
-      aac.sendWriteTransaction(120s, std::move(buildingTransaction.get()))
+  auto res =
+      aac.withSkipScheduler(true)
+          .sendWriteTransaction(120s, std::move(buildingTransaction.get()))
           .thenValue(::reactToPreconditionsCreate)
-          .thenValue(waitForOperationRoundtrip(ci))
-          .thenValue(waitForCurrentToCatchUp(server, callbackInfos,
-                                             callbackList, pollInterval));
-  // Wait synchronously here.
-  // We cannot easily return the future as the callbacks capture local
-  // variables.
-  return future.get();
+          .get();
+
+  if (auto r = waitForOperationRoundtrip(ci, std::move(res)); r.fail()) {
+    // TODO: TRIGGER_CLEANUP
+    return r;
+  }
+
+  return waitForCurrentToCatchUp(server, callbackInfos, callbackList,
+                                 pollInterval);
 }
 
 template<replication::Version ReplicationVersion>
@@ -977,9 +972,10 @@ ClusterCollectionMethods::createCollectionsOnCoordinator(
                                  {databaseExists, oldValue});
 
     using namespace std::chrono_literals;
-    auto future = aac.sendTransaction(120s, trans)
-                      .thenValue(::reactToPreconditions)
-                      .thenValue(waitForOperationRoundtrip(ci));
-    return future.get();
+    auto res = aac.withSkipScheduler(true)
+                   .sendTransaction(120s, trans)
+                   .thenValue(::reactToPreconditions)
+                   .get();
+    return waitForOperationRoundtrip(ci, std::move(res));
   }
 }

--- a/arangod/VocBase/Properties/CollectionConstantProperties.cpp
+++ b/arangod/VocBase/Properties/CollectionConstantProperties.cpp
@@ -47,9 +47,6 @@ bool CollectionConstantProperties::operator==(
   if (isDisjoint != other.isDisjoint) {
     return false;
   }
-  if (cacheEnabled != other.cacheEnabled) {
-    return false;
-  }
   if (smartGraphAttribute != other.smartGraphAttribute) {
     return false;
   }

--- a/arangod/VocBase/Properties/CollectionConstantProperties.h
+++ b/arangod/VocBase/Properties/CollectionConstantProperties.h
@@ -50,7 +50,6 @@ struct CollectionConstantProperties {
   // NOTE: These attributes are not documented
   bool isSmart = false;
   bool isDisjoint = false;
-  bool cacheEnabled = false;
 
   inspection::NonNullOptional<std::string> smartGraphAttribute = std::nullopt;
   inspection::NonNullOptional<std::vector<DataSourceId>> shadowCollections =
@@ -82,8 +81,6 @@ auto inspect(Inspector& f, CollectionConstantProperties& props) {
           .fallback(f.keep()),
       f.field(StaticStrings::IsSmart, props.isSmart).fallback(f.keep()),
       f.field(StaticStrings::IsDisjoint, props.isDisjoint).fallback(f.keep()),
-      f.field(StaticStrings::CacheEnabled, props.cacheEnabled)
-          .fallback(f.keep()),
       f.field(StaticStrings::GraphSmartGraphAttribute,
               props.smartGraphAttribute)
           .invariant(UtilityInvariants::isNonEmptyIfPresent),

--- a/arangod/VocBase/Properties/CollectionMutableProperties.h
+++ b/arangod/VocBase/Properties/CollectionMutableProperties.h
@@ -46,6 +46,8 @@ struct CollectionMutableProperties {
   // Did a short_cut here to avoid concatenated changes
   std::optional<arangodb::velocypack::Builder> schema{std::nullopt};
 
+  bool cacheEnabled = false;
+
   bool operator==(CollectionMutableProperties const&) const;
 };
 
@@ -59,6 +61,8 @@ auto inspect(Inspector& f, CollectionMutableProperties& props) {
           .fallback(f.keep())
           .invariant(CollectionMutableProperties::Invariants::isJsonSchema),
       f.field(StaticStrings::ComputedValues, props.computedValues)
+          .fallback(f.keep()),
+      f.field(StaticStrings::CacheEnabled, props.cacheEnabled)
           .fallback(f.keep()));
 }
 

--- a/tests/VocBase/Properties/CollectionConstantPropertiesTest.cpp
+++ b/tests/VocBase/Properties/CollectionConstantPropertiesTest.cpp
@@ -91,7 +91,6 @@ TEST_F(CollectionConstantPropertiesTest, test_minimal_user_input) {
   ASSERT_TRUE(testee.ok());
   EXPECT_EQ(testee->type, TRI_col_type_e::TRI_COL_TYPE_DOCUMENT);
   EXPECT_FALSE(testee->isSystem);
-  EXPECT_FALSE(testee->cacheEnabled);
   EXPECT_FALSE(testee->smartJoinAttribute.has_value());
   EXPECT_TRUE(std::holds_alternative<TraditionalKeyGeneratorProperties>(
       testee->keyOptions));
@@ -132,7 +131,6 @@ TEST_F(CollectionConstantPropertiesTest, test_collection_type) {
 GenerateBoolAttributeTest(CollectionConstantPropertiesTest, isSystem);
 GenerateBoolAttributeTest(CollectionConstantPropertiesTest, isSmart);
 GenerateBoolAttributeTest(CollectionConstantPropertiesTest, isDisjoint);
-GenerateBoolAttributeTest(CollectionConstantPropertiesTest, cacheEnabled);
 
 GenerateOptionalStringAttributeTest(CollectionConstantPropertiesTest,
                                     smartJoinAttribute);
@@ -173,7 +171,6 @@ class CollectionConstantSmartPropertiesTest
 
 GenerateBoolAttributeTest(CollectionConstantSmartPropertiesTest, isSystem);
 GenerateBoolAttributeTest(CollectionConstantSmartPropertiesTest, isDisjoint);
-GenerateBoolAttributeTest(CollectionConstantSmartPropertiesTest, cacheEnabled);
 
 GenerateOptionalStringAttributeTest(CollectionConstantSmartPropertiesTest,
                                     smartGraphAttribute);

--- a/tests/VocBase/Properties/CollectionMutablePropertiesTest.cpp
+++ b/tests/VocBase/Properties/CollectionMutablePropertiesTest.cpp
@@ -109,6 +109,7 @@ TEST_F(CollectionMutablePropertiesTest, test_minimal_user_input) {
   // does not test internals yet
   EXPECT_TRUE(testee->computedValues.slice().isNull());
   EXPECT_FALSE(testee->schema.has_value());
+  EXPECT_FALSE(testee->cacheEnabled);
 }
 
 TEST_F(CollectionMutablePropertiesTest, test_illegal_names) {

--- a/tests/js/client/shell/shell-index.js
+++ b/tests/js/client/shell/shell-index.js
@@ -1735,7 +1735,7 @@ function IndexUpdateSuite() {
         internal.db[cn].properties({ cacheEnabled: true, schema }); 
 
         let props = internal.db[cn].properties();
-        assertTrue(props.cacheEnabled);
+        assertTrue(props.cacheEnabled, props);
         let s = props.schema;
         delete s.type;
         assertEqual(schema, s);


### PR DESCRIPTION
### Scope & Purpose

Enterprise companion: https://github.com/arangodb/enterprise/pull/1426

Collection creation/update agency operations must skip the scheduler
This is necessary to ensure that the collection creation works even when the medium queue is full

The collection property cacheEnabled is actually mutable.

Note: the enterprise companion also contains some test fixes, but these are actually unrelated to the ones in this PR.