### PR TITLE
BTS-1727: Return proper EXIT_UPGRADE_REQUIRED in cluster mode

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 v3.10.13 (XXXX-XX-XX)
 ---------------------
 
+* BTS-1727: Return proper EXIT_UPGRADE_REQUIRED in cluster mode.
+
 * Fixed a crash during recursive AstNode creation when an exception was thrown.
   This can happen on DB servers when a query plan snippet is created from
   VelocyPack, and the query plan snippet would use more memory than is allowed

--- a/arangod/RestServer/UpgradeFeature.cpp
+++ b/arangod/RestServer/UpgradeFeature.cpp
@@ -27,6 +27,7 @@
 #include "Basics/ScopeGuard.h"
 #include "Basics/StaticStrings.h"
 #include "Basics/application-exit.h"
+#include "Basics/exitcodes.h"
 #include "Cluster/ServerState.h"
 #ifdef USE_ENTERPRISE
 #include "Enterprise/StorageEngine/HotBackupFeature.h"
@@ -131,7 +132,7 @@ void UpgradeFeature::validateOptions(std::shared_ptr<ProgramOptions> options) {
     LOG_TOPIC("47698", FATAL, arangodb::Logger::FIXME)
         << "cannot specify both '--database.auto-upgrade true' and "
            "'--database.upgrade-check false'";
-    FATAL_ERROR_EXIT();
+    FATAL_ERROR_EXIT_CODE(TRI_EXIT_INVALID_OPTION_VALUE);
   }
 
   if (!_upgrade) {
@@ -292,16 +293,26 @@ void UpgradeFeature::upgradeLocalDatabase() {
         methods::Upgrade::startup(*vocbase, _upgrade, ignoreDatafileErrors);
 
     if (res.fail()) {
-      char const* typeName = "initialization";
+      std::string_view typeName = "initialization";
+      int exitCode = TRI_EXIT_FAILED;
 
       if (res.type == methods::VersionResult::UPGRADE_NEEDED) {
         typeName = "upgrade";  // an upgrade failed or is required
 
         if (!_upgrade) {
+          exitCode = TRI_EXIT_UPGRADE_REQUIRED;
           LOG_TOPIC("1c156", ERR, arangodb::Logger::FIXME)
               << "Database '" << vocbase->name() << "' needs upgrade. "
               << "Please start the server with --database.auto-upgrade";
+        } else {
+          exitCode = TRI_EXIT_UPGRADE_FAILED;
         }
+      } else if (res.type == methods::VersionResult::DOWNGRADE_NEEDED) {
+        exitCode = TRI_EXIT_DOWNGRADE_REQUIRED;
+      } else if (res.type ==
+                     methods::VersionResult::CANNOT_PARSE_VERSION_FILE ||
+                 res.type == methods::VersionResult::CANNOT_READ_VERSION_FILE) {
+        exitCode = TRI_EXIT_VERSION_CHECK_FAILED;
       }
 
       LOG_TOPIC("2eb08", FATAL, arangodb::Logger::FIXME)
@@ -310,7 +321,7 @@ void UpgradeFeature::upgradeLocalDatabase() {
           << "Please inspect the logs from the " << typeName << " procedure"
           << " and try starting the server again.";
 
-      FATAL_ERROR_EXIT();
+      FATAL_ERROR_EXIT_CODE(exitCode);
     }
   }
 


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/20415

Fix BTS-1727: https://arangodb.atlassian.net/browse/BTS-1727

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.11: https://github.com/arangodb/arangodb/pull/20418
  - [x] Backport for 3.10: this PR

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [x] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/BTS-1727
- [ ] Design document: 