### PR TITLE
[cmake] fix release tag value for hotfixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -432,7 +432,9 @@ function(determine_repository_version source_dir build_repository have_build_rep
   elseif(BUILD_REPO_INFO STREQUAL "release")
     execute_process(
       WORKING_DIRECTORY ${source_dir}
-      COMMAND ${GIT_EXE} describe --all --tags --match v${ARANGODB_PLAIN_VERSION}
+      string(REPLACE "-" "." RELEASE_TAG ${ARANGODB_VERSION})
+      set(RELEASE_TAG "v${RELEASE_TAG}")
+      COMMAND ${GIT_EXE} describe --all --tags --match ${RELEASE_TAG}
       OUTPUT_VARIABLE TAG_RAW)
     if (NOT TAG_RAW)
       message(FATAL_ERROR "Can't extract tag using the command: 'git describe --all --tags --match v${ARANGODB_PLAIN_VERSION}")


### PR DESCRIPTION
### Scope & Purpose

This fixes a problem with hotfix releases. Now release tag value is calculated based on ARANGODB_PLAIN_VERSION, which does not include the hotfix number.
ARANGODB_VERSION variable holds the full correct version, this must be used to derive release tag value.

*(Please describe the changes in this PR for reviewers, motivation, rationale - **mandatory**)*

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

