### PR TITLE
fix crash upon exception during recursive AstNode creation [BTS-1720]

### DIFF
--- a/arangod/Aql/AstNode.cpp
+++ b/arangod/Aql/AstNode.cpp
@@ -413,8 +413,19 @@ int compareAstNodes(AstNode const* lhs, AstNode const* rhs, bool compareUtf8) {
   }
 }
 
+// private ctor, only called during by FixedSizeAllocator in case of emergency
+// to properly initialize the node
+AstNode::AstNode() noexcept(noexcept(decltype(members)::allocator_type()))
+    : type(NODE_TYPE_NOP), flags(0), _computedValue(nullptr), members{} {
+  // properly zero-initialize all members
+  value.value._int = 0;
+  value.length = 0;
+  value.type = VALUE_TYPE_NULL;
+}
+
 /// @brief create the node
-AstNode::AstNode(AstNodeType type)
+AstNode::AstNode(AstNodeType type) noexcept(
+    noexcept(decltype(members)::allocator_type()))
     : type(type), flags(0), _computedValue(nullptr) {
   // properly zero-initialize all members
   value.value._int = 0;
@@ -502,6 +513,11 @@ AstNode::AstNode(Ast* ast, arangodb::velocypack::Slice slice)
           VPackValueLength l;
           char const* p = v.getString(l);
           setStringValue(ast->resources().registerString(p, l), l);
+          TRI_IF_FAILURE("AstNode::throwOnAllocation") {
+            if (getStringView() == "throw!") {
+              THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
+            }
+          }
           break;
         }
         default: {
@@ -664,24 +680,14 @@ AstNode::AstNode(Ast* ast, arangodb::velocypack::Slice slice)
   if (VPackSlice subNodes = slice.get("subNodes"); subNodes.isArray()) {
     members.reserve(subNodes.length());
 
-    try {
-      for (VPackSlice it : VPackArrayIterator(subNodes)) {
-        int t = it.get("typeID").getNumericValue<int>();
-        if (static_cast<AstNodeType>(t) == NODE_TYPE_NOP) {
-          // special handling for nop as it is a singleton
-          addMember(ast->createNodeNop());
-        } else {
-          addMember(ast->createNode(it));
-        }
+    for (VPackSlice it : VPackArrayIterator(subNodes)) {
+      int t = it.get("typeID").getNumericValue<int>();
+      if (static_cast<AstNodeType>(t) == NODE_TYPE_NOP) {
+        // special handling for nop as it is a singleton
+        addMember(ast->createNodeNop());
+      } else {
+        addMember(ast->createNode(it));
       }
-    } catch (...) {
-      // prevent leaks
-      for (auto const& it : members) {
-        if (it->type != NODE_TYPE_NOP) {
-          delete it;
-        }
-      }
-      throw;
     }
   }
 }
@@ -872,7 +878,9 @@ void AstNode::sort() {
 }
 
 /// @brief return the type name of a node
-std::string_view AstNode::getTypeString() const {
+std::string_view AstNode::getTypeString() const { return getTypeString(type); }
+
+std::string_view AstNode::getTypeString(AstNodeType type) {
   auto it = kTypeNames.find(static_cast<int>(type));
 
   if (it != kTypeNames.end()) {

--- a/arangod/Aql/AstNode.cpp
+++ b/arangod/Aql/AstNode.cpp
@@ -415,6 +415,12 @@ int compareAstNodes(AstNode const* lhs, AstNode const* rhs, bool compareUtf8) {
 
 // private ctor, only called during by FixedSizeAllocator in case of emergency
 // to properly initialize the node
+// Note that since C++17 the default constructor of `std::vector` is
+// `noexcept` iff and only if the  default constructor of its `allocator_type`
+// is. Therefore, we can say that `AstNode::AstNode()` is noexcept, if and
+// only if the default constructor of the allocator type of
+// `std::vector<AstNode*>` is noexcept, which is exactly what this fancy
+// `noexcept` expression does.
 AstNode::AstNode() noexcept(noexcept(decltype(members)::allocator_type()))
     : type(NODE_TYPE_NOP), flags(0), _computedValue(nullptr), members{} {
   // properly zero-initialize all members

--- a/arangod/Aql/AstNode.h
+++ b/arangod/Aql/AstNode.h
@@ -42,6 +42,9 @@ namespace basics {
 struct AttributeName;
 }  // namespace basics
 
+template<typename T>
+class FixedSizeAllocator;
+
 namespace aql {
 class Ast;
 struct Variable;
@@ -230,6 +233,7 @@ static_assert(NODE_TYPE_ARRAY < NODE_TYPE_OBJECT, "incorrect node types order");
 /// @brief the node
 struct AstNode {
   friend class Ast;
+  friend class FixedSizeAllocator<AstNode>;
 
   /// @brief a simple tag that marks the AstNode as a constant node
   /// that will never change after being created
@@ -241,7 +245,8 @@ struct AstNode {
   static constexpr size_t kSortNumberThreshold = 8;
 
   /// @brief create the node
-  explicit AstNode(AstNodeType);
+  explicit AstNode(AstNodeType type) noexcept(
+      noexcept(decltype(members)::allocator_type()));
 
   explicit AstNode(AstNodeType, InternalNode);
 
@@ -288,6 +293,8 @@ struct AstNode {
 
   /// @brief return the type name of a node
   std::string_view getTypeString() const;
+
+  static std::string_view getTypeString(AstNodeType);
 
   /// @brief return the value type name of a node
   std::string_view getValueTypeString() const;
@@ -589,6 +596,10 @@ struct AstNode {
   AstNodeValue value;
 
  private:
+  // private ctor, only called during by FixedSizeAllocator in case of emergency
+  // to properly initialize the node
+  AstNode() noexcept(noexcept(decltype(members)::allocator_type()));
+
   /// @brief helper for building flags
   template<typename... Args>
   static std::underlying_type<AstNodeFlagType>::type makeFlags(

--- a/arangod/Aql/AstNode.h
+++ b/arangod/Aql/AstNode.h
@@ -599,11 +599,11 @@ struct AstNode {
   // private ctor, only called during by FixedSizeAllocator in case of emergency
   // to properly initialize the node
   // Note that since C++17 the default constructor of `std::vector` is
-// `noexcept` iff and only if the  default constructor of its `allocator_type`
-// is. Therefore, we can say that `AstNode::AstNode()` is noexcept, if and
-// only if the default constructor of the allocator type of
-// `std::vector<AstNode*>` is noexcept, which is exactly what this fancy
-// `noexcept` expression does.
+  // `noexcept` iff and only if the  default constructor of its `allocator_type`
+  // is. Therefore, we can say that `AstNode::AstNode()` is noexcept, if and
+  // only if the default constructor of the allocator type of
+  // `std::vector<AstNode*>` is noexcept, which is exactly what this fancy
+  // `noexcept` expression does.
   AstNode() noexcept(noexcept(decltype(members)::allocator_type()));
 
   /// @brief helper for building flags

--- a/arangod/Aql/AstNode.h
+++ b/arangod/Aql/AstNode.h
@@ -598,6 +598,12 @@ struct AstNode {
  private:
   // private ctor, only called during by FixedSizeAllocator in case of emergency
   // to properly initialize the node
+  // Note that since C++17 the default constructor of `std::vector` is
+// `noexcept` iff and only if the  default constructor of its `allocator_type`
+// is. Therefore, we can say that `AstNode::AstNode()` is noexcept, if and
+// only if the default constructor of the allocator type of
+// `std::vector<AstNode*>` is noexcept, which is exactly what this fancy
+// `noexcept` expression does.
   AstNode() noexcept(noexcept(decltype(members)::allocator_type()));
 
   /// @brief helper for building flags

--- a/tests/Basics/FixedSizeAllocatorTest.cpp
+++ b/tests/Basics/FixedSizeAllocatorTest.cpp
@@ -23,10 +23,26 @@
 
 #include "Basics/Common.h"
 
-#include "gtest/gtest.h"
-
-#include "Basics/FixedSizeAllocator.h"
+#include "Aql/Ast.h"
 #include "Aql/AstNode.h"
+#include "Aql/AstResources.h"
+#include "Aql/Query.h"
+#include "Basics/Exceptions.h"
+#include "Basics/FixedSizeAllocator.h"
+#include "Basics/Result.h"
+#include "Basics/debugging.h"
+#include "Logger/LogMacros.h"
+#include "Transaction/OperationOrigin.h"
+#include "Transaction/StandaloneContext.h"
+#include "Utils/ExecContext.h"
+#include "VocBase/VocbaseInfo.h"
+#include "VocBase/vocbase.h"
+
+#include "gtest/gtest.h"
+#include "Mocks/Servers.h"
+
+#include <velocypack/Builder.h>
+#include <velocypack/Parser.h>
 
 using namespace arangodb;
 
@@ -36,6 +52,7 @@ TEST(FixedSizeAllocatorTest, test_Int) {
   EXPECT_EQ(0, allocator.numUsed());
   EXPECT_EQ(0, allocator.usedBlocks());
 
+  allocator.ensureCapacity();
   int* p = allocator.allocate(24);
 
   // first allocation should be aligned to a cache line
@@ -45,6 +62,7 @@ TEST(FixedSizeAllocatorTest, test_Int) {
   EXPECT_EQ(1, allocator.numUsed());
   EXPECT_EQ(1, allocator.usedBlocks());
 
+  allocator.ensureCapacity();
   p = allocator.allocate(42);
 
   EXPECT_EQ(42, *p);
@@ -52,6 +70,7 @@ TEST(FixedSizeAllocatorTest, test_Int) {
   EXPECT_EQ(2, allocator.numUsed());
   EXPECT_EQ(1, allocator.usedBlocks());
 
+  allocator.ensureCapacity();
   p = allocator.allocate(23);
 
   EXPECT_EQ(23, *p);
@@ -71,6 +90,7 @@ TEST(FixedSizeAllocatorTest, test_UInt64) {
   EXPECT_EQ(0, allocator.numUsed());
   EXPECT_EQ(0, allocator.usedBlocks());
 
+  allocator.ensureCapacity();
   uint64_t* p = allocator.allocate(24);
 
   // first allocation should be aligned to a cache line
@@ -80,6 +100,7 @@ TEST(FixedSizeAllocatorTest, test_UInt64) {
   EXPECT_EQ(1, allocator.numUsed());
   EXPECT_EQ(1, allocator.usedBlocks());
 
+  allocator.ensureCapacity();
   p = allocator.allocate(42);
 
   EXPECT_EQ(42, *p);
@@ -87,6 +108,7 @@ TEST(FixedSizeAllocatorTest, test_UInt64) {
   EXPECT_EQ(2, allocator.numUsed());
   EXPECT_EQ(1, allocator.usedBlocks());
 
+  allocator.ensureCapacity();
   p = allocator.allocate(23);
 
   EXPECT_EQ(23, *p);
@@ -102,6 +124,7 @@ TEST(FixedSizeAllocatorTest, test_UInt64) {
 
 TEST(FixedSizeAllocatorTest, test_Struct) {
   struct Testee {
+    Testee() = default;
     Testee(std::string abc, std::string def) : abc(abc), def(def) {}
 
     std::string abc;
@@ -113,6 +136,7 @@ TEST(FixedSizeAllocatorTest, test_Struct) {
   EXPECT_EQ(0, allocator.numUsed());
   EXPECT_EQ(0, allocator.usedBlocks());
 
+  allocator.ensureCapacity();
   Testee* p = allocator.allocate("foo", "bar");
 
   // first allocation should be aligned to a cache line
@@ -123,6 +147,7 @@ TEST(FixedSizeAllocatorTest, test_Struct) {
   EXPECT_EQ(1, allocator.numUsed());
   EXPECT_EQ(1, allocator.usedBlocks());
 
+  allocator.ensureCapacity();
   p = allocator.allocate("foobar", "baz");
   EXPECT_EQ(0, (uintptr_t(p) % alignof(Testee)));
   EXPECT_EQ("foobar", p->abc);
@@ -143,6 +168,7 @@ TEST(FixedSizeAllocatorTest, test_MassAllocation) {
   EXPECT_EQ(0, allocator.usedBlocks());
 
   for (size_t i = 0; i < 10 * 1000; ++i) {
+    allocator.ensureCapacity();
     std::string* p = allocator.allocate("test" + std::to_string(i));
 
     EXPECT_EQ("test" + std::to_string(i), *p);
@@ -169,6 +195,7 @@ TEST(FixedSizeAllocatorTest, test_Clear) {
       numItemsLeft = FixedSizeAllocator<uint64_t>::capacityForBlock(usedBlocks);
       ++usedBlocks;
     }
+    allocator.ensureCapacity();
     uint64_t* p = allocator.allocate(i);
     --numItemsLeft;
 
@@ -182,6 +209,7 @@ TEST(FixedSizeAllocatorTest, test_Clear) {
   EXPECT_EQ(0, allocator.numUsed());
   EXPECT_EQ(0, allocator.usedBlocks());
 
+  allocator.ensureCapacity();
   uint64_t* p = allocator.allocate(42);
   EXPECT_EQ(42, *p);
   EXPECT_EQ(1, allocator.numUsed());
@@ -201,6 +229,7 @@ TEST(FixedSizeAllocatorTest, test_ClearMost) {
       numItemsLeft = FixedSizeAllocator<uint64_t>::capacityForBlock(usedBlocks);
       ++usedBlocks;
     }
+    allocator.ensureCapacity();
     uint64_t* p = allocator.allocate(i);
     --numItemsLeft;
 
@@ -214,8 +243,56 @@ TEST(FixedSizeAllocatorTest, test_ClearMost) {
   EXPECT_EQ(0, allocator.numUsed());
   EXPECT_EQ(1, allocator.usedBlocks());
 
+  allocator.ensureCapacity();
   uint64_t* p = allocator.allocate(42);
   EXPECT_EQ(42, *p);
   EXPECT_EQ(1, allocator.numUsed());
   EXPECT_EQ(1, allocator.usedBlocks());
 }
+
+#ifdef ARANGODB_ENABLE_FAILURE_TESTS
+TEST(FixedSizeAllocatorTest, test_AstNodesRollbackDuringCreation) {
+  // recursive AstNode structure. the AstNode ctor will throw
+  // when it encounters the node with the "throw!" string value,
+  // if the failure point is set.
+  constexpr std::string_view data(R"(
+{"type":"array","typeID":41,"subNodes":[{"type":"value","typeID":40,"value":1,"vTypeID":2},{"type":"array","typeID":41,"subNodes":[{"type":"value","typeID":40,"value":2,"vTypeID":2},{"type":"array","typeID":41,"subNodes":[{"type":"value","typeID":40,"value":3,"vTypeID":2},{"type":"array","typeID":41,"subNodes":[{"type":"value","typeID":40,"value":"throw!","vTypeID":4}]}]}]}]}
+  )");
+
+  // whatever query string will do here.
+  constexpr std::string_view queryString("RETURN null");
+
+  // create a query object so we have an AST object to mess with
+  arangodb::tests::mocks::MockAqlServer server(true);
+  arangodb::CreateDatabaseInfo testDBInfo(server.server(),
+                                          arangodb::ExecContext::current());
+  testDBInfo.load("testVocbase", 2);
+  TRI_vocbase_t vocbase(std::move(testDBInfo));
+  auto query = arangodb::aql::Query::create(
+      arangodb::transaction::StandaloneContext::create(
+          vocbase, arangodb::transaction::OperationOriginTestCase{}),
+      arangodb::aql::QueryString(queryString), nullptr);
+  query->initForTests();
+
+  auto builder = velocypack::Parser::fromJson(data);
+
+  // registration of AstNodes should work fine without failure points
+  query->ast()->resources().registerNode(query->ast(), builder->slice());
+
+  // set a failure point that throws in the AstNode ctor when
+  // it encounters an AstNode with a string value "throw!"
+  TRI_AddFailurePointDebugging("AstNode::throwOnAllocation");
+
+  auto guard = scopeGuard([]() noexcept { TRI_ClearFailurePointsDebugging(); });
+
+  Result res = basics::catchToResult([&]() -> Result {
+    // we expect this to throw a TRI_ERROR_DEBUG exception
+    // because of the failure point
+    query->ast()->resources().registerNode(query->ast(), builder->slice());
+    return {};
+  });
+
+  EXPECT_EQ(TRI_ERROR_DEBUG, res.errorNumber());
+  // we also expect implicitly that the heap was not corrupted
+}
+#endif


### PR DESCRIPTION
### Scope & Purpose

Fix a crash that could occur when an exception was thrown during recursive creation of AstNodes from VelocyPack.
In this case, the FixedSizeAllocator that was responsible for creating and destroying the AstNodes inside its own memory buffers was assuming that the exception was thrown by the creation of the current AstNode. But in fact the exception could have been thrown by a nested AstNode as well. In this case, the cleanup procedure may not have worked.
This PR fixes it by not attempting to roll back the last allocation, but rather to patch the memory hole with a default-constructed AstNode.
This is a relatively small fix that can easily be backported, and it can be improved later.

The issue fixed by this bugfix happened when AstNodes were created on DB servers from a VelocyPack query plan snippet, and the memory usage exceeded the configured query memory usage limit. This can happen especially with larger bind parameter values.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.11: https://github.com/arangodb/arangodb/pull/20368
  - [x] Backport for 3.10: https://github.com/arangodb/arangodb/pull/20371

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 