### PR TITLE
Added REST API `/_api/key-generators`

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 devel
 -----
 
+* Added REST API `/_api/key-generators` to query the available key generators
+  for collections.
+
 * Make AQL optimizer rule `move-filters-into-enumerate` also move filters into
   EnumerateListNodes for early pruning. Previously it could only pull filters 
   into IndexNodes and EnumerateCollectionNodes.

--- a/arangod/GeneralServer/GeneralServerFeature.cpp
+++ b/arangod/GeneralServer/GeneralServerFeature.cpp
@@ -93,6 +93,7 @@
 #include "RestHandler/RestHandlerCreator.h"
 #include "RestHandler/RestImportHandler.h"
 #include "RestHandler/RestIndexHandler.h"
+#include "RestHandler/RestKeyGeneratorsHandler.h"
 #include "RestHandler/RestJobHandler.h"
 #include "RestHandler/RestLicenseHandler.h"
 #include "RestHandler/RestLogHandler.h"
@@ -779,6 +780,10 @@ void GeneralServerFeature::defineRemainingHandlers(
 
   f.addPrefixHandler("/_api/explain",
                      RestHandlerCreator<RestExplainHandler>::createNoData);
+
+  f.addPrefixHandler(
+      "/_api/key-generators",
+      RestHandlerCreator<RestKeyGeneratorsHandler>::createNoData);
 
   f.addPrefixHandler("/_api/query",
                      RestHandlerCreator<RestQueryHandler>::createNoData);

--- a/arangod/RestHandler/RestKeyGeneratorsHandler.cpp
+++ b/arangod/RestHandler/RestKeyGeneratorsHandler.cpp
@@ -1,0 +1,61 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2023 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Jan Steemann
+////////////////////////////////////////////////////////////////////////////////
+
+#include "RestKeyGeneratorsHandler.h"
+#include "ApplicationFeatures/ApplicationServer.h"
+#include "VocBase/KeyGenerator.h"
+
+#include <velocypack/Builder.h>
+
+using namespace arangodb;
+using namespace arangodb::rest;
+
+RestKeyGeneratorsHandler::RestKeyGeneratorsHandler(ArangodServer& server,
+                                                   GeneralRequest* request,
+                                                   GeneralResponse* response)
+    : RestVocbaseBaseHandler(server, request, response) {}
+
+RestStatus RestKeyGeneratorsHandler::execute() {
+  // extract the sub-request type
+  auto const type = _request->requestType();
+
+  if (type == rest::RequestType::GET) {
+    VPackBuilder builder;
+
+    builder.openObject();
+    builder.add(VPackValue("keyGenerators"));
+    builder.openArray();
+    for (auto const& it : KeyGeneratorHelper::generatorNames()) {
+      builder.add(VPackValue(it));
+    }
+    builder.close();
+    builder.close();
+
+    generateResult(rest::ResponseCode::OK, builder.slice());
+    return RestStatus::DONE;
+  }
+
+  generateError(rest::ResponseCode::METHOD_NOT_ALLOWED,
+                TRI_ERROR_HTTP_METHOD_NOT_ALLOWED);
+  return RestStatus::DONE;
+}

--- a/arangod/RestHandler/RestKeyGeneratorsHandler.h
+++ b/arangod/RestHandler/RestKeyGeneratorsHandler.h
@@ -1,0 +1,42 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2023 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Jan Steemann
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "Basics/Common.h"
+#include "RestHandler/RestVocbaseBaseHandler.h"
+
+namespace arangodb {
+
+/// @brief key generators inventory handler
+class RestKeyGeneratorsHandler : public RestVocbaseBaseHandler {
+ public:
+  explicit RestKeyGeneratorsHandler(ArangodServer&, GeneralRequest*,
+                                    GeneralResponse*);
+
+ public:
+  RestStatus execute() override;
+  char const* name() const override final { return "RestKeyGeneratorsHandler"; }
+  RequestLane lane() const override final { return RequestLane::CLIENT_FAST; }
+};
+}  // namespace arangodb

--- a/arangod/VocBase/KeyGenerator.cpp
+++ b/arangod/VocBase/KeyGenerator.cpp
@@ -814,6 +814,15 @@ std::string const KeyGeneratorHelper::highestKey(
     KeyGeneratorHelper::maxKeyLength,
     std::numeric_limits<std::string::value_type>::max());
 
+std::vector<std::string> KeyGeneratorHelper::generatorNames() {
+  std::vector<std::string> names;
+  names.reserve(::generatorNames.size());
+  for (auto const& it : ::generatorNames) {
+    names.push_back(it.first);
+  }
+  return names;
+}
+
 uint64_t KeyGeneratorHelper::decodePadded(char const* data,
                                           size_t length) noexcept {
   uint64_t result = 0;

--- a/arangod/VocBase/KeyGenerator.h
+++ b/arangod/VocBase/KeyGenerator.h
@@ -30,6 +30,7 @@
 #include <memory>
 #include <string>
 #include <string_view>
+#include <vector>
 
 namespace arangodb {
 class KeyGenerator;
@@ -50,8 +51,10 @@ struct KeyGeneratorHelper {
   // greatest possible key
   static std::string const highestKey;
 
-  static std::string encodePadded(uint64_t value);
+  static std::vector<std::string> generatorNames();
+
   static uint64_t decodePadded(char const* p, size_t length) noexcept;
+  static std::string encodePadded(uint64_t value);
 
   /// @brief validate a key
   static bool validateKey(char const* key, size_t len) noexcept;

--- a/arangod/arangoserver.cmake
+++ b/arangod/arangoserver.cmake
@@ -92,6 +92,7 @@ add_library(arangoserver STATIC
   RestHandler/RestImportHandler.cpp
   RestHandler/RestIndexHandler.cpp
   RestHandler/RestJobHandler.cpp
+  RestHandler/RestKeyGeneratorsHandler.cpp
   RestHandler/RestLicenseHandler.cpp
   RestHandler/RestQueryCacheHandler.cpp
   RestHandler/RestQueryHandler.cpp


### PR DESCRIPTION
### Scope & Purpose

* Added REST API `/_api/key-generators` to query the available key generators for collections.
  This can be used by callers (e.g. the web UI) to determine which key generators are available.

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 