### PR TITLE
[CINFRA] Disable a fuilrePoint test for Replication1 if run with Replication2

### DIFF
--- a/tests/js/client/shell/shell-followers-cluster.js
+++ b/tests/js/client/shell/shell-followers-cluster.js
@@ -161,6 +161,11 @@ function FollowersSuite () {
       // now check Current
       assertTrue(result.hasOwnProperty("Current"));
 
+      if (db._properties().replicationVersion === "2") {
+        // The following assertion on current is faked
+        // for replication1, and not in use for replication2
+        return;
+      }
       let tries = 0;
       // try for 10 seconds, and in this period no followers must show up 
       while (++tries < 20) {


### PR DESCRIPTION
### Scope & Purpose

*TestOnly change. The test changed here is using the FailurePoint "FollowerInfo::add" which prohibits Replication1 from reporting a follower to the Agency. This Failure Point is not reached in Replication2 and the behaviour tested here does not exist anymore. Hence I disabled the "current" part of the test. (that the create works without failure point is tested somewhere else)*

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

