### PR TITLE
treat "zkd" and "mdi" indexes as equal when comparing 'em

### DIFF
--- a/arangod/ClusterEngine/ClusterIndexFactory.cpp
+++ b/arangod/ClusterEngine/ClusterIndexFactory.cpp
@@ -212,6 +212,7 @@ void ClusterIndexFactory::linkIndexFactories(ArangodServer& server,
   factory.emplace(mdiIndexFactory._type, mdiIndexFactory);
   factory.emplace(mdiPrefixedIndexFactory._type, mdiPrefixedIndexFactory);
   factory.emplace(invertedIndexFactory._type, invertedIndexFactory);
+  factory.emplace("zkd", mdiIndexFactory);
 }
 
 ClusterIndexFactory::ClusterIndexFactory(ArangodServer& server)

--- a/arangod/Indexes/Index.cpp
+++ b/arangod/Indexes/Index.cpp
@@ -481,17 +481,25 @@ bool Index::CompareIdentifiers(velocypack::Slice const& lhs,
 /// contents are the same
 bool Index::Compare(StorageEngine& engine, VPackSlice const& lhs,
                     VPackSlice const& rhs, std::string const& dbname) {
-  auto lhsType = lhs.get(arangodb::StaticStrings::IndexType);
-  TRI_ASSERT(lhsType.isString());
+  auto normalizeType = [](VPackSlice s) -> std::string_view {
+    TRI_ASSERT(s.isString());
+    // "zkd" is the old naming for "mdi", so we have to treat these
+    // two type names as identical.
+    if (s.stringView() == "zkd") {
+      return "mdi";
+    }
+    return s.stringView();
+  };
 
-  // type must be identical
-  if (!arangodb::basics::VelocyPackHelper::equal(
-          lhsType, rhs.get(arangodb::StaticStrings::IndexType), false)) {
+  auto lhsType = normalizeType(lhs.get(arangodb::StaticStrings::IndexType));
+  auto rhsType = normalizeType(rhs.get(arangodb::StaticStrings::IndexType));
+
+  if (lhsType != rhsType) {
     return false;
   }
 
   return engine.indexFactory()
-      .factory(lhsType.copyString())
+      .factory(std::string{lhsType})
       .equal(lhs, rhs, dbname);
 }
 

--- a/arangod/Indexes/IndexFactory.cpp
+++ b/arangod/Indexes/IndexFactory.cpp
@@ -118,22 +118,24 @@ bool IndexTypeFactory::equal(Index::IndexType type, velocypack::Slice lhs,
                              velocypack::Slice rhs,
                              bool attributeOrderMatters) const {
   // unique must be identical if present
-  auto value = lhs.get(StaticStrings::IndexUnique);
-
-  if (value.isBoolean() &&
-      !basics::VelocyPackHelper::equal(
-          value, rhs.get(StaticStrings::IndexUnique), false)) {
+  bool lhsUnique = basics::VelocyPackHelper::getBooleanValue(
+      lhs, StaticStrings::IndexUnique, false);
+  bool rhsUnique = basics::VelocyPackHelper::getBooleanValue(
+      rhs, StaticStrings::IndexUnique, false);
+  if (lhsUnique != rhsUnique) {
     return false;
   }
 
   // sparse must be identical if present
-  value = lhs.get(StaticStrings::IndexSparse);
-
-  if (value.isBoolean() &&
-      !basics::VelocyPackHelper::equal(
-          value, rhs.get(StaticStrings::IndexSparse), false)) {
+  bool lhsSparse = basics::VelocyPackHelper::getBooleanValue(
+      lhs, StaticStrings::IndexSparse, false);
+  bool rhsSparse = basics::VelocyPackHelper::getBooleanValue(
+      rhs, StaticStrings::IndexSparse, false);
+  if (lhsSparse != rhsSparse) {
     return false;
   }
+
+  VPackSlice value;
 
   if (Index::IndexType::TRI_IDX_TYPE_GEO1_INDEX == type ||
       Index::IndexType::TRI_IDX_TYPE_GEO_INDEX == type) {


### PR DESCRIPTION
### Scope & Purpose

Treat indexes of types "zkd" and "mdi" as equal when comparing them.
Also treat "zkd" indexes with missing "sparse" attribute as equal to those with "sparse=false".

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 