### PR TITLE
fix non-deterministic behavior on Windows

### DIFF
--- a/arangod/Aql/EnumerateListExecutor.h
+++ b/arangod/Aql/EnumerateListExecutor.h
@@ -79,14 +79,14 @@ class EnumerateListExpressionContext final : public QueryExpressionContext {
   std::optional<std::reference_wrapper<InputAqlItemRow const>> _inputRow;
   std::vector<std::pair<VariableId, RegisterId>> const& _varsToRegister;
   VariableId _outputVariableId;
-  std::optional<std::reference_wrapper<AqlValue const>> _currentValue;
+  AqlValue _currentValue;
 };
 
 class EnumerateListExecutorInfos {
  public:
   EnumerateListExecutorInfos(
       RegisterId inputRegister, RegisterId outputRegister, QueryContext& query,
-      Expression* filter,
+      Expression* filter, VariableId outputVariableId,
       std::vector<std::pair<VariableId, RegisterId>>&& varsToRegs);
 
   EnumerateListExecutorInfos() = delete;
@@ -108,9 +108,9 @@ class EnumerateListExecutorInfos {
   // These two are exactly the values in the parent members
   // ExecutorInfo::_inRegs and ExecutorInfo::_outRegs, respectively
   // getInputRegisters() and getOutputRegisters().
-  RegisterId _inputRegister;
-  RegisterId _outputRegister;
-  VariableId _outputVariableId;
+  RegisterId const _inputRegister;
+  RegisterId const _outputRegister;
+  VariableId const _outputVariableId;
   Expression* _filter;
   // Input variable and register pairs required for the filter
   std::vector<std::pair<VariableId, RegisterId>> _varsToRegs;
@@ -172,7 +172,6 @@ class EnumerateListExecutor {
  private:
   AqlValue getAqlValue(AqlValue const& inVarReg, size_t const& pos,
                        bool& mustDestroy);
-  void initialize();
 
   bool checkFilter(AqlValue const& currentValue);
 

--- a/arangod/Aql/ExecutionNode.cpp
+++ b/arangod/Aql/ExecutionNode.cpp
@@ -1987,13 +1987,15 @@ std::unique_ptr<ExecutionBlock> EnumerateListNode::createBlock(
     _filter->variables(inVars);
 
     for (auto const& var : inVars) {
-      auto regId = variableToRegisterId(var);
-      varsToRegs.emplace_back(var->id, regId);
+      if (var->id != _outVariable->id) {
+        auto regId = variableToRegisterId(var);
+        varsToRegs.emplace_back(var->id, regId);
+      }
     }
   }
-  auto executorInfos =
-      EnumerateListExecutorInfos(inputRegister, outRegister, engine.getQuery(),
-                                 filter(), std::move(varsToRegs));
+  auto executorInfos = EnumerateListExecutorInfos(
+      inputRegister, outRegister, engine.getQuery(), filter(), _outVariable->id,
+      std::move(varsToRegs));
   return std::make_unique<ExecutionBlockImpl<EnumerateListExecutor>>(
       &engine, this, std::move(registerInfos), std::move(executorInfos));
 }

--- a/arangod/Aql/RegisterPlan.cpp
+++ b/arangod/Aql/RegisterPlan.cpp
@@ -510,9 +510,7 @@ RegisterId RegisterPlanT<T>::registerVariable(
   }
   TRI_ASSERT(regId.isConstRegister() == (v->type() == Variable::Type::Const));
 
-  bool inserted;
-  std::tie(std::ignore, inserted) =
-      varInfo.try_emplace(v->id, VarInfo(depth, regId));
+  auto [_, inserted] = varInfo.try_emplace(v->id, VarInfo(depth, regId));
   TRI_ASSERT(inserted);
   if (!inserted) {
     THROW_ARANGO_EXCEPTION_MESSAGE(

--- a/arangod/Aql/RegisterPlan.h
+++ b/arangod/Aql/RegisterPlan.h
@@ -25,21 +25,19 @@
 #pragma once
 
 #include "Aql/ExecutionNode.h"
+#include "Aql/VarInfoMap.h"
 #include "Aql/WalkerWorker.h"
 #include "Aql/types.h"
 #include "Basics/Common.h"
-#include "Aql/VarInfoMap.h"
 
 #include <memory>
 #include <stack>
 #include <vector>
 
-namespace arangodb {
-namespace velocypack {
+namespace arangodb::velocypack {
 class Builder;
 class Slice;
-}  // namespace velocypack
-}  // namespace arangodb
+}  // namespace arangodb::velocypack
 
 namespace arangodb::aql {
 

--- a/arangod/Aql/VarInfoMap.h
+++ b/arangod/Aql/VarInfoMap.h
@@ -23,14 +23,14 @@
 
 #pragma once
 
+#include "Aql/types.h"
+
 #include <unordered_map>
 // TODO(MBkkt) Try to use FlatHashMap to achieve better
 //  lookup performance on query execution
 // #include "Containers/FlatHashMap.h"
 
 namespace arangodb::aql {
-
-using VariableId = uint32_t;
 
 struct VarInfo;
 

--- a/arangod/Aql/types.h
+++ b/arangod/Aql/types.h
@@ -29,6 +29,7 @@
 #include "Cluster/ClusterTypes.h"
 #include "Containers/HashSetFwd.h"
 
+#include <cstdint>
 #include <map>
 #include <memory>
 #include <set>

--- a/tests/Aql/EnumerateListExecutorTest.cpp
+++ b/tests/Aql/EnumerateListExecutorTest.cpp
@@ -81,7 +81,8 @@ TEST_F(EnumerateListExecutorTest, test_check_state_first_row_border) {
   SharedAqlItemBlockPtr block{new AqlItemBlock(itemBlockManager, 1000, 5)};
   RegisterInfos registerInfos(RegIdSet{3}, RegIdSet{4}, 4, 5, {},
                               {RegIdSet{0, 1, 2, 3}});
-  EnumerateListExecutorInfos executorInfos(3, 4, *fakedQuery, nullptr, {});
+  EnumerateListExecutorInfos executorInfos(
+      3, 4, *fakedQuery, nullptr, std::numeric_limits<VariableId>::max(), {});
   EnumerateListExecutor testee(fetcher, executorInfos);
   SharedAqlItemBlockPtr inBlock =
       buildBlock<4>(itemBlockManager, {{{{1}, {2}, {3}, {R"([true, 1, 2])"}}},
@@ -120,7 +121,8 @@ TEST_F(EnumerateListExecutorTest, test_check_state_second_row_border) {
   SharedAqlItemBlockPtr block{new AqlItemBlock(itemBlockManager, 1000, 5)};
   RegisterInfos registerInfos(RegIdSet{3}, RegIdSet{4}, 4, 5, {},
                               {RegIdSet{0, 1, 2, 3}});
-  EnumerateListExecutorInfos executorInfos(3, 4, *fakedQuery, nullptr, {});
+  EnumerateListExecutorInfos executorInfos(
+      3, 4, *fakedQuery, nullptr, std::numeric_limits<VariableId>::max(), {});
   EnumerateListExecutor testee(fetcher, executorInfos);
   SharedAqlItemBlockPtr inBlock =
       buildBlock<4>(itemBlockManager, {{{{1}, {2}, {3}, {R"([true, 1, 2])"}}},
@@ -158,7 +160,8 @@ class EnumerateListExecutorTestProduce
   NoStats stats;
 
   EnumerateListExecutorTestProduce()
-      : executorInfos(0, 1, *fakedQuery, nullptr, {}) {}
+      : executorInfos(0, 1, *fakedQuery, nullptr,
+                      std::numeric_limits<VariableId>::max(), {}) {}
 
   auto makeRegisterInfos(RegisterId inputRegister = 0,
                          RegisterId outputRegister = 1,
@@ -179,8 +182,12 @@ class EnumerateListExecutorTestProduce
   auto makeExecutorInfos(RegisterId inputRegister = 0,
                          RegisterId outputRegister = 1)
       -> EnumerateListExecutorInfos {
-    EnumerateListExecutorInfos infos{
-        inputRegister, outputRegister, *fakedQuery, nullptr, {}};
+    EnumerateListExecutorInfos infos{inputRegister,
+                                     outputRegister,
+                                     *fakedQuery,
+                                     nullptr,
+                                     std::numeric_limits<VariableId>::max(),
+                                     {}};
     return infos;
   }
 };


### PR DESCRIPTION
### Scope & Purpose

The register planning could insert different variables with the same register id into the VarInfoMap.
The info from the VarInfoMap was later copied into a vector. VarInfoMap is an unordered container with no guaranteed iteration order. Thus it was not deterministic which of the inserted variables with the same register id value was found first.
The issue did not occur in any of the Linux builds, potentially because there the iteration order for unordered containers is more deterministic than on Windows, for better or worse. It was a bug anyway, and the iteration order must not play a role here.

The issue was uncovered by a recent change in EnumerateListExecutor, which was made only in devel. Thus no backports needed.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 