### PR TITLE
[3.11] Fix copy + use-after free bug in path search

### DIFF
--- a/arangod/Graph/Enumerators/WeightedTwoSidedEnumerator.cpp
+++ b/arangod/Graph/Enumerators/WeightedTwoSidedEnumerator.cpp
@@ -195,25 +195,19 @@ template<class QueueType, class PathStoreType, class ProviderType,
 auto WeightedTwoSidedEnumerator<
     QueueType, PathStoreType, ProviderType,
     PathValidator>::Ball::fetchResults(CandidatesStore& candidates) -> void {
-  std::vector<Step*> looseEnds{};
-
-  if (_direction == Direction::FORWARD) {
-    for (auto& [weight, leftMeetingPoint, rightMeetingPoint] :
-         candidates.getQueue()) {
-      auto& step = leftMeetingPoint;
-      if (!step.isProcessable()) {
-        looseEnds.emplace_back(&step);
+  auto looseEnds = [&]() {
+    switch (_direction) {
+      case Direction::FORWARD: {
+        return candidates.getLeftLooseEnds();
+      }
+      case Direction::BACKWARD: {
+        return candidates.getRightLooseEnds();
+      }
+      default: {
+        TRI_ASSERT(false);
       }
     }
-  } else {
-    for (auto& [weight, leftMeetingPoint, rightMeetingPoint] :
-         candidates.getQueue()) {
-      auto& step = rightMeetingPoint;
-      if (!step.isProcessable()) {
-        looseEnds.emplace_back(&step);
-      }
-    }
-  }
+  }();
 
   if (!looseEnds.empty()) {
     // Will throw all network errors here

--- a/arangod/Graph/Enumerators/WeightedTwoSidedEnumerator.h
+++ b/arangod/Graph/Enumerators/WeightedTwoSidedEnumerator.h
@@ -101,9 +101,29 @@ class WeightedTwoSidedEnumerator {
 
     [[nodiscard]] bool isEmpty() const { return _queue.empty(); }
 
-    [[nodiscard]] std::vector<CalculatedCandidate> getQueue() const& {
-      return _queue;
-    };
+    [[nodiscard]] std::vector<Step*> getLeftLooseEnds() {
+      std::vector<Step*> steps;
+
+      for (auto& [_, step, __] : _queue) {
+        if (!step.isProcessable()) {
+          steps.emplace_back(&step);
+        }
+      }
+
+      return steps;
+    }
+
+    [[nodiscard]] std::vector<Step*> getRightLooseEnds() {
+      std::vector<Step*> steps;
+
+      for (auto& [_, __, step] : _queue) {
+        if (!step.isProcessable()) {
+          steps.emplace_back(&step);
+        }
+      }
+
+      return steps;
+    }
 
     [[nodiscard]] CalculatedCandidate& peek() {
       TRI_ASSERT(!_queue.empty());


### PR DESCRIPTION
### Scope & Purpose

Backport of #20366 ; This can cause crashes in cluster execution.

Note that this PR is branched off of #20362 , so that one has to be merged first.