### PR TITLE
remove now-obsolete code comments

### DIFF
--- a/arangod/Aql/TraversalExecutor.cpp
+++ b/arangod/Aql/TraversalExecutor.cpp
@@ -89,8 +89,8 @@ TraversalExecutorInfos::TraversalExecutorInfos(
               _inputRegister.value() == RegisterId::maxRegisterId));
 
   /*
-   * In the refactored variant we need to parse the correct enumerator type
-   * here, before we're allowed to use it.
+   * We need to parse the correct enumerator type here, before we're allowed to
+   * use it.
    */
   TRI_ASSERT(_traversalEnumerator == nullptr);
 
@@ -134,8 +134,8 @@ TraversalExecutorInfos::TraversalExecutorInfos(
 
   TRI_ASSERT(!ServerState::instance()->isCoordinator());
   /*
-   * In the refactored variant we need to parse the correct enumerator type
-   * here, before we're allowed to use it.
+   * We need to parse the correct enumerator type here, before we're allowed to
+   * use it.
    */
   TRI_ASSERT(_traversalEnumerator == nullptr);
 
@@ -384,7 +384,6 @@ TraversalExecutor::~TraversalExecutor() {
 }
 
 auto TraversalExecutor::doOutput(OutputAqlItemRow& output) -> void {
-  // Refactored variant
   auto currentPath = traversalEnumerator()->getNextPath();
   if (currentPath != nullptr) {
     TRI_ASSERT(_inputRow.isInitialized());
@@ -479,14 +478,12 @@ auto TraversalExecutor::skipRowsRange(AqlItemBlockInputRange& input,
   TRI_ASSERT(false);
 }
 
-//
 // Set a new start vertex for traversal, for this fetch inputs
 // from input until we are either successful or input is unwilling
 // to give us more.
 //
 // TODO: this is quite a big function, refactor
 bool TraversalExecutor::initTraverser(AqlItemBlockInputRange& input) {
-  // refactored variant
   TRI_ASSERT(traversalEnumerator()->isDone());
 
   while (input.hasDataRow()) {

--- a/arangod/Aql/TraversalExecutor.h
+++ b/arangod/Aql/TraversalExecutor.h
@@ -183,7 +183,7 @@ class TraversalExecutorInfos {
 };
 
 /**
- * @brief Implementation of Traversal Node
+ * @brief Implementation of traversal executor
  */
 class TraversalExecutor {
  public:
@@ -215,7 +215,6 @@ class TraversalExecutor {
 
   [[nodiscard]] auto stats() -> Stats;
 
-  // NEW (refactor)
   auto traversalEnumerator() -> arangodb::graph::TraversalEnumerator*;
 
  private:
@@ -226,7 +225,7 @@ class TraversalExecutor {
   Ast _ast;
   InputAqlItemRow _inputRow;
 
-  /// @brief the refactored finder variant.
+  /// @brief the finder variant.
   arangodb::graph::TraversalEnumerator* _traversalEnumerator;
 };
 

--- a/arangod/Aql/TraversalNode.cpp
+++ b/arangod/Aql/TraversalNode.cpp
@@ -780,8 +780,7 @@ std::unique_ptr<ExecutionBlock> TraversalNode::createBlock(
     TRI_ASSERT(!isSmart);
     auto singleServerBaseProviderOptions =
         getSingleServerBaseProviderOptions(opts, filterConditionVariables);
-    auto executorInfos = TraversalExecutorInfos(  // todo add a parameter:
-                                                  // SingleServer, Cluster...
+    auto executorInfos = TraversalExecutorInfos(
         outputRegisterMapping, getStartVertex(), inputRegister,
         plan()->getAst(), opts->uniqueVertices, opts->uniqueEdges, opts->mode,
         opts->defaultWeight, opts->weightAttribute, opts->query(),
@@ -1003,7 +1002,6 @@ std::unique_ptr<ExecutionBlock> TraversalNode::createBlock(
      * SmartGraph Traverser
      */
     if (isSmart() && !isDisjoint()) {
-      // Note: Using refactored smart graph cluster engine.
       return createBlock(engine, std::move(filterConditionVariables),
                          checkPruneAvailability, checkPostFilterAvailability,
                          outputRegisterMapping, inputRegister, registerInfos,
@@ -1014,7 +1012,6 @@ std::unique_ptr<ExecutionBlock> TraversalNode::createBlock(
       /*
        * Default Cluster Traverser
        */
-      // Note: Using refactored cluster engine.
       return createBlock(engine, std::move(filterConditionVariables),
                          checkPruneAvailability, checkPostFilterAvailability,
                          outputRegisterMapping, inputRegister, registerInfos,


### PR DESCRIPTION
### Scope & Purpose

Adjust/remove code comments that refer to "refactored" or "new" traversal variants, as we now only have these and not their older counterparts.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 