### PR TITLE
Suppress alignment errors in rocksdb's crc32c.cc

### DIFF
--- a/ubsan_arangodb_suppressions.txt
+++ b/ubsan_arangodb_suppressions.txt
@@ -15,6 +15,7 @@ null:3rdParty/rocksdb/file/random_access_file_reader.cc
 null:3rdParty/rocksdb/file/writable_file_writer.cc
 null:3rdParty/rocksdb/monitoring/perf_step_timer.h
 null:3rdParty/rocksdb/util/user_comparator_wrapper.h
+alignment:3rdParty/rocksdb/util/crc32c.cc
 
 # fix issues with S2 library
 vptr:region_coverer.cc


### PR DESCRIPTION
### Scope & Purpose

Add a suppression for RocksDB-related UBSan errors to our suppression file:

```
/home/tobias/Documents/ArangoDB/arangodb/arangodb/3rdParty/rocksdb/util/crc32c.cc:672:40: runtime error: load of misaligned address 0x7f638df3b006 for type 'uint32_t' (aka 'unsigned int'), which requires 4 byte alignment
0x7f638df3b006: note: pointer points here
 9f 5b 06 00 01 02  00 03 02 04 00 00 00 00  00 66 72 69 63 61 2f 41  62 69 64 6a 61 6e 00 00  00 00
             ^
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /home/tobias/Documents/ArangoDB/arangodb/arangodb/3rdParty/rocksdb/util/crc32c.cc:672:40 in
/home/tobias/Documents/ArangoDB/arangodb/arangodb/3rdParty/rocksdb/util/crc32c.cc:1236:9: runtime error: load of misaligned address 0x7f638dcb8006 for type 'uint64_t' (aka 'unsigned long'), which requires 8 byte alignment
0x7f638dcb8006: note: pointer points here
 81 21 13 00 01 01  00 00 00 00 00 00 00 01  00 00 00 0d 01 02 38 45  01 42 a9 fc d0 af 13 00  01 02
             ^
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /home/tobias/Documents/ArangoDB/arangodb/arangodb/3rdParty/rocksdb/util/crc32c.cc:1236:9 in
```

