### PR TITLE
Use actual address in output

### DIFF
--- a/scripts/startLocalCluster.sh
+++ b/scripts/startLocalCluster.sh
@@ -305,14 +305,14 @@ for p in `seq $CO_BASE $PORTTOPCO` ; do
 done
 
 if [[ -d "$PWD/enterprise" ]]; then
-    "${BUILD}"/bin/arangosh --server.endpoint "$TRANSPORT://[::1]:$CO_BASE" --javascript.execute "enterprise/scripts/startLocalCluster.js"
+    "${BUILD}"/bin/arangosh --server.endpoint "$TRANSPORT://$ADDRESS:$CO_BASE" --javascript.execute "enterprise/scripts/startLocalCluster.js"
 fi
 
 echo == Done, your cluster is ready at
 for p in `seq $CO_BASE $PORTTOPCO` ; do
   if [ -z "$JWT_SECRET" ];then
-    echo "   ${BUILD}/bin/arangosh --server.endpoint $TRANSPORT://[::1]:$p"
+    echo "   ${BUILD}/bin/arangosh --server.endpoint $TRANSPORT://$ADDRESS:$p"
   else
-    echo "   ${BUILD}/bin/arangosh --server.endpoint $TRANSPORT://[::1]:$p --server.jwt-secret-keyfile cluster/jwt.secret"
+    echo "   ${BUILD}/bin/arangosh --server.endpoint $TRANSPORT://$ADDRESS:$p --server.jwt-secret-keyfile cluster/jwt.secret"
   fi
 done


### PR DESCRIPTION
### Scope & Purpose

`./scripts/startLocalCluster.sh` prints an `arangosh` cmd line that connects to `[::1]`, while the (default) address used is `localhost` (since https://github.com/arangodb/arangodb/pull/19144) - this is not necessarily the same. It now prints the actual address.