### PR TITLE
Don't schedule concurrent compactions for the same column family

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,11 @@
 devel
 -----
 
+* Only schedule a single compaction per RocksDB column family at any given
+  time. Scheduling mutliple concurrent compactions on the same column family
+  can lead to scheduler threads being stalled under some adverse conditions
+  that lead to a stall inside RocksDB.
+
 * Added REST API `/_api/key-generators` to query the available key generators
   for collections.
 


### PR DESCRIPTION
### Scope & Purpose

Don't schedule concurrent compactions for the same column family

* Only schedule a single compaction per RocksDB column family at any given time. Scheduling mutliple concurrent compactions on the same column family can lead to scheduler threads being stalled under some adverse conditions that lead to a stall inside RocksDB.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 