### PR TITLE
added `RANDOM()` AQL function as an alias for `RAND()`

### DIFF
--- a/arangod/Aql/AqlFunctionFeature.cpp
+++ b/arangod/Aql/AqlFunctionFeature.cpp
@@ -292,6 +292,8 @@ void AqlFunctionFeature::addNumericFunctions() {
       Function::makeFlags(FF::CanRunOnDBServerCluster,
                           FF::CanRunOnDBServerOneShard, FF::CanUseInAnalyzer);
   add({"RAND", "", nonDeterministicFlags, &functions::Rand});
+  // RANDOM is an alias for RAND
+  addAlias("RANDOM", "RAND");
 }
 
 void AqlFunctionFeature::addListFunctions() {

--- a/tests/js/client/aql/aql-functions-numeric.js
+++ b/tests/js/client/aql/aql-functions-numeric.js
@@ -3884,6 +3884,13 @@ function ahuacatlNumericFunctionsTestSuite () {
       }
     },
 
+    testRandom : function () {
+      let actual = getQueryResults("FOR r IN [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20 ] RETURN RANDOM()");
+      actual.forEach((value) => {
+        assertTrue(value >= 0.0 && value < 1.0);
+      });
+    },
+
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief test rand function
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
### Scope & Purpose

added `RANDOM()` AQL function as an alias for `RAND()` for better interoperability with other databases and easier discovery of functions.

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 