### PR TITLE
Disabled Rep1 specific test suite for Rep2

### DIFF
--- a/tests/js/client/shell/shell-index-cleanup-cluster.js
+++ b/tests/js/client/shell/shell-index-cleanup-cluster.js
@@ -229,7 +229,13 @@ function indexCleanupSuite() {
 }
 
 // only run when there is a coordinator
-jsunity.run(indexCleanupSuite);
+
+if (db._properties().replicationVersion !== "2") {
+  // In replication two the Index is written to Target in the agency
+  // the Coordinator is not involved with index creation anymore.
+  // Making this test suite obsolete.
+  jsunity.run(indexCleanupSuite);
+}
 
 return jsunity.done();
 


### PR DESCRIPTION
### Scope & Purpose

*This test specifically tests behavior of Replication1 index creation if the Coordinator dies in the Process.
We have moved responsibility to the Agency already (tested) making this test obsolete for Rep2.*

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

