### PR TITLE
Make sure we finish all TransactionActors when resigning

### DIFF
--- a/arangod/Replication2/StateMachines/Document/Actor/ApplyEntries.cpp
+++ b/arangod/Replication2/StateMachines/Document/Actor/ApplyEntries.cpp
@@ -66,7 +66,7 @@ auto ApplyEntriesHandler<Runtime>::operator()(message::Resign&& msg) noexcept
   // spawn a new actor after softShutdown has been called, and this actor will
   // never be finished
   for (auto& [tid, pid] : this->state->_transactionMap) {
-    this->runtime().finishActor(pid, ExitReason::kFinished);
+    this->runtime().finishActor(pid, ExitReason::kShutdown);
   }
   resign();
   this->finish(ExitReason::kFinished);

--- a/arangod/Replication2/StateMachines/Document/Actor/ApplyEntries.cpp
+++ b/arangod/Replication2/StateMachines/Document/Actor/ApplyEntries.cpp
@@ -60,6 +60,14 @@ auto ApplyEntriesHandler<Runtime>::operator()(message::Resign&& msg) noexcept
     -> std::unique_ptr<ApplyEntriesState> {
   LOG_CTX("b0788", DEBUG, this->state->loggerContext)
       << "AppliesEntry actor received resign message";
+  // We have to explicitly finish all started transaction actors.
+  // This is necessary because we have a potential race. The DocumentState can
+  // call softShutdown while we still process some entries. In this case we can
+  // spawn a new actor after softShutdown has been called, and this actor will
+  // never be finished
+  for (auto& [tid, pid] : this->state->_transactionMap) {
+    this->runtime().finishActor(pid, ExitReason::kFinished);
+  }
   resign();
   this->finish(ExitReason::kFinished);
   return std::move(this->state);

--- a/arangod/Replication2/StateMachines/Document/DocumentFollowerState.cpp
+++ b/arangod/Replication2/StateMachines/Document/DocumentFollowerState.cpp
@@ -83,7 +83,9 @@ DocumentFollowerState::DocumentFollowerState(
       << "Spawned ApplyEntries actor " << _applyEntriesActor.id;
 }
 
-DocumentFollowerState::~DocumentFollowerState() { shutdownRuntime(); }
+DocumentFollowerState::~DocumentFollowerState() {
+  ADB_PROD_ASSERT(_runtime->actors.size() == 0);
+}
 
 void DocumentFollowerState::shutdownRuntime() noexcept {
   LOG_CTX("19dec", DEBUG, loggerContext) << "shutting down actor runtime";

--- a/arangod/Replication2/StateMachines/Document/DocumentFollowerState.cpp
+++ b/arangod/Replication2/StateMachines/Document/DocumentFollowerState.cpp
@@ -83,9 +83,7 @@ DocumentFollowerState::DocumentFollowerState(
       << "Spawned ApplyEntries actor " << _applyEntriesActor.id;
 }
 
-DocumentFollowerState::~DocumentFollowerState() {
-  ADB_PROD_ASSERT(_runtime->actors.size() == 0);
-}
+DocumentFollowerState::~DocumentFollowerState() { shutdownRuntime(); }
 
 void DocumentFollowerState::shutdownRuntime() noexcept {
   LOG_CTX("19dec", DEBUG, loggerContext) << "shutting down actor runtime";


### PR DESCRIPTION
### Scope & Purpose

We cannot rely on softShutdown to finish all actors, because we have a race - a concurrently running ApplyEntries actor can spawn new actors after softShutdown has been called. This would cause the runtime shutdown to wait for an actor that was never going to be finished

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

