### PR TITLE
[ZKD] BugFix PR

### DIFF
--- a/arangod/Indexes/IndexFactory.cpp
+++ b/arangod/Indexes/IndexFactory.cpp
@@ -165,6 +165,14 @@ bool IndexTypeFactory::equal(Index::IndexType type, velocypack::Slice lhs,
         return false;
       }
     }
+  } else if (Index::IndexType::TRI_IDX_TYPE_MDI_PREFIXED_INDEX == type) {
+    value = lhs.get(StaticStrings::IndexPrefixFields);
+
+    if (value.isArray() &&
+        !basics::VelocyPackHelper::equal(
+            value, rhs.get(StaticStrings::IndexPrefixFields), false)) {
+      return false;
+    }
   }
 
   // other index types: fields must be identical if present

--- a/arangod/RocksDBEngine/RocksDBZkdIndex.h
+++ b/arangod/RocksDBEngine/RocksDBZkdIndex.h
@@ -42,6 +42,8 @@ class RocksDBZkdIndexBase : public RocksDBIndex {
 
   bool isPrefixed() const noexcept { return !_prefixFields.empty(); }
 
+  bool matchesDefinition(VPackSlice const& info) const override;
+
   std::vector<std::vector<basics::AttributeName>> const& coveredFields()
       const override {
     return _coveredFields;

--- a/tests/js/client/aql/aql-zkdindex-prefix-fields.js
+++ b/tests/js/client/aql/aql-zkdindex-prefix-fields.js
@@ -36,9 +36,7 @@ function optimizerRuleZkd2dIndexTestSuite() {
 
   return {
     tearDown: function () {
-      if (db[colName]) {
-        db[colName].drop();
-      }
+      db._drop(colName);
     },
 
     testSimplePrefix: function () {

--- a/tests/js/client/aql/aql-zkdindex-unique-cluster.js
+++ b/tests/js/client/aql/aql-zkdindex-unique-cluster.js
@@ -1,0 +1,114 @@
+/* global fail */
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2021-2024 ArangoDB GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Lars Maier
+////////////////////////////////////////////////////////////////////////////////
+
+'use strict';
+
+const jsunity = require("jsunity");
+const arangodb = require("@arangodb");
+const internal = require("internal");
+const db = arangodb.db;
+const aql = arangodb.aql;
+const ERRORS = arangodb.errors;
+const {assertTrue, assertFalse, assertEqual} = jsunity.jsUnity.assertions;
+const _ = require("lodash");
+
+const database = "ZkdUniqueClusterTestDatabase";
+
+function zkdClusterUniqueShardKeys() {
+
+  const checkUnsupported = function (c, index) {
+    try {
+      c.ensureIndex(index);
+      fail();
+    } catch (e) {
+      assertEqual(ERRORS.ERROR_CLUSTER_UNSUPPORTED.code, e.errorNum);
+    }
+  };
+
+  return {
+    setUpAll: function () {
+      db._createDatabase(database);
+      db._useDatabase(database);
+    },
+
+    tearDownAll: function () {
+      db._useDatabase("_system");
+      db._dropDatabase(database);
+    },
+
+    setUp: function () {
+      db._create("c", {numberOfShards: 3, shardKeys: ["x"]});
+    },
+    tearDown: function () { db.c.drop(); },
+
+    testZkdClusterUnique: function () {
+      // This should work as expected
+      db.c.ensureIndex({type: 'zkd', fields: ["x", "y"], fieldValueTypes: 'double', unique: true});
+      db.c.ensureIndex({type: 'zkd', fields: ["y", "x", "z"], fieldValueTypes: 'double', unique: true});
+
+      // This should not work
+      checkUnsupported(db.c, {type: 'zkd', fields: ["z", "y"], fieldValueTypes: 'double', unique: true});
+      checkUnsupported(db.c, {type: 'zkd', fields: ["z"], fieldValueTypes: 'double', unique: true});
+      checkUnsupported(db.c, {type: 'zkd', fields: ["y"], fieldValueTypes: 'double', unique: true});
+    },
+
+    testMdiPrefixClusterUnique: function () {
+      // This should work as expected
+      db.c.ensureIndex({
+        type: 'mdi-prefixed',
+        fields: ["z", "y"],
+        prefixFields: ["x"],
+        fieldValueTypes: 'double',
+        unique: true
+      });
+      db.c.ensureIndex({
+        type: 'mdi-prefixed',
+        fields: ["x", "y"],
+        prefixFields: ["z"],
+        fieldValueTypes: 'double',
+        unique: true
+      });
+
+      // This should not work
+      checkUnsupported(db.c, {
+        type: 'mdi-prefixed',
+        fields: ["z", "y"],
+        prefixFields: ["a"],
+        fieldValueTypes: 'double',
+        unique: true
+      });
+      checkUnsupported(db.c, {
+        type: 'mdi-prefixed',
+        fields: ["z"],
+        prefixFields: ["a"],
+        fieldValueTypes: 'double',
+        unique: true
+      });
+    }
+
+  };
+}
+
+jsunity.run(zkdClusterUniqueShardKeys);
+
+return jsunity.done();

--- a/tests/js/client/aql/aql-zkdindex-unique.js
+++ b/tests/js/client/aql/aql-zkdindex-unique.js
@@ -34,7 +34,6 @@ const _ = require("lodash");
 
 const useIndexes = 'use-indexes';
 const removeFilterCoveredByIndex = "remove-filter-covered-by-index";
-const moveFiltersIntoEnumerate = "move-filters-into-enumerate";
 
 function optimizerRuleZkd2dIndexTestSuite() {
     const colName = 'UnitTestZkdIndexCollection';
@@ -42,7 +41,7 @@ function optimizerRuleZkd2dIndexTestSuite() {
 
     return {
         setUpAll: function () {
-            col = db._create(colName);
+            col = db._create(colName, {numberOfShards: 2, shardKeys: ["x"]});
             col.ensureIndex({
                 type: 'zkd',
                 name: 'zkdIndex',

--- a/tests/js/client/aql/aql-zkdindex.js
+++ b/tests/js/client/aql/aql-zkdindex.js
@@ -26,7 +26,7 @@ const jsunity = require("jsunity");
 const arangodb = require("@arangodb");
 const db = arangodb.db;
 const aql = arangodb.aql;
-const {assertTrue, assertFalse, assertEqual} = jsunity.jsUnity.assertions;
+const {assertTrue, assertFalse, assertEqual, assertNotEqual} = jsunity.jsUnity.assertions;
 const _ = require("lodash");
 
 const useIndexes = 'use-indexes';
@@ -265,6 +265,45 @@ function optimizerRuleZkd2dIndexTestSuite() {
       col.drop();
     },
 
+    testFieldValuesTypes: function () {
+      let col = db._create(colName + "4");
+      const idx = col.ensureIndex({
+        type: 'zkd',
+        name: 'zkdIndex',
+        fields: ['x', 'y'],
+        fieldValueTypes: 'double',
+      });
+
+      assertEqual('double', idx.fieldValueTypes);
+      const idx2 = col.index(idx.name);
+      assertEqual('double', idx2.fieldValueTypes);
+      col.drop();
+    },
+
+    testCompareIndex: function () {
+      let col = db._create(colName + "4");
+      const idx1 = col.ensureIndex({
+        type: 'zkd',
+        fields: ['x', 'y'],
+        fieldValueTypes: 'double',
+      });
+
+      const idx2 = col.ensureIndex({
+        type: 'zkd',
+        fields: ['x', 'y'],
+        fieldValueTypes: 'double',
+      });
+
+      const idx3 = col.ensureIndex({
+        type: 'zkd',
+        fields: ['y', 'x'],
+        fieldValueTypes: 'double',
+      });
+
+      assertEqual(idx1.id, idx2.id);
+      assertNotEqual(idx3.id, idx2.id);
+      col.drop();
+    },
   };
 }
 


### PR DESCRIPTION
### Scope & Purpose

This PR fixes a few smaller bugs:
- Indexes did not compare correctly and did not account for `prefixFields`.
- `fieldValueTypes: double` was required for creation but not stored when serialized.