### PR TITLE
Implement SupervisedScheduler::detachThread [BTS-1670]

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,15 @@
+v3.10.12.2 (XXXX-XX-XX)
+-----------------------
+
+* Allow a scheduler thread to detach itself from the scheduler if it sees 
+  that it has to perform a potentially long running task like waiting for
+  a lock. This allows a new scheduler thread to be started and avoids
+  that it can happen that all threads are blocked waiting for a lock,
+  which has in the past led to deadlock situations. The number of detached
+  threads is limited by a configurable option. Currently, only threads
+  waiting for more than 1 second on a collection lock will detach themselves.
+
+
 v3.10.12.1 (2023-12-27)
 -----------------------
 

--- a/Documentation/Metrics/arangodb_scheduler_num_detached_threads.yaml
+++ b/Documentation/Metrics/arangodb_scheduler_num_detached_threads.yaml
@@ -1,0 +1,18 @@
+name: arangodb_scheduler_num_detached_threads
+introducedIn: "3.10.13"
+help: |
+  Current number of detached worker threads.
+unit: number
+type: gauge
+category: Scheduler
+complexity: simple
+exposedBy:
+  - coordinator
+  - dbserver
+  - agent
+  - single
+description: |
+  The number of worker threads currently started and detached from the 
+  scheduler. Worker threads which perform potentially long running
+  tasks like waiting for a lock can detach themselves from the scheduler 
+  to allow new scheduler threads to be started and avoid server blockage.

--- a/Documentation/Metrics/arangodb_scheduler_num_worker_threads.yaml
+++ b/Documentation/Metrics/arangodb_scheduler_num_worker_threads.yaml
@@ -12,5 +12,6 @@ exposedBy:
   - agent
   - single
 description: |
-  The number of worker threads currently started. Worker threads can be started
-  and stopped dynamically based on the server load.
+  The number of worker threads currently started. This includes detached 
+  worker threads. Worker threads can be started and stopped dynamically
+  based on the server load.

--- a/arangod/RocksDBEngine/RocksDBMetaCollection.cpp
+++ b/arangod/RocksDBEngine/RocksDBMetaCollection.cpp
@@ -42,6 +42,7 @@
 #include "RocksDBEngine/RocksDBSettingsManager.h"
 #include "RocksDBEngine/RocksDBTransactionCollection.h"
 #include "RocksDBEngine/RocksDBTransactionState.h"
+#include "Scheduler/SchedulerFeature.h"
 #include "StorageEngine/EngineSelectorFeature.h"
 #include "Transaction/Context.h"
 #include "Transaction/Methods.h"
@@ -1629,7 +1630,38 @@ ErrorCode RocksDBMetaCollection::doLock(double timeout, AccessMode::Type mode) {
   auto timeout_us = std::chrono::duration_cast<std::chrono::microseconds>(
       std::chrono::duration<double>(timeout));
 
+  constexpr auto detachThreshold = std::chrono::microseconds(1000000);
+
   bool gotLock = false;
+  if (timeout_us > detachThreshold) {
+    if (mode == AccessMode::Type::WRITE) {
+      gotLock = _exclusiveLock.tryLockWriteFor(detachThreshold);
+    } else {
+      gotLock = _exclusiveLock.tryLockReadFor(detachThreshold);
+    }
+    if (gotLock) {
+      // keep the lock and exit
+      return TRI_ERROR_NO_ERROR;
+    }
+
+    timeout_us -= detachThreshold;
+    LOG_TOPIC("dd231", INFO, Logger::THREADS)
+        << "Did not get lock within 1 seconds, detaching scheduler thread.";
+    uint64_t currentNumberDetached = 0;
+    uint64_t maximumNumberDetached = 0;
+    Result r = arangodb::SchedulerFeature::SCHEDULER->detachThread(
+        &currentNumberDetached, &maximumNumberDetached);
+    if (r.is(TRI_ERROR_TOO_MANY_DETACHED_THREADS)) {
+      LOG_TOPIC("dd232", WARN, Logger::THREADS)
+          << "Could not detach scheduler thread (currently detached threads: "
+          << currentNumberDetached
+          << ", maximal number of detached threads: " << maximumNumberDetached
+          << "), will continue to acquire "
+             "lock in scheduler thread, this can potentially lead to "
+             "blockages!";
+    }
+  }
+
   if (mode == AccessMode::Type::WRITE) {
     gotLock = _exclusiveLock.tryLockWriteFor(timeout_us);
   } else {

--- a/arangod/Scheduler/Scheduler.cpp
+++ b/arangod/Scheduler/Scheduler.cpp
@@ -85,6 +85,11 @@ bool Scheduler::start() {
   return _cronThread->start();
 }
 
+Result Scheduler::detachThread(uint64_t* detachedThreads,
+                               uint64_t* maximumDetachedThreads) {
+  return {};
+}
+
 void Scheduler::shutdown() {
   TRI_ASSERT(isStopping());
 

--- a/arangod/Scheduler/Scheduler.h
+++ b/arangod/Scheduler/Scheduler.h
@@ -63,6 +63,9 @@ class Scheduler {
   // Scheduling and Task Queuing - the relevant stuff
   // ---------------------------------------------------------------------------
  public:
+  virtual Result detachThread(uint64_t* detachedThreads,
+                              uint64_t* maximumDetachedThreads);
+
   class DelayedWorkItem;
   typedef std::chrono::steady_clock clock;
   typedef std::shared_ptr<DelayedWorkItem> WorkHandle;

--- a/arangod/Scheduler/SchedulerFeature.cpp
+++ b/arangod/Scheduler/SchedulerFeature.cpp
@@ -240,6 +240,17 @@ return HTTP 503 instead of HTTP 200 when their availability API is probed.)");
       new UInt64Parameter(&_fifo1Size),
       arangodb::options::makeDefaultFlags(arangodb::options::Flags::Uncommon));
 
+  options
+      ->addOption("--server.max-number-detached-threads",
+                  "The maximum number of detached scheduler threads.",
+                  new UInt64Parameter(&_nrMaximalDetachedThreads),
+                  arangodb::options::makeDefaultFlags(
+                      arangodb::options::Flags::Default,
+                      arangodb::options::Flags::Uncommon))
+      .setIntroducedIn(31013)
+      .setLongDescription(
+          R"(If a scheduler thread performs a potentially long running operation like waiting for a lock, it can detach itself from the scheduler. This allows a new scheduler thread to be started and avoids blocking all threads with long-running operations, thereby avoiding deadlock situations. The default should normally be OK.)");
+
   // obsolete options
   options->addObsoleteOption("--server.threads", "number of threads", true);
 
@@ -328,7 +339,7 @@ void SchedulerFeature::prepare() {
   auto sched = std::make_unique<SupervisedScheduler>(
       server(), _nrMinimalThreads, _nrMaximalThreads, _queueSize, _fifo1Size,
       _fifo2Size, _fifo3Size, ongoingLowPriorityLimit,
-      _unavailabilityQueueFillGrade);
+      _unavailabilityQueueFillGrade, _nrMaximalDetachedThreads);
 #if (_MSC_VER >= 1)
 #pragma warning(pop)
 #endif

--- a/arangod/Scheduler/SchedulerFeature.h
+++ b/arangod/Scheduler/SchedulerFeature.h
@@ -63,6 +63,7 @@ class SchedulerFeature final : public ArangodFeature {
 
   uint64_t _nrMinimalThreads = 4;
   uint64_t _nrMaximalThreads = 0;
+  uint64_t _nrMaximalDetachedThreads = 1000;
   uint64_t _queueSize = 4096;
   uint64_t _fifo1Size = 4096;
   uint64_t _fifo2Size = 4096;

--- a/arangod/Scheduler/SupervisedScheduler.cpp
+++ b/arangod/Scheduler/SupervisedScheduler.cpp
@@ -178,6 +178,8 @@ DECLARE_GAUGE(arangodb_scheduler_num_working_threads, uint64_t,
               "Number of working threads");
 DECLARE_GAUGE(arangodb_scheduler_num_worker_threads, uint64_t,
               "Number of worker threads");
+DECLARE_GAUGE(arangodb_scheduler_num_detached_threads, uint64_t,
+              "Number of detached worker threads");
 DECLARE_GAUGE(
     arangodb_scheduler_ongoing_low_prio, uint64_t,
     "Total number of ongoing RestHandlers coming from the low prio queue");
@@ -199,7 +201,7 @@ SupervisedScheduler::SupervisedScheduler(
     ArangodServer& server, uint64_t minThreads, uint64_t maxThreads,
     uint64_t maxQueueSize, uint64_t fifo1Size, uint64_t fifo2Size,
     uint64_t fifo3Size, uint64_t ongoingLowPriorityLimit,
-    double unavailabilityQueueFillGrade)
+    double unavailabilityQueueFillGrade, uint64_t maxNumberDetachedThreads)
     : Scheduler(server),
       _nf(server.getFeature<NetworkFeature>()),
       _sharedPRNG(server.getFeature<SharedPRNGFeature>()),
@@ -213,9 +215,11 @@ SupervisedScheduler::SupervisedScheduler(
       _maxNumWorkers(maxThreads),
       _maxFifoSizes{maxQueueSize, fifo1Size, fifo2Size, fifo3Size},
       _ongoingLowPriorityLimit(ongoingLowPriorityLimit),
+      _maxNumberDetachedThreads(maxNumberDetachedThreads),
       _unavailabilityQueueFillGrade(unavailabilityQueueFillGrade),
       _numWorking(0),
       _numAwake(0),
+      _numDetached(0),
       _metricsQueueLength(server.getFeature<metrics::MetricsFeature>().add(
           arangodb_scheduler_queue_length{})),
       _metricsJobsDoneTotal(server.getFeature<metrics::MetricsFeature>().add(
@@ -233,6 +237,9 @@ SupervisedScheduler::SupervisedScheduler(
               arangodb_scheduler_num_working_threads{})),
       _metricsNumWorkerThreads(server.getFeature<metrics::MetricsFeature>().add(
           arangodb_scheduler_num_worker_threads{})),
+      _metricsNumDetachedThreads(
+          server.getFeature<metrics::MetricsFeature>().add(
+              arangodb_scheduler_num_detached_threads{})),
       _metricsHandlerTasksCreated(
           server.getFeature<metrics::MetricsFeature>().add(
               arangodb_scheduler_handler_tasks_created_total{})),
@@ -485,6 +492,59 @@ void SupervisedScheduler::shutdown() {
   }
 }
 
+Result SupervisedScheduler::detachThread(uint64_t* detachedThreads,
+                                         uint64_t* maximumDetachedThreads) {
+  std::lock_guard<std::mutex> guard(_mutex);
+  if (detachedThreads != nullptr) {
+    *detachedThreads = _numDetached;
+  }
+  if (maximumDetachedThreads != nullptr) {
+    *maximumDetachedThreads = _maxNumberDetachedThreads;
+  }
+  // First see if we have already reached the limit:
+  if (_numDetached >= _maxNumberDetachedThreads) {
+    return Result(TRI_ERROR_TOO_MANY_DETACHED_THREADS);
+  }
+
+  // Now we have access to the _workerStates and _detachedWorkerStates
+  // Let's first find ourselves in the _workerStates:
+  uint64_t myNumber = Thread::currentThreadNumber();
+  auto it = _workerStates.begin();
+  while (it != _workerStates.end()) {
+    if ((*it)->_thread->threadNumber() == myNumber) {
+      break;
+    }
+    ++it;
+  }
+  if (it == _workerStates.end()) {
+    return Result(TRI_ERROR_INTERNAL,
+                  "scheduler thread for detaching not found");
+  }
+  std::shared_ptr<WorkerState> state = std::move(*it);
+  _workerStates.erase(it);
+  // Since the thread is effectively taken out of the pool, decrease the
+  // number of workers.
+  --_numWorkers;
+  {
+    std::unique_lock<std::mutex> guard(state->_mutex);
+    state->_stop = true;  // We will be stopped after the current task is done
+                          // We know that we are working, so we do not
+                          // have to wake the thread.
+  }
+  ++_metricsThreadsStopped;
+  try {
+    _detachedWorkerStates.push_back(std::move(state));
+    ++_numDetached;
+  } catch (std::exception const&) {
+    // Ignore error here, the thread itself still holds a copy of the
+    // shared_ptr, so cleanup is guaranteed.
+    // But we do not want to throw here.
+    // Note that we do not count the detached thread in `_numDetached` in
+    // this case! This is intentional!
+  }
+  return {};
+}
+
 void SupervisedScheduler::runWorker() {
   uint64_t id;
 
@@ -576,6 +636,7 @@ void SupervisedScheduler::runSupervisor() {
     uint64_t numAwake = _numAwake.load(std::memory_order_relaxed);
     uint64_t numWorkers = _numWorkers.load(std::memory_order_relaxed);
     uint64_t numWorking = _numWorking.load(std::memory_order_relaxed);
+    uint64_t numDetached = _numDetached.load(std::memory_order_relaxed);
     bool sleeperFound = (numAwake < numWorkers);
 
     bool doStartOneThread =
@@ -600,7 +661,8 @@ void SupervisedScheduler::runSupervisor() {
       _metricsJobsDequeuedTotal.operator=(jobsDequeued);
       _metricsNumAwakeThreads.operator=(numAwake);
       _metricsNumWorkingThreads.operator=(numWorking);
-      _metricsNumWorkerThreads.operator=(numWorkers);
+      _metricsNumWorkerThreads.operator=(numWorkers + numDetached);
+      _metricsNumDetachedThreads.operator=(numDetached);
       roundCount = 0;
     }
 
@@ -637,7 +699,19 @@ void SupervisedScheduler::runSupervisor() {
 
 bool SupervisedScheduler::cleanupAbandonedThreads() {
   std::unique_lock<std::mutex> guard(_mutex);
-  auto i = _abandonedWorkerStates.begin();
+  auto i = _detachedWorkerStates.begin();
+
+  while (i != _detachedWorkerStates.end()) {
+    auto& state = *i;
+    if (!state->_thread->isRunning()) {
+      i = _detachedWorkerStates.erase(i);
+      --_numDetached;
+    } else {
+      i++;
+    }
+  }
+
+  i = _abandonedWorkerStates.begin();
 
   while (i != _abandonedWorkerStates.end()) {
     auto& state = *i;
@@ -648,7 +722,7 @@ bool SupervisedScheduler::cleanupAbandonedThreads() {
     }
   }
 
-  return _abandonedWorkerStates.empty();
+  return _detachedWorkerStates.empty() && _abandonedWorkerStates.empty();
 }
 
 bool SupervisedScheduler::sortoutLongRunningThreads() {
@@ -721,6 +795,12 @@ bool SupervisedScheduler::canPullFromQueue(uint64_t queueIndex) const noexcept {
   uint64_t jobsDequeued = _jobsDequeued.load(std::memory_order_relaxed);
   TRI_ASSERT(jobsDequeued >= jobsDone);
   uint64_t threadsWorking = jobsDequeued - jobsDone;
+  // Detached threads are typically working, too, but should not be
+  // counted here, since the ratios below are only for non-detached
+  // threads:
+  uint64_t threadsDetached = _numDetached.load(std::memory_order_relaxed);
+  threadsWorking =
+      threadsWorking > threadsDetached ? threadsWorking - threadsDetached : 0;
 
   if (queueIndex == HighPriorityQueue) {
     // We can work on high if less than 87.5% of the workers are busy

--- a/arangod/Scheduler/SupervisedScheduler.h
+++ b/arangod/Scheduler/SupervisedScheduler.h
@@ -47,11 +47,22 @@ class SupervisedScheduler final : public Scheduler {
                       uint64_t maxThreads, uint64_t maxQueueSize,
                       uint64_t fifo1Size, uint64_t fifo2Size,
                       uint64_t fifo3Size, uint64_t ongoingLowPriorityLimit,
-                      double unavailabilityQueueFillGrade);
+                      double unavailabilityQueueFillGrade,
+                      uint64_t maxNumberDetachedThreads);
   ~SupervisedScheduler() final;
 
   bool start() override;
   void shutdown() override;
+
+  /// @brief Take current thread out of the Scheduler (to finish some
+  /// potentially long running task and allow a new thread to be started).
+  /// This should be called from a scheduler thread. If an error is returned
+  /// this operation has not worked. The thread can then consider to error
+  /// out instead of starting its long running task. Note that his also
+  /// happens if a configurable total number of detached threads has been
+  /// reached.
+  Result detachThread(uint64_t* detachedThreads,
+                      uint64_t* maximumDetachedThreads) override;
 
   void toVelocyPack(velocypack::Builder&) const override;
   Scheduler::QueueStatistics queueStatistics() const override;
@@ -194,6 +205,7 @@ class SupervisedScheduler final : public Scheduler {
   size_t const _maxNumWorkers;
   uint64_t const _maxFifoSizes[NumberOfQueues];
   uint64_t const _ongoingLowPriorityLimit;
+  uint64_t const _maxNumberDetachedThreads;
 
   /// @brief fill grade of the scheduler's queue (in %) from which onwards
   /// the server is considered unavailable (because of overload)
@@ -201,9 +213,11 @@ class SupervisedScheduler final : public Scheduler {
 
   std::list<std::shared_ptr<WorkerState>> _workerStates;
   std::list<std::shared_ptr<WorkerState>> _abandonedWorkerStates;
-  std::atomic<uint64_t> _numWorking;  // Number of threads actually working
-  std::atomic<uint64_t> _numAwake;    // Number of threads working or spinning
-                                      // (i.e. not sleeping)
+  std::list<std::shared_ptr<WorkerState>> _detachedWorkerStates;
+  std::atomic<uint64_t> _numWorking;   // Number of threads actually working
+  std::atomic<uint64_t> _numAwake;     // Number of threads working or spinning
+                                       // (i.e. not sleeping)
+  std::atomic<uint64_t> _numDetached;  // Number of detached threads
 
   // The following mutex protects the lists _workerStates and
   // _abandonedWorkerStates, whenever one accesses any of these two
@@ -224,6 +238,7 @@ class SupervisedScheduler final : public Scheduler {
   metrics::Gauge<uint64_t>& _metricsNumAwakeThreads;
   metrics::Gauge<uint64_t>& _metricsNumWorkingThreads;
   metrics::Gauge<uint64_t>& _metricsNumWorkerThreads;
+  metrics::Gauge<uint64_t>& _metricsNumDetachedThreads;
 
   metrics::Counter& _metricsHandlerTasksCreated;
   metrics::Counter& _metricsThreadsStarted;

--- a/arangod/Transaction/Manager.cpp
+++ b/arangod/Transaction/Manager.cpp
@@ -776,11 +776,17 @@ std::shared_ptr<transaction::Context> Manager::leaseManagedTrx(
   TRI_IF_FAILURE("leaseManagedTrxFail") { return nullptr; }
 
   auto const role = ServerState::instance()->getRole();
+  std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now();
   std::chrono::steady_clock::time_point endTime;
   if (!ServerState::isDBServer(role)) {  // keep end time as small as possible
-    endTime = std::chrono::steady_clock::now() +
-              std::chrono::milliseconds(int64_t(1000 * _streamingLockTimeout));
+    endTime =
+        now + std::chrono::milliseconds(int64_t(1000 * _streamingLockTimeout));
   }
+  std::chrono::steady_clock::time_point detachTime;
+  if (_streamingLockTimeout >= 1.0) {
+    detachTime = now + std::chrono::milliseconds(1000);
+  }
+  bool alreadyDetached = false;
   // always serialize access on coordinator,
   // TransactionState::_knownServers is modified even for READ
   if (ServerState::isCoordinator(role)) {
@@ -868,8 +874,27 @@ std::shared_ptr<transaction::Context> Manager::leaseManagedTrx(
     TRI_ASSERT(endTime.time_since_epoch().count() == 0 ||
                !ServerState::instance()->isDBServer());
 
-    if (!ServerState::isDBServer(role) &&
-        std::chrono::steady_clock::now() > endTime) {
+    auto now = std::chrono::steady_clock::now();
+    if (!alreadyDetached && detachTime.time_since_epoch().count() != 0 &&
+        now > detachTime) {
+      alreadyDetached = true;
+      LOG_TOPIC("dd234", INFO, Logger::THREADS)
+          << "Did not get lock within 1 seconds, detaching scheduler thread.";
+      uint64_t currentNumberDetached = 0;
+      uint64_t maximumNumberDetached = 0;
+      auto res = SchedulerFeature::SCHEDULER->detachThread(
+          &currentNumberDetached, &maximumNumberDetached);
+      if (res.is(TRI_ERROR_TOO_MANY_DETACHED_THREADS)) {
+        LOG_TOPIC("dd233", WARN, Logger::THREADS)
+            << "Could not detach scheduler thread (currently detached threads: "
+            << currentNumberDetached
+            << ", maximal number of detached threads: " << maximumNumberDetached
+            << "), will continue to acquire "
+               "lock in scheduler thread, this can potentially lead to "
+               "blockages!";
+      }
+    }
+    if (!ServerState::isDBServer(role) && now > endTime) {
       THROW_ARANGO_EXCEPTION_MESSAGE(
           TRI_ERROR_LOCKED, std::string("cannot write-lock, transaction ") +
                                 std::to_string(tid.id()) +

--- a/arangod/Transaction/Methods.cpp
+++ b/arangod/Transaction/Methods.cpp
@@ -1234,6 +1234,20 @@ Result transaction::Methods::determineReplicationTypeAndFollowers(
                                     theLeader);
       }
 
+      TRI_IF_FAILURE("synchronousReplication::blockReplication") {
+        // Block here until the second failure point is switched on, too:
+        bool leave = false;
+        while (true) {
+          TRI_IF_FAILURE("synchronousReplication::unblockReplication") {
+            leave = true;
+          }
+          if (leave) {
+            break;
+          }
+          std::this_thread::sleep_for(std::chrono::milliseconds(300));
+        }
+      }
+
       // we are a valid follower. we do not need to send a proper result with
       // _key, _id, _rev back to the leader, because it will ignore all these
       // data anyway. it is sufficient to send headers and the proper error

--- a/js/common/bootstrap/errors.js
+++ b/js/common/bootstrap/errors.js
@@ -336,6 +336,7 @@
     "ERROR_SUPERVISION_GENERAL_FAILURE" : { "code" : 20501, "message" : "general supervision failure" },
     "ERROR_QUEUE_FULL"             : { "code" : 21003, "message" : "queue is full" },
     "ERROR_QUEUE_TIME_REQUIREMENT_VIOLATED" : { "code" : 21004, "message" : "queue time violated" },
+    "ERROR_TOO_MANY_DETACHED_THREADS" : { "code" : 21005, "message" : "too many detached scheduler threads" },
     "ERROR_ACTION_OPERATION_UNABORTABLE" : { "code" : 6002, "message" : "this maintenance action cannot be stopped" },
     "ERROR_ACTION_UNFINISHED"      : { "code" : 6003, "message" : "maintenance action still processing" },
     "ERROR_HOT_BACKUP_INTERNAL"    : { "code" : 7001, "message" : "internal hot backup error" },

--- a/lib/Basics/errors.dat
+++ b/lib/Basics/errors.dat
@@ -478,6 +478,7 @@ ERROR_SUPERVISION_GENERAL_FAILURE,20501,"general supervision failure","General s
 
 ERROR_QUEUE_FULL,21003,"queue is full","Will be returned if the scheduler queue is full."
 ERROR_QUEUE_TIME_REQUIREMENT_VIOLATED,21004,"queue time violated","Will be returned if a request with a queue time requirement is set and it cannot be fulfilled."
+ERROR_TOO_MANY_DETACHED_THREADS,21005,"too many detached scheduler threads","Will be returned if a scheduler thread tries to detach itself but there are already too many detached scheduler threads."
 
 ################################################################################
 ## Maintenance errors

--- a/tests/Cluster/RebootTrackerTest.cpp
+++ b/tests/Cluster/RebootTrackerTest.cpp
@@ -146,7 +146,7 @@ class RebootTrackerTest
       : mockApplicationServer(),
         scheduler(std::make_unique<SupervisedScheduler>(
             mockApplicationServer.server(), 2, 64, 128, 1024 * 1024, 4096, 4096,
-            128, 0.0)) {}
+            128, 0.0, 42)) {}
 #if (_MSC_VER >= 1)
 #pragma warning(pop)
 #endif

--- a/tests/js/client/server_parameters/detach-threads-cluster.js
+++ b/tests/js/client/server_parameters/detach-threads-cluster.js
@@ -1,0 +1,176 @@
+/* jshint globalstrict:false, strict:false, maxlen: 200 */
+/* global fail, getOptions, assertEqual, assertTrue, assertFalse, arango */
+
+// //////////////////////////////////////////////////////////////////////////////
+// / @brief Test detaching threads in scheduler which wait for locks.
+// /
+// / DISCLAIMER
+// /
+// / Copyright 2023 ArangoDB GmbH, Cologne, Germany
+// /
+// / Licensed under the Apache License, Version 2.0 (the "License")
+// / you may not use this file except in compliance with the License.
+// / You may obtain a copy of the License at
+// /
+// /     http://www.apache.org/licenses/LICENSE-2.0
+// /
+// / Unless required by applicable law or agreed to in writing, software
+// / distributed under the License is distributed on an "AS IS" BASIS,
+// / WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// / See the License for the specific language governing permissions and
+// / limitations under the License.
+// /
+// / @author Max Neunhoeffer
+// //////////////////////////////////////////////////////////////////////////////
+
+// We need the following options for this test. We need a specific number 
+// of threads in the scheduler. 30 threads means that there are 15 low
+// priority lane threads. We will post 100 background jobs which will
+// at first block on `transaction::Manager::leaseManagedTrx` because of
+// a lock. This totally blocks all scheduler threads. If the detaching
+// of scheduler threads waiting for this lock works, then we can Unblock
+// this situation pretty soon (15 threads per second). So after a few
+// seconds, a normal low priority operation will go through again.
+// If you use fewer than 25 threads, then the cluster overwhelm protections
+// will also block the situation since the coordinator will no longer
+// dequeue low priority lane jobs. If you use more than 200 threads, then
+// the test will not test the detaching of threads.
+// We need to set the timeout for acquiring the lease on a managed trx
+// to 600, since its default is 8 seconds which would ruin the test.
+
+if (getOptions === true) {
+  return {
+    'transaction.streaming-lock-timeout' : '600',
+    'transaction.streaming-idle-timeout' : '120',
+    'server.maximal-threads' : '30',
+    'server.minimal-threads' : '30'
+  };
+}
+
+const _ = require('lodash');
+let jsunity = require('jsunity');
+let internal = require('internal');
+let arangodb = require('@arangodb');
+let fs = require('fs');
+let db = arangodb.db;
+let { debugCanUseFailAt, debugRemoveFailAt, debugSetFailAt, debugClearFailAt } = require('@arangodb/test-helper');
+
+function getEndpointAndIdMap() {
+  const health = arango.GET("/_admin/cluster/health").Health;
+  const endpointMap = {};
+  const idMap = {};
+  for (let sid in health) {
+    endpointMap[health[sid].ShortName] = health[sid].Endpoint;
+    idMap[health[sid].ShortName] = sid;
+  }
+  return {endpointMap, idMap};
+}
+
+function createCollectionWithKnownLeaderAndFollower(cn) {
+  db._create(cn, {numberOfShards:1, replicationFactor:2});
+  // Get dbserver names first:
+  let { endpointMap, idMap } = getEndpointAndIdMap();
+  let plan = arango.GET("/_admin/cluster/shardDistribution").results[cn].Plan;
+  let shard = Object.keys(plan)[0];
+  let coordinator = "Coordinator0001";
+  let leader = plan[shard].leader;
+  let follower = plan[shard].followers[0];
+  return { endpointMap, idMap, coordinator, leader, follower, shard };
+}
+
+function detachSchedulerThreadsSuite2() {
+  'use strict';
+  const cn = 'UnitTestsDetachSchedulerThreads';
+
+  const setupTeardown = function () {
+    db._drop(cn);
+  };
+
+  return {
+    setUp: setupTeardown,
+    tearDown: setupTeardown,
+    
+    testDelayReplicationInExclusiveTrx: function() {
+      // We want to create a lockup in leaseManagedTrx.
+
+      let collInfo = createCollectionWithKnownLeaderAndFollower(cn);
+      // We have a shard whose leader and follower is known to us.
+      
+      let followerEndpoint = collInfo.endpointMap[collInfo.follower];
+
+      // Let's insert some documents:
+      let c = db._collection(cn);
+      let l = [];
+      for (let i = 0; i < 100; ++i) {
+        l.push({_key:"K"+i, Hallo:i});
+      }
+      c.insert(l);
+
+      try {
+        // Block replication in the follower, such that it can be released
+        // later on (nested failure points).
+        debugSetFailAt(followerEndpoint, "synchronousReplication::blockReplication");
+
+        // Create a transaction T writing to the replicated collection
+        let trx = arango.POST_RAW("/_api/transaction/begin", {collections:{write:[cn]}});
+        assertEqual(201, trx.code);
+        trx = trx.parsedBody.result.id;
+
+        // Perform one insert within T in the background, it will block, since
+        // it cannot replicate.
+        let blocked = arango.POST_RAW(`/_api/document/${cn}`, {Hallo:1}, {"x-arango-async": "store", "x-arango-trx-id": trx});
+        assertEqual(202, blocked.code);
+        assertTrue(blocked.headers.hasOwnProperty("x-arango-async-id"));
+        blocked = blocked.headers["x-arango-async-id"];
+
+        // Perform multiple read operations within T, they should fight over
+        // the lease of the transaction and block many threads of the same prio.
+        let l = [blocked];
+        for (let i = 0; i < 100; ++i) {
+          let r = arango.POST_RAW(`/_api/document/${cn}`, {_key:"L"+i}, {"x-arango-async": "store", "x-arango-trx-id": trx});
+          assertEqual(202, r.code);
+          assertTrue(r.headers.hasOwnProperty("x-arango-async-id"));
+          l.push(r.headers["x-arango-async-id"]);
+        }
+
+        // Then perform simple reads to the collection. They should soon be
+        // unblocked, because of detached threads.
+        c.document("K1");
+
+        // Unblock everything:
+        debugSetFailAt(followerEndpoint, "synchronousReplication::unblockReplication");
+
+        // And now expect that all ops terminate:
+        let waitForJob = function(id) {
+          let count = 0;
+          while(true) {
+            let r = arango.PUT_RAW(`/_api/job/${id}`, "");
+            if (r.code !== 204) {
+              assertTrue(!r.parsedBody.hasOwnProperty("error"));
+              return r;
+            }
+            if (++count >= 600) {
+              throw "Did not finish in time to wait for jobs.";
+            }
+            internal.wait(0.5);
+          }
+        };
+        for (let j of l) {
+          waitForJob(j);
+        }
+
+        // And abort transaction:
+        let res = arango.DELETE_RAW(`/_api/transaction/${trx}`);
+        assertEqual(200, res.code);
+      } finally {
+        debugClearFailAt(followerEndpoint);
+      }
+    }
+  };
+}
+
+if (db._properties().replicationVersion !== "2" &&
+    internal.debugCanUseFailAt()) {
+  jsunity.run(detachSchedulerThreadsSuite2);
+}
+return jsunity.done();

--- a/tests/js/client/server_parameters/detach-threads-noncluster.js
+++ b/tests/js/client/server_parameters/detach-threads-noncluster.js
@@ -1,0 +1,124 @@
+/* jshint globalstrict:false, strict:false, maxlen: 200 */
+/* global fail, assertEqual, assertTrue, assertFalse, arango, getOptions */
+
+// //////////////////////////////////////////////////////////////////////////////
+// / @brief Test detaching threads in scheduler which wait for locks.
+// /
+// / DISCLAIMER
+// /
+// / Copyright 2023 ArangoDB GmbH, Cologne, Germany
+// /
+// / Licensed under the Apache License, Version 2.0 (the "License")
+// / you may not use this file except in compliance with the License.
+// / You may obtain a copy of the License at
+// /
+// /     http://www.apache.org/licenses/LICENSE-2.0
+// /
+// / Unless required by applicable law or agreed to in writing, software
+// / distributed under the License is distributed on an "AS IS" BASIS,
+// / WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// / See the License for the specific language governing permissions and
+// / limitations under the License.
+// /
+// / @author Max Neunhoeffer
+// //////////////////////////////////////////////////////////////////////////////
+
+// We need the following options for this test. We need a specific number 
+// of threads in the scheduler. 60 threads means that there are 30 low
+// priority lane threads. We will post 200 background jobs which will
+// start an exclusive transaction and thus get stuck in a lock.
+// This totally blocks all scheduler threads. If the detaching
+// of scheduler threads waiting for this lock works, then we can Unblock
+// this situation pretty soon (30 threads per second). So after a few
+// seconds, a normal low priority operation will go through again.
+// If you use fewer than 51 threads, then the cluster overwhelm protections
+// will also block the situation since the coordinator will no longer
+// dequeue low priority lane jobs. If you use more than 200 threads, then
+// the test will not test the detaching of threads.
+if (getOptions === true) {
+  return {
+    'server.maximal-threads' : '60',
+    'server.minimal-threads' : '60'
+  };
+}
+
+const _ = require('lodash');
+const console = require('console');
+let jsunity = require('jsunity');
+let internal = require('internal');
+let arangodb = require('@arangodb');
+let fs = require('fs');
+let db = arangodb.db;
+let { debugCanUseFailAt, debugRemoveFailAt, debugSetFailAt, debugClearFailAt } = require('@arangodb/test-helper');
+
+function detachSchedulerThreadsSuite() {
+  'use strict';
+  const cn = 'UnitTestsDetachSchedulerThreads';
+  const cn2 = 'UnitTestsDetachSchedulerThreads2';
+
+  const setupTeardown = function () {
+    db._drop(cn);
+    db._drop(cn2);
+  };
+
+  return {
+    setUp: setupTeardown,
+    tearDown: setupTeardown,
+    
+    testStartManyExclusiveTrxs: function() {
+      let c = db._create(cn);
+      let c2 = db._create(cn2);
+
+      // Let's insert some documents:
+      let l = [];
+      for (let i = 0; i < 100; ++i) {
+        l.push({Hallo:i});
+      }
+      c.insert(l);
+      c2.insert(l);
+
+      // Create a transaction with an exclusive lock and write something:
+      let t = db._createTransaction({collections:{exclusive:[cn]}});
+      let cc = t.collection(cn);
+      cc.insert({});
+
+      // Now create 200 more writes all waiting for the lock, but
+      // asynchronously, without detached threads, this will make all
+      // low prio threads block:
+      let ts = [];
+      for (let i = 0; i < 200; ++i) {
+        ts.push(arango.POST_RAW(`/_api/document/${cn}`,{Write: i},
+                {"x-arango-async": "store"})
+          .headers["x-arango-async-id"]);
+      }
+
+      // If threads detach, we should first be able to write to the second
+      // collection without too much delay:
+      c2.insert({"CanProceed": true});
+
+      // And then we can commit the transaction:
+      t.commit();
+
+      // Clean up jobs:
+      for (let id of ts) {
+        let count = 0;
+        while (true) {
+          count += 1;
+          if (count >= 60) {
+            throw "Jobs did not succeeed in time!";
+          }
+          let r = arango.PUT_RAW(`/_api/job/${id}`, {});
+          if (r.code === 202) {
+            break;
+          }
+          internal.wait(0.5);
+        }
+      }
+
+    },
+    
+  };
+}
+
+jsunity.run(detachSchedulerThreadsSuite);
+return jsunity.done();


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/20067

This is one measure to resolve https://arangodb.atlassian.net/browse/BTS-1670

In this PR we create a possiblity that a SchedulerThread can notice that it might be up to some longer running task (like waiting for a lock) and then voluntarily decide to detach itself from the scheduler to make room for a new thread to avoid starvation of jobs on the queue.

For now, we use this for acquiring a collection level lock (as read lock for write operations and as write lock for exclusive access), if we cannot acquire the lock within 1s. This will then allow the scheduler to create new threads to continue work on whatever priority is suitable.

- [x] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [x] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.11: https://github.com/arangodb/arangodb/pull/20067
  - [x] Backport for 3.10: https://github.com/arangodb/arangodb/pull/20411

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 