### PR TITLE
remove artificial limitation for `--rocksdb.max-background-jobs`

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 v3.10.13 (XXXX-XX-XX)
 ---------------------
 
+* Removal artificial upper bound value of `128` for the startup option 
+  `--rocksdb.max-background-jobs`.
+
 * Fixed a crash during recursive AstNode creation when an exception was thrown.
   This can happen on DB servers when a query plan snippet is created from
   VelocyPack, and the query plan snippet would use more memory than is allowed

--- a/arangod/RocksDBEngine/RocksDBOptionFeature.cpp
+++ b/arangod/RocksDBEngine/RocksDBOptionFeature.cpp
@@ -1112,9 +1112,8 @@ void RocksDBOptionFeature::validateOptions(
         << "invalid value for '--rocksdb.total-write-buffer-size'";
     FATAL_ERROR_EXIT();
   }
-  if (_maxBackgroundJobs != -1 &&
-      (_maxBackgroundJobs < 1 || _maxBackgroundJobs > 128)) {
-    LOG_TOPIC("cfc5a", FATAL, arangodb::Logger::FIXME)
+  if (_maxBackgroundJobs != -1 && _maxBackgroundJobs < 1) {
+    LOG_TOPIC("cfc5a", FATAL, arangodb::Logger::STARTUP)
         << "invalid value for '--rocksdb.max-background-jobs'";
     FATAL_ERROR_EXIT();
   }


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/20193

Fixes https://arangodb.atlassian.net/browse/BTS-1723

Remove artificial limitation for `--rocksdb.max-background-jobs`.
When the option was set to a value != -1, then the maximum value was 128. This is an artificial limitation which may not make sense on servers with many cores.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.11: https://github.com/arangodb/arangodb/pull/20416
  - [x] Backport for 3.10: this PR

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [x] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/BTS-1723
- [ ] Design document: 