### PR TITLE
fix crash upon exception during recursive AstNode creation [BTS-1720]

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,11 @@
 v3.11.7 (XXXX-XX-XX)
 --------------------
 
+* Fixed a crash during recursive AstNode creation when an exception was thrown.
+  This can happen on DB servers when a query plan snippet is created from
+  VelocyPack, and the query plan snippet would use more memory than is allowed
+  by the query memory limit.
+
 * Fix cmake setup for jemalloc library for the case of memory profiling.
 
 * BTS-1714: Within writing AQL queries the lock timeout was accidentally set to

--- a/arangod/Aql/AstNode.cpp
+++ b/arangod/Aql/AstNode.cpp
@@ -489,6 +489,11 @@ AstNode::AstNode(Ast* ast, arangodb::velocypack::Slice slice)
           VPackValueLength l;
           char const* p = v.getString(l);
           setStringValue(ast->resources().registerString(p, l), l);
+          TRI_IF_FAILURE("AstNode::throwOnAllocation") {
+            if (getStringView() == "throw!") {
+              THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
+            }
+          }
           break;
         }
         default: {

--- a/arangod/Aql/AstNode.cpp
+++ b/arangod/Aql/AstNode.cpp
@@ -415,11 +415,11 @@ int compareAstNodes(AstNode const* lhs, AstNode const* rhs, bool compareUtf8) {
 
 // private ctor, only called during by FixedSizeAllocator in case of emergency
 // to properly initialize the node
-// Note that since C++17 the default constructor of `std::vector` is 
+// Note that since C++17 the default constructor of `std::vector` is
 // `noexcept` iff and only if the  default constructor of its `allocator_type`
 // is. Therefore, we can say that `AstNode::AstNode()` is noexcept, if and
-// only if the default constructor of the allocator type of 
-// `std::vector<AstNode*>` is noexcept, which is exactly what this fancy 
+// only if the default constructor of the allocator type of
+// `std::vector<AstNode*>` is noexcept, which is exactly what this fancy
 // `noexcept` expression does.
 AstNode::AstNode() noexcept(noexcept(decltype(members)::allocator_type()))
     : type(NODE_TYPE_NOP), flags(0), _computedValue(nullptr), members{} {

--- a/arangod/Aql/AstNode.cpp
+++ b/arangod/Aql/AstNode.cpp
@@ -415,6 +415,12 @@ int compareAstNodes(AstNode const* lhs, AstNode const* rhs, bool compareUtf8) {
 
 // private ctor, only called during by FixedSizeAllocator in case of emergency
 // to properly initialize the node
+// Note that since C++17 the default constructor of `std::vector` is 
+// `noexcept` iff and only if the  default constructor of its `allocator_type`
+// is. Therefore, we can say that `AstNode::AstNode()` is noexcept, if and
+// only if the default constructor of the allocator type of 
+// `std::vector<AstNode*>` is noexcept, which is exactly what this fancy 
+// `noexcept` expression does.
 AstNode::AstNode() noexcept(noexcept(decltype(members)::allocator_type()))
     : type(NODE_TYPE_NOP), flags(0), _computedValue(nullptr), members{} {
   // properly zero-initialize all members

--- a/arangod/Aql/AstNode.h
+++ b/arangod/Aql/AstNode.h
@@ -41,6 +41,9 @@ namespace basics {
 struct AttributeName;
 }  // namespace basics
 
+template<typename T>
+class FixedSizeAllocator;
+
 namespace aql {
 class Ast;
 struct Variable;
@@ -229,6 +232,7 @@ static_assert(NODE_TYPE_ARRAY < NODE_TYPE_OBJECT, "incorrect node types order");
 /// @brief the node
 struct AstNode {
   friend class Ast;
+  friend class FixedSizeAllocator<AstNode>;
 
   /// @brief array values with at least this number of members that
   /// are in IN or NOT IN lookups will be sorted, so that we can use
@@ -236,7 +240,8 @@ struct AstNode {
   static constexpr size_t kSortNumberThreshold = 8;
 
   /// @brief create the node
-  explicit AstNode(AstNodeType);
+  explicit AstNode(AstNodeType type) noexcept(
+      noexcept(decltype(members)::allocator_type()));
 
   /// @brief create a node, with defining a value
   explicit AstNode(AstNodeValue const& value);
@@ -279,6 +284,8 @@ struct AstNode {
 
   /// @brief return the type name of a node
   std::string_view getTypeString() const;
+
+  static std::string_view getTypeString(AstNodeType);
 
   /// @brief return the value type name of a node
   std::string_view getValueTypeString() const;
@@ -574,6 +581,10 @@ struct AstNode {
   AstNodeValue value;
 
  private:
+  // private ctor, only called during by FixedSizeAllocator in case of emergency
+  // to properly initialize the node
+  AstNode() noexcept(noexcept(decltype(members)::allocator_type()));
+
   /// @brief helper for building flags
   template<typename... Args>
   static std::underlying_type<AstNodeFlagType>::type makeFlags(

--- a/arangod/Aql/AstNode.h
+++ b/arangod/Aql/AstNode.h
@@ -583,11 +583,11 @@ struct AstNode {
  private:
   // private ctor, only called during by FixedSizeAllocator in case of emergency
   // to properly initialize the node
-  // Note that since C++17 the default constructor of `std::vector` is 
+  // Note that since C++17 the default constructor of `std::vector` is
   // `noexcept` iff and only if the  default constructor of its `allocator_type`
   // is. Therefore, we can say that `AstNode::AstNode()` is noexcept, if and
-  // only if the default constructor of the allocator type of 
-  // `std::vector<AstNode*>` is noexcept, which is exactly what this fancy 
+  // only if the default constructor of the allocator type of
+  // `std::vector<AstNode*>` is noexcept, which is exactly what this fancy
   // `noexcept` expression does.
   AstNode() noexcept(noexcept(decltype(members)::allocator_type()));
 

--- a/arangod/Aql/AstNode.h
+++ b/arangod/Aql/AstNode.h
@@ -583,6 +583,12 @@ struct AstNode {
  private:
   // private ctor, only called during by FixedSizeAllocator in case of emergency
   // to properly initialize the node
+  // Note that since C++17 the default constructor of `std::vector` is 
+  // `noexcept` iff and only if the  default constructor of its `allocator_type`
+  // is. Therefore, we can say that `AstNode::AstNode()` is noexcept, if and
+  // only if the default constructor of the allocator type of 
+  // `std::vector<AstNode*>` is noexcept, which is exactly what this fancy 
+  // `noexcept` expression does.
   AstNode() noexcept(noexcept(decltype(members)::allocator_type()));
 
   /// @brief helper for building flags

--- a/lib/Basics/FixedSizeAllocator.h
+++ b/lib/Basics/FixedSizeAllocator.h
@@ -65,12 +65,6 @@ class FixedSizeAllocator {
       return _data + _numUsed++;
     }
 
-    // roll back the effect of nextSlot()
-    void rollbackSlot() noexcept {
-      TRI_ASSERT(_numUsed > 0);
-      --_numUsed;
-    }
-
     bool full() const noexcept { return _numUsed == _numAllocated; }
 
     size_t numUsed() const noexcept { return _numUsed; }
@@ -100,19 +94,38 @@ class FixedSizeAllocator {
   FixedSizeAllocator() = default;
   ~FixedSizeAllocator() noexcept { clear(); }
 
-  template<typename... Args>
-  T* allocate(Args&&... args) {
+  void ensureCapacity() {
     if (_head == nullptr || _head->full()) {
       allocateBlock();
     }
+  }
+
+  // requires: ensureCapacity() has been called before!
+  template<typename... Args>
+  T* allocate(Args&&... args) {
     TRI_ASSERT(_head != nullptr);
     TRI_ASSERT(!_head->full());
 
+    // get memory location for next T object.
+    // this moves forward the memory pointer in the memory block
+    // and increased _numUsed.
+    T* p = _head->nextSlot();
+    TRI_ASSERT(p != nullptr);
     try {
-      T* p = _head->nextSlot();
-      return new (p) T(std::forward<Args>(args)...);
+      // create new T object in place
+      new (p) T(std::forward<Args>(args)...);
+      return p;
     } catch (...) {
-      _head->rollbackSlot();
+      // if creating the T object has failed, we will have a
+      // gap in the memory block with no valid object in it.
+      // we cannot easily rollback the memory pointer now, because
+      // it may have been moved forward already (e.g. if the ctor
+      // of T invoked the same FixedSizeAllocator recursively).
+      // thus all we can do here is to patch the "hole" in the
+      // memory block with a default-constructed T.
+      // if the default ctor of T throws here, there is not much we
+      // can do anymore.
+      new (p) T();
       throw;
     }
   }

--- a/tests/Basics/FixedSizeAllocatorTest.cpp
+++ b/tests/Basics/FixedSizeAllocatorTest.cpp
@@ -23,10 +23,26 @@
 
 #include "Basics/Common.h"
 
-#include "gtest/gtest.h"
-
-#include "Basics/FixedSizeAllocator.h"
+#include "Aql/Ast.h"
 #include "Aql/AstNode.h"
+#include "Aql/AstResources.h"
+#include "Aql/Query.h"
+#include "Basics/Exceptions.h"
+#include "Basics/FixedSizeAllocator.h"
+#include "Basics/Result.h"
+#include "Basics/debugging.h"
+#include "Logger/LogMacros.h"
+#include "Transaction/OperationOrigin.h"
+#include "Transaction/StandaloneContext.h"
+#include "Utils/ExecContext.h"
+#include "VocBase/VocbaseInfo.h"
+#include "VocBase/vocbase.h"
+
+#include "gtest/gtest.h"
+#include "Mocks/Servers.h"
+
+#include <velocypack/Builder.h>
+#include <velocypack/Parser.h>
 
 using namespace arangodb;
 
@@ -36,6 +52,7 @@ TEST(FixedSizeAllocatorTest, test_Int) {
   EXPECT_EQ(0, allocator.numUsed());
   EXPECT_EQ(0, allocator.usedBlocks());
 
+  allocator.ensureCapacity();
   int* p = allocator.allocate(24);
 
   // first allocation should be aligned to a cache line
@@ -45,6 +62,7 @@ TEST(FixedSizeAllocatorTest, test_Int) {
   EXPECT_EQ(1, allocator.numUsed());
   EXPECT_EQ(1, allocator.usedBlocks());
 
+  allocator.ensureCapacity();
   p = allocator.allocate(42);
 
   EXPECT_EQ(42, *p);
@@ -52,6 +70,7 @@ TEST(FixedSizeAllocatorTest, test_Int) {
   EXPECT_EQ(2, allocator.numUsed());
   EXPECT_EQ(1, allocator.usedBlocks());
 
+  allocator.ensureCapacity();
   p = allocator.allocate(23);
 
   EXPECT_EQ(23, *p);
@@ -71,6 +90,7 @@ TEST(FixedSizeAllocatorTest, test_UInt64) {
   EXPECT_EQ(0, allocator.numUsed());
   EXPECT_EQ(0, allocator.usedBlocks());
 
+  allocator.ensureCapacity();
   uint64_t* p = allocator.allocate(24);
 
   // first allocation should be aligned to a cache line
@@ -80,6 +100,7 @@ TEST(FixedSizeAllocatorTest, test_UInt64) {
   EXPECT_EQ(1, allocator.numUsed());
   EXPECT_EQ(1, allocator.usedBlocks());
 
+  allocator.ensureCapacity();
   p = allocator.allocate(42);
 
   EXPECT_EQ(42, *p);
@@ -87,6 +108,7 @@ TEST(FixedSizeAllocatorTest, test_UInt64) {
   EXPECT_EQ(2, allocator.numUsed());
   EXPECT_EQ(1, allocator.usedBlocks());
 
+  allocator.ensureCapacity();
   p = allocator.allocate(23);
 
   EXPECT_EQ(23, *p);
@@ -102,6 +124,7 @@ TEST(FixedSizeAllocatorTest, test_UInt64) {
 
 TEST(FixedSizeAllocatorTest, test_Struct) {
   struct Testee {
+    Testee() = default;
     Testee(std::string abc, std::string def) : abc(abc), def(def) {}
 
     std::string abc;
@@ -113,6 +136,7 @@ TEST(FixedSizeAllocatorTest, test_Struct) {
   EXPECT_EQ(0, allocator.numUsed());
   EXPECT_EQ(0, allocator.usedBlocks());
 
+  allocator.ensureCapacity();
   Testee* p = allocator.allocate("foo", "bar");
 
   // first allocation should be aligned to a cache line
@@ -123,6 +147,7 @@ TEST(FixedSizeAllocatorTest, test_Struct) {
   EXPECT_EQ(1, allocator.numUsed());
   EXPECT_EQ(1, allocator.usedBlocks());
 
+  allocator.ensureCapacity();
   p = allocator.allocate("foobar", "baz");
   EXPECT_EQ(0, (uintptr_t(p) % alignof(Testee)));
   EXPECT_EQ("foobar", p->abc);
@@ -143,6 +168,7 @@ TEST(FixedSizeAllocatorTest, test_MassAllocation) {
   EXPECT_EQ(0, allocator.usedBlocks());
 
   for (size_t i = 0; i < 10 * 1000; ++i) {
+    allocator.ensureCapacity();
     std::string* p = allocator.allocate("test" + std::to_string(i));
 
     EXPECT_EQ("test" + std::to_string(i), *p);
@@ -169,6 +195,7 @@ TEST(FixedSizeAllocatorTest, test_Clear) {
       numItemsLeft = FixedSizeAllocator<uint64_t>::capacityForBlock(usedBlocks);
       ++usedBlocks;
     }
+    allocator.ensureCapacity();
     uint64_t* p = allocator.allocate(i);
     --numItemsLeft;
 
@@ -182,6 +209,7 @@ TEST(FixedSizeAllocatorTest, test_Clear) {
   EXPECT_EQ(0, allocator.numUsed());
   EXPECT_EQ(0, allocator.usedBlocks());
 
+  allocator.ensureCapacity();
   uint64_t* p = allocator.allocate(42);
   EXPECT_EQ(42, *p);
   EXPECT_EQ(1, allocator.numUsed());
@@ -201,6 +229,7 @@ TEST(FixedSizeAllocatorTest, test_ClearMost) {
       numItemsLeft = FixedSizeAllocator<uint64_t>::capacityForBlock(usedBlocks);
       ++usedBlocks;
     }
+    allocator.ensureCapacity();
     uint64_t* p = allocator.allocate(i);
     --numItemsLeft;
 
@@ -214,8 +243,56 @@ TEST(FixedSizeAllocatorTest, test_ClearMost) {
   EXPECT_EQ(0, allocator.numUsed());
   EXPECT_EQ(1, allocator.usedBlocks());
 
+  allocator.ensureCapacity();
   uint64_t* p = allocator.allocate(42);
   EXPECT_EQ(42, *p);
   EXPECT_EQ(1, allocator.numUsed());
   EXPECT_EQ(1, allocator.usedBlocks());
 }
+
+#ifdef ARANGODB_ENABLE_FAILURE_TESTS
+TEST(FixedSizeAllocatorTest, test_AstNodesRollbackDuringCreation) {
+  // recursive AstNode structure. the AstNode ctor will throw
+  // when it encounters the node with the "throw!" string value,
+  // if the failure point is set.
+  constexpr std::string_view data(R"(
+{"type":"array","typeID":41,"subNodes":[{"type":"value","typeID":40,"value":1,"vTypeID":2},{"type":"array","typeID":41,"subNodes":[{"type":"value","typeID":40,"value":2,"vTypeID":2},{"type":"array","typeID":41,"subNodes":[{"type":"value","typeID":40,"value":3,"vTypeID":2},{"type":"array","typeID":41,"subNodes":[{"type":"value","typeID":40,"value":"throw!","vTypeID":4}]}]}]}]}
+  )");
+
+  // whatever query string will do here.
+  constexpr std::string_view queryString("RETURN null");
+
+  // create a query object so we have an AST object to mess with
+  arangodb::tests::mocks::MockAqlServer server(true);
+  arangodb::CreateDatabaseInfo testDBInfo(server.server(),
+                                          arangodb::ExecContext::current());
+  testDBInfo.load("testVocbase", 2);
+  TRI_vocbase_t vocbase(std::move(testDBInfo));
+  auto query = arangodb::aql::Query::create(
+      arangodb::transaction::StandaloneContext::create(
+          vocbase, arangodb::transaction::OperationOriginTestCase{}),
+      arangodb::aql::QueryString(queryString), nullptr);
+  query->initForTests();
+
+  auto builder = velocypack::Parser::fromJson(data);
+
+  // registration of AstNodes should work fine without failure points
+  query->ast()->resources().registerNode(query->ast(), builder->slice());
+
+  // set a failure point that throws in the AstNode ctor when
+  // it encounters an AstNode with a string value "throw!"
+  TRI_AddFailurePointDebugging("AstNode::throwOnAllocation");
+
+  auto guard = scopeGuard([]() noexcept { TRI_ClearFailurePointsDebugging(); });
+
+  Result res = basics::catchToResult([&]() -> Result {
+    // we expect this to throw a TRI_ERROR_DEBUG exception
+    // because of the failure point
+    query->ast()->resources().registerNode(query->ast(), builder->slice());
+    return {};
+  });
+
+  EXPECT_EQ(TRI_ERROR_DEBUG, res.errorNumber());
+  // we also expect implicitly that the heap was not corrupted
+}
+#endif

--- a/tests/Basics/FixedSizeAllocatorTest.cpp
+++ b/tests/Basics/FixedSizeAllocatorTest.cpp
@@ -32,7 +32,6 @@
 #include "Basics/Result.h"
 #include "Basics/debugging.h"
 #include "Logger/LogMacros.h"
-#include "Transaction/OperationOrigin.h"
 #include "Transaction/StandaloneContext.h"
 #include "Utils/ExecContext.h"
 #include "VocBase/VocbaseInfo.h"
@@ -269,8 +268,7 @@ TEST(FixedSizeAllocatorTest, test_AstNodesRollbackDuringCreation) {
   testDBInfo.load("testVocbase", 2);
   TRI_vocbase_t vocbase(std::move(testDBInfo));
   auto query = arangodb::aql::Query::create(
-      arangodb::transaction::StandaloneContext::create(
-          vocbase, arangodb::transaction::OperationOriginTestCase{}),
+      arangodb::transaction::StandaloneContext::Create(vocbase),
       arangodb::aql::QueryString(queryString), nullptr);
   query->initForTests();
 


### PR DESCRIPTION
### Scope & Purpose

Fix a crash that could occur when an exception was thrown during recursive creation of AstNodes from VelocyPack.
In this case, the FixedSizeAllocator that was responsible for creating and destroying the AstNodes inside its own memory buffers was assuming that the exception was thrown by the creation of the current AstNode. But in fact the exception could have been thrown by a nested AstNode as well. In this case, the cleanup procedure may not have worked.
This PR fixes it by not attempting to roll back the last allocation, but rather to patch the memory hole with a default-constructed AstNode.
This is a relatively small fix that can easily be backported, and it can be improved later.

The issue fixed by this bugfix happened when AstNodes were created on DB servers from a VelocyPack query plan snippet, and the memory usage exceeded the configured query memory usage limit. This can happen especially with larger bind parameter values.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.11: this PR
  - [x] Backport for 3.10: https://github.com/arangodb/arangodb/pull/20371

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 