### PR TITLE
[CINFRA] Only DEBUG output expected error situation

### DIFF
--- a/arangod/Cluster/CreateCollection.cpp
+++ b/arangod/Cluster/CreateCollection.cpp
@@ -203,18 +203,20 @@ bool CreateCollection::first() {
         _doNotIncrement = true;
         return false;
       }
+
       std::stringstream error;
       error << "creating local shard '" << database << "/" << shard
             << "' for central '" << database << "/" << collection
             << "' failed: " << res;
-      LOG_TOPIC("63687", ERR, Logger::MAINTENANCE) << error.str();
-
       if (res.is(TRI_ERROR_REPLICATION_REPLICATED_LOG_NOT_THE_LEADER) ||
           res.is(TRI_ERROR_REPLICATION_REPLICATED_STATE_NOT_FOUND)) {
         // Do not store this error
         // TODO prevent busy loop and wait for log to become ready (CINFRA-831).
         std::this_thread::sleep_for(std::chrono::milliseconds{50});
         ignoreTemporaryError = true;
+        LOG_TOPIC("63688", DEBUG, Logger::MAINTENANCE) << error.str();
+      } else {
+        LOG_TOPIC("63687", ERR, Logger::MAINTENANCE) << error.str();
       }
 
       res.reset(TRI_ERROR_FAILED, error.str());


### PR DESCRIPTION
### Scope & Purpose

*On Replication2 there is an expected uncritical race on new shard creation together with the log. They are both detected at the same time and sometimes the Shard is actually executed before the log. Then the CreateShard job is going to fail quickly and be retried in the next iteration. Only this situation is now put on DEBUG log level so we have the option if we ever get stuck on shard-creation to increase the LogLevel and still see the error, but not raise unnecessary alarms.*

This is the log line in question:

`P ERROR [63687] {maintenance} creating local shard '_system/s2775' for central '_system/573080' failed: {"errorNum":1427,"errorMessage":"replicated state 2772 not found"}`

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

